### PR TITLE
research(abel-ruffini-oq-09): prove gaussian_not_elementary, reduce axioms 3→2

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -91,14 +91,14 @@ theorem constants_zero {F : Type*} [DiffField F] : isConst (0 : F) := by
   unfold isConst
   have h := DiffField.deriv_add (0 : F) 0
   simp only [add_zero] at h
-  linarith
+  linear_combination -h
 
 /-- D(1) = 0: one is a constant. Proof: D(1·1) = D(1)·1 + 1·D(1) → D(1) = 0. -/
 theorem constants_one {F : Type*} [DiffField F] : isConst (1 : F) := by
   unfold isConst
   have h := DiffField.deriv_mul (1 : F) 1
   simp only [mul_one, one_mul] at h
-  linarith
+  linear_combination -h
 
 /-- Constants are closed under addition. -/
 theorem constants_add {F : Type*} [DiffField F] {f g : F}
@@ -120,7 +120,7 @@ theorem deriv_neg {F : Type*} [DiffField F] (f : F) :
   have h0 : DiffField.deriv (0 : F) = 0 := constants_zero
   have h := DiffField.deriv_add f (-f)
   rw [add_neg_cancel, h0] at h
-  linarith
+  linear_combination h.symm
 
 /-- D(f - g) = D(f) - D(g). -/
 theorem deriv_sub {F : Type*} [DiffField F] (f g : F) :
@@ -181,6 +181,96 @@ axiom risch_exp_criterion_gaussian :
         2 * x * p.eval x * q.eval x = q.eval x ^ 2) ↔
     ∃ (F : ℝ → ℝ),
       (∀ x : ℝ, HasDerivAt F (Real.exp (-(x^2))) x) ∧ IsElementaryFn F
+
+/-! ══════════════════════════════════════════════════════════════════
+## Part IV: The Core Algebraic Proof — No Polynomial Risch Solution
+══════════════════════════════════════════════════════════════════ -/
+
+/-!
+### Coefficient Extraction: The Algebraic Heart of the Obstruction
+
+The key identity: for any polynomial p,
+  coeff(p' - C(2)·X·p, natDeg(p) + 1) = -2 · leadingCoeff(p).
+
+**Proof**:
+- coeff(derivative p, natDeg+1) = (natDeg+2) · coeff(p, natDeg+2) = 0
+  (coefficient above degree is zero)
+- coeff(C(2)·X·p, natDeg+1) = 2 · coeff(X·p, natDeg+1) = 2 · coeff(p, natDeg)
+  = 2 · leadingCoeff(p)
+- Net: 0 - 2·leadingCoeff(p) = -2·leadingCoeff(p).
+
+This identity forces a contradiction: if p' - 2xp = 1 (a degree-0 polynomial),
+then the coefficient of the LHS at natDeg+1 is -2·leadingCoeff(p), while the RHS
+has coefficient 0. So leadingCoeff(p) = 0, but p ≠ 0 — contradiction.
+-/
+
+/-- The coefficient of X^(natDegree p + 1) in (derivative p - C 2 · (X · p))
+    equals -2 · leadingCoeff(p). -/
+theorem risch_ode_coeff_top (p : Polynomial ℝ) :
+    (Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p)).coeff
+      (p.natDegree + 1) = -2 * p.leadingCoeff := by
+  simp only [Polynomial.coeff_sub, Polynomial.coeff_C_mul, Polynomial.coeff_X_mul,
+             Polynomial.coeff_derivative]
+  have h0 : p.coeff (p.natDegree + 2) = 0 :=
+    Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
+  push_cast
+  rw [h0, zero_mul, zero_sub]
+  simp only [Polynomial.leadingCoeff]
+  ring
+
+/-- The constant polynomial 1 has coefficient 0 at any position ≥ 1. -/
+theorem poly_one_coeff_pos (n : ℕ) (hn : 0 < n) : (1 : Polynomial ℝ).coeff n = 0 := by
+  rw [Polynomial.coeff_one]
+  simp [Nat.pos_iff_ne_zero.mp hn]
+
+/-- **No polynomial satisfies the Risch ODE for the Gaussian**: p' - C(2)·X·p ≠ 1.
+
+    The operator L[p] = p' - 2·X·p raises degree by 1 for any nonzero p,
+    so its image (polynomials of degree ≥ 1) never contains the constant 1.
+
+    **Proof**:
+    - For p = 0: L[0] = 0 ≠ 1.
+    - For p ≠ 0: leadingCoeff(p) ≠ 0.
+      Coefficient at natDeg(p)+1: LHS gives -2·leadingCoeff(p) (by risch_ode_coeff_top),
+      RHS gives 0 (by poly_one_coeff_pos). So -2·leadingCoeff(p) = 0, forcing
+      leadingCoeff(p) = 0 — contradiction. -/
+theorem no_poly_risch_soln :
+    ∀ p : Polynomial ℝ, Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p) ≠ 1 := by
+  intro p h
+  by_cases hp : p = 0
+  · simp [hp] at h
+  · have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
+    have hcoeff := Polynomial.ext_iff.mp h (p.natDegree + 1)
+    rw [risch_ode_coeff_top, poly_one_coeff_pos _ (by omega)] at hcoeff
+    exact absurd hcoeff (mul_ne_zero (by norm_num) hlc)
+
+/-- No polynomial satisfies L[p] = C(c) for any nonzero constant c.
+    The Risch operator's image avoids all nonzero constants. -/
+theorem no_poly_risch_constant (c : ℝ) (hc : c ≠ 0) :
+    ∀ p : Polynomial ℝ,
+      Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p) ≠ Polynomial.C c := by
+  intro p h
+  by_cases hp : p = 0
+  · simp [hp] at h
+    exact hc (Polynomial.C_eq_zero.mp h.symm)
+  · have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
+    have hcoeff := Polynomial.ext_iff.mp h (p.natDegree + 1)
+    rw [risch_ode_coeff_top] at hcoeff
+    simp only [Polynomial.coeff_C, Nat.succ_ne_zero, ↓reduceIte] at hcoeff
+    exact absurd hcoeff (mul_ne_zero (by norm_num) hlc)
+
+/-- The Risch operator strictly raises degree:
+    For p ≠ 0, natDegree(L[p]) > natDegree(p).
+    Proved by the nonzero coefficient at natDeg(p)+1. -/
+theorem risch_ode_raises_degree (p : Polynomial ℝ) (hp : p ≠ 0) :
+    p.natDegree < (Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p)).natDegree := by
+  have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
+  have hne : (Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p)).coeff
+               (p.natDegree + 1) ≠ 0 := by
+    rw [risch_ode_coeff_top]
+    exact mul_ne_zero (by norm_num) hlc
+  calc p.natDegree < p.natDegree + 1 := Nat.lt_succ_self _
+    _ ≤ _ := Polynomial.le_natDegree_of_ne_zero hne
 
 /-- The Risch operator L[h] = h' - C(2)·X·h. -/
 private def rischOp (h : Polynomial ℝ) : Polynomial ℝ :=
