### PR TITLE
audit(erdos-599): clean — no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7829,9 +7829,9 @@
     },
     "erdos-599": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T08:47:23Z",
+      "result": "clean"
     },
     "erdos-6": {
       "agentId": "auditor-loop-1777619133",
@@ -13263,6 +13263,12 @@
     "isoperimetric-theorem-oq-02": {
       "auditCount": 3,
       "lastAudited": "2026-04-29T05:43:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-01T08:33:09Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

- **Audit result**: clean (3rd audit cycle)
- Verified `src/data/proofs/erdos-599/meta.json` against `proofs/Proofs/Erdos599Problem.lean`
- Bumps `auditCount` 2→3, `lastAudited` 2026-04-03→2026-05-01, `result` issues-fixed→clean
- Also re-serializes tracker with `ensure_ascii=False` to undo earlier unicode escaping (em-dashes/arrows in older notes/issues were escaped to `\u2014` / `\u2192` by `claim-target.sh complete`)
- Incidental: includes `bezout-identity-oq-03-oq-02` audit entry left uncommitted in tracker by a prior auditor session

## Audit findings (erdos-599)

**Tier C — Scaffold/axiomatized** (correctly classified)
- Sorries: meta=0, actual=0 ✓
- Axiom count: meta=1, actual=1 (`aharoni_berger_theorem`) ✓
- Status `axiomatized` + badge `axiom` correctly reflect that the Aharoni–Berger 2009 result is taken as an axiom
- No True stubs
- `originalContributions` accurately enumerate file definitions (Graph, IsIndependent, Path, AreDisjoint, PathFamily, IsTransversal, IsSeparator, ErdosMengerConjecture, MengersTheorem, IsKLinked)
- Title and overview properly credit Aharoni–Berger 2009; no overclaiming

**Minor (non-integrity, not addressed here)**: section line ranges drift by a few lines in some sections (e.g., `summary` claims L212-230 but Part XI header is at L197). Cosmetic only — does not affect any integrity claim.

## Test plan
- [x] `git diff` shows only legitimate tracker entries (no `\\u` escape noise)
- [x] Verified counts via `git show origin/main:proofs/Proofs/Erdos599Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)