### PR TITLE
enrich(erdos-1001-oq-02-oq-01): add conclusion and cross-references

### DIFF
--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -67,6 +67,32 @@
     "theoremCount": 6,
     "defCount": 3
   },
+  "conclusion": {
+    "summary": "The O(A log N / N) convergence rate from OQ-02 is NOT sharp: by Walfisz's 1963 theorem, the true rate is the strictly smaller O(A (log N)^(2/3) (log log N)^(4/3) / N) = o(A log N / N). This is proved via IsBigO.trans_isLittleO from four axioms and six theorems (4 sorries remain for rpow manipulations, all Aristotle candidates). The diophantine approximation rate is thus fully governed by the Vinogradov–Korobov zero-free region for ζ(s), not merely by the elementary Mertens bound.",
+    "implications": "This result connects the convergence rate of a diophantine approximation density to the zero-free region of the Riemann zeta function — a deep link between Diophantine analysis and analytic number theory. The exponent 2/3 in the Walfisz error bound equals the Vinogradov–Korobov zero-free exponent, so any improvement to the zero-free region (e.g., under RH: exponent → 1/2) would sharpen the diophantine approximation rate. The gap between the unconditional Walfisz bound and the RH-conditional O(√N log N) bound is one of the central open problems in analytic number theory.",
+    "openQuestions": [
+      "Under the Riemann Hypothesis, the totient error E(N) = O(√N log N²), giving convergence rate O(A log²N/√N). Can this conditional improvement be formalized with RH as an axiom?",
+      "Is the current Walfisz bound E(N) = O(N(logN)^(2/3)(loglogN)^(4/3)) the best unconditional bound, or can the exponent 2/3 be improved? The best known lower bound is E(N) = Ω(√N).",
+      "Can the Abel summation step (rangeTotientSum_walfisz_error) be proved in Lean using Mathlib's summation-by-parts? This would remove one of the four axioms."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1001",
+      "relationship": "sub-question",
+      "description": "Parent problem: Erdős #1001 base formalization of the diophantine approximation density"
+    },
+    {
+      "targetId": "erdos-1001-oq-02",
+      "relationship": "depends-on",
+      "description": "Direct parent OQ-02: established the O(A log N / N) rate that this proof shows is non-optimal"
+    },
+    {
+      "targetId": "erdos-1001-oq-03",
+      "relationship": "sibling",
+      "description": "OQ-03: related open question on the Erdős #1001 family of density problems"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/Erdos1001OQ02OQ01.lean",
     "namespace": "Erdos1001OQ02OQ01",


### PR DESCRIPTION
Enrichment pass for erdos-1001-oq-02-oq-01 (Erdős #1001 OQ-02-OQ-01: Sharpness of the O(log N / N) Rate).

## Quality improvements

**meta.json**:
- Added `conclusion` with:
  - Summary: the O(log N/N) rate is not sharp; Walfisz gives O((logN)^(2/3)(loglogN)^(4/3)/N)
  - Implications: connects rate to Vinogradov–Korobov zero-free region for ζ(s); RH would give √N improvement
  - 3 open questions: RH-conditional formalization, best unconditional bound (Ω(√N) lower bound), Abel summation proof
- Added `crossReferences` to erdos-1001 (parent), erdos-1001-oq-02 (direct parent establishing O(logN/N)), erdos-1001-oq-03 (sibling OQ)

This fixes the missing `conclusion` field (was scoring 0/15 in quality breakdown).