### PR TITLE
enrich: add annotations and index.ts for 4 gallery proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-02/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-ballot-fiber-preimage-decomp",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 56 },
+    "type": "technique",
+    "title": "Fiber Decomposition: A ∩ f⁻¹'P = ⋃_{t∈P} (A ∩ f⁻¹'{t})",
+    "content": "The theorem `preimage_inter_eq_iUnion` captures the fundamental set-theoretic identity: the preimage of a set P intersected with the domain A decomposes into a disjoint union of singleton fiber intersections. The proof is a clean `ext` argument using `simp` to unfold `mem_inter_iff`, `mem_preimage`, `mem_iUnion`, and `mem_singleton_iff`. This is a purely set-theoretic result requiring no finiteness or surjectivity assumptions — it holds for any function between any types.",
+    "mathContext": "A \\cap f^{-1}(P) = \\bigcup_{t \\in P} (A \\cap f^{-1}(\\{t\\})). \\text{ Proof: } x \\in \\text{LHS} \\iff (x \\in A) \\land (f(x) \\in P) \\iff \\exists t \\in P,\\, x \\in A \\land f(x) = t.",
+    "significance": "supporting",
+    "relatedConcepts": ["preimage decomposition", "fiber of a function", "Set.preimage", "Set.iUnion"],
+    "prerequisites": ["set theory", "Lean 4 Set.ext", "simp lemmas for Set membership"]
+  },
+  {
+    "id": "ann-ballot-fiber-surjon-decomp",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 58, "endLine": 68 },
+    "type": "technique",
+    "title": "Surjectivity Decomposition: A = ⋃_{t∈T} (A ∩ f⁻¹'{t})",
+    "content": "The theorem `surjOn_fiber_decomp` proves that when f is surjective from A onto T, the entire set A decomposes as a union of fibers over T. This uses `SurjOn f A T`: for any x ∈ A, surjectivity gives t = f(x) ∈ T (via `mem_image_of_mem`), placing x in the fiber over t. The key difference from `preimage_inter_eq_iUnion` is that surjectivity (`SurjOn`) is needed to guarantee coverage — without it, the union would only cover the image of f restricted to A, which might miss elements of T.",
+    "mathContext": "\\text{SurjOn}(f, A, T) \\implies A = \\bigcup_{t \\in T} (A \\cap f^{-1}(\\{t\\})). \\text{ This is the cover: every } x \\in A \\text{ lands in fiber over } f(x) \\in T.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.SurjOn", "surjective function", "fiber cover", "preimage singleton"],
+    "prerequisites": ["surjective functions", "Set.SurjOn definition", "mem_image_of_mem"]
+  },
+  {
+    "id": "ann-ballot-fiber-disjoint",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 70, "endLine": 76 },
+    "type": "technique",
+    "title": "Disjointness of Distinct Fibers",
+    "content": "The theorem `singleton_fiber_disjoint` proves that fibers over distinct points are disjoint: if t₁ ≠ t₂ then (A ∩ f⁻¹'{t₁}) ∩ (A ∩ f⁻¹'{t₂}) = ∅. The proof is a direct contradiction: if x is in both fibers, then f(x) = t₁ and f(x) = t₂, so t₁ = t₂, contradicting t₁ ≠ t₂. This is essential for the counting argument: the fiber decomposition is into DISJOINT pieces, so ncard of the union equals the sum of ncards.",
+    "mathContext": "t_1 \\neq t_2 \\implies (A \\cap f^{-1}(\\{t_1\\})) \\cap (A \\cap f^{-1}(\\{t_2\\})) = \\emptyset. \\text{ Without disjointness, } |\\bigcup_t F_t| \\neq \\sum_t |F_t|.",
+    "significance": "supporting",
+    "relatedConcepts": ["fiber disjointness", "disjoint sets", "Set.Disjoint", "inclusion-exclusion"],
+    "prerequisites": ["set disjointness", "Lean 4 disjoint_left"]
+  },
+  {
+    "id": "ann-ballot-uniform-counting",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 83, "endLine": 98 },
+    "type": "insight",
+    "title": "Uniform Fiber Counting: |A ∩ f⁻¹'P| = k · |P|",
+    "content": "The theorem `uniform_fiber_count` is the quantitative heart of the density argument. It combines three ingredients: (1) the preimage decomposition (from Part I), (2) `BallotFiberTransfer.ncard_biUnion_eq_of_uniform` (the parent file's key lemma that counts a union of k-sized disjoint pieces), and (3) the disjointness of fibers. The result: if every fiber over T has exactly k elements, then the fiber over ANY subset P ⊆ T has exactly k·|P| elements. The proof delegates entirely to the parent module, making this a one-step application.",
+    "mathContext": "\\text{If } |A \\cap f^{-1}(\\{t\\})| = k \\text{ for all } t \\in T \\text{ and } P \\subseteq T: \\quad |A \\cap f^{-1}(P)| = \\sum_{t \\in P} |A \\cap f^{-1}(\\{t\\})| = k \\cdot |P|.",
+    "significance": "key",
+    "relatedConcepts": ["ncard of disjoint union", "uniform partition", "counting lemma", "BallotFiberTransfer"],
+    "prerequisites": ["Set.ncard", "finite sets", "BallotFiberTransfer.ncard_biUnion_eq_of_uniform"]
+  },
+  {
+    "id": "ann-ballot-main-theorem",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 105, "endLine": 153 },
+    "type": "insight",
+    "title": "Main Theorem: Uniform Fibers Preserve uniformOn for All Events",
+    "content": "The proof of `uniformOn_fiber_transfer_all` assembles the four previous lemmas into a clean five-step argument. Steps 1–2 establish the ncard counts (A has k·|T| elements; A∩f⁻¹'P has k·|P| elements). Step 3 notes T∩P = P since P ⊆ T. Steps 4–5 handle positivity for ENNReal division and then apply `ENNReal.div_eq_div_iff` to reduce the equality `uniformOn A (f⁻¹'P) = uniformOn T P` to the purely numerical identity `k|P|·|T| = |P|·k|T|`, which follows by `ring`. The cancellation of k is the conceptual crux.",
+    "mathContext": "\\text{uniformOn}(A)(f^{-1}(P)) = \\frac{|A \\cap f^{-1}(P)|}{|A|} = \\frac{k|P|}{k|T|} = \\frac{|P|}{|T|} = \\text{uniformOn}(T)(P). \\text{ The factor } k \\text{ cancels in numerator and denominator.}",
+    "significance": "key",
+    "relatedConcepts": ["ProbabilityTheory.uniformOn", "ENNReal.div_eq_div_iff", "probability measure pushforward", "measure-preserving maps"],
+    "prerequisites": ["ProbabilityTheory.uniformOn definition", "ENNReal arithmetic", "finite probability spaces"]
+  },
+  {
+    "id": "ann-ballot-corollaries",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 160, "endLine": 198 },
+    "type": "context",
+    "title": "Corollaries: All Events, Complement, Union — Immediate from Main Theorem",
+    "content": "The three corollaries `uniformOn_preserves_all_events`, `uniformOn_complement_transfer`, and `uniformOn_union_transfer` follow immediately from `uniformOn_fiber_transfer_all` with one-line proofs. Each is simply a specialization: complements apply with `diff_subset`, unions apply with `union_subset`. These corollaries are mathematically trivial but pedagogically important: they show that uniform-fiber surjections are probability-algebra homomorphisms — they preserve all Boolean combinations of events, not just individual events. This is the discrete analog of a measure-preserving map.",
+    "mathContext": "\\text{If } f \\text{ has uniform fibers, then: } \\text{uniformOn}(A)(f^{-1}(T \\setminus P)) = \\text{uniformOn}(T)(T \\setminus P) \\text{ and } \\text{uniformOn}(A)(f^{-1}(P \\cup Q)) = \\text{uniformOn}(T)(P \\cup Q).",
+    "significance": "supporting",
+    "relatedConcepts": ["Boolean algebra of events", "probability-preserving map", "σ-algebra homomorphism", "measure-preserving transformation"],
+    "prerequisites": ["uniformOn_fiber_transfer_all", "diff_subset", "union_subset"]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -45,7 +45,9 @@
       "SurjOn is needed to prove ncard(A) = k·ncard(T): without surjectivity, there could be 'missing' fibers",
       "The abstract version uses ncard_biUnion_eq_of_uniform from BallotFiberTransfer, making the proof modular",
       "Complement and union corollaries follow immediately from the main theorem — no additional work needed",
