### PR TITLE
fix: add conjecture axioms, fix badge wip→axiom for erdos-1056 and erdos-831

### DIFF
--- a/proofs/Proofs/Erdos1056Problem.lean
+++ b/proofs/Proofs/Erdos1056Problem.lean
@@ -192,7 +192,9 @@ theorem wilson_constraint (p : ℕ) (hp : p.Prime) :
 
 /-- **Erdős Problem #1056:** For every k ≥ 2, there exists a solution.
     That is, for every k there is a prime p and k consecutive intervals
-    whose products are all ≡ 1 (mod p). -/
+    whose products are all ≡ 1 (mod p). [OPEN] -/
+axiom erdos_1056_conjecture : ∀ k : ℕ, k ≥ 2 → HasSolution k
+
 /- ## Part VI: Noll–Simmons Generalization -/
 
 /-- The Noll–Simmons question: For arbitrarily large k, do there exist

--- a/proofs/Proofs/Erdos831Problem.lean
+++ b/proofs/Proofs/Erdos831Problem.lean
@@ -338,6 +338,11 @@ Combined with h(4) ≥ 1 (trivially, any triple has a circumcircle), h(4) = 1.
 ## Part VI: The Main Conjecture
 -/
 
+/-- **Erdős Problem #831 main question:** h(n) → ∞ as n → ∞.
+    The central open problem: does the minimum number of distinct circumradii
+    grow without bound as the point count grows? [OPEN] -/
+axiom erdos_831_growing : ∀ k : ℕ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → h n ≥ k
+
 /-
 ## Part VII: Related Constructions
 -/

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -15,7 +15,7 @@
       "open"
     ],
     "erdosProblemStatus": "open",
-    "badge": "wip",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos1056Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1056",
@@ -25,9 +25,9 @@
       "erdos-945",
       "erdos-1004"
     ],
-    "axiomCount": 0,
-    "lineCount": 215,
-    "assumptions": "0 axioms, 0 sorries. k=2 (p=11) and k=3 (p=17) cases fully proved. Wilson constraint proved via Mathlib. Main conjecture for all k remains open and is not formalized as axiom.",
+    "axiomCount": 1,
+    "lineCount": 217,
+    "assumptions": "1 axiom: erdos_1056_conjecture (main conjecture — for every k ≥ 2 there exists a solution). k=2 (p=11) and k=3 (p=17) cases fully proved by native_decide. Wilson constraint proved via Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15
   },
@@ -193,8 +193,8 @@
       "Finset"
     ],
     "namespace": "Erdos1056",
-    "lineCount": 215,
-    "axiomCount": 0,
+    "lineCount": 217,
+    "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/Erdos1056Problem.lean",

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -15,7 +15,7 @@
       "extremal-geometry",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 831,
     "erdosUrl": "https://erdosproblems.com/831",
@@ -53,9 +53,9 @@
       "areCollinear_perm12, areConcyclic_perm: symmetry lemmas (proved)",
       "erdos_831_summary, erdos_831_open_question: summary theorems"
     ],
-    "axiomCount": 0,
-    "lineCount": 712,
-    "assumptions": "Fully verified: 0 axioms, 0 sorries. h(4)=1 (corrected — h(4)≥2 was false), h_upper_bound, and h_three all proved. Open conjecture; supporting lemmas fully verified.",
+    "axiomCount": 1,
+    "lineCount": 717,
+    "assumptions": "1 axiom: erdos_831_growing (h(n) → ∞ as n → ∞ — the central open question). h(4)=1 (corrected), h_upper_bound, and h_three all proved. 23 theorems, 0 sorries.",
     "theoremCount": 23
   },
   "overview": {
@@ -185,8 +185,8 @@
       "Finset"
     ],
     "namespace": "Erdos831",
-    "lineCount": 712,
-    "axiomCount": 0,
+    "lineCount": 717,
+    "axiomCount": 1,
     "theoremCount": 23,
     "definitionCount": 13,
     "path": "Proofs/Erdos831Problem.lean",


### PR DESCRIPTION
## Summary

Two proofs had `status: axiomatized` with `badge: wip` and `axiomCount: 0` — inconsistent for open Erdős problems (which should have at least one axiom).

### erdos-1056: Consecutive Interval Products ≡ 1 (mod p)
- The main conjecture (`∀ k ≥ 2, HasSolution k`) was in a docstring but not formalized
- **Fix**: add `axiom erdos_1056_conjecture : ∀ k : ℕ, k ≥ 2 → HasSolution k`
- Updated: badge wip→axiom, axiomCount 0→1, lineCount 215→217

### erdos-831: Distinct Radii Circles Through Point Configurations  
- Part VI ("The Main Conjecture") section was completely empty
- **Fix**: add `axiom erdos_831_growing : ∀ k : ℕ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → h n ≥ k`
- Updated: badge wip→axiom, axiomCount 0→1, lineCount 712→717

## Test plan

- [ ] `pnpm build` succeeds with updated meta.json files
- [ ] Both Lean files compile (axioms require no proof — just type-checking)