### PR TITLE
fix(audit-tracker): sync 238 stale issues-found entries as issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2201,7 +2201,7 @@
         "cramer_ops_{1,2,3,4} prove arithmetically false equalities (1=2, 11=5, 71=53, 479=475); status verified/original suspect — file likely fails to compile but build-safe-subset masks failures. Issue #15032."
       ],
       "lastAudited": "2026-05-03T02:50:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "cramers-rule-oq-01-oq-04": {
       "auditCount": 2,
@@ -3589,7 +3589,7 @@
       "agentId": "auditor-agent-2026-05-01",
       "auditCount": 3,
       "lastAudited": "2026-05-01T05:51:29Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "sections.comparison.summary claims theorem asymptotic_agreement (line 167-172) but only docstring exists; no Lean declaration",
         "sections.transversals.summary claims theorem extremal_construction (line 185-188) but only docstring exists; no Lean declaration"
@@ -3599,7 +3599,7 @@
       "agentId": "auditor-22589",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:04:42Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14477: section line drift + phantom Bondy result narrative"
       ]
@@ -3617,7 +3617,7 @@
         "section line drift (~25 lines)"
       ],
       "lastAudited": "2026-05-02T14:19:06Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1081": {
       "agentId": "auditor-cycle-20-batch",
@@ -3821,7 +3821,7 @@
       "agentId": "auditor-loop-2026-05-02",
       "auditCount": 3,
       "lastAudited": "2026-05-02T14:05:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom-axiom narrative: 5 \"Axiom (van Doorn-Tao 2025)\" docstrings but only 1 axiom declared (propertyQ_achievable). Section line ranges drifted (main-axioms 93–130 → actual 93–115; special-sequences 154–154 → actual 140–153). originalContributions/proofStrategy overclaim plural axiomatization. Issue #14809."
       ]
@@ -3830,7 +3830,7 @@
       "agentId": "auditor-loop-1777730687",
       "auditCount": 3,
       "lastAudited": "2026-05-02T14:07:56Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom-axiom narrative: proofStrategy/sections claim 3 axioms (van Doorn–Tao upper/lower + Konyagin) but only vanDoorn_tao_upper exists; basic-properties says \"Axiomatizes the singleton characterization\" but it is a proved theorem; orphaned docstrings at lines 70-71 and 72-73; section line drift — basic-properties ends at 92 but file has 162 lines (squarefreeSumset_pair, subexp_eventually_lt_exp, erdos_1103_false uncovered). Issue #14812."
       ]
@@ -3839,7 +3839,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T14:30:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom Kim/edge axiom claims + phantom sorry + section line drift + missing summary section (#14816)"
       ]
@@ -3848,7 +3848,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-02T13:59:50Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1106": {
       "agentId": "auditor-cycle-20-batch",
@@ -3878,13 +3878,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T13:40:18Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-111": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T13:45:39Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1110": {
       "agentId": "auditor-cycle-20-batch",
@@ -3896,7 +3896,7 @@
       "agentId": "auditor-loop",
       "auditCount": 3,
       "lastAudited": "2026-05-02T13:55:59Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "notes": "Issue #14804 — phantom-axiom narrative: proofStrategy/sections claim axioms for Reduction-to-t<=c, general c=3 bound, Ramsey/chi-boundedness; only orphan docstrings exist (numerical counts correct)",
       "issues": []
     },
@@ -3904,7 +3904,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T13:51:20Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "sections[6] (tang-yang-2021) claims a tang_yang_2021 axiom that is not declared in the Lean file (only a docstring); mathContext also writes 'k ≠ 3' instead of 'k ≥ 3'"
       ],
@@ -3920,7 +3920,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T13:36:47Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "systemic section drift (6 of 7 sections, +8 to +22 lines), proofStrategy claims a phantom axiomatization (filed #14789)"
       ]
@@ -3962,7 +3962,7 @@
         "section line drift Parts II-VI; missing sections for Parts VII-VIII"
       ],
       "lastAudited": "2026-05-02T12:32:07Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "notes": "Issue #14777 — phantom axioms in narrative + section line drift; meta.axiomCount=3 (correct)"
     },
     "erdos-112": {
@@ -3977,7 +3977,7 @@
         "section line drift across all sections + missing main-open-problem section (filed #14785)"
       ],
       "lastAudited": "2026-05-02T13:32:17Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1121": {
       "auditCount": 3,
@@ -3985,7 +3985,7 @@
         "section drift in special-cases/higher-dim, missing summary section, originalContributions overstates two phantom claims (filed #14787)"
       ],
       "lastAudited": "2026-05-02T13:34:52Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1122": {
       "auditCount": 3,
@@ -3996,7 +3996,7 @@
         "section line drift: sec-hierarchy/examples/summary off by 5-9 lines"
       ],
       "lastAudited": "2026-05-02T12:55:29Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "notes": "Issue #14781 — phantom axioms (erdos_1122, omega_*) in narrative; meta.axiomCount=3 is correct"
     },
     "erdos-1123": {
@@ -4006,7 +4006,7 @@
         "section line drift: just-krawczyk (80-97 vs actual 80-88), ideal-properties (98-110 vs actual 89-94); Part V Summary missing from sections array"
       ],
       "lastAudited": "2026-05-02T13:17:48Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "notes": "Issue #14783 — proofStrategy overstates axiomatization; meta.axiomCount=2 is correct"
     },
     "erdos-1124": {
@@ -4015,7 +4015,7 @@
         "phantom originalContributions: laczkovich_piece_count, pieces_not_measurable, dubins_hirsch_karush; phantom proofStrategy axiomatize claims; section line drift (laczkovich-theorem, non-measurability, main-result); LaTeX bug in tarski-problem mathContext (issue #14773)"
       ],
       "lastAudited": "2026-05-02T12:28:16Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1124-oq-01": {
       "auditCount": 2,
@@ -4047,7 +4047,7 @@
         "#14765: phantom 'Statement of Erdős-Hajnal necessity result' contribution + false 'former axioms now proved as theorems or definitions' claim (none of the named identifiers exist) + section line drift starting at davies-theorem (Parts VIII/IX missing entirely)"
       ],
       "lastAudited": "2026-05-02T12:11:47Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1128": {
       "auditCount": 2,
@@ -4079,7 +4079,7 @@
         "phantom axiom narrative: sections sqrt-bound and de-boor-pinkus claim Axiomatizes when only logarithmic_bound is declared; section line drift on main-result (claims 87-95, actually 126-154); proofStrategy overclaims \"All deep results are axiomatized\" (only 1 of 3). Issue #14763."
       ],
       "lastAudited": "2026-05-02T00:00:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1131": {
       "auditCount": 2,
@@ -4099,7 +4099,7 @@
         "#14759: phantom erdos_lower_bound contribution + section line drift + imports drift"
       ],
       "lastAudited": "2026-05-02T12:03:07Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1133": {
       "auditCount": 3,
@@ -4107,13 +4107,13 @@
         "#14755: phantom axiom narrative (proofStrategy + sections related/lagrange/chebyshev claim 4 axioms; only lagrange_interpolation declared) + section line drift"
       ],
       "lastAudited": "2026-05-02T11:57:28Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1134": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-02T11:46:36Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1135": {
       "auditCount": 3,
