### PR TITLE
audit(tracker): erdos-150 issues-found (#14699)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4718,10 +4718,10 @@
       "result": "clean"
     },
     "erdos-150": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T09:39:01Z",
+      "result": "issues-found"
     },
     "erdos-151": {
       "auditCount": 2,


### PR DESCRIPTION
Tracker update for [#14699](https://github.com/rjwalters/lean-genius/issues/14699). Bumps `auditCount` to 3 and flips result to `issues-found` for `erdos-150` after detecting section line drift in `meta.json`.

## Summary
- Marks erdos-150 as audited 2026-05-02 with `issues-found`
- See #14699 for the underlying integrity issue (section startLine/endLine drift)

## Test plan
- [x] Single-entry tracker change, no other modifications
- [x] No Lean source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)