### PR TITLE
audit(tracker): mark erdos-535 issues-found (#14284)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7414,10 +7414,13 @@
       "result": "clean"
     },
     "erdos-535": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-64117",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T15:24:33Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom-axiom narrative + section line drift (#14284)"
+      ]
     },
     "erdos-536": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- Updates `src/data/proofs/audit-tracker.json` for `erdos-535`
- Records audit result `issues-found` referencing #14284
- No unicode escape pollution (regenerated via `ensure_ascii=False`)

Discovered narrative discrepancies in #14284:
- `proofStrategy` lists an Erdős 1964 $N^{3/4}$ upper bound that has no axiom/theorem declaration (docstring only)
- Sections `erdos-upper`, `abbott-hanson`, `lower-bound` claim axioms that aren't in their line ranges; the two real axioms (`abbott_hanson_upper_bound` line 91, `erdos_lower_bound` line 110) sit on section boundaries

## Test plan

- [ ] CI lint passes (tracker JSON validity)
- [ ] Diff is tracker-only, no incidental file changes