### PR TITLE
fix(meta): sync meta.theoremCount with leanFile.theoremCount for 85 proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -19,7 +19,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 1,
     "lineCount": 66,
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "Uses `maclaurin_step` axiom from AmgmInequalityOQ02. If replaced by the proved `maclaurin_step_proved` from AmgmInequalityOQ02OQ03, all results become fully verified.",
     "originalContributions": [

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 219,
-    "theoremCount": 2,
+    "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [
       "powerMean_tendsto_max: M_r(x) → max(x) as r → +∞, proved by squeezing between max·n^{-1/r} and max",

--- a/src/data/proofs/angle-trisection-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "lineCount": 366,
-    "theoremCount": 40,
+    "theoremCount": 44,
     "definitionCount": 3,
     "originalContributions": [
       "prime_dvd_pow_two_eq_two: any prime dividing 2^n equals 2",

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 19,
     "lineCount": 383,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "wip",
     "sorries": 5,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 15,
     "lineCount": 234,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/area-of-circle-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: nball_volume_scaling — Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)). This is a standard measure theory fact requiring careful handling of EuclideanSpace/PiLp volume isomorphism in Mathlib.",
     "lineCount": 211,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 3,
     "originalContributions": [
       "unitBallVolume: definition of Vol(Bⁿ(1)) = πⁿ/² / Γ(n/2+1)",

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Proves new results from first principles using Mathlib's real analysis and integration libraries.",
     "lineCount": 254,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 2,
     "originalContributions": [
       "dalzell2_polynomial_identity: x\u2078(1-x)\u2078 = (1+x\u00b2)\u00b7Q(x) + 16 (remainder +16, opposite sign from n=1)",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 169,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 0,
     "assumptions": "None. Fully machine-verified. Imports ArithmeticSeriesOQ02OQ04.lean (0 axioms).",
     "originalContributions": [

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. All axioms eliminated: fiber_card_uniform proved via fiberSwap bijection, uniformOn_fiber_transfer proved via cross-multiplication bijection showing |(MCS \u2229 MSP)| \u00b7 |CS| = |(CS \u2229 SP)| \u00b7 |MCS|.",
     "lineCount": 1047,
-    "theoremCount": 36,
+    "theoremCount": 40,
     "definitionCount": 18,
     "originalContributions": [
       "projectToSign: projection from multi-candidate sequences to \u00b11 sequences",

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -80,7 +80,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 2511,
-    "theoremCount": 82,
+    "theoremCount": 92,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
       "Binomial coefficients (Mathlib)",

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Proved from first principles using Mathlib's Zsqrtd and EuclideanDomain infrastructure.",
     "lineCount": 323,
-    "theoremCount": 16,
+    "theoremCount": 20,
     "definitionCount": 3,
     "originalContributions": [
       "norm_pos_of_ne_zero: N(z) > 0 for z \u2260 0 in \u2124[\u221a-2] (key for Euclidean algorithm)",

--- a/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
@@ -18,7 +18,7 @@
     "axiomCount": 0,
     "lineCount": 142,
     "assumptions": "None.",
-    "theoremCount": 8,
+    "theoremCount": 6,
     "mathlib_version": "4.26.0"
   },
   "leanFile": {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 207,
-    "theoremCount": 6,
+    "theoremCount": 4,
     "assumptions": "None. The proof is fully machine-checked with no sorry or axiom declarations beyond Mathlib's standard axioms.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-14",

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "dateAdded": "2026-04-05",
     "lineCount": 208,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
@@ -19,7 +19,7 @@
     "axiomCount": 0,
     "lineCount": 160,
     "assumptions": "The main theorem EquivariantBorsukUlam is a True placeholder — the full equivariant Borsuk-Ulam for compact Lie groups requires ~2000 lines of equivariant topology infrastructure not yet in Mathlib (G-CW complexes, equivariant cohomology, equivariant degree theory). The 7 supporting lemmas about equivariant map algebra and fixed-point subspaces are fully verified.",
-    "theoremCount": 7,
+    "theoremCount": 5,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Uses only Mathlib and the admissible_quadruple_0_2_6_8 witness from BoundedPrimeGaps.lean.",
     "lineCount": 187,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [
       "not_admissible_even_ap4: no even AP {a,a+2,a+4,a+6} is admissible (via subset of non-admissible triple)",

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 2,
     "assumptions": "2 structure-encoded assumptions in AngularAverageData: angularAvg_eq (the angular average on RP^{n-1} is proportional to norm with constant sigma_{n-2}/(n-1)), angularAvg_nonneg (non-negativity). These encode integration on the unit sphere which Mathlib lacks.",
     "lineCount": 332,
-    "theoremCount": 19,
+    "theoremCount": 20,
     "definitionCount": 5,
     "originalContributions": [
       "sphereArea: sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) with n=0,1,2 computed",

--- a/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 23,
     "defCount": 3,
     "lineCount": 325,
     "mathlibDependencies": [

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 16,
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.lt_power_cof",

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's SetTheory.Cardinal.Cofinality.",
     "lineCount": 142,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [
       "regular_sup_bounded: for regular κ, sup of < κ-many ordinals below κ.ord stays below κ.ord",

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 2,
     "assumptions": "ClassicalRiceModel encodes 2 mathematical assumptions as structure fields: (1) h_compile \u2014 every behavior has a canonical code (universality); (2) kleene_rec \u2014 Kleene's recursion theorem (every code transformer has a semantic fixed point). These are hypotheses to classical_rice_abstract, not global Lean axioms. The 5 abstract theorems (abstract_rice through no_halting_model) are fully axiom-free.",
     "lineCount": 275,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 4,
     "originalContributions": [
       "abstract_rice: no Bool-evaluation structure can be point-surjective (direct from Lawvere)",

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 5,
     "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma / h_diag), consistency (h_consistent), reflection principle (h_reflection), and D1 axiom of provability logic (h_D1) — 4 Prop-typed assumptions. StrongGodelModel additionally axiomatizes double-negation elimination (h_dne) — 1 more. Total: 5 structure-encoded mathematical assumptions. These are hypotheses, not global Lean axioms.",
     "lineCount": 256,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 5,
     "originalContributions": [
       "diagonal_lemma: abstract Lawvere version of the Gödel-Carnap diagonal lemma",

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "mathlibDependencies": [
       {
         "theorem": "CompleteLattice",

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "lineCount": 146,
     "assumptions": "None.",
-    "theoremCount": 7,
+    "theoremCount": 5,
     "mathlib_version": "4.26.0"
   },
   "leanFile": {

--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) — the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 3 sorries: (1) nested ciSup of zeros = 0 for independent sequences, (2) i.i.d. Lindeberg condition via dominated convergence for truncated moments, (3) i.i.d. Lyapunov condition via rpow moment decay.",
     "lineCount": 729,
-    "theoremCount": 19,
+    "theoremCount": 20,
     "definitionCount": 6,
     "originalContributions": [
       "MartingaleDiffArray: triangular array {X_{n,k}} with martingale difference property and square integrability",

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-02/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using B\u00e9zout's identity in EuclideanDomain.",
     "lineCount": 378,
-    "theoremCount": 6,
+    "theoremCount": 10,
     "definitionCount": 0,
     "originalContributions": [
       "lcm_gcd_dvd_gcd_lcm: lcm(gcd(a,c), gcd(b,c)) \u2223 gcd(lcm(a,b), c) in any EuclideanDomain",

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. (Previously had 1 axiom gcd_lcm_distrib, later replaced by direct Bézout proof.)",
     "lineCount": 391,
-    "theoremCount": 7,
+    "theoremCount": 13,
     "definitionCount": 0,
     "originalContributions": [
       "gcd_dvd_of_dvd_sub: gcd(m₁,m₂) divides any linear combination of m₁ and m₂ differences",

--- a/src/data/proofs/collatz-cycles-oq-04/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 209,
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 3,
     "originalContributions": [
       "CycleConfig structure: encodes j-step Collatz cycle with odd elements, halving counts, and step relation 2^m\u1d62 \u00b7 n_{i+1} = 3n\u1d62 + 1",

--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 283,
-    "theoremCount": 8,
+    "theoremCount": 14,
     "definitionCount": 4,
     "originalContributions": [
       "numDerangements_eq_factorial_mul_altSum: identity D(n) = n! · ∑_{k≤n} (-1)^k/k! proved by strong induction",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
     "axiomCount": 0,
     "lineCount": 154,
     "assumptions": "None. All results proved from Mathlib.",
-    "theoremCount": 10,
+    "theoremCount": 9,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       "Polynomial.IsAlgClosed.degree_eq_card_roots",

--- a/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "lineCount": 440,
-    "theoremCount": 24,
+    "theoremCount": 29,
     "definitionCount": 4,
     "originalContributions": [
       "root_in_cauchy_interval: all real roots lie in (-cauchyBound p, cauchyBound p)",

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -21,7 +21,7 @@
     "sorries": 3,
     "axiomCount": 2,
     "lineCount": 139,
-    "theoremCount": 8,
+    "theoremCount": 6,
     "assumptions": "2 axioms: linnik_theorem (existence of c,L) and xylouris_bound (5 ∈ admissibleExponents). 3 sorries: two in leastPrimeInAP (⟨sorry, sorry⟩ for witness and property of prime in AP) and one in linnikConstant_pos (lower bound argument).",
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",
     "problemStatement": "For coprime integers a, q with q ≥ 1, let p(a, q) denote the least prime p ≡ a (mod q).\n\n**Linnik's theorem** (1944): There exist absolute constants c > 0 and L > 0 such that\n$$p(a,q) \\leq c \\cdot q^L$$\nfor all coprime pairs (a, q).\n\nThe **Linnik constant** is:\n$$L^* = \\inf\\{ L > 0 : \\text{Linnik's theorem holds with exponent } L \\}.$$\n\n**Currently known**: 1 ≤ L* ≤ 5. Best unconditional bound: L* ≤ 5 (Xylouris 2011). Under GRH: L* ≤ 2 + ε. **Conjectured**: L* = 1.",

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-04-05",
     "lineCount": 202,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "0 axioms, 0 sorries. Fully machine-verified using Euler's theorem from Mathlib (ZMod.pow_totient) and Nat.modEq_digits_sum.",
     "dateAdded": "2026-04-04",
     "lineCount": 108,
-    "theoremCount": 9,
+    "theoremCount": 2,
     "definitionCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 18,
+    "theoremCount": 15,
     "mathlibDependencies": [
       {
         "theorem": "Transcendental",

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -48,7 +48,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 1
+    "theoremCount": 12
   },
   "overview": {
     "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental—Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization—the **Lindemann-Weierstrass theorem** (1885)—states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is axiomatized.",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 16,
     "defCount": 4,
     "lineCount": 223,
     "dateAdded": "2026-03-28",

--- a/src/data/proofs/erdos-1-wip-01/meta.json
+++ b/src/data/proofs/erdos-1-wip-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. All results are fully proved in Lean 4 with 0 axioms and 0 sorries.",
     "lineCount": 319,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 0,
     "dateAdded": "2026-04-26",
     "originalContributions": [

--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 3,
     "assumptions": "3 axioms: (1) posUpperDensity_piecewiseSyndetic \u2014 piecewise syndeticity from positive density (pigeonhole argument not yet in Mathlib); (2) hindman_theorem \u2014 Hindman (1974) via idempotent ultrafilters; (3) posUpperDensity_ipStar \u2014 Furstenberg-Katznelson IP Szemer\u00e9di theorem (1985). Previously stated as sorries; converted to axiom declarations reflecting their status as deep results assumed without Lean proof.",
     "lineCount": 473,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 10,
     "originalContributions": [
       "IsSyndetic, IsThick, IsPiecewiseSyndetic: gap condition definitions",

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 475,
-    "theoremCount": 32,
+    "theoremCount": 37,
     "assumptions": "0 axioms, 0 sorries. gFunc_exists proved constructively via Kummer's theorem (carry-free base-p arithmetic). gFunc defined via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 all verified. Open conjecture; supporting lemmas fully verified."
   },
   "overview": {

--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -51,7 +51,7 @@
     "axiomCount": 5,
     "lineCount": 424,
     "assumptions": "5 axioms: qSequence, pisot_no_gap_property, gap_universal_bound, qSequenceM, bugeaud_characterization. 0 sorries.",
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 9
   },
   "overview": {

--- a/src/data/proofs/erdos-130-wip-01/meta.json
+++ b/src/data/proofs/erdos-130-wip-01/meta.json
@@ -37,7 +37,7 @@
     ],
     "date": "2026-04-13",
     "dateAdded": "2026-04-13",
-    "theoremCount": 12
+    "theoremCount": 13
   },
   "overview": {
     "text": "Formalizes the key algebraic identity behind the Anning\u2013Erd\u0151s theorem: for fixed non-collinear P=(0,0), Q=(D,0), R=(r_x,r_y) with integer pairwise distances, any additional point X with integer distances satisfies 2D\u00b7x = 2as\u2212s\u00b2+D\u00b2 (x-coordinate formula) and [4a(tD\u2212r_x\u00b7s)+K]\u00b2 = 4r_y\u00b2[(2Da)\u00b2\u2212(2as\u2212s\u00b2+D\u00b2)\u00b2] (the Anning-Erd\u0151s quadratic constraint). The explicit count 4(2D+1)(2E+1) bounds the number of such points.",

--- a/src/data/proofs/erdos-131-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 2,
     "assumptions": "2 axioms: pham_zakharov_upper_bound (Pham-Zakharov 2024: F(N) ≤ N^{1/4+o(1)}), csaba_lower_bound (Csaba: F(N) >> N^{1/5}).",
     "lineCount": 556,
-    "theoremCount": 20,
+    "theoremCount": 26,
     "definitionCount": 6,
     "originalContributions": [
       "IsNonDividing: no a ∈ A divides sum of ≥2 distinct elements from A\\{a}",

--- a/src/data/proofs/erdos-14-unique-sums/meta.json
+++ b/src/data/proofs/erdos-14-unique-sums/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 3,
     "assumptions": "3 axioms: erdos_upper_construction (Erdős: ∃ A with U(N) << N^{1/2+ε} for all large N), erdos_lower_infinitely_often (∃ A with U(N) >> N^{1/3-ε} for infinitely many N), erdos_freud_finite (Erdős-Freud: ∃ A ⊆ {1,...,N} with U(N) < 2^{3/2} · N^{1/2}).",
     "lineCount": 443,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 13,
     "originalContributions": [
       "repCount: formal count of ways to write n as a+b with a≤b and a,b∈A",

--- a/src/data/proofs/erdos-247-oq-01/meta.json
+++ b/src/data/proofs/erdos-247-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_transcendence_strong — Erdős 1975: if n_k is strictly increasing with HasStrongGrowth (lim sup n_k/k^t = ∞ for all t ≥ 1), then Σ 1/2^{n_k} is transcendental over ℚ.",
     "lineCount": 506,
-    "theoremCount": 22,
+    "theoremCount": 27,
     "definitionCount": 7,
     "originalContributions": [
       "lacunarySum: Σ_{k=1}^∞ 1/2^{n_k} — the lacunary binary sum",

--- a/src/data/proofs/erdos-249-oq-01/meta.json
+++ b/src/data/proofs/erdos-249-oq-01/meta.json
@@ -25,7 +25,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 303,
-    "theoremCount": 21,
+    "theoremCount": 26,
     "definitionCount": 0,
     "assumptions": "None. Imports Erdos249Problem.lean (0 axioms). Fully machine-verified. Open conjecture; all bounding theorems fully verified.",
     "originalContributions": [

--- a/src/data/proofs/erdos-252/meta.json
+++ b/src/data/proofs/erdos-252/meta.json
@@ -49,7 +49,7 @@
     "axiomCount": 5,
     "lineCount": 220,
     "assumptions": "5 axioms: erdos_252_k0 through erdos_252_k4 (irrationality of divisorPowerSum for k=0..4).",
-    "theoremCount": 6
+    "theoremCount": 7
   },
   "leanFile": {
     "path": "Proofs/Erdos252Problem.lean",

--- a/src/data/proofs/erdos-28-additive-bases/meta.json
+++ b/src/data/proofs/erdos-28-additive-bases/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 2,
     "assumptions": "2 axioms for known partial results: grekos_lower_bound (Grekos et al. 2003: if A is an asymptotic basis of order 2, then r_A(n) ≥ 6 for infinitely many n) and borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 for infinitely many n). The Erdős-Turán conjecture itself (lim sup r_A(n) = ∞) remains open.",
     "lineCount": 647,
-    "theoremCount": 15,
+    "theoremCount": 19,
     "definitionCount": 11,
     "originalContributions": [
       "representationCount: r_A(n) = |{(a,b) ∈ A×A : a+b = n}| counting representations",

--- a/src/data/proofs/erdos-366/meta.json
+++ b/src/data/proofs/erdos-366/meta.json
@@ -55,7 +55,7 @@
       "Theorems for known pairs: (8,9) and (12167,12168)"
     ],
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "lineCount": 209,
     "assumptions": "None. All numerical claims (8 is cubeful, 9 is powerful, 12167 is cubeful, 12168 is powerful) are fully proved. The open conjecture is stated as a definition, not assumed. Open conjecture; supporting lemmas fully verified."
   },

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -69,7 +69,7 @@
     ],
     "lineCount": 291,
     "assumptions": "2 axioms: lin_bound (f(2,2) <= 254), lin_bound_meaning (2^255 never divides such sums). 0 sorries.",
-    "theoremCount": 10
+    "theoremCount": 9
   },
   "overview": {
     "historicalContext": "**Prime Power Divisibility of Factorial Sums**\n\nThe interaction between prime divisibility and factorials has deep roots: Legendre's formula $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$ (1808) gives the exact $p$-adic valuation of $n!$, and Kummer's theorem (1852) extends this to binomial coefficients. Erdős and Graham posed Problem #404 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*: for integers $a \\geq 1$ and primes $p$, define $f(a,p) = \\sup\\{k : p^k \\mid a_1! + \\cdots + a_n!$ for some $a = a_1 < \\cdots < a_n\\}$. Is $f(a,p)$ always finite?\n\n**Chronological Development:**\n- **1808 (Legendre):** Formula for $v_p(n!)$ — the foundational tool\n- **1976 (Lin):** Proved $f(2,2) \\leq 254$ — the only known concrete upper bound for any $(a,p)$ pair. Lin's argument used careful analysis of carries in $p$-adic addition of factorials\n- **1980 (Erdős–Graham):** Problem 404 posed formally, alongside the related Problem #403 on factorial sums modulo primes\n\nThe problem is surprisingly resistant because factorial sums can have cancellation patterns that concentrate $p$-adic valuation. The gap between the known lower bound $f(2,2) \\geq 3$ (from $2^3 \\mid 2! + 3!$) and Lin's upper bound of 254 illustrates how little is understood about the $p$-adic structure of factorial sums.",

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "None. All results are fully proved. 19 theorems including: iterate_decreasing, iteration_terminates, iteration_reaches_prime_in (F(n) \u2264 n\u22122), iteration_reaches_prime_half (F(n) \u2264 n/2), sigma_prime_fixed (\u03c3(p)\u22121=p), sigma_composite_growth (\u03c3(n)\u22121>n for composite), one_iteration_infinite, and more. Open conjecture; supporting lemmas fully verified.",
     "lineCount": 424,
     "mathlib_version": "4.26.0",
-    "theoremCount": 19
+    "theoremCount": 18
   },
   "overview": {
     "historicalContext": "This problem originates with Finucane and was popularized by Erdos and Graham in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p. 81). The map $T(n) = \\varphi(n) + 1$ defines a discrete dynamical system on the positive integers: since $\\varphi(n) < n - 1$ for composite $n > 1$, each application strictly decreases the value until a prime fixed point is reached ($T(p) = p$ for primes $p$). The iteration count $F(n) = \\min\\{k \\geq 0 : T^k(n) \\text{ is prime}\\}$ appears as OEIS A039651. Cambie noted that $F(n) = o(n)$ is trivial but the true growth rate remains unknown --- heuristically $F(n) = O(\\log n)$ since $\\varphi(n)/n$ has mean value $6/\\pi^2 \\approx 0.608$, suggesting each step reduces $n$ by a constant factor. Guy discusses the problem in UPINT (B41). The companion problem replacing $\\varphi$ by $\\sigma$ (sum of divisors) yields $n \\mapsto \\sigma(n) - 1$, which is non-decreasing for composites, making termination at a prime an entirely separate open question related to aliquot sequences and the Catalan--Dickson conjecture.",

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom (vosper_case1_exists_large): covers the large-case existence step in Vosper's theorem induction (|A|\u22654 or |B|\u22654). Proof strategy uses Dyson e-transform; deferred to future session. All other lemmas (ap_of_near_periodic, vosper_base, vosper_ap_sdiff_card) fully proved.",
     "lineCount": 885,
-    "theoremCount": 8,
+    "theoremCount": 13,
     "definitionCount": 1,
     "originalContributions": [
       "IsArithmeticProgression: AP definition for Finset (ZMod p) with starting point a and difference d",

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "sorryCount": 0,
     "lineCount": 419,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 3,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -62,7 +62,7 @@
     "axiomCount": 3,
     "lineCount": 328,
     "assumptions": "3 axioms: no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), cilleruelo_granville (conditional). BombieriLangConjecture converted to opaque Prop (not an axiom). squares_contain_3AP proved by explicit construction {1,25,49}.",
-    "theoremCount": 11
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "This problem was posed by Brown, Erdős, and Freedman in [BEF90]. It connects classical results about arithmetic progressions in squares with modern questions in additive combinatorics.\n\nThe classical result that squares contain no 4-term APs (related to Fermat's Last Theorem for n=4) motivates asking about weaker structures. Quasi-progressions relax the exact gap requirement to bounded gaps.\n\nSolymosi (2007) conjectured that even combinatorial cubes don't appear in unbounded sizes. Cilleruelo and Granville (2007) showed this would follow from the Bombieri-Lang conjecture in algebraic geometry.",

--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -80,7 +80,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 346,
-    "theoremCount": 12,
+    "theoremCount": 17,
     "assumptions": "0 axioms, 0 sorries. totient_dvd_self_iff fully proved: φ(n)|n iff n≤1 or n=2^a·3^b. Key technique: 2-adic decomposition n=2^α·m, show φ(m)|2m, prove m has at most one odd prime factor (otherwise 4|φ(m)|2m contradicts m odd), then (p-1)|2p forces p=3. Open conjecture; supporting lemmas fully verified."
   },
   "overview": {

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -54,7 +54,7 @@
     "axiomCount": 0,
     "lineCount": 690,
     "assumptions": "None. All results are fully machine-checked. The Erdős-Hajnal graphs on ω₁² and ω₂² are proved to have chromatic numbers ℵ₁ and ℵ₂ respectively via double pigeonhole arguments. The open questions (Questions 1 and 2) are stated but not assumed. Open conjecture; supporting lemmas fully verified.",
-    "theoremCount": 42
+    "theoremCount": 40
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős in 1969 [Er69b] and sits at the intersection of graph theory, set theory, and infinite combinatorics. It was inspired by Babai's theorem about chromatic properties of graphs on well-ordered vertex sets.\n\nErdős and Hajnal made crucial progress by constructing a counterexample at the ℵ₁ level. They built a graph on ω₁² (the ordinal product of two copies of the first uncountable ordinal) with chromatic number ℵ₁, but where every strictly smaller subgraph (by order type) has countable chromatic number ≤ ℵ₀. This showed that Babai's theorem does not generalize to higher cardinals.\n\nThe natural question then arises: can we do the same construction at the next level? This is Problem #919: does there exist a graph on ω₂² with chromatic number ℵ₂ where smaller subgraphs have chromatic number at most ℵ₀ (not just ℵ₁)?",

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Delegates to FairGamesTheoremOQ03.lean (which is fully verified) and Mathlib's martingale library.",
     "lineCount": 291,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 0,
     "originalContributions": [
       "doob_optional_stopping_theorem: clean standalone statement of the bounded OST",

--- a/src/data/proofs/friendship-theorem-oq-01/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "lineCount": 2276,
-    "theoremCount": 74,
+    "theoremCount": 84,
     "definitionCount": 3,
     "originalContributions": [
       "k_eq_two_no_axiom: k-regular friendship graph \u27f9 k=2, fully axiom-free",

--- a/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 18,
     "lineCount": 192,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Depends on GCDAlgorithmOQ01 (euclideanSteps, decimalDigits, lame_step_bound).",
     "lineCount": 280,
-    "theoremCount": 21,
+    "theoremCount": 22,
     "definitionCount": 2,
     "originalContributions": [
       "lame_five_digit_bound_general: euclideanSteps(a,b) ≤ 5·decimalDigits(b) for ALL b > 0",

--- a/src/data/proofs/herons-formula-oq-03/meta.json
+++ b/src/data/proofs/herons-formula-oq-03/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-04-03",
     "lineCount": 300,
-    "theoremCount": 14,
+    "theoremCount": 18,
     "definitionCount": 4,
     "prerequisites": [
       "Heron's formula for triangles",

--- a/src/data/proofs/herons-formula-oq-04/meta.json
+++ b/src/data/proofs/herons-formula-oq-04/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-04-04",
     "lineCount": 362,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 3,
     "prerequisites": [
       "Heron's formula for triangles",

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -48,7 +48,7 @@
       "Documentation of the complete characterization landscape"
     ],
     "lineCount": 323,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 5,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 3,
     "axiomCount": 7,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "mathlibDependencies": [
       {
         "theorem": "Complex.ofReal",

--- a/src/data/proofs/inverse-galois-oq-06/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: three_dvd_gal_card \u2014 3 divides |Gal(q/\u211a)|. This follows from Dedekind's theorem applied to q mod 7 (which factors as (1-cycle)(1-cycle)(3-cycle)), implying the Galois group contains an element of order divisible by 3. Axiomatized because Mathlib lacks Dedekind's theorem for polynomial Galois groups.",
     "lineCount": 2067,
-    "theoremCount": 65,
+    "theoremCount": 85,
     "definitionCount": 7,
     "originalContributions": [
       "q: the polynomial x\u2075-5x\u2074+10x\u00b3-10x\u00b2+25x-5 (translate of x\u2075+20x+16)",

--- a/src/data/proofs/konigsberg-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 2,
     "assumptions": "2 axioms: directed_euler_circuit_sufficient (balanced digraph → Eulerian circuit exists) and directed_euler_path_sufficient (exactly one source + one sink → Eulerian path exists). The necessary conditions are fully proved; the sufficiency requires an Eulerian circuit construction algorithm (e.g., Hierholzer's algorithm) not yet in Mathlib.",
     "lineCount": 813,
-    "theoremCount": 30,
+    "theoremCount": 35,
     "definitionCount": 8,
     "originalContributions": [
       "Digraph: directed graph definition with finite vertex and edge types",

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 3,
     "assumptions": "3 structure-encoded assumptions: (1) HyperbolicTriangle.law — the first law of cosines cosh(c)=cosh(a)cosh(b)-sinh(a)sinh(b)cos(C) is a structure field (not proved from metric axioms); (2) HyperbolicTriangleAngles.law2 — the second law of cosines cos(C)=-cos(A)cos(B)+sin(A)sin(B)cosh(c) is a structure field; (3) HyperbolicTriangleAngles.defect_pos — the angular defect A+B+C<π is a structure field.",
     "lineCount": 192,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 0,
     "originalContributions": [
       "hyperbolic_law_of_cosines: cosh(c) = cosh(a)·cosh(b) - sinh(a)·sinh(b)·cos(C)",

--- a/src/data/proofs/leibniz-pi-oq-03/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-03/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 277,
-    "theoremCount": 15,
+    "theoremCount": 22,
     "defCount": 2,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -26,7 +26,7 @@
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 206,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 22,
     "defCount": 31,
     "lineCount": 232,
     "mathlibDependencies": [

--- a/src/data/proofs/prob-method-second-moment-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01/meta.json
@@ -19,7 +19,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 147,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
     "originalContributions": [

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -51,7 +51,7 @@
       "ptolemy_of_cw: Ptolemy equality for CW order via relabeling and norm symmetry"
     ],
     "lineCount": 288,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 2
   },
   "overview": {

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 4,
     "assumptions": "4 axioms inherited from ShannonChannelCoding.lean via import chain. 0 sorries. 0 new axioms introduced.",
     "lineCount": 248,
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 1,
     "originalContributions": [
       "uniformDist: uniform distribution on any nonempty Fintype as an InputDist",

--- a/src/data/proofs/shannon-entropy-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 623,
-    "theoremCount": 6,
+    "theoremCount": 14,
     "definitionCount": 3,
     "assumptions": "None. Fully machine-verified from Mathlib. Uses Bochner integral and Gaussian integration.",
     "originalContributions": [

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 341,
-    "theoremCount": 12,
+    "theoremCount": 11,
     "definitionCount": 5,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/sophie-germain-oq-02/meta.json
+++ b/src/data/proofs/sophie-germain-oq-02/meta.json
@@ -16,7 +16,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 156,
-    "theoremCount": 12,
+    "theoremCount": 11,
     "definitionCount": 3,
     "assumptions": [],
     "dateAdded": "2025-12-21",

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 323,
-    "theoremCount": 18,
+    "theoremCount": 21,
     "definitionCount": 6,
     "originalContributions": [
       "dot, normSq, arcLen, tripleProduct, projPerp definitions using Fin 3 → ℝ framework (compatible with Mathlib's crossProduct)",

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully proved: 0 sorries, 0 axioms. Irreducibility is proved over \u2124[X] via case analysis, then transferred to \u211a[X] via Gauss's lemma (Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast).",
     "lineCount": 403,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
       "aeval_sqrt2_plus_sqrt3: f(\u221a2+\u221a3)=0, proved by step-by-step computation (\u03b1\u00b2=5+2\u221a6, \u03b1\u2074=49+20\u221a6)",

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -41,7 +41,7 @@
       "error_bound_from_correction: structured proof reducing axiom to first correction"
     ],
     "lineCount": 207,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/subset-count-multiset-oq-01/meta.json
+++ b/src/data/proofs/subset-count-multiset-oq-01/meta.json
@@ -51,7 +51,7 @@
     ],
     "dateAdded": "2026-04-04",
     "lineCount": 226,
-    "theoremCount": 8,
+    "theoremCount": 12,
     "definitionCount": 2,
     "prerequisites": [
       "Multiset basics, count, toFinset",

--- a/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-04-03",
     "lineCount": 193,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 0,
     "prerequisites": [
       "Bernoulli numbers and their Mathlib formalization",

--- a/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-04-13",
     "lineCount": 324,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 1,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/taylor-theorem-oq-03/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-03/meta.json
@@ -58,7 +58,7 @@
     "dateAdded": "2026-03-23",
     "axiomCount": 0,
     "lineCount": 268,
-    "theoremCount": 20,
+    "theoremCount": 17,
     "definitionCount": 2,
     "assumptions": "0 axioms, 0 sorries. Core Taylor remainder estimates (taylor_mean_remainder_lagrange, taylor_mean_remainder_cauchy) from Mathlib; original work is exponential convergence analysis.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/three-place-identity-oq-02/meta.json
+++ b/src/data/proofs/three-place-identity-oq-02/meta.json
@@ -26,7 +26,7 @@
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 175,
-    "theoremCount": 8,
+    "theoremCount": 6,
     "definitionCount": 5
   },
   "overview": {

--- a/src/data/proofs/wilsons-theorem-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 688,
-    "theoremCount": 33,
+    "theoremCount": 35,
     "definitionCount": 9,
     "originalContributions": [
       "composite_factorial_dvd: for composite n>4, n divides (n-1)!",


### PR DESCRIPTION
## Fix

Sync stale `meta.theoremCount` values to match `leanFile.theoremCount` across 85 gallery proofs.

## Evidence

**Root cause**: `meta.theoremCount` was set at stub creation time and not updated as proofs evolved. `leanFile.theoremCount` (maintained by the enricher) is accurate.

**Selection criteria**: Only proofs where `leanFile.theoremCount == actual grep count` (verified by regex `^(?:private\s+)?(?:theorem|lemma)\s`) were updated. Risky cases where all three counts differ (9 proofs) were excluded.

**Before**: meta.theoremCount stale (ranging from off-by-1 to off-by-20)
**After**: meta.theoremCount == leanFile.theoremCount (verified against Lean source)

85 proofs updated. Each diff is a single-line change to one field.

---
Automated batch fix by lean-mechanic agent.