### PR TITLE
fix(erdos-608): prove companion sorries via Real.sqrt bounds

### DIFF
--- a/proofs/Proofs/Erdos608ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos608ProblemAristotle.lean
@@ -18,12 +18,35 @@ open Real
 noncomputable def c : ℝ := (2 + Real.sqrt 2) / 16
 
 /-- c ≈ 0.2134, so 0.213 < c < 0.214. -/
-lemma c_approx : c > 0.213 ∧ c < 0.214 := by sorry
+lemma c_approx : c > 0.213 ∧ c < 0.214 := by
+  unfold c
+  -- √2 > 1.408 since 1.408² = 1.982464 < 2
+  have h_lo : (1.408 : ℝ) < Real.sqrt 2 := by
+    rw [show (1.408 : ℝ) = Real.sqrt (1.408 ^ 2 : ℝ) from
+      (Real.sqrt_sq (by norm_num : (1.408 : ℝ) ≥ 0)).symm]
+    exact Real.sqrt_lt_sqrt (by norm_num) (by norm_num)
+  -- √2 < 1.424 since 1.424² = 2.027776 > 2
+  have h_hi : Real.sqrt 2 < 1.424 := by
+    rw [show (1.424 : ℝ) = Real.sqrt (1.424 ^ 2 : ℝ) from
+      (Real.sqrt_sq (by norm_num : (1.424 : ℝ) ≥ 0)).symm]
+    exact Real.sqrt_lt_sqrt (by norm_num) (by norm_num)
+  constructor
+  · rw [gt_iff_lt, lt_div_iff (by norm_num : (16 : ℝ) > 0)]; linarith
+  · rw [div_lt_iff (by norm_num : (16 : ℝ) > 0)]; linarith
 
 /-- c < 2/9, proving Erdős's original conjecture is false. -/
-lemma c_lt_two_ninths : c < 2/9 := by sorry
+lemma c_lt_two_ninths : c < 2/9 := by
+  unfold c
+  -- √2 < 14/9 since (14/9)² = 196/81 > 2
+  have h : Real.sqrt 2 < 14 / 9 := by
+    rw [show (14 / 9 : ℝ) = Real.sqrt ((14 / 9 : ℝ) ^ 2) from
+      (Real.sqrt_sq (by norm_num : (14 / 9 : ℝ) ≥ 0)).symm]
+    exact Real.sqrt_lt_sqrt (by norm_num) (by norm_num)
+  rw [div_lt_div_iff (by norm_num : (16 : ℝ) > 0) (by norm_num : (9 : ℝ) > 0)]
+  linarith
 
 /-- c > 0. -/
-lemma c_pos : c > 0 := by sorry
+lemma c_pos : c > 0 := by
+  unfold c; positivity
 
 end Erdos608


### PR DESCRIPTION
## Fix

Prove three sorry'd lemmas in `Erdos608ProblemAristotle.lean` using `Real.sqrt` bounds.

## Evidence

**Before**: `c_approx`, `c_lt_two_ninths`, and `c_pos` all ended with `by sorry`

**After**: All three proved:
- `c_pos`: via `positivity`
- `c_lt_two_ninths`: bound `√2 < 14/9` using `Real.sqrt_sq` + `Real.sqrt_lt_sqrt`, then `linarith`
- `c_approx`: bounds `1.408 < √2 < 1.424` using same pattern, then `linarith` for both sides

Pattern sourced from `Erdos1033Aristotle.lean` (validated working proof).

---
Automated fix by lean-mechanic agent.