### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-02): strengthen IH to eliminate hjoin_dvd sorry

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -173,11 +173,15 @@ private lemma isConstructible_sup_degree (α : ℂ) (h : IsConstructible α) :
       have hβ_int_ℚβ : IsIntegral ℚ β_in_Kaβ := by
         rw [← isIntegral_algebraMap_iff (algebraMap ↥K_aβ ℂ).injective]; exact hβ_int_ℚ
       have hβ_int_Ka : IsIntegral ↥K_a β_in_Kaβ := hβ_int_ℚβ.tower_top
-      -- β generates K_aβ over K_a: any K_a-subfield of K_aβ containing β contains ℚ⟮β⟯
-      -- (since β generates ℚ⟮β⟯ over ℚ ≤ K_a), hence equals K_aβ = K_a ⊔ ℚ⟮β⟯.
-      -- The adjoin_eq_top_of_adjoin_eq_top approach requires ambient field = ℚ⟮β⟯ ≠ K_aβ.
+      -- β generates K_aβ over K_a because K_aβ = K_a ⊔ ℚ⟮β⟯ = K_a(β).
+      -- Proof plan: apply restrictScalars_injective ℚ, then rw [restrictScalars_top].
+      -- LHS = (adjoin ↥K_a {β_in_Kaβ}).restrictScalars ℚ.
+      -- By restrictScalars_adjoin: = adjoin ℚ (↑K_a_image ∪ {β_in_Kaβ}) in IntermField ℚ ↥K_aβ.
+      -- This equals ⊤ because K_a_image ∪ {β} generates K_aβ = K_a ⊔ ℚ⟮β⟯ over ℚ.
+      -- Blocker: restrictScalars_adjoin needs K' : IntermediateField ℚ ↥K_aβ with ↥K' = ↥K_a,
+      -- but ↥K_a and ↥K' are distinct Lean types (subtypes of ℂ vs ↥K_aβ respectively).
       have h_top_Ka : IntermediateField.adjoin ↥K_a ({β_in_Kaβ} : Set ↥K_aβ) = ⊤ := by
-        sorry -- K_aβ = K_a⊔ℚ⟮β⟯; β generates ℚ⟮β⟯/ℚ ≤ K_a, so generates K_aβ/K_a
+        sorry -- K_aβ = K_a⊔ℚ⟮β⟯ = K_a(β); β generates K_aβ/K_a
       have h_finrank_eq : Module.finrank ↥K_a ↥K_aβ =
           (minpoly ↥K_a β_in_Kaβ).natDegree := by
         have := IntermediateField.adjoin.finrank hβ_int_Ka

--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -174,14 +174,56 @@ private lemma isConstructible_sup_degree (α : ℂ) (h : IsConstructible α) :
         rw [← isIntegral_algebraMap_iff (algebraMap ↥K_aβ ℂ).injective]; exact hβ_int_ℚ
       have hβ_int_Ka : IsIntegral ↥K_a β_in_Kaβ := hβ_int_ℚβ.tower_top
       -- β generates K_aβ over K_a because K_aβ = K_a ⊔ ℚ⟮β⟯ = K_a(β).
-      -- Proof plan: apply restrictScalars_injective ℚ, then rw [restrictScalars_top].
-      -- LHS = (adjoin ↥K_a {β_in_Kaβ}).restrictScalars ℚ.
-      -- By restrictScalars_adjoin: = adjoin ℚ (↑K_a_image ∪ {β_in_Kaβ}) in IntermField ℚ ↥K_aβ.
-      -- This equals ⊤ because K_a_image ∪ {β} generates K_aβ = K_a ⊔ ℚ⟮β⟯ over ℚ.
-      -- Blocker: restrictScalars_adjoin needs K' : IntermediateField ℚ ↥K_aβ with ↥K' = ↥K_a,
-      -- but ↥K_a and ↥K' are distinct Lean types (subtypes of ℂ vs ↥K_aβ respectively).
+      -- Proof: restrictScalars_injective + restrict (image of K_a in ↥K_aβ) + lift_injective.
+      -- K_a_im = K_a.restrict le_sup_left : IntermediateField ℚ ↥K_aβ (image of K_a in K_aβ)
+      -- restrictScalars_adjoin_of_algEquiv (restrict_algEquiv) converts ↥K_a → ↥K_a_im base
+      -- restrictScalars_adjoin K_a_im gives adjoin ℚ (↑K_a_im ∪ {β_in_Kaβ}) = ⊤ in IF ℚ ↥K_aβ
+      -- lift_adjoin + lift_top: adjoin ℚ (Subtype.val '' ...) = K_a ⊔ ℚ⟮β⟯ = K_aβ in IF ℚ ℂ
       have h_top_Ka : IntermediateField.adjoin ↥K_a ({β_in_Kaβ} : Set ↥K_aβ) = ⊤ := by
