### PR TITLE
audit(tracker): erdos-255 issues-found (#14570)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5463,10 +5463,10 @@
       "result": "clean"
     },
     "erdos-255": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-2026-05-02T04:57:20.128138Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T04:56:46Z",
+      "result": "issues-found"
     },
     "erdos-256": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Logs erdos-255 audit result as `issues-found` (auditCount 2 -> 3, lastAudited 2026-05-02).
- Linked issue #14570: phantom theorems (`tijdeman_wagner_theorem`, `weyl_theorem`, `star_discrepancy_unbounded`) claimed in `originalContributions` but absent from `proofs/Proofs/Erdos255Problem.lean` (only docstring comments). Plus section line drift in 4 sections.

## Test plan

- [x] Tracker JSON well-formed (single 4-line diff, no unicode pollution).
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)