### PR TITLE
enrich(infinitude-primes-4k3-oq-03): fix annotation range overlap, extend comparison-table

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "oq-answer",
     "proofId": "infinitude-primes-4k3-oq-03",
-    "range": { "startLine": 1, "endLine": 52 },
+    "range": { "startLine": 1, "endLine": 25 },
     "type": "concept",
     "title": "Answering OQ-03: Elementary ≡ 1 (mod 4) Proof",
     "content": "OQ-03 from infinitude-primes-4k3 asks whether the Euclid-style argument for ≡ 3 (mod 4) can be adapted to ≡ 1 (mod 4). The answer is yes, but the construction differs: instead of N = 4(n+1)! − 1, we use N = (2(n+1)!)² + 1. The ≡ 3 proof exploits that products of residues ≡ 1 (mod 4) stay ≡ 1, forcing a prime factor ≡ 3. For ≡ 1, the key is that any prime p dividing k² + 1 must have −1 as a quadratic residue mod p, which by Euler's criterion forces p ≡ 1 (mod 4). This difference (elementary product argument vs. quadratic residue theory) is what makes the ≡ 1 case slightly deeper.",
@@ -14,10 +14,10 @@
   {
     "id": "comparison-table",
     "proofId": "infinitude-primes-4k3-oq-03",
-    "range": { "startLine": 26, "endLine": 44 },
+    "range": { "startLine": 26, "endLine": 52 },
     "type": "concept",
     "title": "Two Parallel Constructions: ≡ 3 vs ≡ 1 (mod 4)",
-    "content": "The module comment compares both constructions side-by-side. For ≡ 3: N = 4(n+1)! − 1 is ≡ 3 (mod 4), and since a product of ≡ 1 numbers is ≡ 1, N must have a prime factor ≡ 3 (mod 4). For ≡ 1: N = (2(n+1)!)² + 1 has an odd prime factor p, and since p | k² + 1, we have −1 ≡ k² (mod p), so −1 is a QR mod p, forcing p ≡ 1 (mod 4). In both cases, the new prime p > n follows by the same argument: if p ≤ n, then p | (n+1)!, so p | N ∓ 1 = ±1, contradiction. The difficulty difference is real: the ≡ 3 argument is completely self-contained in elementary arithmetic, while the ≡ 1 argument requires Euler's criterion (a theorem of quadratic residue theory).",
+    "content": "The module comment compares both constructions side-by-side and states the complete classification. For ≡ 3: N = 4(n+1)! − 1 is ≡ 3 (mod 4), and since a product of ≡ 1 numbers is ≡ 1, N must have a prime factor ≡ 3 (mod 4). For ≡ 1: N = (2(n+1)!)² + 1 has an odd prime factor p, and since p | k² + 1, we have −1 ≡ k² (mod p), so −1 is a QR mod p, forcing p ≡ 1 (mod 4). In both cases, the new prime p > n follows by the same contradiction argument. The complete picture: together InfinitudePrimes4k3 and InfinitudePrimes4k1 classify all odd primes mod 4 — both classes are infinite, every odd prime belongs to exactly one, and 2 is the unique even prime.",
     "mathContext": "\\begin{array}{l|l|l} & p \\equiv 3 \\pmod 4 & p \\equiv 1 \\pmod 4 \\\\ \\hline N & 4(n+1)!-1 & (2(n+1)!)^2+1 \\\\ \\text{Key lemma} & \\prod_{p_i\\equiv 1} \\equiv 1 & (-1/p)=1 \\Rightarrow p\\equiv 1 \\\\ \\text{p > n} & p\\mid (n+1)! \\Rightarrow p\\mid 1 & \\text{same} \\end{array}",
     "significance": "supporting",
     "relatedConcepts": ["Euclid's argument", "Dirichlet's theorem", "arithmetic progressions", "product of residues"],

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -68,7 +68,7 @@
       "id": "main-theorems",
       "title": "Classification Theorems",
       "startLine": 53,
-      "endLine": 100,
+      "endLine": 103,
       "summary": "Four theorems: infinitely_many_primes_1_mod_4 (imports from 4k1), both_classes_infinite (conjunction of 4k1 and 4k3 results), odd_prime_mod_four_classification (every odd prime is ≡ 1 or ≡ 3 mod 4), constructions_cover_all_odd_primes (both Euclid constructions cover all odd primes).",
       "mathContext": "The classification theorem uses InfinitudePrimes4k3.prime_mod_four (proved in the parent file). The conjunction both_classes_infinite packages the key result: both infinite, together covering all odd primes."
     }


### PR DESCRIPTION
Fixes annotation range overlap in `infinitude-primes-4k3-oq-03`.

## Changes

- Fixed `oq-answer` range from `1–52` to `1–25` (was fully containing `comparison-table`)
- Extended `comparison-table` range from `26–44` to `26–52` (now covers the "Complete Picture" section of the module comment, lines 35–52)
- Updated comparison-table content to describe the complete mod-4 classification stated in that section
- Fixed `main-theorems` section `endLine` from 100 to 103 to cover the full file (namespace close)