### PR TITLE
audit(tracker): cevas-theorem-oq-01-oq-03 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14023,6 +14023,12 @@
       "lastAudited": "2026-05-03T09:34:34Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "cevas-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T11:16:04Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary
- Audit of `cevas-theorem-oq-01-oq-03` (Routh's Theorem for general parameters): **clean**

## Verification
- **Tier A original**, badge `original`, status `verified`
- 230 lines (matches `lineCount`)
- 19 theorems+lemmas (matches `theoremCount`)
- 3 noncomputable defs `stdP/stdQ/stdR` (matches `definitionCount`; 3 abbrevs `stdA/stdB/stdC` are auxiliary unit-square constants)
- 0 sorries, 0 axioms, 0 True stubs in the file
- Parent `CevasTheoremOQ01.lean` also verified (0 axioms, 0 sorries)
- Imports only `Mathlib.Tactic` — no Mathlib theorem doing the core work; the polynomial identity is proved by `field_simp; ring` on explicit rational vertex formulas

## Arithmetic spot-checks
- `routh_asymmetric_example`: routhRatio(1/2, 1/3, 1/4) = (1/24 − 1/4)² / ((5/6)(5/6)(5/8)) = (25/576)/(125/288) = **1/10** ✓
- `routh_medial_thirds_area`: routhRatio(1/3, 1/3, 1/3) = (1/27 − 8/27)² / (7/9)³ = (49/729)/(343/729) = **1/7** ✓
- `routh_medians_zero`: at d=e=f=1/2, def = (1−d)(1−e)(1−f) = 1/8 → numerator squared is 0 ✓

## Test plan
- [x] `lineCount`, `theoremCount`, `sorries`, `axiomCount` match Lean source
- [x] No Mathlib wrapper (badge `original` justified)
- [x] Numerical claims in `routh_asymmetric_example` and `routh_medial_thirds_area` verified by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)