### PR TITLE
fix(meta): sync leanFile.definitionCount/theoremCount for 62 proofs (batch 15)

### DIFF
--- a/src/data/proofs/erdos-455/meta.json
+++ b/src/data/proofs/erdos-455/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-455",
-  "title": "Erd\u0151s Problem #455: Monotone Prime Gap Sequences",
+  "title": "Erdős Problem #455: Monotone Prime Gap Sequences",
   "slug": "erdos-455",
-  "description": "If primes q\u2081 < q\u2082 < ... have non-decreasing gaps, must q_n grow faster than n\u00b2?",
+  "description": "If primes q₁ < q₂ < ... have non-decreasing gaps, must q_n grow faster than n²?",
   "leanFile": {
     "path": "Proofs/Erdos455Problem.lean",
     "imports": [
@@ -19,7 +19,9 @@
     "namespace": "Erdos455",
     "lineCount": 142,
     "axiomCount": 1,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
   },
   "meta": {
     "author": "Richter (1976, partial); Open",
@@ -80,13 +82,13 @@
     "assumptions": "1 axiom: erdos_455_conjecture (the open conjecture stated as an abstract Prop)."
   },
   "overview": {
-    "historicalContext": "**Erd\u0151s Problem #455: Monotone Prime Gap Sequences**\n\nThis problem concerns sequences of primes where consecutive gaps never decrease \u2014 a discrete convexity condition. Such sequences must spread out increasingly, but the question is: how fast?\n\n**Historical Development:**\n- **Erd\u0151s** posed the problem: if $q_1 < q_2 < \\cdots$ are primes with $q_{n+1} - q_n \\geq q_n - q_{n-1}$, must $\\lim q_n/n^2 = \\infty$?\n- **Bernd Richter (1976)**, in *\u00dcber die Monotonie von Differenzenfolgen* (Acta Arithmetica), proved the partial result $\\liminf q_n/n^2 > 0.352$, establishing at least quadratic growth.\n- The full conjecture \u2014 superquadratic growth \u2014 remains open.\n\n**Context:** The sequence of all consecutive primes $(2, 3, 5, 7, 11, 13, \\ldots)$ does NOT satisfy the monotone-gap condition, since the gaps $1, 2, 2, 4, 2, \\ldots$ are not non-decreasing. Monotone-gap prime sequences must be carefully chosen subsequences. The problem connects to the Prime Number Theorem (which gives average gap $\\sim \\log n$) and to Cram\u00e9r's conjecture on maximal gaps.",
+    "historicalContext": "**Erdős Problem #455: Monotone Prime Gap Sequences**\n\nThis problem concerns sequences of primes where consecutive gaps never decrease — a discrete convexity condition. Such sequences must spread out increasingly, but the question is: how fast?\n\n**Historical Development:**\n- **Erdős** posed the problem: if $q_1 < q_2 < \\cdots$ are primes with $q_{n+1} - q_n \\geq q_n - q_{n-1}$, must $\\lim q_n/n^2 = \\infty$?\n- **Bernd Richter (1976)**, in *Über die Monotonie von Differenzenfolgen* (Acta Arithmetica), proved the partial result $\\liminf q_n/n^2 > 0.352$, establishing at least quadratic growth.\n- The full conjecture — superquadratic growth — remains open.\n\n**Context:** The sequence of all consecutive primes $(2, 3, 5, 7, 11, 13, \\ldots)$ does NOT satisfy the monotone-gap condition, since the gaps $1, 2, 2, 4, 2, \\ldots$ are not non-decreasing. Monotone-gap prime sequences must be carefully chosen subsequences. The problem connects to the Prime Number Theorem (which gives average gap $\\sim \\log n$) and to Cramér's conjecture on maximal gaps.",
     "problemStatement": "Let $q_1 < q_2 < \\cdots$ be a sequence of primes with non-decreasing gaps:\n$$q_{n+1} - q_n \\geq q_n - q_{n-1}$$\n\n**Open Question**: Must $\\lim_{n \\to \\infty} \\frac{q_n}{n^2} = \\infty$?\n\n**Partial Result (Richter 1976)**: $\\liminf_{n \\to \\infty} \\frac{q_n}{n^2} > 0.352$",
-    "text": "If primes q\u2081 < q\u2082 < ... have non-decreasing gaps, must q_n grow faster than n\u00b2?",
+    "text": "If primes q₁ < q₂ < ... have non-decreasing gaps, must q_n grow faster than n²?",
     "proofStrategy": "We formalize the problem using a structure `MonotoneGapPrimeSeq` that bundles strict monotonicity, primality, and non-decreasing gaps.\n\n1. **HasNonDecreasingGaps**: Predicate $\\forall n,\\, q(n+1) - q(n) \\geq q(n) - q(n-1)$\n2. **MonotoneGapPrimeSeq**: Structure combining `StrictMono`, `allPrime`, and `nonDecGaps`\n3. **Richter's bound**: Axiomatized as $\\liminf q_n/n^2 > 0.352$ (proof requires PNT)\n4. **Open conjecture**: Stated as a `Prop` with equivalence to $\\mathrm{Tendsto}(q_n/n^2, \\mathrm{atTop}, \\mathrm{atTop})$\n5. **Structural properties**: `gaps_pos`, `all_ge_two`, and `nonDecGaps_alt` proved from Mathlib",
     "keyInsights": [
       "**Non-decreasing gaps force discrete convexity**: The condition $q_{n+1} - q_n \\geq q_n - q_{n-1}$ means the sequence lies above its secant lines, a discrete analogue of convexity. This forces gaps to grow at least linearly, hence terms at least quadratically.",
-      "**Consecutive primes fail the condition**: The sequence $(2, 3, 5, 7, 11, 13, \\ldots)$ has gaps $1, 2, 2, 4, 2, \\ldots$ \u2014 the drop from $4$ to $2$ violates monotonicity. Only carefully chosen prime subsequences qualify.",
+      "**Consecutive primes fail the condition**: The sequence $(2, 3, 5, 7, 11, 13, \\ldots)$ has gaps $1, 2, 2, 4, 2, \\ldots$ — the drop from $4$ to $2$ violates monotonicity. Only carefully chosen prime subsequences qualify.",
       "**Richter's bound $\\liminf q_n/n^2 > 0.352$**: Proved in 1976 using prime distribution estimates. This establishes quadratic growth as a lower bound but falls short of the superquadratic conjecture.",
       "**The conjecture asks for strictly superquadratic growth**: Not just $q_n \\geq cn^2$ but $q_n/n^2 \\to \\infty$. A simple asymptotic like $q_n \\sim cn^2$ would refute the conjecture.",
       "**Connection to the Prime Number Theorem**: The PNT gives average prime gap $\\sim \\log p$, so the $n$-th prime is $\\sim n \\log n$. A monotone-gap subsequence must grow much faster than the typical prime."
@@ -123,7 +125,7 @@
       "title": "The Open Conjecture",
       "startLine": 71,
       "endLine": 88,
-      "summary": "States Erd\u0151s's full conjecture as an abstract `Prop` and proves equivalence: the conjecture holds iff $\\mathrm{Tendsto}(q_n/n^2, \\mathrm{atTop}, \\mathrm{atTop})$ for all monotone-gap prime sequences."
+      "summary": "States Erdős's full conjecture as an abstract `Prop` and proves equivalence: the conjecture holds iff $\\mathrm{Tendsto}(q_n/n^2, \\mathrm{atTop}, \\mathrm{atTop})$ for all monotone-gap prime sequences."
     },
     {
       "id": "consequences",
@@ -165,11 +167,11 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the open Erd\u0151s Problem #455 about prime sequences with monotonically non-decreasing gaps. Richter's 1976 result shows such sequences must grow at least quadratically ($\\liminf q_n/n^2 > 0.352$), but the question of whether they must grow strictly faster than $n^2$ remains open after nearly 50 years.",
+    "summary": "This formalization captures the open Erdős Problem #455 about prime sequences with monotonically non-decreasing gaps. Richter's 1976 result shows such sequences must grow at least quadratically ($\\liminf q_n/n^2 > 0.352$), but the question of whether they must grow strictly faster than $n^2$ remains open after nearly 50 years.",
     "implications": "**Theoretical Significance**: The problem connects prime distribution theory with discrete convexity.\n\nA resolution would shed light on how the distribution of primes constrains specially structured subsequences. The monotone-gap condition is a discrete analogue of convexity, and understanding its consequences for prime subsequences touches on deep questions about the regularity of the prime sequence.",
     "openQuestions": [
       "Must $\\lim q_n/n^2 = \\infty$ for all monotone-gap prime sequences, or does some sequence have $q_n = O(n^2)$?",
-      "What is the exact value of Richter's liminf constant \u2014 is $0.352$ optimal or can it be improved?",
+      "What is the exact value of Richter's liminf constant — is $0.352$ optimal or can it be improved?",
       "How many distinct monotone-gap prime sequences exist beginning with a given prime?",
       "Can the problem be generalized to other arithmetic conditions on gaps (e.g., gaps forming an arithmetic progression)?"
     ]

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -201,7 +201,7 @@
     "lineCount": 271,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 8,
+    "definitionCount": 6,
     "path": "Proofs/Erdos456Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-458/meta.json
+++ b/src/data/proofs/erdos-458/meta.json
@@ -108,7 +108,9 @@
     "namespace": "Erdos458",
     "lineCount": 156,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4,
+    "theoremCount": 12
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -71,8 +71,8 @@
     "namespace": null,
     "lineCount": 274,
     "axiomCount": 1,
-    "theoremCount": 9,
-    "definitionCount": 8,
+    "theoremCount": 10,
+    "definitionCount": 9,
     "path": "Proofs/Erdos460Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -106,7 +106,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos469Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 10
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -204,7 +204,7 @@
     "lineCount": 343,
     "axiomCount": 5,
     "theoremCount": 19,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/Erdos483Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-497/meta.json
+++ b/src/data/proofs/erdos-497/meta.json
@@ -134,7 +134,8 @@
     "namespace": null,
     "lineCount": 51,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -18,7 +18,7 @@
     "lineCount": 217,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos504Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -123,7 +123,7 @@
     "lineCount": 97,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos506Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-520/meta.json
+++ b/src/data/proofs/erdos-520/meta.json
@@ -146,7 +146,8 @@
     "namespace": "Erdos520",
     "lineCount": 137,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -146,7 +146,7 @@
     "lineCount": 317,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos524Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-528/meta.json
+++ b/src/data/proofs/erdos-528/meta.json
@@ -192,7 +192,7 @@
     "lineCount": 200,
     "axiomCount": 7,
     "theoremCount": 3,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos528Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -146,7 +146,7 @@
     "lineCount": 371,
     "axiomCount": 3,
     "theoremCount": 27,
-    "definitionCount": 5,
+    "definitionCount": 9,
     "path": "Proofs/Erdos533Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-539/meta.json
+++ b/src/data/proofs/erdos-539/meta.json
@@ -181,7 +181,9 @@
     "namespace": "Erdos539",
     "lineCount": 188,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 13,
+    "theoremCount": 5
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -119,7 +119,8 @@
       "SimpleGraph"
     ],
     "path": "Proofs/Erdos557Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-562",
-  "title": "Erd\u0151s Problem #562: Hypergraph Ramsey Number Tower Growth",
+  "title": "Erdős Problem #562: Hypergraph Ramsey Number Tower Growth",
   "slug": "erdos-562",
-  "description": "For r \u2265 3, prove that log_{r-1} R_r(n) \u224d n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n\u00b2)) from Erd\u0151s\u2013Rado. Lower: twr_{r-1}(\u03a9(n)). Status: OPEN.",
+  "description": "For r ≥ 3, prove that log_{r-1} R_r(n) ≍ n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n²)) from Erdős–Rado. Lower: twr_{r-1}(Ω(n)). Status: OPEN.",
   "meta": {
     "erdosNumber": 562,
     "status": "axiomatized",
@@ -52,22 +52,22 @@
     {
       "id": "graph-ramsey",
       "title": "Classical Graph Ramsey ($r = 2$)",
-      "summary": "Erd\u0151s-Szekeres bounds $2^{n/2} \\leq R(n,n) \\leq 4^n$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$",
+      "summary": "Erdős-Szekeres bounds $2^{n/2} \\leq R(n,n) \\leq 4^n$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$",
       "startLine": 51,
       "endLine": 64,
-      "mathContext": "Erd\u0151s-Szekeres bounds $$$2^{{n/2}$}$ \\leq R(n,n) \\leq $4^{n}$$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$"
+      "mathContext": "Erdős-Szekeres bounds $$$2^{{n/2}$}$ \\leq R(n,n) \\leq $4^{n}$$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$"
     },
     {
       "id": "stepping-up",
-      "title": "Erd\u0151s-Rado Stepping-Up Upper Bound",
-      "summary": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot n^2)$ \u2014 each uniformity increase adds one tower level with quadratic penalty",
+      "title": "Erdős-Rado Stepping-Up Upper Bound",
+      "summary": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot n^2)$ — each uniformity increase adds one tower level with quadratic penalty",
       "startLine": 66,
       "endLine": 72,
-      "mathContext": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot $n^{2}$)$ \u2014 each uniformity increase adds one tower level with quadratic penalty"
+      "mathContext": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot $n^{2}$)$ — each uniformity increase adds one tower level with quadratic penalty"
     },
     {
       "id": "r3-lower",
-      "title": "Erd\u0151s-Hajnal Lower Bound ($r = 3$)",
+      "title": "Erdős-Hajnal Lower Bound ($r = 3$)",
       "summary": "$R_3(n) \\geq \\mathrm{twr}_2(c \\cdot n^2) = 2^{2^{cn^2}}$, matching the upper bound tower height and resolving the $r=3$ case",
       "startLine": 74,
       "endLine": 80,
@@ -83,15 +83,15 @@
     }
   ],
   "overview": {
-    "historicalContext": "Erd\u0151s, Hajnal, and Rado formulated this conjecture in 1965 as the central question in hypergraph Ramsey theory. The story begins with the 1935 Erd\u0151s-Szekeres theorem establishing that graph Ramsey numbers R(n,n) grow exponentially \u2014 as a tower of height 1. The Erd\u0151s-Rado stepping-up lemma (1952) showed that each increase in uniformity r adds one tower level, giving R_r(n) \u2264 twr_{r-1}(c\u00b7n\u00b2). For the lower bound, Erd\u0151s and Hajnal proved R_3(n) \u2265 twr_2(c\u00b7n\u00b2), matching the upper bound for r=3. The general lower bound twr_{r-1}(\u03a9(n)) establishes the tower height as exactly r-1, but with a polynomial gap (linear vs quadratic) in the argument. The conjecture asks whether this gap can be closed to linear. For r=3, the answer is now known to be quadratic (\u0398(n\u00b2)), so the strongest form of the linear conjecture is false. The problem remains open for r \u2265 4 and is considered one of the most fundamental challenges in combinatorics. Recent progress on graph Ramsey numbers by Campos-Griffiths-Morris-Sahasrabudhe (2023) has renewed interest in hypergraph analogues.",
-    "problemStatement": "For r \u2265 3, prove that the (r-1)-fold iterated logarithm of R_r(n) is \u0398(n). Equivalently, R_r(n) = twr_{r-1}(\u0398(n)).",
-    "text": "For r \u2265 3, prove that log_{r-1} R_r(n) \u224d n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n\u00b2)) from Erd\u0151s\u2013Rado. Lower: twr_{r-1}(\u03a9(n)). Status: OPEN.",
-    "proofStrategy": "We formalize the tower function twr(k,n) by recursion on k, define hypergraph Ramsey numbers R_r(n) via sInf over valid 2-colorings of r-uniform hypergraphs, state the Erd\u0151s-Szekeres graph bounds as axioms, prove their conjunction as a theorem, state the Erd\u0151s-Rado stepping-up upper bound and the Erd\u0151s-Hajnal lower bounds as axioms, and formalize the main conjecture as an axiom asserting the existence of constants c\u2081, c\u2082 bounding the tower argument.",
+    "historicalContext": "Erdős, Hajnal, and Rado formulated this conjecture in 1965 as the central question in hypergraph Ramsey theory. The story begins with the 1935 Erdős-Szekeres theorem establishing that graph Ramsey numbers R(n,n) grow exponentially — as a tower of height 1. The Erdős-Rado stepping-up lemma (1952) showed that each increase in uniformity r adds one tower level, giving R_r(n) ≤ twr_{r-1}(c·n²). For the lower bound, Erdős and Hajnal proved R_3(n) ≥ twr_2(c·n²), matching the upper bound for r=3. The general lower bound twr_{r-1}(Ω(n)) establishes the tower height as exactly r-1, but with a polynomial gap (linear vs quadratic) in the argument. The conjecture asks whether this gap can be closed to linear. For r=3, the answer is now known to be quadratic (Θ(n²)), so the strongest form of the linear conjecture is false. The problem remains open for r ≥ 4 and is considered one of the most fundamental challenges in combinatorics. Recent progress on graph Ramsey numbers by Campos-Griffiths-Morris-Sahasrabudhe (2023) has renewed interest in hypergraph analogues.",
+    "problemStatement": "For r ≥ 3, prove that the (r-1)-fold iterated logarithm of R_r(n) is Θ(n). Equivalently, R_r(n) = twr_{r-1}(Θ(n)).",
+    "text": "For r ≥ 3, prove that log_{r-1} R_r(n) ≍ n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n²)) from Erdős–Rado. Lower: twr_{r-1}(Ω(n)). Status: OPEN.",
+    "proofStrategy": "We formalize the tower function twr(k,n) by recursion on k, define hypergraph Ramsey numbers R_r(n) via sInf over valid 2-colorings of r-uniform hypergraphs, state the Erdős-Szekeres graph bounds as axioms, prove their conjunction as a theorem, state the Erdős-Rado stepping-up upper bound and the Erdős-Hajnal lower bounds as axioms, and formalize the main conjecture as an axiom asserting the existence of constants c₁, c₂ bounding the tower argument.",
     "keyInsights": [
       "**Tower hierarchy**: Each increase in uniformity $r$ adds one level to the tower: $R_2(n) = 2^{\\Theta(n)}$, $R_3(n) = 2^{2^{\\Theta(n^2)}}$, and conjecturally $R_r(n) = \\mathrm{twr}_{r-1}(\\Theta(n^?))$",
-      "**Stepping-up penalty**: The Erd\u0151s-Rado lemma incurs a quadratic penalty $n \\mapsto cn^2$ at each step, which may or may not be inherent",
+      "**Stepping-up penalty**: The Erdős-Rado lemma incurs a quadratic penalty $n \\mapsto cn^2$ at each step, which may or may not be inherent",
       "**$r=3$ is resolved**: Both bounds give $\\mathrm{twr}_2(\\Theta(n^2))$, so the strongest linear conjecture is false for $r=3$",
-      "**Polynomial gap for $r \\geq 4$**: The remaining open question is the exact polynomial in $\\mathrm{twr}_{r-1}(n^?)$ \u2014 linear vs quadratic vs intermediate",
+      "**Polynomial gap for $r \\geq 4$**: The remaining open question is the exact polynomial in $\\mathrm{twr}_{r-1}(n^?)$ — linear vs quadratic vs intermediate",
       "**Very few exact values**: Only $R_3(4) = 13$ is known exactly; $R_3(5)$ is bounded between 43 and 48"
     ],
     "prerequisites": [
@@ -101,22 +101,22 @@
     ]
   },
   "references": [
-    "Erd\u0151s, P., Hajnal, A., and Rado, R. (1965). 'Partition relations for cardinal numbers.' Acta Math. Acad. Sci. Hungar., 16, 93\u2013196.",
-    "Erd\u0151s, P. and Szekeres, G. (1935). 'A combinatorial problem in geometry.' Compositio Mathematica, 2, 463\u2013470.",
-    "Erd\u0151s, P. and Rado, R. (1952). 'Combinatorial theorems on classifications of subsets of a given set.' Proc. London Math. Soc., 3(2), 417\u2013439.",
-    "Erd\u0151s, P. (1947). 'Some remarks on the theory of graphs.' Bull. Amer. Math. Soc., 53, 292\u2013294.",
+    "Erdős, P., Hajnal, A., and Rado, R. (1965). 'Partition relations for cardinal numbers.' Acta Math. Acad. Sci. Hungar., 16, 93–196.",
+    "Erdős, P. and Szekeres, G. (1935). 'A combinatorial problem in geometry.' Compositio Mathematica, 2, 463–470.",
+    "Erdős, P. and Rado, R. (1952). 'Combinatorial theorems on classifications of subsets of a given set.' Proc. London Math. Soc., 3(2), 417–439.",
+    "Erdős, P. (1947). 'Some remarks on the theory of graphs.' Bull. Amer. Math. Soc., 53, 292–294.",
     "Campos, M., Griffiths, S., Morris, R., and Sahasrabudhe, J. (2023). 'An exponential improvement for diagonal Ramsey.' arXiv:2303.09521.",
-    "Conlon, D., Fox, J., and Sudakov, B. (2015). 'Recent developments in graph Ramsey theory.' Surveys in Combinatorics, 49\u2013118.",
+    "Conlon, D., Fox, J., and Sudakov, B. (2015). 'Recent developments in graph Ramsey theory.' Surveys in Combinatorics, 49–118.",
     "https://erdosproblems.com/562"
   ],
   "conclusion": {
-    "summary": "This formalization captures the Erd\u0151s-Hajnal-Rado conjecture on hypergraph Ramsey number tower growth: R_r(n) should equal twr_{r-1}(\u0398(n)). The tower function, hypergraph Ramsey numbers, Erd\u0151s-Szekeres graph bounds, the Erd\u0151s-Rado stepping-up upper bound, and known lower bounds are all formalized. The r=3 case is essentially resolved at twr_2(\u0398(n\u00b2)), while the general case for r \u2265 4 remains one of the deepest open problems in combinatorics.",
+    "summary": "This formalization captures the Erdős-Hajnal-Rado conjecture on hypergraph Ramsey number tower growth: R_r(n) should equal twr_{r-1}(Θ(n)). The tower function, hypergraph Ramsey numbers, Erdős-Szekeres graph bounds, the Erdős-Rado stepping-up upper bound, and known lower bounds are all formalized. The r=3 case is essentially resolved at twr_2(Θ(n²)), while the general case for r ≥ 4 remains one of the deepest open problems in combinatorics.",
     "implications": "Resolving this conjecture would determine the fundamental complexity hierarchy of hypergraph Ramsey theory. It would reveal whether the quadratic penalty in the stepping-up lemma is inherent or can be eliminated, with implications for partition calculus, Hales-Jewett theory, and computational complexity lower bounds.",
     "openQuestions": [
-      "Can the Erd\u0151s-Rado stepping-up lemma be improved from O(n\u00b2) to o(n\u00b2) in the tower argument for r \u2265 4?",
-      "What is the exact polynomial exponent in twr_{r-1}(n^\u03b1) for each r?",
-      "Is R_3(5) equal to 43, 44, ... or 48? (Current best bounds: 43 \u2264 R\u2083(5) \u2264 48)",
-      "Can algebraic or topological methods yield better hypergraph Ramsey lower bounds for r \u2265 4?"
+      "Can the Erdős-Rado stepping-up lemma be improved from O(n²) to o(n²) in the tower argument for r ≥ 4?",
+      "What is the exact polynomial exponent in twr_{r-1}(n^α) for each r?",
+      "Is R_3(5) equal to 43, 44, ... or 48? (Current best bounds: 43 ≤ R₃(5) ≤ 48)",
+      "Can algebraic or topological methods yield better hypergraph Ramsey lower bounds for r ≥ 4?"
     ]
   },
   "leanFile": {
@@ -133,23 +133,24 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos562Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 2
   },
   "crossReferences": [
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, ramsey-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, ramsey-theory"
     },
     {
       "targetId": "erdos-1105",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, ramsey-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, ramsey-theory"
     },
     {
       "targetId": "erdos-112",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, ramsey-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, ramsey-theory"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-563/meta.json
+++ b/src/data/proofs/erdos-563/meta.json
@@ -107,7 +107,8 @@
     "namespace": null,
     "lineCount": 65,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 6
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-565/meta.json
+++ b/src/data/proofs/erdos-565/meta.json
@@ -184,7 +184,7 @@
     "lineCount": 286,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos565Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -132,7 +132,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos566Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-567/meta.json
+++ b/src/data/proofs/erdos-567/meta.json
@@ -139,7 +139,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos567Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 5
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-568/meta.json
+++ b/src/data/proofs/erdos-568/meta.json
@@ -139,7 +139,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos568Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 7
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -113,7 +113,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos574Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-577/meta.json
+++ b/src/data/proofs/erdos-577/meta.json
@@ -170,7 +170,7 @@
     "namespace": "Erdos577",
     "lineCount": 192,
     "axiomCount": 2,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 7,
     "path": "Proofs/Erdos577Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-588/meta.json
+++ b/src/data/proofs/erdos-588/meta.json
@@ -162,7 +162,7 @@
     "lineCount": 87,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 0,
+    "definitionCount": 1,
     "path": "Proofs/Erdos588Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-589/meta.json
+++ b/src/data/proofs/erdos-589/meta.json
@@ -154,7 +154,7 @@
     "lineCount": 339,
     "axiomCount": 4,
     "theoremCount": 7,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos589Problem.lean",
     "sorries": 3
   },

