### PR TITLE
fix(meta): erdos-55 phantom-axiom narrative + section line drift

### DIFF
--- a/src/data/proofs/erdos-55/meta.json
+++ b/src/data/proofs/erdos-55/meta.json
@@ -30,7 +30,7 @@
     "historicalContext": "Erdős Problem #55 sits at the intersection of Ramsey theory and additive number theory. Burr and Erdős introduced the concept of Ramsey r-complete sets in their 1985 paper 'On a Ramsey-type problem in additive number theory' (J. Combin. Theory Ser. A). For r=2, they proved c(log N)² ≤ |A ∩ [1,N]| ≤ C(log N)³, leaving a logarithmic gap between the lower and upper bounds. Burr also showed that the k-th powers are Ramsey r-complete for all r,k ≥ 1, providing natural examples but with polynomial (not logarithmic) growth. The problem carried a $250 Erdős prize and remained open for 36 years. In 2021, David Conlon, Jacob Fox, and Huy Tung Pham completely resolved the problem in their paper 'Subset sums, completeness and colorings' (Advances in Mathematics, 2021), proving that the optimal growth rate for r-Ramsey complete sets is Θ(r(log N)²). Their construction uses carefully chosen subsets of powers of 2, while the lower bound extends the Burr-Erdős probabilistic coloring technique to r colors. The linear dependence on r is sharp, revealing the precise cost of additional colors.",
     "problemStatement": "A set of integers A is Ramsey r-complete if, whenever A is r-coloured, all sufficiently large integers can be written as a monochromatic sum of elements of A. Prove any non-trivial bounds about the growth rate of such an A for r > 2.",
     "text": "A set A is Ramsey r-complete if every r-coloring has a monochromatic subset whose sums cover all large integers. The optimal growth rate is Θ(r(log N)²).",
