### PR TITLE
audit(tracker): mark erdos-536 issues-found (#14286)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7420,10 +7420,13 @@
       "result": "issues-fixed"
     },
     "erdos-536": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "issues": [
+        "phantom-axiom narrative + section line drift: prose claims four_elements_fail/weisenberg_construction axiomatized (only docstrings), and lcm_structure/weisenberg_dense_case as axioms (both are theorems). Filed #14286"
+      ],
+      "lastAudited": "2026-05-01T15:33:04Z",
+      "result": "issues-found"
     },
     "erdos-537": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Records the lean-auditor finding for erdos-536 phantom-axiom narrative.

Numerical counts in meta.json are correct (axiomCount=1, sorries=0; the `assumptions` string accurately states "1 axiom: erdos_536_conjecture. 0 sorries."). The narrative drifts:

- `originalContributions[3,4]`: claims `four_elements_fail` and `weisenberg_construction` are stated; they appear only in docstrings — no declarations.
- `sections[weisenberg]`: claims "Three axiomatized results" — but `weisenberg_dense_case` is a theorem (proven via `erdos_536_conjecture (221/225) ...`), and the other two are docstring-only.
- `sections[observations]`: says `lcm_structure` is "axiomatized"; the file declares it as a theorem with a proof body.
- `proofStrategy`: cites "88 lines" (file is 83) and wrong location for `lcm_structure` (claimed 82–84 vs actual 73–80).
- Section line drift: `## Observations` heading is at line 65 in the Lean file, but `sections[observations].startLine` is 77.

Filed #14286 with the precise meta.json fields to update.

## Test plan
- [x] tracker is valid JSON, no unicode escape pollution