### PR TITLE
fix(erdos-446): drop phantom axioms, re-anchor section lines

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7081,9 +7081,12 @@
     },
     "erdos-446": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T11:47:18Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T03:18:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "Phantom axiom narrative: \"Historical axioms: Besicovitch/Erdős\" entry claimed axioms for docstring-only sections; ford section claimed phantom ford_2008_general axiom; delta originalContributions overstated constraints; section line ranges were stale by 10-25 lines."
+      ]
     },
     "erdos-447": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-446/meta.json
+++ b/src/data/proofs/erdos-446/meta.json
@@ -42,11 +42,10 @@
     ],
     "originalContributions": [
       "hasDivisorInInterval definition: ∃d ∈ (n, 2n) with d | m",
-      "delta axiom: asymptotic density with non-negativity and upper bound",
+      "delta axiom: asymptotic density of integers with a divisor in (n, 2n) (type signature only, no constraints in the axiom)",
       "divisorCount: computable number of divisors in (n, 2n)",
       "deltaR axiom: density with exactly r divisors",
       "alpha constant: 1 - (1 + log log 2)/log 2 ≈ 0.08607",
-      "Historical axioms: Besicovitch 1934, Erdős 1935, Erdős 1960",
       "ford_2008_main axiom: exact asymptotic",
       "ford_2008_disproof axiom: δ₁(n) is NOT o(δ(n))",
       "prime_no_divisor theorem: primes > 2n avoid the interval",
@@ -54,7 +53,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 139,
-    "assumptions": "4 axioms: delta, deltaR, ford_2008_main, ford_2008_disproof. 0 sorries."
+    "assumptions": "4 axioms: delta (asymptotic density signature), deltaR (density-with-r-divisors signature), ford_2008_main (Ford 2008 asymptotic), ford_2008_disproof (Ford 2008 disproof of o(δ) conjecture). 0 sorries. Note: Besicovitch 1934, Erdős 1935, Erdős 1960, and ford_2008_general are mentioned only in docstrings, not declared as axioms."
   },
   "overview": {
     "historicalContext": "Erdős Problem #446 studies the density of integers having a divisor in the interval (n, 2n), a question with a remarkable 74-year history spanning from Besicovitch to Ford. Besicovitch (1934) first showed liminf δ(n) = 0, and Erdős (1935) strengthened this to δ(n) → 0. In 1960, Erdős found the correct exponent: δ(n) = (log n)^{-α + o(1)} where α = 1 - (1 + log log 2)/log 2 ≈ 0.08607.\n\nThe problem has two parts. The first asks for the exact growth rate of δ(n). Kevin Ford resolved this completely in a 2008 Annals of Mathematics paper, proving δ(n) ≍ 1/((log n)^α (log log n)^{3/2}). The secondary (log log n)^{3/2} correction factor refined Erdős's 1960 estimate. Tenenbaum (1984) had made partial progress with improved bounds in Compositio Math.\n\nThe second part asks whether δ₁(n) = o(δ(n)), i.e., whether integers with exactly one divisor in (n, 2n) are negligible. Erdős was \"quite sure\" this was true at Oberwolfach in 1986, but noted that \"recent results of Tenenbaum throw some doubt on this.\" His doubt was prescient: Ford proved δ₁(n) is NOT o(δ(n)), and in fact δᵣ(n) ≫ᵣ δ(n) for all r ≥ 1, meaning the divisor count distribution is surprisingly flat.",
@@ -78,36 +77,43 @@
     {
       "id": "definitions",
       "title": "Basic Definitions",
-      "summary": "hasDivisorInInterval, delta, divisorCount, deltaR, delta_decomposition",
+      "summary": "hasDivisorInInterval, integersWithDivisor, delta axiom, divisorCount, integersWithExactlyRDivisors, deltaR axiom",
       "startLine": 37,
-      "endLine": 74
+      "endLine": 64
     },
     {
       "id": "alpha",
       "title": "The Constant α",
-      "summary": "Definition and numerical bounds for α ≈ 0.08607",
-      "startLine": 75,
-      "endLine": 84
+      "summary": "alpha (noncomputable def): 1 - (1 + log log 2) / log 2 ≈ 0.08607",
+      "startLine": 65,
+      "endLine": 71
     },
     {
       "id": "historical",
       "title": "Historical Results",
-      "summary": "Besicovitch 1934, Erdős 1935, Erdős 1960 axioms",
-      "startLine": 85,
-      "endLine": 106
+      "summary": "Docstrings (no axiom declarations) for Besicovitch 1934, Erdős 1935, Erdős 1960 — narrative only",
+      "startLine": 72,
+      "endLine": 84
     },
     {
       "id": "ford",
       "title": "Ford's Resolution (2008)",
-      "summary": "ford_2008_main, ford_2008_disproof, ford_2008_general axioms",
-      "startLine": 107,
-      "endLine": 130
+      "summary": "ford_2008_main and ford_2008_disproof axioms; ford_2008_general appears as docstring (no declaration)",
+      "startLine": 85,
+      "endLine": 106
     },
     {
       "id": "examples",
       "title": "Key Examples",
       "summary": "prime_no_divisor theorem",
-      "startLine": 131,
+      "startLine": 107,
+      "endLine": 118
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_446_summary theorem combining ford_2008_main and ford_2008_disproof",
+      "startLine": 119,
       "endLine": 139
     }
   ],


### PR DESCRIPTION
## Findings

erdos-446 has 4 real axioms (`delta`, `deltaR`, `ford_2008_main`, `ford_2008_disproof`) and 0 sorries. The numerical counts in meta.json all match. However, the narrative fields contained the **phantom axiom pattern** seen in 37+ other erdos entries: claims of axioms that exist only as docstrings.

### Phantom claims (removed)

1. **\`originalContributions[5]\`**: \"Historical axioms: Besicovitch 1934, Erdős 1935, Erdős 1960\" — these appear only as docstring blocks (lines 74-83), no \`axiom\` keyword.
2. **\`sections[3]\` (\"ford\")** summary: \"ford_2008_main, ford_2008_disproof, ford_2008_general axioms\" — \`ford_2008_general\` is mentioned in a docstring (lines 103-105) but never declared.
3. **\`originalContributions[1]\`**: \"delta axiom: asymptotic density with non-negativity and upper bound\" — the actual axiom is just \`axiom delta (n : ℕ) : ℝ\`, no constraints. Reworded to be honest about the type signature.

### Section line drift (re-anchored)

Section startLine/endLine were stale by 10-25 lines after prior edits to the file head:

| Section | Was | Now |
|---|---|---|
| definitions | 37-74 | 37-64 |
| alpha | 75-84 | 65-71 |
| historical | 85-106 | 72-84 |
| ford | 107-130 | 85-106 |
| examples | 131-139 | 107-118 |
| summary (new) | — | 119-139 |

Added the missing Summary section. Updated each summary string to accurately describe what's actually in the corresponding line range.

### Tracker

Updated audit-tracker entry with \`issues-fixed\` and a description of what was found.

## Verification

- \`Proofs/Erdos446Problem.lean\` is untouched
- Section markers (\`/- ## ... -/\`) confirmed via grep at lines 37, 65, 72, 85, 107, 119
- 4 axioms confirmed: \`delta\` (51), \`deltaR\` (63), \`ford_2008_main\` (91), \`ford_2008_disproof\` (100)

🤖 Generated by lean-auditor