### PR TITLE
fix(erdos-714): remove phantom originalContributions entry

### DIFF
--- a/src/data/proofs/erdos-714/meta.json
+++ b/src/data/proofs/erdos-714/meta.json
@@ -44,8 +44,7 @@
       "erdosConjectureLowerBound: the conjecture statement",
       "zarankiewicz_r2 axiom: complete solution for r=2",
       "brown_theorem, erdos_renyi_sos_theorem: lower bound for r=3",
-      "erdos_714_r2, erdos_714_r3 theorems: partial solutions",
-      "projective_plane_construction: construction for r=2"
+      "erdos_714_r2, erdos_714_r3 theorems: partial solutions"
     ],
     "axiomCount": 3,
     "lineCount": 259,


### PR DESCRIPTION
## What

Removes a phantom entry from `meta.originalContributions` in `src/data/proofs/erdos-714/meta.json`.

## Why

The list claimed `projective_plane_construction: construction for r=2`, but no `def`, `theorem`, `axiom`, or `lemma` of that name exists in `proofs/Proofs/Erdos714Problem.lean`. The phrase appears only in a docstring (L186-187) describing background context for the r=2 case.

```
$ grep -n "projective" proofs/Proofs/Erdos714Problem.lean
186:**Projective Planes:**
187:For r = 2, extremal graphs come from incidence graphs of projective planes.
```

This was residual from PR #14004, which cleaned the phantom declaration name from `sections[open-cases/constructions/connections]` but missed the same name here. All other entries in `originalContributions` resolve to real declarations:

- `containsCompleteBipartite` (def, L47)
- `isKrrFree` (def, L55)
- `exKrr` (def, L72)
- `kovari_sos_turan` (axiom, L90)
- `kstExponent` (def, L101)
- `erdosConjectureLowerBound` (def, L113)
- `zarankiewicz_r2` (axiom, L124)
- `brown_theorem` (axiom, L137), `erdos_renyi_sos_theorem` (theorem, L141)
- `erdos_714_r2` (theorem, L148), `erdos_714_r3` (theorem, L160)

## Verification

- `pnpm build` passes (build green, no TypeScript errors)
- JSON syntactically valid

Closes #14026

🤖 Generated with [Claude Code](https://claude.com/claude-code)