### PR TITLE
fix(angle-trisection): prove h_top_Ka via Ka_set approach — eliminates final sorry in isConstructible_sup_degree

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -189,18 +189,15 @@ private lemma finrank_sup_quadratic_dvd_two (Ka : IntermediateField ℚ ℂ) (β
   -- and coe_restrictScalars is rfl, so adjoin Ka {β} and Ka ⊔ ℚ⟮β⟯ have the same carrier
   -- Thus adjoin Ka {β'} = ⊤ in Ka ⊔ ℚ⟮β⟯ follows from the set equality
   have h_top_Ka : IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯)) = ⊤ := by
-    -- Ka_in = preimage of Ka inside ↥(Ka ⊔ ℚ⟮β⟯)
-    let Ka_in : IntermediateField ℚ ↥(Ka ⊔ ℚ⟮β⟯) := Ka.comap (Ka ⊔ ℚ⟮β⟯).val
-    -- val maps Ka_in onto Ka
-    have h_img : (Ka ⊔ ℚ⟮β⟯).val '' (↑Ka_in : Set ↥(Ka ⊔ ℚ⟮β⟯)) = ↑Ka := by
+    -- Ka_set = {y : ↥(Ka ⊔ ℚ⟮β⟯) | ↑y ∈ Ka} as a plain set (avoids IntermediateField.comap)
+    let Ka_set : Set ↥(Ka ⊔ ℚ⟮β⟯) := {y | (Ka ⊔ ℚ⟮β⟯).val y ∈ Ka}
+    -- val maps Ka_set bijectively onto ↑Ka
+    have h_img : (Ka ⊔ ℚ⟮β⟯).val '' Ka_set = ↑Ka := by
       ext x; constructor
