### PR TITLE
research(konigsberg-oq-01-oq-02): eliminate 3 axioms — prove handshaking and necessity

### DIFF
--- a/proofs/Proofs/KonigsbergOQ01OQ02.lean
+++ b/proofs/Proofs/KonigsbergOQ01OQ02.lean
@@ -17,20 +17,18 @@
       inDegree(t)  = outDegree(t) + 1 (end: one extra incoming edge)
       ∀ v ≠ s, t: inDegree(v) = outDegree(v)
 
-  ## Status: Formalized (axiomatized)
+  ## Status: Partially proved
 
-  The theorem is classical and well-known. Full Lean 4 formalization would
-  require substantial graph connectivity infrastructure. We axiomatize the
-  main result and prove:
-  1. Degree balance is necessary for any Eulerian circuit
-  2. In-degree sum equals out-degree sum (handshaking for directed graphs)
+  This file proves:
+  1. Handshaking lemmas for directed graphs (∑ outDegree = |E| = ∑ inDegree)
+  2. **NECESSITY**: Balance is necessary for any Eulerian circuit (proved from first principles)
   3. Concrete directed graphs satisfying the Eulerian criteria
-  4. The relationship between directed and undirected Eulerian theory
+
+  Axiomatized: Hierholzer sufficiency and Eulerian path characterization.
 
   References:
   - Euler (1741): Original Königsberg bridges proof
   - Hierholzer (1873): Constructive proof for undirected case
-  - Robbins (1939): Orientation theorems
   - West (2001): Introduction to Graph Theory, §1.3
 -/
 
@@ -76,14 +74,30 @@ def IsEulerianBalanced (G : DiGraph V) : Prop :=
 PART II: HANDSHAKING LEMMA FOR DIRECTED GRAPHS
 ══════════════════════════════════════════════════════════════ -/
 
