### PR TITLE
audit(tracker): erdos-309 issues-found (#14501)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5846,9 +5846,12 @@
     },
     "erdos-309": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T01:56:43Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axiom narrative: sections claim croot_threshold_1999 axiom and yokota_refined_2002 axiom that are not declared (only docstrings); section line drift around line 213 (#14501)"
+      ]
     },
     "erdos-31": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records erdos-309 audit result in `src/data/proofs/audit-tracker.json`.
- Issue filed: #14501 — phantom-axiom narrative + section line drift.
- Numerical counts (axiomCount=1, sorries=3, lineCount=339) match the Lean source; only the `sections` narrative overstates by claiming `croot_threshold_1999` and `yokota_refined_2002` axioms that are docstrings only.

## Test plan
- [x] Tracker JSON parses (validated via `python3 -c "import json; json.load(open(...))"`)
- [x] Single-entry diff (no unicode escape pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)