### PR TITLE
audit(tracker): erdos-201 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5092,10 +5092,13 @@
       "result": "issues-fixed"
     },
     "erdos-201": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777705064",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T07:01:17Z",
+      "result": "issues-found",
+      "issues": [
+        "section line drift: basic-bounds 89-100, kss-bound 108-109, main-conjecture 119-122, monotonicity 129-149, consequences 156-197 all misaligned; narrative claims gk axiomatized but Lean has noncomputable def gk (only g3_5_eq value axiomatized); filed #14629"
+      ]
     },
     "erdos-202": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Audit tracker update only — no source/meta changes.
- erdos-201 re-audited: section line drift in 5 sections + narrative "gk axiomatized" mismatch with `noncomputable def gk`.
- Issue filed: #14629.

## Test plan
- [x] Tracker JSON parses cleanly (no unicode-escape pollution)
- [x] Only the erdos-201 entry is modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)