### PR TITLE
audit(tracker): erdos-162 issues-found (#14689)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4804,10 +4804,12 @@
       "result": "issues-fixed"
     },
     "erdos-162": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "#14689: stale 'sorry' narrative claims for colourEdgeCount_total/balanced_requires_le_half + 214→237 lineCount drift in historicalContext/conclusion (file has 0 sorries, 237 lines)"
+      ],
+      "lastAudited": "2026-05-02T09:14:15Z",
+      "result": "issues-found"
     },
     "erdos-163": {
       "auditCount": 2,


### PR DESCRIPTION
Marks erdos-162 as audited 2026-05-02 with issue #14689: stale 1-sorry narrative + 214→237 lineCount drift. Lean source on origin/main has 0 sorries and 237 lines; numerical fields are correct, only narrative copy is wrong.