### PR TITLE
fix(meta): correct stale theoremCount/definitionCount for erdos-183

### DIFF
--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -77,7 +77,7 @@
       }
     ],
     "assumptions": "1 axiom: R3k_exponential_lower (c^k lower bound from Schur numbers). R3k_factorial_upper PROVED from R3k_le_three_factorial (induction on pigeonhole recurrence). R3k_inductive_upper PROVED from extracted pigeonhole step. forcing_set_nonempty PROVED via pigeonhole induction. R3k_one, R3k_two PROVED. Monotonicity PROVED.",
-    "theoremCount": 18
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) ≤ ⌈e·k!⌉ follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) ≥ 380^{k/5} - O(1).\n\nErdős offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
@@ -187,8 +187,8 @@
     "namespace": "Erdos183",
     "lineCount": 613,
     "axiomCount": 1,
-    "theoremCount": 18,
-    "definitionCount": 15,
+    "theoremCount": 10,
+    "definitionCount": 14,
     "path": "Proofs/Erdos183Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` and `definitionCount` in `meta.json` for erdos-183 (Multicolor Triangle Ramsey Numbers).

## Evidence

**Actual declarations in `Proofs/Erdos183Problem.lean`:**
- Theorems/lemmas: `forcing_set_nonempty`, `R3k_one`, `R3k_two`, `R3k_mono`, `R3k_ge_three`, `R3k_inductive_upper`, `R3k_le_three_factorial`, `R3k_factorial_upper`, `bounds_summary`, `erdos_183_main` = **10**
- Definitions: `EdgeColoring`, `IsSymmetric`, `HasMonochromaticTriangle`, `HasSomeMonochromaticTriangle`, `AvoidsMonochromaticTriangles`, `ForcesMonochromaticTriangle`, `R3k`, `SchurNumber`, `kthRootR3k`, `ErdosProblem183`, `LimitIsFinite`, `LimitIsInfinite`, `erdos_183_status`, `relatedProblem` = **14**

**Before → After:**
| Field | Before | After |
|-------|--------|-------|
| `meta.theoremCount` | 18 | 10 |
| `leanFile.theoremCount` | 18 | 10 |
| `leanFile.definitionCount` | 15 | 14 |

Addresses audit-tracker entry for erdos-183 (auditCount=3, leanFile.theoremCount 18→10 drift noted).

---
Automated fix by lean-mechanic agent.