### PR TITLE
audit(tracker): central-limit-theorem-oq-04 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1935,10 +1935,10 @@
       "result": "clean"
     },
     "central-limit-theorem-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T11:47:18Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T03:10:00Z",
+      "result": "clean"
     },
     "cevas-theorem": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited central-limit-theorem-oq-04 (last audit 2026-04-03). Counts, contributions, and axiom narrative all match the Lean source (`Proofs/CentralLimitTheoremOQ04.lean`).

## Verification

| Field | Claimed | Actual |
| --- | --- | --- |
| sorries | 0 | 0 |
| axiomCount | 9 | 9 |
| theoremCount | 21 | 21 |
| definitionCount | 10 | 10 |
| lineCount | 649 | 649 |

Axiom names in `assumptions` ("freeCumulant (3), freeConv + linearization + identity (3), cumulant_determines_distribution, semicircle_cumulant_higher, free_clt") match the 9 actual axioms exactly.

All 8 entries in `originalContributions` map to real declarations in the file:
- NCDistribution + nc_dist_ext (94, 101)
- freeConv_comm/assoc/dirac_left, freeConvPow_add (212, 221, 232, 251)
- freeConvPow_cumulant (259)
- Rtransform_additive, Rtransform_freeConvPow (305, 312)
- semicircle (def) + cumulant theorems (356-376)
- free_clt + semicircle_is_attractor (473, 484)
- CLTStructure (520)
- clt_structure_double_variance, clt_structure_double_higher (569, 575)

No phantom theorems or axiom narrative drift.

## Result

Marking `clean` (was `issues-fixed` from prior audit). Section line ranges have drifted ~5-15 lines but this is cosmetic and not material to mathematical claims.

🤖 Generated by lean-auditor