### PR TITLE
fix(agents): restore OAuth load balancing — guard against self-symlink + bootstrap from .env

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -47,6 +47,24 @@ if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
     _repo_root="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
     _tokens_dir="$_repo_root/.loom/tokens"
 
+    # Bootstrap: if .loom/tokens is missing/empty/broken-symlink but .env
+    # has ACCOUNT_KEY_N entries, materialize them into the tokens dir.
+    if [[ ! -d "$_tokens_dir" ]] || ! ls "$_tokens_dir"/*.token &>/dev/null 2>&1; then
+        _env_file="$_repo_root/.env"
+        if [[ -f "$_env_file" ]] && grep -q '^ACCOUNT_KEY_[0-9]\+=' "$_env_file" 2>/dev/null; then
+            # Replace whatever is at $_tokens_dir (broken symlink, etc) with a real dir.
+            rm -f "$_tokens_dir" 2>/dev/null || true
+            mkdir -p "$_tokens_dir" 2>/dev/null || true
+            while IFS='=' read -r key val; do
+                _n="${key#ACCOUNT_KEY_}"
+                [[ "$_n" =~ ^[0-9]+$ ]] || continue
+                printf '%s' "$val" | tr -d "'\"\n" > "$_tokens_dir/agent-$_n.token"
+                chmod 600 "$_tokens_dir/agent-$_n.token" 2>/dev/null || true
+            done < <(grep '^ACCOUNT_KEY_[0-9]\+=' "$_env_file")
+            echo "[wrapper] Bootstrapped $(ls "$_tokens_dir"/*.token 2>/dev/null | wc -l | tr -d ' ') OAuth tokens from .env" >&2
+        fi
+    fi
+
     if [[ -d "$_tokens_dir" ]] && ls "$_tokens_dir"/*.token &>/dev/null; then
         _ranking_file="$_tokens_dir/.ranking"
         _allowlist_file="$_tokens_dir/.allowlist"

--- a/scripts/auditor/launch-agent.sh
+++ b/scripts/auditor/launch-agent.sh
@@ -19,18 +19,26 @@
 
 set -euo pipefail
 
-# Find repo root
+# Find repo root (resolves worktrees to the main repo, not the worktree dir)
 find_repo_root() {
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
-            echo "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    echo "Error: Not in a git repository" >&2
-    return 1
+    local common_git
+    common_git="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        echo "Error: Not in a git repository" >&2
+        return 1
+    }
+    if [[ "$common_git" == ".git" ]]; then
+        local dir="$PWD"
+        while [[ "$dir" != "/" ]]; do
+            if [[ -d "$dir/.git" ]]; then
+                echo "$dir"
+                return 0
+            fi
+            dir="$(dirname "$dir")"
+        done
+        echo "Error: Could not resolve repo root" >&2
+        return 1
+    fi
+    dirname "$common_git"
 }
 
 REPO_ROOT="$(find_repo_root)"
@@ -196,10 +204,18 @@ launch_agent() {
     # Create or update worktree
     create_worktree
 
-    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree
+    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree.
+    # Guard against self-pointing symlinks (corrupts load balancing).
     if [[ -d "$REPO_ROOT/.loom/tokens" ]]; then
-        mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
-        ln -sfn "$REPO_ROOT/.loom/tokens" "$WORKTREE_PATH/.loom/tokens"
+        local src="$REPO_ROOT/.loom/tokens"
+        local dst="$WORKTREE_PATH/.loom/tokens"
+        local src_real dst_real
+        src_real="$(cd "$src" 2>/dev/null && pwd -P)"
+        dst_real="$(dirname "$dst")"; dst_real="$(cd "$dst_real" 2>/dev/null && pwd -P)/$(basename "$dst")"
+        if [[ "$src_real" != "$dst_real" ]]; then
+            mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
+            ln -sfn "$src_real" "$dst"
+        fi
     fi
 
     # Create prompt file

--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -14,18 +14,31 @@
 
 set -euo pipefail
 
-# Find repo root
+# Find repo root (resolves worktrees to the main repo, not the worktree dir)
 find_repo_root() {
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
-            echo "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    echo "Error: Not in a git repository" >&2
-    return 1
+    # git rev-parse --git-common-dir returns the main repo's .git dir,
+    # even when invoked from a worktree (where .git is a file, not a dir).
+    local common_git
+    common_git="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        echo "Error: Not in a git repository" >&2
+        return 1
+    }
+    # --git-common-dir may return ".git" (relative) or an absolute path.
+    if [[ "$common_git" == ".git" ]]; then
+        # Walk up looking for the .git directory in case CWD changed.
+        local dir="$PWD"
+        while [[ "$dir" != "/" ]]; do
+            if [[ -d "$dir/.git" ]]; then
+                echo "$dir"
+                return 0
+            fi
+            dir="$(dirname "$dir")"
+        done
+        echo "Error: Could not resolve repo root" >&2
+        return 1
+    fi
+    # Absolute path; the parent of .git is the repo root.
+    dirname "$common_git"
 }
 
 REPO_ROOT="$(find_repo_root)"
@@ -121,11 +134,22 @@ create_worktree() {
         print_warning "No .env found - deploys will fail without CLOUDFLARE_ACCOUNT_ID"
     fi
 
-    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree
+    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree.
+    # Guard: refuse to create a self-pointing symlink (which would break load
+    # balancing and look identical to a directory in `ls`). See #13577 follow-up.
     if [[ -d "$REPO_ROOT/.loom/tokens" ]]; then
-        mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
-        ln -sfn "$REPO_ROOT/.loom/tokens" "$WORKTREE_PATH/.loom/tokens"
-        print_info "Linked .loom/tokens for OAuth token rotation"
+        local src="$REPO_ROOT/.loom/tokens"
+        local dst="$WORKTREE_PATH/.loom/tokens"
+        local src_real dst_real
+        src_real="$(cd "$src" 2>/dev/null && pwd -P)"
+        dst_real="$(dirname "$dst")"; dst_real="$(cd "$dst_real" 2>/dev/null && pwd -P)/$(basename "$dst")"
+        if [[ "$src_real" == "$dst_real" ]]; then
+            print_warning "Refusing to create self-pointing tokens symlink ($dst → $src). Skipping."
+        else
+            mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
+            ln -sfn "$src_real" "$dst"
+            print_info "Linked .loom/tokens for OAuth token rotation"
+        fi
     fi
 
     # Install node dependencies in worktree

--- a/scripts/mechanic/launch-agent.sh
+++ b/scripts/mechanic/launch-agent.sh
@@ -19,18 +19,26 @@
 
 set -euo pipefail
 
-# Find repo root
+# Find repo root (resolves worktrees to the main repo, not the worktree dir)
 find_repo_root() {
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
-            echo "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    echo "Error: Not in a git repository" >&2
-    return 1
+    local common_git
+    common_git="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+        echo "Error: Not in a git repository" >&2
+        return 1
+    }
+    if [[ "$common_git" == ".git" ]]; then
+        local dir="$PWD"
+        while [[ "$dir" != "/" ]]; do
+            if [[ -d "$dir/.git" ]]; then
+                echo "$dir"
+                return 0
+            fi
+            dir="$(dirname "$dir")"
+        done
+        echo "Error: Could not resolve repo root" >&2
+        return 1
+    fi
+    dirname "$common_git"
 }
 
 REPO_ROOT="$(find_repo_root)"
@@ -194,10 +202,18 @@ launch_agent() {
     # Create or update worktree
     create_worktree
 
-    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree
+    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree.
+    # Guard against self-pointing symlinks (corrupts load balancing).
     if [[ -d "$REPO_ROOT/.loom/tokens" ]]; then
-        mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
-        ln -sfn "$REPO_ROOT/.loom/tokens" "$WORKTREE_PATH/.loom/tokens"
+        local src="$REPO_ROOT/.loom/tokens"
+        local dst="$WORKTREE_PATH/.loom/tokens"
+        local src_real dst_real
+        src_real="$(cd "$src" 2>/dev/null && pwd -P)"
+        dst_real="$(dirname "$dst")"; dst_real="$(cd "$dst_real" 2>/dev/null && pwd -P)/$(basename "$dst")"
+        if [[ "$src_real" != "$dst_real" ]]; then
+            mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
+            ln -sfn "$src_real" "$dst"
+        fi
     fi
 
     # Create prompt file


### PR DESCRIPTION
## Summary

Three structural bugs in agent infrastructure were silently disabling load balancing across the 9 OAuth accounts in `.env`. Every agent (deployer, herald, seeker, auditor, mechanic, etc.) was sharing one quota pool. When that pool hit its weekly limit, every agent stalled — for the deployer this meant 168+ consecutive failed cycles and 58 mergeable PRs sitting unmerged.

## Root causes

### 1. `find_repo_root` walked to the worktree, not the main repo

Each `launch-agent.sh` (deploy, auditor, mechanic) used a hand-rolled `find_repo_root` that stopped at any `.git` (file or dir). In a worktree, `.git` is a *file* pointing to the main gitdir; the function returned the worktree path as `REPO_ROOT`. Then:

```bash
ln -sfn "$REPO_ROOT/.loom/tokens" "$WORKTREE_PATH/.loom/tokens"
```

resolved to the same path on both sides, creating a self-pointing symlink that breaks all subsequent reads (`Too many levels of symbolic links`).

**Fix:** use `git rev-parse --git-common-dir`, which always returns the main repo's gitdir even when invoked from a worktree.

### 2. No guard against self-pointing symlinks

Even with the right `REPO_ROOT`, an upstream bug or stale state could still produce `src == dst`. A self-link looks identical to a directory in `ls -l` but every read fails. Now we resolve src/dst with `pwd -P` and refuse to create the symlink when they match.

### 3. claude-wrapper had no path to discover `.env` tokens

`.env` carries 9 OAuth tokens as `ACCOUNT_KEY_1` through `ACCOUNT_KEY_9`, but the wrapper looked only for `.loom/tokens/*.token` files (or a single `CLAUDE_CODE_OAUTH_TOKEN`). When `.loom/tokens/` was missing or broken, every agent silently fell through to whatever single credential the claude CLI had stashed in macOS Keychain.

**Fix:** the wrapper now bootstraps `.loom/tokens/agent-N.token` from `.env` `ACCOUNT_KEY_N=...` lines on first run, replacing any broken symlink at that path with a real directory. After bootstrap, existing rotation logic (`.ranking`, `.allowlist`, random) takes over.

## Files changed

| File | Change |
|---|---|
| `scripts/agents/claude-wrapper.sh` | Bootstrap from `.env` if tokens dir is missing/empty/broken |
| `scripts/deploy/launch-agent.sh` | Fix `find_repo_root`, add self-link guard |
| `scripts/auditor/launch-agent.sh` | Same |
| `scripts/mechanic/launch-agent.sh` | Same |

Note: `aristotle`, `herald`, `peer-reviewer`, `test` `launch-agent.sh` do NOT symlink tokens (they don't need claude OAuth). They are unaffected.

## Test plan

- [x] **Self-loop case:** simulated `REPO_ROOT == WORKTREE_PATH`, guard correctly refuses `ln -sfn`
- [x] **Bootstrap:** replaced a broken self-loop tokens dir with 3 real token files materialized from a synthetic `.env`
- [x] **Syntax check:** `bash -n` passes for all 4 files
- [ ] **End-to-end:** restart deployer with new wrapper and observe `[wrapper] Using OAuth account: agent-N (mode: ranking)` in logs
- [ ] **Quota recovery:** confirm agents rotate to fresh accounts when one is exhausted

## Why this matters

Without this fix, the load-balancing infrastructure exists but is silently bypassed. As soon as the single in-use account hits its weekly limit, the entire daemon stalls until reset (~7 days worst case). With the fix, the daemon survives any single account exhaustion as long as one of the 9 accounts has capacity.

## Manual recovery for current state

After this PR merges:
1. Verify `.loom/tokens/` is a real directory with `agent-{1..9}.token` files
2. Run `./scripts/agents/check-accounts.sh --ranking` to populate ranking
3. Restart deployer/herald/seeker: `./scripts/deploy/launch-agent.sh` etc.
4. Observe `[wrapper] Using OAuth account: agent-N` in `.loom/logs/deployer.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)