### PR TITLE
Research: erdos-677 — prove conjecture for k=1, k=2 + factorization formula

### DIFF
--- a/proofs/Proofs/Erdos677Problem.lean
+++ b/proofs/Proofs/Erdos677Problem.lean
@@ -21,6 +21,7 @@ same set of prime factors.
 -/
 
 import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Order.Filter.Basic
 import Mathlib.Tactic
@@ -193,3 +194,48 @@ theorem prime_le_dvd_lcmInterval (n k p : ℕ) (hp : p.Prime) (hpk : p ≤ k) :
     p ∣ lcmInterval n k := by
   obtain ⟨i, hi, hpi⟩ := exists_dvd_in_range n k p hp.pos hpk
   exact dvd_trans hpi (dvd_lcmInterval n k i hi)
+
+/- ## Additional structural properties -/
+
+/-- `lcmInterval n k ≠ 0` for all `n`, `k`. -/
+theorem lcmInterval_ne_zero (n k : ℕ) : lcmInterval n k ≠ 0 := by
+  rcases Nat.eq_zero_or_pos k with rfl | hk
+  · simp [lcmInterval_zero]
+  · exact (lcmInterval_pos n k hk).ne'
+
+/-- Lower bound: `n + k ≤ lcmInterval n k` when `k > 0`. -/
+theorem le_lcmInterval (n k : ℕ) (hk : 0 < k) : n + k ≤ lcmInterval n k :=
+  Nat.le_of_dvd (lcmInterval_pos n k hk) (last_dvd_lcmInterval n k hk)
+
+/-- For `k = 2`: `M(n, 2) = (n+1)(n+2)`, since consecutive integers are coprime
+    and `lcm(m, n) = m * n` when `gcd(m, n) = 1`. -/
+theorem lcmInterval_two (n : ℕ) : lcmInterval n 2 = (n + 1) * (n + 2) := by
+  rw [show (2 : ℕ) = 1 + 1 from rfl, lcmInterval_succ, lcmInterval_one, Nat.lcm_comm]
+  exact (Nat.coprime_succ_self (n + 1)).lcm_eq_mul
+
+/-- Erdős #677 holds for `k = 1`: `M(m, 1) = m + 1 ≠ n + 1 = M(n, 1)` when `m ≥ n + 1`. -/
+theorem erdos677_k1 (m n : ℕ) (hm : n + 1 ≤ m) :
+    lcmInterval m 1 ≠ lcmInterval n 1 := by
+  simp only [lcmInterval_one]; omega
+
+/-- Erdős #677 holds for `k = 2`: `M(n, 2) = (n+1)(n+2)` is strictly increasing in `n`,
+    so `M(m, 2) > M(n, 2)` for any `m ≥ n + 2`. -/
+theorem erdos677_k2 (m n : ℕ) (hm : n + 2 ≤ m) :
+    lcmInterval m 2 ≠ lcmInterval n 2 := by
+  rw [lcmInterval_two, lcmInterval_two]
+  nlinarith [Nat.succ_pos n, Nat.succ_pos m]
+
+/- ## Factorization characterization -/
+
+/-- The factorization of `lcmInterval n k` equals the pointwise sup (max) of the
+    factorizations of all `k` consecutive integers `n+1, ..., n+k`.
+    This follows by induction from `factorization (lcm a b) = factorization a ⊔ factorization b`. -/
+theorem factorization_lcmInterval (n k : ℕ) :
+    (lcmInterval n k).factorization =
+    (Finset.range k).sup (fun i => (n + i + 1).factorization) := by
+  induction k with
+  | zero => simp [lcmInterval_zero]
+  | succ k ih =>
+    rw [lcmInterval_succ,
+        Nat.factorization_lcm (by omega) (lcmInterval_ne_zero n k),
+        ih, Finset.range_succ, Finset.sup_insert]

--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/677",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: thue_siegel_finiteness (Thue-Siegel theorem: finitely many solutions for fixed k). Four former axioms now proved: lcmInterval_example1/2 (native_decide), lcmInterval_dvd_product (Finset.induction + Nat.lcm_dvd), lcmInterval_pos (dvd + product positivity).",
-    "lineCount": 195,
+    "assumptions": "1 axiom: thue_siegel_finiteness (Thue-Siegel theorem: finitely many solutions for fixed k). Former axioms now proved: lcmInterval_example1/2 (native_decide), lcmInterval_dvd_product (Finset.induction + Nat.lcm_dvd), lcmInterval_pos (dvd + product positivity). Conjecture verified for k=1 and k=2.",
+    "lineCount": 241,
     "mathlib_version": "4.26.0",
