### PR TITLE
enrich(batch): full schema rewrites + 67 annotation type fixes

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal/annotations.json
@@ -8,12 +8,12 @@
     },
     "type": "concept",
     "title": "Motivation: Eliminating the cos20_gal_order Axiom",
-    "content": "The module-level comment sets out the entire proof strategy in compact form before any Lean code appears. It explains three things: (1) the polynomial p = 8X³-6X-1 arises from cos(3·20°) = 1/2 via the triple-angle formula, giving the three roots cos(20°), cos(100°), cos(220°); (2) the key algebraic identities showing β = 2α²-α-1 and γ = 1-2α² are roots when α is, allowing all roots to be expressed purely in terms of α; (3) how these identities imply [SplittingField:ℚ] = 3, hence |Gal| = 3.\n\nCritically, the comment also states the proof's raison d'être: eliminating the `cos20_gal_order` axiom from `AngleTrisectionOQ02.lean`. That file had assumed |Gal| = 3 as an axiom (tagged `axiomatized`) — this file promotes the result to fully verified (`badge: original, sorries: 0, axiomCount: 0`).",
-    "mathContext": "Triple-angle formula: $\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta$. At $\\theta = 20°$: $4\\cos^3(20°) - 3\\cos(20°) = \\cos(60°) = \\frac{1}{2}$, so $\\cos(20°)$ satisfies $8x^3 - 6x - 1 = 0$. The three roots are $\\cos(20°), \\cos(100°), \\cos(220°)$, corresponding to the three solutions of $3\\theta \\equiv 60° \\pmod{360°}$.",
+    "content": "The module-level comment sets out the entire proof strategy in compact form before any Lean code appears. It explains three things: (1) the polynomial p = 8X\u00b3-6X-1 arises from cos(3\u00b720\u00b0) = 1/2 via the triple-angle formula, giving the three roots cos(20\u00b0), cos(100\u00b0), cos(220\u00b0); (2) the key algebraic identities showing \u03b2 = 2\u03b1\u00b2-\u03b1-1 and \u03b3 = 1-2\u03b1\u00b2 are roots when \u03b1 is, allowing all roots to be expressed purely in terms of \u03b1; (3) how these identities imply [SplittingField:\u211a] = 3, hence |Gal| = 3.\n\nCritically, the comment also states the proof's raison d'\u00eatre: eliminating the `cos20_gal_order` axiom from `AngleTrisectionOQ02.lean`. That file had assumed |Gal| = 3 as an axiom (tagged `axiomatized`) \u2014 this file promotes the result to fully verified (`badge: original, sorries: 0, axiomCount: 0`).",
+    "mathContext": "Triple-angle formula: $\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta$. At $\\theta = 20\u00b0$: $4\\cos^3(20\u00b0) - 3\\cos(20\u00b0) = \\cos(60\u00b0) = \\frac{1}{2}$, so $\\cos(20\u00b0)$ satisfies $8x^3 - 6x - 1 = 0$. The three roots are $\\cos(20\u00b0), \\cos(100\u00b0), \\cos(220\u00b0)$, corresponding to the three solutions of $3\\theta \\equiv 60\u00b0 \\pmod{360\u00b0}$.",
     "significance": "supporting",
     "relatedConcepts": [
       "triple-angle formula",
-      "cos(3θ) = 4cos³θ - 3cosθ",
+      "cos(3\u03b8) = 4cos\u00b3\u03b8 - 3cos\u03b8",
       "axiom elimination",
       "AngleTrisectionOQ02"
     ],
@@ -30,9 +30,9 @@
       "startLine": 40,
       "endLine": 62
     },
-    "type": "theorem",
-    "title": "Algebraic Root Images: All Three Roots Expressible in α",
-    "content": "The three theorems root_image_beta, root_image_gamma, and quadratic_cofactor_root are pure ring identities verifiable by `ring`. They establish the key algebraic fact: if α satisfies 8α³ − 6α − 1 = 0, then β = 2α² − α − 1 and γ = 1 − 2α² are also roots of the same polynomial. The proofs have a uniform structure: expand the target expression algebraically to show it factors as (some polynomial) × (8a³ − 6a − 1), then substitute the hypothesis ha to get 0. This technique — expressing one polynomial relation as a multiple of another using `ring` — is the backbone of the entire splitting field argument.",
+    "type": "insight",
+    "title": "Algebraic Root Images: All Three Roots Expressible in \u03b1",
+    "content": "The three theorems root_image_beta, root_image_gamma, and quadratic_cofactor_root are pure ring identities verifiable by `ring`. They establish the key algebraic fact: if \u03b1 satisfies 8\u03b1\u00b3 \u2212 6\u03b1 \u2212 1 = 0, then \u03b2 = 2\u03b1\u00b2 \u2212 \u03b1 \u2212 1 and \u03b3 = 1 \u2212 2\u03b1\u00b2 are also roots of the same polynomial. The proofs have a uniform structure: expand the target expression algebraically to show it factors as (some polynomial) \u00d7 (8a\u00b3 \u2212 6a \u2212 1), then substitute the hypothesis ha to get 0. This technique \u2014 expressing one polynomial relation as a multiple of another using `ring` \u2014 is the backbone of the entire splitting field argument.",
     "mathContext": "Identities: $8(2\\alpha^2 - \\alpha - 1)^3 - 6(2\\alpha^2 - \\alpha - 1) - 1 = (8\\alpha^3 - 12\\alpha^2 + 3)(8\\alpha^3 - 6\\alpha - 1)$ and $8(1 - 2\\alpha^2)^3 - 6(1 - 2\\alpha^2) - 1 = (-8\\alpha^3 + 6\\alpha - 1)(8\\alpha^3 - 6\\alpha - 1)$. Both vanish when $8\\alpha^3 - 6\\alpha - 1 = 0$.",
     "significance": "key",
     "relatedConcepts": [
@@ -44,7 +44,7 @@
     "prerequisites": [
       "CommRing",
       "ring tactic in Lean 4",
-      "cos(20°), cos(100°), cos(220°) as roots"
+      "cos(20\u00b0), cos(100\u00b0), cos(220\u00b0) as roots"
     ]
   },
   {
@@ -54,9 +54,9 @@
       "startLine": 111,
       "endLine": 149
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Eisenstein Criterion and Gauss's Lemma for Irreducibility",
-    "content": "The irreducibility proof proceeds in two steps. First, q_eis_int_irreducible applies the Eisenstein criterion to q = X³ − 6X² + 9X − 3 ∈ ℤ[X] at the prime p = 3: the lower coefficients (−6, 9, −3) are divisible by 3, the constant term (−3) is not divisible by 9, and the leading coefficient (1) is not divisible by 3. Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` packages these conditions into a single application. Then q_eis_rat_irreducible lifts to ℚ[X] via `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` — a formalization of Gauss's lemma: a primitive polynomial irreducible over ℤ is irreducible over ℚ.",
+    "content": "The irreducibility proof proceeds in two steps. First, q_eis_int_irreducible applies the Eisenstein criterion to q = X\u00b3 \u2212 6X\u00b2 + 9X \u2212 3 \u2208 \u2124[X] at the prime p = 3: the lower coefficients (\u22126, 9, \u22123) are divisible by 3, the constant term (\u22123) is not divisible by 9, and the leading coefficient (1) is not divisible by 3. Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` packages these conditions into a single application. Then q_eis_rat_irreducible lifts to \u211a[X] via `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` \u2014 a formalization of Gauss's lemma: a primitive polynomial irreducible over \u2124 is irreducible over \u211a.",
     "mathContext": "Eisenstein at $p=3$: $q = X^3 - 6X^2 + 9X - 3$ satisfies $3 \\mid -6, 3 \\mid 9, 3 \\mid -3$; $9 \\nmid -3$; $3 \\nmid 1$. Hence $q$ is irreducible over $\\mathbb{Z}$. Gauss's lemma: $q$ is primitive (monic) so irreducibility transfers to $\\mathbb{Q}[X]$.",
     "significance": "key",
     "relatedConcepts": [
@@ -78,9 +78,9 @@
       "startLine": 170,
       "endLine": 237
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Irreducibility Transfers Through Invertible Linear Substitution",
-    "content": "p_irreducible proves p = 8X³ − 6X − 1 is irreducible by reducing to irreducibility of q via the substitution ℓ: X ↦ 2X+2 (with inverse ℓ⁻¹: X ↦ X/2−1). The proof uses the definition of irreducibility directly (not a Mathlib lemma for substitution invariance): if p = a*b, then q = q.comp(ℓ.comp(ℓ⁻¹)) = q.comp(id) = q, and composing the factoring hab with ℓ⁻¹ gives q = (a.comp(ℓ⁻¹)) * (b.comp(ℓ⁻¹)), a factoring of q. Since q is irreducible, one factor is a unit, and the same unit lifts back to a or b via the inverse substitution. Both the ℓ.comp(ℓ⁻¹) = X and ℓ⁻¹.comp(ℓ) = X identities are checked by interval_cases on the coefficient index.",
+    "content": "p_irreducible proves p = 8X\u00b3 \u2212 6X \u2212 1 is irreducible by reducing to irreducibility of q via the substitution \u2113: X \u21a6 2X+2 (with inverse \u2113\u207b\u00b9: X \u21a6 X/2\u22121). The proof uses the definition of irreducibility directly (not a Mathlib lemma for substitution invariance): if p = a*b, then q = q.comp(\u2113.comp(\u2113\u207b\u00b9)) = q.comp(id) = q, and composing the factoring hab with \u2113\u207b\u00b9 gives q = (a.comp(\u2113\u207b\u00b9)) * (b.comp(\u2113\u207b\u00b9)), a factoring of q. Since q is irreducible, one factor is a unit, and the same unit lifts back to a or b via the inverse substitution. Both the \u2113.comp(\u2113\u207b\u00b9) = X and \u2113\u207b\u00b9.comp(\u2113) = X identities are checked by interval_cases on the coefficient index.",
     "mathContext": "If $\\ell = 2X+2$ and $\\ell^{-1} = \\frac{X-2}{2}$, then $p = q \\circ \\ell$. Any factoring $p = ab$ gives $q = q \\circ (\\ell \\circ \\ell^{-1}) = (a \\circ \\ell^{-1}) \\cdot (b \\circ \\ell^{-1})$. Since $q$ is irreducible, one of $a \\circ \\ell^{-1}$, $b \\circ \\ell^{-1}$ is a unit constant $C(c)$, and composing back with $\\ell$ gives $a = C(c)$ or $b = C(c)$, hence a unit.",
     "significance": "key",
     "relatedConcepts": [
@@ -102,16 +102,16 @@
       "startLine": 290,
       "endLine": 311
     },
-    "type": "theorem",
-    "title": "Divisibility Bounds: 3 ∣ |Gal| and |Gal| ∣ 6",
-    "content": "Two divisibility bounds pin |Gal| = 3 from above and below. The lower bound three_dvd_gal_card uses Polynomial.Gal.prime_degree_dvd_card: since p is irreducible of prime degree 3, the Galois group has order divisible by 3 (the degree equals the size of a Gal-orbit on roots, and the orbit size divides |Gal|). The upper bound gal_card_dvd_six uses the injective Galois action on roots: the rootSet has 3 elements (by card_rootSet_eq_natDegree applied to the separable degree-3 polynomial), so Gal embeds into Sym₃ = S₃ with |S₃| = 6. Together: 3 ∣ |Gal| and |Gal| ∣ 6, which with the degree-3 splitting field (proved separately) gives |Gal| = 3.",
+    "type": "insight",
+    "title": "Divisibility Bounds: 3 \u2223 |Gal| and |Gal| \u2223 6",
+    "content": "Two divisibility bounds pin |Gal| = 3 from above and below. The lower bound three_dvd_gal_card uses Polynomial.Gal.prime_degree_dvd_card: since p is irreducible of prime degree 3, the Galois group has order divisible by 3 (the degree equals the size of a Gal-orbit on roots, and the orbit size divides |Gal|). The upper bound gal_card_dvd_six uses the injective Galois action on roots: the rootSet has 3 elements (by card_rootSet_eq_natDegree applied to the separable degree-3 polynomial), so Gal embeds into Sym\u2083 = S\u2083 with |S\u2083| = 6. Together: 3 \u2223 |Gal| and |Gal| \u2223 6, which with the degree-3 splitting field (proved separately) gives |Gal| = 3.",
     "mathContext": "By Galois theory: $|\\text{Gal}(p/\\mathbb{Q})| = [\\text{SplittingField}(p) : \\mathbb{Q}]$ for separable $p$. Also $|\\text{Gal}| \\mid n! = 6$ (permutations of 3 roots) and $3 \\mid |\\text{Gal}|$ (irreducible of prime degree 3). Once $[\\text{SplittingField}:\\mathbb{Q}] = 3$ is established, $|\\text{Gal}| = 3$ follows directly.",
     "significance": "supporting",
     "relatedConcepts": [
       "Polynomial.Gal.prime_degree_dvd_card",
       "Polynomial.Gal.galActionHom_injective",
       "rootSet cardinality",
-      "Sym₃"
+      "Sym\u2083"
     ],
     "prerequisites": [
       "p_irreducible",
@@ -127,9 +127,9 @@
       "startLine": 396,
       "endLine": 444
     },
-    "type": "theorem",
-    "title": "Splitting Field Equals ℚ(α): Root Containment and Degree 3",
-    "content": "rootSet_subset_adjoin proves every root of p in the splitting field lies in ℚ(α). Given a root r, the factored form 8r³−6r−1 = 8(r−α)(r−β)(r−γ) (from factored_eval_eq) combined with r being a root gives 8(r−α)(r−β)(r−γ) = 0. Since the splitting field is a domain and 8 ≠ 0, one factor r−α, r−β, r−γ must be zero, so r ∈ {α, β, γ} ⊆ ℚ(α). Then adjoin_root_eq_top shows ℚ(α) = ⊤ (the whole splitting field) using Polynomial.SplittingField.adjoin_rootSet: the splitting field is generated by all roots, each of which is in ℚ(α). Combining with adjoin_finrank gives [SplittingField : ℚ] = 3.",
+    "type": "insight",
+    "title": "Splitting Field Equals \u211a(\u03b1): Root Containment and Degree 3",
+    "content": "rootSet_subset_adjoin proves every root of p in the splitting field lies in \u211a(\u03b1). Given a root r, the factored form 8r\u00b3\u22126r\u22121 = 8(r\u2212\u03b1)(r\u2212\u03b2)(r\u2212\u03b3) (from factored_eval_eq) combined with r being a root gives 8(r\u2212\u03b1)(r\u2212\u03b2)(r\u2212\u03b3) = 0. Since the splitting field is a domain and 8 \u2260 0, one factor r\u2212\u03b1, r\u2212\u03b2, r\u2212\u03b3 must be zero, so r \u2208 {\u03b1, \u03b2, \u03b3} \u2286 \u211a(\u03b1). Then adjoin_root_eq_top shows \u211a(\u03b1) = \u22a4 (the whole splitting field) using Polynomial.SplittingField.adjoin_rootSet: the splitting field is generated by all roots, each of which is in \u211a(\u03b1). Combining with adjoin_finrank gives [SplittingField : \u211a] = 3.",
     "mathContext": "The key fact: $\\{\\text{roots of } p\\} \\subseteq \\mathbb{Q}(\\alpha)$, so $\\mathbb{Q}(\\alpha) \\supseteq \\text{SplittingField}(p)$. But $\\mathbb{Q}(\\alpha) \\subseteq \\text{SplittingField}(p)$ always, so $\\mathbb{Q}(\\alpha) = \\text{SplittingField}(p)$ and $[\\text{SplittingField}:\\mathbb{Q}] = [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\deg(\\text{minpoly}(\\alpha)) = 3$.",
     "significance": "key",
     "relatedConcepts": [
@@ -153,16 +153,16 @@
       "startLine": 462,
       "endLine": 474
     },
-    "type": "theorem",
-    "title": "Main Theorem: |Gal(8X³-6X-1/ℚ)| = 3",
+    "type": "insight",
+    "title": "Main Theorem: |Gal(8X\u00b3-6X-1/\u211a)| = 3",
     "content": "The main theorem cos20_gal_card assembles all prior results. It invokes Polynomial.Gal.card_of_separable, which says |Gal(p/K)| = [SplittingField : K] for separable p. After converting Nat.card to Fintype.card, it rewrites with splitting_finrank to conclude |Gal| = 3. The companion theorem trisection_poly_irreducible exposes p_irreducible as a public interface. Together these eliminate the `cos20_gal_order` axiom that had been assumed in AngleTrisectionOQ02.lean, upgrading that result from axiomatized to verified.",
-    "mathContext": "For separable $p$: $|\\text{Gal}(p/\\mathbb{Q})| = [\\text{SplittingField}(p) : \\mathbb{Q}] = 3$. Since $\\text{Gal}(\\mathbb{Q}(\\cos 20°)/\\mathbb{Q}) \\cong \\mathbb{Z}/3\\mathbb{Z}$ has prime order, it is cyclic — there are no proper subgroups and no proper intermediate fields, confirming the extension $\\mathbb{Q} \\subset \\mathbb{Q}(\\cos 20°)$ is minimal.",
+    "mathContext": "For separable $p$: $|\\text{Gal}(p/\\mathbb{Q})| = [\\text{SplittingField}(p) : \\mathbb{Q}] = 3$. Since $\\text{Gal}(\\mathbb{Q}(\\cos 20\u00b0)/\\mathbb{Q}) \\cong \\mathbb{Z}/3\\mathbb{Z}$ has prime order, it is cyclic \u2014 there are no proper subgroups and no proper intermediate fields, confirming the extension $\\mathbb{Q} \\subset \\mathbb{Q}(\\cos 20\u00b0)$ is minimal.",
     "significance": "key",
     "relatedConcepts": [
       "Polynomial.Gal.card_of_separable",
       "cos20_gal_order axiom elimination",
       "AngleTrisectionOQ02",
-      "ℤ/3ℤ Galois group",
+      "\u2124/3\u2124 Galois group",
       "solution-of-cubic",
       "abel-ruffini-oq-04-oq-03"
     ],
@@ -176,61 +176,123 @@
   {
     "id": "ann-cos20-poly-setup",
     "proofId": "angle-trisection-cos-20-gal",
-    "range": { "startLine": 64, "endLine": 110 },
+    "range": {
+      "startLine": 64,
+      "endLine": 110
+    },
     "type": "technical",
     "title": "Polynomial p Definition, Basic Properties, and Eisenstein Shift Setup",
     "content": "Lines 64\u2013110 define the central objects and their basic properties. The abbreviation `p : \u211a[X] := 8 * X ^ 3 - 6 * X - C 1` uses `private noncomputable abbrev` \u2014 `noncomputable` because \u211a[X] is a noncomputable type (Lean can\u2019t compute with real/rational field elements at compile time), and `abbrev` so that Lean\u2019s elaborator transparently unfolds it during type-checking. The three helper lemmas `p_ne_zero`, `p_natDegree`, and `p_degree_ne_zero` establish degree-3 properties used repeatedly downstream. `p_natDegree` uses `norm_num` with degree computation lemmas rather than direct `decide` because the polynomial coefficients are rationals.\n\nThe Eisenstein shift `q_eis_int : \u2124[X] := X^3 - C 6 * X^2 + C 9 * X - C 3` is defined over \u2124 (integers), not \u211a, so that Eisenstein\u2019s criterion \u2014 which requires divisibility by a prime ideal in a domain \u2014 can be stated over \u2124. Its monic property is established via explicit `leadingCoeff` computation using `simp` with coefficient lemmas.",
     "mathContext": "$p = 8X^3 - 6X - 1 \\in \\mathbb{Q}[X]$, $\\deg(p) = 3$. The Eisenstein shift: $q = X^3 - 6X^2 + 9X - 3 \\in \\mathbb{Z}[X]$. Key relationship: $q(2X+2) = 8X^3 - 6X - 1 = p$ (verified in `q_comp_eq_p`).",
     "significance": "technical",
-    "relatedConcepts": ["noncomputable", "Polynomial.natDegree", "Eisenstein criterion setup", "\u2124[X] vs \u211a[X]"],
-    "prerequisites": ["Polynomial definitions in Mathlib", "natDegree computation lemmas", "CommRing structure"]
+    "relatedConcepts": [
+      "noncomputable",
+      "Polynomial.natDegree",
+      "Eisenstein criterion setup",
+      "\u2124[X] vs \u211a[X]"
+    ],
+    "prerequisites": [
+      "Polynomial definitions in Mathlib",
+      "natDegree computation lemmas",
+      "CommRing structure"
+    ]
   },
   {
     "id": "ann-cos20-gauss",
     "proofId": "angle-trisection-cos-20-gal",
-    "range": { "startLine": 150, "endLine": 169 },
+    "range": {
+      "startLine": 150,
+      "endLine": 169
+    },
     "type": "technique",
     "title": "Gauss\u2019s Lemma: Lifting Irreducibility from \u2124 to \u211a, and the Substitution Equation",
     "content": "After proving `q_eis_int_irreducible` (q irreducible over \u2124), this section does two things. First, `q_eis_rat_irreducible` lifts irreducibility to \u211a via `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` \u2014 this is Mathlib\u2019s formalization of Gauss\u2019s lemma: a primitive polynomial (here, monic) that is irreducible over \u2124 is irreducible over \u211a. The proof requires manually showing that `q_eis_rat` equals the \u2124\u2192\u211a cast of `q_eis_int` via `Polynomial.map`, since the two definitions look syntactically different despite being equal.\n\nSecond, `q_comp_eq_p` verifies the central algebraic identity $q(2X+2) = p$ using `Polynomial.funext` (extensionality for polynomials by evaluation) followed by `ring`. This approach avoids fiddly coefficient-by-coefficient bookkeeping: instead, Lean reduces equality of polynomials to equality of their evaluations at an arbitrary rational, and `ring` closes the resulting identity.",
     "mathContext": "Gauss\u2019s lemma: $f \\in \\mathbb{Z}[X]$ primitive (monic) and irreducible over $\\mathbb{Z}$ $\\Rightarrow$ $f$ irreducible over $\\mathbb{Q}$. The substitution identity: $q(2X+2) = (2X+2)^3 - 6(2X+2)^2 + 9(2X+2) - 3 = 8X^3 - 6X - 1 = p$.",
     "significance": "supporting",
-    "relatedConcepts": ["Gauss\u2019s lemma", "IsPrimitive.Int.irreducible_iff_irreducible_map_cast", "Polynomial.funext", "Polynomial.map"],
-    "prerequisites": ["q_eis_int_irreducible", "q_eis_int_monic", "Polynomial.map_cast"]
+    "relatedConcepts": [
+      "Gauss\u2019s lemma",
+      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+      "Polynomial.funext",
+      "Polynomial.map"
+    ],
+    "prerequisites": [
+      "q_eis_int_irreducible",
+      "q_eis_int_monic",
+      "Polynomial.map_cast"
+    ]
   },
   {
     "id": "ann-cos20-root-extraction",
     "proofId": "angle-trisection-cos-20-gal",
-    "range": { "startLine": 239, "endLine": 289 },
+    "range": {
+      "startLine": 239,
+      "endLine": 289
+    },
     "type": "technique",
     "title": "Root Extraction in the Splitting Field: From Abstract Existence to Concrete \u03b1",
     "content": "The splitting field of p over \u211a contains all roots of p by definition, but Lean\u2019s `SplittingField` type is abstract \u2014 roots don\u2019t come with names. This section extracts a concrete root. `p_map_degree_ne` verifies the mapped polynomial has non-zero degree (needed for `rootOfSplits`). Then `root_in_sf := rootOfSplits (SplittingField.splits p) p_map_degree_ne` gives a concrete element \u03b1 \u2208 SplittingField(p) satisfying p(\u03b1) = 0.\n\nWith \u03b1 in hand, `root_is_root` and `root_eq_zero` establish `8\u03b1\u00b3 \u2212 6\u03b1 \u2212 1 = 0` by connecting `aeval` (algebra map evaluation) with `p_eval_eq`. Then `beta_is_root` and `gamma_is_root` apply the ring identities from Part I (root_image_beta, root_image_gamma) to verify that \u03b2 = 2\u03b1\u00b2\u2212\u03b1\u22121 and \u03b3 = 1\u22122\u03b1\u00b2 are also roots. This sets up the key conclusion: all three roots of p are polynomial expressions in \u03b1.",
     "mathContext": "$\\alpha = \\text{rootOfSplits}(p) \\in \\text{SplittingField}(p)$, satisfying $8\\alpha^3 - 6\\alpha - 1 = 0$. Then $\\beta = 2\\alpha^2 - \\alpha - 1$ and $\\gamma = 1 - 2\\alpha^2$ are also roots, so $\\{\\alpha, \\beta, \\gamma\\} \\subseteq \\mathbb{Q}(\\alpha)$.",
     "significance": "key",
-    "relatedConcepts": ["rootOfSplits", "Polynomial.aeval", "SplittingField.splits", "root_image_beta"],
-    "prerequisites": ["p_irreducible", "p_separable", "root_image_beta", "root_image_gamma"]
+    "relatedConcepts": [
+      "rootOfSplits",
+      "Polynomial.aeval",
+      "SplittingField.splits",
+      "root_image_beta"
+    ],
+    "prerequisites": [
+      "p_irreducible",
+      "p_separable",
+      "root_image_beta",
+      "root_image_gamma"
+    ]
   },
   {
     "id": "ann-cos20-minpoly-adjoin",
     "proofId": "angle-trisection-cos-20-gal",
-    "range": { "startLine": 313, "endLine": 395 },
+    "range": {
+      "startLine": 313,
+      "endLine": 395
+    },
     "type": "technique",
     "title": "Minimal Polynomial, Adjoin Membership, and Factored Form",
     "content": "This section establishes [\u211a(\u03b1):\u211a] = 3 and that \u03b2, \u03b3 \u2208 \u211a(\u03b1). `minpoly_natDegree` shows the minimal polynomial of \u03b1 has degree 3 by a squeeze argument: minpoly(\u03b1) divides p (since p(\u03b1)=0), so deg(minpoly) \u2264 3; and p divides minpoly(\u03b1) (by irreducibility of both \u2014 any irreducible polynomial with a given root is associate to the minimal polynomial), so deg(minpoly) \u2265 3. Then `adjoin_finrank` uses `IntermediateField.adjoin.finrank` to compute [\u211a(\u03b1):\u211a] = deg(minpoly(\u03b1)) = 3.\n\n`beta_in_adjoin` and `gamma_in_adjoin` prove \u03b2 = 2\u03b1\u00b2\u2212\u03b1\u22121 and \u03b3 = 1\u22122\u03b1\u00b2 lie in \u211a(\u03b1) by explicit membership: \u211a(\u03b1) is closed under addition, subtraction, and multiplication, and \u03b1 \u2208 \u211a(\u03b1) by `mem_adjoin_simple_self`.\n\n`factored_eval_eq` proves the factored form 8a\u00b3-6a-1 = 8(a-\u03b1)(a-\u03b2)(a-\u03b3) as a pure ring identity (using `ring` after reducing to showing the difference is 0 via a key multiplication identity).",
     "mathContext": "$[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\deg(\\text{minpoly}_{\\mathbb{Q}}(\\alpha)) = 3$. The factored form: $8a^3 - 6a - 1 = 8(a-\\alpha)(a-(2\\alpha^2-\\alpha-1))(a-(1-2\\alpha^2))$, a ring identity. Since $\\{\\alpha,\\beta,\\gamma\\} \\subseteq \\mathbb{Q}(\\alpha)$, we get $\\mathbb{Q}(\\alpha) = \\text{SplittingField}(p)$.",
     "significance": "key",
-    "relatedConcepts": ["minpoly.dvd", "IntermediateField.adjoin.finrank", "mem_adjoin_simple_self", "factored form"],
-    "prerequisites": ["root_in_sf", "root_eq_zero", "p_irreducible", "IntermediateField.adjoin"]
+    "relatedConcepts": [
+      "minpoly.dvd",
+      "IntermediateField.adjoin.finrank",
+      "mem_adjoin_simple_self",
+      "factored form"
+    ],
+    "prerequisites": [
+      "root_in_sf",
+      "root_eq_zero",
+      "p_irreducible",
+      "IntermediateField.adjoin"
+    ]
   },
   {
     "id": "ann-cos20-splitting-finrank",
     "proofId": "angle-trisection-cos-20-gal",
-    "range": { "startLine": 446, "endLine": 461 },
-    "type": "theorem",
+    "range": {
+      "startLine": 446,
+      "endLine": 461
+    },
+    "type": "insight",
     "title": "splitting_finrank: [SplittingField(p):\u211a] = 3",
     "content": "The public theorem `splitting_finrank` assembles the two key results: `adjoin_root_eq_top` (\u211a(\u03b1) = SplittingField as intermediate fields) and `adjoin_finrank` ([\u211a(\u03b1):\u211a] = 3). The proof uses `LinearEquiv.finrank_eq` to transfer the finrank from \u211a(\u03b1) to SplittingField \u2014 the `topEquiv` isomorphism between the top intermediate field and the splitting field itself gives the needed linear equivalence. This is technically subtle: Lean distinguishes between the abstract SplittingField type and the intermediate field \u22a4 inside it, and this theorem bridges the two views.\n\nWith splitting_finrank in hand, `cos20_gal_card` follows in two lines: `Polynomial.Gal.card_of_separable` gives |Gal(p)| = [SplittingField:\u211a], and splitting_finrank gives [SplittingField:\u211a] = 3.",
     "mathContext": "$[\\text{SplittingField}(p):\\mathbb{Q}] = [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 3$, using $\\mathbb{Q}(\\alpha) = \\text{SplittingField}(p)$ (from adjoin_root_eq_top) and $\\text{IntermediateField.topEquiv}$ to transfer the finrank. Hence $|\\text{Gal}(p/\\mathbb{Q})| = 3$.",
     "significance": "key",
-    "relatedConcepts": ["LinearEquiv.finrank_eq", "IntermediateField.topEquiv", "adjoin_root_eq_top", "Polynomial.Gal.card_of_separable"],
-    "prerequisites": ["adjoin_finrank", "adjoin_root_eq_top", "splitting_finrank"]
+    "relatedConcepts": [
+      "LinearEquiv.finrank_eq",
+      "IntermediateField.topEquiv",
+      "adjoin_root_eq_top",
+      "Polynomial.Gal.card_of_separable"
+    ],
+    "prerequisites": [
+      "adjoin_finrank",
+      "adjoin_root_eq_top",
+      "splitting_finrank"
+    ]
   }
 ]

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/annotations.json
@@ -1,1 +1,132 @@
-[]
+[
+  {
+    "id": "bu-eh-context",
+    "proofId": "bounded-prime-gaps-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "context",
+    "title": "From Zhang to Maynard-Tao: The Prime Gap Race",
+    "content": "The bounded prime gaps program asks: how small can $\\liminf_{n \\to \\infty}(p_{n+1} - p_n)$ be? The landmark results:\n\n- **Zhang (2013)**: First finite bound, $H \\leq 70{,}000{,}000$\n- **Polymath 8a/8b**: Reduced to $H \\leq 246$ unconditionally via a 50-tuple admissible sieve\n- **Maynard-Tao + EH conjecture**: Reduces to $H \\leq 12$ using a 5-tuple\n\nThis file formalizes the Elliott-Halberstam conditional bound $H \\leq 12$, the optimal 5-tuple witnesses, and the implications TPC → EH → unconditional.",
+    "mathContext": "$H := \\liminf_{n \\to \\infty}(p_{n+1} - p_n)$. Zhang: $H \\leq 7 \\times 10^7$. Polymath 8b unconditional: $H \\leq 246$. Under EH: $H \\leq 12$. Under Twin Prime Conjecture: $H = 2$.",
+    "significance": "context",
+    "prerequisites": [
+      "prime gaps and liminf",
+      "admissible k-tuples",
+      "Bombieri-Vinogradov theorem",
+      "Maynard-Tao sieve"
+    ],
+    "relatedConcepts": [
+      "Zhang's theorem (2013)",
+      "Polymath 8 project",
+      "Twin Prime Conjecture",
+      "Bombieri-Vinogradov equidistribution"
+    ]
+  },
+  {
+    "id": "bu-eh-main-theorem",
+    "proofId": "bounded-prime-gaps-oq-01-oq-02",
+    "range": { "startLine": 30, "endLine": 64 },
+    "type": "insight",
+    "title": "EH Conditional H ≤ 12: The Core Theorem",
+    "content": "The main theorem `eh_conditional_h_le_12` derives $H \\leq 12$ from the Elliott-Halberstam conjecture.\n\nThe proof strategy:\n1. The 5-tuple $\\{0,2,6,8,12\\}$ is admissible (shown in OQ01)\n2. Under EH at level $\\theta = 1/2$, the Maynard-Tao sieve applies to 5-tuples\n3. Therefore infinitely many translates $n + \\{0,2,6,8,12\\}$ contain at least 2 primes\n4. Hence $\\liminf (p_{n+1} - p_n) \\leq 12$\n\nThe theorem `eh_strictly_improves_on_246` confirms $12 < 246$, showing EH gives a strict improvement.",
+    "mathContext": "`eh_conditional_h_le_12`: EH $\\Rightarrow H \\leq 12$. The admissible 5-tuple $\\{0,2,6,8,12\\}$ has `quintuple_card = 5` and diameter `quintuple_le_12 : \\max - \\min \\leq 12`. Under EH: Maynard-Tao sieve gives $H \\leq \\text{diam}(\\mathcal{H}_5) = 12$.",
+    "significance": "key",
+    "prerequisites": [
+      "Elliott-Halberstam conjecture",
+      "admissible tuples and the Maynard-Tao sieve",
+      "prime gaps and liminf",
+      "OQ01 admissibility proof for {0,2,6,8,12}"
+    ],
+    "relatedConcepts": [
+      "Maynard's theorem (2014)",
+      "sieve theory",
+      "admissible constellations",
+      "Goldston-Pintz-Yıldırım method"
+    ]
+  },
+  {
+    "id": "bu-numerical-comparison",
+    "proofId": "bounded-prime-gaps-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 99 },
+    "type": "insight",
+    "title": "The 234-Gap: EH vs Unconditional Bound",
+    "content": "This section formalizes the numerical gap between the two main bounds:\n\n- `eh_bound_lt_polymath_bound`: $12 < 246$ (EH beats unconditional)\n- `bound_gap`: $246 - 12 = 234$ (the improvement from EH)\n- `eh_improvement_factor`: $246 / 12 = 20$ (roughly 20× improvement)\n\nThis 20× improvement traces entirely to the **sieve level**: BV works at $\\theta < 1/2$ (needing $k \\geq 50$ admissible elements) while EH extends to $\\theta = 1/2$ (only needing $k \\geq 5$). A 10× reduction in required tuple size leads to a 20× reduction in the gap bound.",
+    "mathContext": "$\\text{ehBound} = 12$, $\\text{polymath8bBound} = 246$, $\\text{boundGap} = 234$, $\\text{improvementFactor} = 20$. BV level $\\theta < 1/2 \\Rightarrow k \\geq 50$; EH level $\\theta = 1/2 \\Rightarrow k \\geq 5$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Bombieri-Vinogradov theorem at level θ < 1/2",
+      "Elliott-Halberstam at level θ = 1/2",
+      "minimum admissible tuple size for each level"
+    ],
+    "relatedConcepts": [
+      "Polymath 8b result",
+      "admissible 50-tuple for unconditional bound",
+      "sieve level vs tuple size tradeoff",
+      "Bombieri-Vinogradov theorem"
+    ]
+  },
+  {
+    "id": "bu-sieve-level",
+    "proofId": "bounded-prime-gaps-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 143 },
+    "type": "technique",
+    "title": "Sieve Level: Why BV and EH Share 1/2 but Differ in Application",
+    "content": "A subtlety: both BV and EH have `bvLevel = ehLevel = 1/2` as definitional markers in this formalization. The *substantive* difference is in scope:\n\n- **BV** holds *unconditionally* for $\\theta < 1/2$ (strict)\n- **EH** *conjectures* the bound holds at $\\theta = 1/2$ (non-strict)\n\nThe numeric facts (`bv_level_lt_one`, `eh_level_eq_half`, `eh_strictly_better_than_bv`) clarify that while both levels are annotated as 1/2, EH's equality (vs BV's strict inequality) is exactly what allows the sieve to apply to 5-tuples rather than requiring 50-tuples.",
+    "mathContext": "BV: $\\sum_{q \\leq x^{\\theta}} \\max_{(a,q)=1} |\\psi(x; q, a) - x/\\phi(q)| \\ll x (\\log x)^{-A}$ for all $\\theta < 1/2$ (proven). EH conjectures the same for $\\theta \\leq 1/2$ (with $\\theta = 1/2$ being the critical value).",
+    "significance": "supporting",
+    "prerequisites": [
+      "Bombieri-Vinogradov theorem",
+      "Elliott-Halberstam conjecture",
+      "primes in arithmetic progressions ψ(x; q, a)",
+      "Euler's totient function φ(q)"
+    ],
+    "relatedConcepts": [
+      "distribution of primes in residue classes",
+      "Barban-Davenport-Halberstam theorem",
+      "large sieve inequality",
+      "character sum bounds"
+    ]
+  },
+  {
+    "id": "bu-admissible-witnesses",
+    "proofId": "bounded-prime-gaps-oq-01-oq-02",
+    "range": { "startLine": 145, "endLine": 170 },
+    "type": "insight",
+    "title": "Two Optimal 5-Tuple Witnesses for H ≤ 12",
+    "content": "The bound $H \\leq 12$ is witnessed by two distinct admissible 5-tuples of diameter 12:\n\n- `eh_witness_1`: $\\{0, 2, 6, 8, 12\\}$\n- `eh_witness_2`: $\\{0, 4, 6, 10, 12\\}$\n\nThe theorem `two_optimal_5_tuples` confirms both are admissible and have diameter exactly 12. This redundancy matters: it shows the bound $H \\leq 12$ is not an artifact of one special tuple but reflects a genuine structural threshold. The minimum possible gap from 5-tuple sieve is 12 — all 5-tuples with diameter $\\leq 10$ are non-admissible (proved exhaustively in OQ01).",
+    "mathContext": "$\\mathcal{H}_1 = \\{0,2,6,8,12\\}$, $\\mathcal{H}_2 = \\{0,4,6,10,12\\}$ both admissible with $|\\mathcal{H}_i| = 5$ and $\\max\\mathcal{H}_i - \\min\\mathcal{H}_i = 12$. No admissible 5-tuple has diameter $< 12$ (shown in OQ01).",
+    "significance": "key",
+    "prerequisites": [
+      "admissible k-tuples (avoidance condition mod p)",
+      "OQ01 non-admissibility below diameter 12",
+      "diameter of a finite set"
+    ],
+    "relatedConcepts": [
+      "admissible constellations",
+      "prime k-tuples conjecture",
+      "Hardy-Littlewood conjecture",
+      "exhaustive admissibility verification"
+    ]
+  },
+  {
+    "id": "bu-open-hierarchy",
+    "proofId": "bounded-prime-gaps-oq-01-oq-02",
+    "range": { "startLine": 172, "endLine": 218 },
+    "type": "context",
+    "title": "The Implication Hierarchy: TPC → EH → Unconditional",
+    "content": "The formal hierarchy of implications:\n\n1. **TPC (Twin Prime Conjecture)** → $H = 2$ (infinitely many twin primes)\n2. **EH conjecture** → $H \\leq 12$ (this file's main result)\n3. **Unconditional** (Polymath 8b) → $H \\leq 246$\n\nThe theorem `gap_bound_tpc_implies_eh` shows TPC implies EH-level, and `gap_bound_eh_implies_unconditional` shows EH implies the unconditional bound. The theorem `eh_conditional_range` pins $H$ to $[2, 12]$ under EH.\n\nThe `OpenQuestion01OQ02` definition formally records the open status: proving EH to close the gap from 246 to 12.",
+    "mathContext": "TPC $\\Rightarrow H = 2 \\Rightarrow H \\leq 12$ (EH bound) $\\Rightarrow H \\leq 246$ (unconditional). Under EH: $2 \\leq H \\leq 12$. Without EH: $2 \\leq H \\leq 246$. EH itself is open; TPC is open.",
+    "significance": "context",
+    "prerequisites": [
+      "Twin Prime Conjecture",
+      "Elliott-Halberstam conjecture",
+      "Polymath 8b unconditional H ≤ 246",
+      "logical implications in analytic number theory"
+    ],
+    "relatedConcepts": [
+      "Twin Prime Conjecture",
+      "Goldbach conjecture analogy",
+      "conditional vs unconditional results",
+      "Polymath 8 project hierarchy"
+    ]
+  }
+]

