### PR TITLE
fix(meta): erdos-322 phantom axioms + section line drift

### DIFF
--- a/src/data/proofs/erdos-322/meta.json
+++ b/src/data/proofs/erdos-322/meta.json
@@ -50,10 +50,9 @@
       "representationCount: r_k(n) axiomatized",
       "hypothesisK: Hardy-Littlewood conjecture formalized",
       "hypothesisK_fails: negation as polynomial lower bound",
-      "mahler_theorem: r_3(n) ≫ n^{1/12} for infinitely many n",
+      "hypothesisK_fails_for_3: Mahler's 1936 disproof of Hypothesis K for cubes (qualitative)",
       "erdos_chowla_bound: r_k(n) ≫ n^{c/log log n}",
-      "hypothesisKStar: weaker squared sum bound",
-      "erdos_positive_density_claim: unbounded representations from dense sets"
+      "hypothesisKStar: weaker squared sum bound"
     ],
     "axiomCount": 3,
     "lineCount": 182,
@@ -62,8 +61,8 @@
   "overview": {
     "historicalContext": "This problem connects to the classical theory of Waring's problem and the Hardy-Littlewood circle method. Hardy and Littlewood conjectured Hypothesis K: that r_k(n) = n^{o(1)} for k ≥ 3, meaning representations grow slower than any polynomial.\n\nMahler (1936) sensationally disproved this for cubes, showing r_3(n) ≫ n^{1/12} for infinitely many n. Erdős believed Hypothesis K fails for all k ≥ 4, but this remains open. Independently, Erdős and Chowla proved a weaker bound r_k(n) ≫ n^{c/log log n} for all k ≥ 3.\n\nThe weaker Hypothesis K* (bounding the sum Σ r_k(n)² ≪ N^{1+ε}) is probably true but unproven and very deep. Erdős and Graham noted it 'would suffice for most applications' of the original Hypothesis K.",
     "problemStatement": "**Problem Statement (PARTIALLY SOLVED)**\n\nLet k ≥ 3 and let r_k(n) be the number of representations of n as a sum of k many k-th powers.\n\n**Question:** Does there exist c > 0 with r_k(n) > n^c for infinitely many n?\n\n**Results:**\n- k = 3: YES, c = 1/12 works (Mahler 1936)\n- k ≥ 4: OPEN (Erdős conjectured YES)\n- Weaker: r_k(n) ≫ n^{c/log log n} for all k ≥ 3 (Erdős-Chowla)",
-    "text": "This 191-line formalization captures the current state of Erdős Problem #322 with 5 axioms and 0 sorries. It defines the representation count $r_k(n)$ — the number of ways to write $n = x_1^k + \\cdots + x_k^k$ with $x_i \\geq 0$ — and formalizes both Hypothesis K ($r_k(n) = n^{o(1)}$) and its negation ($\\exists c > 0$, $r_k(n) > n^c$ infinitely often). The key axioms encode Mahler's 1936 disproof for $k=3$ ($r_3(n) \\gg n^{1/12}$ infinitely often), the Erdős-Chowla weaker bound ($r_k(n) \\gg n^{c/\\log\\log n}$ for all $k \\geq 3$), and Erdős's positive density claim. Two proved theorems (`erdos_322` and `erdos_322_summary`) synthesize these results.",
-    "proofStrategy": "The formalization is organized in eight parts mirroring the problem's logical structure:\n\n1. **Definitions** (Part I): `kthPowers k` as $\\{m^k : m \\in \\mathbb{N}\\}$ and `representationCount k n` axiomatized as $r_k(n) = |\\{(x_1,\\ldots,x_k) : x_1^k + \\cdots + x_k^k = n\\}|$.\n\n2. **Hypothesis K** (Part II): Formalized as $\\forall \\varepsilon > 0, \\exists N, \\forall n \\geq N, r_k(n) < n^\\varepsilon$, with its negation `hypothesisK_fails` expressing $\\exists c > 0$ with $r_k(n) > n^c$ infinitely often.\n\n3. **Mahler's Theorem** (Part III): Axiomatizes $r_3(n) \\geq c \\cdot n^{1/12}$ for infinitely many $n$, using `Real.rpow` for the fractional exponent.\n\n4. **Open problem** (Part IV): `erdos_conjecture_k4` states the conjecture for $k \\geq 4$.\n\n5. **Erdős-Chowla** (Part V): Axiomatizes the weaker bound using `Real.log (Real.log n)` for the doubly-logarithmic denominator.\n\n6. **Hypothesis K\\*** (Part VI): Defines the squared-sum variant $\\sum_{n \\leq N} r_k(n)^2 \\ll N^{1+\\varepsilon}$ using `Finset.range N`.\n\n7. **Positive density** (Part VII): Axiomatizes unbounded representations from dense subsets.\n\n8. **Summary** (Part VIII): Two proved theorems combining the results.",
+    "text": "This 182-line formalization captures the current state of Erdős Problem #322 with 3 axioms and 0 sorries. It defines the representation count $r_k(n)$ — the number of ways to write $n = x_1^k + \\cdots + x_k^k$ with $x_i \\geq 0$ — and formalizes both Hypothesis K ($r_k(n) = n^{o(1)}$) and its negation ($\\exists c > 0$, $r_k(n) > n^c$ infinitely often). The key axioms encode Mahler's 1936 disproof for $k=3$ (`hypothesisK_fails_for_3`) and the Erdős-Chowla weaker bound ($r_k(n) \\gg n^{c/\\log\\log n}$ for all $k \\geq 3$). Two proved theorems (`erdos_322` and `erdos_322_summary`) synthesize these results.",
+    "proofStrategy": "The formalization is organized in eight parts mirroring the problem's logical structure:\n\n1. **Definitions** (Part I): `kthPowers k` as $\\{m^k : m \\in \\mathbb{N}\\}$ and `representationCount k n` axiomatized as $r_k(n) = |\\{(x_1,\\ldots,x_k) : x_1^k + \\cdots + x_k^k = n\\}|$.\n\n2. **Hypothesis K** (Part II): Formalized as $\\forall \\varepsilon > 0, \\exists N, \\forall n \\geq N, r_k(n) < n^\\varepsilon$, with its negation `hypothesisK_fails` expressing $\\exists c > 0$ with $r_k(n) > n^c$ infinitely often.\n\n3. **Mahler's Theorem** (Part III): Axiomatizes $r_3(n) \\geq c \\cdot n^{1/12}$ for infinitely many $n$, using `Real.rpow` for the fractional exponent.\n\n4. **Open problem** (Part IV): `erdos_conjecture_k4` states the conjecture for $k \\geq 4$.\n\n5. **Erdős-Chowla** (Part V): Axiomatizes the weaker bound using `Real.log (Real.log n)` for the doubly-logarithmic denominator.\n\n6. **Hypothesis K\\*** (Part VI): Defines the squared-sum variant $\\sum_{n \\leq N} r_k(n)^2 \\ll N^{1+\\varepsilon}$ using `Finset.range N`.\n\n7. **Positive density** (Part VII): Documentation placeholder for Erdős's claim about unbounded representations from dense subsets; this section contains an orphaned docstring but no axiom is declared.\n\n8. **Summary** (Part VIII): Two proved theorems combining the results.",
     "keyInsights": [
       "**Hypothesis K:** r_k(n) ≤ n^{o(1)} (Hardy-Littlewood conjecture)",
       "**Mahler (1936):** Disproved for cubes with r_3(n) ≫ n^{1/12}",
@@ -98,46 +97,46 @@
       "id": "mahler",
       "title": "Mahler's Theorem",
       "startLine": 82,
-      "endLine": 101,
+      "endLine": 97,
       "summary": "Axiomatizes Mahler's 1936 theorem: $\\exists c > 0,\\; \\forall N,\\; \\exists n \\geq N,\\; r_3(n) \\geq c \\cdot n^{1/12}$. The corollary `hypothesisK_fails_for_3` restates this in the Hypothesis K framework.",
       "mathContext": "Mahler's proof exploits the algebraic structure of cubic forms: certain integers $n$ have $\\gg n^{1/12}$ representations as sums of 3 cubes because they lie on algebraic curves with many lattice points. The exponent $1/12$ arises from Birch's generalization of the lattice point counting for ternary cubic forms. The result was a major surprise — Hardy and Littlewood had expected Hypothesis K to hold universally."
     },
     {
       "id": "k-geq-4",
       "title": "Status for k ≥ 4",
-      "startLine": 102,
-      "endLine": 112,
+      "startLine": 98,
+      "endLine": 108,
       "summary": "Defines `erdos_conjecture_k4` as $\\forall k \\geq 4,\\; \\text{hypothesisK\\_fails}\\,k$. This remains one of the central open questions in additive number theory.",
       "mathContext": "For $k = 4$ (fourth powers), the situation is much harder than cubes because the density of fourth powers ($\\sim N^{1/4}$) is sparser than cubes ($\\sim N^{1/3}$). No analog of Mahler's algebraic geometry argument is known for fourth powers. Even the weaker question of whether $r_4(n)$ can exceed $n^\\varepsilon$ for some fixed $\\varepsilon > 0$ and infinitely many $n$ is open."
     },
     {
       "id": "erdos-chowla",
       "title": "Erdős-Chowla Bound",
-      "startLine": 113,
-      "endLine": 127,
+      "startLine": 109,
+      "endLine": 123,
       "summary": "Axiomatizes the Erdős-Chowla theorem (1936): for all $k \\geq 3$, $\\exists c > 0$ with $r_k(n) \\geq n^{c/\\log\\log n}$ for infinitely many $n$. Also defines Hypothesis K* ($\\sum_{n \\leq N} r_k(n)^2 \\ll N^{1+\\varepsilon}$).",
       "mathContext": "The Erdős-Chowla bound $r_k(n) \\gg n^{c/\\log\\log n}$ is super-logarithmic but sub-polynomial — it doesn't disprove Hypothesis K but shows $r_k(n)$ can be large. Hypothesis K* controls the $L^2$ norm of $r_k$: $\\sum_{n \\leq N} r_k(n)^2 \\leq C N^{1+\\varepsilon}$ allows occasional polynomial spikes but bounds their frequency. If K* holds, $r_k(n) > n^c$ can happen for at most $O(N^{1-c+\\varepsilon})$ integers $n \\leq N$."
     },
     {
       "id": "hypothesis-k-star",
       "title": "Hypothesis K*",
-      "startLine": 128,
-      "endLine": 143,
+      "startLine": 124,
+      "endLine": 139,
       "summary": "Weaker conjecture on squared sums",
       "mathContext": "Mathematical content: Weaker conjecture on squared sums"
     },
     {
       "id": "positive-density",
       "title": "Positive Density Sets",
-      "startLine": 144,
-      "endLine": 158,
-      "summary": "Axiomatizes Erdős's claim: if $S \\subseteq \\mathbb{N}$ has positive lower density and $B = \\{s^k : s \\in S\\}$, then $\\limsup r_B^{(k)}(n) = \\infty$.",
+      "startLine": 140,
+      "endLine": 149,
+      "summary": "Documentation placeholder for Erdős's claim: if $S \\subseteq \\mathbb{N}$ has positive lower density and $B = \\{s^k : s \\in S\\}$, then $\\limsup r_B^{(k)}(n) = \\infty$. This section contains an orphaned docstring but no axiom is declared.",
       "mathContext": "This generalizes the representation problem to $k$-th powers of arbitrary dense subsets. If $|S \\cap [1,N]| \\geq \\delta N$, then $|B \\cap [1,N^k]| \\geq \\delta N$, so the set of $k$-th powers from $S$ has density $\\sim \\delta N^{1-1/k}$ among integers up to $N^k$. The claim says this density always suffices for unbounded $k$-fold sums — a strong structural result about the additive properties of power sets."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 159,
+      "startLine": 150,
       "endLine": 182,
       "summary": "Two proved theorems: `erdos_322_summary` bundles Mahler's $k=3$ result with the Erdős-Chowla bound for all $k \\geq 3$ as a conjunction; `erdos_322` states `hypothesisK_fails 3` directly.",
       "mathContext": "`erdos_322_summary : hypothesisK_fails 3 ∧ (∀ k ≥ 3, ∃ c > 0, r_k(n) ≥ n^{c/\\log\\log n}$ i.o.$)$. The proof is `⟨hypothesisK_fails_for_3, fun k hk => erdos_chowla_bound k hk⟩` — a direct pairing of the two axiomatized results. These are the only two non-axiom theorems in the file."

--- a/src/data/proofs/erdos-322/meta.json
+++ b/src/data/proofs/erdos-322/meta.json
@@ -130,7 +130,7 @@
       "title": "Positive Density Sets",
       "startLine": 140,
       "endLine": 149,
-      "summary": "Documentation placeholder for Erdős's claim: if $S \\subseteq \\mathbb{N}$ has positive lower density and $B = \\{s^k : s \\in S\\}$, then $\\limsup r_B^{(k)}(n) = \\infty$. This section contains an orphaned docstring but no axiom is declared.",
+      "summary": "Docstring describing Erdős's positive density claim (no corresponding axiom declaration).",
       "mathContext": "This generalizes the representation problem to $k$-th powers of arbitrary dense subsets. If $|S \\cap [1,N]| \\geq \\delta N$, then $|B \\cap [1,N^k]| \\geq \\delta N$, so the set of $k$-th powers from $S$ has density $\\sim \\delta N^{1-1/k}$ among integers up to $N^k$. The claim says this density always suffices for unbounded $k$-fold sums — a strong structural result about the additive properties of power sets."
     },
     {


### PR DESCRIPTION
## Fix

Corrects five narrative/metadata errors in `src/data/proofs/erdos-322/meta.json`. The Lean file has exactly 3 axioms (`representationCount`, `hypothesisK_fails_for_3`, `erdos_chowla_bound`) and is 182 lines with 0 sorries.

## Changes

**1 — Phantom axiom names in `originalContributions`**
- Before: `"mahler_theorem: r_3(n) ≫ n^{1/12} for infinitely many n"` — no `mahler_theorem` identifier in Lean file
- After: `"hypothesisK_fails_for_3: Mahler's 1936 disproof of Hypothesis K for cubes (qualitative)"` — actual axiom name
- Before: `"erdos_positive_density_claim: unbounded representations from dense sets"` — no such axiom declared
- After: removed

**2 — Phantom axiom claim in `proofStrategy` step 7**
- Before: `"7. **Positive density** (Part VII): Axiomatizes unbounded representations from dense subsets."`
- After: `"7. **Positive density** (Part VII): Documentation placeholder for Erdős's claim about unbounded representations from dense subsets; this section contains an orphaned docstring but no axiom is declared."`

**3 — Phantom axiom claim in `sections.positive-density.summary`**
- Before: `"Axiomatizes Erdős's claim: if $S \subseteq \mathbb{N}$ has positive lower density…"`
- After: `"Docstring describing Erdős's positive density claim (no corresponding axiom declaration)."`

**4 — Wrong line/axiom count in `overview.text`**
- Before: "This 191-line formalization … with 5 axioms"
- After: "This 182-line formalization … with 3 axioms"

**5 — Section line drift (Parts III–VIII off by +4)**
- mahler: 82-101 → 82-97
- k-geq-4: 102-112 → 98-108
- erdos-chowla: 113-127 → 109-123
- hypothesis-k-star: 128-143 → 124-139
- positive-density: 144-158 → 140-149
- summary: 159-182 → 150-182

Closes #14493

---
Automated fix by lean-mechanic agent.