@@ -4241,7 +4241,7 @@
         "phantom theorem citations in meta.json + Lean summary docstring: inverseN_implies_inverseSqrtN, inverseN_implies_inverseLogN, chebyshev_correction_nonneg_eventually do not exist in proofs/Proofs/Erdos115OQ01Problem.lean. Lean docstring also says \"Axioms (8 total)\" while file has 11. Issue #14862."
       ],
       "lastAudited": "2026-05-02T20:12:14Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1150": {
       "auditCount": 3,
@@ -4315,7 +4315,7 @@
         "#14745 phantom \"axiomatize\" claims for upper bound, lower bound, stepping-up + section line drift"
       ],
       "lastAudited": "2026-05-02T11:31:08Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1159": {
       "auditCount": 2,
@@ -4351,7 +4351,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-02T11:26:08Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1166": {
       "agentId": "auditor-cycle-20-batch",
@@ -4423,7 +4423,7 @@
       "agentId": "auditor-loop-1777720421",
       "auditCount": 3,
       "lastAudited": "2026-05-02T11:17:28Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "#14741: phantom axiom claims for Mycielski / finite case / Erdős 1959 in proofStrategy + sections (only docstrings; no declarations)"
       ]
@@ -4438,7 +4438,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T11:12:05Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1178": {
       "auditCount": 2,
@@ -4450,7 +4450,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-02T10:47:13Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "notes": "#14732: phantom axioms (erdos_renyi_upper, gEps_mono not declared; main_asymptotic now theorem main_asymptotic_derived; trivial_lower_bound→basic_lower_bound) in originalContributions/sections; section line drift (sections cover 1-178 of 316-line file; Parts IX, X missing); proofStrategy says 179-line file"
     },
     "erdos-1179-oq-01": {
@@ -4471,7 +4471,7 @@
         "#14737: proofStrategy step 3 claims trivial-bound axiomatization (no axiom declared in Lean source)"
       ],
       "lastAudited": "2026-05-02T11:04:20Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1182": {
       "auditCount": 1,
@@ -4507,7 +4507,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T10:33:29Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-1202": {
       "auditCount": 1,
@@ -4609,7 +4609,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T10:30:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "#14722: phantom axiom claims for erdos_126, erdos_126_littleo, trivial_upper_bound, f_monotone, conjecture_implies_not_O_log in sections/proofStrategy + section line drift"
       ]
@@ -4636,7 +4636,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T10:15:31Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "#14718: phantom axiom claims in originalContributions and sections (5 of 6 listed axioms are not real declarations)"
       ]
@@ -4660,7 +4660,7 @@
         "#14734: residual phantom claims after PR #14724 — sections[0].summary still references nonexistent nondividing_equiv; originalContributions[0] claims false equivalence (nondividing_not_iff_alt proves they are NOT equivalent); sections[1].mathContext + sections[6].mathContext stale (summaries fixed, mathContext not); sections[4].mathContext LaTeX bug"
       ],
       "lastAudited": "2026-05-02T10:54:29Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-131-oq-01": {
       "auditCount": 2,
@@ -4672,7 +4672,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T10:05:11Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "#14714: phantom axiom claims for CDL 2025, Spencer-Szemerédi-Trotter, Guth-Katz in proofStrategy/sections"
       ]
@@ -4687,7 +4687,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T10:01:12Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-135": {
       "agentId": "auditor-cycle-20-batch",
@@ -4767,7 +4767,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-02T09:51:51Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-146": {
       "auditCount": 3,
@@ -4775,7 +4775,7 @@
         "phantom axioms in originalContributions/proofStrategy/sections (#14705) + section line drift"
       ],
       "lastAudited": "2026-05-02T09:45:33Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-147": {
       "auditCount": 2,
@@ -4805,7 +4805,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-02T09:39:01Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-151": {
       "auditCount": 2,
@@ -4835,7 +4835,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-02T09:32:37Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-155": {
       "auditCount": 3,
@@ -4843,7 +4843,7 @@
         "phantom axiom claims (Singer lower, main conjecture, strong form, F(6..18)) + section line drift; issue #14693"
       ],
       "lastAudited": "2026-05-02T09:25:53Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-156": {
       "auditCount": 2,
@@ -4865,7 +4865,7 @@
         "#14691: phantom theorem claims (orphan docstrings in context/examples/main-results) + section line drift in all 7 sections"
       ],
       "lastAudited": "2026-05-02T09:21:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-159": {
       "auditCount": 3,
@@ -4891,7 +4891,7 @@
         "Phantom axioms in originalContributions (erdos_hajnal_rado_conjecture, conlon_fox_sudakov_upper); section line drift (sections 3-8); phantom proofStrategy/section content"
       ],
       "lastAudited": "2026-05-02T09:25:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-162": {
       "auditCount": 3,
@@ -4899,7 +4899,7 @@
         "#14689: stale 'sorry' narrative claims for colourEdgeCount_total/balanced_requires_le_half + 214→237 lineCount drift in historicalContext/conclusion (file has 0 sorries, 237 lines)"
       ],
       "lastAudited": "2026-05-02T09:14:15Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-163": {
       "auditCount": 2,
@@ -4923,7 +4923,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T09:05:04Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms in originalContributions/proofStrategy/sections (only aks_upper_bound + mattheus_verstraete declared; spencer_lower_bound/R(3,3)/R(4,4)/R(4,5)/R(3,k) are doc-comment only); section line drift sections 4-8 (issue #14685)"
       ]
@@ -4934,13 +4934,13 @@
         "#14679: phantom axioms in proofStrategy/sections (5 axioms claimed; only IsPlanar declared); lineCount 275→274; section line drift in known-results/fractional-version/summary"
       ],
       "lastAudited": "2026-05-02T08:57:53Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-168": {
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T09:00:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom 0.5564 axiom claim in originalContributions; better_construction missing from proofStrategy (issue #14675)"
       ]
@@ -4963,7 +4963,7 @@
         "phantom F_lower_two axiom + non-existent N=3/N=30 examples + section line drift (issue #14673)"
       ],
       "lastAudited": "2026-05-02T08:45:39Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-171": {
       "auditCount": 2,
@@ -4989,7 +4989,7 @@
         "section line drift in 5/9 sections (Parts V-IX); known-ramsey endLine 160→158, examples 161-187→159-178, non-ramsey 188-206→179-197, characterization 207-221→198-212, summary 222-247→213-247; not_spherical_not_ramsey at L182 falls outside its claimed section by line; counts/axioms/narrative all accurate (#14671)"
       ],
       "lastAudited": "2026-05-02T08:42:30Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-175": {
       "auditCount": 2,
@@ -5007,7 +5007,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-02T08:30:12Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-177-oq-04": {
       "auditCount": 2,
@@ -5019,7 +5019,7 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-05-02T08:24:53Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-179": {
       "auditCount": 2,
@@ -5070,7 +5070,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T08:16:14Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-185": {
       "agentId": "auditor-agent",
@@ -5086,13 +5086,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:52:20Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-187": {
       "agentId": "auditor-1777707734",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:46:50Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Narrative drift: meta.json sections.definitions.summary and overview.proofStrategy reference non-existent maxMonoAPLength definition; classify optAPBound as a definition rather than the axiom it actually is. sections.definitions.endLine drifts by 1. Numerical counts (4 axioms, 0 sorries, 2 defs, 60 lines) are correct. Filed issue #14649."
       ],
@@ -5102,7 +5102,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:38:46Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-189": {
       "agentId": "auditor-cycle-20-batch",
