### PR TITLE
fix(meta): sync stale theoremCount for erdos-671 and erdos-367

### DIFF
--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -76,9 +76,7 @@
       "Basic real analysis (logarithms, limits, sequences)"
     ],
     "date": "1980",
-    "lineCount": 436,
-    "assumptions": "1 axiom: van_doorn_lower_bound (deep result: infinitely many n with product B₂ ≥ cn²log(n), used to prove strong bound fails for k≥3)",
-    "theoremCount": 13
+    "assumptions": "1 axiom: van_doorn_lower_bound (deep result: infinitely many n with product B₂ ≥ cn²log(n), used to prove strong bound fails for k≥3)"
   },
   "overview": {
     "historicalContext": "**Erdős Problem #367: Products of 2-Full Parts**\n\nThis problem connects two classical themes in multiplicative number theory: the distribution of powerful numbers and the multiplicative structure of consecutive integers.\n\n**Background:** The 2-full (or squareful) part $B_2(n)$ captures the 'square content' of $n$'s prime factorization. Golomb (1970) introduced powerful numbers (where every prime divides with exponent $\\geq 2$) and studied their distribution. The function $B_2$ generalizes this: $B_2(n) = \\prod_{v_p(n) \\geq 2} p^{v_p(n)}$ extracts the powerful component from any integer.\n\n**The problem:** Erdős asked whether $\\prod_{n \\leq m < n+k} B_2(m) \\ll n^{2+o(1)}$ for every fixed $k$. The exponent 2 is natural: since $B_2(n) \\leq n$, the product of $k$ terms is at most $n^k$, but heuristically most $B_2(m)$ are small, so the 'effective' exponent should be much less than $k$.\n\n**Progress:**\n- For $k \\leq 2$: the strong bound $\\ll n^2$ holds trivially ($B_2(n) \\leq n$).\n- **van Doorn (2023):** Proved the strong bound **fails** for $k \\geq 3$. Specifically, there exist infinitely many $n$ with $\\prod_{m=n}^{n+2} B_2(m) \\gg n^2 \\log n$. The construction uses the Chinese Remainder Theorem to find $n$ where multiple consecutive integers have large square factors.\n- The **weak bound** $n^{2+o(1)}$ (with the logarithmic slack) remains open for all $k \\geq 3$.",

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -70,7 +70,7 @@
     "axiomCount": 3,
     "lineCount": 396,
     "assumptions": "3 axiom(s) and 7 sorry(s). See the Lean source for details.",
-    "theoremCount": 14
+    "theoremCount": 18
   },
   "overview": {
     "historicalContext": "**Erdos Problem #671**\n\nThis is a deep problem in approximation theory about the relationship between the Lebesgue function and Lagrange interpolation convergence.\n\n**Key History:**\n- 1931: Bernstein proves lambda_n(x) diverges at some point for any interpolation scheme\n- 1980: Erdos and Vertesi prove that for any points, some continuous f has |L^n f(x)| -> infinity a.e.\n- Present: Questions 1 and 2 remain open with $250 prize\n\n**Mathematical Context:**\nThe Lebesgue function lambda_n(x) = sum |p_i^n(x)| controls interpolation error: the error is bounded by (1 + Lambda_n) times the best polynomial approximation. When Lambda_n grows, uniform convergence fails. The questions ask whether *pointwise* convergence can still occur when lambda_n diverges.",


### PR DESCRIPTION
## Fix

Two gallery proofs had stale `meta.theoremCount` fields:

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| `erdos-671` | `theoremCount: 14` | `theoremCount: 18` |
| `erdos-367` | `theoremCount: 13` | `theoremCount: 16` |

Both `leanFile.theoremCount` fields were already correct (18 and 16 respectively). The stale `meta.theoremCount` values had not been updated after the Lean files grew.

Additionally, `erdos-367/meta.json` had duplicate JSON keys (`lineCount` and `theoremCount` appeared twice in the `meta` object). The duplicates were removed; the correct unique values remain.

---
Automated fix by lean-mechanic agent.