### PR TITLE
audit(tracker): mark erdos-489 issues-found (#14338)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7087,9 +7087,12 @@
     },
     "erdos-489": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T18:01:43Z",
+      "result": "issues-found",
+      "issues": [
+        "14338"
+      ]
     },
     "erdos-49": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks `erdos-489` as `issues-found` in `src/data/proofs/audit-tracker.json` and links #14338 (phantom-identifier narrative).

## Test plan
- [x] Tracker entry updated with `result: issues-found`, audit count incremented.
- [x] Issue #14338 documents the phantom identifiers (`squarefreeSetAsBFree`, `squarefree_density`) in section `squarefree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)