### PR TITLE
audit(tracker): erdos-1175 issues-found (#14741)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4356,10 +4356,13 @@
       "result": "issues-fixed"
     },
     "erdos-1175": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777720421",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T11:17:28Z",
+      "result": "issues-found",
+      "issues": [
+        "#14741: phantom axiom claims for Mycielski / finite case / Erdős 1959 in proofStrategy + sections (only docstrings; no declarations)"
+      ]
     },
     "erdos-1176": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Records audit completion for `erdos-1175` with `result: issues-found` and a reference to issue #14741.
- Issue #14741 documents phantom axiom claims for Mycielski / finite case / Erdős 1959 in `proofStrategy` and two section summaries (only docstrings exist; no declarations).
- Numerical fields (`axiomCount: 2`, `theoremCount: 2`, `definitionCount: 10`, `lineCount: 186`, `sorries: 0`) are accurate; the issue is purely narrative.

## Test plan

- [x] Tracker JSON validates (`python3 -c "import json; json.load(...)"`)
- [x] Diff is minimal (7 lines for one entry; no unicode-escape pollution)
- [x] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)