### PR TITLE
audit(area-of-circle-oq-05-oq-01): correct sorry count 4→1

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -18,9 +18,9 @@
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ01.lean",
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 1,
     "axiomCount": 0,
-    "assumptions": "4 sorries: (1) gaussian_sq_eq_double_integral — Fubini step converting (∫ f)² to ∫∫ f⊗f; (2) double_integral_eq_polar — polar change of variables via integral_comp_polarCoord_symm; (3) angular_integral — ∫_{-π}^{π} 1 dθ = 2π via measure of interval; (4) polar_integral_factorization — Fubini on product set Ioi(0) ×ˢ Ioo(-π,π).",
+    "assumptions": "1 sorry: polar_integral_factorization — Fubini on product set Ioi(0) ×ˢ Ioo(-π,π) to separate radial and angular integrals.",
     "originalContributions": [
       "Named theorem for each step of the polar-coordinate proof: Fubini, change of variables, separation, radial, angular",
       "polar_sum_sq lemma: (r·cos θ)² + (r·sin θ)² = r² (compiled, 0 sorry)",
@@ -38,7 +38,7 @@
   "overview": {
     "historicalContext": "The Gaussian integral ∫_{-∞}^{∞} e^{-x²} dx = √π is a fundamental result in analysis with applications throughout probability (normal distribution), physics (quantum mechanics, statistical mechanics), and number theory (theta functions). The standard proof via polar coordinates, due to Poisson, converts the square of the integral to a double integral over ℝ², then changes to polar coordinates (r,θ), separates the resulting integral into radial and angular parts, and computes each. This formalization makes every step of that proof explicit as a named theorem in Lean 4.\n\nThe key identity is that (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} dx dy = ∫₀^∞ ∫_{-π}^π r·e^{-r²} dθ dr = (∫₀^∞ r·e^{-r²} dr)·(∫_{-π}^π dθ) = (1/2)·(2π) = π. The π appears because the angular integral equals 2π — the circumference of the unit circle. This explains the deep geometric connection between the Gaussian integral and circle geometry.",
     "problemStatement": "**Open Question (OQ-01 from OQ-05)**: Can the connection between the Gaussian integral and circle area be made fully explicit by formalizing the polar-coordinate proof?\n\n**Answer**: YES. This file formalizes each step: (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} [Fubini] = ∫_polar r·e^{-r²} [change of variables via integral_comp_polarCoord_symm] = (1/2)·(2π) [separation] = π.",
-    "text": "A 183-line formalization making every step of the classical polar-coordinate proof explicit. The key Lean primitive is `integral_comp_polarCoord_symm` from Mathlib.Analysis.SpecialFunctions.PolarCoord. The Pythagorean lemma `polar_sum_sq` (proving (r·cos θ)² + (r·sin θ)² = r²) and radial integral (imported from AreaOfCircleOQ05) compile with 0 sorries. The main theorem `gaussian_integral_sq_via_polar` and corollary `gaussian_integral_via_polar` are proved modulo 4 intermediate sorries (Fubini steps and polar API details).",
+    "text": "A 183-line formalization making every step of the classical polar-coordinate proof explicit. The key Lean primitive is `integral_comp_polarCoord_symm` from Mathlib.Analysis.SpecialFunctions.PolarCoord. Sections I (Fubini), II (polar change of variables), III (angular = 2π), and IV (radial = 1/2) all compile with 0 sorries. The main theorem `gaussian_integral_sq_via_polar` and corollary `gaussian_integral_via_polar` are proved modulo 1 remaining sorry in `polar_integral_factorization` (Section V: Fubini on the product set Ioi(0) ×ˢ Ioo(-π,π)).",
     "proofStrategy": "**Section I** (Fubini): Rewrite (∫ e^{-x²})² as ∫∫ e^{-(x²+y²)} via product measure. Strategy: integral_mul_right + integral_prod.\n\n**Section II** (Polar Change of Variables): Apply `integral_comp_polarCoord_symm` (which converts ∫_{polarCoord.target} r·f(polarCoord.symm(r,θ)) to ∫ f). After change of variables, (r·cos θ)² + (r·sin θ)² = r² by polar_sum_sq.\n\n**Section III** (Angular Integral = 2π): ∫_{-π}^{π} 1 dθ = volume(Ioo(-π,π)) = 2π via Real.volume_Ioo.\n\n**Section IV** (Radial Integral = 1/2): ∫₀^∞ r·e^{-r²} dr = 1/2, imported from AreaOfCircleOQ05 (proved via FTC with antiderivative -(1/2)·e^{-r²}).\n\n**Section V** (Factorization): Polar integral factors as radial × angular since integrand r·e^{-r²} is independent of θ.\n\n**Section VI** (Main Theorem): Chain: Fubini → polar → factorization → radial(1/2) × angular(2π) → π.",
     "keyInsights": [
       "**integral_comp_polarCoord_symm as the Key**: This Mathlib theorem provides the polar change of variables: ∫_{polarCoord.target} r • f(polarCoord.symm p) = ∫ f. The factor r is the Jacobian of the polar coordinate map.",
@@ -79,7 +79,7 @@
     "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
-    "sorries": 4
+    "sorries": 1
   },
   "sections": [
     {
@@ -87,7 +87,7 @@
       "title": "Section I: Fubini — Square of Gaussian as Double Integral",
       "startLine": 35,
       "endLine": 47,
-      "summary": "States gaussian_sq_eq_double_integral: (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)}. Proof strategy: integral_mul_right + integral_prod (Fubini-Tonelli). Currently sorry.",
+      "summary": "Proves gaussian_sq_eq_double_integral: (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)}. Uses integral_mul_integral (proved via Integrable instance for exp(-x²)) + simp_rw on exp_add. Compiles with 0 sorries.",
       "mathContext": "$(\\int e^{-x^2} dx)^2 = (\\int e^{-x^2} dx)(\\int e^{-y^2} dy) = \\int\\int e^{-(x^2+y^2)} dx\\, dy$ by Fubini."
     },
     {
@@ -95,7 +95,7 @@
       "title": "Section II: Polar Change of Variables",
       "startLine": 49,
       "endLine": 82,
-      "summary": "Proves polar_sum_sq (compiled, no sorry) and states double_integral_eq_polar (sorry). Key: integral_comp_polarCoord_symm converts the 2D integral to polar form.",
+      "summary": "Proves polar_sum_sq (no sorry) and double_integral_eq_polar (no sorry). Key: integral_comp_polarCoord_symm converts the 2D integral to polar form; congr + polarCoord_symm_apply + polar_sum_sq complete the proof. Both compile with 0 sorries.",
       "mathContext": "$\\int\\int e^{-(x^2+y^2)} = \\int_0^\\infty\\int_{-\\pi}^\\pi r e^{-r^2} d\\theta\\, dr$ via polar change of variables with Jacobian $r$."
     },
     {
@@ -103,7 +103,7 @@
       "title": "Section III: Angular Integral = 2π",
       "startLine": 84,
       "endLine": 98,
-      "summary": "States angular_integral: ∫_{-π}^π 1 dθ = 2π. Strategy: volume of interval = 2π via Real.volume_Ioo. Currently sorry.",
+      "summary": "Proves angular_integral: ∫_{-π}^π 1 dθ = 2π via set_integral_const + Real.volume_Ioo + ENNReal.toReal_ofReal + ring. Compiles with 0 sorries.",
       "mathContext": "$\\int_{-\\pi}^\\pi 1\\, d\\theta = \\text{vol}((-\\pi, \\pi)) = 2\\pi$. This is the circumference factor explaining why $\\pi$ appears."
     },
     {
@@ -127,7 +127,7 @@
       "title": "Section VI: Main Theorem",
       "startLine": 127,
       "endLine": 152,
-      "summary": "Proves gaussian_integral_sq_via_polar: (∫ e^{-x²})² = π by chaining the five sections. Also proves gaussian_integral_via_polar: ∫ e^{-x²} = √π. Both compile modulo the 4 sorry dependencies.",
+      "summary": "Proves gaussian_integral_sq_via_polar: (∫ e^{-x²})² = π by chaining the five sections via rw + ring. Also proves gaussian_integral_via_polar: ∫ e^{-x²} = √π. Both compile modulo the 1 sorry in polar_integral_factorization.",
       "mathContext": "$(\\int e^{-x^2})^2 = \\frac{1}{2} \\cdot 2\\pi = \\pi$, hence $\\int_{-\\infty}^\\infty e^{-x^2} dx = \\sqrt{\\pi}$."
     },
     {
@@ -140,12 +140,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Makes every step of the classical polar-coordinate proof of (∫ e^{-x²})² = π explicit as a named theorem. The Pythagorean polar_sum_sq and radial_integral_eq compile with 0 sorries. The main theorem and corollary are proved modulo 4 sorries for the Fubini and measure-theoretic API steps.",
-    "implications": "The 4 sorries target well-defined Mathlib API calls: Fubini for the product-integral identity, integral_comp_polarCoord_symm for the polar change of variables, Real.volume_Ioo chaining for the angular measure, and Fubini on a product set for the separation step. These are HARD sorries suitable for automated proof search (Aristotle). The proof architecture is complete and sound — only the API glue remains.",
+    "summary": "Makes every step of the classical polar-coordinate proof of (∫ e^{-x²})² = π explicit as a named theorem. Sections I–IV all compile with 0 sorries; only polar_integral_factorization (Section V) remains sorry. The main theorem and corollary are proved modulo this 1 sorry.",
+    "implications": "The 1 remaining sorry targets a well-defined Mathlib API call: Fubini on the product set Ioi(0) ×ˢ Ioo(-π,π) to separate radial and angular integrals. This is a HARD sorry suitable for automated proof search (Aristotle). The proof architecture is complete and sound — only the product-Fubini API glue remains.",
     "openQuestions": [
-      "Fill the 4 sorries using Aristotle automated proof search — all are HARD (standard API applications, no new mathematics required)",
+      "Fill the 1 remaining sorry (polar_integral_factorization) using Aristotle automated proof search — a standard Fubini application on the product measure",
       "Generalize the separation lemma to polar integrals of arbitrary f(r)·g(θ) — a reusable Fubini instance on the polar domain"
     ]
   },
-  "sorries": 4
+  "sorries": 1
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -514,10 +514,10 @@
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-05T21:59:44Z",
-      "result": "clean"
+      "lastAudited": "2026-05-03T13:06:30Z",
+      "result": "issues-fixed"
     },
     "area-of-circle-oq-05-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

- meta.json claimed `sorries: 4` but the actual Lean file on `main` has only 1 sorry remaining (`polar_integral_factorization`)
- Three sorries were resolved in recent commits: `gaussian_sq_eq_double_integral` (Fubini), `double_integral_eq_polar` (polar change of variables), and `angular_integral` (angular measure)
- Updates all three `sorries` fields (top-level, `meta.sorries`, `leanFile.sorries`) plus section summaries, `assumptions`, `conclusion`, and `overview.text`

## Evidence

**meta.json claimed**: `sorries: 4`  
**Lean file actual**: 1 sorry at line 143 (`polar_integral_factorization`)

```bash
git show origin/main:proofs/Proofs/AreaOfCircleOQ05OQ01.lean | python3 -c "
import sys,re; c=re.sub(r'/-.*?-/','',sys.stdin.read(),flags=re.DOTALL)
print(len(re.findall(r'\bsorry\b', '\n'.join([l.split(\"--\")[0] for l in c.split('\n')]))))"
# → 1
```

## Note

PR #15218 (`research(area-of-circle-oq-05-oq-01): reduce sorries 4→2`) is open and also touches `meta.json`. This audit PR fixes the tracker-reported mismatch against the current `main` state; PR #15218 may need rebasing after this merges.

---
Discovered during gallery integrity audit.