### PR TITLE
enrich: 4 entries — wilson-primes, bounded-prime-gaps-eh, cube-dissection-volume, four-square-distribution

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7110,6 +7110,21 @@
       "passes": 4,
       "lastEnriched": "2026-05-03T22:05:45Z",
       "quality": 26
+    },
+    "bounded-prime-gaps-oq-01-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-05-04T07:56:55Z",
+      "quality": 100
+    },
+    "wilsons-theorem-oq-01-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-05-04T07:59:57Z",
+      "quality": 98
+    },
+    "dissection-of-cubes-oq-01-oq-03": {
+      "passes": 1,
+      "lastEnriched": "2026-05-04T08:09:35Z",
+      "quality": 98
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {

--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -41,7 +41,8 @@
       "**Bound**: contribution(t) ≤ 384 for all types, with equality when all four components are distinct and nonzero.",
       "**Completeness**: distribution_complete_1 through _10 verifies r₄(n) for n=1..7,9,10 via type enumeration.",
       "**Growth and trivial types**: Every perfect square k² has trivial type (0,0,0,k) contributing exactly 8. Since r₄(n) ~ (π²/2)n on average and each type contributes at most 384, the average number of representation types per n grows linearly — the 24:1 symmetry ratio (= |S₄|) measures how much symmetry collapses the count.",
-      "**Theta function connection**: The generating function $\\theta(q)^4 = \\sum_{n=0}^\\infty r_4(n) q^n$ where $\\theta(q) = \\sum_{k=-\\infty}^\\infty q^{k^2}$. Jacobi's proof that $\\theta(q)^4 = 1 + 8\\sum_{n=1}^\\infty \\sigma^*(n) q^n$ uses the fact that $\\theta^4$ is a weight-2 modular form, expressible in terms of Eisenstein series. The contribution formula in this file is the combinatorial *shadow* of this analytic identity: the 24-fold symmetry group $S_4$ acts on ordered 4-tuples, and the orbit sizes are exactly the contributions defined here."
+      "**Theta function connection**: The generating function $\\theta(q)^4 = \\sum_{n=0}^\\infty r_4(n) q^n$ where $\\theta(q) = \\sum_{k=-\\infty}^\\infty q^{k^2}$. Jacobi's proof that $\\theta(q)^4 = 1 + 8\\sum_{n=1}^\\infty \\sigma^*(n) q^n$ uses the fact that $\\theta^4$ is a weight-2 modular form, expressible in terms of Eisenstein series. The contribution formula in this file is the combinatorial *shadow* of this analytic identity: the 24-fold symmetry group $S_4$ acts on ordered 4-tuples, and the orbit sizes are exactly the contributions defined here.",
+      "**Hurwitz quaternion interpretation**: Four-square representations $n = a^2 + b^2 + c^2 + d^2$ correspond to Hurwitz integers $\\alpha = a + bi + cj + dk$ of norm $N(\\alpha) = n$. The symmetry group acting on representation types is the group of left-units of the Hurwitz order (24 elements, isomorphic to the binary tetrahedral group), and the contribution $2^k \\times (4!/\\prod m_i!)$ counts orbits under this action. This connects the elementary combinatorial formula in this file to the deep algebraic structure of the Hurwitz quaternion ring $\\mathbb{H}(\\mathbb{Z})$."
     ]
   },
   "sections": [
@@ -105,19 +106,20 @@
   },
   "crossReferences": [
     {
-      "targetId": "lagrange-four-squares-waring-g2",
-      "relationship": "related",
-      "description": "Distribution of four-square representations extends Waring g(2)=4 theory"
+      "proofId": "lagrange-four-squares",
+      "relationship": "parent — Lagrange's four-square theorem proves r₄(n) > 0 for all n; this file analyzes how those representations distribute among types"
     },
     {
-      "targetId": "lagrange-four-squares",
-      "relationship": "parent",
-      "description": "Lagrange's four-square theorem proves r₄(n) > 0 for all n; this file analyzes the distribution of those representations"
+      "proofId": "lagrange-four-squares-waring-g2",
+      "relationship": "related — distribution of four-square representations extends Waring g(2)=4 theory to quantitative type analysis"
     },
     {
-      "targetId": "infinitude-primes-4k3",
-      "relationship": "related",
-      "description": "Both use mod-4 arithmetic: primes ≡ 1 (mod 4) are sums of two squares; 4∤d condition in σ*(n) mirrors this mod-4 selection"
+      "proofId": "infinitude-primes-4k3",
+      "relationship": "related — both use mod-4 arithmetic: primes ≡ 1 (mod 4) are sums of two squares; the 4∤d condition in σ*(n) mirrors this mod-4 selection"
+    },
+    {
+      "proofId": "prime-number-theorem",
+      "relationship": "related — Jacobi's formula r₄(n) = 8σ*(n) and the multiplicativity of σ* are closely tied to prime distribution; the average order σ*(n) ~ (π²/12)n (from PNT) gives the growth rate r₄(n) ~ (2π²/3)n"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Four enrichment passes by enricher-2.

## 1. wilsons-theorem-oq-01-oq-01 (quality 63→98, pass 1)
- New `ann-imports-setup` annotation; deepened `ann-consequences`
- 6th keyInsight: von Staudt–Clausen / p-adic valuation of B_{p-1}
- Fixed stale cross-reference; added prime-reciprocal-divergence, fermats-last-theorem, kummer-theorem

## 2. bounded-prime-gaps-oq-01-oq-02 (quality 40→100, pass 1)
- Added 6 annotations from scratch (full coverage)
- Fixed sections and crossReferences schema
- Added prime-number-theorem cross-reference; added implications; expanded openQuestions

## 3. dissection-of-cubes-oq-01-oq-03 (quality 98, schema + accuracy fixes)
- Fixed lineCount: 896 → 256 (verified with wc -l)
- Added definitionCount: 2
- Fixed crossReferences schema; added dissection-of-cubes-oq-02 and -oq-03 cross-references
- Added 7th keyInsight: noncomputable/Classical.decEq design choice

## 4. four-square-distribution (quality 98, schema + depth)
- Fixed crossReferences schema (targetId → proofId)
- Added prime-number-theorem cross-reference (σ*(n) average order)
- Added 7th keyInsight: Hurwitz quaternion interpretation (binary tetrahedral group, orbit sizes = contributions)

## Enrichment tracker
Records passes for all 4 entries.