### PR TITLE
fix(meta): remove phantom axiom identifiers from 11 entries

### DIFF
--- a/src/data/proofs/erdos-1075/meta.json
+++ b/src/data/proofs/erdos-1075/meta.json
@@ -119,18 +119,18 @@
     {
       "id": "conjecture",
       "title": "The Open Conjecture",
-      "summary": "Defines `ErdosConjecture1075` as a `Prop`: $\\exists c_r > r^{-r}$ with edge threshold $(1+\\varepsilon)(n/r)^r$. The `def` (not `axiom`) signals an unresolved question. Also axiomatizes `threshold_comparison`: $(n/r)^r < n^r$ for $r \\ge 3$, quantifying the gap between the two thresholds. The conjecture is a supersaturation question — does slight density excess force structural improvements?",
+      "summary": "Defines `ErdosConjecture1075` as a `Prop`: $\\exists c_r > r^{-r}$ with edge threshold $(1+\\varepsilon)(n/r)^r$. The `def` (not `axiom`) signals an unresolved question. Also documents in source comments `threshold_comparison` (no Lean declaration exists): $(n/r)^r < n^r$ for $r \\ge 3$, quantifying the gap between the two thresholds. The conjecture is a supersaturation question — does slight density excess force structural improvements?",
       "startLine": 100,
       "endLine": 134,
-      "mathContext": "Defines `ErdosConjecture1075` as a `Prop`: $\\exists c_r > r^{-r}$ with edge threshold $(1+\\varepsilon)(n/r)^r$. The `def` (not `axiom`) signals an unresolved question. Also axiomatizes `threshold_comparison`: $(n/r)^r < n^r$ for $r \\ge 3$, quantifying the gap between the two thresholds. The conjecture is a supersaturation question — does slight density excess force structural improvements?"
+      "mathContext": "Defines `ErdosConjecture1075` as a `Prop`: $\\exists c_r > r^{-r}$ with edge threshold $(1+\\varepsilon)(n/r)^r$. The `def` (not `axiom`) signals an unresolved question. Also documents in source comments `threshold_comparison` (no Lean declaration exists): $(n/r)^r < n^r$ for $r \\ge 3$, quantifying the gap between the two thresholds. The conjecture is a supersaturation question — does slight density excess force structural improvements?"
     },
     {
       "id": "asymptotics",
       "title": "Complete Hypergraphs and Asymptotics",
-      "summary": "Defines `completeHypergraphEdges m r = Nat.choose m r` and axiomatizes `binomial_asymptotic`: $\\binom{m}{r}/(m^r/r!) \\to 1$ as $m \\to \\infty$. This bridges the combinatorial edge count $\\binom{m}{r}$ with the density measure $m^r$ used in the problem statement, using `Filter.Tendsto` for the asymptotic.",
+      "summary": "Defines `completeHypergraphEdges m r = Nat.choose m r` and documents in source comments `binomial_asymptotic` (no Lean declaration exists): $\\binom{m}{r}/(m^r/r!) \\to 1$ as $m \\to \\infty$. This bridges the combinatorial edge count $\\binom{m}{r}$ with the density measure $m^r$ used in the problem statement, using `Filter.Tendsto` for the asymptotic.",
       "startLine": 135,
       "endLine": 149,
-      "mathContext": "Defines `completeHypergraphEdges m r = Nat.choose m r` and axiomatizes `binomial_asymptotic`: $\\binom{m}{r}/(m^r/r!) \\to 1$ as $m \\to \\infty$. This bridges the combinatorial edge count $\\binom{m}{r}$ with the density measure $m^r$ used in the problem statement, using `Filter.Tendsto` for the asymptotic."
+      "mathContext": "Defines `completeHypergraphEdges m r = Nat.choose m r` and documents in source comments `binomial_asymptotic` (no Lean declaration exists): $\\binom{m}{r}/(m^r/r!) \\to 1$ as $m \\to \\infty$. This bridges the combinatorial edge count $\\binom{m}{r}$ with the density measure $m^r$ used in the problem statement, using `Filter.Tendsto` for the asymptotic."
     },
     {
       "id": "summary",

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -153,10 +153,10 @@
     {
       "id": "hales-jewett",
       "title": "Hales-Jewett Approach",
-      "summary": "Defines `CombinatorialLine k n` structure with fixed/varying coordinate partition. Axiomatizes `hales_jewett` (monochromatic line guarantee), `generic_projection` (injective line-preserving map [k]ⁿ → Point), and `hunter_observation` (combining both for HasRamseyProperty).",
+      "summary": "Defines `CombinatorialLine k n` structure with fixed/varying coordinate partition. documents in source comments `hales_jewett` (no Lean declaration exists) (monochromatic line guarantee), `generic_projection` (injective line-preserving map [k]ⁿ → Point), and `hunter_observation` (combining both for HasRamseyProperty).",
       "startLine": 148,
       "endLine": 201,
-      "mathContext": "Defines `CombinatorialLine k n` structure with fixed/varying coordinate partition. Axiomatizes `hales_jewett` (monochromatic line guarantee), `generic_projection` (injective line-preserving map [k]ⁿ → Point), and `hunter_observation` (combining both for HasRamseyProperty)."
+      "mathContext": "Defines `CombinatorialLine k n` structure with fixed/varying coordinate partition. documents in source comments `hales_jewett` (no Lean declaration exists) (monochromatic line guarantee), `generic_projection` (injective line-preserving map [k]ⁿ → Point), and `hunter_observation` (combining both for HasRamseyProperty)."
     },
     {
       "id": "main-result",
@@ -177,26 +177,26 @@
     {
       "id": "bounds",
       "title": "Size Bounds",
-      "summary": "Defines `ramseyNumber k` (minimum |A| with Ramsey property, using noncomputable Nat.find). States `ramsey_lower_bound` (R(k) ≥ k, sorry). Axiomatizes `r3_small` (∃ A, A.card ≤ 9 ∧ HasRamseyProperty A 3).",
+      "summary": "Defines `ramseyNumber k` (minimum |A| with Ramsey property, using noncomputable Nat.find). States `ramsey_lower_bound` (R(k) ≥ k, sorry). documents in source comments `r3_small` (no Lean declaration exists) (∃ A, A.card ≤ 9 ∧ HasRamseyProperty A 3).",
       "startLine": 240,
       "endLine": 265,
-      "mathContext": "Defines `ramseyNumber k` (minimum |A| with Ramsey property, using noncomputable Nat.find). States `ramsey_lower_bound` (R(k) ≥ k, sorry). Axiomatizes `r3_small` (∃ A, A.card ≤ 9 ∧ HasRamseyProperty A 3)."
+      "mathContext": "Defines `ramseyNumber k` (minimum |A| with Ramsey property, using noncomputable Nat.find). States `ramsey_lower_bound` (R(k) ≥ k, sorry). documents in source comments `r3_small` (no Lean declaration exists) (∃ A, A.card ≤ 9 ∧ HasRamseyProperty A 3)."
     },
     {
       "id": "related",
       "title": "Related Results",
-      "summary": "Defines `SylvesterGallai` (ordinary line existence) and `HellyProperty` (d+1 convex sets with pairwise intersections have common point). Axiomatizes `sylvester_gallai` for ≥ 3 non-collinear points.",
+      "summary": "Defines `SylvesterGallai` (ordinary line existence) and `HellyProperty` (d+1 convex sets with pairwise intersections have common point). documents in source comments `sylvester_gallai` (no Lean declaration exists) for ≥ 3 non-collinear points.",
       "startLine": 266,
       "endLine": 295,
-      "mathContext": "Defines `SylvesterGallai` (ordinary line existence) and `HellyProperty` (d+1 convex sets with pairwise intersections have common point). Axiomatizes `sylvester_gallai` for $\\geq$ 3 non-collinear points."
+      "mathContext": "Defines `SylvesterGallai` (ordinary line existence) and `HellyProperty` (d+1 convex sets with pairwise intersections have common point). documents in source comments `sylvester_gallai` (no Lean declaration exists) for $\\geq$ 3 non-collinear points."
     },
     {
       "id": "generalizations",
       "title": "Generalizations",
-      "summary": "Defines `Erdos1090Generalized k r` (r-coloring version) and `Erdos1090HigherDim d k` (hyperplanes in ℝᵈ). Axiomatizes `erdos_1090_generalized` via Hales-Jewett for r colors.",
+      "summary": "Defines `Erdos1090Generalized k r` (r-coloring version) and `Erdos1090HigherDim d k` (hyperplanes in ℝᵈ). documents in source comments `erdos_1090_generalized` (no Lean declaration exists) via Hales-Jewett for r colors.",
       "startLine": 296,
       "endLine": 328,
-      "mathContext": "Formal definition: Defines `Erdos1090Generalized k r` (r-coloring version) and `Erdos1090HigherDim d k` (hyperplanes in ℝᵈ). Axiomatizes `erdos_1090_generalized` via Hales-Jewett for r colors."
+      "mathContext": "Formal definition: Defines `Erdos1090Generalized k r` (r-coloring version) and `Erdos1090HigherDim d k` (hyperplanes in ℝᵈ). documents in source comments `erdos_1090_generalized` (no Lean declaration exists) via Hales-Jewett for r colors."
     },
     {
       "id": "summary",

--- a/src/data/proofs/erdos-1098/meta.json
+++ b/src/data/proofs/erdos-1098/meta.json
@@ -170,16 +170,16 @@
       "title": "Infinite Groups and Examples",
       "startLine": 201,
       "endLine": 250,
-      "summary": "Proves `abelian_no_edges` (Z(G) = ⊤ implies no non-commuting pairs). Axiomatizes `infinite_clique_example`, `symmetric_group_clique_bound` (≤ n!), `dihedral_group_center_index`. States `finite_group_finite_index` (sorry).",
-      "mathContext": "Proves `abelian_no_edges` (Z(G) = ⊤ implies no non-commuting pairs). Axiomatizes `infinite_clique_example`, `symmetric_group_clique_bound` (≤ n!), `dihedral_group_center_index`. States `finite_group_finite_index` (sorry)."
+      "summary": "Proves `abelian_no_edges` (Z(G) = ⊤ implies no non-commuting pairs). documents in source comments `infinite_clique_example` (no Lean declaration exists), `symmetric_group_clique_bound` (≤ n!), `dihedral_group_center_index`. States `finite_group_finite_index` (sorry).",
+      "mathContext": "Proves `abelian_no_edges` (Z(G) = ⊤ implies no non-commuting pairs). documents in source comments `infinite_clique_example` (no Lean declaration exists), `symmetric_group_clique_bound` (≤ n!), `dihedral_group_center_index`. States `finite_group_finite_index` (sorry)."
     },
     {
       "id": "generalizations",
       "title": "Generalizations",
       "startLine": 251,
       "endLine": 280,
-      "summary": "Axiomatizes `commutingProbability` and `prob_clique_relation` for finite groups. Defines `isBFCGroup` (bounded finite conjugacy classes) and axiomatizes `bfc_center_connection`.",
-      "mathContext": "Formal definition: Axiomatizes `commutingProbability` and `prob_clique_relation` for finite groups. Defines `isBFCGroup` (bounded finite conjugacy classes) and axiomatizes `bfc_center_connection`."
+      "summary": "Axiomatizes `commutingProbability` and `prob_clique_relation` for finite groups. Defines `isBFCGroup` (bounded finite conjugacy classes) and documents in source comments `bfc_center_connection` (no Lean declaration exists).",
+      "mathContext": "Formal definition: Axiomatizes `commutingProbability` and `prob_clique_relation` for finite groups. Defines `isBFCGroup` (bounded finite conjugacy classes) and documents in source comments `bfc_center_connection` (no Lean declaration exists)."
     },
     {
       "id": "summary",

--- a/src/data/proofs/erdos-1105/meta.json
+++ b/src/data/proofs/erdos-1105/meta.json
@@ -149,7 +149,7 @@
     {
       "id": "turan",
       "title": "Connection to Turan Numbers",
-      "summary": "Defines Turan number `turan n k H` as $\\text{ex}(n, H) = \\sup\\{|E(G)| : G \\text{ is } H\\text{-free}\\}$ via `sSup`. Axiomatizes `ar_turan_lower`: $\\text{AR}(n, H) \\geq \\text{ex}(n, H) + 1$ for $n \\geq k$.",
+      "summary": "Defines Turan number `turan n k H` as $\\text{ex}(n, H) = \\sup\\{|E(G)| : G \\text{ is } H\\text{-free}\\}$ via `sSup`. documents in source comments `ar_turan_lower` (no Lean declaration exists): $\\text{AR}(n, H) \\geq \\text{ex}(n, H) + 1$ for $n \\geq k$.",
       "startLine": 324,
       "endLine": 340,
       "mathContext": "The Turan number $\\text{ex}(n, H) = \\max\\{|E(G)| : G \\text{ on } n \\text{ vertices, } H\\text{-free}\\}$. The key connection: $\\text{AR}(n, H) \\geq \\text{ex}(n, H) + 1$ because an $H$-free graph can be colored rainbow (all edges distinct colors), with remaining edges of $K_n$ getting one extra color. This links anti-Ramsey theory to extremal graph theory."

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -101,10 +101,10 @@
     {
       "id": "covering-sets",
       "title": "Covering Sets",
-      "summary": "Defines `IsCoveringSet` (finite primes $P$ where $\\forall k, \\exists p \\in P, p \\mid 2^k \\cdot m + 1$) and `HasFiniteCoveringSet`. Axiomatizes `covering_set_implies_sierpinski`: covered numbers are Sierpinski.",
+      "summary": "Defines `IsCoveringSet` (finite primes $P$ where $\\forall k, \\exists p \\in P, p \\mid 2^k \\cdot m + 1$) and `HasFiniteCoveringSet`. documents in source comments `covering_set_implies_sierpinski` (no Lean declaration exists): covered numbers are Sierpinski.",
       "startLine": 64,
       "endLine": 80,
-      "mathContext": "Defines `IsCoveringSet` (finite primes $P$ where $\\forall k, \\exists p \\in P, p \\mid 2^k \\cdot m + 1$) and `HasFiniteCoveringSet`. Axiomatizes `covering_set_implies_sierpinski`: covered numbers are Sierpinski."
+      "mathContext": "Defines `IsCoveringSet` (finite primes $P$ where $\\forall k, \\exists p \\in P, p \\mid 2^k \\cdot m + 1$) and `HasFiniteCoveringSet`. documents in source comments `covering_set_implies_sierpinski` (no Lean declaration exists): covered numbers are Sierpinski."
     },
     {
       "id": "main-question",

--- a/src/data/proofs/erdos-1122/meta.json
+++ b/src/data/proofs/erdos-1122/meta.json
@@ -76,7 +76,7 @@
     "keyInsights": [
       "**Additive Determined by Primes:** Additive functions are determined by values on prime powers, since any n factors as a product of coprime prime powers. The `valueDeterminedByPrimes` definition captures this via `Nat.primeFactors` and `Nat.factorization`.",
       "**log is the Unique Monotone Additive:** Erdős proved that the only increasing additive function is c·log. The formalization captures this as `erdos_empty_defect`: empty defect set + additive → logarithmic.",
-      "**Condition Hierarchy:** Empty defect ⊂ Mangerel density ⊂ o(X) density forms a strict chain. The formalization proves `empty_implies_littleO` directly and axiomatizes `mangerel_implies_littleO`.",
+      "**Condition Hierarchy:** Empty defect ⊂ Mangerel density ⊂ o(X) density forms a strict chain. The formalization proves `empty_implies_littleO` directly and documents in source comments `mangerel_implies_littleO` (no Lean declaration exists).",
       "**The Gap:** Between Mangerel's O(X/(log X)^{2+c}) and the conjecture's o(X) lies the open problem. The `hasBoundedPrimeValues` condition in Mangerel's theorem is an additional restriction not present in the conjecture.",
       "**omega as Counterexample:** ω(n) = |{p : p | n}| is additive but not logarithmic, showing additivity alone doesn't force logarithmic form — some monotonicity condition is essential."
     ],
@@ -172,16 +172,16 @@
       "title": "Condition Hierarchy",
       "startLine": 156,
       "endLine": 180,
-      "summary": "Proves `empty_implies_littleO` via `Finset.filter_eq_empty_iff` and `Set.not_mem_empty`. Axiomatizes `mangerel_implies_littleO`. Defines `conditionHierarchy` as the conjunction of both implications.",
-      "mathContext": "Formal definition: Proves `empty_implies_littleO` via `Finset.filter_eq_empty_iff` and `Set.not_mem_empty`. Axiomatizes `mangerel_implies_littleO`. Defines `conditionHierarchy` as the conjunction of both implications."
+      "summary": "Proves `empty_implies_littleO` via `Finset.filter_eq_empty_iff` and `Set.not_mem_empty`. documents in source comments `mangerel_implies_littleO` (no Lean declaration exists). Defines `conditionHierarchy` as the conjunction of both implications.",
+      "mathContext": "Formal definition: Proves `empty_implies_littleO` via `Finset.filter_eq_empty_iff` and `Set.not_mem_empty`. documents in source comments `mangerel_implies_littleO` (no Lean declaration exists). Defines `conditionHierarchy` as the conjunction of both implications."
     },
     {
       "id": "sec-examples",
       "title": "Examples",
       "startLine": 181,
       "endLine": 200,
-      "summary": "Proves `log_has_empty_defect` via `Real.log_le_log` and `ext`/`simp`. Defines `omega` via `Nat.primeFactors.card`. Axiomatizes `omega_is_additive` and `omega_not_logarithmic`.",
-      "mathContext": "Formal definition: Proves `log_has_empty_defect` via `Real.log_le_log` and `ext`/`simp`. Defines `omega` via `Nat.primeFactors.card`. Axiomatizes `omega_is_additive` and `omega_not_logarithmic`."
+      "summary": "Proves `log_has_empty_defect` via `Real.log_le_log` and `ext`/`simp`. Defines `omega` via `Nat.primeFactors.card`. documents in source comments `omega_is_additive` (no Lean declaration exists) and `omega_not_logarithmic`.",
+      "mathContext": "Formal definition: Proves `log_has_empty_defect` via `Real.log_le_log` and `ext`/`simp`. Defines `omega` via `Nat.primeFactors.card`. documents in source comments `omega_is_additive` (no Lean declaration exists) and `omega_not_logarithmic`."
     },
     {
       "id": "sec-summary",

--- a/src/data/proofs/erdos-1124/meta.json
+++ b/src/data/proofs/erdos-1124/meta.json
@@ -141,10 +141,10 @@
     {
       "id": "non-measurability",
       "title": "Non-Measurability Results",
-      "summary": "Axiomatizes `pieces_not_measurable` (any disk decomposition has a non-measurable piece) and `dubins_hirsch_karush` (1963): no decomposition into measurable, translation-congruent pieces exists, since $\\lambda^2(D) = \\pi \\neq 1 = \\lambda^2(S)$.",
+      "summary": "documents in source comments `pieces_not_measurable` (no Lean declaration exists) (any disk decomposition has a non-measurable piece) and `dubins_hirsch_karush` (1963): no decomposition into measurable, translation-congruent pieces exists, since $\\lambda^2(D) = \\pi \\neq 1 = \\lambda^2(S)$.",
       "startLine": 167,
       "endLine": 185,
-      "mathContext": "Axiomatizes `pieces_not_measurable` (any disk decomposition has a non-measurable piece) and `dubins_hirsch_karush` (1963): no decomposition into measurable, translation-congruent pieces exists, since $\\lambda^2(D) = \\pi \\neq 1 = \\lambda^2(S)$."
+      "mathContext": "documents in source comments `pieces_not_measurable` (no Lean declaration exists) (any disk decomposition has a non-measurable piece) and `dubins_hirsch_karush` (1963): no decomposition into measurable, translation-congruent pieces exists, since $\\lambda^2(D) = \\pi \\neq 1 = \\lambda^2(S)$."
     },
     {
       "id": "main-result",

--- a/src/data/proofs/erdos-154/meta.json
+++ b/src/data/proofs/erdos-154/meta.json
@@ -96,7 +96,7 @@
     {
       "id": "lindstrom",
       "title": "Lindström's Theorem (1998)",
-      "summary": "Axiomatizes `lindstrom_sidon_distribution`: for Sidon $A \\subset \\{1,\\ldots,N\\}$, $\\forall m \\geq 2$, $\\forall \\varepsilon > 0$, $A$ is $\\varepsilon$-well-distributed mod $m$ for large $N$. Uses fourth moment bounds on character sums.",
+      "summary": "documents in source comments `lindstrom_sidon_distribution` (no Lean declaration exists): for Sidon $A \\subset \\{1,\\ldots,N\\}$, $\\forall m \\geq 2$, $\\forall \\varepsilon > 0$, $A$ is $\\varepsilon$-well-distributed mod $m$ for large $N$. Uses fourth moment bounds on character sums.",
       "startLine": 50,
       "endLine": 62
     },
@@ -110,7 +110,7 @@
     {
       "id": "even-odd",
       "title": "Even-Odd Balance",
-      "summary": "Axiomatizes `even_odd_balance`: the $m = 2$ case. About half of $A+A$ is even ($\\binom{k}{2} + \\binom{|A|-k}{2}$ sums) and half odd ($k(|A|-k)$ sums), where $k \\approx |A|/2$ from Lindström.",
+      "summary": "documents in source comments `even_odd_balance` (no Lean declaration exists): the $m = 2$ case. About half of $A+A$ is even ($\\binom{k}{2} + \\binom{|A|-k}{2}$ sums) and half odd ($k(|A|-k)$ sums), where $k \\approx |A|/2$ from Lindström.",
       "startLine": 77,
       "endLine": 89
     },

--- a/src/data/proofs/erdos-221/meta.json
+++ b/src/data/proofs/erdos-221/meta.json
@@ -114,8 +114,8 @@
       "title": "Lorentz's Result (1954)",
       "startLine": 93,
       "endLine": 100,
-      "summary": "Axiomatizes `lorentz_1954`: $\\exists A$ with $\\text{IsComplementToPowersOfTwo}(A) \\wedge \\text{HasLorentzDensity}(A)$. The first positive answer, but with the suboptimal density $O(N \\log\\log N / \\log N)$.",
-      "mathContext": "Axiomatizes `lorentz_1954`: $\\exists A$ with $\\text{IsComplementToPowersOfTwo}(A) \\wedge \\text{HasLorentzDensity}(A)$. The first positive answer, but with the suboptimal density $O(N \\log\\log N / \\log N)$."
+      "summary": "documents in source comments `lorentz_1954` (no Lean declaration exists): $\\exists A$ with $\\text{IsComplementToPowersOfTwo}(A) \\wedge \\text{HasLorentzDensity}(A)$. The first positive answer, but with the suboptimal density $O(N \\log\\log N / \\log N)$.",
+      "mathContext": "documents in source comments `lorentz_1954` (no Lean declaration exists): $\\exists A$ with $\\text{IsComplementToPowersOfTwo}(A) \\wedge \\text{HasLorentzDensity}(A)$. The first positive answer, but with the suboptimal density $O(N \\log\\log N / \\log N)$."
     },
     {
       "id": "ruzsa-construction",
@@ -154,24 +154,24 @@
       "title": "Connection to Primitive Roots",
       "startLine": 170,
       "endLine": 189,
-      "summary": "Axiomatizes `primitive_root_order`: $\\text{ord}_{5^n}(2) = \\varphi(5^n) = 4 \\cdot 5^{n-1}$, and `powers_cover_residues`: $\\forall r$ coprime to $5^n$, $\\exists k$ with $2^k \\equiv r \\pmod{5^n}$. These are the algebraic foundations of Ruzsa's construction.",
-      "mathContext": "Axiomatizes `primitive_root_order`: $\\text{ord}_{5^n}(2) = \\varphi(5^n) = 4 \\cdot 5^{n-1}$, and `powers_cover_residues`: $\\forall r$ coprime to $5^n$, $\\exists k$ with $2^k \\equiv r \\pmod{5^n}$."
+      "summary": "documents in source comments `primitive_root_order` (no Lean declaration exists): $\\text{ord}_{5^n}(2) = \\varphi(5^n) = 4 \\cdot 5^{n-1}$, and `powers_cover_residues`: $\\forall r$ coprime to $5^n$, $\\exists k$ with $2^k \\equiv r \\pmod{5^n}$. These are the algebraic foundations of Ruzsa's construction.",
+      "mathContext": "documents in source comments `primitive_root_order` (no Lean declaration exists): $\\text{ord}_{5^n}(2) = \\varphi(5^n) = 4 \\cdot 5^{n-1}$, and `powers_cover_residues`: $\\forall r$ coprime to $5^n$, $\\exists k$ with $2^k \\equiv r \\pmod{5^n}$."
     },
     {
       "id": "generalizations",
       "title": "Generalizations to Other Bases",
       "startLine": 190,
       "endLine": 205,
-      "summary": "Defines $\\text{GeneralizedComplement}(g, A)$ for arbitrary base $g$, and axiomatizes `generalization_to_any_base`: for any $g \\geq 2$, sparse complements to $\\{g^k\\}$ exist with density $O(N/\\log N)$.",
-      "mathContext": "Defines $\\text{GeneralizedComplement}(g, A)$ for arbitrary base $g$, and axiomatizes `generalization_to_any_base`: for any $g \\geq 2$, sparse complements to $\\{g^k\\}$ exist with density $$O(N/\\log N)$$."
+      "summary": "Defines $\\text{GeneralizedComplement}(g, A)$ for arbitrary base $g$, and documents in source comments `generalization_to_any_base` (no Lean declaration exists): for any $g \\geq 2$, sparse complements to $\\{g^k\\}$ exist with density $O(N/\\log N)$.",
+      "mathContext": "Defines $\\text{GeneralizedComplement}(g, A)$ for arbitrary base $g$, and documents in source comments `generalization_to_any_base` (no Lean declaration exists): for any $g \\geq 2$, sparse complements to $\\{g^k\\}$ exist with density $$O(N/\\log N)$$."
     },
     {
       "id": "related",
       "title": "Related Sumset Problems",
       "startLine": 206,
       "endLine": 226,
-      "summary": "Axiomatizes `sumset_covering` ($A + \\{2^k\\}$ covers all large integers) and `additive_basis_order_two` ($A \\cup \\text{PowersOfTwo}$ forms a thin additive basis of order 2). Connects to the broader theory of additive bases.",
-      "mathContext": "Axiomatizes `sumset_covering` ($A + \\{2^k\\}$ covers all large integers) and `additive_basis_order_two` ($A \\cup \\text{PowersOfTwo}$ forms a thin additive basis of order 2)."
+      "summary": "documents in source comments `sumset_covering` (no Lean declaration exists) ($A + \\{2^k\\}$ covers all large integers) and `additive_basis_order_two` ($A \\cup \\text{PowersOfTwo}$ forms a thin additive basis of order 2). Connects to the broader theory of additive bases.",
+      "mathContext": "documents in source comments `sumset_covering` (no Lean declaration exists) ($A + \\{2^k\\}$ covers all large integers) and `additive_basis_order_two` ($A \\cup \\text{PowersOfTwo}$ forms a thin additive basis of order 2)."
     },
     {
       "id": "summary",

--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -146,10 +146,10 @@
     {
       "id": "properties",
       "title": "Properties of the Product",
-      "summary": "Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. Axiomatizes `primitive_root_lower_bound`: these evaluation points provide key lower bounds on $f(n)$.",
+      "summary": "Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. documents in source comments `primitive_root_lower_bound` (no Lean declaration exists): these evaluation points provide key lower bounds on $f(n)$.",
       "startLine": 180,
       "endLine": 201,
-      "mathContext": "Verified: Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. Axiomatizes `primitive_root_lower_bound`: these evaluation points provide key lower bounds on $f(n)$."
+      "mathContext": "Verified: Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. documents in source comments `primitive_root_lower_bound` (no Lean declaration exists): these evaluation points provide key lower bounds on $f(n)$."
     },
     {
       "id": "summary-bounds",

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -132,8 +132,8 @@
       "title": "Non-Trivial Covering Refinement",
       "startLine": 173,
       "endLine": 191,
-      "summary": "Defines `HasDistinctModuli`, `IsNonTrivialCovering` ($\\geq 2$ distinct moduli), and `HasNonTrivialCoveringWithDivisorModuli`. Axiomatizes `haight_strong_theorem`: the stronger result excluding non-trivial coverings.",
-      "mathContext": "Defines `HasDistinctModuli`, `IsNonTrivialCovering` ($\\geq 2$ distinct moduli), and `HasNonTrivialCoveringWithDivisorModuli`. Axiomatizes `haight_strong_theorem`: the stronger result excluding non-trivial coverings."
+      "summary": "Defines `HasDistinctModuli`, `IsNonTrivialCovering` ($\\geq 2$ distinct moduli), and `HasNonTrivialCoveringWithDivisorModuli`. documents in source comments `haight_strong_theorem` (no Lean declaration exists): the stronger result excluding non-trivial coverings.",
+      "mathContext": "Defines `HasDistinctModuli`, `IsNonTrivialCovering` ($\\geq 2$ distinct moduli), and `HasNonTrivialCoveringWithDivisorModuli`. documents in source comments `haight_strong_theorem` (no Lean declaration exists): the stronger result excluding non-trivial coverings."
     },
     {
       "id": "covering-properties",


### PR DESCRIPTION
## Fix

Remove phantom Lean identifiers from 11 gallery entries.

## Entries fixed

| Entry | Phantoms removed |
|-------|-----------------|
| erdos-1075 | `threshold_comparison`, `binomial_asymptotic` |
| erdos-1090 | `hales_jewett`, `r3_small`, `sylvester_gallai`, `erdos_1090_generalized` |
| erdos-1098 | `bfc_center_connection`, `infinite_clique_example` |
| erdos-1105 | `ar_turan_lower` |
| erdos-1113 | `covering_set_implies_sierpinski` |
| erdos-1122 | `mangerel_implies_littleO`, `omega_is_additive` |
| erdos-1124 | `pieces_not_measurable` |
| erdos-154 | `even_odd_balance`, `lindstrom_sidon_distribution` |
| erdos-221 | `generalization_to_any_base`, `lorentz_1954`, `primitive_root_order`, `sumset_covering` |
| erdos-256 | `primitive_root_lower_bound` |
| erdos-277 | `haight_strong_theorem` |

**After**: Each replaced with "documents in source comments `X` (no Lean declaration exists)".

---
Automated fix by lean-mechanic agent.