--- a/src/data/proofs/erdos-592/meta.json
+++ b/src/data/proofs/erdos-592/meta.json
@@ -163,7 +163,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos592Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-594/meta.json
+++ b/src/data/proofs/erdos-594/meta.json
@@ -170,7 +170,7 @@
     "lineCount": 245,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 9,
+    "definitionCount": 12,
     "path": "Proofs/Erdos594Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-601",
-  "title": "Erd\u0151s #601: Infinite Paths and Independent Sets in Ordinal Graphs",
+  "title": "Erdős #601: Infinite Paths and Independent Sets in Ordinal Graphs",
   "slug": "erdos-601",
-  "description": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
+  "description": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
   "meta": {
-    "author": "Paul Erd\u0151s, Andr\u00e1s Hajnal, Eric Milner, Jean Larson",
+    "author": "Paul Erdős, András Hajnal, Eric Milner, Jean Larson",
     "sourceUrl": "https://erdosproblems.com/601",
     "date": "1970",
     "status": "axiomatized",
@@ -52,7 +52,7 @@
       "IsIndependent: independence predicate",
       "HasOrderType: order type of vertex subsets",
       "PropertyP: path-vs-independent-set dichotomy",
-      "criticalOrdinal: \u03c9\u2081^{\u03c9+2} definition",
+      "criticalOrdinal: ω₁^{ω+2} definition",
       "erdos_hajnal_milner: main theorem (1970)",
       "CriticalCaseConjecture: $250 prize problem",
       "MartinsAxiom: set-theoretic axiom",
@@ -107,7 +107,7 @@
     },
     {
       "id": "ehm",
-      "title": "Erd\u0151s-Hajnal-Milner Theorem (1970)",
+      "title": "Erdős-Hajnal-Milner Theorem (1970)",
       "summary": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form.",
       "startLine": 88,
       "endLine": 101,
@@ -116,10 +116,10 @@
     {
       "id": "critical",
       "title": "The Critical Case: $\\omega_1^{\\omega+2}$ ($250)",
-      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize.",
+      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize.",
       "startLine": 102,
       "endLine": 116,
-      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize."
+      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize."
     },
     {
       "id": "martins-axiom",
@@ -140,10 +140,10 @@
     {
       "id": "graph-tools",
       "title": "Graph-Theoretic Tools",
-      "summary": "States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
+      "summary": "States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
       "startLine": 152,
       "endLine": 165,
-      "mathContext": "Mathematical content: States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
+      "mathContext": "Mathematical content: States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
     },
     {
       "id": "independence",
@@ -163,13 +163,13 @@
     }
   ],
   "overview": {
-    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erd\u0151s, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erd\u0151s-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
-    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erd\u0151s-Hajnal-Milner theorem.",
-    "text": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erd\u0151s-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, K\u00f6nig's lemma, independence number, transfinite induction.",
+    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erdős, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erdős-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
+    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erdős-Hajnal-Milner theorem.",
+    "text": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erdős-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, König's lemma, independence number, transfinite induction.",
     "keyInsights": [
-      "**Erd\u0151s-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
-      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ \u2014 new techniques are needed",
+      "**Erdős-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
+      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ — new techniques are needed",
       "**Larson (1990):** Under Martin's Axiom, $P(\\alpha)$ extends to all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, showing set-theoretic dependence",
       "**Ramsey-type dichotomy:** The problem generalizes the infinite Ramsey theorem from $\\omega$ to arbitrary ordinals with order type requirements",
       "**Two-tier prize:** $250 for the critical case $P(\\omega_1^{\\omega+2})$, $500 for the full generalization to all limit ordinals"
@@ -181,13 +181,13 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erd\u0151s-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
-    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms \u2014 the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erd\u0151s-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
+    "summary": "This formalization captures Erdős Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erdős-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
+    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms — the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erdős-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
     "openQuestions": [
-      "Does P(\u03c9\u2081^{\u03c9+2}) hold? ($250 \u2014 the critical boundary case)",
-      "Does P(\u03b1) hold for all limit ordinals \u03b1? ($500 \u2014 the general conjecture)",
+      "Does P(ω₁^{ω+2}) hold? ($250 — the critical boundary case)",
+      "Does P(α) hold for all limit ordinals α? ($500 — the general conjecture)",
       "Is the answer independent of ZFC (provable under MA but not in ZFC alone)?",
-      "Can the Erd\u0151s-Hajnal-Milner bound \u03c9\u2081^{\u03c9+2} be improved in ZFC?",
+      "Can the Erdős-Hajnal-Milner bound ω₁^{ω+2} be improved in ZFC?",
       "What happens for singular cardinals and their ordinal powers?"
     ]
   },
@@ -207,7 +207,7 @@
     "namespace": "Erdos601",
     "lineCount": 259,
     "axiomCount": 4,
-    "theoremCount": 19,
+    "theoremCount": 18,
     "definitionCount": 13,
     "sorries": 10,
     "path": "Proofs/Erdos601Problem.lean"
@@ -215,17 +215,17 @@
   "references": [
     {
       "key": "EHM70",
-      "citation": "Erd\u0151s, Paul, Hajnal, Andr\u00e1s, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
+      "citation": "Erdős, Paul, Hajnal, András, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
       "type": "paper"
     },
     {
       "key": "La90",
-      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal \u03c9^\u03c9, Ann. Pure Appl. Logic 48 (1990), 253-255.",
+      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal ω^ω, Ann. Pure Appl. Logic 48 (1990), 253-255.",
       "type": "paper"
     },
     {
       "key": "EH77",
-      "citation": "Erd\u0151s, Paul and Hajnal, Andr\u00e1s, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
+      "citation": "Erdős, Paul and Hajnal, András, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
       "type": "paper"
     },
     {
@@ -235,7 +235,7 @@
     },
     {
       "key": "EP",
-      "citation": "Erd\u0151s Problems, Problem #601, https://erdosproblems.com/601.",
+      "citation": "Erdős Problems, Problem #601, https://erdosproblems.com/601.",
       "type": "website"
     }
   ],
@@ -243,17 +243,17 @@
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1169",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1174",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
     }
   ],
   "sorries": 10

