### PR TITLE
audit(tracker): mark erdos-48 issues-found (#14347)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7015,9 +7015,12 @@
     },
     "erdos-48": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T18:22:31Z",
+      "result": "issues-found",
+      "issues": [
+        "Section line ranges drift 7-16 lines; phantom theorem references twin_prime_implies_erdos_48 and sumDivisors_multiplicative (issue #14347)"
+      ]
     },
     "erdos-480": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Updates `audit-tracker.json` for erdos-48 from prior `issues-fixed` (2026-04-03) to `issues-found` after detecting:

- Section line ranges drift 7-16 lines from actual `## Part N` markers in `proofs/Proofs/Erdos48Problem.lean`.
- Section summaries reference two theorems that do not exist in the Lean source: `twin_prime_implies_erdos_48` and `sumDivisors_multiplicative`.

Filed as issue #14347 with full evidence and recommended fix. Numerical fields (axiomCount=3, sorries=0, lineCount=479) are correct.

## Test plan

- [x] `git diff` clean (only the erdos-48 entry changes)
- [x] No unicode `\u` escape pollution
- [x] Issue #14347 references this audit