### PR TITLE
research(cs-localization): advance localization_existence with hext_ind + hagree_n

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -358,8 +358,72 @@ theorem localization_existence
     obtain ⟨gₙ, hgₙ, hgₙ_rep⟩ :=
       RieszLpSurjectivity.riesz_lp_surjective_from_rn p q hp1 hptop hpq φₙ
     exact ⟨gₙ, hgₙ, hgₙ_rep⟩
-  -- Consistency + MCT step: gₙ are compatible and yield g ∈ Lq(μ)
-  -- with indicator agreement
+  -- Extract the gₙ family
+  choose g_seq hg_seq_mem hg_seq_rep using hriesz_n
+  -- Key: extByZeroCLM(Sₙ)(1_E^Lp(μₙ)) = 1_E^Lp(μ), for E ⊆ Sₙ
+  -- (Both have representative E.indicator 1 a.e. w.r.t. μ)
+  have hext_ind : ∀ n (E : Set α) (hE : MeasurableSet E) (hEn : E ⊆ spanningSets μ n)
+      (hfin : μ E ≠ ⊤),
+      extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop
+        ((memLp_indicator_const p hE 1 (Or.inr (show (μ.restrict (spanningSets μ n)) E ≠ ⊤ from by
+            rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin))).toLp _) =
+      (memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _ := by
+    intro n E hE hEn hfin
+    have hfin_n : (μ.restrict (spanningSets μ n)) E ≠ ⊤ := by
+      rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin
+    rw [Lp.ext_iff]
+    -- Show both cofunctions are a.e. E.indicator 1 under μ
+    have hlhs : (extByZeroCLM (measurableSet_spanningSets μ n) hp0 hptop
+        ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _) : α → ℝ) =ᵐ[μ]
+        (spanningSets μ n).indicator
+          ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) :=
+      (memLp_indicator_of_restrict_loc (measurableSet_spanningSets μ n) hp0 hptop
+        (Lp.memLp _)).coeFn_toLp
+    have hrhs : ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _ : α → ℝ) =ᵐ[μ]
+        E.indicator 1 :=
+      (memLp_indicator_const p hE 1 (Or.inr hfin)).coeFn_toLp
+    -- Sₙ.indicator (coeFn of 1_E^Lp(μₙ)) =ᵐ[μ] E.indicator 1
+    -- coeFn_toLp gives =ᵐ[μ.restrict Sₙ]; convert to =ᵐ[μ] via ae_restrict_iff'
+    have hkey : (spanningSets μ n).indicator
+        ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) =ᵐ[μ]
+        E.indicator 1 := by
+      have hcoe_restrict : ∀ᵐ a ∂μ, a ∈ spanningSets μ n →
+          (memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ a = E.indicator 1 a :=
+        (ae_restrict_iff' (measurableSet_spanningSets μ n)).mp
+          (memLp_indicator_const p hE 1 (Or.inr hfin_n)).coeFn_toLp
+      filter_upwards [hcoe_restrict] with a ha
+      simp only [Set.indicator_apply]
+      by_cases hn : a ∈ spanningSets μ n
+      · simp only [hn, ite_true]; exact ha hn
+      · simp only [hn, ite_false, Set.indicator_apply, if_neg (fun he => hn (hEn he))]
+    exact hlhs.trans hkey |>.trans hrhs.symm
+  -- For E ⊆ Sₙ with μ(E) < ∞: φ(1_E^Lp(μ)) = ∫_E g_seq n dμ
+  have hagree_n : ∀ n (E : Set α) (hE : MeasurableSet E) (hEn : E ⊆ spanningSets μ n)
+      (hfin : μ E ≠ ⊤),
+      φ ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _) =
+      ∫ a in E, g_seq n a ∂μ := by
+    intro n E hE hEn hfin
+    have hfin_n : (μ.restrict (spanningSets μ n)) E ≠ ⊤ := by
+      rw [Measure.restrict_apply hE, Set.inter_eq_left.mpr hEn]; exact hfin
+    -- φ(1_E) = φ(extByZeroCLM(1_E^Lp(μₙ))) = ∫ 1_E * g_seq n ∂μₙ = ∫_E g_seq n ∂μ
+    rw [← hext_ind n E hE hEn hfin]
+    rw [hg_seq_rep n]
+    -- ∫ (coeFn of 1_E^Lp(μₙ)) * g_seq n ∂(μ.restrict Sₙ) = ∫_E g_seq n ∂μ
+    have hcoe : ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) =ᵐ[μ.restrict (spanningSets μ n)]
+        E.indicator 1 :=
+      (memLp_indicator_const p hE 1 (Or.inr hfin_n)).coeFn_toLp
+    rw [integral_congr_ae (EventuallyEq.mul_right hcoe _)]
+    simp_rw [Set.indicator_apply, Pi.one_apply, ite_mul, one_mul, zero_mul]
+    rw [integral_indicator hE, Measure.restrict_restrict hE,
+      Set.inter_comm, Set.inter_eq_left.mpr hEn]
+  -- Remaining: consistency + MCT + global g ∈ Lq(μ) + indicator agreement for all E
+  -- HARD SORRY: construct g via a.e. limit of g_seq, prove MemLp g q μ via MCT,
+  -- prove indicator agreement using hagree_n + tendsto_setIntegral_of_monotone
+  -- Key tools:
+  --   ae_eq_restrict_of_forall_setIntegral_eq: for consistency (g_seq m = g_seq n a.e. on Sₘ)
+  --   lintegral_iUnion (+ monotone): for MCT bound ‖g‖_Lq ≤ ‖φ‖
+  --   tendsto_setIntegral_of_monotone: ∫_{E∩Sₙ} g dμ → ∫_E g dμ
+  --   lp_truncation_tendsto_zero (proved): ‖1_{E∩Sₙ} - 1_E‖_Lp → 0, so φ(1_{E∩Sₙ}) → φ(1_E)
   sorry
 
 -- ============================================================================

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/knowledge.md
@@ -2,6 +2,53 @@
 
 ---
 
