### PR TITLE
audit(erdos-999): correct section line ranges; add missing Summary section

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10603,10 +10603,10 @@
       "result": "clean"
     },
     "erdos-999": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:19:25Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T04:10:52Z",
+      "result": "issues-fixed"
     },
     "erdos-ko-rado": {
       "auditCount": 2,

--- a/src/data/proofs/erdos-999/meta.json
+++ b/src/data/proofs/erdos-999/meta.json
@@ -108,41 +108,49 @@
       "id": "main-conjecture",
       "title": "The Duffin-Schaeffer Conjecture",
       "startLine": 86,
-      "endLine": 100,
+      "endLine": 94,
       "summary": "The conjecture statement, easy direction, and hard direction.",
       "mathContext": "Mathematical content: The conjecture statement, easy direction, and hard direction."
     },
     {
       "id": "erdos-partial",
       "title": "Erdős's Partial Result",
-      "startLine": 101,
-      "endLine": 110,
+      "startLine": 95,
+      "endLine": 101,
       "summary": "Erdős proved the case when f(q)·q is bounded.",
       "mathContext": "Bound: Erdős proved the case when f(q)·q is bounded."
     },
     {
       "id": "koukoulopoulos-maynard",
       "title": "Koukoulopoulos-Maynard Theorem (2020)",
-      "startLine": 111,
-      "endLine": 120,
+      "startLine": 102,
+      "endLine": 111,
       "summary": "The full conjecture proved after 79 years.",
       "mathContext": "Mathematical content: The full conjecture proved after 79 years."
     },
     {
       "id": "consequences",
       "title": "Consequences",
-      "startLine": 121,
-      "endLine": 137,
+      "startLine": 112,
+      "endLine": 121,
       "summary": "Convergence case, zero-one law, continued fractions.",
       "mathContext": "Mathematical content: Convergence case, zero-one law, continued fractions."
     },
     {
       "id": "khintchine",
       "title": "Khintchine's Theorem",
-      "startLine": 138,
-      "endLine": 147,
+      "startLine": 122,
+      "endLine": 130,
       "summary": "The 1924 result for monotone functions and the limsup set.",
       "mathContext": "Mathematical content: The 1924 result for monotone functions and the limsup set."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 131,
+      "endLine": 147,
+      "summary": "The erdos_999_summary theorem combining the conjecture and zero-one law.",
+      "mathContext": "Mathematical content: The erdos_999_summary theorem combining the conjecture and zero-one law."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Sections in `src/data/proofs/erdos-999/meta.json` from `main-conjecture` onward had wrong `startLine`/`endLine` values that drifted relative to the actual Lean source, and Part IX (Summary) was missing entirely even though it contains the `erdos_999_summary` theorem (the file's main result).

The first three sections (`basic-definitions`, `divergence-condition`, `measure-theory`) were already correct.

## Corrections

`proofs/Proofs/Erdos999Problem.lean` has 147 lines and 9 Parts. Verified Part markers (`/- ## Part N: ... -/`) and content boundaries:

| Section | Before | After |
|---------|--------|-------|
| `main-conjecture` | 86–100 | 86–94 |
| `erdos-partial` | 101–110 | 95–101 |
| `koukoulopoulos-maynard` | 111–120 | 102–111 |
| `consequences` | 121–137 | 112–121 |
| `khintchine` | 138–147 | 122–130 |
| `summary` (new) | — | 131–147 |

The previous `khintchine` range (138–147) actually pointed at Part IX (the summary theorem), not Khintchine content. Part VIII Khintchine + LimsupSet lives at 122–130 in the source.

## Other audit findings

- `axiomCount: 2` matches actual file (axioms `koukoulopoulos_maynard_2020`, `zero_one_law`).
- `sorries: 0` matches actual file.
- `originalContributions` correctly tags docstring-only items (`easy_direction`, `hard_direction`, `erdos_bounded_case`, `convergence_case`, `continued_fraction_case`, `khintchine_theorem`) as "documented not a Lean axiom" — no phantom-axiom narrative issue.
- `status: axiomatized`, `badge: axiom` are correctly aligned.

Audit tracker updated to `auditCount: 3`, `result: issues-fixed`.

## Test plan
- [ ] CI passes (TypeScript build, JSON schema)
- [ ] Manual: open the proof in the gallery and verify each section's "View source" jump lands on the correct Part marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)