### PR TITLE
audit(tracker): erdos-1158 issues-found (#14745)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4248,10 +4248,12 @@
       "result": "clean"
     },
     "erdos-1158": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "#14745 phantom \"axiomatize\" claims for upper bound, lower bound, stepping-up + section line drift"
+      ],
+      "lastAudited": "2026-05-02T11:31:08Z",
+      "result": "issues-found"
     },
     "erdos-1159": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Tracker update for erdos-1158 audit:
- Phantom "axiomatize" claims in proofStrategy steps 5-6 and `sections.upper-bound` / `sections.lower-bound` / `sections.known-cases` (claim axiomatization of upper bound, lower bound, stepping-up lemma when only docstrings exist).
- Section line drift, especially `structural-properties` (claim 280-306, actual 265-306).
- See issue #14745 for full evidence and recommended fix.

## Test plan
- [x] Tracker JSON parses cleanly (manual jq check)
- [x] Diff is unicode-clean (8 lines, only erdos-1158 entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)