### PR TITLE
fix(audit): batch meta corrections — missing sorries field and stale lineCount

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
@@ -3,6 +3,7 @@
   "title": "Gödel's Diagonal Lemma: Fixed-Point Theorem Formalization",
   "slug": "godel-first-incompleteness-oq01-oq-04",
   "description": "Formalizes the Diagonal Lemma (Fixed-Point Lemma) as a general axiom and derives Gödel's First Incompleteness Theorem from it. Unlike the companion OQ-01 which takes G's self-reference as an axiom for a specific formula G=⟨42⟩, this file constructs G as the fixed point of ψ(x)=¬Prov(x) via the Diagonal Lemma, making G_self_reference a derived theorem rather than an axiom. Same axiom count (5), clearer mathematical structure.",
+  "sorries": 0,
   "meta": {
     "author": "Kurt Gödel (1931), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Diagonal_lemma",

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -39,8 +39,8 @@
       "constructions_cover_all_odd_primes: both constructions (4k!−1 and (2k!)²+1) cover all odd primes"
     ],
     "dateAdded": "2026-05-03",
-    "lineCount": 100,
-    "assumptions": "0 new axioms — all results follow from InfinitudePrimes4k1 and InfinitudePrimes4k3, which together use only standard Mathlib and the SumTwoSquares module."
+    "lineCount": 103,
+    "assumptions":"0 new axioms — all results follow from InfinitudePrimes4k1 and InfinitudePrimes4k3, which together use only standard Mathlib and the SumTwoSquares module."
   },
   "overview": {
     "historicalContext": "The infinitude of primes congruent to 1 (mod 4) is a special case of **Dirichlet's theorem** (1837), which requires analytic machinery (Dirichlet L-functions). However, the specific case $p \\equiv 1 \\pmod 4$ has an **elementary proof** using Fermat's theorem that $-1$ is a quadratic residue mod $p$ if and only if $p \\equiv 1 \\pmod 4$.\n\nThis result completes the elementary classification of primes by their residue mod 4:\n- $p = 2$ (the unique even prime)\n- $p \\equiv 1 \\pmod 4$ (infinitely many, proved here)\n- $p \\equiv 3 \\pmod 4$ (infinitely many, proved in `infinitude-primes-4k3`)\n\nThe two elementary proofs are parallel in structure but differ in their key lemma: the ≡ 3 case uses a simple product argument, while the ≡ 1 case requires Euler's criterion for quadratic residues.",
@@ -104,7 +104,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 100,
+    "lineCount": 103,
     "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Integrity Fixes (Batch)

**Found by**: Gallery auditor
**Proofs affected**: 2

### godel-first-incompleteness-oq01-oq-04
- Add missing top-level `sorries: 0` field (was present in `meta` block, absent at root)
- Core claims verified: 5 axioms match, 0 sorries match, status axiomatized is correct

### infinitude-primes-4k3-oq-03
- Fix `lineCount`: 100 → 103 in both `meta` and `leanFile` blocks
- Core claims verified: 0 sorries match, 0 axioms, status verified/original is correct

---
Discovered during gallery integrity audit cycle (2026-05-03).