### PR TITLE
fix(meta): erdos-41 phantom Nash h=4 axiom + phantom powers-of-2 B_h theorem

### DIFF
--- a/src/data/proofs/erdos-41/meta.json
+++ b/src/data/proofs/erdos-41/meta.json
@@ -55,7 +55,7 @@
     "historicalContext": "Erdős Problem #41 asks about the density of B_h sequences - sets where all h-element subset sums are distinct. The h=2 case corresponds to classical Sidon sets, studied extensively in additive combinatorics.\n\nErdős proved the h=2 case: if A is an infinite Sidon set, then liminf |A ∩ {1,...,N}| / √N = 0. This means Sidon sets must be sparse infinitely often at the √N scale.\n\nThe problem generalizes to all h ≥ 2: is liminf |A ∩ {1,...,N}| / N^(1/h) = 0 for infinite B_h sets? Nash (1989) proved this for h=4 using Fourier-analytic methods, and Chen (1996) extended it to all even h.\n\nThe h=3 case (triple sums) remains OPEN with a $500 prize. Odd h ≥ 3 resists the Fourier techniques that work for even h.",
     "problemStatement": "Let $A \\subseteq \\mathbb{N}$ be an infinite set where all triple sums $a + b + c$ are distinct (for distinct $a, b, c \\in A$). Is it true that:\n\n$$\\liminf_{N \\to \\infty} \\frac{|A \\cap \\{1, \\ldots, N\\}|}{N^{1/3}} = 0?$$\n\n**Status by h-value:**\n- h = 2: SOLVED (Erdős)\n- h = 3: **OPEN** ($500 prize)\n- h = 4: SOLVED (Nash 1989)\n- All even h ≥ 2: SOLVED (Chen 1996)\n- All odd h ≥ 3: OPEN",
     "text": "For infinite B_3 sets (distinct triple sums), is liminf |A ∩ {1,...,N}| / N^(1/3) = 0?",
-    "proofStrategy": "We formalize the general B_h density conjecture and state the known results as axioms:\n\n1. **IsBhSet**: A set where all h-element subset sums are distinct\n2. **ErdosBhConjecture(h)**: The density bound liminf ... = 0 holds for all infinite B_h sets\n3. **Axioms**: Erdős (h=2), Nash (h=4), Chen (all even h)\n4. **Open**: The h=3 case remains as a definition, not an axiom\n\nThe proofs of these results require Fourier analysis and analytic number theory beyond Mathlib, so they're axiomatized with references.",
+    "proofStrategy": "We formalize the general B_h density conjecture and state the known results as axioms:\n\n1. **IsBhSet**: A set where all h-element subset sums are distinct\n2. **ErdosBhConjecture(h)**: The density bound liminf ... = 0 holds for all infinite B_h sets\n3. **Axioms**: Erdős (h=2) and Chen (all even h ≥ 2, which subsumes Nash's h=4 result)\n4. **Open**: The h=3 case remains as a definition, not an axiom\n\nThe proofs of these results require Fourier analysis and analytic number theory beyond Mathlib, so they're axiomatized with references.",
     "keyInsights": [
       "**B_h sequences generalize Sidon sets**: B_2 sets are exactly Sidon sets. B_3 sets have distinct triple sums.",
       "**Even vs. odd h**: The Fourier-analytic techniques that prove even h don't extend to odd h, which is why h=3 remains open.",
@@ -83,7 +83,7 @@
       "title": "Solved Cases",
       "startLine": 67,
       "endLine": 94,
-      "summary": "Axioms for Erdős (h=2), Nash (h=4), and Chen (all even h) theorems."
+      "summary": "Axioms for Erdős (h=2) and Chen (all even h ≥ 2). The Nash (h=4) result is a docstring at lines 78–81 with no separate axiom — Chen's axiom covers h=4."
     },
     {
       "id": "open-case",
@@ -104,7 +104,7 @@
       "title": "Examples",
       "startLine": 121,
       "endLine": 151,
-      "summary": "Empty set, singleton, and powers of 2 as B_h sets."
+      "summary": "Theorems for empty set and singleton as B_h sets; `powersOfTwo` defined but no theorem proves it is a B_2 set (only a docstring 'Key lemma')."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Corrects three phantom narrative claims in `src/data/proofs/erdos-41/meta.json` that describe declarations not present in the Lean source.

## Evidence

**Issue 1 — Phantom Nash h=4 axiom in `proofStrategy`:**
- **Before**: `"3. **Axioms**: Erdős (h=2), Nash (h=4), Chen (all even h)"`
- **After**: `"3. **Axioms**: Erdős (h=2) and Chen (all even h ≥ 2, which subsumes Nash's h=4 result)"`
- **Why**: Only two axioms exist (`erdos_b2_theorem`, `chen_even_h_theorem`). Nash appears as a docstring at lines 78–81 but has no separate axiom declaration — Chen's axiom already covers h=4.

**Issue 2 — Phantom Nash axiom in `sections[solved-cases].summary`:**
- **Before**: `"Axioms for Erdős (h=2), Nash (h=4), and Chen (all even h) theorems."`
- **After**: `"Axioms for Erdős (h=2) and Chen (all even h ≥ 2). The Nash (h=4) result is a docstring at lines 78–81 with no separate axiom — Chen's axiom covers h=4."`

**Issue 3 — Phantom powers-of-2 theorem in `sections[examples].summary`:**
- **Before**: `"Empty set, singleton, and powers of 2 as B_h sets."`
- **After**: `"Theorems for empty set and singleton as B_h sets; \`powersOfTwo\` defined but no theorem proves it is a B_2 set (only a docstring 'Key lemma')."`
- **Why**: Only `def powersOfTwo` and a docstring "Key lemma" exist; no theorem proves `IsBhSet powersOfTwo 2`.

All numerical fields (`axiomCount: 2`, `sorries: 0`, line counts) are accurate and unchanged.

Closes #14415

---
Automated fix by lean-mechanic agent.