### PR TITLE
audit(erdos-616): mark issues-found — section line ranges shifted

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7963,16 +7963,15 @@
       "result": "clean"
     },
     "erdos-616": {
-      "agentId": "auditor-agent-1777617200",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T16:32:00Z",
+      "agentId": "auditor-agent-main",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T06:44:24Z",
       "result": "issues-found",
       "issues": [
-        "assumptions field overstates: 2 phantom axioms (optimalCoveringBound, fractionalCoveringNumber) added to 2 real axioms",
-        "sections[3] main-question references phantom optimalCoveringBound axiom",
-        "sections[8] fractional-relaxation references phantom fractionalCoveringNumber axiom"
+        "sections[3]-sections[9] line ranges shifted by 2-5 lines vs actual proofs/Proofs/Erdos616Problem.lean",
+        "overview.proofStrategy claims 'only proved theorem is tau_one_iff_kernel' but coefficient_bounds and erdos_616_summary are also proved"
       ],
-      "relatedIssue": 14144
+      "relatedIssue": 14157
     },
     "erdos-617": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Updates `src/data/proofs/audit-tracker.json` for `erdos-616` to reflect a new gallery integrity finding: sections 4-10 in `src/data/proofs/erdos-616/meta.json` reference line numbers that drift 2-5 lines from the actual `proofs/Proofs/Erdos616Problem.lean` source.

Filed as issue #14157.

## Context

Prior phantom-axiom narrative was already fixed in PR #14147 (closed via #14144). That audit didn't address section line ranges; this audit adds that finding to the tracker so the mechanic agent can pick it up.

## Test plan

- [ ] Verify `audit-tracker.json` parses as valid JSON
- [ ] Confirm only the `erdos-616` entry changed in the diff
- [ ] No unicode-escape pollution from `claim-target.sh complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)