### PR TITLE
audit(tracker): erdos-190 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5009,9 +5009,12 @@
     },
     "erdos-190": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T07:19:59Z",
+      "result": "issues-found",
+      "issues": [
+        "proofStrategy/keyInsight reverse H(k)≤W(k) (Lean proves W(k)≤H(k) at line 177); section line drift in 6/10 sections; filed #14641"
+      ]
     },
     "erdos-191": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks erdos-190 as `issues-found` in `audit-tracker.json` after gallery integrity audit.

Filed companion integrity issue #14641 documenting:
- **Reversed inequality** in `overview.proofStrategy` and `overview.keyInsights[0]`: claims `H(k) ≤ W(k)`, but the Lean theorem `W_le_H` at line 177 proves `W k ≤ H k` (the opposite direction). The Lean direction is mathematically correct.
- **Section line drift**: 6 of 10 sections (van-der-waerden, asymptotics, small-cases, connections, difficulty, summary) point to lines 70–130 lines too low, into the middle of unrelated proofs.

File checks otherwise pass: 348 lines (matches `lineCount`), 3 axioms (`exists_canonical_threshold`, `vanDerWaerden_exists`, `H_root_to_infinity` — matches `axiomCount`), 0 sorries, no True stubs.

## Test plan
- [x] `audit-tracker.json` parses as valid JSON
- [x] Diff is minimal (single entry, no unicode-escape pollution from claim-target.sh bug)
- [ ] Companion `fix(meta)` PR will be filed by mechanic

🤖 Generated with [Claude Code](https://claude.com/claude-code)