### PR TITLE
chore: record audit results for 2 proofs (2026-05-03 session)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -514,9 +514,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T13:06:30Z",
+      "lastAudited": "2026-05-03T13:39:59Z",
       "result": "issues-fixed"
     },
     "area-of-circle-oq-05-oq-02": {


### PR DESCRIPTION
## Audit Session 2026-05-03

Re-audited 2 proofs with open issues:

### konigsberg-oq-01-oq-02
- **Issue**: meta.json claims `sorries: 0` but Lean file (post-PR #15212) has 6 sorries; also `lineCount: 390` vs actual 848, `theoremCount: 8` vs actual 12
- **Action**: Re-confirmed issue; issue #15229 and tracker PR #15231 already in flight
- **Result**: `issues-found`

### area-of-circle-oq-05-oq-01
- **Issue**: meta.json claimed `sorries: 1` but actual Lean file had 0 sorries
- **Action**: Re-confirmed fix was in progress (PRs #15226, #15235); PR #15235 now merged
- **Result**: `issues-fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)