### PR TITLE
fix(meta): remove redundant legacy leanFile fields from 61 proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -307,7 +307,6 @@
     "privateHelperCount": 6,
     "axiomDeclCount": 2,
     "lemmaCount": 0,
-    "defCount": 3,
     "path": "Proofs/AmgmInequalityOQ02.lean",
     "sorries": 0,
     "definitionCount": 3

--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -155,7 +155,6 @@
     "axiomCount": 0,
     "theoremCount": 12,
     "lemmaCount": 0,
-    "defCount": 3,
     "path": "Proofs/AmgmInequalityOQ03.lean",
     "sorries": 0,
     "definitionCount": 3

--- a/src/data/proofs/angle-trisection-oq-05/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05/meta.json
@@ -87,7 +87,6 @@
     "axiomCount": 0,
     "theoremCount": 27,
     "lemmaCount": 0,
-    "defCount": 10,
     "definitionCount": 10,
     "path": "Proofs/AngleTrisectionOQ05.lean",
     "sorries": 0

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -103,7 +103,6 @@
     "axiomCount": 0,
     "theoremCount": 23,
     "lemmaCount": 0,
-    "defCount": 6,
     "definitionCount": 6,
     "path": "Proofs/AngleTrisection.lean",
     "sorries": 0

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
@@ -154,7 +154,6 @@
     "axiomCount": 2,
     "theoremCount": 15,
     "lemmaCount": 1,
-    "defCount": 4,
     "definitionCount": 4,
     "substantiveTheoremCount": 5,
     "sorries": 6,

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -225,7 +225,6 @@
     "axiomCount": 0,
     "theoremCount": 7,
     "lemmaCount": 0,
-    "defCount": 0,
     "definitionCount": 0,
     "substantiveTheoremCount": 2,
     "trivialSpecializations": 5,

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -324,7 +324,6 @@
     "axiomCount": 0,
     "theoremCount": 9,
     "lemmaCount": 0,
-    "defCount": 0,
     "definitionCount": 0,
     "substantiveTheoremCount": 3,
     "trivialSpecializations": 6,

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -310,7 +310,6 @@
     "axiomCount": 0,
     "theoremCount": 9,
     "lemmaCount": 0,
-    "defCount": 0,
     "definitionCount": 0,
     "path": "Proofs/BinomialTheorem.lean",
     "sorries": 0

--- a/src/data/proofs/birthday-problem-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02/meta.json
@@ -241,7 +241,6 @@
     "axiomCount": 0,
     "theoremCount": 18,
     "lemmaCount": 5,
-    "defCount": 2,
     "imports": [
       "Mathlib"
     ],

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -253,7 +253,6 @@
     "axiomCount": 0,
     "theoremCount": 24,
     "lemmaCount": 0,
