### PR TITLE
research(erdos-671): formalize Lagrange interpolation — 16 sorries eliminated, 7 remaining

### DIFF
--- a/proofs/Proofs/Erdos671Problem.lean
+++ b/proofs/Proofs/Erdos671Problem.lean
@@ -26,7 +26,7 @@ import Mathlib
 
 namespace Erdos671
 
-open Polynomial ContinuousMap MeasureTheory
+open ContinuousMap MeasureTheory Filter
 
 /- ## Part I: Basic Definitions -/
 
@@ -41,8 +41,9 @@ def PointSequence := (n : ℕ) → InterpolationPoints n
 
 /-- The Lagrange basis polynomial p_i^n: degree n-1, p_i(a_i) = 1, p_i(a_j) = 0 for j ≠ i. -/
 noncomputable def lagrangeBasis (pts : InterpolationPoints n) (i : Fin n) : Polynomial ℝ :=
-  ∏ j in Finset.univ.filter (· ≠ i),
-    C (1 / (pts.points i - pts.points j)) * (X - C (pts.points j))
+  ∏ j ∈ (Finset.univ : Finset (Fin n)).filter (fun k => k ≠ i),
+    (Polynomial.C (1 / (pts.points i - pts.points j)) *
+     (Polynomial.X - Polynomial.C (pts.points j)) : Polynomial ℝ)
 
 /-- p_i^n(a_i) = 1. -/
 theorem lagrangeBasis_self (pts : InterpolationPoints n) (i : Fin n) :
@@ -61,25 +62,30 @@ theorem lagrangeBasis_other (pts : InterpolationPoints n) (i j : Fin n) (hij : i
     (lagrangeBasis pts i).eval (pts.points j) = 0 := by
   simp only [lagrangeBasis, Polynomial.eval_prod, Polynomial.eval_mul,
              Polynomial.eval_C, Polynomial.eval_sub, Polynomial.eval_X]
-  apply Finset.prod_eq_zero (Finset.mem_filter.mpr ⟨Finset.mem_univ _, hij.symm⟩)
-  simp [sub_self]
+  apply Finset.prod_eq_zero
+  · exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, hij.symm⟩
+  · simp [sub_self]
 
 /- ## Part II: Lagrange Interpolation -/
 
-/-- The Lagrange interpolation operator L^n f(x) = Σ f(a_i) p_i(x). -/
-noncomputable def lagrangeInterp (pts : InterpolationPoints n) (f : ℝ → ℝ) (x : ℝ) : ℝ :=
-  ∑ i : Fin n, f (pts.points i) * (lagrangeBasis pts i).eval x
+/-- The Lagrange interpolation operator L^n f(x) = Σ f(a_i) p_i(x).
+    Takes f on the domain [-1,1] since nodes are always in this interval. -/
+noncomputable def lagrangeInterp (pts : InterpolationPoints n)
+    (f : Set.Icc (-1 : ℝ) 1 → ℝ) (x : ℝ) : ℝ :=
+  ∑ i : Fin n, f ⟨pts.points i, pts.in_interval i⟩ * (lagrangeBasis pts i).eval x
 
 /-- L^n interpolates f at the nodes: L^n f(a_i) = f(a_i). -/
-theorem lagrangeInterp_at_node (pts : InterpolationPoints n) (f : ℝ → ℝ) (i : Fin n) :
-    lagrangeInterp pts f (pts.points i) = f (pts.points i) := by
+theorem lagrangeInterp_at_node (pts : InterpolationPoints n)
+    (f : Set.Icc (-1 : ℝ) 1 → ℝ) (i : Fin n) :
+    lagrangeInterp pts f (pts.points i) = f ⟨pts.points i, pts.in_interval i⟩ := by
   unfold lagrangeInterp
   rw [Finset.sum_eq_single_of_mem i (Finset.mem_univ _)
     (fun k _ hki => by rw [lagrangeBasis_other pts k i hki, mul_zero])]
   rw [lagrangeBasis_self, mul_one]
 
 /-- L^n f is a polynomial of degree ≤ n - 1. -/
-theorem lagrangeInterp_degree (pts : InterpolationPoints n) (f : ℝ → ℝ) :
+theorem lagrangeInterp_degree (pts : InterpolationPoints n)
+    (f : Set.Icc (-1 : ℝ) 1 → ℝ) :
     ∃ p : Polynomial ℝ, p.natDegree ≤ n - 1 ∧
       ∀ x, lagrangeInterp pts f x = p.eval x := by
   sorry
@@ -88,7 +94,7 @@ theorem lagrangeInterp_degree (pts : InterpolationPoints n) (f : ℝ → ℝ) :
 
 /-- The Lebesgue function λ_n(x) = Σ |p_i^n(x)|. -/
 noncomputable def lebesgueFunction (pts : InterpolationPoints n) (x : ℝ) : ℝ :=
-  ∑ i : Fin n, |((lagrangeBasis pts i).eval x)|
+  ∑ i : Fin n, |(lagrangeBasis pts i).eval x|
 
 /-- λ_n(x) ≥ 1 for all x ∈ [-1, 1]. -/
 theorem lebesgueFunction_ge_one (pts : InterpolationPoints n) (x : ℝ)
@@ -106,10 +112,13 @@ This shows Lebesgue constant controls interpolation quality.
 
 /- ## Part IV: Bernstein's Theorem -/
 
+/-- limsup λ_n(x) = ∞ means: for every M, infinitely many n have λ_n(x) ≥ M. -/
+def LebesgueUnbounded (seq : PointSequence) (x : ℝ) : Prop :=
+  ∀ M : ℝ, ∃ᶠ m in atTop, lebesgueFunction (seq m) x ≥ M
+
 /-- Bernstein (1931): For any point sequence, ∃ x₀ where limsup λ_n(x₀) = ∞. -/
 theorem bernstein (seq : PointSequence) :
-    ∃ x₀ ∈ Set.Icc (-1 : ℝ) 1,
-      Filter.limsup (fun n => lebesgueFunction (seq n) x₀) Filter.atTop = ⊤ := by
+    ∃ x₀ ∈ Set.Icc (-1 : ℝ) 1, LebesgueUnbounded seq x₀ := by
   sorry
 
 /-- The Lebesgue constant grows: Λ_n ≥ (2/π) log n + O(1). -/
@@ -121,44 +130,50 @@ theorem lebesgueConstant_growth (pts : InterpolationPoints n) (hn : n ≥ 2) :
 
 /- ## Part V: Erdős-Vértesi Theorem -/
 
+/-- |L^n f(x)| → ∞ means: for every M, infinitely many n have |L^n f(x)| ≥ M. -/
+def InterpUnbounded (seq : PointSequence) (f : Set.Icc (-1 : ℝ) 1 → ℝ) (x : ℝ) : Prop :=
+  ∀ M : ℝ, ∃ᶠ m in atTop, |lagrangeInterp (seq m) f x| ≥ M
+
 /-- Erdős-Vértesi (1980): For any points, ∃ continuous f where |L^n f(x)| → ∞ a.e. -/
 theorem erdos_vertesi (seq : PointSequence) :
     ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
       ∀ᵐ x ∂volume.restrict (Set.Icc (-1 : ℝ) 1),
-        Filter.limsup (fun n => |lagrangeInterp (seq n) f x|) Filter.atTop = ⊤ := by
+        InterpUnbounded seq f x := by
   sorry
 
 -- Divergence is generic: Most continuous functions diverge a.e. (Baire category argument).
 
 /- ## Part VI: Question 1 -/
 
-/-- Question 1: Can λ_n(x) → ∞ yet L^n f(x) → f(x) for some x? -/
+/-- Question 1: Can limsup λ_n(x) = ∞ yet L^n f(x) → f(x) for some x? -/
 def Question1 : Prop :=
   ∃ seq : PointSequence, ∀ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
     ∃ x ∈ Set.Icc (-1 : ℝ) 1,
-      Filter.limsup (fun n => lebesgueFunction (seq n) x) Filter.atTop = ⊤ ∧
-      Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩))
+      LebesgueUnbounded seq x ∧
+      Tendsto (fun m => lagrangeInterp (seq m) f x) atTop (nhds (f ⟨x, by sorry⟩))
 
 /-- Question 1 is OPEN. -/
 axiom question1_open : Question1
 
 /- ## Part VII: Question 2 -/
 
-/-- Question 2: Can λ_n(x) → ∞ for ALL x, yet still have some convergence? -/
+/-- Question 2: Can limsup λ_n(x) = ∞ for ALL x, yet still have some convergence? -/
 def Question2 : Prop :=
   ∃ seq : PointSequence,
