### PR TITLE
enrich(infinitude-primes-4k3-oq-03): fix annotation schema, add mathContext

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
@@ -1,30 +1,50 @@
 [
   {
     "id": "oq-answer",
+    "proofId": "infinitude-primes-4k3-oq-03",
     "range": { "startLine": 1, "endLine": 52 },
+    "type": "concept",
     "title": "Answering OQ-03: Elementary ≡ 1 (mod 4) Proof",
-    "body": "**Open question from infinitude-primes-4k3**: Can the Euclid-style argument for primes ≡ 3 (mod 4) be adapted to prove infinitely many primes ≡ 1 (mod 4)?\n\n**Answer: Yes**, but with a different construction. The ≡ 3 proof uses N = 4(n+1)! − 1 (which is ≡ 3 mod 4 and forces a prime factor ≡ 3 mod 4 by a product argument). For ≡ 1, we use N = (2(n+1)!)² + 1 — any odd prime p dividing this satisfies p² ≡ −1 (mod p), so −1 is a quadratic residue mod p, which by Euler's criterion forces p ≡ 1 (mod 4).\n\nThe ≡ 1 case requires deeper arithmetic: Euler's criterion, not just closure under multiplication.",
-    "type": "overview"
+    "content": "OQ-03 from infinitude-primes-4k3 asks whether the Euclid-style argument for ≡ 3 (mod 4) can be adapted to ≡ 1 (mod 4). The answer is yes, but the construction differs: instead of N = 4(n+1)! − 1, we use N = (2(n+1)!)² + 1. The ≡ 3 proof exploits that products of residues ≡ 1 (mod 4) stay ≡ 1, forcing a prime factor ≡ 3. For ≡ 1, the key is that any prime p dividing k² + 1 must have −1 as a quadratic residue mod p, which by Euler's criterion forces p ≡ 1 (mod 4). This difference (elementary product argument vs. quadratic residue theory) is what makes the ≡ 1 case slightly deeper.",
+    "mathContext": "For $N = (2(n+1)!)^2 + 1$: any odd prime $p \\mid N$ satisfies $(2(n+1)!)^2 \\equiv -1 \\pmod p$, so $\\left(\\frac{-1}{p}\\right) = 1$. Euler's criterion: $\\left(\\frac{-1}{p}\\right) = (-1)^{(p-1)/2}$, which equals 1 iff $p \\equiv 1 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's criterion", "quadratic residues", "Legendre symbol", "Euclid's proof of infinitely many primes"],
+    "prerequisites": ["modular arithmetic", "quadratic reciprocity basics", "Nat.Prime"]
   },
   {
     "id": "comparison-table",
-    "range": { "startLine": 32, "endLine": 44 },
-    "title": "The Two Constructions Compared",
-    "body": "The module comment shows both proofs side-by-side:\n\n| | Primes ≡ 3 (mod 4) | Primes ≡ 1 (mod 4) |\n|-|---------------------|---------------------|\n| Construction | 4(n+1)! − 1 | (2(n+1)!)² + 1 |\n| Key insight | Product of 1 mod 4 stays 1 mod 4 | Primes dividing k²+1 are ≡ 1 mod 4 |\n| Difficulty | Elementary multiplication | Euler's criterion |\n\nBoth constructions ensure the candidate N has a prime factor with the target residue AND is larger than n (because any factor ≤ n would divide (n+1)! and hence divide N ∓ 1 = ±1, contradiction).",
-    "type": "technique"
+    "proofId": "infinitude-primes-4k3-oq-03",
+    "range": { "startLine": 26, "endLine": 44 },
+    "type": "technique",
+    "title": "Two Parallel Constructions: ≡ 3 vs ≡ 1 (mod 4)",
+    "content": "The module comment compares both constructions side-by-side. For ≡ 3: N = 4(n+1)! − 1 is ≡ 3 (mod 4), and since a product of ≡ 1 numbers is ≡ 1, N must have a prime factor ≡ 3 (mod 4). For ≡ 1: N = (2(n+1)!)² + 1 has an odd prime factor p, and since p | k² + 1, we have −1 ≡ k² (mod p), so −1 is a QR mod p, forcing p ≡ 1 (mod 4). In both cases, the new prime p > n follows by the same argument: if p ≤ n, then p | (n+1)!, so p | N ∓ 1 = ±1, contradiction.",
+    "mathContext": "\\begin{array}{l|l|l} & p \\equiv 3 \\pmod 4 & p \\equiv 1 \\pmod 4 \\\\ \\hline N & 4(n+1)!-1 & (2(n+1)!)^2+1 \\\\ \\text{Key lemma} & \\prod_{p_i\\equiv 1} \\equiv 1 & (-1/p)=1 \\Rightarrow p\\equiv 1 \\\\ \\text{p > n} & p\\mid (n+1)! \\Rightarrow p\\mid 1 & \\text{same} \\end{array}",
+    "significance": "key",
+    "relatedConcepts": ["Euclid's argument", "Dirichlet's theorem", "arithmetic progressions", "product of residues"],
+    "prerequisites": ["mod 4 arithmetic", "Nat.dvd_factorial", "prime factorization"]
   },
   {
     "id": "main-theorem",
-    "range": { "startLine": 60, "endLine": 72 },
-    "title": "infinitely_many_primes_1_mod_4 — The OQ Answer",
-    "body": "```lean\ntheorem infinitely_many_primes_1_mod_4 :\n    ∀ n : ℕ, ∃ p : ℕ, Nat.Prime p ∧ p > n ∧ p % 4 = 1 :=\n  InfinitudePrimes4k1.infinitely_many_primes_1_mod_4\n```\n\nThis delegates directly to the proof in `InfinitudePrimes4k1.lean`. The proof is fully verified: 0 sorries, 0 axioms. The key steps are:\n1. Take N = (2·(n+1)!)² + 1\n2. N is odd and > 1, so has an odd prime factor p\n3. By `prime_dvd_sq_add_one_mod_four`: p ≡ 1 (mod 4)\n4. If p ≤ n then p | (n+1)!, so p | N − 1 = (2(n+1)!)², forcing p | 1 — contradiction\n\nThe `prime_dvd_sq_add_one_mod_four` lemma uses `Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one` from Mathlib's SumTwoSquares module, which encodes Euler's criterion.",
-    "type": "proof-step"
+    "proofId": "infinitude-primes-4k3-oq-03",
+    "range": { "startLine": 55, "endLine": 66 },
+    "type": "insight",
+    "title": "infinitely_many_primes_1_mod_4 — Delegation Pattern",
+    "content": "The main theorem is a one-line delegation to InfinitudePrimes4k1.infinitely_many_primes_1_mod_4. This is the correct design: the actual proof lives in InfinitudePrimes4k1.lean, which is imported here. The OQ-03 file serves as a wrapper that packages the result in the context of the parent proof's open question. The Lean proof term is simply an identifier — no tactics needed — making it maximally transparent. The InfinitudePrimes4k1 proof internally uses Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one from Mathlib's SumTwoSquares module to apply Euler's criterion.",
+    "mathContext": "\\forall n \\in \\mathbb{N},\\; \\exists p \\text{ prime},\\; p > n \\wedge p \\equiv 1 \\pmod 4. \\text{ Proof: take } N = (2(n+1)!)^2+1, \\text{ find odd prime } p \\mid N, \\text{ then } p \\equiv 1 \\pmod 4 \\text{ by Euler's criterion, and } p > n \\text{ by divisibility contradiction.}",
+    "significance": "key",
+    "relatedConcepts": ["Euler's criterion", "SumTwoSquares", "Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one", "proof delegation"],
+    "prerequisites": ["InfinitudePrimes4k1", "Mathlib.NumberTheory.SumTwoSquares"]
   },
   {
     "id": "classification-theorem",
-    "range": { "startLine": 74, "endLine": 100 },
-    "title": "Complete mod-4 Classification of Primes",
-    "body": "```lean\ntheorem both_classes_infinite :\n    Set.Infinite {p : ℕ | Nat.Prime p ∧ p % 4 = 1} ∧\n    Set.Infinite {p : ℕ | Nat.Prime p ∧ p % 4 = 3}\n\ntheorem odd_prime_mod_four_classification :\n    p % 4 = 1 ∨ p % 4 = 3  -- for any odd prime p\n```\n\n**The complete picture**: Every prime is either 2 (even) or odd. Every odd prime $p$ has $p \\bmod 4 \\in \\{0,1,2,3\\}$; since $p$ is odd, $p \\bmod 4 \\in \\{1,3\\}$. Both cases occur infinitely often.\n\nThis is the best possible elementary result for mod-4 residues: Dirichlet's theorem in full generality (for all moduli) requires analytic machinery, but the mod-4 case is completely accessible by elementary means.",
-    "type": "insight"
+    "proofId": "infinitude-primes-4k3-oq-03",
+    "range": { "startLine": 68, "endLine": 103 },
+    "type": "insight",
+    "title": "Complete mod-4 Classification: Both Classes Infinite",
+    "content": "Three theorems complete the mod-4 picture. both_classes_infinite packages the conjunction of InfinitudePrimes4k1.primes_1_mod_4_infinite and InfinitudePrimes4k3.primes_3_mod_4_infinite — both residue classes {p prime | p ≡ 1 mod 4} and {p prime | p ≡ 3 mod 4} are Set.Infinite. odd_prime_mod_four_classification delegates to prime_mod_four from InfinitudePrimes4k3: every odd prime satisfies p % 4 ∈ {1, 3} (since p odd means p % 2 = 1, hence p % 4 ∈ {1, 3}). constructions_cover_all_odd_primes wraps everything into a single statement matching each odd prime to a construction witnessing its class.",
+    "mathContext": "Every prime $p$ belongs to exactly one of: $\\{2\\}$, $\\{p: p\\equiv 1\\pmod 4\\}$, $\\{p: p\\equiv 3\\pmod 4\\}$. The first set has one element; the latter two are each countably infinite. Together: $\\{\\text{primes}\\} = \\{2\\} \\cup \\{p: 4\\mid p-1\\} \\cup \\{p: 4\\mid p-3\\}$ — a complete partition. This is the mod-4 special case of Dirichlet's theorem proved without L-functions.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet's theorem", "arithmetic progressions", "Set.Infinite", "modular arithmetic classification"],
+    "prerequisites": ["InfinitudePrimes4k3", "InfinitudePrimes4k1", "Set.Infinite API"]
   }
 ]

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -52,7 +52,8 @@
       "**Parallel structure**: The ≡ 1 and ≡ 3 proofs are exactly parallel: N = X² + 1 vs N = 4k! − 1, with different key lemmas about why prime factors have the target residue.",
       "**Euler's criterion is the key difference**: For ≡ 3, only basic product arithmetic is needed. For ≡ 1, we need the deeper fact that (−1|p) = 1 iff p ≡ 1 (mod 4) — this connects to the theory of quadratic residues.",
       "**Complete mod-4 classification**: Together the two results show every odd prime is ≡ 1 or ≡ 3 (mod 4), and both classes are infinite. This is a complete elementary classification.",
