### PR TITLE
research(puiseux-theorem-oq-02): add gallery entry for multivariate Puiseux series

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-02/annotations.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/annotations.json
@@ -1,47 +1,122 @@
 [
   {
+    "id": "puiseux-oq02-context",
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 5, "endLine": 46 },
+    "type": "context",
+    "title": "Multivariate Puiseux: Iteration Handles the Ordering Problem",
+    "content": "The natural question after the univariate Puiseux theorem is: what is the algebraic closure of K((x₁,...,xₙ)), the Laurent series field in n variables? The naive answer — Hahn series over ℚⁿ — fails: not every Hahn series over an arbitrary ordered abelian group is algebraically closed. The correct answer (McDonald 1995, Aroca-Cano-Jung 2003) is the iterated construction K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄...⦃⦃xₙ⦄⦄, where the lexicographic ordering on the nested HahnSeries automatically gives a well-ordered support for the composite object. The key subtlety documented in this file is that order matters: each step applies Puiseux's theorem to the previous stage, and the resulting field is algebraically closed.",
+    "mathContext": "Goal: identify $\\overline{K((x_1,\\ldots,x_n))}$. Answer: $K\\{\\{x_1\\}\\}\\{\\{x_2\\}\\}\\cdots\\{\\{x_n\\}\\} := \\text{MultiHahnSeries}(n, K)$, defined by $\\text{MultiHahnSeries}(0, K) = K$ and $\\text{MultiHahnSeries}(n+1, K) = \\text{HahnSeries}(\\mathbb{Q}, \\text{MultiHahnSeries}(n, K))$.",
+    "significance": "context",
+    "relatedConcepts": ["Puiseux series", "Hahn series", "algebraic closure", "multivariate formal power series", "lexicographic ordering"],
+    "prerequisites": ["univariate Puiseux theorem", "formal Laurent series", "Hahn series definition", "algebraically closed fields"]
+  },
+  {
     "id": "ann-multihahn-def",
-    "line": 78,
-    "endLine": 80,
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 70, "endLine": 80 },
     "type": "definition",
     "title": "MultiHahnSeries: Iterated Puiseux Construction",
-    "body": "The iterated Hahn series type defined by recursion on depth n. At depth 0, the type is K itself (the coefficient field). At each successor depth, we wrap in HahnSeries ℚ — adding one more variable. This models the tower K ⊂ K⦃⦃x₁⦄⦄ ⊂ K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄ ⊂ ... of iterated Puiseux series fields. The ℚ exponents in HahnSeries ℚ provide the rational-power structure that characterizes Puiseux series.",
-    "math": "\\text{MultiHahnSeries}(0, K) = K, \\quad \\text{MultiHahnSeries}(n+1, K) = \\text{HahnSeries}(\\mathbb{Q}, \\text{MultiHahnSeries}(n, K))"
+    "content": "The iterated Hahn series type defined by recursion on depth n. At depth 0, the type is K itself (the coefficient field). At each successor depth, we wrap in HahnSeries ℚ — adding one more variable. This models the tower K ⊂ K⦃⦃x₁⦄⦄ ⊂ K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄ ⊂ ... of iterated Puiseux series fields. The ℚ exponents in HahnSeries ℚ provide the rational-power structure that characterizes Puiseux series.",
+    "mathContext": "$\\text{MultiHahnSeries}(0, K) = K$, $\\quad \\text{MultiHahnSeries}(n+1, K) = \\text{HahnSeries}(\\mathbb{Q}, \\text{MultiHahnSeries}(n, K))$. Models the tower $K \\subset K\\{\\{x_1\\}\\} \\subset K\\{\\{x_1\\}\\}\\{\\{x_2\\}\\} \\subset \\cdots$",
+    "significance": "key",
+    "relatedConcepts": ["Hahn series", "iterated construction", "type-level recursion in Lean 4", "Puiseux series tower"],
+    "prerequisites": ["HahnSeries ℚ in Mathlib", "Lean 4 def by recursion on ℕ", "Type* universe polymorphism"]
+  },
+  {
+    "id": "puiseux-dimensional-facts",
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 82, "endLine": 90 },
+    "type": "technique",
+    "title": "Dimensional Facts: Base, Single-Variable, and Successor Cases",
+    "content": "Three definitional equality theorems establish the concrete values of MultiHahnSeries. All three are proved by `rfl` — they are true by definition, so Lean's kernel verifies them without any proof terms. multiHahn_zero: MultiHahnSeries 0 K = K. multiHahn_one: MultiHahnSeries 1 K = HahnSeries ℚ K. multiHahn_succ: MultiHahnSeries (n+1) K = HahnSeries ℚ (MultiHahnSeries n K). The rfl proofs succeed because MultiHahnSeries is defined by pattern matching, and each case reduces to the right-hand side definitionally. These theorems serve as helper lemmas for rewriting in later proofs.",
+    "mathContext": "$\\text{MultiHahnSeries}(0, K) = K$ (base), $\\text{MultiHahnSeries}(1, K) = \\text{HahnSeries}(\\mathbb{Q}, K)$ (single-variable), $\\text{MultiHahnSeries}(n+1, K) = \\text{HahnSeries}(\\mathbb{Q}, \\text{MultiHahnSeries}(n, K))$ (successor). All proved by `rfl`.",
+    "significance": "supporting",
+    "relatedConcepts": ["definitional equality", "rfl tactic", "recursive type definition", "Lean 4 pattern matching"],
+    "prerequisites": ["Lean 4 definitional equality", "rfl tactic", "MultiHahnSeries definition"]
+  },
+  {
+    "id": "puiseux-zero-instance",
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 103, "endLine": 113 },
+    "type": "technique",
+    "title": "Zero Instance by Depth Induction",
+    "content": "The Zero instance for MultiHahnSeries n K is proved by induction on n. Base case: MultiHahnSeries 0 K = K (which has Zero by hypothesis `‹Zero K›`). Inductive step: assume Zero (MultiHahnSeries n K) via `ih`; add it as a local instance via `haveI : Zero (MultiHahnSeries n K) := ih`; then `exact inferInstance` — Mathlib's Zero instance for HahnSeries is found by typeclass inference. The `haveI` pattern is essential: Lean cannot automatically apply the induction hypothesis as a typeclass instance without this explicit local introduction.",
+    "mathContext": "Zero structure propagates: if $R$ has Zero, then $\\text{HahnSeries}(\\mathbb{Q}, R)$ has Zero (the zero Hahn series with empty support). By induction: $\\text{MultiHahnSeries}(n, K)$ has Zero for all $n$ when $K$ has Zero.",
+    "significance": "supporting",
+    "relatedConcepts": ["Zero typeclass", "haveI pattern in Lean 4", "typeclass inference", "inductive instance proofs"],
+    "prerequisites": ["Lean 4 instance proofs", "haveI tactic", "HahnSeries.instZero in Mathlib", "induction on ℕ"]
   },
   {
     "id": "ann-commring-induction",
-    "line": 123,
-    "endLine": 129,
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 115, "endLine": 129 },
     "type": "technique",
     "title": "CommRing Instance by Depth Induction",
