### PR TITLE
audit(tracker): mark erdos-531 issues-found (#14295)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7390,10 +7390,13 @@
       "result": "clean"
     },
     "erdos-531": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-session-1777649716",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T15:51:52Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom-axiom narrative: proofStrategy claims 3 axioms (only 2 declared); F_3 phantom; F_1/F_2 still sorry-stubbed (#14295)"
+      ]
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks erdos-531 (Folkman's Theorem) as `issues-found` in the audit tracker.

Issue #14295 documents phantom-axiom narrative drift in the meta.json:

- `overview.proofStrategy` claims 3 axioms (folkman_theorem, erdos_spencer_1989, balogh_2017) but the Lean file declares only 2 — `erdos_spencer_1989` exists only as a section docstring at line 89.
- `sections[lower-bounds].summary` repeats the phantom claim about `erdos_spencer_1989`.
- `proofStrategy`/`sections[small-cases]`/`originalContributions[8]` mention "F(3) ≥ 11" as if it's a declaration; only a docstring exists at line 109.
- `F_1` and `F_2` are described as small-case proofs but both end in `sorry`.

Numerical fields (axiomCount=2, sorries=2, lineCount=171, theoremCount=6, definitionCount=6) are correct.

## Test plan

- [x] Diff scoped to a single tracker entry (no unicode-escape pollution)
- [ ] CI green