### PR TITLE
fix(meta): sync stale lineCount for 13 gallery entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
@@ -22,7 +22,7 @@
     "sorries": 6,
     "axiomCount": 2,
     "theoremCount": 15,
-    "lineCount": 566,
+    "lineCount": 565,
     "defCount": 4,
     "assumptions": "2 axioms: (1) wirtinger_ac — Wirtinger inequality for Lipschitz/AC 2π-periodic functions with zero mean: ∫f² ≤ ∫(f')²; (2) exists_lip_nice_reparam — arc-length reparametrization for Lipschitz curves with positive speed a.e., giving constant-speed and zero-mean reparametrization. 6 technical sorries remain: lip_x/lip_y (MVT bound for periodic C¹ → Lipschitz), hdx_int/hdy_int (derivative-squared integrability from LipschitzWith), harea_zero (area=0 from circumference=0), hf_int (integrability of xy'−yx' for Lipschitz curves).",
     "originalContributions": [
@@ -150,7 +150,7 @@
       "IsoperimetricOQ"
     ],
     "namespace": "LipschitzIsoperimetric",
-    "lineCount": 566,
+    "lineCount": 565,
     "axiomCount": 2,
     "theoremCount": 15,
     "lemmaCount": 1,

--- a/src/data/proofs/binary-gcd-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-05-01",
     "axiomCount": 0,
-    "lineCount": 135,
+    "lineCount": 134,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -201,7 +201,7 @@
       "BinaryGcd"
     ],
     "namespace": "BinaryGcdOQ02",
-    "lineCount": 135,
+    "lineCount": 134,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-1056-oq-01/meta.json
+++ b/src/data/proofs/erdos-1056-oq-01/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1056",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 227,
+    "lineCount": 226,
     "theoremCount": 29,
     "assumptions": "None. All 29 theorems are fully proved. Computational verification via native_decide.",
     "mathlibDependencies": [
@@ -128,7 +128,7 @@
     ],
     "opens": ["Finset"],
     "namespace": "Erdos1056OQ01",
-    "lineCount": 227,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 29,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 1,
     "theoremCount": 54,
     "assumptions": "1 axiom: erdos_1065a (Set.Infinite for primes of the form 2^k·q + 1). erdos_1065b proved from erdos_1065a via Form A ⊂ Form B inclusion.",
-    "lineCount": 564,
+    "lineCount": 563,
     "relatedProblems": [
       {
         "id": "erdos-1057",
@@ -241,7 +241,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 564,
+    "lineCount": 563,
     "structureCount": 0,
     "axiomCount": 1,
     "theoremCount": 54,

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -28,7 +28,7 @@
       "extremal combinatorics",
       "linear programming relaxation"
     ],
-    "lineCount": 274,
+    "lineCount": 275,
     "assumptions": "1 axiom: IsPlanar. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4
@@ -137,7 +137,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 274,
+    "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -70,7 +70,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 3,
     "theoremCount": 7,
-    "lineCount": 180,
+    "lineCount": 179,
     "assumptions": "3 axioms: prime_ap_pnt_upper (PNT upper bound), green_tao (Green-Tao 2008), erdos_200 (open conjecture). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -171,7 +171,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 180,
+    "lineCount": 179,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-275/meta.json
+++ b/src/data/proofs/erdos-275/meta.json
@@ -45,7 +45,7 @@
       "erdos_275 summary theorem combining main result and tightness"
     ],
     "axiomCount": 2,
-    "lineCount": 172,
+    "lineCount": 171,
     "assumptions": "2 axioms: erdos_275_theorem, not_covered_2r_minus_1. 0 sorries.",
     "theoremCount": 1
   },
@@ -182,7 +182,7 @@
     ],
     "opens": [],
     "namespace": "Erdos275",
-    "lineCount": 172,
+    "lineCount": 171,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -21,7 +21,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "theoremCount": 10,
-    "lineCount": 165,
+    "lineCount": 164,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10
@@ -121,7 +121,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 165,
+    "lineCount": 164,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -41,7 +41,7 @@
       "IsLocallySolvable defined via Hörmander duality; hormander_duality proved trivially (5→3 axioms)",
       "Consolidated dencker_weight_exists + weight_implies_estimate → dencker_main: two-step Dencker chain expressed as single axiom (3→2 axioms)"
     ],
