### PR TITLE
fix(meta): erdos-526 phantom-contributions + section line drift

### DIFF
--- a/src/data/proofs/erdos-526/meta.json
+++ b/src/data/proofs/erdos-526/meta.json
@@ -57,11 +57,8 @@
       "partialSum formalization",
       "SheppCriterion predicate",
       "CoversWithProbOne definition",
-      "superCriticalSeq and subCriticalSeq constructions",
       "criticalSeq at 1/n boundary",
       "Shepp's theorem axiomatization",
-      "Harmonic series and Basel problem references",
-      "Euler-Mascheroni constant bound",
       "Main theorem combining all results"
     ],
     "axiomCount": 4,
@@ -128,8 +125,8 @@
     {
       "id": "poisson-connection",
       "title": "Poisson Connection",
-      "startLine": 201,
-      "endLine": 242,
+      "startLine": 177,
+      "endLine": 194,
       "summary": "Proof techniques via Poisson processes"
     }
   ],


### PR DESCRIPTION
## Fix

Corrects two narrative inflation issues in `src/data/proofs/erdos-526/meta.json` — numerical metadata was already correct.

## Evidence

**Phantom `originalContributions` (3 removed):**
- `"superCriticalSeq and subCriticalSeq constructions"` — no `axiom`/`def`/`structure` by these names; lines 119-142 are doc comments only
- `"Harmonic series and Basel problem references"` — docstring prose only (Part IX commentary)
- `"Euler-Mascheroni constant bound"` — docstring prose only (Part IX, lines 207-213)

Remaining 8 entries all map to real Lean declarations: `UnitCircle`, `Arc`, `ArcSequence`, `partialSum`, `SheppCriterion`, `CoversWithProbOne`/`criticalSeq`/`erdos_critical` axioms, `erdos_526_solved`/`erdos_526_summary` theorems.

**Section line drift (poisson-connection):**
- Before: `startLine: 201, endLine: 242` (wrong — those lines are Parts VIII/IX/X)
- After: `startLine: 177, endLine: 194` (correct — Part VII "The Poisson Process Connection")

Closes #14308

---
Automated fix by lean-mechanic agent.