-    "body": "The CommRing instance for MultiHahnSeries n K is proved by induction on n. The base case is K (already a CommRing by hypothesis). The inductive step works as follows: given the inductive hypothesis ih : CommRing (MultiHahnSeries n K), we add it as a local instance via `haveI`, then `exact inferInstance` — Lean's typeclass system automatically finds CommRing (HahnSeries ℚ (MultiHahnSeries n K)) from Mathlib's CommRing instance for HahnSeries. The pattern `haveI : CommRing ... := ih; exact inferInstance` is the canonical Lean 4 idiom for propagating instances through type-level recursion.",
-    "math": "R \\text{ CommRing} \\implies \\text{HahnSeries}(\\mathbb{Q}, R) \\text{ CommRing}"
+    "content": "The CommRing instance for MultiHahnSeries n K is proved by induction on n. The base case is K (already a CommRing by hypothesis). The inductive step works as follows: given the inductive hypothesis ih : CommRing (MultiHahnSeries n K), we add it as a local instance via `haveI`, then `exact inferInstance` — Lean's typeclass system automatically finds CommRing (HahnSeries ℚ (MultiHahnSeries n K)) from Mathlib's CommRing instance for HahnSeries. The pattern `haveI : CommRing ... := ih; exact inferInstance` is the canonical Lean 4 idiom for propagating instances through type-level recursion.",
+    "mathContext": "$R$ CommRing $\\Rightarrow \\text{HahnSeries}(\\mathbb{Q}, R)$ CommRing. By induction: $\\text{MultiHahnSeries}(n, K)$ is a CommRing for all $n \\geq 0$ when $K$ is a CommRing. The tower $K \\subset K\\{\\{x_1\\}\\} \\subset \\cdots$ consists of commutative rings at every level.",
+    "significance": "key",
+    "relatedConcepts": ["CommRing typeclass", "haveI in Lean 4", "HahnSeries.instCommRing", "typeclass propagation through iteration"],
+    "prerequisites": ["CommRing definition", "Lean 4 inductive proofs", "haveI pattern", "HahnSeries.instCommRing in Mathlib"]
   },
   {
     "id": "ann-ismulti-predicate",
-    "line": 148,
-    "endLine": 156,
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 145, "endLine": 156 },
     "type": "definition",
     "title": "IsMultiPuiseuxSeries: Levelwise Common-Denominator Condition",
