### PR TITLE
research(hgcd): prove hgcdMatrix_row_reduction_small; document sorry falsity with counterexamples

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -29,14 +29,17 @@
   5. `lehmerCofactors_invariant_le` — strengthens (4) with the
      residue-monotonicity bound `max ahat' bhat' ≤ max ahat bhat`.
 
-  Out of scope (deferred — see `hgcdMatrix_size_reduction`):
+  Toward size reduction (PARTS VIII–IX):
+  We also prove `hgcdShift_pos` (shift ≥ 1 for large inputs) and
+  `hgcdShift_top_lt` (top-half inputs strictly decrease), which
+  enable the strong induction for Step 4. The joint bound
+  `hgcdMatrix_joint_bound` is stated as a sorry; the missing piece
+  is a "quotient stability" lemma not yet formalized here.
+
+  Out of scope (deferred):
   The bit-complexity claim O(M(n)·log n) requires a Mathlib model of
   fast multiplication and bit operations that does not yet exist.
-  Filling that gap is a multi-thousand-line foundational project. The
-  size-reduction lemma needed for the complexity claim is stated as
-  `hgcdMatrix_size_reduction` below with a focused open question; the
-  remaining piece for closing it is a Cramer-inversion entry bound on
-  the cofactor matrix.
+  Filling that gap is a multi-thousand-line foundational project.
 
   References:
     - Schönhage (1971), "Schnelle Berechnung von Kettenbruchentwicklungen"
@@ -731,45 +734,129 @@ theorem cofactor_apply_err_bound_snd (M : CofactorMatrix) (ea eb : ℤ) (C B : �
     _ = 2 * C * B := by ring
 
 -- ═══════════════════════════════════════════════════════════════
--- PART VIII: SIZE REDUCTION (deferred — open mathematical content)
+-- PART VIII: SIZE REDUCTION PREREQUISITES (Step 4 foundations)
 -- ═══════════════════════════════════════════════════════════════
 
-/-- The HGCD size-reduction lemma: applying `hgcdMatrix` to `(a, b)`
-    yields a pair `(a', b')` whose magnitude is about half of `max a b`.
+/-! ### Shift bounds — prerequisite for strong induction
 
-    This is the only non-trivial mathematical claim that distinguishes
-    HGCD from Lehmer's algorithm. Once established (with the right
-    constants), iterating HGCD gives O(log n) reductions to size 1,
-    each costing one M(n) full-precision matrix-vector multiplication
-    — yielding the O(M(n)·log n) complexity bound.
+The size-reduction proof proceeds by strong induction on `max a b`.
+The key fact enabling the induction is that the top-half inputs
+`(a / 2^s, b / 2^s)` are **strictly smaller** than `(a, b)`, so the
+induction hypothesis applies.
 
-    Stating the lemma precisely requires choosing a `bitsize` measure
-    and the constant in front of `bitsize/2`. Standard formulations:
+These lemmas establish that `hgcdShift a b ≥ 1` (for large enough
+inputs) and hence the top-half truncation truly reduces the input
+magnitude. -/
 
-      ‖M·(a,b)‖∞ ≤ ‖(a,b)‖∞ / 2 + O(1)
+/-- The half-bit shift is at least 1 when `max a b ≥ 4`.
 
-    where ‖·‖∞ is the max of bit-lengths. The O(1) absorbs the
-    "rounding" introduced by truncation of the top half.
+    Proof: `hgcdShift a b = (Nat.log 2 (max a b) + 1) / 2`.
+    Since `max a b ≥ 4 = 2²`, we have `Nat.log 2 (max a b) ≥ 2`,
+    so `(2 + 1) / 2 = 1`. -/
+theorem hgcdShift_pos (a b : ℕ) (h : 4 ≤ max a b) : 1 ≤ hgcdShift a b := by
+  simp only [hgcdShift]
+  have hlog2 : 2 ≤ Nat.log 2 (max a b) := by
+    calc 2 = Nat.log 2 4 := by native_decide
+      _ ≤ Nat.log 2 (max a b) := Nat.log_mono_right h
+  omega
 
-    A complete proof requires:
-      (a) A clean Lean definition of `bitsize` (or use Nat.log 2 + 1).
-      (b) The "advance" lemma for one HGCD step: starting from
-          (a, b) with max bitsize n, after applying the recursively
-          computed M₁ to full precision, the new max bitsize is
-          ≤ n - n/2 + c for some explicit constant c independent of n.
-      (c) Composing two such steps for the recursive call structure.
+/-- The top-half inputs `(a / 2^s, b / 2^s)` are strictly less than
+    `max a b` when `hgcdThreshold ≤ max a b`.
 
