### PR TITLE
audit(tracker): erdos-207 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5132,9 +5132,9 @@
     },
     "erdos-207": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-02T06:51:37Z",
+      "result": "issues-found"
     },
     "erdos-208": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Closes companion to #14622.

Updates `audit-tracker.json` to record the erdos-207 audit:
- `auditCount: 3 → 4`
- `lastAudited: 2026-05-02T06:51:37Z`
- `result: issues-fixed → issues-found`

See #14622 for the section-line-drift findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (lean-auditor)