### PR TITLE
research(inverse-galois-a5): add gallery entry — A₅ Galois realization, first non-solvable (65 theorems, 1 axiom)

### DIFF
--- a/src/data/proofs/inverse-galois-a5/annotations.json
+++ b/src/data/proofs/inverse-galois-a5/annotations.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "inverse-galois-a5-polynomial",
+    "proofId": "inverse-galois-a5",
+    "type": "definition",
+    "range": {
+      "startLine": 85,
+      "endLine": 200
+    },
+    "title": "The Polynomial q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5",
+    "content": "`q : ℚ[X]` is defined explicitly with coefficients. Four key properties are proved:\n\n- **`q_irreducible`**: Proved by Eisenstein's criterion at p=5. Non-leading coefficients are {-5, 25, -10, 10, -5} — all divisible by 5. The constant term -5 is not divisible by 25. Leading coefficient 1 is not divisible by 5. Therefore q is irreducible over ℚ.\n- **`q_natDegree = 5`**: Proved by `norm_num` / computation.\n- **`q_monic`**: Direct from definition (leading coefficient is 1).\n- **`q_separable`**: Follows from irreducibility (`Irreducible.separable`).\n- **`q_rootSet_card = 5`**: The splitting field has exactly 5 distinct roots, proved using Mathlib's `Polynomial.roots` API and separability.",
+    "significance": "key",
+    "mathContext": "Eisenstein's criterion: if $p$ is prime and $p \\mid a_0, \\ldots, a_{n-1}$ but $p^2 \\nmid a_0$ and $p \\nmid a_n$, then $\\sum a_i X^i$ is irreducible over $\\mathbb{Q}$. Here $p=5$, $a_0 = -5$, $a_5 = 1$.",
+    "relatedConcepts": [
+      "Eisenstein's criterion",
+      "Polynomial.Irreducible",
+      "splitting fields",
+      "degree-5 polynomials"
+    ],
+    "prerequisites": [
+      "polynomial arithmetic in Lean 4",
+      "Polynomial.Irreducible.eisenstein",
+      "Polynomial.Separable"
+    ]
+  },
+  {
+    "id": "inverse-galois-a5-order-bounds",
+    "proofId": "inverse-galois-a5",
+    "type": "theorem",
+    "range": {
+      "startLine": 207,
+      "endLine": 328
+    },
+    "title": "Galois Group Order: 5 | |Gal| and |Gal| | 120",
+    "content": "Two key divisibility facts establish bounds on |Gal(q/ℚ)|:\n\n**`five_dvd_gal_card`**: 5 | |Gal|. Since q is irreducible of degree 5, the extension q.SplittingField/ℚ has [q.SplittingField : ℚ] divisible by 5 (a root generates a degree-5 subextension). By Galois theory, 5 | |Gal|.\n\n**`gal_card_dvd_120`**: |Gal| | 120 = 5!. The Galois group acts faithfully on the 5 roots (root permutation action via `Polynomial.Gal.galActionHom`), embedding Gal into S₅ = Perm(Fin 5). Hence |Gal| | |S₅| = 5! = 120.\n\nStructural lemmas about S₅: `perm_fin5_order5_order3_not_commute` shows elements of orders 5 and 3 in S₅ don't commute (used to rule out cyclic subgroups of order 15), and `perm_fin5_no_order_15` shows S₅ has no element of order 15.",
+    "significance": "key",
+    "mathContext": "The divisors of 120 that are divisible by 5 are: 5, 10, 20, 30, 40, 60, 120. The discriminant argument reduces this to divisors of 60: 5, 10, 20, 60. The `three_dvd_gal_card` axiom forces 60.",
+    "relatedConcepts": [
+      "Galois group order",
+      "root permutation action",
+      "Cauchy's theorem",
+      "Polynomial.Gal.galActionHom"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "Fintype.card",
+      "Polynomial.Gal"
+    ]
+  },
+  {
+    "id": "inverse-galois-a5-vandermonde",
+    "proofId": "inverse-galois-a5",
+    "type": "theorem",
+    "range": {
+      "startLine": 1097,
+      "endLine": 1650
+    },
+    "title": "Vandermonde Discriminant: vandermondeProduct² = disc(q) = 32000²",
+    "content": "`vandermondeProduct` = Π_{i<j} (root_i - root_j) in q.SplittingField. The discriminant disc(q) = vandermondeProduct².\n\nThe proof proceeds through several stages:\n1. **`vandermondeProduct_ne_zero`**: The Vandermonde product is nonzero (since q is separable — distinct roots).\n2. **Sophie Germain identity** and polynomial arithmetic in q.SplittingField.\n3. **`ordered_root_diff_prod_eq_vandermonde_sq`**: The ordered product of differences equals vandermondeProduct².\n4. **`prod_eval_derivative_eq_resultant`**: The product of q'(αᵢ) over roots equals Res(q, q').\n5. **`resultant_eq_disc_q`**: Res(q, q') = disc(q) (standard formula).\n6. **`vandermondeProduct_sq_eq_proved`**: Combines all steps. disc(q) = 32000².\n\nConsequence: Since disc(q) is a perfect square in ℚ, every Galois automorphism σ satisfies σ(Δ) = Δ (where Δ = vandermondeProduct). The sign homomorphism σ ↦ sgn(σ) therefore maps every σ to +1, so Gal ≤ A₅.",
+    "significance": "critical",
+    "mathContext": "$\\Delta(q) = \\prod_{i < j}(\\alpha_i - \\alpha_j)^2 = \\text{Res}(q, q')$. Since $\\Delta(q) = 32000^2$ is a perfect square, $\\text{Gal}(q/\\mathbb{Q}) \\subseteq A_5$.",
+    "relatedConcepts": [
+      "polynomial discriminant",
+      "Vandermonde determinant",
+      "resultant formula",
+      "Sophie Germain identity"
+    ],
+    "prerequisites": [
+      "polynomial resultant",
+      "splitting field arithmetic",
+      "Polynomial.discriminant"
+    ]
+  },
+  {
+    "id": "inverse-galois-a5-axiom",
+    "proofId": "inverse-galois-a5",
+    "type": "definition",
+    "range": {
+      "startLine": 309,
+      "endLine": 327
+    },
+    "title": "Axiom: three_dvd_gal_card (Dedekind's Theorem)",
+    "content": "`three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` is the single remaining axiom, corresponding to Dedekind's theorem applied to the Frobenius element at p=7.\n\nSupporting evidence (verified by `decide` / `native_decide`):\n- q mod 7 factors as (X-5)(X-6)(irreducible cubic): `q_root_mod7_at_5`, `q_root_mod7_at_6`, `cubic_factor_no_roots_mod7`. The irreducible cubic factor implies Gal(q/ℚ) contains an element of order 3 (Frobenius at 7).\n- The resolvent sextic has no rational root (`resolvent_no_positive_root`, `resolvent_no_negative_root`, `resolvent_at_zero`). This rules out Gal being a subgroup of order 5, 10, or 20.\n\nDedekind's theorem itself requires formalizing algebraic number theory (prime decomposition in number fields, Frobenius elements) — not yet in Mathlib 4.26.0.",
+    "significance": "key",
+    "mathContext": "**Dedekind's theorem**: If $f \\in \\mathbb{Z}[X]$ and $f \\equiv \\prod g_i^{e_i} \\pmod{p}$ with $g_i$ distinct irreducible mod $p$ and $p \\nmid \\text{disc}(f)$, then $\\text{Gal}(f/\\mathbb{Q})$ (as a permutation group of roots) contains an element with cycle type $\\deg(g_1), \\ldots, \\deg(g_k)$.",
+    "relatedConcepts": [
+      "Dedekind's theorem",
+      "Frobenius element",
+      "resolvent polynomial",
+      "Galois group computation"
+    ],
+    "prerequisites": [
+      "algebraic number theory",
+      "prime decomposition in number fields",
+      "Frobenius elements"
+    ]
+  },
+  {
+    "id": "inverse-galois-a5-main",
+    "proofId": "inverse-galois-a5",
+    "type": "theorem",
+    "range": {
+      "startLine": 1966,
+      "endLine": 2037
+    },
+    "title": "q_gal_iso_a5: Gal(q/ℚ) ≅ A₅",
+    "content": "`q_gal_iso_a5 : Nonempty (q.Gal ≃* alternatingGroup (Fin 5))`.\n\nProof structure:\n1. Build the composite injection φ : Gal →* Perm(Fin 5) via `galActionHom` composed with `permEquiv` (conjugation by a `rootEquiv : rootSet ≃ Fin 5`).\n2. `hinj`: φ is injective (galActionHom is faithful, permEquiv is a MulEquiv).\n3. |φ(Gal)| = 60 (from `q_gal_card = 60`, proved using 5 | |Gal|, |Gal| | 60, and `three_dvd_gal_card`).\n4. φ(Gal) has index 2 in S₅ (since |S₅| = 120 = 2 × 60).\n5. By `Equiv.Perm.eq_alternatingGroup_of_index_eq_two`: φ(Gal) = alternatingGroup (Fin 5).\n6. MulEquiv: Gal ≃* φ(Gal) ≃* A₅.\n\nThis proves the Galois group is EXACTLY A₅ (not just a subgroup).",
+    "significance": "critical",
+    "mathContext": "$[S_5 : A_5] = 2$. Any subgroup of $S_5$ of index 2 is normal and equals the kernel of the sign homomorphism, which is $A_5$. Since $|\\text{Gal}| = 60 = |A_5|$ and $\\text{Gal} \\leq A_5$, we conclude $\\text{Gal} = A_5$.",
+    "relatedConcepts": [
+      "alternating group A₅",
+      "index-2 subgroup characterization",
+      "MulEquiv",
+      "Polynomial.Gal.galActionHom"
+    ],
+    "prerequisites": [
+      "q_gal_card = 60",
+      "Gal embeds into S₅",
+      "Equiv.Perm.eq_alternatingGroup_of_index_eq_two"
+    ]
+  },
+  {
+    "id": "inverse-galois-a5-nonsolvable",
+    "proofId": "inverse-galois-a5",
+    "type": "theorem",
+    "range": {
+      "startLine": 2038,
+      "endLine": 2060
+    },
+    "title": "gal_not_solvable: Non-Solvability of the Galois Group",
+    "content": "`gal_not_solvable : ¬IsSolvable q.Gal`.\n\nProof: Assume IsSolvable q.Gal. By `q_gal_iso_a5`, there exists e : q.Gal ≃* A₅. By `solvable_of_surjective`, IsSolvable A₅ follows from solvability of q.Gal and the surjection e. But `a5_not_solvable : ¬IsSolvable (alternatingGroup (Fin 5))` — A₅ is simple and non-abelian. Contradiction.\n\nThis result is significant: Shafarevich's theorem (1954) guarantees that all solvable groups are realizable as Galois groups over ℚ. A₅ lies outside this scope — its Galois realization required a different approach (the explicit polynomial method used here).",
+    "significance": "key",
+    "mathContext": "$A_5$ is the unique non-abelian simple group of order 60. It is not solvable (its derived series never reaches 1). This is the first non-solvable Galois group in the lean-genius gallery.",
+    "relatedConcepts": [
+      "solvable groups",
+      "Shafarevich's theorem",
+      "simple groups",
+      "IsSolvable"
+    ],
+    "prerequisites": [
+      "q_gal_iso_a5",
+      "a5_not_solvable",
+      "solvable_of_surjective"
+    ]
+  }
+]

