### PR TITLE
fix(meta): sync stale theoremCount across 46 gallery entries

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 296,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 2,
     "dateAdded": "2026-04-26",
     "assumptions": "",

--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -24,7 +24,7 @@
     "sorries": 0,
     "axiomCount": 7,
     "lineCount": 242,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 5,
     "assumptions": "7 axioms: ellipticK (function), ellipticE (function), K_eq_pi_div_2M (Gauss's AGM theorem for k=1/√2), legendre_relation (Legendre's relation for k=1/√2), ellipticE_agm (E via AGM iteration), bs_summable (series convergence from quadratic AGM convergence), S_lt_half (series sum bound). The algebraic derivation π = 4M²/(1-2S) is machine-verified from these axioms.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
@@ -19,7 +19,7 @@
     "axiomCount": 0,
     "lineCount": 163,
     "assumptions": "None. All results proved from Mathlib. (Note: the Wantzel-Galois characterization axiom is in the parent OQ02 file, not here.)",
-    "theoremCount": 10,
+    "theoremCount": 8,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
@@ -42,7 +42,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 11,
     "assumptions": "None. Fully machine-checked. Uses IsTwoThreeNumber from AngleTrisectionOQ04 and IsKFoldConstructible from AngleTrisectionOQ05OQ01; neither introduces axioms relevant to this proof.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "0 axioms, 0 sorries. All results from Mathlib's IsPrincipalIdealRing, Ideal.span, MvPolynomial typeclasses.",
     "dateAdded": "2026-04-24",
     "lineCount": 192,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 3,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "0 axioms, 0 sorries. All results from Mathlib's UniqueFactorizationMonoid typeclasses.",
     "dateAdded": "2026-04-04",
     "lineCount": 127,
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "lineCount": 337,
     "assumptions": "None. All 10 theorems are fully proved with 0 sorries.",
-    "theoremCount": 10,
+    "theoremCount": 9,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "lineCount": 392,
     "assumptions": "None. All 4 theorems (normalization, mean, cross-moment, covariance) are fully machine-verified with 0 sorries and 0 axioms.",
-    "theoremCount": 4,
+    "theoremCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
     "axiomCount": 0,
     "lineCount": 222,
     "assumptions": "None. All results proved from Mathlib's multinomial theorem.",
-    "theoremCount": 12,
+    "theoremCount": 11,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -36,7 +36,7 @@
       "threshold_d10: exact k=3 birthday threshold for d=10 days is n=12 (verified by native_decide)"
     ],
     "lineCount": 317,
