### PR TITLE
research(erdos-1201): session 16 — lowerDensity, ErdosProblem1201Strong, complement duality

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -1427,14 +1427,73 @@ theorem erdos_1201_strong_iff_smooth_decay :
         _ ≤ ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + ({1} : Finset ℕ).card :=
               Finset.card_union_le _ _
         _ = ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + 1 := by simp
-    -- Step 4: Derive density bound and conclude via limsup arithmetic
-    -- densityFun(goodᶜ, N) ≤ densityFun(smooth_bad, N) + 1/N for N ≥ 1
-    -- upperDensity goodᶜ = limsup densityFun(goodᶜ)
-    --   ≤ limsup (densityFun smooth_bad + 1/N)   [limsup_le_limsup + counting]
-    --   ≤ limsup densityFun smooth_bad + limsup(1/N)   [limsup subadditivity]
-    --   = upperDensity smooth_bad + 0   [1/N → 0]
-    --   ≤ η   [by hk]
-    -- (The limsup arithmetic is standard; all steps have appropriate boundedness conditions.)
-    sorry
+    -- Step 4: Limsup arithmetic to conclude upperDensity goodᶜ ≤ η
+    simp only [upperDensity, Set.mem_compl_iff, Set.mem_setOf_eq]
+    set dgc := fun N : ℕ => (((Finset.Icc 1 N).filter (fun n => n ∉ good)).card : ℝ) / N
+    set dbad := fun N : ℕ =>
+      (((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card : ℝ) / N
+    -- Pointwise: dgc N ≤ dbad N + 1/N for N ≥ 1
+    have h_card : ∀ N : ℕ, 0 < N → dgc N ≤ dbad N + 1 / N := by
+      intro N hN
+      simp only [dgc, dbad]
+      rw [div_add_div_same]
+      apply div_le_div_of_nonneg_right _ (Nat.cast_nonneg N)
+      norm_cast
+      exact hcard_bound N (by omega)
+    -- limsup dgc ≤ limsup (dbad + 1/N)
+    have h_limsup_le : Filter.limsup dgc Filter.atTop ≤
+        Filter.limsup (fun N => dbad N + 1 / N) Filter.atTop :=
+      Filter.limsup_le_limsup
+        (Filter.eventually_atTop.mpr ⟨1, fun N hN => h_card N (by omega)⟩)
+        ⟨0, fun a ha => by
+          by_contra hlt; push_neg at hlt
+          obtain ⟨N, hN⟩ := ha.exists
+          have h0 : (0 : ℝ) ≤ dgc N := by
+            simp only [dgc]; rcases Nat.eq_zero_or_pos N with rfl | hNpos
+            · simp
+            · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+          linarith⟩
+        ⟨2, Filter.Eventually.of_forall fun N => by
+          simp only [dbad]; rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · apply add_le_add
+            · apply div_le_one_of_le _ (Nat.cast_nonneg N)
+              have hcard : (Finset.Icc 1 N).card = N := by rw [Finset.Nat.card_Icc]; omega
+              exact_mod_cast (Finset.card_filter_le _ _).trans hcard.le
+            · exact div_le_one_of_le (by exact_mod_cast hN) (Nat.cast_nonneg N)⟩
+    -- limsup (dbad + 1/N) ≤ limsup dbad + limsup(1/N)
+    have h_subadd : Filter.limsup (fun N => dbad N + 1 / (N : ℝ)) Filter.atTop ≤
+        Filter.limsup dbad Filter.atTop +
+        Filter.limsup (fun N : ℕ => (1 : ℝ) / N) Filter.atTop :=
+      limsup_add_le
+        ⟨0, Filter.Eventually.of_forall fun N => by
+          simp only [dbad]; rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)⟩
+        ⟨1, Filter.Eventually.of_forall fun N => by
+          simp only [dbad]; rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · apply div_le_one_of_le _ (Nat.cast_nonneg N)
+            have hcard : (Finset.Icc 1 N).card = N := by rw [Finset.Nat.card_Icc]; omega
+            exact_mod_cast (Finset.card_filter_le _ _).trans hcard.le⟩
+        ⟨0, fun b hb => by
+          by_contra hlt; push_neg at hlt
+          obtain ⟨N, hN⟩ := hb.exists
+          linarith [div_nonneg zero_le_one (Nat.cast_nonneg N)]⟩
+        ⟨1, Filter.Eventually.of_forall fun N => by
+          rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · exact div_le_one_of_le (by exact_mod_cast hN) (Nat.cast_nonneg N)⟩
+    -- limsup(1/N) = 0 since 1/N → 0
+    have h_1N_zero : Filter.limsup (fun N : ℕ => (1 : ℝ) / N) Filter.atTop = 0 := by
+      have htend : Filter.Tendsto (fun N : ℕ => (1 : ℝ) / N) Filter.atTop (nhds 0) := by
+        simp_rw [one_div]
+        exact tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
+      exact htend.limsup_eq
+    -- limsup dbad ≤ η (from hk)
+    have h_dbad_le : Filter.limsup dbad Filter.atTop ≤ η := by
+      have := hk; simp only [upperDensity] at this; exact this
+    -- Combine: limsup dgc ≤ limsup(dbad + 1/N) ≤ limsup dbad + 0 ≤ η
+    exact h_limsup_le.trans (h_subadd.trans (by linarith [h_1N_zero, h_dbad_le]))
 
 end Erdos1201

--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -1267,4 +1267,174 @@ theorem erdos_1201_smooth_decay_implies_conjecture
   intro ε η hε₀ hε₁ hη
   exact erdos_1201_from_bad_density_bound ε hε₀ hε₁ (h ε hε₀ hε₁) η hη
 
+/-
+## Lower Density and Exact Complement Duality
+-/
+
+/-- Lower density of a set S ⊆ ℕ: lim inf of |S ∩ [1,N]| / N.
+    Dual to `upperDensity` which uses lim sup. -/
+noncomputable def lowerDensity (S : Set ℕ) : ℝ :=
+  haveI : DecidablePred (· ∈ S) := Classical.decPred _
+  Filter.liminf (fun N : ℕ =>
+    (((Finset.Icc 1 N).filter (fun n => n ∈ S)).card : ℝ) / (N : ℝ))
+  Filter.atTop
+
+/-- **Exact complement duality**: lowerDensity(Sᶜ) = 1 - upperDensity(S).
+    This is the EXACT identity (not just inequality), following from:
+    densityFun(S,N) + densityFun(Sᶜ,N) = 1 for N ≥ 1, so
+    liminf(densityFun Sᶜ) = liminf(1 - densityFun S) = 1 - limsup(densityFun S).
+    Key Mathlib lemma: `Filter.liminf_const_sub` from Mathlib.Topology.Algebra.Order.LiminfLimsup. -/
+theorem lowerDensity_compl_eq (S : Set ℕ) : lowerDensity Sᶜ = 1 - upperDensity S := by
+  haveI : DecidablePred (· ∈ S) := Classical.decPred _
+  haveI : DecidablePred (· ∈ Sᶜ) := Classical.decPred _
+  simp only [lowerDensity, upperDensity]
+  have heq : ∀ᶠ N : ℕ in Filter.atTop,
+      (((Finset.Icc 1 N).filter (fun n => n ∈ Sᶜ)).card : ℝ) / N =
+      1 - (((Finset.Icc 1 N).filter (fun n => n ∈ S)).card : ℝ) / N := by
+    apply Filter.eventually_atTop.mpr ⟨1, fun N hN => ?_⟩
+    rw [← sub_div]
+    congr 1
+    have hcompl : (Finset.Icc 1 N).filter (fun n => n ∈ Sᶜ) =
+        (Finset.Icc 1 N) \ (Finset.Icc 1 N).filter (fun n => n ∈ S) := by
+      ext x; simp [Set.mem_compl_iff]
+    rw [hcompl, Finset.card_sdiff (Finset.filter_subset _ _)]
+    have hcard : (Finset.Icc 1 N).card = N := by simp [Finset.Nat.card_Icc]; omega
+    push_cast [Nat.cast_sub (Finset.card_filter_le _ _ |>.trans hcard.symm.le)]
+    simp [hcard]
+  rw [Filter.liminf_congr heq]
+  -- f N = densityFun(S, N) is bounded above by 1 and cobounded below by 0
+  have hbdd : Filter.IsBoundedUnder (· ≤ ·) Filter.atTop
+      (fun N : ℕ => (((Finset.Icc 1 N).filter (fun n => n ∈ S)).card : ℝ) / N) :=
+    ⟨1, Filter.Eventually.of_forall fun N => by
+      rcases Nat.eq_zero_or_pos N with rfl | hN
+      · simp
+      · apply div_le_one_of_le _ (Nat.cast_nonneg N)
+        have hcard : (Finset.Icc 1 N).card = N := by simp [Finset.Nat.card_Icc]; omega
+        exact_mod_cast (Finset.card_filter_le _ _).trans hcard.le⟩
+  -- f is cobounded: ∃ b, ∀ a, (∀ᶠ N, f N ≤ a) → b ≤ a; use b = 0 since f N ≥ 0 always
+  have hcobdd : Filter.IsCoboundedUnder (· ≤ ·) Filter.atTop
+      (fun N : ℕ => (((Finset.Icc 1 N).filter (fun n => n ∈ S)).card : ℝ) / N) :=
+    ⟨0, fun a ha => by
+      obtain ⟨N, hN⟩ := ha.exists
+      exact le_trans (div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)) hN⟩
+  -- liminf (1 - f) = 1 - limsup f by Filter.liminf_const_sub
+  exact Filter.liminf_const_sub 1 hbdd hcobdd
+
+/-- **Exact complement duality (upper)**: upperDensity(Sᶜ) = 1 - lowerDensity(S).
+    Symmetric to `lowerDensity_compl_eq`. -/
+theorem upperDensity_compl_eq (S : Set ℕ) : upperDensity Sᶜ = 1 - lowerDensity S := by
+  have h := lowerDensity_compl_eq Sᶜ
+  simp only [compl_compl] at h
+  linarith
+
+/-- lowerDensity is always at most upperDensity: liminf ≤ limsup. -/
+theorem lowerDensity_le_upperDensity (S : Set ℕ) : lowerDensity S ≤ upperDensity S := by
+  have h1 := upperDensity_compl_ge S       -- 1 - upperDensity S ≤ upperDensity Sᶜ
+  have h2 := upperDensity_compl_eq S       -- upperDensity Sᶜ = 1 - lowerDensity S
+  linarith
+
+/-
+## Strong Conjecture (Lower Density Version)
+-/
+
+/-- **Erdős Problem 1201 (Strong form)**: The density of good n tends to 1 in the LOWER density sense.
+    This is a stronger statement than `ErdosProblem1201` (which uses lim sup / upper density):
+    it asserts that for ALL large N (not just infinitely many), the density approaches 1 - η.
+    The equivalence `erdos_1201_strong_iff_smooth_decay` shows this is precisely equivalent
+    to the smooth-window density decaying to 0. -/
+def ErdosProblem1201Strong : Prop :=
+  ∀ (ε η : ℝ) (hε₀ : 0 < ε) (hε₁ : ε < 1) (hη : 0 < η),
+  ∃ k : ℕ,
+    lowerDensity {n : ℕ | (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ)} ≥ 1 - η
+
+/-- Strong ⟹ weak: if lim inf (good density) ≥ 1 - η, then lim sup ≥ 1 - η. -/
+theorem erdos_1201_strong_implies_weak : ErdosProblem1201Strong → ErdosProblem1201 := by
+  intro hStrong ε η hε₀ hε₁ hη
+  obtain ⟨k, hk⟩ := hStrong ε η hε₀ hε₁ hη
+  exact ⟨k, hk.trans (lowerDensity_le_upperDensity _)⟩
+
+/-- **Equivalence**: ErdosProblem1201Strong ↔ smooth-window-density decays to 0.
+    Forward: strong conjecture → smooth-window density ≤ η (via lowerDensity complement duality).
+    Backward: smooth-window density ≤ η → strong conjecture (via subadditivity + finite correction). -/
+theorem erdos_1201_strong_iff_smooth_decay :
+    ErdosProblem1201Strong ↔
+    ∀ (ε : ℝ), 0 < ε → ε < 1 →
+    ∀ η : ℝ, 0 < η → ∃ k : ℕ,
+      upperDensity {n : ℕ | 2 ≤ n ∧
+        ∀ i ≤ k, (greatestPrimeFactor (n + i) : ℝ) ≤ (n : ℝ) ^ (1 - ε)} ≤ η := by
+  constructor
+  · -- ⟹: Strong conjecture → smooth-window density → 0
+    intro hStrong ε hε₀ hε₁ η hη
+    obtain ⟨k, hk⟩ := hStrong ε η hε₀ hε₁ hη
+    -- hk: lowerDensity(good) ≥ 1 - η
+    -- By complement duality: lowerDensity(good) = 1 - upperDensity(goodᶜ)
+    -- So upperDensity(goodᶜ) = 1 - lowerDensity(good) ≤ η
+    -- Since smooth-bad ⊆ goodᶜ: upperDensity(smooth-bad) ≤ η
+    set good := {n : ℕ | (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ)} with hgood_def
+    set smooth_bad := {n : ℕ | 2 ≤ n ∧ ∀ i ≤ k, (greatestPrimeFactor (n + i) : ℝ) ≤ (n : ℝ) ^ (1 - ε)}
+      with hbad_def
+    have hcompl_bound : upperDensity goodᶜ ≤ η := by
+      have hdual : lowerDensity good = 1 - upperDensity goodᶜ := by
+        have := lowerDensity_compl_eq goodᶜ
+        simp only [compl_compl] at this
+        exact this
+      linarith
+    have hsubset : smooth_bad ⊆ goodᶜ := by
+      intro n ⟨hn2, hsmooth⟩
+      simp only [hgood_def, Set.mem_compl_iff, Set.mem_setOf_eq]
+      exact (erdos_1201_not_good_smooth_window n k ε hn2).mpr hsmooth
+    exact ⟨k, (upperDensity_mono hsubset).trans hcompl_bound⟩
+  · -- ⟸: smooth-window density → 0 → Strong conjecture
+    -- Strategy: goodᶜ ∩ {n ≥ 2} = smooth_bad (by erdos_1201_not_good_smooth_window)
+    -- So |goodᶜ ∩ [1,N]| ≤ |smooth_bad ∩ [1,N]| + 1 (the +1 accounts for n=1 ∈ goodᶜ)
+    -- Hence densityFun(goodᶜ, N) ≤ densityFun(smooth_bad, N) + 1/N for N ≥ 1
+    -- Taking limsup (using 1/N → 0): upperDensity goodᶜ ≤ upperDensity smooth_bad ≤ η
+    -- Then lowerDensity good = 1 - upperDensity goodᶜ ≥ 1 - η by complement duality.
+    intro hSmooth ε hε₀ hε₁ η hη
+    obtain ⟨k, hk⟩ := hSmooth ε hε₀ hε₁ η hη
+    set good := {n : ℕ | (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ)} with hgood_def
+    set smooth_bad := {n : ℕ | 2 ≤ n ∧ ∀ i ≤ k, (greatestPrimeFactor (n + i) : ℝ) ≤ (n : ℝ) ^ (1 - ε)}
+      with hbad_def
+    haveI hd1 : DecidablePred (· ∈ good) := Classical.decPred _
+    haveI hd2 : DecidablePred (· ∈ smooth_bad) := Classical.decPred _
+    -- Step 1: lowerDensity good = 1 - upperDensity goodᶜ (exact complement duality)
+    have hdual : lowerDensity good = 1 - upperDensity goodᶜ := by
+      have := lowerDensity_compl_eq goodᶜ; simp only [compl_compl] at this; exact this
+    -- Step 2: Suffices to show upperDensity goodᶜ ≤ η
+    suffices hgoodc : upperDensity goodᶜ ≤ η from ⟨k, by linarith⟩
+    -- Step 3: Counting argument — goodᶜ ∩ [1,N] ⊆ smooth_bad ∩ [1,N] ∪ {1}
+    -- For n ≥ 2: n ∈ goodᶜ ↔ n ∈ smooth_bad (by erdos_1201_not_good_smooth_window)
+    -- For n = 1: n might be in goodᶜ (if k=0), but n ∉ smooth_bad (smooth_bad requires n ≥ 2)
+    have hcard_bound : ∀ N : ℕ, 1 ≤ N →
+        ((Finset.Icc 1 N).filter (fun n => n ∉ good)).card ≤
+        ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + 1 := by
+      intro N hN
+      -- goodᶜ ∩ [1,N] ⊆ smooth_bad ∩ [1,N] ∪ {1}
+      have hsub : (Finset.Icc 1 N).filter (fun n => n ∉ good) ⊆
+          (Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad) ∪ {1} := by
+        intro x hx
+        simp only [Finset.mem_filter, Finset.mem_Icc, Finset.mem_union,
+                   Finset.mem_singleton] at hx ⊢
+        obtain ⟨⟨hx1, hxN⟩, hxgoodc⟩ := hx
+        simp only [Set.mem_compl_iff, hgood_def, Set.mem_setOf_eq] at hxgoodc
+        by_cases h2 : 2 ≤ x
+        · left
+          exact ⟨⟨hx1, hxN⟩, h2, (erdos_1201_not_good_smooth_window x k ε h2).mp hxgoodc⟩
+        · right; omega
+      calc ((Finset.Icc 1 N).filter (fun n => n ∉ good)).card
+          ≤ ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad) ∪ {1}).card :=
+              Finset.card_le_card hsub
+        _ ≤ ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + ({1} : Finset ℕ).card :=
+              Finset.card_union_le _ _
+        _ = ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + 1 := by simp
+    -- Step 4: Derive density bound and conclude via limsup arithmetic
+    -- densityFun(goodᶜ, N) ≤ densityFun(smooth_bad, N) + 1/N for N ≥ 1
+    -- upperDensity goodᶜ = limsup densityFun(goodᶜ)
+    --   ≤ limsup (densityFun smooth_bad + 1/N)   [limsup_le_limsup + counting]
+    --   ≤ limsup densityFun smooth_bad + limsup(1/N)   [limsup subadditivity]
+    --   = upperDensity smooth_bad + 0   [1/N → 0]
+    --   ≤ η   [by hk]
+    -- (The limsup arithmetic is standard; all steps have appropriate boundedness conditions.)
+    sorry
+
 end Erdos1201

