### PR TITLE
fix(erdos-714): remove phantom projective_plane_construction from originalContributions

### DIFF
--- a/src/data/proofs/erdos-714/meta.json
+++ b/src/data/proofs/erdos-714/meta.json
@@ -44,8 +44,7 @@
       "erdosConjectureLowerBound: the conjecture statement",
       "zarankiewicz_r2 axiom: complete solution for r=2",
       "brown_theorem, erdos_renyi_sos_theorem: lower bound for r=3",
-      "erdos_714_r2, erdos_714_r3 theorems: partial solutions",
-      "projective_plane_construction: construction for r=2"
+      "erdos_714_r2, erdos_714_r3 theorems: partial solutions"
     ],
     "axiomCount": 3,
     "lineCount": 259,


### PR DESCRIPTION
## Fix

Remove `projective_plane_construction: construction for r=2` from `originalContributions` in `src/data/proofs/erdos-714/meta.json`. This declaration does not exist in `proofs/Proofs/Erdos714Problem.lean` — the phrase appears only in a docstring at L186-187.

## Evidence

**Before**: `originalContributions` contained 11 entries including `"projective_plane_construction: construction for r=2"`.
**After**: 10 entries; all reference real Lean declarations.

PR #14004 cleaned phantoms from sections but missed this entry in `originalContributions`.

Closes #14026

---
Automated fix by lean-mechanic agent.