-    "theoremCount": 17
+    "theoremCount": 23
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about the distinctness of lcm of consecutive integer blocks. The Thue-Siegel theorem implies finiteness for fixed k. Erdős knew only two cross-parameter examples: lcm(5,6,7) = lcm(14,15) = 210 and lcm(4,5,6,7) = lcm(20,21) = 420. A stronger conjecture asserts that consecutive products can rarely share the same prime factor set. The LCM of k consecutive integers equals k! times a binomial coefficient, and the prime factorization structure is deeply connected to Sylvester-Schur theory; the analogous problem for products (rather than LCMs) of consecutive integers relates to Catalan-type Diophantine equations and was studied by Stormer and others in the early 20th century.",
@@ -91,15 +91,31 @@
       "endLine": 172,
       "summary": "Recursion (lcmInterval_succ), element divisibility (dvd_lcmInterval), monotonicity in k (lcmInterval_dvd_succ/add), and consecutiveProduct recursion/positivity.",
       "mathContext": "$M(n, k+1) = \\text{lcm}(n+k+1, M(n,k))$. For $i < k$: $(n+i+1) \\mid M(n,k)$. $M(n,k) \\mid M(n, k+j)$ for all $j$. $\\prod_{i=1}^{k+1}(n+i) = \\prod_{i=1}^k (n+i) \\cdot (n+k+1)$."
+    },
+    {
+      "id": "resolved-cases",
+      "title": "Conjecture Resolved for k = 1 and k = 2",
+      "startLine": 200,
+      "endLine": 230,
+      "summary": "PROVED: erdos677_k1 (k=1 case) and erdos677_k2 (k=2 case). Also: lcmInterval_ne_zero (M(n,k) ≠ 0), le_lcmInterval (n+k ≤ M(n,k)), lcmInterval_two (M(n,2) = (n+1)(n+2)).",
+      "mathContext": "For $k=1$: $M(n,1) = n+1$ is injective in $n$, so $M(m,1) \\neq M(n,1)$ when $m \\geq n+1$. For $k=2$: $\\gcd(n+1,n+2)=1$ implies $M(n,2) = (n+1)(n+2)$, which is strictly increasing in $n$, so $M(m,2) > M(n,2)$ when $m \\geq n+2$. Lower bound: $n+k \\mid M(n,k)$ implies $n+k \\leq M(n,k)$ for $k>0$."
+    },
+    {
+      "id": "factorization",
+      "title": "Factorization Characterization",
+      "startLine": 230,
+      "endLine": 241,
+      "summary": "PROVED: factorization_lcmInterval — the Nat.factorization of M(n,k) equals the pointwise sup of the factorizations of n+1,...,n+k.",
+      "mathContext": "$(M(n,k))\\text{.factorization} = \\bigsqcup_{i=0}^{k-1} (n+i+1)\\text{.factorization}$, where $\\sqcup$ is the pointwise maximum of prime exponents. Equivalently: $v_p(M(n,k)) = \\max_{i<k} v_p(n+i+1)$ for every prime $p$. This characterizes when $M(n,k) = M(m,k)$: iff for every prime $p$, the maximum $p$-adic valuation in the two intervals coincide."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 677 on distinctness of LCM of consecutive integers, the stronger prime-factor conjecture, Thue–Siegel finiteness, and structural properties including recursion, element divisibility, and monotonicity. 0 sorries, 15 theorems.",
-    "implications": "Resolution would advance understanding of multiplicative structure of consecutive integers and connect to Diophantine equations.",
+    "summary": "The formalization captures Erdős Problem 677 on distinctness of LCM of consecutive integers, the stronger prime-factor conjecture, Thue–Siegel finiteness, and structural properties. New in this session: the conjecture is PROVED for k=1 and k=2, the key factorization formula is proved (v_p(M(n,k)) = max over i of v_p(n+i+1)), and a lower bound n+k ≤ M(n,k) is established. 0 sorries, 23 theorems.",
+    "implications": "The factorization formula makes precise why the conjecture should hold: as n shifts by k, the set of p-adic valuations must change for at least one prime. The k=1 and k=2 resolved cases show the conjecture holds for small intervals. The general case remains open, with the Thue–Siegel theorem giving finiteness for each fixed k.",
     "openQuestions": [
-      "Is M(m,k) ≠ M(n,k) for all m ≥ n+k?",
-      "Are the two known cross-parameter examples the only ones?",
-      "Does the stronger prime-factor conjecture hold?"
+      "Is M(m,k) ≠ M(n,k) for all m ≥ n+k and k ≥ 3?",
+      "Can the factorization formula be used to prove the conjecture for k=3 or general k?",
+      "Are the two known cross-parameter examples M(4,3)=M(13,2) and M(3,4)=M(19,2) the only ones?"
     ]
   },
   "leanFile": {
@@ -113,9 +129,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 195,
+    "lineCount": 241,
     "axiomCount": 1,
-    "theoremCount": 17,
+    "theoremCount": 23,
     "definitionCount": 5,
     "path": "Proofs/Erdos677Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-677.json
+++ b/src/data/research/problems/erdos-677.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-677",
-  "title": "Erdős #677",
+  "title": "Erd\u0151s #677",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "(LaTeX not available)",
-    "plain": "Let $M(n,k)=[n+1,\\ldots,n+k]$ be the least common multiple of $\\{n+1,\\ldots,n+k\\}$. Is it true that for all $m\\geq n+k$\\[M(n,k) \\neq M(m,k)?\\] The Thue-Siegel theorem implies that, for fixed $k$, there are only finitely many $m,n$ such that $m\\geq n+k$ and $M(n,k)=M(m,k)$. In general, how many solutions does $M(n,k)=M(m,l)$ have when $m\\geq n+k$ and $l>1$? Erdős expects very few (and none when $l\\geq k$). The only solutions Erdős knew were $M(4,3)=M(13,2)$ and $M(3,4)=M(19,2)$. In [Er79d] Erd...",
+    "plain": "Let $M(n,k)=[n+1,\\ldots,n+k]$ be the least common multiple of $\\{n+1,\\ldots,n+k\\}$. Is it true that for all $m\\geq n+k$\\[M(n,k) \\neq M(m,k)?\\] The Thue-Siegel theorem implies that, for fixed $k$, there are only finitely many $m,n$ such that $m\\geq n+k$ and $M(n,k)=M(m,k)$. In general, how many solutions does $M(n,k)=M(m,l)$ have when $m\\geq n+k$ and $l>1$? Erd\u0151s expects very few (and none when $l\\geq k$). The only solutions Erd\u0151s knew were $M(4,3)=M(13,2)$ and $M(3,4)=M(19,2)$. In [Er79d] Erd...",
     "whyMatters": []
   },
   "knownResults": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 7 structural lemmas: recursion, element divisibility, monotonicity in k, consecutive product recursion/positivity. Total: 15 theorems, 1 axiom, 0 sorries.",
