### PR TITLE
fix(meta): erdos-199 phantom axioms in originalContributions + section line drift

### DIFF
--- a/src/data/proofs/erdos-199/meta.json
+++ b/src/data/proofs/erdos-199/meta.json
@@ -46,9 +46,8 @@
       "infiniteAP definition for infinite arithmetic progressions",
       "containsInfiniteAP predicate",
       "ErdosConjecture199 formalization of the original question",
-      "baumgartner_partition axiom for the counterexample",
+      "baumgartner_3AP_free axiom encoding the counterexample existence",
       "erdos_199_disproved theorem showing the conjecture is false",
-      "van_der_waerden axiom connecting to Ramsey theory",
       "Concrete examples with naturals and rationals"
     ],
     "axiomCount": 1,
@@ -111,14 +110,14 @@
     {
       "id": "examples",
       "title": "Examples",
-      "startLine": 120,
-      "endLine": 151,
+      "startLine": 116,
+      "endLine": 140,
       "summary": "Concrete examples with naturals and rationals"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 152,
+      "startLine": 142,
       "endLine": 174,
       "summary": "Complete statement of the disproved result"
     }


### PR DESCRIPTION
## Fix

Remove two phantom axiom entries from `originalContributions` and correct section line ranges in `src/data/proofs/erdos-199/meta.json`.

## Evidence

**Problem 1 — Phantom originalContributions:**
- **Before**: Listed `"baumgartner_partition axiom for the counterexample"` and `"van_der_waerden axiom connecting to Ramsey theory"` — neither exists in the Lean file
- **After**: Replaced with `"baumgartner_3AP_free axiom encoding the counterexample existence"` (the single actual axiom at line 75)

**Problem 2 — Section line drift:**
- **examples**: `120–151` → `116–140` (first example comment at 116; second example ends at 139)
- **summary**: `152–174` → `142–174` (Part VII header at 142)

Numerical fields (`axiomCount: 1`, `sorries: 0`, `lineCount: 174`) are unchanged and correct.

Closes #14634

---
Automated fix by lean-mechanic agent.