-    (∀ x ∈ Set.Icc (-1 : ℝ) 1,
-      Filter.limsup (fun n => lebesgueFunction (seq n) x) Filter.atTop = ⊤) ∧
+    (∀ x ∈ Set.Icc (-1 : ℝ) 1, LebesgueUnbounded seq x) ∧
     (∀ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
       ∃ x ∈ Set.Icc (-1 : ℝ) 1,
-        Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩)))
+        Tendsto (fun m => lagrangeInterp (seq m) f x) atTop (nhds (f ⟨x, by sorry⟩)))
 
 /-- Question 2 is OPEN. -/
 axiom question2_open : Question2
 
 /-- Question 2 implies Question 1. -/
 theorem q2_implies_q1 (h : Question2) : Question1 := by
-  sorry
+  obtain ⟨seq, hdiv, hconv⟩ := h
+  exact ⟨seq, fun f => by
+    obtain ⟨x, hx, htend⟩ := hconv f
+    exact ⟨x, hx, hdiv x hx, htend⟩⟩
 
 /- ## Part VIII: Special Point Sequences -/
 
@@ -194,7 +209,7 @@ theorem equidistant_diverges (n : ℕ) (hn : n ≥ 2) :
 theorem faber :
     ∀ seq : PointSequence, ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
       ¬∃ x ∈ Set.Icc (-1 : ℝ) 1,
-        Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩)) := by
+        Tendsto (fun m => lagrangeInterp (seq m) f x) atTop (nhds (f ⟨x, by sorry⟩)) := by
   sorry
 
 -- Pointwise convergence is more delicate than uniform (can succeed where uniform fails).
@@ -204,16 +219,16 @@ theorem faber :
 /-- For typical f, divergence occurs on a set of positive measure. -/
 theorem positive_measure_divergence (seq : PointSequence) :
     ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
-      volume {x ∈ Set.Icc (-1 : ℝ) 1 |
-        Filter.limsup (fun n => |lagrangeInterp (seq n) f x|) Filter.atTop = ⊤} > 0 := by
+      volume {x ∈ Set.Icc (-1 : ℝ) 1 | InterpUnbounded seq f x} > 0 := by
   sorry
 
 /-- Convergence set can have full measure for specific f. -/
 theorem full_measure_convergence :
     ∃ seq : PointSequence, ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
       volume {x ∈ Set.Icc (-1 : ℝ) 1 |
-        Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩))} =
-          volume (Set.Icc (-1 : ℝ) 1) := by
+        Tendsto (fun m => lagrangeInterp (seq m) f x) atTop
+          (nhds (f ⟨x, by sorry⟩))} =
+            volume (Set.Icc (-1 : ℝ) 1) := by
   sorry
 
 /- ## Part XII: The Main Conjecture -/
@@ -228,11 +243,11 @@ axiom main_conjecture_open : MainConjecture
 /-- If Question 2 fails, understanding why would resolve Question 1. -/
 theorem q2_fails_implies (h : ¬Question2) :
     ∀ seq : PointSequence,
-      (∀ x ∈ Set.Icc (-1 : ℝ) 1,
-        Filter.limsup (fun n => lebesgueFunction (seq n) x) Filter.atTop = ⊤) →
+      (∀ x ∈ Set.Icc (-1 : ℝ) 1, LebesgueUnbounded seq x) →
       ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
         ∀ x ∈ Set.Icc (-1 : ℝ) 1,
-          ¬Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩)) := by
+          ¬Tendsto (fun m => lagrangeInterp (seq m) f x) atTop
+            (nhds (f ⟨x, by sorry⟩)) := by
   sorry
 
 end Erdos671

--- a/proofs/Proofs/Erdos671Problem.lean
+++ b/proofs/Proofs/Erdos671Problem.lean
@@ -88,7 +88,29 @@ theorem lagrangeInterp_degree (pts : InterpolationPoints n)
     (f : Set.Icc (-1 : ℝ) 1 → ℝ) :
     ∃ p : Polynomial ℝ, p.natDegree ≤ n - 1 ∧
       ∀ x, lagrangeInterp pts f x = p.eval x := by
-  sorry
+  use ∑ i : Fin n, Polynomial.C (f ⟨pts.points i, pts.in_interval i⟩) * lagrangeBasis pts i
+  refine ⟨?_, fun x => ?_⟩
+  · apply le_trans (Polynomial.natDegree_sum_le _ _)
+    apply Finset.sup_le; intro i _
+    apply le_trans Polynomial.natDegree_mul_le
+    simp only [Polynomial.natDegree_C, zero_add]
+    -- lagrangeBasis pts i is a product of (n-1) degree-1 polynomials
+    unfold lagrangeBasis
+    apply le_trans (Polynomial.natDegree_prod_le _ _)
+    have hcard : (Finset.univ.filter (fun k => k ≠ i)).card = n - 1 := by
+      rw [show Finset.univ.filter (fun k : Fin n => k ≠ i) = Finset.univ.erase i from
+        by ext; simp [Finset.mem_filter, Finset.mem_erase]]
+      simp [Finset.card_erase_of_mem]
+    calc ∑ j ∈ Finset.univ.filter (fun k => k ≠ i),
+          (Polynomial.C (1 / (pts.points i - pts.points j)) *
+           (Polynomial.X - Polynomial.C (pts.points j)) : Polynomial ℝ).natDegree
+        ≤ ∑ j ∈ Finset.univ.filter (fun k => k ≠ i), 1 := by
+          apply Finset.sum_le_sum; intro j _
+          apply le_trans Polynomial.natDegree_mul_le
+          simp [Polynomial.natDegree_C, Polynomial.natDegree_X_sub_C]
+      _ = (Finset.univ.filter (fun k => k ≠ i)).card := by simp
+      _ = n - 1 := hcard
+  · simp only [lagrangeInterp, Polynomial.eval_sum, Polynomial.eval_mul, Polynomial.eval_C]
 
 /- ## Part III: The Lebesgue Function -/
 
@@ -185,9 +207,29 @@ noncomputable def chebyshevNodes (n : ℕ) : InterpolationPoints n where
 
 /-- Equidistant nodes: x_k = -1 + 2k/(n-1). -/
 noncomputable def equidistantNodes (n : ℕ) (hn : n ≥ 2) : InterpolationPoints n where
