### PR TITLE
enrich(cayley-hamilton-cyclic-vector-all-fields): rewrite annotations for V2, fix section ranges and lineCount

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/annotations.json
@@ -1,216 +1,98 @@
 [
   {
-    "id": "ann-chcvaf-header",
+    "id": "ann-chcvaf-v2-header",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 1,
-      "endLine": 47
-    },
+    "range": { "startLine": 1, "endLine": 47 },
     "type": "concept",
-    "title": "Module Header: Three-Step Proof Architecture and Mathlib Gap",
-    "content": "The module docstring lays out the full proof architecture before any Lean code appears. It names three building blocks: (1) the axiom `nonderogatory_similar_companion` (M ~ C(minpoly M), stated but not proved — the Mathlib gap); (2) `companionMatrix_cyclic_e0` (e₀ is cyclic for C(p), proved in CayleyHamiltonMinpolyOQ05OQ01OQ04 via the orbit C(p)^k · e₀ = eₖ); and (3) `cyclic_vector_of_similar` (cyclic vectors transfer under similarity, proved in the same file). The fourth point is the main theorem combining all three. This upfront blueprint is a design pattern for axiomatized formalizations: declare all assumptions explicitly, prove what you can, and clearly demarcate the boundary between verified and assumed content. The `Status: axiomatized (1 axiom, 0 sorries)` tag in the docstring directly matches the gallery's `badge: axiom` classification.",
-    "mathContext": "The proof architecture encodes the logical dependency graph: main theorem depends on (1) + (2) + (3); (2) and (3) depend only on Mathlib; (1) depends on the PID structure theorem for $K[X]$-modules (the Mathlib gap). This layering means any future Mathlib addition of the PID structure theorem would allow replacing the axiom with a proof, upgrading the entry from `axiomatized` to `verified` without any other changes. The imports (lines 41-49) show the two proof files this depends on: `CayleyHamiltonReductionOQ02OQ01` for companion matrix definitions and `CayleyHamiltonMinpolyOQ05OQ01OQ04` for the proved supporting lemmas.",
+    "title": "V2 Architecture: Primary Decomposition Replaces the RCF Axiom",
+    "content": "The module header describes a V1→V2 upgrade that eliminates the RCF similarity axiom entirely. V1 axiomatized `nonderogatory_similar_companion` (M similar to C(minpoly M)) and derived the theorem from it. V2 replaces this with a direct primary decomposition argument from WIP04.\n\nThe three-step V2 proof structure:\n1. **[Proved, WIP04]** Primary decomposition: for each prime power $p_i^{e_i}$ of minpoly, construct a primary vector $v_i$ in the $p_i^{e_i}$-primary component via minimality of minpoly.\n2. **[Proved, WIP04]** CRT combination: $v = \\sum v_i$ is cyclic via Bezout projections.\n3. **[Proved in this file, Section II]** Factorization bridge: every monic polynomial of positive degree over a field factors into coprime monic irreducible prime powers.\n\nThe header quantifies the upgrade: V1's axiom required ~800 lines of Smith normal form and PID structure theory; V2's factorization bridge required ~50–150 lines of Mathlib UFD/multiset API.",
+    "mathContext": "The V2 proof bypasses companion matrices entirely. It works at the level of polynomial annihilator ideals: $v$ is cyclic iff its annihilator $\\mathrm{Ann}(v) = \\{r \\in K[X] : r(M)v = 0\\}$ satisfies $\\deg(\\mathrm{Ann}(v)) \\geq n$. Primary decomposition constructs $v_i$ with $\\mathrm{Ann}(v_i) = (p_i^{e_i})$; CRT shows $\\mathrm{Ann}(\\sum v_i) = \\mathrm{lcm}(p_i^{e_i}) = \\prod p_i^{e_i} = \\mathrm{minpoly}$, giving degree $n$.",
     "significance": "key",
-    "relatedConcepts": [
-      "axiomatized proof architecture",
-      "companion matrix orbit C(p)^k · e₀ = eₖ",
-      "cyclic vector transfer under similarity",
-      "Mathlib gap: PID structure theorem"
-    ],
-    "prerequisites": [
-      "rational canonical form overview",
-      "Lean 4 module docstrings and imports"
-    ]
-  },
-  {
-    "id": "ann-chcvaf-rcf-axiom",
-    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 74,
-      "endLine": 102
-    },
-    "type": "keyInsight",
-    "title": "The RCF Similarity Axiom: Isolating the Mathlib Gap",
-    "content": "`nonderogatory_similar_companion` is the only axiom in this formalization. It states: if M is nonderogatory, there exists an invertible P with M = P⁻¹ · C(minpoly M) · P. This is the single-block rational canonical form theorem (Frobenius normal form). By declaring it as an explicit `axiom` rather than a `sorry`, the formalization makes its assumption transparent: the proof is complete assuming this one fact, and the fact is clearly documented with its mathematical justification (PID module structure theorem) and Mathlib gap. The axiom declaration is also safer than `sorry` — it cannot be accidentally used to close other goals, and it appears explicitly in `#print axioms` output.",
-    "mathContext": "The rational canonical form states that every matrix $M \\in M_n(K)$ is similar to a block diagonal matrix of companion matrices $\\mathrm{diag}(C(d_1), \\ldots, C(d_r))$ where $d_1 \\mid d_2 \\mid \\cdots \\mid d_r$ are the **invariant factors** of $M$. For nonderogatory $M$ (where $\\mathrm{minpoly} = \\mathrm{charpoly}$), the invariant factor decomposition has $r = 1$ and $d_1 = \\mathrm{minpoly}\\, M$. The proof of this uses the structure theorem for $K^n$ as a finitely generated $K[X]$-module: $K^n \\cong \\bigoplus_i K[X]/(d_i)$. Nonderogatory forces $r = 1$ because $d_1 \\cdots d_r = \\mathrm{charpoly}$ and $d_r = \\mathrm{minpoly}$ together with $d_1 \\mid \\cdots \\mid d_r$ give $r = 1, d_1 = \\mathrm{minpoly} = \\mathrm{charpoly}$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Rational Canonical Form",
-      "invariant factors",
-      "PID module structure theorem",
-      "Mathlib gap"
-    ],
-    "prerequisites": [
-      "companion matrix definition",
-      "nonderogatory matrix definition",
-      "K[X]-module structure on K^n"
-    ]
-  },
-  {
-    "id": "ann-chcvaf-main-proof-chain",
-    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 104,
-      "endLine": 155
-    },
-    "type": "proofTechnique",
-    "title": "Three-Step Proof Chain: Axiom → Orbit → Transfer",
-    "content": "The proof of `nonderogatory_has_cyclic_vector` chains three modular steps. After dispatching `n = 0` (trivial: `Fin.elim0` works since there are no degree constraints), the `n > 0` case proceeds: (1) `nonderogatory_similar_companion hn M h` gives the invertible P and the similarity `hMC : M = P.inv * C * P.val`; (2) `hμ_deg` establishes `(minpoly K M).natDegree = n` by rewriting via nonderogatory hypothesis `h : minpoly K M = M.charpoly` and `Matrix.charpoly_natDegree_eq_dim`; (3) `companionMatrix_cyclic_e0 hn (minpoly K M) hμ_monic hμ_deg` gives `hcyc : IsCyclicVector C e₀`; (4) `cyclic_vector_of_similar M C P hMC _ hcyc` transfers the cyclic vector. The proof term is a clean 10-line tactic block.",
-    "mathContext": "The similarity step is key: if $M = P^{-1}CP$ and $w$ is cyclic for $C$, then $v = P^{-1}w$ satisfies $M^k v = P^{-1} C^k w$, so $\\{v, Mv, \\ldots, M^{n-1}v\\} = \\{P^{-1}w, P^{-1}Cw, \\ldots, P^{-1}C^{n-1}w\\} = P^{-1}\\{w, Cw, \\ldots, C^{n-1}w\\}$, which is a basis iff $\\{w, Cw, \\ldots, C^{n-1}w\\}$ is (since $P^{-1}$ is invertible). The orbit property $C^k e_0 = e_k$ makes $\\{e_0, Ce_0, \\ldots, C^{n-1}e_0\\} = \\{e_0, e_1, \\ldots, e_{n-1}\\}$ the standard basis.",
-    "significance": "key",
-    "relatedConcepts": [
-      "matrix similarity",
-      "companion matrix orbit",
-      "cyclic vector transfer",
-      "functional calculus"
-    ],
-    "prerequisites": [
-      "companionMatrix_cyclic_e0",
-      "cyclic_vector_of_similar",
-      "nonderogatory_similar_companion axiom"
-    ]
-  },
-  {
-    "id": "ann-chcvaf-finite-field",
-    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 157,
-      "endLine": 170
-    },
-    "type": "keyInsight",
-    "title": "Finite Fields: Why Union Avoidance Fails but the Theorem Holds",
-    "content": "The corollary `nonderogatory_has_cyclic_vector_finite` specializes the main theorem to `[Fintype K]`. The proof is one line — it just applies the main theorem — but the significance is conceptual. The union avoidance argument (used for infinite fields in OQ-05-OQ-01) works by observing that the non-cyclic vectors form finitely many proper subspaces; over an infinite field, these cannot cover all of $K^n$. Over $\\mathbb{F}_2$ with $n = 2$, there are exactly 3 nonzero vectors and 3 proper 1-dimensional subspaces, each containing one nonzero vector — the union IS all of $\\mathbb{F}_2^2 \\setminus \\{0\\}$. Yet the theorem holds, because the companion matrix approach is field-independent: it never asks which vectors avoid subspaces, only that M is similar to C and e₀ is cyclic for C by structure.",
-    "mathContext": "For $\\mathbb{F}_2^2$: the three nonzero vectors $(1,0), (0,1), (1,1)$ are each the unique nonzero element of a 1-dimensional subspace. Union avoidance requires finding $v$ outside all $\\ker(p(M))$ for finitely many polynomials $p$ with $\\deg(p) < n = \\mathrm{deg}(\\mathrm{minpoly})$, but over $\\mathbb{F}_2$ these kernels exhaust all nonzero vectors. The algebraic proof bypasses this by not using cardinality at all — it uses the structural fact that the companion matrix orbit is exactly the standard basis.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "union avoidance",
-      "finite fields",
-      "F_2 counterexample",
-      "field cardinality"
-    ],
-    "prerequisites": [
-      "nonderogatory_has_cyclic_vector",
-      "companion matrix orbit property"
-    ]
-  },
-  {
-    "id": "ann-chcvaf-cyclic-characterization",
-    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 155,
-      "endLine": 169
-    },
-    "type": "insight",
-    "title": "Polynomial Annihilator Characterization of Cyclic Vectors",
-    "content": "`cyclic_iff_not_killed_below_degree` gives the polynomial annihilator characterization: v is cyclic for M iff no nonzero polynomial p of degree < n kills v under M (i.e., `(aeval M p).mulVec v ≠ 0`). The proof is purely logical — it unfolds `IsCyclicVector` and `CyclicVectorArbitrary.IsCyclicVector` via `simp only`, then splits into two implications closed by direct application of the hypothesis. No matrix computation is needed, because this is essentially unfolding the definition: `IsCyclicVector` IS the annihilator condition, and the corollary just restates it using the `aeval M` notation. The nonderogatory hypothesis `h : IsNonderogatory M` appears in the signature but is not used in the proof body — it is present to make the intended context (nonderogatory matrices) explicit to the reader.",
-    "mathContext": "Formally: $v$ is cyclic for $M$ iff $\\ker(p(M) \\cdot -) \\not\\ni v$ for all nonzero $p$ with $\\deg(p) < n$. Since $M$ is nonderogatory, $\\deg(\\mathrm{minpoly}) = n$, so the bound $\\deg(p) < n$ is exactly the bound needed to avoid the minimal polynomial. Any linear dependence $\\sum_{k < n} c_k M^k v = 0$ would give such a polynomial $p = \\sum c_k X^k$ with $p(M)v = 0$, so the condition is equivalent to $\\{v, Mv, \\ldots, M^{n-1}v\\}$ being linearly independent — i.e., a basis of $K^n$ (by dimension count).",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "aeval (polynomial evaluation at a matrix)",
-      "mulVec (matrix-vector multiplication)",
-      "annihilator ideal",
-      "CyclicVectorArbitrary.IsCyclicVector"
-    ],
-    "prerequisites": [
-      "polynomial evaluation in Lean 4 via aeval",
-      "K[X]-module structure on K^n",
-      "linear independence via dimension"
-    ]
+    "relatedConcepts": ["primary decomposition", "CRT combination", "Bezout projections", "V1 vs V2 axiom elimination", "WIP04"],
+    "prerequisites": ["rational canonical form overview", "primary decomposition for modules over a PID"]
   },
   {
     "id": "ann-chcvaf-abbrev-design",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 48,
-      "endLine": 72
-    },
+    "range": { "startLine": 48, "endLine": 68 },
     "type": "concept",
