### PR TITLE
audit(arithmetic-series-oq-02-oq-02-oq-01): fix lineCount 319→165

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Depends on ArithmeticSeriesOQ02OQ02 (parallel Vandermonde).",
-    "lineCount": 319,
+    "lineCount": 165,
     "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
@@ -106,7 +106,7 @@
   },
   "leanFile": {
     "namespace": "ArithmeticSeriesOQ02OQ02OQ01",
-    "lineCount": 319,
+    "lineCount": 165,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Summary

- Fixes `meta.lineCount` and `leanFile.lineCount`: 319 → 165
- The 319 was the combined line count of `ArithmeticSeriesOQ02OQ02.lean` (154 lines) + `ArithmeticSeriesOQ02OQ02OQ01.lean` (165 lines)
- Only the file under `proofRepoPath` should be counted

```
wc -l proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean  → 165
wc -l proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean      → 154
Total (incorrectly used):                               319
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)