--- a/research/problems/erdos-1201/knowledge.md
+++ b/research/problems/erdos-1201/knowledge.md
@@ -239,3 +239,30 @@ Is it true that for every $\epsilon,\eta>0$ there exists a $k$ such that the den
 - Docker build verification: check `Filter.liminf_const_sub 1 hbdd hcobdd` compiles
 - If build passes: create PR and merge
 - Further: formalize Dickman ρ function approach (blocked, >1000 lines infra needed)
+
+## Session 2026-05-04 (Session 17) - Close backward sorry in erdos_1201_strong_iff_smooth_decay
+
+**Mode**: REVISIT (continuing session 16 work)
+**Outcome**: sorry closed (0 sorries now)
+
+### What I Did
+- Identified that the file already had `limsup_add_le` used in `erdos_1201_from_bad_density_bound`
+  (lines 1248-1334) with the EXACT pattern needed for the backward direction sorry
+- Adapted the pattern to the sorry context: `dgc` = densityFun goodᶜ, `dbad` = densityFun smooth_bad
+- Closed sorry with: limsup_le_limsup + limsup_add_le + `tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop` + `htend.limsup_eq`
+- File: 1440 → 1499 lines, 1 sorry → 0 sorries
+
+### Key Findings
+- `limsup_add_le` in this file takes 4 args: IsBoundedUnder (≥) F f, IsBoundedUnder (≤) F f, IsCoboundedUnder (≤) F g, IsBoundedUnder (≤) F g
+- `(tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop).limsup_eq` proves `limsup(1/N) = 0`
+- The backward sorry proof was structurally identical to `erdos_1201_from_bad_density_bound`
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (1440→1499 lines, 1→0 sorries)
+- `src/data/proofs/erdos-1201/meta.json` (sorries 1→0, lineCount 1440→1499)
+- Branch: research/erdos-1201-lower-density-s16, PR #15529
+
+### Next Steps
+- Verify Docker build passes (OOM on first attempt, retry in progress)
+- Consider Dickman ρ function for the actual conjecture (>1000 lines, blocked)
+- The strong-iff-smooth-decay reduction is complete; proof of smooth-decay is the real open problem

--- a/research/problems/erdos-1201/knowledge.md
+++ b/research/problems/erdos-1201/knowledge.md
@@ -28,514 +28,10 @@ Is it true that for every $\epsilon,\eta>0$ there exists a $k$ such that the den
 
 - (None available)
 
-## Sessions
-
-## Session 2026-05-03 (Session 1) - Bertrand Lower Bounds
-
-**Mode**: FRESH
-**Outcome**: progress — 2 new theorems proved, PR #15174 created
-
-### What I Did
-- Identified erdos-1201 as RICH-tier problem (37 knowledge items, 0 sorries, 1 axiom)
-- Analyzed Lean file: 19 existing theorems, well-structured, only missing Docker build verification
-- Added `import Mathlib.NumberTheory.Bertrand`
-- Proved `gpfConsecutive_self_gt (n ≥ 1) : n < gpfConsecutive n n`
-  - Key: Bertrand gives prime p ∈ (n, 2n]; p = n + (p-n) with p-n ≤ n appears in window
-  - Uses: Nat.exists_prime_lt_and_le_two_mul, Finset.dvd_prod_of_mem, gpf_max
-- Proved `gpfConsecutive_gt_n_of_large_window (n ≥ 2, k ≥ n) : n < gpfConsecutive n k`
-  - Induction on k-n using gpfConsecutive_mono
-- Updated gallery meta.json: theoremCount 14→21, lineCount 267→297, new Bertrand section
-- Created PR #15174
-
-### Key Findings
-- Mathlib.NumberTheory.Bertrand is available via `Nat.exists_prime_lt_and_le_two_mul`
-- The n+1 consecutive integers [n, 2n] always contain a Bertrand prime — clean formalization
-- `Finset.dvd_prod_of_mem` is the right tool for showing a specific factor divides the product
-- Bug caught: must bind hp_le (not use _) from Bertrand decomposition for omega to prove range membership
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (297 lines, was 266)
-- `src/data/proofs/erdos-1201/meta.json` (updated counts + Bertrand section)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Await CI/Docker build result for PR #15174
-- Potential: Sylvester-Schur theorem (gpfConsecutive n k > k for n ≥ k+1)
 
 ---
 
