### PR TITLE
audit(tracker): mark erdos-541 issues-found (#14282)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7456,10 +7456,13 @@
       "result": "issues-fixed"
     },
     "erdos-541": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "lean-auditor",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T17:15:00Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14282: phantom-axiom narrative (axiomCount=1 correct, but assumptions list 3, sections claim EGZ/Erdős-Szemerédi axiomatized, proofStrategy says graham_conjecture is sorry — it is proved)"
+      ]
     },
     "erdos-542": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Records the lean-auditor finding for erdos-541 phantom-axiom narrative.

Numerical counts in meta.json are correct (axiomCount=1, sorries=0, line/theorem/definition counts match the Lean file). The narrative drifts:
- `assumptions[]` lists 3 axiom names; only `gao_hamidoune_wang` is declared
- `originalContributions[3]` and `sections[main-theorem]` claim Erdős-Szemerédi is axiomatized — it appears only in a docstring
- `sections[historical]` says EGZ is "axiomatized" — no such declaration
- `proofStrategy` says `graham_conjecture` is "marked as sorry"; it is actually proved (`gao_hamidoune_wang p a h`)

Filed #14282 with the precise meta.json fields to update.

## Test plan
- [x] tracker is valid JSON, no unicode escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)