### PR TITLE
audit-tracker: hilbert-20-oq-01-oq-03 issues-fixed (sorry 3→2)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11769,10 +11769,10 @@
       "result": "clean"
     },
     "hilbert-20-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:26Z",
-      "result": "clean"
+      "lastAudited": "2026-05-03T00:00:00Z",
+      "result": "issues-fixed"
     },
     "hilbert-21": {
       "auditCount": 6,


### PR DESCRIPTION
## Summary

Updates `audit-tracker.json` for `hilbert-20-oq-01-oq-03` after audit:
- `auditCount`: 1 → 2
- `lastAudited`: 2026-04-23 → 2026-05-03
- `result`: `clean` → `issues-fixed`

Audit findings (sorry count 3→2 in meta.json) are addressed in PR #14901.

Single-entry patch with `ensure_ascii=False` (re-applied manually to avoid the `claim-target.sh complete` unicode-escape pollution bug noted in prior audit reports).

## Test plan
- [x] JSON re-validates after edit
- [x] Diff is exactly 3 lines (auditCount, lastAudited, result) — no `→`/`—` pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)