### PR TITLE
audit(erdos-670): mark clean — meta matches Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8340,10 +8340,10 @@
       "result": "issues-fixed"
     },
     "erdos-670": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T03:35:26Z",
+      "result": "clean"
     },
     "erdos-671": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited erdos-670 (Diameter of Sets with Distinct Distances) and verified the gallery metadata is consistent with the Lean source.

### Verification (against `origin/main`)

| Field | meta.json | Erdos670Problem.lean | Match |
|-------|-----------|----------------------|-------|
| lineCount | 157 | 157 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| sorries | 0 | 0 | ✓ |

Axioms in source: `trivial_gives_half`, `erdos_1997_d1` — match `assumptions` field exactly.

All 12 `originalContributions` identifiers (`PointSet`, `dist'`, `DistinctDistances`, `diameter`, `MainConjecture`, `WeakConjecture`, `trivial_gives_half`, `RealPointSet`, `RealDistinctDistances`, `realDiameter`, `arithmeticProgression`, `SuperlinearConjecture`, `erdos_670_summary`) are present in the file. No phantom section identifiers (sections have empty `identifiers` arrays). Status `axiomatized` + badge `axiom` is correct for the `d ≥ 2` open case.

### Tracker

Marked `auditCount: 2 → 3`, `result: issues-fixed → clean`, `lastAudited: 2026-05-01`.

## Test plan

- [x] `git show origin/main:proofs/Proofs/Erdos670Problem.lean` axiom/sorry counts match meta
- [x] All `originalContributions` identifiers grep-confirmed in source
- [x] Tracker diff contains only the erdos-670 entry (no unicode escape pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)