### PR TITLE
audit(tracker): mark erdos-482 issues-found (#14343)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7032,10 +7032,13 @@
       "result": "clean"
     },
     "erdos-482": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-2026-05-01",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T18:16:45Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom non-periodicity axiom in originalContributions; sections part-1/3/5 describe docstring-only content as axiomatized — issue #14343"
+      ]
     },
     "erdos-483": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-482 as issues-found per gallery integrity audit. See #14343 for details.

Phantom-axiom narrative in `src/data/proofs/erdos-482/meta.json`:
- `originalContributions` claims a "Non-periodicity axiom" — no such axiom exists.
- Sections part-1 / part-3 / part-5 describe docstring-only content as axiomatized.

Numerical fields are correct: `axiomCount: 2`, `sorries: 0`, `lineCount: 128`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)