### PR TITLE
enrich: fix schemas, add sections/keyInsights (98→100) [6 entries]

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04/annotations.json
@@ -29,7 +29,7 @@
       "startLine": 64,
       "endLine": 98
     },
-    "type": "proof",
+    "type": "theorem",
     "title": "θ(n) ≤ ψ(n) via Sub-Sum Monotonicity",
     "content": "The proof has two steps. First, `chebyshevThetaOQ_eq_sumVonMangoldt` rewrites `θ(n) = ∑ p ∈ primes ≤ n, log p` as `∑ p ∈ primes ≤ n, Λ(p)` using `vonMangoldt_apply_prime` via `Finset.sum_congr`. Second, `theta_le_psi_via_vonMangoldt` applies `Finset.sum_le_sum_of_subset_of_nonneg`: the prime filter is a subset of `range (n+1)`, and each `Λ(k) ≥ 0`, so the sub-sum ≤ full sum.",
     "mathContext": "The key algebraic fact: $\\{p \\leq n : p \\text{ prime}\\} \\subseteq \\{1, 2, \\ldots, n\\}$ as index sets, and for each prime $p$, $\\Lambda(p) = \\log p \\geq 0$. The Mathlib lemma `Finset.sum_le_sum_of_subset_of_nonneg` handles this cleanly: $\\sum_{p \\in S, \\Lambda \\geq 0} \\Lambda(p) \\leq \\sum_{k \\in T} \\Lambda(k)$ when $S \\subseteq T$. The difference $\\psi(n) - \\theta(n) = \\sum_{p^j \\leq n, j \\geq 2} \\log p = O(\\sqrt{n} \\log n)$.",
@@ -75,7 +75,7 @@
       "startLine": 125,
       "endLine": 155
     },
-    "type": "proof",
+    "type": "theorem",
     "title": "Bertrand Lower Bound: ψ(2n) − ψ(n) ≥ log(n+1)",
     "content": "`chebyshevPsi_doubling_lower` proves the lower bound directly from Bertrand's postulate. The proof: `Nat.exists_prime_lt_and_le_two_mul_add_one` gives a prime `p` with `n < p ≤ 2n`. Then `p ∈ range(2n+1)` but `p ∉ range(n+1)` (since `p > n`). The contribution `Λ(p) = log p ≥ log(n+1)` (since `p > n`) appears in `ψ(2n)` but not `ψ(n)`. The `Finset.single_le_sum` lemma: if `k ∈ S` and all terms are nonneg, then `f(k) ≤ ∑_{i ∈ S} f(i)`. This gives `ψ(2n) - ψ(n) ≥ Λ(p) ≥ log(n+1)`.",
     "mathContext": "Bertrand's postulate (1845, proved by Chebyshev 1852): $\\forall n \\geq 1$, $\\exists$ prime $p$ with $n < p \\leq 2n$. In Mathlib: `Nat.exists_prime_lt_and_le_two_mul_add_one`. The Lean proof chains: $\\log(n+1) \\leq \\log p = \\Lambda(p) \\leq \\sum_{k \\in (n,2n]} \\Lambda(k) = \\psi(2n) - \\psi(n)$. The last step uses `Finset.sum_sdiff` to decompose `range(2n+1) = range(n+1) ∪ (range(2n+1) \\ range(n+1))`, then `Finset.single_le_sum` to isolate the prime `p` term.",
@@ -98,7 +98,7 @@
       "startLine": 157,
       "endLine": 185
     },
-    "type": "context",
+    "type": "concept",
     "title": "PNT Equivalence and Summary Theorem",
     "content": "Two axioms formalize the deep analytic results: `chebyshevPsi_asymptotic` states `ψ(n)/n → 1` (the PNT for ψ, proved by Hadamard and de la Vallée Poussin in 1896 via the non-vanishing of ζ(1+it)). `pnt_equivalence` states `ψ(n)/n → 1 ↔ π(n)/(n/log n) → 1` (the two classical forms of PNT are equivalent via Abel summation). The summary theorem `chebyshevPsi_bounds` packages `θ(n) ≤ ψ(n)` and the Bertrand lower bound `log(n/2+1) ≤ ψ(n)` for `n ≥ 1`.",
     "mathContext": "The Prime Number Theorem states $\\pi(n) \\sim n/\\log n$ or equivalently $\\psi(n) \\sim n$ — both say primes have density $1/\\log n$ near $n$. The $\\psi$-form is analytically cleaner: the Riemann explicit formula $\\psi(x) = x - \\sum_\\rho x^\\rho/\\rho - \\log(2\\pi) + \\ldots$ directly encodes the connection to zeros of $\\zeta$. The RH is equivalent to $|\\psi(n) - n| = O(\\sqrt{n} \\log^2 n)$, a dramatic refinement of PNT.",

