### PR TITLE
fix(erdos-713): correct section line ranges (drift up to 16 lines)

### DIFF
--- a/src/data/proofs/erdos-713/meta.json
+++ b/src/data/proofs/erdos-713/meta.json
@@ -90,54 +90,54 @@
       "title": "Extremal Numbers",
       "summary": "extremalNumber axiom and bound",
       "startLine": 62,
-      "endLine": 76,
+      "endLine": 73,
       "mathContext": "Axiomatized: extremalNumber axiom and bound"
     },
     {
       "id": "asymptotic-growth",
       "title": "Asymptotic Growth",
       "summary": "hasPowerLawGrowth, hasPowerLawOrder definitions",
-      "startLine": 77,
-      "endLine": 94,
+      "startLine": 74,
+      "endLine": 91,
       "mathContext": "Formal definition: hasPowerLawGrowth, hasPowerLawOrder definitions"
     },
     {
       "id": "main-questions",
       "title": "The Main Questions",
       "summary": "Strong, weak, and rationality questions",
-      "startLine": 95,
-      "endLine": 123,
+      "startLine": 92,
+      "endLine": 120,
       "mathContext": "Mathematical content: Strong, weak, and rationality questions"
     },
     {
       "id": "known-results",
       "title": "Known Results",
       "summary": "Kővári-Sós-Turán, complete bipartite bounds and exponent",
-      "startLine": 124,
-      "endLine": 151,
+      "startLine": 121,
+      "endLine": 140,
       "mathContext": "Bound: Kővári-Sós-Turán, complete bipartite bounds and exponent"
     },
     {
       "id": "original-conjecture",
       "title": "Erdős's Original Conjecture (Disproved)",
       "summary": "erdosOriginalConjecture definition and Erdős-Simonovits counterexample",
-      "startLine": 152,
-      "endLine": 169,
+      "startLine": 141,
+      "endLine": 158,
       "mathContext": "Formal definition: erdosOriginalConjecture definition and Erdős-Simonovits counterexample"
     },
     {
       "id": "hypergraph",
       "title": "Hypergraph Counterexamples",
       "summary": "Frankl-Füredi-Gerbner results for k ≥ 5",
-      "startLine": 170,
-      "endLine": 187,
+      "startLine": 159,
+      "endLine": 171,
       "mathContext": "Frankl-Füredi-Gerbner results for k $\\geq$ 5"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_713 main theorem",
-      "startLine": 188,
+      "startLine": 172,
       "endLine": 195,
       "mathContext": "Verified: erdos_713 main theorem"
     }


### PR DESCRIPTION
## Summary

Gallery integrity audit found section line range drift in `src/data/proofs/erdos-713/meta.json`. Sections 2-8 had `startLine`/`endLine` values that no longer matched the Lean source `proofs/Proofs/Erdos713Problem.lean`. Drift was up to 16 lines by the summary section.

## Evidence

Verified actual section boundaries against `git show origin/main:proofs/Proofs/Erdos713Problem.lean`:

| Section | Was | Now | Header location |
|---------|-----|-----|-----------------|
| basic-definitions | 42-61 | 42-61 | line 42 (no change) |
| extremal-numbers | 62-76 | 62-73 | line 62 |
| asymptotic-growth | 77-94 | 74-91 | line 74 |
| main-questions | 95-123 | 92-120 | line 92 |
| known-results | 124-151 | 121-140 | line 121 |
| original-conjecture | 152-169 | 141-158 | line 141 |
| hypergraph | 170-187 | 159-171 | line 159 |
| summary | 188-195 | 172-195 | line 172 |

## Other audit findings (clean)

- `axiomCount: 2` matches the 2 `axiom` declarations (`extremalNumber`, `erdos_simonovits_counterexample`).
- `theoremCount: 2`, `definitionCount: 8`, `lineCount: 195` all match.
- `status: axiomatized`, `badge: axiom` correctly reflect the open conjecture status with stated axioms.
- 0 sorries verified.

## Test plan

- [ ] CI: lint + build (line ranges only — no Lean changes, no content changes).
- [ ] Visual check: gallery section anchors point to correct line ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)