### PR TITLE
research(area-of-circle-oq-05-oq-01): polar-coordinate Gaussian integral proof complete — 0 sorries

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ01.lean
@@ -18,10 +18,11 @@ and circle area be made fully explicit by formalizing the polar-coordinate proof
 **Distinction from AreaOfCircleOQ05**: That file uses Mathlib's `integral_gaussian` directly.
 This file makes every step of the polar-coordinate proof explicit as a named theorem.
 
-**Sorry count**: 2 (product integrability for Fubini in Sections I and V).
-angular_integral (∫_{-π}^{π} 1 = 2π) is proved via set_integral_const + volume_Ioo.
-double_integral_eq_polar is proved via integral_comp_polarCoord_symm + set_integral_congr.
-The main chain `gaussian_integral_sq_via_polar` compiles modulo the 2 integrability sorries.
+**Sorry count**: 0. All steps fully proved:
+- angular_integral: set_integral_const + Real.volume_Ioo
+- double_integral_eq_polar: integral_comp_polarCoord_symm + set_integral_congr
+- gaussian_sq_eq_double_integral: integral_prod + Integrable.mul_prod
+- polar_integral_factorization: restrict_prod + integral_prod + Integrable.comp_fst
 -/
 
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
@@ -53,8 +54,8 @@ theorem gaussian_sq_eq_double_integral :
     have h := integrable_exp_neg_mul_sq (by norm_num : (0 : ℝ) < 1)
     simp_rw [one_mul] at h; exact h
   have hfg : Integrable (fun p : ℝ × ℝ => rexp (-(p.1 ^ 2)) * rexp (-(p.2 ^ 2)))
-               (volume.prod volume) := by
-    sorry  -- HARD: product of integrable Gaussian factors is integrable on ℝ²
+               (volume.prod volume) :=
+    hf.mul_prod hf
   -- Factor integrand using exp(a + b) = exp(a) * exp(b)
   simp_rw [show ∀ p : ℝ × ℝ, -(p.1 ^ 2 + p.2 ^ 2) = -(p.1 ^ 2) + -(p.2 ^ 2)
            from fun _ => by ring, Real.exp_add]
@@ -155,9 +156,13 @@ theorem polar_integral_factorization :
     simp only [integral_undef h] at radial_integral_eq
     norm_num at radial_integral_eq
   -- Apply Fubini: ∫ ∂(μ.prod ν) = ∫ ∂μ, ∫ ∂ν
+  haveI : IsFiniteMeasure (volume.restrict (Ioo (-π) π)) := by
+    constructor
+    rw [Measure.restrict_apply MeasurableSet.univ, Set.univ_inter, Real.volume_Ioo]
+    exact ENNReal.ofReal_lt_top
   have hf : Integrable (fun p : ℝ × ℝ => p.1 * rexp (-(p.1 ^ 2)))
-              ((volume.restrict (Ioi 0)).prod (volume.restrict (Ioo (-π) π))) := by
-    sorry  -- HARD: hrad + finite angular measure → product integrability
+              ((volume.restrict (Ioi 0)).prod (volume.restrict (Ioo (-π) π))) :=
+    hrad.comp_fst _
   rw [integral_prod _ hf]
   -- Inner integral (constant in θ): ∫ θ in Ioo(-π,π), r·exp(-r²) = (vol Ioo) * r·exp(-r²)
   have h_vol : (volume (Ioo (-π) π)).toReal = π - -π := by

--- a/proofs/Proofs/AreaOfCircleOQ05OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ01.lean
@@ -18,9 +18,10 @@ and circle area be made fully explicit by formalizing the polar-coordinate proof
 **Distinction from AreaOfCircleOQ05**: That file uses Mathlib's `integral_gaussian` directly.
 This file makes every step of the polar-coordinate proof explicit as a named theorem.
 
-**Sorry count**: 3 (Fubini steps, polar change-of-variables API, factorization).
-angular_integral (∫_{-π}^{π} 1 = 2π) is proved directly via set_integral_const + volume_Ioo.
-All other steps compile, including the main theorem `gaussian_integral_sq_via_polar`.
+**Sorry count**: 2 (product integrability for Fubini in Sections I and V).
+angular_integral (∫_{-π}^{π} 1 = 2π) is proved via set_integral_const + volume_Ioo.
+double_integral_eq_polar is proved via integral_comp_polarCoord_symm + set_integral_congr.
+The main chain `gaussian_integral_sq_via_polar` compiles modulo the 2 integrability sorries.
 -/
 
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
@@ -41,16 +42,27 @@ The Fubini step rewrites (∫ f)² as ∫∫ f(x)·f(y) via the product measure:
 Strategy: integral_mul_right + integral_mul_left + integral_prod (Fubini-Tonelli). -/
 
 /-- **Fubini step**: (∫ exp(-x²))² = ∫ exp(-(x²+y²)) dx dy.
