### PR TITLE
audit(erdos-748): mark clean — Cameron-Erdős axiomatization verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8876,9 +8876,9 @@
     },
     "erdos-748": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T10:24:13Z",
+      "result": "clean"
     },
     "erdos-749": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-748 (Cameron-Erdős Conjecture). Previous audit on 2026-04-03 marked `issues-fixed`; this re-audit confirms `clean`.
- Verified all numerical claims and 9 section line ranges against `origin/main` `proofs/Proofs/Erdos748Problem.lean`.

## Verification
| Claim | Source | Result |
|-------|--------|--------|
| `lineCount: 325` | `wc -l` | ✓ |
| `axiomCount: 3` | `trivial_lower_bound`, `green_upper_bound`, `precise_asymptotic` | ✓ |
| `theoremCount: 11` | incl. `cameron_erdos_proved`, `erdos_748_summary`, `erdos_748`, 3 OEIS `native_decide` | ✓ |
| `definitionCount: 5` | `IsSumFree`, `IsSumFree'`, `sumFreeSubsets`, `f`, `cameronErdosConjecture` | ✓ |
| `sorries: 0` | scan | ✓ |
| Section ranges | 46-72, 74-89, 91-114, 116-130, 132-217, 219-254, 256-272, 274-289, 291-325 | All accurate ✓ |

The `structure` section (256-272) correctly notes "No axioms or theorems are declared in this section" — it's informal commentary only.

`originalContributions` and `assumptions` list all 3 axioms by name. Description honestly attributes the solution to Green (2004) and Sapozhenko (2003).

Tier C (axiomatized) — `status="axiomatized"`, `badge="axiom"` correctly reflect that Green/Sapozhenko's main results are taken as axioms.

## Test plan
- [x] Numerical counts match Lean source
- [x] Section line ranges accurate
- [x] No phantom axiom references in narrative
- [x] Tier classification matches actual content

🤖 Generated with [Claude Code](https://claude.com/claude-code)