### PR TITLE
audit(tracker): mark erdos-474 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6972,10 +6972,10 @@
       "result": "clean"
     },
     "erdos-474": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-01",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T19:57:50Z",
+      "result": "clean"
     },
     "erdos-475": {
       "agentId": "auditor-87018",


### PR DESCRIPTION
## Summary
- Re-audited `erdos-474` (Coloring ℝ² for Uncountable Sets) against `Erdos474Problem.lean`
- All meta.json counts match source: 3 axioms, 0 sorries, 2 theorems, 12 definitions, 277 lines
- Status `axiomatized` / badge `axiom` is correct for this open problem with 3 explicit axioms (`sierpinski_kurepa`, `erdos_under_ch`, `shelah_consistency`)
- No phantom-axiom narrative; all named axioms exist in source

## Test plan
- [x] Tracker JSON parses (Python json.load + json.dump)
- [x] Diff is exactly 4 lines (no unicode escape pollution from claim-target.sh bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)