### PR TITLE
fix(meta): sync stale lineCount for erdos-941 (323→324)

### DIFF
--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -58,7 +58,7 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 323,
+    "lineCount": 324,
     "assumptions": "4 axiom(s) and 0 sorry(s).",
     "theoremCount": 11
   },
@@ -156,7 +156,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 217,
-      "endLine": 323,
+      "endLine": 324,
       "summary": "Three equivalent theorems: `erdos_941`, `erdos_941_main`, `erdos_941_solved`, all delegating to `heath_brown_theorem`. Confirms the problem is SOLVED: every sufficiently large integer is a sum of $\\le 3$ powerful numbers.",
       "mathContext": "Three equivalent theorems: `erdos_941`, `erdos_941_main`, `erdos_941_solved`, all delegating to `heath_brown_theorem`. Confirms the problem is SOLVED: every sufficiently large integer is a sum of $\\le 3$ powerful numbers."
     }
@@ -179,7 +179,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Update `erdos-941` meta.json: both `meta.lineCount` and `leanFile.lineCount` reported 323 but the Lean file has 324 lines (`end Erdos941` closing line added). Also updated the Summary section `endLine` from 323 to 324.

## Evidence

**Before**: `leanFile.lineCount: 323`, `meta.lineCount: 323`, `sections[-1].endLine: 323`
**After**: All three values corrected to 324 (matching actual file length)

Verified with: `wc -l proofs/Proofs/Erdos941Problem.lean` → 324

---
Automated fix by lean-mechanic agent.