### PR TITLE
fix(erdos-400): remove phantom axiom claims from originalContributions

### DIFF
--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -50,11 +50,8 @@
       "`sumExcess` and `gExcess`: the excess function $g_k(n) = \\sup\\{\\sum a_i - n\\}$",
       "`ErdosProblem400a`: average growth $\\sum_{n \\le x} g_k(n) \\sim c_k \\cdot x \\log x$",
       "`ErdosProblem400b`: concentration $g_k(n) = c_k \\log x + o(\\log x)$ a.e.",
-      "`gExcess_upper_bound` (axiom): Erdős-Graham bound $g_k(n) = O(\\log n)$",
-      "`gExcess_nonneg` (axiom): $g_k(n) \\ge 0$ from trivial tuple",
-      "`g2_binomial_connection` (axiom): $k = 2$ binomial coefficient link",
-      "`g2_excess_characterization` (axiom): supremum attained for $k = 2$",
-      "`average_g2_growth` (axiom): average growth constant $c_2$ exists"
+      "`gExcess_nonneg` (theorem): $g_k(n) \\ge 0$ from trivial tuple",
+      "`g2_binomial_connection` (theorem): $k = 2$ binomial coefficient link"
     ],
     "axiomCount": 0,
     "lineCount": 171,


### PR DESCRIPTION
## Fix

Three `originalContributions` entries in `src/data/proofs/erdos-400/meta.json` reference axioms that no longer exist in the Lean source. Additionally, two entries are mislabeled as \"(axiom)\" when they have been converted to proved theorems.

## Evidence

**Phantom entries removed**:
- `` `gExcess_upper_bound` (axiom) `` — not in Lean file; only an orphaned docstring (if anything)
- `` `g2_excess_characterization` (axiom) `` — only an orphaned docstring at end of file (line 169)
- `` `average_g2_growth` (axiom) `` — only an orphaned docstring at end of file (line 170)

**Labels corrected**:
- `` `gExcess_nonneg` (axiom) `` → `` `gExcess_nonneg` (theorem) `` — proved at line 143 of Lean file
- `` `g2_binomial_connection` (axiom) `` → `` `g2_binomial_connection` (theorem) `` — proved at line 151 of Lean file

The `meta.axiomCount: 0` and `meta.assumptions` field already correctly reflect the current state (0 axioms); this PR aligns `originalContributions` to match.

**Before**: 9 originalContributions (3 phantom + 2 mislabeled)
**After**: 6 originalContributions (all accurate)

---
Automated fix by lean-mechanic agent.