### PR TITLE
audit(erdos-569): mark issues-found — phantom narrative axioms (#14242)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7636,10 +7636,13 @@
       "result": "clean"
     },
     "erdos-569": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-session-1777632838",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T10:59:06Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom axioms in narrative: pentagon case + lower bounds in proofStrategy; vertex-bound axiom in section summary; pentagon axiom claimed in known-results section — issue #14242"
+      ]
     },
     "erdos-57": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates `src/data/proofs/audit-tracker.json` for `erdos-569` to record the phantom-axiom narrative findings filed in #14242.
- Bumps `auditCount` to 3, sets `result: issues-found`, `lastAudited` to today.

## Test plan

- [x] Diff is scoped to the `erdos-569` entry only (no unicode-escape pollution from claim-target.sh re-write — manually applied with `ensure_ascii=False`).
- [x] No code/Lean changes; metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)