### PR TITLE
fix(meta): erdos-431 phantom section contributions and line drift

### DIFF
--- a/src/data/proofs/erdos-431/meta.json
+++ b/src/data/proofs/erdos-431/meta.json
@@ -93,24 +93,24 @@
       "title": "The Inverse Goldbach Conjecture",
       "summary": "InverseGoldbachPair, InverseGoldbachConjecture",
       "startLine": 54,
-      "endLine": 70,
+      "endLine": 72,
       "mathContext": "Mathematical content: InverseGoldbachPair, InverseGoldbachConjecture"
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions and Growth Bounds",
-      "summary": "countingFunction, GrowthBounds, Elsholtz-Harper 2015",
+      "summary": "countingFunction, GrowthBounds, Elsholtz-Harper 2015 (elsholtz_harper_2015 axiom)",
       "startLine": 71,
-      "endLine": 91,
-      "mathContext": "Bound: countingFunction, GrowthBounds, Elsholtz-Harper 2015"
+      "endLine": 94,
+      "mathContext": "Bound: countingFunction, GrowthBounds, elsholtz_harper_2015 axiom (lines 93-94)"
     },
     {
       "id": "prime-counting",
       "title": "Prime Counting Asymptotics",
-      "summary": "prime_counting_asymptotic: π(x) ~ x/log(x)",
-      "startLine": 92,
+      "summary": "Informal docstring noting π(x) ~ x/log(x); no Lean declaration in this section.",
+      "startLine": 96,
       "endLine": 100,
-      "mathContext": "Mathematical content: prime_counting_asymptotic: π(x) ~ x/log(x)"
+      "mathContext": "Mathematical content: Part 4 header and orphan docstring about prime counting asymptotics — no theorem or axiom declared."
     },
     {
       "id": "three-sets",
@@ -131,24 +131,24 @@
     {
       "id": "goldbach-connection",
       "title": "Connection to Goldbach",
-      "summary": "GoldbachConjecture, goldbach_implies_sumset, primes_sumset_not_primes",
+      "summary": "GoldbachConjecture def, goldbach_implies_sumset theorem; informal docstring noting Primes+Primes ≠ Primes (no declaration).",
       "startLine": 142,
       "endLine": 164,
-      "mathContext": "Mathematical content: GoldbachConjecture, goldbach_implies_sumset, primes_sumset_not_primes"
+      "mathContext": "Mathematical content: GoldbachConjecture (def, line 149), goldbach_implies_sumset (theorem, line 153). Orphan docstring at lines 159-161 describes primes-sumset inequality informally but has no corresponding Lean declaration."
     },
     {
       "id": "structural-constraints",
       "title": "Structural Constraints",
-      "summary": "must_contain_small_elements",
+      "summary": "Informal docstring noting A must contain 2 or be very special; no Lean declaration in this section.",
       "startLine": 165,
-      "endLine": 174,
-      "mathContext": "Mathematical content: must_contain_small_elements"
+      "endLine": 173,
+      "mathContext": "Mathematical content: Part 8 header and orphan docstring (line 168) about structural constraints on A — no theorem or axiom declared."
     },
     {
       "id": "main-statement",
       "title": "Main Problem Statement",
       "summary": "erdos_431_statement combining all results",
-      "startLine": 175,
+      "startLine": 174,
       "endLine": 193,
       "mathContext": "Mathematical content: erdos_431_statement combining all results"
     },


### PR DESCRIPTION
## Fix

Remove phantom declaration names from section summaries and fix section line ranges in `erdos-431/meta.json`.

## Evidence

**Phantom contributions removed**:
- `prime_counting_asymptotic` — only an orphan docstring at line 100, no Lean declaration
- `primes_sumset_not_primes` — orphan docstring at lines 159-161, no Lean declaration
- `must_contain_small_elements` — orphan docstring at line 168, no Lean declaration

**Section line ranges corrected**:
- `inverse-goldbach`: endLine 70 → 72 (InverseGoldbachConjecture declared at line 71)
- `counting-functions`: endLine 91 → 94 (elsholtz_harper_2015 axiom at lines 93-94)
- `prime-counting`: startLine 92 → 96 (section header starts at Part 4 comment)
- `structural-constraints`: endLine 174 → 173
- `main-statement`: startLine 175 → 174 (erdos_431_statement at line 174)

All numerical counts (axiomCount: 3, theoremCount: 6, definitionCount: 11, lineCount: 213, sorries: 0) remain correct and unchanged.

Closes #14400

---
Automated fix by lean-mechanic agent.