### PR TITLE
fix(meta): sync stale theoremCount for 3 gallery entries

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
@@ -25,7 +25,7 @@
     "theoremCount": 24
   },
   "lineCount": 311,
-  "theoremCount": 22,
+  "theoremCount": 24,
   "axiomCount": 0,
   "sorryCount": 0,
   "assumptions": [],

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -25,7 +25,7 @@
     "theoremCount": 10
   },
   "lineCount": 199,
-  "theoremCount": 7,
+  "theoremCount": 10,
   "axiomCount": 0,
   "sorryCount": 0,
   "assumptions": [],

--- a/src/data/proofs/erdos-1155-oq-01-oq-07/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-07/meta.json
@@ -53,7 +53,7 @@
     "lineCount": 355,
     "theoremCount": 21
   },
-  "theoremCount": 20,
+  "theoremCount": 21,
   "defCount": 6,
   "status": "axiomatized",
   "badge": "axiom",


### PR DESCRIPTION
## Fix

Three gallery entries had stale `meta.theoremCount` that disagreed with `meta.leanFile.theoremCount` (auto-extracted from the Lean source). The auditor's `find-targets.ts` only checks the `leanFile` field, so this kind of drift escapes the auto-scan.

| Slug | Before | After |
|---|---|---|
| `elementary-quadratic-reciprocity-oq-03` | 7 | 10 |
| `elementary-quadratic-reciprocity-oq-03-oq-01` | 22 | 24 |
| `erdos-1155-oq-01-oq-07` | 20 | 21 |

## Verification

For each Lean source file, all `theorem`/`lemma` declarations (including `private lemma`) match the new value:

```bash
$ grep -cE '\b(theorem|lemma)\s+\w' proofs/Proofs/ElementaryQuadraticReciprocityOQ03.lean
10
$ grep -cE '\b(theorem|lemma)\s+\w' proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01.lean
24
$ grep -cE '\b(theorem|lemma)\s+\w' proofs/Proofs/Erdos1155OQ01OQ07.lean
21
```

Line-level edits preserve original JSON formatting (no `json.dump` rewrite).

---
Automated fix by lean-mechanic agent.