-        sorry -- K_aβ = K_a⊔ℚ⟮β⟯ = K_a(β); β generates K_aβ/K_a
+        -- K_a_im = image of K_a in ↥K_aβ, as IntermediateField ℚ ↥K_aβ
+        let K_a_im : IntermediateField ℚ ↥K_aβ :=
+          IntermediateField.restrict (le_sup_left (b := ℚ⟮β⟯))
+        -- AlgEquiv ↥K_a ≃ₐ[ℚ] ↥K_a_im (K_a is isomorphic to its image in K_aβ)
+        let i : ↥K_a ≃ₐ[ℚ] ↥K_a_im :=
+          IntermediateField.restrict_algEquiv (le_sup_left (b := ℚ⟮β⟯))
+        -- Algebra/ScalarTower for K_a_im ≤ K_aβ
+        haveI hAlg_Kaim : Algebra ↥K_a_im ↥K_aβ :=
+          (IntermediateField.val K_a_im).toAlgebra
+        haveI hST_Kaim : IsScalarTower ℚ ↥K_a_im ↥K_aβ :=
+          IsScalarTower.of_algebraMap_eq (fun r =>
+            Subtype.ext (by simp [K_a_im, hAlg_Kaim, RingHom.algebraMap_toAlgebra]))
+        -- Key: algebraMap ↥K_a ↥K_aβ = (algebraMap ↥K_a_im ↥K_aβ) ∘ i
+        have hi : algebraMap ↥K_a ↥K_aβ = (algebraMap ↥K_a_im ↥K_aβ) ∘ i := by
+          funext x
+          simp [i, K_a_im, IntermediateField.restrict_algEquiv, AlgEquiv.ofInjectiveField,
+                hAlg_KaKaβ, hAlg_Kaim, RingHom.algebraMap_toAlgebra, IntermediateField.val]
+        -- Apply restrictScalars_injective ℚ to reduce goal to IntermediateField ℚ ↥K_aβ
+        apply (IntermediateField.restrictScalars_injective ℚ)
+        rw [IntermediateField.restrictScalars_top]
+        -- Convert ↥K_a-adjoin to ↥K_a_im-adjoin via AlgEquiv
+        rw [IntermediateField.restrictScalars_adjoin_of_algEquiv i hi,
+            IntermediateField.restrictScalars_adjoin K_a_im]
+        -- Apply lift_injective K_aβ to reduce goal to IntermediateField ℚ ℂ
+        apply (IntermediateField.lift_injective K_aβ)
+        rw [IntermediateField.lift_top, IntermediateField.lift_adjoin]
+        -- Compute the image under Subtype.val
+        have hval_Ka_im : Subtype.val '' (K_a_im : Set ↥K_aβ) = (K_a : Set ℂ) := by
+          ext x; simp [K_a_im, IntermediateField.restrict, IntermediateField.mem_restrict]
+        have hval_β : Subtype.val '' ({β_in_Kaβ} : Set ↥K_aβ) = ({β} : Set ℂ) := by
+          simp [β_in_Kaβ]
+        rw [Set.image_union, hval_Ka_im, hval_β]
+        -- adjoin ℚ (↑K_a ∪ {β}) = K_a ⊔ ℚ⟮β⟯ = K_aβ
+        apply le_antisymm
+        · apply IntermediateField.adjoin_le_iff.mpr
+          intro x hx
+          rcases Set.mem_union.mp hx with hxa | hxβ
+          · exact le_sup_left hxa
+          · exact le_sup_right (Set.mem_singleton_iff.mp hxβ ▸ mem_adjoin_simple_self ℚ β)
+        · apply sup_le
+          · rw [← IntermediateField.adjoin_self ℚ K_a]
+            exact IntermediateField.adjoin.mono ℚ _ _ Set.subset_union_left
+          · change IntermediateField.adjoin ℚ {β} ≤ _
+            exact IntermediateField.adjoin.mono ℚ _ _ Set.subset_union_right
       have h_finrank_eq : Module.finrank ↥K_a ↥K_aβ =
           (minpoly ↥K_a β_in_Kaβ).natDegree := by
         have := IntermediateField.adjoin.finrank hβ_int_Ka

--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -101,8 +101,150 @@ theorem isConstructible_sqrt2 : IsConstructible (Real.sqrt 2 : ℂ) := by
   simpa using IsConstructible.sqrt_ext (Real.sqrt 2 : ℂ) 2 0 h2 h0 hsq
 
 -- ============================================================
--- PART 2: Key Structural Lemma (SORRY — tower degree property)
+-- PART 2: Key Structural Lemmas (tower degree property)
 -- ============================================================
