### PR TITLE
research(erdos-1208): prove distance_sidon_size_bound via fiber counting

### DIFF
--- a/proofs/Proofs/Erdos1208Problem.lean
+++ b/proofs/Proofs/Erdos1208Problem.lean
@@ -97,7 +97,7 @@ theorem distance_sidon_size_bound {α : Type*} [MetricSpace α]
   -- offDiag.card ≤ 2 * (offDiag image).card  by the fiber bound
   have hoff : Q.offDiag.card ≤
       2 * (Q.offDiag.image fun pq => dist pq.1 pq.2).card :=
-    Finset.card_le_mul_card_image Q.offDiag (fun pq => dist pq.1 pq.2) hfiber
+    Finset.card_le_mul_card_image Q.offDiag 2 hfiber
   -- offDiag image ⊆ Q×Q image
   have himg : (Q.offDiag.image fun pq => dist pq.1 pq.2).card ≤
       ((Q ×ˢ Q).image fun pq => dist pq.1 pq.2).card := by

--- a/proofs/Proofs/Erdos1208Problem.lean
+++ b/proofs/Proofs/Erdos1208Problem.lean
@@ -74,7 +74,39 @@ theorem distance_sidon_size_bound {α : Type*} [MetricSpace α]
     (Q : Finset α) (hQ : IsDistanceSidon Q) :
     Q.card * (Q.card - 1) / 2 ≤
       ((Q ×ˢ Q).image (fun pq => dist pq.1 pq.2)).card := by
-  sorry
+  -- Suffices: Q.card*(Q.card-1) ≤ 2 * |image of Q×Q|, then omega handles the /2
+  suffices h : Q.card * (Q.card - 1) ≤
+      2 * ((Q ×ˢ Q).image fun pq => dist pq.1 pq.2).card by omega
+  -- Rewrite LHS as Q.offDiag.card (since card_offDiag gives s.card*(s.card-1))
+  rw [← Finset.card_offDiag]
+  -- Each distance value in the offDiag image appears for at most 2 pairs (a,b) and (b,a)
+  have hfiber : ∀ d ∈ Q.offDiag.image (fun pq => dist pq.1 pq.2),
+      (Q.offDiag.filter (fun pq => dist pq.1 pq.2 = d)).card ≤ 2 := by
+    intro d hd
+    obtain ⟨⟨a, b⟩, hmem, rfl⟩ := Finset.mem_image.mp hd
+    obtain ⟨ha, hb, _⟩ := Finset.mem_offDiag.mp hmem
+    -- Every element of the fiber is (a, b) or (b, a) by IsDistanceSidon
+    have hsub : Q.offDiag.filter (fun pq => dist pq.1 pq.2 = dist a b) ⊆
+        ({(a, b), (b, a)} : Finset (α × α)) := by
+      intro ⟨c, e⟩ hce
+      simp only [Finset.mem_filter, Finset.mem_offDiag] at hce
+      obtain ⟨⟨hc, he, _⟩, hdist⟩ := hce
+      rcases hQ c hc e he a ha b hb hdist with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ <;> simp
+    exact (Finset.card_le_card hsub).trans
+      ((Finset.card_insert_le _ _).trans (by simp [Finset.card_singleton]))
+  -- offDiag.card ≤ 2 * (offDiag image).card  by the fiber bound
+  have hoff : Q.offDiag.card ≤
+      2 * (Q.offDiag.image fun pq => dist pq.1 pq.2).card :=
+    Finset.card_le_mul_card_image Q.offDiag (fun pq => dist pq.1 pq.2) hfiber
+  -- offDiag image ⊆ Q×Q image
+  have himg : (Q.offDiag.image fun pq => dist pq.1 pq.2).card ≤
+      ((Q ×ˢ Q).image fun pq => dist pq.1 pq.2).card := by
+    apply Finset.card_le_card
+    apply Finset.image_subset_image
+    intro ⟨c, e⟩ hce
+    simp only [Finset.mem_offDiag] at hce
+    exact Finset.mem_product.mpr ⟨hce.1, hce.2.1⟩
+  linarith
 
 /-! ## Known Asymptotic Bounds for F_d(n) (Axiomatized)
 

--- a/src/data/proofs/erdos-1208/meta.json
+++ b/src/data/proofs/erdos-1208/meta.json
@@ -17,10 +17,10 @@
       "incidence-geometry"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 137,
-    "assumptions": "2 axioms: fd2_lower_bound (Spencer–Szemerédi–Trotter lower bound F₂(n) ≥ Ω(n^(1/3))), fd2_upper_bound (grid construction upper bound F₂(n) ≤ O(n^(1/2))). 1 sorry in distance_sidon_size_bound.",
+    "lineCount": 169,
+    "assumptions": "2 axioms: fd2_lower_bound (Spencer–Szemerédi–Trotter lower bound F₂(n) ≥ Ω(n^(1/3))), fd2_upper_bound (grid construction upper bound F₂(n) ≤ O(n^(1/2))).",
     "erdosNumber": 1208,
     "erdosUrl": "https://erdosproblems.com/1208",
     "erdosProblemStatus": "open",