-    "title": "Definition Aliasing via abbrev for Cross-File Consistency",
-    "content": "`IsCyclicVector` and `IsNonderogatory` are declared as `abbrev` (reducible definitions) aliasing the `CyclicVectorArbitrary` namespace versions from `CayleyHamiltonMinpolyOQ05OQ01OQ04`. Using `abbrev` rather than `def` is important: `abbrev` in Lean 4 is `@[reducible] def`, meaning it is definitionally transparent. This allows Lean to unify `IsCyclicVector M v` (this namespace) with `CyclicVectorArbitrary.IsCyclicVector M v` without explicit coercions. In particular, the lemmas `companionMatrix_cyclic_e0` and `cyclic_vector_of_similar` (which use `CyclicVectorArbitrary.IsCyclicVector`) can be applied directly to goals stated in terms of the `abbrev`s.",
-    "mathContext": "In Lean 4, `abbrev` creates a definition that is unfolded by the kernel during definitional equality checking. This means `simp`, `rw`, `exact`, and typeclass search all see through it automatically. Without `abbrev` (using `def`), one would need explicit `show ... from ...` or `unfold` steps to unify the two definitions, even though they expand to the same type. The `abbrev` approach is the idiomatic Lean 4 pattern for namespace-local renaming.",
+    "title": "Definition Aliasing via abbrev for Cross-File Compatibility",
+    "content": "`IsCyclicVector` and `IsNonderogatory` are declared as `abbrev` (reducible definitions) aliasing the `GeneralCyclicVector` namespace versions from `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04`. Using `abbrev` rather than `def` is critical: `abbrev` is `@[reducible] def` in Lean 4, meaning it is definitionally transparent. This allows the kernel to unify `IsCyclicVector M v` (this namespace) with `GeneralCyclicVector.IsCyclicVector M v` (WIP04) without explicit coercions.\n\nThe main theorem delegates to `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector`, which uses WIP04-namespaced types in its conclusion. Without `abbrev`, the result type `∃ v, GeneralCyclicVector.IsCyclicVector M v` would not typecheck against the goal `∃ v, IsCyclicVector M v` — even though both unfold to the same proposition.",
+    "mathContext": "In Lean 4, `@[reducible]` makes a definition transparent during *elaboration*: `simp`, `rw`, `exact`, and typeclass synthesis all see through it. A `@[semireducible] def` (the default) is only transparent during *kernel* type-checking but not elaboration — causing 'motive is not type correct' or 'type mismatch' errors in tactic proofs. The `abbrev` pattern is the idiomatic Lean 4 solution for namespace-local renaming when cross-namespace type compatibility is needed.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "abbrev vs def in Lean 4",
-      "reducible definitions",
-      "namespace aliasing",
-      "definitional equality"
-    ],
-    "prerequisites": [
-      "Lean 4 type system basics",
-      "CyclicVectorArbitrary namespace"
-    ]
+    "relatedConcepts": ["abbrev vs def in Lean 4", "reducible definitions", "GeneralCyclicVector (WIP04)", "cross-namespace type compatibility"],
+    "prerequisites": ["Lean 4 elaboration vs kernel type-checking", "GeneralCyclicVector namespace from WIP04"]
   },
   {
-    "id": "ann-chcvaf-section-v-summary",
+    "id": "ann-chcvaf-factorization-private-chain",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 170,
-      "endLine": 199
-    },
+    "range": { "startLine": 73, "endLine": 151 },
+    "type": "technique",
+    "title": "Private UFD Infrastructure: Four Lemmas Building to monic_factored_form",
+    "content": "Section II is an API translation layer: WIP04's `nonderogatory_general_has_cyclic_vector` needs a `Fin k`-indexed factorization, but Mathlib's UFD API delivers a `Multiset`. Four private theorems bridge this gap:\n\n1. **`monic_irreducible_multiset_factorization`** (73–98): Given monic $\\mu$ of positive degree, produces a nonempty `Multiset` of monic irreducibles with product $\\mu$. Extracts from `UniqueFactorizationMonoid.exists_prime_factors` using unit normalization (scaling by leading coefficient inverse).\n\n2. **`coprime_of_distinct_monic_irreducible`** (100–109): Distinct monic irreducibles are coprime. Proof: if $p | q$ with $p, q$ monic irreducible, then $q = p \\cdot u$ with $u$ a unit, forcing $q = p$ by monic normalization — contradiction.\n\n3. **`coprime_pow_of_coprime_irreducible`** (111–115): Coprimality lifts to prime powers. One-liner: `IsCoprime.pow`.\n\n4. **`finset_factorization_from_multiset`** (117–151): The main API bridge. Given a multiset of monic irreducibles, produces `Fin k`-indexed distinct representatives with exponents. Proof by `Multiset.induction`: at each step, check if the new irreducible already appears (increment its exponent) or is new (extend the Fin array). The case split uses `Fin.cons` and matrix update via `if-then-else`.",
+    "mathContext": "The factorization challenge: `exists_prime_factors` gives `∃ f : Multiset K[X], (∀ p ∈ f, Irreducible p) ∧ f.prod = μ`. But WIP04 needs `∃ k : ℕ, ∃ p : Fin k → K[X], ∃ e : Fin k → ℕ, (∀ i, Irreducible (p i)) ∧ ... ∧ (∀ i j, i ≠ j → IsCoprime (p i ^ e i) (p j ^ e j)) ∧ μ = ∏ i, p i ^ e i`. The `finset_factorization_from_multiset` theorem performs the conversion, grouping repeated irreducibles by multiplicity and using `Fin.cons` to build the index type inductively.",
+    "significance": "technical",
+    "relatedConcepts": ["UniqueFactorizationMonoid.exists_prime_factors", "Multiset to Fin k conversion", "IsCoprime.pow", "Fin.cons"],
+    "prerequisites": ["UFD prime factorization", "Multiset.induction in Lean 4", "Fin array construction"]
+  },
+  {
+    "id": "ann-chcvaf-monic-factored-form",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
+    "range": { "startLine": 153, "endLine": 170 },
+    "type": "theorem",
+    "title": "monic_factored_form: The Factorization Bridge (Proved via UFD)",
+    "content": "```lean\nprivate theorem monic_factored_form {K : Type*} [Field K]\n    (μ : K[X]) (hμ_monic : μ.Monic) (hμ_deg : 0 < μ.natDegree) :\n    ∃ (k : ℕ) (_ : 0 < k) (p : Fin k → K[X]) (e : Fin k → ℕ),\n      (∀ i, Irreducible (p i)) ∧\n      (∀ i, (p i).Monic) ∧\n      (∀ i, 0 < e i) ∧\n      (∀ i j : Fin k, i ≠ j → IsCoprime (p i ^ e i) (p j ^ e j)) ∧\n      μ = ∏ i : Fin k, p i ^ e i\n```\n\nThis is the factorization bridge: every monic polynomial of positive degree over a field factors into $k \\geq 1$ coprime monic irreducible prime powers. The proof assembles the four private helpers in sequence: `monic_irreducible_multiset_factorization` → `finset_factorization_from_multiset` → `coprime_of_distinct_monic_irreducible` → `coprime_pow_of_coprime_irreducible`.\n\n**The output type matches WIP04's interface exactly**: $k$ distinct irreducible factors with positive exponents satisfying pairwise coprimality at the prime-power level — this is precisely the signature `nonderogatory_general_has_cyclic_vector` requires for its Bezout decomposition.",
+    "mathContext": "In $K[X]$ (a PID and UFD), the unique factorization theorem gives $\\mu = u \\cdot \\prod_{i=1}^k p_i^{e_i}$ with $u$ a unit, $p_i$ monic irreducible, $e_i \\geq 1$, and $p_i \\neq p_j$ for $i \\neq j$. Since $\\mu$ is monic, $u = 1$. Distinct monic irreducibles in $K[X]$ are coprime (proved by `coprime_of_distinct_monic_irreducible`), and coprimality extends to prime powers (by `IsCoprime.pow`). The pairwise coprimality of distinct prime powers is exactly the condition needed for the Chinese Remainder Theorem in WIP04's Bezout projection construction.",
+    "significance": "key",
+    "relatedConcepts": ["monic_factored_form", "UFD factorization in K[X]", "coprime prime powers", "WIP04 interface contract"],
+    "prerequisites": ["UFD prime factorization theorem", "K[X] is a PID and UFD", "coprimality of distinct monic irreducibles"]
+  },
+  {
+    "id": "ann-chcvaf-main-theorem-v2",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
+    "range": { "startLine": 176, "endLine": 205 },
+    "type": "theorem",
+    "title": "Main Theorem: Two-Case Proof Delegating to WIP04",
+    "content": "The proof of `nonderogatory_has_cyclic_vector` has two cases:\n\n**Case n = 0**: `Fin.elim0` is a function of type `Fin 0 → K`, serving as the trivially-cyclic empty vector. The cyclic condition `∀ p, p ≠ 0 → natDegree p < 0 → ...` is vacuously satisfied since `natDegree p < 0` is never true.\n\n**Case n > 0**: Four sequential steps:\n1. `hμ_monic` from `minpoly.monic (Matrix.isIntegral M)`\n2. `hμ_deg : (minpoly K M).natDegree = n` via nonderogatory `h` and `Matrix.charpoly_natDegree_eq_dim`\n3. `monic_factored_form (minpoly K M) hμ_monic (by omega)` produces `k, p, e, hp_irr, hp_monic, he_pos, hcop, hprod`\n4. `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector hk M h p e hp_irr hp_monic he_pos hcop hprod` closes the goal\n\nAll the algebraic work — primary decomposition, CRT Bezout projections, cyclic vector assembly — is encapsulated in WIP04's theorem. This file only supplies the factorization and the nonderogatory hypothesis.",
+    "mathContext": "The nonderogatory hypothesis `h : IsNonderogatory M` unfolds (via the `abbrev`) to `GeneralCyclicVector.IsNonderogatory M`, which is `minpoly K M = M.charpoly`. Combined with `Matrix.charpoly_natDegree_eq_dim` (the characteristic polynomial of an $n \\times n$ matrix has degree $n$), this gives `(minpoly K M).natDegree = n`. The factorization `minpoly = ∏ p_i^{e_i}` then provides exactly the input WIP04 needs: $k$ coprime irreducible prime powers spanning the eigenvalue structure of $M$.",
+    "significance": "key",
+    "relatedConcepts": ["nonderogatory_general_has_cyclic_vector (WIP04)", "GeneralCyclicVector", "minpoly.monic", "Matrix.isIntegral"],
+    "prerequisites": ["monic_factored_form", "IsNonderogatory as abbrev for GeneralCyclicVector.IsNonderogatory", "WIP04 theorem signature"]
+  },
+  {
+    "id": "ann-chcvaf-finite-field",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
+    "range": { "startLine": 211, "endLine": 217 },
     "type": "insight",
-    "title": "Section V: Summary — Axiom Inventory and Upgrade Path",
-    "content": "The closing /-! docstring (SECTION V) provides a complete summary of the formalization's logical status in three parts. (1) **What is fully proved (sorry-free)**: all five named results — `companionMatrix_cyclic_e0`, `cyclic_vector_of_similar`, `nonderogatory_has_cyclic_vector`, `nonderogatory_has_cyclic_vector_finite`, `cyclic_iff_not_killed_below_degree` — are listed with their sources. (2) **The one axiom**: `nonderogatory_similar_companion` is named precisely with its mathematical content (single-block RCF / Frobenius normal form) and its Mathlib dependency (PID structure theorem for K[X]-modules). (3) **Upgrade path**: quantitative estimate (~800 lines for Smith normal form + ~200 for the RCF reduction) gives a concrete target for future Mathlib development.\n\nThis self-documenting pattern — a closing summary that explicitly enumerates assumptions and open work — is characteristic of high-quality axiomatized formalizations. It allows a reader to audit the proof at a glance without running `#print axioms`.",
-    "mathContext": "Smith normal form for polynomial matrices $M \\in M_n(K[X])$: there exist invertible matrices $U, V$ (over $K[X]$) such that $UMV = \\mathrm{diag}(d_1, \\ldots, d_r, 0, \\ldots)$ where $d_i \\mid d_{i+1}$ (the Smith normal form). Applied to the presentation matrix of the $K[X]$-module $K^n$, this gives the invariant factor decomposition $K^n \\cong \\bigoplus_i K[X]/(d_i)$ — the PID structure theorem. For a nonderogatory matrix, the Smith form of the characteristic matrix $(XI - M)$ has exactly one invariant factor $d_1 = \\mathrm{minpoly}\\, M = \\mathrm{charpoly}\\, M$, directly giving the RCF similarity. Estimated 800 lines captures: Smith algorithm implementation (~400), elementary divisor theory (~200), RCF similarity reduction (~200).",
+    "title": "Finite Fields: Why Union Avoidance Fails but the Theorem Holds",
+    "content": "`nonderogatory_has_cyclic_vector_finite` specializes the main theorem to `[Fintype K]`. The proof is one line — apply the main theorem — but the conceptual significance is substantial. The union avoidance argument (used for infinite fields in `cayley-hamilton-minpoly-oq-05-oq-01`) works by observing that the non-cyclic vectors form finitely many proper subspaces; over an infinite field these cannot cover $K^n$. Over $\\mathbb{F}_2$ with $n = 2$: the 3 nonzero vectors are each covered by 3 proper 1-dimensional subspaces — the union IS all of $\\mathbb{F}_2^2 \\setminus \\{0\\}$. Union avoidance fails.\n\nThe primary decomposition proof bypasses cardinality entirely. The cyclic vector $v = \\sum v_i$ is constructed algebraically from the annihilator structure. The field $K$ appears only as `[Field K]` with no cardinality hypothesis.",
+    "mathContext": "The annihilator-based argument: the CRT combination $v = \\sum_i (b_i F_i)(M) w_i$ (Bezout terms $b_i$, complementary factors $F_i$) satisfies $\\mathrm{Ann}(v) = (\\prod_i p_i^{e_i}) = (\\mathrm{minpoly})$. This holds in any $K[X]$-module, regardless of whether $K$ is finite or infinite. The only cardinality-sensitive step in the union avoidance argument — finding $v \\notin \\bigcup_p \\ker(p(M))$ — is completely bypassed.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Smith normal form",
-      "invariant factors",
-      "PID structure theorem",
-      "#print axioms",
-      "upgrade path from axiomatized to verified"
-    ],
-    "prerequisites": [
-      "Smith normal form for polynomial matrices",
-      "Elementary divisors and invariant factors",
-      "K[X]-module theory"
-    ]
+    "relatedConcepts": ["union avoidance", "finite fields", "F_2 failure case", "cardinality independence of primary decomposition"],
+    "prerequisites": ["nonderogatory_has_cyclic_vector", "union avoidance argument (OQ-01)", "primary decomposition approach"]
   },
   {
-    "id": "ann-chcvaf-axiom-vs-sorry",
+    "id": "ann-chcvaf-cyclic-characterization",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 74,
-      "endLine": 102
-    },
-    "type": "concept",
-    "title": "axiom vs sorry: Making Mathematical Assumptions Explicit",
-    "content": "In Lean 4, `sorry` closes any goal by invoking `sorryAx` (a built-in axiom), while `axiom` introduces a named constant with a specific type. Both appear in `#print axioms` output, but `axiom` is preferable for deliberate mathematical assumptions because: (1) it has a descriptive name that documents what is being assumed; (2) it cannot accidentally close other goals — it must be explicitly applied; (3) it is more honest about the nature of the assumption (a mathematical fact being assumed, not a proof being deferred). For this formalization, `axiom nonderogatory_similar_companion` clearly signals 'we assume the RCF theorem', whereas `sorry` would only indicate 'proof omitted'. The `axiomCount` in meta.json reflects explicit `axiom` declarations; `sorry` counts are tracked separately under `sorries`.",
-    "mathContext": "The distinction matters for the gallery's Axiom Integrity Policy: `axiom` declarations count toward `axiomCount`, while `sorry` counts toward `sorries`. A proof with `axiomCount = 1, sorries = 0` (this file) is more trustworthy than `axiomCount = 0, sorries = 1` (the companion OQ-04 file), because the assumption is named and scoped. Both have status `axiomatized` in the gallery, but the axiom-based version makes the assumption structurally explicit.",
+    "range": { "startLine": 219, "endLine": 230 },
+    "type": "insight",
+    "title": "Polynomial Annihilator Characterization: IFF Statement",
+    "content": "`cyclic_iff_not_killed_below_degree` gives the polynomial annihilator characterization: $v$ is cyclic for $M$ iff no nonzero polynomial $p$ of degree $< n$ annihilates $v$ under $M$.\n\nThe proof is a logic exercise. `constructor` splits into two implications:\n- Forward: if `v` is cyclic and `p ≠ 0, deg(p) < n, p(M)v = 0`, then `hcyc p hdeg hann` gives `p = 0` — contradicting `hne`.\n- Backward: to show `IsCyclicVector M v`, unfold to `∀ p ≠ 0, deg(p) < n → p(M)v ≠ 0`, which is exactly the hypothesis `h'`.\n\nThe `IsNonderogatory M` hypothesis in the signature is unused in the proof body. It documents intended use (nonderogatory matrices where `deg(minpoly) = n` makes the bound tight) without restricting the logic.",
+    "mathContext": "Formally: $v$ cyclic $\\iff$ $\\mathrm{Ann}(v) \\cap \\{p : \\deg(p) < n\\} = \\{0\\}$. Since $\\mathrm{Ann}(v)$ is an ideal of $K[X]$ (a PID), $\\mathrm{Ann}(v) = (q)$ for some $q$. The cyclic condition says $\\deg(q) \\geq n$ — i.e., the minimal polynomial of $v$ (under the $K[X]$-module action $X \\cdot v = Mv$) has degree $\\geq n = \\dim K^n$. For nonderogatory $M$, this forces $q = \\mathrm{minpoly}(M)$ and $K[X]/(q) \\cong K^n$ as $K[X]$-modules.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Lean 4 axiom declaration",
-      "sorry vs axiom",
-      "Axiom Integrity Policy",
-      "#print axioms"
-    ],
-    "prerequisites": [
-      "Lean 4 trusted kernel",
-      "sorryAx built-in"
-    ]
+    "relatedConcepts": ["aeval (polynomial evaluation at a matrix)", "mulVec", "annihilator ideal", "K[X]-module structure"],
+    "prerequisites": ["polynomial evaluation via aeval in Lean 4", "IsCyclicVector definition", "K[X]-module structure on K^n"]
   },
   {
-    "id": "ann-chcvaf-summary",
+    "id": "ann-chcvaf-v2-upgrade-summary",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields",
-    "range": {
-      "startLine": 170,
-      "endLine": 201
-    },
+    "range": { "startLine": 236, "endLine": 264 },
     "type": "context",
-    "title": "Section V: Axiom Inventory and Smith Normal Form Upgrade Path",
-    "content": "The closing `/-!` docstring (lines 174–197) provides a structured inventory of the file's five proved theorems and one axiom. The inventory distinguishes the two categories precisely:\n\n**Fully proved (sorry-free)**: `companionMatrix_cyclic_e0` and `cyclic_vector_of_similar` (both from `CayleyHamiltonMinpolyOQ05OQ01OQ04`), plus `nonderogatory_has_cyclic_vector`, `nonderogatory_has_cyclic_vector_finite`, and `cyclic_iff_not_killed_below_degree` (this file).\n\n**Axiom**: `nonderogatory_similar_companion` — the single-block rational canonical form. The docstring gives both the mathematical content (PID structure theorem for $K[X]$) and an engineering estimate for the upgrade path: ~800 lines for Smith normal form + ~200 lines for the RCF reduction from Smith to companion similarity.\n\nThe namespace closes at line 199 (`end CayleyHamiltonCyclicVectorAllFields`) and the `noncomputable section` closes at line 201 (`end`). This is a common pattern in Lean 4 for formalizations using real numbers or function extensionality: `noncomputable section` suppresses the 'declaration uses sorry' warning for noncomputable definitions, since the field operations on $K$ may not have decidable equality.",
-    "mathContext": "**Smith normal form upgrade**: Given the $n \\times n$ matrix $XI - M$ over $K[X]$, Smith normal form algorithms compute invertible $U(X), V(X) \\in \\mathrm{GL}_n(K[X])$ with $U(X)(XI - M)V(X) = \\mathrm{diag}(d_1(X), \\ldots, d_n(X))$ where $d_i \\mid d_{i+1}$. The $d_i$ are the **elementary divisors** of $XI - M$, and $\\prod_i d_i = \\mathrm{charpoly}(M)$ (by the determinant formula). For nonderogatory $M$: $d_i = 1$ for $i < n$ and $d_n = \\mathrm{charpoly}(M) = \\mathrm{minpoly}(M)$. This gives $XI - M \\sim \\mathrm{diag}(1, \\ldots, 1, \\mathrm{minpoly}(M))$ over $K[X]$, which by the module structure theorem for PIDs yields $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$, i.e., $M \\sim C(\\mathrm{minpoly}\\, M)$. The key Mathlib module `Mathlib.RingTheory.PrincipalIdealDomain` already has the abstract PID structure theorem; the gap is the Smith normal form algorithm for polynomial matrices.",
+    "title": "V2 Upgrade Summary: RCF Axiom Eliminated, Factorization Bridge Proved",
+    "content": "The closing docstring documents the V1→V2 upgrade with a precise mathematical delta:\n\n**V1 → V2 delta** (per docstring, lines 260–263):\n- Removed: `axiom nonderogatory_similar_companion` — the single-block RCF similarity theorem, requiring ~800 lines of Smith normal form + PID structure theory\n- Added: a `sorry` in `monic_factored_form` (~50 lines of normalizedFactors API)\n- Net: deep mathematical axiom → routine API exercise\n\n**Current state (V2-final)**: The `sorry` described in lines 253–258 has been filled by the four private theorems in Section II (`monic_irreducible_multiset_factorization`, `coprime_of_distinct_monic_irreducible`, `coprime_pow_of_coprime_irreducible`, `finset_factorization_from_multiset`). The docstring is stale relative to the current code.\n\nThe five proved results listed (lines 246–251) are accurate: primary decomposition and Bezout projections (WIP04), plus the three theorems in this file.",
+    "mathContext": "V1's axiom encoded the PID structure theorem for $K[X]$-modules: $K^n \\cong \\bigoplus_i K[X]/(d_i)$ with $d_1 \\mid \\cdots \\mid d_r$ the invariant factors. For nonderogatory $M$, this gives $K^n \\cong K[X]/(\\mathrm{minpoly})$, hence $M \\sim C(\\mathrm{minpoly})$. The proof requires Smith normal form for polynomial matrices ($\\sim$400 lines) + elementary divisor theory ($\\sim$200 lines) + the RCF reduction ($\\sim$200 lines). V2 needs none of this: the primary decomposition proof uses only $K[X]$ UFD structure (already in Mathlib) and the Bezout identity.",
     "significance": "context",
-    "relatedConcepts": [
-      "Smith normal form",
-      "elementary divisors",
-      "invariant factors",
-      "PID structure theorem",
-      "noncomputable section"
-    ],
-    "prerequisites": [
-      "Smith normal form for polynomial matrices",
-      "elementary divisors of XI - M",
-      "Lean 4 noncomputable section semantics"
-    ]
+    "relatedConcepts": ["V1 vs V2 architecture", "RCF similarity axiom", "monic_factored_form", "Smith normal form (not needed in V2)"],
+    "prerequisites": ["Smith normal form context (V1)", "PID structure theorem (V1)", "UFD factorization (V2)"]
   }
 ]

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -21,7 +21,7 @@
         "badge": "verified",
         "sorries": 0,
         "axiomCount": 0,
