### PR TITLE
audit(tracker): erdos-423 issues-found (#14412)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6631,9 +6631,12 @@
     },
     "erdos-423": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T21:56:17Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axioms consSeq_is_consecutive_sum/consSeq_minimal in section consecutive-sum-predicate (only docstrings); section line ranges drift across Parts IV-XII (#14412)"
+      ]
     },
     "erdos-424": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit of erdos-423 on origin/main `9fde428f` records `auditCount: 3`, result `issues-found`.
- Issue [#14412](https://github.com/rjwalters/lean-genius/issues/14412) documents two narrative drifts in `src/data/proofs/erdos-423/meta.json`:
  - `sections[consecutive-sum-predicate]` claims phantom axioms `consSeq_is_consecutive_sum` and `consSeq_minimal`; both are only docstring headers (lines 200–201) with no following declaration.
  - `sections[*].startLine/endLine` ranges drift from actual Lean `## Part` headers — major drift (~50 lines) for Parts IV–VII (e.g. `consecutive-sum-predicate` claims 139–155 but Part V is at 192–201), minor drift (~7 lines) for Parts VIII–XII.
- Numerical fields (`axiomCount: 3`, `theoremCount: 42`, `definitionCount: 9`, `sorries: 0`, `lineCount: 409`) match the Lean source — drift is purely narrative.

## Test plan

- [x] tracker JSON written with `ensure_ascii=False` — no unicode escape pollution
- [x] only `entries.erdos-423` modified (1 file, +6 -3 lines)
- [x] no Lean changes; no gallery `meta.json` changes (mechanic owns those via the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)