### PR TITLE
fix(meta): erdos-344 phantom folkman_theorem axiom in sections[2]

### DIFF
--- a/proofs/Proofs/Erdos344Problem.lean
+++ b/proofs/Proofs/Erdos344Problem.lean
@@ -106,8 +106,8 @@ def HasOptimalDensity (A : Set ℕ) : Prop :=
 ## Part III: Folkman's Result
 -/
 
-/--
-**Folkman's Theorem:**
+/-
+**Folkman's Theorem (1966, not axiomatized):**
 If |A ∩ {1,...,N}| ≫ N^{1/2+ε} for some ε > 0, then A is subcomplete.
 -/
 /-

--- a/src/data/proofs/erdos-344/meta.json
+++ b/src/data/proofs/erdos-344/meta.json
@@ -103,7 +103,7 @@
       "startLine": 105,
       "endLine": 115,
       "summary": "Folkman's theorem for N^{1/2+ε} density",
-      "mathContext": "Axiomatized as `folkman_theorem`: $\\text{HasFolkmanDensity}(A) \\to \\text{IsSubcomplete}(A)$. Folkman's 1966 proof was the first to show density forces arithmetic structure in subset sums."
+      "mathContext": "Folkman's 1966 result $\\text{HasFolkmanDensity}(A) \\to \\text{IsSubcomplete}(A)$ is described in a documentation comment but is **not** declared as an axiom or theorem — only the predicate `HasFolkmanDensity` is defined. Folkman's original proof was the first to show density forces arithmetic structure in subset sums."
     },
     {
       "id": "szemeredi-vu",


### PR DESCRIPTION
## Fix

Rewrite `sections[2].mathContext` in `meta.json` — it claimed \"Axiomatized as `folkman_theorem`\" but no such axiom (or any declaration named `folkman_theorem`) exists in the Lean source. Lines 109–112 contain only an orphan `/-- ... -/` doc comment with no declaration attached. Only `HasFolkmanDensity` (the predicate) is defined.

Also convert the orphan doc-comment `/-- **Folkman's Theorem:** ... -/` in `Erdos344Problem.lean` to a regular `/- ... -/` block comment, preventing it from attaching to the wrong declaration.

Numerical fields `axiomCount: 2`, `sorries: 0`, and `assumptions` are all accurate and unchanged.

## Evidence

**Before**: `"mathContext": "Axiomatized as \`folkman_theorem\`: HasFolkmanDensity(A) → IsSubcomplete(A)..."`  
**After**: Accurately describes Folkman's result as documented in a comment (not axiomatized).

Closes #14454

---
Automated fix by lean-mechanic agent.