### PR TITLE
research(erdos-1201): add upperDensity_compl_eq (99→100 theorems)

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -1470,6 +1470,13 @@ theorem lowerDensity_compl (S : Set ℕ) : lowerDensity Sᶜ = 1 - upperDensity 
       exact le_trans (div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)) (hN N le_rfl)⟩
   exact Filter.liminf_const_sub 1 hbdd_above hcobdd
 
+/-- **Complement duality for upper density**: upperDensity(Sᶜ) = 1 - lowerDensity(S).
+    Symmetric to `lowerDensity_compl` (which gives lowerDensity(Sᶜ) = 1 - upperDensity(S)). -/
+theorem upperDensity_compl_eq (S : Set ℕ) : upperDensity Sᶜ = 1 - lowerDensity S := by
+  have h := lowerDensity_compl Sᶜ
+  simp only [compl_compl] at h
+  linarith
+
 /-- **Strong Erdős Conjecture #1201**: Like ErdosProblem1201 but uses lower density (lim inf)
     instead of upper density (lim sup). For every ε, η > 0 there exists k such that the
     LOWER density of {n | P(n,k) > n^(1-ε)} is at least 1 - η.

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -23,9 +23,9 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture, lowerDensity with exact complement duality, full equivalence ErdosProblem1201Strong \u2194 smooth-decay (session 17, 0 sorries).",
-    "lineCount": 1608,
+    "lineCount": 1615,
     "mathlib_version": "4.26.0",
-    "theoremCount": 99
+    "theoremCount": 100
   },
   "overview": {
     "historicalContext": "Erd\u0151s posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) \u2192 \u221e as n \u2192 \u221e, but its distribution among products of consecutive integers is much subtler. The \u03b5=1/2 case was established by Erd\u0151s himself: there exist arbitrarily long windows of consecutive integers containing a prime exceeding \u221an. This connects to the Sylvester-Schur theorem (1892), which implies P(n,k) \u2265 n+k when k < n \u2014 a stronger statement than Bertrand's postulate. The full conjecture \u2014 that large prime factors dominate for almost all starting points n, for any threshold n^(1-\u03b5) \u2014 remains open and is believed to require new tools from analytic number theory, likely Dickman's \u03c1-function for smooth number counts in intervals.",
@@ -165,9 +165,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 1608,
+    "lineCount": 1615,
     "axiomCount": 1,
-    "theoremCount": 99,
+    "theoremCount": 100,
     "definitionCount": 7,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- Adds `upperDensity_compl_eq`: the symmetric companion lemma to `lowerDensity_compl`
  - `lowerDensity_compl`: lD(Sᶜ) = 1 - uD(S)
  - `upperDensity_compl_eq` (new): uD(Sᶜ) = 1 - lD(S)
  - Proof: 3 lines via `lowerDensity_compl` + `compl_compl` simp + `linarith`
- Fixes meta.json counts: lineCount 1608→1615, theoremCount 99→100 (meta + leanFile blocks)
- Closes stale PRs #15544 and #15539 (both had regressed lineCount to 1480)

## Status
- 1 axiom (`erdos_1201_half_case`, ε=1/2 partial result)
- 0 sorries
- 100 public theorems, 7 definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)