### PR TITLE
research(buffons-needle-oq-01-oq-01-oq-04): extend dimension ladder c5/c6, fix recurrence bug

### DIFF
--- a/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean
@@ -98,6 +98,37 @@ theorem sphereArea_three : sphereArea 3 = 2 * π ^ 2 := by
   rw [rpow_natCast]
   ring
 
+/-- σ_4 = 8π²/3 (surface area of S^4 ⊂ ℝ^5).
+    Proof: 2π^{5/2}/Γ(5/2) = 2π^{5/2}/((3/4)√π) = 8π²/3. -/
+theorem sphereArea_four : sphereArea 4 = 8 * π ^ 2 / 3 := by
+  unfold sphereArea
+  simp only [Nat.cast_ofNat]
+  rw [show (4 + 1 : ℝ) / 2 = 5 / 2 from by ring]
+  have h52 : Gamma (5 / 2 : ℝ) = 3 / 4 * √π := by
+    have h32 := Gamma_add_one (show (3 / 2 : ℝ) ≠ 0 from by norm_num)
+    rw [show (3 : ℝ) / 2 + 1 = 5 / 2 from by ring] at h32
+    rw [h32]
+    have h12 := Gamma_add_one (show (1 / 2 : ℝ) ≠ 0 from by norm_num)
+    rw [show (1 : ℝ) / 2 + 1 = 3 / 2 from by ring] at h12
+    rw [h12, Gamma_one_half_eq]; ring
+  rw [h52, show (5 : ℝ) / 2 = 2 + 1 / 2 from by ring, rpow_add pi_pos, rpow_natCast,
+      ← Real.sqrt_eq_rpow]
+  have hpi : (0 : ℝ) < √π := Real.sqrt_pos.mpr pi_pos
+  field_simp [hpi.ne']
+  ring
+
+/-- σ_5 = π³ (surface area of S^5 ⊂ ℝ^6).
+    Proof: 2π^3/Γ(3) = 2π^3/2 = π^3. -/
+theorem sphereArea_five : sphereArea 5 = π ^ 3 := by
+  unfold sphereArea
+  simp only [Nat.cast_ofNat]
+  rw [show (5 + 1 : ℝ) / 2 = 3 from by ring]
+  rw [show Gamma (3 : ℝ) = 2 from by
+    rw [show (3 : ℝ) = 2 + 1 from by norm_num,
+        Gamma_add_one (show (2 : ℝ) ≠ 0 from by norm_num),
+        show (2 : ℝ) = 1 + 1 from by norm_num, Gamma_add_one one_ne_zero, Gamma_one]; ring]
+  rw [rpow_natCast]; ring
+
 /-- The n-sphere/n-ball relationship: σ_{n-1} = n · ω_n where
     ω_n = π^{n/2}/Γ(n/2+1) is the unit n-ball volume.
     This is because differentiating Vol(B^n(r)) = ω_n r^n gives
@@ -159,6 +190,29 @@ theorem cauchyCrofton_four : cauchyCroftonConst 4 = 4 / (3 * π) := by
   push_cast
   have hpi : (0 : ℝ) < π := pi_pos
   field_simp [hpi.ne']
+  ring
+
+/-- c_5 = 3/8: the 5D crossing constant.
+    Proof: c_5 = 2σ_3/(4·σ_4) = 2·2π²/(4·8π²/3) = 3/8. -/
+theorem cauchyCrofton_five : cauchyCroftonConst 5 = 3 / 8 := by
+  unfold cauchyCroftonConst
+  simp only [show (5 : ℕ) - 2 = 3 from rfl, show (5 : ℕ) - 1 = 4 from rfl]
+  rw [sphereArea_three, sphereArea_four]
+  push_cast
+  have hpi2 : (π : ℝ) ^ 2 ≠ 0 := by positivity
+  field_simp [hpi2]
+  ring
+
+/-- c_6 = 16/(15π): the 6D crossing constant.
+    Proof: c_6 = 2σ_4/(5·σ_5) = 2·8π²/3/(5·π³) = 16/(15π). -/
+theorem cauchyCrofton_six : cauchyCroftonConst 6 = 16 / (15 * π) := by
+  unfold cauchyCroftonConst
+  simp only [show (6 : ℕ) - 2 = 4 from rfl, show (6 : ℕ) - 1 = 5 from rfl]
+  rw [sphereArea_four, sphereArea_five]
+  push_cast
+  have hpi : (0 : ℝ) < π := pi_pos
+  have hpi3 : (π : ℝ) ^ 3 ≠ 0 := by positivity
+  field_simp [hpi.ne', hpi3]
   ring
 
 /-- c_n is positive for n ≥ 2. -/
@@ -271,23 +325,22 @@ The constants c_n satisfy a recurrence related to the sphere area recurrence.
 The ratio σ_n/σ_{n-1} controls the geometry.
 -/
 
-/-- The sphere area recurrence: σ_n = 2π/(n) · σ_{n-2} for n ≥ 2.
+/-- The sphere area recurrence: σ_n = 2π/(n-1) · σ_{n-2} for n ≥ 2.
     This follows from Γ((n+1)/2) = ((n-1)/2) · Γ((n-1)/2). -/
 theorem sphereArea_recurrence (n : ℕ) (hn : 2 ≤ n) :
-    sphereArea n = 2 * π / n * sphereArea (n - 2) := by
+    sphereArea n = 2 * π / ((n : ℝ) - 1) * sphereArea (n - 2) := by
   unfold sphereArea
-  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
+  have hn1_pos : (0 : ℝ) < (n : ℝ) - 1 := by
+    have h : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    linarith
+  have hn1_ne : (n : ℝ) - 1 ≠ 0 := hn1_pos.ne'
   have h_cast : ((n : ℕ) : ℝ) + 1 = ((n - 2 : ℕ) : ℝ) + 3 := by push_cast; omega
-  rw [show ((n : ℝ) + 1) / 2 = ((n - 2 : ℕ) : ℝ) / 2 + 3 / 2 from by
-    rw [h_cast]; ring]
-  rw [show ((n - 2 : ℕ) : ℝ) / 2 + 3 / 2 = (((n - 2 : ℕ) : ℝ) + 1) / 2 + 1 from by
-    push_cast; ring]
-  rw [Gamma_add_one (show (((n - 2 : ℕ) : ℝ) + 1) / 2 ≠ 0 from by positivity)]
-  rw [rpow_add pi_pos, rpow_one]
-  rw [show ((n - 2 : ℕ) : ℝ) / 2 + 3 / 2 = ((n : ℝ) + 1) / 2 from by
-    push_cast; omega]
+  rw [show ((n : ℝ) + 1) / 2 = (((n - 2 : ℕ) : ℝ) + 1) / 2 + 1 from by rw [h_cast]; ring]
   rw [show (((n - 2 : ℕ) : ℝ) + 1) / 2 = ((n : ℝ) - 1) / 2 from by push_cast; omega]
-  field_simp [hn_pos.ne']
+  rw [Gamma_add_one (show ((n : ℝ) - 1) / 2 ≠ 0 from by positivity)]
+  rw [rpow_add pi_pos, rpow_one]
+  have hG : Gamma (((n : ℝ) - 1) / 2) ≠ 0 := (Gamma_pos_of_pos (by positivity)).ne'
+  field_simp [hn1_ne, hG]
   ring
 
 /-
@@ -328,5 +381,14 @@ theorem cauchyCrofton_le_one_dim2 : cauchyCroftonConst 2 ≤ 1 := by
   rw [cauchyCrofton_two]
   rw [div_le_one pi_pos]
   linarith [pi_gt_three]
+
+/-- The Cauchy-Crofton constant decays to zero: c_n → 0 as n → ∞.
+
+    Proof sketch: c_n · c_{n+1} = 2/(n·π) (by cancellation via the sphere area recurrence),
+    so c_n^2 ≤ c_{n-1}·c_n = 2/((n-1)·π) for all n ≥ 3 (using c_{n-1} ≥ c_n),
+    hence c_n ≤ √(2/((n-1)·π)) → 0. -/
+theorem cauchyCroftonConst_tendsto_zero :
+    Filter.Tendsto cauchyCroftonConst Filter.atTop (nhds 0) := by
+  sorry
 
 end CauchyCrofton

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
@@ -29,19 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED (audit 2026-04-27): n-dim Cauchy-Crofton formalized end-to-end. 333 lines, 20 theorems, 4 defs, 0 sorries, 0 axiom declarations, 2 structure-encoded assumptions in AngularAverageData (Mathlib gap: spherical Haar measure). Sphere areas computed for n in {0,1,2,3} and the recurrence; Cauchy-Crofton constants for n in {2,3,4} (c_2=2/pi, c_3=1/2, c_4=4/(3 pi)); expectedCrossings formula with linearity, scaling, and unit-circle sanity check. Gallery shipped with badge=axiom, status=axiomatized.",
+    "progressSummary": "PROGRESS: Extended dimension ladder (c_5=3/8, c_6=16/(15π)), fixed sphereArea_recurrence bug (2π/n→2π/(n-1)), tendsTo theorem sorry for Aristotle",
     "builtItems": [
       "Created Proofs/BuffonsNeedleOQ01OQ01OQ04.lean (255 lines, 16 theorems, 5 defs, 0 sorries)",
       "Created gallery data: src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/{meta,annotations,index}",
       "sphereArea, cauchyCroftonConst, AngularAverageData, expectedCrossings definitions",
-      "Dimensional specializations: dim2 (2L/pid), dim3 (L/2d)"
+      "Dimensional specializations: dim2 (2L/pid), dim3 (L/2d)",
+      "sphereArea_four: sphereArea 4 = 8*π^2/3 (BuffonsNeedleOQ01OQ01OQ04.lean)",
+      "sphereArea_five: sphereArea 5 = π^3 (BuffonsNeedleOQ01OQ01OQ04.lean)",
+      "cauchyCrofton_five: cauchyCroftonConst 5 = 3/8 (BuffonsNeedleOQ01OQ01OQ04.lean)",
+      "cauchyCrofton_six: cauchyCroftonConst 6 = 16/(15π) (BuffonsNeedleOQ01OQ01OQ04.lean)"
     ],
     "insights": [
       "n-dim Cauchy-Crofton constant c_n = 2*sigma_{n-2}/((n-1)*sigma_{n-1})",
       "c_2 = 2/pi recovers Buffon-Barbier, c_3 = 1/2 for 3D",
       "Sphere surface area sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) computed for n=0,1,2",
       "Angular averaging on RP^{n-1} requires sphere measure not in Mathlib - axiomatized",
-      "Unit circle sanity check: 4 expected crossings with unit grid"
+      "Unit circle sanity check: 4 expected crossings with unit grid",
+      "sphereArea_recurrence had a bug: claimed 2π/n but correct formula is 2π/(n-1). Fixed in this session. Was not used downstream so did not affect other proofs.",
+      "sphereArea_four = 8π²/3, sphereArea_five = π³ proved by direct Gamma computation",
+      "cauchyCrofton_five = 3/8, cauchyCrofton_six = 16/(15π) proved by substitution",
+      "cauchyCroftonConst_tendsto_zero: c_n→0 follows from c_n^2 ≤ c_{n-1}·c_n = 2/((n-1)π); submitted to Aristotle"
     ],
     "mathlibGaps": [
       "Spherical Haar measure / surface measure on S^(n-1) (blocks discharging AngularAverageData)",
@@ -66,7 +74,8 @@
     "buffons-needle-oq-01-oq-02",
     "buffons-needle-oq-02",
     "buffons-needle-oq-02-oq-01",
-    "buffons-needle-oq-02-oq-02"
+    "buffons-needle-oq-02-oq-02",
+    "buffons-needle-oq-02-oq-03"
   ],
   "references": {
     "papers": [],
@@ -173,6 +182,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
+      "filename": "BuffonsNeedleOQ02OQ03.lean",
+      "lineCount": 256,
+      "theoremCount": 13,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Research session for `buffons-needle-oq-01-oq-01-oq-04` (Higher-Dimensional Cauchy-Crofton Formula).

- **Fixed bug** in `sphereArea_recurrence`: theorem claimed σ_n = 2π/n·σ_{n-2} but the correct formula is σ_n = 2π/(n-1)·σ_{n-2}. The error was in the divisor (n vs n-1). The theorem was not used downstream so other proofs were unaffected.
- **Extended dimension ladder**: added `sphereArea_four` (σ_4 = 8π²/3), `sphereArea_five` (σ_5 = π³), `cauchyCrofton_five` (c_5 = 3/8), `cauchyCrofton_six` (c_6 = 16/(15π)). All proved by direct Gamma function computation.
- **Added** `cauchyCroftonConst_tendsto_zero` with sorry: c_n → 0 as n → ∞. Proof sketch: c_n² ≤ c_{n-1}·c_n = 2/((n-1)·π) via the product formula, so c_n ≤ √(2/((n-1)·π)) → 0. Suitable for Aristotle proof search.

## Files Modified

- `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean` (+74/-12): 6 new theorems, 1 sorry, recurrence fix
- `src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json`: updated knowledge and progress

## Status

**Outcome**: progress (extending completed proof with next-step theorems)
**Next Steps**: Aristotle to prove `cauchyCroftonConst_tendsto_zero`

🤖 Generated by researcher-1