### PR TITLE
fix(area-of-circle-oq-05-oq-01): promote to verified after PR #15218 cleared all sorries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_integral#Polar_coordinates",
     "date": "Classical result, formalized 2026",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "analysis",
       "integration",
@@ -17,20 +17,20 @@
       "measure-theory"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ01.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "1 sorry: polar_integral_factorization — Fubini on product set Ioi(0) ×ˢ Ioo(-π,π) to separate radial and angular integrals.",
+    "assumptions": "None. All 10 theorems fully verified with 0 sorries and 0 axioms. The polar_integral_factorization sorry was resolved via Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst.",
     "originalContributions": [
       "Named theorem for each step of the polar-coordinate proof: Fubini, change of variables, separation, radial, angular",
       "polar_sum_sq lemma: (r·cos θ)² + (r·sin θ)² = r² (compiled, 0 sorry)",
       "Imports radial_integral_eq from AreaOfCircleOQ05 (proved via FTC)",
-      "Main theorem gaussian_integral_sq_via_polar: (∫ e^{-x²})² = π (proved modulo sorries)",
-      "gaussian_integral_via_polar: ∫ e^{-x²} = √π (proved modulo sorries)",
+      "Main theorem gaussian_integral_sq_via_polar: (∫ e^{-x²})² = π (fully proved, 0 sorries)",
+      "gaussian_integral_via_polar: ∫ e^{-x²} = √π (fully proved, 0 sorries)",
       "Connection to circle area: angular=2π (circumference) × radial=1/2 gives π (area)"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 183,
+    "lineCount": 231,
     "theoremCount": 10,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -38,7 +38,7 @@
   "overview": {
     "historicalContext": "The Gaussian integral ∫_{-∞}^{∞} e^{-x²} dx = √π is a fundamental result in analysis with applications throughout probability (normal distribution), physics (quantum mechanics, statistical mechanics), and number theory (theta functions). The standard proof via polar coordinates, due to Poisson, converts the square of the integral to a double integral over ℝ², then changes to polar coordinates (r,θ), separates the resulting integral into radial and angular parts, and computes each. This formalization makes every step of that proof explicit as a named theorem in Lean 4.\n\nThe key identity is that (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} dx dy = ∫₀^∞ ∫_{-π}^π r·e^{-r²} dθ dr = (∫₀^∞ r·e^{-r²} dr)·(∫_{-π}^π dθ) = (1/2)·(2π) = π. The π appears because the angular integral equals 2π — the circumference of the unit circle. This explains the deep geometric connection between the Gaussian integral and circle geometry.",
     "problemStatement": "**Open Question (OQ-01 from OQ-05)**: Can the connection between the Gaussian integral and circle area be made fully explicit by formalizing the polar-coordinate proof?\n\n**Answer**: YES. This file formalizes each step: (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} [Fubini] = ∫_polar r·e^{-r²} [change of variables via integral_comp_polarCoord_symm] = (1/2)·(2π) [separation] = π.",
-    "text": "A 183-line formalization making every step of the classical polar-coordinate proof explicit. The key Lean primitive is `integral_comp_polarCoord_symm` from Mathlib.Analysis.SpecialFunctions.PolarCoord. Sections I (Fubini), II (polar change of variables), III (angular = 2π), and IV (radial = 1/2) all compile with 0 sorries. The main theorem `gaussian_integral_sq_via_polar` and corollary `gaussian_integral_via_polar` are proved modulo 1 remaining sorry in `polar_integral_factorization` (Section V: Fubini on the product set Ioi(0) ×ˢ Ioo(-π,π)).",
+    "text": "A 231-line formalization making every step of the classical polar-coordinate proof explicit. The key Lean primitive is `integral_comp_polarCoord_symm` from Mathlib.Analysis.SpecialFunctions.PolarCoord. All sections compile with 0 sorries: Sections I–IV (Fubini, polar change of variables, angular = 2π, radial = 1/2), and Section V (polar_integral_factorization via Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst). The main theorem `gaussian_integral_sq_via_polar` and corollary `gaussian_integral_via_polar` are fully proved.",
     "proofStrategy": "**Section I** (Fubini): Rewrite (∫ e^{-x²})² as ∫∫ e^{-(x²+y²)} via product measure. Strategy: integral_mul_right + integral_prod.\n\n**Section II** (Polar Change of Variables): Apply `integral_comp_polarCoord_symm` (which converts ∫_{polarCoord.target} r·f(polarCoord.symm(r,θ)) to ∫ f). After change of variables, (r·cos θ)² + (r·sin θ)² = r² by polar_sum_sq.\n\n**Section III** (Angular Integral = 2π): ∫_{-π}^{π} 1 dθ = volume(Ioo(-π,π)) = 2π via Real.volume_Ioo.\n\n**Section IV** (Radial Integral = 1/2): ∫₀^∞ r·e^{-r²} dr = 1/2, imported from AreaOfCircleOQ05 (proved via FTC with antiderivative -(1/2)·e^{-r²}).\n\n**Section V** (Factorization): Polar integral factors as radial × angular since integrand r·e^{-r²} is independent of θ.\n\n**Section VI** (Main Theorem): Chain: Fubini → polar → factorization → radial(1/2) × angular(2π) → π.",
     "keyInsights": [
       "**integral_comp_polarCoord_symm as the Key**: This Mathlib theorem provides the polar change of variables: ∫_{polarCoord.target} r • f(polarCoord.symm p) = ∫ f. The factor r is the Jacobian of the polar coordinate map.",
@@ -74,12 +74,12 @@
       "Proofs.AreaOfCircleOQ05"
     ],
     "namespace": "AreaOfCircleOQ05OQ01",
-    "lineCount": 183,
+    "lineCount": 231,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "sections": [
     {
@@ -119,7 +119,7 @@
       "title": "Section V: Factorization of Polar Integral",
       "startLine": 110,
       "endLine": 125,
-      "summary": "States polar_integral_factorization: ∫_{polarCoord.target} r·e^{-r²} = (∫₀^∞ r·e^{-r²})(∫_{-π}^π 1). Strategy: Fubini on Ioi(0) ×ˢ Ioo(-π,π). Currently sorry.",
+      "summary": "Proves polar_integral_factorization: ∫_{polarCoord.target} r·e^{-r²} = (∫₀^∞ r·e^{-r²})(∫_{-π}^π 1). Uses Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst with IsFiniteMeasure on the angular domain. Fully proved, 0 sorries.",
       "mathContext": "$\\int_{r>0,\\theta\\in(-\\pi,\\pi)} r e^{-r^2} d\\theta\\, dr = \\left(\\int_0^\\infty r e^{-r^2} dr\\right)\\left(\\int_{-\\pi}^\\pi d\\theta\\right)$ since the integrand is independent of $\\theta$."
     },
     {
@@ -127,7 +127,7 @@
       "title": "Section VI: Main Theorem",
       "startLine": 127,
       "endLine": 152,
-      "summary": "Proves gaussian_integral_sq_via_polar: (∫ e^{-x²})² = π by chaining the five sections via rw + ring. Also proves gaussian_integral_via_polar: ∫ e^{-x²} = √π. Both compile modulo the 1 sorry in polar_integral_factorization.",
+      "summary": "Proves gaussian_integral_sq_via_polar: (∫ e^{-x²})² = π by chaining the five sections via rw + ring. Also proves gaussian_integral_via_polar: ∫ e^{-x²} = √π. Both compile with 0 sorries.",
       "mathContext": "$(\\int e^{-x^2})^2 = \\frac{1}{2} \\cdot 2\\pi = \\pi$, hence $\\int_{-\\infty}^\\infty e^{-x^2} dx = \\sqrt{\\pi}$."
     },
     {
@@ -140,12 +140,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Makes every step of the classical polar-coordinate proof of (∫ e^{-x²})² = π explicit as a named theorem. Sections I–IV all compile with 0 sorries; only polar_integral_factorization (Section V) remains sorry. The main theorem and corollary are proved modulo this 1 sorry.",
-    "implications": "The 1 remaining sorry targets a well-defined Mathlib API call: Fubini on the product set Ioi(0) ×ˢ Ioo(-π,π) to separate radial and angular integrals. This is a HARD sorry suitable for automated proof search (Aristotle). The proof architecture is complete and sound — only the product-Fubini API glue remains.",
+    "summary": "Makes every step of the classical polar-coordinate proof of (∫ e^{-x²})² = π explicit as a named theorem. All sections including polar_integral_factorization (Section V) are fully proved. The main theorem and corollary compile with 0 sorries and 0 axioms.",
+    "implications": "All sections are fully proved. The completed proof demonstrates that the polar-coordinate derivation of the Gaussian integral can be formalized end-to-end in Lean 4 using Mathlib's measure theory API (integral_comp_polarCoord_symm, integral_prod, Measure.restrict_prod_eq_prod_restrict).",
     "openQuestions": [
-      "Fill the 1 remaining sorry (polar_integral_factorization) using Aristotle automated proof search — a standard Fubini application on the product measure",
-      "Generalize the separation lemma to polar integrals of arbitrary f(r)·g(θ) — a reusable Fubini instance on the polar domain"
+      "Generalize the separation lemma to polar integrals of arbitrary f(r)·g(θ) — a reusable Fubini instance on the polar domain",
+      "Connect to a formal statement that π = area of unit disk via this polar decomposition"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

PR #15218 eliminated the last sorry (`polar_integral_factorization`) using `Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst`, but did not update `meta.json`. This PR syncs the metadata.

## Evidence

**Lean file**: 0 sorries verified by `grep -n "sorry" proofs/Proofs/AreaOfCircleOQ05OQ01.lean` → no results. File header says "Sorry count: 0. All steps fully proved."

| field | before | after |
|---|---|---|
| `meta.sorries` | 1 | 0 |
| `meta.lineCount` | 183 | 231 |
| `leanFile.sorries` | 1 | 0 |
| `leanFile.lineCount` | 183 | 231 |
| `meta.status` | "formalized" | "verified" |
| `meta.badge` | "wip" | "verified" |
| `meta.assumptions` | "1 sorry: polar_integral_factorization..." | "None. All 10 theorems fully verified..." |
| `sec-factorization.summary` | "Currently sorry." | "Fully proved, 0 sorries." |
| `conclusion.summary` | references 1 sorry | updated to 0 sorries |

---
Automated fix by lean-mechanic agent.