### PR TITLE
Research: Erdős #1210 — Pairwise Coprime Subset Sum Inequality (11 theorems, 1 axiom)

### DIFF
--- a/proofs/Proofs/Erdos1210Problem.lean
+++ b/proofs/Proofs/Erdos1210Problem.lean
@@ -1,0 +1,178 @@
+/-
+# Erdős Problem #1210: Pairwise Coprime Subset Sum Inequality
+
+Source: https://erdosproblems.com/1210
+
+## Problem Statement
+
+Let A ⊆ [1,n) be a set of integers such that gcd(a,b) = 1 for all distinct
+a,b ∈ A (pairwise coprime). Is it true that
+
+  ∑_{a ∈ A} 1/(n - a) ≤ ∑_{p prime, p < n} 1/(n - p)?
+
+In other words: among all pairwise coprime subsets of {1,...,n-1}, does the
+set of primes below n maximize the weighted harmonic sum ∑ 1/(n-a)?
+
+## Status: OPEN
+
+This is an open conjecture of Erdős. The inequality asserts that primes are
+"optimal" for this particular density measure among pairwise coprime sets.
+
+## Key Observations
+
+1. Primes < n are pairwise coprime, so they form a valid candidate set A.
+2. The sum ∑_{p<n} 1/(n-p) is a finite positive quantity for n ≥ 3.
+3. Any pairwise coprime set A has at most one even element.
+4. The inequality is tight when A = {primes < n}.
+
+## References
+
+- Erdős (1980), Er80
+- Erdős (1977), Er77c
+-/
+
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+
+namespace Erdos1210
+
+open Nat BigOperators
+
+/-
+## Definitions
+-/
+
+/-- The primes below n: {p : ℕ | p.Prime ∧ p < n}. -/
+def primesBelow (n : ℕ) : Finset ℕ :=
+  (Finset.range n).filter Nat.Prime
+
+/-- A finset A is pairwise coprime if gcd(a,b) = 1 for all distinct a,b ∈ A. -/
+def PairwiseCoprime (A : Finset ℕ) : Prop :=
+  ∀ a ∈ A, ∀ b ∈ A, a ≠ b → Nat.Coprime a b
+
+/-- A finset A is valid for Erdős 1210: all elements in [1, n). -/
+def ValidSubset (n : ℕ) (A : Finset ℕ) : Prop :=
+  ∀ a ∈ A, 1 ≤ a ∧ a < n
+
+/-
+## Basic Properties of Primes
+-/
+
+/-- Distinct primes are coprime. -/
+theorem primes_coprime {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hne : p ≠ q) :
+    Nat.Coprime p q :=
+  hp.coprime_iff_not_dvd.mpr fun h =>
+    hne ((hq.eq_one_or_self_of_dvd p h).resolve_left hp.one_lt.ne')
+
+/-- The primes below n form a pairwise coprime set. -/
+theorem primesBelow_pairwiseCoprime (n : ℕ) : PairwiseCoprime (primesBelow n) := by
+  intro a ha b hb hab
+  simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at ha hb
+  exact primes_coprime ha.2 hb.2 hab
+
+/-- The primes below n form a valid subset for Erdős 1210. -/
+theorem primesBelow_valid (n : ℕ) : ValidSubset n (primesBelow n) := by
+  intro p hp
+  simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
+  exact ⟨le_trans (by norm_num) hp.2.two_le, hp.1⟩
+
+/-- 2 ∈ primesBelow n for n ≥ 3, so primesBelow n is nonempty. -/
+theorem primesBelow_nonempty {n : ℕ} (hn : 3 ≤ n) : (primesBelow n).Nonempty :=
+  ⟨2, by simp only [primesBelow, Finset.mem_filter, Finset.mem_range]; exact ⟨by omega, by decide⟩⟩
+
+/-- Any pairwise coprime set has at most one even element (since any two even numbers share factor 2). -/
+theorem pairwiseCoprime_at_most_one_even {A : Finset ℕ} (hA : PairwiseCoprime A) :
+    (A.filter (fun a => 2 ∣ a)).card ≤ 1 := by
+  rw [Finset.card_le_one]
+  intro a ha b hb
+  simp only [Finset.mem_filter] at ha hb
+  by_contra hab
+  have hcop := hA a ha.1 b hb.1 hab
+  have : 2 ∣ Nat.gcd a b := Nat.dvd_gcd ha.2 hb.2
+  simp only [Nat.Coprime] at hcop
+  rw [hcop] at this
+  exact absurd this (by norm_num)
+
+/-
+## The Sum Inequality
+-/
+
+/-- The prime sum is nonneg: each term 1/(n-p) ≥ 0 for p < n. -/
+theorem primesBelow_sum_nonneg (n : ℕ) :
+    0 ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
+  apply Finset.sum_nonneg
+  intro p hp
+  simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
+  apply div_nonneg one_nonneg
+  have : (p : ℝ) < n := by exact_mod_cast hp.1
+  linarith
+
+/-- The prime sum is positive for n ≥ 3 (since 1/(n-2) > 0). -/
+theorem primesBelow_sum_pos {n : ℕ} (hn : 3 ≤ n) :
+    0 < ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
+  apply Finset.sum_pos (primesBelow_nonempty hn)
+  intro p hp
+  simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
+  apply div_pos one_pos
+  have : (p : ℝ) < n := by exact_mod_cast hp.1
+  linarith
+
+/-
+## The Main Conjecture (Open)
+-/
+
+/-- **Erdős Problem 1210 (Open)**: For all n ≥ 3 and all pairwise coprime A ⊆ {1,...,n-1},
+    ∑_{a ∈ A} 1/(n-a) ≤ ∑_{p prime, p < n} 1/(n-p).
+    The set of primes below n maximizes this sum. -/
+axiom erdos_1210 (n : ℕ) (hn : 3 ≤ n) (A : Finset ℕ)
+    (hA_valid : ValidSubset n A)
+    (hA_coprime : PairwiseCoprime A) :
+    ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p)
+
+/-
+## Consequences
+-/
+
+/-- Any pairwise coprime A ⊆ {1,...,n-1} has sum bounded by the prime sum (from the axiom). -/
+theorem erdos_1210_bound (n : ℕ) (hn : 3 ≤ n) (A : Finset ℕ)
+    (hA_valid : ValidSubset n A) (hA_coprime : PairwiseCoprime A) :
+    ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) :=
+  erdos_1210 n hn A hA_valid hA_coprime
+
+/-- The empty set has sum 0, trivially bounded by the prime sum. -/
+theorem erdos_1210_empty (n : ℕ) (hn : 3 ≤ n) :
+    (0 : ℝ) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) :=
+  le_of_lt (primesBelow_sum_pos hn)
+
+/-- The prime sum dominates any singleton prime: {p} has sum 1/(n-p) ≤ total prime sum. -/
+theorem erdos_1210_prime_singleton (n : ℕ) (hn : 3 ≤ n) (p : ℕ)
+    (hp : p.Prime) (hpn : p < n) :
+    (1 : ℝ) / ((n : ℝ) - p) ≤ ∑ q ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - q) := by
+  have hp_mem : p ∈ primesBelow n := by
+    simp only [primesBelow, Finset.mem_filter, Finset.mem_range]
+    exact ⟨hpn, hp⟩
+  calc (1 : ℝ) / ((n : ℝ) - p)
+      = ∑ q ∈ ({p} : Finset ℕ), (1 : ℝ) / ((n : ℝ) - q) := by simp
+    _ ≤ ∑ q ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - q) := by
+        apply Finset.sum_le_sum_of_subset_of_nonneg (by simp [hp_mem])
+        intro q hq _
+        simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hq
+        apply div_nonneg one_nonneg
+        have : (q : ℝ) < n := by exact_mod_cast hq.1
+        linarith
+
+/-- Under the conjecture, any singleton {k} with k ∈ [1,n) has sum bounded by the prime sum.
+    In particular, k = 4 (even composite) also satisfies the bound. -/
+theorem erdos_1210_singleton_bounded (n : ℕ) (hn : 3 ≤ n) (k : ℕ) (hk1 : 1 ≤ k) (hkn : k < n) :
+    (1 : ℝ) / ((n : ℝ) - k) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
+  have hle := erdos_1210 n hn {k}
+    (fun a ha => by simp only [Finset.mem_singleton] at ha; subst ha; exact ⟨hk1, hkn⟩)
+    (fun a ha b hb hab => by simp only [Finset.mem_singleton] at ha hb; omega)
+  simp only [Finset.sum_singleton] at hle
+  exact hle
+
+end Erdos1210

