### PR TITLE
fix(audit): correct lineCount for area-of-circle-oq-02-oq-01 (374→163)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 374,
+    "lineCount": 163,
     "originalContributions": [
       "sqrt_pi_pow_eq: (√π)^n = π^(n/2) — bridge between Mathlib and unitBallVolume forms",
       "nball_volume_scaling_theorem: Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)) for n ≥ 1, provable from Mathlib",
@@ -116,7 +116,7 @@
       "Proofs.AreaOfCircleOQ02"
     ],
     "namespace": "AreaOfCircleOQ02OQ01",
-    "lineCount": 374,
+    "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

- Corrects `meta.lineCount` and `leanFile.lineCount` from 374 to 163 for `area-of-circle-oq-02-oq-01`
- The Lean file `proofs/Proofs/AreaOfCircleOQ02OQ01.lean` is 163 lines in git HEAD; the inflated count (374) likely reflects a draft version that was condensed before merging

## Audit findings

All other metadata verified correct against `git show origin/main:proofs/Proofs/AreaOfCircleOQ02OQ01.lean`:
- `status: "verified"` — correct (0 sorries, 0 axioms in file)
- `badge: "mathlib"` — correct (wraps `EuclideanSpace.volume_ball`)
- `sorries: 0` — confirmed
- `axiomCount: 0` — confirmed (no `axiom` declarations, no assumption-carrying structures)
- `theoremCount: 4` — correct by `grep -c "^theorem\|^lemma"` convention (excludes anonymous `example`)
- Section line ranges (up to endLine 161) — accurate within the 163-line file

## Test plan

- [ ] `pnpm build` passes with updated lineCount fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)