### PR TITLE
audit(tracker): erdos-1127 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3990,10 +3990,12 @@
       "result": "clean"
     },
     "erdos-1127": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "#14765: phantom 'Statement of Erdős-Hajnal necessity result' contribution + false 'former axioms now proved as theorems or definitions' claim (none of the named identifiers exist) + section line drift starting at davies-theorem (Parts VIII/IX missing entirely)"
+      ],
+      "lastAudited": "2026-05-02T12:11:47Z",
+      "result": "issues-found"
     },
     "erdos-1128": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary
- Mark erdos-1127 audit as `issues-found` linked to gallery integrity issue #14765.
- Bump auditCount 2→3, refresh lastAudited to 2026-05-02.

## Findings (filed in #14765)
- Phantom `originalContributions` entry: "Statement of Erdős-Hajnal necessity result" — Lean Part VII has only orphaned docstrings, no declaration.
- False `assumptions` claim: "Former axioms ... now proved as theorems or definitions" lists 5 identifiers (q_linear_independent_distinct_distances, erdos_hajnal_necessity, finite_partition_impossible_without_ch, countable_vs_finite_distinction, erdos_distinct_distances_lower_bound) — none appear anywhere in the file.
- Section line drift: davies-theorem, kunen-theorem, necessity-of-ch, summary all wrong; Parts VIII (Countable vs Finite Distinction) and IX (Related Concepts) absent from `sections` list.
- Minor: `Mathlib.Data.Real.Basic` imported in Lean but missing from `mathlibDependencies`.

Counts that were correct: axiomCount=5, sorries=0, lineCount=279, badge=axiom, status=axiomatized.

## Test plan
- [ ] Tracker JSON entry updated; no other lines changed (clean 6/4 diff with non-ASCII preserved).