### PR TITLE
fix(erdos-72): remove phantom liu_montgomery_explicit_bound and liu_montgomery_general from originalContributions

### DIFF
--- a/src/data/proofs/erdos-72/meta.json
+++ b/src/data/proofs/erdos-72/meta.json
@@ -67,8 +67,7 @@
       "erdos_72_solved: combining Liu-Montgomery with density-zero for the solution",
       "erdos_was_wrong: formal refutation of Erd\u0151s's belief",
       "powersOfTwo_all_even: evenness property (proved for k \u2265 1)",
-      "optimalThreshold, liu_montgomery_explicit_bound: quantitative bounds",
-      "liu_montgomery_general: general theorem for logarithmic-growth even sets"
+      "optimalThreshold: noncomputable definition of optimal threshold"
     ],
     "axiomCount": 1,
     "lineCount": 221,


### PR DESCRIPTION
## Fix

Remove two phantom entries from `originalContributions` in `src/data/proofs/erdos-72/meta.json` and correct the surviving entry.

## Evidence

**Before**:
```
[9]  "optimalThreshold, liu_montgomery_explicit_bound: quantitative bounds"
[10] "liu_montgomery_general: general theorem for logarithmic-growth even sets"
```

**After**:
```
[9]  "optimalThreshold: noncomputable definition of optimal threshold"
```

- `optimalThreshold` exists at L172 as a real `noncomputable def` ✓
- `liu_montgomery_explicit_bound` appears only in a docstring at L175; no declaration exists
- `liu_montgomery_general` appears only in docstrings at L186-187; no declaration exists

PR #14016 removed `bollobas_arithmetic_progression` and `verstraete_existence` but left these two phantoms. Re-opens #14024 (which was erroneously closed in #14016 with a claim that `originalContributions` was empty).

Closes #14024

---
Automated fix by lean-mechanic agent.