### PR TITLE
enrich(angle-trisection-oq-03-oq-02): add index.ts, 7 annotations, restructure meta to standard schema

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-oq03oq02-context",
+    "proofId": "angle-trisection-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 26 },
+    "type": "context",
+    "title": "Complexity of the Constructibility Check: Closing the Gap",
+    "content": "This file completes the complexity picture for the halvings-based constructibility check introduced in AngleTrisectionOQ03. That entry proved an O(log d) upper bound: the halvings algorithm terminates in at most Nat.log 2 d steps. This entry proves the bound is tight: inputs d = 2^k require exactly k halvings, so Ω(log d) is a genuine lower bound. The file imports AngleTrisectionOQ03 directly and works in its namespace to access the halvings function and its basic properties.",
+    "mathContext": "Upper bound (OQ-03): $\\mathrm{halvings}(d) \\leq \\lfloor \\log_2 d \\rfloor$. Lower bound (this file): $\\mathrm{halvings}(2^k) = k = \\lfloor \\log_2(2^k) \\rfloor$. Together: $\\Theta(\\log d)$ on input family $\\{2^k\\}$.",
+    "significance": "context",
+    "relatedConcepts": ["algorithm complexity", "tight bounds", "2-adic valuation", "constructibility"],
+    "prerequisites": ["AngleTrisectionOQ03", "Nat.log in Mathlib"]
+  },
+  {
+    "id": "ann-oq03oq02-def",
+    "proofId": "angle-trisection-oq-03-oq-02",
+    "range": { "startLine": 35, "endLine": 57 },
+    "type": "definition",
+    "title": "The halvings Function: Counting Divisions by 2",
+    "content": "halvings counts how many times d is divisible by 2 before becoming odd. Structurally: halvings 0 = 0; halvings (n+1) = 1 + halvings((n+1)/2) if even, else 0. This is exactly the 2-adic valuation v₂(d) — the exponent of 2 in the prime factorization of d. For d = 12 = 4·3: halvings(12) = 1 + halvings(6) = 2 + halvings(3) = 2 + 0 = 2 (since v₂(12) = 2). The `@[simp]` lemmas (halvings_zero, halvings_one, halvings_succ) enable automatic unfolding in tactic proofs. halvings_odd establishes the base case: any odd input terminates immediately.",
+    "mathContext": "$\\mathrm{halvings}(d) = v_2(d) = \\max\\{k : 2^k \\mid d\\}$. $\\mathrm{halvings}(2^a \\cdot m) = a$ when $m$ is odd.",
+    "significance": "key",
+    "relatedConcepts": ["2-adic valuation", "p-adic valuation", "structural recursion", "termination"],
+    "prerequisites": ["natural number recursion", "modular arithmetic"]
+  },
+  {
+    "id": "ann-oq03oq02-two-mul",
+    "proofId": "angle-trisection-oq-03-oq-02",
+    "range": { "startLine": 59, "endLine": 63 },
+    "type": "technique",
+    "title": "halvings_two_mul: The Recursive Equation for Even Inputs",
+    "content": "halvings_two_mul states halvings(2k) = 1 + halvings(k) for k > 0. This is the key recursion unrolled: halvings first checks that 2k is even (it is), then halves to k and adds 1. The proof massages the expression: 2k = (2k−1)+1, then applies halvings_succ with the parity condition, and simplifies (2k−1+1)/2 = k by omega. This lemma is what makes the induction in halvings_pow2 go through, and it also directly gives the O(log d) analysis: each halving reduces d by a factor of 2, so after log₂ d halvings we reach an odd number.",
+    "mathContext": "$\\mathrm{halvings}(2k) = 1 + \\mathrm{halvings}(k)$. Iterating: $\\mathrm{halvings}(2^k \\cdot m) = k + \\mathrm{halvings}(m)$ for odd $m$.",
+    "significance": "key",
+    "relatedConcepts": ["recursion unrolling", "recurrence relation", "Euclidean algorithm"],
+    "prerequisites": ["halvings definition", "omega tactic"]
+  },
+  {
+    "id": "ann-oq03oq02-main",
+    "proofId": "angle-trisection-oq-03-oq-02",
+    "range": { "startLine": 71, "endLine": 83 },
+    "type": "insight",
+    "title": "halvings_pow2: Powers of 2 Achieve the Logarithm Exactly",
+    "content": "halvings_pow2 is the central result: halvings(2^k) = k. The induction step: halvings(2^(k+1)) = halvings(2·2^k) = 1 + halvings(2^k) [by halvings_two_mul, since 2^k > 0] = 1 + k [IH]. The identity halvings(2^k) = Nat.log 2 (2^k) then follows immediately from Mathlib's Nat.log_pow lemma, which proves log_b(b^k) = k for b > 1. Together these establish that halvings is exactly the discrete logarithm on the family of powers of 2 — computing log₂(d) exactly when d is a pure power of 2.",
+    "mathContext": "$\\mathrm{halvings}(2^k) = k = \\lfloor \\log_2(2^k) \\rfloor$. Proof: $\\mathrm{halvings}(2^{k+1}) = \\mathrm{halvings}(2 \\cdot 2^k) = 1 + \\mathrm{halvings}(2^k) = 1 + k$.",
+    "significance": "key",
+    "relatedConcepts": ["discrete logarithm", "Nat.log_pow", "induction", "powers of two"],
+    "prerequisites": ["halvings_two_mul", "Mathlib.Data.Nat.Log"]
+  },
+  {
+    "id": "ann-oq03oq02-lower-bound",
+    "proofId": "angle-trisection-oq-03-oq-02",
+    "range": { "startLine": 85, "endLine": 109 },
+    "type": "technique",
+    "title": "The Ω(log d) Lower Bound: Tightness and Unboundedness",
+    "content": "Three tightness results: (1) constructibility_lower_bound: Nat.log 2 (2^k) ≤ halvings(2^k) follows immediately from halvings_eq_log_pow2 by reflexivity (equality implies ≤). (2) halvings_unbounded: ∀c, ∃d, halvings(d) ≥ c — witnessed by d = 2^c, since halvings(2^c) = c. This proves that no constant-time algorithm can decide the halvings count: for any claimed O(1) bound, the input 2^c witnesses the failure. (3) halvings_complexity_tight packages both equalities. The unboundedness result is the decisive statement: it means O(log d) halvings are not just sufficient but necessary.",
+    "mathContext": "$\\forall c, \\mathrm{halvings}(2^c) = c \\geq c$. So the decision function $d \\mapsto \\mathrm{halvings}(d)$ is unbounded, ruling out any $O(1)$ algorithm. The lower bound $\\Omega(\\log d)$ follows on the input family $\\{2^k\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["algorithm lower bound", "unboundedness", "tight complexity", "Omega notation"],
+    "prerequisites": ["halvings_pow2", "asymptotic complexity"]
+  },
+  {
+    "id": "ann-oq03oq02-separation",
+    "proofId": "angle-trisection-oq-03-oq-02",
+    "range": { "startLine": 111, "endLine": 135 },
+    "type": "insight",
+    "title": "2^k − 1 vs 2^k: Maximal Separation Between Consecutive Inputs",
+    "content": "halvings_pred_pow2 proves halvings(2^k − 1) = 0 for k ≥ 1. The key: 2^k − 1 is odd (since 2^k ≡ 0 mod 2, so 2^k − 1 ≡ 1 mod 2), proved by omega after unfolding the successor structure. Combined with halvings_pow2, the separation theorem halvings_separates_pred gives halvings(2^k − 1) = 0 < k = halvings(2^k). This means consecutive inputs 2^k − 1 and 2^k have maximally different halvings counts: 0 vs k. The interpretation: the constructibility check immediately rejects 2^k − 1 (an odd non-power-of-2) but must process 2^k through all k halvings — confirming the YES-path is expensive and the Ω(log d) lower bound is not vacuous.",
+    "mathContext": "$2^k - 1 \\equiv 1 \\pmod{2}$ for $k \\geq 1$, so $\\mathrm{halvings}(2^k - 1) = 0$. Gap: $|\\mathrm{halvings}(2^k) - \\mathrm{halvings}(2^k - 1)| = k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["separation", "YES-path complexity", "parity", "powers of two"],
+    "prerequisites": ["halvings_odd", "halvings_pow2", "modular arithmetic"]
+  },
+  {
+    "id": "ann-oq03oq02-examples",
+    "proofId": "angle-trisection-oq-03-oq-02",
+    "range": { "startLine": 137, "endLine": 156 },
+    "type": "context",
+    "title": "Concrete Verifications via native_decide",
+    "content": "Eleven examples verify halvings directly: halvings(2^k) = k for k = 0,1,2,3,4,5,8; halvings(3) = halvings(15) = 0 (odd inputs); halvings(6) = 1 (6 = 2·3, one halving); halvings(12) = 2 (12 = 4·3, two halvings). These use native_decide, which compiles the term to native code for efficient evaluation. The examples serve as a sanity check and illustrate the formula at concrete values, making the abstract theorem more accessible.",
+    "mathContext": "Verification: $\\mathrm{halvings}(256) = 8$, $\\mathrm{halvings}(6) = v_2(6) = 1$, $\\mathrm{halvings}(12) = v_2(12) = 2$. The examples collectively confirm the 2-adic valuation interpretation.",
+    "significance": "context",
+    "relatedConcepts": ["native_decide", "concrete verification", "2-adic valuation"],
+    "prerequisites": ["halvings definition", "powers of two"]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/index.ts
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionOQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const angleTrisectionOq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionOq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionOq03Oq02Data: ProofData = {
+  proof: angleTrisectionOq03Oq02Proof,
+  annotations: angleTrisectionOq03Oq02Annotations,
+}

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -3,28 +3,9 @@
   "title": "Ω(log d) Lower Bound for Constructibility: The Algorithm is Tight",
   "slug": "angle-trisection-oq-03-oq-02",
   "description": "Proves that the O(log d) constructibility check from OQ-03 is asymptotically optimal. For inputs d = 2^k, the halvings algorithm requires exactly k = ⌊log₂ d⌋ steps, establishing Ω(log d) as a tight lower bound. No algorithm can decide 'is d a power of 2?' in fewer halvings on this input family.",
-  "leanFile": {
-    "path": "Proofs/AngleTrisectionOQ03OQ02.lean",
-    "imports": [
-      "Mathlib.Data.Nat.Log",
-      "Mathlib.Tactic",
-      "Proofs.AngleTrisectionOQ03"
-    ],
-    "opens": [
-      "AngleTrisectionOQ03",
-      "Nat"
-    ],
-    "namespace": "AngleTrisectionOQ03OQ02",
-    "lineCount": 140,
-    "axiomCount": 0,
-    "sorries": 0,
-    "definitionCount": 1,
-    "theoremCount": 12
-  },
   "meta": {
     "author": "Formalized in Lean 4 (researcher-4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon",
-    "date": "2026",
     "status": "verified",
     "badge": "original",
     "proofRepoPath": "Proofs/AngleTrisectionOQ03OQ02.lean",
@@ -38,90 +19,83 @@
       "powers-of-two",
       "tight-bound"
     ],
-    "difficulty": "intermediate",
-    "mathAreas": ["computational geometry", "complexity theory", "number theory"]
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 156,
+    "theoremCount": 12
   },
