### PR TITLE
fix(meta): sync stale lineCount for 174 proofs (local imports not counted)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "",
-    "lineCount": 234,
+    "lineCount": 768,
     "theoremCount": 3,
     "definitionCount": 3,
     "originalContributions": [

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -75,7 +75,7 @@
   },
   "leanFile": {
     "namespace": "AbelRuffiniGaloisExtensionsOQ04",
-    "lineCount": 234,
+    "lineCount": 768,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 2,

--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -331,7 +331,7 @@
       "Cardinal"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02",
-    "lineCount": 192,
+    "lineCount": 621,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,

--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 192,
+    "lineCount": 621,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-04",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 138,
+    "lineCount": 226,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
@@ -134,7 +134,7 @@
       "BigOperators"
     ],
     "namespace": "AMGMInequalityOQ02OQ01OQ02",
-    "lineCount": 138,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -26,7 +26,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 1162,
     "assumptions": "1 axiom: newton_log_concavity (Newton's log-concavity of elementary symmetric polynomials, inherited from AmgmInequalityOQ02.lean). The maclaurin_step axiom is eliminated by this file — proved here as maclaurin_step_proved. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -137,7 +137,7 @@
       "AmgmInequalityOQ02"
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
-    "lineCount": 226,
+    "lineCount": 1162,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 225,
+    "lineCount": 597,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -188,7 +188,7 @@
       "Finset"
     ],
     "namespace": "PowerMeanCrossZero",
-    "lineCount": 225,
+    "lineCount": 597,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 242,
+    "lineCount": 558,
     "theoremCount": 8,
     "definitionCount": 5,
     "assumptions": "7 axioms: ellipticK (function), ellipticE (function), K_eq_pi_div_2M (Gauss's AGM theorem for k=1/√2), legendre_relation (Legendre's relation for k=1/√2), ellipticE_agm (E via AGM iteration), bs_summable (series convergence from quadratic AGM convergence), S_lt_half (series sum bound). The algebraic derivation π = 4M²/(1-2S) is machine-verified from these axioms.",

--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -150,7 +150,7 @@
       "Real"
     ],
     "namespace": "AmgmInequalityOQ04OQ05",
-    "lineCount": 242,
+    "lineCount": 558,
     "axiomCount": 7,
     "theoremCount": 8,
     "definitionCount": 3,

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
@@ -103,7 +103,7 @@
       "Proofs.AngleTrisectionCos20GalOQ01"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ01",
-    "lineCount": 182,
+    "lineCount": 1072,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 4,

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 182,
+    "lineCount": 1072,
     "assumptions": "No axioms, no sorries. Imports AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01; all key theorems reduce to those parent results via case-splitting.",
     "mathlib_version": "4.26.0",
     "historicalContext": "This entry answers the natural question raised by two near-identical proofs in the gallery: both AngleTrisectionCos20Gal (8X³−6X−1, the minimal polynomial of cos(20°)) and AngleTrisectionCos20GalOQ01 (8X³−4X²−4X+1, the minimal polynomial of cos(π/7)) have Galois groups of order 3, but each proof uses a different Eisenstein prime (p=2 vs p=7). The parameterized unification reveals the common structure: both belong to a family of cyclic cubics over ℚ reducible to Eisenstein form by a suitable linear substitution. The CyclicCubicData typeclass captures the common interface, providing a template extensible to other angles whose minimal polynomials are cyclic cubics.",

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 326,
+    "lineCount": 1216,
     "assumptions": "1 sorry: irreducibility of 4X²-2X-1 over ℚ (routine, provable via rational root theorem checking all candidates ±1, ±1/2, ±1/4). The theorem gal_order_eq_totient_div2_general proves a tautology (x = x by rfl) as a placeholder — it does not state the actual Galois order formula due to missing IsCyclotomicExtension infrastructure. All other theorems (splitting field degree 2, Galois order 2, Vieta identity, totient consistency checks) are genuinely proved.",
     "mathlib_version": "4.26.0",
     "historicalContext": "The angle trisection impossibility proof reduces to computing Galois groups of minimal polynomials of cosines. While the cubic cases (n=7, n=9) have been formalized, the quadratic case n=5 reveals a simplification: cos(π/5) has degree 2 over ℚ, and the Galois group formula φ(2n)/2 gives the correct answer 2. The proof is simpler than the cubic cases because the second root is just β = 1/2 - α (Vieta's: sum of roots = 1/2), avoiding the complex algebraic identities needed for cubics.",

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
@@ -98,7 +98,7 @@
       "Proofs.AngleTrisectionCos20GalOQ01"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ02",
-    "lineCount": 326,
+    "lineCount": 1216,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -59,7 +59,7 @@
       "galois_criterion_implies_degree_criterion: Bridges the Galois criterion (2-group Gal) to the degree criterion (degree = 2^k)"
     ],
     "dateAdded": "2026-03-21",
-    "lineCount": 115,
+    "lineCount": 481,
     "axiomCount": 0,
     "assumptions": "None. All 4 theorems fully proved from Mathlib and OQ-01 with 0 axioms and 0 sorries.",
     "prerequisites": [

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -268,7 +268,7 @@
       "Polynomial"
     ],
     "namespace": "AngleTrisectionOQ02OQ01",
-    "lineCount": 115,
+    "lineCount": 481,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 1,

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
@@ -66,7 +66,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. All theorems proved from Mathlib's cyclotomic polynomial and unit group infrastructure.",
-    "lineCount": 740,
+    "lineCount": 914,
     "prerequisites": [
       "Cyclotomic polynomials and their properties",
       "Unit group of ZMod n and its structure",

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
@@ -226,7 +226,7 @@
       "Polynomial"
     ],
     "namespace": "AngleTrisectionOQ02OQ03OQ01",
-    "lineCount": 740,
+    "lineCount": 914,
     "axiomCount": 0,
     "theoremCount": 32,
     "definitionCount": 9,

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1799,
+    "lineCount": 2539,
     "prerequisites": [
       "Euler's totient function and its basic properties",
       "Fermat primes and their characterization",

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -355,7 +355,7 @@
         "leanType": "(p : ℕ) → (hp : IsFermatPrime p) → (h3 : 3 ≤ p) → IsConstructibleNgon p"
       }
     ],
-    "lineCount": 1799,
+    "lineCount": 2539,
     "axiomCount": 0,
     "theoremCount": 158,
     "definitionCount": 5,

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -271,7 +271,7 @@
       "FiniteDimensional"
     ],
     "namespace": null,
-    "lineCount": 298,
+    "lineCount": 3545,
     "axiomCount": 1,
     "theoremCount": 21,
     "definitionCount": 1,

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -66,7 +66,7 @@
       "Field extensions and degree computations",
       "Compass-and-straightedge constructibility (from OQ-01)"
     ],
-    "lineCount": 298,
+    "lineCount": 3545,
     "relatedProblems": [
       {
         "id": "angle-trisection",

--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -44,7 +44,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 12,
-    "lineCount": 150,
+    "lineCount": 2558,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The import chain includes AngleTrisection.lean (1 axiom for π transcendence, used only for the circle-squaring result) but none of the theorems in this file depend on that axiom.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "AngleTrisectionOQ03"
     ],
     "namespace": "AngleTrisectionOQ03OQ01",
-    "lineCount": 150,
+    "lineCount": 2558,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 2,

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -99,7 +99,7 @@
       "Nat"
     ],
     "namespace": "AngleTrisectionOQ03OQ02",
-    "lineCount": 156,
+    "lineCount": 382,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 156,
+    "lineCount": 382,
     "theoremCount": 10
   },
   "overview": {

--- a/src/data/proofs/angle-trisection-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03/meta.json
@@ -48,7 +48,7 @@
     ],
     "dateAdded": "2026-03-29",
     "axiomCount": 0,
-    "lineCount": 226,
+    "lineCount": 2408,
     "prerequisites": [
       "IsConstructible definition (AngleTrisection.lean)",
       "Gauss-Wantzel theorem (AngleTrisectionOQ02OQ03.lean)",

--- a/src/data/proofs/angle-trisection-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03/meta.json
@@ -84,7 +84,7 @@
       "AngleTrisection"
     ],
     "namespace": "AngleTrisectionOQ03",
-    "lineCount": 226,
+    "lineCount": 2408,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,

--- a/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 328,
+    "lineCount": 927,
     "theoremCount": 55,
     "assumptions": "None. All 54 theorems proved. Pierpont prime verification via native_decide.",
     "mathlibDependencies": [

--- a/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
@@ -103,7 +103,7 @@
     ],
     "opens": [],
     "namespace": "AngleTrisectionOQ04OQ03",
-    "lineCount": 328,
+    "lineCount": 927,
     "axiomCount": 0,
     "theoremCount": 55,
     "definitionCount": 2,

--- a/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
@@ -17,7 +17,7 @@
       "AngleTrisectionOQ05OQ01"
     ],
     "namespace": "AngleTrisectionOQ04OQ04",
-    "lineCount": 152,
+    "lineCount": 1045,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -98,7 +98,7 @@
     ],
     "opens": [],
     "namespace": "AngleTrisection",
-    "lineCount": 383,
+    "lineCount": 1314,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 23,

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -67,7 +67,7 @@
       "Trigonometric identities (triple angle formula)",
       "Basic Galois theory (constructibility criterion)"
     ],
-    "lineCount": 383,
+    "lineCount": 1314,
     "relatedProblems": [
       {
         "id": "angle-trisection-oq-02",

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -165,7 +165,7 @@
       "UnitBallRecurrence"
     ],
     "namespace": "BallVolumeTendsto",
-    "lineCount": 163,
+    "lineCount": 313,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -55,7 +55,7 @@
       "Key insight for odd bound: 4π/(2k+3) ≤ 4π/(2k+2) (larger denominator → smaller fraction)"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 163,
+    "lineCount": 313,
     "prerequisites": [
       "Recurrence for ball volumes (parent proof)",
       "Convergence of exp series (Mathlib)",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
@@ -150,7 +150,7 @@
       "IsoperimetricOQ"
     ],
     "namespace": "LipschitzIsoperimetric",
-    "lineCount": 565,
+    "lineCount": 2503,
     "axiomCount": 2,
     "theoremCount": 15,
     "lemmaCount": 1,

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
@@ -22,7 +22,7 @@
     "sorries": 6,
     "axiomCount": 2,
     "theoremCount": 15,
-    "lineCount": 565,
+    "lineCount": 2503,
     "defCount": 4,
     "assumptions": "2 axioms: (1) wirtinger_ac — Wirtinger inequality for Lipschitz/AC 2π-periodic functions with zero mean: ∫f² ≤ ∫(f')²; (2) exists_lip_nice_reparam — arc-length reparametrization for Lipschitz curves with positive speed a.e., giving constant-speed and zero-mean reparametrization. 6 technical sorries remain: lip_x/lip_y (MVT bound for periodic C¹ → Lipschitz), hdx_int/hdy_int (derivative-squared integrability from LipschitzWith), harea_zero (area=0 from circumference=0), hf_int (integrability of xy'−yx' for Lipschitz curves).",
     "originalContributions": [

--- a/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
@@ -116,7 +116,7 @@
       "Proofs.AreaOfCircleOQ02"
     ],
     "namespace": "AreaOfCircleOQ02OQ01",
-    "lineCount": 163,
+    "lineCount": 374,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 374,
     "originalContributions": [
       "sqrt_pi_pow_eq: (√π)^n = π^(n/2) — bridge between Mathlib and unitBallVolume forms",
       "nball_volume_scaling_theorem: Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)) for n ≥ 1, provable from Mathlib",

--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -74,7 +74,7 @@
       "Proofs.AreaOfCircleOQ05"
     ],
     "namespace": "AreaOfCircleOQ05OQ01",
-    "lineCount": 231,
+    "lineCount": 363,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -30,7 +30,7 @@
       "Connection to circle area: angular=2π (circumference) × radial=1/2 gives π (area)"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 231,
+    "lineCount": 363,
     "theoremCount": 10,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
@@ -66,7 +66,7 @@
       "GaussianBinomial"
     ],
     "namespace": "qVandermondeProof",
-    "lineCount": 217,
+    "lineCount": 390,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Axiom-free and sorry-free.",
-    "lineCount": 217,
+    "lineCount": 390,
     "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -26,7 +26,7 @@
     "axiomCount": 0,
     "theoremCount": 30,
     "defCount": 5,
-    "lineCount": 507,
+    "lineCount": 911,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -199,7 +199,7 @@
       "MulAction"
     ],
     "namespace": "PolyaEnumeration",
