### PR TITLE
audit: dirichlets-theorem-oq-02 + derangements-oq-02 (clean re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2331,9 +2331,9 @@
       "result": "clean"
     },
     "derangements-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-05-02T22:25:00Z",
       "result": "clean"
     },
     "derangements-oq-02-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2459,9 +2459,9 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-05-02T22:14:43Z",
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-01": {


### PR DESCRIPTION
## Audit summary

Re-verifies two gallery entries against their Lean sources (both last audited 2026-04-03).

### dirichlets-theorem-oq-02 — Infinitely Many Primes ≡ 3 (mod 4)

| Field | Claimed | Actual |
|-------|---------|--------|
| lineCount | 101 | 101 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| theoremCount | 3 | 3 ✓ |
| True stubs | n/a | none ✓ |

Tier A original Euclid-style construction; Mathlib deps are correctly listed building blocks (`Nat.exists_prime_and_dvd`, `Nat.Prime.dvd_factorial`, `Set.infinite_iff_exists_gt`).

### derangements-oq-02 — Partial Derangements S(n,k) = C(n,k)·D(n-k)

| Field | Claimed | Actual |
|-------|---------|--------|
| lineCount | 357 | 357 ✓ |
| sorries | 0 | 0 ✓ (in-file docstring at line 340 says "round trips are sorry" but actual code has zero sorries) |
| axiomCount | 0 | 0 ✓ |
| theoremCount | 10 | 10 ✓ |
| definitionCount | 1 | 1 ✓ (noncomputable def) |
| True stubs | n/a | none ✓ |

Tier A original bijective combinatorial proof; mathlibDependencies correctly enumerate the Permutation/Derangement API used as scaffolding.

---
Discovered during gallery integrity audit loop.