### PR TITLE
fix(cramers-rule-oq-01-oq-03): correct cramer_ops_{1,2,3,4} arithmetic

### DIFF
--- a/proofs/Proofs/CramersRuleOQ01OQ03.lean
+++ b/proofs/Proofs/CramersRuleOQ01OQ03.lean
@@ -167,20 +167,20 @@ For small n, Cramer's Rule has competitive operation count.
 The crossover happens around n = 4-5.
 -/
 
-/-- At n = 2: Cramer uses 5 operations, Gaussian uses 3 -/
-theorem cramer_ops_2 : cramerOperations 2 = 5 := by
+/-- At n = 2: Cramer uses 11 operations (3 dets × 3 ops each + 2 divisions). -/
+theorem cramer_ops_2 : cramerOperations 2 = 11 := by
   unfold cramerOperations detOperations detMultiplications detAdditions
     leibnizSummands multsPerSummand
   norm_num [Nat.factorial]
 
-/-- At n = 3: Cramer uses 53 operations, Gaussian uses ~14 -/
-theorem cramer_ops_3 : cramerOperations 3 = 53 := by
+/-- At n = 3: Cramer uses 71 operations (4 dets × 17 ops each + 3 divisions). -/
+theorem cramer_ops_3 : cramerOperations 3 = 71 := by
   unfold cramerOperations detOperations detMultiplications detAdditions
     leibnizSummands multsPerSummand
   norm_num [Nat.factorial]
 
-/-- At n = 4: Cramer uses 475 operations -/
-theorem cramer_ops_4 : cramerOperations 4 = 475 := by
+/-- At n = 4: Cramer uses 479 operations (5 dets × 95 ops each + 4 divisions). -/
+theorem cramer_ops_4 : cramerOperations 4 = 479 := by
   unfold cramerOperations detOperations detMultiplications detAdditions
     leibnizSummands multsPerSummand
   norm_num [Nat.factorial]
@@ -195,8 +195,9 @@ Despite O(n!) complexity, Cramer's Rule is useful when:
 4. Theoretical properties are needed (closed-form, adjugate connection)
 -/
 
-/-- For n = 1, Cramer is trivial: x = b/a (2 operations) -/
-theorem cramer_ops_1 : cramerOperations 1 = 2 := by
+/-- For n = 1, the formula gives 1 operation (one trivial determinant + one division;
+the (n-1)=0 multiplications/(n!-1)=0 additions terms vanish). -/
+theorem cramer_ops_1 : cramerOperations 1 = 1 := by
   unfold cramerOperations detOperations detMultiplications detAdditions
     leibnizSummands multsPerSummand
   norm_num [Nat.factorial]
@@ -216,9 +217,8 @@ theorem single_component_formula (n : ℕ) :
 2. det_operations_formula: Leibniz determinant uses n!·(n-1) + (n!-1) ops
 3. cramer_lower_bound: Cramer uses ≥ (n+1)(n!-1) ops
 4. factorial_ge_cube: n! ≥ n³ for n ≥ 6
-5. Exact operation counts: cramer_ops_{1,2,3,4}
+5. Exact operation counts: cramer_ops_{1,2,3,4} = 1, 11, 71, 479
 6. gaussian_cubic_bound: Gaussian is O(n³) (proved)
-7. cramer_exceeds_gaussian: Cramer > Gaussian for n ≥ 6 (sorry)
 -/
 
 #check cramerOperations

