### PR TITLE
audit(tracker): erdos-32 clean (re-audit 4×)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6108,9 +6108,9 @@
     },
     "erdos-32": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T12:59:28Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T03:22:32Z",
+      "result": "clean"
     },
     "erdos-320": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-32: counts and narrative match Lean source
- 0 sorries (claim 0); 3 axioms (claim 3): erdos_log_squared, kolountzakis_log_loglog, ruzsa_lower_bound
- status: axiomatized / badge: axiom — correct Tier C classification
- assumptions field accurately enumerates all 3 axioms; originalContributions accurately scoped
- mathlibDependencies lists only basic infrastructure — core results are genuinely axiomatized, not Mathlib-delegated

## Test plan
- [x] Verified sorry count via comment-stripped grep on proofs/Proofs/Erdos32Problem.lean
- [x] Verified axiom names match between meta.assumptions and Lean declarations
- [x] Confirmed badge/status appropriate for Tier C (axiomatized historical results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)