### PR TITLE
fix(meta): sync stale theoremCount for 17 gallery proofs

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
@@ -51,7 +51,7 @@
         "module": "Mathlib.FieldTheory.Galois.Basic"
       }
     ],
-    "theoremCount": 32
+    "theoremCount": 5
   },
   "overview": {
     "historicalContext": "The Galois group computation for cos(π/7) is a classical exercise in algebraic number theory, first implicit in Gauss's 1801 *Disquisitiones Arithmeticae* where he characterized constructible regular polygons. The regular heptagon (7-gon) is not constructible by straightedge and compass because [ℚ(cos(2π/7)):ℚ] = 3, which is not a power of 2 — precisely the fact this proof establishes. The minimal polynomial 8X³−4X²−4X+1 arises from the 14th cyclotomic field: cos(π/7) = (ζ₁₄ + ζ₁₄⁻¹)/2 where ζ₁₄ = e^{2πi/14}, and the maximal real subfield ℚ(ζ₁₄)⁺ = ℚ(cos(π/7)) has degree φ(14)/2 = 3 over ℚ. The three roots cos(π/7), cos(3π/7), cos(5π/7) form a single Galois orbit under the automorphism α ↦ 1−2α² (corresponding to ζ₁₄ ↦ ζ₁₄⁵), giving the cyclic Galois group ℤ/3ℤ. This computation is a key example in the theory of totally real abelian extensions.",
@@ -181,7 +181,7 @@
     "namespace": "AngleTrisectionCos20GalOQ01",
     "lineCount": 416,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 5,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
@@ -65,7 +65,7 @@
         "module": "Mathlib.FieldTheory.Galois.Basic"
       }
     ],
-    "theoremCount": 28
+    "theoremCount": 5
   },
   "overview": {
     "historicalContext": "The minimal polynomial of cos(2π/5) = cos(72°) is 4X²+2X−1, derived from the 5th cyclotomic polynomial Φ₅(X) = X⁴+X³+X²+X+1: substituting X = e^{2πi/5} and taking real parts gives cos(2π/5) + cos(4π/5) = −1/2 and cos(2π/5)·cos(4π/5) = −1/4 (Vieta's formulas on the degree-2 real subpolynomial). Clearing denominators yields 4α²+2α−1=0.\n\nThe constructibility of the regular pentagon is ancient: Euclid's *Elements* Book IV gives an explicit ruler-and-compass construction (Proposition 11). But WHY it is constructible — and what distinguishes the pentagon from the heptagon — was first explained algebraically by Carl Friedrich Gauss in 1801. In *Disquisitiones Arithmeticae* §365–366, Gauss proved the extraordinary result that the regular 17-gon (heptadecagon) is constructible by ruler and compass, after 2,000 years of apparent impossibility. His general criterion: a regular n-gon is constructible if and only if n = 2^a · p₁ · p₂ · ··· · pₖ where each pᵢ is a distinct Fermat prime (of the form 2^{2^m}+1). For n = p prime: the p-gon is constructible iff p = 2^{2^m}+1 is a Fermat prime. The regular pentagon (p=5=2^{2^1}+1) is constructible; the regular heptagon (p=7, not a Fermat prime) is not.\n\nThe impossibility of angle trisection was settled by Pierre Wantzel in 1837: to trisect a general angle of 60°, one would need cos(20°) to be constructible, but [ℚ(cos(20°)):ℚ] = 3 (not a power of 2), so it is impossible. Wantzel's proof used the same degree criterion that Gauss had employed positively. This formalization establishes the degree-2 base case: |Gal(4X²+2X−1/ℚ)| = 2 confirms [ℚ(cos(72°)):ℚ] = 2 = 2¹, making the regular pentagon constructible — the algebraic explanation of Euclid's 2,300-year-old construction.",
@@ -236,7 +236,7 @@
     "namespace": "AngleTrisectionCos20GalOQ03OQ01",
     "lineCount": 462,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 5,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ03OQ01.lean"

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
@@ -29,7 +29,7 @@
       "Splitting field degree 3 theorem for 8X³−6X+1",
       "Main theorem: |Gal(8X³−6X+1/ℚ)| = 3"
     ],
