### PR TITLE
fix(erdos-684): correct section line ranges to match actual file structure

### DIFF
--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -81,71 +81,71 @@
       "title": "Smooth and Rough Parts",
       "summary": "smoothPart, roughPart, binomialSmoothPart, binomialRoughPart",
       "startLine": 38,
-      "endLine": 65,
+      "endLine": 104,
       "mathContext": "Mathematical content: smoothPart, roughPart, binomialSmoothPart, binomialRoughPart"
     },
     {
       "id": "f-definition",
       "title": "The Function f(n)",
       "summary": "f, f_property, below_f_small",
-      "startLine": 66,
-      "endLine": 83,
+      "startLine": 105,
+      "endLine": 145,
       "mathContext": "Mathematical content: f, f_property, below_f_small"
     },
     {
       "id": "mahler",
       "title": "Mahler's Classical Result",
       "summary": "mahler_ineffective, f_tendsto_infty_weak",
-      "startLine": 84,
-      "endLine": 99,
+      "startLine": 146,
+      "endLine": 203,
       "mathContext": "Mathematical content: mahler_ineffective, f_tendsto_infty_weak"
     },
     {
       "id": "modern-bounds",
       "title": "Modern Bounds",
       "summary": "tang_exponent, tang_bound, rh_exponent, rh_conditional_bound",
-      "startLine": 100,
-      "endLine": 119,
+      "startLine": 204,
+      "endLine": 215,
       "mathContext": "Bound: tang_exponent, tang_bound, rh_exponent, rh_conditional_bound"
     },
     {
       "id": "heuristic",
       "title": "Heuristic Conjectures",
       "summary": "heuristic_bound, heuristic_conjecture",
-      "startLine": 120,
-      "endLine": 135,
+      "startLine": 216,
+      "endLine": 228,
       "mathContext": "Bound: heuristic_bound, heuristic_conjecture"
     },
     {
       "id": "structure",
       "title": "Structure of Smooth Part",
       "summary": "legendreExponent, kummer_theorem",
-      "startLine": 136,
-      "endLine": 154,
+      "startLine": 229,
+      "endLine": 283,
       "mathContext": "Verified: legendreExponent, kummer_theorem"
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "summary": "f_lower_bound, prime_binomial_structure",
-      "startLine": 155,
-      "endLine": 169,
+      "startLine": 284,
+      "endLine": 330,
       "mathContext": "Formal definition: f_lower_bound, prime_binomial_structure"
     },
     {
       "id": "generalized",
       "title": "The Generalized Problem",
       "summary": "fGeneral, f_is_fGeneral_0",
-      "startLine": 170,
-      "endLine": 182,
+      "startLine": 331,
+      "endLine": 348,
       "mathContext": "Mathematical content: fGeneral, f_is_fGeneral_0"
     },
     {
       "id": "status",
       "title": "Problem Status",
       "summary": "erdos_684_status, erdos_684_statement, summary",
-      "startLine": 195,
-      "endLine": 245,
+      "startLine": 349,
+      "endLine": 401,
       "mathContext": "Mathematical content: erdos_684_status, erdos_684_statement, summary"
     }
   ],


### PR DESCRIPTION
## Fix

Update all 9 section `startLine`/`endLine` values in `src/data/proofs/erdos-684/meta.json` to match the actual layout of `proofs/Proofs/Erdos684Problem.lean` (401 lines, 10 Part sections).

## Evidence

**Before**: All sections were stuck on an earlier file layout (e.g. `smooth-rough` listed 38–65, `status` listed 195–245).

**After**: Ranges aligned to actual Part comment headers:
| Section | Before | After |
|---|---|---|
| smooth-rough | 38–65 | 38–104 |
| f-definition | 66–83 | 105–145 |
| mahler | 84–99 | 146–203 |
| modern-bounds | 100–119 | 204–215 |
| heuristic | 120–135 | 216–228 |
| structure | 136–154 | 229–283 |
| special-cases | 155–169 | 284–330 |
| generalized | 170–182 | 331–348 |
| status | 195–245 | 349–401 |

Build verified: `pnpm build` passes (exit 0).

Closes #14060

---
Automated fix by lean-mechanic agent.