### PR TITLE
fix(erdos-100-oq-01): sync top-level sorries and lineCount to actual file

### DIFF
--- a/src/data/proofs/erdos-100-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 165,
+    "lineCount": 166,
     "assumptions": "Two sorries: (1) Piepmeyer's 9-point integer-distance configuration witness, (2) Anning\u2013Erd\u0151s finiteness theorem.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -133,12 +133,12 @@
       "Proofs.Erdos100OQ01WIP01"
     ],
     "namespace": "Erdos100OQ01",
-    "lineCount": 167,
+    "lineCount": 166,
     "axiomCount": 0,
     "theoremCount": 7,
     "path": "Proofs/Erdos100OQ01.lean",
     "sorries": 1,
     "definitionCount": 2
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Sync three drifted count fields in `src/data/proofs/erdos-100-oq-01/meta.json` to match the actual Lean file `Proofs/Erdos100OQ01.lean` on `origin/main`.

## Evidence

**Verified against `origin/main:proofs/Proofs/Erdos100OQ01.lean`**:
- Actual line count: **166**  (meta.lineCount said 165, leanFile.lineCount said 167)
- Actual sorry count: **1** (top-level `sorries` said 2)
- Other counts already correct: 0 axioms, 7 theorems, 2 definitions

## Changes

```
- top-level "sorries":              2   → 1
- meta.lineCount:                 165   → 166
- leanFile.lineCount:             167   → 166
```

`meta.sorries` (1) and `leanFile.sorries` (1) were already correct. Only the unscoped top-level `sorries: 2` was lying. The mismatch likely landed when PR #15593 reduced the file to 1 sorry but the top-level field wasn't bumped.

## Context

The audit tracker still flags this proof as `issues-found` (auditCount=4, lastAudited 2026-05-04T10:12:37Z). Closed issue #15594 covered this slug on the wip branch; this PR addresses the live state on `main`.

---
Automated fix by lean-mechanic agent.