### PR TITLE
audit(tracker): mark erdos-47 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6948,13 +6948,12 @@
       "result": "clean"
     },
     "erdos-47": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T20:20:16Z",
-      "result": "issues-found",
-      "issues": [
-        "Phantom-axiom narrative: originalContributions lists bloom_quantitative, liu_sawhney_improvement, pomerance_lower_bound as axiomatized but only docstrings exist (no axiom decls). Issue #14373, PR #14375 in flight."
-      ]
+      "agentId": "auditor-agent-2026-05-01",
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T20:29:45Z",
+      "result": "clean",
+      "issues": [],
+      "notes": "Re-audit after PR #14375 merged. Lean: 1 axiom (bloom_theorem L100), 0 sorries, 1 theorem (erdos_47_summary L130), 6 defs. meta originalContributions/proofStrategy correctly distinguish axiom from docstrings; section line ranges (90-107, 108-114, 115-122, 123-132) match actual file structure."
     },
     "erdos-470": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

PR #14375 (merged) fixed the phantom-axiom narrative in `src/data/proofs/erdos-47/meta.json`. The audit tracker still shows `issues-found` from a prior batch — this PR updates it to `clean`.

## Re-audit verification

Lean source `proofs/Proofs/Erdos47Problem.lean`:
- `axiom bloom_theorem : ErdosConjecture47` (line 100) — only axiom
- `theorem erdos_47_summary : ErdosConjecture47 := bloom_theorem` (line 130)
- 6 `def`/`noncomputable def` declarations
- 0 sorries

`meta.json`:
- `axiomCount: 1`, `assumptions: "1 axiom: bloom_theorem. 0 sorries."` ✓
- `originalContributions` correctly notes "Documented in docstrings only (not axiomatized): bloom_quantitative bound, Liu-Sawhney threshold improvement, Pomerance lower-bound construction" ✓
- `proofStrategy`: "Bloom's theorem is axiomatized as the sole axiom; the quantitative refinements ... are described in docstrings only" ✓
- Sections realigned to actual line ranges (bloom 90-107, liu-sawhney 108-114, pomerance 115-122, summary 123-132) ✓

## Test plan

- [x] tracker JSON parses cleanly
- [x] `result: clean` reflects post-#14375 state
- [x] no Unicode pollution (manual edit, not script-mediated)