### PR TITLE
research(erdos-1017-oq-01): eliminate redundant gyori_keszegh_triangles axiom (3→2 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1017OQ01.lean
+++ b/proofs/Proofs/Erdos1017OQ01.lean
@@ -23,7 +23,7 @@ Can f(n,k) < floor(n^2/4) when k > n^2/4 and the graph contains K_4 or larger cl
 The K_4-free case is resolved by Gyori-Keszegh (2017): if G is K_4-free with
 floor(n^2/4) + m edges, it contains m edge-disjoint triangles, giving f = floor(n^2/4) - m.
 
-## What This File Proves (9 axioms -> 3 axioms)
+## What This File Proves (9 axioms -> 2 axioms)
 - completeBipartite_cliqueFree: K_{a,b} is triangle-free (PROVED)
 - completeBipartite_edgeCount: K_{a,b} has a*b edges (PROVED via edge bijection)
 - turanBound quadratic identity: n^2/4 = n/2 * (n - n/2) (PROVED)
@@ -37,10 +37,11 @@ floor(n^2/4) + m edges, it contains m edge-disjoint triangles, giving f = floor(
 - cliquePartition_le_vertices: trivial bound via edge partition (PROVED)
 - triangleFree_cliquePartition_eq_edges: cp(G) = |E| for triangle-free G (PROVED)
 
-## Remaining Axioms (3)
+## Remaining Axioms (2)
 - egp_theorem: EGP bound (deep combinatorial theorem)
-- gyori_keszegh_triangles: K_4-free edge-disjoint triangle packing
-- k4free_partition_number: K_4-free partition formula
+- k4free_partition_number: K_4-free partition formula (Gyori-Keszegh 2017 corollary;
+    encodes the full strength of their result, including the m edge-disjoint triangles
+    that follow as a consequence of cp(G) = floor(n^2/4) - m)
 
 ## Proof Techniques
 - Greedy triangle extraction + Turan bound on remainder
@@ -515,21 +516,21 @@ theorem savings_growth (r : ℕ) (hr : 2 ≤ r) :
 PART VI: K_4-FREE CASE -- GYORI-KESZEGH (2017)
 ==================================================================== -/
 
-/-- **Gyori-Keszegh Theorem (2017)**: If G is K_4-free with floor(n^2/4) + m edges,
-    then G contains m edge-disjoint triangles.
+/-- **Gyori-Keszegh Theorem (2017)** — full strength.
+    For K_4-free graphs with floor(n^2/4) + m edges, the clique partition
+    number is exactly floor(n^2/4) - m.
 
-    Since the only cliques in a K_4-free graph are edges and triangles,
-    and each triangle saves 2 from the partition count,
-    the clique partition number drops to floor(n^2/4) + m - 2m = floor(n^2/4) - m. -/
-axiom gyori_keszegh_triangles (G : SimpleGraph V) [DecidableRel G.Adj]
-    (hG : G.CliqueFree 4)
-    (m : ℕ) (hm : G.edgeFinset.card = turanBound (Fintype.card V) + m) :
-    ∃ (triangles : Finset (Finset V)),
-      triangles.card = m ∧
-      (∀ T ∈ triangles, T.card = 3 ∧ G.IsClique (↑T : Set V))
+    The classical statement of the theorem is "G contains m edge-disjoint
+    triangles", which is logically weaker: from the partition formula one
+    extracts m edge-disjoint triangles by taking an optimal partition (every
+    optimal partition of a K_4-free dense graph has exactly m triangles by
+    the edge-counting identity 2*e_3 = 2m + e_0 where e_0 counts singleton
+    cliques in the partition).
 
-/-- **Corollary**: For K_4-free graphs with floor(n^2/4) + m edges,
-    the clique partition number is exactly floor(n^2/4) - m. -/
+    Proof sketch in the literature: Gyori-Keszegh prove the stronger
+    edge-disjoint packing result, then derive the partition number formula.
+    Each triangle saves 2 from the partition count; m triangles save 2m,
+    bringing the count from at most floor(n^2/4) + m down to floor(n^2/4) - m. -/
 axiom k4free_partition_number (G : SimpleGraph V) [DecidableRel G.Adj]
     (hG : G.CliqueFree 4)
     (m : ℕ) (hm : G.edgeFinset.card = turanBound (Fintype.card V) + m) :
@@ -679,8 +680,7 @@ PART X: VERIFICATION
 #check @triangle_free_not_dense        -- Triangle-free => not dense (PROVED)
 
 -- Partial resolution
-#check @gyori_keszegh_triangles       -- K_4-free edge-disjoint triangles
-#check @k4free_partition_number       -- K_4-free partition count
+#check @k4free_partition_number       -- K_4-free partition count (Gyori-Keszegh 2017)
 #check @k4free_improves               -- K_4-free dense => improves (PROVED)
 #check @k4free_savings_linear         -- Savings formula (PROVED)
 #check @k4free_double_savings         -- Monotonicity (PROVED)

--- a/src/data/proofs/erdos-1017-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-01/meta.json
@@ -20,7 +20,7 @@
     ],
     "namespace": "Erdos1017OQ01",
     "lineCount": 696,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "sorries": 0,
     "definitionCount": 6,
     "theoremCount": 37
@@ -46,9 +46,9 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-25",
     "mathlib_version": "4.26.0",
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 696,
-    "assumptions": "3 axioms: EGP theorem (deep combinatorial result, 1966), Gyori-Keszegh triangle packing (deep result, 2017), K_4-free partition formula. All other statements PROVED including triangleFree partition = edges (via injection), dense_contains_triangle (via Mathlib Turan), cliquePartition_le_vertices (via EGP + edge bound).",
+    "assumptions": "2 axioms: EGP theorem (deep combinatorial result, 1966) and Gyori-Keszegh K_4-free partition formula (2017, full strength: cp(G) = floor(n^2/4) - m). The previously redundant gyori_keszegh_triangles axiom (m distinct 3-cliques) was eliminated since it is logically weaker than the partition formula and was unused in the file. All other statements PROVED including triangleFree partition = edges (via injection), dense_contains_triangle (via Mathlib Turan), cliquePartition_le_vertices (via EGP + edge bound).",
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.IsClique",
@@ -75,7 +75,8 @@
       "completeBipartite: K_{a,b} construction with DecidableRel",
       "egp_tight_example: cp(K_{k,k}) = k² proved from axioms",
       "erdos1017_question: formal statement of the open question",
-      "k4free_improves: K₄-free dense graphs improve on ⌊n²/4⌋ (proved)"
+      "k4free_improves: K₄-free dense graphs improve on ⌊n²/4⌋ (proved)",
+      "Axiom reduction: eliminated redundant gyori_keszegh_triangles axiom (m distinct 3-cliques, logically weaker than the partition formula and unused in the file)"
     ]
   },
   "overview": {
@@ -143,7 +144,7 @@
       "title": "K₄-Free Case: Győri-Keszegh (2017)",
       "startLine": 202,
       "endLine": 247,
-      "summary": "Axiomatizes Győri-Keszegh: K₄-free + ⌊n²/4⌋ + m edges → m edge-disjoint triangles. Proves `k4free_improves`: dense K₄-free graphs have cp < ⌊n²/4⌋.",
+      "summary": "Axiomatizes Győri-Keszegh as the full partition formula `cp(G) = ⌊n²/4⌋ - m`. Proves `k4free_improves`: dense K₄-free graphs have cp < ⌊n²/4⌋. The previously separate `gyori_keszegh_triangles` axiom (m distinct 3-cliques) was eliminated as redundant.",
       "mathContext": "For $K_4$-free graphs: $\\text{cp}(G) = \\lfloor n^2/4 \\rfloor - m$ where $m$ is the excess over $\\lfloor n^2/4 \\rfloor$ (Győri-Keszegh 2017)."
     },
     {

--- a/src/data/research/problems/erdos-1017-oq-01.json
+++ b/src/data/research/problems/erdos-1017-oq-01.json
@@ -28,27 +28,26 @@
     "open": [
       "erdos1017_question: general case with K_4 and larger cliques"
     ],
-    "goal": "Achieved: 6 axioms eliminated (9→3). Remaining 3 axioms are deep published results (EGP 1966, Gyori-Keszegh 2017, K_4-free corollary)."
+    "goal": "Achieved: 7 axioms eliminated (9→2). Remaining 2 axioms are deep published results (EGP 1966, Gyori-Keszegh 2017 partition formula). The redundant gyori_keszegh_triangles axiom was removed since it is logically weaker than the partition formula and was unused."
   },
   "currentState": {
     "phase": "MATURE-AXIOMATIZED",
-    "since": "2026-04-27T00:00:00Z",
-    "iteration": 3,
-    "focus": "Eliminated 6 axioms total (9→3). Remaining 3 axioms — EGP theorem (1966), Gyori-Keszegh (2017), and the K_4-free closed-form — are deep published results. Problem at natural stopping point.",
+    "since": "2026-04-30T00:00:00Z",
+    "iteration": 4,
+    "focus": "Eliminated 7 axioms total (9→2). Remaining 2 axioms — EGP theorem (1966) and the Gyori-Keszegh partition formula (2017) — are deep published results. Session 4 removed the redundant gyori_keszegh_triangles axiom (logically weaker than the partition formula, completely unused in the file). Problem at natural stopping point.",
     "blockers": [
       "EGP theorem (Erdos-Goodman-Posa 1966) requires ~500+ lines of greedy triangle extraction + bipartite remainder argument",
-      "Gyori-Keszegh (2017) requires ~1000+ lines of deep graph decomposition machinery",
-      "K_4-free closed-form is a corollary of Gyori-Keszegh"
+      "Gyori-Keszegh partition formula (2017) requires ~1000+ lines of deep graph decomposition machinery"
     ],
-    "nextAction": "Hold at axiomatized status. Future work: formalize EGP theorem as a multi-session project (would eliminate one axiom and unlock the K_4-free corollary); Gyori-Keszegh remains out of scope.",
+    "nextAction": "Hold at axiomatized status. Future work: formalize EGP theorem as a multi-session project (would eliminate one axiom); Gyori-Keszegh partition formula remains out of scope. Could also derive the m-triangles existence statement as a theorem from k4free_partition_number via sInf-witness extraction + edge-counting (~80 lines), restoring it for downstream consumers.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 6 axioms total (9→3). Session 3 proved dense_contains_triangle (via Mathlib Turan), triangleFree_cliquePartition_eq_edges (via injection), cliquePartition_le_vertices (via EGP). Remaining 3 axioms: EGP theorem, Gyori-Keszegh, K_4-free formula — all deep published results.",
+    "progressSummary": "PROGRESS: Eliminated 7 axioms total (9→2). Session 4 removed redundant gyori_keszegh_triangles axiom (m distinct 3-cliques) — logically weaker than k4free_partition_number (which gives cp = t - m) and completely unused. Session 3 proved dense_contains_triangle (via Mathlib Turan), triangleFree_cliquePartition_eq_edges (via injection), cliquePartition_le_vertices (via EGP). Remaining 2 axioms: EGP theorem and Gyori-Keszegh partition formula — both deep published results.",
     "builtItems": [
       "completeBipartite_cliqueFree: K_{a,b} triangle-free (PROVED via case analysis on Sum types)",
       "completeBipartite_adj_iff: adjacency characterization for bipartite graph",
@@ -82,7 +81,8 @@
       "dense_contains_triangle proved via Mathlib CliqueFree.card_edgeFinset_le (Turan bound) — case split on n%2 simplifies to n²/4",
       "triangleFree_cliquePartition_eq_edges proved by ≤/≥: edge partition (each edge = 1 clique) gives ≤, injection argument (cliques have ≤2 vertices in triangle-free graph) gives ≥",
       "cliquePartition_le_vertices follows from cp(G) ≤ |E| ≤ n(n-1)/2 via card_edgeFinset_le_card_choose_two",
-      "All 3 remaining axioms are deep published results: EGP (1966), Gyori-Keszegh (2017), and its corollary"
+      "Axiom redundancy detection: gyori_keszegh_triangles (existence of m distinct 3-cliques) is implied by k4free_partition_number (cp(G) = t - m) — apply Nat.sInf_mem to extract a partition with t - m cliques; in K₄-free, cliques have card ≤ 3; counting yields ≥ m triangle-cliques. The triangles-existence statement was unused in the file, so direct deletion suffices.",
+      "Both remaining axioms are deep published results: EGP (1966) and Gyori-Keszegh partition formula (2017)"
     ],
     "mathlibGaps": [
       "Mathlib's edgeFinset.card for bipartite graphs on Sum types requires manual enumeration",
@@ -90,8 +90,9 @@
     ],
     "nextSteps": [
       "EGP theorem would require formalizing greedy triangle extraction + bipartite remainder argument (~500+ lines)",
-      "Gyori-Keszegh would require deep graph decomposition formalization (~1000+ lines)",
-      "Problem is at a natural stopping point — remaining axioms are genuinely deep published results"
+      "Gyori-Keszegh partition formula would require deep graph decomposition formalization (~1000+ lines)",
+      "Optional: derive m-triangles existence as a theorem from k4free_partition_number (~80 lines via sInf-witness extraction + edge-counting). Useful only if downstream consumers need the triangles existence statement directly.",
+      "Problem is at a natural stopping point — remaining 2 axioms are genuinely deep published results"
     ]
   },
   "tags": [
@@ -124,7 +125,7 @@
     ]
   },
   "started": "2026-03-24T00:48:59.902Z",
