### PR TITLE
audit(tracker): erdos-154 issues-found (#14695)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4748,10 +4748,10 @@
       "result": "clean"
     },
     "erdos-154": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T09:32:37Z",
+      "result": "issues-found"
     },
     "erdos-155": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Records audit result for `erdos-154` in `audit-tracker.json`:
- `auditCount`: 2 → 3
- `result`: `issues-fixed` → `issues-found`
- `lastAudited`: 2026-05-02T09:32:37Z

## Issue filed

#14695 — Gallery integrity: erdos-154 phantom `lindstrom_sidon_distribution` axiom in originalContributions/proofStrategy

The `meta.json` narrative fields claim a `lindstrom_sidon_distribution` axiom exists, but the Lean file only declares `sumset_distribution`. Numerical accounting (`axiomCount: 1`, `assumptions`, `sorries`, `lineCount`, `status`, `badge`, sections) is correct — only the `meta.originalContributions` list and `overview.proofStrategy` step 4 need reconciliation.

## Test plan

- [x] Diff is exactly 3-line tracker patch (no unicode-escape pollution)
- [x] Issue #14695 references the same auditCount/result transition