### PR TITLE
fix(erdos-714): correct section line ranges (drift 4-26 lines)

### DIFF
--- a/src/data/proofs/erdos-714/meta.json
+++ b/src/data/proofs/erdos-714/meta.json
@@ -107,30 +107,30 @@
       "title": "Open Cases (r >= 4)",
       "summary": "Docstring discussion of r ≥ 4 open cases: no construction achieving ex(n; K_{r,r}) >> n^{2-1/r} is known; best known lower bounds are strictly weaker than the conjectured bound",
       "startLine": 172,
-      "endLine": 184,
+      "endLine": 180,
       "mathContext": "Informal overview — no formal declarations in this section"
     },
     {
       "id": "constructions",
       "title": "Construction Methods",
       "summary": "Docstring descriptions of projective plane constructions (r=2), generalized hexagon constructions (r=3), and norm graphs (Kollár-Rónyai-Szabó 1996, giving Ω(n^{2-2/(r+1)}) edges)",
-      "startLine": 185,
-      "endLine": 219,
+      "startLine": 181,
+      "endLine": 201,
       "mathContext": "Informal constructions — no formal declarations in this section"
     },
     {
       "id": "connections",
       "title": "Connection to Other Problems",
       "summary": "Docstring discussion of K_{2,2} = C_4 equivalence (linking to Problem #768) and the Zarankiewicz matrix formulation via bipartite double cover",
-      "startLine": 220,
-      "endLine": 244,
+      "startLine": 202,
+      "endLine": 218,
       "mathContext": "Informal connections — no formal declarations in this section"
     },
     {
       "id": "summary",
       "title": "Main Results Summary",
       "summary": "erdos_714_summary, zarankiewicz_status theorems",
-      "startLine": 245,
+      "startLine": 219,
       "endLine": 259,
       "mathContext": "Verified: erdos_714_summary, zarankiewicz_status theorems"
     }


### PR DESCRIPTION
## Summary

Auditor pass on `erdos-714` (Zarankiewicz Problem for K_{r,r}). Counts and narrative are correct, but `sections[].startLine`/`endLine` for Parts V–VIII had drifted 4–26 lines from the actual Lean source.

## Evidence

Verified against `origin/main:proofs/Proofs/Erdos714Problem.lean`. Part headers (`## Part X: ...`):

| Part | Header line | Block (start `/-` … end `-/`) |
|------|-------------|-------------------------------|
| I    | 37 | 36–39 |
| II   | 65 | 64–67 |
| III  | 78 | 77–80 |
| IV   | 104 | 103–106 |
| V    | 173 | 172–175 |
| VI   | 182 | 181–184 |
| VII  | 203 | 202–205 |
| VIII | 220 | 219–221 |

Section ranges I–IV were already correct. Section ranges V–VIII have been realigned:

| section | before | after |
|---------|--------|-------|
| open-cases | 172–184 | 172–180 |
| constructions | 185–219 | 181–201 |
| connections | 220–244 | 202–218 |
| summary | 245–259 | 219–259 |

Counts unchanged: `lineCount=259`, `axiomCount=3`, `sorries=0`. The 3 axioms (`kovari_sos_turan` @90, `zarankiewicz_r2` @124, `brown_theorem` @137) are correctly listed in `assumptions`.

## Test plan

- [x] All 8 section ranges land on contiguous, non-overlapping lines covering 36–259
- [x] Each section title matches the corresponding `## Part X:` header in the Lean file
- [x] No phantom axioms or overstated claims; `axiomatized`/`axiom` badge remains correct