### PR TITLE
audit: ballot-problem-oq-03-oq-01-oq-02 (additionalFiles fix)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-04-21",
     "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
+    ],
     "tags": [
       "combinatorics",
       "young-tableaux",


### PR DESCRIPTION
## Summary

- Add `BallotProblemOQ03OQ01OQ02Helpers.lean` to `additionalFiles` so the audit script counts the documented sorries.

## Context

`find-targets.ts` reported a recurring false-positive sorry mismatch: "claims 5, actual 0". The 5 sorries the meta.json documents are real GNW infrastructure sorries living in the Helpers file imported by the gallery face. The audit script's resolver only follows single-level `Proofs.X` imports when `X` ends with `Aristotle`, so the Helpers file was never counted.

After this change:
- Helpers contributes its 5 sorries → audit now sees `actual = 5 = claimed`.
- Issue clears in `find-targets.ts --issues`.

No content/claim changes.

## Test plan
- [x] `python -m json.tool` validates the JSON
- [x] `npx tsx scripts/auditor/find-targets.ts --issues` reports 0 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)