### PR TITLE
enrich(shannon-source-coding-oq-03): 2 sections, 5th keyInsight, module header + bug fix annotations

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-03/annotations.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-module-header",
+    "proofId": "shannon-source-coding-oq-03",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "context",
+    "title": "Module Header: AEP Problem Statement and Development History",
+    "content": "The module opens with the open question from `shannon-source-coding-oq-03`: can the AEP be formalized using Mathlib's probability infrastructure? It defines empirical entropy empEnt(x) = -(1/n)∑log p(xᵢ) = -(1/n)log P(x₁,...,xₙ) and states the McMillan (1953) theorem: P(|empEnt - H| > ε) ≤ Var[-log p]/nε². The 'Mathematical Status' section at lines 36-40 is a historical artifact recording the original sorry structure — noting that `expVal_marginal` and `empEnt_variance` were unproved when the file was first committed. These sorries were subsequently eliminated in PR #15161. The module header connects AEP to source coding: the typical set T_ε^(n) has |T_ε| ≤ exp(n(H+ε)), enabling compression to rate H(p).",
+    "mathContext": "AEP: $\\Pr\\left(\\left|\\frac{-\\log P(\\mathbf{X}_1^n)}{n} - H(p)\\right| > \\varepsilon\\right) \\leq \\frac{\\mathrm{Var}_p[-\\log p(X)]}{n\\varepsilon^2}$. Empirical entropy: $\\mathrm{empEnt}(\\mathbf{x}) = -\\frac{1}{n}\\sum_{i=1}^n \\log p(x_i)$. McMillan's theorem (1953) first proved this almost surely; the Chebyshev approach here gives explicit finite-$n$ rates.",
+    "significance": "context",
+    "relatedConcepts": ["Asymptotic Equipartition Property", "McMillan theorem", "typical sequences", "source coding theorem", "empirical entropy"],
+    "prerequisites": ["Shannon entropy H(p) = -∑ p log p", "discrete memoryless source model", "Chebyshev concentration inequality"]
+  },
+  {
     "id": "ann-discrete-dist",
     "proofId": "shannon-source-coding-oq-03",
     "range": { "startLine": 59, "endLine": 80 },
@@ -178,5 +190,17 @@
     "significance": "context",
     "relatedConcepts": ["binary entropy", "bits vs nats", "uniform distribution", "maximum entropy"],
     "prerequisites": ["Fin.sum_univ_two", "Real.log_one_div", "uniformBin structure"]
+  },
+  {
+    "id": "ann-aep-summary",
+    "proofId": "shannon-source-coding-oq-03",
+    "range": { "startLine": 446, "endLine": 476 },
+    "type": "insight",
+    "title": "Section VIII: Bug Fix Record — Variance vs Mean in Chebyshev",
+    "content": "The closing summary documents a subtle proof repair that reveals a common pitfall in formalizing concentration inequalities. The original `aep_concentration` proof used `rw [expVal_empEnt]`, which rewrites E[empEnt] = H(p) — the mean identity. But Chebyshev's inequality bounds P(|X - μ| > ε) ≤ Var[X]/ε² — it needs the variance, not the mean. The fix was `rw [empEnt_variance]`, which rewrites E[(empEnt - H)²] = logVar/n. The original rewrite would have introduced H into the expression without actually bounding the fluctuations. This is a pedagogically important bug: the mean and variance are both correct equalities, but only the variance is relevant for the Chebyshev application.",
+    "mathContext": "Wrong: `rw [expVal_empEnt]` uses $\\mathbb{E}[\\mathrm{empEnt}] = H$ — this rewrites $H$ in the expression but does not bound $\\mathrm{Var}[\\mathrm{empEnt}]$. Correct: `rw [empEnt_variance]` uses $\\mathbb{E}[(\\mathrm{empEnt}-H)^2] = \\mathrm{logVar}/n$, which IS the numerator in Chebyshev: $\\Pr(|\\mathrm{empEnt}-H| > \\varepsilon) \\leq \\mathbb{E}[(\\mathrm{empEnt}-H)^2]/\\varepsilon^2 = \\mathrm{logVar}/(n\\varepsilon^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev's inequality", "variance vs mean", "empEnt_variance", "expVal_empEnt", "concentration proof patterns"],
+    "prerequisites": ["chebyshev_finite (variance bound)", "empEnt_variance (E[(empEnt-H)²]=logVar/n)", "expVal_empEnt (E[empEnt]=H)"]
   }
 ]

