### PR TITLE
fix(meta): sync stale lineCount and theoremCount for erdos-1093

### DIFF
--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -20,10 +20,10 @@
     "erdosUrl": "https://erdosproblems.com/1093",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 167,
+    "lineCount": 223,
     "assumptions": "1 axiom: els_upper_bound (ELS 1993 upper bound theorem). Former many_deficiency_one_examples axiom eliminated by 16 individually verified native_decide examples spanning k=3..28.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25
+    "theoremCount": 38
   },
   "overview": {
     "historicalContext": "Erdős, Lacampagne, and Selfridge developed this problem across two papers (1988, 1993) and first presented it at the 1986 West Coast Number Theory conference. The question arose from their broader investigation into the prime factorization of binomial coefficients, specifically when $\\binom{n}{k}$ has no 'small' prime factors (all primes dividing it exceed $k$). Under this condition, the falling factorial $n(n-1)\\cdots(n-k+1)$ has a delicate balance: the small prime factors must cancel exactly with $k!$, and the 'deficiency' measures excess smoothness. The ELS upper bound $n \\ll 2^k \\sqrt{k}$ (1993) constrains the search space but leaves both parts of the conjecture open. The problem connects to Dickman's function ($\\Psi(x, y)$ counting $y$-smooth numbers up to $x$), Kummer's theorem (1852) on carries in base-$p$ addition characterizing $v_p(\\binom{n}{k})$, and the broader Erdős program on arithmetic properties of binomial coefficients. The record deficiency of 9 for $\\binom{284}{28}$ has stood since the original investigation, and computational searches have found at least 58 deficiency-1 examples for $n \\leq 10^5$.",
@@ -224,9 +224,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 167,
+    "lineCount": 223,
     "axiomCount": 1,
-    "theoremCount": 25,
+    "theoremCount": 38,
     "definitionCount": 6,
     "path": "Proofs/Erdos1093Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `lineCount` and `theoremCount` in `src/data/proofs/erdos-1093/meta.json`.

## Evidence

`Erdos1093Problem.lean` grew from 167 → 223 lines during research sessions that added structural IsKSmooth theorems, deficiency bound lemmas, and ELS census examples. The meta.json was not updated.

**Before**:
- `lineCount`: 167 (both `meta` and `leanFile` blocks)
- `theoremCount`: 25 (both blocks)

**After**:
- `lineCount`: 223
- `theoremCount`: 38

`sorries` (0) and `axiomCount` (1) verified unchanged by inspection.

Note: PR #15311 (researcher-4) also touches `Erdos1093Problem.lean` with a +2 line proof refactor, but does not update `erdos-1093/meta.json`. This fix brings the metadata up to date with the current file state.

---
Automated fix by lean-mechanic agent.