### PR TITLE
audit(tracker): erdos-1165 issues-found (#14743)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4284,10 +4284,10 @@
       "result": "clean"
     },
     "erdos-1165": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T11:26:08Z",
+      "result": "issues-found"
     },
     "erdos-1166": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records audit completion for erdos-1165 (`issues-found`)
- Finding filed as #14743: phantom "basic probability bounds" claim in `sections.probability-events.summary` (no axiom/theorem actually states `0 ≤ p ≤ 1`); minor section line drift
- All numerical counts verified correct: axiomCount=5, sorries=0, theoremCount=3, definitionCount=3, lineCount=183

## Test plan
- [x] Tracker JSON parses cleanly (no unicode escape pollution)
- [x] Only the erdos-1165 entry changed