### PR TITLE
audit(tracker): erdos-1181 issues-found (#14737)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4399,10 +4399,12 @@
       "result": "clean"
     },
     "erdos-1181": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "issues": [
+        "#14737: proofStrategy step 3 claims trivial-bound axiomatization (no axiom declared in Lean source)"
+      ],
+      "lastAudited": "2026-05-02T11:04:20Z",
+      "result": "issues-found"
     },
     "erdos-1182": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

- Re-audit of `erdos-1181` found residual phantom-axiom claim in `proofStrategy` step 3 (filed #14737)
- Updates `src/data/proofs/audit-tracker.json` with `auditCount: 4`, `result: issues-found`

## Test plan

- [x] Tracker diff is one-entry only (no unicode-escape pollution from `claim-target.sh`)
- [x] Issue #14737 cross-referenced in tracker `issues` field
- [x] Numerical counts (axiomCount=1, sorries=0, lineCount=292) verified against Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)