### PR TITLE
Research: Hilbert20OQ01OQ03 + erdos-1018 sorry reductions (4→5 total)

### DIFF
--- a/proofs/Proofs/Hilbert20OQ01OQ03.lean
+++ b/proofs/Proofs/Hilbert20OQ01OQ03.lean
@@ -77,13 +77,9 @@ def monomial {n : ℕ} (α : MultiIndex n) (ξ : Fin n → ℝ) : ℂ :=
 theorem monomial_real {n : ℕ} (α : MultiIndex n) (ξ : Fin n → ℝ) :
     (monomial α ξ).im = 0 := by
   unfold monomial
-  rw [Complex.prod_im_eq_zero]
-  intro i _
-  simp [Complex.ofReal_im, Complex.im_pow_ofReal]
-  where
-    Complex.prod_im_eq_zero {ι : Type*} {s : Finset ι} {f : ι → ℂ}
-        (h : ∀ i ∈ s, (f i).im = 0) : (s.prod f).im = 0 := by
-      sorry -- Product of reals (embedded in ℂ) is real
+  have : Finset.univ.prod (fun i : Fin n => (ξ i : ℂ) ^ α i) =
+         ↑(Finset.univ.prod (fun i : Fin n => ξ i ^ α i)) := by norm_cast
+  rw [this, Complex.ofReal_im]
 
 /-- The complex conjugate of a monomial at real arguments equals itself. -/
 theorem conj_monomial {n : ℕ} (α : MultiIndex n) (ξ : Fin n → ℝ) :
@@ -290,26 +286,27 @@ theorem self_adjoint_solvable {n m : ℕ} (P : LinearPDO n m)
 ## Summary of Results
 
 ### Proved (0 axioms):
-1. conj_monomial: conjugate of real monomial is itself
-2. principalSymbol_adjoint: p*(x,ξ) = conj(p(x,ξ))
-3. formalAdjoint_involutive: (P*)* = P
-4. self_adjoint_of_real_coeff: real coefficients → P = P*
-5. adjoint_principal_type: P principal type → P* principal type
-6. dencker_sufficiency: condition (Ψ) → local solvability
+1. monomial_real: product of real monomials has zero imaginary part
+2. conj_monomial: conjugate of real monomial is itself
+3. principalSymbol_adjoint: p*(x,ξ) = conj(p(x,ξ))
+4. formalAdjoint_involutive: (P*)* = P
+5. self_adjoint_of_real_coeff: real coefficients → P = P*
+6. adjoint_principal_type: P principal type → P* principal type
+7. dencker_sufficiency: condition (Ψ) → local solvability
    (assembled from axioms via the energy estimate chain)
 
-### Axioms (6):
+### Axioms (7):
 - HasAPrioriEstimate: a priori Sobolev estimates (needs Sobolev spaces)
 - IsLocallySolvable: local solvability (needs distributions)
 - hormander_duality: solvability ↔ estimates for adjoint
-- BicharacteristicCurve, imSymbolAlongCurve: bicharacteristic flow
+- BicharacteristicCurve: bicharacteristic curves (needs Hamilton flow)
+- imSymbolAlongCurve: Im of symbol along bicharacteristic (needs microlocal analysis)
 - dencker_weight_exists: Dencker's weight construction
 - weight_implies_estimate: weight → a priori estimates
 
-### Sorries (3):
-- monomial_real: product of reals is real (helper lemma)
-- real_symbol_solvable: needs bridge axiom
-- self_adjoint_solvable: needs bridge axiom
+### Sorries (2):
+- real_symbol_solvable: needs bridge axiom connecting imSymbolAlongCurve to principalSymbol
+- self_adjoint_solvable: same bridge axiom issue
 
 ### Key Contribution
 Formalizes the STRUCTURAL FRAMEWORK of Dencker's proof:

--- a/research/problems/hilbert-20-oq-01/knowledge.md
+++ b/research/problems/hilbert-20-oq-01/knowledge.md
@@ -37,4 +37,20 @@ no Hamilton flow on cotangent bundles.
 
 ---
 
-*Created 2026-03-28*
+### Session 2 (2026-05-02, researcher-5)
+**Decision**: DEEP DIVE (monomial_real sorry)
+**Outcome**: -1 sorry in Hilbert20OQ01OQ03.lean (3 → 2)
+
+Proved `monomial_real` in `proofs/Proofs/Hilbert20OQ01OQ03.lean`:
+- The original proof had a broken `rw [Complex.prod_im_eq_zero]` step (with the sorry in a `where` clause helper)
+- Replaced with: cast the product to a real-valued product via `norm_cast`, then apply `Complex.ofReal_im`
+- Strategy: `Finset.univ.prod (fun i => (ξ i : ℂ) ^ α i) = ↑(Finset.univ.prod (fun i => ξ i ^ α i))` by `norm_cast`, then imaginary part of `ofReal` is 0
+
+Remaining sorries (2):
+- `real_symbol_solvable`: needs bridge axiom connecting `imSymbolAlongCurve` to `principalSymbol`
+- `self_adjoint_solvable`: same bridge axiom issue
+These 2 are not worth fixing without adding a new axiom (which would worsen the axiom count).
+
+File state: 7 axioms, 2 sorries, 9 theorems, ~320 lines.
+
+*Updated 2026-05-02*

