### PR TITLE
fix(meta): erdos-259 section line drift

### DIFF
--- a/src/data/proofs/erdos-259/meta.json
+++ b/src/data/proofs/erdos-259/meta.json
@@ -78,30 +78,37 @@
     {
       "id": "moebius",
       "title": "The Möbius Function",
-      "startLine": 30,
-      "endLine": 46,
-      "summary": "Definition of squarefree numbers and the connection to μ(n)²."
+      "startLine": 51,
+      "endLine": 81,
+      "summary": "Möbius function values μ(1)…μ(10) computed via native_decide."
+    },
+    {
+      "id": "squarefree",
+      "title": "Squarefree Numbers",
+      "startLine": 82,
+      "endLine": 106,
+      "summary": "Squarefree definition and the μ(n)² indicator characterization."
     },
     {
       "id": "series",
       "title": "The Series Definition",
-      "startLine": 47,
-      "endLine": 62,
-      "summary": "Definition of the series terms and the full infinite sum, with summability."
+      "startLine": 107,
+      "endLine": 134,
+      "summary": "Series term, partial sums, and the summability axiom."
     },
     {
       "id": "main-theorem",
-      "title": "Main Result",
-      "startLine": 63,
-      "endLine": 82,
-      "summary": "Chen-Ruzsa theorem (axiom) and the main Erdős #259 result."
+      "title": "Chen-Ruzsa Theorem and Main Result",
+      "startLine": 135,
+      "endLine": 169,
+      "summary": "Chen-Ruzsa axiom and erdos_259 (main theorem)."
     },
     {
       "id": "examples",
-      "title": "Examples and Computations",
-      "startLine": 83,
+      "title": "Numerical Approximation and Related Results",
+      "startLine": 170,
       "endLine": 239,
-      "summary": "Verified examples of squarefree (1, 6) and non-squarefree (4) numbers."
+      "summary": "Partial sums, infinite squarefree subsets, density, and related problems."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Correct stale `sections[]` line ranges in `erdos-259/meta.json` to match actual Lean source landmarks.

## Evidence

**Before**: 4 sections with ranges 20–90 lines stale; missing squarefree block entirely.

**After**: 6 sections matching actual file:
- imports: 1–29 (unchanged ✓)
- moebius: 51–81 (was 30–46)
- squarefree: 82–106 (new — was missing)
- series: 107–134 (was 47–62)
- main-theorem: 135–169 (was 63–82)
- examples: 170–239 (was 83–239)

Numerical claims (axiomCount=2, sorries=0, badge=axiom, status=axiomatized) are all accurate — no changes needed there.

Closes #14564

---
Automated fix by lean-mechanic agent.