### PR TITLE
fix(quadratic-reciprocity-oq-03): correct badge original→mathlib

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -17,11 +17,11 @@
       "supplementary-laws",
       "verified-computation"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-04-27",
-    "lineCount": 119,
+    "lineCount": 118,
     "originalContributions": [
       "legendreSym_mul_eq: multiplicativity (a·b/p) = (a/p)·(b/p) packaged as a one-line wrapper around `map_mul (legendreSym p)`",
       "legendreSym_neg_one_eq: first supplementary law (-1/p) = (-1)^((p-1)/2) restated as a clean reduction step",


### PR DESCRIPTION
## Fix

Change `badge` from `"original"` to `"mathlib"` — all four reduction lemmas are explicit one-line wrappers around Mathlib's `legendreSym.quadratic_reciprocity'`, `legendreSym.at_neg_one`, and `map_mul`. Also corrects `lineCount` from 119 to 118 (actual file has 118 lines per `wc -l`).

## Evidence

**Before**: `"badge": "original"`, `"lineCount": 119`
**After**: `"badge": "mathlib"`, `"lineCount": 118`

The meta.json `assumptions` field already documented this accurately: "All four reduction lemmas are one-line wrappers around Mathlib's `legendreSym.quadratic_reciprocity'`, `legendreSym.at_neg_one`, and `map_mul`." This fix aligns the badge with the existing honest description.

Closes #14250

---
Automated fix by lean-mechanic agent.