--- a/src/data/proofs/erdos-602/meta.json
+++ b/src/data/proofs/erdos-602/meta.json
@@ -185,7 +185,7 @@
     "lineCount": 299,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 22,
+    "definitionCount": 24,
     "path": "Proofs/Erdos602Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -207,7 +207,7 @@
     "lineCount": 287,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 19,
+    "definitionCount": 18,
     "path": "Proofs/Erdos603Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-605/meta.json
+++ b/src/data/proofs/erdos-605/meta.json
@@ -194,7 +194,7 @@
     "lineCount": 250,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos605Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -157,8 +157,8 @@
     "namespace": "Erdos606",
     "lineCount": 243,
     "axiomCount": 12,
-    "theoremCount": 3,
-    "definitionCount": 7,
+    "theoremCount": 2,
+    "definitionCount": 8,
     "path": "Proofs/Erdos606Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -190,7 +190,7 @@
     "lineCount": 224,
     "axiomCount": 10,
     "theoremCount": 2,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "path": "Proofs/Erdos607Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -179,7 +179,7 @@
     "lineCount": 219,
     "axiomCount": 11,
     "theoremCount": 3,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos609Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -147,7 +147,7 @@
     "lineCount": 268,
     "axiomCount": 2,
     "theoremCount": 19,
-    "definitionCount": 0,
+    "definitionCount": 10,
     "sorries": 19,
     "path": "Proofs/Erdos625Problem.lean"
   },

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -212,7 +212,7 @@
     "lineCount": 244,
     "axiomCount": 7,
     "theoremCount": 13,
