### PR TITLE
fix(meta): erdos-436 phantom axiom in r-function section

### DIFF
--- a/src/data/proofs/erdos-436/meta.json
+++ b/src/data/proofs/erdos-436/meta.json
@@ -74,8 +74,8 @@
       "title": "The $r(k,m,p)$ Function",
       "startLine": 157,
       "endLine": 176,
-      "summary": "Defines $r(k,m,p) = \\min\\{r \\geq 1 : r, \\ldots, r+m-1$ are $k$th power residues$\\}$ via $\\texttt{Nat.find}$. Axiomatizes existence for large primes.",
-      "mathContext": "Formal definition: Defines $r(k,m,p) = \\min\\{r \\geq 1 : r, \\ldots, r+m-1$ are $k$th power residues$\\}$ via $\\texttt{Nat.find}$. Axiomatizes existence for large primes."
+      "summary": "Defines $r(k,m,p) = \\min\\{r \\geq 1 : r, \\ldots, r+m-1$ are $k$th power residues$\\}$ via $\\texttt{Nat.find}$. A docstring at lines 170–173 notes existence for large primes informally; no axiom or theorem formalizes this claim.",
+      "mathContext": "Formal definition: Defines $r(k,m,p) = \\min\\{r \\geq 1 : r, \\ldots, r+m-1$ are $k$th power residues$\\}$ via $\\texttt{Nat.find}$. Existence for large primes is mentioned in a docstring only; no formal declaration."
     },
     {
       "id": "lambda-function",


### PR DESCRIPTION
## Fix

Remove false "Axiomatizes existence for large primes" claim from `r-function` section in `src/data/proofs/erdos-436/meta.json`.

## Evidence

**Before**: `summary` and `mathContext` both claimed "Axiomatizes existence for large primes."

**After**: Both fields accurately state that existence for large primes appears only in a docstring at lines 170–173 with no formal declaration.

**Lean source verification**: Lines 157–176 contain only:
- The Part II header comment (157–159)
- `noncomputable def minConsecKthResidues` (165–168)
- An orphan docstring `/-- Existence for Large Primes: ... -/` (170–173)
- Immediately followed by Part III header (174–176) — no axiom or theorem

The 9 declared axioms (matching `axiomCount: 9`) are all in other sections.

Closes #14395

---
Automated fix by lean-mechanic agent.