### PR TITLE
feat(aristotle): add Erdos795ProblemAristotle companion for distinct subset products

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1799,6 +1799,7 @@ import Proofs.Erdos793Problem
 import Proofs.Erdos794Problem
 import Proofs.Erdos795Aristotle
 import Proofs.Erdos795Problem
+import Proofs.Erdos795ProblemAristotle
 import Proofs.Erdos796Problem
 import Proofs.Erdos797Problem
 import Proofs.Erdos798Aristotle

--- a/proofs/Proofs/Erdos795ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos795ProblemAristotle.lean
@@ -1,0 +1,74 @@
+/-
+  Aristotle targets for Erdős Problem #795: Distinct Subset Products
+  Routine supporting lemmas for automated proof search.
+  See Erdos795Problem.lean for the main formalization.
+
+  This companion imports Proofs.Erdos795Problem and operates in the
+  Erdos795 namespace so that proofs here directly close sorries in
+  the main file.
+
+  Criteria for inclusion:
+  - Routine supporting lemmas (NOT the main Erdős/Raghavan bounds)
+  - No def sorries, no axiom declarations, no open conjectures
+  - No references to noncomputable g (elaboration issues in Aristotle context)
+-/
+import Mathlib
+import Proofs.Erdos795Problem
+
+namespace Erdos795
+
+open Finset Nat
+
+-- Routine: primePi is monotone.
+-- More primes can be ≤ m than ≤ n when n ≤ m.
+theorem primePi_mono {n m : ℕ} (h : n ≤ m) : primePi n ≤ primePi m := by
+  sorry
+
+-- Routine: primePi n ≤ n.
+-- There are at most n primes ≤ n (filter of range n+1 has card ≤ n+1).
+theorem primePi_le_self (n : ℕ) : primePi n ≤ n := by
+  sorry
+
+-- Routine: The empty set has distinct subset products.
+-- Vacuously true: no two distinct subsets exist.
+theorem empty_has_distinct_products : HasDistinctSubsetProducts ∅ := by
+  sorry
+
+-- Routine: Any singleton {a} has distinct subset products.
+-- The only subsets are ∅ and {a}, and ∅.prod id = 1, {a}.prod id = a.
+theorem singleton_has_distinct_products (a : ℕ) :
+    HasDistinctSubsetProducts {a} := by
+  sorry
+
+-- Routine: If A has distinct subset products, so does any subset B ⊆ A.
+-- Subsets of B are also subsets of A, so injectivity transfers.
+theorem subset_has_distinct_products {A B : Finset ℕ}
+    (hA : HasDistinctSubsetProducts A) (hB : B ⊆ A) :
+    HasDistinctSubsetProducts B := by
+  sorry
+
+-- Routine: primePi 2 = 1 (only prime ≤ 2 is 2).
+theorem primePi_two : primePi 2 = 1 := by
+  sorry
+
+-- Routine: If n ≥ 2 then primePi n ≥ 1 (2 is always a prime ≤ n).
+theorem primePi_ge_one {n : ℕ} (hn : n ≥ 2) : primePi n ≥ 1 := by
+  sorry
+
+-- Routine: {2, 3, 5} has distinct subset products.
+-- Subset products: 1, 2, 3, 5, 6, 10, 15, 30 — all distinct.
+theorem primes_235_distinct : HasDistinctSubsetProducts {2, 3, 5} := by
+  sorry
+
+-- Routine: {2, 3, 6} does NOT have distinct subset products.
+-- {2, 3} and {6} both give product 6.
+theorem not_distinct_236 : ¬HasDistinctSubsetProducts {2, 3, 6} := by
+  sorry
+
+-- Routine: {2, 6, 18} has distinct subset products but is not multiplicative Sidon.
+-- Witness: 6 * 6 = 2 * 18 = 36, but {6} ≠ {2, 18}.
+theorem distinct_products_not_sidon :
+    ∃ A : Finset ℕ, HasDistinctSubsetProducts A ∧ ¬IsMultiplicativeSidon A := by
+  sorry
+
+end Erdos795


### PR DESCRIPTION
## Fix

The legacy `Erdos795Aristotle.lean` re-declares `primePi`, `HasDistinctSubsetProducts`, and `IsMultiplicativeSidon` in a separate `Erdos795Aristotle` namespace without importing the main file. Aristotle's proofs in that file cannot close sorries in `Erdos795Problem.lean`.

This new companion `Erdos795ProblemAristotle.lean` imports `Proofs.Erdos795Problem` and operates in `namespace Erdos795`, so any proof here directly closes a sorry in the main file.

## Evidence

**Before**: `Erdos795Aristotle.lean` — standalone namespace `Erdos795Aristotle`, no `import Proofs.Erdos795Problem`, local re-definitions of all types.

**After**: `Erdos795ProblemAristotle.lean` — uses `import Proofs.Erdos795Problem` + `namespace Erdos795`, targets 10 routine sorries:

| Target | Notes |
|--------|-------|
| `primePi_mono` | Finset filter monotonicity |
| `primePi_le_self` | Filter card ≤ range size |
| `empty_has_distinct_products` | Vacuously true |
| `singleton_has_distinct_products` | Two subsets, distinct products |
| `subset_has_distinct_products` | Injectivity transfers |
| `primePi_two` | Small value: π(2) = 1 |
| `primePi_ge_one` | 2 is prime ≤ n for n ≥ 2 |
| `primes_235_distinct` | {2,3,5} example |
| `not_distinct_236` | {2,3,6} counterexample |
| `distinct_products_not_sidon` | Witness {2,6,18} |

Pre-submission checklist: ✅ no `def` sorries, ✅ no axioms, ✅ no `/-!` sections.

---
Automated fix by lean-mechanic agent.