### PR TITLE
audit(tracker): erdos-379 issues-found (#14440)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6323,9 +6323,12 @@
     },
     "erdos-379": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T23:46:04Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14440: narrative claims Lean-verified but main result is axiom (3 axioms total); section line drift; basic-properties section has no Lean theorems"
+      ]
     },
     "erdos-38": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records audit completion for `erdos-379` with result `issues-found`.
- Linked integrity issue: #14440 — narrative claims "Lean verified" / "computer-verified" but main theorem and two supporting lemmas are stated as axioms (3 total). Section line ranges drift 4-11 lines; `basic-properties` section has only orphan docstrings.

## Test plan
- [x] Tracker entry updated with auditCount, lastAudited, result, and issue note
- [x] No unicode escape pollution in diff