### PR TITLE
audit(erdos-565): mark clean — Aragão et al. 2025 axiomatization verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7613,9 +7613,9 @@
     },
     "erdos-565": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T11:02:51Z",
+      "result": "clean"
     },
     "erdos-566": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Summary

Verified erdos-565 against origin/main (32175b9b51f).

**Lean source** (`proofs/Proofs/Erdos565Problem.lean`):
- 286 lines
- 3 axioms: `induced_ramsey_exists`, `aragao_et_al_theorem`, `exponential_lower_bound`
- 1 sorry in `induced_ramsey_ge_ordinary` (comparison lemma — not main theorem)

**meta.json claims (all match):**
- `sorries: 1` ✓
- `axiomCount: 3` ✓
- `lineCount: 286` ✓
- `status: axiomatized`, `badge: axiom` ✓ (Tier C scaffold)
- `assumptions` correctly enumerates 3 axioms + 1 sorry

Main result reduced to axiomatization of the Aragão-Campos-Dahia-Filipe-Marciano (2025) 2^O(n) bound for induced Ramsey numbers.

## Tracker change

- `auditCount: 2 → 3`
- `lastAudited` bumped
- `result: issues-fixed → clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)