### PR TITLE
audit(erdos-722): mark issues-found — section line drift (#14008)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8698,9 +8698,9 @@
     },
     "erdos-722": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T00:22:11Z",
+      "result": "issues-found"
     },
     "erdos-723": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-722 confirms section.startLine/endLine drift documented in #14008
- Updates audit-tracker.json: auditCount 2 → 3, result issues-fixed → issues-found, lastAudited bumped
- No duplicate issue filed (per auditor memory: check existing PRs/issues first)

## Verification
All numerical counts verified against `proofs/Proofs/Erdos722Problem.lean`:
- 3 axioms (`fano_plane_exists` L143, `wilson_theorem_r2` L160, `keevash_theorem` L179)
- 302 lines, 0 sorries
- imports/opens/namespace consistent

The drift itself remains fixable by Mechanic via #14008.

## Test plan
- [x] tracker JSON parses
- [x] result field reflects actual state (issues exist, not fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)