### PR TITLE
audit(ballot-problem-oq-03-oq-01-oq-02): wire Helpers into additionalFiles

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -704,10 +704,10 @@
       "result": "issues-fixed"
     },
     "ballot-problem-oq-03-oq-01-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T23:26:46Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-03T02:35:43Z",
+      "result": "issues-fixed"
     },
     "ballot-problem-oq-03-oq-01-oq-04": {
       "auditCount": 1,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -49,6 +49,9 @@
       "hook_walk_identity_gHookYD: hook walk identity Σ_c hookProd/hookProd(μ\\c)=|μ| proved for all [a,1^b] with b≥1, non-circular via hook_length_formula_gHookYD (session 19)",
       "hook_walk_identity_eightRow: hook walk identity proved for ALL exactly-8-row Young diagrams [a,b,c,d,e,f,g,h] via 7 colLen zones, 36 hookLen lemmas, 8 arm product lemmas, field_simp+ring; 1612 lines, 0 sorries (PART XXII)",
       "hook_walk_identity_nineRow: hook walk identity proved for ALL exactly-9-row Young diagrams [a,b,c,d,e,f,g,h,i] via colLen zones, hookLen lemmas, arm product lemmas, field_simp+ring; 0 sorries (PART XXIII)"
+    ],
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

- The face file `Proofs/BallotProblemOQ03OQ01OQ02.lean` is sorry-free (0) and imports `Proofs.BallotProblemOQ03OQ01OQ02Helpers` (single-level, non-Aristotle).
- `scripts/auditor/find-targets.ts` only follows multi-level submodule imports and `*Aristotle` siblings, so the 5 real sorries in `Helpers.lean` were invisible.
- Result: every audit cycle re-flagged this slug as `sorry mismatch: claims 5, actual 0`, even though both numbers are correct in their own scope.

Adding `Helpers.lean` to `meta.additionalFiles` makes `find-targets` resolve the sibling and count its 5 sorries, which matches the existing claim. After this change, `find-targets --stats` reports `With issues: 0`.

## Verification

```bash
$ npx tsx scripts/auditor/find-targets.ts --stats
Gallery Audit Status:
  Total proofs:     2186
  Audited:          2186
  Unaudited:        0
  With issues:      0
  Critical issues:  0
```

Lean source untouched. Stale `originalContributions[12]` and pre-split `sections[].startLine/endLine` are tracked separately in #14955.

## Test plan

- [x] \`npx tsx scripts/auditor/find-targets.ts --stats\` → 0 issues
- [x] \`npx tsx scripts/auditor/find-targets.ts --issues\` → empty
- [x] Helpers file exists at the path claimed in additionalFiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)