### PR TITLE
audit(erdos-591): mark issues-found — phantom axiom narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7781,9 +7781,12 @@
     },
     "erdos-591": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T07:54:15Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom axiom narrative: originalContributions/proofStrategy/sections claim formalizations of Specker and Chang theorems that exist only as docstrings (issue #14186)"
+      ]
     },
     "erdos-592": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Bumps audit-tracker for erdos-591: auditCount 2→3, result issues-found, lastAudited 2026-05-01.
- Records pointer to integrity issue #14186 covering narrative-inflation findings.

## Audit findings (full detail in #14186)

Lean source `proofs/Proofs/Erdos591Problem.lean` declares 2 axioms (`OrdinalRamseyProperty`, `schipperus_darby_omega_omega_squared`) and 6 theorems with 0 sorries. All numerical fields in `meta.json` match.

**Narrative inflation** (HIGH severity):
- `originalContributions` claims "Formalization of Specker's theorem" and "Formalization of Chang's theorem" — those results appear only as docstring prose, not as `axiom`/`theorem` declarations.
- `proofStrategy` step 2 claims 4 axioms; only 1 (Schipperus-Darby) is declared.
- `sections.known-results.summary` says "Specker's and Chang's theorems as axioms" — false.

This matches the recurring phantom-axiom narrative pattern previously flagged across erdos-9XX and erdos-6XX series.

## Test plan

- [x] Lean source spot-checked for actual axiom/theorem declarations
- [x] meta.json numerical fields verified (axiomCount=2, theoremCount=6, sorries=0, lineCount=175)
- [x] Tracker diff is clean (no unicode escape pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)