### PR TITLE
audit(erdos-583): mark issues-found — phantom axiom narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7727,9 +7727,12 @@
     },
     "erdos-583": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T08:18:11Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axioms in narrative: pyber_theorem, tree_satisfies, complete_graph_satisfies, cycle_satisfies, star_needs_few_paths, bipartite_tight (issue #14195)"
+      ]
     },
     "erdos-584": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audited `erdos-583` (Erdős-Gallai Edge-Disjoint Path Partition Conjecture)
- Found phantom axiom narrative: 6 "axioms" mentioned in proofStrategy/sections/originalContributions are docstrings only
- Filed integrity issue #14195 with recommended fixes
- Bumps audit-tracker.json: result `issues-fixed` → `issues-found`

## Findings

Real axioms in `proofs/Proofs/Erdos583Problem.lean`: `lovasz_theorem`, `chung_theorem`, `fan_theorem` (3 total — matches `axiomCount`).

Phantom axiom claims (docstrings only, no `axiom` declaration):
- `pyber_theorem`
- `tree_satisfies`, `complete_graph_satisfies`, `cycle_satisfies`
- `star_needs_few_paths`, `bipartite_tight`

Numerical fields (axiomCount=3, sorries=0, theoremCount=4, definitionCount=8, lineCount=232) are all correct. Only narrative text overstates.

See #14195 for the full recommended meta.json edits.

## Test plan

- [x] `git show HEAD:proofs/Proofs/Erdos583Problem.lean | grep "^axiom "` → 3 axioms
- [x] All 3 axioms match `assumptions` field
- [x] Phantom names verified via grep — only present in docstrings
- [x] Tracker diff is clean (20 lines, no unicode escape pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)