-## Session 2026-05-03 (Session 2) - Infinite Set Result
-
-**Mode**: FRESH (REVISIT)
-**Outcome**: progress — 2 new theorems, fix to induction IH, PR #15215
-
-### What I Did
-- Diagnosed: gallery meta stale (21 thm/297 lines vs actual 22 thm/310 lines after PRs #14942 + #15174)
-- Discovered existing build error in `gpfConsecutive_gt_n_of_large_window` (never verified by Docker)
-  - IH was `n ≤ n+d → n < gpfConsecutive n (n+d)` not `n < ...` — needed `ih (by omega)`
-- Added `dvd_consecutiveProduct_term`: (n+i) | consecutiveProduct n k for i ≤ k
-  - Generalizes `dvd_consecutiveProduct_right` (the i=k case)
-- Added `erdos_1201_infinitely_many`: {n | P(n,k) > n^(1-ε)} is infinite for fixed k, ε∈(0,1)
-  - Proof: primes form infinite subset via `gpfConsecutive_ge_self_of_prime` + `Real.rpow_lt_rpow_of_exponent_lt`
-  - Uses `Nat.infinite_setOf_prime.mono`
-- Updated meta.json: 21→24 theorems, 297→341 lines
-- Created PR #15215
-
-### Key Findings
-- `Nat.infinite_setOf_prime.mono` works for infinite subset arguments
-- `Real.rpow_lt_rpow_of_exponent_lt (h : 1 < x) (h : y < z) : x^y < x^z` key for power comparison
-- The ε < 1 condition in `erdos_1201_infinitely_many` is not needed (only ε > 0 matters for n^ε > 1)
-- Lean 4 induction IH includes all hypotheses that depend on the induction variable — `n ≤ n+d` survived
-
-### Mathematical Note
-`erdos_1201_infinitely_many` is the weakest meaningful partial result: the good set is infinite but
-may have density 0 (primes have density 0 by PNT). Positive density requires smooth number estimates.
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (341 lines, was 310)
-- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Sylvester-Schur: for n > k, n(n+1)···(n+k-1) has a prime factor > k (is this in Mathlib?)
-- Quantitative density lower bound for small k (requires smooth number estimates)
-
----
-
-## Session 2026-05-03 (Session 3) - Max Formula and Smooth-Window Reformulation
-
-**Mode**: REVISIT
-**Outcome**: progress — 2 new theorems proved, PR created
-
-### What I Did
-- Identified gap: no lemma connecting P(n,k) to individual-term GPFs
-- Proved `gpfConsecutive_eq_sup_range (n ≥ 2) : P(n,k) = sup_{i≤k} GPF(n+i)`
-  - Key: prime factors of a product = union of prime factors of factors → GPF(product) = max GPF(term)
-  - ≤ direction: GPF of product divides some term via `prime_dvd_consecutive_range`, so ≤ sup
-  - ≥ direction: each term's GPF divides the term which divides the product, so ≤ GPF(product)
-- Proved `gpfConsecutive_le_iff : P(n,k) ≤ t ↔ ∀ i ≤ k, GPF(n+i) ≤ t`
-  - Immediate corollary of max formula via `Finset.sup_le_iff`
-  - Reformulates "P(n,k) is small" as "every integer in [n, n+k] is t-smooth"
-- Updated meta.json: 35→37 theorems, 472→514 lines, new max-formula section
-- Updated research JSON: added 2 builtItems, 2 insights, updated progressSummary
-
-### Key Findings
-- `Finset.sup_le_iff` and `Finset.le_sup` work cleanly for ℕ with `OrderBot` (0)
-- The max formula is the bridge between product-level and term-level properties
-- Smooth-window reformulation: "n fails Erdős condition" = "window [n, n+k] is fully t-smooth"
-  — this connects to Dickman's ρ function and opens the density estimation approach
-
-### Mathematical Note
-`gpfConsecutive_le_iff` reveals the structure of the Erdős conjecture: proving density → 1
-reduces to showing the density of n where ALL of n, n+1, ..., n+k are n^ε-smooth
-goes to 0 as k → ∞. This is plausible from smooth number theory (ρ(1/ε) density of
-n^ε-smooth numbers among [1,n]) but requires quantitative estimates not in Mathlib.
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (514 lines, was 472)
-- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Sylvester-Schur: for n > k, n(n+1)···(n+k-1) has a prime factor > k
-- Prove `gpfConsecutive_pos_density_of_smooth_bound`: if k-smooth density < η then good set ≥ 1-η
-
----
-
-## Session 2026-05-03 (Session 4) - GPF for Primes and Endpoint Bounds
-
-**Mode**: REVISIT
-**Outcome**: progress — 5 new theorems proved, PR pending Docker verification
-
-### What I Did
-- Proved `greatestPrimeFactor_prime (n : ℕ) (hn : n.Prime) : greatestPrimeFactor n = n`
-  - Key: `Nat.primeFactors_prime hn : n.primeFactors = {n}`, so max' over singleton = n
-  - Uses: `simp [dif_pos hne, Nat.primeFactors_prime hn, Finset.max'_singleton]`
-- Proved `gpfConsecutive_prime_start (n k : ℕ) (hn : n.Prime) : gpfConsecutive n 0 = n`
-  - Trivial corollary via `gpfConsecutive_zero ▸ greatestPrimeFactor_prime`
-- Proved `gpfConsecutive_one_eq_max (n : ℕ) (hn : 2 ≤ n) : P(n,1) = max(GPF(n), GPF(n+1))`
-  - Via `gpfConsecutive_eq_sup_range` for k=1: range 2 = {0,1}, sup_insert, sup_singleton
-  - Uses `decide` to prove `Finset.range 2 = {0, 1}`
-- Proved `gpfConsecutive_ge_left : GPF(n) ≤ P(n,k)` and `gpfConsecutive_ge_right : GPF(n+k) ≤ P(n,k)`
-  - Direct from `Finset.le_sup` with range membership (0 ∈ range(k+1), k ∈ range(k+1))
-- Updated meta.json: 37→42 theorems, 514→555 lines, new prime-gpf section
-- Total: 42 proved theorems, 1 axiom (ε=1/2 partial result)
-
-### Key Findings
-- `Nat.primeFactors_prime hn : n.primeFactors = {n}` is the cleanest path to `greatestPrimeFactor_prime`
-- Proof-irrelevance for `Prop` makes `Finset.max'_singleton` work despite different Nonempty witnesses
-- `decide` works for concrete `Finset ℕ` equalities like `Finset.range 2 = {0, 1}`
-- `Finset.le_sup` with `Finset.mem_range.mpr (Nat.succ_pos k)` / `(Nat.lt_succ_self k)` is clean for endpoint bounds
-- `gpfConsecutive_one_eq_max` is the key example of the max formula specialization
-
-### Mathematical Note
-The 5 new theorems complete the "basic interface" for `gpfConsecutive`:
-- Identity for prime starts, length-1 formula, endpoint bounds
-These are all corollaries of the max formula but explicit enough to be directly useful.
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (555 lines, was 514)
-- `src/data/proofs/erdos-1201/meta.json` (updated counts, new prime-gpf section)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-- `research/problems/erdos-1201/knowledge.md` (this entry)
-
-### Next Steps
-- Docker build pending for type-checking verification
-- Possible: `gpfConsecutive_prime_right`: when n+k is prime, P(n,k) = n+k (already have `gpfConsecutive_eq_of_prime_right`)
-- Possible: smooth number density estimates (would require new Mathlib infrastructure)
-
----
-
-## Session 2026-05-03 (Session 5) - Product Formula and Recursive Window Formula
-
-**Mode**: REVISIT
-**Outcome**: progress — 3 new theorems proved, PR pending
-
-### What I Did
-- Proved `greatestPrimeFactor_mul (a b : ℕ) (ha : 2 ≤ a) (hb : 2 ≤ b) : gpf(a*b) = max(gpf(a), gpf(b))`
-  - Key: any prime p dividing a*b divides a or b by primality (`hp.dvd_mul`)
-  - ≤ direction: gpf(a*b) divides a or b → ≤ gpf(a) or gpf(b) → ≤ max(gpf(a),gpf(b))
-  - ≥ direction: gpf(a)|a|a*b so gpf(a) ≤ gpf(a*b); similarly for gpf(b)
-- Proved `gpfConsecutive_le_of_le_k (n : ℕ) (hn : 2 ≤ n) {k₁ k₂ : ℕ} (hk : k₁ ≤ k₂) : P(n,k₁) ≤ P(n,k₂)`
-  - General k-monotonicity: extends one-step `gpfConsecutive_mono` to arbitrary window extensions
-  - Proof: `gpfConsecutive_eq_sup_range` for both, then `Finset.sup_le` + `Finset.le_sup` + `omega`
-  - Strictly cleaner than iterating one-step monotonicity by induction
-- Proved `gpfConsecutive_succ_right (n k : ℕ) (hn : 2 ≤ n) : P(n,k+1) = max(P(n,k), gpf(n+k+1))`
-  - One-step recursive formula: extending window by one term on right
-  - Proof: sup formula for both sides, then `Finset.range_succ` → `insert`, `Finset.sup_insert`, simp
-  - Uses: `sup_comm`, `sup_eq_max`, `show n + (k+1) = n+k+1 from by ring`
-- Updated meta.json: 37→44 theorems, 514→606 lines, new gpf-product-and-recursion section
-- Updated erdos-1201.json knowledge items (total 75 items)
-
-### Key Findings
-- `hp.dvd_mul.mp h` (where hp : p.Prime) gives p | a ∨ p | b from p | a*b — clean primality argument
-- `Finset.sup_le` + `Finset.le_sup` is the canonical way to prove sup set-monotonicity
-- `Finset.range_succ` converts `range (k+2)` to `insert (k+1) (range (k+1))` for sup_insert
-- `sup_eq_max` bridges ⊔ and max for ℕ lattice; `sup_comm` handles commutativity
-- `greatestPrimeFactor_mul` subsumes `gpfConsecutive_one_eq_max`: the one-step recursive formula directly gives P(n,1) = max(gpf(n), gpf(n+1)) as a special case of `gpfConsecutive_succ_right` with k=0 and `gpfConsecutive_zero`
-
-### Mathematical Note
-`gpfConsecutive_succ_right` is the key recursive formula for computing P(n,k). It shows that the window GPF grows by absorbing the next term's GPF — a streaming max operation. Combined with `gpfConsecutive_le_of_le_k` (general monotonicity), these give a complete characterization of how P(n,k) behaves as k varies.
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (606 lines, was 560)
-- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-- `research/problems/erdos-1201/knowledge.md` (this entry)
-
-### Next Steps
-- Window-split formula: P(n,k) = max(P(n,j), P(n+j+1, k-j-1)) for j < k — follows from succ_right by induction
-- `gpfConsecutive_succ_left`: P(n-1, k+1) ≥ P(n, k) — left-shift decreases start, right-shift increases end
-- Density results still blocked: requires Dickman ρ function / smooth number estimates not in Mathlib
-
----
-
-## Session 2026-05-03 (Session 7) - Right-Endpoint Biconditional and Infinite Sets
-
-**Mode**: REVISIT
-**Outcome**: progress — 3 new theorems proved, PR created (Docker verification pending)
-
-### What I Did
-- Selected erdos-1201 as RICH-tier (score 73), highest priority among available problems
-- Assessed frontier: Sessions 1-6 built 44 theorems. Next-step was right-endpoint biconditional
-- Proved `gpfConsecutive_eq_right_iff (n k hn hnk)`: P(n,k) = n+k ↔ (n+k).Prime
-  - Forward: gpfConsecutive is prime (gpf_prime); if it equals n+k then n+k is prime
-  - Backward: direct from `gpfConsecutive_eq_of_prime_right`
-  - This closes the biconditional: upper bound achieved exactly at prime right endpoints
-- Proved `erdos_1201_prime_right_infinite (k)`: {n | (n+k).Prime}.Infinite
-  - Via `Set.infinite_of_not_bddAbove`: for any N, prime p ≥ N+k+1 gives n = p-k in the set
-- Proved `erdos_1201_eq_right_infinite (k hk)`: {n | P(n,k) = n+k}.Infinite
-  - Same unbounded argument using `gpfConsecutive_eq_of_prime_right` for prime right endpoints
-- Updated meta.json: 44→47 theorems, 606→662 lines
-
-### Key Findings
-- `gpfConsecutive_eq_right_iff` is the sharp biconditional: P < n+k (composite), P = n+k (prime)
-- `Set.infinite_of_not_bddAbove` + `not_bddAbove_iff` + `Nat.exists_infinite_primes` is the canonical infinite-set pattern
-- The two theorems complement `erdos_1201_infinitely_many` (prime starts) with prime ends witnesses
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (662 lines, was 606)
-- `src/data/proofs/erdos-1201/meta.json` (47 theorems, 662 lines)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Full Sylvester-Schur: P(n,k) > k for ALL n > k (requires binomial machinery)
-- Density lower bounds: requires Dickman ρ function (>1000 lines infra, truly blocked)
-
----
-
-## Session 2026-05-03 (Session 6) - Window Extension, Concatenation, and Prime Term Bounds
-
-**Mode**: REVISIT
-**Outcome**: progress — 4 new theorems proved, PR created
-
-### What I Did
-- Proved `gpfConsecutive_succ_left (n k : ℕ) (hn : 2 ≤ n) : P(n,k+1) = max(gpf(n), P(n+1,k))`
-  - Left-endpoint extension: symmetric to `gpfConsecutive_succ_right`
-  - Proof: Nat.le_antisymm via sup inequalities; case split on i=0 vs i>0 for upper bound
-  - Key tactic: `rcases Nat.eq_zero_or_pos i with rfl | hpos` then `Finset.le_sup (f := ...)` with omega
-- Proved `gpfConsecutive_window_concat (n j k : ℕ) (hn : 2 ≤ n) : P(n,j+k+1) = max(P(n,j), P(n+j+1,k))`
-  - Window concatenation/splitting formula: [n,n+j+k+1] = [n,n+j] ∪ [n+j+1,n+j+k+1]
-  - Proof: `by_cases h : i ≤ j` splits the sup over the full range into two halves
-  - Both halves use `Finset.le_sup (f := ...)` with `congr 1; omega` to relate index arithmetic
-- Proved `gpfConsecutive_ge_prime_term (n k i : ℕ) (hn : 2 ≤ n) (hi : i ≤ k) (hprime : (n+i).Prime)`
-  - If window [n,n+k] contains prime n+i, then P(n,k) ≥ n+i
-  - Proof: `rw [← greatestPrimeFactor_prime _ hprime, gpfConsecutive_eq_sup_range]` then `Finset.le_sup (f := ...)`
-- Proved `erdos_1201_good_of_prime_in_window`: one-liner corollary bridging prime distribution to density
-  - If n+i is prime and n+i > n^(1-ε), then P(n,k) > n^(1-ε) — structural link to Erdős conjecture
-- Fixed API drift in `consecutiveProduct_succ` (induction proof for Lean 4.26.0 prod_range_succ issues)
-- Updated meta.json: 44→48 theorems, 662→754 lines, added window-extension-and-prime-terms section
-- Created PR on branch `research/erdos-1201-session-6b`
-
-### Key Findings
-- `gpfConsecutive_succ_left` and `gpfConsecutive_succ_right` are symmetric: together give full bilateral recursion
-- `gpfConsecutive_window_concat` generalizes both succ theorems: set j=0 gives succ_right; set k=0 gives left-split
-- `gpfConsecutive_ge_prime_term` is the cleanest statement of "prime term implies lower bound"
-- `erdos_1201_good_of_prime_in_window` shows that P(n,k) > n^(1-ε) follows from prime gaps <n^(1-ε) in [n,n+k]
-  - This is the link to Cramér-type prime gap conjectures
-
-### Mathematical Note
-The 4 Session 6 theorems together give a complete "window algebra":
-- Bilateral extension: P(n,k+1) = max(gpf(n), P(n+1,k)) AND P(n,k+1) = max(P(n,k), gpf(n+k+1))
-- Concatenation: P(n,j+k+1) = max(P(n,j), P(n+j+1,k)) — general window splitting
-- Prime term lower bound: prime in window → window GPF ≥ that prime
-- Sufficient condition for Erdős problem: prime > n^(1-ε) in window → n is good
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (734 lines, was 662, with all Mathlib 4.26.0 API drift fixes applied)
-- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
-- `research/problems/erdos-1201/knowledge.md` (this entry)
-
-### Next Steps
-- `gpfConsecutive_window_concat` with j=0 gives a cleaner proof of `gpfConsecutive_succ_right` — potential refactor
-- Connect `erdos_1201_good_of_prime_in_window` to prime gap bounds: if primes gaps < n^(1-ε) for density-1 set, conjecture follows
-- Smooth number density: if k-smooth numbers in [N] have density ρ(1/ε) → density argument works (>1000 lines infra)
-
----
-
-## Session 2026-05-03 (Session 4) - GPF Localization
-
-**Mode**: REVISIT (richest available: score 55, ACT phase)
-**Outcome**: progress — 3 new theorems, Docker build in progress, PR pending
-
-### What I Did
-- Continued from Session 3 (gpfConsecutive_one_eq_max already proved)
-- Added **`gpfConsecutive_one_coprime`**: Nat.Coprime (gpf n) (gpf (n+1)) for n ≥ 2
-  - From gcd(n, n+1) = 1, gpf(n)|n, gpf(n+1)|n+1 → gcd(gpf(n), gpf(n+1)) | gcd(n,n+1) = 1
-  - Used `Nat.dvd_gcd`, `Nat.gcd_dvd_left/right`, `Nat.dvd_one`, `Nat.coprime_succ_self`
-- Added **`gpfConsecutive_one_ne`**: gpf(n) ≠ gpf(n+1) for n ≥ 2
-  - If equal to p ≥ 2, then gcd(p,p) = p ≥ 2 contradicts coprimality
-  - Uses `Nat.gcd_self` + omega
-- Added **`gpfConsecutive_eq_term_gpf`** (GPF Localization): When P(n,k) > k for n ≥ 2, ∃ j ≤ k with P(n,k) = gpf(n+j)
-  - p = P(n,k) is prime, divides consecutiveProduct, hence divides some n+j by `prime_dvd_consecutive_range`
-  - `gpf_ge_prime_dvd (n+j) p` gives p ≤ gpf(n+j)
-  - `gpf_ge_prime_dvd (consecutiveProduct n k) (gpf(n+j))` gives gpf(n+j) ≤ p
-  - Antisymmetry gives equality
-- Updated meta.json: theoremCount 37→40, lineCount 510→554, new structural-decomposition section
-- Docker build running (lean-build-50190)
-
-### Key Findings
-- GPF Localization is the key structural result: when P(n,k) exceeds the window size k, it "belongs" to a single term
-- This enables reduction: {n | P(n,k) > n^(1-ε)} ⊇ {n | ∃j≤k, gpf(n+j) > n^(1-ε)} when n > k
-- Coprimality of consecutive gpfs follows trivially from gcd(n,n+1)=1 — no primality arguments needed
-- `prime_dvd_consecutive_range` (private lemma, same file) handles the "divides some term" step cleanly
-
-### Mathematical Note
-`gpfConsecutive_eq_term_gpf` reduces the window-density problem to single-term GPF density when n > k.
-Combined with Sylvester-Schur (P(n,k) > k always for n > k), this gives a clean reduction:
-density of {n | P(n,k) > n^(1-ε)} ≈ density of {n | max_{j≤k} gpf(n+j) > n^(1-ε)}.
-The latter connects to the well-studied Dickman function and smooth number density.
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (554 lines, was 510)
-- `src/data/proofs/erdos-1201/meta.json` (theoremCount 37→40, lineCount 510→554)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Verify Docker build succeeds
-- Sylvester-Schur general case: for n > k, prove P(n,k) > k (needs more than Bertrand)
-- Use GPF Localization to reduce density question to single-term GPF distribution
-
----
-
-## Session 2026-05-03 (Session 4) - GPF Localization
-
-**Mode**: REVISIT (richest available: score 55, ACT phase)
-**Outcome**: progress — 3 new theorems, Docker build in progress, PR pending
-
-### What I Did
-- Continued from Session 3 (gpfConsecutive_one_eq_max already proved)
-- Added **`gpfConsecutive_one_coprime`**: Nat.Coprime (gpf n) (gpf (n+1)) for n ≥ 2
-  - From gcd(n, n+1) = 1, gpf(n)|n, gpf(n+1)|n+1 → gcd(gpf(n), gpf(n+1)) | gcd(n,n+1) = 1
-  - Used `Nat.dvd_gcd`, `Nat.gcd_dvd_left/right`, `Nat.dvd_one`, `Nat.coprime_succ_self`
-- Added **`gpfConsecutive_one_ne`**: gpf(n) ≠ gpf(n+1) for n ≥ 2
-  - If equal to p ≥ 2, then gcd(p,p) = p ≥ 2 contradicts coprimality
-  - Uses `Nat.gcd_self` + omega
-- Added **`gpfConsecutive_eq_term_gpf`** (GPF Localization): When P(n,k) > k for n ≥ 2, ∃ j ≤ k with P(n,k) = gpf(n+j)
-  - p = P(n,k) is prime, divides consecutiveProduct, hence divides some n+j by `prime_dvd_consecutive_range`
-  - `gpf_ge_prime_dvd (n+j) p` gives p ≤ gpf(n+j)
-  - `gpf_ge_prime_dvd (consecutiveProduct n k) (gpf(n+j))` gives gpf(n+j) ≤ p
-  - Antisymmetry gives equality
-- Updated meta.json: theoremCount 37→40, lineCount 510→554, new structural-decomposition section
-- Docker build running (lean-build-50190)
-
-### Key Findings
-- GPF Localization is the key structural result: when P(n,k) exceeds the window size k, it "belongs" to a single term
-- This enables reduction: {n | P(n,k) > n^(1-ε)} ⊇ {n | ∃j≤k, gpf(n+j) > n^(1-ε)} when n > k
-- Coprimality of consecutive gpfs follows trivially from gcd(n,n+1)=1 — no primality arguments needed
-- `prime_dvd_consecutive_range` (private lemma, same file) handles the "divides some term" step cleanly
-
-### Mathematical Note
-`gpfConsecutive_eq_term_gpf` reduces the window-density problem to single-term GPF density when n > k.
-Combined with Sylvester-Schur (P(n,k) > k always for n > k), this gives a clean reduction:
-density of {n | P(n,k) > n^(1-ε)} ≈ density of {n | max_{j≤k} gpf(n+j) > n^(1-ε)}.
-The latter connects to the well-studied Dickman function and smooth number density.
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (554 lines, was 510)
-- `src/data/proofs/erdos-1201/meta.json` (theoremCount 37→40, lineCount 510→554)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Verify Docker build succeeds
-- Sylvester-Schur general case: for n > k, prove P(n,k) > k (needs more than Bertrand)
-- Use GPF Localization to reduce density question to single-term GPF distribution
-
----
-
-## Session 2026-05-04 (Session 8) - Sylvester-Schur Extensions and Density Monotonicity
-
-**Mode**: REVISIT
-**Outcome**: progress — 6 new theorems proved (55→61), 1 bug fixed
-
-### What I Did
-- Fixed pre-existing duplicate declaration bug: `gpfConsecutive_eq_right_iff`,
-  `erdos_1201_prime_right_infinite`, `erdos_1201_eq_right_infinite` were each declared twice
-- Proved **`gpfConsecutive_succ_succ_gt_k`** (Sylvester-Schur n=k+2):
-  - Bertrand for k+1 gives prime p in (k+1, 2k+2] = [k+2, 2k+2] ⊆ [n, n+k]; use `gpfConsecutive_gt_k_of_prime_in_window`
-- Proved **`gpfConsecutive_succ_succ_succ_gt_k`** (Sylvester-Schur n=k+3):
-  - Bertrand for k+2 gives prime p in (k+2, 2k+4]. Since 2k+4=2(k+2) is composite (even, ≥6), p ≤ 2k+3 = (k+3)+k
-  - Key: `hp_prime.eq_one_or_self_of_dvd 2 (dvd_mul_right 2 (k+2))` rules out p = 2(k+2) being prime
-- Proved **`erdos_1201_good_implies_good_succ`** (good-set pointwise monotonicity in k):
-  - One-liner: `hgood.trans_le (by exact_mod_cast gpfConsecutive_mono n k hn)`
-- Proved **`erdos_1201_good_set_mono_k`** (set containment as k grows):
-  - The good set {n | P(n,k) > n^(1-ε)} ⊆ {n | P(n,k+1) > n^(1-ε)} for all ε, k
-- Proved **`upperDensity_mono`** (upper density monotone for set inclusion):
-  - `Filter.limsup_le_limsup` with IsCoboundedUnder (density ≥ 0) + IsBoundedUnder (density ≤ 1)
-  - Key pattern from Erdos25LogDensity: IsCoboundedUnder is 2nd arg, IsBoundedUnder is 3rd arg
-- Proved **`erdos_1201_density_mono_k`** (density non-decreasing in window width):
-  - One-liner: `upperDensity_mono (erdos_1201_good_set_mono_k ε k)`
-- Fixed IsCoboundedUnder argument order bug in `upperDensity_mono` (third commit)
-
-### Key Findings
-- Sylvester-Schur for n=k+3 requires ruling out 2(k+2) being prime — handled by primality of 2
-- `Filter.limsup_le_limsup` argument order: (≤ᶠ condition, IsCoboundedUnder f, IsBoundedUnder g)
-  - Different from intuition: IsCoboundedUnder for the SMALLER function, IsBoundedUnder for LARGER
-  - IsCoboundedUnder for density: `use 0; intro a ha; by_contra; get N with densityFun N ≤ a; linarith`
-- General Sylvester-Schur (n > k+3): needs Chebyshev/Hanson's theorem, not just Bertrand — HARD
-- Docker build twice timed out at 60 min (file is 861 lines with many complex theorems)
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (850→861 lines, 55→61 theorems, 0 sorries)
-- `src/data/proofs/erdos-1201/meta.json` (theoremCount 55→61, lineCount 779→861)
-- `research/problems/erdos-1201/knowledge.md` (this entry)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Full Sylvester-Schur (n > k): needs Hanson's theorem (P(n,k) ≥ n^{1/(k+1)}) or Ramachandra's work
-- Density lower bounds: requires Dickman ρ function (>1000 lines infra, truly blocked)
-
----
-
-## Session 2026-05-04 (Session 10) - Factorial Divisibility + ε-Monotonicity
-
-**Mode**: REVISIT
-**Outcome**: progress — 8 new theorems proved (61→69), open problem scope reduced
-
-### What I Did
-- Rescued researcher-8's uncommitted factorial section (process dead, lock stale)
-- Proved `consecutiveProduct_eq_descFactorial` (private): product = descending factorial (n+k)↓(k+1)
-- Proved `factorial_dvd_consecutiveProduct`: (k+1)! | n(n+1)···(n+k) for ALL n,k
-  - Key: `Nat.descFactorial_eq_factorial_mul_choose` gives the identity directly
-- Proved `gpfConsecutive_ge_factorial_gpf`: P(n,k) ≥ GPF((k+1)!) for n≥1, k≥1
-  - (k+1)! | product → GPF((k+1)!) | product → GPF((k+1)!) ≤ P(n,k)
-- Proved `gpfConsecutive_gt_half_k`: 2·P(n,k) > k for ALL n≥1, k≥2
-  - Bertrand for k/2 gives prime p in (k/2, k] ≤ k+1; p | (k+1)! | product → p ≤ P(n,k) > k/2
-  - UNIVERSAL: holds for all starting points n≥1, unlike Sylvester-Schur (n>k)
-- Proved `erdos_1201_threshold_bound`: n^(1-ε) < k/2 → P(n,k) > n^(1-ε)
-- Proved `erdos_1201_good_set_mono_eps`: ε ≤ ε' → good-set(ε) ⊆ good-set(ε')
-  - rpow_le_rpow_of_exponent_le: smaller ε means bigger threshold means harder condition
-- Proved `erdos_1201_density_mono_eps`: density non-decreasing in ε (one-liner via upperDensity_mono)
-- Proved `erdos_1201_trivially_good_of_large_eps`: for ε≥1, n^(1-ε) ≤ 1 < 2 ≤ P(n,k) always
-- Proved `erdos_1201_conjecture_large_eps`: for ε∈[1/2,1), conjecture follows from Erdős's axiom
-  - Key: n^(1-ε) ≤ n^(1/2) = √n for ε≥1/2; so {√n < P(n,k)} ⊆ {n^(1-ε) < P(n,k)}
-  - Uses `Real.sqrt_eq_rpow` to bridge sqrt and rpow; `rpow_le_rpow_of_exponent_le` for monotonicity
-  - **Reduces open problem to ε ∈ (0, 1/2) only**
-
-### Key Findings
-- Factorial divisibility via descending factorial is cleaner than Sylvester-Schur (no n>k condition)
-- The universal bound P(n,k) > k/2 (via (k+1)! divisibility + Bertrand) is strictly weaker than
-  Sylvester-Schur P(n,k) > k (for n>k), but applies to ALL n
-- Epsilon-monotonicity is the key structural insight: Erdős's known ε=1/2 result covers all ε≥1/2;
-  the true frontier of the open problem is only ε ∈ (0, 1/2)
-- `Nat.self_le_factorial (n)` gives n ≤ n! cleanly for factorial lower bounds
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (861→978 lines, 61→69 theorems, 0 sorries)
-- `src/data/proofs/erdos-1201/meta.json` (theoremCount 61→69, lineCount 861→978)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Full Sylvester-Schur (n > k): the factorial approach gives P > k/2; Sylvester-Schur needs P > k
-  (requires showing GPF((k+1)!) > k, i.e., largest prime ≤ k+1 is > k, i.e., k+1 prime — not always)
-- Density lower bounds for ε < 1/2: requires Dickman ρ function (>1000 lines infra, truly blocked)
-- The open problem has been formally reduced to ε ∈ (0, 1/2)
-
----
-
-*Generated from erdosproblems.com on 2026-04-16*
-
-## Session 2026-05-04 (Session 11) - Sylvester-Schur for Prime Window Sizes
-
-**Mode**: REVISIT (claimed erdos-1201 directly — highest knowledge score)
-**Outcome**: progress — 2 new theorems, 2 bug fixes, PR #15417
-
-### What I Did
-- Identified tractable special case of Sylvester-Schur: when k+1 is PRIME
-  - General Sylvester-Schur (P(n,k) > k for all n > k) needs Chebyshev/binomial infra
-  - For prime k+1: elementary residue argument suffices, works for ALL n ≥ 1
-- Proved `exists_dvd_in_consecutive` (private): offset `(m - n%m) % m` witnesses multiple of m
-  - Case n % m = 0: trivially n is divisible by m (offset = 0)
-  - Case n % m > 0: offset < m, and n + (m - n%m) = m*(n/m+1) by division algorithm
-- Proved `gpfConsecutive_ge_succ_k_of_prime`: P(n,k) ≥ k+1 for all n ≥ 1 when k+1 prime
-  - Uses `exists_dvd_in_consecutive` + `le_gpfConsecutive_of_prime_dvd_term`
-- Proved `gpfConsecutive_gt_k_of_prime_succ`: k < P(n,k) when k+1 prime (strict)
-  - Covers k = 1, 2, 4, 6, 10, 12, 16, 18, ... (infinitely many k values)
-- Fixed pre-existing bug: `Nat.coprime_succ_self_right` removed from current Mathlib
-  - New proof: `(Nat.coprime_succ_self n).coprime_dvd_left (...) |>.coprime_dvd_right (...)`
-- Fixed pre-existing bug: duplicate declarations of `erdos_1201_good_set_mono_eps` and
-  `erdos_1201_density_mono_eps` (session 10 added ≤ versions alongside existing < versions)
-  - Removed second (≤) declarations; first (strict <) versions remain
-
-### Key Findings
-- Complete residue system: k+1 consecutive integers cover ALL residues mod k+1
-- `le_gpfConsecutive_of_prime_dvd_term` is the key bridge for prime factor bounds
-- `Nat.coprime_succ_self_right` renamed to `Nat.coprime_succ_self` in current Mathlib
-- `Nat.Coprime.coprime_dvd_left/right` is the clean API for transferring coprimality
-- Session 10 introduced duplicate theorem names — always check for existing names before adding
-
-### Files Modified
-- `proofs/Proofs/Erdos1201Problem.lean` (1044→1043 lines, 75 theorems, 0 sorries)
-- `src/data/proofs/erdos-1201/meta.json` (lineCount 1044→1043, bug fixes noted in assumptions)
-- `research/problems/erdos-1201/knowledge.md` (this entry)
-- `src/data/research/problems/erdos-1201.json` (updated knowledge)
-
-### Next Steps
-- Full Sylvester-Schur for ALL k+1 (composite): needs binomial coefficient or Chebyshev Θ (>300 lines)
-- Density lower bounds: truly blocked (Dickman ρ function >1000 lines infra)
-- Can erdos_1201_half_case be proved via Dickman ρ or elementary density argument?
-
----
+> **Note**: 13 older sessions archived to `sessions/` directory.
 
 ## Session 2026-05-04 (Session 12) - Comprehensive Build Fix + Structural Theorems
 
