### PR TITLE
audit(tracker): mark wilsons-theorem-oq-01-oq-01 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14169,6 +14169,12 @@
       "lastAudited": "2026-05-03T22:42:46Z",
       "result": "issues-found",
       "notes": "PR #15376 not yet merged. Section endLine overlap and open question ID prefix mismatch. Comment filed on PR #15376."
+    },
+    "wilsons-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-03T23:25:56Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit Tracker Update

Marks `wilsons-theorem-oq-01-oq-01` as `issues-fixed` after finding and correcting:

- `axiomCount` corrected from 1 to 2 (the 563 Wilson prime was axiomatized but not counted)
- `assumptions` updated to list both axioms (`fiveHundredSixtyThree_is_wilson_prime` + `infinitely_many_wilson_primes`)
- Description fixed: "Verifies the third Wilson prime 563" → "Axiomatizes the third Wilson prime 563"
- `significance` corrected: removed false "First Lean 4 verification" claim (it was an axiom, not a verified theorem)
- `theoremCount`/`definitionCount` corrected to match actual Lean file
- `sections` and `originalContributions` updated to reflect actual file structure

Fix in PR #15393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)