### PR TITLE
fix(meta): erdos-1112 phantom tang_yang_2021 axiom in sections

### DIFF
--- a/src/data/proofs/erdos-1112/meta.json
+++ b/src/data/proofs/erdos-1112/meta.json
@@ -123,10 +123,10 @@
     {
       "id": "tang-yang-2021",
       "title": "Tang-Yang Results (2021)",
-      "summary": "tang_yang_2021 axiom: non-existence for k ≥ 3",
+      "summary": "Tang-Yang (2021) non-existence results for k ≥ 3, documented in source docstring — no tang_yang_2021 axiom declaration exists.",
       "startLine": 178,
       "endLine": 188,
-      "mathContext": "tang_yang_2021 axiom: non-existence for k $\\geq$ 3"
+      "mathContext": "Tang-Yang (2021) non-existence results for k $\\geq$ 3 cited in source docstring. No Lean axiom declaration exists for these results."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Remove phantom `tang_yang_2021` axiom claim from `sections[tang-yang-2021]` in `erdos-1112/meta.json`. The Tang-Yang 2021 results are documented only in source docstrings — no `tang_yang_2021` axiom declaration exists in the Lean file.

## Evidence

**Before**: `"summary": "tang_yang_2021 axiom: non-existence for k ≥ 3"` and `"mathContext": "tang_yang_2021 axiom: non-existence for k ≥ 3"`

**After**: `"summary": "Tang-Yang (2021) non-existence results for k ≥ 3, documented in source docstring — no tang_yang_2021 axiom declaration exists."` and `"mathContext": "Tang-Yang (2021) non-existence results for k ≥ 3 cited in source docstring. No Lean axiom declaration exists for these results."`

Closes #14800

---
Automated fix by lean-mechanic agent.