### PR TITLE
audit(erdos-653): mark issues-found — 7 phantom identifiers

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8220,9 +8220,9 @@
     },
     "erdos-653": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T04:48:53Z",
+      "result": "issues-found"
     },
     "erdos-654": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-653 against Lean source at origin/main `9d270d77`.
- Confirmed the 5 phantom identifiers in #14113 and surfaced **2 additional**: `regular_polygon_r_value` (section `special-configs`), `optimal_exists` (section `extremal-configs`).
- All numerical counts (3 axioms, 2 theorems, 13 defs, 0 sorries, 253 lines) match.
- Tracker updated to `issues-found`; details posted as comment on #14113.

## Test plan
- [x] Inspected `proofs/Proofs/Erdos653Problem.lean` from origin/main
- [x] Verified only 3 `axiom` declarations exist
- [x] Cross-checked every section summary identifier against the file