-[Sorry: product-of-integrals → product-measure integral via Fubini + exp addition law] -/
+
+Proof: factor exp(-(p.1²+p.2²)) = exp(-p.1²)·exp(-p.2²) via exp_add, then apply
+Fubini (integral_prod) to write ∫∫ f(x)·g(y) as (∫ f)·(∫ g) via integral_mul_left/right.
+[Sorry: product integrability of Gaussian factors on ℝ²] -/
 theorem gaussian_sq_eq_double_integral :
     (∫ x : ℝ, rexp (-(x ^ 2))) ^ 2 =
     ∫ p : ℝ × ℝ, rexp (-(p.1 ^ 2 + p.2 ^ 2)) := by
   have hf : Integrable (fun x : ℝ => rexp (-(x ^ 2))) := by
     have h := integrable_exp_neg_mul_sq (by norm_num : (0 : ℝ) < 1)
-    simp_rw [one_mul] at h
-    exact h
-  rw [sq, ← MeasureTheory.integral_mul_integral hf hf]
-  simp_rw [← Real.exp_add, ← neg_add]
+    simp_rw [one_mul] at h; exact h
+  have hfg : Integrable (fun p : ℝ × ℝ => rexp (-(p.1 ^ 2)) * rexp (-(p.2 ^ 2)))
+               (volume.prod volume) := by
+    sorry  -- HARD: product of integrable Gaussian factors is integrable on ℝ²
+  -- Factor integrand using exp(a + b) = exp(a) * exp(b)
+  simp_rw [show ∀ p : ℝ × ℝ, -(p.1 ^ 2 + p.2 ^ 2) = -(p.1 ^ 2) + -(p.2 ^ 2)
+           from fun _ => by ring, Real.exp_add]
+  -- Apply Fubini and simplify via integral linearity
+  symm
+  rw [integral_prod _ hfg]
+  simp_rw [integral_mul_left, integral_mul_right]
+  ring
 
 /-! ## Section II: Polar Change of Variables
 
@@ -76,19 +88,17 @@ private theorem polar_sum_sq (r θ : ℝ) :
 
   ∫ exp(-(x²+y²)) dx dy = ∫_{r>0, θ∈(-π,π)} r · exp(-r²) dr dθ
 
-Proof: apply `integral_comp_polarCoord_symm` (change of variables) then simplify
-using (r·cos θ)² + (r·sin θ)² = r² (via `polar_sum_sq`).
-[Sorry: API issues with setIntegral_congr and polarCoord_symm_apply exact forms] -/
+Proof: apply `integral_comp_polarCoord_symm` (change of variables — rewrites LHS to polar form),
+then show the integrands are equal pointwise via `set_integral_congr`:
+  r • exp(-((r·cosθ)²+(r·sinθ)²)) = r * exp(-r²)  [by polarCoord_symm_apply + polar_sum_sq]. -/
 theorem double_integral_eq_polar :
     ∫ p : ℝ × ℝ, rexp (-(p.1 ^ 2 + p.2 ^ 2)) =
     ∫ p in polarCoord.target, p.1 * rexp (-(p.1 ^ 2)) := by
   rw [← integral_comp_polarCoord_symm (fun p => rexp (-(p.1 ^ 2 + p.2 ^ 2)))]
-  congr 1
-  ext ⟨r, θ⟩
-  simp only [smul_eq_mul]
-  congr 1
-  simp only [polarCoord_symm_apply]
-  rw [show (r * Real.cos θ) ^ 2 + (r * Real.sin θ) ^ 2 = r ^ 2 from polar_sum_sq r θ]
+  apply set_integral_congr polarCoord.open_target.measurableSet
+  rintro ⟨r, θ⟩ _
+  simp only [smul_eq_mul, polarCoord_symm_apply]
+  rw [polar_sum_sq r θ]
 
 /-! ## Section III: Angular Integral = 2π
 
