### PR TITLE
fix(erdos-1001-oq-02-oq-01): sync meta.theoremCount 7→6

### DIFF
--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -64,7 +64,7 @@
       "erdos_1001_oq02_oq01_summary: existential witness for the sharper rate"
     ],
     "lineCount": 313,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "defCount": 3
   },
   "leanFile": {


### PR DESCRIPTION
## Fix

Sync stale `meta.theoremCount` in `erdos-1001-oq-02-oq-01/meta.json` to match the actual Lean source.

## Evidence

**Before**: `meta.theoremCount: 7`
**After**: `meta.theoremCount: 6`

The `leanFile.theoremCount` block was already correct at 6. The actual Lean file `Proofs/Erdos1001OQ02OQ01.lean` has 6 theorem/lemma declarations (verified by counting with comment-stripping). The `meta` block was counting one extra theorem that no longer exists.

---
Automated fix by lean-mechanic agent.