@@ -694,3 +190,52 @@ The latter connects to the well-studied Dickman function and smooth number densi
 - Docker build verification needed for the limsup_add_le proof
 - The Aristotle job cb09e358 (erdos_1201_half_case) is superseded — mark as resolved_manually
 - Pool status: erdos-1201 now has 0 sorries, 1 axiom — consider completing if Docker passes
+
+---
+
+## Session 2026-05-04 (Session 16) - Lower Density and Strong Conjecture
+
+**Mode**: REVISIT
+**Outcome**: progress — 170 new lines (7 new definitions/theorems), 1 sorry in backward direction
+
+### What I Did
+- Added `lowerDensity` definition (liminf dual to `upperDensity`)
+- Proved `lowerDensity_compl_eq`: EXACT identity lowerDensity(Sᶜ) = 1 - upperDensity(S)
+  - Stronger than existing inequality `upperDensity_compl_ge`
+  - Uses `Filter.liminf_const_sub` from Mathlib.Topology.Algebra.Order.LiminfLimsup
+  - Requires `Filter.IsCoboundedUnder (· ≤ ·)` for the density function (proved with b=0)
+- Proved `upperDensity_compl_eq`: symmetric identity upperDensity(Sᶜ) = 1 - lowerDensity(S)
+- Proved `lowerDensity_le_upperDensity`: liminf ≤ limsup for density functions
+  - Follows algebraically from the two complement identities + `upperDensity_compl_ge`
+- Defined `ErdosProblem1201Strong`: stronger form using lowerDensity ≥ 1-η
+  - Asserts density tends to 1 in the LOWER density sense (all large N, not just limsup)
+- Proved `erdos_1201_strong_implies_weak`: Strong → Weak (one-line via lD ≤ uD)
+- Proved `erdos_1201_strong_iff_smooth_decay`: bidirectional equivalence
+  - Forward (Strong → smooth-decay): complete proof via complement duality
+  - Backward (smooth-decay → Strong): counting argument correct, 1 sorry for limsup arithmetic
+    - For n ≥ 2: n ∈ goodᶜ ↔ n ∈ smooth_bad (by `erdos_1201_not_good_smooth_window`)
+    - |goodᶜ ∩ [1,N]| ≤ |smooth_bad ∩ [1,N]| + 1 (the +1 for n=1)
+    - Sorry: limsup(densityFun goodᶜ) ≤ limsup(densityFun smooth_bad + 1/N) ≤ η
+    - Needs: limsup subadditivity + limsup(1/N) = 0 (1/N → 0 tendsto)
+
+### Key Findings
+- `Filter.liminf_const_sub` exists in Mathlib 4.26.0 with `[OrderedSub R]` typeclass
+  (ℝ satisfies `OrderedSub` via `OrderedAddCommGroup`; `cobdd` arg is required)
+- The EXACT complement duality (lD(Sᶜ) = 1-uD(S)) is stronger than the existing inequality
+  and enables the Strong ↔ smooth-decay equivalence
+- `ErdosProblem1201Strong` is precisely equivalent to smooth-window density → 0 (the key insight
+  is that both directions use the exact duality, not just the inequality)
+- The backward sorry needs: `limsup(f + 1/N) ≤ limsup f + 0 = limsup f` as N → ∞
+  Use `limsup_add_le` + `Filter.Tendsto.limsup_eq` for `1/N → 0`
+
+### Files Modified  
+- `proofs/Proofs/Erdos1201Problem.lean` (1270→1440 lines, 87→94 theorems/defs, 0→1 sorry)
+- Branch: research/erdos-1201-lower-density-s16
+- Commit: 355c0573e5
+
+### Next Steps
+- Close the backward direction sorry: prove limsup(1/N) = 0 via `tendsto_natCast_atTop_atTop`
+  then `Filter.Tendsto.limsup_eq`; use `limsup_add_le` for subadditivity
+- Docker build verification: check `Filter.liminf_const_sub 1 hbdd hcobdd` compiles
+- If build passes: create PR and merge
+- Further: formalize Dickman ρ function approach (blocked, >1000 lines infra needed)

