### PR TITLE
fix(meta): erdos-381 phantom HC theorems + dangling doc-comments + section drift

### DIFF
--- a/proofs/Proofs/Erdos381Problem.lean
+++ b/proofs/Proofs/Erdos381Problem.lean
@@ -231,19 +231,19 @@ theorem Q_bounds :
                     (Q x : ℝ) ≤ K₂ * (Real.log x)^C) := by
   sorry
 
-/--
+/-
 **Q(x) has polynomial growth in log x:**
 Q(x) ~ (log x)^α for some 1 < α ≤ C.
 -/
 /- ## Part VII: Structure of Highly Composite Numbers -/
 
-/--
+/-
 **Prime factorization structure:**
 Highly composite numbers have a specific form: they are products of
 primorials with decreasing exponents. If n = 2^{a₁} · 3^{a₂} · ... · p^{a_k},
 then a₁ ≥ a₂ ≥ ... ≥ a_k ≥ 1.
 -/
-/--
+/-
 **Ramanujan's characterization:**
 Ramanujan (1915) gave a complete characterization of highly composite numbers
 based on their prime factorizations. The exponents are non-increasing and the
@@ -260,7 +260,7 @@ def IsSuperiorHighlyComposite (n : ℕ) : Prop :=
 
 /- ## Part VIII: Comparison with Other Sequences -/
 
-/--
+/-
 **Highly composite vs primes:**
 The count Q(x) of highly composite numbers up to x grows much slower
 than π(x), the count of primes: π(x) ~ x/log x, while Q(x) ~ (log x)^α.

--- a/src/data/proofs/erdos-381/meta.json
+++ b/src/data/proofs/erdos-381/meta.json
@@ -50,9 +50,6 @@
       "nicolas_upper_bound axiom (1971)",
       "erdos_question_false theorem: disproof",
       "Q_bounds combined asymptotic bounds",
-      "HC_exponent_decreasing: prime factorization structure",
-      "ramanujan_characterization: largest prime factor property",
-      "HC_sparser_than_primes: Q(x)/π(x) → 0",
       "IsSuperiorHighlyComposite definition",
       "erdos_381_summary: combines lower bound, upper bound, and disproof",
       "Proofs: one_highly_composite, two_highly_composite, four_highly_composite, six_highly_composite, twelve_highly_composite",
@@ -125,30 +122,30 @@
       "title": "Tight Bounds",
       "summary": "(log x)^{1+c} ≪ Q(x) ≪ (log x)^C",
       "startLine": 220,
-      "endLine": 241,
+      "endLine": 237,
       "mathContext": "Mathematical content: (log x)^{1+c} ≪ Q(x) ≪ (log x)^C"
     },
     {
       "id": "structure",
       "title": "Structure of HC Numbers",
       "summary": "Prime factorization properties, Ramanujan characterization, superior HC numbers",
-      "startLine": 242,
-      "endLine": 272,
+      "startLine": 238,
+      "endLine": 260,
       "mathContext": "Mathematical content: Prime factorization properties, Ramanujan characterization, superior HC numbers"
     },
     {
       "id": "comparison",
       "title": "Comparison with Other Sequences",
       "summary": "HC vs primes (Q(x)/π(x) → 0), highly abundant numbers",
-      "startLine": 273,
-      "endLine": 293,
+      "startLine": 261,
+      "endLine": 278,
       "mathContext": "HC vs primes (Q(x)/π(x) $\\to$ 0), highly abundant numbers"
     },
     {
       "id": "summary",
       "title": "Summary and Main Results",
       "summary": "erdos_381 theorem: the conjecture is FALSE; erdos_381_summary combines all key results",
-      "startLine": 294,
+      "startLine": 279,
       "endLine": 335,
       "mathContext": "Verified: erdos_381 theorem: the conjecture is FALSE; erdos_381_summary combines all key results"
     }


### PR DESCRIPTION
## Fix

Remove phantom theorem names from `originalContributions`, convert dangling doc-comments to regular comments, and fix section line drift in `erdos-381`.

## Evidence

**Phantom original contributions**: `HC_exponent_decreasing`, `ramanujan_characterization`, `HC_sparser_than_primes` are listed as contributions but do not exist as `theorem`, `lemma`, or `def` declarations anywhere in the Lean file. They exist only as doc-comments (now converted to regular comments).

**Dangling doc-comments**: 4 orphaned `/-- ... -/` docstrings converted to `/-` regular comments (they preceded section headers or other doc-comments, not declarations).

**Section line drift**: Corrected ranges to match actual `## Part` header positions (Part VI=220, Part VII=238, Part VIII=261, Part IX=279).

Closes #14438

---
Automated fix by lean-mechanic agent.