### PR TITLE
audit(erdos-723): mark issues-found — phantom axiom narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8704,9 +8704,9 @@
     },
     "erdos-723": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-30T23:26:12Z",
+      "result": "issues-found"
     },
     "erdos-724": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Updates audit-tracker.json to record erdos-723 as `issues-found`. Issue #13992 filed.

## Finding

The Lean file `proofs/Proofs/Erdos723Problem.lean` declares **1 axiom** (`bruck_ryser`), matching `axiomCount: 1` in meta.json. However the narrative `sections` describe **4 axioms**:

| Section | Real axiom? |
|---------|-------------|
| existence-prime-power-orders | ❌ docstring only |
| verified-small-orders | ❌ docstring only |
| bruck-ryser-theorem | ✅ axiom at line 91 |
| lam-order-10 | ❌ docstring only |

`overview.proofStrategy` similarly overclaims. Numerical fields are correct; only narrative needs the fix described in #13992.

## Test plan

- [x] Verified Lean axiom count via `grep -c "^axiom "`
- [x] Verified each claimed-axiom section against Lean line ranges