### PR TITLE
enrich: erdos-1054-oq-01-fnorm (14 annotations) + shannon-channel-coding-oq-02-oq-03 (7 annotations)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-scc-oq02oq03-header",
+    "proofId": "shannon-channel-coding-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "context",
+    "title": "Proof Architecture: Three-Step Information-Theoretic Argument",
+    "content": "The file header previews the complete logical chain: (1) H(W) = log M since the message W is uniform over M codewords; (2) I(W;Y^n) ≤ n·C by the MI chain rule for memoryless channels and the data processing inequality; (3) H(W|Ŵ) ≤ 1 + P_e·log M via Fano's inequality. Combining via the chain rule for mutual information: log M = H(W) = I(W;Y^n) + H(W|Y^n) ≤ n·C + 1 + P_e·log M. This derivation is axiomatized as a single Lean axiom; the file then proves the algebraic consequence P_e ≥ (R-C)/(2R) from pure real-number arithmetic.",
+    "mathContext": "$\\log M = H(W) = I(W; Y^n) + H(W \\mid Y^n) \\leq n C + 1 + P_e \\log M \\implies P_e \\geq \\frac{R-C}{2R}$",
+    "significance": "context",
+    "relatedConcepts": ["Fano's inequality", "data processing inequality", "mutual information chain rule", "channel capacity"],
+    "prerequisites": ["Shannon entropy", "mutual information", "discrete memoryless channels"]
+  },
+  {
+    "id": "ann-scc-oq02oq03-error-def",
+    "proofId": "shannon-channel-coding-oq-02-oq-03",
+    "range": { "startLine": 32, "endLine": 37 },
+    "type": "definition",
+    "title": "Average Error Probability of a Block Code",
+    "content": "The definition `codeErrorProb` computes the average (over messages) probability of a decoding error. For each message i, the inner sum computes the probability the channel output y^n is decoded correctly (decoder y = i), and `1 - ...` is the error probability for message i. Dividing by M gives the average. The formula uses the product channel distribution ∏ᵢ W(xᵢ, yᵢ) exploiting the memoryless channel assumption. Note this is a noncomputable definition since it involves Real summation over infinite types.",
+    "mathContext": "P_e = \\frac{1}{M} \\sum_{i=1}^{M} \\Pr[\\hat{W} \\neq i \\mid W = i] = \\frac{1}{M} \\sum_{i=1}^{M} \\left(1 - \\sum_{y^n} \\prod_{j=1}^{n} W(x_{ij}, y_j) \\cdot \\mathbf{1}[\\hat{W}(y^n) = i]\\right)",
+    "significance": "key",
+    "relatedConcepts": ["error probability", "block code", "noncomputable definition", "product distribution"],
+    "prerequisites": ["block codes in Lean", "DMChannel definition", "Fintype summation"]
+  },
+  {
+    "id": "ann-scc-oq02oq03-fano-axiom",
+    "proofId": "shannon-channel-coding-oq-02-oq-03",
+    "range": { "startLine": 39, "endLine": 56 },
+    "type": "technique",
+    "title": "The Fano-MI Converse Axiom: Why It's Axiomatized",
+    "content": "The single axiom `fano_mi_converse_bound` encodes three information-theoretic results in one statement. These require: (i) a formalized definition of Shannon entropy H over finitely-supported distributions, (ii) a proved Fano inequality relating H(W|Ŵ) to P_e and log M, and (iii) the memoryless channel mutual information chain rule I(W;Y^n) ≤ n·C. As of Lean's Mathlib, the Lean 4 information theory library (InformationTheory) exists but the full probabilistic infrastructure for this chain of inequalities is incomplete. Axiomatizing this bound is standard practice in formal information theory — the axiom's statement is mathematically precise and can be discharged when Mathlib's information theory library matures.",
+    "mathContext": "Axiom: $\\log M \\leq n C + 1 + P_e \\log M$. Proof sketch: $\\log M = H(W) = I(W; \\hat{W}) + H(W|\\hat{W}) \\leq I(W; Y^n) + H(W|\\hat{W}) \\leq nC + (1 + P_e \\log M)$.",
+    "significance": "key",
+    "relatedConcepts": ["Fano's inequality", "data processing inequality", "mutual information chain rule", "axiom in formal math"],
+    "prerequisites": ["Shannon entropy", "Fano's inequality derivation", "Lean 4 axiom keyword"]
+  },
+  {
+    "id": "ann-scc-oq02oq03-algebraic-converse",
+    "proofId": "shannon-channel-coding-oq-02-oq-03",
+    "range": { "startLine": 60, "endLine": 79 },
+    "type": "technique",
+    "title": "Algebraic Converse: From Fano-MI Bound to P_e Lower Bound",
+    "content": "The lemma `converse_from_combined_bound` is purely algebraic over ℝ with no information theory. From `log M ≤ n·C + 1 + P_e·log M` (the Fano-MI bound) and `n·R ≤ log M` (the rate condition), it derives P_e ≥ 1 − (n·C+1)/(n·R). The proof splits on whether P_e ≤ 1 (the substantive case) or P_e > 1 (trivially true since we'd need P_e < 0 to violate the bound). The main step: (1−P_e)·log M ≤ n·C+1, combined with log M ≥ n·R, gives (1−P_e)·n·R ≤ n·C+1. Dividing by n·R gives the bound. The `linarith` tactic handles the final linear arithmetic.",
+    "mathContext": "$(1 - P_e)\\log M \\leq nC + 1 \\text{ and } \\log M \\geq nR \\implies (1-P_e) \\cdot nR \\leq nC+1 \\implies P_e \\geq 1 - \\frac{nC+1}{nR}$",
+    "significance": "supporting",
+    "relatedConcepts": ["nlinarith", "linarith", "div_le_iff", "le_div_iff"],
+    "prerequisites": ["real number algebra", "Lean 4 field tactics", "by_cases on inequality"]
+  },
+  {
+    "id": "ann-scc-oq02oq03-threshold",
+    "proofId": "shannon-channel-coding-oq-02-oq-03",
+    "range": { "startLine": 81, "endLine": 104 },
+    "type": "insight",
+    "title": "Threshold Lemma: Block Length n ≥ 2/(R-C) Makes the Gap Appear",
+    "content": "The threshold lemma bridges the asymptotic bound P_e ≥ 1−(n·C+1)/(n·R) to the concrete gap δ = (R−C)/(2R). The key inequality to prove is (R−C)/(2R) ≤ 1 − (n·C+1)/(n·R), which after clearing denominators becomes: (R−C)·(n·R) + 2R·(n·C+1) ≤ 2R·(n·R). The algebraic core is `hkey: n·C·R + 2R ≤ n·R²`, which follows from `n·(R−C) ≥ 2` by multiplying both sides by R. The proof uses `div_add_div` to combine fractions, then `div_le_one` to reduce to a polynomial inequality handled by `linarith`.",
+    "mathContext": "For $n(R-C) \\geq 2$: $1 - \\frac{nC+1}{nR} = \\frac{nR - nC - 1}{nR} \\geq \\frac{nR - nC - n(R-C)/2}{nR} = \\frac{n(R-C)/2}{nR} = \\frac{R-C}{2R}$",
+    "significance": "key",
+    "relatedConcepts": ["div_add_div", "div_le_one", "ring tactic", "threshold conditions"],
+    "prerequisites": ["ordered field arithmetic", "Lean 4 ring/linarith tactics", "ceiling functions"]
+  },
+  {
+    "id": "ann-scc-oq02oq03-helpers",
+    "proofId": "shannon-channel-coding-oq-02-oq-03",
+    "range": { "startLine": 106, "endLine": 118 },
+    "type": "technique",
+    "title": "Gap Positivity and Rate Conversion Lemmas",
+    "content": "`converse_delta_pos` proves δ = (R−C)/(2R) > 0 when R > C via `div_pos`, using `sub_pos.mpr hRC` and `linarith` for 2R > 0. `rate_ge_implies_log` converts the rate condition `R ≤ rate_of_code hn code` (a ratio definition: log(M)/n) into the log form `n·R ≤ log M`. This uses `le_div_iff` with the positivity of n, plus `mul_comm` to match orientation. These two helper lemmas structure the main theorem proof cleanly: δ > 0 comes from `converse_delta_pos`, and the log-rate bound comes from `rate_ge_implies_log`.",
+    "mathContext": "$\\delta = \\frac{R-C}{2R} > 0 \\iff R > C$. Rate condition: $R \\leq \\frac{\\log M}{n} \\iff nR \\leq \\log M$.",
+    "significance": "technical",
+    "relatedConcepts": ["div_pos", "sub_pos", "le_div_iff", "rate_of_code"],
+    "prerequisites": ["BlockCode.rate definition", "Lean 4 div/mul lemmas"]
+  },
+  {
+    "id": "ann-scc-oq02oq03-main-theorem",
+    "proofId": "shannon-channel-coding-oq-02-oq-03",
+    "range": { "startLine": 121, "endLine": 163 },
+    "type": "insight",
+    "title": "Main Theorem: Explicit Threshold ⌈2/(R-C)⌉ with Quantitative Gap",
+    "content": "The main theorem `channel_coding_converse_asymptotic` has four stages in the Lean proof: (1) `converse_delta_pos` provides δ > 0; (2) `⌈2/(R-C)⌉₊` is the explicit natural number threshold using the positive ceiling function; (3) the threshold condition `N ≤ n` translates to `2 ≤ n·(R-C)` via `div_le_iff`; (4) the three helper lemmas chain together with `linarith` to complete the bound. The `set` tactic names C and δ for readability. The use of `⌈2/(R-C)⌉₊` (natural number ceiling) is important: it handles the case R−C = 0 safely (ceiling of infinity is 0 in ℕ) while giving the exact threshold when R > C.",
+    "mathContext": "Main result: $\\forall R > C,\\; \\exists N = \\lceil 2/(R-C) \\rceil,\\; \\forall n \\geq N,\\; \\forall \\text{code with rate} \\geq R:\\; P_e \\geq \\frac{R-C}{2R}$. As $n \\to \\infty$: $P_e \\geq 1 - C/R$ (strong converse).",
+    "significance": "key",
+    "relatedConcepts": ["Nat.ceil", "channel_coding_converse_asymptotic", "strong converse", "set tactic"],
+    "prerequisites": ["natural number ceiling in Lean", "linarith chains", "capacity_nonneg"]
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
@@ -51,7 +51,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The converse to the channel coding theorem is one of Shannon's fundamental results (1948): no communication system can reliably transmit information at rates exceeding channel capacity. While the achievability direction (constructing good codes below capacity) is often emphasized, the converse is equally important — it establishes capacity as the true fundamental limit.\n\nThe standard proof of the converse uses Fano's inequality, which bounds the conditional entropy H(W|Ŵ) in terms of the error probability P_e. Since H(W) = log M (uniform source) and I(W;Y^n) ≤ n·C (memoryless channel + data processing), we get: log M = I(W;Y^n) + H(W|Y^n) ≤ n·C + H(W|Ŵ) ≤ n·C + 1 + P_e·log M. Rearranging: P_e ≥ 1 - (n·C+1)/(n·R). For n large enough, this is bounded below by (R-C)/(2R).",
+    "historicalContext": "Claude Shannon's 1948 paper 'A Mathematical Theory of Communication' introduced both the channel coding theorem (achievability) and its converse in a single landmark paper. The converse — that no code can achieve reliable communication above capacity — is arguably the more fundamental result: it establishes capacity C as a hard upper limit, not merely an achievable benchmark. Shannon's original proof of the converse used a combinatorial counting argument; the modern form using Fano's inequality became standard through the work of Feinstein (1954) and Wolf/Fano in the 1950s.\n\nRobert Fano (1952) proved the inequality that bears his name: for any random variables W (input) and Ŵ (estimate), H(W|Ŵ) ≤ H_b(P_e) + P_e·log(M-1), where H_b is the binary entropy. Combined with Shannon's chain rule H(W) = I(W;Y^n) + H(W|Y^n), this yields a clean algebraic bound. The 'strong converse' — that P_e → 1 as n → ∞ for any rate R > C, not just P_e bounded away from 0 — was proved by Wolfowitz (1957) and requires a more refined argument. This formalization proves the weaker (but classical) asymptotic converse, with an explicit quantitative threshold N = ⌈2/(R-C)⌉.",
     "problemStatement": "**Channel Coding Converse (Asymptotic)**:\nFor any discrete memoryless channel with capacity $C$ and any rate $R > C$, there exists $\\delta > 0$ and $N \\in \\mathbb{N}$ such that for all $n \\geq N$, any block code of length $n$ with rate $\\geq R$ satisfies:\n$$P_e \\geq \\delta = \\frac{R-C}{2R} > 0$$\nSpecifically, $N = \\lceil 2/(R-C) \\rceil$ suffices.",
     "text": "Proves the asymptotic channel coding converse: error probability is bounded away from zero at rates above capacity.",
     "proofStrategy": "The proof has four stages:\n\n1. **Combined bound (axiom)**: fano_mi_converse_bound axiomatizes the three information-theoretic steps that together give log M ≤ n·C + 1 + P_e·log M. The three steps are: (i) H(W) = log M for uniform sources, (ii) I(W;Y^n) ≤ n·C by memoryless channel MI chain rule, (iii) H(W|Ŵ) ≤ 1 + P_e·log M by Fano's inequality with h(P_e) ≤ log 2 ≤ 1 nat.\n\n2. **Algebraic bound (converse_from_combined_bound)**: From log M ≤ n·C + 1 + P_e·log M and log M ≥ n·R, derive P_e ≥ 1 - (n·C+1)/(n·R). The main step is (1-P_e)·log M ≤ n·C+1, combined with log M ≥ n·R to get (1-P_e)·n·R ≤ n·C+1.\n\n3. **Threshold bound (threshold_bound)**: Show that for n ≥ 2/(R-C), we have (R-C)/(2R) ≤ 1 - (n·C+1)/(n·R). The key algebraic fact is n·(R-C) ≥ 2 implies n·R² ≥ n·C·R + 2R, which gives the bound after clearing denominators.\n\n4. **Main theorem**: Combine steps 2 and 3 to get P_e ≥ (R-C)/(2R) for all n ≥ ⌈2/(R-C)⌉.",
@@ -76,7 +76,8 @@
       "startLine": 33,
       "endLine": 37,
       "description": "Defines codeErrorProb: the average fraction of messages decoded incorrectly by a specific decoder.",
-      "summary": "Defines the average error probability of a block code with given encoder and decoder."
+      "summary": "Defines the average error probability of a block code with given encoder and decoder.",
+      "mathContext": "$P_e = \\frac{1}{M}\\sum_{i=1}^M \\Pr[\\hat{W} \\neq i \\mid W=i]$"
     },
     {
       "id": "fano-mi-axiom",
@@ -84,7 +85,8 @@
       "startLine": 51,
       "endLine": 56,
       "description": "Axiomatizes the three-step information-theoretic argument: H(W)=log M, I(W;Y^n)≤n·C, H(W|Ŵ)≤1+P_e·log M. Together these give log M ≤ n·C + 1 + P_e·log M.",
-      "summary": "Key axiom combining Fano inequality and memoryless channel MI bound."
+      "summary": "Key axiom combining Fano inequality and memoryless channel MI bound.",
+      "mathContext": "Axiom: $\\log M \\leq nC + 1 + P_e \\log M$"
     },
     {
       "id": "algebraic-converse",
@@ -92,7 +94,8 @@
       "startLine": 61,
       "endLine": 79,
       "description": "From the Fano-MI bound and the rate condition log M ≥ n·R, derives P_e ≥ 1 - (n·C+1)/(n·R) by algebraic manipulation.",
-      "summary": "Derives the P_e lower bound from the combined Fano-MI inequality."
+      "summary": "Derives the P_e lower bound from the combined Fano-MI inequality.",
+      "mathContext": "$\\log M \\geq nR,\\; \\log M \\leq nC+1+P_e\\log M \\implies P_e \\geq 1 - \\frac{nC+1}{nR}$"
     },
     {
       "id": "threshold-lemma",
@@ -100,7 +103,8 @@
       "startLine": 82,
       "endLine": 104,
       "description": "For n ≥ 2/(R-C), proves (R-C)/(2R) ≤ 1 - (n·C+1)/(n·R) by clearing denominators and using the key polynomial inequality n·R² ≥ n·C·R + 2R.",
-      "summary": "Shows the gap (R-C)/(2R) appears once n exceeds the threshold 2/(R-C)."
+      "summary": "Shows the gap (R-C)/(2R) appears once n exceeds the threshold 2/(R-C).",
+      "mathContext": "$n(R-C) \\geq 2 \\implies \\frac{R-C}{2R} \\leq 1 - \\frac{nC+1}{nR}$"
     },
     {
       "id": "delta-pos",
@@ -108,7 +112,8 @@
       "startLine": 107,
       "endLine": 109,
       "description": "The gap δ = (R-C)/(2R) is strictly positive when R > C.",
-      "summary": "δ > 0 whenever the rate exceeds capacity."
+      "summary": "δ > 0 whenever the rate exceeds capacity.",
+      "mathContext": "$\\delta = \\frac{R-C}{2R} > 0 \\iff R > C$"
     },
     {
       "id": "rate-log-lemma",
@@ -116,7 +121,8 @@
       "startLine": 112,
       "endLine": 118,
       "description": "Translates the rate condition R ≤ rate_of_code into the log form n·R ≤ log M needed for the main proof.",
-      "summary": "Converts rate ≥ R into the log M ≥ n·R inequality."
+      "summary": "Converts rate ≥ R into the log M ≥ n·R inequality.",
+      "mathContext": "$R \\leq \\frac{\\log M}{n} \\iff nR \\leq \\log M$"
     },
     {
       "id": "main-theorem",
@@ -124,7 +130,8 @@
       "startLine": 131,
       "endLine": 163,
       "description": "The main theorem: for R > C, the gap δ = (R-C)/(2R) is positive and any code with rate ≥ R and block length n ≥ ⌈2/(R-C)⌉ has error probability ≥ δ.",
-      "summary": "Main result: P_e ≥ (R-C)/(2R) for sufficiently long codes at rates above capacity."
+      "summary": "Main result: P_e ≥ (R-C)/(2R) for sufficiently long codes at rates above capacity.",
+      "mathContext": "$\\forall n \\geq \\lceil 2/(R-C) \\rceil,\\; \\text{rate} \\geq R \\implies P_e \\geq \\frac{R-C}{2R}$"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Two enrichment passes on 0-annotation proofs.

## erdos-1054-oq-01-fnorm — Erdős #1054 OQ-01: f(n) = o(n) via Sigma Bound

**annotations.json** was empty, now 14 annotations covering all 12 proof sections:
- Problem context with natural density formulation
- Core definitions (sortedDivisors, partialDivisorSums, IsRepresentable, computeF)
- Prime divisors theorem and prime subsequence chain (f(p+1) ≤ p)
- Computational evidence with note on non-tight prime bounds (f(12)=6, not 11)
- Density results and non-representable numbers conjecture {2, 5}
- Open question formal ε-δ-N encoding
- scanl infrastructure: getLast = total sum
- **Sigma bound** (core result): f(σ(m)) ≤ m with Gronwall's theorem connection
- Abundant/superabundant ratio examples (m ∈ {6,12,24,120})
- τ(m) distinct values per m and density argument
- Complete σ-image representability

**meta.json**: expanded historicalContext with Erdős–Alaoglu (1944), Gronwall (1913), Ramanujan (1915); added 5th keyInsight on tau(m) density.

---

## shannon-channel-coding-oq-02-oq-03 — Channel Coding Converse via Fano's Inequality

**annotations.json** was empty, now 7 annotations covering:
- Three-step information-theoretic chain (preview of the whole proof)
- `codeErrorProb` definition with product channel distribution
- `fano_mi_converse_bound` axiom with explanation of why it's axiomatized (Mathlib gaps)
- Algebraic converse lemma (pure real arithmetic, no information theory)
- Threshold lemma with key polynomial inequality n·C·R + 2R ≤ n·R²
- Gap positivity and rate-log helper lemmas
- Main theorem: explicit threshold ⌈2/(R-C)⌉ and `set` tactic structure

**meta.json**: expanded historicalContext with Shannon 1948, Fano 1952, Wolfowitz 1957 strong converse; added `mathContext` to all 7 sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)