+
+/-- Constructible numbers are algebraic over ℚ (basic induction, used in sup_degree). -/
+private lemma isConstructible_algebraic (α : ℂ) (h : IsConstructible α) : IsAlgebraic ℚ α := by
+  induction h with
+  | rational _ h_mem => obtain ⟨q, rfl⟩ := h_mem; exact isAlgebraic_algebraMap q
+  | sqrt_ext β a b _ _ hβ2 ih_a ih_b =>
+    have hβ_sq : β ^ 2 = a := by rw [sq]; exact hβ2
+    have halg_β : IsAlgebraic ℚ β :=
+      IsAlgebraic.of_pow (by norm_num : 0 < 2) (hβ_sq ▸ ih_a)
+    rw [isAlgebraic_iff_isIntegral] at ih_b halg_β ⊢
+    exact ih_b.add halg_β
+
+/-- **Stronger IH**: constructible numbers have 2-power degree over any intermediate base K.
+
+    For any K : IntermediateField ℚ ℂ, finrank ↥K ↥(K ⊔ ℚ⟮α⟯) divides a power of 2.
+
+    This is the key lemma for proving `hjoin_dvd` in `isConstructible_algebraic_degree`:
+    applying it with K = ℚ⟮β⟯ gives `finrank ↥ℚ⟮β⟯ ↥(ℚ⟮β⟯ ⊔ ℚ⟮b⟯) ∣ 2^k'`, which
+    via the tower law gives `finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+1) * 2^k'`.
+
+    **Remaining sorry**: `h_top_Ka` (that β generates K_aβ = K⊔ℚ⟮a⟯⊔ℚ⟮β⟯ over K⊔ℚ⟮a⟯).
+    The adjoin-of-β over K_a equals K_aβ because any K_a-subfield of K_aβ containing β also
+    contains ℚ⟮β⟯ (as β generates ℚ⟮β⟯ over ℚ ≤ K_a). Requires Mathlib API for
+    `IntermediateField.sup` decomposition — not yet available via `adjoin_eq_top_of_adjoin_eq_top`
+    since the ambient field K_aβ ≠ ℚ⟮β⟯. -/
+private lemma isConstructible_sup_degree (α : ℂ) (h : IsConstructible α) :
+    ∀ (K : IntermediateField ℚ ℂ), ∃ n : ℕ, Module.finrank ↥K ↥(K ⊔ ℚ⟮α⟯) ∣ 2 ^ n := by
+  induction h with
+  | rational _ h_mem =>
+    intro K
+    obtain ⟨q, rfl⟩ := h_mem
+    have hq_in_K : algebraMap ℚ ℂ q ∈ K := K.algebraMap_mem q
+    have hle : (ℚ⟮(algebraMap ℚ ℂ q)⟯ : IntermediateField ℚ ℂ) ≤ K :=
+      adjoin_simple_le_iff.mpr hq_in_K
+    rw [sup_eq_left.mpr hle]
+    exact ⟨0, by simp [Module.finrank_self]⟩
+  | sqrt_ext β a b ha hb hβ2 ih_a ih_b =>
+    intro K
+    have hβ_sq : β ^ 2 = a := by rw [sq]; exact hβ2
+    have halg_a : IsAlgebraic ℚ a := isConstructible_algebraic a ha
+    have halg_β : IsAlgebraic ℚ β :=
+      IsAlgebraic.of_pow (by norm_num : 0 < 2) (hβ_sq ▸ halg_a)
+    have hβ_int_ℚ : IsIntegral ℚ β := isAlgebraic_iff_isIntegral.mp halg_β
+    -- K_a = K ⊔ ℚ⟮a⟯, IH gives finrank ↥K ↥K_a ∣ 2^j
+    obtain ⟨j, hj⟩ := ih_a K
+    let K_a : IntermediateField ℚ ℂ := K ⊔ ℚ⟮a⟯
+    -- K_aβ = K_a ⊔ ℚ⟮β⟯ (tower K ≤ K_a ≤ K_aβ)
+    let K_aβ : IntermediateField ℚ ℂ := K_a ⊔ ℚ⟮β⟯
+    have ha_in_Ka : a ∈ K_a := le_sup_right (mem_adjoin_simple_self ℚ a)
+    haveI hAlg_KKa : Algebra ↥K ↥K_a :=
+      (IntermediateField.inclusion (le_sup_left (b := ℚ⟮a⟯))).toAlgebra
+    haveI hST_KKa : IsScalarTower ℚ ↥K ↥K_a :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    haveI hAlg_KaKaβ : Algebra ↥K_a ↥K_aβ :=
+      (IntermediateField.inclusion (le_sup_left (b := ℚ⟮β⟯))).toAlgebra
+    haveI hST_KaKaβ : IsScalarTower ℚ ↥K_a ↥K_aβ :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    haveI hST_K_Ka_Kaβ : IsScalarTower ↥K ↥K_a ↥K_aβ :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    -- Key: finrank ↥K_a ↥K_aβ ∣ 2 (β satisfies X²-a over K_a, a ∈ K_a)
+    -- Proof mirrors hβ_dvd but over the general base K_a.
+    have hβ_Ka_dvd : Module.finrank ↥K_a ↥K_aβ ∣ 2 := by
+      let β_in_Kaβ : ↥K_aβ := ⟨β, le_sup_right (mem_adjoin_simple_self ℚ β)⟩
+      let a_in_Ka : ↥K_a := ⟨a, ha_in_Ka⟩
+      have hβ_int_ℚβ : IsIntegral ℚ β_in_Kaβ := by
+        rw [← isIntegral_algebraMap_iff (algebraMap ↥K_aβ ℂ).injective]; exact hβ_int_ℚ
+      have hβ_int_Ka : IsIntegral ↥K_a β_in_Kaβ := hβ_int_ℚβ.tower_top
+      -- β generates K_aβ over K_a: any K_a-subfield of K_aβ containing β contains ℚ⟮β⟯
+      -- (since β generates ℚ⟮β⟯ over ℚ ≤ K_a), hence equals K_aβ = K_a ⊔ ℚ⟮β⟯.
+      -- The adjoin_eq_top_of_adjoin_eq_top approach requires ambient field = ℚ⟮β⟯ ≠ K_aβ.
+      have h_top_Ka : IntermediateField.adjoin ↥K_a ({β_in_Kaβ} : Set ↥K_aβ) = ⊤ := by
+        sorry -- K_aβ = K_a⊔ℚ⟮β⟯; β generates ℚ⟮β⟯/ℚ ≤ K_a, so generates K_aβ/K_a
+      have h_finrank_eq : Module.finrank ↥K_a ↥K_aβ =
+          (minpoly ↥K_a β_in_Kaβ).natDegree := by
+        have := IntermediateField.adjoin.finrank hβ_int_Ka
+        erw [h_top_Ka, IntermediateField.finrank_top'] at this; exact this
+      set p_Ka : Polynomial ↥K_a := Polynomial.X ^ 2 - Polynomial.C a_in_Ka
+      have h_aeval_Ka : Polynomial.aeval β_in_Kaβ p_Ka = 0 := by
+        simp only [map_sub, map_pow, Polynomial.aeval_X, Polynomial.aeval_C, sub_eq_zero]
+        apply_fun Subtype.val using Subtype.val_injective
+        simp only [SubsemiringClass.coe_pow, β_in_Kaβ, a_in_Ka,
+          RingHom.algebraMap_toAlgebra, IntermediateField.coe_inclusion, Subtype.coe_mk, hβ_sq]
+      have h_deg_pKa : p_Ka.natDegree = 2 := by
+        apply Polynomial.natDegree_sub_eq_left_of_natDegree_lt
+        simp [Polynomial.natDegree_X_pow, Polynomial.natDegree_C]
+      have h_pKa_ne : p_Ka ≠ 0 := by
+        intro h; rw [h, Polynomial.natDegree_zero] at h_deg_pKa; omega
+      have h_dvd_Ka : minpoly ↥K_a β_in_Kaβ ∣ p_Ka := minpoly.dvd _ _ h_aeval_Ka
+      have h_deg_Ka : (minpoly ↥K_a β_in_Kaβ).natDegree ≤ 2 :=
+        (Polynomial.natDegree_le_of_dvd h_dvd_Ka h_pKa_ne).trans (le_of_eq h_deg_pKa)
+      rw [h_finrank_eq]
+      have h_pos_Ka : 1 ≤ (minpoly ↥K_a β_in_Kaβ).natDegree := minpoly.natDegree_pos hβ_int_Ka
+      rcases (by omega : (minpoly ↥K_a β_in_Kaβ).natDegree = 1 ∨
+          (minpoly ↥K_a β_in_Kaβ).natDegree = 2) with h | h
+      · exact h ▸ one_dvd 2
+      · exact h ▸ dvd_refl 2
+    -- Tower K ≤ K_a ≤ K_aβ: finrank ↥K ↥K_aβ ∣ 2^(j+1)
+    have hKaβ_dvd : Module.finrank ↥K ↥K_aβ ∣ 2 ^ (j + 1) := by
+      rw [Module.finrank_mul_finrank ↥K ↥K_a ↥K_aβ, pow_succ]
+      exact Nat.mul_dvd_mul hj hβ_Ka_dvd
+    -- Apply ih_b to K_aβ: finrank ↥K_aβ ↥(K_aβ ⊔ ℚ⟮b⟯) ∣ 2^k
+    obtain ⟨k, hk⟩ := ih_b K_aβ
+    let K_full : IntermediateField ℚ ℂ := K_aβ ⊔ ℚ⟮b⟯
+    haveI hAlg_KaβKfull : Algebra ↥K_aβ ↥K_full :=
+      (IntermediateField.inclusion (le_sup_left (b := ℚ⟮b⟯))).toAlgebra
+    haveI hST_KaβKfull : IsScalarTower ℚ ↥K_aβ ↥K_full :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    haveI hST_K_Kaβ_Kfull : IsScalarTower ↥K ↥K_aβ ↥K_full :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    -- Tower K ≤ K_aβ ≤ K_full: finrank ↥K ↥K_full ∣ 2^(j+1+k)
+    have hKfull_dvd : Module.finrank ↥K ↥K_full ∣ 2 ^ (j + 1 + k) := by
+      rw [Module.finrank_mul_finrank ↥K ↥K_aβ ↥K_full, pow_add]
+      exact Nat.mul_dvd_mul hKaβ_dvd hk
+    -- b + β ∈ K_full (b ∈ ℚ⟮b⟯ ≤ K_full; β ∈ ℚ⟮β⟯ ≤ K_aβ ≤ K_full)
+    have hbβ_in_Kfull : b + β ∈ K_full :=
+      add_mem (le_sup_right (mem_adjoin_simple_self ℚ b))
+              (le_sup_left (le_sup_right (mem_adjoin_simple_self ℚ β)))
+    -- K ⊔ ℚ⟮b+β⟯ ≤ K_full (K ≤ K_aβ ≤ K_full, b+β ∈ K_full)
+    have hK_le_Kfull : K ≤ K_full :=
+      le_sup_left.trans (le_sup_left.trans le_sup_left)
+    have hle_bβ : K ⊔ ℚ⟮(b + β)⟯ ≤ K_full :=
+      sup_le hK_le_Kfull (adjoin_simple_le_iff.mpr hbβ_in_Kfull)
+    -- finrank ↥K ↥(K⊔ℚ⟮b+β⟯) ∣ finrank ↥K ↥K_full ∣ 2^(j+1+k)
+    haveI hAlg_K_Kbβ : Algebra ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) :=
+      (IntermediateField.inclusion (le_sup_left (b := ℚ⟮(b + β)⟯))).toAlgebra
+    haveI hST_K_Kbβ : IsScalarTower ℚ ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    haveI hAlg_Kbβ_Kfull : Algebra ↥(K ⊔ ℚ⟮(b + β)⟯) ↥K_full :=
+      (IntermediateField.inclusion hle_bβ).toAlgebra
+    haveI hST_K_Kbβ_Kfull : IsScalarTower ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) ↥K_full :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    exact ⟨j + 1 + k,
+      (⟨Module.finrank ↥(K ⊔ ℚ⟮(b + β)⟯) ↥K_full,
+        Module.finrank_mul_finrank ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) ↥K_full⟩ : _ ∣ _).trans
+        hKfull_dvd⟩
 
 /-- Constructible numbers are algebraic of 2-power degree.
 
