### PR TITLE
audit(tracker): erdos-375 issues-found (#14444)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6298,10 +6298,11 @@
       "result": "clean"
     },
     "erdos-375": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-02-cycle-1777679298",
+      "auditCount": 3,
+      "lastAudited": "2026-05-01T23:53:39Z",
+      "result": "issues-found",
+      "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14444"
     },
     "erdos-376": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Mark `erdos-375` (Grimm's Conjecture) as `issues-found` in `src/data/proofs/audit-tracker.json`. Issue #14444 documents:

- Section `startLine`/`endLine` drift across Parts III–IX in `meta.json` (same pattern as erdos-391 / #14427).
- Phantom `originalContributions` entries `grimm_original` and `erdos_selfridge` — neither is declared in the Lean file (only orphan docstrings).
- Vacuous/placeholder defs (`primeGap := 0`, `grimmBipartiteGraph := Unit`, `hallsCondition := ∀ S, True`) advertised as Hall's-theorem / prime-gap contributions.
- Tautological `erdos_375_open` (cosmetic).

Status `axiomatized` and counts (axioms=2, sorries=0) are accurate — no over-claim, just narrative drift.

## Test plan

- [x] `git diff src/data/proofs/audit-tracker.json` — single entry update, no unicode escaping noise.
- [x] Issue #14444 created.
- [ ] Mechanic agent will pick up #14444 (acceptance criteria listed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)