### PR TITLE
audit(erdos-6): correct section line ranges to match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7834,10 +7834,11 @@
       "result": "issues-fixed"
     },
     "erdos-6": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777619133",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T07:15:00Z",
+      "result": "issues-fixed",
+      "notes": "Section line ranges drifted from actual Lean section markers — corrected."
     },
     "erdos-60": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-6/meta.json
+++ b/src/data/proofs/erdos-6/meta.json
@@ -77,50 +77,50 @@
   "sections": [
     {
       "id": "prime-gap",
-      "title": "Prime Gap Definition",
-      "summary": "Definition of d_n = p_{n+1} - p_n using Mathlib's prime enumeration",
+      "title": "Prime Gap Definition and Basic Properties",
+      "summary": "Definition of d_n = p_{n+1} - p_n and basic prime gap lemmas",
       "mathContext": "$d_n = p_{n+1} - p_n$, where $p_n$ denotes the $n$-th prime (0-indexed via `Nat.nth Nat.Prime`)",
       "startLine": 32,
-      "endLine": 56
+      "endLine": 67
     },
     {
       "id": "monotone",
       "title": "Monotone Sequences",
       "summary": "HasIncreasingGaps, HasDecreasingGaps, InfinitelyMany predicates",
       "mathContext": "`HasIncreasingGaps n m` $\\iff$ $\\forall i < m,\\; d_{n+i} < d_{n+i+1}$; similarly for decreasing",
-      "startLine": 57,
-      "endLine": 74
+      "startLine": 68,
+      "endLine": 85
     },
     {
       "id": "conjecture",
       "title": "Original Conjecture",
       "summary": "Erdős Problem 6 as InfinitelyManyIncreasing 2",
       "mathContext": "$\\exists^\\infty n,\\; d_n < d_{n+1} < d_{n+2}$, i.e., `InfinitelyManyIncreasing 2`",
-      "startLine": 75,
-      "endLine": 85
+      "startLine": 86,
+      "endLine": 96
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem",
-      "summary": "Banks-Freiberg-Turnage-Butterbaugh (2015) resolution",
+      "title": "Main Theorem and Resolution",
+      "summary": "Banks-Freiberg-Turnage-Butterbaugh (2015) axioms and erdos_6_solved",
       "mathContext": "$\\forall m \\geq 1,\\; \\forall N,\\; \\exists n > N,\\; d_n < d_{n+1} < \\cdots < d_{n+m}$",
-      "startLine": 86,
-      "endLine": 113
+      "startLine": 97,
+      "endLine": 124
     },
     {
       "id": "machinery",
       "title": "Maynard-Tao Machinery",
       "summary": "Key ingredients: bounded gaps theorems of Maynard-Tao and Zhang",
       "mathContext": "$\\exists H,\\; \\forall N,\\; \\exists n > N,\\; |\\{p \\text{ prime} : p \\in [n, n+H]\\}| \\geq m$",
-      "startLine": 114,
-      "endLine": 136
+      "startLine": 125,
+      "endLine": 139
     },
     {
       "id": "generalizations",
-      "title": "Generalizations",
+      "title": "Generalizations and Related Results",
       "summary": "Arbitrarily long runs and oscillation theorems",
       "mathContext": "$\\forall m \\geq 1$, both `InfinitelyManyIncreasing m` and `InfinitelyManyDecreasing m` hold; prime gaps oscillate without eventual monotonicity",
-      "startLine": 148,
+      "startLine": 140,
       "endLine": 191
     }
   ],


### PR DESCRIPTION
## Summary

Gallery integrity fix for erdos-6 (Monotone Prime Gap Sequences, Banks-Freiberg-Turnage-Butterbaugh).

## Findings

Numerical claims are all correct against `proofs/Proofs/Erdos6Problem.lean`:

| Field | Claim | Actual | OK |
|-------|-------|--------|----|
| axiomCount | 2 | 2 (`banks_freiberg_turnage_butterbaugh`, `..._decreasing`) | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 191 | 191 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 7 | 7 | ✓ |

`originalContributions` and `proofStrategy` accurately describe what the Lean file proves. No phantom axioms.

The drift was confined to **section line ranges**, which had stale numbers from before file edits.

## Section Range Corrections

| id | claimed | actual Lean range |
|----|---------|-------------------|
| prime-gap | 32–56 | 32–67 |
| monotone | 57–74 | 68–85 |
| conjecture | 75–85 | 86–96 |
| main-theorem | 86–113 | 97–124 |
| machinery | 114–136 | 125–139 |
| generalizations | 148–191 | 140–191 |

The 137–147 gap (between machinery and generalizations) is closed. Two section titles updated to reflect the slightly broader Lean-source span they now include (`Prime Gap Definition` → `... and Basic Properties`; `Main Theorem` → `... and Resolution`; `Generalizations` → `... and Related Results`).

## Test plan

- [x] `meta.json` is valid JSON
- [x] Lean source unchanged
- [x] All numerical fields still match
- [x] Each `startLine` is at or just after the corresponding `/- ## ... -/` Lean section marker
- [x] Tracker marked `issues-fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)