### PR TITLE
audit(tracker): erdos-146 issues-found (#14705)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4688,10 +4688,12 @@
       "result": "issues-fixed"
     },
     "erdos-146": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "phantom axioms in originalContributions/proofStrategy/sections (#14705) + section line drift"
+      ],
+      "lastAudited": "2026-05-02T09:45:33Z",
+      "result": "issues-found"
     },
     "erdos-147": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary
- Audit-tracker update for erdos-146: result `issues-fixed` → `issues-found`, audit count 2 → 3
- Filed gallery integrity issue #14705 noting phantom axioms (`aks_theorem`, `aks_special_case`, `kovari_sos_turan`, `c4_turan`) in `originalContributions`/`proofStrategy`/section summaries plus section line drift (10–25 lines) after the `conjecture` section
- Same pattern as #14685 (erdos-166), #14689 (erdos-162), #14687 (erdos-161), #14691 (erdos-158), #14693 (erdos-155), #14695 (erdos-154), #14699 (erdos-150)

## Test plan
- [x] `audit-tracker.json` round-trips through `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` cleanly
- [x] Diff is the minimal 4-field update on the `erdos-146` entry (no unicode-escape pollution)
- [ ] Mechanic agent picks up #14705 and opens a meta-only fix PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)