### PR TITLE
fix(erdos-703): correct section line ranges (4 sections off by 5-31 lines)

### DIFF
--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -90,7 +90,7 @@
       "id": "frankl-1977",
       "title": "Frankl's Result for r = 1",
       "startLine": 100,
-      "endLine": 112,
+      "endLine": 117,
       "summary": "Frankl (1977) determined $T(n,1)$: optimal family is large sets ($|A| > (n+1)/2$) plus $\\emptyset$. Pigeonhole argument for large sets avoiding 1-intersection.",
       "mathContext": "Mathematical content: Frankl (1977) determined $T(n,1)$: optimal family is large sets ($|A| > (n+1)/2$) plus $\\emptyset$. Pigeonhole argument for large sets avoiding 1-intersection."
     },
@@ -114,22 +114,22 @@
       "id": "chromatic-connection",
       "title": "Connection to Chromatic Numbers",
       "startLine": 181,
-      "endLine": 204,
+      "endLine": 195,
       "summary": "The exponential bound implies $\\chi(G_n) \\geq c^n$ for the unit distance graph. Frankl-Wilson (1981) proved this independently via mod $p$ methods.",
       "mathContext": "Bound: The exponential bound implies $\\chi(G_n) \\geq c^n$ for the unit distance graph. Frankl-Wilson (1981) proved this independently via mod $p$ methods."
     },
     {
       "id": "frankl-wilson",
       "title": "The Frankl-Wilson Theorem",
-      "startLine": 214,
-      "endLine": 226,
+      "startLine": 196,
+      "endLine": 212,
       "summary": "Generalizes to $L$-avoiding families. The Frankl-Wilson theorem (mod $p$ version): uniform families with modular constraints satisfy $|\\mathcal{F}| \\leq \\binom{n}{s}$, using the linear algebra method.",
       "mathContext": "Verified: Generalizes to $L$-avoiding families. The Frankl-Wilson theorem (mod $p$ version): uniform families with modular constraints satisfy $|\\mathcal{F}| \\leq \\binom{n}{s}$, using the linear algebra method."
     },
     {
       "id": "summary",
       "title": "Summary and Resolution",
-      "startLine": 258,
+      "startLine": 227,
       "endLine": 259,
       "summary": "Combined `erdos_703_solved` theorem: `mainQuestion ∧ T(n,0) = 2^{n-1}`. Clean statement `erdos_703 : mainQuestion := frankl_rodl_1987`.",
       "mathContext": "Combined `erdos_703_solved` theorem: `mainQuestion ∧ T(n,0) = $$2^{{n-1}$}$`. Clean statement `erdos_703 : mainQuestion := frankl_rodl_1987`."


### PR DESCRIPTION
## Summary

Section line ranges in `src/data/proofs/erdos-703/meta.json` had drifted from the actual content in `proofs/Proofs/Erdos703Problem.lean`. This PR corrects four sections.

## What was wrong

| Section | Field | Was | Now | Drift |
|---|---|---|---|---|
| `frankl-1977` | `endLine` | 112 | 117 | +5 lines (truncated) |
| `chromatic-connection` | `endLine` | 204 | 195 | -9 lines (overshoot) |
| `frankl-wilson` | `startLine` | 214 | 196 | -18 lines (overshoot) |
| `frankl-wilson` | `endLine` | 226 | 212 | -14 lines (overshoot) |
| `summary` | `startLine` | 258 | 227 | -31 lines (truncated) |

## Verification against Lean source

Verified against `proofs/Proofs/Erdos703Problem.lean`:

- `frankl-1977`: `theorem large_sets_avoid_1` proof ends at line 117 (`omega` tactic)
- `chromatic-connection`: Part VI content ends at line 195 (closing `-/` of "Frankl-Wilson (1981)" docstring)
- `frankl-wilson`: Part VII spans lines 196-212 (`/-` Part VII comment through closing docstring)
- `summary`: Part IX summary docstring begins at line 227 with `/--`

## Test plan

- [x] JSON syntax validated with `jq`
- [x] `pnpm build` succeeds
- [x] Line ranges verified against Lean source