### PR TITLE
research(cayley-hamilton wip-01): correct axiom rationale — PID structure theorem IS in Mathlib

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean
@@ -234,9 +234,25 @@ theorem cyclic_vector_similar_transfer
 
 /-- **Axiom**: A nonderogatory matrix M is similar to its companion matrix.
     This is the classical theorem that requires the rational canonical form
-    (equivalently, the PID structure theorem for K[X]-modules), which is not
-    currently in Mathlib 4.26.
+    (equivalently, the PID structure theorem for K[X]-modules).
 
+    AUDIT 2026-04-27: The PID structure theorem IS in Mathlib (4.26+):
+    - `Module.equiv_directSum_of_isTorsion` (Mathlib.Algebra.Module.PID)
+    - `Module.equiv_free_prod_directSum` (Mathlib.Algebra.Module.PID)
+    - `Module.exists_ker_toSpanSingleton_eq_annihilator` (Mathlib.Algebra.Module.PID)
+
+    Combined with the AEval module infrastructure
+    (`Module.AEval'` and `Module.AEval.annihilator_top_eq_ker_aeval` in
+    Mathlib.Algebra.Polynomial.Module.AEval), the cyclic vector existence
+    can be derived DIRECTLY from `exists_ker_toSpanSingleton_eq_annihilator`
+    without needing similarity to a companion matrix at all.
+
+    For nonderogatory M with charpoly = minpoly of degree n, the theorem gives
+    x in K^n with ker(p ↦ p • x) = (minpoly K M); since (minpoly) contains no
+    nonzero polynomial of degree < n, x is automatically a cyclic vector.
+
+    The axiom remains for now because writing the bridging code requires
+    discharging the axiom into ~50–150 new lines that have not been built yet.
     The forward direction (similar to companion -> nonderogatory) is trivial
     since minpoly_companionMatrix and charpoly_companionMatrix are proved. -/
 axiom nonderogatory_similar_to_companion (M : Matrix (Fin n) (Fin n) K)

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md
@@ -82,3 +82,92 @@ Gallery entry: status=axiomatized, badge=axiom, axiomCount=1, sorries=0
 
 - `exists_strongly_cyclic` approach (strong induction on natDegree q): viable but complex (~100 more lines). Superseded by WIP04 primary-decomposition route used in V2.
 - V1 Route B (axiomatize `nonderogatory_similar_companion`): superseded by V2 axiom elimination (PR #13041).
+
+---
+
+## Session 2026-04-27 (Session 2 — researcher-10) — Audit and Mathlib Re-Survey
+
+**Mode**: AUDIT
+**Outcome**: documentation updated; full discharge deferred to next session
+
+### What I Did
+
+Audited the existing axiomatized gallery entries
+(cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01 and the parallel
+cayley-hamilton-cyclic-vector-all-fields) and re-surveyed Mathlib for
+the supposedly-missing PID structure theorem.
+
+### Key Finding (correcting prior session)
+
+The PID structure theorem **is** in Mathlib (verified via direct
+inspection of the `.lake` packages):
+
+- `Mathlib.Algebra.Module.PID`:
+  - `Module.equiv_directSum_of_isTorsion` — f.g. torsion module over PID
+    is direct sum of `R/(p_i^e_i)`.
+  - `Module.equiv_free_prod_directSum` — full structure theorem.
+  - `Module.exists_ker_toSpanSingleton_eq_annihilator` — for f.g. module
+    over PID, ∃ x with ker(toSpanSingleton x) = annihilator. This is
+    exactly the cyclic-vector witness once specialized.
+
+- `Mathlib.Algebra.Polynomial.Module.AEval`:
+  - `Module.AEval'` — type synonym making `M` into `R[X]`-module via an
+    endomorphism / matrix.
+  - `Module.AEval.annihilator_top_eq_ker_aeval` — annihilator of AEval
+    equals ker(aeval), connecting module annihilator with minimal poly.
+  - `Module.AEval.instFinitePolynomial` — AEval inherits Module.Finite.
+
+### Why the Earlier Sessions Missed This
+
+The original problem.md (line 52) explicitly suggested searching Mathlib
+for `Matrix.IsCompanion` / `Matrix.RationalCanonicalForm` / similar.
+Those are absent. But the PID structure theorem lives at the more
+abstract `Module` level (via the AEval bridge), not the matrix level —
+and that is what was missed.
+
+### Direct Discharge Path (Route D)
+
+For nonderogatory M ∈ Matrix (Fin n) (Fin n) K:
+
+1. Treat K^n as `Module.AEval' M`. It inherits `Module.Finite K[X]`.
+2. Apply `Module.exists_ker_toSpanSingleton_eq_annihilator` →
+   ∃ x ∈ Module.AEval' M with ker(p ↦ p • x) = annihilator (top).
+3. By `annihilator_top_eq_ker_aeval`, this annihilator is ker(aeval M),
+   which is the principal ideal (minpoly K M).
+4. For nonderogatory M, deg(minpoly K M) = n. No nonzero polynomial of
+   degree < n is in (minpoly).
+5. Pull x back through `Module.AEval.of` to get v ∈ K^n. Then for any
+   p with deg p < n: if `(aeval M p).mulVec v = 0`, then p ∈ (minpoly),
+   so p = 0. That is precisely `IsCyclicVector M v`.
+
+This avoids the companion matrix similarity entirely. The axiom
+`nonderogatory_similar_to_companion` becomes a derived theorem:
+v cyclic + change-of-basis to {v, Mv, …, M^{n-1}v} produces the
+companion-matrix similarity.
+
+### Why Discharge Was Deferred
+
+Disk free at session start: ~750 MiB (95% full). Per project memory,
+under 1 GiB free I should not attempt Docker builds. Lean code that
+cannot be built locally must not be pushed. So the audit is committed
+as documentation; the discharge waits for a session with adequate disk.
+
+### Files Changed (this session)
+
+- `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean`: axiom
+  docstring expanded with the audit and the Route D proof sketch.
+- `src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json`:
+  - `assumptions` corrected.
+  - `openQuestions` rewritten around the actual gap (bridging code).
+  - 3 new `mathlibDependencies` for the PID + AEval lemmas.
+- `research/problems/cayley-hamilton-cyclic-vector-all-fields/state.md`:
+  REOPENED-FOR-DISCHARGE, Route D documented as next-action.
+- `research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md`:
+  this entry.
+
+### Anticipated Next-Session Effort
+
+Estimated 50–150 lines of Lean. The bridging code itself is mostly
+unfolding definitions; the conceptual content is in the four Mathlib
+lemmas above. A future session should attempt to write the new file
+and run the Docker build to verify.

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 290,
-    "assumptions": "1 axiom: nonderogatory_similar_to_companion (nonderogatory matrix is similar to its companion matrix; requires rational canonical form / PID structure theorem, not yet in Mathlib 4.26).",
+    "assumptions": "1 axiom: nonderogatory_similar_to_companion (nonderogatory matrix is similar to its companion matrix). NOTE (audit 2026-04-27): the PID structure theorem IS in Mathlib (Module.equiv_directSum_of_isTorsion, Module.equiv_free_prod_directSum at Mathlib.Algebra.Module.PID), and Module.exists_ker_toSpanSingleton_eq_annihilator combined with Module.AEval' (Mathlib.Algebra.Polynomial.Module.AEval) directly gives a cyclic vector for nonderogatory matrices without needing similarity to a companion matrix at all. The remaining work is bridging code, not a missing structure theorem.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -43,6 +43,21 @@
         "theorem": "Polynomial.le_natDegree_of_mem_supp",
         "description": "Support elements are bounded by natDegree",
         "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
+      },
+      {
+        "theorem": "Module.exists_ker_toSpanSingleton_eq_annihilator",
+        "description": "(Audit 2026-04-27, future use) For f.g. module over PID, exists x with ker(toSpanSingleton x) = annihilator. Discharges nonderogatory_similar_to_companion via AEval module.",
+        "module": "Mathlib.Algebra.Module.PID"
+      },
+      {
+        "theorem": "Module.equiv_directSum_of_isTorsion",
+        "description": "(Audit 2026-04-27, future use) Structure theorem for f.g. torsion modules over PID — invariant factor decomposition.",
+        "module": "Mathlib.Algebra.Module.PID"
+      },
+      {
+        "theorem": "Module.AEval.annihilator_top_eq_ker_aeval",
+        "description": "(Audit 2026-04-27, future use) annihilator of AEval module equals ker of aeval, connecting module-theoretic and polynomial views.",
+        "module": "Mathlib.Algebra.Polynomial.Module.AEval"
       }
     ]
   },
