### PR TITLE
audit(tracker): erdos-306 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5822,9 +5822,9 @@
     },
     "erdos-306": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T02:01:09Z",
+      "result": "clean"
     },
     "erdos-307": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audited `erdos-306` (Egyptian Fractions with Semiprime Denominators).
- Verified meta.json matches `proofs/Proofs/Erdos306Problem.lean`: 0 sorries, 2 axioms (`butler_erdos_graham_theorem`, `twoPrimeProductCount`), no True stubs.
- `originalContributions`, `sections`, `axiomCount`, `lineCount`, badge `axiom`, status `axiomatized` all accurate.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --next` returned erdos-310 (claimed); next unclaimed was erdos-306.
- [x] Confirmed Lean source axioms = 2 (matches meta `axiomCount: 2`).
- [x] Verified no `: True :=` stubs.
- [x] Tracker entry updated; unicode preserved (no `\u2192`/`\u2014` pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)