### PR TITLE
Enrich Quadratic Reciprocity as Algorithm (OQ-03): mathContext, fix crossRefs

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -114,7 +114,7 @@
     "title": "Verified Examples via decide",
     "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |",
     "mathContext": "`decide` works here because Mathlib's `legendreSym p a` is implemented via Euler's criterion in `ZMod p` — for a concrete small prime $p$, `ZMod p` is a `Fintype`, so the equality $a^{(p-1)/2} = \\pm 1$ in `ZMod p` is decidable and Lean can evaluate it during elaboration. No `native_decide` is needed because the search space is tiny ($p \\le 17$). The seven examples are not just illustrative: they exercise multiplicativity (last row), the second supplementary law (rows 2 and 6), and the reciprocity swap (rows 1, 3, 4) — each reduction lemma in this file gets a worked instance.",
-    "significance": "supplementary",
+    "significance": "supporting",
     "relatedConcepts": [
       "decide tactic",
       "Euler's criterion",
@@ -149,5 +149,17 @@
       "Termination of recursive functions",
       "Well-founded induction"
     ]
+  },
+  {
+    "id": "ann-qroq03-exports",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": { "startLine": 108, "endLine": 119 },
+    "type": "context",
+    "title": "Exports: Making the Toolkit Accessible",
+    "content": "The file ends with `end QRAlgorithm` and four `#check` declarations verifying the four main results are accessible under their fully qualified names. This documents the complete public API: anyone importing this file can use `QRAlgorithm.legendreSym_mul_eq`, `QRAlgorithm.legendreSym_neg_one_eq`, `QRAlgorithm.reciprocity_swap`, and `QRAlgorithm.algorithm_descent` directly. The four names correspond exactly to the four reduction steps of the algorithm: factorization, sign, swap, and termination.",
+    "mathContext": "Public API summary: $\\left(\\tfrac{ab}{p}\\right) = \\left(\\tfrac{a}{p}\\right)\\left(\\tfrac{b}{p}\\right)$ (`legendreSym_mul_eq`); $\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2}$ (`legendreSym_neg_one_eq`); $\\left(\\tfrac{q}{p}\\right) = (-1)^{\\ldots}\\left(\\tfrac{p}{q}\\right)$ (`reciprocity_swap`); same with $q < p$ hypothesis (`algorithm_descent`).",
+    "significance": "context",
+    "relatedConcepts": ["namespace", "#check", "public API design", "verified toolkit"],
+    "prerequisites": ["Lean 4 namespace system", "import semantics"]
   }
 ]

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -66,21 +66,27 @@
       "title": "Algorithm Reduction Lemmas",
       "startLine": 44,
       "endLine": 64,
