### PR TITLE
fix(erdos-591): remove phantom originalContributions and correct narrative

### DIFF
--- a/src/data/proofs/erdos-591/meta.json
+++ b/src/data/proofs/erdos-591/meta.json
@@ -40,9 +40,8 @@
     "originalContributions": [
       "Formal statement of the SOLVED Erdős problem in Lean 4",
       "Axiomatization of the ordinal Ramsey property α → (α, n)²",
-      "Formalization of Specker's theorem (ω² works, ω^n fails for n≥3)",
-      "Formalization of Chang's theorem (ω^ω works)",
-      "Formalization of Schipperus-Darby theorem (ω^(ω²) works)",
+      "Documentation of Specker's and Chang's results in module comments",
+      "Axiomatization of the Schipperus-Darby theorem (ω^(ω²) works) as schipperus_darby_omega_omega_squared",
       "Verified ordinal arithmetic identities"
     ],
     "axiomCount": 2,
@@ -53,7 +52,7 @@
     "historicalContext": "Ordinal Ramsey theory extends the classical Ramsey theorem to infinite ordinals. The classical theorem guarantees monochromatic cliques in large finite graphs; ordinal Ramsey theory asks which infinite ordinals have analogous properties.\n\nSpecker (1957) made a surprising discovery: the Ramsey property α → (α, 3)² holds for α = ω² but FAILS for α = ω³, ω⁴, and all ω^n with n ≥ 3. This shows that larger ordinals can have worse Ramsey properties!\n\nChang later proved the property holds again for α = ω^ω, the first limit of limit ordinals. Schipperus (2010) and Darby independently proved the property also holds for α = ω^(ω²), confirming the pattern that limit ordinal exponents restore the Ramsey property.\n\nErdős offered $250 for its resolution, which was claimed when the problem was solved.",
     "problemStatement": "Let $\\alpha = \\omega^{\\omega^2}$. Is it true that in any red/blue coloring of the edges of the complete graph $K_\\alpha$, there is either a red $K_\\alpha$ or a blue $K_3$?\n\nIn arrow notation: Does $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 3)^2$ hold?\n\n**Answer**: YES — Proved independently by Schipperus (2010) and Darby.\n\n**Complete Results**:\n- $\\omega^2 \\to (\\omega^2, 3)^2$ holds (Specker 1957)\n- $\\omega^n \\to (\\omega^n, 3)^2$ FAILS for $n \\geq 3$ (Specker 1957)\n- $\\omega^\\omega \\to (\\omega^\\omega, 3)^2$ holds (Chang)\n- $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 3)^2$ holds (Schipperus 2010, Darby)",
     "text": "The ordinal Ramsey property ω^(ω²) → (ω^(ω²), 3)² holds. Proved independently by Schipperus (2010) and Darby.",
-    "proofStrategy": "We formalize this SOLVED problem by:\n\n1. **Axiomatizing the Ramsey property**: Define `OrdinalRamseyProperty α n` as the statement that every 2-coloring of pairs from α contains a monochromatic copy of order type α (color 1) or a monochromatic n-element set (color 2)\n\n2. **Stating known results as axioms**: Specker's positive result (ω²), Specker's negative results (ω^n for n≥3), Chang's result (ω^ω), and the Schipperus-Darby result (ω^(ω²))\n\n3. **Stating the main theorem**: `erdos_591` asserts that `OrdinalRamseyProperty (ω ^ (ω ^ 2)) 3` holds\n\n4. **Proving ordinal identities**: We verify basic facts like ω² = ω·ω using Mathlib's ordinal arithmetic",
+    "proofStrategy": "We formalize this SOLVED problem by:\n\n1. **Axiomatizing the Ramsey property**: Define `OrdinalRamseyProperty α n` as the statement that every 2-coloring of pairs from α contains a monochromatic copy of order type α (color 1) or a monochromatic n-element set (color 2)\n\n2. **Stating the key result as an axiom**: The Schipperus-Darby result (`schipperus_darby_omega_omega_squared`). Specker's and Chang's results are documented in module comments only — no axiom or theorem declarations for those.\n\n3. **Stating the main theorem**: `erdos_591` asserts that `OrdinalRamseyProperty (ω ^ (ω ^ 2)) 3` holds\n\n4. **Proving ordinal identities**: We verify basic facts like ω² = ω·ω using Mathlib's ordinal arithmetic",
     "keyInsights": [
       "**Arrow notation**: α → (β, n)² means every 2-coloring of pairs from α contains a monochromatic order type β or a monochromatic n-set.",
       "**The surprising failure**: Larger ordinals don't always have better Ramsey properties. ω³ is 'worse' than ω² for this property!",
@@ -102,7 +101,7 @@
       "title": "Known Results",
       "startLine": 57,
       "endLine": 90,
-      "summary": "Specker's and Chang's theorems as axioms."
+      "summary": "Documentation of Specker's and Chang's results in module comments; no axiom or theorem declarations for these results."
     },
     {
       "id": "solved-problem",


### PR DESCRIPTION
## Fix

Remove two phantom contribution claims and correct narrative text in `src/data/proofs/erdos-591/meta.json`. Specker's and Chang's results appear only as doc-comments in the Lean file (lines 62-81) — no `axiom` or `theorem` declarations back them.

## Evidence

**Before**:
- `originalContributions` listed "Formalization of Specker's theorem" and "Formalization of Chang's theorem" — both ghost entries with no Lean declaration
- `proofStrategy` step 2 claimed all four results (Specker positive, Specker negative, Chang, Schipperus-Darby) were "stated as axioms"
- `sections.known-results.summary`: "Specker's and Chang's theorems as axioms."

**After**:
- `originalContributions` entries replaced with "Documentation of Specker's and Chang's results in module comments"
- `proofStrategy` step 2 names only `schipperus_darby_omega_omega_squared` as the actual axiom; notes Specker/Chang are comments only
- `sections.known-results.summary` accurately describes the section as documentation comments

Numerical fields (`axiomCount: 2`, `theoremCount: 6`, `sorries: 0`) are correct and unchanged.

Closes #14186

---
Automated fix by lean-mechanic agent.