### PR TITLE
Enrich pac-learning-bounds-oq-01: add header section (quality 98→100)

### DIFF
--- a/src/data/proofs/pac-learning-bounds-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01/meta.json
@@ -97,9 +97,17 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "File Structure and Namespace Setup",
+      "startLine": 1,
+      "endLine": 18,
+      "summary": "File doc-comment outlines the four-part proof structure (definitions, lower bound ≥1, upper bound ≤1, combined = 1). Import Mathlib, establish LearningTheory.VCDimension namespace (structured for future extension to intervals, half-spaces, etc.), and open Finset to surface membership lemmas for simp.",
+      "mathContext": "Three-part VC scaffold: (i) define class, (ii) prove $\\operatorname{VCdim} \\geq d$ by shattering a $d$-set, (iii) prove $\\operatorname{VCdim} \\leq d$ by ruling out $(d+1)$-set shattering."
+    },
+    {
       "id": "definitions",
       "title": "Definitions: Shatters and Threshold Classifiers",
-      "startLine": 16,
+      "startLine": 20,
       "endLine": 27,
       "summary": "Sets up the standard set-based shattering predicate and defines the threshold hypothesis class on ℕ as { x ↦ x < t : t ∈ ℕ }.",
       "mathContext": "$H$ shatters $S$ iff $\\forall T \\subseteq S, \\exists h \\in H : h \\cap S = T$."


### PR DESCRIPTION
Enrichment pass for `pac-learning-bounds-oq-01` (VC Dimension of Threshold Classifiers on ℕ).

## Changes

**meta.json**: Added header section (lines 1–18) to sections array:
- Covers file doc-comment, Mathlib import, LearningTheory.VCDimension namespace setup, and `open Finset`
- Adjusted definitions section startLine from 16 → 20 for precision
- Quality was 98 (4/5 sections needed); adding this section brings quality to 100

The header section explains the three-part VC proof scaffold (define class → ≥d → ≤d → combined=d) and notes the namespace is structured for future extension to intervals, half-spaces, etc.

Build: ✓ `pnpm build` passes