### PR TITLE
fix(meta): sync leanFile.definitionCount for 26 proofs (batch 9)

### DIFF
--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -167,7 +167,7 @@
     "lineCount": 420,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos738Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-747/meta.json
+++ b/src/data/proofs/erdos-747/meta.json
@@ -198,7 +198,7 @@
     "lineCount": 313,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/Erdos747Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-752/meta.json
+++ b/src/data/proofs/erdos-752/meta.json
@@ -160,7 +160,7 @@
     "lineCount": 206,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos752Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -225,7 +225,7 @@
     "lineCount": 268,
     "axiomCount": 5,
     "theoremCount": 8,
-    "definitionCount": 15,
+    "definitionCount": 17,
     "path": "Proofs/Erdos756Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -127,7 +127,7 @@
     "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos761Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-766/meta.json
+++ b/src/data/proofs/erdos-766/meta.json
@@ -222,7 +222,7 @@
     "lineCount": 181,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos766Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-767/meta.json
+++ b/src/data/proofs/erdos-767/meta.json
@@ -163,7 +163,7 @@
     "lineCount": 193,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos767Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-775/meta.json
+++ b/src/data/proofs/erdos-775/meta.json
@@ -189,7 +189,7 @@
     "lineCount": 281,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos775Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -212,7 +212,7 @@
     "lineCount": 221,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 12,
+    "definitionCount": 11,
     "path": "Proofs/Erdos780Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -204,7 +204,7 @@
     "lineCount": 265,
     "axiomCount": 5,
     "theoremCount": 6,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos781Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -130,8 +130,8 @@
     "namespace": "Erdos783",
     "lineCount": 392,
     "axiomCount": 0,
-    "theoremCount": 30,
-    "definitionCount": 7,
+    "theoremCount": 31,
+    "definitionCount": 5,
     "path": "Proofs/Erdos783Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-809/meta.json
+++ b/src/data/proofs/erdos-809/meta.json
@@ -149,7 +149,7 @@
     "lineCount": 186,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos809Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-810/meta.json
+++ b/src/data/proofs/erdos-810/meta.json
@@ -161,7 +161,7 @@
     "lineCount": 213,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "path": "Proofs/Erdos810Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -187,7 +187,7 @@
     "lineCount": 712,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 17,
+    "definitionCount": 13,
     "path": "Proofs/Erdos831Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-839/meta.json
+++ b/src/data/proofs/erdos-839/meta.json
@@ -149,7 +149,7 @@
     "lineCount": 255,
     "axiomCount": 1,
     "theoremCount": 14,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos839Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -138,7 +138,7 @@
     "lineCount": 247,
     "axiomCount": 3,
     "theoremCount": 25,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "path": "Proofs/Erdos852Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-853/meta.json
+++ b/src/data/proofs/erdos-853/meta.json
@@ -154,7 +154,7 @@
     "lineCount": 523,
     "axiomCount": 4,
     "theoremCount": 33,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "path": "Proofs/Erdos853Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -141,7 +141,7 @@
     "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos863Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -145,7 +145,7 @@
     "lineCount": 85,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 10,
+    "definitionCount": 4,
     "path": "Proofs/Erdos866Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-868/meta.json
+++ b/src/data/proofs/erdos-868/meta.json
@@ -173,7 +173,7 @@
     "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "path": "Proofs/Erdos868Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -209,7 +209,7 @@
     "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 17,
+    "definitionCount": 18,
     "path": "Proofs/Erdos870Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-890/meta.json
+++ b/src/data/proofs/erdos-890/meta.json
@@ -124,7 +124,7 @@
     "lineCount": 210,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos890Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -185,7 +185,7 @@
     "lineCount": 400,
     "axiomCount": 0,
     "theoremCount": 29,
-    "definitionCount": 6,
+    "definitionCount": 11,
     "path": "Proofs/Erdos891Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -157,7 +157,7 @@
     "lineCount": 260,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "sorries": 7,
     "path": "Proofs/Erdos895Problem.lean"
   },

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -188,7 +188,7 @@
     "lineCount": 251,
     "axiomCount": 11,
     "theoremCount": 2,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos898Problem.lean",
     "sorries": 8
   },

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -186,7 +186,7 @@
     "lineCount": 285,
     "axiomCount": 19,
     "theoremCount": 2,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos900Problem.lean",
     "sorries": 3
   },


### PR DESCRIPTION
## Fix

Metadata-only fix: corrects stale `leanFile.definitionCount` (and one `theoremCount`) for 26 gallery proofs in the erdos-730 to erdos-900 range.

## Evidence

**Counting method**: `grep -cE '^(noncomputable |private |protected )?(def |abbrev )'`

This includes `private`, `protected`, and `noncomputable` variants that were missed by earlier batch scripts using only `'^def \|^abbrev '`.

**Before / After** (definitionCount unless noted):

| Proof | Before | After |
|-------|--------|-------|
| erdos-738 | 11 | 10 |
| erdos-747 | 10 | 12 |
| erdos-752 | 10 | 11 |
| erdos-756 | 15 | 17 |
| erdos-761 | 7 | 6 |
| erdos-766 | 11 | 12 |
| erdos-767 | 7 | 8 |
| erdos-775 | 7 | 8 |
| erdos-780 | 12 | 11 |
| erdos-781 | 11 | 10 |
| erdos-783 def | 7 | 5 |
| erdos-783 thm | 30 | 31 |
| erdos-809 | 7 | 8 |
| erdos-810 | 6 | 5 |
| erdos-831 | 17 | 13 |
| erdos-839 | 7 | 6 |
| erdos-852 | 3 | 5 |
| erdos-853 | 5 | 4 |
| erdos-863 | 7 | 8 |
| erdos-866 | 10 | 4 |
| erdos-868 | 4 | 7 |
| erdos-870 | 17 | 18 |
| erdos-890 | 6 | 7 |
| erdos-891 | 6 | 11 |
| erdos-895 | 11 | 14 |
| erdos-898 | 15 | 16 |
| erdos-900 | 18 | 19 |

No Lean source files changed. Only `leanFile.definitionCount` (and `leanFile.theoremCount` for erdos-783) in the respective `meta.json` files.

---
Automated fix by lean-mechanic agent.