### PR TITLE
audit(tracker): erdos-363 issues-found (#14451)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6221,9 +6221,12 @@
     },
     "erdos-363": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T00:05:00Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom Bauer-Bennett/Bennett-Van Luijk axioms in originalContributions; phantom product_eq_range_prod theorem (no such name, 0 sorries); proofStrategy claims combining 3 axioms but only ulas_theorem used in disproof; section line drift Parts VIII-XII (#14451)"
+      ]
     },
     "erdos-364": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks erdos-363 audit as **issues-found** in the tracker.

Linked issue: #14451

## Findings

- **Phantom axioms in originalContributions**: claims "Axiomatization of Bauer-Bennett theorem for n=3 or n=5" and "Axiomatization of Bennett-Van Luijk theorem for size-5 intervals" — neither is declared in the Lean file (docstrings only at Parts VI–VII).
- **Phantom theorem**: claims `product_eq_range_prod: Icc/range reindexing (1 sorry, technical)` — no theorem of that name exists; the reindexing is inline in `single_block_not_square` proof; file has 0 sorries.
- **Inflated proofStrategy**: claims "combining" three axiomatized theorems (Ulas + Bauer-Bennett + Bennett-Van Luijk); the actual disproof uses only `ulas_theorem 4`. `pomerance_observation` is bundled only in `erdos_363_summary`; `erdos_selfridge` supports the auxiliary `single_block_not_square`.
- **Section line drift** at Parts VIII (disproof), X (ulas-conjecture), XI (erdos-selfridge), XII (summary) — section ranges off by ~13 lines.
- Numerical counts (`axiomCount: 3`, `sorries: 0`, `lineCount: 293`, `theoremCount: 5`, `definitionCount: 10`) all match the Lean source.

## Test plan

- [x] Tracker entry updated under `entries.erdos-363` (correct schema)
- [x] Issue #14451 cross-referenced
- [x] No unicode escaping pollution in tracker JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)