-    "lineCount": 507,
+    "lineCount": 911,
     "axiomCount": 0,
     "theoremCount": 30,
     "definitionCount": 5,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
@@ -127,7 +127,7 @@
       "BigOperators"
     ],
     "namespace": "ArithmeticSeriesOQ02OQ03",
-    "lineCount": 163,
+    "lineCount": 372,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
@@ -17,7 +17,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 372,
     "assumptions": "0 axioms, 0 sorries. Fully verified: all 11 theorems proved from Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "mathlib_version": "4.26.0",
-    "lineCount": 78,
+    "lineCount": 666,
     "theoremCount": 2,
     "definitionCount": 0,
     "prerequisites": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
@@ -89,7 +89,7 @@
       "Finset"
     ],
     "namespace": "VandermondeDescFactorial",
-    "lineCount": 78,
+    "lineCount": 666,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -164,7 +164,7 @@
       "ArithmeticSeriesOQ02"
     ],
     "namespace": "ArithmeticSeriesOQ02OQ04",
-    "lineCount": 158,
+    "lineCount": 367,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -48,7 +48,7 @@
       "Ascending factorial",
       "Simplicial numbers"
     ],
-    "lineCount": 158,
+    "lineCount": 367,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -26,7 +26,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
-    "lineCount": 249,
+    "lineCount": 1296,
     "assumptions": ""
   },
   "overview": {

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -127,7 +127,7 @@
       "Proofs.BallotProblemOQ01OQ02"
     ],
     "namespace": "BallotFiberTransfer",
-    "lineCount": 249,
+    "lineCount": 1296,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -187,7 +187,7 @@
       "ChungFellerBijection"
     ],
     "namespace": "ChungFeller",
-    "lineCount": 73,
+    "lineCount": 1237,
     "axiomCount": 0,
     "theoremCount": 2,
     "substantiveTheoremCount": 1,

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -64,7 +64,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 73,
+    "lineCount": 1237,
     "assumptions": "0 axioms, 0 sorries. The previously stated axiom chung_feller_uniform is now a theorem re-exporting ChungFellerBijection.chung_feller_uniform' from BallotProblemOQ01OQ04OQ01.lean. The full proof spans three files: BallotProblemOQ01OQ04Core.lean (definitions and cycle-lemma bridge), BallotProblemOQ01OQ04OQ01.lean (explicit bijection), and BallotProblemOQ01OQ04.lean (gallery face).",
     "mathlib_version": "4.26.0",
     "theoremCount": 2

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 850,
+    "lineCount": 980,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 6,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum b≥2 — the general JDT seam bijection (~150-200 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 850,
+    "lineCount": 980,
     "theoremCount": 10,
     "definitionCount": 8,
     "originalContributions": [

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
@@ -71,7 +71,7 @@
       "Finset"
     ],
     "namespace": "BallotProblemLGVGeneral",
-    "lineCount": 130,
+    "lineCount": 2641,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01.lean",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 130,
+    "lineCount": 2641,
     "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -97,7 +97,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 398,
+    "lineCount": 14296,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
@@ -27,7 +27,7 @@
     ],
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "lineCount": 182,
+    "lineCount": 3104,
     "assumptions": "0 sorries. All proofs are complete. Uses Mathlib's catalan_succ' and catalan_eq_centralBinom_div as infrastructure.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
@@ -172,7 +172,7 @@
       "Finset"
     ],
     "namespace": "BallotProblemOQ03OQ01OQ04",
-    "lineCount": 182,
+    "lineCount": 3104,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
@@ -61,7 +61,7 @@
     ],
     "dateAdded": "2026-04-14",
     "axiomCount": 0,
-    "lineCount": 213,
+    "lineCount": 1338,
     "assumptions": "0 axioms, 0 sorries. The proof is fully verified from PrimeNumberTheorem (which carries 1 axiom for the PNT itself) and Mathlib's filter analysis library.",
     "mathlib_version": "4.26.0",
     "relatedProblems": [

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
@@ -185,7 +185,7 @@
       "PrimeNumberTheorem"
     ],
     "namespace": "BertrandsPostulateOQ03OQ04OQ03",
-    "lineCount": 213,
+    "lineCount": 1338,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BertrandsPostulateOQ03OQ04OQ03.lean",

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
@@ -234,7 +234,7 @@
       "BertrandsPostulateOQ03"
     ],
     "namespace": "BertrandsPostulateOQ03OQ04",
-    "lineCount": 357,
+    "lineCount": 1125,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BertrandsPostulateOQ03OQ04.lean",

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-04-05",
     "axiomCount": 1,
-    "lineCount": 357,
+    "lineCount": 1125,
     "assumptions": "1 axiom: shortIntervalPNT_rh_conditional — assuming the Riemann Hypothesis, the short interval density asymptotic π(x+h) - π(x) ~ h/ln(x) holds for h = x^(1/2+ε). 0 sorries.",
     "mathlib_version": "4.26.0",
     "relatedProblems": [

--- a/src/data/proofs/bertrands-postulate-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/meta.json
@@ -259,7 +259,7 @@
       "Real"
     ],
     "namespace": "BertrandsPostulateOQ03",
-    "lineCount": 308,
+    "lineCount": 510,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 2,

--- a/src/data/proofs/bertrands-postulate-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/meta.json
@@ -58,7 +58,7 @@
     ],
     "dateAdded": "2026-02-22",
     "axiomCount": 3,
-    "lineCount": 308,
+    "lineCount": 510,
     "assumptions": "3 axioms: (1) bhp_short_interval — Baker-Harman-Pintz short interval prime existence for intervals [x, x+h] with h ≥ x^0.525, (2) cramer_conjecture — Cramér's conjecture on maximal prime gaps O(log²p), (3) legendre_conjecture — a prime exists between n² and (n+1)² for all n ≥ 1.",
     "mathlib_version": "4.26.0",
     "relatedProblems": [

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -213,7 +213,7 @@
       "MvPolynomial"
     ],
     "namespace": "NotPID",
-    "lineCount": 192,
+    "lineCount": 319,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 4,

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All results from Mathlib's IsPrincipalIdealRing, Ideal.span, MvPolynomial typeclasses.",
     "dateAdded": "2026-04-24",
-    "lineCount": 192,
+    "lineCount": 319,
     "theoremCount": 10,
     "definitionCount": 3,
     "mathlibDependencies": [

--- a/src/data/proofs/bezout-identity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-02/meta.json
@@ -244,7 +244,7 @@
       "BezoutIdentityOQ03"
     ],
     "namespace": "BezoutIdentityOQ03OQ02",
-    "lineCount": 187,
+    "lineCount": 463,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 2,

--- a/src/data/proofs/bezout-identity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-02/meta.json
@@ -76,7 +76,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 187,
+    "lineCount": 463,
     "assumptions": "0 axioms, 0 sorries. Inductive proof reduces k-moduli case to (k-1)-moduli case + a single 2-moduli combination via crt_iscop.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6

--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 157,
+    "lineCount": 372,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -146,7 +146,7 @@
       "Nat"
     ],
     "namespace": "BinaryGcdOQ01OQ04",
-    "lineCount": 157,
+    "lineCount": 372,
     "axiomCount": 0,
     "theoremCount": 6,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -174,7 +174,7 @@
       "Nat"
     ],
     "namespace": "BinaryGcdOQ01",
-    "lineCount": 215,
+    "lineCount": 675,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 2,

--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -41,7 +41,7 @@
       "Concrete step counts via native_decide"
     ],
     "axiomCount": 0,
-    "lineCount": 215,
+    "lineCount": 675,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
     "prerequisites": [
       "Natural number GCD and divisibility",

--- a/src/data/proofs/binary-gcd-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02/meta.json
@@ -201,7 +201,7 @@
       "BinaryGcd"
     ],
     "namespace": "BinaryGcdOQ02",
-    "lineCount": 134,
+    "lineCount": 311,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 1,

--- a/src/data/proofs/binary-gcd-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-05-01",
     "axiomCount": 0,
-    "lineCount": 134,
+    "lineCount": 311,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -197,7 +197,7 @@
       "BigOperators"
     ],
     "namespace": "QMultinomialCoefficients",
-    "lineCount": 269,
+    "lineCount": 1019,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 12,

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 269,
+    "lineCount": 1019,
     "theoremCount": 12,
     "assumptions": "None. All results proved from Mathlib's q-binomial (Gaussian binomial) infrastructure in CombinationsFormulaOQ03.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 138,
+    "lineCount": 282,
     "theoremCount": 9,
     "definitionCount": 1,
     "assumptions": "1 axiom: buDim_le_formula (the open conjecture: buDim(n,d) ≤ max_{p|n} buDim(p,d)). Lower bound direction proved from buDim_mono in parent file. Specific cases n=4,6,9 proved. buDim function and known results axiomatized in parent file BorsukUlamOQ02OQ01.lean.",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -145,7 +145,7 @@
       "Proofs.BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamOQ02OQ01OQ01",
-    "lineCount": 138,
+    "lineCount": 282,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 1,

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 9,
-    "lineCount": 212,
+    "lineCount": 356,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
@@ -148,7 +148,7 @@
       "Nat"
     ],
     "namespace": "BorsukUlamNonCyclic",
-    "lineCount": 212,
+    "lineCount": 356,
     "axiomCount": 9,
     "theoremCount": 14,
     "substantiveTheoremCount": 10,

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -29,7 +29,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 2,
-    "lineCount": 389,
+    "lineCount": 2406,
     "assumptions": "2 axioms: minAdmissibleDiameter_50 (minimum diameter of admissible 50-tuple), diameter_upper_bound_exists (existence of diameter upper bound). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 23

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -142,7 +142,7 @@
       "BoundedPrimeGaps"
     ],
     "namespace": "BoundedPrimeGapsOQ03OQ01",
-    "lineCount": 389,
+    "lineCount": 2406,
     "axiomCount": 2,
     "theoremCount": 23,
     "definitionCount": 5,

--- a/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
@@ -229,7 +229,7 @@
       "Finset"
     ],
     "namespace": "BoundedPrimeGapsOQ03",
-    "lineCount": 279,
+    "lineCount": 2296,
     "axiomCount": 1,
     "theoremCount": 21,
     "definitionCount": 1,

--- a/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-02-25",
     "axiomCount": 1,
-    "lineCount": 279,
+    "lineCount": 2296,
     "assumptions": "1 axiom: engelsma_lower_bound (Engelsma's lower bound on diameter of optimal 50-tuple). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 21

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
@@ -131,7 +131,7 @@
     "imports": ["Mathlib", "Proofs.BoundedPrimeGaps", "Proofs.BoundedPrimeGapsOQ04"],
     "opens": ["Nat", "Finset", "BoundedPrimeGaps", "BoundedPrimeGapsOQ04", "ArithmeticFunction", "Filter"],
     "namespace": "BoundedPrimeGapsOQ04OQ02",
-    "lineCount": 599,
+    "lineCount": 2982,
     "axiomCount": 6,
     "theoremCount": 10,
     "definitionCount": 8,

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 599,
+    "lineCount": 2982,
     "theoremCount": 10,
     "assumptions": "6 axioms: gaussSumBound (|τ(χ)| = √q for primitive characters), polyaVinogradov (|Σ χ(n)| ≤ √q·log q), largeSieve (bilinear exponential sum bound), siegelWalfisz (ψ(x;q,a) = x/φ(q) + O(xe^{-c√log x}) for small q), vaughanIdentity (von Mangoldt decomposition into bilinear sums), zeroDensityEstimate (N(σ,T,χ) ≪ (qT)^{A(1-σ)}). These are proved theorems missing from Mathlib, not mathematical assumptions.",
     "originalContributions": [

--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -55,7 +55,7 @@
       "PolyaVinogradovHolds: key prerequisite statement",
       "BVPrerequisiteLayer: concrete 4-layer roadmap with estimates"
     ],
-    "lineCount": 366,
+    "lineCount": 2383,
     "erdosUrl": null,
     "dateAdded": "2026-03-27",
     "theoremCount": 12

--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -191,7 +191,7 @@
       "Filter"
     ],
     "namespace": "BoundedPrimeGapsOQ04",
-    "lineCount": 366,
+    "lineCount": 2383,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 10,

--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -311,7 +311,7 @@
       "Real"
     ],
     "namespace": "BoundedPrimeGaps",
-    "lineCount": 2017,
+    "lineCount": 2219,
     "axiomCount": 3,
     "theoremCount": 128,
     "definitionCount": 17,

