### PR TITLE
docs(hurwitz-three-square-impossibility): mark problem complete in problem.md

### DIFF
--- a/research/problems/hurwitz-three-square-impossibility/problem.md
+++ b/research/problems/hurwitz-three-square-impossibility/problem.md
@@ -2,8 +2,16 @@
 
 **Slug**: hurwitz-three-square-impossibility
 **Created**: 2025-12-30T16:59:27-08:00
-**Status**: Active
+**Status**: COMPLETED (2025-12-30; verified 2026-04-27)
 **Source**: gallery-gap
+
+## Resolution
+
+The axiom was successfully replaced. As of 2026-04-27, `proofs/Proofs/HurwitzTheorem.lean`:
+- Contains `theorem no_three_square_identity_proof` at line 944 (full proof, 0 sorries for n=3)
+- Contains `theorem no_three_square_identity` at line 1316 (clean wrapper)
+- Has 0 axioms (down from 1)
+- The single remaining sorry at line 1937 is for the unrelated general n∉{1,2,4,8} case, which is BLOCKED on Clifford algebra structure theorem + Bott periodicity (none of which exist in Mathlib as of 2026-04).
 
 ## Problem Statement
 


### PR DESCRIPTION
## Summary

Research session for `hurwitz-three-square-impossibility`. **Honest finding**: this problem was already fully solved on 2025-12-30. The JSON state was marked `graduated`/`completed`, but `problem.md` still listed `Status: Active`. Synchronizing the markdown to reflect actual state.

## Verification

- `proofs/Proofs/HurwitzTheorem.lean` line 944: `theorem no_three_square_identity_proof` (0 sorries)
- Line 1316: `theorem no_three_square_identity` (clean wrapper)
- 0 axioms (the original target axiom `no_three_square_identity_contradiction` was removed)
- Line 1937 sorry is for the unrelated general n∉{1,2,4,8} case, BLOCKED on Clifford algebra + Bott periodicity (not in Mathlib)

## Status

**Outcome**: documentation-only update; no Lean changes
**Next Steps**: Candidate-pool sync should drop this from active research; the `axiom_to_remove` in the markdown's metadata block is now stale.

**Fix note**: Supersedes #13232 — original branch carried ~819 stale commits; unique commit cherry-picked onto clean branch off main.

🤖 Generated by researcher-7