-    "body": "The IsMultiPuiseuxSeries predicate characterizes which elements of MultiHahnSeries n K are genuine Puiseux series (as opposed to general Hahn series). At level 0 the condition is vacuous (True). At level n+1, two conditions must hold: (1) the outer exponents have a common denominator d — all elements of f.support are of the form k/d for integer k; (2) every coefficient f.coeff q is recursively a multi-Puiseux series at level n. This mirrors the mathematical definition: a multivariate Puiseux series is one where you can substitute xᵢ = tᵢ^(1/dᵢ) for suitable integers dᵢ to get a formal Laurent series.",
-    "math": "\\text{IsMultiPuiseux}(n+1, f) \\iff (\\exists d, \\forall q \\in \\text{supp}(f), q \\in d^{-1}\\mathbb{Z}) \\wedge (\\forall q, \\text{IsMultiPuiseux}(n, f_q))"
+    "content": "The IsMultiPuiseuxSeries predicate characterizes which elements of MultiHahnSeries n K are genuine Puiseux series (as opposed to general Hahn series). At level 0 the condition is vacuous (True). At level n+1, two conditions must hold: (1) the outer exponents have a common denominator d — all elements of f.support are of the form k/d for integer k; (2) every coefficient f.coeff q is recursively a multi-Puiseux series at level n. This mirrors the mathematical definition: a multivariate Puiseux series is one where you can substitute xᵢ = tᵢ^(1/dᵢ) for suitable integers dᵢ to get a formal Laurent series.",
+    "mathContext": "$\\text{IsMultiPuiseux}(n+1, f) \\iff \\left(\\exists d \\in \\mathbb{N}^+,\\, \\forall q \\in \\text{supp}(f),\\, q \\in d^{-1}\\mathbb{Z}\\right) \\wedge \\left(\\forall q \\in \\mathbb{Q},\\, \\text{IsMultiPuiseux}(n, f_q)\\right)$.",
+    "significance": "key",
+    "relatedConcepts": ["Puiseux series support condition", "common denominator", "Hahn series coefficients", "recursive predicate in Lean 4"],
+    "prerequisites": ["HahnSeries.support", "HahnSeries.coeff", "PNat (positive naturals)", "recursive def in Lean 4"]
+  },
+  {
+    "id": "puiseux-base-case",
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 158, "endLine": 161 },
+    "type": "technique",
+    "title": "isMultiPuiseux_base: Base Field Elements Are Trivially Puiseux",
+    "content": "At level 0, IsMultiPuiseuxSeries 0 a = True for any a : K. The proof is simply `trivial`. This is the degenerate case: elements of the base field K have no series structure, no support conditions to satisfy, and no recursive levels. The theorem establishes the foundation of the inductive predicate — without it, the recursion would have no base case. In a practical formalization, this trivial case is important because it allows the predicate to terminate cleanly when propagated down through all levels of the iteration.",
+    "mathContext": "Base field elements $a \\in K = \\text{MultiHahnSeries}(0, K)$ satisfy $\\text{IsMultiPuiseux}(0, a) = \\top$ (vacuously true). No support condition applies at depth 0.",
+    "significance": "supporting",
+    "relatedConcepts": ["trivial tactic", "inductive predicate base cases", "True proposition in Lean 4"],
+    "prerequisites": ["IsMultiPuiseuxSeries definition", "Lean 4 trivial tactic", "recursive predicate base cases"]
   },
   {
     "id": "ann-zero-proof",
-    "line": 166,
-    "endLine": 179,
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 163, "endLine": 179 },
     "type": "technique",
     "title": "Proving Zero is Multi-Puiseux: Empty Support Vacuity",
