### PR TITLE
fix(bounded-prime-gaps-oq-01-oq-02): document trivial markers, drop overclaim

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean
@@ -114,19 +114,32 @@ def bvLevel : ℝ := 1 / 2
 /-- EH level: Elliott-Halberstam conjectures equidistribution up to θ = 1/2. -/
 def ehLevel : ℝ := 1 / 2
 
-/-- BV and EH have the same stated level (1/2), but BV is proved only for strict θ < 1/2. -/
+/-- Definitional marker: `bvLevel` and `ehLevel` are both defined as `1/2`, hence equal by
+    reflexivity. This records the fact that BV and EH share the same numerical level (1/2);
+    the substantive distinction is that BV is proved only for strict `θ < 1/2` while EH
+    conjectures equality at `θ = 1/2`. The encoding here cannot express that finer
+    distinction (real numbers cannot distinguish "all θ < 1/2" from "θ = 1/2"); it merely
+    fixes the level value used by both regimes. -/
 theorem bv_level_eq_eh_level : bvLevel = ehLevel := rfl
 
-/-- Under BV (θ < 1/2), the Maynard-Tao sieve requires k ≥ 50. -/
+/-- Numerical marker: the unconditional Maynard-Tao sieve (Polymath 8b) operates at tuple
+    size k = 50. This theorem is a literal-equality marker (`50 = 50`) recording the value
+    of the BV sieve threshold; it does not formalize the underlying sieve-theoretic claim
+    that 50 elements suffice. The meaningful structural comparisons live in
+    `eh_threshold_lt_bv_threshold` and `eh_threshold_divides_bv` below. -/
 theorem bv_requires_50_elements : (50 : ℕ) = 50 := rfl
 
-/-- Under EH (θ = 1/2), the Maynard-Tao sieve requires only k ≥ 5. -/
+/-- Numerical marker: the EH-conditional Maynard-Tao sieve operates at tuple size k = 5.
+    Like `bv_requires_50_elements`, this is a literal-equality marker recording the value
+    of the EH sieve threshold, not a formalization of the sieve-theoretic content. -/
 theorem eh_requires_5_elements : (5 : ℕ) = 5 := rfl
 
-/-- The EH sieve threshold (5) is strictly less than the BV threshold (50). -/
+/-- The EH sieve threshold (5) is strictly less than the BV threshold (50): the substantive
+    inequality witnessing that EH needs a smaller tuple than BV. -/
 theorem eh_threshold_lt_bv_threshold : (5 : ℕ) < 50 := by norm_num
 
-/-- The EH threshold divides the BV threshold: 5 | 50. -/
+/-- The EH threshold divides the BV threshold (5 | 50): a stronger numeric relation between
+    the two sieve thresholds than mere inequality. -/
 theorem eh_threshold_divides_bv : 5 ∣ 50 := by norm_num
 
 /-

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 206,
+    "lineCount": 219,
     "theoremCount": 25,
     "assumptions": "1 axiom: maynard_tao_sieve_eh — the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements ≤ D, infinitely many prime gaps ≤ D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework.",
     "mathlibDependencies": [
@@ -36,7 +36,7 @@
     "originalContributions": [
       "First direct formalization of eh_conditional_h_le_12 as a theorem derived from maynard_tao_sieve_eh applied to the OQ01 5-tuple",
       "no_admissible_5_tuple_diam_le_10: consolidation of all 5 non-admissibility witnesses for diameter ≤ 10 as a single conjunction",
-      "Sieve level comparison framework: bvLevel = ehLevel = 1/2, but BV needs k ≥ 50 while EH needs k ≥ 5 (10× improvement)",
+      "eh_threshold_lt_bv_threshold (5 < 50) and eh_threshold_divides_bv (5 ∣ 50): the substantive numeric comparison between the EH and BV sieve thresholds. (The companion theorems bv_requires_50_elements and eh_requires_5_elements record the threshold values themselves but are literal-equality markers, not formalizations of the underlying sieve-theoretic content.)",
       "OpenQuestion01OQ02: formal definition of the open problem as ∃ H ≤ 12, H is an unconditional gap bound",
       "eh_solves_oq01oq02: conditional answer to the open question via EH"
     ],
@@ -86,26 +86,26 @@
       "id": "sieve-level",
       "title": "Sieve Level Analysis",
       "startLine": 100,
-      "endLine": 131,
-      "description": "BV vs EH level comparison: bvLevel = ehLevel = 1/2, but BV needs k ≥ 50 and EH needs k ≥ 5. The eh_threshold_lt_bv_threshold (5 < 50) and eh_threshold_divides_bv (5 | 50) are the key structural facts."
+      "endLine": 143,
+      "description": "BV vs EH level comparison: bvLevel = ehLevel = 1/2 (a definitional marker; both regimes share the level value 1/2). The substantive numeric facts are eh_threshold_lt_bv_threshold (5 < 50) and eh_threshold_divides_bv (5 | 50); the companion theorems bv_requires_50_elements and eh_requires_5_elements are literal-equality markers recording the threshold values."
     },
     {
       "id": "witnesses",
       "title": "Admissible Tuple Witnesses",
-      "startLine": 132,
-      "endLine": 158,
+      "startLine": 145,
+      "endLine": 170,
       "description": "Two optimal 5-tuple witnesses for the EH bound: eh_witness_1 ({0,2,6,8,12}) and eh_witness_2 ({0,4,6,10,12}), with two_optimal_5_tuples confirming they are distinct. sieve_witness_comparison shows the 5-tuple is much smaller than the BV 50-tuple."
     },
     {
       "id": "open-problem",
       "title": "Open Problem and Hierarchy",
-      "startLine": 159,
-      "endLine": 199,
-      "description": "OpenQuestion01OQ02 definition, gap_bound_hierarchy (TPC → EH → unconditional), eh_conditional_range (2 ≤ H_opt ≤ 12 under EH), eh_solves_oq01oq02 (EH is sufficient), and h12_unconditional_implies_progress (any unconditional H ≤ 12 surpasses current state of the art)."
+      "startLine": 172,
+      "endLine": 218,
+      "description": "OpenQuestion01OQ02 definition, gap_bound_eh_implies_unconditional and gap_bound_tpc_implies_eh (TPC → EH → unconditional), eh_conditional_range (2 ≤ H_opt ≤ 12 under EH), eh_solves_oq01oq02 (EH is sufficient), and h12_unconditional_implies_progress (any unconditional H ≤ 12 surpasses current state of the art)."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the Elliott-Halberstam conditional improvement of the prime gap bound from H ≤ 246 to H ≤ 12. The 24 proved theorems with 0 sorries and 1 axiom (maynard_tao_sieve_eh) give a complete structural picture: the sieve threshold difference (k=5 vs k=50) traces back to the BV-vs-EH level gap (θ < 1/2 vs θ = 1/2), and the open problem is precisely whether this critical boundary can be crossed without assuming EH.",
+    "summary": "This formalization captures the Elliott-Halberstam conditional improvement of the prime gap bound from H ≤ 246 to H ≤ 12. The 25 proved theorems with 0 sorries and 1 axiom (maynard_tao_sieve_eh) give a complete structural picture: the sieve threshold difference (k=5 vs k=50) traces back to the BV-vs-EH level gap (θ < 1/2 vs θ = 1/2), and the open problem is precisely whether this critical boundary can be crossed without assuming EH.",
     "openQuestions": [
       "Can H ≤ 12 be proved unconditionally — i.e., can the EH conjecture be proved or bypassed?",
       "Does a new sieve technique exist that achieves k=5 without EH-level distribution estimates?",
@@ -134,6 +134,6 @@
     "axiomCount": 0,
     "theoremCount": 25,
     "sorryCount": 0,
-    "lineCount": 206
+    "lineCount": 219
   }
 }


