### PR TITLE
audit: record erdos-634 follow-up (linked to #14888)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8534,11 +8534,12 @@
     },
     "erdos-634": {
       "agentId": "auditor-loop-1777752145",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T20:07:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-02T21:25:00Z",
       "result": "issues-found",
       "issues": [
-        "sorries claim 7 actual 1 (PR #14856 reduced 7→1 but meta.json not refreshed); lineCount 298→332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness — issue #14859"
+        "sorries claim 7 actual 1 (PR #14856 reduced 7→1 but meta.json not refreshed); lineCount 298→332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness — issue #14859",
+        "Re-audit 2026-05-02 vs origin/main a0a5957: PR #14866 fixed only meta.json text; deeper Dissection placeholder + axiom inconsistency unresolved -> issue #14888"
       ]
     },
     "erdos-635": {


### PR DESCRIPTION
## Summary

Tracker update for `erdos-634` recording a re-audit against `origin/main` (a0a5957). PR #14866 closed [#14859](https://github.com/rjwalters/lean-genius/issues/14859) by fixing the meta.json sorry/lineCount text, but the deeper concern — the placeholder `Dissection` structure that makes the file's negative-result axioms inconsistent with its own positive-result proofs — was untouched. Filed [#14888](https://github.com/rjwalters/lean-genius/issues/14888) for the structural fix (mechanic-class).

## Tracker change

- `entries["erdos-634"].auditCount` 3 → 4
- `entries["erdos-634"].lastAudited` → 2026-05-02T21:25:00Z
- `entries["erdos-634"].result` stays `issues-found`
- Appended a second-line issue noting the unresolved structural concern and linking to #14888

🤖 Generated with [Claude Code](https://claude.com/claude-code)