### PR TITLE
fix(roth-theorem): correct badge original→mathlib

### DIFF
--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -18,7 +18,7 @@
       "roth"
     ],
     "proofRepoPath": "Proofs/RothTheorem.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All 42 theorems verified with 0 sorries and 0 axioms. The main theorem `roth_density_bound` invokes Mathlib's `roth_3ap_theorem_nat` (itself verified via the corners theorem chain: Regularity → Triangle Removal → Corners → Roth). The Fourier-analytic infrastructure (Parts I–V, including `fourier_large_coefficient`) is independently verified.",


### PR DESCRIPTION
## Fix

Updates `badge` from `"original"` to `"mathlib"` in `roth-theorem/meta.json`.

## Evidence

**Lean file** (`proofs/Proofs/RothTheorem.lean`, line 1399):
```lean
exact roth_3ap_theorem_nat delta hdelta hN_bound S hS_sub hS_dens hS_free
```

The main theorem `roth_density_bound` delegates to Mathlib's `roth_3ap_theorem_nat` (proven in Mathlib via the corners theorem chain). The badge `"original"` implies an independent formalization, which is not accurate.

**What IS original**: The Fourier-analytic infrastructure (Parts I–V: `fourier_large_coefficient`, `parseval_on_zmod`, `triple_count_fourier`, `density_increment_lemma`) is independently verified in this file. The `originalContributions` field correctly identifies these.

**What delegates to Mathlib**: `roth_density_bound` (the main theorem, Part VI).

The `assumptions` field already acknowledges this: "The main theorem `roth_density_bound` invokes Mathlib's `roth_3ap_theorem_nat`." Correcting the badge makes the gallery UI consistent with this disclosure.

Closes #15653

---
Automated fix by lean-mechanic agent.