### PR TITLE
audit(tracker): erdos-145 issues-found (#14708)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4682,10 +4682,10 @@
       "result": "clean"
     },
     "erdos-145": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T09:51:51Z",
+      "result": "issues-found"
     },
     "erdos-146": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Logs audit result for **erdos-145** (Moments of Squarefree Gaps): phantom axiom claims for Erdős, Hooley, and GHH in `proofStrategy` and the `historical` section `summary`. The Lean source declares only 2 axioms (`chan_2023`, `granville_1998_conditional`), but narrative implies 4-5.

Numerical fields are accurate (`axiomCount=2`, `sorries=0`, `lineCount=133`, section line ranges correct). Only the prose overstates axiomatization.

See #14708 for full details and recommended fix.

## Test plan
- [x] `audit-tracker.json` updated for `erdos-145` (auditCount 2→3, lastAudited bumped, result issues-found)
- [x] No unicode escape pollution in tracker diff (used `ensure_ascii=False`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)