### PR TITLE
enrich(de-moivre-oq-02-oq-02): add 3 annotations, fix significance values, add prerequisites

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02/annotations.json
@@ -8,13 +8,19 @@
     },
     "type": "insight",
     "title": "Key Lemma: 2X·U_k = U_{k+1} + U_{k-1}",
-    "content": "The identity `2X·U_k = U_{k+1} + U_{k-1}` is derived from Mathlib's `U_add_two` (which states U_{k+1} = 2X·U_k - U_{k-1}) by rearranging. In Lean, `have h := U_add_two (R := R) (k - 1)` gives `U_{k+1} = 2X·U_k - U_{k-1}`, and `linear_combination -h` closes the goal `2X·U_k = U_{k+1} + U_{k-1}`. This lemma is used three times: in the base case P(-1), and twice in each induction step.",
-    "mathContext": "From $U_{(k-1)+2} = 2X \\cdot U_{(k-1)+1} - U_{k-1}$, simplifying: $U_{k+1} = 2X \\cdot U_k - U_{k-1}$, so $2X \\cdot U_k = U_{k+1} + U_{k-1}$. This is the polynomial analog of $2\\cos(\\theta) \\cdot \\sin((k+1)\\theta) = \\sin((k+2)\\theta) + \\sin(k\\theta)$ (after multiplying by $\\sin\\theta$).",
+    "content": "The identity `2X·U_k = U_{k+1} + U_{k-1}` is derived from Mathlib's `U_add_two` (which states U_{k+1} = 2X·U_k - U_{k-1}) by rearranging. In Lean, `have h := U_add_two (R := R) (k - 1)` gives `U_{k+1} = 2X·U_k - U_{k-1}`, and `linear_combination -h` closes the goal `2X·U_k = U_{k+1} + U_{k-1}`. This lemma is the engine of the whole proof: it is used three times — once in the base case P(-1), and once in each of Q_succ and Q_pred to handle the 2X·T_m·U_n splitting.",
+    "mathContext": "From $U_{(k-1)+2} = 2X \\cdot U_{(k-1)+1} - U_{k-1}$, simplifying: $U_{k+1} = 2X \\cdot U_k - U_{k-1}$, so $2X \\cdot U_k = U_{k+1} + U_{k-1}$. This is the polynomial analog of $2\\cos\\theta \\cdot \\sin((k+1)\\theta) = \\sin((k+2)\\theta) + \\sin(k\\theta)$.",
     "significance": "key",
     "relatedConcepts": [
       "U_add_two",
       "linear_combination",
-      "Chebyshev recurrence"
+      "Chebyshev recurrence",
+      "second-kind Chebyshev"
+    ],
+    "prerequisites": [
+      "Mathlib.RingTheory.Polynomial.Chebyshev",
+      "linear_combination tactic",
+      "polynomial ring over CommRing"
     ]
   },
   {
@@ -25,16 +31,21 @@
       "endLine": 88
     },
     "type": "technique",
