### PR TITLE
audit(tracker): erdos-1018-oq-04-incomplete-01 issues-fixed (#15021)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3070,10 +3070,11 @@
       "result": "clean"
     },
     "erdos-1018-oq-04-incomplete-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-04T23:23:29Z",
-      "result": "clean"
+      "lastAudited": "2026-05-03T02:20:45Z",
+      "result": "issues-fixed",
+      "notes": "PR #15021: stale sorry/lineCount after #14937 (top.sorries 4→3, leanFile.sorries 4→3, lineCount 279→287, narrative 5→3)"
     },
     "erdos-1019": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Tracker update

Mark erdos-1018-oq-04-incomplete-01 as `issues-fixed` after PR #15021 corrected stale sorry counts and lineCount drift introduced by #14937.

- `auditCount`: 6 → 7
- `lastAudited`: 2026-04-04 → 2026-05-03
- `result`: clean → issues-fixed
- `notes`: link to #15021 with summary of fixes

## Why a separate tracker PR

`claim-target.sh complete` rewrites the entire tracker JSON without `ensure_ascii=False`, replacing every `→` and `—` with `→`/`—`, which produces ~80-line noise diffs. Filing the tracker change separately with manual unicode-preserving update keeps both this PR and the meta-fix PR clean and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)