--- a/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
@@ -30,7 +30,7 @@
     "text": "Formalizes the complexity comparison between Cramer's Rule (O(n!)) and Gaussian elimination (O(n³)).",
     "proofStrategy": "**Approach**\n\n1. Count operations in Leibniz formula: n! summands × (n-1) multiplications each\n2. Count Cramer operations: (n+1) determinants + n divisions\n3. Count Gaussian operations via summation formulas\n4. Prove n! ≥ n³ for n ≥ 6 by strong induction\n5. Compute exact counts for n = 1,2,3,4",
     "keyInsights": [
-      "**Exact counts reveal the gap**: At n = 4, Cramer uses 475 operations vs ~20 for Gaussian. At n = 10, Cramer needs ~40 million vs ~1000 for Gaussian. The gap grows super-exponentially.",
+      "**Exact counts reveal the gap**: At n = 4, Cramer uses 479 operations vs ~20 for Gaussian. At n = 10, Cramer needs ~40 million vs ~1000 for Gaussian. The gap grows super-exponentially.",
       "**Inductive proof of factorial dominance**: The key step n³ ≥ (n+1)² for n ≥ 3 (equivalently n²(n-1) ≥ 2n+1) makes the induction work. The `nlinarith` tactic handles the polynomial inequality automatically.",
       "**Cramer's theoretical value**: Despite O(n!) complexity, Cramer's Rule provides closed-form solutions essential for the adjugate matrix identity A⁻¹ = adj(A)/det(A) and the algebraic proof of the Cayley-Hamilton theorem.",
       "**Term-by-term bounding for Gaussian O(n³)**: The Lean proof of `gaussian_cubic_bound` uses a crude but elegant approach — bound each term of the two summations by n², sum n-1 and n terms respectively, giving (n-1)n² + n² = n³. A tighter bound of n³/3 would require a closed-form summation identity.",
@@ -80,8 +80,8 @@
       "title": "Exact Operation Counts for Small Systems",
       "startLine": 136,
       "endLine": 210,
-      "summary": "Computes exact Cramer operation counts: n=1→2, n=2→5, n=3→53, n=4→475. Discusses when Cramer's Rule is still useful.",
-      "mathContext": "Cramer operations: 2, 5, 53, 475 for $n = 1, 2, 3, 4$."
+      "summary": "Computes exact Cramer operation counts: n=1→1, n=2→11, n=3→71, n=4→479. Discusses when Cramer's Rule is still useful.",
+      "mathContext": "Cramer operations: 1, 11, 71, 479 for $n = 1, 2, 3, 4$."
     }
   ],
   "conclusion": {
@@ -109,8 +109,8 @@
     {
       "name": "cramer_ops_4",
       "type": "supporting",
-      "description": "Cramer's Rule on a 4×4 system requires exactly 475 operations",
-      "leanType": "cramerOperations 4 = 475"
+      "description": "Cramer's Rule on a 4×4 system requires exactly 479 operations",
+      "leanType": "cramerOperations 4 = 479"
     },
     {
       "name": "cramer_lower_bound",
@@ -156,7 +156,7 @@
       {
         "name": "cramer_ops_4",
         "type": "proved",
-        "description": "Cramer on 4×4 uses 475 ops"
+        "description": "Cramer on 4×4 uses 479 ops"
       },
       {
         "name": "gaussian_cubic_bound",


### PR DESCRIPTION
## Fix

Four exact-crossover theorems in `proofs/Proofs/CramersRuleOQ01OQ03.lean` claimed RHS values (2, 5, 53, 475) that don't match the file's own definition of `cramerOperations`. The audit recomputed and confirmed the correct values are (1, 11, 71, 479):

```
cramerOperations(n) = (n+1) * detOperations(n) + n
detOperations(n)    = n!*(n-1) + (n!-1)

n=1: 2*0 + 1 = 1
n=2: 3*3 + 2 = 11
n=3: 4*17 + 3 = 71
n=4: 5*95 + 4 = 479
```

## Evidence

**Before**: `theorem cramer_ops_2 : cramerOperations 2 = 5 := by ... norm_num` — does not close `11 = 5`.

**After**: `theorem cramer_ops_2 : cramerOperations 2 = 11 := by ... norm_num` — closes by definitional unfolding + `norm_num [Nat.factorial]`.

Also fixed:
- Docstrings for `cramer_ops_{1,2,3,4}` updated to the correct counts.
- Summary block: replaced `cramer_ops_{1,2,3,4}` line with explicit values; dropped the stale `cramer_exceeds_gaussian (sorry)` line referencing a nonexistent declaration.
- `meta.json`: `keyInsights[0]`, `sections.exact-counts.{summary, mathContext}`, `mainTheorems[cramer_ops_4].{description, leanType}`, and `leanFile.mainTheorems[cramer_ops_4].description` updated to match.

Closes #15032

---
Automated fix by lean-mechanic agent.