### PR TITLE
fix(meta): sync stale lineCount for 6 proofs (each off by 1)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 21,
-    "lineCount": 467,
+    "lineCount": 466,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,7 +136,7 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 467,
+    "lineCount": 466,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 1,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": null,
     "axiomCount": 7,
     "assumptions": "7 axioms: levy_solovay_inaccessible_ch (Lévy-Solovay 1967: inaccessible + CH consistent), levy_solovay_inaccessible_not_ch (Lévy-Solovay 1967: inaccessible + ¬CH consistent), levy_solovay_measurable_ch (Lévy-Solovay: measurable + CH consistent), levy_solovay_measurable_not_ch (Lévy-Solovay: measurable + ¬CH consistent), mm_consistent (Foreman-Magidor-Shelah 1988: MM consistent with ZFC+supercompact), ma_consistent (Martin-Solovay: MA consistent with ZFC), ultimate_l_implies_ch_consistent (Woodin program: open).",
-    "lineCount": 307,
+    "lineCount": 306,
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
     "originalContributions": [
@@ -145,7 +145,7 @@
     ],
     "opens": ["Cardinal", "ContinuumHypothesis"],
     "namespace": "CantorDiagOQ01OQ02",
-    "lineCount": 307,
+    "lineCount": 306,
     "axiomCount": 7,
     "theoremCount": 14,
     "definitionCount": 9,

--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 283,
+    "lineCount": 282,
     "theoremCount": 14,
     "definitionCount": 4,
     "originalContributions": [
@@ -126,7 +126,7 @@
   ],
   "leanFile": {
     "namespace": "global (noncomputable section)",
-    "lineCount": 283,
+    "lineCount": 282,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/14",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 110,
+    "lineCount": 109,
     "prerequisites": [
       "Additive combinatorics (sumsets and representation functions)",
       "Finite set theory",
@@ -132,7 +132,7 @@
       "Asymptotics"
     ],
     "namespace": null,
-    "lineCount": 110,
+    "lineCount": 109,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 6,

--- a/src/data/proofs/hilbert-20-oq-01/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01/meta.json
@@ -44,7 +44,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "2 axioms: IsLocallySolvable (requires distribution theory), nirenberg_treves (biconditional characterization combining Hörmander 1960 necessity + Dencker 2006 sufficiency, requires microlocal analysis not yet in Mathlib). BicharacteristicCurve is a concrete structure; hormander_necessity and dencker_sufficiency are proved theorems.",
-    "lineCount": 212,
+    "lineCount": 211,
     "prerequisites": [
       "Partial differential equations",
       "Functional analysis and distributions",
@@ -171,7 +171,7 @@
       "NNReal"
     ],
     "namespace": "Hilbert20LocalSolvability",
-    "lineCount": 212,
+    "lineCount": 211,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 241,
+    "lineCount": 240,
     "assumptions": "0 axioms, 0 sorries. Fully verified.",
     "theoremCount": 6,
     "originalContributions": [
@@ -41,7 +41,7 @@
     "imports": ["Mathlib"],
     "opens": ["Real", "Set", "Filter"],
     "namespace": "LebesgueMeasureOQ01OQ01OQ02",
-    "lineCount": 241,
+    "lineCount": 240,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Six gallery proofs had stale `lineCount` values in their `meta.json` — each off by exactly 1 line. Both `meta.lineCount` and `leanFile.lineCount` updated in each file.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| angle-trisection-oq-02-oq-01-oq-02-incomplete-01 | 467 | 466 |
| cantor-diagonalization-oq-01-oq-02 | 307 | 306 |
| derangements-convergence | 283 | 282 |
| erdos-14 | 110 | 109 |
| hilbert-20-oq-01 | 212 | 211 |
| lebesgue-measure-oq-01-oq-01-oq-02 | 241 | 240 |

**Verification**: \`wc -l\` on each Lean source file from \`origin/main\`. No in-flight PRs cover these entries (checked via \`gh pr list --search <slug>\` and reviewing open PR diffs).

---
Automated fix by lean-mechanic agent.