### PR TITLE
enrich(batch): fix invalid annotation types across 4 gallery entries

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "binom-pmf",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 28, "endLine": 43 },
+    "range": {
+      "startLine": 28,
+      "endLine": 43
+    },
     "type": "definition",
     "title": "binomPMF: Algebraic PMF Avoiding Measure Theory",
     "content": "`binomPMF`: The binomial probability mass function $P(X=k) = \\binom{n}{k} p^k (1-p)^{n-k}$. Defined as a real-valued function on $\\mathbb{N}$, not a measure-theoretic probability. This algebraic approach avoids sigma-algebras while capturing all combinatorial identities. Returns 0 for $k > n$ since $\\binom{n}{k} = 0$.",
@@ -22,9 +25,12 @@
   {
     "id": "binomial-expansion",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 48, "endLine": 63 },
-    "type": "theorem",
-    "title": "binomial_expansion: (p+q)^n = Σ C(n,k) p^k q^(n−k)",
+    "range": {
+      "startLine": 48,
+      "endLine": 63
+    },
+    "type": "insight",
+    "title": "binomial_expansion: (p+q)^n = \u03a3 C(n,k) p^k q^(n\u2212k)",
     "content": "`binomial_expansion`: The algebraic binomial theorem $(p+q)^n = \\sum_{k=0}^{n} \\binom{n}{k} p^k q^{n-k}$, proved by rewriting Mathlib's `add_pow`. This is the foundational identity from which every property of the binomial distribution follows.",
     "mathContext": "Mathlib's `add_pow` gives $(p+q)^n = \\sum_k \\binom{n}{k} p^k q^{n-k}$ using `Commute.add_pow`. The proof rewrites this into the desired summation form with a `congr` and `ring` step.",
     "significance": "key",
@@ -41,10 +47,13 @@
   {
     "id": "normalization",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 53, "endLine": 63 },
-    "type": "theorem",
-    "title": "binomPMF_sum_eq_one: The OQ-03 Answer — Binomial Theorem IS Normalization",
-    "content": "`binomPMF_sum_eq_one`: The PMF sums to 1. The proof is a one-line consequence of the binomial theorem: substitute $q = 1-p$ to get $(p + (1-p))^n = 1^n = 1$. This is the heart of the OQ-03 answer — the binomial theorem IS normalization.",
+    "range": {
+      "startLine": 53,
+      "endLine": 63
+    },
+    "type": "insight",
+    "title": "binomPMF_sum_eq_one: The OQ-03 Answer \u2014 Binomial Theorem IS Normalization",
+    "content": "`binomPMF_sum_eq_one`: The PMF sums to 1. The proof is a one-line consequence of the binomial theorem: substitute $q = 1-p$ to get $(p + (1-p))^n = 1^n = 1$. This is the heart of the OQ-03 answer \u2014 the binomial theorem IS normalization.",
     "mathContext": "Setting $q = 1-p$ in $(p+q)^n = \\sum \\binom{n}{k} p^k q^{n-k}$: $1^n = \\sum_{k=0}^{n} \\binom{n}{k} p^k (1-p)^{n-k} = \\sum_{k=0}^{n} \\text{PMF}(k)$. The `add_sub_cancel` lemma gives $p + (1-p) = 1$.",
     "significance": "key",
     "relatedConcepts": [
@@ -60,9 +69,12 @@
   {
     "id": "absorption",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 77, "endLine": 82 },
-    "type": "theorem",
-    "title": "absorption: (k+1)·C(n+1,k+1) = (n+1)·C(n,k)",
+    "range": {
+      "startLine": 77,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "absorption: (k+1)\u00b7C(n+1,k+1) = (n+1)\u00b7C(n,k)",
     "content": "`absorption`: The absorption identity $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. This is the key algebraic tool for computing the mean: it converts each weighted term $k \\cdot \\text{PMF}(k)$ into $(n+1)p$ times a degree-$(n-1)$ binomial term, reducing the moment calculation to normalization.",
     "mathContext": "The absorption identity is equivalent to $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ (shift indices by 1). It arises from the factorial representation: $k \\cdot \\frac{n!}{k!(n-k)!} = n \\cdot \\frac{(n-1)!}{(k-1)!(n-k)!}$. Proved from Mathlib's `Nat.add_one_mul_choose_eq` with `linarith`.",
     "significance": "key",
@@ -79,8 +91,11 @@
   {
     "id": "binomial-mean",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 83, "endLine": 127 },
-    "type": "theorem",
+    "range": {
+      "startLine": 83,
+      "endLine": 127
+    },
+    "type": "insight",
     "title": "binomial_mean: E[X] = np via Absorption + Normalization",
     "content": "`binomial_mean`: $E[X] = np$ for $n \\geq 1$. The proof strips the $k=0$ term (which vanishes), applies absorption to convert each $(k+1) \\cdot \\text{PMF}(k+1)$ into $(n+1)p \\cdot [\\text{degree-}(n-1) \\text{ binomial term}]$, factors out $np$, and uses normalization on the remaining sum.",
     "mathContext": "$E[X] = \\sum_{k=0}^{n} k \\cdot \\binom{n}{k} p^k (1-p)^{n-k} = np \\sum_{j=0}^{n-1} \\binom{n-1}{j} p^j (1-p)^{n-1-j} = np \\cdot 1 = np$. The index shift $j = k-1$ and absorption $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ are the two key steps.",
@@ -99,8 +114,11 @@
   {
     "id": "fair-coin",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 132, "endLine": 162 },
-    "type": "theorem",
+    "range": {
+      "startLine": 132,
+      "endLine": 162
+    },
+    "type": "insight",
     "title": "binomPMF_fair_coin: P(X=k) = C(n,k)/2^n for p = 1/2",
     "content": "`binomPMF_fair_coin`: When $p = 1/2$, $P(k) = \\binom{n}{k}/2^n$. The proof uses $(1/2)^k \\cdot (1/2)^{n-k} = (1/2)^n = 1/2^n$. This is the classical equi-probable model: each of the $2^n$ binary sequences has equal probability, and $\\binom{n}{k}$ of them have exactly $k$ ones.",
     "mathContext": "For the fair coin: $P(X=k) = \\binom{n}{k} (1/2)^k (1/2)^{n-k} = \\binom{n}{k} / 2^n$. The $2^n$ denominator appears because there are $2^n$ equally likely outcomes in $n$ tosses, and $\\binom{n}{k}$ of these have exactly $k$ heads.",
@@ -118,10 +136,13 @@
   {
     "id": "binomial-pgf",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 181, "endLine": 197 },
-    "type": "theorem",
-    "title": "binomial_pgf: E[t^X] = (pt + 1−p)^n via Binomial Theorem",
-    "content": "`binomial_pgf`: The probability generating function $E[t^X] = (pt + 1-p)^n$. Proved by replacing $p$ with $pt$ in the binomial expansion — each term $t^k \\cdot \\text{PMF}(k) = \\binom{n}{k} (pt)^k (1-p)^{n-k}$. The PGF encodes the entire distribution: setting $t=1$ gives normalization, differentiating at $t=1$ gives the mean.",
+    "range": {
+      "startLine": 181,
+      "endLine": 197
+    },
+    "type": "insight",
+    "title": "binomial_pgf: E[t^X] = (pt + 1\u2212p)^n via Binomial Theorem",
+    "content": "`binomial_pgf`: The probability generating function $E[t^X] = (pt + 1-p)^n$. Proved by replacing $p$ with $pt$ in the binomial expansion \u2014 each term $t^k \\cdot \\text{PMF}(k) = \\binom{n}{k} (pt)^k (1-p)^{n-k}$. The PGF encodes the entire distribution: setting $t=1$ gives normalization, differentiating at $t=1$ gives the mean.",
     "mathContext": "The PGF $G(t) = E[t^X] = \\sum_{k=0}^{n} t^k \\binom{n}{k} p^k (1-p)^{n-k} = (pt + (1-p))^n$ by the binomial theorem. $G(1) = 1$ (normalization), $G'(1) = np$ (mean), $G''(1) + G'(1) - (G'(1))^2 = np(1-p)$ (variance). The PGF completely characterizes any distribution on $\\mathbb{N}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -137,9 +158,12 @@
   {
     "id": "double-absorption",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 203, "endLine": 253 },
-    "type": "theorem",
-    "title": "double_absorption: (k+2)(k+1)·C(n+2,k+2) = (n+2)(n+1)·C(n,k)",
+    "range": {
+      "startLine": 203,
+      "endLine": 253
+    },
+    "type": "insight",
+    "title": "double_absorption: (k+2)(k+1)\u00b7C(n+2,k+2) = (n+2)(n+1)\u00b7C(n,k)",
     "content": "`double_absorption`: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$. Two applications of the absorption identity. This gives the second factorial moment $E[X(X-1)] = n(n-1)p^2$, from which the variance formula $\\text{Var}(X) = np(1-p)$ follows algebraically.",
     "mathContext": "Apply absorption twice: $(k+2)\\binom{n+2}{k+2} = (n+2)\\binom{n+1}{k+1}$, then $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. Multiplying: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$. Proved via `nlinarith` from two instances of the single absorption identity.",
     "significance": "key",
@@ -156,9 +180,12 @@
   {
     "id": "binomial-variance",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 255, "endLine": 268 },
-    "type": "theorem",
-    "title": "binomial_variance: Var(X) = np(1−p) via Falling Factorial Moments",
+    "range": {
+      "startLine": 255,
+      "endLine": 268
+    },
+    "type": "insight",
+    "title": "binomial_variance: Var(X) = np(1\u2212p) via Falling Factorial Moments",
     "content": "`binomial_variance`: $\\text{Var}(X) = np(1-p)$ for $n \\geq 2$. Uses the identity $\\text{Var}(X) = E[X^2] - (E[X])^2 = (E[X(X-1)] + E[X]) - (E[X])^2 = n(n-1)p^2 + np - n^2p^2 = np(1-p)$. The second factorial moment avoids the $E[X^2]$ computation directly.",
     "mathContext": "$\\text{Var}(X) = E[X(X-1)] + E[X] - (E[X])^2 = n(n-1)p^2 + np - (np)^2 = np - np^2 = np(1-p)$. The detour through $E[X(X-1)]$ instead of $E[X^2]$ is standard because the falling factorial $k(k-1)$ pairs naturally with the double absorption identity.",
     "significance": "key",
@@ -176,8 +203,11 @@
   {
     "id": "vandermonde-convolution",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 273, "endLine": 328 },
-    "type": "theorem",
+    "range": {
+      "startLine": 273,
+      "endLine": 328
+    },
+    "type": "insight",
     "title": "binomPMF_convolution: Reproductive Property via Vandermonde's Identity",
     "content": "`binomPMF_convolution`: The reproductive property $\\sum_j \\text{PMF}_n(j) \\cdot \\text{PMF}_m(k-j) = \\text{PMF}_{n+m}(k)$. The sum of independent $\\text{Bin}(n,p)$ and $\\text{Bin}(m,p)$ has distribution $\\text{Bin}(n+m,p)$. Proved by factoring out $p^k(1-p)^{n+m-k}$ and applying Vandermonde's identity.",
     "mathContext": "Vandermonde: $\\binom{n+m}{k} = \\sum_{j=0}^{k} \\binom{n}{j}\\binom{m}{k-j}$. Each convolution term: $\\binom{n}{j}p^j(1-p)^{n-j} \\cdot \\binom{m}{k-j}p^{k-j}(1-p)^{m-k+j} = \\binom{n}{j}\\binom{m}{k-j} \\cdot p^k(1-p)^{n+m-k}$. Summing over $j$ gives $\\binom{n+m}{k} p^k (1-p)^{n+m-k}$.",
@@ -197,9 +227,12 @@
   {
     "id": "compound-interest-limit",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 335, "endLine": 409 },
-    "type": "theorem",
-    "title": "tendsto_one_plus_div_pow_exp: (1 + x/n)^n → e^x (First Principles)",
+    "range": {
+      "startLine": 335,
+      "endLine": 409
+    },
+    "type": "insight",
+    "title": "tendsto_one_plus_div_pow_exp: (1 + x/n)^n \u2192 e^x (First Principles)",
     "content": "`tendsto_one_plus_div_pow_exp`: The classical limit $(1 + x/n)^n \\to e^x$, proved from first principles. Strategy: (A) `HasDerivAt(log(1+t), 1, 0)` gives $\\log(1+h)/h \\to 1$ as $h \\to 0$; (B) compose with $h = x/n \\to 0$ to get $n\\log(1+x/n) \\to x$; (C) continuity of `exp` gives $\\exp(n\\log(1+x/n)) = (1+x/n)^n \\to e^x$. This result was not in Mathlib v4.26.0.",
     "mathContext": "The limit $(1+x/n)^n \\to e^x$ is the foundation of compound interest ($x > 0$) and the Poisson limit ($x = -r < 0$). The proof uses the characterization $e^x = \\lim_{n\\to\\infty}(1+x/n)^n$, equivalent to $\\exp = $ the unique solution of $f' = f$, $f(0) = 1$. Key analytic inputs: `Real.hasDerivAt_log` and `Real.continuous_exp`.",
     "significance": "key",
@@ -219,9 +252,12 @@
   {
     "id": "poisson-pmf",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 411, "endLine": 428 },
+    "range": {
+      "startLine": 411,
+      "endLine": 428
+    },
     "type": "definition",
-    "title": "poissonPMF: P(X=k) = e^{−r} r^k / k! as Limiting Distribution",
+    "title": "poissonPMF: P(X=k) = e^{\u2212r} r^k / k! as Limiting Distribution",
     "content": "`poissonPMF`: The Poisson probability mass function $P(X=k) = e^{-r} r^k / k!$. This is the limiting distribution of $\\text{Bin}(n, r/n)$ as $n \\to \\infty$, modeling the count of rare events occurring at rate $r$.",
     "mathContext": "For $X \\sim \\text{Poi}(r)$: $P(X=k) = e^{-r} r^k / k!$ for $k = 0, 1, 2, \\ldots$. The Poisson family is reproductive ($\\text{Poi}(r_1) * \\text{Poi}(r_2) = \\text{Poi}(r_1+r_2)$) and is the unique distribution whose PGF is $e^{r(t-1)}$. The recurrence $P(k+1) = P(k) \\cdot r/(k+1)$ is used in the inductive proof of the Poisson limit.",
     "significance": "key",
@@ -239,9 +275,12 @@
   {
     "id": "poisson-limit",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 527, "endLine": 558 },
-    "type": "theorem",
-    "title": "poisson_limit: Bin(n, r/n)(k) → Poi(r)(k) as n → ∞",
+    "range": {
+      "startLine": 527,
+      "endLine": 558
+    },
+    "type": "insight",
+    "title": "poisson_limit: Bin(n, r/n)(k) \u2192 Poi(r)(k) as n \u2192 \u221e",
     "content": "`poisson_limit`: For each fixed $k$ and $r > 0$, $\\text{Bin}(n, r/n)(k) \\to \\text{Poi}(r)(k)$ as $n \\to \\infty$. Proved by induction on $k$: the base case $(1-r/n)^n \\to e^{-r}$ is the compound interest limit; the inductive step uses the PMF ratio $\\text{PMF}(k+1)/\\text{PMF}(k) = (n-k)(r/n)/((k+1)(1-r/n)) \\to r/(k+1)$, matching the Poisson recurrence.",
     "mathContext": "The Poisson limit theorem: if $n \\to \\infty$ and $np_n \\to r$, then $\\binom{n}{k}p_n^k(1-p_n)^{n-k} \\to e^{-r}r^k/k!$ for each fixed $k$. Here $p_n = r/n$. The inductive proof avoids Stirling's approximation by using the ratio $P(k+1)/P(k) = (n-k)p/((k+1)(1-p))$, which converges to $r/(k+1)$ by `poisson_ratio_tendsto`.",
     "significance": "key",
@@ -261,11 +300,14 @@
   {
     "id": "summary-theorem",
     "proofId": "binomial-theorem-oq-03",
-    "range": { "startLine": 564, "endLine": 580 },
-    "type": "theorem",
+    "range": {
+      "startLine": 564,
+      "endLine": 580
+    },
+    "type": "insight",
     "title": "binomial_oq03_extended_summary: All 7 Properties as a Single Conjunction",
     "content": "`binomial_oq03_extended_summary`: A single conjunction theorem packaging all seven main results: normalization ($\\sum \\text{PMF} = 1$), mean ($np$), variance ($np(1-p)$), PGF ($(pt+1-p)^n$), fair coin ($\\binom{n}{k}/2^n$), convolution (Vandermonde), and the Poisson limit. This serves as the machine-checkable answer to OQ-03.",
-    "mathContext": "The theorem statement is a 7-tuple conjunction, proved by applying each individual theorem. It demonstrates that every listed property of $\\text{Bin}(n,p)$ follows from the algebraic binomial theorem with 0 sorries and 0 axioms. The conjunction type in Lean is `And` (right-associative `∧`).",
+    "mathContext": "The theorem statement is a 7-tuple conjunction, proved by applying each individual theorem. It demonstrates that every listed property of $\\text{Bin}(n,p)$ follows from the algebraic binomial theorem with 0 sorries and 0 axioms. The conjunction type in Lean is `And` (right-associative `\u2227`).",
     "significance": "key",
     "relatedConcepts": [
       "conjunction",

--- a/src/data/proofs/inverse-galois-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-01/annotations.json
@@ -8,8 +8,8 @@
     },
     "type": "concept",
     "title": "Module Overview: The Non-Solvable Frontier",
-    "content": "The Inverse Galois Problem (IGP) asks: does every finite group appear as $\\text{Gal}(K/\\mathbb{Q})$ for some Galois extension $K$? This file explores the *non-solvable frontier* — the boundary at $n = 5$ where symmetric groups transition from solvable to non-solvable.\n\nThe file proves 31 theorems in 11 parts, culminating in the complete characterization `sn_solvable_iff`: $S_n$ is solvable if and only if $n \\leq 4$. For solvable groups, Shafarevich's theorem (1954, axiomatized in `InverseGalois.lean`) guarantees realizability. For non-solvable groups, explicit polynomial constructions are required — and the file documents a census of 18+ groups realized across the Lean-Genius formalization.",
-    "mathContext": "The IGP has deep connections across algebra: Hilbert's irreducibility theorem (1892) proves all $S_n$ and $A_n$ are realizable; Shafarevich (1954) covers all solvable groups; Thompson (1984) proved the Monster group realizable. The full conjecture remains open — all but possibly one sporadic simple group ($M_{23}$) are known to be Galois groups over $\\mathbb{Q}$.",
+    "content": "The Inverse Galois Problem (IGP) asks: does every finite group appear as $\\text{Gal}(K/\\mathbb{Q})$ for some Galois extension $K$? This file explores the *non-solvable frontier* \u2014 the boundary at $n = 5$ where symmetric groups transition from solvable to non-solvable.\n\nThe file proves 31 theorems in 11 parts, culminating in the complete characterization `sn_solvable_iff`: $S_n$ is solvable if and only if $n \\leq 4$. For solvable groups, Shafarevich's theorem (1954, axiomatized in `InverseGalois.lean`) guarantees realizability. For non-solvable groups, explicit polynomial constructions are required \u2014 and the file documents a census of 18+ groups realized across the Lean-Genius formalization.",
+    "mathContext": "The IGP has deep connections across algebra: Hilbert's irreducibility theorem (1892) proves all $S_n$ and $A_n$ are realizable; Shafarevich (1954) covers all solvable groups; Thompson (1984) proved the Monster group realizable. The full conjecture remains open \u2014 all but possibly one sporadic simple group ($M_{23}$) are known to be Galois groups over $\\mathbb{Q}$.",
     "significance": "key",
     "relatedConcepts": [
       "Inverse Galois Problem",
@@ -30,8 +30,8 @@
       "startLine": 60,
       "endLine": 71
     },
-    "type": "theorem",
-    "title": "S₁ through S₄ Are Solvable",
+    "type": "insight",
+    "title": "S\u2081 through S\u2084 Are Solvable",
     "content": "Four `example` declarations confirm that $S_1, S_2, S_3, S_4$ are solvable, all proved by `inferInstance`. The instances come from `AbelRuffiniGaloisExtensions.lean`, which constructs explicit composition series: $S_2 \\cong C_2$ (abelian), $S_3$ via $1 \\to A_3 \\to S_3 \\to C_2 \\to 1$, $S_4$ via the Klein four-group chain.\n\nThese are the 'easy' cases for the Inverse Galois Problem: Shafarevich's theorem covers all of them (and all solvable groups) automatically.",
     "mathContext": "Composition series: $S_2: \\{e\\} \\triangleleft S_2$ (abelian). $S_3: \\{e\\} \\triangleleft A_3 \\triangleleft S_3$ ($A_3 \\cong \\mathbb{Z}/3$). $S_4: \\{e\\} \\triangleleft V_4 \\triangleleft A_4 \\triangleleft S_4$ ($V_4 = \\{e,(12)(34),(13)(24),(14)(23)\\}$, all quotients abelian).",
     "significance": "supporting",
@@ -53,8 +53,8 @@
       "startLine": 73,
       "endLine": 77
     },
-    "type": "theorem",
-    "title": "S₅ Is Not Solvable: The Fundamental Obstruction",
+    "type": "insight",
+    "title": "S\u2085 Is Not Solvable: The Fundamental Obstruction",
     "content": "`s5_not_solvable` proves $\\neg\\text{IsSolvable}(S_5)$ using Mathlib's `Equiv.Perm.not_solvable`. The proof bridges from $\\mathbb{N}$ to Cardinal: the hypothesis $5 \\leq 5$ (trivially true) is cast to $5 \\leq |\\text{Fin}\\,5|$ via `simp` and `norm_cast`, then passed to `Equiv.Perm.not_solvable`.\n\nThis is the group-theoretic heart of both Abel-Ruffini (quintics have no radical formula) and the IGP frontier (non-solvable groups need explicit constructions).",
     "mathContext": "The derived series of $S_5$: $D^0 = S_5$, $D^1 = [S_5, S_5] = A_5$, $D^k = A_5$ for all $k \\geq 1$ (because $A_5$ is perfect: $[A_5, A_5] = A_5$). The series never reaches $\\{e\\}$, so $S_5$ is not solvable.",
     "significance": "key",
@@ -76,8 +76,8 @@
       "startLine": 91,
       "endLine": 96
     },
-    "type": "theorem",
-    "title": "General Non-Solvability for n ≥ 5",
+    "type": "insight",
+    "title": "General Non-Solvability for n \u2265 5",
     "content": "`sn_not_solvable_of_ge_five` generalizes to all $n \\geq 5$: given $5 \\leq n$ in $\\mathbb{N}$, cast to Cardinal and apply `Equiv.Perm.not_solvable`. The same 3-line proof pattern as the specific cases ($S_5, S_6, S_7$).",
     "mathContext": "For $n \\geq 5$: $A_n$ is simple (and non-abelian), so $A_n$ is perfect, so $D^k(S_n) = A_n$ for all $k \\geq 1$. The derived series stalls, making $S_n$ non-solvable. The proof only needs the cardinal inequality $5 \\leq |\\text{Fin}\\,n|$.",
     "significance": "key",
@@ -99,7 +99,7 @@
       "endLine": 120
     },
     "type": "concept",