-    "theoremCount": 32
+    "theoremCount": 5
   },
   "overview": {
     "historicalContext": "The impossibility of angle trisection by compass and straightedge was proved by Wantzel (1837), using the then-new theory of algebraic extensions. The key insight: a 60° angle cannot be trisected because 20° has cosine satisfying the irreducible cubic 8X³−6X−1 = 0, and [ℚ(cos(20°)):ℚ] = 3 is not a power of 2. Galois theory, developed by Évariste Galois before his death in 1832 (but published posthumously in 1846), gave a more conceptual framework: the Galois group of the minimal polynomial determines constructibility.\n\nThe polynomial 8X³−6X+1 is the minimal polynomial of cos(40°) = cos(2π/9) over ℚ. Its three roots are cos(40°), cos(80°), cos(160°), arising from the triple-angle identity cos(3·40°) = cos(120°) = −1/2. The Eisenstein irreducibility argument uses the shift Y=2X−2, which transforms the polynomial into Y³+6Y²+9Y+3 — Eisenstein at p=3. The analogous shift Y=2X+2 works for the cos(20°) polynomial 8X³−6X−1. Both shifts are discovered by looking at where the polynomial takes the value 0: the roots of 8X³−6X±1 are close to ±1/2, and centering the variable near these values produces the p-divisibility structure needed for Eisenstein.\n\nThis result is part of a family: the Galois groups of 8X³−6X−1 (cos(20°)/cos(π/9)), 8X³−6X+1 (cos(40°)/cos(2π/9)), and 8X³−4X²−4X+1 (cos(π/7)) all have order 3. In all three cases, the splitting field is a cyclic extension of degree 3 over ℚ, and the Galois group is ℤ/3ℤ. This is the minimal non-trivial case of the general pattern for cos(2π/p) with odd prime p: the Galois group is cyclic of order (p−1)/2 = 1, 3, 5, ... for p = 3, 7, 11, ...",
@@ -142,7 +142,7 @@
     "namespace": "AngleTrisectionCos20GalOQ03",
     "lineCount": 434,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/angle-trisection-cos-20-gal/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 474,
-    "theoremCount": 33,
+    "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
       "root_image_beta and root_image_gamma: algebraic identities showing all three roots lie in ℚ(α)",
@@ -170,7 +170,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 33
+    "theoremCount": 6
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -55,7 +55,7 @@
       "Moon-Moser theorem (fully proved): tournament_cycle_extendable (SC contradiction forces cycle growth) + grow_cycle_to_hamiltonian (well-founded induction with termination measure |V|-|cycle|)",
       "directed_hamiltonian_threshold (fully proved): arc count > (n-1)² + SC implies Hamiltonicity via probabilistic union bound over n! permutations (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le)"
     ],
