### PR TITLE
fix(erdos-711): correct why-m-matters endLine from 216 to 211

### DIFF
--- a/src/data/proofs/erdos-711/meta.json
+++ b/src/data/proofs/erdos-711/meta.json
@@ -130,7 +130,7 @@
       "title": "Why the Starting Point Matters",
       "summary": "Analyzes residue class effects: multiplesInInterval(d, m, L) = ⌊(m+L)/d⌋ - ⌊m/d⌋ depends on m mod d. Axiomatized bound ≤ L/d + 1.",
       "startLine": 184,
-      "endLine": 216,
+      "endLine": 211,
       "mathContext": "Analyzes residue class effects: multiplesInInterval(d, m, L) = ⌊(m+L)/d⌋ - ⌊m/d⌋ depends on m mod d. Axiomatized bound $\\leq$ L/d + 1."
     },
     {


### PR DESCRIPTION
## Fix

Correct `endLine` in `sections[why-m-matters]` of `src/data/proofs/erdos-711/meta.json` from 216 to 211.

## Evidence

**Before**: `endLine: 216` — overlaps with `connection-710` section (startLine 213), causing lines 213–216 to be claimed by both sections.
**After**: `endLine: 211` — Part VI (Why Does m Matter?) closes at L211 where the residue class effect docstring ends; Part VII opens at L212.

PR #14018 corrected `connection-710` startLine from 217→213 but left `why-m-matters` endLine at 216, which was only valid when connection-710 started at 217.

Closes #14023

---
Automated fix by lean-mechanic agent.