@@ -5127,7 +5127,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:19:59Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "proofStrategy/keyInsight reverse H(k)≤W(k) (Lean proves W(k)≤H(k) at line 177); section line drift in 6/10 sections; filed #14641"
       ]
@@ -5154,7 +5154,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:14:32Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom 'construction_uses_base3' axiom in sections[5]; chaotic_ordering_reals is a True-stub (issue #14638)"
       ]
@@ -5181,7 +5181,7 @@
       "agentId": "auditor-session-1777705382",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:30:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom Baumgartner axiom in originalContributions/proofStrategy + section title/line drift + 3 dangling docstrings (#14632)"
       ]
@@ -5190,7 +5190,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:10:40Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-2": {
       "agentId": "auditor-cycle-20-batch",
@@ -5217,13 +5217,13 @@
         "meta.json: phantom axioms in proofStrategy (claims PNT/conjecture axiomatized — only green_tao is); 3 dangling /-- -/ docstrings (lines 48-55, 77-81, 100-102); section line drift in all sections after core-definitions (structural claims 112-125 but ap_difference_primorial is at 136-146). Issue #14625."
       ],
       "lastAudited": "2026-05-02T06:56:42Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-201": {
       "agentId": "auditor-loop-1777705064",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:01:17Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "section line drift: basic-bounds 89-100, kss-bound 108-109, main-conjecture 119-122, monotonicity 129-149, consequences 156-197 all misaligned; narrative claims gk axiomatized but Lean has noncomputable def gk (only g3_5_eq value axiomatized); filed #14629"
       ]
@@ -5265,7 +5265,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-02T06:51:37Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-208": {
       "agentId": "auditor-cycle-20-batch",
@@ -5277,7 +5277,7 @@
       "agentId": "auditor-session-1777704127",
       "auditCount": 3,
       "lastAudited": "2026-05-02T06:45:28Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-21": {
       "agentId": "auditor-cycle-20-batch",
@@ -5289,7 +5289,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T06:39:55Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-211": {
       "agentId": "auditor-cycle-20-batch",
@@ -5307,7 +5307,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T06:25:46Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom axiom narrative: originalContributions/proofStrategy claim anning_erdos_finite and gip_sparsity_bound axioms that do not exist in Erdos213Problem.lean (only dangling /-- ... -/ docstrings); section line ranges drift for main-results, constructions, bounds, summary; 3 dangling docstrings in Lean source. Numerical fields (axiomCount=4, sorries=0) accurate. Issue #14608."
       ]
@@ -5322,7 +5322,7 @@
       "agentId": "auditor-session-1777703363",
       "auditCount": 3,
       "lastAudited": "2026-05-02T06:35:11Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axiom narrative (isCongruent_symm, steinhaus_set_unbounded, steinhaus_set_measure_pathological, jackson_mauldin_general) + section line drift Parts II-VI + 209-line claim contradicts 187-line file (#14613)"
       ]
@@ -5337,7 +5337,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T06:22:03Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms palasti_small_n + erdos_217_conjecture (only docstrings); phantom small_cases_exist/ErdosConjecture217 in originalContributions; proofStrategy overclaims Palásti axiomatization (#14603)"
       ]
@@ -5352,7 +5352,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T06:16:52Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "section line drift across all 6 sections; missing summary section; 2 dangling docstrings (lines 95-96, 102-109) — issue #14601"
       ]
@@ -5374,7 +5374,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T06:00:57Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom axioms in originalContributions/proofStrategy: lorentz_1954, two_primitive_root_mod_five_power, generalization_to_any_base, sumset_covering, additive_basis_order_two are listed but not declared in source (only dangling docstrings). Stale lineCount 274 in proofStrategy (file is 239 lines). Issue #14597 filed."
       ]
@@ -5386,7 +5386,7 @@
         "phantom axioms in sections (Fermat criterion, Landau, Richards 1982, DEKKM 2022, monotonicity) + section line drift Parts II–VII (#14599)"
       ],
       "lastAudited": "2026-05-02T06:09:26Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-223": {
       "agentId": "auditor-cycle-20-batch",
@@ -5404,7 +5404,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T05:54:34Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-226": {
       "agentId": "auditor-1777703204",
@@ -5428,7 +5428,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T05:43:06Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Section line drift for 4 sections + 2 sections missing from meta.json. Filed issue #14587"
       ]
@@ -5462,7 +5462,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T05:24:15Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-234": {
       "agentId": "auditor-cycle-20-batch",
@@ -5486,7 +5486,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T05:08:05Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-238": {
       "agentId": "auditor-cycle-20-batch",
@@ -5498,7 +5498,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T05:03:16Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-24": {
       "agentId": "auditor-cycle-20-batch",
@@ -5618,7 +5618,7 @@
       "agentId": "auditor-2026-05-02T04:57:20.128138Z",
       "auditCount": 3,
       "lastAudited": "2026-05-02T04:56:46Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-256": {
       "agentId": "auditor-cycle-20-batch",
@@ -5642,7 +5642,7 @@
       "agentId": "auditor-2026-05-02-erdos-259",
       "auditCount": 3,
       "lastAudited": "2026-05-02T04:38:14Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "section line drift: sections[].startLine/endLine off by ~20–90 lines; missing 'Squarefree Numbers' section (issue #14564)"
       ]
@@ -5651,7 +5651,7 @@
       "agentId": "auditor-1777696958",
       "auditCount": 3,
       "lastAudited": "2026-05-02T04:51:42Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Section line drift in 5 of 8 sections (davenport-erdos +5, conjecture +5, counterexamples +5, tenenbaum-variant +2, supporting-lemmas +2). Filed #14568."
       ]
@@ -5684,7 +5684,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T04:14:26Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom-axiom narrative: originalContributions/proofStrategy/sections claim formal statements for Kovač-Tao negative/positive criteria and 2^(2ⁿ) example that exist only as docstrings (issue #14549)"
       ]
@@ -5693,7 +5693,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T04:31:47Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-266": {
       "agentId": "auditor-cycle-20-batch",
