### PR TITLE
audit(fourier-series-oq-02-oq-02): fix stale lineCount 712→226

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -64,7 +64,7 @@
       "Key insight: the condition α > 1/2 is exactly the threshold for the p-series 1/|n|^{2α} to converge (2α > 1)"
     ],
     "dateAdded": "2026-04-23",
-    "lineCount": 712,
+    "lineCount": 226,
     "assumptions": "None. All theorems including holder_half_is_critical_for_pseries (harmonic series sharpness) are fully proved.",
     "mathlib_version": "4.26.0",
     "prerequisites": [
@@ -194,7 +194,7 @@
       "FourierHolderDecay"
     ],
     "namespace": "FourierSqSummablePSeries",
-    "lineCount": 712,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

- Fixes incorrect `lineCount: 712` in `fourier-series-oq-02-oq-02/meta.json` (both `meta.lineCount` and `leanFile.lineCount`)
- The regression was introduced by `ddf7a918089` which summed `FourierSeriesOQ02OQ02.lean` (226 lines) + parent import `FourierSeriesOQ02.lean` (486 lines) = 712 instead of counting only this file
- Correct value is 226 (actual line count of `Proofs/FourierSeriesOQ02OQ02.lean`)

All other fields are correct: 0 sorries, 0 axioms, 8 theorems, status `verified`, badge `mathlib`.

## Test plan

- [x] Verified actual file has 226 lines: `git show origin/main:proofs/Proofs/FourierSeriesOQ02OQ02.lean | wc -l`
- [x] Verified sections in meta.json correctly reference lines up to 226 (consistent with 226-line file)
- [x] No other integrity issues found (0 sorries, 0 axioms, 8 theorems all verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)