### PR TITLE
audit(erdos-636): mark issues-found — section line range drift (#14169)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8110,11 +8110,12 @@
     },
     "erdos-636": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T06:02:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T07:20:00Z",
       "result": "issues-found",
       "issues": [
-        "phantom axioms in narrative: assumptions field claims 7 former axioms (ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count) which are absent from the file; sections efs/ramsey/techniques/ramsey-theory and originalContributions/proofStrategy reference axioms that do not exist — issue #14136"
+        "phantom axioms in narrative: assumptions field claims 7 former axioms (ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count) which are absent from the file; sections efs/ramsey/techniques/ramsey-theory and originalContributions/proofStrategy reference axioms that do not exist — issue #14136",
+        "section line ranges drift: kwan-sudakov 135-152 cuts kwan_sudakov axiom (133-137); optimality 153-177 cuts signature_upper_bound axiom (151-155); related 234-256 covers Part XI content; main-result 257-261 contains only #check directives while erdos_636 theorem is at 244-248 — issue #14169"
       ]
     },
     "erdos-637": {


### PR DESCRIPTION
## Summary

- Re-audit of erdos-636 on origin/main (af243ccbe8e8) after #14143 merged.
- Sorry count (4) and axiom count (2) match Lean source, but section line ranges have drifted.
- Filed issue #14169 with specific evidence and proposed corrected ranges.

## Findings

| Section | meta range | actual content | issue |
|---|---|---|---|
| `kwan-sudakov` | 135-152 | axiom kwan_sudakov at 133-137 | range cuts axiom body |
| `optimality` | 153-177 | axiom signature_upper_bound at 151-155 | range cuts axiom body |
| `related` | 234-256 | Part X content ends at line 225 | covers Part XI instead |
| `main-result` | 257-261 | `theorem erdos_636` at 244-248 | range contains only `#check` directives |

## Test plan

- [x] Verified against `git show origin/main:proofs/Proofs/Erdos636Problem.lean`
- [x] Sorry count: claimed 4 = actual 4
- [x] Axiom count: claimed 2 = actual 2
- [x] Tracker entry updated with new finding

Note: PR #14166 (open) claimed "Section line ranges align with file structure" — that claim is incorrect on current origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)