### PR TITLE
fix(meta): erdos-425 phantom axiom claims and section line drift

### DIFF
--- a/src/data/proofs/erdos-425/meta.json
+++ b/src/data/proofs/erdos-425/meta.json
@@ -58,7 +58,7 @@
     "historicalContext": "Erd\u0151s introduced this problem in his 1968 paper \"On some applications of graph theory to number theoretic problems\" [Er68], where he established both upper and lower bounds for $F(n)$, the maximum size of a multiplicative Sidon subset of $\\{1,\\ldots,n\\}$. The bounds take the form $\\pi(n) + c_i n^{3/4}(\\log n)^{-3/2}$, showing that the prime counting function $\\pi(n)$ is the dominant term.\n\nThe problem was further discussed in Erd\u0151s (1973, 1977) and in the influential monograph of Erd\u0151s and Graham [ErGr80], where the real-number version was proposed: for $A \\subset [1,x]$ with $|ab - cd| \\ge 1$ for all distinct pairs, Erd\u0151s conjectured $\\max |A| = o(x)$. This conjecture was **disproved by Alexander** (reported in [ErGr80]), who showed that linear-sized sets $|A| \\ge cx$ are achievable using an exponential lifting of additive Sidon sets.\n\nThe connection between multiplicative and additive Sidon sets is central: taking logarithms converts products to sums, so $\\log(ab) = \\log a + \\log b$. Classical additive Sidon sets ($B_2$ sequences) have been studied since the 1930s by Sidon, Erd\u0151s, and Tur\u00e1n, with the maximum size being $(1 + o(1))\\sqrt{n}$ (Lindstr\u00f6m 1969). Whether the error term can be reduced to $O(n^\\varepsilon)$ is Erd\u0151s Problem #30, one of his most famous open questions (\\$1000 prize).",
     "problemStatement": "Let $F(n) = \\max |A|$ where $A \\subseteq \\{1,\\ldots,n\\}$ and all products $ab$ ($a < b$) are distinct.\n\n**Questions:**\n1. Is there a constant $c$ such that $F(n) = \\pi(n) + (c + o(1)) n^{3/4}(\\log n)^{-3/2}$?\n2. For $r$-fold products, is $|A| \\le \\pi(n) + O(n^{(r+1)/(2r)})$?\n\n**Real Version:** What is $\\max |A|$ for $A \\subset [1,x]$ with $|ab - cd| \\ge 1$?\n\n**Status:** Integer order of magnitude known; exact constant OPEN. Real version: $o(x)$ conjecture is FALSE (Alexander).",
     "text": "Let F(n) be the maximum size of A \u2286 {1,...,n} such that all pairwise products ab (a < b) are distinct. Erd\u0151s proved \u03c0(n) + c\u2081\u00b7n^(3/4)\u00b7(log n)^(-3/2) \u2264 F(n) \u2264 \u03c0(n) + c\u2082\u00b7n^(3/4)\u00b7(log n)^(-3/2). The exact constant c (if it exists) is unknown. Alexander disproved the real version conjecture.",
