### PR TITLE
fix(erdos-634): correct stale top-level sorries:1 to 6

### DIFF
--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -255,5 +255,5 @@
       "description": "Lagrange's four squares theorem (every positive integer is a sum of four squares) contrasts with the incomplete coverage of dissectable numbers: k², 2k², 3k², k²+m² cover most integers but not all (7, 11, 19 are open). The arithmetic of sums of squares governs which n are dissectable — Lagrange and Fermat's results on square representations directly constrain the structure of dissectable families."
     }
   ],
-  "sorries": 1
+  "sorries": 6
 }


### PR DESCRIPTION
## Fix

Correct stale top-level `sorries: 1` in `erdos-634/meta.json`. After PR #14895 strengthened the `Dissection` structure (restoring honest sorries for `*_dissectable` theorems), `meta.sorries` and `leanFile.sorries` were correctly updated to 6, but the top-level `sorries` field was left at 1 (set by the earlier PR #14866).

## Evidence

**Before**: top-level `"sorries": 1` (stale from PR #14866)
**After**: top-level `"sorries": 6` (consistent with `meta.sorries: 6`, `leanFile.sorries: 6`, and actual Lean file which has 6 sorry statements at lines 81, 137, 142, 147, 152, 159)

The `meta.assumptions` field already correctly lists all 6 sorries: `congruent_implies_similar`, `squares_dissectable`, `two_squares_dissectable`, `three_squares_dissectable`, and two others.

---
Automated fix by lean-mechanic agent.