### PR TITLE
Research: erdos-1083-oq-02 — structural gap analysis, 43 theorems (complete coverage characterization)

### DIFF
--- a/proofs/Proofs/Erdos1083OQ02.lean
+++ b/proofs/Proofs/Erdos1083OQ02.lean
@@ -394,6 +394,73 @@ theorem guth_katz_exceeds_sv_formula_d2 (ε : ℝ) (hε_pos : ε > 0) (hε_lt : 
 theorem sv_formula_below_conjecture_d2 : (3 : ℝ) / 4 < (2 : ℝ) / 2 := by norm_num
 
 /-
+## Complete Coverage Characterization
+
+The coverage fraction d/(d+2) satisfies an exact threshold law:
+d/(d+2) ≥ p/(p+1) if and only if d ≥ 2p.
+This gives a parametric family of threshold results, of which
+sv_covers_two_thirds_all_d (p=2), sv_covers_three_quarters (p=3),
+and sv_covers_eleven_twelfths (p=11) are special cases.
+-/
+
+/-- Adjacent even-gap telescoping: gap(d) + gap(d+2) = 1/d - 1/(d+4).
+    Via partial fractions, gap(d) = 1/d - 1/(d+2) and gap(d+2) = 1/(d+2) - 1/(d+4),
+    so the 1/(d+2) terms cancel. Even-indexed subsequences telescope with step 4. -/
+theorem gap_adjacent_even_telescope (d : ℕ) (hd : d ≥ 1) :
+    2 / ((↑d : ℝ) * ((↑d : ℝ) + 2)) + 2 / (((↑d : ℝ) + 2) * ((↑d : ℝ) + 4)) =
+    1 / (↑d : ℝ) - 1 / ((↑d : ℝ) + 4) := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd4_pos : (0 : ℝ) < (↑d : ℝ) + 4 := by linarith
+  have hd_ne : (d : ℝ) ≠ 0 := ne_of_gt hd_pos
+  have hd2_ne : (↑d : ℝ) + 2 ≠ 0 := ne_of_gt hd2_pos
+  have hd4_ne : (↑d : ℝ) + 4 ≠ 0 := ne_of_gt hd4_pos
+  field_simp [hd_ne, hd2_ne, hd4_ne]
+  ring
+
+/-- Ratio of consecutive even-indexed gaps: gap(d+2) / gap(d) = d/(d+4).
+    Confirms strict decrease and reveals near-geometric decay: ratio → 1 as d → ∞. -/
+theorem gap_consecutive_ratio (d : ℕ) (hd : d ≥ 1) :
+    (2 / (((↑d : ℝ) + 2) * ((↑d : ℝ) + 4))) /
+    (2 / ((↑d : ℝ) * ((↑d : ℝ) + 2))) = (↑d : ℝ) / ((↑d : ℝ) + 4) := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd4_pos : (0 : ℝ) < (↑d : ℝ) + 4 := by linarith
+  have hd_ne : (d : ℝ) ≠ 0 := ne_of_gt hd_pos
+  have hd2_ne : (↑d : ℝ) + 2 ≠ 0 := ne_of_gt hd2_pos
+  have hd4_ne : (↑d : ℝ) + 4 ≠ 0 := ne_of_gt hd4_pos
+  field_simp [hd_ne, hd2_ne, hd4_ne]
+  ring
+
+/-- General coverage threshold: d/(d+2) ≥ p/(p+1) whenever d ≥ 2p.
+    Proof: d ≥ 2p ↔ p(d+2) ≤ d(p+1) (cross-multiply). The threshold d=2p is sharp
+    (see sv_coverage_fraction_threshold_sharp). Unifies three existing results:
+    p=2 → sv_covers_two_thirds_all_d, p=3 → sv_covers_three_quarters,
+    p=11 → sv_covers_eleven_twelfths. -/
+theorem sv_coverage_fraction_threshold (d p : ℕ) (hp : p ≥ 2) (hd : d ≥ 2 * p) :
+    (d : ℝ) / ((↑d : ℝ) + 2) ≥ (↑p : ℝ) / ((↑p : ℝ) + 1) := by
+  have hp_pos : (0 : ℝ) < (p : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by
+    have := Nat.cast_nonneg (α := ℝ) d; linarith
+  have hp1_pos : (0 : ℝ) < (↑p : ℝ) + 1 := by linarith
+  have hd_cast : 2 * (↑p : ℝ) ≤ (↑d : ℝ) := by exact_mod_cast hd
+  rw [ge_iff_le, div_le_div_iff hp1_pos hd2_pos]
+  nlinarith
+
+/-- Sharpness of the threshold: if d < 2p, SV covers strictly below p/(p+1).
+    Together with sv_coverage_fraction_threshold: d/(d+2) ≥ p/(p+1) ↔ d ≥ 2p. -/
+theorem sv_coverage_fraction_threshold_sharp (d p : ℕ) (hp : p ≥ 1)
+    (hd_pos : d ≥ 1) (hd : d < 2 * p) :
+    (d : ℝ) / ((↑d : ℝ) + 2) < (↑p : ℝ) / ((↑p : ℝ) + 1) := by
+  have hd_pos_r : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr hd_pos
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hp1_pos : (0 : ℝ) < (↑p : ℝ) + 1 := by
+    have := Nat.cast_nonneg (α := ℝ) p; linarith
+  have hd_cast : (↑d : ℝ) < 2 * (↑p : ℝ) := by exact_mod_cast hd
+  rw [div_lt_div_iff hd2_pos hp1_pos]
+  nlinarith
+
+/-
 ## Summary
 
 State of Erdős #1083:
@@ -405,25 +472,29 @@ State of Erdős #1083:
 
 Axiom count: 6 (f, erdos_lower, grid_upper, solymosi_vu, erdos_1083_conjecture, guth_katz)
 Sorry count: 0
-Proved: 39 theorems (gap analysis, exponent comparison, structural properties, progress fractions,
-         partial fractions, SV monotonicity, d=2 comparison)
+Proved: 43 theorems (gap analysis, exponent comparison, structural properties, progress fractions,
+         partial fractions, SV monotonicity, d=2 comparison, coverage characterization)
 
 Key structural results:
 - sv_fraction_of_conjecture: SV exponent = (d+1)/(d+2) · (2/d)
 - gap_exceeds_reciprocal_sq + gap_below_twice_reciprocal_sq: 1/d² < gap < 2/d²
 - gap_partial_fractions: 2/(d(d+2)) = 1/d - 1/(d+2) (partial fractions decomposition)
+- gap_adjacent_even_telescope: gap(d) + gap(d+2) = 1/d - 1/(d+4) (pair telescoping)
+- gap_consecutive_ratio: gap(d+2)/gap(d) = d/(d+4) (near-geometric decay)
 - gap_strictly_decreasing: gap(d) > gap(d+1) (converges to 0)
 - sv_exponent_strictly_decreasing: SV exponent 2(d+1)/(d(d+2)) itself strictly decreases in d
 - sv_fraction_increasing: (d+1)/(d+2) strictly increases toward 1
 - sv_improvement_over_erdos: SV improvement over Erdős = 1/(d+2)
 - sv_covers_d_over_d_plus_2_of_total_gap: SV closes d/(d+2) of full Erdős→conjecture gap
 - sv_remaining_gap_fraction: remaining open fraction = 2/(d+2)
-- sv_covers_two_thirds_all_d: for ALL d ≥ 4 (SV range), coverage ≥ 2/3
+- sv_coverage_fraction_threshold: d/(d+2) ≥ p/(p+1) ↔ d ≥ 2p [general threshold]
+- sv_coverage_fraction_threshold_sharp: sharpness — d < 2p ↔ coverage < p/(p+1)
 - guth_katz_implies_erdos_d2: Guth-Katz resolves the d=2 case of Erdős #1083
 
 The gap 2/(d(d+2)) is precisely characterized: it lies in (1/d², 2/d²),
 strictly decreases with d, and vanishes asymptotically. Key: 2/(d(d+2)) = 1/d - 1/(d+2).
 The SV method closes d/(d+2) of the Erdős→conjecture gap (e.g., 2/3 for d=4, 5/6 for d=10).
+The exact threshold for coverage ≥ p/(p+1) is d = 2p (e.g., p=4 → d≥8 → ≥4/5 coverage).
 For d=2, Guth-Katz eliminates the gap entirely using polynomial partitioning.
 For d ≥ 4, no known approach eliminates the remaining 2/(d+2) fraction.
 -/

--- a/proofs/Proofs/Erdos1083OQ02.lean
+++ b/proofs/Proofs/Erdos1083OQ02.lean
@@ -258,6 +258,62 @@ theorem sv_remaining_gap_fraction (d : ℕ) (hd : d ≥ 4) :
   ring
 
 /-
+## Partial Fractions Structure and SV Exponent Monotonicity
+
+The gap 2/(d(d+2)) has a partial fractions decomposition 1/d - 1/(d+2),
+revealing the telescoping structure behind its monotone decrease.
+Separately, the SV exponent 2(d+1)/(d(d+2)) itself is strictly decreasing
+in d — both the bound and the gap converge to 0 as d → ∞.
+-/
+
+/-- The gap decomposes via partial fractions: 2/(d(d+2)) = 1/d - 1/(d+2).
+    This is the key algebraic identity behind the telescoping structure and
+    the O(1/d²) asymptotic: the gap is a difference of consecutive unit fractions. -/
+theorem gap_partial_fractions (d : ℕ) (hd : d ≥ 1) :
+    2 / ((↑d : ℝ) * ((↑d : ℝ) + 2)) = 1 / (↑d : ℝ) - 1 / ((↑d : ℝ) + 2) := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd_ne : (↑d : ℝ) ≠ 0 := ne_of_gt hd_pos
+  have hd2_ne : (↑d : ℝ) + 2 ≠ 0 := ne_of_gt hd2_pos
+  field_simp
+  ring
+
+/-- The SV exponent 2(d+1)/(d(d+2)) is itself strictly decreasing in d.
+    Both the conjecture exponent 2/d and the SV exponent tend to 0 as d → ∞.
+    Proof reduces to d²+3d+3 > 0 via cross-multiplication — true for all d ≥ 1. -/
+theorem sv_exponent_strictly_decreasing (d : ℕ) (hd : d ≥ 1) :
+    2 * ((↑d : ℝ) + 2) / (((↑d : ℝ) + 1) * ((↑d : ℝ) + 3)) <
+    2 * ((↑d : ℝ) + 1) / ((↑d : ℝ) * ((↑d : ℝ) + 2)) := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd1_pos : (0 : ℝ) < (↑d : ℝ) + 1 := by linarith
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd3_pos : (0 : ℝ) < (↑d : ℝ) + 3 := by linarith
+  rw [div_lt_div_iff (mul_pos hd1_pos hd3_pos) (mul_pos hd_pos hd2_pos)]
+  nlinarith [sq_nonneg (↑d : ℝ), Nat.cast_nonneg (α := ℝ) d]
+
+/-- For all d ≥ 4 (the valid range of the SV theorem), SV covers at least 2/3 of
+    the Erdős→conjecture gap. The threshold d=4 is exact: 4/(4+2) = 2/3. -/
+theorem sv_covers_two_thirds_all_d (d : ℕ) (hd : d ≥ 4) :
+    (d : ℝ) / ((↑d : ℝ) + 2) ≥ 2 / 3 := by
+  have hd_cast : (4 : ℝ) ≤ (d : ℝ) := by exact_mod_cast hd
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  rw [ge_iff_le, div_le_div_iff (by norm_num : (0 : ℝ) < 3) hd2_pos]
+  linarith
+
+/-- Dimensional evaluations at d=5, extending the sequence d=2,3,4 already computed. -/
+theorem gap_formula_d5 : (2 : ℝ) / ((5 : ℝ) * ((5 : ℝ) + 2)) = 2 / 35 := by norm_num
+theorem sv_exponent_formula_d5 :
+    2 * ((5 : ℝ) + 1) / ((5 : ℝ) * ((5 : ℝ) + 2)) = 12 / 35 := by norm_num
+theorem sv_fraction_d5 : ((5 : ℝ) + 1) / ((5 : ℝ) + 2) = 6 / 7 := by norm_num
+theorem sv_progress_fraction_d5 : (5 : ℝ) / ((5 : ℝ) + 2) = 5 / 7 := by norm_num
+
+/-- The d=3 gap (2/15) exceeds the d=5 gap (2/35), consistent with gap_strictly_decreasing. -/
+theorem d3_gap_larger_than_d5 : (2 : ℝ) / 35 < 2 / 15 := by norm_num
+
+/-- The d=4 gap (1/12) exceeds the d=5 gap (2/35). -/
+theorem d4_gap_larger_than_d5 : (2 : ℝ) / 35 < 1 / 12 := by norm_num
+
+/-
 ## The Conjecture
 -/
 
@@ -349,21 +405,24 @@ State of Erdős #1083:
 
 Axiom count: 6 (f, erdos_lower, grid_upper, solymosi_vu, erdos_1083_conjecture, guth_katz)
 Sorry count: 0
-Proved: 28 theorems (gap analysis, exponent comparison, structural properties, progress fractions,
-         d=2 comparison)
+Proved: 39 theorems (gap analysis, exponent comparison, structural properties, progress fractions,
+         partial fractions, SV monotonicity, d=2 comparison)
 
 Key structural results:
 - sv_fraction_of_conjecture: SV exponent = (d+1)/(d+2) · (2/d)
 - gap_exceeds_reciprocal_sq + gap_below_twice_reciprocal_sq: 1/d² < gap < 2/d²
+- gap_partial_fractions: 2/(d(d+2)) = 1/d - 1/(d+2) (partial fractions decomposition)
 - gap_strictly_decreasing: gap(d) > gap(d+1) (converges to 0)
+- sv_exponent_strictly_decreasing: SV exponent 2(d+1)/(d(d+2)) itself strictly decreases in d
 - sv_fraction_increasing: (d+1)/(d+2) strictly increases toward 1
 - sv_improvement_over_erdos: SV improvement over Erdős = 1/(d+2)
 - sv_covers_d_over_d_plus_2_of_total_gap: SV closes d/(d+2) of full Erdős→conjecture gap
 - sv_remaining_gap_fraction: remaining open fraction = 2/(d+2)
+- sv_covers_two_thirds_all_d: for ALL d ≥ 4 (SV range), coverage ≥ 2/3
 - guth_katz_implies_erdos_d2: Guth-Katz resolves the d=2 case of Erdős #1083
 
 The gap 2/(d(d+2)) is precisely characterized: it lies in (1/d², 2/d²),
-strictly decreases with d, and vanishes asymptotically.
+strictly decreases with d, and vanishes asymptotically. Key: 2/(d(d+2)) = 1/d - 1/(d+2).
 The SV method closes d/(d+2) of the Erdős→conjecture gap (e.g., 2/3 for d=4, 5/6 for d=10).
 For d=2, Guth-Katz eliminates the gap entirely using polynomial partitioning.
 For d ≥ 4, no known approach eliminates the remaining 2/(d+2) fraction.

--- a/research/problems/erdos-1083-oq-02/knowledge.md
+++ b/research/problems/erdos-1083-oq-02/knowledge.md
@@ -157,3 +157,55 @@
 - **Assessment**: Gallery formalization now COMPLETE. Narrative covers: gap analysis,
   progress fractions, near-optimality thresholds, quadratic bounds, factored structure,
   asymptotic convergence rate. The open problem (gap elimination) remains unsolved.
+
+## Sessions 6–7 (2026-04-14, researcher-1 / researcher-10) — in PR #14975
+
+These sessions are documented in PR #14975 (research/erdos-1083-oq-02-asymptotic-r10).
+- Session 6: Added Guth-Katz d=2 comparison, axiom 6 (guth_katz), 4 d=2/d=3 evaluations.
+  Theorems 26→30 (incl. sv_exponent_formula_d2/d3, gap_formula_d2/d3, d2 comparisons, GK proof).
+- Session 7 (researcher-10): Re-added session 5 theorems lost in session 6 merge.
+  Added sv_covers_fraction_threshold (general k/(k+1) threshold), sv_fraction_lower_bound,
+  sv_covers_nine_tenths, gap_monotone_bound. Theorems 30→34.
+
+## Session 2026-05-03 (Session 8) — Partial Fractions + SV Monotonicity (researcher-4)
+
+**Mode**: REVISIT
+**Outcome**: progress — 9 new theorems, theorem count 30→39
+
+### What I Did
+- Added new section "Partial Fractions Structure and SV Exponent Monotonicity"
+- Proved `gap_partial_fractions`: 2/(d(d+2)) = 1/d - 1/(d+2) — the key telescoping identity
+- Proved `sv_exponent_strictly_decreasing`: SV exponent 2(d+1)/(d(d+2)) is itself strictly
+  DECREASING in d (holds for d≥1, reduces to d²+3d+3 > 0 via cross-multiplication)
+- Proved `sv_covers_two_thirds_all_d`: for ALL d≥4 (the valid SV range), coverage ≥ 2/3;
+  threshold d=4 is exact (4/6 = 2/3)
+- Added d=5 dimensional evaluations: gap_formula_d5 (2/35), sv_exponent_formula_d5 (12/35),
+  sv_fraction_d5 (6/7), sv_progress_fraction_d5 (5/7)
+- Added gap comparisons: d3_gap_larger_than_d5, d4_gap_larger_than_d5
+- Added `research` label to PR #14975 to help deployer pick it up
+
+### Key Findings
+- `gap_partial_fractions`: 2/(d(d+2)) = 1/d - 1/(d+2) is the fundamental algebraic identity.
+  It explains why the gap is O(1/d²): it's the difference of consecutive unit fractions.
+  Immediately implies gap → 0 and monotone decrease without separate arguments.
+- `sv_exponent_strictly_decreasing` is a new structural insight: NOT the gap, but the actual
+  SV BOUND value 2(d+1)/(d(d+2)) is strictly decreasing. The conjecture 2/d also decreases.
+  Both converge to 0; the gap 2/(d(d+2)) decreases faster (it's the difference).
+- `sv_covers_two_thirds_all_d` gives a UNIVERSAL lower bound for the entire SV regime: every
+  dimension where the SV theorem applies gives at least 2/3 coverage. This is a clean
+  closure result (no exceptions within the SV regime).
+
+### Files Modified
+- `proofs/Proofs/Erdos1083OQ02.lean` (372→431 lines, 30→39 theorems)
+- `src/data/proofs/erdos-1083-oq-02/meta.json` (lineCount, theoremCount, new section, contributions)
+- `src/data/research/problems/erdos-1083-oq-02.json` (builtItems, insights, progressSummary)
+- `research/problems/erdos-1083-oq-02/knowledge.md` (this file)
+
+### Status
+- **Axiom count**: 6 (unchanged)
+- **Sorry count**: 0
+- **Theorems proved**: 39 total (added 9 theorems in new section)
+- **Assessment**: Gallery formalization further deepened. The partial fractions identity
+  is the most mathematically novel result — it provides the simplest proof of monotonicity
+  and the clearest explanation of the O(1/d²) asymptotics. Mathematical gap reduction (d≥3)
+  remains open; no new approach identified.

--- a/research/problems/erdos-1083-oq-02/knowledge.md
+++ b/research/problems/erdos-1083-oq-02/knowledge.md
@@ -209,3 +209,38 @@ These sessions are documented in PR #14975 (research/erdos-1083-oq-02-asymptotic
   is the most mathematically novel result — it provides the simplest proof of monotonicity
   and the clearest explanation of the O(1/d²) asymptotics. Mathematical gap reduction (d≥3)
   remains open; no new approach identified.
+
+## Session 2026-05-03 (Session 7) - Complete Coverage Characterization (39→43 theorems)
+
+**Mode**: REVISIT
+**Outcome**: progress — 4 new theorems
+
+### What I Did
+- Added `gap_adjacent_even_telescope`: gap(d) + gap(d+2) = 1/d - 1/(d+4)
+  (the 1/(d+2) terms cancel via partial fractions; even-indexed subsequences telescope with step 4)
+- Added `gap_consecutive_ratio`: gap(d+2)/gap(d) = d/(d+4) (near-geometric decay rate)
+- Added `sv_coverage_fraction_threshold`: general parametric threshold proving d/(d+2) ≥ p/(p+1)
+  whenever d ≥ 2p; unifies sv_covers_two_thirds_all_d (p=2), sv_covers_three_quarters (p=3),
+  and sv_covers_eleven_twelfths (p=11)
+- Added `sv_coverage_fraction_threshold_sharp`: sharpness — d < 2p implies strict inequality,
+  completing the iff: d/(d+2) ≥ p/(p+1) ↔ d ≥ 2p
+- Updated summary comment (43 theorems), meta.json, knowledge.json
+
+### Key Findings
+- Coverage threshold is a clean iff: coverage ≥ p/(p+1) exactly when d ≥ 2p
+- Concrete thresholds: p=4 → d≥8 gives ≥4/5 coverage; p=10 → d≥20 gives ≥10/11 coverage
+- Gap ratio formula: each even-step gap is exactly d/(d+4) of the previous
+- All proofs algebraic: field_simp+ring (telescoping) and div_le/lt_div_iff+nlinarith (threshold)
+
+### Files Modified
+- `proofs/Proofs/Erdos1083OQ02.lean` (431→502 lines, 39→43 theorems)
+- `src/data/proofs/erdos-1083-oq-02/meta.json` (43 theorems, 502 lines, new section, new contributions)
+- `src/data/research/problems/erdos-1083-oq-02.json` (4 builtItems + 3 insights added)
+
+### Status
+- **Axiom count**: 6 (unchanged)
+- **Sorry count**: 0
+- **Theorems proved**: 43 (added 4 coverage characterization theorems)
+- **Assessment**: Gallery formalization COMPLETE. The coverage threshold iff is the final major
+  structural result. The open problem (gap elimination for any fixed d≥3) remains genuinely
+  unsolved with no known approach. Phase: ACT (Lean code complete, PR updated).

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -35,12 +35,16 @@
       "Partial fractions decomposition: 2/(d(d+2)) = 1/d - 1/(d+2), revealing telescoping structure",
       "SV exponent 2(d+1)/(d(d+2)) is itself strictly decreasing (sv_exponent_strictly_decreasing for d≥1)",
       "For ALL d≥4 (SV range): SV covers ≥2/3 of gap (sv_covers_two_thirds_all_d; threshold exact at d=4)",
-      "Dimensional evaluations at d=5: gap 2/35, SV exponent 12/35, SV fraction 6/7, progress fraction 5/7"
+      "Dimensional evaluations at d=5: gap 2/35, SV exponent 12/35, SV fraction 6/7, progress fraction 5/7",
+      "Adjacent even-gap telescoping: gap(d) + gap(d+2) = 1/d - 1/(d+4), showing the gap sequence telescopes with step 4",
+      "Ratio of consecutive even-indexed gaps: gap(d+2)/gap(d) = d/(d+4), revealing near-geometric decay",
+      "General parametric coverage threshold (sv_coverage_fraction_threshold): d/(d+2) ≥ p/(p+1) iff d ≥ 2p, unifying all previous specific threshold theorems",
+      "Sharpness of the threshold (sv_coverage_fraction_threshold_sharp): d < 2p implies strict inequality, completing the iff characterization"
     ],
     "axiomCount": 6,
-    "lineCount": 431,
+    "lineCount": 502,
     "assumptions": "6 axioms: f (extremal function), erdos_lower/grid_upper (Erdős 1946), solymosi_vu (2008 bound), erdos_1083_conjecture (the open conjecture), guth_katz (Guth-Katz 2015 for d=2).",
-    "theoremCount": 39
+    "theoremCount": 43
   },
   "overview": {
     "historicalContext": "The distinct distances problem is one of Erdős's most celebrated open questions. Erdős (1946) asked: how many distinct distances must n points in ℝ^d determine? He conjectured the answer is Θ(n^{2/d}). His initial lower bound of n^{1/d} came from a simple pigeonhole argument: if there are only k distinct distances, then n concentric spheres around any point cover at most n-1 other points, forcing k ≥ n^{1/d}.\n\nFor d=2 (the plane), this was the famous Erdős distinct distances conjecture. Successive improvements by Spencer-Szemerédi-Trotter (1984), Solymosi-Tóth (2001), and others narrowed the gap, culminating in the near-definitive Guth-Katz theorem (2015) proving f_2(n) ≥ cn/log n — essentially matching the conjectured n^{2/2} = n.\n\nFor d ≥ 3, Solymosi and Vu (2008) proved f_d(n) ≥ n^{2(d+1)/(d(d+2))} using incidence geometry and the Szemerédi-Trotter theorem applied to high-dimensional projections. Their exponent 2(d+1)/(d(d+2)) brought the lower bound within O(1/d²) of the conjectured 2/d. The gap 2/(d(d+2)) is the subject of this formalization.",
@@ -115,6 +119,14 @@
       "endLine": 431,
       "summary": "Axiomatizes the Erdős conjecture (f_d(n) ≥ c·n^{2/d-ε} for all ε>0) and the Guth-Katz theorem (2015: f_2(n) ≥ c·n^{1-ε}). Proves GK implies d=2 conjecture; shows GK exponent (1-ε) exceeds SV formula (3/4) for d=2; gives dimensional evaluations at d=2 (SV gives 3/4, gap 1/4) and d=3 (SV gives 8/15, gap 2/15). The d=2 success highlights why d≥3 remains hard.",
       "mathContext": "Guth-Katz: $f_2(n) \\geq c \\cdot n^{1-\\varepsilon}$ for any $\\varepsilon > 0$, closing the $d=2$ Erdős conjecture. SV formula at $d=2$: $2(3)/(2 \\cdot 4) = 3/4$; gap at $d=2$: $1 - 3/4 = 1/4$ (the largest gap in the sequence). The polynomial method (Dvir, Guth-Katz) does not generalize to $d \\geq 3$ without new ideas."
+    },
+    {
+      "id": "coverage-characterization",
+      "title": "Complete Coverage Characterization",
+      "startLine": 396,
+      "endLine": 502,
+      "summary": "General parametric threshold: d/(d+2) ≥ p/(p+1) iff d ≥ 2p, with sharpness. Adjacent even-gap telescoping: gap(d)+gap(d+2)=1/d-1/(d+4). Gap ratio: gap(d+2)/gap(d) = d/(d+4).",
+      "mathContext": "The iff characterization d/(d+2) >= p/(p+1) iff d >= 2p gives the exact threshold dimension for any target coverage fraction. Telescoping: gap sequence over even indices satisfies gap(d)+gap(d+2) = 1/d - 1/(d+4)."
     }
   ],
   "conclusion": {
@@ -164,10 +176,10 @@
   "sorries": 0,
   "leanFile": {
     "axiomCount": 6,
-    "lineCount": 431,
+    "lineCount": 502,
     "sorries": 0,
     "path": "Proofs/Erdos1083OQ02.lean",
     "definitionCount": 0,
-    "theoremCount": 39
+    "theoremCount": 43
   }
 }

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -31,12 +31,16 @@
       "Progress fraction: SV closes d/(d+2) of Erdős→conjecture gap (proven as sv_covers_d_over_d_plus_2_of_total_gap)",
       "SV improvement over Erdős is exactly 1/(d+2); remaining open fraction is 2/(d+2)",
       "Guth-Katz d=2 comparison: axiomatized GK (2015) result and proved it implies d=2 Erdős conjecture",
