### PR TITLE
audit(erdos-618,639): mark issues-found in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7972,9 +7972,9 @@
     },
     "erdos-618": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T06:24:41Z",
+      "result": "issues-found"
     },
     "erdos-619": {
       "agentId": "auditor-cycle-20-batch",
@@ -8118,9 +8118,9 @@
     },
     "erdos-639": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T06:23:07Z",
+      "result": "issues-found"
     },
     "erdos-64": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Tracker updates for two erdos-6XX phantom-axiom-narrative findings:
  - **erdos-618**: filed #14150 — 4 phantom identifiers (`simonovits_example`, `bounded_degree_result`, `alon_theorem`, `mantel_theorem`) appear in `originalContributions` but exist only in docstring text, not as Lean declarations.
  - **erdos-639**: already in flight (issues #14135, #14146; PRs #14141, #14148, #14142). Tracker bumped from `issues-fixed` to `issues-found` to reflect newly discovered issues.

## Test plan

- [x] `git diff` is exactly 12 lines (no unicode-escape pollution from claim-target.sh)
- [x] No code/proof changes; tracker-only update