-  "openQuestion": {
-    "id": "angle-trisection-oq-03-oq-02",
-    "parentId": "angle-trisection-oq-03",
-    "question": "Is Ω(log d) optimal for the constructibility check?",
-    "answer": "Yes — proved in this entry. The halvings algorithm uses exactly Nat.log 2 (2^k) = k steps for d = 2^k, and no algorithm can do better asymptotically on this family."
+  "overview": {
+    "historicalContext": "The impossibility of trisecting a general angle with compass and straightedge was proved by Pierre Wantzel in 1837 using Galois theory: an angle θ is trisectable iff 8x³ − 6x − cos θ has a rational root or splits into linear factors over the iterated quadratic extensions of ℚ. The OQ-03 companion entry formalizes an O(log d) algorithm to check whether a denominator d (determining the angle π/d) satisfies the constructibility conditions by counting halvings of d until it becomes odd. This entry (OQ-03-OQ-02) closes the complexity question: the O(log d) bound is not just an upper bound — it is tight. The halvings algorithm performs exactly Nat.log 2 (2^k) = k steps on inputs d = 2^k, and no algorithm can process these inputs in sub-logarithmic time. The proof connects the constructibility check to the 2-adic valuation v₂(d) — the exact power of 2 dividing d — which is the information-theoretically required number of halvings.",
+    "problemStatement": "Let halvings : ℕ → ℕ count the number of divisions by 2 before d becomes odd. Prove: (1) halvings(2^k) = k for all k; (2) halvings(2^k) = Nat.log 2 (2^k); (3) the step count is unbounded (no O(1) bound suffices); (4) 2^k − 1 is rejected in 0 steps while 2^k requires k steps.",
+    "proofStrategy": "The key lemma is halvings_two_mul: halvings(2k) = 1 + halvings(k) for k > 0. From this, halvings_pow2 follows by induction: halvings(2^(k+1)) = halvings(2·2^k) = 1 + halvings(2^k) = 1 + k. The logarithm identification uses Mathlib's Nat.log_pow lemma. The separation theorem (halvings(2^k − 1) = 0) relies on 2^k − 1 being odd (since 2^k − 1 ≡ 1 mod 2), proved by omega after unfolding the modular arithmetic.",
+    "keyInsights": [
+      "**halvings = 2-adic valuation**: halvings(d) counts the largest power of 2 dividing d — exactly v₂(d). For d = 2^k this is k; for odd d this is 0. The halvings function is the discrete logarithm on powers of 2.",
+      "**Inductive recursion unwinds the algorithm**: halvings(2·n) = 1 + halvings(n) for n > 0 is the key recurrence. Applying it k times: halvings(2^k) = k + halvings(1) = k + 0 = k. No combinatorics beyond induction.",
+      "**Mathlib's Nat.log_pow is the bridge**: The connection halvings(2^k) = Nat.log 2 (2^k) reduces to Nat.log_pow (proving log₂(2^k) = k), which Mathlib provides directly. The proof is a one-liner.",
+      "**YES-path is maximally costly**: 2^k−1 is odd and rejected at step 0. 2^k needs all k halvings. The gap halvings(2^k) − halvings(2^k−1) = k shows the YES-path to 'is a power of 2' costs O(log d) in the worst case.",
+      "**Unboundedness ↔ no constant-time algorithm**: halvings_unbounded (∀c, ∃d, halvings(d) ≥ c) witnesses that any claimed O(1) bound fails on d = 2^c. This makes the lower bound explicit as an existential statement."
+    ]
   },
-  "theorems": [
-    {
-      "name": "halvings_pow2",
-      "statement": "halvings (2^k) = k",
-      "description": "For d = 2^k, the halvings algorithm takes exactly k steps."
-    },
-    {
-      "name": "halvings_eq_log_pow2",
-      "statement": "halvings (2^k) = Nat.log 2 (2^k)",
-      "description": "The step count equals the floor base-2 logarithm."
-    },
-    {
-      "name": "constructibility_lower_bound",
-      "statement": "Nat.log 2 (2^k) ≤ halvings (2^k)",
-      "description": "The algorithm achieves the log lower bound on inputs 2^k."
-    },
-    {
-      "name": "halvings_unbounded",
-      "statement": "∀ c, ∃ d, halvings d ≥ c",
-      "description": "The step count is unbounded: no O(1) algorithm suffices."
-    },
-    {
-      "name": "halvings_complexity_tight",
-      "statement": "halvings (2^k) = Nat.log 2 (2^k) ∧ Nat.log 2 (2^k) = k",
-      "description": "Complete tightness: step count equals log equals exponent."
-    },
-    {
-      "name": "halvings_pred_pow2",
-      "statement": "halvings (2^k - 1) = 0 for k ≥ 1",
-      "description": "2^k - 1 is odd, rejected at the first step."
-    },
-    {
-      "name": "halvings_separates_pred",
-      "statement": "halvings (2^k - 1) < halvings (2^k) for k ≥ 1",
-      "description": "The algorithm correctly separates 2^k from its predecessor."
-    }
-  ],
-  "keyInsights": [
-    "The halvings algorithm for 'is d a power of 2?' takes exactly ⌊log₂ d⌋ steps on d = 2^k",
-    "This matches the information-theoretic lower bound: d = 2^k requires k+1 bits to represent",
-    "The O(log d) algorithm from OQ-03 cannot be asymptotically improved on this input family",
-    "2^k - 1 is odd and rejected immediately, while 2^k requires all k halvings (YES-path cost)",
-    "The halvings count equals Nat.log 2 (2^k) by Mathlib's Nat.log_pow lemma"
-  ],
   "sections": [
     {
+      "id": "halvings-algorithm",
       "title": "The Halvings Algorithm",
-      "description": "Definition of the halvings function counting divisions by 2 until odd.",
-      "lineRange": [1, 50]
+      "startLine": 27,
+      "endLine": 63,
+      "summary": "Defines halvings : ℕ → ℕ by structural recursion (0 for odd inputs, 1 + halvings(n/2) for even). Proves halvings_zero, halvings_one, halvings_succ (equation lemma), halvings_odd (odd → 0), and halvings_two_mul (halvings(2k) = 1 + halvings(k) for k > 0).",
+      "mathContext": "$\\mathrm{halvings}(d) = v_2(d)$, the 2-adic valuation. $\\mathrm{halvings}(2k) = 1 + \\mathrm{halvings}(k)$, $\\mathrm{halvings}(2k+1) = 0$."
     },
     {
+      "id": "exact-step-count",
       "title": "Exact Step Count for Powers of 2",
-      "description": "halvings(2^k) = k proved by induction on k.",
-      "lineRange": [51, 80]
+      "startLine": 64,
+      "endLine": 83,
+      "summary": "halvings_pow2: halvings(2^k) = k, proved by induction using halvings_two_mul. halvings_eq_log_pow2: halvings(2^k) = Nat.log 2 (2^k) using Mathlib's Nat.log_pow.",
+      "mathContext": "$\\mathrm{halvings}(2^k) = k = \\lfloor \\log_2(2^k) \\rfloor$. Induction: $\\mathrm{halvings}(2^{k+1}) = \\mathrm{halvings}(2 \\cdot 2^k) = 1 + \\mathrm{halvings}(2^k) = 1 + k$."
     },
     {
-      "title": "Ω(log d) Lower Bound",
-      "description": "The algorithm is tight: Nat.log 2(2^k) ≤ halvings(2^k), no O(1) algorithm suffices.",
-      "lineRange": [81, 110]
+      "id": "lower-bound",
+      "title": "Ω(log d) Lower Bound and Tightness",
+      "startLine": 85,
+      "endLine": 109,
+      "summary": "constructibility_lower_bound: Nat.log 2 (2^k) ≤ halvings(2^k) (immediate from equality). halvings_unbounded: ∀c, ∃d, halvings(d) ≥ c (witness d = 2^c). halvings_monotone_pow2: larger powers need more halvings. halvings_complexity_tight: both equalities in one conjunction.",
+      "mathContext": "$\\Omega(\\log d)$: for $d = 2^k$, $\\mathrm{halvings}(d) = k = \\log_2 d$. No $O(1)$ algorithm exists since $\\forall c, \\mathrm{halvings}(2^c) = c \\geq c$."
     },
     {
-      "title": "Separation of Powers from Non-Powers",
-      "description": "halvings(2^k - 1) = 0 for k ≥ 1, showing the YES-path requires all k halvings.",
-      "lineRange": [111, 135]
+      "id": "separation",
+      "title": "Separation: Powers vs Non-Powers",
+      "startLine": 111,
+      "endLine": 135,
+      "summary": "halvings_pred_pow2: halvings(2^k − 1) = 0 for k ≥ 1 (since 2^k − 1 is odd). halvings_separates_pred: halvings(2^k − 1) < halvings(2^k), confirming the YES-path cost gap.",
+      "mathContext": "$2^k - 1 \\equiv 1 \\pmod{2}$ (odd), so $\\mathrm{halvings}(2^k - 1) = 0$. Gap: $\\mathrm{halvings}(2^k) - \\mathrm{halvings}(2^k - 1) = k$."
     },
     {
+      "id": "concrete-computations",
       "title": "Concrete Computations",
-      "description": "Numerical verification for small values of k.",
-      "lineRange": [136, 150]
+      "startLine": 137,
+      "endLine": 156,
+      "summary": "native_decide verification: halvings(2^k) = k for k = 0,...,5,8; halvings(3) = halvings(15) = 0; halvings(6) = 1; halvings(12) = 2. Confirms both the formula and the separation for small cases.",
+      "mathContext": "$\\mathrm{halvings}(64) = 6$, $\\mathrm{halvings}(256) = 8$. Odd inputs: $\\mathrm{halvings}(3) = \\mathrm{halvings}(15) = 0$."
     }
   ],
-  "relatedProofs": [
-    "angle-trisection-oq-03",
-    "angle-trisection-oq-03-oq-01",
-    "angle-trisection",
-    "angle-trisection-oq-02-oq-03"
+  "conclusion": {
+    "summary": "This file proves the Ω(log d) lower bound for the halvings-based constructibility check, completing the complexity picture alongside the O(log d) upper bound from OQ-03. The algorithm is tight: halvings(2^k) = k = Nat.log 2(2^k) for all k, and the step count is unbounded.",
+    "implications": "The tightness result means the O(log d) halvings algorithm from OQ-03 is optimal on the worst-case input family {2^k}. Any decision procedure for 'is d a power of 2?' must handle inputs requiring Ω(log d) halvings, so no asymptotically faster algorithm exists within the halvings model. More broadly, the result illustrates that information-theoretic lower bounds (log d bits to encode k in d = 2^k) translate directly to algorithmic lower bounds when the model of computation is itself counting halvings. The separation between halvings(2^k − 1) = 0 and halvings(2^k) = k further shows the function distinguishes YES from NO instances with maximal sharpness.",
+    "openQuestions": [
+      "Can a tight lower bound be proved for the full constructibility test (not just the 'is d a power of 2?' subproblem), using more of the angle-trisection Galois theory from the parent entry?",
+      "What is the complexity of deciding constructibility of a polygon with n sides in terms of n, if we allow arbitrary arithmetic operations rather than just halvings?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-03",
+      "relationship": "companion",
+      "description": "OQ-03 proves the O(log d) upper bound; this entry proves the matching Ω(log d) lower bound"
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "parent",
+      "description": "The parent angle-trisection proof establishes impossibility via Galois theory; OQ-03/OQ-02 analyze the complexity of the constructibility check"
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment: Ω(log d) Lower Bound for Constructibility (angle-trisection-oq-03-oq-02)

### What was missing
- No `index.ts` → proof was invisible on the live site
- No `annotations.json` → zero inline annotations
- `meta.json` used non-standard schema (lineRange, top-level keyInsights, no overview)
- No historicalContext, no conclusion, no crossReferences

### Changes
**New `index.ts`**: standard Vite entry point.

**New `annotations.json`** (7 annotations): halvings as 2-adic valuation, halvings_two_mul recurrence, halvings_pow2 induction, Ω(log d) lower bound/unboundedness, separation of 2^k vs 2^k−1, native_decide examples.

**Restructured `meta.json`**:
- historicalContext: 700+ chars (Wantzel 1837, Galois theory, OQ-03 connection)
- keyInsights: 5 items including halvings = v₂(d)
- sections: lineRange format → startLine/endLine with id/summary/mathContext
- conclusion with implications and 2 openQuestions
- crossReferences to OQ-03 companion and angle-trisection parent

Build: `pnpm build` ✓