### PR TITLE
fix(meta): add missing leanFile objects to 9 gallery proofs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
@@ -139,5 +139,14 @@
       "proofId": "binary-gcd-oq-01-oq-03",
       "relationship": "sibling — further binary GCD variants and extended algorithms"
     }
-  ]
+  ],
+  "leanFile": {
+    "namespace": "BezoutIdentityOQ01OQ01",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -3,6 +3,15 @@
   "title": "Lp Riesz Representation for Sigma-Finite Measures (Complete)",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
   "description": "Advances the sigma-finite Lp Riesz representation from 3 sorries to 1 by proving Step C (density extension, Session 1) and Step B (Lp truncation convergence via Vitali, Session 2). Only localization_existence (Step A, ~150 lines of Lp restriction map infrastructure) remains as a sorry.",
+  "leanFile": {
+    "namespace": "RieszSigmaFiniteComplete",
+    "lineCount": 452,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
+    "sorries": 1
+  },
   "meta": {
     "status": "formalized",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
@@ -17,7 +26,7 @@
     "badge": "formalized",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 386,
+    "lineCount": 452,
     "assumptions": "1 HARD sorry remaining (down from 3): localization_existence (~150 lines, Lp restriction map infrastructure). Step C (density extension) and Step B (lp_truncation_tendsto_zero via Vitali) are both fully proved.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -134,5 +134,14 @@
       "relationship": "sibling",
       "description": "Spherical Ceva via unit vectors — uses the same sin-ratio formula for the Ceva product"
     }
-  ]
+  ],
+  "leanFile": {
+    "namespace": "CevasTheoremNonEuclideanOQ02OQ01",
+    "lineCount": 273,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/CevasTheoremNonEuclideanOQ02OQ01.lean",
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -112,5 +112,14 @@
       "proofId": "picks-theorem-oq-02",
       "relationship": "related"
     }
-  ]
+  ],
+  "leanFile": {
+    "namespace": "RouthTheorem",
+    "lineCount": 231,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 3,
+    "path": "Proofs/CevasTheoremOQ01OQ03.lean",
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -144,5 +144,14 @@
       "author": "Hughes and Piper",
       "year": 1973
     }
-  ]
+  ],
+  "leanFile": {
+    "namespace": "MoultonPlane",
+    "lineCount": 298,
+    "axiomCount": 0,
+    "theoremCount": 29,
+    "definitionCount": 2,
+    "path": "Proofs/DesarguesTheoremOQ01OQ01.lean",
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
@@ -160,5 +160,14 @@
       "description": "Original gallery entry; OQ-01 and OQ-04 provide non-vacuous formalizations"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "namespace": "GodelDiagonal",
+    "lineCount": 242,
+    "axiomCount": 5,
+    "theoremCount": 9,
+    "definitionCount": 6,
+    "path": "Proofs/GodelFirstIncompletenessOQ01OQ04.lean",
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -117,5 +117,14 @@
       "proofId": "infinitude-primes-oq-03",
       "relationship": "sibling — elementary proof of infinitely many primes ≡ 2 (mod 3); same Euclid-style strategy, different modulus, no quadratic residue theory needed"
     }
-  ]
+  ],
+  "leanFile": {
+    "namespace": "InfinitudePrimes4k3OQ03",
+    "lineCount": 104,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/inverse-galois-d4/meta.json
+++ b/src/data/proofs/inverse-galois-d4/meta.json
@@ -103,5 +103,14 @@
       "proofId": "inverse-galois-f20",
       "relationship": "sibling — companion F₂₀ realization via X⁵-2/ℚ (analogous construction for degree 5)"
     }
