### PR TITLE
fix(erdos-698): replace phantom erdos_szekeres_bound with correct declaration name

### DIFF
--- a/src/data/proofs/erdos-698/meta.json
+++ b/src/data/proofs/erdos-698/meta.json
@@ -106,7 +106,7 @@
     {
       "id": "erdos-szekeres",
       "title": "Erdős-Szekeres Observation",
-      "summary": "isValidPair, erdos_szekeres_bound, exponential bound, gcd_always_gt_one",
+      "summary": "isValidPair predicate (L64), axiom erdos_szekeres_exponential (L77): gcd ≥ 2^i bound, theorem gcd_always_gt_one (L85). Note: erdos_szekeres_bound is a phantom — the actual axiom is erdos_szekeres_exponential.",
       "startLine": 57,
       "endLine": 94,
       "mathContext": "Erdős-Szekeres: $\\forall 2 \\leq i < j \\leq n/2: g(n,i,j) > 1$. The GCD is never 1 for central binomial coefficients. Proved via shared prime divisors from Kummer's theorem."


### PR DESCRIPTION
## Fix

The `erdos-szekeres` section summary in `meta.json` listed `erdos_szekeres_bound` as a formal declaration, but no such identifier exists in `Erdos698Problem.lean`. The actual axiom at L77 is `erdos_szekeres_exponential`.

## Evidence

**Before**: `"summary": "isValidPair, erdos_szekeres_bound, exponential bound, gcd_always_gt_one"`

**After**: `"summary": "isValidPair predicate (L64), axiom erdos_szekeres_exponential (L77): gcd ≥ 2^i bound, theorem gcd_always_gt_one (L85). Note: erdos_szekeres_bound is a phantom — the actual axiom is erdos_szekeres_exponential."`

**Verification**: `grep -n "erdos_szekeres" proofs/Proofs/Erdos698Problem.lean` shows only `axiom erdos_szekeres_exponential` at L77.

---
Automated fix by lean-mechanic agent.