### PR TITLE
fix(erdos-936): correct stale section summary claiming proved theorems are axioms

### DIFF
--- a/src/data/proofs/erdos-936/meta.json
+++ b/src/data/proofs/erdos-936/meta.json
@@ -116,7 +116,7 @@
     {
       "id": "four-variants",
       "title": "The Four Variants",
-      "summary": "Individual axioms for each sequence variant",
+      "summary": "Four variant theorems proved from the two conditional axioms: 2^n±1 and n!±1 eventually not powerful, each conditional on abc_conjecture_holds.",
       "startLine": 230,
       "endLine": 285
     },


### PR DESCRIPTION
## Summary

- Section `four-variants` summary said "Individual axioms for each sequence variant" but the four theorems (`erdos_936_two_pow_add_one`, `erdos_936_two_pow_sub_one`, `erdos_936_factorial_add_one`, `erdos_936_factorial_sub_one`) are **proved theorems**, not axioms
- The `assumptions` field already correctly stated "The four variant axioms have been PROVED from these two conditional theorems"

## Test plan

- [x] Verified the four variants are `theorem` declarations (lines 234, 241, 248, 255) derived from `crowdmath_theorem` and `cushing_pascoe_theorem`
- [x] No changes to numerical fields (axiomCount: 3, sorries: 0 remain correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)