-    "defCount": 5,
     "definitionCount": 5,
     "path": "Proofs/BirthdayProblem.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -132,7 +132,6 @@
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
-    "sorryCount": 3,
     "mainTheorems": [
       {
         "name": "mem_spanningSets_eventually",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -87,7 +87,6 @@
   "leanFile": {
     "path": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
     "theoremCount": 13,
-    "defCount": 1,
     "axiomCount": 0,
     "lineCount": 368,
     "sorries": 0,

--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -310,7 +310,6 @@
     "axiomCount": 12,
     "theoremCount": 16,
     "lemmaCount": 0,
-    "defCount": 2,
     "imports": [
       "Mathlib.Probability.Distributions.Gaussian.Basic",
       "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -178,7 +178,6 @@
     "axiomCount": 0,
     "theoremCount": 15,
     "lemmaCount": 4,
-    "defCount": 2,
     "imports": [
       "Mathlib"
     ],

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -184,7 +184,6 @@
     "axiomCount": 0,
     "theoremCount": 27,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Tactic"
     ],

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -53,7 +53,6 @@
     "lineCount": 458,
     "axiomCount": 1,
     "theoremCount": 26,
-    "defCount": 8,
     "sorries": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -49,7 +49,6 @@
     "lineCount": 191,
     "axiomCount": 0,
     "theoremCount": 4,
-    "defCount": 1,
     "sorries": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-1022-oq-01/meta.json
+++ b/src/data/proofs/erdos-1022-oq-01/meta.json
@@ -112,7 +112,6 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Data.Fintype.Basic",

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -176,7 +176,6 @@
     "substantiveTheoremCount": 7,
     "computationalVerifications": 0,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Nat.Factorial.Basic",

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -197,7 +197,6 @@
     "substantiveTheoremCount": 11,
     "computationalVerifications": 14,
     "lemmaCount": 3,
-    "defCount": 5,
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Nat.Factorial.Basic",

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -230,7 +230,6 @@
     "substantiveTheoremCount": 3,
     "computationalVerifications": 4,
     "lemmaCount": 0,
-    "defCount": 2,
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Nat.Factorial.Basic",

--- a/src/data/proofs/erdos-1065-oq-05/meta.json
+++ b/src/data/proofs/erdos-1065-oq-05/meta.json
@@ -149,7 +149,6 @@
     "substantiveTheoremCount": 6,
     "computationalVerifications": 16,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Set.Finite.Basic",

--- a/src/data/proofs/erdos-1097-oq-01/meta.json
+++ b/src/data/proofs/erdos-1097-oq-01/meta.json
@@ -117,7 +117,6 @@
     "axiomCount": 0,
     "theoremCount": 18,
     "lemmaCount": 0,
-    "defCount": 6,
     "imports": [
       "Mathlib.Tactic",
       "Mathlib.Data.Finset.Basic"

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -197,7 +197,6 @@
     "axiomCount": 3,
     "theoremCount": 23,
     "lemmaCount": 0,
-    "defCount": 8,
     "imports": [
       "Mathlib.Tactic",
       "Mathlib.Data.Finset.Basic",

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -197,7 +197,6 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Finset.Basic",

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -184,7 +184,6 @@
   },
   "leanFile": {
     "path": "Proofs/Erdos1126OQ01Problem.lean",
-    "filename": "Erdos1126OQ01Problem.lean",
     "lineCount": 472,
     "axiomCount": 7,
     "sorries": 0,

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -184,7 +184,6 @@
     "axiomCount": 0,
     "theoremCount": 15,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [
       "Mathlib.Tactic",
       "Mathlib.Data.Nat.Basic"

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -342,7 +342,6 @@
     "axiomCount": 0,
     "theoremCount": 18,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [
       "Mathlib"
     ],

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -118,7 +118,6 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 5,
     "imports": [
       "Mathlib.Tactic",
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-327-oq-01/meta.json
+++ b/src/data/proofs/erdos-327-oq-01/meta.json
@@ -113,7 +113,6 @@
     "axiomCount": 0,
     "theoremCount": 6,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -298,7 +298,6 @@
     "axiomCount": 1,
     "theoremCount": 2,
     "lemmaCount": 0,
-    "defCount": 16,
     "imports": [
       "Mathlib"
     ],

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -192,7 +192,6 @@
     "axiomCount": 1,
     "theoremCount": 34,
     "lemmaCount": 0,
-    "defCount": 2,
     "imports": [
       "Mathlib.NumberTheory.Divisors",
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-432/meta.json
+++ b/src/data/proofs/erdos-432/meta.json
@@ -214,7 +214,6 @@
     "axiomCount": 0,
     "theoremCount": 2,
     "lemmaCount": 0,
-    "defCount": 7,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Nat.GCD.Basic",

--- a/src/data/proofs/erdos-444/meta.json
+++ b/src/data/proofs/erdos-444/meta.json
@@ -199,7 +199,6 @@
     "axiomCount": 1,
     "theoremCount": 2,
     "lemmaCount": 0,
-    "defCount": 6,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Real.Basic",

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -101,7 +101,6 @@
     "axiomCount": 0,
     "theoremCount": 32,
     "lemmaCount": 0,
-    "defCount": 10,
     "imports": [
       "Mathlib"
     ],

--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -109,7 +109,6 @@
     "axiomCount": 5,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -126,7 +126,6 @@
     "axiomCount": 2,
     "theoremCount": 3,
     "lemmaCount": 0,
-    "defCount": 2,
     "imports": [
       "Mathlib.Combinatorics.Ramsey",
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -124,7 +124,6 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Finset.Basic",

--- a/src/data/proofs/erdos-567/meta.json
+++ b/src/data/proofs/erdos-567/meta.json
@@ -132,7 +132,6 @@
     "axiomCount": 1,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 5,
     "imports": [
       "Mathlib.Tactic",
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-568/meta.json
+++ b/src/data/proofs/erdos-568/meta.json
@@ -132,7 +132,6 @@
     "axiomCount": 3,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 7,
     "imports": [
       "Mathlib.Tactic",
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -105,7 +105,6 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Real.Basic",

--- a/src/data/proofs/erdos-592/meta.json
+++ b/src/data/proofs/erdos-592/meta.json
@@ -156,7 +156,6 @@
     "axiomCount": 2,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.SetTheory.Ordinal.Arithmetic",
       "Mathlib.SetTheory.Cardinal.Basic",

--- a/src/data/proofs/erdos-654/meta.json
+++ b/src/data/proofs/erdos-654/meta.json
@@ -148,7 +148,6 @@
     "axiomCount": 0,
     "theoremCount": 1,
     "lemmaCount": 0,
-    "defCount": 5,
     "imports": [
       "Mathlib.Analysis.InnerProductSpace.Basic",
       "Mathlib.Data.Finset.Card",

--- a/src/data/proofs/erdos-726/meta.json
+++ b/src/data/proofs/erdos-726/meta.json
@@ -140,7 +140,6 @@
     "axiomCount": 2,
     "theoremCount": 19,
     "lemmaCount": 0,
-    "defCount": 6,
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
       "Mathlib.Data.Nat.Prime.Basic",

--- a/src/data/proofs/erdos-837/meta.json
+++ b/src/data/proofs/erdos-837/meta.json
@@ -152,7 +152,6 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Real.Basic",

--- a/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
@@ -190,7 +190,6 @@
     "lineCount": 142,
     "axiomCount": 0,
     "theoremCount": 10,
-    "defCount": 3,
     "mainTheorems": [
       {
         "name": "euler_formula",

--- a/src/data/proofs/euler-identity-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01/meta.json
@@ -157,7 +157,6 @@
     "lineCount": 213,
     "axiomCount": 3,
     "theoremCount": 7,
-    "defCount": 3,
     "mainTheorems": [
       {
         "name": "euler_formula_taylor",

--- a/src/data/proofs/four-color-theorem-oq-01/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-01/meta.json
@@ -166,7 +166,6 @@
     "axiomCount": 0,
     "theoremCount": 17,
     "lemmaCount": 0,
-    "defCount": 4,
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Combinatorics.SimpleGraph.Coloring",

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -208,7 +208,6 @@
     "axiomCount": 2,
     "theoremCount": 6,
     "lemmaCount": 0,
-    "defCount": 2,
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Combinatorics.SimpleGraph.Coloring",

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -148,7 +148,6 @@
   },
   "leanFile": {
     "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
-    "filename": "FurstenbergCorrespondenceOQ01.lean",
     "lineCount": 929,
     "axiomCount": 1,
     "sorries": 1,

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -273,7 +273,6 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "lemmaCount": 0,
-    "defCount": 12,
     "imports": [
       "Mathlib.Logic.Basic",
       "Mathlib.Tactic"

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -229,7 +229,6 @@
     "axiomCount": 0,
     "theoremCount": 5,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [],
     "opens": [],
     "path": "Proofs/HaltingProblem.lean",

--- a/src/data/proofs/hilbert-10/meta.json
+++ b/src/data/proofs/hilbert-10/meta.json
@@ -216,7 +216,6 @@
     "axiomCount": 4,
     "theoremCount": 7,
     "lemmaCount": 0,
-    "defCount": 12,
     "imports": [],
     "opens": [],
     "path": "Proofs/Hilbert10.lean",

--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -186,7 +186,6 @@
   },
   "leanFile": {
     "path": "Proofs/Hilbert13GeneralSpaces.lean",
-    "filename": "Hilbert13GeneralSpaces.lean",
     "axiomCount": 6,
     "sorries": 0,
     "lineCount": 443,

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -263,7 +263,6 @@
     "axiomCount": 49,
     "theoremCount": 431,
     "lemmaCount": 0,
-    "defCount": 81,
     "imports": [
       "Mathlib.Geometry.Manifold.Algebra.SmoothFunctions",
       "Mathlib.Geometry.Manifold.Sheaf.Basic",

--- a/src/data/proofs/knights-tour-oblique/meta.json
+++ b/src/data/proofs/knights-tour-oblique/meta.json
@@ -146,7 +146,6 @@
     "axiomCount": 1,
     "theoremCount": 111,
     "lemmaCount": 0,
-    "defCount": 46,
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Data.Fin.Basic",

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
@@ -52,7 +52,6 @@
     "theoremCount": 6,
     "definitionCount": 1,
     "path": "Proofs/LebesgueMeasureOQ01OQ01OQ02.lean",
-    "sorryCount": 0,
     "mainTheorems": [
       {
         "name": "thomae_continuous_at_irrational",

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -369,7 +369,6 @@
     "axiomCount": 0,
     "theoremCount": 846,
     "lemmaCount": 14,
-    "defCount": 104,
     "imports": [
       "Mathlib.Analysis.Calculus.Deriv.Basic",
       "Mathlib.Analysis.Calculus.FDeriv.Basic",

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -164,7 +164,6 @@
     "axiomCount": 0,
     "theoremCount": 17,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [
       "Mathlib.Topology.Basic",
       "Mathlib.Topology.Compactness.Compact",

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -220,7 +220,6 @@
     "axiomCount": 5,
     "theoremCount": 9,
     "lemmaCount": 0,
-    "defCount": 2,
     "imports": [
       "Mathlib.Topology.Basic",
       "Mathlib.Topology.Compactness.Compact",

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -225,7 +225,6 @@
     "axiomCount": 0,
     "theoremCount": 12,
     "lemmaCount": 0,
-    "defCount": 1,
     "imports": [
       "Mathlib.Analysis.Convex.Caratheodory",
       "Mathlib.Analysis.Convex.Combination",


### PR DESCRIPTION
## Fix

Drop redundant legacy fields from `leanFile` objects in 61 gallery proof `meta.json` files. Continues the cleanup from #15525.

## Fields Removed

| Field | Replacement | Count |
|-------|-------------|-------|
| `defCount` | `definitionCount` (already present, value matches) | 58 |
| `sorryCount` | `sorries` (already present, value matches) | 2 |
| `filename` | `path` (already present, ends with same basename) | 3 |

Per-file diffs are uniform: one field deletion each, total 61 lines removed across 61 files.

## Skipped (Need Verification)

- 5 entries with mismatched `defCount` vs `definitionCount` (need to read the .lean file to determine the truth):
  `algebraic-numbers-countable-oq-02-oq-02`, `birch-swinnerton-dyer-oq-06`, `erdos-1089`, `erdos-662`, `yang-mills-lattice-oq-01`, `yang-mills-transfer-matrix-oq-01`
- 7 entries with only `defCount` (no `definitionCount` to compare against):
  `amgm-inequality-oq-03-oq-02`, `binomial-theorem-oq-03-oq-02-oq-03`, `cantors-theorem-oq-03`, `hilbert-9-reciprocity`, `triangle-inequality-oq-03`, `yang-mills-2d`, `yang-mills-lattice`, `yang-mills-transfer-matrix`
- `ramsey-r4k-oq-01` (covered by in-flight enrichment PRs #15518/#15521)
- 5 entries already covered by #15525

These are deferred to a future PR after lean-file verification.

## Evidence

**Sample diff** (`amgm-inequality-oq-02/meta.json`):
```diff
-    "defCount": 3,
     "path": "Proofs/AmgmInequalityOQ02.lean",
     "sorries": 0,
     "definitionCount": 3
```

The `LeanFileInfo` schema in `src/types/research.ts` defines these fields for the **research/problems** schema (where `ResearchProblemPage.tsx` consumes them). They are not part of the gallery proofs `meta.json` schema and are not consumed from `meta.leanFile` anywhere in the codebase.

## Validation

- `pnpm build` passes (29s, all 16k+ files emit cleanly)
- All modified files re-parse as valid JSON
- Round-trip preservation verified: only the targeted fields are removed; whitespace and Unicode are preserved exactly

---
Automated fix by lean-mechanic agent.