--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -80,7 +80,7 @@
       "maynard_tao_sieve_eh: The EH-conditional sieve — under Elliott-Halberstam, any admissible 5-tuple of diameter D gives infinitely many prime gaps ≤ D",
       "engelsma_lower_bound: No admissible 50-tuple has diameter < 246 (Engelsma 2013 computer search)"
     ],
-    "lineCount": 2017,
+    "lineCount": 2219,
     "mathlib_version": "4.26.0",
     "theoremCount": 128
   },

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -146,7 +146,7 @@
       "Proofs.BrouwerFixedPointOQ04"
     ],
     "namespace": "NashBrouwer",
-    "lineCount": 519,
+    "lineCount": 1024,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -36,7 +36,7 @@
     "proofStrategy": "Define Nash's deviation map: for each player i and pure strategy k, compute the excess payoff from deviating to pure strategy k; shift weight toward strategies with positive excess, then normalize. This map is continuous (polynomial in strategy profiles) and maps the product simplex to itself. Brouwer FPT gives a fixed point, and the algebra of the fixed-point equation shows all excesses are zero — i.e., no player can improve by deviating.",
     "assumptions": "1 axiom: brouwer_pi_compact_convex (in BrouwerFixedPointOQ04.lean — general Brouwer FPT for products of compact convex sets in finite-dimensional Euclidean spaces). This file has 0 direct axioms; brouwer_product_simplex is now a theorem proved from the general axiom using mixed_strategy_nonempty, mixed_strategy_compact, and mixed_strategy_convex.",
     "axiomCount": 1,
-    "lineCount": 519,
+    "lineCount": 1024,
     "theoremCount": 15,
     "definitionCount": 8
   },

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
@@ -150,7 +150,7 @@
       "Proofs.BrouwerFixedPointOQ04OQ03"
     ],
     "namespace": "KakutaniConstructive",
-    "lineCount": 405,
+    "lineCount": 1066,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 2,

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-12",
     "dateUpdated": "2026-04-12",
     "axiomCount": 1,
-    "lineCount": 405,
+    "lineCount": 1066,
     "theoremCount": 12,
     "defCount": 2,
     "assumptions": "1 axiom (scarf_approx_fixed_point — Scarf's n-dimensional algorithm via Sperner's lemma, with full proof sketch). 0 sorries.",

--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -205,7 +205,7 @@
       "Filter"
     ],
     "namespace": "KakutaniFPT",
-    "lineCount": 505,
+    "lineCount": 754,
     "axiomCount": 2,
     "theoremCount": 22,
     "definitionCount": 11,

--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -53,7 +53,7 @@
     ],
     "historicalContext": "Shizuo Kakutani (1941) proved this generalization of Brouwer's theorem. John Nash (1950) used it to prove the existence of Nash equilibria, earning the Nobel Prize in Economics (1994). The theorem is essential in mathematical economics (Arrow-Debreu general equilibrium) and optimal control (Filippov's lemma).",
     "axiomCount": 2,
-    "lineCount": 505,
+    "lineCount": 754,
     "assumptions": "2 axioms: kakutani_fixed_point_axiom (Kakutani fixed-point theorem for compact convex sets in ℝⁿ) and brouwer_pi_compact_convex (Brouwer FPT for products of compact convex sets — requires Schoenflies-type theorem not yet in Mathlib). 0 sorries.",
     "theoremCount": 22
   },

--- a/src/data/proofs/buffons-needle-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01/meta.json
@@ -216,7 +216,7 @@
       "BuffonsNeedleOQ01OQ01"
     ],
     "namespace": "BuffonsNeedleOQ01",
-    "lineCount": 250,
+    "lineCount": 640,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,

--- a/src/data/proofs/buffons-needle-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01/meta.json
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2026-02-25",
     "axiomCount": 0,
-    "lineCount": 250,
+    "lineCount": 640,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
@@ -77,7 +77,7 @@
       "not_gch_from_intermediate: intermediate cardinals imply ¬GCH"
     ],
     "axiomCount": 0,
-    "lineCount": 303,
+    "lineCount": 698,
     "assumptions": "0 axioms. Former axioms easton_consistent_values, martins_axiom_neutral_on_ch, pfa_implies_not_ch removed. Inherits axioms from ContinuumHypothesis.lean for Gödel/Cohen independence.",
     "theoremCount": 14
   },

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "Cardinal"
     ],
     "namespace": "CantorDiagOQ01OQ01",
-    "lineCount": 303,
+    "lineCount": 698,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -145,7 +145,7 @@
     ],
     "opens": ["Cardinal", "ContinuumHypothesis"],
     "namespace": "CantorDiagOQ01OQ02",
-    "lineCount": 306,
+    "lineCount": 701,
     "axiomCount": 7,
     "theoremCount": 14,
     "definitionCount": 9,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": null,
     "axiomCount": 7,
     "assumptions": "7 axioms: levy_solovay_inaccessible_ch (Lévy-Solovay 1967: inaccessible + CH consistent), levy_solovay_inaccessible_not_ch (Lévy-Solovay 1967: inaccessible + ¬CH consistent), levy_solovay_measurable_ch (Lévy-Solovay: measurable + CH consistent), levy_solovay_measurable_not_ch (Lévy-Solovay: measurable + ¬CH consistent), mm_consistent (Foreman-Magidor-Shelah 1988: MM consistent with ZFC+supercompact), ma_consistent (Martin-Solovay: MA consistent with ZFC), ultimate_l_implies_ch_consistent (Woodin program: open).",
-    "lineCount": 306,
+    "lineCount": 701,
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
     "originalContributions": [

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2026-02-22",
     "axiomCount": 2,
-    "lineCount": 442,
+    "lineCount": 1012,
     "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 28

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -226,7 +226,7 @@
       "Cardinal"
     ],
     "namespace": "CantorDiagonalizationOQ01",
-    "lineCount": 442,
+    "lineCount": 1012,
     "axiomCount": 2,
     "theoremCount": 28,
     "definitionCount": 5,

--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
@@ -139,7 +139,7 @@
       "Cardinal"
     ],
     "namespace": "CantorsTheoremOQ01OQ01",
-    "lineCount": 171,
+    "lineCount": 443,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 2,

--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 171,
+    "lineCount": 443,
     "assumptions": "0 axioms, 0 sorries. Core cardinal facts via Mathlib (Cardinal.cantor, mk_set, aleph_one_le_continuum) and parent file CantorsTheoremOQ01.lean (CH/GCH definitions, conditional results). The main equivalence theorem has no hypotheses; CH and GCH appear as logical propositions in the iff statement rather than as axioms.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -152,7 +152,7 @@
       "PowerMeanCrossZero"
     ],
     "namespace": "PowerMeanMonotone",
-    "lineCount": 193,
+    "lineCount": 790,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 193,
+    "lineCount": 790,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
@@ -51,7 +51,7 @@
     ],
     "dateAdded": "2026-03-27",
     "axiomCount": 0,
-    "lineCount": 262,
+    "lineCount": 400,
     "assumptions": "No axioms. All results proved from Mathlib's inner product space API.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
@@ -137,7 +137,7 @@
       "InnerProductSpace"
     ],
     "namespace": "CauchySchwarzOQ01OQ02",
-    "lineCount": 262,
+    "lineCount": 400,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 4,

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -122,7 +122,7 @@
             "Polynomial"
         ],
         "namespace": "CayleyHamiltonCyclicVectorAllFields",
-        "lineCount": 268,
+        "lineCount": 627,
         "axiomCount": 0,
         "theoremCount": 3,
         "definitionCount": 2,

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -22,7 +22,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "theoremCount": 3,
-        "lineCount": 268,
+        "lineCount": 627,
         "assumptions": "",
         "mathlib_version": "4.26.0",
         "mathlibDependencies": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -79,7 +79,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 345,
+    "lineCount": 615,
     "assumptions": "None. All theorems fully proved. matrix_nonderogatory_implies_module uses the parent proof (CayleyHamiltonMinpolyOQ05OQ01). The incorrect structure_theorem_cyclic_iff was replaced with minpoly_minimal_degree (proved via minpoly.dvd).",
     "mathlib_version": "4.26.0",
     "theoremCount": 19

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -165,7 +165,7 @@
       "Polynomial"
     ],
     "namespace": "NonderogatoryModule",
-    "lineCount": 345,
+    "lineCount": 615,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 6,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 190,
+    "lineCount": 549,
     "assumptions": "None. Axiom-free. Imports WIP04 (which is itself axiom-free) and adds UFD factorization to remove the factored-form hypothesis.",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
@@ -202,7 +202,7 @@
       "GeneralCyclicVector"
     ],
     "namespace": "GeneralCyclicVectorComplete",
-    "lineCount": 190,
+    "lineCount": 549,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
@@ -147,7 +147,7 @@
       "Real"
     ],
     "namespace": "ChebyshevPNTBridgeOQ02",
-    "lineCount": 173,
+    "lineCount": 1110,
     "axiomCount": 0,
     "theoremCount": 5,
     "substantiveTheoremCount": 4,

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 173,
+    "lineCount": 1110,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 5
   },

--- a/src/data/proofs/chebyshev-pnt-bridge/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/meta.json
@@ -112,7 +112,7 @@
   ],
   "leanFile": {
     "namespace": "ChebyshevPNTBridge",
-    "lineCount": 264,
+    "lineCount": 703,
     "path": "Proofs/ChebyshevPNTBridge.lean",
     "axiomCount": 0,
     "theoremCount": 9,

--- a/src/data/proofs/chebyshev-pnt-bridge/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "None. All results fully verified from Mathlib.",
-    "lineCount": 264,
+    "lineCount": 703,
     "theoremCount": 9,
     "definitionCount": 2,
     "originalContributions": [

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
@@ -144,7 +144,7 @@
       "ChineseRemainderNonCoprimeOQ03"
     ],
     "namespace": "ChineseRemainderNonCoprimeList",
-    "lineCount": 216,
+    "lineCount": 607,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 5,

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
@@ -62,7 +62,7 @@
     ],
     "dateAdded": "2026-03-29",
     "axiomCount": 0,
-    "lineCount": 216,
+    "lineCount": 607,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Works over any EuclideanDomain.",
     "theoremCount": 10

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 249,
+    "lineCount": 557,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
@@ -160,7 +160,7 @@
       "Nat"
     ],
     "namespace": "ChineseRemainderNonCoprimeOQ01OQ01",
-    "lineCount": 249,
+    "lineCount": 557,
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 1,

--- a/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 213,
+    "lineCount": 469,
     "assumptions": "1 axiom: eliahou_cycle_bound — Eliahou (1993) proved any non-trivial Collatz cycle has period > 17 billion (Discrete Math 118:45–56). Fully machine-verified results: j=1 uniqueness theorem, halving bounds j=5..8, minimum cycle lengths, case complexity lower bound.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
@@ -137,7 +137,7 @@
       "Proofs.CollatzCycles"
     ],
     "namespace": "CollatzCyclesOQ01",
-    "lineCount": 213,
+    "lineCount": 469,
     "axiomCount": 1,
     "theoremCount": 16,
     "path": "Proofs/CollatzStructuredOQ02OQ01.lean",

--- a/src/data/proofs/continuum-hypothesis-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/meta.json
@@ -173,7 +173,7 @@
       "gch_implies_ch)"
     ],
     "namespace": "ContinuumHypothesisOQ01",
-    "lineCount": 317,
+    "lineCount": 712,
     "axiomCount": 10,
     "theoremCount": 20,
     "definitionCount": 3,

--- a/src/data/proofs/continuum-hypothesis-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/meta.json
@@ -55,7 +55,7 @@
     ],
     "dateAdded": "2026-02-22",
     "axiomCount": 10,
-    "lineCount": 317,
+    "lineCount": 712,
     "assumptions": "10 axioms: VeqL, VeqL_implies_GCH, UltimateL, UltimateL_implies_GCH, PFA, PFA_implies_continuum_eq_aleph_two, MM, MM_implies_PFA, VeqL_incompatible_with_measurable, PFA_large_cardinal_compatible. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 20

--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -70,7 +70,7 @@
     ],
     "dateAdded": "2026-03-27",
     "axiomCount": 2,
-    "lineCount": 584,
+    "lineCount": 1296,
     "assumptions": "2 axioms: bounding_number_uncountable, MA_implies_b_eq_continuum. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 32

--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -180,7 +180,7 @@
       "ContinuumHypothesis"
     ],
     "namespace": "ContinuumHypothesisOQ02",
-    "lineCount": 584,
+    "lineCount": 1296,
     "axiomCount": 2,
     "theoremCount": 32,
     "definitionCount": 6,

