### PR TITLE
audit(tracker): erdos-328 issues-found (#14486)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5984,9 +5984,9 @@
     },
     "erdos-328": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T01:23:43Z",
+      "result": "issues-found"
     },
     "erdos-329": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records erdos-328 audit result in audit-tracker.json: `issues-found` (was `issues-fixed`).
- Companion to integrity issue #14486 (phantom `isSumFree`/`erdos_328_status` contributions, `erdos_newman_disproved` mis-classified as theorem, sections starting at Part III drift by 3–35 lines, Part VIII Summary missing).

## Test plan
- [x] Numerical counts in meta.json verified against Lean source (axiomCount=2, sorries=0, theoremCount=1, definitionCount=9 — all correct)
- [x] Tracker diff is one entry only (no unicode-escape pollution)
- [x] No file changes outside `src/data/proofs/audit-tracker.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)