-    Open question (this proof obligation):
-    Is there a Lean-friendly statement of this lemma that avoids
-    deep dependencies on bit-complexity infrastructure? Stehlé and
-    Zimmermann (2004) give a careful analysis with explicit constants
-    for the binary-recursive variant. -/
-theorem hgcdMatrix_size_reduction :
-    ∀ (a b : ℕ), 4 ≤ max a b → True := by
-  -- Placeholder statement: when filled in, this will assert
-  -- a precise size-reduction bound on `hgcdMatrixOf a b`.
-  -- See research/problems/binary-gcd-oq-03-oq-02/knowledge.md.
-  intros; trivial
+    This is the key induction-measure decrease: the recursive calls in
+    `hgcdMatrix` pass inputs strictly smaller than the current inputs,
+    enabling strong induction on `max a b`.
+
+    Proof: since `hgcdThreshold = 64 ≥ 4`, `hgcdShift ≥ 1`, so
+    `2^s ≥ 2`, and dividing by ≥ 2 strictly decreases a positive value. -/
+theorem hgcdShift_top_lt (a b : ℕ) (h : hgcdThreshold ≤ max a b) :
+    max (a / 2 ^ hgcdShift a b) (b / 2 ^ hgcdShift a b) < max a b := by
+  have h4 : 4 ≤ max a b := by simp only [hgcdThreshold] at h; omega
+  have hpos : 1 ≤ hgcdShift a b := hgcdShift_pos a b h4
+  have hmax_pos : 0 < max a b := by omega
+  have h1lt2s : 1 < 2 ^ hgcdShift a b :=
+    Nat.one_lt_pow (by omega) (by norm_num)
+  calc max (a / 2 ^ hgcdShift a b) (b / 2 ^ hgcdShift a b)
+      ≤ max a b / 2 ^ hgcdShift a b := by
+          apply max_le
+          · exact Nat.div_le_div_right (le_max_left _ _)
+          · exact Nat.div_le_div_right (le_max_right _ _)
+    _ < max a b := Nat.div_lt_self hmax_pos h1lt2s
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART IX: SIZE REDUCTION CLAIM (joint bound — Step 4 proper)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### The joint size-reduction theorem
+
+The complete Step 4 proof proceeds by strong induction on `max a b`,
+using `hgcdShift_top_lt` to ensure the induction measure decreases at
+each recursive call.
+
+The proof requires one additional ingredient not yet in this file:
+
+**Quotient stability** (`hgcd_quotient_stable`, not yet proved):
+  The Euclidean quotients computed from the top-half approximations
+  `(a / 2^s, b / 2^s)` agree with the quotients from the full-precision
+  `(a, b)` for a sufficient number of steps.
+
+  Formally: for each step k of `lehmerCofactors`:
+    `(aHi_k / bHi_k) = (a_k / b_k)`
+  where `aHi_k, bHi_k` are the approximation residues and `a_k, b_k`
+  are the full-precision Euclidean residues.
+
+  This is proved in Stehlé-Zimmermann (2004) using the approximation
+  quality bound from `topBitsApprox_lt` in `BinaryGcdOQ03.lean`. The
+  formalization bridges the ROW-convention output (which `entry_bound`
+  bounds) to the COLUMN-convention output `M.apply(a, b)` (what we
+  actually want to bound for size reduction).
+
+**Proof sketch** (joint induction on `max a b`):
+  - Base (max a b < hgcdThreshold = 64):
+      M = lehmerCofactors 64 a b id.
+      Entry bound: entries ≤ max(a, b) < 64 from entry_bound_of_even/odd.
+      Output bound: M.apply(a, b) gives the Euclidean residues of (a, b),
+      which are bounded by max(a, b). (Requires quotient stability.)
+  - Recursive (hgcdThreshold ≤ max a b):
+      s = hgcdShift a b; M₁ = hgcdMatrix(a/2^s, b/2^s); M = M₂ · M₁.
+      By hgcdShift_top_lt: max(a/2^s, b/2^s) < max a b → IH applies.
+      IH on M₁ gives: entries(M₁) ≤ 2^(s₁+2) where s₁ = hgcdShift(a/2^s, b/2^s).
+      Full-precision apply via cofactor_apply_shift_decomp:
+        M₁.apply(a,b) = 2^s · M₁.apply(a/2^s, b/2^s) + M₁.apply(a%2^s, b%2^s).
+      Signal term: ≤ 2^s · 2^(s₁+2) ≈ 2^(3s/2 + 2) (IH output bound).
+      Error term: ≤ 2 · entries(M₁) · 2^s ≤ 2 · 2^(s₁+2) · 2^s ≈ 2^(3s/2+3).
+      Combined: max(|M₁.apply(a,b)|) ≤ 2^(3s/2 + 3).
+      IH on M₂ (applied to outputs of size ≤ 2^(3s/2+3)):
+        output M.apply(a,b) = M₂.apply(M₁.apply(a,b)) ≤ 2^s + (some additive term).
+
+  The constants above are schematic; Stehlé-Zimmermann give precise bounds
+  with C = O(1) for the binary-recursive variant.
+
+  **Classification**: HARD (requires new Lean infrastructure — quotient
+  stability proof + careful induction setup). Aristotle cannot help. -/
+
+/-- [Sorry] HGCD joint size-reduction bound.
+
+    For sufficient fuel, the column output and all matrix entries of
+    `hgcdMatrix fuel a b` are bounded by `2 ^ (hgcdShift a b + 3)`.
+
+    The `+ 3` constant is conservative (absorbs rounding and two levels
+    of recursion); a tighter analysis would give `+ 2` or `+ 1`.
+    See the proof sketch in the PART IX docstring above.
+
+    **Missing**: `hgcd_quotient_stable` — the quotient stability lemma
+    that connects the row-convention output (bounded by existing lemmas)
+    to the column-convention output `M.apply(a, b)`. -/
+theorem hgcdMatrix_joint_bound (fuel a b : ℕ) (hfuel : a + b ≤ fuel) :
+    let M := hgcdMatrix fuel a b
+    let s := hgcdShift a b
+    (M.apply (a : ℤ) (b : ℤ)).1.natAbs ≤ 2 ^ (s + 3) ∧
+    (M.apply (a : ℤ) (b : ℤ)).2.natAbs ≤ 2 ^ (s + 3) ∧
+    M.α.natAbs ≤ 2 ^ (s + 3) ∧
+    M.β.natAbs ≤ 2 ^ (s + 3) ∧
+    M.γ.natAbs ≤ 2 ^ (s + 3) ∧
+    M.δ.natAbs ≤ 2 ^ (s + 3) := by
+  sorry
 
 /-! ## Summary
 
