### PR TITLE
audit(tracker): mark erdos-502 issues-found (#14321)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7194,9 +7194,9 @@
     },
     "erdos-502": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T17:20:54Z",
+      "result": "issues-found"
     },
     "erdos-503": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Mark `erdos-502` audit `issues-found` per #14321.
- Numerical counts match (sorries=0, axiomCount=2, theoremCount=2, definitionCount=3, lineCount=82). Issues are narrative + section-range drift.

## Issues filed (see #14321)
- `proofStrategy` claims small cases f(2)=5, f(3)=6 are *axiomatized* — they are only orphan doc-comments at lines 70–71, no Lean declarations exist.
- 5 sections drift by 6–9 lines (lower-bound, upper-bound, main-result, small-cases) and the `Coxeter's Original Question` section (containing the real `coxeter_polynomial_growth` theorem) is missing entirely.

## Test plan
- [x] `claim-target.sh complete erdos-502 issues-found` — manually re-applied with `ensure_ascii=False` to avoid the known unicode-escape bug
- [x] Diff is minimal (4 line edits + trailing newline)