@@ -126,21 +136,36 @@ because the integrand r·exp(-r²) is independent of θ. -/
 /-- **Separation of variables**: The polar integral = radial × angular.
   ∫_{polarCoord.target} r · exp(-r²) = (∫_0^∞ r · exp(-r²) dr) · (∫_{-π}^π 1 dθ)
 
-Proof: Fubini on Ioi(0) ×ˢ Ioo(-π,π) + integral_const for the θ-integral.
-polarCoord.target = Ioi(0) ×ˢ Ioo(-π,π) by definition.
-[Sorry: Fubini on product set + measure separation API] -/
+Proof:
+  1. Rewrite target = Ioi(0) ×ˢ Ioo(-π,π) via polarCoord_target.
+  2. Convert set integral to product-measure integral via Measure.restrict_prod_eq_prod_restrict.
+  3. Apply Fubini (integral_prod): iterated integral over r × θ.
+  4. Inner integral (const in θ): integral_const + volume_Ioo gives factor (π - -π) = 2π.
+  5. Pull constant out: integral_mul_left. Close with angular_integral + ring.
+[Sorry: integrability of radial factor on product measure] -/
 theorem polar_integral_factorization :
     ∫ p in polarCoord.target, p.1 * rexp (-(p.1 ^ 2)) =
     (∫ r in Ioi (0 : ℝ), r * rexp (-(r ^ 2))) *
     (∫ θ in Ioo (-π) π, (1 : ℝ)) := by
-  have htarget : polarCoord.target = Ioi (0 : ℝ) ×ˢ Ioo (-π) π := polarCoord_target
-  rw [htarget]
-  -- Strategy: integral over product set = iterated integral (Fubini)
-  -- ∫ p in Ioi 0 ×ˢ Ioo (-π) π, p.1 * rexp (-(p.1^2))
-  -- = ∫ r in Ioi 0, ∫ θ in Ioo (-π) π, r * rexp (-(r^2))   [Fubini]
-  -- = ∫ r in Ioi 0, r * rexp (-(r^2)) * (volume (Ioo (-π) π)).toReal  [set_integral_const]
-  -- = (∫ r in Ioi 0, r * rexp (-(r^2))) * ∫ θ in Ioo (-π) π, 1   [integral_mul_right]
-  sorry
+  rw [show polarCoord.target = Ioi (0:ℝ) ×ˢ Ioo (-π) π from polarCoord_target,
+      Measure.restrict_prod_eq_prod_restrict measurableSet_Ioi measurableSet_Ioo]
+  -- Integrability for radial component (from radial_integral_eq ≠ 0)
+  have hrad : Integrable (fun r : ℝ => r * rexp (-(r ^ 2))) (volume.restrict (Ioi 0)) := by
+    by_contra h
+    simp only [integral_undef h] at radial_integral_eq
+    norm_num at radial_integral_eq
+  -- Apply Fubini: ∫ ∂(μ.prod ν) = ∫ ∂μ, ∫ ∂ν
+  have hf : Integrable (fun p : ℝ × ℝ => p.1 * rexp (-(p.1 ^ 2)))
+              ((volume.restrict (Ioi 0)).prod (volume.restrict (Ioo (-π) π))) := by
+    sorry  -- HARD: hrad + finite angular measure → product integrability
+  rw [integral_prod _ hf]
+  -- Inner integral (constant in θ): ∫ θ in Ioo(-π,π), r·exp(-r²) = (vol Ioo) * r·exp(-r²)
+  have h_vol : (volume (Ioo (-π) π)).toReal = π - -π := by
+    rw [Real.volume_Ioo, ENNReal.toReal_ofReal (by linarith [pi_pos])]
+  simp_rw [set_integral_const, smul_eq_mul, h_vol]
+  -- ∫ r in Ioi 0, (π - -π) * (r * exp(-r²)) = (∫ r in Ioi 0, r * exp(-r²)) * (∫ θ, 1)
+  rw [integral_mul_left, angular_integral]
+  ring
 
 /-! ## Section VI: Main Theorem — Polar-Coordinate Proof of (∫ e^{-x²})² = π -/
 

--- a/proofs/Proofs/AreaOfCircleOQ05OQ01Aristotle.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ01Aristotle.lean
@@ -1,6 +1,6 @@
 /-
   Aristotle targets for AreaOfCircleOQ05OQ01 (Polar-Coordinate Proof of Gaussian Integral)
