### PR TITLE
audit(tracker): erdos-174 issues-found (#14671)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4882,10 +4882,12 @@
       "result": "clean"
     },
     "erdos-174": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "section line drift in 5/9 sections (Parts V-IX); known-ramsey endLine 160→158, examples 161-187→159-178, non-ramsey 188-206→179-197, characterization 207-221→198-212, summary 222-247→213-247; not_spherical_not_ramsey at L182 falls outside its claimed section by line; counts/axioms/narrative all accurate (#14671)"
+      ],
+      "lastAudited": "2026-05-02T08:42:30Z",
+      "result": "issues-found"
     },
     "erdos-175": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- Marks erdos-174 audit complete with `issues-found`
- Issue filed: #14671 (section line drift in Parts V-IX)
- Counts, axioms, narrative claims all verified correct

## Issue Details

Section `startLine`/`endLine` ranges drift from actual Lean source line numbers starting at Part V. Most visible: `not_spherical_not_ramsey` at L182 falls outside its claimed `non-ramsey` section (188-206) by line.

What's correct: axiomCount=5, sorries=0, theoremCount=5, definitionCount=18, lineCount=247, status/badge, all 5 axiom names, originalContributions claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)