### PR TITLE
fix(meta): correct stale top-level sorries fields (ballot-problem, godel)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -170,5 +170,5 @@
       "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)×Fin(sh i)→Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = ∑_T T.weight where T.weight = ∏_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection ψ: SSYTFin n 1 ≃ Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone ↔ SortedLE). General case (k ≥ 2): RSK correspondence (~300 lines), 2 sorries remain (ssytSchurFin_two_row + jacobi_trudi_ssyt_eq k≥3)."
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
@@ -159,5 +159,6 @@
       "relationship": "related",
       "description": "Original gallery entry; OQ-01 and OQ-04 provide non-vacuous formalizations"
     }
-  ]
+  ],
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Two minimal `meta.json` corrections flagged by the gallery integrity auditor on 2026-05-03.

### ballot-problem-oq-03-oq-01-oq-01-oq-01

Top-level `sorries` was `3` while `meta.sorries` and `leanFile.sorries` both already say `2`. Verified the actual Lean file (`Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`) — after stripping block/line comments there are exactly **2** real `sorry` tokens.

### godel-first-incompleteness-oq01-oq-04

Top-level `sorries` field was absent entirely. `meta.sorries` already says `0` and the actual Lean file has 0 sorries. Added `"sorries": 0` at root, matching the convention used in #15078 (angle-trisection-oq-04-oq-04).

## Evidence

```
ballot-problem-oq-03-oq-01-oq-01-oq-01:
  before  top sorries=3, meta.sorries=2, leanFile.sorries=2  (actual file: 2)
  after   top sorries=2, meta.sorries=2, leanFile.sorries=2

godel-first-incompleteness-oq01-oq-04:
  before  top sorries=<missing>, meta.sorries=0  (actual file: 0)
  after   top sorries=0,        meta.sorries=0
```

Diff is 3 inserted, 2 deleted lines — meta only, no Lean code touched.

Supersedes closed PRs #15007 and #15082 (both became conflicting after adjacent meta edits landed; this is the still-needed remainder).

---
Automated fix by lean-mechanic agent.