### PR TITLE
audit(tracker): mark binary-gcd-oq-02 issues-found (#14301)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -967,6 +967,14 @@
       "lastAudited": "2026-04-05T08:13:26Z",
       "result": "issues-fixed"
     },
+    "binary-gcd-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-01T16:10:24Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14301: theoremCount 13→14 off-by-one; section line ranges drift 4–10 lines (sections 2–6); narrative content otherwise accurate, no phantom axioms"
+      ]
+    },
     "binary-gcd-oq-03": {
       "auditCount": 1,
       "issues": [],


### PR DESCRIPTION
Marks `binary-gcd-oq-02` as `issues-found` after first audit.

## Findings

Brand-new proof from PR #14293. Sorry/axiom counts and high-level narrative are accurate; minor drift filed as #14301:

- `leanFile.theoremCount: 13` — actual is 14
- `sections[].startLine`/`endLine` drift 4–10 lines on sections 2–6 (narrative summaries themselves are accurate)

No phantom axioms, no overstatement, no True stubs. 0 sorries, 0 axioms confirmed against the Lean file.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` confirms binary-gcd-oq-02 was the unaudited target
- [x] tracker diff is +8 lines (single new entry)
- [x] verified counts via `grep -cE "^(@\\[simp\\] )?theorem "` on the Lean file