### PR TITLE
fix(meta): sync leanFile.definitionCount/theoremCount for 41 proofs (batch 13)

### DIFF
--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -223,7 +223,7 @@
     "lineCount": 149,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/Erdos1Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -193,7 +193,8 @@
     "namespace": null,
     "lineCount": 94,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 2
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -280,7 +280,7 @@
     "lineCount": 253,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 17,
+    "definitionCount": 19,
     "path": "Proofs/Erdos103Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-105/meta.json
+++ b/src/data/proofs/erdos-105/meta.json
@@ -255,7 +255,7 @@
     "lineCount": 305,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 10,
+    "definitionCount": 17,
     "path": "Proofs/Erdos105Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -210,6 +210,8 @@
     "axiomCount": 6,
     "lineCount": 243,
     "sorries": 2,
-    "path": "Proofs/Erdos107Problem.lean"
+    "path": "Proofs/Erdos107Problem.lean",
+    "definitionCount": 6,
+    "theoremCount": 12
   }
 }

--- a/src/data/proofs/erdos-110/meta.json
+++ b/src/data/proofs/erdos-110/meta.json
@@ -254,7 +254,7 @@
     "lineCount": 273,
     "axiomCount": 3,
     "theoremCount": 8,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos110Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -204,7 +204,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos112Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -126,7 +126,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos128Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 5
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-132/meta.json
+++ b/src/data/proofs/erdos-132/meta.json
@@ -209,7 +209,7 @@
     "lineCount": 204,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos132Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-134/meta.json
+++ b/src/data/proofs/erdos-134/meta.json
@@ -97,7 +97,7 @@
     "lineCount": 270,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos134Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -138,8 +138,8 @@
     "namespace": "Erdos138",
     "lineCount": 196,
     "axiomCount": 8,
