### PR TITLE
audit: erdos-597 clean (3rd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7817,9 +7817,9 @@
     },
     "erdos-597": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T08:51:18Z",
+      "result": "clean"
     },
     "erdos-598": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- **Target**: erdos-597 (Partition Relations for Ordinal Powers, open Erdős/Hajnal problem)
- **Result**: clean — meta.json matches Lean source on origin/main

## Verification

**Lean file `proofs/Proofs/Erdos597Problem.lean` (183 lines)**:
- 6 axioms: `omega_1`, `omega_1_times_omega`, `omega_1_squared`, `partitionArrow`, `erdosHajnalTriangle`, `baumgartnerCounterexample`
- 0 sorries
- 1 theorem (`erdos597_knownResults`)
- 8 definitions (`omega`, `containsClique`, `isK4Free`, `containsCountableBiclique`, `isKAleph0Free`, `hasAtMostAleph1Vertices`, `erdos597Conjecture`, `finiteCaseConjecture`)
- 1 structure (`SimpleGraph'` — 3 graph-data fields, no assumption-encoded fields)

**meta.json claims (all match)**:
- `axiomCount: 6` ✓
- `sorries: 0` ✓
- `lineCount: 183` ✓
- `theoremCount: 1`, `definitionCount: 8` ✓
- All 9 `originalContributions` correspond to real declarations ✓
- All 7 section line ranges align with actual axiom/def/theorem positions ✓
- `status: axiomatized`, `badge: axiom` — appropriate per axiom-integrity policy

## Notes
- Tracker fix-up: `claim-target.sh complete` re-escaped pre-existing UTF-8 (`→`/`—`) as `\u2192`/`\u2014` across many lines. Reverted those non-target edits and kept only the erdos-597 entry update (3-line diff).

## Test plan
- [ ] CI passes
- [ ] Tracker entry reflects 3rd audit, result `clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)