### PR TITLE
fix(meta): correct theoremCount for erdos-700 and erdos-782

### DIFF
--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "sorryCount": 0,
     "lineCount": 419,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 3,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -62,7 +62,7 @@
     "axiomCount": 3,
     "lineCount": 328,
     "assumptions": "3 axioms: no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), cilleruelo_granville (conditional). BombieriLangConjecture converted to opaque Prop (not an axiom). squares_contain_3AP proved by explicit construction {1,25,49}.",
-    "theoremCount": 11
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "This problem was posed by Brown, Erdős, and Freedman in [BEF90]. It connects classical results about arithmetic progressions in squares with modern questions in additive combinatorics.\n\nThe classical result that squares contain no 4-term APs (related to Fermat's Last Theorem for n=4) motivates asking about weaker structures. Quasi-progressions relax the exact gap requirement to bounded gaps.\n\nSolymosi (2007) conjectured that even combinatorial cubes don't appear in unbounded sizes. Cilleruelo and Granville (2007) showed this would follow from the Bombieri-Lang conjecture in algebraic geometry.",


### PR DESCRIPTION
## Fix

Corrects off-by-one `theoremCount` in meta.json for two gallery entries.

## Evidence

**erdos-700**
- Before: `theoremCount: 15`
- After: `theoremCount: 14`
- Source: `Erdos700Problem.lean` has 14 theorem/lemma declarations (8 public + 5 private + 1 public), all counted; origin/main overcounted by 1.

**erdos-782**
- Before: `theoremCount: 11`
- After: `theoremCount: 10`
- Source: `Erdos782Problem.lean` has 10 theorem/lemma declarations (all public); origin/main overcounted by 1.

Both counts verified by direct grep of Lean source files.

---
Automated fix by lean-mechanic agent.