### PR TITLE
fix(deploy): pin GH_REPO to prevent mathlib-fork remote hijacking

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -35,6 +35,10 @@ find_repo_root() {
 REPO_ROOT="$(find_repo_root)"
 cd "$REPO_ROOT"
 
+# Pin gh to the correct repo — this repo has a mathlib-fork remote that gh
+# defaults to over origin, causing all pr commands to target the wrong repo.
+export GH_REPO="rjwalters/lean-genius"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

- Sets `GH_REPO=rjwalters/lean-genius` at the top of `sync-and-deploy.sh`
- Fixes a bug where `gh` CLI defaults to the `mathlib-fork` remote (`rjwalters/mathlib4`), causing `gh pr list` to return 0 results and the merge step to be skipped entirely

## Root Cause

This repo has two remotes: `origin` (lean-genius) and `mathlib-fork` (mathlib4). The `gh` CLI picks `mathlib-fork` over `origin`, so all PR commands silently targeted the wrong repo.

## Test Plan
- [x] Verified: with `GH_REPO` unset, `gh pr list` returns 0 in this repo
- [x] Verified: with `GH_REPO=rjwalters/lean-genius`, `gh pr list` returns the correct list

🤖 Generated with [Claude Code](https://claude.com/claude-code)