### PR TITLE
fix(erdos-570): correct phantom 4-axiom narrative to docstring documentation

### DIFF
--- a/src/data/proofs/erdos-570/meta.json
+++ b/src/data/proofs/erdos-570/meta.json
@@ -60,7 +60,7 @@
     "historicalContext": "**Erdős Problem #570** asks for an upper bound on the Ramsey number R(C_k, H), where C_k is a k-cycle and H is an arbitrary graph without isolated vertices. The conjectured bound R(C_k, H) ≤ 2m + ⌈(k-1)/2⌉, where m = |E(H)|, was first proposed in the context of 'Ramsey size linear graphs' by Erdős, Faudree, Rousseau, and Schelp.\n\nThe resolution spanned over three decades. EFRS themselves proved the even k case in 1993. That same year, Sidorenko handled k = 3 (triangles). Jayawardene extended the result to k = 5 in 1999. The remaining cases - all odd k ≥ 7 - were finally resolved by Cambie, Freschi, Morawski, Petrova, and Pokrovskiy in 2024.\n\nThe problem is notable for requiring fundamentally different techniques for even and odd cycles, and for the 25-year gap between the k = 5 result and the final resolution.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $k \\geq 3$. For any graph $H$ on $m$ edges without isolated vertices,\n$$R(C_k, H) \\leq 2m + \\lceil(k-1)/2\\rceil$$\n\n**Answer:** YES. Proved for all $k \\geq 3$ through combined work of EFRS (even $k$, 1993), Sidorenko ($k=3$, 1993), Jayawardene ($k=5$, 1999), and Cambie et al. (odd $k \\geq 7$, 2024).",
     "text": "For k ≥ 3 and graph H with m edges (no isolated vertices), is R(C_k, H) ≤ 2m + ⌈(k-1)/2⌉? YES - fully resolved through work spanning 1993-2024.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Definitions:** Define cycle graphs constructively with proved symmetry and irreflexivity.\n2. **Ramsey Numbers:** Abstract definition via infimum over colorings of complete graphs.\n3. **Conjecture Statement:** Formalize Erdos570Conjecture with the UpperBound function.\n4. **Individual Cases:** Axiomatize each historical result as a separate axiom.\n5. **Resolution:** Axiomatize the full resolution, combining all cases.\n6. **The CycleGraph definition is constructive:** symm and loopless are fully proved.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Definitions:** Define cycle graphs constructively with proved symmetry and irreflexivity.\n2. **Ramsey Numbers:** Abstract definition via infimum over colorings of complete graphs.\n3. **Conjecture Statement:** Formalize Erdos570Conjecture with the UpperBound function.\n4. **Individual Cases:** Document each historical result (EFRS, Sidorenko, Jayawardene, CFMPP) as docstring commentary — not declared as separate axioms.\n5. **Resolution:** Axiomatize the full resolution, combining all cases.\n6. **The CycleGraph definition is constructive:** symm and loopless are fully proved.",
     "keyInsights": [
       "**Ramsey Numbers:** R(C_k, H) is the minimum n such that any 2-coloring of K_n contains either a red C_k or a blue H.",
       "**Linear Bound:** The bound 2m + ⌈(k-1)/2⌉ is linear in the edge count m, with a small additive term depending on k.",
@@ -111,7 +111,7 @@
     {
       "id": "cases",
       "title": "Proven Cases",
-      "summary": "Four axioms for each historical contribution: EFRS (even k), Sidorenko (k=3), Jayawardene (k=5), CFMPP (odd k≥7).",
+      "summary": "Four historical contributions documented as docstrings (EFRS even k, Sidorenko k=3, Jayawardene k=5, CFMPP odd k≥7); no per-author axioms are declared in this section.",
       "startLine": 106,
       "endLine": 142,
       "mathContext": "Even $k$: proved by regularity method. $k=3$: uses the Turán-type density argument for triangle-free graphs. $k=5$: pentagon-specific embedding. Odd $k \\geq 7$: connected covers technique (2024)."


### PR DESCRIPTION
## Fix

Correct `sections[id="cases"].summary` and `overview.proofStrategy` which claimed four per-author axioms were declared. The Lean file has only one axiom (`erdos_570_resolved`); the four historical contributions (EFRS, Sidorenko, Jayawardene, CFMPP) appear only as docstring commentary.

## Evidence

**Before** (`sections[cases].summary`): "Four axioms for each historical contribution: EFRS (even k), Sidorenko (k=3), Jayawardene (k=5), CFMPP (odd k≥7)."

**After**: "Four historical contributions documented as docstrings (EFRS even k, Sidorenko k=3, Jayawardene k=5, CFMPP odd k≥7); no per-author axioms are declared in this section."

**Before** (`overview.proofStrategy` step 4): "**Individual Cases:** Axiomatize each historical result as a separate axiom."

**After**: "**Individual Cases:** Document each historical result (EFRS, Sidorenko, Jayawardene, CFMPP) as docstring commentary — not declared as separate axioms."

Numerical fields (`axiomCount: 1`, `theoremCount: 2`, `definitionCount: 7`, `sorries: 0`) remain unchanged and are accurate.

Closes #14234

---
Automated fix by lean-mechanic agent.