-        "lineCount": 189,
+        "lineCount": 268,
         "assumptions": "",
         "mathlib_version": "4.26.0",
         "mathlibDependencies": [
@@ -57,51 +57,51 @@
         "keyInsights": [
             "The union avoidance argument (used in `cayley-hamilton-minpoly-oq-05-oq-01` for infinite fields) is a cardinality argument that fails over $\\mathbb{F}_2$ when $n = 2$: all 3 nonzero vectors of $\\mathbb{F}_2^2$ are covered by 3 proper subspaces. Yet the theorem still holds — the RCF similarity approach is purely algebraic and works over any field.",
             "The companion matrix $C(p)$ has a built-in cyclic vector: $e_0 = (1, 0, \\ldots, 0)^T$. The orbit $\\{e_0, C(p)e_0, C(p)^2 e_0, \\ldots\\} = \\{e_0, e_1, e_2, \\ldots\\}$ is simply the standard basis. This is proved in `companionMatrix_cyclic_e0` without any hypothesis on the base field.",
-            "The single axiom `nonderogatory_similar_companion` isolates the one Mathlib gap: the structure theorem for f.g. modules over a PID (K[X]). The axiom is mathematically equivalent to the rational canonical form for nonderogatory matrices. Once Mathlib gains this infrastructure (~800 lines of Smith normal form for polynomial matrices), the axiom can be replaced by a proof.",
-            "The proof chain has minimal dependencies: `nonderogatory_similar_companion` (axiom) → `companionMatrix_cyclic_e0` (proved, uses orbit) → `cyclic_vector_of_similar` (proved, uses AlgHom) → main theorem. Each step is clean and independently verifiable.",
-            "**The $K[X]$-module interpretation of cyclicity**: Giving $K^n$ the $K[X]$-module structure where $X$ acts as $M$, cyclicity of $v$ means exactly that $v$ generates $K^n$ as a $K[X]$-module: $K[X] \\cdot v = K^n$. For nonderogatory $M$, this generator exists because $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as $K[X]$-modules — the image of $1$ under this isomorphism is the cyclic generator. The companion matrix $C(p)$ makes this structure concrete: acting on $K[X]/(p)$ via $X$, the class $\\bar{1}$ satisfies $X^k \\cdot \\bar{1} = \\bar{X^k}$, recovering exactly the orbit property $C(p)^k e_0 = e_k$ that makes $e_0$ cyclic. The axiom `nonderogatory_similar_companion` is precisely the statement that this $K[X]$-module isomorphism exists — the single gap until Mathlib formalizes the PID structure theorem for $K[X]$."
+            "The factorization bridge (`monic_factored_form`) is the key abstraction: it converts Mathlib's UFD `Multiset` output to the `Fin k`-indexed array that WIP04 expects. Four private lemmas accomplish this translation: UFD multiset factorization, coprimality of distinct monic irreducibles, coprimality lifting to prime powers, and the multiset-to-Fin-array conversion. This API translation layer is what makes the primary decomposition theorem from WIP04 applicable here.",
+            "The V2 proof chain is cleaner than V1: `monic_factored_form` (Section II, proved) → `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector` (WIP04, proved) → main theorem. Compared to V1's chain through `nonderogatory_similar_companion` (axiom) → `companionMatrix_cyclic_e0` → `cyclic_vector_of_similar`, V2 requires no companion matrix machinery and works by annihilator algebra alone.",
+            "**The $K[X]$-module interpretation of cyclicity**: Giving $K^n$ the $K[X]$-module structure where $X$ acts as $M$, cyclicity of $v$ means exactly that $v$ generates $K^n$ as a $K[X]$-module: $K[X] \\cdot v = K^n$. For nonderogatory $M$, this generator exists because $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as $K[X]$-modules. The primary decomposition proof constructs this generator directly: $v = \\sum_i v_i$ where $v_i$ generates the $p_i^{e_i}$-primary component, and the Bezout projections ensure $v$ generates the full module. No companion matrix or RCF similarity is needed — the isomorphism is realized via the CRT combination."
         ]
     },
     "sections": [
         {
             "id": "definitions",
             "title": "§ I. Definitions",
-            "startLine": 50,
-            "endLine": 74,
-            "summary": "Defines `IsCyclicVector` and `IsNonderogatory` as abbreviations for the definitions in `GeneralCyclicVector` (WIP04), ensuring type-level compatibility with the primary decomposition theorem.",
-            "mathContext": "A vector $v \\in K^n$ is cyclic for $M$ when $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is linearly independent (equivalently, no nonzero polynomial of degree $< n$ annihilates both $M$ and $v$). A matrix is nonderogatory when $\\mathrm{minpoly}_K(M) = \\mathrm{charpoly}(M)$, both of degree $n$."
+            "startLine": 48,
+            "endLine": 68,
+            "summary": "Defines `IsCyclicVector` and `IsNonderogatory` as `abbrev` (reducible) aliases for the definitions in `GeneralCyclicVector` (WIP04), ensuring type-level compatibility when delegating to the primary decomposition theorem.",
+            "mathContext": "A vector $v \\in K^n$ is cyclic for $M$ when $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is linearly independent (equivalently, no nonzero polynomial of degree $< n$ annihilates both $M$ and $v$). A matrix is nonderogatory when $\\mathrm{minpoly}_K(M) = \\mathrm{charpoly}(M)$, both of degree $n$. Using `abbrev` (not `def`) ensures that WIP04's theorem result type unifies with this file's goal type without explicit coercions."
         },
         {
             "id": "factorization-bridge",
             "title": "§ II. Factorization Bridge",
-            "startLine": 76,
-            "endLine": 98,
-            "summary": "States `monic_factored_form` (sorry): every monic polynomial of positive degree factors into coprime monic irreducible prime powers. This is a routine consequence of K[X] being a UFD; the sorry is purely Mathlib API navigation.",
-            "mathContext": "In $K[X]$ (a UFD with normalization), `normalizedFactors` decomposes any nonzero non-unit polynomial into monic irreducible factors. Grouping by multiplicity gives the prime power factorization $\\mu = \\prod_{i=1}^k p_i^{e_i}$ with pairwise coprimality (distinct primes are coprime in a UFD). The sorry isolates the Lean 4 API challenge of converting between `Multiset` (normalizedFactors output) and `Fin k`-indexed arrays (WIP04 input)."
+            "startLine": 69,
+            "endLine": 170,
+            "summary": "Four private theorems build up to `monic_factored_form`: every monic polynomial of positive degree factors into coprime monic irreducible prime powers (Fin k-indexed). All four are fully proved — the sorry described in the Section V docstring has been filled.",
+            "mathContext": "The bridge converts Mathlib's UFD output (a `Multiset` of primes from `UniqueFactorizationMonoid.exists_prime_factors`) to the `Fin k`-indexed form that WIP04 expects. Four lemmas: (1) multiset factorization from UFD; (2) distinct monic irreducibles are coprime; (3) coprimality lifts to prime powers; (4) multiset → Fin k conversion grouping by multiplicity. The combined result matches WIP04's interface contract exactly."
         },
         {
             "id": "main-theorem",
             "title": "§ III. Main Theorem",
-            "startLine": 100,
-            "endLine": 135,
-            "summary": "Proves nonderogatory_has_cyclic_vector: dispatches n=0, factors minpoly via monic_factored_form, applies WIP04's primary decomposition theorem. Zero axioms.",
-            "mathContext": "Proof: (1) Factor $\\mathrm{minpoly}_K(M) = \\prod_i p_i^{e_i}$ into coprime prime powers. (2) For each $i$, construct primary vector $v_i$ with $p_i^{e_i}(M)v_i = 0$ and $p_i^{e_i-1}(M)v_i \\neq 0$ via minimality of minpoly. (3) $v = \\sum v_i$ is cyclic: Bezout projections extract $r(M)v_i = 0$ from $r(M)v = 0$, giving $p_i^{e_i} | r$ for all $i$, hence $\\mathrm{minpoly} | r$, contradicting $\\deg(r) < n$."
+            "startLine": 172,
+            "endLine": 205,
+            "summary": "Proves `nonderogatory_has_cyclic_vector`: dispatches n=0 (trivial), then factors minpoly via `monic_factored_form` and delegates to WIP04's primary decomposition theorem. Zero axioms, zero sorries.",
+            "mathContext": "Proof: (1) $n = 0$: trivial via `Fin.elim0`. (2) $n > 0$: nonderogatory gives $\\deg(\\mathrm{minpoly}) = n$; `monic_factored_form` gives $\\mathrm{minpoly} = \\prod_i p_i^{e_i}$ (coprime prime powers); `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector` (WIP04) constructs the cyclic vector via Bezout projections."
         },
         {
             "id": "corollaries",
             "title": "§ IV. Corollaries",
-            "startLine": 137,
-            "endLine": 168,
-            "summary": "Two corollaries: nonderogatory_has_cyclic_vector_finite (specializes to finite fields) and cyclic_iff_not_killed_below_degree (polynomial annihilator reformulation).",
-            "mathContext": "The finite field corollary demonstrates that the primary decomposition approach works even when $|K| \\leq n$ — the regime where union avoidance fails. The equivalence corollary: $v$ is cyclic iff $\\forall p \\neq 0$ with $\\deg(p) < n$, $p(M)v \\neq 0$."
+            "startLine": 207,
+            "endLine": 230,
+            "summary": "Two corollaries: `nonderogatory_has_cyclic_vector_finite` (specializes to finite fields, where union avoidance fails) and `cyclic_iff_not_killed_below_degree` (polynomial annihilator reformulation).",
+            "mathContext": "The finite field corollary demonstrates that the primary decomposition approach works even when $|K| \\leq n$ — the regime where union avoidance fails over $\\mathbb{F}_2$. The equivalence corollary: $v$ is cyclic iff $\\forall p \\neq 0$ with $\\deg(p) < n$, $p(M)v \\neq 0$. Both corollaries are one-liners from the main theorem."
         },
         {
             "id": "summary-block",
             "title": "§ V. Proof Summary",
-            "startLine": 170,
-            "endLine": 189,
-            "summary": "Closing docstring: enumerates V2 improvements over V1 (axiom eliminated), the single remaining sorry (routine Mathlib API), and the delta: deep axiom → routine sorry.",
-            "mathContext": "V1 → V2 delta: RCF similarity axiom ($\\sim$800 lines to prove from PID structure theorem) replaced by `monic_factored_form` sorry ($\\sim$50 lines of `normalizedFactors` API). Net effect: the mathematical content of the proof is now fully verified; only the boilerplate of extracting a prime power factorization from Mathlib's UFD API remains."
+            "startLine": 232,
+            "endLine": 268,
+            "summary": "Closing docstring: enumerates the V2 upgrade (axiom eliminated, factorization bridge proved), lists all five proved results, and documents the V1→V2 delta. Note: the 'one sorry' in lines 253–258 refers to an earlier V2-beta state; the sorry is filled in the current file.",
+            "mathContext": "V1 → V2 delta: RCF similarity axiom ($\\sim$800 lines from PID structure theorem + Smith normal form) replaced by direct UFD-based `monic_factored_form` proof. Net: the mathematical content is fully verified with 0 axioms and 0 sorries. The Section V docstring's claim of 'one sorry' describes an intermediate development state."
         }
     ],
     "conclusion": {
@@ -122,23 +122,23 @@
             "Polynomial"
         ],
         "namespace": "CayleyHamiltonCyclicVectorAllFields",