--- a/src/data/proofs/brouwer-fixed-point-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02-oq-02/annotations.json
@@ -2,121 +2,247 @@
   {
     "id": "ann-bfp2-lipschitz-defs",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 37, "endLine": 47 },
+    "range": {
+      "startLine": 37,
+      "endLine": 47
+    },
     "type": "definition",
     "title": "Function Class Hierarchy: Lipschitz and Contraction",
-    "content": "`IsLipschitzOn01 f L` encodes the standard Lipschitz condition on [0,1]: |f(x) - f(y)| ≤ L|x - y| for all x, y ∈ [0,1]. `IsContractionOn01 f L` strengthens this with L < 1, forming a proper sub-class. The theorem `contraction_is_lipschitz` immediately extracts the Lipschitz property from the conjunction, establishing the class inclusion: Contraction ⊊ Lipschitz ⊊ Continuous. This hierarchy is the backbone of the query complexity analysis — different levels of the hierarchy admit fundamentally different convergence rates.",
+    "content": "`IsLipschitzOn01 f L` encodes the standard Lipschitz condition on [0,1]: |f(x) - f(y)| \u2264 L|x - y| for all x, y \u2208 [0,1]. `IsContractionOn01 f L` strengthens this with L < 1, forming a proper sub-class. The theorem `contraction_is_lipschitz` immediately extracts the Lipschitz property from the conjunction, establishing the class inclusion: Contraction \u228a Lipschitz \u228a Continuous. This hierarchy is the backbone of the query complexity analysis \u2014 different levels of the hierarchy admit fundamentally different convergence rates.",
     "mathContext": "$\\text{IsLipschitz}(f, L) \\Leftrightarrow \\forall x, y \\in [0,1],\\; |f(x) - f(y)| \\leq L|x-y|$. $\\text{IsContraction}(f, L) \\Leftrightarrow L \\geq 0 \\land L < 1 \\land \\text{IsLipschitz}(f, L)$. Inclusion: $\\{\\text{contractions}\\} \\subsetneq \\{\\text{Lipschitz}\\} \\subsetneq \\{\\text{continuous}\\}$.",
     "significance": "key",
-    "relatedConcepts": ["Lipschitz continuity", "Banach fixed-point theorem", "contraction mapping", "function class hierarchy"],
-    "prerequisites": ["real-valued functions on [0,1]", "absolute value in ℝ", "Lean 4 structure conjunction"]
+    "relatedConcepts": [
+      "Lipschitz continuity",
+      "Banach fixed-point theorem",
+      "contraction mapping",
+      "function class hierarchy"
+    ],
+    "prerequisites": [
+      "real-valued functions on [0,1]",
+      "absolute value in \u211d",
+      "Lean 4 structure conjunction"
+    ]
   },
   {
     "id": "ann-bfp2-unique-fixed",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 54, "endLine": 66 },
-    "type": "theorem",
+    "range": {
+      "startLine": 54,
+      "endLine": 66
+    },
+    "type": "insight",
     "title": "Contraction Has At Most One Fixed Point",
-    "content": "This is the uniqueness half of Banach's contraction theorem: an L-contraction (L < 1) cannot have two distinct fixed points. The proof is elegant — suppose x₁ ≠ x₂ are both fixed. Then |x₁ - x₂| = |f(x₁) - f(x₂)| ≤ L|x₁ - x₂|, which gives 1 ≤ L, contradicting L < 1. The Lean proof uses `by_contra` and `positivity` to establish |x₁ - x₂| > 0, then derives the contradiction via `linarith`. Note: this proof doesn't require f to be a self-map of [0,1] — it works globally.",
-    "mathContext": "If $f(x_1) = x_1$ and $f(x_2) = x_2$ and $x_1 \\neq x_2$: $|x_1 - x_2| = |f(x_1) - f(x_2)| \\leq L|x_1 - x_2|$, so $1 \\leq L$, contradicting $L < 1$. This is purely algebraic — no topology needed.",
+    "content": "This is the uniqueness half of Banach's contraction theorem: an L-contraction (L < 1) cannot have two distinct fixed points. The proof is elegant \u2014 suppose x\u2081 \u2260 x\u2082 are both fixed. Then |x\u2081 - x\u2082| = |f(x\u2081) - f(x\u2082)| \u2264 L|x\u2081 - x\u2082|, which gives 1 \u2264 L, contradicting L < 1. The Lean proof uses `by_contra` and `positivity` to establish |x\u2081 - x\u2082| > 0, then derives the contradiction via `linarith`. Note: this proof doesn't require f to be a self-map of [0,1] \u2014 it works globally.",
+    "mathContext": "If $f(x_1) = x_1$ and $f(x_2) = x_2$ and $x_1 \\neq x_2$: $|x_1 - x_2| = |f(x_1) - f(x_2)| \\leq L|x_1 - x_2|$, so $1 \\leq L$, contradicting $L < 1$. This is purely algebraic \u2014 no topology needed.",
     "significance": "key",
-    "relatedConcepts": ["Banach fixed-point theorem", "contraction mapping uniqueness", "proof by contradiction in Lean"],
-    "prerequisites": ["IsLipschitzOn01", "by_contra tactic", "positivity", "linarith"]
+    "relatedConcepts": [
+      "Banach fixed-point theorem",
+      "contraction mapping uniqueness",
+      "proof by contradiction in Lean"
+    ],
+    "prerequisites": [
+      "IsLipschitzOn01",
+      "by_contra tactic",
+      "positivity",
+      "linarith"
+    ]
   },
   {
     "id": "ann-bfp2-error-bound",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 74, "endLine": 98 },
-    "type": "theorem",
-    "title": "Contraction Error Bound: |f^n(x₀) - x*| ≤ Lⁿ·D₀",
-    "content": "This is the quantitative heart of Banach's theorem. By induction: |f^(n+1)(x₀) - x*| = |f(f^n(x₀)) - f(x*)| ≤ L·|f^n(x₀) - x*| ≤ L·Lⁿ·D₀ = L^(n+1)·D₀. The `calc` block in Lean makes each step explicit: first use that x* is a fixed point (|f(y) - x*| = |f(y) - f(x*)|), then apply Lipschitz, then the induction hypothesis. `contraction_epsilon_approximation` wraps this into a direct ε-bound by transitivity.",
+    "range": {
+      "startLine": 74,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Contraction Error Bound: |f^n(x\u2080) - x*| \u2264 L\u207f\u00b7D\u2080",
+    "content": "This is the quantitative heart of Banach's theorem. By induction: |f^(n+1)(x\u2080) - x*| = |f(f^n(x\u2080)) - f(x*)| \u2264 L\u00b7|f^n(x\u2080) - x*| \u2264 L\u00b7L\u207f\u00b7D\u2080 = L^(n+1)\u00b7D\u2080. The `calc` block in Lean makes each step explicit: first use that x* is a fixed point (|f(y) - x*| = |f(y) - f(x*)|), then apply Lipschitz, then the induction hypothesis. `contraction_epsilon_approximation` wraps this into a direct \u03b5-bound by transitivity.",
     "mathContext": "By induction: $|f^n(x_0) - x^*| \\leq L^n \\cdot |x_0 - x^*| = L^n D_0$. Since $L < 1$, we have $L^n \\to 0$, so for any $\\varepsilon > 0$, choosing $n \\geq \\log_L(\\varepsilon/D_0) = \\log(\\varepsilon/D_0)/\\log L$ suffices. This gives $O(\\log(D_0/\\varepsilon)/|\\log L|)$ iterations.",
     "significance": "key",
-    "relatedConcepts": ["contraction iteration", "geometric convergence", "induction in Lean", "fixed point distance bound"],
-    "prerequisites": ["Function.iterate", "mul_le_mul_of_nonneg_left", "Lean 4 calc tactic", "pow_succ"]
+    "relatedConcepts": [
+      "contraction iteration",
+      "geometric convergence",
+      "induction in Lean",
+      "fixed point distance bound"
+    ],
+    "prerequisites": [
+      "Function.iterate",
+      "mul_le_mul_of_nonneg_left",
+      "Lean 4 calc tactic",
+      "pow_succ"
+    ]
   },
   {
     "id": "ann-bfp2-finite-iters",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 102, "endLine": 116 },
