### PR TITLE
fix(angle-trisection-oq-02-oq-03-ext): add n=34, correct theorem name and insight

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean
@@ -285,13 +285,13 @@ theorem constructible_up_to_50 :
     TotientIsPow2 6 ∧ TotientIsPow2 8 ∧ TotientIsPow2 10 ∧
     TotientIsPow2 12 ∧ TotientIsPow2 15 ∧ TotientIsPow2 16 ∧
     TotientIsPow2 17 ∧ TotientIsPow2 20 ∧ TotientIsPow2 24 ∧
-    TotientIsPow2 30 ∧ TotientIsPow2 32 ∧ TotientIsPow2 40 ∧
-    TotientIsPow2 48 := by
+    TotientIsPow2 30 ∧ TotientIsPow2 32 ∧ TotientIsPow2 34 ∧
+    TotientIsPow2 40 ∧ TotientIsPow2 48 := by
   refine ⟨⟨1, by decide⟩, ⟨1, by decide⟩, ⟨2, by decide⟩,
           ⟨1, by decide⟩, ⟨2, by decide⟩, ⟨2, by decide⟩,
           ⟨2, by decide⟩, ⟨3, by decide⟩, ⟨3, by decide⟩,
           ⟨4, by decide⟩, ⟨3, by decide⟩, ⟨3, by decide⟩,
           ⟨3, by decide⟩, ⟨4, by decide⟩, ⟨4, by decide⟩,
-          ⟨4, by decide⟩⟩
+          ⟨4, by decide⟩, ⟨4, by decide⟩⟩
 
 end AngleTrisectionOQ02OQ03Ext

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-ext/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-ext/meta.json
@@ -45,7 +45,7 @@
       "**Arithmetic bridge**: φ(n) even for n≥3 (since -1 ∈ (ℤ/nℤ)* has order 2). So φ(n) = 2^k iff φ(n)/2 = 2^{k-1}. This connects the maximal real subfield degree to the cyclotomic degree.",
       "**Non-constructibility criterion**: If p | φ(n) for an odd prime p ≥ 3, then φ(n) is NOT a power of 2 — n-gon is not constructible. This handles all non-Fermat cases.",
       "**Complete n ∈ [3,50] table**: 17 constructible n-gons: n = 2^a × (distinct Fermat primes). The remaining 31 values all have odd prime divisors in φ(n).",
-      "**Fermat primes in range**: Only 3, 5, 17 appear as relevant Fermat primes for n ≤ 50. Products: 3×5=15, 3×17=51>50, 5×17=85>50, so 15 is the only Fermat-prime product ≤ 50."
+      "**Fermat primes in range**: Only 3, 5, 17 appear as relevant Fermat primes for n ≤ 50. Distinct-odd-Fermat-prime products in range: just 3×5=15 (since 3×17=51, 5×17=85, 3×5×17=255 all exceed 50). The remaining constructible n combine these with 2^a multipliers — e.g. 34=2×17, 30=2×3×5, 20=4×5, 24=8×3 — and pure powers of 2 (4, 8, 16, 32)."
     ]
   },
   "sections": [
@@ -123,7 +123,7 @@
       "significance": "Closes the gap between cyclotomic degree and real subfield degree"
     },
     {
-      "name": "constructibility_classification_3_50",
+      "name": "constructible_up_to_50",
       "type": "corollary",
       "statement": "Complete list of n ∈ [3,50] with TotientIsPow2 n",
       "description": "17 constructible regular polygons in range [3,50].",


### PR DESCRIPTION
## Fix

Three annotation/code fixes for `angle-trisection-oq-02-oq-03-ext` per audit issue #15057.

## Evidence

**Finding 1 — Missing n=34 in Lean theorem**:
- **Before**: `constructible_up_to_50` conjunction had 16 values (missing n=34)
- **After**: Added `∧ TotientIsPow2 34` between 32 and 40; proof term `⟨4, by decide⟩` (φ(34)=16=2^4)

**Finding 2 — Theorem name mismatch in meta.json**:
- **Before**: `mainTheorems[1].name = "constructibility_classification_3_50"` (nonexistent name)
- **After**: `mainTheorems[1].name = "constructible_up_to_50"` (matches actual Lean theorem)

**Finding 3 — Misleading key insight**:
- **Before**: "3×17=51>50, so 15 is the only Fermat-prime product ≤ 50" — ignored 2^a multipliers like 34=2×17
- **After**: Clarified that distinct-odd-Fermat-prime products and 2^a multipliers together yield all 17 constructible values

Closes #15057

---
Automated fix by lean-mechanic agent.