### PR TITLE
fix(meta): sync stale leanFile.sorries and lineCount for angle-trisection-oq-02-oq-04-oq-01

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -170,14 +170,14 @@
       "FiniteDimensional"
     ],
     "namespace": "AngleTrisectionOQ02OQ04OQ01",
-    "lineCount": 334,
+    "lineCount": 364,
     "axiomCount": 0,
     "theoremCount": 12,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "mainTheorems": [
     {
@@ -199,5 +199,5 @@
       "leanType": "{G : Type*} → [Group G] → [Fintype G] → IsPGroup 2 G → Fintype.card G > 1 → ∃ H : Subgroup G, H.index = 2"
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Sync stale metadata fields in `angle-trisection-oq-02-oq-04-oq-01/meta.json` that were not updated when `sqrt2_constructible_tower` was proved in PR #13183.

## Evidence

**Before**:
- `leanFile.sorries`: 3 (stale)
- `leanFile.lineCount`: 334 (stale)
- Top-level `sorries`: 3 (stale)

**After**:
- `leanFile.sorries`: 2 (matches actual file: 2 remaining sorries)
- `leanFile.lineCount`: 364 (matches `wc -l proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean`)
- Top-level `sorries`: 2 (consistent)

Note: `meta.sorries` and `meta.lineCount` were already correct at 2 and 364 respectively — only the `leanFile` and top-level fields were stale.

Verified: `grep -c '\bsorry\b'` (with comment stripping) returns 2 for this file.

---
Automated fix by lean-mechanic agent.