### PR TITLE
fix(meta): erdos-476 section line ranges drift

### DIFF
--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -105,55 +105,55 @@
       "title": "Da Silva-Hamidoune Theorem",
       "summary": "The 1994 proof using exterior algebra",
       "startLine": 121,
-      "endLine": 137,
+      "endLine": 135,
       "mathContext": "Verified: The 1994 proof using exterior algebra"
     },
     {
       "id": "tightness",
       "title": "Tightness - Arithmetic Progressions",
       "summary": "APs achieve the bound 2|A| - 3 exactly",
-      "startLine": 138,
-      "endLine": 170,
+      "startLine": 136,
+      "endLine": 229,
       "mathContext": "Bound: APs achieve the bound 2|A| - 3 exactly"
     },
     {
       "id": "cauchy-davenport",
       "title": "Comparison with Cauchy-Davenport",
       "summary": "Ordinary sumsets have bound 2|A| - 1",
-      "startLine": 171,
-      "endLine": 197,
+      "startLine": 231,
+      "endLine": 253,
       "mathContext": "Bound: Ordinary sumsets have bound 2|A| - 1"
     },
     {
       "id": "polynomial-method",
       "title": "The Polynomial Method",
       "summary": "Combinatorial Nullstellensatz and ANR proof",
-      "startLine": 198,
-      "endLine": 223,
+      "startLine": 255,
+      "endLine": 278,
       "mathContext": "Verified: Combinatorial Nullstellensatz and ANR proof"
     },
     {
       "id": "generalization",
       "title": "Generalization to r-Sums",
       "summary": "r-fold restricted sumsets with bound r|A| - r\u00b2 + 1",
-      "startLine": 224,
-      "endLine": 246,
+      "startLine": 279,
+      "endLine": 297,
       "mathContext": "Bound: r-fold restricted sumsets with bound r|A| - r\u00b2 + 1"
     },
     {
       "id": "examples",
       "title": "Small Examples",
       "summary": "Cases |A| = 2 and |A| = 3",
-      "startLine": 247,
-      "endLine": 271,
+      "startLine": 298,
+      "endLine": 335,
       "mathContext": "Mathematical content: Cases |A| = 2 and |A| = 3"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_476_summary combining main results",
-      "startLine": 272,
-      "endLine": 290,
+      "startLine": 337,
+      "endLine": 384,
       "mathContext": "Mathematical content: erdos_476_summary combining main results"
     }
   ],


### PR DESCRIPTION
## Fix

Re-derived section line ranges for erdos-476 from actual Lean source positions.

## Evidence

**Before**: Sections 5-10 collectively ended at line 290, leaving 94 lines (~25%) of the 384-line file uncovered. The `AP_restrictedSumset` proof body (lines 155-219, 65 lines) grew longer than anticipated, shifting all downstream sections by 50-80 lines.

**After**: All 10 sections now map correctly to their actual content spans (42-384).

| Section | Before | After |
|---------|--------|-------|
| da-silva-hamidoune | 121-137 | 121-135 |
| tightness | 138-170 | 136-229 |
| cauchy-davenport | 171-197 | 231-253 |
| polynomial-method | 198-223 | 255-278 |
| generalization | 224-246 | 279-297 |
| examples | 247-271 | 298-335 |
| summary | 272-290 | 337-384 |

Closes #14354

---
Automated fix by lean-mechanic agent.