### PR TITLE
feat(hlf): GNW hook walk infrastructure — isolate gnwProb_key sorry

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -31,8 +31,13 @@ Two-step LGV proof:
    route below remains open)
 
 ### Status
-- Main theorem `hook_length_formula` is proved modulo a single remaining sorry in
-  `hook_walk_identity` (the ≥10×≥10 non-rectangular case; ~300-line GNW argument).
+- Main theorem `hook_length_formula` is proved modulo sorries in the GNW infrastructure
+  (PART XXVI of Helpers). The dispatcher `hook_walk_identity` is now sorry-free; it
+  delegates the ≥10×≥10 non-rectangular case to `hook_walk_identity_gnw`.
+- Remaining sorries (all in BallotProblemOQ03OQ01OQ02Helpers.lean PART XXVI):
+  1. `gnwProb_key` (GNW 1979 KEY theorem — hard combinatorial identity)
+  2. `gnwProb_sum_corners` (standard induction on K — not GNW itself)
+  3. Four TRIVIAL supporting lemmas (strictHookCells_card/nonempty/hookLen_lt)
 - The alternate LGV proof path remains open. See the OPEN comment block in PART V
   for the canonical-config restatement that future work should target.
 -/
@@ -298,8 +303,8 @@ private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
                             omega
                           rw [hrect]
                           exact hook_walk_identity_rectYD hk ha
-                        · -- Non-rectangular ≥10×≥10: requires GNW hook walk
-                          sorry
+                        · -- Non-rectangular ≥10×≥10: GNW hook walk identity
+                          exact hook_walk_identity_gnw μ hn
 
 /-- The general hook-length formula in ℚ, proved by well-founded recursion on μ.card.
     Uses card_SYT_corner_step (Part XIII) + hook_walk_identity. -/
@@ -372,8 +377,9 @@ decreasing_by
 /-- **General Hook-Length Formula (Frame-Robinson-Thrall 1954).**
     For any Young diagram μ: card(SYT(μ)) × hookProd(μ) = μ.card!
     Proof: well-founded induction using card_SYT_corner_step + hook_walk_identity.
-    The sole remaining sorry is hook_walk_identity (verified for all special cases up to
-    9 rows and 9 cols; ≥10×≥10 case requires GNW hook walk proof, ~300 lines). -/
+    The dispatcher hook_walk_identity is now sorry-free; remaining sorries are in
+    PART XXVI (GNW infrastructure): gnwProb_key (GNW 1979 KEY), gnwProb_sum_corners
+    (standard induction), and four TRIVIAL supporting lemmas. -/
 theorem hook_length_formula_general (μ : YoungDiagram) :
     Fintype.card (StandardYoungTableau μ) * hookProd μ = μ.card.factorial := by
   exact_mod_cast hook_length_formula_Q μ
@@ -383,8 +389,8 @@ theorem hook_length_formula_general (μ : YoungDiagram) :
     `hook_length_formula_general`.  The alternate LGV proof path is documented
     as the canonical-config restatement at the top of PART V; it remains open.
     Mathematical status: proved for all shapes with ≤9 rows or ≤9 columns and
