### PR TITLE
fix(meta): erdos-194 phantom construction_uses_base3 axiom + True-stub disclosure

### DIFF
--- a/src/data/proofs/erdos-194/meta.json
+++ b/src/data/proofs/erdos-194/meta.json
@@ -128,10 +128,10 @@
     {
       "id": "construction",
       "title": "Construction Insight",
-      "summary": "construction_uses_base3 axiom explaining the approach",
+      "summary": "Docstring sketching the base-3 digit-pattern construction (no axiom or theorem in this section).",
       "startLine": 196,
       "endLine": 220,
-      "mathContext": "Axiomatized: construction_uses_base3 axiom explaining the approach"
+      "mathContext": "Commentary: base-3 digit-pattern construction insight; no Lean declarations."
     },
     {
       "id": "extensions",
@@ -139,7 +139,7 @@
       "summary": "chaotic_ordering_k_term, chaotic_ordering_reals extensions",
       "startLine": 221,
       "endLine": 244,
-      "mathContext": "Mathematical content: chaotic_ordering_k_term, chaotic_ordering_reals extensions"
+      "mathContext": "Axiomatized: chaotic_ordering_k_term (extension to k >= 3). Placeholder True-stub: chaotic_ordering_reals (statement simplified to \u2203 ordering : \u211d \u2192 \u2115, True, full uncountable-ordering statement not formalized)."
     },
     {
       "id": "related",


### PR DESCRIPTION
## Fix

Two narrative corrections in `src/data/proofs/erdos-194/meta.json`.

## Evidence

**Issue 1 — `sections[5]` (construction): Phantom axiom removed**
- **Before**: `summary` and `mathContext` referenced `construction_uses_base3 axiom` — a name that does not appear anywhere in the Lean file
- **After**: Corrected to describe what the section actually contains: a docstring explaining the base-3 digit-pattern construction, with no Lean declarations

**Issue 2 — `sections[6]` (extensions): True-stub disclosed**
- **Before**: `mathContext` presented `chaotic_ordering_reals` as a substantive extension alongside the real axiom `chaotic_ordering_k_term`
- **After**: `mathContext` discloses that `chaotic_ordering_reals` is a placeholder True-stub (`∃ ordering : ℝ → ℕ, True`), not a formalized result

Numerical fields (`sorries: 0`, `axiomCount: 2`) were already correct and unchanged.

Closes #14638

---
Automated fix by lean-mechanic agent.