### PR TITLE
audit(erdos-714): remove phantom projective_plane_construction contribution

### DIFF
--- a/src/data/proofs/erdos-714/meta.json
+++ b/src/data/proofs/erdos-714/meta.json
@@ -44,8 +44,7 @@
       "erdosConjectureLowerBound: the conjecture statement",
       "zarankiewicz_r2 axiom: complete solution for r=2",
       "brown_theorem, erdos_renyi_sos_theorem: lower bound for r=3",
-      "erdos_714_r2, erdos_714_r3 theorems: partial solutions",
-      "projective_plane_construction: construction for r=2"
+      "erdos_714_r2, erdos_714_r3 theorems: partial solutions"
     ],
     "axiomCount": 3,
     "lineCount": 259,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-714
**Problem**: `originalContributions` claimed a Lean entity (`projective_plane_construction`) that does not exist as a declaration in the source file.

## Evidence

**meta.json claims** (originalContributions):
> "projective_plane_construction: construction for r=2"

**Lean file shows** (`grep -n "projective_plane" proofs/Proofs/Erdos714Problem.lean`): no matches. Projective planes appear only in a docstring section (lines 185-190), already correctly described elsewhere in meta.json as "Docstring descriptions" in the constructions section.

## Verification

All other counts/claims confirmed accurate:
- 3 axioms: `kovari_sos_turan`, `zarankiewicz_r2`, `brown_theorem`
- 5 theorems, 6 definitions, 0 sorries, 259 lines
- status: `axiomatized`, badge: `axiom` — appropriate for axiomatized partial result
- Section line ranges (recently fixed in #14019) all check out

## Fix

Remove the single phantom entry from `originalContributions`. No other changes.

---
Discovered during gallery integrity audit. Severity: LOW (narrative misalignment, no count or status overclaim).