### PR TITLE
fix(erdos-751): remove phantom section summary axioms, fix section line ranges

### DIFF
--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -78,42 +78,42 @@
       "id": "graph-foundations",
       "title": "Graph Theory Foundations",
       "summary": "minDegree, maxDegree, chromaticNumber, girth, cycleLengths definitions",
-      "startLine": 36,
+      "startLine": 37,
       "endLine": 87
     },
     {
       "id": "key-relationships",
       "title": "Key Relationships",
-      "summary": "chromatic_implies_minDeg, four_chromatic_minDeg axioms",
+      "summary": "four_chromatic_minDeg axiom: chi(G) = 4 implies minDegree(G) >= 3",
       "startLine": 88,
-      "endLine": 110
+      "endLine": 107
     },
     {
       "id": "bondy-vince",
       "title": "Bondy-Vince Theorem",
-      "summary": "bondy_vince_theorem and bondy_vince_gap axioms",
-      "startLine": 111,
-      "endLine": 138
+      "summary": "bondy_vince_theorem axiom: minDegree >= 3 implies cycle-length difference <= 2",
+      "startLine": 108,
+      "endLine": 130
     },
     {
       "id": "main-results",
       "title": "Main Results",
       "summary": "erdos_751_chromatic_4, erdos_751_with_girth, erdos_751 theorems",
-      "startLine": 139,
-      "endLine": 191
+      "startLine": 131,
+      "endLine": 183
     },
     {
       "id": "strengthening",
       "title": "Strengthening",
       "summary": "min_degree_3_cycle_gap, chromatic_4_implies_min_deg_3",
-      "startLine": 192,
-      "endLine": 215
+      "startLine": 184,
+      "endLine": 207
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_751_summary combining all results",
-      "startLine": 216,
+      "startLine": 208,
       "endLine": 235
     }
   ],


### PR DESCRIPTION
## Fix

Remove two phantom axiom names from section summaries and realign all 6 section line ranges to match actual `## Part` headings in the Lean file.

## Evidence

**Before**:
- Section `key-relationships` summary: `"chromatic_implies_minDeg, four_chromatic_minDeg axioms"` — `chromatic_implies_minDeg` does not exist; only `four_chromatic_minDeg` (line 104) is declared
- Section `bondy-vince` summary: `"bondy_vince_theorem and bondy_vince_gap axioms"` — `bondy_vince_gap` does not exist; only `bondy_vince_theorem` (line 121) is declared
- All 6 section `startLine`/`endLine` values were off from actual `## Part` headers by 1–9 lines

**After**:
- `key-relationships` summary: `"four_chromatic_minDeg axiom: chi(G) = 4 implies minDegree(G) >= 3"`
- `bondy-vince` summary: `"bondy_vince_theorem axiom: minDegree >= 3 implies cycle-length difference <= 2"`
- Section ranges aligned to actual Part headings: I@37, II@88, III@108, IV@131, V@184, VI@208

Numerical counts (`axiomCount: 5`, `sorries: 2`, `lineCount: 235`) remain unchanged and correct.

Closes #13881

---
Automated fix by lean-mechanic agent.