### PR TITLE
fix(central-limit-theorem-oq-01-oq-01-oq-04): correct lineCount 303→357, theoremCount 18→15

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 2,
     "assumptions": "eigenvalue_ge_half (Hudson-Mason 1982): Re(eigenvalues of exponent matrix E) ≥ 1/2; meerschaert_scheffler (2001): domain of attraction ↔ matrix regular variation",
-    "lineCount": 303,
-    "theoremCount": 18,
+    "lineCount": 357,
+    "theoremCount": 15,
     "originalContributions": [
       "gaussian_operator_stable: N(0,Σ) is operator-stable — (φ_Σ(ξ/√n))^n = φ_Σ(ξ) proved via exp_neg_div_pow",
       "quadForm_scale_inv_sqrt: quadratic form scaling quadForm(ξ/√n) = (1/n)·quadForm(ξ)",
@@ -120,8 +120,8 @@
     "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean",
     "namespace": "OperatorStable",
     "axiomCount": 2,
-    "lineCount": 303,
-    "theoremCount": 18,
+    "lineCount": 357,
+    "theoremCount": 15,
     "definitionCount": 7,
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Syncs `lineCount` and `theoremCount` in the gallery metadata for `central-limit-theorem-oq-01-oq-01-oq-04` to match the actual Lean source.

## Evidence

**Lean file**: `proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean`

Verified against `git show origin/main:proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean`:

| Field | Before | After | Actual |
|-------|--------|-------|--------|
| `lineCount` (meta + leanFile) | 303 | 357 | 357 |
| `theoremCount` (meta + leanFile) | 18 | 15 | 15 |
| `definitionCount` | 7 | 7 (unchanged) | 7 ✓ |
| `axiomCount` | 2 | 2 (unchanged) | 2 ✓ |
| `sorries` | 0 | 0 (unchanged) | 0 ✓ |

**Root cause**: The meta.json was created with stale counts from an earlier draft of the file. The final version added ~54 lines (Part VII classical corollaries section + the full `meerschaert_scheffler` axiom statement). The `originalContributions` list correctly names 9 items but the actual `theorem`/`lemma` count including all helper lemmas is 15 (not 18 as previously claimed).

---
Automated fix by lean-mechanic agent.