-    for all rectangles; `≥10 × ≥10` non-rectangular case is the sole remaining
-    sorry, pending the GNW hook-walk argument (~300 lines). -/
+    for all rectangles; ≥10×≥10 non-rectangular case uses GNW infrastructure
+    (PART XXVI of Helpers) with gnwProb_key as the hard remaining sorry. -/
 theorem hook_length_formula (μ : YoungDiagram) :
     Fintype.card (StandardYoungTableau μ) * hookProd μ = μ.card.factorial :=
   hook_length_formula_general μ

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -13642,4 +13642,107 @@ lemma hook_walk_identity_atMostNineCols (μ : YoungDiagram) (h9c : μ.colLen 9 =
   have hpost : 0 < μ.transpose.card := by rwa [card_transpose]
   exact hook_walk_identity_le9rows μ.transpose h9t hpost
 
+-- ============================================================
+-- PART XXVI: GNW Hook Walk Infrastructure (Greene-Nijenhuis-Wilf 1979)
+-- ============================================================
+/-
+  The Greene-Nijenhuis-Wilf 1979 random-walk proof of the hook-walk identity for
+  non-rectangular Young diagrams with ≥10 rows and ≥10 cols.
+
+  GNW walk from x ∈ μ:
+  - If x is a corner: stop.
+  - Otherwise: pick uniformly from strictHookCells(x) (arm + leg cells strictly
+    beyond x) and recurse.
+
+  Key identity: Σ_{c ∈ corners μ} gnwProb(μ,c,hookLen(x),x) = 1 for all x ∈ μ.
+  GNW KEY: Σ_{x ∈ μ} gnwProb(μ,c,hookLen(x),x) = hookProd(μ) / hookProd(μ\c).
+
+  Hook-walk identity: swap the double sum to obtain μ.card.
+-/
+
+/-- Strict hook cells beyond (i,j): arm cells (i,s) with s > j, and leg cells
+    (r,j) with r > i. These are the cells the GNW walk can jump to from (i,j).
+    Card = hookLength μ i j - 1. -/
+private def strictHookCells (μ : YoungDiagram) (i j : ℕ) : Finset (ℕ × ℕ) :=
+  (Finset.Ico (j + 1) (μ.rowLen i)).image (Prod.mk i) ∪
+  (Finset.Ico (i + 1) (μ.colLen j)).image (fun r => (r, j))
+
+/-- Every cell in strictHookCells μ i j is a member of μ. -/
+private lemma strictHookCells_mem {μ : YoungDiagram} {i j : ℕ} {y : ℕ × ℕ}
+    (hy : y ∈ strictHookCells μ i j) : y ∈ μ := by
+  simp only [strictHookCells, mem_union, mem_image, mem_Ico] at hy
+  rcases hy with ⟨s, ⟨_, hsr⟩, rfl⟩ | ⟨r, ⟨_, hrc⟩, rfl⟩
+  · exact YoungDiagram.mem_iff_lt_rowLen.mpr hsr
+  · exact YoungDiagram.mem_iff_lt_colLen.mpr hrc
+
+/-- Cardinality of strictHookCells is hookLength - 1.
+    The arm and leg image sets are disjoint (arm has first coord i; leg has first coord > i). -/
+private lemma strictHookCells_card {μ : YoungDiagram} {i j : ℕ} (h : (i, j) ∈ μ) :
+    (strictHookCells μ i j).card = hookLength μ i j - 1 := by
+  sorry  -- TRIVIAL: disjointness + card_Ico + hookLength def + omega
+
+/-- For a non-corner cell (i,j), strictHookCells is nonempty. -/
+private lemma strictHookCells_nonempty {μ : YoungDiagram} {i j : ℕ}
+    (hmem : (i, j) ∈ μ) (hnc : ¬isCorner μ (i, j)) :
+    (strictHookCells μ i j).Nonempty := by
+  sorry  -- TRIVIAL: non-corner means rowLen > j+1 or colLen > i+1
+
+/-- Each strict hook cell has strictly smaller hookLength than the base cell. -/
+private lemma strictHookCells_hookLen_lt {μ : YoungDiagram} {i j : ℕ}
+    (hmem : (i, j) ∈ μ) {y : ℕ × ℕ} (hy : y ∈ strictHookCells μ i j) :
+    hookLength μ y.1 y.2 < hookLength μ i j := by
+  sorry  -- TRIVIAL: arm/leg cells satisfy hookLength_add_eq comparison + omega
+
+/-- GNW walk probability: gnwProb μ c K x = probability that a GNW walk started at
+    x ends at corner c, with K as a termination bound (correct when hookLen(x) ≤ K). -/
+noncomputable private def gnwProb (μ : YoungDiagram) (c : ℕ × ℕ) : ℕ → ℕ × ℕ → ℚ
+  | 0, _ => 0
+  | K + 1, x =>
+    if isCorner μ x then (if x = c then 1 else 0)
+    else (1 / (strictHookCells μ x.1 x.2).card : ℚ) *
+         ∑ y ∈ strictHookCells μ x.1 x.2, gnwProb μ c K y
+
+/-- For any cell x ∈ μ with hookLength(x) ≤ K, the sum of gnwProb over all corners = 1.
+    Proof: induction on K.
+    - K = 0: vacuous (hookLen ≥ 1 contradicts hookLen ≤ 0).
+    - K+1, x a corner: sum = indicator{x = c over corners} = 1 (x is the unique corner c=x).
+    - K+1, x not a corner: pull (1/|H*(x)|) out, swap Σ_c Σ_{y∈H*(x)},
+      apply IH to each y (hookLen y < hookLen x ≤ K+1 ⟹ hookLen y ≤ K). -/
+private lemma gnwProb_sum_corners (μ : YoungDiagram) :
+    ∀ K : ℕ, ∀ x : ℕ × ℕ, x ∈ μ → hookLength μ x.1 x.2 ≤ K →
+      ∑ c ∈ (corners μ).attach, gnwProb μ c.val K x = 1 := by
+  sorry  -- HARD (standard induction; not the GNW KEY step)
+
+/-- GNW KEY theorem (Greene-Nijenhuis-Wilf 1979):
+    The sum of GNW walk probabilities over all cells in μ equals the hookProd ratio.
+    This is the hard combinatorial core of the GNW 1979 proof. -/
+private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ c) :
+    ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x =
+    (hookProd μ : ℚ) / hookProd (removeCorner μ c hc) := by
+  sorry  -- GNW 1979 KEY theorem (hard combinatorial identity)
+
+/-- Hook-walk identity for arbitrary non-empty Young diagrams via GNW walk.
+    Proof: rewrite each ratio using gnwProb_key, swap the double sum, and apply
+    gnwProb_sum_corners to collapse each inner sum to 1. -/
+lemma hook_walk_identity_gnw (μ : YoungDiagram) (hn : 0 < μ.card) :
+    ∑ c ∈ (corners μ).attach,
+      ((hookProd μ : ℚ) / hookProd (removeCorner μ c.val (mem_corners.mp c.prop)))
+    = (μ.card : ℚ) := by
+  -- Step 1: rewrite each ratio as Σ_{x∈μ} gnwProb via gnwProb_key
+  have h1 : ∑ c ∈ (corners μ).attach,
+      (hookProd μ : ℚ) / hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) =
+      ∑ c ∈ (corners μ).attach, ∑ x ∈ μ.cells,
+        gnwProb μ c.val (hookLength μ x.1 x.2) x :=
+    Finset.sum_congr rfl (fun c _ => gnwProb_key μ (mem_corners.mp c.prop))
+  rw [h1]
+  -- Step 2: swap Σ_c Σ_x → Σ_x Σ_c
+  rw [Finset.sum_comm]
+  -- Step 3: each inner Σ_c gnwProb = 1 by gnwProb_sum_corners
+  trans (∑ _x ∈ μ.cells, (1 : ℚ))
+  · exact Finset.sum_congr rfl (fun x hx =>
+      gnwProb_sum_corners μ (hookLength μ x.1 x.2) x hx le_rfl)
+  -- Step 4: Σ 1 = μ.card
+  · rw [sum_const_one]
+    simp [YoungDiagram.card]
+
 end HookLengthFormula

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -868,3 +868,59 @@ File at 14022 lines remains beyond practical Docker 32GB build envelope. The edi
 1. **GNW probabilistic hook-walk proof** (~300 lines) is the cleanest path to a sorry-free `hook_walk_identity`; it would also obviate further row-by-row extensions.
 2. **Canonical-config LGV path**: implement `youngLGVConfigOf` plus (A) and (B), giving a second independent proof of `hook_length_formula`. Note the transpose-duality wrinkle for tall shapes.
 3. **File modularization**: at 14022 lines the file no longer fits the Docker memory envelope. PARTS XII–XXIII (~10000 lines of row-by-row coverage) could be split off into a dedicated module to restore buildability before any further large additions.
