### PR TITLE
research(erdos-1201): add Sylvester-Schur base cases via Bertrand postulate

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -317,6 +317,40 @@ theorem dvd_consecutiveProduct_term (n k i : ℕ) (hi : i ≤ k) :
   exact Finset.dvd_prod_of_mem _ (Finset.mem_range.mpr (by omega))
 
 /-
+## Sylvester-Schur: Prime Factor Exceeds Window Size
+-/
+
+/-- If a prime p lies inside the window [n, n+k] and n > k,
+    then gpfConsecutive n k > k (since p ≥ n > k is a prime factor of the product). -/
+theorem gpfConsecutive_gt_k_of_prime_in_window (n k : ℕ) (hkn : k < n)
+    (p : ℕ) (hp_prime : p.Prime) (hn_le : n ≤ p) (hp_le : p ≤ n + k) :
+    k < gpfConsecutive n k := by
+  have h_pos : 0 < consecutiveProduct n k := consecutiveProduct_pos n k (by omega)
+  have h_dvd : p ∣ consecutiveProduct n k := by
+    have h_offset : p - n ≤ k := by omega
+    have heq : n + (p - n) = p := by omega
+    exact heq ▸ dvd_consecutiveProduct_term n k (p - n) h_offset
+  have h_in : p ∈ (consecutiveProduct n k).primeFactors :=
+    Nat.mem_primeFactors.mpr ⟨hp_prime, h_dvd, h_pos.ne'⟩
+  exact Nat.lt_of_lt_of_le (by omega) (gpf_max _ p h_in)
+
+/-- **Sylvester-Schur (base case)**: For k ≥ 1, gpfConsecutive (k+1) k > k.
+    The Bertrand prime p ∈ (k, 2k] lies inside [k+1, 2k+1] = [n, n+k], giving a
+    prime factor p > k of the consecutive product n(n+1)···(2k+1). -/
+theorem gpfConsecutive_succ_gt_k (k : ℕ) (hk : 1 ≤ k) :
+    k < gpfConsecutive (k + 1) k := by
+  obtain ⟨p, hp_prime, hk_lt, hp_le⟩ := Nat.exists_prime_lt_and_le_two_mul k (by omega)
+  exact gpfConsecutive_gt_k_of_prime_in_window (k + 1) k (by omega) p hp_prime
+    (by omega) (by omega)
+
+/-- **Sylvester-Schur (diagonal)**: For n ≥ 2, gpfConsecutive n (n-1) > n-1.
+    The product n(n+1)···(2n-1) always has a prime factor exceeding n-1. -/
+theorem gpfConsecutive_gt_pred_self (n : ℕ) (hn : 2 ≤ n) :
+    n - 1 < gpfConsecutive n (n - 1) := by
+  have h := gpfConsecutive_succ_gt_k (n - 1) (by omega)
+  rwa [Nat.sub_add_cancel (by omega : 1 ≤ n)] at h
+
+/-
 ## Infinitely Many n with Large GPF
 -/
 

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -1017,3 +1017,39 @@ already proved in sessions 15-16.
 2. Alternative: submit b≥2 sorry to Aristotle (it is a HARD sorry for a known
    combinatorial result).
 3. Long-term: `jacobi_trudi_ssyt_eq` k ≥ 3 (RSK bijection, ~300 lines).
