### PR TITLE
audit(tracker): erdos-426 clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6648,10 +6648,10 @@
       "result": "issues-fixed"
     },
     "erdos-426": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-36921",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T21:41:59Z",
+      "result": "clean"
     },
     "erdos-427": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-426 (Erdős Problem #426: Unique Subgraphs) against origin/main 9fde428fe38. All meta.json claims match the Lean source.

| Field | meta.json | Actual | Match |
|---|---|---|---|
| axiomCount | 4 | 4 (CountUniqueSubgraphs, brouwer_1975, bradac_christoph_2024, original_question_false) | ✅ |
| theoremCount | 2 | 2 (erdos_426_resolved, erdos_426_summary) | ✅ |
| definitionCount | 8 | 8 | ✅ |
| sorries | 0 | 0 | ✅ |
| lineCount | 255 | 255 | ✅ |

Narrative (`conclusion.summary`, `proofStrategy`, `keyInsights`) accurately reflects the axiomatized Bradač-Christoph 2024 resolution. No phantom contributions, no overclaiming.

## Test plan

- [x] `audit-tracker.json` parses as valid JSON
- [x] Only `entries.erdos-426` modified (no unicode escape pollution)
- [x] Lean source verified at HEAD: 2 axioms, 2 theorems, 8 defs, 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)