### PR TITLE
audit(tracker): erdos-1134 issues-found (#14749)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4050,10 +4050,10 @@
       "result": "issues-fixed"
     },
     "erdos-1134": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T11:46:36Z",
+      "result": "issues-found"
     },
     "erdos-1135": {
       "auditCount": 3,


### PR DESCRIPTION
Tracker entry update for issue #14749.

erdos-1134 meta.json contains phantom \`klarner_rado_1974\` axiom claims (originalContributions, proofStrategy step 2, references notes, section klarner-rado), plus phantom axiomatization claims for \`elements_have_representation\` (theorem, not axiom) and Φ(τ) = 0 (no such axiom). 7 sections also have stale startLine/endLine.

Numerical counts (4 axioms, 0 sorries, 272 lines) are correct; only the narrative needs repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)