-    "title": "Computing |Sₙ| = n! via Fintype.card_perm",
+    "title": "Computing |S\u2099| = n! via Fintype.card_perm",
     "content": "Five theorems compute $|S_1| = 1$, $|S_2| = 2$, $|S_3| = 6$, $|S_4| = 24$, $|S_5| = 120$, each by the same pattern: `rw [Fintype.card_perm, Fintype.card_fin]; norm_num`. Mathlib's `Fintype.card_perm` gives $|S_n| = (\\text{Fintype.card}(\\alpha))!$ and `Fintype.card_fin` evaluates $|\\text{Fin}\\,n| = n$, reducing to a numerical computation handled by `norm_num`.\n\nThese concrete values are needed for Part IV ($|S_5|/|A_5| = 2$) and the census in Part VIII.",
     "mathContext": "$|S_n| = n!$ counts the number of bijections $\\{1,\\ldots,n\\} \\to \\{1,\\ldots,n\\}$. The factorial grows rapidly: $|S_5| = 120$, $|S_6| = 720$, etc. For the Inverse Galois Problem, these cardinalities determine the degrees of the corresponding splitting fields.",
     "significance": "supporting",
@@ -121,9 +121,9 @@
       "startLine": 122,
       "endLine": 124
     },
-    "type": "theorem",
-    "title": "|A₅| = 60 via native_decide",
-    "content": "`a5_card` proves $|A_5| = 60$ using `native_decide` — a computed verification that evaluates the cardinality by enumerating all 60 even permutations of 5 elements. This contrasts with the algebraic proof ($|A_n| = n!/2$) and the `norm_num`-based proofs for $|S_n|$.",
+    "type": "insight",
+    "title": "|A\u2085| = 60 via native_decide",
+    "content": "`a5_card` proves $|A_5| = 60$ using `native_decide` \u2014 a computed verification that evaluates the cardinality by enumerating all 60 even permutations of 5 elements. This contrasts with the algebraic proof ($|A_n| = n!/2$) and the `norm_num`-based proofs for $|S_n|$.",
     "mathContext": "$|A_5| = 5!/2 = 120/2 = 60$. The 60 elements decompose into conjugacy classes of sizes 1 (identity), 15 (products of two disjoint transpositions), 20 (3-cycles), and 12 + 12 (two classes of 5-cycles). This class structure is why $A_5$ is simple: no union of classes including $\\{e\\}$ has size dividing 60.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -143,9 +143,9 @@
       "startLine": 136,
       "endLine": 138
     },
-    "type": "theorem",
-    "title": "A₅ Is Simple: The Core Fact",
-    "content": "`a5_simple` delegates to Mathlib's `alternatingGroup.isSimpleGroup_five`. $A_5$ is simple: its only normal subgroups are $\\{e\\}$ and $A_5$ itself. This is the ultimate reason $S_n$ is not solvable for $n \\geq 5$ — the derived series reaches $A_n$ and cannot descend further.",
+    "type": "insight",
+    "title": "A\u2085 Is Simple: The Core Fact",
+    "content": "`a5_simple` delegates to Mathlib's `alternatingGroup.isSimpleGroup_five`. $A_5$ is simple: its only normal subgroups are $\\{e\\}$ and $A_5$ itself. This is the ultimate reason $S_n$ is not solvable for $n \\geq 5$ \u2014 the derived series reaches $A_n$ and cannot descend further.",
     "mathContext": "$A_5$ is the smallest non-abelian simple group ($|A_5| = 60$). Proof of simplicity: a normal subgroup $N \\trianglelefteq A_5$ must be a union of conjugacy classes containing $\\{e\\}$, and $|N|$ must divide 60. The class sizes are 1, 15, 20, 12, 12. No sub-sum including 1 (other than 1 and 60) divides 60. Therefore $N = \\{e\\}$ or $N = A_5$.",
     "significance": "key",
     "relatedConcepts": [
@@ -166,8 +166,8 @@
       "startLine": 142,
       "endLine": 151
     },
-    "type": "theorem",
-    "title": "A₅ Is Not Solvable",
+    "type": "insight",
+    "title": "A\u2085 Is Not Solvable",
     "content": "`a5_not_solvable` proves $\\neg\\text{IsSolvable}(A_5)$ by contradiction: if $A_5$ were solvable, then $S_5$ would be solvable (via the short exact sequence $1 \\to A_5 \\to S_5 \\to C_2 \\to 1$ using `solvable_of_ker_le_range`). But $S_5$ is not solvable (by `s5_not_solvable`). Contradiction.\n\nThe proof constructs the exact sequence explicitly: the alternating group injection `(alternatingGroup (Fin 5)).subtype` and the sign map `Equiv.Perm.sign` form a kernel-range pair.",
     "mathContext": "The short exact sequence $1 \\to A_5 \\xrightarrow{\\iota} S_5 \\xrightarrow{\\text{sign}} C_2 \\to 1$ means $S_5$ is an extension of $A_5$ by $C_2$. A group extension with both kernel ($A_5$) and quotient ($C_2$) solvable is solvable. Contrapositive: if the extension ($S_5$) is not solvable, then the kernel ($A_5$) is not solvable.",
     "significance": "key",
@@ -190,10 +190,10 @@
       "startLine": 153,
       "endLine": 158
     },
-    "type": "theorem",
-    "title": "A₅ Is Not Abelian",
-    "content": "`a5_not_commutative` proves $\\neg(\\forall a, b \\in A_5, ab = ba)$ by contradiction: if $A_5$ were abelian, then `isSolvable_of_comm` would give `IsSolvable(A_5)`, contradicting `a5_not_solvable`. This is a stepping stone to the perfectness proof — it rules out the trivial case $[A_5, A_5] = \\{e\\}$ in the simplicity dichotomy.\n\nThe implication chain: abelian $\\Rightarrow$ solvable $\\Rightarrow$ contradiction. This is why every non-abelian simple group is automatically non-solvable.",
-    "mathContext": "For any group: abelian $\\Rightarrow$ solvable (the derived series is $G \\supset [G,G] = \\{e\\}$ in one step). Contrapositive: non-solvable $\\Rightarrow$ non-abelian. $A_5$ has non-commuting elements — for example, the 3-cycle $(1\\,2\\,3)$ and the 3-cycle $(1\\,2\\,4)$ do not commute: $(1\\,2\\,3)(1\\,2\\,4) = (1\\,3)(2\\,4) \\neq (1\\,4)(2\\,3) = (1\\,2\\,4)(1\\,2\\,3)$.",
+    "type": "insight",
+    "title": "A\u2085 Is Not Abelian",
+    "content": "`a5_not_commutative` proves $\\neg(\\forall a, b \\in A_5, ab = ba)$ by contradiction: if $A_5$ were abelian, then `isSolvable_of_comm` would give `IsSolvable(A_5)`, contradicting `a5_not_solvable`. This is a stepping stone to the perfectness proof \u2014 it rules out the trivial case $[A_5, A_5] = \\{e\\}$ in the simplicity dichotomy.\n\nThe implication chain: abelian $\\Rightarrow$ solvable $\\Rightarrow$ contradiction. This is why every non-abelian simple group is automatically non-solvable.",
+    "mathContext": "For any group: abelian $\\Rightarrow$ solvable (the derived series is $G \\supset [G,G] = \\{e\\}$ in one step). Contrapositive: non-solvable $\\Rightarrow$ non-abelian. $A_5$ has non-commuting elements \u2014 for example, the 3-cycle $(1\\,2\\,3)$ and the 3-cycle $(1\\,2\\,4)$ do not commute: $(1\\,2\\,3)(1\\,2\\,4) = (1\\,3)(2\\,4) \\neq (1\\,4)(2\\,3) = (1\\,2\\,4)(1\\,2\\,3)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "abelian group",
@@ -212,9 +212,9 @@
       "startLine": 164,
       "endLine": 186
     },
-    "type": "theorem",
-    "title": "A₅ Is Perfect: [A₅, A₅] = A₅",
-    "content": "`a5_commutator_eq_top` is the deepest original proof in the file (25 lines). Strategy: the commutator subgroup $[A_5, A_5]$ is normal in $A_5$. Since $A_5$ is simple, $[A_5, A_5] = \\{e\\}$ or $[A_5, A_5] = A_5$. If $[A_5, A_5] = \\{e\\}$, then all commutators $aba^{-1}b^{-1} = 1$, so $ab = ba$ for all $a, b$ — but this means $A_5$ is abelian, and abelian groups are solvable, contradicting `a5_not_solvable`. Therefore $[A_5, A_5] = A_5$ (perfect).\n\nThe proof handles the abelian case by explicitly manipulating commutators: from $aba^{-1}b^{-1} = 1$ derive $aba^{-1} = b$, then $ab = ba$ via `group` and `calc`.",
+    "type": "insight",
+    "title": "A\u2085 Is Perfect: [A\u2085, A\u2085] = A\u2085",
+    "content": "`a5_commutator_eq_top` is the deepest original proof in the file (25 lines). Strategy: the commutator subgroup $[A_5, A_5]$ is normal in $A_5$. Since $A_5$ is simple, $[A_5, A_5] = \\{e\\}$ or $[A_5, A_5] = A_5$. If $[A_5, A_5] = \\{e\\}$, then all commutators $aba^{-1}b^{-1} = 1$, so $ab = ba$ for all $a, b$ \u2014 but this means $A_5$ is abelian, and abelian groups are solvable, contradicting `a5_not_solvable`. Therefore $[A_5, A_5] = A_5$ (perfect).\n\nThe proof handles the abelian case by explicitly manipulating commutators: from $aba^{-1}b^{-1} = 1$ derive $aba^{-1} = b$, then $ab = ba$ via `group` and `calc`.",
     "mathContext": "A group $G$ is *perfect* if $G = [G, G]$ (equals its own commutator subgroup). Equivalently, the abelianization $G/[G,G]$ is trivial. For $A_5$: simplicity gives $[A_5, A_5] \\in \\{\\{e\\}, A_5\\}$; non-commutativity rules out $\\{e\\}$. The perfectness of $A_5$ is what makes the derived series of $S_5$ stall: $D^1(S_5) = A_5$ and $D^{k+1}(S_5) = [D^k(S_5), D^k(S_5)] = [A_5, A_5] = A_5$ for all $k \\geq 1$.",
     "significance": "key",
     "relatedConcepts": [
@@ -239,7 +239,7 @@
     },
     "type": "concept",
     "title": "Part IV: Alternating Group as Index-2 Normal Subgroup",
