### PR TITLE
fix(meta): sync stale meta.theoremCount for 11 proofs

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
     "lineCount": 380,
-    "theoremCount": 9,
+    "theoremCount": 6,
     "definitionCount": 5,
     "originalContributions": [
       "IsClub: club sets (closed unbounded subsets of ordinals below \u03ba.ord)",


### PR DESCRIPTION
## Fix

Corrects stale `meta.theoremCount` values in 11 gallery proofs where the count drifted from the actual Lean source declaration count.

## Evidence

`meta.theoremCount` is the count in the outer `meta` section; `leanFile.theoremCount` (already correct) is the count in the `leanFile` section. All fixes align `meta.theoremCount` with the public `theorem`/`lemma` declaration count verified by `grep -c '^theorem \|^lemma '` on each file.

| Proof | Before | After | Actual (grep) |
|---|---|---|---|
| collatz-cycles-oq-04 | 10 | 13 | 13 |
| shannon-entropy-oq-03 | 12 | 11 | 11 |
| binomial-theorem-oq-03-oq-02-oq-03 | 11 | 12 | 12 |
| descartes-rule-of-signs-oq-01-oq-01 | 10 | 9 | 9 |
| arithmetic-series-oq-02-oq-04-oq-01 | 11 | 12 | 12 |
| e-transcendental-oq-01 | 18 | 15 | 15 |
| dirichlets-theorem-oq-03 | 8 | 6 | 6 |
| cantor-diagonalization-oq-02-oq-03-oq-02 | 9 | 6 | 6 |
| amgm-inequality-oq-03-oq-02-oq-04 | 2 | 5 | 5 public (6 total incl. private) |
| cantor-diagonalization-oq-01-oq-01-oq-02 | 8 | 16 | 16 |
| angle-trisection-oq-02-oq-01-oq-02 | 10 | 15 | 15 |

---
Automated fix by lean-mechanic agent.