@@ -823,11 +910,23 @@ theorem hgcdMatrix_size_reduction :
      the error component is at most `2·C·B`. This is the quantitative error
      bound combining Step 2b entry bounds with the low-bit size.
 
-**Remaining for size reduction:**
-- Step 4 (inductive): prove `hgcdMatrix_size_reduction` by fuel induction,
-  combining Steps 2a + 2b + Step 3 error bound with a bitsize argument.
-  Requires showing that `hgcdMatrix fuel aHi bHi` reduces `max(aHi, bHi)`
-  by at least half — which is the recursive core of the HGCD analysis.
+10. **Shift-position bound** (`hgcdShift_pos`): `hgcdShift a b ≥ 1` when
+    `max a b ≥ 4`. Proof: `Nat.log 2 (max a b) ≥ 2` for input ≥ 4, so
+    `(2+1)/2 = 1`. Uses `Nat.log_mono_right`.
+
+11. **Top-half strictly smaller** (`hgcdShift_top_lt`): for threshold inputs,
+    `max (a / 2^s) (b / 2^s) < max a b`. This is the **induction-measure
+    decrease** needed for the Step 4 strong induction. Proof: `2^s ≥ 2`
+    from hgcdShift_pos, then `Nat.div_lt_self`.
+
+**Remaining for size reduction (1 sorry):**
+- `hgcdMatrix_joint_bound` (PART IX): the full joint bound —
+  output and entries ≤ 2^(s+3). The induction structure is set up by
+  `hgcdShift_top_lt` (proved above). The **missing piece** is quotient
+  stability: showing that Lehmer quotients computed from top-half
+  approximations match full-precision Euclidean quotients. This connects
+  the row-convention output (bounded by entry_bound_of_even/odd) to the
+  column-convention output (M.apply a b). See PART IX docstring.
 
 **Out of scope (deferred):**
 - Bit-complexity bound O(M(n)·log n): requires Mathlib infrastructure

--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -784,69 +784,135 @@ theorem hgcdShift_top_lt (a b : ℕ) (h : hgcdThreshold ≤ max a b) :
     _ < max a b := Nat.div_lt_self hmax_pos h1lt2s
 
 -- ═══════════════════════════════════════════════════════════════
+-- PART VIII.5: ROW-CONVENTION OUTPUT BOUND (small case, proved)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- For small inputs, the HGCD matrix's ROW action yields bounded residues.
+
+    When `max a b < hgcdThreshold`, the HGCD matrix equals
+    `lehmerCofactors hgcdThreshold a b id`, and the row-vector product
+    `(a · M.α + b · M.γ, a · M.β + b · M.δ)` gives Euclidean residues
+    bounded by `max a b`.
+
+    **Convention note**: this theorem uses the ROW action, not
+    `M.apply(a, b)` (COLUMN action). The distinction is critical:
+    the row action gives GCD residues (bounded), while the column
+    action can be much larger. See the counterexample at
+    `hgcdMatrix_joint_bound` for details.
+
+    This is the small-case component of the size-reduction argument,
+    proved from `lehmerCofactors_id_apply_le` by one rewrite. -/
+theorem hgcdMatrix_row_reduction_small (fuel a b : ℕ) (h : max a b < hgcdThreshold) :
+    ∃ a' b' : ℕ,
+      (a : ℤ) * (hgcdMatrix (fuel + 1) a b).α
+        + (b : ℤ) * (hgcdMatrix (fuel + 1) a b).γ = ↑a' ∧
+      (a : ℤ) * (hgcdMatrix (fuel + 1) a b).β
+        + (b : ℤ) * (hgcdMatrix (fuel + 1) a b).δ = ↑b' ∧
+      max a' b' ≤ max a b := by
+  rw [hgcdMatrix_small h]
+  exact lehmerCofactors_id_apply_le hgcdThreshold a b
+
+-- ═══════════════════════════════════════════════════════════════
 -- PART IX: SIZE REDUCTION CLAIM (joint bound — Step 4 proper)
 -- ═══════════════════════════════════════════════════════════════
 
-/-! ### The joint size-reduction theorem
+/-! ### The joint size-reduction theorem (statement needs correction)
 
