### PR TITLE
fix(erdos-733): correct section line ranges to match actual file structure

### DIFF
--- a/src/data/proofs/erdos-733/meta.json
+++ b/src/data/proofs/erdos-733/meta.json
@@ -132,32 +132,32 @@
     {
       "id": "upper-bound",
       "title": "Upper Bound",
-      "summary": "f(n) ≤ exp(C√n) via Szemerédi-Trotter.",
+      "summary": "upper_bound axiom (L166): f(n) ≤ exp(C√n) via Szemerédi-Trotter. Lines 163–184 only.",
       "startLine": 163,
-      "endLine": 191,
+      "endLine": 184,
       "mathContext": "Szemerédi-Trotter limits the number of $k$-rich lines, which bounds the possible sequence patterns to $\\exp(O(\\sqrt{n}))$."
     },
     {
       "id": "main-result",
       "title": "The Main Result",
-      "summary": "tight_bounds combining lower and upper, erdos_733 main theorem.",
-      "startLine": 192,
+      "summary": "tight_bounds theorem (L185) combining lower and upper bounds. erdos_733 main theorem (L199). limitConstant def (L222).",
+      "startLine": 185,
       "endLine": 228,
       "mathContext": "$\\exp(c\\sqrt{n}) \\leq f(n) \\leq \\exp(C\\sqrt{n})$, i.e., $f(n) = \\exp(\\Theta(\\sqrt{n}))$."
     },
     {
       "id": "limit-question",
       "title": "The Limit Question",
-      "summary": "limitConstant: does lim log(f(n))/√n exist? What is its value?",
+      "summary": "limit_bounds theorem (L232): lim log(f(n))/√n ∈ [c, C]. erdos_733_summary (L252) is in the summary section.",
       "startLine": 229,
-      "endLine": 254,
+      "endLine": 251,
       "mathContext": "$\\lim_{n \\to \\infty} \\frac{\\log f(n)}{\\sqrt{n}} \\in [c, C]$ if the limit exists. An interesting follow-up posed by Erdős."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Complete solution summary and erdos_733_answer theorem.",
-      "startLine": 255,
+      "summary": "erdos_733_summary theorem (L252) and erdos_733_answer theorem (L267): complete solution summary.",
+      "startLine": 252,
       "endLine": 274,
       "mathContext": "Erdős #733 fully resolved: $f(n) = \\exp(\\Theta(\\sqrt{n}))$ by Szemerédi-Trotter (1983)."
     }


### PR DESCRIPTION
## Fix

Four sections in \`erdos-733/meta.json\` had incorrect line ranges, causing sections to claim declarations that fall outside their stated range:

| Section | Issue | Fix |
|---------|-------|-----|
| \`upper-bound\` | endLine 191 but \`tight_bounds\` is at L185 → misallocated | endLine 191→184 |
| \`main-result\` | startLine 192, missing \`tight_bounds\` (L185) | startLine 192→185 |
| \`limit-question\` | endLine 254 but \`erdos_733_summary\` is at L252 → misallocated | endLine 254→251 |
| \`summary\` | startLine 255, missing \`erdos_733_summary\` (L252) | startLine 255→252 |

## Evidence

**Before**: \`main-result\` claimed \`tight_bounds\` but its startLine (192) was after L185; \`summary\` claimed \`erdos_733_summary\` but its startLine (255) was after L252.

**After**: Each section's startLine/endLine correctly brackets the declarations it describes.

---
Automated fix by lean-mechanic agent.