-      "The proof works for ANY α, β types with Finite hypotheses — it is fully type-parametric"
+      "The proof works for ANY α, β types with Finite hypotheses — it is fully type-parametric",
+      "The cancellation of k is the conceptual heart: ncard(A∩f⁻¹'P)/ncard(A) = k·|P|/k·|T| = |P|/|T|. This telescoping makes the equal-fiber condition precisely the right hypothesis — not stronger, not weaker.",
+      "This is the discrete analog of a measure-preserving map: uniform-fiber surjections are probability-algebra homomorphisms that preserve all event probabilities, just as measure-preserving maps between probability spaces preserve all measure values."
     ],
     "prerequisites": [
       "BallotProblemOQ01OQ02OQ01: ncard_biUnion_eq_of_uniform — the fiber counting lemma",
@@ -115,6 +117,16 @@
       "targetId": "ballot-problem-oq-01-oq-02",
       "relationship": "ancestor",
       "description": "Multi-Candidate Ballot Theorem — the application that motivated the fiber transfer pattern"
+    },
+    {
+      "targetId": "ballot-problem-oq-01",
+      "relationship": "ancestor",
+      "description": "Ballot Problem OQ-01 — the original ballot theorem whose proof motivated the fiber-based approach"
+    },
+    {
+      "targetId": "ballot-problem",
+      "relationship": "ancestor",
+      "description": "Ballot Problem — the classical result that a candidate leading throughout the count wins with probability (a-b)/(a+b)"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-1054-oq-01-fnorm/annotations.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/annotations.json
@@ -36,6 +36,30 @@
     "prerequisites": ["analytic number theory", "asymptotic analysis"]
   },
   {
+    "id": "ann-erdos1054fnorm-computational",
+    "proofId": "erdos-1054-oq-01-fnorm",
+    "range": { "startLine": 118, "endLine": 148 },
+    "type": "context",
+    "title": "Computational Verification of f(n) Values via native_decide",
+    "content": "These theorems use `native_decide` to verify specific values of `computeF`. The pattern reveals interesting behavior: for n = p+1 with p prime, f(n) is typically near p but can be much smaller (e.g., f(12) = 6, not 11, because 12 is the last partial sum of divisors of 6). `f_bounded_50` checks that f(n) ≤ 2n for all representable n ≤ 20. The `native_decide` tactic compiles the decision procedure to native code for fast evaluation of these finitely-checkable propositions.",
+    "mathContext": "f(12) = 6 \\text{ (not 11) because } \\text{partialDivisorSums}(6) = [1,3,6,12] \\text{ and } 12 \\in [1,3,6,12]. \\text{ But } f(32) = 31 = p \\text{ exactly, since div}(31) = \\{1,31\\}.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide tactic", "computeF function", "algorithmic number theory"],
+    "prerequisites": ["Lean 4 native_decide", "decidable propositions", "Finset.filter"]
+  },
+  {
+    "id": "ann-erdos1054fnorm-even-odd",
+    "proofId": "erdos-1054-oq-01-fnorm",
+    "range": { "startLine": 151, "endLine": 188 },
+    "type": "insight",
+    "title": "Dense Representability: Even and Odd Cases; Conjectured Exceptions {2,5}",
+    "content": "Theorems `even_representable_small` and `odd_representable_small` verify computationally that all even n ∈ {4,...,20} and all odd n ∈ {3,7,9,...,21} are representable. The noteworthy omissions are 2 and 5: 2 cannot be a partial sum (the smallest divisor of any m ≥ 1 is 1, but the second-smallest is at least 2, giving partial sums that jump from 1 directly to 1+2=3 at minimum), and 5 requires a delicate argument. Computationally {2,5} appear to be the only non-representable numbers, but this is not proved; whether any non-representable n > 5 exists is part of the open problem.",
+    "mathContext": "\\{n \\geq 1 : n \\text{ not representable}\\} \\overset{?}{=} \\{2, 5\\}. \\text{ All } n \\in \\{1, 3, 4, 6, 7, \\ldots, 21\\} \\setminus \\{2, 5\\} \\text{ verified representable.}",
+    "significance": "supporting",
+    "relatedConcepts": ["natural density", "non-representable numbers", "fin_cases tactic"],
+    "prerequisites": ["IsRepresentable definition", "native_decide", "Finset membership"]
+  },
+  {
     "id": "ann-erdos1054fnorm-open-conjecture",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": { "startLine": 193, "endLine": 213 },
@@ -46,6 +70,18 @@
     "significance": "context",
     "relatedConcepts": ["natural density", "little-o notation", "Schnirelmann density", "open problems"],
     "prerequisites": ["density in number theory", "epsilon-delta formulation"]
+  },
+  {
+    "id": "ann-erdos1054fnorm-one-in-sums",
+    "proofId": "erdos-1054-oq-01-fnorm",
+    "range": { "startLine": 217, "endLine": 253 },
+    "type": "technique",
+    "title": "Infrastructure: 1 is Always a Partial Divisor Sum",
+    "content": "The theorem `one_in_partial_sums` proves that 1 belongs to `partialDivisorSums m` for every m ≥ 1. The proof is non-trivial in Lean 4: it requires extracting the head of the sorted divisor list, proving the head equals 1 (since 1 is the smallest positive divisor of any m ≥ 1), and tracing through the `scanl` computation. The key step uses `Finset.pairwise_sort` sortedness: if the smallest sorted element d > 1, then 1 ∈ rest would precede d, contradicting the sorting order. Hence d = 1.",
+    "mathContext": "\\forall m \\geq 1:\\; 1 \\mid m \\implies 1 \\in \\text{divisors}(m) \\implies d_1 = 1 \\implies \\text{partialDivisorSums}(m)[0] = d_1 = 1.",
+    "significance": "supporting",
+    "relatedConcepts": ["sorted lists", "smallest divisor", "Finset.pairwise_sort", "List.scanl"],
+    "prerequisites": ["Nat.one_mem_divisors", "Finset.pairwise_sort", "List.exists_cons_of_ne_nil"]
   },
   {
     "id": "ann-erdos1054fnorm-scanl-infra",

--- a/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
@@ -40,7 +40,9 @@
       "**Prime case**: f(p+1) ≤ p for any prime p. Since divisors of p are {1, p}, partial sums are {1, p+1}. So p+1 is representable with f(p+1) ≤ p, giving f(p+1)/(p+1) < 1.",
       "**Density**: All partial divisor sums of any m are representable. By varying m, we cover a dense set of representable n.",
       "**Superabundant connection**: Along superabundant numbers m_k (where σ(m_k)/m_k → ∞), f(σ(m_k))/σ(m_k) ≤ m_k/σ(m_k) → 0, proving f(n) = o(n) along this subsequence.",
-      "**Gronwall's theorem and superabundance**: Gronwall's theorem states that lim sup_{n→∞} σ(n)/(n log log n) = e^γ ≈ 1.781. Superabundant numbers m_k maximize σ(m)/m; along these, σ(m_k)/m_k ~ e^γ log log m_k → ∞. The sigma bound gives f(σ(m_k))/σ(m_k) ≤ 1/(e^γ log log m_k) → 0, establishing f(n) = o(n) along this subsequence — the strongest o(n) result in the file."
+      "**Gronwall's theorem and superabundance**: Gronwall's theorem states that lim sup_{n→∞} σ(n)/(n log log n) = e^γ ≈ 1.781. Superabundant numbers m_k maximize σ(m)/m; along these, σ(m_k)/m_k ~ e^γ log log m_k → ∞. The sigma bound gives f(σ(m_k))/σ(m_k) ≤ 1/(e^γ log log m_k) → 0, establishing f(n) = o(n) along this subsequence — the strongest o(n) result in the file.",
+      "**Divisor count multiplies witnesses**: Each m ≥ 1 produces exactly τ(m) representable values (one per prefix sum of sorted divisors). For highly composite numbers, τ(m) can be superpolynomial in log m (colossally abundant numbers), making the representable set extremely dense near values of the form σ(m).",
+      "**2 and 5 are the only conjectured non-representable numbers**: Computationally, every n ≤ 50 except 2 and 5 is representable. Whether any non-representable n > 5 exists is part of the open problem; the finite exception set has not been proved."
     ]
   },
   "sections": [
@@ -94,7 +96,10 @@
       "Mathlib.Data.Real.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Nat", "Finset"],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
     "namespace": "Erdos1054OQ01",
     "lineCount": 521,
     "axiomCount": 0,