@@ -282,97 +372,8 @@ theorem gaussian_not_elementary :
     have := hiter x
     rw [hzero, Polynomial.eval_zero] at this
     exact (mul_eq_zero.mp this.symm).resolve_right (Real.exp_pos _).ne'
-  exact hne (Polynomial.funext hall)
+  exact hne (Polynomial.funext (fun x => (hall x).trans (Polynomial.eval_zero x).symm))
 
-/-! ══════════════════════════════════════════════════════════════════
-## Part IV: The Core Algebraic Proof — No Polynomial Risch Solution
-══════════════════════════════════════════════════════════════════ -/
-
-/-!
-### Coefficient Extraction: The Algebraic Heart of the Obstruction
-
-The key identity: for any polynomial p,
-  coeff(p' - C(2)·X·p, natDeg(p) + 1) = -2 · leadingCoeff(p).
-
-**Proof**:
-- coeff(derivative p, natDeg+1) = (natDeg+2) · coeff(p, natDeg+2) = 0
-  (coefficient above degree is zero)
-- coeff(C(2)·X·p, natDeg+1) = 2 · coeff(X·p, natDeg+1) = 2 · coeff(p, natDeg)
-  = 2 · leadingCoeff(p)
-- Net: 0 - 2·leadingCoeff(p) = -2·leadingCoeff(p).
-
-This identity forces a contradiction: if p' - 2xp = 1 (a degree-0 polynomial),
-then the coefficient of the LHS at natDeg+1 is -2·leadingCoeff(p), while the RHS
-has coefficient 0. So leadingCoeff(p) = 0, but p ≠ 0 — contradiction.
--/
-
-/-- The coefficient of X^(natDegree p + 1) in (derivative p - C 2 · (X · p))
-    equals -2 · leadingCoeff(p). -/
-theorem risch_ode_coeff_top (p : Polynomial ℝ) :
-    (Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p)).coeff
-      (p.natDegree + 1) = -2 * p.leadingCoeff := by
-  simp only [Polynomial.coeff_sub, Polynomial.coeff_C_mul, Polynomial.coeff_X_mul,
-             Polynomial.coeff_derivative]
-  have h0 : p.coeff (p.natDegree + 2) = 0 :=
-    Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
-  push_cast
-  rw [h0, zero_mul, zero_sub]
-  simp only [Polynomial.leadingCoeff]
-  ring
-
-/-- The constant polynomial 1 has coefficient 0 at any position ≥ 1. -/
-theorem poly_one_coeff_pos (n : ℕ) (hn : 0 < n) : (1 : Polynomial ℝ).coeff n = 0 := by
-  rw [Polynomial.coeff_one]
-  simp [Nat.pos_iff_ne_zero.mp hn]
-
-/-- **No polynomial satisfies the Risch ODE for the Gaussian**: p' - C(2)·X·p ≠ 1.
-
-    The operator L[p] = p' - 2·X·p raises degree by 1 for any nonzero p,
-    so its image (polynomials of degree ≥ 1) never contains the constant 1.
-
-    **Proof**:
-    - For p = 0: L[0] = 0 ≠ 1.
-    - For p ≠ 0: leadingCoeff(p) ≠ 0.
-      Coefficient at natDeg(p)+1: LHS gives -2·leadingCoeff(p) (by risch_ode_coeff_top),
-      RHS gives 0 (by poly_one_coeff_pos). So -2·leadingCoeff(p) = 0, forcing
-      leadingCoeff(p) = 0 — contradiction. -/
-theorem no_poly_risch_soln :
-    ∀ p : Polynomial ℝ, Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p) ≠ 1 := by
-  intro p h
-  by_cases hp : p = 0
-  · simp [hp] at h
-  · have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
-    have hcoeff := Polynomial.ext_iff.mp h (p.natDegree + 1)
-    rw [risch_ode_coeff_top, poly_one_coeff_pos _ (by omega)] at hcoeff
-    exact absurd hcoeff (mul_ne_zero (by norm_num) hlc)
-
-/-- No polynomial satisfies L[p] = C(c) for any nonzero constant c.
-    The Risch operator's image avoids all nonzero constants. -/
-theorem no_poly_risch_constant (c : ℝ) (hc : c ≠ 0) :
-    ∀ p : Polynomial ℝ,
-      Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p) ≠ Polynomial.C c := by
-  intro p h
-  by_cases hp : p = 0
-  · simp [hp] at h
-    exact hc (Polynomial.C_eq_zero.mp h.symm)
-  · have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
-    have hcoeff := Polynomial.ext_iff.mp h (p.natDegree + 1)
-    rw [risch_ode_coeff_top] at hcoeff
-    simp only [Polynomial.coeff_C, Nat.succ_ne_zero, ↓reduceIte] at hcoeff
-    exact absurd hcoeff (mul_ne_zero (by norm_num) hlc)
-
-/-- The Risch operator strictly raises degree:
-    For p ≠ 0, natDegree(L[p]) > natDegree(p).
-    Proved by the nonzero coefficient at natDeg(p)+1. -/
-theorem risch_ode_raises_degree (p : Polynomial ℝ) (hp : p ≠ 0) :
-    p.natDegree < (Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p)).natDegree := by
-  have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
-  have hne : (Polynomial.derivative p - Polynomial.C 2 * (Polynomial.X * p)).coeff
-               (p.natDegree + 1) ≠ 0 := by
-    rw [risch_ode_coeff_top]
-    exact mul_ne_zero (by norm_num) hlc
-  calc p.natDegree < p.natDegree + 1 := Nat.lt_succ_self _
-    _ ≤ _ := Polynomial.le_natDegree_of_ne_zero hne
 
 /-! ══════════════════════════════════════════════════════════════════
 ## Part V: Pointwise Reformulation
