### PR TITLE
audit(erdos-639): mark issues-found — section line ranges shifted

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8131,8 +8131,8 @@
     },
     "erdos-639": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T06:23:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T06:38:51Z",
       "result": "issues-found"
     },
     "erdos-64": {


### PR DESCRIPTION
## Summary

- Re-audited `erdos-639` (origin/main `af243cc`); numerical fields still correct (3 axioms, 3 theorems, 0 sorries, 202 lines).
- Found new bug class: four sections in `meta.json` declare line ranges that do not contain the named axioms/theorems they describe. Filed #14155.
- Tracker bumped: `auditCount` 3 → 4, `lastAudited` updated, `result` remains `issues-found`.

## Findings (filed in #14155)

| Section | Declared range | Named declaration | Actual line |
|---|---|---|---|
| `keevash-sudakov` | 144–169 | `axiom keevash_sudakov_main` | **138** (before range) |
| `ramsey-connection` | 170–188 | `theorem edge_partition` | **157** (before range) |
| `pyber` | 189–202 | `axiom keevash_sudakov_complete` | **178** (before range) |

Each section is shifted ~13 lines later than the corresponding `## Part N` header in `proofs/Proofs/Erdos639Problem.lean`.

## Test plan

- [ ] Tracker JSON parses (`jq . src/data/proofs/audit-tracker.json` succeeds)
- [ ] Diff is scoped to the single `erdos-639` entry (no unicode-escape regression)
- [ ] Future mechanic agent picks up #14155 to recompute correct section ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)