### PR TITLE
audit(tracker): mark erdos-509 issues-found (#14319)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7236,9 +7236,9 @@
     },
     "erdos-509": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T17:15:20Z",
+      "result": "issues-found"
     },
     "erdos-51": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks `erdos-509` as `issues-found` in `src/data/proofs/audit-tracker.json` (auditCount 2→3).
- Tracks integrity issue #14319 (4 phantom-axiom items in `originalContributions`).

## Test plan
- [x] Diff is limited to the single tracker entry for erdos-509.
- [x] Unicode characters in unrelated entries restored (worked around `claim-target.sh` `ensure_ascii=True` bug).
- [x] Issue #14319 filed with full evidence from origin/main HEAD `716ea05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)