### PR TITLE
audit(tracker): descartes-rule-of-signs-oq-02-oq-01-oq-02 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2434,6 +2434,12 @@
       "lastAudited": "2026-04-03T17:37:21Z",
       "result": "clean"
     },
+    "descartes-rule-of-signs-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-05-02T23:46:42Z",
+      "result": "clean"
+    },
     "descartes-rule-of-signs-oq-03": {
       "auditCount": 2,
       "issues": [],


### PR DESCRIPTION
## Summary
- Mark descartes-rule-of-signs-oq-02-oq-01-oq-02 (Sturm's theorem) audit as clean
- Verified status="axiomatized", badge="axiom", sorries=0, axiomCount=1 (sturm_exact_count_axiom). Title honestly qualifies; assumptions field accurate.
- Minor metadata staleness noted (lineCount 448→459, theoremCount 22→26, defCount 8→6) — not integrity issues; defer to next enrichment pass.

## Test plan
- [x] tracker JSON validates (single-entry append, 6 lines)
- [x] no unicode escape pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)