### PR TITLE
audit(tracker): mark erdos-490 issues-found (#14335)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7099,9 +7099,12 @@
     },
     "erdos-490": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T17:54:26Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom sidon_bound axiom + van_doorn_observation + their-equivalence narrative; section line drift (issue #14335)"
+      ]
     },
     "erdos-490-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
Marks erdos-490 as issues-found per gallery integrity audit. See #14335 for details.

Phantom identifiers in `src/data/proofs/erdos-490/meta.json` sections:
- Phantom `sidon_bound axiom` (most serious — claims a 3rd axiom that doesn't exist)
- Phantom `van_doorn_observation` theorem (orphaned docstring at line 153)
- "their equivalence" theorem in basic-definitions (orphaned docstring at line 59)
- Section line-range drift in "the-erdos-question" and "szemeredi-theorem"

Numerical `axiomCount: 2` and `sorries: 6` are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)