### PR TITLE
fix(erdos-711): correct section line ranges (drift 4-12 lines)

### DIFF
--- a/src/data/proofs/erdos-711/meta.json
+++ b/src/data/proofs/erdos-711/meta.json
@@ -137,23 +137,23 @@
       "id": "connection-710",
       "title": "Connection to Problem #710",
       "summary": "Axiomatized Erdős-Pomerance bounds for f(n,n): C₁·n·√(log n/log log n) ≤ f(n,n) ≤ C₂·n·√(log n). Shows van Doorn's difference can dominate the base value.",
-      "startLine": 217,
-      "endLine": 243,
+      "startLine": 213,
+      "endLine": 231,
       "mathContext": "Axiomatized Erdős-Pomerance bounds for f(n,n): C₁·n·√($\\log n$/log $\\log n$) $\\leq$ f(n,n) $\\leq$ C₂·n·√($\\log n$). Shows van Doorn's difference can dominate the base value."
     },
     {
       "id": "examples",
       "title": "Small Examples: n=2",
       "summary": "Three fully proved examples with m=1,2,3 all showing f(2,m) ≤ 3. Demonstrates the divergence is asymptotic, not visible at small scale.",
-      "startLine": 244,
-      "endLine": 295,
+      "startLine": 232,
+      "endLine": 283,
       "mathContext": "Three fully proved examples with m=1,2,3 all showing f(2,m) $\\leq$ 3. Demonstrates the divergence is asymptotic, not visible at small scale."
     },
     {
       "id": "summary",
       "title": "Main Results Summary",
       "summary": "Theorem erdos_711_summary combining all results. erdos_711_part2_solved confirms second conjecture. openQuestion records first conjecture status.",
-      "startLine": 296,
+      "startLine": 284,
       "endLine": 333,
       "mathContext": "Verified: Theorem erdos_711_summary combining all results. erdos_711_part2_solved confirms second conjecture. openQuestion records first conjecture status."
     }


### PR DESCRIPTION
## Fix

Three sections in `src/data/proofs/erdos-711/meta.json` had `startLine`/`endLine` values that drifted 4–12 lines from the actual Part headers in `Erdos711Problem.lean`.

## Evidence

Part headers verified from `git show origin/main:proofs/Proofs/Erdos711Problem.lean`:
- L213: `## Part VII: Connection to Problem #710`
- L232: `## Part VIII: Small Examples`
- L284: `## Part IX: Main Results Summary`

| Section | Before | After |
|---------|--------|-------|
| connection-710 startLine | 217 | 213 |
| connection-710 endLine | 243 | 231 |
| examples startLine | 244 | 232 |
| examples endLine | 295 | 283 |
| summary startLine | 296 | 284 |

The `endLine: 333` for summary is unchanged (matches file length).

Closes #14017

---
Automated fix by lean-mechanic agent.