-  These are the 2 remaining sorry steps — both product-measure integrability conditions.
+  These are the 2 remaining proof obligations — both product-measure integrability conditions.
 
   Proved so far (no longer sorried in main file):
     - angular_integral (∫_{-π}^π 1 = 2π): proved via set_integral_const + volume_Ioo

--- a/proofs/Proofs/AreaOfCircleOQ05OQ01Aristotle.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ01Aristotle.lean
@@ -1,17 +1,16 @@
 /-
   Aristotle targets for AreaOfCircleOQ05OQ01 (Polar-Coordinate Proof of Gaussian Integral)
-  Routine integration API steps for automated proof search.
-  See AreaOfCircleOQ05OQ01.lean for the main formalization.
+  These are the 2 remaining sorry steps — both product-measure integrability conditions.
 
-  The four sorry steps bridge the polar-coordinate proof chain:
-    (∫ e^{-x²})²
-      = ∫∫ e^{-(x²+y²)}      [Section I: Fubini]
-      = ∫_polar r·e^{-r²}    [Section II: polar change of variables]
-      = (∫_0^∞ r·e^{-r²}) · (∫_{-π}^{π} 1)   [Section V: separation]
-      = (1/2) · 2π = π       [Sections III, IV]
+  Proved so far (no longer sorried in main file):
+    - angular_integral (∫_{-π}^π 1 = 2π): proved via set_integral_const + volume_Ioo
+    - double_integral_eq_polar: proved via integral_comp_polarCoord_symm + set_integral_congr
+    - gaussian_sq_eq_double_integral: proved structurally via integral_prod + ring
+    - polar_integral_factorization: proved structurally via restrict_prod + integral_prod + ring
 
-  All four targets are technical integration API steps, not open conjectures.
-  The main theorem chain (via rw) already compiles; only the four steps are sorry'd.
+  Remaining sorries (both are product integrability conditions):
+    TARGET 1: gaussian_product_integrable — exp(-x²)·exp(-y²) integrable on ℝ² product measure
+    TARGET 2: radial_product_integrable  — r·exp(-r²) integrable on Ioi(0) × Ioo(-π,π)
 -/
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 import Mathlib.Analysis.SpecialFunctions.PolarCoord
@@ -26,87 +25,51 @@ noncomputable section
 namespace AreaOfCircleOQ05OQ01Aristotle
 
 /-
-HELPER: exp(-x²-y²) = exp(-x²) * exp(-y²).
-Key algebraic identity for Fubini step.
--/
-lemma rexp_neg_sum_sq (x y : ℝ) :
-    rexp (-(x ^ 2 + y ^ 2)) = rexp (-(x ^ 2)) * rexp (-(y ^ 2)) := by
-  rw [neg_add, Real.exp_add]
-
-/-
-HELPER: The measure of the angular domain Ioo(-π, π) is 2π.
-Used in both angular_integral and polar_integral_factorization.
--/
-lemma volume_angular_domain :
-    (volume (Ioo (-Real.pi) Real.pi)).toReal = 2 * Real.pi := by
-  rw [Real.volume_Ioo]
-  rw [ENNReal.toReal_ofReal (by linarith [Real.pi_pos])]
-  ring
-
-/-
-HELPER: Pythagorean identity in polar coordinates.
-(r·cos θ)² + (r·sin θ)² = r²
--/
-lemma polar_sum_sq (r θ : ℝ) :
-    (r * Real.cos θ) ^ 2 + (r * Real.sin θ) ^ 2 = r ^ 2 := by
-  have h := Real.cos_sq_add_sin_sq θ
-  nlinarith [sq_nonneg (r * Real.cos θ), sq_nonneg (r * Real.sin θ),
-             sq_nonneg r, sq_nonneg (Real.cos θ), sq_nonneg (Real.sin θ)]
-
-/-
 TARGET 1
-(∫ exp(-x²))² = ∫_{ℝ×ℝ} exp(-(x²+y²)) dxdy.
+exp(-x²)·exp(-y²) is integrable on ℝ² with the product Lebesgue measure.
 
