### PR TITLE
fix(konigsberg-oq-01-oq-02): sync theoremCount 12→25

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 2,
     "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer's algorithm for directed graph Eulerian circuit — requires graph connectivity infrastructure) and directed_euler_path_iff (Eulerian path degree characterization). All other results (handshaking, necessity, concrete examples, consequences) are proved from first principles.",
     "lineCount": 848,
-    "theoremCount": 12,
+    "theoremCount": 25,
     "definitionCount": 8,
     "originalContributions": [
       "sum_outDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.1=v}| = |E| by double-counting via Finset.sum_comm + Finset.sum_ite_eq'",
@@ -117,7 +117,7 @@
     "namespace": "KonigsbergOQ01OQ02",
     "lineCount": 848,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 25,
     "definitionCount": 10,
     "path": "Proofs/KonigsbergOQ01OQ02.lean",
     "sorries": 6


### PR DESCRIPTION
## Summary

Metadata-only fix for `src/data/proofs/konigsberg-oq-01-oq-02/meta.json`.

Both `meta.theoremCount` and `leanFile.theoremCount` claimed `12`, but the committed Lean file `proofs/Proofs/KonigsbergOQ01OQ02.lean` on `origin/main` actually contains **25** theorem/lemma declarations.

### Before / After

| Field | Before | After |
| --- | --- | --- |
| `meta.theoremCount` | 12 | 25 |
| `leanFile.theoremCount` | 12 | 25 |

### Why it drifted

Research PRs **#15170** and **#15212** added theorem/lemma declarations to `KonigsbergOQ01OQ02.lean` (handshaking proofs, necessity-direction infrastructure, walk-bijection helpers) without updating the structural counts in `meta.json`. The previous metadata sync PR (#15249, `8→12`) only partially caught up. This restores agreement with the actual file contents.

### Verification

```
$ git show origin/main:proofs/Proofs/KonigsbergOQ01OQ02.lean | grep -cE "^(private\s+)?(noncomputable\s+)?(theorem|lemma)\s"
25

$ git show HEAD:src/data/proofs/konigsberg-oq-01-oq-02/meta.json \
    | python3 -c "import json,sys; m=json.load(sys.stdin); print(m['meta']['theoremCount'], m['leanFile']['theoremCount'])"
25 25
```

### Scope

- Metadata-only — the Lean file is **not** modified.
- No changes to `axiomCount`, `sorries`, `lineCount`, `definitionCount`, narrative copy, or any other field.

## Test plan

- [x] `meta.theoremCount` matches actual `theorem`/`lemma` count in committed Lean file (25)
- [x] `leanFile.theoremCount` matches actual count (25)
- [x] JSON remains valid (parses cleanly with `python3 -m json.tool`)
- [x] Diff is the two `12 → 25` lines only