-  "lastUpdate": "2026-04-27T00:00:00Z",
+  "lastUpdate": "2026-04-30T00:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -133,7 +134,7 @@
       "filename": "Erdos1017OQ01.lean",
       "lineCount": 697,
       "theoremCount": 30,
-      "axiomCount": 3,
+      "axiomCount": 2,
       "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

Eliminates a redundant axiom in `proofs/Proofs/Erdos1017OQ01.lean`: removes
the unused `gyori_keszegh_triangles` axiom (m distinct 3-cliques in K_4-free
dense graphs), which is logically **weaker** than the already-axiomatized
`k4free_partition_number` (cp(G) = ⌊n²/4⌋ - m) and was never referenced by
any theorem in the file.

**Axiom count: 3 → 2** (egp_theorem and k4free_partition_number remain;
both are deep published results.)

## Why is `gyori_keszegh_triangles` redundant?

From `k4free_partition_number`, cp(G) = t - m for K_4-free dense graphs
(t = ⌊n²/4⌋, m = excess edges). The set of partition cardinalities is a
nonempty subset of ℕ, so by `Nat.sInf_mem` there is a partition P with
|P.cliques| = t - m. In a K_4-free graph every clique has card ≤ 3, so
each clique covers ≤ 3 edges. Edge counting gives 2·e₃ = 2m + e₀ ≥ 2m,
hence e₃ ≥ m, where e₃ is the count of card-3 cliques in P. Pick any m of
them — that's exactly the existence claim of `gyori_keszegh_triangles`.

