### PR TITLE
audit(sperner-ndim-oq-04): fix stale axiomCount and lineCount

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -41,8 +41,8 @@
       "Proof of walkValid_step: WalkValid is preserved by one Kuhn step"
     ],
     "dateAdded": "2026-04-22",
-    "axiomCount": 0,
-    "lineCount": 1126,
+    "axiomCount": 1,
+    "lineCount": 948,
     "assumptions": "1 axiom: bdry_all_even_of_no_fc_walks — when all boundary-door walks fail to reach FC, the boundary-door set B has even cardinality (used for parity contradiction in kuhn_path_existential). Mathematical proof: under hfail, τ: B→B defined by τ(s₀,Fin.last d) = (kuhnPathStart s₀, Fin.last d) is a FPF involution; hMem and hNe proved; hInv (τ∘τ=id, walkTrace_reversal) requires ~150-line kuhnWalkSeq infrastructure and is axiomatized after 9+ sessions BLOCKED.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: sperner-ndim-oq-04
**Severity**: LOW
**Problem**: After the re-axiomatize commit (aa9145dfa03 / #14937), `meta.axiomCount` and `meta.lineCount` were not updated. The `leanFile` block was synced correctly, but the human-facing `meta` block kept stale numbers.

## Evidence

`proofs/Proofs/SpernerNDimOQ04.lean`:
- 948 lines (`wc -l`)
- 1 axiom declaration at line 907: `axiom bdry_all_even_of_no_fc_walks`
- 0 sorries
- 0 True stubs

`src/data/proofs/sperner-ndim-oq-04/meta.json` (before this PR):
- `meta.axiomCount`: **0** (contradicts `badge: "axiom"`, `status: "axiomatized"`, and the `assumptions` field which correctly describes 1 axiom)
- `meta.lineCount`: **1126** (off by ~178 lines)
- `leanFile.axiomCount`: 1
- `leanFile.lineCount`: 948

The two-block drift means the gallery presentation layer may show inconsistent counts depending on which field is rendered.

## Fix

Two-line patch. `assumptions` text already matches reality, so no narrative change is needed.

## Out of scope

`overview.proofStrategy` mentions an "adj_unique_facet geometric axiom in SpernerTriangulation" but does not surface the new `bdry_all_even_of_no_fc_walks` axiom by name. That is narrative drift better handled by an enrichment pass and was not touched here.

---
Discovered during gallery integrity audit at origin/main 3891c2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)