### PR TITLE
fix(cauchy-schwarz-incomplete-01): sync meta — sorry 1→0, lineCount 452→952

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -2,15 +2,15 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures (Complete)",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
-  "description": "Advances the sigma-finite Lp Riesz representation from 3 sorries to 1 by proving Step C (density extension, Session 1) and Step B (Lp truncation convergence via Vitali, Session 2). Only localization_existence (Step A, ~150 lines of Lp restriction map infrastructure) remains as a sorry.",
+  "description": "Sigma-finite Lp Riesz representation theorem fully formalized in Lean 4: all three steps (A localization, B Lp truncation convergence, C density extension) are proved with 0 sorries in this file. Step A (localization_existence, ~600 lines) was completed in PR #15581 via the Hölder extremizer construction; Step B uses Vitali's convergence theorem; Step C uses Lp.induction.",
   "leanFile": {
     "namespace": "RieszSigmaFiniteComplete",
-    "lineCount": 452,
+    "lineCount": 952,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "meta": {
     "status": "formalized",
@@ -24,10 +24,10 @@
       "density-argument"
     ],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 452,
-    "assumptions": "1 HARD sorry remaining (down from 3): localization_existence (~150 lines, Lp restriction map infrastructure). Step C (density extension) and Step B (lp_truncation_tendsto_zero via Vitali) are both fully proved.",
+    "lineCount": 952,
+    "assumptions": "All three sorries eliminated: Step A (localization_existence) was proved in PR #15581 via the Hölder extremizer construction (g_seq truncations + MCT for hgnorm, ae_eq_of_forall_setIntegral_eq_of_sigmaFinite for indicator agreement). Steps B (lp_truncation_tendsto_zero via Vitali) and C (integral_representation_sf via Lp.induction) were proved earlier. The proof depends on lemmas in the parent file Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean — assess parent's status independently.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,


### PR DESCRIPTION
## Fix

Update `src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json` to match the actual Lean source after PR #15581 ("feat(cs-localization): sigma-finite Riesz — all sorries eliminated").

## Evidence

**Before** (origin/main meta.json):
- `meta.sorries: 1`, `leanFile.sorries: 1`
- `meta.lineCount: 452`, `leanFile.lineCount: 452`
- `assumptions`: "1 HARD sorry remaining (down from 3)…"

**After** (verified against `git show origin/main:proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`):
- Actual sorries (after stripping comments): **0**
- Actual lines: **952**
- All five raw `sorry` token occurrences in the file are inside comments (file header, section dividers).
- Last commit on the file: `2a7d07e4cbc feat(cs-localization): sigma-finite Riesz — all sorries eliminated (#15581)`

## Scope

- Sorry count, line count, description, and assumptions text are updated.
- `meta.status` and `meta.badge` are left as `"formalized"` because the proof depends on lemmas in the parent `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` which still has 3 sorries. Promoting to `"verified"` is a judgment call best made after the parent's status is resolved.

Closes the `sorry mismatch: claims 1, actual 0` flagged by `npx tsx scripts/auditor/find-targets.ts`.

---
Automated fix by lean-mechanic agent.