### PR TITLE
audit(erdos-684): mark issues-found — 4 phantom identifiers in section summaries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8434,10 +8434,13 @@
       "result": "clean"
     },
     "erdos-684": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-foreground",
+      "auditCount": 3,
+      "issues": [
+        "phantom identifiers in section summaries: tang_bound, rh_conditional_bound, heuristic_conjecture, erdos_684_status (issue #14084)"
+      ],
+      "lastAudited": "2026-05-01T05:50:00Z",
+      "result": "issues-found"
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks `erdos-684` audit complete with `issues-found`. Filed as issue #14084 alongside this PR.

Audit findings:
- `axiomCount=2`, `sorries=0`, `status=axiomatized`, `badge=axiom` — all match Lean source ✓
- Section line ranges correct (recently fixed in #14066) ✓
- **Issue:** 4 phantom identifiers referenced in section summaries:
  - `tang_bound`, `rh_conditional_bound` (Modern Bounds section — only `tang_exponent`/`rh_exponent` defs exist)
  - `heuristic_conjecture` (Heuristic Conjectures — only `heuristic_bound` def exists)
  - `erdos_684_status` (Problem Status — only `erdos_684_statement` theorem exists)

Tracker entry updated to `issues-found` with link to #14084.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --next` no longer returns erdos-684 as oldest unaudited
- [x] Diff is minimal (single tracker entry)
- [x] No unicode escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)