### PR TITLE
audit(tracker): erdos-230 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5289,9 +5289,9 @@
     },
     "erdos-230": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T05:49:59Z",
+      "result": "clean"
     },
     "erdos-231": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Verified erdos-230 numeric claims against origin/main Lean source.

## Audit Results
- `sorries: 3` ✓ (matches `git show origin/main:proofs/Proofs/Erdos230Problem.lean`, comments stripped)
- `axiomCount: 1` ✓ (axiom `kahane_ultraflat`)
- `lineCount: 230` ✓
- `status: axiomatized`, `badge: axiom` ✓ (justified by 1 axiom + 3 sorries)
- No True stubs

## Test plan
- [x] Tracker diff is the 3-line entry update only (no unicode escaping pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)