### PR TITLE
fix(meta): sync leanFile.definitionCount/theoremCount for 52 proofs (batch 18)

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -204,8 +204,8 @@
     "namespace": "Erdos1000",
     "lineCount": 1149,
     "axiomCount": 2,
-    "theoremCount": 60,
-    "definitionCount": 8,
+    "theoremCount": 61,
+    "definitionCount": 11,
     "path": "Proofs/Erdos1000Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -195,7 +195,7 @@
     "lineCount": 140,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 0,
+    "definitionCount": 2,
     "path": "Proofs/Erdos1005Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -134,7 +134,7 @@
     "lineCount": 698,
     "axiomCount": 1,
     "theoremCount": 27,
-    "definitionCount": 8,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1008Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1009",
-  "title": "Erd\u0151s Problem #1009: Edge-Disjoint Triangles Beyond Tur\u00e1n",
+  "title": "Erdős Problem #1009: Edge-Disjoint Triangles Beyond Turán",
   "slug": "erdos-1009",
-  "description": "For every c > 0, does there exist f(c) such that every graph with \u230an\u00b2/4\u230b + k edges (k < cn) contains at least k - f(c) edge-disjoint triangles? SOLVED: Gy\u00f6ri (1988) proved this with f(c) \u226a c\u00b2.",
+  "description": "For every c > 0, does there exist f(c) such that every graph with ⌊n²/4⌋ + k edges (k < cn) contains at least k - f(c) edge-disjoint triangles? SOLVED: Györi (1988) proved this with f(c) ≪ c².",
   "meta": {
-    "author": "Erd\u0151s (1971)",
+    "author": "Erdős (1971)",
     "sourceUrl": "https://erdosproblems.com/1009",
     "date": "1971",
     "status": "axiomatized",
@@ -45,30 +45,30 @@
       "Triangle structure: formalized triangle with adjacency proofs",
       "edgeDisjoint, pairwiseEdgeDisjoint: edge-disjointness for triangle families",
       "maxEdgeDisjointTriangles: maximum packing size via sSup",
-      "excessEdges: excess above Tur\u00e1n threshold",
+      "excessEdges: excess above Turán threshold",
       "gyori_theorem axiom: main theorem with f(c) function",
-      "gyori_bound axiom: f(c) << c\u00b2 bound",
+      "gyori_bound axiom: f(c) << c² bound",
       "erdos_small_c axiom: f(c)=0 for c < 1/2",
       "gyori_odd_n, gyori_even_n: refined parity-dependent bounds",
       "completeTripartite: explicit K_{a,b,c} construction",
       "sauer_counterexample axiom: K_{1,m,m} shows f(2) >= 1",
-      "exceeds_turan_has_triangle: corollary of Tur\u00e1n's theorem"
+      "exceeds_turan_has_triangle: corollary of Turán's theorem"
     ],
     "axiomCount": 2,
     "lineCount": 239,
