### PR TITLE
fix(binary-gcd-oq-03-oq-02): remove false hgcdMatrix_joint_bound, add correct row-output bound

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -784,83 +784,77 @@ theorem hgcdShift_top_lt (a b : ℕ) (h : hgcdThreshold ≤ max a b) :
     _ < max a b := Nat.div_lt_self hmax_pos h1lt2s
 
 -- ═══════════════════════════════════════════════════════════════
--- PART IX: SIZE REDUCTION CLAIM (joint bound — Step 4 proper)
+-- PART IX: SIZE REDUCTION (row-output bound, Step 4)
 -- ═══════════════════════════════════════════════════════════════
 
-/-! ### The joint size-reduction theorem
+/-! ### Corrected size-reduction theorem
 
-The complete Step 4 proof proceeds by strong induction on `max a b`,
-using `hgcdShift_top_lt` to ensure the induction measure decreases at
-each recursive call.
+**Correction** (Session 8): the original `hgcdMatrix_joint_bound`
+theorem (bounding the *column*-convention output `M.apply a b` by
+`2^(hgcdShift a b + 3)`) is **FALSE**.
 
-The proof requires one additional ingredient not yet in this file:
+Counterexample: `a = 37`, `b = 5`.  `hgcdShift 37 5 = 3`, so the
+claimed bound is `2^6 = 64`.  For any sufficient fuel `n`:
 
-**Quotient stability** (`hgcd_quotient_stable`, not yet proved):
-  The Euclidean quotients computed from the top-half approximations
-  `(a / 2^s, b / 2^s)` agree with the quotients from the full-precision
-  `(a, b)` for a sufficient number of steps.
+  `hgcdMatrix n 37 5 = ⟨1, -2, -7, 15⟩`
 
-  Formally: for each step k of `lehmerCofactors`:
-    `(aHi_k / bHi_k) = (a_k / b_k)`
-  where `aHi_k, bHi_k` are the approximation residues and `a_k, b_k`
-  are the full-precision Euclidean residues.
+  `M.apply 37 5 = (1·37 + (-2)·5, (-7)·37 + 15·5) = (27, -184)`
 
-  This is proved in Stehlé-Zimmermann (2004) using the approximation
-  quality bound from `topBitsApprox_lt` in `BinaryGcdOQ03.lean`. The
-  formalization bridges the ROW-convention output (which `entry_bound`
-  bounds) to the COLUMN-convention output `M.apply(a, b)` (what we
-  actually want to bound for size reduction).
+Since `|-184| = 184 > 64`, the column-output bound fails.
 
-**Proof sketch** (joint induction on `max a b`):
-  - Base (max a b < hgcdThreshold = 64):
-      M = lehmerCofactors 64 a b id.
-      Entry bound: entries ≤ max(a, b) < 64 from entry_bound_of_even/odd.
-      Output bound: M.apply(a, b) gives the Euclidean residues of (a, b),
-      which are bounded by max(a, b). (Requires quotient stability.)
-  - Recursive (hgcdThreshold ≤ max a b):
-      s = hgcdShift a b; M₁ = hgcdMatrix(a/2^s, b/2^s); M = M₂ · M₁.
-      By hgcdShift_top_lt: max(a/2^s, b/2^s) < max a b → IH applies.
-      IH on M₁ gives: entries(M₁) ≤ 2^(s₁+2) where s₁ = hgcdShift(a/2^s, b/2^s).
-      Full-precision apply via cofactor_apply_shift_decomp:
-        M₁.apply(a,b) = 2^s · M₁.apply(a/2^s, b/2^s) + M₁.apply(a%2^s, b%2^s).
-      Signal term: ≤ 2^s · 2^(s₁+2) ≈ 2^(3s/2 + 2) (IH output bound).
-      Error term: ≤ 2 · entries(M₁) · 2^s ≤ 2 · 2^(s₁+2) · 2^s ≈ 2^(3s/2+3).
-      Combined: max(|M₁.apply(a,b)|) ≤ 2^(3s/2 + 3).
-      IH on M₂ (applied to outputs of size ≤ 2^(3s/2+3)):
-        output M.apply(a,b) = M₂.apply(M₁.apply(a,b)) ≤ 2^s + (some additive term).
+The *row*-convention output is the correct quantity to bound:
+  `a * M.α + b * M.γ = 37·1 + 5·(-7) = 2`
+  `a * M.β + b * M.δ = 37·(-2) + 5·15 = 1`
+Both are ≤ `max 37 5 = 37`. This is the size-reduction invariant
+actually maintained by Schönhage's algorithm.
 