-    "body": "The proof that 0 is a multi-Puiseux series at every level uses induction on n. The base case is trivial. For the inductive step, we construct the pair: (1) the common-denominator witness d = 1, with the proof that f.support is empty (since f = 0, `simp at hq` closes this); (2) the recursive condition: each coefficient of 0 is also 0, and `HahnSeries.coeff_zero` rewrites it, then `exact ih` applies the inductive hypothesis. This pattern — `simp at hq` for empty support vacuity and `HahnSeries.coeff_zero` for zero coefficients — recurs throughout Hahn series proofs.",
-    "math": "\\text{IsMultiPuiseux}(n, 0) \\text{ for all } n, \\text{ since } \\text{supp}(0) = \\emptyset"
+    "content": "The proof that 0 is a multi-Puiseux series at every level uses induction on n. The base case is trivial. For the inductive step, we construct the pair: (1) the common-denominator witness d = 1, with the proof that f.support is empty (since f = 0, `simp at hq` closes this); (2) the recursive condition: each coefficient of 0 is also 0, and `HahnSeries.coeff_zero` rewrites it, then `exact ih` applies the inductive hypothesis. This pattern — `simp at hq` for empty support vacuity and `HahnSeries.coeff_zero` for zero coefficients — recurs throughout Hahn series proofs.",
+    "mathContext": "$\\text{IsMultiPuiseux}(n, 0) $ for all $n$: the zero Hahn series has empty support $\\text{supp}(0) = \\emptyset$, so the common-denominator condition holds vacuously with $d = 1$; each coefficient $0_q = 0$ satisfies the inner condition by induction.",
+    "significance": "supporting",
+    "relatedConcepts": ["HahnSeries.coeff_zero", "empty support", "simp at hypothesis", "PNat witness d=1"],
+    "prerequisites": ["HahnSeries.support_zero", "HahnSeries.coeff_zero", "refine tactic", "letI for local instances"]
   },
   {
     "id": "ann-mathlib-gap",
-    "line": 197,
-    "endLine": 213,
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 181, "endLine": 213 },
     "type": "context",
     "title": "Mathlib Gap: IsAlgClosed for HahnSeries",
-    "body": "The main algebraic closure theorem — if K is algebraically closed and has characteristic 0, then MultiHahnSeries n K is algebraically closed — is described in comments rather than formalized. The proof by induction on n is mathematically clear: the base case is K (algebraically closed by hypothesis); the inductive step needs Puiseux's theorem in the form 'HahnSeries ℚ K is algebraically closed when K is algebraically closed and CharZero'. This instance does not yet exist in Mathlib 4.26. The full Puiseux theorem formalization would require >1000 lines of Newton polygon analysis, ramification theory, and Hensel's lemma variants. This file records the inductive structure so that adding the Mathlib instance will immediately complete the theorem.",
-    "math": "K \\text{ algebraically closed, char } 0 \\implies \\text{MultiHahnSeries}(n, K) \\text{ algebraically closed}"
+    "content": "The main algebraic closure theorem — if K is algebraically closed and has characteristic 0, then MultiHahnSeries n K is algebraically closed — is described in comments rather than formalized. The proof by induction on n is mathematically clear: the base case is K (algebraically closed by hypothesis); the inductive step needs Puiseux's theorem in the form 'HahnSeries ℚ K is algebraically closed when K is algebraically closed and CharZero'. This instance does not yet exist in Mathlib 4.26. The full Puiseux theorem formalization would require Newton polygon analysis, ramification theory, and Hensel's lemma variants. This file records the inductive structure so that adding the Mathlib instance will immediately complete the theorem.",
+    "mathContext": "Conjecture (open in Mathlib 4.26): $K$ alg. closed, $\\text{char}(K) = 0 \\Rightarrow \\text{HahnSeries}(\\mathbb{Q}, K)$ alg. closed. By induction: $K$ alg. closed $\\Rightarrow \\text{MultiHahnSeries}(n, K)$ alg. closed for all $n$. Proof blocked by missing Mathlib instance.",
+    "significance": "context",
+    "relatedConcepts": ["IsAlgClosed typeclass", "CharZero", "Puiseux's theorem", "Mathlib roadmap", "Hensel's lemma"],
+    "prerequisites": ["IsAlgClosed definition", "CharZero typeclass", "Newton polygon theory", "Hensel's lemma"]
+  },
+  {
+    "id": "puiseux-part5-properties",
+    "proofId": "puiseux-theorem-oq-02",
+    "range": { "startLine": 215, "endLine": 238 },
+    "type": "insight",
+    "title": "Single-Variable Recovery and Double-Iteration Stability",
+    "content": "Two structural properties of the iterated construction are stated in Part V. single_variable_is_univariate shows MultiHahnSeries 1 K = HahnSeries ℚ K — proved by rfl, confirming that the n=1 case recovers exactly the parent theorem's setting. The double-iteration stability — HahnSeries ℚ (HahnSeries ℚ K) ≅ HahnSeries ℚ K as algebraically closed fields — is documented in a comment. This is a non-trivial fact following from algebraic closure uniqueness: if HahnSeries ℚ K is algebraically closed, then applying Puiseux again gives an isomorphic field. It is NOT true as valued fields (the valuations are different), only as abstract algebraically closed fields. This is an important subtlety: the iterated construction is not redundant as a valued field tower, only as a bare algebraically closed field.",
+    "mathContext": "$\\text{MultiHahnSeries}(1, K) = \\text{HahnSeries}(\\mathbb{Q}, K)$ (definitional, proved by rfl). Stability: $\\text{HahnSeries}(\\mathbb{Q}, \\text{HahnSeries}(\\mathbb{Q}, K)) \\cong \\text{HahnSeries}(\\mathbb{Q}, K)$ as alg. closed fields (not as valued fields). Follows from uniqueness of algebraic closures.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic closure uniqueness", "valued fields vs abstract fields", "isomorphism of algebraically closed fields", "stability under iteration"],
+    "prerequisites": ["algebraic closure uniqueness theorem", "IsAlgClosed", "single-variable Puiseux theorem", "valued field structure"]
   }
 ]

