### PR TITLE
fix(meta): sync stale lineCount and add missing sorryCount/lineCount

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -44,6 +44,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 12,
+    "lineCount": 150,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The import chain includes AngleTrisection.lean (1 axiom for π transcendence, used only for the circle-squaring result) but none of the theorems in this file depend on that axiom.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -132,6 +132,7 @@
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
+    "sorryCount": 3,
     "mainTheorems": [
       {
         "name": "mem_spanningSets_eventually",

--- a/src/data/proofs/pac-learning-bounds-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01-oq-01/meta.json
@@ -60,7 +60,7 @@
       "pac-learning-bounds-oq-01 (threshold classifiers, VC dim 1)"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 148,
+    "lineCount": 162,
     "relatedProblems": [
       {
         "id": "pac-learning-bounds-oq-01",
@@ -195,7 +195,7 @@
       "Finset"
     ],
     "namespace": "LearningTheory.VCDimension",
-    "lineCount": 158,
+    "lineCount": 162,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Three meta.json fixes for stale or missing count fields:

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| `angle-trisection-oq-03-oq-01` | `meta.lineCount` | missing | 150 (matches leanFile.lineCount and actual file) |
| `pac-learning-bounds-oq-01-oq-01` | `meta.lineCount` | 148 | 162 (actual file size) |
| `pac-learning-bounds-oq-01-oq-01` | `leanFile.lineCount` | 158 | 162 (actual file size) |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` | `leanFile.sorryCount` | missing | 3 (meta.sorries already correct) |

## Evidence

- `angle-trisection-oq-03-oq-01`: leanFile.lineCount=150, actual file=150 lines; meta.lineCount key absent
- `pac-learning-bounds-oq-01-oq-01`: `wc -l Proofs/PACLearningOQ01OQ01.lean` = 162; both meta (148) and leanFile (158) stale from earlier edits
- `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01`: meta.sorries=3 correct; leanFile.sorryCount key absent (informational field)

---
Automated fix by lean-mechanic agent.