### PR TITLE
audit(tracker): erdos-1201 issues-found — stale sorry count (2026-05-04)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13961,10 +13961,12 @@
       "result": "clean"
     },
     "erdos-1201": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-05-03T12:00:00Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "issues": [
+        "meta.lf.sorries=1 but Lean file has 0 sorries; lf.lineCount=1241 but file has 1270 lines. Fix in-flight: PR #15504"
+      ],
+      "lastAudited": "2026-05-04T04:55:09Z",
+      "result": "issues-found"
     },
     "cantor-diagonalization-oq-01-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
## Audit Finding

**Proof**: erdos-1201  
**Issue**: Stale metadata — sorry count and line count lag the Lean file

**meta.json claims**:
- `lf.sorries: 1`
- `lf.lineCount: 1241`

**Lean file shows** (origin/main, commit 070ededd674):
- 0 sorry occurrences
- 1270 lines

## Root Cause

Commit `070ededd674` ("research(erdos-1201): density complement + smooth-decay conditional — 87 thms, 0 sorries") removed the last sorry from the Lean file but the meta.json was not updated to reflect `lf.sorries=0` and the new line count.

## Fix

**Already in-flight**: PR #15504 ("research(erdos-1201): bad-set structure for ε < 1/2") updates `meta.json` with `sorries=0` and `lineCount=1327`.

No additional action needed — this PR just records the audit finding in the tracker.

---
Discovered during gallery integrity audit (2026-05-04).