### PR TITLE
audit(erdos-67): mark clean — Tao discrepancy axiomatization properly disclosed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8335,9 +8335,9 @@
     },
     "erdos-67": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T03:44:01Z",
+      "result": "clean"
     },
     "erdos-670": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks `erdos-67` (Erdős Discrepancy Problem, solved by Tao 2015) audit complete with `clean`.

## Audit findings
- `axiomCount=1` matches: `erdosDiscrepancy` axiom at line 84 ✓
- `sorries=0` matches Lean source ✓
- `lineCount=187`, `theoremCount=2`, `definitionCount=7` all accurate ✓
- `status=axiomatized` + `badge=axiom` correctly signal Tier C (axiomatized scaffold) ✓
- `assumptions` field, `originalContributions`, and `proofStrategy` all explicitly disclose that Tao's theorem is stated as an axiom ✓
- Section line ranges align with Lean structure (imports 1-27, definitions 43-66 contains discrepancy/hasBoundedDiscrepancy/isPlusMinusOne, main-theorem 67-97 contains erdosDiscrepancy axiom + noBoundedDiscrepancy theorem, etc.) ✓
- Section summaries are general; no phantom identifiers referenced ✓

The two derived theorems (`noBoundedDiscrepancy` line 91, `no_discrepancy_2_sequence` line 182) are genuinely proved (not `:= by sorry`).

Tracker entry updated: `auditCount` 2→3, `result` `issues-fixed`→`clean`, `lastAudited` refreshed.

## Test plan
- [x] Diff is minimal (3 lines, single tracker entry)
- [x] No unicode escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)