-    "definitionCount": 12,
+    "definitionCount": 9,
     "path": "Proofs/Erdos626Problem.lean",
     "sorries": 15
   },

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -192,7 +192,7 @@
     "lineCount": 236,
     "axiomCount": 8,
     "theoremCount": 13,
-    "definitionCount": 14,
+    "definitionCount": 10,
     "path": "Proofs/Erdos627Problem.lean",
     "sorries": 16
   },

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -207,7 +207,7 @@
     "lineCount": 246,
     "axiomCount": 11,
     "theoremCount": 11,
-    "definitionCount": 10,
+    "definitionCount": 8,
     "path": "Proofs/Erdos630Problem.lean",
     "sorries": 15
   },

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -206,7 +206,7 @@
     "lineCount": 269,
     "axiomCount": 16,
     "theoremCount": 7,
-    "definitionCount": 9,
+    "definitionCount": 7,
     "path": "Proofs/Erdos631Problem.lean",
     "sorries": 10
   },

--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -175,7 +175,7 @@
     "lineCount": 260,
     "axiomCount": 1,
     "theoremCount": 11,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos632Problem.lean",
     "sorries": 5
   },

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -233,7 +233,7 @@
     "lineCount": 261,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos636Problem.lean",
     "sorries": 4
   },

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -201,7 +201,7 @@
     "namespace": "Erdos637",
     "lineCount": 243,
     "axiomCount": 2,
-    "theoremCount": 13,
+    "theoremCount": 11,
     "definitionCount": 16,
     "sorries": 10,
     "path": "Proofs/Erdos637Problem.lean"

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -130,7 +130,7 @@
     "lineCount": 291,
     "axiomCount": 2,
     "theoremCount": 11,
-    "definitionCount": 8,
+    "definitionCount": 5,
     "path": "Proofs/Erdos640Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-641/meta.json
+++ b/src/data/proofs/erdos-641/meta.json
@@ -165,7 +165,7 @@
     "lineCount": 239,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 17,
+    "definitionCount": 15,
     "path": "Proofs/Erdos641Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -195,7 +195,7 @@
     "lineCount": 263,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "sorries": 6,
     "path": "Proofs/Erdos642Problem.lean"
   },

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-643",
-  "title": "Erd\u0151s Problem #643: Crossed Pairs in Hypergraphs",
+  "title": "Erdős Problem #643: Crossed Pairs in Hypergraphs",
   "slug": "erdos-643",
-  "description": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A\u222aB = C\u222aD and A\u2229B = C\u2229D = \u2205. Conjecture: f(n;t) = (1+o(1))\u00b7C(n,t-1) for t\u22653.",
+  "description": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A∪B = C∪D and A∩B = C∩D = ∅. Conjecture: f(n;t) = (1+o(1))·C(n,t-1) for t≥3.",
   "meta": {
-    "author": "Open Problem (bounds by F\u00fcredi, Pikhurko-Verstra\u00ebte)",
+    "author": "Open Problem (bounds by Füredi, Pikhurko-Verstraëte)",
     "sourceUrl": "https://erdosproblems.com/643",
     "date": "",
     "status": "axiomatized",
@@ -41,33 +41,33 @@
     ],
     "originalContributions": [
       "Formal definition of t-uniform hypergraphs as sets of t-element Finsets",
-      "Definition of 'crossed pair' configuration: four edges A,B,C,D with A\u222aB=C\u222aD and A\u2229B=C\u2229D=\u2205",
+      "Definition of 'crossed pair' configuration: four edges A,B,C,D with A∪B=C∪D and A∩B=C∩D=∅",
       "Definition of the extremal function f(n,t) via Nat.find",
-      "Connection to C\u2084-free graphs for t=2 case (K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n)",
-      "Axiomatization of Pikhurko-Verstra\u00ebte bound: f(n,3) \u2264 (13/9)\u00b7C(n,2)",
+      "Connection to C₄-free graphs for t=2 case (Kővári–Sós–Turán)",
+      "Axiomatization of Pikhurko-Verstraëte bound: f(n,3) ≤ (13/9)·C(n,2)",
       "Construction of sunflower hypergraphs avoiding crossed pairs",
-      "Statement of Erd\u0151s-Rado Sunflower Lemma connection"
+      "Statement of Erdős-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
     "lineCount": 1403,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration\u2014four edges A,B,C,D where A\u222aB = C\u222aD but the pairs {A,B} and {C,D} are both disjoint\u2014generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C\u2084, connecting to the classical K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem.\n\nFor hypergraphs (t\u22653), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstra\u00ebte (2009) for 3-uniform hypergraphs, establishing f(n,3) \u2264 (13/9)\u00b7C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
-    "problemStatement": "Let $f(n;t)$ be the minimal number of edges such that any $t$-uniform hypergraph on $n$ vertices must contain four edges $A, B, C, D$ satisfying:\n$$A \\cup B = C \\cup D \\quad \\text{and} \\quad A \\cap B = C \\cap D = \\emptyset$$\n\n**Known Bounds**:\n- **t = 2**: $f(n;2) = (\\frac{1}{2} + o(1))n^{3/2}$ (K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n)\n- **t = 3**: $f(n;3) \\leq \\frac{13}{9}\\binom{n}{2}$ (Pikhurko-Verstra\u00ebte 2009)\n- **General**: $\\binom{n-1}{t-1} + \\lfloor\\frac{n-1}{t}\\rfloor \\leq f(n;t) < \\frac{7}{2}\\binom{n}{t-1}$\n\n**Conjecture** (OPEN): For $t \\geq 3$,\n$$f(n;t) = (1 + o(1))\\binom{n}{t-1}$$",
-    "text": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A\u222aB = C\u222aD and A\u2229B = C\u2229D = \u2205. Conjecture: f(n;t) = (1+o(1))\u00b7C(n,t-1) for t\u22653.",
-    "proofStrategy": "Our formalization:\n\n1. **Defines hypergraphs** as sets of Finsets with uniformity constraints\n\n2. **Formalizes the crossed pair configuration** with four edges having matching unions and empty intersections\n\n3. **Defines the extremal function** f(n,t) via Nat.find on the property that all hypergraphs with \u2265m edges contain a crossed pair\n\n4. **Explores the t=2 case** connecting to 4-cycles and the K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem\n\n5. **Records known bounds** including the Pikhurko-Verstra\u00ebte upper bound\n\n6. **Constructs sunflower hypergraphs** as examples achieving near-optimal bounds\n\n7. **States the main conjecture** as an asymptotic limit statement",
+    "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration—four edges A,B,C,D where A∪B = C∪D but the pairs {A,B} and {C,D} are both disjoint—generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C₄, connecting to the classical Kővári–Sós–Turán theorem.\n\nFor hypergraphs (t≥3), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstraëte (2009) for 3-uniform hypergraphs, establishing f(n,3) ≤ (13/9)·C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
+    "problemStatement": "Let $f(n;t)$ be the minimal number of edges such that any $t$-uniform hypergraph on $n$ vertices must contain four edges $A, B, C, D$ satisfying:\n$$A \\cup B = C \\cup D \\quad \\text{and} \\quad A \\cap B = C \\cap D = \\emptyset$$\n\n**Known Bounds**:\n- **t = 2**: $f(n;2) = (\\frac{1}{2} + o(1))n^{3/2}$ (Kővári–Sós–Turán)\n- **t = 3**: $f(n;3) \\leq \\frac{13}{9}\\binom{n}{2}$ (Pikhurko-Verstraëte 2009)\n- **General**: $\\binom{n-1}{t-1} + \\lfloor\\frac{n-1}{t}\\rfloor \\leq f(n;t) < \\frac{7}{2}\\binom{n}{t-1}$\n\n**Conjecture** (OPEN): For $t \\geq 3$,\n$$f(n;t) = (1 + o(1))\\binom{n}{t-1}$$",
+    "text": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A∪B = C∪D and A∩B = C∩D = ∅. Conjecture: f(n;t) = (1+o(1))·C(n,t-1) for t≥3.",
+    "proofStrategy": "Our formalization:\n\n1. **Defines hypergraphs** as sets of Finsets with uniformity constraints\n\n2. **Formalizes the crossed pair configuration** with four edges having matching unions and empty intersections\n\n3. **Defines the extremal function** f(n,t) via Nat.find on the property that all hypergraphs with ≥m edges contain a crossed pair\n\n4. **Explores the t=2 case** connecting to 4-cycles and the Kővári–Sós–Turán theorem\n\n5. **Records known bounds** including the Pikhurko-Verstraëte upper bound\n\n6. **Constructs sunflower hypergraphs** as examples achieving near-optimal bounds\n\n7. **States the main conjecture** as an asymptotic limit statement",
     "keyInsights": [
-      "**Crossed Pairs Generalize C\u2084**: For graphs (t=2), avoiding crossed pairs is equivalent to avoiding 4-cycles. The K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem gives f(n,2) = \u0398(n^{3/2}).",
+      "**Crossed Pairs Generalize C₄**: For graphs (t=2), avoiding crossed pairs is equivalent to avoiding 4-cycles. The Kővári–Sós–Turán theorem gives f(n,2) = Θ(n^{3/2}).",
       "**Sunflowers Avoid Crossed Pairs**: A sunflower (all edges share a common core) cannot contain crossed pairs because any two edges intersect in the nonempty core.",
       "**The Gap to Optimal**: The lower bound C(n-1,t-1) comes from sunflower constructions. The conjecture is that this is essentially tight.",
-      "**Connection to Erd\u0151s-Rado**: The Sunflower Lemma (large uniform families contain sunflowers) is a related structural result in extremal combinatorics.",
-      "**Pikhurko-Verstra\u00ebte breakthrough**: Their upper bound f(n,t) = O(n^{t-1}/log^c n) improves the trivial O(n^{t-1}) by a logarithmic factor, suggesting the true answer lies between n^{t-1-\u03b5} and n^{t-1}/polylog"
+      "**Connection to Erdős-Rado**: The Sunflower Lemma (large uniform families contain sunflowers) is a related structural result in extremal combinatorics.",
+      "**Pikhurko-Verstraëte breakthrough**: Their upper bound f(n,t) = O(n^{t-1}/log^c n) improves the trivial O(n^{t-1}) by a logarithmic factor, suggesting the true answer lies between n^{t-1-ε} and n^{t-1}/polylog"
     ],
     "prerequisites": [
-      "Extremal hypergraph theory: $t$-uniform hypergraphs, Tur\u00e1n-type problems, extremal functions",
-      "The K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem: bipartite Tur\u00e1n problem, $\\text{ex}(n, K_{s,t}) = O(n^{2-1/s})$",
-      "Sunflower lemma (Erd\u0151s-Rado): structural constraints on large uniform families",
+      "Extremal hypergraph theory: $t$-uniform hypergraphs, Turán-type problems, extremal functions",
+      "The Kővári-Sós-Turán theorem: bipartite Turán problem, $\\text{ex}(n, K_{s,t}) = O(n^{2-1/s})$",
+      "Sunflower lemma (Erdős-Rado): structural constraints on large uniform families",
       "Asymptotic analysis: $o(1)$, $\\Theta$, and Filter.Tendsto for the main conjecture"
     ]
   },
