### PR TITLE
fix(meta): erdos-174 section line drift in second half of file

### DIFF
--- a/src/data/proofs/erdos-174/meta.json
+++ b/src/data/proofs/erdos-174/meta.json
@@ -137,38 +137,38 @@
       "title": "Known Ramsey Sets",
       "summary": "Rectangles, simplices, trapezoids, regular polygons",
       "startLine": 115,
-      "endLine": 160,
+      "endLine": 158,
       "mathContext": "Mathematical content: Rectangles, simplices, trapezoids, regular polygons"
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "twoPoints, equilateralTriangle, square",
-      "startLine": 161,
-      "endLine": 187,
+      "startLine": 159,
+      "endLine": 178,
       "mathContext": "Mathematical content: twoPoints, equilateralTriangle, square"
     },
     {
       "id": "non-ramsey",
       "title": "Non-Ramsey Sets",
       "summary": "not_spherical_not_ramsey, collinearFour, collinear_not_ramsey",
-      "startLine": 188,
-      "endLine": 206,
+      "startLine": 179,
+      "endLine": 197,
       "mathContext": "Mathematical content: not_spherical_not_ramsey, collinearFour, collinear_not_ramsey"
     },
     {
       "id": "characterization",
       "title": "The Characterization Problem",
       "summary": "erdos_174_question, characterization_exists",
-      "startLine": 207,
-      "endLine": 221,
+      "startLine": 198,
+      "endLine": 212,
       "mathContext": "Mathematical content: erdos_174_question, characterization_exists"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_174 and erdos_174_summary theorems",
-      "startLine": 222,
+      "startLine": 213,
       "endLine": 247,
       "mathContext": "Verified: erdos_174 and erdos_174_summary theorems"
     }


### PR DESCRIPTION
## Fix

Correct five drifted section `startLine`/`endLine` values in erdos-174 meta.json. Parts I–IV were accurate; Parts V–IX drifted by 2–18 lines each.

## Evidence

Verified against `proofs/Proofs/Erdos174Problem.lean` at `origin/main`.

| Section | claimed start | actual start | claimed end | actual end |
|---|---|---|---|---|
| known-ramsey | 115 ✓ | 115 | 160 ❌ | **158** |
| examples | 161 ❌ | **159** | 187 ❌ | **178** |
| non-ramsey | 188 ❌ | **179** | 206 ❌ | **197** |
| characterization | 207 ❌ | **198** | 221 ❌ | **212** |
| summary | 222 ❌ | **213** | 247 ✓ | 247 |

**Concrete consequence before fix**: `theorem not_spherical_not_ramsey` at L182 fell inside the claimed range of `examples` (161–187) rather than `non-ramsey`.

Closes #14671

---
Automated fix by lean-mechanic agent.