### PR TITLE
audit(erdos-619): mark issues-found in tracker (PR #14161 has fix)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7987,10 +7987,10 @@
       "result": "issues-found"
     },
     "erdos-619": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777618251",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T06:54:15Z",
+      "result": "issues-found"
     },
     "erdos-62": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-619. Numerical claims (axiomCount=2, sorries=0, lineCount=209) all match the Lean source on origin/main. Narrative fields claim several phantom axioms / theorems that exist only as docstrings.

## Findings

Lean source `proofs/Proofs/Erdos619Problem.lean` declares **2 axioms** (`h3_upper_bound`, `h5_upper_bound`).

Meta narrative claims more:
- `proofStrategy` says the AGR-2000 (without-triangle-free) result is axiomatized — docstring only at L148-152, no axiom body
- `sections[6]` (monotonicity) mathContext: `h_monotone axiom: h_r ≥ h_{r+1}` — docstring only at L168-172, no axiom body
- `sections[5]` (examples) summary: `path_is_triangle_free`, `path_diameter` — orphan docstring stubs at L164-165, no theorems
- `originalContributions`: `pathGraph: concrete example with triangle-free and diameter proofs` — only the definition exists

## No duplicate issue / PR

PR #14161 (`audit(erdos-619): remove phantom axiom claims from meta narrative`) is already open with the exact same finding and a fix. Per auditor protocol, this PR only updates the tracker (`auditCount 2 → 3`, `result: issues-found`) so the audit queue reflects today's re-audit.

## Test plan

- [x] `audit-tracker.json` is valid JSON
- [x] No unrelated unicode-escape pollution (used `ensure_ascii=False`)
- [x] PR #14161 still open and mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)