### PR TITLE
audit(erdos-649): mark issues-found — Tong/Mahler axioms listed as contributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8187,9 +8187,12 @@
     },
     "erdos-649": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "originalContributions claims Tong's theorem and Mahler's growth theorem as contributions when both are axiom declarations (axiom tong_theorem, axiom mahler_growth) — issue #14123 also covers this proof"
+      ],
+      "lastAudited": "2026-05-01T05:30:00Z",
+      "result": "issues-found"
     },
     "erdos-65": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Marks `erdos-649` as `issues-found` (auditCount 2→3) in the audit tracker.
- Adds an `issues` note pointing to the new finding plus the existing umbrella issue #14123.

## Finding

`src/data/proofs/erdos-649/meta.json` `originalContributions` lists:
- `Tong's theorem: infinitely many failing pairs`
- `Mahler's growth theorem for P(n(n+1))`

Both correspond to `axiom` declarations in `proofs/Proofs/Erdos649Problem.lean`:
- `axiom tong_theorem` (line 210)
- `axiom mahler_growth` (line 272)

This is the same phantom-axiom narrative pattern repaired across many erdos-9XX entries: the proof file's *contributions* list reads as if the theorem was proved when it was axiomatized.

Numerical fields are correct (sorries=0, axiomCount=4, lineCount=364, theoremCount=18, definitionCount=2).

Issue #14123 already covers section line range drift and other narrative phantoms for this proof; the contributions-vs-axioms mismatch fits within that scope.

## Test plan

- [x] `git show origin/main:proofs/Proofs/Erdos649Problem.lean` confirms 4 axioms incl. tong_theorem + mahler_growth and 0 sorries
- [x] Diff is tracker-only, no unicode escaping noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)