### PR TITLE
fix(meta): erdos-535 phantom-axiom narrative + section line drift

### DIFF
--- a/src/data/proofs/erdos-535/meta.json
+++ b/src/data/proofs/erdos-535/meta.json
@@ -31,7 +31,7 @@
     "historicalContext": "**Erdős Problem #535** connects number theory to extremal combinatorics through $\\gcd$-defined hypergraphs. The function $f_r(N)$ measures the maximum size of a subset $A \\subseteq \\{1, \\ldots, N\\}$ such that no $r$ elements share the same pairwise $\\gcd$.\n\nErdős first studied this in 1964 in his paper 'On a problem in elementary number theory and a combinatorial problem,' establishing both the first non-trivial upper bound $f_r(N) \\leq N^{3/4+o(1)}$ via double-counting arguments, and the lower bound $f_3(N) > N^{c/\\log \\log N}$ using multiplicative constructions with smooth numbers. Abbott and Hanson (1970) improved the upper bound to $f_r(N) \\leq N^{1/2+o(1)}$ in *Bull. London Math. Soc.*, using the insight that $\\gcd$-cliques correspond to cliques in auxiliary graphs, then applying Turán's theorem.\n\nThe gap between the polynomial upper bound $N^{1/2}$ and the quasi-polynomial lower bound $N^{c/\\log \\log N}$ is enormous — it spans the entire range between polynomial and sub-polynomial growth rates. Erdős conjectured that the lower bound is tight: $f_r(N) \\leq N^{c/\\log \\log N}$. This conjecture would follow from a strengthened version of the Erdős-Rado Sunflower Lemma (1960), specifically removing the factorial factor from the sunflower bound. The recent breakthrough by Alweiss, Lovett, Wu, and Zhang (2020) on the sunflower conjecture, improving the bound to $(C \\log k)^k$, represents significant progress but does not yet resolve Problem #535.",
     "problemStatement": "For $r \\geq 3$, let $f_r(N)$ denote the maximum size of $A \\subseteq \\{1, \\ldots, N\\}$ such that no $r$ elements $a_1, \\ldots, a_r \\in A$ satisfy $\\gcd(a_i, a_j) = d$ for all $i \\neq j$ (no $r$-element $d$-clique). Estimate $f_r(N)$.\n\n**Status: OPEN** — gap between $N^{1/2+o(1)}$ (upper) and $N^{c/\\log \\log N}$ (lower).",
     "text": "For r ≥ 3, estimate f_r(N): the maximum size of A ⊆ {1,...,N} with no r elements having equal pairwise gcds. Known: N^{1/2+o(1)} upper (Abbott-Hanson), N^{c/log log N} lower (Erdős). Gap remains open.",
