### PR TITLE
fix(erdos-684): remove phantom identifiers from section summaries

### DIFF
--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -103,18 +103,18 @@
     {
       "id": "modern-bounds",
       "title": "Modern Bounds",
-      "summary": "tang_exponent, tang_bound, rh_exponent, rh_conditional_bound",
+      "summary": "tang_exponent, rh_exponent",
       "startLine": 204,
       "endLine": 215,
-      "mathContext": "Bound: tang_exponent, tang_bound, rh_exponent, rh_conditional_bound"
+      "mathContext": "Bound: tang_exponent, rh_exponent"
     },
     {
       "id": "heuristic",
       "title": "Heuristic Conjectures",
-      "summary": "heuristic_bound, heuristic_conjecture",
+      "summary": "heuristic_bound",
       "startLine": 216,
       "endLine": 228,
-      "mathContext": "Bound: heuristic_bound, heuristic_conjecture"
+      "mathContext": "Bound: heuristic_bound"
     },
     {
       "id": "structure",
@@ -143,10 +143,10 @@
     {
       "id": "status",
       "title": "Problem Status",
-      "summary": "erdos_684_status, erdos_684_statement, summary",
+      "summary": "erdos_684_statement",
       "startLine": 349,
       "endLine": 401,
-      "mathContext": "Mathematical content: erdos_684_status, erdos_684_statement, summary"
+      "mathContext": "Mathematical content: erdos_684_statement"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Remove 4 phantom identifier names from `erdos-684` section summaries that were never declared in the Lean source file.

## Evidence

**Before**: section summaries listed `tang_bound`, `rh_conditional_bound`, `heuristic_conjecture`, `erdos_684_status` as if they were Lean declarations.

**After**: summaries list only `tang_exponent`, `rh_exponent`, `heuristic_bound`, `erdos_684_statement` — the identifiers that actually exist in `proofs/Proofs/Erdos684Problem.lean`.

The phantom names only appeared as narrative context in `originalContributions` and `proofStrategy` text; no corresponding `def`/`theorem`/`axiom` declarations exist.

Closes #14084

---
Automated fix by lean-mechanic agent.