### PR TITLE
audit: tracker sync — 1 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14245,6 +14245,12 @@
       "lastAudited": "2026-05-04T10:06:24Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T10:28:50Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit Tracker Sync

### Audits Completed This Cycle

| Proof | Result | Details |
|-------|--------|---------|
| `borsuk-ulam-oq-02-oq-01-oq-01-oq-02` | issues-found | axiomCount discrepancy filed as #15600 |

### dirichlets-theorem-oq-01-oq-01
Already in tracker from previous session (issues-fixed). Proof correctly labeled axiomatized/axiom, previous fix confirmed on PR branch.

### borsuk-ulam-oq-02-oq-01-oq-01-oq-02 (PR #15583)
- `meta.axiomCount: 4` → should be 5 (4 from OQ02OQ01 + 1 buDim_le_formula from OQ02OQ01OQ01)
- `leanFile.axiomCount: 4` → should be 0 (no axioms declared in this file itself)
- Assumptions text says "4 axioms" but lists 5
- Filed issue #15600 for mechanic fix
- Proof correctly labeled axiomatized/axiom, no sorry issues

🤖 Generated with Claude Code