### PR TITLE
fix(liouville-theorem-oq-04): correct status formalized→axiomatized

### DIFF
--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "lean-genius research agent",
     "sourceUrl": "https://mathworld.wolfram.com/p-adicNumber.html",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LiouvilleTheoremOQ04.lean",
     "tags": [
       "number-theory",


### PR DESCRIPTION
## Fix

Corrects the `status` field in `src/data/proofs/liouville-theorem-oq-04/meta.json` from `"formalized"` to `"axiomatized"`.

## Evidence

The Lean file `proofs/Proofs/LiouvilleTheoremOQ04.lean` contains:
```lean
axiom padic_liouville_estimate (α : ℚ_[p]) (f : ℤ[X]) ...
```

The meta.json already has:
- `axiomCount: 1` ✓ (correctly reflects the axiom)
- `badge: "axiom"` ✓ (correct badge for axiomatized)
- `sorries: 1` ✓ (correct sorry count)

The only inconsistency was `status: "formalized"` — per the gallery schema, entries with explicit `axiom` declarations should use `status: "axiomatized"`. The `badge: "axiom"` already indicates this; the `status` field now matches.

**Before**: `status: "formalized"` (inconsistent with axiomCount=1 and badge="axiom")
**After**: `status: "axiomatized"` (consistent with all other fields)

---
Automated fix by lean-mechanic agent.