### PR TITLE
fix(shannon-channel-coding-oq-02-oq-01): sync status verified + research state after #13393

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Robert Fano (1952), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
     "date": "1952",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "tags": [
       "information-theory",

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
@@ -20,28 +20,27 @@
       "fano_from_oq03: H(X|Y) ≤ h(P_e) + P_e*log(|X|-1) via direct delegation to OQ-03's fano_theorem"
     ],
     "open": [
-      "axiom_elimination: replace import_shannon_entropy_blocked once ShannonEntropy.lean compiles",
-      "fano_trivial_singleton: Unit-sum simp tactics for the |X|=1 edge case"
+      "fano_inequality_elimination: propagate fano_from_oq03 into ShannonChannelCoding.lean once ShannonEntropy.lean compiles"
     ],
     "goal": "Eliminate all axioms/sorries by fixing ShannonEntropy.lean line 811 (sum order mismatch in strong_subadditivity)"
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-04T00:00:00-07:00",
-    "iteration": 1,
-    "focus": "Bridge complete. 1 axiom (ShannonEntropy.lean import blocker) + 1 sorry (fano_trivial_singleton). Root cause of blocker identified.",
+    "since": "2026-04-27T17:00:00Z",
+    "iteration": 2,
+    "focus": "Bridge complete + axiom hygiene. Removed dead `axiom import_shannon_entropy_blocked : False` (was unused and unsound). File now has 0 axioms, 0 sorries.",
     "blockers": [
-      "ShannonEntropy.lean strong_subadditivity fails at line 811: linarith cannot cancel ∑ y ∑ z ∑ x f vs ∑ x ∑ y ∑ z f due to syntactic mismatch. Fix: add Finset.sum_comm rewrite before linarith [h_cmi]."
+      "ShannonEntropy.lean strong_subadditivity fails at line 811: linarith cannot cancel ∑ y ∑ z ∑ x f vs ∑ x ∑ y ∑ z f due to syntactic mismatch. Fix: add Finset.sum_comm rewrite before linarith [h_cmi]. (Affects upstream integration only — not this bridge file.)"
     ],
-    "nextAction": "Fix ShannonEntropy.lean line 811 by adding simp_rw [Finset.sum_comm] before linarith [h_cmi]",
+    "nextAction": "Fix ShannonEntropy.lean line 811 by adding simp_rw [Finset.sum_comm] before linarith [h_cmi], then propagate fano_inequality elimination into ShannonChannelCoding.lean using fano_from_oq03.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Bridge proof complete. Definition compatibility proved by rfl. Fano inequality derived from OQ-03. 1 axiom (import blocker) + 1 sorry (edge case).",
+    "progressSummary": "COMPLETED: Bridge proof verified, 0 axioms, 0 sorries. Definition compatibility proved by rfl. Fano inequality derived from OQ-03. Dead unsound axiom (import_shannon_entropy_blocked : False) removed.",
     "builtItems": [
       "ShannonChannelCodingOQ02OQ01.lean: conditional_entropy_defs_agree (proved by rfl)",
       "ShannonChannelCodingOQ02OQ01.lean: fano_from_oq03 (proved, delegates to fano_theorem)",
@@ -114,11 +113,11 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 169,
+      "lineCount": 181,
       "theoremCount": 3,
-      "axiomCount": 2,
+      "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
     },


### PR DESCRIPTION
## Summary

- `meta.json`: `status: axiomatized` → `status: verified` (badge was already `verified` after #13393 but status was left behind)
- `shannon-channel-coding-oq-02-oq-01.json` research problem file: iteration 1 → 2, `axiomCount: 2 → 0`, `sorryCount: 2 → 0`, `lineCount: 169 → 181`
- `currentState` focus and `progressSummary` updated to reflect axiom cleanup completed
- Stale open items removed (`axiom_elimination`, `fano_trivial_singleton` — both resolved)

## Context

PR #13252 carried these metadata corrections but conflicted because the Lean file and core meta changes were already merged via #13393. That PR fixed the badge and axiomCount but left `status: axiomatized` and the research problem JSON at stale iteration-1 state.

This PR is a clean cherry-pick of only the two metadata files that were not covered by #13393.

## Files modified

- `src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json`
- `src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json`