### PR TITLE
fix(meta): erdos-395 phantom extremal_example_tight + dangling doc-comment + section line drift

### DIFF
--- a/proofs/Proofs/Erdos395Problem.lean
+++ b/proofs/Proofs/Erdos395Problem.lean
@@ -144,8 +144,6 @@ theorem erdos_395_solved (n : ℕ) : erdos_395_question n := by
 def extremal_example (n : ℕ) : Fin n → ℂ :=
   fun i => if i.val < n / 2 then 1 else Complex.I
 
-/-- The extremal example has probability exactly Θ(1/n).
-Axiomatized because the precise computation requires CLT-type arguments. -/
 /-
 ## Part VI: Summary
 

--- a/src/data/proofs/erdos-395/meta.json
+++ b/src/data/proofs/erdos-395/meta.json
@@ -61,7 +61,7 @@
     "historicalContext": "Erdős Problem #395 concerns the 'reverse Littlewood-Offord problem.' The classical Littlewood-Offord theorem (1943) provides an upper bound on the probability that a random signed sum of vectors lands near any particular target. Erdős turned this around and asked: must a random signed sum of unit complex vectors land near zero with probability at least c/n? He originally posed the question with threshold 1, but Carnielli and Carolino (2011) found a counterexample — taking z₁ = 1 and zₖ = i for k ≥ 2 forces every signed sum to have magnitude at least √2, so no sign choice gives |sum| ≤ 1.\n\nThe revised question, with threshold √2 instead of 1, became the true open problem. He, Juškevičius, Narayanan, and Spiro resolved it affirmatively in 2024, proving that for any unit complex vectors z₁, ..., zₙ, the probability that |ε₁z₁ + ... + εₙzₙ| ≤ √2 (with random signs εᵢ ∈ {-1,1}) is at least c/n for some absolute constant c > 0. Their proof uses Fourier analysis on the Boolean hypercube and concentration inequalities.\n\nThe 1/n bound is optimal: taking half the vectors equal to 1 and half equal to i achieves probability exactly Θ(1/n). The threshold √2 is sharp in the sense that any smaller threshold can yield probability zero. This result completes the picture of Littlewood-Offord type problems by providing the 'reverse' direction — a lower bound on how many sign choices must produce a small sum.",
     "problemStatement": "**Problem Statement (Solved)**\n\nIf z₁, ..., zₙ ∈ ℂ with |zᵢ| = 1, is the probability that\n\n|ε₁z₁ + ... + εₙzₙ| ≤ √2\n\n(where εᵢ ∈ {-1, 1} uniformly at random) at least c/n for some absolute constant c > 0?\n\n**Original (Erdős):** Threshold 1 — FALSE (Carnielli-Carolino 2011)\n\n**Revised:** Threshold √2 — TRUE (HJNS 2024)\n\nThe bound 1/n is optimal.",
     "text": "For unit complex vectors, is P(|ε₁z₁ + ... + εₙzₙ| ≤ √2) ≥ c/n? YES (HJNS 2024).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Complex Vectors:** Use Fin n → ℂ for vectors\n\n2. **Key Definitions:**\n   - isUnitVector: |zᵢ| = 1\n   - signedSum: ε₁z₁ + ... + εₙzₙ\n   - probSmallSum: P(|sum| ≤ √2)\n\n3. **Counterexample:**\n   - carnielli_carolino_counterexample: shows threshold 1 fails\n   - For z₁ = 1, zₖ = i, every sum has |sum| ≥ √2\n\n4. **Main Results:**\n   - hjns_2024: P(|sum| ≤ √2) ≥ c/n for all unit vectors\n   - extremal_example_tight: 1/n rate is optimal\n\n**Why Axioms:** The HJNS proof uses Fourier analysis and concentration inequalities.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Complex Vectors:** Use Fin n → ℂ for vectors\n\n2. **Key Definitions:**\n   - isUnitVector: |zᵢ| = 1\n   - signedSum: ε₁z₁ + ... + εₙzₙ\n   - probSmallSum: P(|sum| ≤ √2)\n\n3. **Counterexample:**\n   - carnielli_carolino_counterexample: shows threshold 1 fails\n   - For z₁ = 1, zₖ = i, every sum has |sum| ≥ √2\n\n4. **Main Results:**\n   - hjns_2024: P(|sum| ≤ √2) ≥ c/n for all unit vectors\n\n**Why Axioms:** The HJNS proof uses Fourier analysis and concentration inequalities.",
     "keyInsights": [
       "**√2 is Threshold:** The counterexample shows < √2 can have probability 0; √2 always has ≥ c/n.",
       "**Reverse Direction:** Classical L-O bounds probability FROM ABOVE; this bounds FROM BELOW.",
@@ -95,28 +95,28 @@
       "title": "Original Question (False)",
       "summary": "Carnielli-Carolino counterexample refuting threshold 1",
       "startLine": 84,
-      "endLine": 112
+      "endLine": 108
     },
     {
       "id": "revised-true",
       "title": "Revised Question (True)",
       "summary": "HJNS 2024 theorem with threshold √2",
-      "startLine": 113,
-      "endLine": 142
+      "startLine": 109,
+      "endLine": 138
     },
     {
       "id": "optimality",
       "title": "Optimality of 1/n Bound",
       "summary": "Extremal example achieving Θ(1/n)",
-      "startLine": 143,
-      "endLine": 157
+      "startLine": 139,
+      "endLine": 146
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Combined resolution: original false, revised true",
-      "startLine": 158,
-      "endLine": 186
+      "startLine": 147,
+      "endLine": 184
     }
   ],
   "conclusion": {
@@ -139,7 +139,7 @@
       "Complex"
     ],
     "namespace": "Erdos395",
-    "lineCount": 186,
+    "lineCount": 184,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Three-part repair for erdos-395 (Reverse Littlewood-Offord Problem):

### Issue 1 — Phantom `extremal_example_tight` in proofStrategy
Removed `extremal_example_tight: 1/n rate is optimal` from `overview.proofStrategy` Main Results. No such declaration exists in the Lean file; only `def extremal_example` (the data) is present.

### Issue 2 — Dangling doc-comment in Lean file
Deleted `/-- The extremal example has probability exactly Θ(1/n).\nAxiomatized because the precise computation requires CLT-type arguments. -/` (was lines 147-148) which preceded no declaration. Updated `leanFile.lineCount` from 186 to 184.

### Issue 3 — Section line drift
Realigned sections III–VI to actual `## Part` marker positions:

| Section | Before | After |
|---|---|---|
| original-false | 84-112 | 84-108 |
| revised-true | 113-142 | 109-138 |
| optimality | 143-157 | 139-146 |
| summary | 158-186 | 147-184 |

Sections I (48-69) and II (70-83) were already correct.

Closes #14430

---
Automated fix by lean-mechanic agent.