### PR TITLE
feat(cyclic-vector): close final sorry — 0 axioms / 0 sorries (fully verified)

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean
@@ -19,21 +19,21 @@
      p_i^{e_i} | r by pow_irred_dvd_of_annihilated. Then ∏ p_i^{e_i} | r by
      pairwise coprimality, so deg(r) ≥ n — contradiction with deg(r) < n.
 
-  3. **[Sorry: routine]** Factorization bridge: Every monic polynomial of positive
+  3. **[Proved, Aristotle]** Factorization bridge: Every monic polynomial of positive
      degree over a field factors into coprime monic irreducible prime powers.
-     This is a standard consequence of K[X] being a UFD. The sorry is strictly
-     routine Mathlib API work, NOT a mathematical assumption.
+     Proved via UniqueFactorizationMonoid.normalizedFactors in the companion file
+     CayleyHamiltonCyclicVectorAllFieldsAristotle.lean.
 
-  ## Status: 0 axioms, 1 sorry (polynomial factorization bridge)
+  ## Status: 0 axioms, 0 sorries (fully verified)
 
-  The mathematical content is fully verified. The single sorry is a routine
-  application of UniqueFactorizationMonoid.normalizedFactors in Mathlib.
+  All mathematical content is machine-checked. The factorization bridge was proved
+  by Aristotle proof search using Mathlib's UniqueFactorizationMonoid API.
 
   ## Why V2 is Stronger than V1
 
   V1's axiom (RCF similarity) required the structure theorem for finitely
   generated modules over a PID — ~800 lines to formalize, fundamentally deep.
-  V2's sorry is ~50 lines of Mathlib API navigation — routine and Aristotle-suitable.
+  V2 delegates only to standard UFD API in Mathlib.
 
   ## Related Gallery Entries
 
@@ -43,6 +43,7 @@
 -/
 import Mathlib
 import Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04
+import Proofs.CayleyHamiltonCyclicVectorAllFieldsAristotle
 
 noncomputable section
 
@@ -87,8 +88,8 @@ private theorem monic_factored_form {K : Type*} [Field K]
       (∀ i, (p i).Monic) ∧
       (∀ i, 0 < e i) ∧
       (∀ i j : Fin k, i ≠ j → IsCoprime (p i ^ e i) (p j ^ e j)) ∧
-      μ = ∏ i : Fin k, p i ^ e i := by
-  sorry
+      μ = ∏ i : Fin k, p i ^ e i :=
+  CayleyHamiltonCyclicVectorAllFieldsAristotle.monic_factored_form μ hμ_monic hμ_deg
 
 -- ============================================================
 -- SECTION III: Main Theorem
@@ -167,21 +168,14 @@ finitely generated modules over PIDs.
 **What is fully proved (sorry-free, axiom-free)**:
 - Primary decomposition construction (GeneralCyclicVector, WIP04)
 - Bezout projections and CRT-based cyclic vector construction (WIP04)
-- `nonderogatory_has_cyclic_vector`: main theorem (modulo factorization bridge)
+- `monic_factored_form`: proved by Aristotle via UFD API (companion file)
+- `nonderogatory_has_cyclic_vector`: main theorem
 - `nonderogatory_has_cyclic_vector_finite`: finite field corollary
 - `cyclic_iff_not_killed_below_degree`: characterization corollary
 
-**The one sorry**:
-- `monic_factored_form`: monic polynomial factors into coprime prime powers
-  This is a routine consequence of K[X] being a UFD (UniqueFactorizationMonoid).
-  NOT a mathematical assumption — purely Mathlib API navigation.
-  Estimated: ~50 lines using normalizedFactors + Finset.equivFin.
-  Suitable for Aristotle submission.
-
-**V1 → V2 delta**:
-- Removed: `axiom nonderogatory_similar_companion` (RCF similarity, ~800 lines to prove)
-- Added: `sorry` in `monic_factored_form` (routine Mathlib API, ~50 lines to prove)
-- Net: Deep mathematical axiom → routine API sorry
+**V1 → V2 → V3 delta**:
+- V1→V2: Removed `axiom nonderogatory_similar_companion` (RCF similarity), added `sorry` in `monic_factored_form`
+- V2→V3: Proved `monic_factored_form` via Aristotle (companion file); file now 0 axioms, 0 sorries
 -/
 
 end CayleyHamiltonCyclicVectorAllFields

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -2,12 +2,12 @@
   "id": "cayley-hamilton-cyclic-vector-all-fields",
   "title": "Nonderogatory → Cyclic Vector: All Fields (Primary Decomposition)",
   "slug": "cayley-hamilton-cyclic-vector-all-fields",
