### PR TITLE
fix(meta): erdos-1102 phantom axioms + section drift + orphan docstrings

### DIFF
--- a/proofs/Proofs/Erdos1102Problem.lean
+++ b/proofs/Proofs/Erdos1102Problem.lean
@@ -92,18 +92,21 @@ noncomputable def squarefreeDensity : ℝ := 6 / Real.pi^2
 
 /- ## Main Results (van Doorn-Tao 2025) -/
 
-/-- **Axiom (van Doorn-Tao 2025):**
+/- **Result (van Doorn-Tao 2025):**
     Any sequence with property P has density 0.
 
-    If A = {a₁ < a₂ < ...} has property P, then aⱼ / j → ∞. -/
-/-- **Axiom (van Doorn-Tao 2025):**
+    If A = {a₁ < a₂ < ...} has property P, then aⱼ / j → ∞.
+    (Not axiomatized: documented in source commentary only.) -/
+/- **Result (van Doorn-Tao 2025):**
     Sequences with property P can have density going to 0 arbitrarily slowly.
 
-    For any function f → ∞, there exists A with property P and aⱼ/j ≤ f(j). -/
-/-- **Axiom (van Doorn-Tao 2025):**
+    For any function f → ∞, there exists A with property P and aⱼ/j ≤ f(j).
+    (Not axiomatized: documented in source commentary only.) -/
+/- **Result (van Doorn-Tao 2025):**
     Any sequence with property Q has upper density at most 6/π².
 
-    If A = {a₁ < a₂ < ...} has property Q, then limsup (j/aⱼ) ≤ 6/π². -/
+    If A = {a₁ < a₂ < ...} has property Q, then limsup (j/aⱼ) ≤ 6/π².
+    (Not axiomatized: documented in source commentary only.) -/
 /-- **Axiom (van Doorn-Tao 2025):**
     There exists a sequence with property Q achieving density 6/π².
 
@@ -147,8 +150,9 @@ def powersOfTwoMinus1 : ℕ → ℕ := fun n => 2^n - 1
 /-- The sequence 2^n + 1 -/
 def powersOfTwoPlus1 : ℕ → ℕ := fun n => 2^n + 1
 
-/-- **Axiom (van Doorn-Tao 2025):**
+/- **Conjecture/Result (van Doorn-Tao 2025):**
     The sequences 2^n ± 1 and n! ± 1 have property Q.
 
-    Whether they have property P remains open. -/
+    Whether they have property P remains open.
+    (Not axiomatized: documented in source commentary only.) -/
 end Erdos1102

--- a/src/data/proofs/erdos-1102/meta.json
+++ b/src/data/proofs/erdos-1102/meta.json
@@ -42,7 +42,7 @@
     "originalContributions": [
       "Definition of properties P and Q for sequences",
       "Formalization of squarefree density bounds",
-      "Statement of van Doorn-Tao results as axioms",
+      "Statement of the van Doorn-Tao Q-sequence existence result as an axiom (`propertyQ_achievable`)",
       "Connection between squarefree numbers and π"
     ],
     "axiomCount": 1,
@@ -53,7 +53,7 @@
     "historicalContext": "Erdős Problem 1102 was posed in 1981 and concerns the interplay between sequences and squarefree numbers. A number is squarefree if no prime square divides it—equivalently, all prime exponents in its factorization are 0 or 1.\n\nErdős defined two properties based on squarefree translates:\n- **Property P:** For every n ≥ 1, only finitely many elements a ∈ A have n + a squarefree\n- **Property Q:** Infinitely many n have n + a squarefree for all a < n in A\n\nThe density of squarefree numbers is 6/π² ≈ 0.608 (this equals 1/ζ(2)), and this constant plays a central role in the resolution.\n\nvan Doorn and Tao (2025) provided complete answers to Erdős's questions about growth rates, using techniques from analytic number theory and the distribution of squarefree numbers.",
     "problemStatement": "A number is **squarefree** if not divisible by any perfect square > 1.\n\n**Property P:** For every n ≥ 1, only finitely many a ∈ A have n + a squarefree.\n\n**Property Q:** Infinitely many n have n + a squarefree for all a < n in A.\n\nHow fast must sequences A = {a₁ < a₂ < ···} with properties P or Q grow?\n\n**Answer (van Doorn-Tao 2025):**\n- P-sequences have density 0, but can decay arbitrarily slowly\n- Q-sequences have upper density ≤ 6/π², with equality achievable",
     "text": "How fast must sequences with squarefree properties P or Q grow? van Doorn-Tao (2025) resolved this: P-sequences have density 0, Q-sequences have upper density at most 6/π².",