-      "summary": "Three reduction steps: multiplicativity (`legendreSym_mul_eq`), first supplementary law (`legendreSym_neg_one_eq`), and the reciprocity swap (`reciprocity_swap`). Each is a one-line wrapper presenting the Mathlib result in the form needed by the algorithm."
+      "summary": "Three reduction steps: multiplicativity (`legendreSym_mul_eq`), first supplementary law (`legendreSym_neg_one_eq`), and the reciprocity swap (`reciprocity_swap`). Each is a one-line wrapper presenting the Mathlib result in the form needed by the algorithm.",
+      "mathContext": "Multiplicativity: $\\left(\\tfrac{ab}{p}\\right) = \\left(\\tfrac{a}{p}\\right)\\left(\\tfrac{b}{p}\\right)$ (from `map_mul`). First supplementary law: $\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2}$ (from `legendreSym.at_neg_one`). Reciprocity swap: $\\left(\\tfrac{q}{p}\\right) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}\\left(\\tfrac{p}{q}\\right)$ (from `legendreSym.quadratic_reciprocity'`).",
+      "relatedConcepts": ["Legendre symbol", "multiplicativity", "first supplementary law", "Quadratic Reciprocity", "legendreSym.quadratic_reciprocity'", "map_mul"]
     },
     {
       "id": "examples",
       "title": "Verified Example Computations",
       "startLine": 66,
       "endLine": 95,
-      "summary": "Seven concrete Legendre symbol computations verified by `decide`: (3/7)=−1, (2/7)=1, (5/13)=−1, (7/11)=−1, (3/5)=−1, (2/17)=1, (6/7)=−1. Each example is annotated with the QR-based hand calculation that `decide` corroborates."
+      "summary": "Seven concrete Legendre symbol computations verified by `decide`: (3/7)=−1, (2/7)=1, (5/13)=−1, (7/11)=−1, (3/5)=−1, (2/17)=1, (6/7)=−1. Each example is annotated with the QR-based hand calculation that `decide` corroborates.",
+      "mathContext": "$(3/7) = -1$ (by swap: $(3/7) \\cdot (7/3) = -1$, $(7/3) = (1/3) = 1$); $(2/7) = 1$ ($7 \\equiv -1 \\pmod{8}$); $(6/7) = (2/7)\\cdot(3/7) = 1\\cdot(-1) = -1$ (multiplicativity). `decide` evaluates each via Euler's criterion in `ZMod p` at elaboration time.",
+      "relatedConcepts": ["decide tactic", "Euler's criterion", "second supplementary law", "ZMod decidability", "elaboration-time computation"]
     },
     {
       "id": "descent",
       "title": "Algorithm Termination",
       "startLine": 97,
-      "endLine": 118,
-      "summary": "Proves `algorithm_descent`: under the hypothesis `q < p`, the reciprocity swap (q/p) = ±(p/q) reduces the modulus from p to q. This makes the Euclidean-style termination argument explicit at the type level."
+      "endLine": 119,
+      "summary": "Proves `algorithm_descent`: under the hypothesis `q < p`, the reciprocity swap (q/p) = ±(p/q) reduces the modulus from p to q. This makes the Euclidean-style termination argument explicit at the type level. The `#check` exports at lines 111-118 verify that all four lemmas are accessible.",
+      "mathContext": "Termination: `hqp : q < p` in `algorithm_descent` guarantees the modulus decreases. After the swap, applying `legendreSym_mod_left` gives $(p/q) = (p \\bmod q/q)$ with $p \\bmod q < q$. The type-level hypothesis forces callers to supply a proof of strict decrease, exactly the decreasing measure needed for `decreasing_by` in the full recursive algorithm.",
+      "relatedConcepts": ["well-founded recursion", "algorithm_descent", "decreasing_by", "Euclidean algorithm analogy", "#check exports"]
     }
   ],
   "conclusion": {
@@ -94,23 +100,23 @@
   },
   "crossReferences": [
     {
-      "proofId": "quadratic-reciprocity",
-      "relationship": "Foundation",
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundation",
       "description": "The underlying Law of Quadratic Reciprocity that is packaged here as the swap step of an algorithm."
     },
     {
-      "proofId": "quadratic-reciprocity-algorithm",
-      "relationship": "Parent proof",
+      "targetId": "quadratic-reciprocity-algorithm",
+      "relationship": "related",
       "description": "The parent algorithmic presentation of QR; this entry provides the canonical reduction-lemma form."
     },
     {
-      "proofId": "quadratic-reciprocity-algorithm-oq-01",
-      "relationship": "Sibling — full algorithm",
+      "targetId": "quadratic-reciprocity-algorithm-oq-01",
+      "relationship": "extends",
       "description": "Companion entry that builds on these reduction lemmas to give a fully recursive Jacobi-symbol algorithm with well-founded termination and native_decide-verified examples."
     },
     {
-      "proofId": "elementary-quadratic-reciprocity",
-      "relationship": "Related proof",
+      "targetId": "elementary-quadratic-reciprocity",
+      "relationship": "related",
       "description": "An elementary proof of QR via Gauss sums; provides the theoretical foundation that this algorithmic packaging makes computational."
     }
   ],


### PR DESCRIPTION
Enrichment pass for quadratic-reciprocity-oq-03 (quality 96). Added mathContext/relatedConcepts to all 3 sections, fixed crossReferences field names (proofId→targetId), fixed annotation significance value (supplementary→supporting), added 8th annotation for exports section. No Lean source changes.