-The complete Step 4 proof proceeds by strong induction on `max a b`,
-using `hgcdShift_top_lt` to ensure the induction measure decreases at
-each recursive call.
+**FINDING (2026-05-03)**: The theorem `hgcdMatrix_joint_bound` as stated
+is **FALSE**. The column action `M.apply(a, b)` is NOT bounded by
+`2 ^ (hgcdShift a b + 3)`. Two concrete counterexamples:
 
-The proof requires one additional ingredient not yet in this file:
+**Counterexample 1** (base case, a = 31, b = 20, any fuel ≥ 1):
 
-**Quotient stability** (`hgcd_quotient_stable`, not yet proved):
-  The Euclidean quotients computed from the top-half approximations
-  `(a / 2^s, b / 2^s)` agree with the quotients from the full-precision
-  `(a, b)` for a sufficient number of steps.
+  hgcdMatrix (fuel+1) 31 20 = lehmerCofactors 64 31 20 id
+                             = ⟨α=2, β=-9, γ=-3, δ=14⟩
 
-  Formally: for each step k of `lehmerCofactors`:
-    `(aHi_k / bHi_k) = (a_k / b_k)`
-  where `aHi_k, bHi_k` are the approximation residues and `a_k, b_k`
-  are the full-precision Euclidean residues.
+  Derivation: five Lehmer steps of (31,20) with q=1,1,1,4 (stopping at r=0):
+    step 1 q=1: (20,11), M = (0, 1, 1,-1)
+    step 2 q=1: (11, 9), M = (1,-1,-1, 2)
+    step 3 q=1: ( 9, 2), M = (-1, 2, 2,-3)
+    step 4 q=4: ( 2, 1), M = (2,-9,-3,14)
+    step 5 q=2:     r=0 → STOP (r=0 returns None, final state not included)
 
-  This is proved in Stehlé-Zimmermann (2004) using the approximation
-  quality bound from `topBitsApprox_lt` in `BinaryGcdOQ03.lean`. The
-  formalization bridges the ROW-convention output (which `entry_bound`
-  bounds) to the COLUMN-convention output `M.apply(a, b)` (what we
-  actually want to bound for size reduction).
+  Column output: M.apply(31, 20) = (2·31 + (-9)·20, (-3)·31 + 14·20)
+                                 = (62 - 180, -93 + 280) = (-118, 187)
+  natAbs max = 187.
+  Required bound: 2^(hgcdShift 31 20 + 3) = 2^(2+3) = 32.
+  187 > 32 → **VIOLATED**.
 
-**Proof sketch** (joint induction on `max a b`):
-  - Base (max a b < hgcdThreshold = 64):
-      M = lehmerCofactors 64 a b id.
-      Entry bound: entries ≤ max(a, b) < 64 from entry_bound_of_even/odd.
-      Output bound: M.apply(a, b) gives the Euclidean residues of (a, b),
-      which are bounded by max(a, b). (Requires quotient stability.)
-  - Recursive (hgcdThreshold ≤ max a b):
-      s = hgcdShift a b; M₁ = hgcdMatrix(a/2^s, b/2^s); M = M₂ · M₁.
-      By hgcdShift_top_lt: max(a/2^s, b/2^s) < max a b → IH applies.
-      IH on M₁ gives: entries(M₁) ≤ 2^(s₁+2) where s₁ = hgcdShift(a/2^s, b/2^s).
-      Full-precision apply via cofactor_apply_shift_decomp:
-        M₁.apply(a,b) = 2^s · M₁.apply(a/2^s, b/2^s) + M₁.apply(a%2^s, b%2^s).
-      Signal term: ≤ 2^s · 2^(s₁+2) ≈ 2^(3s/2 + 2) (IH output bound).
-      Error term: ≤ 2 · entries(M₁) · 2^s ≤ 2 · 2^(s₁+2) · 2^s ≈ 2^(3s/2+3).
-      Combined: max(|M₁.apply(a,b)|) ≤ 2^(3s/2 + 3).
-      IH on M₂ (applied to outputs of size ≤ 2^(3s/2+3)):
-        output M.apply(a,b) = M₂.apply(M₁.apply(a,b)) ≤ 2^s + (some additive term).
+  (Note the ROW action IS bounded: 31·2 + 20·(-3) = 2, 31·(-9) + 20·14 = 1,
+   max(2,1) = 2 ≤ 31. So `hgcdMatrix_row_reduction_small` is correct.)
 
-  The constants above are schematic; Stehlé-Zimmermann give precise bounds
-  with C = O(1) for the binary-recursive variant.
+**Counterexample 2** (recursive case, a = 256, b = 141, any fuel):
 
-  **Classification**: HARD (requires new Lean infrastructure — quotient
-  stability proof + careful induction setup). Aristotle cannot help. -/
+  s = hgcdShift 256 141 = (Nat.log 2 256 + 1)/2 = 4.
+  aHi = 256/16 = 16, bHi = 141/16 = 8.
+  M₁ = lehmerCofactors 64 16 8 id: first step q=2, r=0 → STOP immediately.
+  M₁ = id.
 
