### PR TITLE
audit: tracker sync — 1 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -704,10 +704,10 @@
       "result": "issues-fixed"
     },
     "ballot-problem-oq-03-oq-01-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T03:44:16Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-04T10:02:00Z",
+      "result": "clean"
     },
     "ballot-problem-oq-03-oq-01-oq-04": {
       "auditCount": 2,
@@ -2782,10 +2782,10 @@
       "result": "clean"
     },
     "erdos-100-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:46Z",
-      "result": "clean"
+      "lastAudited": "2026-05-04T10:12:37Z",
+      "result": "issues-found"
     },
     "erdos-100-oq-02": {
       "auditCount": 4,
@@ -14238,6 +14238,12 @@
       "auditCount": 1,
       "lastAudited": "2026-05-04T08:31:21Z",
       "result": "clean",
+      "issues": []
+    },
+    "dirichlets-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T10:06:24Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },


### PR DESCRIPTION
Audit tracker sync:

- `erdos-100-oq-01`: auditCount 3→4, result clean→issues-found. `meta.sorries` is 2 but Lean file has 1 sorry on branch `research/erdos-100-oq-01-wip-01-fiber`. Issue filed: #15594.

Also includes earlier synced entries (ballot-problem-oq-03-oq-01-oq-02 clean, dirichlets-theorem-oq-01-oq-01 issues-fixed) from session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)