### PR TITLE
fix(angle-trisection-oq-03-oq-02): add missing sorries/axiomCount to meta, update stale lineCount/theoremCount

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -15,11 +15,11 @@
       "Nat"
     ],
     "namespace": "AngleTrisectionOQ03OQ02",
-    "lineCount": 140,
+    "lineCount": 156,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 12
+    "theoremCount": 13
   },
   "meta": {
     "author": "Formalized in Lean 4 (researcher-4)",
@@ -27,6 +27,8 @@
     "date": "2026",
     "status": "verified",
     "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
     "proofRepoPath": "Proofs/AngleTrisectionOQ03OQ02.lean",
     "tags": [
       "geometry",


### PR DESCRIPTION
## Summary

Gallery integrity audit found `angle-trisection-oq-03-oq-02` flagged with `sorry mismatch: claims -1, actual 0` by `find-targets.ts`. The tool reads `meta["meta"]["sorries"] ?? -1` — the `meta` sub-object was missing the `sorries` field, causing it to default to -1.

**Fix:**
- Added `"sorries": 0` to the `meta` object
- Added `"axiomCount": 0` to the `meta` object (also missing)
- Corrected `leanFile.lineCount`: 140 → 156 (file grew by 16 lines with additional `native_decide` examples)
- Corrected `leanFile.theoremCount`: 12 → 13 (one additional theorem `halvings_separates_pred` in current file)

**No integrity concerns**: status (`verified`), badge (`original`), and actual 0 sorries / 0 axioms are all correct.

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` should no longer show this entry
- [ ] `meta["meta"]["sorries"]` is 0, matching actual Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)