### PR TITLE
fix(meta): erdos-111 phantom axioms + section drift + orphan docstrings

### DIFF
--- a/proofs/Proofs/Erdos111Problem.lean
+++ b/proofs/Proofs/Erdos111Problem.lean
@@ -108,13 +108,6 @@ A graph is k-colorable if it admits a proper coloring with at most k colors.
 def IsKColorable {V : Type*} (G : SimpleGraph V) (k : ℕ) : Prop :=
   ∃ f : V → Fin k, IsProperColoring G f
 
-/--
-**Chromatic Number (for finite graphs):**
-The minimum number of colors needed for a proper coloring.
-
-Axiomatized to avoid decidability issues with IsKColorable.
--/
-/-- Every finite graph is k-colorable for some k. -/
 /-
 ## Part IV: Infinite Chromatic Number
 
@@ -151,11 +144,6 @@ def hasOddCycle {V : Type*} (G : SimpleGraph V) : Prop :=
     (∀ i : Fin (2*n + 1), G.Adj (c i) (c ⟨(i.val + 1) % (2*n + 1), Nat.mod_lt _ (by omega)⟩)) ∧
     Function.Injective (fun i : Fin (2*n) => c ⟨i.val, by omega⟩)
 
-/--
-**Bipartite iff No Odd Cycles:**
-A graph is bipartite if and only if it contains no odd cycle.
-This is a classical theorem in graph theory.
--/
 /-
 ## Part VI: Vertex-Disjoint Odd Cycles
 
@@ -174,14 +162,6 @@ def hasVertexDisjointOddCycles {V : Type*} (G : SimpleGraph V) (κ : Cardinal) :
       Set.range path = cycles i ∧
       ∀ k : Fin (2*n + 1), G.Adj (path k) (path ⟨(k.val + 1) % (2*n + 1), Nat.mod_lt _ (by omega)⟩))
 
-/--
-**Erdős-Hajnal-Szemerédi Lower Bound:**
-Every graph with chromatic number ℵ₁ contains ℵ₁ many vertex-disjoint odd cycles
-of some fixed odd length 2r+1. This implies h_G(n) ≫ n.
-
-Proof sketch: If χ(G) = ℵ₁, then G is not countably colorable.
-By a compactness argument, G must contain uncountably many vertex-disjoint odd cycles.
--/
 /--
 **h_G(n) ≫ n for χ(G) = ℵ₁:**
 If G has chromatic number ℵ₁, then h_G(n)/n → ∞ at least linearly.

--- a/src/data/proofs/erdos-111/annotations.json
+++ b/src/data/proofs/erdos-111/annotations.json
@@ -99,8 +99,8 @@
     "id": "ann-e111-cardinal-chromatic",
     "proofId": "erdos-111",
     "range": {
-      "startLine": 131,
-      "endLine": 145
+      "startLine": 122,
+      "endLine": 130
     },
     "type": "concept",
     "title": "Cardinal Chromatic Number",
@@ -119,8 +119,8 @@
     "id": "ann-e111-odd-cycles",
     "proofId": "erdos-111",
     "range": {
-      "startLine": 152,
-      "endLine": 168
+      "startLine": 142,
+      "endLine": 145
     },
     "type": "concept",
     "title": "Odd Cycles and Bipartiteness",
@@ -232,8 +232,8 @@
     "id": "ann-e111-related",
     "proofId": "erdos-111",
     "range": {
-      "startLine": 277,
-      "endLine": 300
+      "startLine": 249,
+      "endLine": 264
     },
     "type": "concept",
     "title": "Related Results and Finite Cases",
@@ -251,8 +251,8 @@
     "id": "ann-e111-summary",
     "proofId": "erdos-111",
     "range": {
-      "startLine": 315,
-      "endLine": 320
+      "startLine": 285,
+      "endLine": 300
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-111/meta.json
+++ b/src/data/proofs/erdos-111/meta.json
@@ -66,7 +66,7 @@
       "erdos_111_summary theorem: combining known bounds"
     ],
     "axiomCount": 4,
