### PR TITLE
audit(tracker): erdos-1109 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3853,9 +3853,9 @@
     },
     "erdos-1109": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T13:40:18Z",
+      "result": "issues-found"
     },
     "erdos-111": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Marks erdos-1109 as `issues-found` in `audit-tracker.json`
- See integrity issue #14791 for findings:
  - Phantom `erdos_sarkozy_lower_1987` / `erdos_sarkozy_upper_1987` axiom claims (the file has only the 2 Konyagin axioms)
  - Section line drift across all 9 sections (off 4–100 lines)

## Test plan
- [x] No unicode escapes in tracker (manually re-applied with `ensure_ascii=False`)
- [x] Diff is 3 lines, scoped to erdos-1109 entry only

🤖 Generated with [Claude Code](https://claude.com/claude-code)