### PR TITLE
fix(meta): erdos-155 phantom axiom/theorem claims + section line drift

### DIFF
--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -35,7 +35,7 @@
     "historicalContext": "The study of Sidon sets ($B_2$ sets) began when the Hungarian mathematician Simon Sidon asked Erdős in 1932 about sets of integers with all pairwise sums distinct. Erdős and Turán (1941) proved the fundamental upper bound $F(N) = O(\\sqrt{N})$ by counting pairwise sums, and Singer (1938) achieved the matching lower bound $F(N) \\ge (1-o(1))\\sqrt{N}$ using perfect difference sets from finite projective geometry. Lindström (1969) refined the upper bound to $F(N) \\le \\sqrt{N} + N^{1/4} + 1$, and the gap between upper and lower bounds in the second-order term remains open (the '$\\sqrt{N} + 1/2$ vs $\\sqrt{N} + N^{1/4}$' question). Erdős posed Problem #155 around 1992, asking about the fine growth structure: since $F(N)$ increases by 1 only $\\sim \\sqrt{N}$ times in $[1,N]$, the increase points should be very sparse — heuristically spaced $\\sim \\sqrt{N}$ apart. The conjecture that $F(N+k) \\le F(N) + 1$ for fixed $k$ formalizes this, and the stronger form $k \\approx \\varepsilon\\sqrt{N}$ would nearly pin down the increase point distribution.",
     "problemStatement": "Is it true that for every $k \\ge 1$, $F(N+k) \\le F(N) + 1$ for all sufficiently large $N$, where $F(N)$ is the maximum Sidon subset size of $\\{1,\\ldots,N\\}$?",
     "text": "Let F(N) be the largest Sidon subset of {1,...,N}. Is F(N+k) ≤ F(N)+1 for all sufficiently large N, for every fixed k? Possibly even for k ≈ ε√N. F(N) ~ √N. Status: OPEN.",
