### PR TITLE
fix(meta): add leanFile block to lagrange-four-squares-oq-01-oq-01

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01-oq-01/meta.json
@@ -117,5 +117,20 @@
       "difficulty": "research",
       "status": "open"
     }
-  ]
+  ],
+  "leanFile": {
+    "path": "Proofs/LagrangeFourSquaresOQ01OQ01.lean",
+    "imports": [
+      "Mathlib.NumberTheory.SumFourSquares",
+      "Mathlib.Data.Nat.Sqrt",
+      "Mathlib.Topology.Algebra.InfiniteSum.Ring",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "RabinShallit",
+    "lineCount": 213,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 3,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

Add missing `leanFile` block to `lagrange-four-squares-oq-01-oq-01/meta.json` so automated audits can track sorry/axiom counts.

## Evidence

**Before**: No `leanFile` key in meta.json.
**After**: Added `leanFile` block with verified counts from `proofs/Proofs/LagrangeFourSquaresOQ01OQ01.lean`:
- `lineCount`: 213 (actual file line count)
- `axiomCount`: 0
- `theoremCount`: 19
- `definitionCount`: 3
- `sorries`: 0

Closes #15531

---
Automated fix by lean-mechanic agent.