-/-- [Sorry] HGCD joint size-reduction bound.
+  With M₁ = id: M₁.apply(256, 141) = (256, 141), so M₂ = hgcdMatrix fuel 256 141.
+  But this is the SAME recursion we started with! For any finite fuel k:
+    hgcdMatrix 0 256 141 = id
+    hgcdMatrix (k+1) 256 141 = (hgcdMatrix k 256 141).mul id = hgcdMatrix k 256 141
+  By induction: hgcdMatrix k 256 141 = id for ALL k.
 
-    For sufficient fuel, the column output and all matrix entries of
-    `hgcdMatrix fuel a b` are bounded by `2 ^ (hgcdShift a b + 3)`.
+  id.apply(256, 141) = (256, 141), natAbs max = 256.
+  Required bound: 2^(4+3) = 128.  256 > 128 → **VIOLATED**.
 
-    The `+ 3` constant is conservative (absorbs rounding and two levels
-    of recursion); a tighter analysis would give `+ 2` or `+ 1`.
-    See the proof sketch in the PART IX docstring above.
+**Root cause — structural issue in `hgcdMatrix`**:
 
-    **Missing**: `hgcd_quotient_stable` — the quotient stability lemma
-    that connects the row-convention output (bounded by existing lemmas)
-    to the column-convention output `M.apply(a, b)`. -/
+  When bHi | aHi (i.e., the top-half pair has r = 0 on the very first
+  Euclidean step), `lehmerCofactors` returns `id` without making any
+  progress. With M₁ = id, the recursive call gets the same (a, b) back,
+  causing the recursion to loop until fuel=0. The fuel hypothesis
+  `a + b ≤ fuel` does NOT prevent this — the natural termination
+  condition for hgcdMatrix is structural (bit-size decrease), not
+  sum-decrease.
+
+  **Fix**: add a guard in `hgcdMatrix`: if M₁ = id, fall back to
+  `lehmerCofactors hgcdThreshold a b id` on the full inputs (which
+  always terminates and is correct, though not size-reducing in one step).
+
+**What IS provable with the current definition**:
+
+  1. `hgcdMatrix_row_reduction_small` (proved above): for small inputs,
+     the ROW action `a·M.α + b·M.γ` and `a·M.β + b·M.δ` are bounded
+     by `max a b`. This is the correct formulation for small inputs.
+
+  2. Entry bounds for the SMALL case: `M.α.natAbs ≤ max a b` etc. follow
+     from `entry_bound_of_even/odd` under the row invariant.
+
+  3. For the LARGE case (recursive), the claim fails both for entries
+     and outputs when M₁ = id (trivial recursion).
+
+  **Next step**: fix `hgcdMatrix` to detect the M₁ = id case and fall
+  back, then re-state `hgcdMatrix_joint_bound` using the ROW convention:
+    `a · M.α + b · M.γ ≤ 2^(s+3)` and `a · M.β + b · M.δ ≤ 2^(s+3)`.
+
+  **Classification**: OPEN (requires fixing the definition, then a new
+  induction argument). This is more than a missing lemma — the definition
+  has a structural defect for the degenerate bHi | aHi case. -/
+
+/-- [Sorry — STATEMENT IS FALSE] HGCD joint size-reduction bound.
+
+    **⚠ WARNING: This theorem as stated is false.**
+    The COLUMN action `M.apply(a, b)` is NOT bounded by `2^(hgcdShift a b + 3)`.
+
+    Counterexample: a=31, b=20, any fuel≥1.
+      M = lehmerCofactors 64 31 20 id = ⟨2,-9,-3,14⟩.
+      M.apply(31,20) = (-118, 187).  max natAbs = 187.
+      2^(hgcdShift 31 20 + 3) = 2^5 = 32.  187 > 32.
+
+    The error is a CONVENTION MISMATCH: the existing infrastructure bounds
+    the ROW action `a·M.α + b·M.γ` (which gives Euclidean residues), not
+    the COLUMN action `M.α·a + M.β·b` (which does not).
+
+    Additionally, `hgcdMatrix` has a structural defect: when the top-half
+    approximation gives M₁ = id (degenerate case bHi | aHi), the recursion
+    loops until fuel=0. Counterexample: a=256, b=141 → id for all fuel.
+
+    See the PART IX docstring for the full analysis.
+    See `hgcdMatrix_row_reduction_small` (proved) for the correct small case. -/
 theorem hgcdMatrix_joint_bound (fuel a b : ℕ) (hfuel : a + b ≤ fuel) :
     let M := hgcdMatrix fuel a b
     let s := hgcdShift a b
@@ -919,14 +985,28 @@ theorem hgcdMatrix_joint_bound (fuel a b : ℕ) (hfuel : a + b ≤ fuel) :
     decrease** needed for the Step 4 strong induction. Proof: `2^s ≥ 2`
     from hgcdShift_pos, then `Nat.div_lt_self`.
 
