### PR TITLE
audit(erdos-714): mark issues-found — phantom contribution remains

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8642,9 +8642,9 @@
     },
     "erdos-714": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T01:27:29Z",
+      "result": "issues-found"
     },
     "erdos-715": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result

Audited **erdos-714** (Zarankiewicz problem for K_{r,r}).

### Counts validated
- axioms: 3 (kovari_sos_turan, zarankiewicz_r2, brown_theorem) ✓
- sorries: 0 ✓
- lineCount: 259 ✓
- theorems/definitions match meta.json

### Issue
`meta.originalContributions[9]` lists `"projective_plane_construction: construction for r=2"`, but no such declaration exists in `proofs/Proofs/Erdos714Problem.lean`. Lines 185–189 contain only a docstring describing projective planes — no `def` or `theorem`.

### Action
Fixes already in flight: #14029, #14031, issue #14026. Not filing duplicate.

This PR only updates `audit-tracker.json` to record the audit completion.