### PR TITLE
fix(meta): remove legacy leanFile fields from 5 gallery proofs

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -138,14 +138,9 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
-    "filename": "AlgebraicNumbersCountableOQ05.lean",
     "lineCount": 296,
     "theoremCount": 13,
     "axiomCount": 0,
-    "defCount": 2,
-    "sorryCount": 0,
-    "isAristotle": false,
-    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ05.lean",
     "definitionCount": 2,
     "sorries": 0
   },

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
@@ -116,8 +116,7 @@
     "namespace": "StrictlyIncreasingEuler",
     "theoremCount": 12,
     "axiomCount": 0,
-    "defCount": 0,
-    "sorryCount": 0,
+    "definitionCount": 0,
     "lineCount": 208,
     "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
@@ -59,10 +59,7 @@
     "namespace": "BirchSwinnertonDyer.BSD389a",
     "theoremCount": 27,
     "axiomCount": 3,
-    "defCount": 2,
-    "sorryCount": 0,
     "lineCount": 273,
-    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyerOQ06.lean",
     "path": "Proofs/BirchSwinnertonDyerOQ06.lean",
     "sorries": 0,
     "definitionCount": 1

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -109,7 +109,6 @@
   "leanFile": {
     "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
     "namespace": "FundamentalArithmeticOQ01OQ01",
-    "sorryCount": 0,
     "axiomCount": 0,
     "lineCount": 221,
     "theoremCount": 12,

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
@@ -72,7 +72,6 @@
     "namespace": "LebesgueMeasureOQ01OQ03",
     "lineCount": 244,
     "axiomCount": 0,
-    "sorryCount": 0,
     "theoremCount": 15,
     "definitionCount": 0,
     "path": "Proofs/LebesgueMeasureOQ01OQ03.lean",


### PR DESCRIPTION
## Fix

Remove non-standard `leanFile` fields from 5 gallery proof meta.json files that accumulated from earlier agent versions.

## Fields Removed

| Field | Issue |
|-------|-------|
| `sorryCount` | Wrong field name; the standard field is `sorries`. Both were present with identical values — `sorryCount` was redundant. |
| `defCount` | Wrong field name; the standard field is `definitionCount`. In `birch-swinnerton-dyer-oq-06`, `defCount=2` was also factually wrong (actual definition count = 1). |
| `filename` | Redundant with `path` field |
| `isAristotle` | Non-standard, not part of leanFile schema |
| `githubUrl` | Non-standard, not part of leanFile schema |

## Evidence

**Before** (`birch-swinnerton-dyer-oq-06` leanFile):
```json
{
  "namespace": "...",
  "axiomCount": 3,
  "defCount": 2,       ← wrong value (actual=1) AND wrong field name
  "sorryCount": 0,     ← redundant duplicate of sorries
  "githubUrl": "...", ← non-standard
  "sorries": 0,        ← correct field
  "definitionCount": 1 ← correct field
}
```

**After**:
```json
{
  "namespace": "...",
  "axiomCount": 3,
  "definitionCount": 1,
  "sorries": 0
}
```

## Proofs Fixed

- `algebraic-numbers-countable-oq-05` — removed `sorryCount`, `defCount`, `filename`, `isAristotle`, `githubUrl`
- `binomial-theorem-oq-03-oq-02-oq-03` — removed `sorryCount`, `defCount`; renamed to `definitionCount: 0`
- `birch-swinnerton-dyer-oq-06` — removed `sorryCount`, `defCount` (wrong value), `githubUrl`
- `fundamental-arithmetic-oq-01-oq-01` — removed `sorryCount`
- `lebesgue-measure-oq-01-oq-03` — removed `sorryCount`

---
Automated fix by lean-mechanic agent.