### PR TITLE
audit(tracker): mark buffons-needle-oq-01-oq-01-oq-04 re-audit issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14188,6 +14188,12 @@
       "lastAudited": "2026-05-03T23:25:56Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T01:51:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1365,9 +1365,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T01:13:36Z",
+      "lastAudited": "2026-05-04T01:39:50Z",
       "result": "issues-fixed"
     },
     "buffons-needle-oq-01-oq-02": {
@@ -10809,7 +10809,7 @@
       "lastAudited": "2026-05-04T01:00:00Z",
       "result": "issues-fixed",
       "issues": [
-        "IsUntouchable def had empty body (parse error); stale Axiomatizes narratives in 4 sections — fixed via PR #15406"
+        "IsUntouchable def had empty body (parse error); stale Axiomatizes narratives in 4 sections \u2014 fixed via PR #15406"
       ]
     },
     "erdos-956": {
@@ -12095,7 +12095,7 @@
       "lastAudited": "2026-05-03T22:58:18Z",
       "result": "issues-fixed",
       "issues": [
-        "hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed; lineCount 410→392, theoremCount 17→15"
+        "hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed; lineCount 410\u2192392, theoremCount 17\u219215"
       ]
     },
     "lagrange-four-squares-oq-01": {


### PR DESCRIPTION
## Summary

Third audit pass on `buffons-needle-oq-01-oq-01-oq-04`. Structural counts were already correct on main (from PR #15426), but narrative errors remained — all fixed in companion PR #15437:

- `sphereArea_recurrence` formula wrong in `keyInsights`: `2*pi/n` → `2*pi/(n-1)` (Lean line 331)
- 5 new `originalContributions` from PR #15398 missing
- `dimension-ladder` section summary stale
- `openQuestions` not updated for newly proved c_5, c_6

PR #15411 closed as superseded.

## Tracker changes

- `auditCount`: 2 → 3, `lastAudited` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)