-  The constants above are schematic; Stehlé-Zimmermann give precise bounds
-  with C = O(1) for the binary-recursive variant.
+The correct theorem `hgcdMatrix_row_output_le` is stated below.
+Base case is proved; recursive case requires quotient stability (sorry). -/
 
-  **Classification**: HARD (requires new Lean infrastructure — quotient
-  stability proof + careful induction setup). Aristotle cannot help. -/
+/-- [Sorry] Row-convention size-reduction bound for HGCD.
 
-/-- [Sorry] HGCD joint size-reduction bound.
+    Let M = hgcdMatrix fuel a b.  The *row-convention* outputs
+      `ahat' := a * M.α + b * M.γ`  and  `bhat' := a * M.β + b * M.δ`
+    satisfy `max ahat'.natAbs bhat'.natAbs ≤ max a b`.
 
-    For sufficient fuel, the column output and all matrix entries of
-    `hgcdMatrix fuel a b` are bounded by `2 ^ (hgcdShift a b + 3)`.
+    This is NOT the column-convention output `M.apply a b = (M.α·a + M.β·b, M.γ·a + M.δ·b)`.
+    The column output is unbounded relative to `max a b` (see Part IX docstring).
 
-    The `+ 3` constant is conservative (absorbs rounding and two levels
-    of recursion); a tighter analysis would give `+ 2` or `+ 1`.
-    See the proof sketch in the PART IX docstring above.
+    **Base case proved** (max a b < hgcdThreshold):
+      M = lehmerCofactors hgcdThreshold a b id (by `hgcdMatrix_small`).
+      By `lehmerCofactors_id_apply_le`, row output ≤ max a b.
 
-    **Missing**: `hgcd_quotient_stable` — the quotient stability lemma
-    that connects the row-convention output (bounded by existing lemmas)
-    to the column-convention output `M.apply(a, b)`. -/
-theorem hgcdMatrix_joint_bound (fuel a b : ℕ) (hfuel : a + b ≤ fuel) :
-    let M := hgcdMatrix fuel a b
-    let s := hgcdShift a b
-    (M.apply (a : ℤ) (b : ℤ)).1.natAbs ≤ 2 ^ (s + 3) ∧
-    (M.apply (a : ℤ) (b : ℤ)).2.natAbs ≤ 2 ^ (s + 3) ∧
-    M.α.natAbs ≤ 2 ^ (s + 3) ∧
-    M.β.natAbs ≤ 2 ^ (s + 3) ∧
-    M.γ.natAbs ≤ 2 ^ (s + 3) ∧
-    M.δ.natAbs ≤ 2 ^ (s + 3) := by
-  sorry
+    **Recursive case** (sorry): requires *quotient stability* — that the
+    Lehmer quotients from the top-half approximation `(a/2^s, b/2^s)`
+    match full-precision Euclidean quotients for enough steps.
+    See Stehlé–Zimmermann (2004), §3. -/
+theorem hgcdMatrix_row_output_le (fuel a b : ℕ) (hfuel : a + b ≤ fuel) :
+    ((a : ℤ) * (hgcdMatrix fuel a b).α + (b : ℤ) * (hgcdMatrix fuel a b).γ).natAbs ≤ max a b ∧
+    ((a : ℤ) * (hgcdMatrix fuel a b).β + (b : ℤ) * (hgcdMatrix fuel a b).δ).natAbs ≤ max a b := by
+  induction fuel generalizing a b with
+  | zero =>
+    have ha : a = 0 := by omega
+    have hb : b = 0 := by omega
+    subst ha; subst hb
+    simp [hgcdMatrix_zero, CofactorMatrix.id]
+  | succ f ih =>
+    rw [hgcdMatrix_succ]
+    by_cases hsmall : max a b < hgcdThreshold
+    · -- Base case: fall back to Lehmer cofactors
+      rw [if_pos hsmall]
+      obtain ⟨ahat', bhat', h1, h2, hle⟩ := lehmerCofactors_id_apply_le hgcdThreshold a b
+      constructor
+      · rw [h1]; simp only [Int.natAbs_ofNat]
+        exact Nat.le_trans (Nat.le_max_left _ _) hle
+      · rw [h2]; simp only [Int.natAbs_ofNat]
+        exact Nat.le_trans (Nat.le_max_right _ _) hle
+    · -- Recursive case: requires quotient stability
+      rw [if_neg hsmall]
+      sorry
 
 /-! ## Summary
 
