### PR TITLE
fix(erdos-1201): remove duplicate theorem declarations, add 4 unique theorems

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -124,6 +124,11 @@ theorem gpf_ge_prime_dvd (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) (hpn : p ∣ 
 theorem consecutiveProduct_zero (n : ℕ) : consecutiveProduct n 0 = n := by
   simp [consecutiveProduct]
 
+/-- consecutiveProduct n 1 = n * (n + 1). -/
+theorem consecutiveProduct_one (n : ℕ) : consecutiveProduct n 1 = n * (n + 1) := by
+  have := consecutiveProduct_succ n 0
+  rwa [consecutiveProduct_zero] at this
+
 /-- consecutiveProduct n k is positive when n ≥ 1. -/
 theorem consecutiveProduct_pos (n k : ℕ) (hn : 1 ≤ n) : 0 < consecutiveProduct n k := by
   apply Finset.prod_pos
@@ -533,6 +538,30 @@ theorem gpfConsecutive_one_eq_max (n : ℕ) (hn : 2 ≤ n) :
              Finset.sup_insert, Finset.sup_singleton]
   simp only [Nat.add_zero]
 
+/-- For n ≥ 2, the greatest prime factors of n and n+1 are coprime.
+    Since gcd(n, n+1) = 1 and gpf(n) ∣ n, gpf(n+1) ∣ n+1, the gcd of the gpfs divides 1. -/
+theorem gpfConsecutive_one_coprime (n : ℕ) (hn : 2 ≤ n) :
+    Nat.Coprime (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) := by
+  have hdn : greatestPrimeFactor n ∣ n := gpf_dvd n hn
+  have hdn1 : greatestPrimeFactor (n + 1) ∣ n + 1 := gpf_dvd (n + 1) (by omega)
+  have hcop : Nat.Coprime n (n + 1) := Nat.coprime_succ_self n
+  have h1 : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) ∣ n :=
+    dvd_trans (Nat.gcd_dvd_left _ _) hdn
+  have h2 : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) ∣ n + 1 :=
+    dvd_trans (Nat.gcd_dvd_right _ _) hdn1
+  exact Nat.dvd_one.mp (hcop ▸ Nat.dvd_gcd h1 h2)
+
+/-- For n ≥ 2, greatestPrimeFactor n ≠ greatestPrimeFactor (n + 1).
+    If equal to p ≥ 2, then gcd(p, p) = p ≥ 2 contradicts the coprimality above. -/
+theorem gpfConsecutive_one_ne (n : ℕ) (hn : 2 ≤ n) :
+    greatestPrimeFactor n ≠ greatestPrimeFactor (n + 1) := by
+  intro h
+  have hcop := gpfConsecutive_one_coprime n hn
+  have hge : 2 ≤ greatestPrimeFactor n := gpf_ge_two n hn
+  have heq : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor n) = 1 := h ▸ hcop
+  rw [Nat.gcd_self] at heq
+  omega
+
 /-- P(n, k) ≥ gpf(n): the window GPF is at least the GPF of the left endpoint. -/
 theorem gpfConsecutive_ge_left (n k : ℕ) (hn : 2 ≤ n) :
     greatestPrimeFactor n ≤ gpfConsecutive n k := by