+
+---
+
+## Session 2026-05-03 (Session 37) — GNW infrastructure: isolate gnwProb_key sorry
+
+**Mode**: FRESH (claimed from pool, RICH knowledge tier)
+**Outcome**: PROGRESS — GNW skeleton added to Helpers PART XXVI; dispatcher now sorry-free
+
+### What I Did
+
+1. Rebased `feature/researcher-6` worktree onto current main (worktree was 50+ commits behind;
+   Helpers file added in commit 61edf3c111c was missing from worktree).
+
+2. Added PART XXVI to `BallotProblemOQ03OQ01OQ02Helpers.lean` (lines 13645–13748, +104 lines):
+   - `strictHookCells μ i j`: arm + leg cells strictly beyond (i,j), card = hookLen - 1
+   - `strictHookCells_mem`: proved — each strict hook cell is in μ
+   - `strictHookCells_card`: sorry (TRIVIAL)
+   - `strictHookCells_nonempty`: sorry (TRIVIAL)
+   - `strictHookCells_hookLen_lt`: sorry (TRIVIAL)
+   - `gnwProb μ c K x`: probability walk from x ends at corner c, bounded by K
+     - `| 0, _ => 0`
+     - `| K+1, x => if isCorner μ x then (if x = c then 1 else 0) else ...`
+   - `gnwProb_sum_corners`: sorry (HARD: standard induction on K, not GNW itself)
+   - `gnwProb_key`: sorry (GNW 1979 KEY theorem — the hard combinatorial identity)
+   - `hook_walk_identity_gnw`: PROVED using gnwProb_key + gnwProb_sum_corners + sum_comm
+
+3. Updated `BallotProblemOQ03OQ01OQ02.lean`:
+   - Replaced `sorry` at line 302 with `exact hook_walk_identity_gnw μ hn`
+   - Updated header and docstring comments to reflect new state
+
+4. Committed to `feature/researcher-6` (commit 53c1033051).
+
+### Key Findings
+
+- `hook_walk_identity_gnw` proof structure: h1 (rewrite each ratio via ← gnwProb_key) →
+  sum_comm (swap Σ_c Σ_x) → gnwProb_sum_corners (each inner Σ = 1) → Finset.sum_const_one
+- The dispatcher `hook_walk_identity` in Main is now 0 sorries (sorry-free)
+- Net sorry count: was 1 (vague dispatcher sorry) → now 5 (all in Helpers PART XXVI):
+  1. `gnwProb_key` (GNW 1979 KEY — the genuinely hard theorem)
+  2. `gnwProb_sum_corners` (HARD: induction on K; provable but ~50 lines)
+  3. `strictHookCells_card` (TRIVIAL: disjointness + card_Ico + omega)
+  4. `strictHookCells_nonempty` (TRIVIAL: non-corner ↔ arm or leg > 0)
+  5. `strictHookCells_hookLen_lt` (TRIVIAL: hookLength_add_eq comparison)
+- Sorries 3–5 are good Aristotle candidates
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (added PART XXVI, +104 lines)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (sorry at 302 → GNW call; comment updates)
+
+### Next Steps
+
+1. Create PR for feature/researcher-6 → main
+2. Submit sorries 3–5 to Aristotle (likely fast proofs)
+3. Tackle `gnwProb_sum_corners` manually (standard induction on K, ~50 lines)
+4. `gnwProb_key` is the remaining hard mathematical content (GNW 1979)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Modularization complete (session 35). The 1 sorry is at line 302 of a 392-line Main file. GNW Route A (~300 lines) is the clear next step.",
+    "progressSummary": "PROGRESS: GNW infrastructure added (session 37). hook_walk_identity_gnw PROVED. Remaining: gnwProb_key (GNW 1979 KEY), gnwProb_sum_corners (standard induction), 3 TRIVIAL lemmas. Dispatcher sorry-free.",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -132,7 +132,11 @@
       "Session 32 (2026-04-27): removed ni_count_eq_syt_count and lgv_det_factors_as_hook_quotient (dead, unprovable scaffolding with arbitrary (r,σ,m) untied to μ)",
       "Session 32: replaced removed sorries with OPEN comment block in PART V documenting canonical-config restatement (A) RSK bijection and (B) Lindström/Jacobi-Trudi det identity",
       "Session 32: documented LGV well-formedness obstruction r-1 ≤ μ.rowLen(r-1), which fails for tall/narrow shapes — needs transpose-duality case split",
