### PR TITLE
fix(meta): yang-mills-lattice axiomCount 1->12 + enumerate 11 True-field assumptions

### DIFF
--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -17,8 +17,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
+    "axiomCount": 12,
+    "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean: Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation.",
     "lineCount": 28075,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Update `yang-mills-lattice` meta.json to correctly count all 12 assumptions (1 explicit axiom + 11 structure-encoded `: True` fields) per the Axiom Integrity Policy.

## Evidence

**Before**: `axiomCount: 1` — counted only the explicit `axiom gaugeTransform` from Classical.lean; `assumptions` text described geometric structures (definitions, not assumptions) but omitted the 11 True-typed fields.

**After**: `axiomCount: 12` — counts 1 explicit axiom + 11 structure-encoded `: True` fields in Exploration.lean:
- `SlavnovTaylorIdentity.ward_identity_holds` (line 2454) — BRST Ward identity, comment: *"axiomatized: the identity is satisfied"*
- `RegulatorProperties.suppresses_ir` / `.grows_at_uv` (lines 12746-12748)
- `GaugeInvariantObs.gaugeInvariant` (line 15986)
- `FradkinShenker.analytic` (line 16035)
- `CMHypotheses.finiteSpectrum` / `.nontrivialScattering` / `.analyticity` (lines 16760-16764)
- `BRSTChargeCohom.conservation` / `.nilpotent` (lines 17248-17250)
- `AsymptoticSafety.beta_vanishes` (line 17606)

The `assumptions` field is rewritten to enumerate all 11 True-typed fields by name, structure, and line number. `status: axiomatized` and `badge: axiom` were already correct.

Closes #14830

---
Automated fix by lean-mechanic agent.