@@ -95,24 +95,24 @@
     },
     {
       "id": "graph-case",
-      "title": "Case t = 2: Graphs and C\u2084",
+      "title": "Case t = 2: Graphs and C₄",
       "startLine": 86,
       "endLine": 110,
-      "summary": "Connection to 4-cycles and K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n"
+      "summary": "Connection to 4-cycles and Kővári–Sós–Turán"
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
       "startLine": 111,
       "endLine": 140,
-      "summary": "Pikhurko-Verstra\u00ebte and general bounds"
+      "summary": "Pikhurko-Verstraëte and general bounds"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
       "startLine": 141,
       "endLine": 157,
-      "summary": "Statement of Erd\u0151s's asymptotic conjecture"
+      "summary": "Statement of Erdős's asymptotic conjecture"
     },
     {
       "id": "constructions",
@@ -123,10 +123,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #643, asking about the extremal function f(n,t) for hypergraphs avoiding crossed pairs. We define the key concepts, record known bounds, explore the connection to 4-cycles in graphs, and construct sunflower hypergraphs achieving near-optimal bounds.",
+    "summary": "This formalization captures Erdős Problem #643, asking about the extremal function f(n,t) for hypergraphs avoiding crossed pairs. We define the key concepts, record known bounds, explore the connection to 4-cycles in graphs, and construct sunflower hypergraphs achieving near-optimal bounds.",
     "implications": "If the conjecture f(n,t) ~ C(n,t-1) is true, it would establish that sunflower-type constructions are essentially optimal for avoiding crossed pairs in uniform hypergraphs. This connects to deep questions in extremal combinatorics about forbidden configurations.",
     "openQuestions": [
-      "Is f(n,t) = (1+o(1))\u00b7C(n,t-1) for all t \u2265 3?",
+      "Is f(n,t) = (1+o(1))·C(n,t-1) for all t ≥ 3?",
       "What is the exact value of f(n,3) for small n?",
       "Are there constructions other than sunflowers achieving good bounds?",
       "How does the problem generalize to non-uniform hypergraphs?"
@@ -189,7 +189,7 @@
     "lineCount": 1403,
     "axiomCount": 3,
     "theoremCount": 42,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos643Problem.lean",
     "sorries": 1
   },
@@ -197,17 +197,17 @@
     {
       "targetId": "erdos-1022",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, hypergraphs"
+      "description": "Related Erdős problem sharing themes: combinatorics, hypergraphs"
     },
     {
       "targetId": "erdos-1023",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, extremal-combinatorics"
+      "description": "Related Erdős problem sharing themes: combinatorics, extremal-combinatorics"
     },
     {
       "targetId": "erdos-1025",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, extremal-combinatorics"
+      "description": "Related Erdős problem sharing themes: combinatorics, extremal-combinatorics"
     }
   ],
   "sorries": 1

--- a/src/data/proofs/erdos-649/meta.json
+++ b/src/data/proofs/erdos-649/meta.json
@@ -166,7 +166,7 @@
     "lineCount": 364,
     "axiomCount": 4,
     "theoremCount": 18,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/Erdos649Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-652/meta.json
+++ b/src/data/proofs/erdos-652/meta.json
@@ -210,7 +210,7 @@
     "lineCount": 175,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos652Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-654/meta.json
+++ b/src/data/proofs/erdos-654/meta.json
@@ -156,7 +156,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos654Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 5
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -168,7 +168,7 @@
     "namespace": "Erdos658",
     "lineCount": 299,
     "axiomCount": 3,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 8,
     "path": "Proofs/Erdos658Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -139,7 +139,7 @@
     "lineCount": 179,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 8,
+    "definitionCount": 10,
     "sorries": 10,
     "path": "Proofs/Erdos660Problem.lean"
   },

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -122,7 +122,7 @@
     "lineCount": 164,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 9,
+    "definitionCount": 7,
     "path": "Proofs/Erdos661Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-662",
   "title": "Distances in Separated Point Sets",
   "slug": "erdos-662",
