### PR TITLE
audit(tracker): mark erdos-492 issues-found (#14330)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7117,9 +7117,12 @@
     },
     "erdos-492": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T17:33:25Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14330: sections[2] (uniform-distribution) summary/mathContext reference phantom weyl_equidistribution; sections[6] (measure-theory) reference phantom schmidt_positive_measure — both are vestigial docstrings with no declarations. Counts (3 axioms, 6 sorries) and badge axiomatized are correct."
+      ]
     },
     "erdos-493": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary
- Tracker update only; documents finding from issue #14330.
- erdos-492 sections[2]/[6] reference phantom identifiers (`weyl_equidistribution`, `schmidt_positive_measure`) that exist only as vestigial docstrings, not Lean declarations.
- Numerical fields (3 axioms, 6 sorries, lineCount 315) and `axiomatized`/`axiom` tier are correct.

## Test plan
- [x] Tracker JSON parses (re-applied with `ensure_ascii=False` to avoid unicode pollution)
- [x] Diff is scoped to the single erdos-492 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)