### PR TITLE
fix(erdos-729): remove phantom sorry claim + correct section line ranges

### DIFF
--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -53,7 +53,7 @@
     "historicalContext": "Erdős proved in 1968 that if $a!b! \\mid n!$ then $a + b \\leq n + O(\\log n)$, using an elegant argument based on Legendre's formula for $v_2(n!) = n - s_2(n)$, where $s_2(n)$ is the binary digit sum. Problem 729, posed later, asks whether this logarithmic bound can be defeated by \"ignoring\" small primes: specifically, whether there are infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ such that $n!/(a!b!)$ has denominator divisible only by primes $\\leq C$. Barreto and Leeham resolved the problem negatively, showing that large primes alone carry sufficient information to enforce the bound. Their proof adapts the technique from Problem #728, extending it to show that for any prime $p > C$, the constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ already implies $a + b \\leq n + O(\\log n)$. This reveals a fundamental rigidity in factorial arithmetic: the divisibility structure is controlled by all primes collectively, and no finite set of exceptions can weaken it.",
     "problemStatement": "Let $C > 0$ be a constant. Are there infinitely many integers $a, b, n$ with $a + b > n + C\\log n$ such that the denominator of $n!/(a!b!)$ contains only primes $\\leq C$?",
     "text": "Let C > 0. Are there infinitely many (a, b, n) with a + b > n + C·log n such that n!/(a!b!) has denominator with only small primes? Barreto-Leeham proved NO: the bound a + b ≤ n + O(log n) persists even ignoring small primes.",
