### PR TITLE
fix(bezout-identity-oq-01-oq-01): correct section overlap and OQ ID prefix

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
@@ -101,7 +101,7 @@
       "id": "properties",
       "title": "GCD Properties",
       "startLine": 148,
-      "endLine": 176,
+      "endLine": 167,
       "summary": "Four derived theorems establishing that binaryGcd inherits all GCD properties from Nat.gcd: symmetry (binaryGcd_comm), left and right divisibility, and universality (any common divisor k divides binaryGcd a b)."
     },
     {
@@ -121,12 +121,12 @@
   ],
   "openQuestions": [
     {
-      "id": "binary-gcd-oq-01-oq-01-oq-01",
+      "id": "bezout-identity-oq-01-oq-01-oq-01",
       "question": "Can the complexity bound be formalized? Stein's algorithm runs in O(log²(max(a,b))) bit operations. Can this be proved in Lean using a bit-length measure on a+b?",
       "status": "open"
     },
     {
-      "id": "binary-gcd-oq-01-oq-01-oq-02",
+      "id": "bezout-identity-oq-01-oq-01-oq-02",
       "question": "Can binaryGcd be extended to integers? The natural extension handles signs separately: binaryGcd |a| |b| gives the GCD magnitude. Does this compose cleanly with Int.gcdA/gcdB to give a binary extended GCD?",
       "status": "open"
     }


### PR DESCRIPTION
## Fix

Two low-severity meta.json corrections identified by the auditor review on PR #15376.

## Evidence

**Before**:
- `properties.endLine: 176` — overlaps with `bezout` section starting at line 168; `bezout_via_binaryGcd` (lines 168–176) was double-counted
- `openQuestions[0].id: "binary-gcd-oq-01-oq-01-oq-01"` — uses wrong prefix
- `openQuestions[1].id: "binary-gcd-oq-01-oq-01-oq-02"` — uses wrong prefix

**After**:
- `properties.endLine: 167` — section ends at the blank line before the Bézout corollary
- `openQuestions[0].id: "bezout-identity-oq-01-oq-01-oq-01"` — matches proof slug
- `openQuestions[1].id: "bezout-identity-oq-01-oq-01-oq-02"` — matches proof slug

Integrity fields (sorries, axiomCount, status, badge) are unchanged — all correct.

---
Automated fix by lean-mechanic agent. Addresses auditor comment on PR #15376.