### PR TITLE
audit(hilbert-20-oq-01-oq-03): correct sorry count 3→2 and lineCount

### DIFF
--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/Hilbert20OQ01OQ03.lean",
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 7,
     "theoremCount": 9,
     "mathlibDependencies": [
@@ -38,7 +38,7 @@
       "Dencker sufficiency theorem assembled from weight->estimate->solvability chain",
       "Adjoint preserves principal type property"
     ],
-    "lineCount": 325,
+    "lineCount": 322,
     "assumptions": [
       "HasAPrioriEstimate: Sobolev a priori estimates (needs Sobolev spaces)",
       "IsLocallySolvable: local solvability (needs distribution theory)",
@@ -125,12 +125,12 @@
   ],
   "leanFile": {
     "namespace": "Hilbert20OQ01OQ03",
-    "lineCount": 325,
+    "lineCount": 322,
     "axiomCount": 7,
     "theoremCount": 9,
     "definitionCount": 7,
     "path": "Proofs/Hilbert20OQ01OQ03.lean",
-    "sorries": 3
+    "sorries": 2
   },
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

Audit of `hilbert-20-oq-01-oq-03` (Dencker's Energy Estimate Approach) found `meta.json` overcounting sorries.

- `meta.sorries`, `leanFile.sorries`, and top-level `sorries` all claim **3**, but the Lean source contains **2** `sorry` occurrences:
  - `real_symbol_solvable` (line 267)
  - `self_adjoint_solvable` (line 279)
- The file's own summary docstring at line 307 explicitly states "### Sorries (2):", so the meta is the side that drifted.
- `lineCount` was 325 but the file is 322 lines.

## Verified counts

| Field | meta.json (was) | Actual | Fixed |
|-------|-----------------|--------|-------|
| sorries | 3 | 2 | 2 |
| lineCount | 325 | 322 | 322 |
| axiomCount | 7 | 7 | — |
| theoremCount | 9 | 9 | — |
| definitionCount | 7 | 7 (6 def + 1 abbrev) | — |

No other discrepancies — the 7 axioms, 9 theorems, and structural-framework architecture all match. Status `axiomatized` / badge `axiom` remain correct.

## Test plan
- [x] JSON validates with `python3 -m json.tool`
- [x] Sorry count verified by stripping comments before counting
- [x] Lean file's own summary section corroborates the corrected value

🤖 Generated with [Claude Code](https://claude.com/claude-code)