--- a/src/data/proofs/puiseux-theorem-oq-02/annotations.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-multihahn-def",
+    "line": 78,
+    "endLine": 80,
+    "type": "definition",
+    "title": "MultiHahnSeries: Iterated Puiseux Construction",
+    "body": "The iterated Hahn series type defined by recursion on depth n. At depth 0, the type is K itself (the coefficient field). At each successor depth, we wrap in HahnSeries ℚ — adding one more variable. This models the tower K ⊂ K⦃⦃x₁⦄⦄ ⊂ K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄ ⊂ ... of iterated Puiseux series fields. The ℚ exponents in HahnSeries ℚ provide the rational-power structure that characterizes Puiseux series.",
+    "math": "\\text{MultiHahnSeries}(0, K) = K, \\quad \\text{MultiHahnSeries}(n+1, K) = \\text{HahnSeries}(\\mathbb{Q}, \\text{MultiHahnSeries}(n, K))"
+  },
+  {
+    "id": "ann-commring-induction",
+    "line": 123,
+    "endLine": 129,
+    "type": "technique",
+    "title": "CommRing Instance by Depth Induction",
+    "body": "The CommRing instance for MultiHahnSeries n K is proved by induction on n. The base case is K (already a CommRing by hypothesis). The inductive step works as follows: given the inductive hypothesis ih : CommRing (MultiHahnSeries n K), we add it as a local instance via `haveI`, then `exact inferInstance` — Lean's typeclass system automatically finds CommRing (HahnSeries ℚ (MultiHahnSeries n K)) from Mathlib's CommRing instance for HahnSeries. The pattern `haveI : CommRing ... := ih; exact inferInstance` is the canonical Lean 4 idiom for propagating instances through type-level recursion.",
+    "math": "R \\text{ CommRing} \\implies \\text{HahnSeries}(\\mathbb{Q}, R) \\text{ CommRing}"
+  },
+  {
+    "id": "ann-ismulti-predicate",
+    "line": 148,
+    "endLine": 156,
+    "type": "definition",
+    "title": "IsMultiPuiseuxSeries: Levelwise Common-Denominator Condition",
+    "body": "The IsMultiPuiseuxSeries predicate characterizes which elements of MultiHahnSeries n K are genuine Puiseux series (as opposed to general Hahn series). At level 0 the condition is vacuous (True). At level n+1, two conditions must hold: (1) the outer exponents have a common denominator d — all elements of f.support are of the form k/d for integer k; (2) every coefficient f.coeff q is recursively a multi-Puiseux series at level n. This mirrors the mathematical definition: a multivariate Puiseux series is one where you can substitute xᵢ = tᵢ^(1/dᵢ) for suitable integers dᵢ to get a formal Laurent series.",
+    "math": "\\text{IsMultiPuiseux}(n+1, f) \\iff (\\exists d, \\forall q \\in \\text{supp}(f), q \\in d^{-1}\\mathbb{Z}) \\wedge (\\forall q, \\text{IsMultiPuiseux}(n, f_q))"
+  },
+  {
+    "id": "ann-zero-proof",
+    "line": 166,
+    "endLine": 179,
+    "type": "technique",
+    "title": "Proving Zero is Multi-Puiseux: Empty Support Vacuity",
+    "body": "The proof that 0 is a multi-Puiseux series at every level uses induction on n. The base case is trivial. For the inductive step, we construct the pair: (1) the common-denominator witness d = 1, with the proof that f.support is empty (since f = 0, `simp at hq` closes this); (2) the recursive condition: each coefficient of 0 is also 0, and `HahnSeries.coeff_zero` rewrites it, then `exact ih` applies the inductive hypothesis. This pattern — `simp at hq` for empty support vacuity and `HahnSeries.coeff_zero` for zero coefficients — recurs throughout Hahn series proofs.",
+    "math": "\\text{IsMultiPuiseux}(n, 0) \\text{ for all } n, \\text{ since } \\text{supp}(0) = \\emptyset"
+  },
+  {
+    "id": "ann-mathlib-gap",
+    "line": 197,
+    "endLine": 213,
+    "type": "context",
+    "title": "Mathlib Gap: IsAlgClosed for HahnSeries",
+    "body": "The main algebraic closure theorem — if K is algebraically closed and has characteristic 0, then MultiHahnSeries n K is algebraically closed — is described in comments rather than formalized. The proof by induction on n is mathematically clear: the base case is K (algebraically closed by hypothesis); the inductive step needs Puiseux's theorem in the form 'HahnSeries ℚ K is algebraically closed when K is algebraically closed and CharZero'. This instance does not yet exist in Mathlib 4.26. The full Puiseux theorem formalization would require >1000 lines of Newton polygon analysis, ramification theory, and Hensel's lemma variants. This file records the inductive structure so that adding the Mathlib instance will immediately complete the theorem.",
+    "math": "K \\text{ algebraically closed, char } 0 \\implies \\text{MultiHahnSeries}(n, K) \\text{ algebraically closed}"
+  }
+]

