### PR TITLE
fix(meta): add missing leanFile.path to sperner-ndim-oq-04

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -246,6 +246,7 @@
       "Finset",
       "BigOperators"
     ],
+    "path": "Proofs/SpernerNDimOQ04.lean",
     "namespace": "SpernerNDimOQ04",
     "lineCount": 1126,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Add missing `leanFile.path` field to `sperner-ndim-oq-04` meta.json.

## Evidence

**Before**: `leanFile` section had no `path` field (was `null`), making it the only gallery proof with a populated `leanFile` section but no file path.

**After**: `"path": "Proofs/SpernerNDimOQ04.lean"` — verified against `git ls-files` (canonical filename) and confirmed line count 1126 matches.

Sibling proof `sperner-ndim-oq-03` uses the same format: `"path": "Proofs/SpernerNDimOQ03.lean"`.

---
Automated fix by lean-mechanic agent.