### PR TITLE
audit(erdos-586): mark issues-found — 2 phantom axioms in narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7744,10 +7744,13 @@
       "result": "issues-fixed"
     },
     "erdos-586": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-5164",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T08:30:00Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axioms in originalContributions/proofStrategy: covering_implies_comparable, no_antichain_k_covering (issue #14189)"
+      ]
     },
     "erdos-587": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Bumps audit-tracker for erdos-586 to record `issues-found` (auditCount 2→3)
- Cites issue #14189 documenting two phantom axioms in `originalContributions` and `proofStrategy`: `covering_implies_comparable` and `no_antichain_k_covering`
- Lean source declares only 3 axioms (`bbmst_theorem`, `bbmst_density_bound`, `antichain_not_covering`); `axiomCount: 3` and `assumptions` field are already correct

## Test plan

- [ ] `git diff` shows only the erdos-586 entry changed
- [ ] No unicode-escape pollution from claim-target.sh bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)