### PR TITLE
fix(meta): erdos-185 phantom small-value axiom narrative

### DIFF
--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -55,7 +55,7 @@
       "capSet_density_lt: density bound from DHJ",
       "f3_eventually_le: eventual bound on f3(n)",
       "meshulam_upper_bound axiom: f₃(n) ≤ 3^n/n",
-      "Small value axioms: f₃(1)=2, f₃(2)=4, f₃(3)=9, f₃(4)=20"
+      "Small value theorems: f₃(1)=2, f₃(2)=4, f₃(3)=9, f₃(4)=20 (proved, not axiomatized)"
     ],
     "axiomCount": 2,
     "prerequisites": [


### PR DESCRIPTION
## Summary

- `originalContributions` line in `src/data/proofs/erdos-185/meta.json` mislabels four small-value cap-set results as "Small value axioms" (`f₃(1)=2`, `f₃(2)=4`, `f₃(3)=9`, `f₃(4)=20`).
- The Lean source proves each as a **theorem**, not an axiom: `theorem f3_1` (line 514), `theorem f3_2` (line 651), `theorem f3_3` (line 739), `theorem f3_4` (line 788) in `proofs/Proofs/Erdos185Problem.lean`.
- The numerical fields are already correct — `axiomCount: 2`, `leanFile.axiomCount: 2`, and `assumptions: \"2 axioms: density_hales_jewett_k3, meshulam_upper_bound. 0 sorries.\"`. Only the narrative line in `originalContributions` was wrong.

## Evidence

```
$ grep -nE "^axiom " proofs/Proofs/Erdos185Problem.lean
314:axiom density_hales_jewett_k3 (δ : ℝ) (hδ : δ > 0) :
429:axiom meshulam_upper_bound (n : ℕ) (hn : n ≥ 1) :

$ grep -nE "^theorem f3_[1-4] " proofs/Proofs/Erdos185Problem.lean
514:theorem f3_1 : f3 1 = 2 := by
651:theorem f3_2 : f3 2 = 4 := by
739:theorem f3_3 : f3 3 = 9 := le_antisymm f3_3_le_9 f3_3_ge_9
788:theorem f3_4 : f3 4 = 20 := le_antisymm f3_4_le_20 f3_4_ge_20
```

## Fix

Replaced the entry with `\"Small value theorems: f₃(1)=2, f₃(2)=4, f₃(3)=9, f₃(4)=20 (proved, not axiomatized)\"`.

## Test plan

- [x] `axiomCount`, `leanFile.axiomCount`, and `assumptions` already correctly show 2 axioms (no changes needed)
- [x] Single-line edit, no Lean rebuild needed
- [x] Discovered during gallery integrity audit (erdos-185)

🤖 Generated with [Claude Code](https://claude.com/claude-code)