### PR TITLE
fix(meta): erdos-334 phantom claims + section line drift

### DIFF
--- a/src/data/proofs/erdos-334/meta.json
+++ b/src/data/proofs/erdos-334/meta.json
@@ -36,7 +36,7 @@
     "originalContributions": [
       "isSmooth and hasSmootPairRepr definitions",
       "smooth_mul: product of smooth numbers is smooth (proved)",
-      "small_has_repr: n ≤ 3 has smooth pair representation (proved)",
+      "small_has_repr: n ≤ 3 has smooth pair representation (theorem stub — currently `sorry`)",
       "minSmoothness function definition",
       "balogExponent = 4/(9·√e) ≈ 0.2695 definition",
       "Conjectured bounds formalized: weakConjecture and strongConjecture",
@@ -97,17 +97,17 @@
     {
       "id": "minimal-smoothness",
       "title": "Part III: The Minimal Smoothness Function",
-      "summary": "minSmoothness definition, minSmoothness_exists axiom",
+      "summary": "minSmoothness definition (placeholder returning 0); existence of f(n) is described in a docstring comment only — no `minSmoothness_exists` axiom or theorem is declared",
       "startLine": 93,
-      "endLine": 112,
-      "mathContext": "Formal definition: minSmoothness definition, minSmoothness_exists axiom"
+      "endLine": 109,
+      "mathContext": "Formal definition: minSmoothness noncomputable def (placeholder). The docstring at lines 105–109 notes that every n has a smooth pair representation, but no Lean axiom or theorem formalizes this claim in this section."
     },
     {
       "id": "known-bounds",
       "title": "Part IV: Known Bounds",
       "summary": "erdos_cube_root_bound, balogExponent, balog_bound axiom",
-      "startLine": 113,
-      "endLine": 141,
+      "startLine": 110,
+      "endLine": 138,
       "mathContext": "Axiomatized: erdos_cube_root_bound, balogExponent, balog_bound axiom"
     },
     {
@@ -129,10 +129,10 @@
     {
       "id": "connections",
       "title": "Part VII: Connection to Other Problems",
-      "summary": "smoothCount ψ(x,y), de_bruijn_asymptotic, Goldbach connection",
+      "summary": "smoothCount ψ(x,y) placeholder def; de Bruijn asymptotic described in docstring only (no `de_bruijn_asymptotic` theorem/axiom declared); goldbachTypeProperty def",
       "startLine": 223,
-      "endLine": 252,
-      "mathContext": "Mathematical content: smoothCount ψ(x,y), de_bruijn_asymptotic, Goldbach connection"
+      "endLine": 246,
+      "mathContext": "smoothCount ψ(x,y) placeholder def; de Bruijn asymptotic $\\psi(x,y) \\sim x\\rho(u)$ mentioned in docstring only — no theorem or axiom in the file; goldbachTypeProperty def (simplified to True)"
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Remove phantom narrative claims from erdos-334 meta.json that referenced declarations not present in the Lean source.

## Evidence

**Phantom 1** — `originalContributions[2]`: `small_has_repr` was marked "(proved)" but the Lean file has `theorem small_has_repr ... := by sorry` (one of the 3 counted sorries).
→ Changed to "(theorem stub — currently \`sorry\`)"

**Phantom 2** — `sections[2].summary` claimed "minSmoothness_exists axiom". No such axiom exists — only a docstring at lines 105–109 describes the idea.
→ Removed the phantom axiom reference; summary now accurately describes the placeholder def.

**Phantom 3** — `sections[6].summary` claimed "de_bruijn_asymptotic". No such theorem/axiom exists — only a docstring at lines 234–237.
→ Removed; mathContext now says "mentioned in docstring only".

Also tightened section line ranges to stop including adjacent section headers:
- sections[2] endLine: 112 → 109
- sections[3] startLine: 113 → 110, endLine: 141 → 138
- sections[6] endLine: 252 → 246

Closes #14467

---
Automated fix by lean-mechanic agent.