### PR TITLE
fix: sync gallery meta.json for basel-oq-04-oq-03 and cauchy-schwarz-incomplete-01

### DIFF
--- a/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
@@ -6,8 +6,8 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-26",
-    "status": "axiomatized",
-    "note": "axiom count reduced 2→1: moebius_dirichlet_series_at_two proved via LSeries_zeta_mul_Lseries_moebius (2026-05-03)",
+    "status": "verified",
+    "note": "all axioms eliminated: moebius_dirichlet_series_at_two proved 2026-05-03; coprime_pair_density_limit proved via tendsto_tsum_of_dominated_convergence (2026-05-03)",
     "proofRepoPath": "Proofs/BaselProblemOQ04OQ03.lean",
     "tags": [
       "number-theory",
@@ -18,7 +18,7 @@
       "coprimality",
       "basel-problem"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-26",
     "mathlibDependencies": [
@@ -47,14 +47,14 @@
       "Möbius decomposition: countCoprimePairs(N) = Σ_{d≤N} μ(d)⌊N/d⌋² (combinatorial identity via Möbius inversion)",
       "coprime_iff_moebius_sum: 1_{gcd(m,n)=1} = Σ_{d|gcd(m,n)} μ(d) (coprimality detector)",
       "card_pairs_divisible: |{(m,n)∈[N]² : d|m, d|n}| = ⌊N/d⌋² (counting lemma)",
-      "moebius_dirichlet_series_at_two: HasSum axiom for Σ μ(d)/d² = 6/π²",
+      "moebius_dirichlet_series_at_two: HasSum proof for Σ μ(d)/d² = 6/π² via Complex L-series bridge",
       "Numerical verification for N=1,2,3,4,5,10 via native_decide",
       "Density bounds: 3/8 < 6/π² < 2/3 (from π > 3 and π < 4)"
     ],
-    "axiomCount": 1,
-    "lineCount": 412,
-    "assumptions": "1 axiom: coprime_pair_density_limit — the density limit theorem using dominated convergence with dominator 1/d² (Σ μ(d)/d²=6/π² is now proved via L-series).",
-    "theoremCount": 21
+    "axiomCount": 0,
+    "lineCount": 558,
+    "assumptions": "No remaining assumptions — fully verified.",
+    "theoremCount": 24
   },
   "overview": {
     "historicalContext": "Ernesto Cesàro (1885) first explicitly stated that the probability that two randomly chosen positive integers are coprime equals 6/π² = 1/ζ(2) ≈ 0.6079. The result connects three branches of mathematics: combinatorics (coprimality, Möbius function), analysis (convergent series, Basel problem), and probability (natural density).\n\nThe mathematical insight is elegant: for each prime p, the probability that p divides both m and n is 1/p², so the probability that p does NOT divide their gcd is (1 - 1/p²). By the Chinese Remainder Theorem, coprimality with respect to different primes is independent, so the probability that gcd(m,n)=1 is ∏_p (1 - 1/p²) = 1/ζ(2) = 6/π².\n\nThis connects to the Basel problem (Euler, 1734): ∑_{n=1}^∞ 1/n² = π²/6, making the density the reciprocal 6/π². The Möbius function μ(n) provides the formal proof tool: the identity 1_{n=1} = Σ_{d|n} μ(d) converts coprimality detection into a finite sum, enabling the counting argument.\n\nThe result was generalized in the 20th century: Bergelson and Richter (2017) showed that for non-integer α > 0, the density of {n : gcd(n, ⌊n^α⌋) = 1} is also 6/π² (Erdős #1149 in our gallery).",
@@ -112,8 +112,8 @@
       "title": "Analytic Axioms (Dirichlet Series and Density Convergence)",
       "startLine": 209,
       "endLine": 245,
-      "summary": "Two axioms: (1) HasSum of μ(d)/d² equals 6/π² (Dirichlet series L(μ,2) = 1/ζ(2)); (2) the density convergence theorem (uses dominated convergence with dominator 1/d²).",
-      "mathContext": "$\\sum_{d=1}^\\infty \\mu(d)/d^2 = 1/\\zeta(2) = 6/\\pi^2$. Axiomatized because the bridge from the algebraic identity $(\\mu*\\zeta)(n) = 1_{n=1}$ to the analytic HasSum statement requires L-series machinery not yet formalized for $\\mathbb{Z}$-valued arithmetic functions."
+      "summary": "Both analytic steps are now fully proved: (1) moebius_dirichlet_series_at_two: HasSum μ(d)/d² = 6/π² proved via Complex L-series bridge; (2) coprime_pair_density_limit: density convergence proved via tendsto_tsum_of_dominated_convergence with dominator 1/d².",
+      "mathContext": "$\\sum_{d=1}^\\infty \\mu(d)/d^2 = 1/\\zeta(2) = 6/\\pi^2$. Proved by converting to the complex L-series $L(\\mu, 2)$ via Mathlib's \\texttt{LSeries\\_zeta\\_mul\\_Lseries\\_moebius}, then extracting the real HasSum. Density convergence uses Tannery's dominated convergence theorem with dominator $1/d^2$."
     },
     {
       "id": "main-theorem",
@@ -149,7 +149,7 @@
     }
   ],
   "conclusion": {
-    "summary": "A formal proof that the natural density of coprime pairs equals 6/π². The Möbius decomposition identity is established combinatorially; the density limit is axiomatized with 2 axioms covering the Dirichlet series and dominated convergence. Small cases verified by computation.",
+    "summary": "A fully verified formal proof that the natural density of coprime pairs equals 6/π². The Möbius decomposition identity is established combinatorially; the Dirichlet series sum and density convergence are both formally proved using Mathlib L-series machinery and Tannery's dominated convergence theorem. Small cases verified by computation.",
     "openQuestions": [
       "Can the dominated convergence argument for coprime_pair_density_limit be formalized using Mathlib tendsto_tsum or measure theory on ℕ?",
       "Can the finite sum exchange sorry in countCoprimePairs_moebius be proved using Finset.sum_comm in Lean 4? (Already proved!)",
@@ -201,9 +201,9 @@
       "ArithmeticFunction"
     ],
     "namespace": "BaselProblemOQ04OQ03",
-    "lineCount": 470,
-    "axiomCount": 1,
-    "theoremCount": 22,
+    "lineCount": 558,
+    "axiomCount": 0,
+    "theoremCount": 24,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/BaselProblemOQ04OQ03.lean"


### PR DESCRIPTION
## Summary

Gallery integrity fixes discovered by auditor: research commit `96064e43a88` updated Lean source files but did not update the corresponding `meta.json` entries.

### basel-problem-oq-04-oq-03
The final axiom (`coprime_pair_density_limit`) was proved via `tendsto_tsum_of_dominated_convergence`, making this a **fully verified proof** of Cesàro 1885.
- `axiomCount`: 1 → 0 (both `meta` and `leanFile` sections)
- `lineCount`: 412 → 558 (both sections)
- `theoremCount`: 21 → 24 (both sections)
- `status`: `axiomatized` → `verified`
- `badge`: `axiom` → `original`
- Updated section/conclusion text to reflect proved (not axiomatized) status

### cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01
Step B (`lp_truncation_tendsto_zero`) was proved, reducing sorries from 2 to 1.
- `sorries`: 2 → 1
- `lineCount`: 343 → 386
- Updated assumptions description

---
Discovered during gallery integrity audit. Verified against `git show origin/main:proofs/Proofs/*.lean` with comment-stripped sorry/axiom counts.