--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -46,7 +46,7 @@
       "Topology"
     ],
     "namespace": "DerangementsNearestInt",
-    "lineCount": 147,
+    "lineCount": 429,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked, building on the alternating series rate bound from DerangementsConvergence.lean.",
     "dateAdded": "2026-05-03",
-    "lineCount": 147,
+    "lineCount": 429,
     "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -142,7 +142,7 @@
       "Topology"
     ],
     "namespace": "KFixedConvergence",
-    "lineCount": 152,
+    "lineCount": 791,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked. The derangements_rate lemma delegates to derangements_convergence_rate from DerangementsConvergence.lean, which proves |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
     "dateAdded": "2026-04-04",
-    "lineCount": 152,
+    "lineCount": 791,
     "theoremCount": 7,
     "definitionCount": 1,
     "originalContributions": [

--- a/src/data/proofs/derangements-convergence-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. The theorem is fully machine-checked. The proof delegates the rate bound to derangements_convergence_rate from DerangementsConvergence.lean, which establishes |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
     "dateAdded": "2026-04-24",
-    "lineCount": 88,
+    "lineCount": 370,
     "theoremCount": 2,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/derangements-convergence-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03/meta.json
@@ -174,7 +174,7 @@
       "Topology"
     ],
     "namespace": "DerangementsConvergenceOQ03",
-    "lineCount": 88,
+    "lineCount": 370,
     "axiomCount": 0,
     "theoremCount": 2,
     "substantiveTheoremCount": 1,

--- a/src/data/proofs/derangements-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-01/meta.json
@@ -217,7 +217,7 @@
       "Equiv.Perm"
     ],
     "namespace": "PartialDerangementsGeneral",
-    "lineCount": 123,
+    "lineCount": 480,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/derangements-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-01/meta.json
@@ -58,7 +58,7 @@
     ],
     "dateAdded": "2026-03-11",
     "axiomCount": 0,
-    "lineCount": 123,
+    "lineCount": 480,
     "assumptions": "0 axioms, 0 sorries. Main result transported from Fin n via Fintype.equivFin and permutation conjugation from parent entry.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-04-03",
     "axiomCount": 1,
-    "lineCount": 328,
+    "lineCount": 602,
     "theoremCount": 29
   },
   "overview": {

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -142,7 +142,7 @@
       "DissectionOfCubesOQ01"
     ],
     "namespace": "DissectionOfCubesOQ01OQ01",
-    "lineCount": 328,
+    "lineCount": 602,
     "axiomCount": 0,
     "theoremCount": 29,
     "definitionCount": 5,

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
@@ -51,7 +51,7 @@
       "volume_constraint_satisfiable: explicit witness (one unit cube)"
     ],
     "dateAdded": "2026-05-03",
-    "lineCount": 256,
+    "lineCount": 896,
     "theoremCount": 14
   },
   "overview": {

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
@@ -126,7 +126,7 @@
       "BigOperators"
     ],
     "namespace": "DissectionOfCubesOQ01OQ03",
-    "lineCount": 256,
+    "lineCount": 896,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 2,

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-02-23",
     "axiomCount": 2,
-    "lineCount": 274,
+    "lineCount": 640,
     "assumptions": "2 axioms inherited from DissectionOfCubes.lean: smaller_cube_above_axiom (the geometric descent axiom: smallest cube on floor has smaller cube above), all_different_implies_long_chains_axiom (all-different sizes implies infinite descending chains). 0 own axioms. 0 sorries.",
     "theoremCount": 5
   },

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -140,7 +140,7 @@
       "DissectionOfCubes"
     ],
     "namespace": "DissectionOfCubesOQ01",
-    "lineCount": 274,
+    "lineCount": 640,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 4,

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -55,7 +55,7 @@
       "Dehn-Sydler completeness theorem statement",
       "tmul_infinite_order_ne_zero: proved via Module.Flat (ℝ flat over ℤ as Bézout + NoZeroSMulDivisors) — lTensor ℝ f injective for injective f : ℤ →ₗ AngleQuot"
     ],
-    "lineCount": 454,
+    "lineCount": 833,
     "assumptions": "0 axioms. All assumptions eliminated. tmul_infinite_order_ne_zero proved via Module.Flat: ℝ is flat over ℤ (Bézout domain + NoZeroSMulDivisors ℤ ℝ), so lTensor ℝ f is injective for any injective f : ℤ →ₗ[ℤ] AngleQuot, giving r⊗x≠0 when r≠0 and x has infinite order. Previously 6 axioms; all eliminated across sessions.",
     "mathlib_version": "4.26.0",
     "wiedijkNumber": 37,

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -251,7 +251,7 @@
       "Real"
     ],
     "namespace": "DehnSydler",
-    "lineCount": 454,
+    "lineCount": 833,
     "axiomCount": 0,
     "theoremCount": 24,
     "definitionCount": 7,

--- a/src/data/proofs/dissection-of-cubes-oq-02-wip-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-wip-01/meta.json
@@ -142,7 +142,7 @@
       "Proofs.DissectionOfCubesOQ02"
     ],
     "namespace": "DissectionOfCubesOQ02WIP01",
-    "lineCount": 103,
+    "lineCount": 482,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 3,

--- a/src/data/proofs/dissection-of-cubes-oq-02-wip-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-wip-01/meta.json
@@ -46,7 +46,7 @@
       "Proves tetra_dehn_ne_zero: D(tetrahedron) = 6 ⊗ [arccos(1/3)] ≠ 0 since arccos(1/3) ∉ πℚ",
       "Proves dehn_invariants_differ: the cube and regular tetrahedron have distinct tensor product Dehn invariants"
     ],
-    "lineCount": 103,
+    "lineCount": 482,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. The proof uses Classical.choice (standard Lean axiom) via Module.Free.chooseBasis to construct a separating ℚ-linear functional; this is not a mathematical axiom but a foundational logic axiom present in all Lean proofs. The irrationality of arccos(1/3)/π is inherited from tetrahedron_angle_irrational_pi in the parent file (DissectionOfCubesOQ02.lean), which is fully proved via Chebyshev recurrence.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -82,7 +82,7 @@
       "Proofs.DivisibilityByThreeOQ01"
     ],
     "namespace": "DivisibilityByThreeOQ01OQ02",
-    "lineCount": 202,
+    "lineCount": 752,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 1,

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -30,7 +30,7 @@
       "digitalRoot_is_fixed_point: digitSum(digitalRoot n) = digitalRoot n (fixed point property)"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 202,
+    "lineCount": 752,
     "theoremCount": 14,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -17,7 +17,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 142,
+    "lineCount": 534,
     "originalContributions": [
       "dvd_iff_dvd_altDigitSum: general alternating block divisibility rule",
       "seven_dvd_iff_altDigitSum: 7 | n iff 7 | alternating sum of 3-digit blocks",

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -51,7 +51,7 @@
       "Proofs.DivisibilityRules"
     ],
     "namespace": "DivisibilityRulesOQ02",
-    "lineCount": 142,
+    "lineCount": 534,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -64,7 +64,7 @@
     ],
     "dateAdded": "2026-02-23",
     "axiomCount": 1,
-    "lineCount": 538,
+    "lineCount": 1299,
     "assumptions": "1 axiom: nesterenko_algebraic_independence (Nesterenko 1996: π, e^π, Γ(1/4) are algebraically independent over ℚ). Former open problem axioms schanuel_conjecture, e_plus_pi_transcendental, e_times_pi_transcendental, e_plus_pi_irrational now proved as theorems from Nesterenko's theorem.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -209,7 +209,7 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 538,
+    "lineCount": 1299,
     "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 2,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
@@ -12,7 +12,7 @@
       "Nat"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 267,
+    "lineCount": 490,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
@@ -77,7 +77,7 @@
       "kronecker_neg_modulus: negating the modulus introduces/removes the sign character",
       "kroneckerNeg1_sq: the sign character is an involution"
     ],
-    "lineCount": 267,
+    "lineCount": 490,
     "theoremCount": 6
   },
   "sections": [

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 268,
+    "lineCount": 417,
     "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen anticoncentration for subset sums). dfx_lower_bound and pow2_dss proved in 2026-04-26 commit. sum_sq_cauchy_schwarz proved via induction in Z.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -210,7 +210,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 268,
+    "lineCount": 417,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -154,7 +154,7 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ03",
-    "lineCount": 249,
+    "lineCount": 398,
     "axiomCount": 0,
     "theoremCount": 24,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -38,7 +38,7 @@
       "Conway-Guy optimality conjecture statement"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 249,
+    "lineCount": 398,
     "theoremCount": 24,
     "definitionCount": 3,
     "prerequisites": [

--- a/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
@@ -46,7 +46,7 @@
     "erdosNumber": 100,
     "proofRepoPath": "Proofs/Erdos100OQ02OQ02.lean",
     "axiomCount": 0,
-    "lineCount": 104,
+    "lineCount": 586,
     "assumptions": "0 own axioms. Inherits 2 axioms from Erdos100Problem.lean: guthKatz_distinct_distances (Guth-Katz 2015) and piepmeyer_construction. Uses diam_ge_n_over_log_n (proved theorem in parent). 0 sorries.",
     "theoremCount": 2
   },

--- a/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
@@ -134,7 +134,7 @@
       "Filter"
     ],
     "namespace": "Erdos100OQ02OQ02",
-    "lineCount": 104,
+    "lineCount": 586,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -114,7 +114,7 @@
       "Set"
     ],
     "namespace": "Erdos100OQ02",
-    "lineCount": 60,
+    "lineCount": 542,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -30,7 +30,7 @@
     "erdosNumber": 100,
     "proofRepoPath": "Proofs/Erdos100OQ02.lean",
     "axiomCount": 2,
-    "lineCount": 60,
+    "lineCount": 542,
     "assumptions": "2 axioms inherited from Erdos100Problem.lean: guthKatz_distinct_distances (Guth-Katz 2015 Ω(n/log n) distinct distances bound), piepmeyer_construction (construction showing sharpness). 0 own axioms. 0 sorries.",
     "theoremCount": 2
   },

--- a/src/data/proofs/erdos-1006-oq-04/meta.json
+++ b/src/data/proofs/erdos-1006-oq-04/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1006",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 410,
     "theoremCount": 11,
     "assumptions": "None. All 11 theorems are fully proved. Builds on coloringOrientation definition and acyclicity results from OQ03.",
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1006-oq-04/meta.json
+++ b/src/data/proofs/erdos-1006-oq-04/meta.json
@@ -117,7 +117,7 @@
     ],
     "opens": ["SimpleGraph"],
     "namespace": "Erdos1006OQ04",
-    "lineCount": 163,
+    "lineCount": 410,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -38,7 +38,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
-    "lineCount": 141,
+    "lineCount": 270,
     "mathlib_version": "4.26.0",
     "assumptions": "4 axioms inherited from Erdos1007Problem.lean: hasUnitEmbedding_exists (unit-distance graph embeddability), min_edges_dimension_4 (minimum edges in 4D unit-distance graph), k33_unique_minimum (K₃,₃ is unique minimum in dimension 3), min_edges_dimension_5 (minimum edges in 5D). 0 own axioms. 0 sorries.",
     "theoremCount": 4

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -133,7 +133,7 @@
       "Finset"
     ],
     "namespace": "Erdos1007OQ05",
-    "lineCount": 141,
+    "lineCount": 270,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1014-oq-01/meta.json
+++ b/src/data/proofs/erdos-1014-oq-01/meta.json
@@ -137,7 +137,7 @@
       "Classical"
     ],
     "namespace": "Erdos1014OQ01",
-    "lineCount": 365,
+    "lineCount": 992,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-1014-oq-01/meta.json
+++ b/src/data/proofs/erdos-1014-oq-01/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-24",
     "axiomCount": 1,
-    "lineCount": 365,
+    "lineCount": 992,
     "assumptions": "1 axiom: R3_lower_bound (Kim-Shearer lower bound R(3,l) ≥ c·l²/log l). The Ramsey number is now defined via Nat.find from RamseysTheorem.lean. Properties (positivity, monotonicity, recurrence, R(2,l)=l) are proved from the definition.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12

--- a/src/data/proofs/erdos-1015-oq-05/meta.json
+++ b/src/data/proofs/erdos-1015-oq-05/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 353,
+    "lineCount": 980,
     "assumptions": "No axioms in this file. All theorems proved from RamseysTheorem.lean. Eliminates 2 of the 8 parent axioms (ramseyNumber definition and ramsey_upper_bound).",
     "mathlib_version": "4.26.0",
     "theoremCount": 14

