### PR TITLE
fix(meta): add missing leanFile.imports and correct lineCount for 14 proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 1,
-    "lineCount": 66,
+    "lineCount": 609,
     "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "Uses `maclaurin_step` axiom from AmgmInequalityOQ02. If replaced by the proved `maclaurin_step_proved` from AmgmInequalityOQ02OQ03, all results become fully verified.",
@@ -116,12 +116,15 @@
   ],
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03",
-    "lineCount": 66,
+    "lineCount": 609,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.AmgmInequalityOQ02"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
@@ -42,7 +42,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "No axioms. Uses natDegree_dvd_card_gal from parent file (also 0 axioms). The theorem prime_degree_dvd_card_from_general is fully proved.",
-    "lineCount": 123,
+    "lineCount": 238,
     "theoremCount": 5
   },
   "overview": {
@@ -161,12 +161,15 @@
     }
   ],
   "leanFile": {
-    "lineCount": 123,
+    "lineCount": 238,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 5
+    "theoremCount": 5,
+    "imports": [
+      "Proofs.AngleTrisectionOQ02OQ01"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/angle-trisection-oq-05-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-05-03",
     "axiomCount": 0,
-    "lineCount": 196,
+    "lineCount": 490,
     "theoremCount": 19,
     "definitionCount": 1,
     "assumptions": "None. 0 axioms, 0 sorries. Inherits from AngleTrisectionOQ05OQ01 (which has 0 axioms).",
@@ -118,12 +118,15 @@
   },
   "leanFile": {
     "namespace": "AngleTrisectionOQ05OQ02",
-    "lineCount": 196,
+    "lineCount": 490,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ05OQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.AngleTrisectionOQ05OQ01"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1938,
+    "lineCount": 2020,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 68
@@ -260,7 +260,8 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib",
+      "Proofs.AreaOfCircleOQ01OQ02OQ02"
     ],
     "opens": [
       "Real",
@@ -268,7 +269,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 2020,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 11,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Depends on ArithmeticSeriesOQ02OQ02 (parallel Vandermonde).",
-    "lineCount": 165,
+    "lineCount": 319,
     "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
@@ -106,12 +106,15 @@
   },
   "leanFile": {
     "namespace": "ArithmeticSeriesOQ02OQ02OQ01",
-    "lineCount": 165,
+    "lineCount": 319,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.ArithmeticSeriesOQ02OQ02"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 169,
+    "lineCount": 327,
     "theoremCount": 12,
     "definitionCount": 0,
     "assumptions": "None. Fully machine-verified. Imports ArithmeticSeriesOQ02OQ04.lean (0 axioms).",
@@ -151,12 +151,15 @@
   ],
   "leanFile": {
     "namespace": "ArithmeticSeriesOQ02OQ04OQ01",
-    "lineCount": 169,
+    "lineCount": 327,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.ArithmeticSeriesOQ02OQ04"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/dissection-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms inherited from DissectionOfCubes.lean: smaller_cube_above_axiom, all_different_implies_long_chains_axiom. 2 sorries for geometric confinement lemmas (smallest_above_is_smaller, global_min_not_reaching_top).",
-    "lineCount": 599,
+    "lineCount": 965,
     "theoremCount": 17,
     "definitionCount": 13,
     "originalContributions": [
@@ -164,12 +164,15 @@
   },
   "leanFile": {
     "namespace": "(builds on DissectionOfCubes namespace)",
-    "lineCount": 599,
+    "lineCount": 965,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 11,
     "path": "Proofs/DissectionOfCubesOQ03.lean",
-    "sorries": 2
+    "sorries": 2,
+    "imports": [
+      "Proofs.DissectionOfCubes"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1095",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 475,
+    "lineCount": 591,
     "theoremCount": 21,
     "assumptions": "0 axioms, 0 sorries. gFunc_exists proved constructively via Kummer's theorem (carry-free base-p arithmetic). gFunc defined via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 all verified. Open conjecture; supporting lemmas fully verified."
   },
@@ -140,13 +140,14 @@
     "imports": [
       "Mathlib.Data.Nat.Choose.Basic",
       "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Tactic"
+      "Mathlib.Tactic",
+      "Proofs.KummerTheoremOQ03"
     ],
     "opens": [
       "Nat"
     ],
     "namespace": "Erdos1095OQ01",
-    "lineCount": 475,
+    "lineCount": 591,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-247-oq-01/meta.json
+++ b/src/data/proofs/erdos-247-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_transcendence_strong — Erdős 1975: if n_k is strictly increasing with HasStrongGrowth (lim sup n_k/k^t = ∞ for all t ≥ 1), then Σ 1/2^{n_k} is transcendental over ℚ.",
-    "lineCount": 506,
+    "lineCount": 1034,
     "theoremCount": 27,
     "definitionCount": 7,
     "originalContributions": [
@@ -63,12 +63,15 @@
   },
   "leanFile": {
     "namespace": "Erdos247",
-    "lineCount": 506,
+    "lineCount": 1034,
     "axiomCount": 1,
     "theoremCount": 27,
     "definitionCount": 7,
     "path": "Proofs/Erdos247Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.LiouvilleTheorem"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-28-additive-bases/meta.json
+++ b/src/data/proofs/erdos-28-additive-bases/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms for known partial results: grekos_lower_bound (Grekos et al. 2003: if A is an asymptotic basis of order 2, then r_A(n) ≥ 6 for infinitely many n) and borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 for infinitely many n). The Erdős-Turán conjecture itself (lim sup r_A(n) = ∞) remains open.",
-    "lineCount": 647,
+    "lineCount": 1152,
     "theoremCount": 19,
     "definitionCount": 11,
     "originalContributions": [
@@ -64,12 +64,15 @@
   },
   "leanFile": {
     "namespace": "Erdos28",
-    "lineCount": 647,
+    "lineCount": 1152,
     "axiomCount": 2,
     "theoremCount": 19,
     "definitionCount": 11,
     "path": "Proofs/Erdos28AdditiveBases.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.Erdos340GreedySidon"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -14,14 +14,15 @@
       "Mathlib.Analysis.Normed.Group.Quotient",
       "Mathlib.MeasureTheory.Group.Integral",
       "Mathlib.Topology.MetricSpace.Holder",
-      "Mathlib.Tactic"
+      "Mathlib.Tactic",
+      "Proofs.FourierSeriesOQ02Incomplete01"
     ],
     "opens": [
       "MeasureTheory",
       "scoped"
     ],
     "namespace": "FourierHolderDecay",
-    "lineCount": 486,
+    "lineCount": 908,
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
@@ -98,7 +99,7 @@
       "full regularity-decay hierarchy: Hölder → C^k → C^∞ → analytic"
     ],
     "axiomCount": 1,
-    "lineCount": 486,
+    "lineCount": 908,
     "assumptions": "1 axiom (holder_decay_is_optimal_seq: Weierstrass sequential optimality, corrected from incorrect cofinite version). The decay_implies_regularity theorem has been fully proved via FourierDecayInfra.",
     "theoremCount": 18
   },

--- a/src/data/proofs/inverse-galois-d4/meta.json
+++ b/src/data/proofs/inverse-galois-d4/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 682,
+    "lineCount": 891,
     "theoremCount": 27,
     "assumptions": "None. All 27 theorems proved.",
     "mathlibDependencies": [
@@ -106,11 +106,14 @@
   ],
   "leanFile": {
     "namespace": "InverseGaloisExtensions",
-    "lineCount": 683,
+    "lineCount": 891,
     "axiomCount": 0,
     "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/InverseGaloisD4.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.NthRootIrrationalOQ01"
+    ]
   }
 }

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -112,7 +112,7 @@
       "Can we formalize the Kronecker-Weber theorem in Lean?",
       "Can Q₈ (quaternion group) be explicitly realized? (last missing group of order ≤ 8)"
     ],
