### PR TITLE
fix(meta): erdos-47 phantom axiom narrative

### DIFF
--- a/src/data/proofs/erdos-47/meta.json
+++ b/src/data/proofs/erdos-47/meta.json
@@ -53,11 +53,9 @@
       "Icc1: interval {1,…,N} as Finset",
       "IsDenseSubset: δ-density via reciprocal sum",
       "ErdosConjecture47: formal statement of the conjecture",
-      "bloom_theorem: Bloom's proof (axiomatized)",
-      "bloom_quantitative: explicit triple-log threshold (axiomatized)",
-      "liu_sawhney_improvement: (log N)^{4/5+ε} threshold (axiomatized)",
-      "pomerance_lower_bound: (log log N)² optimality (axiomatized)",
-      "erdos_47_summary: summary equating conjecture to Bloom's theorem"
+      "bloom_theorem: Bloom's proof (axiomatized, line 100)",
+      "Documented in docstrings only (not axiomatized): bloom_quantitative bound (triple-log threshold), Liu-Sawhney threshold improvement ((log N)^{4/5+ε}), Pomerance lower-bound construction ((log log N)²)",
+      "erdos_47_summary: summary theorem equating conjecture to Bloom's theorem (proved, line 130)"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 1,
@@ -68,7 +66,7 @@
     "historicalContext": "Erdős posed Problem #47 in the 1960s, asking whether sets of positive integers with large reciprocal sums must contain subsets whose reciprocals sum to exactly 1—an Egyptian fraction representation. The problem connects to a rich tradition going back to the Rhind Papyrus (c. 1650 BCE), where ancient Egyptians expressed fractions as sums of unit fractions. Erdős and Graham conjectured that the threshold should be around $(\\log \\log N)^2$. Thomas Bloom resolved the conjecture affirmatively in his landmark 2021 paper [Bl21], using the Hardy–Littlewood circle method combined with structural results on additive energy. Mehtaab Liu and Ashwin Sawhney [LiSa24] subsequently improved Bloom's quantitative bound from $(\\log N)^{1-o(1)}$ down to $(\\log N)^{4/5+o(1)}$, a dramatic polynomial improvement. Carl Pomerance showed that sets with $\\sum 1/a \\approx (\\log \\log N)^2$ can avoid unit fraction subsets, establishing that Erdős's conjectured threshold is essentially tight. The gap between $(\\log \\log N)^2$ and $(\\log N)^{4/5}$ remains one of the central open quantitative questions in combinatorial number theory.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nIf $\\delta > 0$ and $N$ is sufficiently large, and $A \\subseteq \\{1, \\ldots, N\\}$ satisfies $\\sum_{a \\in A} \\frac{1}{a} > \\delta \\log N$, must there exist $S \\subseteq A$ with $\\sum_{n \\in S} \\frac{1}{n} = 1$?\n\n**Answer:** YES (Bloom 2021).\n\n**Quantitative bounds:** $(\\log \\log N)^2 \\leq \\text{threshold} \\leq (\\log N)^{4/5+o(1)}$.",
     "text": "If A ⊆ {1,…,N} has ∑ 1/a > δ log N, must some S ⊆ A have ∑ 1/n = 1? Yes — proved by Bloom (2021). Liu–Sawhney improved the quantitative bound. SOLVED.",
