### PR TITLE
fix(meta): erdos-26 section line ranges drift

### DIFF
--- a/src/data/proofs/erdos-26/meta.json
+++ b/src/data/proofs/erdos-26/meta.json
@@ -95,46 +95,46 @@
       "id": "thick-properties",
       "title": "Properties of Thick Sequences",
       "startLine": 80,
-      "endLine": 94,
-      "summary": "Basic theorems: finite sequences aren't thick, geometric sequences aren't thick, constant sequences are thick.",
-      "mathContext": "Verified: Basic theorems: finite sequences aren't thick, geometric sequences aren't thick, constant sequences are thick."
+      "endLine": 99,
+      "summary": "Basic theorems: finite sequences aren't thick, geometric sequences aren't thick.",
+      "mathContext": "Verified: Basic theorems: finite sequences aren't thick, geometric sequences aren't thick."
     },
     {
       "id": "davenport-erdos",
       "title": "Davenport-Erdős Theorem",
-      "startLine": 95,
-      "endLine": 107,
+      "startLine": 100,
+      "endLine": 112,
       "summary": "The key structural result that Behrend sequences must be thick.",
       "mathContext": "Mathematical content: The key structural result that Behrend sequences must be thick."
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
-      "startLine": 108,
-      "endLine": 118,
+      "startLine": 113,
+      "endLine": 123,
       "summary": "Formal statement of Problem 26: thick sequences should have some Behrend shift.",
       "mathContext": "Mathematical content: Formal statement of Problem 26: thick sequences should have some Behrend shift."
     },
     {
       "id": "counterexamples",
       "title": "Counterexamples",
-      "startLine": 119,
-      "endLine": 142,
+      "startLine": 124,
+      "endLine": 144,
       "summary": "Ruzsa's non-thick counterexample and Van Doorn's thick counterexample, with the main disproof theorem.",
       "mathContext": "Verified: Ruzsa's non-thick counterexample and Van Doorn's thick counterexample, with the main disproof theorem."
     },
     {
       "id": "tenenbaum-variant",
       "title": "Tenenbaum's Weaker Variant",
-      "startLine": 143,
-      "endLine": 154,
+      "startLine": 145,
+      "endLine": 156,
       "summary": "The open question: can we achieve density ≥ 1-ε for any ε > 0?",
       "mathContext": "The open question: can we achieve density $\\geq$ 1-ε for any ε > 0?"
     },
     {
       "id": "supporting-lemmas",
       "title": "Supporting Lemmas",
-      "startLine": 155,
+      "startLine": 157,
       "endLine": 202,
       "summary": "Auxiliary results about multiples of sequences containing 1 and edge cases for weakly Behrend.",
       "mathContext": "Mathematical content: Auxiliary results about multiples of sequences containing 1 and edge cases for weakly Behrend."


### PR DESCRIPTION
## Fix

Update section `startLine`/`endLine` ranges in `src/data/proofs/erdos-26/meta.json` to match actual `/- ## ... -/` markers in `Erdos26Problem.lean`.

## Evidence

**Before**: Section markers were off by 2-5 lines for 5 sections (davenport-erdos, conjecture, counterexamples, tenenbaum-variant, supporting-lemmas).

**After**: All 8 sections now align with actual `/- ##` header positions in the Lean source.

Also removed the unverified "constant sequences are thick" claim from `thick-properties` summary — only a docstring comment exists at line 98, no corresponding theorem declaration.

Closes #14568

---
Automated fix by lean-mechanic agent.