### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-02-incomplete-01): add Galois infrastructure theorems (Session 37)

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -40,6 +40,13 @@ Previously resolved:
 - `isConstructible_map`: IsConstructible preserved under ℚ-algebra endomorphisms of ℂ.
   Key infrastructure for wantzel_galois_iff → direction.
 
+## New Lemmas (Session 37)
+
+- `isConstructible_minpoly_pow2`: IsConstructible α → ∃ m, natDeg(minpoly ℚ α) = 2^m.
+  Clean consequence of isConstructible_algebraic_degree + adjoin.finrank.
+- `isConstructible_irred_degree_pow2`: For p irreducible with constructible root α,
+  natDeg p = 2^m for some m. Positive form of not_constructible_of_bad_degree.
+
 ## Status: 1 sorry (wantzel_galois_iff, out-of-scope Galois), 0 axioms
 -/
 
@@ -617,7 +624,57 @@ theorem regular_7gon_construction_impossible :
   regular_7gon_impossible_degree
 
 -- ============================================================
--- PART 8: Galois Characterization (SORRY — needs full Galois theory)
+-- PART 8: Galois Infrastructure (PROVED)
+-- ============================================================
+
+/-- A constructible number has a minimal polynomial whose degree is a power of 2.
+
+    **Proof**: From `isConstructible_algebraic_degree`, finrank ℚ ℚ⟮α⟯ ∣ 2^n.
+    Since finrank ℚ ℚ⟮α⟯ = natDegree (minpoly ℚ α) (by adjoin.finrank),
+    and any divisor of 2^n is a power of 2, we get natDegree = 2^m. -/
+theorem isConstructible_minpoly_pow2 (α : ℂ) (h : IsConstructible α) :
+    ∃ m : ℕ, (minpoly ℚ α).natDegree = 2 ^ m := by
+  obtain ⟨halg, n, hdvd⟩ := isConstructible_algebraic_degree α h
+  have hint : IsIntegral ℚ α := isAlgebraic_iff_isIntegral.mp halg
+  rw [← IntermediateField.adjoin.finrank hint]
+  obtain ⟨m, _, hm⟩ := (Nat.dvd_prime_pow (by norm_num : Nat.Prime 2)).mp hdvd
+  exact ⟨m, hm⟩
+
+/-- If p is irreducible over ℚ, α is a root of p in ℂ, and α is constructible,
+    then natDegree p is a power of 2.
+
+    **Proof**: natDeg p = natDeg (minpoly ℚ α) (by irreducibility + minpoly | p)
+    = finrank ℚ ℚ⟮α⟯ (by adjoin.finrank), which divides 2^n by
+    `isConstructible_algebraic_degree`. Hence natDeg p = 2^m for some m.
+
+    This is the positive form of `not_constructible_of_bad_degree`:
+    constructibility forces natDeg p to be a power of 2. -/
+theorem isConstructible_irred_degree_pow2 {p : ℚ[X]} (hp : Irreducible p)
+    (α : ℂ) (hpα : Polynomial.aeval α p = 0) (hcα : IsConstructible α) :
+    ∃ m : ℕ, p.natDegree = 2 ^ m := by
+  obtain ⟨halg, n, hn_dvd⟩ := isConstructible_algebraic_degree α hcα
+  have hint : IsIntegral ℚ α := isAlgebraic_iff_isIntegral.mp halg
+  have hmind : (minpoly ℚ α).natDegree = Module.finrank ℚ ↥ℚ⟮α⟯ :=
+    (IntermediateField.adjoin.finrank hint).symm
+  rw [← hmind] at hn_dvd
+  have hdvd : minpoly ℚ α ∣ p := minpoly.dvd ℚ α hpα
+  obtain ⟨c, hc⟩ := hdvd
+  rcases hp.isUnit_or_isUnit hc with h1 | h2
+  · have hunit_zero : (minpoly ℚ α).natDegree = 0 :=
+      Polynomial.natDegree_eq_zero_of_isUnit h1
+    rw [hunit_zero] at hn_dvd
+    exact absurd (Nat.zero_dvd.mp hn_dvd) (Nat.two_pow_pos n).ne'
+  · have hc_deg : c.natDegree = 0 := Polynomial.natDegree_eq_zero_of_isUnit h2
+    have hne : minpoly ℚ α ≠ 0 := minpoly.ne_zero hint
+    have hcne : c ≠ 0 := IsUnit.ne_zero h2
+    have hp_eq : p.natDegree = (minpoly ℚ α).natDegree := by
+      rw [hc, Polynomial.natDegree_mul hne hcne, hc_deg, add_zero]
+    rw [hp_eq]
+    obtain ⟨m, _, hm⟩ := (Nat.dvd_prime_pow (by norm_num : Nat.Prime 2)).mp hn_dvd
+    exact ⟨m, hm⟩
+
+-- ============================================================
+-- PART 9: Galois Characterization (SORRY — needs full Galois theory)
 -- ============================================================
 
 /-- A finite group is a 2-group iff its order is a power of 2. -/

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
@@ -390,3 +390,37 @@ Per project memory `project_mathlib_api_drift_2026_04`, this drift hits a cohort
 1. → direction: Prove `isConstructible_map_algHom` variant for splitting field embeddings using IsAlgClosed.lift
 2. Then prove "all roots of p constructible" and tower argument for finrank
 3. ← direction requires FTGT composition series (much harder, requires Sylow + IntermediateField correspondence)
