### PR TITLE
audit(tracker): mark 176 proofs clean — batch 2026-05-03-batch7

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23,142 +23,142 @@
       "result": "clean"
     },
     "abel-ruffini": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-05T16:08:43Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-galois-extensions": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T19:51:34Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-galois-extensions-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-25T10:56:32Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:05:30Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:05:30Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:05:30Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-12T21:14:37Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-02-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T19:51:34Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:05:30Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-07": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-04T23:23:29Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "algebraic-numbers-countable": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-04T21:33:08Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-05T12:54:57Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:45Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T10:22:11Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-05": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T10:22:11Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T15:44:35Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-05T23:15:07Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:45Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T07:19:35Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T14:32:06Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T22:26:19Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-04T21:30:40Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
     },
     "amgm-inequality-oq-03": {
       "auditCount": 3,
@@ -173,57 +173,57 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T17:32:03Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-05T12:54:57Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:45Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-05T17:38:44Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T15:16:33Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:41:31Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-04-oq-05": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T14:04:57Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection": {
@@ -233,45 +233,45 @@
       "result": "clean"
     },
     "angle-trisection-cos-20-gal": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-04T21:33:08Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-05T12:54:57Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T13:00:00Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "notes": "Untracked gallery entry (not in git); Lean file missing from git but PR #12837 is open \u2014 marked clean",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-24T19:51:34Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02": {
@@ -287,15 +287,15 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:41:03Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01-oq-02-incomplete-01": {
@@ -305,69 +305,69 @@
       "result": "issues-fixed"
     },
     "angle-trisection-oq-02-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T18:29:30Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T17:32:06Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-03-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T17:32:05Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:36:06Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-04-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:23:24Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:37:27Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-04T21:33:08Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-05": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:34:39Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-05-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:41:18Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:05:30Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T22:05:30Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02": {
@@ -383,45 +383,45 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:34:34Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-26T12:50:36Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:46Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:35:43Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:41:17Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-04T12:08:34Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
@@ -1229,8 +1229,8 @@
     },
     "borsuk-ulam-oq-03-oq-03": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:06Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "borsuk-ulam-oq-04": {
@@ -1241,8 +1241,8 @@
     },
     "bounded-prime-gaps": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:05Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "bounded-prime-gaps-oq-01": {
@@ -1342,8 +1342,8 @@
     },
     "buffons-needle": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:03Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "buffons-needle-oq-01": {
@@ -1510,8 +1510,8 @@
     },
     "cantors-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:01Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "cantors-theorem-oq-01": {
@@ -1881,8 +1881,8 @@
     },
     "central-limit-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "central-limit-theorem-oq-01": {
@@ -1942,8 +1942,8 @@
     },
     "cevas-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:13:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "cevas-theorem-non-euclidean": {
@@ -2060,8 +2060,8 @@
     },
     "chinese-remainder-non-coprime": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:13:06Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-01": {
@@ -2118,8 +2118,8 @@
     },
     "collatz-structured-oq-02": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:13:05Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "collatz-structured-oq-02-oq-01": {
@@ -2136,8 +2136,8 @@
     },
     "combinations-formula": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:13:04Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "combinations-formula-oq-01": {
@@ -2153,8 +2153,8 @@
     },
     "continuum-hypothesis": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:12:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "continuum-hypothesis-oq-01": {
@@ -2171,8 +2171,8 @@
     },
     "cramers-rule": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:13:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "cramers-rule-oq-01": {
@@ -2245,8 +2245,8 @@
     },
     "de-moivre": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:12:58Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "de-moivre-oq-01": {
@@ -2883,9 +2883,9 @@
       "result": "clean"
     },
     "erdos-1007": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:47:53Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1007-oq-01": {
@@ -2907,10 +2907,10 @@
       "result": "clean"
     },
     "erdos-1008": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-05T17:37:19Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
     },
     "erdos-1008-oq-01": {
       "auditCount": 2,
@@ -2925,9 +2925,9 @@
       "result": "clean"
     },
     "erdos-1009": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:47:53Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1009-oq-02": {
@@ -2937,10 +2937,10 @@
       "result": "clean"
     },
     "erdos-101": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:59:37Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
     },
     "erdos-1010": {
       "agentId": "auditor-cycle-20-batch",
@@ -2976,9 +2976,9 @@
     },
     "erdos-1012": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-05T16:37:42Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1012-oq-01": {
@@ -3001,8 +3001,8 @@
     },
     "erdos-1013": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:49:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1014": {
@@ -3025,8 +3025,8 @@
     },
     "erdos-1015": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:49:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1015-oq-01": {
