### PR TITLE
audit(tracker): erdos-1079 issues-found (#14477)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3585,10 +3585,13 @@
       ]
     },
     "erdos-1079": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-22589",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T01:04:42Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14477: section line drift + phantom Bondy result narrative"
+      ]
     },
     "erdos-108": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Mark erdos-1079 as `issues-found` (auditCount 3); raised issue #14477.

## Findings
- Section line ranges in `meta.sections` are off by ~9 lines from current `Erdos1079Problem.lean` Part markers.
- Dedicated `bondy` section claims Bondy's strengthening as formalized, but the lone `axiom erdos_1079_summary` encodes only Bollobás–Thomason + Turán. The Lean Part-5 docstring already says this.

## Test plan
- [x] tracker JSON parses (no unicode escapes leaked)
- [x] tracker entry under `entries.erdos-1079` (schema-compliant)
- [x] linked issue #14477 filed with `loom:auditor` + `loom:urgent`