### PR TITLE
audit(erdos-720): mark clean — counts and narrative verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8686,9 +8686,9 @@
     },
     "erdos-720": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T00:34:11Z",
+      "result": "clean"
     },
     "erdos-721": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Auditor pass on `erdos-720` (Size Ramsey Numbers of Paths and Cycles): tracker advanced from `issues-fixed` (2026-04-03) to `clean` after re-verification against `origin/main:proofs/Proofs/Erdos720Problem.lean`.

## Evidence

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 257 | 257 |
| axiomCount | 8 | 8 |
| sorries | 0 | 0 |
| status / badge | axiomatized / axiom | axiom-laden scaffold (Tier C) |

All 8 axioms in `assumptions` (complete_graph_ramsey, beck_path/cycle_theorem, path/cycle_lower_bound, answer_720a/b/c) match the Lean file exactly. `True`-valued definitions (beckSurprise, ramseyComparison, problemConnection559, exactConstantOpen) are illustrative `Prop` placeholders — **not** theorems claimed as proved. Real theorems (`erdos_720`, `erdos_720_main`, `erdos_720_beck`) derive from axioms via `obtain`.

No phantom-axiom narrative; description and overview honestly say "axiomatized".

## Test plan

- [x] Counts match between meta.json and `git show origin/main:` of the Lean file
- [x] No True-stub overstatement
- [x] `assumptions` field lists all axioms by name