### PR TITLE
audit(tracker): erdos-126 issues-found (#14722)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4536,10 +4536,13 @@
       "result": "issues-fixed"
     },
     "erdos-126": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T10:30:00Z",
+      "result": "issues-found",
+      "issues": [
+        "#14722: phantom axiom claims for erdos_126, erdos_126_littleo, trivial_upper_bound, f_monotone, conjecture_implies_not_O_log in sections/proofStrategy + section line drift"
+      ]
     },
     "erdos-127": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for erdos-126 audit.

**Issue filed**: #14722 — phantom axiom claims in sections/proofStrategy + section line drift.

## Findings

- `axiomCount: 2`, `sorries: 0` are correct numerically.
- Only `erdos_turan_lower` and `erdos_turan_upper` are real axioms.
- `sections` (Parts II, IV, V, VI, VII) describe 5 phantom axioms (`erdos_126`, `erdos_126_littleo`, `trivial_upper_bound`, `f_monotone`, `conjecture_implies_not_O_log`) that exist only as docstrings — no Lean declarations.
- `proofStrategy` items 4 and 5 imply axiomatization of the little-o question and structural properties; no such axioms exist.
- `sections[*].startLine` values drift 3–13 lines from the actual section headers in the file.
- `originalContributions` and `assumptions` are correct.

Same phantom-axiom narrative pattern as erdos-13, erdos-145, erdos-146, etc.