### PR TITLE
audit(tracker): erdos-440 issues-found (#14387)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6744,10 +6744,13 @@
       "result": "clean"
     },
     "erdos-440": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-01-session",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T20:40:12Z",
+      "result": "issues-found",
+      "issues": [
+        "PR #14387: phantom axiom erdos_szemeredi_liminf_bound in originalContributions/proofStrategy/section-3 — only tao_elementary_proof and van_doorn_sharp_bound declared in Lean"
+      ]
     },
     "erdos-441": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audit tracker update for erdos-440 (3rd audit, result: issues-found)
- Filed companion issue #14387 for phantom axiom narrative

## Context

erdos-440 originalContributions / proofStrategy / sections claim three axioms exist (`tao_elementary_proof`, `van_doorn_sharp_bound`, `erdos_szemeredi_liminf_bound`) but only the first two are declared in `proofs/Proofs/Erdos440Problem.lean`. Numerical `axiomCount: 2` is correct; the narrative is the only thing wrong.

See #14387 for the proposed meta.json text fixes.

## Test plan

- [x] Tracker JSON parses cleanly (no unicode-escape pollution)
- [x] Diff is minimal (only erdos-440 entry changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)