### PR DESCRIPTION
## Summary

Closes #15572 (Gallery integrity: bounded-prime-gaps-oq-01-oq-02 has trivial tautology theorems with misleading names).

The auditor flagged three concrete concerns; this PR addresses all three with a docstring + metadata change only — no theorem statements or proof terms changed.

## Changes

### 1. Lean docstrings in the "Sieve Level Analysis" section

Three theorems prove only literal equalities by `rfl`:

```lean
theorem bv_level_eq_eh_level : bvLevel = ehLevel := rfl   -- both = 1/2 by definition
theorem bv_requires_50_elements : (50 : ℕ) = 50 := rfl    -- 50 = 50
theorem eh_requires_5_elements  : (5 : ℕ) = 5  := rfl     -- 5 = 5
```

Their previous docstrings ("Under BV (θ < 1/2), the Maynard-Tao sieve requires k ≥ 50.") suggested they formalized sieve-theoretic content. Updated to explicitly call them numerical / definitional markers and point at the substantive inequalities `eh_threshold_lt_bv_threshold` and `eh_threshold_divides_bv` that live alongside them.

### 2. `meta.originalContributions`

Removed the "Sieve level comparison framework: bvLevel = ehLevel = 1/2, but BV needs k ≥ 50 while EH needs k ≥ 5 (10× improvement)" claim — the markers do not formalize that framework. Replaced with a precise credit to `eh_threshold_lt_bv_threshold` (5 < 50) and `eh_threshold_divides_bv` (5 ∣ 50), with a footnote noting the markers' true role.

### 3. `conclusion.summary` count

Was "24 proved theorems"; the file has 25 (`gap_bound_hierarchy` was split into `gap_bound_eh_implies_unconditional` + `gap_bound_tpc_implies_eh` in PR #15528 without the conclusion text being updated). Now reads "25 proved theorems".

### Resync of docstring-driven line growth

The longer docstrings shifted line numbers; updated:
- `meta.lineCount` and `leanFile.lineCount`: 206 → 219
- `sections.sieve-level.endLine`: 131 → 143
- `sections.witnesses.startLine`/`endLine`: 132/158 → 145/170
- `sections.open-problem.startLine`/`endLine`: 159/199 → 172/218

Also refreshed the `open-problem` section description — it referenced the old `gap_bound_hierarchy` name; now lists the two split implications.

## Verification

```
$ wc -l proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean
     219
$ grep -c "^theorem " proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean
25
$ python3 -m json.tool src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json > /dev/null
$ # JSON valid
```

No proof terms changed, so the Lean build is unaffected.

## Test plan

- [x] `python3 -m json.tool` validates the edited JSON
- [x] `wc -l` matches the new `lineCount` (219)
- [x] `grep -c "^theorem "` confirms `theoremCount` unchanged (25)
- [x] Lean diff is docstrings-only — proof terms unchanged

---
Automated fix by lean-mechanic agent.