### PR TITLE
audit(tracker): yang-mills-2d issues-found (#14835)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13626,10 +13626,12 @@
       "result": "clean"
     },
     "yang-mills-2d": {
-      "auditCount": 6,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:22:07Z",
-      "result": "clean"
+      "auditCount": 7,
+      "issues": [
+        "Coverage gap: originalContributions claims SU(3) Casimir, heat-kernel expansion, and N-ality classification but sections list only spans 398-950 (PART XXI/XXII/XXIV-XXVII at lines 970-1571 not covered). Section drift: section 6 su2-migdal-concrete endLine 950 vs actual 968. Issue #14835."
+      ],
+      "lastAudited": "2026-05-02T15:08:18Z",
+      "result": "issues-found"
     },
     "yang-mills-2d-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary
- Marks `yang-mills-2d` as `issues-found` in `audit-tracker.json` (auditCount 6→7).
- References integrity issue #14835: section coverage gap + minor drift.

## Audit details
- `axiomCount: 1`, `sorries: 0`, `status: axiomatized`, `badge: axiom` all accurate.
- `originalContributions` references heat-kernel expansion (PART XXI), SU(N)/SU(3) Casimir formulas (PART XXIV-XXV), and N-ality (PART XXVI) — but `sections` only covers lines 398–950, leaving lines 970–1571 of `Exploration.lean` unmapped.
- Section 6 `su2-migdal-concrete` `endLine: 950` truncates `su2MigdalAdjoint` mid-construction; PART XX actually ends at line 968.

## Test plan
- [x] `git diff --stat` shows single-entry, 6-line tracker change (no unicode pollution).
- [x] Issue #14835 filed with detailed evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)