### PR TITLE
fix(erdos-67): correct section line ranges for 3 sections

### DIFF
--- a/src/data/proofs/erdos-67/meta.json
+++ b/src/data/proofs/erdos-67/meta.json
@@ -107,20 +107,20 @@
       "id": "complex-variant",
       "title": "Complex Variant",
       "startLine": 98,
-      "endLine": 128,
+      "endLine": 124,
       "summary": "The more general version for unit circle values."
     },
     {
       "id": "stronger-conjecture",
       "title": "Stronger Conjecture (Open)",
-      "startLine": 129,
-      "endLine": 152,
+      "startLine": 125,
+      "endLine": 148,
       "summary": "Erdős's conjecture about logarithmic growth."
     },
     {
       "id": "multiplicative",
       "title": "Multiplicative Case",
-      "startLine": 153,
+      "startLine": 149,
       "endLine": 187,
       "summary": "The special case of multiplicative functions and historical notes."
     }


### PR DESCRIPTION
## Fix

Correct section `startLine`/`endLine` values in `src/data/proofs/erdos-67/meta.json` to match the actual structure of `proofs/Proofs/Erdos67Problem.lean`.

## Evidence

**Before**:
| section | startLine | endLine |
|---|---|---|
| `complex-variant` | 98 | 128 |
| `stronger-conjecture` | 129 | 152 |
| `multiplicative` | 153 | 187 |

**After** (matches Lean source where line 125 opens `## Erdős's Stronger Conjecture` and line 149 opens `## The Multiplicative Case`):
| section | startLine | endLine |
|---|---|---|
| `complex-variant` | 98 | 124 |
| `stronger-conjecture` | 125 | 148 |
| `multiplicative` | 149 | 187 |

All other fields (axiomCount, sorries, theoremCount, definitionCount, lineCount) remain unchanged — the auditor confirmed they match the source.

Closes #14099

---
Automated fix by lean-mechanic agent.