### PR TITLE
enrich(batch): fix invalid annotation types across 8 gallery entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "definition",
     "title": "Circle Area and Circumference Definitions",
-    "content": "Two core definitions: `circleArea r = π·r²` and `circumference ρ = 2π·ρ`. These are the antiderivative/integrand pair at the heart of the FTC proof. The relationship A'(r) = C(r) is precisely what the Fundamental Theorem of Calculus exploits. Separating them as named definitions makes the proof structure clear and allows the derivative theorem to state exactly `HasDerivAt circleArea (circumference r) r`. The `noncomputable section` wrapping is required because `Real.pi` is not computable — Lean cannot reduce it to a numeral, only reason about it symbolically.",
+    "content": "Two core definitions: `circleArea r = \u03c0\u00b7r\u00b2` and `circumference \u03c1 = 2\u03c0\u00b7\u03c1`. These are the antiderivative/integrand pair at the heart of the FTC proof. The relationship A'(r) = C(r) is precisely what the Fundamental Theorem of Calculus exploits. Separating them as named definitions makes the proof structure clear and allows the derivative theorem to state exactly `HasDerivAt circleArea (circumference r) r`. The `noncomputable section` wrapping is required because `Real.pi` is not computable \u2014 Lean cannot reduce it to a numeral, only reason about it symbolically.",
     "mathContext": "$A(r) = \\pi r^2$, $\\quad C(\\rho) = 2\\pi\\rho$, $\\quad A'(r) = C(r)$. The circumference is the integrand; the circle area is the antiderivative. The FTC then gives $\\int_0^r C(\\rho)\\,d\\rho = A(r) - A(0) = \\pi r^2$.",
     "significance": "key",
     "relatedConcepts": [
@@ -30,9 +30,9 @@
       "startLine": 53,
       "endLine": 57
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Differentiating Circle Area via hasDerivAt_pow",
-    "content": "The theorem `hasDerivAt_circleArea` proves that `d/dr[πr²] = 2πr` using Mathlib's `hasDerivAt_pow` for `x^2`, combined with `const_mul` for the factor π. The `convert ... using 1; ring` idiom bridges the syntactic gap between `π * (2 * r)` (what `hasDerivAt_pow + const_mul` produces) and `2 * π * r` (what `circumference r` unfolds to). This is a standard Lean pattern: let Mathlib compute the derivative, then reconcile by `ring`.",
+    "content": "The theorem `hasDerivAt_circleArea` proves that `d/dr[\u03c0r\u00b2] = 2\u03c0r` using Mathlib's `hasDerivAt_pow` for `x^2`, combined with `const_mul` for the factor \u03c0. The `convert ... using 1; ring` idiom bridges the syntactic gap between `\u03c0 * (2 * r)` (what `hasDerivAt_pow + const_mul` produces) and `2 * \u03c0 * r` (what `circumference r` unfolds to). This is a standard Lean pattern: let Mathlib compute the derivative, then reconcile by `ring`.",
     "mathContext": "$(\\pi \\cdot x^2)' = \\pi \\cdot 2x = 2\\pi x$. Formally: `hasDerivAt_pow 2 r` gives $\\frac{d}{dx}[x^2] = 2x$; `const_mul` lifts it to $\\frac{d}{dx}[\\pi x^2] = \\pi \\cdot 2x$.",
     "significance": "key",
     "relatedConcepts": [
@@ -54,9 +54,9 @@
       "startLine": 62,
       "endLine": 69
     },
-    "type": "theorem",
-    "title": "FTC Proof: ∫₀ʳ 2πρ dρ = πr²",
-    "content": "This is Part I's main result. The proof assembles three Mathlib ingredients: (1) `h_deriv` — `hasDerivAt_circleArea` instantiated on the interval `[0, r]`; (2) `h_int` — `circumference` is continuous (hence integrable) via `fun_prop`; (3) `integral_eq_sub_of_hasDerivAt` — FTC Part 2. The `simp [circleArea]` at the end simplifies `πr² - π·0² = πr²`. The proof is remarkably short precisely because Mathlib's FTC statement matches our setup perfectly.",
+    "type": "insight",
+    "title": "FTC Proof: \u222b\u2080\u02b3 2\u03c0\u03c1 d\u03c1 = \u03c0r\u00b2",
+    "content": "This is Part I's main result. The proof assembles three Mathlib ingredients: (1) `h_deriv` \u2014 `hasDerivAt_circleArea` instantiated on the interval `[0, r]`; (2) `h_int` \u2014 `circumference` is continuous (hence integrable) via `fun_prop`; (3) `integral_eq_sub_of_hasDerivAt` \u2014 FTC Part 2. The `simp [circleArea]` at the end simplifies `\u03c0r\u00b2 - \u03c0\u00b70\u00b2 = \u03c0r\u00b2`. The proof is remarkably short precisely because Mathlib's FTC statement matches our setup perfectly.",
     "mathContext": "FTC Part 2: if $F'(x) = f(x)$ on $[a,b]$ and $f$ is integrable, then $\\int_a^b f(x)\\,dx = F(b) - F(a)$. Here $F = $ `circleArea`, $f = $ `circumference`, $a = 0$, $b = r$: $\\int_0^r 2\\pi\\rho\\,d\\rho = \\pi r^2 - \\pi \\cdot 0^2 = \\pi r^2$.",
     "significance": "key",
     "relatedConcepts": [
@@ -81,7 +81,7 @@
     },
     "type": "definition",
     "title": "Inscribed Regular n-gon Area Formula",
-    "content": "A regular n-gon inscribed in a circle of radius r consists of n isosceles triangles meeting at the center, each with two sides of length r and an apex angle of 2π/n. The area of each triangle is (1/2)·r²·sin(2π/n), so the total inscribed area is `n/2 · r² · sin(2π/n)`. This is the formula Archimedes implicitly used (for n = 96 in his bound) and which converges to πr² as n → ∞.",
+    "content": "A regular n-gon inscribed in a circle of radius r consists of n isosceles triangles meeting at the center, each with two sides of length r and an apex angle of 2\u03c0/n. The area of each triangle is (1/2)\u00b7r\u00b2\u00b7sin(2\u03c0/n), so the total inscribed area is `n/2 \u00b7 r\u00b2 \u00b7 sin(2\u03c0/n)`. This is the formula Archimedes implicitly used (for n = 96 in his bound) and which converges to \u03c0r\u00b2 as n \u2192 \u221e.",
     "mathContext": "Regular $n$-gon inscribed in circle of radius $r$: $\\text{inscribedArea}(n, r) = \\frac{n}{2} r^2 \\sin\\!\\left(\\frac{2\\pi}{n}\\right)$. As $n \\to \\infty$: $\\frac{n}{2} r^2 \\sin\\!\\left(\\frac{2\\pi}{n}\\right) \\to \\frac{r^2}{2} \\cdot 2\\pi = \\pi r^2$, since $\\lim_{h \\to 0} \\frac{\\sin h}{h} = 1$.",
     "significance": "key",
     "relatedConcepts": [
@@ -104,8 +104,8 @@
       "endLine": 88
     },
     "type": "concept",
-    "title": "Helper: c/n → 0 via tendsto_inv_atTop_zero",
-    "content": "This helper proves that c/n → 0 in ℝ as n → ∞ over ℕ. The key ingredients are: (1) `tendsto_inv_atTop_zero`: 1/x → 0 as x → +∞; (2) `tendsto_natCast_atTop_atTop`: the cast ℕ → ℝ diverges to +∞; (3) `Filter.Tendsto.const_mul`: multiplying a convergent sequence by a constant. Note that `tendsto_const_div_atTop_nhds_0_nat` was removed from Mathlib 4.26, making this composition the current idiomatic approach.",
+    "title": "Helper: c/n \u2192 0 via tendsto_inv_atTop_zero",
+    "content": "This helper proves that c/n \u2192 0 in \u211d as n \u2192 \u221e over \u2115. The key ingredients are: (1) `tendsto_inv_atTop_zero`: 1/x \u2192 0 as x \u2192 +\u221e; (2) `tendsto_natCast_atTop_atTop`: the cast \u2115 \u2192 \u211d diverges to +\u221e; (3) `Filter.Tendsto.const_mul`: multiplying a convergent sequence by a constant. Note that `tendsto_const_div_atTop_nhds_0_nat` was removed from Mathlib 4.26, making this composition the current idiomatic approach.",
     "mathContext": "$\\frac{c}{n} = c \\cdot \\frac{1}{n} \\to c \\cdot 0 = 0$ as $n \\to +\\infty$. Uses $\\frac{1}{n} \\to 0$ via the composition $\\mathbb{N} \\xrightarrow{\\text{cast}} \\mathbb{R} \\xrightarrow{x^{-1}} 0$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -118,7 +118,7 @@
       "Filter.Tendsto",
       "nhds filter",
       "atTop filter",
-      "Nat.cast in ℝ"
+      "Nat.cast in \u211d"
     ]
   },
   {
@@ -129,8 +129,8 @@
       "endLine": 99
     },
     "type": "concept",
-    "title": "sin(h)/h → 1 via the Derivative Characterization",
-    "content": "This is the analytically subtle lemma underlying Archimedes' convergence. Rather than using L'Hôpital's rule or series expansions, the proof derives sin(h)/h → 1 directly from the definition of derivative: sin'(0) = cos(0) = 1, and the derivative is the limit of the difference quotient (sin(h) - sin(0))/(h - 0) = sin(h)/h. Mathlib's `hasDerivAt_iff_tendsto_slope` converts HasDerivAt to this exact limit. The `slope_def_field` and `sin_zero` simplifications then match the form of sin(h)/h.",
+    "title": "sin(h)/h \u2192 1 via the Derivative Characterization",
+    "content": "This is the analytically subtle lemma underlying Archimedes' convergence. Rather than using L'H\u00f4pital's rule or series expansions, the proof derives sin(h)/h \u2192 1 directly from the definition of derivative: sin'(0) = cos(0) = 1, and the derivative is the limit of the difference quotient (sin(h) - sin(0))/(h - 0) = sin(h)/h. Mathlib's `hasDerivAt_iff_tendsto_slope` converts HasDerivAt to this exact limit. The `slope_def_field` and `sin_zero` simplifications then match the form of sin(h)/h.",
     "mathContext": "$\\lim_{h \\to 0,\\, h \\neq 0} \\frac{\\sin h}{h} = \\lim_{h \\to 0,\\, h \\neq 0} \\frac{\\sin h - \\sin 0}{h - 0} = (\\sin)'(0) = \\cos(0) = 1$. This avoids circularity: the derivative of sin is derived in Mathlib from the power series, so no geometric reasoning is smuggled in.",
     "significance": "key",
     "relatedConcepts": [
@@ -141,7 +141,7 @@
     ],
     "prerequisites": [
       "Real.hasDerivAt_sin",
-      "HasDerivAt → Tendsto conversion",
+      "HasDerivAt \u2192 Tendsto conversion",
       "nhdsWithin",
       "slope_def_field"
     ]
@@ -154,8 +154,8 @@
       "endLine": 110
     },
     "type": "concept",
-    "title": "2π/n → 0 Through Nonzero Values",
-    "content": "This lemma establishes that 2π/n converges to 0 in `nhdsWithin 0 {0}ᶜ` — the punctured neighborhood of 0. The `nhdsWithin` is needed because `tendsto_sin_div_nhds_zero` requires the input to avoid 0 (to avoid division by zero). The proof splits into (1) 2π/n → 0 (from `tendsto_const_div_nat`) and (2) 2π/n ≠ 0 for n ≥ 1 (from positivity and cast). The `filter_upwards` tactic makes the eventual membership argument clean.",
+    "title": "2\u03c0/n \u2192 0 Through Nonzero Values",
+    "content": "This lemma establishes that 2\u03c0/n converges to 0 in `nhdsWithin 0 {0}\u1d9c` \u2014 the punctured neighborhood of 0. The `nhdsWithin` is needed because `tendsto_sin_div_nhds_zero` requires the input to avoid 0 (to avoid division by zero). The proof splits into (1) 2\u03c0/n \u2192 0 (from `tendsto_const_div_nat`) and (2) 2\u03c0/n \u2260 0 for n \u2265 1 (from positivity and cast). The `filter_upwards` tactic makes the eventual membership argument clean.",
     "mathContext": "We need $\\frac{2\\pi}{n} \\to 0$ through values $\\neq 0$, i.e., $\\frac{2\\pi}{n} \\in \\{0\\}^c$ eventually. For $n \\geq 1$: $\\frac{2\\pi}{n} > 0$ since $2\\pi > 0$ and $n > 0$. The `nhdsWithin` filter is exactly the right tool: convergence while staying in a set.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -178,8 +178,8 @@
       "endLine": 131
     },
     "type": "insight",
-    "title": "n·sin(2π/n) → 2π: Composing the Key Limits",
-    "content": "This is the analytical heart of Archimedes' proof. The key algebraic insight is writing n·sin(2π/n) = 2π·[sin(2π/n)/(2π/n)] — factoring out 2π and reducing to the sin(h)/h → 1 form with h = 2π/n. The `filter_upwards` with `field_simp` closes the algebraic equivalence, and then the composition `tendsto_sin_div_nhds_zero.comp tendsto_two_pi_div_atTop` assembles the limit chain. A subtlety: `key.symm` fails because `Filter.Eventually.symm` doesn't exist — instead, `key.mono (fun _ h => h.symm)` propagates the `EventuallyEq` symmetry correctly.",
+    "title": "n\u00b7sin(2\u03c0/n) \u2192 2\u03c0: Composing the Key Limits",
+    "content": "This is the analytical heart of Archimedes' proof. The key algebraic insight is writing n\u00b7sin(2\u03c0/n) = 2\u03c0\u00b7[sin(2\u03c0/n)/(2\u03c0/n)] \u2014 factoring out 2\u03c0 and reducing to the sin(h)/h \u2192 1 form with h = 2\u03c0/n. The `filter_upwards` with `field_simp` closes the algebraic equivalence, and then the composition `tendsto_sin_div_nhds_zero.comp tendsto_two_pi_div_atTop` assembles the limit chain. A subtlety: `key.symm` fails because `Filter.Eventually.symm` doesn't exist \u2014 instead, `key.mono (fun _ h => h.symm)` propagates the `EventuallyEq` symmetry correctly.",
     "mathContext": "$n \\sin\\!\\left(\\frac{2\\pi}{n}\\right) = 2\\pi \\cdot \\frac{\\sin(2\\pi/n)}{2\\pi/n} \\xrightarrow{n \\to \\infty} 2\\pi \\cdot 1 = 2\\pi$. The substitution $h = 2\\pi/n \\to 0$ reduces this to $\\lim_{h \\to 0} \\frac{\\sin h}{h} = 1$.",
     "significance": "key",
     "relatedConcepts": [
@@ -202,9 +202,9 @@
       "startLine": 134,
       "endLine": 145
     },
-    "type": "theorem",
-    "title": "Archimedes' Main Theorem: inscribedArea n r → πr²",
-    "content": "This theorem is Archimedes' exhaustion result in modern dress. The proof rewrites inscribedArea as (r²/2) · (n · sin(2π/n)) and applies `tendsto_const_nhds.mul tendsto_n_sin_two_pi_div_n` — the limit of a product is the product of limits. The goal `πr²` is rewritten as `r²/2 · 2π` by ring to match, then `congr'` with a filter_upwards closes the final algebraic identity.",
+    "type": "insight",
+    "title": "Archimedes' Main Theorem: inscribedArea n r \u2192 \u03c0r\u00b2",
+    "content": "This theorem is Archimedes' exhaustion result in modern dress. The proof rewrites inscribedArea as (r\u00b2/2) \u00b7 (n \u00b7 sin(2\u03c0/n)) and applies `tendsto_const_nhds.mul tendsto_n_sin_two_pi_div_n` \u2014 the limit of a product is the product of limits. The goal `\u03c0r\u00b2` is rewritten as `r\u00b2/2 \u00b7 2\u03c0` by ring to match, then `congr'` with a filter_upwards closes the final algebraic identity.",
     "mathContext": "$\\text{inscribedArea}(n, r) = \\frac{n}{2} r^2 \\sin\\!\\left(\\frac{2\\pi}{n}\\right) = \\frac{r^2}{2} \\cdot \\underbrace{n \\sin\\!\\left(\\frac{2\\pi}{n}\\right)}_{\\to 2\\pi} \\to \\frac{r^2}{2} \\cdot 2\\pi = \\pi r^2$.",
     "significance": "key",
     "relatedConcepts": [
@@ -226,20 +226,20 @@
       "startLine": 155,
       "endLine": 160
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Central Connection: Archimedes Limit = FTC Integral",
-    "content": "This is the theorem that answers OQ-01-OQ-02-OQ-03. The proof is just three lines: rewrite the integral as `circleArea r` (using `circumference_integral_eq`), unfold `circleArea` to `π·r²`, and cite `tendsto_inscribed_to_pi_r_sq`. The conceptual content is deep: two 2000-year-apart limiting processes converge to the same value, and in Lean this reduces to two lines of term rewriting. The connection is made rigorous by working in the same metric space ℝ with its unique Hausdorff topology.",
+    "content": "This is the theorem that answers OQ-01-OQ-02-OQ-03. The proof is just three lines: rewrite the integral as `circleArea r` (using `circumference_integral_eq`), unfold `circleArea` to `\u03c0\u00b7r\u00b2`, and cite `tendsto_inscribed_to_pi_r_sq`. The conceptual content is deep: two 2000-year-apart limiting processes converge to the same value, and in Lean this reduces to two lines of term rewriting. The connection is made rigorous by working in the same metric space \u211d with its unique Hausdorff topology.",
     "mathContext": "$\\lim_{n\\to\\infty} \\text{inscribedArea}(n, r) = \\pi r^2 = \\int_0^r 2\\pi\\rho\\,d\\rho$. Formally: the Archimedes sequence has limit `circleArea r`, which is also the FTC integral value. Both limits live in $\\mathbb{R}$ and equal the same expression.",
     "significance": "key",
     "relatedConcepts": [
-      "limit uniqueness in ℝ",
+      "limit uniqueness in \u211d",
       "Hausdorff topology",
       "circumference_integral_eq",
       "tendsto_inscribed_to_pi_r_sq"
     ],
     "prerequisites": [
       "Filter.Tendsto",
-      "nhds in ℝ",
+      "nhds in \u211d",
       "Hausdorff property",
       "circumference_integral_eq"
     ]
@@ -251,9 +251,9 @@
       "startLine": 170,
       "endLine": 182
     },
