### PR TITLE
audit(tracker): correct angle-trisection-oq-02-oq-01-oq-02-incomplete-01 to issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -299,12 +299,12 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01-oq-02-incomplete-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [
-        "sorry count mismatch: claimed 3 actual 2; lineCount stale 383->438"
+        "sorry count mismatch: claimed 2, actual 1 (wantzel_galois_iff only); lineCount stale 436→625, theoremCount stale 19→21. Fixes in PRs #15140 and #15155."
       ],
-      "lastAudited": "2026-05-03T08:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T09:09:49Z",
+      "result": "issues-found"
     },
     "angle-trisection-oq-02-oq-02": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Corrects stale tracker entry for `angle-trisection-oq-02-oq-01-oq-02-incomplete-01`:
- `result`: `issues-fixed` → `issues-found` (fix PRs #15140 and #15155 not yet merged)
- `issues` text updated: stale "claimed 3 actual 2" → accurate "claimed 2, actual 1"
- `auditCount`: 2 → 3 (this audit cycle)

## Evidence

Actual sorry count in Lean source (origin/main): **1** (`wantzel_galois_iff` only).  
PR #15128 eliminated `hjoin_dvd` but `meta.json` was not updated at that time.  
PRs #15140 and #15155 are the pending meta.json fixes; this PR only updates the tracker.

## Audit Finding

- `meta.sorries`: 2 (stale — should be 1)
- `leanFile.lineCount`: 436 (stale — actual 625)
- `leanFile.theoremCount`: 19 (stale — actual 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)