### PR TITLE
research(ballot-jt): S18 — diagnose non-injective bijection, correct proof path for jdt_weight_sum b≥2

### DIFF
--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -895,6 +895,75 @@ with ~150 lines of ring-valued LGV would complete the framework.
 
 ---
 
+## Session 2026-05-02 (Session 18) — Non-injective bijection diagnosis + correct proof path
+
+**Mode**: REVISIT (RICH knowledge tier, score 88)
+**Outcome**: analysis — discovered fundamental flaw in described b≥2 bijection; identified correct proof path via weight factorization + counting identity
+
+### What I Did
+
+1. **Rebased worktree to origin/main** to pick up PR #14882 (Session 17: `jdt_weight_sum_b_one` proved). Confirmed the file now has exactly 2 sorries (not 3):
+   - Line 598: `jdt_weight_sum` b ≥ 2 seam bijection
+   - Line 841: `jacobi_trudi_ssyt_eq` k ≥ 3 (RSK)
+
+2. **Analyzed the "insert violation element" bijection** described in the file's b≥2 sorry comment:
+   - Forward: find first-violation column c; move `Q.sort[c]` from Q to P at position c.
+   - This is the bijection that has been described across sessions 5–17 but never proved.
+
+3. **Discovered it is NON-INJECTIVE for b ≥ 2.** Concrete counterexample (a=3, b=2):
+   - Pair A: `P={1,3,4}`, `Q={0,2,3}`. First violation at c=0 (P.sort[0]=1 ≥ Q.sort[0]=0). Move v=0 from Q to P: `P'={0,1,3,4}`, `Q'={2,3}`.
+   - Pair B: `P={0,1,4}`, `Q={2,3,3}`. First violation at c=2 (P.sort[2]=4 ≥ Q.sort[2]=3). Move v=3 from Q to P: `P'={0,1,3,4}`, `Q'={2,3}`.
+   - Both pairs map to `(P', Q') = ({0,1,3,4}, {2,3})`. The forward map is NOT injective.
+
+4. **Identified the correct proof path.** Key observation:
+   `wt(P) * wt(Q) = ((P.1 + Q.1).map X).prod` — weight depends only on the TOTAL multiset, not the split.
+   
+   Therefore, the polynomial identity `∑_{non-cs (P,Q)} wt = h_{a+1} * h_{b-1}` is equivalent to:
+   
+   **Counting identity**: for every `M : Sym (Fin n) (a+b)`,
+   `#{non-cs (a,b) splits of M} = #{all (a+1,b-1) splits of M}`
+   
+   where `#{all (a+1,b-1) splits of M} = C(a+b, a+1)` (purely combinatorial, no ring structure needed).
+
+5. **The counting identity is provable by the ballot/reflection principle.** For a multiset M of size a+b, splits into (P:a, Q:b) and (P':a+1, Q':b-1) both correspond to choosing k elements from M. The non-col-strict condition picks exactly the splits where `P.sort[0] ≥ Q.sort[0]` (the "bad" ones) — and a ballot-principle bijection maps these exactly to all (a+1,b-1) splits.
+
+### Key Findings
+
+- **The "insert violation element" bijection is provably non-injective for b ≥ 2.** The counterexample above is concrete and definitive. This explains why 17 sessions have failed to prove it — the approach is mathematically wrong.
+
+- **Weight factorization is the key insight**: `wt(P)*wt(Q) = ((P.1+Q.1).map X).prod`. This was already observed in the proof of `jdt_weight_preserved` (which moves one element between P and Q without changing the weight). For the full sum, it means we only need to count splits by total multiset.
+
+- **The correct proof strategy** (no ring-valued LGV or bijection of pairs needed):
+  1. Group the LHS sum by total multiset M: `∑_M ∑_{non-cs splits of M} wt(M)`.
+  2. Each M contributes `|{non-cs splits of M}| * wt(M)`.
+  3. Show `|{non-cs splits of M}| = |{all (a+1,b-1) splits of M}|` by ballot principle bijection.
+  4. Regroup RHS: `h_{a+1} * h_{b-1} = ∑_M |{all (a+1,b-1) splits of M}| * wt(M)`.
+  
+- **Infrastructure needed** (~100-150 lines):
+  - `sym_split_of_union` or similar: for M : Sym n (a+b), a split is a pair (P:a, Q:b) with P.1 + Q.1 = M.1.
+  - `ballot_bijection`: for fixed M, non-cs (a,b) splits ≃ all (a+1,b-1) splits. The bijection: given a non-cs split (P,Q) with violation at c, move Q.sort[c] → minimum element of {P.sort[c+1..], Q.sort[c+1..]}; this is weight-NEUTRAL since M is fixed.
+  - Actually the counting argument may be even simpler: just `Fintype.card_congr` using the ballot principle bijection on fixed M.
+
+### Files Modified
+
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` (this entry)
+
+### Next Steps
+
+1. **Implement weight-factorization approach** for `jdt_weight_sum` b ≥ 2:
+   - Prove `weight_eq_total_multiset` (or use `jdt_weight_preserved` iteratively): `wt(P)*wt(Q) = ((P.1+Q.1).map X).prod`.
+   - Restructure the LHS sum to group by total multiset M.
+   - State and prove the counting identity via ballot bijection on each fiber.
+   - Estimated ~100-150 lines, all within standard Lean combinatorics API.
+
+2. **The b≥2 sorry does NOT need ring-valued LGV.** The counting argument avoids algebra entirely — it's a bijection on a finite set indexed by M.
+
+3. **Do NOT pursue the "insert violation element" approach further.** It is non-injective.
+
+4. **For `jacobi_trudi_ssyt_eq` k ≥ 3**: RSK or algebraic LGV remain the only known paths. This is the harder open sorry.
+
+---
+
 ## Session 2026-05-02 (Session 17) — Prove jdt_weight_sum_b_one bijection
 
 **Mode**: REVISIT (RICH knowledge tier, score 88 → 90)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 17: jdt_weight_sum_b_one proved (sorry 3→2). Remaining: jdt_weight_sum b≥2 seam bijection and jacobi_trudi_ssyt_eq k≥3 (RSK).",
+    "progressSummary": "Session 18: Diagnosed non-injective bijection flaw (b≥2 sorry, 17 sessions stalled). Correct path: weight factorization + counting identity via ballot principle. ~100-150 lines needed for b≥2. 2 sorries remain.",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -115,7 +115,11 @@
       "Session 15 (2026-05-02): Decomposed jdt_weight_sum b ≥ 1 case into b = 1 (jdt_weight_sum_b_one helper, with sorry on bijection) + b ≥ 2 (still sorry, the genuine JDT seam). Sorry count went 1 → 2 in jdt_weight_sum, but the b = 1 base is now an explicit sub-problem with named statement matching the recipe.",
       "Session 15: Proved sym_one_sort_head_singleton: for Q : Sym (Fin n) 1, ∃ q. Q.1.sort = [q] ∧ Q.1 = {q}. Reusable infrastructure for Sym/Multiset proofs (List.length_eq_one_iff + Multiset.sort_eq, ~6 lines). Will be used when filling in the jdt_weight_sum_b_one bijection.",
       "Session 16: With a ≥ 1, min a 1 = 1, so ColStrictSym a 1 P Q reduces to a single inequality on the head of each sort. The negation form ¬ColStrictSym ↔ q ≤ (P.sort)[0] is exactly the precondition the b=1 bijection forward map (P, q) ↦ q ::ₛ P needs to align the sortedness invariant.",
-      "jdt_weight_sum_b_one proved (S17): bijection {(P,Q)//¬CS a 1} ≃ Sym n (a+1) via (P,Q)↦q::ₛP where q=unique element of Q. Key: getq via sym_one_sort_head_singleton.choose, left_inv uses Multiset.sort_cons + Sym.erase_cons_head, right_inv uses Sym.cons_erase, weight by ring."
+      "jdt_weight_sum_b_one proved (S17): bijection {(P,Q)//¬CS a 1} ≃ Sym n (a+1) via (P,Q)↦q::ₛP where q=unique element of Q. Key: getq via sym_one_sort_head_singleton.choose, left_inv uses Multiset.sort_cons + Sym.erase_cons_head, right_inv uses Sym.cons_erase, weight by ring.",
+      "S18: The \"insert violation element\" bijection is NON-INJECTIVE for b≥2. Counterexample: (P={1,3,4},Q={0,2,3}) and (P={0,1,4},Q={2,3,3}) both map to (P={0,1,3,4},Q={2,3}) under the forward map. This explains 17 sessions of failed proof attempts.",
+      "S18: Weight factorization insight: wt(P)*wt(Q) = ((P.1+Q.1).map X).prod — weight depends only on total multiset, not the split. Follows from jdt_weight_preserved applied to each element.",
+      "S18: The polynomial identity for jdt_weight_sum reduces to a COUNTING identity: for every M : Sym n (a+b), #{non-cs (a,b) splits of M} = #{all (a+1,b-1) splits of M}. No ring-valued LGV needed.",
+      "S18: Correct proof path for b≥2: group LHS by total multiset M, count non-cs splits per fiber via ballot bijection, regroup RHS. Estimated ~100-150 lines standard Lean combinatorics."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -123,9 +127,11 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "Implement jdt_weight_sum b≥2 seam bijection (~150-200 lines): find first violation c, insert Q.sort[c] into P, track the seam index through inverses.",
-      "Or: attempt Aristotle on jdt_weight_sum b≥2 sorry — it is a HARD sorry with known combinatorial proof.",
-      "Then tackle jacobi_trudi_ssyt_eq k≥3 (algebraic LGV + RSK, ~300 lines)."
+      "CRITICAL: Do NOT use the insert-violation-element bijection — it is non-injective for b≥2 (S18 counterexample). Use weight-factorization + counting-identity approach instead.",
+      "Implement weight_eq_total_multiset: wt(P)*wt(Q) = ((P.1+Q.1).map X).prod — use jdt_weight_preserved iteratively or direct Multiset.prod lemmas.",
+      "Restructure jdt_weight_sum LHS sum to group by total multiset M : Sym n (a+b). Use Fintype.sum_sigma or equiv to fiber product.",
+      "State and prove ballot_counting_identity: for M : Sym n (a+b), #{non-cs (a,b) splits of M} = C(a+b,a+1). This is the core counting argument — implement as a separate lemma via Fintype.card_congr + ballot bijection.",
+      "For jacobi_trudi_ssyt_eq k≥3: RSK or algebraic LGV remain the only paths. ~300 lines. Consider building BallotProblemOQ03AlgebraicLGV.lean first."
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n",
     "insightsCount": 38,


### PR DESCRIPTION
## Summary

- Diagnosed a fundamental flaw in the `jdt_weight_sum` b≥2 proof strategy that has stalled this problem for 17 sessions: the "insert violation element" forward map is **non-injective**.
- Concrete counterexample: `(P={1,3,4}, Q={0,2,3})` and `(P={0,1,4}, Q={2,3,3})` both map to `(P'={0,1,3,4}, Q'={2,3})` under the described bijection.
- Identified the correct proof path via **weight factorization** + **counting identity** — no ring-valued LGV required.

## Mathematical Content

**Weight factorization insight**: `wt(P)*wt(Q) = ((P.1+Q.1).map X).prod` — weight depends only on the total multiset. This reduces the polynomial sum identity to a counting identity:

> For every `M : Sym (Fin n) (a+b)`, `#{non-cs (a,b) splits of M} = #{all (a+1,b-1) splits of M}`

This counting identity is provable via ballot principle bijection (~100-150 lines of standard Lean combinatorics).

## Files Modified

- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` — Session 18 entry with counterexample, weight factorization insight, and correct proof path
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json` — Updated insights, nextSteps (with explicit warning not to retry non-injective approach), progressSummary

## Test plan

- [ ] Knowledge files update correctly and are consistent
- [ ] No Lean code changes (documentation/research session only)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)