-**Remaining for size reduction (1 sorry):**
-- `hgcdMatrix_joint_bound` (PART IX): the full joint bound —
-  output and entries ≤ 2^(s+3). The induction structure is set up by
-  `hgcdShift_top_lt` (proved above). The **missing piece** is quotient
-  stability: showing that Lehmer quotients computed from top-half
-  approximations match full-precision Euclidean quotients. This connects
-  the row-convention output (bounded by entry_bound_of_even/odd) to the
-  column-convention output (M.apply a b). See PART IX docstring.
+12. **Row-action bound for small inputs** (`hgcdMatrix_row_reduction_small`,
+    PART VIII.5): for `max a b < hgcdThreshold`, the HGCD matrix's ROW
+    action `(a·M.α + b·M.γ, a·M.β + b·M.δ)` gives residues bounded by
+    `max a b`. One-line proof: `rw [hgcdMatrix_small h]; exact
+    lehmerCofactors_id_apply_le hgcdThreshold a b`. This is the CORRECT
+    small-case formulation (ROW convention, not COLUMN).
+
+**Remaining for size reduction (1 sorry — statement needs correction):**
+- `hgcdMatrix_joint_bound` (PART IX): **STATEMENT IS FALSE** as written.
+  The COLUMN action `M.apply(a, b)` is NOT bounded by `2^(s+3)`.
+  Counterexample: a=31, b=20 → M.apply = (-118,187), bound = 32. VIOLATED.
+
+  **Two issues identified**:
+  1. CONVENTION MISMATCH: existing lemmas bound the ROW action; the sorry
+     claims the COLUMN action. For general matrices these differ.
+  2. STRUCTURAL DEFECT in `hgcdMatrix`: when the top-half pair has r=0
+     immediately (bHi | aHi), M₁ = id and the recursion loops until
+     fuel=0. Example: a=256, b=141 → hgcdMatrix k 256 141 = id for all k.
+
+  **Required fix**: correct `hgcdMatrix` to fall back to
+  `lehmerCofactors hgcdThreshold a b id` when M₁ = id, then re-state the
+  theorem in the ROW convention. See PART IX docstring for full analysis.
 
 **Out of scope (deferred):**
 - Bit-complexity bound O(M(n)·log n): requires Mathlib infrastructure

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -412,3 +412,89 @@ The TIGHT bound requires max_entry ≤ 2^(N/4) — which comes from knowing the 
 
 2. **Alternative step 4**: Use the WEAK size-reduction: show that if `hgcdMatrix fuel aHi bHi` is NOT the identity, then `max(output) < max(input)`. This is weaker than "by half" but shows strict decrease, which might be enough for termination-style arguments.
 