-    "theoremCount": 27
+    "theoremCount": 9
   },
   "overview": {
     "prerequisites": [
@@ -261,7 +261,7 @@
     "axiomCount": 1,
     "sorries": 4,
     "path": "Proofs/Erdos1012OQ03.lean",
-    "theoremCount": 27,
+    "theoremCount": 9,
     "definitionCount": 9
   },
   "sorries": 4

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 475,
-    "theoremCount": 37,
+    "theoremCount": 21,
     "assumptions": "0 axioms, 0 sorries. gFunc_exists proved constructively via Kummer's theorem (carry-free base-p arithmetic). gFunc defined via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 all verified. Open conjecture; supporting lemmas fully verified."
   },
   "overview": {
@@ -148,7 +148,7 @@
     "namespace": "Erdos1095OQ01",
     "lineCount": 475,
     "axiomCount": 0,
-    "theoremCount": 37,
+    "theoremCount": 21,
     "definitionCount": 4,
     "path": "Proofs/Erdos1095OQ01Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1109/meta.json
+++ b/src/data/proofs/erdos-1109/meta.json
@@ -76,7 +76,7 @@
     "axiomCount": 2,
     "lineCount": 3713,
     "assumptions": "2 axioms: konyagin_lower_2004, konyagin_upper_2004. 0 sorries.",
-    "theoremCount": 151
+    "theoremCount": 92
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1109: Squarefree Sumsets**\n\nThis problem combines additive combinatorics with multiplicative number theory. It asks: how large can a set be if all its pairwise sums avoid any square factor?\n\n**Historical Development:**\n- **Erdős-Sárközy (1987):** First studied the problem, proving log N ≪ f(N) ≪ N^{3/4} log N. They conjectured the lower bound is closer to the truth.\n- **Sárközy (1992):** Extended to A+B and k-power-free sumsets.\n- **Gyarmati (2001):** Alternative proof of log N lower bound with new A+B results.\n- **Konyagin (2004):** Current best bounds: (log log N)(log N)² ≪ f(N) ≪ N^{11/15+o(1)}.\n\nThe problem connects to the infinite analogue (#1103) and has applications in understanding the structure of squarefree numbers.",
@@ -272,7 +272,7 @@
     "namespace": "Erdos1109",
     "lineCount": 3713,
     "axiomCount": 2,
-    "theoremCount": 151,
+    "theoremCount": 92,
     "definitionCount": 8,
     "path": "Proofs/Erdos1109Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -66,7 +66,7 @@
     "axiomCount": 5,
     "lineCount": 454,
     "assumptions": "5 axioms: erdos_lower_bound, chebyshev_upper_bound, kilgore_cheney_existence, brutman_odd, brutman_pinkus_even. 0 sorries.",
-    "theoremCount": 30
+    "theoremCount": 6
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1129: Optimal Lagrange Interpolation**\n\nThis problem concerns polynomial interpolation, a fundamental topic in numerical analysis dating back to Newton and Lagrange. Given data points (x₁,y₁),...,(xₙ,yₙ), the unique interpolating polynomial of degree ≤ n-1 is P(x) = Σyₖl_k(x), where l_k are the Lagrange basis functions.\n\n**Historical Development:**\n- **Faber (1914)**: First proved that no choice of nodes can keep the Lebesgue constant bounded as n → ∞. This was a fundamental negative result showing polynomial interpolation has inherent limitations.\n- **Bernstein (1931)**: Improved the lower bound to Λ > (2/π - o(1)) log n and found optimal nodes for n = 3.\n- **Erdős (1961)**: Achieved the sharp lower bound Λ ≥ (2/π) log n - O(1).\n- **Erdős (1967)**: Conjectured the equal-height characterization and posed the complex variant.\n- **Kilgore & Cheney (1976)**: Proved existence of minimizing configurations.\n- **Kilgore (1977)**: Proved the equal-height characterization.\n- **de Boor & Pinkus (1978)**: Proved uniqueness for canonical configurations.\n- **Brutman (1980), Brutman & Pinkus (1980)**: Proved roots of unity are optimal on the unit circle.\n- **Rack & Vajda (2015)**: Found the explicit optimal configuration for n = 4.\n\n**Mathematical Setting:**\nThe Lebesgue constant Λ = max_{x∈[-1,1]} Σ|l_k(x)| measures how much interpolation can amplify errors. If f is approximated by P interpolating at nodes x_i, then ||f - P||_∞ ≤ (1 + Λ) · E_n(f), where E_n(f) is the best polynomial approximation error.",
@@ -277,7 +277,7 @@
     "namespace": "Erdos1129",
     "lineCount": 454,
     "axiomCount": 5,
-    "theoremCount": 30,
+    "theoremCount": 6,
     "definitionCount": 10,
     "path": "Proofs/Erdos1129Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -24,7 +24,7 @@
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "theoremCount": 31,
+    "theoremCount": 14,
     "lineCount": 1076,
     "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 0 sorries — all supporting lemmas fully proved: chebyshev_interp, chebyshev_sq_expansion, dct_offdiag, integral_cos_substitution, integral_chebyshev_sq, chebyshev_integral_trace.",
     "mathlib_version": "4.26.0"
@@ -201,7 +201,7 @@
     "namespace": "Erdos1131",
     "lineCount": 1076,
     "axiomCount": 1,
-    "theoremCount": 31,
+    "theoremCount": 14,
     "definitionCount": 6,
     "sorries": 0,
     "path": "Proofs/Erdos1131Problem.lean"

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 11,
     "definitionCount": 7,
     "lineCount": 709,
     "erdosNumber": 1179,
@@ -225,7 +225,7 @@
     "namespace": "Erdos1179OQ01",
     "lineCount": 709,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 11,
     "definitionCount": 5,
     "sorries": 0,
     "path": "Proofs/Erdos1179OQ01.lean"

--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -67,7 +67,7 @@
     ],
     "lineCount": 1104,
     "assumptions": "2 axioms: density_hales_jewett_k3, meshulam_upper_bound. 0 sorries.",
-    "theoremCount": 73
+    "theoremCount": 43
   },
   "overview": {
     "historicalContext": "Cap sets — subsets of $\\{0,1,2\\}^n$ with no three collinear points (i.e., no $x,y,z$ with $x+z=2y$ in $\\mathbb{F}_3^n$) — arose from the study of arithmetic progressions in finite geometry. Leo Moser posed the problem and constructed cap sets of size $\\Omega(3^n/\\sqrt{n})$ using coordinate-sum restrictions. Hillel Furstenberg and Yitzhak Katznelson (1991) proved the density Hales-Jewett theorem using ergodic theory, implying $f_3(n) = o(3^n)$. Roy Meshulam (1995) gave the first quantitative bound $f_3(n) \\leq 3^n/n$ using Fourier-analytic methods. The breakthrough came in 2016 when Jordan Ellenberg and Dion Gijswijt, building on Croot-Lev-Pach's polynomial method, proved $f_3(n) \\leq c^n$ with $c = 3 \\cdot (207 + 33\\sqrt{33})^{1/3}/8 \\approx 2.756$. This resolved a central problem in additive combinatorics and had immediate implications for the sunflower conjecture and other problems.",
@@ -204,7 +204,7 @@
     "namespace": "Erdos185",
     "lineCount": 1104,
     "axiomCount": 2,
-    "theoremCount": 73,
+    "theoremCount": 43,
     "definitionCount": 30,
     "path": "Proofs/Erdos185Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -48,7 +48,7 @@
       "Complete LCM infrastructure: foldl_lcm_pos, init_dvd_foldl_lcm, mem_dvd_foldl_lcm, dvd_systemLCM",
       "Single modulus base case: coverageDensity_singleton and single_modulus_density via filter characterization"
     ],