@@ -107,12 +112,22 @@
     {
       "targetId": "erdos-1054",
       "relationship": "sub-question",
-      "description": "OQ-01: f(n) = o(n) structural results"
+      "description": "Base axiomatization of f(n); formalizes all three open questions and Tao's disproof of Part I"
     },
     {
       "targetId": "erdos-1054-oq-01",
       "relationship": "related",
-      "description": "Related formalization of Erdős #1054 OQ-01"
+      "description": "Companion formalization of Erdős #1054 OQ-01 using the density framework; sigma bound proved there too"
+    },
+    {
+      "targetId": "erdos-1054-oq-02",
+      "relationship": "related",
+      "description": "OQ-02: prime product witnesses qp; Goldbach connection to representability of all even n ≥ 4"
+    },
+    {
+      "targetId": "erdos-1054-construction-d",
+      "relationship": "related",
+      "description": "Construction D: prime square witnesses p²; proves 1+p+p² representable for all primes p"
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/inverse-galois-f20/annotations.json
+++ b/src/data/proofs/inverse-galois-f20/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-igf20-eisenstein",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 41, "endLine": 57 },
+    "type": "technique",
+    "title": "Eisenstein Criterion: X⁵−2 is Irreducible over ℚ",
+    "content": "The four basic properties of X⁵−2 are established via the Eisenstein criterion at p=2: a monic polynomial with leading coefficient not divisible by 2, all other coefficients divisible by 2, and constant term not divisible by 2² is irreducible over ℚ. Here the constant term is −2 (divisible by 2 but not 4), and the leading coefficient is 1. The proof delegates to `NthRootIrrationalOQ01.eisenstein_X_pow_sub_prime`, a general lemma in the gallery. Separability follows from irreducibility in characteristic 0.",
+    "mathContext": "X^5 - 2: \\text{ leading coeff } 1 \\nmid 2, \\text{ other coeffs } \\equiv 0 \\pmod{2}, \\text{ constant } -2 \\not\\equiv 0 \\pmod{4}. \\text{ Eisenstein} \\implies \\text{irreducible over } \\mathbb{Q}.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eisenstein criterion", "irreducibility", "Nat.Prime", "Polynomial.Separable"],
+    "prerequisites": ["Eisenstein criterion", "characteristic 0 separability", "NthRootIrrationalOQ01"]
+  },
+  {
+    "id": "ann-igf20-five-divides",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 62, "endLine": 88 },
+    "type": "insight",
+    "title": "Lower Bound I: 5 | |Gal| from Prime Degree, and |Gal| | 120 from S₅",
+    "content": "Since X⁵−2 is irreducible of degree 5, any root α generates an extension ℚ(α)/ℚ of degree 5. By Galois theory, 5 divides [splitting field : ℚ] = |Gal|. The theorem `five_dvd_gal_card` uses `Polynomial.Gal.prime_degree_dvd_card`. The companion `gal_card_dvd_120` uses the Galois group's faithful action on the 5 roots (injection into S₅ = symmetric group of order 120), which is a fundamental bound: |Gal| divides the order of the symmetric group on the roots.",
+    "mathContext": "X^5 - 2 \\text{ irred.} \\implies [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 5 \\implies 5 \\mid |\\text{Gal}|. \\quad \\text{Gal} \\hookrightarrow S_5 \\implies |\\text{Gal}| \\mid 5! = 120.",
+    "significance": "key",
+    "relatedConcepts": ["Galois correspondence", "degree of extension", "symmetric group action on roots", "Polynomial.Gal.prime_degree_dvd_card"],
+    "prerequisites": ["field extensions", "Galois theory", "group action on roots"]
+  },
+  {
+    "id": "ann-igf20-cyclotomic-root",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 91, "endLine": 135 },
+    "type": "insight",
+    "title": "Key Trick: Ratio of Two Roots is a Primitive 5th Root of Unity",
+    "content": "The theorem `fifth_root_ratio_satisfies_cyclotomic5` proves the key observation: if a⁵ = b⁵ and a ≠ b, then c = a/b satisfies Φ₅(c) = 0. The proof factors X⁵−1 = (X−1)(X⁴+X³+X²+X+1) and notes c ≠ 1 (since a ≠ b). `cyclotomic_5_has_root_in_splitting_field` instantiates this with any two distinct roots α, β of X⁵−2 in the splitting field: both satisfy x⁵ = 2, so their ratio α/β is a primitive 5th root of unity ζ₅ in the splitting field.",
+    "mathContext": "\\alpha^5 = \\beta^5 = 2 \\text{ (two distinct roots)} \\implies c = \\alpha/\\beta \\text{ satisfies } c^5 = 1,\\; c \\neq 1 \\implies \\Phi_5(c) = 0 \\implies \\zeta_5 = c \\in \\text{SF}.",
+    "significance": "key",
+    "relatedConcepts": ["cyclotomic polynomial Φ₅", "5th roots of unity", "IsPrimitiveRoot", "splitting field containment"],
+    "prerequisites": ["cyclotomic polynomials", "field automorphisms", "factor theorem"]
+  },
+  {
+    "id": "ann-igf20-four-divides",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 137, "endLine": 205 },
+    "type": "insight",
+    "title": "Lower Bound II: 4 | finrank, then 20 | |Gal| by Coprimality",
+    "content": "Since ζ₅ ∈ SF satisfies Φ₅ and Φ₅ is irreducible of degree 4, the minimal polynomial of ζ₅ over ℚ has degree 4. By the tower law, 4 divides [SF:ℚ]. `twenty_dvd_gal_card` combines 5 | |Gal| and 4 | |Gal| with the crucial fact gcd(4,5) = 1 (so their product 20 also divides |Gal|) via `Nat.Coprime.mul_dvd_of_dvd_of_dvd`. The cyclotomic polynomial Φ₅ = X⁴+X³+X²+X+1 is identified with `Polynomial.cyclotomic 5 ℚ` and its irreducibility follows from `cyclotomic.irreducible_rat`.",
+    "mathContext": "\\Phi_5 \\text{ irred. of degree 4} \\implies 4 \\mid [\\text{SF}:\\mathbb{Q}]. \\quad \\gcd(4,5)=1,\\; 4 \\mid n,\\; 5 \\mid n \\implies 20 \\mid n \\implies 20 \\mid |\\text{Gal}|.",
+    "significance": "key",
+    "relatedConcepts": ["cyclotomic polynomial", "coprimality", "tower law", "Nat.Coprime.mul_dvd_of_dvd_of_dvd"],
+    "prerequisites": ["cyclotomic polynomials", "tower law for field extensions", "Nat.Coprime"]
+  },
+  {
+    "id": "ann-igf20-fifth-roots",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 211, "endLine": 303 },
+    "type": "technique",
+    "title": "Infrastructure: Every Root of Φ₅ is a Power of ζ",
+    "content": "Parts V-A builds the technical machinery showing that in any field K, if ζ satisfies Φ₅(ζ) = 0 and ζ⁵ = 1, then every other root c of Φ₅ is one of ζ, ζ², ζ³, ζ⁴. The key identity is the factorization Φ₅(c) = (c−ζ)(c−ζ²)(c−ζ³)(c−ζ⁴) (using ζ⁵=1 to reduce powers), proved by `linear_combination`. The auxiliary lemmas ζ≠1, ζ≠−1, ζ²≠1, ζ³≠1, ζ⁴≠1 confirm all powers are distinct, establishing that {ζ, ζ², ζ³, ζ⁴} are exactly the primitive 5th roots of unity.",
+    "mathContext": "\\Phi_5(c) = (c-\\zeta)(c-\\zeta^2)(c-\\zeta^3)(c-\\zeta^4) \\text{ (using } \\zeta^5=1\\text{)} \\implies c \\in \\{\\zeta, \\zeta^2, \\zeta^3, \\zeta^4\\}. \\text{ All distinct since ord}(\\zeta) = 5.",
+    "significance": "supporting",
+    "relatedConcepts": ["primitive roots of unity", "IsPrimitiveRoot", "cyclotomic factorization", "linear_combination tactic"],
+    "prerequisites": ["roots of unity", "cyclotomic polynomial factorization", "Lean 4 linear_combination"]
+  },
+  {
+    "id": "ann-igf20-roots-in-adjoin",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 305, "endLine": 388 },
+    "type": "insight",
+    "title": "Upper Bound Step: All Roots of X⁵−2 Lie in ℚ(α, ζ₅)",
+    "content": "The theorem `roots_in_adjoin_f20` proves every root r of X⁵−2 is in ℚ(α, ζ₅). For any root r: c = r/α satisfies c⁵ = 1. Case c = 1: r = α ∈ ℚ(α, ζ₅). Case c ≠ 1: r ≠ α, so c = r/α is a primitive 5th root, and by `cyclotomic5_root_is_power`, c ∈ {ζ₅, ζ₅², ζ₅³, ζ₅⁴}. In each sub-case, r = c·α is a product of powers of ζ₅ and α, hence in ℚ(α, ζ₅). The follow-up `adjoin_alpha_zeta_eq_top_f20` promotes this to SF = ℚ(α, ζ₅) via `IsSplittingField.adjoin_rootSet'`.",
+    "mathContext": "r^5 = \\alpha^5 = 2 \\implies (r/\\alpha)^5 = 1 \\implies r/\\alpha \\in \\{1, \\zeta_5, \\zeta_5^2, \\zeta_5^3, \\zeta_5^4\\} \\implies r \\in \\mathbb{Q}(\\alpha, \\zeta_5).",
+    "significance": "key",
+    "relatedConcepts": ["splitting field generation", "IntermediateField.adjoin", "IsSplittingField", "Algebra.adjoin_le"],
+    "prerequisites": ["intermediate field lattice", "adjoin_rootSet'", "tower law"]
+  },
+  {
+    "id": "ann-igf20-upper-bound",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 393, "endLine": 491 },
+    "type": "technique",
+    "title": "Upper Bound: Tower Law Gives |Gal| ≤ 20",
+    "content": "The proof of `gal_card_dvd_20` is the most complex in the file. It establishes: [ℚ(α):ℚ] = 5 (from degree of X⁵−2), [SF:ℚ(α)] ≤ 4 (from minpoly of ζ₅ over ℚ(α) dividing Φ₅ of degree 4), and [SF:ℚ] = [SF:ℚ(α)]·5 ≤ 20 via the tower law `Module.finrank_mul_finrank`. Combined with the lower bound 20 | |Gal|, it follows |Gal| = 20 by `Nat.dvd_antisymm`. The main technical challenge is working through Lean's tower law machinery with intermediate fields `Kα = ℚ(α)` and `Kαζ = Kα(ζ₅)`.",
+    "mathContext": "[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 5,\\; [\\text{SF}:\\mathbb{Q}(\\alpha)] \\leq 4 \\implies [\\text{SF}:\\mathbb{Q}] \\leq 20 \\implies |\\text{Gal}| \\leq 20. \\text{ With } 20 \\mid |\\text{Gal}|: |\\text{Gal}| = 20.",
+    "significance": "key",
+    "relatedConcepts": ["tower law", "Module.finrank_mul_finrank", "IntermediateField.adjoin.finrank", "minpoly"],
+    "prerequisites": ["tower law for field extensions", "minpoly degree", "Lean 4 IntermediateField"]
+  },
+  {
+    "id": "ann-igf20-main-results",
+    "proofId": "inverse-galois-f20",
+    "range": { "startLine": 494, "endLine": 528 },
+    "type": "context",
+    "title": "Main Results: |Gal| = 20 and F₂₀ is Realizable",
+    "content": "The file concludes with three corollaries assembling the full result. `x5_sub_2_gal_card` combines the lower and upper bounds via `Nat.dvd_antisymm`. `splitting_field_x5_sub_2_finrank` translates the Galois group cardinality to the field extension degree (equal by `Polynomial.Gal.card_of_separable`). `f20_realizable` witnesses the existential: the Frobenius group F₂₀ is realizable over ℚ, with witness K = splitting field of X⁵−2, using `IsGalois.mk` to assemble the normal, separable, and Galois hypotheses.",
+    "mathContext": "|\\text{Gal}(X^5-2/\\mathbb{Q})| = 20,\\quad [\\text{SF}:\\mathbb{Q}] = 20,\\quad \\exists K/\\mathbb{Q}\\text{ Galois}: |\\text{Gal}(K/\\mathbb{Q})| = 20.",
+    "significance": "key",
+    "relatedConcepts": ["Frobenius group F₂₀", "ℤ/5ℤ ⋊ ℤ/4ℤ", "IsGalois", "inverse Galois problem"],
+    "prerequisites": ["Galois group", "IsGalois", "Nat.dvd_antisymm"]
+  }
+]

