### PR TITLE
audit(erdos-739, erdos-743): mark issues-found — phantom axioms + section line drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8842,9 +8842,9 @@
     },
     "erdos-743": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T09:54:09Z",
+      "result": "issues-found"
     },
     "erdos-744": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8812,9 +8812,9 @@
     },
     "erdos-739": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T09:51:48Z",
+      "result": "issues-found"
     },
     "erdos-74": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Audit tracker updates for two proofs flagged with phantom-axiom narrative + section line drift:

- **erdos-739** — filed as #13895. 2 phantom axioms (`galvin_set_theory_implication`, `shelah_constructibility`) in `originalContributions` and `assumptions`. Section drift 6–10 lines from `set-theory` onward.
- **erdos-743** — filed as #13897. 4 phantom axioms (`gyarfasLehel_stars`, `bollobas_greedy`, `allen_sublinearDegree`, `janzerMontgomery_largeTrees`) in `originalContributions`. Section drift 7–13 lines from `conjecture` onward.

Numerical counts (`axiomCount`, `sorries`, `lineCount`) all correct for both.

## Test plan

- [x] Numerical counts cross-checked against Lean source
- [x] Phantom names confirmed missing via `grep -nE '^axiom '`
- [x] Section drift confirmed by comparing `## ...` header line numbers to `meta.sections[*]`