@@ -130,9 +272,9 @@ private lemma isConstructible_algebraic_degree (α : ℂ) (h : IsConstructible �
     rw [pow_zero]
     rw [IntermediateField.finrank_adjoin_simple_eq_one_iff.mpr
       (IntermediateField.mem_bot.mpr ⟨q, rfl⟩)]
-  | sqrt_ext β a b _ _ hβ2 ih_a ih_b =>
+  | sqrt_ext β a b ha hb hβ2 ih_a ih_b =>
     obtain ⟨halg_a, j, hj_dvd⟩ := ih_a
-    obtain ⟨halg_b, k, hk_dvd⟩ := ih_b
+    obtain ⟨halg_b, _⟩ := ih_b
     -- β is algebraic: β^2 = a with a algebraic
     have hβ_sq : β ^ 2 = a := by rw [sq]; exact hβ2
     have halg_β : IsAlgebraic ℚ β :=
@@ -142,8 +284,6 @@ private lemma isConstructible_algebraic_degree (α : ℂ) (h : IsConstructible �
       rw [isAlgebraic_iff_isIntegral] at halg_b halg_β ⊢
       exact halg_b.add halg_β
     refine ⟨halg_bβ, ?_⟩
-    -- Show Module.finrank ℚ ℚ⟮b+β⟯ ∣ 2^(j+k+1)
-    use j + k + 1
     -- Step A: β² = a → a ∈ ℚ⟮β⟯, so ℚ⟮a⟯ ≤ ℚ⟮β⟯
     have ha_in_β : a ∈ (ℚ⟮β⟯ : IntermediateField ℚ ℂ) := by
       rw [← hβ2]
@@ -237,16 +377,19 @@ private lemma isConstructible_algebraic_degree (α : ℂ) (h : IsConstructible �
          rcases h_range with h | h
          · exact h ▸ one_dvd 2
          · exact h ▸ dvd_refl 2)
-    -- Step D (sorry): finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1)
-    -- Proof plan: tower through ℚ⟮β⟯:
-    --   finrank_join = finrank ↥ℚ⟮β⟯ ↥(join) * finrank ℚ ↥ℚ⟮β⟯
-    --   Need: finrank ↥ℚ⟮β⟯ ↥(join) ∣ 2^k
-    --   This is finrank ↥ℚ⟮β⟯ ↥ℚ⟮β⟯⟮b⟯ ∣ 2^k (since join = ℚ⟮β⟯ adjoin b).
-    --   REQUIRES STRONGER IH on b: not just finrank ℚ ℚ⟮b⟯ ∣ 2^k, but
-    --   ∀ (K : IntermediateField ℚ ℂ) with finrank ℚ K ∣ 2^m, finrank ↥K ↥(K⟮b⟯) ∣ 2^k.
-    --   Current IH (hk_dvd) is too weak — it only gives finrank ℚ ℚ⟮b⟯ ∣ 2^k.
-    have hjoin_dvd : Module.finrank ℚ ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2 ^ (j + k + 1) := by
-      sorry
+    -- Step D: finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+1+k') via stronger IH applied at K = ℚ⟮β⟯
+    -- Tower ℚ ≤ ℚ⟮β⟯ ≤ ℚ⟮b⟯⊔ℚ⟮β⟯: tower law + isConstructible_sup_degree b hb ℚ⟮β⟯
+    haveI hAlg_βjoin : Algebra ↥(ℚ⟮β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) :=
+      (IntermediateField.inclusion (le_sup_right (a := ℚ⟮b⟯))).toAlgebra
+    haveI hST_βjoin : IsScalarTower ℚ ↥(ℚ⟮β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    obtain ⟨k', hk'⟩ := isConstructible_sup_degree b hb (ℚ⟮β⟯ : IntermediateField ℚ ℂ)
+    -- hk' : Module.finrank ↥(ℚ⟮β⟯) ↥(ℚ⟮β⟯ ⊔ ℚ⟮b⟯) ∣ 2^k'; rewrite via sup_comm
+    rw [sup_comm] at hk'
+    have hjoin_dvd : Module.finrank ℚ ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2 ^ (j + 1 + k') := by
+      rw [Module.finrank_mul_finrank ℚ ↥(ℚ⟮β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯), pow_add]
+      exact Nat.mul_dvd_mul hβ_dvd hk'
     -- Step E: finrank ℚ ℚ⟮b+β⟯ ∣ finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) via tower law
     -- ℚ⟮b+β⟯ ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯ (hle) gives:
     --   finrank_join = finrank ↥ℚ⟮b+β⟯ ↥(join) * finrank ℚ ℚ⟮b+β⟯
@@ -259,7 +402,7 @@ private lemma isConstructible_algebraic_degree (α : ℂ) (h : IsConstructible �
           Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
       have htower := Module.finrank_mul_finrank ℚ ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯)
       exact ⟨Module.finrank ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯), htower.symm⟩
-    exact hdvd_le.trans hjoin_dvd
+    exact ⟨j + 1 + k', hdvd_le.trans hjoin_dvd⟩
 
 -- ============================================================
 -- PART 3: Eisenstein Criterion — X³ - 2 is Irreducible

--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean
@@ -4,33 +4,62 @@ Problem: angle-trisection-oq-02-oq-01-oq-02-incomplete-01
 
 Two target lemmas:
 
-1. `finrank_adjoin_β_over_adjoin_a_dvd_two` (Session 32):
+1. `finrank_adjoin_β_over_adjoin_a_dvd_two` (Session 32 — PROVED by Aristotle 2026-05-03):
    Goal: Module.finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2
    Context: β : ℂ algebraic over ℚ, β² = a, ℚ⟮a⟯ ≤ ℚ⟮β⟯.
-   Proof plan: β satisfies X²-a over ↥ℚ⟮a⟯, minpoly degree ≤ 2, finrank ≥ 1, hence divides 2.
+   Proof: tower law + minpoly ℚ β ∣ (minpoly ℚ a).comp(X²) + interval_cases.
 
-2. `adjoin_β_in_sup_eq_top` (Session 33):
+2. `adjoin_β_in_sup_eq_top` (Session 33-34):
    Goal: IntermediateField.adjoin ↥K_a {β_in_Kaβ} = ⊤
    Context: K_a K_aβ : IntermediateField ℚ ℂ, K_aβ = K_a ⊔ ℚ⟮β⟯, β_in_Kaβ : ↥K_aβ
    Proof plan: K_aβ = K_a(β), so β generates K_aβ over K_a.
    Strategy: restrictScalars_injective + restrict (K_a image in ↥K_aβ) + lift_injective.
 -/
 
-import Mathlib.FieldTheory.Galois.Basic
-import Mathlib.FieldTheory.Minpoly.Field
-import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
-import Mathlib.RingTheory.Algebraic.Basic
-import Mathlib.Tactic
+import Mathlib
 
 open Polynomial IntermediateField
 
 namespace AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle
 
+-- Helper: a is algebraic over ℚ (since a = β² and β is algebraic)
+private lemma a_isAlgebraic (β a : ℂ) (halg_β : IsAlgebraic ℚ β) (hβ2 : β * β = a) :
+    IsAlgebraic ℚ a :=
+  hβ2 ▸ IsAlgebraic.mul halg_β halg_β
+
+/-
+Helper: aeval β ((minpoly ℚ a).comp (X ^ 2)) = 0
+-/
+private lemma aeval_comp_eq_zero (β a : ℂ) (halg_β : IsAlgebraic ℚ β) (hβ2 : β * β = a) :
+    Polynomial.aeval β ((minpoly ℚ a).comp (X ^ 2)) = 0 := by
+  rw [ Polynomial.aeval_comp ];
+  norm_num [ sq, hβ2 ]
+
+/-
+Helper: finrank ℚ ℚ⟮β⟯ ≤ 2 * finrank ℚ ℚ⟮a⟯
+Proof: minpoly ℚ β divides (minpoly ℚ a).comp(X²), which has degree 2·deg(minpoly ℚ a).
+finrank ℚ ℚ⟮β⟯ = natDegree(minpoly ℚ β) ≤ natDegree((minpoly ℚ a).comp(X²)) = 2·natDegree(minpoly ℚ a) = 2·finrank ℚ ℚ⟮a⟯
+-/
+private lemma finrank_β_le_two_mul_finrank_a (β a : ℂ)
+    (halg_β : IsAlgebraic ℚ β) (hβ2 : β * β = a) :
+    Module.finrank ℚ ↥(ℚ⟮β⟯) ≤ 2 * Module.finrank ℚ ↥(ℚ⟮a⟯) := by
+  rw [ IntermediateField.adjoin.finrank, IntermediateField.adjoin.finrank ];
+  · have h_deg : minpoly ℚ β ∣ (minpoly ℚ a).comp (X^2) := by
+      refine' minpoly.dvd ℚ β _;
+      convert aeval_comp_eq_zero β a halg_β hβ2 using 1;
+    refine' le_trans ( Polynomial.natDegree_le_of_dvd h_deg _ ) _;
+    · have := minpoly.ne_zero ( show IsIntegral ℚ a from ?_ );
+      · simp_all +decide [ Polynomial.comp_eq_zero_iff ];
+      · exact hβ2 ▸ halg_β.isIntegral.mul halg_β.isIntegral;
+    · rw [ Polynomial.natDegree_comp, Polynomial.natDegree_X_pow, mul_comm ];
+  · exact hβ2 ▸ halg_β.isIntegral.mul halg_β.isIntegral;
+  · exact halg_β.isIntegral
+
 /-- Key lemma: if β is algebraic over ℚ and β² = a, then
     the degree [ℚ⟮β⟯:ℚ⟮a⟯] divides 2.
 
-    Equivalent to: the extension ℚ⟮a⟯ ≤ ℚ⟮β⟯ has degree 1 or 2,
-    which holds because β satisfies the quadratic X² - a over ℚ⟮a⟯. -/
+    Proved by Aristotle (2026-05-03, job 594e3160).
+    Proof: tower law + minpoly ℚ β ∣ (minpoly ℚ a).comp(X²) + interval_cases. -/
 theorem finrank_adjoin_β_over_adjoin_a_dvd_two
     (β a : ℂ)
     (halg_β : IsAlgebraic ℚ β)
@@ -39,7 +68,25 @@ theorem finrank_adjoin_β_over_adjoin_a_dvd_two
     [hAlg : Algebra ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯)]
     [hST : IsScalarTower ℚ ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯)] :
     Module.finrank ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯) ∣ 2 := by