-/-- **Directed Handshaking Lemma**: Sum of all out-degrees = |E| = sum of all in-degrees.
-    Each edge (u,v) contributes exactly 1 to outDegree(u) and 1 to inDegree(v).
-    (Axiomatized: the bijection proof requires Finset.card_biUnion infrastructure.) -/
-axiom sum_outDegree_eq_edgeCount (G : DiGraph V) :
-    ∑ v : V, outDegree G v = G.edges.card
+/-- **Directed Handshaking Lemma**: Sum of all out-degrees = |E|.
+    Proof: ∑_v |{e : e.1=v}| = ∑_e ∑_v [e.1=v] (swap) = ∑_e 1 = |E|. -/
+theorem sum_outDegree_eq_edgeCount (G : DiGraph V) :
+    ∑ v : V, outDegree G v = G.edges.card := by
+  unfold outDegree
+  have step : ∀ v : V, (G.edges.filter fun e => e.1 = v).card =
+      ∑ e ∈ G.edges, if e.1 = v then 1 else 0 := fun v => by
+    rw [Finset.card_eq_sum_ones, Finset.sum_filter]
+  simp_rw [step]
+  rw [Finset.sum_comm]
+  simp only [Finset.sum_ite_eq', Finset.mem_univ, if_true]
+  exact Finset.card_eq_sum_ones.symm
 
-axiom sum_inDegree_eq_edgeCount (G : DiGraph V) :
-    ∑ v : V, inDegree G v = G.edges.card
+/-- Sum of all in-degrees = |E|. Same proof by symmetry on second endpoint. -/
+theorem sum_inDegree_eq_edgeCount (G : DiGraph V) :
+    ∑ v : V, inDegree G v = G.edges.card := by
+  unfold inDegree
+  have step : ∀ v : V, (G.edges.filter fun e => e.2 = v).card =
+      ∑ e ∈ G.edges, if e.2 = v then 1 else 0 := fun v => by
+    rw [Finset.card_eq_sum_ones, Finset.sum_filter]
+  simp_rw [step]
+  rw [Finset.sum_comm]
+  simp only [Finset.sum_ite_eq', Finset.mem_univ, if_true]
+  exact Finset.card_eq_sum_ones.symm
 
 /-- Sum of out-degrees = sum of in-degrees. -/
 theorem sum_outDegree_eq_sum_inDegree (G : DiGraph V) :
@@ -95,42 +109,225 @@ theorem sum_outDegree_eq_sum_inDegree (G : DiGraph V) :
 PART III: NECESSITY — BALANCE IS REQUIRED
 ══════════════════════════════════════════════════════════════ -/
 
-/-- An Eulerian circuit in a directed graph: a sequence of vertices forming a closed walk
-    that uses every edge exactly once. Axiomatized abstractly. -/
+/-- An Eulerian circuit: a closed walk using every edge exactly once.
+    The strong formulation requires unique coverage (∃!) and that every
+    walk step uses a graph edge (hsteps). -/
 def HasEulerianCircuit (G : DiGraph V) : Prop :=
   ∃ (walk : List V), walk.length = G.edges.card + 1 ∧
-    (∀ e ∈ G.edges, ∃ i < walk.length - 1,
+    (∀ e ∈ G.edges, ∃! i : ℕ, i < walk.length - 1 ∧
       walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2) ∧
-    walk.head? = walk.getLast?
+    walk.head? = walk.getLast? ∧
+    (∀ i (hi : i < walk.length - 1),
+      (walk.get ⟨i, by omega⟩, walk.get ⟨i + 1, by omega⟩) ∈ G.edges)
+
+/-
+  Helper: for a closed walk of length n+1, the source-count at v equals
+  the target-count at v. The bijection i ↦ (i=0 ? n-1 : i-1) maps
+  {i < n : walk[i] = v} onto {i < n : walk[i+1] = v}.
+-/
+private lemma closed_walk_balance (walk : List V) (n : ℕ)
+    (hlen : walk.length = n + 1)
+    (hclosed : walk.get ⟨0, by omega⟩ = walk.get ⟨n, by omega⟩)
+    (v : V) :
+    ((Finset.range n).filter fun i => walk.get ⟨i, by omega⟩ = v).card =
+    ((Finset.range n).filter fun i => walk.get ⟨i + 1, by omega⟩ = v).card := by
+  -- Bijection: source position i ↦ target position (i = 0 ? n-1 : i-1)
+  apply Finset.card_bij (fun i _ => if i = 0 then n - 1 else i - 1)
+  · -- Maps into target filter
+    intro i hi
+    simp only [Finset.mem_filter, Finset.mem_range] at hi ⊢
+    obtain ⟨hi_lt, hi_v⟩ := hi
+    refine ⟨by split_ifs <;> omega, ?_⟩
+    split_ifs with h
+    · -- i = 0: target position n-1, need walk[n] = v
+      have heq : walk.get ⟨n - 1 + 1, by omega⟩ = walk.get ⟨n, by omega⟩ := by
+        congr 1; omega
+      rw [heq, ← hclosed, h] at hi_v ⊢; exact hi_v
+    · -- i > 0: target position i-1, need walk[i] = v
+      have heq : walk.get ⟨i - 1 + 1, by omega⟩ = walk.get ⟨i, by omega⟩ := by
+        congr 1; omega
+      rw [heq]; exact hi_v
+  · -- Injective
+    intro i hi j hj heq
+    simp only [Finset.mem_filter, Finset.mem_range] at hi hj
+    split_ifs at heq with h1 h2 <;> omega
+  · -- Surjective: for target position j, preimage is (j = n-1 ? 0 : j+1)
+    intro j hj
+    simp only [Finset.mem_filter, Finset.mem_range] at hj ⊢
+    obtain ⟨hj_lt, hj_v⟩ := hj
+    refine ⟨if j = n - 1 then 0 else j + 1, ⟨by split_ifs <;> omega, ?_⟩, ?_⟩
+    · split_ifs with h
+      · -- j = n-1: preimage = 0, need walk[0] = v
+        -- walk[j+1] = walk[n] = walk[0] (closed), and walk[j+1] = v
+        rw [← hclosed]
+        have heq : walk.get ⟨j + 1, by omega⟩ = walk.get ⟨n, by omega⟩ := by
+          congr 1; omega
+        rw [← heq]; exact hj_v
+      · -- j < n-1: preimage = j+1, need walk[j+1] = v
+        exact hj_v
+    · -- bijection value at preimage = j
+      split_ifs with h
+      · simp [h]; omega
+      · simp; omega
+
+/-- Helper: the walk step map i ↦ (walk[i], walk[i+1]) is a bijection between
+    {i < n : walk[i] = v} and {e ∈ G.edges : e.1 = v}. -/
+private lemma walk_source_eq_outDegree (G : DiGraph V) (walk : List V) (n : ℕ) (v : V)
+    (hlen : walk.length = n + 1)
+    (hcov : ∀ e ∈ G.edges, ∃! i : ℕ, i < n ∧
+      walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2)
+    (hsteps : ∀ i (hi : i < n), (walk.get ⟨i, by omega⟩, walk.get ⟨i + 1, by omega⟩) ∈ G.edges) :
+    ((Finset.range n).filter fun i => walk.get ⟨i, by omega⟩ = v).card =
+    outDegree G v := by
+  unfold outDegree
+  -- Bijection: position i ↦ edge (walk[i], walk[i+1])
+  symm
+  apply Finset.card_bij (fun e he =>
+    -- For each edge e ∈ filter, extract its unique position
+    Classical.choose ((hcov e (Finset.mem_filter.mp he).1).exists))
+  · -- Maps into range-filter (walk[pos(e)] = v)
+    intro e he
+    have hmem := (Finset.mem_filter.mp he).1
+    have hv := (Finset.mem_filter.mp he).2
+    obtain ⟨pos, ⟨hlt, hsrc, _⟩, _⟩ := hcov e hmem
+    have hchoo := Classical.choose_spec ((hcov e hmem).exists)
+    simp only [Finset.mem_filter, Finset.mem_range]
+    constructor
+    · exact hchoo.1.1
+    · rw [hchoo.1.2.1, hv]
+  · -- Injective: pos(e1) = pos(e2) → e1 = e2
+    intro e1 he1 e2 he2 heq
+    have hmem1 := (Finset.mem_filter.mp he1).1
+    have hmem2 := (Finset.mem_filter.mp he2).1
+    have hspec1 := Classical.choose_spec ((hcov e1 hmem1).exists)
+    have hspec2 := Classical.choose_spec ((hcov e2 hmem2).exists)
+    -- heq : pos(e1) = pos(e2), so walk[pos(e1)] = e1.1 = e2.1 and walk[pos+1] = e1.2 = e2.2
+    rw [← heq] at hspec2
+    exact Prod.ext (hspec1.1.2.1.symm.trans hspec2.1.2.1)
+                   (hspec1.1.2.2.symm.trans hspec2.1.2.2)
+  · -- Surjective: for each position i with walk[i] = v, find edge e with pos(e) = i
+    intro i hi
+    simp only [Finset.mem_filter, Finset.mem_range] at hi
+    obtain ⟨hi_lt, hi_v⟩ := hi
+    -- The edge at position i
+    set e := (walk.get ⟨i, by omega⟩, walk.get ⟨i + 1, by omega⟩) with he_def
+    have he_mem : e ∈ G.edges := hsteps i (by omega)
+    have he_src : e.1 = v := hi_v
+    refine ⟨e, Finset.mem_filter.mpr ⟨he_mem, he_src⟩, ?_⟩
+    -- Need: Classical.choose (hcov e he_mem).exists = i
+    -- Both i and (the chosen position) satisfy the ∃! condition for e
+    have hspec := Classical.choose_spec ((hcov e he_mem).exists)
+    -- The uniqueness: any witness = the chosen one
+    -- i satisfies: i < n, walk[i] = e.1, walk[i+1] = e.2
+    have hi_spec : i < n ∧ walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2 :=
+      ⟨by omega, rfl, rfl⟩
+    -- Uniqueness: Classical.choose ... = i (by uniqueness of ∃!)
+    exact (hcov e he_mem).unique hspec.1 hi_spec
+
+/-- Same bijection for in-degree. -/
+private lemma walk_target_eq_inDegree (G : DiGraph V) (walk : List V) (n : ℕ) (v : V)
+    (hlen : walk.length = n + 1)
+    (hcov : ∀ e ∈ G.edges, ∃! i : ℕ, i < n ∧
+      walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2)
+    (hsteps : ∀ i (hi : i < n), (walk.get ⟨i, by omega⟩, walk.get ⟨i + 1, by omega⟩) ∈ G.edges) :
+    ((Finset.range n).filter fun i => walk.get ⟨i + 1, by omega⟩ = v).card =
+    inDegree G v := by
+  unfold inDegree
+  symm
+  apply Finset.card_bij (fun e he =>
+    Classical.choose ((hcov e (Finset.mem_filter.mp he).1).exists))
+  · -- Maps into range-filter (walk[pos(e)+1] = v)
+    intro e he
+    have hmem := (Finset.mem_filter.mp he).1
+    have hv := (Finset.mem_filter.mp he).2
+    have hspec := Classical.choose_spec ((hcov e hmem).exists)
+    simp only [Finset.mem_filter, Finset.mem_range]
+    exact ⟨hspec.1.1, by rw [hspec.1.2.2, hv]⟩
+  · -- Injective (same argument as walk_source_eq_outDegree)
+    intro e1 he1 e2 he2 heq
+    have hmem1 := (Finset.mem_filter.mp he1).1
+    have hmem2 := (Finset.mem_filter.mp he2).1
+    have hspec1 := Classical.choose_spec ((hcov e1 hmem1).exists)
+    have hspec2 := Classical.choose_spec ((hcov e2 hmem2).exists)
+    rw [← heq] at hspec2
+    exact Prod.ext (hspec1.1.2.1.symm.trans hspec2.1.2.1)
+                   (hspec1.1.2.2.symm.trans hspec2.1.2.2)
+  · -- Surjective: for position i with walk[i+1] = v, find edge e with pos(e) = i
+    intro i hi
+    simp only [Finset.mem_filter, Finset.mem_range] at hi
+    obtain ⟨hi_lt, hi_v⟩ := hi
+    set e := (walk.get ⟨i, by omega⟩, walk.get ⟨i + 1, by omega⟩) with he_def
+    have he_mem : e ∈ G.edges := hsteps i (by omega)
+    have he_tgt : e.2 = v := hi_v
+    refine ⟨e, Finset.mem_filter.mpr ⟨he_mem, he_tgt⟩, ?_⟩
+    have hspec := Classical.choose_spec ((hcov e he_mem).exists)
+    have hi_spec : i < n ∧ walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2 :=
+      ⟨by omega, rfl, rfl⟩
+    exact (hcov e he_mem).unique hspec.1 hi_spec
 
 /-- **Necessity**: Any graph with an Eulerian circuit has balanced degrees.
-    At each vertex, every visit contributes one in-edge and one out-edge. -/
-axiom eulerian_circuit_implies_balanced (G : DiGraph V) :
-    HasEulerianCircuit G → IsEulerianBalanced G
+    Proof: For each vertex v, outDegree = |{i : walk[i] = v}| = |{i : walk[i+1] = v}| = inDegree.
+    The first and last equalities use the bijection between edges and walk positions.
+    The middle equality uses the closed walk: walk[0] = walk[n] implies the
+    source-count and target-count at any vertex are equal. -/
+theorem eulerian_circuit_implies_balanced (G : DiGraph V) :
+    HasEulerianCircuit G → IsEulerianBalanced G := by
+  intro ⟨walk, hlen, hcov, hclosed, hsteps⟩
+  intro v
+  unfold IsBalanced
+  set n := G.edges.card with hn
+  -- walk.length - 1 = n
+  have hn_eq : walk.length - 1 = n := by omega
+  -- Normalize hcov to use n instead of walk.length - 1
+  have hcov' : ∀ e ∈ G.edges, ∃! i : ℕ, i < n ∧
+      walk.get ⟨i, by omega⟩ = e.1 ∧ walk.get ⟨i + 1, by omega⟩ = e.2 := by
+    intro e he
+    have h := hcov e he
+    rwa [hn_eq] at h
+  -- Normalize hsteps to use n
+  have hsteps' : ∀ i (hi : i < n), (walk.get ⟨i, by omega⟩, walk.get ⟨i + 1, by omega⟩) ∈ G.edges :=
+    fun i hi => hsteps i (hn_eq ▸ hi)
+  -- Closed walk: walk[0] = walk[n]
+  have hclosed_eq : walk.get ⟨0, by omega⟩ = walk.get ⟨n, by omega⟩ := by
+    have hne : walk ≠ [] := by intro h; simp [h] at hlen
+    -- head? of cons is definitionally some (first element)
+    have h1 : walk.head? = some (walk.get ⟨0, by omega⟩) := by
+      cases walk with
+      | nil => exact absurd rfl hne
+      | cons a t => rfl
+    -- getLast? via List.getLast?_eq_getLast and List.getLast_eq_get
+    have h2 : walk.getLast? = some (walk.get ⟨n, by omega⟩) := by
+      rw [List.getLast?_eq_getLast hne]
+      congr 1
+      simp only [List.getLast_eq_get, List.get_eq_getElem]
+      congr 1
+      omega
+    rw [h1, h2] at hclosed
+    exact Option.some.inj hclosed
+  -- Chain of equalities: inDegree = target-count = source-count = outDegree
+  have h1 := walk_source_eq_outDegree G walk n v hlen hcov' hsteps'
+  have h2 := walk_target_eq_inDegree G walk n v hlen hcov' hsteps'
+  have h3 := closed_walk_balance walk n hlen hclosed_eq v
+  omega
 
 /-
 ══════════════════════════════════════════════════════════════
 PART IV: THE DIRECTED EULERIAN THEOREM (axiomatized)
 ══════════════════════════════════════════════════════════════ -/
 
-/-- A directed graph is weakly connected if its underlying undirected graph is connected.
-    Axiomatized here for the Eulerian theorem. -/
+/-- A directed graph is weakly connected if its underlying undirected graph is connected. -/
 def IsWeaklyConnected (G : DiGraph V) : Prop :=
   ∀ u v : V, u ≠ v → ∃ (path : List V),
     path.head? = some u ∧ path.getLast? = some v ∧
     ∀ i < path.length - 1, (path.get ⟨i, by omega⟩, path.get ⟨i+1, by omega⟩) ∈ G.edges ∨
                             (path.get ⟨i+1, by omega⟩, path.get ⟨i, by omega⟩) ∈ G.edges
 
-/-- **Directed Eulerian Theorem**: A weakly connected directed graph has an Eulerian circuit
-    if and only if every vertex has equal in-degree and out-degree.
-    (Sufficiency is the constructive direction, proved by Hierholzer's algorithm.) -/
+/-- **Directed Eulerian Theorem** (Hierholzer's algorithm, axiomatized):
+    Sufficiency requires constructing an Eulerian walk, which is classical graph theory. -/
 axiom directed_eulerian_iff (G : DiGraph V) (hconn : IsWeaklyConnected G) :
     HasEulerianCircuit G ↔ IsEulerianBalanced G
 
-/-- A directed graph has an Eulerian PATH from s to t (s ≠ t) iff:
-    - outDegree(s) = inDegree(s) + 1
-    - inDegree(t) = outDegree(t) + 1
-    - All other vertices are balanced -/
+/-- A directed graph has an Eulerian PATH from s to t (s ≠ t). -/
 def HasEulerianPath (G : DiGraph V) (s t : V) : Prop :=
   ∃ (walk : List V), walk.head? = some s ∧ walk.getLast? = some t ∧
     walk.length = G.edges.card + 1 ∧
@@ -157,8 +354,7 @@ def directedTriangle : DiGraph (Fin 3) where
 theorem directedTriangle_balanced : IsEulerianBalanced directedTriangle := by
   intro v; fin_cases v <;> native_decide
 
-/-- Example: The directed path A→B→C has an Eulerian path from A to C
-    (outDegree(A) - inDegree(A) = 1, inDegree(C) - outDegree(C) = 1). -/
+/-- Example: The directed path A→B→C has an Eulerian path from A to C. -/
 def directedPath : DiGraph (Fin 3) where
   edges := {(0, 1), (1, 2)}
   noSelfLoops := by decide

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "konigsberg-oq-01-oq-02",
   "title": "Eulerian Paths in Directed Graphs",
   "slug": "konigsberg-oq-01-oq-02",
-  "description": "Extends the Eulerian circuit characterization to directed graphs. A weakly connected digraph has an Eulerian circuit iff every vertex has equal in-degree and out-degree; it has an Eulerian path from s to t iff outdeg(s) = indeg(s)+1, indeg(t) = outdeg(t)+1, and all other vertices are balanced. Proved via the directed handshaking lemma and concrete examples (directed 3-cycle, directed path). 5 theorems proved, 5 axioms.",
+  "description": "Extends the Eulerian circuit characterization to directed graphs. A weakly connected digraph has an Eulerian circuit iff every vertex has equal in-degree and out-degree; it has an Eulerian path from s to t iff outdeg(s) = indeg(s)+1, indeg(t) = outdeg(t)+1, and all other vertices are balanced. Proved via the directed handshaking lemma (proved from first principles via Finset sum-swap) and concrete examples (directed 3-cycle, directed path). 8 theorems proved, 2 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",
@@ -19,13 +19,16 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-03",
-    "axiomCount": 5,
-    "assumptions": "5 axioms: sum_outDegree_eq_edgeCount and sum_inDegree_eq_edgeCount (directed handshaking lemma — requires Finset.card_biUnion infrastructure), eulerian_circuit_implies_balanced (necessity direction), directed_eulerian_iff (full characterization), directed_euler_path_iff (path characterization). All 5 theorems and 2 concrete examples are fully proved.",
-    "lineCount": 193,
-    "theoremCount": 5,
+    "axiomCount": 2,
+    "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer sufficiency — requires constructing an Eulerian walk), directed_euler_path_iff (path characterization). The directed handshaking lemma and necessity direction are fully proved from first principles.",
+    "lineCount": 387,
+    "theoremCount": 8,
     "definitionCount": 8,
     "originalContributions": [
-      "sum_outDegree_eq_sum_inDegree: directed handshaking — sum of out-degrees equals sum of in-degrees, proved from the two counting axioms",
+      "sum_outDegree_eq_edgeCount: ∑_v outDeg(v) = |E|, proved via Finset.sum_comm on the indicator-function expansion of degree counts",
+      "sum_inDegree_eq_edgeCount: ∑_v inDeg(v) = |E|, proved by the same Finset sum-swap argument on second endpoints",
+      "eulerian_circuit_implies_balanced: necessity direction — any Eulerian circuit implies all vertices are degree-balanced, proved by establishing bijections between edge set and walk positions using ∃! (unique coverage) and Finset.card_bij",
+      "sum_outDegree_eq_sum_inDegree: directed handshaking — sum of out-degrees equals sum of in-degrees, proved from the two counting theorems",
       "directedTriangle_balanced: the directed 3-cycle A→B→C→A is Eulerian-balanced (all in-degree = out-degree = 1), verified by native_decide",
       "directedPath_path_degrees: the directed path A→B→C satisfies the Eulerian path degree conditions: outdeg(A)=indeg(A)+1, indeg(C)=outdeg(C)+1, and B is balanced",
       "eulerian_balanced_sum_zero: if G has an Eulerian circuit then ∑ outDeg = ∑ inDeg as integers",
@@ -36,10 +39,11 @@
     "historicalContext": "Euler's 1736 result on the Königsberg bridges established the theory of Eulerian paths in undirected graphs. The directed analogue is a natural extension: in a directed graph, an Eulerian circuit requires that each vertex has equal in-degree and out-degree (one incoming edge matched with one outgoing edge at each visit). The sufficiency direction follows from Hierholzer's algorithm (1873) adapted to directed graphs. The directed Eulerian path characterization (where source and sink have degrees differing by 1) generalizes naturally and has applications in de Bruijn sequences, genome assembly, and routing problems.",
     "problemStatement": "Extend the Eulerian circuit characterization (from undirected graphs) to directed graphs: characterize when a directed graph has an Eulerian circuit or path in terms of in-degrees and out-degrees.",
     "text": "For a weakly connected directed graph G: (1) G has an Eulerian circuit iff every vertex v satisfies inDeg(v) = outDeg(v). (2) G has an Eulerian path from s to t (s≠t) iff outDeg(s)=inDeg(s)+1, inDeg(t)=outDeg(t)+1, and all other vertices v have inDeg(v)=outDeg(v).",
-    "proofStrategy": "Define DiGraph V as a Finset of directed edges with no self-loops. Define outDegree and inDegree by filtering edges. Axiomatize the directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg) and the main Eulerian characterizations. Prove the structural consequence that out-degree sum equals in-degree sum. Verify concrete examples (directed triangle and directed path) by native_decide.",
+    "proofStrategy": "Define DiGraph V as a Finset of directed edges with no self-loops. Prove the directed handshaking lemma by expanding degree counts as indicator-function sums and applying Finset.sum_comm. Prove necessity (Eulerian circuit implies balanced degrees) by establishing bijections between G.edges and walk step positions using the strengthened definition (∃! unique position per edge, plus hsteps condition). The closed walk balance lemma uses a rotation bijection i ↦ (i=0 ? n-1 : i-1). Axiomatize Hierholzer sufficiency and Eulerian path characterization. Verify concrete examples by native_decide.",
     "keyInsights": [
-      "The directed handshaking lemma is the key counting identity: each edge (u,v) contributes exactly 1 to outDeg(u) and 1 to inDeg(v), so both sums equal |E|. This is axiomatized here due to the Finset.card_biUnion infrastructure required for the bijection proof.",
-      "Necessity (Eulerian circuit implies balanced degrees) is clear: each visit to a vertex contributes one use of an incoming edge and one use of an outgoing edge, so the contributions cancel.",
+      "The directed handshaking lemma is proved by Finset.sum_comm: ∑_v |{e : e.1=v}| = ∑_e ∑_v [e.1=v] = ∑_e 1 = |E|. No Finset.card_biUnion needed.",
+      "Necessity requires a bijection between G.edges and walk positions. The key insight is to strengthen HasEulerianCircuit with ∃! (unique position per edge) and an hsteps condition (every walk step is an edge), enabling use of ExistsUnique.unique for injectivity.",
+      "The closed walk balance is proved by a bijection i ↦ (i=0 ? n-1 : i-1) from source positions {i < n : walk[i] = v} to target positions {i < n : walk[i+1] = v}, using the closed walk condition walk[0] = walk[n].",
       "The directed triangle A→B→C→A is the canonical Eulerian circuit example: all three vertices have in-degree = out-degree = 1, verified by native_decide over Fin 3.",
       "For the Eulerian path characterization, the source s has one more outgoing edge than incoming (to start the path), and the sink t has one more incoming edge than outgoing (to end the path). All intermediate vertices are balanced.",
       "Weak connectivity (underlying undirected graph is connected) is the correct connectivity notion for directed Eulerian theory — strong connectivity is not required for the equivalence."
@@ -61,59 +65,58 @@
     },
     {
       "id": "handshaking",
-      "title": "Directed Handshaking Lemma",
-      "startLine": 78,
-      "endLine": 92,
-      "summary": "Axiomatizes sum_outDegree_eq_edgeCount and sum_inDegree_eq_edgeCount. Proves sum_outDegree_eq_sum_inDegree by transitivity.",
-      "mathContext": "$\\sum_{v} \\text{outDeg}(v) = |E| = \\sum_{v} \\text{inDeg}(v)$."
+      "title": "Directed Handshaking Lemma (proved)",
+      "startLine": 77,
+      "endLine": 106,
+      "summary": "Proves sum_outDegree_eq_edgeCount and sum_inDegree_eq_edgeCount from first principles via Finset.sum_comm on indicator-function expansions. Proves sum_outDegree_eq_sum_inDegree by transitivity.",
+      "mathContext": "$\\sum_{v} \\text{outDeg}(v) = |E| = \\sum_{v} \\text{inDeg}(v)$. Proof: $\\sum_v |\\{e : e.1=v\\}| = \\sum_v \\sum_{e \\in E} [e.1=v] = \\sum_{e \\in E} 1 = |E|$ by Finset.sum_comm."
     },
     {
       "id": "necessity",
-      "title": "Necessity: Balance Required for Eulerian Circuit",
-      "startLine": 98,
-      "endLine": 109,
-      "summary": "Defines HasEulerianCircuit as a closed walk covering all edges. Axiomatizes eulerian_circuit_implies_balanced.",
-      "mathContext": "If $G$ has an Eulerian circuit then $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
+      "title": "Necessity: Balance Required for Eulerian Circuit (proved)",
+      "startLine": 107,
+      "endLine": 312,
+      "summary": "Defines HasEulerianCircuit with strengthened ∃! coverage and hsteps conditions. Proves eulerian_circuit_implies_balanced via bijections: walk positions biject with G.edges, and a rotation bijection proves source-count = target-count for any vertex in a closed walk.",
+      "mathContext": "If $G$ has an Eulerian circuit then $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$. Key lemmas: closed_walk_balance (rotation bijection), walk_source_eq_outDegree and walk_target_eq_inDegree (edge-position bijections)."
     },
     {
       "id": "characterization",
       "title": "Directed Eulerian Theorem and Path Characterization",
-      "startLine": 114,
-      "endLine": 144,
-      "summary": "Defines IsWeaklyConnected and HasEulerianPath. Axiomatizes directed_eulerian_iff and directed_euler_path_iff.",
+      "startLine": 313,
+      "endLine": 336,
+      "summary": "Defines IsWeaklyConnected and HasEulerianPath. Axiomatizes directed_eulerian_iff (Hierholzer sufficiency) and directed_euler_path_iff (path characterization).",
       "mathContext": "$G$ has an Eulerian circuit $\\iff$ $\\text{IsEulerianBalanced}(G)$ (given weak connectivity). $G$ has Eulerian path $s \\to t$ $\\iff$ $\\text{outDeg}(s) = \\text{inDeg}(s)+1$, $\\text{inDeg}(t) = \\text{outDeg}(t)+1$, and all others balanced."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
-      "startLine": 151,
-      "endLine": 175,
+      "startLine": 337,
+      "endLine": 366,
       "summary": "Defines directedTriangle (Fin 3, edges {(0,1),(1,2),(2,0)}) and directedPath (Fin 3, edges {(0,1),(1,2)}). Proves directedTriangle_balanced by native_decide and directedPath_path_degrees by case analysis.",
       "mathContext": "Directed 3-cycle: all vertices balanced ($\\text{in} = \\text{out} = 1$). Directed path $0 \\to 1 \\to 2$: $\\text{outDeg}(0) = 1 = \\text{inDeg}(0)+1$, $\\text{inDeg}(2) = 1 = \\text{outDeg}(2)+1$, vertex 1 balanced."
     },
     {
       "id": "consequences",
       "title": "Consequences",
-      "startLine": 182,
-      "endLine": 193,
-      "summary": "Proves eulerian_balanced_sum_zero and eulerian_balanced_implies_degree_balance from the axioms.",
+      "startLine": 367,
+      "endLine": 384,
+      "summary": "Proves eulerian_balanced_sum_zero and eulerian_balanced_implies_degree_balance from the now-proved necessity theorem.",
       "mathContext": "Eulerian circuit $\\Rightarrow$ $\\sum_v \\text{outDeg}(v) = \\sum_v \\text{inDeg}(v)$ (as integers). Eulerian circuit $\\Rightarrow$ $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the directed Eulerian theorem: a weakly connected digraph has an Eulerian circuit iff all vertices are degree-balanced (inDeg = outDeg), and an Eulerian path from s to t iff s has one extra outgoing edge, t has one extra incoming edge, and all other vertices are balanced. 5 theorems proved, 5 axioms (handshaking lemma + main characterizations), 0 sorries, 193 lines.",
+    "summary": "Formalizes the directed Eulerian theorem with 5 axioms eliminated (5→2). The directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg) is proved from first principles via Finset.sum_comm. The necessity direction (Eulerian circuit → balanced degrees) is proved via bijections between G.edges and walk positions using ∃!-coverage and a rotation bijection for closed walks. 8 public theorems, 2 axioms (Hierholzer sufficiency + path characterization), 0 sorries, 387 lines.",
     "implications": "The directed Eulerian theorem underpins de Bruijn sequence construction (a de Bruijn graph is Eulerian), DNA fragment assembly algorithms, and Eulerian circuit algorithms in network flow. The degree-balance characterization is also the basis for Hierholzer's O(|E|) directed Eulerian circuit algorithm.",
     "openQuestions": [
-      "Prove the directed handshaking lemma from first principles using Finset.card_biUnion or a bijection argument",
       "Formalize Hierholzer's algorithm for constructing directed Eulerian circuits with a certified O(|E|) complexity bound",
       "Count Eulerian circuits via the BEST theorem: t_w(G) · ∏_v (outDeg(v)-1)! where t_w(G) is the number of arborescences rooted at w"
     ]
   },
   "leanFile": {
     "namespace": "KonigsbergOQ01OQ02",
-    "lineCount": 193,
-    "axiomCount": 5,
-    "theoremCount": 5,
+    "lineCount": 387,
+    "axiomCount": 2,
+    "theoremCount": 8,
     "definitionCount": 8,
     "path": "Proofs/KonigsbergOQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- **Problem**: `konigsberg-oq-01-oq-02` — Directed Eulerian circuit characterization
- **Axiom count**: 5 → 2 (eliminated `sum_outDegree_eq_edgeCount`, `sum_inDegree_eq_edgeCount`, `eulerian_circuit_implies_balanced`)
- **Lines**: 193 → 387

### Proofs added

1. **Directed handshaking lemma** (`sum_outDegree_eq_edgeCount`, `sum_inDegree_eq_edgeCount`): Expand degree counts as indicator-function sums and apply Finset.sum_comm. No Finset.card_biUnion needed.

2. **Necessity** (`eulerian_circuit_implies_balanced`): Strengthen HasEulerianCircuit with unique-position-per-edge (∃!) and hsteps condition. Prove bijections between G.edges and walk positions. Closed walk balance via rotation bijection i ↦ (i=0 ? n-1 : i-1).

### Remaining axioms (2)
- `directed_eulerian_iff`: Hierholzer sufficiency
- `directed_euler_path_iff`: Eulerian path degree characterization

## Test plan
- [ ] Docker CI build: `./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ01OQ02`
- [ ] Verify 0 sorries, 2 axioms
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)