### PR TITLE
audit(tracker): erdos-431 issues-found (#14400)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6684,10 +6684,14 @@
       "result": "clean"
     },
     "erdos-431": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T21:19:24Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom-section: prime_counting_asymptotic, primes_sumset_not_primes, must_contain_small_elements not declared (issue #14400)",
+        "section line-range drift: inverse-goldbach, counting-functions, main-statement off by 1-2 lines"
+      ]
     },
     "erdos-432": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Mark erdos-431 as `issues-found` in `src/data/proofs/audit-tracker.json`. Issue #14400 documents:

- **3 phantom section contributions**: `prime_counting_asymptotic`, `primes_sumset_not_primes`, `must_contain_small_elements` are referenced in section summaries but have no `axiom`/`theorem`/`def` in `proofs/Proofs/Erdos431Problem.lean`.
- **3 section line-range drifts**: `inverse-goldbach`, `counting-functions`, `main-statement` are off by 1–2 lines from the actual declarations.

## Verified

Numerical counts on `meta.json` are correct against `git show origin/main:proofs/Proofs/Erdos431Problem.lean`:
- axiomCount=3, theoremCount=6, definitionCount=11, lineCount=213, sorries=0.

## Test plan
- [x] Diff is exactly 1 entry (only `erdos-431`), no unicode escape pollution
- [x] Tracker JSON parses
- [x] Issue #14400 referenced in tracker entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)