### PR TITLE
audit(tracker): erdos-225 issues-found (#14591)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5253,9 +5253,9 @@
     },
     "erdos-225": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T05:54:34Z",
+      "result": "issues-found"
     },
     "erdos-226": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-225 audit complete with `issues-found` after gallery integrity audit.

## Findings

Filed in #14591:
- **Section line drift**: `optimality` truncates two theorems (currently 131-209, should extend to 233 to cover `degree_one_l1_norm_eq_four` and `erdos_225_tight`); `equivalences` and `related-results` shifted by ~24 lines.
- **Phantom axiom narrative**: `related-results.summary` and `mathContext` claim "Axiomatizes the Fejér–Riesz theorem and Littlewood's lower bound", but lines 283-326 contain only docstrings — no `axiom` declarations. `axiomCount: 1` is correct (only `erdos_225` at L123); the wording overstates.

Counts (3 sorries, 1 axiom) and `status: axiomatized` / `badge: axiom` are otherwise correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)