### PR TITLE
audit(tracker): angle-trisection-oq-04-oq-04 issues-fixed + oq-03-oq-02 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13893,11 +13893,12 @@
       "result": "clean"
     },
     "angle-trisection-oq-04-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [
-        "missing top-level sorries field; lineCount stale 155->152"
+        "missing top-level sorries field; lineCount stale 155->152",
+        "leanFile.theoremCount stale 12→11; PR #15106"
       ],
-      "lastAudited": "2026-05-03T08:00:00Z",
+      "lastAudited": "2026-05-03T06:29:52Z",
       "result": "issues-fixed"
     },
     "binary-gcd-oq-03-oq-02": {
@@ -13935,6 +13936,15 @@
       ],
       "lastAudited": "2026-05-03T08:00:00Z",
       "result": "issues-fixed"
+    },
+    "angle-trisection-oq-03-oq-02": {
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T06:29:52Z",
+      "result": "issues-found",
+      "issues": [
+        "meta.meta.sorries/axiomCount fields missing; leanFile.lineCount 140→156, theoremCount 12→13"
+      ],
+      "notes": "Fix PR #15099 in-flight; tracker PR #15105 in-flight"
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Audit cycle results for two angle-trisection proofs:

- **angle-trisection-oq-04-oq-04** (`auditCount` 1→2, `result` `issues-fixed`): appended `leanFile.theoremCount stale 12→11; PR #15106`. Fix PR #15106 already in-flight.
- **angle-trisection-oq-03-oq-02** (new entry, `auditCount` 4, `result` `issues-found`): missing `meta.meta.sorries`/`axiomCount` fields plus `leanFile.lineCount` 140→156 and `theoremCount` 12→13 drift. Fix PR #15099 and tracker PR #15105 already in-flight.

## Conflict Notice

PR #15105 also modifies `src/data/proofs/audit-tracker.json` and may merge first. Expect a small textual conflict in the `entries` map; resolution is to keep both entries.

## Test plan

- [x] `git show origin/main:src/data/proofs/audit-tracker.json` baseline used
- [x] Edits applied via Python with `ensure_ascii=False` (no `→` escapes in diff)
- [x] Diff inspected: only the two intended entries changed
- [ ] Deployer merges; if conflict with #15105, re-apply both entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)