### PR TITLE
audit(erdos-645): mark issues-found — phantom main theorem, status overstated

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8159,10 +8159,13 @@
       "result": "clean"
     },
     "erdos-645": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-2026-05-01",
+      "auditCount": 3,
+      "issues": [
+        "Section main-theorem claims phantom axiomatized theorem; status overstated (Tier C narrative on Tier D content); see #14118"
+      ],
+      "lastAudited": "2026-05-01T05:10:00Z",
+      "result": "issues-found"
     },
     "erdos-646": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audit-tracker update only: marks erdos-645 as `issues-found` (auditCount 2 → 3)
- Filed gallery-integrity issue #14118
- No source/meta changes — narrative fix is tracked in #14118 for the mechanic agent

## Findings

The Lean file `proofs/Proofs/Erdos645Problem.lean` is essentially Tier D (definitions / scaffold):
- `erdos_645_statement : Prop` is defined but never proved or asserted via axiom
- The single `axiom erdos645_threshold : ℕ` is a placeholder Nat constant, not a proof
- meta.json presents this as `status: axiomatized` with section `main-theorem` claiming "The axiomatized theorem that Erdős #645 is true" — no such axiom or theorem exists

Numerical counts (sorries=0, axiomCount=1, theoremCount=3, definitionCount=12, lineCount=251) all match the source. Issue is purely narrative.

## Test plan

- [x] git diff clean — only erdos-645 entry in audit-tracker.json modified
- [x] Issue #14118 filed with full evidence and recommended fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)