### PR TITLE
fix(cevas-theorem-oq-01-oq-03): realign section line ranges post-PR-15173

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14029,6 +14029,12 @@
       "lastAudited": "2026-05-03T11:20:49Z",
       "result": "clean",
       "issues": []
+    },
+    "cevas-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-05-03T12:00:00Z",
+      "result": "issues-fixed"
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -57,15 +57,15 @@
     {
       "id": "denominators",
       "title": "Denominator Positivity",
-      "startLine": 35,
-      "endLine": 50,
+      "startLine": 40,
+      "endLine": 54,
       "summary": "Three positivity lemmas: w₁ = 1-e+de > 0, w₂ = 1-f+ef > 0, w₃ = 1-d+fd > 0. Proved by nlinarith from d,e,f ∈ (0,1).",
       "mathContext": "$w_1 = 1-e+de = 1-e(1-d) > 0$ for $d,e \\in (0,1)$."
     },
     {
       "id": "vertices",
       "title": "Inner Triangle Vertex Formulas",
-      "startLine": 54,
+      "startLine": 56,
       "endLine": 70,
       "summary": "Explicit coordinates of P (AD∩BE), Q (BE∩CF), R (CF∩AD) as rational functions of d, e, f.",
       "mathContext": "$P = \\left(\\frac{(1-d)(1-e)}{w_1}, \\frac{d(1-e)}{w_1}\\right)$, $Q = \\left(\\frac{ef}{w_2}, \\frac{(1-e)(1-f)}{w_2}\\right)$, $R = \\left(\\frac{f(1-d)}{w_3}, \\frac{fd}{w_3}\\right)$."
@@ -73,24 +73,24 @@
     {
       "id": "membership",
       "title": "Cevian Membership Proofs",
-      "startLine": 74,
-      "endLine": 145,
+      "startLine": 72,
+      "endLine": 128,
       "summary": "Six membership theorems proving P ∈ AD∩BE, Q ∈ BE∩CF, R ∈ CF∩AD. Each uses an explicit parameter witness and field_simp + ring.",
       "mathContext": "P lies on AD with parameter $t = (1-e)/w_1$, and on BE with parameter $t = d/w_1$."
     },
     {
       "id": "main",
       "title": "Routh's Theorem — Main Formula",
-      "startLine": 149,
-      "endLine": 168,
+      "startLine": 130,
+      "endLine": 151,
       "summary": "routh_theorem_std: signedArea(P,Q,R) = routhRatio(d,e,f) × signedArea(A,B,C). Proved by field_simp + ring after establishing denominator nonvanishing.",
       "mathContext": "$\\frac{\\text{Area}(PQR)}{\\text{Area}(ABC)} = \\frac{(def-(1-d)(1-e)(1-f))^2}{w_1 w_2 w_3}$."
     },
     {
       "id": "applications",
       "title": "Corollaries and Applications",
-      "startLine": 172,
-      "endLine": 230,
+      "startLine": 153,
+      "endLine": 228,
       "summary": "Explicit area form, 1/7 verification (d=e=f=1/3), concurrent degeneration (area=0 iff Ceva), nonnegativity, asymmetric example (1/10), zero condition equivalence.",
       "mathContext": "Special case $d=e=f=1/3$: $\\text{Area}(PQR)/\\text{Area}(ABC) = 1/7$. Ceva condition gives ratio $= 0$."
     }


### PR DESCRIPTION
## Fix

Realigns `sections[*].startLine/endLine` in `cevas-theorem-oq-01-oq-03/meta.json` after PR #15173 added ~30 lines to the Lean file.

The `lineCount` (200→230) and `theoremCount` (14→19) were already synced in `main`, but the per-section line ranges were left pointing at pre-PR positions.

## Evidence

| section | before (stale) | after (correct) |
|---|---|---|
| denominators | 35–50 | 40–54 |
| vertices | 54–70 | 56–70 |
| membership | 74–145 | 72–128 |
| main | 149–168 | 130–151 |
| applications | 172–230 | 153–228 |

Verified against Part I–V header comments in `proofs/Proofs/CevasTheoremOQ01OQ03.lean`.

Also adds tracker entry for `cevas-theorem-oq-01-oq-03` (first audit).

Closes #15192 (superseded — counts already fixed in main; this is the remaining delta).

---
Automated fix by lean-mechanic agent.