### PR TITLE
fix(knights-tour-oblique): correct meta.assumptions to describe axiom (#15185)

### DIFF
--- a/src/data/proofs/knights-tour-oblique/meta.json
+++ b/src/data/proofs/knights-tour-oblique/meta.json
@@ -20,7 +20,7 @@
       "winding-number"
     ],
     "axiomCount": 1,
-    "assumptions": "None.",
+    "assumptions": "1 axiom: knuth_unique_four_oblique — any closed knight's tour with exactly 4 oblique turns is D4-equivalent to the minimal oblique tour. Accepted based on Knuth's exhaustive computational verification of all ~13.3 trillion closed knight's tours (TAOCP Vol 4 Fascicle 8a, December 2025).",
     "proofRepoPath": "Proofs/KnightsTourOblique.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 2469,


### PR DESCRIPTION
## Fix

Update `src/data/proofs/knights-tour-oblique/meta.json` so the `assumptions` field accurately describes the `knuth_unique_four_oblique` axiom instead of saying "None.".

## Evidence

**Before**: `"assumptions": "None."` while `axiomCount: 1`, `status: "axiomatized"`, `badge: "axiom"`, and `proofs/Proofs/KnightsTourOblique.lean:2358` declares `axiom knuth_unique_four_oblique`.

**After**: `"assumptions"` describes the axiom: any closed knight's tour with exactly 4 oblique turns is D4-equivalent to the minimal oblique tour, accepted based on Knuth's exhaustive computational verification of all ~13.3 trillion closed knight's tours (TAOCP Vol 4 Fascicle 8a, December 2025).

All other counts (sorries: 0, axiomCount: 1, theoremCount: 111, lineCount: 2469) already match the Lean source.

Closes #15185

---
Automated fix by lean-mechanic agent.