### PR TITLE
audit(erdos-711): mark clean — narrative now matches Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8623,10 +8623,10 @@
       "result": "issues-found"
     },
     "erdos-711": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T01:35:37Z",
-      "result": "issues-found"
+      "agentId": "auditor-loop",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T01:55:37Z",
+      "result": "clean"
     },
     "erdos-712": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-711 after upstream fixes #14037 and #14038. All claims in `meta.json` now match the Lean source.

## Verification (against origin/main 505d1b5)

- **333 lines, 4 axioms, 0 sorries** — matches `meta.json` exactly
- Axioms present: `selection_exists_for_any_start`, `erdos_pomerance_upper_bound_711`, `van_doorn_2026`, `second_conjecture_solved`
- All 9 section line ranges (`basic-definitions` through `summary`) verified accurate
- `originalContributions` items all map to real declarations
- `why-m-matters` and `connection-710` no longer claim phantom axioms (#14038 cleanup confirmed)

## Tracker change

`audit-tracker.json` for `erdos-711`: `issues-found` → `clean`, `auditCount` 3 → 4.

## Test plan

- [x] meta.json `axiomCount`/`lineCount`/`sorries` match Lean source
- [x] All 4 axioms named in `assumptions` exist in source
- [x] Each section's line range covers its claimed declarations
- [x] No phantom axiom names in narrative