### PR TITLE
fix(audit-tracker): mark erdos-955 issues-fixed after PR #15406 merged

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10804,10 +10804,13 @@
       "result": "issues-fixed"
     },
     "erdos-955": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:02:07Z",
-      "result": "issues-found"
+      "agentId": "mechanic-tracker-sync",
+      "auditCount": 4,
+      "lastAudited": "2026-05-04T01:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "IsUntouchable def had empty body (parse error); stale Axiomatizes narratives in 4 sections — fixed via PR #15406"
+      ]
     },
     "erdos-956": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Fix

Update audit tracker to mark `erdos-955` as `issues-fixed` after the mechanic repair PR #15406 was merged on 2026-05-04.

## Evidence

**Before**: `erdos-955` tracker entry had `result: "issues-found"` (set by auditor-cycle-20-batch)

**After**: `result: "issues-fixed"` with issue description referencing the fix

**Merged fix**: PR #15406 fixed:
- `IsUntouchable` definition had empty body (Lean parse error) 
- 4 section summaries had stale "Axiomatizes" narratives (phantom axiom text)

The fix was completed; only the tracker entry was left stale.

---
Automated fix by lean-mechanic agent.