--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -64,7 +64,8 @@
       "The `Fintype.prod_sum` identity is the algebraic core: it converts a sum over all n-length sequences into a product of independent per-symbol sums, formalizing the i.i.d. assumption",
       "empEnt is a sum of n i.i.d. random variables Zᵢ = -log p(Xᵢ), each with E[Zᵢ] = H(p). The LLN character of empEnt → H follows immediately from this representation",
       "The Chebyshev approach gives explicit finite-n bounds (not just asymptotic convergence), making it ideal for source coding applications where blocklength matters",
-      "The typical set size bound |T_ε^(n)| ≤ exp(n(H+ε)) is the achievability half of Shannon's source coding theorem: sequences outside T_ε have vanishing probability, so compressing only typical sequences suffices"
+      "The typical set size bound |T_ε^(n)| ≤ exp(n(H+ε)) is the achievability half of Shannon's source coding theorem: sequences outside T_ε have vanishing probability, so compressing only typical sequences suffices",
+      "**Variance not mean drives Chebyshev**: The crucial proof repair was that `aep_concentration` requires `empEnt_variance` (rewriting E[(empEnt−H)²] = logVar/n) rather than `expVal_empEnt` (which rewrites E[empEnt] = H). Chebyshev bounds variance — using the mean rewrite produces a tautology that never establishes concentration"
     ],
     "prerequisites": [
       "Shannon entropy H(X) = -∑ p(x) log p(x)",
@@ -74,6 +75,14 @@
     ]
   },
   "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header: Problem Statement and Proof Architecture",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring states OQ-03, defines AEP and empirical entropy, outlines Chebyshev proof strategy, and explains connection to source coding. Historical note: Mathematical Status section records the original sorry structure before variance proof was completed.",
+      "mathContext": "AEP: $P\\left(\\left|\\frac{-\\log P(\\mathbf{X})}{n} - H(p)\\right| > \\varepsilon\\right) \\leq \\frac{\\mathrm{Var}_p[-\\log p(X)]}{n\\varepsilon^2} \\to 0$. Typical set: $T_\\varepsilon^{(n)} = \\{\\mathbf{x} : |\\mathrm{empEnt}(\\mathbf{x}) - H| \\leq \\varepsilon\\}$, $|T_\\varepsilon^{(n)}| \\leq e^{n(H+\\varepsilon)}$."
+    },
     {
       "id": "distributions",
       "title": "Probability Distributions",
@@ -129,6 +138,14 @@
       "endLine": 445,
       "summary": "uniformBin (fair Bernoulli), uniformBin_entropy: H(uniformBin) = log 2. Concrete instance confirming abstract definitions.",
       "mathContext": "The fair coin distribution $p(0) = p(1) = 1/2$ on $\\text{Fin}\\,2$ satisfies $H = -2 \\cdot (1/2) \\log(1/2) = \\log 2 \\approx 0.693$. The $\\texttt{native\\_decide}$ verification confirms the discrete probability axioms and gives a sanity check that the abstract AEP applies to the simplest non-trivial example."
+    },
+    {
+      "id": "aep-summary",
+      "title": "Section VIII: AEP Summary and Bug Fix Record",
+      "startLine": 446,
+      "endLine": 476,
+      "summary": "Closing summary enumerates all 7 proved theorems. Records key bug fix: aep_concentration originally used rw [expVal_empEnt] (wrong — rewrites E[empEnt]=H) but required rw [empEnt_variance] (correct — rewrites E[(empEnt-H)²]=logVar/n).",
+      "mathContext": "Bug: `rw [expVal_empEnt]` rewrites $\\mathbb{E}[\\mathrm{empEnt}] = H$ (the mean). Fix: `rw [empEnt_variance]` rewrites $\\mathbb{E}[(\\mathrm{empEnt}-H)^2] = \\mathrm{logVar}/n$ (the variance). Chebyshev's inequality requires the variance, not the mean."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

- Add module-header section (lines 1-54) documenting AEP problem setup and historical sorry structure
- Add aep-summary section (lines 446-476) covering the variance-vs-mean bug fix record
- Add 5th keyInsight: variance not mean drives Chebyshev bound
- Add ann-module-header annotation explaining McMillan's theorem and development history
- Add ann-aep-summary annotation explaining the key bug fix (wrong rw vs correct rw)

## Test plan

- [x] pnpm build passes
- [x] 9 sections, 5 keyInsights, 3 openQuestions, 17 annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)