### PR TITLE
audit(erdos-588): mark issues-found — 11 phantom contributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7757,9 +7757,12 @@
     },
     "erdos-588": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "originalContributions lists 11 phantom identifiers (Line, OnLine, Collinear, InKGeneralPosition, IsKRich, karteszi_lower_bound, grunbaum_lower_bound, solymosi_stojakovic, erdos_588_conjecture, problem_101, szemeredi_trotter); section k4-open summary claims axioms lower_bound_k4 and erdos_conjecture_k4 that are docstring-only (issue #14192)"
+      ],
+      "lastAudited": "2026-05-01T08:11:06Z",
+      "result": "issues-found"
     },
     "erdos-589": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Mark erdos-588 as `issues-found` in audit tracker
- Numeric counts are correct (2 axioms, 0 sorries, 87 lines, 1 theorem)
- `originalContributions` lists 13 entries; only 2 exist in Lean file
- Section `k4-open` summary claims axioms `lower_bound_k4`/`erdos_conjecture_k4` — docstring-only at lines 62-79
- Filed #14192 for the narrative cleanup (Mechanic agent)

## Test plan
- [x] `python3 -m json.tool` validates `audit-tracker.json`
- [x] Diff is exactly 6 lines (one entry update), no Unicode-escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)