### PR TITLE
audit(tracker): erdos-436 issues-found (#14395)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6715,9 +6715,9 @@
     },
     "erdos-436": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T21:10:47Z",
+      "result": "issues-found"
     },
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Mark erdos-436 as `issues-found` in the audit tracker
- Phantom-axiom narrative confirmed: r-function section description (meta.json line 77) claims "Axiomatizes existence for large primes" but lines 157-176 of `Erdos436Problem.lean` only contain `def minConsecKthResidues` and a docstring header — no `axiom` declaration exists in that range
- All numerical claims match the Lean source (9 axioms, 0 sorries, 686 lines, 49 theorems, 8 defs)
- Existing issue #14395 already files the integrity fix; no duplicate created

## Test plan
- [x] Verify only the `erdos-436` tracker entry changed (no spurious unicode rewrites)
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` still parses tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)