-    "type": "theorem",
-    "title": "Contraction Converges in Finite Iterations via Lⁿ → 0",
-    "content": "This theorem proves existence of a stopping criterion: for L < 1, there always exists N with L^N · D ≤ ε. The key move is using `tendsto_pow_atTop_nhds_zero_of_lt_one` (Mathlib's L^n → 0 theorem) converted via `Metric.tendsto_atTop` to get an explicit N with |L^N - 0| < ε/D. The `nlinarith` closes L^N · D ≤ ε from L^N < ε/D. The D = 0 case is handled separately (trivially N = 0 works). This is the constructive counterpart to the existence proof — it extracts a concrete iteration count from the abstract convergence.",
+    "range": {
+      "startLine": 102,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "Contraction Converges in Finite Iterations via L\u207f \u2192 0",
+    "content": "This theorem proves existence of a stopping criterion: for L < 1, there always exists N with L^N \u00b7 D \u2264 \u03b5. The key move is using `tendsto_pow_atTop_nhds_zero_of_lt_one` (Mathlib's L^n \u2192 0 theorem) converted via `Metric.tendsto_atTop` to get an explicit N with |L^N - 0| < \u03b5/D. The `nlinarith` closes L^N \u00b7 D \u2264 \u03b5 from L^N < \u03b5/D. The D = 0 case is handled separately (trivially N = 0 works). This is the constructive counterpart to the existence proof \u2014 it extracts a concrete iteration count from the abstract convergence.",
     "mathContext": "$L^n \\to 0$ as $n \\to \\infty$ (for $0 \\leq L < 1$). Given $\\varepsilon > 0$ and $D > 0$, choose $N$ with $L^N < \\varepsilon/D$, then $L^N \\cdot D < \\varepsilon$. Query complexity: $O(\\log(D/\\varepsilon) / |\\log L|)$ iterations.",
     "significance": "key",
-    "relatedConcepts": ["tendsto_pow_atTop_nhds_zero_of_lt_one", "Metric.tendsto_atTop", "geometric sequence convergence", "query complexity bound"],
-    "prerequisites": ["Filter.Tendsto", "Metric.tendsto_atTop", "tendsto_pow_atTop_nhds_zero_of_lt_one", "nlinarith"]
+    "relatedConcepts": [
+      "tendsto_pow_atTop_nhds_zero_of_lt_one",
+      "Metric.tendsto_atTop",
+      "geometric sequence convergence",
+      "query complexity bound"
+    ],
+    "prerequisites": [
+      "Filter.Tendsto",
+      "Metric.tendsto_atTop",
+      "tendsto_pow_atTop_nhds_zero_of_lt_one",
+      "nlinarith"
+    ]
   },
   {
     "id": "ann-bfp2-binary-search",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 125, "endLine": 136 },
-    "type": "theorem",
-    "title": "Binary Search via IVT: ε-Fixed Point in n Queries",
-    "content": "A surprisingly short proof: for any continuous self-map f : [0,1] → [0,1], after n binary search steps there exists x with |f(x) - x| ≤ 1/2^n. The proof uses `exists_mem_Icc_isFixedPt_of_mapsTo` — Mathlib's formulation of the Intermediate Value Theorem as a fixed-point existence result. Since an actual fixed point f(x*) = x* exists, |f(x*) - x*| = 0 ≤ 1/2^n. The proof finds the exact fixed point, which is stronger than the 1/2^n bound suggests — the bound is achievable by binary search but the proof takes a shortcut through exact fixed point existence.",
+    "range": {
+      "startLine": 125,
+      "endLine": 136
+    },
+    "type": "insight",
+    "title": "Binary Search via IVT: \u03b5-Fixed Point in n Queries",
+    "content": "A surprisingly short proof: for any continuous self-map f : [0,1] \u2192 [0,1], after n binary search steps there exists x with |f(x) - x| \u2264 1/2^n. The proof uses `exists_mem_Icc_isFixedPt_of_mapsTo` \u2014 Mathlib's formulation of the Intermediate Value Theorem as a fixed-point existence result. Since an actual fixed point f(x*) = x* exists, |f(x*) - x*| = 0 \u2264 1/2^n. The proof finds the exact fixed point, which is stronger than the 1/2^n bound suggests \u2014 the bound is achievable by binary search but the proof takes a shortcut through exact fixed point existence.",
     "mathContext": "IVT fixed-point theorem: any continuous $f: [0,1] \\to [0,1]$ has a fixed point $f(x^*) = x^*$ (Brouwer 1D). Binary search achieves accuracy $1/2^n$ in $n$ steps, so $\\Theta(\\log(1/\\varepsilon))$ queries. This is optimal: the lower bound shows $\\Omega(\\log(1/\\varepsilon))$ queries are necessary.",
     "significance": "key",
-    "relatedConcepts": ["Intermediate Value Theorem", "exists_mem_Icc_isFixedPt_of_mapsTo", "Brouwer fixed-point theorem 1D", "binary search optimality"],
-    "prerequisites": ["ContinuousOn", "exists_mem_Icc_isFixedPt_of_mapsTo", "Icc in ℝ", "positivity for 1/2^n > 0"]
+    "relatedConcepts": [
+      "Intermediate Value Theorem",
+      "exists_mem_Icc_isFixedPt_of_mapsTo",
+      "Brouwer fixed-point theorem 1D",
+      "binary search optimality"
+    ],
+    "prerequisites": [
+      "ContinuousOn",
+      "exists_mem_Icc_isFixedPt_of_mapsTo",
+      "Icc in \u211d",
+      "positivity for 1/2^n > 0"
+    ]
   },
   {
     "id": "ann-bfp2-lower-bound",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 148, "endLine": 162 },
-    "type": "theorem",
-    "title": "Information-Theoretic Lower Bound: Ω(log(1/ε)) Queries",
-    "content": "The lower bound `info_theoretic_bound` proves: if 2^n < 1/ε, then 1/2^n > ε, meaning n queries achieve only 1/2^n accuracy which exceeds ε. This is the information-theoretic argument: n binary queries distinguish at most 2^n scenarios; if the fixed point could be anywhere in 1/2^n-spaced intervals, 2^n < 1/ε means we haven't localized it to within ε. The `queries_needed` contrapositive states: achieving 1/2^n ≤ ε requires 2^n ≥ 1/ε, i.e., n ≥ log₂(1/ε). Together with `binary_search_query_count`, this establishes Θ(log(1/ε)) for continuous functions.",
-    "mathContext": "Lower bound: $n$ binary queries → $2^n$ possible outcomes → resolution $\\geq 1/2^n > \\varepsilon$ when $2^n < 1/\\varepsilon$. Upper bound: binary search achieves $1/2^n$ accuracy. Together: $\\Theta(\\log(1/\\varepsilon))$ is tight for continuous self-maps of $[0,1]$.",
+    "range": {
+      "startLine": 148,
+      "endLine": 162
+    },
+    "type": "insight",
+    "title": "Information-Theoretic Lower Bound: \u03a9(log(1/\u03b5)) Queries",
+    "content": "The lower bound `info_theoretic_bound` proves: if 2^n < 1/\u03b5, then 1/2^n > \u03b5, meaning n queries achieve only 1/2^n accuracy which exceeds \u03b5. This is the information-theoretic argument: n binary queries distinguish at most 2^n scenarios; if the fixed point could be anywhere in 1/2^n-spaced intervals, 2^n < 1/\u03b5 means we haven't localized it to within \u03b5. The `queries_needed` contrapositive states: achieving 1/2^n \u2264 \u03b5 requires 2^n \u2265 1/\u03b5, i.e., n \u2265 log\u2082(1/\u03b5). Together with `binary_search_query_count`, this establishes \u0398(log(1/\u03b5)) for continuous functions.",
+    "mathContext": "Lower bound: $n$ binary queries \u2192 $2^n$ possible outcomes \u2192 resolution $\\geq 1/2^n > \\varepsilon$ when $2^n < 1/\\varepsilon$. Upper bound: binary search achieves $1/2^n$ accuracy. Together: $\\Theta(\\log(1/\\varepsilon))$ is tight for continuous self-maps of $[0,1]$.",
     "significance": "key",
-    "relatedConcepts": ["information theory lower bound", "query complexity", "binary outcomes", "linarith in Lean"],
-    "prerequisites": ["div_lt_iff", "gt_iff_lt", "linarith for arithmetic", "div_le_iff"]
+    "relatedConcepts": [
+      "information theory lower bound",
+      "query complexity",
+      "binary outcomes",
+      "linarith in Lean"
+    ],
+    "prerequisites": [
+      "div_lt_iff",
+      "gt_iff_lt",
+      "linarith for arithmetic",
+      "div_le_iff"
+    ]
   },
   {
     "id": "ann-bfp2-contraction-faster",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 170, "endLine": 180 },
-    "type": "theorem",
-    "title": "Contractions Beat Bisection When L ≤ 1/2",
-    "content": "For L ≤ 1/2, the contraction rate L^n ≤ (1/2)^n — so contractions with small L converge strictly faster than binary search. The proof applies `pow_le_pow_left` (L ≤ 1/2 → L^n ≤ (1/2)^n) with `mul_le_mul_of_nonneg_right` to extend to L^n·D ≤ (1/2)^n·D. The boundary case L = 1/2 makes them equal; for L < 1/2, contractions require fewer iterations than binary search for the same accuracy. This captures the key practical insight: strong contractivity (L ≪ 1) can give dramatic speedups.",
+    "range": {
+      "startLine": 170,
+      "endLine": 180
+    },
+    "type": "insight",
+    "title": "Contractions Beat Bisection When L \u2264 1/2",
+    "content": "For L \u2264 1/2, the contraction rate L^n \u2264 (1/2)^n \u2014 so contractions with small L converge strictly faster than binary search. The proof applies `pow_le_pow_left` (L \u2264 1/2 \u2192 L^n \u2264 (1/2)^n) with `mul_le_mul_of_nonneg_right` to extend to L^n\u00b7D \u2264 (1/2)^n\u00b7D. The boundary case L = 1/2 makes them equal; for L < 1/2, contractions require fewer iterations than binary search for the same accuracy. This captures the key practical insight: strong contractivity (L \u226a 1) can give dramatic speedups.",
     "mathContext": "For $L \\leq 1/2$: $L^n D \\leq (1/2)^n D$. Iteration count ratio: $\\log(D/\\varepsilon)/|\\log L|$ vs $\\log(D/\\varepsilon)/|\\log(1/2)| = \\log(D/\\varepsilon)$. Speedup factor: $|\\log(1/2)|/|\\log L| = \\log 2 / |\\log L| < 1$ when $L < 1/2$.",
     "significance": "supporting",
-    "relatedConcepts": ["pow_le_pow_left", "convergence rate comparison", "Banach vs bisection", "multiplicative monotonicity"],
-    "prerequisites": ["pow_le_pow_left", "mul_le_mul_of_nonneg_right", "Lean 4 norm_num"]
+    "relatedConcepts": [
+      "pow_le_pow_left",
+      "convergence rate comparison",
+      "Banach vs bisection",
+      "multiplicative monotonicity"
+    ],
+    "prerequisites": [
+      "pow_le_pow_left",
+      "mul_le_mul_of_nonneg_right",
+      "Lean 4 norm_num"
+    ]
   },
   {
     "id": "ann-bfp2-quadratic-def",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 187, "endLine": 195 },
+    "range": {
+      "startLine": 187,
+      "endLine": 195
+    },
     "type": "definition",
     "title": "HasQuadraticConvergence: Formalizing Newton-Type Convergence",
-    "content": "`HasQuadraticConvergence x x_star C` encodes the condition |e_{n+1}| ≤ C|e_n|² where eₙ = x(n) - x*, the error at step n. This is the canonical definition of quadratic (second-order) convergence, as analyzed by Kantorovich (1948) for Newton's method. The constant C typically depends on the second derivative of the function near the fixed point. The condition C|e₀| ≤ 1/2 (used in the subsequent theorem) is the Kantorovich condition: the initial error must be small enough for the quadratic decay to dominate.",
+    "content": "`HasQuadraticConvergence x x_star C` encodes the condition |e_{n+1}| \u2264 C|e_n|\u00b2 where e\u2099 = x(n) - x*, the error at step n. This is the canonical definition of quadratic (second-order) convergence, as analyzed by Kantorovich (1948) for Newton's method. The constant C typically depends on the second derivative of the function near the fixed point. The condition C|e\u2080| \u2264 1/2 (used in the subsequent theorem) is the Kantorovich condition: the initial error must be small enough for the quadratic decay to dominate.",
     "mathContext": "$\\text{HasQuadraticConvergence}(x, x^*, C) \\Leftrightarrow \\forall n,\\; |x_{n+1} - x^*| \\leq C |x_n - x^*|^2$. Newton's method for $g(x) = 0$ near a simple root: $x_{n+1} = x_n - g(x_n)/g'(x_n)$, giving $|e_{n+1}| \\leq \\frac{|g''(\\xi)|}{2|g'(x_n)|} |e_n|^2$.",
     "significance": "key",
-    "relatedConcepts": ["Newton's method", "quadratic convergence", "Kantorovich theorem", "order of convergence"],
-    "prerequisites": ["Function sequence in ℕ → ℝ", "absolute value", "Lean 4 Prop definition"]
+    "relatedConcepts": [
+      "Newton's method",
+      "quadratic convergence",
+      "Kantorovich theorem",
+      "order of convergence"
+    ],
+    "prerequisites": [
+      "Function sequence in \u2115 \u2192 \u211d",
+      "absolute value",
+      "Lean 4 Prop definition"
+    ]
   },
   {
     "id": "ann-bfp2-quadratic-rate",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 196, "endLine": 212 },
-    "type": "theorem",
+    "range": {
+      "startLine": 196,
+      "endLine": 212
+    },
+    "type": "insight",
     "title": "Quadratic Convergence: Double-Exponential Decay (1/2)^(2^n)",
-    "content": "This is the key quadratic convergence theorem: under HasQuadraticConvergence with C|e₀| ≤ 1/2, we get C|eₙ| ≤ (1/2)^(2^n). The inductive step is: C|e_{n+1}| ≤ C · C|eₙ|² = (C|eₙ|)² ≤ ((1/2)^(2^n))² = (1/2)^(2·2^n) = (1/2)^(2^(n+1)). The exponent doubles each step: 1, 2, 4, 8, 16... — the number of correct decimal digits doubles. To achieve accuracy ε, need (1/2)^(2^n) ≤ Cε, i.e., 2^n ≥ log₂(1/(Cε)), so n ≥ log₂(log₂(1/(Cε))) = O(log log(1/ε)) steps.",
+    "content": "This is the key quadratic convergence theorem: under HasQuadraticConvergence with C|e\u2080| \u2264 1/2, we get C|e\u2099| \u2264 (1/2)^(2^n). The inductive step is: C|e_{n+1}| \u2264 C \u00b7 C|e\u2099|\u00b2 = (C|e\u2099|)\u00b2 \u2264 ((1/2)^(2^n))\u00b2 = (1/2)^(2\u00b72^n) = (1/2)^(2^(n+1)). The exponent doubles each step: 1, 2, 4, 8, 16... \u2014 the number of correct decimal digits doubles. To achieve accuracy \u03b5, need (1/2)^(2^n) \u2264 C\u03b5, i.e., 2^n \u2265 log\u2082(1/(C\u03b5)), so n \u2265 log\u2082(log\u2082(1/(C\u03b5))) = O(log log(1/\u03b5)) steps.",
     "mathContext": "$C|e_n| \\leq (1/2)^{2^n}$. Proof: $C|e_{n+1}| \\leq (C|e_n|)^2 \\leq ((1/2)^{2^n})^2 = (1/2)^{2^{n+1}}$. The exponent sequence $2^n$ grows double-exponentially, so $\\log \\log$ iterations suffice: e.g., to get 10 correct digits, $2^n \\geq 10^{10}$ means $n \\geq \\lceil\\log_2(10^{10})\\rceil \\approx 34$ steps.",
     "significance": "key",
-    "relatedConcepts": ["double-exponential decay", "Newton's method convergence", "induction on natural numbers", "pow_add in Lean"],
-    "prerequisites": ["HasQuadraticConvergence", "mul_le_mul induction", "pow_add → pow_succ arithmetic", "ring_nf for 2^(k+1)"]
+    "relatedConcepts": [
+      "double-exponential decay",
+      "Newton's method convergence",
+      "induction on natural numbers",
+      "pow_add in Lean"
+    ],
+    "prerequisites": [
+      "HasQuadraticConvergence",
+      "mul_le_mul induction",
+      "pow_add \u2192 pow_succ arithmetic",
+      "ring_nf for 2^(k+1)"
+    ]
   },
   {
     "id": "ann-bfp2-landscape",
     "proofId": "brouwer-fixed-point-oq-02-oq-02",
-    "range": { "startLine": 244, "endLine": 255 },
-    "type": "theorem",
+    "range": {
+      "startLine": 244,
+      "endLine": 255
+    },
+    "type": "insight",
     "title": "Query Complexity Landscape: The Full Picture",
-    "content": "The summary theorem packages three orthogonal facts: (1) binary search is always applicable (1/2^n > 0), (2) contractions always converge (L^n → 0), (3) queries have finite resolution (2^n ≥ 1). Together with `info_theoretic_bound`, `binary_search_query_count`, and `quadratic_convergence_rate`, this establishes the complete complexity hierarchy: Θ(log(1/ε)) for continuous/Lipschitz, O(log(D₀/ε)/|log L|) for contractions, O(log log(1/ε)) for smooth contractions (Newton). The Lean proof uses `refine ⟨..., ..., ...⟩` to split the conjunction, then `tendsto_pow_atTop_nhds_zero_of_lt_one` for the contraction part.",
+    "content": "The summary theorem packages three orthogonal facts: (1) binary search is always applicable (1/2^n > 0), (2) contractions always converge (L^n \u2192 0), (3) queries have finite resolution (2^n \u2265 1). Together with `info_theoretic_bound`, `binary_search_query_count`, and `quadratic_convergence_rate`, this establishes the complete complexity hierarchy: \u0398(log(1/\u03b5)) for continuous/Lipschitz, O(log(D\u2080/\u03b5)/|log L|) for contractions, O(log log(1/\u03b5)) for smooth contractions (Newton). The Lean proof uses `refine \u27e8..., ..., ...\u27e9` to split the conjunction, then `tendsto_pow_atTop_nhds_zero_of_lt_one` for the contraction part.",
     "mathContext": "Query complexity summary: $\\bullet$ Continuous: $\\Theta(\\log(1/\\varepsilon))$ (binary search optimal) $\\bullet$ $L$-contraction: $O(\\log(D_0/\\varepsilon)/|\\log L|)$ (faster when $L \\ll 1$) $\\bullet$ Quadratic: $O(\\log\\log(1/\\varepsilon))$ (Newton-type, optimal for smooth contractive maps)",
     "significance": "key",
-    "relatedConcepts": ["query complexity hierarchy", "information complexity", "PPAD complexity", "algorithm design for fixed points"],
-    "prerequisites": ["tendsto_pow_atTop_nhds_zero_of_lt_one", "Nat.one_le_pow", "exact_mod_cast", "refine with conjunction split"]
+    "relatedConcepts": [
+      "query complexity hierarchy",
+      "information complexity",
+      "PPAD complexity",
+      "algorithm design for fixed points"
+    ],
+    "prerequisites": [
+      "tendsto_pow_atTop_nhds_zero_of_lt_one",
+      "Nat.one_le_pow",
+      "exact_mod_cast",
+      "refine with conjunction split"
+    ]
   }
 ]

--- a/src/data/proofs/central-limit-theorem/annotations.json
+++ b/src/data/proofs/central-limit-theorem/annotations.json
@@ -32,7 +32,7 @@
     "type": "concept",
     "title": "Mathlib Dependencies",
     "content": "We import from multiple Mathlib domains: **Probability.Distributions.Gaussian** for the Gaussian measure, **Fourier.FourierTransform** for characteristic functions, and **Topology.MetricSpace** for the geometric interpretation. This interdisciplinary foundation reflects the theorem's broad reach.",
