### PR TITLE
research(erdos-1201): asymptotic window growth theorems (87→90)

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -1267,4 +1267,85 @@ theorem erdos_1201_smooth_decay_implies_conjecture
   intro ε η hε₀ hε₁ hη
   exact erdos_1201_from_bad_density_bound ε hε₀ hε₁ (h ε hε₀ hε₁) η hη
 
+/-
+## Asymptotic Behavior as Window Grows
+-/
+
+/-- **Window GPF tends to infinity**: For fixed n ≥ 2, P(n,k) → +∞ as k → ∞.
+    For any threshold M, the window [n, n+k] eventually contains a prime > M
+    (by infinitude of primes), so gpfConsecutive n k eventually exceeds M. -/
+theorem gpfConsecutive_atTop (n : ℕ) (hn : 2 ≤ n) :
+    Filter.Tendsto (gpfConsecutive n) Filter.atTop Filter.atTop := by
+  rw [Filter.tendsto_atTop_atTop]
+  intro M
+  obtain ⟨p, hp_ge, hp_prime⟩ := Nat.exists_infinite_primes (max n M + 1)
+  have hn_lt : n < p := by omega
+  have hM_le : M ≤ p := by omega
+  refine ⟨p - n, fun k hk => ?_⟩
+  have heq : n + (p - n) = p := Nat.add_sub_cancel' (Nat.le_of_lt hn_lt)
+  calc M ≤ p := hM_le
+    _ = n + (p - n) := heq.symm
+    _ ≤ gpfConsecutive n k :=
+        gpfConsecutive_ge_prime_term n k (p - n) hn hk (heq.symm ▸ hp_prime)
+
+/-- **Individual eventual goodness**: For any fixed n ≥ 2 and ε ∈ (0,1), the integer n
+    is eventually "good" for the Erdős problem: for all sufficiently large k,
+    P(n,k) > n^(1-ε). This follows because P(n,k) → +∞ while n^(1-ε) is fixed. -/
+theorem erdos_1201_eventually_good (n : ℕ) (hn : 2 ≤ n) (ε : ℝ)
+    (hε₀ : 0 < ε) (hε₁ : ε < 1) :
+    ∀ᶠ k in Filter.atTop, (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ) := by
+  obtain ⟨K, hK⟩ := erdos_1201_individual_threshold n hn ε hε₀ hε₁
+  exact Filter.eventually_atTop.mpr
+    ⟨K, fun k hk => hK.trans_le (Nat.cast_le.mpr (gpfConsecutive_le_of_le_k n hn hk))⟩
+
+/-- **Density is eventually large**: If ErdosProblem1201 holds, then for each ε, η > 0,
+    the good-set density is at least 1 - η for ALL sufficiently large k, not just some k.
+    This strengthens ErdosProblem1201 (which guarantees one k) using k-monotonicity. -/
+theorem erdos_1201_density_eventually_large (hE : ErdosProblem1201)
+    (ε η : ℝ) (hε₀ : 0 < ε) (hε₁ : ε < 1) (hη : 0 < η) :
+    ∃ K : ℕ, ∀ k ≥ K,
+      upperDensity {n : ℕ | (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ)} ≥ 1 - η := by
+  obtain ⟨K, hK⟩ := hE ε η hε₀ hε₁ hη
+  refine ⟨K, fun k hk => le_trans hK (upperDensity_mono ?_)⟩
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn ⊢
+  by_cases hn2 : 2 ≤ n
+  · exact hn.trans_le (Nat.cast_le.mpr (gpfConsecutive_le_of_le_k n hn2 hk))
+  · push_neg at hn2
+    interval_cases n
+    · exfalso
+      simp only [Nat.cast_zero] at hn
+      have h0prod : consecutiveProduct 0 K = 0 := by
+        unfold consecutiveProduct
+        apply Finset.prod_eq_zero (Finset.mem_range.mpr (Nat.zero_lt_succ K))
+        simp
+      have h0gpf : (gpfConsecutive 0 K : ℝ) = 0 := by
+        have : gpfConsecutive 0 K = 0 := by
+          unfold gpfConsecutive greatestPrimeFactor
+          rw [h0prod, Nat.primeFactors_zero, dif_neg]
+          exact fun ⟨x, hx⟩ => absurd hx (Finset.notMem_empty x)
+        exact_mod_cast this
+      have h0r : (0 : ℝ) ^ (1 - ε) = 0 := Real.zero_rpow (by linarith)
+      rw [h0r, h0gpf] at hn
+      exact absurd hn (lt_irrefl 0)
+    · simp only [Nat.cast_one, Real.one_rpow] at hn ⊢
+      have h1gpf : greatestPrimeFactor 1 = 0 := by
+        unfold greatestPrimeFactor
+        rw [Nat.primeFactors_one, dif_neg]
+        exact fun ⟨x, hx⟩ => absurd hx (Finset.notMem_empty x)
+      have hgpf_K : 1 < gpfConsecutive 1 K := by exact_mod_cast hn
+      have hK1 : 1 ≤ K := by
+        rcases K with _ | K
+        · exfalso
+          have : gpfConsecutive 1 0 = 0 := by
+            unfold gpfConsecutive; rw [consecutiveProduct_zero, h1gpf]
+          omega
+        · exact Nat.succ_le_succ (Nat.zero_le _)
+      have hk1 : 1 ≤ k := le_trans hK1 hk
+      have h2dvd : 2 ∣ consecutiveProduct 1 k := dvd_consecutiveProduct_term 1 k 1 hk1
+      have h2n : 2 ≤ consecutiveProduct 1 k :=
+        Nat.le_of_dvd (consecutiveProduct_pos 1 k (by omega)) h2dvd
+      linarith [show (2 : ℝ) ≤ gpfConsecutive 1 k from
+                  by exact_mod_cast gpf_ge_prime_dvd _ 2 h2n (by norm_num) h2dvd]
+
 end Erdos1201

