### PR TITLE
Research: ballot-problem-oq-03-oq-01-oq-01-oq-01 — decompose jdt_weight_sum b≥1 into b=1 helper + b≥2

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -381,6 +381,50 @@ private lemma jdt_weight_preserved (n a b : ℕ)
   conv_rhs => rw [hQ, Multiset.map_cons, Multiset.prod_cons]
   ring
 
+/-- For `Q : Sym (Fin n) 1`, the underlying multiset is the singleton `{q}` where `q` is the
+    unique element of `Q`. We extract `q` and the equation `Q.1.sort = [q]` simultaneously. -/
+private lemma sym_one_sort_head_singleton (n : ℕ) (Q : Sym (Fin n) 1) :
+    ∃ q : Fin n, Q.1.sort (· ≤ ·) = [q] ∧ Q.1 = ({q} : Multiset (Fin n)) := by
+  have hlen : (Q.1.sort (· ≤ ·)).length = 1 := (Multiset.length_sort _ Q.1).trans Q.2
+  obtain ⟨q, hq⟩ := List.length_eq_one_iff.mp hlen
+  refine ⟨q, hq, ?_⟩
+  have hcoe := congrArg (Multiset.ofList) hq
+  rw [Multiset.sort_eq] at hcoe
+  simpa using hcoe
+
+/-- **JDT weight sum, `b = 1` base case.**
+    For `a ≥ 1`, the sum of weights over non-col-strict
+    `(P : Sym (Fin n) a, Q : Sym (Fin n) 1)` pairs equals `h_{a+1} * h_0 = h_{a+1}`.
+
+    **Recipe (bijection ψ : `LHS-subtype ≃ Sym (Fin n) (a+1)`):**
+      * forward: `(P, Q, _) ↦ q ::ₛ P`, where `q` is the unique element of `Q`
+        (i.e. `(Q.1.sort)[0]`).
+      * inverse: `S ↦ ((S.erase qS hS, ⟨{qS}, _⟩), proof_¬ColStrict)`,
+        where `qS = (S.1.sort)[0]` is the smallest element of `S`.
+
+    **Why the bijection respects `¬ColStrictSym a 1 P Q`:**
+    With `a ≥ 1`, `min a 1 = 1`, so `ColStrictSym a 1 P Q ⇔ (P.sort)[0] < (Q.sort)[0] = q`,
+    and `¬ColStrictSym ⇔ q ≤ (P.sort)[0]`. By sortedness of `P.sort`, this means
+    `q ≤ x` for all `x ∈ P.1`. Then `Multiset.sort_cons` gives
+    `(q ::ₘ P.1).sort = q :: P.1.sort`, so `q` is the head of `(q ::ₛ P).1.sort`,
+    making `Sym.erase` and `Sym.cons_erase`/`Sym.erase_cons_head` close the inverses.
+
+    **Status (2026-05-02 session 15):** the helper `sym_one_sort_head_singleton` and the
+    statement of this lemma are now in place. The bijection construction with weight
+    preservation proof is the focused `sorry` below; estimated 100-130 lines using
+    `Sym.cons_erase` (`Data/Sym/Basic.lean:219`), `Sym.erase_cons_head` (`:223`),
+    `Multiset.sort_cons` (`Data/Multiset/Sort.lean:69`). -/
+private lemma jdt_weight_sum_b_one (n a : ℕ) (ha : 1 ≤ a) :
+    ∑ PQ : { PQ : Sym (Fin n) a × Sym (Fin n) 1 // ¬ColStrictSym a 1 PQ.1 PQ.2 },
+      (PQ.1.1.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
+      (PQ.1.2.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
+    hsymm (Fin n) R (a + 1) * hsymm (Fin n) R 0 := by
+  -- Simplify RHS via hsymm 0 = 1
+  rw [hsymm_zero, mul_one]
+  -- Bijection construction is the focused next-session task. See the recipe above
+  -- and lines ~415-465 for the existing detailed comment block.
+  sorry
+
 /-- **Jeu de Taquin weight sum** (key step for two-row Jacobi-Trudi).
     The sum of pair-weights over NON-col-strict (a,b) pairs equals h_{a+1}*h_{b-1}.
 

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -441,76 +441,33 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
       (PQ.1.2.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
     hsymm (Fin n) R (a + 1) * (if 1 ≤ b then hsymm (Fin n) R (b - 1) else 0) := by
   by_cases hb : 1 ≤ b
-  · -- b ≥ 1: JDT bijection
+  · -- b ≥ 1: dispatch on b = 1 vs b ≥ 2
     simp only [if_pos hb]
-    rw [← sum_all_sym_pairs n (a + 1) (b - 1)]
-    -- Need: weight-preserving bijection
-    --   {non-col-strict (a,b) pairs} ≃ {all (a+1, b-1) pairs}
-    -- Forward map: find first violation c in ColStrictSym, let v = Q.sort[c],
-    --   then P' = Sym.cons v P, Q' = Sym.erase Q v (need v ∈ Q.1)
-    -- Inverse map: find the "seam" element in P'.sort to move back to Q'
-    -- Weight preserved by Multiset.prod_cons + Multiset.prod_erase
-    --
-    -- ============================================================================
-    -- DETAILED RECIPE FOR b = 1 BASE CASE (helper for next session)
-    -- ============================================================================
-    -- When b = 1, ColStrictSym a 1 P Q says P.sort[0] < Q.sort[0]; ¬cs gives the
-    -- opposite. Q has size 1, so by Sym.oneEquiv we have Q = oneEquiv q for some
-    -- q : Fin n, with q = Q.sort[0] (only element). Goal becomes:
-    --
-    --   ∑_{(P, q): q ≤ P.sort[0]} wt(P) * X q = h_{a+1}
-    --
-    -- BIJECTION ψ : {(P, q) : q ≤ P.sort[0]} ≃ Sym (Fin n) (a+1)
-    --   forward (P, q) ↦ q ::ₛ P            -- Sym.cons; coe = q ::ₘ P.1
-    --   inverse P' ↦ ((P'.erase q', oneEquiv q')) where
-    --     q' := (P'.1.sort (· ≤ ·)).head    -- smallest element
-    --     proof q' ∈ P'.1: q' is the head of (length a+1) sorted list
-    --     proof q' ≤ (P'.erase q').sort[0]: erase preserves sortedness; q' was min
-    --   weight preservation:
-    --     wt(P) * X q
-    --     = (P.1.map X).prod * X q
-    --     = ((q ::ₘ P.1).map X).prod          -- by Multiset.prod_cons + map_cons
-    --     = wt(q ::ₛ P)
-    -- KEY LEMMAS (verified Mathlib v4.26.0, paths confirmed 2026-04-27 session 13):
-    --   * Multiset.sort_cons (Data/Multiset/Sort.lean:69):
-    --       (∀ b ∈ s, r a b) → sort(a ::ₘ s) r = a :: sort s r
-    --     Applied with: q ≤ P.sort[0] + sortedness ⇒ q ≤ all of P
-    --   * Sym.cons (Data/Sym/Basic.lean:106), coe_cons:123 (rfl):
-    --       (a ::ₛ s : Multiset α) = a ::ₘ s.1
-    --   * Sym.cons_erase (Data/Sym/Basic.lean:219, simp):
-    --       a ::ₛ s.erase a h = s   — closes left_inv
-    --   * Sym.erase_cons_head (Data/Sym/Basic.lean:223, simp):
-    --       (a ::ₛ s).erase a _ = s — closes right_inv direction
-    --   * Sym.oneEquiv (Data/Sym/Basic.lean:477, @[simps apply]):
-    --       α ≃ Sym α 1; oneEquiv_apply rewrites oneEquiv a to ⟨{a}, _⟩
-    --
-    -- INVERSE DIRECTION MECHANISM (the trickiest piece, fleshed out session 13):
-    --   Given P' : Sym (Fin n) (a+1):
-    --     L := (P'.1 : Multiset).sort (· ≤ ·) : List (Fin n), length = a+1, sorted
-    --     L_pos : 0 < L.length := by simp [Multiset.length_sort, P'.2]
-    --     q' := L.head L_pos.ne' : Fin n
-    --   Show q' ∈ P'.1 (need this to apply Sym.erase):
-    --     have : q' ∈ L := List.head_mem L_pos.ne'
-    --     have : q' ∈ (L : Multiset) := Multiset.mem_coe.mpr this
-    --     rw [Multiset.sort_eq] at this
-    --     exact this -- q' ∈ P'.1
-    --   Show q' ≤ (P'.1.erase q').sort[0] (the bijection's domain constraint):
-    --     L = q' :: L.tail (by List.head_cons_tail)
-    --     P'.1 = (q' ::ₘ (L.tail : Multiset)) by Multiset.sort_eq + List congruence
-    --     (P'.1.erase q' : Multiset) = (L.tail : Multiset)
-    --       by Multiset.erase_cons_head (Data/Multiset/AddSub.lean:156):
-    --         (a ::ₘ s).erase a = s
-    --     (P'.1.erase q').sort[0] = L.tail[0] = L[1] (when a ≥ 1)
-    --     Sortedness of L gives L[0] ≤ L[1], so q' ≤ L.tail[0]. ✓
-    --     For a = 0 case: tail is empty, so erased multiset is 0; ColStrictSym is vacuous.
-    -- ESTIMATE: ~80-100 lines for jdt_weight_sum_b_one as a separate helper.
-    -- ============================================================================
-    --
-    -- For b ≥ 2, the bijection generalizes: insert Q.sort[c] into P at position c,
-    -- where c is the first violation index. The inverse map is the JDT seam
-    -- algorithm (find c such that P'.sort[c] came from Q's c-th violation column).
-    -- This is genuinely intricate; ~150-200 lines of focused Lean work.
-    sorry
+    rcases Nat.lt_or_ge b 2 with hb1 | hb2
+    · -- b = 1: use jdt_weight_sum_b_one (RHS is hsymm (a+1) * hsymm 0)
+      have hbeq : b = 1 := by omega
+      subst hbeq
+      -- After subst, hba : 1 ≤ a, and the RHS is hsymm (a+1) * hsymm (1 - 1)
+      -- which is hsymm (a+1) * hsymm 0 by rfl on Nat subtraction.
+      exact jdt_weight_sum_b_one n a hba
+    · -- b ≥ 2: the general JDT seam bijection (still sorry)
+      rw [← sum_all_sym_pairs n (a + 1) (b - 1)]
+      -- Need: weight-preserving bijection
+      --   {non-col-strict (a,b) pairs} ≃ {all (a+1, b-1) pairs}
+      -- Forward map: find first violation c in ColStrictSym, let v = Q.sort[c],
+      --   then P' = Sym.cons v P, Q' = Sym.erase Q v (need v ∈ Q.1)
+      -- Inverse map: find the "seam" element in P'.sort to move back to Q'
+      -- Weight preserved by Multiset.prod_cons + Multiset.prod_erase
+      --
+      -- For b ≥ 2, the bijection generalizes: insert Q.sort[c] into P at position c,
+      -- where c is the first violation index. The inverse map is the JDT seam
+      -- algorithm (find c such that P'.sort[c] came from Q's c-th violation column).
+      -- This is genuinely intricate; ~150-200 lines of focused Lean work.
+      --
+      -- The b = 1 base case (above) demonstrates the construction with q = Q.sort[0]
+      -- and the inverse via head-of-sort. Generalizing requires tracking the
+      -- "seam index" c through the bijection invariants.
+      sorry
   · -- b = 0: ColStrictSym a 0 P Q is vacuously true (quantifies over Fin (min a 0) = Fin 0)
     -- So ¬ColStrictSym = False, the subtype is empty, and the sum equals 0
     push_neg at hb

--- a/proofs/Proofs/FeuerbachsTheoremOQ02.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ02.lean
@@ -8,31 +8,35 @@ import Mathlib.Tactic
 ## Open Question
 "What is the 3D analogue of Feuerbach's theorem for tetrahedra?"
 
-## Answer
-For an **orthocentric tetrahedron** (one where opposite edges are perpendicular),
-the **twenty-four-point sphere** (3D analogue of the nine-point circle) is tangent
-to the insphere and all four exspheres.
+## Status (2026-05-02)
+The natural candidate "3D Feuerbach theorem" — that the (N₂₄, R/3)-sphere is
+tangent to the insphere/exspheres of every orthocentric tetrahedron — is FALSE
+with the standard definitions used here. The explicit counterexample
+T₀ = ((2,0,0), (0,3,0), (0,0,6), (0,0,0)) (orthocentric, since opposite edges
+are pairwise perpendicular) yields:
+  dist(N₂₄, I)² = 3 r²  vs.  (R/3 − r)² = (7/6 − r)²
+which are unequal in closed form (see PART 10 of this file). The five tangency
+sorries previously stated have therefore been REMOVED rather than proved; what
+remains is a coordinate-geometry infrastructure for tetrahedra plus six proved
+results that survive the refutation (Euler line, edge-midpoint equidistance,
+volume–inradius identity, etc.).
 
-Unlike the 2D case, this does NOT hold for arbitrary tetrahedra. The orthocentric
-condition is essential.
+The correct 3D analogue (Murakami 1952; Court 1934) is left as an open
+formalization target: it apparently requires a different sphere (face
+circumcircle data) rather than the (N₂₄, R/3) sphere.
 
-## Key Facts
-1. An orthocentric tetrahedron has the property that opposite edges are perpendicular:
-   AB ⊥ CD, AC ⊥ BD, AD ⊥ BC
-2. The twenty-four-point sphere passes through:
-   - 6 edge midpoints
-   - 4 centroids of the faces
-   - 4 feet of altitudes (from vertices to opposite faces)
-   - 4 midpoints of segments from vertices to the orthocenter
-   - 6 points related to the Monge point
-3. The twenty-four-point sphere has radius R/3 where R is the circumradius
-4. The center of the twenty-four-point sphere is the midpoint of the circumcenter
-   and the Monge point (3D analogue of the orthocenter for non-orthocentric tetrahedra)
+## Key Facts (about an orthocentric tetrahedron)
+1. Opposite edges are perpendicular: AB ⊥ CD, AC ⊥ BD, AD ⊥ BC.
+2. The Monge point M = 4G − 3O lies on the Euler line through O, G, H.
+3. The six edge midpoints are equidistant from the centroid G with common
+   distance R/2 (proved here as `edge_midpoints_equidist_from_centroid`).
+4. The (N₂₄, R/3) sphere — definitions are kept for reference and downstream
+   work — does NOT in general pass through the four face centroids and is NOT
+   in general tangent to the insphere/exspheres.
 
 ## Approach
-Coordinate geometry in ℝ³, following the same pattern as the 2D Feuerbach proof.
-We define an orthocentric tetrahedron, construct the key geometric objects, and
-state the tangency relations.
+Coordinate geometry in ℝ³. Definitions, structural proofs, and a refutation of
+the false candidate; no positive tangency theorem is asserted.
 
 ## References
 - Murakami (1952): Feuerbach's theorem for tetrahedra
@@ -454,107 +458,59 @@ def spheresExternallyTangent (c₁ c₂ : Point3) (r₁ r₂ : ℝ) : Prop :=
   dist3 c₁ c₂ = r₁ + r₂
 
 -- ============================================================
--- PART 10: The 3D Feuerbach Theorem (Orthocentric Case)
+-- PART 10: The 3D Feuerbach Conjecture — Refuted as Stated
 -- ============================================================
 
 /-
-  **Mathematical Status Warning**: The tangency theorems below use
-  `twentyFourPointCenter` (= midpoint(O, M)) and `twentyFourPointRadius` (= R/3).
-  For an orthocentric tetrahedron, N₂₄ = midpoint(O, M) = H (the orthocenter),
-  so these theorems claim: dist(H, I) = |R/3 - r| and dist(H, E_X) = R/3 + r_X.
+  **REFUTATION (2026-05-02)**: The candidate "3D Feuerbach theorem" — that for
+  every orthocentric tetrahedron the twenty-four-point sphere (center
+  `twentyFourPointCenter` = midpoint(O, M), radius `R/3`) is internally tangent
+  to the insphere and externally tangent to all four exspheres — is FALSE
+  with these definitions.
 
-  Numerical verification shows these tangency relations FAIL for the orthocentric
-  tetrahedron (2,0,0), (0,3,0), (0,0,6), (0,0,0):
-    dist(N₂₄, I) ≈ 1.067 but |R/3 - r| ≈ 0.551
-  They hold trivially for the regular tetrahedron (degenerate: N₂₄ = I = O).
+  Counterexample: T₀ = OrthocentricTetrahedron with
+      A = (2, 0, 0), B = (0, 3, 0), C = (0, 0, 6), D = (0, 0, 0).
+  Verification of orthocentricity:
+      AB · CD = (-2, 3, 0) · (0, 0, -6) = 0
+      AC · BD = (-2, 0, 6) · (0, -3, 0) = 0
+      AD · BC = (-2, 0, 0) · (0, -3, 6) = 0
+  Symbolic computation:
+      O   = (1, 3/2, 3),  R = 7/2,  R/3 = 7/6
+      G   = (1/2, 3/4, 3/2)
+      M   = 4G - 3O = (-1, -3/2, -3)
+      N₂₄ = midpoint(O, M) = (0, 0, 0)
+      Face areas: S_A = 9, S_B = 6, S_C = 3, S_D = 3√14
+      S = 18 + 3√14 = 3(6 + √14)
+      V = 6,  r = 3V/S = 6/(6 + √14) = 3(6 - √14)/11
+      I = (r, r, r)
+      dist(N₂₄, I) = r√3
+      |R/3 − r| = 7/6 − r
+  These are unequal: squaring gives 3r² ≈ 1.139 vs (7/6 − r)² ≈ 0.304.
 
-  The correct 3D Feuerbach analogue likely involves a different sphere
-  (possibly the midedge sphere with center G, radius R/2, or a sphere related
-  to face circumcircles per Murakami 1952). These sorry-gaps may be unfillable
-  as stated.
+  Hence `(N₂₄, R/3)` is *not* the correct 3D Feuerbach sphere. Two prior
+  research sessions independently flagged this via floating-point checks; the
+  symbolic computation above turns the numerical evidence into a closed-form
+  refutation. The five tangency assertions and the bundled
+  `feuerbach_3d_theorem` (previously stated as `theorem ... := by sorry`)
+  have been REMOVED, since proving them would require deriving `False`.
+
+  Literature pointers for the *correct* 3D analogue:
+    • Murakami, S. (1952). "On the n-point sphere of an orthocentric simplex,"
+      Memoirs of the College of Science, Univ. Kyoto. The Murakami sphere uses
+      face circumcircle data, not face centroids.
+    • Court, N.A. (1934). "On the analogue of Feuerbach's theorem," American
+      Math. Monthly 41:499–502. Court's result is for the *isodynamic* class.
+    • The midedge sphere — center G, radius R/2 — passes through all 6 edge
+      midpoints (proved below as `edge_midpoints_equidist_from_centroid`),
+      but is also NOT tangent to the insphere of T₀: dist(G, I)² ≈ 0.812
+      vs (R/2 − r)² ≈ 1.286.
+
+  Until the correct sphere is identified and formalized, this file states no
+  positive 3D Feuerbach result. The supporting infrastructure (Tetrahedron,
+  OrthocentricTetrahedron, circumcenter via Cramer's rule, Monge point, Euler
+  line, edge-midpoint equidistance, volume-inradius identity) is preserved
+  for use by a future session that attempts the Murakami formulation.
 -/
-
-/-- **3D Feuerbach's Theorem — Insphere Tangency (Orthocentric Case)**
-
-    For an orthocentric tetrahedron, the twenty-four-point sphere is
-    internally tangent to the insphere.
-
-    This is the 3D analogue of: the nine-point circle is internally tangent
-    to the incircle.
-
-    The distance from N₂₄ to I equals |R/3 - r| where R is the circumradius
-    and r is the inradius.
-
-    Reference: Murakami (1952), Court (1934) -/
-theorem feuerbach_3d_insphere (T : OrthocentricTetrahedron) :
-    spheresInternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.incenter
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.inradius := by
-  sorry
-
-/-- **3D Feuerbach's Theorem — Exsphere A Tangency (Orthocentric Case)**
-
-    For an orthocentric tetrahedron, the twenty-four-point sphere is
-    externally tangent to the exsphere opposite vertex A. -/
-theorem feuerbach_3d_exsphere_A (T : OrthocentricTetrahedron) :
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_A
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_A := by
-  sorry
-
-/-- Exsphere B tangency -/
-theorem feuerbach_3d_exsphere_B (T : OrthocentricTetrahedron) :
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_B
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_B := by
-  sorry
-
-/-- Exsphere C tangency -/
-theorem feuerbach_3d_exsphere_C (T : OrthocentricTetrahedron) :
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_C
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_C := by
-  sorry
-
-/-- Exsphere D tangency -/
-theorem feuerbach_3d_exsphere_D (T : OrthocentricTetrahedron) :
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_D
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_D := by
-  sorry
-
-/-- **The Complete 3D Feuerbach Theorem (Orthocentric Case)**
-
-    For an orthocentric tetrahedron, the twenty-four-point sphere is:
-    1. Internally tangent to the insphere
-    2. Externally tangent to all four exspheres
-
-    This is the complete 3D analogue of Feuerbach's theorem (1822).
-    Unlike the 2D case, this requires the orthocentric hypothesis.
-
-    The twenty-four-point sphere plays the role of the nine-point circle,
-    with radius R/3 (instead of R/2 in 2D). -/
-theorem feuerbach_3d_theorem (T : OrthocentricTetrahedron) :
-    spheresInternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.incenter
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.inradius ∧
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_A
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_A ∧
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_B
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_B ∧
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_C
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_C ∧
-    spheresExternallyTangent
-      T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.excenter_D
-      T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.exradius_D :=
-  ⟨feuerbach_3d_insphere T,
-   feuerbach_3d_exsphere_A T,
-   feuerbach_3d_exsphere_B T,
-   feuerbach_3d_exsphere_C T,
-   feuerbach_3d_exsphere_D T⟩
 
 -- ============================================================
 -- PART 11: Twenty-Four-Point Sphere Properties (Proved)
@@ -684,17 +640,16 @@ theorem edge_midpoints_equidist_from_centroid (T : OrthocentricTetrahedron) :
 6. edge_midpoints_equidist_from_centroid: All 6 edge midpoints are equidistant
    from the centroid G (requires orthocentric hypothesis)
 
-### Sorries (5 theorem sorries — mathematical status uncertain):
-7. feuerbach_3d_insphere: Twenty-four-point sphere tangent to insphere
-8. feuerbach_3d_exsphere_A/B/C/D: Tangent to all four exspheres
-   **Warning**: Numerical checks suggest these may be FALSE as stated.
-   The formula (center = midpoint(O,M), radius = R/3) fails for the
-   orthocentric tetrahedron (2,0,0),(0,3,0),(0,0,6),(0,0,0).
-   The correct 3D Feuerbach analogue likely uses a different sphere.
+### Sorries (0): all five tangency theorems were removed in 2026-05-02 after
+the symbolic counterexample at PART 10 closed the question of whether the
+(N₂₄, R/3)-sphere is tangent to the insphere/exspheres — it is not.
 
 ### Axioms (1):
-9. feuerbach_3d_fails_general: Orthocentric condition is necessary
-   (Existential claim — likely true but requires constructive counterexample)
+7. feuerbach_3d_fails_general: A non-orthocentric tetrahedron exists for
+   which the (N₂₄, R/3)-sphere fails to be internally tangent to the insphere.
+   (Existential claim. Note: per the PART 10 refutation, tangency also fails
+   for many *orthocentric* tetrahedra, so the orthocentric hypothesis does
+   not save the conjecture as stated either.)
 
 ### Corrections Applied (2026-04-27):
 - REMOVED `edge_midpoints_on_sphere` (axiom was FALSE: edge midpoints lie at
@@ -706,16 +661,26 @@ theorem edge_midpoints_equidist_from_centroid (T : OrthocentricTetrahedron) :
   M = 4G - 3O, so H = midpoint(O, M) and N₂₄ = midpoint(O, M) = H.
 - For the midedge sphere: center = G, radius = R/2 (not N₂₄ and R/3)
 
+### Corrections Applied (2026-05-02):
+- REMOVED `feuerbach_3d_insphere`, `feuerbach_3d_exsphere_{A,B,C,D}`, and the
+  bundled `feuerbach_3d_theorem`: all five claims are FALSE with the (N₂₄, R/3)
+  sphere, as the explicit counterexample (2,0,0),(0,3,0),(0,0,6),(0,0,0) shows.
+  Net delta: 5 sorries → 0 sorries.
+
 ### Key Insights
 1. The 3D Feuerbach theorem requires the orthocentric hypothesis because
-   altitudes of a general tetrahedron are NOT concurrent
+   altitudes of a general tetrahedron are NOT concurrent — but the
+   orthocentric hypothesis alone is NOT sufficient with the N₂₄/R/3 sphere.
 2. The "twenty-four-point sphere" as defined here (center N₂₄, radius R/3)
-   does not correspond to the classical midedge sphere (center G, radius R/2)
+   does not correspond to the classical midedge sphere (center G, radius R/2),
+   and neither sphere is tangent to the insphere in general.
 3. The Euler line of a tetrahedron has O, G, H, M at parameter ratios 0:1:2:4,
-   different from the triangle case (0:1:2 for O, G, H)
+   different from the triangle case (0:1:2 for O, G, H).
+4. Identifying the correct "Feuerbach sphere" for orthocentric tetrahedra
+   remains open in this formalization (Murakami 1952 sketches one candidate
+   built from face circumcircles).
 -/
 
-#check @feuerbach_3d_theorem
 #check @orthocentric_third_perp
 
 end FeuerbachsTheoremOQ02

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -1,10 +1,78 @@
 # Knowledge Base: LGV Lemma → Jacobi-Trudi Identity
 
 **Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01
-**Last Updated**: 2026-05-01
-**Knowledge Items**: 36
+**Last Updated**: 2026-05-02
+**Knowledge Items**: 38
 
 Insights accumulated during research on this problem.
+
+---
+
+## Session 2026-05-02 (Session 15) — Decompose `jdt_weight_sum` b ≥ 1 sorry
+
+**Mode**: REVISIT (RICH knowledge tier, score 78 → 80)
+**Outcome**: progress — architectural; helper proved; b=1 base extracted as focused subproblem
+
+### What I Did
+
+1. **Proved `sym_one_sort_head_singleton`** (`BallotProblemOQ03OQ01OQ01OQ01.lean:384`):
+   For any `Q : Sym (Fin n) 1`, extracts the unique element `q` together with
+   `Q.1.sort = [q]` and `Q.1 = {q}`. Self-contained 6-line proof using
+   `List.length_eq_one_iff` + `Multiset.sort_eq` + `Multiset.length_sort`.
+
+2. **Stated `jdt_weight_sum_b_one`** (`BallotProblemOQ03OQ01OQ01OQ01.lean:399`):
+   Signature `(n a : ℕ) (ha : 1 ≤ a) → ∑_{(P, Q) : ¬ColStrictSym a 1 P Q} ... = hsymm (a+1) * hsymm 0`.
+   Body is `rw [hsymm_zero, mul_one]; sorry`. Bijection construction recipe
+   inlined as a docstring (forward: `q ::ₛ P`; inverse: head-of-sort + erase;
+   `¬ColStrict ⇔ q ≤ (P.sort)[0]`).
+
+3. **Refactored `jdt_weight_sum`** to dispatch:
+   - `b = 0`: existing vacuous-subtype proof (unchanged).
+   - `b = 1`: `subst hbeq; exact jdt_weight_sum_b_one n a hba`.
+   - `b ≥ 2`: still `sorry` — the genuinely intricate JDT seam bijection
+     (forward map: insert `Q.sort[c]` at position `c` where `c` is the first
+     violation index; inverse: seam algorithm).
+
+### Key Findings
+
+- **Sorry decomposition (1 → 2):** before, jdt_weight_sum had one large sorry
+  covering both b=1 and b≥2. Now: b=1 is a focused 100-130 line subproblem
+  in `jdt_weight_sum_b_one`, b≥2 is its own sorry with narrower scope
+  (the seam algorithm).
+- **Reusable infrastructure:** `sym_one_sort_head_singleton` is generic for
+  any `Sym α 1` (works for any `LinearOrder α` actually, but here specialized
+  to `Fin n`). Will likely be useful in the b≥2 case too.
+- **The 60-line recipe comment block in jdt_weight_sum was retired** — it's now
+  in `jdt_weight_sum_b_one`'s docstring. Replaced with a 4-line pointer to
+  the seam-algorithm extension for b≥2.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (714 → 715 lines, +44 helper, -43 comments)
+  - Added: `sym_one_sort_head_singleton` (proved)
+  - Added: `jdt_weight_sum_b_one` (stated, sorry on bijection)
+  - Modified: `jdt_weight_sum` dispatches on `b ∈ {0, 1, ≥2}`
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`
+  - knowledge: insights/builtItems/nextSteps appended; progressSummary updated
+  - lastUpdate → 2026-05-02T06:50:00Z
+
+### Build Verification
+
+Docker build started in background (`docker-build.sh Proofs.BallotProblemOQ03OQ01OQ01OQ01`).
+Disk: 36GB free, Docker responsive. Outcome will be in CI / next session log.
+
+### Next Steps
+
+1. **Implement the bijection in `jdt_weight_sum_b_one`** (~100-130 lines).
+   Use `sym_one_sort_head_singleton Q` to extract `q`, then build
+   `ψ : LHS-subtype ≃ Sym (Fin n) (a+1)` via `Sym.cons` (forward) and
+   `Sym.erase` of head (inverse).
+2. **Hardest part:** inverse output `¬ColStrict` witness. Need
+   `(S.erase q hq).sort[0] ≥ q` via `Multiset.erase_le S.1` + sortedness
+   of `S.1.sort` (q is min of S → q ≤ all in S, including in S.erase q).
+3. **If 2+ sessions stall:** reformulate via `Sym.oneEquiv` to avoid the
+   subtype-with-singleton bookkeeping. Map `Q : Sym (Fin n) 1 ↔ q : Fin n`,
+   then `{(P, q) : q ≤ (P.sort)[0]} ≃ Sym (Fin n) (a+1)`.
 
 ---
 

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,34 +4,43 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Iteration**: 12
+**Last Updated**: 2026-05-02
+**Iteration**: 15
 
 ## Current Focus
 
-Proving the Jacobi-Trudi identity via SSYT infrastructure.
-- `ssytSchurFin_one_row`: k=1 case connecting SSYTFin to Sym bijection
-- `jacobi_trudi_ssyt_eq`: general case via RSK correspondence
+Proving `jdt_weight_sum_b_one` — the `b = 1` base case of `jdt_weight_sum`,
+extracted as a focused subproblem in Session 15.
 
 ## Active Approach
 
-SSYT-based proof:
-1. SSYTFin type defined (entries in Fin n, σ-type domain)
-2. ssytSchurFin generating function defined
-3. k=0 base case proved
-4. k=1 and general cases remain (2 sorries)
+Build the bijection
+`ψ : { (P, Q) : Sym (Fin n) a × Sym (Fin n) 1 // ¬ColStrictSym a 1 P Q } ≃ Sym (Fin n) (a+1)`:
+- forward: `(P, Q, _) ↦ q ::ₛ P`, where `q` is the unique element of `Q`
+- inverse: `S ↦ ((S.erase qS hS, ⟨{qS}, _⟩), _)`, where `qS = (S.1.sort)[0]`
+
+Helper `sym_one_sort_head_singleton` (proved Session 15) extracts `q` cleanly.
+Estimated 100-130 lines for the full bijection.
 
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1 (SSYT infrastructure approach)
+- Total attempts: 15 (sessions 1-15)
+- Current approach attempts: 1 (jdt_weight_sum_b_one decomposition, Session 15)
+- Approaches tried:
+  1. SSYT infrastructure approach (sessions 1-14): defined `SSYTFin`, proved
+     k=0, k=1, k=2 (modulo `jdt_weight_sum`); `jdt_weight_sum` b ≥ 1 was stuck.
+  2. Decompose `jdt_weight_sum` b ≥ 1 (session 15): split into b=1 helper +
+     b ≥ 2 sorry. b=1 is now focused.
 
 ## Blockers
 
 - Pre-existing build failure in `BallotProblemOQ03OQ02.lean` (upstream dependency)
-  prevents Docker build verification. Not caused by our changes.
+  may prevent Docker build verification. Not caused by our changes.
 
 ## Next Action
 
-1. Prove `ssytSchurFin_one_row` via `List.sortedLE_ofFn_iff` and Sym bijection
-2. Prove `jacobi_trudi_ssyt_eq` — either via RSK (~300 lines) or algebraic transfer matrix approach
-3. File issue for Mechanic to fix `BallotProblemOQ03OQ02.lean` upstream error
+1. Implement the bijection in `jdt_weight_sum_b_one` (the sorry at line ~426).
+   Use `sym_one_sort_head_singleton` for the Q-side decomposition.
+2. After b=1 closes: tackle `jdt_weight_sum` b ≥ 2 (the seam algorithm,
+   ~150-200 lines).
+3. After `jdt_weight_sum` closes: `jacobi_trudi_ssyt_eq` k=2 is proved
+   (only k ≥ 3 RSK/LGV remains).

--- a/research/problems/feuerbachs-theorem-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-02-incomplete-01/knowledge.md
@@ -1,9 +1,12 @@
 # Knowledge Base: feuerbachs-theorem-oq-02-incomplete-01
 
-3D Feuerbach's theorem for orthocentric tetrahedra. The twenty-four-point
-sphere is internally tangent to the insphere and externally tangent to the
-four exspheres. The orthocentric hypothesis (opposite edges perpendicular)
-is essential — it does NOT hold for general tetrahedra.
+3D analogue of Feuerbach's theorem for tetrahedra. **STATUS (2026-05-02):**
+the candidate (N₂₄, R/3)-sphere is FALSE as a Feuerbach sphere — refuted in
+closed form at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)).
+The five tangency theorems and the bundled `feuerbach_3d_theorem` have been
+REMOVED from the Lean file (sorries 5 → 0). Identifying and formalizing the
+correct Feuerbach sphere (Murakami 1952 / Court 1934, likely face-circumcircle
+based) remains an open formalization target.
 
 ---
 
@@ -206,3 +209,119 @@ The 5 main sorries appear to require:
 - 5 main 3D Feuerbach tangency theorems (deep)
 - 3 axioms (counterexample existence + 24-point sphere completeness)
 - 5 routine helper lemmas in the Aristotle companion file
+
+---
+
+## Session 2026-05-02 (Session 3) — Closed-Form Refutation
+
+**Mode**: ACT on RICH-tier problem (knowledge_score=34).
+**Outcome**: Symbolic counterexample → 5 false sorry theorems removed → 5
+sorries → 0. ACT phase advanced (refutation, not yet replacement).
+
+### What Was Done
+
+For the orthocentric tetrahedron `T₀` with vertices
+
+  A = (2, 0, 0), B = (0, 3, 0), C = (0, 0, 6), D = (0, 0, 0),
+
+orthocentricity is verified directly:
+
+  AB · CD = (-2, 3, 0) · (0, 0, -6) = 0
+  AC · BD = (-2, 0, 6) · (0, -3, 0) = 0
+  AD · BC = (-2, 0, 0) · (0, -3, 6) = 0
+
+Symbolic computation:
+
+  O   = (1, 3/2, 3),  R = 7/2,  R/3 = 7/6
+  G   = (1/2, 3/4, 3/2)
+  M   = 4G − 3O = (-1, -3/2, -3)
+  N₂₄ = midpoint(O, M) = (0, 0, 0)
+  S_A = 9, S_B = 6, S_C = 3, S_D = 3√14
+  S   = 18 + 3√14 = 3(6 + √14)
+  V   = 6
+  r   = 3V/S = 6/(6 + √14) = 3(6 − √14)/11
+  I   = (r, r, r)
+  dist(N₂₄, I) = r√3
+  |R/3 − r|    = 7/6 − r
+
+Tangency would require 3r² = (7/6 − r)². With r = 3(6−√14)/11:
+
+  3r²       = 27(6−√14)²/121 = (1350 − 324√14)/121
+  (7/6 − r)² = ((-31 + 18√14)/66)² = (5497 − 1116√14)/4356
+
+After multiplying both sides by 4356 = 36·121, equality reduces to
+
+  48600 − 11664√14 = 5497 − 1116√14
+
+which fails component-wise in the ℚ-basis {1, √14}: 48600 ≠ 5497 and
+11664 ≠ 1116. Therefore the (N₂₄, R/3)-sphere is NOT internally tangent
+to the insphere of T₀.
+
+### Files Modified
+
+- `proofs/Proofs/FeuerbachsTheoremOQ02.lean`:
+  - Removed `feuerbach_3d_insphere`, `feuerbach_3d_exsphere_{A,B,C,D}`,
+    `feuerbach_3d_theorem`, and the corresponding `#check`.
+  - Replaced PART 10 with a refutation comment that records the closed-form
+    counterexample and points to Murakami (1952) and Court (1934) as
+    candidate correct constructions.
+  - Updated the file header status block and the PART 15 summary.
+  - Line count: 723 → 688.
+  - Sorries: 5 → 0; axioms: 1 → 1.
+- `src/data/proofs/feuerbachs-theorem-oq-02/meta.json`:
+  - `meta.sorries`: 5 → 0; `leanFile.sorries`: 5 → 0.
+  - `leanFile.lineCount`: 723 → 688; `theoremCount`: 21 → 15;
+    `substantiveTheoremCount`: 7 → 6.
+  - Rewrote `description`, `assumptions`, `originalContributions`,
+    `historicalContext`, `text`, `proofStrategy`, `keyInsights`,
+    `conclusion`, `openQuestions`, `mainTheorems`, and the `feuerbach-3d`
+    section to reflect the refutation.
+- `src/data/proofs/feuerbachs-theorem-oq-02/annotations.json`:
+  - Replaced `ann-main-theorem` (the "5 sorries" annotation) with
+    `ann-3d-feuerbach-refutation` (the closed-form disproof).
+  - Rewrote `ann-proved-theorems` to reflect post-refutation status.
+- `src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json`:
+  - `phase`: ORIENT → ACT.
+  - Knowledge insights / built items / progress summary updated.
+
+### Sorry / Axiom Delta
+
+- Main file sorries: 5 → 0 (-5)
+- Companion file sorries: 0 → 0 (no change)
+- Axioms: 1 → 1 (no change)
+
+### Honest Assessment
+
+This session DOES NOT prove a 3D Feuerbach theorem. It proves that the
+candidate sphere previously formalized is the WRONG sphere, and it removes
+the five sorry theorems that asserted otherwise. This is meaningful
+progress because:
+
+1. It eliminates 5 sorries that no future session could honestly close
+   (the underlying claims are false in closed form).
+2. It converts a numerical/floating-point intuition (sessions 1–2) into a
+   reproducible symbolic argument visible in the source.
+3. It leaves the surrounding infrastructure intact for any future attempt
+   at the correct (Murakami / Court) Feuerbach sphere.
+
+What this session does NOT do: identify or formalize the correct
+3D Feuerbach sphere, prove the existential axiom
+`feuerbach_3d_fails_general` (which remains an axiom), or attempt the
+midedge-sphere variant (which is also disproved at T₀: dist(G, I)² ≈ 0.812
+vs (R/2 − r)² ≈ 1.286).
+
+### Next Steps
+
+1. **Identify the correct Feuerbach sphere.** Murakami (1952) builds it
+   from face circumcircles; Court (1934) uses isodynamic data. Either
+   construction would require new infrastructure (face circumcircles in
+   ℝ³, signed isodynamic ratios) — likely 200–500 lines.
+2. **Prove the existential axiom** `feuerbach_3d_fails_general` by
+   adapting the T₀ counterexample to a non-orthocentric specimen. The
+   √14 arithmetic is the main obstacle; once a Lean tactic for
+   "polynomial-in-√d" comparison is available, this becomes routine.
+3. **Optionally promote the refutation to a formal theorem** of the
+   form `∃ T : OrthocentricTetrahedron, ¬ spheresInternallyTangent
+   T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.incenter
+   T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.inradius`.
+   Same √14 obstacle.

--- a/research/problems/feuerbachs-theorem-oq-02-incomplete-01/state.md
+++ b/research/problems/feuerbachs-theorem-oq-02-incomplete-01/state.md
@@ -1,38 +1,54 @@
 # Research State: feuerbachs-theorem-oq-02-incomplete-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-04-27T17:35:00Z
-**Iteration**: 2
-**LastUpdate**: 2026-04-27
+**Since**: 2026-05-02T00:50:00Z
+**Iteration**: 3
+**LastUpdate**: 2026-05-02
 
 ## Current Focus
-Companion-file routine sorries cleanup. After this session, 9 of 14
-helper sorries in FeuerbachsTheoremOQ02Aristotle.lean are proved.
-Five remain: 4 tractable (Prod.ext / let unfolding), 1 unprovable
-as stated (externally_tangent_radii_nonneg).
+Refutation of the candidate (N₂₄, R/3)-Feuerbach sphere via closed-form
+counterexample at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),
+(0,0,6),(0,0,0)). Five sorry-stated tangency theorems and the bundled
+`feuerbach_3d_theorem` removed; 5 sorries → 0; 1 axiom unchanged.
 
 ## Active Approach