-  "description": "Every nonderogatory matrix over ANY field (including finite fields F_q with q ≤ n) has a cyclic vector. Proved axiom-free via primary decomposition and CRT (WIP04): factor minpoly into coprime prime powers, construct primary vectors via minimality, combine with Bezout projections. One routine sorry remains (polynomial factorization bridge).",
+  "description": "Every nonderogatory matrix over ANY field (including finite fields F_q with q ≤ n) has a cyclic vector. Fully verified (0 axioms, 0 sorries) via primary decomposition and CRT (WIP04): factor minpoly into coprime prime powers, construct primary vectors via minimality, combine with Bezout projections. Factorization bridge proved by Aristotle via UniqueFactorizationMonoid API.",
   "meta": {
     "author": "Classical linear algebra (F.G. Frobenius, 1878)",
     "sourceUrl": "",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
     "tags": [
       "linear-algebra",
@@ -18,11 +18,11 @@
       "finite-fields",
       "minimal-polynomial"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 189,
-    "assumptions": "1 sorry: monic_factored_form (routine fact that monic polynomials over a field factor into coprime prime powers via UniqueFactorizationMonoid.normalizedFactors). NOT a mathematical assumption — purely Mathlib API navigation (~50 lines). All mathematical content (primary decomposition, CRT construction) is fully verified via WIP04.",
+    "lineCount": 183,
+    "assumptions": "",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -43,10 +43,10 @@
     ],
     "originalContributions": [
       "V2 upgrade: eliminated RCF similarity axiom via primary decomposition (WIP04)",
-      "Main theorem: nonderogatory_has_cyclic_vector (0 axioms, 1 routine sorry)",
+      "V3 upgrade: proved monic_factored_form via Aristotle (UFD factorization bridge), achieving 0 axioms / 0 sorries",
+      "Main theorem: nonderogatory_has_cyclic_vector (fully verified, all fields including finite)",
       "Corollary: nonderogatory_has_cyclic_vector_finite for any finite field",
-      "Corollary: cyclic_iff_not_killed_below_degree equivalence",
-      "Factorization bridge: monic_factored_form isolates the single remaining sorry (routine Mathlib API)"
+      "Corollary: cyclic_iff_not_killed_below_degree equivalence"
     ],
     "dateAdded": "2026-04-26"
   },
@@ -76,15 +76,15 @@
       "title": "§ II. Factorization Bridge",
       "startLine": 76,
       "endLine": 98,
