### PR TITLE
fix(meta): sync leanFile.axiomCount for 9 proofs — inherited vs local axioms

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 13,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 1,
     "theoremCount": 40,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "sorries": 0,
     "theoremCount": 106,
     "definitionCount": 1,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,


### PR DESCRIPTION
## Fix

Corrects `leanFile.axiomCount` for 9 gallery proofs where the field was counting axioms inherited via imports rather than declared in that specific file.

## Evidence

The `leanFile.axiomCount` field should reflect only axioms declared in the file pointed to by `leanFile.path`. Eight proofs that import all their axioms from parent files were reporting `1` (or `2`) instead of `0`. One proof (`inverse-galois`) had a local axiom removed but the count was not updated.

**Files changed:**
| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| `greens-theorem-oq-04` | `2` | `0` | GreensTheoremOQ04.lean imports axioms from OQ01/OQ03, declares none |
| `inverse-galois-oq-01` | `1` | `0` | InverseGaloisOQ01.lean imports axiom from InverseGaloisA5.lean |
| `inverse-galois` | `5` | `4` | InverseGalois.lean has 4 local axioms; 5th is in InverseGaloisA5.lean |
| `sophie-germain-oq-01` | `1` | `0` | Inherits `sophie_germain_conjecture` from parent file |
| `szemeredi-full-oq-02` | `1` | `0` | Inherits from parent |
| `yang-mills` | `1` | `0` | YangMillsMassGap.lean is a wrapper with 0 local declarations |
| `yang-mills-2d` | `1` | `0` | Points to Exploration.lean which has 0 axiom declarations |
| `yang-mills-lattice` | `1` | `0` | Same Exploration.lean file |
| `yang-mills-transfer-matrix` | `1` | `0` | Same Exploration.lean file |

Note: `meta.axiomCount` (total including imports) is unchanged — this fix only corrects the `leanFile`-scoped count.

---
Automated fix by lean-mechanic agent.