### PR TITLE
research(e-transcendental-oq-02): extend decimal digit proofs to 9 digits (2.718281828...)

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -167,6 +167,37 @@ theorem e_floor_1000000 : ⌊(1000000 : ℝ) * Real.exp 1⌋ = 2718281 := by
 theorem e_digit6 : (⌊(1000000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 1 := by
   rw [e_floor_1000000]; decide
 
+/-- ⌊10000000 · e⌋ = 27182818, so the seventh decimal digit of e is 8. -/
+theorem e_floor_10000000 : ⌊(10000000 : ℝ) * Real.exp 1⌋ = 27182818 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The seventh decimal digit of e is 8. -/
+theorem e_digit7 : (⌊(10000000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 8 := by
+  rw [e_floor_10000000]; decide
+
+/-- ⌊100000000 · e⌋ = 271828182, so the eighth decimal digit of e is 2. -/
+theorem e_floor_100000000 : ⌊(100000000 : ℝ) * Real.exp 1⌋ = 271828182 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The eighth decimal digit of e is 2. -/
+theorem e_digit8 : (⌊(100000000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 2 := by
+  rw [e_floor_100000000]; decide
+
+/-- ⌊1000000000 · e⌋ = 2718281828, so the ninth decimal digit of e is 8.
+    This saturates the Mathlib lower bound exp_one_gt_d9 : 2.718281828 < e. -/
+theorem e_floor_1000000000 : ⌊(1000000000 : ℝ) * Real.exp 1⌋ = 2718281828 := by
+  apply Int.floor_eq_iff.mpr
+  exact ⟨by push_cast; linarith [Real.exp_one_gt_d9],
+         by push_cast; linarith [Real.exp_one_lt_d9]⟩
+
+/-- The ninth decimal digit of e is 8. -/
+theorem e_digit9 : (⌊(1000000000 : ℝ) * Real.exp 1⌋ : ℤ) % 10 = 8 := by
+  rw [e_floor_1000000000]; decide
+
 -- ============================================================
 -- PART IV: NORMAL IMPLIES IRRATIONAL
 -- ============================================================

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -55,8 +55,8 @@
       "Definition IsNormalInBase: rigorous digit-frequency definition — every k-string appears with frequency 1/bᵏ in the Tendsto sense",
       "Definition IsAbsolutelyNormal: normal in every base b ≥ 2",
       "Theorem e_floor: ⌊e⌋ = 2 (proved from Mathlib 9-digit bounds via Int.floor_eq_iff)",
-      "Theorems e_floor_10 through e_floor_1000000: ⌊10ⁿ·e⌋ for n=1..6, giving digits 7,1,8,2,8,1 (all proved by linarith from exp_one bounds + Int.floor_eq_iff)",
-      "Theorems e_digit1..e_digit6: the first 6 decimal digits of e = 2.718281... proved machine-checkably",
+      "Theorems e_floor_10 through e_floor_1000000000: ⌊10ⁿ·e⌋ for n=1..9, giving digits 7,1,8,2,8,1,8,2,8 (all proved by linarith from exp_one bounds + Int.floor_eq_iff)",
+      "Theorems e_digit1..e_digit9: the first 9 decimal digits of e = 2.718281828... proved machine-checkably (saturating the Mathlib lower bound exp_one_gt_d9)",
       "Theorem e_normal_implies_uniform_decimal_digits: IsNormalInBase 10 e → each digit d appears with frequency 1/10 (proved from definition using filter and norm_num)",
       "Axiom rational_digits_eventually_periodic: rationals have eventually periodic base-b expansions (pigeonhole, period divides φ(q))",
       "Axiom periodic_has_missing_ktuple: periodic sequences with period T have missing k-tuples when bᵏ > T (orbit cardinality argument)",
@@ -65,19 +65,19 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 4,
-    "lineCount": 235,
-    "assumptions": "4 axioms: (1) rational_digits_eventually_periodic — rationals have eventually periodic base-b digit expansions (pigeonhole principle, period T | φ(q)); (2) periodic_has_missing_ktuple — a T-periodic sequence on Fin b has at most T distinct k-tuples, so some k-tuple is absent when bᵏ > T; (3) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (uses axioms 1-2 + Tendsto formalism); (4) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026).",
+    "lineCount": 266,
+    "assumptions": "4 axioms: (1) rational_digits_eventually_periodic — rationals have eventually periodic base-b digit expansions (pigeonhole principle, period T | φ(q)); (2) periodic_has_missing_ktuple — a T-periodic sequence on Fin b has at most T distinct k-tuples, so some k-tuple is absent when bᵏ > T; (3) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (uses axioms 1-2 + Tendsto formalism); (4) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026). 27 theorems including first 9 decimal digits of e proved from exp_one bounds.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "In 1909, Émile Borel introduced the concept of a **normal number** and proved that almost every real number (in the sense of Lebesgue measure) is absolutely normal. His theorem is a remarkable fact: though normality is the 'generic' property, proving any specific constant is normal has proved extraordinarily difficult.\n\nFor Euler's constant e = 2.71828182845904523536..., we know:\n- e is irrational (Euler, 1737) — proved via continued fractions and factorial series\n- e is transcendental (Hermite, 1873) — not a root of any polynomial with integer coefficients\n- e has a regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, 1, 1, 8, ...] with a transparent pattern\n- The first 5 × 10¹³ decimal digits of e have been computed; statistical tests detect no anomalies\n\nYet despite all this, we cannot prove e is normal in base 10, base 2, or ANY base. Indeed, no specific real number has ever been proved normal. Borel's theorem proves normality is generic without identifying a single example.\n\nThe irrationality measure of e is exactly 2 (the minimum possible for any irrational) — see e-transcendental-oq-03. This excellent rational approximability property comes from the predictable continued fraction, but paradoxically does not help prove normality.",
-    "problemStatement": "**Open Question (e-transcendental-oq-02)**: Is Euler's number e absolutely normal?\n\nA real number x is **normal in base b** if for every k ≥ 1 and every string s ∈ {0,...,b-1}ᵏ:\n  lim_{N→∞} |{n < N : digits n, n+1, ..., n+k-1 of x in base b equal s}| / N = 1/bᵏ\n\nA number is **absolutely normal** if it is normal in every base b ≥ 2.\n\n**What IS known** (proved in this entry):\n- e is irrational ✓ (Euler, 1737)\n- e is transcendental ✓ (Hermite, 1873)\n- First 6 decimal digits of e: 2.718281... ✓ (proved from Mathlib's exp bounds)\n- Normal numbers must be irrational ✓ (necessary condition, axiomatized proof sketch)\n- Almost all reals are normal ✓ (Borel 1909 — not formalized here)\n\n**Open** (unknown as of 2026):\n- Is e normal in base 10? (?)\n- Is e normal in base 2? (?)\n- Is e absolutely normal? (? — axiomatized here)\n- Is ANY specific constant normal? (? — none proved ever)",
+    "problemStatement": "**Open Question (e-transcendental-oq-02)**: Is Euler's number e absolutely normal?\n\nA real number x is **normal in base b** if for every k ≥ 1 and every string s ∈ {0,...,b-1}ᵏ:\n  lim_{N→∞} |{n < N : digits n, n+1, ..., n+k-1 of x in base b equal s}| / N = 1/bᵏ\n\nA number is **absolutely normal** if it is normal in every base b ≥ 2.\n\n**What IS known** (proved in this entry):\n- e is irrational ✓ (Euler, 1737)\n- e is transcendental ✓ (Hermite, 1873)\n- First 9 decimal digits of e: 2.718281828... ✓ (proved from Mathlib's exp bounds, saturating exp_one_gt_d9)\n- Normal numbers must be irrational ✓ (necessary condition, axiomatized proof sketch)\n- Almost all reals are normal ✓ (Borel 1909 — not formalized here)\n\n**Open** (unknown as of 2026):\n- Is e normal in base 10? (?)\n- Is e normal in base 2? (?)\n- Is e absolutely normal? (? — axiomatized here)\n- Is ANY specific constant normal? (? — none proved ever)",
     "text": "Is Euler's number e = 2.71828... normal in every base? A number is normal if every finite digit string appears with the expected limiting frequency. Despite extensive computation (5 × 10¹³ decimal digits with no anomalies), no proof of normality for e — or any other specific constant — exists in any base.",
-    "proofStrategy": "This entry formalizes the known framework and open status:\n\n**1. Rigorous definitions** (fully proved):\nWe define `nthDigit b n x = ⌊bⁿ·x⌋ % b` (the n-th base-b digit, 0-indexed), `IsNormalInBase b x` (digit frequency definition using Tendsto), and `IsAbsolutelyNormal x`.\n\n**2. Known facts about e** (proved from Mathlib's 9-digit bounds):\nUsing `Real.exp_one_gt_d9 : 2.718281828 < e` and `Real.exp_one_lt_d9 : e < 2.7182818286`, we prove ⌊10ⁿ·e⌋ for n = 0,...,6, extracting the first 6 decimal digits: **2.718281...**\n\n**3. Normal implies irrational** (axiomatized):\nA normal number must be irrational: if x = p/q is rational, its base-b expansion has period T ≤ q. For large k with bᵏ > T, some k-string never appears, contradicting normality. This is a known theorem but its Lean formalization requires connecting ℤ-valued digit functions to Fin b sequences in the Tendsto setting — axiomatized with a complete proof sketch.\n\n**4. The open question** (axiomatized):\nThe main conjecture `e_absolutely_normal : IsAbsolutelyNormal (Real.exp 1)` is axiomatized, reflecting that this is a genuine open problem (2026).",
+    "proofStrategy": "This entry formalizes the known framework and open status:\n\n**1. Rigorous definitions** (fully proved):\nWe define `nthDigit b n x = ⌊bⁿ·x⌋ % b` (the n-th base-b digit, 0-indexed), `IsNormalInBase b x` (digit frequency definition using Tendsto), and `IsAbsolutelyNormal x`.\n\n**2. Known facts about e** (proved from Mathlib's 9-digit bounds):\nUsing `Real.exp_one_gt_d9 : 2.718281828 < e` and `Real.exp_one_lt_d9 : e < 2.7182818286`, we prove ⌊10ⁿ·e⌋ for n = 1,...,9, extracting the first 9 decimal digits: **2.718281828...** The 9th digit saturates the lower bound name.\n\n**3. Normal implies irrational** (axiomatized):\nA normal number must be irrational: if x = p/q is rational, its base-b expansion has period T ≤ q. For large k with bᵏ > T, some k-string never appears, contradicting normality. This is a known theorem but its Lean formalization requires connecting ℤ-valued digit functions to Fin b sequences in the Tendsto setting — axiomatized with a complete proof sketch.\n\n**4. The open question** (axiomatized):\nThe main conjecture `e_absolutely_normal : IsAbsolutelyNormal (Real.exp 1)` is axiomatized, reflecting that this is a genuine open problem (2026).",
     "keyInsights": [
       "Normal numbers are defined by limiting frequencies, not by any finite computation — checking trillions of digits cannot prove normality",
       "Borel's 1909 theorem: almost all reals are absolutely normal, yet no specific constant has ever been proved normal in any base",
-      "The first 6 decimal digits 2.718281... are proved machine-checkably from Mathlib's tight bounds exp_one_gt_d9 and exp_one_lt_d9",
+      "The first 9 decimal digits 2.718281828... are proved machine-checkably from Mathlib's tight bounds exp_one_gt_d9 and exp_one_lt_d9, saturating the lower bound at digit 9",
       "Normality implies irrationality: if x = p/q, its base-b expansion is eventually periodic with period T | φ(q). For k with bᵏ > T, some k-string never appears — contradicting normality",
       "e's regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, ...] shows excellent rational approximability (irrationality measure exactly 2), but this structural regularity has not helped prove normality",
       "The transcendence of e does not imply normality — transcendental Liouville numbers are far from normal",
@@ -112,35 +112,35 @@
       "startLine": 80,
       "endLine": 104,
       "summary": "e is irrational (from ETranscendental), transcendental (from ETranscendental), lies in (2.718281828, 2.7182818286) from Mathlib bounds, and between 2 and 3.",
-      "mathContext": "$e > 2.718281828$ (`exp_one_gt_d9`) and $e < 2.7182818286$ (`exp_one_lt_d9`). These 9-digit Mathlib bounds suffice to pin down the first 6 decimal digits."
+      "mathContext": "$e > 2.718281828$ (`exp_one_gt_d9`) and $e < 2.7182818286$ (`exp_one_lt_d9`). These 9-digit Mathlib bounds pin down all 9 decimal digits of e = 2.718281828..."
     },
     {
       "id": "digit-lemmas",
-      "title": "Decimal Digits 1–6 of e",
+      "title": "Decimal Digits 1–9 of e",
       "startLine": 106,
-      "endLine": 170,
-      "summary": "Machine-checked proofs that e = 2.718281...: ⌊10ⁿ·e⌋ computed for n = 1..6, digits 7,1,8,2,8,1 extracted via floor arithmetic. All proved from exp_one_gt_d9 + exp_one_lt_d9 + Int.floor_eq_iff.",
-      "mathContext": "Pattern: $\\lfloor 10^n \\cdot e \\rfloor = \\lfloor 10^n \\cdot 2.718281...\\rfloor$ pinned between $10^n \\cdot 2.718281828$ and $10^n \\cdot 2.7182818286$. For $n=3$: $2718 < 10^3 e < 2718.2819$, so $\\lfloor 1000e \\rfloor = 2718$ and digit $= 8$."
+      "endLine": 200,
+      "summary": "Machine-checked proofs that e = 2.718281828...: ⌊10ⁿ·e⌋ computed for n = 1..9, digits 7,1,8,2,8,1,8,2,8 extracted via floor arithmetic. All proved from exp_one_gt_d9 + exp_one_lt_d9 + Int.floor_eq_iff. The 9th digit saturates the Mathlib lower bound 2.718281828.",
+      "mathContext": "Pattern: $\\lfloor 10^n \\cdot e \\rfloor$ pinned between $10^n \\cdot 2.718281828$ and $10^n \\cdot 2.7182818286$. For $n=9$: $2718281828 < 10^9 e < 2718281828.6$, so $\\lfloor 10^9 e \\rfloor = 2718281828$ and digit $= 8$."
     },
     {
       "id": "normal-irrational",
       "title": "Normal Implies Irrational (Axiomatized)",
-      "startLine": 172,
-      "endLine": 199,
+      "startLine": 201,
+      "endLine": 230,
       "summary": "Three axioms formalizing the proof that normality implies irrationality: (1) rationals have eventually periodic digit expansions, (2) T-periodic sequences have missing k-tuples when bᵏ > T, (3) the full theorem. Proof sketches provided in docstrings.",
       "mathContext": "If $x = p/q \\in \\mathbb{Q}$, the sequence $n \\mapsto \\lfloor b^n x \\rfloor \\bmod b$ is eventually periodic with period $T \\mid \\varphi(q) \\leq q$. For $k$ with $b^k > T$, the orbit has $\\leq T < b^k$ distinct $k$-tuples, so some string $s_0$ never appears after position $N_0$. Its density is $0 \\neq b^{-k}$."
     },
     {
       "id": "open-question",
       "title": "The Open Question: e is Absolutely Normal",
-      "startLine": 200,
-      "endLine": 235,
+      "startLine": 231,
+      "endLine": 266,
       "summary": "Axiom e_absolutely_normal (the main open conjecture). Consequences: e is normal in base 10, in base 2. Theorem: normality implies uniform decimal digit distribution (each digit 0–9 appears with frequency 1/10).",
       "mathContext": "**Open conjecture** (axiomatized): $e$ is absolutely normal — normal in every base $b \\geq 2$. Computational check: first $5 \\times 10^{13}$ decimal digits pass $\\chi^2$ and serial correlation tests. No proof exists for any specific constant."
     }
   ],
   "conclusion": {
-    "summary": "This entry formalizes the open question of whether e is a normal number. The definitions (nthDigit, IsNormalInBase, IsAbsolutelyNormal) are fully proved. The first 6 decimal digits of e (= 2.718281...) are machine-verified from Mathlib's tight exp bounds. The main conjecture e_absolutely_normal is axiomatized, reflecting genuine open status as of 2026.",
+    "summary": "This entry formalizes the open question of whether e is a normal number. The definitions (nthDigit, IsNormalInBase, IsAbsolutelyNormal) are fully proved. The first 9 decimal digits of e (= 2.718281828...) are machine-verified from Mathlib's tight exp bounds, saturating the exp_one_gt_d9 lower bound. The main conjecture e_absolutely_normal is axiomatized, reflecting genuine open status as of 2026.",
     "implications": "**Theoretical significance**: Proving e is normal in even one base would be a landmark result in analytic number theory. No specific real number has ever been proved normal — Borel's theorem guarantees normality 'almost everywhere' but provides no examples.\n\n**Connection to continued fractions**: e's regular CF [2; 1, 2, 1, 1, 4, 1, 1, 6, ...] (partial quotients growing linearly) is a distinctive structural feature absent from random numbers. Understanding whether this structure influences digit distribution is a key open question.\n\n**Computational evidence**: The distribution of digits in the first 5×10¹³ decimals matches the uniform distribution with no statistically significant deviations. But computational evidence can never constitute proof — finitely many digits cannot demonstrate asymptotic frequency.\n\n**Related open questions**: The normality of π, √2, log 2, and other classical constants is similarly open. Even weaker questions (Are all digits 0–9 infinitely often in e's decimal expansion? Is any specific digit eventually missing?) remain unresolved.",
     "openQuestions": [
       "Is e normal in base 10?",
@@ -168,9 +168,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 235,
+    "lineCount": 266,
     "axiomCount": 4,
-    "theoremCount": 21,
+    "theoremCount": 27,
     "definitionCount": 3,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- Adds theorems `e_floor_10000000`, `e_digit7` (digit = 8), `e_floor_100000000`, `e_digit8` (digit = 2), `e_floor_1000000000`, `e_digit9` (digit = 8) to `ETranscendentalOQ02.lean`
- Each proof uses the same `Int.floor_eq_iff.mpr` + `linarith [Real.exp_one_gt_d9/lt_d9]` + `decide` pattern as the existing 6 digit lemmas
- The 9th digit saturates the Mathlib lower bound `exp_one_gt_d9 : 2.718281828 < e` — we can prove exactly 9 decimal digits from these bounds
- Updates `meta.json`: lineCount 235→266, theoremCount 21→27, section line ranges, narrative updated to mention 2.718281828...

## Mathematical Content

The digits proved:
- e = **2**.718281828...
- Digit 1: **7** (proved e_digit1, existing)
- Digit 2: **1** (proved e_digit2, existing)
- Digit 3: **8** (proved e_digit3, existing)
- Digit 4: **2** (proved e_digit4, existing)
- Digit 5: **8** (proved e_digit5, existing)
- Digit 6: **1** (proved e_digit6, existing)
- Digit 7: **8** (proved e_digit7, new)
- Digit 8: **2** (proved e_digit8, new)
- Digit 9: **8** (proved e_digit9, new)

For digit 9: `2718281828 < 10⁹·e < 2718281828.6` (from 9-digit bounds), so `⌊10⁹·e⌋ = 2718281828` and the digit is 8.

## Test plan

- [ ] All proofs use patterns already verified in CI (linarith from exp bounds + decide)
- [ ] meta.json counts verified: 27 theorems (grep), 266 lines (wc -l)
- [ ] Gallery build: `pnpm build` verifies metadata consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)