### PR TITLE
feat(aristotle): Erdos1100 companion — tau_perp_lower_bound

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -743,6 +743,7 @@ import Proofs.Erdos10PrimePlusPowers
 import Proofs.Erdos10Problem
 import Proofs.Erdos1100OQ01Aristotle
 import Proofs.Erdos1100Problem
+import Proofs.Erdos1100ProblemAristotle
 import Proofs.Erdos1100ProblemProvable
 import Proofs.Erdos1101Problem
 import Proofs.Erdos1102Problem

--- a/proofs/Proofs/Erdos1100ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos1100ProblemAristotle.lean
@@ -1,0 +1,28 @@
+/-
+  Aristotle targets for Erdős Problem #1100
+  Routine supporting lemmas for automated proof search.
+  See Erdos1100ProblemProvable.lean for the main formalization.
+
+  Target: tau_perp_lower_bound
+  The file header notes: "τ⊥(n) ≥ ω(n) trivially (with equality for infinitely many n)"
+
+  Strategy: for each prime factor p | n, the divisor list contains some d with gcd(d, d') = 1
+  where d' is the next divisor. The ω(n) prime factors supply at least ω(n) such transitions.
+
+  Excluded from this companion:
+  - erdos_hall_max_lower_bound: requires Erdős-Hall (1978) — deep analytic NT
+  - erdos_simonovits_bounds: requires Erdős-Simonovits result — deep combinatorics
+-/
+import Mathlib
+import Proofs.Erdos1100ProblemProvable
+
+namespace Erdos1100
+
+open Real Nat Finset
+
+/-- τ⊥(n) ≥ ω(n): At least ω(n) consecutive coprime divisor pairs exist.
+    The problem statement notes this is trivial; primes achieve equality. -/
+theorem tau_perp_lower_bound (n : ℕ) (hn : n > 0) : tauPerp n ≥ omega n := by
+  sorry
+
+end Erdos1100


### PR DESCRIPTION
## Fix

Add Aristotle companion file for `erdos-1100` (Erdős Problem #1100: Coprime Consecutive Divisors).

## Evidence

**Proof**: `erdos-1100` (`Erdos1100ProblemProvable.lean`)  
**Sorries**: 3 (all in theorems)

The file header explicitly notes:
> "τ⊥(n) ≥ ω(n) trivially (with equality for infinitely many n)"

This companion exposes `tau_perp_lower_bound` — the lemma the header calls "trivial" — for Aristotle's automated proof search.

**Excluded** from companion (too deep):
- `erdos_hall_max_lower_bound` — requires Erdős-Hall 1978 (analytic NT)
- `erdos_simonovits_bounds` — requires Erdős-Simonovits theorem

## Files Changed

- `proofs/Proofs/Erdos1100ProblemAristotle.lean` — new companion (29 lines)
- `proofs/Proofs.lean` — register new import

---
Automated fix by lean-mechanic agent.