### PR TITLE
fix(meta): correct status axiomatized→formalized for 3 sorry-only proofs

### DIFF
--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -5,7 +5,7 @@
   "description": "Prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)_{\u2135\u2080}\u00b2 without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
   "meta": {
     "erdosNumber": 1168,
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1168Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/931",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos931Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "consecutive-integers",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 2,
     "erdosNumber": 931,
     "erdosUrl": "https://erdosproblems.com/931",

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/HurwitzTheorem.lean",
     "tags": [
       "algebra",


### PR DESCRIPTION
## Fix

Corrects `meta.status` from `"axiomatized"` to `"formalized"` for three proofs that have outstanding sorry'd theorems but no declared `axiom` statements.

## Evidence

| Proof | Old status | New status | Reason |
|---|---|---|---|
| erdos-931 | axiomatized | formalized | 2 axioms converted to `theorem … := by sorry`; 0 `axiom` declarations remain |
| erdos-1168 | axiomatized | formalized | Axiom replaced with structured sorry'd decomposition; 0 `axiom` declarations |
| hurwitz-theorem-oq-03 | axiomatized | formalized | 1 sorry for Clifford algebra impossibility; 0 `axiom` declarations |

**Before**: `status: "axiomatized"` — implies `axiom` declarations exist  
**After**: `status: "formalized"` — accurately reflects sorry'd theorems remaining

Also corrects `erdos-931` badge from `"axiom"` → `"wip"` since no axiom declarations exist in the Lean file (`meta.axiomCount: 0`, `leanFile.axiomCount: 0`).

The status/badge definitions (from CLAUDE.md):
- `axiomatized` / `axiom` = has `axiom` declarations or structure-encoded assumptions
- `formalized` = has sorries remaining (but no axioms)

---
Automated fix by lean-mechanic agent.