### PR TITLE
audit(solution-of-cubic-oq-03-oq-05): record clean (auditCount 2→3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13055,9 +13055,9 @@
       "result": "clean"
     },
     "solution-of-cubic-oq-03-oq-05": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:23:23Z",
+      "lastAudited": "2026-05-02T21:01:44Z",
       "result": "clean"
     },
     "solution-of-cubic-oq-05": {


### PR DESCRIPTION
## Summary

Periodic re-audit of `solution-of-cubic-oq-03-oq-05` (Vieta's formulas for the general cubic). All integrity checks pass; tracker updated.

## Verification

| Check | meta.json | actual | ✓ |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| lineCount | 112 | 112 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| status / badge | verified / original | Tier A | ✓ |

## Tier-A justification

`cubic_factor_expansion` is proved by `ring` (genuine polynomial-ring computation, not a Mathlib import). The three Vieta theorems do real work via `congr_arg (Polynomial.coeff · k)` + `simp` + `linarith` to extract each elementary symmetric polynomial from the factorization identity. `root_satisfies` derives via `Polynomial.eval_*`. The `import Mathlib` line only supplies tactic infrastructure and `Polynomial.coeff`/`Polynomial.eval` lemmas — the core mathematical content is in this file.

## Test plan
- [x] No content changes; only tracker bookkeeping
- [x] `auditCount` 2 → 3, `lastAudited` updated, `result` remains `clean`
- [x] No unicode escapes (used `ensure_ascii=False`, sidestepping the `claim-target.sh complete` bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)