### PR TITLE
fix(erdos-760): correct section summaries to remove phantom declaration claims

### DIFF
--- a/src/data/proofs/erdos-760/meta.json
+++ b/src/data/proofs/erdos-760/meta.json
@@ -107,14 +107,14 @@
     {
       "id": "erdos-gimbel",
       "title": "Erdős-Gimbel Partial Result",
-      "summary": "aks_theorem (axiom, AKS bound ζ(H) ≥ cm/log m), erdos_760_solved (theorem reducing to aks_theorem)",
+      "summary": "Prose description of the Erdős-Gimbel (1993) weaker bound ζ(H) ≥ c√(m/log m) — docstrings only, no formal declarations in lines 124–138.",
       "startLine": 124,
       "endLine": 138
     },
     {
       "id": "aks-theorem",
       "title": "Alon-Krivelevich-Sudakov Theorem",
-      "summary": "Body of erdos_760_solved and proof technique commentary (no new declarations)",
+      "summary": "axiom aks_theorem (L152): AKS bound ζ(H) ≥ cm/log m. theorem erdos_760_solved (L164): forwards to aks_theorem.",
       "startLine": 139,
       "endLine": 171
     },
@@ -128,14 +128,14 @@
     {
       "id": "related",
       "title": "Related Results",
-      "summary": "erdos_760 summary theorem (lines 224–230, reduces to aks_theorem)",
+      "summary": "Section comment and docstring on Ramsey number connections — no formal declarations in lines 185–193.",
       "startLine": 185,
       "endLine": 193
     },
     {
       "id": "summary",
       "title": "Main Results Summary",
-      "summary": "Closing namespace (end Erdos760)",
+      "summary": "erdos_760 theorem (L224): main result forwards to aks_theorem. Closes namespace.",
       "startLine": 194,
       "endLine": 232
     }


### PR DESCRIPTION
## Fix

Four section summaries in \`erdos-760/meta.json\` had incorrect claims about which declarations they contain:

| Section | Issue | Fix |
|---------|-------|-----|
| \`erdos-gimbel\` [124-138] | Claimed \`aks_theorem\` and \`erdos_760_solved\` — but those are at L152/L164, outside this range | Updated to reflect docstrings-only content |
| \`aks-theorem\` [139-171] | Claimed "no new declarations" — but \`aks_theorem\` (L152) and \`erdos_760_solved\` (L164) ARE here | Added the correct declaration references |
| \`related\` [185-193] | Claimed \`erdos_760\` theorem at "lines 224-230" — those lines are outside this section | Updated to reflect docstrings-only content |
| \`summary\` [194-232] | Said only "Closing namespace" — misses \`theorem erdos_760\` at L224 | Added the theorem reference |

## Evidence

**Before**: \`erdos-gimbel\` claimed \`"aks_theorem (axiom, AKS bound...)\`" but it's at L152 outside the section.

**After**: \`aks-theorem\` correctly states \`"axiom aks_theorem (L152)... theorem erdos_760_solved (L164)"\`.

---
Automated fix by lean-mechanic agent.