### PR TITLE
fix(buffons-needle-oq-01-oq-01-oq-04): correct recurrence formula and sync narrative after PR #15398

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -32,11 +32,16 @@
       "expectedCrossings_dim2: recovers 2L/(pi*d) for n=2",
       "expectedCrossings_dim3: gives L/(2d) for n=3",
       "unit_circle_crossings: unit circle crosses unit grid 4 times on average",
-      "sphereArea_recurrence: sigma_n = 2*pi/n * sigma_{n-2}",
+      "sphereArea_recurrence: sigma_n = 2*pi/(n-1) * sigma_{n-2}",
       "cauchyCrofton_le_one_dim2: c_2 <= 1",
       "sphereArea_three: sigma_3 = 2*pi^2 (S^3 surface area)",
       "cauchyCrofton_four: c_4 = 4/(3*pi) (4D crossing constant)",
-      "expectedCrossings_dim4: gives 4L/(3*pi*d) for n=4"
+      "expectedCrossings_dim4: gives 4L/(3*pi*d) for n=4",
+      "sphereArea_four: sigma_4 = 8*pi^2/3 (proved via Gamma(5/2) = (3/4)*sqrt(pi))",
+      "sphereArea_five: sigma_5 = pi^3 (proved via Gamma(3) = 2)",
+      "cauchyCrofton_five: c_5 = 3/8 (5D crossing constant)",
+      "cauchyCrofton_six: c_6 = 16/(15*pi) (6D crossing constant)",
+      "cauchyCroftonConst_tendsto_zero: c_n -> 0 as n -> infinity (sorry: for Aristotle)"
     ]
   },
   "overview": {
@@ -45,10 +50,10 @@
     "proofStrategy": "**Part I** (lines 36-100): Defines sphere surface area sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) using Mathlib's Gamma function. Proves specific values sigma_0 = 2, sigma_1 = 2*pi, sigma_2 = 4*pi using Gamma computations (Gamma_one_half_eq, Gamma_add_one).\n\n**Part II** (lines 102-140): Defines the Cauchy-Crofton constant c_n = 2*sigma_{n-2}/((n-1)*sigma_{n-1}). Computes c_2 = 2/pi and c_3 = 1/2 by substituting the sphere area values.\n\n**Part III** (lines 142-165): Axiomatizes the angular averaging identity on RP^{n-1} via AngularAverageData structure. The key property: the average of |<v, omega>| over hyperplane normals equals sigma_{n-2}/(n-1) * ||v||.\n\n**Parts IV-VI** (lines 167-255): Proves the n-dimensional expected crossings formula, linearity, scaling, and dimensional specializations. Verifies n=2 gives 2L/(pi*d), n=3 gives L/(2d). Proves the sphere area recurrence and the unit circle crossing count.",
     "keyInsights": [
       "**Dimension-dependent crossing constant**: c_n = 2*sigma_{n-2}/((n-1)*sigma_{n-1}) decreases as n grows: c_2 = 2/pi ~ 0.637, c_3 = 1/2, c_4 = 4/(3*pi) ~ 0.424. In higher dimensions, random hyperplanes are 'less likely' to cross a curve, geometrically because most directions are perpendicular to the curve.",
-      "**Sphere surface areas via Gamma**: The formula sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) unifies diverse geometric constants: sigma_0 = 2 (two points), sigma_1 = 2*pi (circle), sigma_2 = 4*pi (sphere). The Gamma function recurrence gives sigma_n = (2*pi/n)*sigma_{n-2}.",
+      "**Sphere surface areas via Gamma**: The formula sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) unifies diverse geometric constants: sigma_0 = 2 (two points), sigma_1 = 2*pi (circle), sigma_2 = 4*pi (sphere). The Gamma function recurrence gives sigma_n = 2*pi/(n-1) * sigma_{n-2}.",
       "**The angular average is the bridge**: The integral geometry formula reduces to a single analytic identity: the average of |<v, omega>| over the projective sphere. In 2D this is the integral from the parent proof: integral_0^pi |sin(theta + c)| dtheta = 2. In n dimensions, the constant 2 generalizes to sigma_{n-2}/(n-1).",
       "**Unit circle sanity check**: A unit circle (perimeter 2*pi) crossing a line grid with unit spacing should cross 4 times on average (2 entries + 2 exits). The formula gives c_2 * 2*pi / 1 = (2/pi) * 2*pi = 4.",
-      "**Sphere area recurrence proves the dimension ladder**: `sphereArea_recurrence` proves sigma_n = 2*pi/n * sigma_{n-2} using the Gamma function identity Gamma((n+1)/2) = ((n-1)/2) * Gamma((n-1)/2). The proof chains `Gamma_add_one`, `rpow_add`, `push_cast`, and `omega` — a non-trivial mix of analytic and algebraic reasoning. This recurrence is the key to computing c_n for all n: c_4 = 4/(3*pi), c_5 = 2/(3*pi^2), and in general c_n → 0 as n → ∞."
+      "**Sphere area recurrence proves the dimension ladder**: `sphereArea_recurrence` proves sigma_n = 2*pi/(n-1) * sigma_{n-2} using the Gamma function identity Gamma((n+1)/2) = ((n-1)/2) * Gamma((n-1)/2). The proof chains `Gamma_add_one`, `rpow_add`, `push_cast`, and `omega` — a non-trivial mix of analytic and algebraic reasoning. This recurrence is the key to computing c_n for all n: c_4 = 4/(3*pi), c_5 = 3/8, c_6 = 16/(15*pi), and in general c_n → 0 as n → ∞ (the `cauchyCroftonConst_tendsto_zero` sorry)."
     ]
   },
   "sections": [
@@ -89,8 +94,8 @@
       "title": "Part V-VI: Sphere Recurrence and Consistency Checks",
       "startLine": 267,
       "endLine": 394,
-      "summary": "sphereArea_recurrence proves sigma_n = 2*pi/n * sigma_{n-2}. Consistency: angular_constant_dim2 verifies sigma_0/1 = 2. unit_circle_crossings verifies a unit circle crosses 4 times. cauchyCrofton_le_one_dim2 proves c_2 <= 1 (using pi > 3).",
-      "mathContext": "$\\sigma_n = \\frac{2\\pi}{n} \\sigma_{n-2}$ (proved via $\\Gamma((n+1)/2) = \\frac{n-1}{2}\\Gamma((n-1)/2)$). Corollaries: $c_4 = 4/(3\\pi)$, $c_2 \\leq 1$."
+      "summary": "sphereArea_recurrence proves sigma_n = 2*pi/(n-1) * sigma_{n-2}. Higher-dimensional crossing constants computed: c_5 = 3/8 (via sphereArea_three, sphereArea_four), c_6 = 16/(15*pi) (via sphereArea_four, sphereArea_five). Consistency: angular_constant_dim2 verifies sigma_0/1 = 2. unit_circle_crossings verifies a unit circle crosses 4 times. cauchyCrofton_le_one_dim2 proves c_2 <= 1 (using pi > 3). cauchyCroftonConst_tendsto_zero (sorry) states c_n -> 0 as n -> infinity.",
+      "mathContext": "$\\sigma_n = \\frac{2\\pi}{n-1} \\sigma_{n-2}$ (proved via $\\Gamma((n+1)/2) = \\frac{n-1}{2}\\Gamma((n-1)/2)$). Corollaries: $c_4 = 4/(3\\pi)$, $c_5 = 3/8$, $c_6 = 16/(15\\pi)$, $c_2 \\leq 1$. Limit: $c_n \\to 0$ as $n \\to \\infty$ (sorry)."
     }
   ],
   "conclusion": {
@@ -98,7 +103,7 @@
     "implications": "This formalization provides the dimensional framework for integral geometry in Lean. The angular averaging identity, once proved from sphere integration theory, would make the formalization complete. The sphere surface area computations are independently useful for geometric measure theory applications.",
     "openQuestions": [
       "Prove the angular averaging identity from sphere measure theory (requires Haar measure on S^{n-1})",
-      "Compute c_n for dimensions 5-10 and prove c_n -> 0 as n -> infinity (c_4 = 4/(3pi) now proved)",
+      "Discharge the cauchyCroftonConst_tendsto_zero sorry: prove c_n -> 0 as n -> infinity (c_4 = 4/(3*pi), c_5 = 3/8, c_6 = 16/(15*pi) are now proved; the limit proof uses c_n^2 <= c_{n-1}*c_n = 2/((n-1)*pi))",
       "Formalize the Cauchy-Crofton formula for surfaces in R^n (codimension > 1 intersections)"
     ]
   },


