### PR TITLE
fix(meta): erdos-219 section line drift + dangling docstrings + missing summary

### DIFF
--- a/proofs/Proofs/Erdos219Problem.lean
+++ b/proofs/Proofs/Erdos219Problem.lean
@@ -92,14 +92,14 @@ Reference: Annals of Mathematics 167 (2008), 481-547.
 -/
 axiom green_tao_theorem : Erdos219Question
 
-/-- Equivalent formulation: for all k, there exist a, d with d > 0 such that
+/- Equivalent formulation: for all k, there exist a, d with d > 0 such that
     a, a+d, a+2d, ..., a+(k-1)d are all prime. -/
 /-- The answer to Erdős Problem #219 is YES. -/
 theorem erdos_219_answer : Erdos219Question := green_tao_theorem
 
 /- ## Records and Computations -/
 
-/-- Known record (as of 2019): The longest known AP of primes has 23 terms.
+/- Known record (as of 2019): The longest known AP of primes has 23 terms.
 
     The progression is:
     a = 56211383760397, d = 44546738095860 * 23#

--- a/src/data/proofs/erdos-219/meta.json
+++ b/src/data/proofs/erdos-219/meta.json
@@ -73,43 +73,50 @@
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 32,
-      "endLine": 46,
+      "endLine": 42,
       "summary": "Define arithmetic progressions and when they consist of primes."
     },
     {
       "id": "examples-k3",
       "title": "Example: k = 3",
-      "startLine": 47,
-      "endLine": 71,
+      "startLine": 43,
+      "endLine": 55,
       "summary": "Verify {3, 5, 7} is a prime AP of length 3."
     },
     {
       "id": "examples-k5",
       "title": "Example: k = 5",
-      "startLine": 72,
-      "endLine": 92,
+      "startLine": 57,
+      "endLine": 69,
       "summary": "Verify {5, 11, 17, 23, 29} is a prime AP of length 5."
     },
     {
       "id": "green-tao",
       "title": "The Green-Tao Theorem",
-      "startLine": 93,
-      "endLine": 124,
+      "startLine": 71,
+      "endLine": 98,
       "summary": "Axiomatize the main result and answer."
     },
     {
       "id": "records",
       "title": "Records and Computations",
-      "startLine": 125,
-      "endLine": 136,
+      "startLine": 100,
+      "endLine": 109,
       "summary": "State the longest known AP (k = 23)."
     },
     {
       "id": "open",
       "title": "Related Open Problem",
-      "startLine": 137,
-      "endLine": 143,
+      "startLine": 110,
+      "endLine": 127,
       "summary": "The consecutive prime AP question."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 129,
+      "endLine": 146,
+      "summary": "Summary theorem `summary_erdos_219` combining `green_tao_theorem` and the verified small examples."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Three integrity issues in `erdos-219`.

## Evidence

**Issue 1 — Section line drift** (all 6 sections shifted):

| Section | Before | After |
|---|---|---|
| `definitions` | 32–46 | 32–42 |
| `examples-k3` | 47–71 | 43–55 |
| `examples-k5` | 72–92 | 57–69 |
| `green-tao` | 93–124 | 71–98 |
| `records` | 125–136 | 100–109 |
| `open` | 137–143 | 110–127 |

**Issue 2 — Missing summary section**: Added `summary` section (lines 129–146) covering `theorem summary_erdos_219`.

**Issue 3 — Dangling docstrings**: Converted 2 `/--` doc-comments with no following declaration to `/-` block comments:
- Lines 95–96 (equivalent formulation note)
- Lines 102–109 (records note)

Closes #14601

---
Automated fix by lean-mechanic agent.