### PR TITLE
research(erdos-1006-oq-01-oq-02): K₃ strict separation — cover ⊊ comparability (3 new theorems)

### DIFF
--- a/proofs/Proofs/Erdos1006OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1006OQ01OQ02.lean
@@ -198,4 +198,64 @@ theorem cover_subclass_comparability [PartialOrder V]
     ∀ u v, G.Adj u v → (u < v ∨ v < u) :=
   fun u v hadj => cover_implies_related hcover hadj
 
+/-
+## K₃: Strict Separation Between Cover and Comparability Graphs
+
+The triangle K₃ (= ⊤ : SimpleGraph (Fin 3)) is a comparability graph but NOT a cover graph.
+This concretely proves that the inclusion cover ⊊ comparability is strict, as mentioned in the
+comment above. The standard order 0 < 1 < 2 on Fin 3 makes K₃ a comparability graph; but no
+partial order can make K₃ a cover graph, since any two covering edges forming a chain forbid
+the third edge from being a covering relation.
+-/
+
+/-- K₃ is a comparability graph: the standard linear order on Fin 3 (0 < 1 < 2) makes all
+    distinct pairs comparable, so every edge of K₃ is witnessed by a comparability relation. -/
+theorem k3_is_comparability_graph : isComparabilityGraph (⊤ : SimpleGraph (Fin 3)) :=
+  ⟨inferInstance, fun u v => by
+    simp only [SimpleGraph.top_adj]
+    exact ⟨fun h => lt_or_gt_of_ne h,
+           fun h => h.elim ne_of_lt (fun hvu => hvu.ne')⟩⟩
+
+/-- K₃ is NOT a cover graph: no partial order on 3 vertices has all three pairs as covering
+    relations. Core argument: x ⋖ y and y ⋖ z immediately forbid x ⋖ z (since y lies strictly
+    between x and z). With three covering edges required, any orientation of the three covering
+    relations either produces a 3-chain (making the long edge non-covering) or a directed cycle
+    (impossible in a partial order). -/
+theorem k3_not_cover_graph : ¬isCoverGraph (⊤ : SimpleGraph (Fin 3)) := by
+  intro ⟨_, hcover⟩
+  -- x ⋖ y and y ⋖ z is impossible alongside x ⋖ z: y lies strictly between x and z
+  have no_chain : ∀ x y z : Fin 3, x ⋖ y → y ⋖ z → ¬(x ⋖ z) := fun x y z hxy hyz hxz =>
+    hxz.2 hxy.lt hyz.lt
+  -- All pairs in K₃ must have a covering relation
+  have cov : ∀ i j : Fin 3, i ≠ j → (i ⋖ j ∨ j ⋖ i) := fun i j hij =>
+    (hcover i j).mp hij
+  -- 8-way case split on orientations of covering edges {0,1}, {0,2}, {1,2}
+  rcases cov 0 1 (by decide) with h01 | h01 <;>
+  rcases cov 0 2 (by decide) with h02 | h02 <;>
+  rcases cov 1 2 (by decide) with h12 | h12
+  -- (0⋖1, 0⋖2, 1⋖2): chain 0<1<2 violates 0⋖2
+  · exact no_chain 0 1 2 h01 h12 h02
+  -- (0⋖1, 0⋖2, 2⋖1): chain 0<2<1 violates 0⋖1
+  · exact no_chain 0 2 1 h02 h12 h01
+  -- (0⋖1, 2⋖0, 1⋖2): cycle 2<0<1<2 gives 2<2
+  · exact absurd (h02.lt.trans (h01.lt.trans h12.lt)) (lt_irrefl 2)
+  -- (0⋖1, 2⋖0, 2⋖1): chain 2<0<1 violates 2⋖1
+  · exact no_chain 2 0 1 h02 h01 h12
+  -- (1⋖0, 0⋖2, 1⋖2): chain 1<0<2 violates 1⋖2
+  · exact no_chain 1 0 2 h01 h02 h12
+  -- (1⋖0, 0⋖2, 2⋖1): cycle 1<0<2<1 gives 1<1
+  · exact absurd (h01.lt.trans (h02.lt.trans h12.lt)) (lt_irrefl 1)
+  -- (1⋖0, 2⋖0, 1⋖2): chain 1<2<0 violates 1⋖0
+  · exact no_chain 1 2 0 h12 h02 h01
+  -- (1⋖0, 2⋖0, 2⋖1): chain 2<1<0 violates 2⋖0
+  · exact no_chain 2 1 0 h12 h01 h02
+
+/-- Strict separation: the inclusion of cover graphs in comparability graphs is proper.
+    The triangle K₃ (3 vertices, all pairs connected) is a comparability graph
+    (via the linear order 0 < 1 < 2) but not a cover graph (proved above). -/
+theorem cover_strictly_subset_comparability :
+    ∃ (W : Type) (_ : Fintype W) (H : SimpleGraph W),
+      isComparabilityGraph H ∧ ¬isCoverGraph H :=
+  ⟨Fin 3, inferInstance, ⊤, k3_is_comparability_graph, k3_not_cover_graph⟩
+
 end Erdos1006OQ01OQ02

--- a/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1006-oq-01-oq-02",
   "title": "Cover Graph Recognition",
   "slug": "erdos-1006-oq-01-oq-02",
-  "description": "Investigates the computational complexity of recognizing cover graphs — graphs that are Hasse diagrams of finite posets. Proves that cover graph membership is in NP (a poset serves as a polynomial-time verifiable certificate) and establishes the key structural characterization: a graph is a cover graph iff it has a shortcut-free acyclic orientation. States the open conjecture that recognition is in polynomial time and contrasts with the known P-time comparability graph recognition (Golumbic 1977). 6 theorems, 2 axioms, 0 sorries.",
+  "description": "Investigates the computational complexity of recognizing cover graphs — graphs that are Hasse diagrams of finite posets. Proves NP membership, the shortcut-free characterization, and that cover graphs are STRICTLY contained in comparability graphs (K₃ is comparability but not cover). States the open P-time conjecture. 10 theorems, 2 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1006",
@@ -39,10 +39,13 @@
       "cover_implies_related: cover graph edges connect comparable pairs in the poset",
       "cover_graph_in_np: NP membership via poset certificate",
       "cover_search_space_bound: search space for recognition is 2^(n²)",
-      "cover_subclass_comparability: cover graphs are a proper subclass of comparability graphs"
+      "cover_subclass_comparability: cover graphs are a proper subclass of comparability graphs",
+      "k3_is_comparability_graph: K₃ (complete graph on Fin 3) is a comparability graph via standard linear order",
+      "k3_not_cover_graph: K₃ is NOT a cover graph — 8-case proof that no partial order on 3 vertices has all pairs as covering relations",
+      "cover_strictly_subset_comparability: strict separation witness — K₃ is comparability but not cover"
     ],
     "dateAdded": "2026-05-03",
