### PR TITLE
audit(erdos-666): mark issues-found, link integrity issue #14107

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8311,9 +8311,10 @@
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T04:19:26Z",
+      "result": "issues-found",
+      "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14107"
     },
     "erdos-667": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates `src/data/proofs/audit-tracker.json` for `erdos-666`: bumps auditCount to 4, sets `result` to `issues-found`, links integrity issue #14107.

## Context

Audit of `erdos-666` (Erdős Problem #666: C₆ in Hypercube Subgraphs) found two integrity concerns now tracked in #14107:

1. **Phantom / drifted section line ranges** (`bdt`, `conder`, `generalized`) — section ranges in `meta.json` do not match where the corresponding declarations actually live in `Erdos666Problem.lean`. The `bdt` section claims content the file does not have; `conder_better_bound` (lines 188-201) sits inside the `bdt` claimed range, not `conder`'s.
2. **Overclaim in `originalContributions`** — listed as "erdos_conjecture_false theorem: main disproof" but the theorem body is `sorry` (line 137). The completed disproof goes through `chung_counterexample`, which uses the `chung_1992` axiom.

Numerical counts (axiomCount, sorries, lineCount, theoremCount, definitionCount) all match the Lean source — only sections and one contribution wording need reconciliation.

## Test plan

- [x] `git diff --stat` shows 1 file changed, 4 insertions, 3 deletions (no unicode-escape pollution from the known `claim-target.sh` bug).
- [x] Issue #14107 filed with full evidence and recommended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)