-    "proofStrategy": "The formalization builds from basic definitions to the main results:\n\n1. **Infrastructure**: `SubsetOfInterval`, `OrderedPair`, `ProductSet` using `Finset` operations\n2. **Core definitions**: `IsMultiplicativeSidon` (product injectivity), `IsMultiplicativeSidon'` (cardinality characterization)\n3. **Extremal function**: $F(n)$ via `Finset.sup'` over the powerset\n4. **Prime lower bound**: `primes_are_sidon` (axiom, needs unique factorization), giving $F(n) \\ge \\pi(n)$\n5. **Erd\u0151s bounds**: Axiomatized $n^{3/4}(\\log n)^{-3/2}$ secondary term with constants $c_1, c_2$\n6. **Generalizations**: $r$-fold products (`IsRMultiplicativeSidon`), real version (`RealMultSidon`)\n7. **Alexander's disproof**: Construction giving $|A| \\ge cx$ via exponential lifting of Sidon sets\n8. **Additive connection**: `IsSidonSet`, `log_conversion`, classical $\\sqrt{n}$ bound",
+    "proofStrategy": "The formalization builds from basic definitions to the main results:\n\n1. **Infrastructure**: `SubsetOfInterval`, `OrderedPair`, `ProductSet` using `Finset` operations\n2. **Core definitions**: `IsMultiplicativeSidon` (product injectivity), `IsMultiplicativeSidon'` (cardinality characterization)\n3. **Extremal function**: $F(n)$ via `Finset.sup'` over the powerset\n4. **Prime lower bound**: $F(n) \\ge \\pi(n)$ is discussed in source comments (docstring only; no Lean axiom `primes_are_sidon` is declared)\n5. **Erd\u0151s bounds**: Axiomatized $n^{3/4}(\\log n)^{-3/2}$ secondary term with constants $c_1, c_2$ (`erdos_bounds` axiom)\n6. **Generalizations**: $r$-fold products (`IsRMultiplicativeSidon`), real version (`RealMultSidon`)\n7. **Alexander's disproof**: Construction giving $|A| \\ge cx$ via exponential lifting of Sidon sets (`alexander_construction` axiom)\n8. **Additive connection**: `IsSidonSet` (additive $B_2$); log-conversion and classical $\\sqrt{n}$ bound are discussed in source comments only (no Lean declarations)",
     "keyInsights": [
       "**Primes are the core**: Any large multiplicative Sidon set must contain almost all primes $\\le n$, since primes are the only elements whose products are guaranteed distinct (by unique factorization). The gap $F(n) - \\pi(n) = \\Theta(n^{3/4}(\\log n)^{-3/2})$ measures how many composites can be safely added",
       "**The $3/4$ exponent**: The secondary term $n^{3/4}(\\log n)^{-3/2}$ arises from a balance between the number of composite candidates ($\\sim n$) and the collision probability ($\\sim n^{-1/2}$ per element). The upper bound uses collision counting; the lower bound uses greedy construction",
@@ -78,7 +78,7 @@
       "title": "Imports and Namespace",
       "summary": "Imports `Nat.Prime`, `Finset`, `Primorial`, and `Real.Basic`. Opens `Erdos425` namespace for all definitions and theorems.",
       "startLine": 31,
-      "endLine": 38,
+      "endLine": 37,
       "mathContext": "Formal definition: Imports `Nat.Prime`, `Finset`, `Primorial`, and `Real.Basic`. Opens `Erdos425` namespace for all definitions and theorems."
     },
     {
@@ -86,62 +86,62 @@
       "title": "Basic Definitions",
       "summary": "Defines `SubsetOfInterval n`, `OrderedPair A`, `ProductSet A = \\{ab : a,b \\in A,\\, a < b\\}$`, `IsMultiplicativeSidon` (product injectivity), and `IsMultiplicativeSidon'` (cardinality characterization).",
       "startLine": 39,
-      "endLine": 76,
+      "endLine": 75,
       "mathContext": "Defines `SubsetOfInterval n`, `OrderedPair A`, `ProductSet A = \\{ab : a,b \\in A,\\, a < b\\}$`, `IsMultiplicativeSidon` (product injectivity), and `IsMultiplicativeSidon'` (cardinality characterization)."
     },
     {
       "id": "function-f",
       "title": "The Function F(n)",
-      "summary": "$F(n) = \\max |A|$ over multiplicative Sidon $A \\subseteq \\{1,\\ldots,n\\}$ via `Finset.sup'`. Axioms: `primes_are_sidon` and $F(n) \\ge \\pi(n)$.",
+      "summary": "$F(n) = \\max |A|$ over multiplicative Sidon $A \\subseteq \\{1,\\ldots,n\\}$ via `Finset.sup'`. Lower bound $F(n) \\ge \\pi(n)$ discussed in source comments only; no Lean axiom `primes_are_sidon` is declared.",
       "startLine": 77,
-      "endLine": 109,
-      "mathContext": "$F(n) = \\max |A|$ over multiplicative Sidon $A \\subseteq \\{1,\\ldots,n\\}$ via `Finset.sup'`. Axioms: `primes_are_sidon` and $F(n) \\ge \\$\\pi$(n)$."
+      "endLine": 102,
+      "mathContext": "$F(n) = \\max |A|$ over multiplicative Sidon $A \\subseteq \\{1,\\ldots,n\\}$ via `Finset.sup'`. The lower bound $F(n) \\ge \\pi(n)$ is described in docstrings (lines 93-102) with no corresponding Lean declaration."
     },
     {
       "id": "erdos-bounds",
       "title": "Erd\u0151s's Bounds",
       "summary": "Axiom: $\\exists\\, 0 < c_1 \\le c_2$ with $\\pi(n) + c_1 n^{3/4}(\\log n)^{-3/2} \\le F(n) \\le \\pi(n) + c_2 n^{3/4}(\\log n)^{-3/2}$. `MainQuestion`: does a single constant $c$ exist?",
-      "startLine": 110,
-      "endLine": 135,
+      "startLine": 103,
+      "endLine": 128,
       "mathContext": "Axiom: $\\exists\\, 0 < c_1 \\le c_2$ with $\\$\\pi$(n) + c_1 n^{3/4}(\\$\\log n$)^{-3/2} \\le F(n) \\le \\$\\pi$(n) + c_2 n^{3/4}(\\$\\log n$)^{-3/2}$. `MainQuestion`: does a single constant $c$ exist?"
     },
     {
       "id": "r-product",
       "title": "r-Product Generalization",
       "summary": "`IsRMultiplicativeSidon A r` for $r$-fold product distinctness. `RProductConjecture`: $|A| \\le \\pi(n) + O(n^{(r+1)/(2r)})$ with exponent $3/4, 2/3, \\ldots \\to 1/2$.",
-      "startLine": 136,
-      "endLine": 162,
+      "startLine": 129,
+      "endLine": 155,
       "mathContext": "`IsRMultiplicativeSidon A r` for $r$-fold product distinctness. `RProductConjecture`: $|A| \\le \\$\\pi$(n) + $O(n^{(r+1)$/(2r)})$ with exponent $3/4, 2/3, \\ldots \\to 1/2$."
     },
     {
       "id": "real-version",
       "title": "The Real Number Version",
       "summary": "`RealMultSidon`: $|ab - cd| \\ge 1$. Erd\u0151s conjectured $o(x)$---**DISPROVED** by Alexander via Sidon-to-exponential lifting giving $|A| \\ge cx$.",
-      "startLine": 163,
-      "endLine": 199,
+      "startLine": 156,
+      "endLine": 187,
       "mathContext": "Mathematical content: `RealMultSidon`: $|ab - cd| \\ge 1$. Erd\u0151s conjectured $o(x)$---**DISPROVED** by Alexander via Sidon-to-exponential lifting giving $|A| \\ge cx$."
     },
     {
       "id": "sidon-connection",
       "title": "Connection to Additive Sidon Sets",
-      "summary": "`IsSidonSet` (additive $B_2$), `log_conversion` ($\\log(ab) = \\log a + \\log b$), `sidon_bound` ($|S| \\le \\sqrt{n} + n^{1/4}$). Links to Erd\u0151s Problem #30.",
-      "startLine": 200,
-      "endLine": 233,
-      "mathContext": "Bound: `IsSidonSet` (additive $B_2$), `log_conversion` ($\\log(ab) = \\log a + \\log b$), `sidon_bound` ($|S| \\le \\sqrt{n} + n^{1/4}$). Links to Erd\u0151s Problem #30."
+      "summary": "`IsSidonSet` (additive $B_2$ def, line 196). Log-conversion and classical $\\sqrt{n}$ Sidon bound discussed in source comments (no Lean declarations `log_conversion` or `sidon_bound`). Links to Erd\u0151s Problem #30.",
+      "startLine": 188,
+      "endLine": 210,
+      "mathContext": "Formal definition: `IsSidonSet` (line 196). The log-conversion remark ($\\log(ab) = \\log a + \\log b$) and classical $\\sqrt{n}$ bound are docstring commentary only — no corresponding Lean declarations."
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Verified counterexample: $\\{1,2,3,6\\}$ is not multiplicative Sidon since $1 \\cdot 6 = 2 \\cdot 3 = 6$. Proved with `norm_num` and `simp`.",
-      "startLine": 234,
-      "endLine": 248,
+      "startLine": 211,
+      "endLine": 225,
       "mathContext": "Mathematical content: Verified counterexample: $\\{1,2,3,6\\}$ is not multiplicative Sidon since $1 \\cdot 6 = 2 \\cdot 3 = 6$. Proved with `norm_num` and `simp`."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "`erdos_425_summary`: packages Erd\u0151s bounds $\\wedge$ Alexander construction. Proved by `\u27e8erdos_bounds, alexander_construction\u27e9`.",
-      "startLine": 249,
+      "startLine": 226,
       "endLine": 264,
       "mathContext": "Bound: `erdos_425_summary`: packages Erd\u0151s bounds $\\wedge$ Alexander construction. Proved by `\u27e8erdos_bounds, alexander_construction\u27e9`."
     }


