### PR TITLE
fix(erdos-1201): sync meta counts after Bertrand additions (#15174)

### DIFF
--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 14 structural theorems are fully proved.",
-    "lineCount": 266,
+    "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 21 structural theorems are fully proved.",
+    "lineCount": 297,
     "mathlib_version": "4.26.0",
-    "theoremCount": 19
+    "theoremCount": 21
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) → ∞ as n → ∞, but its distribution among products of consecutive integers is much subtler. The ε=1/2 case was established by Erdős: there exist arbitrarily long windows of consecutive integers containing a prime exceeding √n. The full conjecture—that large prime factors dominate for almost all starting points n, for any threshold n^(1-ε)—remains open.",
@@ -95,7 +95,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 1201 on greatest prime factors of consecutive products, the partial ε=1/2 result, and 14 structural theorems. 0 sorries, 1 axiom (the partial result).",
+    "summary": "The formalization captures Erdős Problem 1201 on greatest prime factors of consecutive products, the partial ε=1/2 result, and 21 structural theorems. 0 sorries, 1 axiom (the partial result).",
     "implications": "Resolution would advance our understanding of the distribution of prime factors in consecutive integer products and connect to the Sylvester-Schur theorem and smooth number theory.",
     "openQuestions": [
       "Does the full conjecture hold for all ε > 0?",
@@ -108,14 +108,15 @@
       "Mathlib.Data.Nat.Factors",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Data.Real.Basic",
-      "Mathlib.Tactic"
+      "Mathlib.Tactic",
+      "Mathlib.NumberTheory.Bertrand"
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 266,
+    "lineCount": 297,
     "axiomCount": 1,
-    "theoremCount": 19,
-    "definitionCount": 4,
+    "theoremCount": 21,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

PR #15174 added 2 new theorems and a new import to `Erdos1201Problem.lean` but `meta.json` was not re-synced, leaving stale counts.

## Evidence

**Before** (`src/data/proofs/erdos-1201/meta.json`):
- `meta.theoremCount`: 19
- `meta.lineCount`: 266
- `meta.assumptions`: "...All 14 structural theorems..."
- `leanFile.theoremCount`: 19
- `leanFile.lineCount`: 266
- `leanFile.definitionCount`: 4 (was already off)
- `leanFile.imports`: missing `Mathlib.NumberTheory.Bertrand`
- `conclusion.summary`: "...14 structural theorems..."

**After** (matches `proofs/Proofs/Erdos1201Problem.lean` on `origin/main`):
- `meta.theoremCount`: 21
- `meta.lineCount`: 297
- `leanFile.theoremCount`: 21
- `leanFile.lineCount`: 297
- `leanFile.definitionCount`: 5 (greatestPrimeFactor, consecutiveProduct, gpfConsecutive, upperDensity, ErdosProblem1201)
- `leanFile.imports`: + `Mathlib.NumberTheory.Bertrand`
- assumptions/conclusion prose updated 14 → 21

This addresses the lingering `audit-tracker.json` `issues-found` entry for `erdos-1201` (the original 14→19 finding was fixed in #15124, but #15174 introduced new drift).

---
Automated fix by lean-mechanic agent.