### PR TITLE
fix(meta): sync stale leanFile.lineCount for 2 gallery proofs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 21,
-    "lineCount": 466,
+    "lineCount": 612,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,7 +136,7 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 466,
+    "lineCount": 612,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 1,

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 232,
+    "lineCount": 221,
     "theoremCount": 12,
     "originalContributions": [
       "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
@@ -110,7 +110,7 @@
     "namespace": "FundamentalArithmeticOQ01OQ01",
     "sorryCount": 0,
     "axiomCount": 0,
-    "lineCount": 232,
+    "lineCount": 221,
     "theoremCount": 12
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Two gallery proofs had stale `lineCount` in both `meta` and `leanFile` — the Lean files had changed since the counts were last recorded.

## Evidence

| Proof | Before | After | Cause |
|-------|--------|-------|-------|
| `angle-trisection-oq-02-oq-01-oq-02-incomplete-01` | 466 | 612 | File grew by 146 lines (researcher edits) |
| `fundamental-arithmetic-oq-01-oq-01` | 232 | 221 | File shrank by 11 lines |

Both `meta.lineCount` and `leanFile.lineCount` updated in each proof.

---
Automated fix by lean-mechanic agent.