### PR TITLE
audit(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01): fix lineCount 230→220

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13722,6 +13722,12 @@
       "lastAudited": "2026-05-02T21:39:04Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-02T23:20:19Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
     "badge": "formalized",
     "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 230,
+    "lineCount": 220,
     "assumptions": "3 HARD sorries (not OPEN): lp_truncation_tendsto_zero (~80 lines, Vitali's theorem API), localization_existence (~150 lines, Lp restriction map), density extension (~50 lines, port of parent's integral_representation). Classical proofs: Folland §6.2, Rudin Theorem 6.16.",
     "dateAdded": "2026-05-03"
   },
@@ -88,7 +88,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 230,
+    "lineCount": 220,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Gallery integrity audit of `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` (Lp Riesz Representation for Sigma-Finite Measures).

**Verified clean:**
- Sorries: 3 ✓
- Axioms: 0 ✓
- Theorems: 5 with correct proved/sorry split
- Status `formalized` + badge `formalized` appropriate for sorry'd work
- Narrative accurately discloses 3 HARD (not OPEN) sorries with classical references (Folland §6.2, Rudin Thm 6.16)

**Fixed:** `lineCount` 230 → 220 in two fields (`meta.lineCount` and `leanFile.lineCount`) to match actual file.

This was the last unaudited proof in the gallery (queue: 1 → 0).

## Test plan

- [x] meta.json `lineCount` matches `wc -l` of Lean file
- [x] Sorry/axiom/theorem counts verified
- [x] audit-tracker.json entry added under `entries.<id>` (no unicode pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)