### PR TITLE
fix(cantor-diagonalization-oq-01-oq-02): correct axiomCount 6→7

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13963,8 +13963,10 @@
     "cantor-diagonalization-oq-01-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-05-03T08:07:53Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "axiomCount claimed 6, actual 7 — corrected to 7"
+      ]
     },
     "abel-ruffini-oq-09": {
       "auditCount": 1,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -19,8 +19,8 @@
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": null,
-    "axiomCount": 6,
-    "assumptions": "6 axioms: levy_solovay_inaccessible_ch/not_ch (Lévy-Solovay 1967: small forcing preserves inaccessibility), levy_solovay_measurable_ch/not_ch (Lévy-Solovay: small forcing preserves measurability), mm_consistent (Foreman-Magidor-Shelah 1988: MM consistent with ZFC+supercompact), ma_consistent (Martin-Solovay: MA consistent with ZFC), ultimate_l_implies_ch_consistent (Woodin program: open).",
+    "axiomCount": 7,
+    "assumptions": "7 axioms: levy_solovay_inaccessible_ch (Lévy-Solovay 1967: inaccessible + CH consistent), levy_solovay_inaccessible_not_ch (Lévy-Solovay 1967: inaccessible + ¬CH consistent), levy_solovay_measurable_ch (Lévy-Solovay: measurable + CH consistent), levy_solovay_measurable_not_ch (Lévy-Solovay: measurable + ¬CH consistent), mm_consistent (Foreman-Magidor-Shelah 1988: MM consistent with ZFC+supercompact), ma_consistent (Martin-Solovay: MA consistent with ZFC), ultimate_l_implies_ch_consistent (Woodin program: open).",
     "lineCount": 260,
     "mathlib_version": "4.26.0",
     "theoremCount": 11
@@ -85,7 +85,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the large cardinal landscape around CH: standard large cardinals leave CH undecided (Lévy-Solovay, axiomatized), while forcing axioms (MM, MA) decide ¬CH (proved). 0 sorries, 6 axioms, 11 theorems.",
+    "summary": "Formalizes the large cardinal landscape around CH: standard large cardinals leave CH undecided (Lévy-Solovay, axiomatized), while forcing axioms (MM, MA) decide ¬CH (proved). 0 sorries, 7 axioms, 11 theorems.",
     "implications": "The formalization clarifies the precise boundary: set-theoretic 'size' axioms (large cardinals) don't decide CH, but 'saturation' axioms (forcing axioms) do.",
     "openQuestions": [
       "Does the Woodin Ultimate-L program succeed in settling CH canonically as true?",
@@ -105,7 +105,7 @@
     "opens": ["Cardinal", "ContinuumHypothesis"],
     "namespace": "CantorDiagOQ01OQ02",
     "lineCount": 260,
-    "axiomCount": 6,
+    "axiomCount": 7,
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/CantorDiagonalizationOQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Correct the axiom count in `cantor-diagonalization-oq-01-oq-02/meta.json` from 6 to 7.

## Evidence

**Before**: `meta.axiomCount: 6`, `leanFile.axiomCount: 6` — assumptions text used slash notation (`inaccessible_ch/not_ch`) to group 4 axioms as 2, yielding a count of 5+1=6.

**After**: `meta.axiomCount: 7`, `leanFile.axiomCount: 7` — all 7 axiom declarations listed individually:
1. `levy_solovay_inaccessible_ch`
2. `levy_solovay_inaccessible_not_ch`
3. `levy_solovay_measurable_ch`
4. `levy_solovay_measurable_not_ch`
5. `mm_consistent`
6. `ma_consistent`
7. `ultimate_l_implies_ch_consistent`

Also updated `conclusion.summary` and expanded `assumptions` text. Supersedes conflicting PR #15127.

---
Automated fix by lean-mechanic agent.