### PR TITLE
fix(meta): erdos-295 phantom narrative + dangling docstrings

### DIFF
--- a/proofs/Proofs/Erdos295Problem.lean
+++ b/proofs/Proofs/Erdos295Problem.lean
@@ -42,7 +42,7 @@ This problem asks about representations of 1 as an Egyptian fraction where all
 denominators are at least N. As N grows, we need more terms to sum to 1.
 -/
 
-/--
+/-
 For each N, there exists a representation of 1 as a sum of distinct unit fractions
 with all denominators ≥ N. This is a foundational existence result.
 
@@ -61,10 +61,10 @@ This axiom asserts the existence of this minimal value.
 -/
 axiom k (N : ℕ) : ℕ
 
-/--
+/-
 k(N) achieves a representation of 1 with all denominators ≥ N.
 -/
-/--
+/-
 k(N) is minimal: any representation with denominators ≥ N needs at least k(N) terms.
 -/
 /--

--- a/src/data/proofs/erdos-295/meta.json
+++ b/src/data/proofs/erdos-295/meta.json
@@ -43,7 +43,7 @@
     ],
     "originalContributions": [
       "Formal statement of the OPEN Erdős problem in Lean 4",
-      "Axiomatization of k(N) function with existence and minimality",
+      "Axiomatization of k(N) as an opaque ℕ→ℕ function; existence and minimality described in prose",
       "Formalization of Erdős-Straus bounds: -c < k(N) - (e-1)N < O(N/log N)",
       "Verified concrete Egyptian fraction examples summing to 1"
     ],
@@ -98,16 +98,16 @@
       "title": "Existence of Representations",
       "startLine": 45,
       "endLine": 63,
-      "summary": "Axiom stating that for each N, a representation of 1 exists with denominators ≥ N.",
-      "mathContext": "Axiom stating that for each N, a representation of 1 exists with denominators $\\geq$ N."
+      "summary": "Background prose describing Egyptian fraction existence (no existence axiom declared); `axiom k (N : ℕ) : ℕ` declares k(N) as an opaque ℕ→ℕ function.",
+      "mathContext": "Background: Existence described in prose only; `axiom k (N : ℕ) : ℕ` declares k(N) as an opaque ℕ→ℕ function with no existence or minimality constraints."
     },
     {
       "id": "k-definition",
       "title": "The Function k(N)",
       "startLine": 64,
       "endLine": 87,
-      "summary": "Axioms defining k(N) as the minimal number of terms, with existence and minimality properties.",
-      "mathContext": "Axiomatized: Axioms defining k(N) as the minimal number of terms, with existence and minimality properties."
+      "summary": "Background prose describing achievability and minimality of k(N) (not axioms); `axiom erdos_straus_bounds` stating the Erdős-Straus asymptotic bounds.",
+      "mathContext": "Axiomatized: `axiom erdos_straus_bounds` (-c < k(N) - (e-1)N < O(N/log N)); achievability and minimality of k described in prose only."
     },
     {
       "id": "erdos-straus",


### PR DESCRIPTION
## Fix

Remove 3 dangling doc-comments (`/--`) in `Erdos295Problem.lean` that had no following declaration, and update `meta.json` narrative to accurately describe the 2-axiom formalization.

## Evidence

**Before**: `sections.existence.summary` claimed "Axiom stating that for each N, a representation of 1 exists" — no such axiom exists. `originalContributions[1]` claimed "Axiomatization of k(N) function with existence and minimality" — `axiom k` is only an opaque ℕ→ℕ function.

**After**: Lean file has no dangling `/--` doc-comments. `meta.json` accurately reflects that existence/minimality are described in prose only, and `axiom k` is an unconstrained opaque function.

Closes #14513

---
Automated fix by lean-mechanic agent.