### PR TITLE
fix(erdos-661) + gallery(area-of-circle-oq-01-oq-03-oq-02): meta fixes

### DIFF
--- a/proofs/Proofs/Erdos661Problem.lean
+++ b/proofs/Proofs/Erdos661Problem.lean
@@ -79,15 +79,15 @@ theorem distSq_pos_of_ne {p q : Point2} (h : p ≠ q) : 0 < distSq p q := by
 
 /- ## Main Conjecture -/
 
-/-- **Erdős Problem #661**: Is F(2n) = o(f(2n))?
+/- **Erdős Problem #661**: Is F(2n) = o(f(2n))?
     Equivalently, can bipartite arrangements achieve
     asymptotically fewer distinct distances than general
     point configurations? -/
 /- ## Known Bounds -/
 
-/-- **Guth–Katz (2015)**: f(2n) ≳ n/log n. The minimum number
+/- **Guth–Katz (2015)**: f(2n) ≳ n/log n. The minimum number
     of distinct distances among 2n points is Ω(n/log n). -/
-/-- **Lattice Upper Bound**: f(2n) ≲ n/√(log n) from the integer
+/- **Lattice Upper Bound**: f(2n) ≲ n/√(log n) from the integer
     lattice. Thus the question asks if F(2n) = o(n/√(log n)). -/
 /- ## Basic Bounds -/
 

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "area-of-circle-oq-01-oq-03-oq-02",
+  "title": "Isoperimetric Inequality for Lipschitz Curves (Measure-Theoretic)",
+  "slug": "area-of-circle-oq-01-oq-03-oq-02",
+  "description": "Extends the isoperimetric inequality C² ≥ 4πA from smooth closed curves (proved in area-of-circle-oq-01-oq-03) to Lipschitz closed curves. Uses two axioms: the Wirtinger inequality for Lipschitz/absolutely-continuous functions and the arc-length reparametrization theorem for Lipschitz curves. Verifies the unit circle (equality) and unit square (strict inequality) as examples.",
+  "meta": {
+    "author": "researcher-10",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
+    "tags": [
+      "analysis",
+      "geometry",
+      "measure-theory",
+      "isoperimetric",
+      "lipschitz",
+      "wirtinger",
+      "open-question",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 6,
+    "axiomCount": 2,
+    "theoremCount": 15,
+    "lineCount": 566,
+    "defCount": 4,
+    "assumptions": "2 axioms: (1) wirtinger_ac — Wirtinger inequality for Lipschitz/AC 2π-periodic functions with zero mean: ∫f² ≤ ∫(f')²; (2) exists_lip_nice_reparam — arc-length reparametrization for Lipschitz curves with positive speed a.e., giving constant-speed and zero-mean reparametrization. 6 technical sorries remain: lip_x/lip_y (MVT bound for periodic C¹ → Lipschitz), hdx_int/hdy_int (derivative-squared integrability from LipschitzWith), harea_zero (area=0 from circumference=0), hf_int (integrability of xy'−yx' for Lipschitz curves).",
+    "originalContributions": [
+      "LipschitzClosedCurve structure: Lipschitz-component closed curves (generalizes SmoothClosedCurve)",
+      "LipschitzClosedCurve.circumference and .area via Lebesgue integrals of a.e. derivatives",
+      "SmoothClosedCurve.toLipschitz embedding: smooth → Lipschitz with circumference and area preserved by rfl",
+      "circleLipCurve: circle as Lipschitz curve via toLipschitz embedding",
+      "Square examples: square_isoperimetric_ratio, square_strict_isoperimetric, square_a_strict_isoperimetric fully proved",
+      "wirtinger_sum_sq_bound_lip: ∫(x²+y²) ≤ 2πc² from Wirtinger axiom applied to x and y + constant-speed a.e.",
+      "lipschitz_isoperimetric: 4πA ≤ C² for Lipschitz curves (main theorem, 1 sorry in degenerate case)",
+      "smooth_case_follows_from_lipschitz: isoperimetric for smooth curves follows from Lipschitz generalization",
+      "lip_minimum_circumference: C ≥ 2√(πA) as corollary"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "LipschitzWith",
+        "description": "Lipschitz continuity with constant K",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      },
+      {
+        "theorem": "intervalIntegral.integral_add",
+        "description": "Linearity of interval integrals",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+      },
+      {
+        "theorem": "Real.sqrt_nonneg",
+        "description": "Square root is nonneg",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "dateAdded": "2026-05-03"
+  },
+  "overview": {
+    "historicalContext": "Hurwitz (1901) proved the isoperimetric inequality for smooth curves using Fourier series. The Wirtinger inequality is the key analytical ingredient: for a zero-mean 2π-periodic smooth function f, ∫₀²π f² ≤ ∫₀²π (f')². The natural regularity level for the isoperimetric inequality is Lipschitz (or even rectifiable) curves, since these include all piecewise-smooth curves (polygons, convex bodies). For Lipschitz curves, Rademacher's theorem guarantees differentiability a.e., so the arc-length and Green's theorem formulas remain valid as Lebesgue integrals. The Wirtinger inequality extends to W^{1,2}(S¹) and hence to all Lipschitz functions. Maz'ya (1985) and Federer (1969) contain the foundational measure-theoretic machinery for this generalization.",
+    "problemStatement": "For a Lipschitz closed curve γ in ℝ² with circumference C = ∫|γ'|dt and area A = (1/2)|∫(xy'−yx')dt|, prove 4πA ≤ C².",
+    "text": "Extends the isoperimetric inequality to Lipschitz closed curves using the Wirtinger inequality for Lipschitz/AC functions and arc-length reparametrization. The proof architecture is identical to the smooth case: reparametrize to constant speed c = C/(2π), apply Wirtinger to get ∫(x²+y²) ≤ 2πc², apply Cauchy-Schwarz to bound the area integral, then combine arithmetically. The generalization from C¹ to Lipschitz requires only two axioms: Wirtinger-AC and arc-length reparametrization for Lipschitz curves.",
+    "proofStrategy": "1. Reparametrize via exists_lip_nice_reparam to get γ' with constant speed c = C/(2π) a.e. and zero-mean components. 2. Apply wirtinger_ac to x and y separately, add to get ∫(x²+y²) ≤ ∫(x'²+y'²) = 2πc². 3. Apply Cauchy-Schwarz (from parent file) to bound 2A ≤ c·∫√(x²+y²). 4. Combine: 4πA ≤ 4πA ≤ (2πc)² = C². The arithmetic kernel isoperimetric_from_wirtinger_bounds is reused from the smooth case.",
+    "keyInsights": [
+      "The proof structure is identical to the smooth case; the generalization is modular: only the Wirtinger inequality needs to be extended to Lipschitz",
+      "Rademacher's theorem (Lipschitz → differentiable a.e.) underpins all the integrability claims, but is used implicitly via the Wirtinger axiom",
+      "LipschitzWith K f → f is continuous → f² is integrable on compact intervals; the derivative squared requires more care",
+      "The unit square (piecewise-linear, Lipschitz not smooth) is the canonical non-circular example: C=4a, A=a², ratio 4πA/C² = π/4 < 1, fully proved without sorries",
+      "The SmoothClosedCurve → LipschitzClosedCurve embedding preserves circumference and area by definitional equality (rfl)"
+    ],
+    "prerequisites": [
+      "Lipschitz functions and their properties (LipschitzWith in Mathlib)",
+      "Interval integrals and integrability for continuous functions",
+      "Wirtinger inequality for Sobolev/Lipschitz functions",
+      "Parent: area-of-circle-oq-01-oq-03 (smooth isoperimetric inequality)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lipschitz-curves",
+      "title": "Lipschitz Closed Curves",
+      "startLine": 54,
+      "endLine": 120,
+      "summary": "LipschitzClosedCurve structure with Lipschitz x,y components; circumference and area via Lebesgue integrals; toLipschitz embedding from SmoothClosedCurve; structural bounds (circumference_nonneg, area_nonneg).",
+      "mathContext": "LipschitzClosedCurve generalizes SmoothClosedCurve: replaces ContDiff ℝ 1 with LipschitzWith K. Circumference = ∫√(x'²+y'²) and area = (1/2)|∫(xy'−yx')| remain valid via Rademacher/Lebesgue."
+    },
+    {
+      "id": "examples",
+      "title": "Circle and Square Examples",
+      "startLine": 121,
+      "endLine": 183,
+      "summary": "circleLipCurve via toLipschitz embedding; circle circumference = 2πr and area = πr² by inheritance; square examples: isoperimetric ratio = π/4 < 1 for unit and a×a squares, all proved without sorries.",
+      "mathContext": "The circle achieves equality C² = 4πA; the unit square gives 4πA/C² = π/4 < 1 (strict inequality since π < 4)."
+    },
+    {
+      "id": "axioms",
+      "title": "Core Axioms",
+      "startLine": 185,
+      "endLine": 247,
+      "summary": "wirtinger_ac: Wirtinger inequality for LipschitzWith K functions; exists_lip_nice_reparam: arc-length reparametrization producing constant-speed (a.e.) zero-mean Lipschitz curve.",
+      "mathContext": "Wirtinger holds for W^{1,1}(S¹) ⊂ W^{1,2}(S¹) via Fourier. Reparametrization uses inverse function theorem for monotone AC maps (Banach theorem)."
+    },
+    {
+      "id": "wirtinger-bound",
+      "title": "Wirtinger Sum-of-Squares Bound",
+      "startLine": 248,
+      "endLine": 310,
+      "summary": "wirtinger_sum_sq_bound_lip: ∫(x²+y²) ≤ 2πc². Applies wirtinger_ac to x and y, adds results, bounds ∫(x'²+y'²) = 2πc² via a.e. constant-speed. 2 technical sorries for derivative-squared integrability.",
+      "mathContext": "∫(x²+y²) ≤ ∫(x'²) + ∫(y'²) ≤ ∫(x'²+y'²) = 2πc² (last equality from constant speed a.e.)."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Lipschitz Isoperimetric Inequality",
+      "startLine": 311,
+      "endLine": 467,
+      "summary": "lipschitz_isoperimetric: 4πA ≤ C² for Lipschitz closed curves with positive speed a.e. Degenerate case (C=0 → A=0) has 1 sorry; non-degenerate case uses reparametrization + Wirtinger + Cauchy-Schwarz + arithmetic kernel; 1 sorry for hf_int.",
+      "mathContext": "Proof: reparametrize → wirtinger_sum_sq_bound_lip → area_bound → integral Cauchy-Schwarz → isoperimetric_from_wirtinger_bounds."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries",
+      "startLine": 468,
+      "endLine": 505,
+      "summary": "smooth_case_follows_from_lipschitz: smooth isoperimetric is subsumed; lip_isoperimetric_scale_invariant: ratio 4πA/C² is scale-invariant; lip_minimum_circumference: C ≥ 2√(πA).",
+      "mathContext": "All three corollaries follow from lipschitz_isoperimetric without sorries."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization extends the isoperimetric inequality to Lipschitz closed curves, covering all piecewise-smooth curves (polygons, convex bodies). The proof is structurally identical to the smooth case, demonstrating that Lipschitz regularity is the natural level for the isoperimetric inequality. Two axioms (Wirtinger-AC and arc-length reparametrization) capture the deep analytical content; 6 technical sorries remain for derivative integrability (blocked on Rademacher/LipschitzWith.norm_deriv_le in Mathlib).",
+    "implications": "The Lipschitz isoperimetric inequality strictly generalizes the smooth version and applies to the unit square, regular polygons, and any Lipschitz boundary. The proof strategy — Wirtinger + Cauchy-Schwarz + arithmetic kernel — is fully modular and reuses all infrastructure from the parent smooth proof.",
+    "openQuestions": [
+      "Can the 6 technical sorries be closed using Rademacher's theorem (Lipschitz → differentiable a.e.) once it is formalized in Mathlib?",
+      "Does Mathlib 4.26 have LipschitzWith.norm_deriv_le or an analogue for bounding derivative norms?",
+      "Can the degenerate case (harea_zero: circumference=0 implies area=0) be proved from Mathlib's integral_eq_zero_iff machinery?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AreaOfCircleOQ01OQ03"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Topology",
+      "MeasureTheory",
+      "IsoperimetricOQ"
+    ],
+    "namespace": "LipschitzIsoperimetric",
+    "lineCount": 566,
+    "axiomCount": 2,
+    "theoremCount": 15,
+    "lemmaCount": 1,
+    "defCount": 4,
+    "definitionCount": 4,
+    "substantiveTheoremCount": 5,
+    "sorries": 6,
+    "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
+  },
+  "mainTheorems": [
+    {
+      "name": "lipschitz_isoperimetric",
+      "type": "core",
+      "description": "Isoperimetric inequality 4πA ≤ C² for Lipschitz closed curves with positive speed a.e."
+    },
+    {
+      "name": "wirtinger_ac",
+      "type": "axiom",
+      "description": "Wirtinger inequality for LipschitzWith K functions: ∫f² ≤ ∫(f')²"
+    },
+    {
+      "name": "exists_lip_nice_reparam",
+      "type": "axiom",
+      "description": "Arc-length reparametrization producing constant-speed Lipschitz curve"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hurwitz, A.",
+      "title": "Sur quelques applications géométriques des séries de Fourier",
+      "year": "1901",
+      "venue": "Ann. Sci. Ecole Norm. Sup. (3) 19 (1902), 357–408",
+      "note": "Original Fourier series proof of the isoperimetric inequality using Wirtinger's inequality"
+    },
+    {
+      "authors": "Maz'ya, V.",
+      "title": "Sobolev Spaces",
+      "year": "1985",
+      "venue": "Springer-Verlag",
+      "note": "Section 1.3: Wirtinger inequality for W^{1,1}(S¹)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "This proof extends the smooth isoperimetric inequality (oq-01-oq-03) to Lipschitz closed curves"
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "oq-01 proves arc-length reparametrization for smooth curves; this file's axiom extends it to Lipschitz"
+    }
+  ],
+  "sorries": 6
+}

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -20,7 +20,8 @@
     "erdosUrl": "https://erdosproblems.com/661",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 164,
+    "theoremCount": 10,
+    "lineCount": 165,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "mathlib_version": "4.26.0"
   },
@@ -119,7 +120,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 164,
+    "lineCount": 165,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -25,6 +25,18 @@
     ]
   },
   {
+    "id": "ann-qroq03-namespace-setup",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": { "startLine": 37, "endLine": 47 },
+    "type": "context",
+    "title": "Lean Setup: Linting, Open, and Namespace",
+    "content": "Three short lines before the first theorem:\n\n- `set_option linter.unusedVariables false` — silences a linter warning for the `hqp : q < p` hypothesis in `algorithm_descent`, which is intentionally present for its type-level guarantee but not used in the proof body.\n- `open ZMod` — brings `ZMod`-specific definitions, lemmas, and `Decidable` instances into scope. This is what allows `decide` to discharge Legendre symbol equalities: without the `ZMod` decidability infrastructure, `decide` on `legendreSym p a = n` would not type-check.\n- `namespace QRAlgorithm` — groups all four reduction lemmas under a single namespace, so consumers import them as `QRAlgorithm.legendreSym_mul_eq` etc., making the algorithmic origin clear at the use site.",
+    "mathContext": "The `set_option` is a principled design choice: `hqp : q < p` is a *specification* input (its presence at the type level documents the descent invariant) even though the proof itself does not need it (the underlying `reciprocity_swap` works without the ordering hypothesis). This pattern — adding hypothesis for documentation, suppressing the linter — is common in verified algorithm presentations.",
+    "significance": "context",
+    "relatedConcepts": ["set_option", "open ZMod", "namespace", "Decidable instances", "linter.unusedVariables"],
+    "prerequisites": ["Lean 4 namespace system", "Lean 4 linting infrastructure", "ZMod type"]
+  },
+  {
     "id": "ann-multiplicativity",
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {
@@ -112,7 +124,7 @@
     },
     "type": "concept",
     "title": "Verified Examples via decide",
-    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |",
+    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign: $(7/11) = -(11/7) = -(4/7) = -1$ |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |\n\n**Note on the (5/13) docstring**: the Lean source docstring for this example opens with the incorrect claim `(5/13) = 1 (5 is a quadratic residue mod 13)` and then trails off with `wait, need to check`. This is a draft artifact — the QRs mod 13 are $\\{1, 3, 4, 9, 10, 12\\}$, so 5 is *not* a QR mod 13 and `(5/13) = -1` is correct. The `decide` kernel confirms the right answer; the docstring is simply unfinished.",
     "mathContext": "`decide` works here because Mathlib's `legendreSym p a` is implemented via Euler's criterion in `ZMod p` — for a concrete small prime $p$, `ZMod p` is a `Fintype`, so the equality $a^{(p-1)/2} = \\pm 1$ in `ZMod p` is decidable and Lean can evaluate it during elaboration. No `native_decide` is needed because the search space is tiny ($p \\le 17$). The seven examples are not just illustrative: they exercise multiplicativity (last row), the second supplementary law (rows 2 and 6), and the reciprocity swap (rows 1, 3, 4) — each reduction lemma in this file gets a worked instance.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 2026-04-03 proved hCS integrability and harea_bound structure; main theorem lipschitz_isoperimetric is 1 sorry away (hf_int: integrability of xy-yx for Lipschitz curves)",
+    "progressSummary": "PROGRESS (2026-05-03): Gallery entry created. 6 sorries remain (lip_x/lip_y: MVT bound for C¹→Lipschitz; hdx_int/hdy_int: derivative-squared integrability; harea_zero: degenerate case; hf_int: integrability of xy'-yx'). Blocked on LipschitzWith.norm_deriv_le or Rademacher in Mathlib 4.26. Original session (2026-04-03) proved hCS integrability and harea_bound; main theorem lipschitz_isoperimetric compiles up to 2 sorries (harea_zero + hf_int).",
     "builtItems": [
       "LipschitzClosedCurve structure (proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean)",
       "SmoothClosedCurve.toLipschitz embedding (smooth → Lipschitz, preserves C and A by rfl)",
@@ -250,7 +250,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },


### PR DESCRIPTION
## Summary
- **erdos-661**: Convert 3 orphan `/-- -/` doc comments to `/- -/` (Lean 4.26 compatibility); add `theoremCount: 10`; correct `lineCount` 164→165
- **area-of-circle-oq-01-oq-03-oq-02**: Create gallery entry for `AreaOfCircleOQ01OQ03OQ02.lean` (566 lines, 2 axioms, 15 theorems, 6 sorries, status: axiomatized); fix research JSON sorry count 8→6

## Test plan
- [ ] Gallery builds with new area-of-circle-oq-01-oq-03-oq-02 entry
- [ ] Erdős-661 doc-comment fix avoids Lean 4.26 parser warnings
- [ ] meta.json fields validate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)