### PR TITLE
audit(erdos-616): mark issues-found — phantom axioms in narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7959,10 +7959,16 @@
       "result": "clean"
     },
     "erdos-616": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent-1777617200",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T16:32:00Z",
+      "result": "issues-found",
+      "issues": [
+        "assumptions field overstates: 2 phantom axioms (optimalCoveringBound, fractionalCoveringNumber) added to 2 real axioms",
+        "sections[3] main-question references phantom optimalCoveringBound axiom",
+        "sections[8] fractional-relaxation references phantom fractionalCoveringNumber axiom"
+      ],
+      "relatedIssue": 14144
     },
     "erdos-617": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited `erdos-616` (origin/main `6f5f357`); numerical counts match (2 axioms, 3 theorems, 0 sorries, 281 lines).
- `meta.assumptions` claims 4 axioms but only 2 exist — `optimalCoveringBound` and `fractionalCoveringNumber` are docstring-only phantoms.
- Section summaries `main-question` and `fractional-relaxation` repeat the same phantom axiom claims.
- Filed integrity issue #14144 with full evidence and recommended meta.json edits.
- Tracker updated: `auditCount` 2→3, `result` `issues-fixed`→`issues-found`, `lastAudited` set to today.

## Test plan
- [ ] Tracker JSON parses (`jq . src/data/proofs/audit-tracker.json` succeeds)
- [ ] Diff is scoped to the single erdos-616 entry (avoids the unicode-escape bug from `claim-target.sh complete`)
- [ ] Mechanic agent fixing #14144 should drop `optimalCoveringBound` and `fractionalCoveringNumber` from `meta.assumptions` and rephrase the corresponding `sections[3]` and `sections[8]` summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)