-  sorry
+  -- By the tower law, the degree [ℚ⟮β⟯:ℚ] is equal to the product of the degrees [ℚ⟮β⟯:ℚ⟮a⟯] and [ℚ⟮a⟯:ℚ].
+  have h_tower : Module.finrank ℚ ↥(ℚ⟮β⟯) = Module.finrank ℚ⟮a⟯ ↥(ℚ⟮β⟯) * Module.finrank ℚ ↥(ℚ⟮a⟯) := by
+    rw [ mul_comm, Module.finrank_mul_finrank ];
+  have h_deg_le : Module.finrank ℚ ↥(ℚ⟮β⟯) ≤ 2 * Module.finrank ℚ ↥(ℚ⟮a⟯) := by
+    apply finrank_β_le_two_mul_finrank_a β a halg_β hβ2;
+  have h_deg_pos : 0 < Module.finrank ℚ ↥(ℚ⟮a⟯) := by
+    have h_deg_pos : IsAlgebraic ℚ a := by
+      exact a_isAlgebraic β a halg_β hβ2;
+    have := IntermediateField.adjoin.finrank h_deg_pos.isIntegral;
+    exact this.symm ▸ Polynomial.natDegree_pos_iff_degree_pos.mpr ( Polynomial.degree_pos_of_irreducible ( minpoly.irreducible h_deg_pos.isIntegral ) );
+  have h_deg_le : Module.finrank ℚ⟮a⟯ ↥(ℚ⟮β⟯) ≤ 2 := by
+    nlinarith;
+  interval_cases _ : Module.finrank ℚ⟮a⟯ ↥ℚ⟮β⟯ <;> simp_all +decide;
+  have h_deg_pos : 0 < Module.finrank ℚ ↥(ℚ⟮β⟯) := by
+    have h_alg : IsIntegral ℚ β := by
+      exact halg_β.isIntegral
+    have := IntermediateField.adjoin.finrank h_alg;
+    exact this.symm ▸ Polynomial.natDegree_pos_iff_degree_pos.mpr ( Polynomial.degree_pos_of_irreducible ( minpoly.irreducible h_alg ) );
+  linarith
 
 /-- β (as an element of K_aβ = K_a ⊔ ℚ⟮β⟯) generates K_aβ over K_a.
 