-  ]
+  ],
+  "leanFile": {
+    "namespace": "InverseGaloisExtensions",
+    "lineCount": 683,
+    "axiomCount": 0,
+    "theoremCount": 27,
+    "definitionCount": 2,
+    "path": "Proofs/InverseGaloisD4.lean",
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -77,7 +77,14 @@
       "endLine": 64,
       "summary": "Three reduction steps: multiplicativity (`legendreSym_mul_eq`), first supplementary law (`legendreSym_neg_one_eq`), and the reciprocity swap (`reciprocity_swap`). Each is a one-line wrapper presenting the Mathlib result in the form needed by the algorithm.",
       "mathContext": "Multiplicativity: $\\left(\\tfrac{ab}{p}\\right) = \\left(\\tfrac{a}{p}\\right)\\left(\\tfrac{b}{p}\\right)$ (from `map_mul`). First supplementary law: $\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2}$ (from `legendreSym.at_neg_one`). Reciprocity swap: $\\left(\\tfrac{q}{p}\\right) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}\\left(\\tfrac{p}{q}\\right)$ (from `legendreSym.quadratic_reciprocity'`).",
-      "relatedConcepts": ["Legendre symbol", "multiplicativity", "first supplementary law", "Quadratic Reciprocity", "legendreSym.quadratic_reciprocity'", "map_mul"]
+      "relatedConcepts": [
+        "Legendre symbol",
+        "multiplicativity",
+        "first supplementary law",
+        "Quadratic Reciprocity",
+        "legendreSym.quadratic_reciprocity'",
+        "map_mul"
+      ]
     },
     {
       "id": "examples",
@@ -86,7 +93,13 @@
       "endLine": 95,
       "summary": "Seven concrete Legendre symbol computations verified by `decide`: (3/7)=−1, (2/7)=1, (5/13)=−1, (7/11)=−1, (3/5)=−1, (2/17)=1, (6/7)=−1. Each example is annotated with the QR-based hand calculation that `decide` corroborates.",
       "mathContext": "$(3/7) = -1$ (by swap: $(3/7) \\cdot (7/3) = -1$, $(7/3) = (1/3) = 1$); $(2/7) = 1$ ($7 \\equiv -1 \\pmod{8}$); $(6/7) = (2/7)\\cdot(3/7) = 1\\cdot(-1) = -1$ (multiplicativity). `decide` evaluates each via Euler's criterion in `ZMod p` at elaboration time.",
-      "relatedConcepts": ["decide tactic", "Euler's criterion", "second supplementary law", "ZMod decidability", "elaboration-time computation"]
+      "relatedConcepts": [
+        "decide tactic",
+        "Euler's criterion",
+        "second supplementary law",
+        "ZMod decidability",
+        "elaboration-time computation"
+      ]
     },
     {
       "id": "descent",
@@ -95,7 +108,12 @@
       "endLine": 108,
       "summary": "Proves `algorithm_descent`: under `q < p`, the reciprocity swap (q/p) = ±(p/q) reduces the modulus from p to q. The `hqp` hypothesis is unused in the proof body (one-line `exact reciprocity_swap`) but encodes the termination contract at the type level, forcing callers to supply a decreasing measure.",
       "mathContext": "Termination: `hqp : q < p` guarantees modulus decrease. After the swap, $p \\bmod q < q < p$, so each call to `algorithm_descent` strictly reduces the modulus — the decreasing measure for well-founded recursion.",
-      "relatedConcepts": ["well-founded recursion", "algorithm_descent", "decreasing_by", "Euclidean algorithm analogy"]
+      "relatedConcepts": [
+        "well-founded recursion",
+        "algorithm_descent",
+        "decreasing_by",
+        "Euclidean algorithm analogy"
+      ]
     },
     {
       "id": "exports",
@@ -154,5 +172,14 @@
       "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
       "Mathlib.NumberTheory.LegendreSymbol.Basic"
     ]
+  },
+  "leanFile": {
+    "namespace": "QRAlgorithm",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/QuadraticReciprocityOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
@@ -113,5 +113,14 @@
       "proofId": "prime-number-theorem-oq-01",
       "relationship": "related — prime distribution; density arguments for Wilson prime counts via Mertens' theorem"
     }
-  ]
+  ],
+  "leanFile": {
+    "namespace": "WilsonPrimesOQ01",
+    "lineCount": 124,
+    "axiomCount": 2,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/WilsonsTheoremOQ01OQ01.lean",
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

10 gallery proofs had Lean source files but no leanFile metadata block.

## Evidence

**Before**: 10 proofs with `proofRepoPath` but missing `leanFile` object
**After**: All 10 proofs have `leanFile` with namespace, lineCount, axiomCount, theoremCount, definitionCount, path, and sorries

Proofs fixed:
- bezout-identity-oq-01-oq-01 (189 lines, 6 theorems, 0 sorries)
- cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01 (452 lines, 12 theorems, 1 sorry)
- cevas-theorem-non-euclidean-oq-02-oq-01 (273 lines, 10 theorems)
- cevas-theorem-oq-01-oq-03 (231 lines, 19 theorems)
- desargues-theorem-oq-01-oq-01 (298 lines, 29 theorems)
- godel-first-incompleteness-oq01-oq-04 (242 lines, 9 theorems, 5 axioms)
- infinitude-primes-4k3-oq-03 (104 lines, 4 theorems)
- inverse-galois-d4 (683 lines, 27 theorems)
- quadratic-reciprocity-oq-03 (119 lines, 4 theorems)
- wilsons-theorem-oq-01-oq-01 (124 lines, 8 theorems, 2 axioms)

---
Automated fix by lean-mechanic agent.