### PR TITLE
audit(tracker): erdos-222 issues-found (#14599)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5234,10 +5234,13 @@
       "result": "issues-fixed"
     },
     "erdos-222": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-1777701908",
+      "auditCount": 3,
+      "issues": [
+        "phantom axioms in sections (Fermat criterion, Landau, Richards 1982, DEKKM 2022, monotonicity) + section line drift Parts II–VII (#14599)"
+      ],
+      "lastAudited": "2026-05-02T06:09:26Z",
+      "result": "issues-found"
     },
     "erdos-223": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records audit result for erdos-222 in `audit-tracker.json`
- Filed integrity issue #14599 (phantom axioms in section narratives + section line drift Parts II–VII)
- Numerical counts (3 axioms, 0 sorries, 147 lines) are correct; status `axiomatized` / badge `axiom` remain valid

## Details
Section summaries and `proofStrategy` describe Fermat's criterion, Landau's theorem, Richards (1982), DEKKM (2022), and monotonicity of `nthSumTwoSquares` as if they were axiomatized, but they exist only as docstrings. Section line ranges drift across all post-Part-I sections (Parts V–VII off by 16 lines).

Pattern matches the erdos-22X cluster: #14589 (erdos-226), #14591 (erdos-225), #14597 (erdos-221).

## Test plan
- [x] Tracker JSON parses (Edit verified diff)
- [x] No unicode-escape pollution in diff (only erdos-222 entry changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)