-    "lineCount": 5881,
+    "lineCount": 2091,
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {
@@ -303,7 +303,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
-    "lineCount": 1882,
+    "lineCount": 2091,
     "axiomCount": 4,
     "sorries": 0,
     "theoremCount": 106,
@@ -321,7 +321,8 @@
       "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic",
       "Mathlib.RingTheory.Polynomial.Eisenstein.Criterion",
       "Mathlib.RingTheory.Polynomial.GaussLemma",
-      "Mathlib.NumberTheory.LSeries.PrimesInAP"
+      "Mathlib.NumberTheory.LSeries.PrimesInAP",
+      "Proofs.NthRootIrrationalOQ01"
     ],
     "lemmaCount": 1
   }

--- a/src/data/proofs/wilsons-theorem-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 688,
+    "lineCount": 1114,
     "theoremCount": 35,
     "definitionCount": 9,
     "originalContributions": [
@@ -68,12 +68,15 @@
   },
   "leanFile": {
     "namespace": "WilsonsTheoremGeneralization",
-    "lineCount": 688,
+    "lineCount": 1114,
     "axiomCount": 0,
     "theoremCount": 35,
     "definitionCount": 9,
     "path": "Proofs/WilsonsTheoremOQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "imports": [
+      "Proofs.WilsonsTheoremOQ02"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Add missing `leanFile.imports` field (Proofs.* local imports) and correct `lineCount` to include imported file line counts for 14 proofs.

Per the lineCount convention (commit `ddf7a918089`), `lineCount` should include all local `Proofs.*` imports.

## Evidence

**Before**: `leanFile.imports` missing Proofs.* entries; `lineCount` counted only the file's own lines.  
**After**: `leanFile.imports` lists all local imports; `lineCount` = own lines + sum of imported file lines.

| Proof | Before | After | Import Added |
|-------|--------|-------|-------------|
| amgm-inequality-oq-02-oq-03-oq-03 | 66 | 609 | Proofs.AmgmInequalityOQ02 |
| angle-trisection-oq-02-oq-01-oq-01 | 123 | 238 | Proofs.AngleTrisectionOQ02OQ01 |
| angle-trisection-oq-05-oq-02 | 196 | 490 | Proofs.AngleTrisectionOQ05OQ01 |
| area-of-circle-oq-01-oq-03 | 1938 | 2020 | Proofs.AreaOfCircleOQ01OQ02OQ02 |
| arithmetic-series-oq-02-oq-02-oq-01 | 165 | 319 | Proofs.ArithmeticSeriesOQ02OQ02 |
| arithmetic-series-oq-02-oq-04-oq-01 | 169 | 327 | Proofs.ArithmeticSeriesOQ02OQ04 |
| dissection-of-cubes-oq-03 | 599 | 965 | Proofs.DissectionOfCubes |
| erdos-1095-oq-01 | 475 | 591 | Proofs.KummerTheoremOQ03 |
| erdos-247-oq-01 | 506 | 1034 | Proofs.LiouvilleTheorem |
| erdos-28-additive-bases | 647 | 1152 | Proofs.Erdos340GreedySidon |
| fourier-series-oq-02 | 486 | 908 | Proofs.FourierSeriesOQ02Incomplete01 |
| inverse-galois | 1882 | 2091 | Proofs.NthRootIrrationalOQ01 |
| inverse-galois-d4 | 683 | 891 | Proofs.NthRootIrrationalOQ01 |
| wilsons-theorem-oq-01 | 688 | 1114 | Proofs.WilsonsTheoremOQ02 |

Same class of issue as #15555 (area-of-circle-oq-05-oq-02).

---
Automated fix by lean-mechanic agent.