-    "type": "theorem",
-    "title": "Inscribed Polygon ≤ πr² via sin(x) < x",
-    "content": "This theorem proves the upper bound inscribedArea(n, r) ≤ πr² for all n and r ≥ 0, using Mathlib's `Real.sin_lt`: sin(x) < x for x > 0. The proof handles n = 0 separately (0-gon has area 0), then for n ≥ 1 constructs the chain: `n/2 · r² · sin(2π/n) ≤ n/2 · r² · (2π/n) = πr²`. Notably, `field_simp [ne_of_gt hn']` closes the algebraic simplification completely — adding `; ring` after it would cause a failure.",
+    "type": "insight",
+    "title": "Inscribed Polygon \u2264 \u03c0r\u00b2 via sin(x) < x",
+    "content": "This theorem proves the upper bound inscribedArea(n, r) \u2264 \u03c0r\u00b2 for all n and r \u2265 0, using Mathlib's `Real.sin_lt`: sin(x) < x for x > 0. The proof handles n = 0 separately (0-gon has area 0), then for n \u2265 1 constructs the chain: `n/2 \u00b7 r\u00b2 \u00b7 sin(2\u03c0/n) \u2264 n/2 \u00b7 r\u00b2 \u00b7 (2\u03c0/n) = \u03c0r\u00b2`. Notably, `field_simp [ne_of_gt hn']` closes the algebraic simplification completely \u2014 adding `; ring` after it would cause a failure.",
     "mathContext": "For $x > 0$: $\\sin x < x$, so $\\frac{n}{2}r^2\\sin\\!\\left(\\frac{2\\pi}{n}\\right) \\leq \\frac{n}{2}r^2 \\cdot \\frac{2\\pi}{n} = \\pi r^2$. This is the classical upper bound in Archimedes' double exhaustion: inscribed polygons never overshoot the circle's area.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -276,14 +276,14 @@
       "startLine": 190,
       "endLine": 200
     },
-    "type": "theorem",
-    "title": "ε-N Formulation of Archimedes' Approximation",
-    "content": "This theorem restates the Archimedes convergence in classical ε-N form: for any ε > 0, there exists N such that for all n ≥ N, |inscribedArea(n, r) - πr²| < ε. The proof extracts this directly from the Filter.Tendsto result via `Metric.tendsto_atTop`, which converts topological filter convergence into the metric ε-N definition. This bridge between filter-style and metric convergence is a standard Mathlib pattern.",
+    "type": "insight",
+    "title": "\u03b5-N Formulation of Archimedes' Approximation",
+    "content": "This theorem restates the Archimedes convergence in classical \u03b5-N form: for any \u03b5 > 0, there exists N such that for all n \u2265 N, |inscribedArea(n, r) - \u03c0r\u00b2| < \u03b5. The proof extracts this directly from the Filter.Tendsto result via `Metric.tendsto_atTop`, which converts topological filter convergence into the metric \u03b5-N definition. This bridge between filter-style and metric convergence is a standard Mathlib pattern.",
     "mathContext": "$\\forall \\varepsilon > 0,\\; \\exists N \\in \\mathbb{N},\\; \\forall n \\geq N,\\; |\\text{inscribedArea}(n,r) - \\pi r^2| < \\varepsilon$. Equivalent to the filter formulation via `Metric.tendsto_atTop`.",
     "significance": "supporting",
     "relatedConcepts": [
       "Metric.tendsto_atTop",
-      "ε-N convergence",
+      "\u03b5-N convergence",
       "Real.dist_eq as absolute value",
       "filter-to-metric bridge"
     ],
@@ -300,16 +300,16 @@
       "startLine": 203,
       "endLine": 206
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Uniqueness: Hausdorff Identifies the Two Methods",
-    "content": "This one-line proof is the philosophical core of the file. `tendsto_nhds_unique` states that if a sequence has two limits in a Hausdorff space, they must be equal. Here: if inscribedArea(n, r) → A for any A, then A = the FTC integral. The proof is literally `tendsto_nhds_unique h_exhaust (exhaustion_equals_ftc r)`. This formalizes exactly what Archimedes was implicitly assuming: that the circle has a unique area, and any consistent approximation scheme converges to it.",
+    "content": "This one-line proof is the philosophical core of the file. `tendsto_nhds_unique` states that if a sequence has two limits in a Hausdorff space, they must be equal. Here: if inscribedArea(n, r) \u2192 A for any A, then A = the FTC integral. The proof is literally `tendsto_nhds_unique h_exhaust (exhaustion_equals_ftc r)`. This formalizes exactly what Archimedes was implicitly assuming: that the circle has a unique area, and any consistent approximation scheme converges to it.",
     "mathContext": "In a Hausdorff topological space, limits are unique: if $x_n \\to L_1$ and $x_n \\to L_2$, then $L_1 = L_2$. Here $\\mathbb{R}$ is Hausdorff (T2), so $\\lim_n \\text{inscribedArea}(n,r) = \\int_0^r 2\\pi\\rho\\,d\\rho$ regardless of which path gives the limit.",
     "significance": "key",
     "relatedConcepts": [
       "Hausdorff uniqueness of limits",
       "tendsto_nhds_unique",
       "T2Space",
-      "limit uniqueness in ℝ"
+      "limit uniqueness in \u211d"
     ],
     "prerequisites": [
       "Filter.tendsto_nhds_unique",
@@ -324,10 +324,10 @@
       "startLine": 162,
       "endLine": 167
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Conjunction: FTC Integral and Exhaustion Both Equal circleArea",
-    "content": "`ftc_equals_exhaustion_limit` bundles both core facts into a single conjunction: (1) the FTC integral equals `circleArea r`; (2) the Archimedes sequence converges to `circleArea r`. The proof is a pair `⟨circumference_integral_eq r, ...⟩` where the second component uses `simp [circleArea]` to unfold the definition before applying `tendsto_inscribed_to_pi_r_sq`. This conjunction theorem is useful as a single witness: any downstream result needing both facts can destructure `ftc_equals_exhaustion_limit r` rather than citing the two theorems separately. In Lean, conjunction proofs like `⟨h1, h2⟩` are anonymous constructors for `And`.",
-    "mathContext": "$\\int_0^r 2\\pi\\rho\\,d\\rho = \\pi r^2$ (FTC, Part I) $\\wedge$ $\\lim_{n\\to\\infty}\\text{inscribedArea}(n,r) = \\pi r^2$ (Archimedes, Part II). Together: the common limit value is `circleArea r = πr²`.",
+    "content": "`ftc_equals_exhaustion_limit` bundles both core facts into a single conjunction: (1) the FTC integral equals `circleArea r`; (2) the Archimedes sequence converges to `circleArea r`. The proof is a pair `\u27e8circumference_integral_eq r, ...\u27e9` where the second component uses `simp [circleArea]` to unfold the definition before applying `tendsto_inscribed_to_pi_r_sq`. This conjunction theorem is useful as a single witness: any downstream result needing both facts can destructure `ftc_equals_exhaustion_limit r` rather than citing the two theorems separately. In Lean, conjunction proofs like `\u27e8h1, h2\u27e9` are anonymous constructors for `And`.",
+    "mathContext": "$\\int_0^r 2\\pi\\rho\\,d\\rho = \\pi r^2$ (FTC, Part I) $\\wedge$ $\\lim_{n\\to\\infty}\\text{inscribedArea}(n,r) = \\pi r^2$ (Archimedes, Part II). Together: the common limit value is `circleArea r = \u03c0r\u00b2`.",
     "significance": "supporting",
     "relatedConcepts": [
       "And introduction",
@@ -348,10 +348,10 @@
       "startLine": 184,
       "endLine": 187
     },
-    "type": "theorem",
-    "title": "Archimedes' Squeeze from Below: Inscribed ≤ circleArea",
-    "content": "`archimedes_squeeze_from_below` reframes `inscribed_area_le_pi_r_sq` using the `circleArea` definition: for any n and r ≥ 0, `inscribedArea n r ≤ circleArea r`. The proof is one line: `simp [circleArea]; exact inscribed_area_le_pi_r_sq n r hr`. This phrasing matches Archimedes' geometric intuition: inscribed polygons are strictly inside the circle, so their area never exceeds the true circle area. Combined with convergence from below, this is the lower half of Archimedes' double exhaustion squeeze. In Archimedes' original proof, he used both inscribed (lower bound) and circumscribed (upper bound) polygons to trap the true area by a two-sided argument; this theorem formalizes the lower bound.",
-    "mathContext": "$\\forall n \\in \\mathbb{N},\\; r \\geq 0 \\implies \\text{inscribedArea}(n,r) \\leq \\pi r^2 = \\text{circleArea}(r)$. The sequence is monotone-eventually and bounded above by the limit — a sufficient condition for convergence in ℝ.",
+    "type": "insight",
+    "title": "Archimedes' Squeeze from Below: Inscribed \u2264 circleArea",
+    "content": "`archimedes_squeeze_from_below` reframes `inscribed_area_le_pi_r_sq` using the `circleArea` definition: for any n and r \u2265 0, `inscribedArea n r \u2264 circleArea r`. The proof is one line: `simp [circleArea]; exact inscribed_area_le_pi_r_sq n r hr`. This phrasing matches Archimedes' geometric intuition: inscribed polygons are strictly inside the circle, so their area never exceeds the true circle area. Combined with convergence from below, this is the lower half of Archimedes' double exhaustion squeeze. In Archimedes' original proof, he used both inscribed (lower bound) and circumscribed (upper bound) polygons to trap the true area by a two-sided argument; this theorem formalizes the lower bound.",
+    "mathContext": "$\\forall n \\in \\mathbb{N},\\; r \\geq 0 \\implies \\text{inscribedArea}(n,r) \\leq \\pi r^2 = \\text{circleArea}(r)$. The sequence is monotone-eventually and bounded above by the limit \u2014 a sufficient condition for convergence in \u211d.",
     "significance": "supporting",
     "relatedConcepts": [
       "Archimedes double exhaustion",
@@ -372,9 +372,9 @@
       "startLine": 208,
       "endLine": 213
     },
-    "type": "theorem",
-    "title": "Consistency Check: πr² Equals the FTC Integral",
-    "content": "`exhaustion_consistent` proves the equality `πr² = ∫₀ʳ 2πρ dρ` — the direction opposite to `circumference_integral_eq`. The proof uses `circumference_integral_eq` and then reverses with `.symm`. This seemingly trivial theorem serves as a sanity check and an explicitly named entry point for downstream proofs that need the equality in the form `Real.pi * r ^ 2 = ∫ ρ ...`. In Lean, equality is symmetric but not definitionally, so having both directions as named theorems avoids repeated `rw [← circumference_integral_eq]` patterns.",
+    "type": "insight",
+    "title": "Consistency Check: \u03c0r\u00b2 Equals the FTC Integral",
+    "content": "`exhaustion_consistent` proves the equality `\u03c0r\u00b2 = \u222b\u2080\u02b3 2\u03c0\u03c1 d\u03c1` \u2014 the direction opposite to `circumference_integral_eq`. The proof uses `circumference_integral_eq` and then reverses with `.symm`. This seemingly trivial theorem serves as a sanity check and an explicitly named entry point for downstream proofs that need the equality in the form `Real.pi * r ^ 2 = \u222b \u03c1 ...`. In Lean, equality is symmetric but not definitionally, so having both directions as named theorems avoids repeated `rw [\u2190 circumference_integral_eq]` patterns.",
     "mathContext": "$\\pi r^2 = \\int_0^r 2\\pi\\rho\\,d\\rho$. This is the converse of the FTC direction `circumference_integral_eq`: the FTC gives $\\int = \\pi r^2$; this theorem gives $\\pi r^2 = \\int$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-31/annotations.json
+++ b/src/data/proofs/erdos-31/annotations.json
@@ -8,8 +8,8 @@
     },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #31**: Additive Complements\n\n**Statement**: For any infinite set A ⊆ ℕ, there exists B with density 0 such that A + B covers all but finitely many positive integers.\n\n**Status**: SOLVED (Lorentz 1954)\n\n**Key insight**: Even very sparse infinite sets can be 'completed' to cover almost all of ℕ using another sparse set.\n\n**Origin**: Conjectured by Erdős-Straus.",
-    "mathContext": "This is a fundamental result in additive combinatorics showing the flexibility of additive structure. The sumset A + B = {a + b : a ∈ A, b ∈ B}.",
+    "content": "**Erd\u0151s Problem #31**: Additive Complements\n\n**Statement**: For any infinite set A \u2286 \u2115, there exists B with density 0 such that A + B covers all but finitely many positive integers.\n\n**Status**: SOLVED (Lorentz 1954)\n\n**Key insight**: Even very sparse infinite sets can be 'completed' to cover almost all of \u2115 using another sparse set.\n\n**Origin**: Conjectured by Erd\u0151s-Straus.",
+    "mathContext": "This is a fundamental result in additive combinatorics showing the flexibility of additive structure. The sumset A + B = {a + b : a \u2208 A, b \u2208 B}.",
     "significance": "key",
     "relatedConcepts": [
       "additive-complements",
@@ -17,9 +17,9 @@
       "lorentz-1954"
     ],
     "prerequisites": [
-      "Asymptotic density of subsets of ℕ",
+      "Asymptotic density of subsets of \u2115",
       "Sumset (Minkowski sum) of two sets",
-      "Cofinite subsets of ℕ",
+      "Cofinite subsets of \u2115",
       "Set.Infinite (Mathlib predicate)"
     ]
   },
@@ -32,7 +32,7 @@
     },
     "type": "definition",
     "title": "Density Definitions",
-    "content": "**countingFn A N** = |A ∩ {1,...,N}| (counting function)\n\n**HasDensity A d**: countingFn(A,N)/N → d as N → ∞\n\n**HasDensityZero A**: HasDensity A 0 (sparse sets)\n\n**upperDensity A** = limsup of countingFn(A,N)/N",
+    "content": "**countingFn A N** = |A \u2229 {1,...,N}| (counting function)\n\n**HasDensity A d**: countingFn(A,N)/N \u2192 d as N \u2192 \u221e\n\n**HasDensityZero A**: HasDensity A 0 (sparse sets)\n\n**upperDensity A** = limsup of countingFn(A,N)/N",
     "mathContext": "Density 0 means the set is asymptotically negligible but may still be infinite. Examples: primes, powers of 2, perfect squares.",
     "significance": "key",
     "relatedConcepts": [
@@ -42,7 +42,7 @@
     ],
     "prerequisites": [
       "Filter.Tendsto (limit along a filter)",
-      "Filter.atTop (cofinite filter on ℕ)",
+      "Filter.atTop (cofinite filter on \u2115)",
       "Set.ncard (cardinality of a set)",
       "Filter.limsup (limit superior along a filter)"
     ]
@@ -56,7 +56,7 @@
     },
     "type": "definition",
     "title": "Sumsets and Coverage",
-    "content": "**Sumset A B** = {n | ∃ a ∈ A, ∃ b ∈ B, n = a + b}\nNotation: A +ₛ B\n\n**CoversCofinite A B**: ∃ N₀, ∀ n ≥ N₀, n ∈ A +ₛ B\n\n**CoversAllButFinitely A B**: (ℕ \\ (A +ₛ B)) ∩ ℕ+ is finite\n\nBoth capture 'covers almost all positive integers'.",
+    "content": "**Sumset A B** = {n | \u2203 a \u2208 A, \u2203 b \u2208 B, n = a + b}\nNotation: A +\u209b B\n\n**CoversCofinite A B**: \u2203 N\u2080, \u2200 n \u2265 N\u2080, n \u2208 A +\u209b B\n\n**CoversAllButFinitely A B**: (\u2115 \\ (A +\u209b B)) \u2229 \u2115+ is finite\n\nBoth capture 'covers almost all positive integers'.",
     "mathContext": "The distinction between CoversCofinite and CoversAllButFinitely is technical - both mean the missing set is finite.",
     "significance": "key",
     "relatedConcepts": [
@@ -68,7 +68,7 @@
       "Set.Finite (finiteness of sets in Mathlib)",
       "Set.Icc (closed interval in an ordered type)",
       "Minkowski sum / additive combinatorics sumset",
-      "Cofinite topology / cofinite filter on ℕ"
+      "Cofinite topology / cofinite filter on \u2115"
     ]
   },
   {
@@ -80,7 +80,7 @@
     },
     "type": "concept",
     "title": "Primes Have Density Zero",
-    "content": "**axiom primes_density_zero**: The primes form an infinite set of density 0.\n\nBy the Prime Number Theorem: π(N) ~ N/log N\nSo π(N)/N ~ 1/log N → 0.",
+    "content": "**axiom primes_density_zero**: The primes form an infinite set of density 0.\n\nBy the Prime Number Theorem: \u03c0(N) ~ N/log N\nSo \u03c0(N)/N ~ 1/log N \u2192 0.",
     "mathContext": "This is a standard result from analytic number theory. The primes are sparse (density 0) but infinite.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -89,9 +89,9 @@
       "primes"
     ],
     "prerequisites": [
-      "Prime Number Theorem: π(N) ~ N / log N",
+      "Prime Number Theorem: \u03c0(N) ~ N / log N",
       "Nat.Prime (primality predicate in Mathlib)",
-      "Nat.primeCounting (prime-counting function π(N))",
+      "Nat.primeCounting (prime-counting function \u03c0(N))",
       "HasDensityZero definition (this file)"
     ]
   },
