### PR TITLE
fix(meta): sync leanFile.definitionCount/theoremCount for 29 proofs (batch 17)

### DIFF
--- a/src/data/proofs/erdos-752/meta.json
+++ b/src/data/proofs/erdos-752/meta.json
@@ -160,7 +160,7 @@
     "lineCount": 206,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos752Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -225,7 +225,7 @@
     "lineCount": 268,
     "axiomCount": 5,
     "theoremCount": 8,
-    "definitionCount": 15,
+    "definitionCount": 17,
     "path": "Proofs/Erdos756Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -127,7 +127,7 @@
     "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos761Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-766/meta.json
+++ b/src/data/proofs/erdos-766/meta.json
@@ -222,7 +222,7 @@
     "lineCount": 181,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos766Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-767/meta.json
+++ b/src/data/proofs/erdos-767/meta.json
@@ -163,7 +163,7 @@
     "lineCount": 193,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos767Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-775/meta.json
+++ b/src/data/proofs/erdos-775/meta.json
@@ -189,7 +189,7 @@
     "lineCount": 281,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos775Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -212,7 +212,7 @@
     "lineCount": 221,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 12,
+    "definitionCount": 11,
     "path": "Proofs/Erdos780Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -204,7 +204,7 @@
     "lineCount": 265,
     "axiomCount": 5,
     "theoremCount": 6,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos781Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -130,8 +130,8 @@
     "namespace": "Erdos783",
     "lineCount": 392,
     "axiomCount": 0,
-    "theoremCount": 30,
-    "definitionCount": 7,
+    "theoremCount": 31,
+    "definitionCount": 5,
     "path": "Proofs/Erdos783Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-809/meta.json
+++ b/src/data/proofs/erdos-809/meta.json
@@ -149,7 +149,7 @@
     "lineCount": 186,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos809Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-810/meta.json
+++ b/src/data/proofs/erdos-810/meta.json
@@ -161,7 +161,7 @@
     "lineCount": 213,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "path": "Proofs/Erdos810Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-826/meta.json
+++ b/src/data/proofs/erdos-826/meta.json
@@ -183,7 +183,9 @@
     "namespace": "Erdos826",
     "lineCount": 320,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 11,
+    "theoremCount": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-830/meta.json
+++ b/src/data/proofs/erdos-830/meta.json
@@ -154,7 +154,7 @@
     "lineCount": 142,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/Erdos830Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -187,7 +187,7 @@
     "lineCount": 712,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 17,
+    "definitionCount": 13,
     "path": "Proofs/Erdos831Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-837/meta.json
+++ b/src/data/proofs/erdos-837/meta.json
@@ -160,7 +160,8 @@
     ],
     "opens": [],
     "path": "Proofs/Erdos837Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 4
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-839/meta.json
+++ b/src/data/proofs/erdos-839/meta.json
@@ -149,7 +149,7 @@
     "lineCount": 255,
     "axiomCount": 1,
     "theoremCount": 14,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos839Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -138,7 +138,7 @@
     "lineCount": 247,
     "axiomCount": 3,
     "theoremCount": 25,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "path": "Proofs/Erdos852Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-853/meta.json
+++ b/src/data/proofs/erdos-853/meta.json
@@ -154,7 +154,7 @@
     "lineCount": 523,
     "axiomCount": 4,
     "theoremCount": 33,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "path": "Proofs/Erdos853Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-856",
-  "title": "Erd\u0151s Problem #856: LCM-Free Sets and Logarithmic Density",
+  "title": "Erdős Problem #856: LCM-Free Sets and Logarithmic Density",
   "slug": "erdos-856",
   "description": "Estimate f_k(N), the maximum harmonic sum of subsets of {1,...,N} with no k elements having uniform pairwise LCM. Status: OPEN. Bounds relate to sunflower conjecture.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/856",
     "date": "1970",
     "status": "axiomatized",
