### PR TITLE
fix(meta): erdos-489 phantom identifiers + section line drift

### DIFF
--- a/src/data/proofs/erdos-489/meta.json
+++ b/src/data/proofs/erdos-489/meta.json
@@ -47,6 +47,7 @@
       "IsSparse definition: o(√x) growth condition",
       "BFreeSet definition: numbers not divisible by A",
       "IsBFree definition: A-free numbers",
+      "nthElement axiom: ordered elements of B (well-ordering axiomatized)",
       "gap definition: consecutive gaps",
       "gapSquaredSum definition: Σ(b_{i+1}-b_i)²",
       "normalizedGapStatistic definition: (1/x)Σ gaps²",
@@ -88,7 +89,7 @@
     {
       "id": "gaps",
       "title": "Gaps and Gap Statistics",
-      "summary": "nthElement, gap, gapSquaredSum, normalizedGapStatistic",
+      "summary": "nthElement axiom, gap, gapSquaredSum, normalizedGapStatistic",
       "startLine": 65,
       "endLine": 96
     },
@@ -102,22 +103,22 @@
     {
       "id": "squarefree",
       "title": "The Squarefree Case",
-      "summary": "PrimeSquares, squarefreeSetAsBFree, erdos_squarefree_limit, squarefree_density",
-      "startLine": 118,
-      "endLine": 151
+      "summary": "PrimeSquares definition (A = {p² : p prime}), erdos_squarefree_limit axiom (limit exists for squarefrees); docstring commentary on B = squarefree numbers and density 6/π²",
+      "startLine": 119,
+      "endLine": 144
     },
     {
       "id": "kfree",
       "title": "K-Free Numbers",
       "summary": "IsKFree, IsCubefree",
-      "startLine": 152,
-      "endLine": 168
+      "startLine": 145,
+      "endLine": 161
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_489_summary, erdos_489",
-      "startLine": 169,
+      "startLine": 162,
       "endLine": 190
     }
   ],


### PR DESCRIPTION
## Fix

Remove phantom identifiers from erdos-489 section summaries, correct axiom labeling, and fix section line ranges.

## Evidence

**Before**:
- `squarefree` section summary listed `squarefreeSetAsBFree` and `squarefree_density` — neither exists in the Lean file (lines 128-142 are orphaned docstrings, no `def` or `theorem` follows)
- `nthElement` axiom (line 74) missing from `originalContributions`; unlabeled in `gaps` section summary
- Section line ranges drifted: `squarefree` claimed 118-151 (Part V starts at 145), `kfree` claimed 152-168 (Part VI starts at 162), `summary` claimed 169-190 (Part VI starts at 162)

**After**:
- `squarefree` summary: describes actual declarations (PrimeSquares, erdos_squarefree_limit axiom) + notes docstring commentary
- `nthElement axiom` added to `originalContributions`; labeled correctly in `gaps` section
- Section ranges corrected: `squarefree` 119-144, `kfree` 145-161, `summary` 162-190

Closes #14338

---
Automated fix by lean-mechanic agent.