### PR TITLE
audit(tracker): erdos-161 issues-found (#14687)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4798,10 +4798,12 @@
       "result": "clean"
     },
     "erdos-161": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "Phantom axioms in originalContributions (erdos_hajnal_rado_conjecture, conlon_fox_sudakov_upper); section line drift (sections 3-8); phantom proofStrategy/section content"
+      ],
+      "lastAudited": "2026-05-02T09:25:00Z",
+      "result": "issues-found"
     },
     "erdos-162": {
       "auditCount": 2,


### PR DESCRIPTION
Marks erdos-161 audit as `issues-found` with reference to #14687.

## Issues found
- Phantom axioms `erdos_hajnal_rado_conjecture` and `conlon_fox_sudakov_upper` listed in `originalContributions` — only docstring mentions, no actual axiom declarations
- Section line drift in sections 3-8 (claimed ranges shift by 6-15 lines from actual)
- Phantom content in `proofStrategy` and several section `summary`/`mathContext` fields
- `axiomCount: 4`, `sorries: 0`, `lineCount: 158` are numerically correct

See #14687 for the full breakdown and recommended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)