--- a/src/data/proofs/inverse-galois-a5/index.ts
+++ b/src/data/proofs/inverse-galois-a5/index.ts
@@ -1,0 +1,30 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/InverseGaloisA5.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/inverse-galois-a5/meta.json
+++ b/src/data/proofs/inverse-galois-a5/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "inverse-galois-a5",
+  "title": "A₅ as a Galois Group over ℚ: The First Non-Solvable Realization",
+  "slug": "inverse-galois-a5",
+  "description": "Formalizes that the alternating group A₅ (order 60, the smallest non-solvable simple group) is realizable as a Galois group over ℚ. Uses the polynomial q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5, proven irreducible via Eisenstein at p=5, with Galois group identified as A₅ by: (1) the Vandermonde discriminant proof showing Gal ≤ A₅, and (2) a single axiom (three_dvd_gal_card, from Dedekind's theorem) to force |Gal| = 60. Demonstrates that the Inverse Galois Problem extends beyond the solvable case.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inverse_Galois_problem",
+    "date": "Classical result (Hilbert 1892 for S_n, A₅ folklore); formalized 2026",
+    "status": "axiomatized",
+    "tags": [
+      "galois-theory",
+      "inverse-galois-problem",
+      "alternating-group",
+      "polynomial-irreducibility",
+      "discriminant",
+      "non-solvable"
+    ],
+    "proofRepoPath": "Proofs/InverseGaloisA5.lean",
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "assumptions": "1 axiom: `three_dvd_gal_card` (3 ∣ |Gal(q/ℚ)|), representing Dedekind's theorem (cycle structure of Frobenius at primes forces divisibility) — not yet in Mathlib 4.26.0. This axiom is supported by two distinct computations: (1) q factors mod 7 as (linear)(linear)(irreducible cubic), implying a 3-cycle in the Galois group; (2) the resolvent sextic has no rational root, excluding order-15 and order-30 subgroups.",
+    "originalContributions": [
+      "q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5: Eisenstein irreducibility at p=5 (q_irreducible), degree, monicness, separability",
+      "q_rootSet_card: |roots of q in q.SplittingField| = 5 (proved via Mathlib's Polynomial.roots API)",
+      "five_dvd_gal_card: 5 | |Gal(q/ℚ)| (from irreducibility degree ≤ |Gal| and Cauchy)",
+      "gal_card_dvd_120: |Gal| | 120 = 5! (Gal embeds into S₅ via root permutation action)",
+      "no_subgroup_order_15, no_subgroup_order_30: S₅ has no subgroup of order 15 or 30 (proved by combining transitivity and odd-element structure)",
+      "Vandermonde discriminant chain (Parts VIII–XV): vandermondeProduct, Sophie Germain identity, resultant formula, and a 400-line proof that vandermondeProduct² = disc(q) = 32000²; hence Gal ≤ A₅",
+      "gal_card_dvd_60_of_all_even: |Gal| | 60 from the discriminant being a perfect square",
+      "q_gal_iso_a5: Gal(q/ℚ) ≅ A₅ using index-2 subgroup identification (Equiv.Perm.eq_alternatingGroup_of_index_eq_two)",
+      "a5_realizable_iso: A₅ is realizable as a Galois group over ℚ (main theorem)",
+      "gal_not_solvable: Gal(q/ℚ) is not solvable (transfers non-solvability through the isomorphism)"
+    ],
+    "dateAdded": "2026-05-04",
+    "lineCount": 2067,
+    "theoremCount": 65,
+    "definitionCount": 8,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Inverse Galois Problem (IGP) asks: for which finite groups G does there exist a Galois extension K/ℚ with Gal(K/ℚ) ≅ G? Hilbert (1892) proved S_n and A_n are realizable for all n using Hilbert's irreducibility theorem. Shafarevich (1954) proved every solvable group is realizable. Whether every finite group is realizable remains open.\n\nA₅ (order 60) is the smallest non-solvable simple group — the alternating group on 5 elements. It is the Galois group of many polynomials of degree 5 with non-square discriminant. The polynomial q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5 is a translate of p(x) = x⁵ + 20x + 16, a classical example. The key steps are: prove Gal ≤ A₅ via the perfect-square discriminant, then force |Gal| = 60 via divisibility constraints from Cauchy's theorem and the structure of subgroups of S₅.",
+    "problemStatement": "**Inverse Galois Problem for A₅**: There exists a Galois field extension K/ℚ such that Gal(K/ℚ) ≅ A₅ (the alternating group on 5 elements, of order 60).\n\nFormalized as: `∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K) (_ : IsGalois ℚ K), Nonempty (alternatingGroup (Fin 5) ≃* (K ≃ₐ[ℚ] K))`.",
+    "text": "A 2067-line formalization of the A₅ Inverse Galois theorem using the polynomial q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5. Parts I–IV establish the polynomial's properties (irreducible, degree 5, monic, separable). Parts V–VII bound |Gal|: 5 | |Gal| from Cauchy, |Gal| | 120 from root permutation action. Parts VIII–XV develop the Vandermonde discriminant argument showing Gal ≤ A₅. Parts XVI–XVII conclude Gal ≅ A₅ and prove non-solvability.",
+    "proofStrategy": "**Part I–IV (Polynomial q)**: q is defined as `x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5`. `q_irreducible`: Eisenstein at p=5 (all non-leading coefficients divisible by 5; constant term -5 not divisible by 25). `q_monic`, `q_natDegree = 5`, `q_separable` follow.\n\n**Part V–VII (Galois group order bounds)**: `q_rootSet_card = 5` (5 distinct roots in the splitting field). `five_dvd_gal_card`: |Gal| ≡ 0 (mod 5) from Cauchy (since |Gal| is divisible by 5 via the irreducibility degree bound). `gal_card_dvd_120`: Gal embeds into S₅ via the root permutation action, so |Gal| | 5! = 120.\n\n**Parts VIII–XV (Vandermonde discriminant)**: Defines `vandermondeProduct = Π_{i<j} (root_i - root_j)` in q.SplittingField. Proves the Sophie Germain identity. Shows `vandermondeProduct² = resultant(q, q') = disc(q)`. Computes `disc(q) = 32000²` (a perfect square). Therefore `galSign σ = +1` for all σ ∈ Gal, so Gal ≤ A₅.\n\n**Parts IX–XI (No small subgroups)**: S₅ has no subgroup of order 15 or 30. Combined with 5 | |Gal| and |Gal| | 60, plus `three_dvd_gal_card` (axiom): |Gal| = 60.\n\n**Part XVI (Isomorphism)**: `q_gal_iso_a5`: composing the root-action injection φ : Gal →* S₅ with the permCongr equivalence gives |φ(Gal)| = 60 = 120/2, so φ(Gal) has index 2 in S₅. By `Equiv.Perm.eq_alternatingGroup_of_index_eq_two`, φ(Gal) = A₅.\n\n**Part XVII (Non-solvability)**: `gal_not_solvable` transfers non-solvability through the isomorphism.",
+    "keyInsights": [
+      "**Eisenstein criterion for irreducibility**: The polynomial q = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5 satisfies Eisenstein at p=5. In Lean, `q_irreducible` is proved using `Polynomial.Irreducible.eisenstein_of_irreducible` (or equivalent), leveraging that non-leading coefficients are all divisible by 5 while the constant term is not divisible by 25.",
+      "**Vandermonde discriminant proof (Parts VIII–XV)**: The 400-line proof that vandermondeProduct² = disc(q) = 32000² is the core computational achievement. It uses the Sophie Germain identity, the resultant-discriminant formula, and careful polynomial arithmetic in q.SplittingField. This eliminates the discriminant axiom from earlier sessions.",
+      "**Index-2 subgroup characterization**: The Lean lemma `Equiv.Perm.eq_alternatingGroup_of_index_eq_two` states that the unique subgroup of index 2 in S₅ is A₅. This is the key algebraic fact that bridges |Gal| = 60 to Gal ≅ A₅, without needing to explicitly construct the isomorphism.",
+      "**Axiom evidence (Dedekind's theorem)**: `three_dvd_gal_card` (3 | |Gal|) is supported by two computations: (1) q ≡ (X-5)(X-6)(cubic) mod 7 implies a Frobenius element of order 3; (2) the resolvent sextic has no rational root, ruling out Gal ≤ subgroup of order dividing 20. Either would suffice to show 3 | 60; Dedekind's theorem is the standard proof but not yet in Mathlib.",
+      "**Non-solvability extends Shafarevich**: `gal_not_solvable` shows Gal(q) is not solvable. This is significant: Shafarevich's theorem (1954) guarantees realizations for all solvable groups, but A₅ (being simple and non-abelian) lies outside that scope. The A₅ realization is the first step into non-solvable territory."
+    ],
+    "prerequisites": [
+      "Galois theory and splitting fields",
+      "Polynomial discriminant and Vandermonde product",
+      "Alternating group A₅ and its simplicity",
+      "Eisenstein's criterion for irreducibility"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois",
+      "relationship": "extends",
+      "description": "Parent formalization covers S₃ (solvable); A₅ extends to the first non-solvable realization"
+    },
+    {
+      "targetId": "inverse-galois-d4",
+      "relationship": "related",
+      "description": "D₄ realization (order 8, solvable) — contrast with the non-solvable A₅ case"
+    },
+    {
+      "targetId": "inverse-galois-f20",
+      "relationship": "related",
+      "description": "F₂₀ realization (order 20, solvable) — another solvable predecessor"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "InverseGaloisA5",
+    "lineCount": 2067,
+    "axiomCount": 1,
+    "theoremCount": 65,
+    "definitionCount": 8,
+    "path": "Proofs/InverseGaloisA5.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "sec-iga5-polynomial",
+      "title": "Parts I–IV: The Polynomial q and Its Properties",
+      "startLine": 53,
+      "endLine": 215,
+      "summary": "Defines q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5. Proves irreducibility via Eisenstein at p=5, natDegree=5, monic, separable. Computes |rootSet| = 5.",
+      "mathContext": "$q(x) = x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5$. Eisenstein: non-leading coefficients divisible by 5; constant $-5$ not divisible by 25. Hence $q$ is irreducible over $\\mathbb{Q}$."
+    },
+    {
+      "id": "sec-iga5-order-bounds",
+      "title": "Parts V–VII: Galois Group Order Bounds",
+      "startLine": 207,
+      "endLine": 330,
+      "summary": "Proves: 5 | |Gal| (Cauchy from irreducibility); |Gal| | 120 (Gal embeds into S₅). Establishes perm_fin5_order5_order3_not_commute and perm_fin5_no_order_15 as structural lemmas about S₅.",
+      "mathContext": "$|\\text{Gal}(q/\\mathbb{Q})|$ divides $5! = 120$ and is divisible by 5. Together with the discriminant argument, this forces $|\\text{Gal}| \\in \\{60\\}$."
+    },
+    {
+      "id": "sec-iga5-no-small-subgroups",
+      "title": "Parts IX–XI: No Subgroups of Order 15 or 30 in S₅",
+      "startLine": 329,
+      "endLine": 566,
+      "summary": "Proves no_subgroup_order_15 and no_subgroup_order_30: S₅ = Equiv.Perm (Fin 5) has no subgroup of order 15 or 30. Consequences: gal_card_ne_15 and gal_card_ne_30.",
+      "mathContext": "Order-15 subgroups of $S_5$ would contain an element of order 15, but $S_5$ has none ($\\text{lcm}(3,5) = 15$ requires a $15$-cycle impossible in $S_5$). Similarly for order 30."
+    },
+    {
+      "id": "sec-iga5-vandermonde",
+      "title": "Parts VIII–XV: Vandermonde Discriminant Proof",
+      "startLine": 618,
+      "endLine": 1770,
+      "summary": "Defines p(x) = x⁵ + 20x + 16, vandermondeProduct = Π_{i<j}(root_i - root_j). Proves Sophie Germain identity, disc(q) = resultant(q,q'), vandermondeProduct² = disc(q) = 32000². Hence all Galois automorphisms are even: Gal ≤ A₅.",
+      "mathContext": "$\\Delta(q) = \\prod_{i < j}(\\alpha_i - \\alpha_j)^2 = \\text{Res}(q, q')/\\text{lc}(q)^{2\\deg(q)-1}$. Since $\\Delta(q) = 32000^2$ is a perfect square, $\\sigma(\\Delta^{1/2}) = \\Delta^{1/2}$ for all $\\sigma \\in \\text{Gal}(q/\\mathbb{Q})$, so every automorphism is even."
+    },
+    {
+      "id": "sec-iga5-isomorphism",
+      "title": "Parts XVI–XVII: Galois Isomorphism and Non-Solvability",
+      "startLine": 1960,
+      "endLine": 2067,
+      "summary": "Proves q_gal_iso_a5: Gal(q/ℚ) ≅ A₅ via index-2 subgroup characterization. Main theorem a5_realizable_iso: A₅ is realizable as a Galois group over ℚ. gal_not_solvable: transfers non-solvability from A₅ through the isomorphism.",
+      "mathContext": "$|\\text{Gal}(q/\\mathbb{Q})| = 60$ and the image in $S_5$ has index 2, so it equals $A_5$ (unique index-2 subgroup of $S_5$)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 2067-line axiomatized formalization (1 axiom, 0 sorries) of the A₅ Inverse Galois theorem. The main theorem `a5_realizable_iso` establishes that A₅ is realizable as a Galois group over ℚ via q(x). The Vandermonde discriminant proof (Parts VIII–XV) is the central technical contribution, spanning 1100 lines to establish that disc(q) = 32000². The one remaining axiom, `three_dvd_gal_card`, corresponds to Dedekind's theorem applied to the Frobenius at 7.",
+    "implications": "This is the first non-solvable Galois group formalized in the lean-genius gallery. A₅ being simple and non-solvable means it lies outside the scope of Shafarevich's theorem. The methods — Eisenstein criterion, discriminant via Vandermonde, index-2 subgroup characterization — are representative of Galois group computation for degree-5 polynomials.",
+    "openQuestions": [
+      "Prove three_dvd_gal_card using Dedekind's theorem on Frobenius elements at prime ideals (requires Mathlib's algebraic number theory)",
+      "Extend to PSL(2,7) (order 168) — the next 'sporadic' realization beyond A₅",
+      "Formalize the Hilbert irreducibility theorem to give uniform realizations of S_n and A_n for all n"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `InverseGaloisA5.lean` — 2067-line formalization that A₅ (smallest non-solvable group, order 60) is realizable as a Galois group over ℚ.

- **meta.json**: 65 theorems, 8 definitions, status: axiomatized, badge: axiom, 1 axiom (`three_dvd_gal_card` from Dedekind's theorem). Five sections covering the polynomial q(x), order bounds, no-small-subgroup lemmas, the 1100-line Vandermonde discriminant proof, and the main isomorphism + non-solvability result.
- **annotations.json**: 6 annotations covering q(x) definition (Eisenstein), order bounds, Vandermonde discriminant (critical), the axiom, q_gal_iso_a5 (critical), gal_not_solvable.
- **index.ts**: Standard gallery integration.

Mathematical highlights:
- `q_irreducible`: Eisenstein at p=5 for q(x) = x⁵ - 5x⁴ + 10x³ - 10x² + 25x - 5
- `vandermondeProduct_sq_eq_proved`: disc(q) = 32000² → Gal ≤ A₅ (1100-line proof)
- `q_gal_iso_a5`: Gal ≅ A₅ via index-2 subgroup characterization
- `gal_not_solvable`: A₅ is non-solvable (extends beyond Shafarevich's theorem)
- 1 axiom: `three_dvd_gal_card` (3 | |Gal|) = Dedekind's theorem at p=7, not yet in Mathlib

Labels: research