--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean
@@ -2,16 +2,18 @@
 Aristotle companion for AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
 Problem: angle-trisection-oq-02-oq-01-oq-02-incomplete-01
 
-Isolates the `hβ_dvd` sub-sorry at line 185:
-  Goal: Module.finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2
+Two target lemmas:
 
-Context: β : ℂ algebraic over ℚ, β² = a, ℚ⟮a⟯ ≤ ℚ⟮β⟯,
-         Algebra ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ via inclusion, IsScalarTower ℚ ↥ℚ⟮a⟯ ↥ℚ⟮β⟯.
+1. `finrank_adjoin_β_over_adjoin_a_dvd_two` (Session 32):
+   Goal: Module.finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2
+   Context: β : ℂ algebraic over ℚ, β² = a, ℚ⟮a⟯ ≤ ℚ⟮β⟯.
+   Proof plan: β satisfies X²-a over ↥ℚ⟮a⟯, minpoly degree ≤ 2, finrank ≥ 1, hence divides 2.
 
-Proof plan: β satisfies X²-a over ↥ℚ⟮a⟯, so minpoly ↥ℚ⟮a⟯ βel has degree ≤ 2.
-            finrank = natDegree(minpoly) ≤ 2; finrank ≥ 1; hence divides 2.
-            The key finrank = natDegree step follows from βel generating ↥ℚ⟮β⟯ over ↥ℚ⟮a⟯
-            (since β generates ℚ⟮β⟯ over ℚ, and ↥ℚ⟮a⟯ ⊇ ℚ).
+2. `adjoin_β_in_sup_eq_top` (Session 33):
+   Goal: IntermediateField.adjoin ↥K_a {β_in_Kaβ} = ⊤
+   Context: K_a K_aβ : IntermediateField ℚ ℂ, K_aβ = K_a ⊔ ℚ⟮β⟯, β_in_Kaβ : ↥K_aβ
+   Proof plan: K_aβ = K_a(β), so β generates K_aβ over K_a.
+   Strategy: restrictScalars_injective + restrict (K_a image in ↥K_aβ) + lift_injective.
 -/
 
 import Mathlib.FieldTheory.Galois.Basic
@@ -37,6 +39,35 @@ theorem finrank_adjoin_β_over_adjoin_a_dvd_two
     [hAlg : Algebra ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯)]
     [hST : IsScalarTower ℚ ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯)] :
     Module.finrank ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯) ∣ 2 := by
+  sorry
+
+/-- β (as an element of K_aβ = K_a ⊔ ℚ⟮β⟯) generates K_aβ over K_a.
+
+    Since K_aβ = K_a ⊔ ℚ⟮β⟯ = K_a(β), every element of K_aβ lies in the
+    K_a-closure of β, so adjoin K_a {β_in_Kaβ} = ⊤.
+
+    Proof uses:
+    - restrictScalars_injective ℚ: reduce to goal over ℚ
+    - K_a_im = K_a.restrict (K_a ≤ K_aβ): image of K_a inside ↥K_aβ as IntermediateField ℚ ↥K_aβ
+    - restrict_algEquiv: AlgEquiv ↥K_a ≃ₐ[ℚ] ↥K_a_im
+    - restrictScalars_adjoin_of_algEquiv: convert ↥K_a-adjoin to ↥K_a_im-adjoin
+    - restrictScalars_adjoin K_a_im: get adjoin ℚ (↑K_a_im ∪ {β_in_Kaβ})
+    - lift_injective K_aβ + lift_adjoin + lift_top: reduce to ℂ
+    - adjoin ℚ (↑K_a ∪ {β}) = K_a ⊔ ℚ⟮β⟯ = K_aβ by sup_le and adjoin.mono -/
+theorem adjoin_β_in_sup_eq_top
+    (K_a : IntermediateField ℚ ℂ) (β : ℂ)
+    (hβ_mem : β ∈ K_a ⊔ ℚ⟮β⟯)
+    (β_in_Kaβ : ↥(K_a ⊔ (ℚ⟮β⟯ : IntermediateField ℚ ℂ)))
+    (hβ_val : β_in_Kaβ.val = β) :
+    haveI hAlg : Algebra ↥K_a ↥(K_a ⊔ (ℚ⟮β⟯ : IntermediateField ℚ ℂ)) :=
+      (IntermediateField.inclusion (le_sup_left (b := ℚ⟮β⟯))).toAlgebra
+    haveI hST : IsScalarTower ℚ ↥K_a ↥(K_a ⊔ (ℚ⟮β⟯ : IntermediateField ℚ ℂ)) :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    @IntermediateField.adjoin ℚ _ ℂ _ _ _
+      ↥K_a _ _ ↥(K_a ⊔ (ℚ⟮β⟯ : IntermediateField ℚ ℂ)) _ _
+      hAlg _ ({β_in_Kaβ} : Set _) = ⊤ := by
+  simp only
   sorry
 
 end AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
@@ -294,3 +294,41 @@ Per project memory `project_mathlib_api_drift_2026_04`, this drift hits a cohort
 ### Next Steps
 1. Submit `h_top_Ka` to Aristotle: `IntermediateField.adjoin ↥K_a ({β_in_Kaβ} : Set ↥K_aβ) = ⊤` where `K_a K_aβ : IntermediateField ℚ ℂ`, `K_aβ = K_a ⊔ ℚ⟮β⟯`, `β_in_Kaβ = ⟨β, le_sup_right (mem_adjoin_simple_self ℚ β)⟩`
 2. Try: `apply restrictScalars_injective ℚ; rw [restrictScalars_top]; ...` — may require `K_a_inner : IntermediateField ℚ ↥K_aβ` definition and `adjoin_adjoin_left`
