### PR TITLE
fix(erdos-704): correct upper-bounds section endLine to eliminate overlap

### DIFF
--- a/src/data/proofs/erdos-704/meta.json
+++ b/src/data/proofs/erdos-704/meta.json
@@ -112,7 +112,7 @@
       "title": "Upper Bounds",
       "summary": "Trivial bound, Larman-Rogers 1972, and conjectured bound",
       "startLine": 68,
-      "endLine": 95,
+      "endLine": 92,
       "mathContext": "Bound: Trivial bound, Larman-Rogers 1972, and conjectured bound"
     },
     {


### PR DESCRIPTION
## Fix

The `upper-bounds` section in `erdos-704/meta.json` had `endLine: 95`, causing a 3-line overlap with the `hadwiger-nelson` section (which correctly starts at line 93).

## Evidence

**Before**: `upper-bounds` endLine 95 — lines 93-95 claimed by both sections:
- Line 93: `/-` (opening of Hadwiger-Nelson comment)
- Line 94: `## The Hadwiger-Nelson Problem (n = 2)`
- Line 95: (empty line inside that comment)

**After**: `upper-bounds` endLine 92 — last line of `conjecturedBase` definition (`def conjecturedBase : ℝ := 2^(3/2 : ℝ)  -- ≈ 2.828`), immediately before the Hadwiger-Nelson section begins.

The `hadwiger-nelson` section boundaries (startLine 93, endLine 113) are correct and unchanged.

---
Automated fix by lean-mechanic agent.