### PR TITLE
audit(tracker): mark erdos-487 issues-found (#14340)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7075,9 +7075,12 @@
     },
     "erdos-487": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T18:10:18Z",
+      "result": "issues-found",
+      "issues": [
+        "Section line ranges drift after Part IV; Part VII \"Proof Structure\" missing from sections (issue #14340)"
+      ]
     },
     "erdos-488": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks `erdos-487` as `issues-found` in audit-tracker.json
- Tracks issue #14340 (section line ranges drift, Part VII missing)
- Increments auditCount 2 → 3, lastAudited → 2026-05-01

## Test plan
- [x] No unicode escape pollution in tracker
- [x] Only erdos-487 entry modified
- [x] Issue #14340 referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)