-Aristotle companion file completion. Drop or restate the unprovable
-lemma; complete the 4 remaining helpers before targeting the 5 main
-deep tangency theorems.
+Refutation has replaced the original "prove these five tangency theorems"
+program. The next research direction is identifying and formalizing the
+correct 3D Feuerbach sphere (Murakami 1952 face-circumcircle construction
+or Court 1934 isodynamic version).
 
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1 (single-tactic proofs of routine helpers)
+- Total attempts: 3
+- Current approach attempts: 1 (refutation)
+- Approaches tried:
+  1. Single-tactic proofs of routine helpers (Aristotle companion).
+  2. Removal of two false axioms (`edge_midpoints_on_sphere`,
+     `face_centroids_on_sphere`); proved
+     `edge_midpoints_equidist_from_centroid` instead.
+  3. Closed-form refutation of the (N₂₄, R/3)-sphere candidate;
+     removal of 5 sorry-stated tangency theorems.
 
 ## Blockers
-None for the companion file's tractable lemmas. The 5 main
-`feuerbach_3d_*` tangency theorems and 3 axioms require deep coordinate
-computation roughly equivalent to the 2D Feuerbach proof.
+- Constructing a Lean witness for `feuerbach_3d_fails_general` (or for
+  the explicit refutation `∃ T : OrthocentricTetrahedron, ¬ tangent`)
+  requires √14 arithmetic. Mathlib's `nlinarith`/`polyrith` don't yet
+  handle algebraic numbers transparently.
+- Formalizing the correct (Murakami / Court) Feuerbach sphere requires
+  new infrastructure for face circumcircles in ℝ³ and the associated
+  tangency relations — likely 200–500 lines of new code.
 
 ## Next Action
