### PR TITLE
audit(erdos-596): mark issues-found — phantom axioms in narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7811,9 +7811,12 @@
     },
     "erdos-596": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T07:44:52Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axioms in narrative: section summaries claim Axiom erdos_596 (Part IV) and Axiom erdos_595_k4_k3 (Part V) — neither declared in Lean file; only nesetril_rodl_c4_c6 and erdos_hajnal_c4_trees exist — issue #14179"
+      ]
     },
     "erdos-597": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
Mark erdos-596 as `issues-found` in audit tracker. Filed #14179 for the underlying mismatch.

The Lean file declares exactly 2 axioms (`nesetril_rodl_c4_c6`, `erdos_hajnal_c4_trees`). Numerical fields in meta.json (axiomCount, assumptions) are correct, but two `sections[].summary` strings claim phantom axioms:
- Part IV (`main-conjecture`): "Axiom erdos_596" — but `ErdosProblem596` is a `def`, not an axiom.
- Part V (`related-problem`): "Axiom erdos_595_k4_k3 for the (K₄, K₃) case" — no such axiom is declared.

Same phantom-axiom narrative pattern previously seen across erdos-9XX entries.

## Test plan
- [x] Verified axiom count via `grep -c "^axiom " proofs/Proofs/Erdos596Problem.lean` → 2
- [x] Diff is 6 lines (tracker bump + issue note only)
- [x] Re-saved tracker with `ensure_ascii=False` to avoid the unicode-escape pollution from `claim-target.sh complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)