### PR TITLE
audit(erdos-754): re-audit, mark clean after #13879/#13882 fixes

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8918,9 +8918,9 @@
     },
     "erdos-754": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T09:14:02Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T10:16:27Z",
+      "result": "clean"
     },
     "erdos-755": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-754 after the phantom-declaration / section-line-drift fixes from #13879 (issues-found) and #13882 (mechanic fix) landed.
- Verified all meta.json claims against `proofs/Proofs/Erdos754Problem.lean` — everything matches.
- Updates `audit-tracker.json`: `auditCount` 3→4, `result` `issues-found`→`clean`.

## Verification
- 2 axioms: `avis_erdos_pach_lower_bound`, `swanepoel_erdos_754` — matches `axiomCount`
- 3 theorems, 9 definitions, 0 sorries, lineCount 140 — all match
- Section line ranges (Parts I–V + Summary) line up with file structure
- `originalContributions` reference only declarations actually present
- Status `axiomatized` / badge `axiom` correct given the two open axioms

## Test plan
- [x] No code changes — only audit-tracker JSON update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)