-  points := fun k => -1 + 2 * k.val / (n - 1)
-  in_interval := by sorry
-  distinct := by sorry
+  points := fun k => -1 + 2 * (k.val : ℝ) / ((n : ℝ) - 1)
+  in_interval := by
+    intro k
+    have hn_cast : (1 : ℝ) < (n : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le one_lt_two hn
+    have hn1_pos : (0 : ℝ) < (n : ℝ) - 1 := by linarith
+    simp only [Set.mem_Icc]
+    constructor
+    · have : (0 : ℝ) ≤ 2 * (k.val : ℝ) / ((n : ℝ) - 1) :=
+        div_nonneg (by positivity) (le_of_lt hn1_pos)
+      linarith
+    · have hklt : (k.val : ℝ) < (n : ℝ) := by exact_mod_cast k.isLt
+      have : 2 * (k.val : ℝ) / ((n : ℝ) - 1) ≤ 2 := by
+        rw [div_le_iff hn1_pos]; linarith
+      linarith
+  distinct := by
+    intro k j hkj heq
+    apply hkj
+    have hn_cast : (1 : ℝ) < (n : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le one_lt_two hn
+    have hn1_ne : (n : ℝ) - 1 ≠ 0 := by linarith
+    have h1 : 2 * (k.val : ℝ) / ((n : ℝ) - 1) = 2 * (j.val : ℝ) / ((n : ℝ) - 1) := by
+      linarith
+    have h2 : (k.val : ℝ) = j.val := by field_simp [hn1_ne] at h1; linarith
+    exact Fin.ext (by exact_mod_cast h2)
 
 /-- Equidistant nodes have exponentially growing Lebesgue constant. -/
 theorem equidistant_diverges (n : ℕ) (hn : n ≥ 2) :

--- a/proofs/Proofs/Erdos671Problem.lean
+++ b/proofs/Proofs/Erdos671Problem.lean
@@ -118,10 +118,65 @@ theorem lagrangeInterp_degree (pts : InterpolationPoints n)
 noncomputable def lebesgueFunction (pts : InterpolationPoints n) (x : ℝ) : ℝ :=
   ∑ i : Fin n, |(lagrangeBasis pts i).eval x|
 
-/-- λ_n(x) ≥ 1 for all x ∈ [-1, 1]. -/
-theorem lebesgueFunction_ge_one (pts : InterpolationPoints n) (x : ℝ)
-    (hx : x ∈ Set.Icc (-1 : ℝ) 1) : lebesgueFunction pts x ≥ 1 := by
-  sorry
+/-- Lagrange basis forms a partition of unity: Σ p_i(x) = 1 for all x. -/
+private theorem lagrangeBasis_sum_one {n : ℕ} (pts : InterpolationPoints n)
+    (hn : 0 < n) (x : ℝ) :
+    ∑ i : Fin n, (lagrangeBasis pts i).eval x = 1 := by
+  set Q := ∑ i : Fin n, lagrangeBasis pts i - Polynomial.C 1 with hQ_def
+  have hQroots : ∀ i : Fin n, Q.eval (pts.points i) = 0 := fun i => by
+    simp only [hQ_def, Polynomial.eval_sub, Polynomial.eval_finset_sum, Polynomial.eval_C]
+    rw [Finset.sum_eq_single_of_mem i (Finset.mem_univ _)]
+    · rw [lagrangeBasis_self]; ring
+    · intro j _ hji; exact lagrangeBasis_other pts j i hji
+  have hQdeg : Q.natDegree ≤ n - 1 := by
+    apply le_trans (Polynomial.natDegree_sub_le _ _)
+    simp only [Polynomial.natDegree_C, max_zero_right]
+    apply le_trans (Polynomial.natDegree_sum_le _ _)
+    apply Finset.sup_le; intro i _
+    unfold lagrangeBasis
+    apply le_trans (Polynomial.natDegree_prod_le _ _)
+    have hcard : (Finset.univ.filter (fun k => k ≠ i)).card = n - 1 := by
+      rw [show Finset.univ.filter (fun k : Fin n => k ≠ i) = Finset.univ.erase i from
+        by ext; simp [Finset.mem_filter, Finset.mem_erase]]
+      simp [Finset.card_erase_of_mem]
+    calc ∑ j ∈ Finset.univ.filter (fun k => k ≠ i),
+            (Polynomial.C (1 / (pts.points i - pts.points j)) *
+             (Polynomial.X - Polynomial.C (pts.points j)) : Polynomial ℝ).natDegree
+        ≤ ∑ j ∈ Finset.univ.filter (fun k => k ≠ i), 1 := by
+            apply Finset.sum_le_sum; intro j _
+            apply le_trans Polynomial.natDegree_mul_le
+            simp [Polynomial.natDegree_C, Polynomial.natDegree_X_sub_C]
+      _ = (Finset.univ.filter (fun k => k ≠ i)).card := by simp
+      _ = n - 1 := hcard
+  have hQ_zero : Q = 0 := by
+    by_contra hne
+    have hmem : ∀ i : Fin n, pts.points i ∈ Q.roots :=
+      fun i => (Polynomial.mem_roots hne).mpr (hQroots i)
+    have himage_card : (Finset.image (fun i : Fin n => pts.points i) Finset.univ).card = n := by
+      rw [Finset.card_image_of_injOn]
+      · simp
+      · intro i _ j _ h; by_contra hij; exact absurd h (pts.distinct i j hij)
+    have hsub : Finset.image (fun i : Fin n => pts.points i) Finset.univ ⊆ Q.roots.toFinset := by
+      intro a ha
+      rw [Finset.mem_image] at ha; obtain ⟨i, _, rfl⟩ := ha
+      rw [Multiset.mem_toFinset]; exact hmem i
+    have hge : n ≤ Q.natDegree :=
+      calc n = (Finset.image (fun i : Fin n => pts.points i) Finset.univ).card := himage_card.symm
+        _ ≤ Q.roots.toFinset.card := Finset.card_le_card hsub
+        _ ≤ Multiset.card Q.roots := Multiset.toFinset_card_le_card _
+        _ ≤ Q.natDegree := Polynomial.card_roots_le_degree Q
+    omega
+  have heval : Q.eval x = 0 := by rw [hQ_zero]; simp
+  simp only [hQ_def, Polynomial.eval_sub, Polynomial.eval_finset_sum, Polynomial.eval_C] at heval
+  linarith
+
+/-- λ_n(x) ≥ 1 for all x (requires n ≥ 1 nodes). -/
+theorem lebesgueFunction_ge_one (pts : InterpolationPoints n) (hn : 0 < n) (x : ℝ) :
+    lebesgueFunction pts x ≥ 1 := by
+  unfold lebesgueFunction
+  calc (1 : ℝ) = |∑ i : Fin n, (lagrangeBasis pts i).eval x| := by
+          rw [lagrangeBasis_sum_one pts hn]; simp
+    _ ≤ ∑ i : Fin n, |(lagrangeBasis pts i).eval x| := Finset.abs_sum_le_sum_abs
 
 /-- The Lebesgue constant Λ_n = max_{x ∈ [-1,1]} λ_n(x). -/
 noncomputable def lebesgueConstant (pts : InterpolationPoints n) : ℝ :=
@@ -170,9 +225,9 @@ theorem erdos_vertesi (seq : PointSequence) :
 /-- Question 1: Can limsup λ_n(x) = ∞ yet L^n f(x) → f(x) for some x? -/
 def Question1 : Prop :=
   ∃ seq : PointSequence, ∀ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
-    ∃ x ∈ Set.Icc (-1 : ℝ) 1,
-      LebesgueUnbounded seq x ∧
-      Tendsto (fun m => lagrangeInterp (seq m) f x) atTop (nhds (f ⟨x, by sorry⟩))
+    ∃ x : Set.Icc (-1 : ℝ) 1,
+      LebesgueUnbounded seq x.val ∧
+      Tendsto (fun m => lagrangeInterp (seq m) f x.val) atTop (nhds (f x))
 
 /-- Question 1 is OPEN. -/
 axiom question1_open : Question1
@@ -184,8 +239,8 @@ def Question2 : Prop :=
   ∃ seq : PointSequence,
     (∀ x ∈ Set.Icc (-1 : ℝ) 1, LebesgueUnbounded seq x) ∧
     (∀ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
-      ∃ x ∈ Set.Icc (-1 : ℝ) 1,
-        Tendsto (fun m => lagrangeInterp (seq m) f x) atTop (nhds (f ⟨x, by sorry⟩)))
+      ∃ x : Set.Icc (-1 : ℝ) 1,
+        Tendsto (fun m => lagrangeInterp (seq m) f x.val) atTop (nhds (f x)))
 
 /-- Question 2 is OPEN. -/
 axiom question2_open : Question2
@@ -194,8 +249,8 @@ axiom question2_open : Question2
 theorem q2_implies_q1 (h : Question2) : Question1 := by
   obtain ⟨seq, hdiv, hconv⟩ := h
   exact ⟨seq, fun f => by
-    obtain ⟨x, hx, htend⟩ := hconv f
-    exact ⟨x, hx, hdiv x hx, htend⟩⟩
+    obtain ⟨x, htend⟩ := hconv f
+    exact ⟨x, hdiv x.val x.prop, htend⟩⟩
 
 /- ## Part VIII: Special Point Sequences -/
 
@@ -274,8 +329,8 @@ theorem equidistant_diverges (n : ℕ) (hn : n ≥ 2) :
 /-- Faber's theorem: No point sequence gives uniform convergence for all C⁰. -/
 theorem faber :
     ∀ seq : PointSequence, ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
-      ¬∃ x ∈ Set.Icc (-1 : ℝ) 1,
-        Tendsto (fun m => lagrangeInterp (seq m) f x) atTop (nhds (f ⟨x, by sorry⟩)) := by
+      ¬∃ x : Set.Icc (-1 : ℝ) 1,
+        Tendsto (fun m => lagrangeInterp (seq m) f x.val) atTop (nhds (f x)) := by
   sorry
 
 -- Pointwise convergence is more delicate than uniform (can succeed where uniform fails).
@@ -291,9 +346,8 @@ theorem positive_measure_divergence (seq : PointSequence) :
 /-- Convergence set can have full measure for specific f. -/
 theorem full_measure_convergence :
     ∃ seq : PointSequence, ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
-      volume {x ∈ Set.Icc (-1 : ℝ) 1 |
-        Tendsto (fun m => lagrangeInterp (seq m) f x) atTop
-          (nhds (f ⟨x, by sorry⟩))} =
+      volume (Subtype.val '' {x : Set.Icc (-1 : ℝ) 1 |
+        Tendsto (fun m => lagrangeInterp (seq m) f x.val) atTop (nhds (f x))}) =
             volume (Set.Icc (-1 : ℝ) 1) := by
   sorry
 
@@ -311,9 +365,8 @@ theorem q2_fails_implies (h : ¬Question2) :
     ∀ seq : PointSequence,
       (∀ x ∈ Set.Icc (-1 : ℝ) 1, LebesgueUnbounded seq x) →
       ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
-        ∀ x ∈ Set.Icc (-1 : ℝ) 1,
-          ¬Tendsto (fun m => lagrangeInterp (seq m) f x) atTop
-            (nhds (f ⟨x, by sorry⟩)) := by
+        ∀ x : Set.Icc (-1 : ℝ) 1,
+          ¬Tendsto (fun m => lagrangeInterp (seq m) f x.val) atTop (nhds (f x)) := by
   intro seq hdiv
   by_contra hconv
   push_neg at hconv

--- a/proofs/Proofs/Erdos671Problem.lean
+++ b/proofs/Proofs/Erdos671Problem.lean
@@ -203,7 +203,31 @@ theorem q2_implies_q1 (h : Question2) : Question1 := by
 noncomputable def chebyshevNodes (n : ℕ) : InterpolationPoints n where
   points := fun k => Real.cos ((2 * k.val + 1) * Real.pi / (2 * n))
   in_interval := fun k => Real.cos_mem_Icc _
-  distinct := by sorry
+  distinct := by
+    intro k j hkj heq
+    apply hkj
+    have hn_pos : (0 : ℝ) < 2 * n := by
+      have : 0 < n := k.pos; positivity
+    have hk_in : (2 * (k.val : ℝ) + 1) * Real.pi / (2 * n) ∈ Set.Icc 0 Real.pi := by
+      constructor
+      · positivity
+      · rw [div_le_one (by positivity)]
+        have : (k.val : ℝ) < n := by exact_mod_cast k.isLt
+        nlinarith [Real.pi_pos]
+    have hj_in : (2 * (j.val : ℝ) + 1) * Real.pi / (2 * n) ∈ Set.Icc 0 Real.pi := by
+      constructor
+      · positivity
+      · rw [div_le_one (by positivity)]
+        have : (j.val : ℝ) < n := by exact_mod_cast j.isLt
+        nlinarith [Real.pi_pos]
+    have h_angle : (2 * (k.val : ℝ) + 1) * Real.pi / (2 * n) =
+                  (2 * (j.val : ℝ) + 1) * Real.pi / (2 * n) :=
+      Real.strictAntiOn_cos.injOn hk_in hj_in heq
+    have h_val : (k.val : ℝ) = j.val := by
+      have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+      field_simp [hpi, hn_pos.ne'] at h_angle
+      linarith
+    exact Fin.ext (by exact_mod_cast h_val)
 
 /-- Equidistant nodes: x_k = -1 + 2k/(n-1). -/
 noncomputable def equidistantNodes (n : ℕ) (hn : n ≥ 2) : InterpolationPoints n where

--- a/proofs/Proofs/Erdos671Problem.lean
+++ b/proofs/Proofs/Erdos671Problem.lean
@@ -314,7 +314,10 @@ theorem q2_fails_implies (h : ¬Question2) :
         ∀ x ∈ Set.Icc (-1 : ℝ) 1,
           ¬Tendsto (fun m => lagrangeInterp (seq m) f x) atTop
             (nhds (f ⟨x, by sorry⟩)) := by
-  sorry
+  intro seq hdiv
+  by_contra hconv
+  push_neg at hconv
+  exact h ⟨seq, hdiv, hconv⟩
 
 end Erdos671
 

--- a/research/problems/erdos-671/knowledge.md
+++ b/research/problems/erdos-671/knowledge.md
@@ -15,6 +15,34 @@ Can Lagrange interpolation converge pointwise at a point x where the Lebesgue fu
 **Known**: Bernstein (1931): ∃ x₀ with limsup λ_n(x₀) = ∞ for any sequence.
 **Known**: Erdős-Vértesi (1980): ∃ continuous f with |L^n f(x)| → ∞ a.e. for any sequence.
 
+## Session 2026-05-04 (Session 2) — Compilation fixes + q2_implies_q1
+
+**Mode**: REVISIT (continued from session 1)
+**Outcome**: progress (1 more sorry eliminated, full compilation fix)
+
+### What I Did
+
+- Resolved rebase conflicts in meta.json (kept `"sorries": 19` from HEAD across 2 conflict sites)
+- Proved `q2_implies_q1`: Q2 ⟹ Q1 via `obtain ⟨seq, hdiv, hconv⟩ := h; exact ⟨seq, fun f => ...⟩`
+- Fixed: `C`/`X` ambiguity — removed `Polynomial` from `open`; use `Polynomial.C`/`Polynomial.X` with `(... : Polynomial ℝ)` annotation
+- Fixed: `Filter.limsup = ⊤` — introduced `LebesgueUnbounded`/`InterpUnbounded` helper defs using `∀ M : ℝ, ∃ᶠ m in atTop, ... ≥ M`
+- Updated meta.json: 18 sorries, 274 lines
+- Created PR #15458 (fixing broken code merged by PR #15444)
+- Docker build running (container lean-build-13630)
+
+### Key Findings
+
+- `q2_implies_q1` trivial: Q2 requires ∀ x divergence + ∃ x convergence; Q1 only needs ∃ x divergence + ∃ x convergence. The same sequence and same x witness both.
+- With `open Polynomial ContinuousMap`, bare `C` is ambiguous between `Polynomial.C` and `ContinuousMap.C`. Fix: remove `Polynomial` from open, use qualified names.
+- `∃ᶠ m in atTop, f m ≥ M` is the correct "frequently ≥ M" formulation capturing limsup = +∞ for ℝ-valued functions.
+
+### Files Modified
+
+- `proofs/Proofs/Erdos671Problem.lean` — q2_implies_q1 proved, compilation fixes
+- `src/data/proofs/erdos-671/meta.json` — 18 sorries, 274 lines, updated assumptions
+
+---
+
 ## Session 2026-05-04 (Session 1) — Initial formalization
 
 **Mode**: FRESH (new gallery entry)
@@ -45,10 +73,11 @@ Can Lagrange interpolation converge pointwise at a point x where the Lebesgue fu
 - `proofs/Proofs/Erdos671Problem.lean` (main file)
 - `src/data/proofs/erdos-671/meta.json` (sorries 23→19)
 
-### Remaining Sorries (19)
+### Remaining Sorries (18)
 
 - `lagrangeBasis_self`, `lagrangeBasis_other`, `lagrangeInterp_at_node`: **PROVED**
 - `chebyshevNodes.in_interval`: **PROVED**
+- `q2_implies_q1`: **PROVED**
 - `lagrangeInterp_degree`: degree bound for Lagrange interpolant (HARD)
 - `lebesgueFunction_ge_one`: λ_n ≥ 1 at nodes (HARD — needs partition of unity argument)
 - `bernstein`: Bernstein's 1931 theorem (HARD — needs Baire category or explicit construction)

--- a/research/problems/erdos-671/knowledge.md
+++ b/research/problems/erdos-671/knowledge.md
@@ -1,0 +1,71 @@
+# Erdős Problem #671 — Lagrange Interpolation Convergence
+
+**Status**: `in-progress` (ACT phase)
+**Prize**: $250 open problem
+**Source**: https://erdosproblems.com/671
+
+## Problem Summary
+
+Can Lagrange interpolation converge pointwise at a point x where the Lebesgue function
+λ_n(x) = Σ|p_i^n(x)| diverges (limsup → ∞)?
+
+- **Question 1**: ∃ point sequence where for every continuous f, ∃ x with limsup λ_n(x) = ∞ yet L^n f(x) → f(x)?
+- **Question 2**: Same but limsup λ_n(x) = ∞ for ALL x ∈ [-1,1]?
+
+**Known**: Bernstein (1931): ∃ x₀ with limsup λ_n(x₀) = ∞ for any sequence.
+**Known**: Erdős-Vértesi (1980): ∃ continuous f with |L^n f(x)| → ∞ a.e. for any sequence.
+
+## Session 2026-05-04 (Session 1) — Initial formalization
+
+**Mode**: FRESH (new gallery entry)
+**Outcome**: progress (4 sorries eliminated, compilation fixes)
+
+### What I Did
+
+- Located `proofs/Proofs/Erdos671Problem.lean` with 23 real sorries
+- Fixed bad `import` statements (specific module paths → `import Mathlib`)
+- Proved `lagrangeBasis_self`: `∏ j ≠ i, (1/(a_i-a_j))*(a_i-a_j) = 1` via `Finset.prod_eq_one` + `field_simp`
+- Proved `lagrangeBasis_other`: factor `a_j - a_j = 0` gives product = 0 via `Finset.prod_eq_zero`
+- Proved `lagrangeInterp_at_node`: isolate the i-th term via `Finset.sum_eq_single_of_mem`
+- Proved `chebyshevNodes.in_interval`: `Real.cos_mem_Icc _` (one-liner)
+- Fixed syntax `∏ j in s` → `∏ j ∈ s` (deprecated in current Mathlib)
+- Fixed `Filter.limsup ... = ⊤` type error: ℝ has no Top; use EReal cast `(f n : EReal)`
+- Fixed `lagrangeInterp f` type mismatch: changed `f : ℝ → ℝ` to `f : Set.Icc (-1:ℝ) 1 → ℝ` so `C([-1,1], ℝ)` coerces automatically
+- PR #15444 created and updated
+
+### Key Findings
+
+- `∏ j in s, ...` syntax deprecated; use `∏ j ∈ s, ...`
+- `Filter.limsup (f : ℕ → ℝ) atTop : ℝ` but `⊤ : ℝ` doesn't typecheck (ℝ has no Top); use `(· : EReal)` cast
+- `C(Set.Icc (-1:ℝ) 1, ℝ)` coerces to `Set.Icc (-1:ℝ) 1 → ℝ` via DFunLike automatically
+- Lagrange basis proof strategy: prod = 1 via each factor = 1 (distinctness gives non-zero denominator); prod = 0 via finding one zero factor
+
+### Files Modified
+
+- `proofs/Proofs/Erdos671Problem.lean` (main file)
+- `src/data/proofs/erdos-671/meta.json` (sorries 23→19)
+
+### Remaining Sorries (19)
+
+- `lagrangeBasis_self`, `lagrangeBasis_other`, `lagrangeInterp_at_node`: **PROVED**
+- `chebyshevNodes.in_interval`: **PROVED**
+- `lagrangeInterp_degree`: degree bound for Lagrange interpolant (HARD)
+- `lebesgueFunction_ge_one`: λ_n ≥ 1 at nodes (HARD — needs partition of unity argument)
+- `bernstein`: Bernstein's 1931 theorem (HARD — needs Baire category or explicit construction)
+- `lebesgueConstant_growth`: Λ_n ≥ (2/π)ln(n) - 1 (HARD)
+- `erdos_vertesi`: Erdős-Vértesi 1980 theorem (HARD)
+- `question1_open` / `question2_open`: axioms (OPEN)
+- `chebyshevNodes.distinct`: injectivity of cos on specific points (HARD)
+- `equidistantNodes` (2 sorries): arithmetic bounds (MODERATE)
+- `equidistant_diverges`: exponential Lebesgue constant for equidistant nodes (HARD)
+- `faber`: Faber's theorem (HARD)
+- `positive_measure_divergence`, `full_measure_convergence`: measure-theoretic (HARD)
+- `main_conjecture_open`: axiom (OPEN)
+- `q2_implies_q1`, `q2_fails_implies`: logical implications (MODERATE — should follow from defs)
+
+### Next Steps
+
+1. Try `q2_implies_q1`: should follow directly from definitions (Q2 is strictly stronger than Q1)
+2. Try `lebesgueFunction_ge_one`: use partition of unity; Σ p_i(x) = 1 (interpolating constants) so |Σ p_i(x)| ≤ Σ|p_i(x)|
+3. Try `lagrangeInterp_degree`: use that lagrangeBasis has degree ≤ n-1 and the sum has ≤ n terms
+4. Submit `bernstein`, `lebesgueConstant_growth`, `erdos_vertesi` to Aristotle as HARD sorries

--- a/research/problems/erdos-671/knowledge.md
+++ b/research/problems/erdos-671/knowledge.md
@@ -15,6 +15,59 @@ Can Lagrange interpolation converge pointwise at a point x where the Lebesgue fu
 **Known**: Bernstein (1931): ∃ x₀ with limsup λ_n(x₀) = ∞ for any sequence.
 **Known**: Erdős-Vértesi (1980): ∃ continuous f with |L^n f(x)| → ∞ a.e. for any sequence.
 
+## Session 2026-05-04 (Session 3) — Partition of unity + type refactoring
+
+**Mode**: REVISIT (continued from session 2)
+**Outcome**: progress (6 sorries eliminated: 13 → 7)
+
+### What I Did
+
+- Proved `lagrangeInterp_degree`: interpolant degree ≤ n-1 via `Polynomial.natDegree_prod_le`
+- Proved `equidistantNodes.in_interval` and `.distinct`: arithmetic with `(n:ℝ) - 1` coercions
+- Proved `chebyshevNodes.distinct`: `Real.strictAntiOn_cos.injOn` on [0,π] via angle bounds
+- Proved `lagrangeBasis_sum_one` (partition of unity): Σp_i(x) = 1 via polynomial root counting
+  - Key: Q = Σp_i - 1 has n distinct roots but degree ≤ n-1, so Q = 0
+  - Uses: `Polynomial.card_roots_le_degree`, `Multiset.toFinset_card_le_card`, `Finset.card_image_of_injOn`
+- Proved `lebesgueFunction_ge_one`: λ_n(x) ≥ 1 via triangle inequality + partition of unity
+- Proved `q2_fails_implies`: ¬Q2 → explicit divergence via `by_contra; push_neg`
+- Eliminated 5 type-sorry instances by refactoring `∃ x ∈ S` to `∃ x : Set.Icc S` (subtype)
+  - Q1, Q2, faber, full_measure_convergence types now sorry-free
+  - q2_fails_implies type+proof now fully sorry-free
+- Updated meta.json: 7 sorries, 396 lines, axiomCount=3
+- PR #15458 updated
+
+### Key Findings
+
+- Partition of unity: Σp_i(x) = 1 requires polynomial root counting (not just evaluation at nodes)
+- `Polynomial.card_roots_le_degree` works for ALL polynomials (includes Q=0 corner case)
+- `∃ x ∈ S, P x` notation doesn't give `hx : x ∈ S` inside `P x` — must use subtype `∃ x : S, P x.val`
+- `lebesgueFunction_ge_one` requires `hn : 0 < n` (false for n=0: empty sum = 0 < 1)
+- Build 2 verified (equidistantNodes + lagrangeInterp_degree): compiled clean
+- Build 3 in progress (all new proofs including partition of unity + subtype refactoring)
+
+### Files Modified
+
+- `proofs/Proofs/Erdos671Problem.lean` — 6 sorries eliminated
+- `src/data/proofs/erdos-671/meta.json` — 7 sorries, 396 lines
+
+### Remaining Sorries (7 — all HARD classical results)
+
+- `bernstein`: Bernstein 1931 — requires Baire category or explicit construction
+- `lebesgueConstant_growth`: Λ_n ≥ (2/π)ln n — integration argument on extremal polynomial
+- `erdos_vertesi`: Erdős-Vértesi 1980 — hard analysis (a.e. divergence)
+- `equidistant_diverges`: exponential Lebesgue constant — explicit product bounds
+- `faber`: Faber 1914 — uniform boundedness / Baire category
+- `positive_measure_divergence`, `full_measure_convergence`: measure theory
+
+### Next Steps
+
+1. Check Build 3 result for partition-of-unity proof
+2. Consider `lebesgueConstant_growth` — bound via extremal polynomial construction
+3. Consider `equidistant_diverges` — explicit product estimate for equidistant nodes
+4. Submit `bernstein`, `erdos_vertesi`, `faber` to Aristotle (HARD classical results)
+
+---
+
 ## Session 2026-05-04 (Session 2) — Compilation fixes + q2_implies_q1
 
 **Mode**: REVISIT (continued from session 1)

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 19,
+    "sorries": 18,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -60,11 +60,12 @@
       "chebyshevNodes definition: optimal point sequence",
       "equidistantNodes definition: bad point sequence",
       "faber theorem: no uniform convergence for all C^0",
-      "MainConjecture definition: Q1 iff Q2?"
+      "MainConjecture definition: Q1 iff Q2?",
+      "q2_implies_q1 theorem: Question2 implies Question1 (proved)"
     ],
     "axiomCount": 3,
-    "lineCount": 259,
-    "assumptions": "3 axiom(s) and 19 sorry(s). See the Lean source for details.",
+    "lineCount": 274,
+    "assumptions": "3 axiom(s) and 18 sorry(s). See the Lean source for details.",
     "theoremCount": 14
   },
   "overview": {
@@ -145,11 +146,11 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 259,
+    "lineCount": 274,
     "axiomCount": 3,
     "theoremCount": 14,
     "definitionCount": 10,
-    "sorries": 19,
+    "sorries": 18,
     "path": "Proofs/Erdos671Problem.lean"
   },
   "crossReferences": [
@@ -169,5 +170,5 @@
       "description": "Related Erd\u0151s problem sharing themes: approximation-theory, interpolation, open"
     }
   ],
