### PR TITLE
fix(erdos-704): correct section line ranges (hadwiger-nelson/open-questions/proof-techniques)

### DIFF
--- a/src/data/proofs/erdos-704/meta.json
+++ b/src/data/proofs/erdos-704/meta.json
@@ -119,23 +119,23 @@
       "id": "hadwiger-nelson",
       "title": "Hadwiger-Nelson Problem (n=2)",
       "summary": "The classical plane case with de Grey's 2018 result",
-      "startLine": 96,
-      "endLine": 117,
+      "startLine": 93,
+      "endLine": 113,
       "mathContext": "Mathematical content: The classical plane case with de Grey's 2018 result"
     },
     {
       "id": "open-questions",
       "title": "Open Questions and Derived Results",
       "summary": "Limit definition, exponential growth axiom, base bounds axiom",
-      "startLine": 118,
-      "endLine": 139,
+      "startLine": 115,
+      "endLine": 130,
       "mathContext": "Formal definition: Limit definition, exponential growth axiom, base bounds axiom"
     },
     {
       "id": "proof-techniques",
       "title": "Proof Techniques",
       "summary": "How lower and upper bounds are proved",
-      "startLine": 140,
+      "startLine": 131,
       "endLine": 154,
       "mathContext": "Bound: How lower and upper bounds are proved"
     }


### PR DESCRIPTION
## Fix

Correct section `startLine`/`endLine` values in `src/data/proofs/erdos-704/meta.json` to align with actual comment block boundaries in the Lean source.

## Evidence

| Section | Before | After |
|---|---|---|
| `hadwiger-nelson` | 96–117 | 93–113 |
| `open-questions` | 118–139 | 115–130 |
| `proof-techniques` | 140–154 | 131–154 |

- Line 93: `/-` opens "## The Hadwiger-Nelson Problem (n = 2)"
- Line 113: `hadwiger_nelson_bounds` theorem ends
- Line 115: `/-` opens "## Open Questions"
- Line 131: `/-` opens "## Proof Techniques"

No axiom counts, sorry counts, or status values changed — purely cosmetic display fix.

Closes #14040

---
Automated fix by lean-mechanic agent.