-      "**No Dirichlet L-functions needed**: The special cases a = 1, 3 mod 4 are the only arithmetic progressions {a + 4k} with gcd(a,4) = 1 that admit elementary proofs of infinitude."
+      "**No Dirichlet L-functions needed**: The special cases a = 1, 3 mod 4 are the only arithmetic progressions {a + 4k} with gcd(a,4) = 1 that admit elementary proofs of infinitude.",
+      "**Mathlib's SumTwoSquares is the bridge**: The Mathlib theorem Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one (from NumberTheory.SumTwoSquares) encodes Euler's criterion — it says a prime p with p ≡ 3 (mod 4) cannot divide a number of the form k² + 1. This is the machine-checked version of a classical result connecting quadratic residues to Fermat's theorem on sums of two squares (every prime p ≡ 1 mod 4 is a sum of two squares)."
     ],
     "prerequisites": [
       "Elementary modular arithmetic (residues mod 4)",


### PR DESCRIPTION
## Enrichment Pass: infinitude-primes-4k3-oq-03

Infinitely Many Primes ≡ 1 (mod 4) — Elementary Proof

### Changes

**annotations.json** — fixed schema (body→content) + added enrichment fields for all 4 annotations:
- oq-answer (lines 1–52): Overview with Euler's criterion mathContext
- comparison-table (lines 26–44): LaTeX comparison table of ≡1 vs ≡3 constructions
- main-theorem (lines 55–66): Delegation pattern + Mathlib SumTwoSquares context
- classification-theorem (lines 68–103): Complete mod-4 prime classification

Each annotation now has: `proofId`, `mathContext`, `significance`, `relatedConcepts`, `prerequisites`

**meta.json**:
- Added 5th keyInsight connecting SumTwoSquares to Fermat's theorem on sums of two squares

Note: Also included commit for erdos-1054-oq-01-fnorm enrichment (7 new annotations) — see earlier commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)