-    "lineCount": 320,
+    "lineCount": 300,
     "assumptions": "4 axioms: edgeDeletionFunction, cardinalChromaticNumber, h_at_least_linear, ehs_upper_bound. 0 sorries."
   },
   "overview": {
@@ -95,88 +95,88 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "Bipartite graphs and edge sets",
-      "startLine": 38,
-      "endLine": 62,
+      "startLine": 39,
+      "endLine": 61,
       "mathContext": "Bipartite graph: vertex set splits into $A \\\\cup B$ with edges only between $A$ and $B$. Equivalently: no odd cycle."
     },
     {
       "id": "edge-deletion",
       "title": "Edge Deletion to Bipartiteness",
-      "summary": "edgesToRemoveForBipartite and edgeDeletionFunction h_G (axiomatized)",
-      "startLine": 63,
-      "endLine": 92,
+      "summary": "edgeDeletionFunction h_G (axiomatized)",
+      "startLine": 62,
+      "endLine": 89,
       "mathContext": "$h_G(n)$: min edges to remove from $G[S]$ to make it bipartite, maximized over $|S| = n$. Measures non-bipartiteness of $n$-vertex subgraphs."
     },
     {
       "id": "chromatic-number",
       "title": "Chromatic Number",
-      "summary": "IsProperColoring, IsKColorable, chromaticNumber (axiomatized)",
-      "startLine": 93,
-      "endLine": 125,
+      "summary": "IsProperColoring, IsKColorable",
+      "startLine": 90,
+      "endLine": 110,
       "mathContext": "$\\\\chi(G)$: minimum colors for proper coloring. $\\\\chi(G) = 2 \\\\iff G$ bipartite (for connected graphs)."
     },
     {
       "id": "infinite-chromatic",
       "title": "Infinite Chromatic Number",
       "summary": "cardinalChromaticNumber (axiomatized), hasAleph1ChromaticNumber",
-      "startLine": 126,
-      "endLine": 146,
+      "startLine": 111,
+      "endLine": 131,
       "mathContext": "Cardinal chromatic number: $\\\\chi(G) = \\\\aleph_1$ (uncountably many colors needed). Requires $G$ to be an uncountable graph."
     },
     {
       "id": "odd-cycles",
       "title": "Odd Cycles and Bipartiteness",
-      "summary": "hasOddCycle, bipartite_iff_no_odd_cycle axiom",
-      "startLine": 147,
-      "endLine": 169,
+      "summary": "hasOddCycle",
+      "startLine": 132,
+      "endLine": 146,
       "mathContext": "Odd cycle in $G \\\\Rightarrow G$ not bipartite. Bipartite iff no odd cycle (characterization). $h_G(n)$ counts how far from bipartite."
     },
     {
       "id": "vertex-disjoint-cycles",
       "title": "Vertex-Disjoint Odd Cycles",
-      "summary": "hasVertexDisjointOddCycles, ehs_lower_bound, h_at_least_linear",
-      "startLine": 170,
-      "endLine": 208,
+      "summary": "hasVertexDisjointOddCycles, h_at_least_linear",
+      "startLine": 147,
+      "endLine": 173,
       "mathContext": "Erdos-Hajnal-Szemeredi: $h_G(n) \\\\geq cn$ (linear lower bound). From vertex-disjoint odd cycles in non-bipartite subgraphs."
     },
     {
       "id": "upper-bound",
       "title": "Upper Bound Construction",
       "summary": "ehs_upper_bound axiom",
-      "startLine": 209,
-      "endLine": 227,
+      "startLine": 174,
+      "endLine": 192,
       "mathContext": "EHS upper bound: $h_G(n) \\\\leq Cn$ for some constant $C$ depending on $G$."
     },
     {
       "id": "erdos-conjecture",
       "title": "Erdős's Conjecture",
       "summary": "erdosConjecture111 definition",
-      "startLine": 228,
-      "endLine": 247,
+      "startLine": 193,
+      "endLine": 212,
       "mathContext": "Erdos conjecture: $h_G(n)/n \\\\to \\\\infty$ for graphs with $\\\\chi(G) = \\\\aleph_1$. Super-linear growth of non-bipartiteness."
     },
     {
       "id": "main-question",
       "title": "The Main Open Question",
       "summary": "erdos111_question, erdos_111_gap_exists",
-      "startLine": 248,
-      "endLine": 276,
+      "startLine": 213,
+      "endLine": 242,
       "mathContext": "OPEN: does $h_G(n)/n \\\\to \\\\infty$? Known: $h_G(n) \\\\geq cn$ (linear). Unknown: super-linear."
     },
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "Connection to Problem #74, finite_bipartite_zero",
-      "startLine": 277,
-      "endLine": 301,
+      "summary": "Connection to Problem #74, finite graph comparison",
+      "startLine": 243,
+      "endLine": 264,
       "mathContext": "Connection to Problem #74. Finite bipartite: $h_G(n) = 0$ (trivially bipartite subgraphs)."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_111_summary theorem combining known bounds",
-      "startLine": 302,
-      "endLine": 320,
+      "startLine": 265,
+      "endLine": 300,
       "mathContext": "OPEN. Known: $cn \\\\leq h_G(n) \\\\leq Cn$ (linear bounds). Conjecture: $h_G(n)/n \\\\to \\\\infty$ for $\\\\aleph_1$-chromatic graphs."
     }
   ],
@@ -303,7 +303,7 @@
       "Set"
     ],
     "namespace": "Erdos111",
-    "lineCount": 320,
+    "lineCount": 300,
     "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Three independent meta/source mismatches in erdos-111:

1. **Phantom axiom names in `sections[].summary`** — removed `chromaticNumber (axiomatized)`, `bipartite_iff_no_odd_cycle axiom`, and `ehs_lower_bound` which do not exist as declarations
2. **Section line ranges** — re-anchored all 11 section ranges to actual `## Part …` block-comment positions (all were drifted 3–17 lines)
3. **Orphan docstrings** — removed 3 orphan docstring blocks from `Erdos111Problem.lean` (lines 111–117, 154–158, 177–184) that claimed axioms not present in the file

Also updated annotation line ranges in `annotations.json` that became stale due to the orphan docstring removal, and corrected `lineCount` from 320 to 300.

## Evidence

**Before**: `sections[chromatic-number].summary` = `"IsProperColoring, IsKColorable, chromaticNumber (axiomatized)"` — no `chromaticNumber` axiom exists

**After**: `"IsProperColoring, IsKColorable"`

Closes #14795

---
Automated fix by lean-mechanic agent.