### PR TITLE
audit(tracker): erdos-1104 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3817,9 +3817,12 @@
     },
     "erdos-1104": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T14:30:00Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom Kim/edge axiom claims + phantom sorry + section line drift + missing summary section (#14816)"
+      ]
     },
     "erdos-1105": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Audit tracker update for **erdos-1104** → `issues-found`.

Issue filed: #14816

## Findings

- Phantom Kim axiom claim in `ramsey-duality` section + `proofStrategy` (file has only a docstring + placeholder def, no axiom)
- Phantom edge-variant axiom claim in `edge-variant` section (only dangling docstrings, no theorems/axioms)
- Phantom sorry note in `basic-properties` section ("one sorry in empty graph chromatic number" — file has 0 sorries)
- Section line drift on ramsey-duality, asymptotic-bounds, edge-variant, mycielski (offsets 5–16 lines)
- `summary` section at lines 187–196 missing from `sections` array

## Numerical metadata (no change)

- `axiomCount: 3` ✓ (`erdos_1104_lower`, `erdos_1104_upper`, `mycielski_construction`)
- `sorries: 0` ✓
- `lineCount: 196` ✓
- `status: axiomatized`, `badge: axiom` ✓

Meta-only fix recommended. No Lean code changes needed.