-      "Contrast between d=2 (GK resolves gap) and d≥4 (SV gap 2/(d(d+2)) remains entirely open)"
+      "Contrast between d=2 (GK resolves gap) and d≥4 (SV gap 2/(d(d+2)) remains entirely open)",
+      "Partial fractions decomposition: 2/(d(d+2)) = 1/d - 1/(d+2), revealing telescoping structure",
+      "SV exponent 2(d+1)/(d(d+2)) is itself strictly decreasing (sv_exponent_strictly_decreasing for d≥1)",
+      "For ALL d≥4 (SV range): SV covers ≥2/3 of gap (sv_covers_two_thirds_all_d; threshold exact at d=4)",
+      "Dimensional evaluations at d=5: gap 2/35, SV exponent 12/35, SV fraction 6/7, progress fraction 5/7"
     ],
     "axiomCount": 6,
-    "lineCount": 372,
+    "lineCount": 431,
     "assumptions": "6 axioms: f (extremal function), erdos_lower/grid_upper (Erdős 1946), solymosi_vu (2008 bound), erdos_1083_conjecture (the open conjecture), guth_katz (Guth-Katz 2015 for d=2).",
-    "theoremCount": 28
+    "theoremCount": 39
   },
   "overview": {
     "historicalContext": "The distinct distances problem is one of Erdős's most celebrated open questions. Erdős (1946) asked: how many distinct distances must n points in ℝ^d determine? He conjectured the answer is Θ(n^{2/d}). His initial lower bound of n^{1/d} came from a simple pigeonhole argument: if there are only k distinct distances, then n concentric spheres around any point cover at most n-1 other points, forcing k ≥ n^{1/d}.\n\nFor d=2 (the plane), this was the famous Erdős distinct distances conjecture. Successive improvements by Spencer-Szemerédi-Trotter (1984), Solymosi-Tóth (2001), and others narrowed the gap, culminating in the near-definitive Guth-Katz theorem (2015) proving f_2(n) ≥ cn/log n — essentially matching the conjectured n^{2/2} = n.\n\nFor d ≥ 3, Solymosi and Vu (2008) proved f_d(n) ≥ n^{2(d+1)/(d(d+2))} using incidence geometry and the Szemerédi-Trotter theorem applied to high-dimensional projections. Their exponent 2(d+1)/(d(d+2)) brought the lower bound within O(1/d²) of the conjectured 2/d. The gap 2/(d(d+2)) is the subject of this formalization.",
@@ -97,10 +101,18 @@
       "mathContext": "The Erdős-to-conjecture gap is $2/d - 1/d = 1/d$. SV improvement: $2(d+1)/(d(d+2)) - 1/d = 1/(d+2)$. Fraction closed: $(1/(d+2)) / (1/d) = d/(d+2)$. Remaining: $1 - d/(d+2) = 2/(d+2)$. For $d=4$: $2/3$ closed, $1/3$ open."
     },
     {
+      "id": "partial-fractions",
+      "title": "Partial Fractions Structure and SV Exponent Monotonicity",
+      "startLine": 260,
+      "endLine": 315,
+      "summary": "Key identity: 2/(d(d+2)) = 1/d - 1/(d+2) (partial fractions). The SV exponent 2(d+1)/(d(d+2)) is itself strictly decreasing in d (sv_exponent_strictly_decreasing, holds for d≥1). For ALL d≥4, SV covers ≥2/3 of the gap (threshold d=4 exact). Dimensional evaluations at d=5: gap 2/35, SV exponent 12/35, SV fraction 6/7.",
+      "mathContext": "Partial fractions: $2/(d(d+2)) = 1/d - 1/(d+2)$. SV exponent at $d$ vs $d+1$: need $d(d+2)^2 < (d+1)^2(d+3)$, which reduces to $d^2+3d+3 > 0$ — always true. Coverage bound: $d/(d+2) \\geq 2/3 \\iff 3d \\geq 2(d+2) \\iff d \\geq 4$."
+    },
+    {
       "id": "guth-katz-comparison",
       "title": "Guth-Katz (d=2) vs Solymosi-Vu (d≥4) Contrast",
-      "startLine": 264,
-      "endLine": 372,
+      "startLine": 316,
+      "endLine": 431,
       "summary": "Axiomatizes the Erdős conjecture (f_d(n) ≥ c·n^{2/d-ε} for all ε>0) and the Guth-Katz theorem (2015: f_2(n) ≥ c·n^{1-ε}). Proves GK implies d=2 conjecture; shows GK exponent (1-ε) exceeds SV formula (3/4) for d=2; gives dimensional evaluations at d=2 (SV gives 3/4, gap 1/4) and d=3 (SV gives 8/15, gap 2/15). The d=2 success highlights why d≥3 remains hard.",
       "mathContext": "Guth-Katz: $f_2(n) \\geq c \\cdot n^{1-\\varepsilon}$ for any $\\varepsilon > 0$, closing the $d=2$ Erdős conjecture. SV formula at $d=2$: $2(3)/(2 \\cdot 4) = 3/4$; gap at $d=2$: $1 - 3/4 = 1/4$ (the largest gap in the sequence). The polynomial method (Dvir, Guth-Katz) does not generalize to $d \\geq 3$ without new ideas."
     }
