### PR TITLE
audit(tracker): mark erdos-495 issues-found (#14323)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7135,9 +7135,12 @@
     },
     "erdos-495": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "Phantom-axiom narrative: originalContributions list 3 items only present as doc-comments (cassels_swinnerton_dyer_cubic, ekl_hausdorff_dimension_zero, badziahin_velani_padic); ekl_hausdorff_dimension_zero overclaims — actual axiom is ekl_countable_exceptions; section IV/VI summaries also reference these phantoms — issue #14323"
+      ],
+      "lastAudited": "2026-05-01T17:27:08Z",
+      "result": "issues-found"
     },
     "erdos-496": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks gallery audit of erdos-495 (Littlewood Conjecture) as issues-found.

## Summary
- 3 phantom items in `originalContributions` only present as doc-comments: `cassels_swinnerton_dyer_cubic`, `ekl_hausdorff_dimension_zero`, `badziahin_velani_padic`
- `ekl_hausdorff_dimension_zero` overclaims — actual axiom is `ekl_countable_exceptions` (weaker statement: countable exceptions, not Hausdorff dim 0)
- Section IV summary axiomatizes Cassels–Swinnerton-Dyer (only doc-comment in Lean)
- Section VI summary references Badziahin–Velani partial result (only doc-comment in Lean)

## Numerical counts (correct)
- axiomCount: 2 ✓ (matches `littlewood_rational_case`, `ekl_countable_exceptions`)
- sorries: 0 ✓
- lineCount: 178 ✓

Filed integrity issue: #14323

## Test plan
- [x] tracker JSON parses (jq + python json)
- [x] only erdos-495 entry changed (avoids the unicode-pollution trap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)