### PR TITLE
fix(meta): remove phantom axiom narrative from erdos-71, erdos-710, erdos-720

### DIFF
--- a/src/data/proofs/erdos-71/meta.json
+++ b/src/data/proofs/erdos-71/meta.json
@@ -70,7 +70,7 @@
       "title": "Core Definitions",
       "startLine": 48,
       "endLine": 75,
-      "summary": "Defines ArithProg a d, the containsEven predicate (Even a ∨ Odd d), membership lemma (mem_arithProg_iff), first_mem_arithProg (a ∈ P), and axiomatizes arithProg_infinite.",
+      "summary": "Defines ArithProg a d, the containsEven predicate (Even a ∨ Odd d), membership lemma (mem_arithProg_iff), first_mem_arithProg (a ∈ P), and proves arithProg_infinite (theorem, not axiom).",
       "mathContext": "$P = \\{a + kd : k \\in \\mathbb{N}\\}$ contains even numbers iff $2 \\mid a$ or $d$ is odd (alternating parity). If $d > 0$, $P$ is infinite."
     },
     {
@@ -102,15 +102,15 @@
       "title": "Related Results",
       "startLine": 173,
       "endLine": 188,
-      "summary": "Axiomatizes bondy_simonovits (high min degree → consecutive even cycle lengths) and avg_to_min_degree (average-to-minimum degree subgraph extraction).",
-      "mathContext": "Bondy-Simonovits: $\\delta(G) \\geq d \\implies G$ contains $C_k$ for all even $k \\in [4, 2d]$. Subgraph extraction: $\\bar{d}(G) \\geq 2d \\implies \\exists H \\subseteq G$ with $\\delta(H) \\geq d$."
+      "summary": "Docstring discussion of related results: Bondy-Simonovits (high min degree → consecutive even cycle lengths) and subgraph extraction (average-to-min degree). Neither is declared as an axiom; both are described in docstring prose for context.",
+      "mathContext": "Bondy-Simonovits: $\\delta(G) \\geq d \\implies G$ contains $C_k$ for all even $k \\in [4, 2d]$. Subgraph extraction: $\\bar{d}(G) \\geq 2d \\implies \\exists H \\subseteq G$ with $\\delta(H) \\geq d$. Described in prose only — not formally declared in this file."
     },
     {
       "id": "even-necessity",
       "title": "Why Even Numbers Matter",
       "startLine": 189,
       "endLine": 232,
-      "summary": "Axiomatizes bipartite_no_odd_cycles and even_condition_necessary. The bipartite counterexample K_{n,n} shows odd-only progressions cannot be forced by density.",
+      "summary": "Docstring explanation of why even numbers are necessary: K_{n,n} has arbitrarily high average degree but only even cycles. Names bipartite_no_odd_cycles and even_condition_necessary appear in docstrings only — not declared as axioms in this file.",
       "mathContext": "Bipartite graphs have only even cycles (vertices alternate between parts). $K_{n,n}$ has $\\bar{d} = n$ but $C_{2k+1} \\not\\subseteq K_{n,n}$. So for $P = \\{3, 7, 11, \\ldots\\}$ (all odd), no $c$ works."
     },
     {

--- a/src/data/proofs/erdos-710/meta.json
+++ b/src/data/proofs/erdos-710/meta.json
@@ -66,7 +66,7 @@
     "historicalContext": "**Erdős Problem #710**\n\nThis problem concerns the minimal interval length needed for divisibility matching, a combinatorial problem at the intersection of number theory and extremal combinatorics.\n\n**Key History:**\n- Erdős and Pomerance (1980): Established upper and lower bounds in \"Matching the natural numbers up to n with distinct multiples of another interval\"\n- Erdős [Er92c] (1992): \"Some of my forgotten problems in number theory\" - offered 2000 rupees prize\n- The problem remains OPEN - exact asymptotics unknown\n\n**Mathematical Setting:**\n- Given n, we seek distinct integers a₁,...,aₙ in a short interval starting at n\n- The k-th integer must be divisible by k\n- f(n) = minimal interval length for this to be possible\n- The challenge is finding the precise asymptotic growth rate of f(n)",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a₁,...,aₙ with k | aₖ for all 1 ≤ k ≤ n.\n\nObtain an asymptotic formula for f(n).\n\n**Known Bounds (Erdős-Pomerance 1980):**\n- Lower: (2/√e + o(1)) · n · √(log n / log log n) ≈ 1.213 · n · √(log n / log log n)\n- Upper: (1.7398... + o(1)) · n · √(log n)\n\n**Gap:** The bounds differ by a factor of √(log log n), which grows very slowly but is unbounded.\n\n**Prize:** Erdős offered 2000 rupees (~$78 in 1992) for an asymptotic formula.",
     "text": "Let f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a₁,...,aₙ with k|aₖ for all k. Obtain an asymptotic formula for f(n). Known bounds differ by √(log log n) factor; exact asymptotics remain OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** Define IsValidSelection (divisibility matching), IntervalAdmitsSelection, and minimalIntervalLength f(n)\n\n2. **Counting Functions:** Define multiplesInInterval to count multiples of d in an interval\n\n3. **Known Bounds:** Axiomatize the Erdős-Pomerance upper and lower bounds\n\n4. **Bounds Gap:** Show the gap is √(log log n)\n\n5. **Open Problem:** Axiomatize existence of exact asymptotic\n\n6. **Examples:** Verify divisibility matching for n = 1, 2, 3\n\n7. **Heuristics:** Analyze why the constraint for large k is critical",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** Define IsValidSelection (divisibility matching), IntervalAdmitsSelection, and minimalIntervalLength f(n)\n\n2. **Counting Functions:** Define multiplesInInterval to count multiples of d in an interval\n\n3. **Known Bounds:** Axiomatize the Erdős-Pomerance upper and lower bounds\n\n4. **Bounds Gap:** Show the gap is √(log log n)\n\n5. **Open Problem:** Document the asymptotic gap as an unresolved open question (no axiom)\n\n6. **Examples:** Verify divisibility matching for n = 1, 2, 3\n\n7. **Heuristics:** Analyze why the constraint for large k is critical",
     "keyInsights": [
       "**Divisibility Constraint:** The k-th integer must be divisible by k, making large k the hardest constraint (fewest multiples in any interval)",
       "**Bounds Gap:** The √(log log n) gap between upper and lower bounds is the key mystery",
@@ -110,7 +110,7 @@
     {
       "id": "open-problem",
       "title": "The Open Problem",
-      "summary": "erdos_710_open axiom",
+      "summary": "Docstring discussion of the open asymptotic problem: the exact formula for f(n) is unknown; the √(log log n) gap between the Erdős-Pomerance bounds is unresolved. No axiom declaration in this section.",
       "startLine": 153,
       "endLine": 175
     },
@@ -142,7 +142,7 @@
       "id": "main-results",
       "title": "Main Results Summary",
       "summary": "erdos_710_summary theorem",
-      "startLine": 303,
+      "startLine": 275,
       "endLine": 320,
       "mathContext": "Verified: erdos_710_summary theorem"
     }

--- a/src/data/proofs/erdos-720/meta.json
+++ b/src/data/proofs/erdos-720/meta.json
@@ -60,7 +60,7 @@
       "sizeRamseyNumber via Nat.find as minimal m with Ramsey property",
       "ErdosQuestion720a/b/c: original questions as Filter.Tendsto propositions",
       "beck_path_theorem, beck_cycle_theorem: linear upper bounds (axioms)",
-      "dudek_pralat_bound: improved constant R\u0302(P\u2099) \u2264 900n",
+      "beckPathConstant: Dudеk–Prałat (2017) constant R\u0302(P\u2099) \u2264 900n (def beckPathConstant : \u2115 := 900)",
       "path_lower_bound, cycle_lower_bound: matching \u03a9(n) lower bounds",
       "pathIsLinear, cycleIsLinear: \u0398(n) characterization definitions",
       "answer_720a/b/c: answers to Erd\u0151s's questions",


### PR DESCRIPTION
## Fix

Removes phantom axiom claims from narrative metadata in three gallery entries. All numerical counts were correct; only section summaries and originalContributions contained phantom declaration names.

## Changes

**erdos-710** (closes #14005):
- `sections[open-problem]`: removed phantom `erdos_710_open` axiom claim — lines 153-175 contain only a docstring
- `overview.proofStrategy` item 5: "Axiomatize existence of exact asymptotic" → "Document the asymptotic gap as an unresolved open question (no axiom)"
- `sections[main-results]`: fixed `startLine` 303 → 275 (matches `## Part IX: Main Results Summary` header)

**erdos-71** (closes #14002):
- `sections[core-definitions]`: "axiomatizes arithProg_infinite" → "proves arithProg_infinite" (it is a `theorem`, not `axiom`, at L74)
- `sections[related-results]`: removed "Axiomatizes bondy_simonovits and avg_to_min_degree" — neither is declared in the file; both are described in docstrings only
- `sections[even-necessity]`: removed "Axiomatizes bipartite_no_odd_cycles and even_condition_necessary" — both names appear only in docstrings

**erdos-720** (closes #14001):
- `originalContributions`: replaced phantom `dudek_pralat_bound` with the real declaration `def beckPathConstant : ℕ := 900` (Dudek–Prałat 2017 attribution is in the doc-comment, not a declaration name)

## Evidence

All three Lean files verified at `origin/main`:
- `grep -n '^axiom ' Erdos71Problem.lean` → only `bollobas_theorem` (L146); no bondy_simonovits etc.
- `grep -n 'erdos_710_open\|^axiom' Erdos710Problem.lean` → only 3 real axioms (L73, L118, L129)
- `grep -n 'dudek_pralat_bound\|beckPathConstant' Erdos720Problem.lean` → only `beckPathConstant` (def)

---
Automated fix by lean-mechanic agent.