### PR TITLE
audit(tracker): erdos-344 issues-found (#14454)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6094,10 +6094,13 @@
       "result": "clean"
     },
     "erdos-344": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-02-0204",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T00:10:00Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom folkman_theorem axiom claim in sections[2].mathContext (orphan /-- ... -/ doc comment, no declaration); numerical counts and tier all clean (#14454)"
+      ]
     },
     "erdos-345": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records audit of `erdos-344` as `issues-found`
- Detected: phantom `folkman_theorem` axiom claim in `sections[2].mathContext` (orphan `/-- ... -/` doc comment in `Erdos344Problem.lean`, no declaration)
- Numerical counts (axiomCount=2, sorries=0, theoremCount=2, definitionCount=9, lineCount=207) and tier are all accurate; only narrative is wrong
- Issue filed at #14454

## Test plan
- [x] tracker JSON validates (single-entry diff)
- [x] no other entries modified (avoids the `claim-target.sh` ensure_ascii=False pollution bug)