### PR TITLE
audit: tracker sync — mark 4 proofs clean, 1 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11248,10 +11248,10 @@
       "result": "clean"
     },
     "fair-games-theorem-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
-      "result": "clean"
+      "lastAudited": "2026-05-04T07:07:07Z",
+      "result": "issues-found"
     },
     "fair-games-theorem-oq-02-oq-01-oq-01": {
       "auditCount": 1,
@@ -11260,9 +11260,9 @@
       "result": "clean"
     },
     "fair-games-theorem-oq-02-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
+      "lastAudited": "2026-05-04T07:09:00Z",
       "result": "clean"
     },
     "fair-games-theorem-oq-03": {
@@ -11308,9 +11308,9 @@
       "result": "clean"
     },
     "feuerbachs-theorem-defs-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
+      "lastAudited": "2026-05-04T07:09:00Z",
       "result": "clean"
     },
     "feuerbachs-theorem-oq-01": {
@@ -11376,15 +11376,15 @@
       "result": "clean"
     },
     "fourier-series-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
+      "lastAudited": "2026-05-04T07:08:59Z",
       "result": "clean"
     },
     "fourier-series-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
+      "lastAudited": "2026-05-04T07:08:58Z",
       "result": "clean"
     },
     "fourier-series-oq-02-oq-03": {


### PR DESCRIPTION
## Audit Tracker Sync — 2026-05-04

Updates `src/data/proofs/audit-tracker.json` with results from today's audit session.

### Results

**Clean (no issues found):**
- `fourier-series-oq-02-oq-02`
- `fourier-series-oq-02-oq-01`
- `feuerbachs-theorem-defs-oq-04`
- `fair-games-theorem-oq-02-oq-04`

**Issues found:**
- `fair-games-theorem-oq-02-oq-01` — issues reported in #15548

🤖 Generated with [Claude Code](https://claude.com/claude-code)