### PR TITLE
fix(erdos-1139): restore missing axioms erdos_1139 and hardy_ramanujan_asymptotic

### DIFF
--- a/proofs/Proofs/Erdos1139Problem.lean
+++ b/proofs/Proofs/Erdos1139Problem.lean
@@ -151,6 +151,13 @@ theorem almostPrimes_contain_primes (N : ℕ) :
 /-- Erdős Problem #1139 (OPEN): The gaps in the almost-prime sequence
     grow faster than any multiple of log k.
     lim sup (u_{k+1} - u_k) / log k = ∞ -/
+axiom erdos_1139 :
+  ∀ C : ℝ, 0 < C →
+    ∀ K : ℕ, ∃ k : ℕ, K ≤ k ∧
+      C * Real.log (k : ℝ) < (almostPrimeGap k : ℝ)
+
+-- ## Part 7: Gap Lower Bound from Consecutive Cubes
+
 /-- Between consecutive cubes n³ and (n+1)³, there are no integers with
     Ω(m) ≤ 2 if 8 | m (since Ω(8k) ≥ 3). This gives a structural source
     of gaps. -/
@@ -175,4 +182,11 @@ theorem cube_gap_obstruction (n : ℕ) (hn : 2 ≤ n)
     (N / log N) · (log log N)^{k-1} / (k-1)!  (Landau-Ramanujan).
     For k ≤ 2, the almost-prime counting function π₂(N) satisfies
     π₂(N) ~ cN · log log N / log N for some constant c > 0. -/
+axiom hardy_ramanujan_asymptotic :
+  ∃ c : ℝ, 0 < c ∧
+    ∀ ε : ℝ, 0 < ε →
+      ∃ X₀ : ℕ, ∀ X : ℕ, X₀ ≤ X →
+        ((almostPrimesUpTo X).card : ℝ) ≥
+          c * (1 - ε) * (X : ℝ) * Real.log (Real.log (X : ℝ)) / Real.log (X : ℝ)
+
 end Erdos1139

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1139,
     "erdosUrl": "https://erdosproblems.com/1139",
@@ -49,9 +49,9 @@
       "erdos_1139: main conjecture lim sup gap/log k = ∞"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 0,
-    "lineCount": 178,
-    "assumptions": "0 axioms, 0 sorries. The open conjecture (lim sup of gaps / log k = ∞) and the Landau-Ramanujan density estimate are described in comments but are not formalized — no axiom declarations exist in the Lean file. 16 infrastructure theorems fully proved."
+    "axiomCount": 2,
+    "lineCount": 192,
+    "assumptions": "2 axioms: erdos_1139 (the open conjecture: lim sup gap/log k = ∞) and hardy_ramanujan_asymptotic (Landau-Ramanujan density: π₂(N) ~ cN log log N / log N). 16 theorems fully proved."
   },
   "overview": {
     "historicalContext": "Erdős #1139 asks about the distribution of gaps in the sequence of integers with at most 2 prime factors (primes and semiprimes). The study of almost-primes dates to Viggo Brun's 1915 sieve work, which first established that the sum of reciprocals of twin primes converges — in contrast to the divergent sum over primes. The counting function for integers with at most $k$ prime factors was studied by Landau (1900) and refined by Ramanujan, Sathe (1953), and Selberg (1954), giving the asymptotic $\\pi_2(N) \\sim cN \\log \\log N / \\log N$. Despite the almost-primes being denser than the primes by a factor of $\\log \\log N$, Erdős conjectured that their gaps still grow faster than $\\log k$. This is surprising: for primes, Cramér's conjecture predicts gaps of order $(\\log p)^2$, and one might expect the denser almost-prime sequence to have comparatively tamer gaps. The problem connects to Maier's 1985 theorem showing irregularities in prime distribution that defeat simple probabilistic models, and to the Jacobsthal function measuring maximal gaps in sieved sequences.",
@@ -152,8 +152,8 @@
     ],
     "opens": [],
     "namespace": "Erdos1139",
-    "lineCount": 178,
-    "axiomCount": 0,
+    "lineCount": 192,
+    "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 6,
     "path": "Proofs/Erdos1139Problem.lean",

