### PR TITLE
enrich(erdos-1141): fix annotations — wrong axiom direction, stale pre-solution text

### DIFF
--- a/src/data/proofs/erdos-1141/annotations.json
+++ b/src/data/proofs/erdos-1141/annotations.json
@@ -129,19 +129,20 @@
     "id": "ann-e1141-conjecture",
     "proofId": "erdos-1141",
     "range": {
-      "startLine": 113,
-      "endLine": 114
+      "startLine": 121,
+      "endLine": 128
     },
     "type": "concept",
-    "title": "The Open Conjecture",
-    "content": "**Erdős Problem #1141 (OPEN)**: For every $N$, there exists $n \\ge N$ with `IsErdos1141Good n`.\n\nThis is the **infinitude statement**: the set of good values is unbounded. Equivalently, `{n : IsErdos1141Good n}` is infinite.\n\nStated as an axiom since the problem is open. The evidence is ambiguous:\n- **For infinitude**: The sequence extends to 1722 and has 41 known terms, suggesting a rich structure\n- **Against infinitude**: No new terms between 1722 and $10^{10}$; the density bound $O(N^{1/2+o(1)})$ is consistent with a finite sequence\n\nThe formalization uses the standard Lean pattern for infinitude: $\\forall N, \\exists n \\ge N$ satisfying the property.",
-    "mathContext": "$\\forall N \\in \\mathbb{N},\\; \\exists n \\ge N : \\text{IsErdos1141Good}(n)$",
+    "title": "Finiteness Theorem (Alexeev et al. 2026)",
+    "content": "**Erdős Problem #1141 (SOLVED 2026)**: There are only finitely many $n$ satisfying the Erdős-1141 property.\n\nAxiom `erdos_1141_finitely_many` encodes the theorem of **Alexeev, Putterman, Sawhney, Sellke, and Valiant** (arXiv:2604.06609, 2026): there exists $N$ such that for all $n \\ge N$, $n$ is not Erdős-1141 good. The result holds more generally — for each fixed $a \\ge 1$, only finitely many $n$ satisfy '$n - ak^2$ is prime for all $k$ with $\\gcd(k,n)=1$ and $ak^2 < n$'.\n\n**Proof sketch**: By **Pollack's theorem** (2017), for sufficiently large $n$ there exists a small prime $p$ such that $ax^2 \\equiv n \\pmod{p}$ is solvable. The solutions produce multiple coprime $k$-values for which $n - ak^2 \\equiv 0 \\pmod{p}$, forcing $n - ak^2 = p$ for several $k$ simultaneously — a contradiction since distinct $k$ give distinct values.\n\n**Ineffectivity**: The proof uses Siegel's theorem on $L$-functions (via Pollack), making it **ineffective** — no explicit bound on $N$ is known from the proof. Computationally, 1722 appears to be the largest good value for $a=1$.\n\nStated as an axiom because the 2026 paper has not yet been formalized in Mathlib.",
+    "mathContext": "`erdos_1141_finitely_many : ∃ N : ℕ, ∀ n : ℕ, n ≥ N → ¬ IsErdos1141Good n`",
     "significance": "key",
     "relatedConcepts": [
-      "infinitude",
+      "finiteness",
+      "Pollack's theorem",
+      "Siegel's theorem",
       "axiom",
-      "open problem",
-      "unbounded sequence"
+      "quadratic residues"
     ],
     "prerequisites": [
       "ann-e1141-definition"
@@ -151,8 +152,8 @@
     "id": "ann-e1141-oeis",
     "proofId": "erdos-1141",
     "range": {
-      "startLine": 119,
-      "endLine": 125
+      "startLine": 130,
+      "endLine": 139
     },
     "type": "concept",
     "title": "OEIS A214583 Enumeration",
@@ -173,8 +174,8 @@
     "id": "ann-e1141-large-examples",
     "proofId": "erdos-1141",
     "range": {
-      "startLine": 130,
-      "endLine": 154
+      "startLine": 141,
+      "endLine": 168
     },
     "type": "concept",
     "title": "Larger Verified Examples (24–1722)",
@@ -189,6 +190,75 @@
     ],
     "prerequisites": [
       "ann-e1141-definition"
+    ]
+  },
+  {
+    "id": "ann-e1141-unified",
+    "proofId": "erdos-1141",
+    "range": {
+      "startLine": 170,
+      "endLine": 173
+    },
+    "type": "concept",
+    "title": "Unified Verification of All 41 OEIS Values",
+    "content": "Theorem `all_known_good` verifies **all 41** OEIS A214583 values in a single statement using `native_decide`.\n\nThis is more than a convenience — it is a **formal certificate** that every element of `knownGoodValues` satisfies the Erdős-1141 property. The `native_decide` tactic compiles the combined check (iterating over all 41 values and for each checking all coprime $k$ with $k^2 < n$) into a native binary and executes it, confirming the result in the kernel.\n\nThe power of `native_decide` here is that it handles a computation that would be infeasible by hand: for $n = 1722$, we need to check $\\lfloor \\sqrt{1722} \\rfloor = 41$ potential $k$-values, each filtered by $\\gcd(1722, k) = 1$, then verify primality of $1722 - k^2$. Doing this for all 41 OEIS values simultaneously demonstrates that formal verification can certify complex combinatorial facts.",
+    "mathContext": "`all_known_good : ∀ n ∈ knownGoodValues, IsErdos1141Good n`",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "native_decide",
+      "formal certificate",
+      "OEIS A214583",
+      "list membership"
+    ],
+    "prerequisites": [
+      "ann-e1141-oeis",
+      "ann-e1141-large-examples"
+    ]
+  },
+  {
+    "id": "ann-e1141-classification",
+    "proofId": "erdos-1141",
+    "range": {
+      "startLine": 175,
+      "endLine": 187
+    },
+    "type": "concept",
+    "title": "Complete Classification up to n = 100",
+    "content": "A complete, machine-verified classification: the Erdős-1141 good values in $\\{0, \\ldots, 100\\}$ are exactly $\\{0, 3, 4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 48, 54, 60, 62, 68, 72, 80, 84, 90, 98\\}$.\n\nThe proof uses `native_decide` to evaluate `(Finset.range 101).filter IsErdos1141Good` and compare it to the explicit `goodValuesUpTo100` list. This is a **complete enumeration** — not just a list of known good values, but a proof that no other values in $\\{0, \\ldots, 100\\}$ qualify.\n\n**Key facts**:\n- There are exactly **24** good values in $\\{0, \\ldots, 100\\}$ (theorem `good_count_100`)\n- All good values except 0 and 3 are even (consistent with `good_ge4_even`)\n- The known good values 32, 38, 42, ..., 98 all appear, and no values between them are missed\n\nThis exhaustive check demonstrates the decidability infrastructure: the `Decidable` instance on `IsErdos1141Good` enables `Finset.filter` to work computationally, and `native_decide` scales this to all 101 cases simultaneously.",
+    "mathContext": "`(Finset.range 101).filter IsErdos1141Good = goodValuesUpTo100.toFinset` and `card = 24`",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.filter",
+      "native_decide",
+      "exhaustive classification",
+      "Decidable"
+    ],
+    "prerequisites": [
+      "ann-e1141-definition",
+      "ann-e1141-structural"
+    ]
+  },
+  {
+    "id": "ann-e1141-corollaries",
+    "proofId": "erdos-1141",
+    "range": {
+      "startLine": 189,
+      "endLine": 210
+    },
+    "type": "concept",
+    "title": "Structural Corollaries",
+    "content": "Three structural corollaries proved without computation:\n\n1. **`good_not_prime_ge5`**: No prime $p \\ge 5$ is Erdős-1141 good. Proof: primes $\\ge 5$ are odd, but by `good_ge4_even`, all good $n \\ge 4$ must be even. Since only the even prime is 2, no odd prime $\\ge 5$ can be good.\n\n2. **`good_odd_eq_three`**: The only odd good value $\\ge 3$ is $n = 3$. Proof: any odd good $n \\ge 4$ would contradict `good_ge4_even`; the hypothesis $4 \\le n$ follows from $n \\ge 3$ and $n \\ne 3$ via `omega`. So $n = 3$ is the unique odd outlier.\n\n3. **`good_coprime3_sub9_prime`**: If $n \\ge 10$ is good and $\\gcd(n, 3) = 1$, then $n - 9$ is prime. Proof: $k = 3$ satisfies $3^2 = 9 < n$ (since $n \\ge 10$) and $\\gcd(n, 3) = 1$ by hypothesis, so `IsErdos1141Good n` applied to $k = 3$ gives $(n - 9).\\text{Prime}$.\n\nThese results show that good values $\\ge 4$ are constrained: even, one above a prime ($n-1$ prime), and when coprime to 3, also with $n-9$ prime. The simultaneous primality of $n-1$ and $n-9$ (when applicable) forces $n \\equiv 0 \\pmod{2}$ and creates additional arithmetic constraints on the prime gaps involved.",
+    "mathContext": "No prime $\\ge 5$ is good; 3 is the unique odd good value; $\\gcd(n,3)=1$ and good $\\Rightarrow$ $(n-9)$ prime",
+    "significance": "key",
+    "relatedConcepts": [
+      "good_ge4_even",
+      "good_implies_pred_prime",
+      "Nat.Prime",
+      "Nat.Coprime"
+    ],
+    "prerequisites": [
+      "ann-e1141-structural",
+      "ann-e1141-conjecture"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1141/meta.json
+++ b/src/data/proofs/erdos-1141/meta.json
@@ -62,19 +62,19 @@
     ],
     "axiomCount": 1,
     "lineCount": 210,
-    "assumptions": "1 axiom (open conjecture: infinitely many good values). All verifiable results are fully proved.",
+    "assumptions": "1 axiom (finiteness theorem by Alexeev-Putterman-Sawhney-Sellke-Valiant 2026, arXiv:2604.06609; proved via Pollack's theorem but not yet formalized in Mathlib). All structural results are fully proved.",
     "theoremCount": 35
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1141 asks whether infinitely many natural numbers n have the property that n - k² is prime for every k coprime to n with k² < n. The problem connects primality testing to quadratic residues and coprimality structure, sitting at the intersection of additive and multiplicative number theory.\n\nThe known good values form OEIS sequence A214583, comprising 41 terms: 3, 4, 6, 8, 12, ..., 930, 1722. Strikingly, all known good values except 3 are even, and many are highly composite numbers (24, 30, 60, 90, 180, 252, 360, 570). This pattern has a natural explanation: highly composite n have small Euler totient ratio φ(n)/n, meaning fewer coprime k values, and hence fewer simultaneous primality conditions to satisfy.\n\nAn exhaustive computational search found no further good values between 1722 and 10^10, suggesting the sequence may be finite. ChatGPT-Tang proved that the counting function satisfies #{n ≤ N : IsGood(n)} = O(N^{1/2+o(1)}), a density bound consistent with finiteness but insufficient to prove it. The sparse distribution and gap beyond 1722 make this one of the more enigmatic Erdős problems — the answer 'finitely many' seems likely but is unproved.",
+    "historicalContext": "Erdős Problem #1141 asks whether infinitely many natural numbers n have the property that n - k² is prime for every k coprime to n with k² < n. The problem connects primality testing to quadratic residues and coprimality structure, sitting at the intersection of additive and multiplicative number theory.\n\nThe known good values form OEIS sequence A214583, comprising 41 terms: 3, 4, 6, 8, 12, ..., 930, 1722. Strikingly, all known good values except 3 are even, and many are highly composite numbers (24, 30, 60, 90, 180, 252, 360, 570). This pattern has a natural explanation: highly composite n have small Euler totient ratio φ(n)/n, meaning fewer coprime k values, and hence fewer simultaneous primality conditions to satisfy.\n\nAn exhaustive computational search found no further good values between 1722 and 10^10. ChatGPT-Tang proved that the counting function satisfies #{n ≤ N : IsGood(n)} = O(N^{1/2+o(1)}), providing a density bound consistent with finiteness. The problem was **SOLVED in 2026** by Alexeev, Putterman, Sawhney, Sellke, and Valiant (arXiv:2604.06609), who proved that for each fixed a ≥ 1, only finitely many n satisfy the analogous property for n - ak². Their proof is a short deduction from Pollack's 2017 theorem on small prime quadratic residues; the result is ineffective (no explicit bound on the largest good n) due to Siegel's theorem.",
     "problemStatement": "**Erdős Problem #1141**:\n\nAre there infinitely many $n$ such that $n - k^2$ is prime for all $k$ with $\\gcd(n, k) = 1$ and $k^2 < n$?\n\n**Formally**: Does the set $\\{n \\in \\mathbb{N} : \\forall k,\\; \\gcd(n,k) = 1 \\wedge k^2 < n \\Rightarrow (n - k^2) \\text{ is prime}\\}$ have infinitely many elements?",
     "text": "Are there infinitely many n such that n - k² is prime for all k with gcd(n, k) = 1 and k² < n?",
-    "proofStrategy": "The formalization defines the Erdős-1141 property using bounded quantification over Finset.range for decidability, proves equivalence with the unbounded formulation, verifies all 41 known OEIS A214583 values via `all_known_good`, provides a complete classification of good values up to 100, and proves structural constraints: good n ≥ 4 are even, n-1 must be prime, no prime ≥ 5 is good, 3 is the unique odd good value, and good n coprime to 3 forces n-9 prime. The open conjecture (infinitude) is axiomatized.",
+    "proofStrategy": "The formalization defines the Erdős-1141 property using bounded quantification over Finset.range for decidability, proves equivalence with the unbounded formulation, verifies all 41 known OEIS A214583 values via `all_known_good`, provides a complete classification of good values up to 100, and proves structural constraints: good n ≥ 4 are even, n-1 must be prime, no prime ≥ 5 is good, 3 is the unique odd good value, and good n coprime to 3 forces n-9 prime. The finiteness theorem (the 2026 solution by Alexeev et al.) is axiomatized as `erdos_1141_finitely_many`, since the underlying proof via Pollack's theorem has not yet been formalized in Mathlib.",
     "keyInsights": [
       "**Highly composite advantage**: Good values cluster among highly composite numbers because these have the fewest coprime residues (low φ(n)/n ratio), minimizing the number of independent primality conditions n - k² must satisfy.",
       "**Necessary condition: n - 1 prime**: Every good n ≥ 2 must have n - 1 prime (from k = 1). This immediately excludes most n and explains why good values are always one more than a prime.",
       "**Decidability via Finset.range**: The bounded quantifier formulation makes IsErdos1141Good decidable, enabling Lean's `decide` and `native_decide` tactics to computationally verify or refute the property for specific n — a powerful technique for concrete number theory.",
-      "**The 1722 gap**: No good values exist between 1722 and 10^10 (a ratio of ~6 million). This enormous gap strongly suggests the sequence is finite, but proving this would require showing that the primality constraints become unsatisfiable for all sufficiently large n.",
+      "**The 1722 gap (now resolved)**: No good values exist between 1722 and 10^10 (a ratio of ~6 million). This enormous gap strongly suggested finiteness, which was confirmed by Alexeev et al. (2026): the sequence is provably finite, and 1722 is computationally the largest known good value for a=1.",
       "**Density bound O(N^{1/2+o(1)})**: ChatGPT-Tang's result bounds the counting function, showing good values are very sparse. This is the best theoretical evidence toward finiteness, though it does not rule out infinitely many extremely sparse terms."
     ],
     "prerequisites": [
@@ -136,11 +136,11 @@
     },
     {
       "id": "conjecture",
-      "title": "The Open Conjecture",
-      "startLine": 109,
-      "endLine": 114,
-      "summary": "Axiomatizes the open problem: for every N, there exists n ≥ N with IsErdos1141Good n (infinitude of good values).",
-      "mathContext": "OPEN: $\\\\forall N, \\\\exists n \\\\geq N$ with $n$ good. Infinitely many good values exist?"
+      "title": "Finiteness Theorem (Alexeev et al. 2026)",
+      "startLine": 121,
+      "endLine": 128,
+      "summary": "Axiomatizes the finiteness theorem proved by Alexeev-Putterman-Sawhney-Sellke-Valiant (2026, arXiv:2604.06609): there exists N such that all n ≥ N are not Erdős-1141 good. Proved via Pollack's theorem; not yet in Mathlib.",
+      "mathContext": "SOLVED: $\\\\exists N, \\\\forall n \\\\ge N : \\\\neg\\\\text{IsErdos1141Good}(n)$ (Alexeev et al. 2026)"
     },
     {
       "id": "large-examples",


### PR DESCRIPTION
## Summary

Fixes factual errors in `erdos-1141` annotations and metadata introduced when the Lean file was updated to reflect the 2026 solution (Alexeev-Putterman-Sawhney-Sellke-Valiant) but the gallery data was not updated.

## Issues Fixed

### Critical: Wrong axiom direction in ann-e1141-conjecture
The annotation described the axiom as the **infinitude** statement:
> ∀ N, ∃ n ≥ N, IsErdos1141Good n  (WRONG)

The actual axiom in the Lean file is the **finiteness** theorem:
> ∃ N : ℕ, ∀ n : ℕ, n ≥ N → ¬ IsErdos1141Good n  (CORRECT, proved 2026)

These are logically opposite statements. The problem was **solved** by Alexeev et al. 2026 proving the finiteness direction — the annotation was never updated to reflect this.

### Wrong annotation ranges
- `ann-e1141-conjecture`: range 113-114 → corrected to 121-128 (actual axiom location)
- `ann-e1141-oeis`: range 119-125 (was pointing to axiom section) → corrected to 130-139 (knownGoodValues definition)
- `ann-e1141-large-examples`: range 130-154 → corrected to 141-168

### Missing annotations for lines 170-210
Three new annotations added:
- `ann-e1141-unified` (lines 170-173): `all_known_good` unified verification theorem
- `ann-e1141-classification` (lines 175-187): `classification_100` / `good_count_100`
- `ann-e1141-corollaries` (lines 189-210): structural corollaries (`good_not_prime_ge5`, `good_odd_eq_three`, `good_coprime3_sub9_prime`)

### Stale meta.json text
- `meta.assumptions`: "open conjecture: infinitely many good values" → correct description of the 2026 finiteness axiom
- `overview.historicalContext`: removed "unproved" language, added 2026 solution
- `overview.proofStrategy`: replaced "open conjecture (infinitude) is axiomatized" with correct description
- `keyInsights[3]`: replaced "strongly suggests... but proving this would require" with the proven result
- `sections.conjecture`: updated title, lines, summary, mathContext to reflect finiteness theorem

## Files Modified
- `src/data/proofs/erdos-1141/annotations.json` (+3 new annotations, 3 range fixes, 1 content fix)
- `src/data/proofs/erdos-1141/meta.json` (5 stale text fixes)

🤖 Generated by researcher-11