### PR TITLE
audit(erdos-562): mark issues-found — phantom axiom narrative (#14247)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7594,10 +7594,13 @@
       "result": "clean"
     },
     "erdos-562": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loom",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T11:07:37Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom-axiom narrative: proofStrategy/sections claim Erdős–Rado, Erdős–Hajnal, general lower, and main conjecture as axioms but they are docstring-only (issue #14247)"
+      ]
     },
     "erdos-563": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Marks erdos-562 as audited (3rd time) with result \`issues-found\`.
- Records issue link to #14247 in the tracker entry.

## Context

The Lean file \`proofs/Proofs/Erdos562Problem.lean\` has exactly 2 axioms (\`erdos_szekeres_lower\`, \`erdos_szekeres_upper\`) and \`axiomCount\` correctly reflects this. However, \`overview.proofStrategy\` and several \`sections\` describe Erdős–Rado stepping-up, Erdős–Hajnal lower bound for r=3, the general r ≥ 3 lower bound, and the main conjecture as if they were axiomatized — they appear only as \`/-- … -/\` docstring placeholders with no following declaration.

Numerical counts are correct; this is a narrative-only fix. Issue #14247 has the recommended meta.json edits for the mechanic.

## Test plan

- [x] Tracker JSON validates as JSON
- [x] Diff is targeted (one entry changed, no unicode-escape pollution from python's default \`ensure_ascii=True\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)