### PR TITLE
audit(tracker): erdos-265 issues-found (#14556)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5533,9 +5533,9 @@
     },
     "erdos-265": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T04:31:47Z",
+      "result": "issues-found"
     },
     "erdos-266": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of `erdos-265` (Growth Rates of Sequences with Rational Sums) — phantom-axiom narrative pattern already tracked.

## Findings

**Numerical claims (correct ✓):**
- `axiomCount=2` matches actual: `erdos_265_doubleExp_necessary`, `kovac_tao_theorem`
- `sorries=0` matches
- `lineCount=233` matches

**Narrative claims (overstated ✗ — already filed in #14556, fix in flight in #14561):**
- `originalContributions[3]`: "Formal statement of irrationality threshold at β = 2" — file has only a dangling `/-- Fast double-exponential growth implies irrational sum -/` docstring before a section comment, no actual axiom or theorem
- `proofStrategy`: claims "the irrationality threshold are stated as axioms" — false; only 2 axioms exist and neither is the irrationality threshold
- `sections.cantor-example.summary`: "states rationality of both sums as axioms" — actually proven as `theorem cantorSeq_rational_sum` and `theorem cantorSeq_shifted_rational`
- `sections.irrationality.summary`, `sections.valid-set-poly.summary`: describe formal statements that exist only as docstrings

## Action

No new issue filed — #14556 and PR #14561 already cover this. Tracker updated to reflect re-audit (`auditCount: 2→3`, `result: issues-fixed→issues-found` until #14561 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)