### PR TITLE
Enrich isoperimetric-theorem-oq-02: add header section (quality 98 → 100)

### DIFF
--- a/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Context: Discrete Isoperimetric Hierarchy",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring places the 1D result at the base of the discrete isoperimetric hierarchy: Harper (1966) for hypercubes, Bollobás-Leader (1991) compression for ℤ^d. Imports Mathlib and opens the DiscreteIsoperimetric1D namespace.",
+      "mathContext": "The general discrete isoperimetric problem: minimize $|\\partial S|$ over sets $S$ of fixed size in a graph $G$. For $G = \\mathbb{Z}$: intervals minimize; for $G = \\{0,1\\}^n$: Harper's initial segments; for $G = \\mathbb{Z}^d$: Bollobás–Leader cubes. The 1D case is the base of this hierarchy."
+    },
+    {
       "id": "definitions",
       "title": "Edge Boundary on ℤ",
       "startLine": 33,


### PR DESCRIPTION
## Summary

Second enrichment pass for `isoperimetric-theorem-oq-02` (Discrete Isoperimetric Inequality 1D), following the merged PR #14865 which added 7 annotations and the 5th keyInsight.

**Change**: Added a header section covering lines 1-31 (the module docstring, imports, namespace declaration). This section documents the discrete isoperimetric hierarchy context:
- 1D result (this entry): intervals minimize boundary  
- Hypercube (Harper 1966): initial segments in simplicial order
- ℤ^d (Bollobás-Leader 1991): compression argument

**Sections before**: 4 (scoring 8/10)  
**Sections after**: 5 (scoring 10/10)  
**Quality**: 98 → 100

The 5 sections now cover the full 136-line Lean file from line 1 to line 136.

Note: PR #14889 also previously contained the pac-learning-bounds-oq-01 section fix — that work has been separated and is captured in the enrichment-tracker as a completed pass.