-    "theoremCount": 32,
+    "theoremCount": 43,
     "defCount": 2
   },
   "overview": {

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "1 axiom: poisson_approx_birthday3 (Chen-Stein method: P(no triple) → exp(-C(n,3)/d²) as d → ∞). All other theorems fully proved including choose3_mul_six (Pascal induction, 0 sorries).",
     "dateAdded": "2026-04-04",
     "lineCount": 501,
-    "theoremCount": 19,
+    "theoremCount": 22,
     "definitionCount": 3,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -37,7 +37,7 @@
     "assumptions": "1 axiom: brouwer_pi_compact_convex (in BrouwerFixedPointOQ04.lean — general Brouwer FPT for products of compact convex sets in finite-dimensional Euclidean spaces). This file has 0 direct axioms; brouwer_product_simplex is now a theorem proved from the general axiom using mixed_strategy_nonempty, mixed_strategy_compact, and mixed_strategy_convex.",
     "axiomCount": 1,
     "lineCount": 519,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "definitionCount": 8
   },
   "overview": {

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
     "dateAdded": "2026-04-04",
     "lineCount": 404,
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 2,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
@@ -34,7 +34,7 @@
       "sorry_diagnosis_resolved: documents that making e explicit is sufficient and necessary"
     ],
     "lineCount": 240,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "defCount": 3
   },
   "overview": {

--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 256,
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 4,
     "originalContributions": [
       "collatz_no_fixpoint: collatz(n) = n implies n = 0 (no fixed points)",

--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -35,7 +35,7 @@
       "Proved quasideterminants equal det(A)/entry in the commutative case",
       "Proved proportionality: qdet00 * a11 = a00 * qdet11 over commutative fields"
     ],
-    "theoremCount": 28
+    "theoremCount": 32
   },
   "sections": [
     {

--- a/src/data/proofs/denumerability-rationals-oq-02-oq-02/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-02-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "All results derived from Mathlib's ConditionallyCompleteLinearOrderedField infrastructure (inducedOrderRingIso, uniqueOrderRingIso). No additional axioms beyond Mathlib's standard foundations.",
     "lineCount": 216,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "definitionCount": 2,
     "originalContributions": [
       "isoToReal: noncomputable canonical isomorphism F ≃+*o ℝ for any complete ordered field F",

--- a/src/data/proofs/derangements-convergence-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "No assumptions. The theorem is fully machine-checked. The proof delegates the rate bound to derangements_convergence_rate from DerangementsConvergence.lean, which establishes |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
     "dateAdded": "2026-04-24",
     "lineCount": 88,
-    "theoremCount": 1,
+    "theoremCount": 2,
     "definitionCount": 0,
     "originalContributions": [
       "derangements_eq_round (PROVED): For n ≥ 2, (numDerangements n : ℤ) = round(n! · rexp(-1))",

--- a/src/data/proofs/derangements-oq-03-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 382,
-    "theoremCount": 12,
+    "theoremCount": 27,
     "definitionCount": 5,
     "originalContributions": [
       "fixedPt_tv_tendsto: total variation convergence of fixed-point distribution to Poisson(1)",

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -68,7 +68,7 @@
     "dateAdded": "2026-03-24",
     "axiomCount": 3,
     "lineCount": 698,
-    "theoremCount": 39,
+    "theoremCount": 43,
     "defCount": 8,
     "assumptions": "3 axioms: budan_upper_bound (Rolle induction), budan_parity (conjugate pairs), budanCount_large (leading coefficient dominance). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -186,7 +186,7 @@
   "leanFile": {
     "path": "Proofs/DissectionOfCubesOQ04.lean",
     "lineCount": 561,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 4,
     "axiomCount": 0,
     "sorries": 0

--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 211,
-    "theoremCount": 18,
+    "theoremCount": 21,
     "definitionCount": 1,
     "assumptions": [],
     "dateAdded": "2026-04-12",

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-04-05",
     "lineCount": 202,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/divisibility-rules-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 412,
-    "theoremCount": 41,
+    "theoremCount": 42,
     "definitionCount": 2,
     "originalContributions": [
       "Self-contained alternating digit sum framework with simplified modEq proof (no case split on b < 2 needed)",

--- a/src/data/proofs/divisibility-truncation-general-oq-03/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using only Mathlib.",
     "lineCount": 221,
-    "theoremCount": 22,
+    "theoremCount": 21,
     "definitionCount": 1,
     "originalContributions": [
       "bezout_gives_osculator: gcdA(10,d) is a valid osculator when gcd(10,d)=1, via Bézout identity",

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 249,
-    "theoremCount": 12,
+    "theoremCount": 24,
     "definitionCount": 3,
     "prerequisites": [
       "Erdos Problem #1 (distinct subset sums)",

--- a/src/data/proofs/erdos-1001-oq-03/meta.json
+++ b/src/data/proofs/erdos-1001-oq-03/meta.json
@@ -36,7 +36,7 @@
       "f_d_dimension_ratio: recurrence f_{d+1}·ζ(d+2) = 2A·f_d·ζ(d+1)"
     ],
     "lineCount": 227,
-    "theoremCount": 15,
+    "theoremCount": 13,
     "defCount": 5
   },
   "overview": {

--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -31,7 +31,7 @@
     "axiomCount": 1,
     "lineCount": 156,
     "assumptions": "1 axiom: squareful_sum_threshold (every n ≥ 120 is a sum of 3 squareful numbers). Computationally verified up to 1000.",
-    "theoremCount": 20
+    "theoremCount": 25
   },
   "overview": {
     "historicalContext": "Erdős Problem #1107 asks: for each r ≥ 2, is every sufficiently large integer the sum of at most 3 r-powerful numbers (numbers where every prime factor appears with exponent ≥ r)? The r=2 case (squareful/2-powerful numbers) was resolved by Heath-Brown (1988) using the theory of ternary quadratic forms — he proved that specific quadratic forms represent all large integers, which implies every large n is a sum of 3 squareful numbers.\n\nHowever, Heath-Brown's proof is non-effective: it does not give an explicit threshold N. The proof uses an indirect argument (showing the 'exceptions' are finite) without bounding how large the finite exceptional set can be. Making such results effective — finding the smallest N — is a separate, often computational, task.\n\nThis formalization bridges the gap: exhaustive computation in Lean (using `native_decide`) verifies every integer from 1 to 1000, identifying exactly {7, 15, 23, 87, 111, 119} as the exceptional set and establishing N=120 as the precise threshold. Combined with Heath-Brown's theorem (axiomatized) for n ≥ 120 in general, this gives the complete effective result.",

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -22,7 +22,7 @@
     "badge": "wip",
     "axiomCount": 0,
     "lineCount": 255,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 9,
     "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erdős-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-181-oq-01/meta.json
+++ b/src/data/proofs/erdos-181-oq-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "lineCount": 170,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "assumptions": "The main Burr-Erdős conjecture R_sym(Q_n) ≤ C·2^n and the Tikhomirov (2022) bound R_sym(Q_n) ≤ C·2^{(2-c)n} are stated as axioms. All other results (R_sym(Q_1) = 2, lower bound structure) are fully machine-verified.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-14",

--- a/src/data/proofs/erdos-659-oq-01/meta.json
+++ b/src/data/proofs/erdos-659-oq-01/meta.json
@@ -34,7 +34,7 @@
       "familyFourPointProperty: formal definition of 4-point property for families"
     ],
     "lineCount": 207,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "defCount": 5
   },
   "overview": {

--- a/src/data/proofs/erdos-837-oq-05/meta.json
+++ b/src/data/proofs/erdos-837-oq-05/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-04-13",
     "lineCount": 149,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -139,7 +139,7 @@
     "namespace": null,
     "lineCount": 247,
     "axiomCount": 3,
-    "theoremCount": 20,
+    "theoremCount": 25,
     "definitionCount": 5,
     "path": "Proofs/Erdos852Problem.lean",
     "sorries": 0

--- a/src/data/proofs/euler-totient-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-02/meta.json
@@ -17,7 +17,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API, ZMod, and CRT.",
     "lineCount": 172,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 0,
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-30"

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None — fully machine-verified by Lean 4 using Mathlib.",
     "lineCount": 361,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/harmonic-divergence-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 253,
-    "theoremCount": 42,
+    "theoremCount": 52,
     "definitionCount": 3,
     "originalContributions": [
       "Definition and convergence/monotonicity wrappers for γ_seq (lower) and γ_seq' (upper) sequences",

--- a/src/data/proofs/lagrange-four-squares-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-04-13",
     "lineCount": 226,
-    "theoremCount": 12,
+    "theoremCount": 11,
     "definitionCount": 0,
     "mathlibDependencies": [],
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 192,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 3,
     "dateAdded": "2026-04-24",
     "mathlibDependencies": [

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -51,7 +51,7 @@
       "Formal statements of 4 quantitative bounds: Roth, Behrend, Bloom-Sisask, Kelley-Meka"
     ],
     "lineCount": 234,
-    "theoremCount": 19,
+    "theoremCount": 18,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/sophie-germain-oq-01/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 196,
-    "theoremCount": 24,
+    "theoremCount": 26,
     "definitionCount": 1,
     "assumptions": "1 axiom: `sophie_germain_conjecture` (inherited from parent, states the unproved Sophie Germain prime conjecture).",
     "dateAdded": "2026-04-26",

--- a/src/data/proofs/sperner-ndim-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-01/meta.json
@@ -32,7 +32,7 @@
       "freudenthal_two_intermediate_sets: existence corollary extracting the two explicit Finsets"
     ],
     "lineCount": 220,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "defCount": 1
   },
   "overview": {

--- a/src/data/proofs/subset-count-oq-02-oq-01/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-01/meta.json
@@ -122,7 +122,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 11
+    "theoremCount": 10
   },
   "sorries": 0
 }

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 193,
-    "theoremCount": 4,
+    "theoremCount": 9,
     "definitionCount": 1,
     "prerequisites": [
       "Power sums and Faulhaber's formula",

--- a/src/data/proofs/sylow-theorem-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 387,
-    "theoremCount": 14,
+    "theoremCount": 21,
     "definitionCount": 3,
     "originalContributions": [
       "cyclic_of_both_sylow_normal: full original proof that normal Sylow subgroups of coprime order make G cyclic",

--- a/src/data/proofs/sylow-theorem-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified via Mathlib's Sylow API (Sylow.orbit_eq_top, Sylow.card_eq_index_normalizer, Sylow.equivQuotientNormalizer, card_sylow_modEq_one).",
     "lineCount": 204,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 2,
     "originalContributions": [
       "sylow_count_eq_normalizer_index: proves n_p = [G : N_G(P)] directly via orbit-stabilizer theorem",

--- a/src/data/proofs/sylow-theorem-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 276,
-    "theoremCount": 18,
+    "theoremCount": 21,
     "definitionCount": 1,
     "originalContributions": [
       "Exhaustive computation of exact Sylow numbers for A₅ via native_decide",


### PR DESCRIPTION
## Fix

Bulk repair of `theoremCount` drift between `meta.*` and `leanFile.*` blocks across 46 gallery entries. The two blocks had divergent values; the actual line-anchored theorem/lemma count was computed and the stale side updated to match.

Of 46 entries: **43 had stale `meta.theoremCount`**, **3 had stale `leanFile.theoremCount`**. Single-file proofs only (no `additionalFiles`).

## Counter

Counts top-level `theorem`/`lemma` declarations including `@[simp]`-prefixed and modifier-prefixed forms (`private`, `protected`, `noncomputable`, `nonrec`):

```
^(?:@\[[^\]]+\]\s*)*(?:(?:private|protected|noncomputable|nonrec)\s+)*(?:theorem|lemma)\s
```

Comments stripped before matching (block `/- ... -/` and line `--`).

## Sample (full table in commit message)

| Entry | Side | Before | After | Status |
|-------|------|--------|-------|--------|
| divisibility-by-3-oq-03-oq-02 | meta | 18 | 21 | verified |
| harmonic-divergence-oq-01 | meta | 42 | 52 | verified |
| derangements-oq-03-oq-02 | meta | 12 | 27 | verified |
| dissection-of-cubes-oq-04 | leanFile | 23 | 25 | verified |
| erdos-852 | leanFile | 20 | 25 | axiomatized |
| subset-count-oq-02-oq-01 | leanFile | 11 | 10 | verified |

## Validation

- All 46 single-line edits preserve original JSON formatting (Unicode escapes left as-is).
- All 2223 meta.json files parse successfully.
- Auditor find-targets.ts --issues does not currently flag theoremCount drift, but it is a real internal inconsistency that this PR resolves.

---
Automated fix by lean-mechanic agent.