-    "lineCount": 175,
+    "lineCount": 261,
     "assumptions": "2 axioms: (1) cover_graph_recognition_in_p — the open conjecture that cover recognition is in P; (2) comparability_recognition_in_p — Golumbic's 1977 theorem that comparability graphs are recognized in polynomial time."
   },
   "overview": {
@@ -83,9 +86,17 @@
       "id": "complexity",
       "title": "Algorithmic Complexity (Open)",
       "startLine": 146,
-      "endLine": 175,
+      "endLine": 199,
       "summary": "States two axioms: cover_graph_recognition_in_p (open conjecture) and comparability_recognition_in_p (Golumbic 1977). Proves cover_subclass_comparability.",
       "mathContext": "The open conjecture cover_graph_recognition_in_p is axiomatized as existence of a Bool-valued decision function that correctly classifies cover graphs. Golumbic's result is similarly axiomatized."
+    },
+    {
+      "id": "k3-separation",
+      "title": "K₃: Strict Separation Between Cover and Comparability Graphs",
+      "startLine": 200,
+      "endLine": 261,
+      "summary": "Proves k3_is_comparability_graph (K₃ is comparability via standard Fin 3 order), k3_not_cover_graph (8-case proof no partial order makes all 3 edges covering), and cover_strictly_subset_comparability (strict containment witness).",
+      "mathContext": "Core argument: x ⋖ y and y ⋖ z forces ¬(x ⋖ z) since y lies between x and z. With 3 pairs each requiring a covering direction, every orientation either creates a 3-chain (making the long edge non-covering) or a directed cycle (impossible in a partial order). The 8 cases correspond to the 2^3 orientations of covering edges {0,1}, {0,2}, {1,2}."
     }
   ],
   "conclusion": {
@@ -115,12 +126,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 175,
+    "lineCount": 261,
     "path": "Proofs/Erdos1006OQ01OQ02.lean",
     "axiomCount": 2,
     "sorries": 0,
     "definitionCount": 5,
-    "theoremCount": 7
+    "theoremCount": 10
   },
   "sorries": 0
 }

