### PR TITLE
fix(meta): bertrands-postulate-oq-03-oq-04-oq-03 overstated status/badge (uses primeNumberTheorem axiom)

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Hadamard–de la Vallée Poussin (1896)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Prime_number_theorem",
     "date": "1896",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BertrandsPostulateOQ03OQ04OQ03.lean",
     "tags": [
       "number-theory",
@@ -19,7 +19,7 @@
       "filter-algebra",
       "asymptotics"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -60,9 +60,9 @@
       "pnt_density_gap_summary: Theorem explicitly documenting the gap between proved long-interval and open short-interval density"
     ],
     "dateAdded": "2026-04-14",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 1338,
-    "assumptions": "0 axioms, 0 sorries. The proof is fully verified from PrimeNumberTheorem (which carries 1 axiom for the PNT itself) and Mathlib's filter analysis library.",
+    "assumptions": "Relies on `axiom primeNumberTheorem : PrimeNumberTheorem_Ratio` declared in `Proofs.PrimeNumberTheorem`. All three main theorems (pnt_at_scaled_point, pnt_density_long_interval, pnt_density_gap_summary) depend on this axiom. 0 sorries.",
     "mathlib_version": "4.26.0",
     "relatedProblems": [
       {
@@ -186,7 +186,7 @@
     ],
     "namespace": "BertrandsPostulateOQ03OQ04OQ03",
     "lineCount": 1338,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BertrandsPostulateOQ03OQ04OQ03.lean",
     "theoremCount": 4,


### PR DESCRIPTION
## Fix

Corrects HIGH-severity misrepresentation: this proof claims `verified`/`axiom-free` but depends on an axiom declared in an imported file.

## Evidence

`BertrandsPostulateOQ03OQ04OQ03.lean` imports `Proofs.PrimeNumberTheorem`, which declares:
```lean
axiom primeNumberTheorem : PrimeNumberTheorem_Ratio
```

The file explicitly opens the axiom (`open PrimeNumberTheorem`) and uses it directly:
- `pnt_at_scaled_point` (line ~114): `primeNumberTheorem.comp`
- `pnt_density_long_interval` (line ~160): `have pnt_x := primeNumberTheorem`
- `pnt_density_gap_summary`: calls `pnt_density_long_interval`

All 3 main theorems depend on this axiom. The existing `assumptions` field even mentioned "1 axiom for the PNT itself" but the counts still said 0.

## Changes

| Field | Before | After |
|-------|--------|-------|
| `meta.status` | `"verified"` | `"axiomatized"` |
| `meta.badge` | `"verified"` | `"axiom"` |
| `meta.axiomCount` | `0` | `1` |
| `meta.assumptions` | contradictory (claimed "0 axioms" but mentioned "1 axiom") | accurate description |
| `leanFile.axiomCount` | `0` | `1` |

Closes #15552

---
Automated fix by lean-mechanic agent.