+## Session 2026-05-03 (Session 7) — Sorry Falsity + Convention Counterexamples
+
+**Mode**: REVISIT
+**Outcome**: critical finding — sorry statement is FALSE; new proved theorem added
+
+### What I Did
+
+- Analyzed `hgcdMatrix_joint_bound` (the 1 remaining sorry) in detail.
+- Traced through the Euclidean steps for concrete inputs to determine whether the COLUMN-convention bound `M.apply(a,b) ≤ 2^(s+3)` actually holds.
+- Found two concrete counterexamples proving the sorry is FALSE.
+- Added `hgcdMatrix_row_reduction_small` (proved): the CORRECT small-case bound in ROW convention.
+- Documented the falsity in the sorry docstring and PART IX header comment.
+- Updated the Summary section (now item 12).
+
+### Key Findings
+
+**Counterexample 1 — base case (a=31, b=20)**:
+
+  Tracing 5 Lehmer steps (q=1,1,1,4, stopping at r=0):
+  ```
+  M = lehmerCofactors 64 31 20 id = (α=2, β=-9, γ=-3, δ=14)
+  ```
+  Column output: `M.apply(31,20) = (-118, 187)`, natAbs max = 187.
+  Bound: `2^(hgcdShift(31,20) + 3) = 2^5 = 32`. **187 > 32 — VIOLATED.**
+
+  The ROW action IS bounded: `31·2 + 20·(-3) = 2`, `31·(-9) + 20·14 = 1`.
+  max(2,1) = 2 ≤ 31. So the row convention is fine; only column fails.
+
+**Counterexample 2 — recursive / degenerate case (a=256, b=141)**:
+
+  `hgcdShift = 4`, top-half = (16, 8).
+  `lehmerCofactors 64 16 8 id`: first step q=2, r=0 → STOP → returns `id`.
+  With M₁ = id: `M₁.apply(256,141) = (256,141)`.
+  Recursion body: `M₂ = hgcdMatrix (fuel-1) 256 141 = id` (inductive).
+  `hgcdMatrix k 256 141 = id` for ALL k.
+  `id.apply(256,141) = (256,141)`, bound = `2^7 = 128`. **256 > 128 — VIOLATED.**
+
+**Root cause — two distinct issues**:
+
+1. **Convention mismatch**: the sorry claims the COLUMN action; existing infrastructure
+   (entry_bound, lehmerCofactors_id_apply_le) bounds the ROW action. For products of
+   step matrices, these differ (row applies quotients in forward order, column in reverse).
+
+2. **Structural defect in `hgcdMatrix`**: when `bHi | aHi` (top-half gives r=0 immediately),
+   `lehmerCofactors` returns `id`, and the recursive call gets the same (a,b) back.
+   The fuel decreases but the input never reduces. This is a correctness bug in the definition,
+   not just a missing proof lemma.
+
+**New proved theorem** (`hgcdMatrix_row_reduction_small`):
+
+  ```lean
+  theorem hgcdMatrix_row_reduction_small (fuel a b : ℕ) (h : max a b < hgcdThreshold) :
+      ∃ a' b' : ℕ,
+        (a : ℤ) * (hgcdMatrix (fuel + 1) a b).α + (b : ℤ) * (hgcdMatrix (fuel + 1) a b).γ = ↑a' ∧
+        (a : ℤ) * (hgcdMatrix (fuel + 1) a b).β + (b : ℤ) * (hgcdMatrix (fuel + 1) a b).δ = ↑b' ∧
+        max a' b' ≤ max a b := by
+    rw [hgcdMatrix_small h]
+    exact lehmerCofactors_id_apply_le hgcdThreshold a b
+  ```
+
+  One-line proof using existing infrastructure. This is the correct small-case
+  size-reduction statement (ROW action bounded by max(a,b)).
+
+### Files Modified
+
+- `proofs/Proofs/BinaryGcdOQ03OQ02.lean` — added PART VIII.5 (proved theorem),
+  replaced PART IX header/sorry docstring with counterexample analysis, updated Summary.
+
+### Next Steps
+
+1. **Fix `hgcdMatrix` definition**: add fallback branch — if M₁ = id, use
+   `lehmerCofactors hgcdThreshold a b id` on the full inputs instead of recursing.
+   This restores the property that every call reduces or terminates.
+
+2. **Re-state the size-reduction theorem** in ROW convention:
+   `a · M.α + b · M.γ ≤ 2^(s+3)` and `a · M.β + b · M.δ ≤ 2^(s+3)`.
+   The COLUMN action bound is derivable from the ROW bound only if M is known
+   to be the GCD-reducing matrix (which requires quotient stability first).
+
+3. **Quotient stability**: still needed to connect the top-half Lehmer steps
+   to the full-precision Euclidean quotients. This remains the missing deep lemma.
+
+4. This session clarified that the proof plan has TWO distinct blockers (not one),
+   making the problem harder than previously assessed. BLOCKED in current form
+   until `hgcdMatrix` is fixed.
+

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 5 (2026-05-03): PROGRESS — added PART VII with 6 perturbation-infrastructure theorems (Step 3 algebraic pieces). 0 new sorries, 0 new axioms. The algebraic decomposition apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb) is proved, plus the error bound |apply(ea,eb)| ≤ 2·C·B when entries ≤ C and low-bits ≤ B. Remaining: inductive bitsize argument (Step 4).",
+    "progressSummary": "Session 7 (2026-05-03): CRITICAL FINDING — hgcdMatrix_joint_bound (the 1 remaining sorry) is FALSE as stated. Two concrete counterexamples found: (31,20) gives M.apply=(-118,187) vs bound=32; (256,141) gives hgcdMatrix=id for all fuel, id.apply=(256,141) vs bound=128. Two issues: (1) COLUMN vs ROW convention mismatch, (2) structural defect in hgcdMatrix when top-half gives r=0. Added hgcdMatrix_row_reduction_small (proved) in ROW convention. Problem now BLOCKED on definitional fix.",
     "builtItems": [
       "BinaryGcdOQ03OQ02.lean: hgcdMatrix def — fuel-indexed recursive HGCD (Schönhage). Threshold-based bottoming via lehmerCofactors; otherwise top-half-shift recursion + apply + bottom-half recursion + matrix product.",
       "BinaryGcdOQ03OQ02.lean: cofactor_mul_apply — proves CofactorMatrix.mul corresponds to composition of CofactorMatrix.apply. Algebraic kernel justifying the M₂.mul M₁ return.",
@@ -54,7 +54,8 @@
       "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_shift_decomp — apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb). Key algebraic identity for perturbation argument.",
       "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_natAbs_le — triangle bound |apply(ea,eb).1| ≤ |M.α|·|ea| + |M.β|·|eb| via Int.natAbs_add_le + Int.natAbs_mul.",
       "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound — given |M.α|,|M.β| ≤ C and |ea|,|eb| ≤ B, error component ≤ 2·C·B.",
-      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound_snd — same bound for second component using |M.γ|,|M.δ|."
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound_snd — same bound for second component using |M.γ|,|M.δ|.",
+      "BinaryGcdOQ03OQ02.lean PART VIII.5: hgcdMatrix_row_reduction_small — for small inputs (max<hgcdThreshold), ROW action of hgcdMatrix gives residues bounded by max(a,b). Proved: rw [hgcdMatrix_small h]; exact lehmerCofactors_id_apply_le hgcdThreshold a b."
     ],
     "insights": [
       "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
@@ -71,7 +72,12 @@
       "Sign alternation converts the Cramer identity into an entry BOUND (Session 4). Without sign info, the Bezout formula does not bound individual entries. With EvenPattern, all terms separate and bound M.delta <= a0 when ahat' >= 1.",
       "Entry bound hypothesis 1 <= ahat': requires algorithm to still be running. For HGCD, always satisfied: top-half cofactor applied to full-precision inputs strictly larger than top-half residues.",
       "Step 3 algebraic split is clean: apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb). Proved by ring. This reduces Step 3 to bounding the error apply(ea,eb) using Step 2b entry bounds (|M.α|,|M.β| ≤ max(aHi,bHi)) and the fact ea,eb < 2^s.",
-      "The MISSING piece for closing hgcdMatrix_size_reduction is inductive: need to show hgcdMatrix fuel aHi bHi reduces max(aHi,bHi) by at least half. This is an induction on bitsize that requires fuel to track depth — genuinely recursive and multi-session."
+      "The MISSING piece for closing hgcdMatrix_size_reduction is inductive: need to show hgcdMatrix fuel aHi bHi reduces max(aHi,bHi) by at least half. This is an induction on bitsize that requires fuel to track depth — genuinely recursive and multi-session.",
+      "hgcdMatrix_joint_bound is FALSE for the COLUMN convention. Counterexample a=31,b=20: lehmerCofactors 64 31 20 id = (2,-9,-3,14), M.apply(31,20)=(-118,187), but 2^(hgcdShift(31,20)+3)=32. 187>32.",
+      "hgcdMatrix has a structural defect: when bHi | aHi (top-half r=0 on first Euclidean step), lehmerCofactors returns id. With M1=id, the recursive call computes hgcdMatrix on the same (a,b) again. hgcdMatrix k 256 141 = id for all k.",
+      "COLUMN vs ROW convention: M.apply(a,b) = (M.alpha*a + M.beta*b, ...) is NOT the same as the row action a*M.alpha + b*M.gamma. All existing bounds use ROW convention; the sorry claimed COLUMN. Fix: re-state size-reduction in ROW convention.",
+      "hgcdMatrix_row_reduction_small (proved, Session 7): for max(a,b) < hgcdThreshold, the ROW action of hgcdMatrix gives residues bounded by max(a,b). One-line proof via hgcdMatrix_small + lehmerCofactors_id_apply_le.",
+      "Required fix for hgcdMatrix: add fallback branch — if M1 = id (top-half made no progress), use lehmerCofactors hgcdThreshold a b id on the full inputs. This prevents the infinite-loop degenerate case."
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -80,9 +86,10 @@
       "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
     ],
     "nextSteps": [
-      "Session 5 (Step 3): Perturbation bound. From a = aHi*2^s + a_lo and entries <= max(aHi,bHi), bound |M*(a_lo, b_lo)|. ~50-80 lines.",
-      "Session 6 (Step 4): Close hgcdMatrix_size_reduction with explicit constants by composing Steps 2a+2b+3.",
-      "(Optional) Wire hgcdMatrix into a recursive GCD function. ~50-100 lines.",
+      "Fix hgcdMatrix definition: add guard — if M1 = id, fall back to lehmerCofactors hgcdThreshold a b id on full inputs.",
+      "Re-state the size-reduction sorry in ROW convention: a*M.alpha + b*M.gamma <= 2^(s+3) and a*M.beta + b*M.delta <= 2^(s+3).",
+      "Quotient stability: prove that Lehmer quotients from top-half approximations match full-precision Euclidean quotients. Still the deep missing lemma.",
+      "After definition fix + ROW re-statement: attempt joint induction for size reduction.",
       "(Deferred) O(M(n)log n) complexity: blocked on Mathlib infrastructure."
     ]
   },


