### PR TITLE
audit(tracker): erdos-131 issues-found (#14734)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4585,11 +4585,12 @@
       "result": "clean"
     },
     "erdos-131": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
-        "Phantom sorry/partial-verification claims for nondividing_implies_nonaveraging + section line drift across all 8 sections; counts correct; issue #14716"
+        "Phantom sorry/partial-verification claims for nondividing_implies_nonaveraging + section line drift across all 8 sections; counts correct; issue #14716",
+        "#14734: residual phantom claims after PR #14724 — sections[0].summary still references nonexistent nondividing_equiv; originalContributions[0] claims false equivalence (nondividing_not_iff_alt proves they are NOT equivalent); sections[1].mathContext + sections[6].mathContext stale (summaries fixed, mathContext not); sections[4].mathContext LaTeX bug"
       ],
-      "lastAudited": "2026-05-02T10:15:00Z",
+      "lastAudited": "2026-05-02T10:54:29Z",
       "result": "issues-found"
     },
     "erdos-131-oq-01": {


### PR DESCRIPTION
## Summary

Follow-up tracker entry for erdos-131 after auditing the post-#14724 state of `meta.json`.

PR #14724 fixed phantom-sorry claims in `summary` fields and updated all 8 section line ranges, but left several sibling fields stale and missed a false equivalence claim. New issue #14734 documents the residuals:

- `sections[0].summary` references a nonexistent theorem `nondividing_equiv`
- `originalContributions[0]` claims `IsNonDividing` / `IsNonDividingAlt` are "equivalent formulations", but `nondividing_not_iff_alt` proves they are **not** equivalent (Alt is strictly stronger; counterexample `{2,4}`)
- `sections[1].mathContext` and `sections[6].mathContext` still contain "partially verified" / "primes form non-dividing" claims that were corrected in the corresponding `summary` fields
- `sections[4].mathContext` has a LaTeX rendering bug (extra `$` delimiters inside an exponent)

Counts (`sorries=0`, `axiomCount=2`, `status=axiomatized`, `badge=axiom`) remain correct.

## Test plan

- [x] Tracker JSON parses cleanly
- [x] Diff is exactly 4 insertions / 3 deletions on the `erdos-131` entry
- [x] No unicode-escaping noise (used `ensure_ascii=False`)