### PR TITLE
enrich(inverse-galois-f20): expand sections 3→5, fix annotation line numbers

### DIFF
--- a/src/data/proofs/inverse-galois-f20/annotations.json
+++ b/src/data/proofs/inverse-galois-f20/annotations.json
@@ -14,7 +14,7 @@
   {
     "id": "ann-igf20-five-divides",
     "proofId": "inverse-galois-f20",
-    "range": { "startLine": 62, "endLine": 88 },
+    "range": { "startLine": 63, "endLine": 88 },
     "type": "insight",
     "title": "Lower Bound I: 5 | |Gal| from Prime Degree, and |Gal| | 120 from S₅",
     "content": "Since X⁵−2 is irreducible of degree 5, any root α generates an extension ℚ(α)/ℚ of degree 5. By Galois theory, 5 divides [splitting field : ℚ] = |Gal|. The theorem `five_dvd_gal_card` uses `Polynomial.Gal.prime_degree_dvd_card`. The companion `gal_card_dvd_120` uses the Galois group's faithful action on the 5 roots (injection into S₅ = symmetric group of order 120), which is a fundamental bound: |Gal| divides the order of the symmetric group on the roots.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-igf20-cyclotomic-root",
     "proofId": "inverse-galois-f20",
-    "range": { "startLine": 91, "endLine": 135 },
+    "range": { "startLine": 94, "endLine": 135 },
     "type": "insight",
     "title": "Key Trick: Ratio of Two Roots is a Primitive 5th Root of Unity",
     "content": "The theorem `fifth_root_ratio_satisfies_cyclotomic5` proves the key observation: if a⁵ = b⁵ and a ≠ b, then c = a/b satisfies Φ₅(c) = 0. The proof factors X⁵−1 = (X−1)(X⁴+X³+X²+X+1) and notes c ≠ 1 (since a ≠ b). `cyclotomic_5_has_root_in_splitting_field` instantiates this with any two distinct roots α, β of X⁵−2 in the splitting field: both satisfy x⁵ = 2, so their ratio α/β is a primitive 5th root of unity ζ₅ in the splitting field.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-igf20-four-divides",
     "proofId": "inverse-galois-f20",
-    "range": { "startLine": 137, "endLine": 205 },
+    "range": { "startLine": 141, "endLine": 208 },
     "type": "insight",
     "title": "Lower Bound II: 4 | finrank, then 20 | |Gal| by Coprimality",
     "content": "Since ζ₅ ∈ SF satisfies Φ₅ and Φ₅ is irreducible of degree 4, the minimal polynomial of ζ₅ over ℚ has degree 4. By the tower law, 4 divides [SF:ℚ]. `twenty_dvd_gal_card` combines 5 | |Gal| and 4 | |Gal| with the crucial fact gcd(4,5) = 1 (so their product 20 also divides |Gal|) via `Nat.Coprime.mul_dvd_of_dvd_of_dvd`. The cyclotomic polynomial Φ₅ = X⁴+X³+X²+X+1 is identified with `Polynomial.cyclotomic 5 ℚ` and its irreducibility follows from `cyclotomic.irreducible_rat`.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-igf20-roots-in-adjoin",
     "proofId": "inverse-galois-f20",
-    "range": { "startLine": 305, "endLine": 388 },
+    "range": { "startLine": 309, "endLine": 388 },
     "type": "insight",
     "title": "Upper Bound Step: All Roots of X⁵−2 Lie in ℚ(α, ζ₅)",
     "content": "The theorem `roots_in_adjoin_f20` proves every root r of X⁵−2 is in ℚ(α, ζ₅). For any root r: c = r/α satisfies c⁵ = 1. Case c = 1: r = α ∈ ℚ(α, ζ₅). Case c ≠ 1: r ≠ α, so c = r/α is a primitive 5th root, and by `cyclotomic5_root_is_power`, c ∈ {ζ₅, ζ₅², ζ₅³, ζ₅⁴}. In each sub-case, r = c·α is a product of powers of ζ₅ and α, hence in ℚ(α, ζ₅). The follow-up `adjoin_alpha_zeta_eq_top_f20` promotes this to SF = ℚ(α, ζ₅) via `IsSplittingField.adjoin_rootSet'`.",
@@ -74,7 +74,7 @@
   {
     "id": "ann-igf20-upper-bound",
     "proofId": "inverse-galois-f20",
-    "range": { "startLine": 393, "endLine": 491 },
+    "range": { "startLine": 394, "endLine": 491 },
     "type": "technique",
     "title": "Upper Bound: Tower Law Gives |Gal| ≤ 20",
     "content": "The proof of `gal_card_dvd_20` is the most complex in the file. It establishes: [ℚ(α):ℚ] = 5 (from degree of X⁵−2), [SF:ℚ(α)] ≤ 4 (from minpoly of ζ₅ over ℚ(α) dividing Φ₅ of degree 4), and [SF:ℚ] = [SF:ℚ(α)]·5 ≤ 20 via the tower law `Module.finrank_mul_finrank`. Combined with the lower bound 20 | |Gal|, it follows |Gal| = 20 by `Nat.dvd_antisymm`. The main technical challenge is working through Lean's tower law machinery with intermediate fields `Kα = ℚ(α)` and `Kαζ = Kα(ζ₅)`.",
@@ -86,7 +86,7 @@
   {
     "id": "ann-igf20-main-results",
     "proofId": "inverse-galois-f20",
-    "range": { "startLine": 494, "endLine": 528 },
+    "range": { "startLine": 498, "endLine": 528 },
     "type": "context",
     "title": "Main Results: |Gal| = 20 and F₂₀ is Realizable",
     "content": "The file concludes with three corollaries assembling the full result. `x5_sub_2_gal_card` combines the lower and upper bounds via `Nat.dvd_antisymm`. `splitting_field_x5_sub_2_finrank` translates the Galois group cardinality to the field extension degree (equal by `Polynomial.Gal.card_of_separable`). `f20_realizable` witnesses the existential: the Frobenius group F₂₀ is realizable over ℚ, with witness K = splitting field of X⁵−2, using `IsGalois.mk` to assemble the normal, separable, and Galois hypotheses.",

--- a/src/data/proofs/inverse-galois-f20/meta.json
+++ b/src/data/proofs/inverse-galois-f20/meta.json
@@ -53,27 +53,43 @@
   "sections": [
     {
       "id": "irreducibility",
-      "title": "Parts I–II: Irreducibility and Lower Bound",
+      "title": "Parts I–II: Irreducibility of X⁵−2 and Lower Bound 5 | |Gal|",
       "startLine": 38,
-      "endLine": 138,
-      "summary": "x_fifth_sub_2_irreducible (Eisenstein), x_fifth_sub_2_natDegree=5, x_fifth_sub_2_separable, x_fifth_sub_2_monic. five_dvd_gal_card: 5 | |Gal|. gal_card_dvd_120: |Gal| | 120.",
-      "mathContext": "$X^5 - 2$ irreducible by Eisenstein at $p=2$. $5 \\mid [\\text{SF}:ℚ]$, so $5 \\mid |\\text{Gal}|$."
+      "endLine": 88,
+      "summary": "x_fifth_sub_2_irreducible (Eisenstein at p=2), x_fifth_sub_2_natDegree=5, x_fifth_sub_2_separable, x_fifth_sub_2_monic. five_dvd_gal_card: 5 | |Gal| since irreducible degree 5 extension contributes a 5-cycle. gal_card_dvd_120: |Gal| | 120 via injection into S₅.",
+      "mathContext": "$X^5 - 2$ irreducible by Eisenstein at $p=2$: leading coeff $\\nmid 2$, others $\\mid 2$, constant $\\nmid 4$. $5 \\mid [\\text{SF}:ℚ] \\Rightarrow 5 \\mid |\\text{Gal}|$."
     },
     {
       "id": "cyclotomic",
-      "title": "Parts III–IV: Φ₅ Root in Splitting Field and 4 | |Gal|",
+      "title": "Parts III–IV: Φ₅ Root in Splitting Field and 20 | |Gal|",
       "startLine": 91,
       "endLine": 208,
-      "summary": "fifth_root_ratio_satisfies_cyclotomic5: ratio of distinct roots satisfies Φ₅. cyclotomic_5_irreducible, cyclotomic_5_natDegree=4. four_dvd_splitting_field_finrank. twenty_dvd_gal_card: 20 | |Gal|.",
-      "mathContext": "Ratio $(\\zeta_5 \\cdot \\alpha)/\\alpha = \\zeta_5$ is a root of $\\Phi_5$. $\\Phi_5$ irred. degree 4 $\\Rightarrow$ $4 \\mid |\\text{Gal}|$."
+      "summary": "fifth_root_ratio_satisfies_cyclotomic5: ratio of two distinct roots satisfies Φ₅(r) = 0, so ζ₅ ∈ SF. cyclotomic_5_irreducible (degree 4), four_dvd_splitting_field_finrank. twenty_dvd_gal_card: gcd(4,5) = 1 and both divide |Gal|, so 20 | |Gal|.",
+      "mathContext": "$(r_1/r_2)^5 = 1,\\; r_1 \\neq r_2 \\Rightarrow \\Phi_5(r_1/r_2) = 0 \\Rightarrow \\zeta_5 \\in \\text{SF}$. $\\Phi_5$ irred. deg 4 $\\Rightarrow 4 \\mid |\\text{Gal}|$. $\\gcd(4,5)=1 \\Rightarrow 20 \\mid |\\text{Gal}|$."
+    },
+    {
+      "id": "fifth-root-infra",
+      "title": "Part V-A: Primitive 5th Root Infrastructure",
+      "startLine": 211,
+      "endLine": 388,
+      "summary": "Establishes that every root of Φ₅ is a power of ζ (ζ, ζ², ζ³, ζ⁴). Proves ζ≠1, ζ≠−1, ζᵏ≠1 for k=2,3,4. roots_in_adjoin_f20: every root r of X⁵−2 lies in ℚ(α, ζ₅) since r/α is a 5th root of unity.",
+      "mathContext": "$\\Phi_5(c)=(c-\\zeta)(c-\\zeta^2)(c-\\zeta^3)(c-\\zeta^4)$. $r^5=\\alpha^5 \\Rightarrow (r/\\alpha)^5=1 \\Rightarrow r/\\alpha \\in \\{1,\\zeta,\\zeta^2,\\zeta^3,\\zeta^4\\} \\Rightarrow r \\in \\mathbb{Q}(\\alpha,\\zeta_5)$."
     },
     {
       "id": "upper-bound",
-      "title": "Parts V–VI: Upper Bound and |Gal| = 20",
-      "startLine": 208,
-      "endLine": 529,
-      "summary": "Fifth root properties (ζ≠1, ζ≠-1, ζ^5=1). roots_in_adjoin_f20: all roots lie in ℚ(α,ζ). Degree ≤ 20. Combined: |Gal(X⁵-2/ℚ)| = 20.",
-      "mathContext": "All roots $\\alpha \\cdot \\zeta_5^k$ lie in $\\mathbb{Q}(\\alpha, \\zeta_5)$. $[\\mathbb{Q}(\\alpha, \\zeta_5):ℚ] = 20$."
+      "title": "Part VI: Tower Law Upper Bound and |Gal| = 20",
+      "startLine": 393,
+      "endLine": 491,
+      "summary": "gal_card_dvd_20: [ℚ(α):ℚ] = 5 and [SF:ℚ(α)] ≤ 4 (minpoly of ζ₅ over ℚ(α) divides Φ₅) give [SF:ℚ] ≤ 20 by tower law. Combined with 20 | |Gal|: |Gal| = 20 by Nat.dvd_antisymm.",
+      "mathContext": "$[\\mathbb{Q}(\\alpha):\\mathbb{Q}]=5,\\; [\\text{SF}:\\mathbb{Q}(\\alpha)] \\leq 4 \\Rightarrow [\\text{SF}:\\mathbb{Q}] \\leq 20. \\quad 20 \\mid |\\text{Gal}| \\leq 20 \\Rightarrow |\\text{Gal}|=20$."
+    },
+    {
+      "id": "main-results",
+      "title": "Main Results: x5_sub_2_gal_card and f20_realizable",
+      "startLine": 494,
+      "endLine": 528,
+      "summary": "x5_sub_2_gal_card: |Gal(X⁵−2/ℚ)| = 20. splitting_field_x5_sub_2_finrank: [SF:ℚ] = 20. f20_realizable: the Frobenius group F₂₀ (order 20) is realizable over ℚ, witnessed by the splitting field of X⁵−2 via IsGalois.mk.",
+      "mathContext": "$|\\text{Gal}(X^5-2/\\mathbb{Q})| = 20$; $[\\text{SF}:\\mathbb{Q}] = 20$; $\\exists K/\\mathbb{Q}$ Galois with $|\\text{Gal}(K/\\mathbb{Q})| = 20$ — the Frobenius group $F_{20} \\cong \\mathbb{Z}/5\\mathbb{Z} \\rtimes \\mathbb{Z}/4\\mathbb{Z}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Expands `sections` array in meta.json from 3 coarse entries to 5 fine-grained entries matching the 5 logical parts of the proof (irreducibility, cyclotomic, fifth-root-infra, upper-bound, main-results)
- Fixes 6 annotation `startLine` values in annotations.json that pointed to blank lines between section headers instead of actual Lean constructs (docstrings/theorem keywords) — build was reporting "No Lean construct found at line N" for each

## Quality improvement
96 → 100 pts (sections score 6 → 10: 5 sections × 2 pts each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)