-    "assumptions": "2 axioms: boundFunction (opaque function), gyori_bound (C\u00b2-bound on f(c)). turan_extremal now proved from Mathlib's CliqueFree.card_edgeFinset_le. 5 former axioms converted to Prop defs."
+    "assumptions": "2 axioms: boundFunction (opaque function), gyori_bound (C²-bound on f(c)). turan_extremal now proved from Mathlib's CliqueFree.card_edgeFinset_le. 5 former axioms converted to Prop defs."
   },
   "overview": {
-    "historicalContext": "Erd\u0151s posed this problem in 1971 [Er71], motivated by the classical Tur\u00e1n problem. The Tur\u00e1n number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ (proved by Tur\u00e1n in 1941) is the maximum edges in a triangle-free graph on $n$ vertices. When a graph exceeds this threshold by $k$ edges, triangles must exist by Tur\u00e1n's theorem. Erd\u0151s asked: can we find nearly $k$ edge-disjoint triangles? He originally conjectured $f(c) = 0$ for all $c$ (every excess edge 'belongs to' a unique triangle). Sauer disproved this with $K_{1,m,m}$: it has $2m$ excess edges but only $2m - 1$ edge-disjoint triangles, since the degree-1 vertex is a bottleneck. Erd\u0151s himself proved $f(c) = 0$ for $c < 1/2$ using chromatic number arguments. Gy\u00f6ri (1988) [Gy88] resolved the problem completely, showing $f(c) \\leq Cc^2$ for an absolute constant $C$. The quadratic growth is essentially optimal. Gy\u00f6ri also refined the small-$c$ range: $f(c) = 0$ for $c < 2$ (odd $n$) and $c < 3/2$ (even $n$), reflecting the parity-dependent structure of the Tur\u00e1n graph.",
-    "problemStatement": "For every c > 0, does there exist f(c) such that every graph on n vertices with at least \u230an\u00b2/4\u230b + k edges (where k < cn) contains at least k - f(c) edge-disjoint triangles?",
-    "text": "For every c > 0, does there exist f(c) such that every graph with \u230an\u00b2/4\u230b + k edges (k < cn) contains at least k - f(c) edge-disjoint triangles? SOLVED: Gy\u00f6ri (1988) proved this with f(c) \u226a c\u00b2.",
-    "proofStrategy": "Gy\u00f6ri's proof shows that excess edges beyond Tur\u00e1n bound 'must' form triangles that are nearly disjoint. The key insight is that in dense graphs, the extra edges cannot all concentrate in shared triangles\u2014they must spread out. For small c, the graphs are close enough to the Tur\u00e1n graph that f(c) = 0 works. For larger c, Sauer's complete tripartite construction shows some loss is unavoidable.",
+    "historicalContext": "Erdős posed this problem in 1971 [Er71], motivated by the classical Turán problem. The Turán number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ (proved by Turán in 1941) is the maximum edges in a triangle-free graph on $n$ vertices. When a graph exceeds this threshold by $k$ edges, triangles must exist by Turán's theorem. Erdős asked: can we find nearly $k$ edge-disjoint triangles? He originally conjectured $f(c) = 0$ for all $c$ (every excess edge 'belongs to' a unique triangle). Sauer disproved this with $K_{1,m,m}$: it has $2m$ excess edges but only $2m - 1$ edge-disjoint triangles, since the degree-1 vertex is a bottleneck. Erdős himself proved $f(c) = 0$ for $c < 1/2$ using chromatic number arguments. Györi (1988) [Gy88] resolved the problem completely, showing $f(c) \\leq Cc^2$ for an absolute constant $C$. The quadratic growth is essentially optimal. Györi also refined the small-$c$ range: $f(c) = 0$ for $c < 2$ (odd $n$) and $c < 3/2$ (even $n$), reflecting the parity-dependent structure of the Turán graph.",
+    "problemStatement": "For every c > 0, does there exist f(c) such that every graph on n vertices with at least ⌊n²/4⌋ + k edges (where k < cn) contains at least k - f(c) edge-disjoint triangles?",
+    "text": "For every c > 0, does there exist f(c) such that every graph with ⌊n²/4⌋ + k edges (k < cn) contains at least k - f(c) edge-disjoint triangles? SOLVED: Györi (1988) proved this with f(c) ≪ c².",
+    "proofStrategy": "Györi's proof shows that excess edges beyond Turán bound 'must' form triangles that are nearly disjoint. The key insight is that in dense graphs, the extra edges cannot all concentrate in shared triangles—they must spread out. For small c, the graphs are close enough to the Turán graph that f(c) = 0 works. For larger c, Sauer's complete tripartite construction shows some loss is unavoidable.",
     "keyInsights": [
-      "**Tur\u00e1n baseline**: The threshold $\\lfloor n^2/4 \\rfloor$ is the exact boundary between triangle-free and triangle-containing graphs; every excess edge creates triangle structure",
+      "**Turán baseline**: The threshold $\\lfloor n^2/4 \\rfloor$ is the exact boundary between triangle-free and triangle-containing graphs; every excess edge creates triangle structure",
       "**Triangle packing vs excess edges**: Each excess edge 'should' contribute to a distinct triangle; the function $f(c)$ measures the unavoidable loss in this correspondence",
-      "**Sauer's bottleneck**: $K_{1,m,m}$ shows $f(c) > 0$ is necessary\u2014the single vertex of degree $2m$ must participate in every triangle, creating a packing bottleneck",
-      "**Parity-dependent thresholds**: $f(c) = 0$ extends further for odd $n$ ($c < 2$) than even $n$ ($c < 3/2$) because the unbalanced Tur\u00e1n graph $K_{(n-1)/2,(n+1)/2}$ has different structural properties",
-      "**Gyori's quadratic bound**: $f(c) \\leq Cc^2$ is proved via dependent random choice and K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n; the quadratic growth rate matches the $K_{1,m,m}$ lower bound up to constants"
+      "**Sauer's bottleneck**: $K_{1,m,m}$ shows $f(c) > 0$ is necessary—the single vertex of degree $2m$ must participate in every triangle, creating a packing bottleneck",
+      "**Parity-dependent thresholds**: $f(c) = 0$ extends further for odd $n$ ($c < 2$) than even $n$ ($c < 3/2$) because the unbalanced Turán graph $K_{(n-1)/2,(n+1)/2}$ has different structural properties",
+      "**Gyori's quadratic bound**: $f(c) \\leq Cc^2$ is proved via dependent random choice and Kővári-Sós-Turán; the quadratic growth rate matches the $K_{1,m,m}$ lower bound up to constants"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -87,10 +87,10 @@
     {
       "id": "sec-1009-graph-basics",
       "title": "Graph Basics",
-      "summary": "Defines `numVertices G = |V|`, `numEdges G = |E(G)|`, and `turanThreshold n = \\lfloor n^2/4 \\rfloor$, the Tur\u00e1n number $\\text{ex}(n, K_3)$.",
+      "summary": "Defines `numVertices G = |V|`, `numEdges G = |E(G)|`, and `turanThreshold n = \\lfloor n^2/4 \\rfloor$, the Turán number $\\text{ex}(n, K_3)$.",
       "startLine": 45,
       "endLine": 54,
-      "mathContext": "`numVertices G := Fintype.card V`, `numEdges G := G.edgeFinset.card`, `turanThreshold n := n^2 / 4` (Lean's natural number floor division). The Tur\u00e1n number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ is the maximum edges in a triangle-free graph on $n$ vertices."
+      "mathContext": "`numVertices G := Fintype.card V`, `numEdges G := G.edgeFinset.card`, `turanThreshold n := n^2 / 4` (Lean's natural number floor division). The Turán number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ is the maximum edges in a triangle-free graph on $n$ vertices."
     },
     {
       "id": "sec-1009-triangles",
@@ -102,16 +102,16 @@
     },
     {
       "id": "sec-1009-main",
-      "title": "Gy\u00f6ri's Main Theorem",
-      "summary": "Defines `excessEdges G = |E(G)| - \\lfloor n^2/4 \\rfloor` and axiomatizes Gy\u00f6ri's result: $\\nu_3(G) \\geq k - f(c)$ when $k < cn$, with $f(c) \\leq Cc^2$.",
+      "title": "Györi's Main Theorem",
+      "summary": "Defines `excessEdges G = |E(G)| - \\lfloor n^2/4 \\rfloor` and axiomatizes Györi's result: $\\nu_3(G) \\geq k - f(c)$ when $k < cn$, with $f(c) \\leq Cc^2$.",
       "startLine": 87,
       "endLine": 113,
-      "mathContext": "Gy\u00f6ri (1988): if $|E(G)| = \\lfloor n^2/4 \\rfloor + k$ with $k < cn$, then $\\nu_3(G) \\geq k - f(c)$ where $f(c) = O(c^2)$. The 'excess edges' $k$ count edges beyond Tur\u00e1n; nearly all of them can be assigned to edge-disjoint triangles, with at most $f(c)$ 'wasted'."
+      "mathContext": "Györi (1988): if $|E(G)| = \\lfloor n^2/4 \\rfloor + k$ with $k < cn$, then $\\nu_3(G) \\geq k - f(c)$ where $f(c) = O(c^2)$. The 'excess edges' $k$ count edges beyond Turán; nearly all of them can be assigned to edge-disjoint triangles, with at most $f(c)$ 'wasted'."
     },
     {
       "id": "sec-1009-partial",
-      "title": "Erd\u0151s's Partial Result and Refinements",
-      "summary": "Axiomatizes $f(c) = 0$ for $c < 1/2$ (Erd\u0151s), $c < 2$ for odd $n$, and $c < 3/2$ for even $n$ (Gy\u00f6ri). The parity refinements reflect the structure of the Tur\u00e1n graph.",
+      "title": "Erdős's Partial Result and Refinements",
+      "summary": "Axiomatizes $f(c) = 0$ for $c < 1/2$ (Erdős), $c < 2$ for odd $n$, and $c < 3/2$ for even $n$ (Györi). The parity refinements reflect the structure of the Turán graph.",
       "startLine": 114,
       "endLine": 146,
       "mathContext": "For small $c$: if $k < n/2$, every excess edge participates in a distinct edge-disjoint triangle ($f = 0$). The parity refinement: $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$ has parts of equal size iff $n$ is even, affecting how many excess edges can be packed into disjoint triangles before interference occurs."
@@ -119,28 +119,28 @@
     {
       "id": "sec-1009-sauer",
       "title": "Sauer's Counterexample",
-      "summary": "Defines `completeTripartite a b c` on `Fin a \u2295 Fin b \u2295 Fin c`. Axiomatizes Sauer's result: $K_{1,m,m}$ has $2m$ excess edges but $\\nu_3 = 2m - 1$, proving $f(2) \\geq 1$.",
+      "summary": "Defines `completeTripartite a b c` on `Fin a ⊕ Fin b ⊕ Fin c`. Axiomatizes Sauer's result: $K_{1,m,m}$ has $2m$ excess edges but $\\nu_3 = 2m - 1$, proving $f(2) \\geq 1$.",
       "startLine": 147,
       "endLine": 173,
-      "mathContext": "$K_{1,m,m}$ has $n = 2m+1$ vertices, $|E| = 2m^2 + m$ edges. The Tur\u00e1n threshold is $\\lfloor (2m+1)^2/4 \\rfloor = m^2 + m$, so excess = $m^2 = 2m \\cdot m / (2m) \\approx cn/2$ edges. But the $m$ triangles through the degree-1 part share edges, giving $\\nu_3 = 2m - 1$, one short of $k = 2m$."
+      "mathContext": "$K_{1,m,m}$ has $n = 2m+1$ vertices, $|E| = 2m^2 + m$ edges. The Turán threshold is $\\lfloor (2m+1)^2/4 \\rfloor = m^2 + m$, so excess = $m^2 = 2m \\cdot m / (2m) \\approx cn/2$ edges. But the $m$ triangles through the degree-1 part share edges, giving $\\nu_3 = 2m - 1$, one short of $k = 2m$."
     },
     {
       "id": "sec-1009-corollaries",
-      "title": "Tur\u00e1n's Theorem and Corollaries",
-      "summary": "Axiomatizes Tur\u00e1n's theorem ($G$ triangle-free $\\implies |E| \\leq \\lfloor n^2/4 \\rfloor$) and proves `exceeds_turan_has_triangle` by contraposition\u2014the only fully verified theorem in the file.",
+      "title": "Turán's Theorem and Corollaries",
+      "summary": "Axiomatizes Turán's theorem ($G$ triangle-free $\\implies |E| \\leq \\lfloor n^2/4 \\rfloor$) and proves `exceeds_turan_has_triangle` by contraposition—the only fully verified theorem in the file.",
       "startLine": 174,
       "endLine": 194,
-      "mathContext": "`exceeds_turan_has_triangle`: $|E(G)| > \\lfloor n^2/4 \\rfloor \\Rightarrow \\exists$ triangle in $G$. Proved by contraposition: if no triangle exists, Tur\u00e1n's axiom gives $|E| \\leq \\lfloor n^2/4 \\rfloor$, contradicting the hypothesis."
+      "mathContext": "`exceeds_turan_has_triangle`: $|E(G)| > \\lfloor n^2/4 \\rfloor \\Rightarrow \\exists$ triangle in $G$. Proved by contraposition: if no triangle exists, Turán's axiom gives $|E| \\leq \\lfloor n^2/4 \\rfloor$, contradicting the hypothesis."
     }
   ],
   "conclusion": {
-    "summary": "Gy\u00f6ri (1988) proved the conjecture with f(c) \u226a c\u00b2. This bound is optimal up to constants, as shown by Sauer's construction. The result reveals the structure of dense graphs: excess edges beyond Tur\u00e1n threshold must organize into nearly edge-disjoint triangles.",
-    "implications": "**Extremal Graph Theory**: The problem of counting edge-disjoint triangles beyond the Tur\u00e1n threshold sits at the intersection of extremal graph theory and combinatorial optimization. The Tur\u00e1n number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ gives the maximum triangle-free edge count; this problem asks how many edge-disjoint triangles exist when we exceed this threshold, connecting packing theory to extremal density.\n\n**Triangle Removal and Regularity**: The triangle removal lemma (Ruzsa-Szemer\u00e9di 1978) shows graphs with $o(n^3)$ triangles can be made triangle-free by removing $o(n^2)$ edges. Edge-disjoint triangle packing provides the dual perspective: rather than destroying triangles, we seek to pack as many non-overlapping ones as possible. Szemer\u00e9di's regularity lemma provides the structural framework for both.\n\n**Algorithmic Implications**: Triangle packing is NP-hard in general, but the extremal structure above the Tur\u00e1n threshold provides structural guarantees. Understanding the maximum packing has applications to database join optimization, network coding, and distributed computing where triangle decompositions model local communication patterns.",
+    "summary": "Györi (1988) proved the conjecture with f(c) ≪ c². This bound is optimal up to constants, as shown by Sauer's construction. The result reveals the structure of dense graphs: excess edges beyond Turán threshold must organize into nearly edge-disjoint triangles.",
+    "implications": "**Extremal Graph Theory**: The problem of counting edge-disjoint triangles beyond the Turán threshold sits at the intersection of extremal graph theory and combinatorial optimization. The Turán number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ gives the maximum triangle-free edge count; this problem asks how many edge-disjoint triangles exist when we exceed this threshold, connecting packing theory to extremal density.\n\n**Triangle Removal and Regularity**: The triangle removal lemma (Ruzsa-Szemerédi 1978) shows graphs with $o(n^3)$ triangles can be made triangle-free by removing $o(n^2)$ edges. Edge-disjoint triangle packing provides the dual perspective: rather than destroying triangles, we seek to pack as many non-overlapping ones as possible. Szemerédi's regularity lemma provides the structural framework for both.\n\n**Algorithmic Implications**: Triangle packing is NP-hard in general, but the extremal structure above the Turán threshold provides structural guarantees. Understanding the maximum packing has applications to database join optimization, network coding, and distributed computing where triangle decompositions model local communication patterns.",
     "openQuestions": [
       "What is the exact optimal constant $C$ in $f(c) \\leq Cc^2$? Hunter's simplified proof may give better constants.",
-      "Can similar results be proved for edge-disjoint copies of $K_4$ or larger cliques beyond the Tur\u00e1n threshold $\\text{ex}(n, K_r)$?",
+      "Can similar results be proved for edge-disjoint copies of $K_4$ or larger cliques beyond the Turán threshold $\\text{ex}(n, K_r)$?",
       "What is the computational complexity of finding the maximum edge-disjoint triangle packing? The fractional relaxation is polynomial, but the integer version is NP-hard in general.",
-      "Is there a common generalization for edge-disjoint copies of arbitrary graphs $H$ beyond the Tur\u00e1n threshold $\\text{ex}(n, H)$?",
+      "Is there a common generalization for edge-disjoint copies of arbitrary graphs $H$ beyond the Turán threshold $\\text{ex}(n, H)$?",
       "Can the parity-dependent thresholds ($c < 2$ for odd $n$, $c < 3/2$ for even $n$) be unified into a single formula depending on $n \\bmod 2$?"
     ]
   },
@@ -148,61 +148,61 @@
     {
       "targetId": "ramseys-theorem",
       "relationship": "foundational",
-      "description": "Ramsey theory provides the backdrop for extremal graph problems: just as Ramsey numbers bound unavoidable monochromatic cliques, Tur\u00e1n's theorem bounds unavoidable triangles. Gy\u00f6ri's result extends this by quantifying how many edge-disjoint triangles are forced by edge density above the Tur\u00e1n threshold."
+      "description": "Ramsey theory provides the backdrop for extremal graph problems: just as Ramsey numbers bound unavoidable monochromatic cliques, Turán's theorem bounds unavoidable triangles. Györi's result extends this by quantifying how many edge-disjoint triangles are forced by edge density above the Turán threshold."
     },
     {
       "targetId": "erdos-1008",
       "relationship": "thematic",
-      "description": "Erd\u0151s #1008 studies C\u2084-free subgraphs with many edges in dense graphs; both problems ask how much of a forbidden-subgraph-free structure can be extracted from a graph that just exceeds the corresponding Tur\u00e1n threshold, and both rely on K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n-type arguments."
+      "description": "Erdős #1008 studies C₄-free subgraphs with many edges in dense graphs; both problems ask how much of a forbidden-subgraph-free structure can be extracted from a graph that just exceeds the corresponding Turán threshold, and both rely on Kővári–Sós–Turán-type arguments."
     },
     {
       "targetId": "erdos-1010",
       "relationship": "thematic",
-      "description": "Erd\u0151s #1010 is a neighboring problem in the same cluster of Tur\u00e1n-type and packing questions. Both #1009 and #1010 concern the fine structure of graphs near the Tur\u00e1n threshold and were motivated by similar 1971\u20131975 Erd\u0151s problems on extremal graph theory."
+      "description": "Erdős #1010 is a neighboring problem in the same cluster of Turán-type and packing questions. Both #1009 and #1010 concern the fine structure of graphs near the Turán threshold and were motivated by similar 1971–1975 Erdős problems on extremal graph theory."
     },
     {
       "targetId": "erdos-1012",
       "relationship": "thematic",
-      "description": "Erd\u0151s #1012 concerns another extremal problem on triangle-related structure in dense graphs. Together with #1009, it forms part of Erd\u0151s's systematic study of what happens just beyond Tur\u00e1n's theorem and how triangles pack in graphs of given density."
+      "description": "Erdős #1012 concerns another extremal problem on triangle-related structure in dense graphs. Together with #1009, it forms part of Erdős's systematic study of what happens just beyond Turán's theorem and how triangles pack in graphs of given density."
     },
     {
       "targetId": "szemeredi-regularity",
       "relationship": "complementary",
-      "description": "Szemer\u00e9di's Regularity Lemma is the primary modern tool for analyzing triangle structure in dense graphs. Gy\u00f6ri's proof of the edge-disjoint triangle packing bound relies on regularity-type ideas; the Regularity Lemma generalizes these to arbitrary dense subgraph patterns via the triangle removal lemma."
+      "description": "Szemerédi's Regularity Lemma is the primary modern tool for analyzing triangle structure in dense graphs. Györi's proof of the edge-disjoint triangle packing bound relies on regularity-type ideas; the Regularity Lemma generalizes these to arbitrary dense subgraph patterns via the triangle removal lemma."
     },
     {
       "targetId": "erdos-1",
       "relationship": "thematic",
-      "description": "Erd\u0151s Problem #1 is a central problem in Erd\u0151s's extremal combinatorics program. Like #1009, it exemplifies Erd\u0151s's approach of asking precise quantitative questions about forced combinatorial structure in dense or large discrete systems."
+      "description": "Erdős Problem #1 is a central problem in Erdős's extremal combinatorics program. Like #1009, it exemplifies Erdős's approach of asking precise quantitative questions about forced combinatorial structure in dense or large discrete systems."
     }
   ],
   "references": [
     {
       "authors": [
-        "E. Gy\u00f6ri"
+        "E. Györi"
       ],
       "title": "On the number of edge disjoint triangles in graphs of given size",
       "year": "1988",
-      "venue": "Combinatorics (Eger, 1987), Colloq. Math. Soc. J\u00e1nos Bolyai, vol. 52, North-Holland",
-      "note": "The main reference: Gy\u00f6ri proves f(c) \u2264 Cc\u00b2 and provides parity-dependent refinements f(c)=0 for c<2 (odd n) and c<3/2 (even n)."
+      "venue": "Combinatorics (Eger, 1987), Colloq. Math. Soc. János Bolyai, vol. 52, North-Holland",
+      "note": "The main reference: Györi proves f(c) ≤ Cc² and provides parity-dependent refinements f(c)=0 for c<2 (odd n) and c<3/2 (even n)."
     },
     {
       "authors": [
-        "P. Erd\u0151s"
+        "P. Erdős"
       ],
       "title": "Some unsolved problems in graph theory and combinatorics",
       "year": "1971",
       "venue": "Combinatorial Mathematics and its Applications, Academic Press",
-      "note": "Original problem statement. Erd\u0151s posed the question and proved f(c)=0 for c<1/2."
+      "note": "Original problem statement. Erdős posed the question and proved f(c)=0 for c<1/2."
     },
     {
       "authors": [
-        "P. Tur\u00e1n"
+        "P. Turán"
       ],
       "title": "On an extremal problem in graph theory",
       "year": "1941",
-      "venue": "Matematikai \u00e9s Fizikai Lapok, 48, 436\u2013452",
-      "note": "Proves the Tur\u00e1n theorem: ex(n,K\u2083)=\u230an\u00b2/4\u230b. This is the baseline whose excess is studied in Erd\u0151s #1009."
+      "venue": "Matematikai és Fizikai Lapok, 48, 436–452",
+      "note": "Proves the Turán theorem: ex(n,K₃)=⌊n²/4⌋. This is the baseline whose excess is studied in Erdős #1009."
     },
     {
       "authors": [
@@ -211,16 +211,16 @@
       "title": "On the density of complete bipartite subgraphs in graphs with bounded independent sets",
       "year": "1975",
       "venue": "Proceedings of a conference on graph theory",
-      "note": "Sauer's counterexample: K_{1,m,m} has 2m excess edges but only 2m\u22121 edge-disjoint triangles, proving f(2) \u2265 1 and that f(c)=0 fails for all c."
+      "note": "Sauer's counterexample: K_{1,m,m} has 2m excess edges but only 2m−1 edge-disjoint triangles, proving f(2) ≥ 1 and that f(c)=0 fails for all c."
     },
     {
       "authors": [
         "W. T. Gowers"
       ],
-      "title": "Hypergraph regularity and the multidimensional Szemer\u00e9di theorem",
+      "title": "Hypergraph regularity and the multidimensional Szemerédi theorem",
       "year": "2007",
-      "venue": "Annals of Mathematics, 166(3), 897\u2013946",
-      "note": "Develops the hypergraph regularity lemma used in modern proofs of triangle removal and packing theorems; provides the analytic machinery generalizing Gy\u00f6ri's combinatorial approach."
+      "venue": "Annals of Mathematics, 166(3), 897–946",
+      "note": "Develops the hypergraph regularity lemma used in modern proofs of triangle removal and packing theorems; provides the analytic machinery generalizing Györi's combinatorial approach."
     }
   ],
   "leanFile": {
@@ -235,7 +235,7 @@
     "lineCount": 239,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 9,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1009Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1011/meta.json
+++ b/src/data/proofs/erdos-1011/meta.json
@@ -219,7 +219,7 @@
     "lineCount": 168,
     "axiomCount": 5,
     "theoremCount": 0,
-    "definitionCount": 11,
+    "definitionCount": 9,
     "path": "Proofs/Erdos1011Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -279,7 +279,7 @@
     "lineCount": 441,
     "axiomCount": 4,
     "theoremCount": 12,
-    "definitionCount": 19,
+    "definitionCount": 22,
     "path": "Proofs/Erdos1019Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -256,8 +256,8 @@
     "namespace": "Erdos1022",
     "lineCount": 522,
     "axiomCount": 1,
-    "theoremCount": 25,
-    "definitionCount": 9,
+    "theoremCount": 28,
+    "definitionCount": 7,
     "path": "Proofs/Erdos1022Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1023/meta.json
+++ b/src/data/proofs/erdos-1023/meta.json
@@ -238,7 +238,7 @@
     "lineCount": 366,
     "axiomCount": 5,
     "theoremCount": 17,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "path": "Proofs/Erdos1023Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1024/meta.json
+++ b/src/data/proofs/erdos-1024/meta.json
@@ -239,7 +239,7 @@
     "lineCount": 227,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1024Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1025/meta.json
+++ b/src/data/proofs/erdos-1025/meta.json
@@ -231,7 +231,7 @@
     "lineCount": 246,
     "axiomCount": 4,
     "theoremCount": 6,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos1025Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1028",
-  "title": "Erd\u0151s Problem #1028: Discrepancy of Sign Functions",
+  "title": "Erdős Problem #1028: Discrepancy of Sign Functions",
   "slug": "erdos-1028",
-  "description": "Let H(n) = min_f max_X |\u2211_{x\u2260y\u2208X} f(x,y)| where f: pairs \u2192 {\u00b11}. Erd\u0151s (1963) proved n/4 \u2264 H(n) \u226a n^(3/2). Erd\u0151s-Spencer (1971) proved H(n) \u226b n^(3/2). Answer: H(n) = \u0398(n^(3/2)).",
+  "description": "Let H(n) = min_f max_X |∑_{x≠y∈X} f(x,y)| where f: pairs → {±1}. Erdős (1963) proved n/4 ≤ H(n) ≪ n^(3/2). Erdős-Spencer (1971) proved H(n) ≫ n^(3/2). Answer: H(n) = Θ(n^(3/2)).",
   "meta": {
-    "author": "Erd\u0151s (1963), Erd\u0151s-Spencer (1971)",
+    "author": "Erdős (1963), Erdős-Spencer (1971)",
     "sourceUrl": "https://erdosproblems.com/1028",
     "date": "1971",
     "status": "axiomatized",
@@ -28,16 +28,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erd\u0151s Problem #1028 concerns the discrepancy of sign functions: given a function f mapping pairs from {1,...,n} to {\u00b11}, the discrepancy of a subset X is |\u2211_{x\u2260y\u2208X} f(x,y)|. The function H(n) is the minimum over all sign functions f of the maximum discrepancy over all subsets X. This measures the unavoidable imbalance in signed complete graphs.\n\nErd\u0151s (1963) established the upper bound H(n) = O(n^{3/2}) using the probabilistic method: a random sign function achieves maximum discrepancy O(n^{3/2}) with positive probability. For a subset of size k, the expected discrepancy of a random signing is \u221a(k(k-1)) \u2248 k, and optimizing over k \u2248 \u221an gives the n^{3/2} bound. Note: the originally proposed lower bound H(n) \u2265 n/4 was found to be incorrect (Aristotle verified a counterexample for n=8).\n\nErd\u0151s and Spencer (1971) proved the matching lower bound H(n) = \u03a9(n^{3/2}) using entropy and counting arguments, establishing H(n) = \u0398(n^{3/2}). Their proof showed that any sign function must have some subset with discrepancy at least cn^{3/2}, confirming that random signs are essentially optimal. The formalization includes several theorems proved by Aristotle (Harmonic), including the well-definedness of H(n), symmetric pair sum decomposition, and discrepancy bounds.",
-    "problemStatement": "**Problem Statement**\n\nLet H(n) = min_f max_{X \u2286 {1,...,n}} |\u2211_{x\u2260y\u2208X} f(x,y)|, where f ranges over all functions f: X\u00b2 \u2192 {-1, 1}.\n\nEstimate H(n).\n\n**Status**: SOLVED\n\n**Answer**: H(n) = \u0398(n^(3/2))",
-    "text": "Let H(n) = min_f max_X |\u2211_{x\u2260y\u2208X} f(x,y)| where f: pairs \u2192 {\u00b11}. Erd\u0151s (1963) proved n/4 \u2264 H(n) \u226a n^(3/2). Erd\u0151s-Spencer (1971) proved H(n) \u226b n^(3/2). Answer: H(n) = \u0398(n^(3/2)).",
-    "proofStrategy": "**Proof Approach**\n\n1. **Upper Bound (Probabilistic)**: Random sign functions have max discrepancy O(n^(3/2)) with high probability.\n\n2. **Lower Bound (Erd\u0151s 1963)**: Linear bound n/4 via simple counting.\n\n3. **Improved Lower Bound (Erd\u0151s-Spencer 1971)**: Entropy or counting arguments give n^(3/2).\n\n4. **Key Insight**: The n^(3/2) bound arises from the \u221a(pairs in subset of size k) \u2248 k for k \u2248 \u221an.",
+    "historicalContext": "Erdős Problem #1028 concerns the discrepancy of sign functions: given a function f mapping pairs from {1,...,n} to {±1}, the discrepancy of a subset X is |∑_{x≠y∈X} f(x,y)|. The function H(n) is the minimum over all sign functions f of the maximum discrepancy over all subsets X. This measures the unavoidable imbalance in signed complete graphs.\n\nErdős (1963) established the upper bound H(n) = O(n^{3/2}) using the probabilistic method: a random sign function achieves maximum discrepancy O(n^{3/2}) with positive probability. For a subset of size k, the expected discrepancy of a random signing is √(k(k-1)) ≈ k, and optimizing over k ≈ √n gives the n^{3/2} bound. Note: the originally proposed lower bound H(n) ≥ n/4 was found to be incorrect (Aristotle verified a counterexample for n=8).\n\nErdős and Spencer (1971) proved the matching lower bound H(n) = Ω(n^{3/2}) using entropy and counting arguments, establishing H(n) = Θ(n^{3/2}). Their proof showed that any sign function must have some subset with discrepancy at least cn^{3/2}, confirming that random signs are essentially optimal. The formalization includes several theorems proved by Aristotle (Harmonic), including the well-definedness of H(n), symmetric pair sum decomposition, and discrepancy bounds.",
+    "problemStatement": "**Problem Statement**\n\nLet H(n) = min_f max_{X ⊆ {1,...,n}} |∑_{x≠y∈X} f(x,y)|, where f ranges over all functions f: X² → {-1, 1}.\n\nEstimate H(n).\n\n**Status**: SOLVED\n\n**Answer**: H(n) = Θ(n^(3/2))",
+    "text": "Let H(n) = min_f max_X |∑_{x≠y∈X} f(x,y)| where f: pairs → {±1}. Erdős (1963) proved n/4 ≤ H(n) ≪ n^(3/2). Erdős-Spencer (1971) proved H(n) ≫ n^(3/2). Answer: H(n) = Θ(n^(3/2)).",
+    "proofStrategy": "**Proof Approach**\n\n1. **Upper Bound (Probabilistic)**: Random sign functions have max discrepancy O(n^(3/2)) with high probability.\n\n2. **Lower Bound (Erdős 1963)**: Linear bound n/4 via simple counting.\n\n3. **Improved Lower Bound (Erdős-Spencer 1971)**: Entropy or counting arguments give n^(3/2).\n\n4. **Key Insight**: The n^(3/2) bound arises from the √(pairs in subset of size k) ≈ k for k ≈ √n.",
     "keyInsights": [
-      "Sign function f: pairs \u2192 {\u00b11}",
+      "Sign function f: pairs → {±1}",
       "Discrepancy of X = |sum of f over pairs in X|",
       "H(n) = min over f of max discrepancy",
-      "Erd\u0151s: n/4 \u2264 H(n) \u226a n^(3/2)",
-      "Erd\u0151s-Spencer: H(n) = \u0398(n^(3/2))"
+      "Erdős: n/4 ≤ H(n) ≪ n^(3/2)",
+      "Erdős-Spencer: H(n) = Θ(n^(3/2))"
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -70,14 +70,14 @@
     },
     {
       "id": "erdos-upper",
-      "title": "Erd\u0151s's Upper Bound (1963)",
+      "title": "Erdős's Upper Bound (1963)",
       "summary": "erdos_upper",
       "startLine": 136,
       "endLine": 144
     },
     {
       "id": "erdos-spencer",
-      "title": "Erd\u0151s-Spencer (1971)",
+      "title": "Erdős-Spencer (1971)",
       "summary": "erdos_spencer_lower, erdos_spencer_improves",
       "startLine": 145,
       "endLine": 157,
@@ -125,7 +125,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #1028 asked to estimate H(n), the minimum possible maximum discrepancy over sign functions on pairs. Erd\u0151s (1963) gave n/4 \u2264 H(n) \u226a n^(3/2), and Erd\u0151s-Spencer (1971) closed the gap: H(n) = \u0398(n^(3/2)).",
+    "summary": "Erdős Problem #1028 asked to estimate H(n), the minimum possible maximum discrepancy over sign functions on pairs. Erdős (1963) gave n/4 ≤ H(n) ≪ n^(3/2), and Erdős-Spencer (1971) closed the gap: H(n) = Θ(n^(3/2)).",
     "implications": "1. **Discrepancy Theory**: Fundamental result on unavoidable imbalance\n\n**2. Signed Graphs**: Minimum imbalance in edge-signed complete graphs\n\n3. **Probabilistic Method**: Upper bound via random signs\n\n4. **Ramsey Connection**: Large homogeneous subsets relate to discrepancy.",
     "openQuestions": [
       "What are the exact constants in the asymptotic?",
@@ -141,19 +141,19 @@
       "targetId": "ramseys-theorem"
     },
     {
-      "relationship": "Erd\u0151s #1 (Sidon sets / sum-free sets) shares the probabilistic-method toolkit used to establish the O(n^{3/2}) upper bound.",
+      "relationship": "Erdős #1 (Sidon sets / sum-free sets) shares the probabilistic-method toolkit used to establish the O(n^{3/2}) upper bound.",
       "targetId": "erdos-1"
     },
     {
-      "relationship": "Erd\u0151s #1025 studies signed graph imbalance; the two problems share the signed-complete-graph model and discrepancy extremal questions.",
+      "relationship": "Erdős #1025 studies signed graph imbalance; the two problems share the signed-complete-graph model and discrepancy extremal questions.",
       "targetId": "erdos-1025"
     },
     {
-      "relationship": "Adjacent Erd\u0151s problem in the discrepancy-theory cluster; formalized with the same axiom structure and proof approach.",
+      "relationship": "Adjacent Erdős problem in the discrepancy-theory cluster; formalized with the same axiom structure and proof approach.",
       "targetId": "erdos-1029"
     },
     {
-      "relationship": "Erd\u0151s #500 involves combinatorial counting over pairs; the pair-sum decomposition technique used here appears in related Erd\u0151s pair-counting problems.",
+      "relationship": "Erdős #500 involves combinatorial counting over pairs; the pair-sum decomposition technique used here appears in related Erdős pair-counting problems.",
       "targetId": "erdos-500"
     },
     {
@@ -164,7 +164,7 @@
   "references": [
     {
       "authors": [
-        "P. Erd\u0151s"
+        "P. Erdős"
       ],
       "title": "On some problems in graph theory, combinatorial analysis and combinatorial number theory",
       "venue": "Graph Theory and Combinatorics (Cambridge, 1983)",
@@ -173,15 +173,15 @@
     },
     {
       "authors": [
-        "P. Erd\u0151s",
+        "P. Erdős",
         "J. Spencer"
       ],
       "title": "Imbalances in k-colorations",
       "venue": "Networks",
       "volume": "1",
-      "pages": "379\u2013385",
+      "pages": "379–385",
       "year": "1971",
-      "note": "Establishes the matching \u03a9(n^{3/2}) lower bound, completing H(n) = \u0398(n^{3/2})."
+      "note": "Establishes the matching Ω(n^{3/2}) lower bound, completing H(n) = Θ(n^{3/2})."
     },
     {
       "authors": [
@@ -190,19 +190,19 @@
       "title": "Six standard deviations suffice",
       "venue": "Transactions of the American Mathematical Society",
       "volume": "289",
-      "pages": "679\u2013706",
+      "pages": "679–706",
       "year": "1985",
-      "note": "Landmark discrepancy result proving the entropy method; directly related to the Erd\u0151s-Spencer lower bound technique used here."
+      "note": "Landmark discrepancy result proving the entropy method; directly related to the Erdős-Spencer lower bound technique used here."
     },
     {
       "authors": [
-        "J. Matou\u0161ek",
+        "J. Matoušek",
         "J. Spencer"
       ],
       "title": "Discrepancy in arithmetic progressions",
       "venue": "Journal of the American Mathematical Society",
       "volume": "9",
-      "pages": "195\u2013204",
+      "pages": "195–204",
       "year": "1996",
       "note": "Illustrates the discrepancy-theory framework connecting signed-sum estimates with combinatorial lower bounds."
     },
@@ -241,7 +241,7 @@
     "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos1028Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1033",
-  "title": "Erd\u0151s Problem #1033: Triangle Degree Sums in Dense Graphs",
+  "title": "Erdős Problem #1033: Triangle Degree Sums in Dense Graphs",
   "slug": "erdos-1033",
-  "description": "Let h(n) = max k such that every graph on n vertices with > n\u00b2/4 edges contains a triangle with degree sum \u2265 k. Conjecture: h(n) \u2265 (2(\u221a3\u22121)\u2212o(1))n \u2248 1.464n. Known: (21/16)n \u2264 h(n) \u2264 2(\u221a3\u22121)n.",
+  "description": "Let h(n) = max k such that every graph on n vertices with > n²/4 edges contains a triangle with degree sum ≥ k. Conjecture: h(n) ≥ (2(√3−1)−o(1))n ≈ 1.464n. Known: (21/16)n ≤ h(n) ≤ 2(√3−1)n.",
   "meta": {
-    "author": "Erd\u0151s-Laskar (1985), Fan (1988)",
+    "author": "Erdős-Laskar (1985), Fan (1988)",
     "sourceUrl": "https://erdosproblems.com/1033",
     "date": "1985",
     "status": "axiomatized",
@@ -47,7 +47,7 @@
     "originalContributions": [
       "Formal definition of h(n) as supremum of valid lower bounds",
       "Triangle structure with degree sum formalization",
-      "Statement of Erd\u0151s-Laskar and Fan bounds as axioms",
+      "Statement of Erdős-Laskar and Fan bounds as axioms",
       "Formalization of the main conjecture and its asymptotic equivalent"
     ],
     "relatedProblems": [],
@@ -56,14 +56,14 @@
     "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower). 0 sorries (h_as_min, turan_plus_one, h_four, h_spec all proved). Note: erdos_laskar_upper and fan_lower axioms are too strong for small n (asymptotic results stated as universal)."
   },
   "overview": {
-    "historicalContext": "P\u00e1l Tur\u00e1n proved in 1941 that every graph on $n$ vertices with more than $\\lfloor n^2/4 \\rfloor$ edges contains a triangle \u2014 establishing the foundational result of extremal graph theory. This problem, posed by Erd\u0151s and Laskar, asks a refined question: given that triangles must exist above the Tur\u00e1n threshold, how large must the degree sum of the *heaviest* triangle be?\n\nErd\u0151s and Renu Laskar (1985) proved the initial bounds $(1+c)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$, where the upper bound $2(\\sqrt{3}-1) \\approx 1.464$ comes from optimizing triangle configurations in nearly-bipartite graphs close to the Tur\u00e1n graph $T(n,2)$. Genghua Fan (1988) improved the lower bound to $(21/16)n = 1.3125n$ via careful degree counting arguments.\n\nThe gap between $1.3125n$ and $1.464n$ remains open. The conjectured answer is $h(n) = (2(\\sqrt{3}-1) - o(1))n$, which would mean the Erd\u0151s-Laskar construction is essentially optimal.",
-    "problemStatement": "**Problem Statement**\n\nLet h(n) be such that every graph on n vertices with > n\u00b2/4 edges contains a triangle whose vertices have degrees summing to at least h(n). Estimate h(n).\n\n**Conjecture**: h(n) \u2265 (2(\u221a3\u22121)\u2212o(1))n \u2248 1.464n\n\n**Status**: OPEN",
-    "text": "Let h(n) = max k such that every graph on n vertices with > n\u00b2/4 edges contains a triangle with degree sum \u2265 k. Conjecture: h(n) \u2265 (2(\u221a3\u22121)\u2212o(1))n \u2248 1.464n. Known: (21/16)n \u2264 h(n) \u2264 2(\u221a3\u22121)n.",
-    "proofStrategy": "**Known Approach**\n\n1. **Upper Bound**: Erd\u0151s-Laskar construct graphs just above Tur\u00e1n threshold where all triangles have degree sum \u2264 2(\u221a3\u22121)n.\n\n2. **Lower Bound (Fan)**: Careful analysis shows h(n) \u2265 (21/16)n via degree counting in triangles.\n\n3. **Key Insight**: The constant 2(\u221a3\u22121) arises from optimizing triangle configurations in nearly-bipartite graphs.\n\n4. **Gap**: Closing the 0.15n gap between bounds remains open.",
+    "historicalContext": "Pál Turán proved in 1941 that every graph on $n$ vertices with more than $\\lfloor n^2/4 \\rfloor$ edges contains a triangle — establishing the foundational result of extremal graph theory. This problem, posed by Erdős and Laskar, asks a refined question: given that triangles must exist above the Turán threshold, how large must the degree sum of the *heaviest* triangle be?\n\nErdős and Renu Laskar (1985) proved the initial bounds $(1+c)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$, where the upper bound $2(\\sqrt{3}-1) \\approx 1.464$ comes from optimizing triangle configurations in nearly-bipartite graphs close to the Turán graph $T(n,2)$. Genghua Fan (1988) improved the lower bound to $(21/16)n = 1.3125n$ via careful degree counting arguments.\n\nThe gap between $1.3125n$ and $1.464n$ remains open. The conjectured answer is $h(n) = (2(\\sqrt{3}-1) - o(1))n$, which would mean the Erdős-Laskar construction is essentially optimal.",
+    "problemStatement": "**Problem Statement**\n\nLet h(n) be such that every graph on n vertices with > n²/4 edges contains a triangle whose vertices have degrees summing to at least h(n). Estimate h(n).\n\n**Conjecture**: h(n) ≥ (2(√3−1)−o(1))n ≈ 1.464n\n\n**Status**: OPEN",
+    "text": "Let h(n) = max k such that every graph on n vertices with > n²/4 edges contains a triangle with degree sum ≥ k. Conjecture: h(n) ≥ (2(√3−1)−o(1))n ≈ 1.464n. Known: (21/16)n ≤ h(n) ≤ 2(√3−1)n.",
+    "proofStrategy": "**Known Approach**\n\n1. **Upper Bound**: Erdős-Laskar construct graphs just above Turán threshold where all triangles have degree sum ≤ 2(√3−1)n.\n\n2. **Lower Bound (Fan)**: Careful analysis shows h(n) ≥ (21/16)n via degree counting in triangles.\n\n3. **Key Insight**: The constant 2(√3−1) arises from optimizing triangle configurations in nearly-bipartite graphs.\n\n4. **Gap**: Closing the 0.15n gap between bounds remains open.",
     "keyInsights": [
-      "Tur\u00e1n threshold: n\u00b2/4 edges forces a triangle",
+      "Turán threshold: n²/4 edges forces a triangle",
       "h(n) = guaranteed minimum of max triangle degree sum",
-      "Upper bound 2(\u221a3\u22121)n \u2248 1.464n from Erd\u0151s-Laskar",
+      "Upper bound 2(√3−1)n ≈ 1.464n from Erdős-Laskar",
       "Lower bound (21/16)n = 1.3125n from Fan",
       "Gap of about 0.15n remains open"
     ],
@@ -86,11 +86,11 @@
     },
     {
       "id": "turan-threshold",
-      "title": "Tur\u00e1n Threshold",
+      "title": "Turán Threshold",
       "summary": "turanThreshold, isAboveTuran, turan_has_triangle",
       "startLine": 43,
       "endLine": 60,
-      "mathContext": "Tur\u00e1n (1941): $|E(G)| > \\lfloor n^2/4 \\rfloor \\Rightarrow G$ contains a triangle."
+      "mathContext": "Turán (1941): $|E(G)| > \\lfloor n^2/4 \\rfloor \\Rightarrow G$ contains a triangle."
     },
     {
       "id": "triangles",
@@ -110,15 +110,15 @@
     },
     {
       "id": "constant",
-      "title": "The Constant 2(\u221a3\u22121)",
+      "title": "The Constant 2(√3−1)",
       "summary": "erdosLaskarConstant, erdosLaskar_approx",
       "startLine": 119,
       "endLine": 140,
-      "mathContext": "$2(\\sqrt{3}-1) \\approx 1.464$. Arises from optimizing triangle degree sums in nearly-bipartite graphs near the Tur\u00e1n graph $T(n,2)$."
+      "mathContext": "$2(\\sqrt{3}-1) \\approx 1.464$. Arises from optimizing triangle degree sums in nearly-bipartite graphs near the Turán graph $T(n,2)$."
     },
     {
       "id": "upper-bound",
-      "title": "Erd\u0151s-Laskar Upper Bound",
+      "title": "Erdős-Laskar Upper Bound",
       "summary": "erdos_laskar_upper, upper_bound_tight",
       "startLine": 141,
       "endLine": 158,
@@ -126,7 +126,7 @@
     },
     {
       "id": "original-lower",
-      "title": "Erd\u0151s-Laskar Lower Bound",
+      "title": "Erdős-Laskar Lower Bound",
       "summary": "erdos_laskar_lower, lower_beats_n",
       "startLine": 159,
       "endLine": 176,
@@ -182,7 +182,7 @@
     },
     {
       "id": "turan-graph",
-      "title": "Relation to Tur\u00e1n Graph",
+      "title": "Relation to Turán Graph",
       "summary": "bipartite_no_triangle, turan_plus_one",
       "startLine": 298,
       "endLine": 321,
@@ -197,10 +197,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #1033 asks to estimate h(n), where every graph on n vertices with > n\u00b2/4 edges contains a triangle with degree sum \u2265 h(n). Erd\u0151s-Laskar (1985) proved h(n) \u2264 2(\u221a3\u22121)n, and Fan (1988) proved h(n) \u2265 (21/16)n. The gap remains open.",
-    "implications": "1. **Tur\u00e1n Theory Extension**: Refines our understanding beyond triangle existence\n\n**2. Degree-Sum Problems**: Template for similar extremal questions\n\n3. **Extremal Graph Structure**: Near-Tur\u00e1n graphs have specific triangle properties\n\n4. **Algorithmic Implications**: Finding high-degree-sum triangles.",
+    "summary": "Erdős Problem #1033 asks to estimate h(n), where every graph on n vertices with > n²/4 edges contains a triangle with degree sum ≥ h(n). Erdős-Laskar (1985) proved h(n) ≤ 2(√3−1)n, and Fan (1988) proved h(n) ≥ (21/16)n. The gap remains open.",
+    "implications": "1. **Turán Theory Extension**: Refines our understanding beyond triangle existence\n\n**2. Degree-Sum Problems**: Template for similar extremal questions\n\n3. **Extremal Graph Structure**: Near-Turán graphs have specific triangle properties\n\n4. **Algorithmic Implications**: Finding high-degree-sum triangles.",
     "openQuestions": [
-      "Is h(n) = (2(\u221a3\u22121)\u2212o(1))n? (Main conjecture)",
+      "Is h(n) = (2(√3−1)−o(1))n? (Main conjecture)",
       "What are the extremal graphs achieving h(n)?",
       "Can the lower bound be improved beyond (21/16)n?",
       "What about k-cliques instead of triangles?",
@@ -210,40 +210,40 @@
   "crossReferences": [
     {
       "relationship": "foundational",
-      "description": "Erd\u0151s #905 establishes that every dense graph (above Tur\u00e1n threshold) has an edge in at least n/6 triangles. This codegree result is a prerequisite for understanding triangle degree-sum guarantees and underlies the book lemma used in related lower bound arguments.",
+      "description": "Erdős #905 establishes that every dense graph (above Turán threshold) has an edge in at least n/6 triangles. This codegree result is a prerequisite for understanding triangle degree-sum guarantees and underlies the book lemma used in related lower bound arguments.",
       "targetId": "erdos-905"
     },
     {
       "relationship": "companion",
-      "description": "Erd\u0151s #1034 asks about triangle neighbor counts in dense graphs and is directly companion to #1033. Both probe the structure of triangles above the Tur\u00e1n threshold, with #1034 measuring neighborhood size and #1033 measuring degree sums of triangle vertices.",
+      "description": "Erdős #1034 asks about triangle neighbor counts in dense graphs and is directly companion to #1033. Both probe the structure of triangles above the Turán threshold, with #1034 measuring neighborhood size and #1033 measuring degree sums of triangle vertices.",
       "targetId": "erdos-1034"
     },
     {
       "relationship": "related",
-      "description": "Erd\u0151s #1032 studies 4-chromatic critical graphs with linear minimum degree, connecting the Tur\u00e1n-type threshold with chromatic criticality. Minimum degree conditions are closely tied to degree-sum phenomena in dense graphs.",
+      "description": "Erdős #1032 studies 4-chromatic critical graphs with linear minimum degree, connecting the Turán-type threshold with chromatic criticality. Minimum degree conditions are closely tied to degree-sum phenomena in dense graphs.",
       "targetId": "erdos-1032"
     },
     {
       "relationship": "context",
-      "description": "Ramsey's theorem guarantees clique or independent set structure in dense graphs. Triangle existence above the Tur\u00e1n threshold is the r=3 instance of Ramsey-type problems, and the degree-sum question refines the structural information forced by Ramsey thresholds.",
+      "description": "Ramsey's theorem guarantees clique or independent set structure in dense graphs. Triangle existence above the Turán threshold is the r=3 instance of Ramsey-type problems, and the degree-sum question refines the structural information forced by Ramsey thresholds.",
       "targetId": "ramseys-theorem"
     },
     {
       "relationship": "related",
-      "description": "Erd\u0151s #1031 studies induced regular subgraphs in graphs below the Ramsey threshold. The interplay between degree regularity and extremal thresholds is shared with #1033's analysis of degree sums in triangles near the Tur\u00e1n threshold.",
+      "description": "Erdős #1031 studies induced regular subgraphs in graphs below the Ramsey threshold. The interplay between degree regularity and extremal thresholds is shared with #1033's analysis of degree sums in triangles near the Turán threshold.",
       "targetId": "erdos-1031"
     }
   ],
   "references": [
     {
       "authors": [
-        "P. Erd\u0151s",
+        "P. Erdős",
         "R. Laskar"
       ],
       "title": "A note on the size of a chordal subgraph",
       "venue": "Congressus Numerantium",
       "year": "1985",
-      "note": "Original paper introducing h(n) and establishing both the upper bound 2(\u221a3\u22121)n and an initial lower bound for the degree-sum problem."
+      "note": "Original paper introducing h(n) and establishing both the upper bound 2(√3−1)n and an initial lower bound for the degree-sum problem."
     },
     {
       "authors": [
@@ -253,41 +253,41 @@
       "venue": "Journal of Graph Theory",
       "volume": "12",
       "year": "1988",
-      "pages": "249\u2013263",
-      "note": "Improves the lower bound to h(n) \u2265 (21/16)n via careful degree-counting arguments in triangles above the Tur\u00e1n threshold."
+      "pages": "249–263",
+      "note": "Improves the lower bound to h(n) ≥ (21/16)n via careful degree-counting arguments in triangles above the Turán threshold."
     },
     {
       "authors": [
-        "P. Tur\u00e1n"
+        "P. Turán"
       ],
       "title": "On an extremal problem in graph theory",
-      "venue": "Matematikai \u00e9s Fizikai Lapok",
+      "venue": "Matematikai és Fizikai Lapok",
       "volume": "48",
       "year": "1941",
-      "pages": "436\u2013452",
-      "note": "Foundational result proving that every graph on n vertices with more than n\u00b2/4 edges contains a triangle, establishing the threshold that underlies the entire h(n) problem."
+      "pages": "436–452",
+      "note": "Foundational result proving that every graph on n vertices with more than n²/4 edges contains a triangle, establishing the threshold that underlies the entire h(n) problem."
     },
     {
       "authors": [
-        "B. Bollob\u00e1s"
+        "B. Bollobás"
       ],
       "title": "Extremal Graph Theory",
       "venue": "Academic Press, London",
       "year": "1978",
-      "note": "Comprehensive treatment of Tur\u00e1n-type problems, extremal thresholds, and degree-sum methods in graphs. Standard reference for the techniques used in proving bounds on h(n)."
+      "note": "Comprehensive treatment of Turán-type problems, extremal thresholds, and degree-sum methods in graphs. Standard reference for the techniques used in proving bounds on h(n)."
     },
     {
       "authors": [
-        "T. K\u0151v\u00e1ri",
-        "V.T. S\u00f3s",
-        "P. Tur\u00e1n"
+        "T. Kővári",
+        "V.T. Sós",
+        "P. Turán"
       ],
       "title": "On a problem of K. Zarankiewicz",
       "venue": "Colloquium Mathematicum",
       "volume": "3",
       "year": "1954",
-      "pages": "50\u201357",
-      "note": "K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem on bipartite subgraph densities; the nearly-bipartite structure of Tur\u00e1n graph T(n,2) that achieves the upper bound in the h(n) problem relies on bipartite extremal results from this line of work."
+      "pages": "50–57",
+      "note": "Kővári–Sós–Turán theorem on bipartite subgraph densities; the nearly-bipartite structure of Turán graph T(n,2) that achieves the upper bound in the h(n) problem relies on bipartite extremal results from this line of work."
     }
   ],
   "leanFile": {
@@ -306,7 +306,7 @@
     "lineCount": 1018,
     "axiomCount": 3,
     "theoremCount": 28,
-    "definitionCount": 17,
+    "definitionCount": 19,
     "sorries": 0,
     "path": "Proofs/Erdos1033Problem.lean"
   },

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -215,7 +215,7 @@
     "lineCount": 255,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos1035Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -232,7 +232,7 @@
     "namespace": null,
     "lineCount": 640,
     "axiomCount": 4,
-    "theoremCount": 23,
+    "theoremCount": 22,
     "substantiveTheoremCount": 19,
     "trivialSpecializations": 0,
     "definitionCount": 19,

--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -217,7 +217,7 @@
     "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1051Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1053",
-  "title": "Erd\u0151s Problem #1053: Growth Rate of k-Perfect Numbers",
+  "title": "Erdős Problem #1053: Growth Rate of k-Perfect Numbers",
   "slug": "erdos-1053",
-  "description": "If \u03c3(n) = k\u00b7n (n is k-perfect), must k = o(log log n)? Known: k \u2264 11 exists. Gronwall: \u03c3(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
+  "description": "If σ(n) = k·n (n is k-perfect), must k = o(log log n)? Known: k ≤ 11 exists. Gronwall: σ(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
   "meta": {
-    "author": "Paul Erd\u0151s",
+    "author": "Paul Erdős",
     "erdosNumber": 1053,
     "erdosProblemStatus": "open",
     "status": "axiomatized",
@@ -57,10 +57,10 @@
     },
     {
       "id": "core-definitions",
-      "title": "Core Definitions: \u03c3(n) and k-Perfection",
+      "title": "Core Definitions: σ(n) and k-Perfection",
       "startLine": 28,
       "endLine": 48,
-      "summary": "Defines the sum-of-divisors function \u03c3(n), k-perfect numbers (\u03c3(n) = kn), decidability instance, and the abundancy index \u03c3(n)/n.",
+      "summary": "Defines the sum-of-divisors function σ(n), k-perfect numbers (σ(n) = kn), decidability instance, and the abundancy index σ(n)/n.",
       "mathContext": "$\\sigma(n) = \\sum_{d \\mid n} d$; $\\text{IsKPerfect}(n, k) \\Leftrightarrow \\sigma(n) = k \\cdot n$; abundancy index $I(n) = \\sigma(n)/n$. For prime powers: $\\sigma(p^a) = (p^{a+1}-1)/(p-1)$."
     },
     {
@@ -73,7 +73,7 @@
     },
     {
       "id": "multiperfect",
-      "title": "Multiperfect Numbers (k \u2265 3)",
+      "title": "Multiperfect Numbers (k ≥ 3)",
       "startLine": 82,
       "endLine": 96,
       "summary": "Known triperfect examples (k=3) and the existence of 11-perfect numbers, the largest known multiplicity.",
@@ -84,7 +84,7 @@
       "title": "The Main Conjecture: k = o(log log n)",
       "startLine": 97,
       "endLine": 108,
-      "summary": "States Erd\u0151s's central question: must the perfection multiplicity k grow strictly slower than log log n?",
+      "summary": "States Erdős's central question: must the perfection multiplicity k grow strictly slower than log log n?",
       "mathContext": "Conjecture: $\\sigma(n) = kn \\implies k = o(\\log\\log n)$. Equivalently, $k / \\log\\log n \\to 0$ along the sequence of $k$-perfect numbers."
     },
     {
@@ -92,7 +92,7 @@
       "title": "Gronwall's Theorem and Robin's Inequality",
       "startLine": 109,
       "endLine": 123,
-      "summary": "Gronwall's 1913 result establishing e^\u03b3 \u00b7 log log n as the natural scale, and Robin's 1984 conditional upper bound from the Riemann Hypothesis.",
+      "summary": "Gronwall's 1913 result establishing e^γ · log log n as the natural scale, and Robin's 1984 conditional upper bound from the Riemann Hypothesis.",
       "mathContext": "Gronwall: $\\limsup \\sigma(n)/(n \\log\\log n) = e^\\gamma \\approx 1.781$. Robin (conditional on RH): $\\sigma(n) < e^\\gamma \\cdot n \\cdot \\log\\log n$ for $n \\geq 5041$, giving $k < e^\\gamma \\cdot \\log\\log n$."
     },
     {
@@ -100,21 +100,21 @@
       "title": "Guy's Finiteness Conjecture and Robin's Criterion",
       "startLine": 124,
       "endLine": 152,
-      "summary": "Guy's stronger conjecture (finitely many k-perfect numbers for each k \u2265 3) and the derivation of k = O(log log n) from Robin's criterion.",
+      "summary": "Guy's stronger conjecture (finitely many k-perfect numbers for each k ≥ 3) and the derivation of k = O(log log n) from Robin's criterion.",
       "mathContext": "Guy: $\\forall k \\geq 3, |\\{n : \\sigma(n) = kn\\}| < \\infty$. Robin's criterion derivation: $\\sigma(n) = kn < e^\\gamma n \\log\\log n \\implies k < e^\\gamma \\log\\log n = O(\\log\\log n)$."
     }
   ],
   "overview": {
-    "historicalContext": "The study of perfect numbers ($\\sigma(n) = 2n$) is among the oldest in mathematics, originating with Euclid's *Elements* (Book IX, Proposition 36, c. 300 BCE). The generalization to multiperfect numbers ($\\sigma(n) = kn$ for $k \\geq 3$) was explored by medieval and Renaissance mathematicians, with Robert Recorde noting 120 as triperfect in 1557. Systematic computational searches in the 20th century found multiperfect numbers up to $k = 11$. Thomas Gronwall's 1913 theorem established that $\\limsup \\sigma(n)/(n \\log\\log n) = e^\\gamma$, setting the natural scale. Guy Robin's 1984 breakthrough showed his inequality $\\sigma(n) < e^\\gamma \\cdot n \\cdot \\log\\log n$ (for $n \\geq 5041$) is equivalent to the Riemann Hypothesis, creating a deep connection between perfect number theory and the distribution of primes. Erd\u0151s's question asks whether the integers where $\\sigma(n)/n$ is exactly an integer are forced strictly below Gronwall's extremal growth rate.",
+    "historicalContext": "The study of perfect numbers ($\\sigma(n) = 2n$) is among the oldest in mathematics, originating with Euclid's *Elements* (Book IX, Proposition 36, c. 300 BCE). The generalization to multiperfect numbers ($\\sigma(n) = kn$ for $k \\geq 3$) was explored by medieval and Renaissance mathematicians, with Robert Recorde noting 120 as triperfect in 1557. Systematic computational searches in the 20th century found multiperfect numbers up to $k = 11$. Thomas Gronwall's 1913 theorem established that $\\limsup \\sigma(n)/(n \\log\\log n) = e^\\gamma$, setting the natural scale. Guy Robin's 1984 breakthrough showed his inequality $\\sigma(n) < e^\\gamma \\cdot n \\cdot \\log\\log n$ (for $n \\geq 5041$) is equivalent to the Riemann Hypothesis, creating a deep connection between perfect number theory and the distribution of primes. Erdős's question asks whether the integers where $\\sigma(n)/n$ is exactly an integer are forced strictly below Gronwall's extremal growth rate.",
     "problemStatement": "If $n$ is $k$-perfect ($\\sigma(n) = k \\cdot n$), must $k = o(\\log\\log n)$? That is, does the multiplicative perfection ratio grow strictly slower than $\\log\\log n$ along the sequence of $k$-perfect numbers?",
-    "text": "If \u03c3(n) = k\u00b7n (n is k-perfect), must k = o(log log n)? Known: k \u2264 11 exists. Gronwall: \u03c3(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
-    "proofStrategy": "The formalization axiomatizes the sum-of-divisors function $\\sigma(n)$, defines $k$-perfect numbers, catalogs known examples for $k = 1$ through $k = 11$, states the Euclid\u2013Euler characterization for even perfect numbers, presents Gronwall's extremal bound and Robin's conditional inequality, and formally states the main $o(\\log\\log n)$ conjecture alongside Guy's stronger finiteness conjecture. The final section explicitly derives $k = O(\\log\\log n)$ from Robin's inequality.",
+    "text": "If σ(n) = k·n (n is k-perfect), must k = o(log log n)? Known: k ≤ 11 exists. Gronwall: σ(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
+    "proofStrategy": "The formalization axiomatizes the sum-of-divisors function $\\sigma(n)$, defines $k$-perfect numbers, catalogs known examples for $k = 1$ through $k = 11$, states the Euclid–Euler characterization for even perfect numbers, presents Gronwall's extremal bound and Robin's conditional inequality, and formally states the main $o(\\log\\log n)$ conjecture alongside Guy's stronger finiteness conjecture. The final section explicitly derives $k = O(\\log\\log n)$ from Robin's inequality.",
     "keyInsights": [
       "The abundancy index $\\sigma(n)/n$ is a multiplicative function: for coprime $m,n$, $\\sigma(mn)/(mn) = (\\sigma(m)/m)(\\sigma(n)/n)$, so high abundancy requires many prime factors",
-      "Gronwall's theorem sets $e^\\gamma \\cdot \\log\\log n$ as the extremal growth rate for $\\sigma(n)/n$, achieved along primorial-type numbers \u2014 Erd\u0151s asks if $k$-perfect numbers can reach this ceiling",
+      "Gronwall's theorem sets $e^\\gamma \\cdot \\log\\log n$ as the extremal growth rate for $\\sigma(n)/n$, achieved along primorial-type numbers — Erdős asks if $k$-perfect numbers can reach this ceiling",
       "Robin's inequality is equivalent to the Riemann Hypothesis, connecting k-perfect number growth to the deepest conjecture in analytic number theory",
-      "The gap between $O(\\log\\log n)$ (conditional on RH) and $o(\\log\\log n)$ (Erd\u0151s's question) is the precise frontier: can $k$-perfect numbers approach the Gronwall bound?",
-      "Guy's finiteness conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) is strictly stronger and would resolve Erd\u0151s's question trivially",
+      "The gap between $O(\\log\\log n)$ (conditional on RH) and $o(\\log\\log n)$ (Erdős's question) is the precise frontier: can $k$-perfect numbers approach the Gronwall bound?",
+      "Guy's finiteness conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) is strictly stronger and would resolve Erdős's question trivially",
       "No $k = 12$ perfect number is known despite exhaustive search, suggesting the frontier of computability has been reached near $k = 11$"
     ],
     "prerequisites": [
@@ -126,10 +126,10 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #1053 and its mathematical context: the growth rate of the perfection multiplicity $k$ for $k$-perfect numbers. The key tension is between Gronwall's theorem (showing $\\sigma(n)/n$ can reach $\\sim e^\\gamma \\cdot \\log\\log n$) and the open question of whether $k$-perfect numbers \u2014 where $\\sigma(n)/n$ is exactly an integer \u2014 can saturate this bound. Robin's inequality gives $k = O(\\log\\log n)$ conditional on RH; the $o(\\log\\log n)$ question remains open.",
-    "implications": "**Theoretical Significance**:\n\n1. **EXACT vs APPROXIMATE EXTREMALITY**: A proof of $k = o(\\log\\log n)$ would demonstrate a fundamental gap between what $\\sigma(n)/n$ can achieve approximately (Gronwall: $\\limsup = e^\\gamma \\log\\log n$) and exactly (no $k$-perfect $n$ with $k$ approaching $e^\\gamma \\log\\log n$). This would reveal that the multiplicative structure required for $n \\mid \\sigma(n)$ imposes arithmetic constraints that prevent extremality.\n\n2. **RIEMANN HYPOTHESIS CONNECTION**: Robin's inequality $\\sigma(n) < e^\\gamma n \\log\\log n$ for $n \\geq 5041$ is equivalent to RH. The conditional bound $k = O(\\log\\log n)$ thus means Erd\u0151s's question is at least as hard as proving $k$ cannot reach the $O$-constant \u2014 progress would illuminate the boundary between the $O$ and $o$ regimes that RH controls.\n\n3. **SMOOTH NUMBER ANATOMY**: Colossally abundant numbers (which extremize $\\sigma(n)/n$) have specific prime factorization patterns with many small prime factors. Understanding whether $k$-perfect numbers can mimic these patterns connects to the distribution of smooth numbers and the anatomy of highly composite numbers.\n\n4. **FINITENESS CONJECTURE**: Guy's stronger conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) would trivially resolve Erd\u0151s's question. Progress on finiteness for any specific $k \\geq 3$ would be a major advance in multiplicative number theory.",
+    "summary": "This formalization captures Erdős Problem #1053 and its mathematical context: the growth rate of the perfection multiplicity $k$ for $k$-perfect numbers. The key tension is between Gronwall's theorem (showing $\\sigma(n)/n$ can reach $\\sim e^\\gamma \\cdot \\log\\log n$) and the open question of whether $k$-perfect numbers — where $\\sigma(n)/n$ is exactly an integer — can saturate this bound. Robin's inequality gives $k = O(\\log\\log n)$ conditional on RH; the $o(\\log\\log n)$ question remains open.",
+    "implications": "**Theoretical Significance**:\n\n1. **EXACT vs APPROXIMATE EXTREMALITY**: A proof of $k = o(\\log\\log n)$ would demonstrate a fundamental gap between what $\\sigma(n)/n$ can achieve approximately (Gronwall: $\\limsup = e^\\gamma \\log\\log n$) and exactly (no $k$-perfect $n$ with $k$ approaching $e^\\gamma \\log\\log n$). This would reveal that the multiplicative structure required for $n \\mid \\sigma(n)$ imposes arithmetic constraints that prevent extremality.\n\n2. **RIEMANN HYPOTHESIS CONNECTION**: Robin's inequality $\\sigma(n) < e^\\gamma n \\log\\log n$ for $n \\geq 5041$ is equivalent to RH. The conditional bound $k = O(\\log\\log n)$ thus means Erdős's question is at least as hard as proving $k$ cannot reach the $O$-constant — progress would illuminate the boundary between the $O$ and $o$ regimes that RH controls.\n\n3. **SMOOTH NUMBER ANATOMY**: Colossally abundant numbers (which extremize $\\sigma(n)/n$) have specific prime factorization patterns with many small prime factors. Understanding whether $k$-perfect numbers can mimic these patterns connects to the distribution of smooth numbers and the anatomy of highly composite numbers.\n\n4. **FINITENESS CONJECTURE**: Guy's stronger conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) would trivially resolve Erdős's question. Progress on finiteness for any specific $k \\geq 3$ would be a major advance in multiplicative number theory.",
     "openQuestions": [
-      "Must $k = o(\\log\\log n)$ for $k$-perfect numbers? (Erd\u0151s Problem #1053)",
+      "Must $k = o(\\log\\log n)$ for $k$-perfect numbers? (Erdős Problem #1053)",
       "Are there only finitely many $k$-perfect numbers for each $k \\geq 3$? (Guy's conjecture, strictly stronger)",
       "Does a $k = 12$ perfect number exist, or is $k = 11$ the absolute maximum?",
       "Do odd perfect numbers ($k = 2$, $n$ odd) exist? (Open since antiquity, known: if one exists, $n > 10^{1500}$)"
@@ -139,37 +139,37 @@
     {
       "targetId": "euler-totient",
       "relationship": "related",
-      "description": "Euler's totient \u03c6(n) and the sum-of-divisors \u03c3(n) are both fundamental multiplicative arithmetic functions. Their interplay governs the structure of perfect numbers: for primes p, \u03c3(p) = p+1 while \u03c6(p) = p\u22121, and highly composite numbers extremize both."
+      "description": "Euler's totient φ(n) and the sum-of-divisors σ(n) are both fundamental multiplicative arithmetic functions. Their interplay governs the structure of perfect numbers: for primes p, σ(p) = p+1 while φ(p) = p−1, and highly composite numbers extremize both."
     },
     {
       "targetId": "fundamental-arithmetic",
       "relationship": "depends-on",
-      "description": "The multiplicativity of \u03c3 \u2014 the key property \u03c3(mn) = \u03c3(m)\u03c3(n) for gcd(m,n) = 1 \u2014 follows directly from the Fundamental Theorem of Arithmetic. This multiplicativity is what allows the abundancy index \u03c3(n)/n to be analyzed prime-factor by prime-factor."
+      "description": "The multiplicativity of σ — the key property σ(mn) = σ(m)σ(n) for gcd(m,n) = 1 — follows directly from the Fundamental Theorem of Arithmetic. This multiplicativity is what allows the abundancy index σ(n)/n to be analyzed prime-factor by prime-factor."
     },
     {
       "targetId": "infinitude-primes",
       "relationship": "related",
-      "description": "Gronwall's extremal bound \u03c3(n)/n ~ e^\u03b3 \u00b7 log log n is achieved along primorial-type numbers (products of the first k primes). The infinitude of primes ensures this sequence grows without bound, setting the asymptotic ceiling that Erd\u0151s asks whether k-perfect numbers can approach."
+      "description": "Gronwall's extremal bound σ(n)/n ~ e^γ · log log n is achieved along primorial-type numbers (products of the first k primes). The infinitude of primes ensures this sequence grows without bound, setting the asymptotic ceiling that Erdős asks whether k-perfect numbers can approach."
     },
     {
       "targetId": "erdos-1054",
       "relationship": "related",
-      "description": "Erd\u0151s Problem #1054 concerns the distribution and density of multiply-perfect numbers, directly complementing the growth-rate question here. Together they form a two-part study of the k-perfect number sequence."
+      "description": "Erdős Problem #1054 concerns the distribution and density of multiply-perfect numbers, directly complementing the growth-rate question here. Together they form a two-part study of the k-perfect number sequence."
     },
     {
       "targetId": "erdos-1003",
       "relationship": "related",
-      "description": "Erd\u0151s Problem #1003 concerns the distribution of the abundancy index \u03c3(n)/n over integers, studying when large values occur. The k-perfect numbers \u2014 where \u03c3(n)/n is exactly an integer \u2014 are a special discrete sub-problem within this continuous distribution question."
+      "description": "Erdős Problem #1003 concerns the distribution of the abundancy index σ(n)/n over integers, studying when large values occur. The k-perfect numbers — where σ(n)/n is exactly an integer — are a special discrete sub-problem within this continuous distribution question."
     },
     {
       "targetId": "erdos-1004",
       "relationship": "related",
-      "description": "Erd\u0151s Problem #1004 studies the sum \u2211 \u03c3(n)/n over structured sets, connecting the local behavior of \u03c3(n)/n at k-perfect numbers to global averaging results. Both problems probe the same extremal arithmetic landscape."
+      "description": "Erdős Problem #1004 studies the sum ∑ σ(n)/n over structured sets, connecting the local behavior of σ(n)/n at k-perfect numbers to global averaging results. Both problems probe the same extremal arithmetic landscape."
     },
     {
       "targetId": "perfect-numbers",
       "relationship": "specialization",
-      "description": "Perfect numbers ($\\sigma(n) = 2n$, i.e., $k = 2$) are the foundational case of $k$-perfect numbers. Euclid proved even perfect numbers have the form $2^{p-1}(2^p - 1)$ when $2^p - 1$ is prime (Mersenne prime). Problem #1053 asks whether the sequence of $k$-perfect numbers for all $k \\geq 2$ grows fast enough \u2014 a generalization of the ancient question about the distribution of perfect numbers themselves"
+      "description": "Perfect numbers ($\\sigma(n) = 2n$, i.e., $k = 2$) are the foundational case of $k$-perfect numbers. Euclid proved even perfect numbers have the form $2^{p-1}(2^p - 1)$ when $2^p - 1$ is prime (Mersenne prime). Problem #1053 asks whether the sequence of $k$-perfect numbers for all $k \\geq 2$ grows fast enough — a generalization of the ancient question about the distribution of perfect numbers themselves"
     },
     {
       "targetId": "erdos-1060",
@@ -187,43 +187,43 @@
       "authors": "Gronwall, T. H.",
       "title": "Some asymptotic expressions in the theory of numbers",
       "year": "1913",
-      "venue": "Transactions of the American Mathematical Society, 14(1), 113\u2013122",
-      "note": "Proves lim sup \u03c3(n)/(n log log n) = e^\u03b3, establishing the natural scale for the abundancy index and the ceiling that k-perfect numbers would have to approach."
+      "venue": "Transactions of the American Mathematical Society, 14(1), 113–122",
+      "note": "Proves lim sup σ(n)/(n log log n) = e^γ, establishing the natural scale for the abundancy index and the ceiling that k-perfect numbers would have to approach."
     },
     {
       "authors": "Robin, G.",
-      "title": "Grandes valeurs de la fonction somme des diviseurs et hypoth\u00e8se de Riemann",
+      "title": "Grandes valeurs de la fonction somme des diviseurs et hypothèse de Riemann",
       "year": "1984",
-      "venue": "Journal de Math\u00e9matiques Pures et Appliqu\u00e9es, 63(2), 187\u2013213",
-      "note": "Shows that \u03c3(n) < e^\u03b3 \u00b7 n \u00b7 log log n for all n \u2265 5041 is equivalent to the Riemann Hypothesis, giving the conditional k = O(log log n) bound for k-perfect numbers."
+      "venue": "Journal de Mathématiques Pures et Appliquées, 63(2), 187–213",
+      "note": "Shows that σ(n) < e^γ · n · log log n for all n ≥ 5041 is equivalent to the Riemann Hypothesis, giving the conditional k = O(log log n) bound for k-perfect numbers."
     },
     {
-      "authors": "Alaoglu, L. and Erd\u0151s, P.",
+      "authors": "Alaoglu, L. and Erdős, P.",
       "title": "On highly composite and similar numbers",
       "year": "1944",
-      "venue": "Transactions of the American Mathematical Society, 56(3), 448\u2013469",
-      "note": "Introduces colossally abundant numbers, characterizes the extremal behavior of \u03c3(n)/n, and lays groundwork for understanding which integers can achieve large abundancy indices."
+      "venue": "Transactions of the American Mathematical Society, 56(3), 448–469",
+      "note": "Introduces colossally abundant numbers, characterizes the extremal behavior of σ(n)/n, and lays groundwork for understanding which integers can achieve large abundancy indices."
     },
     {
       "authors": "Guy, R. K.",
       "title": "Unsolved Problems in Number Theory, 3rd edition, Problem B2",
       "year": "2004",
       "venue": "Springer, New York",
-      "note": "Surveys the state of k-perfect numbers including the stronger conjecture that each k \u2265 3 has only finitely many k-perfect numbers, and catalogs known examples up to k = 11."
+      "note": "Surveys the state of k-perfect numbers including the stronger conjecture that each k ≥ 3 has only finitely many k-perfect numbers, and catalogs known examples up to k = 11."
     },
     {
       "authors": "Kanold, H.-J.",
-      "title": "\u00dcber mehrfach vollkommene Zahlen",
+      "title": "Über mehrfach vollkommene Zahlen",
       "year": "1956",
-      "venue": "Journal f\u00fcr die reine und angewandte Mathematik, 197, 82\u201396",
+      "venue": "Journal für die reine und angewandte Mathematik, 197, 82–96",
       "note": "Derives structural necessary conditions for multiply perfect numbers using prime factorization constraints, providing the best unconditional bounds on k available without RH."
     },
     {
       "authors": "Ramanujan, S.",
       "title": "Highly composite numbers",
       "year": "1915",
-      "venue": "Proceedings of the London Mathematical Society, 2(14), 347\u2013409",
-      "note": "Extensive study of the extremal behavior of \u03c3(n)/n, introducing highly composite numbers and establishing foundational results on the distribution of divisor sums."
+      "venue": "Proceedings of the London Mathematical Society, 2(14), 347–409",
+      "note": "Extensive study of the extremal behavior of σ(n)/n, introducing highly composite numbers and establishing foundational results on the distribution of divisor sums."
     }
   ],
   "leanFile": {
@@ -237,22 +237,22 @@
     "theoremCount": 10,
     "substantiveTheoremCount": 2,
     "computationalVerifications": 2,
-    "definitionCount": 4,
+    "definitionCount": 3,
     "mainTheorems": [
       {
         "name": "one_perfect_unique",
         "type": "proved",
-        "description": "The only 1-perfect number is 1 (\u03c3(n) = n implies n = 1)"
+        "description": "The only 1-perfect number is 1 (σ(n) = n implies n = 1)"
       },
       {
         "name": "robin_gives_O_bound",
         "type": "proved",
-        "description": "Robin's inequality (conditional on RH) implies k = O(log log n) for k-perfect n \u2265 5041"
+        "description": "Robin's inequality (conditional on RH) implies k = O(log log n) for k-perfect n ≥ 5041"
       },
       {
         "name": "sigma_def",
         "type": "proved",
-        "description": "\u03c3(n) = \u2211 d, d | n \u2014 the divisor sum function as a Finset.sum"
+        "description": "σ(n) = ∑ d, d | n — the divisor sum function as a Finset.sum"
       }
     ],
     "path": "Proofs/Erdos1053Problem.lean",

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -258,7 +258,7 @@
     "lineCount": 254,
     "axiomCount": 2,
     "theoremCount": 35,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1055Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -238,7 +238,8 @@
       "Mathlib.Tactic"
     ],
     "path": "Proofs/Erdos1059Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 2
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -246,7 +246,8 @@
     "opens": [],
     "namespace": null,
     "path": "Proofs/Erdos1065Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1066/meta.json
+++ b/src/data/proofs/erdos-1066/meta.json
@@ -225,7 +225,7 @@
     "lineCount": 118,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1066Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1069/meta.json
+++ b/src/data/proofs/erdos-1069/meta.json
@@ -250,7 +250,7 @@
     "lineCount": 179,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos1069Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1070",
-  "title": "Erd\u0151s Problem #1070: Independence Number of Unit Distance Graphs",
+  "title": "Erdős Problem #1070: Independence Number of Unit Distance Graphs",
   "slug": "erdos-1070",
-  "description": "Estimate f(n), the minimum independence number of n-point unit distance graphs in \u211d\u00b2. Is f(n) \u2265 n/4? Best bounds: 0.22936n \u2264 f(n) \u2264 (2/7)n. The n/4 question cannot be resolved via density methods.",
+  "description": "Estimate f(n), the minimum independence number of n-point unit distance graphs in ℝ². Is f(n) ≥ n/4? Best bounds: 0.22936n ≤ f(n) ≤ (2/7)n. The n/4 question cannot be resolved via density methods.",
   "meta": {
-    "author": "Erd\u0151s, Larman-Rogers, Croft, ACMVZ",
+    "author": "Erdős, Larman-Rogers, Croft, ACMVZ",
     "sourceUrl": "https://erdosproblems.com/1070",
     "date": "",
     "status": "axiomatized",
@@ -29,7 +29,7 @@
       },
       {
         "id": "erdos-232",
-        "relationship": "Density m\u2081 of unit-distance-free sets"
+        "relationship": "Density m₁ of unit-distance-free sets"
       },
       {
         "id": "erdos-1066",
@@ -42,16 +42,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Unit Distance Graphs, Density, and the Independence Threshold**\n\nA *unit distance graph* (UDG) on $n$ points in $\\mathbb{R}^2$ has edges between points at Euclidean distance exactly 1. The *independence number* $\\alpha(G)$ is the size of the largest subset with no edges. Erd\u0151s defined $f(n) = \\min_G \\alpha(G)$ over all $n$-point UDGs and asked for its growth rate \u2014 in particular, whether $f(n) \\geq n/4$.\n\n**The Larman-Rogers Bridge (1972)**: The key insight connecting discrete and continuous. Let $m_1 = \\sup\\{\\overline{d}(S) : S \\subseteq \\mathbb{R}^2 \\text{ measurable, unit-distance-free}\\}$ be the maximum density of a measurable set avoiding unit distances. Larman and Rogers proved $f(n) \\geq m_1 \\cdot n$ by a probabilistic argument: a random translate of a high-density unit-distance-free set captures $\\geq m_1 n$ of any $n$ given points in expectation.\n\n**Croft's Construction (1967)**: Croft built explicit unit-distance-free sets from hexagonal lattices, proving $m_1 \\geq 0.22936$. Combined with Larman-Rogers: $f(n) \\geq 0.22936n$. This lower bound has stood for over 55 years.\n\n**The Moser Spindle (1961)**: Leo and William Moser constructed a 7-vertex UDG with independence number exactly 2 (and chromatic number 4). By tiling with $\\lfloor n/7 \\rfloor$ copies: $f(n) \\leq (2/7)n \\approx 0.286n$.\n\n**ACMVZ Barrier (2023)**: Ambrus, Csisz\u00e1rik, Matolcsi, Varga, and Zs\u00e1mboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods \u2014 the constraint $d(p,q) \\neq 1$ translates to conditions on Bessel function zeros in the Fourier domain. Since $0.247 < 0.25 = 1/4$, this establishes a *barrier*: the density method alone cannot prove $f(n) \\geq n/4$.\n\n**De Grey and Hadwiger-Nelson (2018)**: The chromatic number $\\chi$ of $\\mathbb{R}^2$ satisfies $5 \\leq \\chi \\leq 7$ (de Grey improved the lower bound from 4 to 5). Since $\\alpha(G) \\cdot \\chi(G) \\geq |V(G)|$, we get $f(n) \\geq n/\\chi \\geq n/7$.\n\n**Current State**: Best bounds $0.22936n \\leq f(n) \\leq (2/7)n$, with the $n/4$ question requiring genuinely new techniques beyond density.",
-    "problemStatement": "**Problem Statement**\n\nLet f(n) be the maximum k such that any n points in \u211d\u00b2 contain k points with no two at distance 1. Estimate f(n).\n\n**Main Question**: Is f(n) \u2265 n/4?\n\n**Best Known Bounds**: 0.22936n \u2264 f(n) \u2264 (2/7)n \u2248 0.285n\n\n**Status**: OPEN - bounds established but exact asymptotic unknown",
-    "text": "Estimate f(n), the minimum independence number of n-point unit distance graphs in \u211d\u00b2. Is f(n) \u2265 n/4? Best bounds: 0.22936n \u2264 f(n) \u2264 (2/7)n. The n/4 question cannot be resolved via density methods.",
-    "proofStrategy": "**Three-Layer Formalization with Proved Theorems and Density Barrier**\n\nThe formalization builds from geometric definitions through axiomatized deep results to proved theorems, including a genuine impossibility result.\n\n**Layer 1 \u2014 Definitions (fully formalized)**: `euclideanDist` wraps Mathlib's `dist` on `EuclideanSpace \\mathbb{R} (\\text{Fin}\\, 2)`. `isUnitDistance` checks $d(p,q) = 1$. `UnitDistanceGraph n` stores a `Finset` of $n$ points with `card_eq` proof. `IsIndependentSet` requires $S \\subseteq V(G)$ and $\\forall p \\neq q \\in S,\\, d(p,q) \\neq 1$. `independenceNumber` uses `Finset.sup` over `powerset.filter`.\n\n**Layer 2 \u2014 Axiomatized quantities and results**: The function `f(n)` is axiomatized with `f_is_minimum` and `f_is_achieved` ensuring it is a valid extremal quantity. The density constant `m1` is axiomatized with positivity and boundedness. Key results axiomatized: `larman_rogers_theorem` ($f(n) \\geq m_1 n$), `croft_lower_bound` ($m_1 \\geq 0.22936$), `moser_spindle_exists` and `moser_spindle_upper_bound` ($f(n) \\leq (2/7)n$), `acmvz_upper_bound` ($m_1 \\leq 0.247$), Hadwiger-Nelson bounds ($5 \\leq \\chi \\leq 7$).\n\n**Layer 3 \u2014 Proved theorems**: `f_lower_bound` chains `larman_rogers_theorem` with `croft_lower_bound` via `nlinarith`. `best_known_bounds` packages both bounds via `exact \u27e8f_lower_bound n, moser_spindle_upper_bound n\u27e9`. `quarter_threshold` verifies $0.247 < 1/4$ by `norm_num`. `density_insufficient_for_quarter` chains `acmvz_upper_bound` with `quarter_threshold` via `calc`. The summary theorem packages all three results.\n\nAll theorems are fully proved (0 sorries). `f_from_chromatic` was proved via explicit fraction clearing and monotonicity arguments; `quarter_conjecture_open` was removed (the $n/4$ question is genuinely open and not formalized as a sorry).",
+    "historicalContext": "**Unit Distance Graphs, Density, and the Independence Threshold**\n\nA *unit distance graph* (UDG) on $n$ points in $\\mathbb{R}^2$ has edges between points at Euclidean distance exactly 1. The *independence number* $\\alpha(G)$ is the size of the largest subset with no edges. Erdős defined $f(n) = \\min_G \\alpha(G)$ over all $n$-point UDGs and asked for its growth rate — in particular, whether $f(n) \\geq n/4$.\n\n**The Larman-Rogers Bridge (1972)**: The key insight connecting discrete and continuous. Let $m_1 = \\sup\\{\\overline{d}(S) : S \\subseteq \\mathbb{R}^2 \\text{ measurable, unit-distance-free}\\}$ be the maximum density of a measurable set avoiding unit distances. Larman and Rogers proved $f(n) \\geq m_1 \\cdot n$ by a probabilistic argument: a random translate of a high-density unit-distance-free set captures $\\geq m_1 n$ of any $n$ given points in expectation.\n\n**Croft's Construction (1967)**: Croft built explicit unit-distance-free sets from hexagonal lattices, proving $m_1 \\geq 0.22936$. Combined with Larman-Rogers: $f(n) \\geq 0.22936n$. This lower bound has stood for over 55 years.\n\n**The Moser Spindle (1961)**: Leo and William Moser constructed a 7-vertex UDG with independence number exactly 2 (and chromatic number 4). By tiling with $\\lfloor n/7 \\rfloor$ copies: $f(n) \\leq (2/7)n \\approx 0.286n$.\n\n**ACMVZ Barrier (2023)**: Ambrus, Csiszárik, Matolcsi, Varga, and Zsámboki proved $m_1 \\leq 0.247$ using Fourier-analytic methods — the constraint $d(p,q) \\neq 1$ translates to conditions on Bessel function zeros in the Fourier domain. Since $0.247 < 0.25 = 1/4$, this establishes a *barrier*: the density method alone cannot prove $f(n) \\geq n/4$.\n\n**De Grey and Hadwiger-Nelson (2018)**: The chromatic number $\\chi$ of $\\mathbb{R}^2$ satisfies $5 \\leq \\chi \\leq 7$ (de Grey improved the lower bound from 4 to 5). Since $\\alpha(G) \\cdot \\chi(G) \\geq |V(G)|$, we get $f(n) \\geq n/\\chi \\geq n/7$.\n\n**Current State**: Best bounds $0.22936n \\leq f(n) \\leq (2/7)n$, with the $n/4$ question requiring genuinely new techniques beyond density.",
+    "problemStatement": "**Problem Statement**\n\nLet f(n) be the maximum k such that any n points in ℝ² contain k points with no two at distance 1. Estimate f(n).\n\n**Main Question**: Is f(n) ≥ n/4?\n\n**Best Known Bounds**: 0.22936n ≤ f(n) ≤ (2/7)n ≈ 0.285n\n\n**Status**: OPEN - bounds established but exact asymptotic unknown",
+    "text": "Estimate f(n), the minimum independence number of n-point unit distance graphs in ℝ². Is f(n) ≥ n/4? Best bounds: 0.22936n ≤ f(n) ≤ (2/7)n. The n/4 question cannot be resolved via density methods.",
+    "proofStrategy": "**Three-Layer Formalization with Proved Theorems and Density Barrier**\n\nThe formalization builds from geometric definitions through axiomatized deep results to proved theorems, including a genuine impossibility result.\n\n**Layer 1 — Definitions (fully formalized)**: `euclideanDist` wraps Mathlib's `dist` on `EuclideanSpace \\mathbb{R} (\\text{Fin}\\, 2)`. `isUnitDistance` checks $d(p,q) = 1$. `UnitDistanceGraph n` stores a `Finset` of $n$ points with `card_eq` proof. `IsIndependentSet` requires $S \\subseteq V(G)$ and $\\forall p \\neq q \\in S,\\, d(p,q) \\neq 1$. `independenceNumber` uses `Finset.sup` over `powerset.filter`.\n\n**Layer 2 — Axiomatized quantities and results**: The function `f(n)` is axiomatized with `f_is_minimum` and `f_is_achieved` ensuring it is a valid extremal quantity. The density constant `m1` is axiomatized with positivity and boundedness. Key results axiomatized: `larman_rogers_theorem` ($f(n) \\geq m_1 n$), `croft_lower_bound` ($m_1 \\geq 0.22936$), `moser_spindle_exists` and `moser_spindle_upper_bound` ($f(n) \\leq (2/7)n$), `acmvz_upper_bound` ($m_1 \\leq 0.247$), Hadwiger-Nelson bounds ($5 \\leq \\chi \\leq 7$).\n\n**Layer 3 — Proved theorems**: `f_lower_bound` chains `larman_rogers_theorem` with `croft_lower_bound` via `nlinarith`. `best_known_bounds` packages both bounds via `exact ⟨f_lower_bound n, moser_spindle_upper_bound n⟩`. `quarter_threshold` verifies $0.247 < 1/4$ by `norm_num`. `density_insufficient_for_quarter` chains `acmvz_upper_bound` with `quarter_threshold` via `calc`. The summary theorem packages all three results.\n\nAll theorems are fully proved (0 sorries). `f_from_chromatic` was proved via explicit fraction clearing and monotonicity arguments; `quarter_conjecture_open` was removed (the $n/4$ question is genuinely open and not formalized as a sorry).",
     "keyInsights": [
-      "**Discrete-continuous bridge**: The Larman-Rogers theorem $f(n) \\geq m_1 \\cdot n$ converts the combinatorial independence problem into a continuous density optimization \u2014 this is one of the most elegant applications of the probabilistic method in discrete geometry",
-      "**Density barrier at $1/4$**: ACMVZ (2023) proved $m_1 \\leq 0.247 < 1/4$, establishing that the Larman-Rogers approach *cannot* prove $f(n) \\geq n/4$ \u2014 any such proof requires fundamentally new techniques, perhaps structural rather than density-based",
+      "**Discrete-continuous bridge**: The Larman-Rogers theorem $f(n) \\geq m_1 \\cdot n$ converts the combinatorial independence problem into a continuous density optimization — this is one of the most elegant applications of the probabilistic method in discrete geometry",
+      "**Density barrier at $1/4$**: ACMVZ (2023) proved $m_1 \\leq 0.247 < 1/4$, establishing that the Larman-Rogers approach *cannot* prove $f(n) \\geq n/4$ — any such proof requires fundamentally new techniques, perhaps structural rather than density-based",
       "**Moser spindle extremality**: The 7-vertex Moser spindle with $\\alpha = 2$ gives $f(n) \\leq (2/7)n \\approx 0.286n$; improving this requires finding a finite UDG with $\\alpha/|V| < 2/7$, which is tied to the chromatic number problem",
-      "**Three levels of lower bounds**: $n/7$ (from $\\chi \\leq 7$), $n/5$ (if $\\chi = 5$ exactly), $0.22936n$ (Croft), and the hypothetical $n/4$ (open) \u2014 each requires increasingly sophisticated arguments",
-      "**Connection to chromatic number**: $f(n) \\geq n/\\chi(\\mathbb{R}^2)$ means resolving the Hadwiger-Nelson problem ($5 \\leq \\chi \\leq 7$) would immediately improve independence bounds \u2014 if $\\chi = 5$ then $f(n) \\geq n/5 = 0.2n$, weaker than Croft but structurally different"
+      "**Three levels of lower bounds**: $n/7$ (from $\\chi \\leq 7$), $n/5$ (if $\\chi = 5$ exactly), $0.22936n$ (Croft), and the hypothetical $n/4$ (open) — each requires increasingly sophisticated arguments",
+      "**Connection to chromatic number**: $f(n) \\geq n/\\chi(\\mathbb{R}^2)$ means resolving the Hadwiger-Nelson problem ($5 \\leq \\chi \\leq 7$) would immediately improve independence bounds — if $\\chi = 5$ then $f(n) \\geq n/5 = 0.2n$, weaker than Croft but structurally different"
     ],
     "prerequisites": [
       "Graph theory fundamentals: independence number, chromatic number, bipartite structure",
@@ -90,16 +90,16 @@
       "title": "The Moser Spindle Upper Bound",
       "startLine": 119,
       "endLine": 149,
-      "summary": "Moser spindle: $\\exists G \\in \\text{UDG}(7) : \\alpha(G) = 2$; tiling gives `moser_spindle_upper_bound`: $f(n) \\leq (2/7)n$; `best_known_bounds` packages both via `exact \u27e8f_lower_bound n, moser_spindle_upper_bound n\u27e9`",
-      "mathContext": "Moser spindle: $\\exists G \\in \\text{UDG}(7) : \\alpha(G) = 2$; tiling gives `moser_spindle_upper_bound`: $f(n) \\leq (2/7)n$; `best_known_bounds` packages both via `exact \u27e8f_lower_bound n, moser_spindle_upper_bound n\u27e9`"
+      "summary": "Moser spindle: $\\exists G \\in \\text{UDG}(7) : \\alpha(G) = 2$; tiling gives `moser_spindle_upper_bound`: $f(n) \\leq (2/7)n$; `best_known_bounds` packages both via `exact ⟨f_lower_bound n, moser_spindle_upper_bound n⟩`",
+      "mathContext": "Moser spindle: $\\exists G \\in \\text{UDG}(7) : \\alpha(G) = 2$; tiling gives `moser_spindle_upper_bound`: $f(n) \\leq (2/7)n$; `best_known_bounds` packages both via `exact ⟨f_lower_bound n, moser_spindle_upper_bound n⟩`"
     },
     {
       "id": "quarter-question",
       "title": "The n/4 Question",
       "startLine": 150,
       "endLine": 169,
-      "summary": "`acmvz_upper_bound`: $m_1 \\leq 0.247$; `quarter_threshold`: $0.247 < 1/4$ by `norm_num`; `density_insufficient_for_quarter`: $m_1 < 1/4$ \u2014 density methods *cannot* prove $f(n) \\geq n/4$",
-      "mathContext": "`acmvz_upper_bound`: $m_1 \\leq 0.247$; `quarter_threshold`: $0.247 < 1/4$ by `norm_num`; `density_insufficient_for_quarter`: $m_1 < 1/4$ \u2014 density methods *cannot* prove $f(n) \\geq n/4$"
+      "summary": "`acmvz_upper_bound`: $m_1 \\leq 0.247$; `quarter_threshold`: $0.247 < 1/4$ by `norm_num`; `density_insufficient_for_quarter`: $m_1 < 1/4$ — density methods *cannot* prove $f(n) \\geq n/4$",
+      "mathContext": "`acmvz_upper_bound`: $m_1 \\leq 0.247$; `quarter_threshold`: $0.247 < 1/4$ by `norm_num`; `density_insufficient_for_quarter`: $m_1 < 1/4$ — density methods *cannot* prove $f(n) \\geq n/4$"
     },
     {
       "id": "hadwiger-nelson",
@@ -114,16 +114,16 @@
       "title": "Summary",
       "startLine": 197,
       "endLine": 235,
-      "summary": "`erdos_1070_summary`: $(\\forall n,\\, 0.22936n \\leq f(n)) \\land (\\forall n,\\, f(n) \\leq (2/7)n) \\land (m_1 < 1/4)$ via `exact \u27e8f_lower_bound, moser_spindle_upper_bound, density_insufficient_for_quarter\u27e9`",
-      "mathContext": "`erdos_1070_summary`: $(\\forall n,\\, 0.22936n \\leq f(n)) \\land (\\forall n,\\, f(n) \\leq (2/7)n) \\land (m_1 < 1/4)$ via `exact \u27e8f_lower_bound, moser_spindle_upper_bound, density_insufficient_for_quarter\u27e9`"
+      "summary": "`erdos_1070_summary`: $(\\forall n,\\, 0.22936n \\leq f(n)) \\land (\\forall n,\\, f(n) \\leq (2/7)n) \\land (m_1 < 1/4)$ via `exact ⟨f_lower_bound, moser_spindle_upper_bound, density_insufficient_for_quarter⟩`",
+      "mathContext": "`erdos_1070_summary`: $(\\forall n,\\, 0.22936n \\leq f(n)) \\land (\\forall n,\\, f(n) \\leq (2/7)n) \\land (m_1 < 1/4)$ via `exact ⟨f_lower_bound, moser_spindle_upper_bound, density_insufficient_for_quarter⟩`"
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #1070 on the independence number $f(n)$ of $n$-point unit distance graphs in $\\mathbb{R}^2$. The Larman-Rogers theorem bridges discrete independence to continuous density $m_1$, and Croft's construction gives $f(n) \\geq 0.22936n$. The Moser spindle provides the upper bound $f(n) \\leq (2/7)n$. The ACMVZ barrier ($m_1 \\leq 0.247 < 1/4$) is formalized as a proved theorem `density_insufficient_for_quarter`, establishing that Erd\u0151s's $n/4$ question requires genuinely new techniques. The summary theorem `erdos_1070_summary` packages all three results. One sorry remains: `quarter_conjecture_open` (the open problem itself). The previously sorry'd `f_from_chromatic` is now fully proved.",
-    "implications": "1. **Discrete-continuous duality**: The Larman-Rogers bridge $f(n) \\geq m_1 \\cdot n$ is a paradigmatic example of converting discrete combinatorial problems to continuous optimization. Similar techniques appear in sphere packing (Cohn-Elkies), graph limits (Lov\u00e1sz), and flag algebras (Razborov).\n\n2. **Density barrier as impossibility**: The proved theorem $m_1 < 1/4$ is a *barrier result* \u2014 it shows that an entire class of techniques (density-based arguments) is insufficient for the target bound. This is analogous to oracle separations in complexity theory or the Razborov-Rudich natural proofs barrier.\n\n**3. Moser spindle and chromatic number**: The Moser spindle simultaneously gives $\\alpha/n \\leq 2/7$ (independence bound) and $\\chi \\geq 4$ (coloring bound). Improving the upper bound on $f(n)/n$ requires finding finite UDGs with smaller $\\alpha/n$ ratios, which is equivalent to finding UDGs with larger chromatic number \u2014 directly linking to the Hadwiger-Nelson problem.\n\n4. **Fourier-analytic methods in combinatorics**: The ACMVZ bound $m_1 \\leq 0.247$ uses the Fourier transform and Bessel functions, exemplifying how harmonic analysis constrains combinatorial objects. This approach has also yielded breakthroughs in the Kakeya problem and Falconer's distance conjecture.\n\n5. **Formalization of open problems**: By axiomatizing $f(n)$ and proving what current methods achieve, the formalization creates a precise specification of the remaining gap \u2014 any claimed proof of $f(n) \\geq n/4$ would need to supply a proof term for `quarter_conjecture_open` without relying solely on `m1`.",
+    "summary": "This formalization captures Erdős Problem #1070 on the independence number $f(n)$ of $n$-point unit distance graphs in $\\mathbb{R}^2$. The Larman-Rogers theorem bridges discrete independence to continuous density $m_1$, and Croft's construction gives $f(n) \\geq 0.22936n$. The Moser spindle provides the upper bound $f(n) \\leq (2/7)n$. The ACMVZ barrier ($m_1 \\leq 0.247 < 1/4$) is formalized as a proved theorem `density_insufficient_for_quarter`, establishing that Erdős's $n/4$ question requires genuinely new techniques. The summary theorem `erdos_1070_summary` packages all three results. One sorry remains: `quarter_conjecture_open` (the open problem itself). The previously sorry'd `f_from_chromatic` is now fully proved.",
+    "implications": "1. **Discrete-continuous duality**: The Larman-Rogers bridge $f(n) \\geq m_1 \\cdot n$ is a paradigmatic example of converting discrete combinatorial problems to continuous optimization. Similar techniques appear in sphere packing (Cohn-Elkies), graph limits (Lovász), and flag algebras (Razborov).\n\n2. **Density barrier as impossibility**: The proved theorem $m_1 < 1/4$ is a *barrier result* — it shows that an entire class of techniques (density-based arguments) is insufficient for the target bound. This is analogous to oracle separations in complexity theory or the Razborov-Rudich natural proofs barrier.\n\n**3. Moser spindle and chromatic number**: The Moser spindle simultaneously gives $\\alpha/n \\leq 2/7$ (independence bound) and $\\chi \\geq 4$ (coloring bound). Improving the upper bound on $f(n)/n$ requires finding finite UDGs with smaller $\\alpha/n$ ratios, which is equivalent to finding UDGs with larger chromatic number — directly linking to the Hadwiger-Nelson problem.\n\n4. **Fourier-analytic methods in combinatorics**: The ACMVZ bound $m_1 \\leq 0.247$ uses the Fourier transform and Bessel functions, exemplifying how harmonic analysis constrains combinatorial objects. This approach has also yielded breakthroughs in the Kakeya problem and Falconer's distance conjecture.\n\n5. **Formalization of open problems**: By axiomatizing $f(n)$ and proving what current methods achieve, the formalization creates a precise specification of the remaining gap — any claimed proof of $f(n) \\geq n/4$ would need to supply a proof term for `quarter_conjecture_open` without relying solely on `m1`.",
     "openQuestions": [
       "What is $\\lim_{n \\to \\infty} f(n)/n$? The limit exists by a subadditivity argument and lies in $[0.22936, 2/7]$. Even determining whether it equals $m_1$ or exceeds it is unknown.",
-      "Is $f(n) \\geq n/4$? The ACMVZ barrier shows $m_1 < 1/4$, so a proof would need structural arguments beyond density \u2014 perhaps exploiting the geometry of specific configurations rather than random translations.",
+      "Is $f(n) \\geq n/4$? The ACMVZ barrier shows $m_1 < 1/4$, so a proof would need structural arguments beyond density — perhaps exploiting the geometry of specific configurations rather than random translations.",
       "Can the Moser spindle upper bound $f(n) \\leq (2/7)n$ be improved? This requires a finite UDG with $\\alpha/|V| < 2/7$. De Grey's 1581-vertex graph with $\\chi = 5$ has $\\alpha/|V| \\approx 0.28$, close but not improving $2/7$.",
       "Is $m_1$ computable to arbitrary precision? Current bounds $0.22936 \\leq m_1 \\leq 0.247$ leave a gap of $0.018$. Can the Fourier-analytic approach of ACMVZ be extended to narrow this further?",
       "Does the analogous problem in $\\mathbb{R}^d$ for $d \\geq 3$ exhibit similar density barriers? The Larman-Rogers argument generalizes, but the Fourier analysis becomes significantly more complex in higher dimensions."
@@ -131,27 +131,27 @@
   },
   "crossReferences": [
     {
-      "relationship": "The Hadwiger-Nelson problem asks for the chromatic number \u03c7(\u211d\u00b2); since any independent set in a unit distance graph is a color class, f(n) \u2265 n/\u03c7(\u211d\u00b2). The current bounds 5 \u2264 \u03c7 \u2264 7 yield n/7 \u2264 f(n), and resolving the chromatic number would immediately sharpen the independence bound.",
+      "relationship": "The Hadwiger-Nelson problem asks for the chromatic number χ(ℝ²); since any independent set in a unit distance graph is a color class, f(n) ≥ n/χ(ℝ²). The current bounds 5 ≤ χ ≤ 7 yield n/7 ≤ f(n), and resolving the chromatic number would immediately sharpen the independence bound.",
       "targetId": "erdos-508"
     },
     {
-      "relationship": "The maximum density m\u2081 of a measurable unit-distance-free set in \u211d\u00b2 is the continuous counterpart of f(n)/n. The Larman-Rogers theorem f(n) \u2265 m\u2081\u00b7n connects both problems; the ACMVZ result m\u2081 \u2264 0.247 < 1/4 (formalized in erdos-232) provides the density barrier central to this formalization.",
+      "relationship": "The maximum density m₁ of a measurable unit-distance-free set in ℝ² is the continuous counterpart of f(n)/n. The Larman-Rogers theorem f(n) ≥ m₁·n connects both problems; the ACMVZ result m₁ ≤ 0.247 < 1/4 (formalized in erdos-232) provides the density barrier central to this formalization.",
       "targetId": "erdos-232"
     },
     {
-      "relationship": "The strict variant: n points in \u211d\u00b2 with all pairwise distances \u2265 1, edges between points at distance exactly 1. Relaxing the 'no two points closer than 1' constraint changes the extremal behavior and leads to different bounds on the independence number.",
+      "relationship": "The strict variant: n points in ℝ² with all pairwise distances ≥ 1, edges between points at distance exactly 1. Relaxing the 'no two points closer than 1' constraint changes the extremal behavior and leads to different bounds on the independence number.",
       "targetId": "erdos-1066"
     },
     {
-      "relationship": "The Szemer\u00e9di-Trotter theorem on k-rich lines is proved via incidence geometry techniques in \u211d\u00b2. Both problems concern extremal properties of finite point configurations in the Euclidean plane, and Szemer\u00e9di-Trotter machinery has been applied to bounding distances and independence in discrete geometry.",
+      "relationship": "The Szemerédi-Trotter theorem on k-rich lines is proved via incidence geometry techniques in ℝ². Both problems concern extremal properties of finite point configurations in the Euclidean plane, and Szemerédi-Trotter machinery has been applied to bounding distances and independence in discrete geometry.",
       "targetId": "erdos-1069"
     },
     {
-      "relationship": "Graph colorings of planar graphs satisfy \u03c7 \u2264 4; unit distance graphs in \u211d\u00b2 are not in general planar, but both problems study the tension between graph structure and geometric embedding. The Moser spindle, which gives the upper bound f(n) \u2264 2n/7, is also a graph with chromatic number 4.",
+      "relationship": "Graph colorings of planar graphs satisfy χ ≤ 4; unit distance graphs in ℝ² are not in general planar, but both problems study the tension between graph structure and geometric embedding. The Moser spindle, which gives the upper bound f(n) ≤ 2n/7, is also a graph with chromatic number 4.",
       "targetId": "four-color-theorem"
     },
     {
-      "relationship": "The Larman-Rogers theorem \u2014 the key lower bound f(n) \u2265 m\u2081\u00b7n \u2014 is proved via a first-moment probabilistic argument: a random translate of a high-density unit-distance-free set captures at least m\u2081\u00b7n of any given n points in expectation, so some translate achieves this bound deterministically.",
+      "relationship": "The Larman-Rogers theorem — the key lower bound f(n) ≥ m₁·n — is proved via a first-moment probabilistic argument: a random translate of a high-density unit-distance-free set captures at least m₁·n of any given n points in expectation, so some translate achieves this bound deterministically.",
       "targetId": "prob-method-expectation"
     }
   ],
@@ -165,9 +165,9 @@
       "venue": "Mathematika",
       "year": "1972",
       "volume": "19",
-      "pages": "1\u201324",
+      "pages": "1–24",
       "doi": "10.1112/S0025579300004903",
-      "note": "Proves the key bridge f(n) \u2265 m\u2081\u00b7n via a probabilistic translation argument, reducing the discrete independence problem to the continuous density optimization."
+      "note": "Proves the key bridge f(n) ≥ m₁·n via a probabilistic translation argument, reducing the discrete independence problem to the continuous density optimization."
     },
     {
       "authors": [
@@ -177,22 +177,22 @@
       "venue": "Eureka (Cambridge)",
       "year": "1967",
       "volume": "30",
-      "pages": "22\u201326",
-      "note": "Constructs an explicit hexagonal-lattice-based unit-distance-free set achieving density \u2265 0.22936, establishing the best-known lower bound on m\u2081 and hence on f(n)/n."
+      "pages": "22–26",
+      "note": "Constructs an explicit hexagonal-lattice-based unit-distance-free set achieving density ≥ 0.22936, establishing the best-known lower bound on m₁ and hence on f(n)/n."
     },
     {
       "authors": [
         "G. Ambrus",
-        "M. Csisz\u00e1rik",
+        "M. Csiszárik",
         "M. Matolcsi",
         "D. Varga",
-        "P. Zs\u00e1mboki"
+        "P. Zsámboki"
       ],
       "title": "On the density of sets avoiding unit distances in Euclidean and hyperbolic spaces",
       "venue": "Discrete and Computational Geometry",
       "year": "2023",
       "doi": "10.1007/s00454-023-00566-3",
-      "note": "Proves m\u2081 \u2264 0.247 via Fourier-analytic methods and Bessel function zeros, establishing that density-based arguments cannot prove f(n) \u2265 n/4 \u2014 the ACMVZ barrier formalized as density_insufficient_for_quarter."
+      "note": "Proves m₁ ≤ 0.247 via Fourier-analytic methods and Bessel function zeros, establishing that density-based arguments cannot prove f(n) ≥ n/4 — the ACMVZ barrier formalized as density_insufficient_for_quarter."
     },
     {
       "authors": [
@@ -203,8 +203,8 @@
       "venue": "Canadian Mathematical Bulletin",
       "year": "1961",
       "volume": "4",
-      "pages": "187\u2013189",
-      "note": "Introduces the 7-vertex Moser spindle unit distance graph with independence number 2, which by tiling gives the upper bound f(n) \u2264 2n/7 \u2248 0.286n."
+      "pages": "187–189",
+      "note": "Introduces the 7-vertex Moser spindle unit distance graph with independence number 2, which by tiling gives the upper bound f(n) ≤ 2n/7 ≈ 0.286n."
     },
     {
       "authors": [
@@ -214,9 +214,9 @@
       "venue": "Geombinatorics",
       "year": "2018",
       "volume": "28",
-      "pages": "18\u201331",
+      "pages": "18–31",
       "arxiv": "1804.02385",
-      "note": "Constructs a unit distance graph with chromatic number 5, improving the lower bound \u03c7(\u211d\u00b2) \u2265 5, and demonstrating that sophisticated finite UDG constructions (1581 vertices) can yield structural coloring information relevant to independence bounds."
+      "note": "Constructs a unit distance graph with chromatic number 5, improving the lower bound χ(ℝ²) ≥ 5, and demonstrating that sophisticated finite UDG constructions (1581 vertices) can yield structural coloring information relevant to independence bounds."
     }
   ],
   "leanFile": {
@@ -228,7 +228,7 @@
     "lineCount": 235,
     "axiomCount": 10,
     "theoremCount": 6,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1070Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -304,7 +304,7 @@
     "lineCount": 323,
     "axiomCount": 1,
     "theoremCount": 23,
-    "definitionCount": 16,
+    "definitionCount": 15,
     "path": "Proofs/Erdos1071Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -244,7 +244,7 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "path": "Proofs/Erdos1072Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1082/meta.json
+++ b/src/data/proofs/erdos-1082/meta.json
@@ -271,7 +271,7 @@
     "lineCount": 342,
     "axiomCount": 2,
     "theoremCount": 23,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos1082Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1086/meta.json
+++ b/src/data/proofs/erdos-1086/meta.json
@@ -247,7 +247,7 @@
     "lineCount": 150,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos1086Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1087/meta.json
+++ b/src/data/proofs/erdos-1087/meta.json
@@ -283,7 +283,7 @@
     "lineCount": 316,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos1087Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -254,7 +254,8 @@
     ],
     "namespace": null,
     "path": "Proofs/Erdos1089Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 12
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -102,7 +102,7 @@
     "lineCount": 333,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 17,
+    "definitionCount": 15,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -174,6 +174,8 @@
     "axiomCount": 5,
     "lineCount": 211,
     "sorries": 0,
-    "path": "Proofs/Erdos1091Problem.lean"
+    "path": "Proofs/Erdos1091Problem.lean",
+    "definitionCount": 7,
+    "theoremCount": 4
   }
 }

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1092",
-  "title": "Erd\u0151s Problem #1092: Chromatic Decomposition Threshold",
+  "title": "Erdős Problem #1092: Chromatic Decomposition Threshold",
   "slug": "erdos-1092",
-  "description": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to \u2264 r while forcing \u03c7(G) \u2264 r+1. Is f\u2082(n) \u226b n? R\u00f6dl (1982) gives f\u2082(n) = O(n\u00b7polylog). Open.",
+  "description": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to ≤ r while forcing χ(G) ≤ r+1. Is f₂(n) ≫ n? Rödl (1982) gives f₂(n) = O(n·polylog). Open.",
   "meta": {
-    "author": "Erd\u0151s\u2013Hajnal\u2013Szemer\u00e9di",
+    "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
@@ -22,26 +22,26 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 160,
-    "assumptions": "0 axioms, 0 sorries. 5 structural theorems fully proved. 2 True-stub documentation markers for disproved claims (Q1, Q2 refuted by R\u00f6dl 1982). Main conjectures removed; file is primarily graph coloring infrastructure. Open conjecture; supporting lemmas fully verified.",
+    "assumptions": "0 axioms, 0 sorries. 5 structural theorems fully proved. 2 True-stub documentation markers for disproved claims (Q1, Q2 refuted by Rödl 1982). Main conjectures removed; file is primarily graph coloring infrastructure. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erd\u0151s, Hajnal, and Szemer\u00e9di introduced this problem as part of their investigation into when local chromatic structure forces global coloring bounds. The function $f_r(n)$ captures a 'local-to-global' threshold: if every subgraph of an $n$-vertex graph can be made $r$-colorable by deleting at most $k$ edges, what is the largest $k$ that still forces $\\chi(G) \\leq r+1$? R\u00f6dl's 1982 construction provided a crucial upper bound, showing $f_2(n) = O(n \\cdot (\\log n)^2)$ via probabilistic and algebraic techniques. Tang subsequently observed that R\u00f6dl's construction directly addresses Question 1, providing evidence that $f_2(n) \\gg n$ may be false. The problem connects to broader themes in extremal graph theory: the interplay between local substructure (each piece is nearly $r$-colorable) and global properties (the whole graph has bounded chromatic number). Similar local-to-global phenomena appear in Szemer\u00e9di's regularity lemma, Brooks' theorem ($\\chi \\leq \\Delta + 1$ from local degree bounds), and Johansson's theorem ($\\chi = O(\\Delta/\\log \\Delta)$ for triangle-free graphs). The problem also relates to Erd\u0151s Problem #744, which considers variant chromatic decomposition thresholds.",
+    "historicalContext": "Erdős, Hajnal, and Szemerédi introduced this problem as part of their investigation into when local chromatic structure forces global coloring bounds. The function $f_r(n)$ captures a 'local-to-global' threshold: if every subgraph of an $n$-vertex graph can be made $r$-colorable by deleting at most $k$ edges, what is the largest $k$ that still forces $\\chi(G) \\leq r+1$? Rödl's 1982 construction provided a crucial upper bound, showing $f_2(n) = O(n \\cdot (\\log n)^2)$ via probabilistic and algebraic techniques. Tang subsequently observed that Rödl's construction directly addresses Question 1, providing evidence that $f_2(n) \\gg n$ may be false. The problem connects to broader themes in extremal graph theory: the interplay between local substructure (each piece is nearly $r$-colorable) and global properties (the whole graph has bounded chromatic number). Similar local-to-global phenomena appear in Szemerédi's regularity lemma, Brooks' theorem ($\\chi \\leq \\Delta + 1$ from local degree bounds), and Johansson's theorem ($\\chi = O(\\Delta/\\log \\Delta)$ for triangle-free graphs). The problem also relates to Erdős Problem #744, which considers variant chromatic decomposition thresholds.",
     "problemStatement": "Let $f_r(n)$ be the maximum $k$ such that if every $m$-vertex subgraph of an $n$-vertex graph $G$ can have its chromatic number reduced to $\\leq r$ by removing $\\leq k$ edges, then $\\chi(G) \\leq r+1$. Is $f_2(n) \\gg n$? More generally, is $f_r(n) \\gg_r rn$?",
-    "text": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to \u2264 r while forcing \u03c7(G) \u2264 r+1. Is f\u2082(n) \u226b n? R\u00f6dl (1982) gives f\u2082(n) = O(n\u00b7polylog). Open.",
-    "proofStrategy": "The formalization builds custom graph infrastructure (`SGraph`, `edgeCount`, `hasColoring`, `chromaticNum`) and defines chromatic reduction via edge deletion (`CanReduceChromatic`). The threshold function `fThreshold r n` is defined as a supremum via `sSup`. Both main questions were removed (disproved by R\u00f6dl). Previously axiomatized claims (questions 1 & 2, trivial lower bound, monotonicity in r) were all found to be false and removed with documented counterexamples. The file now contains 0 axioms: only definitions and 5 proved structural theorems remain.",
+    "text": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to ≤ r while forcing χ(G) ≤ r+1. Is f₂(n) ≫ n? Rödl (1982) gives f₂(n) = O(n·polylog). Open.",
+    "proofStrategy": "The formalization builds custom graph infrastructure (`SGraph`, `edgeCount`, `hasColoring`, `chromaticNum`) and defines chromatic reduction via edge deletion (`CanReduceChromatic`). The threshold function `fThreshold r n` is defined as a supremum via `sSup`. Both main questions were removed (disproved by Rödl). Previously axiomatized claims (questions 1 & 2, trivial lower bound, monotonicity in r) were all found to be false and removed with documented counterexamples. The file now contains 0 axioms: only definitions and 5 proved structural theorems remain.",
     "keyInsights": [
-      "The function $f_r(n)$ is a Tur\u00e1n-type extremal quantity for chromatic properties rather than subgraph avoidance: it measures the critical edge-deletion budget separating local reducibility from global colorability failure",
-      "R\u00f6dl's 1982 construction gives the upper bound $f_2(n) = O(n \\log^2 n)$, the only nontrivial bound known",
-      "The claimed trivial lower bound $f_r(n) \\geq n - 1$ is FALSE: K\u2083 + isolated vertex on 4 vertices satisfies local 1-reducibility with budget 3 but has $\\chi = 3 > 2$. The flaw in the tree argument is that fThreshold quantifies over ALL graphs, not just trees",
+      "The function $f_r(n)$ is a Turán-type extremal quantity for chromatic properties rather than subgraph avoidance: it measures the critical edge-deletion budget separating local reducibility from global colorability failure",
+      "Rödl's 1982 construction gives the upper bound $f_2(n) = O(n \\log^2 n)$, the only nontrivial bound known",
+      "The claimed trivial lower bound $f_r(n) \\geq n - 1$ is FALSE: K₃ + isolated vertex on 4 vertices satisfies local 1-reducibility with budget 3 but has $\\chi = 3 > 2$. The flaw in the tree argument is that fThreshold quantifies over ALL graphs, not just trees",
       "Monotonicity in $r$ ($f_r(n) \\leq f_{r+1}(n)$) fails in this formalization because sSup on $\\mathbb{N}$ returns 0 for unbounded sets: when $r+1 \\geq n$, the defining set is all of $\\mathbb{N}$ and fThreshold collapses to 0",
       "The local-to-global nature of the problem connects to a rich hierarchy: Brooks' theorem (degree $\\to$ chromatic number), Johansson's theorem (girth $\\to$ chromatic bound), regularity methods (approximate structure $\\to$ global properties), and this problem (approximate colorability $\\to$ global colorability)",
-      "A negative answer to Question 1 (which R\u00f6dl's evidence suggests) would mean that local near-bipartiteness does not strongly constrain global 3-colorability, revealing a fundamental limit of local-to-global reasoning in graph coloring"
+      "A negative answer to Question 1 (which Rödl's evidence suggests) would mean that local near-bipartiteness does not strongly constrain global 3-colorability, revealing a fundamental limit of local-to-global reasoning in graph coloring"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
       "Graph theory (vertices, edges, colorings)",
-      "Extremal graph theory (Tur\u00e1n-type problems)"
+      "Extremal graph theory (Turán-type problems)"
     ]
   },
   "sections": [
@@ -50,8 +50,8 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 19,
-      "summary": "Docstring establishing Erd\u0151s Problem #1092 from Erd\u0151s\u2013Hajnal\u2013Szemer\u00e9di, with Tang's observation connecting R\u00f6dl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic.",
-      "mathContext": "Docstring establishing Erd\u0151s Problem #1092 from Erd\u0151s\u2013Hajnal\u2013Szemer\u00e9di, with Tang's observation connecting R\u00f6dl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic."
+      "summary": "Docstring establishing Erdős Problem #1092 from Erdős–Hajnal–Szemerédi, with Tang's observation connecting Rödl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic.",
+      "mathContext": "Docstring establishing Erdős Problem #1092 from Erdős–Hajnal–Szemerédi, with Tang's observation connecting Rödl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic."
     },
     {
       "id": "definitions",
@@ -82,35 +82,35 @@
       "title": "The Main Conjectures",
       "startLine": 64,
       "endLine": 75,
-      "summary": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by R\u00f6dl (1982) and removed; only `True`-valued documentation notes remain.",
-      "mathContext": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by R\u00f6dl (1982) and removed; only `True`-valued documentation notes remain."
+      "summary": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain.",
+      "mathContext": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain."
     },
     {
       "id": "rodl-bounds",
-      "title": "R\u00f6dl's Construction and Structural Properties",
+      "title": "Rödl's Construction and Structural Properties",
       "startLine": 94,
       "endLine": 160,
-      "summary": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, R\u00f6dl upper bound) with counterexamples. No axioms remain.",
-      "mathContext": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, R\u00f6dl upper bound) with counterexamples. No axioms remain."
+      "summary": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain.",
+      "mathContext": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #1092, an open question about the threshold for local-to-global chromatic number reduction. The function $f_r(n)$ measures the maximum edge-deletion budget under which local $r$-reducibility forces global $(r+1)$-colorability. R\u00f6dl's 1982 upper bound $O(n \\log^2 n)$ is the sole remaining axiom. Two previously axiomatized claims were found to be false: the trivial lower bound $f_r(n) \\geq n-1$ (counterexample: K\u2083 + isolated for r=1, n=4) and monotonicity in r (sSup pathology for unbounded sets).",
-    "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of local-to-global reasoning in graph coloring.\n\nA positive answer would establish that local near-$r$-colorability strongly constrains global chromatic number, extending the philosophy behind Brooks' theorem and the regularity lemma. A negative answer (supported by R\u00f6dl's evidence) would show that local chromatic structure is insufficient to control global coloring, delineating a boundary for structural graph theory techniques.",
+    "summary": "This formalization captures Erdős Problem #1092, an open question about the threshold for local-to-global chromatic number reduction. The function $f_r(n)$ measures the maximum edge-deletion budget under which local $r$-reducibility forces global $(r+1)$-colorability. Rödl's 1982 upper bound $O(n \\log^2 n)$ is the sole remaining axiom. Two previously axiomatized claims were found to be false: the trivial lower bound $f_r(n) \\geq n-1$ (counterexample: K₃ + isolated for r=1, n=4) and monotonicity in r (sSup pathology for unbounded sets).",
+    "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of local-to-global reasoning in graph coloring.\n\nA positive answer would establish that local near-$r$-colorability strongly constrains global chromatic number, extending the philosophy behind Brooks' theorem and the regularity lemma. A negative answer (supported by Rödl's evidence) would show that local chromatic structure is insufficient to control global coloring, delineating a boundary for structural graph theory techniques.",
     "openQuestions": [
       "Is $f_2(n) = \\Theta(n)$, or does it grow as $\\Theta(n \\log^\\alpha n)$ for some $\\alpha \\in (0, 2]$?",
-      "Does R\u00f6dl's construction generalize to $r \\geq 3$, or does the threshold behavior change for higher chromatic targets?",
+      "Does Rödl's construction generalize to $r \\geq 3$, or does the threshold behavior change for higher chromatic targets?",
       "Is there a spectral or algebraic characterization of graphs that are locally $r$-reducible but globally not $(r+1)$-colorable?",
-      "What is the relationship between $f_r(n)$ and the Lov\u00e1sz theta function or Ramsey numbers $R(r+1, r+1)$?"
+      "What is the relationship between $f_r(n)$ and the Lovász theta function or Ramsey numbers $R(r+1, r+1)$?"
     ]
   },
   "crossReferences": [
     {
-      "relationship": "Erd\u0151s Problem #744 studies a closely related edge-deletion threshold for k-critical bipartite graphs; R\u00f6dl and Tuza's disproof (1985) of #744 uses constructions directly relevant to Problem #1092",
+      "relationship": "Erdős Problem #744 studies a closely related edge-deletion threshold for k-critical bipartite graphs; Rödl and Tuza's disproof (1985) of #744 uses constructions directly relevant to Problem #1092",
       "targetId": "erdos-744"
     },
     {
-      "relationship": "Problem #58 (chromatic number vs. odd cycle lengths, solved by Gy\u00e1rf\u00e1s 1992) illustrates another dimension of local-to-global chromatic reasoning \u2014 cycle structure forcing \u03c7 \u2014 that complements the edge-deletion threshold approach of #1092",
+      "relationship": "Problem #58 (chromatic number vs. odd cycle lengths, solved by Gyárfás 1992) illustrates another dimension of local-to-global chromatic reasoning — cycle structure forcing χ — that complements the edge-deletion threshold approach of #1092",
       "targetId": "erdos-58"
     },
     {
@@ -118,7 +118,7 @@
       "targetId": "erdos-1091"
     },
     {
-      "relationship": "The Szemer\u00e9di Regularity Lemma is the canonical example of local approximate structure (\u03b5-regular pairs) controlling global graph properties; Problem #1092 asks an analogous local-to-global question for chromatic reducibility",
+      "relationship": "The Szemerédi Regularity Lemma is the canonical example of local approximate structure (ε-regular pairs) controlling global graph properties; Problem #1092 asks an analogous local-to-global question for chromatic reducibility",
       "targetId": "szemeredi-regularity"
     },
     {
@@ -129,9 +129,9 @@
   "references": [
     {
       "authors": [
-        "Erd\u0151s, P.",
+        "Erdős, P.",
         "Hajnal, A.",
-        "Szemer\u00e9di, E."
+        "Szemerédi, E."
       ],
       "title": "On almost bipartite large chromatic graphs",
       "venue": "Annals of Discrete Mathematics",
@@ -140,24 +140,24 @@
     },
     {
       "authors": [
-        "R\u00f6dl, V."
+        "Rödl, V."
       ],
       "title": "On the chromatic number of subgraphs of a given graph",
       "venue": "Proceedings of the American Mathematical Society",
       "volume": 64,
       "year": "1977",
-      "note": "R\u00f6dl's construction establishing the upper bound f_2(n) = O(n\u00b7(log n)^2), the key nontrivial bound for Problem #1092"
+      "note": "Rödl's construction establishing the upper bound f_2(n) = O(n·(log n)^2), the key nontrivial bound for Problem #1092"
     },
     {
       "authors": [
-        "R\u00f6dl, V.",
+        "Rödl, V.",
         "Tuza, Zs."
       ],
       "title": "Double-critical graph conjecture",
       "venue": "Graphs and Combinatorics",
       "volume": 8,
       "year": "1985",
-      "note": "Disproves Erd\u0151s Problem #744 using constructions related to edge-deletion thresholds; the methods are cited in the context of Problem #1092"
+      "note": "Disproves Erdős Problem #744 using constructions related to edge-deletion thresholds; the methods are cited in the context of Problem #1092"
     },
     {
       "authors": [
@@ -167,8 +167,8 @@
       "venue": "Mathematical Proceedings of the Cambridge Philosophical Society",
       "volume": 37,
       "year": "1941",
-      "pages": "194\u2013197",
-      "note": "Brooks' theorem (\u03c7(G) \u2264 \u0394(G) + 1) is the classical local-to-global coloring result; f_r(n) can be viewed as a quantitative variant of this local-degree-to-chromatic-number philosophy"
+      "pages": "194–197",
+      "note": "Brooks' theorem (χ(G) ≤ Δ(G) + 1) is the classical local-to-global coloring result; f_r(n) can be viewed as a quantitative variant of this local-degree-to-chromatic-number philosophy"
     },
     {
       "authors": [
@@ -177,13 +177,13 @@
       "title": "Asymptotic choice number for triangle free graphs",
       "venue": "DIMACS Technical Report",
       "year": "1996",
-      "note": "Johansson's theorem (\u03c7 = O(\u0394/log \u0394) for triangle-free graphs) is another landmark local-to-global chromatic bound; mentioned in the key insights as part of the broader hierarchy"
+      "note": "Johansson's theorem (χ = O(Δ/log Δ) for triangle-free graphs) is another landmark local-to-global chromatic bound; mentioned in the key insights as part of the broader hierarchy"
     },
-    "Erd\u0151s, Hajnal & Szemer\u00e9di: original question on chromatic decomposition thresholds",
-    "R\u00f6dl (1982), graph constructions with high chromatic number and local bipartiteness",
-    "Tang: observation connecting R\u00f6dl's construction to Problem #1092",
-    "Related to Erd\u0151s Problem #744 on chromatic decomposition",
-    "Brooks (1941), coloring theorem: \u03c7(G) \u2264 \u0394(G) + 1",
+    "Erdős, Hajnal & Szemerédi: original question on chromatic decomposition thresholds",
+    "Rödl (1982), graph constructions with high chromatic number and local bipartiteness",
+    "Tang: observation connecting Rödl's construction to Problem #1092",
+    "Related to Erdős Problem #744 on chromatic decomposition",
+    "Brooks (1941), coloring theorem: χ(G) ≤ Δ(G) + 1",
     "https://erdosproblems.com/1092"
   ],
   "leanFile": {
@@ -198,7 +198,9 @@
     "namespace": null,
     "lineCount": 160,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 5,
+    "theoremCount": 5
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -207,7 +207,8 @@
     ],
     "namespace": null,
     "path": "Proofs/Erdos1097Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 8
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -19,7 +19,9 @@
     "namespace": "Erdos901",
     "lineCount": 238,
     "axiomCount": 0,
-    "sorries": 19
+    "sorries": 19,
+    "definitionCount": 9,
+    "theoremCount": 19
   },
   "meta": {
     "author": "Paul Erdős, László Lovász",

--- a/src/data/proofs/erdos-902/meta.json
+++ b/src/data/proofs/erdos-902/meta.json
@@ -208,7 +208,7 @@
     "lineCount": 146,
     "axiomCount": 6,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 7,
     "path": "Proofs/Erdos902Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-914/meta.json
+++ b/src/data/proofs/erdos-914/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-914",
-  "title": "Erd\u0151s Problem #914: Hajnal-Szemer\u00e9di Theorem (Vertex-Disjoint Cliques)",
+  "title": "Erdős Problem #914: Hajnal-Szemerédi Theorem (Vertex-Disjoint Cliques)",
   "slug": "erdos-914",
-  "description": "Every graph on rm vertices with minimum degree \u2265 m(r-1) contains m vertex-disjoint copies of K_r. SOLVED by Hajnal-Szemer\u00e9di (1970).",
+  "description": "Every graph on rm vertices with minimum degree ≥ m(r-1) contains m vertex-disjoint copies of K_r. SOLVED by Hajnal-Szemerédi (1970).",
   "leanFile": {
     "path": "Proofs/Erdos914Problem.lean",
     "imports": [
@@ -19,10 +19,12 @@
     "namespace": "Erdos914",
     "lineCount": 193,
     "axiomCount": 2,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 6,
+    "theoremCount": 1
   },
   "meta": {
-    "author": "Erd\u0151s (conjecture), Hajnal-Szemer\u00e9di (proof 1970)",
+    "author": "Erdős (conjecture), Hajnal-Szemerédi (proof 1970)",
     "sourceUrl": "https://erdosproblems.com/914",
     "date": "1970",
     "status": "axiomatized",
@@ -66,8 +68,8 @@
       "HasMDisjointRCliques definition (m vertex-disjoint K_r's)",
       "HasPerfectKrFactor definition",
       "Dirac's theorem axiom (r=2 case)",
-      "Corr\u00e1di-Hajnal theorem axiom (r=3 case)",
-      "Hajnal-Szemer\u00e9di main theorem axiomatization",
+      "Corrádi-Hajnal theorem axiom (r=3 case)",
+      "Hajnal-Szemerédi main theorem axiomatization",
       "Tightness of degree condition",
       "Kierstead-Kostochka proof approach",
       "Alon-Yuster and KSS generalizations"
@@ -88,15 +90,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "This problem asks when a graph must contain many vertex-disjoint cliques, and is one of the most important results in extremal graph theory about spanning substructures.\n\nThe story begins with **Dirac's theorem (1952)**: every graph on $n \\ge 3$ vertices with $\\delta(G) \\ge n/2$ has a Hamiltonian cycle, which implies the $r = 2$ case (perfect matchings). **Corr\u00e1di and Hajnal (1963)** proved the triangle case: every graph on $3m$ vertices with $\\delta(G) \\ge 2m$ contains $m$ vertex-disjoint triangles, in their paper \"On the maximal number of independent circuits in a graph\" (Acta Mathematica Hungarica).\n\nErd\u0151s conjectured the general statement for all $r \\ge 2$: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$. **Hajnal and Szemer\u00e9di (1970)** proved this conjecture in their landmark paper \"Proof of a conjecture of P. Erd\u0151s\" (Combinatorial Theory and its Applications), though the original proof was notoriously long and complex.\n\n**Kierstead and Kostochka (2008)** gave a significantly shorter proof via **equitable colorings**: a proper $r$-coloring of the complement $\\overline{G}$ with color classes of equal size $m$ yields the desired $K_r$-factor. **Kierstead, Kostochka, Molla, and Yeager (2010)** found a polynomial-time $O(n^5)$ algorithm. The theorem has been generalized by **Alon and Yuster (1996)** and by **Koml\u00f3s, S\u00e1rk\u00f6zy, and Szemer\u00e9di (2001)** to arbitrary $H$-factors.",
+    "historicalContext": "This problem asks when a graph must contain many vertex-disjoint cliques, and is one of the most important results in extremal graph theory about spanning substructures.\n\nThe story begins with **Dirac's theorem (1952)**: every graph on $n \\ge 3$ vertices with $\\delta(G) \\ge n/2$ has a Hamiltonian cycle, which implies the $r = 2$ case (perfect matchings). **Corrádi and Hajnal (1963)** proved the triangle case: every graph on $3m$ vertices with $\\delta(G) \\ge 2m$ contains $m$ vertex-disjoint triangles, in their paper \"On the maximal number of independent circuits in a graph\" (Acta Mathematica Hungarica).\n\nErdős conjectured the general statement for all $r \\ge 2$: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$. **Hajnal and Szemerédi (1970)** proved this conjecture in their landmark paper \"Proof of a conjecture of P. Erdős\" (Combinatorial Theory and its Applications), though the original proof was notoriously long and complex.\n\n**Kierstead and Kostochka (2008)** gave a significantly shorter proof via **equitable colorings**: a proper $r$-coloring of the complement $\\overline{G}$ with color classes of equal size $m$ yields the desired $K_r$-factor. **Kierstead, Kostochka, Molla, and Yeager (2010)** found a polynomial-time $O(n^5)$ algorithm. The theorem has been generalized by **Alon and Yuster (1996)** and by **Komlós, Sárközy, and Szemerédi (2001)** to arbitrary $H$-factors.",
     "problemStatement": "Let $r \\ge 2$ and $m \\ge 1$. Every graph on $rm$ vertices with minimum degree $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$. Equivalently, if $r | n$ and $\\delta(G) \\ge (1 - 1/r)n$, then $G$ has a perfect $K_r$-factor.",
     "text": "The Hajnal-Szemeredi theorem (1970) establishes the exact minimum degree threshold for forcing vertex-disjoint clique factors in graphs. For $r \\ge 2$ and $m \\ge 1$, any graph on $n = rm$ vertices with $\\delta(G) \\ge (1 - 1/r)n$ must contain $m$ vertex-disjoint copies of $K_r$, partitioning the entire vertex set into $r$-cliques. This threshold $(1 - 1/r)n$ is precisely the Turan density, revealing that the same parameter governing subgraph existence (Turan's theorem) also governs the much stronger property of spanning clique factors. The formalization axiomatizes the theorem alongside its special cases (Dirac's matching theorem for $r = 2$, the Corradi-Hajnal triangle factor theorem for $r = 3$) and proves the degree bound is best possible via an extremal construction.",
     "proofStrategy": "The formalization is organized into six parts that build from basic graph definitions to the full characterization theorem.\n\n**Part I (Graph Basics, lines 43-61):** Introduces `completeGraphOnFin r` as the abbreviation for $K_r$ on `Fin r`, and defines `minDegree G` as the minimum over all vertex degrees using `Finset.min'` with a nonemptiness proof from `Finset.univ_nonempty`. This custom definition is needed because Mathlib does not provide a built-in minimum degree function.\n\n**Part II (Cliques and Clique Covers, lines 62-97):** Establishes the combinatorial vocabulary: `IsRClique G S r` requires $|S| = r$ and $G.\\texttt{IsClique}\\, S$; `AreVertexDisjoint` enforces pairwise disjointness; `HasMDisjointRCliques G m r` asserts existence of $m$ disjoint $r$-cliques; and `HasPerfectKrFactor G r` adds the covering condition $\\texttt{biUnion} = \\texttt{univ}$. The distinction between the last two is mathematically significant: $m$ disjoint $K_r$'s use $rm$ vertices total, but proving they cover ALL vertices requires cardinality reasoning.\n\n**Part III (Special Cases, lines 98-118):** Axiomatizes the two classical predecessors: `case_r_equals_2` (Dirac's matching theorem, $r = 2$) and `corradi_hajnal` (Corradi-Hajnal 1963, $r = 3$). These are stated separately because their proofs use fundamentally different techniques from the general case.\n\n**Part IV (Main Theorem, lines 119-147):** The core axioms: `hajnal_szemeredi` states the disjoint cliques result, and `hajnal_szemeredi_factor` states the stronger perfect factor form. Both require $r \\ge 2$, $m \\ge 1$, $|V| = rm$, and $\\delta(G) \\ge m(r-1)$.\n\n**Part V (Tightness, lines 148-163):** `degree_condition_tight` provides the optimality statement: for every $r, m$, there exists a graph with minimum degree $m(r-1) - 1$ having no $m$ disjoint $K_r$'s.\n\n**Part VI (Summary, lines 164-210):** The proved theorem `erdos_914_summary` combines the existential and tightness results into a single conjunction, fully characterizing the minimum degree threshold.",
     "keyInsights": [
-      "**Minimum degree threshold**: $\\delta(G) \\ge m(r-1) = (1-1/r)n$ is the exact threshold for $K_r$-factors \u2014 the Tur\u00e1n density $(1-1/r)$ governs spanning structures, not just subgraph existence",
-      "**Tightness via Tur\u00e1n-like construction**: Taking $m$ disjoint copies of $K_{r-1}$ plus isolated vertices gives $\\delta = r-2$ per component, one below the threshold, with no $K_r$ at all",
-      "**From subgraphs to spanning structures**: Unlike Tur\u00e1n's theorem (which forces a single $K_r$), Hajnal\u2013Szemer\u00e9di forces a $K_r$-factor covering ALL vertices \u2014 a much stronger conclusion from the same minimum degree",
-      "**Equitable coloring duality**: Kierstead\u2013Kostochka's modern proof works by equitably $r$-coloring the complement $\\overline{G}$; equal-size color classes in $\\overline{G}$ correspond to $K_r$'s in $G$",
+      "**Minimum degree threshold**: $\\delta(G) \\ge m(r-1) = (1-1/r)n$ is the exact threshold for $K_r$-factors — the Turán density $(1-1/r)$ governs spanning structures, not just subgraph existence",
+      "**Tightness via Turán-like construction**: Taking $m$ disjoint copies of $K_{r-1}$ plus isolated vertices gives $\\delta = r-2$ per component, one below the threshold, with no $K_r$ at all",
+      "**From subgraphs to spanning structures**: Unlike Turán's theorem (which forces a single $K_r$), Hajnal–Szemerédi forces a $K_r$-factor covering ALL vertices — a much stronger conclusion from the same minimum degree",
+      "**Equitable coloring duality**: Kierstead–Kostochka's modern proof works by equitably $r$-coloring the complement $\\overline{G}$; equal-size color classes in $\\overline{G}$ correspond to $K_r$'s in $G$",
       "**Perfect factor vs disjoint cliques**: `HasMDisjointRCliques` gives $m$ disjoint $K_r$'s using $rm$ vertices total, while `HasPerfectKrFactor` requires `biUnion = univ`, a covering condition that needs additional cardinality reasoning"
     ],
     "prerequisites": [
@@ -153,7 +155,7 @@
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "Axiomatizes $r = 2$ (Dirac's theorem: $2m$ vertices, $\\delta \\ge m$ implies $m$ disjoint edges) and $r = 3$ (Corr\u00e1di-Hajnal 1963: $3m$ vertices, $\\delta \\ge 2m$ implies $m$ disjoint triangles).",
+      "summary": "Axiomatizes $r = 2$ (Dirac's theorem: $2m$ vertices, $\\delta \\ge m$ implies $m$ disjoint edges) and $r = 3$ (Corrádi-Hajnal 1963: $3m$ vertices, $\\delta \\ge 2m$ implies $m$ disjoint triangles).",
       "mathContext": "The $r = 2$ case reduces to perfect matching existence: $\\delta(G) \\ge n/2$ implies a Hamiltonian cycle by Dirac's theorem (1952), and alternating edges of a Hamiltonian cycle on $2m$ vertices yield $m$ disjoint edges. The $r = 3$ case was proved by Corradi and Hajnal (1963) using a swap argument: start with a maximal collection of disjoint triangles and show that if fewer than $m$ triangles exist, uncovered vertices can be swapped in to enlarge the collection. The gap between $r = 3$ (1963) and general $r$ (1970) reflects the significant difficulty of extending the swap argument to larger cliques, where the combinatorial case analysis grows substantially.",
       "startLine": 98,
       "endLine": 118
@@ -184,13 +186,13 @@
     }
   ],
   "conclusion": {
-    "summary": "The Hajnal\u2013Szemer\u00e9di Theorem (1970) completely resolves Erd\u0151s Problem #914: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$, and the minimum degree condition is tight. The formalization axiomatizes the theorem, its special cases ($r = 2, 3$), and the optimality of the degree bound.",
+    "summary": "The Hajnal–Szemerédi Theorem (1970) completely resolves Erdős Problem #914: every graph on $rm$ vertices with $\\delta(G) \\ge m(r-1)$ contains $m$ vertex-disjoint copies of $K_r$, and the minimum degree condition is tight. The formalization axiomatizes the theorem, its special cases ($r = 2, 3$), and the optimality of the degree bound.",
     "implications": "**Extremal Graph Theory**: The Hajnal-Szemeredi theorem is a cornerstone of the minimum degree approach to graph decomposition. It demonstrates that the Turan density $(1 - 1/r)$ is not merely the threshold for forcing a single copy of $K_r$ (Turan's theorem, 1941), but the exact threshold for forcing a spanning $K_r$-factor covering every vertex. This reveals a remarkable rigidity: the same density parameter controls both local (one copy) and global (perfect tiling) properties.\n\n**Equitable Coloring Connection**: The Kierstead-Kostochka (2008) short proof established a deep duality between graph factorization and graph coloring. A $K_r$-factor in $G$ corresponds to an equitable $r$-coloring of the complement $\\overline{G}$, where color classes have equal size. This connection has become a standard technique in extremal combinatorics and has been extended to list coloring and online coloring settings.\n\n**Generalizations to Arbitrary Factors**: Alon and Yuster (1996) proved an approximate version for general $H$-factors: $\\delta(G) \\ge (1 - 1/\\chi(H))n + o(n)$ suffices. Komlos, Sarkozy, and Szemeredi (2001) obtained the exact result for large $n$ using the regularity-blow-up method, establishing the minimum degree threshold for arbitrary $H$-factors as $(1 - 1/\\chi_{cr}(H))n + O(1)$, where $\\chi_{cr}(H)$ is the critical chromatic number.\n\n**Algorithmic Impact**: Kierstead, Kostochka, Molla, and Yeager (2010) gave a polynomial-time $O(n^5)$ algorithm for finding $K_r$-factors when the minimum degree condition is satisfied. This resolved the computational aspect, showing that the existential guarantee is algorithmically constructive.\n\n**Formalization Significance**: The axiomatization captures the full mathematical content of the theorem (existence, perfect factor form, special cases, and tightness) while clearly delineating what is assumed versus proved. The summary theorem `erdos_914_summary` is the unique non-axiom result, demonstrating that the characterization follows formally from the axiomatized components.",
     "openQuestions": [
       "What is the exact minimum degree threshold for perfect $H$-factors for arbitrary graphs $H$? The KSS theorem gives asymptotic answers but exact thresholds are known only for special cases.",
       "Can the $O(n^5)$ algorithm for finding $K_r$-factors be improved, perhaps to near-linear time?",
       "What are the minimum degree thresholds for vertex-disjoint copies of $K_r$ in directed graphs or hypergraphs?",
-      "Can the Hajnal\u2013Szemer\u00e9di theorem be proved constructively in Lean, or does the greedy/equitable-coloring argument require classical reasoning?"
+      "Can the Hajnal–Szemerédi theorem be proved constructively in Lean, or does the greedy/equitable-coloring argument require classical reasoning?"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -177,7 +177,7 @@
     "lineCount": 690,
     "axiomCount": 0,
     "theoremCount": 40,
-    "definitionCount": 15,
+    "definitionCount": 14,
     "path": "Proofs/Erdos919Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-928/meta.json
+++ b/src/data/proofs/erdos-928/meta.json
@@ -201,7 +201,7 @@
     "lineCount": 259,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos928Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -153,8 +153,8 @@
     "namespace": "Erdos931",
     "lineCount": 523,
     "axiomCount": 0,
-    "theoremCount": 44,
-    "definitionCount": 6,
+    "theoremCount": 46,
+    "definitionCount": 5,
     "path": "Proofs/Erdos931Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-932/meta.json
+++ b/src/data/proofs/erdos-932/meta.json
@@ -151,7 +151,7 @@
     "lineCount": 356,
     "axiomCount": 3,
     "theoremCount": 20,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos932Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -158,7 +158,9 @@
     "namespace": null,
     "lineCount": 154,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 7,
+    "theoremCount": 4
   },
   "references": [
     {

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -188,7 +188,7 @@
     "lineCount": 218,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 9,
+    "definitionCount": 13,
     "sorries": 0,
     "path": "Proofs/Erdos938Problem.lean"
   },

--- a/src/data/proofs/erdos-945/meta.json
+++ b/src/data/proofs/erdos-945/meta.json
@@ -134,7 +134,7 @@
     "lineCount": 148,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/Erdos945Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -158,7 +158,7 @@
     "lineCount": 348,
     "axiomCount": 2,
     "theoremCount": 18,
-    "definitionCount": 12,
+    "definitionCount": 18,
     "path": "Proofs/Erdos952Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-953/meta.json
+++ b/src/data/proofs/erdos-953/meta.json
@@ -194,7 +194,7 @@
     "lineCount": 291,
     "axiomCount": 2,
     "theoremCount": 13,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos953Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-957/meta.json
+++ b/src/data/proofs/erdos-957/meta.json
@@ -180,7 +180,7 @@
     "lineCount": 325,
     "axiomCount": 6,
     "theoremCount": 6,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos957Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-958/meta.json
+++ b/src/data/proofs/erdos-958/meta.json
@@ -127,7 +127,7 @@
     "lineCount": 200,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos958Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -163,7 +163,7 @@
     "lineCount": 251,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 8,
+    "definitionCount": 7,
     "path": "Proofs/Erdos960Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -104,7 +104,7 @@
     "lineCount": 229,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 0,
+    "definitionCount": 8,
     "sorries": 23,
     "path": "Proofs/Erdos977Problem.lean"
   },

--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -191,7 +191,7 @@
     "lineCount": 333,
     "axiomCount": 4,
     "theoremCount": 6,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos982Problem.lean",
     "sorries": 3
   },
@@ -199,17 +199,17 @@
     {
       "targetId": "erdos-654",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, distances, geometry, open"
+      "description": "Related Erdős problem sharing themes: discrete-geometry, distances, geometry, open"
     },
     {
       "targetId": "erdos-94",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: convex, discrete-geometry, distances, geometry"
+      "description": "Related Erdős problem sharing themes: convex, discrete-geometry, distances, geometry"
     },
     {
       "targetId": "erdos-103",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: distances, geometry, open"
+      "description": "Related Erdős problem sharing themes: distances, geometry, open"
     }
   ],
   "sorries": 3

--- a/src/data/proofs/erdos-987/meta.json
+++ b/src/data/proofs/erdos-987/meta.json
@@ -95,7 +95,7 @@
     "lineCount": 245,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "path": "Proofs/Erdos987Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-989/meta.json
+++ b/src/data/proofs/erdos-989/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-989",
-  "title": "Erd\u0151s Problem #989: Circle Discrepancy",
+  "title": "Erdős Problem #989: Circle Discrepancy",
   "slug": "erdos-989",
-  "description": "For an infinite sequence A \u2282 \u211d\u00b2, define f(r) = max_C |#(A\u2229C) - \u03c0r\u00b2| over circles of radius r. Beck (1987) proved f(r) \u226b r^{1/2} for all A (lower bound), and \u2203A with f(r) \u226a (r log r)^{1/2} (upper bound). The optimal growth is \u0398\u0303(\u221ar).",
+  "description": "For an infinite sequence A ⊂ ℝ², define f(r) = max_C |#(A∩C) - πr²| over circles of radius r. Beck (1987) proved f(r) ≫ r^{1/2} for all A (lower bound), and ∃A with f(r) ≪ (r log r)^{1/2} (upper bound). The optimal growth is Θ̃(√r).",
   "meta": {
-    "author": "Beck, J\u00f3zsef",
+    "author": "Beck, József",
     "sourceUrl": "https://erdosproblems.com/989",
     "date": "1987",
     "status": "axiomatized",
@@ -25,17 +25,17 @@
     "mathlibDependencies": [
       {
         "theorem": "EuclideanSpace",
-        "description": "Type for points in \u211d\u00b2",
+        "description": "Type for points in ℝ²",
         "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
       },
       {
         "theorem": "Real.pi",
-        "description": "The constant \u03c0 for circle area calculations",
+        "description": "The constant π for circle area calculations",
         "module": "Mathlib.Analysis.SpecialFunctions.Pi.Basic"
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root function for \u221ar bounds",
+        "description": "Square root function for √r bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
@@ -64,11 +64,11 @@
       },
       {
         "id": "erdos-987",
-        "relationship": "Exponential sums controlling equidistribution via the Erd\u0151s-Tur\u00e1n inequality, using related Fourier methods"
+        "relationship": "Exponential sums controlling equidistribution via the Erdős-Turán inequality, using related Fourier methods"
       },
       {
         "id": "erdos-990",
-        "relationship": "Angular discrepancy of polynomial roots on the unit circle via Erd\u0151s-Tur\u00e1n inequality"
+        "relationship": "Angular discrepancy of polynomial roots on the unit circle via Erdős-Turán inequality"
       },
       {
         "id": "erdos-992",
@@ -89,18 +89,18 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Circle Discrepancy and Uniform Distribution**\n\nThis problem asks fundamental questions about how uniformly an infinite sequence of points can be distributed in the plane with respect to circles.\n\nFor a sequence A = {z\u2081, z\u2082, ...} \u2282 \u211d\u00b2, define the circle discrepancy function:\n  f(r) = max_C |#(A \u2229 C) - \u03c0r\u00b2|\nwhere the maximum is over all circles C of radius r.\n\nThe expected count in a circle of radius r (if points had density 1) is \u03c0r\u00b2. The discrepancy measures the worst deviation from this expectation.\n\n**Historical Roots**\n\nThe study of discrepancy begins with Hermann Weyl's 1916 equidistribution theorem and was systematically developed by Klaus Roth, who proved in 1954 that the box discrepancy D(N) \u2265 c\u221a(log N) for points in [0,1]\u00b2. Wolfgang Schmidt extended this to higher dimensions in 1972. The shift from boxes to curved test sets was pioneered by J\u00f3zsef Beck in the 1980s.\n\n**Beck's Complete Solution (1987)**\n\nBeck settled this problem in his landmark paper 'Irregularities of distribution I' (Acta Math. 159, 1987, pp. 1\u201349):\n\n1. **Lower Bound (Universal)**: For ALL sequences A, f(r) \u226b r^{1/2}\n   - No matter how carefully you place points, discrepancy grows at least like \u221ar\n   - Proof uses Fourier analysis and properties of Bessel functions J\u2081\n   - The key insight is that the Fourier transform of a disk indicator is controlled by J\u2081, whose slow decay forces large discrepancy\n\n2. **Upper Bound (Existence)**: There EXISTS a sequence A with f(r) \u226a (r log r)^{1/2}\n   - Uses probabilistic construction: perturb the integer lattice \u2124\u00b2 by small random displacements\n   - The log factor comes from union bounds over O(r\u00b2) possible circle centers\n   - This is a landmark application of the probabilistic method in geometric combinatorics\n\nThis shows the optimal growth rate is \u0398\u0303(\u221ar), with an open question about whether the logarithmic factor is necessary. The connection to the Gauss circle problem (lattice points in circles fluctuate by ~r^{1/4}) shows that circles present a fundamentally harder discrepancy problem than boxes or half-planes.",
-    "problemStatement": "**Problem Statement**\n\nLet A = {z\u2081, z\u2082, ...} \u2282 \u211d\u00b2 be an infinite sequence of points. Define\n  f(r) = max_C |#(A \u2229 C) - \u03c0r\u00b2|\nwhere the maximum is over all circles C of radius r.\n\n**Questions:**\n1. Is f(r) unbounded for every A?\n2. How fast does f(r) grow?\n\n**Answer (Beck 1987):**\n1. YES - f(r) is unbounded for every A\n2. The optimal growth rate is \u0398\u0303(\u221ar):\n   - Universal lower bound: f(r) \u2265 c\u00b7\u221ar for all A\n   - Existence upper bound: \u2203A with f(r) \u2264 C\u00b7\u221a(r log r)\n\n**Status:** SOLVED",
-    "text": "For an infinite sequence A \u2282 \u211d\u00b2, define f(r) = max_C |#(A\u2229C) - \u03c0r\u00b2| over circles of radius r. Beck (1987) proved f(r) \u226b r^{1/2} for all A (lower bound), and \u2203A with f(r) \u226a (r log r)^{1/2} (upper bound). The optimal growth is \u0398\u0303(\u221ar).",
-    "proofStrategy": "**Beck's Approach**\n\n**Lower Bound (Fourier Analysis):**\n1. Express circle indicators via their Fourier transforms: $\\hat{\\mathbf{1}}_B(\\xi) = r J_1(2\\pi r|\\xi|)/|\\xi|$\n2. The Fourier transform of a disk involves Bessel functions J\u2081\n3. Key property: |J\u2081(x)| ~ \u221a(2/(\u03c0x)) cos(x - 3\u03c0/4) for large x\n4. Apply Parseval's identity to relate L\u00b2 discrepancy to Fourier coefficients\n5. The Bessel asymptotics force \u03a9(\u221ar) growth since the Fourier coefficients decay too slowly\n\n**Upper Bound (Probabilistic Construction):**\n1. Start with the integer lattice \u2124\u00b2 (density 1)\n2. Perturb each lattice point z by i.i.d. random displacement \u03b4_z uniform on [-\u03b5, \u03b5]\u00b2\n3. For a single circle: Var[#(A \u2229 C)] = O(r) from boundary contribution\n4. The union bound over O(r\u00b2) possible circle positions introduces the log factor\n5. Second moment method: E[sup_C D] = O(\u221a(r log r))\n\n**Why \u221ar is Natural:**\n- A circle of radius r has circumference 2\u03c0r\n- Points near the boundary can be in or out\n- Fluctuations of order \u221a(boundary length) = \u221ar\n- This is the same heuristic as the central limit theorem for independent boundary events",
+    "historicalContext": "**Circle Discrepancy and Uniform Distribution**\n\nThis problem asks fundamental questions about how uniformly an infinite sequence of points can be distributed in the plane with respect to circles.\n\nFor a sequence A = {z₁, z₂, ...} ⊂ ℝ², define the circle discrepancy function:\n  f(r) = max_C |#(A ∩ C) - πr²|\nwhere the maximum is over all circles C of radius r.\n\nThe expected count in a circle of radius r (if points had density 1) is πr². The discrepancy measures the worst deviation from this expectation.\n\n**Historical Roots**\n\nThe study of discrepancy begins with Hermann Weyl's 1916 equidistribution theorem and was systematically developed by Klaus Roth, who proved in 1954 that the box discrepancy D(N) ≥ c√(log N) for points in [0,1]². Wolfgang Schmidt extended this to higher dimensions in 1972. The shift from boxes to curved test sets was pioneered by József Beck in the 1980s.\n\n**Beck's Complete Solution (1987)**\n\nBeck settled this problem in his landmark paper 'Irregularities of distribution I' (Acta Math. 159, 1987, pp. 1–49):\n\n1. **Lower Bound (Universal)**: For ALL sequences A, f(r) ≫ r^{1/2}\n   - No matter how carefully you place points, discrepancy grows at least like √r\n   - Proof uses Fourier analysis and properties of Bessel functions J₁\n   - The key insight is that the Fourier transform of a disk indicator is controlled by J₁, whose slow decay forces large discrepancy\n\n2. **Upper Bound (Existence)**: There EXISTS a sequence A with f(r) ≪ (r log r)^{1/2}\n   - Uses probabilistic construction: perturb the integer lattice ℤ² by small random displacements\n   - The log factor comes from union bounds over O(r²) possible circle centers\n   - This is a landmark application of the probabilistic method in geometric combinatorics\n\nThis shows the optimal growth rate is Θ̃(√r), with an open question about whether the logarithmic factor is necessary. The connection to the Gauss circle problem (lattice points in circles fluctuate by ~r^{1/4}) shows that circles present a fundamentally harder discrepancy problem than boxes or half-planes.",
+    "problemStatement": "**Problem Statement**\n\nLet A = {z₁, z₂, ...} ⊂ ℝ² be an infinite sequence of points. Define\n  f(r) = max_C |#(A ∩ C) - πr²|\nwhere the maximum is over all circles C of radius r.\n\n**Questions:**\n1. Is f(r) unbounded for every A?\n2. How fast does f(r) grow?\n\n**Answer (Beck 1987):**\n1. YES - f(r) is unbounded for every A\n2. The optimal growth rate is Θ̃(√r):\n   - Universal lower bound: f(r) ≥ c·√r for all A\n   - Existence upper bound: ∃A with f(r) ≤ C·√(r log r)\n\n**Status:** SOLVED",
+    "text": "For an infinite sequence A ⊂ ℝ², define f(r) = max_C |#(A∩C) - πr²| over circles of radius r. Beck (1987) proved f(r) ≫ r^{1/2} for all A (lower bound), and ∃A with f(r) ≪ (r log r)^{1/2} (upper bound). The optimal growth is Θ̃(√r).",
+    "proofStrategy": "**Beck's Approach**\n\n**Lower Bound (Fourier Analysis):**\n1. Express circle indicators via their Fourier transforms: $\\hat{\\mathbf{1}}_B(\\xi) = r J_1(2\\pi r|\\xi|)/|\\xi|$\n2. The Fourier transform of a disk involves Bessel functions J₁\n3. Key property: |J₁(x)| ~ √(2/(πx)) cos(x - 3π/4) for large x\n4. Apply Parseval's identity to relate L² discrepancy to Fourier coefficients\n5. The Bessel asymptotics force Ω(√r) growth since the Fourier coefficients decay too slowly\n\n**Upper Bound (Probabilistic Construction):**\n1. Start with the integer lattice ℤ² (density 1)\n2. Perturb each lattice point z by i.i.d. random displacement δ_z uniform on [-ε, ε]²\n3. For a single circle: Var[#(A ∩ C)] = O(r) from boundary contribution\n4. The union bound over O(r²) possible circle positions introduces the log factor\n5. Second moment method: E[sup_C D] = O(√(r log r))\n\n**Why √r is Natural:**\n- A circle of radius r has circumference 2πr\n- Points near the boundary can be in or out\n- Fluctuations of order √(boundary length) = √r\n- This is the same heuristic as the central limit theorem for independent boundary events",
     "keyInsights": [
-      "f(r) is unbounded for EVERY sequence A \u2014 discrepancy is an unavoidable consequence of placing points in the plane",
-      "The optimal growth rate is \u0398\u0303(\u221ar) \u2014 both lower and upper bounds match up to a \u221a(log r) factor",
-      "The lower bound uses Fourier analysis on \u211d\u00b2 with Bessel function J\u2081 asymptotics, connecting analytic number theory to combinatorial geometry",
+      "f(r) is unbounded for EVERY sequence A — discrepancy is an unavoidable consequence of placing points in the plane",
+      "The optimal growth rate is Θ̃(√r) — both lower and upper bounds match up to a √(log r) factor",
+      "The lower bound uses Fourier analysis on ℝ² with Bessel function J₁ asymptotics, connecting analytic number theory to combinatorial geometry",
       "The upper bound uses the probabilistic method: a randomly perturbed lattice achieves near-optimal discrepancy, a striking example of randomization beating deterministic constructions",
-      "The logarithmic gap between \u221ar and \u221a(r log r) remains open since 1987 \u2014 it is unknown whether the union bound introducing log r is tight or an artifact of the proof",
-      "Circles have strictly higher discrepancy than half-planes (\u221ar \u226b r^{1/4}), reflecting how curvature amplifies irregularity by creating more 'boundary events'",
-      "The Gauss circle problem (counting \u2124\u00b2 points in a circle) is a special case: the fluctuation r^{1/4} is less than \u221ar because the lattice is highly structured"
+      "The logarithmic gap between √r and √(r log r) remains open since 1987 — it is unknown whether the union bound introducing log r is tight or an artifact of the proof",
+      "Circles have strictly higher discrepancy than half-planes (√r ≫ r^{1/4}), reflecting how curvature amplifies irregularity by creating more 'boundary events'",
+      "The Gauss circle problem (counting ℤ² points in a circle) is a special case: the fluctuation r^{1/4} is less than √r because the lattice is highly structured"
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -111,42 +111,42 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Point (as EuclideanSpace \u211d (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (\u03c0r\u00b2). These are the geometric primitives for the discrepancy problem.",
+      "summary": "Defines Point (as EuclideanSpace ℝ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (πr²). These are the geometric primitives for the discrepancy problem.",
       "startLine": 44,
       "endLine": 61,
-      "mathContext": "Defines Point (as EuclideanSpace $\\mathbb{R}$ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (\u03c0r\u00b2). These are the geometric primitives for the discrepancy problem."
+      "mathContext": "Defines Point (as EuclideanSpace $\\mathbb{R}$ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (πr²). These are the geometric primitives for the discrepancy problem."
     },
     {
       "id": "discrepancy-definitions",
       "title": "Point Sequences and Discrepancy",
-      "summary": "Defines PointSequence (\u2115 \u2192 Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - \u03c0r\u00b2|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths).",
+      "summary": "Defines PointSequence (ℕ → Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - πr²|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths).",
       "startLine": 62,
       "endLine": 87,
-      "mathContext": "Defines PointSequence (\u2115 \u2192 Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - \u03c0r\u00b2|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths)."
+      "mathContext": "Defines PointSequence (ℕ → Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - πr²|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths)."
     },
     {
       "id": "lower-bound",
       "title": "Beck's Lower Bound",
-      "summary": "States beck_lower_bound as an axiom (\u2203 c > 0, \u2200 A, f(r) \u2265 c\u221ar eventually) and derives discrepancy_unbounded \u2014 one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity.",
+      "summary": "States beck_lower_bound as an axiom (∃ c > 0, ∀ A, f(r) ≥ c√r eventually) and derives discrepancy_unbounded — one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity.",
       "startLine": 88,
       "endLine": 129,
-      "mathContext": "States beck_lower_bound as an axiom (\u2203 c > 0, \u2200 A, f(r) \u2265 c\u221ar eventually) and derives discrepancy_unbounded \u2014 one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity."
+      "mathContext": "States beck_lower_bound as an axiom (∃ c > 0, ∀ A, f(r) ≥ c√r eventually) and derives discrepancy_unbounded — one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity."
     },
     {
       "id": "upper-bound",
       "title": "Beck's Upper Bound",
-      "summary": "States beck_upper_bound as an axiom (\u2203 A, f(r) \u2264 C\u221a(r log r) eventually) and extracts beckOptimalSequence via Classical.choose \u2014 a non-constructive witness from the probabilistic existence proof.",
+      "summary": "States beck_upper_bound as an axiom (∃ A, f(r) ≤ C√(r log r) eventually) and extracts beckOptimalSequence via Classical.choose — a non-constructive witness from the probabilistic existence proof.",
       "startLine": 130,
       "endLine": 150,
-      "mathContext": "States beck_upper_bound as an axiom (\u2203 A, f(r) \u2264 C\u221a(r log r) eventually) and extracts beckOptimalSequence via Classical.choose \u2014 a non-constructive witness from the probabilistic existence proof."
+      "mathContext": "States beck_upper_bound as an axiom (∃ A, f(r) ≤ C√(r log r) eventually) and extracts beckOptimalSequence via Classical.choose — a non-constructive witness from the probabilistic existence proof."
     },
     {
       "id": "complete-answer",
       "title": "The Complete Answer",
-      "summary": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound \u221ar, and existence of near-optimal \u221a(r log r) sequence. Proved by direct application of the preceding results.",
+      "summary": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound √r, and existence of near-optimal √(r log r) sequence. Proved by direct application of the preceding results.",
       "startLine": 151,
       "endLine": 183,
-      "mathContext": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound \u221ar, and existence of near-optimal \u221a(r log r) sequence. Proved by direct application of the preceding results."
+      "mathContext": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound √r, and existence of near-optimal √(r log r) sequence. Proved by direct application of the preceding results."
     },
     {
       "id": "discrepancy-theory",
@@ -167,35 +167,35 @@
     {
       "id": "open-questions",
       "title": "Open Questions",
-      "summary": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(\u221ar) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in \u211d^d).",
+      "summary": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(√r) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in ℝ^d).",
       "startLine": 240,
       "endLine": 283,
-      "mathContext": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(\u221ar) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in \u211d^d)."
+      "mathContext": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(√r) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in ℝ^d)."
     },
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) \u2265 c\u00b7(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (\u226b r^{1/4}), providing context for why circle discrepancy (\u221ar) is intermediate. Commentary only \u2014 no Lean declarations.",
+      "summary": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) ≥ c·(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (≫ r^{1/4}), providing context for why circle discrepancy (√r) is intermediate. Commentary only — no Lean declarations.",
       "startLine": 284,
       "endLine": 320,
-      "mathContext": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) \u2265 c\u00b7(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (\u226b r^{1/4}), providing context for why circle discrepancy (\u221ar) is intermediate. Commentary only \u2014 no Lean declarations."
+      "mathContext": "Docstring discussion of Schmidt's classical box discrepancy theorem (D(N) ≥ c·(log N)^{d/2}) and Alexander's half-plane discrepancy theorem (≫ r^{1/4}), providing context for why circle discrepancy (√r) is intermediate. Commentary only — no Lean declarations."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) \u2265 c\u221ar. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems.",
+      "summary": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) ≥ c√r. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems.",
       "startLine": 321,
       "endLine": 341,
-      "mathContext": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) \u2265 c\u221ar. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems."
+      "mathContext": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) ≥ c√r. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #989 asked whether the circle discrepancy f(r) is unbounded and how fast it grows. Beck (1987) completely settled this: f(r) \u226b \u221ar for ALL sequences (using Fourier/Bessel analysis), and \u2203 sequence with f(r) \u226a \u221a(r log r) (using probabilistic construction). The optimal rate is \u0398\u0303(\u221ar).",
-    "implications": "1. **Discrepancy Theory**: Foundational result establishing the sharp growth rate for circle discrepancy, resolving the key open question in geometric equidistribution\n\n2. **Fourier Methods in Combinatorics**: Demonstrates the power of harmonic analysis for discrete geometry problems \u2014 the Bessel function connection shows deep interplay between analysis and combinatorics\n\n**3. Probabilistic Method**: The fact that a randomly perturbed lattice achieves near-optimal discrepancy is a striking example of the Erd\u0151s probabilistic method in geometry\n\n4. **Curvature and Discrepancy**: The comparison circles (\u221ar) vs half-planes (r^{1/4}) reveals that boundary curvature \u03ba = 1/r fundamentally amplifies discrepancy \u2014 a geometric insight with implications for all curved test set families\n\n5. **Connection to Number Theory**: The Gauss circle problem (lattice points in circles) is a special case where the highly structured lattice achieves r^{1/4} fluctuation, far below the \u221ar universal lower bound.",
+    "summary": "Erdős Problem #989 asked whether the circle discrepancy f(r) is unbounded and how fast it grows. Beck (1987) completely settled this: f(r) ≫ √r for ALL sequences (using Fourier/Bessel analysis), and ∃ sequence with f(r) ≪ √(r log r) (using probabilistic construction). The optimal rate is Θ̃(√r).",
+    "implications": "1. **Discrepancy Theory**: Foundational result establishing the sharp growth rate for circle discrepancy, resolving the key open question in geometric equidistribution\n\n2. **Fourier Methods in Combinatorics**: Demonstrates the power of harmonic analysis for discrete geometry problems — the Bessel function connection shows deep interplay between analysis and combinatorics\n\n**3. Probabilistic Method**: The fact that a randomly perturbed lattice achieves near-optimal discrepancy is a striking example of the Erdős probabilistic method in geometry\n\n4. **Curvature and Discrepancy**: The comparison circles (√r) vs half-planes (r^{1/4}) reveals that boundary curvature κ = 1/r fundamentally amplifies discrepancy — a geometric insight with implications for all curved test set families\n\n5. **Connection to Number Theory**: The Gauss circle problem (lattice points in circles) is a special case where the highly structured lattice achieves r^{1/4} fluctuation, far below the √r universal lower bound.",
     "openQuestions": [
-      "Is the logarithmic factor necessary? Is the lower bound actually \u03a9(\u221a(r log r))? This has been open since 1987.",
-      "Can we give explicit deterministic constructions achieving \u221a(r log r)? Known low-discrepancy sequences (Halton, Niederreiter) apply to boxes, not circles.",
-      "What is the optimal discrepancy for balls in higher dimensions \u211d^d? The expected answer r^{(d-1)/2} up to logs is supported but not fully proved.",
+      "Is the logarithmic factor necessary? Is the lower bound actually Ω(√(r log r))? This has been open since 1987.",
+      "Can we give explicit deterministic constructions achieving √(r log r)? Known low-discrepancy sequences (Halton, Niederreiter) apply to boxes, not circles.",
+      "What is the optimal discrepancy for balls in higher dimensions ℝ^d? The expected answer r^{(d-1)/2} up to logs is supported but not fully proved.",
       "Are there natural sequences (lattice-based, number-theoretic) achieving near-optimal circle discrepancy without randomization?",
       "What about discrepancy for other families of curved sets (ellipses, convex sets of bounded curvature)?"
     ]
@@ -218,7 +218,7 @@
     "lineCount": 341,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos989Problem.lean",
     "sorries": 0
   },
@@ -231,12 +231,12 @@
     {
       "targetId": "erdos-987",
       "relationship": "related",
-      "description": "Exponential sums controlling equidistribution via the Erd\u0151s-Tur\u00e1n inequality, using related Fourier methods"
+      "description": "Exponential sums controlling equidistribution via the Erdős-Turán inequality, using related Fourier methods"
     },
     {
       "targetId": "erdos-990",
       "relationship": "related",
-      "description": "Angular discrepancy of polynomial roots on the unit circle via Erd\u0151s-Tur\u00e1n inequality"
+      "description": "Angular discrepancy of polynomial roots on the unit circle via Erdős-Turán inequality"
     },
     {
       "targetId": "erdos-992",

--- a/src/data/proofs/erdos-990/meta.json
+++ b/src/data/proofs/erdos-990/meta.json
@@ -182,7 +182,7 @@
     "lineCount": 207,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos990Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.definitionCount` and `leanFile.theoremCount` for 52 proofs in the erdos-901–1097 range.

## Evidence

**Before**: Counts were stale from prior Lean source edits.
**After**: Counts re-derived from grep over Lean source files.

Part of systematic gallery metadata integrity scan (batches 9–18).

---
Automated fix by lean-mechanic agent.