### PR TITLE
fix(meta): solution-of-cubic-oq-03-oq-05 theorem name drift

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
@@ -42,7 +42,7 @@
       "**Generality over CommRing**: the formulas hold over any commutative ring, not just fields or ℂ. This covers e.g. polynomials over ℤ (integer roots, integer coefficients) or ℤ/pℤ (finite field roots), making the results applicable in modular arithmetic and number theory",
       "**Elementary symmetric polynomials**: Vieta's formulas are the isomorphism σ: roots → coefficients via e₁, e₂, e₃. The Newton-Girard identities (expressing power sums p_k = Σ rᵢᵏ in terms of eₖ) follow from Vieta's, connecting the formulas to generating functions and partition theory",
       "**Connection to Galois theory**: the Galois group of the cubic acts by permuting the roots r₁, r₂, r₃. Since the coefficients a, b, c are symmetric functions of the roots (Vieta's formulas), they are fixed by the entire Galois group — this is why coefficients live in the base field even when roots do not. The discriminant Δ = (r₁-r₂)²(r₁-r₃)²(r₂-r₃)², also symmetric, determines whether the Galois group is ℤ/3 (Δ a perfect square) or S₃ (Δ not a perfect square)",
-      "**Roots-as-verification**: the `root_satisfies_poly` theorem provides the reverse direction: given a factorization, each root satisfies the polynomial. This two-way relationship (coefficients ↔ roots) is the core of the fundamental theorem of algebra's constructive content — Vieta's gives the forward map, while root-finding algorithms (Cardano, Newton) provide the reverse"
+      "**Roots-as-verification**: the `root_satisfies` theorem provides the reverse direction: given a factorization, each root satisfies the polynomial. This two-way relationship (coefficients ↔ roots) is the core of the fundamental theorem of algebra's constructive content — Vieta's gives the forward map, while root-finding algorithms (Cardano, Newton) provide the reverse"
     ]
   },
   "crossReferences": [
@@ -117,7 +117,7 @@
       "startLine": 97,
       "endLine": 111,
       "summary": "Proves that if the cubic factors as (x-r₁)(x-r₂)(x-r₃), then evaluating at r₁ gives 0. The proof rewrites using the factorization and evaluates the product: (r₁-r₁)·(r₁-r₂)·(r₁-r₃) = 0·(···) = 0.",
-      "mathContext": "`root_satisfies_poly (h : X^3 + C a * X^2 + C b * X + C c = (X - C r₁) * (X - C r₂) * (X - C r₃)) : Polynomial.eval r₁ (X^3 + C a * X^2 + C b * X + C c) = 0`. Proof: `rw [h]; simp [Polynomial.eval_mul, Polynomial.eval_sub, sub_self]` — evaluating $(r_1 - r_1) = 0$ kills the first factor. This is the reverse direction of the factor theorem: $p(r_i) = 0$ iff $(X - r_i) \\mid p$. Here we prove it directly from the factored form, avoiding the general factor theorem. In Lean, `Polynomial.eval r₁ (X - C r₁) = r₁ - r₁ = 0` by `simp`."
+      "mathContext": "`root_satisfies (h : X^3 + C a * X^2 + C b * X + C c = (X - C r₁) * (X - C r₂) * (X - C r₃)) : Polynomial.eval r₁ (X^3 + C a * X^2 + C b * X + C c) = 0`. Proof: `rw [h]; simp [Polynomial.eval_mul, Polynomial.eval_sub, sub_self]` — evaluating $(r_1 - r_1) = 0$ kills the first factor. This is the reverse direction of the factor theorem: $p(r_i) = 0$ iff $(X - r_i) \\mid p$. Here we prove it directly from the factored form, avoiding the general factor theorem. In Lean, `Polynomial.eval r₁ (X - C r₁) = r₁ - r₁ = 0` by `simp`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Audit (Tier A `verified`/`original`) of solution-of-cubic-oq-03-oq-05 confirmed the integrity claims (sorries 0, axioms 0, lineCount 112, theoremCount 6 all match the Lean source). Found one minor narrative drift: the documentation refers to a theorem named `root_satisfies_poly` in two places, but the actual theorem in `proofs/Proofs/SolutionOfCubicOQ03OQ05.lean:102` is `root_satisfies`.

Fixed:
- `overview.keyInsights[4]`: `root_satisfies_poly` → `root_satisfies`
- `sections[4].mathContext`: `root_satisfies_poly` → `root_satisfies`

Tracker bumped: auditCount 2 → 3, lastAudited 2026-05-02, result `issues-fixed`.

## Test plan

- [x] Verified theorem name in Lean source (line 102: `theorem root_satisfies`)
- [x] Verified no other references to `root_satisfies_poly` in repo
- [x] Tracker updated through python `json.dump(..., ensure_ascii=False)` to avoid the unicode-escape bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)