### PR TITLE
enrich(infinitude-primes-4k3-oq-03): add imports annotation, fix insight→theorem types

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "imports",
+    "proofId": "infinitude-primes-4k3-oq-03",
+    "range": { "startLine": 1, "endLine": 8 },
+    "type": "concept",
+    "title": "Imports: Inheriting Two Completed Proofs",
+    "content": "This file imports both InfinitudePrimes4k3 and InfinitudePrimes4k1 — the two sibling proofs that establish infinitely many primes ≡ 3 and ≡ 1 (mod 4) respectively. The OQ-03 file acts as an integration layer: all four theorems here are either direct delegations or conjunctions of results from these two files. Nat.NumberTheory.SumTwoSquares provides Euler's criterion (Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one), which is the key Mathlib theorem underlying InfinitudePrimes4k1's proof that primes dividing k² + 1 must be ≡ 1 (mod 4).",
+    "mathContext": "The dependency graph: OQ-03 imports Primes4k1 (proves $\\{p \\mid p\\equiv 1\\pmod 4\\}$ infinite) and Primes4k3 (proves $\\{p \\mid p\\equiv 3\\pmod 4\\}$ infinite). Both lean on `Mathlib.NumberTheory.SumTwoSquares` for Euler's criterion: $\\left(\\frac{-1}{p}\\right)=1 \\Leftrightarrow p\\equiv 1\\pmod 4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lean 4 imports", "module composition", "Mathlib.NumberTheory.SumTwoSquares", "Euler's criterion"],
+    "prerequisites": ["InfinitudePrimes4k1", "InfinitudePrimes4k3", "Lean 4 import system"]
+  },
+  {
     "id": "oq-answer",
     "proofId": "infinitude-primes-4k3-oq-03",
     "range": { "startLine": 1, "endLine": 25 },
@@ -27,7 +39,7 @@
     "id": "main-theorem",
     "proofId": "infinitude-primes-4k3-oq-03",
     "range": { "startLine": 55, "endLine": 66 },
-    "type": "insight",
+    "type": "theorem",
     "title": "infinitely_many_primes_1_mod_4 — Delegation Pattern",
     "content": "The main theorem is a one-line delegation to InfinitudePrimes4k1.infinitely_many_primes_1_mod_4. This is the correct design: the actual proof lives in InfinitudePrimes4k1.lean, which is imported here. The OQ-03 file serves as a wrapper that packages the result in the context of the parent proof's open question. The Lean proof term is simply an identifier — no tactics needed — making it maximally transparent. The InfinitudePrimes4k1 proof internally uses Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one from Mathlib's SumTwoSquares module to apply Euler's criterion.",
     "mathContext": "\\forall n \\in \\mathbb{N},\\; \\exists p \\text{ prime},\\; p > n \\wedge p \\equiv 1 \\pmod 4. \\text{ Proof: take } N = (2(n+1)!)^2+1, \\text{ find odd prime } p \\mid N, \\text{ then } p \\equiv 1 \\pmod 4 \\text{ by Euler's criterion, and } p > n \\text{ by divisibility contradiction.}",
@@ -39,7 +51,7 @@
     "id": "classification-theorem",
     "proofId": "infinitude-primes-4k3-oq-03",
     "range": { "startLine": 68, "endLine": 82 },
-    "type": "insight",
+    "type": "theorem",
     "title": "Both Classes Infinite and Complete mod-4 Classification",
     "content": "Two theorems complete the mod-4 picture. both_classes_infinite packages the conjunction of InfinitudePrimes4k1.primes_1_mod_4_infinite and InfinitudePrimes4k3.primes_3_mod_4_infinite — both residue classes {p prime | p ≡ 1 mod 4} and {p prime | p ≡ 3 mod 4} are Set.Infinite. odd_prime_mod_four_classification delegates to prime_mod_four from InfinitudePrimes4k3: every odd prime satisfies p % 4 ∈ {1, 3} since p odd means p % 2 = 1, forcing p % 4 ∈ {1, 3}. Together these give the complete elementary classification of primes by residue mod 4 — all without Dirichlet L-functions.",
     "mathContext": "Every prime $p$ belongs to exactly one of: $\\{2\\}$, $\\{p: p\\equiv 1\\pmod 4\\}$, $\\{p: p\\equiv 3\\pmod 4\\}$. Together: $\\{\\text{primes}\\} = \\{2\\} \\cup \\{p: 4\\mid p-1\\} \\cup \\{p: 4\\mid p-3\\}$ — a complete partition, the mod-4 special case of Dirichlet's theorem proved elementarily.",


### PR DESCRIPTION
Enrichment pass for infinitude-primes-4k3-oq-03 (Infinitely Many Primes ≡ 1 mod 4).

Quality improvements to an already well-enriched entry (94/100, pass 0):

- Added new `imports` annotation (lines 1-8) explaining the dependency graph: why both InfinitudePrimes4k1 and InfinitudePrimes4k3 are imported, and how Mathlib.NumberTheory.SumTwoSquares provides Euler's criterion for the ≡ 1 (mod 4) case
- Fixed `type: "insight"` → `"theorem"` for `main-theorem` and `classification-theorem` annotations (they document theorem statements, not proof insights)

No Lean changes. Build passes (`pnpm build ✓`).