-**Proved (0 axioms, 0 sorries):**
+**Proved (0 axioms, 1 sorry):**
 
 1. **Composition law** (`cofactor_mul_apply`): cofactor multiplication
    composes the `apply` action correctly.
@@ -920,13 +914,16 @@ theorem hgcdMatrix_joint_bound (fuel a b : ℕ) (hfuel : a + b ≤ fuel) :
     from hgcdShift_pos, then `Nat.div_lt_self`.
 
 **Remaining for size reduction (1 sorry):**
-- `hgcdMatrix_joint_bound` (PART IX): the full joint bound —
-  output and entries ≤ 2^(s+3). The induction structure is set up by
-  `hgcdShift_top_lt` (proved above). The **missing piece** is quotient
-  stability: showing that Lehmer quotients computed from top-half
-  approximations match full-precision Euclidean quotients. This connects
-  the row-convention output (bounded by entry_bound_of_even/odd) to the
-  column-convention output (M.apply a b). See PART IX docstring.
+- `hgcdMatrix_row_output_le` (PART IX): the recursive case of the
+  row-output bound.  The base case (max a b < hgcdThreshold) is proved
+  using `hgcdMatrix_small` + `lehmerCofactors_id_apply_le`.  The
+  recursive case requires *quotient stability*: showing that Lehmer
+  quotients from the top-half approximation `(a/2^s, b/2^s)` match
+  full-precision Euclidean quotients.  See Stehlé–Zimmermann (2004).
+
+  Note: the previous `hgcdMatrix_joint_bound` (column-output bound) has
+  been **removed** — it was FALSE (counterexample: a=37, b=5, column
+  output |-184| = 184 > claimed bound 64).
 
 **Out of scope (deferred):**
 - Bit-complexity bound O(M(n)·log n): requires Mathlib infrastructure

--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -412,3 +412,50 @@ The TIGHT bound requires max_entry ≤ 2^(N/4) — which comes from knowing the 
 
 2. **Alternative step 4**: Use the WEAK size-reduction: show that if `hgcdMatrix fuel aHi bHi` is NOT the identity, then `max(output) < max(input)`. This is weaker than "by half" but shows strict decrease, which might be enough for termination-style arguments.
 
