### PR TITLE
audit(tracker): mark binary-gcd-oq-02 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13363,6 +13363,12 @@
       "issues": [
         "badge=original for proof whose reduction lemmas are 1-line Mathlib wrappers; tracked in #14250 + PR #14251"
       ]
+    },
+    "binary-gcd-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-01T16:19:22Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Marks `binary-gcd-oq-02` (Int extension of Stein's binary GCD, merged in #14293) as audited clean.

## Audit findings

- **Sorries**: 0 (matches meta.json)
- **Axioms**: 0 (matches meta.json)
- **True stubs**: none
- **Status `verified`**: justified — file is sorry-free, axiom-free
- **Badge `original`**: justified — the natAbs bridge construction (`binaryGcdInt` def + `binaryGcdInt_eq_intGcd`) is novel; the parent algorithm correctness `binaryGcd_eq_gcd` lives in in-repo file `Proofs.GcdAlgorithmOQ02`, not Mathlib
- **Mathlib dependencies** disclosed honestly: `Int.gcd`, `Int.gcd_dvd_left/right`, `Int.dvd_gcd`, `Int.gcd_comm`, `Int.gcd_self` — used to derive divisibility/comm/self via the bridge, not for the main result
- **Section line ranges**: minor 1–3 line drift (low priority)

## Test plan

- [x] meta.json read from origin/main
- [x] Lean file (`proofs/Proofs/BinaryGcdOQ02.lean`) read from origin/main
- [x] grep confirms 0 sorries, 0 axiom declarations
- [x] No True stubs
- [x] tracker JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)