### PR TITLE
fix(elementary-quadratic-reciprocity-oq-01-oq-02): remove True stub theorem

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean
@@ -239,7 +239,8 @@ theorem isCubicResidue_iff_cubicChar_one (h3 : p % 3 = 1) (a : (ZMod p)ˣ) :
 -- PART 6: Character Uniqueness Framework
 -- ============================================================
 
-/-- **Character uniqueness comparison**:
+/-
+  Character uniqueness comparison:
 
     Quadratic case (parent file OQ01 — the Zolotarev argument):
     - The Legendre symbol is the UNIQUE non-trivial quadratic character
@@ -260,8 +261,8 @@ theorem isCubicResidue_iff_cubicChar_one (h3 : p % 3 = 1) (a : (ZMod p)ˣ) :
     | 3     | 2 nontrivial | CR: (π/ρ)₃ = (ρ/π)₃ | ℤ[ω] (Eisenstein) |
     | 4     | 3 nontrivial | QR4: (π/ρ)₄ = (ρ/π)₄·i^... | ℤ[i] (biquadratic) |
 
-    This table is the "generalized character uniqueness" answering the open question. -/
-theorem character_uniqueness_comparison : True := trivial
+    This table is the "generalized character uniqueness" answering the open question.
+-/
 
 /-- The cardinality of the cubic character kernel (provable without axiom):
     |{a ∈ (ZMod p)ˣ | cubicChar a = 1}| = (p-1)/3 when p ≡ 1 (mod 3).

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 437,
-    "theoremCount": 25,
+    "lineCount": 438,
+    "theoremCount": 24,
     "defCount": 6,
     "assumptions": "Two axioms (both require Eisenstein integers ℤ[ω] not in Mathlib): (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. The hard Euler criterion (cubicEuler_hard) is now fully proved using discrete logarithm in the cyclic group (ZMod p)ˣ.",
     "mathlib_version": "4.26.0"
@@ -159,9 +159,9 @@
       "ZMod"
     ],
     "namespace": "CubicCharacter",
-    "lineCount": 437,
+    "lineCount": 438,
     "axiomCount": 2,
-    "theoremCount": 25,
+    "theoremCount": 24,
     "definitionCount": 6,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 2,
     "lineCount": 438,
     "theoremCount": 24,
@@ -164,7 +164,7 @@
     "theoremCount": 24,
     "definitionCount": 6,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean",
-    "sorries": 0
+    "sorries": 1
   },
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Removes the misleading `character_uniqueness_comparison : True := trivial` placeholder theorem.

## Evidence

**Before**: `theorem character_uniqueness_comparison : True := trivial` at line 264 — a theorem named to suggest a character uniqueness result but proving only `True`.

**After**: The preceding doc comment (`/-- ... -/`) is converted to a regular block comment (`/- ... -/`) so the mathematical comparison table is preserved. No theorem is emitted. `theoremCount` updated 25→24 and `lineCount` updated 437→438.

Closes #15325

---
Automated fix by lean-mechanic agent.