### PR TITLE
research(angle-trisection): structured tower proof for isConstructible_sup_degree

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -270,14 +270,26 @@ private lemma isConstructible_sup_degree (α : ℂ) (h : IsConstructible α) :
       IsScalarTower.of_algebraMap_eq (fun r =>
         Subtype.ext (by simp [RingHom.algebraMap_toAlgebra,
           IntermediateField.coe_inclusion]))
-    -- Tower law K → Ka → Kaβ → Kaβ ⊔ ℚ⟮b⟯
-    have htower_KKa := Module.finrank_mul_finrank ℚ ↥K ↥Ka
-    have htower_KaKaβ := Module.finrank_mul_finrank ↥K ↥Ka ↥Kaβ
+    -- Additional algebra instances for K → Ka → (Kaβ ⊔ ℚ⟮b⟯) tower
+    haveI hAlg_KaJoin : Algebra ↥Ka ↥(Kaβ ⊔ ℚ⟮b⟯) :=
+      (IntermediateField.inclusion (le_sup_left.trans le_sup_left)).toAlgebra
+    haveI hAlg_KJoin : Algebra ↥K ↥(Kaβ ⊔ ℚ⟮b⟯) :=
+      (IntermediateField.inclusion
+        (le_sup_left.trans (le_sup_left.trans le_sup_left))).toAlgebra
+    haveI hST_KKaJoin : IsScalarTower ↥K ↥Ka ↥(Kaβ ⊔ ℚ⟮b⟯) :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra,
+          IntermediateField.coe_inclusion]))
+    -- Tower laws
     have htower_KaβJoin := Module.finrank_mul_finrank ↥Ka ↥Kaβ ↥(Kaβ ⊔ ℚ⟮b⟯)
+    have htower_KJoin := Module.finrank_mul_finrank ↥K ↥Ka ↥(Kaβ ⊔ ℚ⟮b⟯)
     -- finrank K (Kaβ ⊔ ℚ⟮b⟯) ∣ 2^(n₁ + 1 + n₂)
     have h_tower_dvd : Module.finrank ↥K ↥(Kaβ ⊔ ℚ⟮b⟯) ∣ 2 ^ (n₁ + 1 + n₂) := by
-      rw [← htower_KaβJoin, pow_add, pow_add, pow_one]
-      exact Nat.mul_dvd_mul (Nat.mul_dvd_mul hn₁ h_step2) hn₂
+      have h_Ka_dvd : Module.finrank ↥Ka ↥(Kaβ ⊔ ℚ⟮b⟯) ∣ 2 ^ (1 + n₂) := by
+        rw [← htower_KaβJoin, pow_add, pow_one]
+        exact Nat.mul_dvd_mul h_step2 hn₂
+      rw [show n₁ + 1 + n₂ = n₁ + (1 + n₂) from by ring, pow_add, ← htower_KJoin]
+      exact Nat.mul_dvd_mul hn₁ h_Ka_dvd
     -- finrank K (K ⊔ ℚ⟮b+β⟯) ∣ finrank K (Kaβ ⊔ ℚ⟮b⟯)
     have h_dvd_le : Module.finrank ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) ∣
         Module.finrank ↥K ↥(Kaβ ⊔ ℚ⟮b⟯) := by

--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -154,9 +154,142 @@ private lemma isConstructible_algebraic (α : ℂ) (h : IsConstructible α) : Is
     contains ℚ⟮β⟯ (as β generates ℚ⟮β⟯ over ℚ ≤ K_a). Requires Mathlib API for
     `IntermediateField.sup` decomposition — not yet available via `adjoin_eq_top_of_adjoin_eq_top`
     since the ambient field K_aβ ≠ ℚ⟮β⟯. -/
