### PR TITLE
fix(meta): sync leanFile.definitionCount/theoremCount for 22 proofs (batch 12)

### DIFF
--- a/src/data/proofs/erdos-1105/meta.json
+++ b/src/data/proofs/erdos-1105/meta.json
@@ -294,7 +294,7 @@
     "lineCount": 378,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 25,
+    "definitionCount": 26,
     "path": "Proofs/Erdos1105Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -203,6 +203,8 @@
     "axiomCount": 1,
     "lineCount": 172,
     "sorries": 0,
-    "path": "Proofs/Erdos1113Problem.lean"
+    "path": "Proofs/Erdos1113Problem.lean",
+    "definitionCount": 14,
+    "theoremCount": 5
   }
 }

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -181,7 +181,7 @@
     "lineCount": 83,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 1,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1117Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1124/meta.json
+++ b/src/data/proofs/erdos-1124/meta.json
@@ -261,7 +261,7 @@
     "lineCount": 190,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos1124Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1127/meta.json
+++ b/src/data/proofs/erdos-1127/meta.json
@@ -235,7 +235,7 @@
     "lineCount": 279,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos1127Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -190,7 +190,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos1135Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1136/meta.json
+++ b/src/data/proofs/erdos-1136/meta.json
@@ -90,7 +90,8 @@
       "Finset",
       "Filter"
     ],
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1137/meta.json
+++ b/src/data/proofs/erdos-1137/meta.json
@@ -94,7 +94,8 @@
     ],
     "axiomCount": 1,
     "theoremCount": 23,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -155,7 +155,7 @@
     "lineCount": 178,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1139Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -167,7 +167,7 @@
     "namespace": "Erdos1150",
     "lineCount": 341,
     "axiomCount": 3,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 4,
     "path": "Proofs/Erdos1150Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1158/meta.json
+++ b/src/data/proofs/erdos-1158/meta.json
@@ -181,7 +181,7 @@
     "lineCount": 306,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1158Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -172,7 +172,9 @@
     "lineCount": 329,
     "axiomCount": 10,
     "path": "Proofs/Erdos1160Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 5,
+    "theoremCount": 24
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1162",
-  "title": "Erd\u0151s Problem #1162: Number of Subgroups of S_n",
+  "title": "Erdős Problem #1162: Number of Subgroups of S_n",
   "slug": "erdos-1162",
-  "description": "Give an asymptotic formula for the number of subgroups of S_n. Pyber (1993) proved log f(n) \u224d n\u00b2. Roney-Dougal-Tracey (2025) proved log f(n) = (1/16 + o(1))n\u00b2. The constant 1/16 arises from elementary abelian 2-subgroups.",
+  "description": "Give an asymptotic formula for the number of subgroups of S_n. Pyber (1993) proved log f(n) ≍ n². Roney-Dougal-Tracey (2025) proved log f(n) = (1/16 + o(1))n². The constant 1/16 arises from elementary abelian 2-subgroups.",
   "meta": {
-    "author": "Erd\u0151s, Tur\u00e1n (original); Pyber (1993); Roney-Dougal, Tracey (2025)",
+    "author": "Erdős, Turán (original); Pyber (1993); Roney-Dougal, Tracey (2025)",
     "sourceUrl": "https://erdosproblems.com/1162",
     "date": "1993",
     "status": "axiomatized",
@@ -47,11 +47,11 @@
     ],
     "originalContributions": [
       "numSubgroups axiom: f(n) = number of subgroups of S_n",
-      "roney_dougal_tracey: log f(n) / n\u00b2 \u2192 1/16 (Tendsto formulation)",
-      "rdt_implies_pyber: convergence \u2192 eventual bounds (PROVED, no sorry)",
+      "roney_dougal_tracey: log f(n) / n² → 1/16 (Tendsto formulation)",
+      "rdt_implies_pyber: convergence → eventual bounds (PROVED, no sorry)",
       "pyber_theorem: derived from rdt_implies_pyber + roney_dougal_tracey (no longer an axiom)",
       "Elementary abelian 2-group infrastructure (maxElem2Rank, numSubgroupsElem2)",
-      "constant_explanation: (1/4)\u00b2 = 1/16 (proved by norm_num)",
+      "constant_explanation: (1/4)² = 1/16 (proved by norm_num)",
       "Small cases: f(1)=1, f(2)=2, f(3)=6, f(4)=30",
       "erdos1162_asymptotic: formal statement of the asymptotic result"
     ],
@@ -60,16 +60,16 @@
     "assumptions": "1 axiom: roney_dougal_tracey. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Counting subgroups of the symmetric group $S_n$ is a fundamental problem in combinatorial group theory, posed by Erd\u0151s and Tur\u00e1n. The problem has two parts: the asymptotic formula for $f(n) = |\\{H \\leq S_n\\}|$ and a 'statistical theorem on their order' (the distribution of $|H|$ as $H$ ranges over subgroups). The first breakthrough came from Pyber (1993), who established $\\log f(n) \\asymp n^2$ \u2014 the order of magnitude \u2014 using probabilistic arguments about the structure of maximal subgroups. The precise constant eluded researchers for 32 years. Roney-Dougal and Tracey (2025) finally proved $\\log f(n) = (1/16 + o(1))n^2$, showing the dominant contribution comes from elementary abelian 2-subgroups of the wreath product $(\\mathbb{Z}/2\\mathbb{Z}) \\wr S_{\\lfloor n/4 \\rfloor}$. The constant $1/16 = (1/4)^2$ is purely combinatorial: the number of subgroups of $(\\mathbb{Z}/2\\mathbb{Z})^k$ (counted by Gaussian binomial coefficients over $\\mathrm{GF}(2)$) grows as $2^{k^2/4}$, and with $k = n/4$ this gives $n^2/64 \\cdot \\log 2$, which (after careful bookkeeping) yields $n^2/16$.",
+    "historicalContext": "Counting subgroups of the symmetric group $S_n$ is a fundamental problem in combinatorial group theory, posed by Erdős and Turán. The problem has two parts: the asymptotic formula for $f(n) = |\\{H \\leq S_n\\}|$ and a 'statistical theorem on their order' (the distribution of $|H|$ as $H$ ranges over subgroups). The first breakthrough came from Pyber (1993), who established $\\log f(n) \\asymp n^2$ — the order of magnitude — using probabilistic arguments about the structure of maximal subgroups. The precise constant eluded researchers for 32 years. Roney-Dougal and Tracey (2025) finally proved $\\log f(n) = (1/16 + o(1))n^2$, showing the dominant contribution comes from elementary abelian 2-subgroups of the wreath product $(\\mathbb{Z}/2\\mathbb{Z}) \\wr S_{\\lfloor n/4 \\rfloor}$. The constant $1/16 = (1/4)^2$ is purely combinatorial: the number of subgroups of $(\\mathbb{Z}/2\\mathbb{Z})^k$ (counted by Gaussian binomial coefficients over $\\mathrm{GF}(2)$) grows as $2^{k^2/4}$, and with $k = n/4$ this gives $n^2/64 \\cdot \\log 2$, which (after careful bookkeeping) yields $n^2/16$.",
     "problemStatement": "**Problem Statement (Partially Resolved)**\n\nGive an asymptotic formula for the number of subgroups of $S_n$. Is there a statistical theorem on their order?\n\n**Known:**\n- Pyber (1993): $\\log f(n) \\asymp n^2$\n- Roney-Dougal-Tracey (2025): $\\log f(n) = (\\frac{1}{16} + o(1))n^2$\n\nThe asymptotic formula is now established. The statistical theorem on orders remains partially open.",
