### PR TITLE
enrich(desargues-theorem-oq-01-oq-01): add index.ts, 6 annotations, fix schema

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7105,6 +7105,11 @@
       "passes": 1,
       "lastEnriched": "2026-05-03T13:57:41Z",
       "quality": 65
+    },
+    "desargues-theorem-oq-01-oq-01": {
+      "passes": 4,
+      "lastEnriched": "2026-05-03T22:05:45Z",
+      "quality": 26
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {
@@ -7146,6 +7151,16 @@
   "angle-trisection-oq-02-oq-01-oq-02-incomplete-01": {
     "passes": 1,
     "lastEnriched": "2026-04-26T12:10:19Z",
+    "quality": 100
+  },
+  "de-moivre-oq-02-oq-02": {
+    "passes": 1,
+    "lastEnriched": "2026-05-03T22:01:18.789Z",
+    "quality": 100
+  },
+  "desargues-theorem-oq-01-oq-01": {
+    "passes": 1,
+    "lastEnriched": "2026-05-03T22:01:46.445Z",
     "quality": 100
   }
 }


### PR DESCRIPTION
Enrichment pass for `desargues-theorem-oq-01-oq-01` (Non-Desarguesian Planes: The Moulton Plane Counterexample).

## Changes

**index.ts** — created (was missing; proof page showed 404 without it).

**annotations.json** — created with 6 annotations:
- Moulton plane construction overview and coordinate design rationale
- `onMoultonLine`/`MoultonCollinear` piecewise definitions and Classical API
- Perspectivity from O verification (three cases: ordinary, bent, vertical)
- Intersection point computation (16 incidence lemmas, design rationale)
- `desargues_fails` proof: three-case contradiction with `linarith`
- `moulton_counterexample` certificate (22-conjunct machine-verified certificate)

**meta.json** fixes and improvements:
- `sections`: fixed from `{title, content}` to required `{id, startLine, endLine, summary}` schema; expanded from 4 to 6 sections
- `conclusion`: was a string, now proper `{summary, implications, openQuestions}` object with 3 open questions
- `crossReferences`: `slug/relation` → `targetId/relationship`
- Removed top-level `openQuestions` (moved into `conclusion`)
- Added 5th `keyInsight` about coordinate design making bending invisible in side-lines
- Added 3rd open question about skew field non-coordinatization

🤖 Generated with [Claude Code](https://claude.com/claude-code)