@@ -730,192 +759,6 @@ theorem erdos_1201_good_of_prime_in_window (n k i : ℕ) (ε : ℝ) (hn : 2 ≤ 
     (hprime : (n + i).Prime) (hlarge : (n : ℝ) ^ (1 - ε) < n + i) :
     (n : ℝ) ^ (1 - ε) < gpfConsecutive n k :=
   hlarge.trans_le (by exact_mod_cast gpfConsecutive_ge_prime_term n k i hn hi hprime)
-
-/-
-## Two-Term Window: Relationship to Individual GPFs
--/
-
-/-- consecutiveProduct n 1 = n * (n + 1). -/
-theorem consecutiveProduct_one (n : ℕ) : consecutiveProduct n 1 = n * (n + 1) := by
-  have := consecutiveProduct_succ n 0
-  rwa [consecutiveProduct_zero] at this
-
-/-- **Two-Term Window**: P(n, 1) = max(P(n), P(n+1)) for n ≥ 2.
-    The greatest prime factor of n*(n+1) equals the maximum of the per-term greatest prime
-    factors. The ≤ direction uses that any prime dividing n*(n+1) divides n or n+1
-    (by primality). The ≥ direction uses that gpf(n) and gpf(n+1) each divide the product. -/
-theorem gpfConsecutive_one_eq_max (n : ℕ) (hn : 2 ≤ n) :
-    gpfConsecutive n 1 = max (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) := by
-  have hn1 : 2 ≤ n + 1 := by omega
-  have hn_prod : 2 ≤ n * (n + 1) := by nlinarith
-  have h_eq : gpfConsecutive n 1 = greatestPrimeFactor (n * (n + 1)) := by
-    unfold gpfConsecutive; rw [consecutiveProduct_one]
-  rw [h_eq]
-  apply Nat.le_antisymm
-  · -- greatestPrimeFactor (n*(n+1)) ≤ max(gpf n, gpf(n+1)):
-    -- the gpf is prime and divides n*(n+1), so it divides n or n+1 by primality
-    have hprime : (greatestPrimeFactor (n * (n + 1))).Prime := gpf_prime (n * (n + 1)) hn_prod
-    have hdvd : greatestPrimeFactor (n * (n + 1)) ∣ n * (n + 1) := gpf_dvd (n * (n + 1)) hn_prod
-    rcases hprime.dvd_mul.mp hdvd with h | h
-    · exact le_trans (gpf_max n _ (Nat.mem_primeFactors.mpr ⟨hprime, h, by omega⟩))
-                     (le_max_left _ _)
-    · exact le_trans (gpf_max (n + 1) _ (Nat.mem_primeFactors.mpr ⟨hprime, h, by omega⟩))
-                     (le_max_right _ _)
-  · -- max(gpf n, gpf(n+1)) ≤ greatestPrimeFactor (n*(n+1)):
-    -- gpf n | n | n*(n+1) and gpf(n+1) | n+1 | n*(n+1)
-    apply max_le
-    · exact gpf_ge_prime_dvd (n * (n + 1)) _ hn_prod (gpf_prime n hn)
-        (dvd_trans (gpf_dvd n hn) (dvd_mul_right n (n + 1)))
-    · exact gpf_ge_prime_dvd (n * (n + 1)) _ hn_prod (gpf_prime (n + 1) hn1)
-        (dvd_trans (gpf_dvd (n + 1) hn1) (dvd_mul_left (n + 1) n))
-
-/-
-## Structural Decomposition: GPF Localization
--/
-
-/-- For n ≥ 2, the greatest prime factors of n and n+1 are coprime.
-    Since gcd(n, n+1) = 1 and gpf(n) ∣ n, gpf(n+1) ∣ n+1, the gcd of the gpfs divides 1. -/
-theorem gpfConsecutive_one_coprime (n : ℕ) (hn : 2 ≤ n) :
-    Nat.Coprime (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) := by
-  have hdn : greatestPrimeFactor n ∣ n := gpf_dvd n hn
-  have hdn1 : greatestPrimeFactor (n + 1) ∣ n + 1 := gpf_dvd (n + 1) (by omega)
-  have hcop : Nat.Coprime n (n + 1) := Nat.coprime_succ_self n
-  have h1 : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) ∣ n :=
-    dvd_trans (Nat.gcd_dvd_left _ _) hdn
-  have h2 : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) ∣ n + 1 :=
-    dvd_trans (Nat.gcd_dvd_right _ _) hdn1
-  exact Nat.dvd_one.mp (hcop ▸ Nat.dvd_gcd h1 h2)
-
-/-- For n ≥ 2, greatestPrimeFactor n ≠ greatestPrimeFactor (n + 1).
-    If equal to p ≥ 2, then gcd(p, p) = p ≥ 2 contradicts the coprimality above. -/
-theorem gpfConsecutive_one_ne (n : ℕ) (hn : 2 ≤ n) :
-    greatestPrimeFactor n ≠ greatestPrimeFactor (n + 1) := by
-  intro h
-  have hcop := gpfConsecutive_one_coprime n hn
-  have hge : 2 ≤ greatestPrimeFactor n := gpf_ge_two n hn
-  have heq : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor n) = 1 := h ▸ hcop
-  rw [Nat.gcd_self] at heq
-  omega
-
-/-- **GPF Localization**: When gpfConsecutive n k > k, the GPF comes from a single term.
-    Since p = P(n,k) > k divides the product, it divides some term n+j (j ≤ k).
-    As p > k ≥ any difference of indices, p divides at most one term, so p = gpf(n+j). -/
-theorem gpfConsecutive_eq_term_gpf (n k : ℕ) (hn : 2 ≤ n) (hk : k < gpfConsecutive n k) :
-    ∃ j ≤ k, gpfConsecutive n k = greatestPrimeFactor (n + j) := by
-  have hcp : 2 ≤ consecutiveProduct n k :=
-    le_trans hn (consecutiveProduct_ge_n n k (by omega))
-  have hp : (gpfConsecutive n k).Prime := gpf_prime _ hcp
-  have hdvd : gpfConsecutive n k ∣ consecutiveProduct n k := gpf_dvd _ hcp
-  obtain ⟨j, hj_lt, hpj⟩ := prime_dvd_consecutive_range n k _ hp hdvd
-  have hnj : 2 ≤ n + j := by omega
-  exact ⟨j, by omega, Nat.le_antisymm
-    (gpf_ge_prime_dvd (n + j) _ hnj hp hpj)
-    (gpf_ge_prime_dvd _ (greatestPrimeFactor (n + j)) hcp (gpf_prime _ hnj)
-      (dvd_trans (gpf_dvd _ hnj) (dvd_consecutiveProduct_term n k j (by omega))))⟩
-
-/-
-## Two-Term Window: Relationship to Individual GPFs
--/
-
-/-- consecutiveProduct n 1 = n * (n + 1). -/
-theorem consecutiveProduct_one (n : ℕ) : consecutiveProduct n 1 = n * (n + 1) := by
-  have := consecutiveProduct_succ n 0
-  rwa [consecutiveProduct_zero] at this
-
-/-- **Two-Term Window**: P(n, 1) = max(P(n), P(n+1)) for n ≥ 2.
-    The greatest prime factor of n*(n+1) equals the maximum of the per-term greatest prime
-    factors. The ≤ direction uses that any prime dividing n*(n+1) divides n or n+1
-    (by primality). The ≥ direction uses that gpf(n) and gpf(n+1) each divide the product. -/
-theorem gpfConsecutive_one_eq_max (n : ℕ) (hn : 2 ≤ n) :
-    gpfConsecutive n 1 = max (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) := by
-  have hn1 : 2 ≤ n + 1 := by omega
-  have hn_prod : 2 ≤ n * (n + 1) := by nlinarith
-  have h_eq : gpfConsecutive n 1 = greatestPrimeFactor (n * (n + 1)) := by
-    unfold gpfConsecutive; rw [consecutiveProduct_one]
-  rw [h_eq]
-  apply Nat.le_antisymm
-  · -- greatestPrimeFactor (n*(n+1)) ≤ max(gpf n, gpf(n+1)):
-    -- the gpf is prime and divides n*(n+1), so it divides n or n+1 by primality
-    have hprime : (greatestPrimeFactor (n * (n + 1))).Prime := gpf_prime (n * (n + 1)) hn_prod
-    have hdvd : greatestPrimeFactor (n * (n + 1)) ∣ n * (n + 1) := gpf_dvd (n * (n + 1)) hn_prod
-    rcases hprime.dvd_mul.mp hdvd with h | h
-    · exact le_trans (gpf_max n _ (Nat.mem_primeFactors.mpr ⟨hprime, h, by omega⟩))
-                     (le_max_left _ _)
-    · exact le_trans (gpf_max (n + 1) _ (Nat.mem_primeFactors.mpr ⟨hprime, h, by omega⟩))
-                     (le_max_right _ _)
-  · -- max(gpf n, gpf(n+1)) ≤ greatestPrimeFactor (n*(n+1)):
-    -- gpf n | n | n*(n+1) and gpf(n+1) | n+1 | n*(n+1)
-    apply max_le
-    · exact gpf_ge_prime_dvd (n * (n + 1)) _ hn_prod (gpf_prime n hn)
-        (dvd_trans (gpf_dvd n hn) (dvd_mul_right n (n + 1)))
-    · exact gpf_ge_prime_dvd (n * (n + 1)) _ hn_prod (gpf_prime (n + 1) hn1)
-        (dvd_trans (gpf_dvd (n + 1) hn1) (dvd_mul_left (n + 1) n))
-
-/-
-## Two-Term Window: Relationship to Individual GPFs
--/
-
-/-- consecutiveProduct n 1 = n * (n + 1). -/
-theorem consecutiveProduct_one (n : ℕ) : consecutiveProduct n 1 = n * (n + 1) := by
-  have := consecutiveProduct_succ n 0
-  rwa [consecutiveProduct_zero] at this
-
-/-- **Two-Term Window**: P(n, 1) = max(P(n), P(n+1)) for n ≥ 2.
-    The greatest prime factor of n*(n+1) equals the maximum of the per-term greatest prime
-    factors. The ≤ direction uses that any prime dividing n*(n+1) divides n or n+1
-    (by primality). The ≥ direction uses that gpf(n) and gpf(n+1) each divide the product. -/
-theorem gpfConsecutive_one_eq_max (n : ℕ) (hn : 2 ≤ n) :
-    gpfConsecutive n 1 = max (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) := by
-  have hn1 : 2 ≤ n + 1 := by omega
-  have hn_prod : 2 ≤ n * (n + 1) := by nlinarith
-  have h_eq : gpfConsecutive n 1 = greatestPrimeFactor (n * (n + 1)) := by
-    unfold gpfConsecutive; rw [consecutiveProduct_one]
-  rw [h_eq]
-  apply Nat.le_antisymm
-  · -- greatestPrimeFactor (n*(n+1)) ≤ max(gpf n, gpf(n+1)):
-    -- the gpf is prime and divides n*(n+1), so it divides n or n+1 by primality
-    have hprime : (greatestPrimeFactor (n * (n + 1))).Prime := gpf_prime (n * (n + 1)) hn_prod
-    have hdvd : greatestPrimeFactor (n * (n + 1)) ∣ n * (n + 1) := gpf_dvd (n * (n + 1)) hn_prod
-    rcases hprime.dvd_mul.mp hdvd with h | h
-    · exact le_trans (gpf_max n _ (Nat.mem_primeFactors.mpr ⟨hprime, h, by omega⟩))
-                     (le_max_left _ _)
-    · exact le_trans (gpf_max (n + 1) _ (Nat.mem_primeFactors.mpr ⟨hprime, h, by omega⟩))
-                     (le_max_right _ _)
-  · -- max(gpf n, gpf(n+1)) ≤ greatestPrimeFactor (n*(n+1)):
-    -- gpf n | n | n*(n+1) and gpf(n+1) | n+1 | n*(n+1)
-    apply max_le
-    · exact gpf_ge_prime_dvd (n * (n + 1)) _ hn_prod (gpf_prime n hn)
-        (dvd_trans (gpf_dvd n hn) (dvd_mul_right n (n + 1)))
-    · exact gpf_ge_prime_dvd (n * (n + 1)) _ hn_prod (gpf_prime (n + 1) hn1)
-        (dvd_trans (gpf_dvd (n + 1) hn1) (dvd_mul_left (n + 1) n))
-
-/-
-## Structural Decomposition: GPF Localization
--/
-
-/-- For n ≥ 2, the greatest prime factors of n and n+1 are coprime.
-    Since gcd(n, n+1) = 1 and gpf(n) ∣ n, gpf(n+1) ∣ n+1, the gcd of the gpfs divides 1. -/
-theorem gpfConsecutive_one_coprime (n : ℕ) (hn : 2 ≤ n) :
-    Nat.Coprime (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) := by
-  have hdn : greatestPrimeFactor n ∣ n := gpf_dvd n hn
-  have hdn1 : greatestPrimeFactor (n + 1) ∣ n + 1 := gpf_dvd (n + 1) (by omega)
-  have hcop : Nat.Coprime n (n + 1) := Nat.coprime_succ_self n
-  have h1 : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) ∣ n :=
-    dvd_trans (Nat.gcd_dvd_left _ _) hdn
-  have h2 : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor (n + 1)) ∣ n + 1 :=
-    dvd_trans (Nat.gcd_dvd_right _ _) hdn1
-  exact Nat.dvd_one.mp (hcop ▸ Nat.dvd_gcd h1 h2)
-
-/-- For n ≥ 2, greatestPrimeFactor n ≠ greatestPrimeFactor (n + 1).
-    If equal to p ≥ 2, then gcd(p, p) = p ≥ 2 contradicts the coprimality above. -/
-theorem gpfConsecutive_one_ne (n : ℕ) (hn : 2 ≤ n) :
-    greatestPrimeFactor n ≠ greatestPrimeFactor (n + 1) := by
-  intro h
-  have hcop := gpfConsecutive_one_coprime n hn
-  have hge : 2 ≤ greatestPrimeFactor n := gpf_ge_two n hn
-  have heq : Nat.gcd (greatestPrimeFactor n) (greatestPrimeFactor n) = 1 := h ▸ hcop
-  rw [Nat.gcd_self] at heq
-  omega
 
 /-- **GPF Localization**: When gpfConsecutive n k > k, the GPF comes from a single term.
     Since p = P(n,k) > k divides the product, it divides some term n+j (j ≤ k).

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-1201",
   "title": "Greatest Prime Factor of Consecutive Products",
   "slug": "erdos-1201",
