### PR TITLE
fix(erdos-732): remove phantom example_n3 from examples section summary

### DIFF
--- a/src/data/proofs/erdos-732/meta.json
+++ b/src/data/proofs/erdos-732/meta.json
@@ -150,10 +150,10 @@
     {
       "id": "examples",
       "title": "Concrete Examples",
-      "summary": "Axiomatizes example_n3 (IsBlockCompatible [3] 3) and verifies pair-counting for n=4 ([4] and [2,2,2,2,2,2]) and n=6 ([3,3,3,3,3]) using simp/norm_num.",
+      "summary": "Verifies PairCountCondition for n=4 ([4] and [2,2,2,2,2,2]) and n=6 ([3,3,3,3,3]) via anonymous `example` blocks using simp/norm_num. Docstrings describe the n=3 case. No named declaration — `example_n3` does not exist as a theorem or axiom.",
       "startLine": 219,
       "endLine": 257,
-      "mathContext": "Axiomatized: Axiomatizes example_n3 (IsBlockCompatible [3] 3) and verifies pair-counting for n=4 ([4] and [2,2,2,2,2,2]) and n=6 ([3,3,3,3,3]) using simp/norm_num."
+      "mathContext": "Mathematical content: anonymous example blocks verifying PairCountCondition for specific sequences; n=3 case is docstring only."
     },
     {
       "id": "related",


### PR DESCRIPTION
## Fix

The \`examples\` section (L219–257) of \`erdos-732/meta.json\` claimed:
> "Axiomatizes example_n3 (IsBlockCompatible [3] 3)..."

But no \`axiom example_n3\` or \`theorem example_n3\` exists in \`Erdos732Problem.lean\`. The section contains only anonymous \`example\` blocks verifying \`PairCountCondition\` for specific sequences; the n=3 case is docstring-only prose.

## Evidence

**Before**: \`"Axiomatized: Axiomatizes example_n3 (IsBlockCompatible [3] 3)..."\`

**After**: \`"Mathematical content: anonymous example blocks verifying PairCountCondition for specific sequences; n=3 case is docstring only."\`

---
Automated fix by lean-mechanic agent.