### PR TITLE
audit(tracker): sperner-ndim-oq-04 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13117,10 +13117,10 @@
       "result": "clean"
     },
     "sperner-ndim-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:34Z",
-      "result": "clean"
+      "lastAudited": "2026-05-03T01:52:01Z",
+      "result": "issues-fixed"
     },
     "spherical-law-of-cosines": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

Marks `sperner-ndim-oq-04` as **issues-fixed** in the audit tracker after PR #15000 corrects the stale `meta.axiomCount` (0→1) and `meta.lineCount` (1126→948).

- auditCount: 1 → 2
- lastAudited: 2026-05-03T01:52Z
- result: clean → issues-fixed

Companion to #15000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)