### PR TITLE
research(erdos-411): prove Cambie's ratio-4 cases n=148646 and n=4325798

### DIFF
--- a/proofs/Proofs/Erdos411Problem.lean
+++ b/proofs/Proofs/Erdos411Problem.lean
@@ -183,7 +183,94 @@ private theorem ratio3_738_aux :
 theorem cambie_ratio3 : GeneralRatioRelation 738 4 3 :=
   ⟨0, fun k _ => (ratio3_738_aux k).2⟩
 
-/-- Cambie found ratio-4 solutions as well. -/
+/-- g(4m) = 4·g(m) when 4|m > 0: self-similar ratio-4 property.
+    Derived by applying the p=2 totient identity twice: φ(4m)=2φ(2m)=4φ(m). -/
+theorem totientStep_quadruple {m : ℕ} (hm : 4 ∣ m) (hm_pos : 0 < m) :
+    totientStep (4 * m) = 4 * totientStep m := by
+  have h2m : 2 ∣ m := dvd_trans (by norm_num) hm
+  unfold totientStep
+  rw [show 4 * m = 2 * (2 * m) from by ring]
+  rw [Nat.totient_mul_of_prime_of_dvd Nat.prime_two (dvd_mul_right 2 m)]
+  rw [Nat.totient_mul_of_prime_of_dvd Nat.prime_two h2m]
+  ring
+
+private theorem ratio4_148646_aux :
+    ∀ k, 1 ≤ k →
+      4 ∣ iteratedTotientStep k 148646 ∧
+      iteratedTotientStep (k + 4) 148646 = 4 * iteratedTotientStep k 148646 := by
+  intro k
+  induction k using Nat.strongRecOn with
+  | _ k ih =>
+    intro hk
+    refine ⟨?_, ?_⟩
+    · rcases Nat.lt_or_ge k 5 with hlt | hge
+      · interval_cases k <;> native_decide
+      · have h := (ih (k - 4) (by omega) (by omega)).2
+        rw [show k - 4 + 4 = k from by omega] at h
+        rw [h]; exact dvd_mul_right 4 _
+    · rcases Nat.lt_or_ge k 5 with hlt | hge
+      · interval_cases k <;> native_decide
+      · have ih_prev := ih (k - 1) (by omega) (by omega)
+        have h_ratio : iteratedTotientStep (k + 3) 148646 =
+            4 * iteratedTotientStep (k - 1) 148646 := by
+          have h := ih_prev.2
+          rwa [show k - 1 + 4 = k + 3 from by omega] at h
+        have h_pos : 0 < iteratedTotientStep (k - 1) 148646 := by
+          have := iteratedTotientStep_ge_start 148646 (k - 1); omega
+        have h_ak : iteratedTotientStep k 148646 =
+            totientStep (iteratedTotientStep (k - 1) 148646) := by
+          conv_lhs => rw [show k = (k - 1) + 1 from by omega]
+        calc iteratedTotientStep (k + 4) 148646
+            = totientStep (iteratedTotientStep (k + 3) 148646) := rfl
+          _ = totientStep (4 * iteratedTotientStep (k - 1) 148646) := by rw [h_ratio]
+          _ = 4 * totientStep (iteratedTotientStep (k - 1) 148646) :=
+              totientStep_quadruple ih_prev.1 h_pos
+          _ = 4 * iteratedTotientStep k 148646 := by rw [← h_ak]
+
+/-- PROVED: g_{k+4}(148646) = 4·g_k(148646) for all k ≥ 1.
+    Cambie's first ratio-4 solution, proved via structural induction
+    using g(4m) = 4·g(m) for 4|m and 4-divisibility of all iterates from k=1. -/
+theorem cambie_ratio4_148646 : GeneralRatioRelation 148646 4 4 :=
+  ⟨1, fun k hk => (ratio4_148646_aux k hk).2⟩
+
+private theorem ratio4_4325798_aux :
+    ∀ k, 1 ≤ k →
+      4 ∣ iteratedTotientStep k 4325798 ∧
+      iteratedTotientStep (k + 4) 4325798 = 4 * iteratedTotientStep k 4325798 := by
+  intro k
+  induction k using Nat.strongRecOn with
+  | _ k ih =>
+    intro hk
+    refine ⟨?_, ?_⟩
+    · rcases Nat.lt_or_ge k 5 with hlt | hge
+      · interval_cases k <;> native_decide
+      · have h := (ih (k - 4) (by omega) (by omega)).2
+        rw [show k - 4 + 4 = k from by omega] at h
+        rw [h]; exact dvd_mul_right 4 _
+    · rcases Nat.lt_or_ge k 5 with hlt | hge
+      · interval_cases k <;> native_decide
+      · have ih_prev := ih (k - 1) (by omega) (by omega)
+        have h_ratio : iteratedTotientStep (k + 3) 4325798 =
+            4 * iteratedTotientStep (k - 1) 4325798 := by
+          have h := ih_prev.2
+          rwa [show k - 1 + 4 = k + 3 from by omega] at h
+        have h_pos : 0 < iteratedTotientStep (k - 1) 4325798 := by
+          have := iteratedTotientStep_ge_start 4325798 (k - 1); omega
+        have h_ak : iteratedTotientStep k 4325798 =
+            totientStep (iteratedTotientStep (k - 1) 4325798) := by
+          conv_lhs => rw [show k = (k - 1) + 1 from by omega]
+        calc iteratedTotientStep (k + 4) 4325798
+            = totientStep (iteratedTotientStep (k + 3) 4325798) := rfl
+          _ = totientStep (4 * iteratedTotientStep (k - 1) 4325798) := by rw [h_ratio]
+          _ = 4 * totientStep (iteratedTotientStep (k - 1) 4325798) :=
+              totientStep_quadruple ih_prev.1 h_pos
+          _ = 4 * iteratedTotientStep k 4325798 := by rw [← h_ak]
+
+/-- PROVED: g_{k+4}(4325798) = 4·g_k(4325798) for all k ≥ 1.
+    Cambie's second ratio-4 solution. Same proof structure as cambie_ratio4_148646. -/
+theorem cambie_ratio4_4325798 : GeneralRatioRelation 4325798 4 4 :=
+  ⟨1, fun k hk => (ratio4_4325798_aux k hk).2⟩
+
 /-
 ## Section V: Steinerberger's Reduction
 -/

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -44,19 +44,22 @@
       "Formalized the totient-step iteration g(n) = n + φ(n) and its k-fold iterate",
       "Defined DoublingRelation and GeneralRatioRelation capturing the eventual scaling property",
       "Proved known r = 2 solutions (n = 10, 94) via native_decide base case + doubling_propagation induction",
