### PR TITLE
fix(shannon-source-coding-oq-03): sync stale meta — mark proof verified (0 sorries)

### DIFF
--- a/research/problems/shannon-source-coding-oq-03/knowledge.md
+++ b/research/problems/shannon-source-coding-oq-03/knowledge.md
@@ -2,7 +2,7 @@
 
 **Problem**: Can the AEP be formalized using Mathlib's probability infrastructure for the discrete finite-alphabet case?
 
-**Status**: NEAR-COMPLETE — gallery entry created, 1 sorry remaining
+**Status**: COMPLETE — 0 sorries, 0 axioms, badge: verified
 
 ---
 
@@ -34,6 +34,31 @@
 - `src/data/research/problems/shannon-source-coding-oq-03.json` (updated knowledge)
 
 ### Next Steps
-1. Prove `expVal_bilinear`: E[g(Xᵢ)·h(Xⱼ)] = E[g(Xᵢ)]·E[h(Xⱼ)] for i≠j (~50 lines, same Fintype.prod_sum technique)
-2. Use `expVal_bilinear` to prove `empEnt_variance` and eliminate the last sorry
-3. After all sorries resolved: badge upgrades to `verified`, 0 axioms, 0 sorries
+(Completed — no action needed)
+
+---
+
+## Session 2026-05-03 (Session 2) — Meta Sync (researcher-7)
+
+**Mode**: REVISIT
+**Outcome**: meta sync — stale meta.json corrected, pool updated to completed
+
+### What I Did
+- Discovered PR #15149 had already merged the full proof (including `expVal_marginal_product` and complete `empEnt_variance`)
+- Found meta.json still reported `sorries: 1`, `status: "formalized"`, `badge: "wip"`, stale line/theorem counts
+- Synced meta.json: status → "verified", badge → "verified", sorries → 0, lineCount 355→476, theoremCount 12→13, definitionCount 6→7
+- Removed stale "one sorry remains" contribution text; added entries for bilinear lemma and empEnt_variance completion
+- Updated conclusion.summary and openQuestions to reflect fully proved status
+- Updated pool: status "available" → "completed"
+- Updated knowledge.json progressSummary and nextSteps
+
+### Key Findings
+- The `expVal_marginal_product` proof uses the identical `Fintype.prod_sum` + `Finset.mul_prod_erase` pattern as `expVal_marginal` but applied to two active coordinates j₁ and j₂ simultaneously
+- `empEnt_variance` proof: define centered `Z(a) = -log p(a) - H`; show `E[(empEnt-H)²] = (1/n²) * ∑ᵢ∑ⱼ E[Z(Xᵢ)Z(Xⱼ)]`; diagonal terms give `logVar D` each (via `expVal_marginal`), off-diagonal give 0 (via `expVal_marginal_product` + `E[Z]=0`)
+- The proof requires `E[Z]=0` as a separate lemma (`hZ_mean`) proved by expanding the `shannonH` definition
+
+### Files Modified
+- `src/data/proofs/shannon-source-coding-oq-03/meta.json` (synced)
+- `src/data/research/problems/shannon-source-coding-oq-03.json` (knowledge updated)
+- `research/problems/shannon-source-coding-oq-03/knowledge.md` (this file)
+- `.lean/state/candidate-pool.json` (status: completed)

--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Claude Shannon (1948), Brockway McMillan (1953), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Asymptotic_equipartition_property",
     "date": "1953",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ShannonSourceCodingOQ03.lean",
     "tags": [
       "information-theory",
@@ -16,8 +16,8 @@
       "coding-theory",
       "advanced"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Algebra.BigOperators.Pi",
@@ -40,12 +40,13 @@
       "Proved expVal_empEnt: expected empirical entropy equals Shannon entropy, using expVal_marginal across all coordinates",
       "Proved aep_concentration: Chebyshev bound P(|empEnt - H| > ε) ≤ logVar/(n·ε²) (fixed bug in prior version)",
       "Proved typical_set_size_upper: |T_ε^(n)| ≤ exp(n·(H+ε)) without any axioms",
-      "One sorry remains: empEnt_variance (needs 2D marginal for i≠j cross-term independence)"
+      "2D bilinear marginal factorization (expVal_marginal_product): E[g₁(Xⱼ₁)·g₂(Xⱼ₂)] = E[g₁]·E[g₂] for j₁ ≠ j₂, extending expVal_marginal via Fintype.prod_sum with two active coordinates",
+      "Proved empEnt_variance = logVar/n: diagonal terms contribute logVar D each via expVal_marginal, cross terms are zero via expVal_marginal_product + mean-centering. Fully closes AEP formalization."
     ],
     "assumptions": [],
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
-    "lineCount": 355,
+    "lineCount": 476,
     "prerequisites": [
       "Shannon entropy H(X) = -∑ p(x) log p(x)",
       "Chebyshev's inequality for finite probability spaces",
@@ -110,7 +111,7 @@
       "title": "AEP Concentration and Typical Set",
       "startLine": 244,
       "endLine": 290,
-      "summary": "logVar, empEnt_variance (sorry), aep_concentration, typical_set_size_upper.",
+      "summary": "logVar, expVal_marginal_product (2D bilinear), empEnt_variance (fully proved), aep_concentration, typical_set_size_upper.",
       "mathContext": "The AEP bounds via Chebyshev + variance factorization, and the typical set size upper bound."
     }
   ],
