### PR TITLE
audit(erdos-636): mark issues-found — phantom axioms in narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8100,9 +8100,12 @@
     },
     "erdos-636": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T06:02:15Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axioms in narrative: assumptions field claims 7 former axioms (ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count) which are absent from the file; sections efs/ramsey/techniques/ramsey-theory and originalContributions/proofStrategy reference axioms that do not exist — issue #14136"
+      ]
     },
     "erdos-637": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates audit-tracker.json for `erdos-636`: auditCount 2→3, result `issues-fixed`→`issues-found`.
- Records the phantom-axiom narrative findings filed in #14136.

## Findings

Numerical accounting in `meta.json` is correct (axiomCount=2, sorries=4, theoremCount=8). However, the narrative still references seven axioms that no longer exist in the Lean source:

`ramsey_graphs_exist`, `erdos_faudree_sos`, `ks_probabilistic_method`, `signature_distribution`, `non_ramsey_smaller_bound`, `ramsey_forces_complexity`, `induced_path_count`

`grep` confirms none appear in `proofs/Proofs/Erdos636Problem.lean`. Multiple section summaries claim "axiomatizes…" where no axiom exists; `originalContributions` and `proofStrategy` mention "axiomatization of EFS" but only `def efs_exponent : ℝ := 3/2` is present.

See issue #14136 for the full list and recommended fixes.

## Test plan
- [x] `git diff` shows only the `erdos-636` entry changed (no unicode escape pollution)
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)