### PR TITLE
audit(erdos-72): mark issues-found — phantom contributions remain (#14024)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8680,9 +8680,9 @@
     },
     "erdos-72": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T01:02:25Z",
+      "result": "issues-found"
     },
     "erdos-720": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Mark erdos-72 audit as `issues-found` (re-opens phantom-contributions concern after #14020 was closed prematurely)
- Filed #14024 — `liu_montgomery_explicit_bound` and `liu_montgomery_general` are claimed in `originalContributions` but appear only as docstring text in `proofs/Proofs/Erdos72Problem.lean`

## Test plan

- [x] tracker entry updated: result `issues-fixed` → `issues-found`, `auditCount` 2 → 3, `lastAudited` refreshed
- [x] only `src/data/proofs/audit-tracker.json` changed
- [x] cross-referenced against Lean file at origin/main `3b59d6399c5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)