### PR TITLE
audit(cauchy-schwarz-incomplete-01): fix sorry count 2→1, lineCount 343→386

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures (Complete)",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
-  "description": "Advances the sigma-finite Lp Riesz representation from 3 sorries to 2 by proving Step C (density extension) in full: the integration CLM is valid for SigmaFinite μ without IsFiniteMeasure, and Lp.induction extends indicator agreement to all of Lp(μ).",
+  "description": "Advances the sigma-finite Lp Riesz representation from 3 sorries to 1 by proving Step C (density extension, Session 1) and Step B (Lp truncation convergence via Vitali, Session 2). Only localization_existence (Step A, ~150 lines of Lp restriction map infrastructure) remains as a sorry.",
   "meta": {
     "status": "formalized",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
@@ -15,17 +15,18 @@
       "density-argument"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 343,
-    "assumptions": "2 HARD sorries remaining (down from 3): localization_existence (~150 lines, Lp restriction map infrastructure) and lp_truncation_tendsto_zero (~80 lines, Vitali's convergence theorem). Density extension (Step C, ~50 lines) is fully proved: integrationCLM works for SigmaFinite without IsFiniteMeasure, and Lp.induction is valid for sigma-finite measures.",
+    "lineCount": 386,
+    "assumptions": "1 HARD sorry remaining (down from 3): localization_existence (~150 lines, Lp restriction map infrastructure). Step C (density extension) and Step B (lp_truncation_tendsto_zero via Vitali) are both fully proved.",
     "dateAdded": "2026-05-03",
     "theoremCount": 10,
     "originalContributions": [
       "integrationCLM_sf: integration CLM on Lp(μ) for purely sigma-finite μ — proves IsFiniteMeasure was never needed for the CLM construction (Hölder only)",
       "integral_representation_sf: Step C density extension proved — Lp.induction is valid for SigmaFinite without IsFiniteMeasure, completing the missing piece from the parent entry",
       "riesz_lp_surjective_sigma_finite: main theorem assembled with Step C proved — only localization (Step A) remains as sorry",
-      "Identification that the parent 3-sorry structure was correct but IsFiniteMeasure was superfluous for Steps C and the CLM: reduces 3 sorries to 2 with clean proof"
+      "Identification that the parent 3-sorry structure was correct but IsFiniteMeasure was superfluous for Steps C and the CLM: reduces 3 sorries to 2 with clean proof",
+      "lp_truncation_tendsto_zero: Step B proved via Vitali convergence theorem (tendsto_Lp_of_tendsto_ae) — |f - f·1_{Sₙ}| ≤ |f| pointwise enables unifIntegrable_const + unifTight_const, giving eLpNorm(f - f·1_{Sₙ}) → 0"
     ]
   },
   "overview": {
@@ -36,8 +37,9 @@
       "IsFiniteMeasure was unnecessary for integrationCLM: the CLM construction uses only Hölder's inequality (f ∈ Lp, g ∈ Lq → fg ∈ L1), which holds for any measure.",
       "Lp.induction in Mathlib is valid for sigma-finite measures, not just finite ones. Simple functions with finite-measure support are dense in Lp(μ) for any SigmaFinite μ.",
       "The density extension (Step C) depends only on: (a) indicator agreement on μ-finite sets, and (b) density of indicators in Lp. Both hold for SigmaFinite μ.",
-      "The 3-sorry → 2-sorry reduction confirms the parent entry was on the right track: the sorries were correctly classified as HARD (not OPEN), and one of them (density extension) was actually provable with the right setup.",
-      "Remaining gap: Step A (localization, ~150 lines) requires constructing the Lp restriction map Lp(μ) → Lp(μ.restrict S). This is the genuine Lean infrastructure gap for sigma-finite Riesz."
+      "The 3-sorry → 1-sorry reduction confirms the parent entry was on the right track: of three HARD sorries, two (Steps B and C) were provable with the right Mathlib API; only localization (Step A) requires genuinely missing infrastructure.",
+      "Remaining gap: Step A (localization_existence, ~150 lines) requires constructing the Lp restriction map Lp(μ) → Lp(μ.restrict S). This is the genuine Lean infrastructure gap for sigma-finite Riesz.",
+      "Step B proof: Vitali's theorem (tendsto_Lp_of_tendsto_ae) is the key. The domination condition |f - f·1_{Sₙ}| ≤ |f| ∈ L^p enables unifIntegrable_const and unifTight_const to propagate to the difference sequence."
     ]
   },
   "sections": [
@@ -68,34 +70,34 @@
     {
       "id": "spanning-set-lemmas",
       "title": "Spanning Set Approximation Lemmas",
-      "startLine": 216,
-      "endLine": 240,
+      "startLine": 212,
+      "endLine": 234,
       "summary": "mem_spanningSets_eventually and pointwise_mul_indicator_tendsto — proved, identical to parent entry.",
-      "mathContext": "Basic set-theoretic consequences of the sigma-finite exhaustion. Used in the proof of lp_truncation_tendsto_zero (Step B, still sorry)."
+      "mathContext": "Basic set-theoretic consequences of the sigma-finite exhaustion. Used in the proof of lp_truncation_tendsto_zero (Step B)."
     },
     {
-      "id": "step-b-sorry",
-      "title": "Step B: Lp Truncation Convergence (HARD sorry)",
-      "startLine": 241,
-      "endLine": 270,
-      "summary": "lp_truncation_tendsto_zero: eLpNorm(f - f·1_{Sₙ}) → 0. Proof: Vitali's theorem.",
-      "mathContext": "Requires unifIntegrable_of + unifTight_const + tendsto_Lp_of_tendsto_ae. ~80 lines."
+      "id": "step-b-proved",
+      "title": "Step B: Lp Truncation Convergence (Proved)",
+      "startLine": 235,
+      "endLine": 300,
+      "summary": "lp_truncation_tendsto_zero: eLpNorm(f - f·1_{Sₙ}) → 0 via Vitali's convergence theorem.",
+      "mathContext": "unifIntegrable_const + unifTight_const + tendsto_Lp_of_tendsto_ae. Domination |f - f·1_{Sₙ}| ≤ |f| propagates UI/UT from the constant-f sequence."
     },
     {
       "id": "step-a-sorry",
       "title": "Step A: Localization (HARD sorry)",
-      "startLine": 271,
-      "endLine": 305,
+      "startLine": 301,
+      "endLine": 327,
       "summary": "localization_existence: constructs g ∈ Lq(μ) with indicator agreement. ~150 lines.",
       "mathContext": "Classical Folland §6.2 proof. Requires Lp restriction map infrastructure."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem (Assembled)",
-      "startLine": 306,
-      "endLine": 345,
-      "summary": "riesz_lp_surjective_sigma_finite: full Riesz Lp for sigma-finite, assembled from Steps A and C.",
-      "mathContext": "Step C (proved) + Step A (sorry) give the full theorem. Step B is independent supporting infrastructure."
+      "startLine": 328,
+      "endLine": 386,
+      "summary": "riesz_lp_surjective_sigma_finite: full Riesz Lp for sigma-finite, assembled from Steps A, B, and C.",
+      "mathContext": "Steps B and C (proved) + Step A (sorry) give the full theorem."
     }
   ],
   "openQuestions": [
@@ -109,7 +111,8 @@
       "id": "oq-02",
       "question": "Can Step B (lp_truncation_tendsto_zero) be proved using Mathlib's tendsto_Lp_of_tendsto_ae (Vitali's theorem) with unifIntegrable_of and unifTight_const?",
       "difficulty": "hard",
-      "prerequisite": "Vitali's convergence theorem API"
+      "prerequisite": "Vitali's convergence theorem API",
+      "answer": "YES — proved via unifIntegrable_const + unifTight_const + tendsto_Lp_of_tendsto_ae using |f - f·1_{Sₙ}| ≤ |f| as the dominator."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fixes sorry count mismatch: `meta.json` claimed 2 sorries, Lean file has 1
- Fixes lineCount: 343 → 386 (file grew when Step B was proved in #15284)
- Updates description, assumptions, sections, keyInsights, openQuestions to reflect current state (Steps B and C both proved; only Step A remains)

## Background

PR #15284 (Basel problem) included Step B proof (`lp_truncation_tendsto_zero` via Vitali), reducing sorries 2→1, but didn't update `meta.json` for this proof. PR #15301 was intended to fix this but has a merge conflict (its Lean file changes were already merged). This PR provides the clean fix.

## Test plan

- [x] `meta.json` `sorries: 1` matches actual sorry count in Lean file (excluding comments)
- [x] `meta.json` `lineCount: 386` matches actual line count of Lean file
- [x] No changes to Lean source

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)