### PR TITLE
audit(tracker): erdos-237 issues-found (#14574)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5332,9 +5332,9 @@
     },
     "erdos-237": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T05:08:05Z",
+      "result": "issues-found"
     },
     "erdos-238": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Bumps `audit-tracker.json` for `erdos-237`: `auditCount 2 → 3`, `result: issues-found`, `lastAudited` refreshed.
- References issue #14574 (dangling `/--` docstrings at lines 92-103 + section line drift in 5 sections).

## Test plan
- [x] Tracker JSON valid (round-tripped through `json.load`/`json.dump` with `ensure_ascii=False`).
- [x] Diff scoped to a single entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)