@@ -28,15 +28,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erd\u0151s posed this problem in 1970 in his paper 'Some extremal problems in combinatorial number theory' dedicated to A. J. Macintyre, asking for the maximum harmonic sum of subsets of $\\{1, \\ldots, N\\}$ that avoid $k$ elements with uniform pairwise LCM. The uniform pairwise LCM condition means every distinct pair $(a, b)$ in the forbidden subset has $\\text{lcm}(a, b) = t$ for the same $t$. Erd\u0151s proved $f_k(N) \\ll \\log N / \\log\\log N$ using the observation that for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has size $< k$. The problem lay dormant for decades until Tang and Zhang (2025) made significant progress, proving $(\\log N)^{b_k} \\leq f_k(N) \\leq (\\log N)^{c_k}$ for explicit constants $0 < b_k \\leq c_k \\leq 1$, and establishing for $k = 3$ the bounds $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$. The deep connection to the sunflower conjecture \u2014 proved via the Erd\u0151s\u2013Ko\u2013Rado theorem and its LCM analogues \u2014 shows that $c_k < 1$ if and only if the sunflower conjecture holds for $k$-sunflowers. The sunflower lemma of Erd\u0151s and Rado (1960) gives $c_k \\leq 1$, while the conjecture would improve this to $c_k < 1$. Alweiss, Lovett, Wu, and Zhang (2021) made a breakthrough on the sunflower conjecture, which has implications for the upper bound exponents here.",
+    "historicalContext": "Erdős posed this problem in 1970 in his paper 'Some extremal problems in combinatorial number theory' dedicated to A. J. Macintyre, asking for the maximum harmonic sum of subsets of $\\{1, \\ldots, N\\}$ that avoid $k$ elements with uniform pairwise LCM. The uniform pairwise LCM condition means every distinct pair $(a, b)$ in the forbidden subset has $\\text{lcm}(a, b) = t$ for the same $t$. Erdős proved $f_k(N) \\ll \\log N / \\log\\log N$ using the observation that for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has size $< k$. The problem lay dormant for decades until Tang and Zhang (2025) made significant progress, proving $(\\log N)^{b_k} \\leq f_k(N) \\leq (\\log N)^{c_k}$ for explicit constants $0 < b_k \\leq c_k \\leq 1$, and establishing for $k = 3$ the bounds $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$. The deep connection to the sunflower conjecture — proved via the Erdős–Ko–Rado theorem and its LCM analogues — shows that $c_k < 1$ if and only if the sunflower conjecture holds for $k$-sunflowers. The sunflower lemma of Erdős and Rado (1960) gives $c_k \\leq 1$, while the conjecture would improve this to $c_k < 1$. Alweiss, Lovett, Wu, and Zhang (2021) made a breakthrough on the sunflower conjecture, which has implications for the upper bound exponents here.",
     "problemStatement": "Let $k \\geq 3$ and $f_k(N)$ be the maximum value of $\\sum_{n \\in A} 1/n$, where $A$ ranges over all subsets of $\\{1, \\ldots, N\\}$ containing no subset of size $k$ with the same pairwise least common multiple. Estimate $f_k(N)$.",
     "text": "Estimate f_k(N), the maximum harmonic sum of subsets of {1,...,N} with no k elements having uniform pairwise LCM. Status: OPEN. Bounds relate to sunflower conjecture.",
