### PR TITLE
audit(erdos-755): mark issues-found — phantom axioms + section line drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8924,9 +8924,9 @@
     },
     "erdos-755": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T09:22:48Z",
+      "result": "issues-found"
     },
     "erdos-756": {
       "auditCount": 5,


### PR DESCRIPTION
## Summary

Auditor pass on erdos-755 (Equilateral Triangles in ℝ⁶) flagged two integrity issues filed in #13883:

- **Phantom axioms in `meta.originalContributions`**: claims `lenz_construction axiom` and `cdl_general_dimension axiom` exist; neither is declared in the Lean file. Only `cdl_2025_main` is.
- **Section line-range drift**: all 8 sections have wrong `startLine`/`endLine`. Lean Part headings are at lines 37, 64, 101, 115, 137, 189, 202, 221, 239 but meta.json uses 36, 63, 100, 126, 148, 186, 210, 246.

Numerical counts (`axiomCount`=1, `sorries`=1, `lineCount`=272, `definitionCount`=7, `theoremCount`=4) and `status`/`badge` are correct.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --next` no longer returns erdos-755 (claimed → completed)
- [ ] Mechanic picks up #13883 and proposes meta.json fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)