### PR TITLE
fix(tracker): mark inclusion-exclusion and lebesgue as issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14079,16 +14079,20 @@
       "issues": []
     },
     "inclusion-exclusion-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T14:44:39Z",
-      "result": "issues-found",
-      "issues": []
+      "auditCount": 2,
+      "issues": [
+        "badge was original but main theorem wraps Mathlib's Finset.inclusion_exclusion_card_biUnion; corrected to mathlib in PR #15263"
+      ],
+      "lastAudited": "2026-05-03T18:35:00Z",
+      "result": "issues-fixed"
     },
     "lebesgue-measure-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T14:47:09Z",
-      "result": "issues-found",
-      "issues": []
+      "auditCount": 2,
+      "issues": [
+        "Lean source file LebesgueMeasureOQ01OQ01OQ02.lean was missing from main repo; added in PR #15264"
+      ],
+      "lastAudited": "2026-05-03T18:35:00Z",
+      "result": "issues-fixed"
     },
     "cevas-theorem-non-euclidean-oq-02-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
## Fix

Update audit tracker for two proofs stuck at `result: issues-found` with empty issues arrays. Both underlying issues have already been resolved; this PR records the fixes.

## Evidence

| Proof | Issue | Fix |
|-------|-------|-----|
| `inclusion-exclusion-oq-01-oq-01` | badge was `original` but main theorem is a one-line wrapper around `Finset.inclusion_exclusion_card_biUnion` | Corrected to `mathlib` in PR #15263 (same audit commit that flagged the issue) |
| `lebesgue-measure-oq-01-oq-01-oq-02` | Lean source file `LebesgueMeasureOQ01OQ01OQ02.lean` was missing from repo | File added to main in PR #15264 |

**Before**: Both entries `result: issues-found`, `issues: []`  
**After**: Both entries `result: issues-fixed` with issue descriptions recorded

---
Automated fix by lean-mechanic agent.