### PR TITLE
audit(erdos-695): mark clean — section line ranges and counts verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8503,10 +8503,10 @@
       "result": "clean"
     },
     "erdos-695": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T03:25:00Z",
+      "result": "clean"
     },
     "erdos-696": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited erdos-695 against origin/main after the recent fix in #14062.

## Verification (against origin/main)

- **sorries**: 1 ✓ (matches Lean: `conjecture_implies_question2`)
- **axiomCount**: 1 ✓ (matches Lean: `small_prime_conjecture`)
- **status**: `axiomatized` / **badge**: `axiom` ✓
- **sections**: all 7 startLine/endLine ranges correct against `proofs/Proofs/Erdos695Problem.lean`
- **originalContributions**: every item maps to a declaration in the Lean file

No issues found.

## Test plan
- [x] Verified meta.json matches Lean source declarations
- [x] Verified section line ranges
- [x] No sorry/axiom drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)