### PR TITLE
audit(tracker): yang-mills-transfer-matrix clean (audit #7)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13658,10 +13658,11 @@
       "result": "clean"
     },
     "yang-mills-transfer-matrix": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-03T10:22:07Z",
-      "result": "clean"
+      "lastAudited": "2026-05-02T14:38:00Z",
+      "result": "clean",
+      "agentId": "auditor-loop-2026-05-02"
     },
     "yang-mills-transfer-matrix-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- Marked `yang-mills-transfer-matrix` clean after verifying its finite-volume mass-gap proof against `Proofs/YangMills/Exploration.lean`.
- `auditCount` 6 → 7, `lastAudited` refreshed.

## What was verified

- `finite_volume_gap_positive` (line 5379), `physical_mass_gap_positive` (line 5393), and `correlation_decay_rate` (line 539) are real theorems with full proofs (`Real.log_pos`, `div_pos`, `div_le_one`).
- Section line markers in meta (506 / 5326 / 5355 / 5372 / 5421 / 5463 / 5509) match the actual structure-/section-headers in the Lean source.
- `status: "axiomatized"` + `badge: "axiom"` are appropriate: the file proves the **conditional** finite-volume mass gap (modulo a `PerronFrobeniusData` instance carrying `λ₀ > λ₁`); the 4D continuum-limit mass gap remains the open Millennium Problem and is not claimed.
- The `True`-typed placeholder fields enumerated in `assumptions` (SlavnovTaylorIdentity, RegulatorProperties, etc.) are not used by `finite_volume_gap_positive`; the core proof depends only on `TransferMatrix` / `LatticeTransferMatrix` / `PerronFrobeniusData`, none of which use `True` fields.
- `sorries: 0` matches actual count; no overclaim.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --next` returned `yang-mills-transfer-matrix` after `yang-mills` (which is in flight as PR #14824).
- [x] Verified each claimed theorem exists at its declared line and has no `sorry`.
- [x] Verified section line numbers map to real structure declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)