### PR TITLE
fix(abel-ruffini-oq-09): correct lineCount 435→448 after opaque-type fix

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-09/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-09/meta.json
@@ -23,7 +23,7 @@
     "theoremCount": 20,
     "assumptions": "3 axioms: liouville_integration_theorem (structural form of elementary antiderivatives requires differential Galois/Picard-Vessiot theory not in Mathlib), risch_exp_criterion_gaussian (Risch criterion: ∫e^(-x²)dx elementary iff rational Q with Q'-2xQ=1; requires partial fraction analysis), gaussian_not_elementary (∫e^(-x²) has no elementary antiderivative expressible as a rational function; the main theorem). The polynomial obstruction (no polynomial p satisfies p'-2xp=1) is fully proved without axioms.",
     "dateAdded": "2026-05-03",
-    "lineCount": 435,
+    "lineCount": 448,
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "risch_ode_coeff_top: coefficient identity showing L[p] = p'-C(2)·X·p has coefficient -2·leadingCoeff(p) at degree natDeg(p)+1 — the key lemma driving the degree-raising argument",
@@ -168,13 +168,13 @@
       "id": "analogy",
       "title": "Abel-Ruffini Analogy and Summary",
       "startLine": 404,
-      "endLine": 435,
+      "endLine": 448,
       "summary": "Documents the structural analogy between Abel-Ruffini (algebraic Galois theory) and Liouville (differential Galois theory). gaussian_risch_polynomial_obstruction_summary: final packaged theorem stating ¬∃p, p' - C(2)·X·p = 1.",
       "mathContext": "The pattern: Abel-Ruffini (A₅ simplicity → no radical formula for quintic) mirrors Liouville (degree-raising operator → no elementary integral for Gaussian). Both are Galois-theoretic impossibility results where the obstruction is witnessed by a polynomial algebra fact."
     }
   ],
   "conclusion": {
-    "summary": "Formalization of the polynomial obstruction to the Gaussian integral's elementarity. The main theorem (no_poly_risch_soln) is fully machine-checked: no polynomial p satisfies p' - 2xp = 1. The proof uses a clean degree-raising argument. New in this session: L₁[Q]=Q'+Q is proved surjective onto all polynomials (risch_linear_surjective_monomial + risch_linear_surjective_all), completing the contrast with L₂. Three axioms cover the full Liouville-Risch theory (structural form of elementary integrals, Risch criterion, Gaussian non-elementarity), documenting the gap requiring Picard-Vessiot theory not yet in Mathlib. Total: 20 theorems, 3 axioms, 0 sorries, 435 lines.",
+    "summary": "Formalization of the polynomial obstruction to the Gaussian integral's elementarity. The main theorem (no_poly_risch_soln) is fully machine-checked: no polynomial p satisfies p' - 2xp = 1. The proof uses a clean degree-raising argument. New in this session: L₁[Q]=Q'+Q is proved surjective onto all polynomials (risch_linear_surjective_monomial + risch_linear_surjective_all), completing the contrast with L₂. Three axioms cover the full Liouville-Risch theory (structural form of elementary integrals, Risch criterion, Gaussian non-elementarity), documenting the gap requiring Picard-Vessiot theory not yet in Mathlib. Total: 20 theorems, 3 axioms, 0 sorries, 448 lines.",
     "implications": "**Theoretical Significance**: Liouville's integration theorem inaugurated differential algebra and the Risch decision procedure (1969), which underlies symbolic integration in all major computer algebra systems. The degree-raising operator argument is a model case of how algebraic structure (polynomial degree) witnesses transcendence. The structural analogy with Abel-Ruffini (both are Galois-theoretic impossibility results proved by polynomial algebra arguments) is formalized explicitly. The formalization also provides a clean pedagogical development of differential field basics and the Risch criterion framework.",
     "openQuestions": [
       "Reduce the axiom count: extend the polynomial obstruction to rational functions using partial fraction analysis. Key step: if Q = p/q (in lowest terms) satisfies Q' - 2xQ = 1, then poles of Q' must cancel with poles of 2xQ; analyzing the pole order at each root of q leads to a contradiction. This requires Mathlib's partial fraction decomposition.",
@@ -198,7 +198,7 @@
       "Real"
     ],
     "namespace": "AbelRuffiniOQ09",
-    "lineCount": 435,
+    "lineCount": 448,
     "axiomCount": 3,
     "theoremCount": 20,
     "definitionCount": 2,


### PR DESCRIPTION
## Summary

Gallery integrity audit found `abel-ruffini-oq-09` has a stale `lineCount` in meta.json.

**Root cause**: PR #15077 fixed the True-placeholder issue (#15073) by replacing `True` in `liouville_integration_theorem` with proper opaque type declarations (`IsElementaryOver`, `IsLiouvilleForm`, `IsElementaryFn`). This grew the Lean file from 435 to 448 lines, but the meta.json was not updated.

**Fix**:
- `meta.lineCount`: 435 → 448
- `leanFile.lineCount`: 435 → 448  
- `sections.analogy.endLine`: 435 → 448 (last section now ends at line 448)
- `conclusion.summary`: updated the "435 lines" text to "448 lines"

**No integrity concerns**: status (`axiomatized`), badge (`axiom`), sorries (0), axiomCount (3), and theoremCount (20) are all correct.

## Test plan

- [x] `grep -n "lineCount" src/data/proofs/abel-ruffini-oq-09/meta.json` shows 448 in both occurrences
- [x] Actual file line count: `git show HEAD:proofs/Proofs/AbelRuffiniOQ09.lean | wc -l` = 448

🤖 Generated with [Claude Code](https://claude.com/claude-code)