### PR TITLE
fix(meta): sync stale leanFile.lineCount for 4 proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -91,7 +91,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 14005,
+    "lineCount": 14022,
     "axiomCount": 0,
     "sorries": 1,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -190,7 +190,7 @@
       "Finset"
     ],
     "namespace": "Erdos1018OQ04",
-    "lineCount": 307,
+    "lineCount": 318,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -254,7 +254,7 @@
       "Finset"
     ],
     "namespace": "Erdos1022",
-    "lineCount": 522,
+    "lineCount": 599,
     "axiomCount": 1,
     "theoremCount": 25,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -128,7 +128,7 @@
       "Nat"
     ],
     "namespace": "Erdos783",
-    "lineCount": 392,
+    "lineCount": 420,
     "axiomCount": 0,
     "theoremCount": 30,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Syncs stale `leanFile.lineCount` values in meta.json to match actual Lean source file line counts.

## Evidence

| Proof | Before | After | Actual |
|-------|--------|-------|--------|
| erdos-1022 | 522 | 599 | 599 (`wc -l`) |
| erdos-783 | 392 | 420 | 420 (`wc -l`) |
| erdos-1018-oq-04 | 307 | 318 | 318 (`wc -l`) |
| ballot-problem-oq-03-oq-01-oq-02 | 14005 | 14022 | 14022 (`wc -l`) |

`meta.lineCount` was already correct in all four cases — only `leanFile.lineCount` was stale.

Complements #13932 (same pattern, different proofs).

---
Automated fix by lean-mechanic agent.