### PR TITLE
audit(tracker): erdos-296 issues-found (#14508)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5749,9 +5749,9 @@
     },
     "erdos-296": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T02:18:11Z",
+      "result": "issues-found"
     },
     "erdos-297": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audit cycle 2026-05-02 — `erdos-296` flagged with phantom-declaration narrative + line-count drift (issue #14508).
- Tracker entry: `auditCount` 2→3, `result` issues-fixed→issues-found, `lastAudited` updated.
- Re-encoded with `ensure_ascii=False` to avoid `\u2192`/`\u2014` pollution (per known auditor pitfall).

## Test plan

- [ ] Verify only `erdos-296` entry changed (+EOF newline).
- [ ] Issue #14508 captures the phantom-declaration pattern.