### PR TITLE
audit(tracker): mark erdos-532 issues-found (#14289)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7397,9 +7397,12 @@
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T15:43:01Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14289: phantom-axiom narrative (axiomCount=2 correct, but originalContributions claims 3 ultrafilter/Hales-Jewett axioms that are docstring-only) + section line drift Parts VI-IX (~20-30 lines off)"
+      ]
     },
     "erdos-533": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks `erdos-532` (Hindman's Theorem) as `issues-found` after audit found phantom-axiom narrative drift. Filed issue #14289.

- `axiomCount=2` is correct (`hindman_theorem`, `hindman_finite_exists`)
- `overview.originalContributions` claims 3 ultrafilter/Hales-Jewett axioms that are docstring-only in `proofs/Proofs/Erdos532Problem.lean`
- Sections Parts VI–IX (`ultrafilter`, `hales-jewett`, `computational`, `summary`) line ranges drift by ~20–30 lines

## Test plan
- [x] Tracker rewrites without unicode-escape pollution (used `ensure_ascii=False`)
- [x] Diff is minimal — only `erdos-532` entry touched