### PR TITLE
fix(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01): sync leanFile sorries 1→0, lineCount 452→952

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -5,12 +5,12 @@
   "description": "Advances the sigma-finite Lp Riesz representation from 3 sorries to 1 by proving Step C (density extension, Session 1) and Step B (Lp truncation convergence via Vitali, Session 2). Only localization_existence (Step A, ~150 lines of Lp restriction map infrastructure) remains as a sorry.",
   "leanFile": {
     "namespace": "RieszSigmaFiniteComplete",
-    "lineCount": 452,
+    "lineCount": 952,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "meta": {
     "status": "formalized",


### PR DESCRIPTION
## Fix

Syncs `leanFile.sorries` and `leanFile.lineCount` in the gallery metadata after PR #15581 eliminated all sorries from the Lean file without updating the JSON.

## Evidence

**Lean file**: `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`

After stripping comments, the file contains **0 proof-level sorry tactics** (mentions of "sorry" in the file appear only in comments describing the historical proof steps and one theorem named `sorry_diagnosis_resolved`).

**Before** (meta.json):
- `leanFile.sorries: 1`
- `leanFile.lineCount: 452`

**After** (meta.json):
- `leanFile.sorries: 0`
- `leanFile.lineCount: 952`

**Root cause**: PR #15581 (`feat(cs-localization): sigma-finite Riesz — all sorries eliminated`) modified only the Lean file, not the gallery meta.json. The file grew from ~452 to 952 lines as the proof was completed.

**Note**: `status` remains unchanged (the Incomplete01 suffix indicates this is a research helper file; status tracking for the main proof belongs to the parent entry).

---
Automated fix by lean-mechanic agent.