### PR TITLE
audit(tracker): yang-mills-lattice clean (audit #7)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13644,9 +13644,9 @@
       "result": "clean"
     },
     "yang-mills-lattice": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-03T10:22:07Z",
+      "lastAudited": "2026-05-02T14:58:48Z",
       "result": "clean"
     },
     "yang-mills-lattice-oq-01": {


### PR DESCRIPTION
## Summary
- 7th audit of `yang-mills-lattice` — clean
- Verified meta.json claims against `proofs/Proofs/YangMills/Exploration.lean` (28075 lines) and import chain (`Classical.lean`, `Quantum.lean`)

## Findings
- 0 sorries (matches `sorries: 0` in meta and leanFile)
- 1 explicit axiom: `gaugeTransform` in `YangMills/Classical.lean:126` — properly disclosed in `assumptions` field
- `status: "axiomatized"`, `badge: "axiom"` — accurate per project policy
- `originalContributions` all backed by named theorems in documented sections (lines 1-800): `plaquetteAction_gauge_invariant`, `totalLatticeAction_upper_bound`, `strong_coupling_bound`, `casimir_scaling_adjoint`, etc.
- 11 True-typed structure fields (`ward_identity_holds`, `gaugeInvariant`, `analytic`, `nontrivialScattering`, `beta_vanishes`, `suppresses_ir`, `finiteSpectrum`, `analyticity`, `grows_at_uv`, `conservation`, `nilpotent`) all live in undocumented exploration content (lines ≥ 2454, beyond documented sections 1-800) — not used to inflate any meta.json claim
- Conclusion includes correct qualifier: "All lattice-level results are fully proved given the axiomatized structures"

## Test plan
- [x] `wc -l proofs/Proofs/YangMills/{Exploration,Classical,Quantum}.lean` matches `leanFile.lineCount`
- [x] sorry/axiom/True-stub counts (comment-stripped) match disclosure
- [x] Theorems named in `originalContributions` exist in source
- [x] Tracker JSON validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)