-  "description": "Let P(n,k) be the greatest prime factor of n(n+1)\u00b7\u00b7\u00b7(n+k). Erd\u0151s conjectured that for every \u03b5,\u03b7>0 there exists k such that P(n,k) > n^(1-\u03b5) for a set of n of upper density \u2265 1-\u03b7. The \u03b5=1/2 case (P(n,k) > \u221an) was proved by Erd\u0151s.",
+  "description": "Let P(n,k) be the greatest prime factor of n(n+1)···(n+k). Erdős conjectured that for every ε,η>0 there exists k such that P(n,k) > n^(1-ε) for a set of n of upper density ≥ 1-η. The ε=1/2 case (P(n,k) > √n) was proved by Erdős.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1201",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1201Problem.lean",
@@ -22,21 +22,21 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). The main conjecture ErdosProblem1201 is open. All 51 structural theorems are fully proved.",
-    "lineCount": 734,
+    "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. All 55 structural theorems are fully proved.",
+    "lineCount": 779,
     "mathlib_version": "4.26.0",
-    "theoremCount": 48
+    "theoremCount": 55
   },
   "overview": {
-    "historicalContext": "Erd\u0151s posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) \u2192 \u221e as n \u2192 \u221e, but its distribution among products of consecutive integers is much subtler. The \u03b5=1/2 case was established by Erd\u0151s: there exist arbitrarily long windows of consecutive integers containing a prime exceeding \u221an. The full conjecture\u2014that large prime factors dominate for almost all starting points n, for any threshold n^(1-\u03b5)\u2014remains open.",
-    "problemStatement": "For every \u03b5,\u03b7 > 0 there exists k such that the upper density of {n | P(n,k) > n^(1-\u03b5)} is at least 1-\u03b7, where P(n,k) is the greatest prime factor of n(n+1)\u00b7\u00b7\u00b7(n+k).",
-    "text": "Let P(n,k) be the greatest prime factor of n(n+1)\u00b7\u00b7\u00b7(n+k). The main conjecture says for every \u03b5,\u03b7>0 there exists k such that {n | P(n,k) > n^(1-\u03b5)} has upper density \u2265 1-\u03b7. Erd\u0151s proved the \u03b5=1/2 case.",
-    "proofStrategy": "We define greatestPrimeFactor using Nat.primeFactors.max', consecutiveProduct as a Finset.prod, and upperDensity via Filter.limsup. The main conjecture and known partial result (\u03b5=1/2) are formalized. The \u03b5=1/2 result is an axiom; all structural properties are proved.",
+    "historicalContext": "Erdős posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) → ∞ as n → ∞, but its distribution among products of consecutive integers is much subtler. The ε=1/2 case was established by Erdős: there exist arbitrarily long windows of consecutive integers containing a prime exceeding √n. The full conjecture—that large prime factors dominate for almost all starting points n, for any threshold n^(1-ε)—remains open.",
+    "problemStatement": "For every ε,η > 0 there exists k such that the upper density of {n | P(n,k) > n^(1-ε)} is at least 1-η, where P(n,k) is the greatest prime factor of n(n+1)···(n+k).",
+    "text": "Let P(n,k) be the greatest prime factor of n(n+1)···(n+k). The main conjecture says for every ε,η>0 there exists k such that {n | P(n,k) > n^(1-ε)} has upper density ≥ 1-η. Erdős proved the ε=1/2 case.",
+    "proofStrategy": "We define greatestPrimeFactor using Nat.primeFactors.max', consecutiveProduct as a Finset.prod, and upperDensity via Filter.limsup. The main conjecture and known partial result (ε=1/2) are formalized. The ε=1/2 result is an axiom; all structural properties are proved.",
     "keyInsights": [
-      "greatestPrimeFactor n \u2208 n.primeFactors and divides n whenever n \u2265 2",
+      "greatestPrimeFactor n ∈ n.primeFactors and divides n whenever n ≥ 2",
       "gpfConsecutive is monotone in k: increasing window length can only increase the greatest prime factor",
-      "The \u03b5=1/2 case P(n,k) > \u221an is equivalent to P(n,k)\u00b2 > n",
-      "gpfConsecutive_large_of_prime_dvd gives a sufficient criterion: any prime p in the window with p > n^(1-\u03b5) witnesses the condition",
+      "The ε=1/2 case P(n,k) > √n is equivalent to P(n,k)² > n",
+      "gpfConsecutive_large_of_prime_dvd gives a sufficient criterion: any prime p in the window with p > n^(1-ε) witnesses the condition",
       "The full conjecture requires analytic number theory; no elementary proof is known"
     ],
     "prerequisites": [
@@ -58,7 +58,7 @@
       "title": "Main Conjecture and Partial Result",
       "startLine": 54,
       "endLine": 69,
-      "summary": "ErdosProblem1201 (open) and erdos_1201_half_case axiom (\u03b5=1/2 proved by Erd\u0151s).",
+      "summary": "ErdosProblem1201 (open) and erdos_1201_half_case axiom (ε=1/2 proved by Erdős).",
       "mathContext": "$\\forall\\varepsilon,\\eta>0\\,\\exists k: \\overline{d}(\\{n : P(n,k)>n^{1-\\varepsilon}\\})\\geq 1-\\eta$. Axiomatized: $\\forall\\eta>0\\,\\exists k: \\overline{d}(\\{n : P(n,k)>\\sqrt{n}\\})\\geq 1-\\eta$."
     },
     {
@@ -73,9 +73,9 @@
       "id": "consecutive-properties",
       "title": "Properties of Consecutive Products",
       "startLine": 118,
-      "endLine": 159,
-      "summary": "Recursion, positivity, divisibility, and monotonicity of consecutiveProduct.",
-      "mathContext": "$\\prod_{i=0}^{k+1}(n+i) = n \\cdot \\prod_{i=0}^{k}(n+1+i)$. Both $n$ and $n+k$ divide the product. The product is positive for $n \\geq 1$."
+      "endLine": 166,
+      "summary": "Recursion, positivity, divisibility, and monotonicity of consecutiveProduct. consecutiveProduct_one: n*(n+1) formula.",
+      "mathContext": "$\\prod_{i=0}^{k+1}(n+i) = n \\cdot \\prod_{i=0}^{k}(n+1+i)$. $\\text{consecutiveProduct}(n,1) = n(n+1)$. Both $n$ and $n+k$ divide the product. The product is positive for $n \\geq 1$."
     },
     {
       "id": "monotonicity",
@@ -87,18 +87,18 @@
     },
     {
       "id": "half-case",
-      "title": "The \u03b5=1/2 Case",
+      "title": "The ε=1/2 Case",
       "startLine": 231,
       "endLine": 266,
       "summary": "Equivalence of sqrt condition and squared GPF condition; specialization of partial result.",
-      "mathContext": "$P(n,k) > \\sqrt{n} \\iff P(n,k)^2 > n$. The \u03b5=1/2 axiom specializes to: $\\forall\\eta>0\\,\\exists k: \\overline{d}(\\{n: n < P(n,k)^2\\}) \\geq 1-\\eta$."
+      "mathContext": "$P(n,k) > \\sqrt{n} \\iff P(n,k)^2 > n$. The ε=1/2 axiom specializes to: $\\forall\\eta>0\\,\\exists k: \\overline{d}(\\{n: n < P(n,k)^2\\}) \\geq 1-\\eta$."
     },
     {
       "id": "bounds",
       "title": "Upper Bounds and Tight Estimates",
       "startLine": 342,
       "endLine": 395,
-      "summary": "gpfConsecutive_zero (base case), prime_dvd_consecutive_range (induction helper), gpfConsecutive_upper_bound (P(n,k) \u2264 n+k), le_gpfConsecutive_of_prime_dvd_term (lower bound from divisibility), gpfConsecutive_between (Bertrand tight bound n < P(n,n) \u2264 2n).",
+      "summary": "gpfConsecutive_zero (base case), prime_dvd_consecutive_range (induction helper), gpfConsecutive_upper_bound (P(n,k) ≤ n+k), le_gpfConsecutive_of_prime_dvd_term (lower bound from divisibility), gpfConsecutive_between (Bertrand tight bound n < P(n,n) ≤ 2n).",
       "mathContext": "$P(n,0) = \\mathrm{gpf}(n)$. $P(n,k) \\leq n+k$ (every prime factor of any term $n+i$ is $\\leq n+i \\leq n+k$). If prime $p \\mid n+i$ for $i \\leq k$, then $p \\leq P(n,k)$. By Bertrand: $n < P(n,n) \\leq 2n$."
     },
     {
@@ -106,16 +106,16 @@
       "title": "Max Formula and Smooth-Window Reformulation",
       "startLine": 472,
       "endLine": 514,
-      "summary": "gpfConsecutive_eq_sup_range: P(n,k) = sup of individual GPFs. gpfConsecutive_le_iff: P(n,k) \u2264 t iff all terms in window are t-smooth.",
-      "mathContext": "$P(n,k) = \\sup_{0 \\leq i \\leq k} P(n+i)$. Equivalently, $P(n,k) \\leq t \\iff \\forall i \\leq k,\\, P(n+i) \\leq t$ (all terms are $t$-smooth). This connects the Erd\u0151s conjecture to Dickman's $\\rho$ function: density of $t$-smooth numbers in $[n, n+k]$."
+      "summary": "gpfConsecutive_eq_sup_range: P(n,k) = sup of individual GPFs. gpfConsecutive_le_iff: P(n,k) ≤ t iff all terms in window are t-smooth.",
+      "mathContext": "$P(n,k) = \\sup_{0 \\leq i \\leq k} P(n+i)$. Equivalently, $P(n,k) \\leq t \\iff \\forall i \\leq k,\\, P(n+i) \\leq t$ (all terms are $t$-smooth). This connects the Erdős conjecture to Dickman's $\\rho$ function: density of $t$-smooth numbers in $[n, n+k]$."
     },
     {
       "id": "prime-gpf",
       "title": "GPF for Primes and Short Windows",
       "startLine": 515,
-      "endLine": 555,
-      "summary": "greatestPrimeFactor_prime: P(n)=n for prime n. gpfConsecutive_prime_start: P(n,0)=n for prime n. gpfConsecutive_one_eq_max: P(n,1)=max(P(n),P(n+1)). gpfConsecutive_ge_left/right: window GPF bounds from endpoints.",
-      "mathContext": "For prime $n$: $P(n) = n$ (primeFactors is $\\{n\\}$, max = $n$). Length-2 window: $P(n,1) = \\max(P(n), P(n+1))$ (via max formula for $k=1$). Endpoint bounds: $P(n) \\leq P(n,k)$ and $P(n+k) \\leq P(n,k)$."
+      "endLine": 575,
+      "summary": "greatestPrimeFactor_prime: P(n)=n for prime n. gpfConsecutive_prime_start: P(n,0)=n for prime n. gpfConsecutive_one_eq_max: P(n,1)=max(P(n),P(n+1)). gpfConsecutive_one_coprime: gpf(n) and gpf(n+1) are coprime. gpfConsecutive_one_ne: gpf(n) ≠ gpf(n+1). gpfConsecutive_ge_left/right: window GPF bounds from endpoints.",
+      "mathContext": "For prime $n$: $P(n) = n$. Length-2 window: $P(n,1) = \\max(P(n), P(n+1))$. Coprimality: $\\gcd(P(n), P(n+1)) = 1$ (since $\\gcd(n, n+1)=1$ and both gpfs divide their respective terms). Distinctness: $P(n) \\neq P(n+1)$."
     },
     {
       "id": "gpf-product-and-recursion",
@@ -137,18 +137,18 @@
       "id": "window-extension-and-prime-terms",
       "title": "Window Extension, Concatenation, and Prime Term Bounds",
       "startLine": 649,
-      "endLine": 734,
-      "summary": "gpfConsecutive_succ_left: left-endpoint extension P(n,k+1)=max(gpf(n),P(n+1,k)). gpfConsecutive_window_concat: window splitting P(n,j+k+1)=max(P(n,j),P(n+j+1,k)). gpfConsecutive_ge_prime_term: prime term gives lower bound n+i ≤ P(n,k). erdos_1201_good_of_prime_in_window: sufficient condition for good n.",
+      "endLine": 762,
+      "summary": "gpfConsecutive_succ_left: left-endpoint extension P(n,k+1)=max(gpf(n),P(n+1,k)). gpfConsecutive_window_concat: window splitting P(n,j+k+1)=max(P(n,j),P(n+j+1,k)). gpfConsecutive_ge_prime_term: prime term gives lower bound n+i ≤ P(n,k). erdos_1201_good_of_prime_in_window: sufficient condition for good n. gpfConsecutive_eq_term_gpf: GPF localization when k < P(n,k).",
       "mathContext": "Left extension: $P(n,k+1) = \\max(P(n), P(n+1,k))$ (symmetric to succ_right). Window concat: $P(n,j+k+1) = \\max(P(n,j), P(n+j+1,k))$ (split at position $j$). Prime term: if $(n+i)$ prime and $i \\leq k$ then $n+i \\leq P(n,k)$ (since $P(n+i) = n+i$ and $P(n+i) \\leq P(n,k)$). Good n: if $\\exists i \\leq k$ with $n+i$ prime and $n+i > n^{1-\\varepsilon}$, then $P(n,k) > n^{1-\\varepsilon}$."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erd\u0151s Problem 1201 on greatest prime factors of consecutive products, the partial \u03b5=1/2 result, and 51 structural theorems. 0 sorries, 1 axiom (the partial result). Sessions 5-7 add: greatestPrimeFactor_mul (product formula), gpfConsecutive_le_of_le_k (general monotonicity), gpfConsecutive_succ_right (recursive formula), gpfConsecutive_eq_right_iff (biconditional), erdos_1201_prime_right_infinite, erdos_1201_eq_right_infinite, gpfConsecutive_succ_left (left-endpoint extension), gpfConsecutive_window_concat (window concatenation), gpfConsecutive_ge_prime_term, erdos_1201_good_of_prime_in_window.",
+    "summary": "The formalization captures Erdős Problem 1201 on greatest prime factors of consecutive products, the partial ε=1/2 result, and 55 structural theorems. 0 sorries, 1 axiom (the partial result). Sessions 5-9 add: greatestPrimeFactor_mul (product formula), gpfConsecutive_le_of_le_k (general monotonicity), gpfConsecutive_succ_right (recursive formula), gpfConsecutive_eq_right_iff (biconditional), erdos_1201_prime_right_infinite, erdos_1201_eq_right_infinite, gpfConsecutive_succ_left (left-endpoint extension), gpfConsecutive_window_concat (window concatenation), gpfConsecutive_ge_prime_term, erdos_1201_good_of_prime_in_window, consecutiveProduct_one, gpfConsecutive_one_coprime, gpfConsecutive_one_ne, gpfConsecutive_eq_term_gpf.",
     "implications": "Resolution would advance our understanding of the distribution of prime factors in consecutive integer products and connect to the Sylvester-Schur theorem and smooth number theory.",
     "openQuestions": [
-      "Does the full conjecture hold for all \u03b5 > 0?",
-      "What is the optimal window size k needed for density 1-\u03b7?",
-      "Is there a connection to Bertrand's postulate for the \u03b5=1 case?"
+      "Does the full conjecture hold for all ε > 0?",
+      "What is the optimal window size k needed for density 1-η?",
+      "Is there a connection to Bertrand's postulate for the ε=1 case?"
     ]
   },
   "leanFile": {
@@ -161,9 +161,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 734,
+    "lineCount": 779,
     "axiomCount": 1,
-    "theoremCount": 51,
+    "theoremCount": 55,
     "definitionCount": 5,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0
@@ -172,12 +172,12 @@
     {
       "targetId": "erdos-677",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem on LCM of consecutive integers \u2014 both study multiplicative structure of consecutive integer blocks"
+      "description": "Related Erdős problem on LCM of consecutive integers — both study multiplicative structure of consecutive integer blocks"
     },
     {
       "targetId": "erdos-1083-oq-02",
       "relationship": "related",
-      "description": "Related problem on distinct distances \u2014 both involve upper density arguments and structural results about infinite sets"
+      "description": "Related problem on distinct distances — both involve upper density arguments and structural results about infinite sets"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

- PRs #15277 and #15286 were merged after our clean PR #15352, introducing ~200 lines of duplicate theorem declarations that break compilation (e.g., `gpfConsecutive_one_eq_max` appeared 4 times, `consecutiveProduct_one` appeared 3 times)
- This fix restores the clean 734-line version from PR #15352, then adds the 4 genuinely unique theorems from those PRs that weren't already present
- Result: 779 lines, 55 theorems, 0 sorries, 1 axiom (erdos_1201_half_case, unchanged)

## 4 New Unique Theorems Added

| Theorem | Description |
|---------|-------------|
| `consecutiveProduct_one` | `consecutiveProduct n 1 = n * (n + 1)` |
| `gpfConsecutive_one_coprime` | `gpf(n) ⊥ gpf(n+1)` via `gcd(n, n+1) = 1` |
| `gpfConsecutive_one_ne` | `gpf(n) ≠ gpf(n+1)` from coprimality |
| `gpfConsecutive_eq_term_gpf` | GPF localization: when `k < P(n,k)`, GPF comes from a single term |

## Test plan

- [ ] No duplicate theorem names: `grep "^theorem " proofs/Proofs/Erdos1201Problem.lean | sort | uniq -d` → empty
- [ ] 55 total theorem/lemma declarations
- [ ] 0 sorries, 1 axiom
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1201Problem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)