### PR TITLE
fix(angle-trisection-oq-02-oq-01-oq-02-incomplete-01): sync meta after hjoin_dvd elimination

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
   "title": "Completing the Wantzel-Galois Constructibility Proof",
   "slug": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
-  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext) to enable proper tower induction. Proves isConstructible_sqrt2, all concrete impossibility results (angle trisection, cube doubling, regular 7-gon). 2 sorries: hjoin_dvd (needs stronger IH), wantzel_galois_iff (out-of-scope).",
+  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext) to enable proper tower induction. Proves isConstructible_sqrt2, all concrete impossibility results (angle trisection, cube doubling, regular 7-gon). 1 sorry: wantzel_galois_iff (out-of-scope; full Galois characterization requires FTGT bridging not yet available).",
   "meta": {
     "author": "Wantzel (1837), completion formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Straightedge_and_compass_construction",
@@ -17,10 +17,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "theoremCount": 19,
-    "lineCount": 436,
+    "theoremCount": 21,
+    "lineCount": 625,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 436,
+    "lineCount": 625,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 2,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

PR #15128 eliminated the `hjoin_dvd` sorry by strengthening the induction hypothesis, growing `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` from 436→625 lines and adding helper theorems, but left `meta.json` unchanged. The audit gallery now flags `sorry mismatch: claims 2, actual 1` via `scripts/auditor/find-targets.ts`.

This PR syncs the gallery metadata to the current Lean source state.

## Evidence

**Before** (`src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json`):
- `meta.sorries`: 2 (file has 1)
- `meta.theoremCount`: 19 (file has 21)
- `meta.lineCount`: 436 (file has 625)
- `leanFile.{sorries, theoremCount, lineCount}`: 2 / 19 / 436 (stale)
- top-level `sorries`: 2 (stale)
- `description`: "2 sorries: hjoin_dvd (needs stronger IH), wantzel_galois_iff (out-of-scope)"

**After**:
- `meta.sorries`: 1
- `meta.theoremCount`: 21
- `meta.lineCount`: 625
- `leanFile.{sorries, theoremCount, lineCount}`: 1 / 21 / 625
- top-level `sorries`: 1
- `description`: "1 sorry: wantzel_galois_iff (out-of-scope; full Galois characterization requires FTGT bridging not yet available)"

`status` (formalized/wip), `axiomCount` (0), and `definitionCount` (2) unchanged — already correct.

## Validation

```
$ npx tsx scripts/auditor/find-targets.ts --issues
Top 1 audit targets (of 1 total):
  cantor-diagonalization-oq-01-oq-02 (...)  ← unrelated, in PR #15127
```

The angle-trisection-oq-02-oq-01-oq-02-incomplete-01 entry is no longer flagged.

---
Automated fix by lean-mechanic agent.