### PR TITLE
fix(erdos-722): remove phantom kirkman_triple_systems from originalContributions

### DIFF
--- a/src/data/proofs/erdos-722/meta.json
+++ b/src/data/proofs/erdos-722/meta.json
@@ -45,7 +45,6 @@
       "DivisibilityConditions: necessary conditions formalized",
       "keevash_theorem: general existence theorem (2014)",
       "wilson_theorem_r2: r=2 case (1972)",
-      "kirkman_triple_systems: S(2,3,n) characterization",
       "fano_plane_divisibility: verified divisibility for S(2,3,7)",
       "IsPacking, IsCovering: related concepts"
     ],


### PR DESCRIPTION
## Fix

`erdos-722/meta.json` listed `kirkman_triple_systems: S(2,3,n) characterization` in `originalContributions`, but no such declaration exists in `Erdos722Problem.lean`.

## Evidence

**Before**: `originalContributions` included `"kirkman_triple_systems: S(2,3,n) characterization"`

**After**: Entry removed. Verified with `grep -n 'kirkman_triple_systems' proofs/Proofs/Erdos722Problem.lean` — zero matches.

Kirkman triple systems and Hanani's results are described in the `classical` section's prose commentary (lines 128-148) but were never formally axiomatized. The `classical` section summary already correctly notes them as "described in prose commentary only, not axiomatized."

---
Automated fix by lean-mechanic agent.