### PR TITLE
fix(meta): erdos-1121 section line drift + missing summary section + originalContributions overstatement

### DIFF
--- a/src/data/proofs/erdos-1121/meta.json
+++ b/src/data/proofs/erdos-1121/meta.json
@@ -37,8 +37,8 @@
       "Lean definitions of Circle, Line, and geometric predicates",
       "Formal statement of 'no separating line' condition",
       "ErdosConjecture1121 and Goodman-Goodman theorem axiom",
-      "Special cases: two circles, overlapping implies connected",
-      "Higher-dimensional Ball structure and generalization axiom"
+      "CirclesOverlap predicate definition",
+      "Higher-dimensional Ball structure (no generalization axiom declared)"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 1,
@@ -106,17 +106,25 @@
       "id": "special-cases",
       "title": "Part V: Special Cases",
       "startLine": 165,
-      "endLine": 194,
-      "summary": "Two circles case and overlapping circles.",
-      "mathContext": "Two circles case and overlapping circles."
+      "endLine": 184,
+      "summary": "Defines `CirclesOverlap` predicate. Two-circle case and 'overlapping implies connected' are documented in source docstrings — no corresponding Lean theorem declarations exist.",
+      "mathContext": "`CirclesOverlap` definition. Docstring-only: two-circles case and overlapping-implies-no-separating-line (no Lean declarations)."
     },
     {
       "id": "higher-dim",
       "title": "Part VI: Higher Dimensional Generalization",
-      "startLine": 195,
-      "endLine": 218,
-      "summary": "Ball structure in ℝⁿ and generalization axiom.",
-      "mathContext": "Ball structure in ℝⁿ and generalization axiom."
+      "startLine": 185,
+      "endLine": 201,
+      "summary": "Defines `Ball` structure for higher-dimensional generalization. Generalization axiom is mentioned in a docstring — no Lean axiom declaration exists in this section.",
+      "mathContext": "`Ball` structure definition. Docstring-only: higher-dimensional generalization (no axiom declared)."
+    },
+    {
+      "id": "summary",
+      "title": "Part VII: Summary",
+      "startLine": 203,
+      "endLine": 217,
+      "summary": "`erdos_1121_summary` theorem: proved conjunction of the Goodman-Goodman theorem and related results.",
+      "mathContext": "`erdos_1121_summary` theorem combining the main axiom and definitions."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Corrects section line ranges, adds missing Part VII summary section, and trims phantom claims from `originalContributions` in `src/data/proofs/erdos-1121/meta.json`.

## Evidence

**Sections**:
- `special-cases`: endLine 194 → 184 (was absorbing Part VI content)
- `higher-dim`: startLine 195 → 185, endLine 218 → 201 (was absorbing Part VII content)
- **Added** `summary`: 203-217 (Part VII with `erdos_1121_summary` theorem was missing)

**originalContributions**:
- "Special cases: two circles, overlapping implies connected" → "`CirclesOverlap` predicate definition" (no two-circles theorem or overlapping-implies-connected theorem declared; lines 169-173 and 182-184 are docstrings only)
- "Higher-dimensional Ball structure and generalization axiom" → "Higher-dimensional Ball structure (no generalization axiom declared)" (lines 198-201 are a docstring; no axiom follows)

Closes #14787

---
Automated fix by lean-mechanic agent.