### PR TITLE
fix(angle-trisection-incomplete-01): sync leanFile.* + correct lineCount

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 21,
-    "lineCount": 625,
+    "lineCount": 618,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 436,
+    "lineCount": 618,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 2,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Reconciles `meta.lineCount` and `leanFile.*` in `angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json` with the actual on-disk Lean file (618 lines, 1 sorry, 21 theorems+lemmas).

## Evidence

- PR #15143 updated `meta.{sorries,theoremCount}` after #15128 eliminated the `hjoin_dvd` sorry, but missed the `leanFile.*` block (still claiming 436 lines / 19 theorems / 2 sorries from before #15067).
- PR #15143 also set `meta.lineCount = 625` while the actual file is 618 lines (`wc -l` confirms).
- Audit-tracker entry for this proof flags exactly this drift: `sorry count mismatch: claimed 2, actual 1; lineCount stale 436→625, theoremCount stale 19→21`.

**Before** (after #15143):
- `meta.lineCount`: 625 (file is 618)
- `leanFile.lineCount`: 436
- `leanFile.theoremCount`: 19
- `leanFile.sorries`: 2
- top-level `sorries`: 2

**After**:
- `meta.lineCount`: 618
- `leanFile.lineCount`: 618
- `leanFile.theoremCount`: 21
- `leanFile.sorries`: 1
- top-level `sorries`: 1

Counts verified by `wc -l` and a comment-stripping regex over `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean`.

Supersedes the older, conflicting fix branch `fix/mechanic-angle-trisection-incomplete01-sorry-sync` (PR #15140), which was opened before #15143 reconciled the inner `meta.*` block and now has stale counts (it would set lineCount to 625 instead of 618).

---
Automated fix by lean-mechanic agent.