### PR TITLE
Research: fourier-series-oq-01 — sync metadata to completed (axiomatized)

### DIFF
--- a/src/data/research/problems/fourier-series-oq-01.json
+++ b/src/data/research/problems/fourier-series-oq-01.json
@@ -1,29 +1,37 @@
 {
   "slug": "fourier-series-oq-01",
-  "title": "Can Carleson's theorem ($L^2$ Fourier series converge pointwise a",
-  "phase": "ACT",
-  "status": "active",
+  "title": "Carleson's theorem (L² Fourier series converge pointwise a.e.) — axiomatized",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "",
-    "plain": "",
-    "whyMatters": []
+    "formal": "theorem carleson_ae_convergence (f : AddCircle T → ℂ) (hf : Memℒp f 2 haarAddCircle) : ∀ᵐ x ∂haarAddCircle, Tendsto (fun N => fourierPartialSum f N x) atTop (𝓝 (f x))",
+    "plain": "Carleson's theorem: every L² function on the circle has Fourier partial sums converging pointwise almost everywhere. The Lean proof architecture is complete; the deep input is the Carleson-Hunt weak-type maximal inequality, which is axiomatized (beyond current Mathlib).",
+    "whyMatters": [
+      "One of the central theorems of 20th-century harmonic analysis",
+      "Demonstrates how a deep result can be reduced to routine infrastructure plus a single named axiom"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "carleson_ae_convergence: pointwise a.e. convergence of Fourier partial sums for L² functions",
+      "carleson_continuous: corollary for continuous functions",
+      "carleson_and_parseval: joint L² + pointwise convergence statement",
+      "Supporting infrastructure (fourierPartialSum_continuous, divergenceSet_subset_of_approx, IsTrigPoly framework, etc.)"
+    ],
+    "open": [
+      "Eliminating the two remaining axioms (carlesonData, carleson_hunt_maximal) would require a full formalization of time-frequency analysis — separate large project."
+    ],
+    "goal": "Formalize Carleson's theorem with the Carleson-Hunt maximal inequality as the only deep input — DONE."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-04-13T00:00:00Z",
-    "iteration": 5,
-    "focus": "Session 5 (PR #10486) reduced axioms 6 -> 2; remaining axioms are the deep Carleson-Hunt maximal inequality and the bundled Carleson constant.",
-    "blockers": [
-      "carleson_hunt_maximal axiom: weak-type (2,2) bound for the Carleson maximal operator. Genuinely deep — full proof requires ~50 pages of time-frequency analysis (Carleson 1966 / Hunt 1968). Not formalized in Mathlib v4.26.0; an external Carleson4 project exists."
-    ],
-    "nextAction": "Two paths to consider: (1) consolidate `axiom carlesonData` and `axiom carleson_hunt_maximal` into a single existential axiom (refactoring, not real reduction per axiom-integrity policy); (2) wait for / depend on Carleson4 project. Gallery is correctly badged 'axiom'.",
+    "phase": "COMPLETED",
+    "since": "2026-04-27T00:00:00Z",
+    "iteration": 2,
+    "focus": "Closed: 0 sorries, proof architecture complete; status axiomatized with 2 axioms (Carleson constant + Carleson-Hunt weak-type inequality), both deep results beyond current Mathlib.",
+    "blockers": [],
+    "nextAction": "None — removing the remaining axioms would require a separate large formalization project for time-frequency analysis.",
     "attemptCounts": {
       "total": 5,
       "currentApproach": 2,


### PR DESCRIPTION
## Summary

Resolves #13328 (CONFLICTING). Cherry-picked unique commit `e4fd45b83d6` onto current `main`.

The OQ01 problem (Carleson's theorem: L² Fourier series converge pointwise a.e.) has its Lean proof architecture fully formalized:
- `proofs/Proofs/FourierSeriesOQ01.lean`: 0 sorries, 2 axioms (`carlesonData`, `carleson_hunt_maximal`)
- Gallery: `status: axiomatized`, `badge: axiom`, `sorries: 0`, `axiomCount: 2`

The two remaining axioms encode the Carleson-Hunt weak-type maximal inequality (and the constant), the deep harmonic-analysis input that is beyond current Mathlib. Eliminating them is a separate large project.

## Changes

`src/data/research/problems/fourier-series-oq-01.json`:
- title — descriptive (no longer truncated)
- phase ACT — COMPLETED, status active — completed
- problemStatement.formal — real Lean signature `carleson_ae_convergence`
- problemStatement.plain — describes architecture + axiomatization
- knownResults.proven — lists carleson_ae_convergence and corollaries
- knownResults.open — notes axiom-elimination is a separate project
- currentState.{phase,focus,nextAction,blockers} — reflect closed state

## Conflict resolution

The original PR branch had 573 commits (572 already merged). The conflict arose because main had already applied some fields from a batch commit but kept older `currentState` content. Resolved by keeping the COMPLETED state from the PR's unique commit while preserving main's more precise `lastUpdate` timestamp format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)