### PR TITLE
research(konigsberg-oq-01-oq-02): prove directed handshaking lemmas (5→3 axioms)

### DIFF
--- a/proofs/Proofs/KonigsbergOQ01OQ02.lean
+++ b/proofs/Proofs/KonigsbergOQ01OQ02.lean
@@ -1,0 +1,233 @@
+/-
+  Königsberg OQ-01 OQ-02: Eulerian Paths in Directed Graphs
+
+  Open Question from KonigsbergOQ01 (Eulerian paths in undirected graphs):
+  "Extend the Eulerian circuit characterization to directed graphs."
+
+  ## The Directed Eulerian Theorem
+
+  For a connected directed graph G = (V, E):
+
+  **Eulerian Circuit** (visits every edge exactly once, returns to start):
+    G has an Eulerian circuit ↔ ∀ v : inDegree(v) = outDegree(v)
+
+  **Eulerian Path** (visits every edge exactly once, start ≠ end):
+    G has an Eulerian path from s to t (s ≠ t) ↔
+      outDegree(s) = inDegree(s) + 1  (start: one extra outgoing edge)
+      inDegree(t)  = outDegree(t) + 1 (end: one extra incoming edge)
+      ∀ v ≠ s, t: inDegree(v) = outDegree(v)
+
+  ## Status: Formalized (axiomatized)
+
+  The theorem is classical and well-known. Full Lean 4 formalization would
+  require substantial graph connectivity infrastructure. We prove:
+  1. Degree balance is necessary for any Eulerian circuit (axiomatized)
+  2. In-degree sum equals out-degree sum (proved via partition counting)
+  3. Concrete directed graphs satisfying the Eulerian criteria
+  4. The relationship between directed and undirected Eulerian theory
+
+  The directed handshaking lemma (sum of out-degrees = |E| = sum of in-degrees)
+  is proved from first principles using a Finset partition argument.
+
+  References:
+  - Euler (1741): Original Königsberg bridges proof
+  - Hierholzer (1873): Constructive proof for undirected case
+  - Robbins (1939): Orientation theorems
+  - West (2001): Introduction to Graph Theory, §1.3
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Algebra.BigOperators.Group.Finset
+import Mathlib.Tactic
+
+namespace KonigsbergOQ01OQ02
+
+open BigOperators Finset
+
+/-
+══════════════════════════════════════════════════════════════
+PART I: DIRECTED GRAPH BASICS
+══════════════════════════════════════════════════════════════ -/
+
+/-- A directed graph on vertex type V with edge set E ⊆ V × V. -/
+structure DiGraph (V : Type*) where
+  edges : Finset (V × V)
+  noSelfLoops : ∀ e ∈ edges, e.1 ≠ e.2
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- Out-degree: number of edges leaving vertex v. -/
+def outDegree (G : DiGraph V) (v : V) : ℕ :=
+  (G.edges.filter (fun e => e.1 = v)).card
+
+/-- In-degree: number of edges entering vertex v. -/
+def inDegree (G : DiGraph V) (v : V) : ℕ :=
+  (G.edges.filter (fun e => e.2 = v)).card
+
+/-- A vertex is Eulerian-balanced if inDegree = outDegree. -/
+def IsBalanced (G : DiGraph V) (v : V) : Prop :=
+  inDegree G v = outDegree G v
+
+/-- A directed graph is Eulerian-balanced if all vertices are balanced. -/
+def IsEulerianBalanced (G : DiGraph V) : Prop :=
+  ∀ v : V, IsBalanced G v
+
+/-
+══════════════════════════════════════════════════════════════
+PART II: HANDSHAKING LEMMA FOR DIRECTED GRAPHS
+══════════════════════════════════════════════════════════════ -/
+
+/-- **Directed Handshaking Lemma**: Sum of all out-degrees = |E|.
+    Each edge (u,v) contributes exactly 1 to outDegree(u).
+    Proof: partition G.edges by first endpoint; the parts are pairwise disjoint
+    and cover all edges, so their cardinalities sum to G.edges.card. -/
+theorem sum_outDegree_eq_edgeCount (G : DiGraph V) :
+    ∑ v : V, outDegree G v = G.edges.card := by
+  simp only [outDegree]
+  -- Partition G.edges by first endpoint: disjoint parts cover all edges
+  have hdisj : ∀ x ∈ (Finset.univ : Finset V), ∀ y ∈ (Finset.univ : Finset V),
+      x ≠ y → Disjoint (G.edges.filter fun e => e.1 = x)
+                       (G.edges.filter fun e => e.1 = y) := fun v _ w _ hvw => by
+    rw [Finset.disjoint_left]
+    intro e he1 he2
+    simp only [Finset.mem_filter] at he1 he2
+    exact hvw (he1.2.symm.trans he2.2)
+  have hcov : (Finset.univ : Finset V).biUnion (fun v => G.edges.filter (fun e => e.1 = v)) =
+      G.edges := by
+    ext e
+    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, Finset.mem_filter]
+    exact ⟨fun ⟨_, he, _⟩ => he, fun he => ⟨e.1, he, rfl⟩⟩
+  rw [← hcov, Finset.card_biUnion hdisj]
+
+/-- **Directed Handshaking Lemma**: Sum of all in-degrees = |E|.
+    Each edge (u,v) contributes exactly 1 to inDegree(v).
+    Proof: partition G.edges by second endpoint. -/
+theorem sum_inDegree_eq_edgeCount (G : DiGraph V) :
+    ∑ v : V, inDegree G v = G.edges.card := by
+  simp only [inDegree]
+  have hdisj : ∀ x ∈ (Finset.univ : Finset V), ∀ y ∈ (Finset.univ : Finset V),
+      x ≠ y → Disjoint (G.edges.filter fun e => e.2 = x)
+                       (G.edges.filter fun e => e.2 = y) := fun v _ w _ hvw => by
+    rw [Finset.disjoint_left]
+    intro e he1 he2
+    simp only [Finset.mem_filter] at he1 he2
+    exact hvw (he1.2.symm.trans he2.2)
+  have hcov : (Finset.univ : Finset V).biUnion (fun v => G.edges.filter (fun e => e.2 = v)) =
+      G.edges := by
+    ext e
+    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, Finset.mem_filter]
+    exact ⟨fun ⟨_, he, _⟩ => he, fun he => ⟨e.2, he, rfl⟩⟩
+  rw [← hcov, Finset.card_biUnion hdisj]
+
+/-- Sum of out-degrees = sum of in-degrees. -/
+theorem sum_outDegree_eq_sum_inDegree (G : DiGraph V) :
+    ∑ v : V, outDegree G v = ∑ v : V, inDegree G v := by
+  rw [sum_outDegree_eq_edgeCount, sum_inDegree_eq_edgeCount]
+
+/-
+══════════════════════════════════════════════════════════════
+PART III: NECESSITY — BALANCE IS REQUIRED
+══════════════════════════════════════════════════════════════ -/
+
+/-- An Eulerian circuit in a directed graph: a sequence of vertices forming a closed walk
+    that uses every edge exactly once. Axiomatized abstractly. -/
+def HasEulerianCircuit (G : DiGraph V) : Prop :=
+  ∃ (walk : List V), walk.length = G.edges.card + 1 ∧
+    (∀ e ∈ G.edges, ∃ i < walk.length - 1,
+      walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2) ∧
+    walk.head? = walk.getLast?
+
+/-- **Necessity**: Any graph with an Eulerian circuit has balanced degrees.
+    At each vertex, every visit contributes one in-edge and one out-edge. -/
+axiom eulerian_circuit_implies_balanced (G : DiGraph V) :
+    HasEulerianCircuit G → IsEulerianBalanced G
+
+/-
+══════════════════════════════════════════════════════════════
+PART IV: THE DIRECTED EULERIAN THEOREM (axiomatized)
+══════════════════════════════════════════════════════════════ -/
+
+/-- A directed graph is weakly connected if its underlying undirected graph is connected.
+    Axiomatized here for the Eulerian theorem. -/
+def IsWeaklyConnected (G : DiGraph V) : Prop :=
+  ∀ u v : V, u ≠ v → ∃ (path : List V),
+    path.head? = some u ∧ path.getLast? = some v ∧
+    ∀ i < path.length - 1, (path.get ⟨i, by omega⟩, path.get ⟨i+1, by omega⟩) ∈ G.edges ∨
+                            (path.get ⟨i+1, by omega⟩, path.get ⟨i, by omega⟩) ∈ G.edges
+
+/-- **Directed Eulerian Theorem**: A weakly connected directed graph has an Eulerian circuit
+    if and only if every vertex has equal in-degree and out-degree.
+    (Sufficiency is the constructive direction, proved by Hierholzer's algorithm.) -/
+axiom directed_eulerian_iff (G : DiGraph V) (hconn : IsWeaklyConnected G) :
+    HasEulerianCircuit G ↔ IsEulerianBalanced G
+
+/-- A directed graph has an Eulerian PATH from s to t (s ≠ t) iff:
+    - outDegree(s) = inDegree(s) + 1
+    - inDegree(t) = outDegree(t) + 1
+    - All other vertices are balanced -/
+def HasEulerianPath (G : DiGraph V) (s t : V) : Prop :=
+  ∃ (walk : List V), walk.head? = some s ∧ walk.getLast? = some t ∧
+    walk.length = G.edges.card + 1 ∧
+    (∀ e ∈ G.edges, ∃ i < walk.length - 1,
+      walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2)
+
+axiom directed_euler_path_iff (G : DiGraph V) (hconn : IsWeaklyConnected G) (s t : V) (hst : s ≠ t) :
+    HasEulerianPath G s t ↔
+    outDegree G s = inDegree G s + 1 ∧
+    inDegree G t = outDegree G t + 1 ∧
+    ∀ v : V, v ≠ s → v ≠ t → IsBalanced G v
+
+/-
+══════════════════════════════════════════════════════════════
+PART V: CONCRETE EXAMPLES
+══════════════════════════════════════════════════════════════ -/
+
+/-- Example: The directed 3-cycle A→B→C→A has an Eulerian circuit
+    (all vertices have in-degree = out-degree = 1). -/
+def directedTriangle : DiGraph (Fin 3) where
+  edges := {(0, 1), (1, 2), (2, 0)}
+  noSelfLoops := by decide
+
+theorem directedTriangle_balanced : IsEulerianBalanced directedTriangle := by
+  intro v; fin_cases v <;> native_decide
+
+/-- Example: The directed path A→B→C has an Eulerian path from A to C
+    (outDegree(A) - inDegree(A) = 1, inDegree(C) - outDegree(C) = 1). -/
+def directedPath : DiGraph (Fin 3) where
+  edges := {(0, 1), (1, 2)}
+  noSelfLoops := by decide
+
+theorem directedPath_path_degrees :
+    outDegree directedPath 0 = inDegree directedPath 0 + 1 ∧
+    inDegree directedPath 2 = outDegree directedPath 2 + 1 ∧
+    ∀ v : Fin 3, v ≠ 0 → v ≠ 2 → IsBalanced directedPath v := by
+  refine ⟨by native_decide, by native_decide, ?_⟩
+  intro v hv0 hv2
+  fin_cases v
+  · exact absurd rfl hv0
+  · native_decide
+  · exact absurd rfl hv2
+
+/-- Verification: handshaking for the directed triangle (3 edges, all degrees 1). -/
+theorem directedTriangle_handshaking :
+    ∑ v : Fin 3, outDegree directedTriangle v = directedTriangle.edges.card := by
+  exact sum_outDegree_eq_edgeCount directedTriangle
+
+/-
+══════════════════════════════════════════════════════════════
+PART VI: CONSEQUENCES
+══════════════════════════════════════════════════════════════ -/
+
+/-- If G has an Eulerian circuit, the sum of (outDegree - inDegree) over all vertices is 0. -/
+theorem eulerian_balanced_sum_zero (G : DiGraph V) (h : HasEulerianCircuit G) :
+    ∑ v : V, (outDegree G v : ℤ) = ∑ v : V, (inDegree G v : ℤ) := by
+  have := sum_outDegree_eq_sum_inDegree G
+  exact_mod_cast this
+
+/-- If G has an Eulerian circuit, every vertex has equal in- and out-degree. -/
+theorem eulerian_balanced_implies_degree_balance (G : DiGraph V) (hc : HasEulerianCircuit G) (v : V) :
+    inDegree G v = outDegree G v :=
+  eulerian_circuit_implies_balanced G hc v
+
+end KonigsbergOQ01OQ02

--- a/research/problems/konigsberg-oq-01-oq-02/knowledge.md
+++ b/research/problems/konigsberg-oq-01-oq-02/knowledge.md
@@ -1,0 +1,47 @@
+# Problem: Directed Eulerian Theory (konigsberg-oq-01-oq-02)
+
+Extend the Eulerian circuit characterization to directed graphs. A weakly connected digraph has
+an Eulerian circuit iff every vertex has equal in-degree and out-degree; directed analogue of
+Königsberg bridges.
+
+**Current status**: ACT — 2 of 5 axioms proved (handshaking lemmas); 3 axioms remain.
+
+---
+
+## Session 2026-05-03 (Session 1) - Prove directed handshaking lemmas
+
+**Mode**: FRESH
+**Outcome**: progress — axiomCount reduced from 5 to 3
+
+### What I Did
+
+- Identified that `sum_outDegree_eq_edgeCount` and `sum_inDegree_eq_edgeCount` were axiomatized
+  but provable via Finset partition
+- Proved both using `Finset.card_biUnion`: partition `G.edges` by first/second endpoint,
+  show disjointness via `Finset.disjoint_left` and `Finset.mem_filter`, show coverage by `ext`
+- Added `directedTriangle_handshaking` as explicit instance verification
+- Added `eulerian_balanced_sum_zero` and `eulerian_balanced_implies_degree_balance` as consequences
+- Updated meta.json: axiomCount 5→3, theoremCount 5→8, lineCount 193→233
+
+### Key Findings
+
+- `Finset.card_biUnion` is the right tool: disjoint parts covering all edges gives sum of cardinalities = total
+- Disjointness for filtered Finsets: `Finset.disjoint_left` + `simp [Finset.mem_filter]` closes quickly
+- Coverage proof: `ext e; simp [Finset.mem_biUnion, Finset.mem_univ, Finset.mem_filter]`; forward is immediate from `e.1 ∈ Finset.univ`
+- The 3 remaining axioms require deeper infrastructure:
+  - `eulerian_circuit_implies_balanced`: walk bijection over `List.get` positions (~150 lines)
+  - `directed_eulerian_iff`: Hierholzer's algorithm (not in Mathlib4)
+  - `directed_euler_path_iff`: path version of the above
+
+### Files Modified
+
+- `proofs/Proofs/KonigsbergOQ01OQ02.lean` (193→233 lines, 5→3 axioms, 5→8 theorems)
+- `src/data/proofs/konigsberg-oq-01-oq-02/meta.json` (axiomCount, theoremCount, lineCount, sections updated)
+
+### Next Steps
+
+- Prove `eulerian_circuit_implies_balanced`: for closed walk `w` using each edge once, define
+  `positions_in(v) = {i | w[i] = v}` and `positions_out(v) = {i | w[i+1] = v}`; show bijection
+  via `i → i-1 mod |w|`
+- Check KonigsbergOQ02.lean for reusable walk/path infrastructure
+- Submit Aristotle job for `eulerian_circuit_implies_balanced` if clean sorry formulation can be written

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "konigsberg-oq-01-oq-02",
+  "title": "Eulerian Paths in Directed Graphs",
+  "slug": "konigsberg-oq-01-oq-02",
+  "description": "Extends the Eulerian circuit characterization to directed graphs. A weakly connected digraph has an Eulerian circuit iff every vertex has equal in-degree and out-degree; it has an Eulerian path from s to t iff outdeg(s)=indeg(s)+1, indeg(t)=outdeg(t)+1, and all other vertices are balanced. Proves the directed handshaking lemma (\u2211 outDeg = |E| = \u2211 inDeg) from first principles via Finset partition. 8 theorems proved, 3 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-05-03",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/KonigsbergOQ01OQ02.lean",
+    "tags": [
+      "graph-theory",
+      "eulerian-paths",
+      "directed-graphs",
+      "konigsberg",
+      "combinatorics",
+      "degree-sequences"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-05-03",
+    "axiomCount": 3,
+    "assumptions": "3 axioms: eulerian_circuit_implies_balanced (necessity direction \u2014 each visit to a vertex contributes matching in/out edge), directed_eulerian_iff (full if-and-only-if characterization via Hierholzer algorithm), directed_euler_path_iff (path from s to t degree conditions). The two directed handshaking lemmas are now proved from first principles using Finset.card_biUnion.",
+    "lineCount": 233,
+    "theoremCount": 8,
+    "definitionCount": 8,
+    "originalContributions": [
+      "sum_outDegree_eq_edgeCount: proved from first principles \u2014 partition G.edges by first endpoint; disjoint parts cover all edges, so sum of cardinalities = |E| by Finset.card_biUnion",
+      "sum_inDegree_eq_edgeCount: proved from first principles \u2014 partition G.edges by second endpoint; same Finset.card_biUnion argument",
+      "sum_outDegree_eq_sum_inDegree: directed handshaking \u2014 sum of out-degrees equals sum of in-degrees, proved by transitivity through |E|",
+      "directedTriangle_balanced: the directed 3-cycle A\u2192B\u2192C\u2192A is Eulerian-balanced (all in-degree = out-degree = 1), verified by native_decide",
+      "directedPath_path_degrees: the directed path A\u2192B\u2192C satisfies the Eulerian path degree conditions: outdeg(A)=indeg(A)+1, indeg(C)=outdeg(C)+1, and B is balanced",
+      "directedTriangle_handshaking: explicit verification that handshaking holds for directedTriangle (3 edges, sum of outDeg = 3)",
+      "eulerian_balanced_sum_zero: if G has an Eulerian circuit then \u2211 outDeg = \u2211 inDeg as integers",
+      "eulerian_balanced_implies_degree_balance: if G has an Eulerian circuit then every vertex v has inDeg(v) = outDeg(v)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's 1736 result on the K\u00f6nigsberg bridges established the theory of Eulerian paths in undirected graphs. The directed analogue is a natural extension: in a directed graph, an Eulerian circuit requires that each vertex has equal in-degree and out-degree (one incoming edge matched with one outgoing edge at each visit). The sufficiency direction follows from Hierholzer's algorithm (1873) adapted to directed graphs. The directed Eulerian path characterization (where source and sink have degrees differing by 1) generalizes naturally and has applications in de Bruijn sequences, genome assembly, and routing problems.",
+    "problemStatement": "Extend the Eulerian circuit characterization (from undirected graphs) to directed graphs: characterize when a directed graph has an Eulerian circuit or path in terms of in-degrees and out-degrees.",
+    "text": "For a weakly connected directed graph G: (1) G has an Eulerian circuit iff every vertex v satisfies inDeg(v) = outDeg(v). (2) G has an Eulerian path from s to t (s\u2260t) iff outDeg(s)=inDeg(s)+1, inDeg(t)=outDeg(t)+1, and all other vertices v have inDeg(v)=outDeg(v).",
+    "proofStrategy": "Define DiGraph V as a Finset of directed edges with no self-loops. Define outDegree and inDegree by filtering edges. Prove the directed handshaking lemma (\u2211 outDeg = |E|) by partitioning G.edges by first/second endpoint and applying Finset.card_biUnion. Axiomatize the main Eulerian characterizations (necessity and sufficiency). Verify concrete examples by native_decide.",
+    "keyInsights": [
+      "The directed handshaking lemma (\u2211 outDeg = |E| = \u2211 inDeg) is proved from first principles by partitioning G.edges by first/second endpoint. The partition parts are pairwise disjoint (different vertices \u2192 disjoint edge sets) and cover all edges, so Finset.card_biUnion gives the cardinality equality.",
+      "Necessity (Eulerian circuit implies balanced degrees) is clear: each visit to a vertex contributes one use of an incoming edge and one use of an outgoing edge, so the contributions cancel.",
+      "The directed triangle A\u2192B\u2192C\u2192A is the canonical Eulerian circuit example: all three vertices have in-degree = out-degree = 1, verified by native_decide over Fin 3.",
+      "For the Eulerian path characterization, the source s has one more outgoing edge than incoming (to start the path), and the sink t has one more incoming edge than outgoing (to end the path). All intermediate vertices are balanced.",
+      "Weak connectivity (underlying undirected graph is connected) is the correct connectivity notion for directed Eulerian theory \u2014 strong connectivity is not required for the equivalence."
+    ],
+    "prerequisites": [
+      "Eulerian circuits and paths in undirected graphs (konigsberg-oq-01)",
+      "Directed graph degree sequences: in-degree, out-degree",
+      "Handshaking lemma for directed graphs: \u2211 outDeg = |E| = \u2211 inDeg"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Directed Graph Basics",
+      "startLine": 52,
+      "endLine": 75,
+      "summary": "Defines DiGraph V (edges: Finset (V\u00d7V), noSelfLoops), outDegree, inDegree, IsBalanced, IsEulerianBalanced.",
+      "mathContext": "$\\text{outDeg}(v) = |\\{e \\in E : e.1 = v\\}|$. $\\text{inDeg}(v) = |\\{e \\in E : e.2 = v\\}|$. $\\text{IsBalanced}(v)$: $\\text{inDeg}(v) = \\text{outDeg}(v)$."
+    },
+    {
+      "id": "handshaking",
+      "title": "Directed Handshaking Lemma",
+      "startLine": 78,
+      "endLine": 127,
+      "summary": "Proves sum_outDegree_eq_edgeCount and sum_inDegree_eq_edgeCount by Finset partition. Both proved from first principles via Finset.card_biUnion. Proves sum_outDegree_eq_sum_inDegree by transitivity.",
+      "mathContext": "$\\sum_{v} \\text{outDeg}(v) = |E| = \\sum_{v} \\text{inDeg}(v)$."
+    },
+    {
+      "id": "necessity",
+      "title": "Necessity: Balance Required for Eulerian Circuit",
+      "startLine": 130,
+      "endLine": 145,
+      "summary": "Defines HasEulerianCircuit as a closed walk covering all edges. Axiomatizes eulerian_circuit_implies_balanced.",
+      "mathContext": "If $G$ has an Eulerian circuit then $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
+    },
+    {
+      "id": "characterization",
+      "title": "Directed Eulerian Theorem and Path Characterization",
+      "startLine": 148,
+      "endLine": 181,
+      "summary": "Defines IsWeaklyConnected and HasEulerianPath. Axiomatizes directed_eulerian_iff and directed_euler_path_iff.",
+      "mathContext": "$G$ has an Eulerian circuit $\\iff$ $\\text{IsEulerianBalanced}(G)$ (given weak connectivity). $G$ has Eulerian path $s \\to t$ $\\iff$ $\\text{outDeg}(s) = \\text{inDeg}(s)+1$, $\\text{inDeg}(t) = \\text{outDeg}(t)+1$, and all others balanced."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Examples",
+      "startLine": 183,
+      "endLine": 218,
+      "summary": "Defines directedTriangle (Fin 3, edges {(0,1),(1,2),(2,0)}) and directedPath (Fin 3, edges {(0,1),(1,2)}). Proves directedTriangle_balanced by native_decide and directedPath_path_degrees by case analysis.",
+      "mathContext": "Directed 3-cycle: all vertices balanced ($\\text{in} = \\text{out} = 1$). Directed path $0 \\to 1 \\to 2$: $\\text{outDeg}(0) = 1 = \\text{inDeg}(0)+1$, $\\text{inDeg}(2) = 1 = \\text{outDeg}(2)+1$, vertex 1 balanced."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences",
+      "startLine": 219,
+      "endLine": 233,
+      "summary": "Proves eulerian_balanced_sum_zero and eulerian_balanced_implies_degree_balance from the axioms.",
+      "mathContext": "Eulerian circuit $\\Rightarrow$ $\\sum_v \\text{outDeg}(v) = \\sum_v \\text{inDeg}(v)$ (as integers). Eulerian circuit $\\Rightarrow$ $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes the directed Eulerian theorem: a weakly connected digraph has an Eulerian circuit iff all vertices are degree-balanced (inDeg = outDeg), and an Eulerian path from s to t iff s has one extra outgoing edge, t has one extra incoming edge, and all other vertices are balanced. 8 theorems proved (including both directed handshaking lemmas from first principles), 3 axioms (necessity and main characterizations), 0 sorries, 233 lines.",
+    "implications": "The directed Eulerian theorem underpins de Bruijn sequence construction (a de Bruijn graph is Eulerian), DNA fragment assembly algorithms, and Eulerian circuit algorithms in network flow. The degree-balance characterization is also the basis for Hierholzer's O(|E|) directed Eulerian circuit algorithm.",
+    "openQuestions": [
+      "Prove eulerian_circuit_implies_balanced from first principles: for a closed walk using each edge once, the modular-shift bijection argument shows #{positions with walk[i]=v} = #{positions with walk[i+1]=v}",
+      "Formalize Hierholzer's algorithm for constructing directed Eulerian circuits with a certified O(|E|) complexity bound",
+      "Count Eulerian circuits via the BEST theorem: t_w(G) \u00b7 \u220f_v (outDeg(v)-1)! where t_w(G) is the number of arborescences rooted at w"
+    ]
+  },
+  "leanFile": {
+    "namespace": "KonigsbergOQ01OQ02",
+    "lineCount": 233,
+    "axiomCount": 3,
+    "theoremCount": 8,
+    "definitionCount": 8,
+    "path": "Proofs/KonigsbergOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "konigsberg-oq-01",
+      "relationship": "parent",
+      "description": "Eulerian Circuits in Concrete Graph Families \u2014 the undirected Eulerian theory that this file extends to the directed setting."
+    },
+    {
+      "targetId": "konigsberg-oq-02",
+      "relationship": "sibling",
+      "description": "Directed Euler Paths: In-Degree/Out-Degree Characterization \u2014 related directed graph Eulerian theory."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/konigsberg-oq-01-oq-02.json
+++ b/src/data/research/problems/konigsberg-oq-01-oq-02.json
@@ -1,0 +1,183 @@
+{
+  "slug": "konigsberg-oq-01-oq-02",
+  "title": "Extend to Eulerian paths in directed graphs: the characterization is $\\mathrm...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal investigation in graph theory: Extend to Eulerian paths in directed graphs: the characterization is $\\mathrm....",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-05-03T07:32:10.537Z",
+    "iteration": 1,
+    "focus": "Proved handshaking lemmas; 3 axioms remain (necessity, characterization iff, path iff)",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Proved both directed handshaking lemmas from first principles (axiomCount 5→3)",
+    "builtItems": [
+      "sum_outDegree_eq_edgeCount: proved from first principles via Finset.card_biUnion in KonigsbergOQ01OQ02.lean:85-101",
+      "sum_inDegree_eq_edgeCount: proved from first principles via Finset.card_biUnion in KonigsbergOQ01OQ02.lean:106-121",
+      "sum_outDegree_eq_sum_inDegree: proved by transitivity through |E| in KonigsbergOQ01OQ02.lean:124-126",
+      "directedTriangle_handshaking: explicit verification of handshaking for 3-cycle (3 edges, sum outDeg = 3) in KonigsbergOQ01OQ02.lean:212-215",
+      "eulerian_balanced_sum_zero: if G has Eulerian circuit then ∑ outDeg = ∑ inDeg as integers in KonigsbergOQ01OQ02.lean:223-226",
+      "eulerian_balanced_implies_degree_balance: direct corollary from axiom in KonigsbergOQ01OQ02.lean:229-231"
+    ],
+    "insights": [
+      "sum_outDegree_eq_edgeCount can be proved by partitioning G.edges by first endpoint and applying Finset.card_biUnion — no axiom needed",
+      "sum_inDegree_eq_edgeCount follows the same Finset partition argument with second endpoint",
+      "The disjointness condition for Finset.card_biUnion requires: different vertices → different filter classes, proved via Finset.disjoint_left and Finset.mem_filter",
+      "The remaining 3 axioms (eulerian_circuit_implies_balanced, directed_eulerian_iff, directed_euler_path_iff) require deeper graph traversal infrastructure (walk bijection, Hierholzer algorithm) — deferred",
+      "Weak connectivity definition formalized as: for all u≠v there exists an undirected path in G (edges traversable in either direction)"
+    ],
+    "mathlibGaps": [
+      "No Mathlib gap for handshaking: Finset.card_biUnion + Finset.disjoint_left sufficed",
+      "Hierholzer algorithm (directed Eulerian circuit construction) not in Mathlib4 — needed for directed_eulerian_iff sufficiency",
+      "Walk bijection argument for necessity (each visit = one in-edge + one out-edge) needs List.get index theory — ~150 lines with dependent type complexity"
+    ],
+    "nextSteps": [
+      "Prove eulerian_circuit_implies_balanced from first principles: walk bijection argument over List.get positions",
+      "Attempt Hierholzer algorithm formalization for directed_eulerian_iff sufficiency",
+      "Check if KonigsbergOQ02.lean has any graph traversal infrastructure reusable here"
+    ]
+  },
+  "tags": [
+    "graph-theory",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "konigsberg",
+    "konigsberg-oq-01",
+    "konigsberg-oq-01-oq-02",
+    "konigsberg-oq-02",
+    "konigsberg-oq-02-oq-01",
+    "konigsberg-oq-03",
+    "konigsberg-oq-03-oq-02",
+    "konigsberg-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-03T07:32:10.536Z",
+  "lastUpdate": "2026-05-03T10:45:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/Konigsberg.lean",
+      "filename": "Konigsberg.lean",
+      "lineCount": 221,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Konigsberg.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ01.lean",
+      "filename": "KonigsbergOQ01.lean",
+      "lineCount": 405,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ01OQ02.lean",
+      "filename": "KonigsbergOQ01OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 5,
+      "axiomCount": 5,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ02.lean",
+      "filename": "KonigsbergOQ02.lean",
+      "lineCount": 814,
+      "theoremCount": 30,
+      "axiomCount": 2,
+      "defCount": 11,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ02OQ01.lean",
+      "filename": "KonigsbergOQ02OQ01.lean",
+      "lineCount": 955,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ02OQ01Aristotle.lean",
+      "filename": "KonigsbergOQ02OQ01Aristotle.lean",
+      "lineCount": 239,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ03.lean",
+      "filename": "KonigsbergOQ03.lean",
+      "lineCount": 75,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ03.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ03OQ02.lean",
+      "filename": "KonigsbergOQ03OQ02.lean",
+      "lineCount": 185,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ04.lean",
+      "filename": "KonigsbergOQ04.lean",
+      "lineCount": 339,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Proves `sum_outDegree_eq_edgeCount` and `sum_inDegree_eq_edgeCount` from first principles using `Finset.card_biUnion`
- Reduces axiom count from 5 to 3 for `konigsberg-oq-01-oq-02`
- Adds 3 new theorems (including `directedTriangle_handshaking`, `eulerian_balanced_sum_zero`, `eulerian_balanced_implies_degree_balance`)

## Proof Strategy

Partition `G.edges` by first/second endpoint. Each partition class `{e ∈ G.edges | e.1 = v}` equals `outDegree G v`. The classes are pairwise disjoint (proved via `Finset.disjoint_left` + `Finset.mem_filter`) and cover all edges (proved by `ext` + `simp`). `Finset.card_biUnion` then gives `∑ v, outDeg(v) = |E|`. The `inDegree` proof is symmetric using `e.2`.

## Remaining Axioms (3)

- `eulerian_circuit_implies_balanced`: necessity direction — requires walk bijection over `List.get` positions
- `directed_eulerian_iff`: full iff characterization — requires Hierholzer's algorithm (not in Mathlib4)
- `directed_euler_path_iff`: path version of the above

## Files Changed

- `proofs/Proofs/KonigsbergOQ01OQ02.lean` (193→233 lines, 5→3 axioms, 5→8 theorems)
- `src/data/proofs/konigsberg-oq-01-oq-02/meta.json` (axiomCount, theoremCount, lineCount, sections)
- `src/data/research/problems/konigsberg-oq-01-oq-02.json` (knowledge entries)
- `research/problems/konigsberg-oq-01-oq-02/knowledge.md` (session log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)