### PR TITLE
fix(meta): sync ballot-problem-oq-03-oq-01-oq-02 after Helpers refactor

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -27,8 +27,8 @@
     "axiomCount": 0,
     "assumptions": "1 open sorry in GNW infrastructure (BallotProblemOQ03OQ01OQ02Helpers.lean): gnwProb_key — the GNW 1979 probabilistic identity for ≥10-row, ≥10-col, non-rectangular shapes (hard combinatorial identity). The supporting lemmas gnwProb_sum_corners, strictHookCells_card, strictHookCells_nonempty, and strictHookCells_hookLen_lt were proved in PR #14960. hook_walk_identity_gnw (the dispatcher in the gallery face) calls gnwProb_key and is otherwise complete. hookProd_ratio_formula is sorry-free. Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row through 9-row, ≤9-col (transpose duality), all rectangles.",
     "lineCount": 14235,
-    "theoremCount": 484,
-    "definitionCount": 14,
+    "theoremCount": 489,
+    "definitionCount": 24,
     "originalContributions": [
       "hookLength: hook length at cell (i,j) = armLen + legLen + 1 using YoungDiagram.rowLen and colLen",
       "hookLength_pos: hook lengths are always positive (arm + leg + 1 ≥ 1) — unconditional",
@@ -88,8 +88,7 @@
   },
   "leanFile": {
     "imports": [
-      "Proofs.BallotProblemOQ03OQ02",
-      "Proofs.BallotProblemOQ03OQ03"
+      "Proofs.BallotProblemOQ03OQ01OQ02Helpers"
     ],
     "opens": [
       "YoungDiagram",
@@ -97,12 +96,12 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 13837,
+    "lineCount": 398,
     "axiomCount": 0,
-    "sorries": 1,
-    "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
-    "theoremCount": 482,
-    "definitionCount": 22
+    "sorries": 0,
+    "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
+    "theoremCount": 16,
+    "definitionCount": 1
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

After PR #14886 modularized \`BallotProblemOQ03OQ01OQ02\` into a 398-line main file + 13837-line Helpers file, the \`leanFile\` block in \`meta.json\` was left pointing to the Helpers file instead of the main file.

## Evidence

**Before**: \`leanFile.path = BallotProblemOQ03OQ01OQ02Helpers.lean\`, \`leanFile.lineCount = 13837\`, \`leanFile.sorries = 1\`, \`leanFile.theoremCount = 482\`

**After**: \`leanFile.path = BallotProblemOQ03OQ01OQ02.lean\`, \`leanFile.lineCount = 398\`, \`leanFile.sorries = 0\`, \`leanFile.theoremCount = 16\`

Also corrected combined totals:
- \`meta.theoremCount\`: 484 → 489 (16 main + 473 helpers)
- \`meta.definitionCount\`: 14 → 24 (1 main + 23 helpers)

Invariants preserved:
- \`meta.lineCount = 14235\` (398+13837) ✓
- \`meta.sorries = 1\` (from Helpers file) ✓
- \`additionalFiles\` already lists Helpers ✓

---
Automated fix by lean-mechanic agent.