### PR TITLE
research(roth-theorem): add gallery entry — Fourier-analytic Roth with density increment (42 theorems)

### DIFF
--- a/src/data/proofs/roth-theorem/annotations.json
+++ b/src/data/proofs/roth-theorem/annotations.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "roth-theorem-apfree-def",
+    "proofId": "roth-theorem",
+    "type": "definition",
+    "range": {
+      "startLine": 25,
+      "endLine": 28
+    },
+    "title": "AP-Free Definition on ZMod N",
+    "content": "`APFree A` asserts that `A ⊆ ZMod N` contains no nontrivial 3-term arithmetic progression: there are no $a, d$ with $d \\ne 0$ such that $\\{a, a+d, a+2d\\} \\subseteq A$.\n\nWorking in `ZMod N` (rather than `Finset ℕ`) gives automatic wrap-around arithmetic, simplifying the modular structure. The non-triviality condition `d ≠ 0` excludes the degenerate case where $a = a+d = a+2d$.",
+    "significance": "key",
+    "mathContext": "$A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ is *AP-free* (or *3-AP-free*) if $\\nexists a, d \\in \\mathbb{Z}/N\\mathbb{Z}$ with $d \\ne 0$ and $a, a+d, a+2d \\in A$.",
+    "relatedConcepts": [
+      "arithmetic progressions",
+      "Szemerédi's theorem",
+      "ZMod N"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "Finset membership"
+    ]
+  },
+  {
+    "id": "roth-theorem-fourier-coeff",
+    "proofId": "roth-theorem",
+    "type": "definition",
+    "range": {
+      "startLine": 98,
+      "endLine": 99
+    },
+    "title": "Fourier Coefficient on ZMod N",
+    "content": "`fourierCoeff A r = Σ_{x∈A} exp(2πi·val(r·x)/N)` computes the Fourier coefficient of the characteristic function of $A$ at frequency $r \\in \\mathbb{Z}/N\\mathbb{Z}$.\n\nThe additive character is `ψ(x) = exp(2πi·val(x)/N)`. The `ZMod.val` function extracts the representative in `{0,...,N-1}`, making the argument to `exp` a real number. The key property is that ψ is a group homomorphism: `ψ(a+b) = ψ(a)·ψ(b)` (proved as `psi_add`).",
+    "significance": "key",
+    "mathContext": "$\\hat{A}(r) = \\sum_{x \\in A} e^{2\\pi i \\cdot \\mathrm{val}(r \\cdot x)/N} = \\sum_{x \\in A} \\psi(rx)$. Note $\\hat{A}(0) = |A|$ and $|\\hat{A}(r)| \\leq |A|$ for all $r$.",
+    "relatedConcepts": [
+      "discrete Fourier transform",
+      "additive characters",
+      "ZMod.val"
+    ],
+    "prerequisites": [
+      "complex exponentials",
+      "group homomorphisms",
+      "Complex.exp"
+    ]
+  },
+  {
+    "id": "roth-theorem-parseval",
+    "proofId": "roth-theorem",
+    "type": "theorem",
+    "range": {
+      "startLine": 354,
+      "endLine": 397
+    },
+    "title": "Parseval's Identity on ZMod N",
+    "content": "`parseval_on_zmod`: $\\sum_{r \\in \\mathbb{Z}/N\\mathbb{Z}} \\|\\hat{A}(r)\\|^2 = |A| \\cdot N$.\n\nThe proof starts from the complex identity $\\sum_r \\hat{A}(r) \\cdot \\overline{\\hat{A}(r)} = |A| \\cdot N$ and extracts the real part. The key step is character orthogonality: $\\sum_r \\psi(r(x-y)) = N \\cdot \\mathbf{1}[x=y]$, which converts the double sum to a delta function, leaving $\\sum_{x,y \\in A} N \\cdot \\mathbf{1}[x=y] = |A| \\cdot N$.",
+    "significance": "critical",
+    "mathContext": "$\\sum_{r=0}^{N-1} |\\hat{A}(r)|^2 = |A| \\cdot N$. In particular, for the nonzero frequencies: $\\sum_{r \\ne 0} |\\hat{A}(r)|^2 = |A| \\cdot N - |A|^2 = |A|(N - |A|)$.",
+    "relatedConcepts": [
+      "Parseval's theorem",
+      "character orthogonality",
+      "energy of a set"
+    ],
+    "prerequisites": [
+      "Fourier analysis",
+      "character orthogonality",
+      "complex inner product"
+    ]
+  },
+  {
+    "id": "roth-theorem-large-coeff",
+    "proofId": "roth-theorem",
+    "type": "theorem",
+    "range": {
+      "startLine": 615,
+      "endLine": 816
+    },
+    "title": "Large Fourier Coefficient from AP-Freeness",
+    "content": "`fourier_large_coefficient`: If $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ is AP-free with $|A| \\geq \\delta N$, then $\\exists r \\ne 0$ with $\\|\\hat{A}(r)\\| \\geq \\delta^2 N/2$.\n\nThis is the key analytic step in Roth's proof, formalized in two cases:\n\n**Case 1** ($\\delta^2 N < 2$): The bound $\\delta^2 N/2 < 1$. By Parseval, $\\sum_{r \\ne 0} \\|\\hat{A}(r)\\|^2 = |A|(N-|A|) \\geq N-1$. Since there are $N-1$ nonzero frequencies, some $\\|\\hat{A}(r)\\|^2 \\geq 1 > \\delta^2 N/2$.\n\n**Case 2** ($\\delta^2 N \\geq 2$): If all $\\|\\hat{A}(r)\\| < \\delta^2 N/2$ for $r \\ne 0$, use the AP counting identity $|A| \\cdot N = \\sum_r \\hat{A}(r)^2 \\overline{\\hat{A}(2r)}$ (from AP-freeness: tripleCount = 0). Split the nonzero-frequency sum into T₁ (where $2r \\ne 0$) and T₂ (where $2r = 0$, at most one element). Bound each part using the hypothesis and Parseval, obtaining $|A|^2 - N < \\delta^2 N^2/2$, contradicting $|A| \\geq \\delta N$.",
+    "significance": "critical",
+    "mathContext": "If $|A|/N \\geq \\delta$ and $A$ has no 3-AP, then $\\max_{r \\ne 0} |\\hat{A}(r)| \\geq \\delta^2 N / 2$. This was Roth's key insight (1953).",
+    "relatedConcepts": [
+      "density increment strategy",
+      "Parseval pigeonhole",
+      "AP counting identity"
+    ],
+    "prerequisites": [
+      "Fourier analysis",
+      "Parseval's theorem",
+      "AM-GM inequality"
+    ]
+  },
+  {
+    "id": "roth-theorem-density-increment",
+    "proofId": "roth-theorem",
+    "type": "theorem",
+    "range": {
+      "startLine": 1127,
+      "endLine": 1330
+    },
+    "title": "Density Increment Lemma",
+    "content": "`density_increment_lemma`: If $A$ is AP-free with density $\\delta$ in $\\mathbb{Z}/N\\mathbb{Z}$, then some coset of a subgroup has density $\\geq \\delta + \\delta^2/4$.\n\nProof via Fourier decomposition over cosets: Write $\\hat{A}(r) = \\sum_j (f_j - m) \\psi(rj)$ where $f_j$ is the density of $A$ in the $j$-th coset and $m = |A|/g$ is the mean. The large Fourier coefficient $|\\hat{A}(r)| \\geq \\delta^2 N/2$ (from `fourier_large_coefficient`) forces the sum of deviations $\\sum_j |f_j - m|$ to be large. The zero-sum property $\\sum_j (f_j - m) = 0$ implies the positive deviations sum to $\\geq \\delta^2 N/4$, so some coset achieves density $m + \\delta^2 N/(4g) = \\delta + \\delta^2/4$ (in ZMod(N/g)).",
+    "significance": "key",
+    "mathContext": "Starting from density $\\delta$, each density increment step multiplies the ambient size by $g$ while increasing density by $\\delta^2/4$. After $O(1/\\delta)$ steps, density exceeds 2/3 (trivially containing a 3-AP).",
+    "relatedConcepts": [
+      "density increment strategy",
+      "coset restriction",
+      "Fourier decomposition over cosets"
+    ],
+    "prerequisites": [
+      "coset restriction (cosetRestrict)",
+      "Fourier large coefficient",
+      "triangle inequality for complex norms"
+    ]
+  },
+  {
+    "id": "roth-theorem-main",
+    "proofId": "roth-theorem",
+    "type": "theorem",
+    "range": {
+      "startLine": 1372,
+      "endLine": 1401
+    },
+    "title": "Roth's Theorem: roth_density_bound",
+    "content": "`roth_density_bound`: For every $\\delta > 0$, $\\exists N_0$ such that for all $N \\geq N_0$ and $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ with $|A| \\geq \\delta N$, $A$ contains a 3-AP.\n\nThe proof maps $A$ to the natural numbers via `ZMod.val` (which is injective and maps elements of $A$ to $\\{0, \\ldots, N-1\\}$), verifies `apFree_imp_threeAPFree_val` (AP-free in ZMod N → ThreeAPFree on ℕ), and invokes Mathlib's `roth_3ap_theorem_nat` with the `cornersTheoremBound`.\n\nThe key bridge lemma `apFree_imp_threeAPFree_val` uses the fact that if $\\mathrm{val}(x) + \\mathrm{val}(z) = 2\\,\\mathrm{val}(y)$ in $\\mathbb{N}$, then $x + z = 2y$ in $\\mathbb{Z}/N\\mathbb{Z}$ (since $\\mathrm{val}(x) + \\mathrm{val}(z) < 2N$, no modular reduction occurs).",
+    "significance": "critical",
+    "mathContext": "$r_3(N) = o(N)$ where $r_3(N)$ is the maximum size of a subset of $\\{1, \\ldots, N\\}$ without a 3-AP. Roth (1953) proved $r_3(N) = O(N/\\log\\log N)$; better bounds known since.",
+    "relatedConcepts": [
+      "Szemerédi's theorem",
+      "ThreeAPFree",
+      "roth_3ap_theorem_nat",
+      "cornersTheoremBound"
+    ],
+    "prerequisites": [
+      "Mathlib Roth theorem",
+      "ZMod.val injectivity",
+      "ThreeAPFree definition"
+    ]
+  }
+]

