### PR TITLE
enrich(konigsberg-oq-01-oq-02) + fix(dissection-of-cubes-oq-02-wip-01) annotation schemas

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02-wip-01/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-wip-01/annotations.json
@@ -2,97 +2,180 @@
   {
     "id": "ann-piratspan-def",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 20, "endLine": 23 },
+    "range": {
+      "startLine": 20,
+      "endLine": 23
+    },
     "type": "definition",
     "title": "piRatSpan: Rational Multiples of π",
     "content": "Defines piRatSpan as the ℚ-submodule of ℝ spanned by {π}, i.e., the set {q·π | q : ℚ}. This is the 'modulus' for the Dehn invariant: an angle θ contributes zero to the invariant iff θ ∈ piRatSpan, i.e., iff θ/π is rational. The Submodule.span ℚ {Real.pi} construction uses Lean 4's Submodule.span which takes the ℚ-module structure on ℝ.",
     "mathContext": "$\\pi\\mathbb{Q} := \\{q \\cdot \\pi \\mid q \\in \\mathbb{Q}\\} = \\mathrm{span}_{\\mathbb{Q}}\\{\\pi\\} \\subset \\mathbb{R}$ as a $\\mathbb{Q}$-submodule.",
     "significance": "key",
-    "relatedConcepts": ["Submodule", "span", "rational multiples", "Dehn invariant modulus"],
-    "prerequisites": ["ℚ-module structure on ℝ", "Submodule.span"]
+    "relatedConcepts": [
+      "Submodule",
+      "span",
+      "rational multiples",
+      "Dehn invariant modulus"
+    ],
+    "prerequisites": [
+      "ℚ-module structure on ℝ",
+      "Submodule.span"
+    ]
   },
   {
     "id": "ann-angle-class-def",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 24, "endLine": 27 },
+    "range": {
+      "startLine": 24,
+      "endLine": 27
+    },
     "type": "definition",
     "title": "angleClass: Map to ℝ/πℚ",
     "content": "The angleClass function sends each real angle θ to its equivalence class [θ] in the quotient module ℝ ⧸ piRatSpan. Two angles have the same class iff their difference is a rational multiple of π. This is the Dehn invariant's sensitivity: it cannot distinguish angles that differ by rational multiples of π, but can detect irrational multiples.",
     "mathContext": "$\\mathrm{angleClass}(\\theta) = [\\theta] \\in \\mathbb{R}/\\pi\\mathbb{Q}$, where $\\theta \\sim \\theta'$ iff $\\theta - \\theta' \\in \\pi\\mathbb{Q}$.",
     "significance": "key",
-    "relatedConcepts": ["quotient module", "Submodule.mkQ", "angle equivalence"],
-    "prerequisites": ["quotient module construction", "Submodule.mkQ"]
+    "relatedConcepts": [
+      "quotient module",
+      "Submodule.mkQ",
+      "angle equivalence"
+    ],
+    "prerequisites": [
+      "quotient module construction",
+      "Submodule.mkQ"
+    ]
   },
   {
     "id": "ann-dehn-element-def",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 28, "endLine": 31 },
+    "range": {
+      "startLine": 28,
+      "endLine": 31
+    },
     "type": "definition",
     "title": "dehnElement: Tensor Product Dehn Contribution",
     "content": "dehnElement n θ = n ⊗ [θ] in ℝ ⊗_ℚ (ℝ/πℚ), representing the contribution of n edges of dihedral angle θ to the Dehn invariant. The scalar multiplication `(n : ℚ) • (1 ⊗ₜ angleClass θ)` uses the ℚ-module structure: multiplying the ℝ factor by the integer edge count n. For the cube: n=12 (12 edges), θ=π/2. For the tetrahedron: n=6 (6 edges), θ=arccos(1/3).",
     "mathContext": "$D_n(\\theta) = n \\cdot (1 \\otimes_{\\mathbb{Q}} [\\theta]) = (n : \\mathbb{Q}) \\cdot (1 \\otimes [\\theta]) \\in \\mathbb{R} \\otimes_{\\mathbb{Q}} (\\mathbb{R}/\\pi\\mathbb{Q})$.",
     "significance": "key",
-    "relatedConcepts": ["TensorProduct", "scalar multiplication", "Dehn invariant formula"],
-    "prerequisites": ["tensor product over ℚ", "TensorProduct.tmul", "scalar multiplication"]
+    "relatedConcepts": [
+      "TensorProduct",
+      "scalar multiplication",
+      "Dehn invariant formula"
+    ],
+    "prerequisites": [
+      "tensor product over ℚ",
+      "TensorProduct.tmul",
+      "scalar multiplication"
+    ]
   },
   {
     "id": "ann-cube-angle-zero",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 32, "endLine": 43 },
