### PR TITLE
fix(erdos-732): remove phantom axiom narrative + correct section line ranges

### DIFF
--- a/src/data/proofs/erdos-732/meta.json
+++ b/src/data/proofs/erdos-732/meta.json
@@ -54,9 +54,7 @@
       "PairCountCondition: necessary pair-counting condition",
       "pair_count_necessary: necessity theorem",
       "CharacterizationQuestion: Q1 formalization",
-      "characterization_hard: no simple characterization axiom",
       "B: counting function for block-compatible sequences",
-      "erdos_upper_bound: Erdős's upper bound axiom",
       "alon_lower_bound: Alon's lower bound axiom",
       "question_2_solved: Q2 resolution theorem",
       "AsymptoticConstant: asymptotic form",
@@ -128,48 +126,48 @@
     {
       "id": "characterization",
       "title": "Question 1 - Characterization (OPEN)",
-      "summary": "Formalizes CharacterizationQuestion as the existence of a decidable necessary-and-sufficient predicate. Axiomatizes characterization_hard: pair-counting is not sufficient.",
+      "summary": "Formalizes CharacterizationQuestion as the existence of a decidable necessary-and-sufficient predicate. Notes via docstring that pair-counting is not sufficient; no axiom is declared for this claim.",
       "startLine": 126,
       "endLine": 153,
-      "mathContext": "Axiomatized: Formalizes CharacterizationQuestion as the existence of a decidable necessary-and-sufficient predicate. Axiomatizes characterization_hard: pair-counting is not sufficient."
+      "mathContext": "Formal definition: Formalizes CharacterizationQuestion as the existence of a decidable necessary-and-sufficient predicate. Notes via docstring that pair-counting is not sufficient; no axiom is declared for this claim."
     },
     {
       "id": "counting",
       "title": "Question 2 - Counting (SOLVED)",
-      "summary": "Defines B(n), axiomatizes Erdős's upper bound and Alon's lower bound, and axiomatizes question_2_solved combining them.",
+      "summary": "Defines B(n), axiomatizes Alon's lower bound (alon_lower_bound) and question_2_solved. Notes Erdős's upper bound via docstring only; it is not axiomatized in this file.",
       "startLine": 154,
-      "endLine": 202,
-      "mathContext": "Formal definition: Defines B(n), axiomatizes Erdős's upper bound and Alon's lower bound, and axiomatizes question_2_solved combining them."
+      "endLine": 186,
+      "mathContext": "Formal definition: Defines B(n), axiomatizes Alon's lower bound (alon_lower_bound) and question_2_solved. Notes Erdős's upper bound via docstring only; it is not axiomatized in this file."
     },
     {
       "id": "asymptotic",
       "title": "The Asymptotic Constant",
       "summary": "Defines AsymptoticConstant (B(n) = 2^{(c+o(1))√n log n}) and proves constant_at_least_half (c ≥ 1/2) from alon_lower_bound using norm_num.",
-      "startLine": 203,
-      "endLine": 234,
+      "startLine": 187,
+      "endLine": 217,
       "mathContext": "Defines AsymptoticConstant (B(n) = $$2^{{(c+o(1))√n $\\log n$}$}$) and proves constant_at_least_half (c $\\geq$ 1/2) from alon_lower_bound using norm_num."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
       "summary": "Axiomatizes example_n3 (IsBlockCompatible [3] 3) and verifies pair-counting for n=4 ([4] and [2,2,2,2,2,2]) and n=6 ([3,3,3,3,3]) using simp/norm_num.",
-      "startLine": 235,
-      "endLine": 280,
+      "startLine": 219,
+      "endLine": 257,
       "mathContext": "Axiomatized: Axiomatizes example_n3 (IsBlockCompatible [3] 3) and verifies pair-counting for n=4 ([4] and [2,2,2,2,2,2]) and n=6 ([3,3,3,3,3]) using simp/norm_num."
     },
     {
       "id": "related",
       "title": "Related Problems",
       "summary": "Notes connections to Problem #733 (line-compatible sequences) and Steiner systems S(2,k,n).",
-      "startLine": 281,
-      "endLine": 297,
+      "startLine": 259,
+      "endLine": 272,
       "mathContext": "Mathematical content: Notes connections to Problem #733 (line-compatible sequences) and Steiner systems S(2,k,n)."
     },
     {
       "id": "summary",
       "title": "Summary Theorems",
       "summary": "erdos_732_summary packages Q2-solved + pair-counting necessity as a conjunction. erdos_732 is an alias.",
-      "startLine": 298,
+      "startLine": 274,
       "endLine": 316,
       "mathContext": "Mathematical content: erdos_732_summary packages Q2-solved + pair-counting necessity as a conjunction. erdos_732 is an alias."
     }


### PR DESCRIPTION
## Fix

Remove `characterization_hard` and `erdos_upper_bound` from `originalContributions` in meta.json — neither axiom exists in the Lean source. Both are orphan docstrings only. Update section summaries and correct stale line ranges for 5 sections.

## Evidence

**Before**: `originalContributions` listed `characterization_hard: no simple characterization axiom` and `erdos_upper_bound: Erdős's upper bound axiom`. Section line ranges for `counting`, `asymptotic`, `examples`, `related`, `summary` were off by ~16 lines.

**After**: Only real declarations listed. `sections[characterization].summary` and `sections[counting].summary` accurately reflect what is axiomatized vs. documented. Section line ranges match actual Lean source:
- `counting`: 154–186 (was 154–202)
- `asymptotic`: 187–217 (was 203–234)
- `examples`: 219–257 (was 235–280)
- `related`: 259–272 (was 281–297)
- `summary`: 274–316 (was 298–316)

Closes #13911

---
Automated fix by lean-mechanic agent.