### PR TITLE
audit(tracker): erdos-382 issues-found (#14436)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6347,9 +6347,9 @@
     },
     "erdos-382": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-01T23:37:09Z",
+      "result": "issues-found"
     },
     "erdos-383": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker bookkeeping for #14436.

Updates `audit-tracker.json` for `erdos-382`:
- `auditCount` 3 → 4
- `lastAudited` → 2026-05-01T23:37:09Z
- `result` `issues-fixed` → `issues-found`

Findings (full detail in #14436):
- Phantom axiom narrative cites `erdos_382_q1` / `erdos_382_q2_heuristic` that do not exist
- Two dangling doc-comments at Lean lines 275-276 and 285
- `proofStrategy` claims Cramér's implication is axiomatized; `cramer_implies_q1` is actually proved
- Section line drift in cramer / examples / prime-free / summary

Numerical counts (axiomCount=1, sorries=0, lineCount=661) all match the Lean file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)