### PR TITLE
fix(erdos-338): prove sq_mem_squares and squares_order_four_aristotle

### DIFF
--- a/proofs/Proofs/Erdos338Aristotle.lean
+++ b/proofs/Proofs/Erdos338Aristotle.lean
@@ -20,13 +20,23 @@ namespace Erdos338
 theorem mul_self_mem_squares (k : ℕ) : k * k ∈ squares := ⟨k, rfl⟩
 
 /-- k^2 belongs to the squares set (since k^2 = k*k). -/
-theorem sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares := by sorry
+theorem sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares := ⟨k, by ring⟩
 
 /-- Lagrange's four-squares theorem recast as IsBasisOfOrder.
     Every natural number n is a sum of four perfect squares (Nat.sum_four_squares).
     Proof: take N = 0; for any n ≥ 0, Nat.sum_four_squares n gives a b c d with
     a^2 + b^2 + c^2 + d^2 = n. Use multiset {a^2, b^2, c^2, d^2}:
     each element is in squares, card = 4 ≤ 4, Multiset.sum = n. -/
-theorem squares_order_four_aristotle : IsBasisOfOrder squares 4 := by sorry
+theorem squares_order_four_aristotle : IsBasisOfOrder squares 4 := by
+  refine ⟨0, fun n _ => ?_⟩
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares n
+  refine ⟨↑([a ^ 2, b ^ 2, c ^ 2, d ^ 2] : List ℕ), ?_, ?_, ?_⟩
+  · intro x hx
+    simp only [Multiset.mem_coe, List.mem_cons, List.mem_nil_iff, or_false] at hx
+    rcases hx with rfl | rfl | rfl | rfl
+    all_goals exact ⟨_, by ring⟩
+  · simp [Multiset.card_coe]
+  · simp only [Multiset.coe_sum, List.sum_cons, List.sum_nil, add_zero]
+    linarith
 
 end Erdos338


### PR DESCRIPTION
## Fix

Proves two sorry lemmas in `Erdos338Aristotle.lean`:
- `sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares` — proved via `⟨k, by ring⟩`
- `squares_order_four_aristotle : IsBasisOfOrder squares 4` — proved via `Nat.sum_four_squares` with a 4-element multiset witness

## Evidence

**Before**: both theorems had `by sorry`
**After**: explicit proofs using standard Mathlib lemmas

This supersedes PR #13949 (CONFLICTING due to concurrent Erdos608 fixes already merged to main).

---
Automated fix by lean-mechanic agent.