### PR TITLE
fix(meta): erdos-393 section line drift Parts 3-8 + orphan docstrings

### DIFF
--- a/proofs/Proofs/Erdos393Problem.lean
+++ b/proofs/Proofs/Erdos393Problem.lean
@@ -134,9 +134,9 @@ def UnconditionalTendsto : Prop :=
 ## Part 6: Lower Bounds on f(n)
 -/
 
-/-- If n! = a₁ · ... · aₜ with aₜ = a₁ + m, then each aᵢ ≤ n! -/
-/-- The trivial factorization 1 · 2 · ... · n has span n - 1 -/
-/-- f(n) ≥ 1 for n ≥ 2 -/
+-- If n! = a₁ · ... · aₜ with aₜ = a₁ + m, then each aᵢ ≤ n! (not yet formalized)
+-- The trivial factorization 1 · 2 · ... · n has span n - 1 (not yet formalized)
+-- f(n) ≥ 1 for n ≥ 2 (not yet formalized)
 /-
 ## Part 7: Connection to Diophantine Equations
 -/

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3649,7 +3649,7 @@
       "problem_id": "divisibilitybythreeoq01oq02",
       "submitted": "unknown",
       "status": "completed",
-      "outcome": "No improvement (recovered from server)",
+      "outcome": "1 sorries remaining",
       "notes": "Recovered from server at 2026-04-30T07:14:20Z. No sorry reduction."
     },
     {
@@ -3657,9 +3657,19 @@
       "file": "proofs/Proofs/AreaOfCircleOQ01OQ03Aristotle.lean",
       "problem_id": "areaofcircleoq01oq03",
       "submitted": "unknown",
+      "status": "integrated",
+      "outcome": "Already had 0 sorries",
+      "notes": "Recovered from server at 2026-04-30T07:14:26Z. No sorry reduction.",
+      "theorems_proved": 0
+    },
+    {
+      "project_id": "9ddf3174-34e1-44f5-8445-2ceae64d61f5",
+      "file": "proofs/Proofs/AreaOfCircleOQ01OQ03Aristotle.lean",
+      "problem_id": "areaofcircleoq01oq03",
+      "submitted": "unknown",
       "status": "completed",
       "outcome": "No improvement (recovered from server)",
-      "notes": "Recovered from server at 2026-04-30T07:14:26Z. No sorry reduction."
+      "notes": "Recovered from server at 2026-05-01T23:50:10Z. No sorry reduction."
     }
   ]
 }

--- a/src/data/proofs/erdos-393/meta.json
+++ b/src/data/proofs/erdos-393/meta.json
@@ -98,47 +98,47 @@
       "title": "The f(n) = 1 Case",
       "summary": "When n! = k(k+1) for consecutive integers",
       "startLine": 79,
-      "endLine": 98,
+      "endLine": 95,
       "mathContext": "Mathematical content: When n! = k(k+1) for consecutive integers"
     },
     {
       "id": "counting-function",
       "title": "The Counting Function F_m(N)",
       "summary": "Counting n ≤ N with f(n) = m",
-      "startLine": 99,
-      "endLine": 117,
+      "startLine": 96,
+      "endLine": 114,
       "mathContext": "Counting n $\\leq$ N with f(n) = m"
     },
     {
       "id": "abc-conditional",
       "title": "f(n) → ∞ Conditional on ABC",
       "summary": "Luca's result assuming ABC conjecture",
-      "startLine": 118,
-      "endLine": 135,
+      "startLine": 115,
+      "endLine": 132,
       "mathContext": "Mathematical content: Luca's result assuming ABC conjecture"
     },
     {
       "id": "bounds",
       "title": "Lower Bounds on f(n)",
-      "summary": "Basic bounds on the f(n) function",
-      "startLine": 136,
-      "endLine": 150,
-      "mathContext": "Bound: Basic bounds on the f(n) function"
+      "summary": "Informal sketch of lower bounds — not formalized",
+      "startLine": 133,
+      "endLine": 139,
+      "mathContext": "Informal sketch: lower bounds on f(n) — not yet formalized"
     },
     {
       "id": "diophantine",
       "title": "Connection to Diophantine Equations",
       "summary": "P(x) = n! and Brocard's problem",
-      "startLine": 151,
-      "endLine": 166,
+      "startLine": 140,
+      "endLine": 152,
       "mathContext": "Mathematical content: P(x) = n! and Brocard's problem"
     },
     {
       "id": "density",
       "title": "Density Results",
       "summary": "Density zero and sparse values theorems",
-      "startLine": 167,
-      "endLine": 177,
+      "startLine": 153,
+      "endLine": 162,
       "mathContext": "Verified: Density zero and sparse values theorems"
     }
   ],


### PR DESCRIPTION
## Fix

Two-part repair for erdos-393 (Factorial Factorization Span):

### Issue 1 — Orphan doc-comments in Lean file (Part 6)
The three `/-- ... -/` docstrings in Part 6 (lines 137-139) had no declaration to attach to. Converted to plain `--` comments marked "(not yet formalized)" to eliminate orphan-docstring noise without removing the informal content. (Integrated via Aristotle commit `3c18e785eac` already on this branch.)

### Issue 2 — Section line drift Parts 3–8
Realigned `meta.sections[].startLine/endLine` to match actual `## Part` markers:

| Section | Before | After |
|---|---|---|
| consecutive-case | 79-98 | 79-95 |
| counting-function | 99-117 | 96-114 |
| abc-conditional | 118-135 | 115-132 |
| bounds | 136-150 | 133-139 (+ reworded summary) |
| diophantine | 151-166 | 140-152 |
| density | 167-177 | 153-162 |

Also reworded `bounds.summary` from "Basic bounds on the f(n) function" to "Informal sketch of lower bounds — not formalized" to reflect the actual state of the Lean file.

Sections 1–2 (factorizations 41-66, f-function 67-78) were already correct.

Closes #14432

---
Automated fix by lean-mechanic agent.