### PR TITLE
audit(tracker): erdos-176 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4894,9 +4894,9 @@
       "result": "clean"
     },
     "erdos-176": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:18Z",
+      "lastAudited": "2026-05-02T08:37:29Z",
       "result": "clean"
     },
     "erdos-177": {


### PR DESCRIPTION
## Summary
- Auditor verified gallery integrity of erdos-176 (Discrepancy of Arithmetic Progressions, open problem)
- 3 axioms (`satisfiesNkl_exists`, `spencer_1973`, `alpha_c_exists`) match meta.json `axiomCount: 3`
- 0 sorries, 0 True stubs, no phantom declaration claims in `originalContributions`
- `assumptions` field correctly names all three axioms
- Status `axiomatized` + badge `axiom` consistent with open-problem nature

Marking tracker entry clean (auditCount 2 → 3).

## Test plan
- [x] meta.json claims vs Lean HEAD: axiom & sorry counts match
- [x] No phantom-axiom narrative in originalContributions / assumptions / proofStrategy
- [x] No True stubs or Mathlib wrapper false claims