### PR TITLE
audit(tracker): yang-mills-transfer-matrix issues-found (#14840)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13660,10 +13660,12 @@
       "result": "clean"
     },
     "yang-mills-transfer-matrix": {
-      "auditCount": 6,
-      "issues": [],
-      "lastAudited": "2026-04-03T10:22:07Z",
-      "result": "clean"
+      "auditCount": 7,
+      "issues": [
+        "axiomCount inconsistency with same-file precedent: yang-mills-lattice fixed to 12 (PR #14832), yang-mills-transfer-matrix still 1 — same Exploration.lean, same 11 :True structure-encoded fields. Issue #14840."
+      ],
+      "lastAudited": "2026-05-02T15:30:00Z",
+      "result": "issues-found"
     },
     "yang-mills-transfer-matrix-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary
- Tracker update only: marks `yang-mills-transfer-matrix` audit as `issues-found` referencing #14840
- No code/data changes — issue #14840 is filed for maintainer judgment

## Issue context (see #14840 for full details)
Three gallery entries (yang-mills-lattice, yang-mills-2d, yang-mills-transfer-matrix) share `Proofs/YangMills/Exploration.lean` (28k lines, 1 axiom + 11 `: True` structure-encoded fields). Today's PR #14832 set `yang-mills-lattice.axiomCount = 12`. The other two entries still claim `axiomCount = 1`. Per CLAUDE.md axiom-integrity policy and the #14832 precedent, all three should agree.

The project has flip-flopped on this number twice (PRs #11256 → #11573 → #14832), so I filed an issue rather than auto-fixing.

## Test plan
- [x] tracker JSON parses (manual `python3 -c "json.load(open(...))"`)
- [x] only `src/data/proofs/audit-tracker.json` modified
- [x] no unicode-escape pollution (em-dashes preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)