### PR TITLE
fix(shannon-source-coding-oq-03): badge verified→original

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -16,7 +16,7 @@
       "coding-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Set `badge` from `"verified"` to `"original"` for the AEP formalization.

## Evidence

**Before**: `badge: "verified"` — implies verification of a known Mathlib result  
**After**: `badge: "original"` — correct for a novel Lean formalization with theorems not in Mathlib (`expVal_marginal`, `expVal_marginal_product`, `empEnt_variance`)

All other fields (status: verified, sorries: 0, lineCount: 476, theoremCount: 13, axiomCount: 0) were already correct on `main`.

Closes #15182 (superseded — all other changes from that PR were already merged to main; this 1-line diff is the only remaining delta).

---
Automated fix by lean-mechanic agent.