### PR TITLE
audit(tracker): erdos-221 issues-found (#14597)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5229,9 +5229,12 @@
     },
     "erdos-221": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T06:00:57Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom axioms in originalContributions/proofStrategy: lorentz_1954, two_primitive_root_mod_five_power, generalization_to_any_base, sumset_covering, additive_basis_order_two are listed but not declared in source (only dangling docstrings). Stale lineCount 274 in proofStrategy (file is 239 lines). Issue #14597 filed."
+      ]
     },
     "erdos-222": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks erdos-221 audit-tracker entry as `issues-found` (auditCount 2 → 3, lastAudited bumped to 2026-05-02).
- Records issue #14597 in the tracker entry's `issues` field.

## Findings (full detail in #14597)
Phantom-axiom narrative pattern: `originalContributions` and `proofStrategy` claim 5 axioms (`lorentz_1954`, `two_primitive_root_mod_five_power`, `generalization_to_any_base`, `sumset_covering`, `additive_basis_order_two`) that are not declared in `proofs/Proofs/Erdos221Problem.lean` — only dangling `/-- ... -/` docstrings exist. `proofStrategy` also has stale "274 lines" (file is 239).

Numerical counts (`axiomCount: 4`, `sorries: 0`, `lineCount: 239`) are correct. Mechanic can address the narrative drift via #14597.

## Test plan
- [x] Tracker JSON valid (`jq` parses)
- [x] Diff scoped to single entry (no unicode pollution from script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)