### PR TITLE
audit(erdos-728): mark issues-found — phantom divisibility_via_legendre

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8734,9 +8734,9 @@
     },
     "erdos-728": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-30T23:20:37Z",
+      "result": "issues-found"
     },
     "erdos-728-factorial-divisibility": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Mark erdos-728 as `issues-found` in audit-tracker.json (auditCount 2 → 3).
- Filed #13989 detailing phantom `divisibility_via_legendre` axiom in `originalContributions` and the `legendre` section's narrative metadata.
- Numerical counts (`axiomCount=2`, `sorries=1`, `lineCount=246`) match the Lean source — no code change needed.

## Test plan

- [x] `git show origin/main:proofs/Proofs/Erdos728Problem.lean` — confirmed 2 axioms, 1 sorry, 246 lines.
- [x] No `divisibility_via_legendre` declaration in source (only a `/--` docstring at lines 199–203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)