### PR TITLE
fix(meta): correct leanFile.theoremCount for 2 proofs

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -65,7 +65,7 @@
     "namespace": "GaloisCriterion",
     "lineCount": 242,
     "axiomCount": 1,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniOQ04OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
@@ -112,7 +112,7 @@
     "namespace": "DiscreteIsoperimetric1D",
     "lineCount": 136,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/IsoperimetricTheoremOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.theoremCount` values in two gallery proofs where theorem declarations were added to the Lean source after the metadata was generated.

## Evidence

**abel-ruffini-oq-04-oq-03** (`Proofs/AbelRuffiniOQ04OQ03.lean`):
- **Before**: `leanFile.theoremCount: 6`
- **After**: `leanFile.theoremCount: 8`
- **Actual**: 8 theorems — `solvableByRad_implies_solvableGal`, `not_solvableByRad_of_not_solvableGal`, `galois_criterion`, `galois_criterion_rationals`, `solvable_gal_means_radical_formula`, `abel_ruffini_as_galois_special_case`, `not_isSolvable_gal_of_perm_iso`, `not_solvableByRad_of_perm_gal`

**isoperimetric-theorem-oq-02** (`Proofs/IsoperimetricTheoremOQ02.lean`):
- **Before**: `leanFile.theoremCount: 4`
- **After**: `leanFile.theoremCount: 5`
- **Actual**: 5 declarations — `mem_edgeBoundary` (lemma), `edgeBoundary_card_ge_two`, `edgeBoundary_Icc`, `edgeBoundary_Icc_card`, `discrete_isoperimetric_1d`

Verified with `grep -c '^theorem \|^lemma '` on each source file.

---
Automated fix by lean-mechanic agent.