-    "proofStrategy": "The formalization defines reciprocal sums over $\\mathbb{Q}$ for exact arithmetic, the unit fraction sum property ($\\sum 1/n = 1$), and the density condition ($\\sum 1/a > \\delta \\log N$). Bloom's theorem, his quantitative bound, the Liu–Sawhney improvement, and Pomerance's lower bound construction are axiomatized. The summary theorem equates the conjecture with Bloom's result.",
+    "proofStrategy": "The formalization defines reciprocal sums over $\\mathbb{Q}$ for exact arithmetic, the unit fraction sum property ($\\sum 1/n = 1$), and the density condition ($\\sum 1/a > \\delta \\log N$). Bloom's theorem is axiomatized as the sole axiom; the quantitative refinements (bloom_quantitative bound, Liu–Sawhney improvement, Pomerance lower bound) are described in docstrings only — not declared as axioms or theorems in this file. The summary theorem equates the conjecture with Bloom's result.",
     "keyInsights": [
       "**Bloom's resolution (2021):** Proved Erdős's conjecture using the Hardy–Littlewood circle method and structural additive energy bounds—the first proof that harmonic density forces unit fraction subsets",
       "**Quantitative gap:** Best upper bound is $(\\log N)^{4/5+o(1)}$ (Liu–Sawhney), best lower bound is $(\\log \\log N)^2$ (Pomerance)—a vast gap between polynomial and double-logarithmic",
@@ -119,25 +117,33 @@
       "id": "bloom",
       "title": "Bloom's Theorem (2021)",
       "startLine": 90,
-      "endLine": 115,
-      "summary": "Axiomatizes Bloom's qualitative result ($\\texttt{bloom\\_theorem} : \\texttt{ErdosConjecture47}$) and quantitative bound: $\\sum \\frac{1}{a} \\geq C \\cdot \\frac{\\log \\log \\log N}{\\log \\log N} \\cdot \\log N$ suffices.",
-      "mathContext": "Axiomatizes Bloom's qualitative result ($\\texttt{bloom\\_theorem} : \\texttt{ErdosConjecture47}$) and quantitative bound: $\\sum \\frac{1}{a} \\geq C \\cdot \\frac{\\log \\log \\log N}{\\log \\log N} \\cdot \\log N$ suffices."
+      "endLine": 107,
+      "summary": "axiom bloom_theorem (line 100): Bloom's qualitative result ($\\texttt{bloom\\_theorem} : \\texttt{ErdosConjecture47}$). Lines 102–107 document the quantitative threshold in a docstring (no axiom or theorem declared).",
+      "mathContext": "Axiomatized: bloom_theorem (line 100). Docstring only: quantitative bound $\\sum \\frac{1}{a} \\geq C \\cdot \\frac{\\log \\log \\log N}{\\log \\log N} \\cdot \\log N$ suffices (lines 102–107)."
     },
     {
       "id": "liu-sawhney",
       "title": "Liu–Sawhney Improvement (2024)",
-      "startLine": 116,
-      "endLine": 129,
-      "summary": "Axiomatizes the improved threshold: $\\forall \\varepsilon > 0$, $\\sum \\frac{1}{a} \\geq (\\log N)^{4/5+\\varepsilon}$ suffices. A polynomial improvement from $(\\log N)^{1-o(1)}$ to $(\\log N)^{4/5+o(1)}$.",
-      "mathContext": "Axiomatized: Axiomatizes the improved threshold: $\\forall \\varepsilon > 0$, $\\sum \\frac{1}{a} \\geq (\\log N)^{4/5+\\varepsilon}$ suffices. A polynomial improvement from $(\\log N)^{1-o(1)}$ to $(\\log N)^{4/5+o(1)}$."
+      "startLine": 108,
+      "endLine": 114,
+      "summary": "Documents the Liu–Sawhney improved threshold $(\\log N)^{4/5+\\varepsilon}$ in a docstring only — no axiom or theorem declared in this range.",
+      "mathContext": "Docstring only (lines 108–114): improved threshold $\\forall \\varepsilon > 0$, $\\sum \\frac{1}{a} \\geq (\\log N)^{4/5+\\varepsilon}$ suffices."
     },
     {
       "id": "pomerance",
       "title": "Pomerance's Lower Bound",
-      "startLine": 130,
+      "startLine": 115,
+      "endLine": 122,
+      "summary": "Documents Pomerance's lower-bound construction (sets with $\\sum \\frac{1}{a} \\approx (\\log \\log N)^2$ avoiding unit fraction subsets) in a docstring only — no axiom or theorem declared.",
+      "mathContext": "Docstring only (lines 115–122): sets with $\\sum \\frac{1}{a} \\geq (\\log \\log N)^2$ avoiding unit fraction subsets for arbitrarily large $N$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary Theorem",
+      "startLine": 123,
       "endLine": 132,
-      "summary": "Axiomatizes Pomerance's construction: sets with $\\sum \\frac{1}{a} \\geq (\\log \\log N)^2$ avoiding unit fraction subsets exist for arbitrarily large $N$, showing the threshold is at least $(\\log \\log N)^2$.",
-      "mathContext": "Axiomatizes Pomerance's construction: sets with $\\sum \\frac{1}{a} \\geq (\\log \\log N)^2$ avoiding unit fraction subsets exist for arbitrarily large $N$, showing the threshold is at least $(\\log \\log N)^2$."
+      "summary": "theorem erdos_47_summary (line 130): proves ErdosConjecture47 by direct application of bloom_theorem.",
+      "mathContext": "Proved: erdos_47_summary : ErdosConjecture47 := bloom_theorem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

`erdos-47/meta.json` claimed `bloom_quantitative`, `liu_sawhney_improvement`, and `pomerance_lower_bound` were "axiomatized", but these names appear **only as docstring text** in `Proofs/Erdos47Problem.lean` — none are declared as axioms or theorems. The correct `axiomCount: 1` and `assumptions: "1 axiom: bloom_theorem"` were consistent, but three narrative fields contradicted them.

## Evidence

`grep -nE "^(axiom|theorem)" proofs/Proofs/Erdos47Problem.lean`:
- L100 `axiom bloom_theorem : ErdosConjecture47`
- L130 `theorem erdos_47_summary : ErdosConjecture47 := bloom_theorem`

`bloom_quantitative`, `liu_sawhney_improvement`, `pomerance_lower_bound` → **no matches** (docstrings only)

## Changes

- `originalContributions`: replaced 3 phantom-axiom bullets with "Documented in docstrings only (not axiomatized): ..."
- `overview.proofStrategy`: "Only `bloom_theorem` is axiomatized; the quantitative refinements are described in docstrings only"
- `sections`: corrected `bloom` (90–107, axiom at line 100 only), `liu-sawhney` (108–114, docstring only), `pomerance` (115–122, docstring only); added `summary` section (123–132) for `erdos_47_summary` theorem

Closes #14373

---
Automated fix by lean-mechanic agent.