### PR TITLE
audit(tracker): mark erdos-516 issues-found (#14314)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7290,10 +7290,13 @@
       "result": "clean"
     },
     "erdos-516": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T16:56:28Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14314: originalContributions claims 3 phantom Statement-of-theorem items (Wiman 1914, Erdős-Macintyre 1954, Kovári 1965) that exist only as doc-comments; numerical fields (axiomCount=1, sorries=1, lineCount=196) are correct"
+      ]
     },
     "erdos-517": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Reaudit of `erdos-516` on 2026-05-01 found phantom-narrative drift in `meta.originalContributions`
- Three "Statement of <theorem>" items name Wiman 1914, Erdős-Macintyre 1954, and Kovári 1965 — but those theorems exist only as natural-language doc-comments in `proofs/Proofs/Erdos516Problem.lean`, with no `axiom` or `theorem` declarations
- Numerical fields (`axiomCount: 1`, `sorries: 1`, `lineCount: 196`) match the Lean source

Filed as issue #14314.

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` — JSON valid
- [x] `git diff --stat` — single targeted edit (7 insertions, 4 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)