### PR TITLE
audit(angle-trisection-oq-03-oq-01): fix lineCount/theoremCount/sections

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -17,11 +17,11 @@
       "AngleTrisectionOQ03"
     ],
     "namespace": "AngleTrisectionOQ03OQ01",
-    "lineCount": 123,
+    "lineCount": 150,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 2,
-    "theoremCount": 13
+    "theoremCount": 12
   },
   "meta": {
     "author": "Formalized in Lean 4 (researcher-4)",
@@ -117,32 +117,32 @@
   "sections": [
     {
       "title": "Part I: Computable Decision Functions",
-      "lineStart": 24,
-      "lineEnd": 51,
+      "lineStart": 31,
+      "lineEnd": 58,
       "description": "Defines ngonConstructible : ℕ → Bool and proves its correctness"
     },
     {
       "title": "Part II: Program Evaluation",
-      "lineStart": 54,
-      "lineEnd": 80,
+      "lineStart": 60,
+      "lineEnd": 89,
       "description": "#eval commands showing the program computing concrete constructibility answers"
     },
     {
       "title": "Part III: Verified Enumeration",
-      "lineStart": 82,
-      "lineEnd": 100,
+      "lineStart": 91,
+      "lineEnd": 110,
       "description": "native_decide proof that constructibleNgons 100 = [3,4,5,...,96] (exactly 24 polygons)"
     },
     {
       "title": "Part IV: Fermat Prime Verification",
-      "lineStart": 102,
-      "lineEnd": 120,
+      "lineStart": 112,
+      "lineEnd": 131,
       "description": "All five known Fermat primes verified as constructible via decide and native_decide"
     },
     {
       "title": "Part V: Structural Consequences",
-      "lineStart": 122,
-      "lineEnd": 139,
+      "lineStart": 133,
+      "lineEnd": 149,
       "description": "Deductions about the structure of constructible polygons"
     }
   ]

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13747,6 +13747,14 @@
       "notes": "meta.json lineCount stale: 230 → 220 (file is 220 lines). Fixed in both meta.lineCount and leanFile.lineCount. All other fields verified clean: 3 sorries (lines 120/155/192) match meta, 0 axioms, 5 theorems, status/badge formalized appropriate for Tier C scaffold.",
       "auditCount": 1,
       "lastAudited": "2026-05-02T23:37:33Z"
+    },
+    "angle-trisection-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [
+        "lineCount 123→150, theoremCount 13→12, all 5 section line ranges off by ~10 (file has been edited since enrichment); core integrity claims (verified/0 sorries/0 axioms) hold — fixed in PR"
+      ],
+      "result": "issues-fixed",
+      "lastAudited": "2026-05-03T03:37:43Z"
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit summary

**Proof**: `angle-trisection-oq-03-oq-01` (Executable Constructibility Checker for Regular Polygons)

Tier A original; integrity claims hold:
- `status: verified`, `badge: original` ✓
- 0 sorries (file & meta) ✓
- 0 axioms in file; assumption note correctly flags 1 import-chain π-transcendence axiom that no theorem here depends on ✓
- 2 defs ✓
- mathlibDependencies are foundational utilities (decide/totient/filterMap), not deep theorems doing the core work — `original` badge is appropriate

## Issues fixed

Housekeeping drift, file was edited since enrichment:

| Field | Was | Now |
|---|---|---|
| `leanFile.lineCount` | 123 | 150 |
| `leanFile.theoremCount` | 13 | 12 |
| Part I lineStart/End | 24 / 51 | 31 / 58 |
| Part II lineStart/End | 54 / 80 | 60 / 89 |
| Part III lineStart/End | 82 / 100 | 91 / 110 |
| Part IV lineStart/End | 102 / 120 | 112 / 131 |
| Part V lineStart/End | 122 / 139 | 133 / 149 |

Section ranges recomputed from `/-` block boundaries.

## Tracker
Adds `entries.angle-trisection-oq-03-oq-01` (was unaudited; manual unicode-preserving append).