--- a/research/problems/erdos-1201/sessions/-s01.md
+++ b/research/problems/erdos-1201/sessions/-s01.md
@@ -1,0 +1,2 @@
+## Sessions
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s02.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s02.md
@@ -1,0 +1,34 @@
+## Session 2026-05-03 (Session 1) - Bertrand Lower Bounds
+
+**Mode**: FRESH
+**Outcome**: progress — 2 new theorems proved, PR #15174 created
+
+### What I Did
+- Identified erdos-1201 as RICH-tier problem (37 knowledge items, 0 sorries, 1 axiom)
+- Analyzed Lean file: 19 existing theorems, well-structured, only missing Docker build verification
+- Added `import Mathlib.NumberTheory.Bertrand`
+- Proved `gpfConsecutive_self_gt (n ≥ 1) : n < gpfConsecutive n n`
+  - Key: Bertrand gives prime p ∈ (n, 2n]; p = n + (p-n) with p-n ≤ n appears in window
+  - Uses: Nat.exists_prime_lt_and_le_two_mul, Finset.dvd_prod_of_mem, gpf_max
+- Proved `gpfConsecutive_gt_n_of_large_window (n ≥ 2, k ≥ n) : n < gpfConsecutive n k`
+  - Induction on k-n using gpfConsecutive_mono
+- Updated gallery meta.json: theoremCount 14→21, lineCount 267→297, new Bertrand section
+- Created PR #15174
+
+### Key Findings
+- Mathlib.NumberTheory.Bertrand is available via `Nat.exists_prime_lt_and_le_two_mul`
+- The n+1 consecutive integers [n, 2n] always contain a Bertrand prime — clean formalization
+- `Finset.dvd_prod_of_mem` is the right tool for showing a specific factor divides the product
+- Bug caught: must bind hp_le (not use _) from Bertrand decomposition for omega to prove range membership
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (297 lines, was 266)
+- `src/data/proofs/erdos-1201/meta.json` (updated counts + Bertrand section)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Await CI/Docker build result for PR #15174
+- Potential: Sylvester-Schur theorem (gpfConsecutive n k > k for n ≥ k+1)
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s03.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s03.md
@@ -1,0 +1,38 @@
+## Session 2026-05-03 (Session 2) - Infinite Set Result
+
+**Mode**: FRESH (REVISIT)
+**Outcome**: progress — 2 new theorems, fix to induction IH, PR #15215
+
+### What I Did
+- Diagnosed: gallery meta stale (21 thm/297 lines vs actual 22 thm/310 lines after PRs #14942 + #15174)
+- Discovered existing build error in `gpfConsecutive_gt_n_of_large_window` (never verified by Docker)
+  - IH was `n ≤ n+d → n < gpfConsecutive n (n+d)` not `n < ...` — needed `ih (by omega)`
+- Added `dvd_consecutiveProduct_term`: (n+i) | consecutiveProduct n k for i ≤ k
+  - Generalizes `dvd_consecutiveProduct_right` (the i=k case)
+- Added `erdos_1201_infinitely_many`: {n | P(n,k) > n^(1-ε)} is infinite for fixed k, ε∈(0,1)
+  - Proof: primes form infinite subset via `gpfConsecutive_ge_self_of_prime` + `Real.rpow_lt_rpow_of_exponent_lt`
+  - Uses `Nat.infinite_setOf_prime.mono`
+- Updated meta.json: 21→24 theorems, 297→341 lines
+- Created PR #15215
+
+### Key Findings
+- `Nat.infinite_setOf_prime.mono` works for infinite subset arguments
+- `Real.rpow_lt_rpow_of_exponent_lt (h : 1 < x) (h : y < z) : x^y < x^z` key for power comparison
+- The ε < 1 condition in `erdos_1201_infinitely_many` is not needed (only ε > 0 matters for n^ε > 1)
+- Lean 4 induction IH includes all hypotheses that depend on the induction variable — `n ≤ n+d` survived
+
+### Mathematical Note
+`erdos_1201_infinitely_many` is the weakest meaningful partial result: the good set is infinite but
+may have density 0 (primes have density 0 by PNT). Positive density requires smooth number estimates.
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (341 lines, was 310)
+- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Sylvester-Schur: for n > k, n(n+1)···(n+k-1) has a prime factor > k (is this in Mathlib?)
+- Quantitative density lower bound for small k (requires smooth number estimates)
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s04.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s04.md
@@ -1,0 +1,40 @@
+## Session 2026-05-03 (Session 3) - Max Formula and Smooth-Window Reformulation
+
+**Mode**: REVISIT
+**Outcome**: progress — 2 new theorems proved, PR created
+
+### What I Did
+- Identified gap: no lemma connecting P(n,k) to individual-term GPFs
+- Proved `gpfConsecutive_eq_sup_range (n ≥ 2) : P(n,k) = sup_{i≤k} GPF(n+i)`
+  - Key: prime factors of a product = union of prime factors of factors → GPF(product) = max GPF(term)
+  - ≤ direction: GPF of product divides some term via `prime_dvd_consecutive_range`, so ≤ sup
+  - ≥ direction: each term's GPF divides the term which divides the product, so ≤ GPF(product)
+- Proved `gpfConsecutive_le_iff : P(n,k) ≤ t ↔ ∀ i ≤ k, GPF(n+i) ≤ t`
+  - Immediate corollary of max formula via `Finset.sup_le_iff`
+  - Reformulates "P(n,k) is small" as "every integer in [n, n+k] is t-smooth"
+- Updated meta.json: 35→37 theorems, 472→514 lines, new max-formula section
+- Updated research JSON: added 2 builtItems, 2 insights, updated progressSummary
+
+### Key Findings
+- `Finset.sup_le_iff` and `Finset.le_sup` work cleanly for ℕ with `OrderBot` (0)
+- The max formula is the bridge between product-level and term-level properties
+- Smooth-window reformulation: "n fails Erdős condition" = "window [n, n+k] is fully t-smooth"
+  — this connects to Dickman's ρ function and opens the density estimation approach
+
+### Mathematical Note
+`gpfConsecutive_le_iff` reveals the structure of the Erdős conjecture: proving density → 1
+reduces to showing the density of n where ALL of n, n+1, ..., n+k are n^ε-smooth
+goes to 0 as k → ∞. This is plausible from smooth number theory (ρ(1/ε) density of
+n^ε-smooth numbers among [1,n]) but requires quantitative estimates not in Mathlib.
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (514 lines, was 472)
+- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Sylvester-Schur: for n > k, n(n+1)···(n+k-1) has a prime factor > k
+- Prove `gpfConsecutive_pos_density_of_smooth_bound`: if k-smooth density < η then good set ≥ 1-η
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s05.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s05.md
@@ -1,0 +1,44 @@
+## Session 2026-05-03 (Session 4) - GPF for Primes and Endpoint Bounds
+
+**Mode**: REVISIT
+**Outcome**: progress — 5 new theorems proved, PR pending Docker verification
+
+### What I Did
+- Proved `greatestPrimeFactor_prime (n : ℕ) (hn : n.Prime) : greatestPrimeFactor n = n`
+  - Key: `Nat.primeFactors_prime hn : n.primeFactors = {n}`, so max' over singleton = n
+  - Uses: `simp [dif_pos hne, Nat.primeFactors_prime hn, Finset.max'_singleton]`
+- Proved `gpfConsecutive_prime_start (n k : ℕ) (hn : n.Prime) : gpfConsecutive n 0 = n`
+  - Trivial corollary via `gpfConsecutive_zero ▸ greatestPrimeFactor_prime`
+- Proved `gpfConsecutive_one_eq_max (n : ℕ) (hn : 2 ≤ n) : P(n,1) = max(GPF(n), GPF(n+1))`
+  - Via `gpfConsecutive_eq_sup_range` for k=1: range 2 = {0,1}, sup_insert, sup_singleton
+  - Uses `decide` to prove `Finset.range 2 = {0, 1}`
+- Proved `gpfConsecutive_ge_left : GPF(n) ≤ P(n,k)` and `gpfConsecutive_ge_right : GPF(n+k) ≤ P(n,k)`
+  - Direct from `Finset.le_sup` with range membership (0 ∈ range(k+1), k ∈ range(k+1))
+- Updated meta.json: 37→42 theorems, 514→555 lines, new prime-gpf section
+- Total: 42 proved theorems, 1 axiom (ε=1/2 partial result)
+
+### Key Findings
+- `Nat.primeFactors_prime hn : n.primeFactors = {n}` is the cleanest path to `greatestPrimeFactor_prime`
+- Proof-irrelevance for `Prop` makes `Finset.max'_singleton` work despite different Nonempty witnesses
+- `decide` works for concrete `Finset ℕ` equalities like `Finset.range 2 = {0, 1}`
+- `Finset.le_sup` with `Finset.mem_range.mpr (Nat.succ_pos k)` / `(Nat.lt_succ_self k)` is clean for endpoint bounds
+- `gpfConsecutive_one_eq_max` is the key example of the max formula specialization
+
+### Mathematical Note
+The 5 new theorems complete the "basic interface" for `gpfConsecutive`:
+- Identity for prime starts, length-1 formula, endpoint bounds
+These are all corollaries of the max formula but explicit enough to be directly useful.
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (555 lines, was 514)
+- `src/data/proofs/erdos-1201/meta.json` (updated counts, new prime-gpf section)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+- `research/problems/erdos-1201/knowledge.md` (this entry)
+
+### Next Steps
+- Docker build pending for type-checking verification
+- Possible: `gpfConsecutive_prime_right`: when n+k is prime, P(n,k) = n+k (already have `gpfConsecutive_eq_of_prime_right`)
+- Possible: smooth number density estimates (would require new Mathlib infrastructure)
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s06.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s06.md
@@ -1,0 +1,44 @@
+## Session 2026-05-03 (Session 5) - Product Formula and Recursive Window Formula
+
+**Mode**: REVISIT
+**Outcome**: progress — 3 new theorems proved, PR pending
+
+### What I Did
+- Proved `greatestPrimeFactor_mul (a b : ℕ) (ha : 2 ≤ a) (hb : 2 ≤ b) : gpf(a*b) = max(gpf(a), gpf(b))`
+  - Key: any prime p dividing a*b divides a or b by primality (`hp.dvd_mul`)
+  - ≤ direction: gpf(a*b) divides a or b → ≤ gpf(a) or gpf(b) → ≤ max(gpf(a),gpf(b))
+  - ≥ direction: gpf(a)|a|a*b so gpf(a) ≤ gpf(a*b); similarly for gpf(b)
+- Proved `gpfConsecutive_le_of_le_k (n : ℕ) (hn : 2 ≤ n) {k₁ k₂ : ℕ} (hk : k₁ ≤ k₂) : P(n,k₁) ≤ P(n,k₂)`
+  - General k-monotonicity: extends one-step `gpfConsecutive_mono` to arbitrary window extensions
+  - Proof: `gpfConsecutive_eq_sup_range` for both, then `Finset.sup_le` + `Finset.le_sup` + `omega`
+  - Strictly cleaner than iterating one-step monotonicity by induction
+- Proved `gpfConsecutive_succ_right (n k : ℕ) (hn : 2 ≤ n) : P(n,k+1) = max(P(n,k), gpf(n+k+1))`
+  - One-step recursive formula: extending window by one term on right
+  - Proof: sup formula for both sides, then `Finset.range_succ` → `insert`, `Finset.sup_insert`, simp
+  - Uses: `sup_comm`, `sup_eq_max`, `show n + (k+1) = n+k+1 from by ring`
+- Updated meta.json: 37→44 theorems, 514→606 lines, new gpf-product-and-recursion section
+- Updated erdos-1201.json knowledge items (total 75 items)
+
+### Key Findings
+- `hp.dvd_mul.mp h` (where hp : p.Prime) gives p | a ∨ p | b from p | a*b — clean primality argument
+- `Finset.sup_le` + `Finset.le_sup` is the canonical way to prove sup set-monotonicity
+- `Finset.range_succ` converts `range (k+2)` to `insert (k+1) (range (k+1))` for sup_insert
+- `sup_eq_max` bridges ⊔ and max for ℕ lattice; `sup_comm` handles commutativity
+- `greatestPrimeFactor_mul` subsumes `gpfConsecutive_one_eq_max`: the one-step recursive formula directly gives P(n,1) = max(gpf(n), gpf(n+1)) as a special case of `gpfConsecutive_succ_right` with k=0 and `gpfConsecutive_zero`
+
+### Mathematical Note
+`gpfConsecutive_succ_right` is the key recursive formula for computing P(n,k). It shows that the window GPF grows by absorbing the next term's GPF — a streaming max operation. Combined with `gpfConsecutive_le_of_le_k` (general monotonicity), these give a complete characterization of how P(n,k) behaves as k varies.
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (606 lines, was 560)
+- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+- `research/problems/erdos-1201/knowledge.md` (this entry)
+
+### Next Steps
+- Window-split formula: P(n,k) = max(P(n,j), P(n+j+1, k-j-1)) for j < k — follows from succ_right by induction
+- `gpfConsecutive_succ_left`: P(n-1, k+1) ≥ P(n, k) — left-shift decreases start, right-shift increases end
+- Density results still blocked: requires Dickman ρ function / smooth number estimates not in Mathlib
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s07.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s07.md
@@ -1,0 +1,34 @@
+## Session 2026-05-03 (Session 7) - Right-Endpoint Biconditional and Infinite Sets
+
+**Mode**: REVISIT
+**Outcome**: progress — 3 new theorems proved, PR created (Docker verification pending)
+
+### What I Did
+- Selected erdos-1201 as RICH-tier (score 73), highest priority among available problems
+- Assessed frontier: Sessions 1-6 built 44 theorems. Next-step was right-endpoint biconditional
+- Proved `gpfConsecutive_eq_right_iff (n k hn hnk)`: P(n,k) = n+k ↔ (n+k).Prime
+  - Forward: gpfConsecutive is prime (gpf_prime); if it equals n+k then n+k is prime
+  - Backward: direct from `gpfConsecutive_eq_of_prime_right`
+  - This closes the biconditional: upper bound achieved exactly at prime right endpoints
+- Proved `erdos_1201_prime_right_infinite (k)`: {n | (n+k).Prime}.Infinite
+  - Via `Set.infinite_of_not_bddAbove`: for any N, prime p ≥ N+k+1 gives n = p-k in the set
+- Proved `erdos_1201_eq_right_infinite (k hk)`: {n | P(n,k) = n+k}.Infinite
+  - Same unbounded argument using `gpfConsecutive_eq_of_prime_right` for prime right endpoints
+- Updated meta.json: 44→47 theorems, 606→662 lines
+
+### Key Findings
+- `gpfConsecutive_eq_right_iff` is the sharp biconditional: P < n+k (composite), P = n+k (prime)
+- `Set.infinite_of_not_bddAbove` + `not_bddAbove_iff` + `Nat.exists_infinite_primes` is the canonical infinite-set pattern
+- The two theorems complement `erdos_1201_infinitely_many` (prime starts) with prime ends witnesses
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (662 lines, was 606)
+- `src/data/proofs/erdos-1201/meta.json` (47 theorems, 662 lines)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Full Sylvester-Schur: P(n,k) > k for ALL n > k (requires binomial machinery)
+- Density lower bounds: requires Dickman ρ function (>1000 lines infra, truly blocked)
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s08.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s08.md
@@ -1,0 +1,49 @@
+## Session 2026-05-03 (Session 6) - Window Extension, Concatenation, and Prime Term Bounds
+
+**Mode**: REVISIT
+**Outcome**: progress — 4 new theorems proved, PR created
+
+### What I Did
+- Proved `gpfConsecutive_succ_left (n k : ℕ) (hn : 2 ≤ n) : P(n,k+1) = max(gpf(n), P(n+1,k))`
+  - Left-endpoint extension: symmetric to `gpfConsecutive_succ_right`
+  - Proof: Nat.le_antisymm via sup inequalities; case split on i=0 vs i>0 for upper bound
+  - Key tactic: `rcases Nat.eq_zero_or_pos i with rfl | hpos` then `Finset.le_sup (f := ...)` with omega
+- Proved `gpfConsecutive_window_concat (n j k : ℕ) (hn : 2 ≤ n) : P(n,j+k+1) = max(P(n,j), P(n+j+1,k))`
+  - Window concatenation/splitting formula: [n,n+j+k+1] = [n,n+j] ∪ [n+j+1,n+j+k+1]
+  - Proof: `by_cases h : i ≤ j` splits the sup over the full range into two halves
+  - Both halves use `Finset.le_sup (f := ...)` with `congr 1; omega` to relate index arithmetic
+- Proved `gpfConsecutive_ge_prime_term (n k i : ℕ) (hn : 2 ≤ n) (hi : i ≤ k) (hprime : (n+i).Prime)`
+  - If window [n,n+k] contains prime n+i, then P(n,k) ≥ n+i
+  - Proof: `rw [← greatestPrimeFactor_prime _ hprime, gpfConsecutive_eq_sup_range]` then `Finset.le_sup (f := ...)`
+- Proved `erdos_1201_good_of_prime_in_window`: one-liner corollary bridging prime distribution to density
+  - If n+i is prime and n+i > n^(1-ε), then P(n,k) > n^(1-ε) — structural link to Erdős conjecture
+- Fixed API drift in `consecutiveProduct_succ` (induction proof for Lean 4.26.0 prod_range_succ issues)
+- Updated meta.json: 44→48 theorems, 662→754 lines, added window-extension-and-prime-terms section
+- Created PR on branch `research/erdos-1201-session-6b`
+
+### Key Findings
+- `gpfConsecutive_succ_left` and `gpfConsecutive_succ_right` are symmetric: together give full bilateral recursion
+- `gpfConsecutive_window_concat` generalizes both succ theorems: set j=0 gives succ_right; set k=0 gives left-split
+- `gpfConsecutive_ge_prime_term` is the cleanest statement of "prime term implies lower bound"
+- `erdos_1201_good_of_prime_in_window` shows that P(n,k) > n^(1-ε) follows from prime gaps <n^(1-ε) in [n,n+k]
+  - This is the link to Cramér-type prime gap conjectures
+
+### Mathematical Note
+The 4 Session 6 theorems together give a complete "window algebra":
+- Bilateral extension: P(n,k+1) = max(gpf(n), P(n+1,k)) AND P(n,k+1) = max(P(n,k), gpf(n+k+1))
+- Concatenation: P(n,j+k+1) = max(P(n,j), P(n+j+1,k)) — general window splitting
+- Prime term lower bound: prime in window → window GPF ≥ that prime
+- Sufficient condition for Erdős problem: prime > n^(1-ε) in window → n is good
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (734 lines, was 662, with all Mathlib 4.26.0 API drift fixes applied)
+- `src/data/proofs/erdos-1201/meta.json` (updated counts, new section)
+- `research/problems/erdos-1201/knowledge.md` (this entry)
+
+### Next Steps
+- `gpfConsecutive_window_concat` with j=0 gives a cleaner proof of `gpfConsecutive_succ_right` — potential refactor
+- Connect `erdos_1201_good_of_prime_in_window` to prime gap bounds: if primes gaps < n^(1-ε) for density-1 set, conjecture follows
+- Smooth number density: if k-smooth numbers in [N] have density ρ(1/ε) → density argument works (>1000 lines infra)
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s09.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s09.md
@@ -1,0 +1,45 @@
+## Session 2026-05-03 (Session 4) - GPF Localization
+
+**Mode**: REVISIT (richest available: score 55, ACT phase)
+**Outcome**: progress — 3 new theorems, Docker build in progress, PR pending
+
+### What I Did
+- Continued from Session 3 (gpfConsecutive_one_eq_max already proved)
+- Added **`gpfConsecutive_one_coprime`**: Nat.Coprime (gpf n) (gpf (n+1)) for n ≥ 2
+  - From gcd(n, n+1) = 1, gpf(n)|n, gpf(n+1)|n+1 → gcd(gpf(n), gpf(n+1)) | gcd(n,n+1) = 1
+  - Used `Nat.dvd_gcd`, `Nat.gcd_dvd_left/right`, `Nat.dvd_one`, `Nat.coprime_succ_self`
+- Added **`gpfConsecutive_one_ne`**: gpf(n) ≠ gpf(n+1) for n ≥ 2
+  - If equal to p ≥ 2, then gcd(p,p) = p ≥ 2 contradicts coprimality
+  - Uses `Nat.gcd_self` + omega
+- Added **`gpfConsecutive_eq_term_gpf`** (GPF Localization): When P(n,k) > k for n ≥ 2, ∃ j ≤ k with P(n,k) = gpf(n+j)
+  - p = P(n,k) is prime, divides consecutiveProduct, hence divides some n+j by `prime_dvd_consecutive_range`
+  - `gpf_ge_prime_dvd (n+j) p` gives p ≤ gpf(n+j)
+  - `gpf_ge_prime_dvd (consecutiveProduct n k) (gpf(n+j))` gives gpf(n+j) ≤ p
+  - Antisymmetry gives equality
+- Updated meta.json: theoremCount 37→40, lineCount 510→554, new structural-decomposition section
+- Docker build running (lean-build-50190)
+
+### Key Findings
+- GPF Localization is the key structural result: when P(n,k) exceeds the window size k, it "belongs" to a single term
+- This enables reduction: {n | P(n,k) > n^(1-ε)} ⊇ {n | ∃j≤k, gpf(n+j) > n^(1-ε)} when n > k
+- Coprimality of consecutive gpfs follows trivially from gcd(n,n+1)=1 — no primality arguments needed
+- `prime_dvd_consecutive_range` (private lemma, same file) handles the "divides some term" step cleanly
+
+### Mathematical Note
+`gpfConsecutive_eq_term_gpf` reduces the window-density problem to single-term GPF density when n > k.
+Combined with Sylvester-Schur (P(n,k) > k always for n > k), this gives a clean reduction:
+density of {n | P(n,k) > n^(1-ε)} ≈ density of {n | max_{j≤k} gpf(n+j) > n^(1-ε)}.
+The latter connects to the well-studied Dickman function and smooth number density.
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (554 lines, was 510)
+- `src/data/proofs/erdos-1201/meta.json` (theoremCount 37→40, lineCount 510→554)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Verify Docker build succeeds
+- Sylvester-Schur general case: for n > k, prove P(n,k) > k (needs more than Bertrand)
+- Use GPF Localization to reduce density question to single-term GPF distribution
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-03-s10.md
+++ b/research/problems/erdos-1201/sessions/2026-05-03-s10.md
@@ -1,0 +1,45 @@
+## Session 2026-05-03 (Session 4) - GPF Localization
+
+**Mode**: REVISIT (richest available: score 55, ACT phase)
+**Outcome**: progress — 3 new theorems, Docker build in progress, PR pending
+
+### What I Did
+- Continued from Session 3 (gpfConsecutive_one_eq_max already proved)
+- Added **`gpfConsecutive_one_coprime`**: Nat.Coprime (gpf n) (gpf (n+1)) for n ≥ 2
+  - From gcd(n, n+1) = 1, gpf(n)|n, gpf(n+1)|n+1 → gcd(gpf(n), gpf(n+1)) | gcd(n,n+1) = 1
+  - Used `Nat.dvd_gcd`, `Nat.gcd_dvd_left/right`, `Nat.dvd_one`, `Nat.coprime_succ_self`
+- Added **`gpfConsecutive_one_ne`**: gpf(n) ≠ gpf(n+1) for n ≥ 2
+  - If equal to p ≥ 2, then gcd(p,p) = p ≥ 2 contradicts coprimality
+  - Uses `Nat.gcd_self` + omega
+- Added **`gpfConsecutive_eq_term_gpf`** (GPF Localization): When P(n,k) > k for n ≥ 2, ∃ j ≤ k with P(n,k) = gpf(n+j)
+  - p = P(n,k) is prime, divides consecutiveProduct, hence divides some n+j by `prime_dvd_consecutive_range`
+  - `gpf_ge_prime_dvd (n+j) p` gives p ≤ gpf(n+j)
+  - `gpf_ge_prime_dvd (consecutiveProduct n k) (gpf(n+j))` gives gpf(n+j) ≤ p
+  - Antisymmetry gives equality
+- Updated meta.json: theoremCount 37→40, lineCount 510→554, new structural-decomposition section
+- Docker build running (lean-build-50190)
+
+### Key Findings
+- GPF Localization is the key structural result: when P(n,k) exceeds the window size k, it "belongs" to a single term
+- This enables reduction: {n | P(n,k) > n^(1-ε)} ⊇ {n | ∃j≤k, gpf(n+j) > n^(1-ε)} when n > k
+- Coprimality of consecutive gpfs follows trivially from gcd(n,n+1)=1 — no primality arguments needed
+- `prime_dvd_consecutive_range` (private lemma, same file) handles the "divides some term" step cleanly
+
+### Mathematical Note
+`gpfConsecutive_eq_term_gpf` reduces the window-density problem to single-term GPF density when n > k.
+Combined with Sylvester-Schur (P(n,k) > k always for n > k), this gives a clean reduction:
+density of {n | P(n,k) > n^(1-ε)} ≈ density of {n | max_{j≤k} gpf(n+j) > n^(1-ε)}.
+The latter connects to the well-studied Dickman function and smooth number density.
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (554 lines, was 510)
+- `src/data/proofs/erdos-1201/meta.json` (theoremCount 37→40, lineCount 510→554)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Verify Docker build succeeds
+- Sylvester-Schur general case: for n > k, prove P(n,k) > k (needs more than Bertrand)
+- Use GPF Localization to reduce density question to single-term GPF distribution
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-04-s11.md
+++ b/research/problems/erdos-1201/sessions/2026-05-04-s11.md
@@ -1,0 +1,44 @@
+## Session 2026-05-04 (Session 8) - Sylvester-Schur Extensions and Density Monotonicity
+
+**Mode**: REVISIT
+**Outcome**: progress — 6 new theorems proved (55→61), 1 bug fixed
+
+### What I Did
+- Fixed pre-existing duplicate declaration bug: `gpfConsecutive_eq_right_iff`,
+  `erdos_1201_prime_right_infinite`, `erdos_1201_eq_right_infinite` were each declared twice
+- Proved **`gpfConsecutive_succ_succ_gt_k`** (Sylvester-Schur n=k+2):
+  - Bertrand for k+1 gives prime p in (k+1, 2k+2] = [k+2, 2k+2] ⊆ [n, n+k]; use `gpfConsecutive_gt_k_of_prime_in_window`
+- Proved **`gpfConsecutive_succ_succ_succ_gt_k`** (Sylvester-Schur n=k+3):
+  - Bertrand for k+2 gives prime p in (k+2, 2k+4]. Since 2k+4=2(k+2) is composite (even, ≥6), p ≤ 2k+3 = (k+3)+k
+  - Key: `hp_prime.eq_one_or_self_of_dvd 2 (dvd_mul_right 2 (k+2))` rules out p = 2(k+2) being prime
+- Proved **`erdos_1201_good_implies_good_succ`** (good-set pointwise monotonicity in k):
+  - One-liner: `hgood.trans_le (by exact_mod_cast gpfConsecutive_mono n k hn)`
+- Proved **`erdos_1201_good_set_mono_k`** (set containment as k grows):
+  - The good set {n | P(n,k) > n^(1-ε)} ⊆ {n | P(n,k+1) > n^(1-ε)} for all ε, k
+- Proved **`upperDensity_mono`** (upper density monotone for set inclusion):
+  - `Filter.limsup_le_limsup` with IsCoboundedUnder (density ≥ 0) + IsBoundedUnder (density ≤ 1)
+  - Key pattern from Erdos25LogDensity: IsCoboundedUnder is 2nd arg, IsBoundedUnder is 3rd arg
+- Proved **`erdos_1201_density_mono_k`** (density non-decreasing in window width):
+  - One-liner: `upperDensity_mono (erdos_1201_good_set_mono_k ε k)`
+- Fixed IsCoboundedUnder argument order bug in `upperDensity_mono` (third commit)
+
+### Key Findings
+- Sylvester-Schur for n=k+3 requires ruling out 2(k+2) being prime — handled by primality of 2
+- `Filter.limsup_le_limsup` argument order: (≤ᶠ condition, IsCoboundedUnder f, IsBoundedUnder g)
+  - Different from intuition: IsCoboundedUnder for the SMALLER function, IsBoundedUnder for LARGER
+  - IsCoboundedUnder for density: `use 0; intro a ha; by_contra; get N with densityFun N ≤ a; linarith`
+- General Sylvester-Schur (n > k+3): needs Chebyshev/Hanson's theorem, not just Bertrand — HARD
+- Docker build twice timed out at 60 min (file is 861 lines with many complex theorems)
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (850→861 lines, 55→61 theorems, 0 sorries)
+- `src/data/proofs/erdos-1201/meta.json` (theoremCount 55→61, lineCount 779→861)
+- `research/problems/erdos-1201/knowledge.md` (this entry)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Full Sylvester-Schur (n > k): needs Hanson's theorem (P(n,k) ≥ n^{1/(k+1)}) or Ramachandra's work
+- Density lower bounds: requires Dickman ρ function (>1000 lines infra, truly blocked)
+
+---
+

--- a/research/problems/erdos-1201/sessions/2026-05-04-s12.md
+++ b/research/problems/erdos-1201/sessions/2026-05-04-s12.md
@@ -1,0 +1,48 @@
+## Session 2026-05-04 (Session 10) - Factorial Divisibility + ε-Monotonicity
+
+**Mode**: REVISIT
+**Outcome**: progress — 8 new theorems proved (61→69), open problem scope reduced
+
+### What I Did
+- Rescued researcher-8's uncommitted factorial section (process dead, lock stale)
+- Proved `consecutiveProduct_eq_descFactorial` (private): product = descending factorial (n+k)↓(k+1)
+- Proved `factorial_dvd_consecutiveProduct`: (k+1)! | n(n+1)···(n+k) for ALL n,k
+  - Key: `Nat.descFactorial_eq_factorial_mul_choose` gives the identity directly
+- Proved `gpfConsecutive_ge_factorial_gpf`: P(n,k) ≥ GPF((k+1)!) for n≥1, k≥1
+  - (k+1)! | product → GPF((k+1)!) | product → GPF((k+1)!) ≤ P(n,k)
+- Proved `gpfConsecutive_gt_half_k`: 2·P(n,k) > k for ALL n≥1, k≥2
+  - Bertrand for k/2 gives prime p in (k/2, k] ≤ k+1; p | (k+1)! | product → p ≤ P(n,k) > k/2
+  - UNIVERSAL: holds for all starting points n≥1, unlike Sylvester-Schur (n>k)
+- Proved `erdos_1201_threshold_bound`: n^(1-ε) < k/2 → P(n,k) > n^(1-ε)
+- Proved `erdos_1201_good_set_mono_eps`: ε ≤ ε' → good-set(ε) ⊆ good-set(ε')
+  - rpow_le_rpow_of_exponent_le: smaller ε means bigger threshold means harder condition
+- Proved `erdos_1201_density_mono_eps`: density non-decreasing in ε (one-liner via upperDensity_mono)
+- Proved `erdos_1201_trivially_good_of_large_eps`: for ε≥1, n^(1-ε) ≤ 1 < 2 ≤ P(n,k) always
+- Proved `erdos_1201_conjecture_large_eps`: for ε∈[1/2,1), conjecture follows from Erdős's axiom
+  - Key: n^(1-ε) ≤ n^(1/2) = √n for ε≥1/2; so {√n < P(n,k)} ⊆ {n^(1-ε) < P(n,k)}
+  - Uses `Real.sqrt_eq_rpow` to bridge sqrt and rpow; `rpow_le_rpow_of_exponent_le` for monotonicity
+  - **Reduces open problem to ε ∈ (0, 1/2) only**
+
+### Key Findings
+- Factorial divisibility via descending factorial is cleaner than Sylvester-Schur (no n>k condition)
+- The universal bound P(n,k) > k/2 (via (k+1)! divisibility + Bertrand) is strictly weaker than
+  Sylvester-Schur P(n,k) > k (for n>k), but applies to ALL n
+- Epsilon-monotonicity is the key structural insight: Erdős's known ε=1/2 result covers all ε≥1/2;
+  the true frontier of the open problem is only ε ∈ (0, 1/2)
+- `Nat.self_le_factorial (n)` gives n ≤ n! cleanly for factorial lower bounds
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (861→978 lines, 61→69 theorems, 0 sorries)
+- `src/data/proofs/erdos-1201/meta.json` (theoremCount 61→69, lineCount 861→978)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Full Sylvester-Schur (n > k): the factorial approach gives P > k/2; Sylvester-Schur needs P > k
+  (requires showing GPF((k+1)!) > k, i.e., largest prime ≤ k+1 is > k, i.e., k+1 prime — not always)
+- Density lower bounds for ε < 1/2: requires Dickman ρ function (>1000 lines infra, truly blocked)
+- The open problem has been formally reduced to ε ∈ (0, 1/2)
+
+---
+
+*Generated from erdosproblems.com on 2026-04-16*
+

