### PR TITLE
fix(erdos-676): correct section line ranges to match actual file structure

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8377,10 +8377,13 @@
       "result": "clean"
     },
     "erdos-676": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T02:49:13Z",
-      "result": "clean"
+      "agentId": "lean-auditor",
+      "auditCount": 4,
+      "issues": [
+        "section line ranges drifted: RepresentableByPrime (line 160) was in variants section instead of connections; 6 sections corrected via PR #14071"
+      ],
+      "lastAudited": "2026-05-01T03:03:03Z",
+      "result": "issues-fixed"
     },
     "erdos-677": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-676/meta.json
+++ b/src/data/proofs/erdos-676/meta.json
@@ -95,48 +95,48 @@
     {
       "id": "density",
       "title": "Density Results",
-      "summary": "exceptionCount, brun_selberg_bound, density_one",
+      "summary": "exceptionCount, density_one",
       "startLine": 87,
-      "endLine": 105,
-      "mathContext": "Bound: exceptionCount, brun_selberg_bound, density_one"
+      "endLine": 101,
+      "mathContext": "Bound: exceptionCount, density_one"
     },
     {
       "id": "examples",
       "title": "Verified Examples",
       "summary": "five_representable, thirteen_representable",
-      "startLine": 106,
-      "endLine": 135,
+      "startLine": 102,
+      "endLine": 131,
       "mathContext": "Mathematical content: five_representable, thirteen_representable"
     },
     {
       "id": "variants",
       "title": "Variant Problems",
       "summary": "IsRepresentableGeneral, minimalCoefficient, SubpolynomialGrowth",
-      "startLine": 136,
-      "endLine": 165,
+      "startLine": 132,
+      "endLine": 152,
       "mathContext": "Mathematical content: IsRepresentableGeneral, minimalCoefficient, SubpolynomialGrowth"
     },
     {
       "id": "connections",
       "title": "Related Concepts",
       "summary": "RepresentableByPrime, ResidueConstraint, almost_all_covered",
-      "startLine": 166,
-      "endLine": 184,
+      "startLine": 153,
+      "endLine": 180,
       "mathContext": "Mathematical content: RepresentableByPrime, ResidueConstraint, almost_all_covered"
     },
     {
       "id": "status",
       "title": "Problem Status",
       "summary": "erdos_676_status, erdos_676_statement",
-      "startLine": 185,
-      "endLine": 213,
+      "startLine": 181,
+      "endLine": 208,
       "mathContext": "Mathematical content: erdos_676_status, erdos_676_statement"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Known results, open questions, Erdos's belief",
-      "startLine": 214,
+      "startLine": 209,
       "endLine": 225,
       "mathContext": "Mathematical content: Known results, open questions, Erdos's belief"
     }


### PR DESCRIPTION
## Summary

Corrects 6 section line ranges in `src/data/proofs/erdos-676/meta.json` so each section accurately covers the declarations described in its summary.

The most consequential drift: `RepresentableByPrime` (line 160) fell inside the **variants** section (136-165) but its summary (`IsRepresentableGeneral, minimalCoefficient, SubpolynomialGrowth`) does not include it. `RepresentableByPrime` is correctly named in the **connections** section's summary, but that section's range (166-184) started after the declaration.

## Changes

| Section | Before | After |
|---------|--------|-------|
| density | 87-105 | 87-101 |
| examples | 106-135 | 102-131 |
| variants | 136-165 | 132-152 |
| connections | 166-184 | 153-180 |
| status | 185-213 | 181-208 |
| summary | 214-225 | 209-225 |

`definitions` (31-50) and `conjecture` (51-86) were already correct.

Also removes `brun_selberg_bound` from the **density** summary — it appears only in a comment (line 97) and is not a declaration.

## Verification

- All 13 entries in `originalContributions` exist as declarations in `proofs/Proofs/Erdos676Problem.lean`.
- `sorries: 0` matches actual file.
- `axiomCount: 1` matches actual file (only `density_one`).
- `theoremCount: 5`, `definitionCount: 13` match counts in the file.

## Test plan
- [x] `jq -e '.sections | length' src/data/proofs/erdos-676/meta.json` returns 8
- [x] No changes to Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)