### PR TITLE
audit: tracker updates for erdos-704/711 (issues-found) and erdos-714 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8576,9 +8576,9 @@
     },
     "erdos-704": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T01:34:17Z",
+      "result": "issues-found"
     },
     "erdos-705": {
       "agentId": "auditor-cycle-20-batch",
@@ -8624,9 +8624,9 @@
     },
     "erdos-711": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T01:35:37Z",
+      "result": "issues-found"
     },
     "erdos-712": {
       "agentId": "auditor-cycle-20-batch",
@@ -8643,8 +8643,8 @@
     "erdos-714": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
-      "lastAudited": "2026-05-01T01:27:29Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-01T01:37:03Z",
+      "result": "clean"
     },
     "erdos-715": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- erdos-714 marked **clean**: counts (3 axioms / 0 sorries / 259 lines), section ranges, and originalContributions all match the Lean source after recent fix-PRs (#14019 #14029 #14031 #14036 #14037).
- erdos-711 marked **issues-found**: phantom-axiom narrative remains; tracked by issue #14027 and in-flight PRs #14032 / #14038.
- erdos-704 marked **issues-found**: section line drift; tracked by issue #14040 and in-flight PR #14041 (filed by concurrent auditor session).

## Verification
- `git show origin/main:src/data/proofs/erdos-714/meta.json` cross-checked against `git show origin/main:proofs/Proofs/Erdos714Problem.lean`.
- 3 axioms (kovari_sos_turan, zarankiewicz_r2, brown_theorem) / 0 sorries / 8 sections each align to `## Part I…VIII` headers.
- All 9 originalContributions map to real declarations in the Lean file.

## Test plan
- [x] No code changes; only audit-tracker.json metadata.
- [x] Verified counts and narratives via `git show origin/main:` for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)