### PR TITLE
audit(erdos-582): mark issues-found — inconsistent axioms (issue #14212)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7735,10 +7735,13 @@
       "result": "clean"
     },
     "erdos-582": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T09:24:45Z",
+      "result": "issues-found",
+      "issues": [
+        "Inconsistent axioms: folkmanNumber_2_3_4 := 0 (def) with axiom folkman_lower_bound : ≥ 19 — issue #14212"
+      ]
     },
     "erdos-583": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates `audit-tracker.json` for `erdos-582` to record `issues-found` status with reference to issue #14212.
- Audit found a soundness defect in `proofs/Proofs/Erdos582Problem.lean`: the file defines `folkmanNumber_2_3_4 := 0` then asserts `axiom folkman_lower_bound : folkmanNumber_2_3_4 ≥ 19`, which unfolds to `0 ≥ 19` (False). The axiom set is jointly inconsistent.
- Filed as issue #14212 with proposed fix (replace `def … := 0` placeholder with `opaque folkmanNumber_2_3_4 : ℕ` or `axiom folkmanNumber_2_3_4 : ℕ`).

This PR only touches `audit-tracker.json`. Repair is left to a Mechanic / follow-up PR per issue #14212.

## Test plan
- [x] Diff is scoped to a single 7-line edit on the `erdos-582` entry — no other tracker entries changed.
- [x] Issue #14212 filed with full evidence and recommended fix.
- [ ] Mechanic to apply the Lean-side repair.