### PR TITLE
audit(tracker): erdos-1006-oq-01-oq-02 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13945,6 +13945,17 @@
         "meta.meta.sorries/axiomCount fields missing; leanFile.lineCount 140→156, theoremCount 12→13"
       ],
       "notes": "Fix PR #15099 in-flight; tracker PR #15105 in-flight"
+    },
+    "erdos-1006-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T06:49:07Z",
+      "result": "issues-found",
+      "issues": [
+        "leanFile.theoremCount: 10 but actual is 9 named theorems (True stub example over-counted)",
+        "meta.theoremCount: 7 (stale, should be 9)",
+        "description: claims '10 theorems' (should be 9)",
+        "True stub: `example : True := trivial` at line 122 (orphaned placeholder). Fix in PR #15112."
+      ]
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit: erdos-1006-oq-01-oq-02 — issues-found

### Findings

**Proof**: Cover Graph Recognition (`erdos-1006-oq-01-oq-02`)

| Field | Claimed | Actual |
|-------|---------|--------|
| `leanFile.theoremCount` | 10 | 9 (True stub example over-counted) |
| `meta.theoremCount` | 7 | 9 (stale) |
| description | "10 theorems" | should be "9 theorems" |
| True stub | — | `example : True := trivial` at line 122 |

### Evidence

```
$ grep -n "^theorem\|^example\|:= trivial" Erdos1006OQ01OQ02.lean
77: theorem coverOrientation_no_shortcut
92: theorem cover_graph_is_hasse
111: theorem cover_implies_related
122: example : True := trivial  -- The separation witnesses conceptually above
130: theorem cover_graph_in_np
151: theorem cover_search_space_bound
196: theorem cover_subclass_comparability
213: theorem k3_is_comparability_graph
224: theorem k3_not_cover_graph
256: theorem cover_strictly_subset_comparability
```

9 named theorems + 1 orphaned True stub = 10 counted entries; `leanFile.theoremCount` over-counted.

### Status

- 0 sorries ✓
- 2 axioms (comparability_recognition_in_p, cover_graph_recognition_in_p) ✓
- `axiomatized/axiom` badge is correct ✓
- Fix in progress: PR #15112

🤖 Generated with [Claude Code](https://claude.com/claude-code)