--- a/src/data/proofs/erdos-1015-oq-05/meta.json
+++ b/src/data/proofs/erdos-1015-oq-05/meta.json
@@ -133,7 +133,7 @@
       "Finset"
     ],
     "namespace": "Erdos1015OQ05",
-    "lineCount": 353,
+    "lineCount": 980,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -128,7 +128,7 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 335,
+    "lineCount": 653,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 3,
     "axiomCount": 1,
     "theoremCount": 11,
-    "lineCount": 335,
+    "lineCount": 653,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 3 sorries in this file (geometric edge-crossing verifications).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 4,
     "axiomCount": 2,
-    "lineCount": 191,
+    "lineCount": 432,
     "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 4 sorries in dependency chain: 4 in this file + 2 in parent Erdos1021Problem.lean (k3_case_solved, trivial_bound).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -126,7 +126,7 @@
       "Proofs.Erdos1021Problem"
     ],
     "namespace": "Erdos1021OQ01",
-    "lineCount": 191,
+    "lineCount": 432,
     "axiomCount": 2,
     "theoremCount": 8,
     "path": "Proofs/Erdos1021OQ01.lean",

--- a/src/data/proofs/erdos-1027-oq-01/meta.json
+++ b/src/data/proofs/erdos-1027-oq-01/meta.json
@@ -148,7 +148,7 @@
       "Erdos1027"
     ],
     "namespace": "Erdos1027.UnionBound",
-    "lineCount": 183,
+    "lineCount": 536,
     "axiomCount": 0,
     "theoremCount": 5,
     "substantiveTheoremCount": 4,

--- a/src/data/proofs/erdos-1027-oq-01/meta.json
+++ b/src/data/proofs/erdos-1027-oq-01/meta.json
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 183,
+    "lineCount": 536,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved: card_subsets_missing, card_subsets_containing, card_bad_bound, good_set_lower_bound, property_b_from_union_bound.",
     "theoremCount": 5
   },

--- a/src/data/proofs/erdos-1027-oq-03/meta.json
+++ b/src/data/proofs/erdos-1027-oq-03/meta.json
@@ -141,7 +141,7 @@
       "ProbMethod.LovaszLocal"
     ],
     "namespace": "Erdos1027.Constructive",
-    "lineCount": 308,
+    "lineCount": 672,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-1027-oq-03/meta.json
+++ b/src/data/proofs/erdos-1027-oq-03/meta.json
@@ -24,7 +24,7 @@
     "mathlib_version": "4.29.0",
     "axiomCount": 0,
     "assumptions": "No axioms. All 17 theorems proved from Mathlib and the existing LLL infrastructure (LovaszLocalLemma.lean). No dependency on axiomatized results.",
-    "lineCount": 308,
+    "lineCount": 672,
     "relatedProblems": [
       {
         "id": "erdos-1027",

--- a/src/data/proofs/erdos-105-oq-02/meta.json
+++ b/src/data/proofs/erdos-105-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 288,
+    "lineCount": 593,
     "assumptions": "3 axioms: threshold_lower_bound (Beck-SzTr 1983), threshold_upper_bound (Xichuan 2024 + Hickerson), threshold_gap_axiom (Xichuan 2024). All are established mathematical results.",
     "dateAdded": "2026-04-13",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-105-oq-02/meta.json
+++ b/src/data/proofs/erdos-105-oq-02/meta.json
@@ -160,7 +160,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos105OQ02",
-    "lineCount": 288,
+    "lineCount": 593,
     "axiomCount": 3,
     "theoremCount": 20,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -52,7 +52,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 206,
+    "lineCount": 511,
     "assumptions": "2 axioms inherited from Erdos105Problem.lean: xichuan_counterexample (Xichuan's counterexample), beck_szemeredi_trotter_positive (positive result via Szemerédi-Trotter). 0 own axioms. 0 sorries. The previous transitive `axiom thresholdFunction` was replaced with a real `noncomputable def` in the parent Erdos105Problem.lean.",
     "theoremCount": 4
   },

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -184,7 +184,7 @@
       "Set"
     ],
     "namespace": "Erdos105OQ05",
-    "lineCount": 206,
+    "lineCount": 511,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -69,7 +69,7 @@
       "Sieve theory: Selberg sieve, Brun-Titchmarsh inequality (motivational)",
       "Finset operations: filter, card, sum, sum splitting"
     ],
-    "lineCount": 434,
+    "lineCount": 1231,
     "relatedProblems": [
       {
         "id": "erdos-1059-oq-01",

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -165,7 +165,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 434,
+    "lineCount": 1231,
     "namespace": "Erdos1059OQ01OQ01",
     "opens": [
       "Nat"

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -83,7 +83,7 @@
       "Finset operations for counting",
       "Floor binary logarithm (Nat.log) and its monotonicity properties"
     ],
-    "lineCount": 566,
+    "lineCount": 797,
     "relatedProblems": [
       {
         "id": "erdos-1059",

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -188,7 +188,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 566,
+    "lineCount": 797,
     "namespace": "Erdos1059OQ01",
     "opens": [],
     "structureCount": 0,

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 11,
-    "lineCount": 293,
+    "lineCount": 1369,
     "assumptions": "1 axiom: erdos_1131_variance_conjecture (variance form of Erdős #1131 conjecture).",
     "parentProof": "erdos-1131",
     "prerequisites": [

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -112,7 +112,7 @@
     "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 11,
-    "lineCount": 293,
+    "lineCount": 1369,
     "mainTheorems": [
       {
         "name": "variance_identity",

--- a/src/data/proofs/erdos-1146/meta.json
+++ b/src/data/proofs/erdos-1146/meta.json
@@ -230,7 +230,7 @@
       "Erdos37"
     ],
     "namespace": "Erdos1146",
-    "lineCount": 287,
+    "lineCount": 655,
     "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-1146/meta.json
+++ b/src/data/proofs/erdos-1146/meta.json
@@ -68,7 +68,7 @@
       "additive-number-theory",
       "mann-theorem"
     ],
-    "lineCount": 287,
+    "lineCount": 655,
     "assumptions": "2 axioms: smooth23_not_lacunary (deep result about ratios of smooth numbers with only 2 and 3 prime factors), smooth23_schnirelmann_zero (Schnirelmann density of smooth numbers is 0). 0 sorries.",
     "theoremCount": 13
   },

--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/152",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 319,
+    "lineCount": 789,
     "assumptions": "None. All results fully proved. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6

--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -100,7 +100,7 @@
       "Pointwise"
     ],
     "namespace": null,
-    "lineCount": 319,
+    "lineCount": 789,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -59,7 +59,7 @@
       "ramseyC4Kn_ge theorem: trivial lower bound R ≥ n proved from specification (was axiom)"
     ],
     "axiomCount": 0,
-    "lineCount": 282,
+    "lineCount": 909,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "theoremCount": 10
   },

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -164,7 +164,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 282,
+    "lineCount": 909,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/234",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 510,
+    "lineCount": 7104,
     "assumptions": "2 axioms: gallagher_conditional (RH→exponential distribution), average_normalized_gap (PNT). Previously 5 axioms: density_at_infinity proved via Markov, small_gaps_exist proved via Cesàro contrapositive, large_gaps_exist proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 28

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -184,7 +184,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 510,
+    "lineCount": 7104,
     "axiomCount": 2,
     "theoremCount": 28,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-247/meta.json
+++ b/src/data/proofs/erdos-247/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/247",
     "erdosProblemStatus": "partially-solved",
     "axiomCount": 1,
-    "lineCount": 506,
+    "lineCount": 1034,
     "assumptions": "1 axiom: erdos_transcendence_strong. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 27

--- a/src/data/proofs/erdos-247/meta.json
+++ b/src/data/proofs/erdos-247/meta.json
@@ -134,7 +134,7 @@
     ],
     "opens": [],
     "namespace": "Erdos247",
-    "lineCount": 506,
+    "lineCount": 1034,
     "axiomCount": 1,
     "theoremCount": 27,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/25",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 166,
+    "lineCount": 902,
     "assumptions": "3 axioms inherited from Erdos25LogDensity.lean: naturalDensity_implies_logDensity (natural density implies logarithmic density), exists_logDensity_no_naturalDensity (existence of sets with log density but no natural density), davenport_erdos (Davenport-Erdős theorem on log density). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -150,7 +150,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 166,
+    "lineCount": 902,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -28,7 +28,7 @@
       "Asymptotic notation and density of integer sets"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 647,
+    "lineCount": 1152,
     "mathlibDependencies": [
       {
         "theorem": "Set.ncard",

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -345,7 +345,7 @@
       "Filter"
     ],
     "namespace": "Erdos28",
-    "lineCount": 647,
+    "lineCount": 1152,
     "axiomCount": 2,
     "theoremCount": 19,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
+++ b/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "assumptions": "No axioms. All theorems proved from Mathlib. Uses construct_sumDvdProd_pair from OQ-01.",
     "mathlib_version": "4.26.0",
-    "lineCount": 87,
+    "lineCount": 252,
     "erdosNumber": 327,
     "erdosUrl": "https://erdosproblems.com/327",
     "relatedProblems": [

--- a/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
+++ b/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
@@ -135,7 +135,7 @@
       "Nat"
     ],
     "namespace": "Erdos327OQ01OQ04",
-    "lineCount": 87,
+    "lineCount": 252,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -137,7 +137,7 @@
       "Erdos340"
     ],
     "namespace": "Erdos44",
-    "lineCount": 346,
+    "lineCount": 851,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -46,7 +46,7 @@
       "Proof that isSidon_singleton holds"
     ],
     "axiomCount": 1,
-    "lineCount": 346,
+    "lineCount": 851,
     "prerequisites": [
       "Sidon sets (B₂ sequences) and pairwise distinct sums",
       "Greedy algorithms in combinatorics",

--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -202,7 +202,7 @@
       "in"
     ],
     "namespace": null,
-    "lineCount": 343,
+    "lineCount": 890,
     "axiomCount": 5,
     "theoremCount": 19,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -60,7 +60,7 @@
       "Well-ordering principle and Nat.find in Lean 4",
       "Basic additive combinatorics"
     ],
-    "lineCount": 343,
+    "lineCount": 890,
     "assumptions": "5 axioms: schurNumber_4, schurNumber_5, schur_lower_bound, schur_upper_bound, erdos_483_conjecture. Proved: schurNumber_3=14 via native_decide.",
     "theoremCount": 19
   },

--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 215,
+    "lineCount": 386,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved from Mathlib.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -134,7 +134,7 @@
       "Erdos622"
     ],
     "namespace": "Erdos622OQ04",
-    "lineCount": 215,
+    "lineCount": 386,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-65-oq-03/meta.json
+++ b/src/data/proofs/erdos-65-oq-03/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 267,
+    "lineCount": 403,
     "assumptions": "1 axiom: Liu-Montgomery theorem (JAMS 2023) — the main bound on reciprocal cycle sums. This is a deep 43-page result using regularity and probabilistic methods.",
     "originalContributions": [
       "Partial harmonic sum infrastructure with key algebraic identities",

--- a/src/data/proofs/erdos-65-oq-03/meta.json
+++ b/src/data/proofs/erdos-65-oq-03/meta.json
@@ -111,7 +111,7 @@
       "Proofs.LebesgueMeasureOQ03"
     ],
     "namespace": "Erdos65OQ03",
-    "lineCount": 267,
+    "lineCount": 403,
     "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -84,7 +84,7 @@
       "erdos_749_upper_variant: upper density version (proved via by_cases)"
     ],
     "axiomCount": 1,
-    "lineCount": 321,
+    "lineCount": 826,
     "assumptions": "1 axiom: erdos_turan_conjecture_28 (Erdős-Turán conjecture #28, open). sidon_set_density_zero is now a fully proved theorem via Sidon counting bound.",
     "theoremCount": 20
   },

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -168,7 +168,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 321,
+    "lineCount": 826,
     "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "2 axioms: alon_frankl_lovasz_1986 (Alon-Frankl-Lovász 1986 matching bound), kneser_conjecture (chromatic number of Kneser graph KG(n,r) = n-2r+2, Lovász 1978). 0 sorries.",
-    "lineCount": 221,
+    "lineCount": 965,
     "theoremCount": 7
   },
   "overview": {

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -210,7 +210,7 @@
       "Finset"
     ],
     "namespace": "Erdos780",
