### PR TITLE
fix(meta): sync stale leanFile.lineCount for 9 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum — weight-preserving JDT bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} (~80 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). ssytFin_two_row_eq_sum_colstrict proved (row-decomp bijection, no sorry). ssytSchurFin_two_row main theorem proved. k=0,1,2 proved.",
-    "lineCount": 693,
+    "lineCount": 714,
     "theoremCount": 14,
     "definitionCount": 8,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 693,
+    "lineCount": 714,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -212,7 +212,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 255,
+    "lineCount": 296,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -64,7 +64,7 @@
       "prime_h_alpha_unbounded theorem: h_α(p) → ∞ over primes"
     ],
     "axiomCount": 0,
-    "lineCount": 654,
+    "lineCount": 723,
     "assumptions": "Fully verified: 0 axioms, 0 sorries. vose_bounded_sequence proved via trivial witness (constant sequence n_k = 2, h_α(2) = 1). All 34 theorems machine-checked."
   },
   "overview": {
@@ -318,7 +318,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos1099",
-    "lineCount": 654,
+    "lineCount": 723,
     "axiomCount": 0,
     "theoremCount": 36,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -51,7 +51,7 @@
       "Growth rate bounds and limit formulations"
     ],
     "axiomCount": 1,
-    "lineCount": 607,
+    "lineCount": 613,
     "references": [
       {
         "title": "Some remarks on the theory of graphs",
@@ -184,7 +184,7 @@
       "Classical"
     ],
     "namespace": "Erdos183",
-    "lineCount": 607,
+    "lineCount": 613,
     "axiomCount": 1,
     "theoremCount": 18,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-70-oq-01/meta.json
+++ b/src/data/proofs/erdos-70-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 240,
+    "lineCount": 258,
     "theoremCount": 12,
     "assumptions": "0 axioms, 0 sorries. All results proved from Mathlib definitions. The open question itself (OmegaSquaredConjecture) is defined as a Prop but left open — this is the correct formalization of an unsolved problem. Open conjecture; supporting lemmas fully verified.",
     "erdosNumber": 70,
@@ -145,7 +145,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 240,
+    "lineCount": 258,
     "path": "Proofs/Erdos70OQ01Problem.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 498,
+    "lineCount": 499,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 498,
+    "lineCount": 499,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -68,7 +68,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_884 (the OPEN main conjecture). All 8 supporting axioms eliminated: divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, divisors_prime, prime_case_equality, gap_lower_bound — all proved. numDivisors_mul_coprime sorry also proved via σ��� multiplicativity.",
-    "lineCount": 482
+    "lineCount": 498
   },
   "overview": {
     "historicalContext": "Erdős Problem #884 appears in [Er98] and asks about the relationship between two sums over divisor gaps. Given the divisors d₁ < d₂ < ··· < d_t of a positive integer n, one can form either the all-pairs sum (summing 1/(d_j - d_i) over all i < j) or the consecutive-pairs sum (summing only over adjacent divisors). The question is whether the all-pairs sum is controlled by the consecutive-pairs sum up to an absolute constant.\n\nThe problem is related to Erdős Problem #144 on divisor arithmetic. Terence Tao has indicated that this problem appears tractable, suggesting it may be amenable to combinatorial or analytic arguments about divisor distributions.\n\nThe trivial observation is that for primes p, both sums equal 1/(p-1) since there is only one pair of divisors {1, p}. For composite numbers with many divisors, the all-pairs sum has O(τ²) terms while the consecutive-pairs sum has only O(τ) terms, making the conjectured bound non-trivial.",
@@ -238,7 +238,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos884",
-    "lineCount": 482,
+    "lineCount": 498,
     "axiomCount": 1,
     "theoremCount": 33,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -58,7 +58,7 @@
       "strongNegation_implies_prime_free_windows: factorial construction proof"
     ],
     "axiomCount": 2,
-    "lineCount": 348,
+    "lineCount": 359,
     "assumptions": "2 axioms: (1) gaussian_prime_classification (the full characterization of Gaussian primes via norm type), (2) tsuchimura (computational verification — no walk ≤ √26). All other results proved from these axioms or from Mathlib."
   },
   "overview": {
@@ -155,7 +155,7 @@
       "GaussianInt"
     ],
     "namespace": "Erdos952",
-    "lineCount": 348,
+    "lineCount": 359,
     "axiomCount": 2,
     "theoremCount": 18,
     "definitionCount": 18,

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/963",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 704,
+    "lineCount": 706,
     "assumptions": "0 axioms. trivial_upper_bound now proved (f(n) ≤ n - 1 for n ≥ 1, via worst-case witness A = {0,...,n-1} and zero_not_in_dissociated). greedy_lower_bound fully proved via greedy_dissociated + Nat.log arithmetic. The conjectured tight bound f(n) ≤ ⌊log₂ n⌋ + 1 remains open in the formalization (the trivial bound n − 1 is much weaker but axiom-free). The main Erdős conjecture f(n) ≥ ⌊log₂ n⌋ is stated as `def ErdosProblem963` (open).",
     "mathlib_version": "4.26.0"
   },
@@ -137,7 +137,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 704,
+    "lineCount": 706,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Batch fix for stale `leanFile.lineCount` values in 9 gallery entries. These were discovered via automated audit comparing `wc -l` against stored values.

## Evidence

| Entry | Stored | Actual |
|-------|--------|--------|
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | 693 | 714 |
| erdos-1035 | 255 | 296 |
| erdos-1099 | 654 | 723 |
| erdos-183 | 607 | 613 |
| erdos-70-oq-01 | 240 | 258 |
| erdos-795 | 498 | 499 |
| erdos-884 | 482 | 498 |
| erdos-952 | 348 | 359 |
| erdos-963 | 704 | 706 |

Also synced `meta.lineCount` for entries where that field also had the stale value.

No axiom counts, sorry counts, or status fields were changed.

---
Automated fix by lean-mechanic agent.