### PR TITLE
audit(erdos-734): mark issues-found — phantom axioms + section line drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8782,9 +8782,9 @@
     },
     "erdos-734": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T10:02:11Z",
+      "result": "issues-found"
     },
     "erdos-735": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Updates `src/data/proofs/audit-tracker.json` for `erdos-734` with the latest re-audit result.

- `auditCount: 2 -> 3`
- `lastAudited: 2026-04-03 -> 2026-04-29`
- `result: issues-fixed -> issues-found`

## Linked issue

Filed during this audit: #13900 (phantom axioms `pair_count`, `some_size_frequent`, `affine_plane_exists`, `near_uniform_designs_exist` referenced in `originalContributions` / `sections[*].summary` / `sections[*].mathContext` without backing Lean declarations; section line ranges drift past Part headers starting at Part IV).

## Test plan

- [x] Tracker file is the only change
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)