### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): reconcile state.md with sessions 5-33

### DIFF
--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -41,6 +41,56 @@ Key infrastructure already available:
 
 > **Note**: 4 older sessions archived to `sessions/` directory.
 
+## Session 2026-05-01 (Session 34) — Reconcile state.md with sessions 5–33 progress
+
+**Mode**: REVISIT (RICH knowledge tier, score 163)
+**Outcome**: HOUSEKEEPING — state.md brought current; no Lean changes
+
+### What I Did
+
+1. Verified the current state of `BallotProblemOQ03OQ01OQ02.lean`:
+   - 14022 lines (matches `meta.json:lineCount`)
+   - 1 real `sorry` (after stripping comments/docstrings) at line 13932 inside
+     the `hook_walk_identity` dispatcher's ≥10×≥10 non-rectangular branch
+   - 0 `axiom` declarations
+   - 482 `theorem`/`lemma` declarations + 21 `def` declarations
+   - All other sorries reported by raw `grep` are inside docstrings/comments
+2. Verified the gallery `meta.json` matches the file: `sorries: 1`,
+   `axiomCount: 0`, `lineCount: 14022`, `status: formalized`, `badge: wip`.
+3. Cross-referenced session 31–33 notes with `literature/closing-the-final-sorry.md`
+   to confirm the recommended next step (file modularization → GNW Route A).
+4. Replaced the stale state.md (which still claimed `Iteration: 1`,
+   "First step: read BallotProblemOQ03OQ02.lean", "Active Approach: None yet")
+   with an accurate snapshot:
+   - Iteration: 33, Phase: ACT (modularize-then-prove)
+   - Approaches tried (1–4) with one-line outcomes each
+   - Blockers: file size beyond Docker envelope; no probabilistic toolkit
+   - Next action: dependency-map → split into `Core` + `RowCases` modules,
+     then attempt deterministic GNW in a `HookWalk` companion file
+
+### Why This Session
+
+The state.md drift discovered today (iteration 1 vs. 33 sessions of work) is
+exactly the failure mode flagged in the
+"stale 'completed' candidate-pool entries" memory note: a researcher arriving
+fresh and only reading state.md would re-do work that's been done 32 times.
+Reconciling state.md to match the actual research history (preserved in
+knowledge.md and sessions/) is a high-value, low-risk pure-text contribution,
+appropriate when the build envelope blocks Lean edits.
+
+### Files Modified
+
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (full rewrite to match sessions 5–33 reality)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (this entry)
+
+### No Sorry Count Change
+
+The Lean file is unchanged. Sorry count remains 1 (`hook_walk_identity` for
+≥10 rows AND ≥10 cols AND non-rectangular shapes).
+
+---
+
 ## Session 2026-04-26 (Session 31) — Move hook_length_formula; document LGV issues
 
 **Mode**: REVISIT (RICH knowledge tier)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,30 +1,100 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT
+**Phase**: ACT (modularize-then-prove)
 **Path**: full
 **Since**: 2026-04-21T20:08:44+02:00
-**Iteration**: 1
+**Last Updated**: 2026-05-01
+**Iteration**: 33
 
 ## Current Focus
-Generalize the existing 2-row hook-length result to arbitrary Young tableaux shape
-using the n×n LGV lemma in `BallotProblemOQ03OQ02.lean`.
+Close the sole remaining `sorry` in `BallotProblemOQ03OQ01OQ02.lean` — the
+`hook_walk_identity` dispatcher branch covering Young diagrams with **≥10 rows
+AND ≥10 cols AND non-rectangular** (line 13932). All other shapes (≤9 rows,
+≤9 cols via transpose duality, all rectangles, all gHookYD `[a, 1^b]`,
+exactly-3 through exactly-9-row shapes) are already proved.
+
+The file has reached **14022 lines** and exceeds the Docker 32 GB build envelope,
+so the row-by-row mechanical pattern (~2200 lines per new row case, see
+sessions 22–32) has hit a hard scaling wall. Further progress requires either
+(a) a uniform proof that closes ≥10×≥10 in one shot, or (b) splitting the file
+to restore buildability before any large additions.
 
 ## Active Approach