--- a/src/data/research/problems/erdos-1006-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-02.json
@@ -7,24 +7,30 @@
     "formal": ""
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Gallery entry created (Erdos1006OQ01OQ02.lean, 7 theorems, 2 axioms, 0 sorries). Proved shortcut-free property of Hasse orientations and NP membership. Stated open P-time conjecture and Golumbic 1977 comparability recognition.",
+    "progressSummary": "PROGRESS: 10 theorems (was 7). Added k3_is_comparability_graph, k3_not_cover_graph (8-case proof), cover_strictly_subset_comparability. Strict separation between cover and comparability graphs formally proved. 2 axioms, 0 sorries, 261 lines.",
     "builtItems": [
       "coverOrientation_no_shortcut: cover orientations are shortcut-free (Erdos1006OQ01OQ02.lean)",
       "cover_graph_is_hasse: cover graphs admit Hasse-like acyclic orientations (Erdos1006OQ01OQ02.lean)",
       "cover_implies_related: cover graph edges connect comparable pairs in the poset (Erdos1006OQ01OQ02.lean)",
       "cover_graph_in_np: NP membership via poset certificate (Erdos1006OQ01OQ02.lean)",
       "cover_search_space_bound: search space 2^(n^2) (Erdos1006OQ01OQ02.lean)",
-      "cover_subclass_comparability: cover graphs are strictly contained in comparability graphs"
+      "cover_subclass_comparability: cover graphs are strictly contained in comparability graphs",
+      "k3_is_comparability_graph: K₃ is a comparability graph via standard linear order on Fin 3 (Erdos1006OQ01OQ02.lean:213)",
+      "k3_not_cover_graph: K₃ is NOT a cover graph — 8-case proof exhausting orientations of covering edges (Erdos1006OQ01OQ02.lean:224)",
+      "cover_strictly_subset_comparability: strict separation witness, K₃ is comparability but not cover (Erdos1006OQ01OQ02.lean:256)"
     ],
     "insights": [
       "Cover graphs != comparability graphs: cover uses covering arcs only, comparability uses all related pairs; 3-chain distinguishes them",
       "Shortcut-free = Hasse: an acyclic orientation is a Hasse diagram iff it has no shortcut arcs (its own transitive reduction)",
       "NP membership is trivial: the poset P is a certificate that can be verified by checking isCoverGraphOf",
-      "CovBy.2 applies directly: if u covers v and u covers w, then huv.2 huw.lt : not(w < v), proving no shortcuts"
+      "CovBy.2 applies directly: if u covers v and u covers w, then huv.2 huw.lt : not(w < v), proving no shortcuts",
+      "K₃ separates cover from comparability: any 2 covering edges x⋖y, y⋖z form a chain forbidding x⋖z. On K₃ this creates a contradiction in all 8 covering-direction assignments.",
+      "8-case proof structure: each case is either no_chain (chain forces missing edge) or lt_irrefl (cycle gives x<x), covering all orientations of 3 covering edges on 3 vertices.",
+      "CovBy.2 accessor gives ∀ c, a < c → ¬(c < b) — the key tool proving no_chain and the strict separation."
     ],
     "mathlibGaps": [
       "DecidableRel G.Adj not automatic for SimpleGraph; needs explicit instance for decidability",
-      "pow_mul needed in simp for (2^n)^n = 2^(n*n) \u2014 simp alone may not close the goal"
+      "pow_mul needed in simp for (2^n)^n = 2^(n*n) — simp alone may not close the goal"
     ],
     "nextSteps": [
       "Run docker build to verify Lean file compiles with 0 sorries",


### PR DESCRIPTION
Adds k3_is_comparability_graph, k3_not_cover_graph (8-case proof), cover_strictly_subset_comparability. Formalizes the strict inclusion cover ⊊ comparability claimed in PR #15085 line 189. 10 theorems, 2 axioms, 0 sorries, 261 lines.