### PR TITLE
fix(meta): add missing sorries/theoremCount to 13 leanFile blocks

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -146,7 +146,8 @@
     "sorryCount": 0,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ05.lean",
-    "definitionCount": 2
+    "definitionCount": 2,
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -195,7 +195,8 @@
     "lineCount": 94,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "theoremCount": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -183,7 +183,8 @@
     "lineCount": 10,
     "path": "Proofs/Erdos1155OQ01OQ06.lean",
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "theoremCount": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -115,7 +115,8 @@
     "lineCount": 54,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "theoremCount": 0
   },
   "references": [
     "Szemerédi (1975): On sets of integers containing no k elements in arithmetic progression",

--- a/src/data/proofs/erdos-208/meta.json
+++ b/src/data/proofs/erdos-208/meta.json
@@ -147,7 +147,8 @@
     "lineCount": 182,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "theoremCount": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -185,7 +185,8 @@
     "lineCount": 101,
     "axiomCount": 7,
     "sorries": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "theoremCount": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-497/meta.json
+++ b/src/data/proofs/erdos-497/meta.json
@@ -136,7 +136,8 @@
     "lineCount": 51,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "theoremCount": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -184,7 +184,8 @@
     "lineCount": 79,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "theoremCount": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-520/meta.json
+++ b/src/data/proofs/erdos-520/meta.json
@@ -148,7 +148,8 @@
     "lineCount": 137,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "theoremCount": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-563/meta.json
+++ b/src/data/proofs/erdos-563/meta.json
@@ -109,7 +109,8 @@
     "lineCount": 65,
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "theoremCount": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -120,7 +120,8 @@
     "namespace": "Erdos944",
     "lineCount": 120,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "theoremCount": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -111,7 +111,8 @@
     "sorryCount": 0,
     "axiomCount": 0,
     "lineCount": 221,
-    "theoremCount": 12
+    "theoremCount": 12,
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
@@ -38,8 +38,14 @@
     "historicalContext": "Thomae's function (also called the popcorn function or ruler function) was introduced by Carl Johannes Thomae in 1875. It is defined as f(p/q) = 1/q for rationals in reduced form, and f(x) = 0 for irrationals. It became a landmark example in real analysis, being the first known function that is Riemann integrable yet discontinuous on a dense set — namely all rationals. The continuity characterization (continuous at irrationals, discontinuous at rationals) was a key historical insight. It showed that the set of discontinuities can be dense yet have measure zero, which is exactly the Lebesgue criterion for Riemann integrability. The parent proof (lebesgue-measure-oq-01-oq-01) showed the Lebesgue integral is 0; this proof characterizes the exact set of continuity points."
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real", "Set", "Filter"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Set",
+      "Filter"
+    ],
     "namespace": "LebesgueMeasureOQ01OQ01OQ02",
     "lineCount": 240,
     "axiomCount": 0,
@@ -63,7 +69,8 @@
         "statement": "∀ (x : ℝ), ContinuousAt thomae x ↔ Irrational x",
         "description": "The complete characterization: Thomae's function is continuous exactly at the irrationals"
       }
-    ]
+    ],
+    "sorries": 0
   },
   "overview": {
     "historicalContext": "**A Function Continuous Exactly at the Irrationals**\n\nThomaes's function $f : \\mathbb{R} \\to \\mathbb{R}$, introduced in 1875, is defined by:\n$$f(x) = \\begin{cases} \\frac{1}{q} & x = \\frac{p}{q} \\text{ in lowest terms, } q > 0, \\\\ 0 & x \\in \\mathbb{R} \\setminus \\mathbb{Q}. \\end{cases}$$\nThe function is historically significant as the first example of a Riemann-integrable function that is discontinuous on a dense set (the rationals). The key property is that $f$ is continuous at every irrational and discontinuous at every rational — making its continuity set a dense $G_\\delta$ set (the irrationals) and its discontinuity set a dense $F_\\sigma$ set (the rationals).",
@@ -131,7 +138,11 @@
       "question": "Is Thomae's function Riemann integrable on [0,1], and can this be formally derived from the continuity characterization?",
       "context": "The Lebesgue criterion for Riemann integrability states that a bounded function is Riemann integrable if and only if its set of discontinuities has Lebesgue measure zero. The continuity characterization just proved shows Thomae's function is discontinuous exactly at the rationals, which have measure zero. Hence Thomae's function is Riemann integrable on [0,1] with integral 0. Mathlib has the Lebesgue criterion (intervalIntegral.integrableOn_iff_ae) — can this chain be formalized?",
       "difficulty": "medium",
-      "tags": ["riemann-integration", "lebesgue-criterion", "measure-zero"]
+      "tags": [
+        "riemann-integration",
+        "lebesgue-criterion",
+        "measure-zero"
+      ]
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Fix

13 gallery proofs had leanFile metadata blocks missing the standard `sorries` or `theoremCount` fields, causing incomplete schema coverage.

## Evidence

**Before**: 3 proofs had `sorryCount` (non-standard key) but no `sorries`; 10 proofs missing `theoremCount` entirely
**After**: All 13 proofs have canonical `sorries` and `theoremCount` fields

### Proofs fixed

| Proof | Fix |
|-------|-----|
| algebraic-numbers-countable-oq-05 | add `sorries: 0` (had `sorryCount: 0` only) |
| fundamental-arithmetic-oq-01-oq-01 | add `sorries: 0` (had `sorryCount: 0` only) |
| lebesgue-measure-oq-01-oq-01-oq-02 | add `sorries: 0` (had `sorryCount: 0` only) |
| erdos-1155-oq-01-oq-06 | add `theoremCount: 0` |
| erdos-10 | add `theoremCount: 0` |
| erdos-142 | add `theoremCount: 0` |
| erdos-208 | add `theoremCount: 0` |
| erdos-340 | add `theoremCount: 0` |
| erdos-497 | add `theoremCount: 0` |
| erdos-50 | add `theoremCount: 0` |
| erdos-520 | add `theoremCount: 0` |
| erdos-563 | add `theoremCount: 0` |
| erdos-944 | add `theoremCount: 0` |

The 10 erdős problem files are definition-only stubs with 0 theorems/sorries. The 3 gallery proofs used a legacy `sorryCount` key instead of the canonical `sorries`.

---
Automated fix by lean-mechanic agent.