### PR TITLE
fix(meta): erdos-168 phantom 0.5564 axiom claim + add better_construction to proofStrategy

### DIFF
--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -51,7 +51,7 @@
       "Proved: density_bounded (0 \u2264 F(N)/N \u2264 1)",
       "Proved: F_monotone (F(N) \u2264 F(N+1))",
       "Proved: simple_lower_bound (F(N) \u2265 2N/3 - 1)",
-      "Axiomatized GSW limit theorem and numerical approximation \u2248 0.5564",
+      "Axiomatized GSW limit theorem (`gsw_limit_exists`) and the 0.55N density lower bound (`better_construction`)",
       "Formalized the irrationality question"
     ],
     "axiomCount": 2,
@@ -62,7 +62,7 @@
     "historicalContext": "This problem concerns the maximum size of subsets avoiding 'ternary' arithmetic progressions of the form {n, 2n, 3n}. Graham, Spencer, and Witsenhausen (1977) proved the limit lim F(N)/N exists and gave a formula involving 3-smooth numbers.\n\nThe 3-smooth numbers are numbers of the form 2^a \u00b7 3^b: 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, ...\n\nThe limit formula is L = (1/3) \u00b7 \u03a3_{k \u2208 K} 1/d_k where d_1 < d_2 < ... are the 3-smooth numbers and K is determined by a greedy algorithm.\n\nEberhard computed the numerical value as approximately 0.5564. Erd\u0151s asked whether this limit is irrational\u2014this remains open.",
     "problemStatement": "**Question**: Let $F(N)$ be the maximum size of a subset of $\\{1, \\ldots, N\\}$ containing no triple $\\{n, 2n, 3n\\}$. \n\n(i) What is $\\lim_{N \\to \\infty} F(N)/N$?\n\n(ii) Is this limit irrational?\n\n**Answers**:\n- (i) The limit exists (GSW 1977) and equals approximately **0.5564**\n- (ii) **OPEN** - irrationality is not known\n\n**Lower bound**: $F(N) \\geq 2N/3 - 1$ (remove all multiples of 3)",
     "text": "Let F(N) be the maximum size of a subset of {1,...,N} avoiding {n, 2n, 3n} triples. What is lim F(N)/N? Is it irrational?",
-    "proofStrategy": "We formalize the problem and known results:\n\n1. **ContainsTriple**: A set contains some {n, 2n, 3n}\n2. **IsTripleFree**: A set avoids all such triples\n3. **F(N)**: Maximum cardinality of triple-free subsets of {1,...,N}\n4. **density_bounded**: Prove 0 \u2264 F(N)/N \u2264 1\n5. **F_monotone**: Prove F(N) \u2264 F(N+1)\n6. **simple_lower_bound**: Prove F(N) \u2265 2N/3 - 1\n7. **gsw_limit_exists**: Axiomatize that the limit exists\n8. **IrrationalityQuestion**: Formalize the open irrationality question",
+    "proofStrategy": "We formalize the problem and known results:\n\n1. **ContainsTriple**: A set contains some {n, 2n, 3n}\n2. **IsTripleFree**: A set avoids all such triples\n3. **F(N)**: Maximum cardinality of triple-free subsets of {1,...,N}\n4. **density_bounded**: Prove 0 \u2264 F(N)/N \u2264 1\n5. **F_monotone**: Prove F(N) \u2264 F(N+1)\n6. **simple_lower_bound**: Prove F(N) \u2265 2N/3 - 1\n7. **better_construction**: Axiomatize the existence of a triple-free subset of {1,...,N} with cardinality \u2265 0.55N (the known better construction; \u22480.5564 appears only in docstrings)\n8. **gsw_limit_exists**: Axiomatize that the limit exists\n9. **IrrationalityQuestion**: Formalize the open irrationality question",
     "keyInsights": [
       "**{n, 2n, 3n} triples**: These are 'multiplicative' arithmetic progressions with ratio 2, not additive.",
       "**Simple construction**: Removing multiples of 3 gives a triple-free set of size \u2248 2N/3.",


### PR DESCRIPTION
## Fix

Two issues in erdos-168 meta.json narrative fields.

### 1. Phantom 0.5564 axiom in originalContributions

The Lean file has 2 axioms: `gsw_limit_exists` and `better_construction` (0.55N bound). The value ≈0.5564 appears only in docstrings/comments (Eberhard's computation) — not axiomatized.

**Before**: `"Axiomatized GSW limit theorem and numerical approximation ≈ 0.5564"`
**After**: `"Axiomatized GSW limit theorem ('gsw_limit_exists') and the 0.55N density lower bound ('better_construction')"`

### 2. Missing better_construction in proofStrategy

The strategy narrative enumerated 8 steps but mentioned only `gsw_limit_exists` (step 7); `better_construction` was omitted.

Added step 7: `better_construction` — Axiomatize the existence of a triple-free subset with ≥ 0.55N cardinality; note that ≈0.5564 appears only in docstrings.

Renumbered: old step 7 → step 8, old step 8 → step 9.

Closes #14675

---
Automated fix by lean-mechanic agent.