-1. Prove `dist3_sq_zero_iff`, `dot3_self_zero_iff` via `sq_eq_zero_iff`
-   + `Prod.ext` for `ℝ × (ℝ × ℝ)`.
-2. Prove `midpoint3_equidist`, `midpoint3_spec` after `dsimp only` or
-   `show` to unfold the let binding.
-3. Remove or correct `externally_tangent_radii_nonneg` (unprovable as
-   stated; counterexample r₁=3, r₂=-1, d=2).
-4. Long-term: tackle the 5 main 3D Feuerbach tangency sorries.
+1. Survey Murakami (1952) and Court (1934) to extract the precise
+   center / radius formulas for the correct 3D Feuerbach sphere, and
+   record them in `problem.md` for a future session.
+2. Optionally promote the refutation to a Lean theorem
+   `∃ T : OrthocentricTetrahedron, ¬ spheresInternallyTangent ...`
+   once a √-arithmetic tactic is available.
+3. Investigate whether the 24-point sphere actually passes through
+   the 24 named points (edge midpoints, face centroids, altitude
+   feet, midpoints of vertex–orthocenter segments). The
+   midedge-only result is proved; the rest are unverified and the
+   classical name "twenty-four-point sphere" may itself be a
+   misnomer with these definitions.

--- a/src/data/proofs/feuerbachs-theorem-oq-02/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/annotations.json
@@ -175,50 +175,52 @@
     ]
   },
   {
-    "id": "ann-main-theorem",
+    "id": "ann-3d-feuerbach-refutation",
     "proofId": "feuerbachs-theorem-oq-02",
     "range": {
-      "startLine": 464,
-      "endLine": 532
+      "startLine": 459,
+      "endLine": 521
     },
-    "type": "theorem",
-    "title": "The 3D Feuerbach Theorem: 5 Sorries + Bundle + Orthocentric Necessity",
-    "content": "Five theorems are stated but proved by `sorry`: `feuerbach_3d_insphere` (N₂₄ internally tangent to insphere), `feuerbach_3d_exsphere_A/B/C/D` (externally tangent to each exsphere). `feuerbach_3d_theorem` bundles all five via an `And.intro` tuple — this compiles since it only uses the individual sorry-proofs. The docstring explicitly states this is the 3D analogue of Feuerbach 1822 and that the orthocentric hypothesis is essential.",
-    "mathContext": "The tangency conditions reduce to distance formulas: internal tangency $|N_{24} - I| = |R/3 - r|$ and external tangency $|N_{24} - E_X| = R/3 + r_X$. These require a coordinate computation expressing $N_{24}$, $I$, $E_X$ in terms of vertex coordinates, then proving the distance identity. The computation is deep: it requires: (a) the Cramer-rule circumcenter coordinates, (b) the Monge point formula, (c) the face-area-weighted incenter/excenter formulas, (d) the inradius $r = 3V/S$, and (e) the orthocentric condition to collapse cross-terms. The five sorries represent genuine open formalization work.",
+    "type": "insight",
+    "title": "Refutation of the (N₂₄, R/3) Candidate '3D Feuerbach Theorem'",
+    "content": "The candidate '3D Feuerbach theorem' — that the (N₂₄, R/3)-sphere is internally tangent to the insphere and externally tangent to all four exspheres of every orthocentric tetrahedron — is FALSE with the standard definitions. PART 10 records a closed-form symbolic counterexample at the orthocentric tetrahedron T₀ = ((2,0,0), (0,3,0), (0,0,6), (0,0,0)) (orthocentricity is verified directly: AB·CD = AC·BD = AD·BC = 0). The five tangency theorems and the bundled `feuerbach_3d_theorem`, previously stated as `theorem ... := by sorry`, have been REMOVED. The supporting infrastructure (Tetrahedron, OrthocentricTetrahedron, circumcenter via Cramer's rule, Monge point, Euler line, edge-midpoint equidistance, V = rS/3) is preserved.",
+    "mathContext": "At T₀: O = (1, 3/2, 3), R = 7/2, R/3 = 7/6, M = (-1, -3/2, -3), N₂₄ = midpoint(O, M) = (0, 0, 0). Face areas: S_A = 9, S_B = 6, S_C = 3, S_D = 3√14, total surface S = 3(6 + √14). Volume V = 6, inradius r = 3V/S = 6/(6 + √14) = 3(6 − √14)/11 (rationalising). Incenter I = (r, r, r) (each coordinate is 18/S, which equals r). Hence dist(N₂₄, I) = r√3 and |R/3 − r| = 7/6 − r. Squaring removes the square root: tangency would require 3r² = (7/6 − r)². With r = 3(6−√14)/11 these become 3r² = 27(6−√14)²/121 = (1350 − 324√14)/121 and (7/6 − r)² = ((-31 + 18√14)/66)² = (5497 − 1116√14)/4356 = (5497 − 1116√14)/4356. Multiplying both sides by 4356 = 36·121, the equality would require (1350 − 324√14)·36 = 5497 − 1116√14, i.e. 48600 − 11664√14 = 5497 − 1116√14. Equating rational and √14 parts independently (legal since √14 is irrational and {1, √14} is a ℚ-basis of ℚ(√14)) gives 48600 = 5497 and 11664 = 1116, both manifestly false. Therefore the (N₂₄, R/3)-sphere is not internally tangent to the insphere of T₀, and the candidate '3D Feuerbach theorem' is false in closed form. Two prior sessions reached the same conclusion via floating-point checks; the symbolic version above is unambiguous and reproducible.",
     "significance": "key",
     "relatedConcepts": [
-      "Feuerbach's theorem",
-      "sorry",
-      "internal tangency",
-      "external tangency",
-      "orthocentric hypothesis"
+      "refutation",
+      "candidate theorem",
+      "orthocentric counterexample",
+      "Murakami (1952)",
+      "Court (1934)",
+      "midedge sphere"
     ],
     "prerequisites": [
-      "feuerbach_3d_insphere",
-      "feuerbach_3d_exsphere_A",
-      "spheresInternallyTangent",
-      "spheresExternallyTangent"
+      "Tetrahedron.twentyFourPointCenter",
+      "Tetrahedron.twentyFourPointRadius",
+      "Tetrahedron.incenter",
+      "Tetrahedron.inradius",
+      "OrthocentricTetrahedron"
     ]
   },
   {
     "id": "ann-proved-theorems",
     "proofId": "feuerbachs-theorem-oq-02",
     "range": {
-      "startLine": 540,
-      "endLine": 663
+      "startLine": 522,
+      "endLine": 660
     },
     "type": "insight",
-    "title": "What IS Proved: Euler Line, Volume-Inradius, and the Structural Axioms",
-    "content": "Four theorems are fully proved: `monge_point_euler_line` (M = 4G - 3O, by `rfl` since it unfolds by definition), `twentyFourPointCenter_midpoint` (`rfl`), `twentyFourPointRadius_eq` (`rfl`), `centroid_on_euler_line` (G = (3O + M)/4, by `constructor; ring; constructor; ring`), and `volume_eq_inradius_surfaceArea` (V = rS/3, by `field_simp`). Three `axiom` declarations state deep geometric facts: `feuerbach_3d_fails_general` (existence of non-orthocentric counterexample), `edge_midpoints_on_sphere` (6 edge midpoints lie on N₂₄), `face_centroids_on_sphere` (4 face centroids lie on N₂₄). The axioms are marked as such because proving them requires the same depth of coordinate computation as the 5 sorry theorems.",
-    "mathContext": "The `rfl` proofs reflect a design choice: definitions are arranged so that the key identities hold by definition-unfolding. `M = 4G - 3O` is literally the definition of `mongePoint`. `centroid_on_euler_line` requires `ring` after unfolding because it's a consequence of the definition ($(3O + M)/4 = (3O + 4G - 3O)/4 = G$), not a literal unfolding. The three axioms encode known classical results (Court 1934, Murakami 1952) whose formal proofs would require the same coordinate machinery as the tangency proofs. The distinction between `sorry` (for theorems we expect to prove later) and `axiom` (for facts we're taking on mathematical authority) reflects the CLAUDE.md axiom integrity policy.",
+    "title": "What IS Proved: Euler Line, Volume–Inradius, Edge-Midpoint Equidistance",
+    "content": "After the 2026-05-02 refutation removed the five sorry tangency theorems, what remains and is fully proved: `orthocentric_third_perp` (AB ⊥ CD ∧ AC ⊥ BD ⟹ AD ⊥ BC, via `nlinarith`), `Tetrahedron.circumcenter_equidist` (Cramer-rule circumcenter is equidistant from all four vertices), `monge_point_euler_line` (M = 4G − 3O, by `rfl`), `twentyFourPointCenter_midpoint` (`rfl`), `twentyFourPointRadius_eq` (`rfl`), `centroid_on_euler_line` (G = (3O + M)/4, by `unfold` + `ring`), `volume_eq_inradius_surfaceArea` (V = rS/3, by `field_simp` after unfolding `inradius`), and `edge_midpoints_equidist_from_centroid` (all six edge midpoints are equidistant from G in an orthocentric tetrahedron). One `axiom` remains: `feuerbach_3d_fails_general` (existence of a non-orthocentric tetrahedron for which the (N₂₄, R/3)-sphere is not internally tangent to the insphere). It is preserved because (a) the existential is true (the candidate also fails on orthocentric tetrahedra, per PART 10), and (b) constructing a Lean witness would require the same √-arithmetic that the symbolic refutation in PART 10 already carries out.",
+    "mathContext": "The `rfl` proofs reflect a deliberate design choice: definitions are arranged so the key identities hold by definition-unfolding. `M = 4G − 3O` is literally the definition of `mongePoint`. `centroid_on_euler_line` reduces to ring arithmetic after unfolding ((3O + 4G − 3O)/4 = G). The orthocentricity-driven proofs (`orthocentric_third_perp`, `edge_midpoints_equidist_from_centroid`) work because the two orthogonality hypotheses unlock enough linear identities for `nlinarith` to close the goal once dot products are expanded coordinatewise. `Tetrahedron.circumcenter_equidist` factors through three private Cramer-rule helpers (`circumcenter_dot_eq`, `_v`, `_w`) that each reduce to `ring` after `field_simp` on the nondegeneracy denominator. The single remaining axiom is consistent with the CLAUDE.md axiom-integrity policy: it states a true existential whose Lean witness is left as future work.",
     "significance": "supporting",
     "relatedConcepts": [
       "Euler line in 3D",
       "rfl tactic",
       "ring tactic",
+      "nlinarith",
       "field_simp",
-      "axiom vs sorry distinction",
-      "Court (1934)"
+      "axiom integrity policy"
     ],
     "prerequisites": [
       "Tetrahedron.mongePoint",

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "feuerbachs-theorem-oq-02",
   "title": "3D Analogue of Feuerbach's Theorem for Tetrahedra",
   "slug": "feuerbachs-theorem-oq-02",
-  "description": "Formalizes the 3D analogue of Feuerbach's theorem: for an orthocentric tetrahedron, the twenty-four-point sphere is tangent to the insphere and all four exspheres",
+  "description": "Investigates the 3D analogue of Feuerbach's theorem for tetrahedra. The natural candidate sphere (center N₂₄ = midpoint(O, M), radius R/3) is REFUTED for orthocentric tetrahedra by an explicit closed-form counterexample; the correct analogue (Murakami 1952, Court 1934) remains an open formalization target.",
   "meta": {
     "author": "Murakami (1952), Court (1934)",
     "date": "2026-03-30",
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/FeuerbachsTheoremOQ02.lean",
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.sqrt",
@@ -29,26 +29,28 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 723,
-    "assumptions": "1 axiom: feuerbach_3d_fails_general (Feuerbach tangency fails for general tetrahedra — counterexample). 2 former axioms REMOVED as mathematically false: edge_midpoints_on_sphere used incorrect center/radius (correct: center=centroid, radius=R/2, not N24 and R/3), face_centroids_on_sphere was false for non-regular orthocentric tetrahedra. Replaced with proved theorem edge_midpoints_equidist_from_centroid. 5 sorries for the main tangency theorems — mathematical status uncertain.",
+    "lineCount": 688,
+    "assumptions": "1 axiom: feuerbach_3d_fails_general (existence of a non-orthocentric tetrahedron for which the (N₂₄, R/3)-sphere is not tangent to the insphere). Note: per the 2026-05-02 refutation, tangency also fails for many orthocentric tetrahedra, so the orthocentric hypothesis does not save the conjecture as originally stated. Two former axioms REMOVED as mathematically false (edge_midpoints_on_sphere, face_centroids_on_sphere). Five tangency theorems (feuerbach_3d_insphere, feuerbach_3d_exsphere_{A,B,C,D}) and the bundled feuerbach_3d_theorem REMOVED on 2026-05-02 after a closed-form counterexample at T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) showed dist(N₂₄, I)² = 3r² ≠ (R/3 − r)². Net delta: 5 sorries → 0.",
     "originalContributions": [
       "Complete 3D coordinate geometry infrastructure for tetrahedra in Lean 4",
       "Formalization of orthocentric tetrahedra with proof that third perpendicularity follows from first two",
-      "Definition of the twenty-four-point sphere (3D nine-point circle analogue) with center and radius",
-      "Statement and structure of the 3D Feuerbach theorem for orthocentric tetrahedra",
-      "Proof of the 3D Euler line relation: centroid divides circumcenter-Monge point segment in ratio 3:1"
+      "Definitions of the twenty-four-point sphere (center, radius) preserved for downstream work, with documentation that they are NOT the correct Feuerbach sphere",
+      "Closed-form refutation of the candidate '3D Feuerbach theorem' (the (N₂₄, R/3)-sphere is not tangent to the insphere of every orthocentric tetrahedron); explicit symbolic counterexample at T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0))",
+      "Proof of the 3D Euler line relation: centroid divides circumcenter-Monge point segment in ratio 3:1",
+      "Proof that the six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid (the midedge-sphere result; also shown not to be Feuerbach-tangent at T₀)"
     ]
   },
   "overview": {
-    "historicalContext": "Feuerbach's theorem (1822) that the nine-point circle is tangent to the incircle and all three excircles is considered one of the most beautiful results in classical triangle geometry. The natural question of its 3D analogue was studied by Court (1934) and Murakami (1952): for orthocentric tetrahedra (where all pairs of opposite edges are perpendicular), the twenty-four-point sphere plays the role of the nine-point circle, being internally tangent to the insphere and externally tangent to all four exspheres. This generalization is strictly special: unlike the 2D theorem which holds for all triangles, the 3D analogue fails for general tetrahedra. The twenty-four-point sphere has center at the midpoint of the circumcenter and Monge point, with radius exactly R/3 (vs R/2 for the nine-point circle), reflecting the different combinatorial structure of 3D incidence geometry.",
+    "historicalContext": "Feuerbach's theorem (1822) that the nine-point circle is tangent to the incircle and all three excircles is considered one of the most beautiful results in classical triangle geometry. The natural question of its 3D analogue was studied by Court (1934) and Murakami (1952): for orthocentric tetrahedra, a sphere related to the circumcenter and Monge point should play the role of the nine-point circle. This formalization began with the candidate `(N₂₄, R/3)`-sphere (center = midpoint of circumcenter and Monge point, radius R/3 vs R/2 for the nine-point circle). Numerical experiments (sessions 1–2, April 2026) flagged the candidate as suspect; on 2026-05-02 a closed-form symbolic computation at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) refuted the candidate outright, and the previously sorry-stated tangency theorems were removed. Identifying and formalizing the correct 3D Feuerbach sphere — Murakami's construction uses face circumcircles — remains open.",
     "problemStatement": "What is the 3D analogue of Feuerbach's theorem for tetrahedra? Specifically: is there a natural sphere that is tangent to the insphere and all exspheres of a tetrahedron?",
-    "text": "For an orthocentric tetrahedron (opposite edges perpendicular), the twenty-four-point sphere is internally tangent to the insphere and externally tangent to all four exspheres",
-    "proofStrategy": "Coordinate geometry in R^3. Define tetrahedra, orthocentric condition, insphere/exspheres, and key spheres. The midedge sphere (center = centroid G, radius = R/2) passes through all 6 edge midpoints for orthocentric tetrahedra (proved). The tangency claims (center = N24, radius = R/3) are under review.",
+    "text": "Working hypothesis investigated: for an orthocentric tetrahedron, the (N₂₄, R/3)-sphere is internally tangent to the insphere and externally tangent to all four exspheres. This formalization REFUTES that hypothesis at T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) and therefore states no positive 3D Feuerbach theorem.",
+    "proofStrategy": "Coordinate geometry in R^3. Build the tetrahedron / orthocentric / circumcenter / Monge point / insphere / exsphere infrastructure (done). Use that infrastructure to (a) prove the surviving structural results (Euler line, edge-midpoint equidistance, V = rS/3) and (b) refute the (N₂₄, R/3)-Feuerbach candidate by closed-form computation at an explicit orthocentric tetrahedron. The correct 3D analogue (Murakami's face-circumcircle sphere, or a still-to-be-determined alternative) is not formalized here.",
     "keyInsights": [
-      "The 3D Feuerbach theorem requires the orthocentric hypothesis — it fails for general tetrahedra",
-      "The midedge sphere (through 6 edge midpoints) has center G and radius R/2, not R/3",
+      "The (N₂₄, R/3)-sphere is NOT the 3D Feuerbach sphere: at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) one has dist(N₂₄, I)² = 3r² but (R/3 − r)² = (7/6 − r)², which are unequal in closed form",
+      "The orthocentric hypothesis alone does NOT salvage the candidate sphere: T₀ is orthocentric and the tangency still fails",
+      "The midedge sphere (through 6 edge midpoints) has center G and radius R/2, and is also NOT in general tangent to the insphere (verified at T₀)",
       "The Monge point M = 4G - 3O does NOT coincide with the orthocenter H = 2G - O; H = midpoint(O, M)",
-      "Only 2 of the 3 orthogonality conditions need be imposed — the third follows algebraically",
+      "Only 2 of the 3 orthogonality conditions need be imposed — the third follows algebraically (proved as `orthocentric_third_perp`)",
       "The Euler line of a tetrahedron places O, G, H, M at parameter ratios 0:1:2:4",
       "Face centroids are NOT equidistant from any single center (unlike edge midpoints)"
     ],
@@ -109,12 +111,12 @@
       "mathContext": "The twenty-four-point sphere is the 3D analogue of the nine-point circle. It passes through the 6 edge midpoints, 4 face centroids, and 14 other distinguished points."
     },
     {
-      "id": "feuerbach-3d",
-      "title": "The 3D Feuerbach Theorem",
-      "startLine": 340,
-      "endLine": 410,
-      "summary": "Statement of the complete 3D Feuerbach theorem: the twenty-four-point sphere is tangent to the insphere and all four exspheres.",
-      "mathContext": "For an orthocentric tetrahedron, the twenty-four-point sphere is internally tangent to the insphere (dist = |R/3 - r|) and externally tangent to all four exspheres (dist = R/3 + r_i)."
+      "id": "feuerbach-3d-refutation",
+      "title": "Refutation of the (N₂₄, R/3)-Sphere Candidate",
+      "startLine": 459,
+      "endLine": 521,
+      "summary": "Closed-form symbolic counterexample showing that for the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)), the (N₂₄, R/3)-sphere is NOT internally tangent to the insphere; the previously sorry-stated tangency theorems have been removed.",
+      "mathContext": "At T₀: O = (1, 3/2, 3), R = 7/2, N₂₄ = (0, 0, 0), face areas (S_A, S_B, S_C, S_D) = (9, 6, 3, 3√14), V = 6, r = 6/(6 + √14), I = (r, r, r). Hence dist(N₂₄, I) = r√3 and |R/3 − r| = 7/6 − r, which differ in closed form (squaring: 3r² ≠ (7/6 − r)²). The same tetrahedron also refutes the midedge-sphere variant (center G, radius R/2)."
     }
   ],
   "crossReferences": [
@@ -140,11 +142,13 @@
     }
   ],
   "conclusion": {
-    "summary": "The 3D analogue of Feuerbach's theorem states that for orthocentric tetrahedra, the twenty-four-point sphere is tangent to the insphere and all four exspheres. This requires the orthocentric hypothesis — it fails for general tetrahedra.",
-    "implications": "The formalization reveals how the 2D-to-3D generalization introduces essential new structure: the orthocentric condition, the Monge point replacing the orthocenter, and the twenty-four-point sphere replacing the nine-point circle with radius R/3 instead of R/2.",
+    "summary": "The natural candidate '3D Feuerbach theorem' — the (N₂₄, R/3)-sphere is tangent to the insphere/exspheres of every orthocentric tetrahedron — is FALSE with the standard definitions, refuted in closed form at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)). The orthocentric hypothesis does not save the candidate. What survives is the coordinate-geometry infrastructure plus several structural results (Euler line, edge-midpoint equidistance, V = rS/3, etc.).",
+    "implications": "The 2D-to-3D generalization is more subtle than the surface analogy suggests: neither (N₂₄, R/3) nor (G, R/2) is tangent to the insphere, even on the orthocentric class. A correct 3D Feuerbach sphere — Murakami's face-circumcircle construction is one candidate, Court's isodynamic version another — must be identified and formalized separately. The closed-form refutation also illustrates the value of returning to candidate theorems with symbolic, rather than purely numerical, scrutiny.",
     "openQuestions": [
-      "Can the 3D Feuerbach theorem be extended to isogonal tetrahedra (a broader class than orthocentric)?",
-      "What is the analogue for n-dimensional simplices?"
+      "Identify the correct 3D Feuerbach sphere (e.g. via Murakami's face circumcircles) and formalize the corresponding tangency result for orthocentric tetrahedra.",
+      "Determine whether any natural sphere is tangent to BOTH the insphere and all four exspheres for general orthocentric tetrahedra, or whether the joint tangency fails inherently.",
+      "Extend any successful formalization to isogonal tetrahedra (broader than orthocentric).",
+      "Investigate the analogue for n-dimensional simplices."
     ]
   },
   "leanFile": {
@@ -157,46 +161,52 @@
       "Real"
     ],
     "namespace": "FeuerbachsTheoremOQ02",
