### PR TITLE
fix(meta): sync stale theoremCount and lineCount for cevas and picks proofs

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "cevas-theorem-oq-01-oq-03",
   "title": "Routh's Theorem: Area Formula for Non-Concurrent Cevians",
   "slug": "cevas-theorem-oq-01-oq-03",
-  "description": "Proves Routh's theorem for general parameters d, e, f ∈ (0,1): the inner triangle formed by three non-concurrent cevians has signed area equal to routhRatio(d,e,f) = (def-(1-d)(1-e)(1-f))² / ((1-e+de)(1-f+ef)(1-d+fd)) times the original triangle area. Complete proof via coordinate intersection formulas and a single polynomial identity. 14 theorems, 0 axioms.",
+  "description": "Proves Routh's theorem for general parameters d, e, f ∈ (0,1): the inner triangle formed by three non-concurrent cevians has signed area equal to routhRatio(d,e,f) = (def-(1-d)(1-e)(1-f))² / ((1-e+de)(1-f+ef)(1-d+fd)) times the original triangle area. Complete proof via coordinate intersection formulas and a single polynomial identity. 19 theorems, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",
@@ -22,8 +22,8 @@
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 200,
-    "theoremCount": 14,
+    "lineCount": 230,
+    "theoremCount": 19,
     "definitionCount": 3,
     "originalContributions": [
       "routh_theorem_std: Routh's area formula — signedArea(P,Q,R) = routhRatio(d,e,f) * signedArea(A,B,C) for general parameters",
@@ -96,7 +96,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Fully proves Routh's theorem for arbitrary cevian parameters d, e, f ∈ (0,1). The key computation is the polynomial identity for signedArea(P,Q,R)/signedArea(A,B,C), proved by field_simp + ring after explicit vertex formulas. All 6 cevian memberships are verified. 14 theorems, 3 definitions, 0 axioms, 0 sorries.",
+    "summary": "Fully proves Routh's theorem for arbitrary cevian parameters d, e, f ∈ (0,1). The key computation is the polynomial identity for signedArea(P,Q,R)/signedArea(A,B,C), proved by field_simp + ring after explicit vertex formulas. All 6 cevian memberships are verified. 19 theorems, 3 definitions, 0 axioms, 0 sorries.",
     "implications": "This result completes the formalization of classical planar geometry via cevian theory. The Routh formula generalizes Ceva's theorem (ratio = 0 case) and connects to other triangle area formulas. It provides a computational tool for polygon area calculations in lattice geometry.",
     "openQuestions": [
       "Can Routh's theorem be generalized to higher-dimensional simplices? For a d-simplex with cevians from each vertex to the opposite face, is there an analogous interior volume formula?",
@@ -105,9 +105,9 @@
   },
   "leanFile": {
     "namespace": "RouthTheorem",
-    "lineCount": 200,
+    "lineCount": 230,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 19,
     "definitionCount": 3,
     "path": "Proofs/CevasTheoremOQ01OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/picks-theorem-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "picks-theorem-oq-02",
   "title": "GCD Boundary Formula for Lattice Points on a Segment",
   "slug": "picks-theorem-oq-02",
-  "description": "Proves the GCD boundary formula: the segment from (0,0) to (a,b) contains exactly gcd(a,b)+1 integer lattice points, parameterized by k ↦ (k·(a/g), k·(b/g)) for k=0,...,g. Complete proof: injectivity of the parameterization (at least one of a/g or b/g is positive), and completeness via coprimality (gcd(a/g, b/g)=1 forces p|x from x·q=y·p). 12 theorems, 0 axioms.",
+  "description": "Proves the GCD boundary formula: the segment from (0,0) to (a,b) contains exactly gcd(a,b)+1 integer lattice points, parameterized by k ↦ (k·(a/g), k·(b/g)) for k=0,...,g. Complete proof: injectivity of the parameterization (at least one of a/g or b/g is positive), and completeness via coprimality (gcd(a/g, b/g)=1 forces p|x from x·q=y·p). 13 theorems, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",
@@ -21,8 +21,8 @@
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 215,
-    "theoremCount": 12,
+    "lineCount": 245,
+    "theoremCount": 13,
     "definitionCount": 2,
     "originalContributions": [
       "card_segmentPoints: the GCD boundary formula — gcd(a,b)+1 lattice points on segment (0,0)→(a,b)",
@@ -104,7 +104,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Fully proves the GCD boundary formula for lattice points on a segment: card(segmentPoints(a,b)) = gcd(a,b)+1. The proof is machine-verified with 0 axioms and 0 sorries. Key techniques: Finset.card_image_of_injective for the cardinality, Nat.coprime_div_gcd_div_gcd + Nat.Coprime.dvd_of_dvd_mul_right for completeness. 12 theorems, 2 definitions, 215 lines.",
+    "summary": "Fully proves the GCD boundary formula for lattice points on a segment: card(segmentPoints(a,b)) = gcd(a,b)+1. The proof is machine-verified with 0 axioms and 0 sorries. Key techniques: Finset.card_image_of_injective for the cardinality, Nat.coprime_div_gcd_div_gcd + Nat.Coprime.dvd_of_dvd_mul_right for completeness. 13 theorems, 2 definitions, 245 lines.",
     "implications": "This formula is the foundation of the boundary count B in Pick's theorem. A polygon with n edges, each going from (xᵢ,yᵢ) to (xᵢ₊₁,yᵢ₊₁), has boundary count B = Σ gcd(|Δxᵢ|, |Δyᵢ|). With this formula formalized, a constructive proof of Pick's theorem (as opposed to the axiomatized version) requires formalizing triangulation of lattice polygons.",
     "openQuestions": [
       "Can Pick's theorem itself be fully proved in Lean by combining this GCD formula with a triangulation argument (ear-clipping or diagonal decomposition)?",
@@ -114,9 +114,9 @@
   },
   "leanFile": {
     "namespace": "PicksTheoremOQ02",
-    "lineCount": 215,
+    "lineCount": 245,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 2,
     "path": "Proofs/PicksTheoremOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- `cevas-theorem-oq-01-oq-03`: theoremCount 14→19 (file has 3 lemmas + 16 theorems = 19), lineCount 200→230
- `picks-theorem-oq-02`: theoremCount 12→13 (file has 13 theorems), lineCount 215→245
- Updated both `meta` and `leanFile` blocks, plus description and conclusion.summary text references in each file

## Test plan

- [ ] `pnpm build` passes (no structural changes, only count fields)
- [ ] Both gallery entries display correct theorem counts on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)