### PR TITLE
fix(audit): shannon-source-coding-oq-03 badge wip + sync stale counts

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -16,7 +16,7 @@
       "coding-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 1,
     "mathlibDependencies": [
       {
@@ -45,7 +45,7 @@
     "assumptions": [],
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
-    "lineCount": 260,
+    "lineCount": 355,
     "prerequisites": [
       "Shannon entropy H(X) = -∑ p(x) log p(x)",
       "Chebyshev's inequality for finite probability spaces",
@@ -143,9 +143,9 @@
     "imports": ["Mathlib"],
     "opens": ["Real", "Finset", "BigOperators"],
     "namespace": "AEPFormalization",
-    "lineCount": 260,
+    "lineCount": 355,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 6,
     "path": "Proofs/ShannonSourceCodingOQ03.lean",
     "sorries": 1


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `shannon-source-coding-oq-03`

### Issues Found

| Field | Was | Should Be | Why |
|-------|-----|-----------|-----|
| `meta.badge` | `verified` | `wip` | 1 sorry exists; `verified` badge requires 0 sorries |
| `meta.lineCount` | 260 | 355 | File grew from 260 to 355 lines |
| `leanFile.lineCount` | 260 | 355 | Same — stale count |
| `leanFile.theoremCount` | 11 | 12 | Off by 1 — file has 12 theorems/lemmas |

### Context

PR #15161 is currently open and claims to eliminate the last sorry (`empEnt_variance`). Once that PR merges, the badge should change from `wip` → `original` (0 sorries, 0 axioms).

---
Discovered during gallery integrity audit.