### PR TITLE
audit(tracker): erdos-184 issues-found (#14662)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4964,9 +4964,9 @@
     },
     "erdos-184": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T08:16:14Z",
+      "result": "issues-found"
     },
     "erdos-185": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
Audit tracker update for erdos-184. Filed integrity issue #14662 for phantom axiom narrative claims:

- \`sections[known-bounds]\` claims to axiomatize Erdős–Gallai's $O(n\log n)$ bound, but only an orphaned docstring exists (no declaration).
- \`sections[non-disjoint]\` claims to axiomatize $\text{cov}(G) \le n-1$, but only \`coverNumber\` (the function symbol) is axiomatized.
- \`overview.proofStrategy\` lists both phantom bounds in its enumeration of axiomatized results.

Numerical fields (\`axiomCount: 5\`, \`sorries: 0\`, \`assumptions\`) are correct. The fix is purely narrative text in \`meta.json\`.

Discovered during periodic gallery integrity audit.