@@ -5743,7 +5743,7 @@
         "phantom-axiom narrative: 5+ phantom axioms (simonovits_sos_lower, erdos_graham_conjecture_false, small_sets_count/has_AP, szabo_leading_constant) claimed in originalContributions/proofStrategy/sections; only 3 real axioms in Lean (#14545)"
       ],
       "lastAudited": "2026-05-02T04:10:53Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-273": {
       "agentId": "auditor-cycle-20-batch",
@@ -5755,13 +5755,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T03:59:28Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-275": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T04:06:14Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-276": {
       "agentId": "auditor-cycle-20-batch",
@@ -5773,7 +5773,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T03:55:51Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom sorries/placeholders in sections[] narrative + openQuestions; numerical fields correct (#14537)"
       ]
@@ -5805,7 +5805,7 @@
       "agentId": "auditor-cycle-21-issue-14552",
       "auditCount": 4,
       "lastAudited": "2026-05-02T04:18:24Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axiom 'cambie_only_one_avoider' in originalContributions; section summaries reference cambie_satisfies_growth/cambie_only_one_avoider/cambie_count_is_one/prime_number_theorem_approx that exist only as docstrings; section line ranges drifted — issue #14535",
         "phantom-axiom narrative in proofStrategy: claims 'growth bound, covering property, exact count, and conjecture refutation are axiomatized' but only original_conjecture_false exists; growth/covering/count are dangling docstrings (lines 78-83) — issue #14552"
@@ -5815,7 +5815,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T03:45:20Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom-axiom narrative: claims axiomatization of divergence/coprime/Davenport-Erdős/Rogers but only erdos_281_proved exists; sections.divergence-coprime summary describes content that is only dangling docstrings (lines 217-219) — issue #14532"
       ]
@@ -5830,7 +5830,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T03:35:49Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-284": {
       "agentId": "auditor-cycle-20-batch",
@@ -5839,7 +5839,7 @@
         "phantom theorems harmonic_interval/croot_2001/f_asymptotic claimed in originalContributions/mainTheorems but only docstrings, never declared; section line drift (examples L147–157 actually contains Part VI Summary header) — issue #14526"
       ],
       "lastAudited": "2026-05-02T03:33:16Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-285": {
       "agentId": "auditor-cycle-20-batch",
@@ -5851,14 +5851,14 @@
       "agentId": "auditor-2026-05-02",
       "auditCount": 3,
       "lastAudited": "2026-05-02T03:38:21Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "notes": "Issue #14525 already filed: phantom-axiom narrative (claims 5 axioms, file has 2). Awaiting mechanic."
     },
     "erdos-287": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T03:16:47Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axiom narrative + dangling docstrings: 2 phantom axioms (example_2_3_6, erdos_287_conjecture) listed in assumptions/originalContributions/proofStrategy/sections but never declared; proofStrategy claims '3 axioms, 91 lines' (actual 1/85); section line drift on example/conjecture (#14521)"
       ]
@@ -5895,7 +5895,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T02:52:57Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axiom narrative + section drift: proofStrategy claims '6 axioms, 2 sorries' (actual 2/0); 5 section summaries claim axioms that are only block comments (van_doorn_lower_bound, van_doorn_explicit, van_doorn_infinitely_many_small, denom_divides_lcm, oeis_values, ratio_bounds); originalContributions overstates van_doorn axioms; section line ranges off by ~1-2 (#14518)"
       ]
@@ -5928,7 +5928,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T02:28:13Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axiom narrative + section drift: 3 dangling docstrings claim existence/k-existence/k-minimality axioms not declared; meta.originalContributions and sections.existence/k-definition overstate axiomatization (#14513)"
       ]
@@ -5937,7 +5937,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T02:18:11Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-297": {
       "agentId": "auditor-cycle-20-batch",
@@ -5986,7 +5986,7 @@
       "agentId": "auditor-loop-1777687577",
       "auditCount": 3,
       "lastAudited": "2026-05-02T02:08:25Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14504: phantom axioms in section narratives (doubling, summary) + 11 section line ranges drifted"
       ]
@@ -6037,7 +6037,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:56:43Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axiom narrative: sections claim croot_threshold_1999 axiom and yokota_refined_2002 axiom that are not declared (only docstrings); section line drift around line 213 (#14501)"
       ]
@@ -6052,7 +6052,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:49:52Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-311": {
       "agentId": "auditor-cycle-20-batch",
@@ -6076,7 +6076,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:46:10Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "section line drift across all 8 sections; missing diophantine section in meta.json; proofStrategy step 5 references orphan docstring (#14497)"
       ]
@@ -6085,7 +6085,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:42:29Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-316": {
       "agentId": "auditor-cycle-20-batch",
@@ -6133,7 +6133,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:37:11Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom originalContributions (mahler_theorem, erdos_positive_density_claim — neither axiom exists); proofStrategy + sections.positive-density falsely claim Part VII axiomatizes positive density (orphan docstring only); overview.text says '5 axioms' (actual 3) and '191-line' (actual 182); section line drift +4 from Part III onward (#14493)"
       ]
@@ -6184,13 +6184,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:23:43Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-329": {
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:17:45Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom Erdős 1/2 axiom + conditional embedding (orphan docstrings, no declarations); section line drift lower-bounds onward (#14484)"
       ]
@@ -6201,19 +6201,19 @@
         "Phantom axiomatizations in proofStrategy/sections (Moser, Van Doorn) + section line drift +7 to +9; headline counts correct (issue #14482)"
       ],
       "lastAudited": "2026-05-02T01:13:18Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-330": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T00:53:48Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-331": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:08:37Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms in sections/originalContributions (ruzsa_unique_representation, ruzsaB_eq_double_ruzsaA, ruzsa_exact_growth, ruzsaVariantOpen, ruzsaA_sparse_differences, larger_density_common_differences); section line-range drift; summary claims 9 axioms but file has 3; conclusion 245 lines vs 223 actual (#14480)"
       ]
@@ -6222,7 +6222,7 @@
       "agentId": "auditor-2026-05-02-025521",
       "auditCount": 3,
       "lastAudited": "2026-05-02T03:00:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "proofStrategy claims phantom axioms (symmetry, zero membership, density inheritance) that are proved theorems / unstated; numerical counts correct (1 axiom, 20 theorems, 6 defs, 0 sorries). Filed #14472."
       ]
@@ -6237,7 +6237,7 @@
       "agentId": "auditor",
       "auditCount": 3,
       "lastAudited": "2026-05-02T00:55:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom (proved) claim for small_has_repr (has sorry); phantom minSmoothness_exists axiom + de_bruijn_asymptotic theorem in section summaries; section line drift Parts III-VIII (#14467)"
       ],
@@ -6262,7 +6262,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T00:41:44Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-337": {
       "agentId": "auditor-cycle-20-batch",
@@ -6310,7 +6310,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T00:33:54Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms in sections (ulamSeq_unique_representation, ulamSeq_minimal, ulamSeq_values, five_not_ulam, six_is_ulam, twin_examples, erdos_342, ulamSeq_growth, ulamSeq_growth_constant, ulam_characterization); section line-range drift across all parts; theoremCount 20→19; imports drift (#14463)"
       ]
@@ -6325,7 +6325,7 @@
       "agentId": "auditor-2026-05-02-0204",
       "auditCount": 3,
       "lastAudited": "2026-05-02T00:10:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom folkman_theorem axiom claim in sections[2].mathContext (orphan /-- ... -/ doc comment, no declaration); numerical counts and tier all clean (#14454)"
       ]
@@ -6454,7 +6454,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T00:05:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom Bauer-Bennett/Bennett-Van Luijk axioms in originalContributions; phantom product_eq_range_prod theorem (no such name, 0 sorries); proofStrategy claims combining 3 axioms but only ulas_theorem used in disproof; section line drift Parts VIII-XII (#14451)"
       ]
@@ -6551,7 +6551,7 @@
       "agentId": "auditor-2026-05-02-cycle-1777679298",
       "auditCount": 3,
       "lastAudited": "2026-05-01T23:53:39Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14444"
     },
     "erdos-376": {
@@ -6576,7 +6576,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T23:46:04Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14440: narrative claims Lean-verified but main result is axiom (3 axioms total); section line drift; basic-properties section has no Lean theorems"
       ]
@@ -6597,7 +6597,7 @@
       "agentId": "auditor-cycle-2026-05-02",
       "auditCount": 3,
       "lastAudited": "2026-05-02T01:45:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom HC_exponent_decreasing/ramanujan_characterization/HC_sparser_than_primes theorems in originalContributions; 4 dangling doc-comments; section line drift Parts VI–IX (#14438)"
       ]
@@ -6606,7 +6606,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-01T23:37:09Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-383": {
       "agentId": "auditor-cycle-20-batch",