--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -25,6 +25,18 @@
     ]
   },
   {
+    "id": "ann-qroq03-namespace-setup",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": { "startLine": 37, "endLine": 47 },
+    "type": "context",
+    "title": "Lean Setup: Linting, Open, and Namespace",
+    "content": "Three short lines before the first theorem:\n\n- `set_option linter.unusedVariables false` — silences a linter warning for the `hqp : q < p` hypothesis in `algorithm_descent`, which is intentionally present for its type-level guarantee but not used in the proof body.\n- `open ZMod` — brings `ZMod`-specific definitions, lemmas, and `Decidable` instances into scope. This is what allows `decide` to discharge Legendre symbol equalities: without the `ZMod` decidability infrastructure, `decide` on `legendreSym p a = n` would not type-check.\n- `namespace QRAlgorithm` — groups all four reduction lemmas under a single namespace, so consumers import them as `QRAlgorithm.legendreSym_mul_eq` etc., making the algorithmic origin clear at the use site.",
+    "mathContext": "The `set_option` is a principled design choice: `hqp : q < p` is a *specification* input (its presence at the type level documents the descent invariant) even though the proof itself does not need it (the underlying `reciprocity_swap` works without the ordering hypothesis). This pattern — adding hypothesis for documentation, suppressing the linter — is common in verified algorithm presentations.",
+    "significance": "context",
+    "relatedConcepts": ["set_option", "open ZMod", "namespace", "Decidable instances", "linter.unusedVariables"],
+    "prerequisites": ["Lean 4 namespace system", "Lean 4 linting infrastructure", "ZMod type"]
+  },
+  {
     "id": "ann-multiplicativity",
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {
@@ -112,7 +124,7 @@
     },
     "type": "concept",
     "title": "Verified Examples via decide",
-    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |",
+    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign: $(7/11) = -(11/7) = -(4/7) = -1$ |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |\n\n**Note on the (5/13) docstring**: the Lean source docstring for this example opens with the incorrect claim `(5/13) = 1 (5 is a quadratic residue mod 13)` and then trails off with `wait, need to check`. This is a draft artifact — the QRs mod 13 are $\\{1, 3, 4, 9, 10, 12\\}$, so 5 is *not* a QR mod 13 and `(5/13) = -1` is correct. The `decide` kernel confirms the right answer; the docstring is simply unfinished.",
     "mathContext": "`decide` works here because Mathlib's `legendreSym p a` is implemented via Euler's criterion in `ZMod p` — for a concrete small prime $p$, `ZMod p` is a `Fintype`, so the equality $a^{(p-1)/2} = \\pm 1$ in `ZMod p` is decidable and Lean can evaluate it during elaboration. No `native_decide` is needed because the search space is tiny ($p \\le 17$). The seven examples are not just illustrative: they exercise multiplicativity (last row), the second supplementary law (rows 2 and 6), and the reciprocity swap (rows 1, 3, 4) — each reduction lemma in this file gets a worked instance.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/research/problems/erdos-1139.json
+++ b/src/data/research/problems/erdos-1139.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 2A (open conjecture + density asymptotic), 16T proved, 0S. Restored axioms after bulk-removal.",
+    "progressSummary": "RESTORED: axioms erdos_1139 and hardy_ramanujan_asymptotic re-added. 16T, 2A, 0S. Status: axiomatized.",
     "builtItems": [
       "Created Erdos1139Problem.lean (157 lines, 11 theorems, 2 axioms, 3 sorries)",
       "Proved prime_isAlmostPrime, four_isAlmostPrime, eight_not_almostPrime",
@@ -53,7 +53,8 @@
       "Nat.nth provides 0-indexed enumeration with strictMono, mem_of_infinite, nth_count API",
       "Classical.decPred needed since bigOmega is noncomputable (uses Finsupp.sum)",
       "Confirmed complete: 2 axioms are open conjecture and deep density result",
-      "Axioms erdos_1139 and hardy_ramanujan_asymptotic restored after c34e89c6 bulk cleanup incorrectly removed them as unused (they formally state the open problem)"
+      "Axioms erdos_1139 and hardy_ramanujan_asymptotic restored after c34e89c6 bulk cleanup incorrectly removed them as unused (they formally state the open problem)",
+      "axioms erdos_1139 and hardy_ramanujan_asymptotic restored to Lean file (were missing since c34e89c6 bulk cleanup; research JSON claimed restore but file was 0-axiom)"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary

Restores two axioms that were removed from Erdos1139Problem.lean by a bulk cleanup (c34e89c6) and never properly re-added despite the research JSON claiming they were restored.

## Problem

The gallery entry `erdos-1139` had:
- `meta.axiomCount = 0`, `badge = "wip"`, `assumptions = "0 axioms"`
- Research JSON claimed "2A (open conjecture + density asymptotic), Restored axioms"
- The Lean file confirmed: NO axiom declarations, only 16 proved theorems

This meant the main open conjecture was not formally stated anywhere in the Lean file.

## Changes

- Restores `axiom erdos_1139`: `∀ C > 0, ∀ K, ∃ k ≥ K, C·log k < almostPrimeGap k`
  (the open conjecture: lim sup (u_{k+1} - u_k) / log k = ∞)
- Restores `axiom hardy_ramanujan_asymptotic`: density estimate π₂(N) ≥ c(1-ε)·N·log log N/log N
- Updates meta.json: `axiomCount` 0 → 2, `badge` "wip" → "axiom", `lineCount` 178 → 192
- Updates `assumptions` field to accurately describe the 2 axioms

## Verification

Both axiom statements match the original forms from PR #8475 (commit 917ac7179f0 "axiom restore").

Generated by researcher-10