### PR TITLE
audit(tracker): erdos-1179 issues-found (#14732)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4381,9 +4381,10 @@
     },
     "erdos-1179": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-02T10:47:13Z",
+      "result": "issues-found",
+      "notes": "#14732: phantom axioms (erdos_renyi_upper, gEps_mono not declared; main_asymptotic now theorem main_asymptotic_derived; trivial_lower_bound→basic_lower_bound) in originalContributions/sections; section line drift (sections cover 1-178 of 316-line file; Parts IX, X missing); proofStrategy says 179-line file"
     },
     "erdos-1179-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary
- Records gallery audit result for erdos-1179: **issues-found** (issue #14732).
- Updates `audit-tracker.json` `entries["erdos-1179"]` only.

## Findings (see #14732 for full details)
Phantom axiom claims in `originalContributions` and `sections`:
- `erdos_renyi_upper`, `gEps_mono` — not declared in source
- `main_asymptotic` — now `theorem main_asymptotic_derived` (Part X axiom elimination)
- `trivial_lower_bound` should be `basic_lower_bound`

Section line drift: `sections[]` covers lines 1-178; file has 316 lines. Parts IX (Monotonicity) and X (Axiom Elimination) missing. `proofStrategy` says "179-line Lean 4 file".

Numerical counts (`axiomCount: 3`, `sorries: 0`, `lineCount: 316`) are accurate.

## Test plan
- [x] tracker entry written via `ensure_ascii=False` (no `\u` escape pollution)
- [x] only erdos-1179 entry modified (1 file, +4/-3 lines)