### PR TITLE
fix(meta): erdos-166 phantom axioms + section line drift

### DIFF
--- a/src/data/proofs/erdos-166/meta.json
+++ b/src/data/proofs/erdos-166/meta.json
@@ -61,7 +61,6 @@
       "ramsey_symmetric: Verified proof R(s,t) = R(t,s) via color complementation",
       "ramsey_one_left: Verified proof R(1,t) = 1 by singleton witness construction",
       "ramsey_two_left: Verified proof R(2,t) = t via edge-case analysis and le_antisymm",
-      "spencer_lower_bound: Axiom encoding Spencer's 1977 probabilistic bound (k log k)^{5/2}",
       "aks_upper_bound: Axiom encoding AKS 1980 greedy coloring bound k\u00b3/(log k)\u00b2",
       "mattheus_verstraete: Axiom encoding the 2023 solution k\u00b3/(log k)\u2074",
       "Erdos166Statement: Formal problem statement as existential over constants",
@@ -79,7 +78,7 @@
     "historicalContext": "Erd\u0151s offered $250 for proving that $R(4,k)$ grows like $k^3$ up to polylogarithmic factors. Spencer (1977) gave the first non-trivial lower bound $R(4,k) \\geq c(k \\log k)^{5/2}$ using the probabilistic method with dependent random choices. Ajtai, Koml\u00f3s, and Szemer\u00e9di (1980) established the complementary upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ using a greedy algorithm, confirming that $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$ for some $\\alpha$. For 43 years, closing this gap\u2014improving the lower bound exponent from $5/2$ on $(k\\log k)$ to cubic in $k$\u2014resisted all probabilistic approaches. The breakthrough came in 2023 when Sam Mattheus and Jacques Verstraete proved $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry: $K_4$-free graphs built from incidence structures of classical polar spaces over $\\mathbb{F}_q$. This earned them the $250 Erd\u0151s prize and demonstrated that algebraic methods can succeed where probabilistic ones plateau.",
     "problemStatement": "Prove that $R(4,k) \\gg k^3/(\\log k)^{O(1)}$, where $R(4,k)$ is the Ramsey number representing the minimum $N$ such that any 2-coloring of $K_N$ contains either a monochromatic $K_4$ or a monochromatic $K_k$.",
     "text": "Prove that R(4,k) >> k\u00b3/(log k)^O(1). SOLVED by Mattheus-Verstraete (2023): R(4,k) >> k\u00b3/(log k)\u2074, earning the $250 Erd\u0151s prize.",
