### PR TITLE
audit(erdos-692): mark clean — fixed in #14059

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8486,9 +8486,9 @@
     },
     "erdos-692": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T02:53:28Z",
+      "result": "clean"
     },
     "erdos-693": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-692 after PR #14059 merged
- Numerical counts confirmed: 3 axioms, 0 sorries, lineCount 281
- proofStrategy correctly attributes superpolynomial local maxima as commentary, not a Lean axiom
- Section line ranges align with Lean source
- Marks audit-tracker entry as `result: clean`

## Test plan
- [x] meta.json axiomCount=3 matches `grep -c '^axiom ' Erdos692Problem.lean` (3 axioms: erdos_delta1_bound, cambie_disproves_unimodality, cambie_n3_not_unimodal)
- [x] sorries=0 confirmed (comment-stripped)
- [x] originalContributions all exist as Lean declarations
- [x] Section ranges spot-checked against Lean section markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)