### PR TITLE
fix(meta): erdos-209 phantom axioms in proofStrategy + section line drift + dangling docstrings

### DIFF
--- a/proofs/Proofs/Erdos209Problem.lean
+++ b/proofs/Proofs/Erdos209Problem.lean
@@ -67,7 +67,7 @@ Two lines are parallel if they have proportional direction vectors (same slope).
 def areParallel (l₁ l₂ : Line2D) : Prop :=
   l₁.a * l₂.b = l₁.b * l₂.a
 
-/--
+/-
 **Line intersection:**
 Non-parallel lines intersect at exactly one point.
 This is a standard result in linear algebra (solving 2×2 linear systems).
@@ -143,7 +143,7 @@ def HasGallaiTriangle (A : LineArrangement) : Prop :=
 This classical theorem guarantees ordinary points exist.
 -/
 
-/--
+/-
 **Sylvester-Gallai Theorem:**
 Any finite set of non-collinear points in ℝ² determines at least one
 ordinary line (containing exactly 2 points).
@@ -151,7 +151,7 @@ ordinary line (containing exactly 2 points).
 Dual version: Any arrangement of ≥ 3 non-concurrent lines has at least
 one ordinary point (where exactly 2 lines meet).
 -/
-/--
+/-
 **Corollary: At least 3 ordinary points exist**
 For arrangements with d ≥ 3 lines and no parallels, there are at least
 3 ordinary points. (But they might not form a triangle!)
@@ -162,14 +162,14 @@ For arrangements with d ≥ 3 lines and no parallels, there are at least
 Erdős asked: must these ordinary points form a Gallai triangle?
 -/
 
-/--
+/-
 **Erdős's Question:**
 If A is a line arrangement with d ≥ 4 lines, no parallels, and no 4
 concurrent lines, must there exist a Gallai triangle?
 
 Answer: NO!
 -/
-/--
+/-
 **Füredi-Palásti Construction (1984):**
 For d not divisible by 9, there exist d-line arrangements with no
 parallels, no 4-concurrent points, and no Gallai triangles.

