### PR TITLE
chore: record audit results for 4 proofs (2026-05-03 session)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13970,30 +13970,6 @@
     },
     "abel-ruffini-oq-09": {
       "auditCount": 1,
-      "lastAudited": "2026-05-03T08:10:27Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1006-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T08:10:28Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1210": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T08:10:29Z",
-      "result": "clean",
-      "issues": []
-    },
-    "konigsberg-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T08:10:30Z",
-      "result": "clean",
-      "issues": []
-    },
-    "abel-ruffini-oq-09": {
-      "auditCount": 1,
       "lastAudited": "2026-05-03T07:39:19Z",
       "result": "clean",
       "issues": []
@@ -14020,6 +13996,30 @@
       "auditCount": 1,
       "lastAudited": "2026-05-03T07:41:59Z",
       "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T09:30:19Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-01-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T09:30:20Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T09:26:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-source-coding-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T09:34:34Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },


### PR DESCRIPTION
## Audit Tracker Update

Records results from today's gallery integrity audit session.

| Proof | Result | Notes |
|-------|--------|-------|
| `angle-trisection-oq-05-oq-02` | clean | Tier A, 19 theorems, 0 sorries, 0 axioms, badge original ✓ |
| `ballot-problem-oq-01-oq-02-oq-01-oq-02` | clean | Tier A, 8 theorems, 0 sorries, 0 axioms, badge original ✓ |
| `buffons-needle-oq-02-oq-03` | clean | Tier C, axiomatized, 2 axioms, badge axiom ✓ (True stub present but status not verified) |
| `shannon-source-coding-oq-03` | issues-fixed | badge verified→wip (1 sorry), stale lineCount 260→355, theoremCount 11→12; fixed in PR #15164 |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)