### PR TITLE
audit(cayley-hamilton-cyclic-vector-all-fields): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1725,9 +1725,9 @@
       "result": "clean"
     },
     "cayley-hamilton-cyclic-vector-all-fields": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T14:05:44Z",
+      "lastAudited": "2026-05-02T21:15:43Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly": {


### PR DESCRIPTION
## Summary

Re-audit of `cayley-hamilton-cyclic-vector-all-fields` against `origin/main`. **Result: clean.**

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 1 | 1 (`monic_factored_form`, line 91) | ✓ |
| axiomCount (this file) | 0 | 0 | ✓ |
| theoremCount | 4 | 4 (3 `theorem` + 1 `private theorem`) | ✓ |
| definitionCount | 2 | 2 (abbrevs) | ✓ |
| lineCount | 189 | 189 | ✓ |
| imports | `Mathlib`, `Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04` | same | ✓ |
| status / badge | `formalized` / `wip` | matches the 1 remaining sorry | ✓ |

Import-chain check: `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean` has 0 axioms and 0 sorries (confirmed via grep), so the `meta.axiomCount: 0` total claim holds.

## Narrative integrity

- **No delegation opacity**: meta correctly attributes the primary-decomposition core to WIP04 ("Apply WIP04's primary decomposition theorem").
- **No axiom masking**: 0 axioms; the single sorry is explicitly named and characterized as routine UFD API in description, assumptions, conclusion, and Section II/V.
- **No inequality-as-theorem inflation**: the existential `∃ v, IsCyclicVector M v` is what gets proved.
- **No pipeline inflation**: claims are scoped to this file.
- **No "0 sorries with hidden imports"**: file declares 1 sorry honestly; badge is `wip` not `mathlib` or `verified`.

Tier C scaffold (sorry remaining for routine factorization bridge) — language is appropriately hedged throughout.

## Tracker change

Bumped `auditCount` 1 → 2, `lastAudited` → 2026-05-02 for this entry. No other entries touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)