### PR TITLE
audit(erdos-594): mark issues-found — section drift + phantom axiom narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7799,9 +7799,12 @@
     },
     "erdos-594": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T07:50:44Z",
+      "result": "issues-found",
+      "issues": [
+        "section line drift (5/8 sections shifted) + phantom contributions erdos_hajnal_aleph2 and thomassen_1983 (docstring-only, no declaration); tracked in #14183"
+      ]
     },
     "erdos-595": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Bumps `audit-tracker.json` for `erdos-594` to record issues found in this gallery integrity audit.
- Findings tracked in #14183.

## Findings

### Phantom contributions (HIGH severity)
`originalContributions` lists `erdos_hajnal_aleph2` and `thomassen_1983`, but neither is declared in `proofs/Proofs/Erdos594Problem.lean`. Both appear only in unattached `/-- ... -/` docstrings (lines 111-116 and 197-201) — no `axiom` or `theorem` of either name exists. The actual axioms are `erdos_hajnal_shelah` (line 123), `countable_chromatic_insufficient` (146), `contains_all_finite_bipartite` (170).

### Section line drift (MEDIUM severity)
5 of 8 sections have wrong ranges. Cardinals/chromatic/cycles are correct; main-theorem/optimality/related/thomassen/summary are all shifted, with `summary: 238-245` the most off (actual heading at line 213).

### Verified accurate
`axiomCount: 3`, `theoremCount: 4`, `definitionCount: 12`, `lineCount: 245`, `sorries: 0`, `assumptions` text, status/badge — all match Lean source.

## Test plan

- [x] `audit-tracker.json` diff is minimal (one entry only, no unicode escape noise)
- [x] Tracker entry references issue #14183
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)