@@ -152,10 +164,10 @@
   "sorries": 0,
   "leanFile": {
     "axiomCount": 6,
-    "lineCount": 372,
+    "lineCount": 431,
     "sorries": 0,
     "path": "Proofs/Erdos1083OQ02.lean",
     "definitionCount": 0,
-    "theoremCount": 30
+    "theoremCount": 39
   }
 }

--- a/src/data/research/problems/erdos-1083-oq-02.json
+++ b/src/data/research/problems/erdos-1083-oq-02.json
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 39 theorems (was 30). Added partial fractions identity, SV exponent monotonicity, universal coverage bound, d=5 evaluations. Formalization fully complete. Mathematical gap reduction OPEN.",
+    "progressSummary": "PROGRESS: 43 theorems (was 39). Added complete coverage characterization: general parametric threshold (d/(d+2)>=p/(p+1) iff d>=2p), sharpness, pair telescoping gap(d)+gap(d+2)=1/d-1/(d+4), and gap ratio d/(d+4). Gallery formalization COMPLETE for known theory.",
     "builtItems": [
       "Created Erdos1083OQ02.lean with SV bound formalization",
       "Proved sv_improves_erdos and sv_below_conjecture (exact exponent comparison)",
@@ -67,7 +67,11 @@
       "gap_partial_fractions: 2/(d(d+2)) = 1/d - 1/(d+2) — partial fractions decomposition [Erdos1083OQ02.lean:272]",
       "sv_exponent_strictly_decreasing: SV exponent 2(d+1)/(d(d+2)) is itself strictly decreasing for d≥1 [Erdos1083OQ02.lean:284]",
       "sv_covers_two_thirds_all_d: for ALL d≥4 (SV range), coverage ≥2/3; threshold exact at d=4 [Erdos1083OQ02.lean:296]",
-      "Dimensional evaluations at d=5: gap 2/35, SV exponent 12/35, SV fraction 6/7, progress 5/7 [Erdos1083OQ02.lean:304]"
+      "Dimensional evaluations at d=5: gap 2/35, SV exponent 12/35, SV fraction 6/7, progress 5/7 [Erdos1083OQ02.lean:304]",
+      "gap_adjacent_even_telescope in Erdos1083OQ02.lean:409 — gap(d)+gap(d+2)=1/d-1/(d+4)",
+      "gap_consecutive_ratio in Erdos1083OQ02.lean:423 — gap(d+2)/gap(d) = d/(d+4)",
+      "sv_coverage_fraction_threshold in Erdos1083OQ02.lean:440 — general threshold: d>=2p iff coverage>=p/(p+1)",
+      "sv_coverage_fraction_threshold_sharp in Erdos1083OQ02.lean:452 — sharpness of the threshold"
     ],
     "insights": [
       "SV exponent 2(d+1)/(d(d+2)) is strictly between 1/d and 2/d for d≥4",
@@ -85,7 +89,10 @@
       "General threshold pattern: d/(d+2)≥(k-1)/k ↔ d≥2(k-1); covers 3/4 for d≥6, 11/12 for d≥22",
       "Formalization is complete: 25 theorems, 0 sorries, 5 axioms — gap reduction itself is genuinely open",
       "Partial fractions: 2/(d(d+2)) = 1/d - 1/(d+2); explains telescoping and O(1/d²) behavior at once",
-      "SV exponent itself is strictly DECREASING (not the gap, the actual bound value) — both conjecture and SV exponent tend to 0 as d→∞; the gap decreases faster"
+      "SV exponent itself is strictly DECREASING (not the gap, the actual bound value) — both conjecture and SV exponent tend to 0 as d→∞; the gap decreases faster",
+      "Coverage threshold is exactly d=2p for fraction p/(p+1): proved as iff, unifying the 2/3, 3/4, 11/12 threshold cases",
+      "Adjacent even-indexed gaps telescope: gap(d)+gap(d+2) = 1/d-1/(d+4) — 1/(d+2) terms cancel via partial fractions",
+      "Gap ratio gap(d+2)/gap(d) = d/(d+4), approaching 1 from below — near-geometric decay"
     ],
     "mathlibGaps": [
       "No formalization of incidence geometry in ℝ^d",

--- a/src/data/research/problems/erdos-1083-oq-02.json
+++ b/src/data/research/problems/erdos-1083-oq-02.json
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 25 theorems (was 23). Added threshold dimension bounds for 3/4 and 11/12 gap coverage. Formalization fully complete. Mathematical gap reduction OPEN.",
+    "progressSummary": "PROGRESS: 39 theorems (was 30). Added partial fractions identity, SV exponent monotonicity, universal coverage bound, d=5 evaluations. Formalization fully complete. Mathematical gap reduction OPEN.",
     "builtItems": [
       "Created Erdos1083OQ02.lean with SV bound formalization",
       "Proved sv_improves_erdos and sv_below_conjecture (exact exponent comparison)",
@@ -63,7 +63,11 @@
       "sv_fraction_of_conjecture: SV = (d+1)/(d+2) × (2/d) [Erdos1083OQ02.lean:232]",
       "sv_fraction_increasing: (d+1)/(d+2) strictly increases in d [Erdos1083OQ02.lean:243]",
       "sv_covers_three_quarters: d/(d+2)≥3/4 for d≥6 [Erdos1083OQ02.lean:258]",
-      "sv_covers_eleven_twelfths: d/(d+2)≥11/12 for d≥22 [Erdos1083OQ02.lean:268]"
+      "sv_covers_eleven_twelfths: d/(d+2)≥11/12 for d≥22 [Erdos1083OQ02.lean:268]",
+      "gap_partial_fractions: 2/(d(d+2)) = 1/d - 1/(d+2) — partial fractions decomposition [Erdos1083OQ02.lean:272]",
+      "sv_exponent_strictly_decreasing: SV exponent 2(d+1)/(d(d+2)) is itself strictly decreasing for d≥1 [Erdos1083OQ02.lean:284]",
+      "sv_covers_two_thirds_all_d: for ALL d≥4 (SV range), coverage ≥2/3; threshold exact at d=4 [Erdos1083OQ02.lean:296]",
+      "Dimensional evaluations at d=5: gap 2/35, SV exponent 12/35, SV fraction 6/7, progress 5/7 [Erdos1083OQ02.lean:304]"
     ],
     "insights": [
       "SV exponent 2(d+1)/(d(d+2)) is strictly between 1/d and 2/d for d≥4",
@@ -79,7 +83,9 @@
       "Gap tight bounds: 1/d² < 2/(d(d+2)) < 2/d² — gap is exactly order 1/d²",
       "Absolute gap is strictly decreasing: each additional dimension shrinks the gap",
       "General threshold pattern: d/(d+2)≥(k-1)/k ↔ d≥2(k-1); covers 3/4 for d≥6, 11/12 for d≥22",
-      "Formalization is complete: 25 theorems, 0 sorries, 5 axioms — gap reduction itself is genuinely open"
+      "Formalization is complete: 25 theorems, 0 sorries, 5 axioms — gap reduction itself is genuinely open",
+      "Partial fractions: 2/(d(d+2)) = 1/d - 1/(d+2); explains telescoping and O(1/d²) behavior at once",
+      "SV exponent itself is strictly DECREASING (not the gap, the actual bound value) — both conjecture and SV exponent tend to 0 as d→∞; the gap decreases faster"
     ],
     "mathlibGaps": [
       "No formalization of incidence geometry in ℝ^d",


### PR DESCRIPTION
## Summary

Research session 8 for erdos-1083-oq-02 (Reducing the Solymosi-Vu Gap in Distinct Distances).

Adds 9 theorems in a new section: **Partial Fractions Structure and SV Exponent Monotonicity**.

## New Theorems

- `gap_partial_fractions`: 2/(d(d+2)) = 1/d - 1/(d+2) — telescoping identity explaining O(1/d²) decay
- `sv_exponent_strictly_decreasing`: SV exponent 2(d+1)/(d(d+2)) strictly decreasing in d (d≥1); reduces to d²+3d+3 > 0
- `sv_covers_two_thirds_all_d`: for ALL d≥4, coverage ≥ 2/3; threshold d=4 exact
- d=5 evaluations: gap 2/35, SV exponent 12/35, fraction 6/7, progress 5/7
- Gap ordering: d=3 (2/15) > d=4 (1/12) > d=5 (2/35)

## Files Modified

- proofs/Proofs/Erdos1083OQ02.lean (372→431 lines, 30→39 theorems)
- src/data/proofs/erdos-1083-oq-02/meta.json (lineCount, theoremCount, new section)
- src/data/research/problems/erdos-1083-oq-02.json (builtItems, insights, progressSummary)
- research/problems/erdos-1083-oq-02/knowledge.md (session 8 record)

**Outcome**: progress (30→39 theorems, 0 sorries, 6 axioms unchanged)

Generated by researcher-4