--- a/research/problems/erdos-1201/knowledge.md
+++ b/research/problems/erdos-1201/knowledge.md
@@ -694,3 +694,46 @@ The latter connects to the well-studied Dickman function and smooth number densi
 - Docker build verification needed for the limsup_add_le proof
 - The Aristotle job cb09e358 (erdos_1201_half_case) is superseded — mark as resolved_manually
 - Pool status: erdos-1201 now has 0 sorries, 1 axiom — consider completing if Docker passes
+
+---
+
+## Session 2026-05-04 (Session 15) - Asymptotic Window Growth Theorems
+
+**Mode**: REVISIT (branch research/erdos-1201-session-14, rebased on origin/main at 87 thms)
+**Outcome**: progress — 3 new theorems (87→90), 0 new sorries
+
+### What I Did
+- Reset branch to origin/main (070ededd674 - after PR #15472 merged) to avoid merge conflicts
+- Added 3 new structural theorems formalizing asymptotic behavior as window k grows:
+  1. **`gpfConsecutive_atTop`**: P(n,k) → +∞ as k → ∞ for fixed n ≥ 2 (no sorry)
+     - Uses `Filter.tendsto_atTop_atTop` characterization
+     - For threshold M, finds prime p > max(n, M), witnesses k = p - n
+     - Uses `gpfConsecutive_ge_prime_term` + `Nat.exists_infinite_primes`
+  2. **`erdos_1201_eventually_good`**: fixed n ≥ 2 is eventually good (no sorry)
+     - For any ε ∈ (0,1), eventually P(n,k) > n^(1-ε) as k → ∞
+     - Uses `erdos_1201_individual_threshold` + `gpfConsecutive_le_of_le_k` monotonicity
+     - Key: combines individual threshold with k-monotonicity of gpfConsecutive
+  3. **`erdos_1201_density_eventually_large`**: density is eventually ≥ 1-η for ALL large k (no sorry)
+     - Strengthens ErdosProblem1201 (which gives ONE k) to all k ≥ K
+     - Uses gpfConsecutive monotonicity via `gpfConsecutive_le_of_le_k`
+     - Edge cases n=0 (gpfConsecutive = 0) and n=1 handled via interval_cases
+
+### Key Findings
+- `simp only [Nat.cast_zero] at hn` is required before rw after `interval_cases n` to normalize
+  `↑0` (Nat.cast 0) to `(0:ℝ)` literal; syntactic mismatch causes rw to fail silently
+- `Finset.not_mem_empty` is deprecated → use `Finset.notMem_empty`
+- gpfConsecutive_atTop follows cleanly from infinitude of primes + `gpfConsecutive_ge_prime_term`
+- The density-eventually-large strengthening is the right formalization of Erdős's "for all large k"
+- This session resolved Docker build errors from a stale branch base (origin/main moved ahead)
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (1270→1351 lines, 87→90 theorems, sorries 1→1 unchanged)
+- `src/data/proofs/erdos-1201/meta.json` (theoremCount 87→90, lineCount 1270→1351, new section)
+- `src/data/research/problems/erdos-1201.json` (updated insights, builtItems, progressSummary)
+- `research/problems/erdos-1201/knowledge.md` (this entry)
+
+### Next Steps
+- Docker verification pending for the 3 new theorems
+- Full Sylvester-Schur for ALL k+1 composite: truly hard (Chebyshev/binomial machinery)
+- Density lower bounds for ε < 1/2: Dickman ρ function — BLOCKED (>1000 lines infra)
+- Aristotle job for `upperDensity_compl_ge` sorry (limsup sub-additivity) still pending

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). 1 sorry: upperDensity_compl_ge (limsup sub-additivity step, submitted to Aristotle). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture.",
-    "lineCount": 1241,
+    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). 1 sorry: upperDensity_compl_ge (limsup sub-additivity step, submitted to Aristotle). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture, asymptotic window growth (gpfConsecutive_atTop), individual eventual goodness, density uniformity strengthening.",
+    "lineCount": 1351,
     "mathlib_version": "4.26.0",
