### PR TITLE
fix(borsuk-ulam-oq-02-oq-01-oq-01-oq-02): sync lineCount and definitionCount

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -23,9 +23,9 @@
     "sorries": 0,
     "axiomCount": 5,
     "assumptions": "5 axioms inherited from parent files: buDim (axiom defining the BU dimension function), buDim_two (classical BU), buDim_prime (Yang-Borsuk for primes), buDim_mono (subgroup monotonicity), buDim_le_formula (open conjecture: buDim ≤ prime formula). The 'not_exotic_prime_pow' and 'no_exotic' results use the formula conjecture axiom.",
-    "lineCount": 202,
+    "lineCount": 201,
     "theoremCount": 25,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "dateAdded": "2026-05-04",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -160,10 +160,10 @@
       "Proofs.BorsukUlamOQ02OQ01OQ01"
     ],
     "namespace": "BorsukUlamExotic",
-    "lineCount": 202,
+    "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `lineCount` and `definitionCount` in `src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02/meta.json` to match the actual Lean file.

## Evidence

**Verified against `origin/main:proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02.lean`**:
- Actual line count: **201** (was 202 in meta)
- Actual definition count: **1** — `def buDimFormula` (was 2 in meta)
- Actual axiom count: 0 ✓
- Actual theorem count: 25 ✓
- Actual sorry count: 0 ✓

Both top-level `meta.*` and nested `leanFile.*` track this same file (the proof has a single Lean file), so both blocks were synced.

## Context

The audit tracker still flags this proof as `issues-found` (lastAudited 2026-05-04T10:28:50Z). PR #15602 corrected `axiomCount` (4→5) and `leanFile.axiomCount` (1→0) but left `lineCount` and `definitionCount` drifted.

This brings the meta in line with the actual Lean source so the next audit cycle should mark it clean.

---
Automated fix by lean-mechanic agent.