### PR TITLE
audit: solution-of-cubic-oq-03-oq-05 (fix), sum-of-kth-powers, schroeder-bernstein-oq-04, arithmetic-series-oq-02 (re-verify clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13245,9 +13245,9 @@
       "result": "clean"
     },
     "sum-of-kth-powers": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:24:36Z",
+      "lastAudited": "2026-05-02T20:39:53Z",
       "result": "clean"
     },
     "sum-of-kth-powers-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -542,9 +542,9 @@
       "result": "issues-fixed"
     },
     "arithmetic-series-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T11:25:05Z",
+      "lastAudited": "2026-05-02T20:42:23Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12912,9 +12912,9 @@
       "result": "clean"
     },
     "schroeder-bernstein-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:25:05Z",
+      "lastAudited": "2026-05-02T20:41:17Z",
       "result": "clean"
     },
     "shannon-channel-coding": {


### PR DESCRIPTION
## Summary

Auditor loop session — 4 entries audited. One required fixes; three re-verified clean.

### 1. `solution-of-cubic-oq-03-oq-05` — issues-fixed

Two narrative integrity issues in `meta.json` (Lean source itself is clean).

**Phantom theorem name** (`keyInsights[4]`, `sec-roots.mathContext`)
- claimed: `root_satisfies_poly`
- actual: `root_satisfies` (proofs/Proofs/SolutionOfCubicOQ03OQ05.lean:102)

**Discriminant formula mismatch** (`conclusion.implications`)
- previous: `Δ = 18abcd - 4b³d + b²c² - 4ac³ - 27a²d²` (4-variable form `ax³+bx²+cx+d`)
- file's cubic uses `x³ + ax² + bx + c` (3-variable monic)
- replaced with matching `Δ = 18abc - 4a³c + a²b² - 4b³ - 27c²`, plus roots-form `Δ = (r₁-r₂)²(r₁-r₃)²(r₂-r₃)²`

Also fixed a `simp` lemma list to match the actual proof tactic.

### 2. `sum-of-kth-powers` — clean

0 sorries, 0 axioms, 600 lines, 55 theorems (49 public + 6 private). All 6 main theorem statements match meta. mathlibDependencies (sum_range_id, sum_range_succ) are accurate. originalContributions correctly scopes claim to "squares and cubes" rather than first powers (sum_first_powers wraps `Finset.sum_range_id`). Note: file actually extends to k=6, k=7, plus a Bernoulli-polynomial Faulhaber section — meta scopes claims to k=1..5 (understatement, acceptable).

### 3. `schroeder-bernstein-oq-04` — clean

0 sorries, 0 axioms, 314 lines, 17 theorems, 5 definitions. All keyInsight/section refs resolve to actual decls. `noncomputable` tag on bijection correctly attributed in keyInsights[4] to the Lean 4 Multiset-quotient artifact, not a mathematical limitation.

### 4. `arithmetic-series-oq-02` — clean

0 sorries, 0 axioms, 209 lines, 12 theorems, 1 definition. All 5 mainTheorems present at correct names. All 7 originalContributions reference real declarations.

## Tracker updates

- `solution-of-cubic-oq-03-oq-05`: 2→3, clean→issues-fixed
- `sum-of-kth-powers`: 2→3, clean
- `schroeder-bernstein-oq-04`: 2→3, clean
- `arithmetic-series-oq-02`: 3→4, clean

## Test plan
- [x] All meta.json + audit-tracker.json files parse as valid JSON
- [x] No unicode-escape pollution in audit-tracker.json (per memory `feedback_auditor_claim_target_unicode_bug`)
- [x] No changes to Lean sources (proofs unchanged across all 4 entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)