### PR TITLE
audit(tracker): erdos-191 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5017,10 +5017,10 @@
       ]
     },
     "erdos-191": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent-loop",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T07:25:14Z",
+      "result": "clean"
     },
     "erdos-192": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
Re-audit of erdos-191 (last audited 2026-04-03). All integrity checks pass; tracker updated with `result: clean`.

## Verification
- **Line count**: 357 (matches `lineCount`)
- **Axioms**: 4 declared (`erdos_191`, `rodl_upper_construction`, `conlon_fox_sudakov_bound`, `tripleLog_unbounded`) - matches `axiomCount`
- **Sorries**: 1 in `small_n_bound` example - matches `sorries` field
- **True stubs**: 0
- **Status**: `axiomatized` / badge `axiom` - correct given the four axioms encoding Rödl/CFS results
- **proofStrategy**: explicitly mentions axiomatization steps (item 5: "Axiomatize Rödl's affirmative answer", item 6: "Axiomatize Rödl's upper construction and Conlon-Fox-Sudakov lower bound")
- **mathlibDependencies**: populated correctly
- **originalContributions**: accurately scoped to the file's defs/axioms

## Test plan
- [x] `git diff` shows only the four-line tracker entry update with no unicode escape pollution
- [x] No phantom-axiom narrative pattern in `originalContributions`/`proofStrategy`
- [x] Section line ranges align with Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)