### PR TITLE
audit(erdos-58): mark clean — Gyárfás 1992 axiomatization verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7712,9 +7712,9 @@
     },
     "erdos-58": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T10:11:09Z",
+      "result": "clean"
     },
     "erdos-580": {
       "agentId": "auditor-session-1777623758",


### PR DESCRIPTION
## Summary

Routine audit of `erdos-58` (Erdős Problem #58: Chromatic Number vs Odd Cycle Lengths). Marked **clean** in `audit-tracker.json`.

## Verification

All numerical claims in `meta.json` match `proofs/Proofs/Erdos58Problem.lean`:

| Field | meta.json | source | match |
|-------|-----------|--------|-------|
| axiomCount | 3 | 3 (chromaticNumber, gyarfas_upper_bound, gyarfas_equality) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 152 | 152 | ✓ |

- Status `axiomatized` and badge `axiom` are correct (3 explicit axioms).
- Section line ranges align with `## Heading` markers in the source.
- Docstring-only items (Gyárfás structural dichotomy 1992, Gao-Huo-Ma 2021) are correctly **not** counted as axioms — `proofStrategy` and `sections.gao-huo-ma` explicitly note they are commentary only.

No phantom-axiom narrative drift.

## Test plan
- [x] Diff is single 3-line tracker update (no unicode escape pollution)
- [x] No source/meta.json changes