### PR TITLE
Fix: erdos-280 phantom axiom narrative + section line drift

### DIFF
--- a/src/data/proofs/erdos-280/meta.json
+++ b/src/data/proofs/erdos-280/meta.json
@@ -52,7 +52,6 @@
       "OriginalConjecture definition",
       "cambie_n and cambie_a constructions",
       "cambie_increasing theorem (constructive)",
-      "cambie_only_one_avoider axiom",
       "original_conjecture_false axiom",
       "erdos_280_summary theorem"
     ],
@@ -95,29 +94,29 @@
     {
       "id": "counterexample",
       "title": "Cambie's Counterexample",
-      "summary": "cambie_n, cambie_a, cambie_increasing, cambie_satisfies_growth, cambie_only_one_avoider, cambie_count_is_one",
+      "summary": "cambie_n, cambie_a definitions and cambie_increasing theorem (proved). Docstrings note growth bound, covering insight, and count = 1 result.",
       "startLine": 64,
-      "endLine": 93
+      "endLine": 83
     },
     {
       "id": "refutation",
       "title": "Refutation of the Conjecture",
       "summary": "original_conjecture_false, erdos_280_disproved",
-      "startLine": 94,
-      "endLine": 102
+      "startLine": 84,
+      "endLine": 92
     },
     {
       "id": "bound-optimality",
       "title": "Why the Bound is Best Possible",
-      "summary": "prime_number_theorem_approx axiom",
-      "startLine": 103,
-      "endLine": 112
+      "summary": "Block comment explaining why the (1+ε)k log k bound is tight (PNT argument: pₖ ~ k log k). No Lean declarations in this section.",
+      "startLine": 93,
+      "endLine": 97
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_280_summary theorem",
-      "startLine": 113,
+      "startLine": 98,
       "endLine": 113
     }
   ],


### PR DESCRIPTION
## Fix

Corrects phantom-axiom narrative and section line drift in meta.json for erdos-280 (Covering Congruences and Sieve Methods).

## Evidence

**Before**: `originalContributions` included "cambie_only_one_avoider axiom" — not declared (only in a docstring). Section `counterexample` summary listed `cambie_satisfies_growth`, `cambie_only_one_avoider`, `cambie_count_is_one` — none declared. Section `bound-optimality` claimed "prime_number_theorem_approx axiom" — not declared (only in a block comment). `proofStrategy` claimed "The growth bound, covering property, exact count, and conjecture refutation are axiomatized" — only the conjecture refutation is axiomatized; others are informal docstrings. Section line ranges off.

**After**: `originalContributions` accurately lists 7 entries. Section summaries reference only declared symbols. `proofStrategy` accurately describes only `original_conjecture_false` as axiomatized, with growth-bound/covering/count claims marked as informal docstrings. Section line ranges corrected: `counterexample` 64-83, `refutation` 84-92, `bound-optimality` 93-97, `summary` 98-113.

Closes #14535
Closes #14552

---
Automated fix by lean-mechanic agent.