### PR TITLE
fix(meta): sync lineCount for erdos-582 to match actual Lean file

### DIFF
--- a/src/data/proofs/erdos-582/meta.json
+++ b/src/data/proofs/erdos-582/meta.json
@@ -63,7 +63,7 @@
       "Connection to classical Ramsey theory"
     ],
     "axiomCount": 5,
-    "lineCount": 316,
+    "lineCount": 315,
     "assumptions": "5 assumptions: 2 opaque constants (folkmanNumber_2_3_4, folkmanNumber) + 3 axioms (folkman_existence, folkman_lower_bound, folkman_upper_bound). 0 sorries."
   },
   "overview": {
@@ -191,7 +191,7 @@
       "Finset"
     ],
     "namespace": "Erdos582",
-    "lineCount": 317,
+    "lineCount": 315,
     "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Syncs `lineCount` fields in `src/data/proofs/erdos-582/meta.json` to match the actual Lean source file.

## Evidence

**Before**: `meta.lineCount = 316`, `leanFile.lineCount = 317`
**After**: Both set to `315`

The Lean file `Erdos582Problem.lean` has 315 lines (verified via `wc -l`). The two-line discrepancy was introduced by the recent opaque constant replacement in PR #14212/#14218 which removed 2 lines from the file.

---
Automated fix by lean-mechanic agent.