### PR TITLE
fix(hilbert-11): convert vacuous axioms to sorry-theorems, fix counts

### DIFF
--- a/proofs/Proofs/Hilbert11_QuadraticForms.lean
+++ b/proofs/Proofs/Hilbert11_QuadraticForms.lean
@@ -192,22 +192,23 @@ def HasseMinkowskiTheorem : Prop :=
     RepresentsZeroNontrivially Q ↔
       (RepresentsZeroOverReals Q ∧ ∀ p : ℕ, [Fact (Nat.Prime p)] → RepresentsZeroOverPadic Q p)
 
-/-- **Axiom: Hasse-Minkowski Theorem (Alternative Formulation)**
+/-- **Hasse-Minkowski Theorem (Alternative Formulation, placeholder)**
 
     A nondegenerate quadratic form over ℚ is isotropic if and only if
     it is locally isotropic everywhere (over ℝ and all ℚₚ).
 
-    **Why axiomatized**: The Hasse-Minkowski theorem is one of the deepest
-    results in arithmetic theory of quadratic forms. A complete proof requires:
-    - p-adic analysis and Hensel's lemma
-    - Local classification of quadratic forms over ℚₚ
-    - Product formula for Hilbert symbols
-    - Global-to-local techniques via idelic methods or class field theory
-
-    Proven by Minkowski (1890) for ternary forms, generalized by Hasse (1923). -/
-axiom hasse_minkowski_alt (Q : QuadraticForm ℚ (Fin n → ℚ)) :
+    **Status**: Placeholder `sorry`. Because `RepresentsZeroOverReals` and
+    `RepresentsZeroOverPadic` are defined as `True` pending tensor products
+    with ℝ/ℚₚ, this statement currently reduces to `IsIsotropic Q ↔ True`,
+    which is mathematically false. We mark it as `sorry` (instead of an
+    `axiom`) so the gap is visible to `#check_sorry` and gallery sorry
+    counters. A genuine proof requires p-adic analysis, local classification,
+    and the product formula for Hilbert symbols — proven by Minkowski (1890)
+    for ternary forms, generalized by Hasse (1923). -/
+theorem hasse_minkowski_alt (Q : QuadraticForm ℚ (Fin n → ℚ)) :
     IsIsotropic Q ↔ (RepresentsZeroOverReals Q ∧
-      ∀ p : ℕ, [Fact (Nat.Prime p)] → RepresentsZeroOverPadic Q p)
+      ∀ p : ℕ, [Fact (Nat.Prime p)] → RepresentsZeroOverPadic Q p) := by
+  sorry
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART IV: CONSEQUENCES AND APPLICATIONS
@@ -226,16 +227,16 @@ If Q represents a ∈ ℚ* locally everywhere, then Q represents a globally.
 
 This is sometimes called "weak approximation" for quadratic forms. -/
 theorem weak_hasse_principle (Q : QuadraticForm ℚ (Fin n → ℚ)) (a : ℚ) (ha : a ≠ 0) :
-    -- If Q represents a over ℝ and all ℚₚ, then Q represents a over ℚ
+    -- Conclusion is `True` placeholder until weak approximation is formalized.
     True := by
-  trivial -- Follows from Hasse-Minkowski applied to Q - a·x₀²
+  sorry -- Should follow from Hasse-Minkowski applied to Q - a·x₀² (placeholder)
 
 /-- **Ternary Forms**: A ternary quadratic form over ℚ represents every rational
     number that it represents locally. -/
 theorem ternary_representation (Q : QuadraticForm ℚ (Fin 3 → ℚ)) (a : ℚ) :
-    -- For ternary forms, local representation implies global representation
+    -- Conclusion is `True` placeholder until local-global for ternary forms is formalized.
     True := by
-  trivial -- Key application of Hasse-Minkowski
+  sorry -- Key application of Hasse-Minkowski (placeholder)
 
 /-- **Four Squares Theorem (Lagrange)**
 
@@ -280,21 +281,20 @@ structure RationalClassification where
   hasseWittAtInfinity : ℤ  -- ±1
   hasseWittAtPrimes : ℕ → ℤ  -- ±1 for each prime, 1 for almost all
 
-/-- **Axiom: Rational Quadratic Form Classification**
+/-- **Rational Quadratic Form Classification (placeholder)**
 
     Two quadratic forms over ℚ are equivalent if and only if they have the same
     dimension, discriminant (in ℚ*/ℚ*²), and Hasse-Witt invariants at all places.
 