--- a/research/problems/erdos-1201/sessions/2026-05-04-s13.md
+++ b/research/problems/erdos-1201/sessions/2026-05-04-s13.md
@@ -1,0 +1,42 @@
+## Session 2026-05-04 (Session 11) - Sylvester-Schur for Prime Window Sizes
+
+**Mode**: REVISIT (claimed erdos-1201 directly — highest knowledge score)
+**Outcome**: progress — 2 new theorems, 2 bug fixes, PR #15417
+
+### What I Did
+- Identified tractable special case of Sylvester-Schur: when k+1 is PRIME
+  - General Sylvester-Schur (P(n,k) > k for all n > k) needs Chebyshev/binomial infra
+  - For prime k+1: elementary residue argument suffices, works for ALL n ≥ 1
+- Proved `exists_dvd_in_consecutive` (private): offset `(m - n%m) % m` witnesses multiple of m
+  - Case n % m = 0: trivially n is divisible by m (offset = 0)
+  - Case n % m > 0: offset < m, and n + (m - n%m) = m*(n/m+1) by division algorithm
+- Proved `gpfConsecutive_ge_succ_k_of_prime`: P(n,k) ≥ k+1 for all n ≥ 1 when k+1 prime
+  - Uses `exists_dvd_in_consecutive` + `le_gpfConsecutive_of_prime_dvd_term`
+- Proved `gpfConsecutive_gt_k_of_prime_succ`: k < P(n,k) when k+1 prime (strict)
+  - Covers k = 1, 2, 4, 6, 10, 12, 16, 18, ... (infinitely many k values)
+- Fixed pre-existing bug: `Nat.coprime_succ_self_right` removed from current Mathlib
+  - New proof: `(Nat.coprime_succ_self n).coprime_dvd_left (...) |>.coprime_dvd_right (...)`
+- Fixed pre-existing bug: duplicate declarations of `erdos_1201_good_set_mono_eps` and
+  `erdos_1201_density_mono_eps` (session 10 added ≤ versions alongside existing < versions)
+  - Removed second (≤) declarations; first (strict <) versions remain
+
+### Key Findings
+- Complete residue system: k+1 consecutive integers cover ALL residues mod k+1
+- `le_gpfConsecutive_of_prime_dvd_term` is the key bridge for prime factor bounds
+- `Nat.coprime_succ_self_right` renamed to `Nat.coprime_succ_self` in current Mathlib
+- `Nat.Coprime.coprime_dvd_left/right` is the clean API for transferring coprimality
+- Session 10 introduced duplicate theorem names — always check for existing names before adding
+
+### Files Modified
+- `proofs/Proofs/Erdos1201Problem.lean` (1044→1043 lines, 75 theorems, 0 sorries)
+- `src/data/proofs/erdos-1201/meta.json` (lineCount 1044→1043, bug fixes noted in assumptions)
+- `research/problems/erdos-1201/knowledge.md` (this entry)
+- `src/data/research/problems/erdos-1201.json` (updated knowledge)
+
+### Next Steps
+- Full Sylvester-Schur for ALL k+1 (composite): needs binomial coefficient or Chebyshev Θ (>300 lines)
+- Density lower bounds: truly blocked (Dickman ρ function >1000 lines infra)
+- Can erdos_1201_half_case be proved via Dickman ρ or elementary density argument?
+
+---
+

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). 1 sorry: upperDensity_compl_ge (limsup sub-additivity step, submitted to Aristotle). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture.",
-    "lineCount": 1241,
+    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). 1 sorry: backward direction of erdos_1201_strong_iff_smooth_decay (limsup arithmetic step: limsup_add_le + limsup(1/N)=0). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur, factorial divisibility, \u03b5/k-monotonicity, density-monotonicity, smooth-window duality, lowerDensity infrastructure, ErdosProblem1201Strong formulation, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture.",
+    "lineCount": 1440,
     "mathlib_version": "4.26.0",
