### PR TITLE
audit(tracker): erdos-219 issues-found (#14601)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5210,9 +5210,12 @@
     },
     "erdos-219": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T06:16:52Z",
+      "result": "issues-found",
+      "issues": [
+        "section line drift across all 6 sections; missing summary section; 2 dangling docstrings (lines 95-96, 102-109) — issue #14601"
+      ]
     },
     "erdos-22": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit result for erdos-219

`erdos-219` (Erdős Problem #219: Arbitrarily Long Arithmetic Progressions of Primes) — issues found and filed in #14601.

### Findings
- Section line drift across all 6 sections (definitions/examples-k3/examples-k5/green-tao/records/open) — meta line ranges off by up to 25 lines.
- Missing `summary` section in meta — Lean file has `/- ## Summary -/` block at line 129 with `theorem summary_erdos_219`, but no entry in `sections[]`.
- 2 dangling docstrings in the Lean file (lines 95–96 and 102–109) — same pattern as the erdos-237 fix in #14583.
- Numerical fields (axiomCount=1 `green_tao_theorem`, sorries=0, lineCount=148) are correct.

### Tracker change
Updates `audit-tracker.json` for `erdos-219`:
- auditCount 2 → 3
- lastAudited → 2026-05-02T06:16:52Z
- result issues-fixed → issues-found
- issues note added linking to #14601

🤖 Generated with [Claude Code](https://claude.com/claude-code)