### PR TITLE
fix(meta): sync stale leanFile.lineCount for 6 proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -24,7 +24,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
-    "lineCount": 208,
+    "lineCount": 207,
     "assumptions": "1 sorry: final ncard/ENNReal assembly for uniformOn_fiber_transfer' (Mathlib API navigation, not a mathematical gap)."
   },
   "overview": {
@@ -125,7 +125,7 @@
       "Proofs.BallotProblemOQ01OQ02"
     ],
     "namespace": "BallotFiberTransfer",
-    "lineCount": 208,
+    "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum — weight-preserving JDT bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} (~80 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). ssytFin_two_row_eq_sum_colstrict proved (row-decomp bijection, no sorry). ssytSchurFin_two_row main theorem proved. k=0,1,2 proved.",
-    "lineCount": 666,
+    "lineCount": 693,
     "theoremCount": 14,
     "definitionCount": 8,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 666,
+    "lineCount": 693,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Six `meta.json` files had `leanFile.lineCount` values that no longer matched the actual Lean source files.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| birthday-problem-oq-03-oq-01-oq-02 | 463 | 501 |
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | 666 | 693 |
| ballot-problem-oq-03-oq-01-oq-02 | 14005 | 14022 |
| furstenberg-correspondence-oq-01 | 914 | 929 |
| dissection-of-cubes-oq-04 | 557 | 561 |
| ballot-problem-oq-01-oq-02-oq-01 | 208 | 207 |

Fixed using targeted regex replacement to preserve Unicode escape sequences and formatting.

---
Automated fix by lean-mechanic agent.