### PR TITLE
audit(tracker): mark erdos-522 issues-found (#14311)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7332,10 +7332,12 @@
       "result": "issues-fixed"
     },
     "erdos-522": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T16:49:06Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14311: proofStrategy claims phantom Erdős-Offord/Yakir/almost-sure-convergence axioms; root-counting section misclaimed as axiomatized; assumptions misnames axiom (KacPolynomialData → KacPolynomialData.isRademacher)"
+      ]
     },
     "erdos-523": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Mark erdos-522 as `issues-found` in audit-tracker
- Issue: #14311 (phantom-axiom narrative + section misclassification)

## Findings

The Lean file `proofs/Proofs/Erdos522Problem.lean` declares **exactly 1 axiom** (`KacPolynomialData.isRademacher`), and `meta.axiomCount`, `leanFile.axiomCount`, and `originalContributions` all correctly reflect that. The phantom claims live in narrative text:

1. `overview.proofStrategy` describes axiomatizing the Erdős-Offord theorem, Yakir's theorem, and the almost-sure-convergence open question — none of these are actually declared as axioms in the file.
2. `sections[].root-counting` (lines 136–146) is labelled "Axiomatized root counting function for the unit disk", but the file only contains docstrings in that range; no axiom or definition is declared.
3. `assumptions` reads "1 axiom: KacPolynomialData" — should be "1 axiom: KacPolynomialData.isRademacher" (KacPolynomialData itself is a structure, not an axiom).

## Test plan

- [ ] No code changes; the Lean source is untouched.
- [ ] Tracker JSON parses correctly (validated locally).
- [ ] Unicode characters (Erdős, →) preserved as literal UTF-8, not escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)