### PR TITLE
fix(inverse-galois-oq-01): correct stale open question — an_solvable_iff already proved

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11952,9 +11952,9 @@
       "result": "issues-fixed"
     },
     "inverse-galois-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T12:59:28Z",
+      "lastAudited": "2026-05-03T14:08:20Z",
       "result": "issues-fixed"
     },
     "inverse-galois-oq-02": {
@@ -13285,10 +13285,10 @@
       "result": "clean"
     },
     "sum-of-kth-powers-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T12:59:28Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T14:04:10Z",
+      "result": "clean"
     },
     "sylow-theorem": {
       "auditCount": 1,

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -182,7 +182,7 @@
       "Can $\\text{PSL}(2,7)$ (order 168, the second smallest non-abelian simple group) be formally realized as a Galois group over $\\mathbb{Q}$? The standard approach uses the polynomial $x^7 - 7x + 3$, which has Galois group $\\text{PSL}(2,7)$.",
       "Can the quotient realizability theorem be applied constructively to derive new Galois groups from S5? (S5/A5 = C2 is trivial; more interesting quotients require larger realized groups.)",
       "The Inverse Galois Conjecture is stated but marked `sorry` (intentionally — it is open). Can partial results (e.g., all alternating groups are realizable via Hilbert's irreducibility theorem) be formalized as intermediate steps?",
-      "Can the solvability characterization be generalized to alternating groups: $A_n$ solvable $\\Leftrightarrow$ $n \\leq 4$? The forward direction (simplicity of $A_n$ for $n \\geq 5$ implies non-solvability) follows from Mathlib."
+      "The $A_n$ solvability characterization ($A_n$ solvable $\\Leftrightarrow$ $n \\leq 4$) is now formalized in this file (`an_solvable_iff`, Part XII). Can the classification be extended to other group families — for example, generalized symmetric groups $G(m, p, n)$ (complex reflection groups) or wreath products $S_m \\wr S_n$? Are there analogues of the $n \\leq 4$ threshold for these families?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

- `conclusion.openQuestions[3]` asked whether $A_n$ solvable $\Leftrightarrow$ $n \leq 4$ could be formalized, but both `an_not_solvable_of_ge_five` and `an_solvable_iff` are **already sorry-free** in the Lean file (lines 461 and 475)
- Replaced with a genuinely open question about extending the solvability classification to complex reflection groups $G(m,p,n)$ and wreath products
- Updated audit tracker

Closes #15245

## Test plan
- [ ] `src/data/proofs/inverse-galois-oq-01/meta.json` `openQuestions[3]` no longer claims an already-proved theorem is open
- [ ] Verified against `git show origin/main:proofs/Proofs/InverseGaloisOQ01.lean` lines 461–481

🤖 Generated with [Claude Code](https://claude.com/claude-code)