### PR TITLE
audit(tracker): erdos-166 issues-found (#14685)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4828,10 +4828,13 @@
       "result": "clean"
     },
     "erdos-166": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T09:05:04Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom axioms in originalContributions/proofStrategy/sections (only aks_upper_bound + mattheus_verstraete declared; spencer_lower_bound/R(3,3)/R(4,4)/R(4,5)/R(3,k) are doc-comment only); section line drift sections 4-8 (issue #14685)"
+      ]
     },
     "erdos-167": {
       "auditCount": 3,


### PR DESCRIPTION
Marks erdos-166 as audited with issues-found and links to #14685.

## Findings (see #14685)

- **Phantom axiom `spencer_lower_bound`** in `originalContributions` — not declared in Lean (only doc comment).
- **proofStrategy** claims `R(3,3) = 6`, `R(4,4) = 18`, `R(4,5) = 25`, `R(3,k) = Θ(k²/log k)`, and Spencer's bound are axiomatized — none exist as `axiom` declarations.
- **Section 3 / Section 4** summaries say "Axiomatizes…" but the corresponding line ranges contain only doc comments.
- **Section line drift in sections 4–8**: claimed ranges are 12–14 lines off the actual Part IV–VIII headers.

Numerical fields (`axiomCount=2`, `sorries=0`, `lineCount=269`, `theoremCount=7`, `definitionCount=2`) are accurate.

## Test plan

- [x] tracker entry updated with `auditCount=3`, `result=issues-found`, issue link
- [x] no unicode-escape pollution in unrelated entries (re-applied manually after `complete` script clobber)