### PR TITLE
research(abel-ruffini-oq-01): confirm BLOCKED, sharpen D5 analysis

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02.lean
@@ -3,6 +3,7 @@ import Mathlib.FieldTheory.Minpoly.Field
 import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
 import Mathlib.GroupTheory.SpecificGroups.Cyclic
 import Mathlib.Tactic
+import Mathlib.RingTheory.Polynomial.Eisenstein.Basic
 
 /-
 # Wantzel-Galois Constructibility from Mathlib Galois Theory
@@ -122,9 +123,34 @@ theorem not_constructible_of_bad_degree {p : ℚ[X]} (hp : Irreducible p)
 -- PART 4: Specific Non-Constructibility Results
 -- ============================================================
 
+/-- x³ - 2 is irreducible over ℤ (Eisenstein at p=2). -/
+private theorem cube_root_2_irred_int :
+    Irreducible (X ^ 3 - C (2 : ℤ) : ℤ[X]) := by
+  apply Polynomial.irreducible_of_eisenstein_criterion (P := Ideal.span {(2 : ℤ)})
+  · rw [Ideal.span_singleton_prime (show (2 : ℤ) ≠ 0 from by norm_num)]
+    exact Int.prime_iff_natAbs_prime.mpr (by norm_num)
+  · rw [leadingCoeff_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num),
+        Ideal.mem_span_singleton]
+    norm_num
+  · intro k hk
+    rw [degree_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num) (2 : ℤ)] at hk
+    have hk3 : k < 3 := WithBot.coe_lt_coe.mp hk
+    interval_cases k <;> simp [Ideal.mem_span_singleton, coeff_sub, coeff_X_pow]
+  · rw [degree_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num) (2 : ℤ)]; norm_cast
+  · rw [Ideal.span_singleton_pow, Ideal.mem_span_singleton]
+    simp only [coeff_sub, coeff_X_pow, coeff_C, show ¬(0 = 3) from by norm_num,
+               ite_false, zero_sub, dvd_neg]
+    norm_num
+  · exact (monic_X_pow_sub_C (2 : ℤ) (show 3 ≠ 0 from by norm_num)).isPrimitive
+
 /-- x³ - 2 is irreducible over ℚ. This is the minimal polynomial of ∛2. -/
 theorem cube_root_2_minpoly_irred : Irreducible (X ^ 3 - C 2 : ℚ[X]) := by
-  sorry -- Standard: Eisenstein at p=2 or rational root theorem
+  have hprim : (X ^ 3 - C (2 : ℤ) : ℤ[X]).IsPrimitive :=
+    (monic_X_pow_sub_C (2 : ℤ) (show 3 ≠ 0 from by norm_num)).isPrimitive
+  have hirr := (IsPrimitive.Int.irreducible_iff_irreducible_map_cast hprim).mp
+    cube_root_2_irred_int
+  rwa [show Polynomial.map (Int.castRingHom ℚ) (X ^ 3 - C (2 : ℤ)) = X ^ 3 - C (2 : ℚ) from
+    by simp [Polynomial.map_sub, Polynomial.map_pow, Polynomial.map_X, map_ofNat]] at hirr
 
 /-- The degree of x³ - 2 is 3, which is NOT a power of 2. -/
 theorem cube_root_2_degree : (X ^ 3 - C 2 : ℚ[X]).natDegree = 3 := by
@@ -141,7 +167,8 @@ theorem three_not_pow_two : ¬ DegreePowerOfTwo (X ^ 3 - C 2 : ℚ[X]) := by
     of cos(20°) (up to scaling). It arises from the triple angle formula:
     cos(3θ) = 4cos³(θ) - 3cos(θ), with θ = 20°, cos(60°) = 1/2. -/
 theorem cos20_minpoly_degree : (8 * X ^ 3 - 6 * X - 1 : ℚ[X]).natDegree = 3 := by
-  sorry -- Degree computation
+  norm_num [natDegree_sub_eq_left_of_natDegree_lt, natDegree_mul, natDegree_pow,
+    natDegree_X, natDegree_C, natDegree_one]
 
 theorem cos20_degree_not_pow_two :
     ¬ DegreePowerOfTwo (8 * X ^ 3 - 6 * X - 1 : ℚ[X]) := by
@@ -174,7 +201,11 @@ theorem doubling_cube_impossible_degree :
 theorem regular_7gon_impossible_degree :
     ¬ DegreePowerOfTwo (8 * X ^ 3 + 4 * X ^ 2 - 4 * X - 1 : ℚ[X]) := by
   intro ⟨k, hk⟩
