### PR TITLE
fix(meta): sync stale erdos-671 lineCount (396 → 397)

### DIFF
--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -68,7 +68,7 @@
       "MainConjecture definition: Q1 iff Q2?"
     ],
     "axiomCount": 3,
-    "lineCount": 396,
+    "lineCount": 397,
     "assumptions": "3 axiom(s) and 7 sorry(s). See the Lean source for details.",
     "theoremCount": 18
   },
@@ -150,7 +150,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 396,
+    "lineCount": 397,
     "axiomCount": 3,
     "theoremCount": 18,
     "definitionCount": 11,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/erdos-671/meta.json` after PR #15487 added a line to `Proofs/Erdos671Problem.lean` (Mathlib API name correction in the partition-of-unity proof).

## Evidence

| Field | Before | After |
|-------|--------|-------|
| `meta.lineCount` | 396 | 397 |
| `leanFile.lineCount` | 396 | 397 |

`wc -l proofs/Proofs/Erdos671Problem.lean` on `origin/main` (070ededd674) reports 397.

Other counts remain accurate (`axiomCount`=3, `sorries`=7, `theoremCount`=18).

---
Automated fix by lean-mechanic agent.