### PR TITLE
fix(meta): sync leanFile stats for erdos-345, -460, -783, -931

### DIFF
--- a/src/data/proofs/erdos-345/meta.json
+++ b/src/data/proofs/erdos-345/meta.json
@@ -52,7 +52,7 @@
       "threshold_mono_small axiom"
     ],
     "axiomCount": 5,
-    "lineCount": 191,
+    "lineCount": 199,
     "assumptions": "5 axioms: threshold_squares, threshold_cubes, threshold_fourth, threshold_fifth, powerSeq_complete. 0 sorries."
   },
   "overview": {
@@ -176,10 +176,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 191,
+    "lineCount": 199,
     "axiomCount": 5,
     "theoremCount": 10,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos345Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -55,7 +55,7 @@
       "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erdős's question about individual divergence"
     ],
     "axiomCount": 1,
-    "lineCount": 274,
+    "lineCount": 291,
     "assumptions": "2 axioms: eggleton_erdos_selfridge (deep result), filtered_sum_implies_full. sieve_greedy proved from constructive definition (with hactive guard for sentinel case). sieve_conjectured_bound demoted to def. filtered_sum_implies_full converted from axiom to theorem-with-sorry (axiom integrity)."
   },
   "leanFile": {
@@ -69,10 +69,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 274,
+    "lineCount": 291,
     "axiomCount": 1,
-    "theoremCount": 9,
-    "definitionCount": 8,
+    "theoremCount": 10,
+    "definitionCount": 9,
     "path": "Proofs/Erdos460Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -128,10 +128,10 @@
       "Nat"
     ],
     "namespace": "Erdos783",
-    "lineCount": 392,
+    "lineCount": 420,
     "axiomCount": 0,
-    "theoremCount": 30,
-    "definitionCount": 7,
+    "theoremCount": 31,
+    "definitionCount": 5,
     "path": "Proofs/Erdos783Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/931",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 523,
+    "lineCount": 536,
     "assumptions": "2 axioms: stronger_implies_main (Størmer-type smooth number argument), exists_prime_between_blocks_hard (refined: only the hard case with k₁<n₁, tight gap, all factors ≤n₁ — general statement proved as theorem). Computational evidence: hard case hypotheses are vacuously inconsistent for n₁ ≤ 30 with k₁=k₂=3 (hard_case_vacuous_k3_n30). See Lean source. stronger_implies_main and exists_prime_between_blocks_hard converted from axiom to theorem-with-sorry (axiom integrity: do not assert unverified math).",
     "mathlib_version": "4.26.0"
   },
@@ -151,10 +151,10 @@
       "Finset"
     ],
     "namespace": "Erdos931",
-    "lineCount": 523,
+    "lineCount": 536,
     "axiomCount": 0,
-    "theoremCount": 44,
-    "definitionCount": 6,
+    "theoremCount": 46,
+    "definitionCount": 5,
     "path": "Proofs/Erdos931Problem.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Fix

Sync stale `leanFile` stat fields in 4 gallery entries whose Lean files grew after meta.json was created or last updated.

## Evidence

| Proof | Field | meta.json | Actual | Root cause |
|-------|-------|-----------|--------|-----------|
| erdos-783 | `leanFile.lineCount` | 392 | **420** | `composite_replacement_improves_product` added (e9417f6); `meta.lineCount` was already updated but `leanFile.lineCount` was not |
| erdos-783 | `leanFile.theoremCount` | 30 | **31** | Same commit added the theorem |
| erdos-783 | `leanFile.definitionCount` | 7 | **5** | Overcounted at entry creation |
| erdos-931 | `meta.lineCount` | 523 | **536** | `stronger_implies_main` + `exists_prime_between_blocks_hard` added (dd6bdda); neither section was updated |
| erdos-931 | `leanFile.lineCount` | 523 | **536** | Same |
| erdos-931 | `leanFile.theoremCount` | 44 | **46** | +2 theorems added |
| erdos-931 | `leanFile.definitionCount` | 6 | **5** | Overcounted at entry creation |
| erdos-460 | `meta.lineCount` | 274 | **291** | `filtered_sum_implies_full` axiom→theorem conversion added prose/code |
| erdos-460 | `leanFile.lineCount` | 274 | **291** | Same |
| erdos-460 | `leanFile.theoremCount` | 9 | **10** | +1 theorem from conversion |
| erdos-460 | `leanFile.definitionCount` | 8 | **9** | +1 def from conversion |
| erdos-345 | `meta.lineCount` | 191 | **199** | File grew; never updated |
| erdos-345 | `leanFile.lineCount` | 191 | **199** | Same |
| erdos-345 | `leanFile.definitionCount` | 4 | **5** | Undercounted at entry creation |

**Verified unchanged** (all four): `axiomCount`, `sorries`, `leanFile.theoremCount` for erdos-345 (10 ✓).

---
Automated fix by lean-mechanic agent.