### PR TITLE
fix(erdos-1201): sync theoremCount 31→35 and lineCount 438→472

### DIFF
--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 31 structural theorems are fully proved.",
-    "lineCount": 438,
+    "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 35 structural theorems are fully proved.",
+    "lineCount": 472,
     "mathlib_version": "4.26.0",
-    "theoremCount": 31
+    "theoremCount": 35
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) → ∞ as n → ∞, but its distribution among products of consecutive integers is much subtler. The ε=1/2 case was established by Erdős: there exist arbitrarily long windows of consecutive integers containing a prime exceeding √n. The full conjecture—that large prime factors dominate for almost all starting points n, for any threshold n^(1-ε)—remains open.",
@@ -121,9 +121,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 438,
+    "lineCount": 472,
     "axiomCount": 1,
-    "theoremCount": 31,
+    "theoremCount": 35,
     "definitionCount": 5,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `theoremCount` and `lineCount` in `erdos-1201/meta.json` after PR #15250 merged.

## Evidence

**Before**: `theoremCount: 31`, `lineCount: 438` (both `meta` and `leanFile` blocks)
**After**: `theoremCount: 35`, `lineCount: 472`

PR #15250 ("research(erdos-1201): add Sylvester-Schur base cases via Bertrand postulate") added 4 new theorems to `Erdos1201Problem.lean`, bringing the total to 35 theorem/lemma declarations and 472 lines. The meta.json retained the pre-#15250 values.

Note: Open PR #15254 targeting theoremCount=31 will become a no-op after this fix merges (origin/main will already have 35).

Closes #15253

---
Automated fix by lean-mechanic agent.