-    "proofStrategy": "The formalization defines Ramsey r-completeness via r-colorings (functions A → Fin r), monochromatic subsets, and finite sums. Growth rate predicates HasGrowthAtMost and HasGrowthAtLeast capture big-O and big-Ω bounds. The main results — Burr-Erdős bounds (1985) and Conlon-Fox-Pham bounds (2021) — are stated as axioms. Two theorems are then proved: erdos_55_solution combines both CFP bounds into the complete Θ(r(log N)²) characterization, and optimal_growth_r2 derives the r=2 special case with careful constant manipulation using ring and linarith.",
+    "proofStrategy": "The formalization defines Ramsey r-completeness via r-colorings (functions A → Fin r), monochromatic subsets, and finite sums. Growth rate predicates HasGrowthAtMost and HasGrowthAtLeast capture big-O and big-Ω bounds. The Conlon-Fox-Pham bounds (2021) — upper and lower — are stated as axioms (`cfp_upper_bound`, `cfp_lower_bound`). The Burr-Erdős (1985) historical results appear as docstrings only; no Burr-Erdős axioms or theorems are declared in this file. Two theorems are then proved: erdos_55_solution combines both CFP axioms into the complete Θ(r(log N)²) characterization, and optimal_growth_r2 derives the r=2 special case with careful constant manipulation using ring and linarith.",
     "keyInsights": [
       "**Tight characterization**: The optimal growth rate for $r$-Ramsey complete sets is exactly $\\Theta(r(\\log N)^2)$, resolved by Conlon-Fox-Pham (2021)",
       "**Linear dependence on $r$**: The factor $r$ in $Cr(\\log N)^2$ is optimal — more colors require proportionally denser sets",
@@ -75,54 +75,54 @@
       "title": "Burr-Erdős Lower Bound (1985)",
       "summary": "For $r=2$: $\\exists\\,c > 0$ such that no Ramsey 2-complete set satisfies $|A \\cap [1,N]| \\leq c(\\log N)^2$",
       "startLine": 68,
-      "endLine": 81,
-      "mathContext": "Mathematical content: For $r=2$: $\\exists\\,c > 0$ such that no Ramsey 2-complete set satisfies $|A \\cap [1,N]| \\leq c(\\log N)^2$"
+      "endLine": 76,
+      "mathContext": "Historical context (docstring only): For $r=2$, Burr-Erdős (1985) showed $c(\\log N)^2 \\leq |A \\cap [1,N]|$. This result appears as a docstring in the source; no Lean axiom or theorem declares it."
     },
     {
       "id": "burr-erdos-upper",
       "title": "Burr-Erdős Upper Bound and Burr's Theorem",
       "summary": "Upper bound $(\\log N)^3$ for $r=2$ and Burr's theorem that $k$-th powers are Ramsey $r$-complete for all $r,k \\geq 1$",
-      "startLine": 82,
-      "endLine": 95,
-      "mathContext": "Verified: Upper bound $(\\log N)^3$ for $r=2$ and Burr's theorem that $k$-th powers are Ramsey $r$-complete for all $r,k \\geq 1$"
+      "startLine": 77,
+      "endLine": 83,
+      "mathContext": "Historical context (docstring only): Burr-Erdős (1985) upper bound $|A \\cap [1,N]| \\leq C(\\log N)^3$ for $r=2$, and Burr's theorem that $k$-th powers are Ramsey $r$-complete. These results appear as docstrings only; no Lean declarations formalize them in this file."
     },
     {
       "id": "cfp-upper",
       "title": "Conlon-Fox-Pham Upper Bound (2021)",
       "summary": "For all $r \\geq 2$: $\\exists$ Ramsey $r$-complete $A$ with $|A \\cap [1,N]| \\leq Cr(\\log N)^2$",
-      "startLine": 96,
-      "endLine": 108,
+      "startLine": 84,
+      "endLine": 95,
       "mathContext": "Mathematical content: For all $r \\geq 2$: $\\exists$ Ramsey $r$-complete $A$ with $|A \\cap [1,N]| \\leq Cr(\\log N)^2$"
     },
     {
       "id": "cfp-lower",
       "title": "Conlon-Fox-Pham Lower Bound (2021)",
       "summary": "Universal $c > 0$: if $|A \\cap [1,N]| \\leq cr(\\log N)^2$ then $A$ is not $r$-Ramsey complete",
-      "startLine": 109,
-      "endLine": 121,
+      "startLine": 96,
+      "endLine": 108,
       "mathContext": "Mathematical content: Universal $c > 0$: if $|A \\cap [1,N]| \\leq cr(\\log N)^2$ then $A$ is not $r$-Ramsey complete"
     },
     {
       "id": "main-solution",
       "title": "Complete Solution: Θ(r(log N)²)",
       "summary": "Theorem `erdos_55_solution`: combines CFP upper and lower bounds into the tight $\\Theta(r(\\log N)^2)$ characterization",
-      "startLine": 122,
-      "endLine": 143,
+      "startLine": 109,
+      "endLine": 130,
       "mathContext": "Verified: Theorem `erdos_55_solution`: combines CFP upper and lower bounds into the tight $\\Theta(r(\\log N)^2)$ characterization"
     },
     {
       "id": "r2-corollary",
       "title": "Corollary: Optimal Growth for r=2",
       "summary": "Derives $\\Theta((\\log N)^2)$ for $r=2$ from the general bounds, closing the Burr-Erdős gap via `ring` and `linarith`",
-      "startLine": 144,
-      "endLine": 173,
+      "startLine": 132,
+      "endLine": 160,
       "mathContext": "Bound: Derives $\\Theta((\\log N)^2)$ for $r=2$ from the general bounds, closing the Burr-Erdős gap via `ring` and `linarith`"
     },
     {
       "id": "historical-notes",
       "title": "Historical Notes and References",
       "summary": "Timeline from Burr-Erdős (1985) through Conlon-Fox-Pham (2021), construction techniques, and key references",
-      "startLine": 174,
+      "startLine": 162,
       "endLine": 181,
       "mathContext": "Mathematical content: Timeline from Burr-Erdős (1985) through Conlon-Fox-Pham (2021), construction techniques, and key references"
     }


### PR DESCRIPTION
## Fix

Corrects two integrity issues in `src/data/proofs/erdos-55/meta.json` found by the auditor.

## Evidence

**Issue 1 — Phantom-axiom narrative in `proofStrategy`:**
- **Before**: claimed "Burr-Erdős bounds (1985) and Conlon-Fox-Pham bounds (2021) — are stated as axioms"
- **After**: accurately states only CFP bounds are axioms (`cfp_upper_bound`, `cfp_lower_bound`); Burr-Erdős results appear as docstrings only

**Issue 2 — Section line ranges shifted 3-10 lines off:**
| Section | Old range | Corrected range |
|---------|-----------|-----------------|
| `burr-erdos-lower` | 68–81 | 68–76 |
| `burr-erdos-upper` | 82–95 | 77–83 |
| `cfp-upper` | 96–108 | 84–95 |
| `cfp-lower` | 109–121 | 96–108 |
| `main-solution` | 122–143 | 109–130 |
| `r2-corollary` | 144–173 | 132–160 |
| `historical-notes` | 174–181 | 162–181 |

**Issue 3 — Phantom sections `burr-erdos-lower`/`burr-erdos-upper` claimed "Verified":**
- **Before**: `mathContext` used "Verified:" prefix implying Lean declarations exist
- **After**: corrected to "Historical context (docstring only):" accurately describing what's in the source

Closes #14274

---
Automated fix by lean-mechanic agent.