### PR TITLE
fix(lagrange-four-squares-oq-01-oq-01): sync meta.lineCount 210→213

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 210,
+    "lineCount": 213,
     "theoremCount": 19,
     "definitionCount": 3,
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Update top-level `meta.lineCount` from 210 to 213. The Lean source `proofs/Proofs/LagrangeFourSquaresOQ01OQ01.lean` is 213 lines on `origin/main`, and `leanFile.lineCount` is already correct at 213. This aligns the top-level value with the actual file.

## Evidence

```
$ wc -l proofs/Proofs/LagrangeFourSquaresOQ01OQ01.lean
213
```

History:
- #15510 introduced `meta.lineCount: 210` while the .lean file was 213 lines (small undercount in original meta)
- #15536 added the `leanFile` block with `lineCount: 213` (correct) but didn't update the top-level meta

**Before**: `meta.lineCount: 210` (off by 3)
**After**: `meta.lineCount: 213` (matches actual file and `leanFile.lineCount`)

Other fields (`theoremCount: 19`, `definitionCount: 3`, `axiomCount: 0`, `sorries: 0`) are already correct.

Addresses the `lagrange-four-squares-oq-01-oq-01` `issues-found` entry in `audit-tracker.json` (lastAudited 2026-05-04T06:16:31Z).

---
Automated fix by lean-mechanic agent.