### PR TITLE
fix(meta): erdos-1132 phantom erdos_lower_bound + section line drift + imports drift

### DIFF
--- a/src/data/proofs/erdos-1132/meta.json
+++ b/src/data/proofs/erdos-1132/meta.json
@@ -62,7 +62,6 @@
       "almostEverywhereGrowth predicate: Erdős Question 2",
       "denseGoodPoints predicate: Bernstein's result",
       "bernstein_density_theorem: dense good points",
-      "erdos_lower_bound: (2/π)log(n) lower bound",
       "erdos_max_theorem: maximum exceeds threshold"
     ],
     "axiomCount": 2,
@@ -91,50 +90,50 @@
       "id": "lagrange-basis",
       "title": "Lagrange Basis Polynomials",
       "summary": "lagrangeBasis definition and fundamental properties",
-      "startLine": 39,
-      "endLine": 68
+      "startLine": 40,
+      "endLine": 78
     },
     {
       "id": "lebesgue-function",
       "title": "The Lebesgue Function",
       "summary": "lebesgueFunction, lebesgueConstant, lower bound ≥ 1",
-      "startLine": 69,
-      "endLine": 94
+      "startLine": 80,
+      "endLine": 152
     },
     {
       "id": "growth-bounds",
       "title": "Growth of Lebesgue Constants",
       "summary": "Erdős lower bound, Chebyshev nodes, optimal growth rate",
-      "startLine": 95,
-      "endLine": 125
+      "startLine": 154,
+      "endLine": 180
     },
     {
       "id": "main-questions",
       "title": "The Main Questions",
       "summary": "existsGoodPoint, almostEverywhereGrowth predicates",
-      "startLine": 126,
-      "endLine": 161
+      "startLine": 181,
+      "endLine": 215
     },
     {
       "id": "partial-results",
       "title": "Partial Results",
       "summary": "bernstein_density_theorem, erdos_max_theorem",
-      "startLine": 162,
-      "endLine": 191
+      "startLine": 217,
+      "endLine": 245
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "summary": "equidistantNodes and exponential growth",
-      "startLine": 192,
-      "endLine": 208
+      "startLine": 247,
+      "endLine": 260
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_1132 and erdos_1132_summary theorems",
-      "startLine": 209,
-      "endLine": 245
+      "startLine": 261,
+      "endLine": 297
     }
   ],
   "conclusion": {
@@ -229,10 +228,10 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib.Analysis.Calculus.LagrangeInterpolation",
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
       "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
-      "Mathlib.Topology.MetricSpace.Basic"
+      "Mathlib.Topology.MetricSpace.Basic",
+      "Mathlib.LinearAlgebra.Lagrange"
     ],
     "opens": [
       "Real",


### PR DESCRIPTION
## Fix

Three fixes to `erdos-1132/meta.json`.

## Evidence

**Issue 1 — Phantom contribution**:
- Removed `"erdos_lower_bound: (2/π)log(n) lower bound"` from `originalContributions`. No `erdos_lower_bound` declaration exists in the Lean file — only an orphaned docstring at line 159. The actual lower-bound axiom is `erdos_max_theorem`.

**Issue 2 — Section line drift (7 sections all off)**:
| section | before | after |
|---|---|---|
| lagrange-basis | 39–68 | 40–78 |
| lebesgue-function | 69–94 | 80–152 |
| growth-bounds | 95–125 | 154–180 |
| main-questions | 126–161 | 181–215 |
| partial-results | 162–191 | 217–245 |
| special-cases | 192–208 | 247–260 |
| summary | 209–245 | 261–297 |

**Issue 3 — Imports drift**:
- Dropped `Mathlib.Analysis.Calculus.LagrangeInterpolation` (commented out in Lean file, doesn't exist in Mathlib v4.26)
- Added `Mathlib.LinearAlgebra.Lagrange` (the actual import used for Lagrange basis functions)

Closes #14759

---
Automated fix by lean-mechanic agent.