### PR TITLE
fix(erdos-597): correct section line ranges (shifted +6)

### DIFF
--- a/src/data/proofs/erdos-597/meta.json
+++ b/src/data/proofs/erdos-597/meta.json
@@ -79,48 +79,48 @@
       "id": "ordinal-notation",
       "title": "Ordinal Notation",
       "startLine": 32,
-      "endLine": 57,
+      "endLine": 51,
       "summary": "Definitions of ω₁, ω, ω₁ω, and ω₁² as ordinals"
     },
     {
       "id": "graph-structures",
       "title": "Graph Structures",
-      "startLine": 58,
-      "endLine": 92,
+      "startLine": 52,
+      "endLine": 86,
       "summary": "SimpleGraph', containsClique, isK4Free, containsCountableBiclique, isKAleph0Free, hasAtMostAleph1Vertices"
     },
     {
       "id": "partition-arrow",
       "title": "Partition Arrow Notation",
-      "startLine": 93,
-      "endLine": 103,
+      "startLine": 87,
+      "endLine": 97,
       "summary": "Axiomatized partition relation α → (β, γ)²"
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "startLine": 104,
-      "endLine": 124,
+      "startLine": 98,
+      "endLine": 118,
       "summary": "erdos597Conjecture and finiteCaseConjecture definitions"
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 125,
-      "endLine": 142,
+      "startLine": 119,
+      "endLine": 136,
       "summary": "Erdős-Hajnal triangle theorem and Baumgartner counterexample"
     },
     {
       "id": "background",
       "title": "Background and Context",
-      "startLine": 143,
-      "endLine": 172,
+      "startLine": 137,
+      "endLine": 166,
       "summary": "Why both conditions are needed, partition calculus background, set-theoretic context"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 173,
+      "startLine": 167,
       "endLine": 183,
       "summary": "erdos597_knownResults theorem combining positive and negative results"
     }


### PR DESCRIPTION
## Summary

- Section line ranges in `src/data/proofs/erdos-597/meta.json` were shifted by +6 lines (likely drift from an earlier docstring removal).
- Corrected all 7 section ranges to match actual headings in `proofs/Proofs/Erdos597Problem.lean`.
- Pure metadata fix — no Lean source or contribution claim changes.

## Evidence

Actual section heading lines in `proofs/Proofs/Erdos597Problem.lean` (183 lines total):

| Section | Heading | Old range | New range |
|---|---|---|---|
| ordinal-notation | 32 | 32-57 | 32-51 |
| graph-structures | 52 | 58-92 | 52-86 |
| partition-arrow | 87 | 93-103 | 87-97 |
| main-conjecture | 98 | 104-124 | 98-118 |
| known-results | 119 | 125-142 | 119-136 |
| background | 137 | 143-172 | 137-166 |
| summary | 167 | 173-183 | 167-183 |

Other claims in meta.json (axiomCount: 6, sorries: 0, lineCount: 183, theoremCount: 1, definitionCount: 8) all verified accurate against the Lean source.

## Test plan

- [x] meta.json startLine/endLine values match actual headings in `Erdos597Problem.lean`
- [x] No other meta fields changed
- [ ] CI green

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)