-    "content": "Three results establish the structural relationship between $A_n$ and $S_n$: (1) `alternating_normal` — $A_n \\trianglelefteq S_n$ via `inferInstance` (since $A_n = \\ker(\\text{sign})$, a kernel is always normal); (2) `alternating_card_five'` restates $|A_5| = 60$; (3) `s5_div_a5` computes $|S_5|/|A_5| = 120/60 = 2$, confirming the index $[S_5:A_5] = 2$.\n\nThe index-2 condition means $A_n$ is the unique subgroup of index 2 in $S_n$, and the quotient $S_n/A_n \\cong C_2$ is the sign representation.",
+    "content": "Three results establish the structural relationship between $A_n$ and $S_n$: (1) `alternating_normal` \u2014 $A_n \\trianglelefteq S_n$ via `inferInstance` (since $A_n = \\ker(\\text{sign})$, a kernel is always normal); (2) `alternating_card_five'` restates $|A_5| = 60$; (3) `s5_div_a5` computes $|S_5|/|A_5| = 120/60 = 2$, confirming the index $[S_5:A_5] = 2$.\n\nThe index-2 condition means $A_n$ is the unique subgroup of index 2 in $S_n$, and the quotient $S_n/A_n \\cong C_2$ is the sign representation.",
     "mathContext": "For any group $G$ and normal subgroup $N \\trianglelefteq G$ with $[G:N] = 2$: $N$ is automatically normal (since left and right cosets coincide when there are only two). The short exact sequence $1 \\to A_n \\to S_n \\to C_2 \\to 1$ splits for $n \\neq 2, 6$ (the splitting gives $S_n \\cong A_n \\rtimes C_2$, though the semidirect product structure is not needed here).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -263,7 +263,7 @@
     },
     "type": "concept",
     "title": "Part V: The Solvable vs Non-Solvable Landscape",
