### PR TITLE
audit(erdos-570): mark issues-found — phantom 4-axiom narrative (#14234)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7648,10 +7648,13 @@
       "result": "clean"
     },
     "erdos-570": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent-2026-05-01",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T10:50:04Z",
+      "result": "issues-found",
+      "issues": [
+        "sections.cases.summary claims four phantom axioms (EFRS/Sidorenko/Jayawardene/CFMPP) — only erdos_570_resolved exists in Lean; numerical fields correct — issue #14234"
+      ]
     },
     "erdos-571": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Tracker update for erdos-570 audit; result `issues-found`.
- Lean file has only `erdos_570_resolved` axiom, but `sections.cases.summary` claims four named axioms — phantom-narrative pattern.
- Filed integrity issue #14234 with recommended fix.

## Test plan

- [x] Numerical fields verified against `proofs/Proofs/Erdos570Problem.lean` (axiomCount=1, theoremCount=2, definitionCount=7, sorries=0, lineCount=148).
- [x] Diff scoped to single tracker entry (7 insertions / 4 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)