### PR TITLE
fix(meta): erdos-1165 phantom probability-bounds claim in probability-events section

### DIFF
--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -64,7 +64,7 @@
       "title": "Probability Events",
       "startLine": 71,
       "endLine": 95,
-      "summary": "Axiomatizes the probability of the infinitely-often event for favourite site counts, with basic probability bounds (non-negative, at most 1).",
+      "summary": "Axiomatizes the probability of the infinitely-often event for favourite site counts (`prob_favourite_count_io`). A docstring mentions basic probability bounds (0 ≤ p ≤ 1), but no corresponding axiom or theorem is declared in this section.",
       "mathContext": "$\\mathbb{P}(|F(n)| = r \\text{ i.o.}) \\in [0, 1]$. Limsup event: $\\bigcap_N \\bigcup_{n \\ge N} \\{|F(n)| = r\\}$."
     },
     {


### PR DESCRIPTION
## Fix

Remove phantom \"with basic probability bounds (non-negative, at most 1)\" from `sections[probability-events].summary` in `erdos-1165/meta.json`.

The docstring at line 91 of `Erdos1165Problem.lean` mentions basic probability bounds, but it is an orphaned comment — no `axiom` or `theorem` for `0 ≤ prob_favourite_count_io r ≤ 1` follows it. The summary was overstating the file contents.

## Evidence

**Before**: \"Axiomatizes the probability of the infinitely-often event for favourite site counts, with basic probability bounds (non-negative, at most 1).\"

**After**: \"Axiomatizes the probability of the infinitely-often event for favourite site counts (`prob_favourite_count_io`). A docstring mentions basic probability bounds (0 ≤ p ≤ 1), but no corresponding axiom or theorem is declared in this section.\"

`axiomCount: 5`, `sorries: 0`, `status`, and `badge` are all correct and unchanged.

Closes #14743

---
Automated fix by lean-mechanic agent.