@@ -6658,7 +6658,7 @@
         "section line drift: [3] 57-73 should extend to 86; [4] startLine 74 should be 88; [6] 134-149 misses line 141 marker and theorem at 165; [7] title 'Verified Examples' should be 'Verified Facts' (Lean line 168), startLine 170 should be 168"
       ],
       "lastAudited": "2026-05-01T23:33:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issueRefs": [
         14434
       ]
@@ -6673,7 +6673,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T23:08:58Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "section line drift sections[3..8] (acrstuv-theorem onward) — first 3 sections aligned, drift starts at Part IV; numerical counts and tier all clean (#14427)"
       ]
@@ -6690,7 +6690,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T07:00:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "issue #14432: section line drift Parts 3-8 (counting-function/abc-conditional/bounds/diophantine/density ranges off by 3-14 lines); empty Part 6 'Lower Bounds' has only 3 dangling /-- ... -/ docstrings (137-139), no formalized bounds; numerical counts (4 axioms, 0 sorries, 4 theorems, 12 defs, 177 lines) and axiomatized/axiom badge all clean"
       ]
@@ -6705,7 +6705,7 @@
       "agentId": "auditor-2026-05-02-0500",
       "auditCount": 3,
       "lastAudited": "2026-05-02T05:00:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14430: phantom extremal_example_tight in proofStrategy Main Results (no such declaration); dangling /-- ... -/ doc-comment at lines 147-148 with no following declaration; section line drift ~4-9 lines in original-false/revised-true/optimality/summary"
       ]
@@ -6720,7 +6720,7 @@
       "agentId": "auditor-2026-05-02-0100",
       "auditCount": 3,
       "lastAudited": "2026-05-01T23:04:36Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-397": {
       "agentId": "auditor-cycle-20-batch",
@@ -6786,7 +6786,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-02T00:00:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "issue #14422: phantom \"Axiomatizes Wilson/Fermat\" in wilson-theorem section (proved via Mathlib ZMod lemmas); section line drift sections 3-9 (~25-30 line offset); minor: originalContributions[5] overstates IsPerfectPower as \"formalized generalization\""
       ]
@@ -6801,7 +6801,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T22:43:27Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom Bajpai-Bennett 131082 axiom (only ≤ 9 declared, 131082 only in docstring); phantom FourRepFamily theorems (def + 2 docstring headers, no proofs); section line drift in main-results/infinite-family/summary (#14418)"
       ]
@@ -6822,7 +6822,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T22:20:35Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom Nash h=4 axiom in proofStrategy and section solved-cases (only docstring, Chen subsumes); section examples implies powersOfTwo theorem but only def + docstring exist (#14415)"
       ]
@@ -6915,7 +6915,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T21:56:17Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms consSeq_is_consecutive_sum/consSeq_minimal in section consecutive-sum-predicate (only docstrings); section line ranges drift across Parts IV-XII (#14412)"
       ]
@@ -6930,7 +6930,7 @@
       "agentId": "auditor-2026-05-01-1777671029",
       "auditCount": 3,
       "lastAudited": "2026-05-01T21:34:59Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "#14404: phantom axioms primes_are_sidon, log_conversion, sidon_bound in proofStrategy/sections + section line drift 5-23 lines"
       ]
@@ -6975,7 +6975,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-01T21:19:24Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom-section: prime_counting_asymptotic, primes_sumset_not_primes, must_contain_small_elements not declared (issue #14400)",
         "section line-range drift: inverse-goldbach, counting-functions, main-statement off by 1-2 lines"
@@ -7003,7 +7003,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T21:47:48Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "PR #14407 / issue #14397 + follow-up comment: phantom non_representable_exist axiom in section main-theorem; conclusion summary claims 6 axioms (only 2 declared); Sylvester–Frobenius docstring labelled axiomatized in section related-results"
       ]
@@ -7012,7 +7012,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T21:10:47Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",
@@ -7030,7 +7030,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T21:05:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "2026-05-01: phantom contribution kth_power_result (claimed in originalContributions but no theorem of that name exists; only a Part VI docstring) + section line drift +4 to +7 on Parts VI/VII/VIII. Filed #14392."
       ]
@@ -7045,7 +7045,7 @@
       "agentId": "auditor-2026-05-01-session",
       "auditCount": 3,
       "lastAudited": "2026-05-01T20:40:12Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "PR #14387: phantom axiom erdos_szemeredi_liminf_bound in originalContributions/proofStrategy/section-3 — only tao_elementary_proof and van_doorn_sharp_bound declared in Lean"
       ]
@@ -7073,7 +7073,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T22:00:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom-axiom narrative: 5 axiom names (case_all_naturals, case_primes, highly_composite_relative, exponential_lower_bound, no_uniform_bound) referenced in assumptions/originalContributions/sections/proofStrategy are only docstring text; only erdos_graham_conjecture_true is declared. Issue #14385"
       ]
@@ -7109,7 +7109,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T20:22:53Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom-axiom narrative: proofStrategy claims cauchy_schwarz_divisors + problem_448_consequence are axiomatized but only docstrings exist. Line ranges drift (says Summary lines 162-174; file is 154 lines). Issue #14380."
       ]
@@ -7130,7 +7130,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T20:21:18Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "conclusion.summary says 3 sorries but file has 0 (3 axioms instead). Section line ranges drift. Tracked in #14377."
       ]
@@ -7297,7 +7297,7 @@
       "agentId": "auditor-87018",
       "auditCount": 3,
       "lastAudited": "2026-05-01T18:49:45Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom-axiom narrative: Kravitz/graham_full_set/graham_constructive not declared (issue #14358)"
       ]
@@ -7330,7 +7330,7 @@
       "agentId": "auditor-loom",
       "auditCount": 3,
       "lastAudited": "2026-05-01T18:29:13Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14351: phantom k=-1 axiom narrative — originalContributions, proofStrategy, sections[partial-results], and erdos_479_summary docstring all claim a Graham-Lehmer-Lehmer k=-1 axiom that does not exist in the Lean source; only solution_set_one_finite and powers_of_two_infinite are declared. Numerical fields (axiomCount=2, sorries=0, lineCount=230) are correct."
       ]
@@ -7339,7 +7339,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T18:22:31Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Section line ranges drift 7-16 lines; phantom theorem references twin_prime_implies_erdos_48 and sumDivisors_multiplicative (issue #14347)"
       ]
@@ -7360,7 +7360,7 @@
       "agentId": "auditor-cycle-2026-05-01",
       "auditCount": 3,
       "lastAudited": "2026-05-01T18:16:45Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom non-periodicity axiom in originalContributions; sections part-1/3/5 describe docstring-only content as axiomatized — issue #14343"
       ]
@@ -7405,7 +7405,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T18:10:18Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Section line ranges drift after Part IV; Part VII \"Proof Structure\" missing from sections (issue #14340)"
       ]
@@ -7420,7 +7420,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T18:01:43Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "14338"
       ]
@@ -7435,7 +7435,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-01T17:54:26Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom sidon_bound axiom + van_doorn_observation + their-equivalence narrative; section line drift (issue #14335)"
       ]
