### PR TITLE
fix(erdos-684): remove 4 phantom identifiers from section summaries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8438,12 +8438,13 @@
     },
     "erdos-684": {
       "agentId": "auditor-foreground",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
-        "phantom identifiers in section summaries: tang_bound, rh_conditional_bound, heuristic_conjecture, erdos_684_status (issue #14084)"
+        "phantom identifiers in section summaries: tang_bound, rh_conditional_bound, heuristic_conjecture, erdos_684_status (issue #14084)",
+        "phantom identifiers in section summaries: tang_bound, rh_conditional_bound (Modern Bounds), heuristic_conjecture (Heuristic), erdos_684_status (Status); all removed (closes #14084)"
       ],
-      "lastAudited": "2026-05-01T05:50:00Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-01T03:54:00Z",
+      "result": "issues-fixed"
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -103,18 +103,18 @@
     {
       "id": "modern-bounds",
       "title": "Modern Bounds",
-      "summary": "tang_exponent, tang_bound, rh_exponent, rh_conditional_bound",
+      "summary": "tang_exponent, rh_exponent",
       "startLine": 204,
       "endLine": 215,
-      "mathContext": "Bound: tang_exponent, tang_bound, rh_exponent, rh_conditional_bound"
+      "mathContext": "Bound: tang_exponent, rh_exponent"
     },
     {
       "id": "heuristic",
       "title": "Heuristic Conjectures",
-      "summary": "heuristic_bound, heuristic_conjecture",
+      "summary": "heuristic_bound",
       "startLine": 216,
       "endLine": 228,
-      "mathContext": "Bound: heuristic_bound, heuristic_conjecture"
+      "mathContext": "Bound: heuristic_bound"
     },
     {
       "id": "structure",
@@ -143,10 +143,10 @@
     {
       "id": "status",
       "title": "Problem Status",
-      "summary": "erdos_684_status, erdos_684_statement, summary",
+      "summary": "erdos_684_statement",
       "startLine": 349,
       "endLine": 401,
-      "mathContext": "Mathematical content: erdos_684_status, erdos_684_statement, summary"
+      "mathContext": "Mathematical content: erdos_684_statement"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removes 4 phantom identifiers from `src/data/proofs/erdos-684/meta.json` section summaries (and matching `mathContext` fields)
- Identifiers `tang_bound`, `rh_conditional_bound`, `heuristic_conjecture`, `erdos_684_status` do not exist in `proofs/Proofs/Erdos684Problem.lean`
- Replaces each summary with the actual Lean identifiers present in the section's line range

## Context
Discovered during gallery integrity audit. Verified absence:
```
grep -nE "^(noncomputable )?(def|theorem|lemma|axiom|abbrev) (tang_bound|rh_conditional_bound|heuristic_conjecture|erdos_684_status)\b" proofs/Proofs/Erdos684Problem.lean
# (no matches)
```
Existing identifiers: `tang_exponent` (def), `rh_exponent` (def), `heuristic_bound` (def), `erdos_684_statement` (theorem).

Numerical fields already correct: `axiomCount=2`, `sorries=0`, `lineCount=401`, `theoremCount=12`, `definitionCount=11`. Status `axiomatized` and badge `axiom` match the 2 declared axioms (`f_domain_large`, `mahler_ineffective`). Section line ranges already correct.

Also bumps audit-tracker entry to `issues-fixed`.

Closes #14084

## Test plan
- [x] grep confirms phantom identifiers absent from Lean source
- [x] Replacement identifiers verified to exist at the claimed line ranges
- [x] Numerical metadata (axiomCount, sorries, lineCount, theoremCount, definitionCount) unchanged and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)