### PR TITLE
research(feuerbachs-theorem-oq-02): add 2 theorems, fix docstring error

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ02.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ02.lean
@@ -545,6 +545,18 @@ theorem centroid_on_euler_line (T : Tetrahedron) :
   simp only
   constructor <;> [skip; constructor] <;> ring
 
+/-- The twenty-four-point center N₂₄ equals 2G - O, the reflection of the circumcenter
+    through the centroid. Proof: N₂₄ = midpoint(O, M) = (O + 4G - 3O)/2 = 2G - O.
+    Note: for an orthocentric tetrahedron this equals the orthocenter H = 2G - O. -/
+theorem twentyFourPointCenter_is_2G_minus_O (T : Tetrahedron) :
+    T.twentyFourPointCenter =
+      (2 * T.centroid.1 - T.circumcenter.1,
+       2 * T.centroid.2.1 - T.circumcenter.2.1,
+       2 * T.centroid.2.2 - T.circumcenter.2.2) := by
+  unfold Tetrahedron.twentyFourPointCenter midpoint3 Tetrahedron.mongePoint
+  simp only
+  constructor <;> [skip; constructor] <;> ring
+
 -- ============================================================
 -- PART 12: Volume-Inradius Relation (Proved)
 -- ============================================================
@@ -582,20 +594,26 @@ axiom feuerbach_3d_fails_general :
   at distance `twentyFourPointRadius = R/3` from `twentyFourPointCenter`.
   This is **mathematically false**. Counterexample: the regular tetrahedron with
   vertices (1,1,1), (1,-1,-1), (-1,1,-1), (-1,-1,1) has R = √3, so R/3 ≈ 0.577,
-  but each edge midpoint is at distance 1 from the center.
+  but each edge midpoint is at distance 1 from N₂₄ = G = (0,0,0).
 
-  The correct result (proved below): edge midpoints are equidistant from the
-  **centroid** G, with common distance R/2. The center is G, not N₂₄, and the
-  radius is R/2, not R/3.
+  The correct result (proved below): for an orthocentric tetrahedron, all edge midpoints
+  are equidistant from the centroid G. The center is G, not N₂₄. The common squared
+  distance is (|AC|²+|BD|²)/16 for M_AB and M_CD, and (|AB|²+|CD|²)/16 for the other
+  four midpoints (proved in `edge_midpoints_dist_sq_formula`). These two values coincide
+  for orthocentric tetrahedra (since AD⊥BC implies |AB|²+|CD|²=|AC|²+|BD|²), confirming
+  equidistance. Note: the common distance equals R/2 only in special cases (e.g. T₀),
+  not for all orthocentric tetrahedra (the regular tetrahedron has common distance 1
+  while R/2 = √3/2 ≈ 0.866).
 -/
 
 /-- For an orthocentric tetrahedron, all six edge midpoints are equidistant
     from the centroid G. This is the correct 3D analogue of the side midpoints
-    lying on the nine-point circle. The common distance is R/2 (circumradius / 2).
+    lying on the nine-point circle. The exact squared distance is given by
+    `edge_midpoints_dist_sq_formula`.
 
     Proof: dist²(G, M_XY) = |(V₃ + V₄ - V₁ - V₂)|²/16 where {V₁,V₂} and {V₃,V₄}
-    partition the vertices. For an orthocentric tetrahedron, the three perpendicularity
-    conditions force all six such squared norms to be equal. -/
+    partition the vertices. The cross term (V₃-V₁)·(V₄-V₂) vanishes by the
+    orthocentric conditions, making all six such squared norms equal. -/
 theorem edge_midpoints_equidist_from_centroid (T : OrthocentricTetrahedron) :
     dist3_sq T.toTetrahedron.centroid T.toTetrahedron.midpoint_AB =
       dist3_sq T.toTetrahedron.centroid T.toTetrahedron.midpoint_CD ∧
@@ -613,6 +631,29 @@ theorem edge_midpoints_equidist_from_centroid (T : OrthocentricTetrahedron) :
     Tetrahedron.midpoint_AD Tetrahedron.midpoint_BC Tetrahedron.midpoint_BD
     Tetrahedron.midpoint_CD midpoint3 vec3 dot3 at *
   refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;> nlinarith
+
+/-- The exact squared distance from centroid G to each edge midpoint, for an orthocentric
+    tetrahedron. The formula dist²(G, M_AB) = (|AC|² + |BD|²)/16 follows from the
+    orthocentric condition AC⊥BD: writing G - M_AB = (C+D-A-B)/4 = (AC + BD)/4 as
+    vectors, squaring gives |AC|²/16 + 2·(AC·BD)/16 + |BD|²/16, and the cross term
+    vanishes by AC⊥BD. The same argument gives dist²(G, M_AC) = (|AB|²+|CD|²)/16
+    using AB⊥CD.
+
+    These two values coincide for orthocentric tetrahedra (the third condition AD⊥BC
+    forces |AC|²+|BD|² = |AB|²+|CD|²), confirming all six midpoints are equidistant
+    from G. -/
+theorem edge_midpoints_dist_sq_formula (T : OrthocentricTetrahedron) :
+    dist3_sq T.toTetrahedron.centroid T.toTetrahedron.midpoint_AB =
+      (dist3_sq T.toTetrahedron.A T.toTetrahedron.C +
+       dist3_sq T.toTetrahedron.B T.toTetrahedron.D) / 16 ∧
+    dist3_sq T.toTetrahedron.centroid T.toTetrahedron.midpoint_AC =
+      (dist3_sq T.toTetrahedron.A T.toTetrahedron.B +
+       dist3_sq T.toTetrahedron.C T.toTetrahedron.D) / 16 := by
+  have h1 := T.AB_perp_CD
+  have h2 := T.AC_perp_BD
+  unfold dist3_sq Tetrahedron.centroid Tetrahedron.midpoint_AB Tetrahedron.midpoint_AC
+    midpoint3 vec3 dot3 at *
+  refine ⟨?_, ?_⟩ <;> nlinarith
 
 /-
   NOTE: The original axiom `face_centroids_on_sphere` claimed that face centroids lie
