### PR TITLE
fix(fourier-series-oq-02-oq-03-oq-02): add meta.theoremCount + clarify blockers

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
@@ -19,6 +19,7 @@
     "badge": "axiom",
     "sorries": 2,
     "axiomCount": 3,
+    "theoremCount": 11,
     "lineCount": 427,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -25,6 +25,18 @@
     ]
   },
   {
+    "id": "ann-qroq03-namespace-setup",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": { "startLine": 37, "endLine": 47 },
+    "type": "context",
+    "title": "Lean Setup: Linting, Open, and Namespace",
+    "content": "Three short lines before the first theorem:\n\n- `set_option linter.unusedVariables false` — silences a linter warning for the `hqp : q < p` hypothesis in `algorithm_descent`, which is intentionally present for its type-level guarantee but not used in the proof body.\n- `open ZMod` — brings `ZMod`-specific definitions, lemmas, and `Decidable` instances into scope. This is what allows `decide` to discharge Legendre symbol equalities: without the `ZMod` decidability infrastructure, `decide` on `legendreSym p a = n` would not type-check.\n- `namespace QRAlgorithm` — groups all four reduction lemmas under a single namespace, so consumers import them as `QRAlgorithm.legendreSym_mul_eq` etc., making the algorithmic origin clear at the use site.",
+    "mathContext": "The `set_option` is a principled design choice: `hqp : q < p` is a *specification* input (its presence at the type level documents the descent invariant) even though the proof itself does not need it (the underlying `reciprocity_swap` works without the ordering hypothesis). This pattern — adding hypothesis for documentation, suppressing the linter — is common in verified algorithm presentations.",
+    "significance": "context",
+    "relatedConcepts": ["set_option", "open ZMod", "namespace", "Decidable instances", "linter.unusedVariables"],
+    "prerequisites": ["Lean 4 namespace system", "Lean 4 linting infrastructure", "ZMod type"]
+  },
+  {
     "id": "ann-multiplicativity",
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {
@@ -112,7 +124,7 @@
     },
     "type": "concept",
     "title": "Verified Examples via decide",
-    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |",
+    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign: $(7/11) = -(11/7) = -(4/7) = -1$ |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |\n\n**Note on the (5/13) docstring**: the Lean source docstring for this example opens with the incorrect claim `(5/13) = 1 (5 is a quadratic residue mod 13)` and then trails off with `wait, need to check`. This is a draft artifact — the QRs mod 13 are $\\{1, 3, 4, 9, 10, 12\\}$, so 5 is *not* a QR mod 13 and `(5/13) = -1` is correct. The `decide` kernel confirms the right answer; the docstring is simply unfinished.",
     "mathContext": "`decide` works here because Mathlib's `legendreSym p a` is implemented via Euler's criterion in `ZMod p` — for a concrete small prime $p$, `ZMod p` is a `Fintype`, so the equality $a^{(p-1)/2} = \\pm 1$ in `ZMod p` is decidable and Lean can evaluate it during elaboration. No `native_decide` is needed because the search space is tiny ($p \\le 17$). The seven examples are not just illustrative: they exercise multiplicativity (last row), the second supplementary law (rows 2 and 6), and the reciprocity swap (rows 1, 3, 4) — each reduction lemma in this file gets a worked instance.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
@@ -19,12 +19,13 @@
     "phase": "ACT",
     "since": "2026-04-27T00:00:00-07:00",
     "iteration": 3,
-    "focus": "Sorry-elimination + axiom-elimination roadmap recorded. 2 sorries (exp_dominates_polynomial, analytic_hierarchy) and 3 axioms (contour_shift_decay, rate_is_sharp, paley_wiener_converse) remain. Awaiting Docker availability for Lean execution.",
+    "focus": "Sorry-elimination roadmap clear; disk now available (117 GB free as of 2026-05-03). 2 sorries (exp_dominates_polynomial, analytic_hierarchy) and 3 axioms (contour_shift_decay, rate_is_sharp, paley_wiener_converse) remain.",
     "blockers": [
-      "Docker / disk: this session 921 MB free, below 1 GB safe threshold for Lean builds.",
+      "exp_dominates_polynomial needs Filter.cofinite on ℤ + Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero + rpow ≤ npow bound for |n| ≥ 1. API verification needed before writing (~50-80 lines).",
+      "analytic_hierarchy needs exp_dominates_polynomial + Summable.of_nonneg_of_le with exp_decay_summable(δ/2) as comparison (~40 lines).",
       "Axiom elimination requires substantial Mathlib infrastructure (~700-1100 lines per file roadmap)."
     ],
-    "nextAction": "Future session: close exp_dominates_polynomial via Real.tendsto_pow_mul_exp_neg_atTop_nhds (~30-80 lines); close analytic_hierarchy via Summable.of_nonneg_of_le (~40 lines).",
+    "nextAction": "Close exp_dominates_polynomial via: (1) rw [Filter.eventually_cofinite]; (2) show {n : ℤ | M*exp(-c|n|) > C*|n|⁻¹^α} ⊆ {n : ℤ | |n| ≤ N} for large N; (3) use Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero (Nat.ceil α + 1) + composition with (c *·). Then close analytic_hierarchy via Summable.of_nonneg_of_le.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,


### PR DESCRIPTION
## Summary

- Add missing `meta.theoremCount: 11` to gallery entry
- Update research JSON blockers: disk available (117 GB free as of 2026-05-03; prior blocker was 921 MB)
- Clarify sorry-elimination path for exp_dominates_polynomial / analytic_hierarchy

Generated with Claude Code