### PR TITLE
audit(tracker): erdos-111 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3859,9 +3859,9 @@
     },
     "erdos-111": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T13:45:39Z",
+      "result": "issues-found"
     },
     "erdos-1110": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Updates audit-tracker for erdos-111 to `issues-found`. Filed integrity issue #14795:

- 3 phantom-axiom names in `sections[].summary` (`chromaticNumber`, `bipartite_iff_no_odd_cycle`, `ehs_lower_bound` — none exist as declarations)
- Section line ranges drift 6–18 lines from actual `## Part …` markers
- 4 orphan docstrings in source claim "Axiomatized…" but no axiom follows

Numerical counts verify (sorries=0, axioms=4, theorems=2, defs=9, lines=320).

🤖 Generated with [Claude Code](https://claude.com/claude-code)