-    "theoremCount": 29
+    "theoremCount": 12
   },
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.28), as part of their systematic study of covering systems — a topic Erdős championed from his groundbreaking 1950 paper showing that covering systems with distinct moduli greater than 1 exist. The problem asks: given fixed moduli, how should one choose residues to optimize coverage?\n\nCovering systems have a rich history. Erdős introduced them in his 1950 proof that there exist infinitely many odd integers not representable as $2^k + p$ (a prime), using a covering system with moduli $\\{2, 3, 4, 8, 12, 24\\}$. He conjectured that covering systems with arbitrarily large minimum modulus exist — a conjecture that stood for over 60 years until Bob Hough's 2015 proof (Annals of Mathematics) showed that any covering system with distinct moduli must include a modulus at most $10^{16}$, dramatically settling the question in the negative.\n\nR.J. Simpson resolved the minimum question of Problem #278 in 1986 (Discrete Mathematics 59), proving by an elegant averaging argument that equal residues minimize coverage density. His proof uses the key observation that uniformly shifting all residues preserves the expected density, so the minimum cannot exceed the equal-residue density. The maximum question remains open and is fundamentally harder: for coprime moduli, the Chinese Remainder Theorem forces all residue choices to yield the same density $1 - \\prod(1 - 1/n_i)$, but for non-coprime moduli, the overlap structure between congruence classes depends delicately on the residue choices. The problem connects to sieve-theoretic methods in analytic number theory and to combinatorial optimization on lattice structures.",
@@ -174,7 +174,7 @@
     "namespace": "",
     "lineCount": 644,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 12,
     "definitionCount": 7,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -54,7 +54,7 @@
     "axiomCount": 0,
     "lineCount": 690,
     "assumptions": "None. All results are fully machine-checked. The Erdős-Hajnal graphs on ω₁² and ω₂² are proved to have chromatic numbers ℵ₁ and ℵ₂ respectively via double pigeonhole arguments. The open questions (Questions 1 and 2) are stated but not assumed. Open conjecture; supporting lemmas fully verified.",
-    "theoremCount": 40
+    "theoremCount": 17
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős in 1969 [Er69b] and sits at the intersection of graph theory, set theory, and infinite combinatorics. It was inspired by Babai's theorem about chromatic properties of graphs on well-ordered vertex sets.\n\nErdős and Hajnal made crucial progress by constructing a counterexample at the ℵ₁ level. They built a graph on ω₁² (the ordinal product of two copies of the first uncountable ordinal) with chromatic number ℵ₁, but where every strictly smaller subgraph (by order type) has countable chromatic number ≤ ℵ₀. This showed that Babai's theorem does not generalize to higher cardinals.\n\nThe natural question then arises: can we do the same construction at the next level? This is Problem #919: does there exist a graph on ω₂² with chromatic number ℵ₂ where smaller subgraphs have chromatic number at most ℵ₀ (not just ℵ₁)?",
@@ -176,7 +176,7 @@
     "namespace": "Erdos919",
     "lineCount": 690,
     "axiomCount": 0,
