### PR TITLE
fix(angle-trisection-oq-03-oq-02): correct theoremCount 12→13, populate leanFile

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -8,7 +8,6 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon",
     "status": "verified",
     "badge": "original",
-    "theoremCount": 12,
     "proofRepoPath": "Proofs/AngleTrisectionOQ03OQ02.lean",
     "tags": [
       "geometry",
@@ -23,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 156,
-    "theoremCount": 12
+    "theoremCount": 13
   },
   "overview": {
     "historicalContext": "The impossibility of trisecting a general angle with compass and straightedge was proved by Pierre Wantzel in 1837 using Galois theory: an angle θ is trisectable iff 8x³ − 6x − cos θ has a rational root or splits into linear factors over the iterated quadratic extensions of ℚ. The OQ-03 companion entry formalizes an O(log d) algorithm to check whether a denominator d (determining the angle π/d) satisfies the constructibility conditions by counting halvings of d until it becomes odd. This entry (OQ-03-OQ-02) closes the complexity question: the O(log d) bound is not just an upper bound — it is tight. The halvings algorithm performs exactly Nat.log 2 (2^k) = k steps on inputs d = 2^k, and no algorithm can process these inputs in sub-logarithmic time. The proof connects the constructibility check to the 2-adic valuation v₂(d) — the exact power of 2 dividing d — which is the information-theoretically required number of halvings.",
@@ -86,6 +85,24 @@
       "Can a tight lower bound be proved for the full constructibility test (not just the 'is d a power of 2?' subproblem), using more of the angle-trisection Galois theory from the parent entry?",
       "What is the complexity of deciding constructibility of a polygon with n sides in terms of n, if we allow arbitrary arithmetic operations rather than just halvings?"
     ]
+  },
+  "leanFile": {
+    "path": "Proofs/AngleTrisectionOQ03OQ02.lean",
+    "imports": [
+      "Mathlib.Data.Nat.Log",
+      "Mathlib.Tactic",
+      "Proofs.AngleTrisectionOQ03"
+    ],
+    "opens": [
+      "AngleTrisectionOQ03",
+      "Nat"
+    ],
+    "namespace": "AngleTrisectionOQ03OQ02",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 13
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct stale `theoremCount` and populate empty `leanFile` block in `angle-trisection-oq-03-oq-02` meta.json.

## Evidence

**Before**:
- `meta.theoremCount: 12` (duplicate key, both 12)
- `leanFile: {}` (empty)

**After**:
- `meta.theoremCount: 13` (single key)
- `leanFile: { lineCount: 156, axiomCount: 0, sorries: 0, definitionCount: 1, theoremCount: 13, ... }`

**Root cause**: Three theorems prefixed with `@[simp]` on the same line were missed by a `^theorem` grep:
```
44: @[simp] theorem halvings_zero : halvings 0 = 0 := rfl
45: @[simp] theorem halvings_one : halvings 1 = 0 := rfl
48: @[simp] theorem halvings_succ (n : ℕ) : ...
```
Total named theorems: halvings_zero, halvings_one, halvings_succ, halvings_odd, halvings_two_mul, halvings_pow2, halvings_eq_log_pow2, constructibility_lower_bound, halvings_unbounded, halvings_monotone_pow2, halvings_complexity_tight, halvings_pred_pow2, halvings_separates_pred = **13**.

Supersedes PR #15099 (conflicting due to intervening meta.json restructuring).

---
Automated fix by lean-mechanic agent.