### PR TITLE
audit(erdos-669): mark issues-found — phantom identifiers

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8328,10 +8328,13 @@
       "result": "clean"
     },
     "erdos-669": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-2026-05-01",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T03:50:00Z",
+      "result": "issues-found",
+      "issues": [
+        "4 phantom identifiers (burr_grunbaum_sloane, trivial_upper_bound, limit_upper, optimal_configs_exist) in section summaries; section line ranges drift; missing summary section — issue #14091"
+      ]
     },
     "erdos-67": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Mark erdos-669 audit as `issues-found` after spotting 4 phantom identifiers in `meta.json` section summaries (`burr_grunbaum_sloane`, `trivial_upper_bound`, `limit_upper`, `optimal_configs_exist`). These appear only as docstring titles, never as Lean `def`/`theorem`/`axiom` declarations. Section line ranges also drift from the actual file structure. Filed as #14091.

This PR only updates the audit tracker — the meta.json fix lives in #14091.

## Test plan
- [x] Tracker JSON reparses
- [x] No unicode escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)