### PR TITLE
audit(erdos-710): mark issues-found — phantom axiom narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8618,9 +8618,9 @@
     },
     "erdos-710": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T00:08:12Z",
+      "result": "issues-found"
     },
     "erdos-711": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Mark erdos-710 audit as `issues-found` (audit count → 3) after detecting phantom axiom narrative in `open-problem` section + section line drift in `main-results`.
- Issue filed: #14005

## Findings

- `meta.sections[open-problem].summary` claims `erdos_710_open` axiom; only a docstring lives in lines 153-175.
- `proofStrategy` item 5 ("Axiomatize existence of exact asymptotic") describes a non-existent axiom.
- `main-results` listed at lines 303-320; the theorem actually starts at line 293.
- Numerical counts (axiomCount=3, sorries=0, lineCount=320) are correct.

## Test plan

- [x] `git show origin/main:proofs/Proofs/Erdos710Problem.lean | grep -c '^axiom '` → 3
- [x] Visual inspection of lines 150-180 shows only docstring, no axiom
- [ ] Mechanic to fix meta.json per issue #14005

🤖 Generated with [Claude Code](https://claude.com/claude-code)