### PR TITLE
fix(erdos-578): correct section line drift (Parts V–VIII)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7696,10 +7696,13 @@
       "result": "issues-fixed"
     },
     "erdos-578": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-session-1777628135",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T09:50:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "section line drift fixed: riordan, threshold-distribution, properties, summary all shifted to match actual Part V-VIII positions"
+      ]
     },
     "erdos-579": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -915,7 +915,7 @@
     },
     "bezout-identity-oq-03-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-05-01T08:29:33Z",
+      "lastAudited": "2026-05-01T08:33:09Z",
       "result": "clean",
       "issues": []
     },
@@ -7792,10 +7792,13 @@
       "result": "clean"
     },
     "erdos-59": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-session-1777628135",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T09:38:39Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom 7-axiom narrative (actual 5); fix in flight as PR #14211"
+      ]
     },
     "erdos-590": {
       "agentId": "auditor-cycle-20-batch",
@@ -13296,12 +13299,6 @@
     "isoperimetric-theorem-oq-02": {
       "auditCount": 3,
       "lastAudited": "2026-04-29T05:43:30Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-01T08:33:09Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/erdos-578/meta.json
+++ b/src/data/proofs/erdos-578/meta.json
@@ -121,28 +121,28 @@
       "id": "riordan",
       "title": "Riordan's Theorem (2000)",
       "startLine": 99,
-      "endLine": 111,
+      "endLine": 107,
       "summary": "Strengthened result for p > 1/4, proves original conjecture"
     },
     {
       "id": "threshold-distribution",
       "title": "Threshold and Distribution",
-      "startLine": 112,
-      "endLine": 126,
-      "summary": "Threshold at 1/4 is optimal, copies normally distributed",
-      "mathContext": "Threshold: $p \\leq 1/4 \\implies Q_d \\not\\subseteq G(2^d,p)$ a.s. Distribution: the standardized count $(X - \\mathbb{E}[X])/\\sqrt{\\text{Var}(X)} \\to N(0,1)$."
+      "startLine": 108,
+      "endLine": 119,
+      "summary": "Threshold at 1/4 is optimal; normal-distribution refinement is documented in comments only (not axiomatized)",
+      "mathContext": "Threshold: $p \\leq 1/4 \\implies Q_d \\not\\subseteq G(2^d,p)$ a.s. Distribution: the standardized count $(X - \\mathbb{E}[X])/\\sqrt{\\text{Var}(X)} \\to N(0,1)$ (informal, not in Lean)."
     },
     {
       "id": "properties",
       "title": "Hypercube Properties",
-      "startLine": 127,
-      "endLine": 142,
+      "startLine": 120,
+      "endLine": 135,
       "summary": "d-regular, automorphism group d!·2^d"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 143,
+      "startLine": 136,
       "endLine": 151,
       "summary": "Proved conjunction of conjecture and threshold"
     }


### PR DESCRIPTION
## Audit finding

Verified `proofs/Proofs/Erdos578Problem.lean` (origin/main `9ad3e10`, 151 lines).

Counts are correct (`axiomCount: 2`, `sorries: 0`, `theoremCount: 2`, `definitionCount: 9`, `lineCount: 151`). The two axioms `erdos_bollobas_proved` (line 106) and `threshold_at_quarter` (line 112) match `assumptions`.

But the **section line ranges drift starting at Part V** (riordan):

| Section | Claimed | Actual Part header | Fixed |
|---|---|---|---|
| `riordan` | 99–111 | Part V at line 99, ends at 107 | 99–107 |
| `threshold-distribution` | 112–126 | Part VI at line 108 | 108–119 |
| `properties` | 127–142 | Part VII at line 120 | 120–135 |
| `summary` | 143–151 | Part VIII at line 136 | 136–151 |

Also clarified the `threshold-distribution` section summary and `mathContext` to note that the normal-distribution refinement appears in the file only as a documentation comment, not as an axiom or theorem (avoids inflating "Threshold and Distribution" into "two formalized results").

## Tracker

`src/data/proofs/audit-tracker.json`: `erdos-578` audit count 2→3, result `issues-fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)