### PR TITLE
audit(tracker): erdos-554 issues-found (#14969)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7919,9 +7919,12 @@
     },
     "erdos-554": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T11:47:18Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T00:38:10Z",
+      "result": "issues-found",
+      "issues": [
+        "phantom contributions in originalContributions: triangle_ramsey_exponential, triangle_ramsey_upper, oddCycle_ramsey_upper, oddCycle_ramsey_lower (docstrings only, not declared)"
+      ]
     },
     "erdos-555": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Bumps audit tracker for `erdos-554` to `issues-found` after re-audit at origin/main 3891c2b.

Filed integrity issue #14969: 4 named bounds in `meta.originalContributions` (`triangle_ramsey_exponential`, `triangle_ramsey_upper`, `oddCycle_ramsey_upper`, `oddCycle_ramsey_lower`) are not declared anywhere in `proofs/Proofs/Erdos554Problem.lean` — they exist only as informal docstring text in Part III. `grep` returns zero matches for any of the four names.

`status: axiomatized` and `badge: axiom` remain correct (3 real axioms).

## Test plan
- [x] tracker JSON re-serialized with `ensure_ascii=False` to avoid the `→`/`—` escape pollution from `claim-target.sh complete`
- [x] only the `erdos-554` entry changed (6 +/3 - in single entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)