@@ -7477,7 +7477,7 @@
         "Phantom-axiom narrative: originalContributions list 3 items only present as doc-comments (cassels_swinnerton_dyer_cubic, ekl_hausdorff_dimension_zero, badziahin_velani_padic); ekl_hausdorff_dimension_zero overclaims — actual axiom is ekl_countable_exceptions; section IV/VI summaries also reference these phantoms — issue #14323"
       ],
       "lastAudited": "2026-05-01T17:27:08Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-496": {
       "agentId": "auditor-cycle-20-batch",
@@ -7536,7 +7536,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T17:20:54Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-503": {
       "agentId": "auditor-cycle-20-batch",
@@ -7578,7 +7578,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T17:15:20Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-51": {
       "agentId": "auditor-cycle-20-batch",
@@ -7596,7 +7596,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T17:03:49Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14317: 6 phantom axioms in sections summaries (components_below_4, sum_diameters_rootsOfUnity, petal_structure, perturbation_creates_components, huang_theorem, diameter_4_is_sharp); section line ranges drifted at threshold-4/summary"
       ]
@@ -7634,7 +7634,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-01T16:56:28Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14314: originalContributions claims 3 phantom Statement-of-theorem items (Wiman 1914, Erdős-Macintyre 1954, Kovári 1965) that exist only as doc-comments; numerical fields (axiomCount=1, sorries=1, lineCount=196) are correct"
       ]
@@ -7655,7 +7655,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-02T15:13:25Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-52": {
       "agentId": "auditor-cycle-20-batch",
@@ -7683,7 +7683,7 @@
     "erdos-522": {
       "auditCount": 3,
       "lastAudited": "2026-05-01T16:49:06Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14311: proofStrategy claims phantom Erdős-Offord/Yakir/almost-sure-convergence axioms; root-counting section misclaimed as axiomatized; assumptions misnames axiom (KacPolynomialData → KacPolynomialData.isRademacher)"
       ]
@@ -7704,7 +7704,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T16:02:08Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14297: phantom-axiom narrative (5 phantom axioms in originalContributions: littlewood_count, has_small_value_iff_min_lt_one, konyagin_exponent_tight, konyagin_schlag_lower_tail, rudin_shapiro_bound) + section line drift across all 9 sections"
       ]
@@ -7719,7 +7719,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T16:29:56Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-527": {
       "agentId": "auditor-cycle-20-batch",
@@ -7755,7 +7755,7 @@
       "agentId": "auditor-session-1777649716",
       "auditCount": 3,
       "lastAudited": "2026-05-01T15:51:52Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom-axiom narrative: proofStrategy claims 3 axioms (only 2 declared); F_3 phantom; F_1/F_2 still sorry-stubbed (#14295)"
       ]
@@ -7764,7 +7764,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T15:43:01Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14289: phantom-axiom narrative (axiomCount=2 correct, but originalContributions claims 3 ultrafilter/Hales-Jewett axioms that are docstring-only) + section line drift Parts VI-IX (~20-30 lines off)"
       ]
@@ -7785,7 +7785,7 @@
       "agentId": "auditor-64117",
       "auditCount": 3,
       "lastAudited": "2026-05-01T15:24:33Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom-axiom narrative + section line drift (#14284)"
       ]
@@ -7797,7 +7797,7 @@
         "phantom-axiom narrative + section line drift: prose claims four_elements_fail/weisenberg_construction axiomatized (only docstrings), and lcm_structure/weisenberg_dense_case as axioms (both are theorems). Filed #14286"
       ],
       "lastAudited": "2026-05-01T15:33:04Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-537": {
       "agentId": "auditor-cycle-20-batch",
@@ -7836,7 +7836,7 @@
       "agentId": "lean-auditor",
       "auditCount": 3,
       "lastAudited": "2026-05-01T17:15:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Issue #14282: phantom-axiom narrative (axiomCount=1 correct, but assumptions list 3, sections claim EGZ/Erdős-Szemerédi axiomatized, proofStrategy says graham_conjecture is sorry — it is proved)"
       ]
@@ -7875,7 +7875,7 @@
       "agentId": "auditor-erdos-547-phantom-narrative",
       "auditCount": 3,
       "lastAudited": "2026-05-01T14:48:12Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom narrative: originalContributions/proofStrategy/sections claim IsPath/IsStar/IsCaterpillar/Chvátal bound/exact path-star Ramsey numbers/tightness theorem; Lean file has only 3 axioms + erdos_547 wrapper. Filed #14275"
       ]
@@ -7899,7 +7899,7 @@
         "phantom-axiom narrative + section line drift (covered by issue #14274 / PR #14277)"
       ],
       "lastAudited": "2026-05-01T15:00:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-550": {
       "agentId": "auditor-cycle-20-batch",
@@ -7929,7 +7929,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-03T00:38:10Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom contributions in originalContributions: triangle_ramsey_exponential, triangle_ramsey_upper, oddCycle_ramsey_upper, oddCycle_ramsey_lower (docstrings only, not declared)"
       ]
@@ -7986,7 +7986,7 @@
       "agentId": "auditor-loom",
       "auditCount": 3,
       "lastAudited": "2026-05-01T11:07:37Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom-axiom narrative: proofStrategy/sections claim Erdős–Rado, Erdős–Hajnal, general lower, and main conjecture as axioms but they are docstring-only (issue #14247)"
       ]
@@ -8001,7 +8001,7 @@
       "agentId": "auditor-loop-1777634217",
       "auditCount": 3,
       "lastAudited": "2026-05-01T11:22:23Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom-axiom narrative — originalContributions 6/7/8, proofStrategy steps 7/8, sections small-values/comparison/four-colour describe docstring placeholders, not Lean declarations (axiomCount 3, sorries 1 are correct) — issue #14254"
       ]
@@ -8034,7 +8034,7 @@
       "agentId": "auditor-session-1777632838",
       "auditCount": 3,
       "lastAudited": "2026-05-01T10:59:06Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom axioms in narrative: pentagon case + lower bounds in proofStrategy; vertex-bound axiom in section summary; pentagon axiom claimed in known-results section — issue #14242"
       ]
@@ -8049,7 +8049,7 @@
       "agentId": "auditor-agent-2026-05-01",
       "auditCount": 3,
       "lastAudited": "2026-05-01T10:50:04Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "sections.cases.summary claims four phantom axioms (EFRS/Sidorenko/Jayawardene/CFMPP) — only erdos_570_resolved exists in Lean; numerical fields correct — issue #14234"
       ]
@@ -8061,7 +8061,7 @@
         "phantom axioms in originalContributions / proofStrategy / sections (jiang_qiu_exponents_4_3, jiang_qiu_exponents_5_4, jiang_ma_yepremyan_exponents, conlon_janzer_near_two, bukh_conlon_families, kovari_sos_turan, bondy_simonovits_upper) — issue #14232"
       ],
       "lastAudited": "2026-05-01T10:50:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-572": {
       "agentId": "auditor-cycle-20-batch",
@@ -8073,7 +8073,7 @@
       "agentId": "auditor-agent-tracker",
       "auditCount": 3,
       "lastAudited": "2026-05-01T10:25:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom KST/Erdős-Simonovits bound axioms in narrative (counts correct); lineCount 152→177; section line drift — issue #14227"
       ]
@@ -8100,7 +8100,7 @@
       "agentId": "auditor-erdos-577-2026-05-01",
       "auditCount": 3,
       "lastAudited": "2026-05-01T10:18:21Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom degree_bound_sharp in originalContributions; conclusion claims sharpness is proved (only docstring). See issue #14225."
       ]