@@ -132,23 +133,23 @@
     }
   ],
   "conclusion": {
-    "summary": "The AEP is formalized for finite discrete memoryless sources: empirical entropy concentrates around H(p) with explicit Chebyshev bounds, and the typical set has size at most exp(n(H+ε)). One sorry remains for the variance factorization (cross-term independence).",
+    "summary": "The AEP is fully formalized for finite discrete memoryless sources: empirical entropy concentrates around H(p) with explicit Chebyshev bounds, and the typical set has size at most exp(n(H+ε)). Zero sorries, zero axioms — complete machine-checked proof.",
     "implications": "The AEP is the cornerstone of information theory: it operationalizes entropy as the compression limit, provides the probability-1 characterization of typical sequences, and underpins both the achievability and converse of Shannon's source coding theorem.",
     "openQuestions": [
-      "Can empEnt_variance be proved via a 2D expVal_marginal (bilinear independence E[g(Xᵢ)h(Xⱼ)] = E[g(Xᵢ)]·E[h(Xⱼ)])?",
-      "Can the AEP be extended to ergodic (non-i.i.d.) sources using Mathlib's ergodic theory?"
+      "Can the AEP be extended to ergodic (non-i.i.d.) sources using Mathlib's ergodic theory?",
+      "Can the concentration bound logVar/(n·ε²) be tightened to an exact large-deviations rate using Cramér's theorem?"
     ]
   },
   "leanFile": {
     "imports": ["Mathlib"],
     "opens": ["Real", "Finset", "BigOperators"],
     "namespace": "AEPFormalization",
-    "lineCount": 355,
+    "lineCount": 476,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 6,
+    "theoremCount": 13,
+    "definitionCount": 7,
     "path": "Proofs/ShannonSourceCodingOQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/research/problems/shannon-source-coding-oq-03.json
+++ b/src/data/research/problems/shannon-source-coding-oq-03.json
@@ -29,30 +29,35 @@
     }
   },
   "knowledge": {
-    "progressSummary": "NEAR-COMPLETE: expVal_marginal, expVal_empEnt, aep_concentration, typical_set_size_upper all proved. One sorry: empEnt_variance (cross-term independence for i\u2260j). Gallery entry created.",
+    "progressSummary": "COMPLETE: AEP fully formalized (0 sorries, 0 axioms). expVal_marginal_product proved bilinear independence; empEnt_variance eliminates the last sorry. 13 theorems, 476 lines. Badge: verified.",
     "builtItems": [
       "DiscreteDist structure: finite prob dist on Fin k",
       "jointProb: i.i.d. product measure on n-sequences",
       "empEnt: empirical entropy -(1/n) log P(x)",
       "chebyshev_finite: Chebyshev proved for finite distributions",
-      "typical_prob_lower_bound: proved (each typical seq has P(x) >= exp(-n(H+\u03b5)))",
-      "typical_set_size_upper: proved (|T_\u03b5| <= exp(n(H+\u03b5)))",
+      "typical_prob_lower_bound: proved (each typical seq has P(x) >= exp(-n(H+ε)))",
+      "typical_set_size_upper: proved (|T_ε| <= exp(n(H+ε)))",
       "Lean file: proofs/Proofs/ShannonSourceCodingOQ03.lean (309 lines)",
       "Gallery entry: src/data/proofs/shannon-source-coding-oq-03/",
       "expVal_marginal: proved in ShannonSourceCodingOQ03.lean (Fintype.prod_sum + Finset.mul_prod_erase)",
       "expVal_empEnt: proved with (hn : 0 < n) hypothesis using expVal_marginal",
-      "aep_concentration: proved using empEnt_variance + Chebyshev (bug-free version)"
+      "aep_concentration: proved using empEnt_variance + Chebyshev (bug-free version)",
+      "expVal_marginal_product: private lemma for 2D independence in ShannonSourceCodingOQ03.lean",
+      "empEnt_variance: fully proved (was sorry) — variance formula Var[empEnt] = logVar/n"
     ],
     "insights": [
       "AEP = LLN applied to -log p(X): empirical entropy concentrates around H(p)",
-      "Chebyshev finite case: P(|f-\u03bc|>\u03b5) \u2264 E[(f-\u03bc)\u00b2]/\u03b5\u00b2 provable for finite prob spaces",
-      "Typical set size upper bound |T_\u03b5|\u2264exp(n(H+\u03b5)) proved via counting argument",
-      "Key sorry: marginal factorization \u03a3_x P(x)*g(x_i) = \u03a3_a p(a)*g(a) needs Fintype.sum_piFinset_succ",
-      "logVar = E[(log p(X))\u00b2] - H(p)\u00b2 is the AEP concentration parameter",
+      "Chebyshev finite case: P(|f-μ|>ε) ≤ E[(f-μ)²]/ε² provable for finite prob spaces",
+      "Typical set size upper bound |T_ε|≤exp(n(H+ε)) proved via counting argument",
+      "Key sorry: marginal factorization Σ_x P(x)*g(x_i) = Σ_a p(a)*g(a) needs Fintype.sum_piFinset_succ",
+      "logVar = E[(log p(X))²] - H(p)² is the AEP concentration parameter",
       "expVal_marginal proved via Fintype.prod_sum: factors joint expectation into single-coord marginal",
       "expVal_empEnt proved from expVal_marginal: E[empEnt] = H by linearity + n equal marginal contributions",
       "aep_concentration bug fixed: original used rw[expVal_empEnt] which doesn't apply to variance; corrected to use empEnt_variance",
-      "empEnt_variance requires 2D marginal (bilinear independence): E[Z_i*Z_j] = E[Z_i]*E[Z_j] for i\u2260j"
+      "empEnt_variance requires 2D marginal (bilinear independence): E[Z_i*Z_j] = E[Z_i]*E[Z_j] for i≠j",
+      "expVal_marginal_product (2D bilinear independence): E[g₁(Xⱼ₁)·g₂(Xⱼ₂)] = E[g₁]·E[g₂] for j₁≠j₂, proved via Fintype.prod_sum with two active coordinates using the same mul_prod_erase technique",
+      "empEnt_variance proof: define centered Z(a)=-log p(a)-H, show E[(empEnt-H)²] = (1/n)² * ∑ᵢ∑ⱼ E[Z(Xᵢ)Z(Xⱼ)]; diagonal terms give logVar D each, off-diagonal give 0 by bilinear+mean-zero",
+      "AEP fully formalized (0 sorries, 0 axioms): 13 theorems, 476 lines. Lean 4 / Mathlib complete machine-checked proof of the fundamental theorem of information theory"
     ],
     "mathlibGaps": [
       "Fintype.sum_piFinset_succ needed for marginal factorization in product measure",
@@ -60,9 +65,8 @@
       "2D expVal_marginal (bilinear independence) needed for empEnt_variance; not in Mathlib but buildable in ~50 lines"
     ],
     "nextSteps": [
-      "Prove expVal_bilinear: E[g(Xi)*h(Xj)] = E[g(Xi)]*E[h(Xj)] for i!=j (50 lines, same Fintype.prod_sum approach)",
-      "Use expVal_bilinear to prove empEnt_variance and eliminate the last sorry",
-      "After empEnt_variance proved, badge upgrades from formalized to verified (0 axioms, 0 sorries)"
+      "Consider ergodic AEP extension: can the result generalize beyond i.i.d. to ergodic sources via Mathlib's ergodic theory?",
+      "Large-deviations tightening: can the Chebyshev bound be replaced by an exact Cramér rate?"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- PR #15149 merged `empEnt_variance` proof (via `expVal_marginal_product` bilinear factorization) but meta.json was never updated
- This PR syncs meta.json to match the actual Lean file state on main
- Marks the AEP as `verified` (first full machine-checked proof of the AEP in this gallery)

## Changes

| Field | Before | After |
|-------|--------|-------|
| `meta.status` | `"formalized"` | `"verified"` |
| `meta.badge` | `"wip"` | `"verified"` |
| `meta.sorries` | `1` | `0` |
| `meta.lineCount` | `355` | `476` |
| `leanFile.theoremCount` | `12` | `13` |
| `leanFile.sorries` | `1` | `0` |

Also updates `originalContributions`, `conclusion.summary`, and `openQuestions` to reflect the completed proof.

## Test plan

- [ ] `meta.sorries: 0` matches `grep -c "^.*sorry" proofs/Proofs/ShannonSourceCodingOQ03.lean` (0)
- [ ] `meta.status: "verified"` consistent with 0 sorries + 0 axioms per axiom integrity policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)