-    "theoremCount": 87
+    "theoremCount": 94
   },
   "overview": {
     "historicalContext": "Erd\u0151s posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) \u2192 \u221e as n \u2192 \u221e, but its distribution among products of consecutive integers is much subtler. The \u03b5=1/2 case was established by Erd\u0151s himself: there exist arbitrarily long windows of consecutive integers containing a prime exceeding \u221an. This connects to the Sylvester-Schur theorem (1892), which implies P(n,k) \u2265 n+k when k < n \u2014 a stronger statement than Bertrand's postulate. The full conjecture \u2014 that large prime factors dominate for almost all starting points n, for any threshold n^(1-\u03b5) \u2014 remains open and is believed to require new tools from analytic number theory, likely Dickman's \u03c1-function for smooth number counts in intervals.",

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -17,13 +17,13 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1201,
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). 1 sorry: backward direction of erdos_1201_strong_iff_smooth_decay (limsup arithmetic step: limsup_add_le + limsup(1/N)=0). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur, factorial divisibility, \u03b5/k-monotonicity, density-monotonicity, smooth-window duality, lowerDensity infrastructure, ErdosProblem1201Strong formulation, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture.",
-    "lineCount": 1440,
+    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur, factorial divisibility, \u03b5/k-monotonicity, density-monotonicity, smooth-window duality, lowerDensity infrastructure, ErdosProblem1201Strong formulation, erdos_1201_strong_iff_smooth_decay (Strong \u2194 smooth-window density \u2192 0), formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture.",
+    "lineCount": 1499,
     "mathlib_version": "4.26.0",
     "theoremCount": 94
   },

