### PR TITLE
audit(tracker): erdos-405 issues-found (#14422)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6510,10 +6510,13 @@
       "result": "clean"
     },
     "erdos-405": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T00:00:00Z",
+      "result": "issues-found",
+      "issues": [
+        "issue #14422: phantom \"Axiomatizes Wilson/Fermat\" in wilson-theorem section (proved via Mathlib ZMod lemmas); section line drift sections 3-9 (~25-30 line offset); minor: originalContributions[5] overstates IsPerfectPower as \"formalized generalization\""
+      ]
     },
     "erdos-406": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

3rd auditor pass on erdos-405 surfaces issues missed by prior count-only audits (#14421 marked clean).

## Findings (filed as #14422)

- **Phantom axiom narrative**: section `wilson-theorem` summary/mathContext say "Axiomatizes Wilson's theorem ... Fermat's little theorem ..." — both are proved in source via Mathlib `ZMod.wilsons_lemma` and `ZMod.pow_card_sub_one_eq_one`.
- **Section line drift**: `sections[3..9]` `startLine`/`endLine` are systematically ~25–30 lines below the actual content. E.g. `padic-analysis` claims 149–167 (which is Part 5: exceptional case), while the actual p-adic theorems sit at 167–207.
- **Minor narrative inflation**: `originalContributions[5]` "Formalized the Erdős–Graham perfect-power generalization" overstates a single `norm_num` example.

`axiomCount: 3`, `sorries: 0`, `lineCount: 299`, status `axiomatized`, badge `axiom` are all correct — no count fixes needed.

## Tracker change

```
erdos-405: auditCount 2→3, result issues-fixed→issues-found, lastAudited → 2026-05-02
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)