### PR TITLE
audit(erdos-67): mark issues-found — 3 section ranges drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8337,10 +8337,13 @@
       ]
     },
     "erdos-67": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T03:44:01Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "issues": [
+        "section line ranges drift across 3 sections (complex-variant, stronger-conjecture, multiplicative) — issue #14099"
+      ],
+      "lastAudited": "2026-05-01T05:00:00Z",
+      "result": "issues-found"
     },
     "erdos-670": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
## Summary

Records the result of the erdos-67 audit (4th audit cycle): three section line ranges drift in `src/data/proofs/erdos-67/meta.json`, off by ~4 lines each.

Detailed audit findings filed in issue #14099.

## Changes

- `src/data/proofs/audit-tracker.json` erdos-67 entry: `clean` → `issues-found`, auditCount 3 → 4, references issue #14099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)