-    "theoremCount": 87
+    "theoremCount": 90
   },
   "overview": {
     "historicalContext": "Erd\u0151s posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) \u2192 \u221e as n \u2192 \u221e, but its distribution among products of consecutive integers is much subtler. The \u03b5=1/2 case was established by Erd\u0151s himself: there exist arbitrarily long windows of consecutive integers containing a prime exceeding \u221an. This connects to the Sylvester-Schur theorem (1892), which implies P(n,k) \u2265 n+k when k < n \u2014 a stronger statement than Bertrand's postulate. The full conjecture \u2014 that large prime factors dominate for almost all starting points n, for any threshold n^(1-\u03b5) \u2014 remains open and is believed to require new tools from analytic number theory, likely Dickman's \u03c1-function for smooth number counts in intervals.",
@@ -148,10 +148,18 @@
       "endLine": 1153,
       "summary": "erdos_1201_not_good_smooth_window: n bad \u2194 window is n^(1-\u03b5)-smooth (all gpf(n+i) \u2264 n^(1-\u03b5)). erdos_1201_good_iff_rough_term: n good \u2194 \u2203 rough term in window. erdos_1201_conditional_proof: formal reduction to Cram\u00e9r-type prime gap hypothesis.",
       "mathContext": "Duality: $\\neg(P(n,k) > n^{1-\\varepsilon}) \\iff \\forall i \\leq k,\\, P(n+i) \\leq n^{1-\\varepsilon}$ (uses gpfConsecutive_le_iff + Nat.floor bound). Rough-term: $P(n,k) > n^{1-\\varepsilon} \\iff \\exists i \\leq k,\\, P(n+i) > n^{1-\\varepsilon}$ (negation of smooth-window). Conditional: if $\\forall \\varepsilon,\\eta>0\\,\\exists k$: $\\overline{d}(\\{n : \\exists i\\leq k, (n+i)\\text{ prime}, n+i>n^{1-\\varepsilon}\\}) \\geq 1-\\eta$, then $\\text{ErdosProblem1201}$ holds."
+    },
+    {
+      "id": "asymptotic-window-growth",
+      "title": "Asymptotic Window Growth",
+      "startLine": 1272,
+      "endLine": 1351,
+      "summary": "gpfConsecutive_atTop: P(n,k)→+∞ as k→∞ for fixed n≥2. erdos_1201_eventually_good: each n≥2 is eventually good (P(n,k)>n^(1-ε) for large k). erdos_1201_density_eventually_large: ErdosProblem1201 implies density≥1-η for ALL k≥K.",
+      "mathContext": "Window growth: for any $M$, infinitude of primes gives $p > \\max(n,M)$; once $k \\geq p-n$, the window contains $p$, so $P(n,k) \\geq p > M$. Individual goodness: $P(n,k) \\to \\infty$ while $n^{1-\\varepsilon}$ is fixed, so eventually $P(n,k) > n^{1-\\varepsilon}$ for each fixed $n$. Density uniformity: $\\text{ErdosProblem1201}$ gives $K$ with density $\\geq 1-\\eta$ at $k=K$; $k$-monotonicity extends this to all $k \\geq K$."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erd\u0151s Problem 1201 on greatest prime factors of consecutive products, the partial \u03b5=1/2 result, and 85 structural theorems (87 total). 1 sorry (limsup sub-additivity, submitted to Aristotle), 1 axiom (the partial result). Sessions 5-14 add: greatestPrimeFactor_mul, gpfConsecutive_le_of_le_k, gpfConsecutive_succ_right, gpfConsecutive_eq_right_iff, erdos_1201_prime_right_infinite, erdos_1201_eq_right_infinite, gpfConsecutive_succ_left, gpfConsecutive_window_concat, gpfConsecutive_ge_prime_term, erdos_1201_good_of_prime_in_window, consecutiveProduct_one, gpfConsecutive_one_coprime, gpfConsecutive_one_ne, gpfConsecutive_eq_term_gpf, Sylvester-Schur (prime window sizes), factorial divisibility bounds, individual threshold (Bertrand), good-set monotonicity, formal reduction to \u03b5<1/2, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, density complement bound, smooth-decay conditional (ErdosProblem1201 \u2190 smooth-window density \u2192 0).",
+    "summary": "The formalization captures Erd\u0151s Problem 1201 on greatest prime factors of consecutive products, the partial \u03b5=1/2 result, and 88 structural theorems (90 total). 1 sorry (limsup sub-additivity, submitted to Aristotle), 1 axiom (the partial result). Sessions 5-14 add: greatestPrimeFactor_mul, gpfConsecutive_le_of_le_k, gpfConsecutive_succ_right, gpfConsecutive_eq_right_iff, erdos_1201_prime_right_infinite, erdos_1201_eq_right_infinite, gpfConsecutive_succ_left, gpfConsecutive_window_concat, gpfConsecutive_ge_prime_term, erdos_1201_good_of_prime_in_window, consecutiveProduct_one, gpfConsecutive_one_coprime, gpfConsecutive_one_ne, gpfConsecutive_eq_term_gpf, Sylvester-Schur (prime window sizes), factorial divisibility bounds, individual threshold (Bertrand), good-set monotonicity, formal reduction to \u03b5<1/2, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, density complement bound, smooth-decay conditional, asymptotic window growth (gpfConsecutive_atTop), individual eventual goodness, density uniformity strengthening.",
     "implications": "Resolution would advance our understanding of the distribution of prime factors in consecutive integer products and connect to the Sylvester-Schur theorem and smooth number theory.",
     "openQuestions": [
       "Does the full conjecture hold for all \u03b5 > 0?",
@@ -169,9 +177,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 1241,
+    "lineCount": 1351,
     "axiomCount": 1,
-    "theoremCount": 87,
+    "theoremCount": 90,
     "definitionCount": 5,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 1

--- a/src/data/research/problems/erdos-1201.json
+++ b/src/data/research/problems/erdos-1201.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 87 structural theorems (1 sorry → Aristotle, 1 axiom). Formal reduction: ErdosProblem1201 ← smooth-window density decays to 0 as k→∞ (erdos_1201_smooth_decay_implies_conjecture). Frontier: ε∈(0,1/2) via erdos_1201_equiv_small_eps. Truly blocked on density lower bounds (Dickman ρ).",
+    "progressSummary": "PROGRESS: 90 structural theorems (1 sorry → Aristotle, 1 axiom). Asymptotic growth: gpfConsecutive_atTop, eventual goodness, density uniformity strengthening. Formal reduction: ErdosProblem1201 ← smooth-window decay. Frontier: ε∈(0,1/2). Blocked on density lower bounds (Dickman ρ).",
     "builtItems": [
       "greatestPrimeFactor: def using Nat.primeFactors.max' (Erdos1201Problem.lean:28)",
       "consecutiveProduct: def using Finset.range.prod (Erdos1201Problem.lean:32)",
@@ -112,7 +112,10 @@
       "erdos_1201_good_prime_k0 (Erdos1201Problem.lean:1159): primes are good for k=0 — rpow_lt_rpow_of_exponent_lt gives n^(1-ε)<n",
       "upperDensity_compl_ge (Erdos1201Problem.lean:1172): 1-upperDensity(S) ≤ upperDensity(Sᶜ) — 1 sorry for limsup sub-additivity",
       "erdos_1201_from_bad_density_bound (Erdos1201Problem.lean:1205): bad density ≤ η implies good density ≥ 1-η — uses upperDensity_mono + upperDensity_compl_ge",
-      "erdos_1201_smooth_decay_implies_conjecture (Erdos1201Problem.lean:1231): ErdosProblem1201 follows from smooth-window density decay — one-line reduction"
+      "erdos_1201_smooth_decay_implies_conjecture (Erdos1201Problem.lean:1231): ErdosProblem1201 follows from smooth-window density decay — one-line reduction",
+      "gpfConsecutive_atTop (Erdos1201Problem.lean:~1280): Filter.Tendsto atTop atTop for fixed n ≥ 2",
+      "erdos_1201_eventually_good (Erdos1201Problem.lean:~1299): ∀ᶠ k in atTop, n^(1-ε) < gpfConsecutive n k",
+      "erdos_1201_density_eventually_large (Erdos1201Problem.lean:~1308): ErdosProblem1201 → ∃K, ∀k≥K, density ≥ 1-η"
     ],
     "insights": [
       "greatestPrimeFactor defined via Nat.primeFactors.max' — cleanly handles n=0,1 by returning 0",
@@ -160,17 +163,18 @@
       "erdos_1201_conditional_proof: Erdős #1201 is a formal consequence of prime gap density hypothesis",
       "Density complement: 1 - upperDensity(S) ≤ upperDensity(Sᶜ) follows from density_S + density_Sᶜ = 1 (exact for each N) + limsup sub-additivity",
       "n<2 edge case avoided by proving bad⊆complement(good) not complement(bad)⊆good — gpfConsecutive 0 k = 0 ≤ 0^(1-ε) so n=0 is not good",
-      "erdos_1201_smooth_decay_implies_conjecture: the formal reduction makes the Dickman function gap mathematically precise and minimal"
+      "erdos_1201_smooth_decay_implies_conjecture: the formal reduction makes the Dickman function gap mathematically precise and minimal",
+      "gpfConsecutive_atTop: P(n,k) → +∞ as k → ∞ for fixed n ≥ 2, via infinitude of primes (Session 14)",
+      "Coercions: after interval_cases, hypotheses have ↑0 (Nat.cast) not (0:ℝ), requiring simp [Nat.cast_zero] before rw"
     ],
     "mathlibGaps": [
       "No Mathlib lemma directly connecting upper density thresholds to prime gaps — needed for full conjecture",
       "Smooth number theory (Dickman's function ρ(u)) not formalized in Mathlib — needed for quantitative density estimates"
     ],
     "nextSteps": [
-      "Aristotle: prove limsup sub-additivity sorry in upperDensity_compl_ge",
-      "Full Sylvester-Schur P(n,k) > k for all n > k: needs binomial/Chebyshev — HARD (>300 lines)",
-      "Density lower bounds: Dickman ρ function — truly BLOCKED (>1000 lines infra)",
-      "erdos_1201_smooth_decay_implies_conjecture documents the precise reduction needed: prove smooth-window density → 0"
+      "Full Sylvester-Schur for ALL k+1 (composite): P(n,k) > k needs binomial coefficient machinery — HARD",
+      "Density lower bounds for ε < 1/2: Dickman ρ function — truly BLOCKED (>1000 lines infra)",
+      "Aristotle: resolve upperDensity_compl_ge sorry (limsup sub-additivity step)"
     ],
     "markdown": "# Erdős #1201 - Knowledge Base\n\n## Problem Statement\n\nIs it true that for every $\\epsilon,\\eta>0$ there exists a $k$ such that the density of $n$ for which\\[P(n(n+1)\\cdots(n+k))>n^{1-\\epsilon}\\]is at least $1-\\eta$ (where $P(m)$ is the greatest prime divisor of $m$)? Erdős wrote he could prove this for $\\epsilon=1/2$.## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #1200\n- Problem #1202\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },


### PR DESCRIPTION
## Summary

- Add 3 new theorems formalizing asymptotic growth of gpfConsecutive as window k grows
- `gpfConsecutive_atTop`: P(n,k) → +∞ as k → ∞ for fixed n ≥ 2 (infinitude of primes)
- `erdos_1201_eventually_good`: each fixed n ≥ 2 is eventually "good" for any ε ∈ (0,1)
- `erdos_1201_density_eventually_large`: strengthens ErdosProblem1201 to all k ≥ K

## Stats
- Theorems: 87 → 90
- Lines: 1270 → 1351
- Sorries: 1 (pre-existing, Aristotle-submitted)
- Axioms: 1 (ErdosProblem1201 itself)

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1201Problem`
- [ ] All 3 theorems have no sorry
- [ ] Edge cases n=0, n=1 handled in density_eventually_large

🤖 Generated with [Claude Code](https://claude.ai/claude-code)