### PR TITLE
audit(erdos-831): fix h(4)>=2 -> h(4)=1 in conclusion (stale claim)

### DIFF
--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -161,7 +161,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #831 asks for the asymptotics of h(n), where h(n) is the minimum number of distinct circumradii achievable by n points in general position. The answer is UNKNOWN. We know h(3) = 1, h(4) ≥ 2, and h(n) ≤ C(n,3), but the exact growth rate remains open.",
+    "summary": "Erdős Problem #831 asks for the asymptotics of h(n), where h(n) is the minimum number of distinct circumradii achievable by n points in general position. The answer is UNKNOWN. We know h(3) = 1, h(4) = 1, and h(n) ≤ C(n,3), but the exact growth rate remains open.",
     "implications": "**Theoretical Significance**: **Discrete Geometry Connections**\n\n1. **Incidence Geometry:** Related to point-circle incidence problems\n\n2. **Extremal Combinatorics:** Finding configurations that minimize diversity\n\n**3. Unit Distance Problem:** Similar questions about repeated distances (#506)\n\n4. **Orchard Problem:** Similar questions about collinear triples (#104)\n\n5. **Algebraic Geometry:** Connections to algebraic curves through points.",
     "openQuestions": [
       "What is the exact asymptotic growth rate of h(n)?",


### PR DESCRIPTION
## Problem

`src/data/proofs/erdos-831/meta.json` `conclusion.summary` claims:

> "We know h(3) = 1, h(4) >= 2, and h(n) <= C(n,3)"

but h(4) >= 2 was retracted in the Lean source as **false**.

`proofs/Proofs/Erdos831Problem.lean` lines 322-334 explicitly state:
- "Previously axiomatized as h(4) >= 2, but this is FALSE."
- Counterexample: equilateral triangle {A,B,C} + circumcenter D gives 4 points in general position with all 4 circumradii equal to 1/sqrt(3), so h(4) = 1.

The same meta.json's `originalContributions` field already records the correction ("h(4) = 1 (corrected): the claim h(4) >= 2 was false and removed from the Lean source") -- only `conclusion.summary` was still stale.

## Change

`conclusion.summary`: "h(4) >= 2" -> "h(4) = 1".

## lineCount

The original audit task also asked to bump `meta.lineCount` and `leanFile.lineCount` from 717 to 718. I verified against the actual file:

```
wc -l proofs/Proofs/Erdos831Problem.lean              # 717
git show origin/main:proofs/Proofs/Erdos831Problem.lean | wc -l   # 717
awk 'END{print NR}' proofs/Proofs/Erdos831Problem.lean # 717
```

The file ends with a single trailing `\n`, so 717 is correct. **No lineCount change is included** -- the existing values match reality.

## Test plan

- [x] `git diff origin/main` shows only one substantive line change in `conclusion.summary`
- [x] No other fields touched
- [x] Lean source confirms h(4) = 1 (lines 322-334)
- [x] `originalContributions` already aligned -- now `conclusion.summary` matches

[loom:auditor]

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>