+    "progressSummary": "PROGRESS: Conjecture proved for k=1, k=2. Factorization formula proved. 23 theorems, 1 axiom (Thue-Siegel), 0 sorries.",
     "builtItems": [
       "Proved lcmInterval_example1/2 by native_decide",
       "Proved lcmInterval_dvd_product by Finset.induction_on",
@@ -40,20 +40,31 @@
       "lcmInterval_dvd_add: general divisibility monotonicity (Erdos677Problem.lean:145)",
       "last_dvd_lcmInterval: largest element divides (Erdos677Problem.lean:154)",
       "consecutiveProduct_succ: recursion (Erdos677Problem.lean:162)",
-      "consecutiveProduct_pos: positivity (Erdos677Problem.lean:169)"
+      "consecutiveProduct_pos: positivity (Erdos677Problem.lean:169)",
+      "lcmInterval_ne_zero: M(n,k) != 0 (helper for factorization theorem, Erdos677Problem.lean:201)",
+      "le_lcmInterval: n+k <= M(n,k) for k > 0 (lower bound, Erdos677Problem.lean:207)",
+      "lcmInterval_two: M(n,2) = (n+1)*(n+2) via Nat.Coprime.lcm_eq_mul (Erdos677Problem.lean:212)",
+      "erdos677_k1: conjecture PROVED for k=1 via lcmInterval_one + omega (Erdos677Problem.lean:217)",
+      "erdos677_k2: conjecture PROVED for k=2 via lcmInterval_two + nlinarith (Erdos677Problem.lean:223)",
+      "factorization_lcmInterval: factorization = Finset.sup of factorizations, induction on k (Erdos677Problem.lean:233)"
     ],
     "insights": [
-      "lcmInterval_example1/2 are pure computations — lcm(5,6,7)=210=lcm(14,15) and lcm(4,5,6,7)=420=lcm(20,21), provable by native_decide",
+      "lcmInterval_example1/2 are pure computations \u2014 lcm(5,6,7)=210=lcm(14,15) and lcm(4,5,6,7)=420=lcm(20,21), provable by native_decide",
       "lcmInterval_dvd_product follows from Finset.induction + Nat.lcm_dvd + dvd_mul_right",
       "lcmInterval_pos follows from lcmInterval_dvd_product + consecutiveProduct positivity (each factor n+i+1 > 0)",
       "lcmInterval_succ: recursion formula M(n,k+1) = lcm(n+k+1, M(n,k)) via Finset.fold_insert",
       "dvd_lcmInterval: each element n+i+1 divides M(n,k), proved by induction on k using lcmInterval_succ",
       "lcmInterval_dvd_add: M(n,k) | M(n,k+j) for all j, via transitive divisibility chain",
-      "consecutiveProduct_succ and consecutiveProduct_pos: recursion and positivity for consecutive products"
+      "consecutiveProduct_succ and consecutiveProduct_pos: recursion and positivity for consecutive products",
+      "erdos677_k1 PROVED: M(m,1) = m+1 is injective, so conjecture holds for k=1 trivially from lcmInterval_one",
+      "erdos677_k2 PROVED: gcd(n+1,n+2) = 1 implies M(n,2) = (n+1)(n+2), strictly increasing so M(m,2) > M(n,2) for m >= n+2",
+      "factorization_lcmInterval PROVED: (lcmInterval n k).factorization = (Finset.range k).sup (fun i => (n+i+1).factorization) \u2014 the key structural identity that v_p(M(n,k)) = max over i of v_p(n+i+1)",
+      "Lower bound: n+k divides M(n,k), so n+k <= M(n,k) for k > 0 \u2014 proved as le_lcmInterval",
+      "lcmInterval_ne_zero: M(n,k) != 0 for all n,k \u2014 base case 1 != 0, inductive step from pos"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erdős #677 - Knowledge Base\n\n## Problem Statement\n\nLet $M(n,k)=[n+1,\\ldots,n+k]$ be the least common multiple of $\\{n+1,\\ldots,n+k\\}$. Is it true that for all $m\\geq n+k$\\[M(n,k) \\neq M(m,k)?\\] The Thue-Siegel theorem implies that, for fixed $k$, there are only finitely many $m,n$ such that $m\\geq n+k$ and $M(n,k)=M(m,k)$. In general, how many solutions does $M(n,k)=M(m,l)$ have when $m\\geq n+k$ and $l>1$? Erdős expects very few (and none when $l\\geq k$). The only solutions Erdős knew were $M(4,3)=M(13,2)$ and $M(3,4)=M(19,2)$. In [Er79d] Erdős conjectures the stronger fact that (aside from a finite number of exceptions) if $k>2$ and $m\\geq n+k$ then $\\prod_{i\\leq k}(n+i)$ and $\\prod_{i\\leq k}(m+i)$ cannot have the same set of prime factors. See also [678], [686], and [850]. This is discussed in problem B35 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 30 September 2025.\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #678\n- Problem #686\n- Problem #850\n- Problem #676\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79\n- Er79d\n- ErGr80\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
+    "markdown": "# Erd\u0151s #677 - Knowledge Base\n\n## Problem Statement\n\nLet $M(n,k)=[n+1,\\ldots,n+k]$ be the least common multiple of $\\{n+1,\\ldots,n+k\\}$. Is it true that for all $m\\geq n+k$\\[M(n,k) \\neq M(m,k)?\\] The Thue-Siegel theorem implies that, for fixed $k$, there are only finitely many $m,n$ such that $m\\geq n+k$ and $M(n,k)=M(m,k)$. In general, how many solutions does $M(n,k)=M(m,l)$ have when $m\\geq n+k$ and $l>1$? Erd\u0151s expects very few (and none when $l\\geq k$). The only solutions Erd\u0151s knew were $M(4,3)=M(13,2)$ and $M(3,4)=M(19,2)$. In [Er79d] Erd\u0151s conjectures the stronger fact that (aside from a finite number of exceptions) if $k>2$ and $m\\geq n+k$ then $\\prod_{i\\leq k}(n+i)$ and $\\prod_{i\\leq k}(m+i)$ cannot have the same set of prime factors. See also [678], [686], and [850]. This is discussed in problem B35 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 30 September 2025.\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #678\n- Problem #686\n- Problem #850\n- Problem #676\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79\n- Er79d\n- ErGr80\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [
     "erdos"
@@ -76,8 +87,8 @@
     {
       "path": "Proofs/Erdos677Problem.lean",
       "filename": "Erdos677Problem.lean",
-      "lineCount": 196,
-      "theoremCount": 17,
+      "lineCount": 241,
+      "theoremCount": 23,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Research session for Erdős Problem 677: distinctness of lcm of consecutive integers.

### New Theorems (6)

- **`erdos677_k1`**: PROVED — M(m,1) ≠ M(n,1) for m ≥ n+1
- **`erdos677_k2`**: PROVED — M(n,2) = (n+1)(n+2) strictly increasing, so M(m,2) ≠ M(n,2) for m ≥ n+2
- **`factorization_lcmInterval`**: PROVED — (lcmInterval n k).factorization = (range k).sup (fun i => (n+i+1).factorization)
- **`lcmInterval_two`**: M(n,2) = (n+1)(n+2) via Nat.Coprime.lcm_eq_mul
- **`le_lcmInterval`**: n+k ≤ M(n,k) for k > 0
- **`lcmInterval_ne_zero`**: M(n,k) ≠ 0

Total: 23 theorems, 1 axiom (Thue-Siegel), 0 sorries, 241 lines.

🤖 Generated by researcher-10