### PR TITLE
research(binary-gcd-oq-03-oq-02): perturbation infrastructure (Step 3)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -618,7 +618,120 @@ theorem entry_bound_of_odd {a₀ b₀ ahat' bhat' : ℤ} {M : CofactorMatrix}
                mul_nonneg (by linarith : (0:ℤ) ≤ ahat') hβ]
 
 -- ═══════════════════════════════════════════════════════════════
--- PART VII: SIZE REDUCTION (deferred — open mathematical content)
+-- PART VII: PERTURBATION INFRASTRUCTURE (Step 3 building blocks)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Step 3 infrastructure
+
+The HGCD algorithm computes `M₁ = hgcdMatrix fuel (a >> s) (b >> s)` using
+the top-half truncation of `(a, b)`, then applies `M₁` to the full-precision
+`(a, b)`. Step 3 bounds the discrepancy introduced by this truncation.
+
+Write `aHi = a / 2^s`, `bHi = b / 2^s`, `ea = a % 2^s`, `eb = b % 2^s`, so
+that `a = aHi * 2^s + ea` and `b = bHi * 2^s + eb` with `0 ≤ ea, eb < 2^s`.
+
+Linearity of `apply` gives:
+  `M.apply a b = M.apply (aHi*2^s) (bHi*2^s) + M.apply ea eb`
+           `= 2^s · M.apply aHi bHi + M.apply ea eb`.
+
+The first term is bounded by `2^s · max(aHi, bHi)` from residue monotonicity
+(Step 2a applied to the top-half subproblem).  The second (error) term is:
+  `|M.α · ea + M.β · eb| ≤ (|M.α| + |M.β|) · 2^s`
+                        `≤ 2 · max(aHi, bHi) · 2^s`
+using the entry bounds from Step 2b (`entry_bound_of_even/odd`).
+
+The lemmas in this section establish the algebraic pieces.  The
+inductive bitsize argument needed to close `hgcdMatrix_size_reduction`
+is deferred (Step 4). -/
+
+/-- `CofactorMatrix.apply` distributes over addition of inputs.
+    This is pure ring algebra: apply(a₁ + a₂, b₁ + b₂) splits into
+    apply(a₁, b₁) + apply(a₂, b₂) component-wise. -/
+theorem cofactor_apply_add (M : CofactorMatrix) (a₁ a₂ b₁ b₂ : ℤ) :
+    (M.apply (a₁ + a₂) (b₁ + b₂)).1 = (M.apply a₁ b₁).1 + (M.apply a₂ b₂).1 ∧
+    (M.apply (a₁ + a₂) (b₁ + b₂)).2 = (M.apply a₁ b₁).2 + (M.apply a₂ b₂).2 := by
+  simp only [CofactorMatrix.apply]
+  exact ⟨by ring, by ring⟩
+
+/-- `CofactorMatrix.apply` commutes with scalar multiplication.
+    For any scalar `k : ℤ`, `M.apply (k · a) (k · b) = k · M.apply a b`
+    component-wise. -/
+theorem cofactor_apply_smul (M : CofactorMatrix) (k a b : ℤ) :
+    (M.apply (k * a) (k * b)).1 = k * (M.apply a b).1 ∧
+    (M.apply (k * a) (k * b)).2 = k * (M.apply a b).2 := by
+  simp only [CofactorMatrix.apply]
+  exact ⟨by ring, by ring⟩
+
+/-- The full-precision apply equals `2^s` times the top-half apply, plus the
+    error from the low-bits `(ea, eb)`.
+
+    Concretely: `a = aHi * 2^s + ea` and `b = bHi * 2^s + eb`, so by
+    `cofactor_apply_add` and `cofactor_apply_smul`:
+      `(M.apply a b).1 = 2^s · (M.apply aHi bHi).1 + (M.apply ea eb).1`.
+    This is the key decomposition for the perturbation argument. -/
+theorem cofactor_apply_shift_decomp (M : CofactorMatrix) (aHi bHi ea eb : ℤ) (s : ℕ) :
+    let pow2s : ℤ := 2 ^ s
+    (M.apply (aHi * pow2s + ea) (bHi * pow2s + eb)).1 =
+      pow2s * (M.apply aHi bHi).1 + (M.apply ea eb).1 ∧
+    (M.apply (aHi * pow2s + ea) (bHi * pow2s + eb)).2 =
+      pow2s * (M.apply aHi bHi).2 + (M.apply ea eb).2 := by
+  simp only [CofactorMatrix.apply]
+  exact ⟨by ring, by ring⟩
+
+/-- Triangle bound: |M.α · ea + M.β · eb| ≤ |M.α| · |ea| + |M.β| · |eb|.
+
+    This is Int.natAbs triangle inequality for the first component of
+    `M.apply ea eb`. Used to bound the error term in Step 3 given
+    entry bounds on M from Step 2b. -/
+theorem cofactor_apply_natAbs_le (M : CofactorMatrix) (ea eb : ℤ) :
+    (M.apply ea eb).1.natAbs ≤ M.α.natAbs * ea.natAbs + M.β.natAbs * eb.natAbs ∧
+    (M.apply ea eb).2.natAbs ≤ M.γ.natAbs * ea.natAbs + M.δ.natAbs * eb.natAbs := by
+  simp only [CofactorMatrix.apply]
+  constructor
+  · calc (M.α * ea + M.β * eb).natAbs
+        ≤ (M.α * ea).natAbs + (M.β * eb).natAbs := Int.natAbs_add_le _ _
+      _ = M.α.natAbs * ea.natAbs + M.β.natAbs * eb.natAbs := by
+            simp [Int.natAbs_mul]
+  · calc (M.γ * ea + M.δ * eb).natAbs
+        ≤ (M.γ * ea).natAbs + (M.δ * eb).natAbs := Int.natAbs_add_le _ _
+      _ = M.γ.natAbs * ea.natAbs + M.δ.natAbs * eb.natAbs := by
+            simp [Int.natAbs_mul]
+
+/-- Error bound for the first component of `M.apply ea eb` when entries are
+    bounded by `C` and inputs are bounded by `B` (all in ℕ).
+
+    From `cofactor_apply_natAbs_le` with `|M.α|, |M.β| ≤ C` and
+    `|ea|, |eb| ≤ B`, the first component is at most `2 · C · B`. -/
+theorem cofactor_apply_err_bound (M : CofactorMatrix) (ea eb : ℤ) (C B : ℕ)
+    (hα : M.α.natAbs ≤ C) (hβ : M.β.natAbs ≤ C)
+    (hea : ea.natAbs ≤ B) (heb : eb.natAbs ≤ B) :
+    (M.apply ea eb).1.natAbs ≤ 2 * C * B := by
+  have ⟨h, _⟩ := cofactor_apply_natAbs_le M ea eb
+  calc (M.apply ea eb).1.natAbs
+      ≤ M.α.natAbs * ea.natAbs + M.β.natAbs * eb.natAbs := h
+    _ ≤ C * B + C * B := by
+          apply Nat.add_le_add
+          · exact Nat.mul_le_mul hα hea
+          · exact Nat.mul_le_mul hβ heb
+    _ = 2 * C * B := by ring
+
+/-- Error bound for the second component of `M.apply ea eb`. Symmetric to
+    `cofactor_apply_err_bound` using `|M.γ|` and `|M.δ|`. -/
+theorem cofactor_apply_err_bound_snd (M : CofactorMatrix) (ea eb : ℤ) (C B : ℕ)
+    (hγ : M.γ.natAbs ≤ C) (hδ : M.δ.natAbs ≤ C)
+    (hea : ea.natAbs ≤ B) (heb : eb.natAbs ≤ B) :
+    (M.apply ea eb).2.natAbs ≤ 2 * C * B := by
+  have ⟨_, h⟩ := cofactor_apply_natAbs_le M ea eb
+  calc (M.apply ea eb).2.natAbs
+      ≤ M.γ.natAbs * ea.natAbs + M.δ.natAbs * eb.natAbs := h
+    _ ≤ C * B + C * B := by
+          apply Nat.add_le_add
+          · exact Nat.mul_le_mul hγ hea
+          · exact Nat.mul_le_mul hδ heb
+    _ = 2 * C * B := by ring
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART VIII: SIZE REDUCTION (deferred — open mathematical content)
 -- ═══════════════════════════════════════════════════════════════
 
 /-- The HGCD size-reduction lemma: applying `hgcdMatrix` to `(a, b)`
@@ -699,11 +812,22 @@ theorem hgcdMatrix_size_reduction :
    in absolute value by the initial inputs a₀ and b₀. Proved using
    Cramer + sign pattern. This is Step 2b.
 
+9. **Perturbation infrastructure** (PART VII, Step 3 building blocks):
+   - `cofactor_apply_add`: `apply` distributes over addition of inputs.
+   - `cofactor_apply_smul`: `apply` commutes with scalar multiplication.
+   - `cofactor_apply_shift_decomp`: full-precision `apply(aHi·2^s + ea, bHi·2^s + eb)`
+     decomposes as `2^s · apply(aHi, bHi) + apply(ea, eb)`.
+   - `cofactor_apply_natAbs_le`: triangle bound for `natAbs` of both components.
+   - `cofactor_apply_err_bound` / `cofactor_apply_err_bound_snd`: given
+     entry bounds `|M.α|, |M.β| ≤ C` and input bounds `|ea|, |eb| ≤ B`,
+     the error component is at most `2·C·B`. This is the quantitative error
+     bound combining Step 2b entry bounds with the low-bit size.
+
 **Remaining for size reduction:**
-- Step 3: perturbation bound between full-precision (a, b) and
-  top-half-truncated (aHi·2^s, bHi·2^s) after applying M.
-- Step 4: compose 2a + 2b + 3 to close `hgcdMatrix_size_reduction`
-  with explicit bitsize constants.
+- Step 4 (inductive): prove `hgcdMatrix_size_reduction` by fuel induction,
+  combining Steps 2a + 2b + Step 3 error bound with a bitsize argument.
+  Requires showing that `hgcdMatrix fuel aHi bHi` reduces `max(aHi, bHi)`
+  by at least half — which is the recursive core of the HGCD analysis.
 
 **Out of scope (deferred):**
 - Bit-complexity bound O(M(n)·log n): requires Mathlib infrastructure

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -373,3 +373,42 @@ The TIGHT bound requires max_entry ≤ 2^(N/4) — which comes from knowing the 
 1. **Restate `hgcdMatrix_size_reduction`** with a joint statement: `max output ≤ 2^(N/2 + c) ∧ entry_bound ≤ 2^(N/2)`. ~50 lines setup.
 2. **Joint induction proof** by strong induction on `Nat.log 2 (max a b)`. ~150-200 lines.
 3. This is a dedicated session of ~4-6 hours.
+
+## Session 2026-05-03 (Session 5) — Perturbation Infrastructure (Step 3)
+
+**Mode**: REVISIT
+**Outcome**: progress (Step 3 infrastructure added)
+
+### What I Did
+
+- Verified that Sessions 3 and 4 work (Steps 1, 2a, 2b) is already merged into main (PRs #14522 and #14881).
+- Added PART VII (~114 lines) to `BinaryGcdOQ03OQ02.lean` with 6 theorems forming the perturbation infrastructure for Step 3:
+
+  1. `cofactor_apply_add`: `apply` distributes over addition of inputs (ring).
+  2. `cofactor_apply_smul`: `apply` commutes with scalar multiplication (ring).
+  3. `cofactor_apply_shift_decomp`: Decomposes `apply(aHi·2^s + ea, bHi·2^s + eb)` as `2^s · apply(aHi, bHi) + apply(ea, eb)`. This is the key algebraic identity for the perturbation argument.
+  4. `cofactor_apply_natAbs_le`: Triangle bound `|M.apply(ea, eb).1| ≤ |M.α|·|ea| + |M.β|·|eb|` using `Int.natAbs_add_le` + `Int.natAbs_mul`.
+  5. `cofactor_apply_err_bound`: Given `|M.α|, |M.β| ≤ C` and `|ea|, |eb| ≤ B`, then `|apply(ea, eb).1| ≤ 2·C·B`.
+  6. `cofactor_apply_err_bound_snd`: Same for the second component using `|M.γ|` and `|M.δ|`.
+
+- 0 new sorries, 0 new axioms.
+
+### Key Findings
+
+- Steps 1, 2a, 2b all complete in main. The size-reduction proof structure is clear:
+  - `cofactor_apply_shift_decomp` gives the algebraic split: `apply(a, b) = 2^s·apply(aHi, bHi) + apply(ea, eb)`.
+  - `cofactor_apply_err_bound` bounds the error term using Step 2b entry bounds.
+  - The MISSING piece (Step 4) is an inductive proof that `hgcdMatrix fuel aHi bHi` reduces `max(aHi, bHi)` by half — this requires induction on bitsize and is inherently recursive.
+
+- The PART VII placeholder `hgcdMatrix_size_reduction := True` is renamed PART VIII.
+
+### Files Modified
+
+- `proofs/Proofs/BinaryGcdOQ03OQ02.lean` — +124 lines (PART VII: 6 theorems + renamed PART VIII, updated Summary).
+
+### Next Steps
+
+1. **Step 4 (inductive)**: Prove `hgcdMatrix` reduces bitsize by half. Requires fuel-based induction with a strengthened IH tracking `Nat.log 2 (max output) ≤ Nat.log 2 (max input) / 2`. May need a `bitsize_reduction_for_lehmerCofactors` lemma first (that lehmerCofactors on (aHi, bHi) reduces max by at least 1 step).
+
+2. **Alternative step 4**: Use the WEAK size-reduction: show that if `hgcdMatrix fuel aHi bHi` is NOT the identity, then `max(output) < max(input)`. This is weaker than "by half" but shows strict decrease, which might be enough for termination-style arguments.
+

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -1,158 +1,189 @@
 {
-    "slug": "binary-gcd-oq-03-oq-02",
-    "title": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log...",
+  "slug": "binary-gcd-oq-03-oq-02",
+  "title": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log...",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log n) bit complexity through recursive cofactor matrix computation on the top half of the bits?.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
     "phase": "ACT",
-    "status": "active",
-    "tier": "A",
-    "path": "full",
-    "problemStatement": {
-        "formal": "\\text{(formal statement to be added)}",
-        "plain": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log n) bit complexity through recursive cofactor matrix computation on the top half of the bits?.",
-        "whyMatters": []
-    },
-    "knownResults": {
-        "proven": [],
-        "open": [],
-        "goal": ""
-    },
-    "currentState": {
-        "phase": "ACT",
-        "since": "2026-05-01T00:00:00.000Z",
-        "iteration": 5,
-        "focus": "Step 2b complete (Session 4): Cramer identity + sign pattern + entry bounds in PART VI. Next: Session 5 Step 3 perturbation bound.",
-        "blockers": [
-            "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication. Genuinely blocked; not a blocker on size-reduction work."
-        ],
-        "nextAction": "Session 4: Cramer-inversion entry bound. From the row-vector invariant (a₀, b₀) · M = (ahat', bhat') and det M = ±1, invert to (a₀, b₀) = (ahat', bhat') · M⁻¹ and bound entries of M.",
-        "attemptCounts": {
-            "total": 4,
-            "currentApproach": 1,
-            "approachesTried": 2
-        }
-    },
-    "knowledge": {
-        "progressSummary": "Session 4 (2026-05-02): PROGRESS — added PART VI to BinaryGcdOQ03OQ02.lean (+215 lines): row_vec_cramer (Cramer identity), EvenPattern/OddPattern predicates, lehmerInnerStep_even_to_odd + odd_to_even (sign alternation), lehmerCofactors_has_pattern (always EvenPattern or OddPattern), entry_bound_of_even + entry_bound_of_odd (entries ≤ initial inputs when residues ≥ 1). 0 new sorries, 0 new axioms. File: 713 lines. Step 2b complete.",
-        "builtItems": [
-            "BinaryGcdOQ03OQ02.lean: hgcdMatrix def — fuel-indexed recursive HGCD (Schönhage). Threshold-based bottoming via lehmerCofactors; otherwise top-half-shift recursion + apply + bottom-half recursion + matrix product.",
-            "BinaryGcdOQ03OQ02.lean: cofactor_mul_apply — proves CofactorMatrix.mul corresponds to composition of CofactorMatrix.apply. Algebraic kernel justifying the M₂.mul M₁ return.",
-            "BinaryGcdOQ03OQ02.lean: hgcdMatrix_det_unit — induction on fuel proving every HGCD output has det ±1. Uses lehmerCofactors_det_unit at the leaf and CofactorMatrix.det_mul for the recursive case.",
-            "BinaryGcdOQ03OQ02.lean: hgcdMatrix_preserves_gcd — corollary of cofactor_apply_gcd given det ±1. Operational correctness of the recursive HGCD.",
-            "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_invariant — row-vector relation (a₀, b₀) · M = (ahat, bhat) is preserved by one Lehmer inner step. Proved by unfolding lehmerInnerStep + linarith with Nat.div_add_mod.",
-            "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant — multi-step (existential) version, by induction on fuel applying the per-step lemma.",
-            "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_eq — specialisation to M = id and ghost pair = input pair (Step 1 final form).",
-            "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_residue_le — per-step bound bhat' < bhat ∧ ahat' = bhat. omega after splitting the lehmerInnerStep ifs.",
-            "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_max_le — corollary, max ahat' bhat' ≤ max ahat bhat.",
-            "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant_le — strengthens the multi-step invariant with the residue bound carried through the induction by transitivity.",
-            "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_le — specialisation to M = id, the residue-side bound for size reduction (Step 2a final form).",
-            "BinaryGcdOQ03OQ02.lean PART VI: row_vec_cramer — Cramer/Bezout identity: a0*det = ahat*M.delta - bhat*M.gamma. Proved by linear_combination.",
-            "BinaryGcdOQ03OQ02.lean PART VI: EvenPattern / OddPattern — sign predicates for Lehmer cofactor entries.",
-            "BinaryGcdOQ03OQ02.lean PART VI: lehmerInnerStep_even_to_odd + odd_to_even — one step flips sign pattern. nlinarith.",
-            "BinaryGcdOQ03OQ02.lean PART VI: lehmerCofactors_has_pattern — induction: always EvenPattern or OddPattern from id.",
-            "BinaryGcdOQ03OQ02.lean PART VI: entry_bound_of_even + entry_bound_of_odd — entries bounded by initial inputs when residues >=1. Combines Cramer + sign pattern."
-        ],
-        "insights": [
-            "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
-            "The original question conflates two distinct claims: (A) HGCD algorithmic correctness (tractable, ~300-500 lines) and (B) O(M(n) log n) bit complexity (blocked on multiple Mathlib gaps).",
-            "Mathlib has no half-GCD, Schoenhage, Karatsuba, or any fast multiplication; grep against Mathlib confirmed (2026-04-28). Mathlib Computability has Turing/primrec but no bit-complexity model for arithmetic.",
-            "The complexity bound O(M(n) log n) is currently unfalsifiable in Lean: no model in which to state \"M(n) bit operations\". Proving (B) requires upstreaming a bit-complexity framework + fast multiplication first (multi-thousand-line project).",
-            "The single hardest piece on the correctness side is termination of the HGCD recursion: need bitsize(max a b) strict decrease after applying the recursively-computed matrix, which requires showing the matrix accumulated >=1 Euclidean step.",
-            "Recommendation: split the question. Pursue (A) HGCD correctness as a self-contained verification; defer (B) until a complexity model lands in Mathlib or as a separate gallery initiative.",
-            "Operational correctness of Schönhage HGCD reduces entirely to the matrix-determinant invariant already proved for Lehmer (BinaryGcdOQ03.lean). The recursion structure adds no new GCD-preservation obligation; it only redistributes work for asymptotic gain. So Path A (correctness only) requires zero new mathematical content beyond the composition law M.mul ↦ apply ∘ apply.",
-            "Fuel-indexed totality avoids the size-reduction proof obligation in the def. Termination via fuel decreasing; correctness via induction on fuel. The hard math (size reduction) is decoupled from the correctness layer.",
-            "Convention dichotomy (Session 3): the column-action CofactorMatrix.apply (M·(a,b)ᵀ) is the right operator for det-based theorems (cofactor_apply_gcd, hgcdMatrix_preserves_gcd) but does NOT track the algorithm's state when the cofactor is updated by right-multiplication M' = M.mul ⟨0, 1, 1, -q⟩. The state-tracking invariant is instead the row-vector relation (a₀, b₀) · M = (current pair). This is preserved by lehmerInnerStep and is what the size-reduction lemma must use.",
-            "Residue monotonicity (Session 3) is self-contained: max ahat' bhat' ≤ max ahat bhat follows directly from Nat.mod_lt with no matrix-vector machinery. It composes through lehmerCofactors by transitivity.",
-            "Step 2b plan (Session 3 → Session 4): from the row-vector invariant (a₀, b₀) · M = (ahat', bhat') and det M = ±1, invert to (a₀, b₀) = (ahat', bhat') · M⁻¹ where M⁻¹.α = δ, M⁻¹.β = -β, M⁻¹.γ = -γ, M⁻¹.δ = α (up to sign of det). Bound each entry of M⁻¹ by max a₀ b₀ / max ahat' bhat' (using residue monotonicity for the denominator); since |det M| = 1, entries of M are bounded by entries of M⁻¹.",
-            "Sign alternation converts the Cramer identity into an entry BOUND (Session 4). Without sign info, the Bezout formula does not bound individual entries. With EvenPattern, all terms separate and bound M.delta <= a0 when ahat' >= 1.",
-            "Entry bound hypothesis 1 <= ahat': requires algorithm to still be running. For HGCD, always satisfied: top-half cofactor applied to full-precision inputs strictly larger than top-half residues."
-        ],
-        "mathlibGaps": [
-            "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
-            "Fast multiplication algorithms: Mathlib has no Karatsuba, Toom-Cook, or Schoenhage-Strassen FFT-based multiplication (verified 2026-04-28).",
-            "Bit-complexity model for arithmetic operations: Mathlib has Turing/primrec/partrec but nothing that lets you state \"M(n) bit operations to multiply n-bit integers\". Required to formulate the O(M(n) log n) complexity claim.",
-            "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
-        ],
-        "nextSteps": [
-            "Session 5 (Step 3): Perturbation bound. From a = aHi*2^s + a_lo and entries <= max(aHi,bHi), bound |M*(a_lo, b_lo)|. ~50-80 lines.",
-            "Session 6 (Step 4): Close hgcdMatrix_size_reduction with explicit constants by composing Steps 2a+2b+3.",
-            "(Optional) Wire hgcdMatrix into a recursive GCD function. ~50-100 lines.",
-            "(Deferred) O(M(n)log n) complexity: blocked on Mathlib infrastructure."
-        ]
-    },
-    "tags": [
-        "challenging",
-        "extension",
-        "gallery-extracted"
+    "since": "2026-05-01T00:00:00.000Z",
+    "iteration": 5,
+    "focus": "Step 2b complete (Session 4): Cramer identity + sign pattern + entry bounds in PART VI. Next: Session 5 Step 3 perturbation bound.",
+    "blockers": [
+      "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication. Genuinely blocked; not a blocker on size-reduction work."
     ],
-    "relatedProofs": [
-        "binary-gcd",
-        "binary-gcd-oq-01",
-        "binary-gcd-oq-01-oq-04",
-        "binary-gcd-oq-03"
+    "nextAction": "Session 4: Cramer-inversion entry bound. From the row-vector invariant (a₀, b₀) · M = (ahat', bhat') and det M = ±1, invert to (a₀, b₀) = (ahat', bhat') · M⁻¹ and bound entries of M.",
+    "attemptCounts": {
+      "total": 4,
+      "currentApproach": 1,
+      "approachesTried": 2
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Session 5 (2026-05-03): PROGRESS — added PART VII with 6 perturbation-infrastructure theorems (Step 3 algebraic pieces). 0 new sorries, 0 new axioms. The algebraic decomposition apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb) is proved, plus the error bound |apply(ea,eb)| ≤ 2·C·B when entries ≤ C and low-bits ≤ B. Remaining: inductive bitsize argument (Step 4).",
+    "builtItems": [
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix def — fuel-indexed recursive HGCD (Schönhage). Threshold-based bottoming via lehmerCofactors; otherwise top-half-shift recursion + apply + bottom-half recursion + matrix product.",
+      "BinaryGcdOQ03OQ02.lean: cofactor_mul_apply — proves CofactorMatrix.mul corresponds to composition of CofactorMatrix.apply. Algebraic kernel justifying the M₂.mul M₁ return.",
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix_det_unit — induction on fuel proving every HGCD output has det ±1. Uses lehmerCofactors_det_unit at the leaf and CofactorMatrix.det_mul for the recursive case.",
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix_preserves_gcd — corollary of cofactor_apply_gcd given det ±1. Operational correctness of the recursive HGCD.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_invariant — row-vector relation (a₀, b₀) · M = (ahat, bhat) is preserved by one Lehmer inner step. Proved by unfolding lehmerInnerStep + linarith with Nat.div_add_mod.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant — multi-step (existential) version, by induction on fuel applying the per-step lemma.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_eq — specialisation to M = id and ghost pair = input pair (Step 1 final form).",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_residue_le — per-step bound bhat' < bhat ∧ ahat' = bhat. omega after splitting the lehmerInnerStep ifs.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_max_le — corollary, max ahat' bhat' ≤ max ahat bhat.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant_le — strengthens the multi-step invariant with the residue bound carried through the induction by transitivity.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_le — specialisation to M = id, the residue-side bound for size reduction (Step 2a final form).",
+      "BinaryGcdOQ03OQ02.lean PART VI: row_vec_cramer — Cramer/Bezout identity: a0*det = ahat*M.delta - bhat*M.gamma. Proved by linear_combination.",
+      "BinaryGcdOQ03OQ02.lean PART VI: EvenPattern / OddPattern — sign predicates for Lehmer cofactor entries.",
+      "BinaryGcdOQ03OQ02.lean PART VI: lehmerInnerStep_even_to_odd + odd_to_even — one step flips sign pattern. nlinarith.",
+      "BinaryGcdOQ03OQ02.lean PART VI: lehmerCofactors_has_pattern — induction: always EvenPattern or OddPattern from id.",
+      "BinaryGcdOQ03OQ02.lean PART VI: entry_bound_of_even + entry_bound_of_odd — entries bounded by initial inputs when residues >=1. Combines Cramer + sign pattern.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_add — apply distributes over addition of inputs (ring lemma).",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_smul — apply commutes with scalar multiplication (ring lemma).",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_shift_decomp — apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb). Key algebraic identity for perturbation argument.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_natAbs_le — triangle bound |apply(ea,eb).1| ≤ |M.α|·|ea| + |M.β|·|eb| via Int.natAbs_add_le + Int.natAbs_mul.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound — given |M.α|,|M.β| ≤ C and |ea|,|eb| ≤ B, error component ≤ 2·C·B.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound_snd — same bound for second component using |M.γ|,|M.δ|."
     ],
-    "references": {
-        "papers": [],
-        "urls": [],
-        "mathlib": []
-    },
-    "started": "2026-04-26T08:56:57.650Z",
-    "lastUpdate": "2026-05-02T00:00:00.000Z",
-    "significance": 7,
-    "tractability": 5,
-    "leanFiles": [
-        {
-            "path": "Proofs/BinaryGcdOQ01.lean",
-            "filename": "BinaryGcdOQ01.lean",
-            "lineCount": 216,
-            "theoremCount": 2,
-            "axiomCount": 0,
-            "defCount": 2,
-            "sorryCount": 0,
-            "isAristotle": false,
-            "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
-        },
-        {
-            "path": "Proofs/BinaryGcdOQ01OQ03.lean",
-            "filename": "BinaryGcdOQ01OQ03.lean",
-            "lineCount": 226,
-            "theoremCount": 5,
-            "axiomCount": 0,
-            "defCount": 0,
-            "sorryCount": 0,
-            "isAristotle": false,
-            "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ03.lean"
-        },
-        {
-            "path": "Proofs/BinaryGcdOQ01OQ04.lean",
-            "filename": "BinaryGcdOQ01OQ04.lean",
-            "lineCount": 158,
-            "theoremCount": 3,
-            "axiomCount": 0,
-            "defCount": 0,
-            "sorryCount": 0,
-            "isAristotle": false,
-            "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04.lean"
-        },
-        {
-            "path": "Proofs/BinaryGcdOQ03.lean",
-            "filename": "BinaryGcdOQ03.lean",
-            "lineCount": 491,
-            "theoremCount": 14,
-            "axiomCount": 0,
-            "defCount": 13,
-            "sorryCount": 0,
-            "isAristotle": false,
-            "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03.lean"
-        },
-        {
-            "path": "Proofs/BinaryGcdOQ03OQ01.lean",
-            "filename": "BinaryGcdOQ03OQ01.lean",
-            "lineCount": 240,
-            "theoremCount": 9,
-            "axiomCount": 0,
-            "defCount": 2,
-            "sorryCount": 0,
-            "isAristotle": false,
-            "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ01.lean"
-        }
+    "insights": [
+      "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
+      "The original question conflates two distinct claims: (A) HGCD algorithmic correctness (tractable, ~300-500 lines) and (B) O(M(n) log n) bit complexity (blocked on multiple Mathlib gaps).",
+      "Mathlib has no half-GCD, Schoenhage, Karatsuba, or any fast multiplication; grep against Mathlib confirmed (2026-04-28). Mathlib Computability has Turing/primrec but no bit-complexity model for arithmetic.",
+      "The complexity bound O(M(n) log n) is currently unfalsifiable in Lean: no model in which to state \"M(n) bit operations\". Proving (B) requires upstreaming a bit-complexity framework + fast multiplication first (multi-thousand-line project).",
+      "The single hardest piece on the correctness side is termination of the HGCD recursion: need bitsize(max a b) strict decrease after applying the recursively-computed matrix, which requires showing the matrix accumulated >=1 Euclidean step.",
+      "Recommendation: split the question. Pursue (A) HGCD correctness as a self-contained verification; defer (B) until a complexity model lands in Mathlib or as a separate gallery initiative.",
+      "Operational correctness of Schönhage HGCD reduces entirely to the matrix-determinant invariant already proved for Lehmer (BinaryGcdOQ03.lean). The recursion structure adds no new GCD-preservation obligation; it only redistributes work for asymptotic gain. So Path A (correctness only) requires zero new mathematical content beyond the composition law M.mul ↦ apply ∘ apply.",
+      "Fuel-indexed totality avoids the size-reduction proof obligation in the def. Termination via fuel decreasing; correctness via induction on fuel. The hard math (size reduction) is decoupled from the correctness layer.",
+      "Convention dichotomy (Session 3): the column-action CofactorMatrix.apply (M·(a,b)ᵀ) is the right operator for det-based theorems (cofactor_apply_gcd, hgcdMatrix_preserves_gcd) but does NOT track the algorithm's state when the cofactor is updated by right-multiplication M' = M.mul ⟨0, 1, 1, -q⟩. The state-tracking invariant is instead the row-vector relation (a₀, b₀) · M = (current pair). This is preserved by lehmerInnerStep and is what the size-reduction lemma must use.",
+      "Residue monotonicity (Session 3) is self-contained: max ahat' bhat' ≤ max ahat bhat follows directly from Nat.mod_lt with no matrix-vector machinery. It composes through lehmerCofactors by transitivity.",
+      "Step 2b plan (Session 3 → Session 4): from the row-vector invariant (a₀, b₀) · M = (ahat', bhat') and det M = ±1, invert to (a₀, b₀) = (ahat', bhat') · M⁻¹ where M⁻¹.α = δ, M⁻¹.β = -β, M⁻¹.γ = -γ, M⁻¹.δ = α (up to sign of det). Bound each entry of M⁻¹ by max a₀ b₀ / max ahat' bhat' (using residue monotonicity for the denominator); since |det M| = 1, entries of M are bounded by entries of M⁻¹.",
+      "Sign alternation converts the Cramer identity into an entry BOUND (Session 4). Without sign info, the Bezout formula does not bound individual entries. With EvenPattern, all terms separate and bound M.delta <= a0 when ahat' >= 1.",
+      "Entry bound hypothesis 1 <= ahat': requires algorithm to still be running. For HGCD, always satisfied: top-half cofactor applied to full-precision inputs strictly larger than top-half residues.",
+      "Step 3 algebraic split is clean: apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb). Proved by ring. This reduces Step 3 to bounding the error apply(ea,eb) using Step 2b entry bounds (|M.α|,|M.β| ≤ max(aHi,bHi)) and the fact ea,eb < 2^s.",
+      "The MISSING piece for closing hgcdMatrix_size_reduction is inductive: need to show hgcdMatrix fuel aHi bHi reduces max(aHi,bHi) by at least half. This is an induction on bitsize that requires fuel to track depth — genuinely recursive and multi-session."
+    ],
+    "mathlibGaps": [
+      "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
+      "Fast multiplication algorithms: Mathlib has no Karatsuba, Toom-Cook, or Schoenhage-Strassen FFT-based multiplication (verified 2026-04-28).",
+      "Bit-complexity model for arithmetic operations: Mathlib has Turing/primrec/partrec but nothing that lets you state \"M(n) bit operations to multiply n-bit integers\". Required to formulate the O(M(n) log n) complexity claim.",
+      "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
+    ],
+    "nextSteps": [
+      "Session 5 (Step 3): Perturbation bound. From a = aHi*2^s + a_lo and entries <= max(aHi,bHi), bound |M*(a_lo, b_lo)|. ~50-80 lines.",
+      "Session 6 (Step 4): Close hgcdMatrix_size_reduction with explicit constants by composing Steps 2a+2b+3.",
+      "(Optional) Wire hgcdMatrix into a recursive GCD function. ~50-100 lines.",
+      "(Deferred) O(M(n)log n) complexity: blocked on Mathlib infrastructure."
     ]
+  },
+  "tags": [
+    "challenging",
+    "extension",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "binary-gcd",
+    "binary-gcd-oq-01",
+    "binary-gcd-oq-01-oq-04",
+    "binary-gcd-oq-02",
+    "binary-gcd-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-26T08:56:57.650Z",
+  "lastUpdate": "2026-05-02T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/BinaryGcdOQ01.lean",
+      "filename": "BinaryGcdOQ01.lean",
+      "lineCount": 216,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ03.lean",
+      "filename": "BinaryGcdOQ01OQ03.lean",
+      "lineCount": 226,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ04.lean",
+      "filename": "BinaryGcdOQ01OQ04.lean",
+      "lineCount": 158,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ02.lean",
+      "filename": "BinaryGcdOQ02.lean",
+      "lineCount": 135,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ02.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ03.lean",
+      "filename": "BinaryGcdOQ03.lean",
+      "lineCount": 491,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ03OQ01.lean",
+      "filename": "BinaryGcdOQ03OQ01.lean",
+      "lineCount": 240,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ03OQ02.lean",
+      "filename": "BinaryGcdOQ03OQ02.lean",
+      "lineCount": 714,
+      "theoremCount": 22,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds PART VII to `BinaryGcdOQ03OQ02.lean` with 6 algebraic theorems forming the perturbation infrastructure for Step 3 of the HGCD size-reduction proof.

- `cofactor_apply_add`: `apply` distributes over addition (ring)
- `cofactor_apply_smul`: `apply` commutes with scalar multiplication (ring)
- `cofactor_apply_shift_decomp`: key decomposition `apply(aHi·2^s + ea, bHi·2^s + eb) = 2^s · apply(aHi, bHi) + apply(ea, eb)`
- `cofactor_apply_natAbs_le`: triangle bound for natAbs of both components
- `cofactor_apply_err_bound` / `cofactor_apply_err_bound_snd`: given entry bound C and input bound B, error ≤ 2·C·B

**Status**: 0 new sorries, 0 new axioms. Plugging in C = max(aHi, bHi) (Step 2b) and B = 2^s - 1 gives the full perturbation error bound for Step 4.

## Test plan

- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ03OQ02`
- [ ] Verify 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)