### PR TITLE
fix(erdos-1078): correct phantom theorem narrative in section summaries

### DIFF
--- a/src/data/proofs/erdos-1078/meta.json
+++ b/src/data/proofs/erdos-1078/meta.json
@@ -118,16 +118,16 @@
       "title": "Part VI: Comparison with BES Threshold",
       "startLine": 165,
       "endLine": 172,
-      "summary": "asymptotic_agreement: sharp threshold ≈ (r-3/2)n.",
-      "mathContext": "Mathematical content: asymptotic_agreement: sharp threshold ≈ (r-3/2)n."
+      "summary": "Docstring commentary on asymptotic agreement: the sharp threshold (r-1)n - ⌈sn/(2s-1)⌉ ≈ (r-3/2)n for large n since ⌈sn/(2s-1)⌉ ≈ n/2 + O(1). No Lean theorem is declared in Part VI — the section contains only a docstring with Part VII beginning immediately after.",
+      "mathContext": "Docstring commentary on asymptotic agreement between the sharp threshold and the BES threshold (r-3/2)n. asymptotic_agreement is not a Lean declaration — only a docstring heading."
     },
     {
       "id": "transversals",
       "title": "Part VII: Connection to Transversals",
       "startLine": 173,
       "endLine": 188,
-      "summary": "IsIndependentTransversal definition and extremal_construction.",
-      "mathContext": "Formal definition: IsIndependentTransversal definition and extremal_construction."
+      "summary": "IsIndependentTransversal definition: a transversal T with one vertex per part such that no two vertices are adjacent. extremal_construction is noted in a docstring comment only — no Lean declaration of that name exists in this section.",
+      "mathContext": "IsIndependentTransversal definition (lines 185–188): a transversal with one vertex per part, no adjacent pair. extremal_construction is a docstring heading, not a Lean declaration."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Correct two section summaries in erdos-1078 meta.json that named non-existent Lean theorems.

## Evidence

**Before**: sections claimed `asymptotic_agreement` as a theorem and `extremal_construction` as a declaration
**After**: summaries accurately describe docstring-only commentary

Verified against origin/main Lean source (`git show origin/main:proofs/Proofs/Erdos1078Problem.lean`):
- Lines 165–172 (Part VI): only a docstring block `**Asymptotic Agreement:**` followed immediately by Part VII — no theorem
- Lines 185–188 (Part VII): `IsIndependentTransversal` IS a real definition; `extremal_construction` appears only as a docstring heading

`axiomCount=4`, `sorries=0`, and `originalContributions` were already correct and unchanged.

Closes #14133

---
Automated fix by lean-mechanic agent.