-    "lineCount": 221,
+    "lineCount": 965,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-837-oq-05/meta.json
+++ b/src/data/proofs/erdos-837-oq-05/meta.json
@@ -29,7 +29,7 @@
       "Formal statement of A_2 characterization"
     ],
     "dateAdded": "2026-04-13",
-    "lineCount": 149,
+    "lineCount": 227,
     "theoremCount": 5,
     "definitionCount": 3,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-837-oq-05/meta.json
+++ b/src/data/proofs/erdos-837-oq-05/meta.json
@@ -114,7 +114,7 @@
       "Proofs.Erdos837Problem"
     ],
     "namespace": "Erdos837OQ05",
-    "lineCount": 149,
+    "lineCount": 227,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-848-oq-01/meta.json
+++ b/src/data/proofs/erdos-848-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 160,
+    "lineCount": 468,
     "theoremCount": 15,
     "defCount": 1,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",

--- a/src/data/proofs/erdos-848-oq-01/meta.json
+++ b/src/data/proofs/erdos-848-oq-01/meta.json
@@ -136,7 +136,7 @@
     ],
     "opens": [],
     "namespace": "Erdos848OQ01",
-    "lineCount": 160,
+    "lineCount": 468,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 1,

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-04/meta.json
@@ -23,7 +23,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "None. All theorems fully proved with 0 sorries, 0 axioms.",
-    "lineCount": 345,
+    "lineCount": 977,
     "theoremCount": 13,
     "definitionCount": 2,
     "originalContributions": [

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-04/meta.json
@@ -162,7 +162,7 @@
       "Proofs.FairGamesTheoremOQ01"
     ],
     "namespace": "FairGamesOQ02OQ04",
-    "lineCount": 345,
+    "lineCount": 977,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/FairGamesTheoremOQ02OQ04.lean",

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
@@ -125,7 +125,7 @@
     "imports": ["Mathlib", "Proofs.FeuerbachsTheoremDefs"],
     "opens": ["FeuerbachsTheorem", "Real", "EuclideanGeometry"],
     "namespace": "FeuerbachsTheoremDefsOQ04",
-    "lineCount": 190,
+    "lineCount": 877,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 1,

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Inherits from FeuerbachsTheoremDefs.lean which is also 0-sorry.",
-    "lineCount": 190,
+    "lineCount": 877,
     "theoremCount": 12,
     "definitionCount": 1,
     "originalContributions": [

--- a/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
@@ -224,7 +224,7 @@
       "FeuerbachsTheorem"
     ],
     "namespace": "FeuerbachsTheoremOQ01",
-    "lineCount": 1553,
+    "lineCount": 2240,
     "axiomCount": 0,
     "theoremCount": 71,
     "definitionCount": 2,

--- a/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
@@ -58,7 +58,7 @@
     ],
     "dateAdded": "2026-03-13",
     "axiomCount": 0,
-    "lineCount": 1553,
+    "lineCount": 2240,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 71

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -119,7 +119,7 @@
       "FeuerbachsTheoremOQ01"
     ],
     "namespace": "FeuerbachsTheorem",
-    "lineCount": 164,
+    "lineCount": 1717,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0,

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -34,7 +34,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 164,
+    "lineCount": 1717,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -180,7 +180,7 @@
       "AddCircle"
     ],
     "namespace": "FourierHolderL2RL",
-    "lineCount": 83,
+    "lineCount": 534,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 0,

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -67,7 +67,7 @@
       "Key insight: ĉ_n → 0 requires only L²-membership; quantitative bounds are not needed"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 83,
+    "lineCount": 534,
     "assumptions": "0 sorries, 0 axioms. Fully machine-verified.",
     "mathlib_version": "4.26.0",
     "prerequisites": [

--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -194,7 +194,7 @@
       "FourierHolderDecay"
     ],
     "namespace": "FourierSqSummablePSeries",
-    "lineCount": 226,
+    "lineCount": 712,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -64,7 +64,7 @@
       "Key insight: the condition α > 1/2 is exactly the threshold for the p-series 1/|n|^{2α} to converge (2α > 1)"
     ],
     "dateAdded": "2026-04-23",
-    "lineCount": 226,
+    "lineCount": 712,
     "assumptions": "None. All theorems including holder_half_is_critical_for_pseries (harmonic series sharpness) are fully proved.",
     "mathlib_version": "4.26.0",
     "prerequisites": [

--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -196,7 +196,7 @@
       "BigOperators"
     ],
     "namespace": "FriendshipTheorem",
-    "lineCount": 373,
+    "lineCount": 2649,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 6,

--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -45,7 +45,7 @@
     "wiedijkNumber": 83,
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axioms, 0 sorries. FriendshipTheorem.lean imports FriendshipTheoremOQ01.lean which provides both key results: (1) regularity of friendship graphs without universal vertex (via A³ commutativity + complement-connectivity), and (2) k-regular friendship implies k=2 (via characteristic polynomial analysis). Both former axioms eliminated.",
-    "lineCount": 373,
+    "lineCount": 2649,
     "mathlib_version": "4.26.0",
     "theoremCount": 10
   },

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -214,7 +214,7 @@
       "Real"
     ],
     "namespace": "GreensTheoremOQ02",
-    "lineCount": 507,
+    "lineCount": 845,
     "axiomCount": 1,
     "theoremCount": 19,
     "definitionCount": 4,

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -55,7 +55,7 @@
       "19 supporting lemmas on Lipschitz curves, line integrals, L¹ fields, and consequences"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 507,
+    "lineCount": 845,
     "assumptions": "1 axiom (greens_theorem_l1curl — Whitney's 1957 theorem). 19 theorems with 0 sorries. Supporting results are fully proved using Mathlib's LipschitzWith, MeasureTheory, and trigonometric libraries.",
     "theoremCount": 19
   },

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -222,7 +222,7 @@
       "Real"
     ],
     "namespace": "GreensTheoremOQ03",
-    "lineCount": 557,
+    "lineCount": 895,
     "axiomCount": 2,
     "theoremCount": 31,
     "definitionCount": 12,

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -73,7 +73,7 @@
       "research"
     ],
     "axiomCount": 2,
-    "lineCount": 557,
+    "lineCount": 895,
     "prerequisites": [
       "Green's theorem: line integral to double integral",
       "Iterated integrals and Fubini's theorem",

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -137,7 +137,7 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1646,
+    "lineCount": 3688,
     "axiomCount": 0,
     "theoremCount": 27,
     "definitionCount": 15,

--- a/src/data/proofs/inverse-galois-f20/meta.json
+++ b/src/data/proofs/inverse-galois-f20/meta.json
@@ -105,7 +105,7 @@
     "imports": ["Mathlib", "Proofs.NthRootIrrationalOQ01"],
     "opens": [],
     "namespace": "InverseGaloisF20",
-    "lineCount": 529,
+    "lineCount": 738,
     "axiomCount": 0,
     "theoremCount": 27,
     "definitionCount": 3,

--- a/src/data/proofs/inverse-galois-f20/meta.json
+++ b/src/data/proofs/inverse-galois-f20/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 529,
+    "lineCount": 738,
     "theoremCount": 27,
     "assumptions": "None. All 27 theorems proved using Mathlib's Galois theory.",
     "mathlibDependencies": [

--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -149,7 +149,7 @@
   "sorries": 6,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ02.lean",
-    "lineCount": 388,
+    "lineCount": 2993,
     "axiomCount": 3,
     "sorries": 6,
     "theoremCount": 18,

--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -36,7 +36,7 @@
         "relationship": "Sister entry exploring the solvability divide and non-solvable frontier"
       }
     ],
-    "lineCount": 388,
+    "lineCount": 2993,
     "mathlib_version": "4.26.0",
     "theoremCount": 18
   },

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -74,7 +74,7 @@
   },
   "leanFile": {
     "namespace": "KonigsbergOQ02OQ01",
-    "lineCount": 954,
+    "lineCount": 1767,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 5,

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "",
-    "lineCount": 954,
+    "lineCount": 1767,
     "theoremCount": 17,
     "definitionCount": 5,
     "originalContributions": [

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -119,7 +119,7 @@
     "opens": ["Nat"],
     "namespace": "KummerMultinomial",
     "axiomCount": 0,
-    "lineCount": 108,
+    "lineCount": 289,
     "theoremCount": 3,
     "definitionCount": 1,
     "path": "Proofs/KummerTheoremOQ01.lean",

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved: multinomial_eq_prod_choose (via companion file KummerTheoremOQ01Aristotle.lean using reverseRecOn induction), multinomial_pair, multinomial_triple.",
-    "lineCount": 108,
+    "lineCount": 289,
     "theoremCount": 3,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/kummer-theorem-oq-02/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-02/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-29",
     "axiomCount": 0,
-    "lineCount": 412,
+    "lineCount": 603,
     "prerequisites": [
       "Cyclotomic polynomials and their basic properties",
       "Polynomial rings over Z (integral domain structure)",

--- a/src/data/proofs/kummer-theorem-oq-02/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-02/meta.json
@@ -180,7 +180,7 @@
       "Nat"
     ],
     "namespace": "KummerTheoremOQ02",
-    "lineCount": 412,
+    "lineCount": 603,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 4,

--- a/src/data/proofs/kummer-theorem-oq-03/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-03/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 116,
+    "lineCount": 307,
     "theoremCount": 5,
     "definitionCount": 1,
     "assumptions": "None. 0 axioms, 0 sorries. All results derived from Mathlib's Kummer theorem.",

--- a/src/data/proofs/kummer-theorem-oq-03/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-03/meta.json
@@ -185,7 +185,7 @@
       "Nat"
     ],
     "namespace": "KummerTheoremOQ03",
-    "lineCount": 116,
+    "lineCount": 307,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1,

--- a/src/data/proofs/lagrange-four-squares-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04/meta.json
@@ -146,7 +146,7 @@
       "Proofs.LagrangeFourSquares"
     ],
     "namespace": "ThreeSquareTheorem",
-    "lineCount": 226,
+    "lineCount": 618,
     "axiomCount": 1,
     "theoremCount": 11,
     "definitionCount": 0,

--- a/src/data/proofs/lagrange-four-squares-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04/meta.json
@@ -30,7 +30,7 @@
       "Examples: 7, 15, 28, 112 are not sums of three squares"
     ],
     "dateAdded": "2026-04-13",
-    "lineCount": 226,
+    "lineCount": 618,
     "theoremCount": 11,
     "definitionCount": 0,
     "mathlibDependencies": [],

--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -123,7 +123,7 @@
       "ProbMethod.LovaszLocal"
     ],
     "namespace": "ProbMethod.LovaszLocal.OQ02",
-    "lineCount": 240,
+    "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 13,
     "substantiveTheoremCount": 10,

--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
     "assumptions": "1 sorry remains: lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization (all terms equal iff x = 1/(d+1)). Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
-    "lineCount": 240,
+    "lineCount": 604,
     "theoremCount": 13,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/minkowski-theorem-oq-02/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-02/meta.json
@@ -196,7 +196,7 @@
         "leanType": "(α : ℝ) → (Q : ℕ) → 0 < Q → ∃ q p : ℤ, 1 ≤ q ∧ q ≤ Q ∧ |α * q - p| < 1 / Q"
       }
     ],
-    "lineCount": 284,
+    "lineCount": 970,
     "path": "Proofs/MinkowskiTheoremOQ02.lean",
     "definitionCount": 1,
     "theoremCount": 6

--- a/src/data/proofs/minkowski-theorem-oq-02/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 284,
+    "lineCount": 970,
     "assumptions": "Three axioms handle measure-theoretic steps: (1) dirichletSet_convex: the parallelogram {|x| < Q+1, |αx-y| < 1/Q} is convex — intersection of two halfplanes; (2) dirichletSet_measurable: it is Lebesgue measurable — open set hence Borel; (3) dirichletSet_volume: its area equals 4(Q+1)/Q — proved by Fubini or the shear map T(x,y)=(x,αx-y) with det(T)=-1 mapping S to a rectangle. The main theorem and all logical steps are fully proved.",
     "dateAdded": "2026-04-03",
     "mathlibDependencies": [

--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -182,7 +182,7 @@
       "NapoleonsTheorem"
     ],
     "namespace": "NapoleonsTheoremOQ02",
-    "lineCount": 346,
+    "lineCount": 701,
     "axiomCount": 0,
     "theoremCount": 11,
     "sorries": 0,

