### PR TITLE
fix(angle-trisection-oq-04-oq-04): correct leanFile.theoremCount 12->11

### DIFF
--- a/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 12
+    "theoremCount": 11
   },
   "meta": {
     "author": "Formalized in Lean 4 (researcher-7)",


### PR DESCRIPTION
## Summary

Minor metadata fix: `src/data/proofs/angle-trisection-oq-04-oq-04/meta.json` had `leanFile.theoremCount: 12`, but the actual Lean file `proofs/Proofs/AngleTrisectionOQ04OQ04.lean` contains only 11 theorem declarations.

## Verified theorems (11)

1. `totient_11_eq`
2. `totient_23_eq`
3. `not_twoThree_of_large_prime_dvd`
4. `ngon_11_not_neusis`
5. `ngon_11_2fold`
6. `ngon_11_2fold_not_neusis`
7. `ngon_23_not_neusis`
8. `ngon_23_4fold`
9. `ngon_23_4fold_not_neusis`
10. `multi_fold_strictly_stronger_than_neusis`
11. `exists_ngon_at_each_level`

## Proof integrity unchanged

Only `leanFile.theoremCount` is incorrect. The substantive fields are all correct:

- `status: verified`
- `badge: original`
- `sorries: 0`
- `axiomCount: 0`
- `lineCount: 152`

## Test plan

- [x] Verified theorem count by grepping `^theorem ` / `^lemma ` against `git show origin/main:proofs/Proofs/AngleTrisectionOQ04OQ04.lean`
- [x] Diff is a single-line change to the metadata field