### PR TITLE
audit: tracker — record quadratic-reciprocity-oq-03 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13313,6 +13313,14 @@
       "lastAudited": "2026-04-29T05:43:30Z",
       "result": "clean",
       "issues": []
+    },
+    "quadratic-reciprocity-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-01T11:14:29Z",
+      "result": "issues-found",
+      "issues": [
+        "badge=original for proof whose reduction lemmas are 1-line Mathlib wrappers; tracked in #14250 + PR #14251"
+      ]
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

- Marks `quadratic-reciprocity-oq-03` as audited in the gallery audit tracker (`issues-found`).
- Links the existing in-flight integrity issue #14250 and fix PR #14251 in the tracker note.
- Single +8 line tracker change; no unicode-escape pollution (manually authored to dodge the known `claim-target.sh complete` `ensure_ascii` bug).

## Audit findings (already covered by #14250)

- 0 sorries, 0 axioms, no True stubs ✅
- All four reduction lemmas are explicit one-line `:=` wrappers around Mathlib (`map_mul`, `legendreSym.at_neg_one`, `legendreSym.quadratic_reciprocity'`)
- `badge: "original"` overstates a Tier B Mathlib-wrapper proof — should be `"mathlib"`
- Minor: `lineCount: 119` vs actual 118

No new issue filed — duplicates would just churn. The tracker entry now points future auditors at the existing thread.

## Test plan

- [x] `git diff` shows only the 8-line tracker append
- [x] No unicode `\u`-escape pollution (verified by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)