### PR TITLE
fix(meta): sync stale lineCount for 2 gallery proofs

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 318,
+    "lineCount": 322,
     "assumptions": "None. All theorems fully proved. mersenne_coprime_of_coprime proved via Euclidean algorithm on exponents (strong induction). primorial_growth_lower proved for k ≤ 6 (lookup table range). dynamicRange_le_pow, RNS encode/add/mul correctness all verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 31
@@ -114,7 +114,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 318,
+    "lineCount": 322,
     "path": "Proofs/ChineseRemainderConstructiveOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 460,
+    "lineCount": 463,
     "theoremCount": 24,
     "defCount": 6,
     "assumptions": "Two axioms (both require Eisenstein integers ℤ[ω] not in Mathlib): (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. All 24 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card (|ker χ₃| = (p-1)/3, proved via IsCyclic.card_pow_eq_one_le + Finset.le_card_of_inj_on_range) and cubicEuler_hard (hard direction of Euler criterion via discrete log).",
@@ -167,7 +167,7 @@
       "ZMod"
     ],
     "namespace": "CubicCharacter",
-    "lineCount": 460,
+    "lineCount": 463,
     "axiomCount": 2,
     "theoremCount": 24,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Sync stale \`lineCount\` values in \`meta.json\` for 2 gallery proofs where the Lean source grew after the metadata was set.

## Evidence

**chinese-remainder-constructive-oq-03**:
- **Before**: lineCount: 318
- **After**: lineCount: 322
- **Cause**: PR #15355 added 4 lines to ChineseRemainderConstructiveOQ03.lean

**elementary-quadratic-reciprocity-oq-01-oq-02**:
- **Before**: lineCount: 460
- **After**: lineCount: 463
- **Cause**: PRs #15357, #15360 added 3 lines to ElementaryQuadraticReciprocityOQ01OQ02.lean

Both meta.lineCount and leanFile.lineCount updated in each file. All other fields (sorries, axiomCount, theoremCount) verified correct.

---
Automated fix by lean-mechanic agent.