### PR TITLE
audit: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01 (lineCount fix)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13722,6 +13722,13 @@
       "lastAudited": "2026-05-02T21:39:04Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01": {
+      "status": "completed",
+      "result": "issues-fixed",
+      "auditor": "auditor-agent",
+      "completedAt": "2026-05-02T23:12:30Z",
+      "notes": "meta.json lineCount stale: 230 → 220 (file is 220 lines). Fixed in both meta.lineCount and leanFile.lineCount. All other fields verified clean: 3 sorries (lines 120/155/192) match meta, 0 axioms, 5 theorems, status/badge formalized appropriate for Tier C scaffold."
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
     "badge": "formalized",
     "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 230,
+    "lineCount": 220,
     "assumptions": "3 HARD sorries (not OPEN): lp_truncation_tendsto_zero (~80 lines, Vitali's theorem API), localization_existence (~150 lines, Lp restriction map), density extension (~50 lines, port of parent's integral_representation). Classical proofs: Folland §6.2, Rudin Theorem 6.16.",
     "dateAdded": "2026-05-03"
   },
@@ -88,7 +88,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 230,
+    "lineCount": 220,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Audit Summary

Audit of `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` (Lp Riesz Representation for Sigma-Finite Measures).

## Finding

`meta.lineCount` and `leanFile.lineCount` both said 230, but the actual Lean file (`Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean`) is 220 lines.

## Fix

Updated both fields to 220.

## Other fields verified clean

- `sorries`: 3 matches actual sorries (lines 120, 155, 192)
- `axiomCount`: 0 (no `axiom` declarations)
- `theoremCount`: 5 matches actual theorem count
- `mainTheorems`: 5 entries correctly classify proved (2) vs sorry (3)
- Tier C scaffold: status/badge `formalized` correct given sorries > 0
- HARD sorries clearly labeled as classical (not OPEN)
- `crossReferences` to parent file resolves correctly

No narrative failure modes detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)