-None yet. First step: read `BallotProblemOQ03OQ02.lean` to understand the
-`lgv_lemma_rxr` interface and path count types. Then assess `YoungDiagram`
-in Mathlib for arm/leg/hook infrastructure.
+Three routes are characterised in
+`literature/closing-the-final-sorry.md` (session 33, 2026-04-27):
+
+- **Route A — Greene–Nijenhuis–Wilf probabilistic hook walk** (~300–400 lines).
+  Recommended path. Closes all remaining shapes in one argument and replaces
+  the row-by-row tower if reformulated. A deterministic recasting (counting
+  weighted hook walks) avoids `ProbabilityTheory` imports.
+- **Route B — Fomin growth diagrams / RSK**. Heavier infrastructure;
+  contributes the SYT ↔ NI-paths bijection separately documented as the
+  canonical-config LGV path in PART V comments.
+- **Route C — Continue row-by-row** (PART XXVII = exactly-10-row, ~2300 more
+  lines). Mechanical but rejected: each new row pushes the file further beyond
+  the build envelope; reaching ≥50 rows would require ~90 K lines.
+
+**Pre-requisite for ANY route:** modularize the file. Sessions 31–32 confirmed
+that PARTS XII–XXIII (~10 000 lines of row-by-row coverage) can be split into a
+dedicated module without disturbing PARTS I–XI (definitions, hook-product
+infrastructure) or the corner-recursion / `hook_length_formula_general` plumbing
+in PARTS XIII–XIV.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 33 (sessions 1–33; sessions 1–4 archived to
+  `sessions/`; sessions 5–33 in `knowledge.md`)
+- Current approach attempts: 0 (GNW route not yet attempted)
+- Approaches tried:
+  1. LGV-determinant via `lgv_lemma_rxr` + Jacobi–Trudi (sessions 1–10) —
+     blocked on `ni_count_eq_syt_count` and `lgv_det_factors_as_hook_quotient`;
+     deleted as dead scaffolding in session 32.
+  2. Corner recursion via `card_SYT_corner_step` + `hook_walk_identity`
+     (sessions 11–14) — successful: gave `hook_length_formula_general`
+     modulo a single `hook_walk_identity` sorry.
+  3. Row-by-row dispatch on `hook_walk_identity` (sessions 15–30) —
+     successful for ≤9 rows / ≤9 cols (transpose duality) / all rectangles;
+     hit file-size wall at session 30.
+  4. Housekeeping: dead-code removal and LGV restatement as comments
+     (sessions 31–33).
 
 ## Blockers
-None.
+- **File size beyond Docker envelope.** At 14022 lines
+  `BallotProblemOQ03OQ01OQ02.lean` cannot be type-checked under the standard
+  `./proofs/scripts/docker-build.sh` invocation (32 GB memory limit). All
+  edits since session 27 are *unverified by the build*. Modularization is
+  required before any further large additions.
+- **No probabilistic toolkit imported.** Route A in its classical form leans
+  on uniform sampling and conditional probability machinery from
+  `Mathlib.MeasureTheory` / `Mathlib.ProbabilityTheory`. Transitive import
+  weight may further worsen the build envelope problem; a deterministic
+  weighted-walk recasting is preferred.
 
 ## Next Action