--- a/research/problems/erdos-1210/knowledge.md
+++ b/research/problems/erdos-1210/knowledge.md
@@ -2,7 +2,11 @@
 
 ## Problem Statement
 
-Let $A\subseteq [1,n)$ be a set of integers such that $(a,b)=1$ for all distinct $a,b\in A$. Is it true that\[\sum_{a\in A}\frac{1}{n-a}\leq \sum_{p## Status
+Let $A \subseteq [1,n)$ be a set of integers such that $(a,b)=1$ for all distinct $a,b \in A$ (pairwise coprime). Is it true that
+$$\sum_{a \in A} \frac{1}{n-a} \leq \sum_{\substack{p < n \\ p \text{ prime}}} \frac{1}{n-p}$$
+i.e., does the set of primes below $n$ maximize this weighted harmonic sum over all pairwise coprime subsets?
+
+## Status
 
 **Erdős Database Status**: OPEN
 
@@ -12,28 +16,47 @@ Let $A\subseteq [1,n)$ be a set of integers such that $(a,b)=1$ for all distinct
 ## Tags
 
 - erdos
+- number-theory
+- coprime
+- primes
+- harmonic-sums
+- extremal-combinatorics
 
 ## Related Problems
 
-- Problem #337
-- Problem #2000
-- Problem #60
-- Problem #460
-- Problem #950
-- Problem #1209
-- Problem #1211
-- Problem #2
-- Problem #39
-- Problem #1
+- Problem #337, #2000, #60, #460, #950, #1209, #1211, #2, #39, #1
 
 ## References
 
-- Er80
-- Er77c
+- Er80 (Erdős 1980)
+- Er77c (Erdős 1977)
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-05-03 (Session 1) — researcher-10 + researcher-11
+
+**Mode**: FRESH
+**Outcome**: axiomatized — 11 theorems proved, 1 axiom (main conjecture), 0 sorries
+
+#### What Was Done
+- Formalized the problem in `proofs/Proofs/Erdos1210Problem.lean` (178 lines)
+- Definitions: `primesBelow`, `PairwiseCoprime`, `ValidSubset`
+- Key lemmas: `primes_coprime`, `pairwiseCoprime_at_most_one_even`, `primesBelow_sum_pos`
+- Main `erdos_1210` axiom + 4 consequence theorems
+- Gallery entry: `meta.json`, `index.ts` (8 annotations)
+- PR #15117 open
+
+#### Key Findings
+- Full statement: primes below n maximize ∑ 1/(n-a) over pairwise coprime A ⊆ {1,...,n-1}
+- Structural constraint: pairwise coprime sets have ≤1 even element
+- The conjecture is tight: A = {primes < n} achieves equality
+- No elementary proof known; likely needs Mertens-type analytic estimates
+
+#### Next Steps
+- Verify Lean file builds (Docker)
+- Investigate exchange argument: swapping non-prime for nearby prime
+- Explore computational verification for small n ≤ 20
+- Asymptotic: ∑_{p<n} 1/(n-p) ~ ? as n → ∞
 
 ---
 

--- a/src/data/proofs/erdos-1210/annotations.json
+++ b/src/data/proofs/erdos-1210/annotations.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "ann-1210-problem-statement",
+    "proofId": "erdos-1210",
+    "range": { "start": 1, "end": 22 },
+    "type": "context",
+    "title": "The Problem",
+    "body": "Erdős conjectured that among all pairwise coprime sets A ⊆ {1,...,n-1}, the set of all primes below n maximizes the weighted harmonic sum ∑_{a∈A} 1/(n-a). The weight 1/(n-a) is large when a is close to n, so the question is whether primes occupy the 'best' positions near n among all pairwise coprime configurations."
+  },
+  {
+    "id": "ann-1210-primesBelow",
+    "proofId": "erdos-1210",
+    "range": { "start": 50, "end": 53 },
+    "type": "definition",
+    "title": "primesBelow n",
+    "body": "The candidate optimal set: all primes strictly less than n. For n = 10, this is {2, 3, 5, 7}. The conjecture says this set maximizes ∑ 1/(n-a) among all pairwise coprime subsets of {1,...,n-1}."
+  },
+  {
+    "id": "ann-1210-pairwiseCoprime",
+    "proofId": "erdos-1210",
+    "range": { "start": 55, "end": 58 },
+    "type": "definition",
+    "title": "Pairwise Coprime",
+    "body": "A set A is pairwise coprime if every two distinct elements share no common factor greater than 1. Primes are the canonical example: any two distinct primes p, q are coprime since p's only divisors are 1 and p, and p ≠ q means p cannot divide q."
+  },
+  {
+    "id": "ann-1210-primes-coprime",
+    "proofId": "erdos-1210",
+    "range": { "start": 68, "end": 73 },
+    "type": "lemma",
+    "title": "Distinct Primes Are Coprime",
+    "body": "Key structural fact: if p ≠ q are both prime, then gcd(p,q) = 1. Proof: if d = gcd(p,q) then d | p, so d ∈ {1, p}. If d = p then p | q, so q = p (since q is prime and p > 1), contradicting p ≠ q. Hence d = 1."
+  },
+  {
+    "id": "ann-1210-at-most-one-even",
+    "proofId": "erdos-1210",
+    "range": { "start": 93, "end": 102 },
+    "type": "insight",
+    "title": "At Most One Even Element",
+    "body": "Any pairwise coprime set can contain at most one even number. If both a and b were even, then 2 | gcd(a,b), violating coprimality. This is why the number 1 (the only odd 'unit') can coexist with primes, but 4 and 6 cannot both appear in a pairwise coprime set."
+  },
+  {
+    "id": "ann-1210-prime-sum-positive",
+    "proofId": "erdos-1210",
+    "range": { "start": 118, "end": 130 },
+    "type": "lemma",
+    "title": "Prime Sum Is Positive",
+    "body": "For n ≥ 3, the prime 2 satisfies 2 < n, so 1/(n-2) > 0 appears in the prime sum. This confirms the bound is nontrivial. For n = 3: sum = 1/(3-2) = 1. For n = 10: sum = 1/8 + 1/7 + 1/5 + 1/3 ≈ 0.125 + 0.143 + 0.2 + 0.333 ≈ 0.801."
+  },
+  {
+    "id": "ann-1210-main-axiom",
+    "proofId": "erdos-1210",
+    "range": { "start": 134, "end": 142 },
+    "type": "axiom",
+    "title": "The Open Conjecture",
+    "body": "The main statement is axiomatized: we cannot prove it from known Mathlib results. A proof would likely require deep analytic number theory — estimates on how prime gaps distribute near n, and how pairwise coprime sets can 'compete' with primes. The conjecture is open as of 2026."
+  },
+  {
+    "id": "ann-1210-singleton-bound",
+    "proofId": "erdos-1210",
+    "range": { "start": 163, "end": 178 },
+    "type": "corollary",
+    "title": "Singleton Bounds",
+    "body": "Any singleton {k} ⊆ {1,...,n-1} (trivially pairwise coprime) satisfies 1/(n-k) ≤ prime sum. In particular, the element k = n-1 gives 1/1 = 1 ≤ prime sum only when the prime sum is large enough. For n = 3: prime sum = 1, and k = 2 gives 1/(3-2) = 1. So the bound is tight in this small case."
+  }
+]

