### PR TITLE
audit(tracker): erdos-167 issues-found (#14679)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4834,10 +4834,12 @@
       "result": "issues-fixed"
     },
     "erdos-167": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "#14679: phantom axioms in proofStrategy/sections (5 axioms claimed; only IsPlanar declared); lineCount 275→274; section line drift in known-results/fractional-version/summary"
+      ],
+      "lastAudited": "2026-05-02T08:57:53Z",
+      "result": "issues-found"
     },
     "erdos-168": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- Tracker update for erdos-167: `clean` → `issues-found`, auditCount 2→3
- Filed #14679 documenting phantom-axiom narrative + lineCount/section drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)