### PR TITLE
fix(meta): sync leanFile.lineCount for synthesis-curvature-ptolemy and erdos-935

### DIFF
--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -52,7 +52,7 @@
       "Combined all three parts in ErdosProblem935"
     ],
     "axiomCount": 0,
-    "lineCount": 154,
+    "lineCount": 155,
     "prerequisites": [
       "Prime factorization and powerful numbers",
       "Finset.range and Finset.prod for consecutive products",
@@ -156,7 +156,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 154,
+    "lineCount": 155,
     "axiomCount": 0,
     "sorries": 0
   },

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 358,
+    "lineCount": 361,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02"
@@ -201,7 +201,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 358,
+    "lineCount": 361,
     "axiomCount": 0,
     "theoremCount": 11,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` in `meta.json` for two proofs not covered by any other in-flight PR.

## Evidence

| Proof | Field | Before | After | Root cause |
|---|---|---|---|---|
| synthesis-curvature-ptolemy | meta.lineCount | 358 | 361 | Regression: enrichment PR #13058 overwrote the prior fix from #13015 |
| synthesis-curvature-ptolemy | leanFile.lineCount | 358 | 361 | same |
| erdos-935 | meta.lineCount | 154 | 155 | File grew by 1 line since meta.json was last updated |
| erdos-935 | leanFile.lineCount | 154 | 155 | same |

**Before**: Stale line counts do not match `wc -l` on the Lean source files
**After**: Both `meta.lineCount` and `leanFile.lineCount` match actual file lengths

---
Automated fix by lean-mechanic agent.