+-- Helper: (adjoin Ka {β}).restrictScalars ℚ = Ka ⊔ ℚ⟮β⟯, so the carriers are equal
+-- This is used to identify the Ka-finrank of Ka ⊔ ℚ⟮β⟯ with adjoin.finrank
+private lemma finrank_sup_quadratic_dvd_two (Ka : IntermediateField ℚ ℂ) (β : ℂ)
+    (hβ_alg : IsAlgebraic ℚ β) (hβ_sq_mem : β ^ 2 ∈ Ka) :
+    Module.finrank ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) ∣ 2 := by
+  -- β is integral over Ka (algebraic over ℚ ≤ Ka)
+  have hβ_int_Ka : IsIntegral ↥Ka β := by
+    rw [← isAlgebraic_iff_isIntegral]; exact hβ_alg.tower_top ↥Ka
+  -- β lives in Ka ⊔ ℚ⟮β⟯
+  let β' : ↥(Ka ⊔ ℚ⟮β⟯) :=
+    ⟨β, le_sup_right (IntermediateField.mem_adjoin_simple_self ℚ β)⟩
+  -- β'² = algebraMap Ka (Ka ⊔ ℚ⟮β⟯) of the β²-element
+  let a' : ↥Ka := ⟨β ^ 2, hβ_sq_mem⟩
+  -- β' is integral over Ka (same as β being integral over Ka)
+  have hβ'_int : IsIntegral ↥Ka β' := by
+    rw [← isIntegral_algebraMap_iff (algebraMap ↥(Ka ⊔ ℚ⟮β⟯) ℂ).injective]
+    simpa using hβ_int_Ka
+  -- β' satisfies X² - C a' over Ka (annihilating polynomial)
+  have h_aeval : Polynomial.aeval β' (X ^ 2 - C a' : Polynomial ↥Ka) = 0 := by
+    simp only [map_sub, map_pow, aeval_X, aeval_C, sub_eq_zero]
+    apply_fun Subtype.val using Subtype.val_injective
+    simp [β', a', RingHom.algebraMap_toAlgebra, IntermediateField.coe_inclusion]
+  -- p := X² - C a' is nonzero with natDegree 2
+  have h_p_ne : (X ^ 2 - C a' : Polynomial ↥Ka) ≠ 0 := by
+    intro h; have := congr_arg Polynomial.natDegree h
+    simp [Polynomial.natDegree_sub_eq_left_of_natDegree_lt] at this
+  -- minpoly Ka β' divides p, so natDegree ≤ 2
+  have h_dvd : minpoly ↥Ka β' ∣ (X ^ 2 - C a') := minpoly.dvd _ _ h_aeval
+  have h_deg_le : (minpoly ↥Ka β').natDegree ≤ 2 :=
+    (Polynomial.natDegree_le_of_dvd h_dvd h_p_ne).trans (by
+      simp [Polynomial.natDegree_sub_eq_left_of_natDegree_lt])
+  -- β' generates Ka ⊔ ℚ⟮β⟯ over Ka
+  -- Key: (adjoin Ka {β}).restrictScalars ℚ = Ka ⊔ ℚ⟮β⟯ (restrictScalars_adjoin_eq_sup)
+  -- and coe_restrictScalars is rfl, so adjoin Ka {β} and Ka ⊔ ℚ⟮β⟯ have the same carrier
+  -- Thus adjoin Ka {β'} = ⊤ in Ka ⊔ ℚ⟮β⟯ follows from the set equality
+  have h_top_Ka : IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯)) = ⊤ := by
+    apply IntermediateField.restrictScalars_injective ℚ
+    rw [IntermediateField.restrictScalars_top,
+        IntermediateField.restrictScalars_adjoin_eq_sup]
+    -- LHS: (adjoin Ka {β'}).restrictScalars ℚ = Ka_in_Kaβ ⊔ adjoin ℚ {β'}
+    -- Need: Ka_in_Kaβ ⊔ adjoin ℚ {β'} = ⊤ in IntermediateField ℚ (Ka ⊔ ℚ⟮β⟯)
+    rw [IntermediateField.eq_top_iff]
+    intro ⟨x, hx⟩ _
+    -- x ∈ Ka ⊔ ℚ⟮β⟯ in ℂ
+    -- want: ⟨x, hx⟩ ∈ Ka_in_Kaβ ⊔ adjoin ℚ {β'} inside ↥(Ka ⊔ ℚ⟮β⟯)
+    sorry
+  -- finrank Ka (Ka ⊔ ℚ⟮β⟯) = natDegree (minpoly Ka β')
+  have h_finrank : Module.finrank ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) = (minpoly ↥Ka β').natDegree := by
+    have := IntermediateField.adjoin.finrank hβ'_int
+    rw [h_top_Ka, IntermediateField.finrank_top'] at this
+    exact this
+  -- natDegree ∈ {1, 2}, both divide 2
+  rw [h_finrank]
+  have h_pos := minpoly.natDegree_pos hβ'_int
+  omega
+
 private lemma isConstructible_sup_degree (α : ℂ) (h : IsConstructible α) :
     ∀ (K : IntermediateField ℚ ℂ), ∃ n : ℕ, Module.finrank ↥K ↥(K ⊔ ℚ⟮α⟯) ∣ 2 ^ n := by
-  sorry
+  induction h with
+  | rational α h_mem =>
+    intro K
+    obtain ⟨q, rfl⟩ := h_mem
+    -- α = algebraMap ℚ ℂ q ∈ K (rationals are in all IntermediateFields)
+    have hα_in_K : algebraMap ℚ ℂ q ∈ K := K.algebraMap_mem q
+    rw [sup_eq_left.mpr (IntermediateField.adjoin_simple_le_iff.mpr hα_in_K)]
+    exact ⟨0, by simp⟩
+  | sqrt_ext β a b ha hb hβ2 ih_a ih_b =>
+    -- α = b + β, β * β = a, IsConstructible a (ih_a), IsConstructible b (ih_b)
+    have hβ_sq : β ^ 2 = a := by rw [sq]; exact hβ2
+    have halg_a : IsAlgebraic ℚ a := isConstructible_algebraic a ha
+    have halg_β : IsAlgebraic ℚ β :=
+      IsAlgebraic.of_pow (by norm_num : 0 < 2) (hβ_sq ▸ halg_a)
+    intro K
+    -- Ka = K ⊔ ℚ⟮a⟯; IH_a gives finrank K Ka ∣ 2^n₁
+    set Ka := (K ⊔ ℚ⟮a⟯ : IntermediateField ℚ ℂ) with hKa_def
+    obtain ⟨n₁, hn₁⟩ := ih_a K
+    -- Kaβ = Ka ⊔ ℚ⟮β⟯
+    set Kaβ := (Ka ⊔ ℚ⟮β⟯ : IntermediateField ℚ ℂ) with hKaβ_def
+    -- a ∈ Ka (since a ∈ ℚ⟮a⟯ ≤ Ka)
+    have ha_in_Ka : a ∈ Ka := le_sup_right (IntermediateField.mem_adjoin_simple_self ℚ a)
+    -- β² ∈ Ka (since β² = a ∈ Ka)
+    have hβ_sq_in_Ka : β ^ 2 ∈ Ka := hβ_sq ▸ ha_in_Ka
+    -- Key: finrank Ka Kaβ ∣ 2
+    have h_step2 : Module.finrank ↥Ka ↥Kaβ ∣ 2 :=
+      finrank_sup_quadratic_dvd_two Ka β halg_β hβ_sq_in_Ka
+    -- IH_b at Kaβ: finrank Kaβ (Kaβ ⊔ ℚ⟮b⟯) ∣ 2^n₂
+    obtain ⟨n₂, hn₂⟩ := ih_b Kaβ
+    -- b + β ∈ Kaβ ⊔ ℚ⟮b⟯ (β ∈ ℚ⟮β⟯ ≤ Ka ⊔ ℚ⟮β⟯ = Kaβ ≤ Kaβ ⊔ ℚ⟮b⟯, b ∈ ℚ⟮b⟯ ≤ Kaβ ⊔ ℚ⟮b⟯)
+    have hβ_in_Kaβ : β ∈ Kaβ :=
+      le_sup_right (IntermediateField.mem_adjoin_simple_self ℚ β)
+    have hmem : b + β ∈ Kaβ ⊔ ℚ⟮b⟯ :=
+      add_mem (le_sup_left hβ_in_Kaβ)
+              (le_sup_right (IntermediateField.mem_adjoin_simple_self ℚ b))
+    -- K ⊔ ℚ⟮b+β⟯ ≤ Kaβ ⊔ ℚ⟮b⟯
+    have h_le : K ⊔ ℚ⟮(b + β)⟯ ≤ Kaβ ⊔ ℚ⟮b⟯ := by
+      apply sup_le
+      · exact le_sup_left.trans (le_sup_left.trans le_sup_left)
+      · exact IntermediateField.adjoin_simple_le_iff.mpr hmem
+    -- Set up algebra instances for the tower K → Ka → Kaβ → Kaβ ⊔ ℚ⟮b⟯
+    haveI hAlg_KKa : Algebra ↥K ↥Ka :=
+      (IntermediateField.inclusion le_sup_left).toAlgebra
+    haveI hST_KKa : IsScalarTower ℚ ↥K ↥Ka :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+    haveI hAlg_KaKaβ : Algebra ↥Ka ↥Kaβ :=
+      (IntermediateField.inclusion le_sup_left).toAlgebra
+    haveI hST_KKaKaβ : IsScalarTower ↥K ↥Ka ↥Kaβ :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra,
+          IntermediateField.coe_inclusion]))
+    haveI hAlg_KaβJoin : Algebra ↥Kaβ ↥(Kaβ ⊔ ℚ⟮b⟯) :=
+      (IntermediateField.inclusion le_sup_left).toAlgebra
+    haveI hST_KaKaβJoin : IsScalarTower ↥Ka ↥Kaβ ↥(Kaβ ⊔ ℚ⟮b⟯) :=
+      IsScalarTower.of_algebraMap_eq (fun r =>
+        Subtype.ext (by simp [RingHom.algebraMap_toAlgebra,
+          IntermediateField.coe_inclusion]))
+    -- Tower law K → Ka → Kaβ → Kaβ ⊔ ℚ⟮b⟯
+    have htower_KKa := Module.finrank_mul_finrank ℚ ↥K ↥Ka
+    have htower_KaKaβ := Module.finrank_mul_finrank ↥K ↥Ka ↥Kaβ
+    have htower_KaβJoin := Module.finrank_mul_finrank ↥Ka ↥Kaβ ↥(Kaβ ⊔ ℚ⟮b⟯)
+    -- finrank K (Kaβ ⊔ ℚ⟮b⟯) ∣ 2^(n₁ + 1 + n₂)
+    have h_tower_dvd : Module.finrank ↥K ↥(Kaβ ⊔ ℚ⟮b⟯) ∣ 2 ^ (n₁ + 1 + n₂) := by
+      rw [← htower_KaβJoin, pow_add, pow_add, pow_one]
+      exact Nat.mul_dvd_mul (Nat.mul_dvd_mul hn₁ h_step2) hn₂
+    -- finrank K (K ⊔ ℚ⟮b+β⟯) ∣ finrank K (Kaβ ⊔ ℚ⟮b⟯)
+    have h_dvd_le : Module.finrank ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) ∣
+        Module.finrank ↥K ↥(Kaβ ⊔ ℚ⟮b⟯) := by
+      haveI hAlg2 : Algebra ↥(K ⊔ ℚ⟮(b + β)⟯) ↥(Kaβ ⊔ ℚ⟮b⟯) :=
+        (IntermediateField.inclusion h_le).toAlgebra
+      haveI hST2 : IsScalarTower ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) ↥(Kaβ ⊔ ℚ⟮b⟯) :=
+        IsScalarTower.of_algebraMap_eq (fun r =>
+          Subtype.ext (by simp [RingHom.algebraMap_toAlgebra,
+            IntermediateField.coe_inclusion]))
+      exact ⟨Module.finrank ↥(K ⊔ ℚ⟮(b + β)⟯) ↥(Kaβ ⊔ ℚ⟮b⟯),
+        (Module.finrank_mul_finrank ↥K ↥(K ⊔ ℚ⟮(b + β)⟯) ↥(Kaβ ⊔ ℚ⟮b⟯)).symm⟩
+    exact ⟨n₁ + 1 + n₂, h_dvd_le.trans h_tower_dvd⟩
 
 /-- Constructible numbers are algebraic of 2-power degree.
 

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
@@ -424,3 +424,34 @@ Per project memory `project_mathlib_api_drift_2026_04`, this drift hits a cohort
 2. Consider whether `algClosure.lift` (for algebraic closures) provides the missing bridge
 3. ← direction: FTGT + Sylow composition series; requires IntermediateField.orderIsoOfGal and degree-2 extension ↔ adjoin √ characterization
 4. If → direction proves infeasible, mark wantzel_galois_iff as long-term blocked (500+ lines, Zorn + FTGT)
