### PR TITLE
fix(meta): erdos-1080 phantom contribution claims + section line drift

### DIFF
--- a/src/data/proofs/erdos-1080/annotations.json
+++ b/src/data/proofs/erdos-1080/annotations.json
@@ -22,8 +22,8 @@
     "id": "ann-e1080-bipartition",
     "proofId": "erdos-1080",
     "range": {
-      "startLine": 49,
-      "endLine": 57
+      "startLine": 57,
+      "endLine": 58
     },
     "type": "definition",
     "title": "Bipartition Definition",
@@ -41,8 +41,8 @@
     "id": "ann-e1080-edges-between",
     "proofId": "erdos-1080",
     "range": {
-      "startLine": 59,
-      "endLine": 77
+      "startLine": 63,
+      "endLine": 78
     },
     "type": "concept",
     "title": "Edges Between Parts",
@@ -59,8 +59,8 @@
     "id": "ann-e1080-cycle-def",
     "proofId": "erdos-1080",
     "range": {
-      "startLine": 89,
-      "endLine": 94
+      "startLine": 118,
+      "endLine": 119
     },
     "type": "definition",
     "title": "Cycle Definition",
@@ -78,8 +78,8 @@
     "id": "ann-e1080-cycle-free",
     "proofId": "erdos-1080",
     "range": {
-      "startLine": 96,
-      "endLine": 112
+      "startLine": 125,
+      "endLine": 137
     },
     "type": "definition",
     "title": "Cycle-Free Predicates",
@@ -134,8 +134,8 @@
     "id": "ann-e1080-lower-bound",
     "proofId": "erdos-1080",
     "range": {
-      "startLine": 155,
-      "endLine": 163
+      "startLine": 207,
+      "endLine": 213
     },
     "type": "concept",
     "title": "De Caen-Szekely Lower Bound",

--- a/src/data/proofs/erdos-1080/meta.json
+++ b/src/data/proofs/erdos-1080/meta.json
@@ -53,13 +53,11 @@
       "HasCycleOfLength definition: cycle detection predicate",
       "C4Free, C6Free, C4C6Free definitions: cycle-free predicates",
       "maxC4C6FreeEdges: extremal function f(n,m)",
-      "deCaen_szekely_upper_bound: O(n^(10/9)) upper bound",
-      "deCaen_szekely_lower_bound: Ω(n^(58/57)) lower bound",
-      "lazebnik_ustimenko_woldar_bound: Ω(n^(16/15)) improved bound",
+      "luw_superlinear axiom: LUW superlinear construction (formally axiomatized)",
       "erdos_conjecture_false: main disproof theorem",
-      "erdos_c8_observation: C_8 existence guarantee",
-      "kovari_sos_turan: classical extremal result",
-      "erdos_1080_summary: combined summary theorem"
+      "erdos_c8_observation: C_8 existence guarantee (axiom)",
+      "erdos_1080_summary: combined summary theorem",
+      "De Caen–Székely upper/lower bounds and Kővári-Sós-Turán are referenced in source comments; only LUW is formally axiomatized"
     ],
     "axiomCount": 2,
     "lineCount": 335,