-    "title": "Paired Induction: Q(m) = P(m) ∧ P(m-1)",
-    "content": "The Chebyshev recurrence T_{m+2} = 2X·T_{m+1} - T_m is second-order, meaning the induction step for P(m+1) needs BOTH P(m) and P(m-1). The standard solution is to carry a conjunction Q(m) = P(m) ∧ P(m-1) and prove Q by induction instead of P directly. The successor step Q(m) → Q(m+1) is easy: Q(m+1).2 = Q(m).1 (just shift the pair). The hard part is Q(m+1).1 = P(m+1), which uses T_{m+1} = 2X·T_m - T_{m-1} and `linear_combination`.",
-    "mathContext": "Goal at induction step: prove $2T_{m+1} \\cdot U_n = U_{m+1+n} + U_{n-m-1}$. Use $T_{m+1} = 2X \\cdot T_m - T_{m-1}$ so $2T_{m+1} \\cdot U_n = 2 \\cdot (2X \\cdot T_m - T_{m-1}) \\cdot U_n = 2X \\cdot (2T_m \\cdot U_n) - (2T_{m-1} \\cdot U_n)$. Apply IH: $= 2X \\cdot (U_{m+n} + U_{n-m}) - (U_{m-1+n} + U_{n-m+1})$. Apply two_X_U twice: $= (U_{m+n+1} + U_{m+n-1}) + (U_{n-m+1} + U_{n-m-1}) - U_{m-1+n} - U_{n-m+1}$. Cancel to get $U_{m+1+n} + U_{n-m-1}$ ✓. The `linear_combination` tactic finds this automatically.",
-    "significance": "high",
+    "title": "Paired Induction: Q(m) = P(m) ∧ P(m-1) with Successor Step",
+    "content": "The Chebyshev recurrence T_{m+2} = 2X·T_{m+1} - T_m is second-order in m, so the induction step for P(m+1) needs both P(m) and P(m-1). The standard solution is to carry a conjunction Q(m) = P(m) ∧ P(m-1) and prove Q by Int.induction_on. The Q_zero base case proves both P(0) (trivial: 2·1·U_n = 2U_n) and P(-1) (using T_{-1} = X and two_X_U). The Q_succ successor step receives Q(m) = ⟨P(m), P(m-1)⟩ and must return Q(m+1) = ⟨P(m+1), P(m)⟩; the second component is free (just P(m) from the hypothesis), and P(m+1) is closed by linear_combination using T_add_two and two applications of two_X_U.",
+    "mathContext": "Successor step: $2T_{m+1} \\cdot U_n \\stackrel{T_{m+1}=2X T_m - T_{m-1}}{=} 2X(2T_m U_n) - (2T_{m-1}U_n) \\stackrel{\\text{IH}}{=} 2X(U_{m+n}+U_{n-m}) - (U_{m-1+n}+U_{n-m+1})$. Apply two\\_X\\_U to each term: $= (U_{m+n+1}+U_{m+n-1}) + (U_{n-m+1}+U_{n-m-1}) - U_{m-1+n} - U_{n-m+1} = U_{m+1+n} + U_{n-m-1}$ ✓.",
+    "significance": "key",
     "relatedConcepts": [
       "Int.induction_on",
       "linear_combination",
       "T_add_two",
       "second-order recurrence",
       "paired induction"
+    ],
+    "prerequisites": [
+      "integer induction in Lean 4 (Int.induction_on)",
+      "linear_combination tactic",
+      "T_add_two (Chebyshev first-kind recurrence)"
     ]
   },
   {
@@ -45,36 +56,119 @@
       "endLine": 63
     },
     "type": "insight",
