### PR TITLE
fix(batch): add missing theoremCount to 11 gallery entries

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -24,6 +24,7 @@
     "axiomCount": 0,
     "assumptions": "Open problem: Erdős Problem #10 asks whether there exists k such that every sufficiently large integer is a sum of a prime and at most k powers of 2. The Lean file contains 0 formal axiom declarations — it defines the key sets (sumPrimeAndTwoPows, Set.lowerDensity) but leaves the main results as doc-comment descriptions. Classified as axiomatized per CLAUDE.md policy for open conjectures.",
     "lineCount": 94,
+    "theoremCount": 0,
     "prerequisites": [
       "Prime numbers and their distribution",
       "Density of sets of integers (lower density, natural density)",

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -25,6 +25,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 10,
+    "theoremCount": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.rpow_add",

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -29,6 +29,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 54,
+    "theoremCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-208/meta.json
+++ b/src/data/proofs/erdos-208/meta.json
@@ -53,6 +53,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 182,
+    "theoremCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified."
   },
   "overview": {

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -25,6 +25,7 @@
     "axiomCount": 7,
     "assumptions": "7 axioms: greedy_sidon_values (first 11 OEIS A005282 terms), greedy_sidon_strict_mono (StrictMono), greedy_sidon_is_sidon (Sidon invariant at every prefix), greedy_sidon_lower_bound (Ω(N^{1/3}) growth), erdos_turan_upper_bound (O(√N + N^{1/4}) upper bound), greedy_sidon_growth_conjecture (open: Ω(N^{1/2-ε}) for all ε>0), greedy_sidon_diffset_pos_density (open: A-A has positive upper density).",
     "lineCount": 101,
+    "theoremCount": 0,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-497/meta.json
+++ b/src/data/proofs/erdos-497/meta.json
@@ -51,6 +51,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 51,
+    "theoremCount": 0,
     "assumptions": "0 axioms, 0 sorries. Core definitions proved: IsAntichain, antichainCount, ErdosProblem497 (as Prop). Kleitman's theorem is stated as a def/Prop — not an axiom and not proved as a theorem."
   },
   "overview": {

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -67,6 +67,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
     "lineCount": 79,
+    "theoremCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified."
   },
   "overview": {

--- a/src/data/proofs/erdos-520/meta.json
+++ b/src/data/proofs/erdos-520/meta.json
@@ -55,6 +55,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 137,
+    "theoremCount": 0,
     "assumptions": "0 axioms. Structure IsRademacherMultiplicative defines the mathematical object (5 fields: map_one, prob_of_prime, indep_primes, map_mul_coprime, map_non_squarefree). No axiom declarations. Open conjecture; supporting lemmas fully verified."
   },
   "overview": {

--- a/src/data/proofs/erdos-563/meta.json
+++ b/src/data/proofs/erdos-563/meta.json
@@ -22,6 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 65,
+    "theoremCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -37,6 +37,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 120,
+    "theoremCount": 0,
     "assumptions": "0 axioms. Lean source contains only typeclass definitions (IsKVertexCritical, IsErdos944Graph) used as abstract predicates with no declared instances; the known results of Brown, Lattanzio, Jensen, and Martinsson-Steiner are described in comments only, not formally axiomatized. Open conjecture (k = 4 case unsolved)."
   },
   "overview": {

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -22,6 +22,7 @@
     "axiomCount": 0,
     "dateAdded": "2026-04-27",
     "lineCount": 118,
+    "theoremCount": 4,
     "originalContributions": [
       "legendreSym_mul_eq: multiplicativity (a·b/p) = (a/p)·(b/p) packaged as a one-line wrapper around `map_mul (legendreSym p)`",
       "legendreSym_neg_one_eq: first supplementary law (-1/p) = (-1)^((p-1)/2) restated as a clean reduction step",


### PR DESCRIPTION
## Fix

Add missing `theoremCount` field to 11 gallery `meta.json` files where the field was absent but should be set.

## Evidence

**Before**: `theoremCount` field absent (null) in 11 proof meta.json files  
**After**: Field present with correct value matching actual Lean source

| Proof | theoremCount | Notes |
|-------|-------------|-------|
| quadratic-reciprocity-oq-03 | 4 | legendreSym_mul_eq, legendreSym_neg_one_eq, reciprocity_swap, algorithm_descent |
| erdos-10 | 0 | Open-problem stub, no formalized theorems |
| erdos-50 | 0 | Open-problem stub |
| erdos-142 | 0 | Open-problem stub |
| erdos-208 | 0 | Open-problem stub |
| erdos-340 | 0 | Open-problem stub |
| erdos-497 | 0 | Open-problem stub |
| erdos-520 | 0 | Open-problem stub |
| erdos-563 | 0 | Open-problem stub |
| erdos-944 | 0 | Open-problem stub |
| erdos-1155-oq-01-oq-06 | 0 | Placeholder stub |

pnpm build passes after changes.

---
Automated fix by lean-mechanic agent.