### PR TITLE
fix(lagrange-four-squares): remove jacobi_four_squares True stub

### DIFF
--- a/proofs/Proofs/LagrangeFourSquares.lean
+++ b/proofs/Proofs/LagrangeFourSquares.lean
@@ -205,12 +205,6 @@ def r4 (n : ℕ) : ℕ :=
 def sumDivisorsNot4 (n : ℕ) : ℕ :=
   (Finset.filter (fun d => d ∣ n ∧ ¬(4 ∣ d)) (Finset.range (n + 1))).sum id
 
-/-- Jacobi's four-square theorem: r₄(n) = 8 · Σ_{d|n, 4∤d} d -/
-theorem jacobi_four_squares (n : ℕ) (hn : n ≥ 1) :
-    -- The number of ways to write n as ordered sum of 4 integer squares
-    -- equals 8 times the sum of divisors not divisible by 4
-    True := trivial
-
 /-- For prime p, r₄(p) = 8(p + 1) since divisors are 1 and p, neither div by 4 -/
 theorem r4_prime_formula (p : ℕ) (hp : Nat.Prime p) (hp_odd : p % 2 = 1) :
     sumDivisorsNot4 p = 1 + p := by
@@ -400,7 +394,6 @@ theorem hurwitz_representation_count :
 
 -- Part III: Representation Counts
 #check sumDivisorsNot4
-#check jacobi_four_squares
 
 -- Part IV: Waring's Problem
 #check waringG

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -34,8 +34,8 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 5,
-    "assumptions": "5 axiom declarations: legendre_three_squares (3-square obstruction criterion), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound). Previously axiomatized fermat_two_squares, jacobi_four_squares, hurwitz_quaternions_euclidean now proved.",
-    "lineCount": 417,
+    "assumptions": "5 axiom declarations: legendre_three_squares (3-square obstruction criterion), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound). fermat_two_squares has been formally proved. jacobi_four_squares (True stub) removed — Jacobi's r₄(n) formula is not formalized. hurwitz_quaternions_euclidean and hurwitz_representation_count remain as True stubs.",
+    "lineCount": 410,
     "prerequisites": [
       "Quaternion algebra and norm multiplicativity",
       "Euler's four-square identity",
@@ -44,7 +44,7 @@
       "Waring's problem and additive number theory"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 18
+    "theoremCount": 17
   },
   "overview": {
     "historicalContext": "Lagrange's four squares theorem was proved by Joseph-Louis Lagrange in 1770, building on earlier work by Euler. The result answered a question that had puzzled mathematicians since antiquity: Diophantus had noted around 250 CE that certain numbers seemed to require many squares.\n\nThe deeper story involves one of mathematics' greatest coincidences: Euler discovered the four-square identity in 1748, showing that the product of two sums-of-four-squares is itself a sum of four squares. Nearly a century later, Hamilton discovered quaternions in 1843. The four-square identity IS quaternion multiplication! The norm of a product equals the product of norms.\n\nThis explains WHY four squares work when three don't: quaternions form a division algebra, but there is no 3-dimensional division algebra (proved by Frobenius in 1877). The algebraic structure that makes four squares work simply doesn't exist for three.\n\nAs one reviewer put it: \"The four squares theorem is astounding, it says something utterly profound about the universe... that's what binds the galaxies together.\"",
@@ -170,9 +170,9 @@
     ],
     "opens": [],
     "namespace": "LagrangeFourSquares",
-    "lineCount": 417,
+    "lineCount": 410,
     "axiomCount": 5,
-    "theoremCount": 18,
+    "theoremCount": 17,
     "definitionCount": 8,
     "path": "Proofs/LagrangeFourSquares.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Remove the misleading `jacobi_four_squares` stub theorem that proved `True := trivial` while its name/signature implied Jacobi's four-square formula was formalized.

## Evidence

**Before**: `theorem jacobi_four_squares (n : ℕ) (hn : n ≥ 1) : True := trivial` — looked like a proved result, actually proved nothing.

**After**: Stub removed. `meta.json` corrections:
- `theoremCount`: 18 → 17 (one less stub)
- `lineCount`: 417 → 410 (7 lines removed)
- `assumptions`: corrected false claim that `jacobi_four_squares` was "now proved"

The entry remains correctly `axiomatized/axiom`. Jacobi's r₄(n) = 8Σ formula is documented as unformalized in the assumptions field.

Closes #15388

---
Automated fix by lean-mechanic agent.