### PR TITLE
fix(meta): sync stale theoremCount for 13 gallery proofs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "lineCount": 265,
     "mathlibDependencies": [
       {
@@ -121,7 +121,7 @@
     "namespace": "AngleTrisectionOQ02OQ01OQ02",
     "lineCount": 265,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
     "sorries": 2

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 156,
-    "theoremCount": 13
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "The impossibility of trisecting a general angle with compass and straightedge was proved by Pierre Wantzel in 1837 using Galois theory: an angle θ is trisectable iff 8x³ − 6x − cos θ has a rational root or splits into linear factors over the iterated quadratic extensions of ℚ. The OQ-03 companion entry formalizes an O(log d) algorithm to check whether a denominator d (determining the angle π/d) satisfies the constructibility conditions by counting halvings of d until it becomes odd. This entry (OQ-03-OQ-02) closes the complexity question: the O(log d) bound is not just an upper bound — it is tight. The halvings algorithm performs exactly Nat.log 2 (2^k) = k steps on inputs d = 2^k, and no algorithm can process these inputs in sub-logarithmic time. The proof connects the constructibility check to the 2-adic valuation v₂(d) — the exact power of 2 dividing d — which is the information-theoretically required number of halvings.",
@@ -103,7 +103,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 13
+    "theoremCount": 10
   },
   "crossReferences": [
     {

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum b≥2 — the general JDT seam bijection (~150-200 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
     "lineCount": 850,
-    "theoremCount": 19,
+    "theoremCount": 10,
     "definitionCount": 8,
     "originalContributions": [
       "jacobiTrudiMatrix: the k×k matrix with entries h_{sh_i + j - i} (or 0 for negative index) — first Lean 4 Jacobi-Trudi matrix definition",
@@ -80,7 +80,7 @@
     "namespace": "JacobiTrudi",
     "lineCount": 850,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 10,
     "definitionCount": 6,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -100,7 +100,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 16,
+    "theoremCount": 2,
     "definitionCount": 1
   },
   "crossReferences": [

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -21,7 +21,7 @@
         "badge": "verified",
         "sorries": 0,
         "axiomCount": 0,
-        "theoremCount": 8,
+        "theoremCount": 3,
         "lineCount": 268,
         "assumptions": "",
         "mathlib_version": "4.26.0",
@@ -124,7 +124,7 @@
         "namespace": "CayleyHamiltonCyclicVectorAllFields",
         "lineCount": 268,
         "axiomCount": 0,
-        "theoremCount": 8,
+        "theoremCount": 3,
         "definitionCount": 2,
         "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
         "sorries": 0

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -34,7 +34,7 @@
         "relationship": "OQ-02-OQ-01 proves Budan's building blocks; Sturm's exact count goes further, using GCD-based sequences instead of derivative towers."
       }
     ],
-    "theoremCount": 28
+    "theoremCount": 26
   },
   "overview": {
     "historicalContext": "Jacques Charles François Sturm (1829) published the theorem bearing his name as a response to a challenge: given a polynomial equation with real coefficients, how many real roots does it have in a given interval? His elegant answer used a GCD-based sequence (now called the Sturm sequence) to give an exact count via sign-variation differences — the first constructive, computable solution to this classical problem. The theorem appeared in Sturm's 1829 paper 'Mémoire sur la résolution des équations numériques' and immediately became the standard tool for real root counting. It was later extended by Sylvester (1853) and connected to the Hermite quadratic forms theory, which gives the number of real roots via the signature of a quadratic form over ℚ — a bridge between polynomial analysis and number theory.",
@@ -52,7 +52,7 @@
     "namespace": "SturmTheorem",
     "lineCount": 458,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 26,
     "defCount": 8,
     "sorries": 0,
     "mainTheorems": [

--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -69,7 +69,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 3,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "lineCount": 179,
     "assumptions": "3 axioms: prime_ap_pnt_upper (PNT upper bound), green_tao (Green-Tao 2008), erdos_200 (open conjecture). 0 sorries.",
     "mathlib_version": "4.26.0"
@@ -173,7 +173,7 @@
     "namespace": null,
     "lineCount": 179,
     "axiomCount": 3,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 3,
     "path": "Proofs/Erdos200Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/321",
     "erdosUrl": "https://erdosproblems.com/321",
     "axiomCount": 2,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "assumptions": "2 axioms: bleicher_erdos_lower (R(N) \u2265 N/log N, Bleicher\u2013Erd\u0151s 1975) and bleicher_erdos_upper (R(N) \u2264 C\u00b7(N/log N)\u00b7log log N, 1976). Open problem \u2014 precise asymptotic of R(N) remains unknown.",
     "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
@@ -187,7 +187,7 @@
   "leanFile": {
     "lineCount": 190,
     "axiomCount": 2,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 3,
     "imports": [
       "Mathlib.Data.Finset.Basic",

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 531,
     "assumptions": "None. 80 theorems fully verified with 0 axioms and 0 sorries. The open density question (Q1) is stated as a comment only. Open conjecture; supporting lemmas fully verified. New: hMinK_prime_minus_one proves h(p-1)=p for all primes p; hMinK_unbounded proves Q2 (upper half: h(n) is unbounded).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 80
+    "theoremCount": 74
   },
   "sections": [
     {
@@ -208,7 +208,7 @@
     "namespace": null,
     "lineCount": 531,
     "axiomCount": 0,
-    "theoremCount": 80,
+    "theoremCount": 74,
     "definitionCount": 2,
     "path": "Proofs/Erdos770Problem.lean",
     "sorries": 0

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -61,7 +61,7 @@
         "relationship": "Builds infrastructure toward eliminating axiom 1 (Furstenberg correspondence) from the parent proof"
       }
     ],
-    "theoremCount": 32
+    "theoremCount": 30
   },
   "crossReferences": [
     {
@@ -153,7 +153,7 @@
     "axiomCount": 1,
     "sorries": 1,
     "definitionCount": 9,
-    "theoremCount": 32
+    "theoremCount": 30
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "mathlibDependencies": [
       {
         "theorem": "Complex.ofReal",
@@ -126,7 +126,7 @@
     "namespace": "Hilbert20OQ01OQ03",
     "lineCount": 367,
     "axiomCount": 2,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 7,
     "path": "Proofs/Hilbert20OQ01OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -178,7 +178,7 @@
     "namespace": "AEPFormalization",
     "lineCount": 476,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 7,
     "path": "Proofs/ShannonSourceCodingOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -45,7 +45,7 @@
     "lineCount": 948,
     "assumptions": "1 axiom: bdry_all_even_of_no_fc_walks — when all boundary-door walks fail to reach FC, the boundary-door set B has even cardinality (used for parity contradiction in kuhn_path_existential). Mathematical proof: under hfail, τ: B→B defined by τ(s₀,Fin.last d) = (kuhnPathStart s₀, Fin.last d) is a FPF involution; hMem and hNe proved; hInv (τ∘τ=id, walkTrace_reversal) requires ~150-line kuhnWalkSeq infrastructure and is axiomatized after 9+ sessions BLOCKED.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 23
+    "theoremCount": 18
   },
   "overview": {
     "historicalContext": "Harold Kuhn (1968) gave the first algorithmic proof of Sperner's lemma, showing that a fully-colored simplex can be found in polynomial time by path-following in the door graph. This constructive approach contrasts with the combinatorial parity argument of Cohen (1967), which proves existence by counting doors modulo 2 but gives no algorithm to find one. The same year, Herbert Scarf (1967) independently developed a pivoting algorithm for computing approximate fixed points, also based on door-traversal in simplicial subdivisions — the two methods are closely related.\n\nKuhn's algorithm belongs to the broader family of **complementary pivot algorithms**: algorithms that follow a unique path determined by local complementarity or door conditions. Lemke and Howson (1964) had already used this idea for Nash equilibrium computation, following edges of the Nash equilibrium polytope. The realization that Sperner-type path-following and Nash equilibrium computation share the same combinatorial structure eventually led to the PPAD complexity class (Papadimitriou, 1994), which captures all problems reducible to finding a degree-1 vertex in a directed graph on an exponentially large implicit structure. Sperner's lemma is PPAD-complete, so Kuhn's constructive proof is, in complexity-theoretic terms, a PPAD algorithm.",
@@ -251,7 +251,7 @@
     "namespace": "SpernerNDimOQ04",
     "lineCount": 948,
     "axiomCount": 1,
-    "theoremCount": 23,
+    "theoremCount": 18,
     "definitionCount": 6,
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` in `meta.json` for 13 gallery proofs where Lean files evolved (theorems added/removed during research sessions) but the count metadata was not updated.

## Evidence

For each proof, `grep -c "^(theorem|lemma) "` on the current Lean file (with block comments stripped) gives a different value from `leanFile.theoremCount`.

| Proof | Before | After |
|-------|--------|-------|
| angle-trisection-oq-02-oq-01-oq-02 | 16 | 15 |
| angle-trisection-oq-03-oq-02 | 13 | 10 |
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | 19 | 10 |
| ballot-problem-oq-03-oq-01-oq-02 | leanFile 16 | 2 (meta.tc=489 is aggregate, unchanged) |
| cayley-hamilton-cyclic-vector-all-fields | 8 | 3 |
| descartes-rule-of-signs-oq-02-oq-01-oq-02 | 28 | 26 |
| erdos-200 | 7 | 6 |
| erdos-321 | 9 | 8 |
| erdos-770 | 80 | 74 |
| furstenberg-correspondence-oq-01 | 32 | 30 |
| hilbert-20-oq-01-oq-03 | 9 | 10 |
| shannon-source-coding-oq-03 | leanFile 13 | 12 |
| sperner-ndim-oq-04 | 23 | 18 |

**Scope**: Only `theoremCount` fields changed. lineCount and sorries verified correct.
**Verification**: Checked that no open PRs already target these meta.json files.

---
Automated fix by lean-mechanic agent.