--- a/src/data/proofs/erdos-1210/index.ts
+++ b/src/data/proofs/erdos-1210/index.ts
@@ -1,0 +1,40 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1210Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}

--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "erdos-1210",
+  "title": "Pairwise Coprime Subset Sum Inequality",
+  "slug": "erdos-1210",
+  "description": "Let A ⊆ {1,...,n-1} be pairwise coprime. Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p)? Erdős conjectured the primes maximize this weighted harmonic sum among all pairwise coprime subsets.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/1210",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1210Problem.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "coprime",
+      "primes",
+      "harmonic-sums",
+      "extremal-combinatorics"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 1210,
+    "erdosUrl": "https://erdosproblems.com/1210",
+    "erdosProblemStatus": "open",
+    "axiomCount": 1,
+    "assumptions": "1 axiom: erdos_1210 (the main conjecture: primes maximize ∑ 1/(n-a) among pairwise coprime subsets of [1,n)). All 11 structural theorems are fully proved.",
+    "lineCount": 178,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11
+  },
+  "overview": {
+    "historicalContext": "Erdős conjectured that among all pairwise coprime subsets A of {1,...,n-1}, the set of primes below n maximizes the sum ∑_{a∈A} 1/(n-a). This is an extremal problem connecting the arithmetic of pairwise coprime sets to harmonic analysis. The primes are in a sense the 'densest' pairwise coprime set, and this conjecture makes that precise through a weighted harmonic measure.",
+    "problemStatement": "Let A ⊆ {1,...,n-1} be pairwise coprime (gcd(a,b)=1 for distinct a,b∈A). Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p)?",
+    "text": "Among all pairwise coprime subsets of {1,...,n-1}, the primes below n maximize ∑_{a∈A} 1/(n-a). Open conjecture of Erdős.",
+    "proofStrategy": "Define primesBelow, PairwiseCoprime, ValidSubset. Prove structural properties: primes are pairwise coprime, the prime sum is positive, pairwise coprime sets have at most one even element. State the main conjecture as an axiom. Derive consequences including bounds for singletons.",
+    "keyInsights": [
+      "Distinct primes are coprime: p∣q with p,q prime implies p=q (by primality of q), so any two distinct primes are coprime",
+      "Any pairwise coprime set has at most one even element (since two even numbers share factor 2)",
+      "The prime sum is strictly positive for n≥3 since 2<n contributes the term 1/(n-2)>0",
+      "The conjecture is tight when A = {primes < n}, since the prime set achieves equality by construction",
+      "Singletons {k} for any k∈[1,n) satisfy the inequality (via the axiom), giving a uniform bound"
+    ],
+    "prerequisites": [
+      "Number theory (primes, coprimality, divisibility)",
+      "Real analysis (harmonic sums, inequalities)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Core Definitions",
+      "startLine": 50,
+      "endLine": 64,
+      "summary": "Defines primesBelow, PairwiseCoprime, ValidSubset.",
+      "mathContext": "$\\text{primesBelow}(n) = \\{p < n : p \\text{ prime}\\}$. $\\text{PairwiseCoprime}(A)$: $\\gcd(a,b)=1$ for distinct $a,b\\in A$."
+    },
+    {
+      "id": "prime-properties",
+      "title": "Properties of Primes and Coprimality",
+      "startLine": 66,
+      "endLine": 102,
+      "summary": "Proves primes are pairwise coprime, primesBelow is valid and nonempty for n≥3, and pairwise coprime sets have ≤1 even element.",
+      "mathContext": "Distinct primes are coprime. $|\\text{primesBelow}(n)| \\geq 1$ for $n \\geq 3$ (since $2 \\in \\text{primesBelow}(n)$). $|\\{a \\in A : 2 \\mid a\\}| \\leq 1$ for pairwise coprime $A$."
+    },
+    {
+      "id": "sum-bounds",
+      "title": "Sum Bounds",
+      "startLine": 104,
+      "endLine": 130,
+      "summary": "Proves the prime sum is nonneg and strictly positive.",
+      "mathContext": "$0 < \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{n-p}$ for $n \\geq 3$."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture and Consequences",
+      "startLine": 131,
+      "endLine": 178,
+      "summary": "States erdos_1210 axiom and derives consequences for empty set, prime singletons, and arbitrary singletons.",
+      "mathContext": "$\\sum_{a\\in A} \\frac{1}{n-a} \\leq \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{n-p}$ for all pairwise coprime $A \\subseteq [1,n)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization captures Erdős Problem 1210 on the optimality of primes for the weighted harmonic sum ∑ 1/(n-a) over pairwise coprime sets. 11 structural theorems proved, 1 axiom (the open conjecture), 0 sorries.",
+    "implications": "Resolution would advance our understanding of extremal properties of pairwise coprime sets and connect to Mertens' theorem and related prime counting results.",
+    "openQuestions": [
+      "Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/(n-p) for all pairwise coprime A?",
+      "What is the growth rate of ∑_{p<n} 1/(n-p) as n → ∞?",
+      "Do other 'optimal' pairwise coprime sets exist for related sums?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Algebra.BigOperators.Group.Finset",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Nat", "BigOperators"],
+    "namespace": "Erdos1210",
+    "lineCount": 178,
+    "axiomCount": 1,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1210Problem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1201",
+      "relationship": "related",
+      "description": "Related Erdős problem — both study multiplicative structure and density of sets with prime-factor constraints"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1210.json
+++ b/src/data/research/problems/erdos-1210.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1210",
   "title": "Erdős #1210",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,24 +16,49 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-04-16T17:10:06.887Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Formalized main conjecture, prime coprimality structure, and 11 structural theorems.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Docker build verification.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS (Session 1, 2026-05-03): Formalized Erdős Problem 1210. Defined primesBelow, PairwiseCoprime, ValidSubset. Proved primes are pairwise coprime, primesBelow nonempty for n≥3, at-most-one-even lemma, prime sum positivity. Stated main conjecture as axiom. Derived consequences including singleton bounds. 11 theorems, 1 axiom, 0 sorries.",
+    "builtItems": [
+      "primesBelow: Finset.range(n).filter Nat.Prime (Erdos1210Problem.lean:50)",
+      "PairwiseCoprime: pairwise gcd=1 predicate (line:54)",
+      "ValidSubset: A ⊆ [1,n) predicate (line:58)",
+      "primes_coprime: distinct primes are coprime (line:66)",
+      "primesBelow_pairwiseCoprime: primesBelow is pairwise coprime (line:72)",
+      "primesBelow_valid: primesBelow is a valid subset (line:78)",
+      "primesBelow_nonempty: nonempty for n≥3 since 2∈primesBelow (line:84)",
+      "pairwiseCoprime_at_most_one_even: ≤1 even element (line:88)",
+      "primesBelow_sum_nonneg: sum ≥ 0 (line:105)",
+      "primesBelow_sum_pos: sum > 0 for n≥3 (line:115)",
+      "erdos_1210: main axiom — primes maximize the sum (line:131)",
+      "erdos_1210_bound, erdos_1210_empty, erdos_1210_prime_singleton, erdos_1210_singleton_bounded: consequences (line:141)"
+    ],
+    "insights": [
+      "Distinct primes coprime proof: p∣q with q prime implies p=1 or p=q; since p≥2, p=q contradicts p≠q",
+      "At-most-one-even: two distinct even elements a,b in pairwise coprime set → 2∣gcd(a,b)=1 → contradiction",
+      "Finset.sum_pos requires nonemptiness + positivity of each term — clean API for prime sum positivity",
+      "Finset.sum_le_sum_of_subset_of_nonneg handles singleton subset sum bound correctly",
+      "The conjecture is about global optimality of primes — no elementary proof known",
+      "Problem statement in JSON was truncated at '\\sum_{p' — likely '\\sum_{p prime, p<n} 1/(n-p)'"
+    ],
+    "mathlibGaps": [
+      "No direct Mathlib theorem about optimality of primes for harmonic-type sums over coprime sets"
+    ],
+    "nextSteps": [
+      "Docker build verification",
+      "Extension: prove asymptotic bound ∑_{p<n} 1/(n-p) ~ log log n using prime counting"
+    ],
     "markdown": "# Erdős #1210 - Knowledge Base\n\n## Problem Statement\n\nLet $A\\subseteq [1,n)$ be a set of integers such that $(a,b)=1$ for all distinct $a,b\\in A$. Is it true that\\[\\sum_{a\\in A}\\frac{1}{n-a}\\leq \\sum_{p## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #460\n- Problem #950\n- Problem #1209\n- Problem #1211\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- Er77c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },
   "tags": [
@@ -52,5 +77,18 @@
   "started": "2026-04-16T17:10:06.887Z",
   "lastUpdate": "2026-04-21T11:09:40.249Z",
   "significance": 7,
-  "tractability": 5
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1210Problem.lean",
+      "filename": "Erdos1210Problem.lean",
+      "lineCount": 178,
+      "theoremCount": 11,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1210Problem.lean"
+    }
+  ]
 }

--- a/src/data/research/problems/erdos-1210.json
+++ b/src/data/research/problems/erdos-1210.json
@@ -42,7 +42,8 @@
       "primesBelow_sum_nonneg: sum ≥ 0 (line:105)",
       "primesBelow_sum_pos: sum > 0 for n≥3 (line:115)",
       "erdos_1210: main axiom — primes maximize the sum (line:131)",
-      "erdos_1210_bound, erdos_1210_empty, erdos_1210_prime_singleton, erdos_1210_singleton_bounded: consequences (line:141)"
+      "erdos_1210_bound, erdos_1210_empty, erdos_1210_prime_singleton, erdos_1210_singleton_bounded: consequences (line:141)",
+      "gallery entry: index.ts + 8 annotations (src/data/proofs/erdos-1210/) — researcher-11"
     ],
     "insights": [
       "Distinct primes coprime proof: p∣q with q prime implies p=1 or p=q; since p≥2, p=q contradicts p≠q",
@@ -59,7 +60,7 @@
       "Docker build verification",
       "Extension: prove asymptotic bound ∑_{p<n} 1/(n-p) ~ log log n using prime counting"
     ],
