### PR TITLE
audit(erdos-751): mark clean — all claims match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8900,9 +8900,9 @@
     },
     "erdos-751": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T10:43:31Z",
+      "result": "clean"
     },
     "erdos-752": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-751 (Erdős Problem #751: Cycle Lengths in 4-Chromatic Graphs).

All claims in `src/data/proofs/erdos-751/meta.json` verified against `proofs/Proofs/Erdos751Problem.lean`:

- **Numerical**: 235 lines, 5 axioms, 2 sorries, 3 defs (minDegree, maxDegree, minCycleLengthGap), 6 theorems — all match.
- **Named axioms**: chromaticNumber, girth, cycleLengths, four_chromatic_minDeg, bondy_vince_theorem all declared at expected lines.
- **Section ranges**: 37-87, 88-107, 108-130, 131-183, 184-207, 208-235 align with Part I-VI headers.
- **Status**: `axiomatized` / badge `axiom` consistent with 5 real axioms.
- **No phantoms**: no fabricated axioms, no `True` stubs, no Mathlib wrappers.

Marked `clean` in audit-tracker.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --next` returned erdos-751
- [x] meta.json claims verified against `git show HEAD:proofs/Proofs/Erdos751Problem.lean`
- [x] Section endLines = next startLine - 1 (consistent convention)