### PR TITLE
audit(erdos-59): mark issues-found — phantom 7-axiom narrative (actual 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -915,7 +915,7 @@
     },
     "bezout-identity-oq-03-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-05-01T08:29:33Z",
+      "lastAudited": "2026-05-01T08:33:09Z",
       "result": "clean",
       "issues": []
     },
@@ -7792,10 +7792,13 @@
       "result": "clean"
     },
     "erdos-59": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-session-1777628135",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T09:38:39Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom 7-axiom narrative (actual 5); fix in flight as PR #14211"
+      ]
     },
     "erdos-590": {
       "agentId": "auditor-cycle-20-batch",
@@ -13296,12 +13299,6 @@
     "isoperimetric-theorem-oq-02": {
       "auditCount": 3,
       "lastAudited": "2026-04-29T05:43:30Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-01T08:33:09Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Tracker update only

Audited erdos-59 against the Lean source at origin/main (`9ad3e10`).

**Finding**: Narrative drift — meta fields are correct (`axiomCount: 5`, `leanFile.axiomCount: 5`) but the narrative claims **7 axioms** in three places:

- `overview.keyInsights[4]`: "The remaining 7 axioms encode deep results..."
- `conclusion.summary`: "0 sorries, 7 axioms (reduced from 10...)"
- `conclusion.openQuestions[3]`: "Can any of the remaining 7 axioms..."

**Verified actual axiom count = 5** (`proofs/Proofs/Erdos59Problem.lean`):
1. `turanNumber` (line 177)
2. `countFreeGraphs` (line 182)
3. `turanNumber_pos` (line 203)
4. `erdos_frankl_rodl_nonbipartite` (line 215)
5. `morris_saxton_c6_counterexample` (line 225)

(`morris_saxton_conjecture` on line 233 is a `def`, not an `axiom`.)

## Why this PR is tracker-only

PR #14211 (`fix/erdos-59-phantom-axiom-narrative`) is already open and fixes the same drift. Per the auditor "check existing PRs" guidance, this PR does **not** duplicate the fix. It just updates `src/data/proofs/audit-tracker.json`:

- `auditCount`: 3 → 4
- `result`: `issues-fixed` → `issues-found`
- `lastAudited`: 2026-05-01
- Notes the in-flight fix PR

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)