-    "text": "Asymptotic enumeration of subgroups of S_n: log f(n) = (1/16 + o(1))n\u00b2. The constant 1/16 arises from elementary abelian 2-subgroups.",
+    "text": "Asymptotic enumeration of subgroups of S_n: log f(n) = (1/16 + o(1))n². The constant 1/16 arises from elementary abelian 2-subgroups.",
     "proofStrategy": "The formalization axiomatizes f(n) as the subgroup count (not computationally feasible to define constructively), states Pyber's bounds and the Roney-Dougal-Tracey asymptotic using Filter.Tendsto. The connection to elementary abelian 2-groups explains the constant 1/16. Small cases are stated for verification.",
     "keyInsights": [
-      "**The constant 1/16**: Comes from (1/4)\u00b2 \u2014 the dominant subgroups embed as elementary abelian 2-groups on \u230an/4\u230b points, and the number of subgroups of (Z/2Z)^k grows as 2^(k\u00b2/4).",
+      "**The constant 1/16**: Comes from (1/4)² — the dominant subgroups embed as elementary abelian 2-groups on ⌊n/4⌋ points, and the number of subgroups of (Z/2Z)^k grows as 2^(k²/4).",
       "**Most subgroups are 2-groups**: The overwhelming majority of subgroups of S_n have order a power of 2.",
-      "**Wreath product structure**: The key construction is (Z/2Z) \u2240 S_{\u230an/4\u230b} \u2014 wreath products of 2-groups with symmetric groups on a quarter of the points.",
-      "**Gaussian binomial coefficients**: The count of subgroups of (Z/2Z)^k involves Gaussian binomials over GF(2), contributing the k\u00b2/4 term.",
-      "**Axiom reduction to 1**: The original 6-axiom formalization was reduced to 1 through Lean proofs: f1 via Subsingleton\u2192Unique chain, f2-f4 via native_decide, leaving only the single deep published result (Roney-Dougal-Tracey 2025) as an irreducible assumption."
+      "**Wreath product structure**: The key construction is (Z/2Z) ≀ S_{⌊n/4⌋} — wreath products of 2-groups with symmetric groups on a quarter of the points.",
+      "**Gaussian binomial coefficients**: The count of subgroups of (Z/2Z)^k involves Gaussian binomials over GF(2), contributing the k²/4 term.",
+      "**Axiom reduction to 1**: The original 6-axiom formalization was reduced to 1 through Lean proofs: f1 via Subsingleton→Unique chain, f2-f4 via native_decide, leaving only the single deep published result (Roney-Dougal-Tracey 2025) as an irreducible assumption."
     ],
     "prerequisites": [
       "Symmetric groups $S_n$ and their subgroup structure",
@@ -91,7 +91,7 @@
     {
       "id": "trivial-bounds",
       "title": "Part II: Trivial Bounds",
-      "summary": "f(n) \u2264 2^(n!) upper bound.",
+      "summary": "f(n) ≤ 2^(n!) upper bound.",
       "startLine": 54,
       "endLine": 65,
       "mathContext": "Each subgroup is a subset of $S_n$ ($|S_n| = n!$), giving $f(n) \\leq 2^{n!}$."
@@ -142,15 +142,15 @@
       "summary": "erdos1162_asymptotic and erdos_1162 main theorem.",
       "startLine": 173,
       "endLine": 187,
-      "mathContext": "$\\log f(n) = (1/16 + o(1))n^2$. Erd\u0151s's asymptotic formula question is answered."
+      "mathContext": "$\\log f(n) = (1/16 + o(1))n^2$. Erdős's asymptotic formula question is answered."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #1162 asks for an asymptotic formula for the number of subgroups of S_n. Pyber (1993) showed log f(n) \u224d n\u00b2. Roney-Dougal and Tracey (2025) proved the precise asymptotic: log f(n) = (1/16 + o(1))n\u00b2. The constant 1/16 arises from elementary abelian 2-groups embedded via wreath products.",
-    "implications": "**Theoretical Significance**: This result reveals that the subgroup structure of S_n is dominated by 2-groups, specifically elementary abelian 2-subgroups of the wreath product (Z/2Z) \u2240 S_{\u230an/4\u230b}. The constant 1/16 connects to the theory of Gaussian binomial coefficients and the lattice of subspaces of a vector space over GF(2).",
+    "summary": "Erdős Problem #1162 asks for an asymptotic formula for the number of subgroups of S_n. Pyber (1993) showed log f(n) ≍ n². Roney-Dougal and Tracey (2025) proved the precise asymptotic: log f(n) = (1/16 + o(1))n². The constant 1/16 arises from elementary abelian 2-groups embedded via wreath products.",
+    "implications": "**Theoretical Significance**: This result reveals that the subgroup structure of S_n is dominated by 2-groups, specifically elementary abelian 2-subgroups of the wreath product (Z/2Z) ≀ S_{⌊n/4⌋}. The constant 1/16 connects to the theory of Gaussian binomial coefficients and the lattice of subspaces of a vector space over GF(2).",
     "openQuestions": [
       "What is the precise statistical distribution of subgroup orders in S_n?",
-      "Can the error term in log f(n) = (1/16 + o(1))n\u00b2 be made explicit?",
+      "Can the error term in log f(n) = (1/16 + o(1))n² be made explicit?",
       "What fraction of subgroups are abelian? Nilpotent? Solvable?",
       "What is the analogous result for alternating groups A_n?"
     ]
@@ -188,18 +188,18 @@
       "title": "Enumerating finite groups of given order",
       "year": "1993",
       "venue": "Annals of Mathematics 137(1)",
-      "note": "Proved log f(n) \u224d n\u00b2, establishing the order of magnitude"
+      "note": "Proved log f(n) ≍ n², establishing the order of magnitude"
     },
     {
       "authors": "Roney-Dougal, C. M. and Tracey, G.",
       "title": "The number of subgroups of the symmetric group",
       "year": "2025",
       "venue": "Annals of Mathematics (to appear)",
-      "note": "Proved the precise asymptotic: log f(n) = (1/16 + o(1))n\u00b2"
+      "note": "Proved the precise asymptotic: log f(n) = (1/16 + o(1))n²"
     },
     {
       "authors": "Vardi, I.",
-      "title": "Paul Erd\u0151s: Selected problems",
+      "title": "Paul Erdős: Selected problems",
       "year": "1999",
       "venue": "Mathematical Intelligencer 21(3)",
       "note": "Problem 5.73: original statement of the problem"
@@ -223,7 +223,7 @@
     "lineCount": 221,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1162Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -173,7 +173,7 @@
     "lineCount": 183,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/Erdos1165Problem.lean"
   },

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -211,7 +211,7 @@
     "lineCount": 547,
     "axiomCount": 3,
     "theoremCount": 25,
-    "definitionCount": 1,
+    "definitionCount": 7,
     "path": "Proofs/Erdos1166Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1168",
-  "title": "Erd\u0151s Problem #1168: Negative Partition Relation for \u2135_{\u03c9+1}",
+  "title": "Erdős Problem #1168: Negative Partition Relation for ℵ_{ω+1}",
   "slug": "erdos-1168",
-  "description": "Prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)_{\u2135\u2080}\u00b2 without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
+  "description": "Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
   "meta": {
     "erdosNumber": 1168,
     "status": "axiomatized",
@@ -24,21 +24,21 @@
     "lineCount": 255,
     "theoremCount": 11,
     "definitionCount": 9,
-    "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erd\u0151s-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
+    "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erdős-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-28"
   },
   "overview": {
-    "historicalContext": "Partition calculus \u2014 the study of the arrow notation \u03ba \u2192 (\u03b1)\u00b2_\u03bb \u2014 was systematically developed by Erd\u0151s and Rado in their 1956 paper 'A partition calculus in set theory.' The notation \u03ba \u2192 (\u03b1\u2080, \u03b1\u2081, \u2026)\u00b2_c (due to Erd\u0151s-Hajnal-Rado 1965) means: for any c-coloring of 2-element subsets of \u03ba, there exists a color i and a homogeneous set of size \u03b1\u1d62. The problem of negative partition relations for \u2135_{\u03c9+1} \u2014 the successor of the first singular cardinal \u2135_\u03c9 \u2014 sits at the heart of 'pcf theory' (possible cofinalities), developed by Shelah in the 1970s-1980s. The singular nature of \u2135_\u03c9 (it is the supremum of the sequence \u2135_0, \u2135_1, \u2135_2, \u2026 with countable cofinality) gives its successor special combinatorial properties. Under GCH, the desired negative partition relation follows from the Erd\u0151s-Hajnal-Rado 'stepping-up lemma' applied at \u2135_\u03c9. Proving it in ZFC alone \u2014 without assuming GCH \u2014 requires the much deeper structural theory of singular cardinals that Shelah pioneered. Shelah's 1992 result that \u2135_\u03c9^{\u2135_0} < \u2135_{\u03c9_4} (provable in ZFC) exemplifies the power of pcf theory for such problems.",
-    "problemStatement": "Prove in ZFC (without assuming GCH) that\n$$\\aleph_{\\omega+1} \\not\\to (\\aleph_{\\omega+1}, 3, 3, \\ldots)^2_{\\aleph_0}$$\nThat is, there exists a coloring $f : [\\aleph_{\\omega+1}]^2 \\to \\omega$ of 2-element subsets using countably many colors such that:\n- Color 0: has no monochromatic set of cardinality $\\aleph_{\\omega+1}$\n- Colors $i \\geq 1$: each has no monochromatic triangle (3-element set)\n\nFormal Lean definition: `\u00ac partitionRelation aleph_omega_succ targets` where `targets 0 = \u2135_{\u03c9+1}` and `targets (i+1) = 3`.",
-    "proofStrategy": "The file decomposes the known GCH result into a stepping-up framework with two clear subgoals: (1) base_case_under_gch \u2014 under GCH, each \u2135_{n+1} has a 2-coloring where color 0 avoids homogeneous sets of size \u2135_{n+1} and color 1 avoids cliques of size n+3; (2) stepping_up \u2014 these base colorings combine into a countably-colored partition of \u2135_{\u03c9+1} witnessing the negative relation. The theorem erdos_1168_under_gch is proved by composing these two (sorry) lemmas. Cardinal infrastructure is proved from Mathlib: \u2135_{\u03c9+1} is regular, cf(\u2135_\u03c9) = \u2135\u2080, \u2135_n < \u2135_\u03c9 < \u2135_{\u03c9+1}. The open conjecture (ZFC-only proof) is formalized as a Lean Prop without being asserted.",
+    "historicalContext": "Partition calculus — the study of the arrow notation κ → (α)²_λ — was systematically developed by Erdős and Rado in their 1956 paper 'A partition calculus in set theory.' The notation κ → (α₀, α₁, …)²_c (due to Erdős-Hajnal-Rado 1965) means: for any c-coloring of 2-element subsets of κ, there exists a color i and a homogeneous set of size αᵢ. The problem of negative partition relations for ℵ_{ω+1} — the successor of the first singular cardinal ℵ_ω — sits at the heart of 'pcf theory' (possible cofinalities), developed by Shelah in the 1970s-1980s. The singular nature of ℵ_ω (it is the supremum of the sequence ℵ_0, ℵ_1, ℵ_2, … with countable cofinality) gives its successor special combinatorial properties. Under GCH, the desired negative partition relation follows from the Erdős-Hajnal-Rado 'stepping-up lemma' applied at ℵ_ω. Proving it in ZFC alone — without assuming GCH — requires the much deeper structural theory of singular cardinals that Shelah pioneered. Shelah's 1992 result that ℵ_ω^{ℵ_0} < ℵ_{ω_4} (provable in ZFC) exemplifies the power of pcf theory for such problems.",
+    "problemStatement": "Prove in ZFC (without assuming GCH) that\n$$\\aleph_{\\omega+1} \\not\\to (\\aleph_{\\omega+1}, 3, 3, \\ldots)^2_{\\aleph_0}$$\nThat is, there exists a coloring $f : [\\aleph_{\\omega+1}]^2 \\to \\omega$ of 2-element subsets using countably many colors such that:\n- Color 0: has no monochromatic set of cardinality $\\aleph_{\\omega+1}$\n- Colors $i \\geq 1$: each has no monochromatic triangle (3-element set)\n\nFormal Lean definition: `¬ partitionRelation aleph_omega_succ targets` where `targets 0 = ℵ_{ω+1}` and `targets (i+1) = 3`.",
+    "proofStrategy": "The file decomposes the known GCH result into a stepping-up framework with two clear subgoals: (1) base_case_under_gch — under GCH, each ℵ_{n+1} has a 2-coloring where color 0 avoids homogeneous sets of size ℵ_{n+1} and color 1 avoids cliques of size n+3; (2) stepping_up — these base colorings combine into a countably-colored partition of ℵ_{ω+1} witnessing the negative relation. The theorem erdos_1168_under_gch is proved by composing these two (sorry) lemmas. Cardinal infrastructure is proved from Mathlib: ℵ_{ω+1} is regular, cf(ℵ_ω) = ℵ₀, ℵ_n < ℵ_ω < ℵ_{ω+1}. The open conjecture (ZFC-only proof) is formalized as a Lean Prop without being asserted.",
     "keyInsights": [
-      "The arrow notation \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, 3, \u2026)\u00b2_{\u2135\u2080} packs a complex combinatorial statement: there is a 'wild' countably-colored Ramsey coloring of pairs from \u2135_{\u03c9+1} where no single color achieves its target homogeneous set. Color 0 fails at \u2135_{\u03c9+1} (a large homogeneous set), while colors 1, 2, \u2026 fail at triangles (a small target).",
-      "The singularity of \u2135_\u03c9 \u2014 specifically its cofinality cf(\u2135_\u03c9) = \u2135_0 \u2014 is the key feature making \u2135_{\u03c9+1} interesting. Successor cardinals of regular cardinals (like \u2135_2 = (\u2135_1)\u207a) behave differently from successors of singular cardinals. The 'singular cardinal hypothesis' (a strengthening of GCH for singular cardinals) is independent of ZFC, making the problem delicate.",
-      "Under GCH, the result uses the stepping-up lemma: if \u2135_\u03c9 \u219b (\u2135_\u03c9, 3, \u2026)\u00b2_{\u2135_0} holds, then \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026)\u00b2_{\u2135_0} follows. GCH gives good control over cardinal arithmetic at \u2135_\u03c9. Without GCH, one must instead use pcf theory to control possible values of \u2135_\u03c9^{\u2135_0}.",
-      "pcf theory (Shelah) is the main candidate tool for a ZFC proof. For a set A of regular cardinals, pcf(A) = {cf(\u220fA/U) : U ultrafilter on A} is the set of possible cofinalities. Shelah proved that |pcf({\u2135_n : n < \u03c9})| < \u2135_\u03c9 (in ZFC!), which gives cardinal arithmetic results without GCH. Whether this is enough to prove Problem 1168 in ZFC is the core difficulty.",
-      "The Lean formalization is exemplary: IsHomogeneous uses a symmetric relation (f a b = i for all distinct a, b in S), and partitionRelation is universe-polymorphic (works for any type V with cardinality \u03ba). The five proved theorems cover the basic combinatorial properties without requiring any set-theoretic set theory beyond Mathlib's cardinal library.",
-      "The target function uses Lean's `fun | 0 => ... | _ + 1 => ...` pattern matching to define countably many targets: color 0 targets \u2135_{\u03c9+1} (the big homogeneous set) and all other colors target 3 (triangles). This clean encoding shows that Lean's dependent type system handles the countable-color partition relation naturally."
+      "The arrow notation ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} packs a complex combinatorial statement: there is a 'wild' countably-colored Ramsey coloring of pairs from ℵ_{ω+1} where no single color achieves its target homogeneous set. Color 0 fails at ℵ_{ω+1} (a large homogeneous set), while colors 1, 2, … fail at triangles (a small target).",
+      "The singularity of ℵ_ω — specifically its cofinality cf(ℵ_ω) = ℵ_0 — is the key feature making ℵ_{ω+1} interesting. Successor cardinals of regular cardinals (like ℵ_2 = (ℵ_1)⁺) behave differently from successors of singular cardinals. The 'singular cardinal hypothesis' (a strengthening of GCH for singular cardinals) is independent of ZFC, making the problem delicate.",
+      "Under GCH, the result uses the stepping-up lemma: if ℵ_ω ↛ (ℵ_ω, 3, …)²_{ℵ_0} holds, then ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …)²_{ℵ_0} follows. GCH gives good control over cardinal arithmetic at ℵ_ω. Without GCH, one must instead use pcf theory to control possible values of ℵ_ω^{ℵ_0}.",
+      "pcf theory (Shelah) is the main candidate tool for a ZFC proof. For a set A of regular cardinals, pcf(A) = {cf(∏A/U) : U ultrafilter on A} is the set of possible cofinalities. Shelah proved that |pcf({ℵ_n : n < ω})| < ℵ_ω (in ZFC!), which gives cardinal arithmetic results without GCH. Whether this is enough to prove Problem 1168 in ZFC is the core difficulty.",
+      "The Lean formalization is exemplary: IsHomogeneous uses a symmetric relation (f a b = i for all distinct a, b in S), and partitionRelation is universe-polymorphic (works for any type V with cardinality κ). The five proved theorems cover the basic combinatorial properties without requiring any set-theoretic set theory beyond Mathlib's cardinal library.",
+      "The target function uses Lean's `fun | 0 => ... | _ + 1 => ...` pattern matching to define countably many targets: color 0 targets ℵ_{ω+1} (the big homogeneous set) and all other colors target 3 (triangles). This clean encoding shows that Lean's dependent type system handles the countable-color partition relation naturally."
     ]
   },
   "sections": [
@@ -47,14 +47,14 @@
       "title": "Problem Statement and Context",
       "startLine": 1,
       "endLine": 34,
-      "summary": "Docstring stating Erd\u0151s Problem #1168: prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)\u00b2_{\u2135\u2080} in ZFC without GCH. Provides context: GCH case known via Erd\u0151s-Hajnal-Rado, ZFC case requires pcf theory (Shelah)."
+      "summary": "Docstring stating Erdős Problem #1168: prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)²_{ℵ₀} in ZFC without GCH. Provides context: GCH case known via Erdős-Hajnal-Rado, ZFC case requires pcf theory (Shelah)."
     },
     {
       "id": "cardinals",
       "title": "Part I: Cardinal Infrastructure",
       "startLine": 37,
       "endLine": 78,
-      "summary": "Defines aleph_omega and aleph_omega_succ. Proves 6 cardinal facts from Mathlib: \u2135_{\u03c9+1} = aleph(succ \u03c9), \u2135_{\u03c9+1} is regular, cf(\u2135_\u03c9) = \u2135\u2080, \u2135_\u03c9 < \u2135_{\u03c9+1}, \u2135\u2080 < \u2135_\u03c9, \u2135_n < \u2135_\u03c9 for all n."
+      "summary": "Defines aleph_omega and aleph_omega_succ. Proves 6 cardinal facts from Mathlib: ℵ_{ω+1} = aleph(succ ω), ℵ_{ω+1} is regular, cf(ℵ_ω) = ℵ₀, ℵ_ω < ℵ_{ω+1}, ℵ₀ < ℵ_ω, ℵ_n < ℵ_ω for all n."
     },
     {
       "id": "partition-framework",
@@ -68,7 +68,7 @@
       "title": "Part IV: GCH Stepping-Up Framework",
       "startLine": 120,
       "endLine": 189,
-      "summary": "Decomposes the GCH proof into base_case_under_gch (sorry: Erd\u0151s-Rado for each \u2135_{n+1}), stepping_up (sorry: combines base colorings into \u2135\u2080-coloring of \u2135_{\u03c9+1}), and erdos_1168_under_gch (proved by composition). Also defines GCH_at, GCH, and negPartition2."
+      "summary": "Decomposes the GCH proof into base_case_under_gch (sorry: Erdős-Rado for each ℵ_{n+1}), stepping_up (sorry: combines base colorings into ℵ₀-coloring of ℵ_{ω+1}), and erdos_1168_under_gch (proved by composition). Also defines GCH_at, GCH, and negPartition2."
     },
     {
       "id": "structural-theorems",
@@ -121,20 +121,22 @@
     }
   ],
   "conclusion": {
-    "summary": "This file provides a clean Lean 4 formalization of Erd\u0151s Problem #1168: the open question of whether \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, 3, \u2026)\u00b2_{\u2135\u2080} holds in ZFC. The GCH case is decomposed into two sorry lemmas (base_case_under_gch and stepping_up), the open conjecture is defined as a Lean Prop, and ten structural theorems and cardinal facts are proved. The file correctly represents the state of the art: the ZFC case is open.",
-    "implications": "A ZFC proof of Erd\u0151s 1168 would be a significant advance in set-theoretic combinatorics, demonstrating that pcf theory can resolve partition relation questions that previously required GCH. It would also provide a non-trivial theorem in Lean about large cardinals (at the level of \u2135_\u03c9 and its successor), extending Mathlib's cardinal library into research territory. Such a formalization would likely require encoding Shelah's pcf theory \u2014 a substantial Lean project in its own right.",
+    "summary": "This file provides a clean Lean 4 formalization of Erdős Problem #1168: the open question of whether ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} holds in ZFC. The GCH case is decomposed into two sorry lemmas (base_case_under_gch and stepping_up), the open conjecture is defined as a Lean Prop, and ten structural theorems and cardinal facts are proved. The file correctly represents the state of the art: the ZFC case is open.",
+    "implications": "A ZFC proof of Erdős 1168 would be a significant advance in set-theoretic combinatorics, demonstrating that pcf theory can resolve partition relation questions that previously required GCH. It would also provide a non-trivial theorem in Lean about large cardinals (at the level of ℵ_ω and its successor), extending Mathlib's cardinal library into research territory. Such a formalization would likely require encoding Shelah's pcf theory — a substantial Lean project in its own right.",
     "openQuestions": [
-      "Can pcf theory be encoded in Lean 4 using Mathlib's existing ordinal and cardinal infrastructure? The key pcf result needed is |pcf({\u2135_n : n < \u03c9})| < \u2135_\u03c9 \u2014 can this be proved in Lean from ZFC?",
-      "Is there a simpler combinatorial proof of Erd\u0151s 1168 not going through pcf theory, perhaps using a direct Ramsey-theoretic construction of the required coloring?",
-      "Does the Lean formulation of partitionRelation correctly capture the set-theoretic partition relation \u03ba \u2192 (\u03b1\u2080, \u03b1\u2081, \u2026)\u00b2_c? In particular, does the use of a Lean type V with #V = \u03ba accurately model the ordinal-based version?",
-      "Can the stepping-up lemma (used in the GCH proof) be formalized in Lean 4 using Mathlib's cardinal arithmetic, and would it suffice to prove Erd\u0151s 1168 under a weaker assumption than full GCH?"
+      "Can pcf theory be encoded in Lean 4 using Mathlib's existing ordinal and cardinal infrastructure? The key pcf result needed is |pcf({ℵ_n : n < ω})| < ℵ_ω — can this be proved in Lean from ZFC?",
+      "Is there a simpler combinatorial proof of Erdős 1168 not going through pcf theory, perhaps using a direct Ramsey-theoretic construction of the required coloring?",
+      "Does the Lean formulation of partitionRelation correctly capture the set-theoretic partition relation κ → (α₀, α₁, …)²_c? In particular, does the use of a Lean type V with #V = κ accurately model the ordinal-based version?",
+      "Can the stepping-up lemma (used in the GCH proof) be formalized in Lean 4 using Mathlib's cardinal arithmetic, and would it suffice to prove Erdős 1168 under a weaker assumption than full GCH?"
     ]
   },
   "leanFile": {
     "lineCount": 255,
     "axiomCount": 0,
     "path": "Proofs/Erdos1168Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "definitionCount": 9,
+    "theoremCount": 14
   },
   "sorries": 2
 }