+
+## Session 2026-05-03 (Session 37) - Galois Infrastructure: minpoly and irred degree theorems
+
+**Mode**: REVISIT
+**Outcome**: progress — two new proved theorems; key building blocks for wantzel_galois_iff → direction
+
+### What I Did
+- Proved `isConstructible_minpoly_pow2`: ∀ (α : ℂ), IsConstructible α → ∃ m, (minpoly ℚ α).natDegree = 2^m
+  - Proof: `isConstructible_algebraic_degree` gives `finrank ℚ ℚ⟮α⟯ ∣ 2^n`; by `IntermediateField.adjoin.finrank` this equals `(minpoly ℚ α).natDegree`; `Nat.dvd_prime_pow` gives the 2-power form
+  - ~7 lines
+- Proved `isConstructible_irred_degree_pow2`: ∀ {p} (hp : Irreducible p) (α : ℂ), aeval α p = 0 → IsConstructible α → ∃ m, p.natDegree = 2^m
+  - Proof: minpoly.dvd gives minpoly ∣ p; hp.isUnit_or_isUnit rules out both unit cases; when minpoly is the unit, degree = 0 contradicts being a divisor of 2^n; when c is the unit, p.natDegree = minpoly.natDegree (c has degree 0), then apply 2-power conclusion
+  - ~23 lines
+- Updated meta.json: theoremCount 22→24, lineCount 658→715, date 2026-04-26→2026-05-03, added galois-infrastructure section
+- Ran Docker build to verify compilation
+
+### Key Findings
+- **isConstructible_irred_degree_pow2 vs not_constructible_of_bad_degree**: These are dual forms of the same fact. `not_constructible_of_bad_degree` says "natDeg p ≠ 2^k → ¬IsConstructible". The new theorem says "IsConstructible → natDeg p = 2^k". The positive form is cleaner for the → direction of wantzel_galois_iff.
+- **Lean pattern**: `rcases hp.isUnit_or_isUnit hc with h1 | h2` where hc : minpoly ∣ p (written p = minpoly * c). When minpoly is unit: `Polynomial.natDegree_eq_zero_of_isUnit h1` gives degree 0; contradiction via `Nat.zero_dvd + Nat.two_pow_pos`. When c is unit: same lemma gives c.natDegree = 0; then `Polynomial.natDegree_mul + add_zero` gives p.natDegree = minpoly.natDegree.
+- **IsAlgClosed.lift gap**: The → direction of wantzel_galois_iff still needs to extend ℚ(α)→ℂ (sending α↦β) to a full ℂ→ℂ map. `IsAlgClosed.lift` only works for algebraic fields; ℂ is not algebraic over ℚ. This gap remains the fundamental obstacle.
+- **Nat.dvd_prime_pow pattern**: `(Nat.dvd_prime_pow hprime).mp hdvd` gives `⟨m, _, hm⟩` where `hm : n = p^m`. Works for any prime, including p=2 with `by norm_num`.
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` — two new theorems (lines 626-675)
+- `src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json` — counts updated, new section added
+
+### Current Sorries (1 total)
+1. **wantzel_galois_iff** (line ~713): Full Galois theory — requires FTGT + IsAlgClosed extension (Zorn's lemma infrastructure)
+
+### Next Steps
+1. → direction intermediate goal: Prove that for β another root of p, there exists σ : ℂ →ₐ[ℚ] ℂ with σ(α) = β — needs ℂ endomorphism extension, not just ℚ(α)→ℂ lift
+2. Consider whether `algClosure.lift` (for algebraic closures) provides the missing bridge
+3. ← direction: FTGT + Sylow composition series; requires IntermediateField.orderIsoOfGal and degree-2 extension ↔ adjoin √ characterization
+4. If → direction proves infeasible, mark wantzel_galois_iff as long-term blocked (500+ lines, Zorn + FTGT)

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -2,11 +2,11 @@
   "id": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
   "title": "Completing the Wantzel-Galois Constructibility Proof",
   "slug": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
-  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext) to enable proper tower induction. Proves isConstructible_sqrt2, all concrete impossibility results (angle trisection, cube doubling, regular 7-gon). 1 sorry: wantzel_galois_iff (requires FTGT, out-of-scope). New: isConstructible_map (Galois invariance). New: isConstructible_map (Galois invariance). Tower degree theorem fully proved via stronger relative IH isConstructible_sup_degree.",
+  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext) to enable proper tower induction. Proves isConstructible_sqrt2, all concrete impossibility results (angle trisection, cube doubling, regular 7-gon). 1 sorry: wantzel_galois_iff (requires FTGT, out-of-scope). New (s36): isConstructible_map (Galois invariance). New (s37): isConstructible_minpoly_pow2, isConstructible_irred_degree_pow2 (positive form of degree criterion). Tower degree theorem fully proved via stronger relative IH isConstructible_sup_degree.",
   "meta": {
     "author": "Wantzel (1837), completion formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Straightedge_and_compass_construction",
-    "date": "2026-04-26",
+    "date": "2026-05-03",
     "status": "formalized",
     "tags": [
       "geometry",
@@ -19,8 +19,8 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "theoremCount": 22,
-    "lineCount": 658,
+    "theoremCount": 24,
+    "lineCount": 715,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -95,11 +95,18 @@
       "summary": "Derives not_constructible_of_bad_degree via tower degree theorem. Applies to prove angle_trisection_impossible_degree, doubling_cube_impossible_degree, regular_7gon_construction_impossible."
     },
     {
+      "id": "galois-infrastructure",
+      "title": "Galois Infrastructure (PROVED)",
+      "startLine": 626,
+      "endLine": 675,
+      "summary": "Two proved theorems: isConstructible_minpoly_pow2 (any constructible α has minpoly degree = 2^m) and isConstructible_irred_degree_pow2 (positive form: if p irreducible, α root, α constructible, then natDeg p = 2^m). Both use Nat.dvd_prime_pow + IntermediateField.adjoin.finrank."
+    },
+    {
       "id": "galois-sorry",
       "title": "Galois Characterization (SORRY)",
-      "startLine": 613,
-      "endLine": 625,
-      "summary": "States wantzel_galois_iff: α constructible ↔ Gal(minpoly(ℚ,α)) is a 2-group. Sorry remains; requires full FTGT + 500+ lines new infrastructure."
+      "startLine": 676,
+      "endLine": 714,
+      "summary": "States wantzel_galois_iff: α constructible ↔ Gal(minpoly(ℚ,α)) is a 2-group. Sorry remains; requires full FTGT + 500+ lines new infrastructure. Documents → and ← proof strategies and key Lean gaps."
     }
   ],
   "conclusion": {
@@ -136,9 +143,9 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 658,
+    "lineCount": 715,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 24,
     "definitionCount": 2,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "sorries": 1

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
@@ -51,7 +51,9 @@
       "Session 32 PR #15034: 4 API drift fixes applied to AngleTrisectionOQ02OQ01OQ02Incomplete01.lean, file compiles",
       "finrank_adjoin_β_over_adjoin_a_dvd_two: PROVED by Aristotle job 594e3160 (2026-05-03)",
       "h_top_Ka full proof attempt in AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:182 (Session 34, unverified)",
-      "isConstructible_map: ∀ (σ : ℂ →ₐ[ℚ] ℂ), IsConstructible α → IsConstructible (σ α). Proved by induction. (AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:114-124)"
+      "isConstructible_map: ∀ (σ : ℂ →ₐ[ℚ] ℂ), IsConstructible α → IsConstructible (σ α). Proved by induction. (AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:114-124)",
+      "isConstructible_minpoly_pow2: ∃ m, (minpoly ℚ α).natDegree = 2^m (line 635, Session 37)",
+      "isConstructible_irred_degree_pow2: p irred + α root + IsConstructible α → ∃ m, p.natDegree = 2^m (line 652, Session 37)"
     ],
     "insights": [
       "IsConstructible with existential sqrt_ext blocks induction — must make a,b explicit constructor params to get proper IHs",
@@ -80,7 +82,10 @@
       "restrict_algEquiv bridge: IntermediateField.restrict h converts K_a:IntermediateField ℚ ℂ into K_a_im:IntermediateField ℚ ↥K_aβ, enabling restrictScalars_adjoin_of_algEquiv to switch scalar field",
       "Aristotle finrank strategy: tower law + minpoly ℚ β ∣ (minpoly ℚ a).comp(X²) + interval_cases proves finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2",
       "h_top_Ka proved via IntermediateField.restrict + restrict_algEquiv + restrictScalars_adjoin_of_algEquiv + lift_injective pattern (Session 34, PR #15128)",
-      "Session 36: isConstructible_map: IsConstructible preserved by ℚ-algebra maps ℂ→ℂ (induction on sqrt_ext: σ(β·β)=σ(a) gives sqrt_ext (σβ) (σa) (σb)). Key for wantzel_galois_iff → direction."
+      "Session 36: isConstructible_map: IsConstructible preserved by ℚ-algebra maps ℂ→ℂ (induction on sqrt_ext: σ(β·β)=σ(a) gives sqrt_ext (σβ) (σa) (σb)). Key for wantzel_galois_iff → direction.",
+      "isConstructible_irred_degree_pow2 is the positive form of not_constructible_of_bad_degree: constructibility forces natDeg p to be a power of 2",
+      "IsAlgClosed.lift gap: extending ℚ(α)→ℂ maps to ℂ→ℂ endomorphisms requires Zorns lemma infrastructure not available in Mathlib for this purpose",
+      "Nat.dvd_prime_pow pattern: (Nat.dvd_prime_pow hprime).mp hdvd gives ⟨m, _, hm⟩ extracting 2-power witnesses"
     ],
     "mathlibGaps": [
       "isConstructible_algebraic_degree: tower degree induction — IsConstructible α → IsAlgebraic ℚ α ∧ ∃ n, finrank ℚ ℚ⟮α⟯ = 2^n. Needs FiniteDimensional.finrank_mul_finrank + IntermediateField tower lemmas. Estimated ~120 lines.",
@@ -88,9 +93,9 @@
       "finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2 requires showing βelement generates ↥ℚ⟮β⟯ over ↥ℚ⟮a⟯ (adjoin = top in IntermediateField ↥ℚ⟮a⟯ ↥ℚ⟮β⟯)"
     ],
     "nextSteps": [
-      "wantzel_galois_iff → direction: All roots of p in ℂ are constructible via isConstructible_map + IsAlgClosed.lift extension. Then tower argument gives [splitting field:ℚ] = 2^m.",
-      "wantzel_galois_iff ← direction: |p.Gal| = 2^k → FTGT gives tower with [K_{i+1}:K_i]=2 → each step is adjoin square root → IsConstructible via sqrt_ext induction.",
-      "Key Lean gap for both directions: IsAlgClosed.lift for extending ℚ-algebra maps to ℂ→ℂ; also tower induction for finrank product."
+      "→ direction intermediate: prove ∃ σ : ℂ →ₐ[ℚ] ℂ, σ(α) = β for another root β (needs full ℂ endomorphism extension)",
+      "← direction: FTGT + Sylow composition series for 2-groups; needs IntermediateField.orderIsoOfGal + degree-2 ↔ adjoin √",
+      "If → direction proves infeasible (Zorn + FTGT gap), mark wantzel_galois_iff as long-term blocked and move to new problem"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Two new proved theorems added to the Wantzel-Galois constructibility formalization (Session 37):

- **`isConstructible_minpoly_pow2`** (line 635): `IsConstructible α → ∃ m, (minpoly ℚ α).natDegree = 2^m`. Directly deduces from `isConstructible_algebraic_degree` + `IntermediateField.adjoin.finrank` + `Nat.dvd_prime_pow` that the minimal polynomial degree of any constructible number is a power of 2.

- **`isConstructible_irred_degree_pow2`** (line 652): If `p` is irreducible over ℚ, `α` is a root of `p` in ℂ, and `IsConstructible α`, then `∃ m, p.natDegree = 2^m`. This is the positive form of `not_constructible_of_bad_degree` and the key building block for the → direction of `wantzel_galois_iff`.

**Status**: 1 sorry remains (`wantzel_galois_iff` — requires FTGT + IsAlgClosed endomorphism extension, ~500 lines). 0 axioms. Docker build confirms only the expected sorry warning at line 710.

**Theorem count**: 22 → 24. **Line count**: 658 → 715.

## Test plan

- [x] Docker build: only 1 sorry warning (line 710, wantzel_galois_iff), no other errors
- [x] meta.json updated: theoremCount=24, lineCount=715, new galois-infrastructure section
- [x] knowledge.md updated: Session 37 entry documenting techniques and next steps
- [x] research JSON updated: new builtItems and insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)