### PR TITLE
audit(tracker): erdos-185 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4966,10 +4966,14 @@
       "result": "issues-fixed"
     },
     "erdos-185": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T08:00:35Z",
+      "result": "issues-fixed",
+      "issues": [
+        "originalContributions called f3_1, f3_2, f3_3, f3_4 'Small value axioms' but they are theorems (proved). Numerical axiomCount: 2 was correct."
+      ],
+      "notes": "Fixed via PR #14654 — phantom small-value axiom narrative in originalContributions."
     },
     "erdos-186": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Mark erdos-185 audit complete (issues-fixed).

Phantom small-value axiom narrative in `originalContributions` was fixed via PR #14654 — `f3_1`/`f3_2`/`f3_3`/`f3_4` are theorems, not axioms.

Numerical fields (`axiomCount: 2`, `assumptions`, `leanFile.axiomCount: 2`) were already correct; only the single narrative line in `originalContributions` had drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)