@@ -69,7 +67,7 @@
     "historicalContext": "**Erdős Problem #1080**\n\nThis problem explores the threshold for forcing six-cycles in bipartite graphs with an imbalanced partition.\n\n**Key History:**\n- Erdős [Er75]: Posed the problem; noted that C_8 is forced\n- De Caen & Székely [DeSz92]: Disproved the conjecture, established bounds on f(n,m)\n- Faudree & Simonovits: Independently proved the general upper bound\n- Lazebnik, Ustimenko & Woldar [LUW94]: Improved the lower bound using algebraic constructions\n\n**Mathematical Setting:**\nThe problem concerns bipartite graphs G = (X ∪ Y, E) where |X| = ⌊n^(2/3)⌋ and the total vertex count is n. The question asks whether O(n) edges suffice to guarantee a 6-cycle.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet G be a bipartite graph on n vertices where one part has ⌊n^(2/3)⌋ vertices. Does there exist a constant c > 0 such that if G has at least cn edges, then G must contain a C_6 (6-cycle)?\n\n**Answer: NO**\n\nDe Caen and Székely (1992) showed no such constant exists. The extremal function f(n, ⌊n^(2/3)⌋) for C_4,C_6-free bipartite graphs satisfies:\n- Upper bound: O(n^(10/9))\n- Lower bound: Ω(n^(16/15)) (improved by Lazebnik-Ustimenko-Woldar)\n\nSince f grows superlinearly, no constant c works.",
     "text": "Is there a constant c > 0 such that bipartite graphs with n vertices (one part of size ⌊n^(2/3)⌋) and cn edges must contain a C_6? NO, disproved by De Caen-Székely (1992).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Structures:** Define bipartitions, bipartite graphs, and cycle predicates using Mathlib's SimpleGraph.\n\n2. **Extremal Function:** Define f(n,m) as the maximum edge count in C_4,C_6-free bipartite graphs.\n\n3. **Key Bounds:** Axiomatize De Caen-Székely and Lazebnik-Ustimenko-Woldar bounds.\n\n4. **Disproof:** Show that superlinear growth of f contradicts existence of constant c.\n\n5. **Contrast:** Note that C_8 IS forced by cn edges (Erdős's observation).\n\n6. **Related Results:** Include Kővári-Sós-Turán theorem connection.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Structures:** Define bipartitions, bipartite graphs, and cycle predicates using Mathlib's SimpleGraph.\n\n2. **Extremal Function:** Define f(n,m) as the maximum edge count in C_4,C_6-free bipartite graphs.\n\n3. **Key Bound:** Axiomatize the Lazebnik-Ustimenko-Woldar superlinear construction (`luw_superlinear`). De Caen-Székely upper/lower bounds appear only as source comments — no formal axiom or theorem for them exists.\n\n4. **Disproof:** Show that superlinear growth of f contradicts existence of constant c.\n\n5. **Contrast:** Note that C_8 IS forced by cn edges (Erdős's observation, axiomatized as `erdos_c8_observation`).\n\n6. **Related Results:** Kővári-Sós-Turán and C_4/K_{2,2} connections referenced in source comments; no formal declaration for them in the kernel.",
     "keyInsights": [
       "**Superlinear Growth:** f(n, ⌊n^(2/3)⌋) = Θ(n^α) for α ∈ (16/15, 10/9), so no linear bound exists",
       "**C_6 vs C_8 Dichotomy:** C_6 cannot be forced with O(n) edges, but C_8 can",
@@ -90,73 +88,73 @@
       "id": "bipartite-graphs",
       "title": "Bipartite Graphs and Bipartitions",
       "summary": "IsBipartition, bipartition_edges_between, IsBipartite definitions",
-      "startLine": 45,
-      "endLine": 84,
+      "startLine": 47,
+      "endLine": 108,
       "mathContext": "Formal definition: IsBipartition, bipartition_edges_between, IsBipartite definitions"
     },
     {
       "id": "cycles",
       "title": "Cycles in Graphs",
       "summary": "HasCycleOfLength, C4Free, C6Free, C4C6Free predicates",
-      "startLine": 85,
-      "endLine": 113,
+      "startLine": 110,
+      "endLine": 137,
       "mathContext": "Mathematical content: HasCycleOfLength, C4Free, C6Free, C4C6Free predicates"
     },
     {
       "id": "extremal-function",
       "title": "The Extremal Function f(n,m)",
       "summary": "maxC4C6FreeEdges definition and achievability axiom",
-      "startLine": 114,
-      "endLine": 138,
+      "startLine": 139,
+      "endLine": 154,
       "mathContext": "Formal definition: maxC4C6FreeEdges definition and achievability axiom"
     },
     {
       "id": "decaen-szekely",
       "title": "De Caen-Székely Bounds (1992)",
-      "summary": "Upper and lower bounds, Faudree-Simonovits general bound",
-      "startLine": 139,
-      "endLine": 174,
-      "mathContext": "Bound: Upper and lower bounds, Faudree-Simonovits general bound"
+      "summary": "Upper and lower bounds, Faudree-Simonovits general bound — discussed in source comments; no formal axiom for deCaen-Székely bounds in the kernel",
+      "startLine": 159,
+      "endLine": 181,
+      "mathContext": "Discussion only: De Caen-Székely upper/lower bounds and Faudree-Simonovits referenced in docstrings at lines 165-176; no formal declaration follows"
     },
     {
       "id": "lazebnik-improvement",
       "title": "Lazebnik-Ustimenko-Woldar Improvement (1994)",
-      "summary": "Improved lower bound Ω(n^(16/15))",
-      "startLine": 175,
-      "endLine": 188,
-      "mathContext": "Bound: Improved lower bound Ω(n^(16/15))"
+      "summary": "Axiom `luw_superlinear`: LUW superlinear construction formally axiomatized",
+      "startLine": 182,
+      "endLine": 213,
+      "mathContext": "Axiomatized: `luw_superlinear` — the sole LUW result formally in the kernel; other LUW discussion in surrounding docstrings"
     },
     {
       "id": "disproof",
       "title": "Disproof of Erdős's Conjecture",
       "summary": "erdos_conjecture_false and erdos_1080 main theorems",
-      "startLine": 189,
-      "endLine": 234,
+      "startLine": 215,
+      "endLine": 267,
       "mathContext": "Verified: erdos_conjecture_false and erdos_1080 main theorems"
     },
     {
       "id": "c8-observation",
       "title": "The C_8 Observation",
-      "summary": "Erdős's observation that C_8 is guaranteed",
-      "startLine": 235,
-      "endLine": 251,
-      "mathContext": "Mathematical content: Erdős's observation that C_8 is guaranteed"
+      "summary": "Axiom `erdos_c8_observation`: Erdős's observation that C_8 is guaranteed by cn edges",
+      "startLine": 269,
+      "endLine": 284,
+      "mathContext": "Axiomatized: `erdos_c8_observation` — C₈ is forced by linear edge count"
     },
     {
       "id": "related-results",
       "title": "Related Extremal Results",
-      "summary": "Kővári-Sós-Turán theorem, C_4-free characterization",
-      "startLine": 252,
-      "endLine": 282,
-      "mathContext": "Verified: Kővári-Sós-Turán theorem, C_4-free characterization"
+      "summary": "C_4-free characterization (`c4_free_iff_no_K22`, 1 sorry) and Kővári-Sós-Turán commentary",
+      "startLine": 286,
+      "endLine": 306,
+      "mathContext": "Contains `c4_free_iff_no_K22` (1 sorry) and Kővári-Sós-Turán docstrings; no formal kovari_sos_turan theorem"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_1080_summary combining main results",
-      "startLine": 283,
-      "endLine": 310,
-      "mathContext": "Mathematical content: erdos_1080_summary combining main results"
+      "startLine": 308,
+      "endLine": 333,
+      "mathContext": "Verified: erdos_1080_summary combining main results"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Corrects phantom contribution claims and section line drift (~25 lines off) in erdos-1080 (Six-Cycles in Sparse Bipartite Graphs).

## Evidence

**Before**:
- `meta.originalContributions` listed 4 phantom declarations:
  - `deCaen_szekely_upper_bound` — only an orphan docstring at lines 165-170
  - `deCaen_szekely_lower_bound` — only an orphan docstring at lines 171-176
  - `lazebnik_ustimenko_woldar_bound` — only orphan docstrings; actual axiom is `luw_superlinear`
  - `kovari_sos_turan` — only an orphan docstring at lines 290-295
- `overview.proofStrategy` step 3: "Axiomatize De Caen-Székely and LUW bounds" — De Caen-Székely has no axiom
- All 9 section line ranges ~25 lines stale (sections slid forward in source)
- 5 annotation line errors in annotations.json

**After**:
- `originalContributions` corrected: phantom items replaced with accurate summary noting De Caen-Székely/Kővári-Sós-Turán are commentary only
- `proofStrategy` corrected: only `luw_superlinear` is axiomatized; De Caen-Székely bounds are commentary
- All 9 section line ranges updated to match actual `## Part N` header positions
- 5 annotation errors fixed: bipartition (49→57), edges-between (59→63), cycle-def (89→118), cycle-free (96→125), lower-bound (155→207)
- Zero erdos-1080 build errors

Closes #14818

---
Automated fix by lean-mechanic agent.