### PR TITLE
fix(meta): sync stale lineCount for 5 gallery proofs (additionalFiles not counted)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 463,
-    "theoremCount": 24,
+    "lineCount": 562,
+    "theoremCount": 27,
     "defCount": 6,
     "assumptions": "Two axioms (both require Eisenstein integers ℤ[ω] not in Mathlib): (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. All 24 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card (|ker χ₃| = (p-1)/3, proved via IsCyclic.card_pow_eq_one_le + Finset.le_card_of_inj_on_range) and cubicEuler_hard (hard direction of Euler criterion via discrete log).",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-03-29",
     "axiomCount": 3,
-    "lineCount": 232,
+    "lineCount": 499,
     "prerequisites": [
       "Covering systems and congruence classes",
       "Well-ordering principle for natural numbers",

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -74,7 +74,7 @@
       "de-rham",
       "research"
     ],
-    "lineCount": 587,
+    "lineCount": 1144,
     "prerequisites": [
       "Green's theorem for simply-connected regions (OQ-01, OQ-03)",
       "TypeI regions and iterated integrals",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -38,7 +38,7 @@
         "relationship": "Parent entry stating the Inverse Galois Problem and axiomatizing Shafarevich's theorem for solvable groups"
       }
     ],
-    "lineCount": 723,
+    "lineCount": 4822,
     "mathlib_version": "4.26.0",
     "theoremCount": 40
   },

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -112,7 +112,7 @@
       "Can we formalize the Kronecker-Weber theorem in Lean?",
       "Can Q₈ (quaternion group) be explicitly realized? (last missing group of order ≤ 8)"
     ],
-    "lineCount": 1882,
+    "lineCount": 5881,
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `meta.json` for 5 gallery proofs. Four proofs had `additionalFiles` added after `lineCount` was last set, so the count reflected only the main file and missed additional files. One proof had no additional files but the main file grew.

## Evidence

**Before/After:**

| Proof | Old lineCount | New lineCount | Reason |
|-------|---------------|---------------|--------|
| inverse-galois-oq-01 | 723 | 4822 | 3 additionalFiles not counted |
| inverse-galois | 1882 | 5881 | 5 additionalFiles not counted |
| greens-theorem-oq-04 | 587 | 1144 | GreensTheoremOQ03.lean not counted |
| erdos-2-oq-01 | 232 | 499 | Erdos2Problem.lean not counted |
| elementary-quadratic-reciprocity-oq-01-oq-02 | 463 | 562 | main file grew (+99 lines) |

Also fixed `theoremCount` for elementary-quadratic-reciprocity-oq-01-oq-02: 24 → 27.

No Lean code, proof logic, or sorry/axiom counts were changed.

---
Automated fix by lean-mechanic agent.