### PR DESCRIPTION
## Summary

Applies the remaining narrative fixes to `src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json` after PR #15398 landed (which added 5 theorems and fixed the `sphereArea_recurrence` denominator bug).

PR #15426 already synced the structural counts (`lineCount`, `theoremCount`, `sorries`); this PR fixes the narrative drift that remained, and supersedes PR #15411 (which now conflicts with `origin/main`).

## Verified against `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean`

| Lean line | Statement | Used in fix |
|---|---|---|
| 103 | `sphereArea_four : sphereArea 4 = 8 * pi ^ 2 / 3` | new originalContribution |
| 122 | `sphereArea_five : sphereArea 5 = pi ^ 3` | new originalContribution |
| 197 | `cauchyCrofton_five : cauchyCroftonConst 5 = 3 / 8` | new originalContribution + section summary |
| 208 | `cauchyCrofton_six : cauchyCroftonConst 6 = 16 / (15 * pi)` | new originalContribution + section summary |
| 330-331 | `sphereArea n = 2 * pi / ((n : R) - 1) * sphereArea (n - 2)` | corrected recurrence formula |
| 390-392 | `cauchyCroftonConst_tendsto_zero` (sorry) | new originalContribution + openQuestion |

## Fixes applied

1. `keyInsights` (Sphere surface areas): `sigma_n = (2*pi/n)*sigma_{n-2}` -> `sigma_n = 2*pi/(n-1) * sigma_{n-2}`.
2. `keyInsights` (dimension ladder): same correction; also updated to mention `c_5 = 3/8`, `c_6 = 16/(15*pi)`, and `cauchyCroftonConst_tendsto_zero`.
3. `originalContributions` for `sphereArea_recurrence`: same recurrence correction.
4. `originalContributions`: added 5 new entries for `sphereArea_four`, `sphereArea_five`, `cauchyCrofton_five`, `cauchyCrofton_six`, `cauchyCroftonConst_tendsto_zero`.
5. `sections.dimension-ladder`: extended `summary` and `mathContext` with `c_5 = 3/8`, `c_6 = 16/(15*pi)`, and the new sorry. (`endLine` was already 394 from PR #15426.)
6. `openQuestions`: dropped the now-stale "compute c_n for dim 5-10" entry; replaced with a precise statement of the remaining `cauchyCroftonConst_tendsto_zero` sorry.

`axiomCount` (2 structure-encoded assumptions in `AngularAverageData`) is unchanged and correct.

## Test plan

- [x] `python3 -m json.tool meta.json > /dev/null` (JSON valid)
- [x] All formula corrections cross-checked against the Lean file
- [x] All 5 new theorem names match the Lean file (incl. the trailing sorry)
- [x] `axiomCount`, `theoremCount`, `lineCount`, `sorries` left untouched (PR #15426 already correct)

This PR will close PR #15411 as superseded.

Generated with [Claude Code](https://claude.com/claude-code)