### PR TITLE
fix(meta): erdos-210 phantom structure_theorem + section line drift + dangling docstrings

### DIFF
--- a/proofs/Proofs/Erdos210Problem.lean
+++ b/proofs/Proofs/Erdos210Problem.lean
@@ -100,7 +100,7 @@ axiom sylvester_gallai :
   ∀ (S : PointSet), S.card ≥ 3 → NotAllCollinear S →
     ∃ (l : Line), l.p1 ∈ S ∧ l.p2 ∈ S ∧ IsOrdinaryLine S l
 
-/-- f(n) ≥ 1 for n ≥ 3 (immediate consequence of Sylvester-Gallai). -/
+/- f(n) ≥ 1 for n ≥ 3 (immediate consequence of Sylvester-Gallai). -/
 /- ## Part V: Motzkin's Theorem -/
 
 /-- **Motzkin's Theorem (1951):** f(n) → ∞ as n → ∞.
@@ -140,7 +140,7 @@ axiom green_tao_even :
 axiom green_tao_odd :
   ∃ N₀ : ℕ, ∀ n : ℕ, n ≥ N₀ → Odd n → f n ≥ 3 * (n / 4)
 
-/-- The even bound n/2 is tight: take n/2 points on a circle and n/2 at infinity. -/
+/- The even bound n/2 is tight: take n/2 points on a circle and n/2 at infinity. -/
 /- ## Part VIII: Extremal Configurations -/
 
 /-- The Böröczky configuration achieves the minimum for even n.
@@ -149,8 +149,8 @@ It consists of n/2 points on a circle and n/2 points "at infinity"
 def BoroczykyConfiguration (n : ℕ) (hEven : Even n) : Prop :=
   ∃ S : PointSet, S.card = n ∧ OrdinaryLineCount S = n / 2
 
-/-- Böröczky configurations exist for all even n ≥ 4. -/
-/-- For small n, exact values are known. -/
+/- Böröczky configurations exist for all even n ≥ 4. -/
+/- For small n, exact values are known. -/
 /- ## Part IX: The Structure Theory -/
 
 /-- Sets with few ordinary lines have algebraic structure.
@@ -158,7 +158,7 @@ Green-Tao showed: if a set has fewer than n/2 ordinary lines,
 it must lie (mostly) on a cubic curve. -/
 axiom LiesOnCubic (S : PointSet) : Prop
 
-/-- If S has very few ordinary lines, it lies mostly on a cubic. -/
+/- If S has very few ordinary lines, it lies mostly on a cubic. -/
 /- ## Part X: Summary
 
 **Erdős Problem #210: SOLVED (Green-Tao, 2013)**

--- a/src/data/proofs/erdos-210/meta.json
+++ b/src/data/proofs/erdos-210/meta.json
@@ -51,7 +51,7 @@
       "motzkin_theorem axiom and f_tends_to_infinity theorem (proved)",
       "kelly_moser, csima_sawyer axioms",
       "green_tao_even, green_tao_odd axioms",
-      "structure_theorem axiom (cubic curve structure)",
+      "LiesOnCubic axiom (predicate for points lying on a cubic curve)",
       "erdos_210 and erdos_210_summary theorems (proved)"
     ],
     "axiomCount": 9,
@@ -112,47 +112,47 @@
       "id": "motzkin",
       "title": "Motzkin's Theorem",
       "summary": "f(n) → ∞, with f_tends_to_infinity proved",
-      "startLine": 106,
-      "endLine": 119,
+      "startLine": 104,
+      "endLine": 117,
       "mathContext": "f(n) $\\to$ ∞, with f_tends_to_infinity proved"
     },
     {
       "id": "kelly-moser-csima-sawyer",
       "title": "Kelly-Moser and Csima-Sawyer Bounds",
       "summary": "f(n) ≥ 3n/7 and f(n) ≥ 6n/13 for n ≥ 8",
-      "startLine": 120,
-      "endLine": 131,
+      "startLine": 118,
+      "endLine": 129,
       "mathContext": "f(n) $\\geq$ 3n/7 and f(n) $\\geq$ 6n/13 for n $\\geq$ 8"
     },
     {
       "id": "green-tao",
       "title": "Green-Tao Theorem",
       "summary": "f(n) ≥ n/2 for large even n, f(n) ≥ 3⌊n/4⌋ for large odd n, tightness",
-      "startLine": 132,
-      "endLine": 149,
+      "startLine": 130,
+      "endLine": 143,
       "mathContext": "f(n) $\\geq$ n/2 for large even n, f(n) $\\geq$ 3⌊n/4⌋ for large odd n, tightness"
     },
     {
       "id": "extremal",
       "title": "Extremal Configurations",
       "summary": "Böröczky construction, small n values",
-      "startLine": 150,
-      "endLine": 169,
+      "startLine": 144,
+      "endLine": 153,
       "mathContext": "Mathematical content: Böröczky construction, small n values"
     },
     {
       "id": "structure-theory",
       "title": "Structure Theory",
-      "summary": "LiesOnCubic axiom and structure_theorem",
-      "startLine": 170,
-      "endLine": 182,
-      "mathContext": "Formal definition: LiesOnCubic axiom and structure_theorem"
+      "summary": "LiesOnCubic axiom (predicate for points on a cubic curve); no structure_theorem declared",
+      "startLine": 154,
+      "endLine": 161,
+      "mathContext": "Formal definition: LiesOnCubic predicate axiom for points on a cubic curve; no structure_theorem declared"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_210 and erdos_210_summary theorems",
-      "startLine": 183,
+      "startLine": 162,
       "endLine": 196,
       "mathContext": "Verified: erdos_210 and erdos_210_summary theorems"
     }
@@ -181,7 +181,7 @@
     "namespace": "Erdos210",
     "lineCount": 196,
     "axiomCount": 9,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Erdos210Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Three integrity issues in `src/data/proofs/erdos-210/meta.json` and `proofs/Proofs/Erdos210Problem.lean`.

## Evidence

**1. Phantom `structure_theorem` removed (MEDIUM):**
- `originalContributions[8]`: `"structure_theorem axiom (cubic curve structure)"` → `"LiesOnCubic axiom (predicate for points lying on a cubic curve)"`
- `sections.structure-theory.summary` and `mathContext`: drop non-existent `structure_theorem`; only `LiesOnCubic` is declared

**2. Section line drift corrected (LOW):**
| Section | startLine before→after | endLine before→after |
|---|---|---|
| motzkin | 106→104 | 119→117 |
| kelly-moser-csima-sawyer | 120→118 | 131→129 |
| green-tao | 132→130 | 149→143 |
| extremal | 150→144 | 169→153 |
| structure-theory | 170→154 | 182→161 |
| summary | 183→162 | 196 (unchanged) |

**3. Dangling docstrings fixed (LOW):**
Five `/-- ... -/` docstrings with no following declaration converted to `/- ... -/` block comments (lines 103, 143, 152, 153, 161).

**4. Minor: `leanFile.theoremCount`:** 4→3 (only `f_tends_to_infinity`, `erdos_210`, `erdos_210_summary` exist).

**Unchanged:** `axiomCount: 9`, `sorries: 0`, `lineCount: 196` — all correct.

Closes #14616

---
Automated fix by lean-mechanic agent.