### PR TITLE
research(binary-gcd-oq-03-oq-02): HGCD skeleton + matrix-vector invariant

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -173,6 +173,7 @@ import Proofs.BinaryGcdOQ01OQ03
 import Proofs.BinaryGcdOQ01OQ04
 import Proofs.BinaryGcdOQ03
 import Proofs.BinaryGcdOQ03OQ01
+import Proofs.BinaryGcdOQ03OQ02
 import Proofs.BinomialTheorem
 import Proofs.BinomialTheoremOQ01
 import Proofs.BinomialTheoremOQ01Aristotle

--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -75,16 +75,18 @@ def hgcdMatrix : (fuel a b : ℕ) → CofactorMatrix
       CofactorMatrix.id
     else
       -- Step 1: reduce on the top half of the bits.
-      let M₁ := hgcdTopHalfStep a b
-      -- Apply M₁ to the full pair to get the half-reduced pair.
-      let (a₁, b₁) := applyToNat M₁ a b
-      if h : max a₁ b₁ < 2 ^ hgcdThreshold then
-        M₁
+      -- Step 2: recurse on the reduced pair, compose, and return.
+      -- (Branching on whether the half-reduced pair is small enough
+      --  to skip the recursive call.)
+      if (max (applyToNat (hgcdTopHalfStep a b) a b).1
+              (applyToNat (hgcdTopHalfStep a b) a b).2)
+          < 2 ^ hgcdThreshold then
+        hgcdTopHalfStep a b
       else
-        -- Step 2: recurse on the reduced pair.
-        let M₂ := hgcdMatrix fuel a₁ b₁
-        -- Compose: M₂ acts after M₁ on the original pair.
-        M₂.mul M₁
+        (hgcdMatrix fuel
+            (applyToNat (hgcdTopHalfStep a b) a b).1
+            (applyToNat (hgcdTopHalfStep a b) a b).2).mul
+          (hgcdTopHalfStep a b)
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART II: DETERMINANT IS ±1
@@ -97,23 +99,34 @@ theorem hgcdTopHalfStep_det_unit (a b : ℕ) :
   unfold hgcdTopHalfStep
   exact lehmerCofactors_det_unit _ _ _ _ (Or.inl CofactorMatrix.det_id)
 
-/-- The recursive HGCD matrix has determinant `±1`. -/
+/-- Helper: a product of two `±1` integers is itself `±1`. -/
+private theorem mul_unit_of_unit_of_unit {x y : ℤ}
+    (hx : x = 1 ∨ x = -1) (hy : y = 1 ∨ y = -1) :
+    x * y = 1 ∨ x * y = -1 := by
+  rcases hx with hx | hx <;> rcases hy with hy | hy <;>
+    subst hx <;> subst hy <;> simp
+
+/-- The recursive HGCD matrix has determinant `±1`.
+
+    Proof is by induction on the fuel. The fuel-zero case returns the
+    identity matrix (det = 1). At successor fuel the definition has two
+    nested `if`s; we branch on each and use `hgcdTopHalfStep_det_unit`
+    plus the inductive hypothesis. The composed case uses
+    `CofactorMatrix.det_mul`. -/
 theorem hgcdMatrix_det_unit (fuel a b : ℕ) :
     (hgcdMatrix fuel a b).det = 1 ∨ (hgcdMatrix fuel a b).det = -1 := by
   induction fuel generalizing a b with
   | zero => left; exact CofactorMatrix.det_id
   | succ n ih =>
-    unfold hgcdMatrix
-    split_ifs
+    simp only [hgcdMatrix]
+    split_ifs with h₁ h₂
     · left; exact CofactorMatrix.det_id
     · exact hgcdTopHalfStep_det_unit a b
-    · -- Composed case: det(M₂ · M₁) = det M₂ · det M₁; both ±1.
-      rw [CofactorMatrix.det_mul]
-      rcases ih (applyToNat (hgcdTopHalfStep a b) a b).1
-                (applyToNat (hgcdTopHalfStep a b) a b).2 with h2 | h2 <;>
-      rcases hgcdTopHalfStep_det_unit a b with h1 | h1 <;>
-      [left; right; right; left] <;>
-      simp [h1, h2]
+    · rw [CofactorMatrix.det_mul]
+      exact mul_unit_of_unit_of_unit
+        (ih (applyToNat (hgcdTopHalfStep a b) a b).1
+            (applyToNat (hgcdTopHalfStep a b) a b).2)
+        (hgcdTopHalfStep_det_unit a b)
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART III: GCD PRESERVATION

--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -23,6 +23,21 @@
   All cofactor-matrix machinery (det, mul, apply, GCD invariance under
   unimodular matrices) is reused from `BinaryGcdOQ03.lean`.
 
+  **Cofactor convention.** `lehmerCofactors` accumulates the cofactor
+  matrix in the row-vector convention: each Lehmer step `S_k`
+  right-multiplies the accumulator (`M' = M · S_k`), so the invariant
+  maintained is `(a₀, b₀) · M = (current pair)`.
+
+  Consequently this file's `applyToNat M a b` performs the row-vector
+  product `(a, b) · M = (a·M.α + b·M.γ, a·M.β + b·M.δ)`, *not* the
+  column-vector `M.apply` from `BinaryGcdOQ03.lean`. Both products
+  preserve `Nat.gcd` when `det M = ±1`, but only the row product yields
+  the actual reduced pair from the iterated Lehmer steps. The
+  composition order in `hgcdMatrix` (`M_top.mul M_rec`, with the top
+  step on the *left*) is similarly chosen so that
+  `(a, b) · (M_top · M_rec) = ((a, b) · M_top) · M_rec` matches "apply
+  the top-half step first, then recurse".
+
   References:
   - Schönhage (1971), "Schnelle Berechnung von Kettenbruchentwicklungen"
   - Brent & Zimmermann, "Modern Computer Arithmetic", §1.6.3
@@ -59,15 +74,34 @@ def hgcdTopHalfStep (a b : ℕ) : CofactorMatrix :=
   lehmerCofactors n aHi bHi CofactorMatrix.id
 
 /-- Apply a cofactor matrix to a non-negative pair, taking absolute values
-    of the result. In the algorithm both components remain non-negative
-    when the matrix is correctly accumulated; this is a safety wrapper. -/
+    of the result.
+
+    **Convention.** `lehmerCofactors` accumulates the cofactor matrix in the
+    *row-vector* convention: each Lehmer step `S_k` right-multiplies the
+    accumulator (`M' = M · S_k`), so the invariant maintained is
+    `(a₀, b₀) · M = (current pair)`. Hence "applying" `M` to `(a, b)` to
+    obtain the Lehmer-reduced pair means computing the row-vector product
+    `(a, b) · M = (a·M.α + b·M.γ, a·M.β + b·M.δ)`.
+
+    This is *not* the column-vector product `M.apply (a, b)` from
+    `BinaryGcdOQ03.lean` (which would give `(M.α·a + M.β·b, M.γ·a + M.δ·b)`).
+    Both products preserve `Nat.gcd` when `det M = ±1`, but only the
+    row-vector product yields the actual reduced pair from the iterated
+    Lehmer steps. See knowledge.md / state.md for the worked counterexample
+    `(a, b) = (1000, 300)` where the column form does *not* reduce. -/
 def applyToNat (M : CofactorMatrix) (a b : ℕ) : ℕ × ℕ :=
-  let (u, v) := M.apply (↑a) (↑b)
+  let u : ℤ := (a : ℤ) * M.α + (b : ℤ) * M.γ
+  let v : ℤ := (a : ℤ) * M.β + (b : ℤ) * M.δ
   (u.natAbs, v.natAbs)
 
 /-- Recursive HGCD with explicit fuel. Returns a cofactor matrix `M` whose
     determinant is `±1` and which preserves `Nat.gcd`. The size-reduction
-    property is stated separately. -/
+    property is stated separately.
+
+    The recursive composition order — `M_top.mul M_rec` rather than
+    `M_rec.mul M_top` — matches the row-vector convention: row-applying
+    the composite is `(a, b) · M_top · M_rec`, i.e. apply the top-half
+    step first, then apply the recursive matrix to the reduced pair. -/
 def hgcdMatrix : (fuel a b : ℕ) → CofactorMatrix
   | 0,        _, _ => CofactorMatrix.id
   | fuel + 1, a, b =>
@@ -83,10 +117,10 @@ def hgcdMatrix : (fuel a b : ℕ) → CofactorMatrix
           < 2 ^ hgcdThreshold then
         hgcdTopHalfStep a b
       else
-        (hgcdMatrix fuel
+        (hgcdTopHalfStep a b).mul
+          (hgcdMatrix fuel
             (applyToNat (hgcdTopHalfStep a b) a b).1
-            (applyToNat (hgcdTopHalfStep a b) a b).2).mul
-          (hgcdTopHalfStep a b)
+            (applyToNat (hgcdTopHalfStep a b) a b).2)
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART II: DETERMINANT IS ±1
@@ -124,21 +158,39 @@ theorem hgcdMatrix_det_unit (fuel a b : ℕ) :
     · exact hgcdTopHalfStep_det_unit a b
     · rw [CofactorMatrix.det_mul]
       exact mul_unit_of_unit_of_unit
+        (hgcdTopHalfStep_det_unit a b)
         (ih (applyToNat (hgcdTopHalfStep a b) a b).1
             (applyToNat (hgcdTopHalfStep a b) a b).2)
-        (hgcdTopHalfStep_det_unit a b)
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART III: GCD PRESERVATION
 -- ═══════════════════════════════════════════════════════════════
 
-/-- Applying `hgcdMatrix` to `(a, b)` preserves the GCD. This is an
-    immediate consequence of `cofactor_apply_gcd` together with
-    `hgcdMatrix_det_unit`. -/
+/-- Applying `hgcdMatrix` to `(a, b)` (row convention) preserves the GCD.
+    This is the row-vector analogue of `cofactor_apply_gcd`; it follows from
+    `gcd_cofactor_eq` applied to the relabelled coefficients
+    `(α, β, γ, δ) ← (M.α, M.γ, M.β, M.δ)`, since the determinant condition
+    `α·δ - β·γ = M.α·M.δ - M.γ·M.β = M.det = ±1` is symmetric under the
+    swap `β ↔ γ`. -/
 theorem hgcdMatrix_apply_gcd (fuel a b : ℕ) :
     let M := hgcdMatrix fuel a b
-    Int.gcd (M.α * (↑a : ℤ) + M.β * ↑b) (M.γ * ↑a + M.δ * ↑b) = Nat.gcd a b := by
-  exact cofactor_apply_gcd (hgcdMatrix_det_unit fuel a b)
+    Int.gcd ((↑a : ℤ) * M.α + ↑b * M.γ) ((↑a : ℤ) * M.β + ↑b * M.δ)
+      = Nat.gcd a b := by
+  set M := hgcdMatrix fuel a b
+  have hdet : M.α * M.δ - M.γ * M.β = 1 ∨ M.α * M.δ - M.γ * M.β = -1 := by
+    have h := hgcdMatrix_det_unit fuel a b
+    simp only [CofactorMatrix.det] at h
+    rcases h with h | h
+    · left; linarith
+    · right; linarith
+  have h := gcd_cofactor_eq (α := M.α) (β := M.γ) (γ := M.β) (δ := M.δ)
+              (a := a) (b := b) hdet
+  -- h : Int.gcd (M.α * ↑a + M.γ * ↑b) (M.β * ↑a + M.δ * ↑b) = Nat.gcd a b
+  -- Goal differs only by commutativity of `*` on `ℤ`.
+  have eq1 : (↑a : ℤ) * M.α + ↑b * M.γ = M.α * ↑a + M.γ * ↑b := by ring
+  have eq2 : (↑a : ℤ) * M.β + ↑b * M.δ = M.β * ↑a + M.δ * ↑b := by ring
+  rw [eq1, eq2]
+  exact h
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART IV: SIZE REDUCTION (the genuinely new content)
@@ -212,8 +264,23 @@ example : (hgcdMatrix 5 7 3).det = 1 ∨ (hgcdMatrix 5 7 3).det = -1 :=
 
 example :
     let M := hgcdMatrix 4 5 3
-    Int.gcd (M.α * (5 : ℤ) + M.β * 3) (M.γ * 5 + M.δ * 3) = Nat.gcd 5 3 :=
+    Int.gcd ((5 : ℤ) * M.α + (3 : ℤ) * M.γ) ((5 : ℤ) * M.β + (3 : ℤ) * M.δ)
+      = Nat.gcd 5 3 :=
   hgcdMatrix_apply_gcd 4 5 3
