### PR TITLE
audit(tracker): batch clean — 13 verified proofs (erdos, picks, galois, etc.)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13799,6 +13799,84 @@
       "lastAudited": "2026-05-03T04:44:13Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1054-oq-01-fnorm": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1056-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1214": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "four-square-distribution": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-d4": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-f20": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-waring-g2": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minpoly-charpoly": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "picks-theorem-oq-03-cross-poly": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "picks-theorem-oq-03-ext": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "picks-theorem-oq-03-product": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ramsey-r4k": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "zsqrtd-neg-two": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T04:51:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit Batch 2: 13 Clean Proofs

All 13 proofs verified against `origin/main` Lean sources:

| Proof | Status | Sorries | Axioms | Theorems | Lines |
|-------|--------|---------|--------|----------|-------|
| erdos-1054-oq-01-fnorm | verified/original | 0 | 0 | 49 | 521 |
| erdos-1056-oq-01 | verified/original | 0 | 0 | 29 | 226 |
| erdos-1214 | axiomatized/axiom | 0 | 2 | 26 | 308 |
| four-square-distribution | verified/original | 0 | 0 | 38 | 400 |
| inverse-galois-d4 | verified/original | 0 | 0 | 27 | 682 |
| inverse-galois-f20 | verified/original | 0 | 0 | 27 | 529 |
| lagrange-four-squares-waring-g2 | verified/mathlib | 0 | 0 | 68 | 442 |
| minpoly-charpoly | verified/original | 0 | 0 | 17 | 246 |
| picks-theorem-oq-03-cross-poly | verified/original | 0 | 0 | 69 | 695 |
| picks-theorem-oq-03-ext | verified/original | 0 | 0 | 30 | 288 |
| picks-theorem-oq-03-product | verified/original | 0 | 0 | 57 | 604 |
| ramsey-r4k | verified/original | 0 | 0 | 30 | 587 |
| zsqrtd-neg-two | verified/original | 0 | 0 | 20 | 476 |

**Notes**: erdos-1214 has 2 declared axioms (`corrales_schoof`, `zsygmondy`) — correctly axiomatized. lagrange-four-squares-waring-g2 has mathlib badge with proper Mathlib attribution. erdos-1214 sorry is in a comment, not actual code.

**Checks performed**: sorry count (stripping comments), axiom count (declarations + structures), True stubs, theorem/line counts, phantom axiom narratives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)