### PR TITLE
Fix ballot-problem-oq-03-oq-01-oq-02: reconcile meta.json sorry count and stale fields

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], ≤2-col (transpose duality), exactly 3-row ALL [a,b,c] shapes, exactly 4-row ALL [a,b,c,d] shapes (PART XVIII), exactly 5-row ALL [a,b,c,d,e] shapes (PART XIX), exactly 6-row ALL [a,b,c,d,e,f] shapes (PART XX), exactly 7-row ALL [a,b,c,d,e,f,g] shapes (PART XXI), exactly 8-row ALL [a,b,c,d,e,f,g,h] shapes (PART XXII), exactly 9-row ALL [a,b,c,d,e,f,g,h,i] shapes (PART XXIII). General formula has 1 remaining sorry: hook_walk_identity for ≥10-row, ≥10-col, non-rectangular shapes (GNW probabilistic argument, ~300 lines). The 2 previously-stated LGV sorries were dead scaffolding and have been removed.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], ≤2-col (transpose duality), exactly 3-row ALL [a,b,c] shapes, exactly 4-row ALL [a,b,c,d] shapes (PART XVIII), exactly 5-row ALL [a,b,c,d,e] shapes (PART XIX), exactly 6-row ALL [a,b,c,d,e,f] shapes (PART XX), exactly 7-row ALL [a,b,c,d,e,f,g] shapes (PART XXI), exactly 8-row ALL [a,b,c,d,e,f,g,h] shapes (PART XXII), exactly 9-row ALL [a,b,c,d,e,f,g,h,i] shapes (PART XXIII). General formula has 5 remaining sorries in GNW infrastructure: gnwProb_key (GNW 1979 probabilistic identity, hard), gnwProb_sum_corners (standard induction), and three TRIVIAL strictHookCells_* lemmas. The 2 previously-stated LGV sorries were dead scaffolding and have been removed; hookProd_ratio_formula is now sorry-free.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,11 +19,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 5,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "One open sorry: hook_walk_identity for ≥10 rows AND ≥10 cols AND non-rectangular shapes (GNW probabilistic proof, ~300 lines). Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row, exactly 4-row, exactly 5-row, exactly 6-row, exactly 7-row, exactly 8-row, exactly 9-row, ≤9-col (transpose duality), all rectangles. The alternate LGV proof path is documented in PART V as a canonical-config restatement; previously-stated arbitrary-parameter LGV sorries were removed in session 32 as dead, unprovable scaffolding. hook_length_formula_general is proved modulo the single hook_walk_identity sorry.",
-    "lineCount": 14022,
+    "assumptions": "5 open sorries in GNW infrastructure (BallotProblemOQ03OQ01OQ02Helpers.lean): (1) gnwProb_key — the GNW 1979 probabilistic identity for ≥10-row, ≥10-col, non-rectangular shapes (hard); (2) gnwProb_sum_corners — standard induction step (hard); (3-5) strictHookCells_card, strictHookCells_nonempty, strictHookCells_hookLen_lt — TRIVIAL (disjointness/cardinality/inequality lemmas, omega-provable). hook_walk_identity_gnw (the dispatcher in the gallery face) calls these and is otherwise complete. hookProd_ratio_formula is now sorry-free. Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row through 9-row, ≤9-col (transpose duality), all rectangles.",
+    "lineCount": 14148,
     "theoremCount": 484,
     "definitionCount": 14,
     "originalContributions": [
@@ -42,8 +42,8 @@
       "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)",
       "Numerical verification: hook-length formula proved for (2,1), (2,2), (3,1), (3,2), (3,2,1), (4,3,2,1), (3,3), (4,4) shapes",
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
-      "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (1 sorry: ~50 lines Finset.prod_union decomposition)",
-      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — at-most-2-row case proved; ≥3-row case has 1 sorry (~300 lines GNW/RSK)",
+      "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (0 sorries — Finset.prod_union decomposition complete)",
+      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — dispatcher (hook_walk_identity_gnw) in gallery face is sorry-free; open sorries live in GNW infrastructure lemmas (gnwProb_key, gnwProb_sum_corners, three TRIVIAL strictHookCells_* lemmas in Helpers)",
       "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)",
       "corners_gHookYD_cases: characterizes all corners of [a,1^b] as either (0,a-1) with a≥2 or (b,0) (proved, 0 sorries, session 19)",
       "hook_walk_identity_gHookYD: hook walk identity Σ_c hookProd/hookProd(μ\\c)=|μ| proved for all [a,1^b] with b≥1, non-circular via hook_length_formula_gHookYD (session 19)",
@@ -72,7 +72,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. Part XIV adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity. Total: 5 sorries (3 LGV path + 2 corner induction: hookProd_ratio_formula + hook_walk_identity ≥3-row).",
+    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b]. hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. hookProd_ratio_formula is sorry-free. Part XIV proves hook_length_formula_general via corner induction; hook_walk_identity_gnw dispatcher is complete. 5 open sorries remain in GNW infrastructure: gnwProb_key (hard), gnwProb_sum_corners (hard), and three TRIVIAL strictHookCells_* lemmas.",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -91,9 +91,9 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 14022,
+    "lineCount": 399,
     "axiomCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 482,
     "definitionCount": 22
@@ -202,5 +202,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 1
+  "sorries": 5
 }


### PR DESCRIPTION
## Fix

Reconcile `meta.json` for `ballot-problem-oq-03-oq-01-oq-02` to match the current Lean source state after the gallery face was split into face + Helpers + Aristotle companion files.

## Evidence

**Before**: `meta.sorries: 1`, `leanFile.sorries: 1`, `leanFile.lineCount: 14022`, `meta.lineCount: 14022`

**After**:
- `meta.sorries: 5` — gallery face has 0 sorries; 5 open sorries live in `BallotProblemOQ03OQ01OQ02Helpers.lean`
- `leanFile.sorries: 0` — the gallery face file has 0 sorries
- `leanFile.lineCount: 399` — face file is 399 lines (not stale 14022)
- `meta.lineCount: 14148` — face (399) + Helpers (13749)
- `assumptions`: rewritten to enumerate all 5 GNW sorries accurately
- `conclusion.summary`: replaces stale framing
- `originalContributions`: updated hookProd_ratio_formula (0 sorries) and hook_walk_identity entries

Closes #14940

---
Automated fix by lean-mechanic agent.