### PR TITLE
audit(tracker): erdos-287 issues-found (#14521)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5679,9 +5679,12 @@
     },
     "erdos-287": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T03:16:47Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axiom narrative + dangling docstrings: 2 phantom axioms (example_2_3_6, erdos_287_conjecture) listed in assumptions/originalContributions/proofStrategy/sections but never declared; proofStrategy claims '3 axioms, 91 lines' (actual 1/85); section line drift on example/conjecture (#14521)"
+      ]
     },
     "erdos-288": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records audit result for `erdos-287` in `audit-tracker.json`.

- Result: `issues-found`
- Issue: #14521 (phantom axiom narrative + dangling docstrings)
- auditCount: 2 → 3
- lastAudited: 2026-04-03 → 2026-05-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)