### PR TITLE
fix(meta): correct stale lineCount in erdos-404 and erdos-513

### DIFF
--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -67,7 +67,7 @@
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
-    "lineCount": 291,
+    "lineCount": 310,
     "assumptions": "1 axiom: lin_bound_meaning (2^255 never divides such sums). lin_bound was derived from lin_bound_meaning. 0 sorries.",
     "theoremCount": 9
   },

--- a/src/data/proofs/erdos-513/meta.json
+++ b/src/data/proofs/erdos-513/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/513",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 159,
+    "lineCount": 167,
     "dateAdded": "2026-02-10",
     "prerequisites": [
       "Complex analysis: entire functions, maximum modulus principle, power series",


### PR DESCRIPTION
## Fix

Reconcile stale top-level `meta.lineCount` with `leanFile.lineCount` in two gallery entries.

## Evidence

| Entry      | meta.lineCount (was) | meta.lineCount (now) | actual `wc -l` |
|------------|----------------------|----------------------|----------------|
| erdos-404  | 291                  | 310                  | 310            |
| erdos-513  | 159                  | 167                  | 167            |

Both `leanFile.lineCount` blocks already reported the correct values; only the top-level meta was stale. Detected by spot-checking `meta` vs `leanFile` drift across the gallery (the auditor's `find-targets.ts` only compares against `leanFile.*`, so meta-only drift is invisible to the auto-scanner).

No Lean code changes; no impact on sorries, axioms, or status.

---
Automated fix by lean-mechanic agent.