### PR TITLE
fix(meta): erdos-474 assumptions field misdescribes sierpinski_kurepa axiom

### DIFF
--- a/src/data/proofs/erdos-474/meta.json
+++ b/src/data/proofs/erdos-474/meta.json
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 277,
-    "assumptions": "3 axioms: sierpinski_kurepa (Sierpiński-Kurepa — CH implies the result), erdos_under_ch (Erdős under CH), shelah_consistency (Shelah consistency result). 0 sorries."
+    "assumptions": "3 axioms: sierpinski_kurepa (Sierpiński-Kurepa — unconditional 2-color partition result), erdos_under_ch (Erdős — 3-color partition under CH), shelah_consistency (Shelah — failure of 3-color partition is consistent with ZFC). 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #474: Coloring ℝ² for Uncountable Sets**\n\nA foundational problem in infinite Ramsey theory posed by Erdős in 1954, asking when the continuum can be 3-colored so that every uncountable set's pairs realize all colors. Erdős offered a $100 prize for resolving the problem without the Continuum Hypothesis.\n\n**Key History:**\n- 1954: Erdős posed the problem and offered $100\n- Sierpinski and Kurepa independently proved the 2-color case always works\n- Erdős proved the 3-color case holds under CH (c = ℵ₁)\n- Shelah showed a negative answer is consistent with ZFC, though his model requires a very large continuum (much larger than ℵ₂)\n\n**Mathematical Setting:**\nIn partition calculus notation, the question is: When does 2^ℵ₀ → (ℵ₁)³₂ hold? This sits at the intersection of cardinal arithmetic and Ramsey theory, where independence phenomena from ZFC arise naturally. The key open question is whether failure is consistent with c = ℵ₂.",


### PR DESCRIPTION
## Fix

`meta.assumptions` described `sierpinski_kurepa` as "CH implies the result" but this axiom is the **unconditional** Sierpiński-Kurepa 2-color partition theorem — no Continuum Hypothesis required. Only `erdos_under_ch` is CH-conditional.

## Evidence

**Before**: `"3 axioms: sierpinski_kurepa (Sierpiński-Kurepa — CH implies the result), ..."`

**After**: `"3 axioms: sierpinski_kurepa (Sierpiński-Kurepa — unconditional 2-color partition result), erdos_under_ch (Erdős — 3-color partition under CH), shelah_consistency (Shelah — failure of 3-color partition is consistent with ZFC). 0 sorries."`

The other meta.json fields already correctly described it: `originalContributions[6]` says "2-color case always works", `overview.problemStatement` says "2 colors: ALWAYS works (Sierpinski-Kurepa)". Only `meta.assumptions` had the wrong parenthetical.

Closes #14370

---
Automated fix by lean-mechanic agent.