### PR TITLE
audit(cauchy-schwarz-integral-oq-01...-oq-01): fix non-standard badge + lineCount

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13722,6 +13722,12 @@
       "lastAudited": "2026-05-02T21:39:04Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-02T22:55:14Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory",
       "vitali-convergence"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 230,
+    "lineCount": 220,
     "assumptions": "3 HARD sorries (not OPEN): lp_truncation_tendsto_zero (~80 lines, Vitali's theorem API), localization_existence (~150 lines, Lp restriction map), density extension (~50 lines, port of parent's integral_representation). Classical proofs: Folland §6.2, Rudin Theorem 6.16.",
     "dateAdded": "2026-05-03"
   },
@@ -88,7 +88,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 230,
+    "lineCount": 220,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Audit of `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` (Lp Riesz Representation for Sigma-Finite Measures).

**Findings:**
- `badge: "formalized"` is non-standard — only 2 entries in the entire gallery use it. The 55 other files with the same `status: formalized` + sorries pattern use `badge: "wip"`.
- `lineCount: 230` doesn't match the actual file (`wc -l` = 220). Both `meta.lineCount` and `leanFile.lineCount` were stale.

**Verified accurate:**
- `sorries: 3` matches actual sorry count (lines 120, 155, 192)
- `axiomCount: 0` — no axiom declarations
- `theoremCount: 5` — 5 theorem declarations
- `proofRepoPath` exists
- Description and overview correctly state "reduced to three HARD sorries"; no overclaiming
- `status: "formalized"` is correct (sorries remain → not `verified`)

## Changes

- `meta.badge`: `formalized` → `wip`
- `meta.lineCount` / `leanFile.lineCount`: `230` → `220`
- Tracker entry added (with unicode preserved per known `claim-target.sh` escaping bug)

## Test plan
- [x] `git diff` shows only the intended 4-line meta.json change + 6-line tracker addition
- [x] Tracker not polluted with arrow/em-dash unicode escapes
- [x] Sorry count, axiom count, theorem count re-verified against Lean source

Discovered during gallery integrity audit.