--- a/src/data/proofs/erdos-209/meta.json
+++ b/src/data/proofs/erdos-209/meta.json
@@ -55,7 +55,7 @@
     "historicalContext": "**Erdős Problem #209** is a question in incidence geometry about the structure of line arrangements. The classical Sylvester-Gallai theorem (1893) guarantees that any finite set of points not all collinear determines at least one \"ordinary line\" (containing exactly 2 points). Erdős asked: can we extend this to triangles?\n\n**Historical Development:**\n- **1893 (Sylvester-Gallai):** Ordinary points/lines must exist.\n- **1984 (Füredi-Palásti):** Disproved the conjecture for most d.\n- **2016 (Escudero):** Completed the disproof for ALL d ≥ 4.\n\n**Key Insight:** While ordinary points always exist, they can be positioned to avoid forming triangles with only ordinary vertices.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet $A$ be a finite collection of $d \\geq 4$ non-parallel lines in $\\mathbb{R}^2$ such that no point lies on 4 or more lines. Must there exist a **Gallai triangle** (or **ordinary triangle**): three lines from $A$ that form a triangle where each vertex involves exactly two lines?\n\n**Answer: NO!**\n\n**Resolution:**\n- Füredi-Palásti (1984): No for $d$ not divisible by 9\n- Escudero (2016): No for ALL $d \\geq 4$\n\n**Dual Formulation:** Given $n$ points with no 4 collinear, must there exist 3 points where each pair determines an ordinary line?",
     "text": "Must every line arrangement (d ≥ 4 lines, no parallels, no 4-concurrent) have a Gallai triangle? NO, disproved by Füredi-Palásti (1984) and Escudero (2016).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Lines and Arrangements:** Define lines via coefficients, parallel criterion, and line arrangements as finite sets.\n\n2. **Incidence Properties:** Define ordinary points (2 lines), 3-rich points (3+ lines), and Gallai triangles.\n\n3. **Sylvester-Gallai:** Axiomatize that ordinary points always exist.\n\n4. **Counterexamples:** Axiomatize Füredi-Palásti (1984) and Escudero (2016) constructions.\n\n5. **Main Result:** Prove the conjecture is false for all d ≥ 4.\n\n6. **Dual Problem:** Explain the point-line duality.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Lines and Arrangements:** Define lines via coefficients, parallel criterion, and line arrangements as finite sets.\n\n2. **Incidence Properties:** Define ordinary points (2 lines), 3-rich points (3+ lines), and Gallai triangles.\n\n3. **Sylvester-Gallai:** Describe ordinary points and the Sylvester-Gallai theorem in docstrings; not axiomatized in this formalization.\n\n4. **Counterexamples:** Axiomatize the Escudero (2016) construction (`escudero_2016`); cite Füredi-Palásti (1984) in docstrings without a separate axiom.\n\n5. **Main Result:** Prove the conjecture is false for all d ≥ 4.\n\n6. **Dual Problem:** Explain the point-line duality.",
     "keyInsights": [
       "**Ordinary Points Exist:** Sylvester-Gallai guarantees at least one point where exactly 2 lines meet.",
       "**Triangles Blocked:** Ordinary points can be positioned so that every triangle has at least one 3-rich vertex.",
@@ -74,42 +74,49 @@
       "id": "lines-plane",
       "title": "Lines in the Plane",
       "summary": "Line2D structure, containment, parallel criterion, and unique intersection",
-      "startLine": 40,
-      "endLine": 77
+      "startLine": 41,
+      "endLine": 75
     },
     {
       "id": "arrangements",
       "title": "Line Arrangements",
       "summary": "LineArrangement, NoFourConcurrent, NoParallels definitions",
-      "startLine": 78,
-      "endLine": 103
+      "startLine": 76,
+      "endLine": 101
     },
     {
       "id": "ordinary-gallai",
       "title": "Ordinary Points and Gallai Triangles",
       "summary": "IsOrdinaryPoint, Is3RichPoint, IsGallaiTriangle, HasGallaiTriangle definitions",
-      "startLine": 104,
-      "endLine": 142
+      "startLine": 102,
+      "endLine": 140
     },
     {
       "id": "sylvester-gallai",
       "title": "The Sylvester-Gallai Theorem",
-      "summary": "Classical theorem and corollary: at least 3 ordinary points exist",
-      "startLine": 143,
-      "endLine": 177
+      "summary": "Classical theorem and corollary: at least 3 ordinary points exist (not axiomatized)",
+      "startLine": 141,
+      "endLine": 159
     },
     {
       "id": "disproof",
       "title": "The Erdős Question and Its Disproof",
-      "summary": "Füredi-Palásti (1984) and Escudero (2016) counterexamples",
-      "startLine": 178,
-      "endLine": 223
+      "summary": "Füredi-Palásti (1984) and Escudero (2016) counterexamples; escudero_2016 axiom",
+      "startLine": 160,
+      "endLine": 191
     },
     {
       "id": "main-result",
       "title": "Main Result",
       "summary": "erdos_209 theorem: disproved for all d ≥ 4 via Escudero",
-      "startLine": 224,
+      "startLine": 192,
+      "endLine": 215
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_209_summary theorem: alias restating the main disproof",
+      "startLine": 216,
       "endLine": 241
     }
   ],


### PR DESCRIPTION
## Fix

Three-part repair for erdos-209 gallery integrity issues found by the auditor.

## Evidence

**1. Phantom axiom claims in proofStrategy**
- **Before**: Steps 3 & 4 claimed to "axiomatize" Sylvester-Gallai and Füredi-Palásti constructions
- **After**: Step 3 describes Sylvester-Gallai as docstring-only (not axiomatized); Step 4 correctly identifies only `escudero_2016` as the single axiom

**2. Section line ranges (6 sections corrected)**
| section | was | now |
|---------|-----|-----|
| lines-plane | 40-77 | 41-75 |
| arrangements | 78-103 | 76-101 |
| ordinary-gallai | 104-142 | 102-140 |
| sylvester-gallai | 143-177 | 141-159 |
| disproof | 178-223 | 160-191 |
| main-result | 224-241 | 192-215 |

**3. Missing Part VII section added**
- New `summary` section covering lines 216-241 (`erdos_209_summary` theorem)

**4. Dangling docstrings (5 fixed in .lean)**
- Converted 5 `/-- ... -/` doc comments with no following declaration to plain `/- ... -/` block comments

Closes #14620

---
Automated fix by lean-mechanic agent.