### PR TITLE
audit(tracker): erdos-365 issues-found (#14447)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6233,9 +6233,19 @@
     },
     "erdos-365": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
+      "auditCount": 3,
       "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "result": "issues-fixed",
+      "audits": [
+        {
+          "timestamp": "2026-05-01T23:59:01.000Z",
+          "result": "issues-found",
+          "auditor": "auditor",
+          "session": "auditor-2026-05-02-0156"
+        }
+      ],
+      "lastAudit": "2026-05-01T23:59:01.000Z",
+      "lastResult": "issues-found"
     },
     "erdos-366": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records erdos-365 audit result as `issues-found`
- Issue: #14447 — phantom axioms in `assumptions`/`sections`/`proofStrategy` + section line drift across all 7 sections
- axiomCount=3 is numerically correct, but five of eight `assumptions` entries reference axioms that are either theorems (`square_is_powerful`, `cube_is_powerful`) or do not exist in the file (`mahler_pell_gives_powerful`, `infinitely_many_pell`, `walker_gives_nonsquare`)
- Section line ranges are off by ~6-9 lines (same pattern as erdos-393 / #14432)

## Test plan
- [x] Tracker patch is ASCII-clean (no `\u` escapes)
- [x] `auditCount` preserved (2 → 3)
- [x] New `audits[]` entry timestamped and labeled `issues-found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)