### PR TITLE
enrich(zsqrtd-neg-two): add 10 annotations, deepen historical context and sections

### DIFF
--- a/src/data/proofs/zsqrtd-neg-two/annotations.json
+++ b/src/data/proofs/zsqrtd-neg-two/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-zsqrtd-context",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "The Ring ℤ[√−2] and Quadratic Form Representation",
+    "content": "This module formalizes a classical thread in algebraic number theory: which primes can be written as x² + 2y²? The answer—primes p ≡ 1 or 3 (mod 8)—follows from two facts: (1) ℤ[√−2] is a unique factorization domain (here proved via the Euclidean algorithm), and (2) p splits in ℤ[√−2] if and only if −2 is a quadratic residue mod p, which holds exactly when p ≡ 1 or 3 (mod 8) by the supplementary law for the Legendre symbol. The file builds the entire Euclidean domain structure from scratch and then proves the representation theorem as a consequence.",
+    "mathContext": "$\\mathbb{Z}[\\sqrt{-2}] = \\{a + b\\sqrt{-2} : a, b \\in \\mathbb{Z}\\}$. Norm: $N(a + b\\sqrt{-2}) = a^2 + 2b^2$. Prime $p$ splits in $\\mathbb{Z}[\\sqrt{-2}]$ iff $\\left(\\frac{-2}{p}\\right) = 1$ iff $p \\equiv 1$ or $3 \\pmod{8}$.",
+    "significance": "context",
+    "relatedConcepts": ["Gaussian integers", "quadratic forms", "Legendre symbol", "Euclidean domain", "quadratic reciprocity"],
+    "prerequisites": ["ring theory", "algebraic number theory", "quadratic residues"]
+  },
+  {
+    "id": "ann-zsqrtd-norm",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 43, "endLine": 57 },
+    "type": "definition",
+    "title": "Norm Function: N(a + b√−2) = a² + 2b²",
+    "content": "Three foundational norm lemmas establish the arithmetic of ℤ[√−2]. `norm_def'` unpacks the Mathlib Zsqrtd norm to the explicit formula a² + 2b². `norm_nonneg'` uses the fact that d = −2 ≤ 0 to conclude the norm is always non-negative. `norm_eq_zero_iff'` (using d < 0) shows that norm vanishes only at zero. Together these three lemmas characterize the norm as a positive-definite integer-valued function, a prerequisite for using it as a Euclidean valuation.",
+    "mathContext": "$N(a + b\\sqrt{-2}) = a^2 - (-2) \\cdot b^2 = a^2 + 2b^2 \\geq 0$, with equality iff $a = b = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic norm", "positive definite form", "Euclidean valuation"],
+    "prerequisites": ["Zsqrtd Mathlib API", "integer arithmetic"]
+  },
+  {
+    "id": "ann-zsqrtd-units",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 55, "endLine": 98 },
+    "type": "concept",
+    "title": "Unit Group of ℤ[√−2] is {±1}",
+    "content": "`isUnit_iff_norm_one` reduces unit detection to norm = 1, leveraging Mathlib's `norm_eq_one_iff'`. The main `units_eq` theorem then shows the only solutions to a² + 2b² = 1 over ℤ are (a,b) ∈ {(1,0),(−1,0)}, i.e., z ∈ {1,−1}. The proof bounds b² ≤ 1/2 (so b = 0) and then a² = 1 (so a = ±1), using nlinarith and interval_cases. Contrast with ℤ[i] (units {1,i,−1,−i}) and ℤ[√−1 = i] — the extra 2 factor in the norm makes it harder to achieve norm 1 with non-zero imaginary part.",
+    "mathContext": "$N(u) = 1 \\Rightarrow a^2 + 2b^2 = 1 \\Rightarrow b = 0 \\Rightarrow a = \\pm 1$. Units of $\\mathbb{Z}[\\sqrt{-2}]$ are $\\{\\pm 1\\}$, same as $\\mathbb{Z}[\\sqrt{-d}]$ for $d \\geq 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit group", "Gaussian integers", "ring of integers", "norm equation"],
+    "prerequisites": ["unit in a ring", "integer norm equations"]
+  },
+  {
+    "id": "ann-zsqrtd-division",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 99, "endLine": 122 },
+    "type": "technique",
+    "title": "Rounding-Based Division Algorithm",
+    "content": "The noncomputable `instDiv` and `instMod` instances define Euclidean division in ℤ[√−2] via rational rounding. To divide x by y: compute the exact rational quotient x/y = x · ȳ / N(y) (where ȳ = star y is the conjugate), then round each component to the nearest integer. This is the same construction used for ℤ[i] (Gaussian integers) but adapted to the ℤ[√d] framework with d = −2. The key insight is that the rounding error for each component is at most 1/2, and the combined norm error is (1/2)² + 2·(1/2)² = 3/4 < 1, ensuring the remainder has strictly smaller norm.",
+    "mathContext": "$\\lfloor x/y \\rceil = \\langle \\text{round}((x \\cdot \\bar{y})_{\\mathrm{re}} / N(y)),\\, \\text{round}((x \\cdot \\bar{y})_{\\mathrm{im}} / N(y)) \\rangle$. Error bound: $\\epsilon_1^2 + 2\\epsilon_2^2 \\leq (1/2)^2 + 2(1/2)^2 = 3/4 < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["division algorithm", "Gaussian integers", "Hurwitz integers", "rounding"],
+    "prerequisites": ["rational arithmetic", "Euclidean algorithm", "norm multiplicativity"]
+  },
+  {
+    "id": "ann-zsqrtd-rounding-bound",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 112, "endLine": 121 },
+    "type": "insight",
+    "title": "The 3/4 < 1 Bound: Why ℤ[√−2] is Euclidean",
+    "content": "`sq_rounding_error_lt_one` is the decisive lemma. For any rationals r₁, r₂, the rounding error satisfies (r₁ − round r₁)² + 2(r₂ − round r₂)² < 1. Since each |rᵢ − round rᵢ| ≤ 1/2, the left side is bounded by (1/2)² + 2·(1/2)² = 3/4. This bound is sharp: for ℤ[√d] with d ≥ 3 the analogous bound would be (1/2)² + d·(1/2)² = (1+d)/4, which exceeds 1 when d ≥ 3. So d = −2 is the largest negative integer d for which this simple rounding division is Euclidean with respect to the norm.",
+    "mathContext": "$(r_1 - \\lfloor r_1 \\rceil)^2 + 2(r_2 - \\lfloor r_2 \\rceil)^2 \\leq \\frac{1}{4} + \\frac{2}{4} = \\frac{3}{4} < 1$. For $\\mathbb{Z}[\\sqrt{-d}]$: bound is $\\frac{1+d}{4}$; Euclidean by rounding iff $d \\leq 3$ (with $d=3$ requiring a finer argument).",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean domains", "norm remainder bound", "imaginary quadratic fields"],
+    "prerequisites": ["rounding functions", "quadratic norm", "Euclidean algorithm"]
+  },
+  {
+    "id": "ann-zsqrtd-norm-decrease",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 123, "endLine": 238 },
+    "type": "technique",
+    "title": "Norm Decrease and EuclideanDomain Instance",
+    "content": "`norm_mod_lt` verifies the central Euclidean property: N(x % y) < N(y). The proof factors through three steps: (1) express r·ȳ = A − N(y)·q where A = x·ȳ; (2) cast to ℚ to show the components of r·ȳ equal N(y)·ε where ε are the rounding errors; (3) apply `sq_rounding_error_lt_one` to get N(r)·N(y) < N(y)², hence N(r) < N(y). The `instEuclideanDomain` instance then packages this with `quotient_mul_add_remainder_eq` (from `mod_def`: x % y = x − y*(x/y)) and the well-founded `r_wellFounded` to give ℤ[√−2] its full EuclideanDomain typeclass, making it a PID and UFD by Mathlib's algebraic hierarchy.",
+    "mathContext": "$N(x \\bmod y) \\cdot N(y) = N(r \\cdot \\bar{y}) = N(y)^2 (\\varepsilon_1^2 + 2\\varepsilon_2^2) < N(y)^2$, so $N(x \\bmod y) < N(y)$.",
+    "significance": "key",
+    "relatedConcepts": ["EuclideanDomain typeclass", "PID", "UFD", "norm multiplicativity"],
+    "prerequisites": ["Euclidean division", "norm decrease", "Mathlib typeclass hierarchy"]
+  },
+  {
+    "id": "ann-zsqrtd-factoring",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 240, "endLine": 352 },
+    "type": "technique",
+    "title": "Non-Irreducibility in a UFD Yields a Representation",
+    "content": "`sq_add_two_sq_of_nat_prime_of_not_irreducible` is the key bridge lemma: if a rational prime p is not irreducible in ℤ[√−2] (a UFD), then p = a² + 2b². The proof: since p is not irreducible, write p = x·y with neither a unit. Taking norms: p² = N(x)·N(y). Since N(x), N(y) > 1 (neither a unit) and both divide p², the only possibility in {1, p, p²} is N(x) = N(y) = p. So p = N(x) = x.re² + 2·x.im². The divisor trichotomy for prime p² uses `Nat.dvd_prime_pow`, which lists divisors as {1, p^1, p^2}.",
+    "mathContext": "If $p = x \\cdot y$ with $x, y$ non-units in UFD $\\mathbb{Z}[\\sqrt{-2}]$: $p^2 = N(p) = N(x) \\cdot N(y)$, $N(x) \\mid p^2$, $N(x) \\in \\{1, p, p^2\\}$. Since $N(x) > 1$ and $N(y) > 1$: $N(x) = p = x_1^2 + 2x_2^2$.",
+    "significance": "key",
+    "relatedConcepts": ["unique factorization", "norm equation", "prime divisors", "quadratic forms"],
+    "prerequisites": ["UFD", "EuclideanDomain", "norm multiplicativity", "divisors of prime squares"]
+  },
+  {
+    "id": "ann-zsqrtd-qr-argument",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 354, "endLine": 432 },
+    "type": "technique",
+    "title": "Quadratic Residue of −2 Forces Splitting",
+    "content": "`neg_two_is_qr_of_three_mod_eight` uses Mathlib's `ZMod.exists_sq_eq_neg_two_iff` (second supplementary law: (−2/p) = 1 iff p ≡ 1 or 3 mod 8) to show IsSquare(−2 : ZMod p) when p ≡ 3 (mod 8). Then `not_irreducible_of_neg_two_is_qr` shows: given c with c² ≡ −2 (mod p), the elements α = c + √−2 and β = c − √−2 satisfy α·β = c² + 2 ≡ 0 (mod p), so p | α·β in ℤ[√−2]. If p were irreducible (hence prime in a UFD), it would divide α or β, but their imaginary parts ±1 would force p | ±1, contradicting p > 1. So p is not irreducible.",
+    "mathContext": "$p \\equiv 3 \\pmod{8} \\Rightarrow \\exists c: c^2 \\equiv -2 \\pmod{p}$. Then $(c + \\sqrt{-2})(c - \\sqrt{-2}) = c^2 + 2 \\equiv 0$. If $p$ were prime in $\\mathbb{Z}[\\sqrt{-2}]$, then $p \\mid (c \\pm \\sqrt{-2})$, but $\\text{im}(c \\pm \\sqrt{-2}) = \\pm 1$ forces $p \\mid 1$. Contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic residues", "Legendre symbol", "splitting primes", "irreducibility"],
+    "prerequisites": ["ZMod arithmetic", "Legendre symbol", "irreducible vs prime in UFD"]
+  },
+  {
+    "id": "ann-zsqrtd-main-theorem",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 433, "endLine": 468 },
+    "type": "insight",
+    "title": "Main Theorem and Three-Squares Corollary",
+    "content": "`sq_add_two_sq_of_prime_three_mod_eight` combines the two threads: p ≡ 3 (mod 8) → −2 is a QR mod p → p is not irreducible in ℤ[√−2] → p = a² + 2b². The three-squares corollary `prime_three_mod_eight_is_sum_three_sq'` is then trivial: p = a² + 2b² = a² + b² + b². Note the file also proves the p ≡ 1 (mod 8) case as a bonus. The proof elegantly separates concerns: Euclidean structure handles factorization, quadratic reciprocity handles the number-theoretic input, and the bridge lemma connects them.",
+    "mathContext": "$p \\equiv 3 \\pmod{8} \\Rightarrow p = a^2 + 2b^2 \\Rightarrow p = a^2 + b^2 + b^2$. The full characterization of primes $p = x^2 + 2y^2$ is: $p = 2$, or $p \\equiv 1, 3 \\pmod{8}$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre three-squares", "representation by quadratic forms", "sum of squares"],
+    "prerequisites": ["Legendre symbol", "EuclideanDomain", "quadratic forms"]
+  },
+  {
+    "id": "ann-zsqrtd-examples",
+    "proofId": "zsqrtd-neg-two",
+    "range": { "startLine": 469, "endLine": 476 },
+    "type": "context",
+    "title": "Concrete Verifications: p = 3 and p = 11",
+    "content": "Four `example` terms verify the theorems for the smallest primes p ≡ 3 (mod 8): 3 = 1² + 2·1² = 1² + 1² + 1², and 11 = 3² + 2·1² = 3² + 1² + 1². The next such prime is 19 = 1² + 2·3² = 1² + 3² + 3². These examples simultaneously sanity-check the norm-form representations and demonstrate that the three-squares identity y² + y² = 2y² produces repeated values, giving the structure {a, b, b} rather than fully general three-square representations.",
+    "mathContext": "$3 = 1^2 + 2 \\cdot 1^2 = 1^2 + 1^2 + 1^2$. $11 = 3^2 + 2 \\cdot 1^2 = 3^2 + 1^2 + 1^2$. $19 = 1^2 + 2 \\cdot 3^2$. Primes $\\equiv 3 \\pmod{8}$: $3, 11, 19, 43, 59, \\ldots$",
+    "significance": "context",
+    "relatedConcepts": ["sum of squares", "norm computation", "concrete verification"],
+    "prerequisites": ["modular arithmetic", "quadratic forms"]
+  }
+]

