### PR TITLE
fix(tracker): mark angle-trisection-incomplete-01 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -301,10 +301,11 @@
     "angle-trisection-oq-02-oq-01-oq-02-incomplete-01": {
       "auditCount": 3,
       "issues": [
-        "sorry count mismatch: claimed 2, actual 1 (wantzel_galois_iff only); lineCount stale 436→625, theoremCount stale 19→21. Fixes in PRs #15140 and #15155."
+        "sorry count mismatch: claimed 2, actual 1 (wantzel_galois_iff only); lineCount stale 436→625, theoremCount stale 19→21. Fixes in PRs #15140 and #15155.",
+        "Resolved by PRs #15165 (sync leanFile + lineCount 618), #15143 (reconcile meta), #15156 (tracker correction). Current state: meta.sorries=1, lineCount=618, theoremCount=21 — matches Lean source."
       ],
       "lastAudited": "2026-05-03T09:09:49Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "angle-trisection-oq-02-oq-02": {
       "auditCount": 2,


### PR DESCRIPTION
## Fix

Tracker still listed `result: issues-found` citing PRs #15140 and #15155 (both closed). The underlying meta drift was actually resolved by a different chain of PRs that landed afterward.

## Evidence

**Before** (`src/data/proofs/audit-tracker.json` entry for `angle-trisection-oq-02-oq-01-oq-02-incomplete-01`):
- `result`: `issues-found`
- only issue note references closed PRs #15140 / #15155

**After**:
- `result`: `issues-fixed`
- appended follow-up note crediting the actual resolving PRs:
  - #15165 — synced `leanFile.*` and corrected `lineCount` 625→618
  - #15143 — reconciled inner `meta` block
  - #15156 — earlier tracker correction setting status to issues-found

Current `origin/main` state for the entry now matches the Lean source:
- `meta.sorries`: 1 (matches file: 1 `wantzel_galois_iff` sorry)
- `meta.lineCount`: 618 (matches file)
- `meta.theoremCount`: 21 (matches `leanFile.theoremCount`)

## Validation

3-line minimal diff, no other tracker entries touched.

---
Automated fix by lean-mechanic agent.