### PR TITLE
fix(erdos-601): prove ordinal_hierarchy using Aristotle companion lemmas

### DIFF
--- a/proofs/Proofs/Erdos601Problem.lean
+++ b/proofs/Proofs/Erdos601Problem.lean
@@ -151,7 +151,12 @@ noncomputable def omega1_pow_omega : Ordinal := ω₁ ^ ω
 /-- The hierarchy of ordinals approaching the critical point. -/
 theorem ordinal_hierarchy :
     ω < ω₁ ∧ ω₁ < ω₁ ^ ω ∧ ω₁ ^ ω < ω₁ ^ (ω + 1) ∧ ω₁ ^ (ω + 1) < criticalOrdinal := by
-  sorry
+  have h1 : (1 : Ordinal) < ω₁ := Ordinal.one_lt_omega.trans Ordinal.omega0_lt_omega1
+  refine ⟨Ordinal.omega0_lt_omega1, ?_, Ordinal.opow_lt_opow_right h1 (Ordinal.lt_succ ω), ?_⟩
+  · conv_lhs => rw [← Ordinal.opow_one ω₁]
+    exact Ordinal.opow_lt_opow_right h1 Ordinal.one_lt_omega
+  · unfold criticalOrdinal
+    exact Ordinal.opow_lt_opow_right h1 (Ordinal.lt_succ (ω + 1))
 
 /-- All countable ordinals satisfy P. -/
 theorem countable_ordinals (α : Ordinal) (hα : α.card ≤ ℵ₀) : PropertyP α := by

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 9,
     "erdosNumber": 601,
     "erdosUrl": "https://erdosproblems.com/601",
     "erdosProblemStatus": "open",
@@ -61,8 +61,8 @@
       "GeneralConjecture: $500 prize problem"
     ],
     "axiomCount": 4,
-    "lineCount": 259,
-    "assumptions": "4 axioms: critical_case_open, MartinsAxiom, ordinal_ramsey, general_conjecture_open. 10 sorries remain.",
+    "lineCount": 264,
+    "assumptions": "4 axioms: critical_case_open, MartinsAxiom, ordinal_ramsey, general_conjecture_open. 9 sorries remain.",
     "theoremCount": 18
   },
   "sections": [
@@ -206,11 +206,11 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos601",
-    "lineCount": 259,
+    "lineCount": 264,
     "axiomCount": 4,
     "theoremCount": 18,
     "definitionCount": 13,
-    "sorries": 10,
+    "sorries": 9,
     "path": "Proofs/Erdos601Problem.lean"
   },
   "references": [
@@ -257,5 +257,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
     }
   ],
-  "sorries": 10
+  "sorries": 9
 }


### PR DESCRIPTION
## Fix

Proves the `ordinal_hierarchy` sorry in `Erdos601Problem.lean` by inlining
proofs already established in `Erdos601Aristotle.lean`.

## Evidence

**Before**: `theorem ordinal_hierarchy : ω < ω₁ ∧ ω₁ < ω₁^ω ∧ ... := by sorry` (1 of 10 sorries)

**After**: Full proof using:
- `Ordinal.omega0_lt_omega1` for `ω < ω₁`
- `Ordinal.opow_lt_opow_right` for the exponentiation steps
- `Ordinal.one_lt_omega.trans Ordinal.omega0_lt_omega1` for the base `1 < ω₁`

Reduces sorries: 10 → 9. Updates `lineCount`: 259 → 264.

The proof was already implicit in `Erdos601Aristotle.lean` which had:
`omega_lt_omega1`, `omega1_lt_omega1_pow_omega`, `omega1_pow_omega_lt_succ`, `omega1_pow_succ_lt`.

---
Automated fix by lean-mechanic agent.