### PR TITLE
audit(tracker): mark erdos-492 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7117,9 +7117,9 @@
     },
     "erdos-492": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T17:37:10Z",
+      "result": "clean"
     },
     "erdos-493": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary
- erdos-492 audit: counts and narrative match Lean source
- 3 axioms (schmidt_counterexample, davenport_leveque, davenport_erdos), 6 sorries, status axiomatized/badge axiom — all consistent
- proofStrategy honestly names all three axioms; no phantom-axiom narrative

## Test plan
- [x] Reverified `proofs/Proofs/Erdos492Problem.lean` axiom and sorry counts
- [x] Reconciled `meta.assumptions` with axiom names in source
- [x] Tracker entry uses ensure_ascii=False (no \u2192/\u2014 noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)