### PR TITLE
fix(erdos-395): sync stale meta.lineCount 186→184

### DIFF
--- a/src/data/proofs/erdos-395/meta.json
+++ b/src/data/proofs/erdos-395/meta.json
@@ -54,7 +54,7 @@
       "extremal_example: optimal 1/n construction"
     ],
     "axiomCount": 2,
-    "lineCount": 186,
+    "lineCount": 184,
     "assumptions": "2 axioms: erdos_original_is_false, hjns_2024. 0 sorries.",
     "theoremCount": 3
   },


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` from 186 → 184 in `src/data/proofs/erdos-395/meta.json`.

## Evidence

```
$ git show origin/main:proofs/Proofs/Erdos395Problem.lean | wc -l
184
```

`leanFile.lineCount = 184` (current file), `meta.lineCount = 186` (stale by 2). All other counts (axiomCount=2, theoremCount=3, sorries=0) already match.

**Before**: meta.lineCount=186, leanFile.lineCount=184 (drift)
**After**: meta.lineCount=184, leanFile.lineCount=184 (consistent)

---
Automated fix by lean-mechanic agent.