-    "mathContext": "The file uses Mathlib's `MeasureTheory.Measure` for probability measures, `Complex.exp` for characteristic functions $\\varphi_X(t) = \\mathbb{E}[e^{itX}]$, and axiomatizes several deep results (Lévy continuity, Taylor remainder bounds, Berry-Esseen) that are not yet in Mathlib.",
+    "mathContext": "The file uses Mathlib's `MeasureTheory.Measure` for probability measures, `Complex.exp` for characteristic functions $\\varphi_X(t) = \\mathbb{E}[e^{itX}]$, and axiomatizes several deep results (L\u00e9vy continuity, Taylor remainder bounds, Berry-Esseen) that are not yet in Mathlib.",
     "significance": "supporting",
     "prerequisites": [
       "Mathlib.Probability.Distributions.Gaussian",
@@ -75,7 +75,7 @@
       "startLine": 12,
       "endLine": 52
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Characteristic Function at Zero",
     "content": "At $t = 0$, the characteristic function equals 1 for any probability measure: $\\varphi(0) = \\mathbb{E}[e^{i \\cdot 0 \\cdot X}] = \\mathbb{E}[1] = 1$. This normalization anchors the Fourier representation.",
     "mathContext": "This simple fact is essential: it means all characteristic functions pass through the same point, allowing us to compare different distributions on a common scale.",
@@ -119,7 +119,7 @@
       "startLine": 75,
       "endLine": 85
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Taylor Expansion with Error Bound",
     "content": "For small $t$, the characteristic function is well-approximated by its quadratic Taylor polynomial. The error is $O(t^3)$, controlled by the third moment. This approximation is sharp enough to extract the limiting behavior.",
     "mathContext": "The third moment condition $\\mathbb{E}[|X|^3] < \\infty$ ensures the remainder is well-controlled. Without it, convergence may fail (leading to stable distributions instead).",
@@ -163,10 +163,10 @@
       "startLine": 133,
       "endLine": 134
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Heart of CLT: Characteristic Function Convergence",
     "content": "**The Central Computation**: As $n \\to \\infty$, the characteristic function of $S_n$ converges pointwise to $e^{-t^2/2}$. This is the analytical core of CLT.\n\n**Topological insight**: We're watching the orbit of a distribution under the renormalization map $T_n(\\mu) = (1/\\sqrt{n}) \\cdot \\mu^{*n}$. The Gaussian is a fixed point, and all finite-variance distributions are in its basin of attraction.",
-    "mathContext": "The third moment condition ensures uniform convergence on compact sets, which is needed for the next step (Lévy's theorem).",
+    "mathContext": "The third moment condition ensures uniform convergence on compact sets, which is needed for the next step (L\u00e9vy's theorem).",
     "significance": "key",
     "prerequisites": [
       "ann-clt-taylor-theorem",
@@ -185,9 +185,9 @@
       "startLine": 182,
       "endLine": 192
     },
-    "type": "theorem",
-    "title": "Lévy Continuity Theorem",
-    "content": "**The Bridge**: Pointwise convergence of characteristic functions to a continuous function implies weak convergence of probability measures. This connects the Fourier (analysis) world to the distributional (probability) world.\n\nLévy's theorem is the inverse of the continuity of the Fourier transform: if the images converge, so do the preimages.",
+    "type": "insight",
+    "title": "L\u00e9vy Continuity Theorem",
+    "content": "**The Bridge**: Pointwise convergence of characteristic functions to a continuous function implies weak convergence of probability measures. This connects the Fourier (analysis) world to the distributional (probability) world.\n\nL\u00e9vy's theorem is the inverse of the continuity of the Fourier transform: if the images converge, so do the preimages.",
     "mathContext": "Continuity at $t=0$ is essential and automatic for characteristic functions (they equal 1 at 0). The theorem fails for discontinuous limits. Axiomatized as `levy_continuity_axiom` since the full proof requires tightness arguments not yet in Mathlib.",
     "significance": "key",
     "prerequisites": [
@@ -208,10 +208,10 @@
       "startLine": 209,
       "endLine": 219
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Central Limit Theorem",
     "content": "**Statement**: Let $X_1, X_2, \\ldots$ be i.i.d. with mean $\\mu$ and variance $\\sigma^2$. The normalized sum $Z_n = (\\sum X_i - n\\mu)/(\\sigma\\sqrt{n})$ converges in distribution to $N(0,1)$.\n\n**Classical interpretation**: Sums of random effects average toward the bell curve.\n\n**Topological interpretation**: The renormalization flow contracts all finite-variance distributions toward the Gaussian fixed point.",
-    "mathContext": "The proof assembles: (1) Taylor expansion of characteristic function, (2) product-to-exponential limit, (3) Lévy continuity. Each piece is classical; together they prove the most useful theorem in probability.",
+    "mathContext": "The proof assembles: (1) Taylor expansion of characteristic function, (2) product-to-exponential limit, (3) L\u00e9vy continuity. Each piece is classical; together they prove the most useful theorem in probability.",
     "significance": "key",
     "prerequisites": [
       "ann-clt-key-convergence",
@@ -276,10 +276,10 @@
       "startLine": 299,
       "endLine": 318
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Gaussian as Universal Attractor",
     "content": "**CLT Restated**: Every distribution with finite variance is in the basin of attraction of the Gaussian under the renormalization flow. Formally, $T_n(\\mu) \\to \\mathcal{N}$ in the Wasserstein metric as $n \\to \\infty$.\n\nThis is the dynamical systems view: we have a discrete dynamical system on $\\mathcal{P}_2$ with the Gaussian as a globally attracting fixed point (for finite-variance starting points).",
-    "mathContext": "The 'domain of attraction' is exactly the set of distributions with finite variance. Infinite variance leads to stable distributions with $\\alpha < 2$ (Lévy flights).",
+    "mathContext": "The 'domain of attraction' is exactly the set of distributions with finite variance. Infinite variance leads to stable distributions with $\\alpha < 2$ (L\u00e9vy flights).",
     "significance": "key",
     "prerequisites": [
       "ann-clt-topological-intro",
@@ -321,7 +321,7 @@
       "startLine": 349,
       "endLine": 365
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Fourier Self-Duality",
     "content": "The Gaussian is its own Fourier transform (up to scaling). This explains why the same function $e^{-t^2/2}$ appears as both the characteristic function AND the probability density (after appropriate normalization).\n\nSelf-duality under Fourier transform is a unique property that singles out the Gaussian among all probability distributions.",
     "mathContext": "More precisely: if $f(x) = e^{-x^2/2}/\\sqrt{2\\pi}$, then $\\hat{f}(\\xi) = e^{-\\xi^2/2}$. The Hermite functions (Gaussian times polynomials) form an orthonormal basis of eigenfunctions for the Fourier transform.",
@@ -344,7 +344,7 @@
       "startLine": 367,
       "endLine": 403
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Berry-Esseen: Rate of Convergence",
     "content": "**Quantitative CLT**: The Kolmogorov distance between $F_{Z_n}$ and $\\Phi$ (standard normal CDF) is $O(\\rho/\\sqrt{n})$, where $\\rho = \\mathbb{E}[|X|^3]$ is the third absolute moment.\n\n$\\sup_x |F_{Z_n}(x) - \\Phi(x)| \\leq \\frac{C \\rho}{\\sqrt{n}}$ with $C \\approx 0.4748$.\n\nThis tells us HOW FAST the convergence occurs, not just that it happens.",
     "mathContext": "The $1/\\sqrt{n}$ rate is optimal: there exist distributions achieving this rate. The constant $C$ has been refined by many authors.",
@@ -369,7 +369,7 @@
     },
     "type": "insight",
     "title": "Stable Distributions: Beyond Gaussian",
-    "content": "When variance is infinite, the Gaussian is no longer the attractor. Instead, **$\\alpha$-stable distributions** (Lévy distributions) emerge as limits. The Gaussian corresponds to $\\alpha = 2$; the Cauchy to $\\alpha = 1$.\n\nHeavy-tailed phenomena (earthquakes, financial crashes, network traffic) often follow stable laws with $\\alpha < 2$, exhibiting infinite variance and 'Lévy flights.'",
+    "content": "When variance is infinite, the Gaussian is no longer the attractor. Instead, **$\\alpha$-stable distributions** (L\u00e9vy distributions) emerge as limits. The Gaussian corresponds to $\\alpha = 2$; the Cauchy to $\\alpha = 1$.\n\nHeavy-tailed phenomena (earthquakes, financial crashes, network traffic) often follow stable laws with $\\alpha < 2$, exhibiting infinite variance and 'L\u00e9vy flights.'",
     "mathContext": "A distribution is $\\alpha$-stable if it is closed under convolution and appropriate rescaling: $X_1 + X_2 \\stackrel{d}{=} cX$ for some $c$. Only for $\\alpha = 2$ is variance finite.",
     "significance": "key",
     "prerequisites": [
@@ -379,7 +379,7 @@
     ],
     "relatedConcepts": [
       "stable distributions",
-      "Lévy flights",
+      "L\u00e9vy flights",
       "heavy tails",
       "power laws"
     ]
@@ -393,7 +393,7 @@
     },
     "type": "concept",
     "title": "Synthesis: Why the Gaussian is Universal",
-    "content": "The Central Limit Theorem reveals the Gaussian as a **mathematical necessity**, not an accident:\n\n1. **Dynamically**: It is the unique fixed-point attractor of the averaging operation\n2. **Information-theoretically**: It maximizes entropy at fixed variance\n3. **Analytically**: It is self-dual under Fourier transform\n4. **Probabilistically**: It is the only finite-variance stable distribution\n\nWherever we see many small independent effects being summed—measurement errors, thermal fluctuations, stock prices, IQ scores—the Gaussian emerges because averaging dynamics demand it.",
+    "content": "The Central Limit Theorem reveals the Gaussian as a **mathematical necessity**, not an accident:\n\n1. **Dynamically**: It is the unique fixed-point attractor of the averaging operation\n2. **Information-theoretically**: It maximizes entropy at fixed variance\n3. **Analytically**: It is self-dual under Fourier transform\n4. **Probabilistically**: It is the only finite-variance stable distribution\n\nWherever we see many small independent effects being summed\u2014measurement errors, thermal fluctuations, stock prices, IQ scores\u2014the Gaussian emerges because averaging dynamics demand it.",
     "mathContext": "Four independent characterizations of the Gaussian, each from a different branch of mathematics, all pointing to the same conclusion: $N(0,\\sigma^2)$ is the unique distribution that is simultaneously a fixed point of averaging, a maximum entropy distribution at fixed variance, an eigenfunction of the Fourier transform, and an $\\alpha$-stable distribution with $\\alpha = 2$.",
     "significance": "key",
     "prerequisites": [

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/annotations.json
@@ -6,10 +6,10 @@
       "startLine": 32,
       "endLine": 34
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Legendre's Formula for v_p(n!)",
     "content": "States Legendre's formula: the $p$-adic valuation of $n!$ is $v_p(n!) = \\sum_{i=1}^{n} \\lfloor n/p^i \\rfloor$. This is currently a `sorry` -- the connection between Mathlib's `Nat.factorization` API and the summation formula needs to be established.",
-    "mathContext": "$v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor = \\sum_{i=1}^{\\lfloor \\log_p n \\rfloor} \\lfloor n/p^i \\rfloor$. In Lean: `(n !).factorization p = ∑ i ∈ Finset.Ico 1 (n + 1), n / p ^ i`. The sum is finite since $\\lfloor n/p^i \\rfloor = 0$ for $p^i > n$.",
+    "mathContext": "$v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor = \\sum_{i=1}^{\\lfloor \\log_p n \\rfloor} \\lfloor n/p^i \\rfloor$. In Lean: `(n !).factorization p = \u2211 i \u2208 Finset.Ico 1 (n + 1), n / p ^ i`. The sum is finite since $\\lfloor n/p^i \\rfloor = 0$ for $p^i > n$.",
     "significance": "key",
     "prerequisites": [
       "p-adic valuation",
@@ -30,7 +30,7 @@
       "startLine": 41,
       "endLine": 45
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Carry Term Bound: Each Digit Contributes 0 or 1",
     "content": "Proves the fundamental carry bound: $\\lfloor 2n/p^i \\rfloor - 2\\lfloor n/p^i \\rfloor \\leq 1$ for all $i$. This is the combinatorial heart of the proof -- each position in the base-$p$ addition of $n + n$ generates at most one carry. The proof uses `omega` after establishing $2\\lfloor n/p^i \\rfloor \\leq \\lfloor 2n/p^i \\rfloor$.",
     "mathContext": "For any real $x$: $\\lfloor 2x \\rfloor - 2\\lfloor x \\rfloor \\in \\{0, 1\\}$. Writing $x = \\lfloor x \\rfloor + \\{x\\}$, we get $\\lfloor 2x \\rfloor = 2\\lfloor x \\rfloor + \\lfloor 2\\{x\\} \\rfloor$, and $\\lfloor 2\\{x\\} \\rfloor \\in \\{0, 1\\}$ since $0 \\leq \\{x\\} < 1$.",
@@ -54,7 +54,7 @@
       "startLine": 49,
       "endLine": 52
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Carry Terms Vanish for Large Powers",
     "content": "When $p^i > 2n$, the carry term $\\lfloor 2n/p^i \\rfloor = 0$ since the dividend is less than the divisor. This ensures the sum $\\sum_i (\\lfloor 2n/p^i \\rfloor - 2\\lfloor n/p^i \\rfloor)$ has only finitely many nonzero terms.",
     "mathContext": "$p^i > 2n \\Rightarrow \\lfloor 2n/p^i \\rfloor = 0$, so the carry term at position $i$ vanishes. Combined with the carry bound, this gives $v_p\\binom{2n}{n} \\leq \\lfloor \\log_p(2n) \\rfloor$.",
@@ -76,7 +76,7 @@
       "startLine": 55,
       "endLine": 68
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Existence of a Large Power of p",
     "content": "Proves that for any prime $p$ and $n \\geq 1$, there exists $k \\leq 2n$ such that $p^k > 2n$. The proof takes $k = 2n$ and shows $p^{2n} \\geq 2^{2n} > 2n$ by induction. This provides the truncation point for the carry sum, ensuring the valuation $v_p\\binom{2n}{n}$ is bounded by a computable quantity.",
     "mathContext": "$p \\geq 2 \\Rightarrow p^{2n} \\geq 2^{2n} \\geq 2n + 1 > 2n$ for $n \\geq 1$. The induction step: $2^{2(n+1)} = 4 \\cdot 2^{2n} \\geq 4(2n+1) = 8n + 4 \\geq 2(n+1) + 1$ for $n \\geq 0$.",
@@ -100,10 +100,10 @@
       "startLine": 78,
       "endLine": 80
     },
-    "type": "theorem",
-    "title": "Main Bound: p^{v_p(C(2n,n))} ≤ 2n",
+    "type": "insight",
+    "title": "Main Bound: p^{v_p(C(2n,n))} \u2264 2n",
     "content": "The **main theorem**: for any prime $p$ and $n \\geq 1$, $p^{v_p\\binom{2n}{n}} \\leq 2n$. Currently `sorry` -- requires connecting the carry infrastructure (proved) to Mathlib's `Nat.factorization` API. The proof sketch: $v_p\\binom{2n}{n} = \\sum_i \\text{carry}_i \\leq \\lfloor \\log_p(2n) \\rfloor$, so $p^{v_p} \\leq p^{\\log_p(2n)} = 2n$.",
-    "mathContext": "$p^{v_p\\binom{2n}{n}} \\leq 2n$. Equivalently: $v_p\\binom{2n}{n} \\leq \\log_p(2n)$. In Lean: `p ^ ((2 * n).choose n).factorization p ≤ 2 * n`.",
+    "mathContext": "$p^{v_p\\binom{2n}{n}} \\leq 2n$. Equivalently: $v_p\\binom{2n}{n} \\leq \\log_p(2n)$. In Lean: `p ^ ((2 * n).choose n).factorization p \u2264 2 * n`.",
     "significance": "key",
     "prerequisites": [
       "carry bound theorem",
@@ -125,10 +125,10 @@
       "startLine": 84,
       "endLine": 86
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Product Bound via Prime Counting",
     "content": "Corollary: $\\binom{2n}{n} \\leq (2n)^{\\pi(2n)}$. Since $\\binom{2n}{n} = \\prod_{p \\text{ prime}} p^{v_p\\binom{2n}{n}}$ and each factor is $\\leq 2n$, and there are $\\pi(2n)$ primes $\\leq 2n$, the product is bounded by $(2n)^{\\pi(2n)}$. Currently `sorry`.",
-    "mathContext": "$\\binom{2n}{n} = \\prod_{p \\leq 2n} p^{v_p\\binom{2n}{n}} \\leq \\prod_{p \\leq 2n} 2n = (2n)^{\\pi(2n)}$. In Lean: `(2 * n).choose n ≤ (2 * n) ^ (2 * n).primeCounting'`.",
+    "mathContext": "$\\binom{2n}{n} = \\prod_{p \\leq 2n} p^{v_p\\binom{2n}{n}} \\leq \\prod_{p \\leq 2n} 2n = (2n)^{\\pi(2n)}$. In Lean: `(2 * n).choose n \u2264 (2 * n) ^ (2 * n).primeCounting'`.",
     "significance": "key",
     "prerequisites": [
       "prime_pow_val_central_binom_le theorem",
@@ -139,7 +139,7 @@
       "prime counting function",
       "fundamental theorem of arithmetic",
       "multiplicative function bound",
-      "Erdős's argument"
+      "Erd\u0151s's argument"
     ]
   },
   {
@@ -149,7 +149,7 @@
       "startLine": 94,
       "endLine": 96
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Central Binomial Lower Bound",
     "content": "States $(2n+1) \\cdot \\binom{2n}{n} \\geq 4^n$. This follows from the binomial theorem: $4^n = (1+1)^{2n} = \\sum_{k=0}^{2n} \\binom{2n}{k} \\leq (2n+1) \\binom{2n}{n}$ since $\\binom{2n}{n}$ is the maximum binomial coefficient. Currently `sorry`.",
     "mathContext": "$4^n = 2^{2n} = \\sum_{k=0}^{2n} \\binom{2n}{k} \\leq (2n+1) \\cdot \\max_k \\binom{2n}{k} = (2n+1) \\cdot \\binom{2n}{n}$. Equivalently: $\\binom{2n}{n} \\geq 4^n/(2n+1)$.",
@@ -173,7 +173,7 @@
       "startLine": 101,
       "endLine": 103
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Chebyshev's Combined Inequality",
     "content": "The final synthesis: $4^n \\leq (2n+1) \\cdot (2n)^{\\pi(2n)}$. This combines the binomial lower bound with the product upper bound and yields, after taking logarithms: $\\pi(2n) \\geq (n \\ln 4 - \\ln(2n+1)) / \\ln(2n) \\sim n \\ln 4 / \\ln(2n)$. Currently `sorry`.",
     "mathContext": "$4^n \\leq (2n+1) \\cdot (2n)^{\\pi(2n)}$ implies $\\pi(2n) \\geq \\frac{n \\ln 4 - \\ln(2n+1)}{\\ln(2n)} \\sim \\frac{\\ln 4}{2} \\cdot \\frac{2n}{\\ln(2n)} \\approx 0.693 \\cdot \\frac{2n}{\\ln(2n)}$.",

--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01/annotations.json
@@ -1,44 +1,131 @@
 [
   {
     "id": "siegel-zero-existence-question",
-    "line": 45,
-    "type": "insight",
-    "title": "The Central Question",
-    "body": "The SiegelZeroConjecture asks whether every real primitive Dirichlet character χ of conductor q has L(s,χ) ≠ 0 in the region (1 - c/log(q), 1). This is equivalent to asking whether the effective Siegel theorem holds for ALL conductors without a single exception. The consensus (under GRH) is yes, but it is genuinely open unconditionally."
+    "proofId": "dirichlets-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "context",
+    "title": "The Central Open Question: Do Siegel Zeros Exist?",
+    "content": "The **SiegelZeroConjecture** asks whether every real primitive Dirichlet character χ of conductor q has L(s,χ) ≠ 0 in the region (1 - c/log(q), 1). This is equivalent to asking whether the effective Siegel theorem holds for ALL conductors without a single exception.\n\nThe consensus under GRH is yes — no Siegel zeros exist — but this remains genuinely open unconditionally. This formalization explores both worlds: World A (Siegel zeros exist) and World B (they do not), showing what we can prove in each case.",
+    "mathContext": "$\\text{SiegelZeroConjecture}$: $\\forall \\chi$ primitive real, $q = \\text{cond}(\\chi)$, $\\nexists \\beta \\in (1 - c/\\log q,\\, 1)$ with $L(\\beta, \\chi) = 0$. Equivalent to: $\\exists c > 0,\\, \\forall \\chi, q:\\, L(s, \\chi) \\neq 0$ for $\\text{Re}(s) > 1 - c/\\log q$.",
+    "significance": "context",
+    "prerequisites": [
+      "Dirichlet L-functions L(s,χ)",
+      "primitive real characters",
+      "conductor of a character",
+      "Siegel's theorem (ineffective lower bound on L(1,χ))"
+    ],
+    "relatedConcepts": [
+      "Generalized Riemann Hypothesis",
+      "effective vs ineffective bounds",
+      "Landau-Page theorem",
+      "analytic number theory"
+    ]
   },
   {
     "id": "two-worlds-structure",
-    "line": 55,
-    "type": "mathematical",
+    "proofId": "dirichlets-theorem-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 110 },
+    "type": "insight",
     "title": "World A vs World B Dichotomy",
-    "body": "The file organizes results around two worlds. In World A (¬SZC), a Siegel zero exists: L(1,χ) can be exponentially small (smaller than any q^{-ε}), but the Deuring-Heilbronn repulsion makes that conductor unique per region. In World B (SZC), all conductors are 'generic': effective bounds, Linnik L=2, extended Siegel-Walfisz all follow. The key tool for each world is different — Tatuzawa for World A, the effective zero-free region for World B."
+    "content": "The file organizes results around two mutually exclusive worlds:\n\n- **World A (¬SZC)**: A Siegel zero exists — L(1,χ) can be exponentially small (smaller than any q^{-ε}). Tatuzawa's theorem still provides effective bounds for all but one conductor, and the Deuring-Heilbronn repulsion makes that conductor unique per region.\n\n- **World B (SZC)**: All conductors are 'generic' — effective bounds, Linnik's exponent L=2, and extended Siegel-Walfisz all follow.\n\nThe key tools are different in each world: Tatuzawa for World A, the effective zero-free region for World B.",
+    "mathContext": "World A: $\\exists \\beta_1 \\in (1 - c/\\log q, 1)$ with $L(\\beta_1, \\chi_1) = 0$ for some primitive $\\chi_1$. World B: $\\forall \\chi, q:\\, L(s,\\chi) \\neq 0$ on $(1-c/\\log q, 1)$, giving $L(1,\\chi) \\gg (\\log q)^{-1}$ effectively.",
+    "significance": "key",
+    "prerequisites": [
+      "Siegel's theorem",
+      "Tatuzawa's theorem (one-exception effective bound)",
+      "zero-free regions for L-functions",
+      "Siegel-Walfisz theorem"
+    ],
+    "relatedConcepts": [
+      "Deuring-Heilbronn phenomenon",
+      "effective vs ineffective analytic estimates",
+      "Landau-Page uniqueness",
+      "Linnik's constant"
+    ]
   },
   {
     "id": "linnik-siegel-connection",
-    "line": 115,
-    "type": "mathematical",
-    "title": "Linnik's Theorem and Siegel Zeros",
-    "body": "Linnik's 1944 theorem states the smallest prime p ≡ a (mod q) satisfies p ≤ C·q^L for some absolute L. The exponent L is controlled by how bad Siegel zeros can be: current best is L ≤ 5 (Xylouris 2011). If no Siegel zeros exist (World B), then the effective zero-free region for all moduli gives L = 2, matching what GRH would give. The axiom effective_linnik_no_siegel captures this connection."
+    "proofId": "dirichlets-theorem-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 150 },
+    "type": "insight",
+    "title": "Linnik's Constant and Siegel Zeros",
+    "content": "**Linnik's 1944 theorem** states the smallest prime p ≡ a (mod q) satisfies p ≤ C·q^L for some absolute constant L (Linnik's exponent).\n\nThe exponent L is directly controlled by how bad Siegel zeros can be: the current best unconditional bound is L ≤ 5 (Xylouris 2011). If no Siegel zeros exist (World B), then the effective zero-free region for all moduli gives **L = 2**, matching what GRH would give.\n\nThe axiom `effective_linnik_no_siegel` captures this connection: SZC → L ≤ 2.",
+    "mathContext": "Linnik's theorem: $\\exists L, C > 0:\\, p(a,q) := \\min\\{p \\text{ prime}: p \\equiv a \\pmod{q}\\} \\leq C q^L$. Current best: $L \\leq 5$ (Xylouris). Under SZC: $L = 2$. Under GRH: $L = 2 + \\varepsilon$.",
+    "significance": "key",
+    "prerequisites": [
+      "Linnik's theorem on primes in arithmetic progressions",
+      "zero-free regions and the prime counting function",
+      "effective zero-free region under SZC"
+    ],
+    "relatedConcepts": [
+      "primes in arithmetic progressions",
+      "Linnik's constant",
+      "Xylouris 2011 bound L ≤ 5",
+      "GRH and arithmetic progressions"
+    ]
   },
   {
     "id": "landau-page-uniqueness",
-    "line": 155,
-    "type": "mathematical",
-    "title": "Landau-Page: At Most One Exception Per Region",
-    "body": "The Landau-Page theorem (axiomatized in the parent file) says at most one conductor N ≤ Q can have a zero in (1 - c/log(Q), 1). This uniqueness result, proved here as unique_exceptional_conductor_per_region and other_conductors_zero_free_near_one, shows Siegel zeros are 'self-limiting': if one exists, all other L-functions near that region get pushed to a wider zero-free band."
+    "proofId": "dirichlets-theorem-oq-01-oq-01",
+    "range": { "startLine": 151, "endLine": 190 },
+    "type": "insight",
+    "title": "Landau-Page: At Most One Exceptional Conductor Per Region",
+    "content": "The **Landau-Page theorem** says at most one conductor N ≤ Q can have a zero in (1 - c/log(Q), 1). This uniqueness result — formalized as `unique_exceptional_conductor_per_region` and `other_conductors_zero_free_near_one` — shows Siegel zeros are 'self-limiting'.\n\nIf one conductor N₁ has a Siegel zero, all other L-functions for conductors ≤ Q are *automatically* zero-free in a wider band. This is why Tatuzawa's theorem (World A) can still handle all-but-one conductor effectively.",
+    "mathContext": "$\\exists c > 0:\\, \\#\\{N \\leq Q : \\exists \\beta \\in (1 - c/\\log Q, 1),\\, L(\\beta, \\chi_N) = 0\\} \\leq 1$. For all other $N' \\leq Q$: $L(s, \\chi_{N'}) \\neq 0$ on $(1 - c/\\log Q, 1)$.",
+    "significance": "key",
+    "prerequisites": [
+      "Landau-Page theorem",
+      "primitive real characters per conductor",
+      "zero repulsion (Deuring-Heilbronn)"
+    ],
+    "relatedConcepts": [
+      "Tatuzawa's theorem",
+      "exceptional modulus",
+      "Deuring-Heilbronn phenomenon",
+      "primes in arithmetic progressions"
+    ]
   },
   {
     "id": "deuring-heilbronn-consequence",
-    "line": 190,
-    "type": "mathematical",
-    "title": "Deuring-Heilbronn Repulsion",
-    "body": "The theorem siegel_zero_creates_repulsion_region formalizes a key property of Siegel zeros: a zero at β₁ for conductor N₁ forces ALL other L-function zeros ρ to satisfy Re(ρ) < 1 - c₀·(1-β₁)/log(Q). The closer β₁ is to 1, the wider this zero-free region for other characters. This 'repulsion' phenomenon, due to Deuring (1933) and Heilbronn (1934), is why having one Siegel zero actually HELPS some analytic estimates."
+    "proofId": "dirichlets-theorem-oq-01-oq-01",
+    "range": { "startLine": 191, "endLine": 228 },
+    "type": "insight",
+    "title": "Deuring-Heilbronn Repulsion: One Siegel Zero Helps Others",
+    "content": "The theorem `siegel_zero_creates_repulsion_region` formalizes a counterintuitive property: a Siegel zero at β₁ for conductor N₁ forces ALL other L-function zeros ρ to satisfy:\n\n$$\\text{Re}(ρ) < 1 - c_0 \\cdot \\frac{1-β_1}{\\log Q}$$\n\nThe closer β₁ is to 1, the *wider* this zero-free region becomes for all other characters. This **repulsion phenomenon** (Deuring 1933, Heilbronn 1934) means having one Siegel zero actually *helps* some analytic estimates by forcing other L-functions further from the critical line.",
+    "mathContext": "Deuring-Heilbronn: $\\beta_1 \\in (1-c/\\log N_1, 1)$ with $L(\\beta_1, \\chi_1) = 0 \\Rightarrow \\forall \\chi \\neq \\chi_1,\\, \\forall \\rho: L(\\rho, \\chi) = 0:\\, \\text{Re}(\\rho) < 1 - c_0(1-\\beta_1)/\\log Q$. As $\\beta_1 \\to 1^-$, the bound $\\to 1 - 0 = 1$ (wider band).",
+    "significance": "key",
+    "prerequisites": [
+      "Deuring-Heilbronn theorem (1933-1934)",
+      "zero-free region width",
+      "real primitive characters and real zeros"
+    ],
+    "relatedConcepts": [
+      "zero repulsion",
+      "Landau-Page theorem",
+      "effective zero-free regions",
+      "character sum estimates"
+    ]
   },
   {
     "id": "three-tier-hierarchy",
-    "line": 230,
-    "type": "mathematical",
+    "proofId": "dirichlets-theorem-oq-01-oq-01",
+    "range": { "startLine": 229, "endLine": 280 },
+    "type": "insight",
     "title": "The Hierarchy: GRH → SZC → Nonvanishing",
-    "body": "The three_tier_hierarchy theorem captures the logical chain: GRH (no zeros with Re(s) ∈ (1/2,1)) implies SiegelZeroConjecture for the standard c < log(N)/2 range, because any Siegel zero in that range would lie in (1/2, 1) where GRH prohibits zeros. And SZC implies positive L-values via the proved nonvanishing theorem. The Siegel zero question is exactly the gap between GRH and unconditional nonvanishing."
+    "content": "The theorem `three_tier_hierarchy` captures the logical chain of implications:\n\n1. **GRH** (no zeros with Re(s) ∈ (1/2, 1)) implies **SiegelZeroConjecture** for the standard range c < log(N)/2, because any Siegel zero in that range would lie in (1/2, 1)\n2. **SZC** implies **positive L-values** via the proved nonvanishing theorem\n3. **Nonvanishing** is the unconditional result we can prove without GRH or SZC\n\nThe Siegel zero question is *exactly* the gap between GRH and unconditional nonvanishing — the hardest open step in the chain.",
+    "mathContext": "$\\text{GRH} \\Rightarrow \\text{SiegelZeroConjecture (standard range)} \\Rightarrow L(1, \\chi) > 0$. GRH: $L(s,\\chi) \\neq 0$ for $\\text{Re}(s) > 1/2$. SZC standard: $c < \\log(N)/2$. The gaps: GRH → SZC is open; SZC → $L(1,\\chi) > 0$ follows from definitions.",
+    "significance": "key",
+    "prerequisites": [
+      "Generalized Riemann Hypothesis",
+      "SiegelZeroConjecture",
+      "unconditional nonvanishing of L(1,χ)",
+      "implications between analytic conjectures"
+    ],
+    "relatedConcepts": [
+      "GRH",
+      "L-function nonvanishing",
+      "analytic class number formula",
+      "Dirichlet's theorem on primes in progressions"
+    ]
   }
 ]

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/annotations.json
@@ -2,11 +2,14 @@
   {
     "id": "ann-compact-surface",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 47, "endLine": 61 },
+    "range": {
+      "startLine": 47,
+      "endLine": 61
+    },
     "type": "definition",
     "title": "CompactRiemannianSurface: Minimal Axiomatization of Gauss-Bonnet",
-    "content": "Axiomatic structure encoding a compact orientable Riemannian 2-manifold: Euler characteristic χ(M), total Gaussian curvature ∫_M K dA, area ∫_M dA > 0, and the Gauss-Bonnet axiom ∫_M K dA = 2πχ. This is a minimal axiomatization — one axiom captures the entire Gauss-Bonnet theorem.\n\nMathlib v4.26.0 lacks Riemannian metrics and curvature tensors, so this axiomatization substitutes for the full differential-geometric proof. The structure requires area > 0 explicitly to enable division in average curvature computations.",
-    "mathContext": "The structure encodes: $\\chi(M) \\in \\mathbb{Z}$, $\\int_M K\\,dA \\in \\mathbb{R}$, $\\text{Area}(M) > 0$, and the axiom $\\int_M K\\,dA = 2\\pi\\chi(M)$. This is the smooth Gauss-Bonnet theorem — the discrete version (angular deficiency) appears in the parent proof EulerPolyhedralOQ02.lean.",
+    "content": "Axiomatic structure encoding a compact orientable Riemannian 2-manifold: Euler characteristic \u03c7(M), total Gaussian curvature \u222b_M K dA, area \u222b_M dA > 0, and the Gauss-Bonnet axiom \u222b_M K dA = 2\u03c0\u03c7. This is a minimal axiomatization \u2014 one axiom captures the entire Gauss-Bonnet theorem.\n\nMathlib v4.26.0 lacks Riemannian metrics and curvature tensors, so this axiomatization substitutes for the full differential-geometric proof. The structure requires area > 0 explicitly to enable division in average curvature computations.",
+    "mathContext": "The structure encodes: $\\chi(M) \\in \\mathbb{Z}$, $\\int_M K\\,dA \\in \\mathbb{R}$, $\\text{Area}(M) > 0$, and the axiom $\\int_M K\\,dA = 2\\pi\\chi(M)$. This is the smooth Gauss-Bonnet theorem \u2014 the discrete version (angular deficiency) appears in the parent proof EulerPolyhedralOQ02.lean.",
     "significance": "key",
     "relatedConcepts": [
       "Riemannian manifold",
@@ -25,10 +28,13 @@
   {
     "id": "ann-orientable-surface",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 63, "endLine": 75 },
+    "range": {
+      "startLine": 63,
+      "endLine": 75
+    },
     "type": "definition",
-    "title": "OrientableClosedSurface: Genus Extension and χ = 2 − 2g",
-    "content": "Extends CompactRiemannianSurface with genus g ∈ ℕ and the topological relation χ = 2 − 2g. This encodes the classification of orientable closed surfaces: the genus (number of handles) uniquely determines the Euler characteristic.\n\n`total_curvature_genus` immediately follows: substituting χ = 2−2g into Gauss-Bonnet gives ∫K dA = 2π(2−2g) = 4π(1−g). `genus_from_total_curvature` inverts this, showing the genus is uniquely determined by total curvature.",
+    "title": "OrientableClosedSurface: Genus Extension and \u03c7 = 2 \u2212 2g",
+    "content": "Extends CompactRiemannianSurface with genus g \u2208 \u2115 and the topological relation \u03c7 = 2 \u2212 2g. This encodes the classification of orientable closed surfaces: the genus (number of handles) uniquely determines the Euler characteristic.\n\n`total_curvature_genus` immediately follows: substituting \u03c7 = 2\u22122g into Gauss-Bonnet gives \u222bK dA = 2\u03c0(2\u22122g) = 4\u03c0(1\u2212g). `genus_from_total_curvature` inverts this, showing the genus is uniquely determined by total curvature.",
     "mathContext": "For an orientable closed surface of genus $g$: $\\chi(M) = 2 - 2g$. This follows from the Betti numbers: $b_0 = 1$, $b_1 = 2g$, $b_2 = 1$, giving $\\chi = 1 - 2g + 1 = 2 - 2g$. The genus counts the number of handles: $g=0$ (sphere), $g=1$ (torus), $g=2$ (double torus).",
     "significance": "key",
     "relatedConcepts": [
@@ -46,11 +52,14 @@
   {
     "id": "ann-gauss-bonnet",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 89, "endLine": 98 },
-    "type": "theorem",
-    "title": "Gauss-Bonnet: ∫K dA = 2πχ Connecting Geometry to Topology",
-    "content": "States the Gauss-Bonnet theorem as a theorem (unwrapping the structure axiom): ∫_M K dA = 2πχ(M). This is the central result connecting local geometry to global topology — changing the Riemannian metric changes K pointwise but not the integral.\n\nThe proof for embedded surfaces uses Stokes' theorem applied to the connection form; Chern's intrinsic proof uses the Pfaffian of the curvature 2-form. Here it is simply `S.gauss_bonnet`, the structure axiom. The theorem statement also establishes `total_curvature_topological_invariant` and `curvature_metric_independent` as immediate consequences.",
-    "mathContext": "$$\\int_M K\\,dA = 2\\pi\\chi(M)$$\nFor the sphere ($\\chi = 2$): $\\int K\\,dA = 4\\pi$. For the torus ($\\chi = 0$): $\\int K\\,dA = 0$ — so the total curvature of the flat and round tori are identical, even though pointwise curvatures differ. This metric independence is the profound content of Gauss-Bonnet.",
+    "range": {
+      "startLine": 89,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Gauss-Bonnet: \u222bK dA = 2\u03c0\u03c7 Connecting Geometry to Topology",
+    "content": "States the Gauss-Bonnet theorem as a theorem (unwrapping the structure axiom): \u222b_M K dA = 2\u03c0\u03c7(M). This is the central result connecting local geometry to global topology \u2014 changing the Riemannian metric changes K pointwise but not the integral.\n\nThe proof for embedded surfaces uses Stokes' theorem applied to the connection form; Chern's intrinsic proof uses the Pfaffian of the curvature 2-form. Here it is simply `S.gauss_bonnet`, the structure axiom. The theorem statement also establishes `total_curvature_topological_invariant` and `curvature_metric_independent` as immediate consequences.",
+    "mathContext": "$$\\int_M K\\,dA = 2\\pi\\chi(M)$$\nFor the sphere ($\\chi = 2$): $\\int K\\,dA = 4\\pi$. For the torus ($\\chi = 0$): $\\int K\\,dA = 0$ \u2014 so the total curvature of the flat and round tori are identical, even though pointwise curvatures differ. This metric independence is the profound content of Gauss-Bonnet.",
     "significance": "key",
     "relatedConcepts": [
       "Gauss-Bonnet theorem",
@@ -67,10 +76,13 @@
   {
     "id": "ann-topological-invariance",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 95, "endLine": 109 },
-    "type": "theorem",
+    "range": {
+      "startLine": 95,
+      "endLine": 109
+    },
+    "type": "insight",
     "title": "Total Curvature as Topological Invariant: Metric Independence",
-    "content": "Total curvature is a topological invariant: surfaces with the same Euler characteristic have the same total curvature, regardless of which Riemannian metric they carry. `total_curvature_topological_invariant` and `curvature_metric_independent` both follow immediately from substituting ∫K dA = 2πχ.\n\nThis is the profound content of Gauss-Bonnet — geometry is constrained by topology. One can freely deform the metric without changing the total curvature, as long as the topology is preserved.",
+    "content": "Total curvature is a topological invariant: surfaces with the same Euler characteristic have the same total curvature, regardless of which Riemannian metric they carry. `total_curvature_topological_invariant` and `curvature_metric_independent` both follow immediately from substituting \u222bK dA = 2\u03c0\u03c7.\n\nThis is the profound content of Gauss-Bonnet \u2014 geometry is constrained by topology. One can freely deform the metric without changing the total curvature, as long as the topology is preserved.",
     "mathContext": "If $\\chi(S_1) = \\chi(S_2)$, then $\\int_{S_1} K_1\\,dA_1 = \\int_{S_2} K_2\\,dA_2$. The metrics on $S_1, S_2$ can be completely different; only the topology matters. Proof: both sides equal $2\\pi\\chi$ by Gauss-Bonnet.",
     "significance": "key",
     "relatedConcepts": [
@@ -86,10 +98,13 @@
   {
     "id": "ann-curvature-sign",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 112, "endLine": 136 },
-    "type": "theorem",
-    "title": "Curvature Sign ↔ Euler Characteristic Sign (Three Cases)",
-    "content": "Three fundamental curvature-topology constraints: positive total curvature implies χ > 0, negative implies χ < 0, zero implies χ = 0. Each proof substitutes ∫K dA = 2πχ and uses `nlinarith` with π > 0 to derive the sign of χ from the sign of the integral.\n\nThese sign constraints are the first level of topological classification: a surface with ∫K > 0 must be topologically a sphere (χ > 0 → g = 0), ∫K = 0 must be a torus (g = 1), and ∫K < 0 must have genus ≥ 2.",
+    "range": {
+      "startLine": 112,
+      "endLine": 136
+    },
+    "type": "insight",
+    "title": "Curvature Sign \u2194 Euler Characteristic Sign (Three Cases)",
+    "content": "Three fundamental curvature-topology constraints: positive total curvature implies \u03c7 > 0, negative implies \u03c7 < 0, zero implies \u03c7 = 0. Each proof substitutes \u222bK dA = 2\u03c0\u03c7 and uses `nlinarith` with \u03c0 > 0 to derive the sign of \u03c7 from the sign of the integral.\n\nThese sign constraints are the first level of topological classification: a surface with \u222bK > 0 must be topologically a sphere (\u03c7 > 0 \u2192 g = 0), \u222bK = 0 must be a torus (g = 1), and \u222bK < 0 must have genus \u2265 2.",
     "mathContext": "$\\int K\\,dA > 0 \\Rightarrow \\chi > 0$, $\\int K\\,dA < 0 \\Rightarrow \\chi < 0$, $\\int K\\,dA = 0 \\Rightarrow \\chi = 0$. Since $\\int K\\,dA = 2\\pi\\chi$ and $\\pi > 0$, the sign of $\\chi$ matches the sign of $\\int K\\,dA$. Proofs use `nlinarith [Real.pi_pos, S.gauss_bonnet]`.",
     "significance": "key",
     "relatedConcepts": [
@@ -107,10 +122,13 @@
   {
     "id": "ann-special-surfaces",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 140, "endLine": 172 },
-    "type": "theorem",
-    "title": "Total Curvature by Genus: 4π, 0, −4π, and 4π(1−g) General",
-    "content": "Computes total curvature for each genus: sphere (g=0) gives 4π, torus (g=1) gives 0, double torus (g=2) gives −4π. The general formula ∫K dA = 4π(1−g) follows from 2π(2−2g) = 4π(1−g). Each theorem is proved by substituting the genus into `total_curvature_genus` and using `linarith`.\n\nEach additional handle reduces the total curvature by 4π. The genus uniquely determines total curvature: adding one handle means adding a negatively-curved region that exactly cancels 4π of positive curvature.",
+    "range": {
+      "startLine": 140,
+      "endLine": 172
+    },
+    "type": "insight",
+    "title": "Total Curvature by Genus: 4\u03c0, 0, \u22124\u03c0, and 4\u03c0(1\u2212g) General",
+    "content": "Computes total curvature for each genus: sphere (g=0) gives 4\u03c0, torus (g=1) gives 0, double torus (g=2) gives \u22124\u03c0. The general formula \u222bK dA = 4\u03c0(1\u2212g) follows from 2\u03c0(2\u22122g) = 4\u03c0(1\u2212g). Each theorem is proved by substituting the genus into `total_curvature_genus` and using `linarith`.\n\nEach additional handle reduces the total curvature by 4\u03c0. The genus uniquely determines total curvature: adding one handle means adding a negatively-curved region that exactly cancels 4\u03c0 of positive curvature.",
     "mathContext": "Genus $0$: $\\int K\\,dA = 4\\pi$. Genus $1$: $\\int K\\,dA = 0$. Genus $2$: $\\int K\\,dA = -4\\pi$. General: $\\int K\\,dA = 4\\pi(1 - g)$. Each step more negative by $4\\pi$ per handle added. Derived from $\\int K = 2\\pi\\chi = 2\\pi(2-2g) = 4\\pi(1-g)$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -118,7 +136,7 @@
       "torus",
       "genus formula",
       "handle addition",
-      "4π per handle"
+      "4\u03c0 per handle"
     ],
     "prerequisites": [
       "total_curvature_genus",
@@ -128,11 +146,14 @@
   {
     "id": "ann-genus-determination",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 175, "endLine": 200 },
-    "type": "theorem",
+    "range": {
+      "startLine": 175,
+      "endLine": 200
+    },
+    "type": "insight",
     "title": "Curvature Sign Determines Topology: Sphere/Torus/Hyperbolic Classification",
-    "content": "Complete classification from curvature sign: ∫K dA > 0 forces genus 0 (sphere), = 0 forces genus 1 (torus), < 0 forces genus ≥ 2. The negative case uses `by_contra` and `omega` to eliminate g = 0 (where ∫K = 4π > 0, contradicting ∫K < 0) and g = 1 (where ∫K = 0, also contradicting).\n\nThis is the topological content of the **uniformization theorem**: every closed surface admits a metric of constant curvature +1, 0, or −1 matching its genus class.",
-    "mathContext": "$\\int K > 0 \\Rightarrow g = 0$ (sphere), $\\int K = 0 \\Rightarrow g = 1$ (torus), $\\int K < 0 \\Rightarrow g \\geq 2$ (hyperbolic). The uniformization theorem guarantees a round metric (K≡1) for genus 0, a flat metric (K≡0) for genus 1, and a hyperbolic metric (K≡−1) for genus ≥ 2.",
+    "content": "Complete classification from curvature sign: \u222bK dA > 0 forces genus 0 (sphere), = 0 forces genus 1 (torus), < 0 forces genus \u2265 2. The negative case uses `by_contra` and `omega` to eliminate g = 0 (where \u222bK = 4\u03c0 > 0, contradicting \u222bK < 0) and g = 1 (where \u222bK = 0, also contradicting).\n\nThis is the topological content of the **uniformization theorem**: every closed surface admits a metric of constant curvature +1, 0, or \u22121 matching its genus class.",
+    "mathContext": "$\\int K > 0 \\Rightarrow g = 0$ (sphere), $\\int K = 0 \\Rightarrow g = 1$ (torus), $\\int K < 0 \\Rightarrow g \\geq 2$ (hyperbolic). The uniformization theorem guarantees a round metric (K\u22611) for genus 0, a flat metric (K\u22610) for genus 1, and a hyperbolic metric (K\u2261\u22121) for genus \u2265 2.",
     "significance": "key",
     "relatedConcepts": [
       "uniformization theorem",
@@ -151,10 +172,13 @@
   {
     "id": "ann-average-curvature",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 203, "endLine": 238 },
+    "range": {
+      "startLine": 203,
+      "endLine": 238
+    },
     "type": "definition",
-    "title": "Average Gaussian Curvature: K_avg = 2πχ / Area",
-    "content": "Average Gaussian curvature K_avg = ∫K dA / Area(M). By Gauss-Bonnet, K_avg = 2πχ / Area. Verified concretely: unit sphere (area 4π) has K_avg = 1, flat torus has K_avg = 0. The average curvature is always determined by topology and area.\n\nThe `averageCurvature` def requires `area_pos` in CompactRiemannianSurface to make division safe. The Lean proof of `unit_sphere_curvature` uses `simp [averageCurvature, standardSphere]` — the key is that 4π/4π reduces to 1 via `div_self`.",
+    "title": "Average Gaussian Curvature: K_avg = 2\u03c0\u03c7 / Area",
+    "content": "Average Gaussian curvature K_avg = \u222bK dA / Area(M). By Gauss-Bonnet, K_avg = 2\u03c0\u03c7 / Area. Verified concretely: unit sphere (area 4\u03c0) has K_avg = 1, flat torus has K_avg = 0. The average curvature is always determined by topology and area.\n\nThe `averageCurvature` def requires `area_pos` in CompactRiemannianSurface to make division safe. The Lean proof of `unit_sphere_curvature` uses `simp [averageCurvature, standardSphere]` \u2014 the key is that 4\u03c0/4\u03c0 reduces to 1 via `div_self`.",
     "mathContext": "$K_{\\text{avg}} = \\frac{\\int_M K\\,dA}{\\text{Area}(M)} = \\frac{2\\pi\\chi(M)}{\\text{Area}(M)}$. For the unit sphere: $K_{\\text{avg}} = 4\\pi / 4\\pi = 1$. For any flat torus: $K_{\\text{avg}} = 0/\\text{Area} = 0$. The average curvature captures the 'intrinsic roundness' normalized by size.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -172,10 +196,13 @@
   {
     "id": "ann-area-bound",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 262, "endLine": 281 },
-    "type": "theorem",
-    "title": "Bonnet-Type Area Bound: Area ≤ 4π/K_min for Positive Curvature",
-    "content": "Bonnet-type area bound: for a sphere (g=0) with K ≥ K_min > 0 everywhere, Area ≤ 4π/K_min. The proof uses K_min · Area ≤ ∫K dA = 4π. This is the 2D analogue of Bonnet's theorem (diameter ≤ π/√K_min), connecting curvature lower bounds to compactness.\n\n`bonnet_genus_zero` combines this with the genus constraint: a surface with everywhere-positive curvature must be a sphere. The proof combines `area_bound_positive_curvature` with `positive_curvature_is_sphere`.",
+    "range": {
+      "startLine": 262,
+      "endLine": 281
+    },
+    "type": "insight",
+    "title": "Bonnet-Type Area Bound: Area \u2264 4\u03c0/K_min for Positive Curvature",
+    "content": "Bonnet-type area bound: for a sphere (g=0) with K \u2265 K_min > 0 everywhere, Area \u2264 4\u03c0/K_min. The proof uses K_min \u00b7 Area \u2264 \u222bK dA = 4\u03c0. This is the 2D analogue of Bonnet's theorem (diameter \u2264 \u03c0/\u221aK_min), connecting curvature lower bounds to compactness.\n\n`bonnet_genus_zero` combines this with the genus constraint: a surface with everywhere-positive curvature must be a sphere. The proof combines `area_bound_positive_curvature` with `positive_curvature_is_sphere`.",
     "mathContext": "If $K \\geq K_{\\min} > 0$ on a sphere: $\\text{Area}(M) \\leq \\frac{4\\pi}{K_{\\min}}$. Equality holds for the round sphere of radius $r = 1/\\sqrt{K_{\\min}}$ with area $4\\pi r^2 = 4\\pi/K_{\\min}$. The Lean proof: $K_{\\min} \\cdot \\text{Area} \\leq \\int K\\,dA = 4\\pi$ by monotone integration, then `div_le_iff`.",
     "significance": "key",
     "relatedConcepts": [
@@ -194,10 +221,13 @@
   {
     "id": "ann-discrete-connection",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 297, "endLine": 313 },
-    "type": "theorem",
-    "title": "Smooth = Discrete: Both Yield 2πχ as Total Curvature",
-    "content": "Proves smooth and discrete Gauss-Bonnet agree: both give 2πχ as total curvature. The smooth version uses K (Gaussian curvature), the discrete uses δ(v) = 2π − Σθ (angular deficiency). As a triangulation refines (mesh → 0), Σ_v δ(v) → ∫_M K dA, justifying finite element methods in geometric computing.\n\nThe theorems `sphere_agreement`, `torus_agreement`, and `double_torus_agreement` compute numerically: $2\\pi \\cdot 2 = 4\\pi$, $2\\pi \\cdot 0 = 0$, $2\\pi \\cdot (-2) = -4\\pi$, proved by `push_cast; ring`.",
+    "range": {
+      "startLine": 297,
+      "endLine": 313
+    },
+    "type": "insight",
+    "title": "Smooth = Discrete: Both Yield 2\u03c0\u03c7 as Total Curvature",
+    "content": "Proves smooth and discrete Gauss-Bonnet agree: both give 2\u03c0\u03c7 as total curvature. The smooth version uses K (Gaussian curvature), the discrete uses \u03b4(v) = 2\u03c0 \u2212 \u03a3\u03b8 (angular deficiency). As a triangulation refines (mesh \u2192 0), \u03a3_v \u03b4(v) \u2192 \u222b_M K dA, justifying finite element methods in geometric computing.\n\nThe theorems `sphere_agreement`, `torus_agreement`, and `double_torus_agreement` compute numerically: $2\\pi \\cdot 2 = 4\\pi$, $2\\pi \\cdot 0 = 0$, $2\\pi \\cdot (-2) = -4\\pi$, proved by `push_cast; ring`.",
     "mathContext": "Smooth: $\\int_M K\\,dA = 2\\pi\\chi(M)$. Discrete: $\\sum_v \\delta(v) = 2\\pi\\chi(M)$. Both yield $4\\pi$ for $S^2$, $0$ for $T^2$, $-4\\pi$ for genus $2$. The discrete-to-smooth limit: $\\lim_{\\text{mesh} \\to 0} \\sum_v \\delta(v) = \\int_M K\\,dA$. This limit is not formalized here but motivates the connection.",
     "significance": "key",
     "relatedConcepts": [
@@ -216,10 +246,13 @@
   {
     "id": "ann-chern-generalization",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 331, "endLine": 352 },
+    "range": {
+      "startLine": 331,
+      "endLine": 352
+    },
     "type": "definition",
-    "title": "Chern-Gauss-Bonnet for 2n-Manifolds: ∫Pf(Ω) = (2π)^n χ",
-    "content": "Axiomatizes the Chern-Gauss-Bonnet theorem for compact oriented 2n-manifolds: ∫_M Pf(Ω) = (2π)^n χ(M), where Pf(Ω) is the Pfaffian of the curvature 2-form. Proves the n=1 (surface) case reduces to classical Gauss-Bonnet via (2π)^1 · χ = 2πχ.\n\nThe `ChernGaussBonnetManifold` structure encodes dimension n, Pfaffian integral, and Euler characteristic with the axiom. `chern_gb_surface` specializes to n=1 and shows the formula matches `CompactRiemannianSurface.gauss_bonnet` up to the factor (2π)^1 = 2π.",
+    "title": "Chern-Gauss-Bonnet for 2n-Manifolds: \u222bPf(\u03a9) = (2\u03c0)^n \u03c7",
+    "content": "Axiomatizes the Chern-Gauss-Bonnet theorem for compact oriented 2n-manifolds: \u222b_M Pf(\u03a9) = (2\u03c0)^n \u03c7(M), where Pf(\u03a9) is the Pfaffian of the curvature 2-form. Proves the n=1 (surface) case reduces to classical Gauss-Bonnet via (2\u03c0)^1 \u00b7 \u03c7 = 2\u03c0\u03c7.\n\nThe `ChernGaussBonnetManifold` structure encodes dimension n, Pfaffian integral, and Euler characteristic with the axiom. `chern_gb_surface` specializes to n=1 and shows the formula matches `CompactRiemannianSurface.gauss_bonnet` up to the factor (2\u03c0)^1 = 2\u03c0.",
     "mathContext": "For compact oriented $2n$-manifolds: $\\int_M \\text{Pf}(\\Omega) = (2\\pi)^n \\chi(M)$. For surfaces ($n=1$): $\\text{Pf}(\\Omega) = K\\,dA / (2\\pi)$, recovering $\\int K\\,dA = 2\\pi\\chi$. Full formalization requires exterior algebra and Pfaffians beyond current Mathlib scope. The n=4 case is relevant to the Atiyah-Singer index theorem.",
     "significance": "key",
     "relatedConcepts": [
@@ -238,15 +271,18 @@
   {
     "id": "ann-hairy-ball",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 357, "endLine": 383 },
-    "type": "theorem",
-    "title": "Hairy Ball: χ = 2 for Sphere Forces Every Vector Field to Vanish",
-    "content": "The sphere has χ = 2, which by Poincaré-Hopf implies every tangent vector field on S² has zeros (sum of indices = χ = 2 ≠ 0). The torus has χ = 0 and admits nowhere-vanishing vector fields. These are topological applications of the Gauss-Bonnet computation.\n\nTheorems proved here: `sphere_chi_two` (g=0 → χ=2), `torus_chi_zero` (g=1 → χ=0), `chi_from_genus` (general χ=2−2g), `same_genus_same_chi` (isomorphic genera → same χ), `same_genus_same_curvature` (same genus → same ∫K dA).",
-    "mathContext": "Sphere: $\\chi(S^2) = 2 - 2 \\cdot 0 = 2$. By **Poincaré-Hopf**: $\\sum_p \\text{ind}_p(X) = \\chi(M)$. Since $\\chi(S^2) = 2 \\neq 0$, every vector field on $S^2$ must vanish somewhere — the **hairy ball theorem**. Torus: $\\chi(T^2) = 0$, so nowhere-vanishing fields exist (e.g., a constant-direction flow).",
+    "range": {
+      "startLine": 357,
+      "endLine": 383
+    },
+    "type": "insight",
+    "title": "Hairy Ball: \u03c7 = 2 for Sphere Forces Every Vector Field to Vanish",
+    "content": "The sphere has \u03c7 = 2, which by Poincar\u00e9-Hopf implies every tangent vector field on S\u00b2 has zeros (sum of indices = \u03c7 = 2 \u2260 0). The torus has \u03c7 = 0 and admits nowhere-vanishing vector fields. These are topological applications of the Gauss-Bonnet computation.\n\nTheorems proved here: `sphere_chi_two` (g=0 \u2192 \u03c7=2), `torus_chi_zero` (g=1 \u2192 \u03c7=0), `chi_from_genus` (general \u03c7=2\u22122g), `same_genus_same_chi` (isomorphic genera \u2192 same \u03c7), `same_genus_same_curvature` (same genus \u2192 same \u222bK dA).",
+    "mathContext": "Sphere: $\\chi(S^2) = 2 - 2 \\cdot 0 = 2$. By **Poincar\u00e9-Hopf**: $\\sum_p \\text{ind}_p(X) = \\chi(M)$. Since $\\chi(S^2) = 2 \\neq 0$, every vector field on $S^2$ must vanish somewhere \u2014 the **hairy ball theorem**. Torus: $\\chi(T^2) = 0$, so nowhere-vanishing fields exist (e.g., a constant-direction flow).",
     "significance": "supporting",
     "relatedConcepts": [
       "hairy ball theorem",
-      "Poincaré-Hopf theorem",
+      "Poincar\u00e9-Hopf theorem",
       "vector field index",
       "tangent bundle",
       "chi_from_genus"
@@ -254,16 +290,19 @@
     "prerequisites": [
       "OrientableClosedSurface",
       "chi_genus",
-      "Poincaré-Hopf (not formalized here)"
+      "Poincar\u00e9-Hopf (not formalized here)"
     ]
   },
   {
     "id": "ann-concrete-examples",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 390, "endLine": 432 },
+    "range": {
+      "startLine": 390,
+      "endLine": 432
+    },
     "type": "definition",
     "title": "Concrete Surface Instances: standardSphere, flatTorus, hyperbolicGenus2",
-    "content": "Three concrete OrientableClosedSurface instances: (1) standardSphere (area 4π, K_avg = 1), (2) flatTorus with parameters a,b > 0 (area ab, K_avg = 0), (3) hyperbolicGenus2 (area 4π, K_avg = −1). All verify Gauss-Bonnet via `ring` and chi_genus via `norm_num`.\n\nVerification theorems: `standardSphere_avg_curvature` (K_avg = 1), `flatTorus_avg_curvature` (K_avg = 0), `hyperbolicGenus2_avg_curvature` (K_avg = −1). These serve as sanity checks that the structure axioms are satisfied.",
+    "content": "Three concrete OrientableClosedSurface instances: (1) standardSphere (area 4\u03c0, K_avg = 1), (2) flatTorus with parameters a,b > 0 (area ab, K_avg = 0), (3) hyperbolicGenus2 (area 4\u03c0, K_avg = \u22121). All verify Gauss-Bonnet via `ring` and chi_genus via `norm_num`.\n\nVerification theorems: `standardSphere_avg_curvature` (K_avg = 1), `flatTorus_avg_curvature` (K_avg = 0), `hyperbolicGenus2_avg_curvature` (K_avg = \u22121). These serve as sanity checks that the structure axioms are satisfied.",
     "mathContext": "Standard sphere: $\\text{Area} = 4\\pi$, $K = 1$ constant, $\\int K\\,dA = 4\\pi = 2\\pi \\cdot 2$. Flat torus: $\\text{Area} = ab$, $K = 0$, $\\int K\\,dA = 0 = 2\\pi \\cdot 0$. Hyperbolic genus 2: $\\text{Area} = 4\\pi$ (normalized so $K = -1$ gives $\\int K\\,dA = -4\\pi = 2\\pi \\cdot (-2)$). Gauss-Bonnet: `by ring` in all three cases.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -283,11 +322,14 @@
   {
     "id": "ann-boundary-gauss-bonnet",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 452, "endLine": 469 },
+    "range": {
+      "startLine": 452,
+      "endLine": 469
+    },
     "type": "definition",
-    "title": "Gauss-Bonnet with Boundary: ∫K dA + ∫κ_g ds = 2πχ",
-    "content": "CompactSurfaceWithBoundary extends the Gauss-Bonnet framework to surfaces with boundary: ∫_M K dA + ∫_∂M κ_g ds = 2πχ(M). The boundary geodesic curvature term captures how the boundary curves relative to the surface.\n\n`closed_surface_from_boundary` shows that when boundary geodesic curvature is zero (geodesic boundary), the formula reduces to the closed Gauss-Bonnet. Special cases: disk (χ=1) gives ∫K + ∫κ_g = 2π; flat surface (K=0) gives ∫κ_g = 2πχ (the 'turning tangents' theorem).",
-    "mathContext": "$$\\int_M K\\,dA + \\int_{\\partial M} \\kappa_g\\,ds = 2\\pi\\chi(M)$$\nFor a disk ($\\chi = 1$): $\\int K\\,dA + \\int \\kappa_g\\,ds = 2\\pi$. For geodesic boundary ($\\kappa_g = 0$): recovers the closed Gauss-Bonnet. The half-disk: ∫K dA = 0 (flat), ∫κ_g ds = π (half-circle) + 0 (diameter geodesic) = π, and 2πχ = 2π·1 = 2π — wait, that's π ≠ 2π. The corners contribute π at the two right-angle corners.",
+    "title": "Gauss-Bonnet with Boundary: \u222bK dA + \u222b\u03ba_g ds = 2\u03c0\u03c7",
+    "content": "CompactSurfaceWithBoundary extends the Gauss-Bonnet framework to surfaces with boundary: \u222b_M K dA + \u222b_\u2202M \u03ba_g ds = 2\u03c0\u03c7(M). The boundary geodesic curvature term captures how the boundary curves relative to the surface.\n\n`closed_surface_from_boundary` shows that when boundary geodesic curvature is zero (geodesic boundary), the formula reduces to the closed Gauss-Bonnet. Special cases: disk (\u03c7=1) gives \u222bK + \u222b\u03ba_g = 2\u03c0; flat surface (K=0) gives \u222b\u03ba_g = 2\u03c0\u03c7 (the 'turning tangents' theorem).",
+    "mathContext": "$$\\int_M K\\,dA + \\int_{\\partial M} \\kappa_g\\,ds = 2\\pi\\chi(M)$$\nFor a disk ($\\chi = 1$): $\\int K\\,dA + \\int \\kappa_g\\,ds = 2\\pi$. For geodesic boundary ($\\kappa_g = 0$): recovers the closed Gauss-Bonnet. The half-disk: \u222bK dA = 0 (flat), \u222b\u03ba_g ds = \u03c0 (half-circle) + 0 (diameter geodesic) = \u03c0, and 2\u03c0\u03c7 = 2\u03c0\u00b71 = 2\u03c0 \u2014 wait, that's \u03c0 \u2260 2\u03c0. The corners contribute \u03c0 at the two right-angle corners.",
     "significance": "key",
     "relatedConcepts": [
       "geodesic curvature",
@@ -304,10 +346,13 @@
   {
     "id": "ann-girard-formula",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 525, "endLine": 598 },
+    "range": {
+      "startLine": 525,
+      "endLine": 598
+    },
     "type": "definition",
-    "title": "Girard's Formula (1629): K·Area = α + β + γ − π for Geodesic Triangles",
-    "content": "Girard's formula (1629): on a surface of constant curvature K, a geodesic triangle has K·Area = (α + β + γ − π). On the unit sphere: Area = α + β + γ − π (the spherical excess). This directly follows from the polygon Gauss-Bonnet with χ = 1.\n\nRelated theorems proved: `unit_sphere_triangle_area`, `positive_curvature_angle_excess` (α+β+γ > π), `flat_angle_sum_pi` (K=0 recovers Euclidean), `negative_curvature_angle_deficit` (K<0 gives α+β+γ < π), `hyperbolic_triangle_area_bound` (0 < Area < π for K=−1).",
+    "title": "Girard's Formula (1629): K\u00b7Area = \u03b1 + \u03b2 + \u03b3 \u2212 \u03c0 for Geodesic Triangles",
+    "content": "Girard's formula (1629): on a surface of constant curvature K, a geodesic triangle has K\u00b7Area = (\u03b1 + \u03b2 + \u03b3 \u2212 \u03c0). On the unit sphere: Area = \u03b1 + \u03b2 + \u03b3 \u2212 \u03c0 (the spherical excess). This directly follows from the polygon Gauss-Bonnet with \u03c7 = 1.\n\nRelated theorems proved: `unit_sphere_triangle_area`, `positive_curvature_angle_excess` (\u03b1+\u03b2+\u03b3 > \u03c0), `flat_angle_sum_pi` (K=0 recovers Euclidean), `negative_curvature_angle_deficit` (K<0 gives \u03b1+\u03b2+\u03b3 < \u03c0), `hyperbolic_triangle_area_bound` (0 < Area < \u03c0 for K=\u22121).",
     "mathContext": "For a geodesic triangle on a surface of constant curvature $K$:\n$$K \\cdot \\text{Area} = \\alpha + \\beta + \\gamma - \\pi$$\nTrichotomy: $K > 0$ (spherical, angle excess), $K = 0$ (Euclidean, angle sum $= \\pi$), $K < 0$ (hyperbolic, angle deficit). The `GeodesicTriangle` structure (line 525) packages the angles, area, curvature, and the Girard axiom. Proofs use `linarith`.",
     "significance": "key",
     "relatedConcepts": [
@@ -327,14 +372,17 @@
   {
     "id": "ann-poincare-hopf",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 630, "endLine": 685 },
+    "range": {
+      "startLine": 630,
+      "endLine": 685
+    },
     "type": "definition",
-    "title": "Poincaré-Hopf: Σ index(V,p_i) = χ; Hairy Ball as Corollary",
-    "content": "The Poincaré-Hopf index theorem: for a vector field on a compact surface with isolated zeros, Σ index(p_i) = χ(M). The `hairy_ball` theorem (line 644) axiomatizes this: if V has no zeros, then χ = 0. `sphere_no_nonvanishing_field` and `torus_admits_nonvanishing_field` follow as immediate corollaries.\n\n`nonvanishing_iff_chi_zero` gives the complete classification: only surfaces with χ = 0 (torus and Klein bottle) can support nowhere-vanishing vector fields. The proof: `hairy_ball V` directly for the forward direction.",
+    "title": "Poincar\u00e9-Hopf: \u03a3 index(V,p_i) = \u03c7; Hairy Ball as Corollary",
+    "content": "The Poincar\u00e9-Hopf index theorem: for a vector field on a compact surface with isolated zeros, \u03a3 index(p_i) = \u03c7(M). The `hairy_ball` theorem (line 644) axiomatizes this: if V has no zeros, then \u03c7 = 0. `sphere_no_nonvanishing_field` and `torus_admits_nonvanishing_field` follow as immediate corollaries.\n\n`nonvanishing_iff_chi_zero` gives the complete classification: only surfaces with \u03c7 = 0 (torus and Klein bottle) can support nowhere-vanishing vector fields. The proof: `hairy_ball V` directly for the forward direction.",
     "mathContext": "$$\\sum_i \\text{index}(V, p_i) = \\chi(M)$$\nThe hairy ball theorem: every continuous tangent vector field on $S^2$ must vanish somewhere, since $\\chi(S^2) = 2 \\neq 0$. Only the torus ($\\chi = 0$) and Klein bottle ($\\chi = 0$) support non-vanishing fields. The `VectorFieldOnSurface` structure (line 630) records the surface, zero-ness predicate, and the index-sum axiom.",
     "significance": "key",
     "relatedConcepts": [
-      "Poincaré-Hopf theorem",
+      "Poincar\u00e9-Hopf theorem",
       "hairy ball theorem",
       "vector field index",
       "fixed point theory",
@@ -350,10 +398,13 @@
   {
     "id": "ann-morse-theory",
     "proofId": "euler-polyhedral-formula-oq-02-oq-01",
-    "range": { "startLine": 701, "endLine": 746 },
+    "range": {
+      "startLine": 701,
+      "endLine": 746
+    },
     "type": "definition",
-    "title": "Morse Theory: χ = #min − #saddles + #max via Critical Points",
-    "content": "Morse theory relates critical points of smooth functions to topology: χ(M) = #minima − #saddles + #maxima. For S² (χ = 2): every Morse function needs #min + #max ≥ 2 + #saddles. For T² (χ = 0): at least 2 saddles needed whenever min,max ≥ 1.\n\nThe `MorseFunctionOnSurface` structure (line 701) encodes the surface, critical point counts, and the Morse relation as an axiom. `sphere_height_function` and `torus_standard_morse` give the minimal examples. `genus_g_morse_bound` gives the general constraint: min + max − saddles = 2 − 2g.",
+    "title": "Morse Theory: \u03c7 = #min \u2212 #saddles + #max via Critical Points",
+    "content": "Morse theory relates critical points of smooth functions to topology: \u03c7(M) = #minima \u2212 #saddles + #maxima. For S\u00b2 (\u03c7 = 2): every Morse function needs #min + #max \u2265 2 + #saddles. For T\u00b2 (\u03c7 = 0): at least 2 saddles needed whenever min,max \u2265 1.\n\nThe `MorseFunctionOnSurface` structure (line 701) encodes the surface, critical point counts, and the Morse relation as an axiom. `sphere_height_function` and `torus_standard_morse` give the minimal examples. `genus_g_morse_bound` gives the general constraint: min + max \u2212 saddles = 2 \u2212 2g.",
     "mathContext": "The weak Morse inequality: $\\chi(M) = \\sum_{k} (-1)^k c_k$ where $c_k$ is the number of index-$k$ critical points. For surfaces: $\\chi = c_0 - c_1 + c_2$. Sphere: $1 - 0 + 1 = 2$ (height function). Torus: $1 - 2 + 1 = 0$ (standard embedding). The Morse inequalities further constrain individual Betti numbers: $c_k \\geq b_k$.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/gcd-algorithm/annotations.json
+++ b/src/data/proofs/gcd-algorithm/annotations.json
@@ -9,12 +9,12 @@
     "type": "insight",
     "title": "The Oldest Algorithm",
     "content": "The Euclidean algorithm is arguably the oldest non-trivial algorithm still in common use:\n\n$$\\gcd(a, b) = \\gcd(b, a \\mod b)$$\n\n**Why it matters**:\n- Over 2,300 years old (Euclid's Elements, c. 300 BCE)\n- Foundation of modern cryptography (RSA, Diffie-Hellman)\n- Remarkably efficient: O(log min(a, b)) steps\n- Extends to polynomials, Gaussian integers, and more\n\nThe algorithm terminates because $a \\mod b < b$, giving a strictly decreasing sequence.",
-    "mathContext": "In Lean 4 / Mathlib, `Nat.gcd` is defined by well-founded recursion on `b`: `Nat.gcd a 0 = a` and `Nat.gcd a (b+1) = Nat.gcd (b+1) (a % (b+1))`. The key Mathlib theorems are `Nat.gcd_rec : Nat.gcd a b = Nat.gcd b (a % b)` and `Nat.gcd_dvd_left`, `Nat.gcd_dvd_right`, `Nat.dvd_gcd`. Termination follows from `Nat.mod_lt : 0 < b → a % b < b`, which provides the decreasing measure. Complexity: Lamé (1844) proved the step count is at most $5 \\lfloor \\log_{10}(\\min(a,b)) \\rfloor + 1$.",
+    "mathContext": "In Lean 4 / Mathlib, `Nat.gcd` is defined by well-founded recursion on `b`: `Nat.gcd a 0 = a` and `Nat.gcd a (b+1) = Nat.gcd (b+1) (a % (b+1))`. The key Mathlib theorems are `Nat.gcd_rec : Nat.gcd a b = Nat.gcd b (a % b)` and `Nat.gcd_dvd_left`, `Nat.gcd_dvd_right`, `Nat.dvd_gcd`. Termination follows from `Nat.mod_lt : 0 < b \u2192 a % b < b`, which provides the decreasing measure. Complexity: Lam\u00e9 (1844) proved the step count is at most $5 \\lfloor \\log_{10}(\\min(a,b)) \\rfloor + 1$.",
     "significance": "key",
     "prerequisites": [
       "natural number divisibility",
       "modular arithmetic",
-      "well-founded recursion on ℕ",
+      "well-founded recursion on \u2115",
       "Mathlib.Data.Nat.GCD.Basic"
     ],
     "relatedConcepts": [
@@ -22,7 +22,7 @@
       "modular arithmetic",
       "well-founded recursion",
       "Nat.gcd_rec",
-      "Lamé's theorem",
+      "Lam\u00e9's theorem",
       "Wiedijk theorem #69"
     ]
   },
@@ -56,10 +56,10 @@
       "startLine": 66,
       "endLine": 77
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Euclidean Recurrence",
     "content": "**The Core Identity**:\n$$\\gcd(a, b) = \\gcd(b, a \\mod b)$$\n\nThis is the heart of the algorithm. The key insight is that common divisors are preserved:\n\n- If $d | a$ and $d | b$, then $d | (a \\mod b)$ since $a \\mod b = a - qb$\n- Conversely, if $d | b$ and $d | (a \\mod b)$, then $d | a$ since $a = qb + (a \\mod b)$\n\nThus the two pairs have exactly the same common divisors.",
-    "mathContext": "In Lean: `theorem euclidean_recurrence (a : ℕ) {b : ℕ} (hb : b ≠ 0) : Nat.gcd a b = Nat.gcd b (a % b)`. The proof uses `Nat.gcd_comm` twice and `Nat.gcd_rec`. Key supporting fact: $a = \\lfloor a/b \\rfloor \\cdot b + (a \\bmod b)$, so any $d$ dividing $a$ and $b$ also divides $a - \\lfloor a/b \\rfloor \\cdot b = a \\bmod b$. The invariant `gcd (a, b) = gcd (b, a % b)` holds because both sides represent the same lattice meet in $(\\mathbb{N}, \\mid)$.",
+    "mathContext": "In Lean: `theorem euclidean_recurrence (a : \u2115) {b : \u2115} (hb : b \u2260 0) : Nat.gcd a b = Nat.gcd b (a % b)`. The proof uses `Nat.gcd_comm` twice and `Nat.gcd_rec`. Key supporting fact: $a = \\lfloor a/b \\rfloor \\cdot b + (a \\bmod b)$, so any $d$ dividing $a$ and $b$ also divides $a - \\lfloor a/b \\rfloor \\cdot b = a \\bmod b$. The invariant `gcd (a, b) = gcd (b, a % b)` holds because both sides represent the same lattice meet in $(\\mathbb{N}, \\mid)$.",
     "significance": "key",
     "prerequisites": [
       "natural number divisibility",
@@ -80,14 +80,14 @@
       "startLine": 79,
       "endLine": 86
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Base Case: GCD with Zero",
     "content": "**Base Case**: $\\gcd(a, 0) = a$\n\nThis makes sense because:\n- Every number divides 0 (since $0 = 0 \\cdot n$ for any $n$)\n- So the common divisors of $a$ and $0$ are exactly the divisors of $a$\n- The greatest of these is $a$ itself\n\nThis base case terminates the recursion.",
-    "mathContext": "In Lean: `theorem gcd_zero_right (a : ℕ) : Nat.gcd a 0 = a := Nat.gcd_zero_right a`. This follows because `∀ n, n ∣ 0` (since `0 = 0 * n`), so the set of common divisors of $a$ and $0$ equals the set of divisors of $a$, whose maximum in the divisibility order is $a$ itself. Dually, `Nat.gcd_zero_left : Nat.gcd 0 a = a`. Together these give $0$ as the identity of the GCD monoid $(\\mathbb{N}, \\gcd, 0)$.",
+    "mathContext": "In Lean: `theorem gcd_zero_right (a : \u2115) : Nat.gcd a 0 = a := Nat.gcd_zero_right a`. This follows because `\u2200 n, n \u2223 0` (since `0 = 0 * n`), so the set of common divisors of $a$ and $0$ equals the set of divisors of $a$, whose maximum in the divisibility order is $a$ itself. Dually, `Nat.gcd_zero_left : Nat.gcd 0 a = a`. Together these give $0$ as the identity of the GCD monoid $(\\mathbb{N}, \\gcd, 0)$.",
     "significance": "key",
     "prerequisites": [
       "natural number divisibility",
-      "∀ n, n ∣ 0",
+      "\u2200 n, n \u2223 0",
       "identity element of a monoid",
       "Nat.gcd_zero_right in Mathlib"
     ],
@@ -104,10 +104,10 @@
       "startLine": 88,
       "endLine": 94
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "GCD is Commutative",
     "content": "**Symmetry**: $\\gcd(a, b) = \\gcd(b, a)$\n\nThe order of arguments doesn't matter for GCD. This follows directly from the definition: the common divisors of $a$ and $b$ are exactly the common divisors of $b$ and $a$.",
-    "mathContext": "In Lean: `theorem gcd_comm (a b : ℕ) : Nat.gcd a b = Nat.gcd b a := Nat.gcd_comm a b`. Proof sketch: the set of common divisors is symmetric — $\\{d : d \\mid a \\land d \\mid b\\} = \\{d : d \\mid b \\land d \\mid a\\}$ — so their maxima coincide. Commutativity is one of the defining properties of a semilattice: $(\\mathbb{N}, \\gcd)$ is a commutative, idempotent, associative monoid (with identity $0$).",
+    "mathContext": "In Lean: `theorem gcd_comm (a b : \u2115) : Nat.gcd a b = Nat.gcd b a := Nat.gcd_comm a b`. Proof sketch: the set of common divisors is symmetric \u2014 $\\{d : d \\mid a \\land d \\mid b\\} = \\{d : d \\mid b \\land d \\mid a\\}$ \u2014 so their maxima coincide. Commutativity is one of the defining properties of a semilattice: $(\\mathbb{N}, \\gcd)$ is a commutative, idempotent, associative monoid (with identity $0$).",
     "significance": "supporting",
     "prerequisites": [
       "natural number divisibility",
@@ -127,14 +127,14 @@
       "startLine": 96,
       "endLine": 96
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "GCD Divides Both Arguments",
     "content": "**Correctness Property 1**: The GCD divides both inputs.\n\n$$\\gcd(a, b) \\mid a \\text{ and } \\gcd(a, b) \\mid b$$\n\nThis is half of what makes it a *common* divisor. The proofs follow directly from the definition of GCD in Mathlib.",
-    "mathContext": "In Lean: `Nat.gcd_dvd_left a b : Nat.gcd a b ∣ a` and `Nat.gcd_dvd_right a b : Nat.gcd a b ∣ b`. The proofs use strong induction on `b`: base case `gcd a 0 = a ∣ a`; inductive step uses `gcd a b = gcd b (a % b)` and the inductive hypothesis that `gcd b (a % b) ∣ b` and `gcd b (a % b) ∣ (a % b)`, from which `gcd b (a % b) ∣ a` follows since `a = q * b + (a % b)`.",
+    "mathContext": "In Lean: `Nat.gcd_dvd_left a b : Nat.gcd a b \u2223 a` and `Nat.gcd_dvd_right a b : Nat.gcd a b \u2223 b`. The proofs use strong induction on `b`: base case `gcd a 0 = a \u2223 a`; inductive step uses `gcd a b = gcd b (a % b)` and the inductive hypothesis that `gcd b (a % b) \u2223 b` and `gcd b (a % b) \u2223 (a % b)`, from which `gcd b (a % b) \u2223 a` follows since `a = q * b + (a % b)`.",
     "significance": "key",
     "prerequisites": [
       "natural number divisibility",
-      "well-founded induction on ℕ",
+      "well-founded induction on \u2115",
       "Nat.mod definition",
       "Nat.gcd_dvd_left/right in Mathlib"
     ],
@@ -150,10 +150,10 @@
       "startLine": 108,
       "endLine": 114
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "GCD is the Greatest",
     "content": "**Correctness Property 2**: Any common divisor divides the GCD.\n\nIf $d \\mid a$ and $d \\mid b$, then $d \\mid \\gcd(a, b)$.\n\nThis means $\\gcd(a, b)$ is the *greatest* common divisor because every other common divisor must be smaller (since it divides the GCD).\n\n**Universal Property**: This characterizes GCD uniquely.",
-    "mathContext": "In Lean: `Nat.dvd_gcd : d ∣ a → d ∣ b → d ∣ Nat.gcd a b`. Proof by induction: base case `d ∣ gcd a 0 = a` from `d ∣ a`; inductive step `d ∣ gcd a b = gcd b (a % b)` from `d ∣ b` and `d ∣ (a % b)` (which follows from `d ∣ a` and `d ∣ b` since `a % b = a - q * b`). Combined with `gcd_dvd_left/right`, this gives the universal property: $d \\mid \\gcd(a,b) \\iff d \\mid a \\land d \\mid b$.",
+    "mathContext": "In Lean: `Nat.dvd_gcd : d \u2223 a \u2192 d \u2223 b \u2192 d \u2223 Nat.gcd a b`. Proof by induction: base case `d \u2223 gcd a 0 = a` from `d \u2223 a`; inductive step `d \u2223 gcd a b = gcd b (a % b)` from `d \u2223 b` and `d \u2223 (a % b)` (which follows from `d \u2223 a` and `d \u2223 b` since `a % b = a - q * b`). Combined with `gcd_dvd_left/right`, this gives the universal property: $d \\mid \\gcd(a,b) \\iff d \\mid a \\land d \\mid b$.",
     "significance": "key",
     "prerequisites": [
       "natural number divisibility",
@@ -174,10 +174,10 @@
       "startLine": 116,
       "endLine": 131
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Complete Characterization",
     "content": "**The Universal Property of GCD**:\n\n$d = \\gcd(a, b)$ if and only if:\n1. $d \\mid a$ and $d \\mid b$ (it's a common divisor)\n2. For all $e$: if $e \\mid a$ and $e \\mid b$, then $e \\mid d$ (it's the greatest)\n\nThis completely characterizes the GCD and shows it's unique.",
-    "mathContext": "In Lean: `theorem gcd_characterization (a b d : ℕ) : d = Nat.gcd a b ↔ (d ∣ a ∧ d ∣ b ∧ ∀ e, e ∣ a → e ∣ b → e ∣ d)`. The proof uses `Nat.dvd_antisymm` for uniqueness: both `d ∣ gcd a b` (from `Nat.dvd_gcd`) and `gcd a b ∣ d` (applying the maximality hypothesis to `gcd a b`, which divides both `a` and `b`). This is the lattice-theoretic characterization of meet: $d = a \\sqcap b$ iff $d \\leq a$, $d \\leq b$, and $\\forall e, e \\leq a \\land e \\leq b \\Rightarrow e \\leq d$ (where $\\leq$ is the divisibility order).",
+    "mathContext": "In Lean: `theorem gcd_characterization (a b d : \u2115) : d = Nat.gcd a b \u2194 (d \u2223 a \u2227 d \u2223 b \u2227 \u2200 e, e \u2223 a \u2192 e \u2223 b \u2192 e \u2223 d)`. The proof uses `Nat.dvd_antisymm` for uniqueness: both `d \u2223 gcd a b` (from `Nat.dvd_gcd`) and `gcd a b \u2223 d` (applying the maximality hypothesis to `gcd a b`, which divides both `a` and `b`). This is the lattice-theoretic characterization of meet: $d = a \\sqcap b$ iff $d \\leq a$, $d \\leq b$, and $\\forall e, e \\leq a \\land e \\leq b \\Rightarrow e \\leq d$ (where $\\leq$ is the divisibility order).",
     "significance": "key",
     "prerequisites": [
       "universal property of GCD",
@@ -228,7 +228,7 @@
     "type": "concept",
     "title": "Coprimality",
     "content": "Two numbers are **coprime** (or relatively prime) if their GCD is 1:\n\n$$\\gcd(a, b) = 1$$\n\n**Key Examples**:\n- Consecutive integers are always coprime: $\\gcd(n, n+1) = 1$\n- Prime $p$ is coprime to any $a$ with $p \\nmid a$\n- If $\\gcd(a, b) = 1$ and $\\gcd(a, c) = 1$, then $\\gcd(a, bc) = 1$\n\nCoprimality is essential in number theory and cryptography.",
-    "mathContext": "In Lean: `Nat.Coprime a b` is defined as `Nat.gcd a b = 1`. The iff `coprime_iff_gcd_one` is `Iff.rfl`. Key properties in Mathlib: `Nat.Coprime.mul_right : Coprime k m → Coprime k n → Coprime k (m * n)`, `Nat.Coprime.pow_left`, and `Nat.chineseRemainder'` which requires coprimality. For primes: `Nat.Coprime.symm` and `Nat.Prime.coprime_iff_not_dvd : p.Prime → (Nat.Coprime p n ↔ ¬p ∣ n)`.",
+    "mathContext": "In Lean: `Nat.Coprime a b` is defined as `Nat.gcd a b = 1`. The iff `coprime_iff_gcd_one` is `Iff.rfl`. Key properties in Mathlib: `Nat.Coprime.mul_right : Coprime k m \u2192 Coprime k n \u2192 Coprime k (m * n)`, `Nat.Coprime.pow_left`, and `Nat.chineseRemainder'` which requires coprimality. For primes: `Nat.Coprime.symm` and `Nat.Prime.coprime_iff_not_dvd : p.Prime \u2192 (Nat.Coprime p n \u2194 \u00acp \u2223 n)`.",
     "significance": "key",
     "prerequisites": [
       "Nat.Coprime definition in Mathlib",
@@ -249,10 +249,10 @@
       "startLine": 162,
       "endLine": 165
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Consecutive Integers are Coprime",
     "content": "For any $n$, we have $\\gcd(n, n+1) = 1$.\n\nIntuition: if $d$ divides both $n$ and $n+1$, then $d$ divides their difference $(n+1) - n = 1$. So $d = 1$.\n\nThis is why consecutive Fibonacci numbers are always coprime!",
-    "mathContext": "In Lean: `theorem consecutive_coprime (n : ℕ) : Nat.Coprime n (n + 1)` proved via `Nat.coprime_self_add_right` and `Nat.coprime_one_right`. The mathematical argument: if $d \\mid n$ and $d \\mid (n+1)$, then $d \\mid 1$, so $d = 1$. This specializes to `Nat.Coprime.symm (Nat.coprime_succ_self n)`. Related: `Nat.Coprime (Fibonacci n) (Fibonacci (n+1))` — consecutive Fibonacci numbers are coprime, which is why they give the worst case for the Euclidean algorithm.",
+    "mathContext": "In Lean: `theorem consecutive_coprime (n : \u2115) : Nat.Coprime n (n + 1)` proved via `Nat.coprime_self_add_right` and `Nat.coprime_one_right`. The mathematical argument: if $d \\mid n$ and $d \\mid (n+1)$, then $d \\mid 1$, so $d = 1$. This specializes to `Nat.Coprime.symm (Nat.coprime_succ_self n)`. Related: `Nat.Coprime (Fibonacci n) (Fibonacci (n+1))` \u2014 consecutive Fibonacci numbers are coprime, which is why they give the worst case for the Euclidean algorithm.",
     "significance": "supporting",
     "prerequisites": [
       "Nat.Coprime in Mathlib",
@@ -272,13 +272,13 @@
       "startLine": 169,
       "endLine": 178
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Bezout's Identity",
     "content": "**Bezout's Identity**: For any $a, b \\in \\mathbb{N}$, there exist integers $x, y$ such that:\n\n$$\\gcd(a, b) = ax + by$$\n\nThe **extended Euclidean algorithm** computes these coefficients alongside the GCD.\n\n**Applications**:\n- Solving linear Diophantine equations $ax + by = c$\n- Computing modular multiplicative inverses\n- RSA key generation\n\n**Example**: $\\gcd(35, 15) = 5 = 35 \\cdot 1 + 15 \\cdot (-2)$",
-    "mathContext": "In Lean: `theorem bezout_identity (a b : ℕ) : ∃ x y : ℤ, (Nat.gcd a b : ℤ) = a * x + b * y := ⟨Nat.gcdA a b, Nat.gcdB a b, Nat.gcd_eq_gcd_ab a b⟩`. The note to ℤ is crucial: Bezout coefficients can be negative (e.g., $\\gcd(3,5) = 5 \\cdot 2 + 3 \\cdot (-3) = 1$). In Mathlib, `Nat.gcdA` and `Nat.gcdB` are the extended Euclidean algorithm outputs. The identity $ax + by = 1$ for coprime $a, b$ gives the modular inverse: $ax \\equiv 1 \\pmod{b}$.",
+    "mathContext": "In Lean: `theorem bezout_identity (a b : \u2115) : \u2203 x y : \u2124, (Nat.gcd a b : \u2124) = a * x + b * y := \u27e8Nat.gcdA a b, Nat.gcdB a b, Nat.gcd_eq_gcd_ab a b\u27e9`. The note to \u2124 is crucial: Bezout coefficients can be negative (e.g., $\\gcd(3,5) = 5 \\cdot 2 + 3 \\cdot (-3) = 1$). In Mathlib, `Nat.gcdA` and `Nat.gcdB` are the extended Euclidean algorithm outputs. The identity $ax + by = 1$ for coprime $a, b$ gives the modular inverse: $ax \\equiv 1 \\pmod{b}$.",
     "significance": "key",
     "prerequisites": [
-      "integer arithmetic (ℤ)",
+      "integer arithmetic (\u2124)",
       "extended Euclidean algorithm",
       "Nat.gcdA and Nat.gcdB in Mathlib",
       "modular multiplicative inverse"
@@ -296,10 +296,10 @@
       "startLine": 180,
       "endLine": 183
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Bezout Coefficients",
     "content": "Mathlib provides explicit Bezout coefficients via `Nat.gcdA` and `Nat.gcdB`:\n\n$$\\gcd(a, b) = a \\cdot \\text{gcdA}(a, b) + b \\cdot \\text{gcdB}(a, b)$$\n\nThese are computed by the extended Euclidean algorithm, which tracks the linear combination as it computes the GCD.",
-    "mathContext": "In Lean: `theorem bezout_equation (a b : ℕ) : (Nat.gcd a b : ℤ) = a * Nat.gcdA a b + b * Nat.gcdB a b := Nat.gcd_eq_gcd_ab a b`. The coercion `(Nat.gcd a b : ℤ)` is needed since `Nat.gcdA : ℕ → ℕ → ℤ` returns integers. The extended algorithm tracks: at each step $(r_i, x_i, y_i)$ with $r_i = a x_i + b y_i$, updating via $r_{i+1} = r_{i-1} - q_i r_i$, $x_{i+1} = x_{i-1} - q_i x_i$, $y_{i+1} = y_{i-1} - q_i y_i$.",
+    "mathContext": "In Lean: `theorem bezout_equation (a b : \u2115) : (Nat.gcd a b : \u2124) = a * Nat.gcdA a b + b * Nat.gcdB a b := Nat.gcd_eq_gcd_ab a b`. The coercion `(Nat.gcd a b : \u2124)` is needed since `Nat.gcdA : \u2115 \u2192 \u2115 \u2192 \u2124` returns integers. The extended algorithm tracks: at each step $(r_i, x_i, y_i)$ with $r_i = a x_i + b y_i$, updating via $r_{i+1} = r_{i-1} - q_i r_i$, $x_{i+1} = x_{i-1} - q_i x_i$, $y_{i+1} = y_{i-1} - q_i y_i$.",
     "significance": "key",
     "prerequisites": [
       "Nat.gcd_eq_gcd_ab in Mathlib",
@@ -319,7 +319,7 @@
       "startLine": 185,
       "endLine": 185
     },
-    "type": "example",
+    "type": "context",
     "title": "Worked Examples",
     "content": "**Tracing gcd(48, 18)**:\n\n```\ngcd(48, 18) = gcd(18, 48 mod 18) = gcd(18, 12)\ngcd(18, 12) = gcd(12, 18 mod 12) = gcd(12, 6)\ngcd(12, 6)  = gcd(6, 12 mod 6)   = gcd(6, 0)\ngcd(6, 0)   = 6\n```\n\nOnly 4 steps! The algorithm is remarkably efficient.\n\nEach step is verified in Lean using `native_decide` to compute the result directly.",
     "mathContext": "In Lean: each step is verified by `native_decide`, which compiles the decision to native code and evaluates. For `gcd(48, 18) = 6`: the algorithm runs $48 = 2 \\cdot 18 + 12$, $18 = 1 \\cdot 12 + 6$, $12 = 2 \\cdot 6 + 0$, terminating in 3 steps. `native_decide` calls `Nat.decEq` on the reduced expression. Step-tracing examples serve as `#eval`-style tests within the proof system, confirmed by the kernel.",
@@ -346,7 +346,7 @@
     "type": "concept",
     "title": "Euclidean Domains",
     "content": "The algorithm generalizes beyond natural numbers to any **Euclidean domain**:\n\n- **Integers** $\\mathbb{Z}$: Same algorithm with absolute value\n- **Polynomials** $F[x]$: Polynomial GCD and division\n- **Gaussian integers** $\\mathbb{Z}[i]$: Complex number version\n\nA Euclidean domain has:\n1. A Euclidean function $\\phi$ (for $\\mathbb{N}$, just the identity)\n2. Division with remainder: $a = qb + r$ where $\\phi(r) < \\phi(b)$\n\nThis abstraction is key in abstract algebra and computer algebra systems.",
-    "mathContext": "In Lean/Mathlib: `EuclideanDomain` is a typeclass in `Mathlib.Algebra.EuclideanDomain.Defs` requiring a `norm : α → ℕ` and `quotRem : α → α → α × α` satisfying `b ≠ 0 → norm (quotRem a b).2 < norm b`. Instances include `ℤ` (norm = `Int.natAbs`), `F[x]` for fields `F` (norm = polynomial degree), and `ℤ[i]` Gaussian integers (norm = $a^2 + b^2$). The GCD algorithm in a Euclidean domain terminates since `norm` is a natural number that strictly decreases at each step.",
+    "mathContext": "In Lean/Mathlib: `EuclideanDomain` is a typeclass in `Mathlib.Algebra.EuclideanDomain.Defs` requiring a `norm : \u03b1 \u2192 \u2115` and `quotRem : \u03b1 \u2192 \u03b1 \u2192 \u03b1 \u00d7 \u03b1` satisfying `b \u2260 0 \u2192 norm (quotRem a b).2 < norm b`. Instances include `\u2124` (norm = `Int.natAbs`), `F[x]` for fields `F` (norm = polynomial degree), and `\u2124[i]` Gaussian integers (norm = $a^2 + b^2$). The GCD algorithm in a Euclidean domain terminates since `norm` is a natural number that strictly decreases at each step.",
     "significance": "key",
     "prerequisites": [
       "EuclideanDomain typeclass in Mathlib",
@@ -373,13 +373,13 @@
     "type": "concept",
     "title": "Complexity Analysis",
     "content": "**Time Complexity**: $O(\\log(\\min(a, b)))$\n\nThe Euclidean algorithm is extremely efficient:\n\n**Gabriel Lame's Theorem (1844)**:\nThe number of steps is at most 5 times the number of digits in the smaller input.\n\n**Worst Case**: Consecutive Fibonacci numbers\n- $\\gcd(F_{n+1}, F_n)$ takes exactly $n$ steps\n- This gives $O(\\log_\\phi n)$ steps where $\\phi \\approx 1.618$\n\n**Why so fast?** Each step roughly halves the larger number, giving logarithmic behavior.",
-    "mathContext": "Lamé's theorem (1844, first complexity analysis of any algorithm): for inputs $a \\geq b$, the number of division steps is at most $5 \\lfloor \\log_{10} b \\rfloor + 1 \\approx 5 \\log_{10} b$. Proof: each two consecutive steps reduce $b$ by at least a factor of $\\phi^2 \\approx 2.618$ (since remainders satisfy $r_{i+2} < r_i / \\phi^2$). The exact worst case is $\\gcd(F_{n+1}, F_n)$ taking $n-1$ steps (Fibonacci inputs), where $F_n \\approx \\phi^n / \\sqrt{5}$. Modern analysis: average steps $\\approx \\frac{12 \\ln 2}{\\pi^2} \\ln b \\approx 0.843 \\log_2 b$ (Heilbronn 1969, Knuth Vol. 2).",
+    "mathContext": "Lam\u00e9's theorem (1844, first complexity analysis of any algorithm): for inputs $a \\geq b$, the number of division steps is at most $5 \\lfloor \\log_{10} b \\rfloor + 1 \\approx 5 \\log_{10} b$. Proof: each two consecutive steps reduce $b$ by at least a factor of $\\phi^2 \\approx 2.618$ (since remainders satisfy $r_{i+2} < r_i / \\phi^2$). The exact worst case is $\\gcd(F_{n+1}, F_n)$ taking $n-1$ steps (Fibonacci inputs), where $F_n \\approx \\phi^n / \\sqrt{5}$. Modern analysis: average steps $\\approx \\frac{12 \\ln 2}{\\pi^2} \\ln b \\approx 0.843 \\log_2 b$ (Heilbronn 1969, Knuth Vol. 2).",
     "significance": "key",
     "prerequisites": [
       "Fibonacci numbers and their growth rate",
       "logarithmic complexity analysis",
-      "Lamé's theorem (1844)",
-      "golden ratio φ"
+      "Lam\u00e9's theorem (1844)",
+      "golden ratio \u03c6"
     ],
     "relatedConcepts": [
       "Fibonacci numbers",

--- a/src/data/proofs/sqrt2-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.json
@@ -8,8 +8,8 @@
     },
     "type": "concept",
     "title": "Mathlib Imports",
-    "content": "Three Mathlib modules power this formalization:\n\n1. **`Mathlib.Data.Real.Irrational`**: Defines the `Irrational` predicate (`x : ℝ` is irrational iff `x ∉ ℚ` embedded in `ℝ`) and supplies the key lemmas: `irrational_sqrt_two` (main result), `Nat.Prime.irrational_sqrt` (√p is irrational for prime p), and `irrational_sqrt_natCast_iff` (√n irrational iff n is not a perfect square).\n\n2. **`Mathlib.Algebra.Ring.Parity`**: Provides the `Even` and `Odd` predicates and their algebraic properties — in particular `Odd.pow` (odd^n = odd) and `Int.odd_iff_not_even`, which are essential for the classical parity argument.\n\n3. **`Mathlib.Tactic`**: Imports all standard Lean 4 tactics (`omega`, `ring`, `decide`, `by_contra`, `by_cases`, `obtain`, etc.) used throughout the pedagogical proof demonstrations.",
-    "mathContext": "The central Mathlib predicate: $x \\in \\mathbb{R}$ is **irrational** iff $x \\notin \\iota(\\mathbb{Q})$ where $\\iota : \\mathbb{Q} \\hookrightarrow \\mathbb{R}$ is the canonical embedding. In Lean: `Irrational x ↔ x ∉ Set.range ((↑) : ℚ → ℝ)`. The key Mathlib theorem `irrational_sqrt_two : Irrational (Real.sqrt 2)` is available directly; this file wraps and extends it with pedagogical proofs.",
+    "content": "Three Mathlib modules power this formalization:\n\n1. **`Mathlib.Data.Real.Irrational`**: Defines the `Irrational` predicate (`x : \u211d` is irrational iff `x \u2209 \u211a` embedded in `\u211d`) and supplies the key lemmas: `irrational_sqrt_two` (main result), `Nat.Prime.irrational_sqrt` (\u221ap is irrational for prime p), and `irrational_sqrt_natCast_iff` (\u221an irrational iff n is not a perfect square).\n\n2. **`Mathlib.Algebra.Ring.Parity`**: Provides the `Even` and `Odd` predicates and their algebraic properties \u2014 in particular `Odd.pow` (odd^n = odd) and `Int.odd_iff_not_even`, which are essential for the classical parity argument.\n\n3. **`Mathlib.Tactic`**: Imports all standard Lean 4 tactics (`omega`, `ring`, `decide`, `by_contra`, `by_cases`, `obtain`, etc.) used throughout the pedagogical proof demonstrations.",
+    "mathContext": "The central Mathlib predicate: $x \\in \\mathbb{R}$ is **irrational** iff $x \\notin \\iota(\\mathbb{Q})$ where $\\iota : \\mathbb{Q} \\hookrightarrow \\mathbb{R}$ is the canonical embedding. In Lean: `Irrational x \u2194 x \u2209 Set.range ((\u2191) : \u211a \u2192 \u211d)`. The key Mathlib theorem `irrational_sqrt_two : Irrational (Real.sqrt 2)` is available directly; this file wraps and extends it with pedagogical proofs.",
     "significance": "supporting",
     "prerequisites": [],
     "relatedConcepts": [
@@ -29,7 +29,7 @@
     "type": "definition",
     "title": "Definition of Irrational",
     "content": "A real number $x$ is **irrational** if for all integers $p, q$ with $q \\neq 0$, we have $x \\neq p/q$. This is the negation of rationality: there is no way to express $x$ as a ratio of integers.",
-    "mathContext": "In Lean, this is a universal statement: `∀ p q : ℤ, q ≠ 0 → x ≠ p / q`. The proof will show this holds for $x = \\sqrt{2}$ by contradiction.",
+    "mathContext": "In Lean, this is a universal statement: `\u2200 p q : \u2124, q \u2260 0 \u2192 x \u2260 p / q`. The proof will show this holds for $x = \\sqrt{2}$ by contradiction.",
     "significance": "key",
     "relatedConcepts": [
       "rational numbers",
@@ -47,7 +47,7 @@
     "type": "definition",
     "title": "Definition of Coprime",
     "content": "Two integers $p$ and $q$ are **coprime** (or relatively prime) if their greatest common divisor is 1: $\\gcd(p, q) = 1$. Equivalently, they share no prime factors.",
-    "mathContext": "Every rational number can be written in lowest terms $p/q$ where $p$ and $q$ are coprime. This is crucial for the contradiction—if both are even, they're not coprime.",
+    "mathContext": "Every rational number can be written in lowest terms $p/q$ where $p$ and $q$ are coprime. This is crucial for the contradiction\u2014if both are even, they're not coprime.",
     "significance": "key",
     "relatedConcepts": [
       "GCD",
@@ -62,7 +62,7 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Even Square Implies Even Root",
     "content": "**The key lemma**: If $n^2$ is even, then $n$ is even. The proof uses the contrapositive: assume $n$ is odd, show $n^2$ is odd, contradicting that $n^2$ is even.",
     "mathContext": "Why does odd$^2$ = odd? Write $n = 2k+1$. Then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which is odd. The tactic `Odd.pow` handles this in Lean.",
@@ -80,7 +80,7 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Square of Odd is Odd",
     "content": "A direct proof that odd$^2$ = odd. If $n = 2k + 1$ (odd), then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which has the form $2m + 1$ (odd).",
     "mathContext": "The `ring` tactic handles the algebraic manipulation automatically. The `obtain` tactic destructs the existential in the definition of `Odd`.",
@@ -100,10 +100,10 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "lemma",
+    "type": "technique",
     "title": "Divisibility by 2 Preserved by Squaring",
     "content": "A bidirectional lemma: $2 \\mid n^2 \\iff 2 \\mid n$. The forward direction uses `even_of_even_sq`; the reverse is direct calculation: if $n = 2k$, then $n^2 = 4k^2 = 2(2k^2)$.",
-    "mathContext": "The `↔` (iff) in Lean requires proving both directions. The `constructor` tactic splits this into two goals.",
+    "mathContext": "The `\u2194` (iff) in Lean requires proving both directions. The `constructor` tactic splits this into two goals.",
     "significance": "key",
     "prerequisites": [
       "ann-sqrt2-even-of-even-sq"
@@ -120,10 +120,10 @@
       "startLine": 53,
       "endLine": 53
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Supporting Lemmas and Main Theorem: Parity Argument",
-    "content": "This section contains the classical parity-based proof machinery:\n\n**`even_of_sq_even`**: The key lemma — if $n^2$ is even, then $n$ is even. Proved by contradiction via `by_contra`: assume $n$ is odd, derive $n^2$ is odd (`Odd.pow`), contradict the hypothesis.\n\n**`sq_even_div_four`**: If $n$ is even (write $n = k + k$), then $n^2 = 4k^2$, so $4 \\mid n^2$. Proved by `calc` with `ring`.\n\n**`irrational_sqrt_two_classic`**: The main theorem — `Irrational (Real.sqrt 2)` — proved in one line: `exact irrational_sqrt_two` (delegating to Mathlib). The docstring spells out the classical argument: $\\sqrt{2} = a/b$ coprime $\\Rightarrow a^2 = 2b^2 \\Rightarrow a$ even $\\Rightarrow a = 2k \\Rightarrow b^2 = 2k^2 \\Rightarrow b$ even $\\Rightarrow$ both even, contradicting coprimality.",
-    "mathContext": "The classical parity argument formalizes as:\n1. Assume $\\sqrt{2} = a/b$ with $\\gcd(a,b) = 1$ (coprime).\n2. $a^2 = 2b^2$, so $a^2$ is even, so $a$ is even (`even_of_sq_even`): write $a = 2k$.\n3. $4k^2 = 2b^2$, so $b^2 = 2k^2$, so $b$ is even.\n4. Contradiction: $2 \\mid a$ and $2 \\mid b$ contradicts $\\gcd(a,b) = 1$.\n\nThis file has **0 sorries** — the main theorem is fully proved via Mathlib's `irrational_sqrt_two`.",
+    "content": "This section contains the classical parity-based proof machinery:\n\n**`even_of_sq_even`**: The key lemma \u2014 if $n^2$ is even, then $n$ is even. Proved by contradiction via `by_contra`: assume $n$ is odd, derive $n^2$ is odd (`Odd.pow`), contradict the hypothesis.\n\n**`sq_even_div_four`**: If $n$ is even (write $n = k + k$), then $n^2 = 4k^2$, so $4 \\mid n^2$. Proved by `calc` with `ring`.\n\n**`irrational_sqrt_two_classic`**: The main theorem \u2014 `Irrational (Real.sqrt 2)` \u2014 proved in one line: `exact irrational_sqrt_two` (delegating to Mathlib). The docstring spells out the classical argument: $\\sqrt{2} = a/b$ coprime $\\Rightarrow a^2 = 2b^2 \\Rightarrow a$ even $\\Rightarrow a = 2k \\Rightarrow b^2 = 2k^2 \\Rightarrow b$ even $\\Rightarrow$ both even, contradicting coprimality.",
+    "mathContext": "The classical parity argument formalizes as:\n1. Assume $\\sqrt{2} = a/b$ with $\\gcd(a,b) = 1$ (coprime).\n2. $a^2 = 2b^2$, so $a^2$ is even, so $a$ is even (`even_of_sq_even`): write $a = 2k$.\n3. $4k^2 = 2b^2$, so $b^2 = 2k^2$, so $b$ is even.\n4. Contradiction: $2 \\mid a$ and $2 \\mid b$ contradicts $\\gcd(a,b) = 1$.\n\nThis file has **0 sorries** \u2014 the main theorem is fully proved via Mathlib's `irrational_sqrt_two`.",
     "significance": "key",
     "prerequisites": [
       "ann-sqrt2-irrational-def",
@@ -145,7 +145,7 @@
     },
     "type": "insight",
     "title": "Pedagogical Tactic Examples",
-    "content": "This section contains six standalone educational theorems demonstrating core Lean 4 proof techniques. These are NOT part of the main irrationality argument — they serve as a teaching supplement showing how different tactic paradigms apply to simple mathematical facts:\n\n- **`int_sq_nonneg`**: `by_cases` on sign of $n$; uses `sq_nonneg` and `sq_pos_of_neg`. Demonstrates case splitting on a decidable condition.\n- **`sq_add_formula`**: $(a+b)^2 = a^2 + 2ab + b^2$; closed by `ring`. Shows algebraic identity verification.\n- **`imp_trans`**: If $P \\to Q$ and $Q \\to R$, then $P \\to R$; proved by `intro`/`apply` chains. Demonstrates basic propositional logic.\n- **`not_and_iff_or_not`**: De Morgan's law $\\neg(P \\wedge Q) \\iff \\neg P \\vee \\neg Q$; proved with `by_cases` and `cases`. Shows logical equivalence reasoning.\n- **`add_zero_nat`**: $n + 0 = n$; proved by `induction` with `rfl` and `simp`. Demonstrates structural induction on `ℕ`.\n- **`exists_gt_nat`**: $\\forall n \\in \\mathbb{N}, \\exists m > n$; proved via `use n + 1` and `omega`. Shows existential witness construction.",
+    "content": "This section contains six standalone educational theorems demonstrating core Lean 4 proof techniques. These are NOT part of the main irrationality argument \u2014 they serve as a teaching supplement showing how different tactic paradigms apply to simple mathematical facts:\n\n- **`int_sq_nonneg`**: `by_cases` on sign of $n$; uses `sq_nonneg` and `sq_pos_of_neg`. Demonstrates case splitting on a decidable condition.\n- **`sq_add_formula`**: $(a+b)^2 = a^2 + 2ab + b^2$; closed by `ring`. Shows algebraic identity verification.\n- **`imp_trans`**: If $P \\to Q$ and $Q \\to R$, then $P \\to R$; proved by `intro`/`apply` chains. Demonstrates basic propositional logic.\n- **`not_and_iff_or_not`**: De Morgan's law $\\neg(P \\wedge Q) \\iff \\neg P \\vee \\neg Q$; proved with `by_cases` and `cases`. Shows logical equivalence reasoning.\n- **`add_zero_nat`**: $n + 0 = n$; proved by `induction` with `rfl` and `simp`. Demonstrates structural induction on `\u2115`.\n- **`exists_gt_nat`**: $\\forall n \\in \\mathbb{N}, \\exists m > n$; proved via `use n + 1` and `omega`. Shows existential witness construction.",
     "mathContext": "These examples illustrate the main Lean 4 proof paradigms: (1) case analysis (`by_cases`, `by_contra`), (2) algebraic automation (`ring`, `omega`), (3) structural induction (`induction ... with`), (4) existential/universal reasoning (`use`, `intro`), and (5) logical connective manipulation (`constructor`, `cases`). Collectively they show that Lean 4 proofs span a spectrum from near-automatic (`ring`, `decide`) to fully explicit (`intro`/`apply` chains).",
     "significance": "supporting",
     "prerequisites": [],
@@ -165,10 +165,10 @@
       "startLine": 55,
       "endLine": 65
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Squaring Both Sides",
     "content": "From $\\sqrt{2} = p/q$, we square both sides to get $2 = p^2/q^2$, hence $p^2 = 2q^2$. This eliminates the square root and gives us an equation in integers.",
-    "mathContext": "This is the key algebraic step. In Lean, `congrArg (·^2)` applies squaring to both sides of an equation.",
+    "mathContext": "This is the key algebraic step. In Lean, `congrArg (\u00b7^2)` applies squaring to both sides of an equation.",
     "significance": "key",
     "relatedConcepts": [
       "algebraic manipulation",
@@ -185,7 +185,7 @@
     "type": "insight",
     "title": "p Must Be Even",
     "content": "From $p^2 = 2q^2$, we see $p^2$ is even (it's $2 \\times$ something). By our key lemma, this means $p$ itself is even. We write $p = 2k$ for some integer $k$.",
-    "mathContext": "The `obtain ⟨k, hk⟩` tactic extracts the witness $k$ from the existential statement that $p$ is even.",
+    "mathContext": "The `obtain \u27e8k, hk\u27e9` tactic extracts the witness $k$ from the existential statement that $p$ is even.",
     "significance": "key",
     "prerequisites": [
       "ann-sqrt2-even-of-even-sq",
@@ -206,7 +206,7 @@
     "type": "insight",
     "title": "q Must Also Be Even",
     "content": "Substituting $p = 2k$ into $p^2 = 2q^2$ gives $4k^2 = 2q^2$, so $q^2 = 2k^2$. Now $q^2$ is even, so by the same lemma, $q$ is even.",
-    "mathContext": "We've now shown both $p$ and $q$ are divisible by 2. But we assumed they were coprime—a contradiction is imminent!",
+    "mathContext": "We've now shown both $p$ and $q$ are divisible by 2. But we assumed they were coprime\u2014a contradiction is imminent!",
     "significance": "key",
     "prerequisites": [
       "ann-sqrt2-p-even"
@@ -225,8 +225,8 @@
     },
     "type": "insight",
     "title": "The Generalization Insight",
-    "content": "The √2 proof works because 2 is prime and appears exactly once in its factorization (odd multiplicity). The key insight is: **if any prime $p$ appears to odd multiplicity in $n$, then $\\sqrt{n}$ is irrational**.",
-    "mathContext": "If $n = p^{2k+1} \\cdot m$ where $p \\nmid m$, and $\\sqrt{n} = a/b$ in lowest terms, then looking at $p$'s multiplicity in $n \\cdot b^2 = a^2$ gives: $(2k+1) + 2 \\cdot \\text{mult}(p,b) = 2 \\cdot \\text{mult}(p,a)$. The left side is odd, the right side is even—contradiction!",
+    "content": "The \u221a2 proof works because 2 is prime and appears exactly once in its factorization (odd multiplicity). The key insight is: **if any prime $p$ appears to odd multiplicity in $n$, then $\\sqrt{n}$ is irrational**.",
+    "mathContext": "If $n = p^{2k+1} \\cdot m$ where $p \\nmid m$, and $\\sqrt{n} = a/b$ in lowest terms, then looking at $p$'s multiplicity in $n \\cdot b^2 = a^2$ gives: $(2k+1) + 2 \\cdot \\text{mult}(p,b) = 2 \\cdot \\text{mult}(p,a)$. The left side is odd, the right side is even\u2014contradiction!",
     "significance": "key",
     "prerequisites": [
       "ann-sqrt2-contradiction"
@@ -244,10 +244,10 @@
       "startLine": 161,
       "endLine": 164
     },
-    "type": "theorem",
-    "title": "Irrationality of √3",
-    "content": "Since 3 is prime, it appears to multiplicity 1 (odd) in 3. By the same multiplicity argument that proved √2 irrational, √3 is also irrational.",
-    "mathContext": "In Lean, we use `Nat.Prime.irrational_sqrt` which proves √p is irrational for any prime p. The proof reduces to showing 3 is prime via `Nat.prime_three`.",
+    "type": "insight",
+    "title": "Irrationality of \u221a3",
+    "content": "Since 3 is prime, it appears to multiplicity 1 (odd) in 3. By the same multiplicity argument that proved \u221a2 irrational, \u221a3 is also irrational.",
+    "mathContext": "In Lean, we use `Nat.Prime.irrational_sqrt` which proves \u221ap is irrational for any prime p. The proof reduces to showing 3 is prime via `Nat.prime_three`.",
     "significance": "key",
     "prerequisites": [
       "ann-generalization-intro"
@@ -264,10 +264,10 @@
       "startLine": 170,
       "endLine": 173
     },
-    "type": "theorem",
-    "title": "Irrationality of √5",
-    "content": "5 is prime, so it appears to odd multiplicity in 5. Therefore √5 is irrational.",
-    "mathContext": "Same pattern as √3. Mathlib provides `Nat.prime_five` to establish that 5 is prime.",
+    "type": "insight",
+    "title": "Irrationality of \u221a5",
+    "content": "5 is prime, so it appears to odd multiplicity in 5. Therefore \u221a5 is irrational.",
+    "mathContext": "Same pattern as \u221a3. Mathlib provides `Nat.prime_five` to establish that 5 is prime.",
     "significance": "supporting",
     "prerequisites": [
       "ann-generalization-intro"
@@ -284,10 +284,10 @@
       "startLine": 179,
       "endLine": 182
     },
-    "type": "theorem",
-    "title": "Irrationality of √6",
-    "content": "6 = 2 × 3. Both primes 2 and 3 appear to multiplicity 1 (odd). The same argument applies: √6 is irrational.",
-    "mathContext": "This example shows the theorem works for composite numbers too. We use `irrational_sqrt_natCast_iff.mpr` with the fact that 6 is not a perfect square (`¬ IsSquare 6`). The `decide` tactic verifies this computationally.",
+    "type": "insight",
+    "title": "Irrationality of \u221a6",
+    "content": "6 = 2 \u00d7 3. Both primes 2 and 3 appear to multiplicity 1 (odd). The same argument applies: \u221a6 is irrational.",
+    "mathContext": "This example shows the theorem works for composite numbers too. We use `irrational_sqrt_natCast_iff.mpr` with the fact that 6 is not a perfect square (`\u00ac IsSquare 6`). The `decide` tactic verifies this computationally.",
     "significance": "key",
     "prerequisites": [
       "ann-generalization-intro"
@@ -305,9 +305,9 @@
       "startLine": 187,
       "endLine": 193
     },
-    "type": "theorem",
-    "title": "Irrationality of √7",
-    "content": "7 is prime, so √7 is irrational by the same reasoning.",
+    "type": "insight",
+    "title": "Irrationality of \u221a7",
+    "content": "7 is prime, so \u221a7 is irrational by the same reasoning.",
     "mathContext": "We use `by decide : Nat.Prime 7` to verify primality computationally, then apply `Nat.Prime.irrational_sqrt`.",
     "significance": "supporting",
     "prerequisites": [
@@ -325,10 +325,10 @@
       "startLine": 195,
       "endLine": 199
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The General Theorem",
-    "content": "**Main Result**: For any natural number $n$ that is not a perfect square, $\\sqrt{n}$ is irrational. This single theorem subsumes all the specific cases: √2, √3, √5, √6, √7, √8, √10, ...",
-    "mathContext": "The theorem `irrational_sqrt_of_not_square` uses Mathlib's `irrational_sqrt_natCast_iff` which establishes the result based on `¬ IsSquare n`.",
+    "content": "**Main Result**: For any natural number $n$ that is not a perfect square, $\\sqrt{n}$ is irrational. This single theorem subsumes all the specific cases: \u221a2, \u221a3, \u221a5, \u221a6, \u221a7, \u221a8, \u221a10, ...",
+    "mathContext": "The theorem `irrational_sqrt_of_not_square` uses Mathlib's `irrational_sqrt_natCast_iff` which establishes the result based on `\u00ac IsSquare n`.",
     "significance": "key",
     "prerequisites": [
       "ann-sqrt3-proof",
@@ -347,10 +347,10 @@
       "startLine": 201,
       "endLine": 207
     },
-    "type": "example",
+    "type": "context",
     "title": "Perfect Squares vs Non-Squares",
-    "content": "The `decide` tactic can verify whether a number is a perfect square. Non-squares: 2, 3, 5, 6, 7, 8, 10, ... Perfect squares: 1 = 1², 4 = 2², 9 = 3², 16 = 4², ...",
-    "mathContext": "For perfect squares, we provide explicit witnesses: `IsSquare 4` is proven by `⟨2, by ring⟩` showing $4 = 2 \\cdot 2$. The `decide` tactic handles non-squares by computation.",
+    "content": "The `decide` tactic can verify whether a number is a perfect square. Non-squares: 2, 3, 5, 6, 7, 8, 10, ... Perfect squares: 1 = 1\u00b2, 4 = 2\u00b2, 9 = 3\u00b2, 16 = 4\u00b2, ...",
+    "mathContext": "For perfect squares, we provide explicit witnesses: `IsSquare 4` is proven by `\u27e82, by ring\u27e9` showing $4 = 2 \\cdot 2$. The `decide` tactic handles non-squares by computation.",
     "significance": "supporting",
     "prerequisites": [
       "ann-general-theorem"

--- a/src/data/proofs/triangle-inequality/annotations.json
+++ b/src/data/proofs/triangle-inequality/annotations.json
@@ -6,9 +6,9 @@
       "startLine": 66,
       "endLine": 73
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Triangle Inequality (Absolute Value)",
-    "content": "**The fundamental triangle inequality for real numbers: |x + y| ≤ |x| + |y|.**\n\nThis is the core result from which all other forms derive. The proof is a direct application of Mathlib's `abs_add` theorem.",
+    "content": "**The fundamental triangle inequality for real numbers: |x + y| \u2264 |x| + |y|.**\n\nThis is the core result from which all other forms derive. The proof is a direct application of Mathlib's `abs_add` theorem.",
     "mathContext": "$|x + y| \\leq |x| + |y|$",
     "significance": "key",
     "relatedConcepts": [
@@ -23,9 +23,9 @@
       "startLine": 81,
       "endLine": 88
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Reverse Triangle Inequality",
-    "content": "**The reverse triangle inequality: | |x| - |y| | ≤ |x - y|.**\n\nWhile the standard triangle inequality gives an upper bound on |x + y|, this provides a lower bound. It shows that the absolute value function is Lipschitz continuous with constant 1.\n\nGeometrically: the difference in distances to the origin is at most the distance between the points.",
+    "content": "**The reverse triangle inequality: | |x| - |y| | \u2264 |x - y|.**\n\nWhile the standard triangle inequality gives an upper bound on |x + y|, this provides a lower bound. It shows that the absolute value function is Lipschitz continuous with constant 1.\n\nGeometrically: the difference in distances to the origin is at most the distance between the points.",
     "mathContext": "$\\big||x| - |y|\\big| \\leq |x - y|$",
     "significance": "key",
     "relatedConcepts": [
@@ -40,9 +40,9 @@
       "startLine": 110,
       "endLine": 118
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Triangle Inequality (Normed Spaces)",
-    "content": "**Generalization to normed vector spaces: ‖x + y‖ ≤ ‖x‖ + ‖y‖.**\n\nThis is actually an axiom in the definition of a norm. The formalization uses Mathlib's `norm_add_le` which provides this for any seminormed additive commutative group.",
+    "content": "**Generalization to normed vector spaces: \u2016x + y\u2016 \u2264 \u2016x\u2016 + \u2016y\u2016.**\n\nThis is actually an axiom in the definition of a norm. The formalization uses Mathlib's `norm_add_le` which provides this for any seminormed additive commutative group.",
     "mathContext": "$\\|x + y\\| \\leq \\|x\\| + \\|y\\|$",
     "significance": "key",
     "relatedConcepts": [
@@ -57,9 +57,9 @@
       "startLine": 139,
       "endLine": 147
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Triangle Inequality (Metric Spaces)",
-    "content": "**The most general form: dist(x, z) ≤ dist(x, y) + dist(y, z).**\n\nThis is one of the three axioms defining a metric space (along with non-negativity and symmetry). It captures the intuition that the direct path is never longer than a detour.\n\nMathlib's `dist_triangle` provides this for any PseudoMetricSpace.",
+    "content": "**The most general form: dist(x, z) \u2264 dist(x, y) + dist(y, z).**\n\nThis is one of the three axioms defining a metric space (along with non-negativity and symmetry). It captures the intuition that the direct path is never longer than a detour.\n\nMathlib's `dist_triangle` provides this for any PseudoMetricSpace.",
     "mathContext": "$d(x, z) \\leq d(x, y) + d(y, z)$",
     "significance": "key",
     "relatedConcepts": [
@@ -74,9 +74,9 @@
       "startLine": 149,
       "endLine": 153
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Four-Point Triangle Inequality",
-    "content": "**Extension to four points: d(x, w) ≤ d(x, y) + d(y, z) + d(z, w).**\n\nThis is derived by applying the triangle inequality twice. It shows that any path through intermediate points is at least as long as the direct path.",
+    "content": "**Extension to four points: d(x, w) \u2264 d(x, y) + d(y, z) + d(z, w).**\n\nThis is derived by applying the triangle inequality twice. It shows that any path through intermediate points is at least as long as the direct path.",
     "mathContext": "$d(x, w) \\leq d(x, y) + d(y, z) + d(z, w)$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -91,7 +91,7 @@
       "startLine": 173,
       "endLine": 191
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Strict Triangle Inequality",
     "content": "**When does equality hold? Strict inequality occurs when x and y have opposite signs.**\n\nIf x > 0 and y < 0 (or vice versa), then |x + y| < |x| + |y| strictly. Equality holds only when x and y have the same sign (or one is zero).\n\nGeometrically: the triangle inequality becomes equality when the points are collinear.",
     "mathContext": "$xy < 0 \\Rightarrow |x + y| < |x| + |y|$",
@@ -110,7 +110,7 @@
     },
     "type": "insight",
     "title": "Absolute Value is Lipschitz",
-    "content": "**Application: The absolute value function is Lipschitz continuous with constant 1.**\n\nThe reverse triangle inequality | |x| - |y| | ≤ |x - y| is exactly the statement that |·| is 1-Lipschitz. This means small changes in input lead to at most equally small changes in output.",
+    "content": "**Application: The absolute value function is Lipschitz continuous with constant 1.**\n\nThe reverse triangle inequality | |x| - |y| | \u2264 |x - y| is exactly the statement that |\u00b7| is 1-Lipschitz. This means small changes in input lead to at most equally small changes in output.",
     "mathContext": "Lip$(|\\cdot|) = 1$",
     "significance": "key",
     "relatedConcepts": [
@@ -127,7 +127,7 @@
     },
     "type": "insight",
     "title": "Norm is Lipschitz",
-    "content": "**The norm function ‖·‖ is Lipschitz continuous with constant 1.**\n\nThis generalizes the absolute value case to arbitrary normed spaces. It's essential for proving that norms are continuous functions, which is fundamental in functional analysis.",
+    "content": "**The norm function \u2016\u00b7\u2016 is Lipschitz continuous with constant 1.**\n\nThis generalizes the absolute value case to arbitrary normed spaces. It's essential for proving that norms are continuous functions, which is fundamental in functional analysis.",
     "mathContext": "$\\big|\\|x\\| - \\|y\\|\\big| \\leq \\|x - y\\|$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -142,9 +142,9 @@
       "startLine": 232,
       "endLine": 236
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Triangle Inequality for Sums",
-    "content": "**Iterated triangle inequality: ‖∑ xᵢ‖ ≤ ∑ ‖xᵢ‖.**\n\nThe triangle inequality extends by induction to finite sums. This is crucial for bounding errors in numerical computations and proving convergence of series.",
+    "content": "**Iterated triangle inequality: \u2016\u2211 x\u1d62\u2016 \u2264 \u2211 \u2016x\u1d62\u2016.**\n\nThe triangle inequality extends by induction to finite sums. This is crucial for bounding errors in numerical computations and proving convergence of series.",
     "mathContext": "$\\left\\|\\sum_i x_i\\right\\| \\leq \\sum_i \\|x_i\\|$",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
Mixed enrichment batch: two full annotation rewrites and one 8-proof type-fix batch.

## Full Annotation Rewrites

| Proof | Description |
|-------|-------------|
| dirichlets-theorem-oq-01-oq-01 | Rewrote 6 annotations: fixed 5 invalid `mathematical` types, added proper range/content/mathContext/prerequisites/relatedConcepts |
| bounded-prime-gaps-oq-01-oq-02 | Created 6 new annotations from scratch for empty file: EH conjecture, H≤12 theorem, sieve level, admissible 5-tuples, implication hierarchy |

## Type Fix Batch (67 fixes across 8 proofs)

| Proof | Fixes |
|-------|-------|
| sqrt2-irrational | 11 (lemma→technique) |
| gcd-algorithm | 10 (theorem→insight) |
| euler-polyhedral-formula-oq-02-oq-01 | 8 (theorem→insight) |
| chebyshev-pnt-bridge-oq-01 | 8 (theorem→insight) |
| central-limit-theorem | 8 (lemma→technique, theorem→insight) |
| brouwer-fixed-point-oq-02-oq-02 | 8 (theorem→insight) |
| angle-trisection-cos-20-gal | 7 (theorem→insight) |
| triangle-inequality | 7 (theorem→insight) |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)