### PR TITLE
fix(meta): erdos-126 phantom axiom claims in sections/proofStrategy + section line drift

### DIFF
--- a/src/data/proofs/erdos-126/meta.json
+++ b/src/data/proofs/erdos-126/meta.json
@@ -74,7 +74,7 @@
     "historicalContext": "**Origins and Early Work**\n\nErdős Problem #126 originates from the first joint paper of Paul Erdős and Pál Turán, published in 1934 in the American Mathematical Monthly. The investigation was prompted by questions from László Lázár and Tibor Grünwald (later Gallai). The paper studied the arithmetic structure of pairwise sums from finite subsets of the natural numbers.\n\n**The Extremal Function and Known Bounds**\n\nThe central object is the function f(n): the maximum value such that for any n-element subset A ⊆ ℕ, the product ∏_{a≠b∈A}(a+b) has at least f(n) distinct prime factors. Erdős and Turán established the bounds log(n) ≪ f(n) ≪ n/log(n). The upper bound is obtained trivially by taking A = {1, 2, …, n}, where all pairwise sums are at most 2n−1, so there are at most π(2n−1) ∼ 2n/log(n) possible prime factors by the prime number theorem.\n\n**Current Status and Prize**\n\nThe conjecture that f(n)/log(n) → ∞ remains open and carries a $250 Erdős prize. Erdős also noted that even the weaker statement f(n) = o(n/log(n)) — showing the upper bound is not tight — has \"never been seriously attacked.\" No significant progress has been made on narrowing the gap between log(n) and n/log(n) since the original 1934 paper. References: [ErTu34], [Er95c], [Er97], [Er97e].",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $f(n)$ be the maximum value such that for any $A \\subseteq \\mathbb{N}$ with $|A| = n$, the product $\\prod_{a \\neq b \\in A}(a+b)$ has at least $f(n)$ distinct prime factors.\n\n**Conjecture:** $\\frac{f(n)}{\\log n} \\to \\infty$ as $n \\to \\infty$.\n\n**Known:** $\\log n \\ll f(n) \\ll \\frac{n}{\\log n}$ (Erdős–Turán, 1934).\n\n**Prize:** $250 for resolution.",
     "text": "Is it true that f(n)/log(n) → ∞, where f(n) is the maximum number of distinct prime factors guaranteed in the product of all pairwise sums of an n-element set? OPEN ($250 prize).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Extremal function:** `IsMaximalAddFactorsCard` defines f(n) using `Finset.offDiag` for ordered pairs and `Nat.primeFactors` for distinct prime divisors.\n\n2. **Main conjecture:** `ErdosConjecture126` formalizes f(n)/log(n) → ∞ using `Filter.Tendsto` with `atTop`.\n\n3. **Asymptotic bounds:** The Erdős–Turán bounds are stated as axioms using Mathlib's `IsBigO` notation, and combined into `erdos_turan_bounds` (proved).\n\n4. **Secondary question:** The little-o question is stated separately as an axiom.\n\n5. **Structural properties:** Monotonicity of f and the implication that the conjecture rules out f(n) = O(log(n)).\n\nAll deep results are axiomatized since they require sieve theory and the prime number theorem beyond Mathlib's current scope.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Extremal function:** `IsMaximalAddFactorsCard` defines f(n) using `Finset.offDiag` for ordered pairs and `Nat.primeFactors` for distinct prime divisors.\n\n2. **Main conjecture:** `ErdosConjecture126` formalizes f(n)/log(n) → ∞ using `Filter.Tendsto` with `atTop`.\n\n3. **Asymptotic bounds:** The Erdős–Turán bounds are stated as axioms using Mathlib's `IsBigO` notation, and combined into `erdos_turan_bounds` (proved).\n\n4. **Secondary question:** The little-o question f(n) = o(n/log(n)) is discussed in a docstring; no Lean declaration is added for this open sub-question.\n\n5. **Structural properties:** Monotonicity of f and the conjecture's implications are discussed in docstrings; no corresponding Lean declarations are added.\n\nOnly the two Erdős–Turán bounds are axiomatized. The remaining sections discuss open questions and structural observations in docstrings only.",
     "keyInsights": [
       "**Extremal function f(n)**: Counts the minimum number of distinct prime factors guaranteed in products of pairwise sums of any n-element subset of ℕ",
       "**Erdős–Turán bounds (1934)**: The only known bounds are log(n) ≪ f(n) ≪ n/log(n), established 90+ years ago with no improvement since",
@@ -99,43 +99,43 @@
       "id": "main-conjecture",
       "title": "Part II: The Main Conjecture",
       "startLine": 50,
-      "endLine": 70,
-      "summary": "Defines ErdosConjecture126 (f(n)/log(n) → ∞) and states the main axiom erdos_126."
+      "endLine": 67,
+      "summary": "Defines ErdosConjecture126 (f(n)/log(n) → ∞ via Tendsto). The conjecture itself is not asserted as a Lean axiom — it is named only via the definition; the file's docstring describes the open status."
     },
     {
       "id": "known-bounds",
       "title": "Part III: Known Bounds (Erdős–Turán 1934)",
-      "startLine": 71,
-      "endLine": 102,
+      "startLine": 68,
+      "endLine": 99,
       "summary": "Axioms for the lower bound (log(n) = O(f(n))) and upper bound (f(n) = O(n/log(n))). Theorem erdos_turan_bounds combines both."
     },
     {
       "id": "littleo-question",
       "title": "Part IV: The Little-o Question",
-      "startLine": 103,
-      "endLine": 118,
-      "summary": "Axiom erdos_126_littleo: f(n) = o(n/log(n)), an open sub-question about tightness of the upper bound."
+      "startLine": 100,
+      "endLine": 112,
+      "summary": "Discusses the secondary open question f(n) = o(n/log(n)) in a docstring; no Lean declaration is added for this question."
     },
     {
       "id": "trivial-bound",
       "title": "Part V: Trivial Upper Bound Construction",
-      "startLine": 119,
-      "endLine": 134,
-      "summary": "Axiom trivial_upper_bound: existence of A with bounded prime factor count via A = {1,...,n}."
+      "startLine": 113,
+      "endLine": 124,
+      "summary": "Discusses the trivial upper bound construction A = {1,...,n} in a docstring; no Lean declaration is added."
     },
     {
       "id": "monotonicity",
       "title": "Part VI: Monotonicity of f",
-      "startLine": 135,
-      "endLine": 147,
-      "summary": "Axiom f_monotone: the extremal function is monotone non-decreasing."
+      "startLine": 125,
+      "endLine": 134,
+      "summary": "Discusses monotonicity of f in a docstring; no Lean declaration is added."
     },
     {
       "id": "summary",
       "title": "Part VII: Summary and Consequences",
-      "startLine": 148,
+      "startLine": 135,
       "endLine": 152,
-      "summary": "Summary of results and axiom conjecture_implies_not_O_log: the conjecture rules out f(n) = O(log(n))."
+      "summary": "Summary docstring noting f(n)/log(n) → ∞ would imply f is not O(log); no Lean declaration is added."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Remove 5 phantom axiom claims from `erdos-126` meta.json sections and `proofStrategy`, and correct section `startLine`/`endLine` values to match actual Lean source.

## Evidence

**Before**: Sections II, IV, V, VI, VII claimed axioms `erdos_126`, `erdos_126_littleo`, `trivial_upper_bound`, `f_monotone`, `conjecture_implies_not_O_log` that do not exist in the Lean file. `proofStrategy` items 4–5 stated these as axiomatized facts. Section line ranges were off by 3–13 lines starting from Part III.

**After**: Sections accurately describe the content as docstring-only discussions where no Lean declaration was added. `proofStrategy` items 4–5 clarify that only the two Erdős–Turán bounds (`erdos_turan_lower`, `erdos_turan_upper`) are axiomatized. Section line ranges corrected to match actual Part headers in the Lean file.

Closes #14722

---
Automated fix by lean-mechanic agent.