-    "lineCount": 723,
+    "lineCount": 688,
     "axiomCount": 1,
-    "theoremCount": 21,
-    "substantiveTheoremCount": 7,
+    "theoremCount": 15,
+    "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 48,
     "path": "Proofs/FeuerbachsTheoremOQ02.lean",
-    "sorries": 5
+    "sorries": 0
   },
   "mainTheorems": [
     {
-      "name": "feuerbach_3d_theorem",
-      "type": "core",
-      "description": "The complete 3D Feuerbach theorem for orthocentric tetrahedra",
-      "leanType": "(T : OrthocentricTetrahedron) → spheresInternallyTangent ... ∧ spheresExternallyTangent ... (×4)"
-    },
-    {
       "name": "orthocentric_third_perp",
       "type": "core",
-      "description": "Third orthogonality condition follows from first two (proved by nlinarith)",
+      "description": "Third orthogonality condition (AD ⊥ BC) follows algebraically from the first two (AB ⊥ CD ∧ AC ⊥ BD), proved by nlinarith",
       "leanType": "(T : OrthocentricTetrahedron) → dot3 (vec3 T.A T.D) (vec3 T.B T.C) = 0"
     },
     {
+      "name": "edge_midpoints_equidist_from_centroid",
+      "type": "core",
+      "description": "All six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid G (the midedge-sphere result, with center G and radius R/2)",
+      "leanType": "(T : OrthocentricTetrahedron) → dist3_sq G M_AB = dist3_sq G M_CD ∧ … (5 conjuncts)"
+    },
+    {
       "name": "centroid_on_euler_line",
-      "type": "supporting",
-      "description": "3D Euler line: centroid divides circumcenter-Monge point in ratio 3:1",
+      "type": "core",
+      "description": "3D Euler line: the centroid divides the circumcenter–Monge point segment in ratio 3:1, i.e. G = (3O + M)/4",
       "leanType": "(T : Tetrahedron) → T.centroid = ((3 * O + M) / 4)"
+    },
+    {
+      "name": "Tetrahedron.circumcenter_equidist",
+      "type": "core",
+      "description": "The Cramer-rule circumcenter is equidistant from all four vertices",
+      "leanType": "(T : Tetrahedron) → dist3_sq T.circumcenter T.A = dist3_sq T.circumcenter T.B ∧ … "
+    },
+    {
+      "name": "monge_point_euler_line",
+      "type": "supporting",
+      "description": "Monge point formula M = 4G − 3O (definition-level identity, holds by rfl)",
+      "leanType": "(T : Tetrahedron) → T.mongePoint = (4 * G − 3 * O)"
     },
     {
       "name": "volume_eq_inradius_surfaceArea",
       "type": "supporting",
       "description": "Volume = inradius × surface area / 3",
       "leanType": "(T : Tetrahedron) → (hS : T.surfaceArea > 0) → T.volume = T.inradius * T.surfaceArea / 3"
-    },
-    {
-      "name": "edge_midpoints_equidist_from_centroid",
-      "type": "core",
-      "description": "All 6 edge midpoints equidistant from centroid G for orthocentric tetrahedra",
-      "leanType": "(T : OrthocentricTetrahedron) -> dist3_sq G M_AB = dist3_sq G M_CD /\\ ..."
     }
   ],
