### PR TITLE
audit(tracker): erdos-1114 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3889,9 +3889,12 @@
     },
     "erdos-1114": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T13:36:47Z",
+      "result": "issues-found",
+      "issues": [
+        "systemic section drift (6 of 7 sections, +8 to +22 lines), proofStrategy claims a phantom axiomatization (filed #14789)"
+      ]
     },
     "erdos-1115": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-1114 audit as issues-found. See #14789 for details:

- Systemic `sections[].startLine/endLine` drift: 6 of 7 sections off by +8 to +22 lines (`critical-points` 60-81 vs actual 60-73, …, `summary` 169-171 vs actual 147-170).
- `overview.proofStrategy` step 2 claims a "Rolle Application" axiom — not declared in the file; the strict-ordering and Rolle-bounds properties are hypotheses of `balint_theorem`, not standalone axioms.

`meta.axiomCount=2`, `theoremCount=1`, `definitionCount=6`, `lineCount=171`, `sorries=0` — all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)