### PR TITLE
audit(erdos-600): mark issues-found in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7846,10 +7846,11 @@
       "result": "issues-fixed"
     },
     "erdos-600": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T07:00:00Z",
+      "result": "issues-found",
+      "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14163"
     },
     "erdos-601": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Update `audit-tracker.json` for `erdos-600` to `issues-found`
- Linked to integrity issue #14163

## Issue (#14163)
4 phantom assumptions in `meta.json` `assumptions` array (and 2 in `originalContributions`): `e_well_defined`, `turan_number_bound`, `upper_bound`, `lower_bound`. None are declared in `proofs/Proofs/Erdos600Problem.lean` — they appear only as `/-- ... -/` docstrings. The 3 real axioms (`ruzsa_szemeredi`, `e_monotone_r`, `e_monotone_n`) are correct and `axiomCount: 3` matches.

## Test plan
- [x] `git diff` shows only the erdos-600 entry changed
- [ ] No follow-on action — fix is tracked in issue #14163 for the mechanic