@@ -635,31 +676,36 @@ theorem edge_midpoints_equidist_from_centroid (T : OrthocentricTetrahedron) :
 1. orthocentric_third_perp: Third perpendicularity from first two (algebraic identity)
 2. circumcenter_equidist: Circumcenter is equidistant from all four vertices
 3. monge_point_euler_line: Monge point formula M = 4G - 3O
-4. centroid_on_euler_line: Centroid divides O-M in ratio 3:1
-5. volume_eq_inradius_surfaceArea: V = rS/3
-6. edge_midpoints_equidist_from_centroid: All 6 edge midpoints are equidistant
+4. twentyFourPointCenter_midpoint: N₂₄ = midpoint(O, M) (by definition)
+5. twentyFourPointRadius_eq: radius = R/3 (by definition)
+6. centroid_on_euler_line: Centroid divides O-M in ratio 3:1
+7. twentyFourPointCenter_is_2G_minus_O: N₂₄ = 2G - O (algebraic; equals the
+   orthocenter for orthocentric tetrahedra)
+8. volume_eq_inradius_surfaceArea: V = rS/3
+9. edge_midpoints_equidist_from_centroid: All 6 edge midpoints are equidistant
    from the centroid G (requires orthocentric hypothesis)
+10. edge_midpoints_dist_sq_formula: dist²(G, M_AB) = (|AC|²+|BD|²)/16, and
+    dist²(G, M_AC) = (|AB|²+|CD|²)/16 (exact formula using orthocentric conditions)
 
 ### Sorries (0): all five tangency theorems were removed in 2026-05-02 after
 the symbolic counterexample at PART 10 closed the question of whether the
 (N₂₄, R/3)-sphere is tangent to the insphere/exspheres — it is not.
 
 ### Axioms (1):
-7. feuerbach_3d_fails_general: A non-orthocentric tetrahedron exists for
-   which the (N₂₄, R/3)-sphere fails to be internally tangent to the insphere.
-   (Existential claim. Note: per the PART 10 refutation, tangency also fails
-   for many *orthocentric* tetrahedra, so the orthocentric hypothesis does
-   not save the conjecture as stated either.)
+11. feuerbach_3d_fails_general: A non-orthocentric tetrahedron exists for
+    which the (N₂₄, R/3)-sphere fails to be internally tangent to the insphere.
+    (Existential claim. Note: per the PART 10 refutation, tangency also fails
+    for many *orthocentric* tetrahedra, so the orthocentric hypothesis does
+    not save the conjecture as stated either.)
 
 ### Corrections Applied (2026-04-27):
-- REMOVED `edge_midpoints_on_sphere` (axiom was FALSE: edge midpoints lie at
-  distance R/2 from centroid G, not R/3 from N₂₄)
+- REMOVED `edge_midpoints_on_sphere` (axiom was FALSE: edge midpoints do NOT
+  lie at distance R/3 from N₂₄; they ARE equidistant from centroid G)
 - REMOVED `face_centroids_on_sphere` (axiom was FALSE: face centroids are NOT
   equidistant from N₂₄ for non-regular orthocentric tetrahedra)
 - ADDED `edge_midpoints_equidist_from_centroid`: correct theorem using centroid G
 - FIXED docstring: Monge point M ≠ orthocenter H. Correct relation: H = 2G - O,
-  M = 4G - 3O, so H = midpoint(O, M) and N₂₄ = midpoint(O, M) = H.
-- For the midedge sphere: center = G, radius = R/2 (not N₂₄ and R/3)
+  M = 4G - 3O, so N₂₄ = midpoint(O, M) = H.
 
 ### Corrections Applied (2026-05-02):
 - REMOVED `feuerbach_3d_insphere`, `feuerbach_3d_exsphere_{A,B,C,D}`, and the
@@ -667,15 +713,24 @@ the symbolic counterexample at PART 10 closed the question of whether the
   sphere, as the explicit counterexample (2,0,0),(0,3,0),(0,0,6),(0,0,0) shows.
   Net delta: 5 sorries → 0 sorries.
 
+### Corrections Applied (2026-05-03):
+- ADDED `twentyFourPointCenter_is_2G_minus_O`: N₂₄ = 2G - O (proved from the
+  definition of N₂₄ as midpoint(O, M) and M = 4G - 3O)
+- ADDED `edge_midpoints_dist_sq_formula`: exact formula for squared edge-midpoint
+  distance from G. Fixes the previous (incorrect) claim that the common distance
+  is R/2 — the actual formula is (|AC|²+|BD|²)/16 for M_AB/M_CD, which equals
+  R²/4 only in special cases (e.g. T₀) but not in general (e.g. regular tetrahedron:
+  dist² = 1, R²/4 = 3/4 ≠ 1).
+
 ### Key Insights
 1. The 3D Feuerbach theorem requires the orthocentric hypothesis because
    altitudes of a general tetrahedron are NOT concurrent — but the
    orthocentric hypothesis alone is NOT sufficient with the N₂₄/R/3 sphere.
-2. The "twenty-four-point sphere" as defined here (center N₂₄, radius R/3)
-   does not correspond to the classical midedge sphere (center G, radius R/2),
-   and neither sphere is tangent to the insphere in general.
+2. The "twenty-four-point sphere" as defined here (center N₂₄ = 2G - O,
+   radius R/3) does not correspond to the midedge sphere (center G, radius
+   depending on edge lengths), and neither sphere is tangent to the insphere.
 3. The Euler line of a tetrahedron has O, G, H, M at parameter ratios 0:1:2:4,
-   different from the triangle case (0:1:2 for O, G, H).
+   different from the triangle case (0:1:2 for O, G, H). N₂₄ = H = 2G - O.
 4. Identifying the correct "Feuerbach sphere" for orthocentric tetrahedra
    remains open in this formalization (Murakami 1952 sketches one candidate
    built from face circumcircles).

