### PR TITLE
fix(meta): sync stale theoremCount for 3 gallery proofs

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-09/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-09/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "theoremCount": 21,
+    "theoremCount": 24,
     "assumptions": "2 axioms: liouville_integration_theorem (structural form of elementary antiderivatives requires differential Galois/Picard-Vessiot theory not in Mathlib), risch_exp_criterion_gaussian (Risch criterion: ∫e^(-x²)dx elementary iff rational Q with Q'-2xQ=1; requires partial fraction analysis and extension from polynomial to rational case). The Gaussian non-elementarity (gaussian_not_elementary) is now fully proved as a theorem via the iterated Risch operator degree-raising argument.",
     "dateAdded": "2026-05-03",
     "lineCount": 540,
@@ -201,7 +201,7 @@
     "namespace": "AbelRuffiniOQ09",
     "lineCount": 540,
     "axiomCount": 2,
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 3,
     "path": "Proofs/AbelRuffiniOQ09.lean",
     "sorries": 0

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -57,7 +57,7 @@
     "dateAdded": "2026-04-04",
     "lineCount": 507,
     "assumptions": "1 axiom (greens_theorem_l1curl — Whitney's 1957 theorem). 19 theorems with 0 sorries. Supporting results are fully proved using Mathlib's LipschitzWith, MeasureTheory, and trigonometric libraries.",
-    "theoremCount": 22
+    "theoremCount": 19
   },
   "overview": {
     "historicalContext": "**Classical Green's theorem** (George Green, 1828) requires:\n1. **C¹ boundary**: the curve γ must have a continuous derivative everywhere\n2. **C¹ vector field**: P and Q must have continuous partial derivatives\n\n**Hasbrouck Whitney (1957)** proved these conditions can be drastically weakened. His minimal regularity theorem shows Green's theorem holds when:\n1. The boundary is merely **Lipschitz** (derivative exists a.e. but may have jumps at corners)\n2. The curl is merely **L¹** (Lebesgue integrable, not necessarily continuous)\n\nThe key mechanism is **Rademacher's theorem** (1919): every Lipschitz function is differentiable at Lebesgue-almost-every point. This gives a well-defined a.e. tangent vector to any Lipschitz curve, making the line integral meaningful.\n\nThis generalization is practically important: the boundary of a square, polygon, or any piecewise-smooth domain is Lipschitz but NOT C¹ (corners cause derivative jumps).",
@@ -216,7 +216,7 @@
     "namespace": "GreensTheoremOQ02",
     "lineCount": 507,
     "axiomCount": 1,
-    "theoremCount": 22,
+    "theoremCount": 19,
     "definitionCount": 4,
     "path": "Proofs/GreensTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 3,
     "assumptions": "3 axioms: picks_theorem (Pick's formula A=i+B/2-1, matching the gallery's axiomatized PicksTheorem.lean), scaled_area (Area(tP)=t²A), scaled_boundary (|∂(tP)|=t·B for t≥1). The rectangle and triangle Ehrhart polynomials are proved with 0 axioms via Finset combinatorics.",
     "lineCount": 309,
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 7,
     "originalContributions": [
       "rectangle_ehrhart: L(R_{a,b},t) = (ta+1)(tb+1) via Finset.card_product (0 axioms)",
@@ -111,7 +111,7 @@
     "namespace": "EhrhartPolynomial",
     "path": "Proofs/PicksTheoremOQ01OQ02.lean",
     "lineCount": 309,
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 7,
     "axiomCount": 3,
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` in meta.json `meta` and `leanFile` blocks for 3 gallery proofs where Lean files evolved but counts weren't updated. Line counts are all correct; only theorem counts needed correction.

## Evidence

**abel-ruffini-oq-09**
- `meta.theoremCount` / `leanFile.theoremCount`: 21 → 24
- 3 additional attributed theorem/lemma declarations were added since enrichment

**greens-theorem-oq-02**
- `meta.theoremCount` / `leanFile.theoremCount`: 22 → 19
- 3 theorem declarations were removed/consolidated since enrichment

**picks-theorem-oq-01-oq-02**
- `meta.theoremCount` / `leanFile.theoremCount`: 21 → 24
- 3 additional lemmas were added since enrichment

---
Automated fix by lean-mechanic agent.