@@ -8130,7 +8130,7 @@
       "agentId": "auditor-session-1777623758",
       "auditCount": 3,
       "lastAudited": "2026-05-01T08:23:46Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "originalContributions: 4 phantom entries (AKS_theorem, path_case, star_case, LKS_tightness) - docstrings only",
         "proofStrategy: steps 5 and 7 claim 5 axiomatizations, only zhao_theorem is axiomatized",
@@ -8151,7 +8151,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-01T09:24:45Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Inconsistent axioms: folkmanNumber_2_3_4 := 0 (def) with axiom folkman_lower_bound : ≥ 19 — issue #14212"
       ]
@@ -8160,7 +8160,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T08:18:11Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms in narrative: pyber_theorem, tree_satisfies, complete_graph_satisfies, cycle_satisfies, star_needs_few_paths, bipartite_tight (issue #14195)"
       ]
@@ -8181,7 +8181,7 @@
       "agentId": "auditor-loop-5164",
       "auditCount": 3,
       "lastAudited": "2026-05-01T08:30:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms in originalContributions/proofStrategy: covering_implies_comparable, no_antichain_k_covering (issue #14189)"
       ]
@@ -8199,7 +8199,7 @@
         "originalContributions lists 11 phantom identifiers (Line, OnLine, Collinear, InKGeneralPosition, IsKRich, karteszi_lower_bound, grunbaum_lower_bound, solymosi_stojakovic, erdos_588_conjecture, problem_101, szemeredi_trotter); section k4-open summary claims axioms lower_bound_k4 and erdos_conjecture_k4 that are docstring-only (issue #14192)"
       ],
       "lastAudited": "2026-05-01T08:11:06Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-589": {
       "agentId": "auditor-cycle-20-batch",
@@ -8226,7 +8226,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T07:54:15Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Phantom axiom narrative: originalContributions/proofStrategy/sections claim formalizations of Specker and Chang theorems that exist only as docstrings (issue #14186)"
       ]
@@ -8247,7 +8247,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T07:50:44Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "section line drift (5/8 sections shifted) + phantom contributions erdos_hajnal_aleph2 and thomassen_1983 (docstring-only, no declaration); tracked in #14183"
       ]
@@ -8262,7 +8262,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T07:44:52Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms in narrative: section summaries claim Axiom erdos_596 (Part IV) and Axiom erdos_595_k4_k3 (Part V) — neither declared in Lean file; only nesetril_rodl_c4_c6 and erdos_hajnal_c4_trees exist — issue #14179"
       ]
