### PR TITLE
fix(meta): erdos-1080 phantom kovari_sos_turan claim + section corrections

### DIFF
--- a/src/data/proofs/erdos-1080/meta.json
+++ b/src/data/proofs/erdos-1080/meta.json
@@ -103,10 +103,10 @@
     {
       "id": "extremal-function",
       "title": "The Extremal Function f(n,m)",
-      "summary": "maxC4C6FreeEdges definition and achievability axiom",
+      "summary": "maxC4C6FreeEdges definition (lines 152-154); lines 156-158 contain an orphaned achievability docstring with no corresponding Lean declaration",
       "startLine": 139,
-      "endLine": 154,
-      "mathContext": "Formal definition: maxC4C6FreeEdges definition and achievability axiom"
+      "endLine": 158,
+      "mathContext": "Formal definition: maxC4C6FreeEdges (sSup-based def, lines 152-154). Lines 156-158: orphaned '/-- f(n,m) is achieved by some bipartite graph. -/' docstring — no formal axiom declaration follows."
     },
     {
       "id": "decaen-szekely",
@@ -114,7 +114,7 @@
       "summary": "Upper and lower bounds, Faudree-Simonovits general bound — discussed in source comments; no formal axiom for deCaen-Székely bounds in the kernel",
       "startLine": 159,
       "endLine": 181,
-      "mathContext": "Discussion only: De Caen-Székely upper/lower bounds and Faudree-Simonovits referenced in docstrings at lines 165-176; no formal declaration follows"
+      "mathContext": "Discussion only: De Caen-Székely upper/lower bounds and Faudree-Simonovits general bound referenced in docstrings at lines 165-181; no formal declaration follows"
     },
     {
       "id": "lazebnik-improvement",
@@ -222,7 +222,7 @@
       "year": "1954",
       "volume": 3,
       "pages": "50–57",
-      "note": "Classical theorem bounding the number of edges in K_{s,t}-free bipartite graphs; the formalization includes a kovari_sos_turan theorem as a related extremal result."
+      "note": "Classical theorem bounding the number of edges in K_{s,t}-free bipartite graphs; referenced in source comments as context for extremal results. No formal kovari_sos_turan declaration in the kernel — only a docstring at lines 290–295."
     },
     {
       "authors": "Faudree, R. J. and Simonovits, M.",


### PR DESCRIPTION
## Fix

Corrects three metadata errors in `src/data/proofs/erdos-1080/meta.json` introduced by stale auditor findings.

## Evidence

**references[2].note**: Previously claimed the formalization includes the `kovari_sos_turan` theorem. This is a phantom claim — only a docstring exists at lines 290-295 in the Lean file; no formal declaration was ever made.

**extremal-function section**: `endLine` was `154`, leaving the orphaned docstring `'/-- f(n,m) is achieved by some bipartite graph. -/'` (lines 156-158) outside the section boundary. Extended to `158`.

**decaen-szekely mathContext**: Line range `165-176` was stale; corrected to `165-181` to match the actual code.

---
Automated fix by lean-mechanic agent.