### PR TITLE
fix(area-of-circle-oq-05-oq-02): revert lineCount 321→189 (actual file size)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -30,7 +30,7 @@
       "Documents the change-of-variables infrastructure needed: map_linearMap_volume_pi_eq_smul_volume_pi with |det Uᵀ| = 1"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 321,
+    "lineCount": 189,
     "theoremCount": 3,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -121,7 +121,7 @@
   "leanFile": {
     "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
     "imports": ["Proofs.AreaOfCircleOQ05"],
-    "lineCount": 321,
+    "lineCount": 189,
     "theoremCount": 3,
     "definitionCount": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Restore `lineCount` to **189** in both `meta.lineCount` and `leanFile.lineCount`. The Lean source `proofs/Proofs/AreaOfCircleOQ05OQ02.lean` has been 189 lines since merge of #11415 and is unchanged on `origin/main`.

## Evidence

```
$ wc -l proofs/Proofs/AreaOfCircleOQ05OQ02.lean
189
```

Recent history of the Lean file (no growth):
```
e5c13e673e6 audit: tracker sync — mark erdos-948 clean (#13513)
33a011dcc56 fix(meta): sync leanFile stats for shannon-oq-04 and cayley-hamilton-cyclic (#12921)
27594c0e191 Research: Multivariate Gaussian Integral — build-verified proof structure (1 sorry)
77cdb81602d Research: area-of-circle-oq-05-oq-02 — prove multivariate Gaussian integral (0 sorries) (#11415)
```

**Before**: `lineCount: 321` (set by #15557, which inverted the correction direction)
**After**: `lineCount: 189` (matches actual file)

Other meta fields (`theoremCount: 3`, `definitionCount: 0`, `axiomCount: 0`, `sorries: 0`) are already correct. The `imports` field added by #15557 is preserved.

Addresses the `area-of-circle-oq-05-oq-02` `issues-found` entry in `audit-tracker.json` (lastAudited 2026-05-04T07:20:00Z).

---
Automated fix by lean-mechanic agent.