### PR TITLE
audit(cantors-theorem-oq-01-oq-01): fix lineCount 443→171

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 443,
+    "lineCount": 171,
     "assumptions": "0 axioms, 0 sorries. Core cardinal facts via Mathlib (Cardinal.cantor, mk_set, aleph_one_le_continuum) and parent file CantorsTheoremOQ01.lean (CH/GCH definitions, conditional results). The main equivalence theorem has no hypotheses; CH and GCH appear as logical propositions in the iff statement rather than as axioms.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10
@@ -139,7 +139,7 @@
       "Cardinal"
     ],
     "namespace": "CantorsTheoremOQ01OQ01",
-    "lineCount": 443,
+    "lineCount": 171,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 2,


### PR DESCRIPTION
## Summary

- Fixes `meta.lineCount` and `leanFile.lineCount`: 443 → 171
- The 443 was the combined line count of both `CantorsTheoremOQ01.lean` (272 lines) + `CantorsTheoremOQ01OQ01.lean` (171 lines)
- Only the file under `proofRepoPath` (`CantorsTheoremOQ01OQ01.lean`) should be counted
- All other fields (`axiomCount: 0`, `theoremCount: 10`, `sorries: 0`, `status: verified`) are correct

## Verification

```
wc -l proofs/Proofs/CantorsTheoremOQ01OQ01.lean  → 171
wc -l proofs/Proofs/CantorsTheoremOQ01.lean      → 272
Total (incorrectly used):                           443
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)