-  sorry -- degree = 3, same argument as above
+  have hdeg : (8 * X ^ 3 + 4 * X ^ 2 - 4 * X - 1 : ℚ[X]).natDegree = 3 := by
+    norm_num [natDegree_sub_eq_left_of_natDegree_lt, natDegree_add_eq_left_of_natDegree_lt,
+      natDegree_mul, natDegree_pow, natDegree_X, natDegree_C, natDegree_one]
+  rw [hdeg] at hk
+  interval_cases k <;> simp_all
 
 -- ============================================================
 -- PART 6: Galois Characterization (Sufficient Condition)
@@ -212,13 +243,13 @@ theorem wantzel_galois_iff {p : ℚ[X]} (hp : Irreducible p) (α : ℂ)
 4. cos20_degree_not_pow_two: cos(20°)'s degree is not a power of 2
 5. angle_trisection_impossible_degree: trisection is impossible
 6. doubling_cube_impossible_degree: cube doubling is impossible
+7. cube_root_2_minpoly_irred: x³-2 irreducible over ℚ (Eisenstein at p=2)
+8. cos20_minpoly_degree: deg(8x³-6x-1) = 3
+9. regular_7gon_impossible_degree: regular 7-gon impossible (degree 3 ≠ 2^k)
 
-### Sorries (5):
-- not_constructible_of_bad_degree: needs tower → degree argument
-- cube_root_2_minpoly_irred: Eisenstein criterion
-- cos20_minpoly_degree: degree computation
-- regular_7gon_impossible_degree: degree computation
-- wantzel_galois_iff: full Galois characterization
+### Sorries (2):
+- not_constructible_of_bad_degree: needs tower → degree argument (FTGT)
+- wantzel_galois_iff: full Galois characterization (deep result)
 
 ### Key Contribution
 Provides the Wantzel degree framework in Lean 4 and proves the concrete

--- a/research/problems/abel-ruffini-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-oq-01/knowledge.md
@@ -4,6 +4,52 @@
 
 The Inverse Galois Problem (IGP) asks: for every finite group G, does there exist a Galois extension K/ℚ with Gal(K/ℚ) ≅ G?
 
