### PR TITLE
audit(tracker): mark erdos-525 issues-found (#14297)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7343,9 +7343,12 @@
     },
     "erdos-525": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T16:02:08Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14297: phantom-axiom narrative (5 phantom axioms in originalContributions: littlewood_count, has_small_value_iff_min_lt_one, konyagin_exponent_tight, konyagin_schlag_lower_tail, rudin_shapiro_bound) + section line drift across all 9 sections"
+      ]
     },
     "erdos-525-oq-02": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- Marks erdos-525 as `issues-found` in `src/data/proofs/audit-tracker.json` after filing #14297.
- Bumps `auditCount` 2→3, sets `lastAudited` to 2026-05-01T16:02:08Z.
- Records issue note for the phantom-axiom narrative (5 phantom axioms) and section line drift across all 9 sections.

Numerical counts in meta.json (5 axioms, 202 lines, 3 theorems, 10 defs) match the Lean file — only narrative and section ranges are stale.

## Test plan
- [x] `git diff src/data/proofs/audit-tracker.json` shows only the erdos-525 entry change (6 lines)
- [x] No unicode-escape pollution from python json.dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)