### PR TITLE
fix(binary-gcd-oq-03-oq-02): add missing leanFile section and meta.theoremCount

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -23,6 +23,7 @@
     "axiomCount": 0,
     "lineCount": 1020,
     "dateAdded": "2026-05-03",
+    "theoremCount": 33,
     "assumptions": "",
     "mathlibDependencies": [
       {
@@ -154,6 +155,15 @@
       "tags": ["complexity", "bit-complexity", "fast-multiplication", "mathlib"]
     }
   ],
+  "leanFile": {
+    "namespace": "HGcd",
+    "lineCount": 1020,
+    "axiomCount": 0,
+    "theoremCount": 33,
+    "definitionCount": 6,
+    "path": "Proofs/BinaryGcdOQ03OQ02.lean",
+    "sorries": 1
+  },
   "conclusion": {
     "summary": "This formalization of Schönhage's recursive HGCD establishes the core correctness layer in 936 lines with a single sorry. The three main theorems — `cofactor_mul_apply` (compositional algebra), `hgcdMatrix_det_unit` (unimodularity by fuel induction), and `hgcdMatrix_preserves_gcd` (operational correctness) — formally verify that Schönhage's two-level recursion produces a GCD-preserving matrix. The size-reduction infrastructure (row-convention invariant, Cramer identity, entry bounds, perturbation decomposition) is complete except for the quotient stability lemma needed for the recursive size bound. Together with `BinaryGcdOQ03` (the Lehmer hybrid), this represents the first Lean formalization of the HGCD algorithm's correctness structure.",
     "implications": "Schönhage's HGCD is the inner loop of every modern number theory computation involving large integers: RSA key generation, elliptic curve scalar multiplication, polynomial GCD in computer algebra systems, and lattice basis reduction (LLL algorithm). Formalizing its correctness in Lean 4 provides a verified foundation for future cryptographic algorithm verification. The quotient stability sorry (≈200 lines remaining) is the only gap between this formalization and a complete proof of size reduction — once closed, the file would establish the full recursive structure needed to state the $O(M(n)\\log n)$ complexity claim. The GMP library's `mpn_hgcd` implements exactly this algorithm for production GCD computation; a Lean verification would enable formal auditing of such production code.",


### PR DESCRIPTION
## Fix

`binary-gcd-oq-03-oq-02` meta.json was missing its `leanFile` section entirely, and `meta.theoremCount` was null.

## Evidence

**Before**: no `leanFile` section, `meta.theoremCount: null`
**After**: `leanFile` section added with accurate counts; `meta.theoremCount: 33`

Actual counts verified against `origin/main:proofs/Proofs/BinaryGcdOQ03OQ02.lean`:
- 33 public theorems/lemmas
- 1 sorry (line 924, recursive case of hgcdMatrix_joint_bound)
- 0 axioms
- 1020 lines
- 6 definitions
- namespace: `HGcd`

---
Automated fix by lean-mechanic agent.