### PR TITLE
audit(tracker): erdos-178 issues-found (#14664)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4912,10 +4912,10 @@
       "result": "clean"
     },
     "erdos-178": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T08:24:53Z",
+      "result": "issues-found"
     },
     "erdos-179": {
       "auditCount": 2,


### PR DESCRIPTION
Mark erdos-178 as audited (3rd audit) with `issues-found` per #14664.

Findings: 2 real axioms (`beck_1981`, `beck_2017`) but narrative fields claim 3 more (`beck_uniform_bound`, Spencer, EGZ) and a "6 axioms" count. Numerical `axiomCount: 2` is correct; only the narrative needs reconciling. Same phantom-axiom narrative pattern as the rest of the erdos-1XX cluster.

Tracker-only change. No code or gallery edits in this PR; meta.json fix will be addressed via #14664.