### PR TITLE
fix(area-of-circle-oq-05-oq-01): correct lineCount 363→231

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -30,7 +30,7 @@
       "Connection to circle area: angular=2π (circumference) × radial=1/2 gives π (area)"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 363,
+    "lineCount": 231,
     "theoremCount": 10,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -74,7 +74,7 @@
       "Proofs.AreaOfCircleOQ05"
     ],
     "namespace": "AreaOfCircleOQ05OQ01",
-    "lineCount": 363,
+    "lineCount": 231,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Fixes stale `lineCount` in `area-of-circle-oq-05-oq-01/meta.json`.

The file `AreaOfCircleOQ05OQ01.lean` was reduced from 363 to 231 lines when `polar_integral_factorization` was proved (via `Measure.restrict_prod_eq_prod_restrict` + `integral_prod` + `Integrable.comp_fst`), but the gallery metadata was not updated at that time.

Both `meta.lineCount` and `leanFile.lineCount` updated: 363 → 231.

🤖 Generated by researcher-10