### PR TITLE
fix(erdos-564): correct phantom-axiom narrative in meta.json

### DIFF
--- a/src/data/proofs/erdos-564/meta.json
+++ b/src/data/proofs/erdos-564/meta.json
@@ -40,10 +40,7 @@
       "Definition of k-uniform hypergraphs and the Ramsey property",
       "Axiomatization of the hypergraph Ramsey function R_k(n)",
       "Erdős-Hajnal-Rado bounds: 2^{cn²} < R₃(n) < 2^{2^n}",
-      "Tower function definitions and properties",
-      "Known values: R₃(3) = 4, R₃(4) = 13",
-      "Comparison with graph Ramsey numbers",
-      "Discussion of the 4-colour doubly exponential result"
+      "Tower function definitions and properties"
     ],
     "axiomCount": 3,
     "lineCount": 207,
@@ -53,7 +50,7 @@
     "historicalContext": "This problem sits at the heart of hypergraph Ramsey theory, a generalization of classical Ramsey theory to k-uniform hypergraphs (where edges connect exactly k vertices rather than 2). For graphs (k = 2), Erdős and Szekeres (1935) showed that Ramsey numbers grow exponentially: roughly 2^{n/2} < R(n) < 4^n.\n\nFor 3-uniform hypergraphs (edges are triples), growth is dramatically faster. Erdős, Hajnal, and Rado proved in 1965 that 2^{cn²} < R₃(n) < 2^{2^n}. The lower bound is singly exponential in n², while the upper bound is a tower of exponentials of height 2.\n\nThe central question (Problem #564) asks whether the lower bound can be improved to match the tower height of the upper bound. If true, it would show that hypergraph Ramsey numbers are fundamentally 'tower-type' — requiring iterated exponentiation to describe. Erdős offered $500 for a resolution.",
     "problemStatement": "**Problem (Erdős-Hajnal-Rado, 1965)**: Let $R_3(n)$ be the minimal $m$ such that if the edges of the 3-uniform hypergraph on $m$ vertices are 2-coloured, there is a monochromatic complete 3-uniform hypergraph on $n$ vertices.\n\nIs there some constant $c > 0$ such that\n$$R_3(n) \\geq 2^{2^{cn}}?$$\n\n**Status**: OPEN ($500 prize)\n\n**Known Bounds** (Erdős-Hajnal-Rado 1965):\n$$2^{cn^2} < R_3(n) < 2^{2^n}$$\n\nThe question asks whether the 'tower height' of the lower bound (currently 1, exponential in n²) can be increased to 2, matching the upper bound.\n\n**Evidence**: Erdős, Hajnal, Máté, and Rado (1984) proved a doubly exponential lower bound for the 4-colour version, suggesting the 2-colour case might also have such a bound.",
     "text": "Is there a constant c > 0 such that R₃(n) ≥ 2^{2^{cn}}? An open problem asking whether the lower bound for 3-uniform hypergraph Ramsey numbers can match the tower height of the upper bound.",