--- a/src/data/proofs/inverse-galois-f20/meta.json
+++ b/src/data/proofs/inverse-galois-f20/meta.json
@@ -45,7 +45,9 @@
       "**Cyclotomic root in splitting field**: The ratio (⁵√2·ζ)/(⁵√2) = ζ of two distinct roots gives a primitive 5th root of unity ζ₅ in the splitting field.",
       "**Φ₅ irreducible**: The 5th cyclotomic polynomial Φ₅ = X⁴+X³+X²+X+1 is irreducible over ℚ, so [ℚ(ζ₅):ℚ] = 4 and 4 | degree.",
       "**F₂₀ structure**: F₂₀ = ℤ/5ℤ ⋊ ℤ/4ℤ acts: translation by ⁵√2→ζ₅·⁵√2 (order 5) and Galois automorphism ζ₅→ζ₅² (order 4).",
-      "**Solvability**: F₂₀ is solvable (it's a semidirect product of cyclic groups), consistent with X⁵−2 being solvable by radicals (roots are ⁵√2·ζ₅ᵏ)."
+      "**Solvability**: F₂₀ is solvable (it's a semidirect product of cyclic groups), consistent with X⁵−2 being solvable by radicals (roots are ⁵√2·ζ₅ᵏ).",
+      "**Series pattern X^n−2**: The gallery forms a complete pattern — X³−2 (S₃, order 6), X⁴−2 (D₄, order 8), X⁵−2 (F₂₀, order 20). The group order grows as n! (which S_n action saturates) for n=3, then collapses to smaller groups for n=4,5 due to the cyclotomic splitting structure. X⁶−2 would give a more complex solvable group.",
+      "**Φ₅ as minpoly**: The trick of identifying Φ₅(ζ) = 0 with the cyclotomic polynomial in Mathlib (`cyclotomic 5 ℚ`) via `linear_combination` is a key formalization move — Mathlib defines cyclotomic polynomials abstractly, so the identification requires an explicit ring equality proof."
     ]
   },
   "sections": [
@@ -98,12 +100,17 @@
     {
       "targetId": "inverse-galois",
       "relationship": "extends",
-      "description": "F₂₀ realization: third non-trivial Galois group over ℚ"
+      "description": "Base Inverse Galois Problem formalization; X³−2 gives Gal = S₃ (order 6)"
+    },
+    {
+      "targetId": "inverse-galois-d4",
+      "relationship": "sibling",
+      "description": "D₄ realization via X⁴−2 (order 8) — second entry in the X^n−2 series"
     },
     {
       "targetId": "inverse-galois-oq-01",
       "relationship": "related",
-      "description": "Related: inverse Galois problem sub-questions"
+      "description": "Inverse Galois OQ-01: sub-questions on realizability of other groups"
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/pac-learning-bounds-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01-oq-01/annotations.json
@@ -1,3 +1,62 @@
-{
-  "annotations": []
-}
+[
+  {
+    "id": "ann-setup",
+    "proofId": "pac-learning-bounds-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 18 },
+    "type": "context",
+    "title": "Setup — Extending the VC Hierarchy from Thresholds to Intervals",
+    "content": "This file imports `Proofs.PACLearningOQ01` to reuse the `Shatters` predicate and opens the `LearningTheory.VCDimension` namespace. The hierarchy is: threshold classifiers (VC dim 1) → interval classifiers (VC dim 2) → axis-aligned rectangles (VC dim 4) → ... Each step adds one parameter and increases VC dimension. The `Shatters` predicate (`C shatters S` means `∀ T ⊆ S, ∃ h ∈ C, h ∩ S = T`) is defined in OQ-01 and reused here without redefinition.",
+    "mathContext": "VC dimension hierarchy: $\\text{VCdim}(\\text{thresholds}) = 1 < \\text{VCdim}(\\text{intervals}) = 2 < \\text{VCdim}(\\text{rectangles}) = 4 < \\ldots$ Adding one parameter increases VC dimension by (at least) 1.",
+    "significance": "context",
+    "relatedConcepts": ["Shatters predicate", "LearningTheory.VCDimension namespace", "hypothesis class hierarchy"],
+    "prerequisites": ["VC dimension definition", "pac-learning-bounds-oq-01 (thresholds)", "Lean 4 namespace and import"]
+  },
+  {
+    "id": "ann-interval-def",
+    "proofId": "pac-learning-bounds-oq-01-oq-01",
+    "range": { "startLine": 19, "endLine": 24 },
+    "type": "definition",
+    "title": "intervalClassifiers — Intervals as a Hypothesis Class",
+    "content": "An interval classifier on ℕ is parameterized by two endpoints $a \\leq b$ and classifies $x$ as positive iff $a \\leq x \\leq b$. The definition allows 'empty' intervals where $a > b$ (which classify no point as positive), providing the all-negative witness for the ∅ subset in the shattering argument. Without this convention, the pair-shattering proof would need a separate case for the all-negative labeling.",
+    "mathContext": "$H_{\\text{int}} = \\{h \\mid \\exists a,b \\in \\mathbb{N},\\, h = \\{x : a \\leq x \\leq b\\}\\}$. Empty interval: when $a > b$, $\\{x : a \\leq x \\leq b\\} = \\emptyset$.",
+    "significance": "key",
+    "relatedConcepts": ["intervalClassifiers", "thresholdClassifiers", "VC dimension hierarchy", "empty interval convention"],
+    "prerequisites": ["set comprehension in Lean", "VC dimension definition", "Set.mem_setOf_eq"]
+  },
+  {
+    "id": "ann-pair-shattering",
+    "proofId": "pac-learning-bounds-oq-01-oq-01",
+    "range": { "startLine": 25, "endLine": 59 },
+    "type": "technique",
+    "title": "Four-Witness Lower Bound — Every Pair is Shattered",
+    "content": "The proof case-splits on the four possible labelings of $\\{a,b\\}$ (all subsets), providing an interval witness for each. The four cases are handled by `rcases ht with rfl | rfl | rfl | rfl` after the shattering unfolding. The empty interval $[b+1, b]$ handles the all-negative case: since $b+1 > b$, no integer satisfies $b+1 \\leq x \\leq b$, so the interval is empty. This is the standard trick for making interval classifiers a 'complete' hypothesis class that can realize all $2^k$ labelings of $k \\leq 2$ points.",
+    "mathContext": "$\\forall a < b$, $H_{\\text{int}}$ shatters $\\{a,b\\}$: witnesses are $[a,b]$ for $\\{a,b\\}$, $[a,a]$ for $\\{a\\}$, $[b,b]$ for $\\{b\\}$, $[b+1,b]$ (empty) for $\\emptyset$.",
+    "significance": "key",
+    "relatedConcepts": ["interval_shatters_pair", "shattering lower bound", "empty interval trick", "rcases tactic"],
+    "prerequisites": ["Lean rcases tactic", "Finset.mem_insert", "Finset.mem_singleton", "shattering definition"]
+  },
+  {
+    "id": "ann-convexity-obstruction",
+    "proofId": "pac-learning-bounds-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 96 },
+    "type": "insight",
+    "title": "Convexity Obstruction — No Triple is Shattered",
+    "content": "The upper bound uses the adversarial labeling $T = \\{a, c\\}$ (endpoints included, middle $b$ excluded). If any interval $[l,r]$ realizes this labeling on $\\{a,b,c\\}$: $a \\in [l,r]$ forces $l \\leq a$, $c \\in [l,r]$ forces $r \\geq c$. Since $a < b < c$, we get $l \\leq a < b < c \\leq r$, so $l \\leq b \\leq r$, meaning $b \\in [l,r]$. But $b \\notin T$, contradiction. This is the *convexity obstruction*: any interval is convex in $\\mathbb{N}$ (contains all integers between its endpoints), so it cannot separate $\\{a,c\\}$ from $\\{b\\}$ when $a < b < c$.",
+    "mathContext": "$l \\leq a < b < c \\leq r \\Rightarrow l \\leq b \\wedge b \\leq r$ — interval convexity forces $b \\in [l,r]$. The labeling $\\{a,c\\}$ (skip middle) is unrealizable by any interval when $a < b < c$.",
+    "significance": "key",
+    "relatedConcepts": ["interval_not_shatters_triple", "convexity obstruction", "adversarial labeling", "Nat.le_of_lt"],
+    "prerequisites": ["VC dimension upper bound argument", "interval convexity", "Lean omega tactic"]
+  },
+  {
+    "id": "ann-combined",
+    "proofId": "pac-learning-bounds-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 104 },
+    "type": "context",
+    "title": "Combined Bound — VCdim(intervals) = 2",
+    "content": "`interval_vcdim_two` packages both halves into a single statement: (1) every pair is shattered (VC dim ≥ 2) and (2) no triple is shattered (VC dim ≤ 2). The theorem is stated as a conjunction to avoid formalizing a general `VCdim` function, letting the pair of theorems serve as the definition of 'VC dimension equals 2'. This pattern (separate lower and upper bound, combined by `And.intro`) is used throughout the OQ-01 series.",
+    "mathContext": "$\\text{VCdim}(H_{\\text{int}}) = 2$: formally, $\\forall a < b: H_{\\text{int}} \\text{ shatters } \\{a,b\\}$ and $\\forall a < b < c: H_{\\text{int}} \\text{ does not shatter } \\{a,b,c\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["interval_vcdim_two", "VC dimension 2", "And.intro", "lower and upper bound pattern"],
+    "prerequisites": ["Lean And.intro", "shattering predicate", "VC dimension characterization"]
+  }
+]


### PR DESCRIPTION
Enrichment pass adding missing annotations and entry points.

## Proofs enriched

### buffons-needle-oq-02-oq-03 (Cauchy-Crofton Formula)
- Added `index.ts` (proof was invisible to Vite)
- Added 10 annotations covering hyperplane structures, crossing-measure lemma, Fubini axiom, noodle theorem, isotropy axiom, classical 2D/3D cases

### erdos-1056-oq-01 (New Solutions for Consecutive Interval Products ≡ 1)
- Added 9 annotations covering intervalProd definition, Wilson's theorem constraint, new k=4/5/6 solutions, factorial congruence pattern (the key to solution search)

### erdos-1006-oq-04 (DAG Structure of Coloring Orientation)
- Added 6 annotations covering graded DAG rank structure, source/sink layers, arc characterization iff, no horizontal arcs, OQ03 consistency

### erdos-1214 (Prime Support Uniqueness — Corrales-Rodánez–Schoof)
- Added `index.ts` (proof was invisible to Vite)
- Added 7 annotations: ZMod order bridge (p|x^n-1 ↔ ord_p(x)|n), equal-orders via Fermat + antisymmetry, Zsygmondy primitive prime transfer, axiomatized Kummer theory gap