### PR TITLE
audit(erdos-702): mark issues-found in tracker (#14044)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8563,10 +8563,10 @@
       "result": "clean"
     },
     "erdos-702": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777623480",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T01:43:40Z",
+      "result": "issues-found"
     },
     "erdos-703": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates `src/data/proofs/audit-tracker.json` to mark erdos-702 as `issues-found`
- Issue #14044 documents two defects: (1) three phantom-axiom claims in `originalContributions`/section summaries (only `frankl_theorem` is a real axiom), (2) section line range drift of +8 to +25 lines starting at Part IV

## Test plan

- [x] `git diff` shows only the expected single-entry update
- [x] Issue #14044 filed with detailed evidence and recommended fix
- [ ] Mechanic to address #14044 in a follow-up PR