-    "proofStrategy": "The formalization defines $R(s,t)$ as $\\inf\\{N : \\forall c : \\text{Sym2}(\\text{Fin}\\,N) \\to \\text{Bool},\\, \\exists K_s^{\\text{red}} \\lor K_t^{\\text{blue}}\\}$ and verifies fundamental properties from scratch: symmetry via color complementation, $R(1,t) = 1$ by singleton witness, and $R(2,t) = t$ by a detailed $\\text{le\\_antisymm}$ argument with edge-case analysis. Known exact values ($R(3,3) = 6$, $R(4,4) = 18$, $R(4,5) = 25$) and asymptotic bounds ($R(3,k) = \\Theta(k^2/\\log k)$) are axiomatized. The historical bounds\u2014Spencer's $(k \\log k)^{5/2}$, AKS's $k^3/(\\log k)^2$, and Mattheus-Verstraete's $k^3/(\\log k)^4$\u2014are axiomatized and combined into the resolution `erdos_166_solved` (instantiating $A = 4$), a sandwich `current_bounds`, and a `logarithmic_gap` analysis showing $2 \\leq \\alpha \\leq 4$.",
+    "proofStrategy": "The formalization defines $R(s,t)$ as $\\inf\\{N : \\forall c : \\text{Sym2}(\\text{Fin}\\,N) \\to \\text{Bool},\\, \\exists K_s^{\\text{red}} \\lor K_t^{\\text{blue}}\\}$ and verifies fundamental properties from scratch: symmetry via color complementation, $R(1,t) = 1$ by singleton witness, and $R(2,t) = t$ by a detailed $\\text{le\\_antisymm}$ argument with edge-case analysis. Known exact values ($R(3,3) = 6$, $R(4,4) = 18$, $R(4,5) = 25$), asymptotic bounds ($R(3,k) = \\Theta(k^2/\\log k)$), and Spencer's $(k \\log k)^{5/2}$ lower bound are documented in narrative comments (not axiomatized). Only AKS's $k^3/(\\log k)^2$ upper bound and Mattheus-Verstraete's $k^3/(\\log k)^4$ lower bound are axiomatized. These two axioms are combined into the resolution `erdos_166_solved` (instantiating $A = 4$), a sandwich `current_bounds`, and a `logarithmic_gap` analysis showing $2 \\leq \\alpha \\leq 4$.",
     "keyInsights": [
       "**Ramsey numbers $R(4,k)$ grow cubically in $k$:** Both the AKS upper bound $k^3/(\\log k)^2$ and the Mattheus-Verstraete lower bound $k^3/(\\log k)^4$ confirm $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$ for $2 \\leq \\alpha \\leq 4$.",
       "**Algebraic constructions broke the probabilistic barrier:** For 43 years, probabilistic methods could not improve Spencer's $(k \\log k)^{5/2}$ to cubic. Mattheus-Verstraete used incidence graphs of polar spaces over $\\mathbb{F}_q$, achieving $q^3$ vertices, no $K_4$, and independence number $O(q)$.",
@@ -116,46 +115,46 @@
       "id": "section-3",
       "title": "Known Exact Values",
       "startLine": 124,
-      "endLine": 155,
-      "summary": "Axiomatizes $R(3,3) = 6$ (monochromatic triangle in $K_6$), $R(4,4) = 18$, $R(4,5) = 25$, and the tight bounds $R(3,k) = \\Theta(k^2/\\log k)$ from Kim (1995) and Shearer (1983).",
-      "mathContext": "Axiomatizes $R(3,3) = 6$ (monochromatic triangle in $K_6$), $R(4,4) = 18$, $R(4,5) = 25$, and the tight bounds $R(3,k) = \\Theta($k^{2}$/\\log k)$ from Kim (1995) and Shearer (1983)."
+      "endLine": 144,
+      "summary": "Documents $R(3,3) = 6$, $R(4,4) = 18$, $R(4,5) = 25$, and the tight bounds $R(3,k) = \\Theta(k^2/\\log k)$ from Kim (1995) and Shearer (1983) as narrative context. No axiom declarations in this section.",
+      "mathContext": "Narrative context only: $R(3,3) = 6$, $R(4,4) = 18$, $R(4,5) = 25$, $R(3,k) = \\Theta(k^2/\\log k)$ — all doc comments, no declarations."
     },
     {
       "id": "section-4",
       "title": "Historical Lower Bounds",
-      "startLine": 156,
-      "endLine": 167,
-      "summary": "Axiomatizes Spencer's 1977 bound $R(4,k) \\geq c(k \\log k)^{5/2}$ from probabilistic dependent random choice. Best lower bound for 46 years but suboptimal by factor $k^{1/2}$.",
-      "mathContext": "Axiomatized: Axiomatizes Spencer's 1977 bound $R(4,k) \\geq c(k \\log k)^{5/2}$ from probabilistic dependent random choice. Best lower bound for 46 years but suboptimal by factor $k^{1/2}$."
+      "startLine": 145,
+      "endLine": 153,
+      "summary": "Documents Spencer's 1977 bound $R(4,k) \\geq c(k \\log k)^{5/2}$ as narrative context. Best lower bound for 46 years but suboptimal by factor $k^{1/2}$. Not axiomatized — doc comment only.",
+      "mathContext": "Narrative context only: Spencer's bound in doc comment, no axiom declaration."
     },
     {
       "id": "section-5",
       "title": "AKS Upper Bound",
-      "startLine": 170,
-      "endLine": 181,
+      "startLine": 154,
+      "endLine": 166,
       "summary": "Axiomatizes the Ajtai-Koml\u00f3s-Szemer\u00e9di 1980 upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ from greedy coloring. Established the cubic benchmark for $R(4,k)$.",
       "mathContext": "Axiomatized: Axiomatizes the Ajtai-Koml\u00f3s-Szemer\u00e9di 1980 upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ from greedy coloring. Established the cubic benchmark for $R(4,k)$."
     },
     {
       "id": "section-6",
       "title": "The Solution: Mattheus-Verstraete 2023",
-      "startLine": 184,
-      "endLine": 195,
+      "startLine": 168,
+      "endLine": 180,
       "summary": "Axiomatizes the breakthrough $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry (polar spaces over $\\mathbb{F}_q$). Solved Erd\u0151s #166, earned \\$250 prize.",
       "mathContext": "Axiomatized: Axiomatizes the breakthrough $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry (polar spaces over $\\mathbb{F}_q$). Solved Erd\u0151s #166, earned \\$250 prize."
     },
     {
       "id": "section-7",
       "title": "Formal Statement and Resolution",
-      "startLine": 198,
-      "endLine": 233,
+      "startLine": 182,
+      "endLine": 217,
       "summary": "`Erdos166Statement` defines the conjecture as $\\exists c, A > 0$ with cubic lower bound. `erdos_166_solved` proves it by instantiating $A = 4$ from Mattheus-Verstraete. `current_bounds` packages the sandwich inequality $ck^3/(\\log k)^4 \\leq R(4,k) \\leq Ck^3/(\\log k)^2$.",
       "mathContext": "`Erdos166Statement` defines the conjecture as $\\exists c, A > 0$ with cubic lower bound. `erdos_166_solved` proves it by instantiating $A = 4$ from Mattheus-Verstraete. `current_bounds` packages the sandwich inequality $ck^3/(\\log k)^4 \\leq R(4,k) \\leq Ck^3/(\\log k)^2$."
     },
     {
       "id": "section-8",
       "title": "Summary and Logarithmic Gap",
-      "startLine": 234,
+      "startLine": 218,
       "endLine": 269,
       "summary": "`erdos_166_status` confirms resolution. `logarithmic_gap` formalizes the remaining open question: $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$ with $2 \\leq \\alpha \\leq 4$. Determining the exact $\\alpha$ is the natural successor problem.",
       "mathContext": "`logarithmic_gap` formalizes the remaining open question: $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$ with $2 \\leq \\alpha \\leq 4$. Determining the exact $\\alpha$ is the natural successor problem."


### PR DESCRIPTION
## Fix

Remove phantom `spencer_lower_bound` axiom claim and fix section line drift in `src/data/proofs/erdos-166/meta.json`.

## Evidence

**Before**:
- `originalContributions` included `"spencer_lower_bound: Axiom encoding Spencer's 1977 probabilistic bound"` — this does not exist as an `axiom` declaration; Spencer's bound appears only in a doc comment
- `proofStrategy` claimed exact values ($R(3,3)=6$, $R(4,4)=18$, $R(4,5)=25$) and Spencer's bound are "axiomatized" — they are not
- Section-3 summary said "Axiomatizes $R(3,3)=6$..." — those lines (124-144) are all doc comments with no declarations
- Section-4 summary said "Axiomatizes Spencer's 1977 bound" — Spencer's section (145-153) is a doc comment only
- Sections 4-8 had startLine/endLine values off by 11-16 lines

**After**:
- `originalContributions` lists only the 2 real axioms: `aks_upper_bound`, `mattheus_verstraete`
- `proofStrategy` corrected: only AKS and Mattheus-Verstraete are axiomatized; others are narrative context
- Section-3 and section-4 summaries updated to say "Documents" instead of "Axiomatizes"
- All 5 drifted sections (3-8) corrected to actual line ranges
- Numerical fields (axiomCount: 2, sorries: 0, lineCount: 269) unchanged

Closes #14685

---
Automated fix by lean-mechanic agent.