### PR TITLE
audit(tracker): erdos-217 issues-found (#14603)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5198,9 +5198,12 @@
     },
     "erdos-217": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T06:22:03Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axioms palasti_small_n + erdos_217_conjecture (only docstrings); phantom small_cases_exist/ErdosConjecture217 in originalContributions; proofStrategy overclaims Palásti axiomatization (#14603)"
+      ]
     },
     "erdos-218": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for erdos-217 audit. Result: **issues-found** — issue #14603 filed.

## Summary

- Phantom axioms `palasti_small_n` and `erdos_217_conjecture` referenced in `meta.json` sections; only orphan docstrings exist in the Lean file
- `originalContributions` lists nonexistent `small_cases_exist` (n=4..8) and `ErdosConjecture217`
- `proofStrategy` overclaims Palásti's result and the conjecture as axiomatized
- Numerical counts (`axiomCount: 2`, `sorries: 0`, `assumptions` text) are accurate — narrative-only mismatch

## Test plan

- [x] Verified `proofs/Proofs/Erdos217Problem.lean` declarations: 2 axioms, 1 theorem, 4 defs
- [x] Confirmed orphan docstrings at lines 67 and 72-75 with no following declarations
- [x] Filed issue #14603 with concrete reconciliation steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)