### PR TITLE
feat(aristotle): add companion for erdos-553 (Ramsey coloring lemmas)

### DIFF
--- a/proofs/Proofs/Erdos553Aristotle.lean
+++ b/proofs/Proofs/Erdos553Aristotle.lean
@@ -1,0 +1,55 @@
+/-
+  Aristotle companion for Erdős Problem #553: Multi-Color Ramsey Asymptotics
+
+  Routine supporting lemmas for automated proof search by Aristotle.
+  See Erdos553Problem.lean for the main formalization.
+
+  Note: R_3_n, R_3_3_n, and R are defined via Nat.find on sorry witnesses —
+  Aristotle skips those definitions. This companion focuses on:
+  - Structure lemmas about EdgeColoring and IsMonochromaticClique
+  - Turán-type edge count bounds for triangle-free graphs
+  - Asymptotic equivalence reflexivity and symmetry
+
+  Included targets (5):
+  - isMonochromaticClique_subset: sub-cliques of monochromatic cliques are monochromatic
+  - hasMonochromaticTriangle_of_clique3: a 3-monochromatic clique contains a triangle
+  - edgeColoring_isSymmetric_comm: symmetric colorings satisfy c(u,v) = c(v,u)
+  - asymptoticEquiv_refl: f ≍ f (reflexivity of asymptotic equivalence)
+  - triangle_free_turan: triangle-free graphs have at most n²/4 edges (Mantel)
+-/
+
+import Mathlib
+import Proofs.Erdos553Problem
+
+namespace Erdos553Aristotle
+
+open Finset Function Set SimpleGraph
+
+/-- A sub-clique of a monochromatic clique is also monochromatic. -/
+theorem isMonochromaticClique_subset {n k : ℕ} (c : EdgeColoring n k)
+    (S T : Finset (Fin n)) (col : Fin k)
+    (hST : S ⊆ T) (hT : IsMonochromaticClique c T col) :
+    IsMonochromaticClique c S col := by
+  sorry
+
+/-- A symmetric coloring satisfies c(u,v) = c(v,u). -/
+theorem edgeColoring_isSymmetric_comm {n k : ℕ} (c : EdgeColoring n k)
+    (hsym : c.IsSymmetric) (i j : Fin n) : c (i, j) = c (j, i) := by
+  sorry
+
+/-- HasMonochromaticClique with size 3 gives a monochromatic triangle. -/
+theorem hasMonochromaticTriangle_of_clique3 {n k : ℕ} (c : EdgeColoring n k) (col : Fin k)
+    (h : HasMonochromaticClique c col 3) : HasMonochromaticTriangle c col := by
+  sorry
+
+/-- Asymptotic equivalence is reflexive: f ≍ f for any f. -/
+theorem asymptoticEquiv_refl (f : ℕ → ℝ) (hf : ∀ n, 0 ≤ f n) :
+    AsymptoticEquiv f f := by
+  sorry
+
+/-- Turán / Mantel: a triangle-free graph on n vertices has at most n²/4 edges. -/
+theorem triangle_free_turan {n : ℕ} (G : SimpleGraph (Fin n)) (hG : G.CliqueFree 3) :
+    G.edgeFinset.card ≤ n ^ 2 / 4 := by
+  sorry
+
+end Erdos553Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #553 (Multi-Color Ramsey Asymptotics).

Note: `R_3_n`, `R_3_3_n`, and `R` are defined via `Nat.find` on sorry witnesses — Aristotle skips those. This companion targets lemmas that do not depend on sorry-defined functions.

## Targets (5 routine lemmas)

- **isMonochromaticClique_subset**: sub-cliques of monochromatic cliques are monochromatic
- **edgeColoring_isSymmetric_comm**: symmetric colorings satisfy c(u,v) = c(v,u)
- **hasMonochromaticTriangle_of_clique3**: a 3-clique in one color contains a triangle
- **asymptoticEquiv_refl**: `f ≍ f` (reflexivity of asymptotic equivalence)
- **triangle_free_turan**: Mantel's theorem — triangle-free graphs have ≤ n²/4 edges

## Pre-submission checklist

- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (all are supporting structural lemmas)

---
Automated fix by lean-mechanic agent.