### PR TITLE
feat(aristotle): add companion for erdos-630 (list choosability lemmas)

### DIFF
--- a/proofs/Proofs/Erdos630Aristotle.lean
+++ b/proofs/Proofs/Erdos630Aristotle.lean
@@ -1,0 +1,53 @@
+/-
+  Aristotle companion for Erdős Problem #630: List Chromatic Number of Planar Bipartite Graphs
+
+  Routine supporting lemmas for automated proof search by Aristotle.
+  See Erdos630Problem.lean for the main formalization.
+
+  Included targets (5):
+  - isKChoosable_mono: IsKChoosable is upward monotone in k
+  - isListColoring_adj: adjacent vertices receive different colors
+  - bipartite_two_colorable: bipartite graphs are 2-colorable
+  - bipartite_chi_le_two: bipartite graphs have chromatic number ≤ 2
+  - natClog_ge_one: Nat.clog 2 n ≥ 1 for n ≥ 2 (for lower bound statements)
+-/
+
+import Mathlib
+import Proofs.GraphCore
+import Proofs.Erdos630Problem
+
+namespace Erdos630Aristotle
+
+open Erdos630 GraphCore SimpleGraph Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- IsKChoosable is upward-monotone: if G is k-choosable and k ≤ k', then G is k'-choosable.
+    Any list of size ≥ k' also has size ≥ k, so the same coloring exists. -/
+theorem isKChoosable_mono (G : SimpleGraph V) {k k' : ℕ} (hk : k ≤ k')
+    (h : IsKChoosable G k) : IsKChoosable G k' := by
+  sorry
+
+/-- From a valid list coloring, adjacent vertices receive different colors. -/
+theorem isListColoring_adj {G : SimpleGraph V} {C : Type*} [DecidableEq C]
+    {L : ListAssignment V C} {f : V → C}
+    (hf : IsListColoring G L f) {v w : V} (hadj : G.Adj v w) : f v ≠ f w := by
+  sorry
+
+/-- From a valid list coloring, each vertex's color belongs to its list. -/
+theorem isListColoring_mem {G : SimpleGraph V} {C : Type*} [DecidableEq C]
+    {L : ListAssignment V C} {f : V → C}
+    (hf : IsListColoring G L f) (v : V) : f v ∈ L v := by
+  sorry
+
+/-- Bipartite graphs are 2-colorable: the bipartition gives a 2-coloring. -/
+theorem bipartite_isKColorable (G : SimpleGraph V) (hbip : G.IsBipartite) :
+    GraphCore.IsKColorable G 2 := by
+  sorry
+
+/-- The chromatic number of a bipartite graph is at most 2. -/
+theorem bipartite_chromaticNumber_le_two (G : SimpleGraph V) (hbip : G.IsBipartite) :
+    GraphCore.chromaticNumber G ≤ 2 := by
+  sorry
+
+end Erdos630Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #630 (List Chromatic Number of Planar Bipartite Graphs).

## Targets (5 routine lemmas)

- **isKChoosable_mono**: `IsKChoosable` is upward-monotone — if G is k-choosable and k ≤ k', then G is k'-choosable
- **isListColoring_adj**: adjacent vertices receive different colors (extraction from `IsListColoring`)
- **isListColoring_mem**: each vertex's color belongs to its assigned list
- **bipartite_isKColorable**: bipartite graphs are 2-colorable (standard graph theory)
- **bipartite_chromaticNumber_le_two**: bipartite graphs have chromatic number ≤ 2

## Pre-submission checklist

- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (all are supporting facts, not the main Alon-Tarsi theorem)

---
Automated fix by lean-mechanic agent.