-    "type": "proof",
+    "range": {
+      "startLine": 32,
+      "endLine": 43
+    },
+    "type": "lemma",
     "title": "Cube Angle: π/2 Has Zero Class",
     "content": "Two lemmas establish that the cube's dihedral angle π/2 vanishes in ℝ/πℚ. First, pi_half_mem_piRatSpan shows π/2 ∈ piRatSpan since π/2 = (1/2)·π (via Algebra.smul_def and Submodule.mem_span_singleton). Second, cube_angle_class_zero deduces [π/2] = 0 from the membership via Submodule.Quotient.mk_eq_zero.",
     "mathContext": "$\\pi/2 = (1/2)\\pi \\in \\pi\\mathbb{Q} \\Rightarrow [\\pi/2] = 0 \\in \\mathbb{R}/\\pi\\mathbb{Q}$.",
     "significance": "supporting",
-    "relatedConcepts": ["Submodule.mem_span_singleton", "Submodule.Quotient.mk_eq_zero"],
-    "prerequisites": ["quotient module zero criterion"]
+    "relatedConcepts": [
+      "Submodule.mem_span_singleton",
+      "Submodule.Quotient.mk_eq_zero"
+    ],
+    "prerequisites": [
+      "quotient module zero criterion"
+    ]
   },
   {
     "id": "ann-tetra-angle-nonzero",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 44, "endLine": 59 },
-    "type": "proof",
+    "range": {
+      "startLine": 44,
+      "endLine": 59
+    },
+    "type": "lemma",
     "title": "Tetrahedron Angle: arccos(1/3) Has Nonzero Class",
     "content": "arccos_third_not_mem_piRatSpan derives arccos(1/3) ∉ piRatSpan from tetrahedron_angle_irrational_pi (the Chebyshev recurrence proof in the parent file). If arccos(1/3) = q·π for some q : ℚ, then arccos(1/3)/π = q ∈ ℚ — contradicting irrationality. The proof extracts the rational q from membership in Submodule.mem_span_singleton and converts the smul to multiplication. tetra_angle_class_ne_zero then follows by contraposition.",
     "mathContext": "$\\arccos(1/3)/\\pi \\notin \\mathbb{Q}$ (Niven's theorem) $\\Rightarrow \\arccos(1/3) \\notin \\pi\\mathbb{Q} \\Rightarrow [\\arccos(1/3)] \\neq 0 \\in \\mathbb{R}/\\pi\\mathbb{Q}$.",
     "significance": "key",
-    "relatedConcepts": ["Niven's theorem", "tetrahedron_angle_irrational_pi", "Submodule.mem_span_singleton"],
-    "prerequisites": ["Chebyshev recurrence proof", "Niven's irrationality theorem"]
+    "relatedConcepts": [
+      "Niven's theorem",
+      "tetrahedron_angle_irrational_pi",
+      "Submodule.mem_span_singleton"
+    ],
+    "prerequisites": [
+      "Chebyshev recurrence proof",
+      "Niven's irrationality theorem"
+    ]
   },
   {
     "id": "ann-one-tmul-ne-zero",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 61, "endLine": 84 },
-    "type": "proof",
+    "range": {
+      "startLine": 61,
+      "endLine": 84
+    },
+    "type": "lemma",
     "title": "Tensor Product Nonzero: 1 ⊗ m ≠ 0",
     "content": "This is the key algebraic lemma. For any ℚ-module M and nonzero m : M, the tensor 1 ⊗ₜ m is nonzero in ℝ ⊗_ℚ M. The proof constructs a separating ℚ-linear functional φ : M → ℚ with φ(m) ≠ 0. Since M is a ℚ-vector space (free ℚ-module), choose a basis B and take φ = B.coord b where B.repr m b ≠ 0. Then apply the map id ⊗ φ : ℝ ⊗_ℚ M → ℝ ⊗_ℚ ℚ ≅ ℝ (via TensorProduct.rid), which sends 1 ⊗ m to 1·φ(m) ≠ 0. This reflects that ℝ is faithfully flat over ℚ.",
     "mathContext": "Proof: $\\exists \\phi \\in \\mathrm{Hom}_{\\mathbb{Q}}(M, \\mathbb{Q})$ with $\\phi(m) \\neq 0$ (basis coordinate). Then $(\\mathrm{id}_{\\mathbb{R}} \\otimes \\phi)(1 \\otimes m) = 1 \\cdot \\phi(m) \\neq 0$ in $\\mathbb{R} \\otimes_{\\mathbb{Q}} \\mathbb{Q} \\cong \\mathbb{R}$.",
     "significance": "key",
