### PR TITLE
audit(erdos-733): mark issues-found — phantom axioms + count drift (#13913)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8776,9 +8776,9 @@
     },
     "erdos-733": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T10:53:55Z",
+      "result": "issues-found"
     },
     "erdos-734": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Tracker entry for erdos-733 marked `issues-found` (filed issue #13913).
- Findings: phantom axiom names `szemeredi_trotter` and `rich_lines_bound` in `originalContributions` (don't exist in Lean source), `meta.theoremCount` off by 3 (3 → 6), `leanFile.definitionCount` off by 1 (6 → 7).
- Verified correct: `axiomCount=2`, `sorries=2`, `lineCount=274`, `leanFile.theoremCount=6`.

## Test plan

- [ ] Confirm tracker entry updated to `issues-found` with bumped `auditCount`.
- [ ] Confirm issue #13913 contains the phantom-axiom + count-drift evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)