### PR TITLE
fix(meta): erdos-336 phantom axioms + section line drift

### DIFF
--- a/src/data/proofs/erdos-336/meta.json
+++ b/src/data/proofs/erdos-336/meta.json
@@ -47,8 +47,8 @@
       "Stated Nash (1993) upper bound: 1/2",
       "Stated specific values: h(2) = 4, h(3) = 7, 10 ≤ h(4) ≤ 11",
       "Formalized Erdős-Graham example where order ≠ exact order",
-      "Stated characterization: exact order exists iff differences coprime",
-      "Plagne lower-order refinement axiom",
+      "Stated characterization: exact order exists iff differences coprime (docstring only — no axiom declared)",
+      "Plagne (2004) refinement noted in docstring only — no axiom declared",
       "erdos_336_main: combined main result theorem",
       "erdos_336: summary bounds theorem"
     ],
@@ -96,46 +96,46 @@
       "title": "Part 3: Known Bounds",
       "summary": "Erdős-Graham 1980 bounds, Grekos 1988 lower, Nash 1993 upper, current_bounds theorem.",
       "startLine": 67,
-      "endLine": 90,
+      "endLine": 84,
       "mathContext": "Verified: Erdős-Graham 1980 bounds, Grekos 1988 lower, Nash 1993 upper, current_bounds theorem."
     },
     {
       "id": "specific-values",
       "title": "Part 4: Specific Values",
       "summary": "h(2) = 4, h(3) = 7, 10 ≤ h(4) ≤ 11, ratio verification examples.",
-      "startLine": 91,
-      "endLine": 111,
+      "startLine": 85,
+      "endLine": 102,
       "mathContext": "h(2) = 4, h(3) = 7, 10 $\\leq$ h(4) $\\leq$ 11, ratio verification examples."
     },
     {
       "id": "order-differ",
       "title": "Part 5: Order vs Exact Order",
       "summary": "erdosGrahamExample, example_order_2, example_exact_order_3, order_exact_order_differ theorem.",
-      "startLine": 112,
-      "endLine": 131,
+      "startLine": 103,
+      "endLine": 122,
       "mathContext": "Verified: erdosGrahamExample, example_order_2, example_exact_order_3, order_exact_order_differ theorem."
     },
     {
       "id": "characterization",
       "title": "Part 6: Characterization",
-      "summary": "consecutiveDiffs, erdos_graham_characterization axiom (exact order ↔ coprime differences).",
-      "startLine": 132,
-      "endLine": 147,
-      "mathContext": "Axiomatized: consecutiveDiffs, erdos_graham_characterization axiom (exact order ↔ coprime differences)."
+      "summary": "consecutiveDiffs def; characterization theorem (exact order ↔ coprime differences) described in docstring only — no `erdos_graham_characterization` axiom or theorem declared.",
+      "startLine": 123,
+      "endLine": 132,
+      "mathContext": "consecutiveDiffs def at line 129. The Erdős-Graham coprimality characterization is mentioned in the section-header docstring only; no `erdos_graham_characterization` axiom or theorem exists in the file."
     },
     {
       "id": "plagne-refinement",
       "title": "Part 7: Plagne's Refinement",
-      "summary": "plagne_lower_order_2004 axiom: refined lower-order term bounds.",
-      "startLine": 148,
-      "endLine": 159,
-      "mathContext": "Axiomatized: plagne_lower_order_2004 axiom: refined lower-order term bounds."
+      "summary": "Plagne (2004) lower-order refinement described in section-header docstring only — no `plagne_lower_order_2004` axiom or theorem declared.",
+      "startLine": 133,
+      "endLine": 140,
+      "mathContext": "Docstring-only section: Plagne's 2004 refinement of lower-order terms for h(r) is noted in prose; no Lean axiom or theorem formalizes this result in this section."
     },
     {
       "id": "main-results",
       "title": "Part 8: Main Results",
       "summary": "erdos_336_main combining all results, erdos_336 summary bounds theorem.",
-      "startLine": 160,
+      "startLine": 141,
       "endLine": 161,
       "mathContext": "Verified: erdos_336_main combining all results, erdos_336 summary bounds theorem."
     }


### PR DESCRIPTION
## Fix

Remove two phantom axiom references from erdos-336 meta.json and correct section line ranges for Parts 3-8 to match actual Lean source.

## Evidence

**Phantom 1** — `sections[5]` (Part 6) claimed `erdos_graham_characterization axiom`. Lean file has only `def consecutiveDiffs` (line 129) and a docstring in the section header. No axiom or theorem named `erdos_graham_characterization` exists anywhere in the file.

**Phantom 2** — `sections[6]` (Part 7) claimed `plagne_lower_order_2004 axiom`. Lines 133–140 contain only a docstring. No Lean declaration exists.

**originalContributions** entries for both were corrected to say "docstring only — no axiom declared."

**Section line ranges** for Parts 3-8 were off by 6-15 lines (headers included in wrong sections). Corrected using actual `/- ## Part N` header locations from `grep`:

| Section | startLine before→after | endLine before→after |
|---------|------------------------|----------------------|
| Part 3 (known-bounds) | 67 (unchanged) | 90→84 |
| Part 4 (specific-values) | 91→85 | 111→102 |
| Part 5 (order-differ) | 112→103 | 131→122 |
| Part 6 (characterization) | 132→123 | 147→132 |
| Part 7 (plagne-refinement) | 148→133 | 159→140 |
| Part 8 (main-results) | 160→141 | 161 (unchanged) |

Closes #14465

---
Automated fix by lean-mechanic agent.