-    "proofStrategy": "The resolution uses deep results from analytic number theory:\n\n**Property P:** van Doorn-Tao show that aⱼ/j → ∞ for any P-sequence. The key is that for fixed n, the density of a with n + a squarefree is positive (close to 6/π²), so P-sequences must be sparse. However, for any function f → ∞, there exist P-sequences with aⱼ/j ≤ f(j).\n\n**Property Q:** The squarefree numbers themselves form an optimal Q-sequence with density 6/π². For any Q-sequence, considering random n shows the upper density cannot exceed 6/π² (the probability that n + a is squarefree for random a < n).\n\n**Special Sequences:** The sequences 2ⁿ ± 1 and n! ± 1 grow fast enough to have property Q. Whether they have property P remains open.",
+    "proofStrategy": "The formalization axiomatizes one key result from van Doorn-Tao (2025): `propertyQ_achievable` — the squarefree numbers form an optimal Q-sequence achieving density 6/π². Two theorems are derived from this single axiom.\n\n**Discussion only (not axiomatized):**\n- Property P density-0 result (aⱼ/j → ∞)\n- Slow-decay existence for P-sequences\n- Q-sequence upper density ≤ 6/π²\n- Property Q for 2ⁿ ± 1 and n! ± 1\n\nThese results are documented in plain comments in the Lean source but no corresponding axiom or theorem declarations exist.",
     "keyInsights": [
       "**The magic constant 6/π²:** This is 1/ζ(2), the density of squarefree numbers, and appears as the optimal bound for Q-sequences.",
       "**Squarefree numbers:** Numbers not divisible by any square > 1. The sequence 1, 2, 3, 5, 6, 7, 10, 11, 13, 14, ... forms the canonical Q-sequence.",
@@ -72,7 +72,7 @@
       "id": "definitions",
       "title": "Definitions",
       "startLine": 50,
-      "endLine": 65,
+      "endLine": 64,
       "summary": "Properties P and Q formalized as set predicates.",
       "mathContext": "Properties P and Q formalized as set predicates."
     },
@@ -80,7 +80,7 @@
       "id": "squarefree-set",
       "title": "The Squarefree Numbers",
       "startLine": 66,
-      "endLine": 92,
+      "endLine": 91,
       "summary": "The set of squarefree numbers with examples and density constant.",
       "mathContext": "The set of squarefree numbers with examples and density constant."
     },
@@ -88,25 +88,25 @@
       "id": "main-axioms",
       "title": "Main Axioms (van Doorn-Tao)",
       "startLine": 93,
-      "endLine": 130,
-      "summary": "Density bounds for P and Q sequences stated as axioms from the 2025 paper.",
-      "mathContext": "Density bounds for P and Q sequences stated as axioms from the 2025 paper."
+      "endLine": 115,
+      "summary": "One axiom from the 2025 paper: `propertyQ_achievable` (Q-sequence existence at density 6/π²). Three additional results (P density-0, slow-decay existence, Q upper-bound) are documented in plain comments but not axiomatized.",
+      "mathContext": "Axiomatized: the Q-sequence existence result (`propertyQ_achievable`). P-density-0, slow-decay, and Q-upper-bound results are cited in commentary only."
     },
     {
       "id": "derived-theorems",
       "title": "Derived Theorems",
-      "startLine": 131,
-      "endLine": 153,
-      "summary": "Theorems combining the axioms to state that squarefree numbers form an optimal Q-sequence.",
-      "mathContext": "Theorems combining the axioms to state that squarefree numbers form an optimal Q-sequence."
+      "startLine": 117,
+      "endLine": 138,
+      "summary": "Theorems derived from the single axiom `propertyQ_achievable`: squarefree numbers form an optimal Q-sequence.",
+      "mathContext": "Theorems derived from the axiom `propertyQ_achievable` confirming squarefree numbers achieve the optimal Q-sequence density."
     },
     {
       "id": "special-sequences",
       "title": "Special Sequences",
-      "startLine": 154,
-      "endLine": 154,
-      "summary": "Results for 2ⁿ ± 1 and n! ± 1.",
-      "mathContext": "Results for 2ⁿ ± 1 and n! ± 1."
+      "startLine": 140,
+      "endLine": 153,
+      "summary": "`powersOfTwoMinus1` and `powersOfTwoPlus1` definitions; property Q for 2ⁿ ± 1 and n! ± 1 documented in commentary (not axiomatized).",
+      "mathContext": "Definitions of $2^n - 1$ and $2^n + 1$ sequences. Property Q for these sequences is cited in commentary; formal axiomatization is not present."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Three independent meta/source mismatches in erdos-1102:

1. **Phantom axioms** — `originalContributions` and `proofStrategy` implied multiple van Doorn-Tao results were axiomatized; only one axiom (`propertyQ_achievable`) exists. Updated narrative to accurately reflect the single axiomatization.

2. **Orphan docstrings** in Lean file — converted 4 `/-- **Axiom (van Doorn-Tao 2025):** ... -/` blocks that preceded no declarations (lines 95–106 and 150–153) to plain `/- ... -/` comments to avoid misrepresentation as axiom docstrings.

3. **Section line ranges** — re-anchored all section boundaries to actual content:
   - `definitions`: endLine 65→64
   - `squarefree-set`: endLine 92→91
   - `main-axioms`: endLine 130→115; updated summary/mathContext to describe single axiom
   - `derived-theorems`: startLine 131→117, endLine 153→138
   - `special-sequences`: startLine 154→140, endLine 154→153

## Evidence

**Before**: `sections[main-axioms].summary` = `"Density bounds for P and Q sequences stated as axioms"` (plural — only 1 axiom exists)

**After**: `"One axiom from the 2025 paper: propertyQ_achievable ..."`

Closes #14809

---
Automated fix by lean-mechanic agent.