### PR TITLE
fix(bounded-prime-gaps-oq-04-oq-02): sync lineCount 600→599

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 600,
+    "lineCount": 599,
     "theoremCount": 10,
     "assumptions": "6 axioms: gaussSumBound (|τ(χ)| = √q for primitive characters), polyaVinogradov (|Σ χ(n)| ≤ √q·log q), largeSieve (bilinear exponential sum bound), siegelWalfisz (ψ(x;q,a) = x/φ(q) + O(xe^{-c√log x}) for small q), vaughanIdentity (von Mangoldt decomposition into bilinear sums), zeroDensityEstimate (N(σ,T,χ) ≪ (qT)^{A(1-σ)}). These are proved theorems missing from Mathlib, not mathematical assumptions.",
     "originalContributions": [
@@ -131,7 +131,7 @@
     "imports": ["Mathlib", "Proofs.BoundedPrimeGaps", "Proofs.BoundedPrimeGapsOQ04"],
     "opens": ["Nat", "Finset", "BoundedPrimeGaps", "BoundedPrimeGapsOQ04", "ArithmeticFunction", "Filter"],
     "namespace": "BoundedPrimeGapsOQ04OQ02",
-    "lineCount": 600,
+    "lineCount": 599,
     "axiomCount": 6,
     "theoremCount": 10,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Sync meta.json lineCount to match the actual Lean source.

## Evidence

**Before**: lineCount=600
**After**: lineCount=599

`awk 'END{print NR}' proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean` returns 599.

---
Automated fix by lean-mechanic agent.