### PR TITLE
fix(infinitude-primes-4k3-oq-03): correct lineCount 100→103

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -39,7 +39,7 @@
       "constructions_cover_all_odd_primes: both constructions (4k!−1 and (2k!)²+1) cover all odd primes"
     ],
     "dateAdded": "2026-05-03",
-    "lineCount": 100,
+    "lineCount": 103,
     "assumptions": "0 new axioms — all results follow from InfinitudePrimes4k1 and InfinitudePrimes4k3, which together use only standard Mathlib and the SumTwoSquares module."
   },
   "overview": {
@@ -104,7 +104,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 100,
+    "lineCount": 103,
     "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Integrity Fix

**Proof**: infinitude-primes-4k3-oq-03
**Found by**: Gallery auditor

## Problem

meta.json `lineCount` fields claimed 100, but the actual Lean file `InfinitudePrimes4k3OQ03.lean` has 103 lines. The 3 extra lines are the right branch of the case split and the closing `end` declaration — complete proof code.

## Changes

- `meta.lineCount`: 100 → 103
- `leanFile.lineCount`: 100 → 103

---
Discovered during gallery integrity audit.