### PR TITLE
fix(inclusion-exclusion-oq-03): correct theoremCount 11→12, definitionCount 3→4

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "inclusion-exclusion-oq-03",
   "title": "Efficient Inclusion-Exclusion: Zeta and Möbius Transforms",
   "slug": "inclusion-exclusion-oq-03",
-  "description": "Formalizes the Zeta and Möbius transforms on the Boolean subset lattice, proving Möbius inversion (μ ∘ ζ = id) via a Fubini-type sum exchange and signed cancellation identity. Also defines the O(n·2ⁿ) fast subset sum (SOS) DP step and proves odd-even subset balance. 11 theorems, 3 definitions, 0 axioms.",
+  "description": "Formalizes the Zeta and Möbius transforms on the Boolean subset lattice, proving Möbius inversion (μ ∘ ζ = id) via a Fubini-type sum exchange and signed cancellation identity. Also defines the O(n·2ⁿ) fast subset sum (SOS) DP step and proves odd-even subset balance. 12 theorems, 4 definitions, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-03-22",
@@ -23,8 +23,8 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's Finset combinatorics.",
     "lineCount": 337,
-    "theoremCount": 11,
-    "definitionCount": 3,
+    "theoremCount": 12,
+    "definitionCount": 4,
     "originalContributions": [
       "signed_sum_subsets: ∑_{T⊆S} (-1)^|S\\T| = [S=∅] — the core cancellation via prod_add expansion",
       "inner_sum_eq: ∑_{T:U⊆T⊆S} (-1)^|S\\T| = [U=S] — Fubini reduction to signed_sum_subsets",
@@ -114,7 +114,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Proves 11 theorems and 3 definitions (0 axioms, 0 sorries) formalizing: the zeta/Möbius transforms on the Boolean subset lattice, the core signed cancellation identity (via prod_add), Möbius inversion (via Fubini sum exchange), odd-even subset balance (via parity involution), and the O(n·2ⁿ) SOS DP step.",
+    "summary": "Proves 12 theorems and 4 definitions (0 axioms, 0 sorries) formalizing: the zeta/Möbius transforms on the Boolean subset lattice, the core signed cancellation identity (via prod_add), Möbius inversion (via Fubini sum exchange), odd-even subset balance (via parity involution), and the O(n·2ⁿ) SOS DP step.",
     "implications": "**Significance**\n\n1. **Algebraic IE**: Möbius inversion provides a cleaner algebraic proof of the IE principle than direct combinatorial arguments — no case analysis on which sets are included.\n\n2. **Algorithmic insight**: The SOS DP (O(n·2ⁿ)) is 1.5^n times faster than naive O(3ⁿ) enumeration for large n. For n=20, this is 2.7× faster (1,048,576 vs 3,486,784,401 operations).\n\n3. **Foundation for Möbius function**: The Boolean lattice Möbius function (-1)^{|S\\T|} is the simplest case of the general Möbius function on posets (Rota, 1964), which also explains the classical number-theoretic Möbius function μ(n).",
     "openQuestions": [
       "Can zetaStep be composed n times to prove zetaTransform_fold_eq, i.e., that folding zetaStep over Fintype.elems gives zetaTransform?",


### PR DESCRIPTION
## Fix

Syncs `theoremCount` and `definitionCount` in the gallery metadata for `inclusion-exclusion-oq-03` to match the actual Lean source.

## Evidence

**Lean file**: `proofs/Proofs/InclusionExclusionOQ03.lean`

Verified against `git show origin/main:proofs/Proofs/InclusionExclusionOQ03.lean`:

| Field | Before | After | Actual |
|-------|--------|-------|--------|
| `theoremCount` | 11 | 12 | 12 |
| `definitionCount` | 3 | 4 | 4 |
| `lineCount` | 337 | 337 (unchanged) | 337 ✓ |
| `axiomCount` | 0 | 0 (unchanged) | 0 ✓ |
| `sorries` | 0 | 0 (unchanged) | 0 ✓ |

**Root cause**: The metadata understated counts by 1 each:
- Missing theorem: `ie_mobius_summary` (12th theorem/lemma, Part 7 summary)
- Missing definition: `SubsetFn` type alias (4th def; zetaTransform, mobiusTransform, zetaStep were counted but SubsetFn was missed)

The `description` and `conclusion.summary` text also referenced the stale "11 theorems, 3 definitions" and are corrected to "12 theorems, 4 definitions".

---
Automated fix by lean-mechanic agent.