### PR TITLE
feat(cs-localization): sigma-finite Riesz — all sorries eliminated

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -436,11 +436,15 @@ theorem localization_existence
       { measure_univ_lt_top := by
           rw [Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
           exact measure_spanningSets_lt_top μ m }
-    -- Integrability on (μ.restrict Sm) for both sides (needs 1 ≤ q from hpq.symm)
-    have hgm_int : Integrable (g_seq m) (μ.restrict (spanningSets μ m)) := by
-      sorry
-    have hgn_int : Integrable (g_seq n) (μ.restrict (spanningSets μ m)) := by
-      sorry
+    -- Integrability on (μ.restrict Sm) for both sides:
+    -- 1 ≤ q from hpq.symm.one_lt_of_lt hp1 (same pattern as parent at line 885)
+    have hq_ge1 : 1 ≤ q := by linarith [hpq.symm.one_lt_of_lt hp1]
+    have hgm_int : Integrable (g_seq m) (μ.restrict (spanningSets μ m)) :=
+      (hg_seq_mem m).integrable hq_ge1
+    have hgn_small : MemLp (g_seq n) q (μ.restrict (spanningSets μ m)) :=
+      (hg_seq_mem n).mono_measure (Measure.restrict_mono (spanningSets_mono μ hmn) le_rfl)
+    have hgn_int : Integrable (g_seq n) (μ.restrict (spanningSets μ m)) :=
+      hgn_small.integrable hq_ge1
     apply ae_eq_of_forall_setIntegral_eq_of_sigmaFinite
         (fun s _ _ => hgm_int.integrableOn)
         (fun s _ _ => hgn_int.integrableOn)

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -416,14 +416,74 @@ theorem localization_existence
     simp_rw [Set.indicator_apply, Pi.one_apply, ite_mul, one_mul, zero_mul]
     rw [integral_indicator hE, Measure.restrict_restrict hE,
       Set.inter_comm, Set.inter_eq_left.mpr hEn]
-  -- Remaining: consistency + MCT + global g ∈ Lq(μ) + indicator agreement for all E
-  -- HARD SORRY: construct g via a.e. limit of g_seq, prove MemLp g q μ via MCT,
-  -- prove indicator agreement using hagree_n + tendsto_setIntegral_of_monotone
-  -- Key tools:
-  --   ae_eq_restrict_of_forall_setIntegral_eq: for consistency (g_seq m = g_seq n a.e. on Sₘ)
-  --   lintegral_iUnion (+ monotone): for MCT bound ‖g‖_Lq ≤ ‖φ‖
-  --   tendsto_setIntegral_of_monotone: ∫_{E∩Sₙ} g dμ → ∫_E g dμ
-  --   lp_truncation_tendsto_zero (proved): ‖1_{E∩Sₙ} - 1_E‖_Lp → 0, so φ(1_{E∩Sₙ}) → φ(1_E)
+  -- ── Step A1: Norm bound ─────────────────────────────────────────────────────
+  -- HARD sorry: ‖g_seq n‖_{Lq(μ.restrict Sₙ)} ≤ ‖φ‖
+  -- Proof sketch: let φₙ := φ ∘ extByZeroCLM(Sₙ); then ‖φₙ‖ ≤ ‖φ‖.
+  -- riesz_lp_surjective_from_rn gives g_seq n with ‖g_seq n‖_Lq = ‖φₙ‖ ≤ ‖φ‖.
+  -- The equality uses the Hölder extremizer (cf. holder_extremizer_lq_bound in parent).
+  have hgnorm : ∀ n, eLpNorm (g_seq n) q (μ.restrict (spanningSets μ n)) ≤
+      ENNReal.ofReal ‖φ‖ := by
+    intro n
+    sorry
+  -- ── Step A2: Consistency ────────────────────────────────────────────────────
+  -- g_seq m =ᵐ[μ.restrict Sₘ] g_seq n for m ≤ n, via set-integral uniqueness.
+  -- Key: ∫_s gₘ ∂(μ.restrict Sₘ) = ∫_{s∩Sₘ} gₘ ∂μ = φ(1_{s∩Sₘ}) = ∫_{s∩Sₘ} gₙ ∂μ
+  --    = ∫_s gₙ ∂(μ.restrict Sₘ)  [for all measurable s].
+  have hconsist : ∀ m n : ℕ, m ≤ n →
+      g_seq m =ᵐ[μ.restrict (spanningSets μ m)] g_seq n := by
+    intro m n hmn
+    haveI hfin_m : IsFiniteMeasure (μ.restrict (spanningSets μ m)) :=
+      { measure_univ_lt_top := by
+          rw [Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
+          exact measure_spanningSets_lt_top μ m }
+    -- Integrability on (μ.restrict Sm) for both sides (needs 1 ≤ q from hpq.symm)
+    have hgm_int : Integrable (g_seq m) (μ.restrict (spanningSets μ m)) := by
+      sorry
+    have hgn_int : Integrable (g_seq n) (μ.restrict (spanningSets μ m)) := by
+      sorry
+    apply ae_eq_of_forall_setIntegral_eq_of_sigmaFinite
+        (fun s _ _ => hgm_int.integrableOn)
+        (fun s _ _ => hgn_int.integrableOn)
+    intro s hs _
+    -- ∫_s f ∂(μ.restrict Sm) = ∫_{s ∩ Sm} f ∂μ  (Measure.restrict_restrict)
+    have to_mu : ∀ f : α → ℝ,
+        ∫ a in s, f a ∂(μ.restrict (spanningSets μ m)) =
+        ∫ a in s ∩ spanningSets μ m, f a ∂μ := fun f => by
+      rw [show (μ.restrict (spanningSets μ m)).restrict s = μ.restrict (s ∩ spanningSets μ m)
+            from Measure.restrict_restrict (measurableSet_spanningSets μ m)]
+    simp_rw [to_mu]
+    have hfin_int : μ (s ∩ spanningSets μ m) ≠ ⊤ :=
+      ((measure_mono Set.inter_subset_right).trans_lt (measure_spanningSets_lt_top μ m)).ne
+    have hEn_m : s ∩ spanningSets μ m ⊆ spanningSets μ m := Set.inter_subset_right
+    have hEn_n : s ∩ spanningSets μ m ⊆ spanningSets μ n :=
+      hEn_m.trans (spanningSets_mono μ hmn)
+    exact (hagree_n m _ (hs.inter (measurableSet_spanningSets μ m)) hEn_m hfin_int).symm.trans
+          (hagree_n n _ (hs.inter (measurableSet_spanningSets μ m)) hEn_n hfin_int)
+  -- ── Step A3: Construct global g ─────────────────────────────────────────────
+  -- g(a) := g_seq n₀(a) a, where n₀(a) = first n with a ∈ Sₙ.
+  -- By hconsist this is a.e. equal to g_seq n on every Sₙ.
+  have hcover : ∀ a : α, ∃ n, a ∈ spanningSets μ n := fun a => by
+    have := (iUnion_spanningSets μ).symm ▸ mem_univ a
+    exact mem_iUnion.mp this
+  let idx : α → ℕ := fun a => Nat.find (hcover a)
+  let g : α → ℝ := fun a => g_seq (idx a) a
+  -- ── Step A4: MemLp g q μ (via MCT + hgnorm) ─────────────────────────────────
+  -- eLpNorm(g, q, μ)^q = ∫⁻ |g|^q dμ = ⨆_n ∫⁻_{Sₙ} |g|^q dμ [MCT, Sₙ ↑ univ]
+  --                     = ⨆_n ∫⁻_{Sₙ} |g_seq n|^q dμ       [g = g_seq n a.e. on Sₙ]
+  --                     ≤ ⨆_n ‖φ‖^q = ‖φ‖^q                 [by hgnorm]
+  -- AEStronglyMeasurable g: each g_seq n is AEStronglyMeasurable on μ.restrict Sₙ;
+  -- since Sₙ ↑ univ, g is AEStronglyMeasurable on μ.
+  have hg_lq : MemLp g q μ := by
+    sorry
+  -- ── Step A5: Indicator agreement for all E ───────────────────────────────────
+  -- For E with μ(E) < ∞:
+  --   φ(1_E) = lim_n φ(1_{E∩Sₙ})          [by lp_truncation_tendsto_zero + CLM continuity]
+  --          = lim_n ∫_{E∩Sₙ} g dμ         [by hagree_n + g =ᵐ g_seq n on Sₙ]
+  --          = ∫_E g dμ                     [by tendsto_setIntegral_of_monotone + DCT]
+  refine ⟨g, hg_lq, ?_⟩
+  intro E hE hfin
+  -- Use lp_truncation_tendsto_zero for 1_{E\Sₙ} → 0 in Lp,
+  -- then CLM continuity and hagree_n + MCT on the integral side.
   sorry
 
 -- ============================================================================

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -424,7 +424,274 @@ theorem localization_existence
   have hgnorm : ∀ n, eLpNorm (g_seq n) q (μ.restrict (spanningSets μ n)) ≤
       ENNReal.ofReal ‖φ‖ := by
     intro n
-    sorry
+    set μₙ := μ.restrict (spanningSets μ n)
+    set hS := measurableSet_spanningSets μ n
+    set extZ := extByZeroCLM hS hp0 hptop
+    have hg := hg_seq_mem n
+    set g := g_seq n
+    -- Derived constants
+    have hqtop' : q ≠ ⊤ := by
+      intro h; rw [h, ENNReal.toReal_top] at hpq; linarith [hpq.symm.pos]
+    have hq0' : q ≠ 0 := by
+      intro h; rw [h, ENNReal.toReal_zero] at hpq; linarith [hpq.symm.pos]
+    have hq_pos' : 0 < q.toReal := ENNReal.toReal_pos hq0' hqtop'
+    have hp_pos' : 0 < p.toReal := ENNReal.toReal_pos hp0 hptop
+    -- μₙ is finite
+    haveI hfin' : IsFiniteMeasure μₙ :=
+      { measure_univ_lt_top := by
+          simp only [μₙ, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
+          exact measure_spanningSets_lt_top μ n }
+    -- ‖extZ f‖ = ‖f‖ (isometry), hence ‖extZ‖ ≤ 1
+    have hextZ_le : ∀ f : Lp ℝ p μₙ, ‖extZ f‖ ≤ ‖f‖ := fun f => by
+      simp only [extZ, extByZeroCLM, LinearMap.mkContinuous_apply, Lp.norm_def]
+      have hh := memLp_indicator_of_restrict_loc hS hp0 hptop (Lp.memLp f)
+      conv_lhs => rw [eLpNorm_congr_ae hh.coeFn_toLp]
+      rw [eLpNorm_indicator_eq_restrict_loc hS _ hp0 hptop]
+    have hextZ_norm : ‖extZ‖ ≤ 1 :=
+      ContinuousLinearMap.opNorm_le_bound _ zero_le_one (fun f => by
+        rw [one_mul]; exact hextZ_le f)
+    have hphin_le : ‖φ.comp extZ‖ ≤ ‖φ‖ :=
+      (ContinuousLinearMap.opNorm_comp_le _ _).trans
+        (mul_le_of_le_one_right (norm_nonneg _) hextZ_norm)
+    -- hrep: (φ ∘ extZ) f = ∫ f * g ∂μₙ for all f ∈ Lp(μₙ)
+    have hrep : ∀ f : Lp ℝ p μₙ, (φ.comp extZ) f = ∫ a, (f : α → ℝ) a * g a ∂μₙ := by
+      intro f; simp only [ContinuousLinearMap.comp_apply]; exact hg_seq_rep n f
+    -- For each truncation g_k := clamp(g, -k, k), prove ‖g_k‖_q ≤ ‖φ ∘ extZ‖
+    have htrunc : ∀ k : ℕ,
+        eLpNorm (fun a => max (min (g a) (k : ℝ)) (-(k : ℝ))) q μₙ ≤
+        ENNReal.ofReal ‖φ.comp extZ‖ := by
+      intro k
+      set g_k := fun a => max (min (g a) (k : ℝ)) (-(k : ℝ))
+      set h_k := fun a => Real.sign (g_k a) * |g_k a| ^ (q.toReal - 1)
+      -- |g_k a| ≤ k
+      have hgk_bound : ∀ a, |g_k a| ≤ (k : ℝ) := fun a => by
+        simp only [g_k, abs_le]
+        constructor
+        · linarith [le_max_right (min (g a) (k : ℝ)) (-(k : ℝ))]
+        · exact max_le_iff.mpr ⟨min_le_right _ _, neg_le_self (Nat.cast_nonneg k)⟩
+      -- g_k is AEStronglyMeasurable and integrable on μₙ
+      have hgk_asm : AEStronglyMeasurable g_k μₙ :=
+        (hg.1.min measurable_const.aestronglyMeasurable).max
+          measurable_const.aestronglyMeasurable
+      have hgk_int : Integrable g_k μₙ := by
+        rw [← memLp_one_iff_integrable]
+        exact MemLp.of_bound (k : ℝ) hgk_asm
+          (ae_of_all μₙ fun a => by
+            simp only [Real.norm_eq_abs]; exact hgk_bound a)
+      -- h_k is bounded and in Lp
+      have hhk_bound : ∀ᵐ a ∂μₙ, ‖h_k a‖ ≤ (k : ℝ) ^ (q.toReal - 1) :=
+        ae_of_all μₙ fun a => by
+          simp only [h_k, Real.norm_eq_abs, abs_mul]
+          calc |Real.sign (g_k a)| * |g_k a| ^ (q.toReal - 1)
+              ≤ 1 * |g_k a| ^ (q.toReal - 1) :=
+                  mul_le_mul_of_nonneg_right (Real.abs_sign_le_one _) (by positivity)
+            _ = |g_k a| ^ (q.toReal - 1) := one_mul _
+            _ ≤ (k : ℝ) ^ (q.toReal - 1) :=
+                  Real.rpow_le_rpow (abs_nonneg _) (hgk_bound a)
+                    (by linarith [hpq.symm.one_lt_of_lt hp1])
+      have hhk_meas : AEStronglyMeasurable h_k μₙ := by
+        apply AEStronglyMeasurable.mul
+        · exact (Real.measurable_sign.comp_aemeasurable
+              hgk_asm.aemeasurable).aestronglyMeasurable
+        · exact hgk_asm.norm.rpow_const _
+      have hhk_memLp : MemLp h_k p μₙ :=
+        MemLp.of_bound ((k : ℝ) ^ (q.toReal - 1)) hhk_meas hhk_bound
+      -- φₙ(h_k) = ∫ h_k * g ∂μₙ (direct from hrep)
+      have hphi_hk : (φ.comp extZ) (hhk_memLp.toLp h_k) = ∫ a, h_k a * g a ∂μₙ := by
+        rw [hrep (hhk_memLp.toLp h_k)]
+        apply integral_congr_ae
+        filter_upwards [hhk_memLp.coeFn_toLp] with a ha; rw [ha]
+      -- Pointwise: h_k(a) * g_k(a) ≤ h_k(a) * g(a)  (sign agreement)
+      have hpw : ∀ a, h_k a * g_k a ≤ h_k a * g a := fun a => by
+        suffices 0 ≤ h_k a * (g a - g_k a) by linarith [mul_sub (h_k a) (g a) (g_k a)]
+        simp only [h_k, g_k]
+        rcases le_or_gt (g a) (-(k : ℝ)) with h1 | h1
+        · have : max (min (g a) ↑k) (-(↑k : ℝ)) = -(↑k : ℝ) :=
+              max_eq_right (le_trans (min_le_left _ _) h1)
+          rw [this]
+          rcases Nat.eq_zero_or_pos k with rfl | hk
+          · simp
+          · rw [Real.sign_of_neg (neg_lt_zero.mpr (Nat.cast_pos.mpr hk))]
+            exact mul_nonneg_of_nonpos_of_nonpos
+              (mul_neg_of_neg_of_pos (by norm_num) (by positivity)) (by linarith)
+        rcases le_or_gt (k : ℝ) (g a) with h2 | h2
+        · have : max (min (g a) ↑k) (-(↑k : ℝ)) = (↑k : ℝ) :=
+              by rw [min_eq_right h2, max_eq_left (neg_le_self (Nat.cast_nonneg k))]
+          rw [this]
+          rcases Nat.eq_zero_or_pos k with rfl | hk
+          · simp
+          · rw [Real.sign_of_pos (Nat.cast_pos.mpr hk)]
+            exact mul_nonneg (mul_nonneg zero_le_one (by positivity)) (by linarith)
+        · have : max (min (g a) ↑k) (-(↑k : ℝ)) = g a :=
+              by rw [min_eq_left h2.le, max_eq_left (le_of_lt h1)]
+          rw [this, sub_self, mul_zero]
+      -- ∫ h_k * g_k = ‖g_k‖_q^q  (algebraic identity)
+      have hgk_memLq : MemLp g_k q μₙ := by
+        refine ⟨hgk_asm, ?_⟩
+        calc eLpNorm g_k q μₙ
+            ≤ eLpNorm (fun _ => (k : ℝ)) q μₙ := by
+                apply eLpNorm_mono_ae
+                exact ae_of_all μₙ fun a => by
+                  simp [Real.norm_eq_abs]; exact hgk_bound a
+          _ < ⊤ := eLpNorm_const_lt_top hq0' hqtop'
+      have hint_hkgk : ∫ a, h_k a * g_k a ∂μₙ = (eLpNorm g_k q μₙ ^ q.toReal).toReal := by
+        have hpw2 : ∀ a, h_k a * g_k a = |g_k a| ^ q.toReal := fun a => by
+          simp only [h_k]
+          have hsign : Real.sign (g_k a) * g_k a = |g_k a| := by
+            rcases lt_trichotomy (g_k a) 0 with ha | rfl | ha
+            · simp [Real.sign_neg ha, abs_of_neg ha]
+            · simp
+            · simp [Real.sign_pos ha, abs_of_pos ha]
+          rw [show Real.sign (g_k a) * |g_k a| ^ (q.toReal - 1) * g_k a =
+              |g_k a| ^ (q.toReal - 1) * (Real.sign (g_k a) * g_k a) from by ring,
+              hsign, show |g_k a| = |g_k a| ^ (1 : ℝ) from (Real.rpow_one _).symm,
+              ← Real.rpow_add (abs_nonneg _)]
+          norm_num
+        simp_rw [hpw2]
+        have hpw3 : ∀ a, |g_k a| ^ q.toReal =
+            ((‖g_k a‖₊ : ℝ≥0∞) ^ q.toReal).toReal := fun a => by
+          rw [ENNReal.coe_rpow_of_nonneg (le_of_lt hq_pos'), ENNReal.coe_toReal, NNReal.coe_rpow]
+          simp [Real.norm_eq_abs]
+        simp_rw [hpw3]
+        have hf_ne_top : ∀ᵐ a ∂μₙ, (‖g_k a‖₊ : ℝ≥0∞) ^ q.toReal ≠ ⊤ :=
+          ae_of_all μₙ fun a => by
+            rw [ENNReal.coe_rpow_of_nonneg (le_of_lt hq_pos')]; exact ENNReal.coe_ne_top
+        rw [integral_toReal (hgk_asm.enorm.pow_const q.toReal) hf_ne_top]
+        congr 1
+        rw [eLpNorm_eq_lintegral_rpow_enorm hq0' hqtop', ← ENNReal.rpow_mul,
+            one_div, inv_mul_cancel₀ hq_pos'.ne', ENNReal.rpow_one]
+      -- ‖h_k‖_p = ‖g_k‖_q^(q/p)  (norm identity via hpq)
+      have hpq_prod : p.toReal * q.toReal = p.toReal + q.toReal := by
+        have h := hpq.inv_add_inv_eq_one
+        field_simp [hp_pos'.ne', hq_pos'.ne'] at h; linarith
+      have hn_eLpNorm : eLpNorm h_k p μₙ = eLpNorm g_k q μₙ ^ (q.toReal / p.toReal) := by
+        have hpw_real : ∀ a, |h_k a| ^ p.toReal = |g_k a| ^ q.toReal := fun a => by
+          simp only [h_k]
+          rcases eq_or_ne (g_k a) 0 with ha | ha
+          · simp [ha]
+          · have habs_pos : 0 < |g_k a| := abs_pos.mpr ha
+            have hsign1 : |Real.sign (g_k a)| = 1 := by
+              rcases lt_trichotomy (g_k a) 0 with h | h | h
+              · simp [Real.sign_neg h]
+              · exact absurd h ha
+              · simp [Real.sign_pos h]
+            rw [abs_mul, hsign1, one_mul,
+                abs_of_nonneg (Real.rpow_nonneg (abs_nonneg _) _),
+                ← Real.rpow_mul (abs_nonneg _)]
+            congr 1; nlinarith [hpq_prod]
+        have hpw_enn : ∀ a, (‖h_k a‖₊ : ℝ≥0∞) ^ p.toReal =
+            (‖g_k a‖₊ : ℝ≥0∞) ^ q.toReal := fun a => by
+          rw [ENNReal.coe_rpow_of_nonneg (le_of_lt hp_pos'),
+              ENNReal.coe_rpow_of_nonneg (le_of_lt hq_pos')]
+          norm_cast; apply NNReal.coe_injective
+          simp only [NNReal.coe_rpow, NNReal.coe_nnnorm, Real.norm_eq_abs]
+          exact hpw_real a
+        rw [eLpNorm_eq_lintegral_rpow_enorm hp0 hptop,
+            eLpNorm_eq_lintegral_rpow_enorm hq0' hqtop',
+            lintegral_congr (fun a => hpw_enn a), ← ENNReal.rpow_mul]
+        congr 1; field_simp [hp_pos'.ne', hq_pos'.ne']
+      -- Assemble: ‖g_k‖_q^q ≤ ‖φ ∘ extZ‖ * ‖g_k‖_q^(q/p) → ‖g_k‖_q ≤ ‖φ ∘ extZ‖
+      set x := (eLpNorm g_k q μₙ).toReal
+      have hx_nn : 0 ≤ x := ENNReal.toReal_nonneg
+      have hgk_ne_top : eLpNorm g_k q μₙ ≠ ⊤ := hgk_memLq.eLpNorm_lt_top.ne
+      have hqp_eq : q.toReal / p.toReal + 1 = q.toReal := by
+        field_simp [hp_pos'.ne']; linarith [hpq_prod]
+      have hint_hkg_int : Integrable (fun a => h_k a * g_k a) μₙ :=
+        integrable_mul_sf p q hpq (le_of_lt hp1) hptop hhk_memLp hgk_memLq
+      have hint_hg_int : Integrable (fun a => h_k a * g a) μₙ :=
+        integrable_mul_sf p q hpq (le_of_lt hp1) hptop hhk_memLp hg
+      have hint_ineq : ∫ a, h_k a * g_k a ∂μₙ ≤ ∫ a, h_k a * g a ∂μₙ :=
+        integral_mono hint_hkg_int hint_hg_int (fun a => hpw a)
+      have hn_norm : ‖hhk_memLp.toLp h_k‖ = (eLpNorm h_k p μₙ).toReal := by
+        simp only [Lp.norm_def]
+        congr 1; exact eLpNorm_congr_ae hhk_memLp.coeFn_toLp
+      have hchain : x ^ q.toReal ≤ ‖φ.comp extZ‖ * x ^ (q.toReal / p.toReal) := by
+        have hlhs : x ^ q.toReal = (eLpNorm g_k q μₙ ^ q.toReal).toReal := by
+          simp [x, ENNReal.toReal_rpow]
+        have hrhs_eq : x ^ (q.toReal / p.toReal) = (eLpNorm h_k p μₙ).toReal := by
+          rw [hn_eLpNorm, x, ENNReal.toReal_rpow]
+        rw [hlhs, hrhs_eq]
+        calc (eLpNorm g_k q μₙ ^ q.toReal).toReal
+            = ∫ a, h_k a * g_k a ∂μₙ := hint_hkgk.symm
+          _ ≤ ∫ a, h_k a * g a ∂μₙ := hint_ineq
+          _ = (φ.comp extZ) (hhk_memLp.toLp h_k) := hphi_hk.symm
+          _ ≤ ‖(φ.comp extZ) (hhk_memLp.toLp h_k)‖ := le_abs_self _
+          _ ≤ ‖φ.comp extZ‖ * ‖hhk_memLp.toLp h_k‖ :=
+                ContinuousLinearMap.le_opNorm _ _
+          _ = ‖φ.comp extZ‖ * (eLpNorm h_k p μₙ).toReal := by rw [hn_norm]
+      have hx_le : x ≤ ‖φ.comp extZ‖ := by
+        rcases le_or_lt x 0 with hx | hx
+        · linarith [norm_nonneg (φ.comp extZ)]
+        · have hrpow : x ^ q.toReal = x ^ (q.toReal / p.toReal) * x := by
+            conv_lhs =>
+              rw [show q.toReal = q.toReal / p.toReal + 1 from by linarith [hqp_eq]]
+            rw [Real.rpow_add hx, Real.rpow_one]
+          have hxqp_pos : 0 < x ^ (q.toReal / p.toReal) := Real.rpow_pos_of_pos hx _
+          have : x ^ (q.toReal / p.toReal) * x ≤ x ^ (q.toReal / p.toReal) * ‖φ.comp extZ‖ := by
+            calc x ^ (q.toReal / p.toReal) * x
+                = x ^ q.toReal := hrpow.symm
+              _ ≤ ‖φ.comp extZ‖ * x ^ (q.toReal / p.toReal) := hchain
+              _ = x ^ (q.toReal / p.toReal) * ‖φ.comp extZ‖ := mul_comm _ _
+          exact le_of_mul_le_mul_left this hxqp_pos
+      calc eLpNorm g_k q μₙ
+          = ENNReal.ofReal x := (ENNReal.ofReal_toReal hgk_ne_top).symm
+        _ ≤ ENNReal.ofReal ‖φ.comp extZ‖ := ENNReal.ofReal_le_ofReal hx_le
+    -- MCT: eLpNorm g q μₙ ≤ ENNReal.ofReal ‖φ ∘ extZ‖ ≤ ENNReal.ofReal ‖φ‖
+    apply le_trans _ (ENNReal.ofReal_le_ofReal hphin_le)
+    rw [eLpNorm_eq_lintegral_rpow_enorm hq0' hqtop']
+    -- ∫⁻ ‖g‖^q = ⨆_k ∫⁻ ‖g_k‖^q  (truncation MCT, mirrors rn_deriv_memLq_from_trunc)
+    have hgn_lint : ∀ k : ℕ,
+        ∫⁻ a, (‖(fun a => max (min (g a) (k : ℝ)) (-(k : ℝ))) a‖₊ : ℝ≥0∞) ^ q.toReal ∂μₙ ≤
+        (ENNReal.ofReal ‖φ.comp extZ‖) ^ q.toReal := fun k => by
+      have h := htrunc k
+      rw [eLpNorm_eq_lintegral_rpow_enorm hq0' hqtop'] at h
+      calc ∫⁻ a, _ ∂μₙ
+          = ((∫⁻ a, _ ∂μₙ) ^ (1 / q.toReal)) ^ q.toReal := by
+              rw [← ENNReal.rpow_mul, one_div, inv_mul_cancel₀ hq_pos'.ne', ENNReal.rpow_one]
+        _ ≤ (ENNReal.ofReal ‖φ.comp extZ‖) ^ q.toReal :=
+              ENNReal.rpow_le_rpow h (le_of_lt hq_pos')
+    have hMCT : ∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μₙ =
+        ⨆ k : ℕ, ∫⁻ a, (‖(fun a => max (min (g a) (k : ℝ)) (-(k : ℝ))) a‖₊ : ℝ≥0∞)
+          ^ q.toReal ∂μₙ := by
+      have abs_clamp : ∀ (r : ℝ) (k : ℕ), |max (min r k) (-(k : ℝ))| = min |r| k := by
+        intro r k
+        have hk : (0 : ℝ) ≤ k := Nat.cast_nonneg k
+        rcases le_or_lt r (-(k : ℝ)) with h1 | h1
+        · rw [min_eq_left (h1.trans (by linarith)), max_eq_right h1,
+              abs_neg, abs_of_nonneg hk, abs_of_nonpos (h1.trans (by linarith)),
+              min_eq_right (by linarith)]
+        rcases le_or_lt (k : ℝ) r with h2 | h2
+        · rw [min_eq_right h2, max_eq_left (by linarith), abs_of_nonneg hk,
+              abs_of_nonneg (hk.trans h2), min_eq_right h2]
+        · rw [min_eq_left h2.le, max_eq_left h1.le,
+              min_eq_left (abs_le.mpr ⟨by linarith, by linarith⟩)]
+      have sup_min : ∀ (x : ℝ≥0∞), ⨆ k : ℕ, min x k = x := fun x => by
+        rcases eq_or_ne x ⊤ with rfl | hx
+        · simp [min_eq_right le_top, ENNReal.iSup_natCast]
+        · apply le_antisymm (iSup_le fun k => min_le_left x k)
+          obtain ⟨K, hK⟩ := ENNReal.exists_nat_gt hx
+          exact (min_eq_left hK.le).symm ▸ le_iSup _ K
+      have norm_gk_eq : ∀ (a : α) (k : ℕ),
+          (‖max (min (g a) (k : ℝ)) (-(k : ℝ))‖₊ : ℝ≥0∞) = min (‖g a‖₊ : ℝ≥0∞) k := by
+        intro a k; rw [← ENNReal.coe_min]; congr 1; apply NNReal.coe_injective
+        push_cast [Real.norm_eq_abs]; exact abs_clamp (g a) k
+      have ptwise_eq : ∀ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal =
+          ⨆ k : ℕ, (min (‖g a‖₊ : ℝ≥0∞) k) ^ q.toReal := fun a => by
+        rw [← sup_min (‖g a‖₊)]
+        exact (ENNReal.orderIsoRpow q.toReal hq_pos').map_iSup _
+      rw [show (fun a => (‖g a‖₊ : ℝ≥0∞) ^ q.toReal) =
+          (fun a => ⨆ k : ℕ, (min (‖g a‖₊ : ℝ≥0∞) k) ^ q.toReal) from funext ptwise_eq,
+          lintegral_iSup_ae
+            (fun k => (hg.1.enorm.min aemeasurable_const).pow_const q.toReal)
+            (ae_of_all μₙ fun a m k hmk => ENNReal.rpow_le_rpow
+              (min_le_min_left _ (Nat.cast_le.mpr hmk)) (le_of_lt hq_pos'))]
+      simp_rw [← norm_gk_eq]
+    calc (∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μₙ) ^ (1 / q.toReal)
+        ≤ ((ENNReal.ofReal ‖φ.comp extZ‖) ^ q.toReal) ^ (1 / q.toReal) := by
+            apply ENNReal.rpow_le_rpow _ (by positivity)
+            rw [hMCT]; exact iSup_le hgn_lint
+      _ = ENNReal.ofReal ‖φ.comp extZ‖ := by
+            rw [← ENNReal.rpow_mul, mul_one_div_cancel hq_pos'.ne', ENNReal.rpow_one]
   -- ── Step A2: Consistency ────────────────────────────────────────────────────
   -- g_seq m =ᵐ[μ.restrict Sₘ] g_seq n for m ≤ n, via set-integral uniqueness.
   -- Key: ∫_s gₘ ∂(μ.restrict Sₘ) = ∫_{s∩Sₘ} gₘ ∂μ = φ(1_{s∩Sₘ}) = ∫_{s∩Sₘ} gₙ ∂μ
@@ -477,8 +744,67 @@ theorem localization_existence
   --                     ≤ ⨆_n ‖φ‖^q = ‖φ‖^q                 [by hgnorm]
   -- AEStronglyMeasurable g: each g_seq n is AEStronglyMeasurable on μ.restrict Sₙ;
   -- since Sₙ ↑ univ, g is AEStronglyMeasurable on μ.
+  -- Derived constants needed below
+  have hqtop : q ≠ ⊤ := by
+    intro h; rw [h, ENNReal.toReal_top] at hpq; linarith [hpq.symm.pos]
+  have hq0 : q ≠ 0 := by
+    intro h; rw [h, ENNReal.toReal_zero] at hpq; linarith [hpq.symm.pos]
+  have hq_pos : 0 < q.toReal := ENNReal.toReal_pos hq0 hqtop
   have hg_lq : MemLp g q μ := by
-    sorry
+    -- Step 1: g =ᵐ[μ.restrict Sₙ] g_seq n for each n
+    -- Proof: for each k ≤ n, hconsist gives g_seq k =ᵐ[μ.restrict Sₖ] g_seq n.
+    -- For a.e. a ∈ Sₙ: g(a) = g_seq(idx a)(a) where idx a ≤ n, and
+    -- g_seq(idx a)(a) = g_seq n(a) a.e. on S_{idx a} ⊆ Sₙ (finite union of null sets).
+    have hg_eq_n : ∀ n, g =ᵐ[μ.restrict (spanningSets μ n)] g_seq n := by
+      intro n
+      sorry
+    -- Step 2: AEStronglyMeasurable g μ
+    have hg_asm : AEStronglyMeasurable g μ :=
+      aestronglyMeasurable_of_restrict_spanningSets μ fun n =>
+        (hg_seq_mem n).1.congr_ae (hg_eq_n n).symm
+    -- Step 3: eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖
+    have hg_norm : eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖ := by
+      rw [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop]
+      apply ENNReal.rpow_le_rpow _ (by positivity)
+      -- MCT: ∫⁻ ‖g‖^q dμ = ⨆_n ∫⁻_{Sₙ} ‖g‖^q dμ ≤ ⨆_n ‖φ‖^q = ‖φ‖^q
+      have hbound_n : ∀ n,
+          ∫⁻ a in spanningSets μ n, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ ≤
+          (ENNReal.ofReal ‖φ‖) ^ q.toReal := fun n => by
+        have heq : ∫⁻ a in spanningSets μ n, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ =
+            ∫⁻ a, (‖g_seq n a‖₊ : ℝ≥0∞) ^ q.toReal ∂(μ.restrict (spanningSets μ n)) := by
+          rw [lintegral_restrict_univ]
+          apply lintegral_congr_ae
+          filter_upwards [hg_eq_n n] with a ha
+          simp [ha]
+        rw [heq]
+        have h := hgnorm n
+        rw [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop] at h
+        have h2 := ENNReal.rpow_le_rpow h (le_of_lt hq_pos)
+        rwa [← ENNReal.rpow_mul, one_div, inv_mul_cancel₀ hq_pos.ne', ENNReal.rpow_one] at h2
+      -- lintegral over μ = ⨆_n lintegral over μ.restrict Sₙ (Beppo-Levi on spanning sets)
+      have hMCT_global : ∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ =
+          ⨆ n, ∫⁻ a in spanningSets μ n, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ := by
+        set f_ind : ℕ → α → ℝ≥0∞ := fun n a =>
+            (spanningSets μ n).indicator (fun _ => (‖g a‖₊ : ℝ≥0∞) ^ q.toReal) a
+        have hmeas_fn : ∀ n, AEMeasurable (f_ind n) μ := fun n =>
+          ((hg_asm.enorm.pow_const q.toReal).indicator
+            (measurableSet_spanningSets μ n))
+        have hmono : ∀ᵐ a ∂μ, Monotone (fun n => f_ind n a) :=
+          ae_of_all μ fun a m n hmn =>
+            Set.indicator_le_indicator_of_subset (spanningSets_mono μ hmn) (fun _ => le_top) a
+        have hptwise : ∀ a, ⨆ n, f_ind n a = (‖g a‖₊ : ℝ≥0∞) ^ q.toReal := fun a => by
+          apply le_antisymm (iSup_le fun n => Set.indicator_le_self _ _ a)
+          obtain ⟨n, hn⟩ := Set.mem_iUnion.mp
+            ((iUnion_spanningSets μ).symm ▸ Set.mem_univ a)
+          exact le_iSup_of_le n (Set.indicator_of_mem hn _ ▸ le_refl _)
+        rw [show (fun a => (‖g a‖₊ : ℝ≥0∞) ^ q.toReal) = fun a => ⨆ n, f_ind n a
+              from funext (fun a => (hptwise a).symm),
+            lintegral_iSup_ae hmeas_fn hmono]
+        congr 1; ext n
+        exact (lintegral_indicator (measurableSet_spanningSets μ n) _).symm
+      rw [hMCT_global]
+      exact iSup_le hbound_n
+    exact ⟨hg_asm, (lt_of_le_of_lt hg_norm ENNReal.ofReal_lt_top).ne⟩
   -- ── Step A5: Indicator agreement for all E ───────────────────────────────────
   -- For E with μ(E) < ∞:
   --   φ(1_E) = lim_n φ(1_{E∩Sₙ})          [by lp_truncation_tendsto_zero + CLM continuity]
@@ -486,8 +812,9 @@ theorem localization_existence
   --          = ∫_E g dμ                     [by tendsto_setIntegral_of_monotone + DCT]
   refine ⟨g, hg_lq, ?_⟩
   intro E hE hfin
-  -- Use lp_truncation_tendsto_zero for 1_{E\Sₙ} → 0 in Lp,
-  -- then CLM continuity and hagree_n + MCT on the integral side.
+  -- φ(1_E) = lim_n φ(1_{E∩Sₙ})  [CLM continuity + lp_truncation_tendsto_zero]
+  --        = lim_n ∫_{E∩Sₙ} g dμ [hagree_n: φ(1_{E∩Sₙ}) = ∫_{E∩Sₙ} g_seq n = ∫_{E∩Sₙ} g]
+  --        = ∫_E g dμ             [MCT: E∩Sₙ ↑ E, g ∈ Lq ⊆ L1 locally]
   sorry
 
 -- ============================================================================

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -880,11 +880,45 @@ theorem localization_existence
       φ ((memLp_indicator_const p (hE.inter (measurableSet_spanningSets μ n)) 1
           (Or.inr (hfin_n n))).toLp _))
       atTop (nhds (φ (hind.toLp _))) := by
-    -- SORRY: 1_{E∩Sₙ}^Lp → 1_E^Lp in Lp(μ), proved via:
-    -- ‖h_n - h_Lp‖ = (eLpNorm (1_E - 1_E * 1_{Sₙ}) p μ).toReal (since 1_{E∩Sₙ} = 1_E * 1_{Sₙ})
-    -- which → 0 by lp_truncation_tendsto_zero + ENNReal.tendsto_toReal.
     apply (φ.continuous.tendsto _).comp
-    sorry
+    -- Need: Tendsto (fun n => h_n n) atTop (nhds (hind.toLp _)) in Lp(μ)
+    -- Key: dist (hind.toLp _) (h_n n) = (eLpNorm (1_E - 1_E * 1_{Sₙ}) p μ).toReal → 0
+    -- via lp_truncation_tendsto_zero applied to hind = 1_E^MemLp.
+    rw [Metric.tendsto_atTop]
+    intro ε hε
+    -- Convert eLpNorm convergence to toReal convergence
+    have hlim : Tendsto (fun n => (eLpNorm (fun a => (hind : α → ℝ) a -
+        (hind : α → ℝ) a * (spanningSets μ n).indicator (1 : α → ℝ) a) p μ).toReal)
+        atTop (nhds 0) := by
+      have h := (ENNReal.continuousAt_toReal (by norm_num : (0 : ℝ≥0∞) ≠ ⊤)).tendsto
+      have h2 := lp_truncation_tendsto_zero p (le_of_lt hp1) hptop hind
+      have h3 := h.comp h2
+      simp only [Function.comp, ENNReal.toReal_zero] at h3
+      exact h3
+    rw [Metric.tendsto_atTop] at hlim
+    obtain ⟨N, hN⟩ := hlim ε hε
+    refine ⟨N, fun n hn => ?_⟩
+    -- Compute dist (h_n n) (hind.toLp _) = (eLpNorm (1_E - 1_E * 1_{Sₙ}) p μ).toReal
+    have hdist : dist ((memLp_indicator_const p (hE.inter (measurableSet_spanningSets μ n)) 1
+        (Or.inr (hfin_n n))).toLp _) (hind.toLp _) =
+        (eLpNorm (fun a => (hind : α → ℝ) a - (hind : α → ℝ) a *
+            (spanningSets μ n).indicator (1 : α → ℝ) a) p μ).toReal := by
+      rw [dist_comm, dist_eq_norm, Lp.norm_def]
+      apply congr_arg ENNReal.toReal
+      apply eLpNorm_congr_ae
+      -- hind.toLp _ - h_n n =ᵐ 1_E - 1_{E∩Sₙ} = 1_E - 1_E * 1_{Sₙ}
+      filter_upwards [hind.coeFn_toLp,
+        (memLp_indicator_const p (hE.inter (measurableSet_spanningSets μ n)) 1
+          (Or.inr (hfin_n n))).coeFn_toLp,
+        Lp.coeFn_sub (hind.toLp _) ((memLp_indicator_const p
+          (hE.inter (measurableSet_spanningSets μ n)) 1 (Or.inr (hfin_n n))).toLp _)] with a h1 h2 h3
+      rw [h3, h1, h2]
+      -- 1_E a - 1_{E∩Sₙ} a = 1_E a - 1_E a * 1_{Sₙ} a
+      simp only [Set.indicator_apply, Set.mem_inter_iff]
+      by_cases hEa : a ∈ E <;> by_cases hSa : a ∈ spanningSets μ n <;> simp [hEa, hSa]
+    rw [hdist]
+    have h := hN n hn
+    rwa [Real.dist_zero_right, abs_of_nonneg ENNReal.toReal_nonneg] at h
   -- ── Conclude by tendsto_nhds_unique ──────────────────────────────────────────
   -- Both φ(h_n) → φ(1_E) and φ(h_n) = ∫_{E∩Sₙ} g → ∫_E g, so the limits agree.
   have hseq_eq : (fun n => φ ((memLp_indicator_const p

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -757,7 +757,32 @@ theorem localization_existence
     -- g_seq(idx a)(a) = g_seq n(a) a.e. on S_{idx a} ⊆ Sₙ (finite union of null sets).
     have hg_eq_n : ∀ n, g =ᵐ[μ.restrict (spanningSets μ n)] g_seq n := by
       intro n
-      sorry
+      rw [ae_restrict_iff' (measurableSet_spanningSets μ n), ae_iff]
+      simp only [not_imp]
+      -- For each k ≤ n, hconsist gives a null set on Sₖ where g_seq k ≠ g_seq n
+      have hBk_null : ∀ k ≤ n, μ {a | a ∈ spanningSets μ k ∧ g_seq k a ≠ g_seq n a} = 0 :=
+        fun k hkn => by
+          have h := ae_iff.mp
+            ((ae_restrict_iff' (measurableSet_spanningSets μ k)).mp (hconsist k n hkn))
+          convert h using 1; ext a; simp [not_imp]
+      -- The biUnion over k = 0..n is null (finite union of null sets)
+      have h_biUnion_null : μ (⋃ k ∈ Finset.range (n + 1),
+          {a | a ∈ spanningSets μ k ∧ g_seq k a ≠ g_seq n a}) = 0 :=
+        le_antisymm
+          (calc μ (⋃ k ∈ Finset.range (n + 1),
+                  {a | a ∈ spanningSets μ k ∧ g_seq k a ≠ g_seq n a})
+              ≤ ∑ k ∈ Finset.range (n + 1),
+                  μ {a | a ∈ spanningSets μ k ∧ g_seq k a ≠ g_seq n a} :=
+                measure_biUnion_finset_le _ _
+            _ = 0 := Finset.sum_eq_zero fun k hk =>
+                  hBk_null k (Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)))
+          (zero_le _)
+      -- Bad set {a ∈ Sₙ | g a ≠ g_seq n a} ⊆ biUnion (g(a) = g_seq(idx a)(a) definitionally)
+      exact measure_mono_null
+        (fun a ha => Set.mem_biUnion
+          (Finset.mem_range.mpr (Nat.lt_succ_of_le (Nat.find_min' (hcover a) ha.1)))
+          ⟨Nat.find_spec (hcover a), ha.2⟩)
+        h_biUnion_null
     -- Step 2: AEStronglyMeasurable g μ
     have hg_asm : AEStronglyMeasurable g μ :=
       aestronglyMeasurable_of_restrict_spanningSets μ fun n =>
@@ -812,10 +837,60 @@ theorem localization_existence
   --          = ∫_E g dμ                     [by tendsto_setIntegral_of_monotone + DCT]
   refine ⟨g, hg_lq, ?_⟩
   intro E hE hfin
-  -- φ(1_E) = lim_n φ(1_{E∩Sₙ})  [CLM continuity + lp_truncation_tendsto_zero]
-  --        = lim_n ∫_{E∩Sₙ} g dμ [hagree_n: φ(1_{E∩Sₙ}) = ∫_{E∩Sₙ} g_seq n = ∫_{E∩Sₙ} g]
-  --        = ∫_E g dμ             [MCT: E∩Sₙ ↑ E, g ∈ Lq ⊆ L1 locally]
-  sorry
+  -- Derived constant: q ≥ 1 (needed for Integrable from MemLp)
+  have hq_ge1 : (1 : ℝ≥0∞) ≤ q :=
+    calc (1 : ℝ≥0∞) = ENNReal.ofReal 1 := by simp
+      _ ≤ ENNReal.ofReal q.toReal :=
+          ENNReal.ofReal_le_ofReal (hpq.symm.one_lt_of_lt hp1).le
+      _ = q := ENNReal.ofReal_toReal hqtop
+  -- Finite-measure helper for E ∩ Sₙ
+  have hfin_n : ∀ n, μ (E ∩ spanningSets μ n) ≠ ⊤ := fun n =>
+    ((measure_mono Set.inter_subset_left).trans_lt (lt_top_iff_ne_top.mpr hfin)).ne
+  -- ── Step 1: φ(1_{E∩Sₙ}^Lp) = ∫_{E∩Sₙ} g dμ for each n ──────────────────────
+  -- Use hagree_n (E ∩ Sₙ ⊆ Sₙ) to get ∫_{E∩Sₙ} g_seq n, then ae-equality on Sₙ
+  have hphi_En : ∀ n,
+      φ ((memLp_indicator_const p (hE.inter (measurableSet_spanningSets μ n)) 1
+          (Or.inr (hfin_n n))).toLp _) =
+      ∫ a in E ∩ spanningSets μ n, g a ∂μ := fun n => by
+    rw [hagree_n n (E ∩ spanningSets μ n)
+          (hE.inter (measurableSet_spanningSets μ n))
+          Set.inter_subset_right (hfin_n n)]
+    -- ∫_{E∩Sₙ} g_seq n = ∫_{E∩Sₙ} g  by hg_eq_n restricted to E ∩ Sₙ ⊆ Sₙ
+    exact integral_congr_ae ((hg_eq_n n).filter_mono
+      (Measure.ae_mono (Measure.restrict_mono Set.inter_subset_right le_rfl))).symm
+  -- ── Step 2: ∫_{E∩Sₙ} g dμ → ∫_E g dμ  (monotone spanning-set convergence) ────
+  have hUnion_E : (⋃ n, E ∩ spanningSets μ n) = E := by
+    rw [← Set.inter_iUnion, iUnion_spanningSets, Set.inter_univ]
+  have hg_int_E : Integrable g (μ.restrict (⋃ n, E ∩ spanningSets μ n)) := by
+    rw [hUnion_E]
+    exact (hg_lq.mono_measure (Measure.restrict_mono Set.subset_univ le_rfl)).integrable hq_ge1
+  have htend_int : Tendsto (fun n => ∫ a in E ∩ spanningSets μ n, g a ∂μ)
+      atTop (nhds (∫ a in E, g a ∂μ)) := by
+    have h := tendsto_setIntegral_of_monotone
+      (fun n => hE.inter (measurableSet_spanningSets μ n))
+      (fun m n hmn => Set.inter_subset_inter_right E (spanningSets_mono μ hmn))
+      hg_int_E
+    rwa [hUnion_E] at h
+  -- ── Step 3: φ(1_{E∩Sₙ}^Lp) → φ(1_E^Lp)  (CLM continuity + Lp convergence) ───
+  -- φ is bounded: |φ(h_n - h)| ≤ ‖φ‖ * ‖h_n - h‖.
+  -- ‖h_n - h‖_Lp = (eLpNorm (1_{E∩Sₙ} - 1_E) p μ).toReal → 0
+  -- via lp_truncation_tendsto_zero applied to 1_E (1_{E∩Sₙ} = 1_E * 1_{Sₙ}).
+  set hind := indicator_memLp_sf hE hfin p (le_of_lt hp1) hptop
+  have htend_phi : Tendsto (fun n =>
+      φ ((memLp_indicator_const p (hE.inter (measurableSet_spanningSets μ n)) 1
+          (Or.inr (hfin_n n))).toLp _))
+      atTop (nhds (φ (hind.toLp _))) := by
+    -- SORRY: 1_{E∩Sₙ}^Lp → 1_E^Lp in Lp(μ), proved via:
+    -- ‖h_n - h_Lp‖ = (eLpNorm (1_E - 1_E * 1_{Sₙ}) p μ).toReal (since 1_{E∩Sₙ} = 1_E * 1_{Sₙ})
+    -- which → 0 by lp_truncation_tendsto_zero + ENNReal.tendsto_toReal.
+    apply (φ.continuous.tendsto _).comp
+    sorry
+  -- ── Conclude by tendsto_nhds_unique ──────────────────────────────────────────
+  -- Both φ(h_n) → φ(1_E) and φ(h_n) = ∫_{E∩Sₙ} g → ∫_E g, so the limits agree.
+  have hseq_eq : (fun n => φ ((memLp_indicator_const p
+        (hE.inter (measurableSet_spanningSets μ n)) 1 (Or.inr (hfin_n n))).toLp _)) =
+      (fun n => ∫ a in E ∩ spanningSets μ n, g a ∂μ) := funext hphi_En
+  exact (tendsto_nhds_unique (hseq_eq ▸ htend_phi) htend_int).symm
 
 -- ============================================================================
 -- § 6. Main theorem


### PR DESCRIPTION
## Summary

- **All sorries eliminated** in `localization_existence` (Step A of sigma-finite Riesz representation)
- **`hg_eq_n`**: `g =ᵐ[μ.restrict Sₙ] g_seq n` via finite-union null set argument (`measure_biUnion_finset_le`, `Nat.find_min'`)
- **`htend_phi`**: `1_{E∩Sₙ}^Lp → 1_E^Lp` via `lp_truncation_tendsto_zero` + `ENNReal.continuousAt_toReal` + `Lp.coeFn_sub`
- **Conclusion**: `tendsto_nhds_unique` + `tendsto_setIntegral_of_monotone` gives `φ(1_E) = ∫_E g dμ`

The 952-line file is now sorry-free (pending Docker build verification of API names).

## Test plan
- [ ] Docker build `Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01` (running)
- [ ] Key APIs to verify: `measure_biUnion_finset_le`, `Lp.norm_def`, `eLpNorm_congr_ae`, `Lp.coeFn_sub`, `tendsto_setIntegral_of_monotone`, `ENNReal.continuousAt_toReal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)