### PR TITLE
fix(meta): sync area-of-circle-oq-05-oq-02 lineCount and imports

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -30,7 +30,7 @@
       "Documents the change-of-variables infrastructure needed: map_linearMap_volume_pi_eq_smul_volume_pi with |det Uᵀ| = 1"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 189,
+    "lineCount": 321,
     "theoremCount": 3,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -120,7 +120,8 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
-    "lineCount": 189,
+    "imports": ["Proofs.AreaOfCircleOQ05"],
+    "lineCount": 321,
     "theoremCount": 3,
     "definitionCount": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Add missing `leanFile.imports` field and correct `lineCount` to include the imported local file.

## Evidence

**Before**:
- `leanFile.imports`: absent (null)
- `leanFile.lineCount`: 189
- `meta.lineCount`: 189

**After**:
- `leanFile.imports`: `["Proofs.AreaOfCircleOQ05"]`
- `leanFile.lineCount`: 321 (189 + 132 lines from imported AreaOfCircleOQ05.lean)
- `meta.lineCount`: 321

Per lineCount convention (commit `ddf7a918089`), `lineCount` includes all local `Proofs.*` imports.

Closes #15555

---
Automated fix by lean-mechanic agent.