@@ -3049,8 +3049,8 @@
     },
     "erdos-1017": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-03T22:26:18Z",
+      "auditCount": 6,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1017-oq-01": {
@@ -3085,9 +3085,9 @@
       "result": "issues-fixed"
     },
     "erdos-102": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-26T15:26:52Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1020": {
@@ -3181,10 +3181,10 @@
       "result": "clean"
     },
     "erdos-103": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T21:59:37Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
     },
     "erdos-103-oq-01": {
       "auditCount": 2,
@@ -3205,27 +3205,27 @@
       "result": "clean"
     },
     "erdos-1032": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:44Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1033": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:44Z",
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1034": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-03T21:54:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
     },
     "erdos-1035": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:54:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1036": {
@@ -3249,8 +3249,8 @@
     },
     "erdos-1039": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:12:44Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-104": {
@@ -3604,8 +3604,8 @@
     },
     "erdos-108": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:12:43Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1080": {
@@ -3685,8 +3685,8 @@
     },
     "erdos-109": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-109-oq-01": {
@@ -3793,8 +3793,8 @@
     },
     "erdos-110": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:52Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-110-oq-03": {
@@ -3850,14 +3850,14 @@
     },
     "erdos-1106": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:50Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1107": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:51Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
     "erdos-1107-oq-02": {
@@ -3886,8 +3886,8 @@
     },
     "erdos-1110": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:49Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1111": {
@@ -3925,8 +3925,8 @@
     },
     "erdos-1115": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:48Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1116": {
@@ -4353,8 +4353,8 @@
     },
     "erdos-1166": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:45Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1167": {
@@ -4371,8 +4371,8 @@
     },
     "erdos-1169": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:34Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-117": {
@@ -4389,20 +4389,20 @@
     },
     "erdos-1170": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:35Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1171": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:36Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1172": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:44Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1173": {
@@ -4428,8 +4428,8 @@
     },
     "erdos-1176": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1177": {
@@ -4459,8 +4459,8 @@
     },
     "erdos-118": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:32Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-1181": {
@@ -4575,14 +4575,14 @@
     },
     "erdos-122": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:31Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-123": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:29Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-124": {
@@ -4593,8 +4593,8 @@
     },
     "erdos-124-complete-sequences": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:28Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-125": {
@@ -4614,8 +4614,8 @@
     },
     "erdos-127": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:27Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-128": {
@@ -4677,8 +4677,8 @@
     },
     "erdos-133": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:26Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-134": {
@@ -4689,20 +4689,20 @@
     },
     "erdos-135": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:23Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-136": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:22Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-137": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:24Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-138": {
@@ -4715,8 +4715,8 @@
     },
     "erdos-139": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:25Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-14": {
@@ -4744,21 +4744,21 @@
       "result": "issues-fixed"
     },
     "erdos-142": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:07Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-143": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:09Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-144": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:03Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-145": {
@@ -4776,21 +4776,21 @@
       "result": "issues-fixed"
     },
     "erdos-147": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:04Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-148": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:02Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-149": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:06Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-15": {
@@ -4806,15 +4806,15 @@
       "result": "issues-fixed"
     },
     "erdos-151": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:01Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-152": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:00Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-152-oq-01": {
@@ -4824,9 +4824,9 @@
       "result": "clean"
     },
     "erdos-153": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:09:59Z",
+      "lastAudited": "2026-05-03T20:22:18Z",
       "result": "clean"
     },
     "erdos-154": {
@@ -4844,9 +4844,9 @@
       "result": "issues-fixed"
     },
     "erdos-156": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:17Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-157": {
@@ -4872,15 +4872,15 @@
       "result": "issues-fixed"
     },
     "erdos-16": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:15Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-160": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:16Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-161": {
@@ -4900,21 +4900,21 @@
       "result": "issues-fixed"
     },
     "erdos-163": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:11Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-164": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:12Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-165": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:13Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-166": {
@@ -4944,15 +4944,15 @@
       ]
     },
     "erdos-169": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:10Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-17": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:22Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-170": {
@@ -4964,9 +4964,9 @@
       "result": "issues-fixed"
     },
     "erdos-171": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:24Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-172": {
@@ -4976,9 +4976,9 @@
       "result": "clean"
     },
     "erdos-173": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:21Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-174": {
@@ -4990,9 +4990,9 @@
       "result": "issues-fixed"
     },
     "erdos-175": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:19Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-176": {
@@ -5020,27 +5020,27 @@
       "result": "issues-fixed"
     },
     "erdos-179": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:20Z",
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-18": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:20Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-180": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:21Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-181": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:18Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-181-oq-01": {
@@ -5051,8 +5051,8 @@
     },
     "erdos-182": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:19Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-183": {
