### PR TITLE
audit(tracker): erdos-381 issues-found (#14438)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6340,10 +6340,13 @@
       "result": "clean"
     },
     "erdos-381": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-2026-05-02",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T01:45:00Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom HC_exponent_decreasing/ramanujan_characterization/HC_sparser_than_primes theorems in originalContributions; 4 dangling doc-comments; section line drift Parts VI–IX (#14438)"
+      ]
     },
     "erdos-382": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-381 audit complete with `issues-found` (audit cycle 3, prior result was `issues-fixed` 2026-04-03).

Issue filed: #14438 — three phantom theorems in originalContributions, four dangling doc-comments, and section line drift in Parts VI–IX.

## Summary
- Updates `audit-tracker.json` entry for erdos-381 only.
- Preserves unicode characters in the rest of the tracker (no `\u2192`/`\u2014` escape pollution).

## Test plan
- [x] Tracker entry updated (auditCount 2→3, result issues-fixed→issues-found, references #14438)
- [x] No unrelated diff lines