### PR TITLE
fix(audit): sync buffons-needle meta.json after PR #15398 (sorries 0→1)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1365,10 +1365,10 @@
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:48Z",
-      "result": "clean"
+      "lastAudited": "2026-05-04T01:13:36Z",
+      "result": "issues-fixed"
     },
     "buffons-needle-oq-01-oq-02": {
       "auditCount": 2,
@@ -14158,8 +14158,8 @@
       "notes": "Re-audited 2026-05-04: 0 sorries, leanFile.axiomCount=0 (meta.axiomCount=2 from parent imports, by design). covers_unit_cube:=trivial is struct field fill not a True stub. Empty issues array was auditor artifact."
     },
     "chebyshev-bounds-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T22:38:59Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-04T01:13:36Z",
       "result": "clean",
       "issues": [],
       "notes": "Re-audited 2026-05-04: 0 sorries, 4 axioms, all metadata consistent. Empty issues array was auditor artifact."

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -17,12 +17,12 @@
       "gamma-function"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
     "assumptions": "2 structure-encoded assumptions in AngularAverageData: angularAvg_eq (the angular average on RP^{n-1} is proportional to norm with constant sigma_{n-2}/(n-1)), angularAvg_nonneg (non-negativity). These encode integration on the unit sphere which Mathlib lacks.",
-    "lineCount": 332,
-    "theoremCount": 20,
+    "lineCount": 394,
+    "theoremCount": 25,
     "definitionCount": 5,
     "originalContributions": [
       "sphereArea: sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) with n=0,1,2 computed",
@@ -88,7 +88,7 @@
       "id": "dimension-ladder",
       "title": "Part V-VI: Sphere Recurrence and Consistency Checks",
       "startLine": 267,
-      "endLine": 331,
+      "endLine": 394,
       "summary": "sphereArea_recurrence proves sigma_n = 2*pi/n * sigma_{n-2}. Consistency: angular_constant_dim2 verifies sigma_0/1 = 2. unit_circle_crossings verifies a unit circle crosses 4 times. cauchyCrofton_le_one_dim2 proves c_2 <= 1 (using pi > 3).",
       "mathContext": "$\\sigma_n = \\frac{2\\pi}{n} \\sigma_{n-2}$ (proved via $\\Gamma((n+1)/2) = \\frac{n-1}{2}\\Gamma((n-1)/2)$). Corollaries: $c_4 = 4/(3\\pi)$, $c_2 \\leq 1$."
     }
@@ -104,12 +104,12 @@
   },
   "leanFile": {
     "namespace": "CauchyCrofton",
-    "lineCount": 332,
+    "lineCount": 394,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 25,
     "definitionCount": 4,
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -128,5 +128,5 @@
       "description": "N-ball volumes use the same Gamma function framework as sphere surface areas"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- **Proof**: `buffons-needle-oq-01-oq-01-oq-04`
- **Issue**: meta.json claimed `sorries: 0` but PR #15398 added `cauchyCroftonConst_tendsto_zero` with a `sorry` and expanded the file without updating metadata
- **Fix**: Update `sorries: 0 → 1`, `lineCount: 332 → 394`, `theoremCount: 20 → 25` in both `meta` and `leanFile` sections; extend last section `endLine: 331 → 394`
- **Also**: Re-audit `chebyshev-bounds-oq-04` as clean (working-tree sorry is from an uncommitted researcher agent edit, not present on main)

## Evidence

**meta.json claimed**: `sorries: 0`, `lineCount: 332`, `theoremCount: 20`  
**Lean file on origin/main shows**: 1 sorry at line 392 (`cauchyCroftonConst_tendsto_zero`), 394 lines, 25 theorems

The sorry was introduced by PR #15398 ("extend dimension ladder c5/c6, fix recurrence bug") which added `sphereArea_four`, `sphereArea_five`, `cauchyCrofton_five`, `cauchyCrofton_six`, `cauchyCroftonConst_pos`, and `cauchyCroftonConst_tendsto_zero` (sorry) but did not update meta.json.

---
Discovered during gallery integrity audit.