### PR TITLE
audit(tracker): mark erdos-526 issues-found (#14308)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -969,11 +969,9 @@
     },
     "binary-gcd-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-05-01T16:10:24Z",
-      "result": "issues-found",
-      "issues": [
-        "Issue #14301: theoremCount 13→14 off-by-one; section line ranges drift 4–10 lines (sections 2–6); narrative content otherwise accurate, no phantom axioms"
-      ]
+      "lastAudited": "2026-05-01T16:19:22Z",
+      "result": "clean",
+      "issues": []
     },
     "binary-gcd-oq-03": {
       "auditCount": 1,
@@ -7366,9 +7364,9 @@
     },
     "erdos-526": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T16:29:56Z",
+      "result": "issues-found"
     },
     "erdos-527": {
       "agentId": "auditor-cycle-20-batch",
@@ -13371,12 +13369,6 @@
       "issues": [
         "badge=original for proof whose reduction lemmas are 1-line Mathlib wrappers; tracked in #14250 + PR #14251"
       ]
-    },
-    "binary-gcd-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-01T16:19:22Z",
-      "result": "clean",
-      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

- Marks erdos-526 audit result as `issues-found` (filed #14308)
- Numerical claims (sorries=0, axiomCount=4, status=`axiomatized`) verified correct
- Issues found: phantom items in `originalContributions` (`superCriticalSeq`/`subCriticalSeq` constructions exist only as docstrings) + section drift on `poisson-connection`
- Side-effect: collapses a duplicate `binary-gcd-oq-02` entry whose older `issues-found` value was silently shadowed by a more recent `clean` value

## Test plan

- [x] `git show HEAD:src/data/proofs/audit-tracker.json | python3 -c "import json,sys; json.load(sys.stdin)"` parses cleanly
- [x] `entries.erdos-526.result == "issues-found"` and lastAudited reflects this audit
- [x] Diff reviewed — no unicode-escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)