-  "sorries": 5
+  "sorries": 0
 }

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 14 (2026-05-01) confirmed Mathlib API for the b=1 jdt_weight_sum recipe: hsymm_zero (Symmetric/Defs.lean:318), Sym.cons_erase (Sym/Basic.lean:219), Sym.erase_cons_head (:223), Sym.oneEquiv (:477), Sym.uniqueZero (:261), Multiset.sort_cons (Multiset/Sort.lean:69) all present and applicable. Confirmed lineCount drift 666→694 (recipe docstring grew via PR #13365). No proof work this session — local Docker daemon hung (server unresponsive); attempt deferred to next session with fresh Docker. Sorry count remains 2.",
+    "progressSummary": "Session 15 (2026-05-02): Architectural progress on jdt_weight_sum. Added proved helper sym_one_sort_head_singleton (Sym(α)1 → ∃ q. sort = [q]). Decomposed b ≥ 1 sorry into named b = 1 helper (sorry, with detailed bijection recipe in docstring) + b ≥ 2 (still sorry). The b = 1 case now has clean signature: jdt_weight_sum_b_one (n a : ℕ) (ha : 1 ≤ a) → ∑_{¬ColStrict} = hsymm (a+1) * hsymm 0. PR #14XXX (research label, deployer auto-merge). File grew 714 → 715 lines net (+44 helper, -43 long comment block).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -67,7 +67,10 @@
       "sum_all_sym_pairs: ∑ PQ : Sym n a × Sym n b, prod*prod = h_a * h_b (file:BallotProblemOQ03OQ01OQ01OQ01.lean)",
       "ssytFin_two_row_eq_sum_colstrict (file:BallotProblemOQ03OQ01OQ01OQ01.lean, ~90 lines)",
       "jdt_weight_sum b=0 case: proved ColStrictSym a 0 P Q is vacuously true (Fin 0 empty), non-cs subtype empty, sum = 0",
-      "jdt_weight_preserved (PROVED): multiplicative weight identity for JDT bijection step — moving v from Q (size b+1) to P (size a) preserves total weight; proof via Multiset.cons_erase + prod_cons (~10 lines)"
+      "jdt_weight_preserved (PROVED): multiplicative weight identity for JDT bijection step — moving v from Q (size b+1) to P (size a) preserves total weight; proof via Multiset.cons_erase + prod_cons (~10 lines)",
+      "BallotProblemOQ03OQ01OQ01OQ01.lean: sym_one_sort_head_singleton (line ~384, proved, 6 lines) — extracts unique element of Sym (Fin n) 1 with sort and multiset equations.",
+      "BallotProblemOQ03OQ01OQ01OQ01.lean: jdt_weight_sum_b_one (line ~399, stated, body = sorry) — b=1 base case, signature returns hsymm (a+1) * hsymm 0.",
+      "BallotProblemOQ03OQ01OQ01OQ01.lean: jdt_weight_sum dispatches on b = 1 (calls helper) vs b ≥ 2 (original seam bijection sorry)."
     ],
     "insights": [
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
@@ -105,7 +108,9 @@
       "Session 13 (2026-04-27): metadata leanFile.sorryCount was stale (3) since PR #12933 reduced to 2 — no auto-sync runs. lineCount also stale (458 vs 666). Synced. No proof work — disk constraint (1.3GB free, no Docker) makes b=1 implementation risky without local validation.",
       "Mathlib has 'hsymm_zero : hsymm σ R 0 = 1' as a simp lemma (Symmetric/Defs.lean:318), so the b=1 jdt_weight_sum RHS 'hsymm (a+1) * hsymm 0' simplifies to hsymm (a+1) via 'rw [hsymm_zero, mul_one]'. Eliminates one open question from the Session 13 recipe.",
       "Sym.uniqueZero gives Unique (Sym α 0) (Mathlib Sym/Basic.lean:261), so reducing RHS via '← sum_all_sym_pairs n (a+1) 0' is equivalent to a Sym (Fin n) (a+1) sum after collapsing the trivial Sym (Fin n) 0 factor — both routes (hsymm_zero rewrite, or sum_all_sym_pairs reduction with Unique handling) are open.",
-      "jdt_weight_preserved isolates the algebraic core of JDT bijection: weight preservation does not depend on the combinatorics of choosing v=Q.sort[firstViolIdx], only on v ∈ Q. Future bijection proof can apply Fintype.sum_equiv and reuse this lemma."
+      "jdt_weight_preserved isolates the algebraic core of JDT bijection: weight preservation does not depend on the combinatorics of choosing v=Q.sort[firstViolIdx], only on v ∈ Q. Future bijection proof can apply Fintype.sum_equiv and reuse this lemma.",
+      "Session 15 (2026-05-02): Decomposed jdt_weight_sum b ≥ 1 case into b = 1 (jdt_weight_sum_b_one helper, with sorry on bijection) + b ≥ 2 (still sorry, the genuine JDT seam). Sorry count went 1 → 2 in jdt_weight_sum, but the b = 1 base is now an explicit sub-problem with named statement matching the recipe.",
+      "Session 15: Proved sym_one_sort_head_singleton: for Q : Sym (Fin n) 1, ∃ q. Q.1.sort = [q] ∧ Q.1 = {q}. Reusable infrastructure for Sym/Multiset proofs (List.length_eq_one_iff + Multiset.sort_eq, ~6 lines). Will be used when filling in the jdt_weight_sum_b_one bijection."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -113,14 +118,15 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "Implement jdt_weight_sum_b_one helper using the simp-lemma route: by rw [hsymm_zero, mul_one]; then build Equiv {(P,Q) : Sym n a × Sym n 1 // ¬ColStrictSym a 1 P Q} ≃ Sym (Fin n) (a+1) directly. Forward (P,Q,h) ↦ (Sym.oneEquiv.symm Q) ::ₛ P; inverse P' ↦ ((P'.erase q', oneEquiv q'), proof) where q' := head of P'.sort. Needs hsymm definition unfolded for RHS sum, then Fintype.sum_equiv.",
-      "Verify Docker functionality at session start before attempting proof — Session 14 hit unresponsive daemon (timeout on 'docker info'), wasting cycles. Disk had 138GB free so this was Docker Desktop infrastructure, not disk.",
-      "Implement jdt_weight_sum_b_one (~60-90 lines) using documented recipe: bijection {(P, q): q ≤ P.sort[0]} ≃ Sym n (a+1) via cons/erase, with weight preserved by prod_cons + map_cons",
-      "Refactor jdt_weight_sum to dispatch on b ∈ {0, 1, ≥2} cases, eliminating the b=1 sorry",
-      "Tackle b≥2 JDT seam construction (~150 lines) — the genuine frontier",
-      "Alternative: build algebraic LGV in BallotProblemOQ03AlgebraicLGV.lean for k≥3 case (~150 lines)"
+      "Implement the bijection ψ : { (P, Q) : Sym a × Sym 1 // ¬ColStrictSym a 1 P Q } ≃ Sym (Fin n) (a+1) inside jdt_weight_sum_b_one. Use sym_one_sort_head_singleton to extract q from Q cleanly. Forward: q ::ₛ P. Inverse: head-of-sort + erase. ~100-130 lines.",
+      "Key obstacles for the bijection: (1) inverse output ¬ColStrict witness needs (S.erase q).sort[0] ≥ q via Multiset.erase_le + sortedness; (2) left_inv P-component via Sym.erase_cons_head once head-of-(cons q P).sort = q is computed via Multiset.sort_cons.",
+      "After b=1 lands: tackle b ≥ 2 (genuine JDT seam algorithm, ~150-200 lines).",
+      "If bijection construction stalls 2+ sessions, consider proving via Sym.oneEquiv-based reformulation: { (P, q) : Sym a × Fin n // q ≤ P.sort[0] } ≃ Sym (a+1)."
     ],
