### PR TITLE
audit(tracker): erdos-259 issues-found (#14564)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5487,10 +5487,13 @@
       "result": "issues-fixed"
     },
     "erdos-259": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-02-erdos-259",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T04:38:14Z",
+      "result": "issues-found",
+      "issues": [
+        "section line drift: sections[].startLine/endLine off by ~20–90 lines; missing 'Squarefree Numbers' section (issue #14564)"
+      ]
     },
     "erdos-26": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Records `erdos-259` audit result as `issues-found`, linking issue #14564.
- The proof's numerical claims are accurate (axiomCount=2, sorries=0, badge=axiom, status=axiomatized).
- Issue: `sections[]` line ranges in `meta.json` are off by ~20–90 lines from the actual Lean source, and the `Squarefree Numbers` block has no matching section entry.

## Test plan

- [x] Tracker JSON parses (`python3 -c "import json; json.load(open(...))"`)
- [x] Diff is 4-line surgical edit limited to the `erdos-259` entry
- [x] Issue #14564 documents the proposed `sections[]` rewrite