### PR TITLE
audit: record erdos-115-oq-01 issues-found (linked to #14862)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4225,10 +4225,12 @@
       "result": "clean"
     },
     "erdos-115-oq-01": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T11:22:57Z",
-      "result": "clean"
+      "auditCount": 3,
+      "issues": [
+        "phantom theorem citations in meta.json + Lean summary docstring: inverseN_implies_inverseSqrtN, inverseN_implies_inverseLogN, chebyshev_correction_nonneg_eventually do not exist in proofs/Proofs/Erdos115OQ01Problem.lean. Lean docstring also says \"Axioms (8 total)\" while file has 11. Issue #14862."
+      ],
+      "lastAudited": "2026-05-02T20:12:14Z",
+      "result": "issues-found"
     },
     "erdos-1150": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary
- Audit of `erdos-115-oq-01` ("Rate of o(1) Correction in Lemniscate Derivatives") found 3 phantom theorem citations in `meta.json` (overview, sections) and the Lean file's own summary docstring; cross-referenced into #14862.
- Tracker bumped: `auditCount` 2→3, `result: clean → issues-found`, issue note added.

## Test plan
- [x] `jq '.entries["erdos-115-oq-01"]' src/data/proofs/audit-tracker.json` shows new entry
- [x] Diff is one targeted entry — unicode escape pollution from `claim-target.sh complete` was reverted manually
- [x] Companion issue #14862 documents the phantom names and the axiom count mismatch (8 in docstring vs 11 actual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)