@@ -102,10 +102,10 @@
       "startLine": 70,
       "endLine": 90
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Powers of 2 Bijection (Verified)",
-    "content": "**lemma powers_of_2_in_Icc_eq** ✓\n\n{2^k} ∩ [1,N] = image of [0, log₂N] under k ↦ 2^k\n\n**Proof**:\n- If n = 2^k ∈ [1,N], then k ≤ log₂N\n- If k ≤ log₂N, then 2^k ≤ N\n\nThis bijection enables counting powers of 2.",
-    "mathContext": "The powers of 2 in [1,N] are exactly {1, 2, 4, ..., 2^⌊log₂N⌋}. There are ⌊log₂N⌋ + 1 of them.",
+    "content": "**lemma powers_of_2_in_Icc_eq** \u2713\n\n{2^k} \u2229 [1,N] = image of [0, log\u2082N] under k \u21a6 2^k\n\n**Proof**:\n- If n = 2^k \u2208 [1,N], then k \u2264 log\u2082N\n- If k \u2264 log\u2082N, then 2^k \u2264 N\n\nThis bijection enables counting powers of 2.",
+    "mathContext": "The powers of 2 in [1,N] are exactly {1, 2, 4, ..., 2^\u230alog\u2082N\u230b}. There are \u230alog\u2082N\u230b + 1 of them.",
     "significance": "key",
     "relatedConcepts": [
       "bijection",
@@ -126,9 +126,9 @@
       "startLine": 93,
       "endLine": 111
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Powers of 2 Count Bound (Verified)",
-    "content": "**theorem powers_of_2_count_bound** ✓\n\n|{2^k} ∩ [1,N]| ≤ log₂(N) + 1\n\n**Proof**: Uses the bijection to [0, log₂N], then counts that interval.\n\nThis is tight: exactly log₂(N) + 1 powers of 2 in [1,N].",
+    "content": "**theorem powers_of_2_count_bound** \u2713\n\n|{2^k} \u2229 [1,N]| \u2264 log\u2082(N) + 1\n\n**Proof**: Uses the bijection to [0, log\u2082N], then counts that interval.\n\nThis is tight: exactly log\u2082(N) + 1 powers of 2 in [1,N].",
     "mathContext": "The count is O(log N), which is much smaller than N. This is why powers of 2 have density 0.",
     "significance": "key",
     "relatedConcepts": [
@@ -150,10 +150,10 @@
       "startLine": 118,
       "endLine": 173
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Log Ratio Limit (Verified)",
-    "content": "**theorem tendsto_log_add_one_div** ✓\n\n(log₂(N) + 1)/N → 0 as N → ∞\n\n**Proof strategy**: Squeeze theorem\n- Lower: 0 ≤ f(N)\n- Upper: f(N) ≤ (Real.log N / Real.log 2 + 1)/N → 0\n\nUses Mathlib's `tendsto_pow_log_div_mul_add_atTop` for log N/N → 0.",
-    "mathContext": "This is the key analytic lemma. The proof carefully bounds Nat.log by Real.log and uses that log N/N → 0.",
+    "content": "**theorem tendsto_log_add_one_div** \u2713\n\n(log\u2082(N) + 1)/N \u2192 0 as N \u2192 \u221e\n\n**Proof strategy**: Squeeze theorem\n- Lower: 0 \u2264 f(N)\n- Upper: f(N) \u2264 (Real.log N / Real.log 2 + 1)/N \u2192 0\n\nUses Mathlib's `tendsto_pow_log_div_mul_add_atTop` for log N/N \u2192 0.",
+    "mathContext": "This is the key analytic lemma. The proof carefully bounds Nat.log by Real.log and uses that log N/N \u2192 0.",
     "significance": "key",
     "relatedConcepts": [
       "squeeze-theorem",
@@ -163,7 +163,7 @@
     "prerequisites": [
       "Filter.Tendsto.squeeze (squeeze theorem for limits)",
       "Real.log (natural logarithm in Mathlib)",
-      "tendsto_pow_log_div_mul_add_atTop (log N / N → 0 in Mathlib)",
+      "tendsto_pow_log_div_mul_add_atTop (log N / N \u2192 0 in Mathlib)",
       "Nat.log_le_clog (Nat.log bounded by Real.log)"
     ]
   },
@@ -174,9 +174,9 @@
       "startLine": 175,
       "endLine": 184
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Powers of 2 Have Density Zero (Verified)",
-    "content": "**theorem powers_of_2_density_zero** ✓\n\nHasDensityZero {n | ∃ k, n = 2^k}\n\n**Proof**: Combine the count bound with the log limit:\n\ncountingFn/N ≤ (log₂(N) + 1)/N → 0",
+    "content": "**theorem powers_of_2_density_zero** \u2713\n\nHasDensityZero {n | \u2203 k, n = 2^k}\n\n**Proof**: Combine the count bound with the log limit:\n\ncountingFn/N \u2264 (log\u2082(N) + 1)/N \u2192 0",
     "mathContext": "This verified theorem is a model case for showing sparse sets have density 0. The same pattern applies to other sparse sets.",
     "significance": "key",
     "relatedConcepts": [
@@ -198,10 +198,10 @@
       "startLine": 188,
       "endLine": 215
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Squares Bijection (Verified)",
-    "content": "**lemma squares_in_Icc_eq** ✓\n\n{k²} ∩ [1,N] = image of [1, √N] under k ↦ k²\n\n**Proof**:\n- If n = k² ∈ [1,N], then k ≤ √N\n- If k ≤ √N, then k² ≤ N\n\nUses `Nat.le_sqrt` and `Nat.sqrt_le` from Mathlib.",
-    "mathContext": "The squares in [1,N] are {1, 4, 9, ..., ⌊√N⌋²}. There are ⌊√N⌋ of them.",
+    "content": "**lemma squares_in_Icc_eq** \u2713\n\n{k\u00b2} \u2229 [1,N] = image of [1, \u221aN] under k \u21a6 k\u00b2\n\n**Proof**:\n- If n = k\u00b2 \u2208 [1,N], then k \u2264 \u221aN\n- If k \u2264 \u221aN, then k\u00b2 \u2264 N\n\nUses `Nat.le_sqrt` and `Nat.sqrt_le` from Mathlib.",
+    "mathContext": "The squares in [1,N] are {1, 4, 9, ..., \u230a\u221aN\u230b\u00b2}. There are \u230a\u221aN\u230b of them.",
     "significance": "key",
     "relatedConcepts": [
       "squares",
@@ -210,7 +210,7 @@
     ],
     "prerequisites": [
       "Nat.sqrt (integer square root in Mathlib)",
-      "Nat.le_sqrt (characterization: k ≤ √N ↔ k² ≤ N)",
+      "Nat.le_sqrt (characterization: k \u2264 \u221aN \u2194 k\u00b2 \u2264 N)",
       "Finset.image (image of a function on a Finset)",
       "Set.Icc (closed interval)"
     ]
@@ -224,8 +224,8 @@
     },
     "type": "concept",
     "title": "Squares Count Bound (Verified)",
-    "content": "**theorem squares_count_bound** ✓\n\n|{k²} ∩ [1,N]| ≤ √N + 1\n\n**Proof**: Uses the bijection to [1, √N], then counts.\n\nThe +1 handles the case N = 0.",
-    "mathContext": "The count is O(√N), much smaller than N. This is why squares have density 0.",
+    "content": "**theorem squares_count_bound** \u2713\n\n|{k\u00b2} \u2229 [1,N]| \u2264 \u221aN + 1\n\n**Proof**: Uses the bijection to [1, \u221aN], then counts.\n\nThe +1 handles the case N = 0.",
+    "mathContext": "The count is O(\u221aN), much smaller than N. This is why squares have density 0.",
     "significance": "key",
     "relatedConcepts": [
       "counting",
@@ -248,8 +248,8 @@
     },
     "type": "concept",
     "title": "Square Root Ratio Limit (Verified)",
-    "content": "**theorem tendsto_sqrt_inv** ✓\n\n(√N + 1)/N → 0 as N → ∞\n\n**Proof strategy**: Squeeze theorem\n- Upper bound: (√N + 1)/N ≤ 2/√N → 0\n- Key: √N ≤ N (for N ≥ 1)\n\nUses `tendsto_rpow_atTop` for √N → ∞.",
-    "mathContext": "This is the analytic lemma for squares. The proof bounds (√N + 1)/N by 2/√N and shows that tends to 0.",
+    "content": "**theorem tendsto_sqrt_inv** \u2713\n\n(\u221aN + 1)/N \u2192 0 as N \u2192 \u221e\n\n**Proof strategy**: Squeeze theorem\n- Upper bound: (\u221aN + 1)/N \u2264 2/\u221aN \u2192 0\n- Key: \u221aN \u2264 N (for N \u2265 1)\n\nUses `tendsto_rpow_atTop` for \u221aN \u2192 \u221e.",
+    "mathContext": "This is the analytic lemma for squares. The proof bounds (\u221aN + 1)/N by 2/\u221aN and shows that tends to 0.",
     "significance": "key",
     "relatedConcepts": [
       "squeeze-theorem",
@@ -258,7 +258,7 @@
     ],
     "prerequisites": [
       "Real.sqrt (real square root in Mathlib)",
-      "tendsto_rpow_atTop (x^r → ∞ for r > 0)",
+      "tendsto_rpow_atTop (x^r \u2192 \u221e for r > 0)",
       "Filter.Tendsto.squeeze / tendsto_of_tendsto_of_tendsto_of_le_of_le",
       "Real.sqrt_le_sqrt (monotonicity of sqrt)"
     ]
@@ -270,9 +270,9 @@
       "startLine": 297,
       "endLine": 306
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Squares Have Density Zero (Verified)",
-    "content": "**theorem squares_density_zero** ✓\n\nHasDensityZero {n | ∃ k, n = k²}\n\n**Proof**: Same pattern as powers of 2:\ncountingFn/N ≤ (√N + 1)/N → 0",
+    "content": "**theorem squares_density_zero** \u2713\n\nHasDensityZero {n | \u2203 k, n = k\u00b2}\n\n**Proof**: Same pattern as powers of 2:\ncountingFn/N \u2264 (\u221aN + 1)/N \u2192 0",
     "mathContext": "Another verified density-zero theorem. Together with primes and powers of 2, these are key examples of sparse infinite sets.",
     "significance": "key",
     "relatedConcepts": [
@@ -294,10 +294,10 @@
       "startLine": 310,
       "endLine": 320
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Main Theorem Statement",
-    "content": "**Erdos31Statement**:\n∀ A : Set ℕ, A.Infinite →\n  ∃ B : Set ℕ, HasDensityZero B ∧ CoversAllButFinitely A B\n\n**axiom lorentz_theorem : Erdos31Statement** ✓\n\nThis is the core result: Lorentz (1954) proved it constructively.",
-    "mathContext": "The theorem says any infinite A can be 'completed' to cover almost all of ℕ using a density-0 set B. The construction builds B by filling gaps.",
+    "content": "**Erdos31Statement**:\n\u2200 A : Set \u2115, A.Infinite \u2192\n  \u2203 B : Set \u2115, HasDensityZero B \u2227 CoversAllButFinitely A B\n\n**axiom lorentz_theorem : Erdos31Statement** \u2713\n\nThis is the core result: Lorentz (1954) proved it constructively.",
+    "mathContext": "The theorem says any infinite A can be 'completed' to cover almost all of \u2115 using a density-0 set B. The construction builds B by filling gaps.",
     "significance": "key",
     "relatedConcepts": [
       "lorentz-theorem",
@@ -320,7 +320,7 @@
     },
     "type": "concept",
     "title": "Lorentz's Density Bound",
-    "content": "**axiom lorentz_B_bound**:\n\nFor infinite A, ∃ B with:\n- HasDensityZero B ✓\n- CoversAllButFinitely A B ✓  \n- |B ∩ [1,N]| ≤ C · N/log N for some C > 0\n\nThe bound O(N/log N) is essentially optimal.",
+    "content": "**axiom lorentz_B_bound**:\n\nFor infinite A, \u2203 B with:\n- HasDensityZero B \u2713\n- CoversAllButFinitely A B \u2713  \n- |B \u2229 [1,N]| \u2264 C \u00b7 N/log N for some C > 0\n\nThe bound O(N/log N) is essentially optimal.",
     "mathContext": "This strengthened version shows B can be quite sparse - growing slower than any polynomial. For most A, B can be even sparser.",
     "significance": "key",
     "relatedConcepts": [
@@ -342,9 +342,9 @@
       "startLine": 340,
       "endLine": 352
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Powers of 2 Example (Verified)",
-    "content": "**example** ✓: ∃ B with density 0 such that {2^k} +ₛ B covers cofinitely.\n\n**Proof**:\n1. Show {2^k} is infinite (injective function)\n2. Apply lorentz_theorem\n\nThe powers of 2 are extremely sparse but still completable!",
+    "content": "**example** \u2713: \u2203 B with density 0 such that {2^k} +\u209b B covers cofinitely.\n\n**Proof**:\n1. Show {2^k} is infinite (injective function)\n2. Apply lorentz_theorem\n\nThe powers of 2 are extremely sparse but still completable!",
     "mathContext": "This example shows even very sparse sets like powers of 2 have additive complements with density 0.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -368,7 +368,7 @@
     },
     "type": "concept",
     "title": "Optimal B-Density is Zero (Verified)",
-    "content": "**OptimalBDensity A** = inf{d : ∃ B with density d covering cofinitely}\n\n**theorem optimal_B_density_zero** ✓:\nFor infinite A, OptimalBDensity A = 0\n\n**Proof**:\n- sInf ≤ 0: Lorentz gives B with density 0\n- 0 ≤ sInf: Densities are ≥ 0 (non-negative)",
+    "content": "**OptimalBDensity A** = inf{d : \u2203 B with density d covering cofinitely}\n\n**theorem optimal_B_density_zero** \u2713:\nFor infinite A, OptimalBDensity A = 0\n\n**Proof**:\n- sInf \u2264 0: Lorentz gives B with density 0\n- 0 \u2264 sInf: Densities are \u2265 0 (non-negative)",
     "mathContext": "This theorem uses real analysis (csInf, le_antisymm) to show that 0 is not just achievable but optimal.",
     "significance": "key",
     "relatedConcepts": [
@@ -378,7 +378,7 @@
     ],
     "prerequisites": [
       "Real.sInf (infimum of a set of reals in Mathlib)",
-      "le_antisymm (antisymmetry of ≤ to prove equality)",
+      "le_antisymm (antisymmetry of \u2264 to prove equality)",
       "lorentz_theorem axiom (this file)",
       "HasDensity / density non-negativity"
     ]
@@ -390,9 +390,9 @@
       "startLine": 415,
       "endLine": 452
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Coverage Requires Infinity (Verified)",
-    "content": "**theorem coverage_requires_density** ✓:\n\nIf A +ₛ B covers cofinitely, then:\n- ¬(HasDensityZero A ∧ HasDensityZero B), OR\n- A.Infinite, OR\n- B.Infinite\n\n**Key insight**: Finite A × Finite B = Finite sumset, which can't cover cofinitely.\n\nProof constructs the finite sumset and shows its complement is infinite.",
+    "content": "**theorem coverage_requires_density** \u2713:\n\nIf A +\u209b B covers cofinitely, then:\n- \u00ac(HasDensityZero A \u2227 HasDensityZero B), OR\n- A.Infinite, OR\n- B.Infinite\n\n**Key insight**: Finite A \u00d7 Finite B = Finite sumset, which can't cover cofinitely.\n\nProof constructs the finite sumset and shows its complement is infinite.",
     "mathContext": "This is a nice structural result: to cover almost everything, you need at least one infinite set. Both being finite is impossible.",
     "significance": "key",
     "relatedConcepts": [
@@ -403,7 +403,7 @@
     "prerequisites": [
       "Set.Finite.image (image of a finite set is finite)",
       "Set.Finite.prod (product of finite sets is finite)",
-      "Set.infinite_of_not_bddAbove (unbounded subsets of ℕ are infinite)",
+      "Set.infinite_of_not_bddAbove (unbounded subsets of \u2115 are infinite)",
       "CoversAllButFinitely / CoversCofinite definitions (this file)"
     ]
   },
@@ -414,10 +414,10 @@
       "startLine": 456,
       "endLine": 471
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Connection to Additive Bases (Verified)",
-    "content": "**IsAsymptoticBasis A h**: A is an asymptotic basis of order h\n(h-fold sums from A cover all large n)\n\n**theorem infinite_set_augmentable** ✓:\nFor infinite A, ∃ B with density 0 such that A ∪ B is an asymptotic basis of order 2.\n\n**Proof**: Apply Lorentz, then use sumset_covers_implies_basis.",
-    "mathContext": "This connects Erdős #31 to the theory of additive bases. Any infinite set becomes a basis of order 2 when augmented appropriately.",
+    "content": "**IsAsymptoticBasis A h**: A is an asymptotic basis of order h\n(h-fold sums from A cover all large n)\n\n**theorem infinite_set_augmentable** \u2713:\nFor infinite A, \u2203 B with density 0 such that A \u222a B is an asymptotic basis of order 2.\n\n**Proof**: Apply Lorentz, then use sumset_covers_implies_basis.",
+    "mathContext": "This connects Erd\u0151s #31 to the theory of additive bases. Any infinite set becomes a basis of order 2 when augmented appropriately.",
     "significance": "key",
     "relatedConcepts": [
       "asymptotic-basis",
@@ -427,7 +427,7 @@
     "prerequisites": [
       "lorentz_theorem axiom (this file)",
       "IsAsymptoticBasis definition (this file)",
-      "Sumset / sumset notation +ₛ (this file)",
+      "Sumset / sumset notation +\u209b (this file)",
       "Set.union_subset (union of sets)"
     ]
   },
@@ -438,9 +438,9 @@
       "startLine": 400,
       "endLine": 408
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Strengthened Version",
-    "content": "**Erdos31Strengthened**: ∃ universal C > 0 such that\nfor ALL infinite A, the B from Lorentz satisfies |B ∩ [1,N]| ≤ C · N/log N.\n\n**axiom lorentz_strengthened** ✓\n\nThis shows the O(N/log N) bound works uniformly for all A.",
+    "content": "**Erdos31Strengthened**: \u2203 universal C > 0 such that\nfor ALL infinite A, the B from Lorentz satisfies |B \u2229 [1,N]| \u2264 C \u00b7 N/log N.\n\n**axiom lorentz_strengthened** \u2713\n\nThis shows the O(N/log N) bound works uniformly for all A.",
     "mathContext": "The strengthened version is more useful for applications since the constant C doesn't depend on A.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -464,7 +464,7 @@
     },
     "type": "concept",
     "title": "Summary and Status",
-    "content": "**Erdős Problem #31: SOLVED** (Lorentz 1954)\n\n**Verified theorems**:\n- powers_of_2_density_zero ✓\n- squares_density_zero ✓\n- optimal_B_density_zero ✓\n- coverage_requires_density ✓\n- infinite_set_augmentable ✓\n\n**Key results**:\n1. Any infinite A has a density-0 complement B\n2. B can be chosen with |B ∩ [1,N]| = O(N/log N)\n3. A ∪ B becomes an asymptotic basis of order 2\n\n**Implications**: Sparse sets have flexible additive structure.",
+    "content": "**Erd\u0151s Problem #31: SOLVED** (Lorentz 1954)\n\n**Verified theorems**:\n- powers_of_2_density_zero \u2713\n- squares_density_zero \u2713\n- optimal_B_density_zero \u2713\n- coverage_requires_density \u2713\n- infinite_set_augmentable \u2713\n\n**Key results**:\n1. Any infinite A has a density-0 complement B\n2. B can be chosen with |B \u2229 [1,N]| = O(N/log N)\n3. A \u222a B becomes an asymptotic basis of order 2\n\n**Implications**: Sparse sets have flexible additive structure.",
     "mathContext": "This formalization has 5 verified theorems and comprehensive axiomatization of Lorentz's results. A landmark result in additive combinatorics.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/fundamental-arithmetic-oq-02/annotations.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-02/annotations.json
@@ -50,7 +50,7 @@
       "startLine": 41,
       "endLine": 43
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Multiplicativity of the Norm",
     "content": "Proves N(z*w) = N(z)*N(w) by expanding both sides and using the ring tactic. This multiplicativity is what makes the norm useful for studying factorization: if z = a*b, then N(z) = N(a)*N(b), constraining possible factorizations.",
     "mathContext": "$N(zw) = N(z) \\cdot N(w)$ for all $z, w \\in \\mathbb{Z}[\\sqrt{-5}]$. This follows from the norm being the restriction of the field norm, which is a group homomorphism.",
@@ -72,7 +72,7 @@
       "startLine": 46,
       "endLine": 54
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Units Have Norm 1",
     "content": "If z is a unit in Z[sqrt(-5)], then N(z) = 1. Proof: if z*w = 1, then N(z)*N(w) = 1, and since both norms are non-negative integers, both must equal 1. This means the only units are +1 and -1.",
     "mathContext": "$z \\in \\mathbb{Z}[\\sqrt{-5}]^\\times \\Rightarrow N(z) = 1$. Since $a^2 + 5b^2 = 1$ forces $b = 0, a = \\pm 1$, the unit group is $\\{\\pm 1\\}$.",
@@ -94,7 +94,7 @@
       "startLine": 64,
       "endLine": 65
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "First Factorization: 6 = 2 * 3",
     "content": "Verifies the first factorization of 6 in Z[sqrt(-5)]: the product of the embeddings of 2 and 3 equals the embedding of 6. This is the 'standard' factorization from the integers.",
     "mathContext": "$6 = 2 \\cdot 3$ in $\\mathbb{Z}[\\sqrt{-5}]$, where $2 = \\langle 2, 0 \\rangle$ and $3 = \\langle 3, 0 \\rangle$.",
@@ -114,7 +114,7 @@
       "startLine": 69,
       "endLine": 70
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Second Factorization: 6 = (1+sqrt(-5))(1-sqrt(-5))",
     "content": "Verifies the second factorization: (1 + sqrt(-5)) * (1 - sqrt(-5)) = 1 - (-5) = 6. This genuinely different factorization is the heart of the counterexample. Both factors are algebraic integers not in Z.",
     "mathContext": "$6 = (1 + \\sqrt{-5})(1 - \\sqrt{-5})$ since the product equals $1^2 - (\\sqrt{-5})^2 = 1 - (-5) = 6$. This is a difference-of-squares identity.",
@@ -136,7 +136,7 @@
       "startLine": 77,
       "endLine": 89
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Norm Computations for All Factors",
     "content": "Computes the norms of all elements involved: N(2) = 4, N(3) = 9, N(1+sqrt(-5)) = 6, N(1-sqrt(-5)) = 6, N(6) = 36. The consistency check 36 = 4*9 = 6*6 reflects the two factorizations via multiplicativity of the norm.",
     "mathContext": "$N(2) = 4$, $N(3) = 9$, $N(1 \\pm \\sqrt{-5}) = 1 + 5 = 6$, $N(6) = 36$. Note $4 \\cdot 9 = 36 = 6 \\cdot 6$, mirroring the two factorizations.",
@@ -157,7 +157,7 @@
       "startLine": 96,
       "endLine": 121
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "All Four Factors Are Non-Units",
     "content": "Proves 2, 3, 1+sqrt(-5), and 1-sqrt(-5) are all non-units by showing their norms (4, 9, 6, 6 respectively) are not equal to 1. This is the first half of showing irreducibility.",
     "mathContext": "Since $N(z) = 1 \\Leftrightarrow z \\in \\{\\pm 1\\}$, and $N(2) = 4 \\neq 1$, $N(3) = 9 \\neq 1$, $N(1 \\pm \\sqrt{-5}) = 6 \\neq 1$, none of these elements are units.",
@@ -177,7 +177,7 @@
       "startLine": 125,
       "endLine": 128
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "No Element Has Norm 2 or 3",
     "content": "The crucial Diophantine result: the equations a^2 + 5b^2 = 2 and a^2 + 5b^2 = 3 have no integer solutions. This is proved by nlinarith (nonlinear integer arithmetic). This gap in the norm values is what makes factorization fail.",
     "mathContext": "The quadratic form $a^2 + 5b^2$ takes values $\\{0, 1, 4, 5, 6, 9, \\ldots\\}$ on $\\mathbb{Z}^2$, skipping 2 and 3. This gap is what prevents nontrivial factorization of elements with norm 4, 6, or 9.",
@@ -199,7 +199,7 @@
       "startLine": 132,
       "endLine": 136
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Norm 1 Implies Unit",
     "content": "The converse direction: if N(z) = 1, then z is a unit. Since a^2 + 5b^2 = 1 forces b = 0 and a = +/-1, the element z must be +/-1, which are indeed units. Combined with the earlier result, this gives: z is a unit iff N(z) = 1.",
     "mathContext": "$N(z) = 1 \\Rightarrow z \\in \\mathbb{Z}[\\sqrt{-5}]^\\times$. The equation $a^2 + 5b^2 = 1$ over $\\mathbb{Z}$ has solutions $(\\pm 1, 0)$ only.",
@@ -221,7 +221,7 @@
       "startLine": 141,
       "endLine": 166
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "2 Is Irreducible in Z[sqrt(-5)]",
     "content": "The most detailed irreducibility proof: if 2 = a*b, then N(a)*N(b) = 4. Since no element has norm 2, the only factorizations of 4 as a product of positive norms are 1*4 and 4*1. In either case, one factor has norm 1 and is therefore a unit. The proof uses omega to eliminate impossible norm values.",
     "mathContext": "If $2 = ab$ then $4 = N(a)N(b)$. Since $N(a), N(b) \\geq 1$ and $N(a), N(b) \\neq 2, 3$, we need $N(a) \\in \\{1, 4\\}$. If $N(a) = 1$ then $a$ is a unit; if $N(a) = 4$ then $N(b) = 1$ and $b$ is a unit.",
@@ -244,7 +244,7 @@
       "startLine": 170,
       "endLine": 180
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "2 Does Not Divide (1 + sqrt(-5))",
     "content": "Proves that 2 does not divide (1 + sqrt(-5)) by a direct divisibility argument: if (1+sqrt(-5)) = 2*z, extracting the imaginary part gives 2*z.im = 1, which has no integer solution. This is the key non-primality witness.",
     "mathContext": "If $2 \\mid (1 + \\sqrt{-5})$, then $1 + \\sqrt{-5} = 2(a + b\\sqrt{-5})$ gives $2b = 1$, impossible in $\\mathbb{Z}$. So $2 \\nmid (1+\\sqrt{-5})$, yet $2 \\mid (1+\\sqrt{-5})(1-\\sqrt{-5}) = 6$, proving 2 is not prime.",
@@ -266,7 +266,7 @@
       "startLine": 186,
       "endLine": 192
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Factorizations Are Essentially Different",
     "content": "The final theorem: since 2 is irreducible but does not divide (1+sqrt(-5)) despite dividing their product 6, the element 2 is irreducible but not prime. In an integral domain, unique factorization holds if and only if every irreducible is prime, so this witnesses the failure of the UFD property.",
     "mathContext": "$2 \\mid (1+\\sqrt{-5})(1-\\sqrt{-5})$ but $2 \\nmid (1+\\sqrt{-5})$ and $2 \\nmid (1-\\sqrt{-5})$, so 2 is not prime. Since 2 is irreducible but not prime, $\\mathbb{Z}[\\sqrt{-5}]$ is not a UFD.",

--- a/src/data/proofs/intermediate-value-theorem/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 49,
       "endLine": 56
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Main IVT Statement",
     "content": "**Continuous functions on closed intervals hit all intermediate values.**\n\nThis is the core IVT: if $f$ is continuous on $[a, b]$, then the image $f([a, b])$ contains the entire interval $[f(a), f(b)]$.\n\nThe proof is a direct application of Mathlib's `intermediate_value_Icc`.",
     "mathContext": "$f : \\mathbb{R} \\to \\mathbb{R}$ continuous on $[a, b]$\n\n$\\Rightarrow [f(a), f(b)] \\subseteq f([a, b])$",
@@ -29,9 +29,9 @@
       "startLine": 60,
       "endLine": 62
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Symmetric Version",
-    "content": "**The IVT also works when f(b) ≤ f(a).**\n\nThis version handles the case where the function values are in the opposite order: $[f(b), f(a)] \\subseteq f([a, b])$.\n\nTogether with the main theorem, this covers all cases regardless of which endpoint has the larger value.",
+    "content": "**The IVT also works when f(b) \u2264 f(a).**\n\nThis version handles the case where the function values are in the opposite order: $[f(b), f(a)] \\subseteq f([a, b])$.\n\nTogether with the main theorem, this covers all cases regardless of which endpoint has the larger value.",
     "mathContext": "If $f(b) \\leq f(a)$:\n\n$[f(b), f(a)] \\subseteq f([a, b])$",
     "significance": "key",
     "prerequisites": [
@@ -50,7 +50,7 @@
       "startLine": 77,
       "endLine": 81
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Explicit Existence Form",
     "content": "**For any c between f(a) and f(b), there exists x with f(x) = c.**\n\nThis is the 'textbook' formulation: given a target value $c$ in the interval $[f(a), f(b)]$, we can assert the existence of a point $x$ where $f$ achieves that value.\n\nNote: IVT gives existence but not uniqueness - there may be multiple such $x$ values.",
     "mathContext": "$c \\in [f(a), f(b)] \\Rightarrow \\exists x \\in [a, b], f(x) = c$",
@@ -73,7 +73,7 @@
       "startLine": 114,
       "endLine": 134
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Bolzano's Theorem (Root-Finding)",
     "content": "**If f(a) < 0 < f(b), then f has a root in (a, b).**\n\nThis is the most famous corollary of IVT, often called Bolzano's theorem after Bernard Bolzano who first stated IVT rigorously in 1817.\n\nThe proof shows not just existence in $[a, b]$, but that the root is in the **open** interval $(a, b)$ - it cannot be at the endpoints since $f(a) \\neq 0$ and $f(b) \\neq 0$.",
     "mathContext": "$f(a) < 0$ and $f(b) > 0$\n\n$\\Rightarrow \\exists x \\in (a, b), f(x) = 0$",
@@ -96,9 +96,9 @@
       "startLine": 114,
       "endLine": 134
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Bolzano Proof Strategy",
-    "content": "The proof has two parts:\n\n1. **Get existence in [a, b]**: Since 0 is between f(a) and f(b), IVT gives us some x in [a, b] with f(x) = 0.\n\n2. **Show x is in (a, b)**: We prove x ≠ a because f(a) < 0 ≠ f(x) = 0, and similarly x ≠ b because f(b) > 0 ≠ f(x) = 0.\n\nThis is a common pattern: use IVT for the closed interval, then refine to the open interval using the hypothesis values.",
+    "content": "The proof has two parts:\n\n1. **Get existence in [a, b]**: Since 0 is between f(a) and f(b), IVT gives us some x in [a, b] with f(x) = 0.\n\n2. **Show x is in (a, b)**: We prove x \u2260 a because f(a) < 0 \u2260 f(x) = 0, and similarly x \u2260 b because f(b) > 0 \u2260 f(x) = 0.\n\nThis is a common pattern: use IVT for the closed interval, then refine to the open interval using the hypothesis values.",
     "mathContext": "Strategy:\n1. $0 \\in [f(a), f(b)]$ since $f(a) < 0 < f(b)$\n2. Apply IVT to get $x \\in [a, b]$\n3. $x \\neq a$ since $f(x) = 0 \\neq f(a)$\n4. $x \\neq b$ since $f(x) = 0 \\neq f(b)$",
     "significance": "key",
     "prerequisites": [
@@ -118,9 +118,9 @@
       "startLine": 156,
       "endLine": 163
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Root from Opposite Signs",
-    "content": "**If f(a) · f(b) < 0, then f has a root in (a, b).**\n\nThis generalizes Bolzano's theorem: instead of specifying which endpoint is positive and which is negative, we just require that they have opposite signs (their product is negative).\n\nThe proof splits into cases: either f(a) > 0 and f(b) < 0, or f(a) < 0 and f(b) > 0.",
+    "content": "**If f(a) \u00b7 f(b) < 0, then f has a root in (a, b).**\n\nThis generalizes Bolzano's theorem: instead of specifying which endpoint is positive and which is negative, we just require that they have opposite signs (their product is negative).\n\nThe proof splits into cases: either f(a) > 0 and f(b) < 0, or f(a) < 0 and f(b) > 0.",
     "mathContext": "$f(a) \\cdot f(b) < 0 \\Leftrightarrow $ opposite signs\n\n$\\Rightarrow \\exists x \\in (a, b), f(x) = 0$",
     "significance": "key",
     "prerequisites": [
@@ -140,7 +140,7 @@
       "startLine": 173,
       "endLine": 176
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Continuous Images of Connected Sets",
     "content": "**Continuous functions preserve connectedness.**\n\nThis is the topological principle underlying IVT. If $S$ is connected and $f$ is continuous, then $f(S)$ is connected.\n\nFor subsets of $\\mathbb{R}$, connected means 'interval-like': if two points are in the set, all points between them are too.",
     "mathContext": "$S$ connected, $f$ continuous\n\n$\\Rightarrow f(S)$ connected\n\nConnected in $\\mathbb{R}$ = interval",
@@ -163,7 +163,7 @@
       "startLine": 191,
       "endLine": 205
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Odd-Degree Polynomials Have Roots",
     "content": "**Every odd-degree real polynomial has at least one real root.**\n\nThe proof uses the fact that odd-degree polynomials tend to $+\\infty$ in one direction and $-\\infty$ in the other (or vice versa). Therefore there exist points where the polynomial is positive and negative, and Bolzano's theorem gives a root.\n\nThis generalizes to any continuous function that takes both positive and negative values.",
     "mathContext": "For odd degree $n$:\n\n$\\lim_{x \\to +\\infty} p(x) = +\\infty$\n$\\lim_{x \\to -\\infty} p(x) = -\\infty$\n\n(or vice versa)\n\n$\\Rightarrow p$ has a real root",
@@ -186,9 +186,9 @@
       "startLine": 191,
       "endLine": 205
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Fixed Point Theorem for Intervals",
-    "content": "**If f : [a,b] → [a,b] is continuous, it has a fixed point.**\n\nA fixed point is a value $x$ where $f(x) = x$. The proof applies IVT to the function $g(x) = f(x) - x$:\n- At $x = a$: $g(a) = f(a) - a \\geq 0$ (since $f(a) \\geq a$)\n- At $x = b$: $g(b) = f(b) - b \\leq 0$ (since $f(b) \\leq b$)\n\nBy IVT, $g$ has a zero, which is a fixed point of $f$.\n\nThis is the 1-dimensional case of Brouwer's fixed point theorem.",
+    "content": "**If f : [a,b] \u2192 [a,b] is continuous, it has a fixed point.**\n\nA fixed point is a value $x$ where $f(x) = x$. The proof applies IVT to the function $g(x) = f(x) - x$:\n- At $x = a$: $g(a) = f(a) - a \\geq 0$ (since $f(a) \\geq a$)\n- At $x = b$: $g(b) = f(b) - b \\leq 0$ (since $f(b) \\leq b$)\n\nBy IVT, $g$ has a zero, which is a fixed point of $f$.\n\nThis is the 1-dimensional case of Brouwer's fixed point theorem.",
     "mathContext": "$f : [a, b] \\to [a, b]$ continuous\n\n$\\Rightarrow \\exists x \\in [a, b], f(x) = x$",
     "significance": "key",
     "prerequisites": [

--- a/src/data/proofs/knights-tour-oblique/annotations.json
+++ b/src/data/proofs/knights-tour-oblique/annotations.json
@@ -122,8 +122,8 @@
     },
     "type": "definition",
     "title": "Dot Product of Move Vectors",
-    "content": "The **dot product** measures alignment between vectors:\n\n- **Positive**: vectors point in similar directions (acute angle, < 90°)\n- **Zero**: vectors are perpendicular (right angle, = 90°)\n- **Negative**: vectors point in opposing directions (obtuse angle, > 90°)\n\nFor knight moves, this determines whether a turn is 'oblique'.",
-    "mathContext": "$\\vec{v}_1 \\cdot \\vec{v}_2 = dx_1 \\cdot dx_2 + dy_1 \\cdot dy_2$\n\nGeometrically: $\\vec{v}_1 \\cdot \\vec{v}_2 = |\\vec{v}_1| |\\vec{v}_2| \\cos\\theta$\n\nSo $\\cos\\theta < 0 \\iff \\theta > 90°$ iff dot product is negative.",
+    "content": "The **dot product** measures alignment between vectors:\n\n- **Positive**: vectors point in similar directions (acute angle, < 90\u00b0)\n- **Zero**: vectors are perpendicular (right angle, = 90\u00b0)\n- **Negative**: vectors point in opposing directions (obtuse angle, > 90\u00b0)\n\nFor knight moves, this determines whether a turn is 'oblique'.",
+    "mathContext": "$\\vec{v}_1 \\cdot \\vec{v}_2 = dx_1 \\cdot dx_2 + dy_1 \\cdot dy_2$\n\nGeometrically: $\\vec{v}_1 \\cdot \\vec{v}_2 = |\\vec{v}_1| |\\vec{v}_2| \\cos\\theta$\n\nSo $\\cos\\theta < 0 \\iff \\theta > 90\u00b0$ iff dot product is negative.",
     "significance": "key",
     "relatedConcepts": [
       "dot product",
@@ -141,8 +141,8 @@
     },
     "type": "definition",
     "title": "Oblique Turns",
-    "content": "An **oblique turn** is one where the knight's direction changes by more than 90 degrees. This happens when consecutive move vectors have negative dot product.\n\nFor knight moves, the possible dot products are:\n- **Acute** (< 90°): 5, 4, 1\n- **Right** (= 90°): 0  \n- **Oblique** (> 90°): -1, -4, -5\n\nOblique turns occur when the knight 'doubles back' significantly.",
-    "mathContext": "$\\text{isOblique}(\\vec{v}_1, \\vec{v}_2) \\iff \\vec{v}_1 \\cdot \\vec{v}_2 < 0$\n\nExample: NNE (+1,+2) followed by SSW (-1,-2) gives:\n$(1)(-1) + (2)(-2) = -1 - 4 = -5 < 0$ ✓ Oblique!",
+    "content": "An **oblique turn** is one where the knight's direction changes by more than 90 degrees. This happens when consecutive move vectors have negative dot product.\n\nFor knight moves, the possible dot products are:\n- **Acute** (< 90\u00b0): 5, 4, 1\n- **Right** (= 90\u00b0): 0  \n- **Oblique** (> 90\u00b0): -1, -4, -5\n\nOblique turns occur when the knight 'doubles back' significantly.",
+    "mathContext": "$\\text{isOblique}(\\vec{v}_1, \\vec{v}_2) \\iff \\vec{v}_1 \\cdot \\vec{v}_2 < 0$\n\nExample: NNE (+1,+2) followed by SSW (-1,-2) gives:\n$(1)(-1) + (2)(-2) = -1 - 4 = -5 < 0$ \u2713 Oblique!",
     "significance": "key",
     "prerequisites": [
       "ann-dot-product"
@@ -160,7 +160,7 @@
       "startLine": 118,
       "endLine": 122
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Possible Dot Product Values",
     "content": "For any two knight move vectors, the dot product is one of exactly 7 values: {-5, -4, -1, 0, 1, 4, 5}.\n\nThis can be verified by exhaustive case analysis over all 8 x 8 = 64 pairs of directions. The proof uses `sorry` as a placeholder for this mechanical verification.",
     "mathContext": "The symmetric distribution around 0 reflects the geometry: for every acute pair there's a corresponding obtuse pair (with the second vector negated).",
@@ -203,7 +203,7 @@
     },
     "type": "definition",
     "title": "Counting Oblique Turns",
-    "content": "The `obliqueCount` function counts turns where the knight changes direction by more than 90°.\n\nA closed 64-move tour has 64 turns (including the turn from move 63 back to move 0). We pair consecutive move vectors and count those with negative dot product.\n\n**Knuth's theorem**: This count is always ≥ 4.",
+    "content": "The `obliqueCount` function counts turns where the knight changes direction by more than 90\u00b0.\n\nA closed 64-move tour has 64 turns (including the turn from move 63 back to move 0). We pair consecutive move vectors and count those with negative dot product.\n\n**Knuth's theorem**: This count is always \u2265 4.",
     "mathContext": "$\\text{obliqueCount}(T) = |\\{i : \\vec{v}_i \\cdot \\vec{v}_{i+1} < 0\\}|$\n\nwhere indices are cyclic (mod 64).",
     "significance": "key",
     "prerequisites": [
@@ -225,7 +225,7 @@
     "type": "insight",
     "title": "Discretizing Directions into Z/8Z",
     "content": "A crucial insight: knight moves have exactly 8 directions, which we number 0-7 counterclockwise. This maps to $\\mathbb{Z}/8\\mathbb{Z}$ (integers mod 8).\n\n**Direction assignments**:\n- 0: NNE (+1,+2)\n- 1: ENE (+2,+1)\n- 2: ESE (+2,-1)\n- 3: SSE (+1,-2)\n- 4: SSW (-1,-2)\n- 5: WSW (-2,-1)\n- 6: WNW (-2,+1)\n- 7: NNW (-1,+2)\n\nOpposite directions differ by 4 (mod 8).",
-    "mathContext": "$\\text{dir} : \\text{MoveVector} \\to \\mathbb{Z}/8\\mathbb{Z}$\n\nConsecutive directions differ by 1 unit = 45°.\nA full rotation is 8 units = 360°.",
+    "mathContext": "$\\text{dir} : \\text{MoveVector} \\to \\mathbb{Z}/8\\mathbb{Z}$\n\nConsecutive directions differ by 1 unit = 45\u00b0.\nA full rotation is 8 units = 360\u00b0.",
     "significance": "key",
     "relatedConcepts": [
       "modular arithmetic",
@@ -242,7 +242,7 @@
     },
     "type": "definition",
     "title": "Turn Angles in Z/8Z",
-    "content": "The **turn angle** between consecutive moves is the difference of their directions (mod 8). This signed value represents how much the knight rotated.\n\n**Angle meanings**:\n- 0: straight ahead (same direction)\n- 1, 2: slight turn (acute, ≤ 90°)\n- 3: sharp turn (~135°)\n- 4: complete reversal (180°)\n- 5: sharp turn (~-135° = 225°)\n- 6, 7: slight turn (acute)",
+    "content": "The **turn angle** between consecutive moves is the difference of their directions (mod 8). This signed value represents how much the knight rotated.\n\n**Angle meanings**:\n- 0: straight ahead (same direction)\n- 1, 2: slight turn (acute, \u2264 90\u00b0)\n- 3: sharp turn (~135\u00b0)\n- 4: complete reversal (180\u00b0)\n- 5: sharp turn (~-135\u00b0 = 225\u00b0)\n- 6, 7: slight turn (acute)",
     "mathContext": "$\\text{turn}(\\vec{v}_1, \\vec{v}_2) = \\text{dir}(\\vec{v}_2) - \\text{dir}(\\vec{v}_1) \\in \\mathbb{Z}/8\\mathbb{Z}$",
     "significance": "key",
     "prerequisites": [
@@ -260,9 +260,9 @@
       "startLine": 208,
       "endLine": 211
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Oblique = Large Turn Angle",
-    "content": "**Key equivalence**: A turn is oblique (dot product < 0) if and only if the turn angle is in {3, 4, 5} mod 8.\n\n- **Angles 3, 5**: ~135° turns (obtuse)\n- **Angle 4**: 180° reversal (directly back)\n\nNon-oblique turns have angles in {0, 1, 2, 6, 7}.\n\nThis connects the geometric definition (dot product) to the algebraic one (modular arithmetic).",
+    "content": "**Key equivalence**: A turn is oblique (dot product < 0) if and only if the turn angle is in {3, 4, 5} mod 8.\n\n- **Angles 3, 5**: ~135\u00b0 turns (obtuse)\n- **Angle 4**: 180\u00b0 reversal (directly back)\n\nNon-oblique turns have angles in {0, 1, 2, 6, 7}.\n\nThis connects the geometric definition (dot product) to the algebraic one (modular arithmetic).",
     "mathContext": "$\\text{isOblique}(\\vec{v}_1, \\vec{v}_2) \\iff \\text{turn}(\\vec{v}_1, \\vec{v}_2) \\in \\{3, 4, 5\\}$\n\nVerified by checking all 64 pairs.",
     "significance": "key",
     "prerequisites": [
@@ -281,9 +281,9 @@
       "startLine": 222,
       "endLine": 233
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Winding Constraint",
-    "content": "**Fundamental constraint**: In a closed tour, the sum of all turn angles equals 0 (mod 8).\n\n**Intuition**: The knight returns to its starting position *and* starting direction. The total rotation must be a multiple of 360°, which is 8 units in our discretization.\n\nThis is analogous to the winding number of a closed curve being an integer.",
+    "content": "**Fundamental constraint**: In a closed tour, the sum of all turn angles equals 0 (mod 8).\n\n**Intuition**: The knight returns to its starting position *and* starting direction. The total rotation must be a multiple of 360\u00b0, which is 8 units in our discretization.\n\nThis is analogous to the winding number of a closed curve being an integer.",
     "mathContext": "$\\sum_{i=0}^{63} \\text{turn}(\\vec{v}_i, \\vec{v}_{i+1}) \\equiv 0 \\pmod{8}$\n\nThe Gauss-Bonnet theorem for discrete curves!",
     "significance": "key",
     "prerequisites": [
@@ -303,7 +303,7 @@
       "startLine": 991,
       "endLine": 1109
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The 4-Oblique Lower Bound",
     "content": "**Main Theorem**: Every closed knight's tour has at least 4 oblique turns.\n\n**Proof**: Each of the 4 corner squares (a1, a8, h1, h8) has exactly 2 knight-adjacent squares. When the tour passes through a corner, the knight must enter from one neighbor and exit to the other. This forced path creates an oblique turn at each corner.\n\nSince the tour visits all 64 squares including all 4 corners, we get at least 4 oblique turns.",
     "mathContext": "$\\forall T : \\text{ClosedTour}, \\quad \\text{obliqueCount}(T) \\geq 4$\n\nThis is proved by the corner-forcing argument: corners have degree 2 in the knight graph, forcing oblique turns.",
@@ -327,7 +327,7 @@
     },
     "type": "concept",
     "title": "D4 Symmetry of the Chessboard",
-    "content": "The chessboard has 8 symmetries forming the **dihedral group D4**:\n\n- **4 rotations**: 0°, 90°, 180°, 270° about the center\n- **4 reflections**: horizontal, vertical, two diagonals\n\nThese preserve the knight graph: if squares A, B are knight-adjacent, so are their images under any D4 transformation.\n\nThis 8-fold symmetry reduces the search space for uniqueness.",
+    "content": "The chessboard has 8 symmetries forming the **dihedral group D4**:\n\n- **4 rotations**: 0\u00b0, 90\u00b0, 180\u00b0, 270\u00b0 about the center\n- **4 reflections**: horizontal, vertical, two diagonals\n\nThese preserve the knight graph: if squares A, B are knight-adjacent, so are their images under any D4 transformation.\n\nThis 8-fold symmetry reduces the search space for uniqueness.",
     "mathContext": "$D_4 = \\langle r, s \\mid r^4 = s^2 = 1, srs = r^{-1} \\rangle$\n\n$|D_4| = 8$, reducing ~13 trillion tours to ~1.7 trillion equivalence classes.",
     "significance": "key",
     "relatedConcepts": [
@@ -345,8 +345,8 @@
     },
     "type": "definition",
     "title": "Rotating Squares",
-    "content": "We define 90° counterclockwise rotation about the board center.\n\nFor a square at (x, y), the rotated position is (7-y, x). This maps:\n- a1 (0,0) → a8 (0,7) → h8 (7,7) → h1 (7,0) → a1\n\nApplying 4 times returns to the original, matching the cyclic group structure.",
-    "mathContext": "$R_{90°}(x, y) = (7-y, x)$\n\nThe board center is at (3.5, 3.5). The formula accounts for this by using 7 - y instead of -y.",
+    "content": "We define 90\u00b0 counterclockwise rotation about the board center.\n\nFor a square at (x, y), the rotated position is (7-y, x). This maps:\n- a1 (0,0) \u2192 a8 (0,7) \u2192 h8 (7,7) \u2192 h1 (7,0) \u2192 a1\n\nApplying 4 times returns to the original, matching the cyclic group structure.",
+    "mathContext": "$R_{90\u00b0}(x, y) = (7-y, x)$\n\nThe board center is at (3.5, 3.5). The formula accounts for this by using 7 - y instead of -y.",
     "significance": "supporting",
     "relatedConcepts": [
       "rotation",
@@ -362,8 +362,8 @@
     },
     "type": "definition",
     "title": "D4 Transformations",
-    "content": "We encode D4 elements as pairs (reflect, rotate):\n\n- `reflect`: Whether to flip horizontally first\n- `rotate`: How many 90° counterclockwise rotations\n\nThe 8 combinations give all D4 symmetries. We apply reflection first (if any), then rotation.",
-    "mathContext": "D4 elements: {id, r, r², r³, s, sr, sr², sr³}\n\nwhere r = 90° rotation, s = horizontal reflection.\n\nThe encoding (Bool × Fin 4) gives a natural representation.",
+    "content": "We encode D4 elements as pairs (reflect, rotate):\n\n- `reflect`: Whether to flip horizontally first\n- `rotate`: How many 90\u00b0 counterclockwise rotations\n\nThe 8 combinations give all D4 symmetries. We apply reflection first (if any), then rotation.",
+    "mathContext": "D4 elements: {id, r, r\u00b2, r\u00b3, s, sr, sr\u00b2, sr\u00b3}\n\nwhere r = 90\u00b0 rotation, s = horizontal reflection.\n\nThe encoding (Bool \u00d7 Fin 4) gives a natural representation.",
     "significance": "supporting",
     "prerequisites": [
       "ann-d4-intro",
@@ -381,9 +381,9 @@
       "startLine": 290,
       "endLine": 292
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Knight Graph Invariance",
-    "content": "Knight adjacency is preserved under D4 symmetries: if A and B are knight-adjacent, so are g(A) and g(B) for any g ∈ D4.\n\n**Why?** The L-shaped knight move is preserved under rotation and reflection. Both operations preserve the product |dx| × |dy| = 2 and the sum |dx| + |dy| = 3.",
+    "content": "Knight adjacency is preserved under D4 symmetries: if A and B are knight-adjacent, so are g(A) and g(B) for any g \u2208 D4.\n\n**Why?** The L-shaped knight move is preserved under rotation and reflection. Both operations preserve the product |dx| \u00d7 |dy| = 2 and the sum |dx| + |dy| = 3.",
     "mathContext": "$A \\sim B \\iff g(A) \\sim g(B)$ for all $g \\in D_4$\n\nThis makes D4 a group of graph automorphisms.",
     "significance": "key",
     "prerequisites": [
@@ -402,7 +402,7 @@
       "startLine": 312,
       "endLine": 321
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Oblique Count is D4-Invariant",
     "content": "**Key invariance**: Applying a D4 symmetry to a tour doesn't change its oblique count.\n\n**Why?** D4 transformations are orthogonal (they preserve angles and distances). Since 'oblique' is defined by dot product sign, and orthogonal transformations preserve dot products, the count is invariant.\n\nThis lets us work with equivalence classes of tours.",
     "mathContext": "$\\text{obliqueCount}(g \\cdot T) = \\text{obliqueCount}(T)$ for all $g \\in D_4$\n\nOrthogonal transformations satisfy: $\\langle Qv, Qw \\rangle = \\langle v, w \\rangle$",
@@ -444,7 +444,7 @@
       "startLine": 2239,
       "endLine": 2245
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Unique Minimal Tour",
     "content": "The explicit 64-square minimal oblique tour is constructed from Knuth's Fig. A-19(t). It visits squares in a specific order that achieves exactly 4 oblique turns.\n\nThe tour is verified using `native_decide` to check:\n- All 64 squares are visited exactly once (nodup)\n- Consecutive squares are knight-adjacent (path)\n- The tour closes (last square adjacent to first)\n- Oblique count equals 4\n\nKnuth called it 'a beauty.'",
     "mathContext": "$\\exists T^* : \\text{ClosedTour}, \\quad \\text{obliqueCount}(T^*) = 4$\n\nExplicitly constructed and computationally verified.",
@@ -465,7 +465,7 @@
       "startLine": 2335,
       "endLine": 2335
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Uniqueness of the Minimal Tour",
     "content": "**Remarkable result**: Any closed knight's tour with exactly 4 oblique turns is D4-equivalent to the minimal tour.\n\nAmong ~13 trillion directed closed tours (or ~1.7 trillion up to symmetry), **exactly ONE equivalence class** achieves the minimum of 4 oblique turns.\n\nThis is accepted as an **axiom** (`knuth_unique_four_oblique`) based on Donald Knuth's exhaustive computational verification in TAOCP Vol 4 Fascicle 8a (December 2025).",
     "mathContext": "$\\forall T, \\quad \\text{obliqueCount}(T) = 4 \\implies \\exists g \\in D_4, \\quad g \\cdot T = T^*$\n\nThe axiom could be eliminated via SAT/LRAT certificate verification in Lean.",
@@ -487,7 +487,7 @@
       "startLine": 2369,
       "endLine": 2375
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Main Theorem 1: Lower Bound",
     "content": "**Theorem 1 (Lower Bound)**: Every closed knight's tour on an 8x8 board has at least 4 oblique turns.\n\nThis is proven mathematically via the corner-forcing argument: each of the 4 corners has only 2 knight-adjacent squares, so passing through a corner forces an oblique turn.",
     "mathContext": "$\\forall T : \\text{ClosedTour}, \\quad \\text{obliqueCount}(T) \\geq 4$",
@@ -507,7 +507,7 @@
       "startLine": 2401,
       "endLine": 2430
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Main Theorem 2: Uniqueness",
     "content": "**Theorem 2 (Uniqueness)**: There exists exactly one closed knight's tour (up to D4 symmetry) with exactly 4 oblique turns.\n\nThis combines:\n- **Existence**: The minimal tour is explicitly constructed from Knuth's Fig. A-19(t)\n- **Uniqueness**: Accepted as axiom based on Knuth's enumeration\n\nThe 'beauty' Knuth described is this unique minimal-oblique tour.",
     "mathContext": "$\\exists! T : \\text{ClosedTour}, \\quad \\text{isCanonical}(T) \\land \\text{obliqueCount}(T) = 4$\n\nThe notation $\\exists!$ means 'there exists exactly one.'",

--- a/src/data/proofs/mathematical-induction/annotations.json
+++ b/src/data/proofs/mathematical-induction/annotations.json
@@ -9,13 +9,13 @@
     "type": "concept",
     "title": "The Foundation of Recursive Reasoning",
     "content": "Mathematical induction is the principle that allows us to prove statements about all natural numbers by:\n\n1. **Base Case**: Prove the statement holds for 0\n2. **Inductive Step**: Prove that if it holds for $n$, it holds for $n+1$\n\n$$P(0) \\land (\\forall n. P(n) \\to P(n+1)) \\to \\forall n. P(n)$$\n\nThis is Peano's fifth axiom, and it's what distinguishes the natural numbers from other structures.",
-    "mathContext": "In Lean 4, `Nat` is defined as an inductive type with constructors `zero : Nat` and `succ : Nat → Nat`. The `Nat.rec` recursor is automatically generated and has the type signature: `Nat.rec : {motive : Nat → Sort u} → motive 0 → (∀ n, motive n → motive (n+1)) → ∀ n, motive n`. The induction principle is *definitionally* the recursor — there is no distinction in Lean's type theory between proving by induction and computing by recursion.",
+    "mathContext": "In Lean 4, `Nat` is defined as an inductive type with constructors `zero : Nat` and `succ : Nat \u2192 Nat`. The `Nat.rec` recursor is automatically generated and has the type signature: `Nat.rec : {motive : Nat \u2192 Sort u} \u2192 motive 0 \u2192 (\u2200 n, motive n \u2192 motive (n+1)) \u2192 \u2200 n, motive n`. The induction principle is *definitionally* the recursor \u2014 there is no distinction in Lean's type theory between proving by induction and computing by recursion.",
     "significance": "key",
     "prerequisites": [
-      "natural numbers (ℕ)",
+      "natural numbers (\u2115)",
       "propositions and predicates in Lean",
-      "universal quantification (∀)",
-      "logical connectives (∧, →)"
+      "universal quantification (\u2200)",
+      "logical connectives (\u2227, \u2192)"
     ],
     "relatedConcepts": [
       "Peano axioms",
@@ -36,8 +36,8 @@
     },
     "type": "insight",
     "title": "Historical Context and Approach",
-    "content": "The Principle of Mathematical Induction was rigorously formulated by Giuseppe Peano in 1889 as the fifth axiom in his axiomatization of the natural numbers.\n\nHowever, the technique has much older roots:\n- **Pascal (1665)**: Used induction explicitly in 'Traité du Triangle Arithmétique'\n- **Fermat**: Used infinite descent (contrapositive induction)\n- **Ancient Greeks**: Euclid implicitly used inductive reasoning\n\nIn modern type theory, induction is built into the foundations: natural numbers are an inductive type, and the induction principle is automatically generated as the recursor.",
-    "mathContext": "Peano's 1889 axiomatization introduced five axioms for the naturals: (1) 0 is a natural number; (2) every natural has a successor; (3) 0 is not a successor; (4) the successor function is injective; (5) the induction schema. Dedekind's contemporaneous work 'Was sind und was sollen die Zahlen?' (1888) gave an equivalent categorical characterization: ℕ is the unique (up to isomorphism) simply infinite system. In type theory, Lean implements Dedekind's categorical view — the `Nat` inductive type is defined by its recursor, and the induction principle is an immediate consequence of the universal property of the initial algebra.",
+    "content": "The Principle of Mathematical Induction was rigorously formulated by Giuseppe Peano in 1889 as the fifth axiom in his axiomatization of the natural numbers.\n\nHowever, the technique has much older roots:\n- **Pascal (1665)**: Used induction explicitly in 'Trait\u00e9 du Triangle Arithm\u00e9tique'\n- **Fermat**: Used infinite descent (contrapositive induction)\n- **Ancient Greeks**: Euclid implicitly used inductive reasoning\n\nIn modern type theory, induction is built into the foundations: natural numbers are an inductive type, and the induction principle is automatically generated as the recursor.",
+    "mathContext": "Peano's 1889 axiomatization introduced five axioms for the naturals: (1) 0 is a natural number; (2) every natural has a successor; (3) 0 is not a successor; (4) the successor function is injective; (5) the induction schema. Dedekind's contemporaneous work 'Was sind und was sollen die Zahlen?' (1888) gave an equivalent categorical characterization: \u2115 is the unique (up to isomorphism) simply infinite system. In type theory, Lean implements Dedekind's categorical view \u2014 the `Nat` inductive type is defined by its recursor, and the induction principle is an immediate consequence of the universal property of the initial algebra.",
     "significance": "key",
     "prerequisites": [
       "history of mathematical logic",
@@ -60,10 +60,10 @@
       "startLine": 57,
       "endLine": 70
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Weak Induction (Standard Form)",
-    "content": "**Weak Induction**: The standard form of mathematical induction.\n\n```lean\ntheorem weak_induction (P : ℕ → Prop)\n    (base : P 0)\n    (step : ∀ n, P n → P (n + 1)) :\n    ∀ n, P n\n```\n\nThe proof uses Lean's `induction` tactic, which applies the `Nat.rec` recursor. This is the most common form of induction used in practice.",
-    "mathContext": "In Lean 4, the `induction n with` tactic desugars to an application of `Nat.rec`. The `| zero => exact base` branch fills in the base case, and `| succ k ih => exact step k ih` fills in the inductive step with `ih : P k`. This is definitionally equal to `Nat.rec base step n`. Lean checks that the two constructors cover all cases of the `Nat` inductive type, giving totality. The `∀ n, P n` conclusion is a dependent function type `(n : ℕ) → P n`.",
+    "content": "**Weak Induction**: The standard form of mathematical induction.\n\n```lean\ntheorem weak_induction (P : \u2115 \u2192 Prop)\n    (base : P 0)\n    (step : \u2200 n, P n \u2192 P (n + 1)) :\n    \u2200 n, P n\n```\n\nThe proof uses Lean's `induction` tactic, which applies the `Nat.rec` recursor. This is the most common form of induction used in practice.",
+    "mathContext": "In Lean 4, the `induction n with` tactic desugars to an application of `Nat.rec`. The `| zero => exact base` branch fills in the base case, and `| succ k ih => exact step k ih` fills in the inductive step with `ih : P k`. This is definitionally equal to `Nat.rec base step n`. Lean checks that the two constructors cover all cases of the `Nat` inductive type, giving totality. The `\u2200 n, P n` conclusion is a dependent function type `(n : \u2115) \u2192 P n`.",
     "significance": "key",
     "prerequisites": [
       "Lean 4 `induction` tactic",
@@ -89,13 +89,13 @@
     },
     "type": "insight",
     "title": "Induction IS the Recursor",
-    "content": "The alternative proof `weak_induction'` shows that induction is literally the recursor:\n\n```lean\ntheorem weak_induction' ... : ∀ n, P n :=\n  Nat.rec base step\n```\n\nIn type theory, the induction principle for any inductive type is automatically generated as its **recursor**. For `Nat`, this is `Nat.rec`.",
-    "mathContext": "The term `Nat.rec base step : ∀ n, P n` is a fully elaborated proof term with no tactics. In the Curry-Howard correspondence, this term is simultaneously a proof of `∀ n, P n` and a program computing values of type `P n` by recursion on `n`. Lean's kernel reduces `Nat.rec base step 0` to `base` and `Nat.rec base step (n+1)` to `step n (Nat.rec base step n)` by `ι`-reduction (iota reduction). This is the computational content of the induction principle.",
+    "content": "The alternative proof `weak_induction'` shows that induction is literally the recursor:\n\n```lean\ntheorem weak_induction' ... : \u2200 n, P n :=\n  Nat.rec base step\n```\n\nIn type theory, the induction principle for any inductive type is automatically generated as its **recursor**. For `Nat`, this is `Nat.rec`.",
+    "mathContext": "The term `Nat.rec base step : \u2200 n, P n` is a fully elaborated proof term with no tactics. In the Curry-Howard correspondence, this term is simultaneously a proof of `\u2200 n, P n` and a program computing values of type `P n` by recursion on `n`. Lean's kernel reduces `Nat.rec base step 0` to `base` and `Nat.rec base step (n+1)` to `step n (Nat.rec base step n)` by `\u03b9`-reduction (iota reduction). This is the computational content of the induction principle.",
     "significance": "key",
     "prerequisites": [
       "Nat.rec recursor type signature",
       "proof terms vs tactics in Lean",
-      "ι-reduction (iota reduction)",
+      "\u03b9-reduction (iota reduction)",
       "Curry-Howard correspondence"
     ],
     "relatedConcepts": [
@@ -115,14 +115,14 @@
       "startLine": 87,
       "endLine": 99
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Strong Induction (Complete Induction)",
-    "content": "**Strong Induction**: Instead of assuming just $P(n)$, we assume $P(k)$ for **all** $k < n$.\n\n```lean\ntheorem strong_induction (P : ℕ → Prop)\n    (step : ∀ n, (∀ k, k < n → P k) → P n) :\n    ∀ n, P n\n```\n\n**Key insight**: The base case is implicit! When $n = 0$, the hypothesis '$\\forall k < 0, P(k)$' is vacuously true (there are no such $k$), so we must prove $P(0)$ directly.",
-    "mathContext": "The Lean proof uses `Nat.strong_induction_on` from Mathlib, which has signature `Nat.strong_induction_on : ∀ {P : ℕ → Sort*} (n : ℕ), (∀ m, (∀ a, a < m → P a) → P m) → P n`. Internally, this is proved by weak induction on the auxiliary predicate `Q(n) := ∀ k < n, P k`, then extracting `P n` from `Q(n+1)`. The `step` function in strong induction takes a proof of `∀ k < n, P k` — when `n = 0`, this is the empty function (proof of `False.elim` applied to `Nat.not_lt_zero`), so `P 0` must still be established from the step alone using the vacuously true hypothesis.",
+    "content": "**Strong Induction**: Instead of assuming just $P(n)$, we assume $P(k)$ for **all** $k < n$.\n\n```lean\ntheorem strong_induction (P : \u2115 \u2192 Prop)\n    (step : \u2200 n, (\u2200 k, k < n \u2192 P k) \u2192 P n) :\n    \u2200 n, P n\n```\n\n**Key insight**: The base case is implicit! When $n = 0$, the hypothesis '$\\forall k < 0, P(k)$' is vacuously true (there are no such $k$), so we must prove $P(0)$ directly.",
+    "mathContext": "The Lean proof uses `Nat.strong_induction_on` from Mathlib, which has signature `Nat.strong_induction_on : \u2200 {P : \u2115 \u2192 Sort*} (n : \u2115), (\u2200 m, (\u2200 a, a < m \u2192 P a) \u2192 P m) \u2192 P n`. Internally, this is proved by weak induction on the auxiliary predicate `Q(n) := \u2200 k < n, P k`, then extracting `P n` from `Q(n+1)`. The `step` function in strong induction takes a proof of `\u2200 k < n, P k` \u2014 when `n = 0`, this is the empty function (proof of `False.elim` applied to `Nat.not_lt_zero`), so `P 0` must still be established from the step alone using the vacuously true hypothesis.",
     "significance": "key",
     "prerequisites": [
       "Nat.strong_induction_on from Mathlib",
-      "vacuous truth (∀ k < 0, P k)",
+      "vacuous truth (\u2200 k < 0, P k)",
       "predicate strengthening technique",
       "weak induction"
     ],
@@ -145,11 +145,11 @@
     "type": "concept",
     "title": "Why Use Strong Induction?",
     "content": "Strong induction is more convenient when the proof of $P(n)$ needs information about values other than $n-1$.\n\n**Example**: To prove every $n \\geq 2$ has a prime divisor:\n- If $n$ is prime, done.\n- If $n = ab$ is composite, we need $P(a)$ where $a$ could be much smaller than $n-1$.\n\nWeak induction would require a more complex auxiliary statement.",
-    "mathContext": "The prime divisor example illustrates why strong induction has better ergonomics for certain classes of proofs. With weak induction only, proving 'every n ≥ 2 has a prime divisor' requires the auxiliary predicate 'for all m ≤ n with m ≥ 2, m has a prime divisor' — this is the predicate strengthening technique `strong_from_weak` formalizes. A key heuristic: strong induction is needed when the induction goes to a value other than `n-1`, such as `n/2` (binary search), `n-k` for variable `k` (dynamic programming), or an arbitrary divisor (number theory). In Lean, `Nat.strong_induction_on` and `Nat.strongRecOn` are the main tools.",
+    "mathContext": "The prime divisor example illustrates why strong induction has better ergonomics for certain classes of proofs. With weak induction only, proving 'every n \u2265 2 has a prime divisor' requires the auxiliary predicate 'for all m \u2264 n with m \u2265 2, m has a prime divisor' \u2014 this is the predicate strengthening technique `strong_from_weak` formalizes. A key heuristic: strong induction is needed when the induction goes to a value other than `n-1`, such as `n/2` (binary search), `n-k` for variable `k` (dynamic programming), or an arbitrary divisor (number theory). In Lean, `Nat.strong_induction_on` and `Nat.strongRecOn` are the main tools.",
     "significance": "key",
     "prerequisites": [
       "prime numbers",
-      "divisibility in ℕ",
+      "divisibility in \u2115",
       "composite number decomposition",
       "inductive hypothesis"
     ],
@@ -169,10 +169,10 @@
       "startLine": 113,
       "endLine": 133
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Weak Induction Implies Strong",
-    "content": "**Weak → Strong**: Strengthen the predicate to $Q(n) = \\forall k < n. P(k)$.\n\n1. **Base**: $Q(0)$ is vacuously true (no $k < 0$).\n2. **Step**: If $Q(n)$ holds (i.e., $P(k)$ for all $k < n$), then by the strong step hypothesis, $P(n)$ holds, so $Q(n+1)$ holds.\n3. By weak induction on $Q$, we get $Q(n)$ for all $n$, which gives $P(n)$.\n\nThis is a classic proof technique: strengthening the induction hypothesis.",
-    "mathContext": "The key move is introducing the auxiliary predicate `Q(n) := ∀ k < n, P k`. In Lean: `let Q : ℕ → Prop := fun n => ∀ k, k < n → P k`. The weak induction hypothesis gives `Q_base : Q 0` (vacuously, since `k < 0` is false by `Nat.not_lt_zero`) and `Q_step : ∀ n, Q n → Q (n+1)` (using `Nat.lt_succ_iff_lt_or_eq` to split `k < n+1` into `k < n` or `k = n`). This technique of strengthening the induction hypothesis is a fundamental proof strategy: when the obvious induction hypothesis is too weak to close the inductive step, add more structure to the predicate.",
+    "content": "**Weak \u2192 Strong**: Strengthen the predicate to $Q(n) = \\forall k < n. P(k)$.\n\n1. **Base**: $Q(0)$ is vacuously true (no $k < 0$).\n2. **Step**: If $Q(n)$ holds (i.e., $P(k)$ for all $k < n$), then by the strong step hypothesis, $P(n)$ holds, so $Q(n+1)$ holds.\n3. By weak induction on $Q$, we get $Q(n)$ for all $n$, which gives $P(n)$.\n\nThis is a classic proof technique: strengthening the induction hypothesis.",
+    "mathContext": "The key move is introducing the auxiliary predicate `Q(n) := \u2200 k < n, P k`. In Lean: `let Q : \u2115 \u2192 Prop := fun n => \u2200 k, k < n \u2192 P k`. The weak induction hypothesis gives `Q_base : Q 0` (vacuously, since `k < 0` is false by `Nat.not_lt_zero`) and `Q_step : \u2200 n, Q n \u2192 Q (n+1)` (using `Nat.lt_succ_iff_lt_or_eq` to split `k < n+1` into `k < n` or `k = n`). This technique of strengthening the induction hypothesis is a fundamental proof strategy: when the obvious induction hypothesis is too weak to close the inductive step, add more structure to the predicate.",
     "significance": "key",
     "prerequisites": [
       "predicate strengthening / generalization",
@@ -196,10 +196,10 @@
       "startLine": 135,
       "endLine": 147
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Strong Induction Implies Weak",
-    "content": "**Strong → Weak**: This direction is straightforward.\n\nWeak induction is a special case of strong induction where we only use the hypothesis at $n-1$.\n\nGiven base case $P(0)$ and step $P(n) \\to P(n+1)$, we can construct the strong step: assuming $P(k)$ for all $k < n$, use only $P(n-1)$ (when $n > 0$) to get $P(n)$.\n\nThis shows both principles have the same expressive power!",
-    "mathContext": "The proof unfolds by case analysis on `n`. For `n = 0`, use `base` directly (no inductive hypothesis needed). For `n = succ m`, the strong hypothesis gives `∀ k < m+1, P k`; applying it at `k = m` (using `Nat.lt_succ_self m : m < m+1`) yields `P m`, and then `step m : P m → P (m+1)` closes the case. This exhibits weak induction as the restriction of strong induction where only the immediately preceding value is used. The logical equivalence confirms both principles are equally expressive: they axiomatize the same class of structures (the standard model ℕ plus non-standard models of Peano arithmetic).",
+    "content": "**Strong \u2192 Weak**: This direction is straightforward.\n\nWeak induction is a special case of strong induction where we only use the hypothesis at $n-1$.\n\nGiven base case $P(0)$ and step $P(n) \\to P(n+1)$, we can construct the strong step: assuming $P(k)$ for all $k < n$, use only $P(n-1)$ (when $n > 0$) to get $P(n)$.\n\nThis shows both principles have the same expressive power!",
+    "mathContext": "The proof unfolds by case analysis on `n`. For `n = 0`, use `base` directly (no inductive hypothesis needed). For `n = succ m`, the strong hypothesis gives `\u2200 k < m+1, P k`; applying it at `k = m` (using `Nat.lt_succ_self m : m < m+1`) yields `P m`, and then `step m : P m \u2192 P (m+1)` closes the case. This exhibits weak induction as the restriction of strong induction where only the immediately preceding value is used. The logical equivalence confirms both principles are equally expressive: they axiomatize the same class of structures (the standard model \u2115 plus non-standard models of Peano arithmetic).",
     "significance": "supporting",
     "prerequisites": [
       "case analysis on Nat (zero/succ)",
@@ -222,16 +222,16 @@
       "startLine": 154,
       "endLine": 164
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Example: Sum of First n Natural Numbers",
-    "content": "A classic application of weak induction:\n\n$$2 \\cdot \\sum_{i=0}^{n} i = n(n+1)$$\n\nOr equivalently: $0 + 1 + 2 + \\cdots + n = \\frac{n(n+1)}{2}$\n\n**Base case** ($n = 0$): $2 \\cdot 0 = 0 \\cdot 1$ ✓\n\n**Inductive step**: Assuming the formula for $n$, we verify it for $n+1$ using `ring` to handle the algebra.",
-    "mathContext": "In Lean, `∑ i ∈ Finset.range (n+1), i` computes the sum using `Finset.sum`. The proof uses `Finset.sum_range_succ : ∑ i ∈ Finset.range (n+1), f i = (∑ i ∈ Finset.range n, f i) + f n` to unfold the last term, then the inductive hypothesis rewrites the prefix sum, and `ring` closes the remaining arithmetic identity. The factor of 2 avoids division in ℕ (which truncates in Lean). Lean's `ring` tactic handles polynomial identities over commutative (semi)rings, including ℕ. This is entry #74 in Wiedijk's 100 Theorems list.",
+    "content": "A classic application of weak induction:\n\n$$2 \\cdot \\sum_{i=0}^{n} i = n(n+1)$$\n\nOr equivalently: $0 + 1 + 2 + \\cdots + n = \\frac{n(n+1)}{2}$\n\n**Base case** ($n = 0$): $2 \\cdot 0 = 0 \\cdot 1$ \u2713\n\n**Inductive step**: Assuming the formula for $n$, we verify it for $n+1$ using `ring` to handle the algebra.",
+    "mathContext": "In Lean, `\u2211 i \u2208 Finset.range (n+1), i` computes the sum using `Finset.sum`. The proof uses `Finset.sum_range_succ : \u2211 i \u2208 Finset.range (n+1), f i = (\u2211 i \u2208 Finset.range n, f i) + f n` to unfold the last term, then the inductive hypothesis rewrites the prefix sum, and `ring` closes the remaining arithmetic identity. The factor of 2 avoids division in \u2115 (which truncates in Lean). Lean's `ring` tactic handles polynomial identities over commutative (semi)rings, including \u2115. This is entry #74 in Wiedijk's 100 Theorems list.",
     "significance": "supporting",
     "prerequisites": [
       "Finset.sum and Finset.range in Mathlib",
       "Finset.sum_range_succ lemma",
       "ring tactic for arithmetic identities",
-      "arithmetic in ℕ (no subtraction pitfalls)"
+      "arithmetic in \u2115 (no subtraction pitfalls)"
     ],
     "relatedConcepts": [
       "arithmetic series",
@@ -250,14 +250,14 @@
       "startLine": 166,
       "endLine": 173
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Example: Existence of Prime Divisors",
     "content": "Every natural number $n \\geq 2$ has a prime divisor.\n\nThis requires strong induction because if $n = ab$ is composite, we apply the hypothesis to $a$, which could be much smaller than $n-1$.\n\nWe use Mathlib's `Nat.exists_prime_and_dvd` which encapsulates this strong induction argument.",
-    "mathContext": "Mathlib's `Nat.exists_prime_and_dvd` has signature `Nat.exists_prime_and_dvd : n ≠ 1 → ∃ p, Nat.Prime p ∧ p ∣ n`. The condition `n ≠ 1` is equivalent to `2 ≤ n` for `n : ℕ` (since `n = 0` gives divisor 2 via convention, or we need `n ≥ 2`). Internally, Mathlib proves this by strong induction: if `n` is prime, `n ∣ n`; if `n = a * b` with `1 < a, b < n`, apply the induction hypothesis to `a`. In Lean, `omega` or `Nat.lt_of_dvd_of_lt` are used to verify that proper divisors are strictly smaller, satisfying the strong induction decrease condition. This is a prototypical use of strong induction in number theory.",
+    "mathContext": "Mathlib's `Nat.exists_prime_and_dvd` has signature `Nat.exists_prime_and_dvd : n \u2260 1 \u2192 \u2203 p, Nat.Prime p \u2227 p \u2223 n`. The condition `n \u2260 1` is equivalent to `2 \u2264 n` for `n : \u2115` (since `n = 0` gives divisor 2 via convention, or we need `n \u2265 2`). Internally, Mathlib proves this by strong induction: if `n` is prime, `n \u2223 n`; if `n = a * b` with `1 < a, b < n`, apply the induction hypothesis to `a`. In Lean, `omega` or `Nat.lt_of_dvd_of_lt` are used to verify that proper divisors are strictly smaller, satisfying the strong induction decrease condition. This is a prototypical use of strong induction in number theory.",
     "significance": "key",
     "prerequisites": [
       "Nat.Prime definition in Mathlib",
-      "divisibility (Dvd) in ℕ",
+      "divisibility (Dvd) in \u2115",
       "Nat.exists_prime_and_dvd from Mathlib",
       "omega tactic for linear arithmetic"
     ],
@@ -278,10 +278,10 @@
       "startLine": 180,
       "endLine": 186
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Well-Ordering Principle",
-    "content": "**Well-Ordering Principle**: Every nonempty subset of $\\mathbb{N}$ has a least element.\n\nIn Lean, this is captured by `Nat.find`: given a decidable predicate $P$ and a proof that some $n$ satisfies $P$, `Nat.find` returns the smallest such $n$.\n\n```lean\ntheorem well_ordering (P : ℕ → Prop) [DecidablePred P]\n    (hne : ∃ n, P n) :\n    ∃ m, P m ∧ ∀ n, P n → m ≤ n\n```",
-    "mathContext": "`Nat.find` in Lean has type `(h : ∃ n, P n) → ℕ` where `P` must be `DecidablePred`. It requires a proof of existence to return the minimum witness. `Nat.find_spec h : P (Nat.find h)` and `Nat.find_min' h : P n → Nat.find h ≤ n` provide the minimality. The `DecidablePred` typeclass constraint means the predicate must be computably decidable — this is necessary because `Nat.find` is implemented by linear search from 0. For non-computable predicates (requiring `Classical.choice`), one uses `Nat.find` with `Classical.decideEq` or works with `Nat.sInf` from order theory.",
+    "content": "**Well-Ordering Principle**: Every nonempty subset of $\\mathbb{N}$ has a least element.\n\nIn Lean, this is captured by `Nat.find`: given a decidable predicate $P$ and a proof that some $n$ satisfies $P$, `Nat.find` returns the smallest such $n$.\n\n```lean\ntheorem well_ordering (P : \u2115 \u2192 Prop) [DecidablePred P]\n    (hne : \u2203 n, P n) :\n    \u2203 m, P m \u2227 \u2200 n, P n \u2192 m \u2264 n\n```",
+    "mathContext": "`Nat.find` in Lean has type `(h : \u2203 n, P n) \u2192 \u2115` where `P` must be `DecidablePred`. It requires a proof of existence to return the minimum witness. `Nat.find_spec h : P (Nat.find h)` and `Nat.find_min' h : P n \u2192 Nat.find h \u2264 n` provide the minimality. The `DecidablePred` typeclass constraint means the predicate must be computably decidable \u2014 this is necessary because `Nat.find` is implemented by linear search from 0. For non-computable predicates (requiring `Classical.choice`), one uses `Nat.find` with `Classical.decideEq` or works with `Nat.sInf` from order theory.",
     "significance": "key",
     "prerequisites": [
       "DecidablePred typeclass",
@@ -307,10 +307,10 @@
       "startLine": 188,
       "endLine": 202
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Well-Ordering Implies Strong Induction",
-    "content": "**Proof by contraposition**: If $\\neg \\forall n. P(n)$, then the set $S = \\{n : \\neg P(n)\\}$ is nonempty.\n\nBy well-ordering, $S$ has a minimum $m$. But then $P(k)$ holds for all $k < m$, so by the strong induction hypothesis, $P(m)$ should hold—contradiction!\n\nThis shows well-ordering and induction are equivalent principles.",
-    "mathContext": "The Lean proof uses `by_contra h; push_neg at h` to obtain `∃ n, ¬P n`. Then `well_ordering (fun n => ¬P n) h` gives the minimal counterexample `m` with `hm : ¬P m` and `hmin : ∀ n, ¬P n → m ≤ n`. The key step: `intro k hkm` with `hkm : k < m` gives `by_contra hk; exact Nat.not_lt.mpr (hmin k hk) hkm` — the minimality of `m` says `m ≤ k`, contradicting `k < m`. So all `k < m` satisfy `P k`, and the strong induction `step` gives `P m`, contradicting `hm`. This is the standard proof that WOP ↔ strong induction, formalized with Lean's contradiction tactics.",
+    "content": "**Proof by contraposition**: If $\\neg \\forall n. P(n)$, then the set $S = \\{n : \\neg P(n)\\}$ is nonempty.\n\nBy well-ordering, $S$ has a minimum $m$. But then $P(k)$ holds for all $k < m$, so by the strong induction hypothesis, $P(m)$ should hold\u2014contradiction!\n\nThis shows well-ordering and induction are equivalent principles.",
+    "mathContext": "The Lean proof uses `by_contra h; push_neg at h` to obtain `\u2203 n, \u00acP n`. Then `well_ordering (fun n => \u00acP n) h` gives the minimal counterexample `m` with `hm : \u00acP m` and `hmin : \u2200 n, \u00acP n \u2192 m \u2264 n`. The key step: `intro k hkm` with `hkm : k < m` gives `by_contra hk; exact Nat.not_lt.mpr (hmin k hk) hkm` \u2014 the minimality of `m` says `m \u2264 k`, contradicting `k < m`. So all `k < m` satisfy `P k`, and the strong induction `step` gives `P m`, contradicting `hm`. This is the standard proof that WOP \u2194 strong induction, formalized with Lean's contradiction tactics.",
     "significance": "key",
     "prerequisites": [
       "proof by contraposition in Lean (by_contra, push_neg)",
@@ -337,14 +337,14 @@
     },
     "type": "concept",
     "title": "Connection to Type Theory",
-    "content": "In Lean's type theory, the natural numbers are defined as an **inductive type**:\n\n```lean\ninductive Nat where\n  | zero : Nat\n  | succ : Nat → Nat\n```\n\nThe induction principle is automatically generated as the **recursor** `Nat.rec`:\n\n```lean\nNat.rec : (base : P 0) → (step : ∀ n, P n → P (n+1)) → (n : ℕ) → P n\n```\n\nThis is exactly the computational content of the induction principle!",
-    "mathContext": "In Lean 4's kernel, `Nat` is a primitive type but behaves as if defined by `inductive Nat where | zero : Nat | succ : Nat → Nat`. The universe-polymorphic recursor `Nat.rec : {motive : Nat → Sort u} → motive 0 → (∀ n, motive n → motive (n+1)) → ∀ n, motive n` is the unique elimination rule. When `motive : Nat → Prop`, this gives the induction principle; when `motive : Nat → Type`, this gives primitive recursion. Lean's definitional equality includes ι-reduction: `Nat.rec f g 0 ≡ f` and `Nat.rec f g (succ n) ≡ g n (Nat.rec f g n)`. This means proofs and programs defined by `Nat.rec` compute, enabling the Curry-Howard correspondence between mathematical proofs and executable programs.",
+    "content": "In Lean's type theory, the natural numbers are defined as an **inductive type**:\n\n```lean\ninductive Nat where\n  | zero : Nat\n  | succ : Nat \u2192 Nat\n```\n\nThe induction principle is automatically generated as the **recursor** `Nat.rec`:\n\n```lean\nNat.rec : (base : P 0) \u2192 (step : \u2200 n, P n \u2192 P (n+1)) \u2192 (n : \u2115) \u2192 P n\n```\n\nThis is exactly the computational content of the induction principle!",
+    "mathContext": "In Lean 4's kernel, `Nat` is a primitive type but behaves as if defined by `inductive Nat where | zero : Nat | succ : Nat \u2192 Nat`. The universe-polymorphic recursor `Nat.rec : {motive : Nat \u2192 Sort u} \u2192 motive 0 \u2192 (\u2200 n, motive n \u2192 motive (n+1)) \u2192 \u2200 n, motive n` is the unique elimination rule. When `motive : Nat \u2192 Prop`, this gives the induction principle; when `motive : Nat \u2192 Type`, this gives primitive recursion. Lean's definitional equality includes \u03b9-reduction: `Nat.rec f g 0 \u2261 f` and `Nat.rec f g (succ n) \u2261 g n (Nat.rec f g n)`. This means proofs and programs defined by `Nat.rec` compute, enabling the Curry-Howard correspondence between mathematical proofs and executable programs.",
     "significance": "key",
     "prerequisites": [
       "inductive types in Lean 4",
       "Nat.rec universe-polymorphic recursor",
       "Sort u hierarchy (Prop, Type 0, Type 1, ...)",
-      "ι-reduction (iota reduction)",
+      "\u03b9-reduction (iota reduction)",
       "Curry-Howard correspondence"
     ],
     "relatedConcepts": [
@@ -367,8 +367,8 @@
     },
     "type": "concept",
     "title": "Generalizing to Other Data Types",
-    "content": "Induction generalizes to any inductively defined type. For lists:\n\n```lean\ntheorem list_induction (P : List α → Prop)\n    (base : P [])\n    (step : ∀ x xs, P xs → P (x :: xs)) :\n    ∀ l, P l\n```\n\nThis is **structural induction**: prove for the empty list, and prove for `x :: xs` assuming it holds for `xs`.",
-    "mathContext": "The list recursor `List.rec` has two cases mirroring the two constructors: `nil : List α` and `cons : α → List α → List α`. The `list_induction` theorem directly applies `List.rec`. In Lean, the `induction l with | nil => ... | cons x xs ih => ...` tactic desugars to `List.rec`. Structural induction applies to *any* inductive type: trees, terms, formulas, etc. For well-founded recursion on non-inductive structures (e.g., termination of algorithms), Lean uses `termination_by` with a well-founded relation, generalizing structural induction via `WellFounded.induction`. The `Finset.induction_on` lemma used in `sum_first_n` is another instance: induction on finite sets by adding one element at a time.",
+    "content": "Induction generalizes to any inductively defined type. For lists:\n\n```lean\ntheorem list_induction (P : List \u03b1 \u2192 Prop)\n    (base : P [])\n    (step : \u2200 x xs, P xs \u2192 P (x :: xs)) :\n    \u2200 l, P l\n```\n\nThis is **structural induction**: prove for the empty list, and prove for `x :: xs` assuming it holds for `xs`.",
+    "mathContext": "The list recursor `List.rec` has two cases mirroring the two constructors: `nil : List \u03b1` and `cons : \u03b1 \u2192 List \u03b1 \u2192 List \u03b1`. The `list_induction` theorem directly applies `List.rec`. In Lean, the `induction l with | nil => ... | cons x xs ih => ...` tactic desugars to `List.rec`. Structural induction applies to *any* inductive type: trees, terms, formulas, etc. For well-founded recursion on non-inductive structures (e.g., termination of algorithms), Lean uses `termination_by` with a well-founded relation, generalizing structural induction via `WellFounded.induction`. The `Finset.induction_on` lemma used in `sum_first_n` is another instance: induction on finite sets by adding one element at a time.",
     "significance": "supporting",
     "prerequisites": [
       "List inductive type (nil, cons constructors)",

--- a/src/data/proofs/navier-stokes/annotations.json
+++ b/src/data/proofs/navier-stokes/annotations.json
@@ -41,7 +41,7 @@
       "startLine": 24,
       "endLine": 122
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Key Numerical Inequality",
     "content": "This is the heart of the depletion mechanism: $\\kappa \\cdot c_{FK} > 2$ proves that geometric depletion (from vortex stretching alignment) overwhelms the potential for concentration. The factor $\\kappa = 4$ comes from the geometry of strain-vorticity interaction.",
     "mathContext": "When $\\kappa \\cdot c_{FK} > 2$, the depletion coefficient $d = 2 - \\kappa \\cdot c_{FK}$ becomes negative, meaning the system naturally depletes rather than concentrates. Numerically: $4 \\times 2.11 = 8.44 > 2$.",
@@ -82,7 +82,7 @@
       "startLine": 150,
       "endLine": 163
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Bernoulli's Inequality",
     "content": "The classical Bernoulli inequality $(1+x)^n \\geq 1 + nx$ for $x \\geq -1$ is proved by induction. This elementary result becomes surprisingly powerful when applied to backward-time energy growth, establishing that solutions cannot remain bounded while growing at a positive rate.",
     "mathContext": "**Bernoulli's inequality**: For $x \\geq -1$ and $n \\in \\mathbb{N}$, $(1+x)^n \\geq 1 + nx$. Proof by induction: base $n=0$ trivial; step uses $(1+x)^{n+1} = (1+x)^n(1+x) \\geq (1+nx)(1+x) = 1+(n+1)x+nx^2 \\geq 1+(n+1)x$. In the enstrophy argument: starting from $E_0 > 0$ with discrete growth step $h = 1/(\\lambda_1)$, after $n$ steps $E_n = E_0(1+\\lambda_1 h)^n = E_0 \\cdot 2^n$. Bernoulli gives $E_n \\geq E_0(1+n)$, providing the linear lower bound needed to show $E_n \\to \\infty$.",
@@ -99,7 +99,7 @@
       "startLine": 170,
       "endLine": 176
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Backward Growth is Unbounded",
     "content": "Using Bernoulli's inequality, this shows that if enstrophy grows at rate $\\lambda_1$ (the spectral gap) in backward time, it must eventually exceed any bound $M$. This is the quantitative engine behind the Liouville theorem: bounded ancient solutions cannot have positive growth rate.",
     "mathContext": "For $E_0 > 0$ and step $h > 0$: $$E_0(1 + \\lambda_1 h)^n \\geq E_0(1 + n\\lambda_1 h) \\to \\infty$$ as $n \\to \\infty$.",
@@ -120,7 +120,7 @@
       "startLine": 358,
       "endLine": 390
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Enstrophy is Monotone in Backward Time",
     "content": "A key technical lemma: for ancient solutions, enstrophy $E(\\tau)$ is monotonically increasing in backward time $\\tau$. Since $dE/d\\tau \\geq 2(\\lambda_1 - C_S)E > 0$ (spectral gap exceeds stretching), $E$ cannot decrease going backward. This monotonicity is the bridge to the Liouville theorem.",
     "mathContext": "The proof applies the mean value theorem: if $E'(\\tau) \\geq 0$ everywhere on $[\\tau_1, \\tau_2]$, then $E(\\tau_2) \\geq E(\\tau_1)$.",
@@ -141,7 +141,7 @@
       "startLine": 408,
       "endLine": 415
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Liouville Theorem for Bounded Ancient Solutions",
     "content": "The climax of Part III: any bounded ancient solution must be constant. The proof is elegant: $E$ is monotone increasing (backward) and bounded above by $M$, so it must converge to a constant. But a constant non-zero $E$ contradicts the positive growth rate from the spectral gap.",
     "mathContext": "This mirrors classical Liouville theorems: bounded harmonic functions on $\\mathbb{R}^n$ are constant. Here, the spectral gap provides the rigidity that forces constancy.",
@@ -163,7 +163,7 @@
       "startLine": 645,
       "endLine": 645
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "ESS Theorem: Type I Blowup Impossible",
     "content": "The Escauriaza-Seregin-Sverak theorem (2003) rules out Type I (self-similar) blowup for Navier-Stokes. This proof formalizes it: bounded ancient solutions are constant, constant solutions have zero dissipation, but the spectral gap requires positive dissipation for non-trivial solutions. Contradiction.",
     "mathContext": "Type I blowup would have $|u(x,t)| \\leq C/\\sqrt{T-t}$. The rescaled solution around the blowup would be an ancient solution with bounded enstrophy - now shown impossible.",
@@ -241,7 +241,7 @@
       "startLine": 786,
       "endLine": 792
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Effective Beta Vanishes",
     "content": "For Type II blowup with $\\alpha > 1$, the effective stretching coefficient $\\beta = C_\\beta(T-t)^{\\alpha-1}$ vanishes as $t \\to T$. This is the key decay: because $\\alpha - 1 > 0$, the power $(T-t)^{\\alpha-1} \\to 0$ faster than stretching can grow.",
     "mathContext": "Given any $\\epsilon > 0$, there exists $t_0$ near $T$ such that $C_\\beta(T-t)^{\\alpha-1} < \\epsilon$ for $t > t_0$. Choose $\\epsilon = c_d/2$ to make stretching negligible compared to dissipation.",
@@ -261,7 +261,7 @@
       "startLine": 894,
       "endLine": 898
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Type II Implies Eventual Stability",
     "content": "The heart of Part VI: for Type II scenarios, there exists $t_0 < T$ such that for all $t > t_0$, we have $S(t) \\leq \\nu P(t)$. Stretching is dominated by dissipation near the potential blowup time! This is the stability that prevents blowup.",
     "mathContext": "The proof chains: $(T-t)^{\\alpha-1} < c_d/(2C_\\beta)$ implies $S \\leq (c_d/2)\\Omega E \\leq (\\nu P)/2 \\leq \\nu P$. Dissipation wins.",
@@ -282,7 +282,7 @@
       "startLine": 138,
       "endLine": 140
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Enstrophy Bounded After Stability",
     "content": "Once stability kicks in ($S \\leq \\nu P$), the enstrophy derivative $E' = 2S - 2\\nu P \\leq 0$ becomes non-positive. Enstrophy is non-increasing after $t_0$, so $E(t) \\leq E(t_0)$ for all $t > t_0$. Combined with the early-time bound, $E$ is globally bounded.",
     "mathContext": "By the monotonicity theorem for functions with non-positive derivative on a convex domain, $E(t) \\leq E(t_0)$ for $t \\in [t_0, T)$.",
@@ -302,7 +302,7 @@
       "startLine": 997,
       "endLine": 1001
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Type II Blowup is Impossible",
     "content": "The culmination of Part VI: Type II blowup cannot occur. The proof: eventual stability gives bounded $E$, BKM criterion converts bounded $E$ to bounded $\\Omega$, but blowup means $\\Omega \\to \\infty$. Contradiction. Combined with ESS (no Type I), **all blowup is impossible**.",
     "mathContext": "This is a proof by contradiction. Assume blowup occurs at time $T$. Then $\\Omega(t) \\to \\infty$ as $t \\to T$. But we proved $\\Omega(t) \\leq C$ for all $t < T$. This contradiction rules out blowup entirely.",

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.json
@@ -33,7 +33,7 @@
     "type": "definition",
     "title": "How Mathlib Handles Infinite Sums",
     "content": "Mathlib's `tsum` (topological sum) function is the standard way to express infinite sums in Lean. Crucially, `tsum f` only equals the expected limit if the sum **converges**. For divergent series, `tsum` returns **0** by convention.",
-    "mathContext": "Formally: `tsum f = if h : Summable f then (h.choose : α) else 0`. This junk-value convention means all lemmas that do useful things — `tsum_add`, `tsum_eq_zero_add`, `tsum_geometric_two` — carry a `Summable f` hypothesis. Without it, `tsum f = 0` and you can only prove $0 = 0$.",
+    "mathContext": "Formally: `tsum f = if h : Summable f then (h.choose : \u03b1) else 0`. This junk-value convention means all lemmas that do useful things \u2014 `tsum_add`, `tsum_eq_zero_add`, `tsum_geometric_two` \u2014 carry a `Summable f` hypothesis. Without it, `tsum f = 0` and you can only prove $0 = 0$.",
     "significance": "key",
     "prerequisites": [
       "real analysis",
@@ -57,7 +57,7 @@
     "type": "definition",
     "title": "Defining the Natural Number Series",
     "content": "We define `naturals n = n + 1` to get the sequence $1, 2, 3, 4, \\ldots$ (offset by 1 because $\\mathbb{N}$ starts at 0 in Lean).",
-    "mathContext": "The function `naturals : ℕ → ℝ` defined by `naturals n = ↑(n + 1)` gives the series $\\sum_{n=0}^{\\infty} (n+1) = 1 + 2 + 3 + \\cdots$. The cast `↑` coerces `ℕ` to `ℝ`. This offset-by-one indexing is standard in Lean/Mathlib: `Finset.range n = {0, 1, ..., n-1}`, so `∑ k in Finset.range n, naturals k = \\frac{n(n+1)}{2}`.",
+    "mathContext": "The function `naturals : \u2115 \u2192 \u211d` defined by `naturals n = \u2191(n + 1)` gives the series $\\sum_{n=0}^{\\infty} (n+1) = 1 + 2 + 3 + \\cdots$. The cast `\u2191` coerces `\u2115` to `\u211d`. This offset-by-one indexing is standard in Lean/Mathlib: `Finset.range n = {0, 1, ..., n-1}`, so `\u2211 k in Finset.range n, naturals k = \\frac{n(n+1)}{2}`.",
     "significance": "supporting",
     "prerequisites": [
       "natural numbers",
@@ -76,10 +76,10 @@
       "startLine": 8,
       "endLine": 45
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The False Claim Would Require Convergence",
     "content": "This theorem shows that IF we could prove $\\sum n = -\\frac{1}{12}$, THEN the series would need to be `Summable`. But the series diverges, so this implication is vacuously true - we can never satisfy the hypothesis.",
-    "mathContext": "The argument uses the contrapositive of `tsum_eq_zero_of_not_summable`: if `¬ Summable f`, then `tsum f = 0`. So `tsum naturals = -1/12` would force `tsum naturals ≠ 0`, hence `Summable naturals` — but we prove `¬ Summable naturals` by showing partial sums are unbounded. The `sorry` marks the exact point where the informal argument breaks the formal rules.",
+    "mathContext": "The argument uses the contrapositive of `tsum_eq_zero_of_not_summable`: if `\u00ac Summable f`, then `tsum f = 0`. So `tsum naturals = -1/12` would force `tsum naturals \u2260 0`, hence `Summable naturals` \u2014 but we prove `\u00ac Summable naturals` by showing partial sums are unbounded. The `sorry` marks the exact point where the informal argument breaks the formal rules.",
     "significance": "key",
     "prerequisites": [
       "real analysis",
@@ -102,7 +102,7 @@
     "type": "definition",
     "title": "The Grandi Series",
     "content": "The **Grandi series** $1-1+1-1+\\cdots$ has partial sums that alternate forever between 0 and 1. It does not converge in any standard sense.",
-    "mathContext": "Defined as `grandi n = (-1)^n`. The partial sums are $S_n = \\frac{1-(-1)^{n+1}}{2}$, oscillating between 0 and 1. The **Cesàro mean** is $\\lim_{N\\to\\infty}\\frac{1}{N}\\sum_{n=0}^{N-1} S_n = \\frac{1}{2}$, which the Numberphile video conflates with the series limit. In Mathlib: `¬ Summable grandi` because the partial sums do not converge.",
+    "mathContext": "Defined as `grandi n = (-1)^n`. The partial sums are $S_n = \\frac{1-(-1)^{n+1}}{2}$, oscillating between 0 and 1. The **Ces\u00e0ro mean** is $\\lim_{N\\to\\infty}\\frac{1}{N}\\sum_{n=0}^{N-1} S_n = \\frac{1}{2}$, which the Numberphile video conflates with the series limit. In Mathlib: `\u00ac Summable grandi` because the partial sums do not converge.",
     "significance": "key",
     "prerequisites": [
       "real analysis",
@@ -123,10 +123,10 @@
       "startLine": 55,
       "endLine": 56
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "FALLACY: Cannot Prove Grandi = 1/2",
     "content": "Here we attempt to prove the Numberphile claim that $1-1+1-1+\\cdots = \\frac{1}{2}$. **This is impossible** - the `sorry` can never be filled in. Since the series isn't summable, `tsum grandi = 0` by definition, and $0 \\neq \\frac{1}{2}$.",
-    "mathContext": "Formally: `tsum_eq_zero_of_not_summable : ¬ Summable f → tsum f = 0`. Since `¬ Summable grandi`, we get `tsum grandi = 0`. The goal `tsum grandi = 1/2` reduces to `(0 : ℝ) = 1/2`, which `norm_num` immediately refutes. Any `sorry`-free proof here would yield `False`.",
+    "mathContext": "Formally: `tsum_eq_zero_of_not_summable : \u00ac Summable f \u2192 tsum f = 0`. Since `\u00ac Summable grandi`, we get `tsum grandi = 0`. The goal `tsum grandi = 1/2` reduces to `(0 : \u211d) = 1/2`, which `norm_num` immediately refutes. Any `sorry`-free proof here would yield `False`.",
     "significance": "key",
     "prerequisites": [
       "Grandi series",
@@ -148,7 +148,7 @@
     "type": "concept",
     "title": "The Shift-and-Add Trick",
     "content": "The Numberphile proof adds $S_2$ to a shifted copy of itself:\n$$2S_2 = (1-2+3-4+\\cdots) + (0+1-2+3+\\cdots)$$\nThis term-by-term addition is ONLY valid for convergent series!",
-    "mathContext": "The **Riemann series theorem** (Riemann, 1853) states that any conditionally convergent series can be rearranged to converge to any value in $\\mathbb{R} \\cup \\{\\pm\\infty\\}$. For *divergent* series, term-by-term operations are completely undefined. The shift operation in Mathlib is `tsum_eq_zero_add : Summable f → tsum f = f 0 + tsum (f ∘ Nat.succ)`, which requires a summability witness.",
+    "mathContext": "The **Riemann series theorem** (Riemann, 1853) states that any conditionally convergent series can be rearranged to converge to any value in $\\mathbb{R} \\cup \\{\\pm\\infty\\}$. For *divergent* series, term-by-term operations are completely undefined. The shift operation in Mathlib is `tsum_eq_zero_add : Summable f \u2192 tsum f = f 0 + tsum (f \u2218 Nat.succ)`, which requires a summability witness.",
     "significance": "key",
     "prerequisites": [
       "infinite series",
@@ -169,10 +169,10 @@
       "startLine": 78,
       "endLine": 91
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Alternating Naturals Don't Converge Either",
     "content": "The series $1-2+3-4+5-6+\\cdots$ also diverges. Its partial sums grow without bound in absolute value: $1, -1, 2, -2, 3, -3, \\ldots$",
-    "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ — both grow without bound. `¬ Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 → ∞`, so it cannot tend to 0.",
+    "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ \u2014 both grow without bound. `\u00ac Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 \u2192 \u221e`, so it cannot tend to 0.",
     "significance": "key",
     "prerequisites": [
       "real analysis",
@@ -192,10 +192,10 @@
       "startLine": 93,
       "endLine": 97
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Shifting Requires Convergence Proof",
     "content": "Mathlib's lemmas for manipulating series (like `tsum_eq_zero_add`) all require a `Summable` hypothesis. This is the **type-level gatekeeper** that prevents invalid reasoning.",
-    "mathContext": "The relevant Mathlib lemma: `theorem tsum_eq_zero_add {f : ℕ → α} (hf : Summable f) : ∑' n, f n = f 0 + ∑' n, f (n + 1)`. Without `hf`, both sides equal 0 by `tsum_eq_zero_of_not_summable`, making the equation trivially `0 = 0 + 0`. The `Summable` term is a **proof witness** — it cannot be faked; you must construct it from first principles.",
+    "mathContext": "The relevant Mathlib lemma: `theorem tsum_eq_zero_add {f : \u2115 \u2192 \u03b1} (hf : Summable f) : \u2211' n, f n = f 0 + \u2211' n, f (n + 1)`. Without `hf`, both sides equal 0 by `tsum_eq_zero_of_not_summable`, making the equation trivially `0 = 0 + 0`. The `Summable` term is a **proof witness** \u2014 it cannot be faked; you must construct it from first principles.",
     "significance": "key",
     "prerequisites": [
       "Lean 4 dependent types",
@@ -214,10 +214,10 @@
       "startLine": 99,
       "endLine": 105
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "FALLACY: Shift-Add Blocked by Type System",
     "content": "When we try to apply the shift-and-add manipulation to our divergent series, **Lean blocks us**. We would need `Summable alternatingNaturals`, but we proved this is false!",
-    "mathContext": "The attempted proof calls `tsum_eq_zero_add h` where `h : Summable alternatingNaturals`. But `alternatingNaturals_not_summable : ¬ Summable alternatingNaturals` makes it impossible to construct such `h` without `sorry`. Lean's elaborator rejects the proof: there is no term of type `Summable alternatingNaturals` to supply. The `sorry` here is a permanent red flag — it marks the exact location where the informal argument breaks the formal rules.",
+    "mathContext": "The attempted proof calls `tsum_eq_zero_add h` where `h : Summable alternatingNaturals`. But `alternatingNaturals_not_summable : \u00ac Summable alternatingNaturals` makes it impossible to construct such `h` without `sorry`. Lean's elaborator rejects the proof: there is no term of type `Summable alternatingNaturals` to supply. The `sorry` here is a permanent red flag \u2014 it marks the exact location where the informal argument breaks the formal rules.",
     "significance": "key",
     "prerequisites": [
       "Lean 4 type checking",
@@ -236,10 +236,10 @@
       "startLine": 110,
       "endLine": 128
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Partial Sums Grow Without Bound",
     "content": "The sum $1+2+\\cdots+n = \\frac{n(n+1)}{2}$, which grows without bound as $n \\to \\infty$. This is the formal statement that the series diverges.",
-    "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `∑ k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < ∑ k in Finset.range n, naturals k`. This implies `¬ Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 → ∞`.",
+    "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `\u2211 k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `\u2200 M : \u211d, \u2203 N : \u2115, \u2200 n \u2265 N, M < \u2211 k in Finset.range n, naturals k`. This implies `\u00ac Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 \u2192 \u221e`.",
     "significance": "key",
     "prerequisites": [
       "real analysis",
@@ -258,10 +258,10 @@
       "startLine": 206,
       "endLine": 213
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "MAIN RESULT: The Sum Does NOT Equal -1/12",
     "content": "Here's the key theorem: $\\sum_{n=1}^{\\infty} n \\neq -\\frac{1}{12}$. The proof is almost trivial once we know the series doesn't converge:\n1. `naturals` is not summable\n2. Therefore `tsum naturals = 0` (by Mathlib convention)\n3. $0 \\neq -\\frac{1}{12}$ (by `norm_num`)",
-    "mathContext": "Proof sketch: `have h0 : tsum naturals = 0 := tsum_eq_zero_of_not_summable naturals_not_summable; have h1 : (0 : ℝ) ≠ -1/12 := by norm_num; rw [h0]; exact h1`. The three-step argument reflects the mathematical reality: **standard summation assigns no value to this series** — not $-1/12$, not $+\\infty$, just the junk value 0.",
+    "mathContext": "Proof sketch: `have h0 : tsum naturals = 0 := tsum_eq_zero_of_not_summable naturals_not_summable; have h1 : (0 : \u211d) \u2260 -1/12 := by norm_num; rw [h0]; exact h1`. The three-step argument reflects the mathematical reality: **standard summation assigns no value to this series** \u2014 not $-1/12$, not $+\\infty$, just the junk value 0.",
     "significance": "key",
     "prerequisites": [
       "real analysis",
@@ -283,7 +283,7 @@
     "type": "concept",
     "title": "What -1/12 Actually Means",
     "content": "The value $-\\frac{1}{12}$ is real - it comes from the **Riemann zeta function** $\\zeta(s) = \\sum n^{-s}$ analytically continued to $s = -1$. But this is a DIFFERENT mathematical operation than ordinary summation.",
-    "mathContext": "The Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$ and extends uniquely to a meromorphic function on $\\mathbb{C} \\setminus \\{1\\}$. At $s = -1$: $\\zeta(-1) = -\\frac{1}{12}$. In Lean, this would be a *different function type*: `riemannZeta : ℂ → ℂ` vs `tsum : (ℕ → ℝ) → ℝ`. The Lean type system makes the distinction **syntactically enforced** — you cannot accidentally confuse ordinary summation with zeta regularization.",
+    "mathContext": "The Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$ and extends uniquely to a meromorphic function on $\\mathbb{C} \\setminus \\{1\\}$. At $s = -1$: $\\zeta(-1) = -\\frac{1}{12}$. In Lean, this would be a *different function type*: `riemannZeta : \u2102 \u2192 \u2102` vs `tsum : (\u2115 \u2192 \u211d) \u2192 \u211d`. The Lean type system makes the distinction **syntactically enforced** \u2014 you cannot accidentally confuse ordinary summation with zeta regularization.",
     "significance": "key",
     "prerequisites": [
       "complex analysis",
@@ -304,10 +304,10 @@
       "startLine": 215,
       "endLine": 224
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Step 2 Fails: Cannot Shift Divergent Series",
     "content": "The second step uses the shift-and-add manipulation. **BLOCKED**: This requires `Summable` which we cannot prove for divergent series.",
-    "mathContext": "Step 2 of the Numberphile argument claims $2S_2 = \\frac{1}{4}$ by shifting and adding. In Lean: `tsum alternatingNaturals + tsum (fun n => alternatingNaturals (n+1)) = 1/4`. By `tsum_eq_zero_of_not_summable`, both `tsum`s equal 0, giving `0 + 0 = 0 ≠ 1/4`. The shift lemma `tsum_eq_zero_add` is unavailable since `¬ Summable alternatingNaturals`. Step 2 thus fails in two independent ways: the computed value is wrong, and the manipulation is illegal.",
+    "mathContext": "Step 2 of the Numberphile argument claims $2S_2 = \\frac{1}{4}$ by shifting and adding. In Lean: `tsum alternatingNaturals + tsum (fun n => alternatingNaturals (n+1)) = 1/4`. By `tsum_eq_zero_of_not_summable`, both `tsum`s equal 0, giving `0 + 0 = 0 \u2260 1/4`. The shift lemma `tsum_eq_zero_add` is unavailable since `\u00ac Summable alternatingNaturals`. Step 2 thus fails in two independent ways: the computed value is wrong, and the manipulation is illegal.",
     "significance": "key",
     "prerequisites": [
       "alternating series",
@@ -326,10 +326,10 @@
       "startLine": 226,
       "endLine": 227
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Step 3 'Works' But Is Useless",
     "content": "Interestingly, the equation $S - S_2 = 4S$ **does typecheck** - but it's trivially true because both sides equal 0! This shows how Mathlib's convention prevents false conclusions: we can prove $0 - 0 = 4 \\cdot 0$, but this tells us nothing about $-\\frac{1}{12}$.",
-    "mathContext": "The algebraic step $S - S_2 = 4S$ typechecks as: `tsum naturals - tsum alternatingNaturals = 4 * tsum naturals`. Since both `tsum` values are 0 by `tsum_eq_zero_of_not_summable`, this becomes `0 - 0 = 4 * 0`, i.e., `0 = 0` — provable by `ring`. The Numberphile argument uses this *form* to conclude $S = -\\frac{1}{12}$, but Lean sees only `0 = 0`: no information about the actual series value is transmitted.",
+    "mathContext": "The algebraic step $S - S_2 = 4S$ typechecks as: `tsum naturals - tsum alternatingNaturals = 4 * tsum naturals`. Since both `tsum` values are 0 by `tsum_eq_zero_of_not_summable`, this becomes `0 - 0 = 4 * 0`, i.e., `0 = 0` \u2014 provable by `ring`. The Numberphile argument uses this *form* to conclude $S = -\\frac{1}{12}$, but Lean sees only `0 = 0`: no information about the actual series value is transmitted.",
     "significance": "key",
     "prerequisites": [
       "Mathlib tsum API",
@@ -351,7 +351,7 @@
     "type": "concept",
     "title": "Conclusion: Type Systems Enforce Rigor",
     "content": "Lean's type system and Mathlib's design choices enforce mathematical rigor automatically:\n\n1. **Summable typeclass**: Acts as proof obligation before series manipulation\n2. **tsum = 0 convention**: Prevents arithmetic on divergent 'values'\n3. **Distinct types**: Regularization would be a different function entirely\n\nThe -1/12 result is useful in physics, but it requires different mathematical machinery that Lean would model with appropriate types.",
-    "mathContext": "The `Summable` typeclass is a **proof-carrying data** pattern: before calling `tsum_add (h1 : Summable f) (h2 : Summable g)`, you must supply witnesses `h1` and `h2` — real mathematical proofs that cannot be fabricated. Lean's kernel verifies proof correctness definitionally, making it impossible to accidentally apply series lemmas to divergent series. This is the fundamental difference between informal mathematics (where errors propagate undetected) and formal verification (where each step is machine-checked).",
+    "mathContext": "The `Summable` typeclass is a **proof-carrying data** pattern: before calling `tsum_add (h1 : Summable f) (h2 : Summable g)`, you must supply witnesses `h1` and `h2` \u2014 real mathematical proofs that cannot be fabricated. Lean's kernel verifies proof correctness definitionally, making it impossible to accidentally apply series lemmas to divergent series. This is the fundamental difference between informal mathematics (where errors propagate undetected) and formal verification (where each step is machine-checked).",
     "significance": "key",
     "prerequisites": [
       "Lean 4 type system",


### PR DESCRIPTION
Schema fix batch: corrected invalid annotation types in 8 gallery entries.

Valid types per schema: `concept | definition | technique | insight | context`

## Changes

| Proof | Fixed | Invalid types found |
|-------|-------|---------------------|
| intermediate-value-theorem | 9 | theorem(8), tactic(1) |
| mathematical-induction | 8 | theorem(8) |
| ramanujan-sum-fallacy | 9 | theorem(7), lemma(2) |
| area-of-circle-oq-01-oq-02-oq-03 | 10 | theorem(10) |
| knights-tour-oblique | 10 | theorem(10) |
| navier-stokes | 10 | theorem(9), lemma(1) |
| erdos-31 | 11 | theorem(11) |
| fundamental-arithmetic-oq-02 | 11 | theorem(11) |

**Total**: 78 annotation types fixed.

**Mapping applied**: theorem→insight, lemma→technique, tactic→technique, example→context