--- a/src/data/proofs/zsqrtd-neg-two/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two/meta.json
@@ -37,41 +37,67 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The ring ℤ[√−2] = {a + b√−2 : a,b ∈ ℤ} is a Euclidean domain with norm N(a+b√−2) = a²+2b². Being Euclidean, it is a PID and UFD. By analogy with Gaussian integers (ℤ[i], norm = a²+b²), a prime p is a norm in ℤ[√−2] iff -2 is a quadratic residue mod p iff p ≡ 1,3 (mod 8) by quadratic reciprocity. For primes p ≡ 3 (mod 8), p = a²+2b², which gives p = a²+b²+b² (sum of three squares).",
-    "problemStatement": "Prove: (1) ℤ[√−2] is Euclidean with norm N(a+b√−2) = a²+2b². (2) For prime p ≡ 3 (mod 8): p = a²+2b² for some a,b. (3) Such p is a sum of three squares.",
-    "proofStrategy": "Euclidean division: define x/y and x%y in ℤ[√−2] using rational arithmetic rounding. Prove N(x%y) < N(y) by estimating rounding errors. For p = a²+2b²: use the fact that -2 is a QR mod p (from p ≡ 3 mod 8 + quadratic reciprocity) to get p non-prime in ℤ[√−2], then factor p = π·π̄ giving p = N(π) = a²+2b².",
+    "historicalContext": "The study of which integers are represented by the quadratic form x² + 2y² is classical. Fermat (1640s) first observed that a prime p ≠ 2 is a sum x² + 2y² iff p = 2 or p ≡ 1, 3 (mod 8), but left no proof. Euler (1770) established the supplementary laws for the Legendre symbol, giving (−2/p) = 1 iff p ≡ 1 or 3 (mod 8), which is precisely the splitting condition for p in ℤ[√−2]. Gauss, in the Disquisitiones Arithmeticae (1801), developed the theory of binary quadratic forms and showed that forms with class number 1 (like x² + 2y², which has discriminant −8 and class number h(−8) = 1) represent all primes that split. The algebraic proof via Euclidean domains became canonical after Gauss: ℤ[√−2] is Euclidean with norm N(a+b√−2) = a²+2b², hence a PID and UFD, so every prime that is not irreducible factors as p = N(α) = a²+2b². The three-squares connection—p = a²+b²+b² when p = a²+2b²—gives a partial case of Legendre's three-square theorem (1798): n is a sum of three squares iff n ≠ 4^a(8b+7). Primes p ≡ 3 (mod 8) satisfy 3 ≡ 3 (mod 8), so they are not excluded, confirming the corollary. The Mathlib Zsqrtd library (Mario Carneiro, 2017) provides the foundational ℤ[√d] framework on which this formalization builds.",
+    "problemStatement": "Prove: (1) ℤ[√−2] is Euclidean with norm N(a+b√−2) = a²+2b². (2) For prime p ≡ 3 (mod 8): p = a²+2b² for some a,b ∈ ℤ. (3) Such p is a sum of three squares.",
+    "proofStrategy": "The proof separates into two independent threads that are then composed. Thread 1 (Euclidean structure): Define Euclidean division in ℤ[√−2] by rounding the rational quotient x·ȳ/N(y); verify N(x%y) < N(y) using the bound (1/2)²+2·(1/2)² = 3/4 < 1 on rounding errors. This gives the full EuclideanDomain instance, making ℤ[√−2] a UFD. Thread 2 (Number theory): Use ZMod.exists_sq_eq_neg_two_iff (Mathlib's second supplementary law) to show −2 is a QR mod p when p ≡ 3 (mod 8), then show this forces p to not be irreducible in ℤ[√−2] via a splitting argument (p | (c+√−2)(c−√−2) but p ∤ either factor). Composition: non-irreducibility in a UFD forces p = N(x) = x.re²+2·x.im² for some factor x.",
     "keyInsights": [
-      "**Euclidean norm**: N(a+b√−2) = a²+2b². Division algorithm: N(x%y) < N(y) proved by showing the rounding error satisfies (r₁)²+2(r₂)² < 1 for r₁,r₂ ∈ (-1/2, 1/2].",
-      "**QR criterion**: -2 is a QR mod p iff p ≡ 1 or 3 (mod 8). For p ≡ 3 (mod 8): (-2/p) = 1 → p factors in ℤ[√−2] → p = a²+2b².",
-      "**Three squares**: If p = a²+2b², then p = a²+b²+b² is a sum of three squares.",
-      "**Units**: Units of ℤ[√−2] are ±1 (since N(u)=1 requires a²+2b²=1 with a,b∈ℤ, giving only (±1,0))."
+      "**Rounding bound is sharp at d = −2**: The Euclidean property holds because (1/2)²+2·(1/2)² = 3/4 < 1. For ℤ[√−d] with d ≥ 3, the bound (1+d)/4 ≥ 1, so simple rounding division fails. ℤ[√−2] is the largest-|d| case where this elementary construction works.",
+      "**Non-irreducibility forces norm representation**: In a UFD, if p = x·y with neither factor a unit, then p² = N(p) = N(x)·N(y), forcing N(x) = p (by prime divisor structure of p²). So p is a norm, i.e., p = a²+2b². This norm-argument is the algebraic heart of the proof.",
+      "**Splitting criterion via Legendre symbol**: p is not irreducible in ℤ[√−2] iff −2 is a QR mod p iff (−2/p) = 1 iff p ≡ 1 or 3 (mod 8). The imaginary part ±1 of α = c+√−2 is what prevents p from dividing α even though p | α·ᾱ, completing the splitting argument.",
+      "**Three-squares as a free corollary**: p = a²+2b² immediately gives p = a²+b²+b² — no additional work. The structure of the representation (with two equal summands) is a signature of the x²+2y² form.",
+      "**Units are ±1**: N(u) = 1 forces b = 0 (since 2b²≤1 over ℤ) then a = ±1. Contrast with ℤ[i] (4 units: ±1, ±i) and ℤ[ζ₃] (6 units). The unit group size controls how many essentially different representations there are.",
+      "**Class number 1 guarantees uniqueness**: h(−8) = 1 means every form of discriminant −8 is equivalent to x²+2y², so every prime that splits is represented — no need to check additional forms. This is the algebraic number theory theorem underlying the whole argument."
     ]
   },
   "sections": [
     {
-      "id": "zsqrtd-structure",
-      "title": "Norm, Units, and Euclidean Division",
+      "id": "zsqrtd-norm-units",
+      "title": "Norm Properties and Unit Group",
       "startLine": 39,
-      "endLine": 250,
-      "summary": "norm_def', norm_nonneg', norm_eq_zero_iff'. isUnit_iff_norm_one: unit iff norm=1. units_eq: units are ±1. natCast_not_unit. Euclidean division: mod_def, sq_rounding_error_lt_one, norm_mod_lt.",
-      "mathContext": "$N(a+b\\sqrt{-2}) = a^2 + 2b^2$. Units: $\\{\\pm 1\\}$."
+      "endLine": 98,
+      "summary": "Establishes the norm N(a+b√−2) = a²+2b² (norm_def', norm_nonneg', norm_eq_zero_iff'), characterizes units as exactly ±1 (isUnit_iff_norm_one, units_eq), and proves natural number primes p > 1 are not units (natCast_not_unit).",
+      "mathContext": "$N(a+b\\sqrt{-2}) = a^2 + 2b^2$. Units: $\\{\\pm 1\\}$ (only solutions to $a^2 + 2b^2 = 1$ over $\\mathbb{Z}$)."
     },
     {
-      "id": "primes-representation",
-      "title": "Prime Representations and Three-Squares",
-      "startLine": 241,
+      "id": "zsqrtd-euclidean-division",
+      "title": "Euclidean Division Algorithm",
+      "startLine": 99,
+      "endLine": 238,
+      "summary": "Constructs division (instDiv) and modulo (instMod) by rounding the rational quotient. Proves the key rounding error bound (sq_rounding_error_lt_one: (r₁−round r₁)²+2(r₂−round r₂)² < 1) and the Euclidean property (norm_mod_lt: N(x%y) < N(y)). Packages everything into the EuclideanDomain typeclass instance.",
+      "mathContext": "Division: $\\lfloor x/y \\rceil_\\mathbb{Z} = \\langle \\mathrm{round}(\\frac{(x\\bar{y})_1}{N(y)}), \\mathrm{round}(\\frac{(x\\bar{y})_2}{N(y)}) \\rangle$. Error bound: $\\frac{3}{4} < 1$ ensures $N(x \\bmod y) < N(y)$."
+    },
+    {
+      "id": "zsqrtd-norm-representation",
+      "title": "Non-Irreducibility Yields Norm Representation",
+      "startLine": 240,
+      "endLine": 353,
+      "summary": "sq_add_two_sq_of_nat_prime_of_not_irreducible: if p is not irreducible in ℤ[√−2], write p = x·y with non-units; then N(x)·N(y) = p², and since both norms > 1 divide p², N(x) = p = x.re²+2·x.im².",
+      "mathContext": "$p = x \\cdot y$, $N(x) \\cdot N(y) = p^2$, $N(x) \\in \\{1, p, p^2\\}$, $N(x) > 1$, $N(y) > 1$ $\\Rightarrow$ $N(x) = p = a^2 + 2b^2$."
+    },
+    {
+      "id": "zsqrtd-qr-splitting",
+      "title": "Quadratic Residue of −2 and Prime Splitting",
+      "startLine": 354,
+      "endLine": 432,
+      "summary": "neg_two_is_qr_of_three_mod_eight: uses Mathlib's ZMod.exists_sq_eq_neg_two_iff (second supplementary law) to get IsSquare(−2 mod p) for p ≡ 3 (mod 8). not_irreducible_of_neg_two_is_qr: constructs α = c+√−2, shows p | α·ᾱ but p ∤ α (since im(α) = ±1 would force p | 1), contradicting irreducibility.",
+      "mathContext": "$p \\equiv 3 \\pmod{8} \\Rightarrow \\left(\\frac{-2}{p}\\right) = 1 \\Rightarrow \\exists c, c^2 \\equiv -2 \\pmod{p} \\Rightarrow p \\mid (c+\\sqrt{-2})(c-\\sqrt{-2})$ but $p \\nmid (c \\pm \\sqrt{-2})$."
+    },
+    {
+      "id": "zsqrtd-main-results",
+      "title": "Main Theorems and Examples",
+      "startLine": 433,
       "endLine": 476,
-      "summary": "sq_add_two_sq_of_nat_prime_of_not_irreducible. neg_two_is_qr_of_three_mod_eight. sq_add_two_sq_of_prime_three_mod_eight: p ≡ 3 mod 8 → p = a²+2b². prime_three_mod_eight_is_sum_three_sq: p ≡ 3 mod 8 → p = x²+y²+z².",
-      "mathContext": "For prime $p \\equiv 3 \\pmod{8}$: $\\left(\\frac{-2}{p}\\right) = 1$, so $p = a^2 + 2b^2 = a^2 + b^2 + b^2$."
+      "summary": "sq_add_two_sq_of_prime_three_mod_eight: composes the QR result with the norm representation. sq_add_two_sq_of_prime_one_mod_eight: bonus result for p ≡ 1 (mod 8). prime_three_mod_eight_is_sum_three_sq': trivial corollary p = a²+b²+b². Four concrete examples for p = 3, 11.",
+      "mathContext": "$p \\equiv 3 \\pmod{8} \\Rightarrow p = a^2 + 2b^2 \\Rightarrow p = a^2 + b^2 + b^2$. Examples: $3 = 1^2 + 1^2 + 1^2$, $11 = 3^2 + 1^2 + 1^2$."
     }
   ],
   "conclusion": {
-    "summary": "ℤ[√−2] Euclidean domain theory proved: 20 theorems, 0 sorries, 0 axioms. Primes p ≡ 3 (mod 8) are x²+2y², hence sums of three squares.",
-    "implications": "This is a non-trivial application of algebraic number theory to a concrete representation problem. The Euclidean domain structure of ℤ[√−2] is more elementary than the Gaussian integers but uses the same framework.",
+    "summary": "This file gives a complete machine-checked proof that primes p ≡ 3 (mod 8) are representable as x²+2y² and hence as sums of three squares, via 20 theorems with 0 sorries and 0 axioms. The proof builds the entire Euclidean domain structure of ℤ[√−2] from scratch and combines it with the Legendre symbol's supplementary law.",
+    "implications": "The proof is a microcosm of algebraic number theory: the Euclidean domain structure of ℤ[√−2] (the ring-theoretic input) combines with quadratic reciprocity (the number-theoretic input) to yield a concrete representation theorem. The same template—build the ring structure, identify the splitting condition, apply the norm argument—generalizes to ℤ[√−3] (Eisenstein integers, primes p ≡ 1 mod 3 = sums a²+ab+b²), ℤ[√−7] (primes p ≡ 1,2,4 mod 7), and other rings of integers of imaginary quadratic fields with class number 1. The three-squares connection is especially clean: the 'waste' in x²+2y² (two distinct squares vs one repeated) directly gives two equal summands. More broadly, the file demonstrates that Mathlib's Zsqrtd framework provides a reusable scaffold for quadratic form representation theorems.",
     "openQuestions": [
-      "Can the full Legendre three-square theorem (n is not sum of three squares iff n = 4^a(8b+7)) be formalized using ℤ[√−2]?",
-      "Can the class number formula for ℤ[√−2] (h(-2)=1, PIDs) be proved in Lean?",
-      "Can representations by x²+ny² be systematically formalized for small n?"
+      "Can the complete characterization of primes p = x²+2y² (i.e., p = 2 or p ≡ 1, 3 mod 8, including p ≡ 1 mod 8) be unified into a single bi-conditional iff statement in Lean?",
+      "Can the full Legendre three-square theorem (n is a sum of three squares iff n ≠ 4^a·(8b+7)) be formalized building on this file's infrastructure?",
+      "Can representations by x²+ny² for n = 3, 7, 11 (other class-number-1 imaginary quadratic fields) be proved by a parallel construction, and can the n-parametric version be stated as a typeclass over EuclideanDomain instances?"
     ]
   },
   "leanFile": {
@@ -91,9 +117,19 @@
   },
   "crossReferences": [
     {
+      "targetId": "fermat-two-squares",
+      "relationship": "parallel",
+      "description": "Fermat's two-squares theorem (p = x²+y² iff p ≡ 1 mod 4) uses the same Gaussian integers / norm argument with ℤ[i] in place of ℤ[√−2]"
+    },
+    {
       "targetId": "lagrange-four-squares-waring-g2",
       "relationship": "related",
-      "description": "Legendre exclusion criterion and three-squares"
+      "description": "Lagrange four-squares and Waring's problem; the three-squares corollary here (p ≡ 3 mod 8) is a partial case of Legendre's three-square exclusion theorem"
+    },
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "related",
+      "description": "Every natural number is a sum of four squares; primes p ≡ 3 mod 8 proved here as sums of three squares provide special cases"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment: ℤ[√−2]: Euclidean Domain and x² + 2y² Representations

**Annotations** (0 → 10): all with mathContext, significance, relatedConcepts, prerequisites
- Module overview with mathematical landscape and Fermat/Euler/Gauss historical framing
- Norm properties (norm_def', norm_nonneg', norm_eq_zero_iff')
- Unit group characterization (±1 only; contrast with ℤ[i]'s 4 units)
- Rounding-based division algorithm construction
- Key 3/4 < 1 bound — why ℤ[√−2] is Euclidean (d=−2 is the boundary case)
- norm_mod_lt proof and EuclideanDomain typeclass instance
- Non-irreducibility → norm representation bridge lemma
- Quadratic residue of −2 and prime splitting argument
- Main representation and three-squares corollary
- Concrete verifications for p = 3, 11

**meta.json improvements**:
- historicalContext: 383 → 1500+ chars (Fermat 1640s, Euler 1770, Gauss 1801, Legendre 1798, Mathlib Zsqrtd)
- keyInsights: 4 → 6 (added class number 1 guarantee; sharpness of d=−2 rounding bound)
- sections: 2 → 5 granular sections with mathContext on each
- conclusion.implications: generalization to other imaginary quadratic fields
- crossReferences: fermat-two-squares, lagrange-four-squares, lagrange-four-squares-waring-g2

Build: `pnpm build` ✓