-  "sorries": 19
+  "sorries": 18
 }

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 15,
+    "sorries": 7,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -51,21 +51,25 @@
       "InterpolationPoints structure: n distinct points in [-1,1]",
       "lagrangeBasis definition: Lagrange basis polynomials p_i^n",
       "lagrangeInterp definition: interpolation operator L^n f",
+      "lagrangeBasis_sum_one (proved): partition of unity via root counting",
       "lebesgueFunction definition: lambda_n(x) = sum |p_i(x)|",
       "lebesgueConstant definition: Lambda_n = max lambda_n(x)",
+      "lebesgueFunction_ge_one (proved): lambda_n(x) >= 1 for n >= 1",
+      "lagrangeInterp_degree (proved): interpolant has degree <= n-1",
+      "chebyshevNodes.distinct (proved): cos strict anti-monotonicity",
+      "equidistantNodes.in_interval and distinct (proved): arithmetic bounds",
       "bernstein theorem: divergence at some point (sorry)",
       "erdos_vertesi theorem: a.e. divergence for some f (sorry)",
-      "Question1 definition: convergence despite local divergence",
-      "Question2 definition: convergence despite universal divergence",
-      "chebyshevNodes definition: optimal point sequence",
-      "equidistantNodes definition: bad point sequence",
-      "faber theorem: no uniform convergence for all C^0",
-      "MainConjecture definition: Q1 iff Q2?",
-      "q2_implies_q1 theorem: Question2 implies Question1 (proved)"
+      "Question1 definition: convergence despite local divergence (subtype formulation)",
+      "Question2 definition: convergence despite universal divergence (subtype formulation)",
+      "q2_implies_q1 (proved): Question2 implies Question1",
+      "q2_fails_implies (proved): negation gives explicit divergence",
+      "faber theorem: no universal convergent sequence (sorry)",
+      "MainConjecture definition: Q1 iff Q2?"
     ],
     "axiomCount": 3,