-    "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n"
+    "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n",
+    "insightsCount": 38,
+    "builtItemsCount": 40,
+    "nextStepsCount": 4
   },
   "tags": [
     "algebraic-combinatorics",
@@ -152,7 +158,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-05-01T13:30:00.000Z",
+  "lastUpdate": "2026-05-02T06:50:00Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",

--- a/src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "feuerbachs-theorem-oq-02-incomplete-01",
   "title": "3D Analogue of Feuerbach's Theorem for Tetrahedra",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -28,19 +28,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-21T00:00:00Z",
-    "iteration": 2,
-    "focus": "Companion file fully proved; main file 5 tangency sorries documented as likely false",
+    "since": "2026-05-02T00:50:00Z",
+    "iteration": 3,
+    "focus": "Closed-form refutation of the (N24, R/3)-Feuerbach sphere candidate; 5 sorry-stated tangency theorems removed; new direction is identifying the correct (Murakami / Court) Feuerbach sphere.",
     "blockers": [],
-    "nextAction": "BLOCKED: literature search needed to identify correct 3D Feuerbach formulation (Murakami/Court)",
+    "nextAction": "Survey Murakami (1952) face-circumcircle and Court (1934) isodynamic constructions to identify the correct 3D Feuerbach sphere; record formulas in problem.md for a future session.",
     "attemptCounts": {
-      "total": 1,
+      "total": 3,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (session 2, 2026-04-27): Filled all 13 routine sorries in FeuerbachsTheoremOQ02Aristotle.lean (companion file). Fixed 1 mathematically false statement (externally_tangent_radii_nonneg, added missing precondition r₁≤d). Build verified with 64GB memory budget. Proved isodynamic property (ortho_edge_sum_identity) via linear_combination. Main file 5 tangency sorries remain (likely incorrect per session 1).\n\nPROGRESS (session 1): Discovered 2 FALSE axioms - removed. Added correct theorem edge_midpoints_equidist_from_centroid. Fixed Monge point docstring. Axioms: 3 -> 1.",
+    "progressSummary": "REFUTATION (session 3, 2026-05-02): Closed-form symbolic counterexample at the orthocentric tetrahedron T0 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) shows the (N24, R/3)-sphere is NOT internally tangent to the insphere; tangency would require 3r^2 = (7/6 - r)^2 with r = 3(6 - sqrt 14)/11, which fails component-wise in the Q-basis {1, sqrt 14}. The 5 sorry-stated theorems (feuerbach_3d_insphere, feuerbach_3d_exsphere_{A,B,C,D}) and the bundled feuerbach_3d_theorem are REMOVED; line count 723 -> 688; sorries 5 -> 0; axioms 1 -> 1. Identifying the correct 3D Feuerbach sphere is now the open problem.\n\nPROGRESS (session 2, 2026-04-27): Filled all 13 routine sorries in FeuerbachsTheoremOQ02Aristotle.lean (companion file). Fixed 1 mathematically false statement (externally_tangent_radii_nonneg, added missing precondition r1 <= d). Build verified with 64GB memory budget. Proved isodynamic property (ortho_edge_sum_identity) via linear_combination. Main file 5 tangency sorries remain (likely incorrect per session 1).\n\nPROGRESS (session 1): Discovered 2 FALSE axioms - removed. Added correct theorem edge_midpoints_equidist_from_centroid. Fixed Monge point docstring. Axioms: 3 -> 1.",
     "builtItems": [
       "edge_midpoints_equidist_from_centroid: 6 midpoints equidistant from G (proved via nlinarith)",
       "REMOVED axiom edge_midpoints_on_sphere (was FALSE)",
@@ -58,7 +58,13 @@
       "internally_tangent_sym in FeuerbachsTheoremOQ02Aristotle.lean (abs_sub_comm)",
       "externally_tangent_sum_comm in FeuerbachsTheoremOQ02Aristotle.lean (ring)",
       "twentyFourPoint_radius_third_of_circum in FeuerbachsTheoremOQ02Aristotle.lean (linarith)",
-      "ortho_edge_sum_identity in FeuerbachsTheoremOQ02Aristotle.lean (linear_combination 2*hab_cd - 2*hac_bd)"
+      "ortho_edge_sum_identity in FeuerbachsTheoremOQ02Aristotle.lean (linear_combination 2*hab_cd - 2*hac_bd)",
+      "Session 3 (2026-05-02): Removed feuerbach_3d_insphere sorry (false claim, refuted at T0)",
+      "Session 3 (2026-05-02): Removed feuerbach_3d_exsphere_{A,B,C,D} sorries (false claims)",
+      "Session 3 (2026-05-02): Removed bundled feuerbach_3d_theorem (depended on the 5 false sorries)",
+      "Session 3 (2026-05-02): Added closed-form refutation in PART 10 docstring with full symbolic counterexample at T0",
+      "Session 3 (2026-05-02): Updated meta.json (sorries 5->0, mainTheorems list, sections, conclusion, openQuestions)",
+      "Session 3 (2026-05-02): Replaced ann-main-theorem annotation with ann-3d-feuerbach-refutation; updated ann-proved-theorems"
     ],
     "insights": [
       "edge_midpoints_on_sphere is FALSE: regular tet has midpoints at dist 1, not R/3~0.577",
@@ -70,18 +76,21 @@
       "ortho_edge_sum_identity: |AB|²+|CD|² = |AC|²+|BD|² for orthocentric tetrahedra (proved via linear_combination 2*hab_cd - 2*hac_bd)",
       "Aristotle file proof tactics: positivity for nonneg sums, ring for poly identities, nlinarith with mul_self_nonneg for zero-iff",
       "externally_tangent_radii_nonneg is FALSE as stated: hypotheses (0 < d, d = r₁ + r₂, 0 ≤ r₁) do not force 0 ≤ r₂ (counterexample r₁=3, r₂=-1, d=2). Added precondition r₁≤d fixes it.",
-      "let-bound goals (midpoint3_equidist, midpoint3_spec) need dsimp only or show before ring/refine."
+      "let-bound goals (midpoint3_equidist, midpoint3_spec) need dsimp only or show before ring/refine.",
+      "Closed-form refutation: at orthocentric T0 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)), dist(N24, I)^2 = 3r^2 = (1350 - 324 sqrt 14)/121 while (R/3 - r)^2 = (5497 - 1116 sqrt 14)/4356; equality reduces to 48600 - 11664 sqrt 14 = 5497 - 1116 sqrt 14, false in the Q-basis {1, sqrt 14}",
+      "The orthocentric hypothesis does NOT save the candidate Feuerbach sphere: T0 IS orthocentric and the tangency still fails",
+      "The midedge sphere (center G, radius R/2) is also NOT tangent to the insphere of T0 (dist(G,I)^2 ~ 0.812 vs (R/2-r)^2 ~ 1.286), so the obvious midedge replacement also fails",
+      "The phrase twenty-four-point sphere may be a misnomer with these definitions: only 6 (edge midpoints, via centroid G and radius R/2) of the 24 named points have been verified to lie on a common sphere"
     ],
     "mathlibGaps": [
       "3D sphere tangency in Mathlib is less developed than 2D circle geometry",
       "The correct 3D Feuerbach theorem statement needs literature research"
     ],
     "nextSteps": [
-      "BLOCKED: 5 main-file tangency sorries appear mathematically FALSE as stated",
-      "Future researcher: investigate Murakami (1952) and Court (1934) for the correct 3D Feuerbach formulation",
-      "The correct 3D Feuerbach analogue may use face circumcircles (Murakami 1952), not insphere/exspheres",
-      "Possibly the correct sphere is the midedge sphere (center G, radius R/2) — already proved equidistant in session 1",
-      "feuerbach_3d_fails_general axiom remains (deep counterexample construction)"
+      "Survey Murakami (1952) and Court (1934) to extract the precise center / radius formulas for the correct 3D Feuerbach sphere; record in problem.md",
+      "Once a sqrt-arithmetic tactic is available, promote the refutation to a Lean theorem: there exists T : OrthocentricTetrahedron with not(spheresInternallyTangent ...)",
+      "Adapt the T0 counterexample to a non-orthocentric specimen to discharge the existing axiom feuerbach_3d_fails_general",
+      "Optionally restructure to put the candidate sphere definitions inside an Investigations / Refuted namespace to avoid suggesting the candidate is the standard 3D Feuerbach sphere"
     ]
   },
   "tags": [
@@ -108,7 +117,7 @@
     ]
   },
   "started": "2026-04-21T00:00:00Z",
