### PR TITLE
fix(meta): correct lineCount for fourier-series-oq-02-oq-01 (534→83)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11376,10 +11376,10 @@
       "result": "clean"
     },
     "fourier-series-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
-      "result": "clean"
+      "lastAudited": "2026-05-04T06:48:46Z",
+      "result": "issues-fixed"
     },
     "fourier-series-oq-02-oq-02": {
       "auditCount": 2,

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -67,7 +67,7 @@
       "Key insight: ĉ_n → 0 requires only L²-membership; quantitative bounds are not needed"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 534,
+    "lineCount": 83,
     "assumptions": "0 sorries, 0 axioms. Fully machine-verified.",
     "mathlib_version": "4.26.0",
     "prerequisites": [
@@ -180,7 +180,7 @@
       "AddCircle"
     ],
     "namespace": "FourierHolderL2RL",
-    "lineCount": 534,
+    "lineCount": 83,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

- `FourierSeriesOQ02OQ01.lean` is 83 lines; both `meta.lineCount` and `leanFile.lineCount` were set to 534 (stale/wrong value)
- All other fields are correct: 0 sorries, 0 axioms, 1 theorem, `verified` status

## Audit

Discovered via gallery integrity audit. No other issues found for this proof.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)