### PR TITLE
fix(meta): erdos-190 reversed W(k)≤H(k) inequality + section line drift

### DIFF
--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -29,9 +29,9 @@
     "historicalContext": "This is a canonical Ramsey theory problem from Erdős-Graham [ErGr79, p.333; ErGr80, p.17]. Unlike van der Waerden numbers W(k) (which require monochromatic APs only), H(k) allows rainbow APs as an alternative 'win condition'. The existence of H(k) follows from Szemerédi's theorem: for N large enough, either pigeonhole forces a monochromatic AP, or the coloring uses enough colors for a rainbow AP. The known result H(k)^{1/k} → ∞ is relatively straightforward, but the stronger question H(k)^{1/k}/k → ∞ — equivalently, whether H(k) grows faster than k^k — remains open.",
     "problemStatement": "Let H(k) denote the smallest N such that any finite coloring of {1,...,N} contains either a monochromatic k-term AP or a rainbow k-term AP (all different colors). Estimate H(k), and determine if H(k)^{1/k}/k → ∞.",
     "text": "Estimate H(k), the smallest N guaranteeing either a monochromatic or rainbow k-term arithmetic progression in every coloring of {1,...,N}.",
-    "proofStrategy": "The formalization defines arithmetic progressions, monochromatic/rainbow colorings, the canonical property, and the H(k) function via Nat.find. Van der Waerden numbers W(k) are similarly defined. Known results (H(k)^{1/k} → ∞, H(k) ≤ W(k), lower bounds) are axioms. The main conjecture H(k)^{1/k}/k → ∞ is stated. A summary theorem combines the known results.",
+    "proofStrategy": "The formalization defines arithmetic progressions, monochromatic/rainbow colorings, the canonical property, and the H(k) function via Nat.find. Van der Waerden numbers W(k) are similarly defined. Known results (H(k)^{1/k} → ∞, lower bounds) are axioms; W(k) ≤ H(k) is a proved theorem (W_le_H). The main conjecture H(k)^{1/k}/k → ∞ is stated. A summary theorem combines the known results.",
     "keyInsights": [
-      "H(k) ≤ W(k) because rainbow APs provide an easier 'win condition' than monochromatic only",
+      "W(k) ≤ H(k) (proved): for k ≥ 3, rainbow k-APs require ≥ 3 colors so are impossible in any 2-coloring, meaning any coloring satisfying the H(k) canonical condition must have a monochromatic AP — so H(k) satisfies the van der Waerden property.",
       "H(k)^{1/k} → ∞ is known — the k-th root grows without bound",
       "Whether H(k)^{1/k}/k → ∞ (equivalently H(k) > k^k eventually) is open",
       "Rainbow and monochromatic conditions compete via the pigeonhole principle",
@@ -47,80 +47,80 @@
     {
       "id": "arithmetic-progressions",
       "title": "Part 1: Arithmetic Progressions",
-      "startLine": 40,
-      "endLine": 53,
+      "startLine": 41,
+      "endLine": 54,
       "summary": "Definition of k-term arithmetic progressions as sets {a, a+d, ..., a+(k-1)d} and as function sequences.",
       "mathContext": "Formal definition: Definition of k-term arithmetic progressions as sets {a, a+d, ..., a+(k-1)d} and as function sequences."
     },
     {
       "id": "colorings",
       "title": "Part 2: Colorings",
-      "startLine": 54,
-      "endLine": 82,
+      "startLine": 55,
+      "endLine": 83,
       "summary": "Colorings of {1,...,N}, monochromatic sets (all same color), and rainbow sets (all distinct colors).",
       "mathContext": "Mathematical content: Colorings of {1,...,N}, monochromatic sets (all same color), and rainbow sets (all distinct colors)."
     },
     {
       "id": "canonical-property",
       "title": "Part 3: The Canonical Property",
-      "startLine": 83,
-      "endLine": 96,
+      "startLine": 84,
+      "endLine": 97,
       "summary": "A coloring has the canonical property for k-APs if it contains a monochromatic OR rainbow k-AP.",
       "mathContext": "Mathematical content: A coloring has the canonical property for k-APs if it contains a monochromatic OR rainbow k-AP."
     },
     {
       "id": "h-function",
       "title": "Part 4: The H(k) Function",
-      "startLine": 97,
-      "endLine": 119,
+      "startLine": 98,
+      "endLine": 158,
       "summary": "H(k) defined via Nat.find as the minimum N guaranteeing the canonical property. Existence, specification, and minimality axioms.",
       "mathContext": "Axiomatized: H(k) defined via Nat.find as the minimum N guaranteeing the canonical property. Existence, specification, and minimality axioms."
     },
     {
       "id": "van-der-waerden",
       "title": "Part 5: Relation to van der Waerden Numbers",
-      "startLine": 120,
-      "endLine": 140,
-      "summary": "Van der Waerden number W(k) defined via Nat.find. H(k) ≤ W(k) and H(k) ≥ k for k ≥ 3.",
-      "mathContext": "Van der Waerden number W(k) defined via Nat.find. H(k) $\\leq$ W(k) and H(k) $\\geq$ k for k $\\geq$ 3."
+      "startLine": 159,
+      "endLine": 233,
+      "summary": "Van der Waerden number W(k) defined via Nat.find. W(k) ≤ H(k) (proved theorem W_le_H, k ≥ 3) and H(k) ≥ k for k ≥ 1.",
+      "mathContext": "Van der Waerden number W(k) defined via Nat.find. W(k) $\\leq$ H(k) (proved theorem W_le_H for k $\\geq$ 3) and H(k) $\\geq$ k for k $\\geq$ 1."
     },
     {
       "id": "asymptotics",
       "title": "Part 6: Known Asymptotic Results",
-      "startLine": 141,
-      "endLine": 161,
+      "startLine": 234,
+      "endLine": 255,
       "summary": "Known: H(k)^{1/k} → ∞. Conjecture: H(k)^{1/k}/k → ∞ (super-exponential growth).",
       "mathContext": "Known: H(k)^{1/k} $\\to$ ∞. Conjecture: H(k)^{1/k}/k $\\to$ ∞ (super-exponential growth)."
     },
     {
       "id": "small-cases",
       "title": "Part 7: Small Cases",
-      "startLine": 162,
-      "endLine": 169,
+      "startLine": 256,
+      "endLine": 259,
       "summary": "Bounds on small values: H(3) ≤ 10, H(4) ≤ 100.",
       "mathContext": "Bounds on small values: H(3) $\\leq$ 10, H(4) $\\leq$ 100."
     },
     {
       "id": "connections",
       "title": "Part 8: Connections",
-      "startLine": 170,
-      "endLine": 188,
+      "startLine": 260,
+      "endLine": 278,
       "summary": "Connection to Szemerédi's theorem (density → existence) and canonical vs standard Ramsey theory.",
       "mathContext": "Connection to Szemerédi's theorem (density $\\to$ existence) and canonical vs standard Ramsey theory."
     },
     {
       "id": "difficulty",
       "title": "Part 9: Why This Is Hard",
-      "startLine": 189,
-      "endLine": 208,
+      "startLine": 279,
+      "endLine": 298,
       "summary": "The challenge of precise asymptotics: interplay between monochromatic and rainbow conditions via pigeonhole.",
       "mathContext": "Mathematical content: The challenge of precise asymptotics: interplay between monochromatic and rainbow conditions via pigeonhole."
     },
     {
       "id": "summary",
       "title": "Part 10: Summary",
-      "startLine": 209,
-      "endLine": 250,
+      "startLine": 299,
+      "endLine": 348,
       "summary": "H_pos axiom, summary theorem combining H(k) > 0 and H(k)^{1/k} → ∞. Status: OPEN.",
       "mathContext": "H_pos axiom, summary theorem combining H(k) > 0 and H(k)^{1/k} $\\to$ ∞. Status: OPEN."
     }


### PR DESCRIPTION
## Fix

Corrects two narrative errors in `src/data/proofs/erdos-190/meta.json` for Erdős Problem #190.

## Evidence

**Finding 1 — Reversed inequality (factual error)**

**Before**: `keyInsights[0]` claimed `"H(k) ≤ W(k)"` and `proofStrategy` listed it as an axiom.

**After**: The Lean file proves `theorem W_le_H (k : ℕ) (hk : k ≥ 3) : W k ≤ H k`. Direction is `W(k) ≤ H(k)`: 2-colorings can't produce rainbow k-APs (only 2 colors, need k ≥ 3). `keyInsights[0]` and `proofStrategy` now correctly state `W(k) ≤ H(k)` and note it is a proved theorem, not an axiom.

**Finding 2 — Section line drift (sections 5–10)**

**Before**: Sections 5–10 pointed into the middle of unrelated content (e.g., `van-der-waerden` claimed lines 120–140, but Part V marker is at line 159).

**After**: All 10 section line ranges updated to match the actual `## Part …` markers: Part I=41, II=55, III=84, IV=98, V=159, VI=234, VII=256, VIII=260, IX=279, X=299.

Closes #14641

---
Automated fix by lean-mechanic agent.