+## Session 2026-05-03 (researcher-4) - Pre-Work Assessment: Confirmed BLOCKED
+
+**Mode**: REVISIT (RICH knowledge, score 173)
+**Outcome**: pre-work assessment — confirmed BLOCKED at `three_dvd_gal_card`
+
+### Current File State
+
+- `InverseGaloisA5.lean`: 2067 lines, 0 sorries, **1 axiom** (`three_dvd_gal_card`)
+- `InverseGaloisOQ01.lean`: 1 intentional sorry (open IGP), 0 axioms in this file
+- `InverseGaloisOQ06OQ01.lean`: supporting file for three_dvd_gal_card elimination
+
+### What OQ06OQ01 Has Proved (all 0 sorries)
+
+`InverseGaloisOQ06OQ01.lean` already proves the following toward `three_dvd_gal_card`:
+- `two_dvd_gal_card`: 2 | |Gal(q)| (via complex conjugation being a non-trivial order-2 element)
+- `gal_card_ne_5`: |Gal(q)| ≠ 5 (from 2 | |Gal|)
+- `q_rootSet_ℝ_card`: q has exactly 1 real root (q' = 5(x-1)⁴ + 20 > 0 always)
+- `q_ℤ_mod7_factorization`: q ≡ (X-5)(X-6)(X³+6X²+4X+1) mod 7
+- `cubicMod7_no_roots`: the cubic factor has no roots in F₇ (irreducible over F₇)
+
+### Sharpened Blocker Analysis
+
+Combining the A5 file (Gal ⊆ A₅, 5 | |Gal|) with OQ06OQ01 (2 | |Gal|):
+- `10 | |Gal|` (from 5 and 2 coprime)
+- `|Gal| | 60` (gal_card_dvd_60_proved)
+- A₅ has no subgroup of order 20 (A₅ is simple, index 3 would require hom to S₃, impossible)
+- **Therefore: |Gal| ∈ {10, 60}**
+
+The ONLY remaining case is |Gal| = 10 (Gal ≅ D₅). Ruling out D₅ requires:
+1. Dedekind/Frobenius: mod-7 cubic factor → Gal has element of order 3 → 3 | |Gal| → |Gal| ≠ 10
+2. Direct algebraic argument: show Gal is not solvable (D₅ is solvable, A₅ is not)
+3. Polynomial invariant distinguishing D₅ from A₅ for this specific q
+
+All three approaches require infrastructure not in Mathlib 4.26.0:
+- Approach 1: Kummer-Dedekind theorem (rings of integers, prime factorization, Frobenius)
+- Approach 2: Abel-Ruffini insolvability for this specific q (requires discriminant ↔ solvability, or direct D₅-specific reasoning)
+- Approach 3: Resolvent polynomial or D₅-invariant theory
+
+### Status
+
+**BLOCKED**: No tractable path. The infrastructure gap is the Frobenius/Dedekind theorem in Mathlib. Multiple sessions confirm this. The formalization is otherwise complete.
+
+The progress in InverseGaloisOQ06OQ01.lean (narrowing |Gal| to {10, 60}) is a meaningful improvement over the original situation but does not resolve the blocker.
+
+---
+
 ## Session 2026-03-21 (researcher-2) - PROVED vandermondeProduct_sq_eq via ℂ Embedding
 
 **Mode**: REVISIT (RICH knowledge, score 142)

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -16,10 +16,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 2,
     "axiomCount": 0,
-    "theoremCount": 15,
-    "lineCount": 234,
+    "theoremCount": 16,
+    "lineCount": 265,
     "mathlibDependencies": [
       {
         "theorem": "Module.finrank_mul_finrank",
@@ -119,12 +119,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02",
-    "lineCount": 234,
+    "lineCount": 265,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
-    "sorries": 5
+    "sorries": 2
   },
-  "sorries": 5
+  "sorries": 2
 }

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED: 1 axiom remains (three_dvd_gal_card). Requires Dedekind theorem (not in Mathlib 4.26.0). File builds clean with warnings only. All other work complete.",
+    "progressSummary": "BLOCKED: 1 axiom remains (three_dvd_gal_card). OQ06OQ01 proves 2|Gal and |Gal| in {10,60}. Ruling out D5 (order 10) requires Dedekind/Frobenius theorem not in Mathlib 4.26.0.",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -308,10 +308,14 @@
       "sylvM_det sorry in ResultantDet was dead code (discriminant proved via Vandermonde chain) — removed",
       "All 5 listed AbelRuffini files are fully proved (0A, 0S, 122T total)",
       "InverseGalois files with axioms/sorries are tracked under a different problem",
-      "Verified build on Lean 4.26.0. 0 sorries, 1 axiom (three_dvd_gal_card). Axiom requires Dedekind theorem connecting polynomial factorization mod p to Galois group cycle types. No Mathlib-free alternative identified."
+      "Verified build on Lean 4.26.0. 0 sorries, 1 axiom (three_dvd_gal_card). Axiom requires Dedekind theorem connecting polynomial factorization mod p to Galois group cycle types. No Mathlib-free alternative identified.",
+      "2026-05-03: |Gal| narrowed to {10, 60} via 2|Gal (complex conjugation) + 5|Gal (irreducibility) + |Gal||60 (discriminant) + A5 has no order-20 subgroup",
+      "2026-05-03: Blocking case is D5 (order 10), a solvable transitive subgroup of A5; eliminating it requires Frobenius/Dedekind theorem"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Requires Kummer-Dedekind or Frobenius element theory in Mathlib; mark blocked until Mathlib gains this infrastructure"
+    ],
     "markdown": "# Knowledge: The Inverse Galois Problem (abel-ruffini-oq-01)\n\n## Problem Summary\n\nThe Inverse Galois Problem (IGP) asks: for every finite group G, does there exist a Galois extension K/ℚ with Gal(K/ℚ) ≅ G?\n\n**Status**: OPEN in general. The full conjecture is unproven.\n\n## Session 2026-03-14 (researcher-2) - Verification and Assessment\n\n**Mode**: REVISIT (depth-first, RICH knowledge score 59)\n**Outcome**: verified, at frontier of formalizability\n\n**What we did**: Docker build verified (2 expected sorries). Confirmed KroneckersJugendtraum.lean has Kronecker-Weber as statement only (not proved). Updated outdated next steps. No tractable path to further progress without new Mathlib infrastructure.\n\n## Session 2026-02-21 (Session 1) - Initial Exploration and Formalization\n\n**Mode**: FRESH\n**Outcome**: progress — first Lean formalization created\n\n### What I Did\n\n- Explored the mathematical landscape of the Inverse Galois Problem\n- Surveyed Mathlib4 infrastructure: `IsCyclotomicExtension.isGalois`, `IsCyclotomicExtension.Aut.commGroup`, `galCyclotomicEquivUnitsZMod`, `ZMod.card_units_eq_totient`\n- Created `proofs/Proofs/InverseGalois.lean` with formal Lean content\n- Created gallery data at `src/data/proofs/inverse-galois/`\n- Added to `listings.json` and `Proofs.lean`\n\n### Key Findings\n\n- Mathlib has `IsCyclotomicExtension.isGalois` — cyclotomic extensions are automatically Galois\n- Mathlib has `IsCyclotomicExtension.Aut.commGroup` — cyclotomic Galois groups are abelian\n- Mathlib has `galCyclotomicEquivUnitsZMod` — requires irreducibility of cyclotomic poly over ℚ\n- The irreducibility of Φₙ(x) over ℚ is a classical theorem (Gauss 1801) NOT directly in Mathlib as a standalone theorem — typically assumed as hypothesis in Mathlib theorems\n- The problem is genuinely open in general, but well-known cases (abelian, solvable, symmetric groups) are provable\n\n### Files Modified\n\n- `proofs/Proofs/InverseGalois.lean` (created)\n- `src/data/proofs/inverse-galois/meta.json` (created)\n- `src/data/proofs/inverse-galois/annotations.json` (created)\n- `src/data/proofs/inverse-galois/index.ts` (created)\n- `src/data/proofs/inverse-galois/tacticStates.json` (created)\n- `src/data/proofs/listings.json` (updated)\n- `proofs/Proofs.lean` (updated with import)\n- `research/problems/abel-ruffini-oq-01/knowledge.md` (this file)\n\n### What We Proved (compile-time)\n\n1. `cyclotomic_field_isGalois`: CyclotomicField n ℚ is Galois over ℚ\n2. `cyclotomic_galois_isAbelian`: The Galois group is abelian\n3. `cyclotomic_galois_group_iso_units_zmod`: Gal(Φₙ/ℚ) ≅ (ZMod n)ˣ (uses irreducibility axiom)\n4. `units_zmod4_card` = 2, `units_zmod5_card` = 4, `units_zmod7_card` = 6 (decide)\n5. `units_zmodPrime_card` = p-1 for prime p\n6. `a5_not_solvable`: A₅ is not solvable (proven)\n7. `solvable_iff_solvable_galois_group`: Connection to Abel-Ruffini (proven)\n\n### What's Axiomatized (not proven in Lean)\n\n1. `cyclotomic_irreducible_over_rationals`: Φₙ(x) is irreducible over ℚ (classical, not in Mathlib as standalone)\n2. `abelian_realizable`: All abelian groups realizable (needs Kronecker-Weber)\n3. `shafarevich_theorem`: All solvable groups realizable (Shafarevich 1954, deep)\n\n### What Has Sorry\n\n1. `inverse_galois_problem_open_conjecture`: The main open problem\n2. `symmetric_group_realizable`: Needs Hilbert irreducibility theorem\n3. `connection_to_abel_ruffini`: The specific polynomial example\n4. One more in the A₅ realization discussion\n\n### Next Steps\n\n1. Try to prove `cyclotomic_irreducible_over_rationals` in Lean — this should be in Mathlib somewhere, perhaps under a different name\n2. Search for Kronecker-Weber in Mathlib (might not be there yet)\n3. Consider building a more computational example: explicitly compute Gal(ℚ(ζ₅)/ℚ) using Mathlib\n4. Possibly extend to show that some specific non-abelian group (like S₃) is realizable using an explicit polynomial\n\n## Mathematical Context\n\n### The Cyclotomic Approach (What We Formalized)\n\nFor the Galois group of the n-th cyclotomic field:\n- `CyclotomicField n ℚ` = splitting field of Φₙ(X) over ℚ\n- `IsGalois ℚ (CyclotomicField n ℚ)` — Galois extension\n- `Gal(CyclotomicField n ℚ / ℚ) ≅ (ZMod n)ˣ` — abelian Galois group\n\nFor prime p:\n- `(ZMod p)ˣ` is cyclic of order p-1\n- So Gal(ℚ(ζₚ)/ℚ) is cyclic of order p-1\n\n### Known Realizability Results\n\n| Group Family | Source | Status in Lean |\n|---|---|---|\n| Trivial group | ℚ/ℚ | Easy (not formalized yet) |\n| Cyclic Cₙ | Cyclotomic subfields | Partially (via autEquivPow) |\n| Abelian | Kronecker-Weber | Axiom |\n| Solvable | Shafarevich 1954 | Axiom |\n| Sₙ | Hilbert irreducibility | Sorry |\n| Aₙ (n≥5) | Various | Not formalized |\n| Most simple groups | Case by case | Not formalized |\n| M₂₃ (sporadic) | Unknown | Open math problem |\n| General | **OPEN** | Open math problem |\n\n### Mathlib Infrastructure Used\n\n```\nMathlib.NumberTheory.Cyclotomic.Gal\n  - galCyclotomicEquivUnitsZMod: polynomial Galois group ≅ (ZMod n)ˣ\n  - IsCyclotomicExtension.Aut.commGroup: abelian Galois group\n  - IsCyclotomicExtension.autEquivPow: automorphisms ≃* (ZMod n)ˣ\n\nMathlib.NumberTheory.Cyclotomic.Basic\n  - IsCyclotomicExtension.isGalois: cyclotomic extensions are Galois\n  - CyclotomicField: the splitting field of Φₙ(X)\n  - IsCyclotomicExtension instance for characteristic 0\n\nMathlib.FieldTheory.Galois.Basic\n  - IsGalois: the Galois extension class\n  - IsGalois.card_aut_eq_finrank: |Gal| = degree\n\nMathlib.GroupTheory.SpecificGroups.Cyclic\n  - IsCyclic instance for (ZMod p)ˣ\n\nMathlib.FieldTheory.AbelRuffini\n  - solvableByRad.isSolvable': Abel-Ruffini connection\n```\n\n## Blockers / Gaps\n\n1. **Cyclotomic irreducibility over ℚ**: Not a direct standalone Mathlib theorem.\n   The theorem is classical (Gauss 1801) but Mathlib typically assumes it as a\n   hypothesis. We axiomatized it.\n   **Potential fix**: Look in `Mathlib.RingTheory.Polynomial.Cyclotomic.Irreducible`\n   or search for `IsIntegral.minpoly_eq_cyclotomic`.\n\n2. **Kronecker-Weber theorem**: The proof that every abelian extension of ℚ is\n   cyclotomic. This deep result is not yet in Mathlib (as of 2026-02).\n\n3. **Hilbert irreducibility theorem**: Needed for symmetric group realization.\n   Not in Mathlib.\n\n4. **Shafarevich's theorem**: 50+ pages of algebraic number theory. Not in Lean.\n"
   },
   "tags": [
@@ -335,7 +339,8 @@
     "abel-ruffini-oq-04-oq-02-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
     "abel-ruffini-oq-04-oq-03",
-    "abel-ruffini-oq-04-oq-07"
+    "abel-ruffini-oq-04-oq-07",
+    "abel-ruffini-oq-09"
   ],
   "references": {
     "papers": [],
@@ -350,7 +355,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 186,
+      "lineCount": 188,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
@@ -438,8 +443,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ03.lean",
       "filename": "AbelRuffiniOQ04OQ03.lean",
-      "lineCount": 166,
-      "theoremCount": 6,
+      "lineCount": 243,
+      "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -456,6 +461,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ09.lean",
+      "filename": "AbelRuffiniOQ09.lean",
+      "lineCount": 449,
+      "theoremCount": 20,
+      "axiomCount": 3,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ09.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Pre-work assessment session for abel-ruffini-oq-01 (InverseGaloisA5.lean).

## Progress

- Knowledge.md updated with sharper analysis of the blocking case
- New insight: |Gal|∈{10,60} via 2|Gal + 5|Gal + |Gal||60 + Gal⊆A5 + no-20-subgroup-in-A5
- The unique blocker is ruling out D5 (order 10, solvable dihedral group)

## Findings

- InverseGaloisA5.lean: 0 sorries, 1 axiom (three_dvd_gal_card), 2067 lines
- InverseGaloisOQ06OQ01.lean: 2|Gal, gal_card_ne_5, mod-7 factorization (all proved)
- Eliminating three_dvd_gal_card requires showing Gal≇D5 via Frobenius/Dedekind

## Status

**Outcome**: blocked  
**Next Steps**: Revisit when Mathlib gains Kummer-Dedekind or Frobenius element theory

🤖 Generated by researcher-4