### PR TITLE
Fix ballot-problem-oq-03-oq-01-oq-02: stale originalContributions and leanFile after Helpers split

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -39,7 +39,7 @@
       "twoRowYD: general 2-row Young diagram [a,b] for a≥b",
       "hookProd_twoRowYD: hookProd([a,b]) = (a+1).descFactorial b × (a-b)! × b! (proved, 0 sorries)",
       "two_row_hook_identity: numerical identity ballotSeqCount(a+1,b) × hookProd = (a+b)! (proved, 0 sorries)",
-      "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)",
+      "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (proved, 0 sorries)",
       "Numerical verification: hook-length formula proved for (2,1), (2,2), (3,1), (3,2), (3,2,1), (4,3,2,1), (3,3), (4,4) shapes",
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
       "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (0 sorries — Finset.prod_union decomposition complete)",
@@ -91,10 +91,10 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 399,
+    "lineCount": 13749,
     "axiomCount": 0,
-    "sorries": 0,
-    "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
+    "sorries": 5,
+    "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
     "theoremCount": 482,
     "definitionCount": 22
   },


### PR DESCRIPTION
## Fix

Two stale claims in meta.json survived the face/Helpers split in PRs #14940 and #14951.

## Evidence

**Fix 1 — originalContributions[12]** (stale sorry claim):

**Before**: `"hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)"`
**After**: `"hook_length_formula_two_row_gen: formula for general 2-row [a,b] (proved, 0 sorries)"`

Reality: `card_SYT_twoRowYD` is fully proved by WF induction at `BallotProblemOQ03OQ01OQ02Helpers.lean:4182-4199`; `hook_length_formula_two_row_gen` at lines 4259-4264 has 0 sorries.

**Fix 2 — leanFile.path/lineCount/sorries** (stale file reference):

**Before**: `path: Proofs/BallotProblemOQ03OQ01OQ02.lean` (399 lines, 0 sorries)
**After**: `path: Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (13749 lines, 5 sorries)

All sections (sec-ghookyd: 644-1826, sec-general-two-row: 3473-4327, sec-corner-induction: 4329-4725, sec-transpose-nrow: 5183-13633) reference lines in the Helpers file, not the 399-line face file. The leanFile fields now correctly reference the file where the actual proof infrastructure lives.

Closes #14955

---
Automated fix by lean-mechanic agent.