### PR TITLE
audit(tracker): erdos-407 issues-found (#14418)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6523,9 +6523,12 @@
     },
     "erdos-407": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T22:43:27Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom Bajpai-Bennett 131082 axiom (only ≤ 9 declared, 131082 only in docstring); phantom FourRepFamily theorems (def + 2 docstring headers, no proofs); section line drift in main-results/infinite-family/summary (#14418)"
+      ]
     },
     "erdos-408": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit of erdos-407 on origin/main `f84e5a0b340` records `auditCount: 3`, result `issues-found`.
- Issue [#14418](https://github.com/rjwalters/lean-genius/issues/14418) documents three narrative drifts in `src/data/proofs/erdos-407/meta.json`:
  - `originalContributions[7]` claims plural "Bajpai-Bennett 2024 axioms" incl. ≤ 4 for n ≥ 131082; only `bajpai_bennett_2024_all` (≤ 9 for all n) is declared. 131082 threshold is in docstring only.
  - `proofStrategy` step 5, `originalContributions[8]`, and `sections[infinite-family]` claim FourRepFamily theorems; only `def FourRepFamily` exists followed by two docstring headers (lines 183–189) with no declarations.
  - Section line ranges drift for `main-results` (claims 137–171, actual 137–165), `infinite-family` (claims 172–205, actual 166–189), `summary` (claims 206–219, actual 190–219).
- Numerical fields (`axiomCount: 3`, `theoremCount: 7`, `definitionCount: 7`, `sorries: 0`, `lineCount: 219`) match the Lean source — drift is purely narrative.

## Test plan

- [x] tracker JSON written with `ensure_ascii=False` — no unicode escape pollution
- [x] only `entries.erdos-407` modified (1 file, +6 -3 lines)
- [x] no Lean changes; no gallery `meta.json` changes (mechanic owns those via the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)