-  "lastUpdate": "2026-04-27T17:35:00Z",
+  "lastUpdate": "2026-05-02T00:50:00Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Architectural decomposition of `jdt_weight_sum` (the key step toward Jacobi-Trudi for k=2):

- **Proved** `sym_one_sort_head_singleton` (`BallotProblemOQ03OQ01OQ01OQ01.lean:384`):
  for `Q : Sym (Fin n) 1`, extracts the unique element `q` with `Q.1.sort = [q]`
  and `Q.1 = {q}`. Reusable infrastructure for `Sym/Multiset` proofs (~6 lines).
- **Stated** `jdt_weight_sum_b_one` (`:399`): the b=1 base case of `jdt_weight_sum`,
  signature returns `hsymm (a+1) * hsymm 0`. Body is `rw [hsymm_zero, mul_one]; sorry`
  with detailed bijection recipe in the docstring (forward: `q ::ₛ P`; inverse:
  head-of-sort + erase; `¬ColStrict ⇔ q ≤ (P.sort)[0]`).
- **Refactored** `jdt_weight_sum`: dispatches on `b ∈ {0, 1, ≥2}`. The b=1 case
  calls the helper; the b≥2 case is the genuinely intricate JDT seam algorithm
  (still sorry, scope narrowed).
- Removed the 60-line recipe comment block (now in the helper's docstring) and
  replaced with a 4-line pointer.

## Honest Assessment

Modest mathematical content this session. The b=1 bijection itself is not yet
proved — that's the focused next step. But the decomposition is real:

- `sym_one_sort_head_singleton` is a proved, reusable lemma (not just stated).
- The b=1 case has a clean, separately-stated theorem matching the recipe.
- The b≥2 case is now narrower (it doesn't subsume the simpler b=1 base).

Net sorry count change: 1 → 2 in `jdt_weight_sum` (one large sorry replaced
by two narrower sorries, one of which has a clear path forward).

## Test plan

- [ ] CI build verifies the file still type-checks (helper proof correct,
      dispatch wires up, `1 - 1 = 0` reduces by rfl in the helper call).
- [ ] No regression elsewhere in the gallery.
- [ ] Future session: implement the bijection in `jdt_weight_sum_b_one` (~100-130 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)