### PR TITLE
audit(tracker): erdos-519 issues-found (#14837)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7637,9 +7637,9 @@
     },
     "erdos-519": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:44:42Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T15:13:25Z",
+      "result": "issues-found"
     },
     "erdos-52": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker entry for erdos-519 advanced from `issues-fixed` (auditCount 2) to `issues-found` (auditCount 3).

See #14837 for details. Three independent issues:

1. Phantom axiom narrative — `sections[id="biro"].summary` claims to axiomatize Biró 1994 ($c=1/2$), but file has only `biro_2000` axiom.
2. Phantom axiom narrative — `sections[id="optimal-constant"].summary` claims to axiomatize $c\approx0.7$ conjecture; it's only a comment.
3. `leanFile.imports` lists 4 imports; file actually imports `Mathlib.Analysis.SpecialFunctions.Pow.Complex` and `Mathlib.Tactic` only.
4. Minor section line drift (4–14 lines off).

Quantitative claims (`axiomCount=2`, `sorries=0`, `lineCount=287`, `theoremCount=6`, `definitionCount=7`) all verified correct.