### PR TITLE
fix(meta): sync stale lineCount for ballot-problem-oq-03-oq-01-oq-02

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -26,7 +26,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 open sorry in GNW infrastructure (BallotProblemOQ03OQ01OQ02Helpers.lean): gnwProb_key — the GNW 1979 probabilistic identity for ≥10-row, ≥10-col, non-rectangular shapes (hard combinatorial identity). The supporting lemmas gnwProb_sum_corners, strictHookCells_card, strictHookCells_nonempty, and strictHookCells_hookLen_lt were proved in PR #14960. hook_walk_identity_gnw (the dispatcher in the gallery face) calls gnwProb_key and is otherwise complete. hookProd_ratio_formula is sorry-free. Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row through 9-row, ≤9-col (transpose duality), all rectangles.",
-    "lineCount": 14235,
+    "lineCount": 14296,
     "theoremCount": 489,
     "definitionCount": 24,
     "originalContributions": [


### PR DESCRIPTION
## Fix

Sync stale `meta.lineCount` for `ballot-problem-oq-03-oq-01-oq-02`.

## Evidence

**Before**: `meta.lineCount = 14235`
**After**: `meta.lineCount = 14296`

The proof spans two files:
- Main: `Proofs/BallotProblemOQ03OQ01OQ02.lean` — 398 lines (`leanFile.lineCount` is already correct at 398)
- Helpers: `Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` — 13,898 lines

Total actual: 398 + 13,898 = 14,296 lines. The previous count (14,235) was recorded before 61 lines were added to the helpers file. No other fields changed.

No in-flight PRs cover this entry (checked via `gh pr list --search ballot-problem-oq-03` and `git ls-remote --heads origin | grep ballot`).

---
Automated fix by lean-mechanic agent.