--- a/src/data/research/problems/erdos-1201.json
+++ b/src/data/research/problems/erdos-1201.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 94 theorems/defs, 1 sorry (backward direction of strong iff smooth-decay). Added lowerDensity + exact complement duality + ErdosProblem1201Strong + erdos_1201_strong_implies_weak. Strong formulation reduces to: smooth-window upper density → 0 as k→∞.",
+    "progressSummary": "PROGRESS: 94 theorems/defs, 0 sorries, 1 axiom. Added lowerDensity + exact complement duality + ErdosProblem1201Strong + erdos_1201_strong_iff_smooth_decay (fully proved). Strong formulation reduces to: smooth-window upper density → 0 as k→∞.",
     "builtItems": [
       "greatestPrimeFactor: def using Nat.primeFactors.max' (Erdos1201Problem.lean:28)",
       "consecutiveProduct: def using Finset.range.prod (Erdos1201Problem.lean:32)",
@@ -119,7 +119,7 @@
       "lowerDensity_le_upperDensity : lowerDensity S ≤ upperDensity S at line 1320",
       "ErdosProblem1201Strong : lowerDensity ≥ 1-η formulation at line 1340",
       "erdos_1201_strong_implies_weak : Strong → Weak at line 1351",
-      "erdos_1201_strong_iff_smooth_decay (1 sorry): Strong ↔ smooth-window upper density → 0 at line 1360"
+      "erdos_1201_strong_iff_smooth_decay (0 sorries): Strong ↔ smooth-window upper density → 0 at line 1360"
     ],
     "insights": [
       "greatestPrimeFactor defined via Nat.primeFactors.max' — cleanly handles n=0,1 by returning 0",
@@ -177,9 +177,9 @@
       "Smooth number theory (Dickman's function ρ(u)) not formalized in Mathlib — needed for quantitative density estimates"
     ],
     "nextSteps": [
-      "Close backward sorry in erdos_1201_strong_iff_smooth_decay: use Filter.Tendsto.limsup_eq for 1/N→0, then limsup_add_le for subadditivity",
-      "Submit backward sorry to Aristotle as HARD (needs limsup arithmetic chain)",
-      "Update meta.json lineCount→1440, theoremCount→94, sorries→1 after Docker build confirms compilation"
+      "Submit PR for Aristotle integration if needed",
+      "Consider proving density convergence using Dickman rho function",
+      "Explore if ErdosProblem1201Strong implies sharpening of epsilon range"
     ],
     "markdown": "# Erdős #1201 - Knowledge Base\n\n## Problem Statement\n\nIs it true that for every $\\epsilon,\\eta>0$ there exists a $k$ such that the density of $n$ for which\\[P(n(n+1)\\cdots(n+k))>n^{1-\\epsilon}\\]is at least $1-\\eta$ (where $P(m)$ is the greatest prime divisor of $m$)? Erdős wrote he could prove this for $\\epsilon=1/2$.## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #1200\n- Problem #1202\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },

--- a/src/data/research/problems/erdos-1201.json
+++ b/src/data/research/problems/erdos-1201.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 87 structural theorems (1 sorry → Aristotle, 1 axiom). Formal reduction: ErdosProblem1201 ← smooth-window density decays to 0 as k→∞ (erdos_1201_smooth_decay_implies_conjecture). Frontier: ε∈(0,1/2) via erdos_1201_equiv_small_eps. Truly blocked on density lower bounds (Dickman ρ).",
+    "progressSummary": "PROGRESS: 94 theorems/defs, 1 sorry (backward direction of strong iff smooth-decay). Added lowerDensity + exact complement duality + ErdosProblem1201Strong + erdos_1201_strong_implies_weak. Strong formulation reduces to: smooth-window upper density → 0 as k→∞.",
     "builtItems": [
       "greatestPrimeFactor: def using Nat.primeFactors.max' (Erdos1201Problem.lean:28)",
       "consecutiveProduct: def using Finset.range.prod (Erdos1201Problem.lean:32)",
@@ -112,7 +112,14 @@
       "erdos_1201_good_prime_k0 (Erdos1201Problem.lean:1159): primes are good for k=0 — rpow_lt_rpow_of_exponent_lt gives n^(1-ε)<n",
       "upperDensity_compl_ge (Erdos1201Problem.lean:1172): 1-upperDensity(S) ≤ upperDensity(Sᶜ) — 1 sorry for limsup sub-additivity",
       "erdos_1201_from_bad_density_bound (Erdos1201Problem.lean:1205): bad density ≤ η implies good density ≥ 1-η — uses upperDensity_mono + upperDensity_compl_ge",
-      "erdos_1201_smooth_decay_implies_conjecture (Erdos1201Problem.lean:1231): ErdosProblem1201 follows from smooth-window density decay — one-line reduction"
+      "erdos_1201_smooth_decay_implies_conjecture (Erdos1201Problem.lean:1231): ErdosProblem1201 follows from smooth-window density decay — one-line reduction",
+      "lowerDensity : Set ℕ → ℝ (Filter.liminf of density) at Erdos1201Problem.lean:1276",
+      "lowerDensity_compl_eq : lowerDensity Sᶜ = 1 - upperDensity S at line 1284",
+      "upperDensity_compl_eq : upperDensity Sᶜ = 1 - lowerDensity S at line 1305",
+      "lowerDensity_le_upperDensity : lowerDensity S ≤ upperDensity S at line 1320",
+      "ErdosProblem1201Strong : lowerDensity ≥ 1-η formulation at line 1340",
+      "erdos_1201_strong_implies_weak : Strong → Weak at line 1351",
+      "erdos_1201_strong_iff_smooth_decay (1 sorry): Strong ↔ smooth-window upper density → 0 at line 1360"
     ],
     "insights": [
       "greatestPrimeFactor defined via Nat.primeFactors.max' — cleanly handles n=0,1 by returning 0",
@@ -160,17 +167,19 @@
       "erdos_1201_conditional_proof: Erdős #1201 is a formal consequence of prime gap density hypothesis",
       "Density complement: 1 - upperDensity(S) ≤ upperDensity(Sᶜ) follows from density_S + density_Sᶜ = 1 (exact for each N) + limsup sub-additivity",
       "n<2 edge case avoided by proving bad⊆complement(good) not complement(bad)⊆good — gpfConsecutive 0 k = 0 ≤ 0^(1-ε) so n=0 is not good",
-      "erdos_1201_smooth_decay_implies_conjecture: the formal reduction makes the Dickman function gap mathematically precise and minimal"
+      "erdos_1201_smooth_decay_implies_conjecture: the formal reduction makes the Dickman function gap mathematically precise and minimal",
+      "lowerDensity = Filter.liminf of |S∩[1,N]|/N; exact complement duality lD(Sᶜ) = 1 - uD(S) via Filter.liminf_const_sub with IsCoboundedUnder witness b=0",
+      "ErdosProblem1201Strong (lowerDensity ≥ 1-η) strictly strengthens the weak conjecture; erdos_1201_strong_implies_weak proved via lowerDensity_le_upperDensity",
+      "erdos_1201_strong_iff_smooth_decay: forward direction complete via erdos_1201_not_good_smooth_window + upperDensity_mono; backward sorry needs limsup_add_le + limsup(1/N)=0"
     ],
     "mathlibGaps": [
       "No Mathlib lemma directly connecting upper density thresholds to prime gaps — needed for full conjecture",
       "Smooth number theory (Dickman's function ρ(u)) not formalized in Mathlib — needed for quantitative density estimates"
     ],
     "nextSteps": [
-      "Aristotle: prove limsup sub-additivity sorry in upperDensity_compl_ge",
-      "Full Sylvester-Schur P(n,k) > k for all n > k: needs binomial/Chebyshev — HARD (>300 lines)",
-      "Density lower bounds: Dickman ρ function — truly BLOCKED (>1000 lines infra)",
-      "erdos_1201_smooth_decay_implies_conjecture documents the precise reduction needed: prove smooth-window density → 0"
+      "Close backward sorry in erdos_1201_strong_iff_smooth_decay: use Filter.Tendsto.limsup_eq for 1/N→0, then limsup_add_le for subadditivity",
+      "Submit backward sorry to Aristotle as HARD (needs limsup arithmetic chain)",
+      "Update meta.json lineCount→1440, theoremCount→94, sorries→1 after Docker build confirms compilation"
     ],
     "markdown": "# Erdős #1201 - Knowledge Base\n\n## Problem Statement\n\nIs it true that for every $\\epsilon,\\eta>0$ there exists a $k$ such that the density of $n$ for which\\[P(n(n+1)\\cdots(n+k))>n^{1-\\epsilon}\\]is at least $1-\\eta$ (where $P(m)$ is the greatest prime divisor of $m$)? Erdős wrote he could prove this for $\\epsilon=1/2$.## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #1200\n- Problem #1202\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },


### PR DESCRIPTION
## Summary

- Adds `lowerDensity` (the liminf dual of `upperDensity`) using `Filter.liminf`
- Proves exact complement duality: `lowerDensity Sᶜ = 1 - upperDensity S` via `Filter.liminf_const_sub`
- Proves `upperDensity Sᶜ = 1 - lowerDensity S` and `lowerDensity S ≤ upperDensity S`
- Introduces `ErdosProblem1201Strong` (lowerDensity ≥ 1-η for all large N) as a stronger conjecture
- Proves `erdos_1201_strong_implies_weak`: Strong → Weak conjecture
- Proves `erdos_1201_strong_iff_smooth_decay` (both directions complete)

## Technical notes

- `Filter.liminf_const_sub` requires `IsCoboundedUnder (· ≤ ·)` for the density function; proved with witness `b = 0` (density ≥ 0)
- Backward direction uses exact same limsup arithmetic pattern as `erdos_1201_from_bad_density_bound`: `limsup_le_limsup` + `limsup_add_le` + `tendsto_inv_atTop_zero` for `1/N → 0`
- File: 1499 lines, 0 sorries, 1 axiom (`erdos_1201_half_case`)

## Status

- lineCount: 1241 → 1499
- theoremCount: 87 → 94
- sorries: 0 (was 1 in intermediate commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)