### PR TITLE
fix(erdos-730): correct conjecture section to remove phantom axiom claim

### DIFF
--- a/src/data/proofs/erdos-730/meta.json
+++ b/src/data/proofs/erdos-730/meta.json
@@ -74,8 +74,8 @@
       "title": "Main Conjecture",
       "startLine": 44,
       "endLine": 47,
-      "summary": "Axiomatizes the EGRS conjecture: `Set.Infinite CentralBinomPairs`. Stated as an axiom reflecting the open status of the problem.",
-      "mathContext": "Axiomatized: Set.Infinite CentralBinomPairs (docstring + one-line axiom)"
+      "summary": "Prose statement of the open conjecture — no axiom declaration in this range. Lines 44–47 contain only a section comment and a docstring describing the EGRS conjecture. The conjecture `Set.Infinite CentralBinomPairs` is open and not formally axiomatized here.",
+      "mathContext": "Mathematical content: open conjecture statement (prose only, no axiom declaration in lines 44–47)."
     },
     {
       "id": "examples",


### PR DESCRIPTION
## Fix

The `conjecture` section (lines 44–47) of `erdos-730/meta.json` falsely claimed to axiomatize `Set.Infinite CentralBinomPairs`. Inspection of `Erdos730Problem.lean` shows lines 44–47 contain only a section comment and docstring — no `axiom` declaration. The actual `axiomCount: 1` correctly counts only `triple_10003` at line 55.

## Evidence

**Before**: `"summary": "Axiomatizes the EGRS conjecture: \`Set.Infinite CentralBinomPairs\`. Stated as an axiom reflecting the open status of the problem."`

**After**: `"summary": "Prose statement of the open conjecture — no axiom declaration in this range. Lines 44–47 contain only a section comment and a docstring..."`

---
Automated fix by lean-mechanic agent.