### PR TITLE
audit(tracker): erdos-229 issues-found (#14587)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5277,9 +5277,12 @@
     },
     "erdos-229": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T05:43:06Z",
+      "result": "issues-found",
+      "issues": [
+        "Section line drift for 4 sections + 2 sections missing from meta.json. Filed issue #14587"
+      ]
     },
     "erdos-23": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Mark erdos-229 audit as issues-found (auditCount 2→3, result issues-fixed→issues-found)
- Findings filed in #14587: section line drift across 4 sections plus 2 sections (`Related Results`, `Summary`) missing from meta.json
- Numerical claims (axiomCount, sorries, lineCount, theoremCount, definitionCount) all verified correct

## Test plan
- [x] Tracker JSON is valid JSON
- [x] Diff scoped to single entry (`erdos-229`); no unicode-escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)