### PR TITLE
fix(meta): erdos-492 sections reference phantom identifiers

### DIFF
--- a/src/data/proofs/erdos-492/meta.json
+++ b/src/data/proofs/erdos-492/meta.json
@@ -64,10 +64,10 @@
     {
       "id": "uniform-distribution",
       "title": "Part III: Uniform Distribution",
-      "summary": "isUniformlyDistributed, weyl_equidistribution, erdosDavenportSeq",
+      "summary": "isUniformlyDistributed, erdosDavenportSeq",
       "startLine": 113,
       "endLine": 141,
-      "mathContext": "Mathematical content: isUniformlyDistributed, weyl_equidistribution, erdosDavenportSeq"
+      "mathContext": "Mathematical content: isUniformlyDistributed, erdosDavenportSeq"
     },
     {
       "id": "conjecture-fate",
@@ -96,10 +96,10 @@
     {
       "id": "measure-theory",
       "title": "Part VII: Measure-Theoretic Formulation",
-      "summary": "almostAllUniform, conjecture_iff_ae, schmidt_positive_measure",
+      "summary": "almostAllUniform, conjecture_iff_ae",
       "startLine": 259,
       "endLine": 284,
-      "mathContext": "Mathematical content: almostAllUniform, conjecture_iff_ae, schmidt_positive_measure"
+      "mathContext": "Mathematical content: almostAllUniform, conjecture_iff_ae"
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Removed phantom identifiers `weyl_equidistribution` and `schmidt_positive_measure` from two section summaries in erdos-492 meta.json.

## Evidence

**Before**:
- `sections[2]` (uniform-distribution) summary/mathContext listed `weyl_equidistribution` — appears only as a docstring heading in the Lean file, no theorem/axiom declaration.
- `sections[6]` (measure-theory) summary/mathContext listed `schmidt_positive_measure` — same: docstring only, no Lean declaration.

**After**:
- `sections[2]`: `"isUniformlyDistributed, erdosDavenportSeq"` (phantom dropped)
- `sections[6]`: `"almostAllUniform, conjecture_iff_ae"` (phantom dropped)

Numerical fields (axiomCount=3, sorries=6, status=axiomatized) unchanged — already correct.

Closes #14330

---
Automated fix by lean-mechanic agent.