### PR TITLE
audit(tracker): erdos-198 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5056,10 +5056,13 @@
       "result": "clean"
     },
     "erdos-198": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-session-1777705382",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T07:30:00Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom Baumgartner axiom in originalContributions/proofStrategy + section title/line drift + 3 dangling docstrings (#14632)"
+      ]
     },
     "erdos-199": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Update audit-tracker.json: erdos-198 → issues-found
- Linked issue: #14632

## Findings
Phantom Baumgartner axiom in `originalContributions` and `proofStrategy`
(meta describes "Axiomatization of Baumgartner's lacunary construction"
but the Lean file has only the two factorial axioms). Plus section title
drift ("Factorial Construction" vs Lean "The Constructions"; "Verified
Examples" vs "First Few Elements"), section line drift, and 3 dangling
`/-- ... -/` docstrings (lines 71, 109, 115).

Numerical fields (axiomCount=2, sorries=0, lineCount=151) are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)