### PR TITLE
fix(erdos-733): remove phantom axioms, correct theorem/def counts

### DIFF
--- a/src/data/proofs/erdos-733/meta.json
+++ b/src/data/proofs/erdos-733/meta.json
@@ -53,8 +53,6 @@
       "richLines definition: lines with >= 2 points",
       "isLineCompatible definition: realizable sequences",
       "countLineCompatible function: sequence count f(n)",
-      "szemeredi_trotter axiom: incidence theorem",
-      "rich_lines_bound axiom: k-rich lines bound",
       "lower_bound axiom: exp(c*sqrt(n)) lower bound",
       "upper_bound axiom: exp(C*sqrt(n)) upper bound",
       "erdos_733 theorem: complete tight bounds",
@@ -62,7 +60,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 274,
-    "theoremCount": 3,
+    "theoremCount": 6,
     "prerequisites": [
       "Combinatorial geometry: point-line incidences",
       "Szemerédi-Trotter incidence theorem",
@@ -118,7 +116,7 @@
     {
       "id": "szemeredi-trotter",
       "title": "The Szemerédi-Trotter Theorem",
-      "summary": "Axiomatized incidence bound and k-rich lines corollary.",
+      "summary": "Motivating exposition only — docstrings state the Szemerédi-Trotter incidence bound and k-rich lines corollary. No axioms or declarations in this section; ST is invoked indirectly through the lower_bound and upper_bound axioms.",
       "startLine": 107,
       "endLine": 133,
       "mathContext": "$I(P, L) \\leq C(n^{2/3}m^{2/3} + n + m)$ for $n$ points and $m$ lines. Corollary: $\\leq O(n^2/k^3 + n/k)$ lines with $\\geq k$ points."
@@ -190,7 +188,7 @@
     "lineCount": 274,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos733Problem.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Fix

Remove phantom `szemeredi_trotter` and `rich_lines_bound` entries from `originalContributions` (lines 113–122 in the Lean file are orphan docstrings with no following declarations). Correct `meta.theoremCount` from 3→6 and `leanFile.definitionCount` from 6→7. Update `szemeredi-trotter` section summary to clarify it contains exposition only, not declarations.

## Evidence

**Before**:
- `originalContributions` listed `szemeredi_trotter axiom: incidence theorem` and `rich_lines_bound axiom: k-rich lines bound` — neither exists as an `axiom` declaration
- `meta.theoremCount: 3` (actual: 6 theorems by grep)
- `leanFile.definitionCount: 6` (actual: 7 defs/abbrevs)

**After**:
- Phantom entries removed; only real `lower_bound` and `upper_bound` axioms remain
- `meta.theoremCount: 6`, `leanFile.definitionCount: 7`
- Section summary corrected

Closes #13913

---
Automated fix by lean-mechanic agent.