-      "Proved Cambie's ratio-3 case g_{k+4}(738) = 3·g_k(738) for all k via strong induction over k mod 4 using totientStep_triple (axiom-free)",
+      "Proved Cambie's ratio-3 case g_{k+4}(738) = 3·g_k(738) for all k via strong induction using totientStep_triple (axiom-free)",
+      "totientStep_quadruple: proved g(4m) = 4·g(m) when 4|m via double application of Nat.totient_mul_of_prime_of_dvd with p=2",
+      "cambie_ratio4_148646: proved g_{k+4}(148646) = 4·g_k(148646) for all k≥1 via strong induction (native_decide base cases k=1..4)",
+      "cambie_ratio4_4325798: proved g_{k+4}(4325798) = 4·g_k(4325798) for all k≥1 via same structure",
       "Stated Steinerberger's (2025) reduction (DoublingRelation n 2 ↔ φ(n) + φ(n + φ(n)) = n) as a definition; equivalence proof not yet formalized",
       "Proved even preservation under g using Mathlib's Nat.totient_even",
       "Stated Cambie's structural conjecture (n = 2^l·p with p ∈ {2,3,5,7,35,47}) as a definition; conjecture itself is open"
     ],
     "axiomCount": 0,
-    "lineCount": 216,
-    "assumptions": "No axioms. All results (cambie_ratio3, r=2 solutions n=10/94) are proved. Open conjecture stated as definition, not axiom.",
-    "theoremCount": 12
+    "lineCount": 303,
+    "assumptions": "No axioms. All results (cambie_ratio3, cambie_ratio4_148646, cambie_ratio4_4325798, r=2 solutions n=10/94) are proved. Open conjecture stated as definition, not axiom.",
+    "theoremCount": 17
   },
   "leanFile": {
     "path": "Proofs/Erdos411Problem.lean",
-    "lineCount": 216,
+    "lineCount": 303,
     "namespace": "root",
     "imports": [
       "Mathlib.Data.Nat.Totient",
@@ -77,7 +80,7 @@
       "CambieConjecture"
     ],
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 17,
     "sorries": 0,
     "definitionCount": 6
   },

