### PR TITLE
audit(erdos-573): mark issues-found — phantom KST bound narrative (#14227)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7666,10 +7666,13 @@
       "result": "clean"
     },
     "erdos-573": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent-tracker",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T10:25:00Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom KST/Erdős-Simonovits bound axioms in narrative (counts correct); lineCount 152→177; section line drift — issue #14227"
+      ]
     },
     "erdos-574": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audited `erdos-573` (Extremal Numbers for {C₃, C₄}-free Graphs) against `origin/main` Lean source.
- **Counts are correct** (5 axioms, 0 sorries) — `assumptions` field accurately lists the five axioms.
- **Narrative drift** found: `overview.proofStrategy` and section summaries claim the Kővári-Sós-Turán bound and Erdős-Simonovits bound are *axiomatized*. Reality: only the extremal *functions* `exC4 : ℕ → ℕ` and `exC4C5 : ℕ → ℕ` are axiomatized; the bounds appear only as doc-string commentary.
- **Section drift**: `summary` startLine 174 misses first theorem at line 168. `lineCount: 152` but file is 177 lines.

Filed as integrity issue #14227 with specific recommended meta.json edits.

## Test plan

- [x] Verified Lean source against `git show origin/main:proofs/Proofs/Erdos573Problem.lean`
- [x] Verified `axiomCount: 5` matches actual `^axiom ` declarations
- [x] Verified `sorries: 0` matches actual Lean
- [x] Confirmed lines 95-109 (section `kst-theorem`) contain only doc-strings, no axiom/theorem
- [x] Confirmed lines 110-121 (section `erdos-simonovits`) contain only `axiom exC4C5 : ℕ → ℕ` (function only) and doc-strings
- [x] Tracker diff is minimal (7 insertions, 4 deletions; only erdos-573 entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)