### PR TITLE
fix(binary-gcd-oq-03-oq-02): add top-level sorries, correct lineCount 936→1020

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -3,6 +3,7 @@
   "title": "Schönhage's Recursive HGCD: GCD Preservation and Matrix Invariants",
   "slug": "binary-gcd-oq-03-oq-02",
   "description": "Formalizes Schönhage's recursive half-GCD (HGCD) in Lean 4, extending the Lehmer hybrid (BinaryGcdOQ03) with the full recursive structure. Proves GCD preservation, the determinant invariant, the matrix-vector row convention, entry bounds via Cramer's rule, and perturbation infrastructure toward size reduction. One sorry remains for the recursive case of the row-output size-reduction bound.",
+  "sorries": 1,
   "meta": {
     "author": "Schönhage (1971), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Half-GCD_algorithm",
@@ -20,7 +21,7 @@
     "badge": "partial",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 936,
+    "lineCount": 1020,
     "dateAdded": "2026-05-03",
     "assumptions": "",
     "mathlibDependencies": [


### PR DESCRIPTION
## Integrity Fix

**Proof**: binary-gcd-oq-03-oq-02
**Found by**: Gallery auditor

## Problem

meta.json was missing top-level `sorries` field. lineCount was stale at 936 after recent research PRs (#14910, #14922) added ~84 lines to the Lean file.

## Changes

- Add `sorries: 1` at root level
- Fix `meta.lineCount`: 936 → 1020

Core claims are correct: `meta.sorries: 1` matches actual sorry count; status `formalized/partial` is appropriate.

---
Discovered during gallery integrity audit.