-    "theoremCount": 40,
+    "theoremCount": 17,
     "definitionCount": 14,
     "path": "Proofs/Erdos919Problem.lean",
     "sorries": 0

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "0 sorries, 0 axioms. All 7 Fano upper-triangular residuals (F43, F53, F63, F65, F73, F75, F76) in derEval14_injective were closed by PR #13632 via explicit Fano-line Leibniz proofs using fin_cases, simp, antisymmetry constraints, and linarith. G2_der_dimension is a proved theorem (not an axiom): finrank ℝ Der(𝕆) = 14 via upper bound (injective derEval14 map) and lower bound (derBasis14_linearIndependent, proved in PR #13121).",
     "lineCount": 1646,
-    "theoremCount": 65,
+    "theoremCount": 27,
     "definitionCount": 19,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
@@ -139,7 +139,7 @@
     "namespace": "HurwitzTheoremOQ04",
     "lineCount": 1646,
     "axiomCount": 0,
-    "theoremCount": 65,
+    "theoremCount": 27,
     "definitionCount": 15,
     "sorries": 0,
     "path": "Proofs/HurwitzTheoremOQ04.lean"

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 52
+    "theoremCount": 8
   },
   "overview": {
     "historicalContext": "The Banach-Tarski paradox (1924) is one of the most counterintuitive results in mathematics: the closed unit ball in ℝ³ can be decomposed into finitely many pieces (5 suffice) and those pieces reassembled — using only rotations and translations — into two complete copies of the original ball. This appears to violate conservation of volume, but the pieces are non-measurable sets (constructed using the Axiom of Choice) to which Lebesgue measure cannot be assigned.\n\nThe paradox has a precise 1914 predecessor: Felix Hausdorff's *Grundzüge der Mengenlehre* proved that the 2-sphere $S^2$ minus a countable set $D$ admits a paradoxical decomposition under $\\text{SO}(3)$. The key algebraic ingredient was Hausdorff's discovery that $\\text{SO}(3)$ contains a free subgroup of rank 2: rotations $\\varphi$ (by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (by $\\arccos(1/3)$ around the $x$-axis) generate a free group, proved by an algebraic-number-theoretic argument — nontrivial words produce vectors with irrational coordinates that can never equal the identity.\n\nBanach and Tarski extended this in 1924 by handling the exceptional countable set $D$ (via a Hilbert-hotel argument: any countably infinite set under a fixed rotation of infinite order can be rearranged to absorb one more point) and by extending from $S^2$ to the full ball $B^3$ via a cone construction. The Straus–von Neumann optimization later showed 5 pieces suffice; whether 4 pieces can suffice for the full ball remains open (Dougherty–Foreman 1992 showed 4 pieces suffice using sets with the Baire property).\n\nThe conceptual unification came from Alfred Tarski. In 1938 ('Algebraische Fassung des Maßproblems') he proved the fundamental equivalence: a group $G$ is *amenable* — admits a finitely-additive left-invariant probability measure on all its subsets — if and only if no $G$-set is paradoxical. M. M. Day named the property 'amenable' in 1949. The chain $F_2 \\hookrightarrow \\text{SO}(3) \\Rightarrow \\text{SO}(3)$ non-amenable $\\Rightarrow B^3$ paradoxical is then the clean conceptual proof.\n\nThe 2D case is fundamentally different: $\\text{SO}(2)$ is abelian (hence amenable), so no paradoxical decomposition of bounded plane sets can exist using rotations. Robert Solovay proved in 1970 that, assuming an inaccessible cardinal, ZF is consistent with every subset of $\\mathbb{R}$ being Lebesgue measurable — in which model the Banach-Tarski paradox fails, confirming the Axiom of Choice is essential. In 1990, Miklós Laczkovich showed the disk can be 'squared' via translations only, but with infinitely many pieces — a different phenomenon, provable in ZF.",
@@ -216,7 +216,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 52,
+    "theoremCount": 8,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 1278,
     "assumptions": "1 axiom (conic_implies_pascal_constraint). 1 sorry in proof_sketch_conic_implies_pascal (pending Sylvester's law for the standard conic reduction).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 46
+    "theoremCount": 25
   },
   "overview": {
     "historicalContext": "Blaise Pascal discovered this theorem in 1639, at age 16, calling it the *Hexagrammum Mysticum* (Mystic Hexagram). His original proof, presented to the Académie Parisienne, was lost, but its statement was recorded by Leibniz, who found it among Pascal's papers. Pascal claimed to derive over 400 corollaries from this single result.\n\nThe theorem became a cornerstone of projective geometry, which was systematically developed by Jean-Victor Poncelet in his 1822 *Traité des propriétés projectives des figures*. Charles-Julien Brianchon discovered the dual theorem in 1806 as a student at the École Polytechnique: if a hexagon is circumscribed about a conic, the three main diagonals are concurrent.\n\nThe configuration of 60 Pascal lines arising from permutations of six points on a conic — the *Hexagrammum Mysticum* configuration — attracted major attention from Jakob Steiner (1828), Thomas Kirkman (1849), Arthur Cayley (1849), and George Salmon (1852), who discovered its remarkable incidence properties: 20 Steiner points, 60 Kirkman points, and 15 Plücker lines.\n\nPascal's theorem appears as #28 in Freek Wiedijk's list of 100 greatest theorems. The formalization here uses projective coordinates in $\\mathbb{R}^3$ with the cross product serving double duty for line-through and line-intersection, and the key algebraic identity axiomatized via the Cayley-Bacharach / Bézout argument.",
@@ -228,7 +228,7 @@
     "namespace": null,
     "lineCount": 1278,
     "axiomCount": 1,
-    "theoremCount": 46,
+    "theoremCount": 25,
     "definitionCount": 27,
     "path": "Proofs/PascalsHexagon.lean",
     "sorries": 1

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 1401,
     "assumptions": "No axioms, no sorries. Fully verified. Main theorem roth_density_bound proved via Mathlib's corners-theorem chain (Regularity Lemma → Triangle Removal → Corners → Roth). Fourier-analytic density increment infrastructure (Parts I-V) independently verified.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 42
+    "theoremCount": 12
   },
   "overview": {
     "historicalContext": "Roth's theorem, proved by Klaus Friedrich Roth in 1953, was a landmark achievement in number theory and combinatorics. It confirmed the k=3 case of the Erdos-Turan conjecture (1936) that every dense subset of the integers contains arithmetic progressions of any length.\n\nRoth introduced Fourier-analytic methods to additive combinatorics, a revolutionary approach that opened an entirely new toolbox. His key insight was the density increment strategy: if a set A of density delta in [N] has no 3-term AP, then there exists a long arithmetic progression P where A has density at least delta + c*delta^2. Iterating this increment (which can only happen O(1/delta) times before density exceeds 1) yields a contradiction.\n\nThe quantitative bounds have been dramatically improved over the decades: Bourgain (1999, 2008), Sanders (2011), and most recently Bloom and Sisask (2020) achieved r_3(N) = O(N/(log N)^{1+c}). In 2023, Kelley and Meka achieved the breakthrough bound r_3(N) = O(N * exp(-c * (log N)^{1/12})).\n\nRoth's theorem is the natural starting point for the Szemeredi program because it introduces the core techniques (Fourier analysis, density increment) in their simplest setting.",
@@ -219,7 +219,7 @@
     "namespace": "Szemeredi.Roth",
     "lineCount": 1401,
     "axiomCount": 0,
-    "theoremCount": 42,
+    "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/RothTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` in `meta.json` for 17 gallery proofs. The legacy enrichment pass counted private lemmas and `@[simp]`-attributed theorems using a broader pattern. All 17 are corrected to the canonical count: lines matching `^(theorem|lemma) ` at column 0 (matching `enrich-research.ts` convention).

## Evidence

For each proof, `grep -c "^theorem \|^lemma "` on the current Lean file gives a different value from both `meta.theoremCount` and `leanFile.theoremCount`.

| Proof | Before | After |
|-------|--------|-------|
| erdos-1109 | 151 | 92 |
| lebesgue-measure-oq-06 | 52 | 8 |
| hurwitz-theorem-oq-04 | 65 | 27 |
| roth-theorem-k3 | 42 | 12 |
| erdos-185 | 73 | 43 |
| erdos-919 | 40 | 17 |
| erdos-1129 | 30 | 6 |
| angle-trisection-cos-20-gal | 33 | 6 |
| angle-trisection-cos-20-gal-oq-01 | 32 | 5 |
| angle-trisection-cos-20-gal-oq-03 | 32 | 5 |
| angle-trisection-cos-20-gal-oq-03-oq-01 | 28 | 5 |
| pascals-hexagon | 46 | 25 |
| erdos-1012-oq-03 | 27 | 9 |
| erdos-278 | 29 | 12 |
| erdos-1179-oq-01 | 28 | 11 |
| erdos-1131 | 31 | 14 |
| erdos-1095-oq-01 | 37 | 21 |

Follows same pattern as PR #15448 (13 proofs) and PR #15441 (3 proofs).

---
Automated fix by lean-mechanic agent.