### PR TITLE
enrich: fix stale cross-refs, add annotations, and section improvements for 3 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-03/meta.json
@@ -81,7 +81,8 @@
       "**Ballot = SYT**: SYT of shape (m,k) biject with ballot sequences, counted by ballotSeqCount(m+1,k) — this is the RSK/ballot connection",
       "**Hook product for 2-row (m,m)**: Row 0 hooks (m+1, m, …, 2) give (m+1)!; row 1 hooks (m, m-1, …, 1) give m!; total = (m+1)! · m!",
       "**Catalan formula connection**: C_m · (m+1) = C(2m,m), with `choose_mul_factorial_mul_factorial` providing the final cancellation",
-      "**Cancellation**: Multiply through by (m+1) using catalan_formula and choose_mul_factorial, then expand (m+1)! via factorial_succ"
+      "**Cancellation**: Multiply through by (m+1) using catalan_formula and choose_mul_factorial, then expand (m+1)! via factorial_succ",
+      "**LGV antisymmetry**: lgv_swap_sources and lgv_swap_targets prove that lgvDet is antisymmetric in its source/target pairs — swapping pairs negates the determinant, mirroring row/column transposition for matrices. This is why the path-count determinant counts non-intersecting path systems with the right signed orientation, which is the key algebraic fact behind the LGV lemma's counting power."
     ],
     "prerequisites": [
       "Combinatorics (ballot sequences, binomial coefficients)",


### PR DESCRIPTION
## Enrichment Pass — feature/enricher-1

Batch enrichment of proof gallery entries. All changes validated with \`pnpm build\`.

### Entries Enriched

**bezout-identity-oq-01-oq-01** (quality → 100)
- Fixed stale `crossReferences`: removed non-existent `binary-gcd-oq-01-oq-03`, added `binary-gcd` and `binary-gcd-oq-03`, refined `binary-gcd-oq-01` to name Lamé's theorem

**bounded-prime-gaps-oq-01-oq-02** (quality → 100)
- Added 5 annotations covering the EH conditional theorem, numerical comparison, sieve level analysis, admissible witnesses, and open problem hierarchy
- Fixed `sections.description` → `sections.summary` (5 sections)
- Fixed `crossReferences.id`/`title` → `crossReferences.proofId` (schema compliance)
- Added missing `conclusion.implications` field

**four-square-distribution** (quality 98 → 100)
- Added 5th section: "Imports, Module Header, and Key Insight" (lines 1–38) covering the preamble, module comment, and the formula contribution = multinomial × 2^(nonzero count)

**ballot-problem-oq-03-oq-03** (quality 98 → 100)
- Added 5th keyInsight on LGV antisymmetry: `lgv_swap_sources`/`lgv_swap_targets` prove lgvDet is antisymmetric under source/target transposition — the algebraic foundation of the LGV lemma's non-intersecting path counting

## Validation

All changes validated with `pnpm build` (no TypeScript errors, no schema violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)