### PR TITLE
fix(meta): sync stale axiomCount for erdos-404, erdos-1017, erdos-513

### DIFF
--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1017",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 696,
-    "assumptions": "3 axioms inherited from Erdos1017OQ01.lean: egp_theorem (Erdős-Gallai-type partitioning theorem), gyori_keszegh_triangles (Győri-Keszegh triangle counting result), k4free_partition_number (K₄-free partition number bound). 0 own axioms. 0 sorries.",
+    "assumptions": "2 axioms inherited from Erdos1017OQ01.lean: egp_theorem (Erdős-Gallai-type partitioning theorem), k4free_partition_number (K₄-free partition number bound). gyori_keszegh_triangles was removed. 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -188,7 +188,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 696,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 37,
     "definitionCount": 6,
     "path": "Proofs/Erdos1017OQ01.lean",

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -59,7 +59,7 @@
       "Two proved examples by native_decide",
       "erdos_404_summary: proved conjunction of Lin's bounds"
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "prerequisites": [
       "p-adic valuation (padicValNat) and basic properties",
       "Factorials and divisibility in number theory",
@@ -68,7 +68,7 @@
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
     "lineCount": 291,
-    "assumptions": "2 axioms: lin_bound (f(2,2) <= 254), lin_bound_meaning (2^255 never divides such sums). 0 sorries.",
+    "assumptions": "1 axiom: lin_bound_meaning (2^255 never divides such sums). lin_bound was derived from lin_bound_meaning. 0 sorries.",
     "theoremCount": 9
   },
   "overview": {
@@ -204,8 +204,8 @@
       "Filter"
     ],
     "namespace": "Erdos404",
-    "lineCount": 291,
-    "axiomCount": 2,
+    "lineCount": 310,
+    "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 8,
     "path": "Proofs/Erdos404Problem.lean",

--- a/src/data/proofs/erdos-513/meta.json
+++ b/src/data/proofs/erdos-513/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 513,
     "erdosUrl": "https://erdosproblems.com/513",
     "erdosProblemStatus": "open",
-    "axiomCount": 6,
+    "axiomCount": 4,
     "lineCount": 159,
     "dateAdded": "2026-02-10",
     "prerequisites": [
@@ -28,7 +28,7 @@
       "Wiman-Valiron theory: maximum term μ(r), central index, and their relation to M(r)",
       "Lacunary series: gap series with controlled coefficient growth"
     ],
-    "assumptions": "6 axioms: maxModulus, maxModulus_nonneg, maxTerm_le_maxModulus, kovari_lower_bound, clunie_hayman_upper_bound, erdos_513_exact_value. 0 sorries.",
+    "assumptions": "4 axioms: maxTerm_le_maxModulus, kovari_lower_bound, clunie_hayman_upper_bound, erdos_513_exact_value. maxModulus and maxModulus_nonneg were proved from Mathlib. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "crossReferences": [
@@ -127,8 +127,8 @@
     ],
     "opens": [],
     "namespace": "Erdos513",
-    "lineCount": 159,
-    "axiomCount": 6,
+    "lineCount": 167,
+    "axiomCount": 4,
     "theoremCount": 10,
     "definitionCount": 3,
     "path": "Proofs/Erdos513Problem.lean",


### PR DESCRIPTION
## Fix

Correct stale `axiomCount` (and `lineCount`) in three gallery entries where axioms were removed/derived in previous research PRs but metadata was not updated.

## Evidence

| Slug | Field | Before | After | Reason |
|------|-------|--------|-------|--------|
| erdos-404 | axiomCount | 2 | 1 | `lin_bound` derived from `lin_bound_meaning` (#13285) |
| erdos-404 | lineCount | 291 | 310 | File grew with new proof |
| erdos-1017 | axiomCount | 3 | 2 | `gyori_keszegh_triangles` removed from Erdos1017OQ01.lean |
| erdos-513 | axiomCount | 6 | 4 | `maxModulus`/`maxModulus_nonneg` proved from Mathlib |
| erdos-513 | lineCount | 159 | 167 | File grew with new proofs |

Also verified correct (no fix needed): erdos-582 (5 = 2 opaques + 3 axioms), erdos-1012-oq-03 (1 axiom confirmed).

---
Automated fix by lean-mechanic agent.