### PR TITLE
audit(tracker): erdos-39 issues-found (#14434)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6394,10 +6394,17 @@
       "result": "clean"
     },
     "erdos-39": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-02-0128",
+      "auditCount": 4,
+      "issues": [
+        "phantom AKS/Ruzsa axiom claims in proofStrategy step 3 + originalContributions[2] (only erdos_sidon_upper_bound is an axiom; AKS/Ruzsa are docstrings on lines 90-98)",
+        "section line drift: [3] 57-73 should extend to 86; [4] startLine 74 should be 88; [6] 134-149 misses line 141 marker and theorem at 165; [7] title 'Verified Examples' should be 'Verified Facts' (Lean line 168), startLine 170 should be 168"
+      ],
+      "lastAudited": "2026-05-01T23:33:00Z",
+      "result": "issues-found",
+      "issueRefs": [
+        14434
+      ]
     },
     "erdos-390": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Records the audit result for **erdos-39** (Infinite Sidon Set Growth Rate) in the audit tracker as `issues-found`, linking issue #14434.

## Findings

- **Numerical counts correct**: axiomCount=1, sorries=0, status/badge `axiomatized`/`axiom` ✓
- **Phantom-axiom narrative**: `overview.proofStrategy` step 3 and `meta.originalContributions[2]` claim AKS / Ruzsa are axiomatized — but Lean source has only one axiom (`erdos_sidon_upper_bound`); AKS / Ruzsa appear only as `/-- ... -/` docstrings on lines 90–98.
- **Section line drift / title mismatch**: indices 3, 4, 6, 7 misaligned vs `Erdos39Problem.lean`; section 7 title `Verified Examples` should be `Verified Facts` (Lean line 168).

A follow-up content PR will fix the meta.json narrative and section ranges; this PR only updates the tracker.

## Test plan

- [x] Tracker entry retains valid JSON, no unicode-escape pollution
- [x] `issueRefs` points to #14434
- [x] No other entries modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)