### PR TITLE
fix(erdos-669): remove phantom identifiers and correct section line ranges

### DIFF
--- a/src/data/proofs/erdos-669/meta.json
+++ b/src/data/proofs/erdos-669/meta.json
@@ -86,34 +86,41 @@
       "title": "f_k and F_k Functions",
       "summary": "ExactlyKPoints, AtLeastKPoints, f_k, F_k",
       "startLine": 53,
-      "endLine": 72
+      "endLine": 71
     },
     {
       "id": "orchard",
       "title": "The Orchard Problem (k=3)",
-      "summary": "orchardProblem, burr_grunbaum_sloane, k3_limit",
+      "summary": "orchardProblem, k3_limit",
       "startLine": 73,
-      "endLine": 95
+      "endLine": 87
     },
     {
       "id": "upper-bound",
       "title": "Trivial Upper Bound",
-      "summary": "trivial_upper_bound, limit_upper",
-      "startLine": 96,
-      "endLine": 108
+      "summary": "Section header and docstring commentary on trivial upper bound; contains no Lean declarations.",
+      "startLine": 89,
+      "endLine": 94
     },
     {
       "id": "conjecture",
       "title": "The General Conjecture",
       "summary": "limit_conjecture, k3_matches, k3_conjecture_true",
-      "startLine": 109,
-      "endLine": 122
+      "startLine": 95,
+      "endLine": 107
     },
     {
       "id": "configs",
       "title": "Optimal Configurations",
-      "summary": "optimal_configs_exist",
-      "startLine": 123,
+      "summary": "Section header and docstring discussing optimal configurations; contains no Lean declarations.",
+      "startLine": 109,
+      "endLine": 113
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_669_summary",
+      "startLine": 114,
       "endLine": 128
     }
   ],


### PR DESCRIPTION
## Fix

Remove 4 phantom identifiers from section summaries and correct section line ranges in `erdos-669` meta.json to match actual Lean source structure.

## Evidence

**Phantom identifiers removed:**
- `orchard` section: removed `burr_grunbaum_sloane` (only a docstring, no Lean declaration)
- `upper-bound` section: removed `trivial_upper_bound`, `limit_upper` (only docstrings)
- `configs` section: removed `optimal_configs_exist` (only a docstring)

**Section line ranges corrected:**
- `functions`: endLine 72 → 71 (F_k ends at line 71)
- `orchard`: endLine 95 → 87 (k3_limit axiom ends at line 87; Part IV starts at 89)
- `upper-bound`: startLine 96 → 89, endLine 108 → 94 (Part IV commentary at lines 89-94 only)
- `conjecture`: startLine 109 → 95, endLine 122 → 107 (limit_conjecture/k3_matches/k3_conjecture_true all before line 109)
- `configs`: startLine 123 → 109, endLine 128 → 113 (Part VI commentary at lines 109-113)
- Added missing `summary` section: lines 114-128 containing `erdos_669_summary` theorem

Closes #14091

---
Automated fix by lean-mechanic agent.