### PR TITLE
audit: ballot-problem-oq-03-oq-01-oq-02 issues-fixed (Helpers additionalFiles)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -52,6 +52,9 @@
       "hook_walk_identity_gHookYD: hook walk identity Σ_c hookProd/hookProd(μ\\c)=|μ| proved for all [a,1^b] with b≥1, non-circular via hook_length_formula_gHookYD (session 19)",
       "hook_walk_identity_eightRow: hook walk identity proved for ALL exactly-8-row Young diagrams [a,b,c,d,e,f,g,h] via 7 colLen zones, 36 hookLen lemmas, 8 arm product lemmas, field_simp+ring; 1612 lines, 0 sorries (PART XXII)",
       "hook_walk_identity_nineRow: hook walk identity proved for ALL exactly-9-row Young diagrams [a,b,c,d,e,f,g,h,i] via colLen zones, hookLen lemmas, arm product lemmas, field_simp+ring; 0 sorries (PART XXIII)"
+    ],
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Adds `meta.additionalFiles: [Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean]` so the auditor's sorry-count check aggregates over the gallery face + its Helpers companion.
- Resolves a persistent (3 audits in a row) `sorry mismatch: claims 5, actual 0` flag.

## Why
The find-targets script only auto-follows `*Aristotle.lean` for single-level `Proofs.X` imports; non-Aristotle Helpers companions must be declared via `additionalFiles`. Gallery face has 0 sorries, Helpers has 5, and `meta.sorries=5` is correct. Without this declaration the script saw face-only (0) and flagged the 5 vs 0 mismatch every cycle.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --issues` returns 0 issues after the change
- [x] No tracker unicode-escape pollution (re-applied entry by hand per the known claim-target.sh bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)