### PR TITLE
enrich(erdos-1054-oq-01-fnorm): restructure sections into 5 non-overlapping ranges

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
@@ -48,35 +48,43 @@
   "sections": [
     {
       "id": "prime-structure",
-      "title": "Parts I–III: Prime Divisor Structure and f Bounds",
+      "title": "Parts I–III: Definitions, Prime Divisor Structure, and f Bounds",
       "startLine": 35,
-      "endLine": 150,
-      "summary": "prime_divisors_eq, prime_sortedDivisors, prime_partialDivisorSums. representable_prime_plus_one: p+1 representable. f_prime_plus_one_le: f(p+1) ≤ p.",
+      "endLine": 115,
+      "summary": "Core definitions (sortedDivisors, partialDivisorSums, IsRepresentable, computeF). prime_divisors_eq, prime_sortedDivisors, prime_partialDivisorSums. representable_prime_plus_one: p+1 representable. f_prime_plus_one_le: f(p+1) ≤ p.",
       "mathContext": "For prime $p$: divisors $= \\{1, p\\}$, partial sums $= \\{1, p+1\\}$. So $f(p+1) \\leq p$."
     },
     {
       "id": "computational",
-      "title": "Parts IV–VI: Computational Evidence and Density",
-      "startLine": 117,
-      "endLine": 230,
-      "summary": "f values for n=3,4,6,8,12,...,32 via native_decide. f_bounded_50: all n ≤ 50 representable. even_representable_small, odd_representable_small.",
-      "mathContext": "$f(3)=2, f(4)=3, f(6)=5, \\ldots, f(32)=31$ verified computationally."
+      "title": "Parts IV–VI: Computational Evidence, Density, and Open Conjecture",
+      "startLine": 116,
+      "endLine": 214,
+      "summary": "f values for n=3,4,6,8,12,...,32 via native_decide. f_bounded_50: all representable n ≤ 20 have f(n) ≤ 2n. even_representable_small, odd_representable_small. Formal definition of almost_all_little_o encoding the open conjecture.",
+      "mathContext": "$f(3)=2, f(4)=3, f(6)=5, \\ldots, f(32)=31$ verified computationally. Open: $\\forall \\varepsilon > 0$, density of $\\{n : f(n) \\geq \\varepsilon n\\}$ is 0."
     },
     {
-      "id": "sigma-bound",
-      "title": "Parts VII–IX: Sigma Bound and Abundancy",
-      "startLine": 230,
-      "endLine": 400,
-      "summary": "partialDivisorSums_getLast_eq_sigma. f_sigma_bound: f(σ(m)) ≤ m. sigma_representable. sigma values for m=6,12,20,24,30,36,48,60,120. Ratio theorems.",
-      "mathContext": "$f(\\sigma(m)) \\leq m$ for all $m \\geq 1$. Key lemma: $\\sigma(m)$ is the last partial divisor sum."
+      "id": "sigma-infra",
+      "title": "Parts VII–VIII: Sigma Bound Infrastructure",
+      "startLine": 215,
+      "endLine": 345,
+      "summary": "one_in_partial_sums: 1 is always a partial sum. scanl_add_getLast: last element of scanl equals sum. partialDivisorSums_getLast_eq_sigma: last partial sum = σ(m). sortedDivisors_sum_eq bridges list sum to Mathlib σ. f_sigma_bound: f(σ(m)) ≤ m. sigma_representable: σ(m) is always representable.",
+      "mathContext": "$\\text{getLast}(\\text{partialDivisorSums}(m)) = \\sigma(m)$, so $f(\\sigma(m)) \\leq m$ for all $m \\geq 1$."
     },
     {
-      "id": "representability",
-      "title": "Parts X–XII: Complete Representability",
-      "startLine": 400,
+      "id": "sigma-results",
+      "title": "Part IX–XI: Abundancy Ratios and Representability Density",
+      "startLine": 346,
+      "endLine": 445,
+      "summary": "sigma_prime, sigma_ge_succ: σ(m) ≥ m+1 for m ≥ 2. Concrete σ-values for m ∈ {6,12,20,24,30,36,48,60,120}. Ratio theorems showing f(σ(m))/σ(m) < 1/2 for abundant numbers. partialSums_all_representable: every partial sum is representable. partialDivisorSums_length = τ(m). f_witness_bound: abstract f(n) ≤ m bound.",
+      "mathContext": "$\\sigma(m)/m > 2 \\implies f(\\sigma(m))/\\sigma(m) < 1/2$. Each $m$ generates $\\tau(m)$ representable values simultaneously."
+    },
+    {
+      "id": "complete-representability",
+      "title": "Part XII: Complete Representability of σ-Values and Summary",
+      "startLine": 446,
       "endLine": 521,
-      "summary": "partialSums_all_representable: all partial divisor sums representable. f_witness_bound. sigma_values_representable: all σ(m) representable.",
-      "mathContext": "All elements of $\\text{partialDivisorSums}(m)$ are representable, establishing density."
+      "summary": "sigma_values_representable: every value in range of σ is representable, formally verified for {1,3,4,6,7,8,12,13,14,15,18,20,24,28}. Mathematical summary: proves f(n) = o(n) along the σ-subsequence of superabundant numbers via Gronwall's theorem. Lists all 19 proved theorems and identifies what remains open.",
+      "mathContext": "$\\forall n \\in \\text{range}(\\sigma)$, $n$ is representable. Combined with Gronwall: $f(\\sigma(m_k))/\\sigma(m_k) \\leq 1/(e^\\gamma \\log\\log m_k) \\to 0$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: Fix Overlapping Section Ranges

Restructures the `sections` array of `meta.json` from 4 overlapping ranges to 5 clean non-overlapping sections covering the complete 521-line Lean file.

**Before (4 sections with overlap):**
- prime-structure: 35–150
- computational: 117–230 *(overlaps 117–150 with prime-structure)*
- sigma-bound: 230–400
- representability: 400–521

**After (5 sections, no overlap):**
- `prime-structure` (35–115): Definitions + prime divisor structure + f bounds
- `computational` (116–214): Computational evidence + open conjecture definition
- `sigma-infra` (215–345): Sigma bound infrastructure (scanl lemmas, f_sigma_bound)
- `sigma-results` (346–445): Abundancy ratios + all-partial-sums representability
- `complete-representability` (446–521): σ-range representability + mathematical summary

**Quality impact:** sections 8/10 → 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)