### PR TITLE
fix(erdos-613): prove companion sorries via simp+omega

### DIFF
--- a/proofs/Proofs/Erdos613Aristotle.lean
+++ b/proofs/Proofs/Erdos613Aristotle.lean
@@ -19,16 +19,19 @@ open Erdos613 Nat
     This is a pure binomial coefficient identity: C(2n+1,2) - C(n,2) - 1. -/
 theorem critical_edge_count_formula_ari (n : ℕ) (hn : n ≥ 1) :
     criticalEdgeCount n = n * n + n + (n * (n + 1)) / 2 - 1 := by
-  sorry
+  simp only [criticalEdgeCount, Nat.choose_two_right]
+  omega
 
 /-- criticalEdgeCount is strictly increasing for n ≥ 1 -/
 theorem criticalEdgeCount_mono (n : ℕ) (hn : n ≥ 1) :
     criticalEdgeCount n < criticalEdgeCount (n + 1) := by
-  sorry
+  simp only [criticalEdgeCount, Nat.choose_two_right]
+  omega
 
 /-- criticalEdgeCount n ≥ 2 for all n ≥ 1 -/
 theorem criticalEdgeCount_pos (n : ℕ) (hn : n ≥ 1) :
     criticalEdgeCount n ≥ 2 := by
-  sorry
+  simp only [criticalEdgeCount, Nat.choose_two_right]
+  omega
 
 end Erdos613Aristotle


### PR DESCRIPTION
## Fix

Fills in 3 sorry'd theorems in `proofs/Proofs/Erdos613Aristotle.lean` using `simp only [criticalEdgeCount, Nat.choose_two_right]; omega`.

## Evidence

**Before**: 3 theorem sorries in companion file  
**After**: Proofs filled in using pattern confirmed working in PR #13917

All three lemmas — the binomial identity, strict monotonicity, and lower bound — follow from expanding `criticalEdgeCount` via `Nat.choose_two_right` and closing with `omega`.

The same technique (`simp only [criticalEdgeCount, Nat.choose_two_right]; omega`) was already validated in PR #13917 for the equivalent `critical_edge_count_formula'`.

---
Automated fix by lean-mechanic agent.