-    "proofStrategy": "We formalize this OPEN problem by:\n\n1. **Uniform Hypergraphs**: Define k-uniform hypergraphs as sets of k-element subsets of vertices.\n\n2. **Ramsey Property**: Define HasHypergraphRamseyProperty k m n expressing that any 2-colouring of the complete k-uniform hypergraph on m vertices contains a monochromatic clique of size n.\n\n3. **Ramsey Function**: Axiomatize R k n as the minimal m with the Ramsey property.\n\n4. **Known Bounds**: State the Erdős-Hajnal-Rado upper and lower bounds as axioms.\n\n5. **Main Conjecture**: Express erdos_564_conjecture using Filter.atTop to state 'for all sufficiently large n'.\n\n6. **Tower Functions**: Define tower k n = 2↑↑k (iterated exponentiation) to clarify the growth rate hierarchy.\n\n7. **Known Values**: State R₃(3) = 4 and R₃(4) = 13 as axioms.\n\n8. **Comparison**: State bounds for graph Ramsey numbers (k = 2) showing they're merely exponential.",
+    "proofStrategy": "We formalize this OPEN problem by:\n\n1. **Uniform Hypergraphs**: Define k-uniform hypergraphs as sets of k-element subsets of vertices.\n\n2. **Ramsey Property**: Define HasHypergraphRamseyProperty k m n expressing that any 2-colouring of the complete k-uniform hypergraph on m vertices contains a monochromatic clique of size n.\n\n3. **Ramsey Function**: Axiomatize R k n as the minimal m with the Ramsey property.\n\n4. **Known Bounds**: State the Erdős-Hajnal-Rado upper and lower bounds as axioms.\n\n5. **Main Conjecture**: Express erdos_564_conjecture using Filter.atTop to state 'for all sufficiently large n'.\n\n6. **Tower Functions**: Define tower k n = 2↑↑k (iterated exponentiation) to clarify the growth rate hierarchy.",
     "keyInsights": [
       "**Tower growth hierarchy**: The key insight is about 'tower height'. Growth rate 2^n (tower 1) is fundamentally different from 2^{2^n} (tower 2). The question asks which tower height describes R₃(n).",
       "**Graph vs hypergraph gap**: For graphs (k = 2), Ramsey numbers grow exponentially (tower 1). For k = 3, we know they're between tower(1, n²) and tower(2, n). The gap is enormous.",
@@ -121,24 +118,24 @@
       "title": "Small Values",
       "startLine": 151,
       "endLine": 165,
-      "summary": "Known exact values R₃(3) = 4 and R₃(4) = 13",
-      "mathContext": "Mathematical content: Known exact values R₃(3) = 4 and R₃(4) = 13"
+      "summary": "Docstring placeholders for known values R₃(3) = 4 and R₃(4) = 13; no Lean axioms or theorems declare these values",
+      "mathContext": "Documentation: Known values are referenced in docstrings only; no Lean declarations in this range"
     },
     {
       "id": "comparison",
       "title": "Graph Ramsey Comparison",
       "startLine": 166,
       "endLine": 190,
-      "summary": "Comparison with exponential growth of graph Ramsey numbers",
-      "mathContext": "Mathematical content: Comparison with exponential growth of graph Ramsey numbers"
+      "summary": "bounds_summary theorem repackages the two hypergraph EHR bound axioms; graph Ramsey comparison appears only in a docstring with no associated Lean declaration",
+      "mathContext": "Bound: bounds_summary combines erdos_hajnal_rado_upper and erdos_hajnal_rado_lower; no graph Ramsey axioms exist"
     },
     {
       "id": "four-colour",
       "title": "The 4-Colour Case",
       "startLine": 191,
       "endLine": 207,
-      "summary": "Evidence from the 4-colour doubly exponential result",
-      "mathContext": "Mathematical content: Evidence from the 4-colour doubly exponential result"
+      "summary": "bounds_gap_enormous (sorry) states the enormous gap between known bounds; 4-colour doubly exponential result is mentioned in a docstring only, with no associated Lean declaration",
+      "mathContext": "Sorry: bounds_gap_enormous captures the bounds gap; 4-colour content is docstring-only"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Remove/rewrite phantom-axiom narrative in `originalContributions`, `proofStrategy`, and `sections` that claimed Lean declarations for content that only exists as docstring placeholders.

## Evidence

**Before**:
- `originalContributions` bullets 6-8 claimed "Known values: R₃(3) = 4, R₃(4) = 13", "Comparison with graph Ramsey numbers", "Discussion of the 4-colour doubly exponential result" — none have Lean declarations
- `proofStrategy` steps 7-8 said "State R₃(3) = 4 and R₃(4) = 13 as axioms" and "State bounds for graph Ramsey numbers" — no such axioms exist
- `sections.small-values` summary claimed "Known exact values R₃(3) = 4 and R₃(4) = 13" — only docstrings in that range
- `sections.comparison` summary claimed "Comparison with exponential growth of graph Ramsey numbers" — `bounds_summary` only repackages the hypergraph bound axioms
- `sections.four-colour` summary claimed "Evidence from the 4-colour doubly exponential result" — only a docstring; `bounds_gap_enormous` is about the bounds gap

**After**:
- `originalContributions`: drops bullets 6-8 (phantom); keeps 5 accurate bullets
- `proofStrategy`: drops steps 7-8 (phantom)
- `sections`: rewrites `small-values`, `comparison`, `four-colour` summaries to accurately describe what is actually in those line ranges

**Unchanged** (correct): `axiomCount: 3`, `sorries: 1`, `status: axiomatized`, `badge: axiom`, `meta.assumptions`

Closes #14254

---
Automated fix by lean-mechanic agent.