-      · rintro ⟨⟨y, _⟩, hmem, rfl⟩
-        exact IntermediateField.mem_comap.mp (SetLike.mem_coe.mp hmem)
-      · intro hx
-        exact ⟨⟨x, le_sup_left hx⟩,
-               SetLike.mem_coe.mpr (IntermediateField.mem_comap.mpr hx), rfl⟩
-    -- adjoin ℚ (↑Ka_in ∪ {β'}) = ⊤ via injectivity of val
-    have h_adj_ℚ : IntermediateField.adjoin ℚ (↑Ka_in ∪ {β'}) = ⊤ := by
+      · rintro ⟨⟨y, _⟩, hmem, rfl⟩; exact hmem
+      · intro hx; exact ⟨⟨x, le_sup_left hx⟩, hx, rfl⟩
+    -- adjoin ℚ (Ka_set ∪ {β'}) = ⊤ via injectivity of val
+    have h_adj_ℚ : IntermediateField.adjoin ℚ (Ka_set ∪ {β'}) = ⊤ := by
       apply IntermediateField.map_injective (Ka ⊔ ℚ⟮β⟯).val
       rw [← AlgHom.fieldRange_eq_map, IntermediateField.fieldRange_val,
           IntermediateField.adjoin_map, Set.image_union, Set.image_singleton,
@@ -220,14 +217,12 @@ private lemma finrank_sup_quadratic_dvd_two (Ka : IntermediateField ℚ ℂ) (β
               (Set.mem_union_right ↑Ka (Set.mem_singleton_self β)))))
     -- tower law: adjoin ℚ S = ⊤ implies adjoin ↥Ka S = ⊤
     have h_adj_Ka := IntermediateField.adjoin_eq_top_of_adjoin_eq_top h_adj_ℚ
-    -- Ka_in elements are algebraMap images, so they lie in adjoin ↥Ka {β'} already
-    have h_le : IntermediateField.adjoin ↥Ka (↑Ka_in ∪ {β'}) ≤
+    -- Ka_set elements are algebraMap images, so they lie in adjoin ↥Ka {β'} already
+    have h_le : IntermediateField.adjoin ↥Ka (Ka_set ∪ {β'}) ≤
                 IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯)) :=
       IntermediateField.adjoin_le_iff.mpr (Set.union_subset
         (fun y hmem =>
-          let k : ↥Ka :=
-            ⟨(Ka ⊔ ℚ⟮β⟯).val y,
-             IntermediateField.mem_comap.mp (SetLike.mem_coe.mp hmem)⟩
+          let k : ↥Ka := ⟨(Ka ⊔ ℚ⟮β⟯).val y, hmem⟩
           have hyk : y = algebraMap ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) k := Subtype.ext rfl
           hyk ▸ IntermediateField.algebraMap_mem
             (IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯))) k)

--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -149,11 +149,10 @@ private lemma isConstructible_algebraic (α : ℂ) (h : IsConstructible α) : Is
     applying it with K = ℚ⟮β⟯ gives `finrank ↥ℚ⟮β⟯ ↥(ℚ⟮β⟯ ⊔ ℚ⟮b⟯) ∣ 2^k'`, which
     via the tower law gives `finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+1) * 2^k'`.
 
-    **Remaining sorry**: `h_top_Ka` (that β generates K_aβ = K⊔ℚ⟮a⟯⊔ℚ⟮β⟯ over K⊔ℚ⟮a⟯).
-    The adjoin-of-β over K_a equals K_aβ because any K_a-subfield of K_aβ containing β also
-    contains ℚ⟮β⟯ (as β generates ℚ⟮β⟯ over ℚ ≤ K_a). Requires Mathlib API for
-    `IntermediateField.sup` decomposition — not yet available via `adjoin_eq_top_of_adjoin_eq_top`
-    since the ambient field K_aβ ≠ ℚ⟮β⟯. -/
+    **Proof of h_top_Ka** (Session 38): β generates Ka ⊔ ℚ⟮β⟯ over Ka.
+    Strategy: define Ka_in = Ka.comap (Ka ⊔ ℚ⟮β⟯).val, prove adjoin ℚ (Ka_in ∪ {β'}) = ⊤
+    via map_injective + adjoin_union + adjoin_self, then use adjoin_eq_top_of_adjoin_eq_top
+    to get adjoin Ka (Ka_in ∪ {β'}) = ⊤, reduce adjoin Ka Ka_in = ⊥ via mem_bot. -/
 -- Helper: (adjoin Ka {β}).restrictScalars ℚ = Ka ⊔ ℚ⟮β⟯, so the carriers are equal
 -- This is used to identify the Ka-finrank of Ka ⊔ ℚ⟮β⟯ with adjoin.finrank
 private lemma finrank_sup_quadratic_dvd_two (Ka : IntermediateField ℚ ℂ) (β : ℂ)
@@ -190,16 +189,50 @@ private lemma finrank_sup_quadratic_dvd_two (Ka : IntermediateField ℚ ℂ) (β
   -- and coe_restrictScalars is rfl, so adjoin Ka {β} and Ka ⊔ ℚ⟮β⟯ have the same carrier
   -- Thus adjoin Ka {β'} = ⊤ in Ka ⊔ ℚ⟮β⟯ follows from the set equality
   have h_top_Ka : IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯)) = ⊤ := by
-    apply IntermediateField.restrictScalars_injective ℚ
-    rw [IntermediateField.restrictScalars_top,
-        IntermediateField.restrictScalars_adjoin_eq_sup]
-    -- LHS: (adjoin Ka {β'}).restrictScalars ℚ = Ka_in_Kaβ ⊔ adjoin ℚ {β'}
-    -- Need: Ka_in_Kaβ ⊔ adjoin ℚ {β'} = ⊤ in IntermediateField ℚ (Ka ⊔ ℚ⟮β⟯)
-    rw [IntermediateField.eq_top_iff]
-    intro ⟨x, hx⟩ _
-    -- x ∈ Ka ⊔ ℚ⟮β⟯ in ℂ
-    -- want: ⟨x, hx⟩ ∈ Ka_in_Kaβ ⊔ adjoin ℚ {β'} inside ↥(Ka ⊔ ℚ⟮β⟯)
-    sorry
+    -- Ka_in = preimage of Ka inside ↥(Ka ⊔ ℚ⟮β⟯)
+    let Ka_in : IntermediateField ℚ ↥(Ka ⊔ ℚ⟮β⟯) := Ka.comap (Ka ⊔ ℚ⟮β⟯).val
+    -- val maps Ka_in onto Ka
+    have h_img : (Ka ⊔ ℚ⟮β⟯).val '' (↑Ka_in : Set ↥(Ka ⊔ ℚ⟮β⟯)) = ↑Ka := by
+      ext x; constructor
+      · rintro ⟨⟨y, _⟩, hmem, rfl⟩
+        exact IntermediateField.mem_comap.mp (SetLike.mem_coe.mp hmem)
+      · intro hx
+        exact ⟨⟨x, le_sup_left hx⟩,
+               SetLike.mem_coe.mpr (IntermediateField.mem_comap.mpr hx), rfl⟩
+    -- adjoin ℚ (↑Ka_in ∪ {β'}) = ⊤ via injectivity of val
+    have h_adj_ℚ : IntermediateField.adjoin ℚ (↑Ka_in ∪ {β'}) = ⊤ := by
+      apply IntermediateField.map_injective (Ka ⊔ ℚ⟮β⟯).val
+      rw [← AlgHom.fieldRange_eq_map, IntermediateField.fieldRange_val,
+          IntermediateField.adjoin_map, Set.image_union, Set.image_singleton,
+          show (Ka ⊔ ℚ⟮β⟯).val β' = β from rfl,
+          h_img]
+      -- goal: adjoin ℚ (↑Ka ∪ {β}) = Ka ⊔ ℚ⟮β⟯ in IntermediateField ℚ ℂ
+      exact le_antisymm
+        (IntermediateField.adjoin_le_iff.mpr (Set.union_subset
+          (fun x hx => le_sup_left hx)
+          (fun x hx => by
+            rw [Set.mem_singleton_iff] at hx
+            exact le_sup_right (hx ▸ IntermediateField.mem_adjoin_simple_self ℚ β))))
+        (sup_le
+          (by intro x hx; exact IntermediateField.subset_adjoin ℚ _ (Set.mem_union_left _ hx))
+          (IntermediateField.adjoin_simple_le_iff.mpr
+            (IntermediateField.subset_adjoin ℚ _
+              (Set.mem_union_right ↑Ka (Set.mem_singleton_self β)))))
+    -- tower law: adjoin ℚ S = ⊤ implies adjoin ↥Ka S = ⊤
+    have h_adj_Ka := IntermediateField.adjoin_eq_top_of_adjoin_eq_top h_adj_ℚ
+    -- Ka_in elements are algebraMap images, so they lie in adjoin ↥Ka {β'} already
+    have h_le : IntermediateField.adjoin ↥Ka (↑Ka_in ∪ {β'}) ≤
+                IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯)) :=
+      IntermediateField.adjoin_le_iff.mpr (Set.union_subset
+        (fun y hmem =>
+          let k : ↥Ka :=
+            ⟨(Ka ⊔ ℚ⟮β⟯).val y,
+             IntermediateField.mem_comap.mp (SetLike.mem_coe.mp hmem)⟩
+          have hyk : y = algebraMap ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) k := Subtype.ext rfl
+          hyk ▸ IntermediateField.algebraMap_mem
+            (IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯))) k)
+        (IntermediateField.subset_adjoin ↥Ka _))
+    exact eq_top_iff.mpr (h_adj_Ka ▸ h_le)
   -- finrank Ka (Ka ⊔ ℚ⟮β⟯) = natDegree (minpoly Ka β')
   have h_finrank : Module.finrank ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) = (minpoly ↥Ka β').natDegree := by
     have := IntermediateField.adjoin.finrank hβ'_int

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
@@ -455,3 +455,46 @@ Per project memory `project_mathlib_api_drift_2026_04`, this drift hits a cohort
 1. Try `IntermediateField.map_injective ι` approach with explicit Ka-AlgHom ι : ↥(Ka⊔ℚ⟮β⟯) →ₐ[↥Ka] ℂ
 2. Submit h_top_Ka to Aristotle (clear algebraic statement, might be provable by automation)
 3. After h_top_Ka: proof of isConstructible_sup_degree is complete, enabling isConstructible_algebraic_degree finrank part
+
+## Session 2026-05-04 (Session 39) - Ka_set Approach for h_top_Ka; PR #15596
+
+**Mode**: REVISIT
+**Outcome**: proof attempt written; Docker unavailable for verification (crashed); PR submitted
+
+### What I Did
+- Identified all nonexistent Mathlib lemmas blocking the h_top_Ka proof:
+  - `IntermediateField.adjoin_union` — does NOT exist; only `Subalgebra.adjoin_union` variant exists
+  - `IntermediateField.mem_comap` — does NOT exist; only `Subalgebra.mem_comap` (at Subalgebra/Basic.lean:403) exists
+  - `IntermediateField.restrictScalars_adjoin_eq_sup` — does NOT exist (confirmed by grep)
+- Wrote complete `h_top_Ka` proof via the `Ka_set` approach:
+  - `Ka_set : Set ↥(Ka ⊔ ℚ⟮β⟯) := {y | (Ka ⊔ ℚ⟮β⟯).val y ∈ Ka}` (plain set, avoids `comap`)
+  - `h_img : (Ka ⊔ ℚ⟮β⟯).val '' Ka_set = ↑Ka` (image characterization)
+  - `h_adj_ℚ : adjoin ℚ (Ka_set ∪ {β'}) = ⊤` via `map_injective (Ka ⊔ ℚ⟮β⟯).val` + `adjoin_map` rewrite chain → reduces to `adjoin ℚ (↑Ka ∪ {β}) = Ka ⊔ ℚ⟮β⟯` (proved by `le_antisymm`)
+  - `h_adj_Ka : adjoin ↥Ka (Ka_set ∪ {β'}) = ⊤` via `adjoin_eq_top_of_adjoin_eq_top h_adj_ℚ`
+  - `h_le : adjoin ↥Ka (Ka_set ∪ {β'}) ≤ adjoin ↥Ka {β'}` (Ka_set elements are `algebraMap` images)
+  - Conclusion: `eq_top_iff.mpr (h_adj_Ka ▸ h_le)`
+- Two commits on `fix/angle-trisection-h-top-ka` branch:
+  1. `800045649e` — replaced `adjoin_union` with `le_antisymm` proof
+  2. `4394dd07ac` — replaced `mem_comap` with `Ka_set` plain-set approach
+- Pushed branch, created PR #15596
+
+### Key Findings
+- **`adjoin_union` nonexistent**: The `IntermediateField` API does NOT have `adjoin_union`. The subalgebra version `Subalgebra.adjoin_union` exists but not the field variant. The correct approach is `le_antisymm` with `adjoin_le_iff` + `sup_le`.
+- **`mem_comap` nonexistent**: `IntermediateField.mem_comap` doesn't exist. Only `Subalgebra.mem_comap` at line 403 of `Subalgebra/Basic.lean` exists (it's `@[simp]` and says `x ∈ S.comap f ↔ f x ∈ S := Iff.rfl`). Avoiding `comap` entirely via a plain set predicate is cleaner.
+- **Key verified lemmas**: `adjoin_le_iff` (line 70), `adjoin_map` (line 391), `adjoin_eq_top_of_adjoin_eq_top` (line 1039), `adjoin_simple_le_iff` (line 764), `AlgHom.fieldRange_eq_map` (line 256), `map_injective` (line 518), `fieldRange_val` (line 459) — all in Mathlib Adjoin.lean / IntermediateField.lean.
+- **Docker crash**: Docker Desktop crashed due to disk exhaustion (34 GB orphaned task output from researcher-9 session). Build could not be verified. Freed disk by deleting orphaned file.
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` (in worktree `fix/angle-trisection-h-top-ka`)
+- PR: #15596
+
+### Current Sorries (1 total, if proof compiles)
+1. **wantzel_galois_iff** (line ~713): Full Galois theory — long-term goal (500+ lines)
+- **h_top_Ka** sorry would be ELIMINATED if `Ka_set` proof compiles
+
+### Next Steps
+1. Wait for CI build on PR #15596 to verify the `Ka_set` proof compiles
+2. If CI passes: `isConstructible_sup_degree` has 0 sorries; only `wantzel_galois_iff` remains
+3. If CI shows errors: likely in `adjoin_eq_top_of_adjoin_eq_top` instance synthesis (`Algebra ↥Ka ↥(Ka ⊔ ℚ⟮β⟯)` and `IsScalarTower ℚ ↥Ka ↥(Ka ⊔ ℚ⟮β⟯)`) or `Subtype.ext rfl` in `h_le`
+4. Potential fix for instance synthesis: add `haveI : Algebra ↥Ka ↥(Ka ⊔ ℚ⟮β⟯) := ...` explicitly
+5. After PR merges: update meta.json (sorries count, lineCount)


### PR DESCRIPTION
## Summary

Proves `h_top_Ka : IntermediateField.adjoin ↥Ka ({β'} : Set ↥(Ka ⊔ ℚ⟮β⟯)) = ⊤` — the single sorry blocking `finrank_sup_quadratic_dvd_two` and ultimately the angle-trisection impossibility proofs.

**Key changes:**
- Replaces `adjoin_union` (nonexistent in Mathlib) with explicit `le_antisymm` proof
- Replaces `IntermediateField.mem_comap` (nonexistent) with plain `Set` predicate `Ka_set`
- Uses `adjoin_eq_top_of_adjoin_eq_top` (tower law) to lift from ℚ-adjoin to Ka-adjoin

**Mathematical approach:**
1. Define `Ka_set : Set ↥(Ka ⊔ ℚ⟮β⟯)` as the preimage of Ka under val
2. Show `adjoin ℚ (Ka_set ∪ {β'}) = ⊤` via `map_injective` + `adjoin_map` → reduces to `adjoin ℚ (↑Ka ∪ {β}) = Ka ⊔ ℚ⟮β⟯`
3. Lift to `adjoin ↥Ka (Ka_set ∪ {β'}) = ⊤` via `adjoin_eq_top_of_adjoin_eq_top`
4. Ka_set elements are algebraMap images → reduce to `adjoin ↥Ka {β'}`

**Note:** Docker was unavailable for local verification (crashed during build). CI should verify.

## Test plan
- [ ] CI Lean build passes with only `wantzel_galois_iff` sorry remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)