### PR TITLE
fix(sum-of-kth-powers-oq-04): clear stale V1/V2 axiom references from narrative

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "sum-of-kth-powers-oq-04",
   "title": "Euler-Maclaurin Asymptotics for Power Sums",
   "slug": "sum-of-kth-powers-oq-04",
-  "description": "Asymptotic formula for power sums: sum_{i=0}^{n-1} i^k / n^{k+1} -> 1/(k+1) as n -> infinity. Axiomatizes Bernoulli polynomial leading behavior and monic polynomial asymptotics. Proves k=0 and k=1 special cases exactly.",
+  "description": "Asymptotic formula for power sums: sum_{i=0}^{n-1} i^k / n^{k+1} -> 1/(k+1) as n -> infinity. Proves Bernoulli polynomial leading behavior and monic polynomial asymptotics (0 axioms). 2 routine sorries remain. Includes exact k=0 and k=1 special cases.",
   "meta": {
     "author": "Euler (1738), Maclaurin (1742), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%E2%80%93Maclaurin_formula",
@@ -51,7 +51,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Euler-Maclaurin formula was discovered independently by Euler (1738) in 'Methodus generalis summandi progressiones' and by Maclaurin (1742) in 'Treatise of Fluxions'. It provides an asymptotic expansion connecting a discrete sum ∑_{j=a}^{b} f(j) to the integral ∫_a^b f(x) dx plus correction terms involving Bernoulli numbers B_{2k} and derivatives of f. The simplest consequence, requiring no correction terms, is: ∑_{i=0}^{n-1} i^k / n^{k+1} → 1/(k+1), which matches the Riemann sum approximation to ∫₀¹ x^k dx = 1/(k+1). Faulhaber's formula (1631), which gives the exact closed form (k+1)·∑ i^k = B_{k+1}(n) - B_{k+1}(0) using Bernoulli polynomials, provides the algebraic route to this asymptotic. Johann Faulhaber computed power sums up to k=17 by hand; the Bernoulli polynomial formulation was clarified by Jakob Bernoulli in 'Ars Conjectandi' (1713). The formalization here shows that the asymptotic is a purely algebraic consequence of Faulhaber's formula and the monicity of B_{k+1}, requiring only one non-trivial analytical axiom.",
+    "historicalContext": "The Euler-Maclaurin formula was discovered independently by Euler (1738) in 'Methodus generalis summandi progressiones' and by Maclaurin (1742) in 'Treatise of Fluxions'. It provides an asymptotic expansion connecting a discrete sum ∑_{j=a}^{b} f(j) to the integral ∫_a^b f(x) dx plus correction terms involving Bernoulli numbers B_{2k} and derivatives of f. The simplest consequence, requiring no correction terms, is: ∑_{i=0}^{n-1} i^k / n^{k+1} → 1/(k+1), which matches the Riemann sum approximation to ∫₀¹ x^k dx = 1/(k+1). Faulhaber's formula (1631), which gives the exact closed form (k+1)·∑ i^k = B_{k+1}(n) - B_{k+1}(0) using Bernoulli polynomials, provides the algebraic route to this asymptotic. Johann Faulhaber computed power sums up to k=17 by hand; the Bernoulli polynomial formulation was clarified by Jakob Bernoulli in 'Ars Conjectandi' (1713). The formalization here shows that the asymptotic is a purely algebraic consequence of Faulhaber's formula and the monicity of B_{k+1}, requiring only two routine analytical sorry arguments (V3 proved the monic polynomial ratio theorem).",
     "problemStatement": "$$\\frac{\\sum_{i=0}^{n-1} i^k}{n^{k+1}} \\to \\frac{1}{k+1} \\quad \\text{as } n \\to \\infty$$",
     "text": "A 193-line formalization of asymptotic power sum behavior. Defines the normalized power sum ratio, proves monic polynomial ratio limits from first principles (V3 eliminated the monic_poly_ratio_tendsto axiom), and proves the general asymptotic theorem using Faulhaber's formula and filter limits. Includes exact formulas for k=0 (trivial) and k=1 (via Gauss sum). 2 routine sorries remain.",
     "proofStrategy": "The proof uses Faulhaber's formula: (k+1) * sum i^k = B_{k+1}(n) - B_{k+1}(0), where B_{k+1} is the Bernoulli polynomial. Since B_{k+1} is monic of degree k+1, the ratio B_{k+1}(n)/n^{k+1} -> 1, giving sum i^k / n^{k+1} -> 1/(k+1).",
@@ -59,9 +59,9 @@
       "The asymptotic 1/(k+1) is the Riemann sum interpretation: ∑_{i<n} (i/n)^k · (1/n) → ∫₀¹ x^k dx = 1/(k+1), where each term i^k/n^{k+1} = (i/n)^k/n is a rectangle of width 1/n at height (i/n)^k",
       "Faulhaber's formula bridges the algebraic and analytic: (k+1)·∑ i^k = B_{k+1}(n) - B_{k+1}(0) lets the limit reduce to the fact that B_{k+1}(n)/n^{k+1} → 1 (monicity of B_{k+1})",
       "bernoulli_poly_leading was previously an axiom but is now proved from Mathlib's coeff_bernoulli API: coeff(B_n, n) = bernoulli(0) · C(n,n) = 1, and coefficients above degree n vanish — a clean proof of monicity without algebraic manipulation",
-      "The main proof is a three-step filter computation: rewrite using Faulhaber (filter_upwards), split numerator (sub_div + Tendsto.sub), apply the monic limit axiom and const_div_pow_tendsto_zero independently",
+      "The main proof is a three-step filter computation: rewrite using Faulhaber (filter_upwards), split numerator (sub_div + Tendsto.sub), apply monic_poly_ratio_tendsto and const_div_pow_tendsto_zero independently",
       "The k=1 case gives the exact formula (n-1)/(2n) for all n > 0, not just asymptotically — confirmed by the Gauss induction gauss_sum_rat proving 2·∑ i = n(n-1) in ℚ",
-      "The one remaining axiom (monic_poly_ratio_tendsto) has a clear proof strategy but requires decomposing a polynomial into its leading term plus lower-degree terms in the Mathlib filter API — an achievable but technically involved formalization target"
+      "monic_poly_ratio_tendsto is now proved (V3): p = X^d + q with deg(q) < d, so p(n)/n^d = 1 + q(n)/n^d → 1. The 2 remaining sorries are: low_degree_poly_ratio_tendsto_zero (each monomial c·n^i/n^d → 0) and the degree bound natDegree(p - X^d) < d (routine algebra)"
     ]
   },
   "sections": [
@@ -82,10 +82,10 @@
     },
     {
       "id": "axioms",
-      "title": "Bernoulli Polynomial Axioms",
+      "title": "Bernoulli Polynomial Lemmas",
       "startLine": 41,
       "endLine": 50,
-      "summary": "Axiomatizes: B_{k+1} is monic of degree k+1, and monic polynomial ratios tend to 1.",
+      "summary": "Proves: B_{k+1} has leading coefficient 1 and natDegree k+1 (from coeff_bernoulli). These were axioms in V1/V2 and are now fully proved theorems.",
       "mathContext": "$B_{k+1}$ monic of degree $k+1$; $p(n)/n^d \\to 1$ for monic $p$ of degree $d$"
     },
     {
@@ -93,7 +93,7 @@
       "title": "Main Asymptotic Theorem",
       "startLine": 52,
       "endLine": 68,
-      "summary": "Proves powerSumRatio k -> 1/(k+1) using Faulhaber's formula and filter limit manipulations with the monic polynomial axiom.",
+      "summary": "Proves powerSumRatio k -> 1/(k+1) using Faulhaber's formula and filter limit manipulations with the proved monic polynomial theorem.",
       "mathContext": "$R_k(n) \\to \\frac{1}{k+1}$ as $n \\to \\infty$"
     },
     {
@@ -116,7 +116,7 @@
     "summary": "The asymptotic formula sum i^k / n^{k+1} -> 1/(k+1) is proved for all k, with exact formulas for k=0 and k=1 as special cases. 0 axioms remain (monic_poly_ratio_tendsto was proved in V3 via X^d + lower-order decomposition). 2 routine sorries remain: low_degree_poly_ratio_tendsto_zero and natDegree_sub_leading.",
     "implications": "Connects discrete power sums to continuous integration via the Riemann sum interpretation, laying groundwork for a full Euler-Maclaurin formalization in Lean 4.",
     "openQuestions": [
-      "Prove monic_poly_ratio_tendsto: decompose p = X^d + q with deg(q) < d, show q(n)/n^d → 0 term by term using const_div_pow_tendsto_zero for each monomial",
+      "Prove low_degree_poly_ratio_tendsto_zero: decompose q.eval n into monomial sum ∑ c_i * n^i, divide by n^d to get ∑ c_i/n^{d-i}, apply const_div_pow_tendsto_zero for each term. Prove natDegree(p - X^d) < d from leadingCoeff = 1 (routine algebra).",
       "Can the full Euler-Maclaurin formula with Bernoulli correction terms be formalized? The formula ∑_{j=a}^{b} f(j) = ∫_a^b f + (f(a)+f(b))/2 + ∑ B_{2k}/(2k)! · (f^{(2k-1)}(b) - f^{(2k-1)}(a)) requires differentiation and big-O error term infrastructure",
       "Extend to the error term: ∑ i^k = n^{k+1}/(k+1) + n^k/2 + O(n^{k-1}), proving the sub-leading Bernoulli correction",
       "Can the Riemann sum interpretation be formalized directly using Mathlib's MeasureTheory.intervalIntegral, proving ∑ f(i/n)/n → ∫₀¹ f for smooth f?"


### PR DESCRIPTION
## Summary

- Section `axioms` title/summary updated: lines 41-50 contain proved theorems (V3), not axioms
- `keyInsights[5]`: removed stale "one remaining axiom (monic_poly_ratio_tendsto)" — it was proved in V3
- `keyInsights[3]`, section `main-theorem` summary: replaced "axiom" with "theorem"
- `description` top-level: replaced "Axiomatizes..." with "Proves..."
- `historicalContext`: replaced "one non-trivial analytical axiom" with current sorry count
- `openQuestions[0]`: updated from monic_poly_ratio_tendsto (proved) to actual remaining sorries

Structural counts unchanged: `sorries=2`, `axiomCount=0`, `status=formalized`, `badge=wip`.

## Test plan

- [ ] JSON is valid
- [ ] No integrity counts changed (sorries/axiomCount/status/badge)
- [ ] All "axiom" references now accurately describe proved theorems or remaining sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)