-    "lineCount": 316,
-    "assumptions": "3 axiom(s) and 15 sorry(s). See the Lean source for details.",
+    "lineCount": 396,
+    "assumptions": "3 axiom(s) and 7 sorry(s). See the Lean source for details.",
     "theoremCount": 14
   },
   "overview": {
@@ -92,43 +96,43 @@
   "sections": [
     {
       "id": "lagrange-setup",
-      "title": "§I-II: Interpolation Points and Lagrange Basis",
+      "title": "\u00a7I-II: Interpolation Points and Lagrange Basis",
       "startLine": 34,
       "endLine": 75,
-      "summary": "Defines InterpolationPoints (n points in [-1,1], distinct), PointSequence, and the Lagrange basis polynomial lagrangeBasis. Proves lagrangeBasis_self (p_i(a_i)=1) and lagrangeBasis_other (p_i(a_j)=0 for i≠j). Defines lagrangeInterp as the weighted sum and proves it reproduces function values at nodes.",
+      "summary": "Defines InterpolationPoints (n points in [-1,1], distinct), PointSequence, and the Lagrange basis polynomial lagrangeBasis. Proves lagrangeBasis_self (p_i(a_i)=1) and lagrangeBasis_other (p_i(a_j)=0 for i\u2260j). Defines lagrangeInterp as the weighted sum and proves it reproduces function values at nodes.",
       "mathContext": "The Lagrange basis polynomial $p_i^n(x) = \\prod_{j \\neq i} \\frac{x - a_j^n}{a_i^n - a_j^n}$ has degree $n-1$ and satisfies $p_i^n(a_j^n) = \\delta_{ij}$ (Kronecker delta). The interpolation operator $L^n f(x) = \\sum_{i=1}^n f(a_i^n) p_i^n(x)$ is the unique degree-$(n-1)$ polynomial agreeing with $f$ at all $n$ nodes."
     },
     {
       "id": "lebesgue-function",
-      "title": "§III: The Lebesgue Function and Constant",
+      "title": "\u00a7III: The Lebesgue Function and Constant",
       "startLine": 77,
       "endLine": 96,
-      "summary": "Defines lebesgueFunction λ_n(x) = Σ|p_i^n(x)| and lebesgueConstant Λ_n = sup_x λ_n(x). Proves lebesgueFunction_ge_one (λ_n(x) ≥ 1 whenever x is a node). These measure the worst-case amplification of interpolation errors.",
+      "summary": "Defines lebesgueFunction \u03bb_n(x) = \u03a3|p_i^n(x)| and lebesgueConstant \u039b_n = sup_x \u03bb_n(x). Proves lebesgueFunction_ge_one (\u03bb_n(x) \u2265 1 whenever x is a node). These measure the worst-case amplification of interpolation errors.",
       "mathContext": "The Lebesgue constant $\\Lambda_n = \\sup_{x \\in [-1,1]} \\sum_{i=1}^n |p_i^n(x)|$ controls interpolation error: $\\|f - L^n f\\|_\\infty \\leq (1 + \\Lambda_n) \\inf_p \\|f - p\\|_\\infty$ over degree-$(n-1)$ polynomials $p$. Chebyshev nodes minimize $\\Lambda_n$, giving $\\Lambda_n \\sim \\frac{2}{\\pi} \\ln n$; equidistant nodes give $\\Lambda_n \\sim \\frac{2^n}{en \\ln n}$ (exponential growth)."
     },
     {
       "id": "bernstein-erdos-vertesi",
-      "title": "§IV-V: Bernstein's Theorem and Erdős–Vértesi",
+      "title": "\u00a7IV-V: Bernstein's Theorem and Erd\u0151s\u2013V\u00e9rtesi",
       "startLine": 97,
       "endLine": 122,
-      "summary": "Axiomatizes bernstein (1931): for ANY point sequence, there exists x₀ ∈ [-1,1] with limsup λ_n(x₀) = ∞. Axiomatizes erdos_vertesi (1980): for any sequence, there exists a continuous f such that limsup |L^n f(x)| = ∞ for almost every x ∈ [-1,1]. Also proves lebesgueConstant_growth: Λ_n ≥ (2/π)ln(n) - 2 for n ≥ 2.",
-      "mathContext": "Bernstein (1931) showed $\\Lambda_n \\to \\infty$ for ANY point sequence — no optimal nodes exist in the pointwise sense. Erdős and Vértesi (1980) strengthened this: divergence occurs for measure-1 set of $x$. The growth bound $\\Lambda_n \\geq \\frac{2}{\\pi} \\ln n - 2$ is universal; it holds with equality (up to $O(1)$) for Chebyshev nodes."
+      "summary": "Axiomatizes bernstein (1931): for ANY point sequence, there exists x\u2080 \u2208 [-1,1] with limsup \u03bb_n(x\u2080) = \u221e. Axiomatizes erdos_vertesi (1980): for any sequence, there exists a continuous f such that limsup |L^n f(x)| = \u221e for almost every x \u2208 [-1,1]. Also proves lebesgueConstant_growth: \u039b_n \u2265 (2/\u03c0)ln(n) - 2 for n \u2265 2.",
+      "mathContext": "Bernstein (1931) showed $\\Lambda_n \\to \\infty$ for ANY point sequence \u2014 no optimal nodes exist in the pointwise sense. Erd\u0151s and V\u00e9rtesi (1980) strengthened this: divergence occurs for measure-1 set of $x$. The growth bound $\\Lambda_n \\geq \\frac{2}{\\pi} \\ln n - 2$ is universal; it holds with equality (up to $O(1)$) for Chebyshev nodes."
     },
     {
       "id": "open-questions",
-      "title": "§VI-VII: Question 1 and Question 2",
+      "title": "\u00a7VI-VII: Question 1 and Question 2",
       "startLine": 123,
       "endLine": 155,
-      "summary": "States Question1 (does there exist a sequence where limsup λ_n(x) = ∞ yet L^n f(x) → f(x) for every continuous f at some x?) and Question2 (same with limsup λ_n(x) = ∞ for ALL x). Both axiomatized as open. Proves q2_implies_q1: Question2 is strictly stronger than Question1.",
-      "mathContext": "Question 1 asks: can the Lebesgue function be unbounded pointwise yet interpolation still converge? Question 2 is the global version. The implication $Q_2 \\Rightarrow Q_1$ is immediate. Both questions probe the boundary between pointwise Lebesgue function growth and interpolation convergence — asking whether $\\limsup \\lambda_n(x) = \\infty$ is compatible with $L^n f(x) \\to f(x)$."
+      "summary": "States Question1 (does there exist a sequence where limsup \u03bb_n(x) = \u221e yet L^n f(x) \u2192 f(x) for every continuous f at some x?) and Question2 (same with limsup \u03bb_n(x) = \u221e for ALL x). Both axiomatized as open. Proves q2_implies_q1: Question2 is strictly stronger than Question1.",
+      "mathContext": "Question 1 asks: can the Lebesgue function be unbounded pointwise yet interpolation still converge? Question 2 is the global version. The implication $Q_2 \\Rightarrow Q_1$ is immediate. Both questions probe the boundary between pointwise Lebesgue function growth and interpolation convergence \u2014 asking whether $\\limsup \\lambda_n(x) = \\infty$ is compatible with $L^n f(x) \\to f(x)$."
     },
     {
       "id": "special-sequences-conjecture",
-      "title": "§VIII-XII: Special Sequences and Main Conjecture",
+      "title": "\u00a7VIII-XII: Special Sequences and Main Conjecture",
       "startLine": 153,
       "endLine": 249,
-      "summary": "Defines chebyshevNodes (optimal: $x_k = \\cos((2k+1)π/2n)$) and equidistantNodes (divergent: $x_k = -1 + 2k/(n-1)$). Axiomatizes equidistant_diverges, faber (Faber's theorem: no universal convergent sequence), and measure-theoretic results. States MainConjecture about pointwise convergence for Chebyshev nodes.",
-      "mathContext": "Chebyshev nodes $x_k = \\cos\\frac{(2k-1)\\pi}{2n}$ minimize $\\|\\omega_n\\|_\\infty$ where $\\omega_n(x) = \\prod_{i=1}^n (x-x_i)$, giving the smallest possible max interpolation error for polynomials. Faber's theorem (1914): there is NO point sequence for which $L^n f \\to f$ uniformly for every continuous $f$ — universal convergent interpolation is impossible."
+      "summary": "Defines chebyshevNodes (optimal: $x_k = \\cos((2k+1)\u03c0/2n)$) and equidistantNodes (divergent: $x_k = -1 + 2k/(n-1)$). Axiomatizes equidistant_diverges, faber (Faber's theorem: no universal convergent sequence), and measure-theoretic results. States MainConjecture about pointwise convergence for Chebyshev nodes.",
+      "mathContext": "Chebyshev nodes $x_k = \\cos\\frac{(2k-1)\\pi}{2n}$ minimize $\\|\\omega_n\\|_\\infty$ where $\\omega_n(x) = \\prod_{i=1}^n (x-x_i)$, giving the smallest possible max interpolation error for polynomials. Faber's theorem (1914): there is NO point sequence for which $L^n f \\to f$ uniformly for every continuous $f$ \u2014 universal convergent interpolation is impossible."
     }
   ],
   "conclusion": {
@@ -146,29 +150,29 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 316,
+    "lineCount": 396,
     "axiomCount": 3,
-    "theoremCount": 14,
-    "definitionCount": 10,
-    "sorries": 15,
+    "theoremCount": 18,
+    "definitionCount": 11,
+    "sorries": 7,
     "path": "Proofs/Erdos671Problem.lean"
   },
   "crossReferences": [
     {
       "targetId": "erdos-1130",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, approximation-theory, interpolation, lebesgue-function"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, approximation-theory, interpolation, lebesgue-function"
     },
     {
       "targetId": "erdos-1132",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, interpolation, lebesgue-function, open"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, interpolation, lebesgue-function, open"
     },
     {
       "targetId": "erdos-1131",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: approximation-theory, interpolation, open"
+      "description": "Related Erd\u0151s problem sharing themes: approximation-theory, interpolation, open"
     }
   ],
-  "sorries": 15
+  "sorries": 7
 }

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 18,
+    "sorries": 15,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -64,8 +64,8 @@
       "q2_implies_q1 theorem: Question2 implies Question1 (proved)"
     ],
     "axiomCount": 3,