-    "relatedConcepts": ["faithful flatness", "separating functional", "Module.Free.chooseBasis", "TensorProduct.rid", "LinearMap.lTensor"],
-    "prerequisites": ["tensor product universal property", "free module basis", "axiom of choice"]
+    "relatedConcepts": [
+      "faithful flatness",
+      "separating functional",
+      "Module.Free.chooseBasis",
+      "TensorProduct.rid",
+      "LinearMap.lTensor"
+    ],
+    "prerequisites": [
+      "tensor product universal property",
+      "free module basis",
+      "axiom of choice"
+    ]
   },
   {
     "id": "ann-cube-dehn-zero",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 86, "endLine": 91 },
-    "type": "proof",
+    "range": {
+      "startLine": 86,
+      "endLine": 91
+    },
+    "type": "theorem",
     "title": "D(cube) = 0",
     "content": "cube_dehn_zero proves dehnElement 12 (π/2) = 0. Since angleClass(π/2) = 0 (proved earlier), and tensoring with 0 gives 0, the scalar multiple 12 ⊗ [π/2] = 12 ⊗ 0 = 0. The proof unfolds dehnElement, rewrites using cube_angle_class_zero, then simplifies with simp.",
     "mathContext": "$D(\\text{cube}) = 12 \\cdot (1 \\otimes [\\pi/2]) = 12 \\cdot (1 \\otimes 0) = 0$.",
     "significance": "supporting",
-    "relatedConcepts": ["dehnElement", "cube_angle_class_zero", "tensor product of zero"],
-    "prerequisites": ["cube_angle_class_zero"]
+    "relatedConcepts": [
+      "dehnElement",
+      "cube_angle_class_zero",
+      "tensor product of zero"
+    ],
+    "prerequisites": [
+      "cube_angle_class_zero"
+    ]
   },
   {
     "id": "ann-tetra-dehn-nonzero",
     "proofId": "dissection-of-cubes-oq-02-wip-01",
-    "range": { "startLine": 92, "endLine": 103 },
-    "type": "proof",
+    "range": {
+      "startLine": 92,
+      "endLine": 103
+    },
+    "type": "theorem",
     "title": "D(tetrahedron) ≠ 0 and Invariant Separation",
     "content": "tetra_dehn_ne_zero proves dehnElement 6 (arccos(1/3)) ≠ 0 using smul_ne_zero: the scalar 6 ≠ 0 (by norm_num) and the base element 1 ⊗ [arccos(1/3)] ≠ 0 (by one_tmul_ne_zero with tetra_angle_class_ne_zero). dehn_invariants_differ then combines cube_dehn_zero and tetra_dehn_ne_zero: D(cube) = 0 but D(tet) ≠ 0, so D(cube) ≠ D(tet). This is the invariant separation that underlies Hilbert's Third Problem.",
     "mathContext": "$D(\\text{tet}) = 6 \\cdot (1 \\otimes [\\arccos(1/3)]) \\neq 0$ by smul_ne_zero, since $6 \\neq 0$ and $1 \\otimes [\\arccos(1/3)] \\neq 0$. Thus $D(\\text{cube}) = 0 \\neq D(\\text{tet})$.",
     "significance": "key",
-    "relatedConcepts": ["smul_ne_zero", "one_tmul_ne_zero", "Dehn invariant separation"],
-    "prerequisites": ["tetra_dehn_ne_zero", "cube_dehn_zero", "smul_ne_zero"]
+    "relatedConcepts": [
+      "smul_ne_zero",
+      "one_tmul_ne_zero",
+      "Dehn invariant separation"
+    ],
+    "prerequisites": [
+      "tetra_dehn_ne_zero",
+      "cube_dehn_zero",
+      "smul_ne_zero"
+    ]
   }
 ]

