### PR TITLE
research(ballot-oq-03-oq-01-oq-01-oq-01): ColStrictSym b=1 characterisation helpers (Session 16)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -424,6 +424,19 @@ private lemma colStrictSym_a_one_iff_phead_lt_qhead {n a : ℕ} (ha : 1 ≤ a)
     subst hjeq
     exact h
 
+/-- **Negation form of the b=1 column-strict characterisation.**
+
+    For `a ≥ 1` and `Q : Sym (Fin n) 1` with unique element `q = (Q.1.sort)[0]`,
+    `¬ColStrictSym a 1 P Q` iff `q ≤ (P.1.sort)[0]`. This is the precise condition
+    that the b=1 bijection forward map needs: when we form `q ::ₛ P`, the `q`
+    must be ≤ every element of `P` for the sortedness invariant to align. -/
+private lemma not_colStrictSym_a_one_iff_qhead_le_phead {n a : ℕ} (ha : 1 ≤ a)
+    (P : Sym (Fin n) a) (Q : Sym (Fin n) 1) :
+    ¬ ColStrictSym a 1 P Q ↔
+      (Q.1.sort (· ≤ ·))[0]'((Multiset.length_sort _ Q.1).trans Q.2 ▸ Nat.one_pos) ≤
+      (P.1.sort (· ≤ ·))[0]'((Multiset.length_sort _ P.1).trans P.2 ▸ ha) := by
+  rw [colStrictSym_a_one_iff_phead_lt_qhead ha P Q, not_lt]
+
 /-- **JDT weight sum, `b = 1` base case.**
     For `a ≥ 1`, the sum of weights over non-col-strict
     `(P : Sym (Fin n) a, Q : Sym (Fin n) 1)` pairs equals `h_{a+1} * h_0 = h_{a+1}`.

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -454,11 +454,19 @@ private lemma not_colStrictSym_a_one_iff_qhead_le_phead {n a : ℕ} (ha : 1 ≤ 
     `(q ::ₘ P.1).sort = q :: P.1.sort`, so `q` is the head of `(q ::ₛ P).1.sort`,
     making `Sym.erase` and `Sym.cons_erase`/`Sym.erase_cons_head` close the inverses.
 
-    **Status (2026-05-02 session 15):** the helper `sym_one_sort_head_singleton` and the
-    statement of this lemma are now in place. The bijection construction with weight
-    preservation proof is the focused `sorry` below; estimated 100-130 lines using
-    `Sym.cons_erase` (`Data/Sym/Basic.lean:219`), `Sym.erase_cons_head` (`:223`),
-    `Multiset.sort_cons` (`Data/Multiset/Sort.lean:69`). -/
+    **Status (2026-05-02 session 16):** infrastructure for the bijection is in place:
+      * `sym_one_sort_head_singleton` (S15) — extracts the unique q from Q : Sym n 1.
+      * `colStrictSym_a_one_iff_phead_lt_qhead` (S16) — `ColStrictSym a 1 P Q` reduces
+        to a single inequality `(P.sort)[0] < (Q.sort)[0]` for a ≥ 1.
+      * `not_colStrictSym_a_one_iff_qhead_le_phead` (S16) — negation form
+        `¬ColStrictSym ↔ q ≤ (P.sort)[0]` ready for direct use in the bijection.
+
+    The remaining `sorry` is the bijection construction itself with weight
+    preservation; estimated 80-100 lines using
+    `Sym.oneEquiv` (`Data/Sym/Basic.lean:477`), `Sym.cons_erase` (`:219`),
+    `Sym.erase_cons_head` (`:223`), `Multiset.sort_cons` (`Data/Multiset/Sort.lean:69`),
+    plus the existing `jdt_weight_preserved` (line 368) for the weight algebra at b=0.
+    Aristotle target: `BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean`. -/
 private lemma jdt_weight_sum_b_one (n a : ℕ) (ha : 1 ≤ a) :
     ∑ PQ : { PQ : Sym (Fin n) a × Sym (Fin n) 1 // ¬ColStrictSym a 1 PQ.1 PQ.2 },
       (PQ.1.1.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -392,6 +392,38 @@ private lemma sym_one_sort_head_singleton (n : ℕ) (Q : Sym (Fin n) 1) :
   rw [Multiset.sort_eq] at hcoe
   simpa using hcoe
 
+/-- **Characterisation of `ColStrictSym a 1 P Q` for `a ≥ 1`.**
+
+    With `a ≥ 1` we have `min a 1 = 1`, so `Fin (min a 1)` has the unique inhabitant `0`,
+    and the column-strict condition reduces to a single inequality on the head of each sort.
+    Combined with `sym_one_sort_head_singleton`, the right-hand side simplifies to
+    `(P.1.sort)[0] < q` where `q` is the unique element of `Q`.
+
+    **Use:** characterising the subtype `{(P, Q) // ¬ColStrictSym a 1 P Q}` as
+    `{(P, q) // q ≤ (P.1.sort)[0]}`, which the bijection in `jdt_weight_sum_b_one`
+    targets. The negation form `¬ColStrictSym ↔ q ≤ (P.1.sort)[0]` follows by
+    `not_lt`. -/
+private lemma colStrictSym_a_one_iff_phead_lt_qhead {n a : ℕ} (ha : 1 ≤ a)
+    (P : Sym (Fin n) a) (Q : Sym (Fin n) 1) :
+    ColStrictSym a 1 P Q ↔
+      (P.1.sort (· ≤ ·))[0]'((Multiset.length_sort _ P.1).trans P.2 ▸ ha) <
+      (Q.1.sort (· ≤ ·))[0]'((Multiset.length_sort _ Q.1).trans Q.2 ▸ Nat.one_pos) := by
+  unfold ColStrictSym
+  have hmin : min a 1 = 1 := Nat.min_eq_right ha
+  constructor
+  · intro h
+    -- Apply at the unique element of `Fin (min a 1) = Fin 1`
+    exact h ⟨0, hmin ▸ Nat.one_pos⟩
+  · intro h j
+    -- Every `j : Fin (min a 1)` has `j.val = 0`
+    have hj0 : j.val = 0 := by
+      have : j.val < min a 1 := j.isLt
+      omega
+    -- Cast `j` to `⟨0, _⟩` and reduce the indexing
+    have hjeq : j = ⟨0, hmin ▸ Nat.one_pos⟩ := Fin.ext hj0
+    subst hjeq
+    exact h
+
 /-- **JDT weight sum, `b = 1` base case.**
     For `a ≥ 1`, the sum of weights over non-col-strict
     `(P : Sym (Fin n) a, Q : Sym (Fin n) 1)` pairs equals `h_{a+1} * h_0 = h_{a+1}`.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -2,9 +2,68 @@
 
 **Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01
 **Last Updated**: 2026-05-02
-**Knowledge Items**: 38
+**Knowledge Items**: 39
 
 Insights accumulated during research on this problem.
+
+---
+
+## Session 2026-05-02 (Session 16) — ColStrictSym b=1 characterisation helpers
+
+**Mode**: REVISIT (RICH knowledge tier, score 80 → 82)
+**Outcome**: progress — two helpers added that reduce the residual bijection
+estimate from 100-130 lines to 80-100 lines
+
+### What I Did
+
+1. **Proved `colStrictSym_a_one_iff_phead_lt_qhead`**
+   (`BallotProblemOQ03OQ01OQ01OQ01.lean:406`):
+   For `a ≥ 1`, `min a 1 = 1`, so the universal quantifier over `Fin (min a 1)`
+   inside `ColStrictSym a 1 P Q` reduces to a single inequality on the head of
+   each sort. ~20-line proof: `unfold ColStrictSym`, then `Fin.ext` on the
+   forced index value `j.val = 0`.
+
+2. **Proved `not_colStrictSym_a_one_iff_qhead_le_phead`**
+   (`BallotProblemOQ03OQ01OQ01OQ01.lean:421`):
+   Negation-form companion: `¬ColStrictSym ↔ (Q.sort)[0] ≤ (P.sort)[0]`.
+   Trivial 1-line proof on top of the previous lemma via `not_lt`.
+
+3. **Updated `jdt_weight_sum_b_one` docstring** to inventory the helpers
+   and reorient the residual sorry estimate (now 80-100 lines using
+   `Sym.oneEquiv` + characterisation helpers, down from 100-130).
+
+### Key Findings
+
+- The condition `¬ColStrictSym a 1 P Q` (with `a ≥ 1`) is *exactly*
+  `q ≤ (P.sort)[0]` where `q` is the unique element of Q. This is the
+  precondition the b=1 bijection forward map `(P, q) ↦ q ::ₛ P` needs to
+  ensure that `q ::ₘ P.1` re-sorts to `q :: P.1.sort` (q is the new min).
+
+- `Sym.oneEquiv : α ≃ Sym α 1` lives at `Mathlib.Data.Sym.Basic:477`
+  (verified via the existing Aristotle target file's preflight notes).
+  The bijection chain is therefore:
+  `{ (P, Q) // ¬CS } ≃ { (P, q) // q ≤ (P.sort)[0] } ≃ Sym (Fin n) (a+1)`,
+  with the first step provided by `Sym.oneEquiv` + characterisation, and the
+  second step by `Sym.cons_erase`/`Sym.erase_cons_head` + `Multiset.sort_cons`.
+
+- Build verification deferred: Docker daemon was hung during the session
+  (other agent's `BinaryGcdOQ03OQ02` build stuck since 04:57 AM, ≈5+ hours).
+  CI will verify the helpers compile.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (715 → 728 lines net)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/{knowledge.md, state.md}`
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`
+
+### Next Steps
+
+1. Implement the bijection in `jdt_weight_sum_b_one` (~80-100 lines) using
+   `Sym.oneEquiv` to convert Q ↔ Fin n, then the characterisation helpers,
+   then `Sym.cons_erase` + `Multiset.sort_cons` for the inverses.
+2. Alternative: submit `BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean` to
+   Aristotle now that the characterisation helpers are in place.
+3. Then tackle `jdt_weight_sum` b ≥ 2 (the seam algorithm, ~150-200 lines).
 
 ---
 

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -5,12 +5,13 @@
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
 **Last Updated**: 2026-05-02
-**Iteration**: 15
+**Iteration**: 16
 
 ## Current Focus
 
-Proving `jdt_weight_sum_b_one` — the `b = 1` base case of `jdt_weight_sum`,
-extracted as a focused subproblem in Session 15.
+Proving `jdt_weight_sum_b_one` — the `b = 1` base case of `jdt_weight_sum`.
+Session 16 added two characterisation helpers; the residual bijection
+construction is the only remaining sub-task.
 
 ## Active Approach
 
@@ -19,28 +20,42 @@ Build the bijection
 - forward: `(P, Q, _) ↦ q ::ₛ P`, where `q` is the unique element of `Q`
 - inverse: `S ↦ ((S.erase qS hS, ⟨{qS}, _⟩), _)`, where `qS = (S.1.sort)[0]`
 
-Helper `sym_one_sort_head_singleton` (proved Session 15) extracts `q` cleanly.
-Estimated 100-130 lines for the full bijection.
+Helpers in place:
+- `sym_one_sort_head_singleton` (S15): extracts `q` from `Q : Sym (Fin n) 1`
+- `colStrictSym_a_one_iff_phead_lt_qhead` (S16): characterises ColStrictSym
+  at b=1 as a single inequality `(P.sort)[0] < (Q.sort)[0]`
+- `not_colStrictSym_a_one_iff_qhead_le_phead` (S16): negation form
+  `q ≤ (P.sort)[0]` ready for direct use in the bijection
+
+Estimated 80-100 lines for the residual bijection (down from 100-130 with
+the characterisation in hand).
 
 ## Attempt Count
-- Total attempts: 15 (sessions 1-15)
-- Current approach attempts: 1 (jdt_weight_sum_b_one decomposition, Session 15)
+- Total attempts: 16 (sessions 1-16)
+- Current approach attempts: 2 (jdt_weight_sum_b_one decomposition,
+  Session 15 + characterisation helpers, Session 16)
 - Approaches tried:
   1. SSYT infrastructure approach (sessions 1-14): defined `SSYTFin`, proved
      k=0, k=1, k=2 (modulo `jdt_weight_sum`); `jdt_weight_sum` b ≥ 1 was stuck.
   2. Decompose `jdt_weight_sum` b ≥ 1 (session 15): split into b=1 helper +
      b ≥ 2 sorry. b=1 is now focused.
+  3. Characterise ColStrictSym at b=1 (session 16): two helpers reduce the
+     subtype predicate to a single inequality, simplifying the bijection.
 
 ## Blockers
 
-- Pre-existing build failure in `BallotProblemOQ03OQ02.lean` (upstream dependency)
-  may prevent Docker build verification. Not caused by our changes.
+- Docker daemon hung during S16 (other agent's `BinaryGcdOQ03OQ02` build
+  has been running since 04:57 AM, apparently stuck). Build verification
+  deferred to CI.
 
 ## Next Action
 
-1. Implement the bijection in `jdt_weight_sum_b_one` (the sorry at line ~426).
-   Use `sym_one_sort_head_singleton` for the Q-side decomposition.
-2. After b=1 closes: tackle `jdt_weight_sum` b ≥ 2 (the seam algorithm,
+1. Implement the bijection in `jdt_weight_sum_b_one` (the sorry at
+   line ~466). Use `Sym.oneEquiv` to convert Q to Fin n, then the
+   characterisation helpers, then the cons/erase chain.
+2. Alternative: submit `BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean`
+   to Aristotle now that the characterisation helpers are in place.
+3. After b=1 closes: tackle `jdt_weight_sum` b ≥ 2 (the seam algorithm,
    ~150-200 lines).
-3. After `jdt_weight_sum` closes: `jacobi_trudi_ssyt_eq` k=2 is proved
+4. After `jdt_weight_sum` closes: `jacobi_trudi_ssyt_eq` k=2 is proved
    (only k ≥ 3 RSK/LGV remains).

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 15 (2026-05-02): Architectural progress on jdt_weight_sum. Added proved helper sym_one_sort_head_singleton (Sym(α)1 → ∃ q. sort = [q]). Decomposed b ≥ 1 sorry into named b = 1 helper (sorry, with detailed bijection recipe in docstring) + b ≥ 2 (still sorry). The b = 1 case now has clean signature: jdt_weight_sum_b_one (n a : ℕ) (ha : 1 ≤ a) → ∑_{¬ColStrict} = hsymm (a+1) * hsymm 0. PR #14XXX (research label, deployer auto-merge). File grew 714 → 715 lines net (+44 helper, -43 long comment block).",
+    "progressSummary": "Session 16: Added two characterisation helpers (colStrictSym_a_one_iff_phead_lt_qhead and its negation form). The subtype condition ¬ColStrictSym a 1 P Q now has a clean reformulation as q ≤ (P.sort)[0], reducing the residual bijection sorry estimate from 100-130 lines to 80-100 lines. Sorry count unchanged (jdt_weight_sum_b_one still has 1 sorry; jdt_weight_sum b ≥ 2 still has 1 sorry).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -70,7 +70,9 @@
       "jdt_weight_preserved (PROVED): multiplicative weight identity for JDT bijection step — moving v from Q (size b+1) to P (size a) preserves total weight; proof via Multiset.cons_erase + prod_cons (~10 lines)",
       "BallotProblemOQ03OQ01OQ01OQ01.lean: sym_one_sort_head_singleton (line ~384, proved, 6 lines) — extracts unique element of Sym (Fin n) 1 with sort and multiset equations.",
       "BallotProblemOQ03OQ01OQ01OQ01.lean: jdt_weight_sum_b_one (line ~399, stated, body = sorry) — b=1 base case, signature returns hsymm (a+1) * hsymm 0.",
-      "BallotProblemOQ03OQ01OQ01OQ01.lean: jdt_weight_sum dispatches on b = 1 (calls helper) vs b ≥ 2 (original seam bijection sorry)."
+      "BallotProblemOQ03OQ01OQ01OQ01.lean: jdt_weight_sum dispatches on b = 1 (calls helper) vs b ≥ 2 (original seam bijection sorry).",
+      "colStrictSym_a_one_iff_phead_lt_qhead (BallotProblemOQ03OQ01OQ01OQ01.lean:406): characterise ColStrictSym at b=1 as a single inequality (P.sort)[0] < (Q.sort)[0]",
+      "not_colStrictSym_a_one_iff_qhead_le_phead (BallotProblemOQ03OQ01OQ01OQ01.lean:421): negation form q ≤ (P.sort)[0] for direct use in the bijection"
     ],
     "insights": [
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
@@ -110,7 +112,8 @@
       "Sym.uniqueZero gives Unique (Sym α 0) (Mathlib Sym/Basic.lean:261), so reducing RHS via '← sum_all_sym_pairs n (a+1) 0' is equivalent to a Sym (Fin n) (a+1) sum after collapsing the trivial Sym (Fin n) 0 factor — both routes (hsymm_zero rewrite, or sum_all_sym_pairs reduction with Unique handling) are open.",
       "jdt_weight_preserved isolates the algebraic core of JDT bijection: weight preservation does not depend on the combinatorics of choosing v=Q.sort[firstViolIdx], only on v ∈ Q. Future bijection proof can apply Fintype.sum_equiv and reuse this lemma.",
       "Session 15 (2026-05-02): Decomposed jdt_weight_sum b ≥ 1 case into b = 1 (jdt_weight_sum_b_one helper, with sorry on bijection) + b ≥ 2 (still sorry, the genuine JDT seam). Sorry count went 1 → 2 in jdt_weight_sum, but the b = 1 base is now an explicit sub-problem with named statement matching the recipe.",
-      "Session 15: Proved sym_one_sort_head_singleton: for Q : Sym (Fin n) 1, ∃ q. Q.1.sort = [q] ∧ Q.1 = {q}. Reusable infrastructure for Sym/Multiset proofs (List.length_eq_one_iff + Multiset.sort_eq, ~6 lines). Will be used when filling in the jdt_weight_sum_b_one bijection."
+      "Session 15: Proved sym_one_sort_head_singleton: for Q : Sym (Fin n) 1, ∃ q. Q.1.sort = [q] ∧ Q.1 = {q}. Reusable infrastructure for Sym/Multiset proofs (List.length_eq_one_iff + Multiset.sort_eq, ~6 lines). Will be used when filling in the jdt_weight_sum_b_one bijection.",
+      "Session 16: With a ≥ 1, min a 1 = 1, so ColStrictSym a 1 P Q reduces to a single inequality on the head of each sort. The negation form ¬ColStrictSym ↔ q ≤ (P.sort)[0] is exactly the precondition the b=1 bijection forward map (P, q) ↦ q ::ₛ P needs to align the sortedness invariant."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -118,10 +121,10 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "Implement the bijection ψ : { (P, Q) : Sym a × Sym 1 // ¬ColStrictSym a 1 P Q } ≃ Sym (Fin n) (a+1) inside jdt_weight_sum_b_one. Use sym_one_sort_head_singleton to extract q from Q cleanly. Forward: q ::ₛ P. Inverse: head-of-sort + erase. ~100-130 lines.",
-      "Key obstacles for the bijection: (1) inverse output ¬ColStrict witness needs (S.erase q).sort[0] ≥ q via Multiset.erase_le + sortedness; (2) left_inv P-component via Sym.erase_cons_head once head-of-(cons q P).sort = q is computed via Multiset.sort_cons.",
-      "After b=1 lands: tackle b ≥ 2 (genuine JDT seam algorithm, ~150-200 lines).",
-      "If bijection construction stalls 2+ sessions, consider proving via Sym.oneEquiv-based reformulation: { (P, q) : Sym a × Fin n // q ≤ P.sort[0] } ≃ Sym (a+1)."
+      "Implement b_one_equiv : { (P, Q) // ¬ColStrictSym a 1 P Q } ≃ Sym (Fin n) (a+1) using Sym.oneEquiv (chain via Fin n) and Sym.cons_erase / Sym.erase_cons_head; ~80 lines.",
+      "Apply the equivalence in jdt_weight_sum_b_one via Fintype.sum_equiv with weight preservation by jdt_weight_preserved (b=0 specialisation).",
+      "After b=1 closes: tackle jdt_weight_sum b ≥ 2 (the seam algorithm, ~150-200 lines).",
+      "Consider submitting BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean to Aristotle now that the characterisation helpers are in place — the bijection construction is the only remaining sub-goal."
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n",
     "insightsCount": 38,


### PR DESCRIPTION
## Summary

Session 16 progress on `ballot-problem-oq-03-oq-01-oq-01-oq-01` (Jacobi-Trudi via SSYT).
Adds two characterisation helpers that simplify the residual bijection in
`jdt_weight_sum_b_one`.

- `colStrictSym_a_one_iff_phead_lt_qhead` — for `a ≥ 1`, `min a 1 = 1`, so
  `ColStrictSym a 1 P Q` reduces to a single inequality on the head of each sort.
- `not_colStrictSym_a_one_iff_qhead_le_phead` — negation form
  `¬ColStrictSym ↔ q ≤ (P.sort)[0]`, the precise precondition the b=1
  bijection forward map needs.

The subtype `{ (P, Q) // ¬ColStrictSym a 1 P Q }` now has a clean reformulation
as `q ≤ (P.sort)[0]`, reducing the residual bijection sorry estimate from
100-130 lines to 80-100 lines.

## What changed

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (715 → 728 lines net)
- Knowledge files: `knowledge.md` (Session 16 entry), `state.md` (iteration
  15 → 16, active-approach refresh), `knowledge.json`
  (insights/builtItems/nextSteps + progressSummary).
- Pool note refresh.

## Honest assessment

Modest progress. Sorry count unchanged (still 1 in `jdt_weight_sum_b_one` and
1 in `jdt_weight_sum` b ≥ 2). The two helpers are real proved infrastructure
that the bijection construction will rely on for direction analysis, but the
bijection itself is the next concrete step.

## Build verification

Docker daemon was hung during this session (other agent's
`BinaryGcdOQ03OQ02` build stuck since 04:57 AM). Build verification deferred
to CI. Likely-fragile points to look at on review:

1. The `subst hjeq` step in `colStrictSym_a_one_iff_phead_lt_qhead` —
   relies on definitional reduction of `(⟨0, _⟩ : Fin (min a 1)).val` to `0`
   plus proof-irrelevance for the bound proofs in `(_)[0]'_`.
2. The `▸` rewrites in the iff statement's bound proofs
   (`(Multiset.length_sort _ P.1).trans P.2 ▸ ha`).

If CI build fails, doctor agent fixes.

## Test plan

- [ ] `pnpm build` succeeds
- [ ] CI verifies Lean compilation of the helpers
- [ ] No regressions in dependent files

🤖 Generated with [Claude Code](https://claude.com/claude-code)