### PR TITLE
fix(erdos-1201): correct theoremCount 14→19, lineCount 267→266; update audit tracker

### DIFF
--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -23,9 +23,9 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 14 structural theorems are fully proved.",
-    "lineCount": 267,
+    "lineCount": 266,
     "mathlib_version": "4.26.0",
-    "theoremCount": 14
+    "theoremCount": 19
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) → ∞ as n → ∞, but its distribution among products of consecutive integers is much subtler. The ε=1/2 case was established by Erdős: there exist arbitrarily long windows of consecutive integers containing a prime exceeding √n. The full conjecture—that large prime factors dominate for almost all starting points n, for any threshold n^(1-ε)—remains open.",
@@ -112,9 +112,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 267,
+    "lineCount": 266,
     "axiomCount": 1,
-    "theoremCount": 14,
+    "theoremCount": 19,
     "definitionCount": 4,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Gallery integrity audit found `erdos-1201` meta.json with stale `theoremCount` (14 vs actual 19) and `lineCount` (267 vs actual 266). The prior fix PR #15091 is CONFLICTING — this PR fixes the same issues independently.

**Changes:**
- `erdos-1201/meta.json`: `theoremCount` 14 → 19 and `lineCount` 267 → 266 (both `meta` and `leanFile` blocks updated)
- `audit-tracker.json`: mark `erdos-1201` issues-fixed (2nd audit, was issues-found)
- `audit-tracker.json`: add `abel-ruffini-oq-09` issues-fixed (verified clean; True stubs fixed by #15077, lineCount fixed by #15104)
- `audit-tracker.json`: add `erdos-1006-oq-01-oq-02` issues-fixed (theoremCount and True stub fixed by #15112)

**No integrity concerns for affected proofs**: status/badge/sorries/axioms are all correct for all three proofs.

## Test plan
- [ ] `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited proofs
- [ ] `erdos-1201/meta.json` has `theoremCount: 19` and `lineCount: 266`
- [ ] `audit-tracker.json` has entries for `abel-ruffini-oq-09`, `erdos-1006-oq-01-oq-02`, and updated `erdos-1201`

🤖 Generated with [Claude Code](https://claude.com/claude-code)