### PR TITLE
research(erdos-321): prove maxDistinctReciprocal_ge_one, fix meta theoremCount

### DIFF
--- a/proofs/Proofs/Erdos321Problem.lean
+++ b/proofs/Proofs/Erdos321Problem.lean
@@ -133,6 +133,22 @@ noncomputable def maxDistinctReciprocal (N : ℕ) : ℕ :=
     (Finset.range (N + 1)).powerset)
     Finset.card
 
+/-- R(N) ≥ 1 for all N ≥ 1: the singleton {1} witnesses the lower bound. -/
+theorem maxDistinctReciprocal_ge_one (N : ℕ) (hN : N ≥ 1) :
+    1 ≤ maxDistinctReciprocal N := by
+  unfold maxDistinctReciprocal
+  have hmem : ({1} : Finset ℕ) ∈ Finset.filter
+      (fun A => HasDistinctReciprocalSums A ∧ ∀ n ∈ A, 1 ≤ n ∧ n ≤ N)
+      (Finset.range (N + 1)).powerset := by
+    simp only [Finset.mem_filter, Finset.mem_powerset, Finset.singleton_subset_iff,
+               Finset.mem_range, Finset.mem_singleton]
+    exact ⟨by omega, singleton_hasDistinctReciprocalSums 1 le_rfl,
+           fun n hn => hn ▸ ⟨le_rfl, hN⟩⟩
+  have : ({1} : Finset ℕ).card ≤ Finset.sup (Finset.filter
+      (fun A => HasDistinctReciprocalSums A ∧ ∀ n ∈ A, 1 ≤ n ∧ n ≤ N)
+      (Finset.range (N + 1)).powerset) Finset.card := Finset.le_sup hmem
+  simpa using this
+
 /- ## Known Bounds -/
 
 /-- **Bleicher–Erdős lower bound (1975)**: R(N) ≥ c·N/log N for all large N.

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -18,11 +18,12 @@
     "sourceUrl": "https://erdosproblems.com/321",
     "erdosUrl": "https://erdosproblems.com/321",
     "axiomCount": 2,
+    "theoremCount": 9,
     "assumptions": "2 axioms: bleicher_erdos_lower (R(N) \u2265 N/log N, Bleicher\u2013Erd\u0151s 1975) and bleicher_erdos_upper (R(N) \u2264 C\u00b7(N/log N)\u00b7log log N, 1976). Open problem \u2014 precise asymptotic of R(N) remains unknown.",
     "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 174,
+    "lineCount": 190,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sup",
@@ -40,7 +41,8 @@
       "Proved equivalence of two subset sum formulations (distinct subsets \u2194 injective map)",
       "Proved hereditary property: subsets of sets with distinct reciprocal sums inherit distinctness",
       "Proved conjecture holds trivially for A = {1,...,N} (erdos_321_asymptotics)",
-      "Connected Bleicher\u2013Erd\u0151s bounds to Egyptian fraction theory and greedy algorithms"
+      "Connected Bleicher\u2013Erd\u0151s bounds to Egyptian fraction theory and greedy algorithms",
+      "maxDistinctReciprocal_ge_one: PROVED \u2014 R(N) \u2265 1 for N \u2265 1, witnessed by singleton {1} \u2208 {1,...,N}"
     ],
     "prerequisites": [
       "Combinatorial number theory (subset sums, extremal problems)",
@@ -76,25 +78,25 @@
     },
     {
       "id": "r-definition",
-      "title": "R(N) Definition",
+      "title": "R(N) Definition and Lower Bound",
       "startLine": 126,
-      "endLine": 134,
-      "summary": "Defines `maxDistinctReciprocal N` as the maximum cardinality over subsets of $\\{1,\\ldots,N\\}$ with distinct reciprocal sums, via `Finset.sup` over the filtered powerset.",
-      "mathContext": "$R(N) = \\max\\{|A| : A \\subseteq [N], \\text{ all reciprocal subset sums distinct}\\}$, noncomputable due to the existential in the filter predicate."
+      "endLine": 150,
+      "summary": "Defines `maxDistinctReciprocal N` as the maximum cardinality over subsets of $\\{1,\\ldots,N\\}$ with distinct reciprocal sums, via `Finset.sup` over the filtered powerset. `maxDistinctReciprocal_ge_one` (PROVED, line 137): $R(N) \\geq 1$ for all $N \\geq 1$, witnessed by the singleton $\\{1\\}$.",
+      "mathContext": "$R(N) = \\max\\{|A| : A \\subseteq [N], \\text{ all reciprocal subset sums distinct}\\} \\geq 1$ since $\\{1\\} \\subseteq [N]$ trivially has distinct sums ($0 \\neq 1$)."
     },
     {
       "id": "known-bounds",
       "title": "Bleicher-Erd\u0151s Bounds (Axiomatized)",
-      "startLine": 136,
-      "endLine": 155,
+      "startLine": 152,
+      "endLine": 175,
       "summary": "Three doc-comment descriptions of the known bounds: lower bound $R(N) \\geq N/\\log N$ (Bleicher-Erd\u0151s 1975, constructive via prime factorization), upper bound $R(N) \\leq C \\cdot (N/\\log N) \\cdot \\log\\log N$ (1976, counting argument via $\\text{lcm}(1,\\ldots,N)$), and combined $\\Theta(N/\\log N)$ statement.",
       "mathContext": "$c_1 \\cdot \\frac{N}{\\log N} \\leq R(N) \\leq c_2 \\cdot \\frac{N \\log\\log N}{\\log N}$. The gap is one iterated logarithm factor."
     },
     {
       "id": "main-conjecture",
       "title": "Erd\u0151s Problem #321: Exact Asymptotics (OPEN)",
-      "startLine": 143,
-      "endLine": 155,
+      "startLine": 177,
+      "endLine": 190,
       "summary": "States the main problem: determine the exact asymptotic behavior of $R(N)$. The formal theorem `erdos_321_asymptotics` is tautological (take $f = R$, proved by `rfl`). The real open problem is finding an explicit closed-form for the iterated log correction.",
       "mathContext": "The conjecture: is $\\lim_{N \\to \\infty} R(N) \\cdot \\log N / N = c$ for some constant $c > 0$, or do iterated log corrections persist?"
     }
