### PR TITLE
fix(meta): sync leanFile.definitionCount/theoremCount for 21 proofs (batch 10)

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -204,8 +204,8 @@
     "namespace": "Erdos1000",
     "lineCount": 1149,
     "axiomCount": 2,
-    "theoremCount": 60,
-    "definitionCount": 8,
+    "theoremCount": 61,
+    "definitionCount": 11,
     "path": "Proofs/Erdos1000Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -19,7 +19,9 @@
     "namespace": "Erdos901",
     "lineCount": 238,
     "axiomCount": 0,
-    "sorries": 19
+    "sorries": 19,
+    "definitionCount": 9,
+    "theoremCount": 19
   },
   "meta": {
     "author": "Paul Erdős, László Lovász",

--- a/src/data/proofs/erdos-902/meta.json
+++ b/src/data/proofs/erdos-902/meta.json
@@ -208,7 +208,7 @@
     "lineCount": 146,
     "axiomCount": 6,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 7,
     "path": "Proofs/Erdos902Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-914/meta.json
+++ b/src/data/proofs/erdos-914/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-914",
-  "title": "Erd\u0151s Problem #914: Hajnal-Szemer\u00e9di Theorem (Vertex-Disjoint Cliques)",
+  "title": "Erdős Problem #914: Hajnal-Szemerédi Theorem (Vertex-Disjoint Cliques)",
   "slug": "erdos-914",
-  "description": "Every graph on rm vertices with minimum degree \u2265 m(r-1) contains m vertex-disjoint copies of K_r. SOLVED by Hajnal-Szemer\u00e9di (1970).",
+  "description": "Every graph on rm vertices with minimum degree ≥ m(r-1) contains m vertex-disjoint copies of K_r. SOLVED by Hajnal-Szemerédi (1970).",
   "leanFile": {
     "path": "Proofs/Erdos914Problem.lean",
     "imports": [
@@ -19,10 +19,12 @@
     "namespace": "Erdos914",
     "lineCount": 193,
     "axiomCount": 2,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 6,
+    "theoremCount": 1
   },
   "meta": {
-    "author": "Erd\u0151s (conjecture), Hajnal-Szemer\u00e9di (proof 1970)",
+    "author": "Erdős (conjecture), Hajnal-Szemerédi (proof 1970)",
     "sourceUrl": "https://erdosproblems.com/914",
     "date": "1970",
     "status": "axiomatized",
@@ -66,8 +68,8 @@
       "HasMDisjointRCliques definition (m vertex-disjoint K_r's)",
       "HasPerfectKrFactor definition",
       "Dirac's theorem axiom (r=2 case)",
-      "Corr\u00e1di-Hajnal theorem axiom (r=3 case)",
-      "Hajnal-Szemer\u00e9di main theorem axiomatization",
+      "Corrádi-Hajnal theorem axiom (r=3 case)",
+      "Hajnal-Szemerédi main theorem axiomatization",
       "Tightness of degree condition",
       "Kierstead-Kostochka proof approach",
       "Alon-Yuster and KSS generalizations"
@@ -88,15 +90,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "This problem asks when a graph must contain many vertex-disjoint cliques, and is one of the most important results in extremal graph theory about spanning substructures.\n\nThe story begins with **Dirac's theorem (1952)**: every graph on $n \\ge 3$ vertices with $\\delta(G) \\ge n/2$ has a Hamiltonian cycle, which implies the $r = 2$ case (perfect matchings). **Corr\u00e1di and Hajnal (1963)** proved the triangle case: every graph on $3m$ vertices with $\\delta(G) \\ge 2m$ contains $m$ vertex-disjoint triangles, in their paper \"On the maximal number of independent circuits in a graph\" (Acta Mathematica Hungarica).\n\nErd\u0151s conjectured the general statement for all $r \\ge 2$: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$. **Hajnal and Szemer\u00e9di (1970)** proved this conjecture in their landmark paper \"Proof of a conjecture of P. Erd\u0151s\" (Combinatorial Theory and its Applications), though the original proof was notoriously long and complex.\n\n**Kierstead and Kostochka (2008)** gave a significantly shorter proof via **equitable colorings**: a proper $r$-coloring of the complement $\\overline{G}$ with color classes of equal size $m$ yields the desired $K_r$-factor. **Kierstead, Kostochka, Molla, and Yeager (2010)** found a polynomial-time $O(n^5)$ algorithm. The theorem has been generalized by **Alon and Yuster (1996)** and by **Koml\u00f3s, S\u00e1rk\u00f6zy, and Szemer\u00e9di (2001)** to arbitrary $H$-factors.",
+    "historicalContext": "This problem asks when a graph must contain many vertex-disjoint cliques, and is one of the most important results in extremal graph theory about spanning substructures.\n\nThe story begins with **Dirac's theorem (1952)**: every graph on $n \\ge 3$ vertices with $\\delta(G) \\ge n/2$ has a Hamiltonian cycle, which implies the $r = 2$ case (perfect matchings). **Corrádi and Hajnal (1963)** proved the triangle case: every graph on $3m$ vertices with $\\delta(G) \\ge 2m$ contains $m$ vertex-disjoint triangles, in their paper \"On the maximal number of independent circuits in a graph\" (Acta Mathematica Hungarica).\n\nErdős conjectured the general statement for all $r \\ge 2$: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$. **Hajnal and Szemerédi (1970)** proved this conjecture in their landmark paper \"Proof of a conjecture of P. Erdős\" (Combinatorial Theory and its Applications), though the original proof was notoriously long and complex.\n\n**Kierstead and Kostochka (2008)** gave a significantly shorter proof via **equitable colorings**: a proper $r$-coloring of the complement $\\overline{G}$ with color classes of equal size $m$ yields the desired $K_r$-factor. **Kierstead, Kostochka, Molla, and Yeager (2010)** found a polynomial-time $O(n^5)$ algorithm. The theorem has been generalized by **Alon and Yuster (1996)** and by **Komlós, Sárközy, and Szemerédi (2001)** to arbitrary $H$-factors.",
     "problemStatement": "Let $r \\ge 2$ and $m \\ge 1$. Every graph on $rm$ vertices with minimum degree $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$. Equivalently, if $r | n$ and $\\delta(G) \\ge (1 - 1/r)n$, then $G$ has a perfect $K_r$-factor.",
     "text": "The Hajnal-Szemeredi theorem (1970) establishes the exact minimum degree threshold for forcing vertex-disjoint clique factors in graphs. For $r \\ge 2$ and $m \\ge 1$, any graph on $n = rm$ vertices with $\\delta(G) \\ge (1 - 1/r)n$ must contain $m$ vertex-disjoint copies of $K_r$, partitioning the entire vertex set into $r$-cliques. This threshold $(1 - 1/r)n$ is precisely the Turan density, revealing that the same parameter governing subgraph existence (Turan's theorem) also governs the much stronger property of spanning clique factors. The formalization axiomatizes the theorem alongside its special cases (Dirac's matching theorem for $r = 2$, the Corradi-Hajnal triangle factor theorem for $r = 3$) and proves the degree bound is best possible via an extremal construction.",
     "proofStrategy": "The formalization is organized into six parts that build from basic graph definitions to the full characterization theorem.\n\n**Part I (Graph Basics, lines 43-61):** Introduces `completeGraphOnFin r` as the abbreviation for $K_r$ on `Fin r`, and defines `minDegree G` as the minimum over all vertex degrees using `Finset.min'` with a nonemptiness proof from `Finset.univ_nonempty`. This custom definition is needed because Mathlib does not provide a built-in minimum degree function.\n\n**Part II (Cliques and Clique Covers, lines 62-97):** Establishes the combinatorial vocabulary: `IsRClique G S r` requires $|S| = r$ and $G.\\texttt{IsClique}\\, S$; `AreVertexDisjoint` enforces pairwise disjointness; `HasMDisjointRCliques G m r` asserts existence of $m$ disjoint $r$-cliques; and `HasPerfectKrFactor G r` adds the covering condition $\\texttt{biUnion} = \\texttt{univ}$. The distinction between the last two is mathematically significant: $m$ disjoint $K_r$'s use $rm$ vertices total, but proving they cover ALL vertices requires cardinality reasoning.\n\n**Part III (Special Cases, lines 98-118):** Axiomatizes the two classical predecessors: `case_r_equals_2` (Dirac's matching theorem, $r = 2$) and `corradi_hajnal` (Corradi-Hajnal 1963, $r = 3$). These are stated separately because their proofs use fundamentally different techniques from the general case.\n\n**Part IV (Main Theorem, lines 119-147):** The core axioms: `hajnal_szemeredi` states the disjoint cliques result, and `hajnal_szemeredi_factor` states the stronger perfect factor form. Both require $r \\ge 2$, $m \\ge 1$, $|V| = rm$, and $\\delta(G) \\ge m(r-1)$.\n\n**Part V (Tightness, lines 148-163):** `degree_condition_tight` provides the optimality statement: for every $r, m$, there exists a graph with minimum degree $m(r-1) - 1$ having no $m$ disjoint $K_r$'s.\n\n**Part VI (Summary, lines 164-210):** The proved theorem `erdos_914_summary` combines the existential and tightness results into a single conjunction, fully characterizing the minimum degree threshold.",
     "keyInsights": [
-      "**Minimum degree threshold**: $\\delta(G) \\ge m(r-1) = (1-1/r)n$ is the exact threshold for $K_r$-factors \u2014 the Tur\u00e1n density $(1-1/r)$ governs spanning structures, not just subgraph existence",
-      "**Tightness via Tur\u00e1n-like construction**: Taking $m$ disjoint copies of $K_{r-1}$ plus isolated vertices gives $\\delta = r-2$ per component, one below the threshold, with no $K_r$ at all",
-      "**From subgraphs to spanning structures**: Unlike Tur\u00e1n's theorem (which forces a single $K_r$), Hajnal\u2013Szemer\u00e9di forces a $K_r$-factor covering ALL vertices \u2014 a much stronger conclusion from the same minimum degree",
-      "**Equitable coloring duality**: Kierstead\u2013Kostochka's modern proof works by equitably $r$-coloring the complement $\\overline{G}$; equal-size color classes in $\\overline{G}$ correspond to $K_r$'s in $G$",
+      "**Minimum degree threshold**: $\\delta(G) \\ge m(r-1) = (1-1/r)n$ is the exact threshold for $K_r$-factors — the Turán density $(1-1/r)$ governs spanning structures, not just subgraph existence",
+      "**Tightness via Turán-like construction**: Taking $m$ disjoint copies of $K_{r-1}$ plus isolated vertices gives $\\delta = r-2$ per component, one below the threshold, with no $K_r$ at all",
+      "**From subgraphs to spanning structures**: Unlike Turán's theorem (which forces a single $K_r$), Hajnal–Szemerédi forces a $K_r$-factor covering ALL vertices — a much stronger conclusion from the same minimum degree",
+      "**Equitable coloring duality**: Kierstead–Kostochka's modern proof works by equitably $r$-coloring the complement $\\overline{G}$; equal-size color classes in $\\overline{G}$ correspond to $K_r$'s in $G$",
       "**Perfect factor vs disjoint cliques**: `HasMDisjointRCliques` gives $m$ disjoint $K_r$'s using $rm$ vertices total, while `HasPerfectKrFactor` requires `biUnion = univ`, a covering condition that needs additional cardinality reasoning"
     ],
     "prerequisites": [
@@ -153,7 +155,7 @@
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "Axiomatizes $r = 2$ (Dirac's theorem: $2m$ vertices, $\\delta \\ge m$ implies $m$ disjoint edges) and $r = 3$ (Corr\u00e1di-Hajnal 1963: $3m$ vertices, $\\delta \\ge 2m$ implies $m$ disjoint triangles).",
+      "summary": "Axiomatizes $r = 2$ (Dirac's theorem: $2m$ vertices, $\\delta \\ge m$ implies $m$ disjoint edges) and $r = 3$ (Corrádi-Hajnal 1963: $3m$ vertices, $\\delta \\ge 2m$ implies $m$ disjoint triangles).",
       "mathContext": "The $r = 2$ case reduces to perfect matching existence: $\\delta(G) \\ge n/2$ implies a Hamiltonian cycle by Dirac's theorem (1952), and alternating edges of a Hamiltonian cycle on $2m$ vertices yield $m$ disjoint edges. The $r = 3$ case was proved by Corradi and Hajnal (1963) using a swap argument: start with a maximal collection of disjoint triangles and show that if fewer than $m$ triangles exist, uncovered vertices can be swapped in to enlarge the collection. The gap between $r = 3$ (1963) and general $r$ (1970) reflects the significant difficulty of extending the swap argument to larger cliques, where the combinatorial case analysis grows substantially.",
       "startLine": 98,
       "endLine": 118
@@ -184,13 +186,13 @@
     }
   ],
   "conclusion": {
-    "summary": "The Hajnal\u2013Szemer\u00e9di Theorem (1970) completely resolves Erd\u0151s Problem #914: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$, and the minimum degree condition is tight. The formalization axiomatizes the theorem, its special cases ($r = 2, 3$), and the optimality of the degree bound.",
+    "summary": "The Hajnal–Szemerédi Theorem (1970) completely resolves Erdős Problem #914: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$, and the minimum degree condition is tight. The formalization axiomatizes the theorem, its special cases ($r = 2, 3$), and the optimality of the degree bound.",
     "implications": "**Extremal Graph Theory**: The Hajnal-Szemeredi theorem is a cornerstone of the minimum degree approach to graph decomposition. It demonstrates that the Turan density $(1 - 1/r)$ is not merely the threshold for forcing a single copy of $K_r$ (Turan's theorem, 1941), but the exact threshold for forcing a spanning $K_r$-factor covering every vertex. This reveals a remarkable rigidity: the same density parameter controls both local (one copy) and global (perfect tiling) properties.\n\n**Equitable Coloring Connection**: The Kierstead-Kostochka (2008) short proof established a deep duality between graph factorization and graph coloring. A $K_r$-factor in $G$ corresponds to an equitable $r$-coloring of the complement $\\overline{G}$, where color classes have equal size. This connection has become a standard technique in extremal combinatorics and has been extended to list coloring and online coloring settings.\n\n**Generalizations to Arbitrary Factors**: Alon and Yuster (1996) proved an approximate version for general $H$-factors: $\\delta(G) \\ge (1 - 1/\\chi(H))n + o(n)$ suffices. Komlos, Sarkozy, and Szemeredi (2001) obtained the exact result for large $n$ using the regularity-blow-up method, establishing the minimum degree threshold for arbitrary $H$-factors as $(1 - 1/\\chi_{cr}(H))n + O(1)$, where $\\chi_{cr}(H)$ is the critical chromatic number.\n\n**Algorithmic Impact**: Kierstead, Kostochka, Molla, and Yeager (2010) gave a polynomial-time $O(n^5)$ algorithm for finding $K_r$-factors when the minimum degree condition is satisfied. This resolved the computational aspect, showing that the existential guarantee is algorithmically constructive.\n\n**Formalization Significance**: The axiomatization captures the full mathematical content of the theorem (existence, perfect factor form, special cases, and tightness) while clearly delineating what is assumed versus proved. The summary theorem `erdos_914_summary` is the unique non-axiom result, demonstrating that the characterization follows formally from the axiomatized components.",
     "openQuestions": [
       "What is the exact minimum degree threshold for perfect $H$-factors for arbitrary graphs $H$? The KSS theorem gives asymptotic answers but exact thresholds are known only for special cases.",
       "Can the $O(n^5)$ algorithm for finding $K_r$-factors be improved, perhaps to near-linear time?",
       "What are the minimum degree thresholds for vertex-disjoint copies of $K_r$ in directed graphs or hypergraphs?",
-      "Can the Hajnal\u2013Szemer\u00e9di theorem be proved constructively in Lean, or does the greedy/equitable-coloring argument require classical reasoning?"
+      "Can the Hajnal–Szemerédi theorem be proved constructively in Lean, or does the greedy/equitable-coloring argument require classical reasoning?"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -177,7 +177,7 @@
     "lineCount": 690,
     "axiomCount": 0,
     "theoremCount": 40,
-    "definitionCount": 15,
+    "definitionCount": 14,
     "path": "Proofs/Erdos919Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-928/meta.json
+++ b/src/data/proofs/erdos-928/meta.json
@@ -201,7 +201,7 @@
     "lineCount": 259,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos928Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -153,8 +153,8 @@
     "namespace": "Erdos931",
     "lineCount": 523,
     "axiomCount": 0,
-    "theoremCount": 44,
-    "definitionCount": 6,
+    "theoremCount": 46,
+    "definitionCount": 5,
     "path": "Proofs/Erdos931Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-932/meta.json
+++ b/src/data/proofs/erdos-932/meta.json
@@ -151,7 +151,7 @@
     "lineCount": 356,
     "axiomCount": 3,
     "theoremCount": 20,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos932Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -158,7 +158,9 @@
     "namespace": null,
     "lineCount": 154,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 7,
+    "theoremCount": 4
   },
   "references": [
     {

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -188,7 +188,7 @@
     "lineCount": 218,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 9,
+    "definitionCount": 13,
     "sorries": 0,
     "path": "Proofs/Erdos938Problem.lean"
   },

--- a/src/data/proofs/erdos-945/meta.json
+++ b/src/data/proofs/erdos-945/meta.json
@@ -134,7 +134,7 @@
     "lineCount": 148,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos945Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -158,7 +158,7 @@
     "lineCount": 348,
     "axiomCount": 2,
     "theoremCount": 18,
-    "definitionCount": 12,
+    "definitionCount": 18,
     "path": "Proofs/Erdos952Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-953/meta.json
+++ b/src/data/proofs/erdos-953/meta.json
@@ -194,7 +194,7 @@
     "lineCount": 291,
     "axiomCount": 2,
     "theoremCount": 13,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos953Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-957/meta.json
+++ b/src/data/proofs/erdos-957/meta.json
@@ -180,7 +180,7 @@
     "lineCount": 325,
     "axiomCount": 6,
     "theoremCount": 6,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos957Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-958/meta.json
+++ b/src/data/proofs/erdos-958/meta.json
@@ -127,7 +127,7 @@
     "lineCount": 200,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos958Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -163,7 +163,7 @@
     "lineCount": 251,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 8,
+    "definitionCount": 7,
     "path": "Proofs/Erdos960Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -104,7 +104,7 @@
     "lineCount": 229,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 0,
+    "definitionCount": 8,
     "sorries": 23,
     "path": "Proofs/Erdos977Problem.lean"
   },

--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -191,7 +191,7 @@
     "lineCount": 333,
     "axiomCount": 4,
     "theoremCount": 6,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos982Problem.lean",
     "sorries": 3
   },
@@ -199,17 +199,17 @@
     {
       "targetId": "erdos-654",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, distances, geometry, open"
+      "description": "Related Erdős problem sharing themes: discrete-geometry, distances, geometry, open"
     },
     {
       "targetId": "erdos-94",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: convex, discrete-geometry, distances, geometry"
+      "description": "Related Erdős problem sharing themes: convex, discrete-geometry, distances, geometry"
     },
     {
       "targetId": "erdos-103",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: distances, geometry, open"
+      "description": "Related Erdős problem sharing themes: distances, geometry, open"
     }
   ],
   "sorries": 3

--- a/src/data/proofs/erdos-987/meta.json
+++ b/src/data/proofs/erdos-987/meta.json
@@ -95,7 +95,7 @@
     "lineCount": 245,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "path": "Proofs/Erdos987Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-989/meta.json
+++ b/src/data/proofs/erdos-989/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-989",
-  "title": "Erd\u0151s Problem #989: Circle Discrepancy",
+  "title": "Erdős Problem #989: Circle Discrepancy",
   "slug": "erdos-989",
-  "description": "For an infinite sequence A \u2282 \u211d\u00b2, define f(r) = max_C |#(A\u2229C) - \u03c0r\u00b2| over circles of radius r. Beck (1987) proved f(r) \u226b r^{1/2} for all A (lower bound), and \u2203A with f(r) \u226a (r log r)^{1/2} (upper bound). The optimal growth is \u0398\u0303(\u221ar).",
+  "description": "For an infinite sequence A ⊂ ℝ², define f(r) = max_C |#(A∩C) - πr²| over circles of radius r. Beck (1987) proved f(r) ≫ r^{1/2} for all A (lower bound), and ∃A with f(r) ≪ (r log r)^{1/2} (upper bound). The optimal growth is Θ̃(√r).",
   "meta": {
-    "author": "Beck, J\u00f3zsef",
+    "author": "Beck, József",
     "sourceUrl": "https://erdosproblems.com/989",
     "date": "1987",
     "status": "axiomatized",
@@ -25,17 +25,17 @@
     "mathlibDependencies": [
       {
         "theorem": "EuclideanSpace",
-        "description": "Type for points in \u211d\u00b2",
+        "description": "Type for points in ℝ²",
         "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
       },
       {
         "theorem": "Real.pi",
-        "description": "The constant \u03c0 for circle area calculations",
+        "description": "The constant π for circle area calculations",
         "module": "Mathlib.Analysis.SpecialFunctions.Pi.Basic"
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root function for \u221ar bounds",
+        "description": "Square root function for √r bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
@@ -64,11 +64,11 @@
       },
       {
         "id": "erdos-987",
-        "relationship": "Exponential sums controlling equidistribution via the Erd\u0151s-Tur\u00e1n inequality, using related Fourier methods"
+        "relationship": "Exponential sums controlling equidistribution via the Erdős-Turán inequality, using related Fourier methods"
       },
       {
         "id": "erdos-990",
-        "relationship": "Angular discrepancy of polynomial roots on the unit circle via Erd\u0151s-Tur\u00e1n inequality"
+        "relationship": "Angular discrepancy of polynomial roots on the unit circle via Erdős-Turán inequality"
       },
       {
         "id": "erdos-992",
@@ -89,18 +89,18 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Circle Discrepancy and Uniform Distribution**\n\nThis problem asks fundamental questions about how uniformly an infinite sequence of points can be distributed in the plane with respect to circles.\n\nFor a sequence A = {z\u2081, z\u2082, ...} \u2282 \u211d\u00b2, define the circle discrepancy function:\n  f(r) = max_C |#(A \u2229 C) - \u03c0r\u00b2|\nwhere the maximum is over all circles C of radius r.\n\nThe expected count in a circle of radius r (if points had density 1) is \u03c0r\u00b2. The discrepancy measures the worst deviation from this expectation.\n\n**Historical Roots**\n\nThe study of discrepancy begins with Hermann Weyl's 1916 equidistribution theorem and was systematically developed by Klaus Roth, who proved in 1954 that the box discrepancy D(N) \u2265 c\u221a(log N) for points in [0,1]\u00b2. Wolfgang Schmidt extended this to higher dimensions in 1972. The shift from boxes to curved test sets was pioneered by J\u00f3zsef Beck in the 1980s.\n\n**Beck's Complete Solution (1987)**\n\nBeck settled this problem in his landmark paper 'Irregularities of distribution I' (Acta Math. 159, 1987, pp. 1\u201349):\n\n1. **Lower Bound (Universal)**: For ALL sequences A, f(r) \u226b r^{1/2}\n   - No matter how carefully you place points, discrepancy grows at least like \u221ar\n   - Proof uses Fourier analysis and properties of Bessel functions J\u2081\n   - The key insight is that the Fourier transform of a disk indicator is controlled by J\u2081, whose slow decay forces large discrepancy\n\n2. **Upper Bound (Existence)**: There EXISTS a sequence A with f(r) \u226a (r log r)^{1/2}\n   - Uses probabilistic construction: perturb the integer lattice \u2124\u00b2 by small random displacements\n   - The log factor comes from union bounds over O(r\u00b2) possible circle centers\n   - This is a landmark application of the probabilistic method in geometric combinatorics\n\nThis shows the optimal growth rate is \u0398\u0303(\u221ar), with an open question about whether the logarithmic factor is necessary. The connection to the Gauss circle problem (lattice points in circles fluctuate by ~r^{1/4}) shows that circles present a fundamentally harder discrepancy problem than boxes or half-planes.",
-    "problemStatement": "**Problem Statement**\n\nLet A = {z\u2081, z\u2082, ...} \u2282 \u211d\u00b2 be an infinite sequence of points. Define\n  f(r) = max_C |#(A \u2229 C) - \u03c0r\u00b2|\nwhere the maximum is over all circles C of radius r.\n\n**Questions:**\n1. Is f(r) unbounded for every A?\n2. How fast does f(r) grow?\n\n**Answer (Beck 1987):**\n1. YES - f(r) is unbounded for every A\n2. The optimal growth rate is \u0398\u0303(\u221ar):\n   - Universal lower bound: f(r) \u2265 c\u00b7\u221ar for all A\n   - Existence upper bound: \u2203A with f(r) \u2264 C\u00b7\u221a(r log r)\n\n**Status:** SOLVED",
-    "text": "For an infinite sequence A \u2282 \u211d\u00b2, define f(r) = max_C |#(A\u2229C) - \u03c0r\u00b2| over circles of radius r. Beck (1987) proved f(r) \u226b r^{1/2} for all A (lower bound), and \u2203A with f(r) \u226a (r log r)^{1/2} (upper bound). The optimal growth is \u0398\u0303(\u221ar).",
-    "proofStrategy": "**Beck's Approach**\n\n**Lower Bound (Fourier Analysis):**\n1. Express circle indicators via their Fourier transforms: $\\hat{\\mathbf{1}}_B(\\xi) = r J_1(2\\pi r|\\xi|)/|\\xi|$\n2. The Fourier transform of a disk involves Bessel functions J\u2081\n3. Key property: |J\u2081(x)| ~ \u221a(2/(\u03c0x)) cos(x - 3\u03c0/4) for large x\n4. Apply Parseval's identity to relate L\u00b2 discrepancy to Fourier coefficients\n5. The Bessel asymptotics force \u03a9(\u221ar) growth since the Fourier coefficients decay too slowly\n\n**Upper Bound (Probabilistic Construction):**\n1. Start with the integer lattice \u2124\u00b2 (density 1)\n2. Perturb each lattice point z by i.i.d. random displacement \u03b4_z uniform on [-\u03b5, \u03b5]\u00b2\n3. For a single circle: Var[#(A \u2229 C)] = O(r) from boundary contribution\n4. The union bound over O(r\u00b2) possible circle positions introduces the log factor\n5. Second moment method: E[sup_C D] = O(\u221a(r log r))\n\n**Why \u221ar is Natural:**\n- A circle of radius r has circumference 2\u03c0r\n- Points near the boundary can be in or out\n- Fluctuations of order \u221a(boundary length) = \u221ar\n- This is the same heuristic as the central limit theorem for independent boundary events",
+    "historicalContext": "**Circle Discrepancy and Uniform Distribution**\n\nThis problem asks fundamental questions about how uniformly an infinite sequence of points can be distributed in the plane with respect to circles.\n\nFor a sequence A = {z₁, z₂, ...} ⊂ ℝ², define the circle discrepancy function:\n  f(r) = max_C |#(A ∩ C) - πr²|\nwhere the maximum is over all circles C of radius r.\n\nThe expected count in a circle of radius r (if points had density 1) is πr². The discrepancy measures the worst deviation from this expectation.\n\n**Historical Roots**\n\nThe study of discrepancy begins with Hermann Weyl's 1916 equidistribution theorem and was systematically developed by Klaus Roth, who proved in 1954 that the box discrepancy D(N) ≥ c√(log N) for points in [0,1]². Wolfgang Schmidt extended this to higher dimensions in 1972. The shift from boxes to curved test sets was pioneered by József Beck in the 1980s.\n\n**Beck's Complete Solution (1987)**\n\nBeck settled this problem in his landmark paper 'Irregularities of distribution I' (Acta Math. 159, 1987, pp. 1–49):\n\n1. **Lower Bound (Universal)**: For ALL sequences A, f(r) ≫ r^{1/2}\n   - No matter how carefully you place points, discrepancy grows at least like √r\n   - Proof uses Fourier analysis and properties of Bessel functions J₁\n   - The key insight is that the Fourier transform of a disk indicator is controlled by J₁, whose slow decay forces large discrepancy\n\n2. **Upper Bound (Existence)**: There EXISTS a sequence A with f(r) ≪ (r log r)^{1/2}\n   - Uses probabilistic construction: perturb the integer lattice ℤ² by small random displacements\n   - The log factor comes from union bounds over O(r²) possible circle centers\n   - This is a landmark application of the probabilistic method in geometric combinatorics\n\nThis shows the optimal growth rate is Θ̃(√r), with an open question about whether the logarithmic factor is necessary. The connection to the Gauss circle problem (lattice points in circles fluctuate by ~r^{1/4}) shows that circles present a fundamentally harder discrepancy problem than boxes or half-planes.",
+    "problemStatement": "**Problem Statement**\n\nLet A = {z₁, z₂, ...} ⊂ ℝ² be an infinite sequence of points. Define\n  f(r) = max_C |#(A ∩ C) - πr²|\nwhere the maximum is over all circles C of radius r.\n\n**Questions:**\n1. Is f(r) unbounded for every A?\n2. How fast does f(r) grow?\n\n**Answer (Beck 1987):**\n1. YES - f(r) is unbounded for every A\n2. The optimal growth rate is Θ̃(√r):\n   - Universal lower bound: f(r) ≥ c·√r for all A\n   - Existence upper bound: ∃A with f(r) ≤ C·√(r log r)\n\n**Status:** SOLVED",
+    "text": "For an infinite sequence A ⊂ ℝ², define f(r) = max_C |#(A∩C) - πr²| over circles of radius r. Beck (1987) proved f(r) ≫ r^{1/2} for all A (lower bound), and ∃A with f(r) ≪ (r log r)^{1/2} (upper bound). The optimal growth is Θ̃(√r).",
+    "proofStrategy": "**Beck's Approach**\n\n**Lower Bound (Fourier Analysis):**\n1. Express circle indicators via their Fourier transforms: $\\hat{\\mathbf{1}}_B(\\xi) = r J_1(2\\pi r|\\xi|)/|\\xi|$\n2. The Fourier transform of a disk involves Bessel functions J₁\n3. Key property: |J₁(x)| ~ √(2/(πx)) cos(x - 3π/4) for large x\n4. Apply Parseval's identity to relate L² discrepancy to Fourier coefficients\n5. The Bessel asymptotics force Ω(√r) growth since the Fourier coefficients decay too slowly\n\n**Upper Bound (Probabilistic Construction):**\n1. Start with the integer lattice ℤ² (density 1)\n2. Perturb each lattice point z by i.i.d. random displacement δ_z uniform on [-ε, ε]²\n3. For a single circle: Var[#(A ∩ C)] = O(r) from boundary contribution\n4. The union bound over O(r²) possible circle positions introduces the log factor\n5. Second moment method: E[sup_C D] = O(√(r log r))\n\n**Why √r is Natural:**\n- A circle of radius r has circumference 2πr\n- Points near the boundary can be in or out\n- Fluctuations of order √(boundary length) = √r\n- This is the same heuristic as the central limit theorem for independent boundary events",
     "keyInsights": [
-      "f(r) is unbounded for EVERY sequence A \u2014 discrepancy is an unavoidable consequence of placing points in the plane",
-      "The optimal growth rate is \u0398\u0303(\u221ar) \u2014 both lower and upper bounds match up to a \u221a(log r) factor",
-      "The lower bound uses Fourier analysis on \u211d\u00b2 with Bessel function J\u2081 asymptotics, connecting analytic number theory to combinatorial geometry",
+      "f(r) is unbounded for EVERY sequence A — discrepancy is an unavoidable consequence of placing points in the plane",
+      "The optimal growth rate is Θ̃(√r) — both lower and upper bounds match up to a √(log r) factor",
+      "The lower bound uses Fourier analysis on ℝ² with Bessel function J₁ asymptotics, connecting analytic number theory to combinatorial geometry",
       "The upper bound uses the probabilistic method: a randomly perturbed lattice achieves near-optimal discrepancy, a striking example of randomization beating deterministic constructions",
-      "The logarithmic gap between \u221ar and \u221a(r log r) remains open since 1987 \u2014 it is unknown whether the union bound introducing log r is tight or an artifact of the proof",
-      "Circles have strictly higher discrepancy than half-planes (\u221ar \u226b r^{1/4}), reflecting how curvature amplifies irregularity by creating more 'boundary events'",
-      "The Gauss circle problem (counting \u2124\u00b2 points in a circle) is a special case: the fluctuation r^{1/4} is less than \u221ar because the lattice is highly structured"
+      "The logarithmic gap between √r and √(r log r) remains open since 1987 — it is unknown whether the union bound introducing log r is tight or an artifact of the proof",
+      "Circles have strictly higher discrepancy than half-planes (√r ≫ r^{1/4}), reflecting how curvature amplifies irregularity by creating more 'boundary events'",
+      "The Gauss circle problem (counting ℤ² points in a circle) is a special case: the fluctuation r^{1/4} is less than √r because the lattice is highly structured"
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -111,42 +111,42 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Point (as EuclideanSpace \u211d (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (\u03c0r\u00b2). These are the geometric primitives for the discrepancy problem.",
+      "summary": "Defines Point (as EuclideanSpace ℝ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (πr²). These are the geometric primitives for the discrepancy problem.",
       "startLine": 44,
       "endLine": 61,
-      "mathContext": "Defines Point (as EuclideanSpace $\\mathbb{R}$ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (\u03c0r\u00b2). These are the geometric primitives for the discrepancy problem."
+      "mathContext": "Defines Point (as EuclideanSpace $\\mathbb{R}$ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (πr²). These are the geometric primitives for the discrepancy problem."
     },
     {
       "id": "discrepancy-definitions",
       "title": "Point Sequences and Discrepancy",
-      "summary": "Defines PointSequence (\u2115 \u2192 Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - \u03c0r\u00b2|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths).",
+      "summary": "Defines PointSequence (ℕ → Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - πr²|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths).",
       "startLine": 62,
       "endLine": 87,
-      "mathContext": "Defines PointSequence (\u2115 \u2192 Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - \u03c0r\u00b2|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths)."
+      "mathContext": "Defines PointSequence (ℕ → Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - πr²|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths)."
     },
     {
       "id": "lower-bound",
       "title": "Beck's Lower Bound",
-      "summary": "States beck_lower_bound as an axiom (\u2203 c > 0, \u2200 A, f(r) \u2265 c\u221ar eventually) and derives discrepancy_unbounded \u2014 one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity.",
+      "summary": "States beck_lower_bound as an axiom (∃ c > 0, ∀ A, f(r) ≥ c√r eventually) and derives discrepancy_unbounded — one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity.",
       "startLine": 88,
       "endLine": 129,
-      "mathContext": "States beck_lower_bound as an axiom (\u2203 c > 0, \u2200 A, f(r) \u2265 c\u221ar eventually) and derives discrepancy_unbounded \u2014 one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity."
+      "mathContext": "States beck_lower_bound as an axiom (∃ c > 0, ∀ A, f(r) ≥ c√r eventually) and derives discrepancy_unbounded — one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity."
     },
     {
       "id": "upper-bound",
       "title": "Beck's Upper Bound",
-      "summary": "States beck_upper_bound as an axiom (\u2203 A, f(r) \u2264 C\u221a(r log r) eventually) and extracts beckOptimalSequence via Classical.choose \u2014 a non-constructive witness from the probabilistic existence proof.",
+      "summary": "States beck_upper_bound as an axiom (∃ A, f(r) ≤ C√(r log r) eventually) and extracts beckOptimalSequence via Classical.choose — a non-constructive witness from the probabilistic existence proof.",
       "startLine": 130,
       "endLine": 150,
-      "mathContext": "States beck_upper_bound as an axiom (\u2203 A, f(r) \u2264 C\u221a(r log r) eventually) and extracts beckOptimalSequence via Classical.choose \u2014 a non-constructive witness from the probabilistic existence proof."
+      "mathContext": "States beck_upper_bound as an axiom (∃ A, f(r) ≤ C√(r log r) eventually) and extracts beckOptimalSequence via Classical.choose — a non-constructive witness from the probabilistic existence proof."
     },
     {
       "id": "complete-answer",
       "title": "The Complete Answer",
-      "summary": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound \u221ar, and existence of near-optimal \u221a(r log r) sequence. Proved by direct application of the preceding results.",
+      "summary": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound √r, and existence of near-optimal √(r log r) sequence. Proved by direct application of the preceding results.",
       "startLine": 151,
       "endLine": 183,
-      "mathContext": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound \u221ar, and existence of near-optimal \u221a(r log r) sequence. Proved by direct application of the preceding results."
+      "mathContext": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound √r, and existence of near-optimal √(r log r) sequence. Proved by direct application of the preceding results."
     },
     {
       "id": "discrepancy-theory",
@@ -167,35 +167,35 @@
     {
       "id": "open-questions",
       "title": "Open Questions",
-      "summary": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(\u221ar) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in \u211d^d).",
+      "summary": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(√r) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in ℝ^d).",
       "startLine": 240,
       "endLine": 283,
-      "mathContext": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(\u221ar) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in \u211d^d)."
+      "mathContext": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(√r) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in ℝ^d)."
     },
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) \u2265 c\u00b7(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (\u226b r^{1/4}), providing context for why circle discrepancy (\u221ar) is intermediate. Commentary only \u2014 no Lean declarations.",
+      "summary": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) ≥ c·(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (≫ r^{1/4}), providing context for why circle discrepancy (√r) is intermediate. Commentary only — no Lean declarations.",
       "startLine": 284,
       "endLine": 320,
-      "mathContext": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) \u2265 c\u00b7(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (\u226b r^{1/4}), providing context for why circle discrepancy (\u221ar) is intermediate. Commentary only \u2014 no Lean declarations."
+      "mathContext": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) ≥ c·(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (≫ r^{1/4}), providing context for why circle discrepancy (√r) is intermediate. Commentary only — no Lean declarations."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) \u2265 c\u221ar. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems.",
+      "summary": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) ≥ c√r. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems.",
       "startLine": 321,
       "endLine": 341,
-      "mathContext": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) \u2265 c\u221ar. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems."
+      "mathContext": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) ≥ c√r. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #989 asked whether the circle discrepancy f(r) is unbounded and how fast it grows. Beck (1987) completely settled this: f(r) \u226b \u221ar for ALL sequences (using Fourier/Bessel analysis), and \u2203 sequence with f(r) \u226a \u221a(r log r) (using probabilistic construction). The optimal rate is \u0398\u0303(\u221ar).",
-    "implications": "1. **Discrepancy Theory**: Foundational result establishing the sharp growth rate for circle discrepancy, resolving the key open question in geometric equidistribution\n\n2. **Fourier Methods in Combinatorics**: Demonstrates the power of harmonic analysis for discrete geometry problems \u2014 the Bessel function connection shows deep interplay between analysis and combinatorics\n\n**3. Probabilistic Method**: The fact that a randomly perturbed lattice achieves near-optimal discrepancy is a striking example of the Erd\u0151s probabilistic method in geometry\n\n4. **Curvature and Discrepancy**: The comparison circles (\u221ar) vs half-planes (r^{1/4}) reveals that boundary curvature \u03ba = 1/r fundamentally amplifies discrepancy \u2014 a geometric insight with implications for all curved test set families\n\n5. **Connection to Number Theory**: The Gauss circle problem (lattice points in circles) is a special case where the highly structured lattice achieves r^{1/4} fluctuation, far below the \u221ar universal lower bound.",
+    "summary": "Erdős Problem #989 asked whether the circle discrepancy f(r) is unbounded and how fast it grows. Beck (1987) completely settled this: f(r) ≫ √r for ALL sequences (using Fourier/Bessel analysis), and ∃ sequence with f(r) ≪ √(r log r) (using probabilistic construction). The optimal rate is Θ̃(√r).",
+    "implications": "1. **Discrepancy Theory**: Foundational result establishing the sharp growth rate for circle discrepancy, resolving the key open question in geometric equidistribution\n\n2. **Fourier Methods in Combinatorics**: Demonstrates the power of harmonic analysis for discrete geometry problems — the Bessel function connection shows deep interplay between analysis and combinatorics\n\n**3. Probabilistic Method**: The fact that a randomly perturbed lattice achieves near-optimal discrepancy is a striking example of the Erdős probabilistic method in geometry\n\n4. **Curvature and Discrepancy**: The comparison circles (√r) vs half-planes (r^{1/4}) reveals that boundary curvature κ = 1/r fundamentally amplifies discrepancy — a geometric insight with implications for all curved test set families\n\n5. **Connection to Number Theory**: The Gauss circle problem (lattice points in circles) is a special case where the highly structured lattice achieves r^{1/4} fluctuation, far below the √r universal lower bound.",
     "openQuestions": [
-      "Is the logarithmic factor necessary? Is the lower bound actually \u03a9(\u221a(r log r))? This has been open since 1987.",
-      "Can we give explicit deterministic constructions achieving \u221a(r log r)? Known low-discrepancy sequences (Halton, Niederreiter) apply to boxes, not circles.",
-      "What is the optimal discrepancy for balls in higher dimensions \u211d^d? The expected answer r^{(d-1)/2} up to logs is supported but not fully proved.",
+      "Is the logarithmic factor necessary? Is the lower bound actually Ω(√(r log r))? This has been open since 1987.",
+      "Can we give explicit deterministic constructions achieving √(r log r)? Known low-discrepancy sequences (Halton, Niederreiter) apply to boxes, not circles.",
+      "What is the optimal discrepancy for balls in higher dimensions ℝ^d? The expected answer r^{(d-1)/2} up to logs is supported but not fully proved.",
       "Are there natural sequences (lattice-based, number-theoretic) achieving near-optimal circle discrepancy without randomization?",
       "What about discrepancy for other families of curved sets (ellipses, convex sets of bounded curvature)?"
     ]
