### PR TITLE
fix(meta): erdos-158 phantom theorem claims + section line drift

### DIFF
--- a/src/data/proofs/erdos-158/meta.json
+++ b/src/data/proofs/erdos-158/meta.json
@@ -70,51 +70,51 @@
     {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 25,
-      "endLine": 43,
+      "startLine": 27,
+      "endLine": 51,
       "summary": "Define B₂[g] sets using extended cardinality and the normalized counting function."
     },
     {
       "id": "sidon-equiv",
       "title": "B₂[1] = Sidon Sets",
-      "startLine": 44,
-      "endLine": 52,
+      "startLine": 53,
+      "endLine": 60,
       "summary": "Axiom establishing that B₂[1] sets are exactly Sidon sets."
     },
     {
       "id": "main-results",
       "title": "Main Results",
-      "startLine": 53,
-      "endLine": 77,
-      "summary": "The ESS94 theorem (log bound) and its consequence (liminf = 0) for Sidon sets."
+      "startLine": 62,
+      "endLine": 80,
+      "summary": "Axiomatized ESS94 consequence: liminf A(N)/√N = 0 for infinite Sidon sets (sidon_liminf_zero). The stronger ESS94 log bound is described informally in a docstring but not axiomatized."
     },
     {
       "id": "open-problem",
       "title": "The Open Problem",
-      "startLine": 78,
-      "endLine": 89,
+      "startLine": 82,
+      "endLine": 92,
       "summary": "Formal statement of Problem #158: does liminf = 0 hold for B₂[2]?"
     },
     {
       "id": "relations",
       "title": "Implications and Relations",
-      "startLine": 90,
-      "endLine": 105,
+      "startLine": 94,
+      "endLine": 107,
       "summary": "Sidon ⊂ B₂[2] inclusion and how the conjecture generalizes the known result."
     },
     {
       "id": "context",
       "title": "Why √N?",
-      "startLine": 106,
+      "startLine": 109,
       "endLine": 118,
-      "summary": "Upper bound on Sidon set size explaining the √N normalization."
+      "summary": "Informal discussion of the √N upper bound for Sidon sets (docstring narrative, no formal bound declared)."
     },
     {
       "id": "examples",
       "title": "Examples",
       "startLine": 119,
-      "endLine": 125,
-      "summary": "Perfect squares form a Sidon set."
+      "endLine": 124,
+      "summary": "Informal discussion (docstring) that perfect squares form a Sidon set. No formal proof declared."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Fix phantom formal-content claims and section line drift in `src/data/proofs/erdos-158/meta.json`.

## Evidence

**Before**:
- `context` section summary: "Upper bound on Sidon set size explaining the √N normalization" — lines 109-118 are an orphan docstring; no formal bound declared
- `examples` section summary: "Perfect squares form a Sidon set" — lines 119-124 are an orphan docstring; no theorem proves this  
- `main-results` section summary implied two formal results (ESS94 log bound + liminf=0) — only `sidon_liminf_zero` (the consequence) is axiomatized; the log bound is a docstring only
- All 7 section line ranges drifted (off by 2-9 lines)

**After**:
- `context` summary: "Informal discussion of the √N upper bound... (docstring narrative, no formal bound declared)"
- `examples` summary: "Informal discussion (docstring)... No formal proof declared"
- `main-results` summary: "Axiomatized ESS94 consequence: sidon_liminf_zero. The stronger log bound is described informally"
- All 7 sections corrected to actual line ranges
- Numerical fields (axiomCount: 2, sorries: 0, lineCount: 125) unchanged

Closes #14691

---
Automated fix by lean-mechanic agent.