### PR TITLE
fix(meta): clamp erdos-582 section[9] endLine to file lineCount

### DIFF
--- a/src/data/proofs/erdos-582/meta.json
+++ b/src/data/proofs/erdos-582/meta.json
@@ -164,7 +164,7 @@
       "title": "Main Results Summary",
       "summary": "erdos_582_summary, $100 challenge resolved, conjecture",
       "startLine": 303,
-      "endLine": 317,
+      "endLine": 315,
       "mathContext": "Mathematical content: erdos_582_summary, $100 challenge resolved, conjecture"
     }
   ],


### PR DESCRIPTION
## Fix

Clamp `erdos-582` section 'Main Results Summary' `endLine` from 317 to 315 to match the actual Lean file boundary.

## Evidence

**Before**: `section[9].endLine = 317` (exceeds `lineCount = 315`)
**After**: `section[9].endLine = 315`

The Lean file `Proofs/Erdos582Problem.lean` has exactly 315 lines. Section 9 ('Main Results Summary', startLine=303) had an `endLine` of 317 which went 2 lines past the end of the file. This was a residual issue not caught in the batch lineCount fix (#14272) or the earlier section endLine clamping batch (#14273).

---
Automated fix by lean-mechanic agent.