### PR TITLE
enrich(fundamental-arithmetic-oq-01-oq-01): add 5 annotations for Finsupp FTA

### DIFF
--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-finsupp-representation",
+    "proofId": "fundamental-arithmetic-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 60 },
+    "type": "concept",
+    "title": "Finsupp Encoding: Prime Exponent Maps as Functions ℕ →₀ ℕ",
+    "content": "The Finsupp (finite support function) encodes a number's factorization algebraically: `n.factorization : ℕ →₀ ℕ` maps each prime p to its exponent in n, with finite support (only finitely many primes divide n). The reconstruction formula `fta_reconstruction` recovers n from this map via `n.factorization.prod (· ^ ·)` — the Finsupp product of all prime powers. This delegates entirely to Mathlib's `Nat.factorization_prod_pow_eq_self`. The Finsupp approach contrasts with the sorted-list FTA: here the representation is a function, not a list, enabling cleaner algebraic reasoning (Finsupp forms a commutative monoid under addition).",
+    "mathContext": "$n = \\prod_{p \\in \\text{support}(f)} p^{f(p)}$ where $f = n.\\text{factorization} : \\mathbb{N} \\to_0 \\mathbb{N}$ and $\\text{support}(f) = \\{p \\text{ prime}: p \\mid n\\}$. Lean: `n.factorization.prod (· ^ ·) = n` for $n \\neq 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Finsupp (finite support functions)", "Nat.factorization", "prime exponent map", "Nat.factorization_prod_pow_eq_self"],
+    "prerequisites": ["Mathlib.Data.Nat.Factorization.Basic", "Finsupp definition and prod operation", "Nat.primeFactors"]
+  },
+  {
+    "id": "ann-uniqueness-valuation-proof",
+    "proofId": "fundamental-arithmetic-oq-01-oq-01",
+    "range": { "startLine": 87, "endLine": 118 },
+    "type": "technique",
+    "title": "Uniqueness via p-adic Valuation: finsupp_prime_prod_factorization",
+    "content": "The algebraic heart of the proof is `finsupp_prime_prod_factorization`: if f has prime support then `(f.prod (·^·)).factorization = f`. The proof works pointwise at each prime a. After distributing factorization over the Finset product (via `factorization_finset_prod`), the key step computes `(p ^ f p).factorization a` for each p in the support: it equals f(p) if p=a and 0 otherwise (since primes are coprime). This indicator-function collapse is executed by `Finset.sum_ite_eq` followed by checking the support membership. The chain `g = (g.prod (·^·)).factorization = n.factorization` then gives uniqueness in `fta_uniqueness`.",
+    "mathContext": "For prime-support $f$: $\\left(\\prod_p p^{f(p)}\\right).\\text{factorization}(a) = \\sum_p (p^{f(p)}).\\text{factorization}(a) = \\sum_p [p=a]\\cdot f(p) = f(a)$. Hence $(f.\\text{prod}(\\cdot^{\\cdot})).\\text{factorization} = f$.",
+    "significance": "key",
+    "relatedConcepts": ["p-adic valuation", "Finset.sum_ite_eq", "Nat.factorization_pow", "Finsupp.single_apply", "indicator function collapse"],
+    "prerequisites": ["factorization_finset_prod helper lemma", "Finsupp.ext for pointwise equality", "Nat.Prime.factorization = Finsupp.single p 1", "Finset.sum_congr for rewriting a sum"]
+  },
+  {
+    "id": "ann-fta-unique-existence",
+    "proofId": "fundamental-arithmetic-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 154 },
+    "type": "concept",
+    "title": "FTA as Unique Existence: ∃! f with Prime Support and f.prod (·^·) = n",
+    "content": "The main theorem `fundamental_theorem_of_arithmetic` states the FTA in its purest algebraic form: for n ≠ 0, there exists a unique f : ℕ →₀ ℕ with prime support satisfying f.prod (·^·) = n. The canonical witness is n.factorization. Existence is `fta_reconstruction`. Uniqueness follows immediately from `fta_uniqueness`, which uses `finsupp_prime_prod_factorization` to show any such g must equal n.factorization. The proof of `fta_uniqueness` is a two-step calculation: g = (g.prod (·^·)).factorization (by finsupp_prime_prod_factorization), and that product equals n by hypothesis.",
+    "mathContext": "$\\forall n \\neq 0,\\ \\exists! f: \\mathbb{N}\\to_0\\mathbb{N}$, $[\\text{support}(f) \\subseteq \\text{Primes}]$ and $f.\\text{prod}(\\cdot^{\\cdot}) = n$. Uniqueness: if $g.\\text{prod}(\\cdot^{\\cdot}) = n$ with prime support, then $g = (g.\\text{prod}(\\cdot^{\\cdot})).\\text{factorization} = n.\\text{factorization}$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental theorem of arithmetic", "unique factorization domain", "∃! in Lean 4", "Finsupp canonical form"],
+    "prerequisites": ["fta_reconstruction (existence)", "fta_uniqueness (uniqueness)", "finsupp_prime_prod_factorization (key algebraic identity)"]
+  },
+  {
+    "id": "ann-finsupp-vs-list",
+    "proofId": "fundamental-arithmetic-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Two FTA Formalizations: Sorted List vs Finsupp Exponent Map",
+    "content": "This file represents one of two complementary FTA formalizations in the gallery. `FundamentalArithmetic.lean` uses sorted prime lists with repetition; this file uses Finsupp prime exponent maps. The approaches have different strengths: sorted lists are closer to elementary proofs and easier to visualize; Finsupp maps integrate better with algebraic structures like unique factorization domains (UFDs) and ring theory. The Finsupp form directly supports: (1) multiplying factorizations via Finsupp addition, (2) checking divisibility via pointwise inequality, (3) GCD/LCM via pointwise min/max. The file imports only `Mathlib.Data.Nat.Factorization.Basic`, deliberately avoiding the list-based FTA.",
+    "mathContext": "List FTA: $n \\mapsto$ sorted list $[p_1, p_1, \\ldots, p_2, p_2, \\ldots]$. Finsupp FTA: $n \\mapsto f = \\{p_1 \\mapsto e_1, p_2 \\mapsto e_2, \\ldots\\}$. Product of lists = Product $\\prod p_i^{e_i}$ of Finsupp. Algebraic operations: $\\text{fact}(mn) = \\text{fact}(m) + \\text{fact}(n)$; $\\text{fact}(\\gcd(m,n)) = \\min(\\text{fact}(m),\\text{fact}(n))$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unique factorization domain", "Finsupp arithmetic operations", "FundamentalArithmetic.lean comparison", "prime factorization algebraic structure"],
+    "prerequisites": ["FundamentalArithmetic.lean (list-based FTA)", "Finsupp.add for multiplying factorizations", "Nat.factorization_mul"]
+  },
+  {
+    "id": "ann-corollaries-injectivity",
+    "proofId": "fundamental-arithmetic-oq-01-oq-01",
+    "range": { "startLine": 158, "endLine": 196 },
+    "type": "insight",
+    "title": "Corollaries: Factorization Injectivity and Coprimality via Disjoint Supports",
+    "content": "Three key corollaries follow immediately from uniqueness. `factorization_determines_number` proves injectivity of n.factorization on positive naturals: m = n iff m.factorization = n.factorization. `factorization_eq_iff_valuations` refines this: m = n iff they agree at every prime p (pointwise p-adic valuation equality). `coprime_factorization_disjoint` connects coprimality to the Finsupp representation: gcd(m,n)=1 iff m.factorization.support and n.factorization.support are disjoint (no shared prime factors). These corollaries turn the FTA from an existence/uniqueness statement into a practical tool for arithmetic reasoning.",
+    "mathContext": "Injectivity: $m.\\text{fact} = n.\\text{fact} \\Rightarrow m = n$. Valuation characterization: $m = n \\iff \\forall p:\\ m.\\text{fact}(p) = n.\\text{fact}(p)$. Coprimality: $\\gcd(m,n)=1 \\iff \\text{support}(m.\\text{fact}) \\cap \\text{support}(n.\\text{fact}) = \\emptyset$.",
+    "significance": "supporting",
+    "relatedConcepts": ["p-adic valuation", "coprimality via disjoint support", "Nat.Coprime", "Nat.coprime_iff_disjoint", "factorization injectivity"],
+    "prerequisites": ["fta_reconstruction for the calc chain", "Finsupp.ext for support disjointness", "Nat.coprime_iff_disjoint from Mathlib"]
+  }
+]

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/index.ts
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/index.ts
@@ -1,0 +1,20 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/FundamentalArithmeticOQ01OQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug, description: meta.description,
+  meta: meta.meta, sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -1,0 +1,115 @@
+{
+  "id": "fundamental-arithmetic-oq-01-oq-01",
+  "title": "Self-Contained FTA via Finsupp Prime Exponent Maps",
+  "slug": "fundamental-arithmetic-oq-01-oq-01",
+  "description": "Proves the Fundamental Theorem of Arithmetic using Mathlib's Nat.factorization (the prime exponent map approach), entirely self-contained without importing the parent file. The key result is a uniqueness theorem: if f : ℕ →₀ ℕ has prime support and f.prod (·^·) = n, then f = n.factorization. This algebraic formulation complements the sorted-list approach of FundamentalArithmetic.lean.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-05-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "factorization",
+      "finsupp",
+      "p-adic-valuation",
+      "unique-factorization",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-05-03",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 220,
+    "theoremCount": 12,
+    "originalContributions": [
+      "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
+      "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",
+      "fundamental_theorem_of_arithmetic: ∃! f : ℕ →₀ ℕ with prime support and f.prod (·^·) = n",
+      "factorization_determines_number: factorization injectivity — equal factorizations imply equal numbers",
+      "factorization_eq_iff_valuations: m = n iff ∀ p, m.factorization p = n.factorization p",
+      "factorization_eq_zero_iff_one: n.factorization = 0 iff n = 1",
+      "fta_mem_support_iff_dvd: prime p divides n iff p ∈ n.factorization.support",
+      "coprime_factorization_disjoint: coprime numbers have disjoint factorization supports"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Fundamental Theorem of Arithmetic — every positive integer has a unique prime factorization — was explicitly proved by Gauss in Disquisitiones Arithmeticae (1801). Modern algebra rephrases this as: ℕ is a Unique Factorization Monoid (UFM). Mathlib implements two equivalent representations: (1) sorted lists via Nat.primeFactorsList, and (2) finite support functions via Nat.factorization : ℕ → (ℕ →₀ ℕ). The Finsupp approach naturally encodes the algebraic structure — factorization is a monoid homomorphism from (ℕ×,·) to (ℕ →₀ ℕ, +), and the exponents add under multiplication.",
+    "problemStatement": "Can the unique factorization theorem be proved in a self-contained way that avoids importing the parent FundamentalArithmetic.lean, using only Mathlib's Nat.factorization primitives? Specifically: does every positive natural n admit a UNIQUE representation as f.prod (·^·) where f : ℕ →₀ ℕ has prime support?",
+    "text": "Yes. The Finsupp-based FTA states: for every n ≠ 0, there exists a unique f : ℕ →₀ ℕ with (∀ p ∈ f.support, p.Prime) and f.prod (·^·) = n. The canonical witness is n.factorization, the Mathlib prime exponent map. The key algebraic lemma is: (f.prod (·^·)).factorization = f when f has prime support — proving that factorization and reconstruction are mutual inverses.",
+    "proofStrategy": "The proof proceeds in three stages: (1) Existence: Nat.factorization_prod_pow_eq_self gives n.factorization.prod (·^·) = n directly. (2) Key lemma: To show (f.prod (·^·)).factorization = f, apply Finsupp.ext and compute the a-component. Distribute factorization over the product using factorization_finset_prod, then use factorization_pow and Prime.factorization to reduce each term to an indicator function. Collapse with Finset.sum_ite_eq. (3) Uniqueness: Any g with g.prod (·^·) = n satisfies g = (g.prod (·^·)).factorization = n.factorization.",
+    "keyInsights": [
+      "Nat.factorization and Finsupp.prod (·^·) are mutual inverses on the space of prime-supported Finsupps — establishing a bijection between positive naturals and prime exponent maps",
+      "The factorization distributes over products: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization (for nonzero m), proved by induction using Nat.factorization_mul",
+      "For prime p, p.factorization = Finsupp.single p 1 — so (p^k).factorization a = if p = a then k else 0, making the indicator-sum argument clean",
+      "The Finsupp representation is algebraically cleaner than the list representation: factorization(m·n) = factorization(m) + factorization(n) in the Finsupp sense, and coprimality is disjoint support"
+    ],
+    "prerequisites": [
+      "Finsupp: Lean 4 type for finitely-supported functions α →₀ M",
+      "Nat.factorization: the prime exponent map n ↦ (p ↦ v_p(n))",
+      "Nat.primeFactors: the finite set of prime divisors of n",
+      "Finsupp.prod: ∏ p ∈ f.support, g p (f p)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "helper",
+      "title": "Helper: Factorization Distributes Over Products",
+      "content": "We first prove that factorization distributes over Finset products of nonzero naturals: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization. The proof is by induction on s using Nat.factorization_mul."
+    },
+    {
+      "id": "existence",
+      "title": "Existence: Reconstruction Formula",
+      "content": "Every positive natural n equals n.factorization.prod (·^·). This is Nat.factorization_prod_pow_eq_self from Mathlib — the reconstruction of n from its prime exponent map."
+    },
+    {
+      "id": "key-lemma",
+      "title": "Key Algebraic Lemma",
+      "content": "For any f : ℕ →₀ ℕ with prime support: (f.prod (·^·)).factorization = f. The proof applies Finsupp.ext and computes the a-component by distributing factorization over the product, using factorization_pow and Prime.factorization to reduce to indicator functions."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness of the Representation",
+      "content": "If g has prime support and g.prod (·^·) = n, then g = n.factorization. Proof: g = (g.prod (·^·)).factorization = n.factorization, using the key lemma and the hypothesis."
+    },
+    {
+      "id": "fta",
+      "title": "Full FTA Statement",
+      "content": "∃! f : ℕ →₀ ℕ, (∀ p ∈ f.support, p.Prime) ∧ f.prod (·^·) = n. The canonical witness is n.factorization; uniqueness follows from the key lemma."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries",
+      "content": "The factorization map is injective on positive naturals; m = n iff their factorizations agree at every prime; n = 1 iff factorization is zero; coprime numbers have disjoint factorization supports."
+    }
+  ],
+  "conclusion": "The FTA has a clean algebraic formulation via Finsupp: every positive natural has a unique prime exponent map. This self-contained proof avoids the parent file entirely, demonstrating that Mathlib's Nat.factorization machinery is sufficient to prove both existence and uniqueness from scratch. The key insight is that factorization and reconstruction are mutual inverses — a consequence of Nat.factorization_prod_pow_eq_self combined with the distribution of factorization over products.",
+  "leanFile": {
+    "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
+    "namespace": "FundamentalArithmeticOQ01OQ01",
+    "sorryCount": 0,
+    "axiomCount": 0,
+    "lineCount": 220,
+    "theoremCount": 12
+  },
+  "crossReferences": [
+    {
+      "id": "fundamental-arithmetic",
+      "relationship": "parent",
+      "description": "Parent proof using the sorted-list approach (Nat.primeFactorsList)"
+    },
+    {
+      "id": "fundamental-arithmetic-oq-01",
+      "relationship": "sibling",
+      "description": "Multiplicative property of factorization — factorization(m·n) = factorization(m) + factorization(n)"
+    },
+    {
+      "id": "fundamental-arithmetic-oq-02",
+      "relationship": "sibling",
+      "description": "Failure of unique factorization in ℤ[√(-5)]"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
Adds 5 mathematical annotations to the Self-Contained FTA via Finsupp gallery entry.

## Annotations

- **ann-finsupp-representation** (lines 56-60): Explains the Finsupp encoding n.factorization : ℕ →₀ ℕ and the reconstruction formula n.factorization.prod (· ^ ·) = n
- **ann-uniqueness-valuation-proof** (lines 87-118): Deep dive into `finsupp_prime_prod_factorization` — the p-adic valuation argument, indicator function collapse via `Finset.sum_ite_eq`, and how uniqueness follows
- **ann-fta-unique-existence** (lines 137-154): The main FTA as ∃! f with prime support; the two-step calc chain proving uniqueness
- **ann-finsupp-vs-list** (lines 1-28): Context comparing two FTA formalizations: sorted prime lists vs Finsupp exponent maps; algebraic advantages of Finsupp
- **ann-corollaries-injectivity** (lines 158-196): Factorization injectivity, p-adic valuation characterization, coprimality via disjoint supports

Also adds the previously-untracked `index.ts` and `meta.json` files (untracked in main repo, now committed).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)