### PR TITLE
audit(tracker): amgm-inequality clean (audit #3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -113,9 +113,9 @@
       "result": "clean"
     },
     "amgm-inequality": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:08:13Z",
+      "lastAudited": "2026-05-02T15:44:35Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02": {


### PR DESCRIPTION
## Summary
- Re-audited amgm-inequality (3rd audit)
- 0 axioms, 0 sorries — matches meta.json
- 8 theorems = 3 substantive originals + 5 mathlib wrappers
- status: verified, badge: mathlib (consistent)

## Verification
- Source: \`proofs/Proofs/AMGMInequality.lean\` (origin/main)
- Substantive originals: \`am_gm_two\`, \`am_gm_two_eq_iff\`, \`product_le_mean_sq\`
- Mathlib wrappers: \`am_gm_two'\`, \`am_gm_weighted\`, \`am_gm_two_via_weighted\`, \`am_ge_gm\`, \`am_gm_three\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)