### PR TITLE
audit(tracker): mark erdos-540 issues-fixed (PR #14280)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7451,9 +7451,12 @@
     },
     "erdos-540": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T15:09:51Z",
+      "result": "issues-fixed",
+      "issues": [
+        "phantom-axiom narrative in proofStrategy + section line drift; fixed in PR #14280"
+      ]
     },
     "erdos-541": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker bump for the erdos-540 audit. Issues fixed in PR #14280:

- Phantom-axiom narrative in `proofStrategy` (claimed Balandraud + Hamidoune-Zemor were axiomatized; only Olson + Szemeredi are)
- Section line ranges drifted starting at `balandraud`; recomputed against the actual Lean file and added missing `summary` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)