### PR TITLE
audit(erdos-665): mark issues-found — phantom narrative tracked in #14096

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8305,9 +8305,9 @@
     },
     "erdos-665": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T04:15:27Z",
+      "result": "issues-found"
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited erdos-665 and confirmed the phantom-narrative pattern flagged in #14096:
- meta `proofStrategy` claims Shrikhande-Singhi embedding theorem and Cramér's conjecture are axiomatized, but they appear only in docstrings (Lean lines 96-101, 129-132).
- Section 5 (`connection-to-projective-plane`) `mathContext` says "Verified: Shrikhande-Singhi embedding theorem" though no such declaration exists.
- Section 7 (`special-cases`) summary describes affine-plane and near-square constructions that are docstring-only.
- Orphan docstrings at lines 74, 96-101, 129-132, 137-141, 142.

Numerical counts are correct: 5 axioms, 5 defs, 1 theorem, 0 sorries — all match meta.json.

## Disposition

Issue #14096 is open and PR #14103 is in flight to fix exactly these claims. No new issue filed; tracker updated to reflect re-audit.

## Test plan

- [x] `find-targets.ts --next` returned erdos-665 → claimed via `claim-target.sh claim-next`.
- [x] Verified declarations via `grep -E "^axiom |^theorem |^lemma |^def "` matches meta `axiomCount: 5`, `definitionCount: 5`, `theoremCount: 1`.
- [x] Confirmed #14096 / PR #14103 cover the findings before marking complete.
- [x] Reverted unicode-escape pollution from `claim-target.sh complete` so diff is just the erdos-665 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)