-    "content": "Commentary and one theorem partitioning all finite groups into the solvable realm (covered by Shafarevich: cyclic, abelian, dihedral, $p$-groups, $S_1$–$S_4$, all groups of order $< 60$) and the non-solvable realm (requiring explicit constructions). `trivial_realizable` proves the trivial group is realized by the trivial extension $\\mathbb{Q}/\\mathbb{Q}$, using $|\\text{Gal}(\\mathbb{Q}/\\mathbb{Q})| = 1$ from `IsGalois.card_aut_eq_finrank` and $[\\mathbb{Q}:\\mathbb{Q}] = 1$.\n\nThe commentary catalogs which non-solvable groups have been realized: $A_5$ (order 60) and $S_5$ (order 120), with $\\text{PSL}(2,7)$ (168), $A_6$ (360), and sporadic groups as future targets.",
+    "content": "Commentary and one theorem partitioning all finite groups into the solvable realm (covered by Shafarevich: cyclic, abelian, dihedral, $p$-groups, $S_1$\u2013$S_4$, all groups of order $< 60$) and the non-solvable realm (requiring explicit constructions). `trivial_realizable` proves the trivial group is realized by the trivial extension $\\mathbb{Q}/\\mathbb{Q}$, using $|\\text{Gal}(\\mathbb{Q}/\\mathbb{Q})| = 1$ from `IsGalois.card_aut_eq_finrank` and $[\\mathbb{Q}:\\mathbb{Q}] = 1$.\n\nThe commentary catalogs which non-solvable groups have been realized: $A_5$ (order 60) and $S_5$ (order 120), with $\\text{PSL}(2,7)$ (168), $A_6$ (360), and sporadic groups as future targets.",
     "mathContext": "Shafarevich's theorem (1954): every solvable group is $\\text{Gal}(K/\\mathbb{Q})$ for some $K$. All groups of order $< 60$ are solvable (Burnside's $p^aq^b$ theorem + Feit-Thompson odd-order theorem). The smallest non-solvable group is $A_5$ with $|A_5| = 60 = 2^2 \\cdot 3 \\cdot 5$, which has three distinct prime factors as required.",
     "significance": "key",
     "relatedConcepts": [
@@ -285,7 +285,7 @@
       "startLine": 261,
       "endLine": 267
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Fixed Field Existence",
     "content": "`fixed_field_exists` proves that for any subgroup $H \\leq \\text{Gal}(K/F)$, the fixed field $K^H = \\{x \\in K \\mid \\forall \\sigma \\in H, \\sigma(x) = x\\}$ exists as an intermediate field. The proof is a direct application of Mathlib's `IntermediateField.fixedField`.\n\nThis is the foundational step for the Galois correspondence: every subgroup determines a fixed field, and the degree formulas in subsequent theorems quantify this relationship.",
     "mathContext": "$K^H = \\{x \\in K : \\sigma(x) = x \\text{ for all } \\sigma \\in H\\}$. The Galois correspondence: $H \\mapsto K^H$ gives an inclusion-reversing bijection between subgroups of $\\text{Gal}(K/F)$ and intermediate fields $F \\subseteq E \\subseteq K$, with inverse $E \\mapsto \\text{Gal}(K/E)$.",
@@ -309,7 +309,7 @@
       "startLine": 271,
       "endLine": 278
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Fixed Field Degree Formula: [K : K^H] = |H|",
     "content": "`finrank_over_fixed_field` proves that the degree of a Galois extension $K$ over the fixed field $K^H$ equals the order of the subgroup $H \\leq \\text{Gal}(K/F)$. This is a direct consequence of Mathlib's `IntermediateField.finrank_fixedField_eq_card` with a `Nat.card` to `Fintype.card` conversion.\n\nThis is the quantitative content of the Galois correspondence: subgroup size determines field extension degree.",
     "mathContext": "The fundamental theorem of Galois theory: $H \\leq \\text{Gal}(K/F) \\longleftrightarrow K^H$ (intermediate field), with $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$. The tower law gives $[K:F] = [K:K^H] \\cdot [K^H:F] = |H| \\cdot [G:H] = |G|$, consistent with $[K:F] = |\\text{Gal}(K/F)|$ for Galois extensions.",
@@ -333,7 +333,7 @@
       "startLine": 282,
       "endLine": 300
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Fixed Field Degree over Base: [K^H : F] = [G : H]",
     "content": "`finrank_fixed_field_over_base` proves $[K^H:F] = [G:H]$ (the index of $H$ in $G$). The proof is the most technical in the file: it combines the tower law $[K:F] = [K:K^H] \\cdot [K^H:F]$ with $[K:K^H] = |H|$ (previous theorem) and Lagrange's theorem $|G| = |H| \\cdot [G:H]$, then uses `nlinarith` to solve the resulting integer equation.\n\nTogether with `finrank_over_fixed_field`, these two theorems give the complete quantitative Galois correspondence.",
     "mathContext": "From the tower law: $[K^H:F] = [K:F] / [K:K^H] = |G| / |H| = [G:H]$. The proof handles the division in $\\mathbb{N}$ (where division truncates) by working with the multiplicative identity $|H| \\cdot [G:H] = |G| = [K:K^H] \\cdot [K^H:F] = |H| \\cdot [K^H:F]$ and cancelling $|H| > 0$.",
@@ -357,7 +357,7 @@
       "startLine": 310,
       "endLine": 320
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Sign Homomorphism: Kernel and Surjectivity",
     "content": "`sign_surjective` ($\\text{sign}$ is surjective for $n \\geq 2$) and `sign_ker_eq_alternating` ($\\ker(\\text{sign}) = A_n$) establish the short exact sequence $1 \\to A_n \\to S_n \\xrightarrow{\\text{sign}} C_2 \\to 1$. Surjectivity uses `Equiv.Perm.sign_surjective` from Mathlib; the kernel characterization follows from the definition of `alternatingGroup` as the kernel of sign.",
     "mathContext": "The sign homomorphism $\\text{sign}: S_n \\to \\{\\pm 1\\} \\cong C_2$ classifies permutations as even ($+1$) or odd ($-1$). Its kernel $A_n$ is the alternating group. The surjectivity for $n \\geq 2$ relies on the existence of transpositions, which have sign $-1$. This exact sequence is used in `a5_not_solvable` to transfer non-solvability from $S_5$ to $A_5$.",
@@ -381,9 +381,9 @@
       "startLine": 365,
       "endLine": 378
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Part VIII: Census of 18+ Realized Galois Groups",
-    "content": "An extensive commentary and one theorem documenting all groups explicitly realized as Galois groups over $\\mathbb{Q}$ across the Lean-Genius formalization. The census includes: cyclic groups $C_1$ through $C_{12}$ (via cyclotomic extensions $\\mathbb{Q}(\\zeta_p)$), $V_4 \\cong C_2^2$ (8th cyclotomic), $C_4 \\times C_2$ (15th cyclotomic), $C_2^3$ (compositum), $S_3$ ($X^3-2$), $D_4$ ($X^4-2$), $F_{20}$ ($X^5-2$), $A_5$ ($x^5+20x-16$), and $S_5$ ($x^5-4x+2$).\n\n`nonsolvable_realized_orders` states that Galois extensions of orders 60 ($A_5$) and 120 ($S_5$) exist. The 2 `sorry`s are structural — they require importing `InverseGaloisA5` and `AbelRuffiniOQ04OQ01` without creating import cycles.",
+    "content": "An extensive commentary and one theorem documenting all groups explicitly realized as Galois groups over $\\mathbb{Q}$ across the Lean-Genius formalization. The census includes: cyclic groups $C_1$ through $C_{12}$ (via cyclotomic extensions $\\mathbb{Q}(\\zeta_p)$), $V_4 \\cong C_2^2$ (8th cyclotomic), $C_4 \\times C_2$ (15th cyclotomic), $C_2^3$ (compositum), $S_3$ ($X^3-2$), $D_4$ ($X^4-2$), $F_{20}$ ($X^5-2$), $A_5$ ($x^5+20x-16$), and $S_5$ ($x^5-4x+2$).\n\n`nonsolvable_realized_orders` states that Galois extensions of orders 60 ($A_5$) and 120 ($S_5$) exist. The 2 `sorry`s are structural \u2014 they require importing `InverseGaloisA5` and `AbelRuffiniOQ04OQ01` without creating import cycles.",
     "mathContext": "The census shows the formalized frontier: all solvable groups are covered abstractly (Shafarevich axiom), while the non-solvable frontier extends to $A_5$ (via $x^5+20x-16$, Sylow analysis) and $S_5$ (via $x^5-4x+2$, Eisenstein + discriminant). The next non-solvable targets in order of complexity: $\\text{PSL}(2,7) \\cong GL(3,\\mathbb{F}_2)$ (order 168, realized by $x^7-7x+3$), $A_6$ (order 360), and $\\text{PSL}(2,11)$ (order 660).",
     "significance": "key",
     "relatedConcepts": [
@@ -405,9 +405,9 @@
       "startLine": 408,
       "endLine": 419
     },
-    "type": "theorem",
-    "title": "The Complete Characterization: Sₙ Solvable iff n ≤ 4",
-    "content": "`sn_solvable_iff` is the synthesis theorem: $S_n$ is solvable if and only if $n \\leq 4$. The forward direction ($\\Rightarrow$) uses `sn_not_solvable_of_ge_five`: if $n > 4$ then $5 \\leq n$ and $S_n$ is not solvable — contradicting the hypothesis. The backward direction ($\\Leftarrow$) uses `interval_cases n` to split into 5 cases ($n = 0, 1, 2, 3, 4$), each solved by `infer_instance`.\n\nThis is the complete answer to the question 'which symmetric groups are solvable?' — the structural divide that drives both Abel-Ruffini and the Inverse Galois Problem.",
+    "type": "insight",
+    "title": "The Complete Characterization: S\u2099 Solvable iff n \u2264 4",
+    "content": "`sn_solvable_iff` is the synthesis theorem: $S_n$ is solvable if and only if $n \\leq 4$. The forward direction ($\\Rightarrow$) uses `sn_not_solvable_of_ge_five`: if $n > 4$ then $5 \\leq n$ and $S_n$ is not solvable \u2014 contradicting the hypothesis. The backward direction ($\\Leftarrow$) uses `interval_cases n` to split into 5 cases ($n = 0, 1, 2, 3, 4$), each solved by `infer_instance`.\n\nThis is the complete answer to the question 'which symmetric groups are solvable?' \u2014 the structural divide that drives both Abel-Ruffini and the Inverse Galois Problem.",
     "mathContext": "$S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$. Equivalently: the derived series of $S_n$ reaches $\\{e\\}$ iff $n \\leq 4$. For $n \\geq 5$, the derived series stalls at $A_n$ (perfect for $n \\geq 5$). This characterization implies: a polynomial of degree $n$ with generic Galois group $S_n$ is solvable by radicals iff $n \\leq 4$ (Abel-Ruffini).",
     "significance": "key",
     "relatedConcepts": [
@@ -428,10 +428,10 @@
       "startLine": 397,
       "endLine": 402
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Inverse Galois Conjecture (Open Problem)",
-    "content": "`inverse_galois_conjecture` states: for every finite group $G$, there exists a Galois extension $K/\\mathbb{Q}$ with $\\text{Gal}(K/\\mathbb{Q}) \\cong G$. The `sorry` is intentional — this is one of the most important open problems in algebra.\n\nKnown cases: all solvable groups (Shafarevich 1954), all symmetric and alternating groups (Hilbert 1892), 25 of 26 sporadic simple groups (various authors, 1970s–2000s), all groups of Lie type over $\\mathbb{F}_p$ for sufficiently large $p$ (various). The only sporadic group with unknown status over $\\mathbb{Q}$ is $M_{23}$.",
-    "mathContext": "$\\forall G \\text{ finite}, \\exists K/\\mathbb{Q} \\text{ Galois}: \\text{Gal}(K/\\mathbb{Q}) \\cong G$. This is equivalent to asking: every finite group is a quotient of $\\text{Gal}(\\overline{\\mathbb{Q}}/\\mathbb{Q})$, the absolute Galois group of $\\mathbb{Q}$ — one of the most mysterious objects in mathematics.",
+    "content": "`inverse_galois_conjecture` states: for every finite group $G$, there exists a Galois extension $K/\\mathbb{Q}$ with $\\text{Gal}(K/\\mathbb{Q}) \\cong G$. The `sorry` is intentional \u2014 this is one of the most important open problems in algebra.\n\nKnown cases: all solvable groups (Shafarevich 1954), all symmetric and alternating groups (Hilbert 1892), 25 of 26 sporadic simple groups (various authors, 1970s\u20132000s), all groups of Lie type over $\\mathbb{F}_p$ for sufficiently large $p$ (various). The only sporadic group with unknown status over $\\mathbb{Q}$ is $M_{23}$.",
+    "mathContext": "$\\forall G \\text{ finite}, \\exists K/\\mathbb{Q} \\text{ Galois}: \\text{Gal}(K/\\mathbb{Q}) \\cong G$. This is equivalent to asking: every finite group is a quotient of $\\text{Gal}(\\overline{\\mathbb{Q}}/\\mathbb{Q})$, the absolute Galois group of $\\mathbb{Q}$ \u2014 one of the most mysterious objects in mathematics.",
     "significance": "key",
     "relatedConcepts": [
       "Inverse Galois Problem",
@@ -452,7 +452,7 @@
       "startLine": 428,
       "endLine": 433
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Cayley's Theorem: G Embeds into S_{|G|}",
     "content": "`cayley_card` proves Cayley's theorem: every finite group $G$ admits an injective homomorphism into $S_{|G|}$ (the symmetric group on $|G|$ elements). The proof uses the left-regular representation: $g \\mapsto (x \\mapsto gx)$. Lean's `MulAction.toPermHom G G` gives the homomorphism; injectivity follows because if $gx = hx$ for all $x$, then setting $x = 1$ gives $g = h$.\n\nThis connects the Inverse Galois Problem to symmetric groups: realizing all $S_n$ is necessary for IGP (since every $G$ embeds into some $S_n$).",
     "mathContext": "Cayley's theorem: $\\phi: G \\hookrightarrow S_G$ via $\\phi(g)(x) = gx$. This is injective: $\\phi(g) = \\phi(h) \\Rightarrow gx = hx$ for all $x \\Rightarrow g = h$ (set $x = e$). For IGP: $G \\hookrightarrow S_n$ means $G$ is a subgroup of $S_n$, but being a Galois group requires $G$ as a *quotient* of $\\text{Gal}(K/\\mathbb{Q})$, which is a stronger condition.",

--- a/src/data/proofs/mean-value-theorem-oq-03/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-03/annotations.json
@@ -2,10 +2,13 @@
   {
     "id": "ann-namespace-setup",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 47, "endLine": 74 },
+    "range": {
+      "startLine": 47,
+      "endLine": 74
+    },
     "type": "concept",
     "title": "Normed Space Framework: All Results Parameterized over Arbitrary E",
-    "content": "The entire development is parameterized over an arbitrary normed space $E$ over $\\mathbb{R}$ via type class constraints `[NormedAddCommGroup E] [NormedSpace ℝ E]`. This means all results apply simultaneously to $\\mathbb{R}^n$, sequence spaces $\\ell^p$, and function spaces $L^p$ — any complete normed space is a Banach space where these theorems hold.\n\nThe namespace setup also declares a second normed space `F` for Banach-to-Banach maps in the later sections. Variables are declared once and automatically inferred throughout.",
+    "content": "The entire development is parameterized over an arbitrary normed space $E$ over $\\mathbb{R}$ via type class constraints `[NormedAddCommGroup E] [NormedSpace \u211d E]`. This means all results apply simultaneously to $\\mathbb{R}^n$, sequence spaces $\\ell^p$, and function spaces $L^p$ \u2014 any complete normed space is a Banach space where these theorems hold.\n\nThe namespace setup also declares a second normed space `F` for Banach-to-Banach maps in the later sections. Variables are declared once and automatically inferred throughout.",
     "mathContext": "A normed space $E$ over $\\mathbb{R}$ satisfies $\\|\\alpha x\\| = |\\alpha| \\|x\\|$ and the triangle inequality $\\|x + y\\| \\leq \\|x\\| + \\|y\\|$. The type class inference system automatically provides these properties for any concrete normed space. Lean's universe polymorphism ensures `E` can be finite or infinite-dimensional.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -23,10 +26,13 @@
   {
     "id": "ann-core-inequality",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 76, "endLine": 97 },
-    "type": "theorem",
-    "title": "Mean Value Inequality: ‖f(x) − f(a)‖ ≤ C(x−a) for Bounded Derivative",
-    "content": "For $f : \\mathbb{R} \\to E$ with $\\|f'(x)\\| \\leq C$ on $[a,b]$, we have $\\|f(x) - f(a)\\| \\leq C(x-a)$ for all $x \\in [a,b]$. This is the central result — all other theorems either specialize it, provide counterexamples to strengthening it, or derive consequences. The one-line proof delegates to Mathlib's `norm_image_sub_le_of_norm_deriv_le_segment'`.",
+    "range": {
+      "startLine": 76,
+      "endLine": 97
+    },
+    "type": "insight",
+    "title": "Mean Value Inequality: \u2016f(x) \u2212 f(a)\u2016 \u2264 C(x\u2212a) for Bounded Derivative",
+    "content": "For $f : \\mathbb{R} \\to E$ with $\\|f'(x)\\| \\leq C$ on $[a,b]$, we have $\\|f(x) - f(a)\\| \\leq C(x-a)$ for all $x \\in [a,b]$. This is the central result \u2014 all other theorems either specialize it, provide counterexamples to strengthening it, or derive consequences. The one-line proof delegates to Mathlib's `norm_image_sub_le_of_norm_deriv_le_segment'`.",
     "mathContext": "The proof uses a partition argument: divide $[a,x]$ into subintervals, apply the triangle inequality $\\|f(x) - f(a)\\| \\leq \\sum \\|f(t_{i+1}) - f(t_i)\\|$, use differentiability to bound each term by $C(t_{i+1} - t_i)$, and sum to get $C(x-a)$. This avoids the intermediate value theorem entirely, which is why it works for vectors.",
     "significance": "key",
     "relatedConcepts": [
@@ -44,9 +50,12 @@
   {
     "id": "ann-scalar-inequality",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 99, "endLine": 106 },
-    "type": "theorem",
-    "title": "Scalar Specialization: |f(x) − f(a)| ≤ C(x−a) for ℝ-Valued Functions",
+    "range": {
+      "startLine": 99,
+      "endLine": 106
+    },
+    "type": "insight",
+    "title": "Scalar Specialization: |f(x) \u2212 f(a)| \u2264 C(x\u2212a) for \u211d-Valued Functions",
     "content": "When $E = \\mathbb{R}$, the vector inequality becomes $|f(x) - f(a)| \\leq C(x-a)$. Lean's type unification automatically specializes, so the proof is simply `mean_value_inequality hf hC`. This is strictly weaker than the classical scalar MVT which gives exact equality at some point $c$.",
     "mathContext": "For $\\mathbb{R}$-valued functions, $\\|f(x) - f(a)\\| = |f(x) - f(a)|$ since the norm on $\\mathbb{R}$ is the absolute value. The inequality loses the sign information: it cannot distinguish $f(b) > f(a)$ from $f(b) < f(a)$. The classical equality is proved separately in `classical_mvt_gives_equality`.",
     "significance": "supporting",
@@ -63,9 +72,12 @@
   {
     "id": "ann-classical-equality",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 108, "endLine": 133 },
-    "type": "theorem",
-    "title": "Classical MVT Equality: ∃c ∈ (a,b) with f'(c) = (f(b)−f(a))/(b−a)",
+    "range": {
+      "startLine": 108,
+      "endLine": 133
+    },
+    "type": "insight",
+    "title": "Classical MVT Equality: \u2203c \u2208 (a,b) with f'(c) = (f(b)\u2212f(a))/(b\u2212a)",
     "content": "For $f : \\mathbb{R} \\to \\mathbb{R}$ continuous on $[a,b]$ and differentiable on $(a,b)$, $\\exists c \\in (a,b)$ with $f'(c) = \\frac{f(b)-f(a)}{b-a}$. Uses Mathlib's `exists_deriv_eq_slope`. This relies on the **intermediate value theorem** applied to $g(x) = f(x) - \\lambda x$ (reducing to Rolle's theorem), which is why it has no vector analogue.",
     "mathContext": "Proof sketch: define $g(x) = f(x) - \\frac{f(b)-f(a)}{b-a} x$. Then $g(a) = g(b)$, so by Rolle's theorem $\\exists c, g'(c) = 0$, giving $f'(c) = \\frac{f(b)-f(a)}{b-a}$. Rolle's theorem itself uses the extreme value theorem (continuous function on $[a,b]$ attains its extrema) and the definition of derivative at an extremum.",
     "significance": "key",
@@ -85,7 +97,10 @@
   {
     "id": "ann-counterexample",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 135, "endLine": 160 },
+    "range": {
+      "startLine": 135,
+      "endLine": 160
+    },
     "type": "insight",
     "title": "Circular Motion: Why MVT Equality Fails for Vector Functions",
     "content": "Circular motion counterexample: $f(t) = (\\cos t, \\sin t)$ on $[0, 2\\pi]$ shows MVT equality is impossible for vector functions. Net displacement: $f(2\\pi) - f(0) = (0,0)$, yet $\\|f'(t)\\| = 1$ everywhere. The 'slope' would be $(0,0)/(2\\pi) = (0,0)$, requiring $f'(c) = 0$ for some $c$, but $f'(t) = (-\\sin t, \\cos t)$ never vanishes. The obstruction is topological: the image traces a closed curve with winding number 1.\n\n`circular_counterexample` proves $f(2\\pi) - f(0) = (0,0)$ and `circular_derivative_norm` proves $\\|f'(t)\\| = 1$.",
@@ -94,7 +109,7 @@
     "relatedConcepts": [
       "circular motion",
       "winding number",
-      "IVT failure in ℝⁿ",
+      "IVT failure in \u211d\u207f",
       "topology",
       "Real.sin_sq_add_cos_sq"
     ],
@@ -107,15 +122,18 @@
   {
     "id": "ann-lipschitz",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 163, "endLine": 185 },
-    "type": "theorem",
-    "title": "Derivative Bound ⇒ Lipschitz: ‖Df‖_op ≤ L on Convex Set",
+    "range": {
+      "startLine": 163,
+      "endLine": 185
+    },
+    "type": "insight",
+    "title": "Derivative Bound \u21d2 Lipschitz: \u2016Df\u2016_op \u2264 L on Convex Set",
     "content": "If $\\|Df(x)\\|_{\\text{op}} \\leq L$ on a convex set $S$, then $f$ is $L$-Lipschitz on $S$. Uses NNReal for the Lipschitz constant. Convexity is essential: for any $x, y \\in S$, the segment $[x,y] \\subseteq S$, so MVT applies along it. On non-convex domains, derivative bounds do not imply Lipschitz.\n\n`constant_of_deriv_zero_vector` (line 173) follows immediately: zero derivative ($L=0$) gives 0-Lipschitz, meaning $f$ is constant.",
     "mathContext": "If $\\|Df(x)\\|_{\\text{op}} \\leq L$ for all $x \\in S$ (convex), then $\\|f(x) - f(y)\\| \\leq L \\|x - y\\|$ for all $x, y \\in S$. This bridges pointwise derivative information and global regularity, and is the key to proving that smooth maps between manifolds are locally Lipschitz. NNReal is used for $L$ since Lipschitz constants are non-negative.",
     "significance": "key",
     "relatedConcepts": [
       "Lipschitz continuity",
-      "Fréchet derivative",
+      "Fr\u00e9chet derivative",
       "operator norm",
       "convex sets",
       "NNReal",
@@ -131,10 +149,13 @@
   {
     "id": "ann-zero-deriv-constant",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 173, "endLine": 202 },
-    "type": "theorem",
-    "title": "Zero Derivative ⇒ Constant (Vector Version): ‖f(b)−f(a)‖ ≤ 0",
-    "content": "If $f'(x) = 0$ for all $x \\in [a,b)$, then $f(b) = f(a)$. The proof is a beautiful application of MVT with $C = 0$: $\\|f(b) - f(a)\\| \\leq 0 \\cdot (b-a) = 0$, and $\\|f(b) - f(a)\\| \\geq 0$ (norm non-negativity), so by `le_antisymm`: $\\|f(b) - f(a)\\| = 0$, hence $f(b) = f(a)$ by `norm_eq_zero`.\n\nThis cannot be proved via the scalar MVT for vector functions — it genuinely requires the vector inequality.",
+    "range": {
+      "startLine": 173,
+      "endLine": 202
+    },
+    "type": "insight",
+    "title": "Zero Derivative \u21d2 Constant (Vector Version): \u2016f(b)\u2212f(a)\u2016 \u2264 0",
+    "content": "If $f'(x) = 0$ for all $x \\in [a,b)$, then $f(b) = f(a)$. The proof is a beautiful application of MVT with $C = 0$: $\\|f(b) - f(a)\\| \\leq 0 \\cdot (b-a) = 0$, and $\\|f(b) - f(a)\\| \\geq 0$ (norm non-negativity), so by `le_antisymm`: $\\|f(b) - f(a)\\| = 0$, hence $f(b) = f(a)$ by `norm_eq_zero`.\n\nThis cannot be proved via the scalar MVT for vector functions \u2014 it genuinely requires the vector inequality.",
     "mathContext": "Key steps: (1) $\\|0\\| = 0 \\leq 0$, (2) $0 \\cdot (b-a) = 0$, (3) antisymmetry of $\\leq$ with norm non-negativity, (4) `norm_eq_zero` gives $f(b) - f(a) = 0$, (5) `sub_eq_zero` gives $f(b) = f(a)$. The vector version is strictly more powerful than the scalar: it works for any normed space $E$.",
     "significance": "key",
     "relatedConcepts": [
@@ -154,9 +175,12 @@
   {
     "id": "ann-contraction-bound",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 205, "endLine": 226 },
-    "type": "theorem",
-    "title": "Contraction Bound: ‖T'‖ ≤ q Implies ‖T(x)−T(a)‖ ≤ q(x−a)",
+    "range": {
+      "startLine": 205,
+      "endLine": 226
+    },
+    "type": "insight",
+    "title": "Contraction Bound: \u2016T'\u2016 \u2264 q Implies \u2016T(x)\u2212T(a)\u2016 \u2264 q(x\u2212a)",
     "content": "If $\\|T'(x)\\| \\leq q$ on $[a,b]$, then $\\|T(x) - T(a)\\| \\leq q(x-a)$. Exactly the MVT inequality in contraction mapping language. When $q < 1$, $T$ is a strict contraction, enabling Banach's fixed-point theorem: the Picard iteration $T^n(x_0)$ converges to a unique fixed point.",
     "mathContext": "In the Banach fixed-point theorem, one needs $\\|T(x) - T(y)\\| \\leq q\\|x-y\\|$ with $q < 1$. The MVT inequality provides this when $\\|DT\\|_{\\text{op}} \\leq q < 1$. For ODEs, the Picard operator $\\Phi(u)(t) = x_0 + \\int_0^t F(s, u(s))\\,ds$ is a contraction when $F$ is Lipschitz in the second argument.",
     "significance": "supporting",
@@ -173,9 +197,12 @@
   {
     "id": "ann-displacement-bound",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 229, "endLine": 262 },
-    "type": "theorem",
-    "title": "Displacement Bound: ‖f(T)−f(0)‖ ≤ CT (Constant-Coefficient Gronwall)",
+    "range": {
+      "startLine": 229,
+      "endLine": 262
+    },
+    "type": "insight",
+    "title": "Displacement Bound: \u2016f(T)\u2212f(0)\u2016 \u2264 CT (Constant-Coefficient Gronwall)",
     "content": "For $f : \\mathbb{R} \\to \\mathbb{R}$ with $\\|f'\\| \\leq C$ on $[0,T]$: $\\|f(T) - f(0)\\| \\leq CT$. The simplest 'derivative controls displacement' principle. The proof specializes MVT to the endpoint $T$ and simplifies. This is the constant-coefficient case of Gronwall's inequality, which generalizes to $y'(t) \\leq \\alpha y(t) + \\beta$.",
     "mathContext": "Gronwall's inequality: if $y'(t) \\leq \\alpha y(t) + \\beta$ and $y(0) = y_0$, then $y(t) \\leq (y_0 + \\beta/\\alpha)e^{\\alpha t} - \\beta/\\alpha$. The displacement bound is the $\\alpha = 0$ case: $y'(t) \\leq C$ gives $y(t) - y(0) \\leq Ct$. Used to bound solution growth in ODEs.",
     "significance": "supporting",
@@ -193,15 +220,18 @@
   {
     "id": "ann-banach-general",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 265, "endLine": 291 },
-    "type": "theorem",
-    "title": "Banach Space MVT: ‖f(b)−f(a)‖ ≤ C‖b−a‖ for Fréchet Differentiable Maps",
-    "content": "The most general form — for $f : E \\to F$ between arbitrary normed spaces, differentiable on a convex set with $\\|Df(x)\\|_{\\text{op}} \\leq C$: $\\|f(b) - f(a)\\| \\leq C\\|b - a\\|$. Uses `fderivWithin` (Fréchet derivative within a set). This is the foundation for the implicit function theorem, inverse function theorem, and Nash-Moser iteration in infinite dimensions.",
-    "mathContext": "The Fréchet derivative $Df(x) : E \\to_L F$ is a bounded linear map. Its operator norm $\\|Df(x)\\|_{\\text{op}} = \\sup_{\\|h\\|=1} \\|Df(x)(h)\\|$ measures the maximum infinitesimal stretching. The inequality says $f$ cannot stretch distances more than $C$-fold globally. Mathlib's `Convex.norm_image_sub_le_of_norm_fderivWithin_le` provides the core bound.",
+    "range": {
+      "startLine": 265,
+      "endLine": 291
+    },
+    "type": "insight",
+    "title": "Banach Space MVT: \u2016f(b)\u2212f(a)\u2016 \u2264 C\u2016b\u2212a\u2016 for Fr\u00e9chet Differentiable Maps",
+    "content": "The most general form \u2014 for $f : E \\to F$ between arbitrary normed spaces, differentiable on a convex set with $\\|Df(x)\\|_{\\text{op}} \\leq C$: $\\|f(b) - f(a)\\| \\leq C\\|b - a\\|$. Uses `fderivWithin` (Fr\u00e9chet derivative within a set). This is the foundation for the implicit function theorem, inverse function theorem, and Nash-Moser iteration in infinite dimensions.",
+    "mathContext": "The Fr\u00e9chet derivative $Df(x) : E \\to_L F$ is a bounded linear map. Its operator norm $\\|Df(x)\\|_{\\text{op}} = \\sup_{\\|h\\|=1} \\|Df(x)(h)\\|$ measures the maximum infinitesimal stretching. The inequality says $f$ cannot stretch distances more than $C$-fold globally. Mathlib's `Convex.norm_image_sub_le_of_norm_fderivWithin_le` provides the core bound.",
     "significance": "key",
     "relatedConcepts": [
       "Banach space",
-      "Fréchet derivative",
+      "Fr\u00e9chet derivative",
       "operator norm",
       "implicit function theorem",
       "inverse function theorem",
@@ -217,14 +247,17 @@
   {
     "id": "ann-ode-uniqueness",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 294, "endLine": 329 },
-    "type": "theorem",
-    "title": "ODE Difference Bound: ‖(f−g)(x)‖ ≤ q(x−a) when f(a)=g(a)",
-    "content": "If $f(a) = g(a)$ and $\\|f'(t) - g'(t)\\| \\leq q$ on $[a,b)$, then $\\|(f(x)-g(x)) - (f(a)-g(a))\\| \\leq q(x-a)$. The proof constructs $h = f - g$ using `HasDerivWithinAt.sub`, then applies Mathlib's MVT. This is the core of Picard-Lindelöf uniqueness: two ODE solutions with close derivatives remain close.",
+    "range": {
+      "startLine": 294,
+      "endLine": 329
+    },
+    "type": "insight",
+    "title": "ODE Difference Bound: \u2016(f\u2212g)(x)\u2016 \u2264 q(x\u2212a) when f(a)=g(a)",
+    "content": "If $f(a) = g(a)$ and $\\|f'(t) - g'(t)\\| \\leq q$ on $[a,b)$, then $\\|(f(x)-g(x)) - (f(a)-g(a))\\| \\leq q(x-a)$. The proof constructs $h = f - g$ using `HasDerivWithinAt.sub`, then applies Mathlib's MVT. This is the core of Picard-Lindel\u00f6f uniqueness: two ODE solutions with close derivatives remain close.",
     "mathContext": "For the ODE $x' = F(t,x)$ with $L$-Lipschitz $F$: if $x_1, x_2$ are solutions with $x_1(a) = x_2(a)$, then $\\|(x_1-x_2)'\\| = \\|F(t,x_1)-F(t,x_2)\\| \\leq L\\|x_1-x_2\\|$. Combined with Gronwall, this gives uniqueness: $x_1 = x_2$. The `difference_bound_for_odes` theorem establishes the key bound.",
     "significance": "key",
     "relatedConcepts": [
-      "Picard-Lindelöf theorem",
+      "Picard-Lindel\u00f6f theorem",
       "ODE uniqueness",
       "Gronwall inequality",
       "contraction mapping",
@@ -238,16 +271,19 @@
   {
     "id": "ann-strict-mono",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 331, "endLine": 345 },
-    "type": "theorem",
+    "range": {
+      "startLine": 331,
+      "endLine": 345
+    },
+    "type": "insight",
     "title": "Strict Monotonicity from Positive Derivative (Requires Scalar MVT Equality)",
-    "content": "Strict monotonicity: $f' > 0$ on $(a,b)$ with $f$ continuous on $[a,b]$ implies $f(a) < f(b)$. This *cannot* be proved from the vector inequality — it genuinely needs the scalar MVT equality. Proof: get $c$ via `exists_deriv_eq_slope`, observe $f'(c) > 0$, substitute $f'(c) = \\frac{f(b)-f(a)}{b-a}$, use $b-a > 0$ and `div_mul_cancel₀` to get $f(b)-f(a) > 0$.",
-    "mathContext": "The vector inequality only gives $|f(b)-f(a)| \\leq C(b-a)$ — non-negative, unable to determine the sign of $f(b)-f(a)$. The equality $f'(c) = \\frac{f(b)-f(a)}{b-a} > 0$ preserves sign information. This is why the scalar MVT equality retains independent value alongside the vector inequality.",
+    "content": "Strict monotonicity: $f' > 0$ on $(a,b)$ with $f$ continuous on $[a,b]$ implies $f(a) < f(b)$. This *cannot* be proved from the vector inequality \u2014 it genuinely needs the scalar MVT equality. Proof: get $c$ via `exists_deriv_eq_slope`, observe $f'(c) > 0$, substitute $f'(c) = \\frac{f(b)-f(a)}{b-a}$, use $b-a > 0$ and `div_mul_cancel\u2080` to get $f(b)-f(a) > 0$.",
+    "mathContext": "The vector inequality only gives $|f(b)-f(a)| \\leq C(b-a)$ \u2014 non-negative, unable to determine the sign of $f(b)-f(a)$. The equality $f'(c) = \\frac{f(b)-f(a)}{b-a} > 0$ preserves sign information. This is why the scalar MVT equality retains independent value alongside the vector inequality.",
     "significance": "key",
     "relatedConcepts": [
       "monotone functions",
       "first derivative test",
-      "div_mul_cancel₀",
+      "div_mul_cancel\u2080",
       "sign preservation",
       "strict_mono_of_deriv_pos"
     ],
@@ -260,11 +296,14 @@
   {
     "id": "ann-antiderivative",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 347, "endLine": 363 },
-    "type": "theorem",
-    "title": "Antiderivative Uniqueness: f' = g' ⇒ f − g is Constant",
+    "range": {
+      "startLine": 347,
+      "endLine": 363
+    },
+    "type": "insight",
+    "title": "Antiderivative Uniqueness: f' = g' \u21d2 f \u2212 g is Constant",
     "content": "If $f' = g'$ on $[a,b)$, then $f(x) - g(x) = f(a) - g(a)$ for all $x \\in [a,b]$. Proof: set $h = f - g$, show $h' = 0$ via `sub_eq_zero`, apply MVT with $C = 0$ (reusing the constant_of_deriv_zero_vector technique). Uses vector machinery even for a scalar result, showing the vector approach subsumes the scalar case.\n\nThis is the uniqueness part of the fundamental theorem of calculus: the constant of integration $f(a) - g(a)$ is the only degree of freedom.",
-    "mathContext": "In Lean, the proof chain is: $f' - g' = 0$ → apply `constant_of_deriv_zero_vector` to $h = f - g$ → $h(b) = h(a)$ → $f(b) - g(b) = f(a) - g(a)$. The uniqueness statement can also be written as: the kernel of the differentiation operator is exactly the constant functions.",
+    "mathContext": "In Lean, the proof chain is: $f' - g' = 0$ \u2192 apply `constant_of_deriv_zero_vector` to $h = f - g$ \u2192 $h(b) = h(a)$ \u2192 $f(b) - g(b) = f(a) - g(a)$. The uniqueness statement can also be written as: the kernel of the differentiation operator is exactly the constant functions.",
     "significance": "key",
     "relatedConcepts": [
       "fundamental theorem of calculus",
@@ -281,16 +320,19 @@
   {
     "id": "ann-banach-fderiv-zero",
     "proofId": "mean-value-theorem-oq-03",
-    "range": { "startLine": 429, "endLine": 441 },
-    "type": "theorem",
-    "title": "Banach Constant-Function Theorem: Df = 0 on Convex S ⇒ f Constant",
-    "content": "If the Fréchet derivative $Df = 0$ on a convex set $S \\subseteq E$, then $f$ is constant on $S$. Full Banach space generalization of `constant_of_deriv_zero_vector`. The proof mirrors the $\\mathbb{R} \\to E$ version: set $C = 0$ in the Banach MVT, use $\\|0\\|_{\\text{op}} = 0 \\leq 0$, then antisymmetry.\n\nAlso in this section: `banach_mvt_differentiableAt` (line 407) and `banach_mvt_hasFDerivWithinAt` (line 418) provide alternative hypotheses for the Banach MVT — differentiability at a point vs. `hasFDerivWithinAt`.",
+    "range": {
+      "startLine": 429,
+      "endLine": 441
+    },
+    "type": "insight",
+    "title": "Banach Constant-Function Theorem: Df = 0 on Convex S \u21d2 f Constant",
+    "content": "If the Fr\u00e9chet derivative $Df = 0$ on a convex set $S \\subseteq E$, then $f$ is constant on $S$. Full Banach space generalization of `constant_of_deriv_zero_vector`. The proof mirrors the $\\mathbb{R} \\to E$ version: set $C = 0$ in the Banach MVT, use $\\|0\\|_{\\text{op}} = 0 \\leq 0$, then antisymmetry.\n\nAlso in this section: `banach_mvt_differentiableAt` (line 407) and `banach_mvt_hasFDerivWithinAt` (line 418) provide alternative hypotheses for the Banach MVT \u2014 differentiability at a point vs. `hasFDerivWithinAt`.",
     "mathContext": "For $f : E \\to F$ with $Df(x) = 0$ (the zero operator) for all $x \\in S$: $\\|f(b) - f(a)\\| \\leq 0 \\cdot \\|b-a\\| = 0$. This generalizes to: if $Df = Dg$ on a connected open set, then $f - g$ is constant. Connectedness is needed; convexity is sufficient because the MVT applies along line segments.",
     "significance": "key",
     "relatedConcepts": [
       "constant function",
       "connected domain",
-      "Fréchet derivative",
+      "Fr\u00e9chet derivative",
       "zero operator",
       "banach_mean_value_inequality"
     ],

--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "concept",
     "title": "The Tractatus and Its Formalization",
-    "content": "The Tractatus Logico-Philosophicus opens: 'The world is everything that is the case.' What follows is an attempt to express the formal skeleton of that vision in Lean 4 — the ontology of objects, states of affairs, facts, and truth-functional propositions. We formalize the part that *can* be formalized, and annotate where the philosophy exceeds the formalism.",
+    "content": "The Tractatus Logico-Philosophicus opens: 'The world is everything that is the case.' What follows is an attempt to express the formal skeleton of that vision in Lean 4 \u2014 the ontology of objects, states of affairs, facts, and truth-functional propositions. We formalize the part that *can* be formalized, and annotate where the philosophy exceeds the formalism.",
     "mathContext": "The Tractatus contains a nearly axiomatic ontology buried in its numbered propositions (1, 1.1, 2.01, 2.02, etc.). We extract and formalize the structural core: types for objects and states of affairs, a model-theoretic notion of world, an inductive grammar for propositions, and a recursive evaluation function. The result is a miniature model theory built from scratch.",
     "significance": "key",
     "prerequisites": [
@@ -33,8 +33,8 @@
     },
     "type": "concept",
     "title": "Mathlib Import",
-    "content": "We import `Mathlib.Tactic` for proof automation (`simp`, `tauto`, etc.) and access to classical logic lemmas like `not_not` and `not_and_or`. The formalization is otherwise self-contained — no Mathlib theorems appear in the definitions, only in the proofs.",
-    "mathContext": "The key Mathlib contributions: `Classical.em : ∀ P : Prop, P ∨ ¬P` (law of excluded middle, an axiom of classical logic), `not_not : ¬¬P ↔ P` (double negation elimination), and `not_and_or : ¬(P ∧ Q) ↔ ¬P ∨ ¬Q` (De Morgan). Tactics `simp`, `tauto`, and `ring` are decision procedures for propositional reasoning and ring equations.",
+    "content": "We import `Mathlib.Tactic` for proof automation (`simp`, `tauto`, etc.) and access to classical logic lemmas like `not_not` and `not_and_or`. The formalization is otherwise self-contained \u2014 no Mathlib theorems appear in the definitions, only in the proofs.",
+    "mathContext": "The key Mathlib contributions: `Classical.em : \u2200 P : Prop, P \u2228 \u00acP` (law of excluded middle, an axiom of classical logic), `not_not : \u00ac\u00acP \u2194 P` (double negation elimination), and `not_and_or : \u00ac(P \u2227 Q) \u2194 \u00acP \u2228 \u00acQ` (De Morgan). Tactics `simp`, `tauto`, and `ring` are decision procedures for propositional reasoning and ring equations.",
     "significance": "supporting",
     "prerequisites": [
       "Lean 4 import system",
@@ -56,8 +56,8 @@
     },
     "type": "concept",
     "title": "Objects: The Simple (TLP 2.02)",
-    "content": "TLP 2.02: 'The object is simple.' We model Tractarian objects as a `variable` type parameter — Lean knows nothing about its inhabitants except that the type exists. This captures Wittgenstein's insistence that objects have no analyzable internal structure.\n\n**[Interpretive choice]** Using a bare type parameter captures *simplicity* (no structure) but not the Tractarian claim that an object's *form* determines which states of affairs it can enter (TLP 2.0141). A dependent-type encoding — where each object carries a type constraining its combinatorial possibilities — would better capture 2.0141 but at the cost of specifying structure Wittgenstein deliberately leaves open. We opt for the lighter encoding.",
-    "mathContext": "In Lean, `variable (TractObject : Type)` introduces a universe-polymorphic type parameter. Any theorem or definition mentioning `TractObject` is implicitly universally quantified over all types — so our results hold regardless of what objects 'are.'",
+    "content": "TLP 2.02: 'The object is simple.' We model Tractarian objects as a `variable` type parameter \u2014 Lean knows nothing about its inhabitants except that the type exists. This captures Wittgenstein's insistence that objects have no analyzable internal structure.\n\n**[Interpretive choice]** Using a bare type parameter captures *simplicity* (no structure) but not the Tractarian claim that an object's *form* determines which states of affairs it can enter (TLP 2.0141). A dependent-type encoding \u2014 where each object carries a type constraining its combinatorial possibilities \u2014 would better capture 2.0141 but at the cost of specifying structure Wittgenstein deliberately leaves open. We opt for the lighter encoding.",
+    "mathContext": "In Lean, `variable (TractObject : Type)` introduces a universe-polymorphic type parameter. Any theorem or definition mentioning `TractObject` is implicitly universally quantified over all types \u2014 so our results hold regardless of what objects 'are.'",
     "significance": "key",
     "prerequisites": [
       "Lean 4 type parameters",
@@ -82,8 +82,8 @@
     },
     "type": "concept",
     "title": "States of Affairs: Sachverhalte (TLP 2.01)",
-    "content": "TLP 2.01: 'An atomic fact is a combination of objects.' A state of affairs (*Sachverhalt*) is a possible way objects might combine. We model this as an abstract type parameter, just like objects.\n\n**[Interpretive choice]** We do *not* encode states of affairs as sets of objects or as predicates over objects. The Tractatus arguably intends something more structural — the *way* objects hang together, not merely *which* objects are involved (the 'form' of TLP 2.032). By keeping Sachverhalt abstract, we preserve this openness. The cost is that we cannot express *within* the formalization how objects compose into states of affairs.",
-    "mathContext": "The choice to keep `Sachverhalt` abstract rather than defining it as `Set TractObject -> Prop` or `List TractObject` is deliberate. An extensional encoding would commit us to saying that states of affairs with the same objects are identical — which conflicts with 'aRb' and 'bRa' being distinct states of affairs involving the same objects.",
+    "content": "TLP 2.01: 'An atomic fact is a combination of objects.' A state of affairs (*Sachverhalt*) is a possible way objects might combine. We model this as an abstract type parameter, just like objects.\n\n**[Interpretive choice]** We do *not* encode states of affairs as sets of objects or as predicates over objects. The Tractatus arguably intends something more structural \u2014 the *way* objects hang together, not merely *which* objects are involved (the 'form' of TLP 2.032). By keeping Sachverhalt abstract, we preserve this openness. The cost is that we cannot express *within* the formalization how objects compose into states of affairs.",
+    "mathContext": "The choice to keep `Sachverhalt` abstract rather than defining it as `Set TractObject -> Prop` or `List TractObject` is deliberate. An extensional encoding would commit us to saying that states of affairs with the same objects are identical \u2014 which conflicts with 'aRb' and 'bRa' being distinct states of affairs involving the same objects.",
     "significance": "key",
     "prerequisites": [
       "Lean 4 type parameters",
@@ -108,7 +108,7 @@
     },
     "type": "definition",
     "title": "Worlds: The Totality of Facts (TLP 1, 2.04)",
-    "content": "TLP 1: 'The world is everything that is the case.' TLP 2.04: 'The totality of existing atomic facts is the world.' A world is a function `Sachverhalt -> Prop` — for each state of affairs, it says whether that state of affairs obtains.\n\nThis is the standard model-theoretic move: a 'world' or 'model' is a truth-value assignment to atomic propositions. What is distinctive about the Tractarian version is the ontological weight: for Wittgenstein, the world literally *is* the totality of facts, not something that *has* facts as properties.",
+    "content": "TLP 1: 'The world is everything that is the case.' TLP 2.04: 'The totality of existing atomic facts is the world.' A world is a function `Sachverhalt -> Prop` \u2014 for each state of affairs, it says whether that state of affairs obtains.\n\nThis is the standard model-theoretic move: a 'world' or 'model' is a truth-value assignment to atomic propositions. What is distinctive about the Tractarian version is the ontological weight: for Wittgenstein, the world literally *is* the totality of facts, not something that *has* facts as properties.",
     "mathContext": "Defining `World` as `Sachverhalt -> Prop` means a world is a predicate on states of affairs. This is equivalent to a subset of `Sachverhalt` (via the correspondence `Set a = (a -> Prop)`). We use the predicate form because it integrates more naturally with Lean's type theory.",
     "significance": "key",
     "prerequisites": [
@@ -135,7 +135,7 @@
     },
     "type": "concept",
     "title": "Propositions: The Inductive Grammar (TLP 4.21, 5)",
-    "content": "TLP 4.21: 'The simplest proposition, the elementary proposition, asserts the existence of an atomic fact.' TLP 5: 'The proposition is a truth-function of elementary propositions.'\n\nWe define propositions as an inductive type with three constructors: `elementary` (asserts a state of affairs), `neg` (negation), and `conj` (conjunction). Every proposition is a finite tree built from these constructors.\n\nTLP 5.101 tells us that all truth-functions arise from successive applications of negation and conjunction. The other connectives — disjunction, implication, biconditional — are defined, not primitive.",
+    "content": "TLP 4.21: 'The simplest proposition, the elementary proposition, asserts the existence of an atomic fact.' TLP 5: 'The proposition is a truth-function of elementary propositions.'\n\nWe define propositions as an inductive type with three constructors: `elementary` (asserts a state of affairs), `neg` (negation), and `conj` (conjunction). Every proposition is a finite tree built from these constructors.\n\nTLP 5.101 tells us that all truth-functions arise from successive applications of negation and conjunction. The other connectives \u2014 disjunction, implication, biconditional \u2014 are defined, not primitive.",
     "mathContext": "The `inductive` keyword in Lean defines a freely generated type. `Proposition S` is parametric in a type `S` of states of affairs. The three constructors give us a complete basis for propositional logic: $\\{\\neg, \\land\\}$ is functionally complete (any Boolean function can be expressed using only negation and conjunction).",
     "significance": "key",
     "prerequisites": [
@@ -162,7 +162,7 @@
     },
     "type": "definition",
     "title": "Derived Connectives (TLP 5.101)",
-    "content": "TLP 5.101: 'The truth-functions of every number of elementary propositions can be written in a schema.' We define:\n\n- **Disjunction** $p \\lor q$ as $\\neg(\\neg p \\land \\neg q)$\n- **Implication** $p \\to q$ as $\\neg(p \\land \\neg q)$\n- **Biconditional** $p \\leftrightarrow q$ as $(p \\to q) \\land (q \\to p)$\n- **NAND** $p \\mid q$ as $\\neg(p \\land q)$\n\nThe NAND gate (TLP 5.5) is historically significant: Wittgenstein recognized — independently of Sheffer (1913) — that a single binary operation suffices for all truth-functions.",
+    "content": "TLP 5.101: 'The truth-functions of every number of elementary propositions can be written in a schema.' We define:\n\n- **Disjunction** $p \\lor q$ as $\\neg(\\neg p \\land \\neg q)$\n- **Implication** $p \\to q$ as $\\neg(p \\land \\neg q)$\n- **Biconditional** $p \\leftrightarrow q$ as $(p \\to q) \\land (q \\to p)$\n- **NAND** $p \\mid q$ as $\\neg(p \\land q)$\n\nThe NAND gate (TLP 5.5) is historically significant: Wittgenstein recognized \u2014 independently of Sheffer (1913) \u2014 that a single binary operation suffices for all truth-functions.",
     "mathContext": "These definitions are not just convenient abbreviations. They demonstrate the Tractarian thesis that the expressive power of propositional logic reduces entirely to $\\{\\neg, \\land\\}$, and further to the single Sheffer stroke $\\{\\mid\\}$. The theorems below verify that these definitions produce the expected semantics.",
     "significance": "key",
     "prerequisites": [
@@ -190,7 +190,7 @@
     "type": "definition",
     "title": "Semantic Evaluation: Picture Theory (TLP 2.21, 4.06)",
     "content": "TLP 2.21: 'The picture agrees with reality or not; it is right or wrong, true or false.' TLP 4.06: 'Propositions can be true or false only by being pictures of the reality.'\n\nThe `eval` function is the heart of the formalization. It recursively computes the truth value of a proposition relative to a world:\n- An elementary proposition $e(s)$ is true in world $w$ iff the state of affairs $s$ obtains in $w$\n- $\\neg p$ is true iff $p$ is false\n- $p \\land q$ is true iff both $p$ and $q$ are true\n\nThis is Wittgenstein's picture theory reduced to its formal core: a proposition 'pictures' reality by having the same truth conditions.",
-    "mathContext": "The function is defined by structural recursion on the `Proposition` inductive type. Lean automatically verifies that the recursion terminates because each recursive call is on a structurally smaller argument. The return type `Prop` means evaluation lives in Lean's universe of propositions — we are using Lean's logic to model Wittgenstein's.",
+    "mathContext": "The function is defined by structural recursion on the `Proposition` inductive type. Lean automatically verifies that the recursion terminates because each recursive call is on a structurally smaller argument. The return type `Prop` means evaluation lives in Lean's universe of propositions \u2014 we are using Lean's logic to model Wittgenstein's.",
     "significance": "key",
     "prerequisites": [
       "Lean 4 structural recursion",
@@ -217,7 +217,7 @@
     "type": "definition",
     "title": "Bool-Valued Evaluator and Correctness Bridge",
     "content": "`evalBool` is a computable counterpart to `eval`. Where `eval` returns a `Prop` (inhabiting Lean's logical universe, opaque to computation), `evalBool` returns a `Bool` (a concrete data type that `#eval` can print). The structure mirrors `eval` exactly: elementary propositions look up the world, negation flips, conjunction uses Boolean AND.\n\nThe bridge theorem `evalBool_correct` proves that the two evaluators agree: `evalBool w = true` if and only if `eval (fun s => w s = true)` holds. The proof is by structural induction on the proposition, matching the pattern of `truth_functional_compositionality`.",
-    "mathContext": "The `Bool`/`Prop` distinction is fundamental in Lean 4. `Prop` is the universe of logical propositions — it supports classical reasoning and quantification but is computationally erased. `Bool` is a concrete inductive type with two constructors (`true`, `false`) that persists at runtime. `evalBool` lives in `Bool` and is therefore computable; `evalBool_correct` bridges back to `Prop`-land where the theorems live.",
+    "mathContext": "The `Bool`/`Prop` distinction is fundamental in Lean 4. `Prop` is the universe of logical propositions \u2014 it supports classical reasoning and quantification but is computationally erased. `Bool` is a concrete inductive type with two constructors (`true`, `false`) that persists at runtime. `evalBool` lives in `Bool` and is therefore computable; `evalBool_correct` bridges back to `Prop`-land where the theorems live.",
     "significance": "key",
     "prerequisites": [
       "Lean 4 Bool vs Prop",
@@ -241,8 +241,8 @@
     },
     "type": "definition",
     "title": "Tautology and Contradiction (TLP 4.46, 6.1)",
-    "content": "TLP 4.46: 'Among the possible groups of truth-conditions there are two extreme cases.' TLP 6.1: 'The propositions of logic are tautologies.'\n\n`IsTautology p` means $p$ evaluates to true in *every* world. `IsContradiction p` means $p$ evaluates to false in *every* world. These are the two extreme cases of TLP 4.46 — a tautology says nothing about which world is actual (it holds in all of them), while a contradiction rules out every possibility.",
-    "mathContext": "Both definitions use universal quantification over `World S`. A tautology is $\\forall w, \\text{eval}(p, w)$; a contradiction is $\\forall w, \\neg\\text{eval}(p, w)$. The key philosophical point: for Wittgenstein, tautologies are not 'truths about the world' — they are limit cases that show the structure of logical space without saying anything about it.",
+    "content": "TLP 4.46: 'Among the possible groups of truth-conditions there are two extreme cases.' TLP 6.1: 'The propositions of logic are tautologies.'\n\n`IsTautology p` means $p$ evaluates to true in *every* world. `IsContradiction p` means $p$ evaluates to false in *every* world. These are the two extreme cases of TLP 4.46 \u2014 a tautology says nothing about which world is actual (it holds in all of them), while a contradiction rules out every possibility.",
+    "mathContext": "Both definitions use universal quantification over `World S`. A tautology is $\\forall w, \\text{eval}(p, w)$; a contradiction is $\\forall w, \\neg\\text{eval}(p, w)$. The key philosophical point: for Wittgenstein, tautologies are not 'truths about the world' \u2014 they are limit cases that show the structure of logical space without saying anything about it.",
     "significance": "key",
     "prerequisites": [
       "propositional logic",
@@ -295,10 +295,10 @@
       "startLine": 319,
       "endLine": 331
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "[Main Result] Compositionality is Model-Independent",
     "content": "truth_functional_compositionality_gen proves that compositionality -- the property that two worlds agreeing on all elementary states of affairs agree on every compound proposition -- holds in any world model, not just the free model. This is a purely structural consequence of the inductive definition of Proposition: it requires no assumptions about which worlds exist or how they are constrained. The proof is structurally identical to truth_functional_compositionality but operates over an arbitrary WorldModel parameter M.",
-    "mathContext": "Formally: `∀ (M : WorldModel S) (p : Proposition S) (w₁ w₂ : M.W), (∀ s, M.holds w₁ s ↔ M.holds w₂ s) → (evalM M p w₁ ↔ evalM M p w₂)`. The proof proceeds by structural induction on `p`. The base case uses the hypothesis directly; the inductive steps lift the biconditionals through `¬` and `∧` using `Iff.not` and `Iff.and`. No property of the model `M` beyond its definition is used.",
+    "mathContext": "Formally: `\u2200 (M : WorldModel S) (p : Proposition S) (w\u2081 w\u2082 : M.W), (\u2200 s, M.holds w\u2081 s \u2194 M.holds w\u2082 s) \u2192 (evalM M p w\u2081 \u2194 evalM M p w\u2082)`. The proof proceeds by structural induction on `p`. The base case uses the hypothesis directly; the inductive steps lift the biconditionals through `\u00ac` and `\u2227` using `Iff.not` and `Iff.and`. No property of the model `M` beyond its definition is used.",
     "significance": "key",
     "prerequisites": [
       "model theory",
@@ -321,10 +321,10 @@
       "startLine": 359,
       "endLine": 361
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Tautologies Are World-Invariant (TLP 6.1)",
-    "content": "TLP 6.1: 'The propositions of logic are tautologies.' This theorem states that a proposition holds in every world if and only if it is a tautology. The proof is `rfl` — it holds by definition. This is not a deficiency; it reflects that the *definition* of tautology captures exactly what 'proposition of logic' means in the Tractarian framework.",
-    "mathContext": "The `rfl` tactic closes the goal because `IsTautology p` is definitionally equal to `forall w : World S, p.eval w`. In Lean's type theory, definitional equality means no proof is needed — the two expressions are *computationally identical*.",
+    "content": "TLP 6.1: 'The propositions of logic are tautologies.' This theorem states that a proposition holds in every world if and only if it is a tautology. The proof is `rfl` \u2014 it holds by definition. This is not a deficiency; it reflects that the *definition* of tautology captures exactly what 'proposition of logic' means in the Tractarian framework.",
+    "mathContext": "The `rfl` tactic closes the goal because `IsTautology p` is definitionally equal to `forall w : World S, p.eval w`. In Lean's type theory, definitional equality means no proof is needed \u2014 the two expressions are *computationally identical*.",
     "significance": "key",
     "prerequisites": [
       "Lean 4 definitional equality",
@@ -345,10 +345,10 @@
       "startLine": 372,
       "endLine": 374
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Contradictions Hold Nowhere (TLP 4.46)",
-    "content": "If a proposition is a contradiction, it is false in every world. The proof is immediate from the definition — again, this reflects that the formalization has correctly captured the Tractarian concept.",
-    "mathContext": "Formally: `IsContradiction p → ∀ w : World S, ¬ p.eval w`. Since `IsContradiction p` is defined as `∀ w, ¬ p.eval w`, this is again a definitional unfolding. The `intro h w` tactic pattern suffices: `h : IsContradiction p` gives `h w : ¬ p.eval w` immediately. Analogously to the tautology case, the proof witnesses the adequacy of the definition.",
+    "content": "If a proposition is a contradiction, it is false in every world. The proof is immediate from the definition \u2014 again, this reflects that the formalization has correctly captured the Tractarian concept.",
+    "mathContext": "Formally: `IsContradiction p \u2192 \u2200 w : World S, \u00ac p.eval w`. Since `IsContradiction p` is defined as `\u2200 w, \u00ac p.eval w`, this is again a definitional unfolding. The `intro h w` tactic pattern suffices: `h : IsContradiction p` gives `h w : \u00ac p.eval w` immediately. Analogously to the tautology case, the proof witnesses the adequacy of the definition.",
     "significance": "supporting",
     "prerequisites": [
       "Lean 4 definitional equality",
@@ -367,9 +367,9 @@
       "startLine": 389,
       "endLine": 391
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Elementary Proposition Bivalence (TLP 4.023)",
-    "content": "TLP 4.023: 'The proposition determines reality to this extent, that one only needs to say \"Yes\" or \"No\" to it.' For any state of affairs $s$ and world $w$, either $s$ obtains in $w$ or it does not: $w(s) \\lor \\neg w(s)$.\n\nThe proof invokes `Classical.em` — the law of excluded middle. This is a *classical* axiom in Lean's foundation; it is not provable constructively. Wittgenstein assumes bivalence throughout the Tractatus, so classical logic is the appropriate foundation here.",
+    "content": "TLP 4.023: 'The proposition determines reality to this extent, that one only needs to say \"Yes\" or \"No\" to it.' For any state of affairs $s$ and world $w$, either $s$ obtains in $w$ or it does not: $w(s) \\lor \\neg w(s)$.\n\nThe proof invokes `Classical.em` \u2014 the law of excluded middle. This is a *classical* axiom in Lean's foundation; it is not provable constructively. Wittgenstein assumes bivalence throughout the Tractatus, so classical logic is the appropriate foundation here.",
     "mathContext": "`Classical.em` provides $P \\lor \\neg P$ for any proposition $P$. In Lean 4, this is available from `import Mathlib.Tactic` (or directly from `Init.Classical`). Constructive type theories reject this axiom, leading to a different notion of truth. The Tractatus is firmly classical.",
     "significance": "key",
     "prerequisites": [
@@ -393,7 +393,7 @@
       "startLine": 412,
       "endLine": 420
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Truth-Functional Compositionality (TLP 5)",
     "content": "TLP 5: 'The proposition is a truth-function of elementary propositions.' This is the central theorem of the formalization. It states: if two worlds agree on every elementary proposition, they agree on every compound proposition.\n\nThe proof proceeds by structural induction on the proposition:\n- **Base case** (`elementary`): direct from the hypothesis that the worlds agree on elementaries\n- **Negation** (`neg`): if $p$ has the same truth value in both worlds, so does $\\neg p$\n- **Conjunction** (`conj`): if $p$ and $q$ each have the same truth values, so does $p \\land q$\n\nThis is the formal content of 'truth-functionality': compound truth values are determined entirely by elementary truth values.",
     "mathContext": "The `induction p with` tactic performs structural induction on the `Proposition` type. The `Iff.not` and `Iff.and` lemmas lift biconditionals through negation and conjunction. The `simp only [Proposition.eval]` step unfolds the recursive definition.",
@@ -419,10 +419,10 @@
       "startLine": 437,
       "endLine": 439
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Logical Independence (TLP 2.061, 2.062)",
-    "content": "TLP 2.061: 'Atomic facts are independent of one another.' TLP 2.062: 'From the existence or non-existence of one atomic fact it is impossible to infer the existence or non-existence of another.'\n\nGiven *any* truth-value assignment to states of affairs, there exists a world realizing it. The proof is beautifully trivial: in our encoding, a truth-value assignment `S -> Prop` literally *is* a `World S`. The witness is the assignment itself.\n\n**[Interpretive choice]** This triviality is both a strength and a limitation. It means independence is *built into the encoding* rather than *proved from it*. A richer encoding — where states of affairs had internal structure involving shared objects — would make independence a substantive theorem requiring proof. Our encoding achieves independence 'for free' by design, which is faithful to the Tractatus's treatment of it as foundational rather than derived.",
-    "mathContext": "The proof: `IndependentWorlds.realizable assignment` delegates to the `IndependentWorlds` typeclass instance. The witness is `⟨assignment, fun s => Iff.rfl⟩` — the assignment itself is the world, and the realization condition holds by reflexivity of `↔`. The triviality of this proof reveals that in the free model, independence is a *definitional* rather than *substantive* property.",
+    "content": "TLP 2.061: 'Atomic facts are independent of one another.' TLP 2.062: 'From the existence or non-existence of one atomic fact it is impossible to infer the existence or non-existence of another.'\n\nGiven *any* truth-value assignment to states of affairs, there exists a world realizing it. The proof is beautifully trivial: in our encoding, a truth-value assignment `S -> Prop` literally *is* a `World S`. The witness is the assignment itself.\n\n**[Interpretive choice]** This triviality is both a strength and a limitation. It means independence is *built into the encoding* rather than *proved from it*. A richer encoding \u2014 where states of affairs had internal structure involving shared objects \u2014 would make independence a substantive theorem requiring proof. Our encoding achieves independence 'for free' by design, which is faithful to the Tractatus's treatment of it as foundational rather than derived.",
+    "mathContext": "The proof: `IndependentWorlds.realizable assignment` delegates to the `IndependentWorlds` typeclass instance. The witness is `\u27e8assignment, fun s => Iff.rfl\u27e9` \u2014 the assignment itself is the world, and the realization condition holds by reflexivity of `\u2194`. The triviality of this proof reveals that in the free model, independence is a *definitional* rather than *substantive* property.",
     "significance": "key",
     "prerequisites": [
       "TLP 2.061",
@@ -445,10 +445,10 @@
       "startLine": 450,
       "endLine": 452
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Double Negation (Classical Logic)",
     "content": "Double negation elimination: $\\neg\\neg p \\leftrightarrow p$ in every world. This uses `not_not` from Mathlib, which depends on `Classical.em`. The Tractatus assumes classical logic; an intuitionist would reject this equivalence, accepting only the left-to-right direction ($p \\to \\neg\\neg p$).",
-    "mathContext": "Formally: `∀ (p : Proposition S) (w : World S), p.eval (Proposition.neg (Proposition.neg p)) w ↔ p.eval w`. The proof unfolds `Proposition.eval` on the double negation, then applies `not_not : ¬¬P ↔ P` (from `Mathlib.Tactic`, which imports `Classical.em`). Constructive alternatives would prove only the weaker `p.eval w → ¬¬ p.eval w`.",
+    "mathContext": "Formally: `\u2200 (p : Proposition S) (w : World S), p.eval (Proposition.neg (Proposition.neg p)) w \u2194 p.eval w`. The proof unfolds `Proposition.eval` on the double negation, then applies `not_not : \u00ac\u00acP \u2194 P` (from `Mathlib.Tactic`, which imports `Classical.em`). Constructive alternatives would prove only the weaker `p.eval w \u2192 \u00ac\u00ac p.eval w`.",
     "significance": "supporting",
     "prerequisites": [
       "classical logic",
@@ -469,10 +469,10 @@
       "startLine": 463,
       "endLine": 471
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "De Morgan's Laws (TLP 5.101)",
-    "content": "De Morgan's laws verify that our definitions of derived connectives produce the expected semantics. The first law: $(p \\lor q)$ — defined as $\\neg(\\neg p \\land \\neg q)$ — evaluates to $p.\\text{eval}(w) \\lor q.\\text{eval}(w)$. The second: $\\neg(p \\land q)$ evaluates to $\\neg p.\\text{eval}(w) \\lor \\neg q.\\text{eval}(w)$.\n\nThese confirm that the $\\{\\neg, \\land\\}$ basis generates the full propositional calculus as Wittgenstein claims in TLP 5.101.",
-    "mathContext": "The `simp` tactic with `not_and_or` and `not_not` rewrites the nested negations into the standard disjunctive form. These are classical equivalences — `not_and_or` states $\\neg(P \\land Q) \\leftrightarrow \\neg P \\lor \\neg Q$.",
+    "content": "De Morgan's laws verify that our definitions of derived connectives produce the expected semantics. The first law: $(p \\lor q)$ \u2014 defined as $\\neg(\\neg p \\land \\neg q)$ \u2014 evaluates to $p.\\text{eval}(w) \\lor q.\\text{eval}(w)$. The second: $\\neg(p \\land q)$ evaluates to $\\neg p.\\text{eval}(w) \\lor \\neg q.\\text{eval}(w)$.\n\nThese confirm that the $\\{\\neg, \\land\\}$ basis generates the full propositional calculus as Wittgenstein claims in TLP 5.101.",
+    "mathContext": "The `simp` tactic with `not_and_or` and `not_not` rewrites the nested negations into the standard disjunctive form. These are classical equivalences \u2014 `not_and_or` states $\\neg(P \\land Q) \\leftrightarrow \\neg P \\lor \\neg Q$.",
     "significance": "key",
     "prerequisites": [
       "propositional logic",
@@ -494,9 +494,9 @@
       "startLine": 481,
       "endLine": 486
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Excluded Middle as Tautology (TLP 4.46)",
-    "content": "$p \\lor \\neg p$ is a tautology — it holds in every world. This is the paradigmatic example of TLP 6.1: a 'proposition of logic' that is true regardless of which states of affairs obtain. For Wittgenstein, this does not say something *about* the world; it shows something about the structure of logical space.",
+    "content": "$p \\lor \\neg p$ is a tautology \u2014 it holds in every world. This is the paradigmatic example of TLP 6.1: a 'proposition of logic' that is true regardless of which states of affairs obtain. For Wittgenstein, this does not say something *about* the world; it shows something about the structure of logical space.",
     "mathContext": "The proof first applies `simp` to reduce the disjunction (defined via double negation) to a standard form, then invokes `Classical.em` to supply the excluded middle instance.",
     "significance": "key",
     "prerequisites": [
@@ -520,10 +520,10 @@
       "startLine": 495,
       "endLine": 499
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "p and not-p Is a Contradiction",
-    "content": "$p \\land \\neg p$ holds in no world — the paradigmatic contradiction. The proof is immediate: `simp [Proposition.eval]` decomposes the conjunction into $p.\\text{eval}(w)$ and $\\neg p.\\text{eval}(w)$, which are directly contradictory.",
-    "mathContext": "Formally: `IsContradiction (Proposition.conj p (Proposition.neg p))`. After unfolding `Proposition.eval`, the goal becomes `¬(p.eval w ∧ ¬ p.eval w)`, which is `not_and_not_self : ¬(P ∧ ¬P)` — a theorem provable constructively (no classical axiom needed). This is the non-contradiction law, the dual of excluded middle.",
+    "content": "$p \\land \\neg p$ holds in no world \u2014 the paradigmatic contradiction. The proof is immediate: `simp [Proposition.eval]` decomposes the conjunction into $p.\\text{eval}(w)$ and $\\neg p.\\text{eval}(w)$, which are directly contradictory.",
+    "mathContext": "Formally: `IsContradiction (Proposition.conj p (Proposition.neg p))`. After unfolding `Proposition.eval`, the goal becomes `\u00ac(p.eval w \u2227 \u00ac p.eval w)`, which is `not_and_not_self : \u00ac(P \u2227 \u00acP)` \u2014 a theorem provable constructively (no classical axiom needed). This is the non-contradiction law, the dual of excluded middle.",
     "significance": "supporting",
     "prerequisites": [
       "propositional logic",
@@ -543,10 +543,10 @@
       "startLine": 508,
       "endLine": 522
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Implication and Biconditional Semantics",
     "content": "These theorems verify that the derived connectives have their standard semantics:\n- $(p \\to q).\\text{eval}(w) \\leftrightarrow (p.\\text{eval}(w) \\to q.\\text{eval}(w))$\n- $(p \\leftrightarrow q).\\text{eval}(w) \\leftrightarrow (p.\\text{eval}(w) \\leftrightarrow q.\\text{eval}(w))$\n\nThe `tauto` tactic handles the classical propositional reasoning after `simp` normalizes the definitions.",
-    "mathContext": "These are **semantic adequacy theorems**: they verify that the syntactic definitions of `→` and `↔` (both encoded via `¬` and `∧`) produce the right semantic behavior. Without them, we could only claim that the definitions typecheck — not that they mean what we intend. The `tauto` tactic is a complete decision procedure for classical propositional logic, so both proofs are fully automated.",
+    "mathContext": "These are **semantic adequacy theorems**: they verify that the syntactic definitions of `\u2192` and `\u2194` (both encoded via `\u00ac` and `\u2227`) produce the right semantic behavior. Without them, we could only claim that the definitions typecheck \u2014 not that they mean what we intend. The `tauto` tactic is a complete decision procedure for classical propositional logic, so both proofs are fully automated.",
     "significance": "supporting",
     "prerequisites": [
       "propositional logic",
@@ -567,10 +567,10 @@
       "startLine": 534,
       "endLine": 538
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Modus Ponens (Metalogical, TLP 4.121)",
-    "content": "If $p \\to q$ is true in a world and $p$ is true in that world, then $q$ is true in that world. This is a meta-theorem: it is proved in Lean (the metalanguage) *about* propositions in our object language.\n\nThis is precisely the kind of thing Wittgenstein says can be *shown* by the symbolism but not *said* within it (TLP 4.121: 'What can be shown cannot be said'). The formal system shows that modus ponens preserves truth — it does not contain a proposition asserting this fact. Our Lean theorem *says* what the Tractarian framework can only *show*.",
-    "mathContext": "The proof rewrites the implication hypothesis using `impl_semantics`, then applies it to the premise. This two-step pattern — semantic reduction, then function application — mirrors the informal reasoning.",
+    "content": "If $p \\to q$ is true in a world and $p$ is true in that world, then $q$ is true in that world. This is a meta-theorem: it is proved in Lean (the metalanguage) *about* propositions in our object language.\n\nThis is precisely the kind of thing Wittgenstein says can be *shown* by the symbolism but not *said* within it (TLP 4.121: 'What can be shown cannot be said'). The formal system shows that modus ponens preserves truth \u2014 it does not contain a proposition asserting this fact. Our Lean theorem *says* what the Tractarian framework can only *show*.",
+    "mathContext": "The proof rewrites the implication hypothesis using `impl_semantics`, then applies it to the premise. This two-step pattern \u2014 semantic reduction, then function application \u2014 mirrors the informal reasoning.",
     "significance": "key",
     "prerequisites": [
       "propositional logic",
@@ -593,10 +593,10 @@
       "startLine": 550,
       "endLine": 558
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "NAND Functional Completeness (TLP 5.5)",
     "content": "TLP 5.5 anticipates the Sheffer stroke: all truth-functions can be derived from a single binary operation. We show:\n- $\\text{nand}(p, p)$ is equivalent to $\\neg p$ (NAND with itself gives negation)\n- $\\neg\\text{nand}(p, q)$ is equivalent to $p \\land q$ (negated NAND gives conjunction)\n\nSince $\\{\\neg, \\land\\}$ is functionally complete, and both are expressible via NAND, NAND alone suffices for all truth-functions. Wittgenstein's insight (shared with Sheffer, 1913) is that the apparent multiplicity of logical connectives conceals a deeper unity.",
-    "mathContext": "The first proof uses `tauto` after simplification — the equivalence $\\neg(p \\land p) \\leftrightarrow \\neg p$ follows from the idempotence of conjunction. The second uses `not_not` to eliminate the double negation.",
+    "mathContext": "The first proof uses `tauto` after simplification \u2014 the equivalence $\\neg(p \\land p) \\leftrightarrow \\neg p$ follows from the idempotence of conjunction. The second uses `not_not` to eliminate the double negation.",
     "significance": "key",
     "prerequisites": [
       "propositional logic",
@@ -620,10 +620,10 @@
       "startLine": 594,
       "endLine": 605
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "[Main Result] Independence is a Modeling Choice",
     "content": "constrained_independence_fails proves that IndependentWorlds fails for the constrained model when the two distinguished states of affairs are distinct. The assignment {a -> True, b -> False} has no constrained realizer, because the constraint b-must-obtain-when-a-does prevents such an assignment from being a world. This demonstrates that independence is not a logical law but a property of the chosen world model. The Tractatus builds independence into its ontology (TLP 2.061); our formalization makes this assumption explicit and shows precisely where it breaks.",
-    "mathContext": "Formally: `¬ ∀ assignment : S → Prop, ∃ cw : ConstrainedWorld S a b, ∀ s, cw.val s ↔ assignment s`. The witness assignment is `fun s => s = a` (only `a` obtains). A constrained world requires `w a → w b`, so any world realizing this assignment must have `w b`, i.e., `b = a`. Since `a ≠ b` (hypothesis), no constrained world exists. The proof is by contradiction using `absurd`.",
+    "mathContext": "Formally: `\u00ac \u2200 assignment : S \u2192 Prop, \u2203 cw : ConstrainedWorld S a b, \u2200 s, cw.val s \u2194 assignment s`. The witness assignment is `fun s => s = a` (only `a` obtains). A constrained world requires `w a \u2192 w b`, so any world realizing this assignment must have `w b`, i.e., `b = a`. Since `a \u2260 b` (hypothesis), no constrained world exists. The proof is by contradiction using `absurd`.",
     "significance": "key",
     "prerequisites": [
       "TLP 2.061",
@@ -646,7 +646,7 @@
       "startLine": 644,
       "endLine": 648
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Constrained Models: Weather Example and Independence Failure",
     "content": "The `weatherModel` is a concrete constrained model with three states of affairs (rain, clouds, snow) and one structural constraint: rain implies clouds. A world is a subtype `{ w : WeatherFacts -> Prop // w .rain -> w .clouds }` -- only truth-value assignments satisfying the constraint count as possible worlds.\n\nThe key theorem `weather_independence_fails` proves that in this model, there is no world where rain holds but clouds does not. This is a direct failure of elementary independence (Theorem 5): in the free model, the assignment {rain := True, clouds := False, snow := anything} is a valid world, but in the weather model it violates the constraint.\n\nThis demonstrates the philosophical point: independence is a property of the *model*, not of propositional logic itself. The Tractatus builds independence into its ontology (TLP 2.061); our formalization makes this assumption explicit and shows what happens when it is relaxed.",
     "mathContext": "The proof of `weather_independence_fails` is a clean contradiction: given a hypothetical world `w` with `w.val .rain` and `not w.val .clouds`, we apply `w.property` (the constraint `w.val .rain -> w.val .clouds`) to the first hypothesis, obtaining `w.val .clouds`, which contradicts the second hypothesis.",
@@ -675,7 +675,7 @@
     },
     "type": "concept",
     "title": "Concrete Examples: From Abstract to Computable",
-    "content": "The Tractarian machinery above is parametric in an abstract type `S` of states of affairs. Here we instantiate `S` with a concrete two-element type (`TwoFacts`: rain and snow) to make the formalization interactive.\n\nTwo kinds of evaluation are demonstrated:\n- **Prop-valued** (`eval`): the `example` proofs confirm that `itRains` holds in `rainyWorld` and `itSnows` does not. These are type-checked but not executable.\n- **Bool-valued** (`evalBool`): the `#eval` calls compute truth values at elaboration time, printing `true` or `false` in the Lean infoview. This makes the formalization tangible — readers can modify the world and see results immediately.\n\nThe `TwoFacts` type derives `DecidableEq`, `Repr`, and `Fintype`, making it suitable for both decidable evaluation and (in principle) exhaustive truth-table enumeration.",
+    "content": "The Tractarian machinery above is parametric in an abstract type `S` of states of affairs. Here we instantiate `S` with a concrete two-element type (`TwoFacts`: rain and snow) to make the formalization interactive.\n\nTwo kinds of evaluation are demonstrated:\n- **Prop-valued** (`eval`): the `example` proofs confirm that `itRains` holds in `rainyWorld` and `itSnows` does not. These are type-checked but not executable.\n- **Bool-valued** (`evalBool`): the `#eval` calls compute truth values at elaboration time, printing `true` or `false` in the Lean infoview. This makes the formalization tangible \u2014 readers can modify the world and see results immediately.\n\nThe `TwoFacts` type derives `DecidableEq`, `Repr`, and `Fintype`, making it suitable for both decidable evaluation and (in principle) exhaustive truth-table enumeration.",
     "mathContext": "The `Fintype` instance certifies that `TwoFacts` has finitely many inhabitants. Combined with `DecidableEq`, this would allow enumerating all $2^2 = 4$ possible worlds and computing a complete truth table. The `Repr` instance enables `#eval` to print the type's constructors.",
     "significance": "key",
     "prerequisites": [
@@ -729,10 +729,10 @@
       "startLine": 49,
       "endLine": 55
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "First-Order Compositionality (TLP 5, extended) [Companion File]",
-    "content": "The compositionality theorem — if two worlds agree on all elementary states of affairs, they agree on every proposition — extends to the first-order language including quantifiers.\n\nThe proof by structural induction on `FOProp` handles five cases. The propositional cases (`lift`, `negFO`, `conjFO`) are routine. The quantifier cases are the interesting ones: for `forall_ f`, the induction hypothesis states that compositionality holds for `f d` for each `d : D`. We apply it pointwise to transfer the universal quantification from one world to the other.\n\nThis theorem validates Wittgenstein's thesis (TLP 5) in the extended setting: truth-values of first-order propositions are still determined entirely by elementary truth-values, even when quantifiers range over an external domain.",
-    "mathContext": "The key technical step is that Lean's recursor for HOAS inductives provides an induction hypothesis of the form `forall d, (f d).eval w1 <-> (f d).eval w2`, which is exactly what is needed. This is stronger than what a naive induction would provide — it quantifies over all domain elements, not just structurally smaller terms.",
+    "content": "The compositionality theorem \u2014 if two worlds agree on all elementary states of affairs, they agree on every proposition \u2014 extends to the first-order language including quantifiers.\n\nThe proof by structural induction on `FOProp` handles five cases. The propositional cases (`lift`, `negFO`, `conjFO`) are routine. The quantifier cases are the interesting ones: for `forall_ f`, the induction hypothesis states that compositionality holds for `f d` for each `d : D`. We apply it pointwise to transfer the universal quantification from one world to the other.\n\nThis theorem validates Wittgenstein's thesis (TLP 5) in the extended setting: truth-values of first-order propositions are still determined entirely by elementary truth-values, even when quantifiers range over an external domain.",
+    "mathContext": "The key technical step is that Lean's recursor for HOAS inductives provides an induction hypothesis of the form `forall d, (f d).eval w1 <-> (f d).eval w2`, which is exactly what is needed. This is stronger than what a naive induction would provide \u2014 it quantifies over all domain elements, not just structurally smaller terms.",
     "significance": "key",
     "prerequisites": [
       "first-order logic",
@@ -757,8 +757,8 @@
     },
     "type": "insight",
     "title": "The Infinite Domain Problem (TLP 5.52, Geach 1981, Soames 1983) [Companion File]",
-    "content": "TLP 5.52 claims quantifiers are N-operator applications: the universal quantifier over f(x) is N applied to all values {f(a), f(b), f(c), ...}. For finite domains this works — the universal quantifier is a finite conjunction, and the N-operator handles finite lists.\n\nFor infinite domains, Wittgenstein's claim is philosophically problematic. The N-operator is a finitary syntactic construction: it takes a finite list of propositions and produces their joint denial. Applying it to infinitely many values requires an infinitary extension that the Tractatus does not provide.\n\nGeach (1981) argues this is a fundamental gap: the Tractatus cannot express genuinely infinite quantification within its truth-functional framework. Soames (1983) strengthens the point, showing that the claim in TLP 5 — that all propositions are truth-functions of elementary propositions — fails for infinite-domain quantification.\n\nOur formalization sidesteps this problem by defining `FOProp.eval` directly using Lean's `forall` and `exists`, which handle infinite domains natively. The philosophical question — whether Wittgenstein's finitary framework can be extended to the infinite case — remains open.",
-    "mathContext": "Lean's `∀ x : D, P x` and `∃ x : D, P x` work for any type `D`, including infinite types like `ℕ` or `ℝ`. The `FOProp.eval` function uses these natively: `(forall_ f).eval w := ∀ d : D, (f d).eval w`. This is an infinitary extension of the finitary N-operator — we adopt Lean's metatheoretic `∀` rather than constructing an object-level infinite conjunction. Geach's objection applies to the Tractarian N-operator, not to this HOAS encoding.",
+    "content": "TLP 5.52 claims quantifiers are N-operator applications: the universal quantifier over f(x) is N applied to all values {f(a), f(b), f(c), ...}. For finite domains this works \u2014 the universal quantifier is a finite conjunction, and the N-operator handles finite lists.\n\nFor infinite domains, Wittgenstein's claim is philosophically problematic. The N-operator is a finitary syntactic construction: it takes a finite list of propositions and produces their joint denial. Applying it to infinitely many values requires an infinitary extension that the Tractatus does not provide.\n\nGeach (1981) argues this is a fundamental gap: the Tractatus cannot express genuinely infinite quantification within its truth-functional framework. Soames (1983) strengthens the point, showing that the claim in TLP 5 \u2014 that all propositions are truth-functions of elementary propositions \u2014 fails for infinite-domain quantification.\n\nOur formalization sidesteps this problem by defining `FOProp.eval` directly using Lean's `forall` and `exists`, which handle infinite domains natively. The philosophical question \u2014 whether Wittgenstein's finitary framework can be extended to the infinite case \u2014 remains open.",
+    "mathContext": "Lean's `\u2200 x : D, P x` and `\u2203 x : D, P x` work for any type `D`, including infinite types like `\u2115` or `\u211d`. The `FOProp.eval` function uses these natively: `(forall_ f).eval w := \u2200 d : D, (f d).eval w`. This is an infinitary extension of the finitary N-operator \u2014 we adopt Lean's metatheoretic `\u2200` rather than constructing an object-level infinite conjunction. Geach's objection applies to the Tractarian N-operator, not to this HOAS encoding.",
     "significance": "key",
     "prerequisites": [
       "TLP 5.52",
@@ -784,10 +784,10 @@
       "startLine": 997,
       "endLine": 1006
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "[Main Result] Structural and Semantic Equivalence Diverge",
     "content": "structEq_ne_semEq proves that structural and semantic equivalence are genuinely different relations: there exist propositions that are semantically equivalent (same truth value in every possible world) but not structurally equivalent (different syntactic trees). The witness is neg(neg(elementary s)) vs elementary s: double negation gives semantic equivalence, but the syntactic trees have different shapes. This makes explicit what the formalization captures (truth conditions) and what it cannot (logical form). With the introduction of formEq, this is now contextualized within the three-level hierarchy structEq < formEq < semEq.",
-    "mathContext": "Formally: `∃ (p q : Proposition S), Proposition.semEq p q ∧ ¬ Proposition.structEq p q`. The witness pair is `(neg (neg (elementary s)), elementary s)`. Semantic equivalence holds because double negation elimination is valid classically (`not_not`). Structural non-equivalence holds because the two syntax trees have different depth (2 vs 0 `neg` constructors) — Lean can confirm this by case analysis on the inductive type.",
+    "mathContext": "Formally: `\u2203 (p q : Proposition S), Proposition.semEq p q \u2227 \u00ac Proposition.structEq p q`. The witness pair is `(neg (neg (elementary s)), elementary s)`. Semantic equivalence holds because double negation elimination is valid classically (`not_not`). Structural non-equivalence holds because the two syntax trees have different depth (2 vs 0 `neg` constructors) \u2014 Lean can confirm this by case analysis on the inductive type.",
     "significance": "key",
     "prerequisites": [
       "TLP 4.0141",
@@ -813,8 +813,8 @@
     },
     "type": "insight",
     "title": "Analytical Decomposition: Invariance vs Dependence vs Limits",
-    "content": "The formalization's 25 theorems divide sharply into three classes, and the division is philosophically decisive.\n\n**Core invariants** hold in every WorldModel with no assumptions beyond classical logic: compositionality (`truth_functional_compositionality_gen`), bivalence (`elem_prop_bivalence`), double negation, De Morgan laws. These are properties of the *proposition grammar itself* — they would hold in any model-theoretic semantics for this language.\n\n**Model assumptions** hold in the free model (where `World S = S -> Prop`) but can fail in constrained models: `elementary_independence` is the canonical example. It is not a theorem of propositional logic — it is a choice about which functions count as worlds. The `weatherModel` and `ConstrainedWorld` demonstrate that relaxing this choice breaks independence while preserving all core invariants.\n\n**Formal limits** are provable *boundaries* of the system: `saying_showing_triviality` and `nontrivial_expressibility_requires_world_dependence` prove exactly what the object language can and cannot express. `structEq_ne_semEq` (the structural vs semantic divergence) proves that truth-conditional equivalence is strictly weaker than syntactic identity.\n\nThe Tractatus is not a set of truths about the world — it is a specification of a semantic architecture. This classification makes that architecture explicit: what is logical structure, what is ontological assumption, and what is provable boundary.",
-    "mathContext": "The three-way classification maps to standard model-theoretic vocabulary: core invariants correspond to valid sentences (true in all models), model assumptions correspond to sentences whose truth depends on which model is selected, and formal limits correspond to incompleteness results — proven boundaries on expressive power. The classification is verified by inspecting each theorem's proof: invariants use only structural induction and classical propositional lemmas; model assumptions invoke the `IndependentWorlds` typeclass or the `freeModel` instance; limits invoke the `saying_showing_triviality` family.",
+    "content": "The formalization's 25 theorems divide sharply into three classes, and the division is philosophically decisive.\n\n**Core invariants** hold in every WorldModel with no assumptions beyond classical logic: compositionality (`truth_functional_compositionality_gen`), bivalence (`elem_prop_bivalence`), double negation, De Morgan laws. These are properties of the *proposition grammar itself* \u2014 they would hold in any model-theoretic semantics for this language.\n\n**Model assumptions** hold in the free model (where `World S = S -> Prop`) but can fail in constrained models: `elementary_independence` is the canonical example. It is not a theorem of propositional logic \u2014 it is a choice about which functions count as worlds. The `weatherModel` and `ConstrainedWorld` demonstrate that relaxing this choice breaks independence while preserving all core invariants.\n\n**Formal limits** are provable *boundaries* of the system: `saying_showing_triviality` and `nontrivial_expressibility_requires_world_dependence` prove exactly what the object language can and cannot express. `structEq_ne_semEq` (the structural vs semantic divergence) proves that truth-conditional equivalence is strictly weaker than syntactic identity.\n\nThe Tractatus is not a set of truths about the world \u2014 it is a specification of a semantic architecture. This classification makes that architecture explicit: what is logical structure, what is ontological assumption, and what is provable boundary.",
+    "mathContext": "The three-way classification maps to standard model-theoretic vocabulary: core invariants correspond to valid sentences (true in all models), model assumptions correspond to sentences whose truth depends on which model is selected, and formal limits correspond to incompleteness results \u2014 proven boundaries on expressive power. The classification is verified by inspecting each theorem's proof: invariants use only structural induction and classical propositional lemmas; model assumptions invoke the `IndependentWorlds` typeclass or the `freeModel` instance; limits invoke the `saying_showing_triviality` family.",
     "significance": "key",
     "prerequisites": [
       "model theory",
@@ -843,7 +843,7 @@
       "startLine": 1106,
       "endLine": 1112
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Central Result: Expressibility Requires World-Dependence",
     "content": "Any attempt to represent world-independent content in a truth-functional language collapses to triviality; therefore, meaningful propositions must correspond to variation across possible worlds.\n\nThe argument proceeds in two steps. First, `world_constant_taut_or_contra` shows that any proposition with the same truth value in all worlds is either a tautology or a contradiction. Second, `saying_showing_triviality` applies this to the `expresses` relation: if a proposition tracks a fixed meta-level property P in every world, its truth value is world-constant, so it collapses to a tautology (when P is true) or a contradiction (when P is false). The downstream theorems `nontrivial_expressibility_requires_world_dependence` and `nontrivial_cannot_express_world_independent` derive that nontrivial propositions -- those that are true in some worlds and false in others -- cannot express any world-independent content at all.",
     "mathContext": "The key lemma `world_constant_taut_or_contra` uses `Classical.em` (via `by_cases`) to split on whether the proposition holds in a reference world. The `saying_showing_triviality` theorem reduces the `expresses` hypothesis to the world-constant case via transitivity of biconditionals. Together they establish a provable boundary on the expressive power of the object language: the only world-independent facts it can represent are the trivially true and the trivially false.",
@@ -875,14 +875,14 @@
     },
     "type": "insight",
     "title": "The Ladder (TLP 6.54)",
-    "content": "TLP 6.54: 'My propositions serve as elucidations in the following way: anyone who understands me eventually recognizes them as nonsensical, when he has used them — as steps — to climb beyond them. He must, so to speak, throw away the ladder after he has climbed up it.'\n\nEverything above is the ladder. The view from the top — that logical form is shared between language and reality rather than represented by either — is precisely what Lean, or any formal system, shows through its structure rather than states as a theorem. The residue left over after formalization is the most Wittgensteinian part.\n\n**[Interpretive choice]** The Tractatus is self-consciously paradoxical: it uses meaningful propositions to argue that certain things cannot be meaningfully said. Any formalization must pick a side — either the ladder is meaningful (in which case the self-undermining thesis fails) or it is not (in which case the formalization formalizes nothing). We take the first option: the formal skeleton is mathematically meaningful, and the philosophical claim about its limitations is carried by the annotations, not the code.",
-    "mathContext": "The self-undermining character of TLP 6.54 is formally analogous to Gödel's incompleteness: a system powerful enough to express its own limitations is powerful enough to expose them as limitations. In Lean, the theorems about what the object language *cannot* say (`saying_showing_triviality`, `nontrivial_cannot_express_world_independent`) are provable *in the metalanguage* — they use Lean's full logical power. The object language itself cannot state them — that is precisely TLP 6.54's point.",
+    "content": "TLP 6.54: 'My propositions serve as elucidations in the following way: anyone who understands me eventually recognizes them as nonsensical, when he has used them \u2014 as steps \u2014 to climb beyond them. He must, so to speak, throw away the ladder after he has climbed up it.'\n\nEverything above is the ladder. The view from the top \u2014 that logical form is shared between language and reality rather than represented by either \u2014 is precisely what Lean, or any formal system, shows through its structure rather than states as a theorem. The residue left over after formalization is the most Wittgensteinian part.\n\n**[Interpretive choice]** The Tractatus is self-consciously paradoxical: it uses meaningful propositions to argue that certain things cannot be meaningfully said. Any formalization must pick a side \u2014 either the ladder is meaningful (in which case the self-undermining thesis fails) or it is not (in which case the formalization formalizes nothing). We take the first option: the formal skeleton is mathematically meaningful, and the philosophical claim about its limitations is carried by the annotations, not the code.",
+    "mathContext": "The self-undermining character of TLP 6.54 is formally analogous to G\u00f6del's incompleteness: a system powerful enough to express its own limitations is powerful enough to expose them as limitations. In Lean, the theorems about what the object language *cannot* say (`saying_showing_triviality`, `nontrivial_cannot_express_world_independent`) are provable *in the metalanguage* \u2014 they use Lean's full logical power. The object language itself cannot state them \u2014 that is precisely TLP 6.54's point.",
     "significance": "key",
     "prerequisites": [
       "TLP 6.54",
       "saying vs showing",
       "metalanguage vs object language",
-      "Gödel incompleteness"
+      "G\u00f6del incompleteness"
     ],
     "relatedConcepts": [
       "TLP 6.54",
@@ -899,9 +899,9 @@
       "startLine": 1174,
       "endLine": 1228
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Proposition 7 (TLP 7)",
-    "content": "TLP 7: *Wovon man nicht sprechen kann, darueber muss man schweigen.* — 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem `proposition_seven` proves that any proposition expressing a world-independent truth must be either a tautology or a contradiction. The object language can formally match any world-independent truth P — a tautology matches True, a contradiction matches False — but this matching is trivial. The proposition does not 'say' P in any meaningful sense.\n\nThe `axiom silence : True` enacts Wittgenstein's silence as a formal gesture — a deliberately axiomatic declaration that marks the boundary of formalization. It is trivially true but axiomatic by design, not by necessity.",
+    "content": "TLP 7: *Wovon man nicht sprechen kann, darueber muss man schweigen.* \u2014 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem `proposition_seven` proves that any proposition expressing a world-independent truth must be either a tautology or a contradiction. The object language can formally match any world-independent truth P \u2014 a tautology matches True, a contradiction matches False \u2014 but this matching is trivial. The proposition does not 'say' P in any meaningful sense.\n\nThe `axiom silence : True` enacts Wittgenstein's silence as a formal gesture \u2014 a deliberately axiomatic declaration that marks the boundary of formalization. It is trivially true but axiomatic by design, not by necessity.",
     "mathContext": "The type of `proposition_seven` is `forall (q : Proposition S) (P : Prop), [Nonempty S] -> (forall w : World S, q.eval w <-> P) -> IsTautology q or IsContradiction q`. This says: if a proposition's truth value is the same constant P in every world, then the proposition must be a tautology (if P is true) or a contradiction (if P is false). No proposition can non-trivially express a metalogical property.",
     "significance": "key",
     "prerequisites": [
@@ -929,8 +929,8 @@
     },
     "type": "concept",
     "title": "First-Order Extension: FOProp (TLP 5.52) [Companion File]",
-    "content": "TLP 5.52: 'If the values of xi are the total values of a function f(x) for all values of x, then N(xi) = ~(exists x).f(x).'\n\nThe companion file TractatusQuantifiers.lean extends the propositional calculus with first-order quantifiers. The type `FOProp S D` adds universal and existential quantification over a domain `D` to the propositional base.\n\nThe binding mechanism uses higher-order abstract syntax (HOAS): `forall_ : (D -> FOProp S D) -> FOProp S D`. Lean functions represent variable binding, avoiding the machinery of variable names, alpha-equivalence, and capture-avoiding substitution. The tradeoff is that induction over HOAS terms requires care — Lean's structural recursion handles evaluation, but proof by induction requires the recursor to supply induction hypotheses that apply pointwise under binders.\n\n**[Interpretive choice]** HOAS imports Lean's own binding mechanism into the object language. A purist encoding would use de Bruijn indices, which are self-contained but harder to read. We chose HOAS for clarity, accepting that it ties the formalization more tightly to Lean's metatheory.",
-    "mathContext": "The `FOProp` inductive type has five constructors: `lift` (embed propositional formulas), `negFO`, `conjFO`, `forall_`, and `exists_`. The `lift` constructor makes the extension conservative — every propositional formula is a first-order formula. Lean accepts the HOAS constructors because the occurrences of `FOProp` in `D -> FOProp S D` are strictly positive.",
+    "content": "TLP 5.52: 'If the values of xi are the total values of a function f(x) for all values of x, then N(xi) = ~(exists x).f(x).'\n\nThe companion file TractatusQuantifiers.lean extends the propositional calculus with first-order quantifiers. The type `FOProp S D` adds universal and existential quantification over a domain `D` to the propositional base.\n\nThe binding mechanism uses higher-order abstract syntax (HOAS): `forall_ : (D -> FOProp S D) -> FOProp S D`. Lean functions represent variable binding, avoiding the machinery of variable names, alpha-equivalence, and capture-avoiding substitution. The tradeoff is that induction over HOAS terms requires care \u2014 Lean's structural recursion handles evaluation, but proof by induction requires the recursor to supply induction hypotheses that apply pointwise under binders.\n\n**[Interpretive choice]** HOAS imports Lean's own binding mechanism into the object language. A purist encoding would use de Bruijn indices, which are self-contained but harder to read. We chose HOAS for clarity, accepting that it ties the formalization more tightly to Lean's metatheory.",
+    "mathContext": "The `FOProp` inductive type has five constructors: `lift` (embed propositional formulas), `negFO`, `conjFO`, `forall_`, and `exists_`. The `lift` constructor makes the extension conservative \u2014 every propositional formula is a first-order formula. Lean accepts the HOAS constructors because the occurrences of `FOProp` in `D -> FOProp S D` are strictly positive.",
     "significance": "key",
     "prerequisites": [
       "first-order logic",


### PR DESCRIPTION
Schema fix batch: corrects annotation types that don't match the valid schema (concept | definition | technique | insight | context).

## Entries Fixed

| Proof | Type Fixes |
|-------|-----------|
| mean-value-theorem-oq-03 | 12 (theorem→insight) |
| binomial-theorem-oq-03 | 12 (theorem→insight) |
| inverse-galois-oq-01 | 16 (theorem→insight) |
| tractatus-ontology | 19 (theorem→insight, axiom→concept) |

**Total: 59 annotation type fixes**

## Labels
enrichment