### PR TITLE
fix(meta): erdos-310 phantom axiom narrative + section drift

### DIFF
--- a/src/data/proofs/erdos-310/meta.json
+++ b/src/data/proofs/erdos-310/meta.json
@@ -65,7 +65,7 @@
     "historicalContext": "**Erdos Problem #310**\n\nThis problem was posed by Erdos and Graham [ErGr80] and concerns the representation of rational numbers as sums of unit fractions (Egyptian fractions) drawn from dense subsets of integers.\n\n**Key History:**\n- Erdos and Graham: Original problem formulation\n- Croot: Early work on density conditions for unit fraction sums\n- Bloom (2021): Proved the density of integers representable as sums of distinct unit fractions summing to 1\n- Liu and Sawhney (2024): Resolved Erdos #310 by observing Bloom's result implies the conjecture\n\n**Mathematical Setting:**\nThe problem asks: given any subset A of {1,...,N} with |A| >= alpha*N (an alpha-dense set), can we always find S contained in A such that the sum of 1/n for n in S equals a/b where b is bounded by a constant depending only on alpha?\n\nThis touches on deep questions about the distribution of unit fractions and the structure of Egyptian fraction representations.",
     "problemStatement": "**Problem Statement (Proved)**\n\nLet $\\alpha > 0$ and $N \\geq 1$. Is it true that for any $A \\subseteq \\{1,\\ldots,N\\}$ with $|A| \\geq \\alpha N$, there exists $S \\subseteq A$ such that\n$$\\frac{a}{b} = \\sum_{n \\in S} \\frac{1}{n}$$\nwith $a \\leq b = O_\\alpha(1)$?\n\n**Answer: YES**\n\nLiu and Sawhney (2024) proved that for $(\\log N)^{-1/7+o(1)} \\leq \\alpha \\leq 1/2$, there exists $S \\subseteq A$ with $a/b = \\sum_{n \\in S} 1/n$ where $a \\leq b \\leq \\exp(O(1/\\alpha))$.\n\nThey also proved this bound is **sharp**: the dependence $b \\leq \\exp(O(1/\\alpha))$ cannot be improved.",
     "text": "For any dense subset A of {1,...,N}, can we find S in A such that the sum of 1/n for n in S equals a/b with bounded denominator? YES, proved by Liu-Sawhney (2024).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - unitFractionSum: sum of 1/n over a finite set\n   - isDense: the alpha-density condition\n   - hasBoundedDenom: bounded denominator property\n   - erdosGrahamConjecture: the formal statement\n\n2. **Main Axioms:**\n   - liu_sawhney_theorem: the 2024 resolution with quantitative bounds\n   - bloom_unit_fraction_density: Bloom's foundational 2021 result\n   - liu_sawhney_sharpness: optimality of the exponential bound\n\n3. **Examples:**\n   - Classic Egyptian fractions (1/2 + 1/3 + 1/6 = 1)\n   - Various unit fraction sums verified by norm_num\n\n4. **Related Results:**\n   - egyptian_fraction_exists: every positive rational has a representation\n   - croot_theorem: density implies representability\n   - Connection to Erdos-Straus conjecture\n\n5. **Main Theorem:** erdos_310 uses liu_sawhney_theorem to prove erdosGrahamConjecture",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - unitFractionSum: sum of 1/n over a finite set\n   - isDense: the alpha-density condition\n   - hasBoundedDenom: bounded denominator property\n   - erdosGrahamConjecture: the formal statement\n\n2. **Main Axioms:**\n   - liu_sawhney_theorem: the 2024 resolution with quantitative bounds (only axiom declared)\n   - Bloom 2021 and Liu-Sawhney sharpness referenced in docstrings only, not axiomatized\n\n3. **Examples:**\n   - Classic Egyptian fractions (1/2 + 1/3 + 1/6 = 1)\n   - Various unit fraction sums verified by norm_num\n\n4. **Related Results:**\n   - Egyptian fraction existence and Croot's theorem referenced in docstrings only, not axiomatized\n   - Connection to Erdos-Straus conjecture\n\n5. **Main Theorem:** erdos_310 uses liu_sawhney_theorem to prove erdosGrahamConjecture",
     "keyInsights": [
       "**Egyptian Fractions:** Ancient Egyptians represented all fractions as sums of distinct unit fractions; this problem studies when such representations exist within restricted sets",
       "**Density Threshold:** The problem asks for a universal constant depending only on density alpha, not on N",
@@ -101,10 +101,10 @@
     {
       "id": "liu-sawhney",
       "title": "Liu-Sawhney Theorem",
-      "summary": "liu_sawhney_theorem and bloom_unit_fraction_density axioms",
+      "summary": "liu_sawhney_theorem axiom",
       "startLine": 84,
       "endLine": 122,
-      "mathContext": "Verified: liu_sawhney_theorem and bloom_unit_fraction_density axioms"
+      "mathContext": "Verified: liu_sawhney_theorem axiom (only axiom in file; Bloom's result referenced in docstring only)"
     },
     {
       "id": "examples",
@@ -125,18 +125,18 @@
     {
       "id": "sharpness",
       "title": "Sharpness of Bounds",
-      "summary": "liu_sawhney_sharpness axiom showing bounds are optimal",
+      "summary": "Sharpness of bounds — docstring commentary on optimality of exp(O(1/α)), not axiomatized",
       "startLine": 180,
       "endLine": 198,
-      "mathContext": "Axiomatized: liu_sawhney_sharpness axiom showing bounds are optimal"
+      "mathContext": "Commentary: sharpness of b ≤ exp(O(1/α)) bound; no axiom declaration in this section"
     },
     {
       "id": "egyptian-fractions",
       "title": "Egyptian Fractions",
-      "summary": "egyptian_fraction_exists, egyptian_fraction_greedy axioms",
+      "summary": "Egyptian fraction representations — docstring commentary only, no axiom declarations",
       "startLine": 199,
       "endLine": 224,
-      "mathContext": "Axiomatized: egyptian_fraction_exists, egyptian_fraction_greedy axioms"
+      "mathContext": "Commentary: Egyptian fraction existence and greedy algorithm; no axioms declared in this section"
     },
     {
       "id": "historical-context",
@@ -157,10 +157,10 @@
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "croot_theorem, erdos_310_summary",
+      "summary": "erdos_310_summary theorem (croot_theorem referenced in docstring only, not declared)",
       "startLine": 297,
       "endLine": 308,
-      "mathContext": "Verified: croot_theorem, erdos_310_summary"
+      "mathContext": "Verified: erdos_310_summary theorem; Croot's theorem is referenced in docstring commentary only"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Corrects five phantom axiom/result claims in `src/data/proofs/erdos-310/meta.json`.

## Evidence

The Lean file (`proofs/Proofs/Erdos310Problem.lean`, 308 lines) declares exactly **1 axiom**: `liu_sawhney_theorem`. The following names appeared in meta.json as axioms/theorems but exist only as docstrings in the Lean file:

| Phantom | Location in meta.json |
|---------|-----------------------|
| `bloom_unit_fraction_density` | `proofStrategy` + `sections.liu-sawhney.summary` |
| `liu_sawhney_sharpness` | `proofStrategy` + `sections.sharpness.summary` |
| `egyptian_fraction_exists` | `proofStrategy` + `sections.egyptian-fractions.summary` |
| `egyptian_fraction_greedy` | `sections.egyptian-fractions.summary` |
| `croot_theorem` | `proofStrategy` + `sections.related-results.summary` |

## Changes

- `proofStrategy` step 2 & 4: removed phantom entries; noted they are docstrings only
- `sections.liu-sawhney.summary`: changed to `liu_sawhney_theorem axiom` only
- `sections.sharpness.summary`: changed to docstring commentary description
- `sections.egyptian-fractions.summary`: changed to docstring commentary description
- `sections.related-results.summary`: removed phantom `croot_theorem`

Numerical fields (`axiomCount: 1`, `sorries: 0`, `lineCount: 308`) are correct and unchanged.

Closes #14499

---
Automated fix by lean-mechanic agent.