-    "lineCount": 368,
+    "lineCount": 367,
     "assumptions": [
       "HasAPrioriEstimate: Sobolev a priori estimates (needs Sobolev spaces)",
       "dencker_main: Dencker's theorem: ConditionPsi → a priori estimates for P* (microlocal analysis)"
@@ -124,7 +124,7 @@
   ],
   "leanFile": {
     "namespace": "Hilbert20OQ01OQ03",
-    "lineCount": 368,
+    "lineCount": 367,
     "axiomCount": 2,
     "theoremCount": 9,
     "definitionCount": 7,

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
@@ -41,7 +41,7 @@
     "assumptions": "1 new axiom: fano_mi_converse_bound (combines Fano inequality + memoryless channel MI subadditivity: log M ≤ n·C + 1 + P_e·log M). Plus axioms inherited from ShannonChannelCoding.lean via import.",
     "dateAdded": "2026-05-03",
     "axiomCount": 1,
-    "lineCount": 163,
+    "lineCount": 162,
     "prerequisites": [
       "Discrete memoryless channels and channel capacity (ShannonChannelCoding.lean)",
       "Block codes and rate definition",
@@ -156,7 +156,7 @@
   ],
   "leanFile": {
     "axiomCount": 1,
-    "lineCount": 163,
+    "lineCount": 162,
     "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 1,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 12,
     "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean (shared file): Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation.",
-    "lineCount": 28075,
+    "lineCount": 28074,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_pos",
@@ -216,7 +216,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28075,
+    "lineCount": 28074,
     "structureCount": 365,
     "axiomCount": 0,
     "theoremCount": 1787,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 12,
     "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean: Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation. Additionally, the file contains approximately 41 structural placeholder theorems beyond line 8000 of the form `theorem X (...(h:P)...): P := h` — these state their hypothesis as conclusion and establish no new mathematical content; they are named after significant physics results (including Creutz confinement, continuum mass gap, and Witten index) to serve as organizational anchors for future formalization.",
-    "lineCount": 28075,
+    "lineCount": 28074,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_nonneg",
@@ -147,7 +147,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28075,
+    "lineCount": 28074,
     "structureCount": 365,
     "axiomCount": 0,
     "theoremCount": 1787,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 12,
     "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean: Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation.",
-    "lineCount": 28075,
+    "lineCount": 28074,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_pos",
@@ -137,7 +137,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28075,
+    "lineCount": 28074,
     "structureCount": 365,
     "axiomCount": 0,
     "theoremCount": 1787,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` to match actual Lean source file lengths.

## Evidence

Each entry's Lean source has drifted from the cached count by 1–2 lines (one entry by 0). Both `meta.lineCount` (in the `meta.*` sub-block) and `leanFile.lineCount` (in the `leanFile.*` sub-block) were updated to the same target value.

| Slug | Was | Now | File |
|---|---|---|---|
| area-of-circle-oq-01-oq-03-oq-02 | 566 | 565 | `Proofs/AreaOfCircleOQ01OQ03OQ02.lean` |
| binary-gcd-oq-02 | 135 | 134 | `Proofs/BinaryGcdOQ02.lean` |
| erdos-1056-oq-01 | 227 | 226 | `Proofs/Erdos1056OQ01.lean` |
| erdos-1065 | 564 | 563 | `Proofs/Erdos1065.lean` |
| erdos-167 | 274 | 275 | `Proofs/Erdos167.lean` |
| erdos-200 | 180 | 179 | `Proofs/Erdos200.lean` |
| erdos-275 | 172 | 171 | `Proofs/Erdos275.lean` |
| erdos-661 | 165 | 164 | `Proofs/Erdos661.lean` |
| hilbert-20-oq-01-oq-03 | 368 | 367 | `Proofs/Hilbert20OQ01OQ03.lean` |
| shannon-channel-coding-oq-02-oq-03 | 163 | 162 | `Proofs/ShannonChannelCodingOQ02OQ03.lean` |
| yang-mills-2d | 28075 | 28074 | `Proofs/YangMills/Exploration.lean` |
| yang-mills-lattice | 28075 | 28074 | (same file) |
| yang-mills-transfer-matrix | 28075 | 28074 | (same file) |

Verified each meta.json still parses as valid JSON. Used line-level regex (not `json.dump`) to preserve original formatting.

Excluded entries already addressed by in-flight PRs: angle-trisection-oq-02-oq-01-oq-02-incomplete-01 (#15140/#15155), erdos-1201 (#15124), erdos-395 (#15152).

---
Automated fix by lean-mechanic agent.