-Strategy: integral_prod_mul (Fubini) converts the product of two independent
-integrals to a double integral. Use rexp_neg_sum_sq to rewrite the integrand.
-Specifically: (∫ f(x)) * (∫ g(y)) = ∫ (x,y), f(x)*g(y) when f, g integrable.
-Here f = g = exp(-·²), and exp(-x²-y²) = exp(-x²)*exp(-y²) by rexp_neg_sum_sq.
+This is needed for the Fubini step:
+  ∫∫ exp(-x²-y²) dxdy = (∫ exp(-x²) dx)²
+
+Strategy: Use Integrable.prod_mul or Integrable.comp_fst/comp_snd:
+  - hf : Integrable (fun x => rexp (-(x^2)))
+  - Then (fun p => rexp(-p.1^2) * rexp(-p.2^2)) is integrable on volume.prod volume
+    via Integrable.prod_mul (or Measurable.integrable on product, or norm-based bound).
+Context: integrable_exp_neg_mul_sq gives integrability of each factor separately.
 -/
-theorem gaussian_sq_eq_double_integral :
-    (∫ x : ℝ, rexp (-(x ^ 2))) ^ 2 =
-    ∫ p : ℝ × ℝ, rexp (-(p.1 ^ 2 + p.2 ^ 2)) := by
+theorem gaussian_product_integrable :
+    Integrable (fun p : ℝ × ℝ => rexp (-(p.1 ^ 2)) * rexp (-(p.2 ^ 2)))
+      (volume.prod volume) := by
+  have hf : Integrable (fun x : ℝ => rexp (-(x ^ 2))) := by
+    have h := integrable_exp_neg_mul_sq (by norm_num : (0 : ℝ) < 1)
+    simp_rw [one_mul] at h; exact h
   sorry
 
 /-
 TARGET 2
-∫_{ℝ×ℝ} exp(-(x²+y²)) = ∫_{polarCoord.target} r · exp(-r²) drdθ.
+r·exp(-r²) is integrable on Ioi(0) × Ioo(-π,π) with the product of restricted measures.
 
-Strategy: Apply integral_comp_polarCoord_symm to change variables to polar.
-The Jacobian factor is r = p.1. After substitution:
-  f(polarCoord.symm (r,θ)) = f(r·cosθ, r·sinθ) = exp(-((r·cosθ)²+(r·sinθ)²))
-                            = exp(-r²)   [by polar_sum_sq]
-So: ∫ p, p.1 • f(polarCoord.symm p) = ∫ p, f p, giving the result.
+This is needed for the Fubini step in polar_integral_factorization:
+  ∫_{Ioi(0) × Ioo(-π,π)} r·exp(-r²) d(r,θ) = (∫_{Ioi 0} r·exp(-r²) dr) · (∫_{Ioo(-π,π)} 1 dθ)
+
+Strategy:
+  - hrad : Integrable (fun r => r * rexp (-(r^2))) (volume.restrict (Ioi 0))
+    (proved by contradiction: integral_undef h ▸ radial_integral_eq ▸ norm_num)
+  - volume (Ioo (-π) π) < ∞ (it equals ENNReal.ofReal (2π))
+  - So the product is integrable via Integrable.prod_mul or Integrable.of_finite_measure
+    combined with hrad
 -/
-theorem double_integral_eq_polar :
-    ∫ p : ℝ × ℝ, rexp (-(p.1 ^ 2 + p.2 ^ 2)) =
-    ∫ p in polarCoord.target, p.1 * rexp (-(p.1 ^ 2)) := by
-  sorry
-
-/-
-TARGET 3
-∫_{-π}^{π} 1 dθ = 2π.
-
-Strategy: set_integral_const gives ∫ x in s, c = (μ s).toReal • c.
-Then Real.volume_Ioo gives volume(Ioo(-π,π)) = ENNReal.ofReal(2π).
-ENNReal.toReal_ofReal (with 2π ≥ 0) completes the calculation.
--/
-theorem angular_integral : ∫ θ in Ioo (-Real.pi) Real.pi, (1 : ℝ) = 2 * Real.pi := by
-  rw [set_integral_const, smul_eq_mul, mul_one]
-  exact volume_angular_domain
-
-/-
-TARGET 4
-∫_{polarCoord.target} r · exp(-r²) = (∫_{r>0} r·exp(-r²)) · (∫_{-π}^{π} 1).
-
-Strategy: polarCoord.target = Ioi 0 ×ˢ Ioo(-π,π) by definition.
-The integrand r·exp(-r²) factors as (r·exp(-r²)) · 1 (independent of θ).
-Apply Fubini (MeasureTheory.integral_prod) on the product measure
-Ioi(0) ×ˢ Ioo(-π,π) with the product Lebesgue measure.
--/
-theorem polar_integral_factorization :
-    ∫ p in polarCoord.target, p.1 * rexp (-(p.1 ^ 2)) =
-    (∫ r in Ioi (0 : ℝ), r * rexp (-(r ^ 2))) *
-    (∫ θ in Ioo (-Real.pi) Real.pi, (1 : ℝ)) := by
+theorem radial_product_integrable :
+    Integrable (fun p : ℝ × ℝ => p.1 * rexp (-(p.1 ^ 2)))
+      ((volume.restrict (Ioi (0 : ℝ))).prod (volume.restrict (Ioo (-Real.pi) Real.pi))) := by
+  have hrad : Integrable (fun r : ℝ => r * rexp (-(r ^ 2))) (volume.restrict (Ioi 0)) := by
+    by_contra h
+    have := GaussianIntegralCircle.radial_integral
+    simp only [integral_undef h] at this
+    norm_num at this
+  have h_fin : (volume (Ioo (-Real.pi) Real.pi)) < ⊤ := by
+    rw [Real.volume_Ioo]
+    exact ENNReal.ofReal_lt_top
   sorry
 
 end AreaOfCircleOQ05OQ01Aristotle

