### PR TITLE
fix(erdos-710): remove phantom section identifiers and correct section overlap

### DIFF
--- a/src/data/proofs/erdos-710/meta.json
+++ b/src/data/proofs/erdos-710/meta.json
@@ -94,18 +94,18 @@
     {
       "id": "constraint-analysis",
       "title": "Divisibility Constraint Analysis",
-      "summary": "multiplesInInterval, multiples_sparse",
+      "summary": "multiplesInInterval definition: counting multiples of d in an interval",
       "startLine": 89,
       "endLine": 112,
-      "mathContext": "Mathematical content: multiplesInInterval, multiples_sparse"
+      "mathContext": "Mathematical content: multiplesInInterval definition"
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
-      "summary": "erdos_pomerance_lower_bound, erdos_pomerance_upper_bound, bounds_gap",
+      "summary": "erdos_pomerance_lower_bound axiom, erdos_pomerance_upper_bound axiom",
       "startLine": 113,
       "endLine": 152,
-      "mathContext": "Bound: erdos_pomerance_lower_bound, erdos_pomerance_upper_bound, bounds_gap"
+      "mathContext": "Bound: erdos_pomerance_lower_bound axiom, erdos_pomerance_upper_bound axiom"
     },
     {
       "id": "open-problem",
@@ -125,24 +125,24 @@
     {
       "id": "heuristics",
       "title": "Heuristic Analysis",
-      "summary": "constraintDensity, critical_constraint_heuristic",
+      "summary": "smallest_multiple_bound theorem: greedy algorithm bound for divisibility matching",
       "startLine": 230,
       "endLine": 263,
-      "mathContext": "Mathematical content: constraintDensity, critical_constraint_heuristic"
+      "mathContext": "Verified: smallest_multiple_bound theorem"
     },
     {
       "id": "greedy",
       "title": "Greedy Algorithm Insight",
-      "summary": "smallest_multiple_bound theorem",
+      "summary": "Part VIII related-problems notes and fValues placeholder sequence",
       "startLine": 264,
-      "endLine": 290,
-      "mathContext": "Verified: smallest_multiple_bound theorem"
+      "endLine": 273,
+      "mathContext": "Related: Part VIII connection notes and fValues placeholder"
     },
     {
       "id": "main-results",
       "title": "Main Results Summary",
       "summary": "erdos_710_summary theorem",
-      "startLine": 275,
+      "startLine": 274,
       "endLine": 320,
       "mathContext": "Verified: erdos_710_summary theorem"
     }


### PR DESCRIPTION
## Fix

Three section summaries in `erdos-710/meta.json` referenced non-existent Lean identifiers, and two sections overlapped.

## Evidence

**Phantom identifiers (identifiers appear in summaries but have no declaration in the Lean file):**

| Section | Phantom | Actual content at those lines |
|---------|---------|-------------------------------|
| `constraint-analysis` | `multiples_sparse` | Docstring text: "For large k, multiples are sparse" (lines 101-105) — prose only |
| `known-bounds` | `bounds_gap` | Docstring title: "**Gap Between Bounds:**" (lines 133-137) — prose only |
| `heuristics` | `critical_constraint_heuristic` | Docstring: "**Critical Constraint:**" (lines 230-234) — prose only |
| `heuristics` | `constraintDensity` | At line 227, inside `examples` range (176-229), not in `heuristics` (230-263) |

**Section overlap:**
- `greedy` claimed lines 264-290; `main-results` claimed lines 275-320 → 16-line overlap at 275-290
- Actual greedy content (`smallest_multiple_bound`) is at lines 246-260, inside `heuristics` range
- Lines 264-273 contain: Part VIII "Connection to Related Problems" comment + `fValues` def

**After:**
- Phantom identifiers removed from all three section summaries
- `heuristics` summary updated to reflect actual content: `smallest_multiple_bound` theorem (lines 246-260)
- `greedy` endLine: 290 → 273 (eliminates overlap)
- `greedy` summary updated to "Part VIII related-problems notes and fValues placeholder sequence"
- `main-results` startLine: 275 → 274 (starts at Part IX comment opening `/-`)

---
Automated fix by lean-mechanic agent.