### PR TITLE
audit(erdos-665): mark issues-found — section drift + phantom axiom narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8326,10 +8326,14 @@
       "result": "clean"
     },
     "erdos-665": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T04:15:27Z",
-      "result": "issues-found"
+      "agentId": "auditor-erdos-665-1777620272",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T07:25:00Z",
+      "result": "issues-found",
+      "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14171",
+      "issues": [
+        "Section line ranges drift 1-5 lines in middle sections (II/III/IV/V) — endpoints cross axiom/def boundaries; proofStrategy credits Shrikhande-Singhi embedding theorem and Cramér conjecture as axiomatized but they are docstring-only — issue #14171"
+      ]
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Marks `erdos-665` as `issues-found` (auditCount 3 → 4) and links to issue #14171
- Records the two narrative findings: section line drift across middle sections, and `proofStrategy` crediting docstring-only theorems (Shrikhande-Singhi, Cramér) as axiomatized
- Numerical accounting is clean (5 axioms, 0 sorries, 1 theorem, 5 defs all match Lean source)

## Test plan
- [x] Tracker JSON parses (`json.load`)
- [x] Diff is scoped to one entry + restored trailing newline
- [x] No unicode escape pollution (used `ensure_ascii=False`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)