### PR TITLE
audit(tracker): taylor-sincos-convergence-oq-03 clean (audit #4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13395,9 +13395,9 @@
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T11:22:28Z",
+      "lastAudited": "2026-05-02T15:50:25Z",
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-04": {


### PR DESCRIPTION
## Summary

Audited `taylor-sincos-convergence-oq-03` against Lean source. **No issues — clean.**

## Findings

| Field | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| sorries | 3 | 3 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True stubs | (none) | 0 | ✓ |
| theoremCount | 12 | 12 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| lineCount | 224 | 224 | ✓ |
| status | `formalized` | (3 sorries) | ✓ |
| badge | `wip` | (3 sorries) | ✓ |

## Notes

- The 3 sorries are explicitly disclosed in `assumptions`: "alternating tail bound, alternating remainder for sin, alternating remainder for cos."
- `originalContributions` honestly qualifies the ASE theorem as "(abstract, with proof strategy)" — the abstract `alternating_partial_sum_even_bounds` is fully proved; `alternating_tail_bound` is the sorry'd extension.
- `openQuestions` and `keyInsights` both surface the sorries as a "Mathlib Interface Gap" (connecting `Real.sin` to its alternating Taylor series).
- `wip` badge correctly signals incomplete state.

No overstating. Tracker bumped to audit #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)