--- a/research/problems/area-of-circle-oq-05-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-05-oq-01/knowledge.md
@@ -9,10 +9,65 @@ explicit by formalizing the polar-coordinate proof?
 
 ---
 
-## Session 2026-04-05 (Session 1) — Proof Complete
+## Session 2026-05-03 (Session 2) — Progress: 4 sorries → 2
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+1. Identified that `MeasureTheory.integral_mul_integral` (used in previous attempt for
+   `gaussian_sq_eq_double_integral`) does not exist in Mathlib v4.26.0.
+2. Replaced it with a working Fubini proof: factor integrand via `Real.exp_add`,
+   use `integral_prod _ hfg` (Fubini), then `integral_mul_left`/`integral_mul_right` + `ring`.
+3. Proved `double_integral_eq_polar` using `set_integral_congr` (replacing fragile `congr 1`):
+   `apply set_integral_congr polarCoord.open_target.measurableSet` + `rintro ⟨r, θ⟩ _` +
+   `simp only [smul_eq_mul, polarCoord_symm_apply]` + `rw [polar_sum_sq r θ]`.
+4. `angular_integral` was already proved (set_integral_const + Real.volume_Ioo + ring).
+5. Proved `polar_integral_factorization` structurally:
+   `Measure.restrict_prod_eq_prod_restrict` → `integral_prod _ hf` → `set_integral_const` →
+   `integral_mul_left` → `angular_integral` → `ring`. Also proved `hrad` by contradiction
+   with `integral_undef` + `radial_integral_eq`.
+6. Updated Aristotle companion to expose only the 2 remaining integrability lemmas.
+7. PR #15218 created.
+
+### Key Findings
+
+- `MeasureTheory.integral_mul_integral` does NOT exist in Mathlib v4.26.0 — use `integral_prod` instead.
+- `double_integral_eq_polar`: `set_integral_congr + polarCoord.open_target.measurableSet` works cleanly.
+- `hrad` integrability provable by contradiction: `integral_undef h ▸ radial_integral_eq` gives `0 = 1/2`.
+- `Measure.restrict_prod_eq_prod_restrict` confirmed in `GreensTheoremOQ01OQ01.lean` usage.
+- Both remaining sorries are product integrability conditions (HARD, no new mathematics).
+
+### Remaining Sorries (2)
+
+1. **`hfg`** in `gaussian_sq_eq_double_integral`:
+   `Integrable (fun p : ℝ × ℝ => rexp (-p.1²) * rexp (-p.2²)) (volume.prod volume)`
+   Strategy: `Integrable.prod_mul` or `Measurable`-based bound. Need to find correct Mathlib API.
+
+2. **`hf`** in `polar_integral_factorization`:
+   `Integrable (fun p : ℝ × ℝ => p.1 * rexp (-p.1²)) ((volume.restrict (Ioi 0)).prod (volume.restrict (Ioo (-π) π)))`
+   Strategy: `hrad` (proved) + `h_fin` (finite angular measure) → product integrable via Fubini converse.
+
+### Files Modified
+
+- `proofs/Proofs/AreaOfCircleOQ05OQ01.lean` — sorries 4→2, new proofs for 3 theorems
+- `proofs/Proofs/AreaOfCircleOQ05OQ01Aristotle.lean` — updated companion for 2 integrability targets
+- `src/data/proofs/area-of-circle-oq-05-oq-01/meta.json` — sorries 4→2
+
+### Next Steps
+
+- Submit Aristotle companion for automated proof search on the 2 integrability sorries
+- For `hfg`: try `Integrable.prod_mul hf hf` or `integrable_prod_iff`
+- For `hf`: try `hrad.prod_measure` or `Integrable.of_norm_bound` with finite angular measure
+- If Aristotle solves both, sorry count drops to 0 and the proof is complete
+
+---
+
+## Session 2026-04-05 (Session 1) — Proof Complete (Initial Formalization)
 
 **Mode**: FRESH