-    "lineCount": 274,
-    "assumptions": "3 axiom(s) and 18 sorry(s). See the Lean source for details.",
+    "lineCount": 316,
+    "assumptions": "3 axiom(s) and 15 sorry(s). See the Lean source for details.",
     "theoremCount": 14
   },
   "overview": {
@@ -92,43 +92,43 @@
   "sections": [
     {
       "id": "lagrange-setup",
-      "title": "\u00a7I-II: Interpolation Points and Lagrange Basis",
+      "title": "§I-II: Interpolation Points and Lagrange Basis",
       "startLine": 34,
       "endLine": 75,
-      "summary": "Defines InterpolationPoints (n points in [-1,1], distinct), PointSequence, and the Lagrange basis polynomial lagrangeBasis. Proves lagrangeBasis_self (p_i(a_i)=1) and lagrangeBasis_other (p_i(a_j)=0 for i\u2260j). Defines lagrangeInterp as the weighted sum and proves it reproduces function values at nodes.",
+      "summary": "Defines InterpolationPoints (n points in [-1,1], distinct), PointSequence, and the Lagrange basis polynomial lagrangeBasis. Proves lagrangeBasis_self (p_i(a_i)=1) and lagrangeBasis_other (p_i(a_j)=0 for i≠j). Defines lagrangeInterp as the weighted sum and proves it reproduces function values at nodes.",
       "mathContext": "The Lagrange basis polynomial $p_i^n(x) = \\prod_{j \\neq i} \\frac{x - a_j^n}{a_i^n - a_j^n}$ has degree $n-1$ and satisfies $p_i^n(a_j^n) = \\delta_{ij}$ (Kronecker delta). The interpolation operator $L^n f(x) = \\sum_{i=1}^n f(a_i^n) p_i^n(x)$ is the unique degree-$(n-1)$ polynomial agreeing with $f$ at all $n$ nodes."
     },
     {
       "id": "lebesgue-function",
-      "title": "\u00a7III: The Lebesgue Function and Constant",
+      "title": "§III: The Lebesgue Function and Constant",
       "startLine": 77,
       "endLine": 96,
-      "summary": "Defines lebesgueFunction \u03bb_n(x) = \u03a3|p_i^n(x)| and lebesgueConstant \u039b_n = sup_x \u03bb_n(x). Proves lebesgueFunction_ge_one (\u03bb_n(x) \u2265 1 whenever x is a node). These measure the worst-case amplification of interpolation errors.",
+      "summary": "Defines lebesgueFunction λ_n(x) = Σ|p_i^n(x)| and lebesgueConstant Λ_n = sup_x λ_n(x). Proves lebesgueFunction_ge_one (λ_n(x) ≥ 1 whenever x is a node). These measure the worst-case amplification of interpolation errors.",
       "mathContext": "The Lebesgue constant $\\Lambda_n = \\sup_{x \\in [-1,1]} \\sum_{i=1}^n |p_i^n(x)|$ controls interpolation error: $\\|f - L^n f\\|_\\infty \\leq (1 + \\Lambda_n) \\inf_p \\|f - p\\|_\\infty$ over degree-$(n-1)$ polynomials $p$. Chebyshev nodes minimize $\\Lambda_n$, giving $\\Lambda_n \\sim \\frac{2}{\\pi} \\ln n$; equidistant nodes give $\\Lambda_n \\sim \\frac{2^n}{en \\ln n}$ (exponential growth)."
     },
     {
       "id": "bernstein-erdos-vertesi",
-      "title": "\u00a7IV-V: Bernstein's Theorem and Erd\u0151s\u2013V\u00e9rtesi",
+      "title": "§IV-V: Bernstein's Theorem and Erdős–Vértesi",
       "startLine": 97,
       "endLine": 122,
-      "summary": "Axiomatizes bernstein (1931): for ANY point sequence, there exists x\u2080 \u2208 [-1,1] with limsup \u03bb_n(x\u2080) = \u221e. Axiomatizes erdos_vertesi (1980): for any sequence, there exists a continuous f such that limsup |L^n f(x)| = \u221e for almost every x \u2208 [-1,1]. Also proves lebesgueConstant_growth: \u039b_n \u2265 (2/\u03c0)ln(n) - 2 for n \u2265 2.",
-      "mathContext": "Bernstein (1931) showed $\\Lambda_n \\to \\infty$ for ANY point sequence \u2014 no optimal nodes exist in the pointwise sense. Erd\u0151s and V\u00e9rtesi (1980) strengthened this: divergence occurs for measure-1 set of $x$. The growth bound $\\Lambda_n \\geq \\frac{2}{\\pi} \\ln n - 2$ is universal; it holds with equality (up to $O(1)$) for Chebyshev nodes."
+      "summary": "Axiomatizes bernstein (1931): for ANY point sequence, there exists x₀ ∈ [-1,1] with limsup λ_n(x₀) = ∞. Axiomatizes erdos_vertesi (1980): for any sequence, there exists a continuous f such that limsup |L^n f(x)| = ∞ for almost every x ∈ [-1,1]. Also proves lebesgueConstant_growth: Λ_n ≥ (2/π)ln(n) - 2 for n ≥ 2.",
+      "mathContext": "Bernstein (1931) showed $\\Lambda_n \\to \\infty$ for ANY point sequence — no optimal nodes exist in the pointwise sense. Erdős and Vértesi (1980) strengthened this: divergence occurs for measure-1 set of $x$. The growth bound $\\Lambda_n \\geq \\frac{2}{\\pi} \\ln n - 2$ is universal; it holds with equality (up to $O(1)$) for Chebyshev nodes."
     },
     {
       "id": "open-questions",
-      "title": "\u00a7VI-VII: Question 1 and Question 2",
+      "title": "§VI-VII: Question 1 and Question 2",
       "startLine": 123,
       "endLine": 155,
-      "summary": "States Question1 (does there exist a sequence where limsup \u03bb_n(x) = \u221e yet L^n f(x) \u2192 f(x) for every continuous f at some x?) and Question2 (same with limsup \u03bb_n(x) = \u221e for ALL x). Both axiomatized as open. Proves q2_implies_q1: Question2 is strictly stronger than Question1.",
-      "mathContext": "Question 1 asks: can the Lebesgue function be unbounded pointwise yet interpolation still converge? Question 2 is the global version. The implication $Q_2 \\Rightarrow Q_1$ is immediate. Both questions probe the boundary between pointwise Lebesgue function growth and interpolation convergence \u2014 asking whether $\\limsup \\lambda_n(x) = \\infty$ is compatible with $L^n f(x) \\to f(x)$."
+      "summary": "States Question1 (does there exist a sequence where limsup λ_n(x) = ∞ yet L^n f(x) → f(x) for every continuous f at some x?) and Question2 (same with limsup λ_n(x) = ∞ for ALL x). Both axiomatized as open. Proves q2_implies_q1: Question2 is strictly stronger than Question1.",
+      "mathContext": "Question 1 asks: can the Lebesgue function be unbounded pointwise yet interpolation still converge? Question 2 is the global version. The implication $Q_2 \\Rightarrow Q_1$ is immediate. Both questions probe the boundary between pointwise Lebesgue function growth and interpolation convergence — asking whether $\\limsup \\lambda_n(x) = \\infty$ is compatible with $L^n f(x) \\to f(x)$."
     },
     {
       "id": "special-sequences-conjecture",
-      "title": "\u00a7VIII-XII: Special Sequences and Main Conjecture",
+      "title": "§VIII-XII: Special Sequences and Main Conjecture",
       "startLine": 153,
       "endLine": 249,
-      "summary": "Defines chebyshevNodes (optimal: $x_k = \\cos((2k+1)\u03c0/2n)$) and equidistantNodes (divergent: $x_k = -1 + 2k/(n-1)$). Axiomatizes equidistant_diverges, faber (Faber's theorem: no universal convergent sequence), and measure-theoretic results. States MainConjecture about pointwise convergence for Chebyshev nodes.",
-      "mathContext": "Chebyshev nodes $x_k = \\cos\\frac{(2k-1)\\pi}{2n}$ minimize $\\|\\omega_n\\|_\\infty$ where $\\omega_n(x) = \\prod_{i=1}^n (x-x_i)$, giving the smallest possible max interpolation error for polynomials. Faber's theorem (1914): there is NO point sequence for which $L^n f \\to f$ uniformly for every continuous $f$ \u2014 universal convergent interpolation is impossible."
+      "summary": "Defines chebyshevNodes (optimal: $x_k = \\cos((2k+1)π/2n)$) and equidistantNodes (divergent: $x_k = -1 + 2k/(n-1)$). Axiomatizes equidistant_diverges, faber (Faber's theorem: no universal convergent sequence), and measure-theoretic results. States MainConjecture about pointwise convergence for Chebyshev nodes.",
+      "mathContext": "Chebyshev nodes $x_k = \\cos\\frac{(2k-1)\\pi}{2n}$ minimize $\\|\\omega_n\\|_\\infty$ where $\\omega_n(x) = \\prod_{i=1}^n (x-x_i)$, giving the smallest possible max interpolation error for polynomials. Faber's theorem (1914): there is NO point sequence for which $L^n f \\to f$ uniformly for every continuous $f$ — universal convergent interpolation is impossible."
     }
   ],
   "conclusion": {
@@ -146,29 +146,29 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 274,
+    "lineCount": 316,
     "axiomCount": 3,
     "theoremCount": 14,
     "definitionCount": 10,
-    "sorries": 18,
+    "sorries": 15,
     "path": "Proofs/Erdos671Problem.lean"
   },
   "crossReferences": [
     {
       "targetId": "erdos-1130",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: analysis, approximation-theory, interpolation, lebesgue-function"
+      "description": "Related Erdős problem sharing themes: analysis, approximation-theory, interpolation, lebesgue-function"
     },
     {
       "targetId": "erdos-1132",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: analysis, interpolation, lebesgue-function, open"
+      "description": "Related Erdős problem sharing themes: analysis, interpolation, lebesgue-function, open"
     },
     {
       "targetId": "erdos-1131",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: approximation-theory, interpolation, open"
+      "description": "Related Erdős problem sharing themes: approximation-theory, interpolation, open"
     }
   ],
-  "sorries": 18
+  "sorries": 15
 }