@@ -218,7 +218,7 @@
     "lineCount": 341,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos989Problem.lean",
     "sorries": 0
   },
@@ -231,12 +231,12 @@
     {
       "targetId": "erdos-987",
       "relationship": "related",
-      "description": "Exponential sums controlling equidistribution via the Erd\u0151s-Tur\u00e1n inequality, using related Fourier methods"
+      "description": "Exponential sums controlling equidistribution via the Erdős-Turán inequality, using related Fourier methods"
     },
     {
       "targetId": "erdos-990",
       "relationship": "related",
-      "description": "Angular discrepancy of polynomial roots on the unit circle via Erd\u0151s-Tur\u00e1n inequality"
+      "description": "Angular discrepancy of polynomial roots on the unit circle via Erdős-Turán inequality"
     },
     {
       "targetId": "erdos-992",

--- a/src/data/proofs/erdos-990/meta.json
+++ b/src/data/proofs/erdos-990/meta.json
@@ -182,7 +182,7 @@
     "lineCount": 207,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos990Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Metadata-only fix: corrects stale `leanFile.definitionCount` (and `theoremCount` where drifted) for 21 gallery proofs in the erdos-901 to erdos-1000 range. Also populates missing null counts for erdos-901, erdos-914, erdos-935.

## Evidence

**Counting method**: `grep -cE '^(noncomputable |private |protected )?(def |abbrev )'`

| Proof | definitionCount Before→After | theoremCount Before→After |
|-------|------------------------------|--------------------------|
| erdos-901 | null→9 | null→19 |
| erdos-902 | 10→7 | — |
| erdos-914 | null→6 | null→1 |
| erdos-919 | 15→14 | — |
| erdos-928 | 8→9 | — |
| erdos-931 | 6→5 | 44→46 |
| erdos-932 | 11→12 | — |
| erdos-935 | null→7 | null→4 |
| erdos-938 | 9→13 | — |
| erdos-945 | 3→4 | — |
| erdos-952 | 12→18 | — |
| erdos-953 | 5→6 | — |
| erdos-957 | 9→10 | — |
| erdos-958 | 10→11 | — |
| erdos-960 | 8→7 | — |
| erdos-977 | 0→8 | — |
| erdos-982 | 8→9 | — |
| erdos-987 | 6→8 | — |
| erdos-989 | 13→14 | — |
| erdos-990 | 11→12 | — |
| erdos-1000 | 8→11 | 60→61 |

No Lean source files changed.

---
Automated fix by lean-mechanic agent.