-    "proofStrategy": "The formalization defines `DividesFactorial` and `DividesFactorialModSmall` (allowing small prime factors in the denominator), states `InfinitelyManyExceptions` as the open question, and axiomatizes both Erdős's 1968 result and the Barreto-Leeham resolution. Legendre's formula is stated via `factorialPadicVal` and the digit sum identity. The main theorem `erdos_729_statement` combines both results, and `erdos_729_summary` provides the complete answer. Two `sorry`s remain: `legendre_for_two` and `binomial_rigidity`.",
+    "proofStrategy": "The formalization defines `DividesFactorial` and `DividesFactorialModSmall` (allowing small prime factors in the denominator), states `InfinitelyManyExceptions` as the open question, and axiomatizes both Erdős's 1968 result and the Barreto-Leeham resolution. Legendre's formula is stated via `factorialPadicVal` and the digit sum identity. The main theorem `erdos_729_statement` combines both results, and `erdos_729_summary` provides the complete answer.",
     "keyInsights": [
       "Legendre's formula $v_p(n!) = (n - s_p(n))/(p-1)$ connects factorial divisibility to base-$p$ digit sums, with the special case $v_2(n!) = n - s_2(n)$ being particularly clean",
       "If $a!b! \\mid n!$, then $v_p(a!) + v_p(b!) \\leq v_p(n!)$ for all primes $p$. Using just $p = 2$ and the digit sum identity gives $a + b \\leq n + s_2(a) + s_2(b) - s_2(n) \\leq n + O(\\log n)$",
@@ -70,47 +70,47 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "startLine": 35,
-      "endLine": 56,
+      "startLine": 31,
+      "endLine": 64,
       "summary": "Defines `factorialPadicVal` via Legendre's formula $\\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$, axiomatizes `legendre_formula`, and defines `DividesFactorial n a b` as $a! \\cdot b! \\mid n!$.",
       "mathContext": "Formal definition: Defines `factorialPadicVal` via Legendre's formula $\\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$, axiomatizes `legendre_formula`, and defines `DividesFactorial n a b` as $a! \\cdot b! \\mid n!$."
     },
     {
       "id": "erdos-classical",
       "title": "Erdős's Classical Result (1968)",
-      "startLine": 57,
-      "endLine": 74,
+      "startLine": 65,
+      "endLine": 82,
       "summary": "Axiomatizes `erdos_1968_classical`: $a!b! \\mid n! \\implies a + b \\leq n + O(\\log n)$. Proves `erdos_proof_via_powers_of_two` by forwarding to the axiom, documenting that the original proof uses only the $p = 2$ constraint.",
       "mathContext": "Axiomatizes `erdos_1968_classical`: $a!b! \\implies a + b \\leq n + O(\\log n)$. Proves `erdos_proof_via_powers_of_two` by forwarding to the axiom, documenting that the original proof uses only the $p = 2$ constraint."
     },
     {
       "id": "relaxed-condition",
       "title": "The Relaxed Condition",
-      "startLine": 75,
-      "endLine": 94,
+      "startLine": 83,
+      "endLine": 102,
       "summary": "Defines `SmallPrimes C` as primes $\\leq C$, and `DividesFactorialModSmall` allowing a correction factor $k$ with only small prime factors. This formalizes 'ignoring small primes in the denominator'.",
       "mathContext": "Formal definition: Defines `SmallPrimes C` as primes $\\leq C$, and `DividesFactorialModSmall` allowing a correction factor $k$ with only small prime factors. This formalizes 'ignoring small primes in the denominator'."
     },
     {
       "id": "question",
       "title": "The Question",
-      "startLine": 95,
-      "endLine": 107,
+      "startLine": 103,
+      "endLine": 115,
       "summary": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729.",
       "mathContext": "Defines `InfinitelyManyExceptions C`: are there infinitely many $(a, b, n)$ with $a + b > n + C\\$\\log n$$ and `DividesFactorialModSmall`? This is the formal statement of Erdős Problem 729."
     },
     {
       "id": "barreto-leeham",
       "title": "Barreto-Leeham Resolution",
-      "startLine": 108,
-      "endLine": 123,
+      "startLine": 116,
+      "endLine": 131,
       "summary": "Axiomatizes `barreto_leeham_theorem`: $\\neg\\text{InfinitelyManyExceptions}(C)$ for all $C > 0$. Also states `barreto_leeham_bound`: the bound $a + b \\leq n + D\\log n$ persists with an explicit constant $D$.",
       "mathContext": "Axiomatizes `barreto_leeham_theorem`: $\\neg\\text{InfinitelyManyExceptions}(C)$ for all $C > 0$. Also states `barreto_leeham_bound`: the bound $a + b \\leq n + D\\log n$ persists with an explicit constant $D$."
     },
     {
       "id": "proof-strategy",
       "title": "Proof Strategy",
-      "startLine": 124,
+      "startLine": 132,
       "endLine": 140,
       "summary": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component.",
       "mathContext": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component."
@@ -119,41 +119,40 @@
       "id": "legendre-details",
       "title": "Legendre's Formula Details",
       "startLine": 141,
-      "endLine": 160,
-      "summary": "Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. The theorem `legendre_for_two` ($v_2(n!) = n - s_2(n)$) has a `sorry`.",
-      "mathContext": "Formal definition: Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. The theorem `legendre_for_two` ($v_2(n!) = n - s_2(n)$) has a `sorry`."
+      "endLine": 162,
+      "summary": "Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. Proves `legendre_for_two` ($v_2(n!) = n - s_2(n)$) by forwarding to the axiom via `simp`.",
+      "mathContext": "Formal definition: Defines `digitSum p n` recursively and axiomatizes `legendre_identity`: $v_p(n!) = (n - s_p(n))/(p-1)$. Proves `legendre_for_two` ($v_2(n!) = n - s_2(n)$) by forwarding to the axiom via `simp`."
     },
     {
       "id": "implications",
       "title": "Implications and Rigidity",
-      "startLine": 161,
-      "endLine": 178,
-      "summary": "Axiomatizes `factorial_rigidity` and states `binomial_rigidity` (with `sorry`): when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer.",
-      "mathContext": "Axiomatized: Axiomatizes `factorial_rigidity` and states `binomial_rigidity` (with `sorry`): when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer."
+      "startLine": 163,
+      "endLine": 184,
+      "summary": "Axiomatizes `factorial_rigidity` and proves `binomial_rigidity`: when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer (proved via `Nat.choose_mul_factorial_mul_factorial`).",
+      "mathContext": "Axiomatized: Axiomatizes `factorial_rigidity` and proves `binomial_rigidity`: when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer (proved via `Nat.choose_mul_factorial_mul_factorial`)."
     },
     {
       "id": "main-statement",
       "title": "Main Problem Statement",
-      "startLine": 179,
-      "endLine": 193,
+      "startLine": 185,
+      "endLine": 199,
       "summary": "Proves `erdos_729_statement`: combines `erdos_1968_classical` and `barreto_leeham_theorem` into a single conjunction, establishing both the classical bound and its robustness.",
       "mathContext": "Verified: Proves `erdos_729_statement`: combines `erdos_1968_classical` and `barreto_leeham_theorem` into a single conjunction, establishing both the classical bound and its robustness."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 194,
-      "endLine": 207,
+      "startLine": 200,
+      "endLine": 217,
       "summary": "Proves `erdos_729_summary`: the answer is NO, and the explicit bound $a + b \\leq n + D\\log n$ holds, combining `barreto_leeham_theorem` and `barreto_leeham_bound`.",
       "mathContext": "Proves `erdos_729_summary`: the answer is NO, and the explicit bound $a + b \\leq n + D\\$\\log n$$ holds, combining `barreto_leeham_theorem` and `barreto_leeham_bound`."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 729 is solved negatively: there are NOT infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ where the denominator of $n!/(a!b!)$ has only small prime factors. The formalization captures the classical Erdős bound, the relaxed condition, the Barreto-Leeham resolution, and the proof strategy via large primes, with two remaining `sorry`s on supporting lemmas.",
+    "summary": "Erdős Problem 729 is solved negatively: there are NOT infinitely many $(a, b, n)$ with $a + b > n + C\\log n$ where the denominator of $n!/(a!b!)$ has only small prime factors. The formalization captures the classical Erdős bound, the relaxed condition, the Barreto-Leeham resolution, and the proof strategy via large primes.",
     "implications": "The result demonstrates a fundamental rigidity in factorial arithmetic: the constraint $a + b \\leq n + O(\\log n)$ arises from all primes collectively and cannot be circumvented by ignoring finitely many. This connects to the robustness of Legendre's formula under prime localization and suggests that factorial divisibility is determined by the global prime structure, not any local subset.",
     "openQuestions": [
       "What is the optimal constant in the $O(\\log n)$ bound? Can it be made explicit as a function of $C$?",
-      "Can the proof of `legendre_for_two` ($v_2(n!) = n - s_2(n)$) be completed in Lean using Mathlib's `padicValNat` machinery?",
       "How does the bound behave for specific parametric families, e.g., $(a, b, n) = (n/2, n/2, n)$?",
       "Is there an analogue for multinomial coefficients $n!/(a_1! \\cdots a_k!)$ with $k > 2$?"
     ]


### PR DESCRIPTION
## Fix

Remove stale phantom sorry claim from `proofStrategy` and correct all 10 section line ranges to match the actual Lean file headers.

## Evidence

**Before**: `proofStrategy` ended with "Two `sorry`s remain: `legendre_for_two` and `binomial_rigidity`." — both theorems are fully proved in the Lean file (0 sorries).

**After**: Sentence removed. Section `startLine`/`endLine` fields regenerated from actual `/-## Part N: ...` headers in `Erdos729Problem.lean`.

Section drift (all 10 sections corrected):
- `basic-definitions`: 35→31 / 56→64
- `erdos-classical`: 57→65 / 74→82
- `relaxed-condition`: 75→83 / 94→102
- `question`: 95→103 / 107→115
- `barreto-leeham`: 108→116 / 123→131
- `proof-strategy`: 124→132 (endLine unchanged)
- `legendre-details`: endLine 160→162 (startLine unchanged)
- `implications`: 161→163 / 178→184
- `main-statement`: 179→185 / 193→199
- `summary`: 194→200 / 207→217

Closes #13985

---
Automated fix by lean-mechanic agent.