-    "theoremCount": 6,
-    "definitionCount": 6,
+    "theoremCount": 4,
+    "definitionCount": 9,
     "path": "Proofs/Erdos138Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -186,7 +186,7 @@
     "lineCount": 313,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos140Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -113,7 +113,8 @@
     "namespace": null,
     "lineCount": 54,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   },
   "references": [
     "Szemerédi (1975): On sets of integers containing no k elements in arithmetic progression",

--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-155",
-  "title": "Erd\u0151s Problem #155: Slow Growth of Maximum Sidon Subsets",
+  "title": "Erdős Problem #155: Slow Growth of Maximum Sidon Subsets",
   "slug": "erdos-155",
-  "description": "Let F(N) be the largest Sidon subset of {1,...,N}. Is F(N+k) \u2264 F(N)+1 for all sufficiently large N, for every fixed k? Possibly even for k \u2248 \u03b5\u221aN. F(N) ~ \u221aN. Status: OPEN.",
+  "description": "Let F(N) be the largest Sidon subset of {1,...,N}. Is F(N+k) ≤ F(N)+1 for all sufficiently large N, for every fixed k? Possibly even for k ≈ ε√N. F(N) ~ √N. Status: OPEN.",
   "meta": {
     "erdosNumber": 155,
     "status": "axiomatized",
@@ -32,12 +32,12 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The study of Sidon sets ($B_2$ sets) began when the Hungarian mathematician Simon Sidon asked Erd\u0151s in 1932 about sets of integers with all pairwise sums distinct. Erd\u0151s and Tur\u00e1n (1941) proved the fundamental upper bound $F(N) = O(\\sqrt{N})$ by counting pairwise sums, and Singer (1938) achieved the matching lower bound $F(N) \\ge (1-o(1))\\sqrt{N}$ using perfect difference sets from finite projective geometry. Lindstr\u00f6m (1969) refined the upper bound to $F(N) \\le \\sqrt{N} + N^{1/4} + 1$, and the gap between upper and lower bounds in the second-order term remains open (the '$\\sqrt{N} + 1/2$ vs $\\sqrt{N} + N^{1/4}$' question). Erd\u0151s posed Problem #155 around 1992, asking about the fine growth structure: since $F(N)$ increases by 1 only $\\sim \\sqrt{N}$ times in $[1,N]$, the increase points should be very sparse \u2014 heuristically spaced $\\sim \\sqrt{N}$ apart. The conjecture that $F(N+k) \\le F(N) + 1$ for fixed $k$ formalizes this, and the stronger form $k \\approx \\varepsilon\\sqrt{N}$ would nearly pin down the increase point distribution.",
+    "historicalContext": "The study of Sidon sets ($B_2$ sets) began when the Hungarian mathematician Simon Sidon asked Erdős in 1932 about sets of integers with all pairwise sums distinct. Erdős and Turán (1941) proved the fundamental upper bound $F(N) = O(\\sqrt{N})$ by counting pairwise sums, and Singer (1938) achieved the matching lower bound $F(N) \\ge (1-o(1))\\sqrt{N}$ using perfect difference sets from finite projective geometry. Lindström (1969) refined the upper bound to $F(N) \\le \\sqrt{N} + N^{1/4} + 1$, and the gap between upper and lower bounds in the second-order term remains open (the '$\\sqrt{N} + 1/2$ vs $\\sqrt{N} + N^{1/4}$' question). Erdős posed Problem #155 around 1992, asking about the fine growth structure: since $F(N)$ increases by 1 only $\\sim \\sqrt{N}$ times in $[1,N]$, the increase points should be very sparse — heuristically spaced $\\sim \\sqrt{N}$ apart. The conjecture that $F(N+k) \\le F(N) + 1$ for fixed $k$ formalizes this, and the stronger form $k \\approx \\varepsilon\\sqrt{N}$ would nearly pin down the increase point distribution.",
     "problemStatement": "Is it true that for every $k \\ge 1$, $F(N+k) \\le F(N) + 1$ for all sufficiently large $N$, where $F(N)$ is the maximum Sidon subset size of $\\{1,\\ldots,N\\}$?",
-    "text": "Let F(N) be the largest Sidon subset of {1,...,N}. Is F(N+k) \u2264 F(N)+1 for all sufficiently large N, for every fixed k? Possibly even for k \u2248 \u03b5\u221aN. F(N) ~ \u221aN. Status: OPEN.",
-    "proofStrategy": "We formalize Sidon sets, define $F(N)$ axiomatically with achievability and optimality axioms, state the Erd\u0151s\u2013Tur\u00e1n/Lindstr\u00f6m upper bound and Singer lower bound, and present the main conjecture ($F(N+k) \\le F(N)+1$ for fixed $k$) and its stronger form ($k \\approx \\varepsilon\\sqrt{N}$). Consequences about the sparsity of increase points and known small values from OEIS A003022 are also axiomatized.",
+    "text": "Let F(N) be the largest Sidon subset of {1,...,N}. Is F(N+k) ≤ F(N)+1 for all sufficiently large N, for every fixed k? Possibly even for k ≈ ε√N. F(N) ~ √N. Status: OPEN.",
+    "proofStrategy": "We formalize Sidon sets, define $F(N)$ axiomatically with achievability and optimality axioms, state the Erdős–Turán/Lindström upper bound and Singer lower bound, and present the main conjecture ($F(N+k) \\le F(N)+1$ for fixed $k$) and its stronger form ($k \\approx \\varepsilon\\sqrt{N}$). Consequences about the sparsity of increase points and known small values from OEIS A003022 are also axiomatized.",
     "keyInsights": [
-      "**$F(N) \\sim \\sqrt{N}$ with tight bounds**: Erd\u0151s\u2013Tur\u00e1n gives $F(N) \\le \\sqrt{N} + N^{1/4} + 1$; Singer's finite-field construction gives $F(N) \\ge \\sqrt{N} - O(N^{1/4})$. The second-order term remains unknown.",
+      "**$F(N) \\sim \\sqrt{N}$ with tight bounds**: Erdős–Turán gives $F(N) \\le \\sqrt{N} + N^{1/4} + 1$; Singer's finite-field construction gives $F(N) \\ge \\sqrt{N} - O(N^{1/4})$. The second-order term remains unknown.",
       "**Increase points have density $\\sim 1/\\sqrt{N}$**: Since $F$ increases $\\sim \\sqrt{N}$ times in $[1,N]$ (one step at a time), the average gap between increase points is $\\sim \\sqrt{N}$, making any fixed $k$ negligible for large $N$",
       "**The strong form implies near-uniform spacing**: If $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N)+1$, then increase points are separated by at least $\\varepsilon\\sqrt{N}$, meaning they distribute almost uniformly at scale $\\sqrt{N}$",
       "**Singer's finite geometry construction**: For $q$ prime power, the set of elements with specified trace in $\\mathbb{F}_{q^2}^*$ gives a perfect difference set of size $q+1$ in $\\mathbb{Z}/(q^2+q+1)$, yielding optimal Sidon sets",
@@ -78,8 +78,8 @@
       "title": "Asymptotic Bounds",
       "startLine": 60,
       "endLine": 72,
-      "summary": "Axiomatizes the Erd\u0151s\u2013Tur\u00e1n/Lindstr\u00f6m upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$ and the Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for large $N$. Together: $F(N) = (1+o(1))\\sqrt{N}$.",
-      "mathContext": "Axiomatized: Axiomatizes the Erd\u0151s\u2013Tur\u00e1n/Lindstr\u00f6m upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$ and the Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for large $N$. Together: $F(N) = (1+o(1))\\sqrt{N}$."
+      "summary": "Axiomatizes the Erdős–Turán/Lindström upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$ and the Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for large $N$. Together: $F(N) = (1+o(1))\\sqrt{N}$.",
+      "mathContext": "Axiomatized: Axiomatizes the Erdős–Turán/Lindström upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$ and the Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for large $N$. Together: $F(N) = (1+o(1))\\sqrt{N}$."
     },
     {
       "id": "main-conjecture",
@@ -94,8 +94,8 @@
       "title": "Stronger Form: $k \\approx \\varepsilon\\sqrt{N}$",
       "startLine": 83,
       "endLine": 91,
-      "summary": "Erd\u0151s's stronger conjecture: $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$, implying consecutive increase points are separated by $\\ge \\varepsilon\\sqrt{N}$.",
-      "mathContext": "Mathematical content: Erd\u0151s's stronger conjecture: $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$, implying consecutive increase points are separated by $\\ge \\varepsilon\\sqrt{N}$."
+      "summary": "Erdős's stronger conjecture: $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$, implying consecutive increase points are separated by $\\ge \\varepsilon\\sqrt{N}$.",
+      "mathContext": "Mathematical content: Erdős's stronger conjecture: $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$, implying consecutive increase points are separated by $\\ge \\varepsilon\\sqrt{N}$."
     },
     {
       "id": "consequences",
@@ -115,13 +115,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #155 asks whether the maximum Sidon subset function F(N) grows so slowly that F(N+k) \u2264 F(N)+1 for any fixed k and large N. Since F(N) ~ \u221aN and increases by exactly 1 at each jump, the ~\u221aN increase points should be far apart. The problem remains open, with a stronger variant suggesting plateaus of length ~\u03b5\u221aN between consecutive increases.",
-    "implications": "A positive answer would provide precise structural information about the distribution of maximum Sidon sets, showing that optimal Sidon subsets of [N] and [N+k] differ by at most one element for large N. This connects to the broader question of understanding the second-order term in F(N) = \u221aN + O(N^{1/4}), with implications for combinatorial number theory and the structure of B_2 sequences.",
+    "summary": "Erdős Problem #155 asks whether the maximum Sidon subset function F(N) grows so slowly that F(N+k) ≤ F(N)+1 for any fixed k and large N. Since F(N) ~ √N and increases by exactly 1 at each jump, the ~√N increase points should be far apart. The problem remains open, with a stronger variant suggesting plateaus of length ~ε√N between consecutive increases.",
+    "implications": "A positive answer would provide precise structural information about the distribution of maximum Sidon sets, showing that optimal Sidon subsets of [N] and [N+k] differ by at most one element for large N. This connects to the broader question of understanding the second-order term in F(N) = √N + O(N^{1/4}), with implications for combinatorial number theory and the structure of B_2 sequences.",
     "openQuestions": [
-      "Does F(N+k) \u2264 F(N)+1 hold for all fixed k and sufficiently large N?",
-      "Does the stronger form with k \u2248 \u03b5\u221aN hold? What is the largest growth rate k(N) for which F(N+k(N)) \u2264 F(N)+1?",
-      "What is the second-order term in F(N) = \u221aN + ??? Specifically, is F(N) = \u221aN + O(1) or F(N) = \u221aN + \u0398(N^{1/4})?",
-      "Are the increase points of F(N) approximately uniformly distributed at scale \u221aN, or do they cluster?",
+      "Does F(N+k) ≤ F(N)+1 hold for all fixed k and sufficiently large N?",
+      "Does the stronger form with k ≈ ε√N hold? What is the largest growth rate k(N) for which F(N+k(N)) ≤ F(N)+1?",
+      "What is the second-order term in F(N) = √N + ??? Specifically, is F(N) = √N + O(1) or F(N) = √N + Θ(N^{1/4})?",
+      "Are the increase points of F(N) approximately uniformly distributed at scale √N, or do they cluster?",
       "Can probabilistic methods (random Sidon sets) shed light on the gap structure of F?"
     ]
   },
@@ -137,15 +137,15 @@
     "lineCount": 199,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/Erdos155Problem.lean",
     "sorries": 0
   },
   "references": [
-    "Erd\u0151s\u2013Tur\u00e1n (1941): On a problem of Sidon in additive number theory",
+    "Erdős–Turán (1941): On a problem of Sidon in additive number theory",
     "Singer (1938): A theorem in finite projective geometry and some applications to number theory",
-    "Lindstr\u00f6m (1969): An inequality for B_2 sequences",
-    "Erd\u0151s (1992, 1994): Problem statements on slow growth of F(N)",
+    "Lindström (1969): An inequality for B_2 sequences",
+    "Erdős (1992, 1994): Problem statements on slow growth of F(N)",
     "Cilleruelo (2010): Sidon sets in N^d",
     "Ruzsa (1993): Solving a linear equation in a set of integers",
     "O'Bryant (2004): A complete annotated bibliography of work related to Sidon sets",
@@ -156,17 +156,17 @@
     {
       "targetId": "erdos-156",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     },
     {
       "targetId": "erdos-332",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, difference-sets, open"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, difference-sets, open"
     },
     {
       "targetId": "erdos-340",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, open, sidon-sets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, open, sidon-sets"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "erdos-156",
-  "title": "Erd\u0151s Problem #156: Minimum Size of Maximal Sidon Sets",
+  "title": "Erdős Problem #156: Minimum Size of Maximal Sidon Sets",
   "slug": "erdos-156",
-  "description": "Does there exist a maximal Sidon set A \u2282 {1,...,N} of size O(N^{1/3})?",
+  "description": "Does there exist a maximal Sidon set A ⊂ {1,...,N} of size O(N^{1/3})?",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "coauthors": [
-      "S\u00e1rk\u00f6zy",
-      "S\u00f3s"
+      "Sárközy",
+      "Sós"
     ],
     "sourceUrl": "https://erdosproblems.com/156",
     "status": "formalized",
@@ -60,8 +60,8 @@
       "Two equivalent formal definitions of Sidon sets with proved equivalence theorem",
       "Greedy Sidon construction with proof that it produces valid Sidon sets",
       "Maximal Sidon set predicate and interval-based formalization",
-      "Erd\u0151s-Tur\u00e1n upper bound and greedy lower bound stated as axioms",
-      "Ruzsa's N^{1/3+\u03b5} result formalized for arbitrary \u03b5 > 0",
+      "Erdős-Turán upper bound and greedy lower bound stated as axioms",
+      "Ruzsa's N^{1/3+ε} result formalized for arbitrary ε > 0",
       "Main conjecture as disjunction: O(N^{1/3}) or super-N^{1/3} lower bound",
       "Sumset formalization with cardinality formula for Sidon sets",
       "Growth exponent conjecture via Filter.Tendsto of log ratio",
@@ -73,13 +73,13 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Simon Sidon introduced what are now called Sidon sets (or $B_2$ sequences) in 1932 while studying lacunary Fourier series. A Sidon set is a set of integers where all pairwise sums $a + b$ (with $a \\leq b$) are distinct. Erd\u0151s and Tur\u00e1n proved in 1941 that any Sidon set $A \\subseteq \\{1, \\ldots, N\\}$ has size at most $\\sqrt{N} + O(N^{1/4})$, and constructions based on modular arithmetic (Singer difference sets, Erd\u0151s-Tur\u00e1n) achieve this bound up to lower-order terms. The greedy algorithm \u2014 include each element that preserves the Sidon property \u2014 produces sets of size $\\Theta(\\sqrt{N})$.\n\nThe study of *maximal* Sidon sets \u2014 those that cannot be extended within $\\{1, \\ldots, N\\}$ \u2014 reveals a subtler landscape. The greedy construction automatically produces maximal sets, but these are large (size $\\sim \\sqrt{N}$). Erd\u0151s, S\u00e1rk\u00f6zy, and S\u00f3s [ESS94] asked whether much smaller maximal Sidon sets exist, specifically of size $O(N^{1/3})$. Ruzsa [Ru98b] made a breakthrough by constructing maximal Sidon sets of size $O(N^{1/3+\\varepsilon})$ for any $\\varepsilon > 0$, using a clever recursive method that creates sufficient 'coverage' of sums while keeping the set sparse.\n\nThe gap between Ruzsa's $N^{1/3+\\varepsilon}$ and the conjectured $N^{1/3}$ remains open. The exponent $1/3$ is natural: a maximal Sidon set of size $s$ must 'cover' all $\\sim N$ elements (each absent element must have its sum represented), and each pair in the set covers $O(s)$ sums, requiring $s^2 \\cdot s \\sim N$ \u2014 i.e., $s \\sim N^{1/3}$. Whether logarithmic factors can be eliminated is the core question. OEIS A382397 tracks related sequences.",
+    "historicalContext": "Simon Sidon introduced what are now called Sidon sets (or $B_2$ sequences) in 1932 while studying lacunary Fourier series. A Sidon set is a set of integers where all pairwise sums $a + b$ (with $a \\leq b$) are distinct. Erdős and Turán proved in 1941 that any Sidon set $A \\subseteq \\{1, \\ldots, N\\}$ has size at most $\\sqrt{N} + O(N^{1/4})$, and constructions based on modular arithmetic (Singer difference sets, Erdős-Turán) achieve this bound up to lower-order terms. The greedy algorithm — include each element that preserves the Sidon property — produces sets of size $\\Theta(\\sqrt{N})$.\n\nThe study of *maximal* Sidon sets — those that cannot be extended within $\\{1, \\ldots, N\\}$ — reveals a subtler landscape. The greedy construction automatically produces maximal sets, but these are large (size $\\sim \\sqrt{N}$). Erdős, Sárközy, and Sós [ESS94] asked whether much smaller maximal Sidon sets exist, specifically of size $O(N^{1/3})$. Ruzsa [Ru98b] made a breakthrough by constructing maximal Sidon sets of size $O(N^{1/3+\\varepsilon})$ for any $\\varepsilon > 0$, using a clever recursive method that creates sufficient 'coverage' of sums while keeping the set sparse.\n\nThe gap between Ruzsa's $N^{1/3+\\varepsilon}$ and the conjectured $N^{1/3}$ remains open. The exponent $1/3$ is natural: a maximal Sidon set of size $s$ must 'cover' all $\\sim N$ elements (each absent element must have its sum represented), and each pair in the set covers $O(s)$ sums, requiring $s^2 \\cdot s \\sim N$ — i.e., $s \\sim N^{1/3}$. Whether logarithmic factors can be eliminated is the core question. OEIS A382397 tracks related sequences.",
     "problemStatement": "A Sidon set $A \\subseteq \\{1, \\ldots, N\\}$ is **maximal** if for every $x \\in \\{1, \\ldots, N\\} \\setminus A$, the set $A \\cup \\{x\\}$ is not a Sidon set (i.e., adding $x$ creates a repeated sum).\n\n**Question**: Does there exist a constant $C > 0$ and a family of maximal Sidon sets $\\{A_N\\}_{N \\geq 1}$ with $|A_N| \\leq C \\cdot N^{1/3}$ for all $N$?",
-    "text": "Does there exist a maximal Sidon set A \u2282 {1,...,N} of size O(N^{1/3})?",
-    "proofStrategy": "The formalization provides two equivalent definitions of Sidon sets \u2014 the standard version (`IsSidonSet`, requiring $a + b = c + d$ with $a \\leq b, c \\leq d$ to imply $\\{a,b\\} = \\{c,d\\}$) and a strict version (`IsSidonSetAlt`, requiring $a < b, c < d$ to imply $a = c, b = d$) \u2014 with a detailed equivalence proof. The greedy construction is defined recursively and proved to always yield Sidon sets. Maximality is defined via the `IsMaximalSidonSet` predicate combining subset-of-interval, Sidon property, and non-extendability. The Erd\u0151s-Tur\u00e1n upper bound ($\\leq \\sqrt{N} + C$) and greedy lower bound ($\\geq c\\sqrt{N}$) are axioms. Ruzsa's result is formalized as: for all $\\varepsilon > 0$, there exist maximal Sidon sets of size $\\leq N^{1/3 + \\varepsilon}$. The main conjecture is a disjunction \u2014 either $O(N^{1/3})$ is achievable or there is a growing lower bound.",
+    "text": "Does there exist a maximal Sidon set A ⊂ {1,...,N} of size O(N^{1/3})?",
+    "proofStrategy": "The formalization provides two equivalent definitions of Sidon sets — the standard version (`IsSidonSet`, requiring $a + b = c + d$ with $a \\leq b, c \\leq d$ to imply $\\{a,b\\} = \\{c,d\\}$) and a strict version (`IsSidonSetAlt`, requiring $a < b, c < d$ to imply $a = c, b = d$) — with a detailed equivalence proof. The greedy construction is defined recursively and proved to always yield Sidon sets. Maximality is defined via the `IsMaximalSidonSet` predicate combining subset-of-interval, Sidon property, and non-extendability. The Erdős-Turán upper bound ($\\leq \\sqrt{N} + C$) and greedy lower bound ($\\geq c\\sqrt{N}$) are axioms. Ruzsa's result is formalized as: for all $\\varepsilon > 0$, there exist maximal Sidon sets of size $\\leq N^{1/3 + \\varepsilon}$. The main conjecture is a disjunction — either $O(N^{1/3})$ is achievable or there is a growing lower bound.",
     "keyInsights": [
-      "**Sidon sets are maximally spread sumsets**: A Sidon set $A$ has $|A + A| = |A|(|A|+1)/2$ \u2014 the maximum possible for its cardinality. This is because all pairwise sums are distinct, making Sidon sets extremal objects in additive combinatorics",
-      "**The Erd\u0151s-Tur\u00e1n bound is tight**: The classical bound $|A| \\leq \\sqrt{N} + O(N^{1/4})$ for Sidon sets in $\\{1,\\ldots,N\\}$ is essentially sharp \u2014 constructions from finite geometry (Singer difference sets) achieve $|A| \\sim \\sqrt{N}$. The proof uses the pigeonhole principle: all $\\binom{|A|}{2} + |A|$ sums lie in $\\{2, \\ldots, 2N\\}$",
+      "**Sidon sets are maximally spread sumsets**: A Sidon set $A$ has $|A + A| = |A|(|A|+1)/2$ — the maximum possible for its cardinality. This is because all pairwise sums are distinct, making Sidon sets extremal objects in additive combinatorics",
+      "**The Erdős-Turán bound is tight**: The classical bound $|A| \\leq \\sqrt{N} + O(N^{1/4})$ for Sidon sets in $\\{1,\\ldots,N\\}$ is essentially sharp — constructions from finite geometry (Singer difference sets) achieve $|A| \\sim \\sqrt{N}$. The proof uses the pigeonhole principle: all $\\binom{|A|}{2} + |A|$ sums lie in $\\{2, \\ldots, 2N\\}$",
       "**Maximality forces coverage**: A maximal Sidon set must 'cover' every absent element: for each $x \\notin A$, there must exist $a, b \\in A$ with $a + b = x + c$ for some $c \\in A$ (or similar collision). This coverage requirement creates the tension between sparsity and maximality",
       "**The $N^{1/3}$ heuristic**: If $|A| = s$, the set covers roughly $s^2$ sums in $A + A$ and each sum 'blocks' $O(s)$ potential additions, giving coverage of $\\sim s^3$ elements. Requiring $s^3 \\sim N$ yields $s \\sim N^{1/3}$, explaining why this exponent is natural",
       "**Ruzsa's recursive construction**: Ruzsa's breakthrough builds maximal Sidon sets by starting with a Sidon set $S$ in a smaller interval and recursively extending it to fill gaps, ensuring maximality. The extra $\\varepsilon$ in the exponent comes from logarithmic factors in the recursive depth"
@@ -95,16 +95,16 @@
       "title": "Module Docstring",
       "startLine": 1,
       "endLine": 18,
-      "summary": "Problem statement, definition of Sidon sets and maximality, references to Erd\u0151s-S\u00e1rk\u00f6zy-S\u00f3s [ESS94] and Ruzsa [Ru98b].",
-      "mathContext": "Formal definition: Problem statement, definition of Sidon sets and maximality, references to Erd\u0151s-S\u00e1rk\u00f6zy-S\u00f3s [ESS94] and Ruzsa [Ru98b]."
+      "summary": "Problem statement, definition of Sidon sets and maximality, references to Erdős-Sárközy-Sós [ESS94] and Ruzsa [Ru98b].",
+      "mathContext": "Formal definition: Problem statement, definition of Sidon sets and maximality, references to Erdős-Sárközy-Sós [ESS94] and Ruzsa [Ru98b]."
     },
     {
       "id": "sidon-definitions",
       "title": "Sidon Set Definitions",
       "startLine": 19,
       "endLine": 81,
-      "summary": "Two definitions of Sidon sets (IsSidonSet with \u2264, IsSidonSetAlt with <) and a detailed equivalence proof via case analysis on orderings. The proof handles all four combinations of a \u2264 b vs a > b and c \u2264 d vs c > d.",
-      "mathContext": "Two definitions of Sidon sets (IsSidonSet with \u2264, IsSidonSetAlt with <) and a detailed equivalence proof via case analysis on orderings. The proof handles all four combinations of a \u2264 b vs a > b and c \u2264 d vs c > d."
+      "summary": "Two definitions of Sidon sets (IsSidonSet with ≤, IsSidonSetAlt with <) and a detailed equivalence proof via case analysis on orderings. The proof handles all four combinations of a ≤ b vs a > b and c ≤ d vs c > d.",
+      "mathContext": "Two definitions of Sidon sets (IsSidonSet with ≤, IsSidonSetAlt with <) and a detailed equivalence proof via case analysis on orderings. The proof handles all four combinations of a ≤ b vs a > b and c ≤ d vs c > d."
     },
     {
       "id": "maximal-sidon",
@@ -127,32 +127,32 @@
       "title": "Classical Bounds",
       "startLine": 132,
       "endLine": 148,
-      "summary": "Two axioms: sidon_upper_bound (|A| \u2264 \u221aN + C for Sidon A \u2286 {1,...,N}) and greedy_lower_bound (|greedy(N)| \u2265 c\u221aN). These establish that greedy Sidon sets have size \u0398(\u221aN).",
-      "mathContext": "Two axioms: sidon_upper_bound (|A| $\\leq$ \u221aN + C for Sidon A \u2286 {1,...,N}) and greedy_lower_bound (|greedy(N)| $\\geq$ c$\\sqrt{N}$). These establish that greedy Sidon sets have size \u0398(\u221aN)."
+      "summary": "Two axioms: sidon_upper_bound (|A| ≤ √N + C for Sidon A ⊆ {1,...,N}) and greedy_lower_bound (|greedy(N)| ≥ c√N). These establish that greedy Sidon sets have size Θ(√N).",
+      "mathContext": "Two axioms: sidon_upper_bound (|A| $\\leq$ √N + C for Sidon A ⊆ {1,...,N}) and greedy_lower_bound (|greedy(N)| $\\geq$ c$\\sqrt{N}$). These establish that greedy Sidon sets have size Θ(√N)."
     },
     {
       "id": "ruzsa-construction",
       "title": "Ruzsa's Small Maximal Sidon Sets",
       "startLine": 149,
       "endLine": 161,
-      "summary": "Axiom ruzsa_small_maximal: for any \u03b5 > 0, there exist maximal Sidon sets of size \u2264 N^{1/3+\u03b5}. This is the key breakthrough result that motivates the conjecture.",
-      "mathContext": "Axiom ruzsa_small_maximal: for any \u03b5 > 0, there exist maximal Sidon sets of size $\\leq$ N^{1/3+\u03b5}. This is the key breakthrough result that motivates the conjecture."
+      "summary": "Axiom ruzsa_small_maximal: for any ε > 0, there exist maximal Sidon sets of size ≤ N^{1/3+ε}. This is the key breakthrough result that motivates the conjecture.",
+      "mathContext": "Axiom ruzsa_small_maximal: for any ε > 0, there exist maximal Sidon sets of size $\\leq$ N^{1/3+ε}. This is the key breakthrough result that motivates the conjecture."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
       "startLine": 162,
       "endLine": 183,
-      "summary": "The central axiom erdos_156_conjecture: either \u2203 C > 0 with maximal Sidon sets of size \u2264 C\u00b7N^{1/3} for all N, or \u2200 C > 0 the bound C\u00b7N^{1/3} is eventually exceeded.",
-      "mathContext": "The central axiom erdos_156_conjecture: either \u2203 C > 0 with maximal Sidon sets of size $\\leq$ C\u00b7N^{1/3} for all N, or \u2200 C > 0 the bound C\u00b7N^{1/3} is eventually exceeded."
+      "summary": "The central axiom erdos_156_conjecture: either ∃ C > 0 with maximal Sidon sets of size ≤ C·N^{1/3} for all N, or ∀ C > 0 the bound C·N^{1/3} is eventually exceeded.",
+      "mathContext": "The central axiom erdos_156_conjecture: either ∃ C > 0 with maximal Sidon sets of size $\\leq$ C·N^{1/3} for all N, or ∀ C > 0 the bound C·N^{1/3} is eventually exceeded."
     },
     {
       "id": "gap-and-minimum",
       "title": "Gap Analysis and Minimum Size",
       "startLine": 184,
       "endLine": 203,
-      "summary": "Defines minMaximalSidonSize via Nat.find and states the growth exponent conjecture: \u2203 \u03b1 \u2208 [1/3, 1/2] such that log(minMaximalSidonSize N)/log N \u2192 \u03b1.",
-      "mathContext": "Defines minMaximalSidonSize via Nat.find and states the growth exponent conjecture: \u2203 \u03b1 \u2208 [1/3, 1/2] such that log(minMaximalSidonSize N)/log N $\\to$ \u03b1."
+      "summary": "Defines minMaximalSidonSize via Nat.find and states the growth exponent conjecture: ∃ α ∈ [1/3, 1/2] such that log(minMaximalSidonSize N)/log N → α.",
+      "mathContext": "Defines minMaximalSidonSize via Nat.find and states the growth exponent conjecture: ∃ α ∈ [1/3, 1/2] such that log(minMaximalSidonSize N)/log N $\\to$ α."
     },
     {
       "id": "additive-combinatorics",
@@ -172,14 +172,14 @@
     }
   ],
   "conclusion": {
-    "summary": "This 261-line formalization of Erd\u0151s Problem #156 defines Sidon sets with two equivalent characterizations (proved equivalent via detailed case analysis), constructs greedy Sidon sets with an inductive Sidon-ness proof, and states the main conjecture about minimal maximal Sidon sets. Classical bounds (Erd\u0151s-Tur\u00e1n, greedy), Ruzsa's N^{1/3+\u03b5} breakthrough, and two equivalent formulations of the open problem (via constants and via infimum) provide a complete formal framework. Three sorries remain in structural proofs.",
+    "summary": "This 261-line formalization of Erdős Problem #156 defines Sidon sets with two equivalent characterizations (proved equivalent via detailed case analysis), constructs greedy Sidon sets with an inductive Sidon-ness proof, and states the main conjecture about minimal maximal Sidon sets. Classical bounds (Erdős-Turán, greedy), Ruzsa's N^{1/3+ε} breakthrough, and two equivalent formulations of the open problem (via constants and via infimum) provide a complete formal framework. Three sorries remain in structural proofs.",
     "implications": "**Theoretical Significance**: Resolution would determine the exact sparsity threshold for Sidon-type coverage: how few elements suffice to 'block' all possible extensions in {1,...,N}.\n\nAn affirmative answer (O(N^{1/3}) achievable) would require new constructions beyond Ruzsa's recursive method, potentially using algebraic or probabilistic techniques. A negative answer would establish a fundamental barrier separating the combinatorial notion of maximality from pure counting arguments.",
     "openQuestions": [
-      "Does the growth exponent \u03b1 = lim log(minMaximalSidonSize N)/log N exist, and if so, is it exactly 1/3?",
-      "Can Ruzsa's construction be derandomized or simplified to remove the \u03b5 in the exponent?",
+      "Does the growth exponent α = lim log(minMaximalSidonSize N)/log N exist, and if so, is it exactly 1/3?",
+      "Can Ruzsa's construction be derandomized or simplified to remove the ε in the exponent?",
       "What is the typical size of a random maximal Sidon set in {1,...,N}?",
-      "How does the problem generalize to B_h sequences for h > 2 \u2014 what is the minimal maximal B_h set size?",
-      "Is there a polynomial-time algorithm to find a maximal Sidon set of size O(N^{1/3+\u03b5}) in {1,...,N}?"
+      "How does the problem generalize to B_h sequences for h > 2 — what is the minimal maximal B_h set size?",
+      "Is there a polynomial-time algorithm to find a maximal Sidon set of size O(N^{1/3+ε}) in {1,...,N}?"
     ]
   },
   "leanFile": {
@@ -191,14 +191,14 @@
     "lineCount": 652,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/Erdos156Problem.lean",
     "sorries": 3
   },
   "references": [
     {
       "key": "ESS94",
-      "citation": "P. Erd\u0151s, A. S\u00e1rk\u00f6zy, V. T. S\u00f3s, 'On sum sets of Sidon sets', Journal of Number Theory (1994)"
+      "citation": "P. Erdős, A. Sárközy, V. T. Sós, 'On sum sets of Sidon sets', Journal of Number Theory (1994)"
     },
     {
       "key": "Ru98b",
@@ -213,17 +213,17 @@
     {
       "targetId": "erdos-155",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     },
     {
       "targetId": "erdos-757",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     },
     {
       "targetId": "erdos-789",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     }
   ],
   "sorries": 3

--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -135,7 +135,7 @@
     "lineCount": 256,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos160Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -187,7 +187,7 @@
     "lineCount": 580,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos183Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-184/meta.json
+++ b/src/data/proofs/erdos-184/meta.json
@@ -175,7 +175,7 @@
     "lineCount": 242,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos184Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -207,7 +207,7 @@
     "lineCount": 1104,
     "axiomCount": 2,
     "theoremCount": 73,
-    "definitionCount": 29,
+    "definitionCount": 30,
     "path": "Proofs/Erdos185Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-189/meta.json
+++ b/src/data/proofs/erdos-189/meta.json
@@ -117,7 +117,7 @@
     "lineCount": 145,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos189Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -162,7 +162,7 @@
     "lineCount": 403,
     "axiomCount": 1,
     "theoremCount": 19,
-    "definitionCount": 7,
+    "definitionCount": 10,
     "path": "Proofs/Erdos193Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -138,7 +138,7 @@
     "lineCount": 155,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos196Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -192,7 +192,7 @@
     "lineCount": 329,
     "axiomCount": 4,
     "theoremCount": 9,
-    "definitionCount": 12,
+    "definitionCount": 16,
     "path": "Proofs/Erdos27Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-30/meta.json
+++ b/src/data/proofs/erdos-30/meta.json
@@ -175,7 +175,9 @@
     "namespace": "Erdos30",
     "lineCount": 194,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 8,
+    "theoremCount": 4
   },
   "references": [
     {

--- a/src/data/proofs/erdos-31/meta.json
+++ b/src/data/proofs/erdos-31/meta.json
@@ -158,7 +158,7 @@
     "lineCount": 786,
     "axiomCount": 1,
     "theoremCount": 22,
-    "definitionCount": 14,
+    "definitionCount": 12,
     "path": "Proofs/Erdos31Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -142,7 +142,7 @@
     "namespace": "Erdos35",
     "lineCount": 373,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 10,
     "definitionCount": 9,
     "path": "Proofs/Erdos35Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -308,7 +308,8 @@
     ],
     "namespace": "Erdos4",
     "path": "Proofs/Erdos4Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "definitionCount": 16
   },
   "references": [
     {

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -195,7 +195,7 @@
     "lineCount": 291,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "mainTheorems": [
       {
         "name": "repUnbounded_iff",

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -182,7 +182,8 @@
     "namespace": null,
     "lineCount": 79,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-51/meta.json
+++ b/src/data/proofs/erdos-51/meta.json
@@ -137,7 +137,9 @@
     "namespace": null,
     "lineCount": 69,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4,
+    "theoremCount": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-59/meta.json
+++ b/src/data/proofs/erdos-59/meta.json
@@ -173,7 +173,7 @@
     "lineCount": 337,
     "axiomCount": 5,
     "theoremCount": 7,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos59Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-65/meta.json
+++ b/src/data/proofs/erdos-65/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-65",
-  "title": "Erd\u0151s Problem #65: Cycle Lengths in Dense Graphs",
+  "title": "Erdős Problem #65: Cycle Lengths in Dense Graphs",
   "slug": "erdos-65",
-  "description": "Let G be a graph with n vertices and kn edges. Is the sum of reciprocals of cycle lengths \u03a3 1/a\u1d62 \u226b log k? Is this sum minimized when G is complete bipartite?",
+  "description": "Let G be a graph with n vertices and kn edges. Is the sum of reciprocals of cycle lengths Σ 1/aᵢ ≫ log k? Is this sum minimized when G is complete bipartite?",
   "meta": {
-    "author": "Erd\u0151s & Hajnal",
+    "author": "Erdős & Hajnal",
     "sourceUrl": "https://erdosproblems.com/65",
     "date": "",
     "status": "verified",
@@ -26,10 +26,10 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Posed by Erd\u0151s and Hajnal, this problem connects edge density to cycle structure in extremal graph theory. The first part was proved by Gy\u00e1rf\u00e1s, Koml\u00f3s, and Szemer\u00e9di in their 1984 paper 'On a problem of K. Zarankiewicz,' establishing that \u03a3 1/a\u1d62 grows at least logarithmically with edge density. Liu and Montgomery (2020) proved the sharp constant is (1/2 - o(1)), resolving the quantitative question completely. The second part \u2014 whether complete bipartite graphs minimize the cycle variety \u2014 remains open and connects to deep questions about the interaction between graph symmetry and cycle structure.",
-    "problemStatement": "Let G be a graph with n vertices and kn edges, and let a\u2081 < a\u2082 < ... be the distinct cycle lengths in G. Is \u03a3 1/a\u1d62 \u226b log k? Is this sum minimized when G is a complete bipartite graph?",
-    "text": "Let G be a graph with n vertices and kn edges. Is the sum of reciprocals of cycle lengths \u03a3 1/a\u1d62 \u226b log k? Is this sum minimized when G is complete bipartite?",
-    "proofStrategy": "The formalization defines cycle detection predicates, edge density, and the reciprocal sum. The GKS theorem is stated as an axiom. The open minimization question is formalized as Erdos65Question. Related results include the K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem.",
+    "historicalContext": "Posed by Erdős and Hajnal, this problem connects edge density to cycle structure in extremal graph theory. The first part was proved by Gyárfás, Komlós, and Szemerédi in their 1984 paper 'On a problem of K. Zarankiewicz,' establishing that Σ 1/aᵢ grows at least logarithmically with edge density. Liu and Montgomery (2020) proved the sharp constant is (1/2 - o(1)), resolving the quantitative question completely. The second part — whether complete bipartite graphs minimize the cycle variety — remains open and connects to deep questions about the interaction between graph symmetry and cycle structure.",
+    "problemStatement": "Let G be a graph with n vertices and kn edges, and let a₁ < a₂ < ... be the distinct cycle lengths in G. Is Σ 1/aᵢ ≫ log k? Is this sum minimized when G is a complete bipartite graph?",
+    "text": "Let G be a graph with n vertices and kn edges. Is the sum of reciprocals of cycle lengths Σ 1/aᵢ ≫ log k? Is this sum minimized when G is complete bipartite?",
+    "proofStrategy": "The formalization defines cycle detection predicates, edge density, and the reciprocal sum. The GKS theorem is stated as an axiom. The open minimization question is formalized as Erdos65Question. Related results include the Kővári-Sós-Turán theorem.",
     "keyInsights": [
       "Dense graphs must have diverse cycle lengths - proved by GKS (1984)",
       "Complete bipartite graphs have only even cycles {4, 6, 8, ...}",
@@ -46,10 +46,10 @@
     {
       "id": "header",
       "title": "Problem Statement",
-      "summary": "Erd\u0151s-Hajnal problem: edge density vs cycle length variety, GKS theorem, minimization question",
+      "summary": "Erdős-Hajnal problem: edge density vs cycle length variety, GKS theorem, minimization question",
       "startLine": 1,
       "endLine": 23,
-      "mathContext": "Verified: Erd\u0151s-Hajnal problem: edge density vs cycle length variety, GKS theorem, minimization question"
+      "mathContext": "Verified: Erdős-Hajnal problem: edge density vs cycle length variety, GKS theorem, minimization question"
     },
     {
       "id": "core-definitions",
@@ -70,10 +70,10 @@
     {
       "id": "gks-theorem",
       "title": "GKS Theorem (1984)",
-      "summary": "Gy\u00e1rf\u00e1s-Koml\u00f3s-Szemer\u00e9di: \u03a3 1/a\u1d62 \u2265 c\u00b7log(e/n) for graphs with e edges on n vertices",
+      "summary": "Gyárfás-Komlós-Szemerédi: Σ 1/aᵢ ≥ c·log(e/n) for graphs with e edges on n vertices",
       "startLine": 87,
       "endLine": 108,
-      "mathContext": "Gy\u00e1rf\u00e1s-Koml\u00f3s-Szemer\u00e9di: $\\sum$ 1/a\u1d62 $\\geq$ c\u00b7log(e/n) for graphs with e edges on n vertices"
+      "mathContext": "Gyárfás-Komlós-Szemerédi: $\\sum$ 1/aᵢ $\\geq$ c·log(e/n) for graphs with e edges on n vertices"
     },
     {
       "id": "open-question",
@@ -109,11 +109,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #65 is PARTIALLY SOLVED. The logarithmic lower bound \u03a3 1/a\u1d62 \u226b log k was proved by Gy\u00e1rf\u00e1s-Koml\u00f3s-Szemer\u00e9di (1984), with sharp constant by Liu-Montgomery (2020). The minimization question remains open.",
-    "implications": "The logarithmic lower bound $\\sum 1/a_i \\gg \\log k$ reveals a structural principle: dense graphs contain not just many cycles, but cycles of many different lengths, with the reciprocal-length sum growing logarithmically with edge density. The sharp constant by Liu-Montgomery (2020) quantifies this bridge between Tur\u00e1n-type density ($kn$ edges) and the cycle spectrum. The complete bipartite minimization conjecture, if resolved, would identify the extremal structure \u2014 analogous to how Tur\u00e1n's theorem identifies the $K_{r+1}$-free extremal graph. This connects to the broader program in extremal graph theory of understanding how local substructure (cycle lengths) is constrained by global density.",
+    "summary": "Erdős Problem #65 is PARTIALLY SOLVED. The logarithmic lower bound Σ 1/aᵢ ≫ log k was proved by Gyárfás-Komlós-Szemerédi (1984), with sharp constant by Liu-Montgomery (2020). The minimization question remains open.",
+    "implications": "The logarithmic lower bound $\\sum 1/a_i \\gg \\log k$ reveals a structural principle: dense graphs contain not just many cycles, but cycles of many different lengths, with the reciprocal-length sum growing logarithmically with edge density. The sharp constant by Liu-Montgomery (2020) quantifies this bridge between Turán-type density ($kn$ edges) and the cycle spectrum. The complete bipartite minimization conjecture, if resolved, would identify the extremal structure — analogous to how Turán's theorem identifies the $K_{r+1}$-free extremal graph. This connects to the broader program in extremal graph theory of understanding how local substructure (cycle lengths) is constrained by global density.",
     "openQuestions": [
       "Is the reciprocal sum minimized by complete bipartite graphs among all graphs with the same edge count?",
-      "What is the analogous result for odd cycle lengths only \u2014 does parity restriction change the extremal structure?",
+      "What is the analogous result for odd cycle lengths only — does parity restriction change the extremal structure?",
       "Can the Liu-Montgomery sharp constant be formalized in Lean using Mathlib's graph theory infrastructure?"
     ]
   },
@@ -139,7 +139,7 @@
       "relationship": "related"
     },
     {
-      "relevance": "The Szemer\u00e9di Regularity Lemma is a key tool in proving cycle-structure results for dense graphs, including the GKS theorem approach.",
+      "relevance": "The Szemerédi Regularity Lemma is a key tool in proving cycle-structure results for dense graphs, including the GKS theorem approach.",
       "targetId": "szemeredi-regularity",
       "relationship": "related"
     },
@@ -152,56 +152,56 @@
   "references": [
     {
       "authors": [
-        "A. Gy\u00e1rf\u00e1s",
-        "J. Koml\u00f3s",
-        "E. Szemer\u00e9di"
+        "A. Gyárfás",
+        "J. Komlós",
+        "E. Szemerédi"
       ],
       "title": "On a problem of K. Zarankiewicz",
       "venue": "Acta Mathematica Hungarica",
       "year": "1984",
       "volume": "44",
-      "pages": "283\u2013293",
-      "note": "Proves \u03a3 1/a\u1d62 \u2265 c\u00b7log(e/n) for graphs with e edges; the GKS theorem axiomatized in this formalization."
+      "pages": "283–293",
+      "note": "Proves Σ 1/aᵢ ≥ c·log(e/n) for graphs with e edges; the GKS theorem axiomatized in this formalization."
     },
     {
       "authors": [
         "H. Liu",
         "R. Montgomery"
       ],
-      "title": "A solution to Erd\u0151s and Hajnal's odd cycle problem",
+      "title": "A solution to Erdős and Hajnal's odd cycle problem",
       "venue": "Journal of the American Mathematical Society",
       "year": "2023",
       "volume": "36",
-      "pages": "1191\u20131234",
-      "note": "Proves the sharp constant (1/2 \u2212 o(1)) log k for the reciprocal sum, fully resolving the quantitative part of Problem 65."
+      "pages": "1191–1234",
+      "note": "Proves the sharp constant (1/2 − o(1)) log k for the reciprocal sum, fully resolving the quantitative part of Problem 65."
     },
     {
       "authors": [
-        "P. Erd\u0151s",
+        "P. Erdős",
         "A. Hajnal"
       ],
       "title": "On the structure of graphs without cycles of given lengths",
-      "venue": "Colloquium Mathematicum Societatis J\u00e1nos Bolyai",
+      "venue": "Colloquium Mathematicum Societatis János Bolyai",
       "year": "1966",
-      "note": "Original problem statement by Erd\u0151s and Hajnal posing both the logarithmic lower bound and the minimization question."
+      "note": "Original problem statement by Erdős and Hajnal posing both the logarithmic lower bound and the minimization question."
     },
     {
       "authors": [
-        "B. Bollob\u00e1s"
+        "B. Bollobás"
       ],
       "title": "Extremal Graph Theory",
       "venue": "Academic Press",
       "year": "1978",
-      "note": "Standard reference for extremal graph theory including K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem and Zarankiewicz problem techniques used in this formalization."
+      "note": "Standard reference for extremal graph theory including Kővári-Sós-Turán theorem and Zarankiewicz problem techniques used in this formalization."
     },
     {
       "authors": [
-        "E. Szemer\u00e9di"
+        "E. Szemerédi"
       ],
       "title": "Regular Partitions of Graphs",
-      "venue": "Probl\u00e8mes Combinatoires et Th\u00e9orie des Graphes (Colloq. Internat. CNRS)",
+      "venue": "Problèmes Combinatoires et Théorie des Graphes (Colloq. Internat. CNRS)",
       "year": "1978",
-      "pages": "399\u2013401",
+      "pages": "399–401",
       "note": "The Regularity Lemma, a key structural tool underlying density-based cycle arguments in extremal graph theory."
     }
   ],
@@ -217,7 +217,9 @@
     "namespace": "Erdos65",
     "lineCount": 217,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 9,
+    "theoremCount": 1
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-73/meta.json
+++ b/src/data/proofs/erdos-73/meta.json
@@ -201,7 +201,7 @@
     "namespace": "Erdos73",
     "lineCount": 314,
     "axiomCount": 3,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 10,
     "path": "Proofs/Erdos73Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -113,7 +113,7 @@
     "lineCount": 214,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 10,
+    "definitionCount": 7,
     "path": "Proofs/Erdos75Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-88/meta.json
+++ b/src/data/proofs/erdos-88/meta.json
@@ -169,7 +169,7 @@
     "lineCount": 257,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 21,
+    "definitionCount": 22,
     "path": "Proofs/Erdos88Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-91/meta.json
+++ b/src/data/proofs/erdos-91/meta.json
@@ -121,7 +121,7 @@
     "lineCount": 276,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos91Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-93/meta.json
+++ b/src/data/proofs/erdos-93/meta.json
@@ -149,7 +149,7 @@
     "lineCount": 146,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos93Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -175,7 +175,7 @@
     "lineCount": 152,
     "axiomCount": 8,
     "theoremCount": 0,
-    "definitionCount": 9,
+    "definitionCount": 11,
     "path": "Proofs/Erdos94Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-95/meta.json
+++ b/src/data/proofs/erdos-95/meta.json
@@ -164,7 +164,7 @@
     "lineCount": 184,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos95Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -152,7 +152,7 @@
     "lineCount": 285,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos96Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-97/meta.json
+++ b/src/data/proofs/erdos-97/meta.json
@@ -138,7 +138,7 @@
     "lineCount": 163,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos97Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
Corrects leanFile counts for 41 proofs in the erdos-1 to erdos-196 range. Adds missing null/zero counts for 10 proofs with unpopulated leanFile counts. Metadata-only, no Lean source changes. Automated fix by lean-mechanic agent.