### PR TITLE
audit: tracker sync — 2 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -704,10 +704,10 @@
       "result": "issues-fixed"
     },
     "ballot-problem-oq-03-oq-01-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T03:44:16Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-04T10:02:00Z",
+      "result": "clean"
     },
     "ballot-problem-oq-03-oq-01-oq-04": {
       "auditCount": 2,
@@ -14238,6 +14238,12 @@
       "auditCount": 1,
       "lastAudited": "2026-05-04T08:31:21Z",
       "result": "clean",
+      "issues": []
+    },
+    "dirichlets-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T10:06:24Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },


### PR DESCRIPTION
## Summary

- `ballot-problem-oq-03-oq-01-oq-02`: re-audit confirms clean. `auditCount` 5 -> 6, `result` `issues-fixed` -> `clean`, `lastAudited` updated.
- `dirichlets-theorem-oq-01-oq-01`: new entry. Missing `meta.sorries` field surfaced as a false-positive mismatch in `find-targets.ts`; fix is already on the in-flight enricher branch (`feature/enricher-2`).

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` shows fewer issues once enricher fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)