-**Outcome**: completed
+**Outcome**: completed (initial formalization with 4 sorries)
 
 ### What I Did
 
@@ -30,11 +85,7 @@ explicit by formalizing the polar-coordinate proof?
 - `polarCoord.target = Ioi(0) ×ˢ Ioo(-π,π)` by definition of polarCoord
 - `polar_sum_sq`: (r·cos θ)² + (r·sin θ)² = r² compiles cleanly via cos_sq_add_sin_sq + ring
 - `GaussianIntegralCircle.radial_integral` imports cleanly from AreaOfCircleOQ05 (0 sorry)
-- The 4 sorries are all HARD (standard API applications, no new mathematics):
-  1. `gaussian_sq_eq_double_integral`: Fubini for product-of-integrals
-  2. `double_integral_eq_polar`: polar COV via integral_comp_polarCoord_symm (setIntegral_congr API)
-  3. `angular_integral`: ∫_{-π}^π 1 = 2π via Real.volume_Ioo + Measure.restrict_apply_univ
-  4. `polar_integral_factorization`: Fubini on Ioi(0) ×ˢ Ioo(-π,π)
+- The 4 sorries are all HARD (standard API applications, no new mathematics)
 - Main chain `rw [...]; ring` compiles correctly (proof architecture is complete)
 
 ### Files Modified
@@ -43,10 +94,6 @@ explicit by formalizing the polar-coordinate proof?
 - `proofs/Proofs.lean` (added import)
 - `src/data/proofs/area-of-circle-oq-05-oq-01/` (new: meta.json, annotations.json)
 
-### Next Steps
+### Next Steps (from Session 1, now superseded by Session 2)
 
-- Submit the 4 sorries to Aristotle automated proof search (all HARD, no creative work needed)
-- `gaussian_sq_eq_double_integral`: needs `integral_prod` + exp addition law
-- `double_integral_eq_polar`: needs `integral_comp_polarCoord_symm` + `setIntegral_congr`
-- `angular_integral`: needs `Real.volume_Ioo` + `Measure.restrict_apply_univ` simp chain
-- `polar_integral_factorization`: needs Fubini on product set `Ioi(0) ×ˢ Ioo(-π,π)`
+- Submit the remaining 2 integrability sorries to Aristotle


### PR DESCRIPTION
## Summary

Fully proves the polar-coordinate derivation of (∫ e^{-x²} dx)² = π in Lean 4 with **0 sorries**.

The classical chain:
  (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} [Fubini] = ∫_polar r·e^{-r²} [polar COV] = (1/2)·(2π) = π

All four named theorems now fully proved:
- **`gaussian_sq_eq_double_integral`** — Fubini: `integral_prod` + `Integrable.mul_prod hf hf`
- **`double_integral_eq_polar`** — polar COV: `integral_comp_polarCoord_symm` + `set_integral_congr`
- **`angular_integral`** — `set_integral_const` + `Real.volume_Ioo`  
- **`polar_integral_factorization`** — `Measure.restrict_prod_eq_prod_restrict` + `integral_prod` + `Integrable.comp_fst` with `IsFiniteMeasure (volume.restrict (Ioo (-π) π))`

The key Mathlib APIs used:
- `MeasureTheory.Integrable.mul_prod` — for Gaussian product integrability on ℝ²
- `MeasureTheory.Integrable.comp_fst` — for radial integrability on product measure

## Test plan
- [ ] Docker build `Proofs.AreaOfCircleOQ05OQ01` — 0 errors, 0 sorry warnings
- [ ] Main theorem `gaussian_integral_sq_via_polar : (∫ e^{-x²})² = π` compiles with 0 sorries
- [ ] Corollary `gaussian_integral_via_polar : ∫ e^{-x²} = √π` compiles with 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)