### PR TITLE
audit(tracker): erdos-302 issues-found (#14504)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5797,10 +5797,13 @@
       "result": "clean"
     },
     "erdos-302": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777687577",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T02:08:25Z",
+      "result": "issues-found",
+      "issues": [
+        "Issue #14504: phantom axioms in section narratives (doubling, summary) + 11 section line ranges drifted"
+      ]
     },
     "erdos-303": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Tracker Update

Mark `erdos-302` as `issues-found` (auditCount 2→3) following [#14504](https://github.com/rjwalters/lean-genius/issues/14504).

**Findings:**
- Phantom axioms in `meta.json` `sections` field: `doubling` section claims an axiom for `|A| > 2N/3 forces doubling` (file only has `equal_case_threshold` theorem); `summary` section claims `erdos_302_density_open` axiom (does not exist in file).
- All 11 sections have stale `startLine`/`endLine` values; ranges stop at line 261 but the Lean file is 414 lines.
- Numerical fields (axiomCount=3, sorries=0, lineCount=414) are accurate — only narrative/structural claims drifted.

Tracker-only change. Issue #14504 has the recommended fix.