### PR TITLE
fix(meta): sync stale leanFile.lineCount for 5 proofs

### DIFF
--- a/src/data/proofs/erdos-1001-oq-02/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02/meta.json
@@ -67,7 +67,7 @@
       "convergence_faster_than_sqrtN: rate is better than O(1/√N)",
       "three_distance_connection: connects rate to three-distance theorem"
     ],
-    "lineCount": 296,
+    "lineCount": 315,
     "theoremCount": 6,
     "defCount": 5
   },
@@ -165,7 +165,7 @@
       "Mathlib.NumberTheory.ArithmeticFunction"
     ],
     "namespace": "Erdos1001OQ02",
-    "lineCount": 296,
+    "lineCount": 315,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -190,7 +190,7 @@
       "Finset"
     ],
     "namespace": "Erdos1018OQ04",
-    "lineCount": 307,
+    "lineCount": 318,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -254,7 +254,7 @@
       "Finset"
     ],
     "namespace": "Erdos1022",
-    "lineCount": 522,
+    "lineCount": 599,
     "axiomCount": 1,
     "theoremCount": 25,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 496,
+    "lineCount": 499,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 496,
+    "lineCount": 499,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-886/meta.json
+++ b/src/data/proofs/erdos-886/meta.json
@@ -67,7 +67,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 154,
+    "lineCount": 153,
     "assumptions": "1 axiom: erdos_rosenfeld_four_divisors. 0 sorries."
   },
   "overview": {
@@ -189,7 +189,7 @@
       "Real"
     ],
     "namespace": "Erdos886",
-    "lineCount": 154,
+    "lineCount": 153,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 11,


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.lineCount` values (and `meta.lineCount` where also out of sync) for 5 gallery proofs whose Lean source files grew after their metadata was last updated.

## Evidence

All counts verified by line count of `git show origin/main:<path>`:

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| `erdos-1022` | `leanFile.lineCount` | 522 | **599** |
| `erdos-1001-oq-02` | `leanFile.lineCount` | 296 | **315** |
| `erdos-1001-oq-02` | `meta.lineCount` | 296 | **315** |
| `erdos-1018-oq-04` | `leanFile.lineCount` | 307 | **318** |
| `erdos-795` | `leanFile.lineCount` | 496 | **499** |
| `erdos-795` | `meta.lineCount` | 496 | **499** |
| `erdos-886` | `leanFile.lineCount` | 154 | **153** |
| `erdos-886` | `meta.lineCount` | 154 | **153** |

All other fields (`sorries`, `axiomCount`, `theoremCount`, `definitionCount`) verified correct and unchanged.

Not covered by any existing open PR: #13955, #13945, #13925 (which address different proofs).

---
Automated fix by lean-mechanic agent.