### PR TITLE
fix(erdos-1201): sync meta after PR #14942 + clear stale audit-tracker entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -300,11 +300,9 @@
     },
     "angle-trisection-oq-02-oq-01-oq-02-incomplete-01": {
       "auditCount": 3,
-      "issues": [
-        "sorry count mismatch: claimed 2, actual 1 (wantzel_galois_iff only); lineCount stale 436→625, theoremCount stale 19→21. Fixes in PRs #15140 and #15155."
-      ],
-      "lastAudited": "2026-05-03T09:09:49Z",
-      "result": "issues-found"
+      "issues": [],
+      "lastAudited": "2026-05-03T11:30:00Z",
+      "result": "issues-fixed"
     },
     "angle-trisection-oq-02-oq-02": {
       "auditCount": 2,
@@ -13956,11 +13954,9 @@
     },
     "erdos-1201": {
       "auditCount": 1,
-      "issues": [
-        "theoremCount 14→19: meta.json claims 14 theorems but Lean file has 19; lineCount 267→266 (trivial). Status/axioms/sorries correct. Research PR #15091 in flight will update meta."
-      ],
-      "lastAudited": "2026-05-03T07:03:19Z",
-      "result": "issues-found"
+      "issues": [],
+      "lastAudited": "2026-05-03T11:30:00Z",
+      "result": "issues-fixed"
     },
     "cantor-diagonalization-oq-01-oq-02": {
       "auditCount": 1,

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 21 structural theorems are fully proved.",
-    "lineCount": 297,
+    "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 22 structural theorems are fully proved.",
+    "lineCount": 310,
     "mathlib_version": "4.26.0",
-    "theoremCount": 21
+    "theoremCount": 22
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) → ∞ as n → ∞, but its distribution among products of consecutive integers is much subtler. The ε=1/2 case was established by Erdős: there exist arbitrarily long windows of consecutive integers containing a prime exceeding √n. The full conjecture—that large prime factors dominate for almost all starting points n, for any threshold n^(1-ε)—remains open.",
@@ -95,7 +95,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 1201 on greatest prime factors of consecutive products, the partial ε=1/2 result, and 21 structural theorems. 0 sorries, 1 axiom (the partial result).",
+    "summary": "The formalization captures Erdős Problem 1201 on greatest prime factors of consecutive products, the partial ε=1/2 result, and 22 structural theorems. 0 sorries, 1 axiom (the partial result).",
     "implications": "Resolution would advance our understanding of the distribution of prime factors in consecutive integer products and connect to the Sylvester-Schur theorem and smooth number theory.",
     "openQuestions": [
       "Does the full conjecture hold for all ε > 0?",
@@ -113,9 +113,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 297,
+    "lineCount": 310,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 22,
     "definitionCount": 5,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Two related metadata corrections discovered while looking for unaddressed auditor work.

### 1. `erdos-1201/meta.json` sync after PR #14942

PR #14942 added theorem `gpfConsecutive_ge_self_of_prime` (+13 lines) but merged 14 seconds after PR #15183 synced `meta.json`. As a result the gallery still claims 21 theorems / 297 lines while the file has 22 / 310.

| field | before | after |
|---|---|---|
| `meta.theoremCount` | 21 | 22 |
| `meta.lineCount` | 297 | 310 |
| `meta.assumptions` (count phrase) | "21 structural theorems" | "22 structural theorems" |
| `conclusion.summary` (count phrase) | "21 structural theorems" | "22 structural theorems" |
| `leanFile.theoremCount` | 21 | 22 |
| `leanFile.lineCount` | 297 | 310 |

Verified against `proofs/Proofs/Erdos1201Problem.lean` on `origin/main` (`7ecac68`):
- `wc -l` = 310
- `grep -cE "^(theorem|lemma)\s+"` = 22
- `grep -cE "^axiom\s+"` = 1
- `sorries` (excluding comments) = 0

### 2. Audit-tracker: clear two stale `issues-found` entries

Both entries cite fixes that have since merged:

- `angle-trisection-oq-02-oq-01-oq-02-incomplete-01` — note cited PRs #15140/#15155 (both closed); the actual sync landed in merged PR #15165. Current `meta.json` matches Lean source.
- `erdos-1201` — original `14→19` mismatch was fixed by merged PR #15124 (and re-synced by #15183 / by this PR for #14942's drift).

## Evidence

**Before** (origin/main):
- `audit-tracker.json` has `result: issues-found` for both entries with stale issue text referencing closed PRs.
- `erdos-1201/meta.json` claims 21 theorems / 297 lines vs source 22 / 310.

**After**:
- Both audit entries: `result: issues-fixed`, `issues: []`, `lastAudited: 2026-05-03T11:30:00Z`.
- `erdos-1201/meta.json` matches Lean source.

---
Automated fix by lean-mechanic agent.