### PR TITLE
fix: commit e-transcendental-oq-02 gallery entry; fix lineCount 237→235

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -536,6 +536,7 @@ import Proofs.DivisibilityTruncationGeneralOQ01
 import Proofs.DivisibilityTruncationGeneralOQ03
 import Proofs.ETranscendentalOQ01
 import Proofs.ETranscendentalOQ01OQ01
+import Proofs.ETranscendentalOQ02
 import Proofs.ETranscendentalOQ03
 import Proofs.EhrhartCubeProven
 import Proofs.EhrhartPolynomialOQ03

--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -1,0 +1,235 @@
+import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Data.Complex.ExponentialBounds
+import Mathlib.Data.Real.Irrational
+import Mathlib.Topology.Algebra.Order.Floor
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic
+import Proofs.eTranscendental
+
+/-!
+# Is e a Normal Number? (Open Question)
+
+## The Problem
+
+Is Euler's number e = 2.71828182845904523536... **normal** in every base?
+
+A real number is **normal in base b** if every k-length string of base-b digits appears
+with equal asymptotic frequency 1/bᵏ in its expansion. A number is **absolutely normal** if
+it is normal in every base b ≥ 2.
+
+## What IS Known
+
+1. **e is irrational** (Euler, 1737) and **transcendental** (Hermite, 1873)
+2. **e's continued fraction** [2; 1, 2, 1, 1, 4, 1, 1, 6, ...] has the regular pattern [2; (1, 2k, 1)_{k≥1}]
+3. **e's first 5 × 10¹³ decimal digits** have been computed; statistical tests show no anomalies
+4. **The irrationality measure of e is exactly 2** (see ETranscendentalOQ03)
+5. **Every rational number is NOT normal** in any base (eventually periodic expansions)
+
+## What is NOT Known
+
+Whether e is normal in ANY base remains completely open as of 2026.
+No specific constant has been proved normal, though almost all reals are (Borel, 1909).
+
+## This Entry Proves
+
+- The first 6 decimal digits of e from Mathlib bounds: 2.718281...
+- Normality implies irrationality (via periodic expansion argument)
+- Normal numbers are irrational, so e's irrationality is a necessary condition
+- The open conjecture: e is absolutely normal (axiomatized)
+
+## Status
+
+- [x] Normality defined rigorously (digit frequency version)
+- [x] Decimal digits 1–6 of e proved from exp_one bounds
+- [x] `normal_imp_irrational`: normality implies irrationality
+- [x] e is irrational (necessary condition for normality)
+- [ ] Whether e is normal in base 10, base 2, or any base (OPEN — axiomatized)
+-/
+
+open Real Filter
+
+set_option maxHeartbeats 400000
+
+namespace ETranscendentalOQ02
+
+-- ============================================================
+-- PART I: DEFINITIONS
+-- ============================================================
+
+/-- The n-th base-b digit of x (0-indexed, counts from the integer part). -/
+noncomputable def nthDigit (b : ℕ) (n : ℕ) (x : ℝ) : ℤ :=
+  ⌊(b : ℝ) ^ n * x⌋ % (b : ℤ)
+
+/-- x is normal in base b: every k-string of base-b digits appears with frequency 1/bᵏ. -/
+def IsNormalInBase (b : ℕ) (x : ℝ) : Prop :=
+  ∀ k : ℕ, ∀ s : Fin k → Fin b,
+    Tendsto
+      (fun N : ℕ =>
+        (((Finset.range N).filter
+          (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ) /
+        (N : ℝ))
+      atTop (nhds ((b : ℝ) ^ (-(k : ℤ))))
+
+/-- A number is absolutely normal if it is normal in every base ≥ 2. -/
+def IsAbsolutelyNormal (x : ℝ) : Prop :=
+  ∀ b : ℕ, 2 ≤ b → IsNormalInBase b x
+
+-- ============================================================
+-- PART II: KNOWN PROPERTIES OF e
+-- ============================================================
+
+/-- e is irrational (Euler, 1737 — proved via transcendence). -/
+theorem e_irrational : Irrational (Real.exp 1) :=
+  ETranscendental.e_irrational
+
+/-- e is transcendental over ℤ (Hermite, 1873). -/
+theorem e_transcendental : Transcendental ℤ (Real.exp 1) :=
+  ETranscendental.e_transcendental
+
+/-- Tight bounds on e from Mathlib. -/
+theorem e_bounds : 2.718281828 < Real.exp 1 ∧ Real.exp 1 < 2.7182818286 :=
+  ⟨by linarith [Real.exp_one_gt_d9], Real.exp_one_lt_d9⟩
+
+/-- The integer part of e is 2. -/
+theorem e_floor : ⌊Real.exp 1⌋ = 2 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- e lies strictly between 2 and 3. -/
+theorem e_between_2_3 : (2 : ℝ) < Real.exp 1 ∧ Real.exp 1 < 3 :=
+  ⟨by linarith [Real.exp_one_gt_d9], by linarith [Real.exp_one_lt_d9]⟩
+
+-- ============================================================
+-- PART III: DECIMAL DIGIT LEMMAS
+-- Digits of e = 2.71828182845... proved from Mathlib bounds.
+-- nthDecDigit n = ⌊10ⁿ · e⌋ % 10, giving digit at position n after decimal.
+-- ============================================================
+
+/-- ⌊10 · e⌋ = 27, so the first decimal digit of e is 7. -/
+theorem e_floor_10 : ⌊(10 : ℝ) * Real.exp 1⌋ = 27 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The first decimal digit of e is 7. -/
+theorem e_digit1 : (⌊(10 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 7 := by
+  rw [e_floor_10]; decide
+
+/-- ⌊100 · e⌋ = 271, so the second decimal digit of e is 1. -/
+theorem e_floor_100 : ⌊(100 : ℝ) * Real.exp 1⌋ = 271 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The second decimal digit of e is 1. -/
+theorem e_digit2 : (⌊(100 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 1 := by
+  rw [e_floor_100]; decide
+
+/-- ⌊1000 · e⌋ = 2718, so the third decimal digit of e is 8. -/
+theorem e_floor_1000 : ⌊(1000 : ℝ) * Real.exp 1⌋ = 2718 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The third decimal digit of e is 8. -/
+theorem e_digit3 : (⌊(1000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 8 := by
+  rw [e_floor_1000]; decide
+
+/-- ⌊10000 · e⌋ = 27182, so the fourth decimal digit of e is 2. -/
+theorem e_floor_10000 : ⌊(10000 : ℝ) * Real.exp 1⌋ = 27182 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The fourth decimal digit of e is 2. -/
+theorem e_digit4 : (⌊(10000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 2 := by
+  rw [e_floor_10000]; decide
+
+/-- ⌊100000 · e⌋ = 271828, so the fifth decimal digit of e is 8. -/
+theorem e_floor_100000 : ⌊(100000 : ℝ) * Real.exp 1⌋ = 271828 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The fifth decimal digit of e is 8. -/
+theorem e_digit5 : (⌊(100000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 8 := by
+  rw [e_floor_100000]; decide
+
+/-- ⌊1000000 · e⌋ = 2718281, so the sixth decimal digit of e is 1. -/
+theorem e_floor_1000000 : ⌊(1000000 : ℝ) * Real.exp 1⌋ = 2718281 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The sixth decimal digit of e is 1. -/
+theorem e_digit6 : (⌊(1000000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 1 := by
+  rw [e_floor_1000000]; decide
+
+-- ============================================================
+-- PART IV: NORMAL IMPLIES IRRATIONAL
+-- ============================================================
+
+/-- **Axiom**: Rational numbers have eventually periodic base-b expansions.
+    Proof sketch: if x = p/q, then bⁿ·(p/q) mod 1 = (bⁿ·p mod q)/q, and
+    bⁿ mod q is periodic (pigeonhole on {0,...,q-1}).
+    The period T divides φ(q) ≤ q. -/
+axiom rational_digits_eventually_periodic (b : ℕ) (hb : 2 ≤ b) (q : ℚ) :
+    ∃ (T : ℕ) (N₀ : ℕ), 0 < T ∧ ∀ n ≥ N₀, nthDigit b (n + T) q = nthDigit b n q
+
+/-- In a sequence with period T, at most T distinct k-tuples appear after the period starts.
+    If bᵏ > T, some k-tuple never appears.
+    Proof sketch: the orbit map n ↦ (f(n),...,f(n+k-1)) is periodic with period T on ℕ≥N₀,
+    so its image has cardinality ≤ T. But |Fin k → Fin b| = bᵏ > T, so some tuple is absent. -/
+axiom periodic_has_missing_ktuple (b T k : ℕ) (hb : 2 ≤ b) (hT : 0 < T)
+    (hk : T < b ^ k) (f : ℕ → Fin b) (N₀ : ℕ)
+    (hperiod : ∀ n ≥ N₀, f (n + T) = f n) :
+    ∃ s : Fin k → Fin b, ∀ n ≥ N₀, ∃ i : Fin k, f (n + i.val) ≠ s i
+
+/-- Normal numbers must be irrational.
+    Proof: if x = p/q is rational, its expansion has period T ≤ q (by rational_digits_eventually_periodic).
+    Choose k with bᵏ > T (exists since b ≥ 2). By periodic_has_missing_ktuple, some k-string s₀
+    never appears in the expansion after position N₀, so its count is bounded by N₀.
+    Hence count(s₀, N)/N → 0 as N → ∞. But normality requires count(s₀, N)/N → 1/bᵏ > 0.
+    Contradiction (the Tendsto codings need cast between Fin b and ℤ-valued nthDigit). -/
+axiom normal_imp_irrational (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) : Irrational x
+
+-- ============================================================
+-- PART V: OPEN QUESTION
+-- ============================================================
+
+/-- **Open Question (2026)**: Is e absolutely normal?
+    Computational evidence (first 5 × 10¹³ digits) is consistent with normality,
+    but no proof exists for any base. -/
+axiom e_absolutely_normal : IsAbsolutelyNormal (Real.exp 1)
+
+/-- e is normal in base 10 (consequence of absolute normality axiom). -/
+theorem e_normal_base_10 : IsNormalInBase 10 (Real.exp 1) :=
+  e_absolutely_normal 10 (by norm_num)
+
+/-- e is normal in base 2 (binary — consequence of absolute normality axiom). -/
+theorem e_normal_binary : IsNormalInBase 2 (Real.exp 1) :=
+  e_absolutely_normal 2 le_rfl
+
+/-- If e is normal in base 10, every decimal digit 0–9 appears with
+    asymptotic frequency 1/10 in e's decimal expansion. -/
+theorem e_normal_implies_uniform_decimal_digits
+    (hn : IsNormalInBase 10 (Real.exp 1)) (d : Fin 10) :
+    Tendsto
+      (fun N : ℕ =>
+        (((Finset.range N).filter
+          (fun n => nthDigit 10 n (Real.exp 1) = (d : ℤ))).card : ℝ) / N)
+      atTop (nhds (1 / 10)) := by
+  have h := hn 1 (fun _ => d)
+  simp [nthDigit] at h ⊢
+  convert h using 2
+  · congr 1; ext N; congr 1; ext n; simp
+  · norm_num
+
+/-- e is irrational — a necessary condition for normality (not sufficient). -/
+theorem e_irrational_necessary_for_normality : Irrational (Real.exp 1) :=
+  e_irrational
+
+end ETranscendentalOQ02

--- a/src/data/proofs/e-transcendental-oq-02/annotations.json
+++ b/src/data/proofs/e-transcendental-oq-02/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-oq02-overview",
+    "proofId": "e-transcendental-oq-02",
+    "range": {
+      "startLine": 11,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "Normal Numbers: Definition, History, and Why e's Status Is Open",
+    "content": "A real number x is normal in base b if every finite string of base-b digits appears with the expected asymptotic frequency: k-digit strings appear with frequency 1/bᵏ. Absolute normality means normality in every base b ≥ 2. Borel (1909) proved that Lebesgue-almost-every real is absolutely normal — a measure-theoretic result showing normality is the 'generic' property. Yet despite this, no specific mathematical constant has ever been proved normal in any base. The problem for e is compounded by its very structured nature: unlike a random number, e arises from a specific mathematical definition (e = Σ 1/n!) and has a highly patterned continued fraction. The 'almost all' proof is existential — it cannot be adapted to prove any particular number is normal.",
+    "mathContext": "Normal in base $b$: $\\forall k \\geq 1, \\forall s \\in \\{0,\\ldots,b-1\\}^k$: $\\lim_{N\\to\\infty} \\frac{|\\{n < N : (d_n,\\ldots,d_{n+k-1}) = s\\}|}{N} = b^{-k}$. Borel (1909): $\\lambda(\\{x \\in [0,1] : x \\text{ not absolutely normal}\\}) = 0$. Status of $e$: computationally consistent with normality for $5 \\times 10^{13}$ digits; mathematically unresolved.",
+    "significance": "key",
+    "relatedConcepts": ["normal numbers", "Borel 1909", "absolutely normal", "digit frequency", "e"]
+  },
+  {
+    "id": "ann-oq02-nthdigit",
+    "proofId": "e-transcendental-oq-02",
+    "range": {
+      "startLine": 62,
+      "endLine": 63
+    },
+    "type": "technique",
+    "title": "nthDigit Definition: ⌊bⁿ·x⌋ % b",
+    "content": "The n-th base-b digit is defined as `⌊bⁿ·x⌋ % b`. This is an integer-valued definition: bⁿ·x scales x so that the integer part captures the first n+1 digits in base b, and the floor-then-mod operation extracts just the n-th digit. For example, with b=10 and x=e≈2.71828...: nthDigit 10 0 e = ⌊e⌋ % 10 = 2 % 10 = 2 (integer part); nthDigit 10 1 e = ⌊10e⌋ % 10 = 27 % 10 = 7 (first decimal digit). Using ℤ (rather than ℕ) avoids subtraction issues and works for negative reals.",
+    "mathContext": "`nthDigit b n x = ⌊b^n \\cdot x⌋ \\bmod b \\in \\mathbb{Z}`. For $x \\geq 0$: the sequence $(\\text{nthDigit}\\,b\\,n\\,x)_{n \\geq 0}$ gives the base-$b$ expansion. For $n=0$: integer part digit. For $n \\geq 1$: fractional part digits. The $\\bmod$ ensures the result is in $\\{0,\\ldots,b-1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["digit extraction", "floor function", "base-b expansion"]
+  },
+  {
+    "id": "ann-oq02-isnormalinbase",
+    "proofId": "e-transcendental-oq-02",
+    "range": {
+      "startLine": 66,
+      "endLine": 74
+    },
+    "type": "technique",
+    "title": "IsNormalInBase: Tendsto Formalization of Digit Frequency",
+    "content": "The definition of normality uses Lean 4's Filter.Tendsto to express limiting frequency. For each k and each k-string s : Fin k → Fin b, we require that the proportion of starting positions n < N where the k consecutive digits match s converges to 1/bᵏ. The Finset.filter operation counts positions where ALL k digits match simultaneously. Note the Fin b type for string characters (automatically bounded in {0,...,b-1}) vs the ℤ return type of nthDigit — the filter condition casts (s i : ℤ) for comparison. The limit target 1/bᵏ is expressed as (b : ℝ) ^ (-(k : ℤ)), using integer exponents to handle the negative power cleanly.",
+    "mathContext": "`IsNormalInBase b x`: $\\forall k, s: (\\text{Fin}\\,k \\to \\text{Fin}\\,b)$, $\\text{Tendsto}\\left(N \\mapsto \\frac{|\\{n < N : \\forall i, d_{n+i} = s(i)\\}|}{N}\\right) \\text{atTop}\\; (\\mathcal{N}(b^{-k}))$. Uses `(b : ℝ) ^ (-(k : ℤ))` for $b^{-k}$.",
+    "significance": "key",
+    "relatedConcepts": ["Tendsto", "Filter.atTop", "digit frequency", "Finset.filter"]
+  },
+  {
+    "id": "ann-oq02-e-digits",
+    "proofId": "e-transcendental-oq-02",
+    "range": {
+      "startLine": 106,
+      "endLine": 170
+    },
+    "type": "technique",
+    "title": "Machine-Verified Decimal Digits of e via Tight Mathlib Bounds",
+    "content": "A uniform pattern proves each decimal digit of e. The two Mathlib lemmas `Real.exp_one_gt_d9 : 2.718281828 < exp 1` and `Real.exp_one_lt_d9 : exp 1 < 2.7182818286` provide a 9-digit window. For each digit position, we show ⌊10ⁿ·e⌋ = k by proving k ≤ 10ⁿ·e < k+1 via linarith from the bounds. The digit itself is then k % 10, proved by `decide` after rewriting with the floor theorem. All 6 digits 7,1,8,2,8,1 are individually machine-checked. This approach generalizes: with tighter Mathlib bounds, more digits could be proved the same way.",
+    "mathContext": "Pattern: `Int.floor_eq_iff.mpr ⟨by push_cast; linarith [exp_one_gt_d9], by push_cast; linarith [exp_one_lt_d9]⟩` proves $\\lfloor 10^n e \\rfloor = k$ when $10^n \\cdot 2.718281828 \\leq k$ and $k + 1 > 10^n \\cdot 2.7182818286$. For $n=6$: $2718281.828 < 10^6 e < 2718281.86$, so $\\lfloor 10^6 e \\rfloor = 2718281$ and digit $= 1$.",
+    "significance": "key",
+    "relatedConcepts": ["exp_one_gt_d9", "exp_one_lt_d9", "Int.floor_eq_iff", "linarith", "decide"]
+  },
+  {
+    "id": "ann-oq02-rational-periodic",
+    "proofId": "e-transcendental-oq-02",
+    "range": {
+      "startLine": 175,
+      "endLine": 181
+    },
+    "type": "concept",
+    "title": "Why Rational Numbers Have Periodic Expansions",
+    "content": "The axiom `rational_digits_eventually_periodic` captures a classical number-theoretic fact: if x = p/q, then ⌊bⁿ·p/q⌋ % b depends only on bⁿ mod q (by the division algorithm). Since there are only q residues, the sequence bⁿ mod q is eventually periodic by pigeonhole, with period dividing φ(q) ≤ q. This is why all long division representations of fractions eventually repeat. The axiom is stated for the ℤ-valued nthDigit function with ℚ input (not ℝ), allowing the period argument to work over the integers.",
+    "mathContext": "For $x = p/q \\in \\mathbb{Q}$: $\\lfloor b^n \\cdot (p/q) \\rfloor \\bmod b = f(b^n \\bmod q)$ for some function $f$. By pigeonhole on $\\{0,\\ldots,q-1\\}$, the sequence $b^n \\bmod q$ repeats with period $T$ dividing $\\text{ord}_q(b)$ which divides $\\varphi(q) \\leq q$.",
+    "significance": "supporting",
+    "relatedConcepts": ["eventually periodic", "pigeonhole principle", "rational numbers", "period"]
+  },
+  {
+    "id": "ann-oq02-normal-irrational",
+    "proofId": "e-transcendental-oq-02",
+    "range": {
+      "startLine": 191,
+      "endLine": 198
+    },
+    "type": "concept",
+    "title": "Normal Implies Irrational: Proof Sketch",
+    "content": "The theorem `normal_imp_irrational` is a classical result: every normal number is irrational. The proof idea: if x = p/q is rational, its base-b expansion has period T ≤ q (rational_digits_eventually_periodic). For any k with bᵏ > T, the orbit map n ↦ (digit_n, ..., digit_{n+k-1}) is T-periodic, so its image has at most T distinct k-tuples. Since there are bᵏ > T possible k-tuples, some string s₀ is never seen after position N₀. The count of s₀ in [0,N) is bounded by N₀, so count/N → 0. But normality requires count/N → 1/bᵏ > 0 — a contradiction. The axiomatization is needed because connecting the ℤ-valued nthDigit definition to the Fin b setting in the Tendsto framework requires careful casting.",
+    "mathContext": "If $x = p/q$ and expansion has period $T$, then for $k$ with $b^k > T$: the image $\\{(d_n,\\ldots,d_{n+k-1}) : n \\geq N_0\\}$ has cardinality $\\leq T < b^k$. Some $s_0$ never appears: $|\\{n < N : \\text{matches}\\}| \\leq N_0$ for all $N$. So frequency $\\to 0 \\neq b^{-k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["normality", "irrationality", "periodic expansion", "orbit cardinality"]
+  },
+  {
+    "id": "ann-oq02-uniform-digits",
+    "proofId": "e-transcendental-oq-02",
+    "range": {
+      "startLine": 219,
+      "endLine": 231
+    },
+    "type": "technique",
+    "title": "Consequence of Normality: Uniform Decimal Digit Distribution",
+    "content": "The theorem `e_normal_implies_uniform_decimal_digits` shows that if e is normal in base 10, then each digit 0-9 appears with frequency exactly 1/10. This follows immediately from the k=1 case of IsNormalInBase 10: for each d : Fin 10, the frequency of single-digit strings (d) tends to 10⁻¹ = 1/10. The proof extracts this from the normality hypothesis via `simp`, a `congr` to align the filter condition, and `norm_num` for 1/10 = (10 : ℝ)^(-(1 : ℤ)). This demonstrates the gallery's approach: conditional theorems assuming the open axiom, showing what would follow.",
+    "mathContext": "From `IsNormalInBase 10 e` with $k=1$, $s = (d)$: $\\lim_{N\\to\\infty} \\frac{|\\{n < N : \\text{nthDigit}\\,10\\,n\\,e = d\\}|}{N} = 10^{-1} = 1/10$.",
+    "significance": "supporting",
+    "relatedConcepts": ["uniform distribution", "decimal digits", "Tendsto", "normality consequence"]
+  }
+]

--- a/src/data/proofs/e-transcendental-oq-02/index.ts
+++ b/src/data/proofs/e-transcendental-oq-02/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/ETranscendentalOQ02.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -1,0 +1,219 @@
+{
+  "id": "e-transcendental-oq-02",
+  "title": "Is e a Normal Number? (Open Question)",
+  "slug": "e-transcendental-oq-02",
+  "description": "Is Euler's number e = 2.71828182845904523536... normal in every base? A number is normal if every finite digit string appears with the expected limiting frequency. Despite extensive computation (5 × 10¹³ decimal digits with no anomalies), no proof of normality for e — or any other specific constant — exists in any base.",
+  "meta": {
+    "author": "Borel (1909 for almost-all normality); open for e",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Normal_number",
+    "date": "1909",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/ETranscendentalOQ02.lean",
+    "tags": [
+      "number-theory",
+      "normal-numbers",
+      "open-problem",
+      "e",
+      "digit-distribution",
+      "analysis",
+      "research",
+      "borel",
+      "transcendental"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "theoremCount": 21,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.exp_one_gt_d9",
+        "description": "e > 2.718281828 — 9-decimal lower bound on Euler's number",
+        "module": "Mathlib.Data.Complex.ExponentialBounds"
+      },
+      {
+        "theorem": "Real.exp_one_lt_d9",
+        "description": "e < 2.7182818286 — 10-decimal upper bound on Euler's number",
+        "module": "Mathlib.Data.Complex.ExponentialBounds"
+      },
+      {
+        "theorem": "Int.floor_eq_iff",
+        "description": "⌊x⌋ = n ↔ n ≤ x < n+1 — characterizes the floor function",
+        "module": "Mathlib.Topology.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Filter.Tendsto",
+        "description": "Limit definition for sequences and filters — used to define digit frequency convergence",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "Transcendental",
+        "description": "Definition: x is transcendental over R if no nonzero polynomial over R has x as root",
+        "module": "Mathlib.RingTheory.Algebraic.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Definition nthDigit: the n-th base-b digit of x as ⌊bⁿ·x⌋ % b (integer-valued, 0-indexed)",
+      "Definition IsNormalInBase: rigorous digit-frequency definition — every k-string appears with frequency 1/bᵏ in the Tendsto sense",
+      "Definition IsAbsolutelyNormal: normal in every base b ≥ 2",
+      "Theorem e_floor: ⌊e⌋ = 2 (proved from Mathlib 9-digit bounds via Int.floor_eq_iff)",
+      "Theorems e_floor_10 through e_floor_1000000: ⌊10ⁿ·e⌋ for n=1..6, giving digits 7,1,8,2,8,1 (all proved by linarith from exp_one bounds + Int.floor_eq_iff)",
+      "Theorems e_digit1..e_digit6: the first 6 decimal digits of e = 2.718281... proved machine-checkably",
+      "Theorem e_normal_implies_uniform_decimal_digits: IsNormalInBase 10 e → each digit d appears with frequency 1/10 (proved from definition using filter and norm_num)",
+      "Axiom rational_digits_eventually_periodic: rationals have eventually periodic base-b expansions (pigeonhole, period divides φ(q))",
+      "Axiom periodic_has_missing_ktuple: periodic sequences with period T have missing k-tuples when bᵏ > T (orbit cardinality argument)",
+      "Axiom normal_imp_irrational: normality in any base implies irrationality (uses the two combinatorial axioms)",
+      "Axiom e_absolutely_normal: e is absolutely normal — the main open conjecture (2026)"
+    ],
+    "dateAdded": "2026-05-04",
+    "axiomCount": 4,
+    "lineCount": 235,
+    "assumptions": "4 axioms: (1) rational_digits_eventually_periodic — rationals have eventually periodic base-b digit expansions (pigeonhole principle, period T | φ(q)); (2) periodic_has_missing_ktuple — a T-periodic sequence on Fin b has at most T distinct k-tuples, so some k-tuple is absent when bᵏ > T; (3) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (uses axioms 1-2 + Tendsto formalism); (4) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "In 1909, Émile Borel introduced the concept of a **normal number** and proved that almost every real number (in the sense of Lebesgue measure) is absolutely normal. His theorem is a remarkable fact: though normality is the 'generic' property, proving any specific constant is normal has proved extraordinarily difficult.\n\nFor Euler's constant e = 2.71828182845904523536..., we know:\n- e is irrational (Euler, 1737) — proved via continued fractions and factorial series\n- e is transcendental (Hermite, 1873) — not a root of any polynomial with integer coefficients\n- e has a regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, 1, 1, 8, ...] with a transparent pattern\n- The first 5 × 10¹³ decimal digits of e have been computed; statistical tests detect no anomalies\n\nYet despite all this, we cannot prove e is normal in base 10, base 2, or ANY base. Indeed, no specific real number has ever been proved normal. Borel's theorem proves normality is generic without identifying a single example.\n\nThe irrationality measure of e is exactly 2 (the minimum possible for any irrational) — see e-transcendental-oq-03. This excellent rational approximability property comes from the predictable continued fraction, but paradoxically does not help prove normality.",
+    "problemStatement": "**Open Question (e-transcendental-oq-02)**: Is Euler's number e absolutely normal?\n\nA real number x is **normal in base b** if for every k ≥ 1 and every string s ∈ {0,...,b-1}ᵏ:\n  lim_{N→∞} |{n < N : digits n, n+1, ..., n+k-1 of x in base b equal s}| / N = 1/bᵏ\n\nA number is **absolutely normal** if it is normal in every base b ≥ 2.\n\n**What IS known** (proved in this entry):\n- e is irrational ✓ (Euler, 1737)\n- e is transcendental ✓ (Hermite, 1873)\n- First 6 decimal digits of e: 2.718281... ✓ (proved from Mathlib's exp bounds)\n- Normal numbers must be irrational ✓ (necessary condition, axiomatized proof sketch)\n- Almost all reals are normal ✓ (Borel 1909 — not formalized here)\n\n**Open** (unknown as of 2026):\n- Is e normal in base 10? (?)\n- Is e normal in base 2? (?)\n- Is e absolutely normal? (? — axiomatized here)\n- Is ANY specific constant normal? (? — none proved ever)",
+    "text": "Is Euler's number e = 2.71828... normal in every base? A number is normal if every finite digit string appears with the expected limiting frequency. Despite extensive computation (5 × 10¹³ decimal digits with no anomalies), no proof of normality for e — or any other specific constant — exists in any base.",
+    "proofStrategy": "This entry formalizes the known framework and open status:\n\n**1. Rigorous definitions** (fully proved):\nWe define `nthDigit b n x = ⌊bⁿ·x⌋ % b` (the n-th base-b digit, 0-indexed), `IsNormalInBase b x` (digit frequency definition using Tendsto), and `IsAbsolutelyNormal x`.\n\n**2. Known facts about e** (proved from Mathlib's 9-digit bounds):\nUsing `Real.exp_one_gt_d9 : 2.718281828 < e` and `Real.exp_one_lt_d9 : e < 2.7182818286`, we prove ⌊10ⁿ·e⌋ for n = 0,...,6, extracting the first 6 decimal digits: **2.718281...**\n\n**3. Normal implies irrational** (axiomatized):\nA normal number must be irrational: if x = p/q is rational, its base-b expansion has period T ≤ q. For large k with bᵏ > T, some k-string never appears, contradicting normality. This is a known theorem but its Lean formalization requires connecting ℤ-valued digit functions to Fin b sequences in the Tendsto setting — axiomatized with a complete proof sketch.\n\n**4. The open question** (axiomatized):\nThe main conjecture `e_absolutely_normal : IsAbsolutelyNormal (Real.exp 1)` is axiomatized, reflecting that this is a genuine open problem (2026).",
+    "keyInsights": [
+      "Normal numbers are defined by limiting frequencies, not by any finite computation — checking trillions of digits cannot prove normality",
+      "Borel's 1909 theorem: almost all reals are absolutely normal, yet no specific constant has ever been proved normal in any base",
+      "The first 6 decimal digits 2.718281... are proved machine-checkably from Mathlib's tight bounds exp_one_gt_d9 and exp_one_lt_d9",
+      "Normality implies irrationality: if x = p/q, its base-b expansion is eventually periodic with period T | φ(q). For k with bᵏ > T, some k-string never appears — contradicting normality",
+      "e's regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, ...] shows excellent rational approximability (irrationality measure exactly 2), but this structural regularity has not helped prove normality",
+      "The transcendence of e does not imply normality — transcendental Liouville numbers are far from normal",
+      "Computational evidence (first 5×10¹³ digits pass χ² and correlation tests) is necessary but not sufficient — we need a mathematical proof"
+    ],
+    "prerequisites": [
+      "Real analysis (limits, sequences)",
+      "Number theory (rational approximation)",
+      "Digit expansions and continued fractions"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Context",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Overview of normal numbers (Borel 1909), what is known about e's digit distribution, and the open question of e's normality.",
+      "mathContext": "**Normal number**: $x$ is normal in base $b$ if for every $k \\geq 1$ and every $s \\in \\{0,\\ldots,b-1\\}^k$: $\\lim_{N \\to \\infty} \\frac{|\\{n < N : (d_n,\\ldots,d_{n+k-1}) = s\\}|}{N} = \\frac{1}{b^k}$. Borel (1909): Lebesgue-a.e. $x$ is absolutely normal."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions: Normal Numbers",
+      "startLine": 57,
+      "endLine": 78,
+      "summary": "Three definitions: nthDigit (the n-th base-b digit as ⌊bⁿ·x⌋ % b), IsNormalInBase (Tendsto digit frequency condition), IsAbsolutelyNormal (normal in all bases ≥ 2).",
+      "mathContext": "`nthDigit b n x = ⌊b^n · x⌋ % b ∈ ℤ`. `IsNormalInBase b x`: for all $k$ and $s : \\text{Fin}\\,k \\to \\text{Fin}\\,b$, frequency of $s$ in base-$b$ expansion tends to $b^{-k}$."
+    },
+    {
+      "id": "known-properties",
+      "title": "Known Properties of e",
+      "startLine": 80,
+      "endLine": 104,
+      "summary": "e is irrational (from ETranscendental), transcendental (from ETranscendental), lies in (2.718281828, 2.7182818286) from Mathlib bounds, and between 2 and 3.",
+      "mathContext": "$e > 2.718281828$ (`exp_one_gt_d9`) and $e < 2.7182818286$ (`exp_one_lt_d9`). These 9-digit Mathlib bounds suffice to pin down the first 6 decimal digits."
+    },
+    {
+      "id": "digit-lemmas",
+      "title": "Decimal Digits 1–6 of e",
+      "startLine": 106,
+      "endLine": 170,
+      "summary": "Machine-checked proofs that e = 2.718281...: ⌊10ⁿ·e⌋ computed for n = 1..6, digits 7,1,8,2,8,1 extracted via floor arithmetic. All proved from exp_one_gt_d9 + exp_one_lt_d9 + Int.floor_eq_iff.",
+      "mathContext": "Pattern: $\\lfloor 10^n \\cdot e \\rfloor = \\lfloor 10^n \\cdot 2.718281...\\rfloor$ pinned between $10^n \\cdot 2.718281828$ and $10^n \\cdot 2.7182818286$. For $n=3$: $2718 < 10^3 e < 2718.2819$, so $\\lfloor 1000e \\rfloor = 2718$ and digit $= 8$."
+    },
+    {
+      "id": "normal-irrational",
+      "title": "Normal Implies Irrational (Axiomatized)",
+      "startLine": 172,
+      "endLine": 199,
+      "summary": "Three axioms formalizing the proof that normality implies irrationality: (1) rationals have eventually periodic digit expansions, (2) T-periodic sequences have missing k-tuples when bᵏ > T, (3) the full theorem. Proof sketches provided in docstrings.",
+      "mathContext": "If $x = p/q \\in \\mathbb{Q}$, the sequence $n \\mapsto \\lfloor b^n x \\rfloor \\bmod b$ is eventually periodic with period $T \\mid \\varphi(q) \\leq q$. For $k$ with $b^k > T$, the orbit has $\\leq T < b^k$ distinct $k$-tuples, so some string $s_0$ never appears after position $N_0$. Its density is $0 \\neq b^{-k}$."
+    },
+    {
+      "id": "open-question",
+      "title": "The Open Question: e is Absolutely Normal",
+      "startLine": 200,
+      "endLine": 235,
+      "summary": "Axiom e_absolutely_normal (the main open conjecture). Consequences: e is normal in base 10, in base 2. Theorem: normality implies uniform decimal digit distribution (each digit 0–9 appears with frequency 1/10).",
+      "mathContext": "**Open conjecture** (axiomatized): $e$ is absolutely normal — normal in every base $b \\geq 2$. Computational check: first $5 \\times 10^{13}$ decimal digits pass $\\chi^2$ and serial correlation tests. No proof exists for any specific constant."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes the open question of whether e is a normal number. The definitions (nthDigit, IsNormalInBase, IsAbsolutelyNormal) are fully proved. The first 6 decimal digits of e (= 2.718281...) are machine-verified from Mathlib's tight exp bounds. The main conjecture e_absolutely_normal is axiomatized, reflecting genuine open status as of 2026.",
+    "implications": "**Theoretical significance**: Proving e is normal in even one base would be a landmark result in analytic number theory. No specific real number has ever been proved normal — Borel's theorem guarantees normality 'almost everywhere' but provides no examples.\n\n**Connection to continued fractions**: e's regular CF [2; 1, 2, 1, 1, 4, 1, 1, 6, ...] (partial quotients growing linearly) is a distinctive structural feature absent from random numbers. Understanding whether this structure influences digit distribution is a key open question.\n\n**Computational evidence**: The distribution of digits in the first 5×10¹³ decimals matches the uniform distribution with no statistically significant deviations. But computational evidence can never constitute proof — finitely many digits cannot demonstrate asymptotic frequency.\n\n**Related open questions**: The normality of π, √2, log 2, and other classical constants is similarly open. Even weaker questions (Are all digits 0–9 infinitely often in e's decimal expansion? Is any specific digit eventually missing?) remain unresolved.",
+    "openQuestions": [
+      "Is e normal in base 10?",
+      "Is e normal in base 2 (binary)?",
+      "Is e absolutely normal (the main conjecture axiomatized here)?",
+      "Does every decimal digit 0–9 appear infinitely often in e's decimal expansion? (Weaker — also open)",
+      "Is π normal in any base?",
+      "Can the formal proof of normal_imp_irrational be completed in Lean 4 (eliminating the axiom)?",
+      "Does e's regular continued fraction structure imply anything about its normality?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Algebraic.Basic",
+      "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
+      "Mathlib.Data.Complex.ExponentialBounds",
+      "Mathlib.Data.Real.Irrational",
+      "Mathlib.Topology.Algebra.Order.Floor",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Tactic",
+      "Proofs.eTranscendental"
+    ],
+    "opens": [
+      "Real",
+      "Filter"
+    ],
+    "namespace": "ETranscendentalOQ02",
+    "lineCount": 235,
+    "axiomCount": 4,
+    "theoremCount": 21,
+    "definitionCount": 3,
+    "path": "Proofs/ETranscendentalOQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "e-transcendental",
+      "relationship": "extends",
+      "description": "Extends the base e-transcendental formalization; imports e_irrational and e_transcendental from ETranscendental"
+    },
+    {
+      "targetId": "e-transcendental-oq-03",
+      "relationship": "related",
+      "description": "The irrationality measure of e is exactly 2 (minimum possible); this excellent approximability comes from the regular CF, but does not imply normality"
+    },
+    {
+      "targetId": "e-transcendental-oq-01",
+      "relationship": "related",
+      "description": "Open question about transcendence of e+π — another instance where we know much about e but cannot resolve a basic question about its arithmetic nature"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Émile Borel",
+      "title": "Les probabilités dénombrables et leurs applications arithmétiques",
+      "year": "1909",
+      "venue": "Rendiconti del Circolo Matematico di Palermo",
+      "note": "Introduced normal numbers and proved almost all reals are absolutely normal (measure-theoretic argument)"
+    },
+    {
+      "authors": "David Bailey and Richard Crandall",
+      "title": "On the Random Character of Fundamental Constant Expansions",
+      "year": "2001",
+      "venue": "Experimental Mathematics",
+      "note": "Survey of computational evidence for normality of e, π, log 2; proposes 'hot spot' conjecture linking digit distribution to chaotic dynamics"
+    },
+    {
+      "authors": "Alexander Yee",
+      "title": "e - 5 Trillion Digits",
+      "year": "2021",
+      "venue": "numberworld.org",
+      "note": "Computation of 5×10¹³ decimal digits of e; statistical analysis consistent with normality"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

Commits the untracked `e-transcendental-oq-02` gallery files to main and corrects a `lineCount` discrepancy.

## Evidence

**Before**: Files existed on disk but were untracked (`git status` showed `??`). meta.json had `lineCount: 237` but actual file has 235 lines.

**After**:
- `proofs/Proofs/ETranscendentalOQ02.lean` committed (235 lines, 0 sorries, 4 axioms, 21 theorems)
- `src/data/proofs/e-transcendental-oq-02/` committed (meta.json, annotations.json, index.ts)
- `proofs/Proofs.lean` updated to register `ETranscendentalOQ02` module
- `lineCount` corrected: 237 → 235 in both `meta.lineCount` and `leanFile.lineCount`
- `sections.open-question.endLine` corrected: 237 → 235

Note: An open PR #14961 also introduces these files on `feature/researcher-11`. If #14961 merges first, this PR will conflict and can be closed. If this merges first, #14961 should apply the lineCount fix and rebase.

Closes #15573

---
Automated fix by lean-mechanic agent.