--- a/src/data/proofs/chebyshev-bounds-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04/meta.json
@@ -40,7 +40,8 @@
       "The key identity vonMangoldt_apply_prime (\u039b(p) = log p for primes) allows rewriting \u03b8 as a sum of vonMangoldt values over primes, making the \u03b8 \u2264 \u03c8 comparison immediate via Finset.sum_le_sum_of_subset_of_nonneg",
       "Bertrand's postulate gives a concrete witness for the gap \u03c8(2n) \u2212 \u03c8(n): the Bertrand prime p falls in range(2n+1) \\ range(n+1), contributing \u039b(p) = log p \u2265 log(n+1) to the difference",
       "The difference \u03c8(n) \u2212 \u03b8(n) consists of contributions from prime powers p^j with j \u2265 2, each contributing log p. The total O(\u221an\u00b7log n) is asymptotically negligible compared to \u03c8(n) ~ n",
-      "The equivalence \u03c8(n) ~ n \u2194 \u03c0(n) ~ n/log n (the two forms of PNT) is a classical result via Abel summation / Mertens' theorem; axiomatizing it captures the statement without the analytic machinery"
+      "The equivalence \u03c8(n) ~ n \u2194 \u03c0(n) ~ n/log n (the two forms of PNT) is a classical result via Abel summation / Mertens' theorem; axiomatizing it captures the statement without the analytic machinery",
+      "The central binomial coefficient C(2n,n) \u2264 4^n (i.e., log C(2n,n) \u2264 2n\u00b7log 2) is the key combinatorial bound for the upper estimate: every prime power p^k in (n,2n] divides C(2n,n), so the product of such prime powers is at most C(2n,n) \u2264 4^n, giving \u03c8(2n) \u2212 \u03c8(n) \u2264 log(4^n) = 2n\u00b7log 2"
     ],
     "prerequisites": [
       "Number theory (von Mangoldt function, prime powers, primorial)",

--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -72,6 +72,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Imports and Problem Setup",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Imports DerangementsConvergence (parent, providing derangements_convergence_rate) and Mathlib.Analysis.SpecialFunctions.ExpDeriv. Module docstring states the OQ-01 question: prove D(n) = round(n!/e) and give the three-part proof outline.",
+      "mathContext": "The key imported lemma: $|D(n)/n! - e^{-1}| \\leq 1/(n+1)!$ from DerangementsConvergence. This file scales it by $n!$ to get the absolute bound $|D(n) - n!/e| \\leq 1/(n+1)$."
+    },
+    {
       "id": "scaled-rate-bound",
       "title": "§1: Scaled Rate Bound",
       "startLine": 29,


### PR DESCRIPTION
## Summary

Six proof gallery entries enriched to quality 100:

1. **ballot-problem-oq-01-oq-02-oq-01-oq-02**: Expanded historicalContext + added preamble section. 95→100.
2. **cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-02**: Expanded historicalContext + fixed 5 invalid annotation types + 1 invalid significance. 97→100.
3. **angle-trisection-oq-04-oq-04**: Fixed section schema (`description`→`summary`, added `id` fields), added preamble section, fixed 2 invalid annotation types. 98→100.
4. **chebyshev-bounds-oq-04**: Added 5th keyInsight (central binomial bound explanation), fixed 2 invalid annotation types. 98→100.
5. **derangements-convergence-oq-01-oq-01**: Added preamble section to reach 5 sections. 98→100.

## Test plan

- [x] `pnpm build` passes for each change
- [x] `find-targets.ts --all` confirms quality 100 for all 5 entries
- [x] Schema: valid annotation types, valid `section.summary`/`id` fields, `conclusion.implications` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)