### PR TITLE
feat(erdos-820): add gcd_characterization to Aristotle companion

### DIFF
--- a/proofs/Proofs/Erdos820Aristotle.lean
+++ b/proofs/Proofs/Erdos820Aristotle.lean
@@ -122,6 +122,13 @@ theorem prime_dvd_gcd_pow_cong_right {p k l n : ℕ} (hp : p.Prime) (hl : l ≥ 
   have hdvd : p ∣ l^n - 1 := dvd_trans h (Nat.gcd_dvd_right _ _)
   exact (Nat.modEq_iff_dvd' hln).mpr hdvd
 
+-- If p | gcd(k^n-1, l^n-1), there exists d | n with k^d ≡ 1 [MOD p] and l^d ≡ 1 [MOD p].
+-- Proof: take d = n; k^n ≡ 1 [MOD p] from p | k^n-1 (via gcd_dvd_left), similarly for l.
+theorem gcd_characterization (k l n p : ℕ) (hp : Nat.Prime p) :
+    p ∣ Nat.gcd (k^n - 1) (l^n - 1) →
+    ∃ d : ℕ, d ∣ n ∧ (k^d ≡ 1 [MOD p]) ∧ (l^d ≡ 1 [MOD p]) := by
+  sorry
+
 /-
   ## Section 4: Concrete GCD Computations for Small n
 


### PR DESCRIPTION
## Fix

Add `gcd_characterization` theorem to the existing `Erdos820Aristotle.lean` companion file as a new Aristotle target.

## Evidence

**Before**: The companion file (introduced in #13016) had only basic gcd symmetry, divisibility, and small-case computation theorems — no theorem about prime divisibility yielding modular congruence.

**After**: Added `gcd_characterization`:
```lean
theorem gcd_characterization (k l n p : ℕ) (hp : Nat.Prime p) :
    p ∣ Nat.gcd (k^n - 1) (l^n - 1) →
    ∃ d : ℕ, d ∣ n ∧ (k^d ≡ 1 [MOD p]) ∧ (l^d ≡ 1 [MOD p])
```

**Why Aristotle-suitable**: The trivial witness is `d = n`. Then:
- `d ∣ n` is `dvd_refl n`
- `k^n ≡ 1 [MOD p]` follows from `p ∣ k^n - 1` (via `gcd_dvd_left`) using `Nat.modEq_iff_dvd'`
- `l^n ≡ 1 [MOD p]` similarly via `gcd_dvd_right`

The companion already has helper lemmas `prime_dvd_gcd_pow_cong_left/right` that Aristotle can use as scaffolding.

---
Automated fix by lean-mechanic agent.