-      "BallotProblemOQ03OQ01OQ02Helpers.lean: PARTS I-XXIV extracted; 22 private declarations de-privatized for cross-file access"
+      "BallotProblemOQ03OQ01OQ02Helpers.lean: PARTS I-XXIV extracted; 22 private declarations de-privatized for cross-file access",
+      "strictHookCells: arm+leg strict hook cells def (Helpers:13666)",
+      "strictHookCells_mem: proved — each strict hook cell is in μ (Helpers:13671)",
+      "gnwProb: GNW walk probability by Nat.rec on K bound (Helpers:13698)",
+      "hook_walk_identity_gnw: PROVED via gnwProb_key + gnwProb_sum_corners + sum_comm (Helpers:13727)"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -210,7 +214,11 @@
       "The two LGV auxiliary lemmas were stated for arbitrary (r, σ, m) with no link to μ. Most parameter choices yield false numerical equalities (e.g. μ=⊥ vs r=1, σ=fun _ => 5). Removing them is honest housekeeping, not a content regression.",
       "youngLGVConfig wellFormed condition r-1 ≤ σ⟨0⟩ reduces to μ.rowLen(numRows-1) ≥ numRows-1 — fails for tall shapes like (1,1,…,1). The general LGV statement requires applying LGV to whichever of μ, μᵀ is wide enough.",
       "Session 33 (2026-04-27): row-by-row tower has hit diminishing returns at 14022 lines. Adding row N+1 costs ~2200 lines for one branch and worsens the build envelope. The remaining sorry is uniformly closeable only by GNW (~300 lines, probability) or RSK/Fomin growth (~600 lines, also gives full HLF). Modularization (split PARTS XIVc-XXVI) must precede further additions to restore buildability.",
