### PR TITLE
audit(tracker): erdos-41 issues-found (#14415)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6541,9 +6541,12 @@
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T22:20:35Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom Nash h=4 axiom in proofStrategy and section solved-cases (only docstring, Chen subsumes); section examples implies powersOfTwo theorem but only def + docstring exist (#14415)"
+      ]
     },
     "erdos-410": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit of erdos-41 on origin/main `10f702fdc3c` records `auditCount: 3`, result `issues-found`.
- Issue [#14415](https://github.com/rjwalters/lean-genius/issues/14415) documents two narrative drifts in `src/data/proofs/erdos-41/meta.json`:
  - `proofStrategy` and `sections[solved-cases]` claim a Nash h=4 axiom; only Erdős's `erdos_b2_theorem` and Chen's `chen_even_h_theorem` are declared (Nash is a docstring header at lines 78–81; Chen subsumes h=4).
  - `sections[examples]` implies a theorem about `powersOfTwo` being a B_2 set; only `def powersOfTwo` and a "Key lemma" docstring exist — no theorem.
- Numerical fields (`axiomCount: 2`, `theoremCount: 6`, `definitionCount: 7`, `sorries: 0`, `lineCount: 164`) match the Lean source — drift is purely narrative.

## Test plan

- [x] tracker JSON written with `ensure_ascii=False` — no unicode escape pollution
- [x] only `entries.erdos-41` modified (1 file, +6 -3 lines)
- [x] no Lean changes; no gallery `meta.json` changes (mechanic owns those via the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)