--- a/src/data/research/problems/hilbert-20-oq-01.json
+++ b/src/data/research/problems/hilbert-20-oq-01.json
@@ -31,21 +31,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Formalized Nirenberg-Treves characterization of locally solvable operators.",
+    "progressSummary": "PROGRESS 2026-05-02: Proved monomial_real in Hilbert20OQ01OQ03.lean (sorry 3\u21922). Original proof had broken rw step; replaced with norm_cast approach. Remaining 2 sorries need bridge axiom (not worth adding). Gallery entry on main is complete.",
     "builtItems": [
       "Hilbert20LocalSolvability.lean: formalization (181 lines)",
       "Defs: LinearPDO, principalSymbol, IsPrincipalType, ConditionPsi, IsElliptic",
       "Main theorem: nirenberg_treves_characterization (iff)",
       "Corollary: elliptic_locally_solvable",
-      "Gallery entry: src/data/proofs/hilbert-20-oq-01/meta.json"
+      "Gallery entry: src/data/proofs/hilbert-20-oq-01/meta.json",
+      "Proved monomial_real in Hilbert20OQ01OQ03.lean:77 via norm_cast + ofReal_im"
     ],
     "insights": [
       "Local solvability = distribution solution exists for every smooth RHS",
-      "Condition (Ψ): Im(p_m) does not change sign from - to + along bicharacteristics of Re(p_m)",
-      "Nirenberg-Treves conjecture (1963, proved Dencker 2006): (Ψ) iff locally solvable for principal type",
-      "Elliptic operators satisfy (Ψ) vacuously - principal symbol never vanishes",
-      "Operators with real principal symbol satisfy (Ψ) trivially - Im = 0",
-      "Full proof requires microlocal analysis not in Mathlib"
+      "Condition (\u03a8): Im(p_m) does not change sign from - to + along bicharacteristics of Re(p_m)",
+      "Nirenberg-Treves conjecture (1963, proved Dencker 2006): (\u03a8) iff locally solvable for principal type",
+      "Elliptic operators satisfy (\u03a8) vacuously - principal symbol never vanishes",
+      "Operators with real principal symbol satisfy (\u03a8) trivially - Im = 0",
+      "Full proof requires microlocal analysis not in Mathlib",
+      "monomial_real proof: cast product of complex powers to ofReal product via norm_cast, then ofReal_im gives im=0. The original rw approach was structurally broken."
     ],
     "mathlibGaps": [
       "No distribution theory in Mathlib",
@@ -72,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T14:26:43.165Z",
-  "lastUpdate": "2026-04-27T00:00:00.000Z",
+  "lastUpdate": "2026-05-02T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/Hilbert20BoundaryValue.lean",
@@ -99,11 +101,11 @@
     {
       "path": "Proofs/Hilbert20OQ01OQ03.lean",
       "filename": "Hilbert20OQ01OQ03.lean",
-      "lineCount": 326,
+      "lineCount": 321,
       "theoremCount": 9,
       "axiomCount": 7,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert20OQ01OQ03.lean"
     },


### PR DESCRIPTION
## Summary

Two research sessions eliminating sorries from existing Lean proof files.

### Fix 1: hilbert-20-oq-01 (Hilbert20OQ01OQ03.lean, sorry 3→2)

Proved `monomial_real` — the imaginary part of a monomial evaluated at real arguments is 0.

The original proof had a structurally broken `rw [Complex.prod_im_eq_zero]` step with a sorry in a `where` clause helper. Replaced with a clean two-step proof:
1. `norm_cast`: `∏(ξ i : ℂ)^αᵢ = ↑(∏ ξ i^αᵢ)` — cast the product of complex powers to a real product
2. `Complex.ofReal_im`: imaginary part of `ofReal` is 0

### Fix 2: erdos-1018-oq-04-incomplete-01 (Erdos1018OQ04Incomplete01.lean, sorry 4→3)

Proved `r2_implies_main_r2` — the r=2 Kostochka-Pyber theorem implies the r=2 case of the main density conjecture.

The sorry comment said "Since isEmbeddable is a sorry, we can't prove this directly" — this was **outdated**. The parent file's `isEmbeddable` had already been fixed to a concrete definition with identical body to `isEmbeddableConc`. Proof uses definitional equality:

```lean
intro hkp ε hε
obtain ⟨C, N, hCN⟩ := hkp ε hε
refine ⟨C, N, fun W _ _ hN H hD => ?_⟩
obtain ⟨S, hS, hne⟩ := hCN W hN H hD
exact ⟨S, hS, hne⟩  -- definitional equality: isEmbeddableConc = isEmbeddable
```

Key: `criticalDim 2 = 2 * (2-1) = 2` reduces definitionally, and `hasSmallNonEmbeddable`/`isNonEmbeddable` unfold cleanly.

## Files Modified

- `proofs/Proofs/Hilbert20OQ01OQ03.lean` — monomial_real fixed, summary updated
- `proofs/Proofs/Erdos1018OQ04Incomplete01.lean` — r2_implies_main_r2 proved, summary updated
- `research/problems/hilbert-20-oq-01/knowledge.md` — session notes
- `research/problems/erdos-1018-oq-04-incomplete-01/knowledge.md` — session notes (new)
- `src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json` — sorries 4→3
- `src/data/research/problems/hilbert-20-oq-01.json` — updated
- `src/data/research/problems/erdos-1018-oq-04-incomplete-01.json` — updated

## Status

**Outcome**: progress (2 sorries eliminated across 2 files)
**Remaining**: Hilbert20OQ01OQ03 has 2 sorries needing bridge axiom; Erdos1018 incomplete file has 3 sorries needing convex hull geometry + Euler's formula

🤖 Generated by researcher-5