### PR TITLE
research(erdos-1201): add ErdosProblem1201Strong ↔ smooth-decay equivalence (99 theorems)

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -1470,4 +1470,139 @@ theorem lowerDensity_compl (S : Set ℕ) : lowerDensity Sᶜ = 1 - upperDensity 
       exact le_trans (div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)) (hN N le_rfl)⟩
   exact Filter.liminf_const_sub 1 hbdd_above hcobdd
 
+/-- **Strong Erdős Conjecture #1201**: Like ErdosProblem1201 but uses lower density (lim inf)
+    instead of upper density (lim sup). For every ε, η > 0 there exists k such that the
+    LOWER density of {n | P(n,k) > n^(1-ε)} is at least 1 - η.
+    This is a stronger statement than `ErdosProblem1201` (which uses lim sup / upper density):
+    it asserts that for ALL large N (not just infinitely many), the density approaches 1 - η.
+    The equivalence `erdos_1201_strong_iff_smooth_decay` shows this is precisely equivalent
+    to the smooth-window density decaying to 0. -/
+def ErdosProblem1201Strong : Prop :=
+  ∀ (ε η : ℝ) (hε₀ : 0 < ε) (hε₁ : ε < 1) (hη : 0 < η),
+  ∃ k : ℕ,
+    lowerDensity {n : ℕ | (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ)} ≥ 1 - η
+
+/-- Strong ⟹ weak: if lim inf (good density) ≥ 1 - η, then lim sup ≥ 1 - η. -/
+theorem erdos_1201_strong_implies_weak : ErdosProblem1201Strong → ErdosProblem1201 := by
+  intro hStrong ε η hε₀ hε₁ hη
+  obtain ⟨k, hk⟩ := hStrong ε η hε₀ hε₁ hη
+  exact ⟨k, hk.trans (lowerDensity_le_upperDensity _)⟩
+
+/-- **Equivalence**: ErdosProblem1201Strong ↔ smooth-window-density decays to 0.
+    Forward: strong conjecture → smooth-window density ≤ η (via lowerDensity complement duality).
+    Backward: smooth-window density ≤ η → strong conjecture (via subadditivity + finite correction). -/
+theorem erdos_1201_strong_iff_smooth_decay :
+    ErdosProblem1201Strong ↔
+    ∀ (ε : ℝ), 0 < ε → ε < 1 →
+    ∀ η : ℝ, 0 < η → ∃ k : ℕ,
+      upperDensity {n : ℕ | 2 ≤ n ∧
+        ∀ i ≤ k, (greatestPrimeFactor (n + i) : ℝ) ≤ (n : ℝ) ^ (1 - ε)} ≤ η := by
+  constructor
+  · intro hStrong ε hε₀ hε₁ η hη
+    obtain ⟨k, hk⟩ := hStrong ε η hε₀ hε₁ hη
+    set good := {n : ℕ | (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ)} with hgood_def
+    set smooth_bad := {n : ℕ | 2 ≤ n ∧ ∀ i ≤ k, (greatestPrimeFactor (n + i) : ℝ) ≤ (n : ℝ) ^ (1 - ε)}
+      with hbad_def
+    have hcompl_bound : upperDensity goodᶜ ≤ η := by
+      have hdual : lowerDensity good = 1 - upperDensity goodᶜ := by
+        have := lowerDensity_compl goodᶜ
+        simp only [compl_compl] at this
+        exact this
+      linarith
+    have hsubset : smooth_bad ⊆ goodᶜ := by
+      intro n ⟨hn2, hsmooth⟩
+      simp only [hgood_def, Set.mem_compl_iff, Set.mem_setOf_eq]
+      exact (erdos_1201_not_good_smooth_window n k ε hn2).mpr hsmooth
+    exact ⟨k, (upperDensity_mono hsubset).trans hcompl_bound⟩
+  · intro hSmooth ε hε₀ hε₁ η hη
+    obtain ⟨k, hk⟩ := hSmooth ε hε₀ hε₁ η hη
+    set good := {n : ℕ | (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ)} with hgood_def
+    set smooth_bad := {n : ℕ | 2 ≤ n ∧ ∀ i ≤ k, (greatestPrimeFactor (n + i) : ℝ) ≤ (n : ℝ) ^ (1 - ε)}
+      with hbad_def
+    haveI hd1 : DecidablePred (· ∈ good) := Classical.decPred _
+    haveI hd2 : DecidablePred (· ∈ smooth_bad) := Classical.decPred _
+    have hdual : lowerDensity good = 1 - upperDensity goodᶜ := by
+      have := lowerDensity_compl goodᶜ; simp only [compl_compl] at this; exact this
+    suffices hgoodc : upperDensity goodᶜ ≤ η from ⟨k, by linarith⟩
+    have hcard_bound : ∀ N : ℕ, 1 ≤ N →
+        ((Finset.Icc 1 N).filter (fun n => n ∉ good)).card ≤
+        ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + 1 := by
+      intro N hN
+      have hsub : (Finset.Icc 1 N).filter (fun n => n ∉ good) ⊆
+          (Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad) ∪ {1} := by
+        intro x hx
+        simp only [Finset.mem_filter, Finset.mem_Icc, Finset.mem_union,
+                   Finset.mem_singleton] at hx ⊢
+        obtain ⟨⟨hx1, hxN⟩, hxgoodc⟩ := hx
+        simp only [Set.mem_compl_iff, hgood_def, Set.mem_setOf_eq] at hxgoodc
+        by_cases h2 : 2 ≤ x
+        · left
+          exact ⟨⟨hx1, hxN⟩, h2, (erdos_1201_not_good_smooth_window x k ε h2).mp hxgoodc⟩
+        · right; omega
+      calc ((Finset.Icc 1 N).filter (fun n => n ∉ good)).card
+          ≤ ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad) ∪ {1}).card :=
+              Finset.card_le_card hsub
+        _ ≤ ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + ({1} : Finset ℕ).card :=
+              Finset.card_union_le _ _
+        _ = ((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card + 1 := by simp
+    simp only [upperDensity, Set.mem_compl_iff, Set.mem_setOf_eq]
+    set dgc := fun N : ℕ => (((Finset.Icc 1 N).filter (fun n => n ∉ good)).card : ℝ) / N
+    set dbad := fun N : ℕ =>
+      (((Finset.Icc 1 N).filter (fun n => n ∈ smooth_bad)).card : ℝ) / N
+    have h_card : ∀ N : ℕ, 0 < N → dgc N ≤ dbad N + 1 / N := by
+      intro N hN
+      simp only [dgc, dbad]
+      rw [div_add_div_same]
+      apply div_le_div_of_nonneg_right _ (Nat.cast_nonneg N)
+      norm_cast
+      exact hcard_bound N (by omega)
+    have h_limsup_le : Filter.limsup dgc Filter.atTop ≤
+        Filter.limsup (fun N => dbad N + 1 / N) Filter.atTop :=
+      Filter.limsup_le_limsup
+        (Filter.eventually_atTop.mpr ⟨1, fun N hN => h_card N (by omega)⟩)
+        ⟨0, fun a ha => by
+          by_contra hlt; push_neg at hlt
+          obtain ⟨N, hN⟩ := ha.exists
+          have h0 : (0 : ℝ) ≤ dgc N := by
+            simp only [dgc]; rcases Nat.eq_zero_or_pos N with rfl | hNpos
+            · simp
+            · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+          linarith⟩
+        ⟨2, Filter.Eventually.of_forall fun N => by
+          simp only [dbad]; rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · apply add_le_add
+            · apply div_le_one_of_le _ (Nat.cast_nonneg N)
+              have hcard : (Finset.Icc 1 N).card = N := icc_one_card N
+              exact_mod_cast (Finset.card_filter_le _ _).trans hcard.le
+            · exact div_le_one_of_le (by exact_mod_cast hN) (Nat.cast_nonneg N)⟩
+    have h_subadd : Filter.limsup (fun N => dbad N + 1 / (N : ℝ)) Filter.atTop ≤
+        Filter.limsup dbad Filter.atTop +
+        Filter.limsup (fun N : ℕ => (1 : ℝ) / N) Filter.atTop :=
+      limsup_add_le
+        ⟨0, Filter.Eventually.of_forall fun N => by
+          simp only [dbad]; rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)⟩
+        ⟨1, Filter.Eventually.of_forall fun N => by
+          simp only [dbad]; rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · exact div_le_one_of_le
+              (by exact_mod_cast (Finset.card_filter_le _ _).trans (icc_one_card N).le)
+              (Nat.cast_nonneg N)⟩
+        ⟨0, fun b hb => by
+          by_contra hlt; push_neg at hlt
+          obtain ⟨N, hN⟩ := hb.exists
+          linarith [div_nonneg zero_le_one (Nat.cast_nonneg N)]⟩
+        ⟨1, Filter.Eventually.of_forall fun N => by
+          rcases Nat.eq_zero_or_pos N with rfl | hN
+          · simp
+          · exact div_le_one_of_le (by exact_mod_cast hN) (Nat.cast_nonneg N)⟩
+    have h_1N_zero : Filter.limsup (fun N : ℕ => (1 : ℝ) / N) Filter.atTop = 0 := by
+      exact (by simp_rw [one_div];
+             exact tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop).limsup_eq
+    have h_dbad_le : Filter.limsup dbad Filter.atTop ≤ η := by
+      simp only [upperDensity] at hk; exact hk
+    linarith [h_limsup_le, h_subadd, h_1N_zero, h_dbad_le]
+
 end Erdos1201

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture, lowerDensity with exact complement duality. upperDensity_compl_ge (limsup sub-additivity) is fully proved.",
-    "lineCount": 1480,
+    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture, lowerDensity with exact complement duality, full equivalence ErdosProblem1201Strong \u2194 smooth-decay (session 17, 0 sorries).",
+    "lineCount": 1608,
     "mathlib_version": "4.26.0",
-    "theoremCount": 97
+    "theoremCount": 99
   },
   "overview": {
     "historicalContext": "Erd\u0151s posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) \u2192 \u221e as n \u2192 \u221e, but its distribution among products of consecutive integers is much subtler. The \u03b5=1/2 case was established by Erd\u0151s himself: there exist arbitrarily long windows of consecutive integers containing a prime exceeding \u221an. This connects to the Sylvester-Schur theorem (1892), which implies P(n,k) \u2265 n+k when k < n \u2014 a stronger statement than Bertrand's postulate. The full conjecture \u2014 that large prime factors dominate for almost all starting points n, for any threshold n^(1-\u03b5) \u2014 remains open and is believed to require new tools from analytic number theory, likely Dickman's \u03c1-function for smooth number counts in intervals.",
@@ -165,10 +165,10 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 1473,
+    "lineCount": 1608,
     "axiomCount": 1,
-    "theoremCount": 97,
-    "definitionCount": 6,
+    "theoremCount": 99,
+    "definitionCount": 7,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

- Adds `def ErdosProblem1201Strong` — strong form of the Erdős #1201 conjecture using lower density (lim inf) instead of upper density (lim sup)
- Proves `erdos_1201_strong_implies_weak` — one-line: strong ⟹ weak via `lowerDensity_le_upperDensity`
- Proves `erdos_1201_strong_iff_smooth_decay` — full equivalence: ErdosProblem1201Strong ↔ smooth-window density decays to 0 (0 sorries)

**Stats**: 97 → 99 public theorems, 1473 → 1608 lines, 0 sorries throughout

## Mathematical content

The backward direction closes a non-trivial gap:
"smooth-window density le eta implies lowerDensity(good) ge 1-eta"

Proof strategy:
1. Counting: |goodc cap [1,N]| le |smooth_bad cap [1,N]| + 1 (n=1 edge case)
2. Filter.limsup_le_limsup: pointwise bound to limsup inequality
3. limsup_add_le: limsup(f+g) le limsup f + limsup g
4. limsup(1/N) = 0 via tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
5. lowerDensity_compl (in main): complement duality closes the argument

## Notes

- Build verification needed (Docker build was killed by memory during concurrent builds)
- Based cleanly on origin/main with all 97 existing theorems preserved
- Uses import Mathlib (already in main) — limsup_add_le available

🤖 Generated with [Claude Code](https://claude.com/claude-code)