### PR TITLE
audit(tracker): erdos-213 issues-found (#14608)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5174,9 +5174,12 @@
     },
     "erdos-213": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T06:25:46Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom axiom narrative: originalContributions/proofStrategy claim anning_erdos_finite and gip_sparsity_bound axioms that do not exist in Erdos213Problem.lean (only dangling /-- ... -/ docstrings); section line ranges drift for main-results, constructions, bounds, summary; 3 dangling docstrings in Lean source. Numerical fields (axiomCount=4, sorries=0) accurate. Issue #14608."
+      ]
     },
     "erdos-214": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-213 audit complete with `issues-found` after filing #14608.

## Findings (see #14608 for full detail)
- Phantom axiom narrative: `originalContributions` and `proofStrategy` claim `anning_erdos_finite` and `gip_sparsity_bound` axioms that do not exist in `Erdos213Problem.lean` — they are dangling `/-- ... -/` docstrings on lines 69-74, 119-125, 126-129.
- Section line ranges drift for `main-results`, `constructions`, `bounds`, and `summary` (`## ` headers actually at lines 67, 89, 118, 130).
- 3 dangling docstrings in the Lean source.
- Numerical counts accurate: `axiomCount: 4` and `sorries: 0` match the source.

## Test plan
- [x] Tracker JSON edited with `ensure_ascii=False` to preserve `→`/`—` characters.
- [x] Diff is purely additive: 6 insertions / 3 deletions, single entry updated.
- [ ] Mechanic agent will produce companion `fix(meta): erdos-213 ...` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)