@@ -112,9 +127,9 @@
     "summary": "This file makes concrete progress on the nonderogatory cyclic vector theorem. The companion matrix cyclic vector (companionMat_e0_cyclic) is fully proved via the Krylov orbit argument. The remaining sorry is precisely stated as an axiom: nonderogatory matrices are similar to their companion matrices. This decomposes the original vague sorry into a proved part and a precisely-located mathematical gap.",
     "implications": "The orbit argument C^k e0 = e_k is now formally verified in Lean 4, establishing a concrete constructive fact about companion matrices. The similarity transfer theorem is also verified. The only remaining mathematical content is the rational canonical form / PID structure theorem, which is a known Mathlib gap. This decomposition makes the remaining work modular: once the similarity axiom is proved, the entire chain completes automatically.",
     "openQuestions": [
-      "Can nonderogatory_similar_to_companion be proved using existing Mathlib infrastructure (e.g., primary decomposition for finitely generated modules)?",
-      "When will Mathlib add the rational canonical form or the PID module structure theorem?",
-      "Can a direct proof via the Cayley-Hamilton theorem avoid the rational canonical form entirely? (M annihilated by charpoly + nonderogatory forces minpoly = charpoly, but getting a cyclic vector from this requires the similarity.)"
+      "AUDIT 2026-04-27: The PID structure theorem IS in Mathlib at Mathlib.Algebra.Module.PID (Module.equiv_directSum_of_isTorsion, Module.equiv_free_prod_directSum, Module.exists_ker_toSpanSingleton_eq_annihilator). Why was the axiom introduced? The original work appears to predate awareness of these results, or chose the companion-matrix route for pedagogical clarity.",
+      "Direct route to discharge the axiom: apply Module.exists_ker_toSpanSingleton_eq_annihilator to Module.AEval' M (K^n with K[X]-action via M, defined in Mathlib.Algebra.Polynomial.Module.AEval). Combined with Module.AEval.annihilator_top_eq_ker_aeval and the connection between aeval kernel and minpoly, this yields a cyclic vector directly — no companion matrix similarity needed. Estimated effort: 50-150 lines of bridging code.",
+      "Alternative route (preserves companion-matrix architecture): prove nonderogatory_similar_to_companion via the cyclic vector existence (above) plus a change-of-basis argument — the cyclic vector v gives basis {v, Mv, ..., M^{n-1}v} in which M acts as the companion matrix of minpoly = charpoly. This is the classical proof and works once the cyclic vector is established."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary

Rebased from PR #13389 (conflicting). Reset to `origin/main`, cherry-picked the 2 unique commits. The third commit (erdos-1178 Lean + section summary fixes) resolved empty — already on main.

### Unique commits applied

- `research(cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01)`: corrects axiom docstring and meta.json — the PID structure theorem IS in Mathlib (Module.equiv_directSum_of_isTorsion, Module.exists_ker_toSpanSingleton_eq_annihilator via Module.AEval'). Adds 3 mathlibDependencies entries for future discharge.
- `research(cayley-hamilton-cyclic-vector-all-fields)`: records the 2026-04-27 audit session in knowledge.md (Route D discharge path, why earlier sessions missed the module-level infrastructure).

### What was NOT included

- The erdos-1178 commit (`a1f375d663e`) resolved as empty — the Lean file and meta.json changes were already on main via a different path.

### Files changed

- `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean` — axiom docstring expanded with audit note and Route D proof sketch
- `src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json` — corrected `assumptions` field, new `openQuestions`, 3 new `mathlibDependencies`
- `research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md` — Session 2 audit appended

Closes #13389

🤖 Generated with [Claude Code](https://claude.com/claude-code)