### PR TITLE
audit(tracker): erdos-1120 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3940,10 +3940,12 @@
       "result": "issues-fixed"
     },
     "erdos-1120": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "section line drift across all sections + missing main-open-problem section (filed #14785)"
+      ],
+      "lastAudited": "2026-05-02T13:32:17Z",
+      "result": "issues-found"
     },
     "erdos-1121": {
       "auditCount": 2,


### PR DESCRIPTION
Marks erdos-1120 audit as issues-found. See #14785 for details:

- All `sections[].startLine/endLine` drift by 6-12 lines from actual `-- ##` markers in `proofs/Proofs/Erdos1120Problem.lean`.
- The final `## Main Open Problem Statement` section (`erdos_1120_main` theorem) is collapsed into the `conjectures` section in meta.json.

Numerical counts (`sorries=0`, `axiomCount=2`, `theoremCount=14`, `lineCount=183`, 4 defs + 1 structure) all verify correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)