### PR TITLE
audit(tracker): mark erdos-547 issues-found (#14275)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7492,10 +7492,13 @@
       "result": "clean"
     },
     "erdos-547": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-erdos-547-phantom-narrative",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T14:48:12Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom narrative: originalContributions/proofStrategy/sections claim IsPath/IsStar/IsCaterpillar/Chvátal bound/exact path-star Ramsey numbers/tightness theorem; Lean file has only 3 axioms + erdos_547 wrapper. Filed #14275"
+      ]
     },
     "erdos-548": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks erdos-547 audit complete with `issues-found` result
- References newly filed integrity issue #14275 (phantom narrative)
- Bumps auditCount 2 → 3, updates lastAudited to 2026-05-01

## Audit findings
The Lean file (`proofs/Proofs/Erdos547Problem.lean`, 132 lines) contains only:
- 2 defs: `EdgeColoring`, `HasMonochromaticCopy`
- 3 axioms: `ramseyNumber`, `IsTree`, `tree_ramsey_bound`
- 1 theorem: `erdos_547` (one-line wrapper around the bound axiom)

But meta.json `originalContributions`/`proofStrategy`/`sections` claim:
- IsPath/IsStar/IsCaterpillar predicates with inclusion proofs and degree axioms
- Exact Ramsey numbers R(P_n) = n and R(S_n) = 2n−2
- Chvátal's degree-dependent bound with comparison analysis
- Tightness and ordering theorems

None of these exist in the Lean source — Parts IV, V, VI, VIII are docstring section headers only.

Numerical fields (`axiomCount: 3`, `sorries: 0`) are correct; the issue is purely narrative scope. See #14275 for the recommended rewrite.

## Test plan
- [x] Tracker JSON parses cleanly (no unicode escaping pollution)
- [x] Diff scoped to single entry (no claim-target.sh `\u2192`/`\u2014` noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)