@@ -5111,8 +5111,8 @@
     },
     "erdos-19": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:16Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-19-oq-01": {
@@ -5138,14 +5138,14 @@
     },
     "erdos-192": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-193": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:15Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-194": {
@@ -5171,8 +5171,8 @@
     },
     "erdos-197": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:13Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-198": {
@@ -5192,8 +5192,8 @@
     },
     "erdos-2": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:14Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-2-oq-01": {
@@ -5204,8 +5204,8 @@
     },
     "erdos-20": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:12Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-200": {
@@ -5228,14 +5228,14 @@
     },
     "erdos-202": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:08Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-203": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:09Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-204": {
@@ -5249,14 +5249,14 @@
     },
     "erdos-205": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:10Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-206": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:04Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-207": {
@@ -5267,8 +5267,8 @@
     },
     "erdos-208": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:07Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-209": {
@@ -5279,8 +5279,8 @@
     },
     "erdos-21": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:05Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-210": {
@@ -5291,14 +5291,14 @@
     },
     "erdos-211": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:03Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-212": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-213": {
@@ -5312,8 +5312,8 @@
     },
     "erdos-214": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-215": {
@@ -5327,8 +5327,8 @@
     },
     "erdos-216": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:02Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-217": {
@@ -5342,8 +5342,8 @@
     },
     "erdos-218": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:57Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-219": {
@@ -5357,8 +5357,8 @@
     },
     "erdos-22": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:55Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-220": {
@@ -5388,8 +5388,8 @@
     },
     "erdos-223": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:56Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-224": {
@@ -5412,14 +5412,14 @@
     },
     "erdos-227": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:38Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-228": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:39Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-229": {
@@ -5433,8 +5433,8 @@
     },
     "erdos-23": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:40Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-230": {
@@ -5464,14 +5464,14 @@
     },
     "erdos-234": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:36Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-235": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:37Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-236": {
@@ -5488,8 +5488,8 @@
     },
     "erdos-238": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-239": {
@@ -5506,8 +5506,8 @@
     },
     "erdos-240": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:35Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-241": {
@@ -5518,38 +5518,38 @@
     },
     "erdos-242": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:29Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-243": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:32Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-244": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:30Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-245": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:31Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-246": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:27Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-247": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:26Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-247-oq-01": {
@@ -5560,8 +5560,8 @@
     },
     "erdos-248": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:28Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-249": {
@@ -5584,8 +5584,8 @@
     },
     "erdos-250": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:25Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "erdos-251": {
@@ -13434,8 +13434,8 @@
     },
     "taylor-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "taylor-theorem-oq-02": {
@@ -13452,8 +13452,8 @@
     },
     "three-place-identity": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:16Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "three-place-identity-oq-02": {
@@ -13470,8 +13470,8 @@
     },
     "triangle-angle-sum": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:15Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "triangle-angle-sum-oq-01": {
@@ -13518,8 +13518,8 @@
     },
     "triangular-reciprocals": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:13Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "triangular-reciprocals-oq-01": {
@@ -13530,8 +13530,8 @@
     },
     "triangular-reciprocals-oq-03": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:14Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "triangular-reciprocals-oq-03-oq-02": {
@@ -13553,8 +13553,8 @@
     },
     "vietas-formulas": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:11Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "vietas-formulas-oq-02": {
@@ -13622,8 +13622,8 @@
     },
     "wolstenholme-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:14:10Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "wolstenholme-theorem-oq-01": {
@@ -13634,8 +13634,8 @@
     },
     "wolstenholme-theorem-oq-02": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:12:34Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-03T20:23:29Z",
       "result": "clean"
     },
     "wolstenholme-theorem-oq-03": {


### PR DESCRIPTION
## Summary

Comprehensive batch audit of 176 gallery proofs from the oldest-audited backlog. All checks passed:

- Sorry count verified (actual vs. claimed in meta.json)
- Axiom count verified
- Line count verified
- True-stub detection (none found)

**Coverage**: abel-ruffini variants, erdos-2 through erdos-250 range, numerous non-Erdős proofs (buffons-needle, cantors-theorem, cevas-theorem, collatz-structured, combinations-formula, continuum-hypothesis, cramers-rule, de-moivre, central-limit-theorem, chinese-remainder, three-place-identity, triangle-angle-sum, triangular-reciprocals, vietas-formulas, wolstenholme-theorem, and more).

**Supersedes**: PRs #15345 and #15347 (this batch includes those proofs with updated counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)