### PR TITLE
research(pythagorean-theorem-oq-05): mark COMPLETED — answered by gallery oq-03

### DIFF
--- a/research/problems/pythagorean-theorem-oq-05/state.md
+++ b/research/problems/pythagorean-theorem-oq-05/state.md
@@ -1,0 +1,30 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-05-03T20:00:00Z
+**Iteration**: 1
+
+## Result
+
+This research question is answered by the existing gallery proof
+`pythagorean-theorem-oq-03` (verified, 0 axioms, 0 sorries).
+
+## What Was Found
+
+The gallery proof `PythagoreanTheoremOQ03.lean` already formalizes
+the non-Euclidean Pythagorean theorem analogs:
+- Hyperbolic: cosh c = cosh a · cosh b
+- Spherical: cos c = cos a · cos b
+
+These are exactly what the research question asks about. The problem
+is fully addressed by the existing verified gallery entry.
+
+## Next Action
+
+None. The gallery proof `pythagorean-theorem-oq-03` answers this question.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1


### PR DESCRIPTION
## Summary

- Non-Euclidean Pythagorean theorem analogs (hyperbolic: cosh c = cosh a·cosh b; spherical: cos c = cos a·cos b) are already formalized in verified gallery proof `pythagorean-theorem-oq-03` (0 axioms, 0 sorries)
- Mark `pythagorean-theorem-oq-05` as COMPLETED

## Test plan

- [ ] Verify `pythagorean-theorem-oq-03` meta.json shows status=verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)