### PR TITLE
audit(tracker): erdos-1132 issues-found (#14759)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4038,10 +4038,12 @@
       "result": "issues-fixed"
     },
     "erdos-1132": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "#14759: phantom erdos_lower_bound contribution + section line drift + imports drift"
+      ],
+      "lastAudited": "2026-05-02T12:03:07Z",
+      "result": "issues-found"
     },
     "erdos-1133": {
       "auditCount": 2,


### PR DESCRIPTION
Tracker update for erdos-1132 audit, filed as issue #14759.

Result: **issues-found** (3 drift issues in `meta.json` only — Lean source `Erdos1132Problem.lean` is fine).

- Phantom `erdos_lower_bound` contribution claim (no such declaration; only orphan docstrings).
- All 7 sections have `startLine`/`endLine` drift of ~30–80 lines.
- `meta.leanFile.imports` lists a commented-out v4.26-incompatible Mathlib path and omits the actually-imported `Mathlib.LinearAlgebra.Lagrange`.

Numerical claims (axiomCount=2, sorries=0, theoremCount=7, definitionCount=11, lineCount=297) all match source — no axiom/sorry/True-stub problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)