-    **Why axiomatized**: The complete classification theorem requires:
-    - Full development of Hasse-Witt invariants and their product formula
-    - Local classification at each prime (using p-adic valuations)
-    - Global assembly via strong approximation or class field theory
-    - Careful treatment of the discriminant in the square-class group
-
-    This is a consequence of the Hasse-Minkowski theorem together with
-    local classification results. -/
-axiom rational_classification_complete (Q₁ Q₂ : QuadraticForm ℚ (Fin n → ℚ)) :
-    AreEquivalent Q₁ Q₂ ↔ True  -- Should compare classifications; placeholder
+    **Status**: Placeholder `sorry`. The right-hand side is currently `True`,
+    so the statement reduces to `AreEquivalent Q₁ Q₂ ↔ True`, which is
+    mathematically false. We mark it as `sorry` (instead of an `axiom`) so
+    the gap is visible to `#check_sorry` and gallery sorry counters. A
+    genuine classification requires Hasse-Witt invariants, local
+    classification at each prime, and global assembly via class field theory. -/
+theorem rational_classification_complete (Q₁ Q₂ : QuadraticForm ℚ (Fin n → ℚ)) :
+    AreEquivalent Q₁ Q₂ ↔ True := by
+  sorry
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART VI: WITT RING STRUCTURE
@@ -315,9 +315,9 @@ If Q₁ ⊥ Q ≅ Q₂ ⊥ Q (orthogonal sum), then Q₁ ≅ Q₂.
 This allows "cancellation" of common summands in quadratic form equations. -/
 theorem witt_cancellation {F : Type*} [Field F] [CharZero F] (n m : ℕ)
     (Q₁ Q₂ Q : QuadraticForm F (Fin n → F)) :
-    -- If Q₁ ⊥ Q ≅ Q₂ ⊥ Q then Q₁ ≅ Q₂
+    -- Conclusion is `True` placeholder until Witt's theorem is formalized.
     True := by
-  trivial -- Witt's theorem (1937)
+  sorry -- Witt's theorem (1937) (placeholder)
 
 /-- The hyperbolic plane H = ⟨1, -1⟩ is the basic "trivial" quadratic form. -/
 def hyperbolicPlane (F : Type*) [Field F] : QuadraticForm F (Fin 2 → F) :=