### PR DESCRIPTION
## Summary

- Adds `hgcdMatrix_row_reduction_small` (proved): for small inputs, the HGCD matrix ROW action yields residues bounded by `max a b`. One-line proof via `hgcdMatrix_small` + `lehmerCofactors_id_apply_le`.
- Documents that `hgcdMatrix_joint_bound` (the 1 remaining sorry) is **FALSE** as stated, with two concrete counterexamples.
- Updates knowledge.md and JSON with Session 7 analysis.

## Critical Finding

The sorry claims the COLUMN action `M.apply(a, b)` is bounded by `2^(hgcdShift a b + 3)`. This is false:

**Counterexample 1** (base case): `a=31, b=20`. Tracing 5 Lehmer steps gives `M = (2,-9,-3,14)`. Column output: `M.apply(31,20) = (-118,187)`. Bound: `2^5 = 32`. **187 > 32.**

**Counterexample 2** (structural defect): `a=256, b=141`. Top-half is `(16,8)`, which gives `r=0` on the first Euclidean step, so `M1 = id`. With `M1 = id`, the recursive call gets `(256,141)` again — the recursion loops until `fuel=0` and `hgcdMatrix k 256 141 = id` for all `k`. `id.apply(256,141) = (256,141)`, bound = `128`. **256 > 128.**

Two root causes:
1. **Convention mismatch**: existing bounds use the ROW action `a·M.alpha + b·M.gamma`, not the COLUMN action `M.apply(a,b)`.
2. **Structural defect**: when `bHi | aHi`, `lehmerCofactors` returns `id` without any progress, causing the recursion to loop.

**Fix needed**: add a guard in `hgcdMatrix` — if `M1 = id`, fall back to `lehmerCofactors hgcdThreshold a b id` on the full inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)