--- a/src/data/proofs/erdos-1169/meta.json
+++ b/src/data/proofs/erdos-1169/meta.json
@@ -192,7 +192,7 @@
     "lineCount": 225,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 5,
+    "definitionCount": 13,
     "path": "Proofs/Erdos1169Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1182/meta.json
+++ b/src/data/proofs/erdos-1182/meta.json
@@ -146,7 +146,7 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 9,
+    "definitionCount": 8,
     "path": "Proofs/Erdos1182Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1202/meta.json
+++ b/src/data/proofs/erdos-1202/meta.json
@@ -167,6 +167,8 @@
     "axiomCount": 1,
     "lineCount": 115,
     "sorries": 0,
-    "path": "Proofs/Erdos1202Problem.lean"
+    "path": "Proofs/Erdos1202Problem.lean",
+    "definitionCount": 3,
+    "theoremCount": 3
   }
 }

--- a/src/data/proofs/erdos-1205/meta.json
+++ b/src/data/proofs/erdos-1205/meta.json
@@ -151,6 +151,8 @@
     "axiomCount": 2,
     "lineCount": 87,
     "sorries": 0,
-    "path": "Proofs/Erdos1205Problem.lean"
+    "path": "Proofs/Erdos1205Problem.lean",
+    "definitionCount": 3,
+    "theoremCount": 1
   }
 }

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-1206",
-  "title": "Erd\u0151s Problem #1206",
+  "title": "Erdős Problem #1206",
   "slug": "erdos-1206",
   "description": "Does ... contain a Sidon set of size ...? Is there an infinite set ... of positive density such that ... is a Sidon set? This question may also be asked for higher powers, and [324] suggests that f...",
   "meta": {
@@ -22,15 +22,15 @@
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for the axiom declarations."
   },
   "overview": {
-    "historicalContext": "Erd\u0151s Problem #1206 concerns Sidon sets among cube numbers. A Sidon set (also called a B\u2082 set) is a set of integers where all pairwise sums are distinct\u2014equivalently, all pairwise differences are distinct. Sidon introduced these in 1932 in connection with Fourier analysis. Erd\u0151s and Tur\u00e1n proved the fundamental bound: any Sidon subset of {1,...,N} has at most N^(1/2) + O(N^(1/4)) elements. Problem #1206 asks whether {1\u00b3, 2\u00b3, ..., N\u00b3} contains an unexpectedly large Sidon set of size \u226b N\u2014much larger relative to the set's cardinality than the Erd\u0151s\u2013Tur\u00e1n bound suggests for a generic subset of {1,...,N\u00b3}. The problem was marked solved on erdosproblems.com following work by Gabdullin and Konyagin (2024), who showed the short-interval cube set {n\u00b3 : N - cN^(1/2) \u2264 n \u2264 N} is Sidon. Garaev, Garayev, and Konyagin (2026) improved this to size \u226b N^(4/7-o(1)) for infinitely many N, using more refined estimates on the quadratic factor n\u00b2 + nm + m\u00b2. The problem is part of a broader Erd\u0151s program relating polynomial sequences to additive combinatorics, with analogues for squares (Problem #773) and linear sets (Problem #530).",
-    "problemStatement": "Does $\\{1,2^3,\\ldots,N^3\\}$ contain a Sidon set of size $\\gg N$? Is there an infinite set $A\\subset \\mathbb{N}$ of positive density such that $\\{a^3 : a\\in A\\}$ is a Sidon set? This question may also be asked for higher powers, and [324] suggests that for fifth powers $\\{n^5 :n\\geq 1\\}$ may itself be a Sidon set. Gabdullin and Konyagin [GaKo24] proved that there is a constant $c>0$ such that $\\{ n^3 : N-cN^{1/2}\\leq n\\leq N\\}$ is a Sidon set. Garaev, Garayev, and Konyagin [GGK26] have proved that the exponent $1/2$ can be improved to $4/7-o(1)$ for infinitely many $N$, and to $3/5$ for all $N$ if we replace $n^3$ with $n^4$. In [Er80] Erd\u0151s defines $g_k(A)$ to be the maximal size of a Sidon set of $\\{a^k : a\\in A\\}$, and asks whether $g_k(A)\\geq g_k(\\{1,\\ldots,N\\})$ where $N=\\lvert A\\rvert$. (See [530] for the linear analogue.) See also [773] for an analogous question about squares.",
-    "proofStrategy": "Pending formalization. The key mathematical idea is that consecutive cubes in a short interval satisfy the Sidon property via the factoring n\u00b3 - m\u00b3 = (n-m)(n\u00b2 + nm + m\u00b2). In the interval [N - cN^(1/2), N], the quadratic factor varies by only O(cN^(3/2)), while it is approximately 3N\u00b2. Two distinct differences (n\u2081-n\u2082) \u2260 (n\u2083-n\u2084) then imply n\u2081\u00b3 - n\u2082\u00b3 \u2260 n\u2083\u00b3 - n\u2084\u00b3 for small enough c, establishing the Sidon property. A Lean formalization would need: `IsSidon` for Finset \u2124, `Finset.image (fun n => n^3) (Finset.Ico ...)` for the cube set, and arithmetic lemmas about the quadratic factor.",
+    "historicalContext": "Erdős Problem #1206 concerns Sidon sets among cube numbers. A Sidon set (also called a B₂ set) is a set of integers where all pairwise sums are distinct—equivalently, all pairwise differences are distinct. Sidon introduced these in 1932 in connection with Fourier analysis. Erdős and Turán proved the fundamental bound: any Sidon subset of {1,...,N} has at most N^(1/2) + O(N^(1/4)) elements. Problem #1206 asks whether {1³, 2³, ..., N³} contains an unexpectedly large Sidon set of size ≫ N—much larger relative to the set's cardinality than the Erdős–Turán bound suggests for a generic subset of {1,...,N³}. The problem was marked solved on erdosproblems.com following work by Gabdullin and Konyagin (2024), who showed the short-interval cube set {n³ : N - cN^(1/2) ≤ n ≤ N} is Sidon. Garaev, Garayev, and Konyagin (2026) improved this to size ≫ N^(4/7-o(1)) for infinitely many N, using more refined estimates on the quadratic factor n² + nm + m². The problem is part of a broader Erdős program relating polynomial sequences to additive combinatorics, with analogues for squares (Problem #773) and linear sets (Problem #530).",
+    "problemStatement": "Does $\\{1,2^3,\\ldots,N^3\\}$ contain a Sidon set of size $\\gg N$? Is there an infinite set $A\\subset \\mathbb{N}$ of positive density such that $\\{a^3 : a\\in A\\}$ is a Sidon set? This question may also be asked for higher powers, and [324] suggests that for fifth powers $\\{n^5 :n\\geq 1\\}$ may itself be a Sidon set. Gabdullin and Konyagin [GaKo24] proved that there is a constant $c>0$ such that $\\{ n^3 : N-cN^{1/2}\\leq n\\leq N\\}$ is a Sidon set. Garaev, Garayev, and Konyagin [GGK26] have proved that the exponent $1/2$ can be improved to $4/7-o(1)$ for infinitely many $N$, and to $3/5$ for all $N$ if we replace $n^3$ with $n^4$. In [Er80] Erdős defines $g_k(A)$ to be the maximal size of a Sidon set of $\\{a^k : a\\in A\\}$, and asks whether $g_k(A)\\geq g_k(\\{1,\\ldots,N\\})$ where $N=\\lvert A\\rvert$. (See [530] for the linear analogue.) See also [773] for an analogous question about squares.",
+    "proofStrategy": "Pending formalization. The key mathematical idea is that consecutive cubes in a short interval satisfy the Sidon property via the factoring n³ - m³ = (n-m)(n² + nm + m²). In the interval [N - cN^(1/2), N], the quadratic factor varies by only O(cN^(3/2)), while it is approximately 3N². Two distinct differences (n₁-n₂) ≠ (n₃-n₄) then imply n₁³ - n₂³ ≠ n₃³ - n₄³ for small enough c, establishing the Sidon property. A Lean formalization would need: `IsSidon` for Finset ℤ, `Finset.image (fun n => n^3) (Finset.Ico ...)` for the cube set, and arithmetic lemmas about the quadratic factor.",
     "keyInsights": [
-      "The algebraic identity n\u00b3 - m\u00b3 = (n-m)(n\u00b2 + nm + m\u00b2) reduces the Sidon condition for consecutive cubes to controlling the quadratic factor n\u00b2 + nm + m\u00b2, which is nearly constant (~3N\u00b2) in a short interval near N.",
-      "Gabdullin and Konyagin (2024) showed the short-interval set {n\u00b3 : N - cN^(1/2) \u2264 n \u2264 N} is Sidon (size \u226b N^(1/2)), establishing that cube numbers contain large Sidon subsets even in highly restricted ranges.",
-      "Garaev, Garayev, and Konyagin (2026) improved the Sidon size to \u226b N^(4/7-o(1)) for infinitely many N (and \u226b N^(3/5) for fourth powers), pushing closer to the full \u226b N goal of the problem.",
-      "The conjecture that {n\u2075 : n \u2265 1} is itself a Sidon set is equivalent to the Diophantine statement that a\u2075 + b\u2075 = c\u2075 + d\u2075 has no positive integer solutions with {a,b} \u2260 {c,d}\u2014open as of 2025.",
-      "Erd\u0151s's g_k(A) formulation asks whether {1,...,N} extremizes the Sidon density among k-th power sets, connecting the problem to a family of extremal additive combinatorics questions."
+      "The algebraic identity n³ - m³ = (n-m)(n² + nm + m²) reduces the Sidon condition for consecutive cubes to controlling the quadratic factor n² + nm + m², which is nearly constant (~3N²) in a short interval near N.",
+      "Gabdullin and Konyagin (2024) showed the short-interval set {n³ : N - cN^(1/2) ≤ n ≤ N} is Sidon (size ≫ N^(1/2)), establishing that cube numbers contain large Sidon subsets even in highly restricted ranges.",
+      "Garaev, Garayev, and Konyagin (2026) improved the Sidon size to ≫ N^(4/7-o(1)) for infinitely many N (and ≫ N^(3/5) for fourth powers), pushing closer to the full ≫ N goal of the problem.",
+      "The conjecture that {n⁵ : n ≥ 1} is itself a Sidon set is equivalent to the Diophantine statement that a⁵ + b⁵ = c⁵ + d⁵ has no positive integer solutions with {a,b} ≠ {c,d}—open as of 2025.",
+      "Erdős's g_k(A) formulation asks whether {1,...,N} extremizes the Sidon density among k-th power sets, connecting the problem to a family of extremal additive combinatorics questions."
     ]
   },
   "sections": [
@@ -40,22 +40,22 @@
       "startLine": 1,
       "endLine": 6,
       "summary": "Doc-comment header: source URL (erdosproblems.com/1206) and status SOLVED. The problem is solved by Gabdullin-Konyagin (2024) and Garaev-Garayev-Konyagin (2026).",
-      "mathContext": "Erd\u0151s Problem #1206: Does {1\u00b3, 2\u00b3, ..., N\u00b3} contain a Sidon set of size \u226b N? Status SOLVED \u2014 Gabdullin-Konyagin showed {n\u00b3 : N-cN^{1/2} \u2264 n \u2264 N} is Sidon."
+      "mathContext": "Erdős Problem #1206: Does {1³, 2³, ..., N³} contain a Sidon set of size ≫ N? Status SOLVED — Gabdullin-Konyagin showed {n³ : N-cN^{1/2} ≤ n ≤ N} is Sidon."
     },
     {
       "id": "problem-statement",
       "title": "Problem Statement: Sidon Sets in Cube Numbers",
       "startLine": 7,
       "endLine": 14,
-      "summary": "The problem text from erdosproblems.com. Asks two related questions: (1) does {1\u00b3,...,N\u00b3} have a Sidon subset of size \u226b N? (2) does a positive-density A \u2282 \u2115 exist with {a\u00b3 : a \u2208 A} Sidon? Also cites the Gabdullin-Konyagin and GGK results and the fifth-power conjecture.",
-      "mathContext": "Key results: {n\u00b3 : N - cN^{1/2} \u2264 n \u2264 N} is Sidon (size \u226b N^{1/2}), proved via n\u00b3 - m\u00b3 = (n-m)(n\u00b2 + nm + m\u00b2). The exponent 1/2 improves to 4/7-o(1) for infinitely many N. Fifth powers {n\u2075} may be Sidon (Diophantine conjecture a\u2075+b\u2075=c\u2075+d\u2075 has no non-trivial solutions)."
+      "summary": "The problem text from erdosproblems.com. Asks two related questions: (1) does {1³,...,N³} have a Sidon subset of size ≫ N? (2) does a positive-density A ⊂ ℕ exist with {a³ : a ∈ A} Sidon? Also cites the Gabdullin-Konyagin and GGK results and the fifth-power conjecture.",
+      "mathContext": "Key results: {n³ : N - cN^{1/2} ≤ n ≤ N} is Sidon (size ≫ N^{1/2}), proved via n³ - m³ = (n-m)(n² + nm + m²). The exponent 1/2 improves to 4/7-o(1) for infinitely many N. Fifth powers {n⁵} may be Sidon (Diophantine conjecture a⁵+b⁵=c⁵+d⁵ has no non-trivial solutions)."
     },
     {
       "id": "imports",
       "title": "Mathlib Import",
       "startLine": 16,
       "endLine": 16,
-      "summary": "Imports all of Mathlib. A full formalization would use Mathlib's `IsSidon` predicate (if available) or define it as \u2200 a b c d \u2208 S, a + b = c + d \u2192 {a,b} = {c,d}, plus `Finset.image`, `Finset.Ico`, and integer arithmetic from `Mathlib.Data.Int.Order`.",
+      "summary": "Imports all of Mathlib. A full formalization would use Mathlib's `IsSidon` predicate (if available) or define it as ∀ a b c d ∈ S, a + b = c + d → {a,b} = {c,d}, plus `Finset.image`, `Finset.Ico`, and integer arithmetic from `Mathlib.Data.Int.Order`.",
       "mathContext": "Relevant Mathlib modules: `Mathlib.Combinatorics.Additive.SidonSet` (if it exists in 4.x), `Mathlib.Data.Int.Basic` (for integer arithmetic), `Mathlib.Data.Nat.GCD.Basic` (for gcd arguments in Sidon proofs)."
     },
     {
@@ -63,8 +63,8 @@
       "title": "Placeholder Theorem: Sidon Cubes (Sorry)",
       "startLine": 18,
       "endLine": 21,
-      "summary": "Stub `theorem erdos_1206 : True := by sorry`. The actual theorem to formalize: \u2203 c > 0, \u2200 N, IsSidon {n\u00b3 : N - c\u00b7N^(1/2) \u2264 n \u2264 N}, proved via the algebraic identity n\u00b3 - m\u00b3 = (n-m)(n\u00b2+nm+m\u00b2) showing all pairwise sums/differences are distinct in short intervals.",
-      "mathContext": "Target type: `\u2203 c : \u211d, 0 < c \u2227 \u2200 N : \u2115, 0 < N \u2192 (Finset.image (\u00b7 ^ 3) (Finset.Ico (N - Nat.sqrt N) N)).card = (Finset.Ico (N - Nat.sqrt N) N).card`. The Sidon condition requires all pairwise sums $a^3 + b^3 = c^3 + d^3$ to imply $\\{a,b\\} = \\{c,d\\}$."
+      "summary": "Stub `theorem erdos_1206 : True := by sorry`. The actual theorem to formalize: ∃ c > 0, ∀ N, IsSidon {n³ : N - c·N^(1/2) ≤ n ≤ N}, proved via the algebraic identity n³ - m³ = (n-m)(n²+nm+m²) showing all pairwise sums/differences are distinct in short intervals.",
+      "mathContext": "Target type: `∃ c : ℝ, 0 < c ∧ ∀ N : ℕ, 0 < N → (Finset.image (· ^ 3) (Finset.Ico (N - Nat.sqrt N) N)).card = (Finset.Ico (N - Nat.sqrt N) N).card`. The Sidon condition requires all pairwise sums $a^3 + b^3 = c^3 + d^3$ to imply $\\{a,b\\} = \\{c,d\\}$."
     },
     {
       "id": "sorry-tracking",
@@ -76,29 +76,29 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #1206 is mathematically solved: Gabdullin-Konyagin (2024) proved that consecutive cube numbers form a Sidon set in short intervals of width cN^(1/2), giving a Sidon subset of {n\u00b3 : n \u2264 N} of size \u226b N^(1/2). Garaev-Garayev-Konyagin (2026) improved this to \u226b N^(4/7-o(1)}. The Lean formalization is a pending stub; it will require defining the Sidon property for cube-number Finsets and verifying the quadratic factor estimates.",
-    "implications": "The result contributes to understanding Sidon structure in polynomial sequences. The algebraic factoring technique may extend to higher powers, potentially confirming Erd\u0151s's conjecture that {n\u2075} is itself a Sidon set.",
+    "summary": "Erdős Problem #1206 is mathematically solved: Gabdullin-Konyagin (2024) proved that consecutive cube numbers form a Sidon set in short intervals of width cN^(1/2), giving a Sidon subset of {n³ : n ≤ N} of size ≫ N^(1/2). Garaev-Garayev-Konyagin (2026) improved this to ≫ N^(4/7-o(1)}. The Lean formalization is a pending stub; it will require defining the Sidon property for cube-number Finsets and verifying the quadratic factor estimates.",
+    "implications": "The result contributes to understanding Sidon structure in polynomial sequences. The algebraic factoring technique may extend to higher powers, potentially confirming Erdős's conjecture that {n⁵} is itself a Sidon set.",
     "openQuestions": [
-      "Can the Sidon subset size be improved to \u226b N, achieving the full goal of the problem?",
-      "Is {n\u2075 : n \u2265 1} itself a Sidon set (equivalently: does a\u2075 + b\u2075 = c\u2075 + d\u2075 have no solutions with {a,b} \u2260 {c,d})?",
-      "Does the extremal conjecture g_k(A) \u2265 g_k({1,...,N}) hold for k \u2265 3?"
+      "Can the Sidon subset size be improved to ≫ N, achieving the full goal of the problem?",
+      "Is {n⁵ : n ≥ 1} itself a Sidon set (equivalently: does a⁵ + b⁵ = c⁵ + d⁵ have no solutions with {a,b} ≠ {c,d})?",
+      "Does the extremal conjecture g_k(A) ≥ g_k({1,...,N}) hold for k ≥ 3?"
     ]
   },
   "crossReferences": [
     {
       "proofId": "erdos-340-greedy-sidon",
       "relationship": "related",
-      "description": "Greedy Sidon Sequence Infrastructure (Erd\u0151s Problem #340) \u2014 formalizes the greedy construction of Sidon sets in {1,...,N}. Problem #1206 asks about Sidon subsets of specifically the cube numbers {n\u00b3}. The greedy approach in #340 gives a Sidon set of size \u226b N^(1/2) in {1,...,N}; #1206's result (consecutive cubes form a Sidon set) achieves the same N^(1/2) scale but with an algebraically structured rather than greedily constructed sequence. Both results are tied to the Erd\u0151s-Tur\u00e1n N^(1/2) bound."
+      "description": "Greedy Sidon Sequence Infrastructure (Erdős Problem #340) — formalizes the greedy construction of Sidon sets in {1,...,N}. Problem #1206 asks about Sidon subsets of specifically the cube numbers {n³}. The greedy approach in #340 gives a Sidon set of size ≫ N^(1/2) in {1,...,N}; #1206's result (consecutive cubes form a Sidon set) achieves the same N^(1/2) scale but with an algebraically structured rather than greedily constructed sequence. Both results are tied to the Erdős-Turán N^(1/2) bound."
     },
     {
       "proofId": "erdos-1202",
       "relationship": "sibling",
-      "description": "Erd\u0151s #1202 (Prime Sets with Quantitative Density Conditions) is an adjacent problem in the same Erd\u0151s 1200s cluster. Both #1202 and #1206 concern structured subsets with quantitative size lower bounds \u2014 #1202 for prime sets, #1206 for cube-number Sidon sets. Problems #1201\u20131220 in Erd\u0151s's archive form a cluster on analytic and combinatorial number theory; these two are adjacent entries with similar quantitative threshold structure."
+      "description": "Erdős #1202 (Prime Sets with Quantitative Density Conditions) is an adjacent problem in the same Erdős 1200s cluster. Both #1202 and #1206 concern structured subsets with quantitative size lower bounds — #1202 for prime sets, #1206 for cube-number Sidon sets. Problems #1201–1220 in Erdős's archive form a cluster on analytic and combinatorial number theory; these two are adjacent entries with similar quantitative threshold structure."
     },
     {
       "proofId": "fundamental-arithmetic",
       "relationship": "foundational",
-      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) underpins the Sidon proof via the algebraic identity n\u00b3 - m\u00b3 = (n-m)(n\u00b2 + nm + m\u00b2). The Sidon condition requires all pairwise sum differences to be distinct; the factorization shows that in a short interval [N - cN^(1/2), N], the quadratic factor n\u00b2+nm+m\u00b2 is nearly constant (~3N\u00b2), making distinct pairs (n,m) give distinct differences. This is a multiplicative structure argument at heart \u2014 the same principles used in factoring in FTA."
+      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) underpins the Sidon proof via the algebraic identity n³ - m³ = (n-m)(n² + nm + m²). The Sidon condition requires all pairwise sum differences to be distinct; the factorization shows that in a short interval [N - cN^(1/2), N], the quadratic factor n²+nm+m² is nearly constant (~3N²), making distinct pairs (n,m) give distinct differences. This is a multiplicative structure argument at heart — the same principles used in factoring in FTA."
     }
   ],
   "sorries": 0,
@@ -111,7 +111,7 @@
     "lineCount": 102,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 0,
+    "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/Erdos1206Problem.lean"
   }

--- a/src/data/proofs/erdos-1208/meta.json
+++ b/src/data/proofs/erdos-1208/meta.json
@@ -147,6 +147,8 @@
     "axiomCount": 2,
     "lineCount": 137,
     "sorries": 1,
-    "path": "Proofs/Erdos1208Problem.lean"
+    "path": "Proofs/Erdos1208Problem.lean",
+    "definitionCount": 1,
+    "theoremCount": 4
   }
 }


### PR DESCRIPTION
Corrects leanFile counts for 22 proofs in the erdos-1105 to erdos-1208 range. Adds missing null/zero counts for erdos-1113, -1160, -1168, -1202, -1205, -1208. Metadata-only, no Lean source changes. Automated fix by lean-mechanic agent.