### PR TITLE
audit(tracker): erdos-442 clean, erdos-439 issues-found (#14392)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6757,9 +6757,10 @@
     },
     "erdos-442": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T20:55:00Z",
+      "result": "clean",
+      "notes": "2026-05-01: Verified 2 axioms (tao_counterexample, tao_construction) match declared. axiomCount=2, sorries=0, theorems=8, lineCount=255. Narrative consistent with Lean source. Section line ranges drift by 2 on Parts V/VI/VII (minor, not actionable)."
     },
     "erdos-443": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6733,9 +6733,12 @@
     },
     "erdos-439": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T21:05:00Z",
+      "result": "issues-found",
+      "issues": [
+        "2026-05-01: phantom contribution kth_power_result (claimed in originalContributions but no theorem of that name exists; only a Part VI docstring) + section line drift +4 to +7 on Parts VI/VII/VIII. Filed #14392."
+      ]
     },
     "erdos-44": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Two tracker entries from a single auditor session:

- **erdos-442 → clean** (Erdős Problem #442: LCM Sums Over Dense Subsets — disproved by Tao 2024)
- **erdos-439 → issues-found** (filed #14392 for phantom contribution + section line drift)

## erdos-442 (clean)

Lean source (`proofs/Proofs/Erdos442Problem.lean`, 255 lines) declares **exactly 2 axioms**:
- `tao_counterexample` (line 128)
- `tao_construction` (line 146)

Both names appear correctly in `meta.assumptions` ("2 axioms: tao_counterexample, tao_construction") and are referenced in `proofStrategy` items 4 and 5. Numerical fields match: axiomCount=2, sorries=0, theoremCount=8, lineCount=255. No phantom axioms, no True stubs.

Minor: section line ranges for Parts V/VI/VII drift by 2 lines. Below threshold for a separate fix.

## erdos-439 (issues-found, #14392)

Lean source declares **3 axioms** (`ess_two_colors`, `ess_three_colors`, `khalfalah_szemeredi`) — all match `meta.assumptions` and `meta.axiomCount`. sorries=0, no True stubs.

Two narrative drifts:
1. `meta.originalContributions[8]` claims contribution `kth_power_result` but no theorem of that name exists (only a Part VI docstring describes it).
2. Section line ranges drift +4 to +7 lines on Parts VI/VII/VIII (`kth-powers`, `graph-perspective`, `summary`).

See #14392 for recommended fixes.

## Test plan

- [x] Verified erdos-442: 2 declared axioms match 2 named in narrative
- [x] Verified erdos-439: 3 declared axioms match 3 named in narrative
- [x] Confirmed `kth_power_result` is absent from erdos-439 Lean source
- [x] Cross-checked section line ranges against `Part X` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)