### PR TITLE
fix(meta): yang-mills-transfer-matrix + yang-mills-2d axiomCount 1->12

### DIFF
--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
+    "axiomCount": 12,
+    "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean (shared file): Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation.",
     "lineCount": 28075,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "1 explicit axiom: gaugeTransform (YangMills/Classical.lean line 126). Additionally, 11 structure fields typed as ': True' in peripheral illustrative structures (SlavnovTaylorIdentity, RegulatorProperties, GaugeInvariantObs, FradkinShenker, CMHypotheses, BRSTChargeCohom, AsymptoticSafety) — these are trivially satisfied placeholders (provable by 'trivial') that carry no mathematical content and do not constitute real assumptions. The core mass gap proof (finite_volume_gap_positive) depends only on TransferMatrix, LatticeTransferMatrix, and PerronFrobeniusData structures, none of which use True-typed fields.",
+    "axiomCount": 12,
+    "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean: Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation.",
     "lineCount": 28075,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Apply the yang-mills-lattice precedent (PR #14832) consistently to all three Exploration.lean sibling entries: set `axiomCount: 12` (1 explicit axiom + 11 structure-encoded `: True` fields) and enumerate all 11 fields with line references in the `assumptions` text.

## Evidence

**Before**: `yang-mills-transfer-matrix.axiomCount = 1`, `yang-mills-2d.axiomCount = 1`
**After**: Both set to `12`, matching `yang-mills-lattice` (PR #14832) and the CLAUDE.md axiom-integrity policy

All three entries share the same `Exploration.lean` file (28,075 lines) and import the same `Classical.lean` axiom. Consistency requires identical counts.

The 11 `: True` structure fields are now enumerated in both entries' `assumptions` text (same format as yang-mills-lattice).

Closes #14840

---
Automated fix by lean-mechanic agent.