### PR TITLE
audit(tracker): erdos-365 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6239,19 +6239,25 @@
     },
     "erdos-365": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-02T00:29:20Z",
+      "result": "clean",
       "audits": [
         {
           "timestamp": "2026-05-01T23:59:01.000Z",
           "result": "issues-found",
           "auditor": "auditor",
           "session": "auditor-2026-05-02-0156"
+        },
+        {
+          "timestamp": "2026-05-02T00:29:20Z",
+          "result": "clean",
+          "auditor": "auditor",
+          "session": "auditor-2026-05-02"
         }
       ],
-      "lastAudit": "2026-05-01T23:59:01.000Z",
-      "lastResult": "issues-found"
+      "lastAudit": "2026-05-02T00:29:20Z",
+      "lastResult": "clean"
     },
     "erdos-366": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Audit cycle for erdos-365 (Consecutive Powerful Numbers): all gallery metadata matches Lean source.
- Records 4th audit pass with result `clean`; resolves prior `issues-fixed` state.

## Audit findings (clean)

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| sorries | 0 | 0 | yes |
| axiomCount | 3 | 3 (`question1_false`, `golomb_counterexample`, `walker_infinitely_many`) | yes |
| theoremCount | 4 | 4 (`square_is_powerful`, `cube_is_powerful`, `example_8_9`, `erdos_365_summary`) | yes |
| definitionCount | 8 | 8 | yes |
| lineCount | 181 | 181 | yes |
| status / badge | `axiomatized` / `axiom` | 3 axioms present, 0 sorries, no True stubs | Tier C — appropriate |
| Section line ranges | 40-64, 66-84, 86-99, 100-124, 126-139, 140-155, 157-181 | All match Part I-VII headers | yes |

`proofStrategy` correctly notes Part III declares no axioms (only doc-comments). `originalContributions` items are all verifiable in source. No phantom axioms, no Mathlib wrapper masquerading as original work.

## Test plan
- [x] JSON validity check (`python3 -c 'json.load(open(...))'`)
- [x] Diff scoped to single entry (`git diff --stat`: 11 insertions, 5 deletions)
- [x] No unicode-escape pollution (manually applied edit per known `claim-target.sh` bug)