### PR TITLE
enrich: fix annotations schema for chinese-remainder and desargues-theorem-oq-01-oq-01

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/annotations.json
@@ -1,96 +1,135 @@
-{
-  "id": "chinese-remainder-constructive-oq-03-oq-03",
-  "source": "lean-genius-researcher",
-  "annotations": [
-    {
-      "id": "ann-001",
-      "type": "theorem",
-      "lean": "theorem pow2_coprime_odd (k : ℕ) {m : ℕ} (hm : m % 2 = 1) :\n    Nat.Coprime (2 ^ k) m :=\n  Nat.Coprime.pow_left k (Nat.coprime_two_right.mpr (Nat.odd_iff.mpr hm))",
-      "line": 61,
-      "title": "Powers of 2 are coprime to odd numbers",
-      "body": "The fundamental coprimality result: 2^k and any odd number m have gcd 1. The proof chains three Mathlib lemmas: Nat.odd_iff converts the mod-2 condition to the Odd predicate, Nat.coprime_two_right.mpr gives Nat.Coprime 2 m when m is odd, and Nat.Coprime.pow_left lifts this to 2^k.",
-      "tags": ["coprimality", "power-of-2", "core-result"]
+[
+  {
+    "id": "ann-pow2-coprime-odd",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-03",
+    "range": {
+      "startLine": 61,
+      "endLine": 70
     },
-    {
-      "id": "ann-002",
-      "type": "theorem",
-      "lean": "theorem pow2_not_coprime_pow2 {k j : ℕ} (hk : 1 ≤ k) (hj : 1 ≤ j) :\n    ¬ Nat.Coprime (2 ^ k) (2 ^ j)",
-      "line": 72,
-      "title": "Two positive powers of 2 are never coprime",
-      "body": "The uniqueness constraint: any two distinct powers of 2 share factor 2. Since 2 ∣ 2^k and 2 ∣ 2^j for k, j ≥ 1, we have 2 ∣ gcd(2^k, 2^j), so gcd ≥ 2 > 1. This explains why an RNS base can contain at most one power of 2.",
-      "tags": ["coprimality", "power-of-2", "uniqueness-constraint"]
+    "type": "theorem",
+    "title": "Powers of 2 are Coprime to Odd Numbers",
+    "content": "`pow2_coprime_odd` proves `Nat.Coprime (2^k) m` for any odd `m` (i.e., `m % 2 = 1`). The proof chains three Mathlib lemmas: `Nat.odd_iff.mpr hm` converts the mod-2 condition to `Odd m`; `Nat.coprime_two_right.mpr` lifts this to `Nat.Coprime 2 m`; `Nat.Coprime.pow_left k` extends coprimality to `2^k`. The entire proof is a single term-mode chain — no tactics needed.",
+    "mathContext": "$\\gcd(2^k, m) = 1$ whenever $m$ is odd, because any common divisor divides $2^k$ (so is a power of 2) and also divides $m$ (which is odd), forcing it to be 1. This is the fundamental fact making power-of-2 RNS channels compatible with odd channels: $2^k$ contributes a factor of 2 to the dynamic range without conflicting with any odd modulus.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.Coprime.pow_left",
+      "Nat.coprime_two_right",
+      "Nat.odd_iff"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Nat.Coprime definition (gcd = 1)"
+    ]
+  },
+  {
+    "id": "ann-pow2-not-coprime",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-03",
+    "range": {
+      "startLine": 72,
+      "endLine": 84
     },
-    {
-      "id": "ann-003",
-      "type": "definition",
-      "lean": "structure Pow2RNSBase where\n  power : ℕ\n  oddMods : List ℕ\n  power_pos : 1 ≤ power\n  mods_ge_three : ∀ m ∈ oddMods, 3 ≤ m\n  mods_odd : ∀ m ∈ oddMods, m % 2 = 1\n  mods_coprime : oddMods.Pairwise Nat.Coprime",
-      "line": 87,
-      "title": "The Pow2RNSBase structure",
-      "body": "A valid power-of-2 RNS base has one power-of-2 channel (exponent ≥ 1) and a list of odd channels (each ≥ 3, pairwise coprime). The constraints ensure: (1) the power-of-2 channel is ≥ 2, (2) each odd channel is a valid RNS channel, (3) the odd channels are mutually coprime. Together with pow2_coprime_odd, this makes the full list pairwise coprime.",
-      "tags": ["structure", "rns-base", "hardware"]
+    "type": "theorem",
+    "title": "Two Positive Powers of 2 are Never Coprime",
+    "content": "`pow2_not_coprime_pow2` proves `¬ Nat.Coprime (2^k) (2^j)` when `k ≥ 1` and `j ≥ 1`. Since `2 ∣ 2^k` and `2 ∣ 2^j`, we have `2 ∣ gcd(2^k, 2^j)`, so the gcd is at least 2, not 1. This establishes the uniqueness constraint: an RNS base can contain **at most one** power of 2 as a modulus.",
+    "mathContext": "In the residue number system, the moduli must be pairwise coprime to guarantee the Chinese Remainder Theorem (CRT) applies — each residue vector has a unique integer representative in $[0, M)$ where $M$ is the dynamic range. Since $\\gcd(2^k, 2^j) = 2^{\\min(k,j)} \\geq 2$, two powers of 2 cannot both appear as moduli.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.Coprime",
+      "Chinese Remainder Theorem",
+      "RNS validity"
+    ],
+    "prerequisites": [
+      "pow2_coprime_odd",
+      "Nat.dvd_pow"
+    ]
+  },
+  {
+    "id": "ann-pow2rnsbase-structure",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-03",
+    "range": {
+      "startLine": 87,
+      "endLine": 102
     },
-    {
-      "id": "ann-004",
-      "type": "theorem",
-      "lean": "theorem Pow2RNSBase.pairwise_coprime (b : Pow2RNSBase) :\n    b.moduli.Pairwise Nat.Coprime",
-      "line": 103,
-      "title": "A Pow2RNSBase gives a pairwise coprime list",
-      "body": "The full moduli list [2^power, m₁, ..., mₙ] is pairwise coprime. Proof uses List.Pairwise.cons: the head (2^power) is coprime to each mᵢ via pow2_coprime_odd (since each mᵢ is odd by mods_odd), and the tail is pairwise coprime by mods_coprime.",
-      "tags": ["pairwise-coprimality", "rns-validity", "structure"]
+    "type": "definition",
+    "title": "Pow2RNSBase: Structure for Power-of-2 RNS Bases",
+    "content": "`Pow2RNSBase` is a structure with fields: `power : ℕ` (the exponent, so the power-of-2 channel is `2^power`), `oddMods : List ℕ` (the odd channels), `power_pos : 1 ≤ power` (so the channel is ≥ 2), `mods_ge_three : ∀ m ∈ oddMods, 3 ≤ m` (odd channels are proper moduli, ≥ 3), `mods_odd : ∀ m ∈ oddMods, m % 2 = 1`, and `mods_coprime : oddMods.Pairwise Nat.Coprime`. The `moduli` field (computed) is `[2^power] ++ oddMods`. Together with `pow2_coprime_odd`, the constraints make the full moduli list pairwise coprime.",
+    "mathContext": "Hardware RNS systems like the {4, 3, 5, 7} base (used in DSP chips) have one power-of-2 channel for efficient modular reduction via bitwise AND. The structure formalizes this hardware design pattern: one channel of the form $2^k$ (cheap to implement: `x mod 2^k = x &&& (2^k - 1)`) plus several odd prime channels (implemented via Montgomery reduction or lookup tables).",
+    "significance": "key",
+    "relatedConcepts": [
+      "List.Pairwise",
+      "Nat.Coprime",
+      "RNS base hardware design"
+    ],
+    "prerequisites": [
+      "pow2_coprime_odd",
+      "pow2_not_coprime_pow2"
+    ]
+  },
+  {
+    "id": "ann-pairwise-coprime",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-03",
+    "range": {
+      "startLine": 103,
+      "endLine": 128
     },
-    {
-      "id": "ann-005",
-      "type": "theorem",
-      "lean": "theorem Pow2RNSBase.dynamicRange_eq (b : Pow2RNSBase) :\n    b.toRNSBase.dynamicRange = 2 ^ b.power * b.oddMods.prod",
-      "line": 130,
-      "title": "Dynamic range formula for power-of-2 RNS base",
-      "body": "The dynamic range (product of all moduli) factors as 2^power times the product of the odd moduli. For {4, 3, 5, 7}: range = 4 × 3 × 5 × 7 = 420. For {16, 3, 5, 7, 11, 13}: range = 16 × 15015 = 240240. The factored form makes the dependence on k explicit.",
-      "tags": ["dynamic-range", "product-formula", "hardware"]
+    "type": "theorem",
+    "title": "Pow2RNSBase Gives a Pairwise Coprime Moduli List",
+    "content": "`Pow2RNSBase.pairwise_coprime` proves the full moduli list `[2^power, m₁, ..., mₙ]` is pairwise coprime. The proof uses `List.Pairwise.cons`: the head `2^power` must be coprime to each `mᵢ` in `oddMods`, which follows from `pow2_coprime_odd` since each `mᵢ` is odd (by `mods_odd`); the tail `oddMods` is pairwise coprime by `mods_coprime`. This satisfies the CRT hypothesis for the full moduli list.",
+    "mathContext": "For CRT to give a unique representation, the moduli must be pairwise coprime: $\\gcd(m_i, m_j) = 1$ for all $i \\neq j$. The `Pow2RNSBase` constraints exactly encode this: within the odd channels (`mods_coprime`), between the power-of-2 channel and each odd channel (`pow2_coprime_odd` + `mods_odd`). The dynamic range is then $M = 2^k \\cdot \\prod m_i$ and every integer in $[0, M)$ has a unique residue vector.",
+    "significance": "key",
+    "relatedConcepts": [
+      "List.Pairwise.cons",
+      "Nat.Coprime",
+      "Chinese Remainder Theorem"
+    ],
+    "prerequisites": [
+      "Pow2RNSBase structure",
+      "pow2_coprime_odd"
+    ]
+  },
+  {
+    "id": "ann-dynamic-range",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-03",
+    "range": {
+      "startLine": 130,
+      "endLine": 165
     },
-    {
-      "id": "ann-006",
-      "type": "example",
-      "lean": "theorem base_4_3_5_7_coprime : [4, 3, 5, 7].Pairwise Nat.Coprime := by decide\ntheorem base_4_3_5_7_range : [4, 3, 5, 7].prod = 420 := by norm_num",
-      "line": 141,
-      "title": "The base {4, 3, 5, 7}: range 420",
-      "body": "A concrete 4-channel RNS base with a power-of-2 channel: 4 = 2², with odd channels 3, 5, 7. Dynamic range 420. Compare with the prime base {2, 3, 5, 7} (range 210): replacing 2 with 4 doubles the range with the same channel count.",
-      "tags": ["concrete-example", "hardware", "4-channel"]
+    "type": "insight",
+    "title": "Dynamic Range Formula and Hardware Efficiency Comparison",
+    "content": "`dynamicRange_eq` proves `b.toRNSBase.dynamicRange = 2^b.power * b.oddMods.prod` — the dynamic range factors as the power-of-2 channel times the product of odd channels. `pow2_channel_doubles_range` proves `[4,3,5,7].prod = 2 * [2,3,5,7].prod`: replacing the channel 2 with 4 = 2² doubles the dynamic range from 210 to 420 with no change in channel count. Concrete examples verify: `base_4_3_5_7_coprime` (by `decide`), `base_4_3_5_7_range` (by `norm_num`), `base_16_3_5_7_11_13_range = 240240` (by `norm_num`).",
+    "mathContext": "For a base $\\{2^k, m_1, \\ldots, m_n\\}$, the dynamic range is $M = 2^k \\cdot \\prod m_i$. Increasing $k$ by 1 doubles $M$. Hardware benefit: `x mod 2^k` is computed as `x & (2^k - 1)`, a single instruction. Increasing $k$ from 1 to 4 (using 16 instead of 2) increases the range by $16/2 = 8\\times$ at the cost of a wider AND mask — essentially free in hardware. The {16, 3, 5, 7, 11, 13} base gives range 240240, covering a 17.9-bit integer range with only 6 modular reduction operations.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.prod",
+      "dynamicRange",
+      "hardware modular arithmetic"
+    ],
+    "prerequisites": [
+      "Pow2RNSBase.pairwise_coprime",
+      "Nat.pow",
+      "norm_num for concrete arithmetic"
+    ]
+  },
+  {
+    "id": "ann-invalidity-and-bit-width",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-03",
+    "range": {
+      "startLine": 168,
+      "endLine": 203
     },
-    {
-      "id": "ann-007",
-      "type": "example",
-      "lean": "theorem base_16_3_5_7_11_13_coprime :\n    [16, 3, 5, 7, 11, 13].Pairwise Nat.Coprime := by decide\ntheorem base_16_3_5_7_11_13_range : [16, 3, 5, 7, 11, 13].prod = 240240 := by norm_num",
-      "line": 153,
-      "title": "The base {16, 3, 5, 7, 11, 13}: range 240240",
-      "body": "A 6-channel RNS base: 16 = 2⁴, with the first 5 odd primes. Dynamic range 240240. A hardware implementation would compute mod-16 via a 4-bit AND mask, while the 5 odd channels use standard modular arithmetic. The large range (up to 240240 representable values) makes this base suitable for DSP applications.",
-      "tags": ["concrete-example", "hardware", "6-channel", "dsp"]
-    },
-    {
-      "id": "ann-008",
-      "type": "theorem",
-      "lean": "theorem pow2_channel_doubles_range :\n    [4, 3, 5, 7].prod = 2 * [2, 3, 5, 7].prod := by norm_num",
-      "line": 160,
-      "title": "Replacing 2 with 4 doubles the dynamic range",
-      "body": "For the same 4 channels and same channel count, using 4 = 2² instead of 2 doubles the dynamic range from 210 to 420. This illustrates the general principle: replacing 2^j with 2^k (j < k) multiplies the range by 2^(k-j). The hardware overhead of the power-of-2 channel is essentially the same (bitwise AND with a wider mask).",
-      "tags": ["efficiency", "range-comparison", "hardware"]
-    },
-    {
-      "id": "ann-009",
-      "type": "theorem",
-      "lean": "theorem base_2_4_invalid : ¬ [2, 4].Pairwise Nat.Coprime := by decide\ntheorem base_4_8_invalid : ¬ [4, 8].Pairwise Nat.Coprime := by decide",
-      "line": 168,
-      "title": "Two powers of 2 make an invalid base",
-      "body": "Concrete witnesses for the uniqueness constraint. gcd(2, 4) = 2 ≠ 1 and gcd(4, 8) = 4 ≠ 1. These are verified by decide (kernel computation). The general case is proved by pow2_not_coprime_pow2.",
-      "tags": ["invalidity", "uniqueness-constraint", "counter-examples"]
-    },
-    {
-      "id": "ann-010",
-      "type": "theorem",
-      "lean": "theorem pow2_bit_length (k : ℕ) : Nat.log 2 (2 ^ k) = k :=\n  Nat.log_pow (by norm_num : 1 < 2) k",
-      "line": 188,
-      "title": "Hardware bit-width of the power-of-2 channel",
-      "body": "⌊log₂(2^k)⌋ = k, confirming that the 2^k channel requires a k-bit AND mask for modular reduction. The reduction x mod 2^k = x &&& (2^k - 1) uses a k-bit mask. This is a single instruction on modern hardware, making the power-of-2 channel the cheapest RNS channel to implement.",
-      "tags": ["hardware", "bit-operations", "efficiency"]
-    }
-  ]
-}
+    "type": "technique",
+    "title": "Invalidity Witnesses and Hardware Bit-Width Verification",
+    "content": "`base_2_4_invalid` and `base_4_8_invalid` are concrete witnesses for the uniqueness constraint: `¬ [2, 4].Pairwise Nat.Coprime` and `¬ [4, 8].Pairwise Nat.Coprime`, both proved by `decide` (kernel computation of `gcd(2,4) = 2` and `gcd(4,8) = 4`). `pow2_bit_length` proves `Nat.log 2 (2^k) = k` via `Nat.log_pow`: this confirms the `2^k` channel requires exactly a `k`-bit AND mask for modular reduction, with `x mod 2^k = x &&& (2^k - 1)`. These results ground the hardware efficiency claims in formal verification.",
+    "mathContext": "The `decide` tactic delegates to the kernel's definitional reduction: for small lists, it computes `Nat.gcd 2 4 = 2 ≠ 1` directly. `Nat.log 2 (2^k) = k` is a key formula: the bit-width of the modulus equals its binary logarithm. In hardware, the reduction `x mod 2^k` costs one AND instruction; the full modulus needs `k` bits of storage. Compare: `x mod 7` requires a division or Montgomery multiplication — roughly $O(k^2)$ gate area. The power-of-2 channel is asymptotically cheaper.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "decide tactic",
+      "Nat.log_pow",
+      "hardware cost model"
+    ],
+    "prerequisites": [
+      "pow2_not_coprime_pow2",
+      "Nat.log definition"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/index.ts
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/index.ts
@@ -1,4 +1,8 @@
-import meta from './meta.json';
-import annotations from './annotations.json';
-
-export { meta, annotations };
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChineseRemainderConstructiveOQ03OQ03.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const chineseRemainderConstructiveOq03Oq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const chineseRemainderConstructiveOq03Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const chineseRemainderConstructiveOq03Oq03Data: ProofData = { proof: chineseRemainderConstructiveOq03Oq03Proof, annotations: chineseRemainderConstructiveOq03Oq03Annotations, tacticStates: [] }


### PR DESCRIPTION
## Summary

Enrichment batch fixing annotation schemas and adding new annotations for 2 entries:

- **chinese-remainder-constructive-oq-03-oq-03**: Rewrote `annotations.json` from non-standard object wrapper (`{id, source, annotations:[...]}`) to proper plain array with full schema (`proofId`, `range`, `content`, `mathContext`, `significance`, `relatedConcepts`, `prerequisites`). Fixed `index.ts` from bare `export {meta, annotations}` to typed `Proof`/`Annotation`/`ProofData` exports. 6 annotations covering: pow2 coprimality chain, uniqueness constraint, Pow2RNSBase structure, pairwise_coprime proof, dynamic range + hardware efficiency, invalidity witnesses + bit-width.
- **desargues-theorem-oq-01-oq-01**: Created `annotations.json` (5 annotations: Moulton line piecewise def, perspectivity verification, intersection structure, desargues_fails linear system, moulton_counterexample certificate), `index.ts` with typed exports, and fixed `meta.json` schema (sections `content→summary` + `id`/`startLine`/`endLine`, conclusion string→object, crossReferences `slug/relation→targetId/relationship`).

Labels: enrichment

🤖 Generated with [Claude Code](https://claude.ai/claude-code)