@@ -404,8 +404,11 @@ over any local field (this is Meyer's theorem for p-adics). -/
 theorem dimension_five_always_isotropic (p : ℕ) [Fact (Nat.Prime p)]
     (Q : QuadraticForm ℚ (Fin 5 → ℚ)) :
     RepresentsZeroOverPadic Q p := by
-  -- Meyer's theorem: forms in ≥ 5 variables are isotropic over ℚₚ
-  trivial
+  -- Meyer's theorem: forms in ≥ 5 variables are isotropic over ℚₚ.
+  -- Conclusion currently unfolds to `True` since `RepresentsZeroOverPadic` is a
+  -- placeholder definition; we mark this as `sorry` until the proper formal
+  -- statement (via tensor products with ℚₚ) is in place.
+  sorry
 
 /-- **Open Problem**: Full classification of quadratic forms over general
     number fields remains an active area of research. -/
@@ -435,10 +438,11 @@ def HilbertSymbol (a b : ℚ) (p : ℕ) [Fact (Nat.Prime p)] : ℤ :=
 
 This is a generalization of quadratic reciprocity. -/
 theorem hilbert_reciprocity (a b : ℚ) (ha : a ≠ 0) (hb : b ≠ 0) :
-    -- Product of all Hilbert symbols equals 1
+    -- Conclusion is `True` placeholder until the product formula for Hilbert
+    -- symbols is formalized.
     True := by
-  -- Consequence of global class field theory
-  trivial
+  -- Consequence of global class field theory (placeholder)
+  sorry
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART X: SUMMARY

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 7,
     "mathlibDependencies": [
       {
         "theorem": "QuadraticForm",
@@ -30,11 +30,11 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 11,
-    "axiomCount": 5,
-    "lineCount": 494,
-    "assumptions": "5 axiom declarations: diagonalForm, sylvester_law_of_inertia, hasse_minkowski_alt, rational_classification_complete, selmer_curve_no_rational_points. Additionally, 5 theorem-stubs with vacuous True conclusions (proved by trivial, not genuine proofs): weak_hasse_principle, ternary_representation, witt_cancellation, dimension_five_always_isotropic, hilbert_reciprocity. Three definitions use True as a placeholder body (RepresentsZeroOverReals, RepresentsZeroOverPadic, HasseMinkowskiNumberField), so hasse_minkowski_alt reduces to IsIsotropic Q ↔ True — a vacuous axiom. HilbertSymbol is hardcoded to 1 as a placeholder. See Lean source for complete statements.",
+    "axiomCount": 3,
+    "lineCount": 498,
+    "assumptions": "3 axiom declarations: diagonalForm (existence of diagonal quadratic forms), sylvester_law_of_inertia (real classification by signature), selmer_curve_no_rational_points (Selmer's counterexample to Hasse for cubics). Two former axioms (hasse_minkowski_alt, rational_classification_complete) are now placeholder theorems with sorry, since their conclusions reduce to True ↔ True via True-placeholder definitions; converting to sorry makes the gap visible to #check_sorry instead of asserting a vacuous axiom. Five additional placeholder theorems carry sorry: weak_hasse_principle, ternary_representation, witt_cancellation, dimension_five_always_isotropic, hilbert_reciprocity (their formal statements depend on tensor products with R/Q_p that are not yet formalized). Three definitions still use True as a placeholder body (RepresentsZeroOverReals, RepresentsZeroOverPadic, HasseMinkowskiNumberField), and HilbertSymbol is hardcoded to 1. Only four_squares_connection is fully proved (via Mathlib's Nat.sum_four_squares).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7
+    "theoremCount": 9
   },
   "overview": {
     "historicalContext": "Hilbert's 11th Problem, posed in his famous 1900 address at the International Congress of Mathematicians in Paris, asks for the classification of quadratic forms $Q(x_1, \\ldots, x_n) = \\sum a_{ij} x_i x_j$ with coefficients in algebraic number fields. The roots of this question trace to Gauss's *Disquisitiones Arithmeticae* (1801), which classified binary quadratic forms over $\\mathbb{Z}$ using genera and class numbers. Hermann Minkowski, Hilbert's close friend and colleague at Gottingen, proved the local-global principle for ternary quadratic forms in 1890 using his geometry of numbers. Helmut Hasse, a student of Kurt Hensel (inventor of $p$-adic numbers), extended this in his 1923 dissertation to all dimensions, establishing the full Hasse-Minkowski theorem: a quadratic form over $\\mathbb{Q}$ represents zero nontrivially if and only if it does so over $\\mathbb{R}$ and over $\\mathbb{Q}_p$ for every prime $p$. Ernst Witt developed the algebraic theory of quadratic forms in 1937, introducing the Witt ring $W(F)$ and proving Witt cancellation. James Sylvester's law of inertia (1852) had earlier provided the classification over $\\mathbb{R}$ via the signature $(p,q)$. The discovery by Ernst Selmer in 1951 that the cubic curve $3x^3 + 4y^3 + 5z^3 = 0$ violates the Hasse principle showed this beautiful local-global approach is special to quadratic forms. Yuri Manin's introduction of the Brauer-Manin obstruction (1970) provided a systematic explanation for such failures.",
@@ -83,26 +83,26 @@
     {
       "id": "hasse-minkowski",
       "title": "The Hasse-Minkowski Theorem",
-      "summary": "The central result. Defines `RepresentsZeroOverReals` and `RepresentsZeroOverPadic` (placeholder `True` pending tensor product formalization), states `HasseMinkowskiTheorem` as a `def`, and axiomatizes `hasse_minkowski_alt`: $Q$ is isotropic $\\iff$ locally isotropic everywhere.",
+      "summary": "The central result. Defines `RepresentsZeroOverReals` and `RepresentsZeroOverPadic` (placeholder `True` pending tensor product formalization), states `HasseMinkowskiTheorem` as a `def`, and gives `hasse_minkowski_alt` ($Q$ is isotropic $\\iff$ locally isotropic everywhere) as a placeholder theorem with `sorry`.",
       "startLine": 157,
-      "endLine": 210,
-      "mathContext": "Defines `RepresentsZeroOverReals` and `RepresentsZeroOverPadic` (placeholder `True` pending tensor product formalization), states `HasseMinkowskiTheorem` as a `def`, and axiomatizes `hasse_minkowski_alt`: $Q$ is isotropic $\\iff$ locally isotropic everywhere."
+      "endLine": 211,
+      "mathContext": "Defines `RepresentsZeroOverReals` and `RepresentsZeroOverPadic` (placeholder `True` pending tensor product formalization), states `HasseMinkowskiTheorem` as a `def`, and gives `hasse_minkowski_alt` ($Q$ is isotropic $\\iff$ locally isotropic everywhere) as a placeholder theorem with `sorry`."
     },
     {
       "id": "consequences",
       "title": "Consequences and Applications",
-      "summary": "Derives the weak Hasse principle (local representation of $a \\in \\mathbb{Q}^*$ implies global), ternary representation theorem, and axiomatizes **Lagrange's four squares theorem** (1770): $\\forall n \\in \\mathbb{N}, \\exists a,b,c,d \\in \\mathbb{Z}: n = a^2 + b^2 + c^2 + d^2$.",
-      "startLine": 211,
-      "endLine": 253,
-      "mathContext": "Derives the weak Hasse principle (local representation of $a \\in \\mathbb{Q}^*$ implies global), ternary representation theorem, and axiomatizes **Lagrange's four squares theorem** (1770): $\\forall n \\in \\mathbb{N}, \\exists a,b,c,d \\in \\mathbb{Z}: n = a^2 + b^2 + c^2 + d^2$."
+      "summary": "States the weak Hasse principle and ternary representation theorem as placeholder theorems with `sorry` (their formal statements depend on tensor products with $\\mathbb{R}/\\mathbb{Q}_p$ and on Hasse-Minkowski). Proves **Lagrange's four squares theorem** (1770): $\\forall n \\in \\mathbb{N}, \\exists a,b,c,d \\in \\mathbb{Z}: n = a^2 + b^2 + c^2 + d^2$ via Mathlib's `Nat.sum_four_squares`.",
+      "startLine": 212,
+      "endLine": 254,
+      "mathContext": "States the weak Hasse principle and ternary representation theorem as placeholder theorems with `sorry`. Proves **Lagrange's four squares theorem** via Mathlib."
     },
     {
       "id": "classification",
       "title": "Classification Results",
-      "summary": "Defines classification types: `realClassification` (signature), `finiteFieldClassification` (dimension + discriminant class), and `RationalClassification` (dimension, discriminant in $\\mathbb{Q}^*/\\mathbb{Q}^{*2}$, Hasse-Witt invariants $\\varepsilon_v$). Axiomatizes completeness of rational classification.",
-      "startLine": 254,
-      "endLine": 299,
-      "mathContext": "Defines classification types: `realClassification` (signature), `finiteFieldClassification` (dimension + discriminant class), and `RationalClassification` (dimension, discriminant in $\\mathbb{Q}^*/\\mathbb{Q}^{*2}$, Hasse-Witt invariants $\\varepsilon_v$). Axiomatizes completeness of rational classification."
+      "summary": "Defines classification types: `realClassification` (signature), `finiteFieldClassification` (dimension + discriminant class), and `RationalClassification` (dimension, discriminant in $\\mathbb{Q}^*/\\mathbb{Q}^{*2}$, Hasse-Witt invariants $\\varepsilon_v$). States completeness of rational classification as a placeholder theorem with `sorry`.",
+      "startLine": 255,
+      "endLine": 298,
+      "mathContext": "Defines classification types: `realClassification` (signature), `finiteFieldClassification` (dimension + discriminant class), and `RationalClassification` (dimension, discriminant in $\\mathbb{Q}^*/\\mathbb{Q}^{*2}$, Hasse-Witt invariants $\\varepsilon_v$). States completeness of rational classification as a placeholder theorem with `sorry`."
     },
     {
       "id": "witt-ring",
@@ -123,26 +123,26 @@
     {
       "id": "number-fields",
       "title": "Extensions to Number Fields",
-      "summary": "States the Hasse-Minkowski theorem for general number fields $K$. Proves **Meyer's theorem** for $\\dim \\geq 5$: forms in $\\geq 5$ variables are always isotropic over $\\mathbb{Q}_p$. Lists open problems: explicit algorithms, Langlands connections, function fields, higher reciprocity.",
+      "summary": "States the Hasse-Minkowski theorem for general number fields $K$. **Meyer's theorem** for $\\dim \\geq 5$ (every form in $\\geq 5$ variables is isotropic over $\\mathbb{Q}_p$) is stated as a placeholder theorem with `sorry`. Lists open problems: explicit algorithms, Langlands connections, function fields, higher reciprocity.",
       "startLine": 383,
-      "endLine": 420,
-      "mathContext": "States the Hasse-Minkowski theorem for general number fields $K$. Proves **Meyer's theorem** for $\\dim \\geq 5$: forms in $\\geq 5$ variables are always isotropic over $\\mathbb{Q}_p$."
+      "endLine": 423,
+      "mathContext": "States the Hasse-Minkowski theorem for general number fields $K$. **Meyer's theorem** for $\\dim \\geq 5$ stated as a placeholder theorem with `sorry`."
     },
     {
       "id": "hilbert-symbol",
       "title": "Hilbert Symbol and Reciprocity",
-      "summary": "Defines the **Hilbert symbol** $(a,b)_p \\in \\{\\pm 1\\}$ and states **Hilbert reciprocity**: $\\prod_v (a,b)_v = 1$, which generalizes quadratic reciprocity and connects quadratic forms to class field theory.",
-      "startLine": 421,
-      "endLine": 445,
-      "mathContext": "Defines the **Hilbert symbol** $(a,b)_p \\in \\{\\pm 1\\}$ and states **Hilbert reciprocity**: $\\prod_v (a,b)_v = 1$, which generalizes quadratic reciprocity and connects quadratic forms to class field theory."
+      "summary": "Defines the **Hilbert symbol** $(a,b)_p \\in \\{\\pm 1\\}$ (hardcoded to 1 as a placeholder) and states **Hilbert reciprocity** $\\prod_v (a,b)_v = 1$ as a placeholder theorem with `sorry`. The genuine theorem generalizes quadratic reciprocity and connects quadratic forms to class field theory.",
+      "startLine": 424,
+      "endLine": 449,
+      "mathContext": "Defines the **Hilbert symbol** $(a,b)_p \\in \\{\\pm 1\\}$ (hardcoded to 1) and states **Hilbert reciprocity** $\\prod_v (a,b)_v = 1$ as a placeholder theorem with `sorry`."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "The `hilbert11_summary` theorem (proved by `trivial`) synthesizes all components: Hasse-Minkowski theorem, classification theory, Witt ring, Hilbert symbol, Selmer counterexample, and open problems. Includes `#check` commands verifying key definitions.",
-      "startLine": 446,
-      "endLine": 494,
-      "mathContext": "The `hilbert11_summary` theorem (proved by `trivial`) synthesizes all components: Hasse-Minkowski theorem, classification theory, Witt ring, Hilbert symbol, Selmer counterexample, and open problems. Includes `#check` commands verifying key definitions."
+      "summary": "A `hilbert11_summary : (1 : ℕ) + 1 = 2` proved by `rfl` synthesizes all components in its docstring: Hasse-Minkowski theorem, classification theory, Witt ring, Hilbert symbol, Selmer counterexample, and open problems. Includes `#check` commands verifying key definitions.",
+      "startLine": 450,
+      "endLine": 498,
+      "mathContext": "A `hilbert11_summary : (1 : ℕ) + 1 = 2` proved by `rfl` synthesizes all components in its docstring. Includes `#check` commands verifying key definitions."
     }
   ],
   "conclusion": {
@@ -206,12 +206,12 @@
       "Matrix"
     ],
     "namespace": "Hilbert11QuadraticForms",
-    "lineCount": 494,
-    "axiomCount": 5,
-    "theoremCount": 7,
+    "lineCount": 498,
+    "axiomCount": 3,
+    "theoremCount": 9,
     "definitionCount": 17,
     "path": "Proofs/Hilbert11_QuadraticForms.lean",
-    "sorries": 0
+    "sorries": 7
   },
   "references": [
     {
@@ -249,5 +249,5 @@
       "leanType": "forall n : Nat, exists a b c d : Int, n = a^2 + b^2 + c^2 + d^2"
     }
   ],
-  "sorries": 0
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

Convert two vacuous `axiom` declarations in `Hilbert11_QuadraticForms.lean` to `sorry`-based theorems, and convert 5 trivially-proved `True`-stub theorems to `sorry` proofs.

## Evidence

**Problem**: `hasse_minkowski_alt` and `rational_classification_complete` were declared as `axiom`, permanently asserting false mathematical statements (their conclusions reduced to `True` via placeholder `True` definitions). An axiom is silently assumed to be true — these were corrupting any downstream reasoning.

**Fix**:
- `hasse_minkowski_alt`: `axiom` → `theorem ... := by sorry`
- `rational_classification_complete`: `axiom` → `theorem ... := by sorry`
- 5 True-stub theorems (`weak_hasse_principle`, `ternary_representation`, `witt_cancellation`, `dimension_five_always_isotropic`, `hilbert_reciprocity`): `trivial` → `sorry`, making the placeholder gaps visible to `#check_sorry`

**Metadata updated**:
| Field | Before | After |
|-------|--------|-------|
| `axiomCount` | 5 | 3 |
| `sorries` | 0 | 7 |
| `theoremCount` | 7 | 9 |
| `lineCount` | 494 | 498 |

Closes #15172

---
Automated fix by lean-mechanic agent.