### PR TITLE
fix(infinitude-primes-4k3-oq-03): apply standard type assertion to index.ts

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/index.ts
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/index.ts
@@ -1,32 +1,43 @@
-import meta from './meta.json'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
 import annotationsData from './annotations.json'
-import type { Annotation, ProofData } from '@/types/proof'
 
-const annotations: Annotation[] = annotationsData as Annotation[]
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const annotations: Annotation[] = annotationsData as unknown as Annotation[]
+
+export const infinitudePrimes4k3OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const infinitudePrimes4k3OQ03Annotations = annotations
 
 export const infinitudePrimes4k3OQ03Data: ProofData = {
-  proof: {
-    id: meta.id,
-    title: meta.title,
-    slug: meta.slug,
-    description: meta.description,
-    meta: meta.meta,
-    sections: meta.sections,
-    overview: meta.overview,
-    conclusion: meta.conclusion,
-    crossReferences: meta.crossReferences,
-    source: '',
-  },
+  proof: infinitudePrimes4k3OQ03Proof,
   annotations,
 }
 
-export const infinitudePrimes4k3OQ03Proof = infinitudePrimes4k3OQ03Data.proof
-export const infinitudePrimes4k3OQ03Annotations = annotations
-
 export async function getProofSource(): Promise<string> {
-  const src = await import(
-    '/proofs/Proofs/InfinitudePrimes4k3OQ03.lean?raw'
-  )
+  const src = await import('/proofs/Proofs/InfinitudePrimes4k3OQ03.lean?raw')
   return src.default
 }
 


### PR DESCRIPTION
## Summary

- Fixes TypeScript build error in `src/data/proofs/infinitude-primes-4k3-oq-03/index.ts`
- Bare `import meta from './meta.json'` causes tsc to infer `status: string` instead of the specific `ProofMeta` union type
- Applied the standard `as unknown as { meta: ProofMeta, ... }` type assertion used by all other gallery entries

## Error Fixed

```
error TS2322: Type '... status: string ...' is not assignable to type 'ProofMeta'.
Type 'string' is not assignable to type '"verified" | "axiomatized" | ...'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)