-  "description": "For 1-separated points in \u211d\u00b2, is the number of pairs at distance \u2264 t maximized by the triangular lattice? f(1)=6, f(\u221a3)=12, f(3)=18. Erd\u0151s\u2013Lov\u00e1sz\u2013Vesztergombi. Open.",
+  "description": "For 1-separated points in ℝ², is the number of pairs at distance ≤ t maximized by the triangular lattice? f(1)=6, f(√3)=12, f(3)=18. Erdős–Lovász–Vesztergombi. Open.",
   "meta": {
     "erdosNumber": 662,
     "status": "axiomatized",
@@ -19,7 +19,7 @@
     "sourceUrl": "https://erdosproblems.com/662",
     "erdosUrl": "https://erdosproblems.com/662",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_662_lattice_optimal (the main open conjecture \u2014 unprovable). kissing_number_2d fully proved via angular sector pigeonhole (Complex.arg \u2192 normalized angle \u2192 6 bins \u2192 injective \u2192 card \u2264 6). All supporting lemmas proved: unit_neighbor_bound, neighbor_sqDist_eq_one, neighbor_dot_le_half, contact_number_3n.",
+    "assumptions": "1 axiom: erdos_662_lattice_optimal (the main open conjecture — unprovable). kissing_number_2d fully proved via angular sector pigeonhole (Complex.arg → normalized angle → 6 bins → injective → card ≤ 6). All supporting lemmas proved: unit_neighbor_bound, neighbor_sqDist_eq_one, neighbor_dot_le_half, contact_number_3n.",
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 375
@@ -30,8 +30,8 @@
       "title": "Problem Statement and Background",
       "startLine": 1,
       "endLine": 10,
-      "summary": "Module docstring introducing the Erd\u0151s\u2013Lov\u00e1sz\u2013Vesztergombi conjecture (1997): among 1-separated point sets in $\\mathbb{R}^2$, the triangular lattice maximizes the number of pairs at distance $\\le t$.",
-      "mathContext": "Mathematical content: Module docstring introducing the Erd\u0151s\u2013Lov\u00e1sz\u2013Vesztergombi conjecture (1997): among 1-separated point sets in $\\mathbb{R}^2$, the triangular lattice maximizes the number of pairs at distance $\\le t$."
+      "summary": "Module docstring introducing the Erdős–Lovász–Vesztergombi conjecture (1997): among 1-separated point sets in $\\mathbb{R}^2$, the triangular lattice maximizes the number of pairs at distance $\\le t$.",
+      "mathContext": "Mathematical content: Module docstring introducing the Erdős–Lovász–Vesztergombi conjecture (1997): among 1-separated point sets in $\\mathbb{R}^2$, the triangular lattice maximizes the number of pairs at distance $\\le t$."
     },
     {
       "id": "imports",
@@ -94,7 +94,7 @@
       "title": "2D Kissing Number Theorem",
       "startLine": 243,
       "endLine": 298,
-      "summary": "**Fully proved**: At most 6 unit vectors in $\\mathbb{R}^2$ can have pairwise dot product $\\le 1/2$. Proof: angular sector pigeonhole \u2014 assign each vector to one of 6 sectors of width $\\pi/3$; sector map is injective (collision implies angular separation $< \\pi/3$ implies dot $> 1/2$, contradiction), so $|S| \\le 6$.",
+      "summary": "**Fully proved**: At most 6 unit vectors in $\\mathbb{R}^2$ can have pairwise dot product $\\le 1/2$. Proof: angular sector pigeonhole — assign each vector to one of 6 sectors of width $\\pi/3$; sector map is injective (collision implies angular separation $< \\pi/3$ implies dot $> 1/2$, contradiction), so $|S| \\le 6$.",
       "mathContext": "The 2D kissing number theorem, fully machine-checked. Angular sector pigeonhole with Complex.arg parametrization. No sorries, no axioms."
     },
     {
@@ -110,20 +110,20 @@
       "title": "Main Conjecture (OPEN)",
       "startLine": 368,
       "endLine": 375,
-      "summary": "States the Erd\u0151s\u2013Lov\u00e1sz\u2013Vesztergombi conjecture: for all $t \\ge 1$ and sufficiently large $n$, $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ for every 1-separated $S$ with $|S| = n$. Axiomatized as the conjecture remains open.",
-      "mathContext": "States the Erd\u0151s\u2013Lov\u00e1sz\u2013Vesztergombi conjecture: for all $t \\ge 1$ and sufficiently large $n$, $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ for every 1-separated $S$ with $|S| = n$. Axiomatized as the conjecture remains open."
+      "summary": "States the Erdős–Lovász–Vesztergombi conjecture: for all $t \\ge 1$ and sufficiently large $n$, $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ for every 1-separated $S$ with $|S| = n$. Axiomatized as the conjecture remains open.",
+      "mathContext": "States the Erdős–Lovász–Vesztergombi conjecture: for all $t \\ge 1$ and sufficiently large $n$, $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ for every 1-separated $S$ with $|S| = n$. Axiomatized as the conjecture remains open."
     }
   ],
   "overview": {
-    "historicalContext": "Erd\u0151s, Lov\u00e1sz, and Vesztergombi posed this problem in their 1997 paper 'Problems and results on the grid,' asking whether the triangular lattice universally maximizes short-range pair interactions among 1-separated point sets. The question extends a classical line of inquiry beginning with Thue's 1910 proof that the hexagonal lattice gives the densest circle packing in the plane, later made rigorous by Fejes T\u00f3th (1940). The t = 1 case reduces to the contact number problem \u2014 how many unit-distance pairs can occur in a 1-separated set \u2014 which was resolved by Harborth (1974), who showed the exact answer is \u230a3n \u2212 \u221a(12n \u2212 3)\u230b, achieved by hexagonal configurations. For general t, the problem connects to the Gauss circle problem for the Loeschian quadratic form a\u00b2 + ab + b\u00b2 (the norm form of the Eisenstein integers \u2124[\u03c9]), since counting lattice points within distance t is equivalent to counting representations by this form. Despite nearly three decades since its posing, the conjecture remains open for all t > 1.",
+    "historicalContext": "Erdős, Lovász, and Vesztergombi posed this problem in their 1997 paper 'Problems and results on the grid,' asking whether the triangular lattice universally maximizes short-range pair interactions among 1-separated point sets. The question extends a classical line of inquiry beginning with Thue's 1910 proof that the hexagonal lattice gives the densest circle packing in the plane, later made rigorous by Fejes Tóth (1940). The t = 1 case reduces to the contact number problem — how many unit-distance pairs can occur in a 1-separated set — which was resolved by Harborth (1974), who showed the exact answer is ⌊3n − √(12n − 3)⌋, achieved by hexagonal configurations. For general t, the problem connects to the Gauss circle problem for the Loeschian quadratic form a² + ab + b² (the norm form of the Eisenstein integers ℤ[ω]), since counting lattice points within distance t is equivalent to counting representations by this form. Despite nearly three decades since its posing, the conjecture remains open for all t > 1.",
     "problemStatement": "For $n$ points in $\\mathbb{R}^2$ with all pairwise distances $\\ge 1$, is the number of pairs at distance $\\le t$ maximized (for each $t \\ge 1$ and $n$ sufficiently large) by the triangular lattice configuration? That is, does $\\text{pairs}_t(S) \\le n \\cdot f(t)/2$ hold, where $f(t)$ is the coordination number of the triangular lattice at radius $t$?",
-    "text": "For 1-separated points in \u211d\u00b2, is the number of pairs at distance \u2264 t maximized by the triangular lattice? f(1)=6, f(\u221a3)=12, f(3)=18. Erd\u0151s\u2013Lov\u00e1sz\u2013Vesztergombi. Open.",
+    "text": "For 1-separated points in ℝ², is the number of pairs at distance ≤ t maximized by the triangular lattice? f(1)=6, f(√3)=12, f(3)=18. Erdős–Lovász–Vesztergombi. Open.",
     "proofStrategy": "The formalization defines 1-separated point sets and the pair count function, constructs the triangular lattice with computable lattice point counting via the Loeschian norm $a^2 + ab + b^2$, and verifies $f(1) = 6$, $f(\\sqrt{3}) = 12$ by `native_decide`. The $t = 1$ case is fully proved: neighbors lie on the unit circle (algebraic reduction), dot products $\\le 1/2$ (from separation), and the 2D kissing number $\\le 6$ (angular sector pigeonhole via Complex.arg). This gives the contact number bound $3n$. The general conjecture remains axiomatized.",
     "keyInsights": [
       "**Loeschian quadratic form**: Distances in the triangular lattice are governed by $a^2 + ab + b^2$, the norm form of the Eisenstein integers $\\mathbb{Z}[\\omega]$, connecting discrete geometry to algebraic number theory",
       "**Contact number resolved**: The $t = 1$ case follows from the 2D kissing number (6) via double counting: at most $6n$ ordered pairs, hence $\\le 3n$ unordered pairs, matching Harborth's exact formula $\\lfloor 3n - \\sqrt{12n-3}\\rfloor$",
-      "**Coordination shells**: The triangular lattice has $f(1) = 6$, $f(\\sqrt{3}) = 12$, $f(3) = 18$ \u2014 these are the first coordination shells, with shell sizes determined by representations of Loeschian numbers",
-      "**Extends Thue's theorem**: Just as the triangular lattice maximizes packing density, the conjecture asserts it maximizes pair counts \u2014 a stronger optimality property for the hexagonal lattice",
+      "**Coordination shells**: The triangular lattice has $f(1) = 6$, $f(\\sqrt{3}) = 12$, $f(3) = 18$ — these are the first coordination shells, with shell sizes determined by representations of Loeschian numbers",
+      "**Extends Thue's theorem**: Just as the triangular lattice maximizes packing density, the conjecture asserts it maximizes pair counts — a stronger optimality property for the hexagonal lattice",
       "**Boundary effects**: The formulation requires $n \\ge N$ because finite lattice patches have fewer pairs per point near the boundary; the conjecture is asymptotic in nature"
     ],
     "prerequisites": [
@@ -132,20 +132,20 @@
     ]
   },
   "conclusion": {
-    "summary": "Formalizes Erd\u0151s Problem #662 on the optimality of the triangular lattice for maximizing distance-constrained pair counts in 1-separated planar point sets. The formalization establishes the Loeschian distance formula, known coordination shell values, and proves the contact number bound (3n) for the t = 1 case via the 2D kissing number argument.",
+    "summary": "Formalizes Erdős Problem #662 on the optimality of the triangular lattice for maximizing distance-constrained pair counts in 1-separated planar point sets. The formalization establishes the Loeschian distance formula, known coordination shell values, and proves the contact number bound (3n) for the t = 1 case via the 2D kissing number argument.",
     "implications": "A positive resolution would establish the triangular lattice as the universal extremal configuration for short-range pair interactions in 2D, extending Thue's packing density result to a counting statement. This has applications in crystallography (optimal coordination), statistical mechanics (hard-disk models), and coding theory (optimal point configurations).",
     "openQuestions": [
-      "Can the conjecture be proved for the second shell t = \u221a3, which requires bounding the number of pairs at distance \u2264 \u221a3 by 6n?",
+      "Can the conjecture be proved for the second shell t = √3, which requires bounding the number of pairs at distance ≤ √3 by 6n?",
       "Is the triangular lattice the unique maximizer (up to boundary effects and isometries), or do other configurations achieve the same pair count?",
-      "Does an analogous result hold in \u211d\u00b3 for the FCC or HCP lattice?",
+      "Does an analogous result hold in ℝ³ for the FCC or HCP lattice?",
       "Can the Loeschian form connection to Eisenstein integers yield an algebraic proof for specific values of t?"
     ]
   },
   "references": [
-    "Erd\u0151s, Lov\u00e1sz & Vesztergombi (1997): Problems and results on the grid",
-    "Thue (1910): \u00dcber die dichteste Zusammenstellung von kongruenten Kreisen in einer Ebene",
-    "Fejes T\u00f3th (1940): \u00dcber einen geometrischen Satz",
-    "Harborth (1974): L\u00f6sung zu Problem 664A (contact number formula)",
+    "Erdős, Lovász & Vesztergombi (1997): Problems and results on the grid",
+    "Thue (1910): Über die dichteste Zusammenstellung von kongruenten Kreisen in einer Ebene",
+    "Fejes Tóth (1940): Über einen geometrischen Satz",
+    "Harborth (1974): Lösung zu Problem 664A (contact number formula)",
     "Swanepoel (2009): Combinatorial distance geometry in normed spaces",
     "https://erdosproblems.com/662"
   ],
