### PR TITLE
fix(meta): erdos-309 phantom axiom narrative + section drift

### DIFF
--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -72,7 +72,7 @@
     "historicalContext": "**Egyptian Fractions and Erdős's Question**\n\nThis problem concerns a fundamental question about **Egyptian fractions** - sums of distinct unit fractions 1/n. The ancient Egyptians represented all fractions this way.\n\n**The Question:** Given denominators from {1, ..., N}, how many integers can be represented as such sums? Specifically, is this count o(log N) (sublogarithmic)?\n\n**The Answer:** NO. The count F(N) grows like log N + γ, where γ ≈ 0.5772 is the Euler-Mascheroni constant.\n\n**Key Contributors:**\n- Yokota (1997): First logarithmic lower bound\n- Croot (1999): Exact threshold for representability\n- Yokota (2002): Refined bounds with (log log N)² correction\n\n**The harmonic number H_N = 1 + 1/2 + ... + 1/N ~ log N + γ** is central to understanding this problem, as representable integers are bounded by H_N.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $N \\geq 1$. Define $F(N)$ as the count of integers expressible as sums of distinct unit fractions with denominators from $\\{1, \\ldots, N\\}$.\n\n**Question:** Is $F(N) = o(\\log N)$?\n\n**Answer:** NO.\n\n**Precise Result:**\n$$F(N) = \\log N + \\gamma - \\Theta\\left(\\frac{(\\log\\log N)^2}{\\log N}\\right)$$\n\nwhere $\\gamma \\approx 0.5772$ is the Euler-Mascheroni constant.\n\n**Bounds:**\n- Upper: $F(N) \\leq \\log N + O(1)$ (trivial, from $k \\leq H_N$)\n- Lower: $F(N) \\geq \\log N + \\gamma - O((\\log\\log N)^2/\\log N)$ (Yokota 2002)",
     "text": "How many integers can be written as sums of distinct unit fractions with denominators from {1,...,N}? Answer: Θ(log N) such integers, answering Erdős's question negatively.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Unit Fractions:**\n   - unitFraction(n) = 1/n for positive n\n   - sumUnitFractions(S) = Σ_{d ∈ S} 1/d\n\n2. **Representability:**\n   - denominatorRange(N) = {1, ..., N}\n   - IsRepresentable(N, k): k = Σ_{d ∈ S} 1/d for some S ⊆ {1,...,N}\n   - countRepresentable(N) = F(N)\n\n3. **Harmonic Numbers:**\n   - harmonicNumber(N) = H_N = Σ_{n=1}^{N} 1/n\n   - H_N ~ log N + γ (Euler-Mascheroni)\n\n4. **Main Results (Axiomatized):**\n   - Trivial upper bound: F(N) ≤ ⌊log N⌋ + 2\n   - Yokota (1997): F(N) ≥ log N - O(log log N)\n   - Croot (1999): Exact threshold characterization\n   - Yokota (2002): Tight bounds\n\n5. **Answer:**\n   - erdos_309_answer: F(N) = Θ(log N), NOT o(log N)",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Unit Fractions:**\n   - unitFraction(n) = 1/n for positive n\n   - sumUnitFractions(S) = Σ_{d ∈ S} 1/d\n\n2. **Representability:**\n   - denominatorRange(N) = {1, ..., N}\n   - IsRepresentable(N, k): k = Σ_{d ∈ S} 1/d for some S ⊆ {1,...,N}\n   - countRepresentable(N) = F(N)\n\n3. **Harmonic Numbers:**\n   - harmonicNumber(N) = H_N = Σ_{n=1}^{N} 1/n\n   - H_N ~ log N + γ (Euler-Mascheroni)\n\n4. **Main Results:**\n   - Trivial upper bound: F(N) ≤ ⌊log N⌋ + 2 (proved)\n   - Yokota (1997): F(N) ≥ log N - O(log log N) — **axiomatized** as `yokota_lower_bound_1997`\n   - Croot (1999): Exact threshold characterization — referenced in commentary only, not axiomatized\n   - Yokota (2002): Tight bounds — referenced in commentary only, not axiomatized\n\n5. **Answer:**\n   - erdos_309_answer: F(N) = Θ(log N), NOT o(log N)",
     "keyInsights": [
       "**Egyptian Fractions:** Ancient mathematical concept - all fractions as sums of distinct 1/n",
       "**Harmonic Connection:** Representable integers k satisfy k ≤ H_N ~ log N + γ",
@@ -141,25 +141,25 @@
     {
       "id": "yokota-1997",
       "title": "Yokota's Lower Bound (1997)",
-      "summary": "yokota_lower_bound_1997 axiom",
-      "startLine": 200,
-      "endLine": 212,
+      "summary": "yokota_lower_bound_1997 axiom (Yokota 1997)",
+      "startLine": 207,
+      "endLine": 215,
       "mathContext": "Yokota (1997): $R(N) \\\\geq c\\\\log N$. First proof of logarithmic lower bound."
     },
     {
       "id": "croot-1999",
       "title": "Croot's Threshold (1999)",
-      "summary": "croot_threshold_1999 axiom",
-      "startLine": 213,
-      "endLine": 226,
+      "summary": "Croot's threshold (1999) — descriptive docstring, not axiomatized",
+      "startLine": 217,
+      "endLine": 225,
       "mathContext": "Croot (1999): every integer $m \\\\leq H_N - c\\\\sqrt{\\\\log N}$ is representable for large $N$."
     },
     {
       "id": "yokota-2002",
       "title": "Yokota's Refined Bound (2002)",
-      "summary": "yokota_refined_2002 axiom",
+      "summary": "Yokota's refined bound (2002) — descriptive docstring, not axiomatized",
       "startLine": 227,
-      "endLine": 239,
+      "endLine": 235,
       "mathContext": "Yokota (2002): refined constants in $R(N) = \\\\Theta(\\\\log N)$."
     },
     {


### PR DESCRIPTION
## Fix

Corrects phantom axiom claims and section line drift in `src/data/proofs/erdos-309/meta.json`.

## Evidence

**Phantom axioms removed**

The Lean file has exactly 1 axiom: `yokota_lower_bound_1997` (line 213). Croot 1999 and Yokota 2002 appear only as docstrings with no `axiom` declaration.

| Section | Before | After |
|---------|--------|-------|
| `croot-1999` summary | `croot_threshold_1999 axiom` | `Croot's threshold (1999) — descriptive docstring, not axiomatized` |
| `yokota-2002` summary | `yokota_refined_2002 axiom` | `Yokota's refined bound (2002) — descriptive docstring, not axiomatized` |

**Section line drift corrected**

| Section | Before | After |
|---------|--------|-------|
| `yokota-1997` | 200–212 | 207–215 |
| `croot-1999` | 213–226 | 217–225 |
| `yokota-2002` | 227–239 | 227–235 |

**proofStrategy step 4** updated to clarify only Yokota 1997 is axiomatized.

Closes #14501

---
Automated fix by lean-mechanic agent.