--- a/src/data/proofs/konigsberg-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/annotations.json
@@ -146,6 +146,73 @@
     ]
   },
   {
+    "id": "ann-koe02-open-walk-counting",
+    "proofId": "konigsberg-oq-01-oq-02",
+    "range": { "startLine": 419, "endLine": 504 },
+    "type": "technique",
+    "title": "Open-Walk Counting: Target-Count Excess at the Last Vertex",
+    "content": "`open_walk_last_target_excess` proves that for a walk ending at $w$ (with $w \\neq \\text{walk}[0]$), the count of positions where $w$ is a target exceeds the count where $w$ is a source by exactly 1. Proof: isolate position $n-1$ from the target filter (it contributes one extra since $\\text{walk}[n]=w$), then build a bijection from the remaining target positions $T \\setminus \\{n-1\\}$ to source positions $S$ via $i \\mapsto i+1$. The symmetric lemma `open_walk_first_source_excess` handles the first vertex. Together these prove that an open walk creates an asymmetry of exactly ±1 at its endpoints — the counting foundation for the Eulerian path degree conditions.",
+    "mathContext": "Open walk $v_0 \\to \\cdots \\to v_n$ with $v_0 \\neq v_n = w$: $|\\{i < n : v_{i+1} = w\\}| = |\\{i < n : v_i = w\\}| + 1$. Bijection: $T \\setminus \\{n-1\\} \\to S$ via $i \\mapsto i+1$, where $n-1 \\in T$ is the extra target position. Surjection inverse: $j \\mapsto j-1$ (valid since $v_0 \\neq w$ implies $j \\geq 1$ for any $j \\in S$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_bij with explicit bijection",
+      "walk-position counting",
+      "Eulerian path degree imbalance",
+      "split_ifs + omega pattern"
+    ],
+    "prerequisites": [
+      "Finset.mem_filter",
+      "List.get with bounded index proofs",
+      "Finset.card_bij: requires maps_to, injective, surjective proofs"
+    ]
+  },
+  {
+    "id": "ann-koe02-maxtrail-closed",
+    "proofId": "konigsberg-oq-01-oq-02",
+    "range": { "startLine": 513, "endLine": 728 },
+    "type": "insight",
+    "title": "maxTrail + maxTrail_closed: Greedy Trail is Closed in Balanced Graphs",
+    "content": "`maxTrail E v` is a noncomputable greedy function: at each step, if there is an outgoing edge from the current vertex, follow it (removing it from E); otherwise stop. Termination is by `|E|.card` since each step erases one edge. `maxTrail_closed` proves the key theorem: in a balanced digraph, the greedy trail always returns to its starting vertex. The proof is by contradiction: assume the trail ends at `last_v ≠ v`. By maximality (`maxTrailRem_last_no_out`), all outgoing edges of `last_v` were used, so `src_count(last_v) = outDeg(last_v)`. By `open_walk_last_target_excess`: `tgt_count(last_v) = src_count(last_v) + 1`. But `tgt_count ≤ inDeg(last_v) = outDeg(last_v)` (balance). Contradiction: `outDeg + 1 ≤ outDeg`.",
+    "mathContext": "maxTrail terminates: $|E| \\to |E|-1$ per step (erase one edge). maxTrail_closed: if last vertex $u \\neq v$, then $\\text{outDeg}(u) = \\text{src\\_count}(u)$ (all outgoing edges used) and $\\text{tgt\\_count}(u) = \\text{src\\_count}(u)+1$ (open-walk counting). But $\\text{tgt\\_count}(u) \\leq \\text{inDeg}(u) = \\text{outDeg}(u)$. So $\\text{outDeg}(u)+1 \\leq \\text{outDeg}(u)$ — contradiction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "noncomputable def in Lean 4",
+      "termination_by Finset.card",
+      "greedy algorithm correctness",
+      "balance contradiction",
+      "maxTrailRem_last_no_out"
+    ],
+    "prerequisites": [
+      "Classical.choose: nonconstructive selection of outgoing edge",
+      "Finset.card_erase_lt_of_mem: |E\\ {e}| < |E|",
+      "open_walk_last_target_excess: counting imbalance at last vertex",
+      "IsEulerianBalanced: inDeg = outDeg at every vertex"
+    ]
+  },
+  {
+    "id": "ann-koe02-circuit-exists",
+    "proofId": "konigsberg-oq-01-oq-02",
+    "range": { "startLine": 737, "endLine": 848 },
+    "type": "concept",
+    "title": "Circuit Existence, Balance Preservation, and Path Necessity",
+    "content": "`circuit_exists` applies `maxTrail_closed` directly: start from any vertex with an outgoing edge, run the greedy trail, which is closed by balance, giving a `DirectedCircuit` structure. `remove_circuit_balanced` (sorry'd) would prove that removing a circuit's edges preserves balance — the circuit passes through each vertex equally often as source and target (by `closed_walk_balance`), so both degrees decrease by the same amount. `euler_path_implies_degree_balance` (sorry'd) proves necessity for Eulerian paths: in an open walk from $s$ to $t$, applying `open_walk_first_source_excess` to $s$ and `open_walk_last_target_excess` to $t$ yields the asymmetric degree conditions; closed-walk balance handles interior vertices. These two sorries are the remaining obstacles to eliminating the `directed_eulerian_iff` axiom.",
+    "mathContext": "Circuit existence: $G$ balanced, $|E| \\geq 1 \\Rightarrow \\exists$ directed circuit in $G$. Remove circuit: for each $v$, circuit passes through $v$ equally as source ($s_v$ times) and target ($t_v = s_v$ times by closed-walk balance), so $\\text{outDeg}_{G'}(v) = \\text{outDeg}_G(v) - s_v = \\text{inDeg}_G(v) - s_v = \\text{inDeg}_{G'}(v)$. Path necessity: $s$ has $\\text{outDeg}(s) = \\text{inDeg}(s)+1$ (extra source at start); $t$ has $\\text{inDeg}(t) = \\text{outDeg}(t)+1$ (extra target at end).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "DirectedCircuit structure",
+      "Hierholzer's algorithm: splice circuits together",
+      "remove_circuit_balanced",
+      "euler_path_implies_degree_balance",
+      "open_walk_first/last_source/target_excess"
+    ],
+    "prerequisites": [
+      "maxTrail_closed: greedy trail is closed in balanced graph",
+      "DirectedCircuit: structure with head_eq_last, length_ge_2, steps_in_G",
+      "DiGraph.removeEdgeSet: G' = G minus edge set S",
+      "Finset.sdiff: set difference for Finset"
+    ]
+  },
+  {
     "id": "ann-koe02-applications",
     "proofId": "konigsberg-oq-01-oq-02",
     "range": { "startLine": 1, "endLine": 48 },

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -105,6 +105,14 @@
       "endLine": 389,
       "summary": "Proves eulerian_balanced_sum_zero and eulerian_balanced_implies_degree_balance from the main theorem.",
       "mathContext": "Eulerian circuit $\\Rightarrow$ $\\sum_v \\text{outDeg}(v) = \\sum_v \\text{inDeg}(v)$ (as integers). Eulerian circuit $\\Rightarrow$ $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
+    },
+    {
+      "id": "hierholzer-infrastructure",
+      "title": "Hierholzer Infrastructure: Greedy Trail and Circuit Existence",
+      "startLine": 390,
+      "endLine": 848,
+      "summary": "Develops the mathematical infrastructure for Hierholzer's directed Eulerian algorithm in 6 steps. (1) Open-walk counting: for an open walk u→w (u≠w), target-count(w) = source-count(w)+1. (2) maxTrail: a greedy trail following outgoing edges, terminating since |E| decreases by 1 per step. (3) maxTrail_closed: in a balanced digraph, the greedy trail is always a closed circuit. (4) circuit_exists: every non-empty balanced digraph contains a directed circuit. (5) remove_circuit_balanced (sorry): removing a circuit preserves balance. (6) euler_path_implies_degree_balance (sorry): Eulerian path implies asymmetric degree conditions at start/end. Steps 1–4 are proved; steps 5–6 are sorry'd pending Finset sdiff API work.",
+      "mathContext": "Key theorem: $G$ balanced + $G.edges \\neq \\emptyset$ $\\Rightarrow$ $\\exists$ directed circuit in $G$. Proof: run greedy trail from any vertex $v$ with an outgoing edge; by balance, the trail closes (proof by contradiction using open-walk counting). Removing the circuit preserves balance (each vertex appears equally often as trail source and target)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

**konigsberg-oq-01-oq-02**: Add HierholzerInfrastructure section + 3 annotations for lines 390-848
- Added `hierholzer-infrastructure` section to `sections` array covering lines 390–848 (previously uncovered)
- `ann-koe02-open-walk-counting` (419–504): bijection proof for open-walk counting
- `ann-koe02-maxtrail-closed` (513–728): greedy trail + balance contradiction proof
- `ann-koe02-circuit-exists` (737–848): circuit existence, remove_circuit_balanced, euler_path_implies_degree_balance

**dissection-of-cubes-oq-02-wip-01**: Fix 5 annotation types from invalid 'proof' to valid schema values
- `ann-cube-angle-zero`, `ann-tetra-angle-nonzero`, `ann-one-tmul-ne-zero` → `lemma`
- `ann-cube-dehn-zero`, `ann-tetra-dehn-nonzero` → `theorem`

## Test plan
- [x] pnpm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)