### PR TITLE
feat(aristotle): add companion for erdos-548 (Erdős-Sós graph lemmas)

### DIFF
--- a/proofs/Proofs/Erdos548Aristotle.lean
+++ b/proofs/Proofs/Erdos548Aristotle.lean
@@ -1,0 +1,53 @@
+/-
+  Aristotle companion for Erdős Problem #548: The Erdős-Sós Conjecture
+
+  Routine supporting lemmas for automated proof search by Aristotle.
+  See Erdos548Problem.lean for the main formalization.
+
+  Note: extremalNumber is defined via Nat.sInf on a sorry-based bound;
+  Aristotle skips that. This companion focuses on concrete graph constructions
+  (pathGraph, starGraph) and the handshaking lemma.
+
+  Included targets (5):
+  - pathGraph_adj_symm: adjacency in the path graph is symmetric (by definition)
+  - starGraph_center_adj: center vertex is adjacent to every leaf
+  - starGraph_adj_symm: adjacency in the star graph is symmetric (by definition)
+  - sum_degrees_twice_edges_ari: handshaking lemma for edgeCount
+  - containsSubgraph_refl: every graph contains itself as a subgraph
+-/
+
+import Mathlib
+import Proofs.Erdos548Problem
+
+namespace Erdos548Aristotle
+
+open Erdos548 SimpleGraph Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- Adjacency in the path graph is symmetric: if i→j then j→i. -/
+theorem pathGraph_adj_symm (n : ℕ) (i j : Fin n) :
+    (pathGraph n).Adj i j ↔ (pathGraph n).Adj j i := by
+  sorry
+
+/-- The center vertex (index 0) is adjacent to every leaf in the star graph. -/
+theorem starGraph_center_adj (k : ℕ) (hk : k ≥ 1) (j : Fin (k + 1))
+    (hj : j.val ≠ 0) : (starGraph k).Adj ⟨0, Nat.zero_lt_succ k⟩ j := by
+  sorry
+
+/-- Adjacency in the star graph is symmetric. -/
+theorem starGraph_adj_symm (k : ℕ) (i j : Fin (k + 1)) :
+    (starGraph k).Adj i j ↔ (starGraph k).Adj j i := by
+  sorry
+
+/-- The handshaking lemma: sum of degrees equals twice the edge count.
+    Uses Mathlib's SimpleGraph.sum_degrees_eq_twice_card_edges. -/
+theorem sum_degrees_twice_edges_ari (G : SimpleGraph V) [DecidableRel G.Adj] :
+    (Finset.univ.sum fun v => G.degree v) = 2 * G.edgeFinset.card := by
+  sorry
+
+/-- Every graph contains itself as a subgraph (identity injection). -/
+theorem containsSubgraph_refl (G : SimpleGraph V) : ContainsSubgraph G G := by
+  sorry
+
+end Erdos548Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #548 (The Erdős-Sós Conjecture).

Note: `extremalNumber` is defined via `Nat.sInf` — Aristotle skips that. This companion focuses on concrete graph structure lemmas and the handshaking lemma.

## Targets (5 routine lemmas)

- **pathGraph_adj_symm**: adjacency in the path graph is symmetric (by construction)
- **starGraph_center_adj**: center vertex is adjacent to every leaf in the star graph
- **starGraph_adj_symm**: adjacency in the star graph is symmetric (by construction)
- **sum_degrees_twice_edges_ari**: handshaking lemma — sum of degrees = 2 × edge count
- **containsSubgraph_refl**: every graph contains itself as a subgraph (identity injection)

## Pre-submission checklist

- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (all are structural supporting lemmas)

---
Automated fix by lean-mechanic agent.