### PR TITLE
fix(meta): sync leanFile.definitionCount/theoremCount for 7 proofs (batch 16)

### DIFF
--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -140,7 +140,9 @@
     "namespace": "Erdos701",
     "lineCount": 284,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 8,
+    "theoremCount": 7
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-706/meta.json
+++ b/src/data/proofs/erdos-706/meta.json
@@ -151,7 +151,7 @@
     "lineCount": 71,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "path": "Proofs/Erdos706Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-725/meta.json
+++ b/src/data/proofs/erdos-725/meta.json
@@ -101,7 +101,9 @@
       "ExtendedConjecture"
     ],
     "axiomCount": 3,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 10,
+    "theoremCount": 1
   },
   "overview": {
     "historicalContext": "A $k \\times n$ Latin rectangle is a $k \\times n$ array filled with $n$ symbols such that each symbol appears exactly once per row and at most once per column. When $k = n$, this is a Latin square — objects studied since Euler's work on the 36 officers problem (1782).\n\nThe enumeration of Latin rectangles began with Euler and was pursued systematically in the 20th century. Erdős and Kaplansky (1946) proved the first asymptotic formula: $L(k,n) \\sim e^{-\\binom{k}{2}} (n!)^k$ when $k = o((\\log n)^{3/2-\\varepsilon})$. Their proof used a careful inclusion-exclusion sieve over column collision events, counting the expected number of repeated entries in any column and showing the higher-order correction terms vanish in this regime.\n\nYamamoto (1951) dramatically extended the validity of this formula to $k \\leq n^{1/3-o(1)}$, improving the growth from logarithmic to polynomial. This extension required refined estimates on the permanent of certain 0-1 matrices.\n\nGodsil and McKay (1990) connected Latin rectangle counting to matrix permanents, establishing two-sided bounds $c_1 \\cdot e^{-\\binom{k}{2}}(n!)^k \\leq L(k,n) \\leq c_2 \\cdot e^{-\\binom{k}{2}}(n!)^k$. Their work leveraged the resolution of van der Waerden's permanent conjecture by Egorychev (1981) and Falikman (1981). McKay and Wanless (2005) later extended the asymptotic to $k = o(n^{6/7})$, the current frontier. The full problem for $k = \\Theta(n)$ remains open.",

--- a/src/data/proofs/erdos-726/meta.json
+++ b/src/data/proofs/erdos-726/meta.json
@@ -148,7 +148,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos726Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 6
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-733/meta.json
+++ b/src/data/proofs/erdos-733/meta.json
@@ -190,7 +190,7 @@
     "lineCount": 274,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos733Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -167,7 +167,7 @@
     "lineCount": 420,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos738Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-747/meta.json
+++ b/src/data/proofs/erdos-747/meta.json
@@ -198,7 +198,7 @@
     "lineCount": 313,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/Erdos747Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.definitionCount` and `leanFile.theoremCount` for 7 proofs in the erdos-687–750 range, closing the coverage gap between batch-15 and batch-9.

## Evidence

**Before**: Counts were stale (some at 0 due to missing initial population).
**After**: Counts re-derived from grep over Lean source files.

Affected: erdos-701, erdos-706, erdos-725, erdos-726, erdos-733, erdos-738, erdos-747.

---
Automated fix by lean-mechanic agent.