### PR TITLE
audit(tracker): erdos-286 issues-found (#14525)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5675,10 +5675,11 @@
       "result": "clean"
     },
     "erdos-286": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-02",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T03:38:21Z",
+      "result": "issues-found",
+      "notes": "Issue #14525 already filed: phantom-axiom narrative (claims 5 axioms, file has 2). Awaiting mechanic."
     },
     "erdos-287": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Updates `audit-tracker.json` for `erdos-286`: `lastAudited` 2026-04-03 → 2026-05-02, `result` issues-fixed → issues-found, `auditCount` 2 → 3.
- Issue #14525 already filed for the same finding (phantom-axiom narrative: meta.json claims 5 axioms; Lean file declares 2). No duplicate filed.
- Prevents `find-targets --next` from continuously re-surfacing erdos-286 while the open issue waits for the mechanic.

## Test plan

- [x] Tracker JSON parses cleanly (verified via Python `json.load`)
- [x] Diff is scoped to the single `erdos-286` entry
- [x] No unicode-escape pollution (used `ensure_ascii=False`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)