### PR TITLE
Enrich Quadratic Reciprocity Reduction Lemmas: fill annotation gap + openQuestion

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -92,6 +92,18 @@
     ]
   },
   {
+    "id": "ann-examples-section",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": { "startLine": 65, "endLine": 73 },
+    "type": "context",
+    "title": "Verified Computations Section: From Theory to Numbers",
+    "content": "The examples section opens with two simple cases: (3/7) = -1 (verified with a full docstring explaining the reciprocity derivation) and (2/7) = 1 (4 is 2² ≡ 4 and 3² = 9 ≡ 2 mod 7, so 2 is a QR mod 7). These two examples immediately demonstrate the algorithm: (3/7) uses the reciprocity swap and (2/7) uses the second supplementary law. The docstring for (3/7) writes out the derivation step by step, providing a human-readable proof trace alongside the machine-verified `decide` check. This dual presentation — hand proof + decide — is the pedagogically ideal format: the reader sees why the algorithm works while the kernel confirms it produces the right number.",
+    "mathContext": "$\\left(\\tfrac{3}{7}\\right) \\cdot \\left(\\tfrac{7}{3}\\right) = (-1)^{\\frac{3-1}{2} \\cdot \\frac{7-1}{2}} = (-1)^{1 \\cdot 3} = -1$. Since $\\left(\\tfrac{7}{3}\\right) = \\left(\\tfrac{1}{3}\\right) = 1$, we get $\\left(\\tfrac{3}{7}\\right) = -1$. And $3^2 = 9 \\equiv 2 \\pmod{7}$, so $\\left(\\tfrac{2}{7}\\right) = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["decide tactic", "second supplementary law", "reciprocity derivation trace", "hand proof vs machine proof"],
+    "prerequisites": ["Legendre symbol", "legendreSym in Lean 4", "p mod 4 and p mod 8 case analysis"]
+  },
+  {
     "id": "ann-decide-examples",
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -88,7 +88,8 @@
     "implications": "The companion proof `quadratic-reciprocity-algorithm-oq-01` builds on this packaging by implementing the full recursive algorithm (Jacobi-symbol form, well-founded termination, native_decide-verified examples). This entry exposes the *minimum* set of lemmas needed to turn QR into a computation, useful as a teaching artifact and as a stepping stone for downstream verified applications such as Solovay-Strassen primality testing and Tonelli-Shanks square roots.",
     "openQuestions": [
       "Can the second supplementary law $\\left(\\tfrac{2}{p}\\right) = (-1)^{(p^2-1)/8}$ be packaged as a fourth reduction lemma in the same one-line wrapper style, completing the standalone algorithmic toolkit?",
-      "Can the descent statement be strengthened to a recursion principle that takes the three reduction lemmas as inputs and produces a verified Legendre symbol computer, without going through the Jacobi-symbol detour of `quadratic-reciprocity-algorithm-oq-01`?"
+      "Can the descent statement be strengthened to a recursion principle that takes the three reduction lemmas as inputs and produces a verified Legendre symbol computer, without going through the Jacobi-symbol detour of `quadratic-reciprocity-algorithm-oq-01`?",
+      "Can the verified Legendre symbol computation be extended to the Jacobi symbol (a/n) for composite n via the same three-step reduction, and proved correct against Mathlib's JacobiSym, giving a unified algorithmic toolkit for primality testing via Solovay-Strassen?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Enrichment pass for `quadratic-reciprocity-oq-03`

**Quality before:** 96 (0 annotation passes)

### Changes

**annotations.json** (had 6 annotations, adding 1 more):
- Added `ann-examples-section` (lines 65–73): covers the previously unannotated section header and first two `decide` examples. Explains the dual hand-proof + machine-verify format, and the specific QR derivations for (3/7)=-1 (reciprocity swap) and (2/7)=1 (second supplementary law).

**meta.json**:
- Added 3rd `openQuestion` to conclusion: Jacobi symbol extension for composite moduli, connecting to Solovay-Strassen primality testing via the same three-step reduction toolkit.

The 6 existing annotations were already high quality; the new annotation fills the gap at lines 65-73 that was not covered.