### PR TITLE
audit(tracker): erdos-281 issues-found (#14532)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5642,10 +5642,13 @@
       "result": "issues-fixed"
     },
     "erdos-281": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T03:45:20Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom-axiom narrative: claims axiomatization of divergence/coprime/Davenport-Erdős/Rogers but only erdos_281_proved exists; sections.divergence-coprime summary describes content that is only dangling docstrings (lines 217-219) — issue #14532"
+      ]
     },
     "erdos-282": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Records erdos-281 audit result: **issues-found** (auditCount 2→3)
- Issue #14532: phantom-axiom narrative + dangling docstrings

## Findings

erdos-281 has 1 axiom in source (`erdos_281_proved`), but meta.json prose claims axiomatization of "divergence of reciprocals", "the coprime special case", and "Davenport-Erdős and Rogers theorems" — three things that do not exist as declarations. The `divergence-coprime` section summary describes lines 215-231, which contain only two dangling docstrings.

## Test plan
- [x] tracker entry uses `entries.<id>` schema
- [x] no unicode-escape pollution (`ensure_ascii=False`)
- [x] only erdos-281 entry modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)