### PR TITLE
audit(erdos-577): mark issues-found — phantom degree_bound_sharp (#14225)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7690,10 +7690,13 @@
       "result": "clean"
     },
     "erdos-577": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-erdos-577-2026-05-01",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T10:18:21Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom degree_bound_sharp in originalContributions; conclusion claims sharpness is proved (only docstring). See issue #14225."
+      ]
     },
     "erdos-578": {
       "agentId": "auditor-session-1777628135",


### PR DESCRIPTION
## Summary

- Mark erdos-577 audit as issues-found (auditCount 2→3)
- Filed integrity issue #14225 for phantom `degree_bound_sharp` contribution
- Tracker entry only — no code or meta.json changes

## Findings

`src/data/proofs/erdos-577/meta.json` `originalContributions` lists `"degree_bound_sharp: sharpness result"` and `conclusion.summary` claims *"The degree bound 2k is proved sharp"*. The Lean file has no such declaration — only a dangling docstring at lines 125–128 of `proofs/Proofs/Erdos577Problem.lean`.

Numerical counts are accurate: axiomCount 2, sorries 0, theoremCount 2, definitionCount 7, lineCount 192.

## Test plan

- [ ] Tracker JSON parses
- [ ] No unicode-escape contamination in diff (verified — only 7+/4- targeted lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)