### PR TITLE
Enrich Chung-Feller Theorem: gallery face coverage + openQuestion

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/annotations.json
@@ -147,6 +147,30 @@
     ]
   },
   {
+    "id": "ann-three-file-architecture",
+    "proofId": "ballot-problem-oq-01-oq-04",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "Three-File Architecture: Eliminating an Axiom via Re-export",
+    "content": "The file header documents a notable software architecture pattern for formal proofs: a placeholder axiom was eliminated by splitting the proof into three files. The problem was a circular dependency — `chung_feller_uniform` needed to live in the gallery face file (for naming), but the bijection proof that establishes it needed to import the gallery face to access shared definitions. The solution was to extract those shared definitions into a `Core` file that both can import, then have the gallery face import the bijection file and re-export the theorem under its conventional name. This is a clean way to handle what would otherwise be an unsolvable import cycle in Lean 4.",
+    "mathContext": "Import chain: `Core ← OQ01 (bijection) ← Gallery face`. `Core` defines `IsBalancedPath`, `upstepsAboveAxis`, etc. `OQ01` proves `chung_feller_uniform'` using the explicit bijection. The gallery face re-exports it as `chung_feller_uniform`. No axiom use at any level.",
+    "significance": "context",
+    "relatedConcepts": ["modular proof architecture", "import cycles", "re-export pattern", "axiom elimination", "Core module pattern"],
+    "prerequisites": ["Lean 4 import system", "namespace re-export", "BallotProblemOQ01OQ04Core.lean"]
+  },
+  {
+    "id": "ann-reexport-theorem",
+    "proofId": "ballot-problem-oq-01-oq-04",
+    "range": { "startLine": 50, "endLine": 73 },
+    "type": "insight",
+    "title": "Gallery Face: Re-exporting the Proved Chung-Feller Theorem",
+    "content": "The gallery face file is intentionally thin — it exists to provide a stable named entry point `chung_feller_uniform` in the `ChungFeller` namespace while the actual proof lives in the companion bijection file. The re-export is a single invocation of `ChungFellerBijection.chung_feller_uniform'`. This pattern is widely used in Mathlib: a 'face' module exposes a stable API while the underlying proof is in a separate module that can evolve independently. The key claim in the docstring is that the bijection proof has 0 sorries and 0 axiom uses, which any `#check @chung_feller_uniform` at the top of a downstream file can verify.",
+    "mathContext": "Final statement: $\\forall j, k \\leq n,\\; |\\text{balancedPathsOfType}(n, j)| = |\\text{balancedPathsOfType}(n, k)|$. With `balanced_path_total` ($\\binom{2n}{n} = C_n \\cdot (n+1)$), each of the $n+1$ path types has exactly $C_n$ balanced paths.",
+    "significance": "key",
+    "relatedConcepts": ["Chung-Feller theorem", "gallery face pattern", "stable API", "ChungFellerBijection", "proof re-export"],
+    "prerequisites": ["ChungFellerBijection.chung_feller_uniform'", "balanced_path_total", "upstepsAboveAxis"]
+  },
+  {
     "id": "ann-chung-feller-axiom",
     "proofId": "ballot-problem-oq-01-oq-04",
     "range": {

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -128,7 +128,8 @@
     "implications": "**Mathematical Significance**\n\n1. **Cycle Lemma Bridge**: The prepend-one-good-rotation theorem is the key structural fact: the 2n+1 cyclic rotations of a prepended balanced path contain exactly 1 good rotation, creating the foundation for the (n+1)-uniform partition.\n\n2. **Catalan Connection**: Via balanced_path_total, the total count C(2n,n) factors as Cₙ × (n+1), so the uniform (n+1)-partition yields Cₙ members per type.\n\n3. **Explicit Bijection**: The cycle-lemma route to Chung-Feller is constructive. The map l ↦ (Dyck-tail of good rotation, upstepsAboveAxis l) is bijective, with no appeal to algebraic topology or generating functions.\n\n4. **Architectural Note**: The previously stated axiom chung_feller_uniform was eliminated by extracting shared definitions to a Core file and flipping the import direction so the gallery face can re-export the bijection-proved theorem under its conventional name.",
     "openQuestions": [
       "Can a q-analog of the Chung-Feller theorem be formalized, tracking the area under the path?",
-      "Does chungFellerMap admit a description in terms of the RSK correspondence, given that Dyck paths and Catalan structures are RSK-related?"
+      "Does chungFellerMap admit a description in terms of the RSK correspondence, given that Dyck paths and Catalan structures are RSK-related?",
+      "Can the Chung-Feller proof be extended to the Lindström-Gessel-Viennot lemma setting, where balanced paths in a planar DAG replace ±1 lattice paths and the cycle lemma generalizes to non-intersecting path families?"
     ]
   },
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment pass for `ballot-problem-oq-01-oq-04`

**Quality before:** 94 (0 annotation passes)

### Changes

**annotations.json** (had 7 annotations, adding 2 more):
- Added `ann-three-file-architecture` (lines 1–49): explains how the 3-file proof architecture (Core → OQ01 bijection → gallery face) resolved a circular dependency and eliminated the placeholder axiom
- Added `ann-reexport-theorem` (lines 50–73): explains the gallery face re-export pattern — the file is intentionally thin, providing a stable `chung_feller_uniform` entry point while the actual proof lives in the bijection companion file

**meta.json**:
- Added 3rd `openQuestion` to conclusion: LGV lemma generalization of Chung-Feller to non-intersecting path families in planar DAGs

The 7 existing annotations were already high quality; the new ones provide explicit coverage of the gallery face sections (lines 1-73) that were previously uncovered (the original annotations covered Core file line ranges).