### PR TITLE
fix(meta): erdos-634 stale sorry/lineCount post-#14856

### DIFF
--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 1,
     "erdosNumber": 634,
     "erdosUrl": "https://erdosproblems.com/634",
     "erdosProblemStatus": "open",
@@ -54,8 +54,8 @@
       "erdos-633"
     ],
     "axiomCount": 3,
-    "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 7 sorries.",
-    "lineCount": 298
+    "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 1 sorry.",
+    "lineCount": 332
   },
   "overview": {
     "historicalContext": "**Triangle Dissection Problem — A Bridge Between Geometry and Number Theory**\n\nPaul Erdős posed this problem with a $25 prize, asking for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The problem appears in Erdős and Graham's 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*.\n\n**Known Positive Results**: The most natural construction uses **grid subdivision**: dividing each side of a triangle into $k$ equal parts produces $k^2$ congruent triangles. More sophisticated constructions yield $2k^2$ (via right triangle reflections), $3k^2$ (via equilateral triangle trisections), $6k^2$ (combining both), and $k^2 + m^2$ (via a two-scale grid). The special case $n = 27$ also works via an equilateral triangle construction that does not fit any of these parametric families.\n\n**Known Negative Results**: Michael Beeson proved in 2012 that no triangle can be dissected into exactly 7 or 11 congruent triangles, using exhaustive geometric case analysis of the possible edge-matching patterns at vertices. Both 7 and 11 are primes of the form $4k + 3$, which led to the conjecture that all such primes (except 3, which is $3 \\cdot 1^2$) are non-dissectable.\n\n**The Similar Case**: Alexander Soifer completely solved the analogous problem for *similar* (rather than congruent) triangles in his 1990 book *How Does One Cut a Triangle?*: all $n \\geq 1$ except 2, 3, and 5 admit similar dissections. The stark contrast between the similar and congruent cases highlights how rigidity (disallowing scaling) fundamentally changes the combinatorics.\n\n**Open**: The case $n = 19$ (the next prime of form $4k + 3$) remains unknown, and the complete characterization is still open with the $25 prize unclaimed.",
@@ -169,7 +169,7 @@
       "title": "Main Results — Erdős Problem #634",
       "summary": "The partial answer theorem `erdos_634_partial`: $\\forall k \\geq 1, \\text{IsDissectable}(k^2) \\wedge \\neg\\text{IsDissectable}\\, 7 \\wedge \\neg\\text{IsDissectable}\\, 11$, combining the grid subdivision theorem with Beeson's axioms.",
       "startLine": 265,
-      "endLine": 298,
+      "endLine": 332,
       "mathContext": "The partial answer theorem `erdos_634_partial`: $\\forall k \\geq 1, \\text{IsDissectable}(k^2) \\wedge \\neg\\text{IsDissectable}\\, 7 \\wedge \\neg\\text{IsDissectable}\\, 11$, combining the grid subdivision theorem with Beeson's axioms."
     }
   ],
@@ -193,11 +193,11 @@
       "Function"
     ],
     "namespace": "Erdos634",
-    "lineCount": 298,
+    "lineCount": 332,
     "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 15,
-    "sorries": 7,
+    "sorries": 1,
     "path": "Proofs/Erdos634Problem.lean"
   },
   "references": [
@@ -254,5 +254,5 @@
       "description": "Lagrange's four squares theorem (every positive integer is a sum of four squares) contrasts with the incomplete coverage of dissectable numbers: k², 2k², 3k², k²+m² cover most integers but not all (7, 11, 19 are open). The arithmetic of sums of squares governs which n are dissectable — Lagrange and Fermat's results on square representations directly constrain the structure of dissectable families."
     }
   ],
-  "sorries": 7
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Refresh `src/data/proofs/erdos-634/meta.json` after PR #14856 proved 6 dissectability sorries but left meta stale.

## Evidence

**Before**: `meta.sorries: 7`, `meta.lineCount: 298`, assumptions "7 sorries.", leanFile.sorries: 7, leanFile.lineCount: 298, sections.main-result.endLine: 298
**After**: `meta.sorries: 1`, `meta.lineCount: 332`, assumptions "1 sorry.", leanFile.sorries: 1, leanFile.lineCount: 332, sections.main-result.endLine: 332

The remaining 1 sorry is in `congruent_implies_similar` (line 81), a basic reduction lemma. All 6 dissectability sorries were proved in #14856.

Closes #14859

---
Automated fix by lean-mechanic agent.