### PR TITLE
audit(tracker): mark erdos-476 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6985,9 +6985,9 @@
     },
     "erdos-476": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T18:54:23Z",
+      "result": "clean"
     },
     "erdos-476-oq-05": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

- erdos-476 (Erdős-Heilbronn Conjecture) audit: **clean**
- Verified meta.json claims match Lean source `proofs/Proofs/Erdos476Problem.lean`

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 (code-only) | ✓ |
| axiomCount | 1 | 1 (`erdos_heilbronn_bound`) | ✓ |
| lineCount | 384 | 384 | ✓ |
| status/badge | axiomatized/axiom | matches axiom + theorem alias | ✓ |
| originalContributions | identifies axiom + proved theorems | matches | ✓ |

`erdos_heilbronn_bound` is the only axiom; `erdos_476` is `:= erdos_heilbronn_bound`. AP_restrictedSumset, AP_achieves_bound, card_two_case, card_three_lower_bound, erdos_476_summary are all fully proved. No True stubs, no sorries.

## Test plan

- [x] sorry/axiom counts verified via comment-stripped grep
- [x] tracker entry transitions issues-fixed (auditCount 2) → clean (auditCount 3)