### PR TITLE
fix(pnpm): approve build scripts for better-sqlite3 and esbuild

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true


### PR DESCRIPTION
pnpm 11 requires explicit `allowBuilds` approval in `pnpm-workspace.yaml`. The file existed with placeholder values (`set this to true or false`), which caused `ERR_PNPM_IGNORED_BUILDS` and blocked all website builds.

## Changes
- Set `better-sqlite3: true` and `esbuild: true` in `pnpm-workspace.yaml`

## Test plan
- [ ] `pnpm build` completes without `ERR_PNPM_IGNORED_BUILDS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)