-    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erd\u0151s's 1970 upper bound and Tang\u2013Zhang's 2025 improved bounds are axiomatized. The sunflower conjecture connection is formalized as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two results are proved in Lean: LCM commutativity and the divisor set LCM property.",
+    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erdős's 1970 upper bound and Tang–Zhang's 2025 improved bounds are axiomatized. The sunflower conjecture connection is formalized as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two results are proved in Lean: LCM commutativity and the divisor set LCM property.",
     "keyInsights": [
       "**Harmonic vs. natural density**: The problem measures $f_k(N) = \\max \\sum 1/n$ (logarithmic density) rather than $\\max |A|$ (natural density). This is subtler: for $k \\geq 4$, sets of linear size can avoid the LCM condition, but the harmonic sum is bounded.",
-      "**Erd\u0151s's prime factorization trick**: For each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements (else $k$ elements have $\\text{lcm} = t$). Summing over primes dividing elements of $A$ yields $f_k(N) \\ll \\log N / \\log\\log N$.",
-      "**Tang\u2013Zhang breakthrough (2025)**: Improved Erd\u0151s's bound from $\\log N / \\log\\log N$ to $(\\log N)^{c_k}$ with $c_k \\leq 1$. For $k = 3$: exponents between $0.438$ and $0.889$, leaving a significant gap.",
-      "**Sunflower equivalence**: The upper bound exponent $c_k < 1$ holds if and only if the Erd\u0151s\u2013Rado sunflower conjecture holds for $k$-petalled sunflowers. This connects a number-theoretic problem to a purely set-theoretic conjecture.",
+      "**Erdős's prime factorization trick**: For each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements (else $k$ elements have $\\text{lcm} = t$). Summing over primes dividing elements of $A$ yields $f_k(N) \\ll \\log N / \\log\\log N$.",
+      "**Tang–Zhang breakthrough (2025)**: Improved Erdős's bound from $\\log N / \\log\\log N$ to $(\\log N)^{c_k}$ with $c_k \\leq 1$. For $k = 3$: exponents between $0.438$ and $0.889$, leaving a significant gap.",
+      "**Sunflower equivalence**: The upper bound exponent $c_k < 1$ holds if and only if the Erdős–Rado sunflower conjecture holds for $k$-petalled sunflowers. This connects a number-theoretic problem to a purely set-theoretic conjecture.",
       "**Divisor structure and LCM**: If $A = \\{d : d \\mid n\\}$, all pairs have $\\text{lcm}(a,b) \\mid n$, creating rich LCM structure. Avoiding uniform LCM subsets constrains how 'divisor-rich' $A$ can be."
     ],
     "prerequisites": [
@@ -50,8 +50,8 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 46,
-      "summary": "Header documenting Erd\u0151s Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization.",
-      "mathContext": "Mathematical content: Header documenting Erd\u0151s Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization."
+      "summary": "Header documenting Erdős Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization.",
+      "mathContext": "Mathematical content: Header documenting Erdős Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization."
     },
     {
       "id": "lcm-basics",
@@ -79,7 +79,7 @@
     },
     {
       "id": "erdos-bound",
-      "title": "Erd\u0151s 1970 Upper Bound",
+      "title": "Erdős 1970 Upper Bound",
       "startLine": 108,
       "endLine": 132,
       "summary": "Axiomatizes $f_k(N) \\leq C \\cdot \\log N / \\log\\log N$ for some $C > 0$, and the key lemma: for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements.",
@@ -87,7 +87,7 @@
     },
     {
       "id": "tang-zhang",
-      "title": "Tang\u2013Zhang 2025 Bounds",
+      "title": "Tang–Zhang 2025 Bounds",
       "startLine": 133,
       "endLine": 158,
       "summary": "Axiomatizes $\\exists b_k \\leq c_k$ with $(\\log N)^{b_k - \\varepsilon} \\leq f_k(N) \\leq (\\log N)^{c_k + \\varepsilon}$ for all $\\varepsilon > 0$ eventually. For $k = 3$: $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$.",
@@ -106,8 +106,8 @@
       "title": "Natural Density Variant",
       "startLine": 197,
       "endLine": 225,
-      "summary": "Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erd\u0151s's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536.",
-      "mathContext": "Formal definition: Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erd\u0151s's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536."
+      "summary": "Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536.",
+      "mathContext": "Formal definition: Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536."
     },
     {
       "id": "examples",
@@ -119,12 +119,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file proves LCM properties and the divisor set lemma, axiomatizes Erd\u0151s's 1970 bound, Tang\u2013Zhang's 2025 improvement, and the sunflower equivalence. The formalization covers 10 sections across 307 lines.",
-    "implications": "**Theoretical Significance**: Resolution would bridge combinatorial number theory and the sunflower conjecture.\n\nThe equivalence c_k < 1 \u27fa sunflower conjecture shows that progress on either problem implies progress on the other. The Alweiss\u2013Lovett\u2013Wu\u2013Zhang (2021) sunflower breakthrough may lead to improved bounds on f_k(N).",
+    "summary": "Erdős Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file proves LCM properties and the divisor set lemma, axiomatizes Erdős's 1970 bound, Tang–Zhang's 2025 improvement, and the sunflower equivalence. The formalization covers 10 sections across 307 lines.",
+    "implications": "**Theoretical Significance**: Resolution would bridge combinatorial number theory and the sunflower conjecture.\n\nThe equivalence c_k < 1 ⟺ sunflower conjecture shows that progress on either problem implies progress on the other. The Alweiss–Lovett–Wu–Zhang (2021) sunflower breakthrough may lead to improved bounds on f_k(N).",
     "openQuestions": [
       "What is the precise growth exponent $c_k$ for $f_k(N) \\sim (\\log N)^{c_k}$? Is it rational?",
-      "Can the Tang\u2013Zhang gap for $k = 3$ ($0.438 \\leq c_3 \\leq 0.889$) be narrowed?",
-      "Does the Alweiss\u2013Lovett\u2013Wu\u2013Zhang sunflower improvement give a concrete value of $c_k < 1$?",
+      "Can the Tang–Zhang gap for $k = 3$ ($0.438 \\leq c_3 \\leq 0.889$) be narrowed?",
+      "Does the Alweiss–Lovett–Wu–Zhang sunflower improvement give a concrete value of $c_k < 1$?",
       "Is there a polynomial-time algorithm to compute (or approximate) $f_k(N)$ for given $k$ and $N$?"
     ]
   },
