### PR TITLE
fix(meta): erdos-391 section line ranges drift Parts IV-IX

### DIFF
--- a/src/data/proofs/erdos-391/meta.json
+++ b/src/data/proofs/erdos-391/meta.json
@@ -109,46 +109,46 @@
       "title": "The ACRSTUV Theorem (2025)",
       "summary": "Main asymptotic formula and corollaries: limit equals 1/e, second-order correction",
       "startLine": 106,
-      "endLine": 138,
+      "endLine": 133,
       "mathContext": "Mathematical content: Main asymptotic formula and corollaries: limit equals 1/e, second-order correction"
     },
     {
       "id": "explicit-bounds",
       "title": "Explicit Bounds",
       "summary": "t(n) ≤ n/e for n ≠ 1,2,4; t(n) ≥ n/3 for n ≥ 43632; sharpness of 43632",
-      "startLine": 139,
-      "endLine": 161,
+      "startLine": 134,
+      "endLine": 153,
       "mathContext": "t(n) $\\leq$ n/e for n $\\neq$ 1,2,4; t(n) $\\geq$ n/3 for n $\\geq$ 43632; sharpness of 43632"
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "summary": "Explicit values t(1)=1, t(2)=2, t(3)=2, t(4)=3; exception at n=4",
-      "startLine": 162,
-      "endLine": 176,
+      "startLine": 154,
+      "endLine": 163,
       "mathContext": "Mathematical content: Explicit values t(1)=1, t(2)=2, t(3)=2, t(4)=3; exception at n=4"
     },
     {
       "id": "guy-selfridge",
       "title": "Guy-Selfridge Conjectures",
       "summary": "Definitions and proofs of both Guy-Selfridge conjectures",
-      "startLine": 177,
-      "endLine": 197,
+      "startLine": 164,
+      "endLine": 182,
       "mathContext": "Formal definition: Definitions and proofs of both Guy-Selfridge conjectures"
     },
     {
       "id": "factorization-perspective",
       "title": "The Factorization Perspective",
       "summary": "Balanced factorization view — optimal factorization always exists",
-      "startLine": 198,
-      "endLine": 209,
+      "startLine": 183,
+      "endLine": 190,
       "mathContext": "Mathematical content: Balanced factorization view — optimal factorization always exists"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_391_summary theorem assembling all four main results",
-      "startLine": 210,
+      "startLine": 191,
       "endLine": 227,
       "mathContext": "Verified: erdos_391_summary theorem assembling all four main results"
     }


### PR DESCRIPTION
## Fix

Realign `meta.sections[3..8].startLine/endLine` for erdos-391 to match actual `## Part` markers in `proofs/Proofs/Erdos391Problem.lean`.

## Evidence

**Before**: Sections IV–IX had line ranges drifted by +5 to +19 lines each
**After**: All 9 section ranges correctly aligned with the Lean source file:

| Section | Before | After |
|---|---|---|
| acrstuv-theorem | 106-138 | 106-133 |
| explicit-bounds | 139-161 | 134-153 |
| small-cases | 162-176 | 154-163 |
| guy-selfridge | 177-197 | 164-182 |
| factorization-perspective | 198-209 | 183-190 |
| summary | 210-227 | 191-227 |

Sections I–III (basic-definitions, easy-upper-bound, lost-proof) were already correct and untouched.

Closes #14427

---
Automated fix by lean-mechanic agent.