### PR TITLE
audit: tracker — record erdos-564 issues-found (#14254)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7606,10 +7606,13 @@
       "result": "clean"
     },
     "erdos-564": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777634217",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T11:22:23Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom-axiom narrative — originalContributions 6/7/8, proofStrategy steps 7/8, sections small-values/comparison/four-colour describe docstring placeholders, not Lean declarations (axiomCount 3, sorries 1 are correct) — issue #14254"
+      ]
     },
     "erdos-565": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates `audit-tracker.json` to mark erdos-564 audit as `issues-found` (3rd audit, 2026-05-01)
- Documents the phantom-axiom narrative pattern in the issues field, linking to #14254

## Context

Gallery integrity audit (2026-05-01) found that erdos-564 has correct numerical counts (3 axioms, 1 sorry, status `axiomatized`), but `originalContributions` 6/7/8, `proofStrategy` steps 7/8, and sections `small-values`/`comparison`/`four-colour` describe declarations that exist only as docstring comments — not Lean axioms or theorems.

Same pattern as erdos-562 (#14247), erdos-569 (#14242), erdos-570 (#14234), erdos-571 (#14232), erdos-573 (#14227). See issue #14254 for evidence and recommended meta.json edits.

## Test plan

- [x] `git diff` shows only the erdos-564 entry change (7 lines)
- [x] No unicode-escape pollution (`\\u2192`, `\\u2014` re-applied as raw em-dash)
- [x] `python3 -c "import json; json.load(...)"` parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)