### PR TITLE
fix(meta): clamp section endLine to file lineCount in 2 entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -84,7 +84,7 @@
       "id": "summary",
       "title": "Proof Status Summary",
       "startLine": 177,
-      "endLine": 208,
+      "endLine": 207,
       "summary": "Documents what is proved (fiber decomposition, disjointness, positive decomposition, ENNReal ratio) vs. remaining sorry steps (ncard_biUnion API, uniformOn assembly).",
       "mathContext": "Pipeline: $\\text{fiber\\_card\\_uniform} \\xrightarrow{\\text{ncard\\_biUnion}} |\\text{MCS}| = k|\\text{CS}| \\xrightarrow{\\text{ENNReal}} \\text{uniformOn equality}$. Mathematical content complete; remaining work is Mathlib API navigation."
     }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
@@ -174,7 +174,7 @@
       "id": "commentary",
       "title": "III. Commentary: Significance, Architecture, Mathlib Facts",
       "startLine": 154,
-      "endLine": 191,
+      "endLine": 190,
       "summary": "End-of-file documentation of the WIP01-WIP05 architecture (squarefree → prime-power → general → UFD-wrapped) and an enumerated list of Mathlib facts used. Explains why WIP05 supersedes WIP01's axiom-based version.",
       "mathContext": "Architectural summary of the cluster's axiom-elimination strategy. Documents the dependency chain: WIP02 (squarefree, CRT) → WIP03 (prime power, induction) → WIP04 (general factored, primary decomposition) → WIP05 (UFD factorization wrapper)."
     }


### PR DESCRIPTION
## Fix

Corrects section `endLine` values that exceeded the file's actual line count by 1 in two gallery entries.

## Evidence

**ballot-problem-oq-01-oq-02-oq-01**:
- Section `summary`: `endLine` 208 → 207 (file has 207 lines by `wc -l`)

**cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05**:
- Section `commentary`: `endLine` 191 → 190 (file has 190 lines by `wc -l`)

The off-by-one arises from the final newline convention (`wc -l` counts newlines, so a file ending with `\n` shows one fewer line than `split('\n')` returns). Section annotations should use the `wc -l` convention consistent with `lineCount`.

---
Automated fix by lean-mechanic agent.