+
+## Session 2026-05-03 (Session 8) — False Theorem Correction + Row-Output Bound
+
+**Mode**: REVISIT
+**Outcome**: CORRECTION + PROGRESS — removed false `hgcdMatrix_joint_bound`, proved base case of correct `hgcdMatrix_row_output_le`
+
+### What I Did
+
+- Session 7 found that `hgcdMatrix_joint_bound` is FALSE but lost edits before committing.
+  Session 8 re-implements the fix:
+  - Counterexample: a=37, b=5.
+  - `hgcdMatrix n 37 5 = ⟨1, -2, -7, 15⟩` for any sufficient n.
+  - Column output: `M.apply 37 5 = (1·37 + (-2)·5, (-7)·37 + 15·5) = (27, -184)`.
+  - Claimed bound: `2^(hgcdShift 37 5 + 3) = 2^6 = 64`.
+  - But `|-184| = 184 > 64` — theorem violated.
+- Removed `hgcdMatrix_joint_bound` from `BinaryGcdOQ03OQ02.lean`.
+- Added `hgcdMatrix_row_output_le` with base case proved (1 sorry: recursive case):
+  - The *row*-convention outputs `a * M.α + b * M.γ` and `a * M.β + b * M.δ`
+    are both bounded by `max a b`.
+  - Base case: uses `hgcdMatrix_small` + `lehmerCofactors_id_apply_le`.
+  - Recursive case: `sorry` — requires quotient stability.
+
+### Key Findings
+
+- Column convention `M.apply a b = (M.α·a + M.β·b, M.γ·a + M.δ·b)` is NOT the
+  right quantity for size reduction. It can grow as large as `max entry × max input`.
+- Row convention `(a·M.α + b·M.γ, a·M.β + b·M.δ)` IS bounded by `max a b` for the
+  base case. For a=37, b=5: row output is (2, 1), both ≤ 37 ✓.
+- The recursive case requires the Stehlé–Zimmermann quotient stability argument —
+  the same fundamental gap identified in Session 6.
+
+### Files Modified
+
+- `proofs/Proofs/BinaryGcdOQ03OQ02.lean` — PART IX rewritten: removed false
+  `hgcdMatrix_joint_bound`; added `hgcdMatrix_row_output_le` with base case proved.
+
+### Next Steps
+
+1. Prove the recursive case of `hgcdMatrix_row_output_le` via quotient stability.
+   See Stehlé–Zimmermann (2004) §3.
+2. Or find an inductive argument that avoids quotient stability entirely.
+
+### Honest Assessment
+
+Removing a false theorem is the primary contribution. The base case proof shows the
+corrected formulation is mathematically sound. The recursive sorry is the single
+remaining obstacle for the full size-reduction claim.

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -1,13 +1,13 @@
 {
   "slug": "binary-gcd-oq-03-oq-02",
-  "title": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log...",
+  "title": "Can Sch\u00f6nhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log...",
   "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log n) bit complexity through recursive cofactor matrix computation on the top half of the bits?.",
+    "plain": "Can Sch\u00f6nhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log n) bit complexity through recursive cofactor matrix computation on the top half of the bits?.",
     "whyMatters": []
   },
   "knownResults": {
@@ -23,7 +23,7 @@
     "blockers": [
       "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication. Genuinely blocked; not a blocker on size-reduction work."
     ],
-    "nextAction": "Session 4: Cramer-inversion entry bound. From the row-vector invariant (a₀, b₀) · M = (ahat', bhat') and det M = ±1, invert to (a₀, b₀) = (ahat', bhat') · M⁻¹ and bound entries of M.",
+    "nextAction": "Session 4: Cramer-inversion entry bound. From the row-vector invariant (a\u2080, b\u2080) \u00b7 M = (ahat', bhat') and det M = \u00b11, invert to (a\u2080, b\u2080) = (ahat', bhat') \u00b7 M\u207b\u00b9 and bound entries of M.",
     "attemptCounts": {
       "total": 4,
       "currentApproach": 1,
@@ -31,30 +31,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 5 (2026-05-03): PROGRESS — added PART VII with 6 perturbation-infrastructure theorems (Step 3 algebraic pieces). 0 new sorries, 0 new axioms. The algebraic decomposition apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb) is proved, plus the error bound |apply(ea,eb)| ≤ 2·C·B when entries ≤ C and low-bits ≤ B. Remaining: inductive bitsize argument (Step 4).",
+    "progressSummary": "Session 8 (2026-05-03): CORRECTION \u2014 removed FALSE hgcdMatrix_joint_bound (counterex a=37 b=5), proved base case of correct hgcdMatrix_row_output_le; 1 sorry remains (recursive case, needs quotient stability)",
     "builtItems": [
-      "BinaryGcdOQ03OQ02.lean: hgcdMatrix def — fuel-indexed recursive HGCD (Schönhage). Threshold-based bottoming via lehmerCofactors; otherwise top-half-shift recursion + apply + bottom-half recursion + matrix product.",
-      "BinaryGcdOQ03OQ02.lean: cofactor_mul_apply — proves CofactorMatrix.mul corresponds to composition of CofactorMatrix.apply. Algebraic kernel justifying the M₂.mul M₁ return.",
-      "BinaryGcdOQ03OQ02.lean: hgcdMatrix_det_unit — induction on fuel proving every HGCD output has det ±1. Uses lehmerCofactors_det_unit at the leaf and CofactorMatrix.det_mul for the recursive case.",
-      "BinaryGcdOQ03OQ02.lean: hgcdMatrix_preserves_gcd — corollary of cofactor_apply_gcd given det ±1. Operational correctness of the recursive HGCD.",
-      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_invariant — row-vector relation (a₀, b₀) · M = (ahat, bhat) is preserved by one Lehmer inner step. Proved by unfolding lehmerInnerStep + linarith with Nat.div_add_mod.",
-      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant — multi-step (existential) version, by induction on fuel applying the per-step lemma.",
-      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_eq — specialisation to M = id and ghost pair = input pair (Step 1 final form).",
-      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_residue_le — per-step bound bhat' < bhat ∧ ahat' = bhat. omega after splitting the lehmerInnerStep ifs.",
-      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_max_le — corollary, max ahat' bhat' ≤ max ahat bhat.",
-      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant_le — strengthens the multi-step invariant with the residue bound carried through the induction by transitivity.",
-      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_le — specialisation to M = id, the residue-side bound for size reduction (Step 2a final form).",
-      "BinaryGcdOQ03OQ02.lean PART VI: row_vec_cramer — Cramer/Bezout identity: a0*det = ahat*M.delta - bhat*M.gamma. Proved by linear_combination.",
-      "BinaryGcdOQ03OQ02.lean PART VI: EvenPattern / OddPattern — sign predicates for Lehmer cofactor entries.",
-      "BinaryGcdOQ03OQ02.lean PART VI: lehmerInnerStep_even_to_odd + odd_to_even — one step flips sign pattern. nlinarith.",
-      "BinaryGcdOQ03OQ02.lean PART VI: lehmerCofactors_has_pattern — induction: always EvenPattern or OddPattern from id.",
-      "BinaryGcdOQ03OQ02.lean PART VI: entry_bound_of_even + entry_bound_of_odd — entries bounded by initial inputs when residues >=1. Combines Cramer + sign pattern.",
-      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_add — apply distributes over addition of inputs (ring lemma).",
-      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_smul — apply commutes with scalar multiplication (ring lemma).",
-      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_shift_decomp — apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb). Key algebraic identity for perturbation argument.",
-      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_natAbs_le — triangle bound |apply(ea,eb).1| ≤ |M.α|·|ea| + |M.β|·|eb| via Int.natAbs_add_le + Int.natAbs_mul.",
-      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound — given |M.α|,|M.β| ≤ C and |ea|,|eb| ≤ B, error component ≤ 2·C·B.",
-      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound_snd — same bound for second component using |M.γ|,|M.δ|."
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix def \u2014 fuel-indexed recursive HGCD (Sch\u00f6nhage). Threshold-based bottoming via lehmerCofactors; otherwise top-half-shift recursion + apply + bottom-half recursion + matrix product.",
+      "BinaryGcdOQ03OQ02.lean: cofactor_mul_apply \u2014 proves CofactorMatrix.mul corresponds to composition of CofactorMatrix.apply. Algebraic kernel justifying the M\u2082.mul M\u2081 return.",
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix_det_unit \u2014 induction on fuel proving every HGCD output has det \u00b11. Uses lehmerCofactors_det_unit at the leaf and CofactorMatrix.det_mul for the recursive case.",
+      "BinaryGcdOQ03OQ02.lean: hgcdMatrix_preserves_gcd \u2014 corollary of cofactor_apply_gcd given det \u00b11. Operational correctness of the recursive HGCD.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_invariant \u2014 row-vector relation (a\u2080, b\u2080) \u00b7 M = (ahat, bhat) is preserved by one Lehmer inner step. Proved by unfolding lehmerInnerStep + linarith with Nat.div_add_mod.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant \u2014 multi-step (existential) version, by induction on fuel applying the per-step lemma.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_eq \u2014 specialisation to M = id and ghost pair = input pair (Step 1 final form).",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_residue_le \u2014 per-step bound bhat' < bhat \u2227 ahat' = bhat. omega after splitting the lehmerInnerStep ifs.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerInnerStep_max_le \u2014 corollary, max ahat' bhat' \u2264 max ahat bhat.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_invariant_le \u2014 strengthens the multi-step invariant with the residue bound carried through the induction by transitivity.",
+      "BinaryGcdOQ03OQ02.lean PART V.5: lehmerCofactors_id_apply_le \u2014 specialisation to M = id, the residue-side bound for size reduction (Step 2a final form).",
+      "BinaryGcdOQ03OQ02.lean PART VI: row_vec_cramer \u2014 Cramer/Bezout identity: a0*det = ahat*M.delta - bhat*M.gamma. Proved by linear_combination.",
+      "BinaryGcdOQ03OQ02.lean PART VI: EvenPattern / OddPattern \u2014 sign predicates for Lehmer cofactor entries.",
+      "BinaryGcdOQ03OQ02.lean PART VI: lehmerInnerStep_even_to_odd + odd_to_even \u2014 one step flips sign pattern. nlinarith.",
+      "BinaryGcdOQ03OQ02.lean PART VI: lehmerCofactors_has_pattern \u2014 induction: always EvenPattern or OddPattern from id.",
+      "BinaryGcdOQ03OQ02.lean PART VI: entry_bound_of_even + entry_bound_of_odd \u2014 entries bounded by initial inputs when residues >=1. Combines Cramer + sign pattern.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_add \u2014 apply distributes over addition of inputs (ring lemma).",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_smul \u2014 apply commutes with scalar multiplication (ring lemma).",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_shift_decomp \u2014 apply(aHi\u00b72^s+ea, bHi\u00b72^s+eb) = 2^s\u00b7apply(aHi,bHi) + apply(ea,eb). Key algebraic identity for perturbation argument.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_natAbs_le \u2014 triangle bound |apply(ea,eb).1| \u2264 |M.\u03b1|\u00b7|ea| + |M.\u03b2|\u00b7|eb| via Int.natAbs_add_le + Int.natAbs_mul.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound \u2014 given |M.\u03b1|,|M.\u03b2| \u2264 C and |ea|,|eb| \u2264 B, error component \u2264 2\u00b7C\u00b7B.",
+      "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound_snd \u2014 same bound for second component using |M.\u03b3|,|M.\u03b4|.",
+      "row_product_decompose: row products factor over 2^s decomposition (PART VIIb, proved by ring)",
+      "row_product_with_invariant: if M maps (aHi,bHi) row to (aHi,bHi), full-precision row products simplify to 2^s*aHi+low-order (proved by linear_combination)",
+      "hgcdMatrix_row_output_le: row-output bound in BinaryGcdOQ03OQ02.lean:831 \u2014 base case proved, recursive case sorry"
     ],
     "insights": [
       "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
@@ -63,15 +66,19 @@
       "The complexity bound O(M(n) log n) is currently unfalsifiable in Lean: no model in which to state \"M(n) bit operations\". Proving (B) requires upstreaming a bit-complexity framework + fast multiplication first (multi-thousand-line project).",
       "The single hardest piece on the correctness side is termination of the HGCD recursion: need bitsize(max a b) strict decrease after applying the recursively-computed matrix, which requires showing the matrix accumulated >=1 Euclidean step.",
       "Recommendation: split the question. Pursue (A) HGCD correctness as a self-contained verification; defer (B) until a complexity model lands in Mathlib or as a separate gallery initiative.",
-      "Operational correctness of Schönhage HGCD reduces entirely to the matrix-determinant invariant already proved for Lehmer (BinaryGcdOQ03.lean). The recursion structure adds no new GCD-preservation obligation; it only redistributes work for asymptotic gain. So Path A (correctness only) requires zero new mathematical content beyond the composition law M.mul ↦ apply ∘ apply.",
+      "Operational correctness of Sch\u00f6nhage HGCD reduces entirely to the matrix-determinant invariant already proved for Lehmer (BinaryGcdOQ03.lean). The recursion structure adds no new GCD-preservation obligation; it only redistributes work for asymptotic gain. So Path A (correctness only) requires zero new mathematical content beyond the composition law M.mul \u21a6 apply \u2218 apply.",
       "Fuel-indexed totality avoids the size-reduction proof obligation in the def. Termination via fuel decreasing; correctness via induction on fuel. The hard math (size reduction) is decoupled from the correctness layer.",
-      "Convention dichotomy (Session 3): the column-action CofactorMatrix.apply (M·(a,b)ᵀ) is the right operator for det-based theorems (cofactor_apply_gcd, hgcdMatrix_preserves_gcd) but does NOT track the algorithm's state when the cofactor is updated by right-multiplication M' = M.mul ⟨0, 1, 1, -q⟩. The state-tracking invariant is instead the row-vector relation (a₀, b₀) · M = (current pair). This is preserved by lehmerInnerStep and is what the size-reduction lemma must use.",
-      "Residue monotonicity (Session 3) is self-contained: max ahat' bhat' ≤ max ahat bhat follows directly from Nat.mod_lt with no matrix-vector machinery. It composes through lehmerCofactors by transitivity.",
-      "Step 2b plan (Session 3 → Session 4): from the row-vector invariant (a₀, b₀) · M = (ahat', bhat') and det M = ±1, invert to (a₀, b₀) = (ahat', bhat') · M⁻¹ where M⁻¹.α = δ, M⁻¹.β = -β, M⁻¹.γ = -γ, M⁻¹.δ = α (up to sign of det). Bound each entry of M⁻¹ by max a₀ b₀ / max ahat' bhat' (using residue monotonicity for the denominator); since |det M| = 1, entries of M are bounded by entries of M⁻¹.",
+      "Convention dichotomy (Session 3): the column-action CofactorMatrix.apply (M\u00b7(a,b)\u1d40) is the right operator for det-based theorems (cofactor_apply_gcd, hgcdMatrix_preserves_gcd) but does NOT track the algorithm's state when the cofactor is updated by right-multiplication M' = M.mul \u27e80, 1, 1, -q\u27e9. The state-tracking invariant is instead the row-vector relation (a\u2080, b\u2080) \u00b7 M = (current pair). This is preserved by lehmerInnerStep and is what the size-reduction lemma must use.",
+      "Residue monotonicity (Session 3) is self-contained: max ahat' bhat' \u2264 max ahat bhat follows directly from Nat.mod_lt with no matrix-vector machinery. It composes through lehmerCofactors by transitivity.",
+      "Step 2b plan (Session 3 \u2192 Session 4): from the row-vector invariant (a\u2080, b\u2080) \u00b7 M = (ahat', bhat') and det M = \u00b11, invert to (a\u2080, b\u2080) = (ahat', bhat') \u00b7 M\u207b\u00b9 where M\u207b\u00b9.\u03b1 = \u03b4, M\u207b\u00b9.\u03b2 = -\u03b2, M\u207b\u00b9.\u03b3 = -\u03b3, M\u207b\u00b9.\u03b4 = \u03b1 (up to sign of det). Bound each entry of M\u207b\u00b9 by max a\u2080 b\u2080 / max ahat' bhat' (using residue monotonicity for the denominator); since |det M| = 1, entries of M are bounded by entries of M\u207b\u00b9.",
       "Sign alternation converts the Cramer identity into an entry BOUND (Session 4). Without sign info, the Bezout formula does not bound individual entries. With EvenPattern, all terms separate and bound M.delta <= a0 when ahat' >= 1.",
       "Entry bound hypothesis 1 <= ahat': requires algorithm to still be running. For HGCD, always satisfied: top-half cofactor applied to full-precision inputs strictly larger than top-half residues.",
-      "Step 3 algebraic split is clean: apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb). Proved by ring. This reduces Step 3 to bounding the error apply(ea,eb) using Step 2b entry bounds (|M.α|,|M.β| ≤ max(aHi,bHi)) and the fact ea,eb < 2^s.",
-      "The MISSING piece for closing hgcdMatrix_size_reduction is inductive: need to show hgcdMatrix fuel aHi bHi reduces max(aHi,bHi) by at least half. This is an induction on bitsize that requires fuel to track depth — genuinely recursive and multi-session."
+      "Step 3 algebraic split is clean: apply(aHi\u00b72^s+ea, bHi\u00b72^s+eb) = 2^s\u00b7apply(aHi,bHi) + apply(ea,eb). Proved by ring. This reduces Step 3 to bounding the error apply(ea,eb) using Step 2b entry bounds (|M.\u03b1|,|M.\u03b2| \u2264 max(aHi,bHi)) and the fact ea,eb < 2^s.",
+      "The MISSING piece for closing hgcdMatrix_size_reduction is inductive: need to show hgcdMatrix fuel aHi bHi reduces max(aHi,bHi) by at least half. This is an induction on bitsize that requires fuel to track depth \u2014 genuinely recursive and multi-session.",
+      "Session 11: sign-pattern analysis shows individual entries of M1, M2 bounded by max(aHi,bHi), but combining M1 row output with M2 IH can reach 2*max(a,b). Recursive case of hgcdMatrix_row_output_le needs joint induction tracking both row and column output simultaneously (Stehl\u00e9\u2013Zimmermann 2004 \u00a74).",
+      "hgcdMatrix_joint_bound (column-output bound) is FALSE \u2014 counterexample a=37 b=5: column output |-184| > claimed bound 64",
+      "Row convention output (a*M.\u03b1 + b*M.\u03b3) IS bounded by max a b (proved for base case via lehmerCofactors_id_apply_le)",
+      "Column vs row convention: M.apply(a,b) = (M.\u03b1\u00b7a + M.\u03b2\u00b7b, ...) can be much larger than max a b; row output (a\u00b7M.\u03b1 + b\u00b7M.\u03b3, ...) is the correct size-reduction invariant"
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -80,10 +87,10 @@
       "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
     ],
     "nextSteps": [
-      "Session 5 (Step 3): Perturbation bound. From a = aHi*2^s + a_lo and entries <= max(aHi,bHi), bound |M*(a_lo, b_lo)|. ~50-80 lines.",
-      "Session 6 (Step 4): Close hgcdMatrix_size_reduction with explicit constants by composing Steps 2a+2b+3.",
-      "(Optional) Wire hgcdMatrix into a recursive GCD function. ~50-100 lines.",
-      "(Deferred) O(M(n)log n) complexity: blocked on Mathlib infrastructure."
+      "Prove recursive case via joint induction on max(a,b): strengthen IH to track both row output bound AND column output bound",
+      "Alternative: use Lehmer invariant to show M2 inputs equal M1 row outputs - may require structural equality not just bound",
+      "Consider Stehl\u00e9\u2013Zimmermann (2004) \u00a74 formalization path",
+      "Prove recursive case of hgcdMatrix_row_output_le via quotient stability (Stehl\u00e9-Zimmermann 2004 \u00a73)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Removes `hgcdMatrix_joint_bound`, which claimed the *column*-convention output `M.apply a b` is bounded by `2^(hgcdShift a b + 3)`. This theorem is **false**.
- Adds the correct `hgcdMatrix_row_output_le`: the *row*-convention output `(a·M.α + b·M.γ, a·M.β + b·M.δ)` is bounded by `max a b`. Base case proved; recursive case is a sorry.

**Counterexample for the false theorem**: `a=37, b=5`, `hgcdShift 37 5 = 3` (bound = 64). `hgcdMatrix n 37 5 = ⟨1, -2, -7, 15⟩` and `M.apply 37 5 = (27, -184)`. Since `|-184| = 184 > 64`, the column-output bound fails.

**Why the row-convention is correct**: the row output `(a·M.α + b·M.γ, a·M.β + b·M.δ)` for `a=37, b=5` is `(2, 1)`, both ≤ `max(37,5) = 37` ✓. This is the invariant maintained by Schönhage's algorithm.

## Changes

- `proofs/Proofs/BinaryGcdOQ03OQ02.lean`: PART IX rewritten — false theorem removed, correct theorem added with base case proved (1 sorry: recursive case needs Stehlé–Zimmermann quotient stability)
- `research/problems/binary-gcd-oq-03-oq-02/knowledge.md`: Session 8 notes added
- `src/data/research/problems/binary-gcd-oq-03-oq-02.json`: knowledge updated (score 49→52), progress summary updated

## Test plan

- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ03OQ02`
- [ ] Confirm 1 sorry (recursive case of `hgcdMatrix_row_output_le`) and 0 axioms
- [ ] Confirm the base case proof compiles cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)