-    "proofStrategy": "**Formalization Structure:**\n\n1. **Definitions (lines 43–64):** `HasNoRGCDSubset` and `HasNoGCDClique` capture the $\\gcd$-clique-free property; `f(r, N)` is the extremal function via `sSup`.\n\n2. **Upper Bounds (lines 66–110):** Trivial bound $f_r(N) \\leq N$, Erdős's $N^{3/4}$ (1964), and Abbott-Hanson's $N^{1/2}$ (1970), with `exponent_improvement` verifying $3/4 > 1/2$.\n\n3. **Lower Bound (lines 112–126):** Erdős's quasi-polynomial construction $f_3(N) > N^{c/\\log \\log N}$.\n\n4. **Conjecture and Sunflower (lines 128–162):** `ErdosConjecture` and the reduction to a stronger Sunflower Lemma.\n\n5. **Summary (lines 192–220):** Conjunction of Abbott-Hanson and Erdős bounds.",
+    "proofStrategy": "**Formalization Structure:**\n\n1. **Definitions (lines 43–64):** `HasNoRGCDSubset` and `HasNoGCDClique` capture the $\\gcd$-clique-free property; `f(r, N)` is the extremal function via `sSup`.\n\n2. **Upper Bounds (lines 66–110):** The trivial bound $f_r(N) \\leq N$ (lines 66–75) and Erdős's $N^{3/4+o(1)}$ (1964) (lines 76–85) are discussed in docstring comments but not axiomatized. Abbott-Hanson's $N^{1/2+o(1)}$ (1970) is axiomatized via `abbott_hanson_upper_bound` (line 91); `exponent_improvement` verifies $3/4 > 1/2$.\n\n3. **Lower Bound (lines 112–126):** Erdős's quasi-polynomial construction $f_3(N) > N^{c/\\log \\log N}$.\n\n4. **Conjecture and Sunflower (lines 128–162):** `ErdosConjecture` and the reduction to a stronger Sunflower Lemma.\n\n5. **Summary (lines 192–220):** Conjunction of Abbott-Hanson and Erdős bounds.",
     "keyInsights": [
       "**Turán-type Hypergraph Problem:** $f_r(N)$ is the independence number of the $r$-uniform $\\gcd$-hypergraph on $\\{1, \\ldots, N\\}$, connecting number-theoretic structure to combinatorial extremal theory",
       "**Polynomial vs Quasi-Polynomial Gap:** The upper bound $N^{1/2+o(1)}$ and lower bound $N^{c/\\log \\log N}$ differ by an enormous factor — one of the widest open gaps in combinatorial number theory",
@@ -72,16 +72,16 @@
     {
       "id": "erdos-upper",
       "title": "Erdős's Original Upper Bound (1964)",
-      "summary": "Axiom: $f_r(N) \\leq N^{3/4+o(1)}$ via double-counting arguments on divisor pairs",
+      "summary": "Historical discussion of Erdős's 1964 result $f_r(N) \\leq N^{3/4+o(1)}$; documented in docstring comments only, not axiomatized. The `abbott_hanson_upper_bound` axiom is declared at line 91 in the following section.",
       "startLine": 78,
-      "endLine": 92,
-      "mathContext": "Axiomatized: Axiom: $f_r(N) \\leq N^{3/4+o(1)}$ via double-counting arguments on divisor pairs"
+      "endLine": 85,
+      "mathContext": "Discussed in docstrings only: $f_r(N) \\leq N^{3/4+o(1)}$ (Erdős 1964, not axiomatized)."
     },
     {
       "id": "abbott-hanson",
       "title": "Abbott-Hanson Upper Bound (1970)",
       "summary": "Axiom: $f_r(N) \\leq N^{1/2+o(1)}$ via auxiliary graph construction and Turán's theorem; `exponent_improvement` verifies $3/4 > 1/2$",
-      "startLine": 93,
+      "startLine": 86,
       "endLine": 111,
       "mathContext": "Verified: Axiom: $f_r(N) \\leq N^{1/2+o(1)}$ via auxiliary graph construction and Turán's theorem; `exponent_improvement` verifies $3/4 > 1/2$"
     },
@@ -89,7 +89,7 @@
       "id": "lower-bound",
       "title": "Erdős's Lower Bound",
       "summary": "Axiom: $f_3(N) > N^{c/\\log \\log N}$ using smooth numbers with $\\leq k$ prime factors for $k \\sim \\log \\log N$",
-      "startLine": 112,
+      "startLine": 105,
       "endLine": 127,
       "mathContext": "Axiomatized: Axiom: $f_3(N) > N^{c/\\log \\log N}$ using smooth numbers with $\\leq k$ prime factors for $k \\sim \\log \\log N$"
     },


### PR DESCRIPTION
## Fix

Reconcile `src/data/proofs/erdos-535/meta.json` narrative and section boundaries with the actual Lean file.

## Evidence

**Before**:
- `sections[erdos-upper]` (endLine 92) summary claimed "Axiom: $f_r(N) \leq N^{3/4+o(1)}$" — no such axiom exists; lines 78–92 are docstring-only discussion
- `sections[abbott-hanson]` (startLine 93) missed `abbott_hanson_upper_bound` declared at line 91
- `sections[lower-bound]` (startLine 112) missed `erdos_lower_bound` declared at line 110
- `overview.proofStrategy` listed trivial and Erdős $N^{3/4}$ bounds as axiomatized alongside Abbott-Hanson

**After**:
- `sections[erdos-upper]` endLine: 92 → 85; summary corrected to "historical docstring discussion, not axiomatized"
- `sections[abbott-hanson]` startLine: 93 → 86 (captures axiom at line 91)
- `sections[lower-bound]` startLine: 112 → 105 (captures axiom at line 110)
- `overview.proofStrategy` distinguishes docstring-only bounds from the two axiomatized ones

Numerical fields (`axiomCount: 2`, `sorries: 0`) were already correct and are unchanged.

Closes #14284

---
Automated fix by lean-mechanic agent.