### PR TITLE
fix(meta): erdos-207 section line drift (admissibility/conjecture/solution)

### DIFF
--- a/src/data/proofs/erdos-207/meta.json
+++ b/src/data/proofs/erdos-207/meta.json
@@ -104,30 +104,30 @@
       "title": "Admissibility and Triple Count",
       "summary": "Defines `IsAdmissible(n)$: $n \\bmod 6 \\in \\{1,3\\}$ and `stsTripleCount $= n(n-1)/6$. Axiomatizes Kirkman's 1847 theorem characterizing STS existence.",
       "startLine": 96,
-      "endLine": 125,
+      "endLine": 130,
       "mathContext": "Formal definition: Defines `IsAdmissible(n)$: $n \\bmod 6 \\in \\{1,3\\}$ and `stsTripleCount $= n(n-1)/6$. Axiomatizes Kirkman's 1847 theorem characterizing STS existence."
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
       "summary": "Formalizes erdos207Conjecture: $\\forall g \\geq 2, \\exists N: \\forall n \\geq N$, IsAdmissible$(n) \\implies \\exists$ STS$(n)$ with girth $\\geq g$.",
-      "startLine": 126,
-      "endLine": 139,
+      "startLine": 132,
+      "endLine": 144,
       "mathContext": "Mathematical content: Formalizes erdos207Conjecture: $\\forall g \\geq 2, \\exists N: \\forall n \\geq N$, IsAdmissible$(n) \\implies \\exists$ STS$(n)$ with girth $\\geq g$."
     },
     {
       "id": "solution",
       "title": "The KSSS Solution",
       "summary": "Axiomatizes `kwan_sah_sawhney_simkin_2022 : erdos207Conjecture` and derives `erdos_207 : erdos207Conjecture` as the main result of the formalization.",
-      "startLine": 140,
-      "endLine": 158,
+      "startLine": 146,
+      "endLine": 163,
       "mathContext": "Axiomatized: Axiomatizes `kwan_sah_sawhney_simkin_2022 : erdos207Conjecture` and derives `erdos_207 : erdos207Conjecture` as the main result of the formalization."
     },
     {
       "id": "special-cases",
       "title": "Girth 2, Pasch, and Anti-Pasch",
       "summary": "Proves `sts_has_girth_at_least_2` (trivial from unique pair coverage). Defines `IsPaschConfiguration` ($|S|=4, |\\bigcup S|=6$) and states `girth_3_iff_pasch_free`.",
-      "startLine": 159,
+      "startLine": 165,
       "endLine": 197,
       "mathContext": "Formal definition: Proves `sts_has_girth_at_least_2` (trivial from unique pair coverage). Defines `IsPaschConfiguration` ($|S|=4, |\\bigcup S|=6$) and states `girth_3_iff_pasch_free`."
     },


### PR DESCRIPTION
## Fix

Correct three drifted section line ranges in `src/data/proofs/erdos-207/meta.json` so gallery anchors point at the correct Lean source blocks.

## Evidence

**Before**:
- `admissibility`: 96–125 (cuts off 5 lines short of `sts_triple_count_formula` end at 130)
- `conjecture`: 126–139 (entirely outside `def erdos207Conjecture` at lines 141–144)
- `solution`: 140–158 (cuts off `theorem erdos_207` at lines 162–163)
- `special-cases`: 159–197 (overlaps with old solution range)

**After**:
- `admissibility`: 96–130
- `conjecture`: 132–144
- `solution`: 146–163
- `special-cases`: 165–197 (startLine bumped to avoid overlap)

Cosmetic fix only — no change to axiomCount, sorries, status, or badge.

Closes #14622

---
Automated fix by lean-mechanic agent.