### PR TITLE
audit(tracker): erdos-314 issues-found (#14497)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5882,9 +5882,12 @@
     },
     "erdos-314": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T01:46:10Z",
+      "result": "issues-found",
+      "issues": [
+        "section line drift across all 8 sections; missing diophantine section in meta.json; proofStrategy step 5 references orphan docstring (#14497)"
+      ]
     },
     "erdos-315": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Updates audit-tracker.json for erdos-314.

**Result**: issues-found (issue #14497)
**auditCount**: 2 → 3
**lastAudited**: 2026-04-03 → 2026-05-02

## Findings

- All 8 section line ranges in `src/data/proofs/erdos-314/meta.json` are wrong (drift of up to ~50 lines on later sections).
- "Connection to Diophantine Approximation" section in the Lean file (lines 204–213) is missing from `sections`.
- proofStrategy step 5 ("Approximation: m(n)/n → e") refers to content that exists only as orphan docstrings (lines 151–152), no actual axiom/theorem/def.

## Counts (verified correct)

axiomCount=5, sorries=0, lineCount=239, theoremCount=9, definitionCount=5; status/badge correctly `axiomatized`/`axiom`.

See #14497 for full evidence and recommended fix.