--- a/src/data/proofs/roth-theorem/index.ts
+++ b/src/data/proofs/roth-theorem/index.ts
@@ -1,0 +1,30 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/RothTheorem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "roth-theorem",
+  "title": "Roth's Theorem: AP-Free Sets Have Density o(1)",
+  "slug": "roth-theorem",
+  "description": "Formalizes Roth's 1953 theorem: every subset of Z/NZ with no 3-term arithmetic progression has density o(1). The formalization develops the complete Fourier-analytic machinery (character orthogonality, Parseval, AP counting, density increment) over Z/NZ, then invokes Mathlib's corners-theorem-based Roth. The key standalone result is `fourier_large_coefficient`: AP-free sets of density δ have a large Fourier coefficient ≥ δ²N/2.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Roth%27s_theorem_on_arithmetic_progressions",
+    "date": "Classical result (Roth 1953); Fourier-analytic approach formalized 2026",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "additive-combinatorics",
+      "arithmetic-progressions",
+      "fourier-analysis",
+      "szemeredi",
+      "density-increment",
+      "roth"
+    ],
+    "proofRepoPath": "Proofs/RothTheorem.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 42 theorems verified with 0 sorries and 0 axioms. The main theorem `roth_density_bound` invokes Mathlib's `roth_3ap_theorem_nat` (itself verified via the corners theorem chain: Regularity → Triangle Removal → Corners → Roth). The Fourier-analytic infrastructure (Parts I–V, including `fourier_large_coefficient`) is independently verified.",
+    "originalContributions": [
+      "APFree definition and basic properties (apFree_empty, apFree_singleton, apFree_subset) on ZMod N",
+      "tripleCount: exact count of 3-APs; apFree_iff_tripleCount_zero equivalence",
+      "fourierCoeff on ZMod N with Fourier bound (fourierCoeff_norm_le)",
+      "parseval_on_zmod: Parseval's identity Σ‖Â(r)‖² = |A|·N proved via character orthogonality",
+      "triple_count_fourier: AP count = N⁻¹ Σ Â(r)² conj(Â(2r)) — Fourier counting identity",
+      "fourier_large_coefficient: AP-free density-δ set has ‖Â(r)‖ ≥ δ²N/2 for some r≠0 (two-case proof: δ²N<2 via Parseval pigeonhole; δ²N≥2 via Fourier identity + AM-GM)",
+      "cosetRestrict: coset restriction to ZMod(N/g); apFree_coset_restrict: AP-free preserved under restriction",
+      "density_increment_lemma: AP-free density-δ set has some coset with density δ + δ²/4",
+      "roth_density_bound: main theorem via Mathlib roth_3ap_theorem_nat"
+    ],
+    "dateAdded": "2026-05-04",
+    "lineCount": 1401,
+    "theoremCount": 42,
+    "definitionCount": 6,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Roth's theorem (1953) was a landmark in additive combinatorics: every subset of integers with positive upper density contains a 3-term arithmetic progression. The original proof used Fourier analysis (the density increment strategy). The k=3 case was later subsumed by Szemerédi's theorem (1975) for general k-APs, but Roth's Fourier method remains fundamental.\n\nThe Fourier-analytic proof proceeds by density increment: if A ⊆ Z/NZ has density δ but no 3-AP, then A's Fourier transform has a large coefficient at some frequency r≠0 (the key analytic lemma). This large coefficient means A looks 'structured' — concentrated in a coset of a subgroup. Restricting to that coset increases the density to δ + δ²/4. Iterating O(1/δ²) times reaches density 1, giving a 3-AP by the pigeonhole principle.\n\nModern proofs achieve better quantitative bounds: Bourgain (1999) gave N/(log log N)^{1/2} and Bloom-Sisask (2020) gave N/log^{1+c} N. The qualitative result here suffices for Roth's original theorem.",
+    "problemStatement": "**Roth's Theorem**: For every δ > 0, there exists N₀ such that for all N ≥ N₀, every subset A ⊆ Z/NZ with |A| ≥ δN contains a 3-term arithmetic progression {a, a+d, a+2d} with d ≠ 0.",
+    "text": "A 1401-line formalization developing the full Fourier-analytic proof of Roth's theorem from first principles on Z/NZ. Parts I–V (Fourier analysis, AP counting, large coefficient, density increment) are fully self-contained; Part VI wraps via Mathlib's `roth_3ap_theorem_nat`. The key standalone result is `fourier_large_coefficient` — a complete, independently verified proof of the crucial analytic step.",
+    "proofStrategy": "**Part I (AP-free basics)**: Define `APFree A` on `ZMod N`; prove empty/singleton cases; monotonicity under subset. Cardinality bound `card_le_nat` via `ZMod.card N`.\n\n**Part II (AP counting)**: `tripleCount A` counts nontrivial 3-APs via filter on `ZMod N × ZMod N`. Prove `apFree_iff_tripleCount_zero` using Finset.card_eq_zero.\n\n**Part III (Fourier analysis)**: `fourierCoeff A r = Σ_{x∈A} exp(2πi val(r·x)/N)`. Additive character `ψ`: prove `psi_add`, `psi_zero`, `psi_ne_one`, `psi_norm`, `conj_psi`. Prove `char_orthogonality`: `Σ_r ψ(rc) = N·δ(c,0)` via shift argument. Use to prove `parseval_on_zmod` and `triple_count_fourier`.\n\n**Part IV (Large coefficient)**: `fourier_large_coefficient` — two cases: (1) δ²N < 2: Parseval gives max ≥ 1 > δ²N/2; (2) δ²N ≥ 2: contradiction via Fourier identity + AM-GM bound on sum over T₁ ∪ T₂ splitting by kernel of ×2.\n\n**Part V (Density increment)**: `cosetRestrict A g hg hgN j hj` restricts A to the j-th coset in ZMod(N/g). Prove `apFree_coset_restrict` (AP-free preserved) and `density_increment_lemma` (some coset achieves density δ + δ²/4).\n\n**Part VI (Main theorem)**: `roth_density_bound` maps A to ℕ via `ZMod.val`, verifies `apFree_imp_threeAPFree_val`, then invokes `roth_3ap_theorem_nat`.",
+    "keyInsights": [
+      "**Character Orthogonality as Foundation**: The entire Fourier-analytic approach rests on `char_orthogonality` — the sum of ψ(rc) over all r vanishes when c≠0. This is proved via a shift argument: multiplication by ψ(c)≠1 is a bijection on the sum, forcing it to zero. All subsequent results build on this.",
+      "**AP Count Fourier Identity**: `triple_count_fourier` shows `tripleCount A + |A| = N⁻¹ Σ_r Â(r)² conj(Â(2r))`. This converts combinatorial AP counting to a Fourier sum, enabling analytic methods.",
+      "**Two-Case Analysis in `fourier_large_coefficient`**: The proof splits on δ²N < 2 vs ≥ 2. In the first case, Parseval forces a Fourier coefficient ≥ 1. In the second, a contradiction is derived using the Fourier counting identity, the AM-GM bound, and careful handling of the kernel of multiplication by 2 in ZMod N (which has at most one nonzero element).",
+      "**Coset Restriction Preserves AP-Freeness**: `apFree_coset_restrict` shows that a 3-AP in ZMod(N/g) lifts to a 3-AP in ZMod N via the map k ↦ j + k·g. This requires careful mod arithmetic: `val(a+b)*g ≡ (val a + val b)*g (mod N)` when `g·(N/g) = N`.",
+      "**Mathlib Integration Point**: The main theorem defers to Mathlib's `roth_3ap_theorem_nat` (via `ThreeAPFree` and the corners theorem bound). The custom machinery provides `fourier_large_coefficient` and `density_increment_lemma` as independently verified results — showing the Fourier approach is fully formalized even though the iteration is handled by Mathlib."
+    ],
+    "prerequisites": [
+      "Fourier analysis on finite groups",
+      "3-term arithmetic progressions",
+      "ZMod N and character theory",
+      "Density increment strategy"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "special-case",
+      "description": "Roth's theorem is the k=3 case of Szemerédi's theorem on k-APs in dense sets"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Szemeredi.Roth",
+    "lineCount": 1401,
+    "axiomCount": 0,
+    "theoremCount": 42,
+    "definitionCount": 6,
+    "path": "Proofs/RothTheorem.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "sec-roth-apfree",
+      "title": "Part I: AP-Free Set Definitions",
+      "startLine": 21,
+      "endLine": 62,
+      "summary": "Defines `APFree A` (no nontrivial 3-AP in A). Proves `apFree_empty`, `apFree_singleton`, `apFree_subset`. Cardinality bounds: `card_le_nat` (|A| ≤ N) via `Finset.card_le_univ + ZMod.card`.",
+      "mathContext": "$A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ is AP-free if $\\nexists a, d$ with $d \\ne 0$ and $\\{a, a+d, a+2d\\} \\subseteq A$."
+    },
+    {
+      "id": "sec-roth-counting",
+      "title": "Part II: AP Counting via tripleCount",
+      "startLine": 63,
+      "endLine": 90,
+      "summary": "Defines `tripleCount A` = #{(a,d) : d≠0, a∈A, a+d∈A, a+2d∈A} as a Finset filter. Proves `apFree_iff_tripleCount_zero`: A is AP-free iff tripleCount = 0.",
+      "mathContext": "$\\text{tripleCount}(A) = 0 \\iff A \\text{ is AP-free}$."
+    },
+    {
+      "id": "sec-roth-fourier",
+      "title": "Part III: Fourier Analysis on Z/NZ",
+      "startLine": 91,
+      "endLine": 398,
+      "summary": "Defines `fourierCoeff A r = Σ_{x∈A} exp(2πi val(rx)/N)`. Develops character ψ with psi_add, psi_zero, psi_ne_one, psi_norm, conj_psi. Proves char_orthogonality (shift argument), parseval_on_zmod (Σ‖Â(r)‖² = |A|·N), and triple_count_fourier (AP count identity).",
+      "mathContext": "$\\hat{A}(r) = \\sum_{x \\in A} \\psi(rx)$ where $\\psi(x) = e^{2\\pi i \\cdot \\mathrm{val}(x)/N}$. Parseval: $\\sum_r |\\hat{A}(r)|^2 = |A| \\cdot N$."
+    },
+    {
+      "id": "sec-roth-large-coeff",
+      "title": "Part IV: Large Fourier Coefficient from AP-Freeness",
+      "startLine": 529,
+      "endLine": 817,
+      "summary": "Proves `fourier_large_coefficient`: if A is AP-free with density δ, then ∃ r≠0 with ‖Â(r)‖ ≥ δ²N/2. Two cases: δ²N < 2 (Parseval pigeonhole gives max ≥ 1); δ²N ≥ 2 (Fourier counting identity + AM-GM + kernel of ×2 has ≤1 nonzero element).",
+      "mathContext": "Key: AP-free $\\implies \\text{tripleCount} = 0 \\implies N^{-1} \\sum_r \\hat{A}(r)^2 \\overline{\\hat{A}(2r)} = |A| \\implies$ some $r \\ne 0$ has large $|\\hat{A}(r)|$."
+    },
+    {
+      "id": "sec-roth-increment",
+      "title": "Part V: Density Increment Lemma",
+      "startLine": 818,
+      "endLine": 1330,
+      "summary": "Defines `cosetRestrict A g j` (restriction to j-th coset in ZMod(N/g)). Proves `apFree_coset_restrict` (AP-free preserved). Main result: `density_increment_lemma` — if A is AP-free with density δ, some coset of size N/g has density ≥ δ + δ²/4.",
+      "mathContext": "Fourier decomposition over cosets gives $\\hat{A}(r) = \\sum_j (f_j - m) \\psi(rj)$. Large $|\\hat{A}(r)|$ implies max coset density $\\geq \\delta + \\delta^2/4$."
+    },
+    {
+      "id": "sec-roth-main",
+      "title": "Part VI: Main Theorem",
+      "startLine": 1330,
+      "endLine": 1401,
+      "summary": "Proves `roth_density_bound`: for all δ > 0, ∃ N₀ such that every subset of ZMod N with density ≥ δ contains a 3-AP. Maps A to ℕ via ZMod.val, uses apFree_imp_threeAPFree_val, and invokes Mathlib's `roth_3ap_theorem_nat`.",
+      "mathContext": "$\\forall \\delta > 0, \\exists N_0, \\forall N \\geq N_0, \\forall A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ with $|A| \\geq \\delta N$: $A$ has a 3-AP."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified formalization (0 sorries, 0 axioms) of Roth's theorem and its key Fourier-analytic components. The 42-theorem file develops complete machinery: character theory, Parseval, AP counting, large Fourier coefficient (the key standalone lemma), and density increment. The main theorem wraps via Mathlib's `roth_3ap_theorem_nat`.",
+    "implications": "The independently verified `fourier_large_coefficient` theorem provides a formalized version of the core analytic step that underlies quantitative improvements to Roth's theorem (Bourgain, Bloom-Sisask). The density increment infrastructure could be extended to prove better bounds.",
+    "openQuestions": [
+      "Formalize Bourgain's quantitative bound r₃(N) = O(N/(log log N)^{1/2})",
+      "Formalize the Bloom-Sisask bound r₃(N) = O(N/log^{1+c} N)",
+      "Prove Szemerédi's theorem (k=4 case) using the regularity lemma approach"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds a complete gallery entry for `RothTheorem.lean` — the 1401-line Fourier-analytic formalization of Roth's 1953 theorem.

- **meta.json**: Full metadata — 42 theorems, 6 definitions, 0 sorries, 0 axioms, `status: verified`, `badge: original`. Six sections covering AP-Free basics, AP counting, Fourier analysis on ZMod N, large Fourier coefficient, density increment, and the main theorem.
- **annotations.json**: 6 annotations covering the key definitions and theorems: `APFree`, `fourierCoeff`, `parseval_on_zmod` (critical), `fourier_large_coefficient` (critical), `density_increment_lemma`, and `roth_density_bound`.
- **index.ts**: Standard gallery integration module.

The key standalone result is `fourier_large_coefficient`: AP-free sets of density δ in ZMod N have a Fourier coefficient ≥ δ²N/2 at some nonzero frequency. This is fully independently verified (Parts I–V); Part VI defers the final density-increment iteration to Mathlib's `roth_3ap_theorem_nat`.

Labels: research