### PR TITLE
audit(tracker): erdos-1123 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3964,10 +3964,14 @@
       "notes": "Issue #14781 — phantom axioms (erdos_1122, omega_*) in narrative; meta.axiomCount=3 is correct"
     },
     "erdos-1123": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "proofStrategy claims 'axiomatizes the Just-Krawczyk conditional isomorphism and ZFC independence' — neither is axiomatized (only docstring placeholders)",
+        "section line drift: just-krawczyk (80-97 vs actual 80-88), ideal-properties (98-110 vs actual 89-94); Part V Summary missing from sections array"
+      ],
+      "lastAudited": "2026-05-02T13:17:48Z",
+      "result": "issues-found",
+      "notes": "Issue #14783 — proofStrategy overstates axiomatization; meta.axiomCount=2 is correct"
     },
     "erdos-1124": {
       "auditCount": 3,


### PR DESCRIPTION
Marks erdos-1123 audit as issues-found. See #14783 for details:

- `overview.proofStrategy` claims the Just-Krawczyk conditional isomorphism and ZFC independence are "axiomatized" — neither is declared in the Lean file (only docstring placeholders in Part III).
- `sections[].startLine/endLine` drift in `just-krawczyk` (80-97 vs actual 80-88) and `ideal-properties` (98-110 vs actual 89-94); Part V Summary (lines 95-110) missing from sections array entirely.

`meta.axiomCount=2`, `originalContributions`, `assumptions` field — all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)