### PR TITLE
fix(meta): sync leanFile lineCount for 4 proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -91,7 +91,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 14005,
+    "lineCount": 14022,
     "axiomCount": 0,
     "sorries": 1,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Chen-Stein method: P(no triple) \u2192 exp(-C(n,3)/d\u00b2) as d \u2192 \u221e). All other theorems fully proved including choose3_mul_six (Pascal induction, 0 sorries).",
     "dateAdded": "2026-04-04",
-    "lineCount": 463,
+    "lineCount": 501,
     "theoremCount": 19,
     "definitionCount": 3,
     "originalContributions": [
@@ -139,7 +139,7 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 463,
+    "lineCount": 501,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -190,7 +190,7 @@
       "Finset"
     ],
     "namespace": "Erdos1018OQ04",
-    "lineCount": 307,
+    "lineCount": 318,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 12,

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -54,7 +54,7 @@
       "Ergodic theory concepts"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 914,
+    "lineCount": 929,
     "relatedProblems": [
       {
         "id": "furstenberg-correspondence",
@@ -148,7 +148,7 @@
   "leanFile": {
     "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
     "filename": "FurstenbergCorrespondenceOQ01.lean",
-    "lineCount": 914,
+    "lineCount": 929,
     "axiomCount": 1,
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields in leanFile sections for 4 gallery proofs whose source files grew after the initial meta.json was written.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| furstenberg-correspondence-oq-01 | meta.lineCount | 914 | 929 |
| furstenberg-correspondence-oq-01 | leanFile.lineCount | 914 | 929 |
| erdos-1018-oq-04 | leanFile.lineCount | 307 | 318 |
| ballot-problem-oq-03-oq-01-oq-02 | leanFile.lineCount | 14005 | 14022 |
| birthday-problem-oq-03-oq-01-oq-02 | meta.lineCount | 463 | 501 |
| birthday-problem-oq-03-oq-01-oq-02 | leanFile.lineCount | 463 | 501 |

All counts verified with `wc -l` against the Lean source files.

---
Automated fix by lean-mechanic agent.