### PR TITLE
research(ballot-jt-oq01oq01oq01): Session 14 — Mathlib API verification + meta sync

### DIFF
--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -1,10 +1,86 @@
 # Knowledge Base: LGV Lemma → Jacobi-Trudi Identity
 
 **Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01
-**Last Updated**: 2026-04-26
-**Knowledge Items**: 34
+**Last Updated**: 2026-05-01
+**Knowledge Items**: 36
 
 Insights accumulated during research on this problem.
+
+---
+
+## Session 2026-05-01 (Session 14) — Mathlib API Verification; Docker Hung
+
+**Mode**: REVISIT (RICH knowledge tier, score 76 → 78)
+**Outcome**: scouted — no proof progress; Mathlib API for b=1 recipe verified
+
+### What I Did
+
+1. **Confirmed all six Mathlib lemmas needed for the b=1 recipe** (Mathlib v4.26.0
+   sources at `.loom/worktrees/stokes-dd/proofs/.lake/packages/mathlib/`):
+   - `MvPolynomial.hsymm_zero : hsymm σ R 0 = 1` — `Symmetric/Defs.lean:318` (simp)
+   - `Sym.uniqueZero : Unique (Sym α 0)` — `Sym/Basic.lean:261`
+   - `Sym.cons_erase : a ::ₛ s.erase a h = s` — `Sym/Basic.lean:219`
+   - `Sym.erase_cons_head : (a ::ₛ s).erase a _ = s` — `Sym/Basic.lean:223`
+   - `Sym.oneEquiv : α ≃ Sym α 1` — `Sym/Basic.lean:477`
+   - `Multiset.sort_cons` — `Multiset/Sort.lean:69`
+
+2. **Eliminated one open question from Session 13's recipe**: With `hsymm_zero` already
+   in Mathlib as a simp lemma, the b=1 case can dispatch via
+   `rw [hsymm_zero, mul_one]` to reduce RHS from `h_{a+1} * h_0` to `h_{a+1}`,
+   skipping the `← sum_all_sym_pairs n (a+1) 0` rewrite path. The bijection then
+   targets `Sym (Fin n) (a+1)` directly (no need to handle `Sym n 0`).
+
+3. **Confirmed lineCount drift in metadata**: Session 13 recorded 666 lines for
+   `BallotProblemOQ03OQ01OQ01OQ01.lean`; current file is 694 lines. PR #13365 added
+   the inverse-direction recipe (lines 422-441) without updating leanFiles metadata.
+   Synced `leanFiles[].lineCount` to 694.
+
+4. **Did NOT attempt the b=1 proof**: Local Docker daemon hung (`docker info`
+   timed out at "Server:" line — backend running but unresponsive). Disk had
+   138GB free, so this is Docker Desktop infrastructure overload (likely from
+   concurrent multi-agent activity), not a workspace constraint. Kicked off
+   `docker-build.sh` but it never progressed past the header echo. Per established
+   feedback ("Docker build I/O errors during heavy multi-agent activity is a
+   Docker infrastructure failure"), did not attempt unverified Lean changes.
+
+### Key Findings
+
+- The b=1 recipe is now fully grounded in confirmed Mathlib lemmas (six dependencies,
+  all paths checked against actual Mathlib source). No discovery work remains for the
+  helper proof — only writing it.
+- Recommended dispatch path: `by rw [hsymm_zero, mul_one]; <bijection>` rather than
+  the `← sum_all_sym_pairs` route. Cleaner because RHS becomes `hsymm (Fin n) R (a+1)`,
+  matching directly the codomain of the bijection.
+
+### Files Modified
+
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`
+  - `knowledge.progressSummary` updated for Session 14
+  - `knowledge.insights` += 2 entries (Mathlib API confirmation, dispatch route)
+  - `knowledge.nextSteps` prepended 2 entries (concrete recipe, Docker pre-check)
+  - `leanFiles[BallotProblemOQ03OQ01OQ01OQ01.lean].lineCount`: 666 → 694
+  - `lastUpdate` → 2026-05-01T13:30:00Z
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` (this entry)
+
+### Next Steps
+
+1. **Verify Docker at session start** before claiming this problem (this session
+   wasted the claim slot due to Docker hang).
+2. **Implement `jdt_weight_sum_b_one` helper** as a separate `private lemma` above
+   `jdt_weight_sum`. Statement:
+   ```
+   private lemma jdt_weight_sum_b_one (n a : ℕ) (ha : 1 ≤ a) :
+       ∑ PQ : { PQ : Sym (Fin n) a × Sym (Fin n) 1 // ¬ColStrictSym a 1 PQ.1 PQ.2 },
+         (PQ.1.1.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
+         (PQ.1.2.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
+       hsymm (Fin n) R (a + 1) * hsymm (Fin n) R 0
+   ```
+   Proof: `rw [hsymm_zero, mul_one]`; then build the equiv `ψ : LHS_subtype ≃ Sym (Fin n) (a+1)` and `Fintype.sum_equiv ψ`.
+3. **Refactor `jdt_weight_sum`** to dispatch on `b ∈ {0, 1, ≥2}`: keep b=0 case as is,
+   call `jdt_weight_sum_b_one` for b=1 (via `subst` after `rcases Nat.lt_or_ge b 2`),
+   leave b≥2 as `sorry` (the genuine frontier requiring full JDT seam algorithm).
+4. **Submit `jdt_weight_sum_b_one` to Aristotle** if implementation stalls — the
+   bijection is a known formalization (HARD sorry, not OPEN).
 
 ---
 

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 13 (2026-04-27) confirmed file state (666 lines, 10 theorems, 0 axioms, 2 sorries — was tracked as 458 lines / 3 sorries; metadata stale since PR #12933 sorries 3→2). Synced leanFile.lineCount/sorryCount/defCount. No proof work this session: disk constraint (1.3GB free) blocks Docker, and the b=1 jdt_weight_sum proof needs Docker validation. 2 sorries remain (b=1 case at line 421 with documented recipe; k≥3 case at line 664 blocked on algebraic LGV).",
+    "progressSummary": "Session 14 (2026-05-01) confirmed Mathlib API for the b=1 jdt_weight_sum recipe: hsymm_zero (Symmetric/Defs.lean:318), Sym.cons_erase (Sym/Basic.lean:219), Sym.erase_cons_head (:223), Sym.oneEquiv (:477), Sym.uniqueZero (:261), Multiset.sort_cons (Multiset/Sort.lean:69) all present and applicable. Confirmed lineCount drift 666→694 (recipe docstring grew via PR #13365). No proof work this session — local Docker daemon hung (server unresponsive); attempt deferred to next session with fresh Docker. Sorry count remains 2.",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -101,7 +101,9 @@
       "Session 10 (2026-04-27, survey only): both remaining sorries (jdt_weight_sum, jacobi_trudi_ssyt_eq k>=3) are correctly stated as of session 9. No fast fixes available; each is a focused 100-300 line proof body. Released for an agent with budget for sustained work.",
       "Session 11 (2026-04-27): documented concrete b=1 recipe using Sym.oneEquiv (alpha ≃ Sym alpha 1, Mathlib.Data.Sym.Basic:477), Sym.cons/cons_erase/erase_cons_head, and Multiset.sort_cons. Recipe lives in jdt_weight_sum b≥1 branch comment as actionable Lean plan. Next session can implement jdt_weight_sum_b_one directly without re-discovering API.",
       "Sym.oneEquiv is @[simps apply], so oneEquiv_apply rewrites oneEquiv a to ⟨{a}, _⟩ definitionally — cleanest way to handle Sym (Fin n) 1 in proofs",
-      "Session 13 (2026-04-27): metadata leanFile.sorryCount was stale (3) since PR #12933 reduced to 2 — no auto-sync runs. lineCount also stale (458 vs 666). Synced. No proof work — disk constraint (1.3GB free, no Docker) makes b=1 implementation risky without local validation."
+      "Session 13 (2026-04-27): metadata leanFile.sorryCount was stale (3) since PR #12933 reduced to 2 — no auto-sync runs. lineCount also stale (458 vs 666). Synced. No proof work — disk constraint (1.3GB free, no Docker) makes b=1 implementation risky without local validation.",
+      "Mathlib has 'hsymm_zero : hsymm σ R 0 = 1' as a simp lemma (Symmetric/Defs.lean:318), so the b=1 jdt_weight_sum RHS 'hsymm (a+1) * hsymm 0' simplifies to hsymm (a+1) via 'rw [hsymm_zero, mul_one]'. Eliminates one open question from the Session 13 recipe.",
+      "Sym.uniqueZero gives Unique (Sym α 0) (Mathlib Sym/Basic.lean:261), so reducing RHS via '← sum_all_sym_pairs n (a+1) 0' is equivalent to a Sym (Fin n) (a+1) sum after collapsing the trivial Sym (Fin n) 0 factor — both routes (hsymm_zero rewrite, or sum_all_sym_pairs reduction with Unique handling) are open."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -109,6 +111,8 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
+      "Implement jdt_weight_sum_b_one helper using the simp-lemma route: by rw [hsymm_zero, mul_one]; then build Equiv {(P,Q) : Sym n a × Sym n 1 // ¬ColStrictSym a 1 P Q} ≃ Sym (Fin n) (a+1) directly. Forward (P,Q,h) ↦ (Sym.oneEquiv.symm Q) ::ₛ P; inverse P' ↦ ((P'.erase q', oneEquiv q'), proof) where q' := head of P'.sort. Needs hsymm definition unfolded for RHS sum, then Fintype.sum_equiv.",
+      "Verify Docker functionality at session start before attempting proof — Session 14 hit unresponsive daemon (timeout on 'docker info'), wasting cycles. Disk had 138GB free so this was Docker Desktop infrastructure, not disk.",
       "Implement jdt_weight_sum_b_one (~60-90 lines) using documented recipe: bijection {(P, q): q ≤ P.sort[0]} ≃ Sym n (a+1) via cons/erase, with weight preserved by prod_cons + map_cons",
       "Refactor jdt_weight_sum to dispatch on b ∈ {0, 1, ≥2} cases, eliminating the b=1 sorry",
       "Tackle b≥2 JDT seam construction (~150 lines) — the genuine frontier",
@@ -146,7 +150,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-04-27T22:34:00.000Z",
+  "lastUpdate": "2026-05-01T13:30:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",
@@ -305,7 +309,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 666,
+      "lineCount": 694,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 6,


### PR DESCRIPTION
## Summary

Session 14 of `ballot-problem-oq-03-oq-01-oq-01-oq-01` (Jacobi-Trudi via LGV).
REVISIT mode, RICH knowledge tier (score 76).

Pure-text contributions this session — no Lean source changes.

### Mathlib API verified for b=1 recipe

Confirmed all six Mathlib lemmas needed for the documented `jdt_weight_sum` b=1
recipe are present in Mathlib v4.26.0 with correct paths:

| Lemma | Path |
|---|---|
| `MvPolynomial.hsymm_zero : hsymm σ R 0 = 1` (simp) | `Symmetric/Defs.lean:318` |
| `Sym.uniqueZero : Unique (Sym α 0)` | `Sym/Basic.lean:261` |
| `Sym.cons_erase` | `Sym/Basic.lean:219` |
| `Sym.erase_cons_head` | `Sym/Basic.lean:223` |
| `Sym.oneEquiv : α ≃ Sym α 1` | `Sym/Basic.lean:477` |
| `Multiset.sort_cons` | `Multiset/Sort.lean:69` |

This eliminates one open question from Session 13's recipe: with `hsymm_zero` as
a simp lemma, the b=1 case can dispatch via `rw [hsymm_zero, mul_one]` to
reduce the RHS `h_{a+1} * h_0` to `h_{a+1}`, so the bijection targets
`Sym (Fin n) (a+1)` directly (no need to handle `Sym n 0`).

### Why no proof work this session

Local Docker daemon hung — `docker info` timed out at the "Server:" line
(daemon backend running but unresponsive). Disk had 138GB free, so this is
Docker Desktop infrastructure overload, not a workspace constraint. Per
established feedback ("Docker build I/O errors during heavy multi-agent
activity is a Docker infrastructure failure, not Lean code"), did not attempt
unverified Lean changes.

### Meta sync

`leanFiles[BallotProblemOQ03OQ01OQ01OQ01.lean].lineCount`: 666 → 694.
PR #13365 grew the file via the inverse-direction recipe docstring without
re-syncing leanFile metadata.

### Files

- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`:
  progressSummary, +2 insights, +2 nextSteps, lineCount, lastUpdate
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md`:
  Session 14 entry

### Next session

1. Verify Docker before claiming this problem (Session 14 wasted the slot).
2. Implement `jdt_weight_sum_b_one` helper using the simp-lemma route documented
   in `knowledge.md` Session 14.
3. Refactor `jdt_weight_sum` to dispatch on `b ∈ {0, 1, ≥2}`.
4. Submit b=1 helper to Aristotle if implementation stalls — it is a HARD sorry,
   not OPEN.

## Test plan
- [x] JSON lints (jq parse OK)
- [x] knowledge.md renders (markdown lints OK)
- [ ] No Lean source changed → no Docker build needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)