--- a/src/data/proofs/puiseux-theorem-oq-02/index.ts
+++ b/src/data/proofs/puiseux-theorem-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PuiseuxTheoremOQ02.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const puiseuxTheoremOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const puiseuxTheoremOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const puiseuxTheoremOQ02Data: ProofData = {
+  proof: puiseuxTheoremOQ02Proof,
+  annotations: puiseuxTheoremOQ02Annotations,
+}

--- a/src/data/proofs/puiseux-theorem-oq-02/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "puiseux-theorem-oq-02",
+  "title": "Puiseux Theorem OQ-02: Multivariate Generalization via Iterated Hahn Series",
+  "slug": "puiseux-theorem-oq-02",
+  "description": "Formalizes the multivariate generalization of Puiseux's theorem via iterated Hahn series: K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄...⦃⦃xₙ⦄⦄ defined as `MultiHahnSeries n K`. Proves that this construction inherits CommRing from K by induction, defines the recursive IsMultiPuiseuxSeries predicate, and establishes base cases. The algebraic closure of iterated Laurent series is the iterated Puiseux series field (McDonald 1995, Aroca-Cano-Jung 2003).",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Puiseux_series#Generalizations",
+    "date": "McDonald 1995; Aroca-Cano-Jung 2003; formalized 2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "series",
+      "hahn-series",
+      "algebraic-closure",
+      "multivariate",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/PuiseuxTheoremOQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 6 theorems and 4 definitions fully verified with 0 sorries and 0 axioms. The main algebraic closure theorem (MultiHahnSeries n K is algebraically closed when K is) requires HahnSeries ℚ K to be algebraically closed — open in Mathlib — so it is described in comments rather than formalized as a theorem.",
+    "originalContributions": [
+      "MultiHahnSeries: iterated HahnSeries ℚ type (n-variate Puiseux series)",
+      "instZeroMultiHahn: Zero instance for MultiHahnSeries by induction on n",
+      "instCommRingMultiHahn: CommRing instance for MultiHahnSeries by induction on n",
+      "IsMultiPuiseuxSeries: recursive common-denominator predicate for multivariate Puiseux series",
+      "isMultiPuiseux_base: base field elements are trivially multi-Puiseux",
+      "isMultiPuiseux_zero: zero is multi-Puiseux at every level (empty support)",
+      "Dimensional facts: multiHahn_zero, multiHahn_one, multiHahn_succ"
+    ],
+    "dateAdded": "2026-05-04",
+    "lineCount": 238,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Puiseux's theorem (1850) establishes that the field of Puiseux series over an algebraically closed field of characteristic 0 is itself algebraically closed. Puiseux series are formal power series with rational exponents: elements of K⦃⦃x⦄⦄ = ⋃ₙ K((x^{1/n})). The multivariate generalization asks: what is the algebraic closure of the field of formal Laurent series K((x₁,...,xₙ)) in several variables?\n\nThe answer, established by McDonald (1995) and refined by Aroca, Cano, and Jung (2003), is the iterated Puiseux series field K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄...⦃⦃xₙ⦄⦄, defined by applying the univariate Puiseux construction once per variable. The key subtlety is the ordering: multivariate Puiseux series require a well-order on ℚⁿ for the support to be well-ordered, and the lexicographic ordering of the iterated construction handles this automatically.\n\nThis formalization uses Mathlib's HahnSeries ℚ K as the Lean model for one-variable Puiseux series (Hahn series over the rationals), then iterates: MultiHahnSeries 0 K = K, MultiHahnSeries (n+1) K = HahnSeries ℚ (MultiHahnSeries n K).",
+    "problemStatement": "**Open Question (OQ-02 from Puiseux's Theorem)**: How does Puiseux's theorem generalize to higher dimensions?\n\n**Answer**: The multivariate Puiseux series K⦃⦃x₁,...,xₙ⦄⦄ is defined as the n-fold iterated HahnSeries ℚ construction: `MultiHahnSeries n K`. This inherits CommRing from K by induction and supports the IsMultiPuiseuxSeries predicate capturing the levelwise common-denominator condition.",
+    "text": "A 238-line formalization of the multivariate Puiseux series structure via iterated Hahn series. The key definition is `MultiHahnSeries : ℕ → Type* → Type*` with `MultiHahnSeries 0 K = K` and `MultiHahnSeries (n+1) K = HahnSeries ℚ (MultiHahnSeries n K)`. The algebraic instances (Zero, CommRing) are proved by induction on depth. The IsMultiPuiseuxSeries predicate captures the recursive common-denominator condition. All 6 theorems and 4 definitions are fully verified with 0 sorries.",
+    "proofStrategy": "**Part I** (Iterated Construction): Define `MultiHahnSeries` by recursion on depth. Base case is the coefficient field K; successor step wraps in HahnSeries ℚ.\n\n**Part II** (Algebraic Instances): Prove Zero and CommRing instances for MultiHahnSeries by induction. The inductive step uses Mathlib's existing instances for HahnSeries.\n\n**Part III** (IsMultiPuiseuxSeries Predicate): Define the recursive predicate: at level 0, True; at level n+1, (∃ common denominator for outer exponents) ∧ (all coefficients recursively satisfy the predicate). Prove base cases.\n\n**Part IV** (Algebraic Closure): The full theorem requires IsAlgClosed (HahnSeries ℚ K) when K is algebraically closed and char 0 — this is open in Mathlib. Documented in comments with the inductive structure.\n\n**Part V** (Dimensional Facts): Single-variable case recovers HahnSeries ℚ K; iterated construction agrees with the univariate base theorem at depth 1.",
+    "keyInsights": [
+      "**Iteration is the Key**: The multivariate Puiseux series is not a direct generalization but an iterated application of the univariate construction, one variable at a time with lexicographic ordering.",
+      "**CommRing by Induction**: The algebraic structure propagates cleanly: HahnSeries ℚ R is a CommRing when R is, so the depth-n induction hypothesis gives the depth-n+1 result automatically via Mathlib's typeclass inference.",
+      "**IsMultiPuiseuxSeries Predicate**: The levelwise common-denominator condition captures exactly which elements of MultiHahnSeries n K are genuine Puiseux series (as opposed to more general Hahn series).",
+      "**Mathlib Gap**: The main algebraic closure theorem requires HahnSeries ℚ K to be IsAlgClosed when K is — this instance is not yet in Mathlib 4.26, blocking full formalization of the structural theorem."
+    ],
+    "prerequisites": [
+      "Formal power series and Hahn series",
+      "Algebraic closure and algebraically closed fields",
+      "Typeclass inheritance in Lean 4"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "puiseux-theorem",
+      "relationship": "extends",
+      "description": "Parent formalization proving the univariate Puiseux theorem structure; this file generalizes it to n variables via iterated HahnSeries"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.HahnSeries.Basic",
+      "Mathlib.FieldTheory.IsAlgClosed.Basic",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "PuiseuxTheoremOQ02",
+    "lineCount": 238,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "path": "Proofs/PuiseuxTheoremOQ02.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "sec-iteration",
+      "title": "Part I: Iterated Puiseux Series",
+      "startLine": 54,
+      "endLine": 90,
+      "summary": "Defines MultiHahnSeries : ℕ → Type* → Type* by recursion: level 0 is K, level n+1 is HahnSeries ℚ (MultiHahnSeries n K). Proves dimensional facts: multiHahn_zero, multiHahn_one, multiHahn_succ (all definitional equalities, 0 sorries).",
+      "mathContext": "MultiHahnSeries 0 K = K, MultiHahnSeries (n+1) K = HahnSeries ℚ (MultiHahnSeries n K). This models K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄...⦃⦃xₙ⦄⦄ as an n-fold iterated Hahn series over ℚ."
+    },
+    {
+      "id": "sec-instances",
+      "title": "Part II: Algebraic Instances for Iterated Construction",
+      "startLine": 92,
+      "endLine": 129,
+      "summary": "Proves instZeroMultiHahn and instCommRingMultiHahn by induction on n. Base: inherits from K. Inductive step: haveI : CommRing (MultiHahnSeries n K) := ih, then exact inferInstance (Mathlib's CommRing instance for HahnSeries). Both compile with 0 sorries.",
+      "mathContext": "The tower K ⊂ HahnSeries ℚ K ⊂ HahnSeries ℚ (HahnSeries ℚ K) ⊂ ... consists of commutative rings at every level. HahnSeries ℚ R is a CommRing when R is, propagating via Mathlib's typeclass system."
+    },
+    {
+      "id": "sec-predicate",
+      "title": "Part III: The Multivariate Puiseux Property",
+      "startLine": 131,
+      "endLine": 179,
+      "summary": "Defines IsMultiPuiseuxSeries : (n : ℕ) → MultiHahnSeries n K → Prop by recursion. At level 0: True; at level n+1: (∃ d : ℕ+, exponents ∈ (1/d)·ℤ) ∧ (∀ coefficient recursively satisfies the predicate). Proves isMultiPuiseux_base (trivial) and isMultiPuiseux_zero (empty support + recursion). Both compile 0 sorries.",
+      "mathContext": "IsMultiPuiseuxSeries captures elements of MultiHahnSeries n K whose support has a common denominator at every level of the iteration. This is the correct multivariate generalization of the Puiseux condition."
+    },
+    {
+      "id": "sec-main-comment",
+      "title": "Part IV: Multivariate Algebraic Closure (Documented)",
+      "startLine": 181,
+      "endLine": 213,
+      "summary": "Documents the multivariate_puiseux_theorem (MultiHahnSeries n K is IsAlgClosed when K is algebraically closed and CharZero). The inductive structure is clear; the gap is that IsAlgClosed (HahnSeries ℚ K) is not yet in Mathlib 4.26. Recorded in comments with proof sketch.",
+      "mathContext": "By induction on n: base case is K (algebraically closed by hypothesis); inductive step applies Puiseux's theorem to conclude HahnSeries ℚ (MultiHahnSeries n K) is algebraically closed. The induction also requires CharZero propagation."
+    },
+    {
+      "id": "sec-properties",
+      "title": "Part V: Properties of the Iterated Construction",
+      "startLine": 215,
+      "endLine": 238,
+      "summary": "Proves single_variable_is_univariate: MultiHahnSeries 1 K = HahnSeries ℚ K (definitional equality, 0 sorry). Documents double_puiseux_redundant: HahnSeries ℚ (HahnSeries ℚ K) ≅ HahnSeries ℚ K as algebraically closed fields (requires algebraic closure uniqueness, not yet formalized).",
+      "mathContext": "The single-variable case recovers the parent PuiseuxTheorem.lean exactly. The double-iteration redundancy follows from the uniqueness of algebraic closures up to isomorphism."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes the multivariate Puiseux series structure as iterated HahnSeries ℚ. All definitions (MultiHahnSeries, instZeroMultiHahn, instCommRingMultiHahn, IsMultiPuiseuxSeries) and theorems (6 total) compile with 0 sorries and 0 axioms. The algebraic closure theorem is blocked by a Mathlib gap (IsAlgClosed for HahnSeries ℚ K) and is documented in comments.",
+    "implications": "The iterated Hahn series framework provides a clean model for multivariate Puiseux series in Lean 4. Once Mathlib adds IsAlgClosed for HahnSeries, the full algebraic closure theorem will follow by a simple induction on depth.",
+    "openQuestions": [
+      "Prove IsAlgClosed (HahnSeries ℚ K) when K is algebraically closed and CharZero (requires full Puiseux theorem in Lean) — needed to complete multivariate_puiseux_theorem",
+      "Add Field instance for MultiHahnSeries n K when K is a field (requires HahnSeries field instance from Mathlib)",
+      "Formalize the monomial ordering structure on ℚⁿ for the lexicographic support well-order"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

- Adds complete gallery entry for `puiseux-theorem-oq-02` (PuiseuxTheoremOQ02.lean)
- The Lean file has 238 lines, 0 sorries, 0 axioms, 6 theorems, 4 definitions
- No Lean file changes needed — file was already verified

## What's Formalized

`MultiHahnSeries n K` models the n-variate Puiseux series K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄...⦃⦃xₙ⦄⦄ as an iterated Hahn series:
- `MultiHahnSeries 0 K = K`
- `MultiHahnSeries (n+1) K = HahnSeries ℚ (MultiHahnSeries n K)`

Instances `instZeroMultiHahn` and `instCommRingMultiHahn` are proved by induction on depth. The `IsMultiPuiseuxSeries` predicate captures the recursive common-denominator condition.

The main algebraic closure theorem requires `IsAlgClosed (HahnSeries ℚ K)` — open in Mathlib 4.26 — so it is documented in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)