### PR TITLE
fix(erdos-770): correct theoremCount 80→74

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9524,10 +9524,12 @@
       "issues": []
     },
     "erdos-770": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:21:50Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T08:10:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "theoremCount 80→74: meta.meta.theoremCount and leanFile.theoremCount overcounted by 6 after PR #15094 merged"
+      ]
     },
     "erdos-771": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -57,9 +57,9 @@
     ],
     "axiomCount": 0,
     "lineCount": 531,
-    "assumptions": "None. 80 theorems fully verified with 0 axioms and 0 sorries. The open density question (Q1) is stated as a comment only. Open conjecture; supporting lemmas fully verified. New: hMinK_prime_minus_one proves h(p-1)=p for all primes p; hMinK_unbounded proves Q2 (upper half: h(n) is unbounded).",
+    "assumptions": "None. 74 theorems fully verified with 0 axioms and 0 sorries. The open density question (Q1) is stated as a comment only. Open conjecture; supporting lemmas fully verified. New: hMinK_prime_minus_one proves h(p-1)=p for all primes p; hMinK_unbounded proves Q2 (upper half: h(n) is unbounded).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 80
+    "theoremCount": 74
   },
   "sections": [
     {
@@ -208,7 +208,7 @@
     "namespace": null,
     "lineCount": 531,
     "axiomCount": 0,
-    "theoremCount": 80,
+    "theoremCount": 74,
     "definitionCount": 2,
     "path": "Proofs/Erdos770Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- Corrects `theoremCount` from 80 to 74 in both `meta.meta` and `leanFile` fields
- Actual Lean file (`Proofs/Erdos770Problem.lean`) has 74 `theorem`/`lemma` declarations (verified by grep)
- Overcounting (by 6) introduced after research PR #15094 merged new theorems with stale count

## Evidence

```
$ git show origin/main:proofs/Proofs/Erdos770Problem.lean | grep -c '^theorem\|^lemma'
74
```

Meta claimed: 80 (both `meta.theoremCount` and `leanFile.theoremCount`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)