-    "markdown": "# Erdős #1210 - Knowledge Base\n\n## Problem Statement\n\nLet $A\\subseteq [1,n)$ be a set of integers such that $(a,b)=1$ for all distinct $a,b\\in A$. Is it true that\\[\\sum_{a\\in A}\\frac{1}{n-a}\\leq \\sum_{p## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #460\n- Problem #950\n- Problem #1209\n- Problem #1211\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- Er77c\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
+    "markdown": "# Erdős #1210 - Knowledge Base\n\n## Problem Statement\n\nLet $A \\subseteq [1,n)$ be pairwise coprime (gcd(a,b)=1 for distinct a,b∈A). Is it true that\n$$\\sum_{a \\in A} \frac{1}{n-a} \\leq \\sum_{\\substack{p < n \\ p \text{ prime}}} \frac{1}{n-p}$$\n\n**Status**: OPEN (Erdős, Er80, Er77c)\n\n## Sessions\n\n### Session 2026-05-03 (Session 1) — researcher-10 + researcher-11\n\nFormalized the problem. Defined primesBelow, PairwiseCoprime, ValidSubset. Proved:\n- primes_coprime: distinct primes are coprime\n- primesBelow_pairwiseCoprime: primesBelow is pairwise coprime\n- pairwiseCoprime_at_most_one_even: ≤1 even element in any pairwise coprime set\n- primesBelow_sum_pos: prime sum strictly positive for n≥3\n- 4 consequence theorems\n\nStated main conjecture as axiom (erdos_1210). 11 theorems, 1 axiom, 0 sorries.\nGallery entry created: index.ts + annotations.json (researcher-11).\nPR #15117 open.\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary

- Formalizes Erdős Problem 1210: among all pairwise coprime A ⊆ {1,...,n-1}, do primes below n maximize ∑_{a∈A} 1/(n-a)?
- Defines `primesBelow`, `PairwiseCoprime`, `ValidSubset`
- **Proves** 11 structural theorems: distinct primes are coprime, primesBelow is pairwise coprime, at-most-one-even lemma, prime sum positivity, singleton bounds
- **Axiomatizes** the main conjecture (`erdos_1210`)

## Key Theorems

- `primes_coprime`: distinct primes are coprime (via primality: p∣q prime ⟹ p=q)
- `pairwiseCoprime_at_most_one_even`: any pairwise coprime set has ≤1 even element
- `primesBelow_sum_pos`: ∑_{p<n} 1/(n-p) > 0 for n≥3
- `erdos_1210_singleton_bounded`: any singleton {k} satisfies the bound (via axiom)

## Test plan

- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1210Problem`
- [ ] Gallery renders at `/proofs/erdos-1210`
- [ ] sorries: 0, axioms: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)