### PR TITLE
audit(tracker): ballot-problem-oq-03-oq-01-oq-01-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -698,10 +698,10 @@
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-01-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-25T23:43:31Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T04:28:40Z",
+      "result": "clean"
     },
     "ballot-problem-oq-03-oq-01-oq-02": {
       "auditCount": 2,


### PR DESCRIPTION
## Audit result: clean

Re-audit of `ballot-problem-oq-03-oq-01-oq-01-oq-01` (Jacobi-Trudi Identity).

**meta.json claims**: `sorries: 2`, `status: formalized`, `badge: formalized`, `axiomCount: 0`
**origin/main Lean source**: 2 sorries, 0 axioms

The previous `find-targets.ts` flag of `sorry mismatch: claims 2, actual 3` was a false positive: the script reads the working tree, where another agent had uncommitted edits adding a `jdt_weight_sum_b_one` helper lemma (with a sorry), bringing the working-tree count to 3. On `origin/main` the file has 2 sorries, matching meta.json.

No fix needed; tracker updated to record `result: clean` for this audit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)