### PR TITLE
audit(tracker): yang-mills clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13619,13 +13619,11 @@
       "result": "clean"
     },
     "yang-mills": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 9,
-      "issues": [
-        "sorry mismatch corrected in meta.json"
-      ],
-      "lastAudited": "2026-04-03T10:21:34Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-1777732646",
+      "auditCount": 10,
+      "issues": [],
+      "lastAudited": "2026-05-02T14:39:43Z",
+      "result": "clean"
     },
     "yang-mills-2d": {
       "auditCount": 6,


### PR DESCRIPTION
## Audit Result: **clean**

**Proof**: yang-mills (Yang-Mills Existence and Mass Gap)

### Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| `sorries` | 0 | 0 across all 5 modules | ✓ |
| `axiomCount` | 16 | 1 explicit (`gaugeTransform`) + 15 structure-encoded | ✓ |
| `status` | `axiomatized` | core 4D mass gap conjecture is OPEN | ✓ |
| `badge` | `axiom` | matches axiomatized status | ✓ |

### Structure-encoded assumption tally (15)

| File | Structure | Fields |
|------|-----------|--------|
| Core.lean | `CompactSimpleGaugeGroup` | compact, connected, simple (3) |
| Core.lean | `GaugeLieAlgebra` | bracket_anticomm, bracket_jacobi (2) |
| Classical.lean | `FieldStrength` | antisymmetric (1) |
| Classical.lean | `YangMillsAction` | coupling_pos, action_nonneg (2) |
| Classical.lean | `Instanton` | action_formula (1) |
| Classical.lean | `EnergyMomentumTensor` | symmetric, energy_density_nonneg (2) |
| Quantum.lean | `WightmanQFT` | vacuum_normalized, energy_bounded_below, vacuum_lowest_energy (3) |
| Quantum.lean | `QuantumYangMillsTheory` | nontrivial (1) |

Plus 1 explicit `axiom gaugeTransform` in Classical.lean = **16 total**.

### Narrative integrity

- Title is the Millennium Problem name; first sentence of `description` opens with "Formalization infrastructure for the Yang-Mills Millennium Prize Problem."
- `proofStrategy` explicitly states "This is formalization **infrastructure**, not a proof of the Millennium Problem itself."
- `conclusion.summary` and wrapper docstring both classify the 4D mass gap as **OPEN CONJECTURE**.
- Wrapper docstring's `## Key Limitations` honestly discloses bounded-vs-unbounded H, expectation-vs-spectral gap, and ~64% heuristic content.
- 13 `True`-typed structure fields in Exploration.lean are flagged in `proofStrategy` as "~23% trivial (numerology, tautologies, or vacuous existence claims)".

No issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)