+## Session 2026-05-04 (Session 4) — hext_ind + hagree_n Proved
+
+**Mode**: REVISIT (ACT)
+**Outcome**: progress — hext_ind and hagree_n proved, 1 sorry remains (consistency + MCT)
+
+### What I Did
+
+1. **Chose g_seq family from hriesz_n**: `choose g_seq hg_seq_mem hg_seq_rep using hriesz_n`
+
+2. **Proved `hext_ind`**: `extByZeroCLM(Sₙ)(1_E^Lp(μₙ)) = 1_E^Lp(μ)` for E ⊆ Sₙ
+   - After `rw [Lp.ext_iff]`, prove both sides equal `E.indicator 1` a.e. w.r.t. μ
+   - `hlhs`: coeFn of extByZeroCLM f = Sₙ.indicator (coeFn f) a.e. (from `memLp_indicator_of_restrict_loc.coeFn_toLp`)
+   - `hkey`: Sₙ.indicator (coeFn f) = E.indicator 1 a.e. — **key technique**:
+     - `coeFn_toLp` for `MemLp f p (μ.restrict Sₙ)` gives `=ᵐ[μ.restrict Sₙ]`, NOT `=ᵐ[μ]`
+     - Convert via `(ae_restrict_iff' hSₙ).mp coeFn_toLp`: from `=ᵐ[μ.restrict Sₙ]` to `∀ᵐ a ∂μ, a ∈ Sₙ → coeFn a = E.indicator 1 a`
+     - Then `filter_upwards` + `by_cases hn : a ∈ Sₙ` to handle both cases
+   - Chain: `exact hlhs.trans hkey |>.trans hrhs.symm`
+
+3. **Proved `hagree_n`**: `φ(1_E) = ∫_E g_seq n dμ` for E ⊆ Sₙ, μ(E) ≠ ⊤
+   - Rewrite: `φ(1_E) = φ(extByZeroCLM(1_E^Lp(μₙ)))` via `hext_ind`
+   - Apply `hg_seq_rep n`: = `∫ coeFn(1_E^Lp(μₙ)) * g_seq n ∂(μ.restrict Sₙ)`
+   - Simplify indicator via `integral_indicator hE` + `Measure.restrict_restrict hE` + `Set.inter_eq_left.mpr hEn`
+
+4. **1 sorry remains in `localization_existence`**: consistency + MCT + global g construction
+
+### Key Findings
+
+- **`ae_restrict_iff'` as type bridge**: `coeFn_toLp` for `MemLp f p (μ.restrict S)` gives `=ᵐ[μ.restrict S]`; use `(ae_restrict_iff' hS).mp` to get `∀ᵐ a ∂μ, a ∈ S → f a = ...`
+- **Chain direction matters**: `hlhs.trans hkey |>.trans hrhs.symm` (NOT circular)
+- `Measure.restrict_restrict hE : (μ.restrict Sₙ).restrict E = μ.restrict (E ∩ Sₙ)` — useful for changing integral base
+- **PR #15485**: `fix/cs-localization-hext-ind` (fresh branch from main, 1 commit, 66 lines new)
+
+### Files Modified
+
+- `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` (main repo, +66 lines)
+
+### Next Steps
+
+1. **Prove consistency**: `g_seq m =ᵐ[μ.restrict Sₘ] g_seq n` for m ≤ n
+   - For E ⊆ Sₘ ⊆ Sₙ: `hagree_n m E ... = hagree_n n E ...`
+   - Apply `ae_eq_restrict_of_forall_setIntegral_eq` (AEEqOfIntegral.lean:403)
+2. **Prove MCT step**: define `g := fun a => lim (g_seq · a)` (limit exists by consistency a.e.)
+   - `MemLp g q μ` via `lintegral_iUnion` + monotone bound from `‖φₙ‖ ≤ ‖φ‖`
+3. **Prove indicator agreement**: `φ(1_{E∩Sₙ}) → φ(1_E)` via `lp_truncation_tendsto_zero` already proved
+
+---
+
 ## Session 2026-05-04 (Session 3) — extByZeroCLM + Localization Structure
 
 **Mode**: REVISIT (ACT)

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01.json
@@ -29,33 +29,40 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 1 sorry remains (MCT/consistency for g \u2208 Lq). extByZeroCLM + finite-measure Riesz application proved. Awaiting Docker build verification.",
+    "progressSummary": "PROGRESS: 1 sorry remains in localization_existence (consistency+MCT); hext_ind+hagree_n proved this session",
     "builtItems": [
       "integrationCLM_sf: integration CLM for pure SigmaFinite mu",
       "integral_representation_sf: density extension via Lp.induction",
       "riesz_lp_surjective_sigma_finite: main theorem with Step C proved",
       "mem_spanningSets_eventually + pointwise_mul_indicator_tendsto (ported)",
       "lp_truncation_tendsto_zero: Lp truncation DCT proof via ENNReal dominated convergence + continuity of rpow (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean:249)",
-      "eLpNorm_indicator_eq_restrict_loc: eLpNorm(S.indicator f, \u03bc) = eLpNorm(f, \u03bc.restrict S) via lintegral_indicator",
-      "memLp_indicator_of_restrict_loc: MemLp(S.indicator f, \u03bc) from MemLp(f, \u03bc.restrict S) + aestronglyMeasurable_indicator_iff",
-      "extByZeroCLM: isometric CLM Lp(\u03bc.restrict S) \u2192L[\u211d] Lp(\u03bc), proved with ae_restrict_iff + coeFn_toLp"
+      "eLpNorm_indicator_eq_restrict_loc: eLpNorm(S.indicator f, μ) = eLpNorm(f, μ.restrict S) via lintegral_indicator",
+      "memLp_indicator_of_restrict_loc: MemLp(S.indicator f, μ) from MemLp(f, μ.restrict S) + aestronglyMeasurable_indicator_iff",
+      "extByZeroCLM: isometric CLM Lp(μ.restrict S) →L[ℝ] Lp(μ), proved with ae_restrict_iff + coeFn_toLp",
+      "hext_ind: AE equality extByZeroCLM indicator = Lp indicator in localization_existence (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean:365)",
+      "hagree_n: φ(1_E) = ∫_E g_seq n for E ⊆ Sₙ (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean:401)"
     ],
     "insights": [
       "Step C (density extension) proved: Lp.induction is valid for SigmaFinite without IsFiniteMeasure",
-      "integrationCLM does not need IsFiniteMeasure \u2014 Holder inequality suffices",
+      "integrationCLM does not need IsFiniteMeasure — Holder inequality suffices",
       "3 sorries reduced to 2: localization + Vitali remain; density extension proved",
-      "lp_truncation_tendsto_zero uses ENNReal dominated convergence (tendsto_lintegral_of_dominated_convergence) + continuity of x\u21a6x^r at 0 via ENNReal.continuousAt_rpow_const \u2014 no Vitali needed",
+      "lp_truncation_tendsto_zero uses ENNReal dominated convergence (tendsto_lintegral_of_dominated_convergence) + continuity of x↦x^r at 0 via ENNReal.continuousAt_rpow_const — no Vitali needed",
       "localization_existence (last sorry) submitted to Aristotle job 1eb03084-d2a8-4280-ac52-12e23d7ca689 on 2026-05-04. Strategy: spanningSets exhaustion + finite-measure Riesz + MCT gluing. ~150 lines estimated.",
-      "localization_existence needs extByZeroCLM to compose \u03c6 with restriction, then riesz_lp_surjective_from_rn applies to each spanning set",
-      "The MCT/consistency step (g\u2099\u2192g globally in Lq) is the only remaining sorry; all infrastructure is now in place"
+      "localization_existence needs extByZeroCLM to compose φ with restriction, then riesz_lp_surjective_from_rn applies to each spanning set",
+      "The MCT/consistency step (gₙ→g globally in Lq) is the only remaining sorry; all infrastructure is now in place",
+      "ae_restrict_iff type bridge: coeFn_toLp for MemLp f p (μ.restrict S) gives =ᵐ[μ.restrict S]; use (ae_restrict_iff hS).mp to get ∀ᵐ a ∂μ, a ∈ S → f a = ...",
+      "AE chain direction: hlhs.trans hkey |>.trans hrhs.symm avoids circular chains",
+      "hext_ind proved: extByZeroCLM(Sₙ)(1_E^Lp(μₙ)) = 1_E^Lp(μ) for E ⊆ Sₙ via ae chain",
+      "hagree_n proved: φ(1_E) = ∫_E g_seq n dμ for E ⊆ Sₙ with finite measure, via hext_ind + hg_seq_rep + integral_indicator"
     ],
     "mathlibGaps": [
       "Lp restriction map Lp(mu) -> Lp(mu.restrict S) not available as isometric map",
       "Vitali convergence theorem (tendsto_Lp_of_tendsto_ae) API verbosity for unifIntegrable + unifTight"
     ],
     "nextSteps": [
-      "Prove MCT/consistency: g\u2099 (from finite Riesz on \u03bc.restrict S\u2099) are consistent a.e., uniform Lq bound \u2016g\u2099\u2016 \u2264 \u2016\u03c6\u2016, MCT gives g \u2208 Lq(\u03bc)",
-      "Prove indicator agreement: 1_{E\u2229S\u2099} \u2192 1_E in Lp by DCT (\u03bc(E)<\u221e), continuity of \u03c6 + DCT for integral"
+      "Prove consistency: g_seq m =ᵐ[μ.restrict Sₘ] g_seq n via ae_eq_restrict_of_forall_setIntegral_eq (AEEqOfIntegral.lean:403)",
+      "Define global g := lim g_seq pointwise, prove MemLp g q μ via lintegral_iUnion bound",
+      "Prove indicator agreement: φ(1_{E∩Sₙ}) → φ(1_E) via CLM continuity + lp_truncation_tendsto_zero"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Advances `localization_existence` (Step A of sigma-finite Lp Riesz representation theorem) with two structured proof steps
- `hext_ind`: proves `extByZeroCLM(Sₙ)(1_E^Lp(μₙ)) = 1_E^Lp(μ)` for E ⊆ Sₙ, using `ae_restrict_iff'` to convert `coeFn_toLp` from `=ᵐ[μ.restrict Sₙ]` to `=ᵐ[μ]`
- `hagree_n`: proves `φ(1_E) = ∫_E g_seq n dμ` for all E ⊆ Sₙ with finite μ-measure

## Details

Previous state (from merged #15462): single `sorry` for consistency + MCT in `localization_existence`

New state: `choose g_seq` + `hext_ind` + `hagree_n` proved; 1 sorry remains for:
- Consistency: `g_seq m =ᵐ[μ.restrict Sₘ] g_seq n` via `ae_eq_restrict_of_forall_setIntegral_eq`
- MCT: define global `g := lim g_seq`, prove `MemLp g q μ` via `lintegral_iUnion` bound
- Indicator agreement: `φ(1_{E∩Sₙ}) → φ(1_E)` (via `lp_truncation_tendsto_zero`) + `∫_{E∩Sₙ} g dμ → ∫_E g dμ` (via `tendsto_setIntegral_of_monotone`)

## Test plan

- [ ] Docker build passes for `Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01`
- [ ] 1 sorry remains (localization_existence MCT step), down from 2 in session 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)