@@ -91,23 +91,23 @@
       "id": "size-bound",
       "title": "Size Bound: k(k-1)/2 Distinct Distances Required",
       "startLine": 58,
-      "endLine": 78,
-      "summary": "States (with sorry) the key lemma: a distance-Sidon subset Q of size k uses at least k(k-1)/2 distinct distances. This is the combinatorial heart: C(k,2) pairs each need a unique distance.",
-      "mathContext": "The sorry reflects that proving `Q.card * (Q.card - 1) / 2 ≤ (Q ×ˢ Q).image (dist).card` requires counting theory for Finset images. The relevant Mathlib lemmas would be `Finset.card_image_le` and injectivity arguments; the full proof requires showing the image-of-pairs is injective under IsDistanceSidon."
+      "endLine": 109,
+      "summary": "Proves the key lemma: a distance-Sidon subset Q of size k uses at least k(k-1)/2 distinct distances. Uses fiber bound: each distance value appears for at most 2 ordered pairs (a,b) and (b,a) by IsDistanceSidon.",
+      "mathContext": "Proved via `Finset.card_offDiag` + `Finset.card_le_mul_card_image` (fiber bound ≤ 2) + `Finset.card_le_card` (offDiag image ⊆ Q×Q image). No sorry remains."
     },
     {
       "id": "axioms",
       "title": "Axioms: Lower and Upper Bounds for F₂(n)",
-      "startLine": 79,
-      "endLine": 124,
+      "startLine": 111,
+      "endLine": 148,
       "summary": "Axiomatizes the two key bounds for d=2: fd2_lower_bound (Spencer–Szemerédi–Trotter 1984: F₂(n) ≥ Ω(n^{1/3})) and fd2_upper_bound (grid construction: ∃ n-point sets where every distance-Sidon subset has size ≤ O(n^{1/2})).",
       "mathContext": "fd2_lower_bound axiom: `∃ C > 0, ∀ n, ∀ P: Finset ℝ², |P|=n → ∃ Q⊆P, IsDistanceSidon Q ∧ C·n^{1/3} ≤ |Q|`. fd2_upper_bound: `∃ C > 0, ∀ n, ∃ P, |P|=n ∧ ∀ Q⊆P, IsDistanceSidon Q → |Q| ≤ C·n^{1/2}`. Both use EuclideanSpace ℝ (Fin 2) for the Euclidean plane."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: F₂(n) ≥ Ω(n^{1/3})",
-      "startLine": 125,
-      "endLine": 137,
+      "startLine": 149,
+      "endLine": 169,
       "summary": "Proves erdos_1208 as a one-line derivation from fd2_lower_bound: every n-point planar set contains a distance-Sidon subset of size ≥ Ω(n^{1/3}). The #check lines verify all key declarations.",
       "mathContext": "`theorem erdos_1208 := fd2_lower_bound`: the main result is immediate from the axiom, confirming the lower bound direction F₂(n) ≥ Ω(n^{1/3}). The upper bound from fd2_upper_bound is stated separately, showing the open gap [1/3, 1/2]."
     }
@@ -143,11 +143,11 @@
       "description": "Erdős #1202 (Prime Sets with Quantitative Density Conditions) is in the same Erdős 1200s cluster. Both #1202 and #1208 formalize open/solved Erdős problems with quantitative lower bound structure, both using axioms to capture deep results (sieve theory for #1202, Szemerédi-Trotter incidence bounds for #1208). The 1200-numbered problems in Erdős's archive span analytic number theory and combinatorial geometry, reflecting his unified interest in threshold phenomena."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "axiomCount": 2,
-    "lineCount": 137,
-    "sorries": 1,
+    "lineCount": 169,
+    "sorries": 0,
     "path": "Proofs/Erdos1208Problem.lean",
     "definitionCount": 1,
     "theoremCount": 4


### PR DESCRIPTION
## Summary

- Proves `distance_sidon_size_bound`: a distance-Sidon subset Q of size k requires at least k(k-1)/2 distinct distance values
- Proof: fiber counting via `Finset.card_le_mul_card_image` — each distance value appears for ≤ 2 ordered pairs (a,b) and (b,a) in `Q.offDiag`, by `IsDistanceSidon`
- Updates `meta.json`: sorries 1→0, lineCount 137→169

## Proof sketch

1. `suffices Q.card*(Q.card-1) ≤ 2*D` — omega handles /2
2. Rewrite via `Finset.card_offDiag`
3. `IsDistanceSidon` ⟹ each distance has ≤ 2 offDiag preimages: the pair {(a,b),(b,a)}
4. `Finset.card_le_mul_card_image Q.offDiag 2 hfiber` ⟹ offDiag.card ≤ 2 * |image|
5. offDiag image ⊆ Q×Q image
6. `linarith`

🤖 Generated with [Claude Code](https://claude.com/claude-code)