### PR TITLE
fix(abel-ruffini-oq-09): replace True placeholders with opaque types; add meta.theoremCount

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -131,6 +131,19 @@ theorem deriv_sub {F : Type*} [DiffField F] (f g : F) :
 ## Part II: Liouville Integration Theorem (Axiom)
 ══════════════════════════════════════════════════════════════════ -/
 
+/-- Elementarity predicate: g belongs to an elementary extension of F.
+    Opaque placeholder — formalization requires Picard-Vessiot theory (not in Mathlib). -/
+opaque IsElementaryOver {F : Type*} [DiffField F] (f g : F) : Prop
+
+/-- Liouville logarithmic-sum predicate: g = v₀ + Σᵢ cᵢ·ln(vᵢ) in an elementary extension.
+    Opaque placeholder — requires a `log` function on DiffField elements (not in Mathlib). -/
+opaque IsLiouvilleForm {F : Type*} [DiffField F]
+    (g v₀ : F) {n : ℕ} (c : Fin n → F) (v : Fin n → F) : Prop
+
+/-- Elementary function predicate for ℝ → ℝ.
+    Opaque placeholder — formalization requires differential Galois theory (not in Mathlib). -/
+opaque IsElementaryFn (f : ℝ → ℝ) : Prop
+
 /-- **Liouville's Integration Theorem** (Liouville 1835, Risch 1969):
     If f ∈ F has an elementary antiderivative, the antiderivative has the form
     g = v₀ + Σᵢ cᵢ·ln(vᵢ) where v₀, vᵢ ∈ F and cᵢ ∈ C (constant subfield).
@@ -143,11 +156,11 @@ axiom liouville_integration_theorem
     {F : Type*} [DiffField F]
     (f : F) (g : F)
     (hantideriv : DiffField.deriv g = f)
-    (helem : True)  -- g belongs to an elementary extension (axiomatized)
+    (helem : IsElementaryOver f g)
     : ∃ (n : ℕ) (v₀ : F) (c : Fin n → F) (v : Fin n → F),
         (∀ i, isConst (c i)) ∧
         (∀ i, v i ≠ 0) ∧
-        True  -- g = v₀ + Σ cᵢ · ln(vᵢ) in the logarithmic extension
+        IsLiouvilleForm g v₀ c v  -- g = v₀ + Σ cᵢ · ln(vᵢ) in the logarithmic extension
 
 /-! ══════════════════════════════════════════════════════════════════
 ## Part III: Risch Criterion and Gaussian Non-Elementarity (Axioms)
@@ -167,7 +180,7 @@ axiom risch_exp_criterion_gaussian :
         p.eval x * (Polynomial.derivative q).eval x -
         2 * x * p.eval x * q.eval x = q.eval x ^ 2) ↔
     ∃ (F : ℝ → ℝ),
-      (∀ x : ℝ, HasDerivAt F (Real.exp (-(x^2))) x) ∧ True
+      (∀ x : ℝ, HasDerivAt F (Real.exp (-(x^2))) x) ∧ IsElementaryFn F
 
 /-- **Gaussian integral is not elementary** (Liouville 1835).
     The antiderivative of e^(-x²) cannot be expressed as a rational function.

--- a/src/data/proofs/abel-ruffini-oq-09/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-09/meta.json
@@ -20,6 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
+    "theoremCount": 20,
     "assumptions": "3 axioms: liouville_integration_theorem (structural form of elementary antiderivatives requires differential Galois/Picard-Vessiot theory not in Mathlib), risch_exp_criterion_gaussian (Risch criterion: ∫e^(-x²)dx elementary iff rational Q with Q'-2xQ=1; requires partial fraction analysis), gaussian_not_elementary (∫e^(-x²) has no elementary antiderivative expressible as a rational function; the main theorem). The polynomial obstruction (no polynomial p satisfies p'-2xp=1) is fully proved without axioms.",
     "dateAdded": "2026-05-03",
     "lineCount": 435,


### PR DESCRIPTION
## Fix

Replace vacuous `True` placeholders in three axioms of `AbelRuffiniOQ09.lean` with `opaque` type declarations, and add the missing `theoremCount: 20` field to `meta.json`.

## Evidence

**Before**: `liouville_integration_theorem` had `(helem : True)` (trivially dischargeable) and `True` as the conclusion. `risch_exp_criterion_gaussian` had `∧ True` on the RHS of the iff, making the biconditional vacuous.

**After**: Three `opaque` declarations (`IsElementaryOver`, `IsLiouvilleForm`, `IsElementaryFn`) give the axioms genuine non-trivial mathematical content that Lean cannot reduce to `True`. `meta.theoremCount: 20` added to match `leanFile.theoremCount`.

Note: these axioms are not used in any proven theorem, so the 20 machine-checked results are unaffected.

Closes #15073

---
Automated fix by lean-mechanic agent.