### PR TITLE
fix(erdos-639): remove phantom Pyber and ERS originalContributions

### DIFF
--- a/src/data/proofs/erdos-639/meta.json
+++ b/src/data/proofs/erdos-639/meta.json
@@ -46,9 +46,7 @@
       "Axiomatization of the Keevash-Sudakov theorem for n ≥ 7 and its tightness",
       "Connection to Ramsey number R(3,3) = 6 as the phase transition point",
       "The extremal balanced bipartite coloring construction as a concrete Lean definition",
-      "Pyber's ⌊n²/4⌋ + 2 monochromatic clique covering result",
-      "Proof of mono_iff_red_or_blue and edge_partition without sorry (verified by Aristotle)",
-      "Erdős-Rousseau-Schelp asymptotic version with explicit ε-δ formulation"
+      "Proof of mono_iff_red_or_blue and edge_partition without sorry (verified by Aristotle)"
     ],
     "relatedProblems": [
       "ramseys-theorem"


### PR DESCRIPTION
## Fix

Removes two `originalContributions` entries from `src/data/proofs/erdos-639/meta.json` that reference results existing only as orphaned docstrings in the Lean source — not as theorems, axioms, or definitions.

## Evidence

**Phantom entries removed**:
- `"Pyber's ⌊n²/4⌋ + 2 monochromatic clique covering result"` — appears only as a docstring at line 174 of `Erdos639Problem.lean`, not as any declaration
- `"Erdős-Rousseau-Schelp asymptotic version with explicit ε-δ formulation"` — appears only as a docstring at line 176 of `Erdos639Problem.lean`, not as any declaration

**Before**: 8 `originalContributions` entries (entries 6 and 8 were phantom)
**After**: 6 `originalContributions` entries (all correspond to actual Lean declarations)

## History

This re-applies the fix from issue #14135 (closed as COMPLETED). Multiple fix PRs were created (#14142, #14154, #14167) but all were closed without merging due to confusion about whether the fix had already landed. It had not: the Pyber and ERS entries remain in `origin/main` at the time of this PR.

The `proofStrategy` and section `summary` already correctly describe both results as docstring-only — this PR aligns `originalContributions` to match that accurate description.

---
Automated fix by lean-mechanic agent.