### PR TITLE
fix(erdos-649): correct phantom axiom claims and P(m*n) narrative in meta

### DIFF
--- a/src/data/proofs/erdos-649/meta.json
+++ b/src/data/proofs/erdos-649/meta.json
@@ -40,8 +40,8 @@
       }
     ],
     "originalContributions": [
-      "Axiomatized greatest prime factor P(m) function",
-      "Properties: P(p) = p, P(p^k) = p, P(m*n) = max(P(m), P(n))",
+      "Greatest prime factor P(m) defined via Mathlib's primeFactorsList",
+      "Properties proved: P(p) = p (gpf_prime), P(p^k) = p (gpf_prime_power), P(m) | m (gpf_divides), P(m).Prime (gpf_is_prime); P(m*n) = max(P(m), P(n)) is noted in a docstring only",
       "Erdős conjecture formal statement",
       "Key lemma: 2^k ≢ -1 (mod 7) for all k",
       "Counterexample theorem: no n with P(n) = 2, P(n+1) = 7",
@@ -59,7 +59,7 @@
     "historicalContext": "**Erdős Problem #649**\n\nThis problem asks whether all prime pairs can be realized as greatest prime factors of consecutive integers.\n\n**Key History:**\n- Erdős believed the problem was 'probably hopelessly difficult'\n- Multiple counterexamples discovered via modular arithmetic\n- Tong proved infinitely many pairs fail for any fixed p\n- Mahler (1935) studied growth of P(n(n+1))\n\n**The Counterexamples:**\n- (2, 7): 2^k ≢ -1 (mod 7) since ord_7(2) = 3 is odd\n- (19, 2): 2 is a primitive root mod 19\n- Infinitely many pairs via quadratic reciprocity obstructions",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet P(m) denote the greatest prime factor of m.\n\nIs it true that for any two primes p, q, there exists n such that:\n- P(n) = p\n- P(n+1) = q\n\n**Answer: NO**\n\nThe pair (p, q) = (2, 7) has no solution, and infinitely many other pairs fail.",
     "text": "Can any two primes p, q be achieved as P(n) = p and P(n+1) = q for some n? DISPROVED: The pair (2, 7) fails since 2^k ≢ -1 (mod 7) for all k.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Greatest Prime Factor:** Axiomatize P(m) with key properties\n\n2. **Erdős Conjecture:** Define as ∀ p q prime, ∃ n with P(n) = p, P(n+1) = q\n\n3. **Counterexample (2, 7):**\n   - If P(n) = 2, then n = 2^k for some k\n   - If P(2^k + 1) = 7, then 7 | (2^k + 1)\n   - But 2^k cycles {1, 2, 4} mod 7, never reaching 6 ≡ -1\n   - Contradiction\n\n4. **Main Theorem:** Apply the counterexample to disprove the conjecture\n\n5. **Extensions:** Tong's theorem on infinitely many failures",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Greatest Prime Factor:** Define P(m) via Mathlib's primeFactorsList; prove properties gpf_prime, gpf_prime_power, gpf_divides; axiomatize specific facts (gpf_eq_two_iff, consecutive_gpf_divides) used in the counterexample\n\n2. **Erdős Conjecture:** Define as ∀ p q prime, ∃ n with P(n) = p, P(n+1) = q\n\n3. **Counterexample (2, 7):**\n   - If P(n) = 2, then n = 2^k for some k\n   - If P(2^k + 1) = 7, then 7 | (2^k + 1)\n   - But 2^k cycles {1, 2, 4} mod 7, never reaching 6 ≡ -1\n   - Contradiction\n\n4. **Main Theorem:** Apply the counterexample to disprove the conjecture\n\n5. **Extensions:** Tong's theorem on infinitely many failures",
     "keyInsights": [
       "**Powers of 2 mod 7:** The cycle {1, 2, 4} has period 3, never hitting 6 ≡ -1",
       "**Order Theory:** ord_7(2) = 3 is odd, so -1 ∉ ⟨2⟩ in (Z/7Z)*",
@@ -77,10 +77,10 @@
     {
       "id": "gpf-definition",
       "title": "Greatest Prime Factor",
-      "summary": "Definition of P(m), axioms for primes, prime powers, products",
+      "summary": "Definition of P(m) via primeFactorsList, private helpers, and theorems: gpf_one, gpf_prime_power, gpf_divides, gpf_prime, gpf_is_prime. No axioms in this section — all 4 axioms (gpf_eq_two_iff, consecutive_gpf_divides, tong_theorem, mahler_growth) appear in later sections.",
       "startLine": 39,
       "endLine": 96,
-      "mathContext": "Formal definition: Definition of P(m), axioms for primes, prime powers, products"
+      "mathContext": "def greatestPrimeFactor (line 59), theorems gpf_prime, gpf_prime_power, gpf_divides, gpf_is_prime. P(m*n) = max(P(m), P(n)) appears only as a docstring comment (line 98), with no Lean proof."
     },
     {
       "id": "conjecture",


### PR DESCRIPTION
## Fix

Correct text-only narrative drift in erdos-649 meta.json. Numerical fields were already correct; only narrative text is updated.

## Evidence

**Problem 1**: `originalContributions[0]` claimed "Axiomatized greatest prime factor P(m) function"
**Reality**: `def greatestPrimeFactor` (line 59) uses Mathlib's `primeFactorsList` — it is defined, not axiomatized.

**Problem 2**: `originalContributions[1]` claimed "P(m*n) = max(P(m), P(n))" as a proved property
**Reality**: Line 98 is only a docstring `/-- P(m * n) = max(P(m), P(n)) for m, n > 1. -/` with no theorem body; the next line is a section comment starting Part II.

**Problem 3**: `proofStrategy` step 1 said "Axiomatize P(m) with key properties"
**Reality**: P(m) is defined; only specific arithmetic facts are axiomatized.

**Problem 4**: `sections[0].summary` claimed "axioms for primes, prime powers, products"
**Reality**: No axioms in lines 39–96; all 4 axioms are at lines 125, 131, 210, 272.

Closes #14114

---
Automated fix by lean-mechanic agent.