@@ -153,7 +153,7 @@
     "lineCount": 375,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 19,
     "lemmaCount": 10,
     "defCount": 12,
     "imports": [
@@ -169,23 +169,24 @@
       "Classical"
     ],
     "path": "Proofs/Erdos662Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 10
   },
   "crossReferences": [
     {
       "targetId": "erdos-103",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: distances, open, packing"
+      "description": "Related Erdős problem sharing themes: distances, open, packing"
     },
     {
       "targetId": "erdos-1084",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorial-geometry, open, packing"
+      "description": "Related Erdős problem sharing themes: combinatorial-geometry, open, packing"
     },
     {
       "targetId": "erdos-1087",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorial-geometry, distances, open"
+      "description": "Related Erdős problem sharing themes: combinatorial-geometry, distances, open"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -196,7 +196,7 @@
     "lineCount": 515,
     "axiomCount": 4,
     "theoremCount": 36,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "path": "Proofs/Erdos667Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -203,7 +203,7 @@
     "lineCount": 282,
     "axiomCount": 3,
     "theoremCount": 14,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos668Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-669/meta.json
+++ b/src/data/proofs/erdos-669/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-669",
-  "title": "Erd\u0151s Problem #669: k-Point Lines and the Orchard Problem",
+  "title": "Erdős Problem #669: k-Point Lines and the Orchard Problem",
   "slug": "erdos-669",
-  "description": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R\u00b2. For k=3, the Orchard Problem: f_3(n) = F_3(n) = n\u00b2/6 - O(n) (Burr-Gr\u00fcnbaum-Sloane 1974). General k remains open.",
+  "description": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R². For k=3, the Orchard Problem: f_3(n) = F_3(n) = n²/6 - O(n) (Burr-Grünbaum-Sloane 1974). General k remains open.",
   "meta": {
-    "author": "Burr-Gr\u00fcnbaum-Sloane (1974, k=3 case)",
+    "author": "Burr-Grünbaum-Sloane (1974, k=3 case)",
     "sourceUrl": "https://erdosproblems.com/669",
     "date": "1974",
     "status": "axiomatized",
@@ -58,17 +58,17 @@
     "assumptions": "1 axiom: k3_limit. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erd\u0151s Problem #669** concerns the maximum number of lines determined by point configurations in the plane, measured by how many points lie on each line. Two functions are studied: f_k(n) counts lines through exactly k points, while F_k(n) counts lines through at least k points. The problem asks for the asymptotic behavior of both as n grows.\n\nThe most celebrated special case is the **Orchard Problem** (k=3), which goes back to Sylvester in the 19th century: how many 3-point lines can n points determine? Burr, Gr\u00fcnbaum, and Sloane resolved this in their 1974 paper, proving that both f_3(n) and F_3(n) equal n\u00b2/6 up to an O(n) error term. Their proof uses elegant constructions from finite projective planes.\n\nFor general k, a trivial upper bound comes from double counting: each line with \u2265 k points accounts for at least C(k,2) point-pairs, and there are only C(n,2) pairs total. This gives F_k(n) \u2264 C(n,2)/C(k,2), or asymptotically F_k(n)/n\u00b2 \u2264 1/(k(k-1)). Whether this bound is tight for all k remains an open problem. The conjecture is that lim f_k(n)/n\u00b2 = lim F_k(n)/n\u00b2 = 1/(k(k-1)) for all k \u2265 2.",
+    "historicalContext": "**Erdős Problem #669** concerns the maximum number of lines determined by point configurations in the plane, measured by how many points lie on each line. Two functions are studied: f_k(n) counts lines through exactly k points, while F_k(n) counts lines through at least k points. The problem asks for the asymptotic behavior of both as n grows.\n\nThe most celebrated special case is the **Orchard Problem** (k=3), which goes back to Sylvester in the 19th century: how many 3-point lines can n points determine? Burr, Grünbaum, and Sloane resolved this in their 1974 paper, proving that both f_3(n) and F_3(n) equal n²/6 up to an O(n) error term. Their proof uses elegant constructions from finite projective planes.\n\nFor general k, a trivial upper bound comes from double counting: each line with ≥ k points accounts for at least C(k,2) point-pairs, and there are only C(n,2) pairs total. This gives F_k(n) ≤ C(n,2)/C(k,2), or asymptotically F_k(n)/n² ≤ 1/(k(k-1)). Whether this bound is tight for all k remains an open problem. The conjecture is that lim f_k(n)/n² = lim F_k(n)/n² = 1/(k(k-1)) for all k ≥ 2.",
     "problemStatement": "**Problem Statement (Open)**\n\nLet $f_k(n)$ = maximum number of lines through exactly $k$ points of any $n$-point set in $\\mathbb{R}^2$.\nLet $F_k(n)$ = maximum number of lines through at least $k$ points.\n\n**Determine:** $\\lim_{n \\to \\infty} f_k(n)/n^2$ and $\\lim_{n \\to \\infty} F_k(n)/n^2$.\n\n**Known:**\n- $k=2$: $f_2(n) = F_2(n) = \\binom{n}{2}$\n- $k=3$ (Orchard Problem): $f_3(n) = F_3(n) = n^2/6 - O(n)$ (SOLVED, BGS 1974)\n- Upper bound: $F_k(n) \\leq \\binom{n}{2}/\\binom{k}{2}$\n\n**Conjecture:** Both limits equal $\\frac{1}{k(k-1)}$ for all $k \\geq 2$.",
-    "text": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R\u00b2. For k=3, the Orchard Problem: f_3(n) = F_3(n) = n\u00b2/6 - O(n) (Burr-Gr\u00fcnbaum-Sloane 1974). General k remains open.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Geometry:** Define Point (R\u00b2), Line (ax+by=c), OnLine, pointsOnLine.\n2. **Counting Functions:** Define f_k (exactly k) and F_k (at least k) using sSup.\n3. **Orchard Problem:** Axiomatize the BGS theorem for k=3 with explicit error bounds.\n4. **Limits:** State the k=3 asymptotic limit as 1/6.\n5. **Upper Bounds:** Axiomatize the trivial bound F_k \u2264 C(n,2)/C(k,2).\n6. **Conjecture:** Define the 1/(k(k-1)) conjecture; prove it holds for k=3.\n7. **Summary:** The k=3 case is fully proved from axioms.",
+    "text": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R². For k=3, the Orchard Problem: f_3(n) = F_3(n) = n²/6 - O(n) (Burr-Grünbaum-Sloane 1974). General k remains open.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Geometry:** Define Point (R²), Line (ax+by=c), OnLine, pointsOnLine.\n2. **Counting Functions:** Define f_k (exactly k) and F_k (at least k) using sSup.\n3. **Orchard Problem:** Axiomatize the BGS theorem for k=3 with explicit error bounds.\n4. **Limits:** State the k=3 asymptotic limit as 1/6.\n5. **Upper Bounds:** Axiomatize the trivial bound F_k ≤ C(n,2)/C(k,2).\n6. **Conjecture:** Define the 1/(k(k-1)) conjecture; prove it holds for k=3.\n7. **Summary:** The k=3 case is fully proved from axioms.",
     "keyInsights": [
       "**The Orchard Problem:** Sylvester's classical question of how many 3-point lines n points can determine, solved by BGS (1974).",
       "**Two Functions:** f_k counts 'exactly k' lines while F_k counts 'at least k' - they agree asymptotically for k=3.",
-      "**Double Counting Bound:** F_k(n) \u2264 C(n,2)/C(k,2) from the pigeonhole principle on point-pairs.",
-      "**k=3 Limit:** Both f_3(n)/n\u00b2 and F_3(n)/n\u00b2 tend to 1/6 as n \u2192 \u221e.",
+      "**Double Counting Bound:** F_k(n) ≤ C(n,2)/C(k,2) from the pigeonhole principle on point-pairs.",
+      "**k=3 Limit:** Both f_3(n)/n² and F_3(n)/n² tend to 1/6 as n → ∞.",
       "**Projective Plane Constructions:** Optimal configurations for k=3 come from points of PG(2,q).",
-      "**General k Open:** Whether the limit equals 1/(k(k-1)) for k \u2265 4 remains one of the main open questions in discrete geometry."
+      "**General k Open:** Whether the limit equals 1/(k(k-1)) for k ≥ 4 remains one of the main open questions in discrete geometry."
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -120,11 +120,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #669 asks for the asymptotic behavior of f_k(n) (exactly k-point lines) and F_k(n) (at least k-point lines). The k=3 case is the famous Orchard Problem, solved by Burr-Gr\u00fcnbaum-Sloane (1974): both functions equal n\u00b2/6 - O(n). The general conjecture is that both limits equal 1/(k(k-1)).",
-    "implications": "The Orchard Problem connects to fundamental questions in discrete geometry and combinatorics. Optimal configurations relate to finite projective planes, and the counting functions connect to the Szemer\u00e9di-Trotter incidence theorem.",
+    "summary": "Erdős Problem #669 asks for the asymptotic behavior of f_k(n) (exactly k-point lines) and F_k(n) (at least k-point lines). The k=3 case is the famous Orchard Problem, solved by Burr-Grünbaum-Sloane (1974): both functions equal n²/6 - O(n). The general conjecture is that both limits equal 1/(k(k-1)).",
+    "implications": "The Orchard Problem connects to fundamental questions in discrete geometry and combinatorics. Optimal configurations relate to finite projective planes, and the counting functions connect to the Szemerédi-Trotter incidence theorem.",
     "openQuestions": [
-      "Is lim f_k(n)/n\u00b2 = 1/(k(k-1)) for all k \u2265 4?",
-      "Is lim F_k(n)/n\u00b2 = 1/(k(k-1)) for all k \u2265 4?",
+      "Is lim f_k(n)/n² = 1/(k(k-1)) for all k ≥ 4?",
+      "Is lim F_k(n)/n² = 1/(k(k-1)) for all k ≥ 4?",
       "What point configurations achieve the maximum for general k?",
       "How does the problem generalize to higher dimensions?"
     ]
@@ -146,14 +146,14 @@
     "lineCount": 128,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos669Problem.lean",
     "sorries": 0
   },
   "references": [
     {
       "key": "BGS74",
-      "citation": "Burr, S.A., Gr\u00fcnbaum, B., Sloane, N.J.A., The orchard problem, Geom. Dedicata 2 (1974), 397-424",
+      "citation": "Burr, S.A., Grünbaum, B., Sloane, N.J.A., The orchard problem, Geom. Dedicata 2 (1974), 397-424",
       "type": "paper"
     }
   ],
@@ -161,12 +161,12 @@
     {
       "targetId": "erdos-588",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, incidences, point-line"
+      "description": "Related Erdős problem sharing themes: discrete-geometry, incidences, point-line"
     },
     {
       "targetId": "erdos-104",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, incidences"
+      "description": "Related Erdős problem sharing themes: discrete-geometry, incidences"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -147,7 +147,7 @@
     "lineCount": 249,
     "axiomCount": 3,
     "theoremCount": 14,
-    "definitionCount": 0,
+    "definitionCount": 10,
     "sorries": 23,
     "path": "Proofs/Erdos671Problem.lean"
   },

--- a/src/data/proofs/erdos-675/meta.json
+++ b/src/data/proofs/erdos-675/meta.json
@@ -132,7 +132,7 @@
     "lineCount": 134,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 9,
+    "definitionCount": 13,
     "path": "Proofs/Erdos675Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-678",
-  "title": "Erd\u0151s Problem #678: LCM of Consecutive Integers",
+  "title": "Erdős Problem #678: LCM of Consecutive Integers",
   "slug": "erdos-678",
   "description": "Can a shorter interval of consecutive integers have larger LCM than a longer interval starting later? Yes! Solved by Cambie (2024) with Lean proof.",
   "meta": {
-    "author": "Erd\u0151s (1979), solved by Cambie (2024)",
+    "author": "Erdős (1979), solved by Cambie (2024)",
     "sourceUrl": "https://erdosproblems.com/678",
     "date": "1979",
     "status": "formalized",
@@ -52,7 +52,7 @@
     "relatedProblems": [
       {
         "id": "erdos-646",
-        "relationship": "Related Erd\u0151s problem on factorial divisibility and prime power structure"
+        "relationship": "Related Erdős problem on factorial divisibility and prime power structure"
       }
     ],
     "axiomCount": 0,
@@ -69,16 +69,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erd\u0151s posed this problem in 1979, asking a counterintuitive question: can a shorter interval of consecutive integers have a larger LCM than a longer interval starting further along?\n\nThe referee of the 1979 paper (later identified as John Selfridge) immediately found examples: M(96,7) > M(104,8). The full answer\u2014infinitely many such comparisons\u2014was proved by Stijn Cambie in 2024, with a Lean-verified proof showing that for all sufficiently large k, such pairs exist. The phenomenon is driven by the distribution of prime powers: the LCM of an interval is essentially determined by which prime powers it contains, and an interval that captures a large prime power (such as 2^7 = 128) can have a much larger LCM than a slightly longer interval that misses it. Chebyshev's classical estimates show log M(n,k) \u2248 k, making the precise combinatorics of prime power placement critical.",
-    "problemStatement": "Let M(n,k) = lcm{n+1, n+2, ..., n+k} be the LCM of k consecutive integers starting at n+1.\n\n**Question:** Are there infinitely many triples (m, n, k) with k \u2265 3 and m \u2265 n+k such that M(n,k) > M(m,k+1)?\n\n**Answer:** YES (Cambie 2024)",
+    "historicalContext": "Erdős posed this problem in 1979, asking a counterintuitive question: can a shorter interval of consecutive integers have a larger LCM than a longer interval starting further along?\n\nThe referee of the 1979 paper (later identified as John Selfridge) immediately found examples: M(96,7) > M(104,8). The full answer—infinitely many such comparisons—was proved by Stijn Cambie in 2024, with a Lean-verified proof showing that for all sufficiently large k, such pairs exist. The phenomenon is driven by the distribution of prime powers: the LCM of an interval is essentially determined by which prime powers it contains, and an interval that captures a large prime power (such as 2^7 = 128) can have a much larger LCM than a slightly longer interval that misses it. Chebyshev's classical estimates show log M(n,k) ≈ k, making the precise combinatorics of prime power placement critical.",
+    "problemStatement": "Let M(n,k) = lcm{n+1, n+2, ..., n+k} be the LCM of k consecutive integers starting at n+1.\n\n**Question:** Are there infinitely many triples (m, n, k) with k ≥ 3 and m ≥ n+k such that M(n,k) > M(m,k+1)?\n\n**Answer:** YES (Cambie 2024)",
     "text": "Can a shorter interval of consecutive integers have larger LCM than a longer interval starting later? Yes! Solved by Cambie (2024) with Lean proof.",
     "proofStrategy": "The formalization:\n\n1. Defines `intervalLcm n k` computing lcm{n+1,...,n+k}\n2. Verifies Selfridge's examples computationally via `native_decide`\n3. States Cambie's theorem: for large k, such comparisons always exist\n4. Develops supporting theory on prime power divisibility\n\nThe key insight: intervals can 'skip' prime powers, dramatically affecting their LCM.",
     "keyInsights": [
-      "**Selfridge Examples:** M(96,7) = 1,073,741,700 > M(104,8) = 786,145,080 \u2014 verified computationally!",
+      "**Selfridge Examples:** M(96,7) = 1,073,741,700 > M(104,8) = 786,145,080 — verified computationally!",
       "**Prime Power Effect:** An interval containing 2^7 = 128 has LCM divisible by 128, but nearby intervals may only need 2^6.",
       "**Cambie's Theorem (2024):** For all sufficiently large k, there exist n,m with M(n,k) > M(m,k+1).",
-      "**Growth Rate:** Erd\u0151s proved n_k/k \u2192 \u221e where n_k is the minimal n for which the comparison holds.",
-      "**Counterintuition:** More numbers \u2260 larger LCM. The starting position matters crucially."
+      "**Growth Rate:** Erdős proved n_k/k → ∞ where n_k is the minimal n for which the comparison holds.",
+      "**Counterintuition:** More numbers ≠ larger LCM. The starting position matters crucially."
     ],
     "prerequisites": [
       "Least common multiple (LCM) of natural numbers",
@@ -92,31 +92,31 @@
   "sections": [
     {
       "id": "interval-lcm-defs",
-      "title": "\u00a71: Interval LCM Definitions and Basic Properties",
+      "title": "§1: Interval LCM Definitions and Basic Properties",
       "startLine": 40,
       "endLine": 95,
       "summary": "Defines intervalLcm n k = lcm{n+1,...,n+k} and equivalent form intervalLcm'. Proves intervalLcm_eq_intervalLcm', intervalLcm_zero (lcm of empty = 1), intervalLcm_one, intervalLcm_mono_right (monotone in k), and dvd_intervalLcm (every element divides the lcm).",
-      "mathContext": "$\\text{lcm}(n+1, n+2, \\ldots, n+k) = \\prod_{p^a \\leq k} p^{\\lfloor \\log_p(n+k) \\rfloor - \\lfloor \\log_p n \\rfloor}$. The Chebyshev function gives $\\text{lcm}(1,\\ldots,n) \\approx e^n$ (prime number theorem). For shifted intervals, the lcm depends on which prime powers land in the interval \u2014 a number-theoretic question at the heart of this problem."
+      "mathContext": "$\\text{lcm}(n+1, n+2, \\ldots, n+k) = \\prod_{p^a \\leq k} p^{\\lfloor \\log_p(n+k) \\rfloor - \\lfloor \\log_p n \\rfloor}$. The Chebyshev function gives $\\text{lcm}(1,\\ldots,n) \\approx e^n$ (prime number theorem). For shifted intervals, the lcm depends on which prime powers land in the interval — a number-theoretic question at the heart of this problem."
     },
     {
       "id": "selfridge-examples",
-      "title": "\u00a72: Selfridge's Examples and the Comparison Predicate",
+      "title": "§2: Selfridge's Examples and the Comparison Predicate",
       "startLine": 97,
       "endLine": 128,
       "summary": "Defines erdosLcmComparison n m k: lcm{n+1,...,n+k} > lcm{m+1,...,m+k+1}. Verifies Selfridge's two concrete examples: lcm(97,...,103) > lcm(105,...,112) and lcm(133,...,139) > lcm(140,...,147). Both by native_decide. States erdos_678_infinitely_many (infinitely many such n, m) as an axiom.",
-      "mathContext": "Selfridge observed that $\\text{lcm}(97,\\ldots,103) > \\text{lcm}(105,\\ldots,112)$ despite the second interval being longer \u2014 a $k$-element interval can have larger lcm than a $(k+1)$-element interval starting later. This counterintuitive comparison arises when the longer interval contains no additional prime powers beyond those in the shorter interval, but the shorter one includes a larger prime."
+      "mathContext": "Selfridge observed that $\\text{lcm}(97,\\ldots,103) > \\text{lcm}(105,\\ldots,112)$ despite the second interval being longer — a $k$-element interval can have larger lcm than a $(k+1)$-element interval starting later. This counterintuitive comparison arises when the longer interval contains no additional prime powers beyond those in the shorter interval, but the shorter one includes a larger prime."
     },
     {
       "id": "cambie-theorem",
-      "title": "\u00a73: Cambie's Theorem and Technical Bounds",
+      "title": "§3: Cambie's Theorem and Technical Bounds",
       "startLine": 129,
       "endLine": 167,
-      "summary": "Axiomatizes cambie_2024: for all sufficiently large k, any k-element interval has smaller lcm than some (k+1)-element interval \u2014 the exact content of Erd\u0151s's 1978 question. Proves prime_power_divides_intervalLcm, interval_skip_prime_power, intervalLcm_growth (lcm grows at least exponentially), and intervalLcm_chebyshev_upper bound.",
-      "mathContext": "Cambie (2024) proved that for large $k$, there always exists $n$ with $\\text{lcm}(n+1,\\ldots,n+k) > \\text{lcm}(m+1,\\ldots,m+k+1)$ for some $m$ \u2014 resolving Erd\u0151s's question. The key tool is the Chebyshev upper bound $\\text{lcm}(n+1,\\ldots,n+k) \\leq e^{2.000733k}$ and explicit prime power distribution in short intervals."
+      "summary": "Axiomatizes cambie_2024: for all sufficiently large k, any k-element interval has smaller lcm than some (k+1)-element interval — the exact content of Erdős's 1978 question. Proves prime_power_divides_intervalLcm, interval_skip_prime_power, intervalLcm_growth (lcm grows at least exponentially), and intervalLcm_chebyshev_upper bound.",
+      "mathContext": "Cambie (2024) proved that for large $k$, there always exists $n$ with $\\text{lcm}(n+1,\\ldots,n+k) > \\text{lcm}(m+1,\\ldots,m+k+1)$ for some $m$ — resolving Erdős's question. The key tool is the Chebyshev upper bound $\\text{lcm}(n+1,\\ldots,n+k) \\leq e^{2.000733k}$ and explicit prime power distribution in short intervals."
     },
     {
       "id": "growth-rate",
-      "title": "\u00a74: Growth Rate and the Main Theorem",
+      "title": "§4: Growth Rate and the Main Theorem",
       "startLine": 169,
       "endLine": 187,
       "summary": "Defines minimalN k as the smallest n where the comparison holds for all k-element intervals. Axiomatizes erdos_growth_rate: minimalN k grows superlinearly. Proves erdos_678 (existence) from the Selfridge examples. Wraps up with the complete formalization of the LCM comparison problem.",
@@ -124,16 +124,16 @@
     },
     {
       "id": "open-questions-678",
-      "title": "\u00a75: Open Questions on Interval LCM Comparisons",
+      "title": "§5: Open Questions on Interval LCM Comparisons",
       "startLine": 126,
       "endLine": 187,
       "summary": "The formalization captures the full state: Selfridge examples (verified), Cambie's theorem (axiomatized), growth rate (axiomatized). Open: what is the exact growth rate of N(k)? Can the first comparison be found for k=6 or smaller? What is the density of n where such comparisons occur?",
-      "mathContext": "Beyond Cambie's qualitative result, quantitative questions remain: How large must the starting index $n$ be? How often does the comparison $\\text{lcm}(n+1,\\ldots,n+k) > \\text{lcm}(m+1,\\ldots,m+k+1)$ hold for random $n,m$? These connect to the distribution of prime powers in short intervals \u2014 a topic at the frontier of analytic number theory."
+      "mathContext": "Beyond Cambie's qualitative result, quantitative questions remain: How large must the starting index $n$ be? How often does the comparison $\\text{lcm}(n+1,\\ldots,n+k) > \\text{lcm}(m+1,\\ldots,m+k+1)$ hold for random $n,m$? These connect to the distribution of prime powers in short intervals — a topic at the frontier of analytic number theory."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #678 asks whether a shorter interval can have larger LCM than a longer one starting later. The answer is YES: Selfridge found concrete examples in 1979, and Cambie proved infinitely many exist in 2024. Our formalization verifies specific examples computationally and states the main theoretical results.",
-    "implications": "**Theoretical Significance**: This problem connects to:\n\n1. **Prime distribution:** Intervals containing prime powers have structured LCMs\n**2. Smooth numbers:** Intervals avoiding large primes have smaller LCMs\n3. **Computational number theory:** LCM computations are tractable for moderate intervals\n4. **Chebyshev bounds:** The growth rate log M(n,k) \u2248 k uses prime-counting estimates.",
+    "summary": "Erdős Problem #678 asks whether a shorter interval can have larger LCM than a longer one starting later. The answer is YES: Selfridge found concrete examples in 1979, and Cambie proved infinitely many exist in 2024. Our formalization verifies specific examples computationally and states the main theoretical results.",
+    "implications": "**Theoretical Significance**: This problem connects to:\n\n1. **Prime distribution:** Intervals containing prime powers have structured LCMs\n**2. Smooth numbers:** Intervals avoiding large primes have smaller LCMs\n3. **Computational number theory:** LCM computations are tractable for moderate intervals\n4. **Chebyshev bounds:** The growth rate log M(n,k) ≈ k uses prime-counting estimates.",
     "openQuestions": [
       "Find the exact threshold K where Cambie's theorem applies",
       "Characterize all (n,m,k) triples satisfying the comparison",
@@ -144,7 +144,7 @@
   "references": [
     {
       "authors": "Cambie, Stijn",
-      "title": "On a problem of Erd\u0151s about the LCM of consecutive integers",
+      "title": "On a problem of Erdős about the LCM of consecutive integers",
       "year": "2024",
       "venue": "arXiv preprint",
       "note": "Proved infinitely many examples exist where shorter intervals have larger LCM"
@@ -159,7 +159,7 @@
     {
       "targetId": "lagrange-theorem",
       "relationship": "foundational",
-      "description": "Lagrange's theorem on subgroup orders constrains the LCM of divisors studied in Problem #678. The LCM of a set of integers is governed by their prime factorizations, and Lagrange's theorem provides structural constraints on how these factorizations interact within the multiplicative group (\u2124/n\u2124)\u00d7"
+      "description": "Lagrange's theorem on subgroup orders constrains the LCM of divisors studied in Problem #678. The LCM of a set of integers is governed by their prime factorizations, and Lagrange's theorem provides structural constraints on how these factorizations interact within the multiplicative group (ℤ/nℤ)×"
     }
   ],
   "leanFile": {
@@ -169,7 +169,7 @@
     "lineCount": 236,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 0,
+    "definitionCount": 4,
     "sorries": 4,
     "path": "Proofs/Erdos678Problem.lean"
   },

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -215,7 +215,7 @@
     "lineCount": 357,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos682Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -176,7 +176,7 @@
     "lineCount": 401,
     "axiomCount": 2,
     "theoremCount": 12,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos684Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -213,7 +213,7 @@
     "lineCount": 293,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos686Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.definitionCount` and `leanFile.theoremCount` in meta.json for 62 proofs (erdos-455 to erdos-686).

## Evidence

**Before**: Counts were stale from prior Lean source edits that didn't update gallery JSON.
**After**: Counts re-derived via grep over actual Lean source files, including `@[simp]`-tagged and noncomputable/private/protected variants.

Part of systematic gallery metadata integrity scan (batches 9–15).

---
Automated fix by lean-mechanic agent.