### PR TITLE
audit(erdos-659): mark issues-found, link integrity issue #14110

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8256,10 +8256,13 @@
       "result": "clean"
     },
     "erdos-659": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777609366",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T04:30:00Z",
+      "result": "issues-found",
+      "issues": [
+        "Section range drift (axiom/theorem swapped); 3 of 6 isConfiguration cases reduce to True (isoTrap1, isoTrap2, kite) — issue #14110"
+      ]
     },
     "erdos-659-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Updates `src/data/proofs/audit-tracker.json` for `erdos-659`: bumps auditCount to 3, sets `result` to `issues-found`, links integrity issue #14110.

## Context

Audit of `erdos-659` (Erdős Problem #659: Point Configurations with Few Distances) found two integrity concerns now tracked in #14110:

1. **Section range drift** — `axiom` section (59–76) does not cover `axiom moreeOsburnWorks` at line 89; `theorem` section (77–95) does not cover `theorem erdos_659` at line 100. The two sections effectively swap content.
2. **Degenerate `True` placeholders** in `def isConfiguration` — 3 of 6 cases (`isoTrap1`, `isoTrap2`, `kite`) reduce to `True`, undermining the `originalContributions` claim of "Classification of 6 configurations with only 2 distances."

Numerical counts (axiomCount=1, sorries=1, lineCount=220, theoremCount=2, definitionCount=9) all match the Lean source — only sections and one definition's content need reconciliation.

## Test plan

- [x] `git diff --stat` shows 1 file changed, 7 insertions, 4 deletions (no unicode-escape pollution from the `claim-target.sh complete` bug — manually re-applied).
- [x] Issue #14110 filed with full evidence and recommended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)