### PR DESCRIPTION
## Summary

Continuing formalization of Erdős Problem #671 (Lagrange Interpolation Convergence, $250 prize).

**Session 1 (sorries: 23 → 19)**
- Fixed bad import statements  
- Proved: `lagrangeBasis_self`, `lagrangeBasis_other`, `lagrangeInterp_at_node`, `chebyshevNodes.in_interval`

**Session 2 (sorries: 19 → 15)**
- Fixed `C`/`X` namespace ambiguity (removed `Polynomial` from `open`)
- Fixed `Filter.limsup = ⊤` type error (introduced `LebesgueUnbounded`/`InterpUnbounded`)
- Proved: `q2_implies_q1` (Q2 implies Q1 via definition unpacking)

**Session 3 (sorries: 15 → 7)**
- Proved: `lagrangeInterp_degree` (interpolant has degree ≤ n-1 via `Polynomial.natDegree_prod_le`)
- Proved: `equidistantNodes.in_interval` and `.distinct` (arithmetic bounds with `(n:ℝ)-1`)
- Proved: `chebyshevNodes.distinct` via `Real.strictAntiOn_cos.injOn`
- Proved: `lagrangeBasis_sum_one` (partition of unity: Σp_i(x)=1) via polynomial root counting — n distinct roots of degree-(n-1) polynomial → zero polynomial
- Proved: `lebesgueFunction_ge_one` (λ_n(x) ≥ 1) via partition of unity + triangle inequality
- Proved: `q2_fails_implies` (¬Q2 → explicit divergence) via `push_neg`
- Eliminated 5 type-sorry instances by refactoring to `x : Set.Icc (-1:ℝ) 1` subtype

**Remaining 7 sorries** (all require deep analysis from 1930s-1980s)
- `bernstein`: Bernstein 1931 divergence theorem
- `lebesgueConstant_growth`: Λ_n ≥ (2/π)ln n lower bound
- `erdos_vertesi`: Erdős-Vértesi 1980 a.e. divergence
- `equidistant_diverges`: exponential Lebesgue constant for equidistant nodes
- `faber`: Faber 1914 no-universal-convergence theorem
- `positive_measure_divergence`, `full_measure_convergence`: measure-theoretic results

**3 axioms** (open questions with $250 prize):
- `question1_open`, `question2_open`, `main_conjecture_open`

## Test plan
- [x] Build 2 verified (equidistantNodes + lagrangeInterp_degree): no errors
- [ ] Build 3 in progress (all new proofs including partition of unity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)