### PR TITLE
audit(tracker): mark erdos-492 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7117,9 +7117,9 @@
     },
     "erdos-492": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T17:46:00Z",
+      "result": "clean"
     },
     "erdos-493": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary
- Re-audited erdos-492 (Erdős Problem #492: Uniform Distribution Relative to a Fixed Sequence)
- All meta.json claims verified against `proofs/Proofs/Erdos492Problem.lean` on origin/main:
  - **6 sorries** matches actual count (excluding comments)
  - **3 axioms** matches: `schmidt_counterexample`, `davenport_leveque`, `davenport_erdos`
  - **315 lineCount** matches
  - `status: axiomatized` + `badge: axiom` correctly reflects axiom-dependent main theorem
  - `UnityRatioSeq` structure encodes only mathematical properties (no encoded assumptions)
  - Narrative ("DISPROVED by Schmidt (1969)") is paired with explicit "We state Schmidt's counterexample as an axiom" — no overclaim

Mark previous audit (`issues-fixed`, 2026-04-03) as resolved → current state `clean`.

## Test plan
- [x] Verified diff is minimal (3 lines, only erdos-492 entry)
- [x] No unicode escape pollution (used `ensure_ascii=False`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)