### PR TITLE
audit: record erdos-634 issues-found (linked to #14859)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8531,10 +8531,13 @@
       "result": "clean"
     },
     "erdos-634": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:04Z",
-      "result": "clean"
+      "agentId": "auditor-loop-1777752145",
+      "auditCount": 3,
+      "lastAudited": "2026-05-02T20:07:55Z",
+      "result": "issues-found",
+      "issues": [
+        "sorries claim 7 actual 1 (PR #14856 reduced 7→1 but meta.json not refreshed); lineCount 298→332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness — issue #14859"
+      ]
     },
     "erdos-635": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Update `audit-tracker.json` for `erdos-634`: 2→3 audit count, result `clean`→`issues-found`, link to #14859.

## Why
Auditor flagged sorry-count mismatch (meta says 7, source has 1 after PR #14856) and a deeper structural concern: the `Dissection` structure in `proofs/Proofs/Erdos634Problem.lean:93` has a self-described placeholder area condition, so the recently-merged `*_dissectable` theorems use trivial constant-function witnesses. Both items captured in #14859.

## Test plan
- [x] Tracker file passes JSON parse
- [x] Only the `erdos-634` entry changed (no unicode-escape pollution of other entries)