### PR TITLE
audit(desargues-oq-01-oq-01): fix stale lineCount/theoremCount/definitionCount

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14143,9 +14143,9 @@
       "issues": []
     },
     "desargues-theorem-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T22:01:42Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-05-03T22:16:59Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -23,9 +23,9 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 260,
-    "theoremCount": 25,
-    "definitionCount": 3,
+    "lineCount": 297,
+    "theoremCount": 30,
+    "definitionCount": 12,
     "mathlibDependencies": [
       {
         "theorem": "Classical.propDecidable",


### PR DESCRIPTION
## Summary

- Fixes stale metadata in `desargues-theorem-oq-01-oq-01/meta.json` — counts diverged after the proof was finalized
- lineCount: 260 → 297
- theoremCount: 25 → 30
- definitionCount: 3 → 12
- Updates audit tracker

All integrity fields remain correct: sorries=0, axiomCount=0, status=verified, badge=original.

## Test plan

- [ ] Verify lineCount matches `wc -l proofs/Proofs/DesarguesTheoremOQ01OQ01.lean`
- [ ] No changes to Lean source or integrity fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)