### PR TITLE
research(erdos-100-oq-01-wip-01): complete Anning–Erdős proof — 0 sorries

### DIFF
--- a/proofs/Proofs/Erdos100OQ01WIP01.lean
+++ b/proofs/Proofs/Erdos100OQ01WIP01.lean
@@ -183,11 +183,71 @@ theorem int_dist_card_le
     (hS_noncol : ¬∀ p ∈ S, ∀ q ∈ S, ∀ r ∈ S,
       (p.1 - r.1) * (q.2 - r.2) = (q.1 - r.1) * (p.2 - r.2)) :
     S.card ≤ 2 * d ^ 2 + 2 := by
-  -- Fix two distinct anchor points P₁, P₂ ∈ S
-  -- For Q ∈ S \ {P₁,P₂}: distance pair (k₁,k₂) ∈ {1..d}², at most d² choices
-  -- Each choice gives ≤ 2 points (by three_pts_two_circles_contra)
-  -- So |S| - 2 ≤ 2*d², hence |S| ≤ 2*d² + 2
-  sorry
+  -- Extract two non-coincident anchor points from non-collinearity
+  push_neg at hS_noncol
+  obtain ⟨P₁, hP₁S, P₂, hP₂S, _, _, hncol⟩ := hS_noncol
+  have hP₁₂ : P₁ ≠ P₂ := by
+    intro h; apply hncol; rw [← h]
+  -- Remove anchors: T = S \ {P₁, P₂}
+  have hP₂_in_erase : P₂ ∈ S.erase P₁ :=
+    Finset.mem_erase.mpr ⟨hP₁₂.symm, hP₂S⟩
+  -- S.card ≤ T.card + 2
+  have hT_card : S.card ≤ ((S.erase P₁).erase P₂).card + 2 := by
+    have h1 := Finset.card_erase_of_mem hP₁S
+    have h2 := Finset.card_erase_of_mem hP₂_in_erase
+    omega
+  -- T ⊆ S
+  have hT_sub : (S.erase P₁).erase P₂ ⊆ S := fun x hx =>
+    (Finset.mem_erase.mp (Finset.mem_erase.mp hx).2).2
+  -- Sufficient: T.card ≤ 2 * d²
+  suffices h : ((S.erase P₁).erase P₂).card ≤ 2 * d ^ 2 by linarith
+  -- Distance-pair index set
+  let pairs := (Finset.Icc 1 d) ×ˢ (Finset.Icc 1 d)
+  -- T ⊆ biUnion of fibers over (k₁,k₂) ∈ {1..d}²
+  have hT_cover : (S.erase P₁).erase P₂ ⊆ pairs.biUnion (fun kp =>
+      ((S.erase P₁).erase P₂).filter (fun Q =>
+        (Q.1 - P₁.1) ^ 2 + (Q.2 - P₁.2) ^ 2 = (kp.1 : ℝ) ^ 2 ∧
+        (Q.1 - P₂.1) ^ 2 + (Q.2 - P₂.2) ^ 2 = (kp.2 : ℝ) ^ 2)) := by
+    intro Q hQ
+    have hQP₁ : Q ≠ P₁ := (Finset.mem_erase.mp (Finset.mem_erase.mp hQ).2).1
+    have hQP₂ : Q ≠ P₂ := (Finset.mem_erase.mp hQ).1
+    obtain ⟨k₁, hk₁pos, hk₁le, hd₁⟩ := hS_dist Q (hT_sub hQ) P₁ hP₁S hQP₁
+    obtain ⟨k₂, hk₂pos, hk₂le, hd₂⟩ := hS_dist Q (hT_sub hQ) P₂ hP₂S hQP₂
+    simp only [Finset.mem_biUnion, Finset.mem_product, Finset.mem_Icc, Finset.mem_filter]
+    exact ⟨(k₁, k₂), ⟨⟨hk₁pos, hk₁le⟩, ⟨hk₂pos, hk₂le⟩⟩, hQ, hd₁, hd₂⟩
+  -- Each fiber has ≤ 2 elements (by two-circle intersection)
+  have hfiber_le : ∀ kp ∈ pairs, (((S.erase P₁).erase P₂).filter (fun Q =>
+      (Q.1 - P₁.1) ^ 2 + (Q.2 - P₁.2) ^ 2 = (kp.1 : ℝ) ^ 2 ∧
+      (Q.1 - P₂.1) ^ 2 + (Q.2 - P₂.2) ^ 2 = (kp.2 : ℝ) ^ 2)).card ≤ 2 := by
+    intro ⟨k₁, k₂⟩ _
+    by_contra hF
+    push_neg at hF
+    obtain ⟨Q₁, hQ₁, Q₂, hQ₂, Q₃, hQ₃, h12, h13, h23⟩ := Finset.two_lt_card.mp hF
+    have hQ₁' := (Finset.mem_filter.mp hQ₁).2
+    have hQ₂' := (Finset.mem_filter.mp hQ₂).2
+    have hQ₃' := (Finset.mem_filter.mp hQ₃).2
+    exact three_pts_two_circles_contra P₁ P₂ (k₁ : ℝ) (k₂ : ℝ) hP₁₂
+      Q₁ Q₂ Q₃ h12 h13 h23
+      hQ₁'.1 hQ₁'.2 hQ₂'.1 hQ₂'.2 hQ₃'.1 hQ₃'.2
+  -- pairs.card = d²
+  have hpairs_card : pairs.card = d ^ 2 := by
+    simp only [pairs, Finset.card_product, Finset.card_Icc]
+    have : d + 1 - 1 = d := by omega
+    rw [this]; ring
+  -- Chain the bounds
+  calc ((S.erase P₁).erase P₂).card
+      ≤ (pairs.biUnion (fun kp =>
+          ((S.erase P₁).erase P₂).filter (fun Q =>
+            (Q.1 - P₁.1) ^ 2 + (Q.2 - P₁.2) ^ 2 = (kp.1 : ℝ) ^ 2 ∧
+            (Q.1 - P₂.1) ^ 2 + (Q.2 - P₂.2) ^ 2 = (kp.2 : ℝ) ^ 2))).card :=
+          Finset.card_le_card hT_cover
+    _ ≤ ∑ kp ∈ pairs, (((S.erase P₁).erase P₂).filter (fun Q =>
+          (Q.1 - P₁.1) ^ 2 + (Q.2 - P₁.2) ^ 2 = (kp.1 : ℝ) ^ 2 ∧
+          (Q.1 - P₂.1) ^ 2 + (Q.2 - P₂.2) ^ 2 = (kp.2 : ℝ) ^ 2)).card :=
+          Finset.card_biUnion_le
+    _ ≤ ∑ _ ∈ pairs, 2 := Finset.sum_le_sum hfiber_le
+    _ = pairs.card * 2 := by rw [Finset.sum_const]; simp [smul_eq_mul]
+    _ = 2 * d ^ 2 := by rw [hpairs_card]; ring
 
 /-! ## Main theorem -/
 

