### PR TITLE
audit: cayley-hamilton-minpoly-oq-05-oq-01 (clean re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1796,9 +1796,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-05-02T23:16:45Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-01": {


### PR DESCRIPTION
## Summary

Re-audit of cayley-hamilton-minpoly-oq-05-oq-01 (last audited 2026-04-03).

**Result: clean** — meta.json claims match Lean source.

## Verification

- File: `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean` — 270 lines (matches `lineCount: 270`)
- 0 sorries (only mention is in docstring referring to another file's sorry)
- 0 `axiom` declarations, no structure-encoded assumptions (`axiomCount: 0` correct)
- 5 theorems + 2 definitions (matches counts)
- Tier A: genuine independent proof. Mathlib provides building blocks (Bezout via `gcd_eq_gcd_ab`, `normalizedFactors`, `minpoly.dvd`, `charpoly_natDegree_eq_dim`) but the union-avoidance + GCD-annihilation argument constructing the cyclic vector is independently formalized
- Status `verified` and badge `original` are warranted; `mathlibDependencies` correctly disclose imported tools

## Test plan

- [x] sorry/axiom/True grep clean
- [x] line counts match
- [x] theorem/definition counts match
- [x] no Mathlib wrapper of the main result

🤖 Generated with [Claude Code](https://claude.com/claude-code)