### PR TITLE
research(ballot-problem-oq-01-oq-04-oq-01): Chung-Feller bijection gallery entry

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "cf-dyck-good-rotation",
+    "proofId": "ballot-problem-oq-01-oq-04-oq-01",
+    "type": "definition",
+    "range": {
+      "startLine": 44,
+      "endLine": 74
+    },
+    "title": "IsDyckPath and chungFellerRot: Core Definitions",
+    "content": "`IsDyckPath D n` asserts that D is a balanced ±1 path of semi-length n where all prefix sums are ≥ 0. Formally: `IsBalancedPath D n ∧ ∀ k, (D.take k).sum ≥ 0`.\n\n`chungFellerRot l = cyclicRotation (1::l) (rightmostMinPos (1::l))` — the 'good rotation'. Starting from the augmented path (1::l), rotate by the position of the rightmost minimum. The rightmost minimum position is the canonical choice ensuring uniqueness.\n\nKey invariant: among all n+1 cyclic rotations of (1::l), exactly one is a 'good rotation' (starts with 1, all subsequent prefix sums ≥ 1). The good rotation position is unique and canonical.",
+    "significance": "key",
+    "mathContext": "A Dyck path of semi-length $n$ is a path from $(0,0)$ to $(2n,0)$ using $\\pm 1$ steps that never goes below the $x$-axis. The good rotation of a balanced path $l$ uses the 'cycle lemma': among $2n$ rotations of any lattice path from $(0,0)$ to $(0,0)$, exactly one never dips below the axis.",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "Dyck paths",
+      "cyclic rotation",
+      "rightmostMinPos"
+    ],
+    "prerequisites": [
+      "IsBalancedPath definition",
+      "cyclicRotation",
+      "rightmostMinPos"
+    ]
+  },
+  {
+    "id": "cf-tail-is-dyck",
+    "proofId": "ballot-problem-oq-01-oq-04-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 332,
+      "endLine": 390
+    },
+    "title": "chungFellerRot_tail_is_dyck: The Good Rotation's Tail is a Dyck Path",
+    "content": "`chungFellerRot_tail_is_dyck {l : List ℤ} {n : ℕ} (hn : 0 < n) (hbal : IsBalancedPath l n) : IsDyckPath (chungFellerRot l).tail n`\n\nThis is the central structural result. Proof chain:\n1. `chungFellerRot_head_eq_one`: the good rotation starts with 1.\n2. `chungFellerRot_tail_nonneg_prefixSum`: the tail has all prefix sums ≥ 0.\n3. `chungFellerRot_tail_upsteps_all_above`: all upsteps in the tail are above the axis (position of upstep = position in prefix sum sequence where value increases, which is always ≥ 1 for the tail).\n4. `chungFellerRot_tail_type_eq_n`: upstepsAboveAxis(tail) = n.\n5. Combine: tail is balanced with all prefix sums ≥ 0 → IsDyckPath.",
+    "significance": "critical",
+    "mathContext": "The Chung-Feller bijection maps $l$ to $(\\text{tail}(\\text{rot}(l)), \\text{type}(l))$. For this to work, $\\text{tail}(\\text{rot}(l))$ must be a Dyck path — this theorem establishes that invariant.",
+    "relatedConcepts": [
+      "Dyck paths",
+      "cyclic rotation",
+      "prefix sums",
+      "upstepsAboveAxis"
+    ],
+    "prerequisites": [
+      "chungFellerRot_head_eq_one",
+      "chungFellerRot_tail_nonneg_prefixSum",
+      "chungFellerRot_tail_type_eq_n"
+    ]
+  },
+  {
+    "id": "cf-orbit-same-dyck",
+    "proofId": "ballot-problem-oq-01-oq-04-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 388,
+      "endLine": 456
+    },
+    "title": "orbit_same_dyck: Rotation Orbit Has Same Dyck Image",
+    "content": "`orbit_same_dyck {l₁ l₂ : List ℤ} {n : ℕ} {r : ℕ}` (hbal₁, hbal₂ : balanced) (hr : l₂ is a rotation of l₁ by r) `: chungFellerRot l₁ = chungFellerRot l₂`\n\nIf two balanced paths are in the same rotation orbit (one is a cyclic rotation of the other), they have the same good rotation output. This is because: the augmented path (1::l₂) is a rotation of (1::l₁), the good rotation of both coincides (there's a unique 'good' position in each orbit by the cycle lemma), so the good rotations are identical.\n\nConsequence: the Dyck path `(chungFellerRot l).tail` depends only on the rotation orbit, not on the specific representative l in the orbit.",
+    "significance": "key",
+    "mathContext": "Orbit structure: the $n+1$ elements of the rotation orbit of $1::D$ (for a Dyck path $D$) each correspond to a distinct balanced path type. The map $l \\mapsto \\text{tail}(\\text{rot}(l))$ collapses the orbit to its canonical Dyck representative.",
+    "relatedConcepts": [
+      "rotation orbits",
+      "cycle lemma",
+      "Chung-Feller bijection"
+    ],
+    "prerequisites": [
+      "chungFellerRot definition",
+      "cyclicRotation_compose_wrap",
+      "rightmostMinPos uniqueness"
+    ]
+  },
+  {
+    "id": "cf-bijection-exists",
+    "proofId": "ballot-problem-oq-01-oq-04-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 782,
+      "endLine": 1023
+    },
+    "title": "chung_feller_bijection_exists: The Bijection is Bijective",
+    "content": "`chung_feller_bijection_exists (n : ℕ) (hn : 0 < n) : Function.Bijective (chungFellerMap n hn)`\n\n`chungFellerMap n hn l = ((chungFellerRot l).tail, ⟨upstepsAboveAxis l, ...⟩)`\n\n**Injectivity**: Given chungFellerMap(l₁) = chungFellerMap(l₂) = (D, type), both l₁ and l₂ have the same Dyck image D and same type (number of axis-crossing upsteps). Since the Dyck image uniquely determines the orbit, and the type uniquely determines which element of the orbit, l₁ = l₂.\n\n**Surjectivity**: Given a pair (D, ⟨k, hk⟩), the k-th cyclic rotation of (1::D) gives a balanced path l with chungFellerRot(l) = (1::D), so tail = D, and the rotation type = k.",
+    "significance": "critical",
+    "mathContext": "The Chung-Feller bijection: $\\phi_n : \\{\\text{balanced paths of length }2n\\} \\xrightarrow{\\sim} \\{\\text{Dyck paths of semi-length }n\\} \\times \\{0,1,\\ldots,n\\}$.",
+    "relatedConcepts": [
+      "bijection",
+      "Equiv.ofBijective",
+      "injectivity and surjectivity"
+    ],
+    "prerequisites": [
+      "chungFellerMap definition",
+      "orbit_same_dyck",
+      "chungFellerRot_tail_is_dyck"
+    ]
+  },
+  {
+    "id": "cf-uniform",
+    "proofId": "ballot-problem-oq-01-oq-04-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 1023,
+      "endLine": 1164
+    },
+    "title": "chung_feller_uniform': Uniform Distribution Over Path Types",
+    "content": "`chung_feller_uniform' (n : ℕ) (j k : ℕ) (hj : j ≤ n) (hk : k ≤ n)`: |{balanced paths of length 2n and type j}| = |{balanced paths of length 2n and type k}|\n\nwhere 'type j' means upstepsAboveAxis = j.\n\nProof: Apply `Set.ncard_congr` with the type-swapping map:\n`f(l) = (e.symm((e(l).1, ⟨k, hk⟩)).val`\nwhere `e = Equiv.ofBijective (chungFellerMap n hn') (chung_feller_bijection_exists n hn')`.\n\nThis sends a type-j balanced path l to the unique type-k balanced path sharing the same Dyck image. The map is well-defined (by the bijection), and bijective (Equiv.symm is injective). The key observation: e(l).1 is the Dyck image (orbit-canonical), and replacing the type component with k gives a type-k path.\n\nFor n=0: trivially true (only one path type exists).",
+    "significance": "critical",
+    "mathContext": "**Chung-Feller theorem (1949)**: For all $0 \\leq j, k \\leq n$, $|\\{\\text{balanced paths of length }2n\\text{ and type }j\\}| = C_n$. The $n+1$ types are equidistributed.",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "uniform distribution",
+      "Set.ncard_congr"
+    ],
+    "prerequisites": [
+      "chung_feller_bijection_exists",
+      "Set.ncard_congr",
+      "Equiv.ofBijective"
+    ]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/index.ts
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/index.ts
@@ -1,0 +1,30 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "ballot-problem-oq-01-oq-04-oq-01",
+  "title": "Chung-Feller Bijection: Rotation Index to Path Type",
+  "slug": "ballot-problem-oq-01-oq-04-oq-01",
+  "description": "Constructs and verifies the Chung-Feller bijection between balanced paths and (Dyck path, type index) pairs, proving that all n+1 path types of balanced lattice paths of length 2n have equal cardinality (the Catalan number Cₙ). The bijection maps a balanced path to its 'good rotation' (cyclic rotation until the last 1 becomes the head) and the rotation's type index. The main results are `chung_feller_bijection_exists` (the bijection is bijective) and `chung_feller_uniform'` (uniform distribution over path types via the bijection).",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number#Second_proof",
+    "date": "Classical result (Chung-Feller 1949); formalized 2026",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "ballot-problem",
+      "chung-feller",
+      "bijection",
+      "lattice-paths",
+      "dyck-paths"
+    ],
+    "proofRepoPath": "Proofs/BallotProblemOQ01OQ04OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 12 theorems verified with 0 sorries and 0 axioms. Imports BallotProblemOQ01OQ04Core.lean (the definition infrastructure, also 0 axioms).",
+    "originalContributions": [
+      "IsDyckPath: definition of Dyck paths as balanced paths with all prefix sums ≥ 0",
+      "chungFellerRot: the 'good rotation' — cyclicRotation (1::l) (rightmostMinPos (1::l))",
+      "chungFellerRot_head_eq_one: the good rotation always starts with 1",
+      "chungFellerRot_tail_nonneg_prefixSum: tail of good rotation has non-negative prefix sums",
+      "chungFellerRot_tail_upsteps_all_above: all upsteps in the tail are above the axis",
+      "chungFellerRot_tail_type_eq_n: the tail has upstepsAboveAxis = n (it's a Dyck path)",
+      "chungFellerRot_tail_is_dyck: the tail of the good rotation is a Dyck path",
+      "orbit_same_dyck: all balanced paths in the same rotation orbit map to the same Dyck path",
+      "chungFellerMap: the bijection candidate (balanced path → Dyck path × path type index)",
+      "chung_feller_bijection_exists: the map is bijective (injective + surjective)",
+      "chung_feller_uniform': all n+1 path types of balanced paths have the same cardinality"
+    ],
+    "dateAdded": "2026-05-04",
+    "lineCount": 1164,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Chung-Feller theorem (1949) states that among all balanced lattice paths of length 2n (equal steps up and down), the paths with exactly k 'upsteps above the axis' are counted by the Catalan number Cₙ = C(2n,n)/(n+1), independently of k ∈ {0,1,...,n}. This gives a combinatorial proof that Cₙ = C(2n,n)/(n+1) by counting all (n+1)·Cₙ balanced paths.\n\nThe bijection proceeds by 'good rotation': given a balanced path l, prepend 1 to get (1::l), then cyclically rotate by the position of the rightmost minimum. The rotation starts with 1 (always) and its tail is a Dyck path. The rotation index encodes the 'type' of l — how many upsteps cross the axis.\n\nThis formalization answers OQ-01 of ballot-problem-oq-01-oq-04: 'Can we prove the bijection explicitly?' with a complete, verified proof.",
+    "problemStatement": "**Chung-Feller theorem**: For any n ≥ 1 and any j, k ∈ {0,...,n}:\n|{balanced paths of length 2n and type j}| = |{balanced paths of length 2n and type k}|\n(where 'type j' means the path has exactly j upsteps above the horizontal axis).\n\nFormalized as: `chung_feller_uniform'`.",
+    "text": "A 1164-line explicit construction of the Chung-Feller bijection. The proof establishes: (1) the good rotation produces a Dyck path as its tail, (2) paths in the same rotation orbit share the same Dyck image, (3) the bijection chungFellerMap is injective (via inversion) and surjective, (4) uniform distribution follows by type-swapping through the bijection.",
+    "proofStrategy": "**Definitions**: `chungFellerRot l = cyclicRotation (1::l) (rightmostMinPos (1::l))` — cyclic rotation of (1::l) by the position of the rightmost minimum. `chungFellerMap n hn l = (tail of chungFellerRot l, upstepsAboveAxis l)`.\n\n**Step 1 (good rotation is Dyck)**: `chungFellerRot_tail_is_dyck` — the tail D of the good rotation satisfies IsDyckPath D n. Proof: D has all non-negative prefix sums (since the rightmostMinPos rotation ensures this) and upstepsAboveAxis D = n.\n\n**Step 2 (orbit invariance)**: `orbit_same_dyck` — if l₂ is a cyclic rotation of l₁ by r, then chungFellerRot l₁ = chungFellerRot l₂ (they map to the same Dyck path). The good rotation is orbit-canonical.\n\n**Step 3 (bijectivity)**: `chung_feller_bijection_exists` — injectivity: if two balanced paths have the same (Dyck, type) pair, they must be the same path (reconstruct from D and type). Surjectivity: every (D, k) pair comes from some balanced path (the k-th rotation of (1::D)).\n\n**Step 4 (uniformity)**: `chung_feller_uniform'` — apply `Set.ncard_congr` with the type-swapping map: send a type-j path l to the unique type-k preimage sharing the same Dyck path. This map is well-defined and bijective via the bijection e.",
+    "keyInsights": [
+      "**Rightmost minimum rotation**: The key insight is that among all cyclic rotations of (1::l), exactly one starts with 1 and has all subsequent prefix sums ≥ 1 (the 'good rotation'). Taking the rightmost minimum position ensures uniqueness. This is the cycle lemma in disguise.",
+      "**Orbit-canonical Dyck path**: All n+1 balanced paths in the same rotation orbit (the orbit of 1::D under cyclic rotation) share the same Dyck path D as their chungFellerRot tail. This is the structural key: the bijection sends each orbit to a single Dyck path, with the path type encoding which element of the orbit the path is.",
+      "**Type-swapping surjection for uniformity**: `chung_feller_uniform'` avoids recomputing cardinalities by using `Set.ncard_congr`. The type-swapping map l ↦ e.symm((e(l).1, ⟨k, ...⟩)) replaces the type index j with k while keeping the Dyck path. This is a bijection between type-j and type-k paths.",
+      "**Injectivity via reconstruction**: To show injectivity of chungFellerMap, given (D, type₁) = (D, type₂), reconstruct the original paths as specific rotations of (1::D). The reconstruction uses cyclicRotation_get?_zero and the inverse rotation formula."
+    ],
+    "prerequisites": [
+      "Dyck paths and Catalan numbers",
+      "Chung-Feller theorem",
+      "Cyclic rotation and the cycle lemma",
+      "Ballot sequences and lattice paths"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "ballot-problem-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "Parent OQ-04 axiomatizes chung_feller_uniform; OQ-04-OQ-01 proves the explicit bijection, eliminating the need for the axiom"
+    },
+    {
+      "targetId": "ballot-problem-oq-01",
+      "relationship": "related",
+      "description": "Parent ballot problem formalization; this proves the uniform distribution subcase"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.BallotProblemOQ01OQ04Core"
+    ],
+    "namespace": "ChungFellerBijection",
+    "lineCount": 1164,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "path": "Proofs/BallotProblemOQ01OQ04OQ01.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "sec-cf-definitions",
+      "title": "Definitions: IsDyckPath and chungFellerRot",
+      "startLine": 44,
+      "endLine": 74,
+      "summary": "IsDyckPath D n: D is balanced and all prefix sums are ≥ 0. chungFellerRot l: the 'good rotation' — cyclicRotation (1::l) (rightmostMinPos (1::l)).",
+      "mathContext": "A Dyck path of semi-length n is a balanced $\\pm 1$ sequence of length $2n$ with all prefix sums $\\geq 0$. There are $C_n$ Dyck paths."
+    },
+    {
+      "id": "sec-cf-good-rotation",
+      "title": "Good Rotation Properties (L74–340)",
+      "startLine": 74,
+      "endLine": 388,
+      "summary": "Proves: chungFellerRot_head_eq_one (head = 1), chungFellerRot_tail_nonneg_prefixSum (tail prefix sums ≥ 0), chungFellerRot_tail_upsteps_all_above (tail has only axis-crossing upsteps), chungFellerRot_tail_type_eq_n (tail type = n), chungFellerRot_tail_is_dyck (tail is Dyck).",
+      "mathContext": "The good rotation of any balanced path starts with 1 and its tail is a Dyck path. The rotation position (rightmostMinPos) ensures this."
+    },
+    {
+      "id": "sec-cf-orbit",
+      "title": "Orbit Invariance and Bijection Map (L388–781)",
+      "startLine": 388,
+      "endLine": 782,
+      "summary": "orbit_same_dyck: all paths in the same rotation orbit have the same chungFellerRot. chungFellerMap definition (L456): maps balanced path to (Dyck tail, type index).",
+      "mathContext": "Each rotation orbit of a Dyck path $D$ contains exactly $n+1$ balanced paths. The bijection maps orbit position (type) to a single Dyck target."
+    },
+    {
+      "id": "sec-cf-bijection",
+      "title": "Bijectivity: chung_feller_bijection_exists (L782–1023)",
+      "startLine": 782,
+      "endLine": 1023,
+      "summary": "Proves chung_feller_bijection_exists: chungFellerMap is bijective. Injectivity: same (D, type) ⟹ same path (via reconstruction from orbit). Surjectivity: every (D, k) comes from k-th rotation of (1::D).",
+      "mathContext": "Bijectivity of $\\text{chungFellerMap} : \\{\\text{balanced paths of length }2n\\} \\to \\{\\text{Dyck paths of semi-length }n\\} \\times \\text{Fin}(n+1)$."
+    },
+    {
+      "id": "sec-cf-uniform",
+      "title": "Uniform Distribution: chung_feller_uniform' (L1023–1164)",
+      "startLine": 1023,
+      "endLine": 1164,
+      "summary": "Proves chung_feller_uniform': |{type-j balanced paths}| = |{type-k balanced paths}| for all j,k ≤ n. Uses Set.ncard_congr with the type-swapping map l ↦ e.symm((e(l).1, k)).",
+      "mathContext": "Corollary: $|\\{\\text{balanced paths of type }j\\}| = C_n$ for each $j = 0,1,\\ldots,n$. All $(n+1)C_n$ balanced paths are uniformly distributed over types."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of the Chung-Feller bijection. The 12-theorem file proves that chungFellerMap is a bijection between balanced paths and (Dyck path, type index) pairs, deriving uniform distribution of balanced paths over path types as a corollary.",
+    "implications": "This completes the proof of the Chung-Feller theorem (1949) in Lean 4. The bijection provides an elementary combinatorial proof that all n+1 types of balanced lattice paths are equinumerous, and hence each type is counted by the Catalan number. The construction also gives a canonical form for balanced paths (their rotation type).",
+    "openQuestions": [
+      "Generalize to k-balanced paths (paths with p ups and q downs, gcd(p,q)=1) — the generalized ballot problem",
+      "Connect to the Lindström-Gessel-Viennot lemma for multi-path generalizations",
+      "Prove the Chung-Feller theorem using the kernel method (generating function approach) for a second proof"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `ballot-problem-oq-01-oq-04-oq-01` — the Chung-Feller bijection between balanced lattice paths and (Dyck path, type index) pairs.

**Source**: `proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean` (1164 lines, 0 sorries, 0 axioms)
**Imports**: `Proofs.BallotProblemOQ01OQ04Core` (also 0 axioms)
**Namespace**: `ChungFellerBijection`
**Status**: verified | badge: original

## Key Results

- `IsDyckPath` and `chungFellerRot`: core definitions (good rotation via rightmost minimum position)
- `chungFellerRot_tail_is_dyck`: the tail of the good rotation is a Dyck path
- `orbit_same_dyck`: all balanced paths in the same rotation orbit share the same Dyck image
- `chung_feller_bijection_exists`: `chungFellerMap` is bijective (injectivity + surjectivity)
- `chung_feller_uniform'`: all n+1 path types have equal cardinality (= Cₙ)

## Mathematical Content

The Chung-Feller theorem (1949): among all balanced lattice paths of length 2n, the paths with exactly k "upsteps above the axis" are counted by the Catalan number Cₙ, independently of k ∈ {0,1,...,n}.

The bijection sends each balanced path to its "good rotation" (cyclic rotation of 1::l by the rightmost minimum position), producing a Dyck path as the tail. All n+1 balanced paths in the same rotation orbit map to the same Dyck path; the rotation type encodes which element of the orbit the path is.

## Gallery Entry

- `src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json` — 12 theorems, 3 defs
- `src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/annotations.json` — 5 annotations
- `src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/index.ts` — standard pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)