+
+## Session 2026-05-03 (Session 34) - Aristotle Proves finrank_dvd_two; h_top_Ka Proof Attempt
+
+**Mode**: REVISIT
+**Outcome**: progress — `finrank_adjoin_β_over_adjoin_a_dvd_two` proved by Aristotle; full h_top_Ka proof written; `adjoin_β_in_sup_eq_top` submitted to Aristotle
+
+### What I Did
+- Retrieved Aristotle result for job `594e3160` (Session 32 submission): `finrank_adjoin_β_over_adjoin_a_dvd_two` proved
+- Integrated Aristotle proof into companion file (replaced sorry with full proof via tower law + minpoly comp + interval_cases)
+- Wrote full ~45-line proof of `h_top_Ka` in the main file using:
+  - `IntermediateField.restrict` to build `K_a_im : IntermediateField ℚ ↥K_aβ` (image of K_a)
+  - `IntermediateField.restrict_algEquiv` for the AlgEquiv ↥K_a ≃ₐ[ℚ] ↥K_a_im
+  - `restrictScalars_adjoin_of_algEquiv i hi` to switch the scalar field from ↥K_a to ↥K_a_im
+  - `restrictScalars_adjoin K_a_im` to get adjoin ℚ (↑K_a_im ∪ {β_in_Kaβ})
+  - `lift_injective K_aβ + lift_adjoin + lift_top` to reduce to ℂ
+  - `adjoin ℚ (↑K_a ∪ {β}) = K_a ⊔ ℚ⟮β⟯ = K_aβ` via `sup_le` + `adjoin.mono`
+- Added `adjoin_β_in_sup_eq_top` standalone lemma to companion file
+- Submitted new Aristotle job `3127b935` for `adjoin_β_in_sup_eq_top`
+
+### Key Findings
+- **Aristotle strategy for finrank_dvd_two**: Tower law `finrank ℚ ℚ⟮β⟯ = [ℚ⟮β⟯:ℚ⟮a⟯] * [ℚ⟮a⟯:ℚ]`. Upper bound via `minpoly ℚ β ∣ (minpoly ℚ a).comp(X²)`. Then `interval_cases [ℚ⟮β⟯:ℚ⟮a⟯]`.
+- **h_top_Ka proof key**: `IntermediateField.restrict h` converts `K_a : IntermediateField ℚ ℂ` with `h : K_a ≤ K_aβ` into `K_a_im : IntermediateField ℚ ↥K_aβ` — the crucial bridge that makes `restrictScalars_adjoin` applicable.
+- **Potential issue**: `hi : algebraMap ↥K_a ↥K_aβ = (algebraMap ↥K_a_im ↥K_aβ) ∘ i` may need more specific simp lemmas. Not yet verified by Docker build.
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` — h_top_Ka full proof attempt
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean` — finrank_dvd_two integrated; adjoin_β_in_sup_eq_top added
+- `research/aristotle-jobs.json` — new job `3127b935` added
+
+### Current Sorries (2 total)
+1. **h_top_Ka** (line ~182): Full proof written — needs Docker verification to confirm compilation
+2. **wantzel_galois_iff** (line ~579): Full Galois theory — long-term goal
+
+### Next Steps
+1. Check Aristotle job `3127b935` for `adjoin_β_in_sup_eq_top`
+2. Run Docker build to verify `h_top_Ka` proof compiles
+3. If `h_top_Ka` compiles: `isConstructible_algebraic_degree` sorry count drops to 0; only `wantzel_galois_iff` remains
+4. Update PR #15128 with the compiled proof

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
@@ -267,3 +267,30 @@ Per project memory `project_mathlib_api_drift_2026_04`, this drift hits a cohort
 1. Submit `hβ_dvd` sub-sorry to Aristotle: context is `β : ℂ, a : ℂ, halg_β : IsAlgebraic ℚ β, hβ2 : β * β = a, hAlg_aβ : Algebra ↥ℚ⟮a⟯ ↥ℚ⟮β⟯, hST_aβ : IsScalarTower ℚ ↥ℚ⟮a⟯ ↥ℚ⟮β⟯, ha_le_β : ℚ⟮a⟯ ≤ ℚ⟮β⟯`; goal `finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2`
 2. For `hjoin_dvd`: consider reformulating with stronger IH (relative constructibility)
 3. After PR #15034 merges, continue proof work on hβ_dvd
