### PR TITLE
fix(meta): correct ballot-problem top-level sorries 5→1; add theoremCount to 14 entries

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -43,6 +43,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
+    "theoremCount": 12,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The import chain includes AngleTrisection.lean (1 axiom for π transcendence, used only for the circle-squaring result) but none of the theorems in this file depend on that axiom.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -27,6 +27,7 @@
     "date": "2026",
     "status": "verified",
     "badge": "original",
+    "theoremCount": 12,
     "proofRepoPath": "Proofs/AngleTrisectionOQ03OQ02.lean",
     "tags": [
       "geometry",

--- a/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
@@ -42,6 +42,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
+    "theoremCount": 12,
     "assumptions": "None. Fully machine-checked. Uses IsTwoThreeNumber from AngleTrisectionOQ04 and IsKFoldConstructible from AngleTrisectionOQ05OQ01; neither introduces axioms relevant to this proof.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -214,5 +214,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 5
+  "sorries": 1
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03/meta.json
@@ -21,6 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
+    "theoremCount": 5,
     "mathlibDependencies": [
       {
         "theorem": "Metric.closedBall",

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -21,6 +21,7 @@
         "badge": "verified",
         "sorries": 0,
         "axiomCount": 0,
+        "theoremCount": 4,
         "lineCount": 268,
         "assumptions": "",
         "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
@@ -20,6 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
+    "theoremCount": 7,
     "newAxiomCount": 2,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -20,6 +20,7 @@
     "badge": "axiom",
     "sorries": 3,
     "axiomCount": 1,
+    "theoremCount": 11,
     "lineCount": 287,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 3 sorries in this file (geometric edge-crossing verifications).",
     "dateAdded": "2026-04-03",

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -50,6 +50,7 @@
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 2,
+    "theoremCount": 16,
     "lineCount": 192,
     "assumptions": "2 axioms: erdos_1139 (the open conjecture: lim sup gap/log k = ∞) and hardy_ramanujan_asymptotic (Landau-Ramanujan density: π₂(N) ~ cN log log N / log N). 16 theorems fully proved."
   },

--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -69,6 +69,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 3,
+    "theoremCount": 7,
     "lineCount": 180,
     "assumptions": "3 axioms: prime_ap_pnt_upper (PNT upper bound), green_tao (Green-Tao 2008), erdos_200 (open conjecture). 0 sorries.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-446/meta.json
+++ b/src/data/proofs/erdos-446/meta.json
@@ -52,6 +52,7 @@
       "erdos_446_summary theorem: combines Ford's results"
     ],
     "axiomCount": 4,
+    "theoremCount": 2,
     "lineCount": 139,
     "assumptions": "4 axioms: delta (asymptotic density signature), deltaR (density-with-r-divisors signature), ford_2008_main (Ford 2008 asymptotic), ford_2008_disproof (Ford 2008 disproof of o(δ) conjecture). 0 sorries. Note: Besicovitch 1934, Erdős 1935, Erdős 1960, and ford_2008_general are mentioned only in docstrings, not declared as axioms."
   },

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -19,6 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
+    "theoremCount": 4,
     "newAxiomCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -21,6 +21,7 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
+    "theoremCount": 15,
     "assumptions": "2 OPEN sorries inside helper lemmas of `padic_liouville_estimate`: (1) `padicNorm_poly_eval_lb` — the clearing-denominator lower bound `1/(polyCoeffL1(f) · H^d) ≤ ‖f(r/s)‖_p` (line 255); (2) `cofactor_uniform_bound` — the Taylor factorization upper bound `‖f(r/s)‖_p ≤ M · ‖α − r/s‖_p` over ℚ_[p] (line 306). `padic_liouville_estimate` itself is now a theorem (no longer an axiom) that combines these two helpers with `irred_no_rational_roots` to deliver the p-adic Liouville bound. The main theorem `padic_algebraic_not_liouville` is fully proved (no sorry): uses `exists_pow_lt_of_lt_one` to find n₀ with 2^n₀ > 1/C, then derives C < 1/H^n₀ ≤ 1/2^n₀ < C from the Liouville and estimate bounds.",
     "dateAdded": "2026-04-26",
     "mathlibDependencies": [

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
@@ -19,6 +19,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
+    "theoremCount": 5,
     "mathlibDependencies": [
       {
         "theorem": "Analysis.SpecialFunctions.Log.Basic",

--- a/src/data/proofs/shannon-source-coding-oq-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-01/meta.json
@@ -18,6 +18,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
+    "theoremCount": 16,
     "mathlibDependencies": [
       {
         "theorem": "Analysis.SpecialFunctions.Log.Basic",


### PR DESCRIPTION
## Fix

Two categories of meta.json corrections from a proactive gallery integrity scan.

### 1. ballot-problem-oq-03-oq-01-oq-02: top-level sorries 5 → 1

PR #15050 updated `meta.sorries` and `leanFile.sorries` from 5 to 1 (after PR #14960 proved 4 sorries), but the top-level `sorries` field at the root of the JSON was left unchanged at 5.

**Before**: `meta.sorries=1, leanFile.sorries=1, top-level sorries=5`
**After**: all three consistent at `1`

Actual sorry count verified: 1 sorry (`gnwProb_key`) in `BallotProblemOQ03OQ01OQ02Helpers.lean`.

### 2. Add missing meta.theoremCount to 14 gallery entries

These proofs have `leanFile.theoremCount` set but are missing `meta.theoremCount`. Values propagated from `leanFile`:

| Proof | theoremCount |
|-------|-------------|
| angle-trisection-oq-03-oq-01 | 12 |
| angle-trisection-oq-03-oq-02 | 12 |
| angle-trisection-oq-04-oq-04 | 12 |
| brouwer-fixed-point-oq-01-oq-02-oq-03 | 5 |
| cayley-hamilton-cyclic-vector-all-fields | 4 |
| erdos-1006-oq-01-oq-02 | 7 |
| erdos-1018-oq-04-incomplete-01 | 11 |
| erdos-1139 | 16 |
| erdos-200 | 7 |
| erdos-446 | 2 |
| infinitude-primes-4k3-oq-03 | 4 |
| liouville-theorem-oq-04 | 15 |
| shannon-channel-coding-oq-02-oq-03 | 5 |
| shannon-source-coding-oq-01 | 16 |

None of these are covered by open PR #15030 (which handles a different set).

## Evidence

All changes are meta.json only — no Lean source touched. Sorries value verified against actual file contents after stripping comments.

---
Automated fix by lean-mechanic agent.