### PR TITLE
fix(meta): clean up legacy leanFile.defCount in 14 deferred proofs

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -196,7 +196,6 @@
     "substantiveTheoremCount": 7,
     "computationalVerifications": 0,
     "lemmaCount": 1,
-    "defCount": 4,
     "imports": [
       "Mathlib.Data.Real.Basic",
       "Mathlib.Order.ConditionallyCompleteLattice.Basic",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -238,7 +238,7 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "lemmaCount": 0,
-    "defCount": 0,
+    "definitionCount": 0,
     "mainTheorems": [
       {
         "name": "tendsto_powerMean_zero",

--- a/src/data/proofs/cantors-theorem-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-03/meta.json
@@ -189,7 +189,7 @@
     "axiomCount": 0,
     "theoremCount": 17,
     "lemmaCount": 0,
-    "defCount": 0,
+    "definitionCount": 0,
     "imports": [
       "Mathlib"
     ],

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -248,7 +248,6 @@
     "substantiveTheoremCount": 8,
     "computationalVerifications": 27,
     "lemmaCount": 0,
-    "defCount": 3,
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Set.Finite.Basic",

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -245,7 +245,6 @@
     "substantiveTheoremCount": 5,
     "sorryTheorems": 0,
     "lemmaCount": 4,
-    "defCount": 13,
     "imports": [
       "Mathlib"
     ],
@@ -256,7 +255,7 @@
     "namespace": null,
     "path": "Proofs/Erdos1089Problem.lean",
     "sorries": 0,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -156,7 +156,6 @@
     "axiomCount": 1,
     "theoremCount": 9,
     "lemmaCount": 10,
-    "defCount": 12,
     "imports": [
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Real.Basic",
@@ -171,7 +170,7 @@
     ],
     "path": "Proofs/Erdos662Problem.lean",
     "sorries": 0,
-    "definitionCount": 10
+    "definitionCount": 12
   },
   "crossReferences": [
     {

--- a/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
@@ -203,7 +203,6 @@
     "axiomCount": 3,
     "theoremCount": 11,
     "lemmaCount": 0,
-    "defCount": 4,
     "definitionCount": 4,
     "substantiveTheoremCount": 3,
     "trivialSpecializations": 2,

--- a/src/data/proofs/hilbert-9-reciprocity/meta.json
+++ b/src/data/proofs/hilbert-9-reciprocity/meta.json
@@ -175,7 +175,7 @@
     "axiomCount": 1,
     "theoremCount": 5,
     "lemmaCount": 0,
-    "defCount": 0,
+    "definitionCount": 0,
     "imports": [
       "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
       "Mathlib.NumberTheory.Zsqrtd.GaussianInt",

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -192,7 +192,7 @@
     "axiomCount": 0,
     "theoremCount": 15,
     "lemmaCount": 0,
-    "defCount": 0,
+    "definitionCount": 0,
     "imports": [
       "Mathlib.Topology.MetricSpace.Ultra.Basic",
       "Mathlib.NumberTheory.Padics.PadicNorm",

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -221,7 +221,7 @@
     "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
-    "defCount": 641,
+    "definitionCount": 641,
     "imports": [
       "Proofs.YangMills.Classical",
       "Proofs.YangMills.Quantum"

--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -154,7 +154,6 @@
     "axiomCount": 2,
     "theoremCount": 21,
     "lemmaCount": 0,
-    "defCount": 6,
     "imports": [
       "Proofs.YangMills.Quantum"
     ],

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -152,7 +152,7 @@
     "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
-    "defCount": 641,
+    "definitionCount": 641,
     "imports": [
       "Proofs.YangMills.Classical",
       "Proofs.YangMills.Quantum"

--- a/src/data/proofs/yang-mills-transfer-matrix-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix-oq-01/meta.json
@@ -171,7 +171,6 @@
     "axiomCount": 1,
     "theoremCount": 19,
     "lemmaCount": 0,
-    "defCount": 7,
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
       "Mathlib.Analysis.SpecialFunctions.Exp"

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -142,7 +142,7 @@
     "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
-    "defCount": 641,
+    "definitionCount": 641,
     "imports": [
       "Proofs.YangMills.Classical",
       "Proofs.YangMills.Quantum"


### PR DESCRIPTION
## Fix

Continues the legacy `leanFile.defCount` cleanup from #15525 / #15530. Handles the 14 entries those PRs deferred because they required reading the actual Lean source to verify the correct definition count.

## Per-Entry Actions

| Slug | Action | Verified count |
|------|--------|---------------|
| algebraic-numbers-countable-oq-02-oq-02 | drop redundant `defCount` (4 → existing `definitionCount` 5 was right) | 5 |
| amgm-inequality-oq-03-oq-02 | rename `defCount` → `definitionCount` | 0 |
| cantors-theorem-oq-03 | rename `defCount` → `definitionCount` | 0 |
| erdos-1065 | drop redundant `defCount` (3 = existing `definitionCount` 3) | 3 |
| **erdos-1089** | update `definitionCount` 12 → 13, drop `defCount` | **13** |
| **erdos-662** | update `definitionCount` 10 → 12, drop `defCount` | **12** |
| fourier-series-oq-02-oq-03-oq-02 | drop redundant `defCount` (4 = existing `definitionCount` 4) | 4 |
| hilbert-9-reciprocity | rename `defCount` → `definitionCount` | 0 |
| triangle-inequality-oq-03 | rename `defCount` → `definitionCount` | 0 |
| yang-mills-2d | rename `defCount` → `definitionCount` | 641 |
| yang-mills-lattice-oq-01 | drop redundant `defCount` (6 → existing `definitionCount` 8 was right) | 8 |
| yang-mills-lattice | rename `defCount` → `definitionCount` | 641 |
| yang-mills-transfer-matrix-oq-01 | drop redundant `defCount` (7 → existing `definitionCount` 8 was right) | 8 |
| yang-mills-transfer-matrix | rename `defCount` → `definitionCount` | 641 |

Two entries (`erdos-1089`, `erdos-662`) had stale `definitionCount` — `defCount` was the truer value. The other four mismatched entries were the inverse: `definitionCount` was correct.

## Counting Method

Counts derived from the Lean source by:
1. Stripping nested block `/- ... -/` comments
2. Stripping `--` line comments
3. Matching ``\b(def|abbrev|opaque)\s+\w+``

Cross-validated against four already-clean entries (amgm-inequality-oq-02, basel-problem, birthday-problem, central-limit-theorem) before applying — all matched their existing `leanFile.definitionCount`.

## Validation

- `pnpm build` succeeds in 25s, all ~16k files emit cleanly
- All 14 modified `meta.json` files re-parse as valid JSON
- Diff is minimal: 9 lines added, 16 removed across 14 files

After this lands, no gallery `meta.json` carries legacy `leanFile.defCount` (the proofs schema canonicalizes on `definitionCount`).

---
Automated fix by lean-mechanic agent.