### PR TITLE
fix(lagrange-four-squares): remove hurwitz True stubs, fix meta counts

### DIFF
--- a/proofs/Proofs/LagrangeFourSquares.lean
+++ b/proofs/Proofs/LagrangeFourSquares.lean
@@ -364,23 +364,6 @@ theorem every_nat_is_quaternion_norm (n : ℕ) :
   obtain ⟨a, b, c, d, h⟩ := lagrange_four_squares n
   exact ⟨⟨a, b, c, d⟩, by simp [LipschitzQuaternion.norm]; omega⟩
 
-/-- The Hurwitz quaternions include half-integers: (a+b·i+c·j+d·k)/2
-    where a,b,c,d are all integers or all half-integers.
-    They form a Euclidean domain (Hurwitz, 1896). -/
-theorem hurwitz_quaternions_euclidean :
-    -- The Hurwitz quaternion order is a Euclidean domain
-    -- with respect to the quaternion norm
-    True := trivial
-
-/-- The number of ways to write n as a norm of a Hurwitz quaternion
-    equals 24 times the sum of odd divisors of n (when n is odd).
-    This gives yet another proof of Lagrange's theorem. -/
-theorem hurwitz_representation_count :
-    ∀ n : ℕ, n ≥ 1 → Odd n →
-      -- The number of Hurwitz quaternion norms equal to n
-      -- is 24 · σ(n) where σ is the sum-of-divisors function
-      True := fun _ _ _ => trivial
-
 -- ═════════════════════════════════════════════════════════════════════════
 -- VERIFICATION CHECKS
 -- ═════════════════════════════════════════════════════════════════════════
@@ -405,6 +388,5 @@ theorem hurwitz_representation_count :
 -- Part V: Quaternions
 #check LipschitzQuaternion
 #check every_nat_is_quaternion_norm
-#check hurwitz_quaternions_euclidean
 
 end LagrangeFourSquares

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12090,7 +12090,10 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-05-03T22:58:18Z",
-      "result": "issues-found"
+      "result": "issues-fixed",
+      "issues": [
+        "hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed; lineCount 410→392, theoremCount 17→15"
+      ]
     },
     "lagrange-four-squares-oq-01": {
       "auditCount": 1,

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -34,8 +34,8 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 5,
-    "assumptions": "5 axiom declarations: legendre_three_squares (3-square obstruction criterion), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound). fermat_two_squares has been formally proved. jacobi_four_squares (True stub) removed — Jacobi's r₄(n) formula is not formalized. hurwitz_quaternions_euclidean and hurwitz_representation_count remain as True stubs.",
-    "lineCount": 410,
+    "assumptions": "5 axiom declarations: legendre_three_squares (3-square obstruction criterion), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound). fermat_two_squares has been formally proved. jacobi_four_squares, hurwitz_quaternions_euclidean, and hurwitz_representation_count True stubs removed — Jacobi's r₄(n) formula and Hurwitz quaternion results are not formalized.",
+    "lineCount": 392,
     "prerequisites": [
       "Quaternion algebra and norm multiplicativity",
       "Euler's four-square identity",
@@ -44,7 +44,7 @@
       "Waring's problem and additive number theory"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 17
+    "theoremCount": 15
   },
   "overview": {
     "historicalContext": "Lagrange's four squares theorem was proved by Joseph-Louis Lagrange in 1770, building on earlier work by Euler. The result answered a question that had puzzled mathematicians since antiquity: Diophantus had noted around 250 CE that certain numbers seemed to require many squares.\n\nThe deeper story involves one of mathematics' greatest coincidences: Euler discovered the four-square identity in 1748, showing that the product of two sums-of-four-squares is itself a sum of four squares. Nearly a century later, Hamilton discovered quaternions in 1843. The four-square identity IS quaternion multiplication! The norm of a product equals the product of norms.\n\nThis explains WHY four squares work when three don't: quaternions form a division algebra, but there is no 3-dimensional division algebra (proved by Frobenius in 1877). The algebraic structure that makes four squares work simply doesn't exist for three.\n\nAs one reviewer put it: \"The four squares theorem is astounding, it says something utterly profound about the universe... that's what binds the galaxies together.\"",
@@ -111,7 +111,7 @@
       "id": "two-squares-connection",
       "title": "Connection to Two Squares Theorem",
       "startLine": 129,
-      "endLine": 398,
+      "endLine": 365,
       "summary": "Cross-reference to Fermat's Two Squares Theorem showing the contrast between universal four squares and restrictive two squares.",
       "mathContext": "Fermat: $n = a^2 + b^2 \\iff$ every prime $p \\equiv 3 \\pmod{4}$ divides $n$ to even power. Two squares is far more restrictive than four."
     }
@@ -170,9 +170,9 @@
     ],
     "opens": [],
     "namespace": "LagrangeFourSquares",
-    "lineCount": 410,
+    "lineCount": 392,
     "axiomCount": 5,
-    "theoremCount": 17,
+    "theoremCount": 15,
     "definitionCount": 8,
     "path": "Proofs/LagrangeFourSquares.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Remove `hurwitz_quaternions_euclidean` and `hurwitz_representation_count` True stub theorems that proved `True := trivial` while their names and docstrings implied Hurwitz quaternion results were formalized.

## Evidence

**Before**: Two theorems with meaningful docstrings but `True` return types, proving nothing:
```lean
theorem hurwitz_quaternions_euclidean : True := trivial
theorem hurwitz_representation_count : ∀ n : ℕ, n ≥ 1 → Odd n → True := fun _ _ _ => trivial
```

**After**: Theorems removed; meta.json updated:
- `lineCount`: 410 → 392
- `theoremCount`: 17 → 15  
- `sections[two-squares-connection].endLine`: 398 → 365
- `assumptions`: updated to note all three stub theorems removed
- `audit-tracker.json`: lagrange-four-squares marked `issues-fixed`

## Note

Supersedes PR #15401 (same fix, but that PR had a merge conflict due to stale `audit-tracker.json`).

---
Automated fix by lean-mechanic agent.