### PR TITLE
fix(meta): sync stale lineCount (and theoremCount) for 5 gallery proofs

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 463,
-    "theoremCount": 24,
+    "lineCount": 562,
+    "theoremCount": 27,
     "defCount": 6,
     "assumptions": "Two axioms (both require Eisenstein integers ℤ[ω] not in Mathlib): (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. All 24 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card (|ker χ₃| = (p-1)/3, proved via IsCyclic.card_pow_eq_one_le + Finset.le_card_of_inj_on_range) and cubicEuler_hard (hard direction of Euler criterion via discrete log).",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-03-29",
     "axiomCount": 3,
-    "lineCount": 232,
+    "lineCount": 499,
     "prerequisites": [
       "Covering systems and congruence classes",
       "Well-ordering principle for natural numbers",

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -74,7 +74,7 @@
       "de-rham",
       "research"
     ],
-    "lineCount": 587,
+    "lineCount": 1144,
     "prerequisites": [
       "Green's theorem for simply-connected regions (OQ-01, OQ-03)",
       "TypeI regions and iterated integrals",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -38,7 +38,7 @@
         "relationship": "Parent entry stating the Inverse Galois Problem and axiomatizing Shafarevich's theorem for solvable groups"
       }
     ],
-    "lineCount": 723,
+    "lineCount": 4822,
     "mathlib_version": "4.26.0",
     "theoremCount": 40
   },

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -112,7 +112,7 @@
       "Can we formalize the Kronecker-Weber theorem in Lean?",
       "Can Q₈ (quaternion group) be explicitly realized? (last missing group of order ≤ 8)"
     ],
-    "lineCount": 1882,
+    "lineCount": 5881,
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {


### PR DESCRIPTION
## Fix

Sync stale `lineCount` (and `theoremCount`) fields for 5 gallery proofs where the counts had drifted from reality.

## Evidence

Four proofs had `additionalFiles` added after `lineCount` was last set, so the count only reflected the main file and missed the additional files:

| Proof | Before | After |
|-------|--------|-------|
| `inverse-galois-oq-01` | 723 | 4822 (now includes 3 additionalFiles) |
| `inverse-galois` | 1882 | 5881 (now includes 5 additionalFiles) |
| `greens-theorem-oq-04` | 587 | 1144 (now includes GreensTheoremOQ03.lean) |
| `erdos-2-oq-01` | 232 | 499 (now includes Erdos2Problem.lean) |

One proof had no additionalFiles but the main file grew:

| Proof | Before | After |
|-------|--------|-------|
| `elementary-quadratic-reciprocity-oq-01-oq-02` | lineCount 463→562, theoremCount 24→27 |

## Method

Manually counted lines across each proof's main file and all `additionalFiles` entries, then updated the `lineCount` (and `theoremCount` where applicable) in each `meta.json`.

---
Automated fix by lean-mechanic agent.