### PR TITLE
research(erdos-324): prove degree-2 quadratic impossibility subcases

### DIFF
--- a/proofs/Proofs/Erdos324Problem.lean
+++ b/proofs/Proofs/Erdos324Problem.lean
@@ -163,6 +163,37 @@ theorem constant_not_distinct (c : ℤ) :
   exact absurd (h hp1 hp2 heq) (by decide)
 
 /-
+## Section V.c: Quadratic Impossibility Subcases
+-/
+
+/-- Quadratic polynomials with no linear term cannot have distinct pair sums:
+    1² + 8² = 4² + 7² = 65 gives a collision for any nonzero leading coefficient a. -/
+theorem quadratic_no_linear_not_distinct (a c : ℤ) (ha : a ≠ 0) :
+    ¬HasDistinctPairSums (C a * X ^ 2 + C c) := by
+  intro h
+  have hp1 : ((1 : ℕ), (8 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have hp2 : ((4 : ℕ), (7 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have heq : pairSumFn (C a * X ^ 2 + C c) (1, 8) =
+             pairSumFn (C a * X ^ 2 + C c) (4, 7) := by
+    simp [pairSumFn, eval_add, eval_mul, eval_pow, eval_X, eval_C]; ring
+  exact absurd (h hp1 hp2 heq) (by decide)
+
+/-- Monic quadratics with negative linear coefficient -(n+2) fail distinct pair sums:
+    f(0)+f(1) = f(n+1)+f(n+2) via the identity (n+1)·((n+1)-(n+2)) = -(n+1). -/
+theorem monic_neg_linear_quad_not_distinct (n : ℕ) (c : ℤ) :
+    ¬HasDistinctPairSums (X ^ 2 - C ((n : ℤ) + 2) * X + C c) := by
+  intro h
+  have hp1 : ((0 : ℕ), (1 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]
+  have hp2 : ((n + 1 : ℕ), (n + 2 : ℕ)) ∈ orderedPairs := by simp [orderedPairs]; omega
+  have hne : ((0 : ℕ), (1 : ℕ)) ≠ ((n + 1 : ℕ), (n + 2 : ℕ)) := by
+    intro h; simp [Prod.mk.injEq] at h; omega
+  have heq : pairSumFn (X ^ 2 - C ((n : ℤ) + 2) * X + C c) (0, 1) =
+             pairSumFn (X ^ 2 - C ((n : ℤ) + 2) * X + C c) (n + 1, n + 2) := by
+    simp [pairSumFn, eval_sub, eval_add, eval_mul, eval_pow, eval_X, eval_C]
+    push_cast; ring
+  exact absurd (h hp1 hp2 heq) hne
+
+/-
 ## Section VI: Counting Pair Sums
 -/
 

--- a/research/problems/erdos-324/knowledge.md
+++ b/research/problems/erdos-324/knowledge.md
@@ -2,56 +2,99 @@
 
 ## Problem Statement
 
-Forum
-Favourites
-Tags
-More
- Go
- Go
-Dual View
-Random Solved
-Random Open
-
 Does there exist a polynomial $f(x)\in\mathbb{Z}[x]$ such that all the sums $f(a)+f(b)$ with $a<b$ nonnegative integers are distinct?
 
-
-
-Erd\H{o}s and Graham describe this problem as 'very annoying'. Probably $f(x)=x^5$ should work. The Lander, Parkin, and Selfridge conjecture would imply that $f(x)=x^n$ has this property for all $n\geq 5$.
-
-
-Back to the problem
+Erdős and Graham describe this problem as 'very annoying'. Probably $f(x)=x^5$ should work. The Lander, Parkin, and Selfridge conjecture would imply that $f(x)=x^n$ has this property for all $n\geq 5$.
 
 ## Status
 
 **Erdős Database Status**: OPEN
+**Lean File**: `proofs/Proofs/Erdos324Problem.lean` (303 lines, 14 theorems, 1 axiom, 0 sorries)
 
-**Tractability Score**: 5/10
-**Aristotle Suitable**: No
+## Current State
 
-## Tags
+**PROGRESS**: 0 sorries, 1 deep axiom (`min_degree_for_distinct`). File is actively growing with partial proofs of degree-2 impossibility subcases.
 
-- erdos
+### Proved Theorems
 
-## Related Problems
+| Theorem | Content |
+|---------|---------|
+| `quintic_implies_324` | QuinticConjecture → ErdosProblem324 |
+| `lps_implies_power_distinct` | LPS conjecture → solution exists (take n=5) |
+| `squares_not_distinct` | 1²+8²=4²+7²=65 |
+| `cubes_not_distinct` | 1³+12³=9³+10³=1729 (taxicab) |
+| `quartics_not_distinct` | 59⁴+158⁴=133⁴+134⁴=635318657 (Euler 1772) |
+| `zeroth_power_not_distinct` | 0⁰+1⁰=0⁰+2⁰=2 |
+| `first_power_not_distinct` | 0+3=1+2=3 |
+| `power_below_five_not_distinct` | xⁿ fails for all n<5 |
+| `linear_not_distinct` | f(0)+f(3)=f(1)+f(2) for any linear f |
+| `constant_not_distinct` | f(0)+f(1)=f(0)+f(2)=2c |
+| `quadratic_no_linear_not_distinct` | ax²+c fails: 1²+8²=4²+7²=65 for any a≠0 |
+| `monic_neg_linear_quad_not_distinct` | x²-(n+2)x+c fails: f(0)+f(1)=f(n+1)+f(n+2) |
+| `card_strict_pairs` (private) | #{(a,b):a<b, a,b≤N} = C(N+1,2) |
+| `distinct_count_eq_binomial` | Distinct pair sums achieve maximum count C(N+1,2) |
 
-- Problem #2000
-- Problem #83
-- Problem #888
-- Problem #1998
-- Problem #323
-- Problem #325
-- Problem #2
-- Problem #39
-- Problem #1
+### Remaining Axiom
 
-## References
+**`min_degree_for_distinct`**: ∀ f : ℤ[X], HasDistinctPairSums f → f.natDegree ≥ 5
 
-- (None available)
+This encodes the claim that ALL degree ≤ 4 polynomials fail. The provable subcases so far:
+- ✓ degree 0: `constant_not_distinct` (proved for all constants)
+- ✓ degree 1: `linear_not_distinct` (proved for all linear polynomials)
+- ✓ degree 2, no linear term: `quadratic_no_linear_not_distinct` (any ax²+c fails via 65 identity)
+- ✓ degree 2, negative linear -(n+2): `monic_neg_linear_quad_not_distinct` (parametric n≥0)
+- ✗ degree 2, general quadratic: OPEN (positive linear term b≥1 is hard)
+- ✗ degree 3, 4: OPEN (only power polynomials covered by `cubes/quartics_not_distinct`)
+
+## Key Insights
+
+### Algebraic Structure of Collisions
+
+For a quadratic ax²+bx+c, two pairs (j,j+d) and (k,k+d) with equal gap d collide iff:
+`a(j+k+d)+b = 0`, i.e., j+k+d = -b/a.
+
+This requires:
+- a | b (integrality)
+- -b/a - d ≥ 1 (non-negativity of k when j=0)
+
+For b≤-2a with a|b: works. For other cases: need different witnesses.
+
+### Quadratic Subcases Covered (degree 2)
+
+| Sub-case | Witness pairs | Condition |
+|----------|--------------|-----------|
+| ax²+c (any a≠0) | (1,8) and (4,7) | 1²+8²=4²+7²=65 |
+| x²-(n+2)x+c (any n≥0) | (0,1) and (n+1,n+2) | algebraic identity |
+| x²-x+c | (2,6) and (4,5) | 2²+6²+2(2+6)... wait, check |
+| x²+x+c | (0,8) and (5,6) | 0²+8²+(0+8)=72=5²+6²+(5+6) |
+| x²+2x+c | (0,7) and (3,6) | 49+14=63=9+36+18... |
+
+The positive-b monic case: for x²+bx+c with b≥1, specific witnesses exist but depend on b. No uniform parametric family found yet.
+
+### Why min_degree_for_distinct Is Hard
+
+For general quadratics ax²+bx+c, the existence of a collision is guaranteed by density arguments (infinitely many pairs, quadratic growth), but translating this to an explicit Lean proof for all a,b,c simultaneously seems to require case analysis that's not easily parametrized.
+
+The full proof likely requires:
+1. A complete parametric collision formula for positive b, OR
+2. A Dirichlet/Waring-type argument showing infinite collisions exist, OR
+3. A reduction to known results about sum-of-two-squares representations
+
+## Open Questions
+
+1. Can `min_degree_for_distinct` be fully proved (degree 2, 3, 4 in full generality)?
+2. Does any degree-5 polynomial with a linear term (e.g., x⁵+x) have distinct pair sums?
+3. Is there a computational verification of QuinticConjecture for all a,b,c,d < 1000?
 
 ## Sessions
 
-(No research sessions yet)
+### Session 1-17 (prior work)
+- Proved 6/7 original axioms, leaving only `min_degree_for_distinct`
+- 0 sorries, file fully verified except for the deep axiom
 
----
+### Session 19 (2026-05-04)
+Added two new theorems partially proving `min_degree_for_distinct`:
+1. `quadratic_no_linear_not_distinct`: f=ax²+c always fails (uses 1²+8²=4²+7²=65, works for any leading coeff a)
+2. `monic_neg_linear_quad_not_distinct`: f=x²-(n+2)x+c always fails (parametric: f(0)+f(1)=f(n+1)+f(n+2) is an algebraic identity)
 
-*Generated from erdosproblems.com on 2026-01-12*
+The remaining challenge for degree-2: general quadratics with positive linear coefficient.

--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -22,10 +22,10 @@
     "dateAdded": "2025-01-01",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "assumptions": "1 axiom: min_degree_for_distinct (any polynomial with distinct pair sums has degree ≥ 5). distinct_count_eq_binomial now proved (PR #6733). Six former axioms proved: lps_implies_power_distinct (trivial), squares/cubes/quartics_not_distinct (via counterexamples 65/1729/635318657), linear_not_distinct (f(0)+f(3)=f(1)+f(2)).",
-    "lineCount": 272,
-    "dateUpdated": "2026-03-28",
-    "theoremCount": 12
+    "assumptions": "1 axiom: min_degree_for_distinct (any polynomial with distinct pair sums has degree ≥ 5). distinct_count_eq_binomial now proved. Six former axioms proved: lps_implies_power_distinct (trivial), squares/cubes/quartics_not_distinct (via counterexamples 65/1729/635318657), linear_not_distinct (f(0)+f(3)=f(1)+f(2)). New: quadratic_no_linear_not_distinct (ax²+c fails, 1²+8²=4²+7²=65), monic_neg_linear_quad_not_distinct (x²-(n+2)x+c fails, f(0)+f(1)=f(n+1)+f(n+2)).",
+    "lineCount": 303,
+    "dateUpdated": "2026-05-04",
+    "theoremCount": 14
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed Problem #324 in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p. 53), describing it as 'very annoying.' The question asks whether any polynomial $f \\in \\mathbb{Z}[X]$ can make all sums $f(a) + f(b)$ with $a < b$ nonnegative integers distinct.\n\nThe problem connects to a rich history of equal-sums-of-powers questions. Diophantus studied representations of numbers as sums of squares. Fermat (1640s) characterized which integers are sums of two squares. The failure of $x^2$: $65 = 1^2 + 8^2 = 4^2 + 7^2$ follows from 65 having prime factors 5 and 13, both $\\equiv 1 \\pmod{4}$. The iconic failure of $x^3$ is the Hardy-Ramanujan taxicab number $1729 = 1^3 + 12^3 = 9^3 + 10^3$, discovered by Ramanujan in 1919 during Hardy's hospital visit. Euler (1772) found $59^4 + 158^4 = 133^4 + 134^4$, showing $x^4$ fails.\n\nThe Lander-Parkin-Selfridge (LPS) conjecture (1967) predicts that $x_1^n + x_2^n = y_1^n + y_2^n$ has no nontrivial solutions for $n \\geq 5$, generalizing Fermat's Last Theorem (the $k = 1$ case, proved by Wiles 1995). LPS would immediately resolve Problem #324 via $f(x) = x^5$. Despite extensive computational searches, no counterexample to $a^5 + b^5 = c^5 + d^5$ has been found, making the quintic the natural candidate.",
@@ -202,9 +202,9 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 272,
+    "lineCount": 303,
     "axiomCount": 1,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 7,
     "path": "Proofs/Erdos324Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Partial progress toward eliminating the \`min_degree_for_distinct\` axiom in Erdős Problem #324.

Two new proved theorems showing quadratic polynomials fail distinct pair sums:

- **\`quadratic_no_linear_not_distinct\`**: any ax²+c (a≠0) fails via 1²+8²=4²+7²=65 — works for ALL leading coefficients
- **\`monic_neg_linear_quad_not_distinct\`**: x²-(n+2)x+c fails for any n≥0 via f(0)+f(1)=f(n+1)+f(n+2), proved by \`ring\`

## Files Modified
- \`proofs/Proofs/Erdos324Problem.lean\`: +31 lines (Section V.c), theorems 12→14
- \`src/data/proofs/erdos-324/meta.json\`: lineCount 272→303, theoremCount 12→14
- \`research/problems/erdos-324/knowledge.md\`: full analysis of degree-2 collision structure

## Status
**Outcome**: progress — 2 new proved theorems, axiom count unchanged (1), sorries unchanged (0).
**Next Steps**: Cover remaining degree-2 cases (positive linear coefficient), then degree-3 and degree-4.

🤖 Generated by researcher-4