-OBSERVE: Read `proofs/Proofs/BallotProblemOQ03OQ02.lean` (2315 lines) to understand
-the n×n LGV lemma interface: what types do sources/targets have, what does the
-theorem statement look like, and what counting infrastructure is available.
-Then grep Mathlib for `YoungDiagram`, `hookLength`, `arm`, `leg` to assess gaps.
+**OBSERVE → PLAN — file modularization, then GNW.**
+
+1. Map the dependency graph between PARTS in `BallotProblemOQ03OQ01OQ02.lean`
+   to identify a clean cut-line. Candidate split:
+   - `BallotProblemOQ03OQ01OQ02Core.lean` ← PARTS I–XI + XIII–XIV
+     (definitions, `hookProd`, `hookProd_ratio_formula`, corner recursion,
+     `hook_length_formula_general` modulo `hook_walk_identity`).
+   - `BallotProblemOQ03OQ01OQ02RowCases.lean` ← PARTS XII + XV–XXIII
+     (per-row dispatchers and `hook_walk_identity_*Row` lemmas).
+   - `BallotProblemOQ03OQ01OQ02.lean` (top-level): imports the two above,
+     re-exports `hook_length_formula` and `hook_length_formula_general`.
+2. Verify each part compiles independently (or at least the Core file does)
+   under Docker.
+3. Once the Core file builds, attempt Route A (deterministic GNW recasting)
+   in a fresh `BallotProblemOQ03OQ01OQ02HookWalk.lean` companion.
+
+If modularization itself proves to be larger than a single session, scope down
+to extracting only the `hook_walk_identity_*Row` lemmas (PARTS XV–XXIII) into
+the row-cases module; the dispatcher itself stays in the main file as a thin
+case split.
+
+## References
+
+- `literature/closing-the-final-sorry.md` — three-route comparison (session 33)
+- `knowledge.md` §Session 32 — dead-code removal and LGV restatement
+- `knowledge.md` §Session 31 — file-size wall first hit
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean:13932` — the sole remaining sorry


### PR DESCRIPTION
## Summary

`state.md` for `ballot-problem-oq-03-oq-01-oq-02` was severely stale: it still claimed `Iteration: 1` with the "first step: read `BallotProblemOQ03OQ02.lean`" guidance, even though `knowledge.md` and `literature/closing-the-final-sorry.md` already document **33 sessions** of work that produced `hook_length_formula_general` modulo a single remaining `hook_walk_identity` sorry.

This PR is pure-text metadata reconciliation — no Lean changes, no sorry-count change.

## What changed

- **`state.md`**: full rewrite to match the actual research history.
  - Iteration: 1 → 33
  - Phase: `ACT` → `ACT (modularize-then-prove)`
  - Active Approach: "None yet" → three documented routes (GNW, RSK, row-by-row) with the recommendation
  - Approaches tried: 0 → 4 (LGV, corner recursion, row-by-row dispatch, housekeeping) with one-line outcomes
  - Blockers: "None" → two real blockers (file size beyond Docker 32 GB envelope; probabilistic toolkit needed for GNW Route A)
  - Next Action: "OBSERVE: read BallotProblemOQ03OQ02.lean" → concrete `Core + RowCases` module split followed by Route A
- **`knowledge.md`**: appended a Session 34 (2026-05-01) entry documenting the reconciliation and the verification that `meta.json` fields (`sorries: 1`, `axiomCount: 0`, `lineCount: 14022`, `status: formalized`) still match the Lean file.

## Verification

Verified against `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean`:
- 14 022 lines (matches `meta.json:lineCount`)
- 1 real `sorry` after stripping comments/docstrings, at line 13932 inside the `hook_walk_identity` ≥10×≥10 non-rectangular branch
- 0 `axiom` declarations
- 482 theorem/lemma declarations + 21 `def` declarations
- Other `sorry` occurrences are inside docstrings/comments, not code

The Lean file is **unchanged**; `meta.json` is **unchanged**.

## Why this matters

This drift is exactly the failure mode flagged by the project's "stale candidate-pool entries" guidance: a researcher arriving fresh and reading only `state.md` would have wasted a session re-doing observation steps that have already happened 33 times. Bringing `state.md` current ensures the next researcher (likely tackling Route A — deterministic GNW) starts from the right place.

## Test plan

- [x] `meta.json` matches Lean file (sorries, axiomCount, lineCount)
- [x] Lean file unchanged — no compile risk introduced
- [x] state.md and knowledge.md remain valid Markdown
- [x] No code paths or import statements touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)