### PR TITLE
audit(tracker): erdos-1121 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3946,10 +3946,12 @@
       "result": "issues-fixed"
     },
     "erdos-1121": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "section drift in special-cases/higher-dim, missing summary section, originalContributions overstates two phantom claims (filed #14787)"
+      ],
+      "lastAudited": "2026-05-02T13:34:52Z",
+      "result": "issues-found"
     },
     "erdos-1122": {
       "auditCount": 3,


### PR DESCRIPTION
Marks erdos-1121 audit as issues-found. See #14787 for details:

- `sections[]`: line drift in `special-cases` (165-194 vs actual 165-184) and `higher-dim` (195-218 vs actual 185-201); Part VII Summary (lines 203-217) missing from sections array.
- `originalContributions[]`: claims "Special cases: two circles, overlapping implies connected" and "Higher-dimensional Ball structure and generalization axiom" — neither the special-case theorems nor the higher-dim axiom are actually declared in the Lean file (only docstrings).

`meta.axiomCount=1`, `theoremCount=1`, `lineCount=218`, `sorries=0` — all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)