-      "Session 35: Modularization — split 14022-line file into Helpers (13645 lines, 0 sorries) + Main (392 lines, 1 sorry). The sorry is now at line 302 of a 392-line file."
+      "Session 35: Modularization — split 14022-line file into Helpers (13645 lines, 0 sorries) + Main (392 lines, 1 sorry). The sorry is now at line 302 of a 392-line file.",
+      "GNW structure: hook_walk_identity_gnw proved once gnwProb_key and gnwProb_sum_corners accepted; proof uses sum_comm to swap Σ_c Σ_x",
+      "Dispatcher hook_walk_identity now sorry-free; sorries isolated to PART XXVI GNW infrastructure",
+      "gnwProb_sum_corners is HARD but NOT the GNW KEY step — it is a standard induction on hookLen bound K (~50 lines)",
+      "gnwProb_key (GNW 1979 KEY) is the sole mathematically deep sorry; 3 TRIVIAL supporting lemmas also remain"
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
@@ -218,10 +226,10 @@
       "BallotProblemOQ03.lean regression (omega failure near minSharedStepIdx_preserved) blocks all builds"
     ],
     "nextSteps": [
-      "Verify CI/Docker build succeeds for Helpers + Main",
-      "Implement GNW Route A in Main (line 302, ~300 lines)",
-      "GNW: deterministic recasting avoids ProbabilityTheory; ~300 lines for hook walk argument",
-      "After GNW proof: update meta.json sorries 1→0, status formalized→verified"
+      "Submit strictHookCells_card/nonempty/hookLen_lt to Aristotle (TRIVIAL)",
+      "Prove gnwProb_sum_corners manually: induction on K, ~50 lines",
+      "Tackle gnwProb_key (GNW 1979 KEY): hard combinatorial identity, core of GNW 1979",
+      "Create PR for feature/researcher-6 → main with current PART XXVI skeleton"
     ]
   },
   "tags": [


### PR DESCRIPTION
Adds PART XXVI (GNW infrastructure) to BallotProblemOQ03OQ01OQ02Helpers.lean. The hook_walk_identity dispatcher in Main is now sorry-free; the >=10x>=10 non-rectangular case delegates to hook_walk_identity_gnw.

Remaining sorries in Helpers PART XXVI: gnwProb_key (GNW 1979 KEY theorem), gnwProb_sum_corners (standard induction on K), and 3 TRIVIAL supporting lemmas.

🤖 Generated with Claude Code