@@ -501,8 +502,8 @@ theorem risch_linear_surjective_all (p : Polynomial ℝ) :
   | monomial n a =>
     obtain ⟨Qn, hQn⟩ := risch_linear_surjective_monomial n
     refine ⟨Polynomial.C a * Qn, ?_⟩
-    simp only [Polynomial.derivative_mul, Polynomial.derivative_C, zero_mul, zero_add,
-               Polynomial.monomial_eq_C_mul_X]
+    simp only [Polynomial.derivative_mul, Polynomial.derivative_C, zero_mul, zero_add]
+    rw [← Polynomial.C_mul_X_pow_eq_monomial]
     linear_combination Polynomial.C a * hQn
 
 /-! ══════════════════════════════════════════════════════════════════

--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -285,8 +285,8 @@ private lemma rischOp_iter_ne_zero (g : Polynomial ℝ) (hg : g ≠ 0) :
   | succ n ih =>
     simp only [Function.iterate_succ_apply']
     intro heq
-    have hdeg := risch_ode_raises_degree (rischOp^[n] g) ih
-    unfold rischOp at heq
+    have hdeg : (rischOp^[n] g).natDegree < (rischOp (rischOp^[n] g)).natDegree :=
+      risch_ode_raises_degree (rischOp^[n] g) ih
     rw [heq, Polynomial.natDegree_zero] at hdeg
     exact Nat.not_lt_zero _ hdeg
 
@@ -372,7 +372,7 @@ theorem gaussian_not_elementary :
     have := hiter x
     rw [hzero, Polynomial.eval_zero] at this
     exact (mul_eq_zero.mp this.symm).resolve_right (Real.exp_pos _).ne'
-  exact hne (Polynomial.funext (fun x => (hall x).trans (Polynomial.eval_zero x).symm))
+  exact hne (Polynomial.funext fun x => by simp [hall x])
 
 
 /-! ══════════════════════════════════════════════════════════════════

--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -482,7 +482,7 @@ theorem risch_linear_surjective_monomial (n : ℕ) :
     refine ⟨Polynomial.X ^ (n + 1) - Polynomial.C (↑(n + 1) : ℝ) * Qn, ?_⟩
     have hd_pow : Polynomial.derivative (Polynomial.X ^ (n + 1) : Polynomial ℝ) =
         Polynomial.C (↑(n + 1) : ℝ) * Polynomial.X ^ n := by
-      simp [Polynomial.derivative_X_pow, Nat.add_sub_cancel]
+      simp [Polynomial.derivative_X_pow]
     simp only [Polynomial.derivative_sub, Polynomial.derivative_mul, Polynomial.derivative_C,
                zero_mul, zero_add, hd_pow]
     linear_combination -Polynomial.C (↑(n + 1) : ℝ) * hQn

--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -316,7 +316,7 @@ theorem risch_ode_coeff_top (p : Polynomial ℝ) :
   have h0 : p.coeff (p.natDegree + 2) = 0 :=
     Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
   push_cast
-  rw [h0, mul_zero, zero_sub]
+  rw [h0, zero_mul, zero_sub]
   simp only [Polynomial.leadingCoeff]
   ring
 

--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -342,7 +342,7 @@ theorem no_poly_risch_soln :
   by_cases hp : p = 0
   · simp [hp] at h
   · have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
-    have hcoeff := congr_arg (fun q : Polynomial ℝ => q.coeff (p.natDegree + 1)) h
+    have hcoeff := Polynomial.ext_iff.mp h (p.natDegree + 1)
     rw [risch_ode_coeff_top, poly_one_coeff_pos _ (by omega)] at hcoeff
     exact absurd hcoeff (mul_ne_zero (by norm_num) hlc)
 
@@ -356,7 +356,7 @@ theorem no_poly_risch_constant (c : ℝ) (hc : c ≠ 0) :
   · simp [hp] at h
     exact hc (Polynomial.C_eq_zero.mp h.symm)
   · have hlc : p.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hp
-    have hcoeff := congr_arg (fun q : Polynomial ℝ => q.coeff (p.natDegree + 1)) h
+    have hcoeff := Polynomial.ext_iff.mp h (p.natDegree + 1)
     rw [risch_ode_coeff_top] at hcoeff
     simp only [Polynomial.coeff_C, Nat.succ_ne_zero, ↓reduceIte] at hcoeff
     exact absurd hcoeff (mul_ne_zero (by norm_num) hlc)
@@ -501,7 +501,8 @@ theorem risch_linear_surjective_all (p : Polynomial ℝ) :
   | monomial n a =>
     obtain ⟨Qn, hQn⟩ := risch_linear_surjective_monomial n
     refine ⟨Polynomial.C a * Qn, ?_⟩
-    simp only [Polynomial.derivative_mul, Polynomial.derivative_C, zero_mul, zero_add]
+    simp only [Polynomial.derivative_mul, Polynomial.derivative_C, zero_mul, zero_add,
+               Polynomial.monomial_eq_C_mul_X]
     linear_combination Polynomial.C a * hQn
 
 /-! ══════════════════════════════════════════════════════════════════

--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -492,13 +492,13 @@ theorem risch_linear_surjective_monomial (n : ℕ) :
 theorem risch_linear_surjective_all (p : Polynomial ℝ) :
     ∃ Q : Polynomial ℝ, Polynomial.derivative Q + Q = p := by
   induction p using Polynomial.induction_on' with
-  | h_add p q hp hq =>
+  | add p q hp hq =>
     obtain ⟨Qp, hQp⟩ := hp
     obtain ⟨Qq, hQq⟩ := hq
     exact ⟨Qp + Qq, by
       simp only [Polynomial.derivative_add]
       linear_combination hQp + hQq⟩
-  | h_monomial n a =>
+  | monomial n a =>
     obtain ⟨Qn, hQn⟩ := risch_linear_surjective_monomial n
     refine ⟨Polynomial.C a * Qn, ?_⟩
     simp only [Polynomial.derivative_mul, Polynomial.derivative_C, zero_mul, zero_add]

--- a/proofs/Proofs/AbelRuffiniOQ09.lean
+++ b/proofs/Proofs/AbelRuffiniOQ09.lean
@@ -3,6 +3,7 @@ import Mathlib.Algebra.Polynomial.Basic
 import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Analysis.Calculus.Deriv.Polynomial
 import Mathlib.Tactic
 
 /-!
@@ -51,10 +52,9 @@ The operator L₁[Q] = Q' + Q preserves degree (unlike L₂[Q] = Q' - 2xQ which 
 
 ## Status
 
-- **Axiom count**: 3 (liouville_integration_theorem, risch_exp_criterion_gaussian,
-  gaussian_not_elementary)
+- **Axiom count**: 2 (liouville_integration_theorem, risch_exp_criterion_gaussian)
 - **Sorry count**: 0
-- **Theorems proved**: 16
+- **Theorems proved**: 21 (including gaussian_not_elementary, proved from polynomial degree obstruction)
 
 ## References
 
@@ -163,7 +163,7 @@ axiom liouville_integration_theorem
         IsLiouvilleForm g v₀ c v  -- g = v₀ + Σ cᵢ · ln(vᵢ) in the logarithmic extension
 
 /-! ══════════════════════════════════════════════════════════════════
-## Part III: Risch Criterion and Gaussian Non-Elementarity (Axioms)
+## Part III: Risch Criterion and Gaussian Non-Elementarity
 ══════════════════════════════════════════════════════════════════ -/
 
 /-- **Risch Criterion for ∫e^(-x²)dx**:
@@ -182,17 +182,107 @@ axiom risch_exp_criterion_gaussian :
     ∃ (F : ℝ → ℝ),
       (∀ x : ℝ, HasDerivAt F (Real.exp (-(x^2))) x) ∧ IsElementaryFn F
 
+/-- The Risch operator L[h] = h' - C(2)·X·h. -/
+private def rischOp (h : Polynomial ℝ) : Polynomial ℝ :=
+  Polynomial.derivative h - Polynomial.C 2 * (Polynomial.X * h)
+
+/-- Iterating L raises degree, so L^n(g) ≠ 0 whenever g ≠ 0. -/
+private lemma rischOp_iter_ne_zero (g : Polynomial ℝ) (hg : g ≠ 0) :
+    ∀ n : ℕ, rischOp^[n] g ≠ 0 := by
+  intro n
+  induction n with
+  | zero => simpa
+  | succ n ih =>
+    simp only [Function.iterate_succ_apply']
+    intro heq
+    have hdeg := risch_ode_raises_degree (rischOp^[n] g) ih
+    unfold rischOp at heq
+    rw [heq, Polynomial.natDegree_zero] at hdeg
+    exact Nat.not_lt_zero _ hdeg
+
+/-- HasDerivAt for h(t)·exp(-t²): derivative is L[h](x)·exp(-x²). -/
+private lemma hasDerivAt_mul_gauss (h : Polynomial ℝ) (x : ℝ) :
+    HasDerivAt (fun t => h.eval t * Real.exp (-(t ^ 2)))
+      ((rischOp h).eval x * Real.exp (-(x ^ 2))) x := by
+  have h1 : HasDerivAt (fun t => h.eval t) (h.derivative.eval x) x := h.hasDerivAt x
+  have hg : HasDerivAt (fun t : ℝ => -(t ^ 2)) (-2 * x) x := by
+    have h' := (hasDerivAt_pow 2 x).neg
+    simp only [Nat.cast_ofNat] at h'
+    have heq : -(2 * x ^ (2 - 1)) = -2 * x := by norm_num
+    rwa [heq] at h'
+  have h2 : HasDerivAt (fun t => Real.exp (-(t ^ 2)))
+      (Real.exp (-(x ^ 2)) * (-2 * x)) x :=
+    (Real.hasDerivAt_exp _).comp x hg
+  have h3 := h1.mul h2
+  convert h3 using 1
+  unfold rischOp
+  simp only [Polynomial.eval_sub, Polynomial.eval_mul, Polynomial.eval_C, Polynomial.eval_X]
+  ring
+
+/-- The n-th real derivative of (f.eval) equals (L^n g).eval · exp(-·²)
+    whenever f.eval = g.eval · exp(-·²) pointwise. -/
+private lemma risch_iterate_eq (f g : Polynomial ℝ)
+    (h0 : ∀ x : ℝ, f.eval x = g.eval x * Real.exp (-(x ^ 2))) (n : ℕ) :
+    ∀ x : ℝ, (Polynomial.derivative^[n] f).eval x =
+              (rischOp^[n] g).eval x * Real.exp (-(x ^ 2)) := by
+  induction n with
+  | zero => simpa
+  | succ n ih =>
+    intro x
+    have hLHS : HasDerivAt (fun t => (Polynomial.derivative^[n] f).eval t)
+        ((Polynomial.derivative (Polynomial.derivative^[n] f)).eval x) x :=
+      (Polynomial.derivative^[n] f).hasDerivAt x
+    have hRHS : HasDerivAt (fun t => (rischOp^[n] g).eval t * Real.exp (-(t ^ 2)))
+        ((rischOp (rischOp^[n] g)).eval x * Real.exp (-(x ^ 2))) x :=
+      hasDerivAt_mul_gauss (rischOp^[n] g) x
+    have heq_fn : (fun t => (Polynomial.derivative^[n] f).eval t) =
+                  (fun t => (rischOp^[n] g).eval t * Real.exp (-(t ^ 2))) :=
+      funext ih
+    rw [heq_fn] at hLHS
+    have huniq := HasDerivAt.unique hLHS hRHS
+    rw [Function.iterate_succ_apply' Polynomial.derivative n f,
+        Function.iterate_succ_apply' rischOp n g]
+    exact huniq
+
 /-- **Gaussian integral is not elementary** (Liouville 1835).
     The antiderivative of e^(-x²) cannot be expressed as a rational function.
 
-    Proof sketch: Risch criterion reduces to finding rational Q with Q' - 2xQ = 1.
-    The polynomial obstruction (no_poly_risch_soln) handles polynomial Q.
-    Rational Q is axiomatized: partial fractions show poles of Q' and 2xQ
-    cannot cancel except when Q is polynomial, reducing to the proved case. -/
-axiom gaussian_not_elementary :
+    **Proof**: If d/dx[p(x)/q(x)] = e^(-x²) with q never vanishing, the quotient
+    rule gives f(x) = g(x)·e^(-x²) where f = p'q - pq' and g = q². The iterated
+    Risch operator L[h] = h' - 2xh satisfies d/dx[h·e^(-x²)] = L[h]·e^(-x²),
+    so differentiating n = deg(f)+1 times yields 0 = L^n(g)·e^(-x²). Since
+    e^(-x²) > 0 and L raises degree (so L^n(g) ≠ 0), this is a contradiction. -/
+theorem gaussian_not_elementary :
     ¬∃ (p q : Polynomial ℝ),
       (∀ x : ℝ, q.eval x ≠ 0) ∧
-      ∀ x : ℝ, HasDerivAt (fun t => p.eval t / q.eval t) (Real.exp (-(x^2))) x
+      ∀ x : ℝ, HasDerivAt (fun t => p.eval t / q.eval t) (Real.exp (-(x^2))) x := by
+  rintro ⟨p, q, hq, hderiv⟩
+  have hq_ne : q ≠ 0 := by intro h; simp [h] at hq
+  set f := Polynomial.derivative p * q - p * Polynomial.derivative q with hf_def
+  set g := q ^ 2 with hg_def
+  have hg_ne : g ≠ 0 := pow_ne_zero _ hq_ne
+  have hfg : ∀ x : ℝ, f.eval x = g.eval x * Real.exp (-(x ^ 2)) := by
+    intro x
+    have hdiv : HasDerivAt (fun t => p.eval t / q.eval t)
+        (((Polynomial.derivative p).eval x * q.eval x -
+          p.eval x * (Polynomial.derivative q).eval x) / q.eval x ^ 2) x :=
+      (p.hasDerivAt x).div (q.hasDerivAt x) (hq x)
+    have heq := HasDerivAt.unique hdiv (hderiv x)
+    have hqne : q.eval x ^ 2 ≠ 0 := pow_ne_zero _ (hq x)
+    rw [div_eq_iff hqne] at heq
+    simp only [hf_def, hg_def, Polynomial.eval_sub, Polynomial.eval_mul, Polynomial.eval_pow]
+    linear_combination heq
+  set n := f.natDegree + 1 with hn_def
+  have hzero : Polynomial.derivative^[n] f = 0 :=
+    Polynomial.iterate_derivative_eq_zero (Nat.lt_succ_self _)
+  have hiter := risch_iterate_eq f g hfg n
+  have hne : rischOp^[n] g ≠ 0 := rischOp_iter_ne_zero g hg_ne n
+  have hall : ∀ x : ℝ, (rischOp^[n] g).eval x = 0 := by
+    intro x
+    have := hiter x
+    rw [hzero, Polynomial.eval_zero] at this
+    exact (mul_eq_zero.mp this.symm).resolve_right (Real.exp_pos _).ne'
+  exact hne (Polynomial.funext hall)
 
 /-! ══════════════════════════════════════════════════════════════════
 ## Part IV: The Core Algebraic Proof — No Polynomial Risch Solution

--- a/src/data/proofs/abel-ruffini-oq-09/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-09/meta.json
@@ -19,11 +19,11 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
-    "theoremCount": 20,
-    "assumptions": "3 axioms: liouville_integration_theorem (structural form of elementary antiderivatives requires differential Galois/Picard-Vessiot theory not in Mathlib), risch_exp_criterion_gaussian (Risch criterion: ∫e^(-x²)dx elementary iff rational Q with Q'-2xQ=1; requires partial fraction analysis), gaussian_not_elementary (∫e^(-x²) has no elementary antiderivative expressible as a rational function; the main theorem). The polynomial obstruction (no polynomial p satisfies p'-2xp=1) is fully proved without axioms.",
+    "axiomCount": 2,
+    "theoremCount": 21,
+    "assumptions": "2 axioms: liouville_integration_theorem (structural form of elementary antiderivatives requires differential Galois/Picard-Vessiot theory not in Mathlib), risch_exp_criterion_gaussian (Risch criterion: ∫e^(-x²)dx elementary iff rational Q with Q'-2xQ=1; requires partial fraction analysis and extension from polynomial to rational case). The Gaussian non-elementarity (gaussian_not_elementary) is now fully proved as a theorem via the iterated Risch operator degree-raising argument.",
     "dateAdded": "2026-05-03",
-    "lineCount": 448,
+    "lineCount": 540,
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "risch_ode_coeff_top: coefficient identity showing L[p] = p'-C(2)·X·p has coefficient -2·leadingCoeff(p) at degree natDeg(p)+1 — the key lemma driving the degree-raising argument",
@@ -33,7 +33,8 @@
       "gaussian_vs_linear_contrast: side-by-side comparison of degree-raising (L₂: Gaussian) vs degree-preserving (L₁: linear exponent) operators, with explicit solutions for the elementary case",
       "DiffField typeclass: basic differential field infrastructure with proved constants_zero/one/add/mul and deriv_neg/sub",
       "risch_linear_surjective_monomial: L₁[Q]=Q'+Q is surjective onto every monomial X^n — proved by induction using recurrence Q_{n+1}=X^{n+1}-C(n+1)·Q_n",
-      "risch_linear_surjective_all: L₁ is surjective onto ALL polynomials — proved by linearity (Polynomial.induction_on') using monomial surjectivity"
+      "risch_linear_surjective_all: L₁ is surjective onto ALL polynomials — proved by linearity (Polynomial.induction_on') using monomial surjectivity",
+      "gaussian_not_elementary: fully machine-checked proof that ∫e^(-x²)dx has no elementary antiderivative expressible as a rational function p(x)/q(x). Proof: quotient rule gives f=g·e^(-x²) with f=p'q-pq', g=q²; iterated Risch operator L^n(g)·e^(-x²)=0 (from iterate_derivative_eq_zero); since e^(-x²)>0 and L raises degree (L^n(g)≠0), contradiction. Reduces gaussian_not_elementary from axiom to theorem."
     ],
     "mathlibDependencies": [
       {
@@ -198,10 +199,10 @@
       "Real"
     ],
     "namespace": "AbelRuffiniOQ09",
-    "lineCount": 448,
-    "axiomCount": 3,
-    "theoremCount": 20,
-    "definitionCount": 2,
+    "lineCount": 540,
+    "axiomCount": 2,
+    "theoremCount": 21,
+    "definitionCount": 3,
     "path": "Proofs/AbelRuffiniOQ09.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/abel-ruffini-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-09.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 20 theorems (was 18). Added risch_linear_surjective_monomial and risch_linear_surjective_all: L₁ is surjective onto all polynomials, completing the L₁/L₂ contrast. 3 axioms, 0 sorries, 435 lines.",
+    "progressSummary": "COMPLETE: axioms reduced 3→2, gaussian_not_elementary proved as theorem, all API drift fixed, Docker build passes",
     "builtItems": [
       "DiffField typeclass: field with derivation (2 axioms: additivity + Leibniz). File: Proofs/AbelRuffiniOQ09.lean:79",
       "constants_zero/one/add/mul: constants form a subfield. Lines 90-113",
@@ -43,7 +43,8 @@
       "gaussian_vs_linear_contrast: conjunction packaging the L₁ vs L₂ dichotomy. Line 341",
       "Gallery entry: src/data/proofs/abel-ruffini-oq-09/ (meta.json, annotations.json, index.ts, tacticStates.json)",
       "risch_linear_surjective_monomial: L₁[Q]=Q'+Q surjective onto X^n via induction with recurrence Q_{n+1}=X^{n+1}-C(n+1)·Q_n [AbelRuffiniOQ09.lean:372]",
-      "risch_linear_surjective_all: L₁ surjective onto all polynomials by Polynomial.induction_on' + linearity [AbelRuffiniOQ09.lean:389]"
+      "risch_linear_surjective_all: L₁ surjective onto all polynomials by Polynomial.induction_on' + linearity [AbelRuffiniOQ09.lean:389]",
+      "rischOp def + rischOp_iter_ne_zero + hasDerivAt_mul_gauss + risch_iterate_eq + gaussian_not_elementary theorem in AbelRuffiniOQ09.lean:276-375"
     ],
     "insights": [
       "The operator L[p] = p' - C(2)·X·p raises polynomial degree by exactly 1 for any nonzero p (L is degree-raising), so its image consists only of polynomials of degree ≥ 1, excluding all nonzero constants",
@@ -52,7 +53,9 @@
       "Polynomial.funext allows converting pointwise ODE equalities to polynomial ring equalities, using ℝ being an infinite integral domain",
       "Mathlib has no Picard-Vessiot / differential Galois theory, requiring 3 axioms: Liouville structure theorem, Risch criterion, and Gaussian non-elementarity",
       "The Abel-Ruffini/Liouville analogy is structural: A₅ simplicity (algebraic Galois) corresponds to degree-raising of L₂ (differential Galois) — both witness obstruction to expressibility in prescribed form",
-      "L₁[Q]=Q'+Q is surjective onto ALL polynomials: proved by induction Q_{n+1}=X^{n+1}-C(n+1)·Q_n and linearity. Completes the contrast: L₁ onto everything, L₂ onto nothing nonzero-constant."
+      "L₁[Q]=Q'+Q is surjective onto ALL polynomials: proved by induction Q_{n+1}=X^{n+1}-C(n+1)·Q_n and linearity. Completes the contrast: L₁ onto everything, L₂ onto nothing nonzero-constant.",
+      "gaussian_not_elementary proved as a theorem (not axiom) via iterated Risch operator: L^n(g)·exp(-x²)=0 forces L^n(g)=0 by exp_pos, but rischOp_iter_ne_zero shows L^n(g)≠0 for g=q²≠0",
+      "Key API drift fixes needed: Polynomial.induction_on' case names h_add→add, h_monomial→monomial; push_cast mul_zero→zero_mul; congr_arg lambda→Polynomial.ext_iff.mp; Polynomial.monomial_eq_C_mul_X→C_mul_X_pow_eq_monomial; linarith fails on abstract DiffField type, use linear_combination instead"
     ],
     "mathlibGaps": [
       "Mathlib has no Picard-Vessiot theory (Picard-Vessiot extensions, differential Galois groups) — estimated >1000 lines to formalize the Liouville structure theorem",


### PR DESCRIPTION
## Summary

- Converts `gaussian_not_elementary` from an axiom to a fully machine-checked Lean 4 theorem
- Reduces axiom count from 3 to 2 (only `liouville_integration_theorem` and `risch_exp_criterion_gaussian` remain as axioms)
- Also fixes pre-existing Mathlib API drift bugs that prevented the original file from building

## Mathematical Proof

If d/dx[p(x)/q(x)] = e^(-x²) with q(x) never vanishing, the quotient rule gives:
```
f(x) = g(x)·e^(-x²)   where f = p'q - pq',  g = q²
```
The Risch operator L[h] = h' - 2xh satisfies d/dx[h·e^(-x²)] = L[h]·e^(-x²), so differentiating n = deg(f)+1 times yields 0 = L^n(g)·e^(-x²). Since e^(-x²) > 0 everywhere (Real.exp_pos) and L strictly raises polynomial degree (risch_ode_raises_degree), L^n(g) ≠ 0 — contradiction.

## New Lean Code

- `rischOp`: private def of L[h] = h' - C(2)·X·h
- `rischOp_iter_ne_zero`: L^n(g) ≠ 0 whenever g ≠ 0 (induction + degree-raising)
- `hasDerivAt_mul_gauss`: HasDerivAt for h(t)·exp(-t²), derivative = L[h](x)·exp(-x²)
- `risch_iterate_eq`: (D^n f)(x) = (L^n g)(x)·exp(-x²) whenever f = g·exp(-x²) pointwise
- `gaussian_not_elementary`: the main theorem (was axiom)

## API Drift Fixes

The original file had pre-existing Mathlib API drift bugs (now also fixed):
- `Polynomial.induction_on'` case names `h_add`→`add`, `h_monomial`→`monomial`
- `push_cast` + `mul_zero`→`zero_mul` (coeff ordering changed)
- `congr_arg` lambda not beta-reduced for `rw` → `Polynomial.ext_iff.mp`
- `Polynomial.monomial_eq_C_mul_X` (wrong name) → `← Polynomial.C_mul_X_pow_eq_monomial`
- `linarith` on abstract `DiffField` type → `linear_combination`

## Test plan

- [x] Docker build `Proofs.AbelRuffiniOQ09` passes (0 errors, 0 sorries)
- [x] `meta.json` updated: axiomCount 3→2, theoremCount 20→21, lineCount 448→540
- [x] `research/problems/abel-ruffini-oq-09.json` updated with COMPLETE status

🤖 Generated with [Claude Code](https://claude.com/claude-code)