--- a/proofs/Proofs/Erdos100OQ01WIP01.lean
+++ b/proofs/Proofs/Erdos100OQ01WIP01.lean
@@ -1,0 +1,214 @@
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+/-!
+# Anning–Erdős Finiteness: Proof Infrastructure
+
+Proves the Anning–Erdős theorem: any non-collinear planar point set with all
+pairwise integer distances bounded by d has at most 2d² + 2 points.
+
+## Proof sketch
+
+Fix two anchor points P₁, P₂ ∈ S. Every other Q ∈ S lies on the intersection
+of two circles (dist(Q,P₁) = k₁ and dist(Q,P₂) = k₂). Two distinct circles
+intersect in at most 2 points (via the quadratic root bound). Since there are
+d² possible distance pairs, |S| − 2 ≤ 2d², so |S| ≤ 2d² + 2.
+-/
+
+namespace Erdos100OQ01WIP01
+
+open Real Finset
+
+/-! ## Algebraic root bound -/
+
+/-- A nonzero quadratic has at most 2 roots: given two distinct roots p, q,
+    any third root must equal p or q. -/
+lemma quadratic_at_most_two_roots (a b c : ℝ) (ha : a ≠ 0)
+    (p q r : ℝ)
+    (hp : a * p ^ 2 + b * p + c = 0)
+    (hq : a * q ^ 2 + b * q + c = 0)
+    (hpq : p ≠ q)
+    (hr : a * r ^ 2 + b * r + c = 0) :
+    r = p ∨ r = q := by
+  have hsum : a * (p + q) + b = 0 := by
+    have key : (p - q) * (a * (p + q) + b) = 0 := by
+      have : (p - q) * (a * (p + q) + b) =
+          (a * p ^ 2 + b * p + c) - (a * q ^ 2 + b * q + c) := by ring
+      rw [this, hp, hq, sub_self]
+    rcases mul_eq_zero.mp key with h | h
+    · exact absurd (sub_eq_zero.mp h) hpq
+    · exact h
+  rcases eq_or_ne r p with rfl | hrp
+  · exact Or.inl rfl
+  · right
+    have hsum2 : a * (r + p) + b = 0 := by
+      have key : (r - p) * (a * (r + p) + b) = 0 := by
+        have : (r - p) * (a * (r + p) + b) =
+            (a * r ^ 2 + b * r + c) - (a * p ^ 2 + b * p + c) := by ring
+        rw [this, hr, hp, sub_self]
+      rcases mul_eq_zero.mp key with h | h
+      · exact absurd (sub_eq_zero.mp h) hrp
+      · exact h
+    linarith [mul_left_cancel₀ ha (show a * (p + q) = a * (r + p) by linarith)]
+
+/-! ## Circle intersection lemma -/
+
+/-- Three distinct points cannot simultaneously lie on two circles with distinct centers. -/
+theorem three_pts_two_circles_contra
+    (c₁ c₂ : ℝ × ℝ) (r₁ r₂ : ℝ)
+    (hc : c₁ ≠ c₂)
+    (p q s : ℝ × ℝ)
+    (hpq : p ≠ q) (hps : p ≠ s) (hqs : q ≠ s)
+    (hp1 : (p.1 - c₁.1) ^ 2 + (p.2 - c₁.2) ^ 2 = r₁ ^ 2)
+    (hp2 : (p.1 - c₂.1) ^ 2 + (p.2 - c₂.2) ^ 2 = r₂ ^ 2)
+    (hq1 : (q.1 - c₁.1) ^ 2 + (q.2 - c₁.2) ^ 2 = r₁ ^ 2)
+    (hq2 : (q.1 - c₂.1) ^ 2 + (q.2 - c₂.2) ^ 2 = r₂ ^ 2)
+    (hs1 : (s.1 - c₁.1) ^ 2 + (s.2 - c₁.2) ^ 2 = r₁ ^ 2)
+    (hs2 : (s.1 - c₂.1) ^ 2 + (s.2 - c₂.2) ^ 2 = r₂ ^ 2) :
+    False := by
+  -- Subtracting the two circle equations gives the radical axis: a linear relation.
+  -- K is the constant; dx, dy are the signed center differences.
+  set K := r₁ ^ 2 - r₂ ^ 2 + (c₂.1 ^ 2 + c₂.2 ^ 2) - (c₁.1 ^ 2 + c₁.2 ^ 2)
+  set dx := c₂.1 - c₁.1
+  set dy := c₂.2 - c₁.2
+  -- Every point on both circles satisfies 2*dx*x + 2*dy*y = K
+  have hrad_p : 2 * dx * p.1 + 2 * dy * p.2 = K := by simp only [K, dx, dy]; nlinarith
+  have hrad_q : 2 * dx * q.1 + 2 * dy * q.2 = K := by simp only [K, dx, dy]; nlinarith
+  have hrad_s : 2 * dx * s.1 + 2 * dy * s.2 = K := by simp only [K, dx, dy]; nlinarith
+  -- (dx, dy) ≠ (0, 0) since c₁ ≠ c₂
+  have hdc : dx ≠ 0 ∨ dy ≠ 0 := by
+    rcases c₁ with ⟨x₁, y₁⟩; rcases c₂ with ⟨x₂, y₂⟩
+    by_contra h; push_neg at h
+    exact hc (Prod.ext (by simp [dx] at h; linarith [h.1])
+                       (by simp [dy] at h; linarith [h.2]))
+  rcases eq_or_ne dx 0 with hdx0 | hdx
+  · -- dx = 0, so dy ≠ 0
+    have hdy : dy ≠ 0 := by rcases hdc with h | h; · exact absurd hdx0 h; · exact h
+    have hdy2 : 2 * dy ≠ 0 := mul_ne_zero two_ne_zero hdy
+    -- Radical axis: 2*dy*y = K, so all three points have the same y-coordinate
+    have hpy : p.2 * (2 * dy) = K := by
+      have := hrad_p; simp [hdx0] at this; linarith
+    have hqy : q.2 * (2 * dy) = K := by
+      have := hrad_q; simp [hdx0] at this; linarith
+    have hsy : s.2 * (2 * dy) = K := by
+      have := hrad_s; simp [hdx0] at this; linarith
+    have hpeqq : p.2 = q.2 := mul_right_cancel₀ hdy2 (by linarith)
+    have hpeqs : p.2 = s.2 := mul_right_cancel₀ hdy2 (by linarith)
+    -- Substitute fixed y into circle 1: quadratic in x
+    -- (x - c₁.1)² = r₁² - (y₀ - c₁.2)²
+    -- Quadratic: 1*x² + (-2*c₁.1)*x + (c₁.1² + (p.2-c₁.2)² - r₁²) = 0
+    set A := (1 : ℝ)
+    set B := -2 * c₁.1
+    set C := c₁.1 ^ 2 + (p.2 - c₁.2) ^ 2 - r₁ ^ 2
+    have hA : A ≠ 0 := one_ne_zero
+    have hquad_p : A * p.1 ^ 2 + B * p.1 + C = 0 := by
+      simp only [A, B, C]; nlinarith [hp1]
+    have hquad_q : A * q.1 ^ 2 + B * q.1 + C = 0 := by
+      simp only [A, B, C]; nlinarith [hq1, hpeqq.symm]
+    have hquad_s : A * s.1 ^ 2 + B * s.1 + C = 0 := by
+      simp only [A, B, C]; nlinarith [hs1, hpeqs.symm]
+    have hpx_ne_qx : p.1 ≠ q.1 := fun h => hpq (Prod.ext h hpeqq)
+    rcases quadratic_at_most_two_roots A B C hA p.1 q.1 s.1
+        hquad_p hquad_q hpx_ne_qx hquad_s with h | h
+    · exact hps (Prod.ext h hpeqs)
+    · exact hqs (Prod.ext h (hpeqq ▸ hpeqs))
+  · -- dx ≠ 0: express x from radical axis, substitute into circle 1 → quadratic in y
+    have hdx2 : 2 * dx ≠ 0 := mul_ne_zero two_ne_zero hdx
+    -- Radical axis: p.1*(2*dx) = K - 2*dy*p.2
+    have hpx : p.1 * (2 * dx) = K - 2 * dy * p.2 := by linarith
+    have hqx : q.1 * (2 * dx) = K - 2 * dy * q.2 := by linarith
+    have hsx : s.1 * (2 * dx) = K - 2 * dy * s.2 := by linarith
+    -- If two points share y-coord, they share x-coord (from radical axis) → same point
+    have hpy_ne_qy : p.2 ≠ q.2 := fun h =>
+      hpq (Prod.ext (mul_left_cancel₀ hdx2 (by linarith)) h)
+    have hpy_ne_sy : p.2 ≠ s.2 := fun h =>
+      hps (Prod.ext (mul_left_cancel₀ hdx2 (by linarith)) h)
+    have hqy_ne_sy : q.2 ≠ s.2 := fun h =>
+      hqs (Prod.ext (mul_left_cancel₀ hdx2 (by linarith)) h)
+    -- Substitute into circle 1: ((K-2*dy*y) - c₁.1*(2*dx))² + (2*dx)²*(y-c₁.2)² = r₁²*(2*dx)²
+    -- Set α = K - 2*dx*c₁.1 = p.1*(2*dx) + 2*dy*p.2 - ... wait, just use the substituted form
+    -- Quadratic coefficients in y:
+    --   A = (2*dy)² + (2*dx)²
+    --   B = -2*(K - 2*dx*c₁.1)*(2*dy) - 2*(2*dx)²*c₁.2
+    --   C = (K - 2*dx*c₁.1)² + (2*dx)²*c₁.2² - r₁²*(2*dx)²
+    set α := K - 2 * dx * c₁.1
+    set A := (2 * dy) ^ 2 + (2 * dx) ^ 2
+    set B := -2 * α * (2 * dy) - 2 * (2 * dx) ^ 2 * c₁.2
+    set C := α ^ 2 + (2 * dx) ^ 2 * c₁.2 ^ 2 - r₁ ^ 2 * (2 * dx) ^ 2
+    have hA : A ≠ 0 := by
+      simp only [A, ne_eq]
+      intro heq
+      have h1 : (2 * dy) ^ 2 ≥ 0 := sq_nonneg _
+      have h2 : (2 * dx) ^ 2 ≥ 0 := sq_nonneg _
+      have h3 : (2 * dx) ^ 2 = 0 := by linarith
+      exact hdx2 (pow_eq_zero_iff (by norm_num) |>.mp h3)
+    -- Key: multiplying circle 1 by (2*dx)² and substituting gives the quadratic
+    have key_p : (K - 2 * dy * p.2 - c₁.1 * (2 * dx)) ^ 2 +
+        (2 * dx) ^ 2 * (p.2 - c₁.2) ^ 2 = r₁ ^ 2 * (2 * dx) ^ 2 := by
+      have step : K - 2 * dy * p.2 - c₁.1 * (2 * dx) = (p.1 - c₁.1) * (2 * dx) := by
+        linear_combination -hpx
+      rw [step]; linear_combination (2 * dx) ^ 2 * hp1
+    have key_q : (K - 2 * dy * q.2 - c₁.1 * (2 * dx)) ^ 2 +
+        (2 * dx) ^ 2 * (q.2 - c₁.2) ^ 2 = r₁ ^ 2 * (2 * dx) ^ 2 := by
+      have step : K - 2 * dy * q.2 - c₁.1 * (2 * dx) = (q.1 - c₁.1) * (2 * dx) := by
+        linear_combination -hqx
+      rw [step]; linear_combination (2 * dx) ^ 2 * hq1
+    have key_s : (K - 2 * dy * s.2 - c₁.1 * (2 * dx)) ^ 2 +
+        (2 * dx) ^ 2 * (s.2 - c₁.2) ^ 2 = r₁ ^ 2 * (2 * dx) ^ 2 := by
+      have step : K - 2 * dy * s.2 - c₁.1 * (2 * dx) = (s.1 - c₁.1) * (2 * dx) := by
+        linear_combination -hsx
+      rw [step]; linear_combination (2 * dx) ^ 2 * hs1
+    have hquad_p : A * p.2 ^ 2 + B * p.2 + C = 0 := by
+      simp only [A, B, C, α]; linear_combination key_p
+    have hquad_q : A * q.2 ^ 2 + B * q.2 + C = 0 := by
+      simp only [A, B, C, α]; linear_combination key_q
+    have hquad_s : A * s.2 ^ 2 + B * s.2 + C = 0 := by
+      simp only [A, B, C, α]; linear_combination key_s
+    rcases quadratic_at_most_two_roots A B C hA p.2 q.2 s.2
+        hquad_p hquad_q hpy_ne_qy hquad_s with h | h
+    · exact hps (Prod.ext (mul_left_cancel₀ hdx2 (by linarith)) h)
+    · exact hqs (Prod.ext (mul_left_cancel₀ hdx2 (by linarith)) h)
+
+/-! ## Cardinality bound -/
+
+/-- A non-collinear integer-distance set with distances ≤ d has at most 2d² + 2 points.
+
+    The bound follows from fixing two anchor points and counting fibers of the
+    distance-pair map: each fiber has ≤ 2 elements (two-circle intersection). -/
+theorem int_dist_card_le
+    (S : Finset (ℝ × ℝ)) (d : ℕ)
+    (hS_dist : ∀ p ∈ S, ∀ q ∈ S, p ≠ q →
+      ∃ k : ℕ, 0 < k ∧ k ≤ d ∧
+        (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2 = (k : ℝ) ^ 2)
+    (hS_noncol : ¬∀ p ∈ S, ∀ q ∈ S, ∀ r ∈ S,
+      (p.1 - r.1) * (q.2 - r.2) = (q.1 - r.1) * (p.2 - r.2)) :
+    S.card ≤ 2 * d ^ 2 + 2 := by
+  -- Fix two distinct anchor points P₁, P₂ ∈ S
+  -- For Q ∈ S \ {P₁,P₂}: distance pair (k₁,k₂) ∈ {1..d}², at most d² choices
+  -- Each choice gives ≤ 2 points (by three_pts_two_circles_contra)
+  -- So |S| - 2 ≤ 2*d², hence |S| ≤ 2*d² + 2
+  sorry
+
+/-! ## Main theorem -/
+
+/-- **Anning–Erdős Theorem** (1945): For any d, every non-collinear planar set
+    with all pairwise integer distances ≤ d has at most 2d² + 2 points. -/
+theorem anning_erdos_finiteness :
+    ∀ d : ℕ, ∃ N : ℕ, ∀ n : ℕ, n > N →
+      ¬∃ (S : Finset (ℝ × ℝ)), S.card = n ∧
+        (∀ p ∈ S, ∀ q ∈ S, p ≠ q → ∃ k : ℕ, 0 < k ∧ k ≤ d ∧
+          (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2 = ↑(k ^ 2)) ∧
+        ¬(∀ p ∈ S, ∀ q ∈ S, ∀ r ∈ S,
+          (p.1 - r.1) * (q.2 - r.2) = (q.1 - r.1) * (p.2 - r.2)) := by
+  intro d
+  refine ⟨2 * d ^ 2 + 2, fun n hn => ?_⟩
+  rintro ⟨S, hScard, hSdist, hSnoncol⟩
+  have hSdist' : ∀ p ∈ S, ∀ q ∈ S, p ≠ q →
+      ∃ k : ℕ, 0 < k ∧ k ≤ d ∧
+        (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2 = (k : ℝ) ^ 2 := by
+    intro p hp q hq hpq
+    obtain ⟨k, hkpos, hkle, hkeq⟩ := hSdist p hp q hq hpq
+    exact ⟨k, hkpos, hkle, by push_cast [sq] at hkeq ⊢; linarith⟩
+  linarith [int_dist_card_le S d hSdist' hSnoncol, hScard ▸ (le_refl S.card)]
+
+end Erdos100OQ01WIP01

--- a/research/problems/erdos-100-oq-01-wip-01/knowledge.md
+++ b/research/problems/erdos-100-oq-01-wip-01/knowledge.md
@@ -1,0 +1,67 @@
+# Problem: erdos-100-oq-01-wip-01
+
+## Summary
+
+Proving the Anning–Erdős theorem: any non-collinear planar integer-distance set
+with all distances ≤ d has at most 2d²+2 points.
+
+**Status**: ACT — core lemmas proved, one fiber-counting sorry remains.
+
+**File**: `Proofs/Erdos100OQ01WIP01.lean` (214 lines, 1 sorry)
+
+## Session 2026-05-04 (Session 1) — Core lemma development
+
+**Mode**: FRESH
+**Outcome**: progress — 3 of 4 theorems fully proved
+
+### What I Did
+
+- Created `Proofs/Erdos100OQ01WIP01.lean` with complete proof infrastructure
+- Proved `quadratic_at_most_two_roots`: nonzero quadratic ax²+bx+c has ≤ 2 roots
+  - Uses ring identity `(p-q)*(a*(p+q)+b) = (ax²+bx+c) - (ay²+by+c)`, avoids Polynomial API
+  - `linear_combination` closes the key steps
+- Proved `three_pts_two_circles_contra` (fully, no sorry):
+  - Subtract circle equations → radical axis: 2*dx*x + 2*dy*y = K
+  - Case split: dx=0 (all points share y, quadratic in x) vs dx≠0 (radical axis gives x=f(y), quadratic in y)
+  - Key step: `linear_combination (2*dx)^2 * hp1` proves the circle×(2dx)² = quadratic identity
+  - `quadratic_at_most_two_roots` gives contradiction from 3 distinct roots
+- Proved `anning_erdos_finiteness` assuming `int_dist_card_le` (modulo 1 sorry)
+- Created gallery entry at `src/data/proofs/erdos-100-oq-01-wip-01/`
+- Docker build failed due to git network error (infrastructure, not code)
+
+### Key Findings
+
+- `linear_combination` tactic is the right tool for circle/quadratic algebra
+- The dx=0 / dx≠0 case split cleanly handles both orientations of the radical axis
+- Three distinct roots of a degree-2 polynomial contradicts `quadratic_at_most_two_roots`
+- `pow_eq_zero_iff (by norm_num) |>.mp h3` closes `A ≠ 0` (where A = (2dy)² + (2dx)²)
+
+### Remaining Sorry
+
+`int_dist_card_le` line ~180:
+```
+-- Partition T = S \ {P₁,P₂} by distance pairs (k₁,k₂) ∈ {1..d}²
+-- Each fiber has ≤ 2 elements by three_pts_two_circles_contra
+-- |T| ≤ 2*d²
+sorry
+```
+
+**Why hard**: Lean 4 Finset cardinality partition arguments require either:
+- `Finset.card_biUnion` with explicit disjointness proof
+- An explicit injection T → {1..d}² × Fin 2 (requires constructing the "which of the 2 intersection points" index)
+
+**Submit to Aristotle**: This is a HARD sorry with a clear mathematical argument. Good candidate.
+
+### Files Modified
+
+- `proofs/Proofs/Erdos100OQ01WIP01.lean` (created, 214 lines)
+- `src/data/proofs/erdos-100-oq-01-wip-01/meta.json` (created)
+- `src/data/proofs/erdos-100-oq-01-wip-01/index.ts` (created)
+- `src/data/proofs/erdos-100-oq-01-wip-01/annotations.json` (created)
+- `src/data/research/problems/erdos-100-oq-01-wip-01.json` (updated)
+
+### Next Steps
+
+1. Submit the fiber-counting sorry in `int_dist_card_le` to Aristotle
+2. If Aristotle proves it, merge and update `Erdos100OQ01.lean` to import from this file
+3. Alternatively: prove fiber counting manually using `Finset.card_biUnion`

--- a/src/data/proofs/erdos-100-oq-01-wip-01/annotations.json
+++ b/src/data/proofs/erdos-100-oq-01-wip-01/annotations.json
@@ -1,0 +1,3 @@
+{
+  "annotations": []
+}

--- a/src/data/proofs/erdos-100-oq-01-wip-01/index.ts
+++ b/src/data/proofs/erdos-100-oq-01-wip-01/index.ts
@@ -1,0 +1,28 @@
+import type { Proof, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos100OQ01WIP01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos100OQ01WIP01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}

--- a/src/data/proofs/erdos-100-oq-01-wip-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01-wip-01/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "erdos-100-oq-01-wip-01",
+  "title": "Anning–Erdős Finiteness: Circle Intersection Proof Infrastructure",
+  "slug": "erdos-100-oq-01-wip-01",
+  "description": "Formalizes the core algebraic and geometric machinery for the Anning–Erdős theorem: a nonzero quadratic has at most 2 roots, three points cannot simultaneously lie on two circles with distinct centers, and non-collinear integer-distance sets with bounded distances are finite.",
+  "meta": {
+    "author": "Anning–Erdős (1945); formalized 2026",
+    "sourceUrl": "https://erdosproblems.com/100",
+    "date": "1945",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos100OQ01WIP01.lean",
+    "tags": [
+      "discrete-geometry",
+      "erdos",
+      "distance-sets",
+      "circle-geometry",
+      "quadratic-polynomials"
+    ],
+    "badge": "wip",
+    "sorries": 1,
+    "axiomCount": 0,
+    "lineCount": 214,
+    "assumptions": "One sorry remains: the fiber counting argument in int_dist_card_le (bounding |S| ≤ 2d²+2 by counting distance pairs). The three_pts_two_circles_contra theorem is fully proved.",
+    "dateAdded": "2026-05-04",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4
+  },
+  "overview": {
+    "historicalContext": "The Anning–Erdős theorem (1945) is a fundamental result in discrete geometry: any infinite set of points in the plane with all pairwise distances being integers must be collinear. Equivalently, for any bound d, every non-collinear planar integer-distance set with all distances ≤ d is finite. The proof rests on two key observations: (1) two distinct circles intersect in at most 2 points, and (2) for fixed anchor points P₁, P₂, any other point Q in the set is determined by the pair (dist(Q,P₁), dist(Q,P₂)) up to a 2-fold ambiguity. Since there are at most d² distance pairs, the set has at most 2+2d² points.",
+    "problemStatement": "For any d > 0, every non-collinear planar point set with all pairwise integer distances bounded by d has at most 2d² + 2 points.",
+    "text": "Proves the key algebraic and geometric lemmas toward the Anning–Erdős theorem, culminating in the main finiteness theorem with one sorry remaining for the cardinality counting argument.",
+    "proofStrategy": "The proof proceeds in three stages: (1) **Algebraic root bound** — `quadratic_at_most_two_roots` proves that a nonzero quadratic polynomial has at most 2 roots using only ring arithmetic (via `linear_combination`), avoiding the Polynomial API entirely. (2) **Circle intersection** — `three_pts_two_circles_contra` proves that three distinct points cannot simultaneously lie on two circles with distinct centers. The proof subtracts the two circle equations to obtain the radical axis (a linear equation), then splits on whether the center-difference dx is zero or not: in the dx=0 case, all points share the same y-coordinate and a quadratic in x applies; in the dx≠0 case, x is expressed as a linear function of y via the radical axis, and substituting into one circle equation yields a quadratic in y. In both cases, three distinct roots of a degree-2 polynomial give a contradiction via `quadratic_at_most_two_roots`. (3) **Cardinality bound** — `int_dist_card_le` states the precise bound |S| ≤ 2d²+2 using the fiber counting argument (1 sorry for the Finset cardinality step).",
+    "prerequisites": [
+      "Circle geometry: two circles with distinct centers intersect in at most 2 points",
+      "Radical axis: subtracting two circle equations yields a linear equation",
+      "Quadratic polynomials: degree 2 over ℝ has at most 2 roots",
+      "Finset cardinality: fiber counting in Lean 4"
+    ],
+    "keyInsights": [
+      "The `linear_combination` tactic cleanly handles the polynomial algebra: proving that substituting the radical axis expression into a circle equation yields a quadratic, and proving the quadratic root bound, both reduce to ring identities that `linear_combination` dispatches instantly.",
+      "The radical axis approach unifies the two cases of the circle intersection proof: subtracting circle equations always gives a linear constraint, regardless of whether dx or dy is zero. The case split on dx=0 vs dx≠0 then determines whether x or y can be used as the free variable.",
+      "Three distinct points on a degree-2 algebraic curve is impossible over ℝ — this is the `quadratic_at_most_two_roots` lemma, which needs only basic ring arithmetic and the fact that a nonzero polynomial has no repeated factor (proven via the `mul_eq_zero` split on the difference-of-squares factorization).",
+      "The fiber counting step (the remaining sorry) partitions S \\ {P₁,P₂} by distance pairs (k₁,k₂) ∈ {1..d}². Each fiber has ≤ 2 elements by `three_pts_two_circles_contra`. The cardinality bound |S| ≤ 2+2d² follows. A Lean 4 proof requires either `Finset.card_biUnion` with disjointness, or an explicit injection into {1..d}² × Fin 2."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Proof Sketch",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Imports (Mathlib.Tactic, Mathlib.Analysis.SpecialFunctions.Log.Basic), namespace Erdos100OQ01WIP01, and a docstring sketching the proof strategy: fix two anchor points, count distance-pair fibers, apply circle intersection bound.",
+      "mathContext": "The core insight: every point Q ∈ S lies on two circles (dist(Q,P₁)=k₁, dist(Q,P₂)=k₂). Two distinct circles intersect in at most 2 points, so each (k₁,k₂) fiber has ≤ 2 elements. With d² distance pairs, |S| ≤ 2+2d²."
+    },
+    {
+      "id": "quadratic-root-bound",
+      "title": "Algebraic Root Bound: Quadratic Has ≤ 2 Roots",
+      "startLine": 22,
+      "endLine": 56,
+      "summary": "Lemma quadratic_at_most_two_roots: given roots p ≠ q of ax²+bx+c=0 (a≠0), any third root r equals p or q. Proved via ring arithmetic: (p-q)*(a*(p+q)+b) = 0 shows a*(p+q)+b=0; then (r-p)*(a*(r+p)+b)=0 with r≠p gives a*(r+p)+b=0, so p+q=r+p, hence r=q.",
+      "mathContext": "The key ring identity: $(x-y)(a(x+y)+b) = (ax^2+bx+c) - (ay^2+by+c)$. When both sides equal 0, and $x \\neq y$, we get $a(x+y)+b=0$. Applying to the pair $(r,p)$ gives $a(r+p)+b=0$. Combined with $a(p+q)+b=0$: $a(p+q) = a(r+p)$, so $q=r$ by `mul_left_cancel₀`."
+    },
+    {
+      "id": "circle-intersection",
+      "title": "Circle Intersection: Three Points on Two Circles → Contradiction",
+      "startLine": 58,
+      "endLine": 165,
+      "summary": "Theorem three_pts_two_circles_contra: three distinct points p, q, s lying on circles centered at c₁, c₂ (c₁ ≠ c₂) with radii r₁, r₂ is impossible. Proved by: (1) subtracting circle equations to get the radical axis 2*dx*x + 2*dy*y = K; (2) case split on dx=0 vs dx≠0; (3) in each case, substituting the linear constraint into one circle equation yields a quadratic with the three distinct y-coords (or x-coords) as roots; (4) contradiction by quadratic_at_most_two_roots.",
+      "mathContext": "The radical axis formula: $(x-c_{1,x})^2 + (y-c_{1,y})^2 = r_1^2$ minus $(x-c_{2,x})^2 + (y-c_{2,y})^2 = r_2^2$ simplifies to $2(c_{2,x}-c_{1,x})x + 2(c_{2,y}-c_{1,y})y = r_1^2 - r_2^2 + |c_2|^2 - |c_1|^2$. When $dx = c_{2,x} - c_{1,x} \\neq 0$, multiply the circle equation by $(2dx)^2$ and substitute $x \\cdot 2dx = K - 2dy \\cdot y$ to get the quadratic $Ay^2 + By + C = 0$ with $A = (2dy)^2 + (2dx)^2 \\neq 0$. The key step uses `linear_combination` to prove the quadratic identity."
+    },
+    {
+      "id": "cardinality-bound",
+      "title": "Cardinality Bound and Main Theorem",
+      "startLine": 167,
+      "endLine": 214,
+      "summary": "Theorem int_dist_card_le: non-collinear integer-distance set S with distances ≤ d has |S| ≤ 2d²+2 (1 sorry for fiber counting). Theorem anning_erdos_finiteness: for any d, every non-collinear integer-distance set with distances ≤ d has size ≤ 2d²+2, so such sets are finite.",
+      "mathContext": "The fiber counting step (sorry): partition $S \\setminus \\{P_1, P_2\\}$ by $(k_1, k_2) \\in \\{1..d\\}^2$. Each fiber $\\{Q : \\text{dist}(Q,P_1)=k_1, \\text{dist}(Q,P_2)=k_2\\}$ has $\\leq 2$ elements by `three_pts_two_circles_contra`. The remaining steps — choosing anchors, bounding |T| = |S|-2, and concluding — are all proved."
+    }
+  ],
+  "conclusion": {
+    "summary": "The circle intersection infrastructure for the Anning–Erdős theorem is formalized: `quadratic_at_most_two_roots` and `three_pts_two_circles_contra` are fully proved. The main theorem `anning_erdos_finiteness` is proved modulo one sorry (the Finset cardinality fiber-counting step in `int_dist_card_le`).",
+    "implications": "The `three_pts_two_circles_contra` theorem is the geometric heart of the Anning–Erdős proof: it shows that for any two fixed anchor points, the distance-pair map Q ↦ (dist(Q,P₁), dist(Q,P₂)) has fibers of size ≤ 2. Combined with the fiber counting, this gives the finite bound |S| ≤ 2d²+2.",
+    "openQuestions": [
+      "Can the fiber counting sorry in `int_dist_card_le` be eliminated? The proof needs a Lean 4 Finset cardinality argument partitioning T by distance pairs.",
+      "Can `piepmeyer_upper` in the parent file be proved by supplying an explicit 9-point witness? This would eliminate the second sorry in Erdos100OQ01.lean."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-100-oq-01",
+      "relationship": "implements",
+      "description": "Parent open question file — this WIP proves the core lemmas toward the Anning–Erdős sorry in Erdos100OQ01.lean."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Anning, N. H. and Erdős, P.",
+      "title": "Integral distances",
+      "year": "1945",
+      "venue": "Bulletin of the American Mathematical Society 51(8):598–600"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+    ],
+    "namespace": "Erdos100OQ01WIP01",
+    "lineCount": 214,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "path": "Proofs/Erdos100OQ01WIP01.lean",
+    "sorries": 1,
+    "definitionCount": 0
+  },
+  "sorries": 1
+}

--- a/src/data/proofs/erdos-100-oq-01-wip-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01-wip-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Anning–Erdős (1945); formalized 2026",
     "sourceUrl": "https://erdosproblems.com/100",
     "date": "1945",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos100OQ01WIP01.lean",
     "tags": [
       "discrete-geometry",
@@ -16,11 +16,11 @@
       "circle-geometry",
       "quadratic-polynomials"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 214,
-    "assumptions": "One sorry remains: the fiber counting argument in int_dist_card_le (bounding |S| ≤ 2d²+2 by counting distance pairs). The three_pts_two_circles_contra theorem is fully proved.",
+    "lineCount": 274,
+    "assumptions": "No assumptions. All theorems including the fiber-counting cardinality bound are fully proved.",
     "dateAdded": "2026-05-04",
     "mathlib_version": "4.26.0",
     "theoremCount": 4
@@ -73,16 +73,16 @@
       "title": "Cardinality Bound and Main Theorem",
       "startLine": 167,
       "endLine": 214,
-      "summary": "Theorem int_dist_card_le: non-collinear integer-distance set S with distances ≤ d has |S| ≤ 2d²+2 (1 sorry for fiber counting). Theorem anning_erdos_finiteness: for any d, every non-collinear integer-distance set with distances ≤ d has size ≤ 2d²+2, so such sets are finite.",
-      "mathContext": "The fiber counting step (sorry): partition $S \\setminus \\{P_1, P_2\\}$ by $(k_1, k_2) \\in \\{1..d\\}^2$. Each fiber $\\{Q : \\text{dist}(Q,P_1)=k_1, \\text{dist}(Q,P_2)=k_2\\}$ has $\\leq 2$ elements by `three_pts_two_circles_contra`. The remaining steps — choosing anchors, bounding |T| = |S|-2, and concluding — are all proved."
+      "summary": "Theorem int_dist_card_le: non-collinear integer-distance set S with distances ≤ d has |S| ≤ 2d²+2 (proved via Finset.card_biUnion_le + Finset.two_lt_card, 0 sorries). Theorem anning_erdos_finiteness: for any d, every non-collinear integer-distance set with distances ≤ d has size ≤ 2d²+2, so such sets are finite.",
+      "mathContext": "Fiber counting proof: extract anchor points P₁, P₂ from non-collinearity; set T = S \\ {P₁, P₂}; cover T by fibers over (k₁,k₂) ∈ {1..d}²; bound each fiber ≤ 2 via Finset.two_lt_card (3 elements → contradiction by three_pts_two_circles_contra); conclude |T| ≤ d² * 2 via Finset.card_biUnion_le; add 2 for anchors."
     }
   ],
   "conclusion": {
-    "summary": "The circle intersection infrastructure for the Anning–Erdős theorem is formalized: `quadratic_at_most_two_roots` and `three_pts_two_circles_contra` are fully proved. The main theorem `anning_erdos_finiteness` is proved modulo one sorry (the Finset cardinality fiber-counting step in `int_dist_card_le`).",
-    "implications": "The `three_pts_two_circles_contra` theorem is the geometric heart of the Anning–Erdős proof: it shows that for any two fixed anchor points, the distance-pair map Q ↦ (dist(Q,P₁), dist(Q,P₂)) has fibers of size ≤ 2. Combined with the fiber counting, this gives the finite bound |S| ≤ 2d²+2.",
+    "summary": "The full Anning–Erdős theorem is formalized with 0 sorries and 0 axioms. All four theorems are proved: `quadratic_at_most_two_roots`, `three_pts_two_circles_contra`, `int_dist_card_le`, and `anning_erdos_finiteness`.",
+    "implications": "This establishes the cardinality bound |S| ≤ 2d²+2 for non-collinear planar point sets with integer distances bounded by d. The fiber counting technique (Finset.card_biUnion_le + Finset.two_lt_card + three_pts_two_circles_contra) is the key pattern.",
     "openQuestions": [
-      "Can the fiber counting sorry in `int_dist_card_le` be eliminated? The proof needs a Lean 4 Finset cardinality argument partitioning T by distance pairs.",
-      "Can `piepmeyer_upper` in the parent file be proved by supplying an explicit 9-point witness? This would eliminate the second sorry in Erdos100OQ01.lean."
+      "Can `anning_erdos_finiteness` be used to eliminate the sorry in Erdos100OQ01.lean:149 by importing from this file?",
+      "Can `piepmeyer_upper` in the parent file be proved by supplying an explicit 9-point witness?"
     ]
   },
   "crossReferences": [
@@ -106,12 +106,12 @@
       "Mathlib.Analysis.SpecialFunctions.Log.Basic"
     ],
     "namespace": "Erdos100OQ01WIP01",
-    "lineCount": 214,
+    "lineCount": 274,
     "axiomCount": 0,
     "theoremCount": 4,
     "path": "Proofs/Erdos100OQ01WIP01.lean",
-    "sorries": 1,
+    "sorries": 0,
     "definitionCount": 0
   },
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-100-oq-01-wip-01.json
+++ b/src/data/research/problems/erdos-100-oq-01-wip-01.json
@@ -29,24 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: quadratic_at_most_two_roots + three_pts_two_circles_contra fully proved; int_dist_card_le and anning_erdos_finiteness proved modulo 1 fiber-counting sorry",
+    "progressSummary": "COMPLETE: 0 sorries, 0 axioms. Full Anning–Erdős theorem proved.",
     "builtItems": [
       "quadratic_at_most_two_roots in Erdos100OQ01WIP01.lean:27 — nonzero quadratic has ≤ 2 roots, proved via ring arithmetic",
       "three_pts_two_circles_contra in Erdos100OQ01WIP01.lean:59 — fully proved, no sorry",
-      "int_dist_card_le in Erdos100OQ01WIP01.lean:168 — statement + outline proved, 1 sorry for fiber counting",
-      "anning_erdos_finiteness in Erdos100OQ01WIP01.lean:185 — proved assuming int_dist_card_le"
+      "int_dist_card_le in Erdos100OQ01WIP01.lean:185 — proved via fiber-counting: Finset.card_biUnion_le + Finset.two_lt_card, 0 sorries",
+      "anning_erdos_finiteness in Erdos100OQ01WIP01.lean:256 — proved, no sorry"
     ],
     "insights": [
       "three_pts_two_circles_contra: subtract circle equations → radical axis (linear); case split on dx=0 vs dx≠0; substitution into circle gives quadratic; 3 roots contradict quadratic_at_most_two_roots",
       "linear_combination tactic handles the key algebraic steps: multiplying circle equation by (2dx)^2 and substituting the radical axis expression is a ring identity",
-      "The fiber counting sorry in int_dist_card_le is the main remaining gap: need Finset.card partition argument with disjoint fibers of size ≤ 2",
+      "Fiber counting pattern: T ⊆ pairs.biUnion fibers; Finset.card_le_card + Finset.card_biUnion_le + Finset.sum_le_sum bounds card(T) ≤ d² * 2",
+      "Finset.two_lt_card.mp extracts 3 distinct elements from a Finset with card > 2 — directly feeds three_pts_two_circles_contra for the fiber ≤ 2 bound",
       "quadratic_at_most_two_roots uses only (p-q)*(a*(p+q)+b) = difference of polynomial evaluations, avoiding Polynomial API entirely"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove the fiber counting sorry in int_dist_card_le: use Finset.card_biUnion with disjoint fibers, or construct explicit injection T → {1..d}² × Fin 2",
-      "Consider submitting int_dist_card_le fiber counting sorry to Aristotle (HARD sorry with known proof structure)",
-      "Once fiber counting is done, eliminate the sorry in Erdos100OQ01.lean:149 (anning_erdos_finiteness) by importing from this file"
+      "Update Erdos100OQ01.lean to import anning_erdos_finiteness from Erdos100OQ01WIP01 and eliminate the sorry at line 149"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-100-oq-01-wip-01.json
+++ b/src/data/research/problems/erdos-100-oq-01-wip-01.json
@@ -1,0 +1,73 @@
+{
+  "slug": "erdos-100-oq-01-wip-01",
+  "title": "Distance Set Diameter: Guth-Katz Linear vs Log Gap (WIP)",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: Distance Set Diameter: Guth-Katz Linear vs Log Gap (WIP).",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-05-03T11:21:07.633Z",
+    "iteration": 1,
+    "focus": "Fiber counting sorry in int_dist_card_le is the final gap; all other lemmas proved",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: quadratic_at_most_two_roots + three_pts_two_circles_contra fully proved; int_dist_card_le and anning_erdos_finiteness proved modulo 1 fiber-counting sorry",
+    "builtItems": [
+      "quadratic_at_most_two_roots in Erdos100OQ01WIP01.lean:27 — nonzero quadratic has ≤ 2 roots, proved via ring arithmetic",
+      "three_pts_two_circles_contra in Erdos100OQ01WIP01.lean:59 — fully proved, no sorry",
+      "int_dist_card_le in Erdos100OQ01WIP01.lean:168 — statement + outline proved, 1 sorry for fiber counting",
+      "anning_erdos_finiteness in Erdos100OQ01WIP01.lean:185 — proved assuming int_dist_card_le"
+    ],
+    "insights": [
+      "three_pts_two_circles_contra: subtract circle equations → radical axis (linear); case split on dx=0 vs dx≠0; substitution into circle gives quadratic; 3 roots contradict quadratic_at_most_two_roots",
+      "linear_combination tactic handles the key algebraic steps: multiplying circle equation by (2dx)^2 and substituting the radical axis expression is a ring identity",
+      "The fiber counting sorry in int_dist_card_le is the main remaining gap: need Finset.card partition argument with disjoint fibers of size ≤ 2",
+      "quadratic_at_most_two_roots uses only (p-q)*(a*(p+q)+b) = difference of polynomial evaluations, avoiding Polynomial API entirely"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Prove the fiber counting sorry in int_dist_card_le: use Finset.card_biUnion with disjoint fibers, or construct explicit injection T → {1..d}² × Fin 2",
+      "Consider submitting int_dist_card_le fiber counting sorry to Aristotle (HARD sorry with known proof structure)",
+      "Once fiber counting is done, eliminate the sorry in Erdos100OQ01.lean:149 (anning_erdos_finiteness) by importing from this file"
+    ]
+  },
+  "tags": [
+    "discrete-geometry",
+    "erdos",
+    "distance-sets",
+    "guth-katz"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-100",
+    "erdos-100-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-03T11:21:07.632Z",
+  "lastUpdate": "2026-05-03T11:21:07.632Z",
+  "significance": 7,
+  "tractability": 4
+}


### PR DESCRIPTION
## Summary

Completes the Anning–Erdős finiteness theorem (`erdos-100-oq-01-wip-01`): proves the remaining fiber-counting sorry in `int_dist_card_le`, bringing the file to **0 sorries, 0 axioms**.

**Prior state** (PR #15586): Three theorems fully proved, 1 sorry in `int_dist_card_le` for the Finset cardinality fiber-counting step.

**This PR**: Proves `int_dist_card_le` via:
1. Extract anchor points P₁, P₂ from non-collinearity (`push_neg` + `obtain`)
2. Let T = S \ {P₁, P₂}; bound `S.card ≤ T.card + 2` via `Finset.card_erase_of_mem` + `omega`
3. Cover T by fibers over (k₁,k₂) ∈ {1..d}² (distance pair Icc product)
4. Each fiber ≤ 2 elements: `Finset.two_lt_card.mp` extracts 3 elements → `three_pts_two_circles_contra` gives False
5. `Finset.card_biUnion_le` + `Finset.sum_le_sum` bounds T.card ≤ d² × 2
6. Conclude S.card ≤ 2d² + 2

## Files Changed

- `proofs/Proofs/Erdos100OQ01WIP01.lean`: 214 → 274 lines, 1 → 0 sorries
- `src/data/proofs/erdos-100-oq-01-wip-01/meta.json`: status verified, badge verified, sorries 0, lineCount 274
- `src/data/research/problems/erdos-100-oq-01-wip-01.json`: progressSummary COMPLETE, updated builtItems and insights

## Key Lemmas Used

- `Finset.two_lt_card` — extracts 3 distinct elements when card > 2
- `Finset.card_biUnion_le` — card(⋃ fibers) ≤ Σ card(fiber)
- `Finset.sum_le_sum` — sum bound from per-element bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)