### PR TITLE
audit(tracker): erdos-1111 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3870,10 +3870,12 @@
       "result": "clean"
     },
     "erdos-1111": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T13:55:59Z",
+      "result": "issues-found",
+      "notes": "Issue #14804 — phantom-axiom narrative: proofStrategy/sections claim axioms for Reduction-to-t<=c, general c=3 bound, Ramsey/chi-boundedness; only orphan docstrings exist (numerical counts correct)",
+      "issues": []
     },
     "erdos-1112": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit result

**Proof:** erdos-1111 (Anticomplete High-Chromatic Subgraphs)
**Result:** issues-found
**Issue:** #14804

## Findings

Numerical counts (axioms=6, sorries=0, lineCount=224, theorems=2, defs=7) match the Lean file. Status `axiomatized` and badge `axiom` are appropriate.

Phantom-axiom narrative pattern in meta.json:

- `overview.proofStrategy` lists "reduction to t ≤ c" alongside the El Zahar-Erdős axiom — but no such axiom is declared.
- `sections[el-zahar-erdos-1985].mathContext` lists "Reduction to t ≤ c, d(3, 3) ≤ 8, general c = 3 bound" — only `d(3, 3) ≤ 8` is a real axiom.
- `sections[connections].mathContext` says "Axiomatized: Ramsey connection and chi-boundedness axioms" — Part VII contains zero declarations, only orphan `/-- ... -/` docstrings.

## Tracker change

Bumps `auditCount` 2 → 3, sets `lastAudited`, `result: "issues-found"`, links #14804.