### PR TITLE
fix(erdos-665): correct section line ranges and remove phantom narrative

### DIFF
--- a/src/data/proofs/erdos-665/meta.json
+++ b/src/data/proofs/erdos-665/meta.json
@@ -82,33 +82,33 @@
       "id": "connection-to-projective-plane",
       "title": "Connection to Projective Planes",
       "startLine": 94,
-      "endLine": 122,
-      "summary": "Shrikhande-Singhi embedding theorem and conditional negative answer via prime power conjecture.",
-      "mathContext": "Verified: Shrikhande-Singhi embedding theorem and conditional negative answer via prime power conjecture."
+      "endLine": 112,
+      "summary": "Defines projectivePlanePoints, projectivePlaneLineSize; axiomatizes prime_power_planes_implies_unbounded (conditional negative answer). Shrikhande-Singhi is referenced only in docstring narrative.",
+      "mathContext": "Formal definition: projectivePlanePoints, projectivePlaneLineSize; axiom: prime_power_planes_implies_unbounded."
     },
     {
       "id": "connection-to-prime-gaps",
       "title": "Connection to Prime Gaps",
-      "startLine": 123,
-      "endLine": 147,
-      "summary": "Correlation between h(n) and largest prime gap; Cramér's conjecture implications.",
-      "mathContext": "Mathematical content: Correlation between h(n) and largest prime gap; Cramér's conjecture implications."
+      "startLine": 113,
+      "endLine": 132,
+      "summary": "Axiomatizes largestPrimeGap and h_correlates_with_prime_gap. Cramér's conjecture is referenced only in docstring narrative.",
+      "mathContext": "Axioms: largestPrimeGap, h_correlates_with_prime_gap."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 148,
-      "endLine": 167,
-      "summary": "Perfect square primes give affine planes with blocks of size exactly √n; near-square constructions.",
-      "mathContext": "Mathematical content: Perfect square primes give affine planes with blocks of size exactly √n; near-square constructions."
+      "startLine": 133,
+      "endLine": 143,
+      "summary": "Section header and orphan docstrings discussing affine planes for n=q²; contains no Lean declarations.",
+      "mathContext": "Commentary only; no Lean declarations in this range."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 168,
+      "startLine": 144,
       "endLine": 170,
-      "summary": "Combines all results into a summary theorem: unconditional bound, conditional negative answer, and prime gap correlation.",
-      "mathContext": "Verified: Combines all results into a summary theorem: unconditional bound, conditional negative answer, and prime gap correlation."
+      "summary": "Combines axioms via erdos_665_summary theorem.",
+      "mathContext": "Verified: erdos_665_summary theorem combines erdos_larson_bound, prime_power_planes_implies_unbounded, h_correlates_with_prime_gap."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Correct 4 section line ranges in `erdos-665` meta.json that were misaligned with the actual Lean source structure, and remove phantom narrative from section summaries.

## Evidence

**Before** (incorrect):
- `connection-to-projective-plane`: endLine 122 — overshoot by 10 lines, pulled `axiom largestPrimeGap` (line 121) into the wrong section
- `connection-to-prime-gaps`: startLine 123, endLine 147 — missed `largestPrimeGap` (line 121) and extended past actual content
- `special-cases`: startLine 148, endLine 167 — actual Part VI (L134-143) has no declarations; this range covered summary docstring + `erdos_665_summary` theorem instead
- `summary`: startLine 168, endLine 170 — only captured the closing `end` statement, missing the summary theorem at L157-167

**After** (correct, matching Lean file at 170 lines):
- `connection-to-projective-plane`: endLine → 112 (ends before Part V header)
- `connection-to-prime-gaps`: startLine → 113, endLine → 132 (covers `largestPrimeGap` and `h_correlates_with_prime_gap` axioms)
- `special-cases`: startLine → 133, endLine → 143 (Part VI: commentary only, no declarations)
- `summary`: startLine → 144, endLine → 170 (Part VII: covers `erdos_665_summary` theorem at L157-167)

Phantom narrative also clarified: Shrikhande-Singhi embedding theorem and Cramér's conjecture appear only as docstrings, not as Lean declarations; summaries now say so explicitly.

Closes #14096

---
Automated fix by lean-mechanic agent.