### PR TITLE
fix(meta): erdos-474 phantom axioms in section narratives

### DIFF
--- a/src/data/proofs/erdos-474/meta.json
+++ b/src/data/proofs/erdos-474/meta.json
@@ -115,10 +115,10 @@
     {
       "id": "two-color",
       "title": "The Two-Color Case (Solved)",
-      "summary": "sierpinski_kurepa axiom, two_color_partition axiom",
+      "summary": "sierpinski_kurepa axiom",
       "startLine": 102,
       "endLine": 124,
-      "mathContext": "Axiomatized: sierpinski_kurepa axiom, two_color_partition axiom"
+      "mathContext": "Axiomatized: sierpinski_kurepa axiom"
     },
     {
       "id": "under-ch",
@@ -131,10 +131,10 @@
     {
       "id": "shelah",
       "title": "Shelah's Consistency Result",
-      "summary": "shelah_consistency axiom, shelah_large_c axiom",
+      "summary": "shelah_consistency axiom",
       "startLine": 143,
       "endLine": 167,
-      "mathContext": "Axiomatized: shelah_consistency axiom, shelah_large_c axiom"
+      "mathContext": "Axiomatized: shelah_consistency axiom"
     },
     {
       "id": "open-question",
@@ -147,26 +147,26 @@
     {
       "id": "related",
       "title": "Related Results",
-      "summary": "NegativePartition, higher_colors_harder, erdos_rado_two_color",
+      "summary": "motivational docstrings: higher color numbers, Erdős-Rado connection (NegativePartition def is in open-question section)",
       "startLine": 201,
       "endLine": 237,
-      "mathContext": "Mathematical content: NegativePartition, higher_colors_harder, erdos_rado_two_color"
+      "mathContext": "Documentation only: motivational docstrings for higher colors and Erdős-Rado"
     },
     {
       "id": "argument",
       "title": "The Argument Structure",
-      "summary": "ch_argument axiom, large_c_failure axiom",
+      "summary": "erdos_474_summary theorem (line 249), erdos_474 theorem (starts line 265)",
       "startLine": 238,
       "endLine": 266,
-      "mathContext": "Axiomatized: ch_argument axiom, large_c_failure axiom"
+      "mathContext": "Verified: erdos_474_summary theorem (line 249), erdos_474 theorem (starts line 265)"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_474_summary theorem, erdos_474 theorem",
+      "summary": "erdos_474 theorem proof conclusion, end Erdos474",
       "startLine": 267,
       "endLine": 277,
-      "mathContext": "Verified: erdos_474_summary theorem, erdos_474 theorem"
+      "mathContext": "Closing: remainder of erdos_474 theorem body (lines 267-275), namespace end"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Removed phantom axiom identifiers from section summaries and mathContext fields in erdos-474/meta.json.

## Evidence

**Before**: 5 phantom identifiers claimed as axiom declarations that do not exist anywhere in `proofs/Proofs/Erdos474Problem.lean`:
- `two_color_partition` — no declaration; only `sierpinski_kurepa` exists
- `shelah_large_c` — no declaration; only docstring about "Shelah's Large Continuum"
- `higher_colors_harder`, `erdos_rado_two_color` — docstring titles, not declarations
- `ch_argument`, `large_c_failure` — do not appear anywhere in the file
- `argument` section falsely claimed "Axiomatized" when it actually contains real theorems

**After**:
- `two-color`: `"sierpinski_kurepa axiom"` only
- `shelah`: `"shelah_consistency axiom"` only
- `related`: accurate docstring-only description
- `argument`: describes real theorems `erdos_474_summary` (line 249) and `erdos_474` (line 265)
- `summary`: corrects description for closing range (267-277)

**Note**: `leanFile.definitionCount: 12` is correct and intentionally unchanged. The audit used `grep -cE "^def "` which misses the 3 `noncomputable def` declarations (`continuum`, `aleph1`, `aleph2`). Total is 12.

Closes #14356

---
Automated fix by lean-mechanic agent.