### PR TITLE
audit(tracker): erdos-393 issues-found (#14432)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6423,10 +6423,13 @@
       "result": "issues-fixed"
     },
     "erdos-393": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T07:00:00Z",
+      "result": "issues-found",
+      "issues": [
+        "issue #14432: section line drift Parts 3-8 (counting-function/abc-conditional/bounds/diophantine/density ranges off by 3-14 lines); empty Part 6 'Lower Bounds' has only 3 dangling /-- ... -/ docstrings (137-139), no formalized bounds; numerical counts (4 axioms, 0 sorries, 4 theorems, 12 defs, 177 lines) and axiomatized/axiom badge all clean"
+      ]
     },
     "erdos-394": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks `erdos-393` as audited at 2026-05-02T07:00:00Z with `issues-found` and links issue #14432.
- Findings: section line drift Parts 3-8 (counting-function/abc-conditional/bounds/diophantine/density ranges off by 3-14 lines); empty Part 6 "Lower Bounds" contains only three dangling `/-- ... -/` docstrings with no theorems.
- Numerical counts (4 axioms, 0 sorries, 4 theorems, 12 defs, 177 lines) and the `axiomatized`/`axiom` badge match the Lean source — credibility risk is LOW.

## Test plan
- [x] `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` — JSON valid
- [x] Diff is 7+/4-, only the `erdos-393` entry changed, no `\u2192`/`\u2014` unicode escapes