### PR TITLE
fix(erdos-729): remove phantom identifiers from section summaries

### DIFF
--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -112,8 +112,8 @@
       "title": "Proof Strategy",
       "startLine": 132,
       "endLine": 140,
-      "summary": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component.",
-      "mathContext": "Axiomatizes `proof_extends_erdos_argument`: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition, since the correction factor $k$ has no $p$-component."
+      "summary": "Prose discussion of the proof strategy: for primes $p > C$, the $p$-adic constraint $v_p(a!) + v_p(b!) \\leq v_p(n!)$ holds even under the relaxed condition. No axiom declaration in this range — description only.",
+      "mathContext": "Prose description of proof strategy for relaxed divisibility. No axiom declaration in this range."
     },
     {
       "id": "legendre-details",
@@ -128,8 +128,8 @@
       "title": "Implications and Rigidity",
       "startLine": 163,
       "endLine": 184,
-      "summary": "Axiomatizes `factorial_rigidity` and proves `binomial_rigidity`: when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer (proved via `Nat.choose_mul_factorial_mul_factorial`).",
-      "mathContext": "Axiomatized: Axiomatizes `factorial_rigidity` and proves `binomial_rigidity`: when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer (proved via `Nat.choose_mul_factorial_mul_factorial`)."
+      "summary": "Proves `binomial_rigidity`: when $a + b = n$, $n!/(a!b!) = \\binom{n}{a}$ is always an integer (proved via `Nat.choose_mul_factorial_mul_factorial`). Prose docstring notes the rigidity of factorial structure.",
+      "mathContext": "Verified: proves `binomial_rigidity` via Nat.choose_mul_factorial_mul_factorial."
     },
     {
       "id": "main-statement",


### PR DESCRIPTION
## Fix

Two section summaries in `erdos-729/meta.json` claimed Lean declarations that do not exist.

## Evidence

**proof-strategy section (lines 132-140):**
- Before: "Axiomatizes `proof_extends_erdos_argument`: ..."
- Verified: `grep -n 'proof_extends_erdos_argument' proofs/Proofs/Erdos729Problem.lean` → zero matches
- Lines 132-140 contain only a Part 6 comment (lines 132-136), an empty line, and a dangling docstring (lines 138-140) with no following Lean declaration
- After: "Prose discussion of the proof strategy ... No axiom declaration in this range."

**implications section (lines 163-184):**
- Before: "Axiomatizes `factorial_rigidity` and proves `binomial_rigidity`..."
- Verified: `grep -n 'factorial_rigidity' proofs/Proofs/Erdos729Problem.lean` → zero matches
- Lines 163-184 contain a Part 8 comment, a prose docstring about "rigidity," and `binomial_rigidity` theorem (line 172)
- After: "Proves `binomial_rigidity` ... Prose docstring notes the rigidity of factorial structure."

---
Automated fix by lean-mechanic agent.