### PR TITLE
audit: fix badge/metadata for fundamental-arithmetic-oq-01-oq-01 and erdos-1001-oq-02-oq-01

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14032,9 +14032,9 @@
     },
     "cevas-theorem-oq-01-oq-03": {
       "auditCount": 1,
-      "lastAudited": "2026-05-03T12:17:48Z",
-      "result": "clean",
-      "issues": []
+      "issues": [],
+      "lastAudited": "2026-05-03T12:00:00Z",
+      "result": "issues-fixed"
     },
     "pac-learning-bounds-oq-01-oq-01": {
       "auditCount": 1,
@@ -14048,11 +14048,21 @@
       "result": "clean",
       "issues": []
     },
-    "cevas-theorem-oq-01-oq-03": {
+    "fundamental-arithmetic-oq-01-oq-01": {
       "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-05-03T12:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T14:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "badge was original but existence direction uses Nat.factorization_prod_pow_eq_self (Mathlib); corrected to mathlib"
+      ]
+    },
+    "erdos-1001-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T14:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "lineCount was 248 (actual 313); leanFile section was missing \u2014 both corrected"
+      ]
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -63,9 +63,18 @@
       "improvement_factor_tends_to_zero: the factor 1/(logN)^(1/3) → 0",
       "erdos_1001_oq02_oq01_summary: existential witness for the sharper rate"
     ],
-    "lineCount": 248,
+    "lineCount": 313,
     "theoremCount": 7,
     "defCount": 3
+  },
+  "leanFile": {
+    "path": "Proofs/Erdos1001OQ02OQ01.lean",
+    "namespace": "Erdos1001OQ02OQ01",
+    "sorries": 4,
+    "axiomCount": 4,
+    "lineCount": 313,
+    "theoremCount": 6,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "**From Rate to Sharp Rate: Mertens (1874) vs. Walfisz (1963)**\n\nThe parent problem OQ-02 established the rate O(A log N / N) for convergence of the diophantine approximation density S(N,A,c) to f(A,c). This rate came from the elementary Mertens error bound: ∑_{n≤x} φ(n) = (3/π²)x² + O(x log x), which dates to 1874 and follows from partial summation with the trivial estimate ∑_{n≤x} μ(n)/n = O(1).\n\nIn 1963, Walfisz proved a substantially sharper error bound: ∑_{n≤x} φ(n) = (3/π²)x² + O(x (log x)^(2/3) (log log x)^(4/3)). This used Vinogradov's method of exponential sums applied to the zero-free region for ζ(s): ζ(σ+it) ≠ 0 for σ > 1 - c/(log t)^(2/3) (log log t)^(1/3). The same exponent 2/3 appears in both the zero-free region and the error bound — a deep connection between zeros of the Riemann zeta function and the distribution of arithmetic functions.\n\nFor the diophantine approximation problem, the Walfisz bound propagates via Abel summation to give a rate O(A (log N)^(2/3) (log log N)^(4/3) / N), which is strictly smaller order than the O(A log N / N) rate from OQ-02. This definitively answers the sharpness question: the OQ-02 rate was not optimal.",

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "unique-factorization",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
@@ -26,7 +26,7 @@
     "originalContributions": [
       "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
       "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",
-      "fundamental_theorem_of_arithmetic: ∃! f : ℕ →₀ ℕ with prime support and f.prod (·^·) = n",
+      "fundamental_theorem_of_arithmetic: ∃! f : ℕ →₀ ℕ with prime support and f.prod (·^·) = n (existence via Nat.factorization_prod_pow_eq_self; uniqueness via finsupp_prime_prod_factorization)",
       "factorization_determines_number: factorization injectivity — equal factorizations imply equal numbers",
       "factorization_eq_iff_valuations: m = n iff ∀ p, m.factorization p = n.factorization p",
       "factorization_eq_zero_iff_one: n.factorization = 0 iff n = 1",


### PR DESCRIPTION
## Summary

- **fundamental-arithmetic-oq-01-oq-01**: badge `original` → `mathlib` — the existence direction of the FTA (`fta_reconstruction`) is a direct one-line call to Mathlib's `Nat.factorization_prod_pow_eq_self`; the description already says "using Mathlib's Nat.factorization" but the badge claimed independent proof. Also clarify in `originalContributions` that existence is via Mathlib while uniqueness (`finsupp_prime_prod_factorization`) is independently proved.

- **erdos-1001-oq-02-oq-01**: correct stale `lineCount` 248→313 (file grew from 248 to 313 lines since meta was created); add missing `leanFile` section (all fields were `null`/missing). Key integrity fields (sorries=4, axiomCount=4, status=axiomatized, badge=axiom) were already correct.

## Evidence

```
# fundamental-arithmetic: existence direction is one-line Mathlib call
theorem fta_reconstruction (n : ℕ) (hn : n ≠ 0) :
    n.factorization.prod (· ^ ·) = n :=
  Nat.factorization_prod_pow_eq_self hn  -- ← pure Mathlib

# erdos-1001: actual line count
git show HEAD:proofs/Proofs/Erdos1001OQ02OQ01.lean | wc -l
# → 313 (meta claimed 248)
```

## Audit results

| Proof | sorries | axioms | lineCount | badge |
|-------|---------|--------|-----------|-------|
| fundamental-arithmetic-oq-01-oq-01 | 0 ✓ | 0 ✓ | 220 ✓ | mathlib (was: original) |
| erdos-1001-oq-02-oq-01 | 4 ✓ | 4 ✓ | 313 (was: 248) | axiom ✓ |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)