### PR TITLE
fix(angle-trisection-oq-02-oq-01-oq-02-incomplete-01): sync meta.json after hjoin_dvd proof (sorries 2→1, lineCount 436→625)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
   "title": "Completing the Wantzel-Galois Constructibility Proof",
   "slug": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
-  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext) to enable proper tower induction. Proves isConstructible_sqrt2, all concrete impossibility results (angle trisection, cube doubling, regular 7-gon). 2 sorries: hjoin_dvd (needs stronger IH), wantzel_galois_iff (out-of-scope).",
+  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext) to enable proper tower induction. Proves isConstructible_sqrt2, isConstructible_algebraic_degree, all concrete impossibility results (angle trisection, cube doubling, regular 7-gon). 1 sorry: wantzel_galois_iff (requires full FTGT + 500+ lines Galois infrastructure).",
   "meta": {
     "author": "Wantzel (1837), completion formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Straightedge_and_compass_construction",
@@ -17,10 +17,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 19,
-    "lineCount": 436,
+    "lineCount": 625,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -54,7 +54,7 @@
   "overview": {
     "historicalContext": "The three classical problems of antiquity — trisecting an angle, doubling the cube, and constructing the regular heptagon — were posed by Greek geometers and remained open for over 2000 years. Pierre Laurent Wantzel proved their impossibility in 1837 using nascent field theory, predating the full development of Galois theory by a decade. Wantzel's key insight was that any ruler-and-compass construction amounts to a tower of quadratic field extensions, so constructible lengths must have degree over ℚ that is a power of 2. Since cos(20°), ∛2, and cos(2π/7) each satisfy irreducible cubics over ℚ — and 3 is not a power of 2 — none can be constructed.\n\nThis file is the completion of a two-part Lean 4 formalization. The parent file (AngleTrisectionOQ02OQ01OQ02.lean) set up the overall framework but left five theorems as sorry. The root cause was a subtle design flaw: the `sqrt_ext` constructor required `IsConstructible β` as a precondition, making structural induction produce induction hypotheses for both `a` and `b` but not for the square root β itself — blocking the tower-degree argument.\n\nThis file fixes `IsConstructible` by removing the `IsConstructible β` precondition from `sqrt_ext`. Under the fixed definition, √2 IS constructible (β = √2, β² = 2 ∈ ℚ). The key theorem `isConstructible_algebraic_degree` then shows every constructible α is algebraic over ℚ with `finrank ℚ ℚ⟮α⟯ ∣ 2^n`, which is exactly what is needed to prove the three impossibility results.",
     "problemStatement": "Prove not_constructible_of_bad_degree: if p is irreducible over ℚ with degree not a power of 2, then no root of p in ℂ is constructible. Also prove cube_root_2_minpoly_irred, cos20_minpoly_degree, and regular_7gon_impossible_degree which were sorried in the parent.",
-    "proofStrategy": "Key insight: removing the `IsConstructible β` precondition from `sqrt_ext` gives the mathematically correct definition where √2 is constructible. The tower-degree theorem `isConstructible_algebraic_degree` is then proved by structural induction: for constructible α, α is algebraic over ℚ and `finrank ℚ ℚ⟮α⟯ ∣ 2^n`. Then `not_constructible_of_bad_degree`: α constructible → `finrank ℚ ℚ⟮α⟯ ∣ 2^n` → `deg(minpoly ℚ α) ∣ 2^n` → p irreducible + minpoly ∣ p → `deg(p) ∣ 2^n` → contradiction since deg(p) is not a power of 2. For irreducibility of X³-2: use Eisenstein at p=2 over ℤ then lift to ℚ via Gauss's lemma. The remaining sorry (`hjoin_dvd`) is in the tower step: bounding `finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯)` requires a stronger IH over arbitrary base fields.",
+    "proofStrategy": "Key insight: removing the `IsConstructible β` precondition from `sqrt_ext` gives the mathematically correct definition where √2 is constructible. The tower-degree theorem `isConstructible_algebraic_degree` is then proved by structural induction: for constructible α, α is algebraic over ℚ and `finrank ℚ ℚ⟮α⟯ ∣ 2^n`. The `hjoin_dvd` tower step (bounding `finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯)`) was proved by strengthening the IH over arbitrary base fields. Then `not_constructible_of_bad_degree`: α constructible → `finrank ℚ ℚ⟮α⟯ ∣ 2^n` → `deg(minpoly ℚ α) ∣ 2^n` → p irreducible + minpoly ∣ p → `deg(p) ∣ 2^n` → contradiction since deg(p) is not a power of 2. For irreducibility of X³-2: use Eisenstein at p=2 over ℤ then lift to ℚ via Gauss's lemma. The remaining sorry (`wantzel_galois_iff`) requires the full Fundamental Theorem of Galois Theory and 500+ lines of new infrastructure.",
     "keyInsights": [
       "Removing `IsConstructible β` from the `sqrt_ext` precondition gives the mathematically correct definition: square roots of constructibles are constructible, so √2 IS constructible under the fixed definition",
       "Under the fixed definition, `isConstructible_algebraic_degree` (structural induction giving `finrank ℚ ℚ⟮α⟯ ∣ 2^n`) is the key tool for `not_constructible_of_bad_degree` — not a rationality collapse",
@@ -97,13 +97,13 @@
     {
       "id": "galois-sorry",
       "title": "Galois Characterization (SORRY)",
-      "startLine": 280,
-      "endLine": 306,
+      "startLine": 601,
+      "endLine": 625,
       "summary": "States wantzel_galois_iff: α constructible ↔ Gal(minpoly(ℚ,α)) is a 2-group. Sorry remains; requires full FTGT + 500+ lines new infrastructure."
     }
   ],
   "conclusion": {
-    "summary": "Reduces the parent's 5 sorries to 2 by: (1) redesigning IsConstructible (removing `IsConstructible β` precondition from `sqrt_ext`) to enable tower-degree induction, (2) proving `not_constructible_of_bad_degree` via `isConstructible_algebraic_degree` (degree ∣ 2^n argument), (3) proving Eisenstein irreducibility for X³-2, (4) computing all three polynomial degrees. The remaining sorries (hjoin_dvd and wantzel_galois_iff) require a stronger induction hypothesis over arbitrary base fields and the full Galois correspondence respectively.",
+    "summary": "Reduces the parent's 5 sorries to 1 by: (1) redesigning IsConstructible (removing `IsConstructible β` precondition from `sqrt_ext`) to enable tower-degree induction, (2) proving `isConstructible_algebraic_degree` (finrank ∣ 2^n) with the hjoin_dvd tower step proved using a stronger IH over arbitrary base fields, (3) proving `not_constructible_of_bad_degree` via the degree ∣ 2^n argument, (4) proving Eisenstein irreducibility for X³-2, (5) computing all three polynomial degrees. The remaining sorry (wantzel_galois_iff) requires the full Fundamental Theorem of Galois Theory and 500+ lines of new infrastructure.",
     "implications": "The three classical impossibility results — angle trisection, cube doubling, regular 7-gon — are now fully proved (0 axioms) in this file. The proof demonstrates that the IsConstructible definition choice is critical: existential vs explicit constructors has dramatic consequences for what can be proved by induction.",
     "openQuestions": [
       "Can wantzel_galois_iff be proved using Mathlib's IntermediateField.orderIsoOfGal and Sylow theory for 2-groups?",
@@ -116,7 +116,7 @@
     {
       "targetId": "angle-trisection-oq-02-oq-01-oq-02",
       "relationship": "completes",
-      "description": "This file completes 3 of the 5 sorries from the parent proof by fixing the IsConstructible definition (removing the `IsConstructible β` precondition from `sqrt_ext`). The fixed definition enables the tower-degree induction (`isConstructible_algebraic_degree`), which is used to prove `not_constructible_of_bad_degree` and the three concrete impossibility results."
+      "description": "This file completes 4 of the 5 sorries from the parent proof by fixing the IsConstructible definition (removing the `IsConstructible β` precondition from `sqrt_ext`). The fixed definition enables the tower-degree induction (`isConstructible_algebraic_degree`), which is used to prove `not_constructible_of_bad_degree` and the three concrete impossibility results. The hjoin_dvd tower step was also proved using a strengthened IH over arbitrary base fields."
     },
     {
       "targetId": "abel-ruffini",
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 436,
+    "lineCount": 625,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 2,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- **sorries 2→1**: PR #15128 proved `hjoin_dvd` (strengthened IH over arbitrary base fields) but did not update `meta.json`. Only `wantzel_galois_iff` remains (requires full FTGT + 500+ lines Galois infrastructure).
- **lineCount 436→625**: Same PR expanded the Lean file by 189 lines; both `meta.lineCount` and `leanFile.lineCount` now reflect actual file length.
- **Text corrections**: `description`, `proofStrategy`, `conclusion.summary` updated to remove `hjoin_dvd` as an open sorry and reflect current state.
- **crossReferences**: "completes 3 of 5 sorries" → "completes 4 of 5 sorries".
- **galois-sorry section lines**: Updated from 280-306 (stale) to 601-625 (actual location in expanded file).

## Evidence

```
Lean file actual: 1 sorry (wantzel_galois_iff, line 623), 625 lines
meta.json claimed: 2 sorries, 436 lines
```

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)