### PR TITLE
audit(tracker): cramers-rule-oq-01-oq-03 issues-found (#15032)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2194,10 +2194,12 @@
       "result": "clean"
     },
     "cramers-rule-oq-01-oq-03": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-03T11:26:09Z",
-      "result": "clean"
+      "auditCount": 4,
+      "issues": [
+        "cramer_ops_{1,2,3,4} prove arithmetically false equalities (1=2, 11=5, 71=53, 479=475); status verified/original suspect — file likely fails to compile but build-safe-subset masks failures. Issue #15032."
+      ],
+      "lastAudited": "2026-05-03T02:50:00Z",
+      "result": "issues-found"
     },
     "cramers-rule-oq-01-oq-04": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Tracker update marking `cramers-rule-oq-01-oq-03` as issues-found per audit issue #15032.

The four `cramer_ops_{1,2,3,4}` theorems in `proofs/Proofs/CramersRuleOQ01OQ03.lean` claim equalities that disagree with the file's own definitions:

| Theorem | Claim | Actual `cramerOperations n` |
|---|---|---|
| `cramer_ops_1` | `= 2` | 1 |
| `cramer_ops_2` | `= 5` | 11 |
| `cramer_ops_3` | `= 53` | 71 |
| `cramer_ops_4` | `= 475` | 479 |

`norm_num [Nat.factorial]` cannot prove `1 = 2` etc., so the file should not type-check. Status `verified/original` is therefore suspect (`build-safe-subset.sh` continues past `lake build` failures, masking the issue).

See #15032 for full analysis and recommended fixes.

## Test plan
- [ ] Mechanic / builder picks up #15032 and either corrects the literal RHS values to match `cramerOperations`, or redefines `cramerOperations` to match the intended small-n totals.
- [ ] `./proofs/scripts/docker-build.sh Proofs.CramersRuleOQ01OQ03` succeeds after fix.
- [ ] meta.json status reverts to `formalized`/`wip` until resolved, or stays `verified` once the proofs actually compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)