### PR TITLE
fix(meta): sync stale leanFile.lineCount for 9 gallery entries

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 2,
     "axiomCount": 0,
     "theoremCount": 19,
-    "lineCount": 438,
+    "lineCount": 436,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,7 +136,7 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 438,
+    "lineCount": 436,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 2,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum b≥2 — the general JDT seam bijection (~150-200 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 843,
+    "lineCount": 850,
     "theoremCount": 14,
     "definitionCount": 8,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 843,
+    "lineCount": 850,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 6,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 290,
+    "lineCount": 306,
     "assumptions": "1 axiom: nonderogatory_similar_to_companion (nonderogatory matrix is similar to its companion matrix). NOTE (audit 2026-04-27): the PID structure theorem IS in Mathlib (Module.equiv_directSum_of_isTorsion, Module.equiv_free_prod_directSum at Mathlib.Algebra.Module.PID), and Module.exists_ker_toSpanSingleton_eq_annihilator combined with Module.AEval' (Mathlib.Algebra.Polynomial.Module.AEval) directly gives a cyclic vector for nonderogatory matrices without needing similarity to a companion matrix at all. The remaining work is bridging code, not a missing structure theorem.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -143,7 +143,7 @@
       "BigOperators"
     ],
     "namespace": "CompanionCyclicVector",
-    "lineCount": 290,
+    "lineCount": 306,
     "axiomCount": 1,
     "theoremCount": 11,
     "definitionCount": 2,

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 448,
+    "lineCount": 458,
     "dateAdded": "2026-05-03",
     "assumptions": "1 axiom: sturm_exact_count_axiom. All supporting lemmas proved, including the key structural property (mod_eval_at_root), sequence non-emptiness, linear case verification, and four corollaries (no-roots, unique-root, two-roots, monotonicity).",
     "relatedProblems": [
@@ -50,7 +50,7 @@
   },
   "leanFile": {
     "namespace": "SturmTheorem",
-    "lineCount": 448,
+    "lineCount": 458,
     "axiomCount": 1,
     "theoremCount": 22,
     "defCount": 8,

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 3,
     "axiomCount": 1,
     "theoremCount": 11,
-    "lineCount": 287,
+    "lineCount": 335,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 3 sorries in this file (geometric edge-crossing verifications).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
@@ -128,7 +128,7 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 287,
+    "lineCount": 335,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",

--- a/src/data/proofs/erdos-1102/meta.json
+++ b/src/data/proofs/erdos-1102/meta.json
@@ -46,7 +46,7 @@
       "Connection between squarefree numbers and π"
     ],
     "axiomCount": 1,
-    "lineCount": 154,
+    "lineCount": 158,
     "assumptions": "1 axiom: propertyQ_achievable. 0 sorries.",
     "theoremCount": 2
   },
@@ -200,7 +200,7 @@
       "Topology"
     ],
     "namespace": "Erdos1102",
-    "lineCount": 154,
+    "lineCount": 158,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-115-oq-01/meta.json
+++ b/src/data/proofs/erdos-115-oq-01/meta.json
@@ -37,7 +37,7 @@
     "parentProof": "erdos-115",
     "openQuestionType": "extension",
     "openQuestionOf": "erdos-115",
-    "lineCount": 176,
+    "lineCount": 178,
     "theoremCount": 2
   },
   "crossReferences": [
@@ -113,7 +113,7 @@
   },
   "leanFile": {
     "axiomCount": 11,
-    "lineCount": 176,
+    "lineCount": 178,
     "path": "Proofs/Erdos115OQ01Problem.lean",
     "sorries": 0,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-274/meta.json
+++ b/src/data/proofs/erdos-274/meta.json
@@ -45,7 +45,7 @@
       "Axiomatization of Sun's theorem for abelian groups"
     ],
     "axiomCount": 1,
-    "lineCount": 130,
+    "lineCount": 127,
     "assumptions": "1 axiom: sun_abelian_case. 0 sorries.",
     "theoremCount": 3
   },
@@ -114,7 +114,7 @@
       "title": "Summary",
       "summary": "erdos_274_summary: abelian case proved via Sun's theorem",
       "startLine": 111,
-      "endLine": 130
+      "endLine": 127
     }
   ],
   "conclusion": {
@@ -140,7 +140,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos274",
-    "lineCount": 130,
+    "lineCount": 127,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-375/meta.json
+++ b/src/data/proofs/erdos-375/meta.json
@@ -59,7 +59,7 @@
       "Hall's marriage theorem formulation (grimmBipartiteGraph, hallsCondition; placeholder defs)"
     ],
     "axiomCount": 2,
-    "lineCount": 357,
+    "lineCount": 354,
     "assumptions": "2 axioms: (1) ramachandra_shorey_tijdeman — Ramachandra-Shorey-Tijdeman (1975) partial result for k << (log n / log log n)^3; (2) grimm_difficulty — the known mathematical implication Grimm conjecture → Legendre conjecture (via prime gap bounds p_{n+1}-p_n ≪ p_n^{1/2-ε}), requiring analytic number theory not yet in Mathlib.",
     "theoremCount": 6
   },
@@ -151,7 +151,7 @@
       "title": "Main Results Summary",
       "summary": "erdos_375_summary, grimm_difficulty",
       "startLine": 311,
-      "endLine": 356,
+      "endLine": 354,
       "mathContext": "Mathematical content: erdos_375_summary, grimm_difficulty"
     }
   ],
@@ -180,7 +180,7 @@
       "Finset"
     ],
     "namespace": "Erdos375",
-    "lineCount": 357,
+    "lineCount": 354,
     "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Batch correction of stale `leanFile.lineCount` (and `meta.lineCount`) in 9 gallery entries where Lean source files were modified post-merge without updating the gallery metadata.

## Evidence

| Entry | Before | After | Delta | Root Cause |
|-------|--------|-------|-------|------------|
| erdos-1018-oq-04-incomplete-01 | 287 | 335 | +48 | PR #15009 added K3/K4 proof structure |
| cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01 | 290 | 306 | +16 | Post-merge edit |
| descartes-rule-of-signs-oq-02-oq-01-oq-02 | 448 | 458 | +10 | Post-merge edit |
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | 843 | 850 | +7 | Post-merge edit |
| erdos-1102 | 154 | 158 | +4 | Post-merge edit |
| erdos-115-oq-01 | 176 | 178 | +2 | Post-merge edit |
| angle-trisection-oq-02-oq-01-oq-02-incomplete-01 | 438 | 436 | -2 | Post-merge edit |
| erdos-274 | 130 | 127 | -3 | Post-merge edit; section summary.endLine clamped 130→127 |
| erdos-375 | 357 | 354 | -3 | Post-merge edit; section main-results.endLine clamped 356→354 |

Two entries (erdos-274, erdos-375) also had section endLine values that exceeded the file length — those were clamped to the actual line count.

---
Automated fix by lean-mechanic agent.