### PR TITLE
audit(tracker): erdos-13 issues-found (#14718)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4560,10 +4560,13 @@
       "result": "issues-fixed"
     },
     "erdos-13": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T10:15:31Z",
+      "result": "issues-found",
+      "issues": [
+        "#14718: phantom axiom claims in originalContributions and sections (5 of 6 listed axioms are not real declarations)"
+      ]
     },
     "erdos-130": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for erdos-13 audit.

**Issue filed**: #14718 — phantom axiom claims in originalContributions and sections.

## Findings

- `axiomCount: 1`, `sorries: 0` are correct numerically.
- `originalContributions` lists 6 entries as "axiom" but only `bedert_theorem` is a real axiom in the Lean file.
  - `upperThird_card`, `upperThird_achieves_bound` are proved **theorems**, not axioms.
  - `upperThird_divisibilityFree`, `upperThird_optimal`, `upperThird_sumFree` have no declaration at all (only orphan docstrings).
- Section summaries for `upper-third`, `bedert`, and `sum-free` overstate axiomatization accordingly.

Same phantom-axiom narrative pattern seen in many erdos-9XX audits.