--- a/research/problems/feuerbachs-theorem-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-02-incomplete-01/knowledge.md
@@ -325,3 +325,86 @@ vs (R/2 − r)² ≈ 1.286).
    T.toTetrahedron.twentyFourPointCenter T.toTetrahedron.incenter
    T.toTetrahedron.twentyFourPointRadius T.toTetrahedron.inradius`.
    Same √14 obstacle.
+
+---
+
+## Session 2026-05-03 (Session 4) — Formula Correction + Two New Theorems
+
+**Mode**: REVISIT (ACT phase, RICH knowledge tier)
+**Outcome**: Added 2 provable theorems, corrected 1 false docstring claim.
+
+### Mathematical Finding: R/2 Claim Is False
+
+The previous docstring for `edge_midpoints_equidist_from_centroid` claimed the
+common distance from G to edge midpoints is R/2. This is FALSE for the regular
+tetrahedron A=(1,1,1), B=(1,-1,-1), C=(-1,1,-1), D=(-1,-1,1):
+
+- G = O = (0,0,0), R = √3, R/2 = √3/2 ≈ 0.866
+- midpoint_AB = (1,0,0), dist(G, midpoint_AB) = 1 ≠ √3/2
+
+The CORRECT formula: dist²(G, M_AB) = (|AC|²+|BD|²)/16.
+
+Proof: G - M_AB = (C+D-A-B)/4 = ((C-A)+(D-B))/4. Squaring:
+|(C-A)+(D-B)|² = |C-A|² + 2(C-A)·(D-B) + |D-B|²
+= |AC|² + 0 + |BD|² (by AC⊥BD condition).
+
+For T₀: (|AC|²+|BD|²)/16 = 49/16 = R²/4 ✓ (R = 7/2)
+For regular: (8+8)/16 = 1 ≠ R²/4 = 3/4 ✗
+
+The R/2 formula holds for T₀ but NOT in general. The docstring is now corrected.
+
+### New Theorem: twentyFourPointCenter_is_2G_minus_O
+
+N₂₄ = 2G - O (proved by ring from definitions).
+
+Algebraically: N₂₄ = midpoint(O, 4G-3O) = (O+4G-3O)/2 = 2G-O.
+
+Consequence: for an orthocentric tetrahedron, the orthocenter H = 2G-O coincides
+with N₂₄. So `twentyFourPointCenter_is_2G_minus_O` confirms N₂₄ = H for
+orthocentric tetrahedra.
+
+### New Theorem: edge_midpoints_dist_sq_formula
+
+dist²(G, M_AB) = (|AC|² + |BD|²)/16 (using AC⊥BD)
+dist²(G, M_AC) = (|AB|² + |CD|²)/16 (using AB⊥CD)
+
+Proved by nlinarith using the orthocentric perpendicularity hypotheses.
+
+### Files Modified
+
+- `proofs/Proofs/FeuerbachsTheoremOQ02.lean`:
+  - Added `twentyFourPointCenter_is_2G_minus_O` theorem (lines ~548-558)
+  - Added `edge_midpoints_dist_sq_formula` theorem (lines ~645-656)
+  - Fixed PART 14 block comment (removed false R/2 claim)
+  - Fixed `edge_midpoints_equidist_from_centroid` docstring (corrected R/2 reference)
+  - Updated PART 15 summary (10 theorems listed, corrections noted)
+  - Line count: 688 → 743
+
+### Sorry / Axiom Delta
+
+- Sorries: 0 → 0 (no change)
+- Axioms: 1 → 1 (no change)
+- Theorems: 8 → 10 (+2)
+
+### Honest Assessment
+
+The two new theorems are algebraic/coordinatewise facts, provable by ring and
+nlinarith. They add genuine mathematical content:
+1. `twentyFourPointCenter_is_2G_minus_O` crystallizes the geometric identity.
+2. `edge_midpoints_dist_sq_formula` provides the exact value (not just equidistance),
+   and corrects an error in the prior docstring.
+
+The session does NOT close the remaining axiom `feuerbach_3d_fails_general`. That
+axiom requires exhibiting a concrete non-orthocentric tetrahedron, computing face
+areas (which involve sqrt), and showing the tangency condition fails. The sqrt in
+face areas makes this very hard to formalize without specialized algebraic-number
+arithmetic tactics.
+
+### Next Steps
+
+1. **feuerbach_3d_fails_general**: Still an axiom. Possible approach: find a
+   non-orthocentric tetrahedron where all face areas are rational (Pythagorean
+   condition: a²b²+b²c²+a²c² is a perfect square for the face BCD). This is
+   a number-theoretic search problem.
+2. **Murakami sphere**: Survey the face-circumcircle-based construction and
+   add it to the file's infrastructure.

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "feuerbachs-theorem-oq-02",
   "title": "3D Analogue of Feuerbach's Theorem for Tetrahedra",
   "slug": "feuerbachs-theorem-oq-02",
-  "description": "Investigates the 3D analogue of Feuerbach's theorem for tetrahedra. The natural candidate sphere (center N₂₄ = midpoint(O, M), radius R/3) is REFUTED for orthocentric tetrahedra by an explicit closed-form counterexample; the correct analogue (Murakami 1952, Court 1934) remains an open formalization target.",
+  "description": "Investigates the 3D analogue of Feuerbach's theorem for tetrahedra. The natural candidate sphere (center N\u2082\u2084 = midpoint(O, M), radius R/3) is REFUTED for orthocentric tetrahedra by an explicit closed-form counterexample; the correct analogue (Murakami 1952, Court 1934) remains an open formalization target.",
   "meta": {
     "author": "Murakami (1952), Court (1934)",
     "date": "2026-03-30",
@@ -30,28 +30,28 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
     "lineCount": 688,
-    "assumptions": "1 axiom: feuerbach_3d_fails_general (existence of a non-orthocentric tetrahedron for which the (N₂₄, R/3)-sphere is not tangent to the insphere). Note: per the 2026-05-02 refutation, tangency also fails for many orthocentric tetrahedra, so the orthocentric hypothesis does not save the conjecture as originally stated. Two former axioms REMOVED as mathematically false (edge_midpoints_on_sphere, face_centroids_on_sphere). Five tangency theorems (feuerbach_3d_insphere, feuerbach_3d_exsphere_{A,B,C,D}) and the bundled feuerbach_3d_theorem REMOVED on 2026-05-02 after a closed-form counterexample at T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) showed dist(N₂₄, I)² = 3r² ≠ (R/3 − r)². Net delta: 5 sorries → 0.",
+    "assumptions": "1 axiom: feuerbach_3d_fails_general (existence of a non-orthocentric tetrahedron for which the (N\u2082\u2084, R/3)-sphere is not tangent to the insphere). Note: per the 2026-05-02 refutation, tangency also fails for many orthocentric tetrahedra, so the orthocentric hypothesis does not save the conjecture as originally stated. Two former axioms REMOVED as mathematically false (edge_midpoints_on_sphere, face_centroids_on_sphere). Five tangency theorems (feuerbach_3d_insphere, feuerbach_3d_exsphere_{A,B,C,D}) and the bundled feuerbach_3d_theorem REMOVED on 2026-05-02 after a closed-form counterexample at T\u2080 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) showed dist(N\u2082\u2084, I)\u00b2 = 3r\u00b2 \u2260 (R/3 \u2212 r)\u00b2. Net delta: 5 sorries \u2192 0.",
     "originalContributions": [
       "Complete 3D coordinate geometry infrastructure for tetrahedra in Lean 4",
       "Formalization of orthocentric tetrahedra with proof that third perpendicularity follows from first two",
       "Definitions of the twenty-four-point sphere (center, radius) preserved for downstream work, with documentation that they are NOT the correct Feuerbach sphere",
-      "Closed-form refutation of the candidate '3D Feuerbach theorem' (the (N₂₄, R/3)-sphere is not tangent to the insphere of every orthocentric tetrahedron); explicit symbolic counterexample at T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0))",
+      "Closed-form refutation of the candidate '3D Feuerbach theorem' (the (N\u2082\u2084, R/3)-sphere is not tangent to the insphere of every orthocentric tetrahedron); explicit symbolic counterexample at T\u2080 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0))",
       "Proof of the 3D Euler line relation: centroid divides circumcenter-Monge point segment in ratio 3:1",
-      "Proof that the six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid (the midedge-sphere result; also shown not to be Feuerbach-tangent at T₀)"
+      "Proof that the six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid (the midedge-sphere result; also shown not to be Feuerbach-tangent at T\u2080)"
     ],
     "theoremCount": 15
   },
   "overview": {
-    "historicalContext": "Feuerbach's theorem (1822) that the nine-point circle is tangent to the incircle and all three excircles is considered one of the most beautiful results in classical triangle geometry. The natural question of its 3D analogue was studied by Court (1934) and Murakami (1952): for orthocentric tetrahedra, a sphere related to the circumcenter and Monge point should play the role of the nine-point circle. This formalization began with the candidate `(N₂₄, R/3)`-sphere (center = midpoint of circumcenter and Monge point, radius R/3 vs R/2 for the nine-point circle). Numerical experiments (sessions 1–2, April 2026) flagged the candidate as suspect; on 2026-05-02 a closed-form symbolic computation at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) refuted the candidate outright, and the previously sorry-stated tangency theorems were removed. Identifying and formalizing the correct 3D Feuerbach sphere — Murakami's construction uses face circumcircles — remains open.",
+    "historicalContext": "Feuerbach's theorem (1822) that the nine-point circle is tangent to the incircle and all three excircles is considered one of the most beautiful results in classical triangle geometry. The natural question of its 3D analogue was studied by Court (1934) and Murakami (1952): for orthocentric tetrahedra, a sphere related to the circumcenter and Monge point should play the role of the nine-point circle. This formalization began with the candidate `(N\u2082\u2084, R/3)`-sphere (center = midpoint of circumcenter and Monge point, radius R/3 vs R/2 for the nine-point circle). Numerical experiments (sessions 1\u20132, April 2026) flagged the candidate as suspect; on 2026-05-02 a closed-form symbolic computation at the orthocentric tetrahedron T\u2080 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) refuted the candidate outright, and the previously sorry-stated tangency theorems were removed. Identifying and formalizing the correct 3D Feuerbach sphere \u2014 Murakami's construction uses face circumcircles \u2014 remains open.",
     "problemStatement": "What is the 3D analogue of Feuerbach's theorem for tetrahedra? Specifically: is there a natural sphere that is tangent to the insphere and all exspheres of a tetrahedron?",
-    "text": "Working hypothesis investigated: for an orthocentric tetrahedron, the (N₂₄, R/3)-sphere is internally tangent to the insphere and externally tangent to all four exspheres. This formalization REFUTES that hypothesis at T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) and therefore states no positive 3D Feuerbach theorem.",
-    "proofStrategy": "Coordinate geometry in R^3. Build the tetrahedron / orthocentric / circumcenter / Monge point / insphere / exsphere infrastructure (done). Use that infrastructure to (a) prove the surviving structural results (Euler line, edge-midpoint equidistance, V = rS/3) and (b) refute the (N₂₄, R/3)-Feuerbach candidate by closed-form computation at an explicit orthocentric tetrahedron. The correct 3D analogue (Murakami's face-circumcircle sphere, or a still-to-be-determined alternative) is not formalized here.",
+    "text": "Working hypothesis investigated: for an orthocentric tetrahedron, the (N\u2082\u2084, R/3)-sphere is internally tangent to the insphere and externally tangent to all four exspheres. This formalization REFUTES that hypothesis at T\u2080 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) and therefore states no positive 3D Feuerbach theorem.",
+    "proofStrategy": "Coordinate geometry in R^3. Build the tetrahedron / orthocentric / circumcenter / Monge point / insphere / exsphere infrastructure (done). Use that infrastructure to (a) prove the surviving structural results (Euler line, edge-midpoint equidistance, V = rS/3) and (b) refute the (N\u2082\u2084, R/3)-Feuerbach candidate by closed-form computation at an explicit orthocentric tetrahedron. The correct 3D analogue (Murakami's face-circumcircle sphere, or a still-to-be-determined alternative) is not formalized here.",
     "keyInsights": [
-      "The (N₂₄, R/3)-sphere is NOT the 3D Feuerbach sphere: at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) one has dist(N₂₄, I)² = 3r² but (R/3 − r)² = (7/6 − r)², which are unequal in closed form",
-      "The orthocentric hypothesis alone does NOT salvage the candidate sphere: T₀ is orthocentric and the tangency still fails",
-      "The midedge sphere (through 6 edge midpoints) has center G and radius R/2, and is also NOT in general tangent to the insphere (verified at T₀)",
+      "The (N\u2082\u2084, R/3)-sphere is NOT the 3D Feuerbach sphere: at the orthocentric tetrahedron T\u2080 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) one has dist(N\u2082\u2084, I)\u00b2 = 3r\u00b2 but (R/3 \u2212 r)\u00b2 = (7/6 \u2212 r)\u00b2, which are unequal in closed form",
+      "The orthocentric hypothesis alone does NOT salvage the candidate sphere: T\u2080 is orthocentric and the tangency still fails",
+      "The midedge sphere (through 6 edge midpoints) has center G and radius R/2, and is also NOT in general tangent to the insphere (verified at T\u2080)",
       "The Monge point M = 4G - 3O does NOT coincide with the orthocenter H = 2G - O; H = midpoint(O, M)",
-      "Only 2 of the 3 orthogonality conditions need be imposed — the third follows algebraically (proved as `orthocentric_third_perp`)",
+      "Only 2 of the 3 orthogonality conditions need be imposed \u2014 the third follows algebraically (proved as `orthocentric_third_perp`)",
       "The Euler line of a tetrahedron places O, G, H, M at parameter ratios 0:1:2:4",
       "Face centroids are NOT equidistant from any single center (unlike edge midpoints)"
     ],
@@ -77,7 +77,7 @@
       "startLine": 92,
       "endLine": 120,
       "summary": "Non-degenerate tetrahedron with four vertices and positive volume condition via scalar triple product.",
-      "mathContext": "The non-degeneracy condition uses det(B-A, C-A, D-A) ≠ 0, ensuring the four vertices are non-coplanar."
+      "mathContext": "The non-degeneracy condition uses det(B-A, C-A, D-A) \u2260 0, ensuring the four vertices are non-coplanar."
     },
     {
       "id": "orthocentric",
@@ -85,7 +85,7 @@
       "startLine": 148,
       "endLine": 176,
       "summary": "Definition of orthocentric tetrahedra and proof that the third perpendicularity condition follows from the first two.",
-      "mathContext": "An orthocentric tetrahedron has AB ⊥ CD and AC ⊥ BD. We prove AD ⊥ BC follows by algebraic manipulation of the dot product. This is the key structural condition for the 3D Feuerbach theorem."
+      "mathContext": "An orthocentric tetrahedron has AB \u22a5 CD and AC \u22a5 BD. We prove AD \u22a5 BC follows by algebraic manipulation of the dot product. This is the key structural condition for the 3D Feuerbach theorem."
     },
     {
       "id": "special-points",
@@ -101,7 +101,7 @@
       "startLine": 240,
       "endLine": 305,
       "summary": "Definitions of incenter, inradius, four excenters, and four exradii using face-area-weighted coordinates.",
-      "mathContext": "The incenter is the face-area-weighted average of vertices: I = (S_A·A + S_B·B + S_C·C + S_D·D) / S. The inradius is r = 3V/S. Excenters use negative weights."
+      "mathContext": "The incenter is the face-area-weighted average of vertices: I = (S_A\u00b7A + S_B\u00b7B + S_C\u00b7C + S_D\u00b7D) / S. The inradius is r = 3V/S. Excenters use negative weights."
     },
     {
       "id": "twenty-four-point-sphere",
@@ -113,11 +113,11 @@
     },
     {
       "id": "feuerbach-3d-refutation",
-      "title": "Refutation of the (N₂₄, R/3)-Sphere Candidate",
+      "title": "Refutation of the (N\u2082\u2084, R/3)-Sphere Candidate",
       "startLine": 459,
       "endLine": 521,
-      "summary": "Closed-form symbolic counterexample showing that for the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)), the (N₂₄, R/3)-sphere is NOT internally tangent to the insphere; the previously sorry-stated tangency theorems have been removed.",
-      "mathContext": "At T₀: O = (1, 3/2, 3), R = 7/2, N₂₄ = (0, 0, 0), face areas (S_A, S_B, S_C, S_D) = (9, 6, 3, 3√14), V = 6, r = 6/(6 + √14), I = (r, r, r). Hence dist(N₂₄, I) = r√3 and |R/3 − r| = 7/6 − r, which differ in closed form (squaring: 3r² ≠ (7/6 − r)²). The same tetrahedron also refutes the midedge-sphere variant (center G, radius R/2)."
+      "summary": "Closed-form symbolic counterexample showing that for the orthocentric tetrahedron T\u2080 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)), the (N\u2082\u2084, R/3)-sphere is NOT internally tangent to the insphere; the previously sorry-stated tangency theorems have been removed.",
+      "mathContext": "At T\u2080: O = (1, 3/2, 3), R = 7/2, N\u2082\u2084 = (0, 0, 0), face areas (S_A, S_B, S_C, S_D) = (9, 6, 3, 3\u221a14), V = 6, r = 6/(6 + \u221a14), I = (r, r, r). Hence dist(N\u2082\u2084, I) = r\u221a3 and |R/3 \u2212 r| = 7/6 \u2212 r, which differ in closed form (squaring: 3r\u00b2 \u2260 (7/6 \u2212 r)\u00b2). The same tetrahedron also refutes the midedge-sphere variant (center G, radius R/2)."
     }
   ],
   "crossReferences": [
@@ -143,8 +143,8 @@
     }
   ],
   "conclusion": {
-    "summary": "The natural candidate '3D Feuerbach theorem' — the (N₂₄, R/3)-sphere is tangent to the insphere/exspheres of every orthocentric tetrahedron — is FALSE with the standard definitions, refuted in closed form at the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)). The orthocentric hypothesis does not save the candidate. What survives is the coordinate-geometry infrastructure plus several structural results (Euler line, edge-midpoint equidistance, V = rS/3, etc.).",
-    "implications": "The 2D-to-3D generalization is more subtle than the surface analogy suggests: neither (N₂₄, R/3) nor (G, R/2) is tangent to the insphere, even on the orthocentric class. A correct 3D Feuerbach sphere — Murakami's face-circumcircle construction is one candidate, Court's isodynamic version another — must be identified and formalized separately. The closed-form refutation also illustrates the value of returning to candidate theorems with symbolic, rather than purely numerical, scrutiny.",
+    "summary": "The natural candidate '3D Feuerbach theorem' \u2014 the (N\u2082\u2084, R/3)-sphere is tangent to the insphere/exspheres of every orthocentric tetrahedron \u2014 is FALSE with the standard definitions, refuted in closed form at the orthocentric tetrahedron T\u2080 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)). The orthocentric hypothesis does not save the candidate. What survives is the coordinate-geometry infrastructure plus several structural results (Euler line, edge-midpoint equidistance, V = rS/3, etc.).",
+    "implications": "The 2D-to-3D generalization is more subtle than the surface analogy suggests: neither (N\u2082\u2084, R/3) nor (G, R/2) is tangent to the insphere, even on the orthocentric class. A correct 3D Feuerbach sphere \u2014 Murakami's face-circumcircle construction is one candidate, Court's isodynamic version another \u2014 must be identified and formalized separately. The closed-form refutation also illustrates the value of returning to candidate theorems with symbolic, rather than purely numerical, scrutiny.",
     "openQuestions": [
       "Identify the correct 3D Feuerbach sphere (e.g. via Murakami's face circumcircles) and formalize the corresponding tangency result for orthocentric tetrahedra.",
       "Determine whether any natural sphere is tangent to BOTH the insphere and all four exspheres for general orthocentric tetrahedra, or whether the joint tangency fails inherently.",
@@ -162,10 +162,10 @@
       "Real"
     ],
     "namespace": "FeuerbachsTheoremOQ02",
-    "lineCount": 688,
+    "lineCount": 743,
     "axiomCount": 1,
-    "theoremCount": 15,
-    "substantiveTheoremCount": 6,
+    "theoremCount": 17,
+    "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 48,
     "path": "Proofs/FeuerbachsTheoremOQ02.lean",
@@ -175,38 +175,38 @@
     {
       "name": "orthocentric_third_perp",
       "type": "core",
-      "description": "Third orthogonality condition (AD ⊥ BC) follows algebraically from the first two (AB ⊥ CD ∧ AC ⊥ BD), proved by nlinarith",
-      "leanType": "(T : OrthocentricTetrahedron) → dot3 (vec3 T.A T.D) (vec3 T.B T.C) = 0"
+      "description": "Third orthogonality condition (AD \u22a5 BC) follows algebraically from the first two (AB \u22a5 CD \u2227 AC \u22a5 BD), proved by nlinarith",
+      "leanType": "(T : OrthocentricTetrahedron) \u2192 dot3 (vec3 T.A T.D) (vec3 T.B T.C) = 0"
     },
     {
       "name": "edge_midpoints_equidist_from_centroid",
       "type": "core",
       "description": "All six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid G (the midedge-sphere result, with center G and radius R/2)",
-      "leanType": "(T : OrthocentricTetrahedron) → dist3_sq G M_AB = dist3_sq G M_CD ∧ … (5 conjuncts)"
+      "leanType": "(T : OrthocentricTetrahedron) \u2192 dist3_sq G M_AB = dist3_sq G M_CD \u2227 \u2026 (5 conjuncts)"
     },
     {
       "name": "centroid_on_euler_line",
       "type": "core",
-      "description": "3D Euler line: the centroid divides the circumcenter–Monge point segment in ratio 3:1, i.e. G = (3O + M)/4",
-      "leanType": "(T : Tetrahedron) → T.centroid = ((3 * O + M) / 4)"
+      "description": "3D Euler line: the centroid divides the circumcenter\u2013Monge point segment in ratio 3:1, i.e. G = (3O + M)/4",
+      "leanType": "(T : Tetrahedron) \u2192 T.centroid = ((3 * O + M) / 4)"
     },
     {
       "name": "Tetrahedron.circumcenter_equidist",
       "type": "core",
       "description": "The Cramer-rule circumcenter is equidistant from all four vertices",
-      "leanType": "(T : Tetrahedron) → dist3_sq T.circumcenter T.A = dist3_sq T.circumcenter T.B ∧ … "
+      "leanType": "(T : Tetrahedron) \u2192 dist3_sq T.circumcenter T.A = dist3_sq T.circumcenter T.B \u2227 \u2026 "
     },
     {
       "name": "monge_point_euler_line",
       "type": "supporting",
-      "description": "Monge point formula M = 4G − 3O (definition-level identity, holds by rfl)",
-      "leanType": "(T : Tetrahedron) → T.mongePoint = (4 * G − 3 * O)"
+      "description": "Monge point formula M = 4G \u2212 3O (definition-level identity, holds by rfl)",
+      "leanType": "(T : Tetrahedron) \u2192 T.mongePoint = (4 * G \u2212 3 * O)"
     },
     {
       "name": "volume_eq_inradius_surfaceArea",
       "type": "supporting",
-      "description": "Volume = inradius × surface area / 3",
-      "leanType": "(T : Tetrahedron) → (hS : T.surfaceArea > 0) → T.volume = T.inradius * T.surfaceArea / 3"
+      "description": "Volume = inradius \u00d7 surface area / 3",
+      "leanType": "(T : Tetrahedron) \u2192 (hS : T.surfaceArea > 0) \u2192 T.volume = T.inradius * T.surfaceArea / 3"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json
@@ -6,7 +6,7 @@
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "Complete 5 sorries in FeuerbachsTheoremOQ02.lean: prove the 3D Feuerbach analogue — the insphere of an orthocentric tetrahedron is tangent to each of the 4 face circumspheres",
+    "formal": "Complete 5 sorries in FeuerbachsTheoremOQ02.lean: prove the 3D Feuerbach analogue \u2014 the insphere of an orthocentric tetrahedron is tangent to each of the 4 face circumspheres",
     "plain": "Feuerbach's theorem (2D): the incircle of a triangle is tangent to its 9-point circle. The 3D analogue for orthocentric tetrahedra: the insphere is internally tangent to 4 'face circumspheres'. The file has 5 sorry-gaps in the proof using Lean 4 3D geometry with dot products and sphere equations.",
     "whyMatters": [
       "Closes 5 sorries in FeuerbachsTheoremOQ02.lean extending the 2D Feuerbach gallery entry",
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "REFUTATION (session 3, 2026-05-02): Closed-form symbolic counterexample at the orthocentric tetrahedron T0 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) shows the (N24, R/3)-sphere is NOT internally tangent to the insphere; tangency would require 3r^2 = (7/6 - r)^2 with r = 3(6 - sqrt 14)/11, which fails component-wise in the Q-basis {1, sqrt 14}. The 5 sorry-stated theorems (feuerbach_3d_insphere, feuerbach_3d_exsphere_{A,B,C,D}) and the bundled feuerbach_3d_theorem are REMOVED; line count 723 -> 688; sorries 5 -> 0; axioms 1 -> 1. Identifying the correct 3D Feuerbach sphere is now the open problem.\n\nPROGRESS (session 2, 2026-04-27): Filled all 13 routine sorries in FeuerbachsTheoremOQ02Aristotle.lean (companion file). Fixed 1 mathematically false statement (externally_tangent_radii_nonneg, added missing precondition r1 <= d). Build verified with 64GB memory budget. Proved isodynamic property (ortho_edge_sum_identity) via linear_combination. Main file 5 tangency sorries remain (likely incorrect per session 1).\n\nPROGRESS (session 1): Discovered 2 FALSE axioms - removed. Added correct theorem edge_midpoints_equidist_from_centroid. Fixed Monge point docstring. Axioms: 3 -> 1.",
+    "progressSummary": "SESSION 4 (2026-05-03): Added 2 new theorems: (1) twentyFourPointCenter_is_2G_minus_O - N24=2G-O proved by ring; (2) edge_midpoints_dist_sq_formula - exact squared distance formula from G to edge midpoints, proved by nlinarith. Also fixed incorrect docstring claim that common distance is R/2 (false for regular tetrahedron). File: 688->743 lines, theorems: 8->10, 0 sorries, 1 axiom unchanged. REFUTATION (session 3, 2026-05-02): Closed-form symbolic counterexample at the orthocentric tetrahedron T0 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) shows the (N24, R/3)-sphere is NOT internally tangent to the insphere; tangency would require 3r^2 = (7/6 - r)^2 with r = 3(6 - sqrt 14)/11, which fails component-wise in the Q-basis {1, sqrt 14}. The 5 sorry-stated theorems (feuerbach_3d_insphere, feuerbach_3d_exsphere_{A,B,C,D}) and the bundled feuerbach_3d_theorem are REMOVED; line count 723 -> 688; sorries 5 -> 0; axioms 1 -> 1. Identifying the correct 3D Feuerbach sphere is now the open problem.\n\nPROGRESS (session 2, 2026-04-27): Filled all 13 routine sorries in FeuerbachsTheoremOQ02Aristotle.lean (companion file). Fixed 1 mathematically false statement (externally_tangent_radii_nonneg, added missing precondition r1 <= d). Build verified with 64GB memory budget. Proved isodynamic property (ortho_edge_sum_identity) via linear_combination. Main file 5 tangency sorries remain (likely incorrect per session 1).\n\nPROGRESS (session 1): Discovered 2 FALSE axioms - removed. Added correct theorem edge_midpoints_equidist_from_centroid. Fixed Monge point docstring. Axioms: 3 -> 1.",
     "builtItems": [
       "edge_midpoints_equidist_from_centroid: 6 midpoints equidistant from G (proved via nlinarith)",
       "REMOVED axiom edge_midpoints_on_sphere (was FALSE)",
@@ -49,7 +49,7 @@
       "Added mathematical warnings to tangency theorems",
       "Companion file (FeuerbachsTheoremOQ02Aristotle.lean): 13 sorries -> 0 (session 2)",
       "ortho_edge_sum_identity proved (isodynamic property of orthocentric tetrahedra)",
-      "Fixed false statement externally_tangent_radii_nonneg by adding hr₁_le_d precondition",
+      "Fixed false statement externally_tangent_radii_nonneg by adding hr\u2081_le_d precondition",
       "dist3_sq_nonneg in FeuerbachsTheoremOQ02Aristotle.lean (positivity)",
       "dist3_sq_comm in FeuerbachsTheoremOQ02Aristotle.lean (ring)",
       "dot3_self_nonneg in FeuerbachsTheoremOQ02Aristotle.lean (nlinarith)",
@@ -64,7 +64,10 @@
       "Session 3 (2026-05-02): Removed bundled feuerbach_3d_theorem (depended on the 5 false sorries)",
       "Session 3 (2026-05-02): Added closed-form refutation in PART 10 docstring with full symbolic counterexample at T0",
       "Session 3 (2026-05-02): Updated meta.json (sorries 5->0, mainTheorems list, sections, conclusion, openQuestions)",
-      "Session 3 (2026-05-02): Replaced ann-main-theorem annotation with ann-3d-feuerbach-refutation; updated ann-proved-theorems"
+      "Session 3 (2026-05-02): Replaced ann-main-theorem annotation with ann-3d-feuerbach-refutation; updated ann-proved-theorems",
+      "FeuerbachsTheoremOQ02.lean: theorem twentyFourPointCenter_is_2G_minus_O (pure ring proof)",
+      "FeuerbachsTheoremOQ02.lean: theorem edge_midpoints_dist_sq_formula (exact formula dist^2(G,M_AB)=(|AC|^2+|BD|^2)/16, proved by nlinarith using AC perp BD)",
+      "FeuerbachsTheoremOQ02.lean: corrected docstrings for PART 14 (removed false R/2 claim, added correct formula reference)"
     ],
     "insights": [
       "edge_midpoints_on_sphere is FALSE: regular tet has midpoints at dist 1, not R/3~0.577",
@@ -73,14 +76,17 @@
       "Monge point M != orthocenter H. Euler line: O(0), G(1), H(2), M(4). H = midpoint(O,M)",
       "N24 = midpoint(O,M) = H for orthocentric tetrahedra",
       "Tangency formulas (dist(H,I)=|R/3-r|) fail numerically for right-angle tetrahedra",
-      "ortho_edge_sum_identity: |AB|²+|CD|² = |AC|²+|BD|² for orthocentric tetrahedra (proved via linear_combination 2*hab_cd - 2*hac_bd)",
+      "ortho_edge_sum_identity: |AB|\u00b2+|CD|\u00b2 = |AC|\u00b2+|BD|\u00b2 for orthocentric tetrahedra (proved via linear_combination 2*hab_cd - 2*hac_bd)",
       "Aristotle file proof tactics: positivity for nonneg sums, ring for poly identities, nlinarith with mul_self_nonneg for zero-iff",
-      "externally_tangent_radii_nonneg is FALSE as stated: hypotheses (0 < d, d = r₁ + r₂, 0 ≤ r₁) do not force 0 ≤ r₂ (counterexample r₁=3, r₂=-1, d=2). Added precondition r₁≤d fixes it.",
+      "externally_tangent_radii_nonneg is FALSE as stated: hypotheses (0 < d, d = r\u2081 + r\u2082, 0 \u2264 r\u2081) do not force 0 \u2264 r\u2082 (counterexample r\u2081=3, r\u2082=-1, d=2). Added precondition r\u2081\u2264d fixes it.",
       "let-bound goals (midpoint3_equidist, midpoint3_spec) need dsimp only or show before ring/refine.",
       "Closed-form refutation: at orthocentric T0 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)), dist(N24, I)^2 = 3r^2 = (1350 - 324 sqrt 14)/121 while (R/3 - r)^2 = (5497 - 1116 sqrt 14)/4356; equality reduces to 48600 - 11664 sqrt 14 = 5497 - 1116 sqrt 14, false in the Q-basis {1, sqrt 14}",
       "The orthocentric hypothesis does NOT save the candidate Feuerbach sphere: T0 IS orthocentric and the tangency still fails",
       "The midedge sphere (center G, radius R/2) is also NOT tangent to the insphere of T0 (dist(G,I)^2 ~ 0.812 vs (R/2-r)^2 ~ 1.286), so the obvious midedge replacement also fails",
-      "The phrase twenty-four-point sphere may be a misnomer with these definitions: only 6 (edge midpoints, via centroid G and radius R/2) of the 24 named points have been verified to lie on a common sphere"
+      "The phrase twenty-four-point sphere may be a misnomer with these definitions: only 6 (edge midpoints, via centroid G and radius R/2) of the 24 named points have been verified to lie on a common sphere",
+      "The docstring claim that edge midpoints are at distance R/2 from G is FALSE for the regular tetrahedron A=(1,1,1),B=(1,-1,-1),C=(-1,1,-1),D=(-1,-1,1): dist=1 but R/2=sqrt(3)/2. The correct formula is dist^2(G, M_AB) = (|AC|^2+|BD|^2)/16.",
+      "The 24-point center N24 = 2G - O (reflection of circumcenter through centroid). This follows from N24 = midpoint(O, M) = midpoint(O, 4G-3O) = (O+4G-3O)/2 = 2G-O. For orthocentric tetrahedra, this equals the orthocenter H = 2G-O.",
+      "For orthocentric tetrahedra, the third perp condition AD perp BC forces |AC|^2+|BD|^2 = |AB|^2+|CD|^2, confirming all 6 edge midpoints are equidistant from G. The common squared distance is (|AC|^2+|BD|^2)/16 = (|AB|^2+|CD|^2)/16."
     ],
     "mathlibGaps": [
       "3D sphere tangency in Mathlib is less developed than 2D circle geometry",
@@ -108,7 +114,7 @@
   "references": {
     "papers": [
       "Feuerbach (1822) - 2D theorem",
-      "Coolidge (1929) - Treatise on the circle and sphere — 3D analogues"
+      "Coolidge (1929) - Treatise on the circle and sphere \u2014 3D analogues"
     ],
     "urls": [],
     "mathlib": [


### PR DESCRIPTION
## Summary

Research session 4 for feuerbachs-theorem-oq-02-incomplete-01.

Two new proved theorems in proofs/Proofs/FeuerbachsTheoremOQ02.lean:

1. twentyFourPointCenter_is_2G_minus_O: N24 = 2G - O (ring proof). Confirms N24 = H for orthocentric tetrahedra.

2. edge_midpoints_dist_sq_formula: dist2(G, M_AB) = (|AC|2+|BD|2)/16 and dist2(G, M_AC) = (|AB|2+|CD|2)/16. Proved by nlinarith using AC perp BD and AB perp CD.

Docstring error corrected: previous claim "common distance is R/2" is false for the regular tetrahedron (dist=1, R/2=sqrt(3)/2). The correct formula is (|AC|2+|BD|2)/16.

## Progress

- Lines: 688 to 743
- Theorems: 8 to 10
- Sorries: 0 (unchanged)
- Axioms: 1 (unchanged, feuerbach_3d_fails_general still an axiom)

Remaining blocker: feuerbach_3d_fails_general requires a non-orthocentric witness with face areas computed via sqrt, which is hard to formalize directly.

Bot: Generated by researcher-1