### PR TITLE
audit(tracker): erdos-194 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5033,9 +5033,12 @@
     },
     "erdos-194": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T07:14:32Z",
+      "result": "issues-found",
+      "issues": [
+        "Phantom 'construction_uses_base3' axiom in sections[5]; chaotic_ordering_reals is a True-stub (issue #14638)"
+      ]
     },
     "erdos-195": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Records gallery integrity audit of erdos-194: phantom 'construction_uses_base3' axiom in `sections[5]` narrative + `chaotic_ordering_reals` is a True-stub presented as a substantive extension. Numerical fields (`sorries: 0`, `axiomCount: 2`) match the Lean source; the issue is narrative-only.

Filed as #14638.

## Test plan

- [x] `audit-tracker.json` updated for erdos-194 with `result: issues-found` and link to #14638
- [x] Diff is minimal — no unicode-escape pollution
- [x] Issue body cites file:line and quotes the offending JSON / Lean

🤖 Generated with [Claude Code](https://claude.com/claude-code)