### PR TITLE
audit(dirichlets-theorem-oq-02): re-verify clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2459,9 +2459,9 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-05-02T22:08:36Z",
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-01": {


### PR DESCRIPTION
## Audit summary

**Target**: dirichlets-theorem-oq-02 — Infinitely Many Primes ≡ 3 (mod 4)
**Result**: clean (re-audit, count 4→5)
**Tier**: A — fully formalized elementary theorem

## Verified facts

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| sorries | 0 | 0 |
| axiomCount | 0 | 0 |
| lineCount | 101 | 101 |
| theoremCount | 3 | 3 |
| status | verified | matches |
| badge | original | matches |

`originalContributions` (3 theorems) all present and proved:
- `exists_prime_factor_three_mod_four` — strong induction on n
- `infinite_primes_three_mod_four` — N = 4·(n+1)! − 1 construction
- `exists_prime_three_mod_four` — concrete witness p=3

## Mathlib usage check

The 3 listed `mathlibDependencies` (`Nat.exists_prime_and_dvd`, `Nat.Prime.dvd_factorial`, `Set.infinite_iff_exists_gt`) are basic supporting lemmas. The Euclid-style argument is constructed from scratch in this file — not a Mathlib wrapper. `original` badge is correct.

## Tracker update

Only the dirichlets-theorem-oq-02 entry changed (`auditCount: 4 → 5`, `lastAudited` timestamp). The unicode-escaping bug in claim-target.sh `complete` produced ~158 lines of `→`/`—` noise; I reverted that and re-applied the legitimate 2-line change manually (per feedback memory `feedback_auditor_claim_target_unicode_bug.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)