-      "summary": "States `monic_factored_form` (sorry): every monic polynomial of positive degree factors into coprime monic irreducible prime powers. This is a routine consequence of K[X] being a UFD; the sorry is purely Mathlib API navigation.",
-      "mathContext": "In $K[X]$ (a UFD with normalization), `normalizedFactors` decomposes any nonzero non-unit polynomial into monic irreducible factors. Grouping by multiplicity gives the prime power factorization $\\mu = \\prod_{i=1}^k p_i^{e_i}$ with pairwise coprimality (distinct primes are coprime in a UFD). The sorry isolates the Lean 4 API challenge of converting between `Multiset` (normalizedFactors output) and `Fin k`-indexed arrays (WIP04 input)."
+      "summary": "States and proves `monic_factored_form`: every monic polynomial of positive degree factors into coprime monic irreducible prime powers. Proved by Aristotle via UniqueFactorizationMonoid.normalizedFactors API (companion file CayleyHamiltonCyclicVectorAllFieldsAristotle.lean).",
+      "mathContext": "In $K[X]$ (a UFD with normalization), `normalizedFactors` decomposes any nonzero non-unit polynomial into monic irreducible factors. Grouping by multiplicity gives the prime power factorization $\\mu = \\prod_{i=1}^k p_i^{e_i}$ with pairwise coprimality (distinct primes are coprime in a UFD). The proof converts between `Multiset` (normalizedFactors output) and `Fin k`-indexed arrays (WIP04 input) via an auxiliary finset_factorization_from_multiset lemma."
     },
     {
       "id": "main-theorem",
       "title": "§ III. Main Theorem",
       "startLine": 100,
       "endLine": 135,
-      "summary": "Proves nonderogatory_has_cyclic_vector: dispatches n=0, factors minpoly via monic_factored_form, applies WIP04's primary decomposition theorem. Zero axioms.",
+      "summary": "Proves nonderogatory_has_cyclic_vector: dispatches n=0, factors minpoly via monic_factored_form (proved), applies WIP04's primary decomposition theorem. Zero axioms, zero sorries.",
       "mathContext": "Proof: (1) Factor $\\mathrm{minpoly}_K(M) = \\prod_i p_i^{e_i}$ into coprime prime powers. (2) For each $i$, construct primary vector $v_i$ with $p_i^{e_i}(M)v_i = 0$ and $p_i^{e_i-1}(M)v_i \\neq 0$ via minimality of minpoly. (3) $v = \\sum v_i$ is cyclic: Bezout projections extract $r(M)v_i = 0$ from $r(M)v = 0$, giving $p_i^{e_i} | r$ for all $i$, hence $\\mathrm{minpoly} | r$, contradicting $\\deg(r) < n$."
     },
     {
@@ -100,31 +100,29 @@
       "title": "§ V. Proof Summary",
       "startLine": 170,
       "endLine": 189,
-      "summary": "Closing docstring: enumerates V2 improvements over V1 (axiom eliminated), the single remaining sorry (routine Mathlib API), and the delta: deep axiom → routine sorry.",
-      "mathContext": "V1 → V2 delta: RCF similarity axiom ($\\sim$800 lines to prove from PID structure theorem) replaced by `monic_factored_form` sorry ($\\sim$50 lines of `normalizedFactors` API). Net effect: the mathematical content of the proof is now fully verified; only the boilerplate of extracting a prime power factorization from Mathlib's UFD API remains."
+      "summary": "Closing docstring: V1→V2→V3 delta. V2 eliminated RCF similarity axiom. V3 (this version) proves monic_factored_form via Aristotle, achieving 0 axioms / 0 sorries.",
+      "mathContext": "V1→V2: RCF similarity axiom ($\\sim$800 lines to prove from PID structure theorem) replaced by `monic_factored_form` sorry. V2→V3: Aristotle proved `monic_factored_form` via UFD normalizedFactors API (~130 lines in companion file). Net: fully machine-verified proof over ALL fields."
     }
   ],
   "conclusion": {
-    "summary": "V2 of this formalization eliminates the RCF similarity axiom, proving the cyclic vector theorem axiom-free via primary decomposition (WIP04). The single remaining sorry (monic_factored_form) is routine Mathlib API work, not a mathematical assumption.",
-    "implications": "The upgrade from V1 (1 axiom, 0 sorries) to V2 (0 axioms, 1 sorry) replaces a deep mathematical assumption (PID structure theorem, ~800 lines to formalize) with a routine API exercise (~50 lines of normalizedFactors navigation). The primary decomposition approach (Bezout projections + CRT) is the key innovation: it bypasses companion matrices entirely, working directly with polynomial annihilators.",
-    "openQuestions": [
-      "Fill the monic_factored_form sorry using Mathlib's UniqueFactorizationMonoid.normalizedFactors API + Finset.equivFin. Estimated ~50 lines. Suitable for Aristotle submission.",
-      "Can the factorization bridge be proved without Finset.equivFin? A direct Finset-indexed version of WIP04's theorem would eliminate the Fin k conversion overhead."
-    ]
+    "summary": "V3 of this formalization is fully verified: 0 axioms, 0 sorries. The cyclic vector theorem holds over ALL fields (including finite fields F_q with q ≤ n) via primary decomposition (WIP04). The factorization bridge monic_factored_form was proved by Aristotle via UniqueFactorizationMonoid.normalizedFactors.",
+    "implications": "The V1→V2→V3 progression: V1 (1 axiom, 0 sorries) axiomatized RCF similarity. V2 (0 axioms, 1 sorry) replaced the deep PID structure theorem axiom with a routine UFD API sorry. V3 (0 axioms, 0 sorries) closes the final sorry via Aristotle. The primary decomposition approach (Bezout projections + CRT) bypasses companion matrices and cardinality arguments, working over any field.",
+    "openQuestions": []
   },
   "leanFile": {
     "imports": [
       "Mathlib",
-      "Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04"
+      "Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04",
+      "Proofs.CayleyHamiltonCyclicVectorAllFieldsAristotle"
     ],
     "opens": ["Matrix", "Polynomial"],
     "namespace": "CayleyHamiltonCyclicVectorAllFields",
-    "lineCount": 189,
+    "lineCount": 183,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -157,7 +155,7 @@
     {
       "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector",
       "statement": "∀ (M : Matrix (Fin n) (Fin n) K), IsNonderogatory M → ∃ v, IsCyclicVector M v",
-      "description": "Main theorem: every nonderogatory matrix over ANY field has a cyclic vector. 0 axioms, 1 sorry (routine factorization bridge)."
+      "description": "Main theorem: every nonderogatory matrix over ANY field has a cyclic vector. Fully verified: 0 axioms, 0 sorries."
     },
     {
       "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector_finite",
@@ -170,5 +168,5 @@
       "description": "Polynomial annihilator characterization: cyclic iff not killed by any nonzero polynomial of degree < n."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json
@@ -19,9 +19,9 @@
     "phase": "COMPLETED",
     "since": "2026-04-25T13:30:37+02:00",
     "iteration": 2,
-    "focus": "Gallery entry CayleyHamiltonCyclicVectorAllFields.lean V2 (axiom-free): 0 axioms, 1 sorry (monic_factored_form, routine ~50-line Mathlib UFM API). Eliminated RCF similarity axiom by routing through WIP04 primary decomposition (PR #13041, 2026-04-27).",
+    "focus": "Gallery entry CayleyHamiltonCyclicVectorAllFields.lean V3 (fully verified): 0 axioms, 0 sorries. monic_factored_form proved via Aristotle companion file (PR pending, 2026-05-02).",
     "blockers": [],
-    "nextAction": "Submit monic_factored_form (routine UFM/normalizedFactors API) to Aristotle to reach 0 sorries / 0 axioms.",
+    "nextAction": "",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOMATIZED-COMPLETE → V2 AXIOM-FREE: PR #13041 (2026-04-27) eliminated nonderogatory_similar_companion axiom by routing through WIP04 primary decomposition (GeneralCyclicVector.nonderogatory_general_has_cyclic_vector). Gallery file now has 0 axioms, 1 routine sorry (monic_factored_form: monic μ over a field factors into coprime monic prime powers — UniqueFactorizationMonoid API, ~50 lines, Aristotle-suitable). Mathematical content fully verified.",
+    "progressSummary": "VERIFIED (0 axioms, 0 sorries): V3 integrates Aristotle's proof of monic_factored_form from companion file into main gallery entry. All content fully machine-checked. V1 (1 axiom) → V2 (0 axioms, 1 sorry) → V3 (0/0) progression complete.",
     "builtItems": [
       "exists_strongly_cyclic: helper theorem stated with detailed proof sketch (CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean:301)",
       "nonderogatory_squarefree_has_cyclic_vector: PROVED assuming exists_strongly_cyclic (line 325) — main theorem complete",
@@ -50,17 +50,14 @@
       "Route B (axiomatize) succeeded: declare nonderogatory_similar_companion as axiom, prove main theorem from it + proved lemmas from CyclicVectorArbitrary namespace",
       "axiom vs sorry: using explicit Lean 4 axiom declaration is cleaner than sorry — the assumption is named, documented, and intentional",
       "Gallery entry created at src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/ with 1 axiom, 0 sorries, status=axiomatized",
-      "PR #13041 (2026-04-27) eliminated the RCF similarity axiom: V2 routes through WIP04 primary decomposition + Bezout/CRT, leaving only monic_factored_form as a routine UFM Mathlib API sorry (~50 lines). The deep mathematical axiom (PID structure theorem) is now replaced by a routine API navigation."
+      "PR #13041 (2026-04-27) eliminated the RCF similarity axiom: V2 routes through WIP04 primary decomposition + Bezout/CRT, leaving only monic_factored_form as a routine UFM Mathlib API sorry (~50 lines). The deep mathematical axiom (PID structure theorem) is now replaced by a routine API navigation.",
+      "V3 (2026-05-02): Aristotle proved monic_factored_form in companion file CayleyHamiltonCyclicVectorAllFieldsAristotle.lean. Main file imports companion and delegates to its theorem. File now 0 axioms / 0 sorries — fully machine-verified."
     ],
     "mathlibGaps": [
       "monic_factored_form: routine consequence of K[X] being a UniqueFactorizationMonoid (normalizedFactors → toFinset/count → coprime prime-power product). Not actually a Mathlib gap — just API assembly (~50 lines). Aristotle-suitable.",
       "Rational Canonical Form (PID structure theorem) is a real Mathlib gap (~800 lines), but V2 no longer depends on it."
     ],
-    "nextSteps": [
-      "Submit monic_factored_form to Aristotle (routine UFM API, ~50 lines) — would close the file to 0 sorries / 0 axioms.",
-      "Alternative manual route: normalizedFactors μ → toFinset for distinct primes → count for exponents → use Polynomial.normalizedFactors_prod + Polynomial.Monic.normalizedFactors_prod to recover μ. Coprimality from Prime.coprime_iff_not_dvd on distinct primes.",
-      "After 0/0: optionally upstream monic_factored_form to Mathlib as Polynomial.UniqueFactorizationMonoid lemma — generally useful."
-    ],
+    "nextSteps": [],
     "markdown": "# Knowledge Base: cayley-hamilton-cyclic-vector-all-fields\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Integrates Aristotle's proof of `monic_factored_form` from `CayleyHamiltonCyclicVectorAllFieldsAristotle.lean` into the main gallery file
- Adds `import Proofs.CayleyHamiltonCyclicVectorAllFieldsAristotle` and delegates the theorem with a one-line term-mode proof
- Gallery `cayley-hamilton-cyclic-vector-all-fields` advances from V2 (0 axioms, 1 sorry) to V3 (0 axioms, 0 sorries)
- Updates gallery meta.json: status `formalized` → `verified`, badge `wip` → `verified`, sorries 1 → 0

## Mathematical Content

`monic_factored_form` states that every monic polynomial of positive degree over a field factors into a finite product of coprime monic irreducible prime powers. This is a standard consequence of K[X] being a UniqueFactorizationMonoid.

Aristotle proved this in the companion file (integrated 2026-04-30) via:
1. `monic_irreducible_multiset_factorization` — UFD prime factorization lifted to monic factors
2. `finset_factorization_from_multiset` — groups multiset into distinct primes with multiplicities
3. `coprime_of_distinct_monic_irreducible` — distinct monic irreducibles are coprime
4. Assembly into `monic_factored_form`

## V1 → V2 → V3 Progression

| Version | Axioms | Sorries | Method |
|---------|--------|---------|--------|
| V1 | 1 (RCF similarity) | 0 | Axiomatized PID structure theorem |
| V2 (PR #13041) | 0 | 1 (UFD bridge) | Primary decomposition via WIP04 |
| V3 (this PR) | 0 | 0 | Aristotle proves UFD bridge |

## Test plan

- [ ] Docker build `Proofs.CayleyHamiltonCyclicVectorAllFields` passes
- [ ] Gallery meta.json shows `status: verified`, `sorries: 0`
- [ ] pnpm build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)