### PR TITLE
fix(erdos-711): remove phantom-axiom narrative from why-m-matters and connection-710 sections

### DIFF
--- a/src/data/proofs/erdos-711/meta.json
+++ b/src/data/proofs/erdos-711/meta.json
@@ -128,18 +128,18 @@
     {
       "id": "why-m-matters",
       "title": "Why the Starting Point Matters",
-      "summary": "Analyzes residue class effects: multiplesInInterval(d, m, L) = ⌊(m+L)/d⌋ - ⌊m/d⌋ depends on m mod d. Axiomatized bound ≤ L/d + 1.",
+      "summary": "Analyzes residue class effects: multiplesInInterval(d, m, L) = ⌊(m+L)/d⌋ - ⌊m/d⌋ depends on m mod d. Standard bound L/d + 1 stated in docstring (no axiom).",
       "startLine": 184,
       "endLine": 211,
-      "mathContext": "Analyzes residue class effects: multiplesInInterval(d, m, L) = ⌊(m+L)/d⌋ - ⌊m/d⌋ depends on m mod d. Axiomatized bound $\\leq$ L/d + 1."
+      "mathContext": "Analyzes residue class effects: multiplesInInterval(d, m, L) = ⌊(m+L)/d⌋ - ⌊m/d⌋ depends on m mod d. Standard bound L/d + 1 stated in docstring (no axiom)."
     },
     {
       "id": "connection-710",
       "title": "Connection to Problem #710",
-      "summary": "Axiomatized Erdős-Pomerance bounds for f(n,n): C₁·n·√(log n/log log n) ≤ f(n,n) ≤ C₂·n·√(log n). Shows van Doorn's difference can dominate the base value.",
+      "summary": "Documents Erdős-Pomerance bounds for f(n,n): C₁·n·√(log n/log log n) ≤ f(n,n) ≤ C₂·n·√(log n) and van Doorn's dominance result in docstrings (no axiom — bounds formalized in upper-bounds and van-doorn sections).",
       "startLine": 213,
       "endLine": 231,
-      "mathContext": "Axiomatized Erdős-Pomerance bounds for f(n,n): C₁·n·√($\\log n$/log $\\log n$) $\\leq$ f(n,n) $\\leq$ C₂·n·√($\\log n$). Shows van Doorn's difference can dominate the base value."
+      "mathContext": "Documents Erdős-Pomerance bounds for f(n,n): C₁·n·√($\\log n$/log $\\log n$) $\\leq$ f(n,n) $\\leq$ C₂·n·√($\\log n$) in docstrings (no axiom — bounds formalized in upper-bounds and van-doorn sections)."
     },
     {
       "id": "examples",


### PR DESCRIPTION
## Fix

Replace phantom "Axiomatized bound" narrative in two sections of `src/data/proofs/erdos-711/meta.json` with accurate docstring-only descriptions.

## Evidence

**`sections[why-m-matters]`**:
- Before: `summary`/`mathContext` claimed "Axiomatized bound ≤ L/d + 1."
- After: "Standard bound L/d + 1 stated in docstring (no axiom)."
- Reality: Lines 206-211 contain only a docstring with the standard bound; no `axiom` declaration exists in this section.

**`sections[connection-710]`**:
- Before: `summary`/`mathContext` claimed "Axiomatized Erdős-Pomerance bounds for f(n,n)..."
- After: "Documents Erdős-Pomerance bounds... in docstrings (no axiom — bounds formalized in upper-bounds and van-doorn sections)."
- Reality: Lines 216-227 contain only docstrings ("Problem #710 Bounds (for reference)" and "van Doorn's Result in Context"); the 4 real axioms are all in earlier sections (lines 73, 109, 170, 181).

Numerical counts (`axiomCount: 4`, `sorries: 0`, `lineCount: 333`) are correct and unchanged.

Closes #14027

---
Automated fix by lean-mechanic agent.