### PR TITLE
fix(cevas-theorem-oq-01-oq-03): sync stale counts + section ranges

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14023,6 +14023,12 @@
       "lastAudited": "2026-05-03T09:34:34Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "cevas-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T11:11:54Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 200,
-    "theoremCount": 14,
+    "lineCount": 230,
+    "theoremCount": 19,
     "definitionCount": 3,
     "originalContributions": [
       "routh_theorem_std: Routh's area formula — signedArea(P,Q,R) = routhRatio(d,e,f) * signedArea(A,B,C) for general parameters",
@@ -57,15 +57,15 @@
     {
       "id": "denominators",
       "title": "Denominator Positivity",
-      "startLine": 35,
-      "endLine": 50,
+      "startLine": 40,
+      "endLine": 54,
       "summary": "Three positivity lemmas: w₁ = 1-e+de > 0, w₂ = 1-f+ef > 0, w₃ = 1-d+fd > 0. Proved by nlinarith from d,e,f ∈ (0,1).",
       "mathContext": "$w_1 = 1-e+de = 1-e(1-d) > 0$ for $d,e \\in (0,1)$."
     },
     {
       "id": "vertices",
       "title": "Inner Triangle Vertex Formulas",
-      "startLine": 54,
+      "startLine": 56,
       "endLine": 70,
       "summary": "Explicit coordinates of P (AD∩BE), Q (BE∩CF), R (CF∩AD) as rational functions of d, e, f.",
       "mathContext": "$P = \\left(\\frac{(1-d)(1-e)}{w_1}, \\frac{d(1-e)}{w_1}\\right)$, $Q = \\left(\\frac{ef}{w_2}, \\frac{(1-e)(1-f)}{w_2}\\right)$, $R = \\left(\\frac{f(1-d)}{w_3}, \\frac{fd}{w_3}\\right)$."
@@ -73,24 +73,24 @@
     {
       "id": "membership",
       "title": "Cevian Membership Proofs",
-      "startLine": 74,
-      "endLine": 145,
+      "startLine": 72,
+      "endLine": 128,
       "summary": "Six membership theorems proving P ∈ AD∩BE, Q ∈ BE∩CF, R ∈ CF∩AD. Each uses an explicit parameter witness and field_simp + ring.",
       "mathContext": "P lies on AD with parameter $t = (1-e)/w_1$, and on BE with parameter $t = d/w_1$."
     },
     {
       "id": "main",
       "title": "Routh's Theorem — Main Formula",
-      "startLine": 149,
-      "endLine": 168,
+      "startLine": 130,
+      "endLine": 151,
       "summary": "routh_theorem_std: signedArea(P,Q,R) = routhRatio(d,e,f) × signedArea(A,B,C). Proved by field_simp + ring after establishing denominator nonvanishing.",
       "mathContext": "$\\frac{\\text{Area}(PQR)}{\\text{Area}(ABC)} = \\frac{(def-(1-d)(1-e)(1-f))^2}{w_1 w_2 w_3}$."
     },
     {
       "id": "applications",
       "title": "Corollaries and Applications",
-      "startLine": 172,
-      "endLine": 230,
+      "startLine": 153,
+      "endLine": 228,
       "summary": "Explicit area form, 1/7 verification (d=e=f=1/3), concurrent degeneration (area=0 iff Ceva), nonnegativity, asymmetric example (1/10), zero condition equivalence.",
       "mathContext": "Special case $d=e=f=1/3$: $\\text{Area}(PQR)/\\text{Area}(ABC) = 1/7$. Ceva condition gives ratio $= 0$."
     }
@@ -105,9 +105,9 @@
   },
   "leanFile": {
     "namespace": "RouthTheorem",
-    "lineCount": 200,
+    "lineCount": 230,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 19,
     "definitionCount": 3,
     "path": "Proofs/CevasTheoremOQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Audit of `cevas-theorem-oq-01-oq-03` (Routh's theorem for general parameters; PR #15173 just merged 2026-05-03).

**Integrity verdict**: claims match the Lean kernel.
- `status: verified`, `badge: original` ✓
- 0 sorries, 0 axioms, 0 True stubs ✓
- `axiomCount: 0` ✓

**Drift fixed** (cosmetic, low severity):
- `lineCount` 200 → 230 (file is now 230 lines)
- `theoremCount` 14 → 19 (3 lemmas + 16 theorems)
- All 5 section `startLine`/`endLine` ranges drifted 5–25 lines; realigned to PART I–V structure
- `leanFile.{lineCount,theoremCount}` synced to match

`definitionCount: 3` retained — represents the 3 `noncomputable def` (stdP/stdQ/stdR); the 3 `abbrev` std{A,B,C} are coordinate constants, not contributions, so excluding them is the right interpretation.

Tracker: `cevas-theorem-oq-01-oq-03` → `issues-fixed`.

## Test plan
- [x] sorry/axiom/True-stub count verified against `proofs/Proofs/CevasTheoremOQ01OQ03.lean`
- [x] Section line ranges spot-checked against the PART I–V markers
- [x] Audit tracker entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)