--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "lineCount": 346,
+    "lineCount": 701,
     "assumptions": "0 axioms. 0 sorries. Fully verified using only 1+ω+ω²=0, ω³=1, and √3²=3.",
     "mathlib_version": "4.26.0",
     "parentProof": "napoleons-theorem",

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -45,7 +45,7 @@
   },
   "leanFile": {
     "path": "Proofs/PNPBarriersUnified.lean",
-    "lineCount": 6370,
+    "lineCount": 6777,
     "imports": [
       "Mathlib.Logic.Basic",
       "Mathlib.Tactic",

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2025-12-29",
     "millenniumProblem": "p-vs-np",
-    "lineCount": 6370,
+    "lineCount": 6777,
     "mathlib_version": "4.26.0",
     "theoremCount": 303
   },

--- a/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "No axioms. Computational verification via native_decide. Depends on PartitionTheoremOQ01 for definitions (rr1GapPartitions, rr1Mod5Partitions, rr2GapPartitions, rr2Mod5Partitions).",
     "mathlib_version": "4.26.0",
-    "lineCount": 71,
+    "lineCount": 3623,
     "relatedProblems": [
       {
         "id": "partition-theorem-oq-01",

--- a/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
@@ -160,7 +160,7 @@
       "RogersRamanujan"
     ],
     "namespace": "PartitionTheoremOQ01OQ01",
-    "lineCount": 71,
+    "lineCount": 3623,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 0,

--- a/src/data/proofs/prob-method-second-moment-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01/meta.json
@@ -154,7 +154,7 @@
     ],
     "opens": [],
     "namespace": "ProbMethod.SecondMoment",
-    "lineCount": 147,
+    "lineCount": 373,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/prob-method-second-moment-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01/meta.json
@@ -18,7 +18,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 147,
+    "lineCount": 373,
     "theoremCount": 4,
     "definitionCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",

--- a/src/data/proofs/ptolemys-complex-proof-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof-oq-02/meta.json
@@ -160,7 +160,7 @@
       "Real"
     ],
     "namespace": "PtolemysComplexProofOQ02",
-    "lineCount": 351,
+    "lineCount": 833,
     "axiomCount": 0,
     "theoremCount": 11,
     "substantiveTheoremCount": 1,

--- a/src/data/proofs/ptolemys-complex-proof-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof-oq-02/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "lineCount": 351,
+    "lineCount": 833,
     "assumptions": "Core result derived via Mathlib's Real.sin_add (line 199 of PtolemysComplexProofOQ02.lean): the key chord-length lemma norm_exp_diff uses Real.sin_add to establish ‖exp(2αI) − exp(−2βI)‖ = 2sin(α+β). All other steps — Ptolemy equality application, CCW order verification, remaining chord lemmas, and non-degeneracy conditions — are independently formalized. 0 axiom declarations, 0 sorries.",
     "theoremCount": 11
   },

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -157,7 +157,7 @@
       "Real"
     ],
     "namespace": "PtolemysTheoremOQ01Incomplete01",
-    "lineCount": 489,
+    "lineCount": 1251,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 489,
+    "lineCount": 1251,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axioms. The hcx identity proved via mul_left_cancel₀ with factor (2I)²·E₁₂E₃₄, using hE (phase cancellation) and ring.",
     "theoremCount": 7,
     "definitionCount": 0

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -238,7 +238,7 @@
       "EuclideanGeometry"
     ],
     "namespace": "SphericalPtolemy",
-    "lineCount": 270,
+    "lineCount": 510,
     "axiomCount": 0,
     "theoremCount": 3,
     "sorries": 0,

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -55,7 +55,7 @@
     ],
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "lineCount": 270,
+    "lineCount": 510,
     "assumptions": "0 axioms. 0 sorries (core result via Mathlib bridge). Relies on Mathlib's EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical for the Euclidean Ptolemy step. Assumes: Cospherical condition (points on common circle), angle conditions for diagonal crossing, unit sphere (‖a‖=‖b‖=‖c‖=‖d‖=1).",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01",

--- a/src/data/proofs/ptolemys-theorem-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 482,
+    "lineCount": 627,
     "assumptions": "None. All results fully verified from Mathlib with 0 sorries and 0 axioms.",
     "theoremCount": 13,
     "definitionCount": 2

--- a/src/data/proofs/ptolemys-theorem-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/meta.json
@@ -148,7 +148,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 482,
+    "lineCount": 627,
     "axiomCount": 0,
     "theoremCount": 13,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/randomized-maxcut-oq-04/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-04/meta.json
@@ -24,7 +24,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
-    "lineCount": 401,
+    "lineCount": 528,
     "assumptions": "No remaining sorries. All theorems fully proved: max_ge_avg, greedyContrib_ge_half, conditional_expectation_method, card_filter_mem, card_filter_mem_nmem, sum_cutWeight_eq, exists_good_partition'.",
     "theoremCount": 15
   },

--- a/src/data/proofs/randomized-maxcut-oq-04/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-04/meta.json
@@ -148,7 +148,7 @@
       "Mathlib"
     ],
     "namespace": "MaxCutDerandomization",
-    "lineCount": 401,
+    "lineCount": 528,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 4,

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -180,7 +180,7 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.TriangleRemoval",
-    "lineCount": 465,
+    "lineCount": 3062,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 6,

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -47,7 +47,7 @@
       "Edge-disjointness lower bound: edge removal requires >= |A|N edges",
       "Statement of Roth's theorem via triangle removal as alternative to Fourier proof"
     ],
-    "lineCount": 465,
+    "lineCount": 3062,
     "theoremCount": 16,
     "definitionCount": 4,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -59,7 +59,7 @@
     "assumptions": "5 axiom(s): brouwer_compact_convex, mazur_compact_convex_hull, brouwer_finite_dim_subset, peano_existence_via_schauder, infinite_dim_counterexample. 0 sorries remain.",
     "proofRepoPath": "Proofs/SchauderFixedPoint.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 601,
+    "lineCount": 916,
     "theoremCount": 9
   },
   "overview": {

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -215,7 +215,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 601,
+    "lineCount": 916,
     "structureCount": 0,
     "axiomCount": 5,
     "theoremCount": 9,

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "assumptions": "0 axioms in this file. Removed the unused `axiom import_shannon_entropy_blocked : False` placeholder (asserting False is logically unsound — even an unused declaration is a footgun). The blocker explanation is preserved as a comment block. The target axiom `fano_inequality` lives in ShannonChannelCoding.lean (a different file); this bridge file's `fano_from_oq03` theorem would discharge it once ShannonEntropy.lean's strong_subadditivity is fixed (line 811 sum-order issue, fix sketched in this file).",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 181,
+    "lineCount": 1069,
     "prerequisites": [
       "Fano's inequality (OQ-03): H(X|Y) ≤ h(P_e) + P_e·log(|X|-1)",
       "Binary entropy function and concavity (OQ-04)",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -148,7 +148,7 @@
       "FanoInequality"
     ],
     "namespace": "FanoFromConditionalEntropy",
-    "lineCount": 181,
+    "lineCount": 1069,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -50,7 +50,7 @@
     "assumptions": "0 axioms, 0 sorries. All lemmas fully proved: sum_sq_le_max, slice_sq_le_max, formula_pe_ge_map_pe, gibbs_inequality, fano_per_element, fano_map_bound, fano_func_mono, cauchy_schwarz_sum, per_slice_bound, and fano_theorem. Complete independent formalization of Fano's inequality.",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 664,
+    "lineCount": 888,
     "prerequisites": [
       "Shannon entropy and conditional entropy",
       "Binary entropy function h(p) and its concavity (Proofs.ShannonChannelCodingOQ04)",

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -188,7 +188,7 @@
       "Real"
     ],
     "namespace": "FanoInequality",
-    "lineCount": 664,
+    "lineCount": 888,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ03.lean",

--- a/src/data/proofs/shannon-channel-coding-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04-oq-01-oq-01/meta.json
@@ -68,7 +68,7 @@
       "Set"
     ],
     "namespace": "InformationTheory.BinaryEntropy",
-    "lineCount": 102,
+    "lineCount": 452,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",

--- a/src/data/proofs/shannon-channel-coding-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 102,
+    "lineCount": 452,
     "theoremCount": 4,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/shannon-channel-coding-oq-04-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 126,
+    "lineCount": 350,
     "theoremCount": 4,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/shannon-channel-coding-oq-04-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-04-oq-01/meta.json
@@ -66,7 +66,7 @@
       "Real"
     ],
     "namespace": "InformationTheory.BinaryEntropy",
-    "lineCount": 126,
+    "lineCount": 350,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -45,7 +45,7 @@
       "Conditional MI non-negativity: I(X;Z|Y) ≥ 0 from SSA"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 341,
+    "lineCount": 1242,
     "theoremCount": 11,
     "definitionCount": 5,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -188,7 +188,7 @@
       "Finset"
     ],
     "namespace": "InformationTheory",
-    "lineCount": 341,
+    "lineCount": 1242,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 6,

--- a/src/data/proofs/shapley-folkman-oq-03/meta.json
+++ b/src/data/proofs/shapley-folkman-oq-03/meta.json
@@ -33,7 +33,7 @@
     "proofStrategy": "Apply sum_close_to_convexHull (from ShapleyFolkman.lean) to decompose x as Σf(i) with f(i) ∈ conv(S(i)) and at most dim(E) 'excess' indices where f(i) ∉ S(i). For each excess index j, replace f(j) by any g(j) ∈ S(j). The sum x' = Σg(i) lies in ΣS(i). The distance bound uses convexHull_dist_le_diam (proved in this file) for each excess index. A Finset.sum_subset argument shows non-excess terms contribute zero to the difference.",
     "assumptions": "0 axioms. 0 sorries. Fully machine-checked. The parent ShapleyFolkman.lean has 0 sorries (completed 2026-04-24 via WF induction on total minCaraDepth), making this proof fully verified end-to-end.",
     "axiomCount": 0,
-    "lineCount": 203,
+    "lineCount": 1441,
     "theoremCount": 5,
     "definitionCount": 0
   },

--- a/src/data/proofs/shapley-folkman-oq-03/meta.json
+++ b/src/data/proofs/shapley-folkman-oq-03/meta.json
@@ -162,7 +162,7 @@
       "Proofs.ShapleyFolkman"
     ],
     "namespace": "ShapleyFolkmanOQ03",
-    "lineCount": 203,
+    "lineCount": 1441,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ShapleyFolkmanOQ03.lean",

--- a/src/data/proofs/solution-of-cubic-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-05/meta.json
@@ -102,7 +102,7 @@
       "GeneralQuartic"
     ],
     "namespace": "SolutionOfCubicOQ05",
-    "lineCount": 183,
+    "lineCount": 840,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 3,

--- a/src/data/proofs/solution-of-cubic-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-05/meta.json
@@ -66,7 +66,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 183,
+    "lineCount": 840,
     "assumptions": "None. All theorems fully proved from Mathlib with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9

--- a/src/data/proofs/sophie-germain-oq-01/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01/meta.json
@@ -205,7 +205,7 @@
       "SophieGermain"
     ],
     "namespace": "SophieGermainOQ01",
-    "lineCount": 196,
+    "lineCount": 648,
     "axiomCount": 1,
     "theoremCount": 26,
     "definitionCount": 1,

--- a/src/data/proofs/sophie-germain-oq-01/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 196,
+    "lineCount": 648,
     "theoremCount": 26,
     "definitionCount": 1,
     "assumptions": "1 axiom: `sophie_germain_conjecture` (inherited from parent, states the unproved Sophie Germain prime conjecture).",

--- a/src/data/proofs/sophie-germain-oq-02/meta.json
+++ b/src/data/proofs/sophie-germain-oq-02/meta.json
@@ -158,7 +158,7 @@
       "Finset"
     ],
     "namespace": "SophieGermainOQ02",
-    "lineCount": 156,
+    "lineCount": 452,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 3,

--- a/src/data/proofs/sophie-germain-oq-02/meta.json
+++ b/src/data/proofs/sophie-germain-oq-02/meta.json
@@ -15,7 +15,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 156,
+    "lineCount": 452,
     "theoremCount": 11,
     "definitionCount": 3,
     "assumptions": [],

--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -169,7 +169,7 @@
       "SpernerNDim"
     ],
     "namespace": "DisplacementBrouwer",
-    "lineCount": 452,
+    "lineCount": 1121,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 5,

--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -32,7 +32,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 452,
+    "lineCount": 1121,
     "assumptions": "0 axioms, 0 sorries. All theorems fully verified. Takes Sperner lemma (sperner_ndim) as a hypothesis parameter, cleanly separating combinatorial and analytical arguments.",
     "mathlib_version": "4.26.0",
     "theoremCount": 13

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -249,7 +249,7 @@
     ],
     "path": "Proofs/SpernerNDimOQ04.lean",
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 948,
+    "lineCount": 1617,
     "axiomCount": 1,
     "theoremCount": 18,
     "definitionCount": 6,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 1,