-    "proofStrategy": "We formalize Sidon sets, define $F(N)$ axiomatically with achievability and optimality axioms, state the Erdős–Turán/Lindström upper bound and Singer lower bound, and present the main conjecture ($F(N+k) \\le F(N)+1$ for fixed $k$) and its stronger form ($k \\approx \\varepsilon\\sqrt{N}$). Consequences about the sparsity of increase points and known small values from OEIS A003022 are also axiomatized.",
+    "proofStrategy": "We formalize Sidon sets and define $F(N)$ concretely as `(sidonSets N).sup Finset.card`. Achievability, optimality, monotonicity ($F(N) \\le F(N+1) \\le F(N)+1$), increase-count bounds, and $F(1)=1, F(2)=2, F(3)=3$ are proven as theorems. Only the Erdős–Turán/Lindström upper bound is axiomatized (`erdos_turan_upper`). Singer's lower bound, the main conjecture ($F(N+k) \\le F(N)+1$), its stronger form ($k \\approx \\varepsilon\\sqrt{N}$), and known values $F(6)=4, F(11)=5, F(18)=6$ are described in docstring context but not formally declared.",
     "keyInsights": [
       "**$F(N) \\sim \\sqrt{N}$ with tight bounds**: Erdős–Turán gives $F(N) \\le \\sqrt{N} + N^{1/4} + 1$; Singer's finite-field construction gives $F(N) \\ge \\sqrt{N} - O(N^{1/4})$. The second-order term remains unknown.",
       "**Increase points have density $\\sim 1/\\sqrt{N}$**: Since $F$ increases $\\sim \\sqrt{N}$ times in $[1,N]$ (one step at a time), the average gap between increase points is $\\sim \\sqrt{N}$, making any fixed $k$ negligible for large $N$",
@@ -53,65 +53,65 @@
       "id": "imports",
       "title": "Imports",
       "startLine": 26,
-      "endLine": 30,
+      "endLine": 27,
       "summary": "Imports `Finset`, `Nat`, `Filter`, and Mathlib tactics for finite set operations and real-valued bounds.",
       "mathContext": "Bound: Imports `Finset`, `Nat`, `Filter`, and Mathlib tactics for finite set operations and real-valued bounds."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 31,
-      "endLine": 51,
-      "summary": "Defines `IsSidonSet` ($\\forall a \\le b, c \\le d \\in S : a+b = c+d \\Rightarrow (a,b) = (c,d)$) and axiomatizes $F(N)$ with achievability and optimality. The axiom `maxSidonSize : \\mathbb{N} \\to \\mathbb{N}$ is opaque, characterized by its properties.",
-      "mathContext": "Defines `IsSidonSet` ($\\forall a \\le b, c \\le d \\in S : a+b = c+d \\Rightarrow (a,b) = (c,d)$) and axiomatizes $F(N)$ with achievability and optimality. The axiom `maxSidonSize : \\mathbb{N} \\to \\mathbb{N}$ is opaque, characterized by its properties."
+      "startLine": 28,
+      "endLine": 71,
+      "summary": "Defines `IsSidonSet` and `maxSidonSize N = (sidonSets N).sup Finset.card` (concrete definition). Proven theorems `maxSidon_achievable` and `maxSidon_optimal` characterize F(N).",
+      "mathContext": "Definitions and theorems: IsSidonSet, maxSidonSize (concrete), maxSidon_achievable (theorem), maxSidon_optimal (theorem)."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity",
-      "startLine": 52,
-      "endLine": 59,
-      "summary": "Axiomatizes $F(N) \\le F(N+1) \\le F(N) + 1$: the sequence $F(1), F(2), \\ldots$ is nondecreasing with steps of 0 or 1.",
-      "mathContext": "Axiomatized: Axiomatizes $F(N) \\le F(N+1) \\le F(N) + 1$: the sequence $F(1), F(2), \\ldots$ is nondecreasing with steps of 0 or 1."
+      "startLine": 73,
+      "endLine": 111,
+      "summary": "Proven theorems: `maxSidon_monotone` ($F(N) \\le F(N+1)$) and `maxSidon_step` ($F(N+1) \\le F(N)+1$). Neither is an axiom.",
+      "mathContext": "Theorems (proved): maxSidon_monotone, maxSidon_step."
     },
     {
       "id": "asymptotic-bounds",
       "title": "Asymptotic Bounds",
-      "startLine": 60,
-      "endLine": 72,
-      "summary": "Axiomatizes the Erdős–Turán/Lindström upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$ and the Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for large $N$. Together: $F(N) = (1+o(1))\\sqrt{N}$.",
-      "mathContext": "Axiomatized: Axiomatizes the Erdős–Turán/Lindström upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$ and the Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for large $N$. Together: $F(N) = (1+o(1))\\sqrt{N}$."
+      "startLine": 113,
+      "endLine": 122,
+      "summary": "Axiom `erdos_turan_upper`: $F(N) \\le \\sqrt{N} + N^{1/4} + 1$. Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ is described in a docstring (line 120-122) but not formally declared.",
+      "mathContext": "Axiom: erdos_turan_upper. Singer lower bound: docstring context only, no declaration."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture: $F(N+k) \\le F(N) + 1$",
-      "startLine": 73,
-      "endLine": 82,
-      "summary": "The central open problem: for every fixed $k \\ge 1$, $F(N+k) \\le F(N) + 1$ for all sufficiently large $N$. The quantifier structure $\\forall k, \\exists N_0, \\forall N \\ge N_0$ allows $N_0$ to depend on $k$.",
-      "mathContext": "The central open problem: for every fixed $k \\ge 1$, $F(N+k) \\le F(N) + 1$ for all sufficiently large $N$. The quantifier structure $\\forall k, \\exists N_0, \\forall N \\ge N_0$ allows $N_0$ to depend on $k$."
+      "startLine": 122,
+      "endLine": 128,
+      "summary": "The central open conjecture is described in a docstring (lines 124-128) only. No axiom or theorem is formally declared for this conjecture.",
+      "mathContext": "Docstring context only: main conjecture F(N+k) ≤ F(N)+1 for fixed k; no formal declaration."
     },
     {
       "id": "strong-form",
       "title": "Stronger Form: $k \\approx \\varepsilon\\sqrt{N}$",
-      "startLine": 83,
-      "endLine": 91,
-      "summary": "Erdős's stronger conjecture: $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$, implying consecutive increase points are separated by $\\ge \\varepsilon\\sqrt{N}$.",
-      "mathContext": "Mathematical content: Erdős's stronger conjecture: $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$, implying consecutive increase points are separated by $\\ge \\varepsilon\\sqrt{N}$."
+      "startLine": 129,
+      "endLine": 133,
+      "summary": "Erdős's stronger conjecture ($F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$) is described in a docstring (lines 131-133) only. No formal declaration.",
+      "mathContext": "Docstring context only: stronger conjecture about ε√N spacing; no formal declaration."
     },
     {
       "id": "consequences",
       "title": "Consequences: Sparse Increase Points",
-      "startLine": 92,
-      "endLine": 101,
-      "summary": "The number of increase points in $[1,M]$ is $\\le (1+\\varepsilon)\\sqrt{M}$. Since $F(M) \\sim \\sqrt{M}$ and each increase adds 1, this count equals $F(M) - 1 \\sim \\sqrt{M}$.",
-      "mathContext": "Mathematical content: The number of increase points in $[1,M]$ is $\\le (1+\\varepsilon)\\sqrt{M}$. Since $F(M) \\sim \\sqrt{M}$ and each increase adds 1, this count equals $F(M) - 1 \\sim \\sqrt{M}$."
+      "startLine": 134,
+      "endLine": 162,
+      "summary": "Proven theorem `increase_count_le`: the count of increase points in $[1,M]$ is $\\le F(M)$. The stronger (1+ε)√M bound is described in a docstring (lines 159-162) but not declared.",
+      "mathContext": "Theorem (proved): increase_count_le (count ≤ F(M)). Asymptotic bound vs √M: docstring only."
     },
     {
       "id": "small-values",
       "title": "Known Small Values (OEIS A003022)",
-      "startLine": 102,
-      "endLine": 109,
-      "summary": "Axiomatizes $F(1)=1, F(2)=2, F(3)=3, F(6)=4, F(11)=5, F(18)=6$. Gaps between increase points: $1, 1, 3, 5, 7$, growing as $\\sim \\sqrt{N}$.",
-      "mathContext": "Axiomatized: Axiomatizes $F(1)=1, F(2)=2, F(3)=3, F(6)=4, F(11)=5, F(18)=6$. Gaps between increase points: $1, 1, 3, 5, 7$, growing as $\\sim \\sqrt{N}$."
+      "startLine": 163,
+      "endLine": 199,
+      "summary": "Proven theorems: `maxSidonSize_1=1`, `maxSidonSize_2=2`, `maxSidonSize_3=3`. Values $F(6)=4, F(11)=5, F(18)=6$ are not declared in this file.",
+      "mathContext": "Theorems (proved): maxSidonSize_1, maxSidonSize_2, maxSidonSize_3. F(6), F(11), F(18): not declared."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Fix multiple phantom formal-content overclaims and section line drift in `src/data/proofs/erdos-155/meta.json`.

## Evidence

**Before** (selected phantom claims):
- `proofStrategy`: "define F(N) axiomatically" — F(N) = `(sidonSets N).sup Finset.card` is a **concrete definition**
- `proofStrategy`: "Singer lower bound...axiomatized" — Singer's bound is only in a docstring, not declared
- `proofStrategy`: "small values from OEIS A003022 are axiomatized" — F(1..3) are **theorems**; F(6,11,18) are not in the file at all
- `monotonicity` section: "Axiomatizes F(N)≤F(N+1)≤F(N)+1" — `maxSidon_monotone` and `maxSidon_step` are **proven theorems**
- `asymptotic-bounds` section: "Axiomatizes...Singer lower bound" — Singer bound is a docstring only
- `main-conjecture` and `strong-form` sections: presented as formal content — both are docstrings only with no declarations
- `small-values` section: "Axiomatizes F(1)=1...F(18)=6" — F(1,2,3) are theorems; F(6,11,18) are not declared
- All 8 section startLine/endLine values off by 1-70 lines

**After**: All overclaims corrected, line ranges fixed. Numerical fields (axiomCount: 1, sorries: 0) unchanged.

Closes #14693

---
Automated fix by lean-mechanic agent.