+
+## Session 2026-05-03 (Session 33) - Eliminated hjoin_dvd via isConstructible_sup_degree
+
+**Mode**: REVISIT
+**Outcome**: progress — hjoin_dvd eliminated; h_top_Ka sorry remains
+
+### What I Did
+- Added `isConstructible_algebraic` (fully proved, ~10 lines): simple induction showing constructible numbers are algebraic
+- Added `isConstructible_sup_degree` (140 lines, 1 sorry `h_top_Ka`): stronger IH proving `∀ K, finrank ↥K ↥(K ⊔ ℚ⟮α⟯) ∣ 2^n` for any base K
+- Eliminated `hjoin_dvd` sorry in `isConstructible_algebraic_degree` by applying `isConstructible_sup_degree b hb ℚ⟮β⟯`, giving `finrank ↥ℚ⟮β⟯ ↥(ℚ⟮β⟯ ⊔ ℚ⟮b⟯) ∣ 2^k'`, then tower law
+- Pushed PR #15128
+
+### Key Findings
+- **hjoin_dvd pattern**: Apply `isConstructible_sup_degree b hb (ℚ⟮β⟯)` at K=ℚ⟮β⟯, use `sup_comm`, then `Module.finrank_mul_finrank ℚ ↥ℚ⟮β⟯ ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯)` + `Nat.mul_dvd_mul hβ_dvd hk'`
+- **h_top_Ka blocker**: `adjoin ↥K_a {β_in_Kaβ} = ⊤` in `IntermediateField ↥K_a ↥K_aβ` is blocked by Lean4 type-level issue: `↥K_a` (subtype of ℂ) ≠ any `IntermediateField ℚ ↥K_aβ` as Lean types, so `restrictScalars_adjoin` cannot be applied directly
+- **Proof plan for h_top_Ka**: `apply restrictScalars_injective ℚ; rw [restrictScalars_top]; rw [restrictScalars_adjoin K_a_inner {β_in_Kaβ}]` where `K_a_inner : IntermediateField ℚ ↥K_aβ` is K_a's image; then show `adjoin ℚ (↑K_a_inner ∪ {β_in_Kaβ}) = ⊤` since K_a_inner ∪ {β} generates K_aβ = K_a ⊔ ℚ⟮β⟯ over ℚ
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean`
+
+### Current Sorries (2 total)
+1. **h_top_Ka** (line ~179): `adjoin ↥K_a {β_in_Kaβ} = ⊤` in `IntermediateField ↥K_a ↥K_aβ`  — the only blocker for `isConstructible_sup_degree`
+2. **wantzel_galois_iff** (line ~579): Full Galois theory — long-term goal
+
+### Next Steps
+1. Submit `h_top_Ka` to Aristotle: `IntermediateField.adjoin ↥K_a ({β_in_Kaβ} : Set ↥K_aβ) = ⊤` where `K_a K_aβ : IntermediateField ℚ ℂ`, `K_aβ = K_a ⊔ ℚ⟮β⟯`, `β_in_Kaβ = ⟨β, le_sup_right (mem_adjoin_simple_self ℚ β)⟩`
+2. Try: `apply restrictScalars_injective ℚ; rw [restrictScalars_top]; ...` — may require `K_a_inner : IntermediateField ℚ ↥K_aβ` definition and `adjoin_adjoin_left`

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 32, 2026-05-03): All 4 Mathlib API drift errors fixed (PR #15034). File compiles with 3 expected sorries. Next: submit h\u03b2_dvd to Aristotle and reformulate hjoin_dvd IH.",
+    "progressSummary": "PROGRESS: finrank_dvd_two proved by Aristotle; h_top_Ka full proof written (unverified); adjoin_\u03b2_in_sup_eq_top submitted to Aristotle (3127b935)",
     "builtItems": [
       "isConstructible_mem_range: all constructible numbers are rational (Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:89)",
       "not_constructible_of_bad_degree: proved via rationality + minpoly.eq_X_sub_C (line 179)",
@@ -48,7 +48,9 @@
       "Session 29: Restored isConstructible_sqrt2 \u2014 \u221a2 IS constructible under fixed definition",
       "Session 29: isConstructible_algebraic_degree (private lemma): IsConstructible \u03b1 \u2192 IsAlgebraic \u211a \u03b1 \u2227 \u2203n, finrank \u211a \u211a\u27ee\u03b1\u27ef \u2223 2^n (2 sorries remain: h\u03b2_dvd, hjoin_dvd)",
       "Session 29: not_constructible_of_bad_degree: Dvd-based proof using isConstructible_algebraic_degree",
-      "Session 32 PR #15034: 4 API drift fixes applied to AngleTrisectionOQ02OQ01OQ02Incomplete01.lean, file compiles"
+      "Session 32 PR #15034: 4 API drift fixes applied to AngleTrisectionOQ02OQ01OQ02Incomplete01.lean, file compiles",
+      "finrank_adjoin_\u03b2_over_adjoin_a_dvd_two: PROVED by Aristotle job 594e3160 (2026-05-03)",
+      "h_top_Ka full proof attempt in AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:182 (Session 34, unverified)"
     ],
     "insights": [
       "IsConstructible with existential sqrt_ext blocks induction \u2014 must make a,b explicit constructor params to get proper IHs",
@@ -73,7 +75,9 @@
       "Session 31 (2026-04-27): Docker build fails on origin/main with 4 Mathlib API drift errors at lines 155,156,176,332,338. Released claim \u2014 Mechanic should repair across the angle-trisection/erdos-1151 cohort affected by 2026-04-26 Mathlib upgrade.",
       "Session 32: le_sup_left/le_sup_right replaces mem_sup_left/mem_sup_right in IntermediateField lattice (Mathlib 2026-04-26 rename)",
       "Session 32: Module.finrank_mul_finrank requires have-then-rw pattern; direct rw with explicit type args fails due to implicit instance resolution",
-      "Session 32: Nat.eq_zero_of_dvd_of_lt removed; replacement is Nat.zero_dvd.mp when hypothesis is 0 dvd n"
+      "Session 32: Nat.eq_zero_of_dvd_of_lt removed; replacement is Nat.zero_dvd.mp when hypothesis is 0 dvd n",
+      "restrict_algEquiv bridge: IntermediateField.restrict h converts K_a:IntermediateField \u211a \u2102 into K_a_im:IntermediateField \u211a \u21a5K_a\u03b2, enabling restrictScalars_adjoin_of_algEquiv to switch scalar field",
+      "Aristotle finrank strategy: tower law + minpoly \u211a \u03b2 \u2223 (minpoly \u211a a).comp(X\u00b2) + interval_cases proves finrank \u21a5\u211a\u27eea\u27ef \u21a5\u211a\u27ee\u03b2\u27ef \u2223 2"
     ],
     "mathlibGaps": [
       "isConstructible_algebraic_degree: tower degree induction \u2014 IsConstructible \u03b1 \u2192 IsAlgebraic \u211a \u03b1 \u2227 \u2203 n, finrank \u211a \u211a\u27ee\u03b1\u27ef = 2^n. Needs FiniteDimensional.finrank_mul_finrank + IntermediateField tower lemmas. Estimated ~120 lines.",
@@ -81,9 +85,9 @@
       "finrank \u21a5\u211a\u27eea\u27ef \u21a5\u211a\u27ee\u03b2\u27ef \u2223 2 requires showing \u03b2element generates \u21a5\u211a\u27ee\u03b2\u27ef over \u21a5\u211a\u27eea\u27ef (adjoin = top in IntermediateField \u21a5\u211a\u27eea\u27ef \u21a5\u211a\u27ee\u03b2\u27ef)"
     ],
     "nextSteps": [
-      "Submit h\u03b2_dvd sub-sorry to Aristotle: prove finrank \u21a5\u211a\u27eea\u27ef \u21a5\u211a\u27ee\u03b2\u27ef \u2223 2 given \u03b2*\u03b2=a, hAlg_a\u03b2, hST_a\u03b2, ha_le_\u03b2",
-      "For hjoin_dvd: reformulate IsConstructible IH to be K-relative (finrank K K\u27eeb\u27ef \u2223 2^k for all K/\u211a)",
-      "wantzel_galois_iff remains out-of-scope (500+ lines Galois theory)"
+      "Check Aristotle job 3127b935 for adjoin_\u03b2_in_sup_eq_top",
+      "Run Docker build to verify h_top_Ka proof (restrict + restrictScalars_adjoin_of_algEquiv strategy)",
+      "If h_top_Ka compiles: update PR #15128; only wantzel_galois_iff sorry remains"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Adds isConstructible_algebraic: constructible numbers are algebraic (fully proved)  
- Adds isConstructible_sup_degree: stronger IH — for any K, finrank K (K+Q[a]) | 2^n (1 sorry: h_top_Ka)
- Eliminates hjoin_dvd sorry in isConstructible_algebraic_degree via tower law + stronger IH at K=Q[b]

Remaining sorry h_top_Ka: adjoin K_a {b} = top in IntermediateField K_a K_ab. 
Mathematically clear (K_ab = K_a(b) since K_ab = K_a sup Q[b]). 
Blocked by Lean4 type mismatch in restrictScalars_adjoin. Submitted to Aristotle.

Generated with Claude Code