-        "lineCount": 189,
+        "lineCount": 268,
         "axiomCount": 0,
         "theoremCount": 4,
         "definitionCount": 2,
         "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
-        "sorries": 1
+        "sorries": 0
     },
     "crossReferences": [
         {
             "targetId": "cayley-hamilton-minpoly-oq-05-oq-01",
             "relationship": "extends",
-            "description": "Converse: nonderogatory ← cyclic (proved for infinite fields using union avoidance). This file proves the opposite direction for ALL fields via the RCF similarity axiom, bypassing cardinality arguments entirely."
+            "description": "Converse: nonderogatory ← cyclic (proved for infinite fields using union avoidance). This file proves the opposite direction for ALL fields via primary decomposition (WIP04), bypassing both cardinality arguments and the RCF similarity theorem."
         },
         {
             "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
             "relationship": "companion",
-            "description": "Alternative approach using module theory with sorry. This file uses the axiom approach, giving 0 sorries and explicit axiom declaration — contrasting proof architectures for the same theorem."
+            "description": "Alternative approach using module theory with sorry. Both files now use 0 axioms; this file (V2) uses primary decomposition from WIP04 while OQ-04 uses a different module-theory approach — contrasting proof architectures for the same theorem."
         },
         {
             "targetId": "cayley-hamilton-reduction-oq-02-oq-01",


### PR DESCRIPTION
## Summary

- Rewrote all 9 annotations (V1-based with wrong line numbers) → 8 fresh V2 annotations matching the actual 268-line file
- V1 content removed: RCF similarity axiom, companion matrix orbit, V1 proof chain
- V2 content added: private UFD infrastructure (4 lemmas), monic_factored_form bridge, two-case main theorem delegating to WIP04
- Fixed all 5 section line ranges in meta.json (file grew 189 → 268 lines)
- Fixed leanFile.sorries 1 → 0 (sorry was filled by Section II private lemmas)
- Updated stale keyInsights and crossReferences that referenced the removed V1 RCF axiom

enrichment