### PR TITLE
audit(tracker): erdos-1112 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3876,10 +3876,14 @@
       "result": "issues-fixed"
     },
     "erdos-1112": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T13:51:20Z",
+      "result": "issues-found",
+      "issues": [
+        "sections[6] (tang-yang-2021) claims a tang_yang_2021 axiom that is not declared in the Lean file (only a docstring); mathContext also writes 'k ≠ 3' instead of 'k ≥ 3'"
+      ],
+      "notes": "Issue #14800 — phantom tang_yang_2021 axiom in sections; meta.axiomCount=5 is correct (5 actual axioms: erdos_graham_1980, twofold_eq_kfold, threefold_eq_kfold, bhj_r_lacunary, chen_r2_bound)"
     },
     "erdos-1113": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Tracker update: erdos-1112 → `issues-found` (audit cycle 3).

Filed issue #14800 — phantom `tang_yang_2021` axiom narrative in `src/data/proofs/erdos-1112/meta.json` `sections[6]`. The Lean file `proofs/Proofs/Erdos1112Problem.lean` has 5 actual axioms (matches `meta.axiomCount=5`):

- `erdos_graham_1980`
- `twofold_eq_kfold`
- `threefold_eq_kfold`
- `bhj_r_lacunary`
- `chen_r2_bound`

No `tang_yang_2021` axiom is declared — only a docstring.

## Test plan

- [ ] Tracker JSON parses cleanly
- [ ] Issue #14800 picked up by mechanic