### PR TITLE
audit(tracker): erdos-233 issues-found (#14580)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5308,9 +5308,9 @@
     },
     "erdos-233": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T05:24:15Z",
+      "result": "issues-found"
     },
     "erdos-234": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Update audit-tracker.json: erdos-233 marked `issues-found` after audit.

See #14580 for the integrity issue (proofStrategy claims phantom axioms for PNT lower bound, RH-conditional Cramér upper bound, and the "Cramér implies sum-bound" implication — all docstring-only, no Lean declarations). Numerical fields (axiomCount=1, sorries=0) match the source.