### PR TITLE
fix(meta): erdos-502 phantom small-case axiomatization + section line drift

### DIFF
--- a/src/data/proofs/erdos-502/meta.json
+++ b/src/data/proofs/erdos-502/meta.json
@@ -45,48 +45,56 @@
       "id": "binary-construction",
       "title": "The Binary Vector Construction",
       "startLine": 37,
-      "endLine": 50,
+      "endLine": 44,
       "summary": "Constructs `binaryTwoVec n i j` \u2014 indicator vectors $e_i + e_j \\in \\{0,1\\}^n$ \u2014 forming a two-distance set with distances $\\sqrt{2}$ (one shared coordinate) and $2$ (disjoint supports), giving $\\binom{n}{2}$ points.",
       "mathContext": "Constructs `binaryTwoVec n i j` \u2014 indicator vectors $e_i + e_j \\in \\{0,1\\}^n$ \u2014 forming a two-distance set with distances $\\sqrt{2}$ (one shared coordinate) and $2$ (disjoint supports), giving $\\binom{n}{2}$ points."
     },
     {
       "id": "lower-bound",
       "title": "Lower Bounds",
-      "startLine": 51,
-      "endLine": 60,
+      "startLine": 45,
+      "endLine": 51,
       "summary": "Basic lower bound $f(n) \\geq \\binom{n}{2}$ from binary vectors, improved to $f(n) \\geq \\binom{n+1}{2}$ via projection into a suitable $(n-1)$-dimensional affine subspace.",
       "mathContext": "Bound: Basic lower bound $f(n) \\geq \\binom{n}{2}$ from binary vectors, improved to $f(n) \\geq \\binom{n+1}{2}$ via projection into a suitable $(n-1)$-dimensional affine subspace."
     },
     {
       "id": "upper-bound",
       "title": "Upper Bound \u2014 Bannai\u2013Bannai\u2013Stanton",
-      "startLine": 61,
-      "endLine": 68,
+      "startLine": 52,
+      "endLine": 59,
       "summary": "The BBS theorem: $f(n) \\leq \\binom{n+2}{2}$. The proof associates to each point a polynomial vanishing on the other distance, bounding the dimension of the resulting polynomial space by $\\binom{n+2}{2}$.",
       "mathContext": "The BBS theorem: $f(n) \\leq \\binom{n+2}{2}$. The proof associates to each point a polynomial vanishing on the other distance, bounding the dimension of the resulting polynomial space by $\\binom{n+2}{2}$."
     },
     {
       "id": "main-result",
       "title": "Main Combined Bounds",
-      "startLine": 69,
-      "endLine": 76,
+      "startLine": 60,
+      "endLine": 67,
       "summary": "The sandwich theorem: $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$, establishing $f(n) = \\Theta(n^2)$ with an additive gap of at most $n+1$.",
       "mathContext": "The sandwich theorem: $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$, establishing $f(n) = \\Theta($n^{2}$)$ with an additive gap of at most $n+1$."
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
-      "startLine": 77,
+      "startLine": 68,
+      "endLine": 71,
+      "summary": "Descriptive remarks about $f(2) = 5$ (regular pentagon) and $f(3) = 6$ as orphan doc-comments; no Lean declarations for these exact values.",
+      "mathContext": "Historical values: $f(2) = 5$ (vertices of a regular pentagon) and $f(3) = 6$; not formalized in Lean."
+    },
+    {
+      "id": "coxeter",
+      "title": "Coxeter's Original Question",
+      "startLine": 72,
       "endLine": 82,
-      "summary": "Exact values: $f(2) = 5$ (vertices of a regular pentagon) and $f(3) = 6$. These match the lower bound $\\binom{3}{2} = 3$ and $\\binom{4}{2} = 6$ respectively, with the planar case being exceptional.",
-      "mathContext": "Bound: Exact values: $f(2) = 5$ (vertices of a regular pentagon) and $f(3) = 6$. These match the lower bound $\\binom{3}{2} = 3$ and $\\binom{4}{2} = 6$ respectively, with the planar case being exceptional."
+      "summary": "`coxeter_polynomial_growth` theorem: $f(n) \\leq \\binom{n+2}{2}$ confirms polynomial growth, resolving Coxeter's question as a corollary of BBS.",
+      "mathContext": "Verified: `coxeter_polynomial_growth` theorem derives $f(n) = O(n^2)$ directly from `upper_bound_bbs`."
     }
   ],
   "overview": {
     "historicalContext": "H.S.M. Coxeter posed this problem to Erd\u0151s around 1961, asking whether the maximum size of a two-distance set in $\\mathbb{R}^n$ is polynomial in $n$. Erd\u0151s initially believed he could prove $f(n) \\leq n^{O(1)}$ but discovered an error, leaving only exponential bounds. The question remained open until Bannai, Bannai, and Stanton (1983) proved $f(n) \\leq \\binom{n+2}{2}$ using the polynomial method: for a two-distance set with distances $d_1, d_2$, the polynomials $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$ are linearly independent in a space of dimension $\\binom{n+2}{2}$, yielding the bound. Blokhuis (1984) simplified the argument using linear algebra over the Gram matrix. In 2021, Petrov and Pohoata gave an even simpler proof leveraging the Croot\u2013Lev\u2013Pach polynomial method from additive combinatorics. For the lower bound, the binary vector construction $\\{e_i + e_j : i < j\\}$ gives $\\binom{n}{2}$ points; a clever projection into $\\mathbb{R}^n$ from $\\mathbb{R}^{n+1}$ improves this to $\\binom{n+1}{2}$. The exact value $f(n)$ is known only for small $n$: Kelly (1947) showed $f(2) = 5$ (regular pentagon), and $f(3) = 6$ is classical.",
     "problemStatement": "Given n, find the maximum cardinality f(n) of a finite set A \u2286 \u211d\u207f such that the set of pairwise distances {|x-y| : x \u2260 y \u2208 A} has exactly two elements.",
     "text": "What is the maximum size f(n) of a set A \u2286 \u211d\u207f with exactly two distinct pairwise distances? Bannai\u2013Bannai\u2013Stanton proved f(n) \u2264 C(n+2,2); a projection construction gives f(n) \u2265 C(n+1,2). Status: SOLVED.",
-    "proofStrategy": "The formalization defines the two-distance set property, constructs binary vectors as witnesses for the lower bound, and states the Bannai\u2013Bannai\u2013Stanton upper bound. The main theorem combines both into the sandwich $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$. Small cases $f(2) = 5$ and $f(3) = 6$ are axiomatized. Coxeter's polynomial growth question is resolved as a direct corollary of BBS.",
+    "proofStrategy": "The formalization defines the two-distance set property, constructs binary vectors as witnesses for the lower bound, and states the Bannai\u2013Bannai\u2013Stanton upper bound. The main theorem combines both into the sandwich $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$. Small cases $f(2) = 5$ and $f(3) = 6$ are recorded as descriptive remarks but not formalized. Coxeter's polynomial growth question is resolved as a direct corollary of BBS.",
     "keyInsights": [
       "**Binary vector construction**: Vectors $e_i + e_j \\in \\{0,1\\}^n$ give distances $\\sqrt{2}$ (shared coordinate) or $2$ (disjoint), yielding $\\binom{n}{2}$ points; projection improves this to $\\binom{n+1}{2}$",
       "**Polynomial method for upper bound**: For distances $d_1, d_2$, the polynomials $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$ are linearly independent in $\\mathbb{R}[x_1,\\ldots,x_n]_{\\leq 2}$, whose dimension is $\\binom{n+2}{2}$",


### PR DESCRIPTION
## Fix

Two issues repaired for erdos-502:

### 1. Phantom small-case axiomatization in `proofStrategy`

**Before**: "Small cases f(2) = 5 and f(3) = 6 are axiomatized."

**After**: "Small cases f(2) = 5 and f(3) = 6 are recorded as descriptive remarks but not formalized."

Lines 70-71 of the Lean source are orphan doc-comments with no following declarations — there are no axioms or theorems for these values.

### 2. Section line ranges corrected + missing `coxeter` section added

| Section | Before | After |
|---------|--------|-------|
| binary-construction | 37-50 | 37-44 |
| lower-bound | 51-60 | 45-51 |
| upper-bound | 61-68 | 52-59 |
| main-result | 69-76 | 60-67 |
| small-cases | 77-82 | 68-71 (now correctly describes doc-comments only) |
| coxeter (NEW) | — | 72-82 (contains `coxeter_polynomial_growth` theorem) |

`axiomCount: 2`, `sorries: 0`, `lineCount: 82` are all correct and unchanged.

Closes #14321

---
Automated fix by lean-mechanic agent.