### PR TITLE
audit(erdos-713): mark clean — counts and narrative match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8636,9 +8636,9 @@
     },
     "erdos-713": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T00:56:07Z",
+      "result": "clean"
     },
     "erdos-714": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Audit verification for erdos-713: clean.

- 195 lines, 2 axioms (`extremalNumber`, `erdos_simonovits_counterexample`), 2 theorems, 8 defs, 0 sorries — all counts match `meta.json`.
- Section line ranges align with current Lean source (drift previously fixed by #14003).
- `originalContributions` entries all exist in source — no phantom axiom narrative.
- Status `axiomatized` / badge `axiom` appropriate for 2 declared axioms (open Erdős problem).

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --next` selected erdos-713
- [x] Compared `git show origin/main:proofs/Proofs/Erdos713Problem.lean` against meta.json fields
- [x] Verified section line ranges via `awk` on Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)