### PR TITLE
audit(tracker): erdos-1122 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3952,10 +3952,16 @@
       "result": "issues-fixed"
     },
     "erdos-1122": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "phantom 'erdos_1122' axiom claim in originalContributions/proofStrategy (only docstring placeholder)",
+        "phantom 'omega' axioms claimed in originalContributions/proofStrategy (none declared)",
+        "conclusion.summary states '7 axioms' and '217 lines'; actual is 3 axioms / 208 lines",
+        "section line drift: sec-hierarchy/examples/summary off by 5-9 lines"
+      ],
+      "lastAudited": "2026-05-02T12:55:29Z",
+      "result": "issues-found",
+      "notes": "Issue #14781 — phantom axioms (erdos_1122, omega_*) in narrative; meta.axiomCount=3 is correct"
     },
     "erdos-1123": {
       "auditCount": 2,


### PR DESCRIPTION
Marks erdos-1122 audit as issues-found. See #14781 for details:

- `originalContributions[9]` claims `erdos_1122` axiom (only docstring placeholder, not declared)
- `originalContributions[11]` claims plural omega "axioms" (none declared)
- `conclusion.summary` states "7 axioms" and "217 lines" when actual is 3 axioms / 208 lines
- Last 3 sections (sec-hierarchy / sec-examples / sec-summary) drift 5-9 lines

`meta.axiomCount=3` and `meta.assumptions` field are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)