### PR TITLE
audit(tracker): erdos-33 issues-found (#14482)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5992,10 +5992,12 @@
       "result": "issues-fixed"
     },
     "erdos-33": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "Phantom axiomatizations in proofStrategy/sections (Moser, Van Doorn) + section line drift +7 to +9; headline counts correct (issue #14482)"
+      ],
+      "lastAudited": "2026-05-02T01:13:18Z",
+      "result": "issues-found"
     },
     "erdos-330": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records erdos-33 audit result. See issue #14482 for the phantom-axiomatization details: proofStrategy and sections claim Moser's 1.06 bound and Van Doorn's 2φ^(5/2) construction are axiomatized, but only `cilleruelo_habsieger_lower_bound` is. Section line ranges drift +7 to +9. Headline counts are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)