### PR TITLE
audit(tracker): erdos-280 issues-found (#14535)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5637,9 +5637,12 @@
     },
     "erdos-280": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T03:50:26Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axiom 'cambie_only_one_avoider' in originalContributions; section summaries reference cambie_satisfies_growth/cambie_only_one_avoider/cambie_count_is_one/prime_number_theorem_approx that exist only as docstrings; section line ranges drifted — issue #14535"
+      ]
     },
     "erdos-281": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Mark erdos-280 audit complete with issues-found result; tracking issue #14535.

## Findings

- **Phantom axiom in `originalContributions`**: lists `cambie_only_one_avoider axiom` — exists only as a docstring (lines 79-81), not declared.
- **Section summaries reference phantom decls**: `cambie_satisfies_growth`, `cambie_only_one_avoider`, `cambie_count_is_one`, `prime_number_theorem_approx axiom` — all docstring-only, never declared.
- **Section line ranges drifted**: counterexample/refutation/bound-optimality/summary all off by 1-15 lines.

Numerical fields (`axiomCount: 1`, `sorries: 0`, `lineCount: 113`, `theoremCount: 3`, `definitionCount: 6`) are correct.

See #14535 for full evidence and recommended fix.

## Test plan

- [x] Tracker JSON parses
- [x] Diff is 6 insertions / 3 deletions touching only erdos-280

🤖 Generated with [Claude Code](https://claude.com/claude-code)