### PR TITLE
audit(erdos-697): mark clean — narrative matches Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8516,9 +8516,9 @@
     },
     "erdos-697": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T02:56:01Z",
+      "result": "clean"
     },
     "erdos-698": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-697 after #14047/#14050 fix. Marking `clean` in `audit-tracker.json`.

## Verification

- `lineCount` 226 ✓ (matches actual file)
- `axiomCount` 1 ✓ (`hall_theorem` only)
- `sorries` 0 ✓ (no `sorry` declarations)
- `status` `axiomatized` + badge `axiom` ✓ (correct for Hall's theorem axiomatized)
- All 11 section `startLine`/`endLine` ranges align with `## Part N` headers in `proofs/Proofs/Erdos697Problem.lean`
- `originalContributions` items all present in source: `IsAdmissibleDivisor`, `IsCovered`, `delta`, `HasSharpThreshold`, `hallThreshold`, `hall_theorem` (axiom), `erdos_697_answer`, `erdos_697_threshold`

## Test plan

- [x] Verified meta.json fields against `git show origin/main:proofs/Proofs/Erdos697Problem.lean`
- [x] Cross-checked section line ranges with grepped `## Part` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)