### PR TITLE
fix(meta): erdos-516 phantom-axiom narrative in originalContributions

### DIFF
--- a/src/data/proofs/erdos-516/meta.json
+++ b/src/data/proofs/erdos-516/meta.json
@@ -52,9 +52,9 @@
       "Definition of entire functions of finite order",
       "Maximum and minimum modulus functions M(r) and m(r)",
       "Statement of Fuchs's theorem (1963) solving the main problem",
-      "Statement of Wiman's theorem (1914) under stronger gaps",
-      "Statement of Erdős-Macintyre theorem (1954)",
-      "Statement of Kovári's extension (1965) for infinite order",
+      "Documentation of Wiman's theorem (1914) under stronger gaps (no Lean axiom; doc-comment only)",
+      "Documentation of Erdős-Macintyre theorem (1954) (no Lean axiom; doc-comment only)",
+      "Documentation of Kovári's extension (1965) for infinite order (no Lean axiom; doc-comment only)",
       "Formalization of the remaining open conjecture (Fejér gaps)"
     ],
     "axiomCount": 1,


### PR DESCRIPTION
## Fix

Remove three phantom `originalContributions` claims for Wiman, Erdős-Macintyre, and Kovári theorems that appear only as doc-comments in the Lean source — not as actual declarations.

## Evidence

**Before**: `"Statement of Wiman's theorem (1914) under stronger gaps"` (and similarly for Erdős-Macintyre and Kovári) — misleads readers into thinking these are Lean axioms or theorems.

**After**: `"Documentation of Wiman's theorem (1914) under stronger gaps (no Lean axiom; doc-comment only)"` — accurately reflects that these appear only in source comments.

No changes to `axiomCount` (1), `sorries` (1), `lineCount` (196), or `sections[]` — those fields were already correct.

Closes #14314

---
Automated fix by lean-mechanic agent.