### PR TITLE
audit(tracker): erdos-444 issues-found (#14385)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6769,9 +6769,12 @@
     },
     "erdos-444": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T22:00:00Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom-axiom narrative: 5 axiom names (case_all_naturals, case_primes, highly_composite_relative, exponential_lower_bound, no_uniform_bound) referenced in assumptions/originalContributions/sections/proofStrategy are only docstring text; only erdos_graham_conjecture_true is declared. Issue #14385"
+      ]
     },
     "erdos-445": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audited erdos-444 (Erdős Problem #444: Generalized Divisor Functions)
- Filed #14385 for phantom-axiom narrative
- Marks tracker entry `issues-found`, auditCount 2 → 3

## Findings

Lean source (`proofs/Proofs/Erdos444Problem.lean`, 137 lines) declares **exactly 1 axiom** (`erdos_graham_conjecture_true`, line 85). Numerical fields in meta.json (`axiomCount: 1`, `sorries: 0`, `theoremCount: 2`, `defCount: 6`, `lineCount: 137`) match.

But the narrative claims **5 additional axioms** that exist only as orphan docstring text:
- `case_all_naturals`, `case_primes` (Section 3 — Special Cases)
- `highly_composite_relative`, `exponential_lower_bound`, `no_uniform_bound` (Section 4 — Structural Properties)

These names appear in:
- `meta.assumptions` (full text)
- `meta.originalContributions` (2 of 6 items)
- `overview.proofStrategy` (items 3, 4, 5)
- `sections[2].mathContext` ("two specialization axioms")
- `sections[3].mathContext` ("three axioms in this section form a hierarchy")

Same family as the documented erdos-9XX phantom-axiom pattern (now ~38 instances).

## Test plan

- [x] Read meta.json against Lean source
- [x] Confirmed only `axiom erdos_graham_conjecture_true` is declared
- [x] Verified phantom names are orphan docstrings (lines 91-108)
- [x] Filed #14385 with recommended fixes for prose-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)