### PR TITLE
audit(tracker): amgm-inequality-oq-03-oq-03 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -197,10 +197,10 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:21:34Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-02T15:16:33Z",
+      "result": "clean"
     },
     "amgm-inequality-oq-03-oq-03-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

Re-audit of `amgm-inequality-oq-03-oq-03` confirms meta.json claims match Lean source.

## Audit Results

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | yes |
| axiomCount | 0 | 0 | yes |
| lineCount | 65 | 65 | yes |
| theoremCount | 2 | 2 | yes |
| definitionCount | 1 | 1 | yes |
| True stubs | n/a | 0 | yes |

- Tier A: direct computational proof of $M_1(a,b) = (a+b)/2$ and $M_{-1}(a,b) = 2ab/(a+b)$ for $n=2$.
- Badge `original` appropriate — Mathlib usage is foundational tactics (ring, field_simp, norm_num, rpow_one, rpow_neg_one), not a key theorem call.
- proofStrategy and conclusion accurately note that the $r \to \pm\infty$ limit cases and full monotonicity remain as docstring sketches, not Lean theorems.

## Test Plan
- [x] Verified sorry count via comment-stripping grep
- [x] Verified axiom count (no `^axiom` declarations, no structure-encoded assumptions)
- [x] Verified theorem/def counts match
- [x] Verified line count via `wc -l`
- [x] Confirmed no `True` stubs

Result: `clean` (auditCount 2 → 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)