### PR TITLE
fix(aristotle): prove companion sorries in Erdos338 and Erdos608

### DIFF
--- a/proofs/Proofs/Erdos338Aristotle.lean
+++ b/proofs/Proofs/Erdos338Aristotle.lean
@@ -20,13 +20,23 @@ namespace Erdos338
 theorem mul_self_mem_squares (k : ℕ) : k * k ∈ squares := ⟨k, rfl⟩
 
 /-- k^2 belongs to the squares set (since k^2 = k*k). -/
-theorem sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares := by sorry
+theorem sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares := ⟨k, by ring⟩
 
 /-- Lagrange's four-squares theorem recast as IsBasisOfOrder.
     Every natural number n is a sum of four perfect squares (Nat.sum_four_squares).
     Proof: take N = 0; for any n ≥ 0, Nat.sum_four_squares n gives a b c d with
     a^2 + b^2 + c^2 + d^2 = n. Use multiset {a^2, b^2, c^2, d^2}:
     each element is in squares, card = 4 ≤ 4, Multiset.sum = n. -/
-theorem squares_order_four_aristotle : IsBasisOfOrder squares 4 := by sorry
+theorem squares_order_four_aristotle : IsBasisOfOrder squares 4 := by
+  refine ⟨0, fun n _ => ?_⟩
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares n
+  refine ⟨↑([a ^ 2, b ^ 2, c ^ 2, d ^ 2] : List ℕ), ?_, ?_, ?_⟩
+  · intro x hx
+    simp only [Multiset.mem_coe, List.mem_cons, List.mem_nil_iff, or_false] at hx
+    rcases hx with rfl | rfl | rfl | rfl
+    all_goals exact ⟨_, by ring⟩
+  · simp [Multiset.card_coe]
+  · simp only [Multiset.coe_sum, List.sum_cons, List.sum_nil, add_zero]
+    linarith
 
 end Erdos338

--- a/proofs/Proofs/Erdos608ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos608ProblemAristotle.lean
@@ -18,12 +18,37 @@ open Real
 noncomputable def c : ℝ := (2 + Real.sqrt 2) / 16
 
 /-- c ≈ 0.2134, so 0.213 < c < 0.214. -/
-lemma c_approx : c > 0.213 ∧ c < 0.214 := by sorry
+lemma c_approx : c > 0.213 ∧ c < 0.214 := by
+  unfold c
+  constructor
+  · rw [gt_iff_lt, lt_div_iff (by norm_num : (16 : ℝ) > 0)]
+    have h : (1.408 : ℝ) < Real.sqrt 2 := by
+      calc (1.408 : ℝ) = Real.sqrt ((1.408 : ℝ) ^ 2) :=
+            (Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 1.408)).symm
+        _ < Real.sqrt 2 := Real.sqrt_lt_sqrt (by norm_num) (by norm_num)
+    linarith
+  · rw [div_lt_iff (by norm_num : (16 : ℝ) > 0)]
+    have h : Real.sqrt 2 < (1.424 : ℝ) := by
+      calc Real.sqrt 2 < Real.sqrt ((1.424 : ℝ) ^ 2) :=
+            Real.sqrt_lt_sqrt (by norm_num) (by norm_num : (2 : ℝ) < (1.424 : ℝ) ^ 2)
+        _ = 1.424 := Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 1.424)
+    linarith
 
 /-- c < 2/9, proving Erdős's original conjecture is false. -/
-lemma c_lt_two_ninths : c < 2/9 := by sorry
+lemma c_lt_two_ninths : c < 2/9 := by
+  unfold c
+  rw [div_lt_div_iff (by norm_num : (16 : ℝ) > 0) (by norm_num : (9 : ℝ) > 0)]
+  have h : Real.sqrt 2 < 14 / 9 := by
+    calc Real.sqrt 2 < Real.sqrt ((14 / 9 : ℝ) ^ 2) :=
+          Real.sqrt_lt_sqrt (by norm_num) (by norm_num : (2 : ℝ) < (14 / 9) ^ 2)
+      _ = 14 / 9 := Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 14 / 9)
+  linarith
 
 /-- c > 0. -/
-lemma c_pos : c > 0 := by sorry
+lemma c_pos : c > 0 := by
+  unfold c
+  apply div_pos
+  · linarith [Real.sqrt_nonneg 2]
+  · norm_num
 
 end Erdos608


### PR DESCRIPTION
## Fix

Proves two sets of companion file sorries via standard Lean tactics, eliminating the need for Aristotle submission on these lemmas.

## Evidence

**Erdos338Aristotle.lean**

- `sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares` — proved via `⟨k, by ring⟩` since `squares = {n | ∃ k, n = k * k}` and `k^2 = k*k` by ring.
- `squares_order_four_aristotle : IsBasisOfOrder squares 4` — proved via `Nat.sum_four_squares` (Lagrange's theorem in Mathlib): take N=0, for any n get a,b,c,d with a²+b²+c²+d²=n, witness multiset `[a², b², c², d²]` with card 4 ≤ 4 and the correct sum.

**Erdos608ProblemAristotle.lean** (c = (2 + √2)/16 ≈ 0.2134)

- `c_pos` — proved via `div_pos` + `sqrt_nonneg`.
- `c_lt_two_ninths` — proved by showing `√2 < 14/9` via `sqrt_lt_sqrt` (since `2 < (14/9)²`), then `linarith`.
- `c_approx` — proved by bounding `1.408 < √2 < 1.424` via `sqrt_lt_sqrt` on both sides, then `linarith`.

---
Automated fix by lean-mechanic agent.