### PR TITLE
audit(tracker): erdos-226 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5270,10 +5270,10 @@
       "result": "issues-found"
     },
     "erdos-226": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-1777703204",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T06:27:41Z",
+      "result": "clean"
     },
     "erdos-227": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Audit of erdos-226 (Entire Functions Preserving Rationality / Barth-Schneider 1970): **clean**.

## Verification

- **Sorries**: 0 (matches `meta.sorries`, `leanFile.sorries`)
- **Axioms**: 1 — `barth_schneider_1970` (matches `axiomCount: 1`)
- **True stubs**: none
- **Theorem count**: 6 ✓; **Definition count**: 8 ✓; **Line count**: 268 ✓
- **Section line ranges**: all 10 sections accurate against `## Part N` headers
- **Status / badge**: `axiomatized` / `axiom` correctly reflects the single load-bearing axiom

## Narrative integrity

No phantom-axiom trap. The `sections` field explicitly notes:

- Part 8 ("Extensions"): "Docstring discussion of the 1971 ℂ extension; no axiom is declared."
- Part 9 ("Why This Works"): "Lines 207-220 are a docstring … no `no_polynomial_works` axiom is declared."
- Part 6 ("Barth-Schneider"): notes the monotonicity commentary at lines 153-155 is docstring-only.

`originalContributions` accurately scoped:
- transcendental ⇒ non-linear via degree-1 polynomial encoding (lines 170-178)
- `rationals_countable_dense` derived from `Set.countable_range` + `Rat.denseRange_ratCast` (lines 82-85)
- `erdos_question_affirmative` instantiates the axiom at A = B = ℚ

## Tracker change

erdos-226: auditCount 2 → 3, result issues-fixed → clean, lastAudited 2026-04-03 → 2026-05-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)