### PR TITLE
research(fundamental-arithmetic-oq-01-oq-01): prove FTA via Finsupp prime exponent maps

### DIFF
--- a/proofs/Proofs/FundamentalArithmeticOQ01OQ01.lean
+++ b/proofs/Proofs/FundamentalArithmeticOQ01OQ01.lean
@@ -1,0 +1,220 @@
+/-
+Self-Contained Fundamental Theorem of Arithmetic via Finsupp
+Open Question: fundamental-arithmetic-oq-01-oq-01
+
+Proves the FTA using Mathlib's Nat.factorization (prime exponent map),
+as an alternative to the sorted-list approach in FundamentalArithmetic.lean.
+
+Key theorem: Every positive natural n has a unique representation as
+  n = ∏ p ∈ n.primeFactors, p ^ (n.factorization p)
+where n.factorization : ℕ →₀ ℕ maps each prime to its exponent in n.
+
+The Finsupp (finite support function) approach:
+- Encodes factorization algebraically as a function ℕ → ℕ with finite support
+- Uniqueness follows from injectivity of the factorization map
+- Complements the list approach: sorted lists vs. prime exponent maps
+
+This file imports only Mathlib.Data.Nat.Factorization.Basic, avoiding
+FundamentalArithmetic.lean and FundamentalArithmeticOQ01.lean.
+
+References:
+- Nat.factorization_prod_pow_eq_self: the reconstruction formula
+- Nat.support_factorization: support equals primeFactors
+- Nat.Prime.factorization: prime p has factorization = Finsupp.single p 1
+-/
+
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+namespace FundamentalArithmeticOQ01OQ01
+
+open Finsupp Nat
+
+-- ============================================================
+-- Helper: factorization distributes over Finset products
+-- ============================================================
+
+/-- Factorization distributes over Finset products of nonzero naturals:
+    (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization -/
+private lemma factorization_finset_prod (s : Finset ℕ) (h : ∀ m ∈ s, m ≠ 0) :
+    (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization := by
+  induction s using Finset.induction_on with
+  | empty => simp [Nat.factorization_one]
+  | insert ha ih =>
+    rename_i a s _
+    rw [Finset.prod_insert ha, Finset.sum_insert ha]
+    rw [Nat.factorization_mul (h a (Finset.mem_insert_self a s))
+      (Finset.prod_ne_zero (fun m hm => h m (Finset.mem_insert_of_mem hm)))]
+    congr 1
+    exact ih (fun m hm => h m (Finset.mem_insert_of_mem hm))
+
+-- ============================================================
+-- Part I: Reconstruction Formula (Existence)
+-- ============================================================
+
+/-- **FTA Existence (Finsupp form)**: Every positive natural equals the Finsupp
+    product of its prime powers: n.factorization.prod (· ^ ·) = n. -/
+theorem fta_reconstruction (n : ℕ) (hn : n ≠ 0) :
+    n.factorization.prod (· ^ ·) = n :=
+  Nat.factorization_prod_pow_eq_self hn
+
+-- ============================================================
+-- Part II: Support is Exactly the Prime Factors
+-- ============================================================
+
+/-- The support of n.factorization equals n's prime factors. -/
+theorem fta_support_eq_primeFactors (n : ℕ) :
+    n.factorization.support = n.primeFactors :=
+  Nat.support_factorization n
+
+/-- Every element of n.factorization.support is prime. -/
+theorem fta_support_prime (n : ℕ) {p : ℕ} (hp : p ∈ n.factorization.support) :
+    p.Prime := by
+  rw [Nat.support_factorization] at hp
+  exact Nat.prime_of_mem_primeFactors hp
+
+/-- A prime p divides n iff p ∈ n.factorization.support. -/
+theorem fta_mem_support_iff_dvd {n p : ℕ} (hn : n ≠ 0) (hp : p.Prime) :
+    p ∈ n.factorization.support ↔ p ∣ n := by
+  rw [Nat.support_factorization, Nat.mem_primeFactors hn]
+  exact ⟨fun h => h.2, fun h => ⟨hp, h, hn⟩⟩
+
+-- ============================================================
+-- Part III: Key Algebraic Lemma
+-- ============================================================
+
+/-- **Key identity**: If f : ℕ →₀ ℕ has prime support, then the factorization
+    of its Finsupp prime-power product recovers f itself.
+
+    Proof: At each prime a, the a-adic valuation of ∏ p^(f p) equals f a,
+    since: (i) the a-th factor contributes exactly f a to the valuation,
+    and (ii) all other factors p^(f p) with p ≠ a are coprime to a. -/
+theorem finsupp_prime_prod_factorization (f : ℕ →₀ ℕ)
+    (hf : ∀ p ∈ f.support, p.Prime) :
+    (f.prod (· ^ ·)).factorization = f := by
+  apply Finsupp.ext
+  intro a
+  simp only [Finsupp.prod]
+  -- Step 1: distribute factorization over the Finset product
+  have hne : ∀ p ∈ f.support, p ^ f p ≠ 0 := fun p hp =>
+    pow_ne_zero (f p) (hf p hp).ne_zero
+  rw [factorization_finset_prod _ hne]
+  -- Step 2: distribute Finsupp apply over the sum
+  simp only [Finsupp.finset_sum_apply]
+  -- Step 3: compute (p ^ f p).factorization a for each prime p
+  have step : ∀ p ∈ f.support, (p ^ f p).factorization a = if p = a then f p else 0 := by
+    intro p hp
+    have hprime : p.Prime := hf p hp
+    rw [Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul,
+        hprime.factorization, Finsupp.single_apply]
+    split_ifs <;> simp
+  rw [Finset.sum_congr rfl step]
+  -- Step 4: collapse the indicator sum
+  rw [Finset.sum_ite_eq]
+  -- Step 5: if a ∉ support then f a = 0
+  split_ifs with hmem
+  · rfl
+  · exact (Finsupp.not_mem_support_iff.mp hmem).symm
+
+-- ============================================================
+-- Part IV: Uniqueness of the Finsupp Representation
+-- ============================================================
+
+/-- **FTA Uniqueness**: If g : ℕ →₀ ℕ has prime support and
+    g.prod (· ^ ·) = n, then g is exactly n's canonical factorization. -/
+theorem fta_uniqueness {n : ℕ} (hn : n ≠ 0) (g : ℕ →₀ ℕ)
+    (hg_prime : ∀ p ∈ g.support, p.Prime)
+    (hg_prod : g.prod (· ^ ·) = n) :
+    g = n.factorization := by
+  calc g = (g.prod (· ^ ·)).factorization := (finsupp_prime_prod_factorization g hg_prime).symm
+    _ = n.factorization := by rw [hg_prod]
+
+-- ============================================================
+-- Part V: The Full FTA (Finsupp Formulation)
+-- ============================================================
+
+/-- **Fundamental Theorem of Arithmetic (Finsupp formulation)**:
+    Every positive natural n has a UNIQUE representation f : ℕ →₀ ℕ with
+    prime support satisfying f.prod (· ^ ·) = n.
+
+    This is the algebraic FTA: n encodes uniquely as a prime exponent map.
+    The canonical witness is n.factorization.
+
+    Contrast with the list FTA (FundamentalArithmetic.lean): there, the
+    representation uses a sorted list of primes with repetition. Here, it
+    uses a Finsupp mapping each prime to its multiplicity. Both are unique
+    representations; the Finsupp form has cleaner algebraic properties. -/
+theorem fundamental_theorem_of_arithmetic (n : ℕ) (hn : n ≠ 0) :
+    ∃! f : ℕ →₀ ℕ,
+      (∀ p ∈ f.support, p.Prime) ∧
+      f.prod (· ^ ·) = n := by
+  refine ⟨n.factorization, ⟨fta_support_prime n, fta_reconstruction n hn⟩, ?_⟩
+  intro g ⟨hg_prime, hg_prod⟩
+  exact fta_uniqueness hn g hg_prime hg_prod
+
+-- ============================================================
+-- Part VI: Corollaries
+-- ============================================================
+
+/-- If two positive naturals have equal prime exponent maps, they are equal.
+    The factorization map is injective on positive naturals. -/
+theorem factorization_determines_number {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0)
+    (h : m.factorization = n.factorization) : m = n :=
+  calc m = m.factorization.prod (· ^ ·) := (fta_reconstruction m hm).symm
+    _ = n.factorization.prod (· ^ ·) := by rw [h]
+    _ = n := fta_reconstruction n hn
+
+/-- m = n iff they have equal p-adic valuations at every prime p. -/
+theorem factorization_eq_iff_valuations {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0) :
+    m = n ↔ ∀ p : ℕ, m.factorization p = n.factorization p := by
+  constructor
+  · intro h; simp [h]
+  · intro h
+    apply factorization_determines_number hm hn
+    ext p; exact h p
+
+/-- n = 1 iff its factorization is identically zero (no prime factors). -/
+theorem factorization_eq_zero_iff_one {n : ℕ} (hn : n ≠ 0) :
+    n.factorization = 0 ↔ n = 1 := by
+  constructor
+  · intro h
+    have : n.factorization.prod (· ^ ·) = 1 := by
+      rw [h]; simp [Finsupp.prod]
+    rwa [fta_reconstruction n hn] at this
+  · intro h; rw [h, Nat.factorization_one]
+
+/-- The exponent of a prime p in n equals n.factorization p. -/
+theorem prime_exponent_eq_factorization {n p : ℕ} (hn : n ≠ 0) (hp : p.Prime) :
+    n.factorization p = (n.factorization.prod (· ^ ·)).factorization p := by
+  rw [fta_reconstruction n hn]
+
+/-- For coprime m, n: their prime exponent maps have disjoint support. -/
+theorem coprime_factorization_disjoint {m n : ℕ}
+    (hcop : Nat.Coprime m n) :
+    Disjoint m.factorization.support n.factorization.support :=
+  Nat.coprime_iff_disjoint.mp hcop
+
+-- ============================================================
+-- Part VII: Computational Examples
+-- ============================================================
+
+/-- Example: 12 = 2² · 3¹. The factorization map encodes {2 ↦ 2, 3 ↦ 1}. -/
+example : (12 : ℕ).factorization = Finsupp.single 2 2 + Finsupp.single 3 1 := by
+  native_decide
+
+/-- Example: primeFactors of 30 = {2, 3, 5} (equals factorization support). -/
+example : (30 : ℕ).primeFactors = {2, 3, 5} := by native_decide
+
+/-- Example: The Finsupp product {2 ↦ 2, 3 ↦ 1}.prod (·^·) = 12. -/
+example : (Finsupp.single 2 2 + Finsupp.single 3 1 : ℕ →₀ ℕ).prod (· ^ ·) = 12 := by
+  native_decide
+
+/-- Example: The factorization of 1 is the zero Finsupp. -/
+example : (1 : ℕ).factorization = 0 := Nat.factorization_one
+
+/-- Example: Coprimality via disjoint support: gcd(12, 35) = 1. -/
+example : Disjoint (12 : ℕ).factorization.support (35 : ℕ).factorization.support := by
+  native_decide
+
+end FundamentalArithmeticOQ01OQ01

--- a/research/problems/fundamental-arithmetic-oq-01-oq-01/knowledge.md
+++ b/research/problems/fundamental-arithmetic-oq-01-oq-01/knowledge.md
@@ -1,0 +1,57 @@
+# fundamental-arithmetic-oq-01-oq-01
+
+**Problem**: Can the unique factorization be proved in a way that avoids the parent file, giving a self-contained proof of the Fundamental Theorem from Mathlib primitives?
+
+## Problem Summary
+
+This problem asks for a self-contained proof of the FTA that avoids importing `FundamentalArithmetic.lean`. The parent file uses the sorted-list approach (`Nat.primeFactorsList`). This problem explores the algebraic (Finsupp) approach using `Nat.factorization : ℕ → (ℕ →₀ ℕ)`.
+
+**Answer**: Yes. The Finsupp-based FTA states: for n ≠ 0, there exists a unique f : ℕ →₀ ℕ with prime support satisfying f.prod (·^·) = n. The canonical witness is n.factorization.
+
+## Key Mathlib Facts Used
+
+- `Nat.factorization_prod_pow_eq_self`: n.factorization.prod (·^·) = n (reconstruction)
+- `Nat.support_factorization`: n.factorization.support = n.primeFactors
+- `Nat.Prime.factorization hp`: p.factorization = Finsupp.single p 1
+- `Nat.factorization_pow`: (n^k).factorization = k • n.factorization
+- `Nat.factorization_mul`: (m*n).factorization = m.factorization + n.factorization
+- `Finsupp.finset_sum_apply`: distributes Finsupp apply over sums
+- `Finset.sum_ite_eq`: collapses indicator sums
+
+## Session 2026-05-03 (Session 1) — Complete Proof
+
+**Mode**: FRESH (first attempt)
+**Outcome**: complete — 0 sorries, 0 axioms, 12 theorems, 220 lines
+
+### What I Did
+- Selected problem (score 0, fresh, tractable)
+- Wrote full proof in `FundamentalArithmeticOQ01OQ01.lean`
+- Key proof strategy: the algebraic identity (f.prod (·^·)).factorization = f for prime-support f
+- Helper lemma: `factorization_finset_prod` (distribution over products by induction)
+- Created gallery entry with meta.json, index.ts, annotations.json
+- Updated listings.json with new entry
+- Docker build pending
+
+### Files Modified
+- `proofs/Proofs/FundamentalArithmeticOQ01OQ01.lean` (new, 220 lines)
+- `src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json` (new)
+- `src/data/proofs/fundamental-arithmetic-oq-01-oq-01/index.ts` (new)
+- `src/data/proofs/fundamental-arithmetic-oq-01-oq-01/annotations.json` (new)
+- `src/data/proofs/listings.json` (added entry)
+
+### Key Findings
+
+**The algebraic core**: `finsupp_prime_prod_factorization` proves (f.prod (·^·)).factorization = f for prime-support f. The proof:
+1. Distribute factorization over the Finset product (induction, using Nat.factorization_mul)
+2. Use Nat.factorization_pow + Prime.factorization to reduce each term to indicators
+3. Collapse with Finset.sum_ite_eq
+
+**Uniqueness follows cleanly**: g = (g.prod (·^·)).factorization = n.factorization.
+
+**Proof contrast with parent file**:
+- Parent: sorted list [2,2,3,5,...] with `Nat.primeFactorsList`
+- This file: Finsupp {2 ↦ 2, 3 ↦ 1, 5 ↦ 1} with `Nat.factorization`
+
+### Next Steps
+- Verify Docker build completes without errors
+- Promote to gallery with PR

--- a/research/problems/fundamental-arithmetic-oq-01-oq-01/problem.md
+++ b/research/problems/fundamental-arithmetic-oq-01-oq-01/problem.md
@@ -1,0 +1,39 @@
+# Problem: Can the unique factorization be proved in a way that avoids the parent file, ...
+
+## Statement
+
+### Plain Language
+AVAILABLE: Can the unique factorization be proved in a way that avoids the parent file, giving a self-contained proof of the Fundamental Theorem from Mathlib primitives?.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 5
+tags:
+  - number-theory
+  - factorization
+  - coprime
+  - p-adic-valuation
+  - research
+  - seeker-selected
+```
+
+**Significance**: 6/10
+**Tractability**: 5/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: Can the unique factorization be proved in a way that avoids the parent file, giving a self-contained proof of the Fundamental Theorem from Mathlib primitives?
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/fundamental-arithmetic-oq-01-oq-01/state.md
+++ b/research/problems/fundamental-arithmetic-oq-01-oq-01/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-05-03T15:08:41+02:00
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/src/data/research/problems/fundamental-arithmetic-oq-01-oq-01.json
+++ b/src/data/research/problems/fundamental-arithmetic-oq-01-oq-01.json
@@ -1,0 +1,127 @@
+{
+  "slug": "fundamental-arithmetic-oq-01-oq-01",
+  "title": "Can the unique factorization be proved in a way that avoids the parent file, ...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: Can the unique factorization be proved in a way that avoids the parent file, giving a self-contained proof of the Fundamental Theorem from Mathlib primitives?.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-05-03T11:41:44.695Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: FTA proved via Finsupp approach. 12 theorems, 0 sorries, 0 axioms. Key result: finsupp_prime_prod_factorization (factorization of Finsupp prime power product = original Finsupp), plus uniqueness and existence FTA. Docker build pending.",
+    "builtItems": [
+      "factorization_finset_prod: helper lemma (\u220f m \u2208 s, m).factorization = \u2211 m \u2208 s, m.factorization",
+      "fta_reconstruction: n.factorization.prod (\u00b7^\u00b7) = n (Nat.factorization_prod_pow_eq_self)",
+      "fta_support_eq_primeFactors: support = primeFactors",
+      "fta_support_prime: elements of factorization support are prime",
+      "fta_mem_support_iff_dvd: p \u2208 support \u2194 p \u2223 n (for prime p)",
+      "finsupp_prime_prod_factorization: KEY LEMMA \u2014 (f.prod (\u00b7^\u00b7)).factorization = f",
+      "fta_uniqueness: g.prod(\u00b7^\u00b7) = n with prime support \u2192 g = n.factorization",
+      "fundamental_theorem_of_arithmetic: \u2203! f with prime support and f.prod(\u00b7^\u00b7) = n",
+      "factorization_determines_number: injectivity of factorization on positive naturals",
+      "factorization_eq_iff_valuations: m = n \u2194 \u2200 p, m.factorization p = n.factorization p",
+      "factorization_eq_zero_iff_one: factorization = 0 \u2194 n = 1",
+      "coprime_factorization_disjoint: coprime \u2192 disjoint factorization supports"
+    ],
+    "insights": [
+      "Nat.factorization and Finsupp.prod (\u00b7^\u00b7) are mutual inverses on prime-supported Finsupps",
+      "factorization_finset_prod (distribution over products) proved by induction using Nat.factorization_mul",
+      "For prime p: (p^k).factorization a = if p = a then k else 0 \u2014 key for indicator-sum uniqueness argument",
+      "finsupp_prime_prod_factorization is the algebraic core: (f.prod (\u00b7^\u00b7)).factorization = f for prime-support f",
+      "The Finsupp FTA (\u2203! f with prime support and f.prod(\u00b7^\u00b7) = n) has the canonical witness n.factorization"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Docker build pending \u2014 verify Lean proof compiles"
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "factorization",
+    "coprime",
+    "p-adic-valuation",
+    "research",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "fundamental-arithmetic",
+    "fundamental-arithmetic-oq-01",
+    "fundamental-arithmetic-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-03T11:41:44.694Z",
+  "lastUpdate": "2026-05-03T11:41:44.694Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/FundamentalArithmetic.lean",
+      "filename": "FundamentalArithmetic.lean",
+      "lineCount": 225,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalArithmetic.lean"
+    },
+    {
+      "path": "Proofs/FundamentalArithmeticOQ01.lean",
+      "filename": "FundamentalArithmeticOQ01.lean",
+      "lineCount": 114,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalArithmeticOQ01.lean"
+    },
+    {
+      "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
+      "filename": "FundamentalArithmeticOQ01OQ01.lean",
+      "lineCount": 221,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalArithmeticOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/FundamentalArithmeticOQ02.lean",
+      "filename": "FundamentalArithmeticOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalArithmeticOQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `FundamentalArithmeticOQ01OQ01.lean` (220 lines, 0 sorries, 0 axioms, 12 theorems)
- Self-contained FTA proof using `Nat.factorization : ℕ → (ℕ →₀ ℕ)`, avoids importing the sorted-list parent file
- Gallery data already merged (PR #15224 — annotations, meta.json, index.ts)

## Key Results

- `finsupp_prime_prod_factorization`: the algebraic core — `(f.prod (·^·)).factorization = f` when `f` has prime support
- `fundamental_theorem_of_arithmetic`: `∃! f : ℕ →₀ ℕ` with prime support and `f.prod (·^·) = n`
- Corollaries: factorization injectivity, valuation characterization, coprimality via disjoint support

## Proof Strategy

1. **Helper**: `factorization_finset_prod` distributes factorization over Finset products (induction on Finset using `Nat.factorization_mul`)
2. **Key lemma**: pointwise computation via `Nat.factorization_pow` + `Prime.factorization = Finsupp.single p 1` → indicator function → collapse with `Finset.sum_ite_eq`
3. **Uniqueness**: two-step chain `g = (g.prod (·^·)).factorization = n.factorization`

## Test plan

- [ ] Docker build (`./proofs/scripts/docker-build.sh Proofs.FundamentalArithmeticOQ01OQ01`) completes with 0 errors
- [ ] `sorryCount = 0`, `axiomCount = 0` confirmed
- [ ] Gallery page renders correctly