### PR TITLE
audit(tracker): erdos-168 issues-found (#14675)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4840,10 +4840,13 @@
       "result": "issues-fixed"
     },
     "erdos-168": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T09:00:00Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom 0.5564 axiom claim in originalContributions; better_construction missing from proofStrategy (issue #14675)"
+      ]
     },
     "erdos-169": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- Mark erdos-168 audit complete with `issues-found` result
- References issue #14675

## Findings

- meta.json `originalContributions[5]` claims an axiom of "numerical approximation ≈ 0.5564"; the actual second axiom (`better_construction`) gives a 0.55N density bound. 0.5564 appears only in docstrings.
- meta.json `proofStrategy` enumerates 8 steps and mentions only 1 of the 2 axioms (`gsw_limit_exists`); `better_construction` is omitted.

Counts (axiomCount=2, sorries=0) and status (`axiomatized`/`axiom`) are accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)