@@ -183,9 +185,9 @@
     }
   ],
   "leanFile": {
-    "lineCount": 174,
+    "lineCount": 190,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 3,
     "imports": [
       "Mathlib.Data.Finset.Basic",
@@ -216,6 +218,11 @@
         "name": "erdos_321_asymptotics",
         "type": "tautology",
         "description": "Tautological existence: \u2203 f, R(N) = f(N), proved by rfl \u2014 the real content is the axiomatized Bleicher\u2013Erd\u0151s bounds"
+      },
+      {
+        "name": "maxDistinctReciprocal_ge_one",
+        "type": "original",
+        "description": "R(N) \u2265 1 for all N \u2265 1: singleton {1} is a valid witness \u2014 proves {1} \u2208 filtered powerset via Finset.le_sup"
       }
     ],
     "path": "Proofs/Erdos321Problem.lean",

--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -25,6 +25,18 @@
     ]
   },
   {
+    "id": "ann-qroq03-namespace-setup",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": { "startLine": 37, "endLine": 47 },
+    "type": "context",
+    "title": "Lean Setup: Linting, Open, and Namespace",
+    "content": "Three short lines before the first theorem:\n\n- `set_option linter.unusedVariables false` — silences a linter warning for the `hqp : q < p` hypothesis in `algorithm_descent`, which is intentionally present for its type-level guarantee but not used in the proof body.\n- `open ZMod` — brings `ZMod`-specific definitions, lemmas, and `Decidable` instances into scope. This is what allows `decide` to discharge Legendre symbol equalities: without the `ZMod` decidability infrastructure, `decide` on `legendreSym p a = n` would not type-check.\n- `namespace QRAlgorithm` — groups all four reduction lemmas under a single namespace, so consumers import them as `QRAlgorithm.legendreSym_mul_eq` etc., making the algorithmic origin clear at the use site.",
+    "mathContext": "The `set_option` is a principled design choice: `hqp : q < p` is a *specification* input (its presence at the type level documents the descent invariant) even though the proof itself does not need it (the underlying `reciprocity_swap` works without the ordering hypothesis). This pattern — adding hypothesis for documentation, suppressing the linter — is common in verified algorithm presentations.",
+    "significance": "context",
+    "relatedConcepts": ["set_option", "open ZMod", "namespace", "Decidable instances", "linter.unusedVariables"],
+    "prerequisites": ["Lean 4 namespace system", "Lean 4 linting infrastructure", "ZMod type"]
+  },
+  {
     "id": "ann-multiplicativity",
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {
@@ -112,7 +124,7 @@
     },
     "type": "concept",
     "title": "Verified Examples via decide",
-    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |",
+    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign: $(7/11) = -(11/7) = -(4/7) = -1$ |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |\n\n**Note on the (5/13) docstring**: the Lean source docstring for this example opens with the incorrect claim `(5/13) = 1 (5 is a quadratic residue mod 13)` and then trails off with `wait, need to check`. This is a draft artifact — the QRs mod 13 are $\\{1, 3, 4, 9, 10, 12\\}$, so 5 is *not* a QR mod 13 and `(5/13) = -1` is correct. The `decide` kernel confirms the right answer; the docstring is simply unfinished.",
     "mathContext": "`decide` works here because Mathlib's `legendreSym p a` is implemented via Euler's criterion in `ZMod p` — for a concrete small prime $p$, `ZMod p` is a `Fintype`, so the equality $a^{(p-1)/2} = \\pm 1$ in `ZMod p` is decidable and Lean can evaluate it during elaboration. No `native_decide` is needed because the search space is tiny ($p \\le 17$). The seven examples are not just illustrative: they exercise multiplicativity (last row), the second supplementary law (rows 2 and 6), and the reciprocity swap (rows 1, 3, 4) — each reduction lemma in this file gets a worked instance.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
## Summary

- Prove `maxDistinctReciprocal_ge_one`: R(N) ≥ 1 for all N ≥ 1, witnessed by {1}
- Fix meta.json: `meta.theoremCount` was null → 9; `lineCount` 174 → 190
- Update section line ranges to match actual file content

The theorem that R(N) ≥ 1 was listed in the research JSON as a planned next step but never implemented. The proof constructs explicit membership in the filtered powerset and applies Finset.le_sup.

## Test plan
- Lean file: no sorry, proof is structural (Finset API)
- meta.json counts verified against file line count and theorem count

Generated with Claude Code