### PR TITLE
audit(erdos-1018-oq-04-incomplete-01): fix stale sorry/lineCount after #14937

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -20,8 +20,8 @@
     "badge": "axiom",
     "sorries": 3,
     "axiomCount": 1,
-    "lineCount": 279,
-    "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 4 sorries in this file (geometric edge-crossing verifications).",
+    "lineCount": 287,
+    "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 3 sorries in this file (geometric edge-crossing verifications).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
   },
@@ -88,7 +88,7 @@
   ],
   "conclusion": {
     "summary": "This completion pass replaces the vacuous sorry-based `isEmbeddable` with a concrete definition via vertex maps and convex hull separation. K\u2083 and K\u2084 planarity are established with explicit coordinates, reducing them from axioms to theorems (pending geometric verification sorries). The density argument shows n^(1+\u03b5) edges eventually exceed the planar bound 3n, and the Kostochka-Pyber r=2 result is axiomatized as a bridge to the main conjecture.",
-    "implications": "With `isEmbeddableConc` in place, the van Kampen-Flores axioms in the parent formalization now make genuine mathematical claims. The 5 remaining sorries are more tractable than the original `isEmbeddable` sorry: 4 are geometric intersection verifications (potentially provable with Mathlib's convex set library), and 1 is a definition-equivalence sorry whose resolution would unify the two formalizations. This pattern \u2014 resolving a central conceptual sorry to expose finer technical sorries \u2014 represents steady progress in formalization. If the convex hull intersection sorries are filled, the file would establish K\u2083 and K\u2084 planarity as proper theorems in Lean 4, which are not yet in Mathlib.",
+    "implications": "With `isEmbeddableConc` in place, the van Kampen-Flores axioms in the parent formalization now make genuine mathematical claims. The 3 remaining sorries are more tractable than the original `isEmbeddable` sorry: 2 are geometric edge-crossing verifications for the K\u2083 and K\u2084 explicit embeddings (potentially provable with Mathlib's convex set library), and 1 is the planar edge bound |E| \u2264 3|V| - 6 (Euler's formula for planar graphs, not yet in Mathlib). This pattern \u2014 resolving a central conceptual sorry to expose finer technical sorries \u2014 represents steady progress in formalization. If the convex hull intersection sorries are filled, the file would establish K\u2083 and K\u2084 planarity as proper theorems in Lean 4, which are not yet in Mathlib.",
     "openQuestions": [
       "Can Mathlib's `Convex.Hull` and `Set.inter` machinery prove that two non-parallel line segments in \u211d\u00b2 in general position share at most one point (needed for K\u2083 and K\u2084 planarity)?",
       "Can `turanNumber` be defined using Mathlib's extremal graph theory (which is under active development)?",
@@ -127,12 +127,12 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 279,
+    "lineCount": 287,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
-    "sorries": 4,
+    "sorries": 3,
     "definitionCount": 1
   },
-  "sorries": 4
+  "sorries": 3
 }


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1018-oq-04-incomplete-01
**Severity**: HIGH (sorry count mismatch)
**Discovered by**: gallery integrity audit, 2026-05-03

## Problem

After research PR #14937 (commit 0f85e861f72) proved `r2_implies_main_r2` and dropped sorries 4→3, only `meta.sorries` was updated. Three other count fields and two narrative fields stayed stale.

## Evidence

`proofs/Proofs/Erdos1018OQ04Incomplete01.lean` (origin/main, 287 lines):

```
141:    sorry -- Geometric verification: the three edges of a triangle meet only at vertices
163:    sorry -- K₄ planarity requires checking 6 edges don't improperly cross
202:  sorry -- Requires Euler's formula for planar graphs
```

3 sorries, 1 axiom (`kostochka_pyber_r2`), 287 lines.

`src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json` before this PR:

| Field | Before | After (this PR) | Actual |
|---|---|---|---|
| `meta.sorries` | 3 | 3 (unchanged) | 3 |
| `meta.lineCount` | 279 | 287 | 287 |
| `meta.assumptions` (sorry count phrase) | "4 sorries in this file" | "3 sorries in this file" | 3 |
| `conclusion.implications` | "5 remaining sorries (4 geometric + 1 def-equivalence)" | "3 remaining sorries (2 K₃/K₄ geometric + 1 planar Euler bound)" | 3 |
| `leanFile.lineCount` | 279 | 287 | 287 |
| `leanFile.sorries` | 4 | 3 | 3 |
| top-level `sorries` | 4 | 3 | 3 |

## Notes

- The "5 remaining sorries" narrative in `conclusion.implications` predates #14937 — that field never matched `meta.sorries: 4`. Same drift pattern (overstating open sorry count), so I corrected it in the same PR.
- PR #14986 is in flight to prove K₃_planar / K₄_planar (3→1 sorries). This PR fixes the **current main** state; if #14986 lands first, the meta will need another bump (3→1).

---
Automated fix by lean-auditor agent. 6-line minimal patch + 1 narrative correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)