### PR TITLE
audit(erdos-571): mark issues-found — phantom axiom narrative (#14232)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7654,10 +7654,13 @@
       "result": "issues-fixed"
     },
     "erdos-571": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-session-1777631912",
+      "auditCount": 3,
+      "issues": [
+        "phantom axioms in originalContributions / proofStrategy / sections (jiang_qiu_exponents_4_3, jiang_qiu_exponents_5_4, jiang_ma_yepremyan_exponents, conlon_janzer_near_two, bukh_conlon_families, kovari_sos_turan, bondy_simonovits_upper) — issue #14232"
+      ],
+      "lastAudited": "2026-05-01T10:50:00Z",
+      "result": "issues-found"
     },
     "erdos-572": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks erdos-571 audit as `issues-found` after detecting the recurring phantom-axiom narrative pattern
- Multiple meta.json fields (`originalContributions`, `overview.proofStrategy`, three `sections[].summary` entries) reference axioms that are only docstring text — never declared in `proofs/Proofs/Erdos571Problem.lean`
- Numerical counts (`axiomCount: 3`, `theoremCount: 1`, `definitionCount: 8`) and the `assumptions` field are correct
- Phantom names: `jiang_qiu_exponents_4_3`, `jiang_qiu_exponents_5_4`, `jiang_ma_yepremyan_exponents`, `conlon_janzer_near_two`, `bukh_conlon_families`, `kovari_sos_turan`, `bondy_simonovits_upper`
- Real axioms (verified): `conlon_janzer_lee_exponents` (L108), `jiang_qiu_low_exponents` (L120), `exponent_7_5` (L127)

Filed issue #14232 with recommended per-field rewrites; mechanic can land the prose fix.

## Test plan
- [x] `grep -n "^axiom " proofs/Proofs/Erdos571Problem.lean` returns exactly 3 axioms
- [x] `grep -E "jiang_qiu_exponents|jiang_ma_yepremyan_exponents|conlon_janzer_near_two|bukh_conlon_families|kovari_sos_turan|bondy_simonovits_upper" proofs/Proofs/Erdos571Problem.lean` returns no matches
- [x] `git diff` on tracker is 22 lines, no unicode-escape noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)