@@ -144,18 +144,20 @@
     "namespace": "Erdos856",
     "lineCount": 260,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 10,
+    "theoremCount": 4
   },
   "crossReferences": [
     {
       "targetId": "erdos-855",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: number-neighbor"
+      "description": "Related Erdős problem sharing themes: number-neighbor"
     },
     {
       "targetId": "erdos-857",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: number-neighbor"
+      "description": "Related Erdős problem sharing themes: number-neighbor"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -141,7 +141,7 @@
     "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos863Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -145,7 +145,7 @@
     "lineCount": 85,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 10,
+    "definitionCount": 4,
     "path": "Proofs/Erdos866Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-868/meta.json
+++ b/src/data/proofs/erdos-868/meta.json
@@ -173,7 +173,7 @@
     "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 4,
+    "definitionCount": 7,
     "path": "Proofs/Erdos868Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -209,7 +209,7 @@
     "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 17,
+    "definitionCount": 18,
     "path": "Proofs/Erdos870Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-890/meta.json
+++ b/src/data/proofs/erdos-890/meta.json
@@ -124,7 +124,7 @@
     "lineCount": 210,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos890Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -185,7 +185,7 @@
     "lineCount": 400,
     "axiomCount": 0,
     "theoremCount": 29,
-    "definitionCount": 6,
+    "definitionCount": 11,
     "path": "Proofs/Erdos891Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -157,7 +157,7 @@
     "lineCount": 260,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "sorries": 7,
     "path": "Proofs/Erdos895Problem.lean"
   },

--- a/src/data/proofs/erdos-897/meta.json
+++ b/src/data/proofs/erdos-897/meta.json
@@ -139,7 +139,9 @@
     "namespace": "Erdos897",
     "lineCount": 141,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 7,
+    "theoremCount": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -188,7 +188,7 @@
     "lineCount": 251,
     "axiomCount": 11,
     "theoremCount": 2,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos898Problem.lean",
     "sorries": 8
   },

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -186,7 +186,7 @@
     "lineCount": 285,
     "axiomCount": 19,
     "theoremCount": 2,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos900Problem.lean",
     "sorries": 3
   },


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.definitionCount` and `leanFile.theoremCount` for 29 proofs in the erdos-751–900 range.

## Evidence

**Before**: Counts were stale from prior Lean source edits.
**After**: Counts re-derived from grep over Lean source files, including `@[simp]`-tagged and noncomputable/private/protected variants.

Part of systematic gallery metadata integrity scan (batches 9–17).

---
Automated fix by lean-mechanic agent.