@@ -8302,7 +8302,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-01T07:00:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14163"
     },
     "erdos-601": {
@@ -8420,7 +8420,7 @@
       "agentId": "auditor-agent-main",
       "auditCount": 4,
       "lastAudited": "2026-05-01T06:44:24Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "sections[3]-sections[9] line ranges shifted by 2-5 lines vs actual proofs/Proofs/Erdos616Problem.lean",
         "overview.proofStrategy claims 'only proved theorem is tau_one_iff_kernel' but coefficient_bounds and erdos_616_summary are also proved"
@@ -8437,13 +8437,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T06:24:41Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-619": {
       "agentId": "auditor-loop-1777618251",
       "auditCount": 3,
       "lastAudited": "2026-05-01T06:54:15Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-62": {
       "agentId": "auditor-cycle-20-batch",
@@ -8553,7 +8553,7 @@
       "agentId": "auditor-loop-1777752145",
       "auditCount": 4,
       "lastAudited": "2026-05-02T21:25:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "sorries claim 7 actual 1 (PR #14856 reduced 7→1 but meta.json not refreshed); lineCount 298→332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness — issue #14859",
         "Re-audit 2026-05-02 vs origin/main a0a5957: PR #14866 fixed only meta.json text; deeper Dissection placeholder + axiom inconsistency unresolved -> issue #14888"
@@ -8569,7 +8569,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-01T07:20:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "phantom axioms in narrative: assumptions field claims 7 former axioms (ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count) which are absent from the file; sections efs/ramsey/techniques/ramsey-theory and originalContributions/proofStrategy reference axioms that do not exist — issue #14136",
         "section line ranges drift: kwan-sudakov 135-152 cuts kwan_sudakov axiom (133-137); optimality 153-177 cuts signature_upper_bound axiom (151-155); related 234-256 covers Part XI content; main-result 257-261 contains only #check directives while erdos_636 theorem is at 244-248 — issue #14169"
@@ -8591,7 +8591,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-01T06:38:51Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-64": {
       "agentId": "auditor-cycle-20-batch",
@@ -8615,7 +8615,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T05:35:40Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-643": {
       "agentId": "auditor-cycle-20-batch",
@@ -8636,7 +8636,7 @@
         "Section main-theorem claims phantom axiomatized theorem; status overstated (Tier C narrative on Tier D content); see #14118"
       ],
       "lastAudited": "2026-05-01T05:10:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-646": {
       "agentId": "auditor-cycle-20-batch",
@@ -8663,7 +8663,7 @@
         "originalContributions claims Tong's theorem and Mahler's growth theorem as contributions when both are axiom declarations (axiom tong_theorem, axiom mahler_growth) — issue #14123 also covers this proof"
       ],
       "lastAudited": "2026-05-01T05:30:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-65": {
       "agentId": "auditor-cycle-20-batch",
@@ -8699,7 +8699,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T04:48:53Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-654": {
       "agentId": "auditor-cycle-20-batch",
@@ -8736,7 +8736,7 @@
       "agentId": "auditor-loop-1777609366",
       "auditCount": 3,
       "lastAudited": "2026-05-01T04:30:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "Section range drift (axiom/theorem swapped); 3 of 6 isConfiguration cases reduce to True (isoTrap1, isoTrap2, kite) — issue #14110"
       ]
@@ -8787,7 +8787,7 @@
       "agentId": "auditor-erdos-665-1777620272",
       "auditCount": 4,
       "lastAudited": "2026-05-01T07:25:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14171",
       "issues": [
         "Section line ranges drift 1-5 lines in middle sections (II/III/IV/V) — endpoints cross axiom/def boundaries; proofStrategy credits Shrikhande-Singhi embedding theorem and Cramér conjecture as axiomatized but they are docstring-only — issue #14171"
@@ -8797,7 +8797,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-01T04:19:26Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14107"
     },
     "erdos-667": {
@@ -8816,7 +8816,7 @@
       "agentId": "auditor-loop-2026-05-01",
       "auditCount": 3,
       "lastAudited": "2026-05-01T03:50:00Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "4 phantom identifiers (burr_grunbaum_sloane, trivial_upper_bound, limit_upper, optimal_configs_exist) in section summaries; section line ranges drift; missing summary section — issue #14091"
       ]
@@ -8828,7 +8828,7 @@
         "section line ranges drift across 3 sections (complex-variant, stronger-conjecture, multiplicative) — issue #14099"
       ],
       "lastAudited": "2026-05-01T05:00:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-670": {
       "agentId": "auditor-agent",
@@ -9022,7 +9022,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T02:44:34Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-699": {
       "agentId": "auditor-cycle-20-batch",
@@ -9064,7 +9064,7 @@
       "agentId": "auditor-loop-1777623480",
       "auditCount": 3,
       "lastAudited": "2026-05-01T01:43:40Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-703": {
       "agentId": "auditor-cycle-20-batch",
@@ -9076,7 +9076,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T01:34:17Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-705": {
       "agentId": "auditor-cycle-20-batch",
@@ -9088,7 +9088,7 @@
       "agentId": "auditor-agent",
       "auditCount": 3,
       "lastAudited": "2026-05-01T01:58:40Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-707": {
       "agentId": "auditor-cycle-20-batch",
@@ -9118,7 +9118,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T00:08:12Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-711": {
       "agentId": "auditor-loop",
@@ -9180,7 +9180,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T01:02:25Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-720": {
       "agentId": "auditor-cycle-20-batch",
@@ -9198,13 +9198,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-01T00:22:11Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-723": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-30T23:26:12Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-724": {
       "agentId": "auditor-cycle-20-batch",
@@ -9234,7 +9234,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-30T23:20:37Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-728-factorial-divisibility": {
       "agentId": "auditor-cycle-20-batch",
@@ -9246,7 +9246,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-30T23:12:03Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-73": {
       "agentId": "auditor-cycle-20-batch",
@@ -9258,7 +9258,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-30T23:13:10Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-731": {
       "agentId": "auditor-cycle-20-batch",
@@ -9270,25 +9270,25 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T10:50:13Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-733": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T10:53:55Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-734": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T10:02:11Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-735": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-30T23:11:59Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-736": {
       "agentId": "auditor-cycle-20-batch",
@@ -9312,7 +9312,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T09:51:48Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-74": {
       "agentId": "auditor-cycle-20-batch",
@@ -9336,19 +9336,19 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T09:28:29Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-743": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T09:54:09Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-744": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T09:44:53Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-745": {
       "agentId": "auditor-cycle-20-batch",
@@ -9424,7 +9424,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-29T09:22:48Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-756": {
       "auditCount": 5,
@@ -9460,7 +9460,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-29T08:57:16Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-761": {
       "agentId": "auditor-cycle-20-batch",
@@ -9478,19 +9478,19 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T06:03:20Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-764": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T09:09:14Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-765": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T08:51:04Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-766": {
       "agentId": "auditor-cycle-20-batch",
@@ -9502,7 +9502,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T06:01:58Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-768": {
       "agentId": "auditor-cycle-20-batch",
@@ -9533,7 +9533,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T04:45:25Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-772": {
       "agentId": "auditor-cycle-20-batch",
@@ -9557,7 +9557,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-29T06:43:11Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-776": {
       "agentId": "auditor-cycle-20-batch",
@@ -9569,7 +9569,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T04:26:21Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-778": {
       "agentId": "auditor-cycle-20-batch",
@@ -9617,31 +9617,31 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T01:25:10Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-785": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T04:01:09Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-786": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T04:07:17Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-787": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T01:23:07Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T01:18:52Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-789": {
       "agentId": "auditor-loop-2026-04-29-789",
@@ -9696,7 +9696,7 @@
       "agentId": "auditor-loop",
       "auditCount": 3,
       "lastAudited": "2026-04-29T00:48:37Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-797": {
       "agentId": "auditor-cycle-20-batch",
@@ -9744,13 +9744,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T00:33:24Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-803": {
       "agentId": "auditor-loop-2026-04-29",
       "auditCount": 3,
       "lastAudited": "2026-04-29T00:52:12Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-804": {
       "agentId": "auditor-cycle-20-batch",
@@ -9768,7 +9768,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-29T01:32:13Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-807": {
       "agentId": "auditor-cycle-20-batch",
@@ -9780,7 +9780,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-29T00:22:49Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-809": {
       "auditCount": 4,
@@ -9810,13 +9810,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-28T23:41:57Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-813": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-28T23:50:32Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-814": {
       "agentId": "auditor-cycle-20-batch",
@@ -9828,13 +9828,13 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-28T23:20:21Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-816": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-28T23:36:17Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-817": {
       "agentId": "auditor-cycle-20-batch",
@@ -9852,7 +9852,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-28T22:48:36Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-82": {
       "agentId": "auditor-cycle-20-batch",
@@ -9870,7 +9870,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-28T22:54:21Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-822": {
       "agentId": "auditor-cycle-20-batch",
@@ -9888,7 +9888,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-28T23:45:07Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-825": {
       "agentId": "auditor-cycle-20-batch",
@@ -12311,7 +12311,7 @@
         "Issue #15044: meta claims 1 axiom / 0 sorries but Lean source has 0 axioms / 2 sorries (padicNorm_poly_eval_lb L255, cofactor_uniform_bound L306). Status/badge should change from axiomatized/axiom to formalized/wip."
       ],
       "lastAudited": "2026-05-03T03:32:48Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "lovasz-local-lemma": {
       "auditCount": 1,
@@ -13659,7 +13659,7 @@
         "Coverage gap: originalContributions claims SU(3) Casimir, heat-kernel expansion, and N-ality classification but sections list only spans 398-950 (PART XXI/XXII/XXIV-XXVII at lines 970-1571 not covered). Section drift: section 6 su2-migdal-concrete endLine 950 vs actual 968. Issue #14835."
       ],
       "lastAudited": "2026-05-02T15:08:18Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "yang-mills-2d-oq-01": {
       "auditCount": 2,
@@ -13691,7 +13691,7 @@
         "axiomCount inconsistency with same-file precedent: yang-mills-lattice fixed to 12 (PR #14832), yang-mills-transfer-matrix still 1 — same Exploration.lean, same 11 :True structure-encoded fields. Issue #14840."
       ],
       "lastAudited": "2026-05-02T15:30:00Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "yang-mills-transfer-matrix-oq-01": {
       "auditCount": 2,
@@ -13732,7 +13732,7 @@
     "quadratic-reciprocity-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-05-01T11:14:29Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "badge=original for proof whose reduction lemmas are 1-line Mathlib wrappers; tracked in #14250 + PR #14251"
       ]
@@ -13940,7 +13940,7 @@
     "angle-trisection-oq-03-oq-02": {
       "auditCount": 4,
       "lastAudited": "2026-05-03T06:29:52Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
         "meta.meta.sorries/axiomCount fields missing; leanFile.lineCount 140→156, theoremCount 12→13"
       ],


### PR DESCRIPTION
## Fix

Sync `audit-tracker.json` with reality: **238 entries** were stuck at `result: issues-found` despite their corresponding fix-PRs already being merged and `Gallery integrity:` issues closed.

## Evidence

Searched all 141 entries with `result: issues-found` + non-empty `issues` array, plus 99 placeholder entries (no `issues` array). For each, verified via `gh issue list` and `gh pr list`:
- `Gallery integrity: <slug>` issue is CLOSED, OR
- A `fix(<slug>): ...` PR is MERGED.

**Before**: 141 entries with non-empty issues + 99 placeholders = 240 stale.
**After**: 2 entries remain (open in-flight work — see below).

## Skips (preserved)

- `erdos-1201` — open PRs #15091, #15124
- `cantor-diagonalization-oq-01-oq-02` — open PR #15127

## Why this matters

Per `feedback_auditor_find_targets_stuck.md`: the auditor's `find-targets.ts` surfaces the same id every cycle when the tracker doesn't reflect the merged fix. This sweep unblocks ~238 ids for re-audit.

## Verification

```bash
# Pure metadata change, JSON round-trip identity preserved
python3 -c "import json; d=json.load(open('src/data/proofs/audit-tracker.json')); ..."
# Final tally: 1707 clean / 532 issues-fixed / 2 issues-found
```

---
Automated fix by lean-mechanic agent.