### PR TITLE
fix(derangements-convergence-oq-01-oq-01): sync lineCount 130→147

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked, building on the alternating series rate bound from DerangementsConvergence.lean.",
     "dateAdded": "2026-05-03",
-    "lineCount": 130,
+    "lineCount": 147,
     "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [
@@ -46,7 +46,7 @@
       "Topology"
     ],
     "namespace": "DerangementsNearestInt",
-    "lineCount": 130,
+    "lineCount": 147,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Update `lineCount` from 130 to 147 in both `meta.lineCount` and `leanFile.lineCount` for derangements-convergence-oq-01-oq-01.

## Evidence

**Before**: `meta.lineCount: 130`, `leanFile.lineCount: 130`

**After**: `meta.lineCount: 147`, `leanFile.lineCount: 147`

**Verification**:
```
wc -l proofs/Proofs/DerangementsConvergenceOQ01OQ01.lean
→ 147
```

The `theoremCount` (7) was already correct.

---
Automated fix by lean-mechanic agent.