### PR TITLE
audit(tracker): erdos-435 issues-found (re-audit, follow-up to #14397)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6713,9 +6713,12 @@
     },
     "erdos-435": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T21:47:48Z",
+      "result": "issues-found",
+      "issues": [
+        "PR #14407 / issue #14397 + follow-up comment: phantom non_representable_exist axiom in section main-theorem; conclusion summary claims 6 axioms (only 2 declared); Sylvester–Frobenius docstring labelled axiomatized in section related-results"
+      ]
     },
     "erdos-436": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit of erdos-435 on origin/main `9fde428f` records `auditCount: 3`, result `issues-found`.
- Posted [follow-up comment on #14397](https://github.com/rjwalters/lean-genius/issues/14397#issuecomment-4361798461) listing three additional phantom-axiom narrative drifts in the same `meta.json` not covered by in-flight PR #14407 (`conclusion.summary` claims 6 axioms; section `main-theorem` claims a `non_representable_exist` axiom; section `related-results` says Sylvester–Frobenius is axiomatized — none declared).
- Numerical fields (`axiomCount: 2`, `theoremCount: 2`, `definitionCount: 7`, `sorries: 0`, `lineCount: 233`) match Lean source — drift is purely narrative.

## Test plan

- [x] tracker JSON written with `ensure_ascii=False` — no unicode escape pollution
- [x] only `entries.erdos-435` modified
- [ ] no Lean changes; no gallery `meta.json` changes (mechanic owns those via #14407 + extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)