--- a/src/data/research/problems/erdos-411.json
+++ b/src/data/research/problems/erdos-411.json
@@ -19,13 +19,12 @@
     "phase": "ACT",
     "since": "2026-04-28T00:00:00.000Z",
     "iteration": 4,
-    "focus": "All known cases (n=10, n=94, n=738) PROVED as axiom-free theorems. Main characterization (ErdosProblem411) remains OPEN.",
+    "focus": "All known cases (n=10, n=94, n=738, n=148646, n=4325798) PROVED as axiom-free theorems. Main characterization (ErdosProblem411) remains OPEN.",
     "blockers": [
       "ErdosProblem411 (full characterization of all solutions) is the open question; not provable without major advance",
-      "CambieConjecture (n=2^l·p with p∈{2,3,5,7,35,47}) is conjectural — no proof strategy known",
-      "n=148646 and n=4325798 ratio-4 cases not yet formalized (would replicate cambie_ratio3 pattern with totientStep_quadruple lemma)"
+      "CambieConjecture (n=2^l·p with p∈{2,3,5,7,35,47}) is conjectural — no proof strategy known"
     ],
-    "nextAction": "Optional: formalize n=148646 and n=4325798 ratio-4 cases by adapting cambie_ratio3 proof structure with a totientStep_quadruple lemma analogous to totientStep_triple.",
+    "nextAction": "Submit PR for ratio-4 additions. No further sorry/axiom elimination possible.",
     "attemptCounts": {
       "total": 4,
       "currentApproach": 0,
@@ -33,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM-FREE: Erdos411Problem.lean has 0 axioms and 0 sorries (217 lines). All previously axiomatized known cases now PROVED as theorems: doubling_r2_n10, doubling_r2_n94 (via native_decide + doubling_propagation), and cambie_ratio3 (g_{k+4}(738)=3·g_k(738) via strong induction over k mod 4 using totientStep_triple). The main conjecture ErdosProblem411 (full characterization) remains an open `def : Prop`, as does CambieConjecture; these are stated, not assumed.",
+    "progressSummary": "AXIOM-FREE: Erdos411Problem.lean has 0 axioms and 0 sorries (303 lines). All known cases proved as theorems: doubling_r2_n10, doubling_r2_n94 (via native_decide + doubling_propagation), cambie_ratio3 (g_{k+4}(738)=3·g_k(738)), cambie_ratio4_148646 (g_{k+4}(148646)=4·g_k(148646) for k≥1), cambie_ratio4_4325798 (g_{k+4}(4325798)=4·g_k(4325798) for k≥1). The main conjecture ErdosProblem411 (full characterization) remains an open `def : Prop`, as does CambieConjecture; these are stated, not assumed.",
     "builtItems": [
       "Survey: identified proof strategy for steinerberger_r2_equiv and downstream axioms",
       "totient_double_even: φ(2m)=2φ(m) for even m (from Mathlib)",
@@ -42,7 +41,10 @@
       "iteratedTotientStep_ge_start: iterates ≥ starting value",
       "doubling_propagation: base case + self-similar implies all k",
       "PROVED doubling_r2_n10: axiom→theorem (6A→5A)",
-      "PROVED doubling_r2_n94: axiom→theorem (5A→4A)"
+      "PROVED doubling_r2_n94: axiom→theorem (5A→4A)",
+      "totientStep_quadruple: g(4m)=4·g(m) for 4|m (double-prime-totient identity)",
+      "PROVED cambie_ratio4_148646: g_{k+4}(148646)=4·g_k(148646) for k≥1 (strong induction + native_decide base cases k=1..4)",
+      "PROVED cambie_ratio4_4325798: g_{k+4}(4325798)=4·g_k(4325798) for k≥1 (same proof structure)"
     ],
     "insights": [
       "φ(2m) = 2φ(m) for even m — key identity enabling the scaling argument",
@@ -55,7 +57,9 @@
       "Both r=2 solutions (n=10, n=94) proved: native_decide for base case, structural induction for propagation."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove Steinerberger's equivalence: DoublingRelation n 2 ↔ φ(n)+φ(n+φ(n))=n (requires open problem progress)"
+    ],
     "markdown": "# Erdős #411 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $g_1=g(n)=n+\\phi(n)$ and $g_k(n)=g(g_{k-1}(n))$. For which $n$ and $r$ is it true that $g_{k+r}(n)=2g_k(n)$ for all large $k$?\n\n\n\nThe known solutions to $g_{k+2}(n)=2g_k(n)$ are $n=10$ and $n=94$. Selfridge and Weintraub found solutions to $g_{k+9}(n)=9g_k(n)$ and Weintraub found\\[g_{k+25}(3114)=729g_k(3114)\\]for all $k\\geq 6$.\n\nSteinerberger \\cite{St25} has observed that, for $r=2$, this problem is equivalent to asking for solutions to\\[\\phi(n)+\\phi(n+\\phi(n))=n,\\]and has shown that if this holds then either the odd part of $n$ is in $\\{1,3,5,7,35,47\\}$, or is equal to $8m+7$ or $6m+5$, where $8m+7\\geq 10^{10}$ is a prime number and $\\phi(6m+5)=4m+4$. Whether there are infinitely many such $m$ is related to the question of whether\\[\\phi(n)=\\frac{2}{3}(n+1)\\]has infinitely many solutions.\n\nCambie conjectures that the only solutions have $r=2$ and $n=2^lp$ for some $l\\geq 1$ and $p\\in \\{2,3,5,7,35,47\\}$. Cambie has shown this problem is reducible to the question of which integers $r,t\\geq 1$ and primes $p\\equiv 7\\pmod{8}$ satisfy $g_k(2p^t)=4p^t$, and conjectures there are no solutions to this except when $t=1$ and $p\\in \\{7,47\\}$. Cambie has also observed that\\[g_{k+4}(738)=3g_k(738),\\]\\[g_{k+4}(148646)=4g_k(148646),\\]and\\[g_{k+4}(4325798)=4g_{k}(4325798)\\]for all $k\\geq 1$.\n\n\n\n\nReferences\n\n\n[St25] S. Steinerberger, On an iterated arithmetic function problem of Erd\\H{o}s and Graham. arXiv:2504.08023 (2025).\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #410\n- Problem #412\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #22\n\n## References\n\n- St25\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
@@ -79,8 +83,8 @@
     {
       "path": "Proofs/Erdos411Problem.lean",
       "filename": "Erdos411Problem.lean",
-      "lineCount": 217,
-      "theoremCount": 10,
+      "lineCount": 303,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Prove `cambie_ratio4_148646`: g_{k+4}(148646) = 4·g_k(148646) for all k≥1
- Prove `cambie_ratio4_4325798`: g_{k+4}(4325798) = 4·g_k(4325798) for all k≥1
- Add `totientStep_quadruple`: g(4m) = 4·g(m) when 4|m, proved by applying `Nat.totient_mul_of_prime_of_dvd` twice with p=2

## Proof structure
Strong induction on k (k ≥ 1 precondition):
- Base cases k=1..4: verified by `native_decide`
- Inductive step (k ≥ 5):
  - Divisibility: a_{k+4} = 4·a_k, so 4|a_k from IH at k-4
  - Ratio: a_{k+4} = g(a_{k+3}) = g(4·a_{k-1}) = 4·g(a_{k-1}) = 4·a_k using `totientStep_quadruple`

File: 216 → 303 lines, 12 → 17 theorems, still 0 sorries, 0 axioms.

## Test plan
- [ ] Docker build `Proofs.Erdos411Problem` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)