-    "title": "T_{-1} = X: Inline Mini-Proof",
-    "content": "The base case P(-1) requires T_{-1} = X, which is not directly in Mathlib but follows from T_add_two at n=-1: T(1) = 2X·T(0) - T(-1) gives X = 2X - T(-1), so T(-1) = X. This mini-proof is done inline with `have hm1 : T R (-1 : ℤ) = X` using `T_add_two (R := R) (-1 : ℤ)` and `linear_combination -h`.",
-    "mathContext": "From $T_{(-1)+2} = 2X \\cdot T_{(-1)+1} - T_{-1}$, i.e., $T_1 = 2X \\cdot T_0 - T_{-1}$, using $T_1 = X$ and $T_0 = 1$: $X = 2X \\cdot 1 - T_{-1}$, so $T_{-1} = X$. Combined with `two_X_U n`: $2T_{-1} \\cdot U_n = 2X \\cdot U_n = U_{n+1} + U_{n-1}$, and $U_{-1+n} + U_{n-(-1)} = U_{n-1} + U_{n+1}$ ✓.",
-    "significance": "medium",
+    "title": "T_{-1} = X: Inline Mini-Proof from T_add_two",
+    "content": "The base case P(-1) requires T_{-1} = X, which is not directly in Mathlib but follows from T_add_two at n=-1: T(1) = 2X·T(0) - T(-1) gives X = 2X·1 - T(-1), so T(-1) = X. This mini-proof is done inline with `have hm1 : T R (-1 : ℤ) = X` using T_add_two(-1) and `linear_combination -h`. Once T_{-1} = X is established, P(-1) reduces to 2X·U_n = U_{n-1} + U_{n+1}, which is exactly the two_X_U lemma. This pattern — using T_add_two at a shifted argument to recover a value not in the library — is a recurring technique for negative integer Chebyshev evaluations.",
+    "mathContext": "From $T_{(-1)+2} = 2X \\cdot T_{(-1)+1} - T_{-1}$, using $T_1 = X$ and $T_0 = 1$: $X = 2X \\cdot 1 - T_{-1}$, so $T_{-1} = X$. Then $2T_{-1} \\cdot U_n = 2X \\cdot U_n = U_{n+1} + U_{n-1} = U_{-1+n} + U_{n-(-1)}$ ✓.",
+    "significance": "supporting",
     "relatedConcepts": [
       "T_add_two",
       "T_zero",
       "T_one",
       "negative integer Chebyshev",
       "linear_combination"
+    ],
+    "prerequisites": [
+      "T_add_two (Chebyshev recurrence)",
+      "T_zero, T_one (initial conditions)",
+      "two_X_U key lemma"
+    ]
+  },
+  {
+    "id": "ann-dmo2-q-pred",
+    "proofId": "de-moivre-oq-02-oq-02",
+    "range": {
+      "startLine": 89,
+      "endLine": 112
+    },
+    "type": "technique",
+    "title": "Q_pred: Backward Induction Step via T_{m-2} = 2X·T_{m-1} - T_m",
+    "content": "The predecessor step is the symmetric counterpart to Q_succ. Given Q(m) = ⟨P(m), P(m-1)⟩, Q_pred must produce Q(m-1) = ⟨P(m-1), P(m-2)⟩. The first component P(m-1) is free from the hypothesis. For P(m-2), use T_add_two at (m-2) rearranged as T_{m-2} = 2X·T_{m-1} - T_m. Then 2T_{m-2}·U_n = 2X·(2T_{m-1}·U_n) - (2T_m·U_n), and apply P(m-1) and P(m) from the IH, then two_X_U twice, with linear_combination closing the resulting algebraic identity. This symmetric structure — needing both a successor and predecessor step for integer induction — is what makes the paired conjunction Q the right carrier.",
+    "mathContext": "Predecessor step: $2T_{m-2} \\cdot U_n \\stackrel{T_{m-2}=2X T_{m-1}-T_m}{=} 2X(2T_{m-1}U_n) - (2T_mU_n)$. By IH: $= 2X(U_{m-1+n}+U_{n-m+1}) - (U_{m+n}+U_{n-m})$. By two\\_X\\_U: $= (U_{m+n}+U_{m-2+n}) + (U_{n-m+2}+U_{n-m}) - U_{m+n} - U_{n-m} = U_{m-2+n} + U_{n-m+2}$ ✓.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.induction_on predecessor step",
+      "T_add_two",
+      "linear_combination",
+      "backward induction",
+      "integer induction on ℤ"
+    ],
+    "prerequisites": [
+      "Q_succ (successor step for comparison)",
+      "T_add_two at shifted argument",
+      "two_X_U key lemma"
+    ]
+  },
+  {
+    "id": "ann-dmo2-main-theorem",
+    "proofId": "de-moivre-oq-02-oq-02",
+    "range": {
+      "startLine": 114,
+      "endLine": 125
+    },
+    "type": "insight",
+    "title": "T_mul_U_product: Int.induction_on Assembles the Three Cases",
+    "content": "The main theorem T_mul_U_product assembles the three private lemmas into a complete integer induction via Int.induction_on. The pattern `suffices h : Q n m from h.1` extracts P(m) from Q(m), then Int.induction_on dispatches to Q_zero (base), Q_succ (successor), and Q_pred (predecessor/negative). The Q_pred case has a subtle syntactic issue in Lean: the predecessor case produces `Q n (-↑k - 1)` for `k : ℕ`, and the argument is `Q n (-(↑k : ℤ))`, requiring a careful cast. This is the only publicly exported result of the PolynomialIdentity section; all the machinery (two_X_U, P, Q, Q_zero, Q_succ, Q_pred) is private.",
+    "mathContext": "$\\forall m : \\mathbb{Z},\\; (2 : R[X]) \\cdot T_R(m) \\cdot U_R(n) = U_R(m+n) + U_R(n-m)$. Proof assembles: $Q(0) \\land \\text{Q\\_succ} \\land \\text{Q\\_pred} \\xrightarrow{\\text{Int.induction\\_on}} Q(m) \\implies P(m)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Int.induction_on",
+      "suffices tactic",
+      "PolynomialIdentity section",
+      "private vs public lemmas"
+    ],
+    "prerequisites": [
+      "Q_zero, Q_succ, Q_pred",
+      "Int.induction_on in Lean 4",
+      "CommRing variable abstraction"
     ]
   },
   {
     "id": "ann-dmo2-trig-form",
     "proofId": "de-moivre-oq-02-oq-02",
     "range": {
-      "startLine": 139,
+      "startLine": 128,
       "endLine": 171
     },
     "type": "insight",
-    "title": "From Polynomial to Trigonometric Identity",
-    "content": "The polynomial identity T_mul_U_product is evaluated at cos θ to get the trigonometric form. The key is that `Polynomial.eval (cos θ)` distributes over multiplication and addition, so `congr_arg (Polynomial.eval (cos θ)) h` and `simp only [eval_mul, eval_add, map_ofNat]` suffice. The trig spreading identity 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ) then follows by substituting U_real_cos (which relates U_n(cos θ)·sin θ to sin((n+1)θ)).",
-    "mathContext": "The polynomial map `eval (cos θ) : ℝ[X] → ℝ` is a ring homomorphism, so it preserves all polynomial equalities. After evaluation: $2T_m(\\cos\\theta) \\cdot U_n(\\cos\\theta) = U_{m+n}(\\cos\\theta) + U_{n-m}(\\cos\\theta)$. Setting $m=1$ and using $T_1(\\cos\\theta) = \\cos\\theta$ gives $2\\cos\\theta \\cdot U_n(\\cos\\theta) = U_{n+1}(\\cos\\theta) + U_{n-1}(\\cos\\theta)$. Multiplying by $\\sin\\theta$ and using $U_k(\\cos\\theta) \\cdot \\sin\\theta = \\sin((k+1)\\theta)$ gives the spreading identity.",
-    "significance": "medium",
+    "title": "From Polynomial to Trigonometric: Three Corollaries",
+    "content": "The RealEvaluation section derives three corollaries from T_mul_U_product. First, chebyshev_T_U_product_to_sum evaluates the polynomial identity at cos θ using congr_arg and simp. Second, chebyshev_cos_U specializes to m=1: since T_1(cos θ) = cos θ, this gives 2·cos θ·U_n(cos θ) = U_{n+1}(cos θ) + U_{n-1}(cos θ), a clean recurrence for U at real values. Third, two_cos_sin_spreading multiplies by sin θ and applies U_real_cos (which states U_n(cos θ)·sin θ = sin((n+1)θ)) to get the pure trig spreading identity. The `nlinarith` at the end handles sin²θ + cos²θ = 1 as an auxiliary fact. Crucially, no case split on sin θ = 0 is needed because the algebraic proof avoids dividing by sin θ.",
+    "mathContext": "Evaluation chain: polynomial identity $\\xrightarrow{\\text{eval}(\\cos\\theta)}$ $2T_m(c)U_n(c) = U_{m+n}(c) + U_{n-m}(c)$ $\\xrightarrow{m=1}$ $2c \\cdot U_n(c) = U_{n+1}(c) + U_{n-1}(c)$ $\\xrightarrow{\\times \\sin\\theta}$ $2\\cos\\theta \\cdot \\sin((n+1)\\theta) = \\sin((n+2)\\theta) + \\sin(n\\theta)$, where $c = \\cos\\theta$.",
+    "significance": "supporting",
     "relatedConcepts": [
-      "Polynomial.eval",
+      "Polynomial.eval ring homomorphism",
       "congr_arg",
       "U_real_cos",
       "T_real_cos",
-      "ring homomorphism"
+      "T_one",
+      "nlinarith with auxiliary hypothesis"
+    ],
+    "prerequisites": [
+      "T_mul_U_product polynomial identity",
+      "U_real_cos (Mathlib: U_n(cos θ)·sin θ = sin((n+1)θ))",
+      "T_real_cos (Mathlib: T_n(cos θ) = cos(nθ))"
+    ]
+  },
+  {
+    "id": "ann-dmo2-summary",
+    "proofId": "de-moivre-oq-02-oq-02",
+    "range": {
+      "startLine": 174,
+      "endLine": 182
+    },
+    "type": "context",
+    "title": "Summary Theorem: Cross-Product and Recurrence Together",
+    "content": "The demoivre_oq02oq02_summary theorem packages the two main results as a conjunction for easy export: the full cross-product formula at arbitrary (m, n, θ) and the m=1 recurrence corollary. As a trivial conjunction proof, it serves as a single import point for downstream use. It also signals the boundary of the namespace — everything provable here about T×U mixed products has been captured. The pattern of a summary theorem as a ∧-conjunction of the key results, proved by ⟨theorem1, theorem2⟩, is a clean documentation idiom in Lean formalization.",
+    "mathContext": "Summary: $(\\forall m, n, \\theta)\\; 2T_m(\\cos\\theta)U_n(\\cos\\theta) = U_{m+n}(\\cos\\theta) + U_{n-m}(\\cos\\theta)$ $\\;\\land\\;$ $(\\forall n, \\theta)\\; 2\\cos\\theta \\cdot U_n(\\cos\\theta) = U_{n+1}(\\cos\\theta) + U_{n-1}(\\cos\\theta)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "conjunction proof pattern",
+      "namespace boundary",
+      "documentation theorem",
+      "Lean formalization idiom"
+    ],
+    "prerequisites": [
+      "chebyshev_T_U_product_to_sum",
+      "chebyshev_cos_U"
     ]
   }
 ]

