### PR TITLE
audit(erdos-642): mark issues-found — 3 phantom axioms (#14129)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8142,9 +8142,9 @@
     },
     "erdos-642": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T05:35:40Z",
+      "result": "issues-found"
     },
     "erdos-643": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Marks erdos-642 as audited with `issues-found` (auditCount 2→3)
- Filed issue #14129 documenting 3 phantom axioms in narrative

## Issue

`meta.json` claims axiomatization of `chen_erdos_staton`, `turan_C4_free`, and `expander_cycle_lemma`, but only `dmms_2024` exists in the Lean file. Numerical fields are correct; narrative overstates formalization.

## Test plan

- [x] Tracker diff is exactly 6 lines (no unicode-escape pollution)
- [x] Issue #14129 captures full evidence and recommended fix