### PR TITLE
fix(meta): correct bounded-prime-gaps-oq-01-oq-02 line/theorem counts

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 200,
-    "theoremCount": 24,
+    "lineCount": 206,
+    "theoremCount": 25,
     "assumptions": "1 axiom: maynard_tao_sieve_eh — the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements ≤ D, infinitely many prime gaps ≤ D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework.",
     "mathlibDependencies": [
       {
@@ -132,8 +132,8 @@
   "sorries": 0,
   "leanFile": {
     "axiomCount": 0,
-    "theoremCount": 24,
+    "theoremCount": 25,
     "sorryCount": 0,
-    "lineCount": 200
+    "lineCount": 206
   }
 }


### PR DESCRIPTION
## Summary

Corrects four metadata count discrepancies in `src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json` so they match the actual Lean source at `proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean`.

The Lean file has 206 lines and 25 `^theorem ` declarations, but meta.json claimed 200 and 24 respectively. The discrepancy is consistent with `gap_bound_hierarchy` having been split into `gap_bound_eh_implies_unconditional` + `gap_bound_tpc_implies_eh` (one extra theorem, six extra lines) without the meta counts being updated.

## Changes

- `meta.lineCount`: 200 -> 206
- `meta.theoremCount`: 24 -> 25
- `leanFile.lineCount`: 200 -> 206
- `leanFile.theoremCount`: 24 -> 25

No other fields changed. `status: axiomatized`, `badge: axiom`, `sorries: 0`, and `axiomCount: 1` are all correct and untouched.

## Verification

```
$ git show origin/main:proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean | wc -l
     206
$ git show origin/main:proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean | grep -c "^theorem "
25
```

## Test plan

- [x] `python3 -m json.tool` validates the edited JSON
- [x] Diff is exactly the 4 intended numeric edits, no other touch-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)