--- a/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
@@ -108,7 +108,8 @@
     "implications": "**Theoretical Significance**\n\n1. **Over any CommRing R**: Unlike the parent OQ-02 (which uses trigonometry and is specific to ℝ), this identity holds algebraically in any commutative ring — broader generality.\n\n2. **Basis for U×U product formula**: The T×U cross-product can serve as a building block for the U×U product formula $U_m \\cdot U_n = \\sum_{k=0}^{\\min(m,n)} U_{m+n-2k}$ via recurrence matching.\n\n3. **Sin spreading identity**: The trig corollary $2\\cos\\theta \\cdot \\sin((n+1)\\theta) = \\sin((n+2)\\theta) + \\sin(n\\theta)$ is an important building block for Fourier-type series manipulations.",
     "openQuestions": [
       "Can the U×U product formula U_m · U_n = ∑_{k=0}^{min(m,n)} U_{m+n-2k} be proved by recurrence matching over ℝ[X]?",
-      "Can the T×U cross-product be proved over a more general setting (e.g., Chebyshev polynomials over ℤ)?"
+      "Can the T×U cross-product be proved over a more general setting (e.g., Chebyshev polynomials over ℤ)?",
+      "Does a T×V cross-product formula hold for the third-kind Chebyshev polynomials V_n (satisfying V_n(cos θ) = cos((n+½)θ)/cos(θ/2))?"
     ]
   },
   "relatedProblems": [
@@ -126,7 +127,12 @@
     {
       "targetId": "de-moivre-oq-01",
       "relationship": "sibling",
-      "description": "OQ-01 established T_n(cos θ) = cos(nθ); U_real_cos (U_n(cos θ)·sin θ = sin((n+1)θ)) is the second-kind analog."
+      "description": "OQ-01 established T_n(cos θ) = cos(nθ); U_real_cos (U_n(cos θ)·sin θ = sin((n+1)θ)) is the second-kind analog used here."
+    },
+    {
+      "targetId": "de-moivre-oq-03",
+      "relationship": "related",
+      "description": "OQ-03 explores further Chebyshev product identities; the T×U cross-product formula here is a stepping stone to U×U and higher mixed-kind formulas."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for **de-moivre-oq-02-oq-02** (Chebyshev T·U Cross-Product Formula).

## Quality improvements

**New annotations (3):**
- `ann-dmo2-q-pred` (lines 89–112): explains the backward induction step Q_pred — symmetric to Q_succ, uses T_{m-2} = 2X·T_{m-1} - T_m
- `ann-dmo2-main-theorem` (lines 114–125): documents how T_mul_U_product assembles Q_zero/Q_succ/Q_pred via Int.induction_on, including the subtle ℕ→ℤ cast in the predecessor case
- `ann-dmo2-summary` (lines 174–182): context annotation for the conjunction summary theorem at the namespace boundary

**Schema conformance fixes:**
- `significance` values corrected: "high" → "key", "medium" → "supporting"
- Added `prerequisites` field to all 7 annotations (was missing from all existing 4)

**Extended coverage:**
- ann-dmo2-trig-form range extended to 128–171 to cover chebyshev_T_U_product_to_sum section header

**Meta improvements:**
- Added `de-moivre-oq-03` cross-reference
- Added third-kind Chebyshev openQuestion (T×V formula for V_n)