### PR TITLE
fix(gallery): correct axiom status and line count in 2 meta.json files

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-05-03",
     "axiomCount": 4,
     "assumptions": "4 axioms: (1) chebyshevPsi_doubling_le — ψ(2n) − ψ(n) ≤ 2n·log 2 via the central binomial coefficient C(2n,n) ≤ 4^n; (2) chebyshevPsi_upper_bound — ψ(n) ≤ 2n·log 2 by telescoping the doubling lemma; (3) chebyshevPsi_asymptotic — ψ(n)/n → 1, the Prime Number Theorem for ψ; (4) pnt_equivalence — ψ(n)/n → 1 ↔ π(n) ~ n/log n, the equivalence of PNT forms.",
-    "lineCount": 186,
+    "lineCount": 185,
     "theoremCount": 8,
     "definitionCount": 2,
     "originalContributions": [
@@ -113,7 +113,7 @@
   ],
   "leanFile": {
     "namespace": "ChebyshevBoundsOQ04",
-    "lineCount": 186,
+    "lineCount": 185,
     "path": "Proofs/ChebyshevBoundsOQ04.lean",
     "axiomCount": 4,
     "theoremCount": 8,

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Researcher",
     "sourceUrl": "https://en.wikipedia.org/wiki/Squaring_the_square",
     "date": "2026-05-03",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DissectionOfCubesOQ01OQ03.lean",
     "tags": [
       "geometry",
@@ -17,8 +17,10 @@
       "open-problem",
       "wiedijk-100"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
+    "axiomCount": 2,
+    "assumptions": "2 inherited axioms from DissectionOfCubes.lean: (1) smaller_cube_above_axiom — the smallest cube on the bottom face has smaller cubes directly above it; (2) all_different_implies_long_chains_axiom — a dissection with all different sizes has arbitrarily long decreasing chains. These underlie the collision existence theorem (volume_dissection_has_collision) via every_dissection_has_collision.",
     "mathlibDependencies": [
       {
         "theorem": "Finset.single_le_sum",
@@ -49,7 +51,6 @@
       "volume_constraint_satisfiable: explicit witness (one unit cube)"
     ],
     "dateAdded": "2026-05-03",
-    "axiomCount": 0,
     "lineCount": 256,
     "theoremCount": 14
   },
@@ -103,7 +104,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Proves that the volume constraint ∑ c.side³ = 1 can be formally incorporated into cube dissections via VolumeDissection. The 14 theorems establish volume bounds, connect the constraint to collision pairs (2s³ ≤ 1), and confirm satisfiability. All proofs are axiom-free — they use only Mathlib and the base dissection axioms.",
+    "summary": "Proves that the volume constraint ∑ c.side³ = 1 can be formally incorporated into cube dissections via VolumeDissection. The 14 theorems establish volume bounds, connect the constraint to collision pairs (2s³ ≤ 1), and confirm satisfiability. Volume bound proofs (theorems 1–7, 9–14) are axiom-free; the collision bridge (theorem 8, volume_dissection_has_collision) inherits 2 axioms from the base DissectionOfCubes.lean.",
     "implications": "**Strengthening the geometric model**: VolumeDissection provides a more faithful model of cube dissections than the base CubeDissection (which has covers_unit_cube : True). Any result proved for VolumeDissection automatically applies to genuine cube tilings.\n\n**Collision bound sharpening**: The volume constraint gives 2s³ ≤ 1 for any collision pair, i.e., s ≤ 2^{-1/3} ≈ 0.794. Combined with the side ≤ 1 bound, this provides quantitative constraints on how large any repeated-size cube can be.",
     "openQuestions": [
       "Can the lower bound on collision pairs be sharpened using the volume constraint? OQ-01 gives ≥2; does ∑side³=1 force more?",


### PR DESCRIPTION
## Summary

Two auditor-found gallery integrity fixes:

### Fix 1 (LOW): chebyshev-bounds-oq-04 lineCount off by one
`proofs/Proofs/ChebyshevBoundsOQ04.lean` is exactly 185 lines, but meta.json claimed 186. Updated both `meta.lineCount` and `leanFile.lineCount` to 185.

### Fix 2 (HIGH): dissection-of-cubes-oq-01-oq-03 axiom masking
The proof imports `Proofs.DissectionOfCubes`, which contains two axiom declarations:
- `smaller_cube_above_axiom` (line 206)
- `all_different_implies_long_chains_axiom` (line 221)

The theorem `volume_dissection_has_collision` calls `every_dissection_has_collision` (in `DissectionOfCubesOQ01`), which calls `dissection_of_cubes` (in `DissectionOfCubes`), which transitively depends on both axioms via `all_different_implies_long_chains`. Despite this, the meta.json claimed `status: verified`, `badge: original`, `axiomCount: 0` and described the entry as axiom-free.

Changes:
- `meta.status`: `verified` -> `axiomatized`
- `meta.badge`: `original` -> `axiom`
- `meta.axiomCount`: `0` -> `2`
- Added `meta.assumptions` describing the two inherited axioms
- Updated `conclusion.summary` to remove the "All proofs are axiom-free" claim and clarify that only theorems 1-7 and 9-14 are axiom-free; theorem 8 (`volume_dissection_has_collision`) inherits 2 axioms from the base
- `leanFile.axiomCount` remains `0` (this file declares no new axioms)

Per the Axiom Integrity Policy in CLAUDE.md, transitively-inherited axioms must be reflected in `meta.axiomCount` and `meta.status`.

## Test plan

- [x] Verified `wc -l proofs/Proofs/ChebyshevBoundsOQ04.lean` returns 185
- [x] Verified the two `axiom` declarations exist in `proofs/Proofs/DissectionOfCubes.lean` (lines 206, 221)
- [x] Traced the dependency chain `volume_dissection_has_collision` -> `every_dissection_has_collision` -> `dissection_of_cubes` -> `all_different_implies_long_chains` -> both axioms
- [x] JSON validates with `python3 -m json.tool`