+
+## Session 2026-05-04 (Session 38) - Tower argument for isConstructible_sup_degree
+
+**Mode**: REVISIT
+**Outcome**: progress — structured full tower proof for isConstructible_sup_degree; one technical sorry on generator property
+
+### What I Did
+- Rewrote the single sorry in `isConstructible_sup_degree` with a complete structured proof:
+  - New helper lemma `finrank_sup_quadratic_dvd_two Ka β (hβ_alg) (hβ_sq_mem)`: proves `finrank Ka (Ka ⊔ ℚ⟮β⟯) ∣ 2` when β is algebraic and β² ∈ Ka
+  - Full induction for `isConstructible_sup_degree` over both cases `rational` and `sqrt_ext`
+  - Tower argument: K → Ka=K⊔ℚ⟮a⟯ → Kaβ=Ka⊔ℚ⟮β⟯ → Kaβ⊔ℚ⟮b⟯, combining n₁, 1, n₂ to give n₁+1+n₂
+  - Divisibility via sub-field containment: K⊔ℚ⟮b+β⟯ ≤ Kaβ⊔ℚ⟮b⟯ (tower law dvd argument)
+- Total sorry count: still 1 (h_top_Ka inside finrank_sup_quadratic_dvd_two)
+
+### Key Findings
+- **h_top_Ka sorry**: `adjoin ↥Ka {β'} = ⊤` in IntermediateField ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) — β' generates Ka⊔ℚ⟮β⟯ over Ka. Mathematically obvious (by definition of simple adjoin), but Lean formalization requires a Ka-AlgHom ↥(Ka⊔ℚ⟮β⟯) →ₐ[↥Ka] ℂ and use of `map_injective`. The fundamental challenge is that adjoin Ka {β} (IntermediateField Ka ℂ) and Ka⊔ℚ⟮β⟯ (IntermediateField ℚ ℂ) have the same carrier but live in different type universes.
+- **Key Mathlib lemmas identified**: `restrictScalars_adjoin_eq_sup`, `coe_restrictScalars`, `map_injective`, `adjoin_map`, `adjoin.finrank`, `minpoly.degree_dvd`, `lift_top`, `lift_adjoin_simple`
+- **Alternative approach**: Show `finrank ≤ 2` directly via spanning {1, β'} — requires showing every element of Ka⊔ℚ⟮β⟯ is of form a+b·β, which reduces to the same generator property
+- **adjoin.finrank goes WRONG direction**: `minpoly.degree_dvd` gives natDegree ∣ finrank (not finrank ∣ 2); the generator property is needed to get finrank = natDegree ≤ 2
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` — replaced single sorry with structured 200-line proof (lines ~157-292)
+
+### Current Sorries (1 total)
+1. **h_top_Ka** (line ~202): `adjoin ↥Ka {β'} = ⊤` in IntermediateField ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) — generator property for the quadratic extension step
+2. **wantzel_galois_iff** (line ~713): Full Galois theory (long-term)
+
+### Next Steps
+1. Try `IntermediateField.map_injective ι` approach with explicit Ka-AlgHom ι : ↥(Ka⊔ℚ⟮β⟯) →ₐ[↥Ka] ℂ
+2. Submit h_top_Ka to Aristotle (clear algebraic statement, might be provable by automation)
+3. After h_top_Ka: proof of isConstructible_sup_degree is complete, enabling isConstructible_algebraic_degree finrank part


### PR DESCRIPTION
## Summary

- Adds `finrank_sup_quadratic_dvd_two`: proves `Module.finrank Ka (Ka ⊔ ℚ⟮β⟯) ∣ 2` for any `IntermediateField Ka` and β with β² ∈ Ka, using minpoly divisibility by X²-a and omega
- Adds `isConstructible_sup_degree`: full structural induction — rational case uses `finrank = 1`; sqrt_ext case uses tower K → Ka = K⊔ℚ⟮a⟯ → Kaβ = Ka⊔ℚ⟮β⟯ → Kaβ⊔ℚ⟮b⟯ with IH exponents n₁ + 1 + n₂
- Fixes undefined-reference compilation error in `isConstructible_algebraic_degree` (which referenced `isConstructible_sup_degree` before it was defined)
- 1 sorry remains: `h_top_Ka` — the generator property that β' generates Ka⊔ℚ⟮β⟯ over Ka; this requires bridging `IntermediateField ℚ ℂ` and `IntermediateField Ka ℂ` type universes

## Test plan

- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01` (running)
- [ ] Verify exactly 1 sorry (h_top_Ka) in the compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)