### PR TITLE
research(erdos-1201): add right-endpoint biconditional and infinite-set results (Session 6)

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -776,4 +776,54 @@ theorem gpfConsecutive_eq_term_gpf (n k : ℕ) (hn : 2 ≤ n) (hk : k < gpfConse
     (gpf_ge_prime_dvd _ (greatestPrimeFactor (n + j)) hcp (gpf_prime _ hnj)
       (dvd_trans (gpf_dvd _ hnj) (dvd_consecutiveProduct_term n k j (by omega))))⟩
 
+/-
+## Right-Endpoint Characterization: P(n,k) = n+k ↔ n+k is Prime
+-/
+
+/-- **Right-endpoint biconditional**: P(n,k) = n+k if and only if n+k is prime,
+    for n ≥ 1 and n+k ≥ 2.
+
+    Forward: if P(n,k) = n+k, then n+k is prime. Since n+k divides the consecutive
+    product and the product is ≥ n+k ≥ 2, the GPF of the product is prime; and since
+    P = n+k, n+k equals this prime value.
+
+    Backward: if n+k is prime, gpfConsecutive_eq_of_prime_right applies directly. -/
+theorem gpfConsecutive_eq_right_iff (n k : ℕ) (hn : 1 ≤ n) (hnk : 2 ≤ n + k) :
+    gpfConsecutive n k = n + k ↔ (n + k).Prime := by
+  constructor
+  · intro h
+    have h_dvd : n + k ∣ consecutiveProduct n k := dvd_consecutiveProduct_right n k
+    have h_pos : 0 < consecutiveProduct n k := consecutiveProduct_pos n k hn
+    have h_ge2 : 2 ≤ consecutiveProduct n k := Nat.le_trans hnk (Nat.le_of_dvd h_pos h_dvd)
+    rw [← h]; exact gpf_prime _ h_ge2
+  · exact gpfConsecutive_eq_of_prime_right n k hn
+
+/-- For any k, the set of n where (n+k) is prime is infinite.
+    For any bound N, pick a prime p > N+k; then n = p-k satisfies (n+k) = p prime and n > N. -/
+theorem erdos_1201_prime_right_infinite (k : ℕ) :
+    Set.Infinite {n : ℕ | (n + k).Prime} := by
+  apply Set.infinite_of_not_bddAbove
+  rw [not_bddAbove_iff]
+  intro N
+  obtain ⟨p, hp_ge, hp_prime⟩ := Nat.exists_infinite_primes (N + k + 1)
+  refine ⟨p - k, ?_, by omega⟩
+  simp only [Set.mem_setOf_eq]
+  rwa [Nat.sub_add_cancel (by omega)]
+
+/-- For any k ≥ 1, infinitely many n satisfy P(n,k) = n+k: the upper bound n+k is achieved
+    infinitely often. By gpfConsecutive_eq_right_iff, this is equivalent to n+k being prime,
+    and primes are infinite. Complements erdos_1201_infinitely_many (prime starts n). -/
+theorem erdos_1201_eq_right_infinite (k : ℕ) (hk : 0 < k) :
+    Set.Infinite {n : ℕ | gpfConsecutive n k = n + k} := by
+  apply Set.infinite_of_not_bddAbove
+  rw [not_bddAbove_iff]
+  intro N
+  obtain ⟨p, hp_ge, hp_prime⟩ := Nat.exists_infinite_primes (N + k + 1)
+  have hkp : k ≤ p := by omega
+  have hn1 : 1 ≤ p - k := by omega
+  refine ⟨p - k, ?_, by omega⟩
+  simp only [Set.mem_setOf_eq]
+  have hprime_rw : (p - k + k).Prime := by rwa [Nat.sub_add_cancel hkp]
+  exact gpfConsecutive_eq_of_prime_right _ k hn1 hprime_rw
+
 end Erdos1201


### PR DESCRIPTION
## Summary

Three new theorems completing the right-endpoint characterization of `gpfConsecutive`:

- **`gpfConsecutive_eq_right_iff`**: `P(n,k) = n+k ↔ (n+k).Prime` — closes the biconditional for when the upper bound is achieved
- **`erdos_1201_prime_right_infinite`**: `{n | (n+k).Prime}` is infinite
- **`erdos_1201_eq_right_infinite`** (k ≥ 1): `{n | P(n,k) = n+k}` is infinite — complements `erdos_1201_infinitely_many` (prime starts) with prime ends

Total: **47 structural theorems**, 1 axiom (ε=1/2 partial), 0 sorries.

## Mathematical context

`gpfConsecutive_eq_right_iff` gives a complete sharp characterization: combined with `gpfConsecutive_le_right` (P ≤ n+k) and `gpfConsecutive_eq_of_prime_right` (P = n+k when prime), we now know the maximum is achieved EXACTLY at prime right endpoints.

The two infinite-set witnesses are complementary: `erdos_1201_infinitely_many` uses primes as left endpoints to show P > n^(1-ε); `erdos_1201_eq_right_infinite` uses primes as right endpoints to show P = n+k exactly.

## Test plan

- [ ] Docker build via `./proofs/scripts/docker-build.sh Proofs.Erdos1201Problem`
- [ ] All new theorems use only proved API from Sessions 1-5
- [ ] 0 sorries, 1 axiom unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)