### PR TITLE
audit: erdos-77 (clean re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9501,9 +9501,10 @@
     },
     "erdos-77": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T11:47:18Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-02T22:35:00Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-770": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit summary

**Target**: erdos-77 — Ramsey Number Growth Rate
**Result**: clean (re-verify, was last audited 2026-04-03)

## Verified against `proofs/Proofs/Erdos77Problem.lean`

| Field | Claimed | Actual |
|-------|---------|--------|
| status | axiomatized | ✓ |
| badge | axiom | ✓ |
| lineCount | 244 | 244 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 5 | 5 ✓ |
| theoremCount | 4 | 4 ✓ |
| definitionCount | 3 | 3 ✓ |
| namespace | Erdos77 | ✓ |
| True stubs | n/a | none ✓ |

All 5 axioms named in `assumptions` field are present in source: `RamseyNumber`, `erdos_upper_bound`, `liminf_lower_bound`, `limsup_upper_bound`, `gnnw_2024_limsup`. Theorems present: `erdos_upper_bound'`, `erdos_bounds`, `current_best_bounds`, `erdos_conjecture_consistent`. Defs present: `ramseyGrowthRate`, `LimitExists`, `ErdosConjecture`.

`status: axiomatized` / `badge: axiom` is appropriate for an open Erdős problem. The narrative honestly states the axiomatization (overview, proofStrategy, originalContributions all mention "axiomatize"), with no phantom-axiom inflation.

---
Discovered during gallery integrity audit loop.