### PR TITLE
fix(meta): erdos-532 phantom-axiom narrative + section line drift

### DIFF
--- a/src/data/proofs/erdos-532/meta.json
+++ b/src/data/proofs/erdos-532/meta.json
@@ -53,9 +53,9 @@
       "Proved IP set infinitude from singleton membership",
       "Singleton membership in FS(A) for a ∈ A",
       "Disjoint sum closure for FS(A)",
-      "Idempotent ultrafilter existence axiom with IP-set property",
-      "Ultrafilter implies Hindman axiom (modern proof path)",
-      "Hales-Jewett implies Hindman axiom (alternative proof path)",
+      "Ultrafilter proof strategy described in docstring (idempotent ultrafilters in (βℕ, +)); no Lean declaration",
+      "Modern ultrafilter proof path sketched in docstring; no Lean declaration",
+      "Hales-Jewett connection sketched in docstring; no Lean declaration",
       "Finite Hindman theorem axiom and Hindman numbers definition"
     ],
     "axiomCount": 2,
@@ -128,30 +128,30 @@
       "title": "Ultrafilter Proof (Modern Approach)",
       "summary": "Idempotent ultrafilters in (βℕ, +) and ultrafilter proof strategy",
       "startLine": 202,
-      "endLine": 248,
-      "mathContext": "Verified: Idempotent ultrafilters in (βℕ, +) and ultrafilter proof strategy"
+      "endLine": 227,
+      "mathContext": "Narrative: docstring-only description of the ultrafilter proof strategy via idempotent ultrafilters in (βℕ, +); no Lean declarations in this section"
     },
     {
       "id": "hales-jewett",
       "title": "Hales-Jewett Connection",
       "summary": "Deriving Hindman from Hales-Jewett theorem",
-      "startLine": 249,
-      "endLine": 266,
-      "mathContext": "Verified: Deriving Hindman from Hales-Jewett theorem"
+      "startLine": 228,
+      "endLine": 240,
+      "mathContext": "Narrative: docstring-only sketch of deriving Hindman from the Hales-Jewett theorem; no Lean declarations in this section"
     },
     {
       "id": "computational",
       "title": "Computational Aspects",
       "summary": "Hindman numbers and the finite version",
-      "startLine": 267,
-      "endLine": 294,
+      "startLine": 241,
+      "endLine": 268,
       "mathContext": "Mathematical content: Hindman numbers and the finite version"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Problem status, combined results, and impact",
-      "startLine": 295,
+      "startLine": 269,
       "endLine": 303,
       "mathContext": "Mathematical content: Problem status, combined results, and impact"
     }


### PR DESCRIPTION
## Fix

Corrects phantom-axiom narrative drift and section line range drift in `src/data/proofs/erdos-532/meta.json` for Hindman's Theorem (IP Sets).

## Evidence

**`originalContributions` phantom axioms (Before)**:
- "Idempotent ultrafilter existence axiom with IP-set property" — docstring-only (lines 206–216), no declaration
- "Ultrafilter implies Hindman axiom (modern proof path)" — docstring-only (lines 217–227), no declaration
- "Hales-Jewett implies Hindman axiom (alternative proof path)" — docstring-only (lines 232–240), no declaration

**After**: downgraded to "described/sketched in docstring; no Lean declaration"

**`sections.mathContext` mislabels (Before)**:
- `ultrafilter`: "Verified: Idempotent ultrafilters..." — no declarations in this section
- `hales-jewett`: "Verified: Deriving Hindman..." — no declarations in this section

**After**: replaced "Verified:" with "Narrative: docstring-only..."

**Section line drift (Before → After)**:
| section | before | after |
|---|---|---|
| ultrafilter | endLine: 248 | endLine: 227 |
| hales-jewett | startLine: 249, endLine: 266 | startLine: 228, endLine: 240 |
| computational | startLine: 267, endLine: 294 | startLine: 241, endLine: 268 |
| summary | startLine: 295 | startLine: 269 |

Numerical fields (`axiomCount: 2`, `sorries: 0`, theorem/definition counts) are correct and left unchanged.

Closes #14289

---
Automated fix by lean-mechanic agent.