### PR DESCRIPTION
## Fix

Three phantom declaration names and drifted section line ranges in `erdos-425/meta.json`.

## Evidence

**Phantom claims removed**:
- `primes_are_sidon` — only a docstring at lines 93-102, no Lean axiom/theorem/def
- `log_conversion` — docstring remark at lines 200-206, no Lean declaration
- `sidon_bound` — docstring remark at lines 207-210, no Lean declaration

Updated `overview.proofStrategy` items 4 and 8, and sections `function-f` and `sidon-connection` summaries to accurately describe what is and isn't formalized.

**Section line ranges corrected** (Part headers from Lean source):
| Section | Old start | New start | Old end | New end |
|---------|-----------|-----------|---------|---------|
| imports | 31 | 31 | 38 | 37 |
| basic-definitions | 39 | 39 | 76 | 75 |
| function-f | 77 | 77 | 109 | 102 |
| erdos-bounds | 110 | 103 | 135 | 128 |
| r-product | 136 | 129 | 162 | 155 |
| real-version | 163 | 156 | 199 | 187 |
| sidon-connection | 200 | 188 | 233 | 210 |
| examples | 234 | 211 | 248 | 225 |
| summary | 249 | 226 | 264 | 264 |

All numerical counts (`axiomCount: 2`, `theoremCount: 1`, `definitionCount: 11`, `lineCount: 264`, `sorries: 0`, `originalContributions`) unchanged and correct.

Closes #14404

---
Automated fix by lean-mechanic agent.