### PR TITLE
fix(erdos-955): add IsUntouchable body and remove stale Axiomatizes narratives

### DIFF
--- a/proofs/Proofs/Erdos955Problem.lean
+++ b/proofs/Proofs/Erdos955Problem.lean
@@ -117,6 +117,7 @@ There exist sets A with positive density such that s⁻¹(A) = ∅. -/
 /-- **Untouchable Numbers:**
 k is "untouchable" if s(n) = k has no solutions. Examples: 2, 5, 52, 88, 96, ... -/
 def IsUntouchable (k : ℕ) : Prop :=
+  ¬∃ n : ℕ, n > 0 ∧ s n = k
 
 /-
 ## Part VII: Partial Results

--- a/src/data/proofs/erdos-955/meta.json
+++ b/src/data/proofs/erdos-955/meta.json
@@ -66,7 +66,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: ppt_bound (Pollack-Pomerance-Thompson 2018: if |A cap [1,x]| <= x^{1/2+o(1)} then s^{-1}(A) has density 0), erdos_955_summary (combined partial results: primes, sums of two squares, sparse sets). Former axioms s_eq_s_alt, six_perfect, twentyeight_perfect, forward_fails, erdos_1973_empty_preimage, two_untouchable, five_untouchable, pollack_primes, troupe_many_factors, troupe_two_squares, s_bound now proved as theorems or definitions.",
-    "lineCount": 191,
+    "lineCount": 192,
     "theoremCount": 2
   },
   "overview": {
@@ -108,10 +108,10 @@
     {
       "id": "perfect-numbers",
       "title": "Perfect, Deficient, and Abundant Numbers",
-      "summary": "Classifies natural numbers by comparing $s(n)$ with $n$: perfect ($s(n) = n$), deficient ($s(n) < n$), and abundant ($s(n) > n$). Axiomatizes that 6 and 28 are perfect numbers, the first two examples known since antiquity.",
+      "summary": "Classifies natural numbers by comparing $s(n)$ with $n$: perfect ($s(n) = n$), deficient ($s(n) < n$), and abundant ($s(n) > n$). The first two perfect numbers, 6 and 28, are classical examples known since antiquity.",
       "startLine": 59,
       "endLine": 75,
-      "mathContext": "Classifies natural numbers by comparing $s(n)$ with $n$: perfect ($s(n) = n$), deficient ($s(n) < n$), and abundant ($s(n) > n$). Axiomatizes that 6 and 28 are perfect numbers, the first two examples known since antiquity."
+      "mathContext": "Classifies natural numbers by comparing $s(n)$ with $n$: perfect ($s(n) = n$), deficient ($s(n) < n$), and abundant ($s(n) > n$). The first two perfect numbers, 6 and 28, are classical examples known since antiquity."
     },
     {
       "id": "density",
@@ -140,18 +140,18 @@
     {
       "id": "contrasts",
       "title": "Contrasting Behaviors",
-      "summary": "Axiomatizes two striking contrasts: (1) Forward failure—there exist density-0 sets $A$ with $s(A)$ having positive density (e.g., semiprimes). (2) Empty preimages—untouchable numbers like 2 and 5 are never values of $s(n)$, so even large target sets can have empty fibers.",
+      "summary": "Documents two striking contrasts via docstrings: (1) Forward failure—there exist density-0 sets $A$ with $s(A)$ having positive density (e.g., semiprimes). (2) Empty preimages—untouchable numbers like 2 and 5 are never values of $s(n)$, so even large target sets can have empty fibers. Defines `IsUntouchable k` as $\\neg\\exists n > 0, s(n) = k$.",
       "startLine": 113,
       "endLine": 136,
-      "mathContext": "Axiomatizes two striking contrasts: (1) Forward failure—there exist density-0 sets $A$ with $s(A)$ having positive density (e.g., semiprimes). (2) Empty preimages—untouchable numbers like 2 and 5 are never values of $s(n)$, so even large target sets can have empty fibers."
+      "mathContext": "Documents two striking contrasts via docstrings: (1) Forward failure—there exist density-0 sets $A$ with $s(A)$ having positive density (e.g., semiprimes). (2) Empty preimages—untouchable numbers like 2 and 5 are never values of $s(n)$, so even large target sets can have empty fibers."
     },
     {
       "id": "partial-results",
       "title": "Partial Results",
-      "summary": "Axiomatizes three key results: Pollack (2014) proved the conjecture for $A$ = primes using modular distribution of $s(n)$. Troupe (2015) handled integers with many prime factors. Troupe (2020) proved the case $A$ = sums of two squares, exploiting the known density $\\sim x/\\sqrt{\\log x}$ and multiplicative structure.",
+      "summary": "Documents three key partial results via docstrings: Pollack (2014) proved the conjecture for $A$ = primes using modular distribution of $s(n)$. Troupe (2015) handled integers with many prime factors. Troupe (2020) proved the case $A$ = sums of two squares, exploiting the known density $\\sim x/\\sqrt{\\log x}$ and multiplicative structure. Also defines `IsSumOfTwoSquares`.",
       "startLine": 137,
       "endLine": 162,
-      "mathContext": "Axiomatizes three key results: Pollack (2014) proved the conjecture for $A$ = primes using modular distribution of $s(n)$. Troupe (2020) proved the case $A$ = sums of two squares, exploiting the known density $\\sim x/\\sqrt{\\log x}$ and multiplicative structure."
+      "mathContext": "Documents three key partial results via docstrings: Pollack (2014) proved the conjecture for $A$ = primes using modular distribution of $s(n)$. Troupe (2020) proved the case $A$ = sums of two squares, exploiting the known density $\\sim x/\\sqrt{\\log x}$ and multiplicative structure."
     },
     {
       "id": "ppt-bound",
@@ -164,10 +164,10 @@
     {
       "id": "growth-bound",
       "title": "Growth Bound on s(n)",
-      "summary": "Axiomatizes $s(n) \\leq n(2 + \\log\\log n)$, explaining why the PPT threshold is $1/2$: since $s$ maps $[1,x]$ into $[1, O(x \\log\\log x)]$, sets growing slower than $\\sqrt{x}$ in the range are too sparse to capture enough preimages.",
+      "summary": "Documents $s(n) \\leq n(2 + \\log\\log n)$ via a docstring, explaining why the PPT threshold is $1/2$: since $s$ maps $[1,x]$ into $[1, O(x \\log\\log x)]$, sets growing slower than $\\sqrt{x}$ in the range are too sparse to capture enough preimages.",
       "startLine": 181,
       "endLine": 190,
-      "mathContext": "Axiomatizes $s(n) \\leq n(2 + \\log\\log n)$, explaining why the PPT threshold is $1/2$: since $s$ maps $[1,x]$ into $[1, O(x \\log\\log x)]$, sets growing slower than $\\sqrt{x}$ in the range are too sparse to capture enough preimages."
+      "mathContext": "Documents $s(n) \\leq n(2 + \\log\\log n)$ via a docstring, explaining why the PPT threshold is $1/2$: since $s$ maps $[1,x]$ into $[1, O(x \\log\\log x)]$, sets growing slower than $\\sqrt{x}$ in the range are too sparse to capture enough preimages."
     },
     {
       "id": "summary",
@@ -204,7 +204,7 @@
       "Filter"
     ],
     "namespace": "Erdos955",
-    "lineCount": 191,
+    "lineCount": 192,
     "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

Repairs three integrity issues in the erdos-955 gallery entry found by auditor.

## Evidence

**Issue 1 (HIGH)**: `IsUntouchable` definition had `:=` with no body, causing a Lean parse error.
- **Before**: `def IsUntouchable (k : ℕ) : Prop :=` (empty)
- **After**: `def IsUntouchable (k : ℕ) : Prop := ¬∃ n : ℕ, n > 0 ∧ s n = k`

**Issue 2 (MEDIUM)**: Four section summaries claimed "Axiomatizes" for content that is only docstrings or definitions (no axiom declarations).
- **perfect-numbers**: removed "Axiomatizes that 6 and 28 are perfect numbers" (those axioms were removed long ago)
- **contrasts**: changed "Axiomatizes two striking contrasts" → "Documents two striking contrasts via docstrings"
- **partial-results**: changed "Axiomatizes three key results" → "Documents three key partial results via docstrings"
- **growth-bound**: changed "Axiomatizes s(n) ≤ n(2+loglog n)" → "Documents ... via a docstring"

**Issue 3**: `leanFile.definitionCount` was already 14 in meta.json (correct); updated `lineCount` from 191→192 to reflect the added body line.

Closes #15399

---
Automated fix by lean-mechanic agent.