### PR TITLE
audit(tracker): mark erdos-511 issues-found (#14317)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7254,9 +7254,12 @@
     },
     "erdos-511": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T17:03:49Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14317: 6 phantom axioms in sections summaries (components_below_4, sum_diameters_rootsOfUnity, petal_structure, perturbation_creates_components, huang_theorem, diameter_4_is_sharp); section line ranges drifted at threshold-4/summary"
+      ]
     },
     "erdos-512": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates `src/data/proofs/audit-tracker.json` for erdos-511: bumps auditCount 2→3, sets result to `issues-found`, references #14317.

Audit found that the meta.json `sections` field for erdos-511 names 6 axioms that exist only as `/-` block comments (not as Lean declarations) and that two section line ranges (`threshold-4`, `summary`) are misaligned with the current file. `axiomCount: 2` and `originalContributions` are correct; the issue is isolated to `sections`.

See #14317 for the integrity issue and proposed fix.

## Test plan
- [ ] Tracker JSON parses (no unicode escape noise)
- [ ] Diff is limited to the erdos-511 entry + trailing newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)