### PR TITLE
fix(meta): erdos-150 section line drift in Parts IV-X

### DIFF
--- a/src/data/proofs/erdos-150/meta.json
+++ b/src/data/proofs/erdos-150/meta.json
@@ -121,56 +121,56 @@
       "id": "binary-entropy",
       "title": "Binary Entropy Function",
       "summary": "binaryEntropy H(p) definition and properties",
-      "startLine": 122,
-      "endLine": 147,
+      "startLine": 120,
+      "endLine": 142,
       "mathContext": "Formal definition: binaryEntropy H(p) definition and properties"
     },
     {
       "id": "bradac-theorem",
       "title": "Bradac's Theorem",
       "summary": "limit_exists, alpha, bradac_upper_bound, alpha_less_than_two",
-      "startLine": 148,
-      "endLine": 191,
+      "startLine": 143,
+      "endLine": 201,
       "mathContext": "limit_exists, $\\alpha$, bradac_upper_bound, alpha_less_than_two"
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem",
       "summary": "erdos_150: the limit exists and alpha < 2",
-      "startLine": 192,
-      "endLine": 214,
+      "startLine": 202,
+      "endLine": 224,
       "mathContext": "erdos_150: the limit exists and $\\alpha$ < 2"
     },
     {
       "id": "bounds-summary",
       "title": "Bounds Summary",
       "summary": "alpha_lower_bound, alpha_upper_bound, alpha_bounds",
-      "startLine": 215,
-      "endLine": 241,
+      "startLine": 225,
+      "endLine": 251,
       "mathContext": "Bound: alpha_lower_bound, alpha_upper_bound, alpha_bounds"
     },
     {
       "id": "bradac-conjecture",
       "title": "Bradac's Conjecture",
       "summary": "bradac_conjecture: alpha = 3^{1/3}",
-      "startLine": 242,
-      "endLine": 255,
+      "startLine": 252,
+      "endLine": 265,
       "mathContext": "bradac_conjecture: $\\alpha$ = $$3^{{1/3}$}$"
     },
     {
       "id": "special-values",
       "title": "Special Values",
       "summary": "c_seymour_bound, c_5_ge_3, c_8_ge_9, c_11_ge_27",
-      "startLine": 256,
-      "endLine": 296,
+      "startLine": 266,
+      "endLine": 306,
       "mathContext": "Bound: c_seymour_bound, c_5_ge_3, c_8_ge_9, c_11_ge_27"
     },
     {
       "id": "main-results",
       "title": "Main Results Summary",
       "summary": "erdos_150_summary, erdos_150_answer",
-      "startLine": 297,
-      "endLine": 325,
+      "startLine": 307,
+      "endLine": 334,
       "mathContext": "Mathematical content: erdos_150_summary, erdos_150_answer"
     }
   ],


### PR DESCRIPTION
## Fix

Correct 7 section startLine/endLine values in `src/data/proofs/erdos-150/meta.json` to match actual `## Part N` header positions.

## Evidence

Parts I-III were already accurate. Parts IV-X had drifted 2-10 lines:

| Section | Before | After |
|---------|--------|-------|
| binary-entropy | 122-147 | 120-142 |
| bradac-theorem | 148-191 | 143-201 |
| main-theorem | 192-214 | 202-224 |
| bounds-summary | 215-241 | 225-251 |
| bradac-conjecture | 242-255 | 252-265 |
| special-values | 256-296 | 266-306 |
| main-results | 297-325 | 307-334 |

No narrative, axiom, or numerical field changes. All corrections confirmed against actual `## Part N` header lines in `proofs/Proofs/Erdos150Problem.lean`.

Closes #14699

---
Automated fix by lean-mechanic agent.