### PR TITLE
audit(tracker): erdos-1177 issues-found (#14739)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4369,9 +4369,9 @@
     },
     "erdos-1177": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T11:12:05Z",
+      "result": "issues-found"
     },
     "erdos-1178": {
       "auditCount": 2,


### PR DESCRIPTION
Tracker update for erdos-1177 audit. Issues filed in #14739:

- Phantom 'cardinal axiomatization' claim in `proofStrategy` and `sections[0]`
- Phantom 'Erdos 1959 connection' section (sections[6], lines 179-193) — does not exist in Lean source
- Section line drift across all 8 sections

Numerical counts (axiomCount=5, sorries=0, theoremCount=7, definitionCount=6) are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)