### PR TITLE
fix(meta): erdos-314 section line drift + missing diophantine section

### DIFF
--- a/src/data/proofs/erdos-314/meta.json
+++ b/src/data/proofs/erdos-314/meta.json
@@ -63,7 +63,7 @@
     "historicalContext": "**Erdős Problem #314: Harmonic Sum Error Term**\n\nThis problem from Erdős-Graham (1980) studies partial harmonic sums. Given n, let m(n) be the minimal integer such that the harmonic sum from n to m reaches at least 1. The error ε(n) is how much the sum overshoots 1.\n\n**Historical Development:**\n- **Erdős-Graham (1980):** Posed the question: is lim inf n²ε(n) = 0?\n- **Lim-Steinerberger (2024):** Proved YES with explicit bounds.\n\n**Key Insight:** Since harmonic sums grow like log(m/n), we have m(n) ≈ e·n. The question asks how precisely the sum can hit 1.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nLet n ≥ 1 and m(n) be minimal such that ∑_{k=n}^{m} 1/k ≥ 1.\nDefine ε(n) = ∑_{k=n}^{m(n)} 1/k - 1 (the overshoot).\n\n**Question:** Is lim inf n²ε(n) = 0?\n\n**Solution (Lim-Steinerberger 2024):**\nYES! There exist infinitely many n such that:\nε(n)n² ≪ (log log n / log n)^{1/2}\n\n**Optimal Exponent Conjecture (OPEN):**\nlim inf ε(n)n^{2+δ} = ∞ for all δ > 0",
     "text": "Let m(n) be minimal with partial harmonic sum ≥ 1, and ε(n) the overshoot. Is lim inf n²ε(n) = 0? SOLVED by Lim-Steinerberger (2024): YES, with infinitely many n achieving ε(n)n² ≪ (log log n / log n)^{1/2}.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Harmonic Sums:** Define H_n and partial sums via Finset.sum.\n\n2. **m(n):** Axiomatize as the minimal m with partial sum ≥ 1.\n\n3. **ε(n):** Define as the overshoot: partial sum minus 1.\n\n4. **Bounds:** Prove 0 ≤ ε(n) ≤ 1/n.\n\n5. **Approximation:** m(n)/n → e as n → ∞.\n\n6. **Main Theorem:** Axiomatize Lim-Steinerberger bound.\n\n7. **Optimal Exponent:** State the remaining open conjecture.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Harmonic Sums:** Define H_n and partial sums via Finset.sum.\n\n2. **m(n):** Axiomatize as the minimal m with partial sum ≥ 1.\n\n3. **ε(n):** Define as the overshoot: partial sum minus 1.\n\n4. **Bounds:** Prove 0 ≤ ε(n) ≤ 1/n.\n\n5. **Approximation (sketch only):** m(n)/n → e as n → ∞ — documented in orphan docstrings, not formalized in Lean.\n\n6. **Main Theorem:** Axiomatize Lim-Steinerberger bound.\n\n7. **Optimal Exponent:** State the remaining open conjecture.",
     "keyInsights": [
       "**Harmonic Growth:** H_n ≈ ln(n) + γ where γ is Euler-Mascheroni constant",
       "**m(n) ≈ e·n:** The ratio m(n)/n approaches e ≈ 2.718",
@@ -83,63 +83,71 @@
       "title": "Harmonic Sum Definitions",
       "summary": "harmonicNumber, partialHarmonicSum",
       "startLine": 33,
-      "endLine": 51,
+      "endLine": 67,
       "mathContext": "Mathematical content: harmonicNumber, partialHarmonicSum"
     },
     {
       "id": "m-function",
       "title": "The Function m(n)",
       "summary": "Minimal m with partial sum ≥ 1",
-      "startLine": 52,
-      "endLine": 71,
+      "startLine": 69,
+      "endLine": 86,
       "mathContext": "Minimal m with partial sum $\\geq$ 1"
     },
     {
       "id": "epsilon",
       "title": "The Error Term ε(n)",
       "summary": "Definition and basic bounds",
-      "startLine": 72,
-      "endLine": 91,
+      "startLine": 87,
+      "endLine": 145,
       "mathContext": "Formal definition: Definition and basic bounds"
     },
     {
       "id": "approximation",
       "title": "Approximation of m(n)",
-      "summary": "m(n)/n → e asymptotically",
-      "startLine": 92,
-      "endLine": 104,
+      "summary": "m(n)/n → e asymptotically (sketch only — orphan docstrings, not formalized)",
+      "startLine": 146,
+      "endLine": 152,
       "mathContext": "m(n)/n $\\to$ e asymptotically"
     },
     {
       "id": "main-question",
       "title": "The Main Question",
       "summary": "Is lim inf n²ε(n) = 0?",
-      "startLine": 105,
-      "endLine": 114,
+      "startLine": 153,
+      "endLine": 162,
       "mathContext": "Mathematical content: Is lim inf n²ε(n) = 0?"
     },
     {
       "id": "solution",
       "title": "Lim-Steinerberger Theorem (2024)",
       "summary": "YES with explicit bounds",
-      "startLine": 115,
-      "endLine": 131,
+      "startLine": 163,
+      "endLine": 196,
       "mathContext": "Bound: YES with explicit bounds"
     },
     {
       "id": "optimal",
       "title": "Optimal Exponent Conjecture",
-      "summary": "Exponent 2 conjectured optimal",
-      "startLine": 132,
-      "endLine": 143,
+      "summary": "Exponent 2 conjectured optimal (docstring only — not formalized)",
+      "startLine": 197,
+      "endLine": 203,
       "mathContext": "Mathematical content: Exponent 2 conjectured optimal"
+    },
+    {
+      "id": "diophantine-connection",
+      "title": "Connection to Diophantine Approximation",
+      "summary": "eulerMascheroni definition",
+      "startLine": 204,
+      "endLine": 213,
+      "mathContext": "Euler-Mascheroni constant definition and connection to Diophantine approximation via harmonic sums"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Main results and open questions",
-      "startLine": 158,
-      "endLine": 184,
+      "startLine": 214,
+      "endLine": 238,
       "mathContext": "Mathematical content: Main results and open questions"
     }
   ],


### PR DESCRIPTION
## Fix

Corrects all 8 section line ranges and adds missing section in `src/data/proofs/erdos-314/meta.json`.

## Evidence

All section `startLine`/`endLine` values were wrong (off by ~20–30 lines each). The Lean file's actual section headers were at different positions than recorded.

| Section | Before | After |
|---------|--------|-------|
| harmonic-defs | 33–51 | 33–67 |
| m-function | 52–71 | 69–86 |
| epsilon | 72–91 | 87–145 |
| approximation | 92–104 | 146–152 |
| main-question | 105–114 | 153–162 |
| solution | 115–131 | 163–196 |
| optimal | 132–143 | 197–203 |
| summary | 158–184 | 214–238 |

**Added missing section**: `diophantine-connection` (lines 204–213) covering the `eulerMascheroni` definition that was entirely absent from `sections`.

**Clarified**: `approximation` and `optimal` sections contain orphan docstrings only (no executable Lean); noted in summaries and proofStrategy.

Closes #14497

---
Automated fix by lean-mechanic agent.