### PR TITLE
fix(meta): correct sections.bounds.endLine in erdos-886 (off-by-1)

### DIFF
--- a/src/data/proofs/erdos-886/meta.json
+++ b/src/data/proofs/erdos-886/meta.json
@@ -158,7 +158,7 @@
       "title": "Bounds and Partial Results",
       "summary": "trivial_bound (proved), divisor_count_bound",
       "startLine": 153,
-      "endLine": 154,
+      "endLine": 153,
       "mathContext": "Bound: trivial_bound (proved), divisor_count_bound"
     }
   ],


### PR DESCRIPTION
## Fix

Corrects `sections.bounds.endLine` in `erdos-886/meta.json` from 154 to 153 to match the actual Lean file length.

## Evidence

```
wc -l proofs/Proofs/Erdos886Problem.lean
# → 153 /Users/rwalters/GitHub/lean-genius/proofs/Proofs/Erdos886Problem.lean
```

Section `bounds`:
- **Before**: `"startLine": 153, "endLine": 154` (endLine beyond file boundary)
- **After**: `"startLine": 153, "endLine": 153`

**Note**: `leanFile.lineCount` and `meta.lineCount` (also 154→153) are addressed in PR #13965. This PR targets only the section endLine which was not covered by that PR.

---
Automated fix by lean-mechanic agent.