+
+---
+
+## Session 2026-05-03 (Session 18) — Bijection non-injectivity analysis
+
+**Mode**: REVISIT (RICH, score 95)
+**Outcome**: blocked — confirmed non-injectivity of "first violation" map for b ≥ 2
+
+### Key Finding: "First Violation" Map is Non-Injective
+
+Explicitly verified with M = {1,2,3,4}, a=2, b=2:
+- T={1,2} (Q={1,2}, P={3,4}): first violation c=0, move Q.sort[0]=1 → P'={1,3,4}, Q'={2}
+- T={2,3} (Q={2,3}, P={1,4}): first violation c=1, move Q.sort[1]=3 → P'={1,3,4}, Q'={2}
+
+Both map to the same (P',Q') = ({1,3,4}, {2}). The map is 2:1, not a bijection.
+
+This non-injectivity holds even within the same fiber (same total multiset M={1,2,3,4}).
+
+### Why Alternative Maps Also Fail
+
+- "Move Q.sort[0]" (minimum): T={1,3} and T={2,3} both map to Q'={3} split.
+- "Move Q.sort[b-1]" (maximum): T={1,2} and T={1,3} both map to Q'={1} split.
+
+The correct bijection requires a more subtle construction — likely the Bender-Knuth involution or the dual RSK bijection for 1-row tableaux.
+
+### Status
+
+The b ≥ 2 sorry is BLOCKED on constructing the correct bijection. The correct bijection likely exists (counts match: 4 bad (2,2) splits of M={1,2,3,4} = 4 all (3,1) splits) but requires non-obvious construction.
+
+Recommend: submit to Aristotle as a HARD sorry, or investigate Bender-Knuth/RSK literature for 1-row tableaux.
+
+### Next Steps
+
+1. Look up "Bender-Knuth involution for 2-row SSYT" — this likely gives the correct bijection.
+2. Alternative: try proof by induction where the inductive step reduces b≥2 to b=1.
+3. Alternative: find an algebraic proof (MvPolynomial evaluation argument).

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -29,12 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Survey of Wantzel-Galois characterization. Main gap: constructible number field definition not in Mathlib. Key lemma (divisors of 2^k are 2-powers) partially proved.",
+    "progressSummary": "PROGRESS: 3 more sorries proved (Eisenstein + degree). Main file now has 2 sorries: not_constructible_of_bad_degree (FTGT) and wantzel_galois_iff (Galois correspondence). PR #15175.",
     "builtItems": [
       "AngleTrisectionOQ02OQ01OQ02.lean: ~130 lines, 0 axioms, 2 sorries",
       "IsConstructibleFromQ: defined as finrank is power of 2",
       "two_group_gal_implies_degree_pow2: key lemma (partial)",
-      "galois_card_eq_finrank: from Mathlib"
+      "galois_card_eq_finrank: from Mathlib",
+      "cube_root_2_minpoly_irred proved in AngleTrisectionOQ02OQ01OQ02.lean: Eisenstein at p=2 over ℤ + IsPrimitive.Int.irreducible_iff_irreducible_map_cast to transfer to ℚ",
+      "cos20_minpoly_degree proved: deg(8x³-6x-1)=3 via norm_num",
+      "regular_7gon_impossible_degree proved: degree=3 inline + interval_cases"
     ],
     "insights": [
       "Main gap: IsConstructibleFromQ definition and equivalence with geometric construction",


### PR DESCRIPTION
## Summary

- Prove three new structural theorems for Erdős Problem #1201 (greatest prime factor of consecutive products)
- `gpfConsecutive_gt_k_of_prime_in_window`: if prime p lies in window [n, n+k] with k < n, then P(n,k) > k
- `gpfConsecutive_succ_gt_k`: Sylvester-Schur base case — P(k+1, k) > k for all k ≥ 1, via Bertrand prime in [k+1, 2k+1]
- `gpfConsecutive_gt_pred_self`: diagonal corollary — P(n, n-1) > n-1 for all n ≥ 2

Gallery updated: 24→27 theorems, 341→375 lines, new `sylvester-schur` and `infinite-large-gpf` sections in meta.json.

## Mathematical Content

The Sylvester-Schur theorem states that for any product of k+1 consecutive integers all > k, one factor must exceed k. The base case (starting at k+1) follows directly from Bertrand's postulate: the Bertrand prime p ∈ (k, 2k] falls inside the window [k+1, 2k+1], so p divides the consecutive product, giving P(k+1, k) ≥ p > k.

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1201Problem` (in progress)
- [ ] Verify 27 theorems, 0 sorries, 1 axiom (erdos_1201_half_case)
- [ ] Gallery meta counts match Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)