### PR TITLE
audit(erdos-732): mark issues-found — phantom decls + section line drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8770,9 +8770,9 @@
     },
     "erdos-732": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T10:50:13Z",
+      "result": "issues-found"
     },
     "erdos-733": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Mark `erdos-732` audit result as `issues-found` in `src/data/proofs/audit-tracker.json`
- Issue #13911 documents the findings (phantom `characterization_hard`/`erdos_upper_bound` in `originalContributions` and section narratives; ~16-line drift for `counting`/`asymptotic`/`examples`/`related`/`summary`).
- Numerical counts (3 axioms, 4 theorems, 10 defs, 0 sorries, 316 lines) all verified correct.

## Test plan

- [x] Diff is tracker-only, no Lean source touched
- [x] Issue #13911 filed with detailed reproduction