+
+/-- **Convention sanity check.** For `(a, b) = (1000, 300)` the top-half
+    Lehmer step extracts `aHi = 31, bHi = 9` (`shift = 5`) and runs two
+    cofactor steps, yielding `M = ⟨1, -2, -3, 7⟩`.
+
+    * Row-apply (this file's convention):
+      `(1000·1 + 300·(-3), 1000·(-2) + 300·7) = (100, 100)` — reduced.
+    * Column-apply (the previous, *incorrect*, convention):
+      `(1·1000 + (-2)·300, (-3)·1000 + 7·300) = (400, -900)` — *not* reduced.
+
+    Both pairs preserve `Nat.gcd 1000 300 = 100`, but only the row-apply
+    pair is a valid Lehmer reduction (max bit-size 7 < 10). -/
+example : applyToNat (hgcdTopHalfStep 1000 300) 1000 300 = (100, 100) := by
+  native_decide
 
 /-! ## Summary
 

--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -16,9 +16,12 @@
       because there is no bit-complexity model of arithmetic and no fast
       multiplication. Deferred -- documented as a Mathlib infrastructure gap.
 
-  This file establishes (A) and the structural skeleton for (B). The
-  size-reduction lemma is stated with the precise quantitative bound and
-  marked `sorry`; closing it is the focus of follow-up sessions.
+  This file establishes (A), the matrix-vector invariant that
+  underpins (B) (the row-vector relation `(a₀, b₀) · M = (current pair)`
+  for `M = lehmerCofactors fuel a₀ b₀ id`), and the structural
+  skeleton for (B). The size-reduction lemma itself is stated with
+  the precise quantitative bound and marked `sorry`; closing it is
+  the focus of follow-up sessions.
 
   All cofactor-matrix machinery (det, mul, apply, GCD invariance under
   unimodular matrices) is reused from `BinaryGcdOQ03.lean`.
@@ -193,7 +196,136 @@ theorem hgcdMatrix_apply_gcd (fuel a b : ℕ) :
   exact h
 
 -- ═══════════════════════════════════════════════════════════════
--- PART IV: SIZE REDUCTION (the genuinely new content)
+-- PART IV: MATRIX-VECTOR INVARIANT (foundational for size reduction)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Matrix-vector invariant for `lehmerCofactors`
+
+The maintained invariant of the Lehmer-step machine is that the
+accumulated cofactor matrix, applied (in row-vector convention) to
+the *original* pair, recovers the *current* pair after each step.
+
+Formally: if `(a₀, b₀)` is the initial pair (as integers, allowing
+the proof to track sign cleanly) and `M` is the cofactor accumulator
+at some intermediate step where the current pair is `(ahat, bhat)`,
+then:
+
+    a₀ * M.α + b₀ * M.γ = ahat
+    a₀ * M.β + b₀ * M.δ = bhat
+
+Starting from `M = id`, the relation holds trivially because
+`(a₀, b₀) · id = (a₀, b₀)`. We prove it carries through one step
+of `lehmerInnerStep`, then iterate to cover `lehmerCofactors`.
+
+This invariant is the foundation of the size-reduction argument
+for `hgcdMatrix_size_reduction`: combined with the bound
+`bhat_final ≤ bhat₀` (Euclidean-step monotonicity, separate
+lemma) and the determinant condition (Cramer inversion), it
+gives entry bounds on the cofactor matrix.
+
+The proof of `hgcdMatrix_size_reduction` itself is still `sorry`
+in PART V; this PART supplies the first of three components
+identified in the next-action plan in
+`research/problems/binary-gcd-oq-03-oq-02/state.md`. -/
+
+/-- Matrix-vector invariant for one Lehmer inner step.
+
+    Given a "ghost original pair" `(a₀, b₀)` consistent with the
+    current state `(ahat, bhat, M)` via the row-vector relation
+    `(a₀, b₀) · M = (ahat, bhat)`, the relation persists after one
+    `lehmerInnerStep` to the new state `(ahat', bhat', M')`.
+
+    Proof: unfold `lehmerInnerStep` to extract the form of the new
+    matrix entries (`α' = β`, `β' = α - q·β`, `γ' = δ`,
+    `δ' = γ - q·δ`) and the new pair (`ahat' = bhat`,
+    `bhat' = ahat % bhat`). The first conclusion is exactly `h_inv₂`;
+    the second follows from `h_inv₁ - q · h_inv₂` and
+    `Nat.div_add_mod`. -/
+theorem lehmerInnerStep_invariant {a₀ b₀ : ℤ} {ahat bhat : ℕ} {M : CofactorMatrix}
+    {ahat' bhat' : ℕ} {M' : CofactorMatrix}
+    (h_inv₁ : a₀ * M.α + b₀ * M.γ = (ahat : ℤ))
+    (h_inv₂ : a₀ * M.β + b₀ * M.δ = (bhat : ℤ))
+    (h_step : lehmerInnerStep ahat bhat M = some (ahat', bhat', M')) :
+    a₀ * M'.α + b₀ * M'.γ = (ahat' : ℤ) ∧
+    a₀ * M'.β + b₀ * M'.δ = (bhat' : ℤ) := by
+  simp [lehmerInnerStep] at h_step
+  split at h_step <;> simp_all
+  split at h_step <;> simp_all
+  -- Surviving case: bhat ≠ 0 and ahat % bhat ≠ 0; the some-equation
+  -- has reduced to the equality of the triples.
+  obtain ⟨rfl, rfl, rfl⟩ := h_step
+  refine ⟨?_, ?_⟩
+  · -- a₀ * M'.α + b₀ * M'.γ = a₀ * M.β + b₀ * M.δ = bhat
+    exact h_inv₂
+  · -- a₀ * (M.α - q·M.β) + b₀ * (M.γ - q·M.δ) = ahat % bhat
+    have expand :
+        a₀ * (M.α - ((ahat / bhat : ℕ) : ℤ) * M.β)
+          + b₀ * (M.γ - ((ahat / bhat : ℕ) : ℤ) * M.δ)
+        = (a₀ * M.α + b₀ * M.γ)
+            - ((ahat / bhat : ℕ) : ℤ) * (a₀ * M.β + b₀ * M.δ) := by ring
+    rw [expand, h_inv₁, h_inv₂]
+    -- Goal: (ahat : ℤ) - ↑(ahat/bhat) * (bhat : ℤ) = ↑(ahat % bhat)
+    -- From Nat.div_add_mod: bhat * (ahat/bhat) + ahat % bhat = ahat
+    -- Cast to ℤ: ↑bhat * ↑(ahat/bhat) + ↑(ahat%bhat) = ↑ahat
+    -- Then commute multiplication and rearrange.
+    have hdivmod_int :
+        (bhat : ℤ) * ((ahat / bhat : ℕ) : ℤ) + ((ahat % bhat) : ℤ) = (ahat : ℤ) := by
+      exact_mod_cast Nat.div_add_mod ahat bhat
+    have hcomm : ((ahat / bhat : ℕ) : ℤ) * (bhat : ℤ)
+               = (bhat : ℤ) * ((ahat / bhat : ℕ) : ℤ) := by ring
+    linarith
+
+/-- Multi-step matrix-vector invariant for `lehmerCofactors`.
+
+    Existential form: there exist final residues `(ahat', bhat')`
+    such that applying the accumulated matrix to the ghost original
+    pair recovers them. Proved by induction on `fuel`, applying
+    `lehmerInnerStep_invariant` to the head step.
+
+    Note: the existential form avoids defining a parallel
+    "track residues" function; the residues are determined by the
+    iterated `lehmerInnerStep`s, but expressing them explicitly is
+    not needed for the entry-bound argument. -/
+theorem lehmerCofactors_invariant {a₀ b₀ : ℤ} (fuel ahat bhat : ℕ) (M : CofactorMatrix)
+    (h_inv₁ : a₀ * M.α + b₀ * M.γ = (ahat : ℤ))
+    (h_inv₂ : a₀ * M.β + b₀ * M.δ = (bhat : ℤ)) :
+    ∃ ahat' bhat' : ℕ,
+      a₀ * (lehmerCofactors fuel ahat bhat M).α
+        + b₀ * (lehmerCofactors fuel ahat bhat M).γ = (ahat' : ℤ) ∧
+      a₀ * (lehmerCofactors fuel ahat bhat M).β
+        + b₀ * (lehmerCofactors fuel ahat bhat M).δ = (bhat' : ℤ) := by
+  induction fuel generalizing ahat bhat M with
+  | zero => exact ⟨ahat, bhat, h_inv₁, h_inv₂⟩
+  | succ n ih =>
+    simp only [lehmerCofactors]
+    match hstep : lehmerInnerStep ahat bhat M with
+    | none => exact ⟨ahat, bhat, h_inv₁, h_inv₂⟩
+    | some (ahat'', bhat'', M'') =>
+      have ⟨h₁', h₂'⟩ := lehmerInnerStep_invariant h_inv₁ h_inv₂ hstep
+      exact ih ahat'' bhat'' M'' h₁' h₂'
+
+/-- Specialisation of `lehmerCofactors_invariant` to `M = id` and the
+    "ghost original pair" being the algorithm's actual input pair
+    `(ahat, bhat)`.
+
+    Concretely: row-applying the accumulated cofactor matrix to the
+    input pair yields the final Euclidean-residue pair. This is the
+    correctness of `applyToNat (lehmerCofactors fuel ahat bhat id)
+    ahat bhat`: it equals the final reduced pair. -/
+theorem lehmerCofactors_id_apply_eq (fuel ahat bhat : ℕ) :
+    ∃ ahat' bhat' : ℕ,
+      (ahat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).α
+        + (bhat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).γ
+            = (ahat' : ℤ) ∧
+      (ahat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).β
+        + (bhat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).δ
+            = (bhat' : ℤ) := by
+  apply lehmerCofactors_invariant
+  · simp [CofactorMatrix.id]
+  · simp [CofactorMatrix.id]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART V: SIZE REDUCTION (the genuinely new content)
 -- ═══════════════════════════════════════════════════════════════
 
 /-- The bitsize of a natural number: `Nat.log 2 n + 1` for `n > 0`,
@@ -210,7 +342,15 @@ def bitsize (n : ℕ) : ℕ := if n = 0 then 0 else Nat.log 2 n + 1
     `BinaryGcdOQ03.lean`; closing it is the next-session focus.
 
     The constant `c = hgcdThreshold + 2` is an over-approximation; the
-    Brent–Zimmermann analysis gives `c = O(1)` more precisely. -/
+    Brent–Zimmermann analysis gives `c = O(1)` more precisely.
+
+    The matrix-vector invariant in PART IV is the first of three
+    components needed to close this proof; the remaining two are
+    (a) Euclidean-residue monotonicity (`bhat_final ≤ bhat₀`,
+    derivable from `lehmerInnerStep` flipping `(ahat, bhat)` to
+    `(bhat, ahat % bhat)` with `ahat % bhat < bhat`) and (b) a
+    perturbation argument bounding the difference between
+    `(a, b) · M` and `(aHi · 2^shift, bHi · 2^shift) · M = (aHi', bHi') · 2^shift`. -/
 theorem hgcdMatrix_size_reduction (fuel a b : ℕ)
     (hfuel : bitsize (max a b) ≤ fuel)
     (hbig : 2 ^ hgcdThreshold ≤ max a b) :
@@ -230,7 +370,7 @@ theorem hgcdMatrix_size_reduction (fuel a b : ℕ)
   sorry
 
 -- ═══════════════════════════════════════════════════════════════
--- PART V: COMPLEXITY (DEFERRED)
+-- PART VI: COMPLEXITY (DEFERRED)
 -- ═══════════════════════════════════════════════════════════════
 
 /-! ### Bit-complexity claim — deferred
@@ -252,7 +392,7 @@ initiative; we therefore document the complexity claim here without
 attempting to formalise it. -/
 
 -- ═══════════════════════════════════════════════════════════════
--- PART VI: COMPUTATIONAL SANITY CHECKS
+-- PART VII: COMPUTATIONAL SANITY CHECKS
 -- ═══════════════════════════════════════════════════════════════
 
 example : (hgcdMatrix 0 100 80).det = 1 := by
@@ -290,13 +430,21 @@ example : applyToNat (hgcdTopHalfStep 1000 300) 1000 300 = (100, 100) := by
 * `hgcdTopHalfStep_det_unit`: the top-half Lehmer step keeps `det = ±1`.
 * `hgcdMatrix_det_unit`: the recursive HGCD matrix is unimodular.
 * `hgcdMatrix_apply_gcd`: applying the HGCD matrix preserves `Nat.gcd`.
+* `lehmerInnerStep_invariant`, `lehmerCofactors_invariant`,
+  `lehmerCofactors_id_apply_eq`: the row-vector matrix-vector
+  invariant `(a₀, b₀) · M = (current pair)` is preserved by the
+  Lehmer-step machine. Foundational lemma for the size-reduction
+  argument (Step 1 of three in the proof plan).
 
 **Deferred**
 
 * `hgcdMatrix_size_reduction`: stated, currently `sorry`. Proving it is
-  the genuinely new mathematical content of this OQ; see Part IV docstring.
+  the genuinely new mathematical content of this OQ; see Part V docstring.
+  Step 1 (matrix-vector invariant) is now in PART IV; remaining work is
+  Steps 2 (entry bound via Cramer + residue monotonicity) and 3
+  (perturbation argument from low bits + recursion-iteration).
 * Bit complexity `O(M(n) log n)`: not formulable in Mathlib today; see
-  Part V docstring for the foundational gaps.
+  Part VI docstring for the foundational gaps.
 -/
 
 end LehmerGcd

--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -324,6 +324,97 @@ theorem lehmerCofactors_id_apply_eq (fuel ahat bhat : ℕ) :
   · simp [CofactorMatrix.id]
   · simp [CofactorMatrix.id]
 
+/-! ### Residue monotonicity (Step 2 toward size reduction)
+
+The Lehmer-step machine never grows the residues: each successful
+inner step sets `ahat' = bhat` and `bhat' = ahat % bhat`, so the
+maximum of the pair is non-increasing. Composed over multiple
+steps, this gives the bound `max ahat_final bhat_final ≤
+max ahat_initial bhat_initial` for the iterated `lehmerCofactors`.
+
+Combined with the matrix-vector invariant from PART IV, this
+is the residue-bound half of the size-reduction proof: applying
+the accumulated matrix to the input pair yields a Euclidean-
+residue pair whose max is bounded by the input max. The
+remaining piece is the cofactor-entry bound (Cramer inversion
+applied to the invariant), which is the focus of follow-up
+sessions. -/
+
+/-- One successful Lehmer inner step strictly decreases `bhat` and
+    sets `ahat' = bhat`. -/
+theorem lehmerInnerStep_residue_le {ahat bhat : ℕ} {M : CofactorMatrix}
+    {ahat' bhat' : ℕ} {M' : CofactorMatrix}
+    (h : lehmerInnerStep ahat bhat M = some (ahat', bhat', M')) :
+    bhat' < bhat ∧ ahat' = bhat := by
+  simp [lehmerInnerStep] at h
+  split at h <;> simp_all
+  split at h <;> simp_all
+  -- Surviving case: bhat ≠ 0 and ahat % bhat ≠ 0; substitution gives
+  -- ahat' = bhat, bhat' = ahat % bhat, M' = explicit matrix.
+  obtain ⟨rfl, rfl, _⟩ := h
+  refine ⟨?_, rfl⟩
+  -- Goal: ahat % bhat < bhat. omega uses bhat ≠ 0 from context.
+  omega
+
+/-- One successful Lehmer inner step does not increase the maximum
+    of the pair `(ahat, bhat)`. -/
+theorem lehmerInnerStep_max_le {ahat bhat : ℕ} {M : CofactorMatrix}
+    {ahat' bhat' : ℕ} {M' : CofactorMatrix}
+    (h : lehmerInnerStep ahat bhat M = some (ahat', bhat', M')) :
+    max ahat' bhat' ≤ max ahat bhat := by
+  obtain ⟨hb_lt, ha_eq⟩ := lehmerInnerStep_residue_le h
+  -- ahat' = bhat ≤ max ahat bhat; bhat' < bhat ≤ max ahat bhat.
+  have h1 : ahat' ≤ max ahat bhat := by rw [ha_eq]; exact le_max_right _ _
+  have h2 : bhat' ≤ max ahat bhat :=
+    le_trans (le_of_lt hb_lt) (le_max_right _ _)
+  exact max_le h1 h2
+
+/-- Multi-step matrix-vector invariant for `lehmerCofactors` with the
+    additional bound that the final residues do not exceed the initial
+    `(ahat, bhat)` in maximum. Strengthens `lehmerCofactors_invariant`. -/
+theorem lehmerCofactors_invariant_le {a₀ b₀ : ℤ} (fuel ahat bhat : ℕ)
+    (M : CofactorMatrix)
+    (h_inv₁ : a₀ * M.α + b₀ * M.γ = (ahat : ℤ))
+    (h_inv₂ : a₀ * M.β + b₀ * M.δ = (bhat : ℤ)) :
+    ∃ ahat' bhat' : ℕ,
+      a₀ * (lehmerCofactors fuel ahat bhat M).α
+        + b₀ * (lehmerCofactors fuel ahat bhat M).γ = (ahat' : ℤ) ∧
+      a₀ * (lehmerCofactors fuel ahat bhat M).β
+        + b₀ * (lehmerCofactors fuel ahat bhat M).δ = (bhat' : ℤ) ∧
+      max ahat' bhat' ≤ max ahat bhat := by
+  induction fuel generalizing ahat bhat M with
+  | zero => exact ⟨ahat, bhat, h_inv₁, h_inv₂, le_refl _⟩
+  | succ n ih =>
+    simp only [lehmerCofactors]
+    match hstep : lehmerInnerStep ahat bhat M with
+    | none => exact ⟨ahat, bhat, h_inv₁, h_inv₂, le_refl _⟩
+    | some (ahat'', bhat'', M'') =>
+      have ⟨h₁', h₂'⟩ := lehmerInnerStep_invariant h_inv₁ h_inv₂ hstep
+      have hbound := lehmerInnerStep_max_le hstep
+      have ⟨ahat', bhat', hα, hβ, hmax⟩ := ih ahat'' bhat'' M'' h₁' h₂'
+      exact ⟨ahat', bhat', hα, hβ, le_trans hmax hbound⟩
+
+/-- Specialisation of `lehmerCofactors_invariant_le` to `M = id` and
+    the "ghost original pair" being the actual input pair `(ahat, bhat)`.
+
+    Combined statement: row-applying the accumulated cofactor matrix to
+    `(ahat, bhat)` yields a residue pair `(ahat', bhat')` with
+    `max ahat' bhat' ≤ max ahat bhat`. This is the residue-side bound
+    used in the size-reduction argument; together with an entry-bound
+    on the cofactor matrix it gives the bitsize halving. -/
+theorem lehmerCofactors_id_apply_le (fuel ahat bhat : ℕ) :
+    ∃ ahat' bhat' : ℕ,
+      (ahat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).α
+        + (bhat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).γ
+            = (ahat' : ℤ) ∧
+      (ahat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).β
+        + (bhat : ℤ) * (lehmerCofactors fuel ahat bhat CofactorMatrix.id).δ
+            = (bhat' : ℤ) ∧
+      max ahat' bhat' ≤ max ahat bhat := by
+  apply lehmerCofactors_invariant_le
+  · simp [CofactorMatrix.id]
+  · simp [CofactorMatrix.id]
+
 -- ═══════════════════════════════════════════════════════════════
 -- PART V: SIZE REDUCTION (the genuinely new content)
 -- ═══════════════════════════════════════════════════════════════

--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -346,15 +346,18 @@ theorem lehmerInnerStep_residue_le {ahat bhat : ℕ} {M : CofactorMatrix}
     {ahat' bhat' : ℕ} {M' : CofactorMatrix}
     (h : lehmerInnerStep ahat bhat M = some (ahat', bhat', M')) :
     bhat' < bhat ∧ ahat' = bhat := by
-  simp [lehmerInnerStep] at h
-  split at h <;> simp_all
-  split at h <;> simp_all
-  -- Surviving case: bhat ≠ 0 and ahat % bhat ≠ 0; substitution gives
-  -- ahat' = bhat, bhat' = ahat % bhat, M' = explicit matrix.
-  obtain ⟨rfl, rfl, _⟩ := h
-  refine ⟨?_, rfl⟩
-  -- Goal: ahat % bhat < bhat. omega uses bhat ≠ 0 from context.
-  omega
+  -- Mirror the case-split structure of `lehmerInnerStep_det`.
+  -- bhat = 0 and ahat % bhat = 0 both make the step return `none`,
+  -- contradicting `some (...)`. The surviving branch substitutes
+  -- ahat' := bhat, bhat' := ahat % bhat, and gives bhat ≠ 0.
+  by_cases hb : bhat = 0
+  · simp [lehmerInnerStep, hb] at h
+  · by_cases hr : ahat % bhat = 0
+    · simp [lehmerInnerStep, hb, hr] at h
+    · simp [lehmerInnerStep, hb, hr] at h
+      obtain ⟨rfl, rfl, _⟩ := h
+      refine ⟨?_, rfl⟩
+      exact Nat.mod_lt _ (Nat.pos_of_ne_zero hb)
 
 /-- One successful Lehmer inner step does not increase the maximum
     of the pair `(ahat, bhat)`. -/

--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -1,0 +1,222 @@
+/-
+  HGCD (Half-GCD) -- Schönhage's recursive cofactor algorithm
+
+  Open question OQ-02 of binary-gcd-OQ-03: can Schönhage's recursive
+  HGCD be formalized?  We split the question into three parts:
+
+  (A) **Correctness**: there is a function `hgcdMatrix : ℕ → ℕ → CofactorMatrix`
+      such that for all `a b : ℕ`, `(hgcdMatrix a b).det ∈ {±1}` and
+      applying it to `(a, b)` preserves `Nat.gcd a b`.
+
+  (B) **Size reduction**: applying `hgcdMatrix a b` reduces the bitsize
+      of `max a b` by approximately half (the genuinely new mathematical
+      content vs. plain Lehmer).
+
+  (C) **Bit complexity** O(M(n) log n): currently inexpressible in Mathlib
+      because there is no bit-complexity model of arithmetic and no fast
+      multiplication. Deferred -- documented as a Mathlib infrastructure gap.
+
+  This file establishes (A) and the structural skeleton for (B). The
+  size-reduction lemma is stated with the precise quantitative bound and
+  marked `sorry`; closing it is the focus of follow-up sessions.
+
+  All cofactor-matrix machinery (det, mul, apply, GCD invariance under
+  unimodular matrices) is reused from `BinaryGcdOQ03.lean`.
+
+  References:
+  - Schönhage (1971), "Schnelle Berechnung von Kettenbruchentwicklungen"
+  - Brent & Zimmermann, "Modern Computer Arithmetic", §1.6.3
+  - Stehlé & Zimmermann (2004), "A binary recursive gcd algorithm"
+-/
+
+import Proofs.BinaryGcdOQ03
+
+open Nat Int
+
+namespace LehmerGcd
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART I: HGCD DEFINITION
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Threshold below which HGCD bottoms out and returns the identity
+    cofactor matrix. The caller is expected to fall back to plain
+    Euclidean / Lehmer reduction below this size. -/
+def hgcdThreshold : ℕ := 4
+
+/-- One Lehmer-style reduction step on the top half of the bits of `(a, b)`.
+    Given `a b : ℕ` with `max a b ≥ 2^hgcdThreshold`, extracts the top
+    `n - n/2` bits and runs `lehmerCofactors` on the approximation to
+    get a cofactor matrix.  Used as the recursive base step inside HGCD. -/
+def hgcdTopHalfStep (a b : ℕ) : CofactorMatrix :=
+  let n := Nat.log 2 (max a b) + 1
+  let shift := n / 2
+  let aHi := a / 2 ^ shift
+  let bHi := b / 2 ^ shift
+  -- Run plain Lehmer cofactor accumulation on the top half.
+  -- Using the same `lehmerCofactors` routine that already has det-unit
+  -- accounted for in BinaryGcdOQ03.
+  lehmerCofactors n aHi bHi CofactorMatrix.id
+
+/-- Apply a cofactor matrix to a non-negative pair, taking absolute values
+    of the result. In the algorithm both components remain non-negative
+    when the matrix is correctly accumulated; this is a safety wrapper. -/
+def applyToNat (M : CofactorMatrix) (a b : ℕ) : ℕ × ℕ :=
+  let (u, v) := M.apply (↑a) (↑b)
+  (u.natAbs, v.natAbs)
+
+/-- Recursive HGCD with explicit fuel. Returns a cofactor matrix `M` whose
+    determinant is `±1` and which preserves `Nat.gcd`. The size-reduction
+    property is stated separately. -/
+def hgcdMatrix : (fuel a b : ℕ) → CofactorMatrix
+  | 0,        _, _ => CofactorMatrix.id
+  | fuel + 1, a, b =>
+    if max a b < 2 ^ hgcdThreshold then
+      CofactorMatrix.id
+    else
+      -- Step 1: reduce on the top half of the bits.
+      let M₁ := hgcdTopHalfStep a b
+      -- Apply M₁ to the full pair to get the half-reduced pair.
+      let (a₁, b₁) := applyToNat M₁ a b
+      if h : max a₁ b₁ < 2 ^ hgcdThreshold then
+        M₁
+      else
+        -- Step 2: recurse on the reduced pair.
+        let M₂ := hgcdMatrix fuel a₁ b₁
+        -- Compose: M₂ acts after M₁ on the original pair.
+        M₂.mul M₁
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART II: DETERMINANT IS ±1
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The Lehmer cofactor accumulator preserves det = ±1 starting from
+    the identity. Re-stated here for `hgcdTopHalfStep`. -/
+theorem hgcdTopHalfStep_det_unit (a b : ℕ) :
+    (hgcdTopHalfStep a b).det = 1 ∨ (hgcdTopHalfStep a b).det = -1 := by
+  unfold hgcdTopHalfStep
+  exact lehmerCofactors_det_unit _ _ _ _ (Or.inl CofactorMatrix.det_id)
+
+/-- The recursive HGCD matrix has determinant `±1`. -/
+theorem hgcdMatrix_det_unit (fuel a b : ℕ) :
+    (hgcdMatrix fuel a b).det = 1 ∨ (hgcdMatrix fuel a b).det = -1 := by
+  induction fuel generalizing a b with
+  | zero => left; exact CofactorMatrix.det_id
+  | succ n ih =>
+    unfold hgcdMatrix
+    split_ifs
+    · left; exact CofactorMatrix.det_id
+    · exact hgcdTopHalfStep_det_unit a b
+    · -- Composed case: det(M₂ · M₁) = det M₂ · det M₁; both ±1.
+      rw [CofactorMatrix.det_mul]
+      rcases ih (applyToNat (hgcdTopHalfStep a b) a b).1
+                (applyToNat (hgcdTopHalfStep a b) a b).2 with h2 | h2 <;>
+      rcases hgcdTopHalfStep_det_unit a b with h1 | h1 <;>
+      [left; right; right; left] <;>
+      simp [h1, h2]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART III: GCD PRESERVATION
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Applying `hgcdMatrix` to `(a, b)` preserves the GCD. This is an
+    immediate consequence of `cofactor_apply_gcd` together with
+    `hgcdMatrix_det_unit`. -/
+theorem hgcdMatrix_apply_gcd (fuel a b : ℕ) :
+    let M := hgcdMatrix fuel a b
+    Int.gcd (M.α * (↑a : ℤ) + M.β * ↑b) (M.γ * ↑a + M.δ * ↑b) = Nat.gcd a b := by
+  exact cofactor_apply_gcd (hgcdMatrix_det_unit fuel a b)
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART IV: SIZE REDUCTION (the genuinely new content)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The bitsize of a natural number: `Nat.log 2 n + 1` for `n > 0`,
+    and `0` for `n = 0`. -/
+def bitsize (n : ℕ) : ℕ := if n = 0 then 0 else Nat.log 2 n + 1
+
+@[simp] theorem bitsize_zero : bitsize 0 = 0 := by simp [bitsize]
+
+/-- **Size reduction (statement)**: for inputs above the HGCD threshold,
+    one application of `hgcdMatrix` reduces `bitsize (max a b)` to
+    approximately `bitsize (max a b) / 2 + c`.
+
+    This is the only mathematically novel claim in the file relative to
+    `BinaryGcdOQ03.lean`; closing it is the next-session focus.
+
+    The constant `c = hgcdThreshold + 2` is an over-approximation; the
+    Brent–Zimmermann analysis gives `c = O(1)` more precisely. -/
+theorem hgcdMatrix_size_reduction (fuel a b : ℕ)
+    (hfuel : bitsize (max a b) ≤ fuel)
+    (hbig : 2 ^ hgcdThreshold ≤ max a b) :
+    bitsize (max (applyToNat (hgcdMatrix fuel a b) a b).1
+                 (applyToNat (hgcdMatrix fuel a b) a b).2)
+      ≤ bitsize (max a b) / 2 + (hgcdThreshold + 2) := by
+  -- Deferred: this is the substantive next-session goal. The proof
+  -- requires:
+  --   (a) bounding the entries of `hgcdTopHalfStep a b` by
+  --       2^(bitsize(max a b)/2 + 2) (a Lehmer accumulator entry-bound
+  --       lemma — likely Mathlib gap, may need to prove inline);
+  --   (b) using the unimodularity to bound the entries of the inverse
+  --       and hence the difference between (a, b) and the new pair;
+  --   (c) iterating the half-reduction twice (once for the top step,
+  --       once for the recursive call) to halve the bitsize.
+  -- See research/problems/binary-gcd-oq-03-oq-02/state.md.
+  sorry
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART V: COMPLEXITY (DEFERRED)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Bit-complexity claim — deferred
+
+The classical Schönhage analysis gives `T_hgcd(n) = O(M(n) · log n)`
+where `M(n)` is the bit cost of multiplying two `n`-bit integers and
+`n = bitsize(max a b)`. We **cannot state this in Lean today** because:
+
+* Mathlib has no bit-complexity model for arithmetic. `Computability`
+  has Turing machines and `primrec` / `partrec`, but nothing that
+  attaches "bit operations" to integer arithmetic primitives.
+* Mathlib has no fast multiplication (Karatsuba, Toom–Cook,
+  Schönhage–Strassen). All multiplication on `ℕ` / `ℤ` is opaque.
+* There is no big-integer-as-array-of-words representation in Mathlib;
+  `ℕ` and `ℤ` are abstract algebraic structures.
+
+Filling these gaps is a multi-thousand-line Mathlib-contribution
+initiative; we therefore document the complexity claim here without
+attempting to formalise it. -/
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART VI: COMPUTATIONAL SANITY CHECKS
+-- ═══════════════════════════════════════════════════════════════
+
+example : (hgcdMatrix 0 100 80).det = 1 := by
+  unfold hgcdMatrix
+  exact CofactorMatrix.det_id
+
+example : (hgcdMatrix 5 7 3).det = 1 ∨ (hgcdMatrix 5 7 3).det = -1 :=
+  hgcdMatrix_det_unit 5 7 3
+
+example :
+    let M := hgcdMatrix 4 5 3
+    Int.gcd (M.α * (5 : ℤ) + M.β * 3) (M.γ * 5 + M.δ * 3) = Nat.gcd 5 3 :=
+  hgcdMatrix_apply_gcd 4 5 3
+
+/-! ## Summary
+
+**Established (1 sorry, 0 axioms)**
+
+* Definitions: `hgcdThreshold`, `hgcdTopHalfStep`, `applyToNat`, `hgcdMatrix`.
+* `hgcdTopHalfStep_det_unit`: the top-half Lehmer step keeps `det = ±1`.
+* `hgcdMatrix_det_unit`: the recursive HGCD matrix is unimodular.
+* `hgcdMatrix_apply_gcd`: applying the HGCD matrix preserves `Nat.gcd`.
+
+**Deferred**
+
+* `hgcdMatrix_size_reduction`: stated, currently `sorry`. Proving it is
+  the genuinely new mathematical content of this OQ; see Part IV docstring.
+* Bit complexity `O(M(n) log n)`: not formulable in Mathlib today; see
+  Part V docstring for the foundational gaps.
+-/
+
+end LehmerGcd

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -521,7 +521,15 @@ now in place.
       max ahat' bhat' ≤ max ahat bhat` for `M = lehmerCofactors
       fuel ahat bhat id`.
 
-3. Verified the file via Docker build.
+3. Attempted Docker build verification. Docker daemon was
+   unresponsive (multiple stuck `docker-build.sh` processes
+   from concurrent agents; matches the
+   "Docker build I/O errors during heavy multi-agent activity"
+   pattern documented in working memory). Build verification
+   deferred to next session. The proofs are written to mirror
+   existing patterns from `BinaryGcdOQ03.lean`
+   (`lehmerInnerStep_det`, `lehmerCofactors_det_unit`); risk of
+   a tactic-script issue is low but non-zero.
 
 ### Key Findings
 

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -134,3 +134,78 @@ This survey produces a structural insight (the correctness/complexity split)
 and identifies infrastructure gaps. It does **not** prove anything. The next
 session can act on the recommendation in ~1–2 sessions of pure correctness
 work, or escalate the complexity gap to a separate initiative.
+
+## Session 2026-05-01 (Session 2) — HGCD skeleton compiled, det+gcd theorems proved
+
+**Mode**: REVISIT (acted on Session-1 recommendation)
+**Outcome**: progress — phase ORIENT → ACT; correctness side (A) reduced
+to a single sorry (the size-reduction lemma).
+
+### What I Did
+
+- Made the scope decision recommended by Session 1: correctness-only.
+  Documented (B) bit complexity as a Mathlib infrastructure gap and
+  did not attempt it.
+- Updated `problemStatement.formal` from the placeholder
+  `\\text{(formal statement to be added)}` to a concrete 3-part
+  spec: (A) correctness, (B) size reduction, (C) complexity (deferred).
+- Updated `problemStatement.whyMatters` (was empty) and
+  `knownResults.proven/open/goal` (were empty) with the classical
+  references and precise sub-goals.
+- Created `proofs/Proofs/BinaryGcdOQ03OQ02.lean` (~190 lines) with:
+  - `hgcdThreshold`, `hgcdTopHalfStep`, `applyToNat`, `hgcdMatrix`
+    (recursive HGCD with explicit fuel; two recursive calls composed
+    with `CofactorMatrix.mul`).
+  - `hgcdTopHalfStep_det_unit` (top-half step is unimodular).
+  - `hgcdMatrix_det_unit` (recursive HGCD matrix is unimodular —
+    induction on fuel; uses `CofactorMatrix.det_mul` for the
+    composed branch).
+  - `hgcdMatrix_apply_gcd` (application preserves `Nat.gcd` —
+    immediate from the previous theorem and the existing
+    `cofactor_apply_gcd` from `BinaryGcdOQ03`).
+  - `bitsize` helper.
+  - `hgcdMatrix_size_reduction` — **statement only, sorry**. The only
+    sorry in the file. Quantitative bound is
+    `bitsize(max(M·(a,b))) ≤ bitsize(max a b)/2 + (hgcdThreshold+2)`.
+  - Three `example` smoke checks at the end (`det = 1` at fuel 0,
+    `det = ±1` at fuel 5, `gcd` preservation at fuel 4).
+- Registered the new file in `proofs/Proofs.lean`.
+
+### Key Findings
+
+- The det-unit and gcd-preservation halves of HGCD correctness are
+  almost mechanical given the existing `CofactorMatrix` infrastructure
+  in `BinaryGcdOQ03.lean`. They were proved with one induction and
+  a four-way `rcases` on the determinant signs.
+- The genuinely new mathematical content of OQ-02 is the
+  size-reduction lemma `hgcdMatrix_size_reduction`. Closing it
+  requires bounding the entries of the Lehmer cofactor accumulator
+  by `2^(bitsize(max a b)/2 + 2)` — a Lehmer accumulator entry-bound
+  lemma which appears not to exist either in Mathlib or in
+  `BinaryGcdOQ03.lean`, and which is the natural focus of the next
+  session.
+- (C) bit complexity remains genuinely Mathlib-blocked; no Lean
+  formulation is currently possible. Documenting this in a Part-V
+  comment is itself a (small) contribution.
+
+### Files Modified
+
+- `proofs/Proofs/BinaryGcdOQ03OQ02.lean` (new, ~190 lines, 1 sorry, 0 axioms)
+- `proofs/Proofs.lean` (added import)
+- `src/data/research/problems/binary-gcd-oq-03-oq-02.json` (formal
+  statement + whyMatters + knownResults populated)
+
+### Next Steps
+
+1. Prove `hgcdMatrix_size_reduction`. The critical lemma is an
+   entry bound on `lehmerCofactors`: each entry of the accumulated
+   matrix is at most `2^(fuel + 1)`. Combined with the Cramer
+   inversion already used in `dvd_of_det_unit`, this gives the
+   half-bitsize bound on the residual.
+2. Once size reduction is established, derive a non-trivial
+   termination measure (e.g. lexicographic on
+   `(bitsize(max a b), fuel)`) and consider replacing the explicit
+   fuel parameter with a `WellFounded.fix` definition.
+3. (Optional, lower priority) wire `hgcdMatrix` into the existing
+   `lehmerGcd` to give a recursive variant `hgcdGcd` and prove
+   `hgcdGcd a b = Nat.gcd a b`.

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -209,3 +209,139 @@ to a single sorry (the size-reduction lemma).
 3. (Optional, lower priority) wire `hgcdMatrix` into the existing
    `lehmerGcd` to give a recursive variant `hgcdGcd` and prove
    `hgcdGcd a b = Nat.gcd a b`.
+
+## Session 2026-05-01 (Session 3) — Cofactor convention fix
+
+**Mode**: continuation of Session 2 (same day)
+**Outcome**: progress — corrected a convention mismatch that would
+have made `hgcdMatrix_size_reduction` *false as previously stated*.
+The lemma is now well-aligned with the algorithm semantics; sorry
+count unchanged at 1.
+
+### What I Did
+
+While reviewing the file before attempting the size-reduction proof,
+I traced `lehmerInnerStep` and `lehmerCofactors` against the
+`CofactorMatrix.apply` definition, and discovered they use *different*
+matrix conventions:
+
+* `lehmerInnerStep` updates the accumulator via
+  `M' = M · S` where `S = ⟨0, 1, 1, -q⟩` (right-multiplication by
+  the step matrix). Equivalently, the maintained invariant is
+  `(a₀, b₀) · M = (current pair)` — **row-vector convention**.
+
+* `CofactorMatrix.apply (a, b) = (M.α·a + M.β·b, M.γ·a + M.δ·b)` is
+  the **column-vector** product `M · (a, b)ᵀ`.
+
+These products are equal only when `M.β = M.γ`, i.e. for the very
+first Lehmer step (where `S = ⟨0, 1, 1, -q⟩` is symmetric on those
+entries). After two or more Lehmer steps with distinct quotients,
+the row and column products diverge.
+
+For the Session-2 `applyToNat` (which used `M.apply`), this means:
+
+* `cofactor_apply_gcd` is still applicable — column-applying any
+  unimodular matrix preserves gcd. So `hgcdMatrix_apply_gcd` was
+  *true* but read against the column product, not the actual
+  Lehmer-reduced pair.
+* `hgcdMatrix_size_reduction` was *false* in general, because the
+  column-applied pair is not the reduced pair — it can even be
+  larger than the input.
+
+Concrete demonstration (now a `native_decide` test in the file):
+take `(a, b) = (1000, 300)`. `hgcdTopHalfStep` extracts `aHi = 31,
+bHi = 9` (`shift = 5`, `n = 10`) and runs two cofactor steps on
+those:
+
+* step 1: `q = 3, r = 4`, `M₁ = ⟨0, 1, 1, -3⟩`,
+* step 2: `q = 2, r = 1`, `M₂ = ⟨1, -2, -3, 7⟩` (β = -2 ≠ γ = -3).
+
+| Convention   | Result on (1000, 300)                    | Reduced? |
+|--------------|------------------------------------------|----------|
+| Row-apply    | (1000·1 + 300·(-3), 1000·(-2) + 300·7) = (100, 100) | yes (max bitsize 7 < 10) |
+| Column-apply | (1·1000 + (-2)·300, (-3)·1000 + 7·300) = (400, -900) → (400, 900) | **no** (max bitsize 10) |
+
+Both pairs preserve `Nat.gcd 1000 300 = 100`; only the row-apply
+pair is the actual Lehmer reduction.
+
+Fix applied:
+
+1. `applyToNat M a b` now computes `(a·M.α + b·M.γ, a·M.β + b·M.δ)`
+   directly (row product), bypassing `M.apply`.
+2. `hgcdMatrix`'s recursive composition swapped from
+   `(M_rec).mul (M_top)` to `(M_top).mul (M_rec)`, so that the
+   row-apply of the composite is "top-half first, then recurse".
+3. `hgcdMatrix_apply_gcd` restated with the row product on the
+   left-hand side. Proof: relabel `(α, β, γ, δ) ← (M.α, M.γ, M.β,
+   M.δ)` and apply `gcd_cofactor_eq` from `BinaryGcdOQ03`; the
+   det condition `α·δ - β·γ = M.α·M.δ - M.γ·M.β = M.det` is
+   symmetric under the swap `β ↔ γ`. Plus a `ring`-rewrite to
+   match goal multiplication order.
+4. `hgcdMatrix_det_unit` updated to feed
+   `mul_unit_of_unit_of_unit` arguments in the new order
+   (top-half first).
+5. File-level docstring expanded to spell out the convention; new
+   `native_decide` example pins the row-apply behaviour on the
+   `(1000, 300)` case.
+
+### Key Findings
+
+* This is a non-trivial bug: it would have surfaced only when
+  somebody tried to *use* the cofactor matrix to reduce a pair, which
+  is exactly what HGCD does. The pure correctness theorems
+  (`hgcdMatrix_det_unit`, `hgcdMatrix_apply_gcd`) were both true under
+  the column convention, but the SIZE-REDUCTION lemma — the
+  genuinely new content of OQ-02 — would have been false.
+* The fix is local to `BinaryGcdOQ03OQ02.lean` and does not require
+  changes to `BinaryGcdOQ03.lean`, because `lehmerCofactors`'s row
+  convention is consistent within itself; the issue was only at the
+  boundary where we tried to "apply" the accumulated matrix.
+* Note that `lehmerReduce` in `BinaryGcdOQ03.lean` *also* uses
+  `M.apply`, which has the same issue — it does not actually
+  produce the Lehmer-reduced pair for matrices with two or more
+  steps. The existing `lehmerGcd` algorithm is gcd-correct via
+  fuel exhaustion + euclidGcd fallback, but the Lehmer "speedup"
+  is not actually realised. This is a separate finding worth a
+  follow-up issue against the OQ-03 line.
+
+### Files Modified
+
+* `proofs/Proofs/BinaryGcdOQ03OQ02.lean` — convention fix:
+  `applyToNat` body, `hgcdMatrix` mul order, `hgcdMatrix_det_unit`
+  arg order, `hgcdMatrix_apply_gcd` restated and re-proved, file-level
+  + `applyToNat` docstrings, smoke-check example updated, new
+  `native_decide` example for the (1000, 300) case. Sorry count
+  unchanged at 1; axiom count unchanged at 0.
+* `research/problems/binary-gcd-oq-03-oq-02/state.md` — Session-3
+  block, updated active-approach narrative.
+* `research/problems/binary-gcd-oq-03-oq-02/knowledge.md` — this
+  Session-3 entry.
+
+### Next Steps
+
+The size-reduction lemma is now well-typed against the actual
+Lehmer-reduced pair. The proof plan from Session 2 carries over,
+with one wording change:
+
+1. **Lehmer accumulator entry bound** —
+   prove `|M.α|, |M.β|, |M.γ|, |M.δ| ≤ max(ahat, bhat)` (or some
+   simple polynomial bound) for `M = lehmerCofactors fuel ahat
+   bhat id`. Most likely route: maintain the matrix-vector
+   invariant `(ahat₀, bhat₀) · M = (current pair)` *as a
+   theorem*, and combine it with sign tracking on the cofactors
+   (the alternation `α, δ` vs `β, γ` per step).
+2. **Half-bitsize residual via the entry bound** —
+   write `a = aHi · 2^shift + aLo`, similar for b, expand the
+   row product, and bound the result by
+   `2^shift · (aHi' + |M.α| + |M.γ|)`.
+3. **Iterate** the half-reduction (top-half + recursive call) to
+   close the threshold gap.
+
+Step 1 is the bulk of the work and the natural focus of a future
+session.
+
+A separate follow-up: file an issue against `BinaryGcdOQ03.lean`
+noting that `lehmerReduce` uses `M.apply` (column) on a
+row-accumulated `M`, so the "Lehmer step" in the existing algorithm
+does not actually reduce the pair. The algorithm is still
+gcd-correct via fuel exhaustion + `euclidGcd` fallback.

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -345,3 +345,137 @@ noting that `lehmerReduce` uses `M.apply` (column) on a
 row-accumulated `M`, so the "Lehmer step" in the existing algorithm
 does not actually reduce the pair. The algorithm is still
 gcd-correct via fuel exhaustion + `euclidGcd` fallback.
+
+## Session 2026-05-01 (Session 4) — Matrix-vector invariant
+
+**Mode**: continuation of Session 3 (same day)
+**Outcome**: progress — Step 1 of three for `hgcdMatrix_size_reduction`
+done. Three new theorems established in `BinaryGcdOQ03OQ02.lean`'s
+new PART IV. Sorry count unchanged at 1; axiom count unchanged at 0.
+
+### What I Did
+
+Implemented the matrix-vector invariant for `lehmerCofactors`, which
+is the foundational lemma identified by the Session-2 (and Session-3
+restated) proof plan.
+
+The invariant: for `M = lehmerCofactors fuel ahat₀ bhat₀ id`, there
+exist final residues `(ahat', bhat')` (from iterating `lehmerInnerStep`)
+such that
+
+```
+ahat₀ * M.α + bhat₀ * M.γ = ahat'    (in ℤ)
+ahat₀ * M.β + bhat₀ * M.δ = bhat'    (in ℤ)
+```
+
+— equivalently `(ahat₀, bhat₀) · M = (ahat', bhat')` in row-vector
+convention. This is the algebraic content underlying the algorithm:
+the matrix encodes the linear combination producing the current
+Euclidean residues from the inputs.
+
+Three theorems added, in escalating generality:
+
+1. `lehmerInnerStep_invariant {a₀ b₀ : ℤ}`: per-step preservation
+   of the relation, parameterised over a "ghost original pair"
+   `(a₀, b₀)` (allowing `a₀, b₀` to be different from the current
+   `(ahat, bhat)` so that the induction can carry through). Proof:
+   unfold `lehmerInnerStep`, split on `bhat = 0` then on
+   `ahat % bhat = 0`, reach the surviving case where the new
+   matrix is `⟨M.β, M.α - q·M.β, M.δ, M.γ - q·M.δ⟩` and the new
+   pair is `(bhat, ahat % bhat)`. The first conclusion is
+   `h_inv₂` directly; the second follows from
+   `h_inv₁ - q · h_inv₂` plus `Nat.div_add_mod`. Uses `linarith`
+   with a `mul_comm` hint to handle the ℤ-cast multiplication.
+
+2. `lehmerCofactors_invariant {a₀ b₀ : ℤ} (fuel)`: existential
+   multi-step version. Inductive on `fuel`; base case is
+   `⟨ahat, bhat, h_inv₁, h_inv₂⟩`; successor case uses
+   `match hstep : lehmerInnerStep ahat bhat M with` (the same
+   pattern as the existing `lehmerCofactors_det_unit`) to split
+   on whether the head step succeeds, applying
+   `lehmerInnerStep_invariant` to compute the new invariants and
+   `ih` to descend.
+
+3. `lehmerCofactors_id_apply_eq`: specialisation to `M = id`
+   and ghost pair = input pair. Direct corollary of (2).
+
+Choice of formulation: the existential form was preferred over
+defining a parallel "track residues" function, because the explicit
+residues are not needed for the entry-bound argument that
+follows — only their existence and the invariant relation. This
+keeps the file additions to a single section without a new
+recursive definition.
+
+Build verification: Docker daemon was unresponsive during multiple
+attempts at session start (matches the Session-3 docker-daemon
+failure mode under heavy multi-agent activity). Proofs are written
+conservatively to mirror existing `lehmerInnerStep_det` and
+`lehmerCofactors_det_unit` patterns; build risk should be low but
+remains unverified this session. PR remains DRAFT pending
+build success.
+
+### Key Findings
+
+* The matrix-vector invariant is genuinely the right generalised
+  statement for the inductive proof. The naive form
+  `(ahat₀, bhat₀) · M = (final pair)` would not survive the
+  inductive step because the "current pair" changes; the ghost
+  original pair `(a₀, b₀)` remains fixed throughout the
+  recursion, which is exactly what's needed.
+* The decomposition into per-step + multi-step keeps the
+  arithmetic-heavy reasoning (Nat.div_add_mod + cast handling)
+  isolated to the per-step lemma, while the inductive proof
+  is purely structural. This split mirrors how the existing
+  file separates `lehmerInnerStep_det` (one step) from
+  `lehmerCofactors_det_unit` (induction).
+* Sign tracking is automatic in ℤ: `a₀, b₀ : ℤ` means we don't
+  have to worry about `Nat`-subtraction-truncation in the
+  linear-combination steps. The only ℕ↔ℤ bridging is in the
+  Euclidean-modulo step.
+
+### Files Modified
+
+* `proofs/Proofs/BinaryGcdOQ03OQ02.lean` — added PART IV
+  (matrix-vector invariant) with three theorems
+  (`lehmerInnerStep_invariant`, `lehmerCofactors_invariant`,
+  `lehmerCofactors_id_apply_eq`). Renumbered subsequent parts
+  V→VI (complexity), VI→VII (sanity checks), and added
+  `PART V: SIZE REDUCTION` heading. Updated file-level
+  docstring and final summary section. Sorry count unchanged
+  at 1; axiom count unchanged at 0; +157 lines, -9 lines.
+* `research/problems/binary-gcd-oq-03-oq-02/state.md` — Session 4
+  block, iteration 4 → 5, restated next-action plan
+  (1 done, 2-5 remain).
+* `research/problems/binary-gcd-oq-03-oq-02/knowledge.md` —
+  this Session-4 entry.
+
+### Next Steps
+
+The matrix-vector invariant is now in place. The natural next
+session continues with **Step 2** of the proof plan: the
+**Lehmer accumulator entry bound**.
+
+With the invariant `a₀ * M.α + b₀ * M.γ = ahat'` and
+`a₀ * M.β + b₀ * M.δ = bhat'` (with `det M = ±1`), Cramer's rule
+recovers `a₀, b₀` from the final residues:
+
+```
+a₀ = ±(δ * ahat' - β * bhat')
+b₀ = ±(α * bhat' - γ * ahat')
+```
+
+Combined with `bhat' < ahat'` (Euclidean residues form a
+decreasing sequence in `bhat`) and `ahat' ≥ 1` (assuming the
+algorithm hasn't terminated), this gives:
+
+```
+|α|, |β|, |γ|, |δ| ≤ max(|a₀|, |b₀|) / max(ahat', bhat')
+```
+
+So the entries of `M` are bounded by the input size divided by
+the residual size — precisely the bound needed for the
+perturbation analysis in Step 3.
+
+Step 2 will need a separate small lemma about Euclidean-step
+monotonicity (`bhat_final ≤ bhat₀`), provable by induction on
+fuel using `Nat.mod_lt`.

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -479,3 +479,110 @@ perturbation analysis in Step 3.
 Step 2 will need a separate small lemma about Euclidean-step
 monotonicity (`bhat_final ≤ bhat₀`), provable by induction on
 fuel using `Nat.mod_lt`.
+
+## Session 2026-05-02 (Session 5) — Residue monotonicity (Step 2a)
+
+**Mode**: REVISIT (continuation of in-progress problem; tier RICH)
+**Outcome**: progress — added the residue-monotonicity bound for
+the iterated Lehmer machine. The size-reduction `sorry` is unchanged
+in count, but a major component of its proof (the residue side) is
+now in place.
+
+### What I Did
+
+1. Re-read Session-4 state. The matrix-vector invariant
+   (`lehmerCofactors_invariant`, `lehmerCofactors_id_apply_eq`)
+   is in place; the next-action plan called for a Cramer-inversion
+   entry bound that requires residue monotonicity as a prerequisite.
+
+2. Implemented Step 2a: the small but missing lemma about Euclidean-
+   step monotonicity, in four parts:
+
+   - `lehmerInnerStep_residue_le`: per-step structure result.
+     Proves `ahat' = bhat ∧ bhat' < bhat` for any successful inner
+     step. Proof uses the existing `lehmerInnerStep_det` pattern
+     (`simp [lehmerInnerStep] at h`, two `split at h <;> simp_all`,
+     destructure the surviving equation), then `omega`.
+
+   - `lehmerInnerStep_max_le`: the corollary
+     `max ahat' bhat' ≤ max ahat bhat`. Direct from the structure
+     result and `le_max_right`.
+
+   - `lehmerCofactors_invariant_le`: existential multi-step version
+     strengthening Session-4's `lehmerCofactors_invariant` with
+     the residue bound. Same induction structure as the parent;
+     the recursive case combines per-step `_max_le` with the IH's
+     bound via `le_trans`.
+
+   - `lehmerCofactors_id_apply_le`: specialisation to `M = id` and
+     ghost-pair = input-pair. Direct from the multi-step lemma;
+     gives the closed form
+     `(ahat, bhat) · M = (ahat', bhat') ∧
+      max ahat' bhat' ≤ max ahat bhat` for `M = lehmerCofactors
+      fuel ahat bhat id`.
+
+3. Verified the file via Docker build.
+
+### Key Findings
+
+- **Step 2 splits cleanly into 2a (residue monotonicity) and 2b
+  (entry bound).** Session-4's plan named "entry bound from
+  invariant + residue monotonicity + Cramer" as one piece; in
+  practice the residue monotonicity is a self-contained ~30-line
+  lemma that doesn't need the determinant or the invariant.
+  Separating it lets 2b focus narrowly on the Cramer inversion.
+
+- **The proof of `lehmerInnerStep_residue_le` is mechanical.** The
+  per-step structure (`ahat' = bhat`, `bhat' = ahat % bhat`) is
+  exactly the Euclidean update; `omega` handles the inequality
+  given `bhat ≠ 0` from the surviving branch.
+
+- **`lehmerInnerStep_max_le` is the right shape for induction.**
+  The conjunction `ahat' = bhat ∧ bhat' < bhat` is too specific
+  to thread through the multi-step induction directly; the
+  weaker `max ahat' bhat' ≤ max ahat bhat` composes via
+  transitivity and is exactly what `_invariant_le` needs.
+
+### Files Modified
+
+- `proofs/Proofs/BinaryGcdOQ03OQ02.lean`: 450 → 541 lines.
+  Four new theorems in PART IV. 0 axioms, 1 unchanged sorry
+  (in `hgcdMatrix_size_reduction`).
+
+### Next Steps
+
+Step 2b: Cramer-inversion entry bound. With
+`lehmerCofactors_id_apply_le` in hand we have
+`(ahat, bhat) · M = (ahat', bhat')` with `max ahat' bhat' ≤
+max ahat bhat` and `det M = ±1`. Cramer's rule gives
+
+```
+ahat = ±(δ · ahat' - β · bhat')
+bhat = ±(α · bhat' - γ · ahat')
+```
+
+so by the standard identity for unimodular 2×2 matrices,
+the cofactor entries can be bounded by the input size. The
+delicate point is what to do when `ahat' = 0` or `bhat' = 0`
+(either residue degenerate). One option: state the Cramer
+identity as a triangular bound (e.g. `|α| · ahat' + |γ| · bhat' =
+|ahat|`) and recover individual entry bounds from it; another
+is to handle the `bhat' = 0` case separately (algorithm has
+terminated, `bhat = 0` originally, trivial bound).
+
+Step 3: perturbation analysis. After the entry bound, combine
+with `applyToNat M aHi bHi → applyToNat M a b` low-bit error
+(of size `2^shift · max(|α|+|γ|, |β|+|δ|)`) and the half-
+bitsize bound on the Hi-pair to close the size-reduction
+inequality.
+
+### Honest Assessment
+
+This session removes one of the two prerequisites for the entry-
+bound argument. It is a *modest* result — the lemma is short
+and follows known patterns from `BinaryGcdOQ03.lean` — but it
+is on the critical path: without `lehmerCofactors_id_apply_le`
+the Cramer step in 2b has no cofactor-side bound to invoke.
+The size-reduction sorry remains unchanged in count, which is
+the honest read: this is intermediate-step infrastructure,
+not a result anyone will cite without 2b/3 also closed.

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -1,31 +1,72 @@
 # Current State
 
-**Phase**: ORIENT
-**Since**: 2026-04-28
-**Iteration**: 2
+**Phase**: ACT
+**Since**: 2026-05-01
+**Iteration**: 3
 
 ## Current Focus
 
-Decide scope of formalization: correctness-only (recommended) vs correctness-plus-complexity (deferred). See knowledge.md "Research strategy (recommended)" for the split.
+Proving the **size-reduction lemma** `hgcdMatrix_size_reduction` —
+the only sorry remaining in `proofs/Proofs/BinaryGcdOQ03OQ02.lean`.
+
+Quantitative target:
+
+```
+bitsize (max (applyToNat (hgcdMatrix fuel a b) a b).1
+             (applyToNat (hgcdMatrix fuel a b) a b).2)
+  ≤ bitsize (max a b) / 2 + (hgcdThreshold + 2)
+```
 
 ## Active Approach
 
-Session 1 survey recommendation: pursue **correctness-only** formalization of `hgcdMatrix : ℕ → ℕ → CofactorMatrix` in a new `BinaryGcdOQ03OQ02.lean`, reusing the cofactor-matrix machinery already verified in `BinaryGcdOQ03.lean`. Defer the O(M(n)·log n) complexity claim until Mathlib has a bit-complexity model and fast multiplication.
+**Correctness-only formalization** as recommended by Session 1.
+Session 2 (2026-05-01) executed the recommendation:
+
+1. Defined `hgcdMatrix : ℕ → ℕ → ℕ → CofactorMatrix` (recursive HGCD
+   with explicit fuel; two recursive calls composed via
+   `CofactorMatrix.mul`).
+2. Proved `hgcdMatrix_det_unit` — the matrix is unimodular (det = ±1).
+3. Proved `hgcdMatrix_apply_gcd` — applying it preserves `Nat.gcd`.
+4. Stated `hgcdMatrix_size_reduction` with the precise quantitative
+   bound (sorry, deferred).
+5. Documented the bit-complexity claim (C) as a Mathlib infrastructure
+   gap in a Part-V comment.
+
+The two correctness theorems were essentially mechanical given the
+existing `BinaryGcdOQ03.lean` cofactor-matrix machinery. The
+size-reduction lemma is the genuinely new content.
 
 ## Blockers
 
-- **Complexity claim only**: O(M(n)·log n) is currently unfalsifiable in Lean. Mathlib has no bit-complexity model for arithmetic operations and no fast multiplication (Karatsuba / Toom-Cook / FFT). Filling these gaps is a multi-thousand-line foundational project that should not be attempted as part of an HGCD formalization.
-
-No blocker on the correctness side; all needed cofactor-matrix machinery exists.
+* **Size reduction proof** requires an entry bound on
+  `lehmerCofactors`: each entry of the accumulated matrix should be
+  at most roughly `2^(fuel+1)`. This Lehmer entry-bound lemma does not
+  appear to exist either in Mathlib or in `BinaryGcdOQ03.lean`, and
+  must be proved inline.
+* **Bit complexity (C)** remains genuinely blocked: Mathlib has no
+  bit-complexity model and no fast multiplication. This is documented
+  in `BinaryGcdOQ03OQ02.lean` Part V; not a blocker on (A) and (B).
 
 ## Next Action
 
-1. Confirm scope decision (correctness-only).
-2. Draft `hgcdMatrix` definition + termination measure (`bitsize a + bitsize b`).
-3. State and prove the size-reduction lemma: applying `hgcdMatrix(a,b)` to `(a,b)` yields `(a',b')` with `bitsize(max a' b') ≤ bitsize(max a b)/2 + O(1)`. This is the only genuinely new mathematical content vs. the existing Lehmer formalization.
+1. Prove the Lehmer accumulator entry bound:
+   `(lehmerCofactors fuel ahat bhat M).α ≤ ... bound ...` (and
+   analogous for β, γ, δ). Likely by induction on fuel using
+   `lehmerInnerStep_det` and the explicit step form
+   `euclidStepMatrix q = ⟨0, 1, 1, -q⟩`.
+2. Combine the entry bound with Cramer's rule (inverse of a
+   unimodular matrix has the same entry bound up to sign) to bound
+   `applyToNat (hgcdTopHalfStep a b) a b` by
+   `2^(bitsize(max a b)/2 + 2)`.
+3. Iterate the half-reduction twice (once at the top level, once in
+   the recursive call) to close `hgcdMatrix_size_reduction`.
+4. Once size reduction is proved, replace the explicit-fuel
+   definition with a `WellFounded.fix` definition (lexicographic
+   on `bitsize`).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+* Total attempts: 1 (Session 2 — skeleton + det/gcd theorems)
+* Current approach attempts: 1
+* Approaches tried: 1 (HGCD as Lehmer-step composition with
+  explicit fuel)

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: ACT
 **Since**: 2026-05-01
-**Iteration**: 5
+**Iteration**: 6
 
 ## Current Focus
 
@@ -96,9 +96,43 @@ convention; see "Active Approach").
 The two correctness theorems remain mechanical given the existing
 cofactor-matrix machinery. The size-reduction lemma is the genuinely
 new content, and its statement is now well-aligned with the actual
-algorithm semantics. Step 1 (invariant) is now done; Steps 2 (entry
-bound from invariant + residue monotonicity + Cramer) and 3
-(perturbation analysis from low bits) remain.
+algorithm semantics. Step 1 (invariant) is done; Step 2a (residue
+monotonicity) is done as of Session 5; Step 2b (entry bound via
+Cramer inversion) and Step 3 (perturbation analysis) remain.
+
+* Session 5 (2026-05-02) executed Step 2a of the next-action plan:
+  residue monotonicity for `lehmerCofactors`.
+
+  Four new theorems extending PART IV of `BinaryGcdOQ03OQ02.lean`:
+
+  - `lehmerInnerStep_residue_le`: per-step bound. A successful
+    `lehmerInnerStep` returns `ahat' = bhat` and `bhat' < bhat`.
+    Proof follows the `lehmerInnerStep_det` pattern: unfold the
+    definition, two `split at h <;> simp_all` calls eliminate the
+    `if` chain, and `omega` handles `ahat % bhat < bhat`.
+
+  - `lehmerInnerStep_max_le`: corollary. `max ahat' bhat' ≤
+    max ahat bhat`.
+
+  - `lehmerCofactors_invariant_le`: strengthens
+    `lehmerCofactors_invariant` (Session 4) with the residue bound
+    `max ahat' bhat' ≤ max ahat bhat`. Same induction structure as
+    the parent, threading `lehmerInnerStep_max_le` through each
+    recursive step via transitivity.
+
+  - `lehmerCofactors_id_apply_le`: specialisation to `M = id` and
+    ghost pair = input pair. Combined statement: row-applying the
+    accumulated cofactor matrix to `(ahat, bhat)` yields a Euclidean-
+    residue pair whose max is bounded by `max ahat bhat`.
+
+  This gives the residue-side bound used in the size-reduction
+  argument. The remaining piece (Step 2b) is a Cramer-inversion
+  bound on the cofactor entries: from
+  `a₀ M.α + b₀ M.γ = ahat'` and `a₀ M.β + b₀ M.δ = bhat'` with
+  `det M = ±1`, Cramer gives the entries in terms of `(a₀, b₀)`
+  and `(ahat', bhat')`. With residue monotonicity providing
+  `(ahat', bhat') ≤ (ahat, bhat)` componentwise (in max), this
+  closes the entry bound.
 
 ## Blockers
 
@@ -116,18 +150,19 @@ bound from invariant + residue monotonicity + Cramer) and 3
 1. ✅ **Done in Session 4**: Matrix-vector invariant
    (`lehmerCofactors_invariant`).
 
-2. **Lehmer accumulator entry bound** (next-session focus). With the
-   matrix-vector invariant in hand, the entry bound follows from
-   Cramer's rule on the inverse and the Euclidean-residue
-   monotonicity bound `bhat_final ≤ bhat₀`.
+2a. ✅ **Done in Session 5**: Residue monotonicity
+    (`lehmerCofactors_invariant_le`, `lehmerCofactors_id_apply_le`).
 
-   Concretely: from `a₀ * M.α + b₀ * M.γ = ahat'` and
-   `a₀ * M.β + b₀ * M.δ = bhat'` with `det M = ±1`, Cramer gives
-   `a₀ = ±(δ * ahat' - β * bhat')` and `b₀ = ±(α * bhat' - γ * ahat')`,
-   so `|α|, |β|, |γ|, |δ|` are bounded by `max(|a₀|, |b₀|)` whenever
-   the corresponding residue is `≥ 1`. Combined with residue
-   monotonicity, this gives the entry bound on `lehmerCofactors`
-   needed for size reduction.
+2b. **Cramer-inversion entry bound** (next-session focus). From
+   `lehmerCofactors_id_apply_le` we have
+   `(ahat, bhat) · M = (ahat', bhat')` with `max ahat' bhat' ≤
+   max ahat bhat` and `det M = ±1`. Cramer's rule gives
+   `ahat = ±(δ · ahat' - β · bhat')` and `bhat = ±(α · bhat' -
+   γ · ahat')`, from which one extracts entry bounds in terms of
+   `(ahat, bhat)`. Care is needed on degenerate residue values
+   (e.g. `bhat' = 0`). The Lean version will likely state the
+   bound `|α|, |γ| ≤ ahat` (and `|β|, |δ| ≤ bhat`) on a generic
+   non-degenerate run, then handle the degenerate case separately.
 
 3. **Perturbation analysis**: combine the entry bound with
    `applyToNat M a b = (a · M.α + b · M.γ, a · M.β + b · M.δ)` and
@@ -144,8 +179,8 @@ bound from invariant + residue monotonicity + Cramer) and 3
 
 ## Attempt Counts
 
-* Total attempts: 3 (Session 2 — skeleton; Session 3 — convention fix;
-  Session 4 — matrix-vector invariant)
-* Current approach attempts: 3
+* Total attempts: 4 (Session 2 — skeleton; Session 3 — convention fix;
+  Session 4 — matrix-vector invariant; Session 5 — residue monotonicity)
+* Current approach attempts: 4
 * Approaches tried: 1 (HGCD as Lehmer-step composition with explicit
   fuel; row-vector cofactor convention)

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: ACT
 **Since**: 2026-05-01
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
 
@@ -11,6 +11,9 @@ only sorry remaining in `proofs/Proofs/BinaryGcdOQ03OQ02.lean`. The
 Session-3 (2026-05-01) work corrected a cofactor-convention mismatch
 that would have made the lemma *false as previously stated*; the
 lemma is now well-typed against the actual Lehmer-reduced pair.
+Session 4 (2026-05-01) added the **matrix-vector invariant** for
+`lehmerCofactors` — the foundational lemma underpinning the entry-
+bound argument, which is Step 2 in the multi-step proof plan.
 
 Quantitative target:
 
@@ -68,10 +71,34 @@ convention; see "Active Approach").
   - File-level docstring and `applyToNat` docstring document the
     convention and the worked counterexample.
 
+* Session 4 (2026-05-01) executed Step 1 of the next-action plan:
+  the matrix-vector invariant for `lehmerCofactors`.
+
+  Three new theorems in a new PART IV of `BinaryGcdOQ03OQ02.lean`
+  (parts V/VI/VII renumbered):
+
+  - `lehmerInnerStep_invariant`: per-step invariant. Given a "ghost
+    original pair" `(a₀, b₀)` consistent with the current state
+    `(ahat, bhat, M)` via `(a₀, b₀) · M = (ahat, bhat)`, the
+    relation persists across one `lehmerInnerStep`. Proof unfolds
+    `lehmerInnerStep`, splits on the two `if` branches, then
+    discharges using `h_inv₁ - q · h_inv₂` plus `Nat.div_add_mod`.
+
+  - `lehmerCofactors_invariant`: existential multi-step version.
+    Inductive on `fuel`, applying the per-step lemma in the
+    successor case via `match hstep : lehmerInnerStep ahat bhat M
+    with` (the same destructuring pattern used in the existing
+    `lehmerCofactors_det_unit` proof).
+
+  - `lehmerCofactors_id_apply_eq`: specialisation to `M = id` and
+    ghost pair = input pair. Direct corollary.
+
 The two correctness theorems remain mechanical given the existing
 cofactor-matrix machinery. The size-reduction lemma is the genuinely
 new content, and its statement is now well-aligned with the actual
-algorithm semantics.
+algorithm semantics. Step 1 (invariant) is now done; Steps 2 (entry
+bound from invariant + residue monotonicity + Cramer) and 3
+(perturbation analysis from low bits) remain.
 
 ## Blockers
 
@@ -86,24 +113,39 @@ algorithm semantics.
 
 ## Next Action
 
-1. Prove the Lehmer accumulator entry bound:
-   `(lehmerCofactors fuel ahat bhat M).α ≤ ... bound ...` (and
-   analogous for β, γ, δ). Likely by induction on fuel using
-   `lehmerInnerStep_det` and the explicit step form
-   `euclidStepMatrix q = ⟨0, 1, 1, -q⟩`.
-2. Combine the entry bound with Cramer's rule (inverse of a
-   unimodular matrix has the same entry bound up to sign) to bound
-   `applyToNat (hgcdTopHalfStep a b) a b` by
-   `2^(bitsize(max a b)/2 + 2)`.
-3. Iterate the half-reduction twice (once at the top level, once in
-   the recursive call) to close `hgcdMatrix_size_reduction`.
-4. Once size reduction is proved, replace the explicit-fuel
+1. ✅ **Done in Session 4**: Matrix-vector invariant
+   (`lehmerCofactors_invariant`).
+
+2. **Lehmer accumulator entry bound** (next-session focus). With the
+   matrix-vector invariant in hand, the entry bound follows from
+   Cramer's rule on the inverse and the Euclidean-residue
+   monotonicity bound `bhat_final ≤ bhat₀`.
+
+   Concretely: from `a₀ * M.α + b₀ * M.γ = ahat'` and
+   `a₀ * M.β + b₀ * M.δ = bhat'` with `det M = ±1`, Cramer gives
+   `a₀ = ±(δ * ahat' - β * bhat')` and `b₀ = ±(α * bhat' - γ * ahat')`,
+   so `|α|, |β|, |γ|, |δ|` are bounded by `max(|a₀|, |b₀|)` whenever
+   the corresponding residue is `≥ 1`. Combined with residue
+   monotonicity, this gives the entry bound on `lehmerCofactors`
+   needed for size reduction.
+
+3. **Perturbation analysis**: combine the entry bound with
+   `applyToNat M a b = (a · M.α + b · M.γ, a · M.β + b · M.δ)` and
+   the decomposition `a = aHi · 2^shift + aLo` (similar for `b`)
+   to bound the residual by `2^shift · (residue(aHi, bHi) +
+   |M.α| + |M.γ|)`.
+
+4. **Iterate** the half-reduction (top-half + recursive call)
+   to close `hgcdMatrix_size_reduction`.
+
+5. Once size reduction is proved, replace the explicit-fuel
    definition with a `WellFounded.fix` definition (lexicographic
    on `bitsize`).
 
 ## Attempt Counts
 
-* Total attempts: 2 (Session 2 — skeleton; Session 3 — convention fix)
-* Current approach attempts: 2
+* Total attempts: 3 (Session 2 — skeleton; Session 3 — convention fix;
+  Session 4 — matrix-vector invariant)
+* Current approach attempts: 3
 * Approaches tried: 1 (HGCD as Lehmer-step composition with explicit
   fuel; row-vector cofactor convention)

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -2,12 +2,15 @@
 
 **Phase**: ACT
 **Since**: 2026-05-01
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
 
-Proving the **size-reduction lemma** `hgcdMatrix_size_reduction` —
-the only sorry remaining in `proofs/Proofs/BinaryGcdOQ03OQ02.lean`.
+Proving the **size-reduction lemma** `hgcdMatrix_size_reduction` — the
+only sorry remaining in `proofs/Proofs/BinaryGcdOQ03OQ02.lean`. The
+Session-3 (2026-05-01) work corrected a cofactor-convention mismatch
+that would have made the lemma *false as previously stated*; the
+lemma is now well-typed against the actual Lehmer-reduced pair.
 
 Quantitative target:
 
@@ -17,24 +20,58 @@ bitsize (max (applyToNat (hgcdMatrix fuel a b) a b).1
   ≤ bitsize (max a b) / 2 + (hgcdThreshold + 2)
 ```
 
+where `applyToNat M a b = (a·M.α + b·M.γ, a·M.β + b·M.δ)` (row
+convention; see "Active Approach").
+
 ## Active Approach
 
 **Correctness-only formalization** as recommended by Session 1.
-Session 2 (2026-05-01) executed the recommendation:
 
-1. Defined `hgcdMatrix : ℕ → ℕ → ℕ → CofactorMatrix` (recursive HGCD
-   with explicit fuel; two recursive calls composed via
-   `CofactorMatrix.mul`).
-2. Proved `hgcdMatrix_det_unit` — the matrix is unimodular (det = ±1).
-3. Proved `hgcdMatrix_apply_gcd` — applying it preserves `Nat.gcd`.
-4. Stated `hgcdMatrix_size_reduction` with the precise quantitative
-   bound (sorry, deferred).
-5. Documented the bit-complexity claim (C) as a Mathlib infrastructure
-   gap in a Part-V comment.
+* Session 2 (2026-05-01) put down the skeleton: `hgcdMatrix`,
+  det-unit, gcd preservation, and the size-reduction lemma stated
+  with `sorry`.
+* Session 3 (2026-05-01) discovered and fixed a cofactor-convention
+  mismatch:
 
-The two correctness theorems were essentially mechanical given the
-existing `BinaryGcdOQ03.lean` cofactor-matrix machinery. The
-size-reduction lemma is the genuinely new content.
+  `lehmerCofactors` in `BinaryGcdOQ03.lean` accumulates the cofactor
+  matrix in the **row-vector** convention: each Lehmer step
+  `S_k = ⟨0, 1, 1, -q⟩` *right*-multiplies the accumulator
+  (`M' = M · S_k`), so the maintained invariant is
+  `(a₀, b₀) · M = (current pair)`.
+
+  The previous Session-2 `applyToNat` used `M.apply` (column-vector
+  product `M · (a, b)ᵀ`). This is *not* the row product
+  `(a, b) · M`; the two differ as soon as `M.β ≠ M.γ`, which happens
+  whenever Lehmer runs ≥ 2 steps with different quotients.
+
+  Concrete counterexample (now a `native_decide` test in the file):
+  for `(a, b) = (1000, 300)`, Lehmer on the top half `(31, 9)` builds
+  `M = ⟨1, -2, -3, 7⟩`. Row-apply gives `(100, 100)` — reduced;
+  column-apply gives `(400, 900)` — *larger* than the input. Both
+  preserve gcd `100`, but only row-apply realises the half-bitsize
+  reduction the size-reduction lemma claims.
+
+  Fix in Session 3:
+
+  - `applyToNat` rewritten to `(a·M.α + b·M.γ, a·M.β + b·M.δ)`.
+  - `hgcdMatrix` recursive composition swapped from
+    `M_rec.mul M_top` to `M_top.mul M_rec`, so that
+    `(a, b) · (M_top · M_rec)` reads "apply top first, then recurse"
+    in row convention.
+  - `hgcdMatrix_apply_gcd` restated with the row product on the
+    left-hand side; the proof reduces to `gcd_cofactor_eq` applied
+    to the relabelled coefficients
+    `(α, β, γ, δ) ← (M.α, M.γ, M.β, M.δ)` (det condition is
+    symmetric under the swap `β ↔ γ`).
+  - `hgcdMatrix_det_unit` updated to feed
+    `mul_unit_of_unit_of_unit` in the new argument order.
+  - File-level docstring and `applyToNat` docstring document the
+    convention and the worked counterexample.
+
+The two correctness theorems remain mechanical given the existing
+cofactor-matrix machinery. The size-reduction lemma is the genuinely
+new content, and its statement is now well-aligned with the actual
+algorithm semantics.
 
 ## Blockers
 
@@ -66,7 +103,7 @@ size-reduction lemma is the genuinely new content.
 
 ## Attempt Counts
 
-* Total attempts: 1 (Session 2 — skeleton + det/gcd theorems)
-* Current approach attempts: 1
-* Approaches tried: 1 (HGCD as Lehmer-step composition with
-  explicit fuel)
+* Total attempts: 2 (Session 2 — skeleton; Session 3 — convention fix)
+* Current approach attempts: 2
+* Approaches tried: 1 (HGCD as Lehmer-step composition with explicit
+  fuel; row-vector cofactor convention)

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -31,20 +31,20 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-01T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "Prove hgcdMatrix_size_reduction (single sorry in BinaryGcdOQ03OQ02.lean). Requires entry-bound lemma on lehmerCofactors.",
+    "iteration": 4,
+    "focus": "Prove hgcdMatrix_size_reduction (single sorry in BinaryGcdOQ03OQ02.lean). Step 1 (matrix-vector invariant for lehmerCofactors) DONE in Session 4; Steps 2 (entry bound via Cramer + residue monotonicity) and 3 (perturbation analysis from low bits) remain.",
     "blockers": [
       "Bit complexity (C) remains genuinely Mathlib-blocked: no bit-complexity model, no fast multiplication. Documented as deferred in BinaryGcdOQ03OQ02.lean Part V."
     ],
-    "nextAction": "Prove entry bound on lehmerCofactors entries (each ≤ ~2^(fuel+1)); use Cramer inversion to bound applyToNat output by 2^(bitsize(max a b)/2 + 2); iterate to close hgcdMatrix_size_reduction.",
+    "nextAction": "Prove the Lehmer accumulator entry bound using the now-available matrix-vector invariant + Cramer inversion on the unimodular cofactor (|α|, |β|, |γ|, |δ| ≤ max(|a₀|, |b₀|) / max(ahat', bhat')) plus a small Euclidean residue monotonicity lemma. Then combine with the (a = aHi·2^shift + aLo) decomposition for the perturbation argument.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 3, 2026-05-01): cofactor-convention fix landed. applyToNat now uses row-vector product matching the lehmerCofactors accumulator; hgcdMatrix mul order swapped; hgcdMatrix_apply_gcd restated and re-proved; native_decide example demonstrates the (1000,300) reduction. hgcdMatrix_size_reduction is now well-typed against the actual Lehmer-reduced pair (was false-as-stated under Session-2 column convention). Sorry count unchanged at 1; axiom count unchanged at 0. Separate follow-up: BinaryGcdOQ03.lean lehmerReduce has the same column-apply issue but is gcd-correct via fuel/fallback.",
+    "progressSummary": "PROGRESS (Session 4, 2026-05-01): matrix-vector invariant for lehmerCofactors added — three new theorems in BinaryGcdOQ03OQ02.lean PART IV (lehmerInnerStep_invariant, lehmerCofactors_invariant, lehmerCofactors_id_apply_eq). This is Step 1 of three for hgcdMatrix_size_reduction; Steps 2-3 (entry bound via Cramer + residue monotonicity, perturbation analysis from low bits) remain. Sorry count unchanged at 1; axiom count unchanged at 0. Build verification blocked by Docker daemon unresponsiveness (same pattern as Session 3); proofs mirror existing lehmerInnerStep_det / lehmerCofactors_det_unit patterns.",
     "builtItems": [
       "hgcdThreshold (BinaryGcdOQ03OQ02.lean): bottom-out threshold for HGCD recursion.",
       "hgcdTopHalfStep (BinaryGcdOQ03OQ02.lean): one Lehmer-style reduction on the top half of the bits.",
@@ -57,7 +57,11 @@
       "BinaryGcdOQ03OQ02.lean: applyToNat rewritten to row-vector product (Session 3)",
       "BinaryGcdOQ03OQ02.lean: hgcdMatrix recursive composition reordered to M_top.mul M_rec (Session 3)",
       "BinaryGcdOQ03OQ02.lean: hgcdMatrix_apply_gcd restated and re-proved against the row product, via gcd_cofactor_eq with relabelled (α, β, γ, δ) ← (M.α, M.γ, M.β, M.δ) (Session 3)",
-      "BinaryGcdOQ03OQ02.lean: native_decide example pinning row-apply behaviour on (1000, 300) → (100, 100) (Session 3)"
+      "BinaryGcdOQ03OQ02.lean: native_decide example pinning row-apply behaviour on (1000, 300) → (100, 100) (Session 3)",
+      "BinaryGcdOQ03OQ02.lean PART IV (Session 4): lehmerInnerStep_invariant — per-step matrix-vector invariant for lehmerInnerStep (ghost original pair (a₀, b₀) with (a₀, b₀) · M = (current pair) is preserved across one step).",
+      "BinaryGcdOQ03OQ02.lean PART IV (Session 4): lehmerCofactors_invariant — existential multi-step matrix-vector invariant for lehmerCofactors, by induction on fuel.",
+      "BinaryGcdOQ03OQ02.lean PART IV (Session 4): lehmerCofactors_id_apply_eq — specialisation to M = id and ghost pair = input pair (a, b).",
+      "BinaryGcdOQ03OQ02.lean: file reorganised PART IV (size reduction → V), V (complexity → VI), VI (sanity checks → VII); file-level docstring and final summary updated to mention the matrix-vector invariant."
     ],
     "insights": [
       "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
@@ -71,7 +75,11 @@
       "Session 2: the genuinely new content is the entry-bound lemma on lehmerCofactors — an upper bound roughly 2^(fuel+1) on each entry. This bound does not appear in Mathlib or BinaryGcdOQ03.lean and must be proved inline (likely 30-80 lines).",
       "Session 3 (2026-05-01): discovered cofactor-convention mismatch in BinaryGcdOQ03OQ02.lean. lehmerCofactors accumulates M in row-vector convention (M • S right-multiplication, invariant (a₀,b₀)·M = current pair), but the Session-2 applyToNat used CofactorMatrix.apply (column product M·(a,b)ᵀ). Products differ once M.β ≠ M.γ (i.e., for ≥2 Lehmer steps with distinct quotients). Counterexample (1000, 300): row-apply gives reduced (100, 100); column-apply gives (400, 900) — *not* reduced. Both preserve gcd; only row-apply realises the half-bitsize reduction.",
       "Session 3: hgcdMatrix_size_reduction was therefore false-as-stated under the column-apply applyToNat. The lemma is now well-typed against the actual Lehmer-reduced pair after rewriting applyToNat to (a·M.α + b·M.γ, a·M.β + b·M.δ) and swapping the recursive mul order to M_top.mul M_rec.",
-      "Session 3 (separate finding): BinaryGcdOQ03.lean lehmerReduce uses the same column-apply formula on a row-accumulated cofactor, so the Lehmer step in the existing algorithm does not actually realise a reduction either. lehmerGcd is still gcd-correct via fuel exhaustion + euclidGcd fallback. Worth a follow-up issue on the OQ-03 line."
+      "Session 3 (separate finding): BinaryGcdOQ03.lean lehmerReduce uses the same column-apply formula on a row-accumulated cofactor, so the Lehmer step in the existing algorithm does not actually realise a reduction either. lehmerGcd is still gcd-correct via fuel exhaustion + euclidGcd fallback. Worth a follow-up issue on the OQ-03 line.",
+      "Session 4 (2026-05-01): the matrix-vector invariant requires generalisation to a 'ghost original pair' (a₀, b₀) parameterised at the theorem level — not just (a₀, b₀) = (input ahat, input bhat). The naive form would not survive the inductive step because the current pair changes; the ghost pair stays fixed.",
+      "Session 4: per-step / multi-step decomposition mirrors the existing lehmerInnerStep_det / lehmerCofactors_det_unit split. Per-step lemma carries the arithmetic (Nat.div_add_mod + ℤ-cast handling); multi-step lemma is purely structural induction.",
+      "Session 4: Sign tracking is automatic when stating (a₀, b₀) over ℤ — no Nat-subtraction-truncation worries. Only ℕ↔ℤ bridging is in the Euclidean modulo step.",
+      "Session 4: the existential form (∃ ahat' bhat', ...) avoids defining a parallel 'track residues' function. The explicit residues aren't needed for the entry-bound argument that follows — only their existence + the invariant relation."
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -80,11 +88,11 @@
       "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
     ],
     "nextSteps": [
-      "Prove the Lehmer accumulator entry bound: |M.α|, |M.β|, |M.γ|, |M.δ| ≤ max(ahat, bhat) + 1 (or simple polynomial bound) for M = lehmerCofactors fuel ahat bhat id. Most likely route: maintain the matrix-vector invariant (ahat₀, bhat₀) · M = (current pair) as a theorem, combine with sign-tracking on the alternating cofactor parities.",
-      "Combine the entry bound with the row-product expansion (a = aHi·2^shift + aLo, similar for b) to bound the residual by 2^shift · (aHi' + |M.α| + |M.γ|).",
-      "Iterate the half-reduction (top + recursive call) to close the threshold gap and discharge hgcdMatrix_size_reduction.",
-      "Once size reduction is proved, replace explicit-fuel hgcdMatrix with a WellFounded.fix definition (lexicographic on bitsize).",
-      "Follow-up issue on BinaryGcdOQ03.lean: lehmerReduce uses column-apply on a row-accumulated cofactor; lehmerGcd remains gcd-correct only by fuel exhaustion + euclidGcd fallback."
+      "Step 2 (next session): Lehmer accumulator entry bound. With the matrix-vector invariant (lehmerCofactors_invariant) and det = ±1 (lehmerCofactors_det_unit), Cramer inversion gives a₀ = ±(δ·ahat' - β·bhat'), b₀ = ±(α·bhat' - γ·ahat'). Combined with bhat' < ahat' (Euclidean residue monotonicity, separate small lemma using Nat.mod_lt), this gives |α|, |β|, |γ|, |δ| ≤ max(|a₀|, |b₀|) / max(ahat', bhat').",
+      "Step 3: combine entry bound with applyToNat M a b = (a·M.α + b·M.γ, a·M.β + b·M.δ) and decomposition a = aHi·2^shift + aLo (similar b). Bound residual by 2^shift · (residue(aHi, bHi) + |M.α| + |M.γ|).",
+      "Step 4: iterate the half-reduction (top-half + recursive call) to discharge hgcdMatrix_size_reduction's threshold gap.",
+      "Step 5: once size reduction is proved, replace explicit-fuel hgcdMatrix with a WellFounded.fix definition (lexicographic on bitsize).",
+      "Follow-up issue on BinaryGcdOQ03.lean: lehmerReduce uses column-apply on a row-accumulated cofactor; lehmerGcd remains gcd-correct only by fuel exhaustion + euclidGcd fallback. (Open since Session 3.)"
     ]
   },
   "tags": [
@@ -104,7 +112,7 @@
     "mathlib": []
   },
   "started": "2026-04-26T08:56:57.650Z",
-  "lastUpdate": "2026-05-01T00:00:00.000Z",
+  "lastUpdate": "2026-05-01T15:04:42Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -29,30 +29,42 @@
     "goal": "Formalize parts (A) and (B) of the problem statement in BinaryGcdOQ03OQ02.lean. Document part (C) as deferred with a precise enumeration of the missing Mathlib infrastructure."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-04-26T08:56:57.650Z",
-    "iteration": 2,
-    "focus": "Decide scope: correctness-only HGCD formalization, or include complexity claim (deferred).",
+    "phase": "ACT",
+    "since": "2026-05-01T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Prove hgcdMatrix_size_reduction (single sorry in BinaryGcdOQ03OQ02.lean). Requires entry-bound lemma on lehmerCofactors.",
     "blockers": [
-      "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication."
+      "Bit complexity (C) remains genuinely Mathlib-blocked: no bit-complexity model, no fast multiplication. Documented as deferred in BinaryGcdOQ03OQ02.lean Part V."
     ],
-    "nextAction": "Confirm scope decision. If correctness-only: draft hgcdMatrix definition and termination measure in BinaryGcdOQ03OQ02.lean.",
+    "nextAction": "Prove entry bound on lehmerCofactors entries (each ≤ ~2^(fuel+1)); use Cramer inversion to bound applyToNat output by 2^(bitsize(max a b)/2 + 2); iterate to close hgcdMatrix_size_reduction.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED (Session 1, 2026-04-28): identified that the question splits into (A) HGCD correctness (tractable, all needed matrix machinery exists in BinaryGcdOQ03.lean) and (B) O(M(n) log n) complexity (blocked on Mathlib gaps: no fast multiplication, no bit-complexity model). Recommendation: pursue (A) only; defer (B) to a separate Mathlib-contribution initiative.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS (Session 2, 2026-05-01): correctness-only formalization started. Created BinaryGcdOQ03OQ02.lean (~190 lines, 0 axioms, 1 sorry) with hgcdMatrix definition (recursive HGCD with explicit fuel), proved hgcdMatrix_det_unit and hgcdMatrix_apply_gcd. Single remaining sorry is hgcdMatrix_size_reduction — the genuinely new mathematical content of the OQ. Bit-complexity claim (C) documented as Mathlib-blocked (Part V comment).",
+    "builtItems": [
+      "hgcdThreshold (BinaryGcdOQ03OQ02.lean): bottom-out threshold for HGCD recursion.",
+      "hgcdTopHalfStep (BinaryGcdOQ03OQ02.lean): one Lehmer-style reduction on the top half of the bits.",
+      "applyToNat (BinaryGcdOQ03OQ02.lean): apply a cofactor matrix to a non-negative pair, taking absolute values.",
+      "hgcdMatrix (BinaryGcdOQ03OQ02.lean): recursive HGCD with explicit fuel, two recursive calls composed via CofactorMatrix.mul.",
+      "hgcdTopHalfStep_det_unit (BinaryGcdOQ03OQ02.lean): top-half step is unimodular.",
+      "hgcdMatrix_det_unit (BinaryGcdOQ03OQ02.lean): recursive HGCD matrix is unimodular (induction on fuel).",
+      "hgcdMatrix_apply_gcd (BinaryGcdOQ03OQ02.lean): application of hgcdMatrix preserves Nat.gcd.",
+      "bitsize (BinaryGcdOQ03OQ02.lean): bitsize helper used in size-reduction statement."
+    ],
     "insights": [
       "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
       "The original question conflates two distinct claims: (A) HGCD algorithmic correctness (tractable, ~300-500 lines) and (B) O(M(n) log n) bit complexity (blocked on multiple Mathlib gaps).",
       "Mathlib has no half-GCD, Schoenhage, Karatsuba, or any fast multiplication; grep against Mathlib confirmed (2026-04-28). Mathlib Computability has Turing/primrec but no bit-complexity model for arithmetic.",
       "The complexity bound O(M(n) log n) is currently unfalsifiable in Lean: no model in which to state \"M(n) bit operations\". Proving (B) requires upstreaming a bit-complexity framework + fast multiplication first (multi-thousand-line project).",
       "The single hardest piece on the correctness side is termination of the HGCD recursion: need bitsize(max a b) strict decrease after applying the recursively-computed matrix, which requires showing the matrix accumulated >=1 Euclidean step.",
-      "Recommendation: split the question. Pursue (A) HGCD correctness as a self-contained verification; defer (B) until a complexity model lands in Mathlib or as a separate gallery initiative."
+      "Recommendation: split the question. Pursue (A) HGCD correctness as a self-contained verification; defer (B) until a complexity model lands in Mathlib or as a separate gallery initiative.",
+      "Session 2 (2026-05-01): det-unit and gcd-preservation halves of HGCD correctness were essentially mechanical given existing CofactorMatrix infrastructure — proved with one induction over fuel + a four-way rcases on determinant signs.",
+      "Session 2: explicit-fuel recursive definition lets us sidestep the termination proof entirely until size-reduction is established. Once size-reduction is proved, fuel can be replaced by WellFounded.fix on bitsize.",
+      "Session 2: the genuinely new content is the entry-bound lemma on lehmerCofactors — an upper bound roughly 2^(fuel+1) on each entry. This bound does not appear in Mathlib or BinaryGcdOQ03.lean and must be proved inline (likely 30-80 lines)."
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -61,11 +73,11 @@
       "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
     ],
     "nextSteps": [
-      "Decide scope: correctness-only (recommended, ~300-500 lines) vs correctness-plus-complexity (deferred, multi-thousand lines of foundational work).",
-      "If correctness-only: define hgcdMatrix : Nat -> Nat -> CofactorMatrix recursively in a new BinaryGcdOQ03OQ02.lean, with termination measure bitsize a + bitsize b; reuse cofactor_apply_gcd for the GCD invariance.",
-      "Prove the size-reduction lemma: applying hgcdMatrix(a,b) yields (a',b') with bitsize(max a' b') roughly bitsize(max a b)/2. This is the only genuinely new mathematical content vs the existing Lehmer formalization.",
-      "If complexity-in-scope: escalate to Architect or Hermit role - this becomes a separate Mathlib-contribution-class initiative (bit-complexity model + Karatsuba upstream).",
-      "Update problem statement: replace placeholder formal-statement-to-be-added with a concrete Lean-style spec, e.g. correctness: hgcdMatrix a b applied to (a,b) preserves Nat.gcd a b."
+      "Prove the Lehmer accumulator entry bound: each entry of (lehmerCofactors fuel ahat bhat M) is at most ~2^(fuel+1). Likely by induction on fuel using lehmerInnerStep_det and the explicit step form euclidStepMatrix q = ⟨0, 1, 1, -q⟩.",
+      "Combine the entry bound with Cramer's rule (inverse of unimodular matrix has same entry bound up to sign) to bound applyToNat (hgcdTopHalfStep a b) a b by 2^(bitsize(max a b)/2 + 2).",
+      "Iterate the half-reduction twice (top-level + recursive call) to close hgcdMatrix_size_reduction.",
+      "Once size reduction is proved, replace the explicit-fuel definition with a WellFounded.fix definition (lexicographic on bitsize).",
+      "(Optional, lower priority) Wire hgcdMatrix into lehmerGcd to give a recursive variant hgcdGcd and prove hgcdGcd a b = Nat.gcd a b."
     ]
   },
   "tags": [
@@ -85,7 +97,7 @@
     "mathlib": []
   },
   "started": "2026-04-26T08:56:57.650Z",
-  "lastUpdate": "2026-04-28T00:00:00.000Z",
+  "lastUpdate": "2026-05-01T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -143,6 +155,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ03OQ02.lean",
+      "filename": "BinaryGcdOQ03OQ02.lean",
+      "lineCount": 222,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }
   ]
 }

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 2, 2026-05-01): correctness-only formalization started. Created BinaryGcdOQ03OQ02.lean (~190 lines, 0 axioms, 1 sorry) with hgcdMatrix definition (recursive HGCD with explicit fuel), proved hgcdMatrix_det_unit and hgcdMatrix_apply_gcd. Single remaining sorry is hgcdMatrix_size_reduction — the genuinely new mathematical content of the OQ. Bit-complexity claim (C) documented as Mathlib-blocked (Part V comment).",
+    "progressSummary": "PROGRESS (Session 3, 2026-05-01): cofactor-convention fix landed. applyToNat now uses row-vector product matching the lehmerCofactors accumulator; hgcdMatrix mul order swapped; hgcdMatrix_apply_gcd restated and re-proved; native_decide example demonstrates the (1000,300) reduction. hgcdMatrix_size_reduction is now well-typed against the actual Lehmer-reduced pair (was false-as-stated under Session-2 column convention). Sorry count unchanged at 1; axiom count unchanged at 0. Separate follow-up: BinaryGcdOQ03.lean lehmerReduce has the same column-apply issue but is gcd-correct via fuel/fallback.",
     "builtItems": [
       "hgcdThreshold (BinaryGcdOQ03OQ02.lean): bottom-out threshold for HGCD recursion.",
       "hgcdTopHalfStep (BinaryGcdOQ03OQ02.lean): one Lehmer-style reduction on the top half of the bits.",
@@ -53,7 +53,11 @@
       "hgcdTopHalfStep_det_unit (BinaryGcdOQ03OQ02.lean): top-half step is unimodular.",
       "hgcdMatrix_det_unit (BinaryGcdOQ03OQ02.lean): recursive HGCD matrix is unimodular (induction on fuel).",
       "hgcdMatrix_apply_gcd (BinaryGcdOQ03OQ02.lean): application of hgcdMatrix preserves Nat.gcd.",
-      "bitsize (BinaryGcdOQ03OQ02.lean): bitsize helper used in size-reduction statement."
+      "bitsize (BinaryGcdOQ03OQ02.lean): bitsize helper used in size-reduction statement.",
+      "BinaryGcdOQ03OQ02.lean: applyToNat rewritten to row-vector product (Session 3)",
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix recursive composition reordered to M_top.mul M_rec (Session 3)",
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix_apply_gcd restated and re-proved against the row product, via gcd_cofactor_eq with relabelled (α, β, γ, δ) ← (M.α, M.γ, M.β, M.δ) (Session 3)",
+      "BinaryGcdOQ03OQ02.lean: native_decide example pinning row-apply behaviour on (1000, 300) → (100, 100) (Session 3)"
     ],
     "insights": [
       "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
@@ -64,7 +68,10 @@
       "Recommendation: split the question. Pursue (A) HGCD correctness as a self-contained verification; defer (B) until a complexity model lands in Mathlib or as a separate gallery initiative.",
       "Session 2 (2026-05-01): det-unit and gcd-preservation halves of HGCD correctness were essentially mechanical given existing CofactorMatrix infrastructure — proved with one induction over fuel + a four-way rcases on determinant signs.",
       "Session 2: explicit-fuel recursive definition lets us sidestep the termination proof entirely until size-reduction is established. Once size-reduction is proved, fuel can be replaced by WellFounded.fix on bitsize.",
-      "Session 2: the genuinely new content is the entry-bound lemma on lehmerCofactors — an upper bound roughly 2^(fuel+1) on each entry. This bound does not appear in Mathlib or BinaryGcdOQ03.lean and must be proved inline (likely 30-80 lines)."
+      "Session 2: the genuinely new content is the entry-bound lemma on lehmerCofactors — an upper bound roughly 2^(fuel+1) on each entry. This bound does not appear in Mathlib or BinaryGcdOQ03.lean and must be proved inline (likely 30-80 lines).",
+      "Session 3 (2026-05-01): discovered cofactor-convention mismatch in BinaryGcdOQ03OQ02.lean. lehmerCofactors accumulates M in row-vector convention (M • S right-multiplication, invariant (a₀,b₀)·M = current pair), but the Session-2 applyToNat used CofactorMatrix.apply (column product M·(a,b)ᵀ). Products differ once M.β ≠ M.γ (i.e., for ≥2 Lehmer steps with distinct quotients). Counterexample (1000, 300): row-apply gives reduced (100, 100); column-apply gives (400, 900) — *not* reduced. Both preserve gcd; only row-apply realises the half-bitsize reduction.",
+      "Session 3: hgcdMatrix_size_reduction was therefore false-as-stated under the column-apply applyToNat. The lemma is now well-typed against the actual Lehmer-reduced pair after rewriting applyToNat to (a·M.α + b·M.γ, a·M.β + b·M.δ) and swapping the recursive mul order to M_top.mul M_rec.",
+      "Session 3 (separate finding): BinaryGcdOQ03.lean lehmerReduce uses the same column-apply formula on a row-accumulated cofactor, so the Lehmer step in the existing algorithm does not actually realise a reduction either. lehmerGcd is still gcd-correct via fuel exhaustion + euclidGcd fallback. Worth a follow-up issue on the OQ-03 line."
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -73,11 +80,11 @@
       "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
     ],
     "nextSteps": [
-      "Prove the Lehmer accumulator entry bound: each entry of (lehmerCofactors fuel ahat bhat M) is at most ~2^(fuel+1). Likely by induction on fuel using lehmerInnerStep_det and the explicit step form euclidStepMatrix q = ⟨0, 1, 1, -q⟩.",
-      "Combine the entry bound with Cramer's rule (inverse of unimodular matrix has same entry bound up to sign) to bound applyToNat (hgcdTopHalfStep a b) a b by 2^(bitsize(max a b)/2 + 2).",
-      "Iterate the half-reduction twice (top-level + recursive call) to close hgcdMatrix_size_reduction.",
-      "Once size reduction is proved, replace the explicit-fuel definition with a WellFounded.fix definition (lexicographic on bitsize).",
-      "(Optional, lower priority) Wire hgcdMatrix into lehmerGcd to give a recursive variant hgcdGcd and prove hgcdGcd a b = Nat.gcd a b."
+      "Prove the Lehmer accumulator entry bound: |M.α|, |M.β|, |M.γ|, |M.δ| ≤ max(ahat, bhat) + 1 (or simple polynomial bound) for M = lehmerCofactors fuel ahat bhat id. Most likely route: maintain the matrix-vector invariant (ahat₀, bhat₀) · M = (current pair) as a theorem, combine with sign-tracking on the alternating cofactor parities.",
+      "Combine the entry bound with the row-product expansion (a = aHi·2^shift + aLo, similar for b) to bound the residual by 2^shift · (aHi' + |M.α| + |M.γ|).",
+      "Iterate the half-reduction (top + recursive call) to close the threshold gap and discharge hgcdMatrix_size_reduction.",
+      "Once size reduction is proved, replace explicit-fuel hgcdMatrix with a WellFounded.fix definition (lexicographic on bitsize).",
+      "Follow-up issue on BinaryGcdOQ03.lean: lehmerReduce uses column-apply on a row-accumulated cofactor; lehmerGcd remains gcd-correct only by fuel exhaustion + euclidGcd fallback."
     ]
   },
   "tags": [

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -6,14 +6,27 @@
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log n) bit complexity through recursive cofactor matrix computation on the top half of the bits?.",
-    "whyMatters": []
+    "formal": "\\text{(A) Correctness: } \\exists\\, \\mathtt{hgcdMatrix} : \\mathbb{N} \\to \\mathbb{N} \\to \\mathtt{CofactorMatrix} \\text{ such that for all } a,b \\in \\mathbb{N}: \\det(\\mathtt{hgcdMatrix}\\, a\\, b) \\in \\{1, -1\\} \\text{ and } \\gcd(\\mathtt{hgcdMatrix}\\, a\\, b \\cdot (a,b)) = \\gcd(a,b). \\\\ \\text{(B) Size reduction: } \\forall a, b, \\text{ if } \\mathtt{bitsize}(\\max(a,b)) \\geq k_0 \\text{ then } \\mathtt{bitsize}(\\max(\\mathtt{hgcdMatrix}\\, a\\, b \\cdot (a,b))) \\leq \\lceil \\mathtt{bitsize}(\\max(a,b))/2 \\rceil + c. \\\\ \\text{(C) Complexity: } T_{\\mathtt{hgcd}}(n) = O(M(n) \\log n) \\text{ in a bit-complexity model. (Deferred — Mathlib gap.)}",
+    "plain": "Can Schönhage's recursive HGCD (half-GCD) be formalized? Three sub-claims: (A) gcd-preserving cofactor matrix; (B) halves the bitsize; (C) runs in O(M(n) log n) bit operations. (A)+(B) are tractable in Lean; (C) is blocked on Mathlib's lack of a bit-complexity model and fast multiplication.",
+    "whyMatters": [
+      "HGCD (Lehmer-Schönhage hybrid) is the asymptotically fastest deterministic GCD algorithm in classical models — formalizing the correctness side completes the gallery's GCD-algorithm progression from naive Euclid through Lehmer to HGCD.",
+      "The size-reduction step is the only genuinely new mathematical content beyond the existing Lehmer cofactor framework; everything else reuses BinaryGcdOQ03 infrastructure.",
+      "Identifying (C) as Mathlib-blocked is itself a contribution: it documents a foundational gap (no bit-complexity model) that prevents stating asymptotic claims about any arithmetic algorithm in Mathlib today."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Schönhage (1971) established correctness and O(M(n) log n) bit complexity of recursive HGCD.",
+      "Stehlé–Zimmermann (2004, 'A binary recursive gcd algorithm') give a binary variant and a careful complexity analysis.",
+      "Brent–Zimmermann, 'Modern Computer Arithmetic', §1.6.3, gives a textbook-level treatment used as the formalization reference.",
+      "All required 2x2 cofactor-matrix invariants (det ∈ {±1}, gcd preservation) are already proved in proofs/Proofs/BinaryGcdOQ03.lean."
+    ],
+    "open": [
+      "Recursive hgcdMatrix definition that splits on the top half of bits, with structural termination (Mathlib gap: no native HGCD).",
+      "Size-reduction lemma: applying hgcdMatrix(a,b) reduces bitsize(max a b) by roughly half.",
+      "Formal statement of O(M(n) log n) bit complexity — currently inexpressible in Mathlib (no bit-complexity model)."
+    ],
+    "goal": "Formalize parts (A) and (B) of the problem statement in BinaryGcdOQ03OQ02.lean. Document part (C) as deferred with a precise enumeration of the missing Mathlib infrastructure."
   },
   "currentState": {
     "phase": "ORIENT",

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 4, 2026-05-01): matrix-vector invariant for lehmerCofactors added — three new theorems in BinaryGcdOQ03OQ02.lean PART IV (lehmerInnerStep_invariant, lehmerCofactors_invariant, lehmerCofactors_id_apply_eq). This is Step 1 of three for hgcdMatrix_size_reduction; Steps 2-3 (entry bound via Cramer + residue monotonicity, perturbation analysis from low bits) remain. Sorry count unchanged at 1; axiom count unchanged at 0. Build verification blocked by Docker daemon unresponsiveness (same pattern as Session 3); proofs mirror existing lehmerInnerStep_det / lehmerCofactors_det_unit patterns.",
+    "progressSummary": "PROGRESS (Session 5, 2026-05-02): residue monotonicity for lehmerCofactors added — four new theorems in BinaryGcdOQ03OQ02.lean PART IV (lehmerInnerStep_residue_le, lehmerInnerStep_max_le, lehmerCofactors_invariant_le, lehmerCofactors_id_apply_le). This is Step 2a of the size-reduction proof plan; Step 2b (Cramer entry bound) and Step 3 (perturbation analysis) remain. Sorry count unchanged at 1; axiom count unchanged at 0.",
     "builtItems": [
       "hgcdThreshold (BinaryGcdOQ03OQ02.lean): bottom-out threshold for HGCD recursion.",
       "hgcdTopHalfStep (BinaryGcdOQ03OQ02.lean): one Lehmer-style reduction on the top half of the bits.",
@@ -61,7 +61,11 @@
       "BinaryGcdOQ03OQ02.lean PART IV (Session 4): lehmerInnerStep_invariant — per-step matrix-vector invariant for lehmerInnerStep (ghost original pair (a₀, b₀) with (a₀, b₀) · M = (current pair) is preserved across one step).",
       "BinaryGcdOQ03OQ02.lean PART IV (Session 4): lehmerCofactors_invariant — existential multi-step matrix-vector invariant for lehmerCofactors, by induction on fuel.",
       "BinaryGcdOQ03OQ02.lean PART IV (Session 4): lehmerCofactors_id_apply_eq — specialisation to M = id and ghost pair = input pair (a, b).",
-      "BinaryGcdOQ03OQ02.lean: file reorganised PART IV (size reduction → V), V (complexity → VI), VI (sanity checks → VII); file-level docstring and final summary updated to mention the matrix-vector invariant."
+      "BinaryGcdOQ03OQ02.lean: file reorganised PART IV (size reduction → V), V (complexity → VI), VI (sanity checks → VII); file-level docstring and final summary updated to mention the matrix-vector invariant.",
+      "BinaryGcdOQ03OQ02.lean PART IV (Session 5): lehmerInnerStep_residue_le — single-step structure result ahat' = bhat ∧ bhat' < bhat.",
+      "BinaryGcdOQ03OQ02.lean PART IV (Session 5): lehmerInnerStep_max_le — single-step max bound max ahat' bhat' ≤ max ahat bhat.",
+      "BinaryGcdOQ03OQ02.lean PART IV (Session 5): lehmerCofactors_invariant_le — strengthens Session-4 lehmerCofactors_invariant with the residue bound max ahat_final bhat_final ≤ max ahat_initial bhat_initial.",
+      "BinaryGcdOQ03OQ02.lean PART IV (Session 5): lehmerCofactors_id_apply_le — specialisation combining matrix-vector invariant + residue bound for M = id, ghost pair = input pair."
     ],
     "insights": [
       "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
@@ -79,7 +83,9 @@
       "Session 4 (2026-05-01): the matrix-vector invariant requires generalisation to a 'ghost original pair' (a₀, b₀) parameterised at the theorem level — not just (a₀, b₀) = (input ahat, input bhat). The naive form would not survive the inductive step because the current pair changes; the ghost pair stays fixed.",
       "Session 4: per-step / multi-step decomposition mirrors the existing lehmerInnerStep_det / lehmerCofactors_det_unit split. Per-step lemma carries the arithmetic (Nat.div_add_mod + ℤ-cast handling); multi-step lemma is purely structural induction.",
       "Session 4: Sign tracking is automatic when stating (a₀, b₀) over ℤ — no Nat-subtraction-truncation worries. Only ℕ↔ℤ bridging is in the Euclidean modulo step.",
-      "Session 4: the existential form (∃ ahat' bhat', ...) avoids defining a parallel 'track residues' function. The explicit residues aren't needed for the entry-bound argument that follows — only their existence + the invariant relation."
+      "Session 4: the existential form (∃ ahat' bhat', ...) avoids defining a parallel 'track residues' function. The explicit residues aren't needed for the entry-bound argument that follows — only their existence + the invariant relation.",
+      "Session 5 (2026-05-02): Step 2 splits into 2a (residue monotonicity) and 2b (Cramer entry bound). Residue monotonicity is a self-contained ~30-line lemma; doesn't need the determinant or the matrix-vector invariant. Separating it lets 2b focus narrowly on Cramer inversion.",
+      "Session 5: lehmerInnerStep_residue_le proves ahat' = bhat ∧ bhat' < bhat for any successful inner step; lehmerInnerStep_max_le derives the multi-step-friendly form max ahat' bhat' ≤ max ahat bhat by le_max_right + transitivity. The latter is the right shape for induction (per-step strict-decrease doesn't compose; max-bound does)."
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -88,8 +94,8 @@
       "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
     ],
     "nextSteps": [
-      "Step 2 (next session): Lehmer accumulator entry bound. With the matrix-vector invariant (lehmerCofactors_invariant) and det = ±1 (lehmerCofactors_det_unit), Cramer inversion gives a₀ = ±(δ·ahat' - β·bhat'), b₀ = ±(α·bhat' - γ·ahat'). Combined with bhat' < ahat' (Euclidean residue monotonicity, separate small lemma using Nat.mod_lt), this gives |α|, |β|, |γ|, |δ| ≤ max(|a₀|, |b₀|) / max(ahat', bhat').",
-      "Step 3: combine entry bound with applyToNat M a b = (a·M.α + b·M.γ, a·M.β + b·M.δ) and decomposition a = aHi·2^shift + aLo (similar b). Bound residual by 2^shift · (residue(aHi, bHi) + |M.α| + |M.γ|).",
+      "Step 2b (next session): Cramer-inversion entry bound. With lehmerCofactors_id_apply_le we have (ahat, bhat) · M = (ahat', bhat') with max ahat' bhat' ≤ max ahat bhat and det M = ±1. Cramer gives ahat = ±(δ·ahat' - β·bhat'), bhat = ±(α·bhat' - γ·ahat'). Care needed for degenerate residues (ahat' = 0 or bhat' = 0).",
+      "Step 3: perturbation analysis. After entry bound, combine with applyToNat M a b = (a·M.α + b·M.γ, a·M.β + b·M.δ) and the decomposition a = aHi·2^shift + aLo to bound residual by 2^shift · (residue(aHi, bHi) + |M.α| + |M.γ|).",
       "Step 4: iterate the half-reduction (top-half + recursive call) to discharge hgcdMatrix_size_reduction's threshold gap.",
       "Step 5: once size reduction is proved, replace explicit-fuel hgcdMatrix with a WellFounded.fix definition (lexicographic on bitsize).",
       "Follow-up issue on BinaryGcdOQ03.lean: lehmerReduce uses column-apply on a row-accumulated cofactor; lehmerGcd remains gcd-correct only by fuel exhaustion + euclidGcd fallback. (Open since Session 3.)"


### PR DESCRIPTION
## Summary

Open question OQ-02 of `binary-gcd-OQ-03` asked whether Schönhage's recursive HGCD (half-GCD) can be formalized at O(M(n) log n) bit complexity. Session 1 (2026-04-28) surveyed the question and recommended splitting it. Session 2 (2026-05-01) put down the skeleton. Session 3 (2026-05-01) corrected a cofactor-convention mismatch. **Session 4 (2026-05-01, latest commit on this PR)** added the matrix-vector invariant for `lehmerCofactors` — Step 1 of the size-reduction proof plan.

The question splits into:

| Part | Status |
|------|--------|
| (A) Correctness — `hgcdMatrix` is unimodular and preserves `Nat.gcd` | **Proved** |
| (B) Size reduction — bit-size halves per application | Stated; `sorry`. Step 1 of proof (matrix-vector invariant) **proved** in Session 4; Steps 2-3 remain |
| (C) Bit complexity O(M(n) log n) | **Mathlib-blocked** — documented in-file |

## What this PR adds

`proofs/Proofs/BinaryGcdOQ03OQ02.lean` (new, ~480 lines, **0 axioms, 1 sorry**):

### PART I-III (Sessions 2-3)
* Definitions: `hgcdThreshold`, `hgcdTopHalfStep`, `applyToNat`, `hgcdMatrix`, `bitsize`
* `hgcdTopHalfStep_det_unit` — top-half Lehmer step is unimodular
* `hgcdMatrix_det_unit` — recursive HGCD matrix is unimodular (induction on fuel)
* `hgcdMatrix_apply_gcd` — application preserves `Nat.gcd` (row-product form, via `gcd_cofactor_eq` with relabelled coefficients)

### PART IV (Session 4) — Matrix-vector invariant
* `lehmerInnerStep_invariant` — per-step preservation: if a "ghost original pair" `(a₀, b₀)` satisfies `a₀·M.α + b₀·M.γ = ahat` and `a₀·M.β + b₀·M.δ = bhat`, then the same relation holds after one `lehmerInnerStep` with the updated matrix and new pair `(bhat, ahat % bhat)`. Proof unfolds `lehmerInnerStep`, splits on `bhat = 0` and `r = 0`, then discharges via `h_inv₁ - q · h_inv₂` plus `Nat.div_add_mod`.
* `lehmerCofactors_invariant` — existential multi-step version. There exist final residues `(ahat', bhat')` such that applying the accumulated cofactor matrix to the ghost original pair recovers them. Inductive on fuel; uses `match hstep : lehmerInnerStep ahat bhat M with` (mirrors `lehmerCofactors_det_unit`).
* `lehmerCofactors_id_apply_eq` — specialisation to `M = id` and ghost pair = input pair `(ahat, bhat)`. Direct corollary.

### PART V (Session 2, still sorry)
* `hgcdMatrix_size_reduction` — **stated only, sorry**; the only sorry in the file. Steps 2-3 of the proof plan remain.

### PART VI-VII
* Bit-complexity gap (deferred — Mathlib infrastructure)
* `native_decide` smoke checks pinning the row-apply behaviour

The file imports from `Proofs.BinaryGcdOQ03` and reuses all 2x2 cofactor-matrix machinery. `proofs/Proofs.lean` updated with the new import.

## Session-4 matrix-vector invariant (the new content)

The maintained invariant of the Lehmer-step machine is that the accumulated cofactor matrix, applied (in row-vector convention) to the *original* pair, recovers the *current* pair after each step. Formally:

```
a₀ * M.α + b₀ * M.γ = ahat
a₀ * M.β + b₀ * M.δ = bhat
```

Starting from `M = id` this holds trivially because `(a₀, b₀) · id = (a₀, b₀)`. The Session-4 work proves it carries through one step of `lehmerInnerStep`, then iterates to cover `lehmerCofactors`.

**Why it matters.** This invariant is the foundation of the size-reduction argument. Combined with:

* the bound `bhat_final ≤ bhat₀` (Euclidean-step monotonicity, separate small lemma using `Nat.mod_lt`), and
* the determinant condition `det M = ±1` (`lehmerCofactors_det_unit`, already proved),

Cramer's rule on the unimodular cofactor gives entry bounds `|α|, |β|, |γ|, |δ| ≤ max(|a₀|, |b₀|) / max(ahat', bhat')`. This is exactly the bound needed for the perturbation analysis closing `hgcdMatrix_size_reduction`.

**Generalisation choice.** The "ghost original pair" `(a₀, b₀)` is parameterised at the theorem level rather than fixed to `(input ahat, input bhat)`. The naive form would not survive the inductive step because the *current* pair changes; the ghost pair stays fixed throughout the recursion, which is exactly what the induction needs.

**Existential vs explicit form.** `lehmerCofactors_invariant` uses `∃ ahat' bhat', ...` rather than defining a parallel "track residues" function. The explicit residues are not needed for the entry-bound argument that follows — only their existence and the invariant relation. This keeps the file additions to a single section without a new recursive definition.

## Session-3 cofactor-convention fix (recap)

`lehmerCofactors` in `BinaryGcdOQ03.lean` accumulates the cofactor matrix in the **row-vector** convention: each Lehmer step `S_k = ⟨0, 1, 1, -q⟩` *right*-multiplies the accumulator. Session 2's `applyToNat` used the column form `M.apply`, which differs whenever `M.β ≠ M.γ` (any ≥ 2-step Lehmer accumulator). Session 3 rewrote `applyToNat` to the row product, swapped the `hgcdMatrix` recursive composition order (`M_top.mul M_rec`), and restated `hgcdMatrix_apply_gcd` against the row product. See the `(1000, 300) → (100, 100)` `native_decide` example in PART VII.

**Separate finding (Session 3, worth a follow-up issue):** `lehmerReduce` in `BinaryGcdOQ03.lean` uses the same column-apply formula on a row-accumulated cofactor, so the existing "Lehmer step" does not actually reduce the pair either. `lehmerGcd` is gcd-correct only by fuel exhaustion + `euclidGcd` fallback.

## Metadata reconciliation

`src/data/research/problems/binary-gcd-oq-03-oq-02.json`:

* Session 4: iteration 3 → 4, attemptCounts 1 → 3, four new `knowledge.builtItems` (one per Session-4 lemma, one for the file reorg), four new `knowledge.insights` documenting the design choices, restated `nextSteps` reflecting Step-1 done.

`research/problems/binary-gcd-oq-03-oq-02/state.md` and `knowledge.md` extended with the Session-4 narrative; iteration count 4 → 5.

## Build verification status

⚠️ **Docker build verification was attempted twice (Sessions 3 and 4) and Docker daemon was unresponsive** during heavy multi-agent activity. This matches the documented Docker infrastructure failure mode. `docker version` and `docker info` calls hang for >10s without returning; `docker-build.sh` stalls at the daemon-handshake phase before spawning a container.

The Session-4 proofs are written to mirror existing patterns (`lehmerInnerStep_det`, `lehmerCofactors_det_unit`) closely:
* `lehmerInnerStep_invariant` uses the same `simp [lehmerInnerStep] at h_step; split at h_step <;> simp_all; split at h_step <;> simp_all; obtain ⟨rfl, rfl, rfl⟩ := h_step` pattern as `lehmerInnerStep_det`, then standard `ring` + `linarith` arithmetic.
* `lehmerCofactors_invariant` uses the same `match hstep : lehmerInnerStep ahat bhat M with` destructuring inside an inductive case as `lehmerCofactors_det_unit`.
* `lehmerCofactors_id_apply_eq` is a direct corollary using `apply lehmerCofactors_invariant` + `simp [CofactorMatrix.id]`.

Build risk should be low but remains unverified this session. Marking this PR as **draft** until a Docker rebuild succeeds.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ03OQ02` succeeds with no errors and exactly 1 `sorry` warning (on `hgcdMatrix_size_reduction` in PART V)
- [ ] `pnpm build` succeeds (gallery integration)
- [ ] No new axioms

## Next session

Continue with **Step 2** of the proof plan: the **Lehmer accumulator entry bound**.

1. Prove a small Euclidean residue monotonicity lemma: starting from any `(ahat₀, bhat₀)`, after fuel iterations of `lehmerInnerStep`, the final `bhat_final ≤ bhat₀` (by induction on fuel using `Nat.mod_lt`).
2. With the matrix-vector invariant + `det M = ±1` + residue monotonicity, Cramer gives `|α|, |β|, |γ|, |δ| ≤ max(|a₀|, |b₀|) / max(ahat_final, bhat_final)`.
3. Then the perturbation argument: combine the entry bound with `applyToNat M a b = (a·M.α + b·M.γ, a·M.β + b·M.δ)` and the decomposition `a = aHi·2^shift + aLo` to bound the residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)