### PR TITLE
audit(erdos-698): mark issues-found — 8 sections still drift after #14051

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8522,9 +8522,9 @@
     },
     "erdos-698": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T02:44:34Z",
+      "result": "issues-found"
     },
     "erdos-699": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Tracker entry for erdos-698 advances to auditCount=3 with result=issues-found
- Issue #14064 documents the remaining 8-section line-range drift (PR #14051 corrected only the summary section's endLine)

## Verified during audit

- axiomCount=2 ✓ (`erdos_szekeres_exponential` L77, `min_gcd_growth` L146)
- sorries=0 ✓
- lineCount=293 ✓
- originalContributions ✓ (phantom kummer/lucas entry already removed in #14051)

## Test plan

- [x] Tracker diff is exactly 3 lines (auditCount, lastAudited, result) for erdos-698
- [x] No other entries touched
- [x] Issue #14064 filed with drift table

🤖 Generated with [Claude Code](https://claude.com/claude-code)