### PR TITLE
audit(erdos-1078): mark issues-found — 2 phantom theorems in sections (#14133)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3563,10 +3563,14 @@
       "result": "issues-fixed"
     },
     "erdos-1078": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent-2026-05-01",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T05:51:29Z",
+      "result": "issues-found",
+      "issues": [
+        "sections.comparison.summary claims theorem asymptotic_agreement (line 167-172) but only docstring exists; no Lean declaration",
+        "sections.transversals.summary claims theorem extremal_construction (line 185-188) but only docstring exists; no Lean declaration"
+      ]
     },
     "erdos-1079": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Audit of erdos-1078 against `proofs/Proofs/Erdos1078Problem.lean` on `origin/main` (`6f5f357`):

- **Numerical counts: all correct** — axiomCount=4, sorries=0, lineCount=205, theoremCount=4, definitionCount=5 all match the source.
- **Phantom theorems in 2 section summaries** — `asymptotic_agreement` and `extremal_construction` are claimed in `sections[].summary` / `mathContext` but exist only as docstrings (no Lean declarations).

Filed issue #14133 with the full evidence and recommended fix.

This PR only updates `audit-tracker.json` (auditCount 2 → 3, result `issues-fixed` → `issues-found`).

## Test plan
- [x] Tracker JSON validates
- [x] Diff is ASCII-clean — preserved arrow `→` characters in unrelated existing entries (used `ensure_ascii=False`)
- [x] Phantom claims verified via `git show origin/main:proofs/Proofs/Erdos1078Problem.lean | grep -nE "extremal_construction|asymptotic_agreement"` returning only `asymptotic_threshold` (a real theorem on line 99, not the claimed `asymptotic_agreement`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)