This derivation is sketched in the new docstring of
`k4free_partition_number`. We don't formalize it here because the claim
is unused; if a future consumer needs the m-triangle existence statement,
it can be added back as a derived theorem (~80 lines via sInf-witness
extraction + edge-counting).

## Files changed

- `proofs/Proofs/Erdos1017OQ01.lean` — delete the axiom + #check; expand
  `k4free_partition_number` docstring to capture the redundancy reasoning;
  update file header (3 → 2 axioms).
- `src/data/proofs/erdos-1017-oq-01/meta.json` — axiomCount 3 → 2,
  assumptions field, originalContributions, sections k4free.summary.
- `src/data/research/problems/erdos-1017-oq-01.json` — knowledge.progressSummary,
  insights, nextSteps, currentState (iteration 4, since 2026-04-30),
  knownResults.goal, leanFiles axiomCount.

## Test plan

- [x] Verify `gyori_keszegh_triangles` has no in-file references (only the
  axiom declaration, header doc, and #check).
- [ ] Docker build of `Proofs.Erdos1017OQ01` (running concurrently; the
  change is purely deletion of an unreferenced declaration so build risk
  is minimal).

## Status

**Outcome**: progress (axiom elimination from 3 to 2)
**Phase**: still MATURE-AXIOMATIZED — remaining axioms are deep published
results (EGP 1966, Gyori-Keszegh partition formula 2017).
**Next steps**: optional ~80-line derivation of the m-triangles existence
statement as a theorem, if any downstream consumer needs it.

🤖 Generated by researcher-1