-    "lineCount": 948,
+    "lineCount": 1617,
     "assumptions": "1 axiom: bdry_all_even_of_no_fc_walks — when all boundary-door walks fail to reach FC, the boundary-door set B has even cardinality (used for parity contradiction in kuhn_path_existential). Mathematical proof: under hfail, τ: B→B defined by τ(s₀,Fin.last d) = (kuhnPathStart s₀, Fin.last d) is a FPF involution; hMem and hNe proved; hInv (τ∘τ=id, walkTrace_reversal) requires ~150-line kuhnWalkSeq infrastructure and is axiomatized after 9+ sessions BLOCKED.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18

--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -182,7 +182,7 @@
       "CubeRoot2IrrationalOQ03"
     ],
     "namespace": "Sqrt2MinpolyOQ01",
-    "lineCount": 252,
+    "lineCount": 456,
     "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 0,

--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 252,
+    "lineCount": 456,
     "dateAdded": "2026-04-23",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -201,7 +201,7 @@
       "CubeRoot2IrrationalOQ03"
     ],
     "namespace": "Sqrt2MinpolyOQ02",
-    "lineCount": 202,
+    "lineCount": 406,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 0,

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 406,
     "dateAdded": "2026-04-06",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 361,
+    "lineCount": 776,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02",

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -205,7 +205,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 361,
+    "lineCount": 776,
     "axiomCount": 0,
     "theoremCount": 12,
     "sorries": 0,

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -51,7 +51,7 @@
       "Triangle counting and subgraph enumeration",
       "Roth's theorem on 3-term arithmetic progressions"
     ],
-    "lineCount": 1196,
+    "lineCount": 1839,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -177,7 +177,7 @@
       "Szemeredi.Core"
     ],
     "namespace": "Szemeredi.Counting",
-    "lineCount": 1196,
+    "lineCount": 1839,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/szemeredi-full-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-full-oq-02/meta.json
@@ -175,7 +175,7 @@
       "Filter"
     ],
     "namespace": "SzemerediDensity",
-    "lineCount": 118,
+    "lineCount": 492,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/szemeredi-full-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-full-oq-02/meta.json
@@ -39,7 +39,7 @@
       "Formal statement of k≥4 density bound using the axiomatized szemeredi_k_ge_4",
       "Documentation of Gowers uniformity norm gap: U^{k-1} formulation blocked by missing Mathlib infrastructure"
     ],
-    "lineCount": 118,
+    "lineCount": 492,
     "assumptions": "1 axiom (szemeredi_k_ge_4) inherited from SzemerediTheorem.lean — requires hypergraph regularity for k≥4.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -166,7 +166,7 @@
       "Classical"
     ],
     "namespace": "Szemeredi.Hypergraph",
-    "lineCount": 322,
+    "lineCount": 535,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 6,

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 322,
+    "lineCount": 535,
     "assumptions": "Infrastructure file: 0 sorries, 0 axioms. Provides definitions (SimplicialComplex, completeComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity) and supporting lemmas. A previously-attempted naive_implies_gowers theorem was removed; the obstruction (sub-complex topCliques are not generally transversals of vertex sub-parts) is documented in-file (Part VII), and three provable surrogates are supplied instead (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty).",
     "mathlib_version": "4.26.0",
     "theoremCount": 14

--- a/src/data/proofs/szemeredi-regularity-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02/meta.json
@@ -195,7 +195,7 @@
       "Classical"
     ],
     "namespace": "SzemerediFKComparison",
-    "lineCount": 399,
+    "lineCount": 1042,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 2,

--- a/src/data/proofs/szemeredi-regularity-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02/meta.json
@@ -42,7 +42,7 @@
       "sz_two_steps_tower: 2-step Szemerédi bound ≥ 4^(4^n) — tower growth quantified",
       "fk_bound_at_half: explicit FK bound 4^4 = 256 at ε = 1/2 vs Szemerédi's tower"
     ],
-    "lineCount": 399,
+    "lineCount": 1042,
     "assumptions": "0 axioms, 0 sorries. Fully verified using Mathlib's SimpleGraph, Finset, and ε-regularity infrastructure.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -181,7 +181,7 @@
       "Szemeredi.Core"
     ],
     "namespace": "Szemeredi.Regularity",
-    "lineCount": 533,
+    "lineCount": 643,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 0,

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -55,7 +55,7 @@
       "Cauchy-Schwarz inequality (for density convexity)",
       "Szemerédi core definitions (edgeDensity, IsEpsilonRegular, etc.)"
     ],
-    "lineCount": 533,
+    "lineCount": 643,
     "mathlib_version": "4.26.0",
     "theoremCount": 17
   },

--- a/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
@@ -34,7 +34,7 @@
       "cos_taylor_remainder_bound': eliminates axiom, proved via taylor_mean_remainder_bound"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 238,
+    "lineCount": 586,
     "theoremCount": 11,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
@@ -243,7 +243,7 @@
       "TaylorSinCosConvergence"
     ],
     "namespace": "TaylorSinCosConvergenceOQ01",
-    "lineCount": 238,
+    "lineCount": 586,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0,

--- a/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
@@ -78,7 +78,7 @@
       "Proofs.EulerIdentityOQ01OQ01"
     ],
     "namespace": "TaylorSinCosConvergenceOQ02",
-    "lineCount": 274,
+    "lineCount": 764,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 0,

--- a/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
@@ -29,7 +29,7 @@
       "Period-4 derivative lemmas for iteratedDeriv of sin and cos at 0"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 274,
+    "lineCount": 764,
     "theoremCount": 16,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
@@ -30,7 +30,7 @@
       "Optimality: C = 1 is the minimum possible bound constant (sin/cos achieve it)"
     ],
     "dateAdded": "2026-04-13",
-    "lineCount": 324,
+    "lineCount": 672,
     "theoremCount": 18,
     "definitionCount": 1,
     "mathlibDependencies": [

--- a/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
@@ -207,7 +207,7 @@
       "Real"
     ],
     "namespace": "TaylorBoundedDerivConvergence",
-    "lineCount": 324,
+    "lineCount": 672,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 1,

--- a/src/data/proofs/triangle-angle-sum-oq-01/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 4,
-    "lineCount": 260,
+    "lineCount": 572,
     "assumptions": "saccheri_legendre (angle sum ≤ π in neutral geometry), defect_transitivity_axiom (zero defect propagates), angle_sum_pi_implies_playfair (main characterization), parallel_implies_angle_sum (forward direction). All are classical theorems of neutral geometry requiring ~1000 lines of infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5

--- a/src/data/proofs/triangle-angle-sum-oq-01/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-01/meta.json
@@ -125,7 +125,7 @@
       "ParallelPostulate"
     ],
     "namespace": "TriangleAngleSumOQ01",
-    "lineCount": 260,
+    "lineCount": 572,
     "axiomCount": 4,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ01.lean",

--- a/src/data/proofs/twin-primes-special-oq-01/meta.json
+++ b/src/data/proofs/twin-primes-special-oq-01/meta.json
@@ -221,7 +221,7 @@
       "TwinPrimes"
     ],
     "namespace": "TwinPrimesSpecialOQ01",
-    "lineCount": 150,
+    "lineCount": 340,
     "axiomCount": 1,
     "theoremCount": 25,
     "definitionCount": 0,

--- a/src/data/proofs/twin-primes-special-oq-01/meta.json
+++ b/src/data/proofs/twin-primes-special-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 150,
+    "lineCount": 340,
     "theoremCount": 25,
     "definitionCount": 0,
     "assumptions": "1 axiom: `twin_prime_conjecture` (inherited from parent TwinPrimes.lean, states the unproved Twin Prime Conjecture).",

--- a/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
@@ -175,7 +175,7 @@
     ],
     "opens": [],
     "namespace": "QuarticDiscriminant",
-    "lineCount": 304,
+    "lineCount": 687,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 3,

--- a/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
@@ -26,7 +26,7 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "defCount": 3,
-    "lineCount": 304,
+    "lineCount": 687,
     "mathlibDependencies": [
       {
         "theorem": "ring",

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 12,
     "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean (shared file): Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation.",
-    "lineCount": 28074,
+    "lineCount": 28477,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_pos",

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -216,7 +216,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28074,
+    "lineCount": 28477,
     "structureCount": 365,
     "axiomCount": 0,
     "theoremCount": 1787,

--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -149,7 +149,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 500,
+    "lineCount": 624,
     "structureCount": 7,
     "axiomCount": 2,
     "theoremCount": 21,

--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "assumptions": "2 axioms: (1) os_reconstruction — the GNS construction from reflection-positive lattice OS data producing a WightmanQFT; this is mathematically proven (Osterwalder-Schrader 1973, Osterwalder-Seiler 1978) but requires functional analysis (Bochner's theorem, GNS construction) beyond current Mathlib. (2) os_mass_gap_transfer — that exponential decay of Schwinger functions implies a spectral gap in the reconstructed Hilbert space via the Kallen-Lehmann representation; similarly proven but requires the full OS machinery. The 2D results (Migdal formula, string tension, SU(2) computation) are fully proved with 0 axioms.",
-    "lineCount": 500,
+    "lineCount": 624,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_neg",

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -147,7 +147,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28074,
+    "lineCount": 28477,
     "structureCount": 365,
     "axiomCount": 0,
     "theoremCount": 1787,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 12,
     "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean: Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation. Additionally, the file contains approximately 41 structural placeholder theorems beyond line 8000 of the form `theorem X (...(h:P)...): P := h` — these state their hypothesis as conclusion and establish no new mathematical content; they are named after significant physics results (including Creutz confinement, continuum mass gap, and Witten index) to serve as organizational anchors for future formalization.",
-    "lineCount": 28074,
+    "lineCount": 28477,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_nonneg",

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 12,
     "assumptions": "1 explicit axiom (`gaugeTransform`, YangMills/Classical.lean) plus 11 structure-encoded assumptions of type `True` in Exploration.lean: Slavnov-Taylor/BRST Ward identity (`SlavnovTaylorIdentity.ward_identity_holds`, line 2454), regulator IR/UV behavior (`RegulatorProperties.suppresses_ir`, `RegulatorProperties.grows_at_uv`, lines 12746-12748), gauge invariance of observables (`GaugeInvariantObs.gaugeInvariant`, line 15986), Fradkin-Shenker analyticity (`FradkinShenker.analytic`, line 16035), Coleman-Mandula finite spectrum/non-trivial scattering/S-matrix analyticity (`CMHypotheses.finiteSpectrum`, `CMHypotheses.nontrivialScattering`, `CMHypotheses.analyticity`, lines 16760-16764), BRST charge conservation and nilpotency (`BRSTChargeCohom.conservation`, `BRSTChargeCohom.nilpotent`, lines 17248-17250), and asymptotic-safety beta-function vanishing (`AsymptoticSafety.beta_vanishes`, line 17606). Each `: True` field is satisfied by `trivial`, stipulating a substantive QFT property as a hypothesis without proof obligation.",
-    "lineCount": 28074,
+    "lineCount": 28477,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_pos",

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -137,7 +137,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28074,
+    "lineCount": 28477,
     "structureCount": 365,
     "axiomCount": 0,
     "theoremCount": 1787,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields for 174 gallery proofs where `leanFile.imports` lists local `Proofs.*` files that were never included in the line count.

## Evidence

Each proof's `lineCount` was set from the main `.lean` file only. When local sibling/helper/parent files were imported, their lines were silently excluded.

**Method**: For each proof, `actual = wc -l mainFile + Σ wc -l localImport` for all `Proofs.*` entries in `leanFile.imports`.

**Sample fixes**:

- amgm-inequality-oq-02-oq-01-oq-02: 138 -> 226 (AmgmInequalityOQ02OQ01.lean +88 lines)
- erdos-234: 510 -> 7104 (RiemannHypothesis.lean +6594 lines)
- ballot-problem-oq-03-oq-01-oq-02: 398 -> 14296 (BallotProblemOQ03OQ01OQ02Helpers.lean +13898 lines)
- yang-mills-2d/lattice/transfer-matrix: 28074 -> 28477 (YangMills/Classical.lean + Quantum.lean)

174 proofs total. Build passes (pnpm build). No overlap with open PR #15470.

---
Automated fix by lean-mechanic agent.