### PR TITLE
audit(tracker): erdos-425 issues-found (#14404)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6642,10 +6642,13 @@
       "result": "issues-fixed"
     },
     "erdos-425": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-01-1777671029",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T21:34:59Z",
+      "result": "issues-found",
+      "issues": [
+        "#14404: phantom axioms primes_are_sidon, log_conversion, sidon_bound in proofStrategy/sections + section line drift 5-23 lines"
+      ]
     },
     "erdos-426": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks `erdos-425` audit result `issues-found` after a re-audit pass against `origin/main` 9fde428fe38.

Filed issue #14404 documenting phantom axiom claims in narrative fields (`overview.proofStrategy`, `sections[2]`, `sections[6]`) that reference declarations not present in `proofs/Proofs/Erdos425Problem.lean`:

- `primes_are_sidon` (claimed as axiom in proofStrategy item 4 + sections[2])
- `log_conversion` (claimed in proofStrategy item 8 + sections[6])
- `sidon_bound` (claimed in sections[6])

Plus secondary section line drift (5-23 lines below actual Part headers).

Numerical fields are accurate: `axiomCount: 2` matches the 2 declared axioms (`erdos_bounds`, `alexander_construction`); `theoremCount: 1`, `definitionCount: 11`, `sorries: 0`, `lineCount: 264` all match.

## Test plan

- [x] `git diff` is 7 net lines, no unicode escape pollution (manual `ensure_ascii=False` write to avoid the recurring `claim-target.sh` bug)
- [x] Issue #14404 filed with full evidence
- [x] Tracker entry now reflects `issues-found` with the issue link

🤖 Generated with [Claude Code](https://claude.com/claude-code)