### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-01-oq-01): extend natDegree_dvd_card beyond CharZero

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -55,6 +55,7 @@ import Proofs.AngleTrisectionOQ01
 import Proofs.AngleTrisectionOQ02
 import Proofs.AngleTrisectionOQ02OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01
+import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ02
 import Proofs.AngleTrisectionOQ02OQ01OQ02Aristotle
 import Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01

--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,165 @@
+/-
+  Angle Trisection OQ02-OQ01-OQ01-OQ01:
+  Extension Beyond CharZero — natDegree_dvd_card for Separable Polynomials
+
+  Question: Does natDegree(p) | |Gal(p)| hold for irreducible polynomials beyond CharZero?
+
+  Answer: YES for separable irreducibles over any field.
+          NO in general: in characteristic p, inseparable irreducibles (e.g., X^p - t over
+          F_p(t)) can have |Gal| = 1 while natDegree = p, so natDegree ∤ |Gal|.
+
+  The CharZero hypothesis in `natDegree_dvd_card_gal` (AngleTrisectionOQ02OQ01.lean) was only
+  needed to derive separability from irreducibility via `Irreducible.separable`. The tower-law
+  argument itself requires only separability, not CharZero. We make this explicit here:
+
+    natDegree_dvd_card_gal_of_sep : Irreducible p → p.Separable → natDegree p ∣ Nat.card p.Gal
+
+  The CharZero version follows as a one-line corollary. We also recover the Galois-criterion
+  results from the parent file in this more general setting.
+
+  Parent: AngleTrisectionOQ02OQ01.lean (CharZero version)
+  Answers: angle-trisection-oq-02-oq-01-oq-01-oq-01
+-/
+
+import Mathlib
+import Proofs.AngleTrisectionOQ02OQ01
+
+open Polynomial
+
+open scoped IntermediateField
+
+namespace AngleTrisectionOQ02OQ01OQ01OQ01
+
+/-!
+## Part I: Main Theorem — Separability Suffices
+-/
+
+/-- For any irreducible *separable* polynomial over any field (of any characteristic),
+    natDegree(p) divides |Gal(p)|.
+
+    This strictly generalizes `natDegree_dvd_card_gal` (which requires CharZero): the
+    CharZero hypothesis is only needed to infer separability from irreducibility. The
+    tower-law proof goes through unchanged once separability is assumed explicitly.
+
+    Proof: By `Gal.card_of_separable`, rewrite |Gal(p)| = finrank(F, SplittingField(p)).
+    Pick a root α of p in its splitting field. Tower law gives:
+      finrank(F, SplittingField) = finrank(F, F⟮α⟯) · finrank(F⟮α⟯, SplittingField)
+    Since minpoly(F, α) = p (by irreducibility), finrank(F, F⟮α⟯) = natDegree(p). -/
+theorem natDegree_dvd_card_gal_of_sep {F : Type*} [Field F]
+    {p : F[X]} (p_irr : Irreducible p) (p_sep : p.Separable) :
+    p.natDegree ∣ Nat.card p.Gal := by
+  rw [Gal.card_of_separable p_sep]
+  have hp : p.degree ≠ 0 := by
+    intro h
+    exact absurd (natDegree_eq_zero_iff_degree_le_zero.mpr (le_of_eq h))
+      (Irreducible.natDegree_pos p_irr).ne'
+  have hp' : (p.map (algebraMap F p.SplittingField)).degree ≠ 0 := by
+    rwa [degree_map_eq_of_injective (RingHom.injective (algebraMap F p.SplittingField))]
+  let α : p.SplittingField :=
+    rootOfSplits (SplittingField.splits p) hp'
+  have hα : IsIntegral F α := .of_finite F α
+  use Module.finrank F⟮α⟯ p.SplittingField
+  suffices (minpoly F α).natDegree = p.natDegree by
+    letI _ : AddCommGroup F⟮α⟯ := Ring.toAddCommGroup
+    rw [← Module.finrank_mul_finrank F F⟮α⟯ p.SplittingField,
+      IntermediateField.adjoin.finrank hα, this]
+  suffices minpoly F α ∣ p by
+    have key := (minpoly.irreducible hα).dvd_symm p_irr this
+    apply le_antisymm
+    · exact natDegree_le_of_dvd this p_irr.ne_zero
+    · exact natDegree_le_of_dvd key (minpoly.ne_zero hα)
+  apply minpoly.dvd F α
+  rw [aeval_def, eval₂_eq_eval_map]
+  exact eval_rootOfSplits (SplittingField.splits p) hp'
+
+/-!
+## Part II: CharZero Corollary
+-/
+
+/-- Over CharZero, every irreducible is separable, so natDegree_dvd_card_gal_of_sep applies.
+    Recovers `AngleTrisectionOQ02OQ01.natDegree_dvd_card_gal` as a one-line corollary. -/
+theorem natDegree_dvd_card_gal_charZero {F : Type*} [Field F] [CharZero F]
+    {p : F[X]} (p_irr : Irreducible p) :
+    p.natDegree ∣ Nat.card p.Gal :=
+  natDegree_dvd_card_gal_of_sep p_irr p_irr.separable
+
+/-!
+## Part III: Galois Criterion Results in the Separable Setting
+
+The 2-group Galois criterion from AngleTrisectionOQ02OQ01 used CharZero only through
+`natDegree_dvd_card_gal`. With our generalization, the same results hold for separable
+irreducibles over any field.
+-/
+
+/-- For a separable irreducible p over any field: if Gal(p) is a 2-group,
+    then natDegree(p) divides some power of 2. -/
+theorem galois_2group_implies_degree_pow2_sep {F : Type*} [Field F]
+    {p : F[X]} (p_irr : Irreducible p) (p_sep : p.Separable)
+    (hGal : IsPGroup 2 p.Gal) :
+    ∃ n : ℕ, p.natDegree ∣ 2 ^ n := by
+  have hdvd := natDegree_dvd_card_gal_of_sep p_irr p_sep
+  obtain ⟨n, hn⟩ := IsPGroup.iff_card.mp hGal
+  exact ⟨n, dvd_trans hdvd (hn ▸ dvd_refl _)⟩
+
+/-- For a separable irreducible p over any field: if Gal(p) is a 2-group,
+    then natDegree(p) is itself a power of 2. -/
+theorem galois_2group_implies_degree_is_pow2_sep {F : Type*} [Field F]
+    {p : F[X]} (p_irr : Irreducible p) (p_sep : p.Separable)
+    (hGal : IsPGroup 2 p.Gal) :
+    ∃ k : ℕ, p.natDegree = 2 ^ k := by
+  obtain ⟨n, hdvd⟩ := galois_2group_implies_degree_pow2_sep p_irr p_sep hGal
+  have hpos : 0 < p.natDegree := Irreducible.natDegree_pos p_irr
+  exact AngleTrisectionOQ01.dvd_pow_two_is_pow_two _ n hpos hdvd
+
+/-!
+## Part IV: The Inseparable Obstruction
+
+When separability fails, the divisibility natDegree(p) ∣ |Gal(p)| can fail.
+
+**Classical example**: Over F = F_p(t) (characteristic p > 0), the polynomial
+q = X^p - t is irreducible (Eisenstein at t) and inseparable (q' = 0).
+Its splitting field is F_p(t^{1/p}), which is purely inseparable of degree p over F.
+The Galois group is trivial: there is only one root t^{1/p}, and the only automorphism
+fixing F is the identity. So |Gal(q)| = 1 while natDegree(q) = p, giving p ∤ 1.
+
+This shows separability is NOT just a proof artifact — it is necessary for the theorem.
+The CharZero hypothesis in the original theorem was doing real mathematical work
+(ensuring all irreducibles are separable). Our generalization identifies separability
+as the exact hypothesis needed.
+-/
+
+/-- In characteristic p > 0, an inseparable irreducible polynomial has trivial Galois group.
+    The divisibility natDegree(p) ∣ |Gal(p)| therefore fails whenever natDegree(p) > 1.
+
+    Stated as an axiom: a full proof requires building the function field F_p(t), proving
+    irreducibility via Eisenstein's criterion, and computing the automorphism group of a
+    purely inseparable extension — substantial infrastructure beyond this gallery's scope. -/
+axiom insep_gal_trivial {F : Type*} [Field F] {p : ℕ} [CharP F p] [hp : Fact p.Prime]
+    {f : F[X]} (hf_irr : Irreducible f) (hf_insep : ¬f.Separable) :
+    Nat.card f.Gal = 1
+
+/-- Consequence: for an inseparable irreducible of degree > 1, natDegree ∤ |Gal|. -/
+theorem natDeg_notDvd_gal_of_insep {F : Type*} [Field F] {p : ℕ} [CharP F p]
+    [hp : Fact p.Prime] {f : F[X]} (hf_irr : Irreducible f) (hf_insep : ¬f.Separable)
+    (hf_deg : 1 < f.natDegree) :
+    ¬(f.natDegree ∣ Nat.card f.Gal) := by
+  rw [insep_gal_trivial hf_irr hf_insep]
+  intro ⟨k, hk⟩
+  omega
+
+/-!
+## Summary
+
+| Theorem | Hypothesis | Conclusion |
+|---------|-----------|------------|
+| `natDegree_dvd_card_gal_of_sep` | Irreducible, Separable | natDegree ∣ |Gal| |
+| `natDegree_dvd_card_gal_charZero` | Irreducible, CharZero | natDegree ∣ |Gal| |
+| `galois_2group_implies_degree_pow2_sep` | Irred, Sep, 2-group Gal | natDegree ∣ 2^n |
+| `galois_2group_implies_degree_is_pow2_sep` | Irred, Sep, 2-group Gal | natDegree = 2^k |
+| `natDeg_notDvd_gal_of_insep` | Irred, Insep, degree > 1 | natDegree ∤ |Gal| |
+
+Theorems proved: 5 (0 sorries)
+Axioms: 1 (insep_gal_trivial — documents the inseparable counterexample)
+-/
+
+end AngleTrisectionOQ02OQ01OQ01OQ01

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,76 @@
+# angle-trisection-oq-02-oq-01-oq-01-oq-01
+
+**Problem**: Does the theorem extend beyond CharZero? Separability is the key hypothesis — inseparable irreducibles in characteristic p have Gal group of smaller order than expected.
+
+## Problem Summary
+
+The parent theorem `natDegree_dvd_card_gal` (AngleTrisectionOQ02OQ01.lean) uses `[CharZero F]`. This problem asks whether the theorem extends to fields of other characteristics. The answer is: yes for separable irreducibles over any field; no for inseparable ones.
+
+**Answer**: The CharZero hypothesis serves only to derive `p.Separable` from `Irreducible p` via `Irreducible.separable`. The tower-law proof itself is characteristic-free. Replacing `[CharZero F]` with `(p_sep : p.Separable)` gives the maximally general theorem.
+
+---
+
+## Session 2026-05-04 (Session 1) — Complete Proof
+
+**Mode**: FRESH
+**Outcome**: progress — 5 theorems, 0 sorries, 1 axiom (counterexample); Docker build pending
+
+### What I Did
+- Analyzed parent proof `natDegree_dvd_card_gal`: CharZero used only in `p_irr.separable` (line 33)
+- Wrote `natDegree_dvd_card_gal_of_sep`: same tower-law proof, explicit `p_sep : p.Separable`
+- CharZero corollary: `natDegree_dvd_card_gal_charZero` (one-liner via `Irreducible.separable`)
+- 2-group Galois criterion: `galois_2group_implies_degree_pow2_sep` and `_is_pow2_sep` — work in any char
+- Inseparable counterexample: documented X^p - t over F_p(t), axiomatized as `insep_gal_trivial`
+- Proved consequence: `natDeg_notDvd_gal_of_insep` shows divisibility fails for insep irreds of degree > 1
+- Created gallery entry with meta.json, annotations.json, index.ts
+- Committed to branch `research/angle-trisection-beyond-charzero`
+
+### Key Findings
+- `Gal.card_of_separable p_sep` works with explicit Separable hypothesis — no CharZero needed
+- The proof structure is identical to the parent; only one argument changes
+- PerfectField corollary would need `PerfectField.separable_of_irreducible` or similar Mathlib API
+- Inseparable irreducibles over function fields (char p) provide clean counterexamples
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean` (new, ~155 lines)
+- `src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/` (new gallery entry)
+- `src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json` (updated knowledge)
+
+### Next Steps
+- Await Docker build verification
+- Push branch, create PR if build passes
+- Optional: prove `insep_gal_trivial` using RatFunc/FractionRing over ZMod p
+
+---
+
+## Session 2026-05-04 (Session 2) — Recovery + Import Fix + PR Push
+
+**Mode**: REVISIT (branch not pushed, work lost from previous session)
+**Outcome**: progress — branch recovered from local git, import added, PRpushed
+
+### What I Did
+- Discovered branch `research/angle-trisection-beyond-charzero` was committed locally but never pushed to remote (previous session ended before push)
+- Branch was checked out in `.loom/worktrees/researcher-7` worktree (PID was dead/stale)
+- Created new worktree `.loom/worktrees/angle-trisection-beyond-charzero` from the branch
+- Found missing `import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01` in `Proofs.lean`
+  — file existed on branch but was not registered for Lake compilation
+- Added the import (alphabetically between OQ01 and OQ01OQ02)
+- Fixed `lineCount: 155 → 165` in meta.json (both `meta` and `leanFile` sections)
+- Pushed branch with 3 commits: original research + import fix + lineCount fix
+- Docker build running: `Proofs.AngleTrisectionOQ02OQ01OQ01OQ01` (PID 48975, waiting for result)
+
+### Key Findings
+- Branch was never pushed because researcher session ended at commit stage
+- `Proofs.lean` must always be updated with the new import for Lake to compile the file
+- `listings.json` is untracked/generated — deployer handles it, no need to add in PR
+- Docker build is waiting on busy Docker daemon (other concurrent builds)
+
+### Files Modified
+- `proofs/Proofs.lean` (added import)
+- `src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json` (lineCount fix)
+
+### Next Steps
+- Verify Docker build success
+- Create PR once build confirms compilation
+- Optional: prove `insep_gal_trivial` using RatFunc/FractionRing over ZMod p
+

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "ann-01",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "Separability as the Exact Hypothesis: Why CharZero Can Be Dropped",
+    "content": "The key rewrite is `Gal.card_of_separable p_sep` — this converts |Gal(p)| to Module.finrank F (SplittingField p). The signature of `Gal.card_of_separable` takes `p.Separable`, not `[CharZero F]`. Over CharZero, `Irreducible.separable` derives p.Separable automatically; here we ask the caller to supply it directly. Every subsequent step in the tower-law proof is characteristic-free.",
+    "mathContext": "Gal.card_of_separable : p.Separable → Nat.card p.Gal = Module.finrank F p.SplittingField. This is the only place where characteristic information was needed — and it only needed Separable, not CharZero.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Polynomial.Gal.card_of_separable",
+      "separability vs CharZero",
+      "tower law"
+    ],
+    "prerequisites": [
+      "Polynomial.Gal",
+      "Polynomial.Separable",
+      "splitting fields"
+    ]
+  },
+  {
+    "id": "ann-02",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 88
+    },
+    "type": "technique",
+    "title": "One-Line CharZero Corollary via Irreducible.separable",
+    "content": "The CharZero version is now a one-line corollary: `natDegree_dvd_card_gal_of_sep p_irr p_irr.separable`. The `Irreducible.separable` instance (requiring [CharZero F]) automatically produces p.Separable, which is forwarded to the general theorem. This demonstrates the standard pattern for combining instance-based hypotheses with explicit hypotheses.",
+    "mathContext": "Irreducible.separable : [CharZero F] → Irreducible p → p.Separable. Once separability is an explicit argument, CharZero becomes just one way to provide it.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Irreducible.separable",
+      "CharZero",
+      "corollary pattern"
+    ],
+    "prerequisites": [
+      "Polynomial.Irreducible.separable",
+      "CharZero typeclass"
+    ]
+  },
+  {
+    "id": "ann-03",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 148
+    },
+    "type": "concept",
+    "title": "The Inseparable Counterexample: Why Separability Is Necessary",
+    "content": "Over F = F_p(t) (rational functions in characteristic p), the polynomial X^p - t is irreducible by Eisenstein's criterion (it's Eisenstein at the prime t in F_p[t]). Its derivative is 0, so it is inseparable. The splitting field is F_p(t^{1/p}), a purely inseparable extension of degree p. The Galois group Gal(X^p - t) consists of field automorphisms of F_p(t^{1/p}) fixing F_p(t). Since (t^{1/p})^p = t, any automorphism must send t^{1/p} to a root of X^p - t in F_p(t^{1/p}), which has only one root t^{1/p}. So the only automorphism is the identity: |Gal| = 1, natDegree = p, p ∤ 1.",
+    "mathContext": "X^p - t ∈ F_p(t)[X]: irreducible (Eisenstein), inseparable (derivative = 0), Gal = {id} (only one root t^{1/p} in purely inseparable extension), |Gal| = 1 but natDegree = p.",
+    "significance": "key",
+    "relatedConcepts": [
+      "purely inseparable extensions",
+      "Eisenstein criterion",
+      "Frobenius endomorphism",
+      "characteristic p fields"
+    ],
+    "prerequisites": [
+      "Polynomial.Separable",
+      "function fields",
+      "purely inseparable extensions"
+    ]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,19 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[]
+}
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug, description: meta.description,
+  meta: meta.meta, sections: meta.sections, source: sourceRaw,
+  overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,99 @@
+{
+  "id": "angle-trisection-oq-02-oq-01-oq-01-oq-01",
+  "title": "Extension Beyond CharZero: natDegree_dvd_card for Separable Polynomials",
+  "slug": "angle-trisection-oq-02-oq-01-oq-01-oq-01",
+  "description": "Extends the natDegree | |Gal| theorem from CharZero fields to any field with an explicit separability hypothesis. Identifies separability — not CharZero — as the exact condition needed for the tower-law argument, and shows the theorem fails for inseparable irreducibles.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "field-extensions",
+      "separability",
+      "characteristic-p"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-05-04",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Gal.card_of_separable",
+        "description": "Card of Galois group equals finrank of splitting field (requires Separable)",
+        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+      },
+      {
+        "theorem": "Polynomial.Irreducible.separable",
+        "description": "Irreducible polynomials over CharZero fields are separable",
+        "module": "Mathlib.RingTheory.Separable"
+      },
+      {
+        "theorem": "IsPGroup.iff_card",
+        "description": "p-group iff card is a power of p",
+        "module": "Mathlib.GroupTheory.PGroup"
+      }
+    ],
+    "originalContributions": [
+      "natDegree_dvd_card_gal_of_sep: extends the tower-law proof to any field with Separable hypothesis",
+      "Identifies separability as the exact necessary condition — not CharZero",
+      "galois_2group_implies_degree_pow2_sep: 2-group Galois criterion for separable polynomials over any field",
+      "galois_2group_implies_degree_is_pow2_sep: degree = 2^k for separable polynomials over any field",
+      "Axiomatized inseparable counterexample: insep_gal_trivial and natDeg_notDvd_gal_of_insep"
+    ],
+    "axiomCount": 1,
+    "assumptions": "One axiom: insep_gal_trivial (states that inseparable irreducibles have trivial Galois group). Full proof would require building F_p(t) and computing the automorphism group of a purely inseparable extension. All other theorems are axiom-free.",
+    "lineCount": 155,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "axiomCount": 1,
+    "sorryCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "lineCount": 155
+  },
+  "overview": {
+    "historicalContext": "The theorem $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$ for irreducible polynomials follows from the tower law in field theory: if $\\alpha$ is a root of $p$ in the splitting field $E$, then $[E:F] = [E:F(\\alpha)] \\cdot [F(\\alpha):F]$, where $[F(\\alpha):F] = \\deg(p)$. This argument is characteristic-free — it does not use the field's characteristic at all. The CharZero hypothesis in prior formalizations entered only to ensure that the irreducible polynomial $p$ is separable, which is needed for $\\text{Gal}(p)$ to be defined and for $\\text{Gal}(p)$ to have the expected cardinality via `Gal.card_of_separable`. In characteristic $p > 0$, the story splits: separable irreducibles behave exactly as in characteristic 0, but inseparable irreducibles (e.g., $X^p - t$ over $\\mathbb{F}_p(t)$) have trivial Galois groups despite having degree $p$, so the divisibility fails. The boundary between characteristic-0 behavior and characteristic-$p$ pathology is precisely separability.",
+    "problemStatement": "**Question**: Does $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$ hold for irreducible polynomials beyond characteristic zero?\\n\\n**Answer**: Yes, for *separable* irreducible polynomials over any field. No in general: in characteristic $p$, an inseparable irreducible (e.g., $X^p - t$ over $\\mathbb{F}_p(t)$) has $|\\text{Gal}| = 1$ and $\\text{natDegree} = p$, so $p \\nmid 1$.\\n\\n**Key theorem**: `natDegree_dvd_card_gal_of_sep` — for any field $F$ and any irreducible separable $p \\in F[X]$, $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$.",
+    "keyInsights": [
+      "The CharZero hypothesis is only a proxy for separability: over CharZero every irreducible is separable, but separability is the true structural requirement.",
+      "The tower-law argument (Gal.card_of_separable + IntermediateField.adjoin.finrank) is entirely characteristic-free once separability is assumed.",
+      "Separability is both sufficient (the theorem holds) and necessary (inseparable counterexamples exist in char p) for the divisibility.",
+      "The 2-group Galois criterion for constructibility extends verbatim to any characteristic, covering e.g. separable cubic trisection obstructions over finite fields."
+    ]
+  },
+  "sections": [
+    {
+      "title": "Main Theorem: Separability Suffices",
+      "content": "The theorem `natDegree_dvd_card_gal_of_sep` proves natDegree(p) | |Gal(p)| for any irreducible separable polynomial over any field. The proof is identical to the CharZero version — rewrite |Gal(p)| = finrank via `Gal.card_of_separable`, pick a root α in the splitting field, apply the tower law, and use irreducibility to show minpoly(F,α) = p.",
+      "leanCode": "theorem natDegree_dvd_card_gal_of_sep {F : Type*} [Field F]\n    {p : F[X]} (p_irr : Irreducible p) (p_sep : p.Separable) :\n    p.natDegree ∣ Nat.card p.Gal"
+    },
+    {
+      "title": "CharZero Corollary",
+      "content": "Over CharZero, every irreducible is separable (`Irreducible.separable`), so the new theorem subsumes the original one-line corollary.",
+      "leanCode": "theorem natDegree_dvd_card_gal_charZero {F : Type*} [Field F] [CharZero F]\n    {p : F[X]} (p_irr : Irreducible p) :\n    p.natDegree ∣ Nat.card p.Gal :=\n  natDegree_dvd_card_gal_of_sep p_irr p_irr.separable"
+    },
+    {
+      "title": "Galois Criterion in Any Characteristic",
+      "content": "The 2-group Galois criterion results from AngleTrisectionOQ02OQ01 transfer directly: for a separable irreducible over any field, if Gal(p) is a 2-group then natDegree(p) is a power of 2.",
+      "leanCode": "theorem galois_2group_implies_degree_is_pow2_sep {F : Type*} [Field F]\n    {p : F[X]} (p_irr : Irreducible p) (p_sep : p.Separable)\n    (hGal : IsPGroup 2 p.Gal) :\n    ∃ k : ℕ, p.natDegree = 2 ^ k"
+    },
+    {
+      "title": "The Inseparable Obstruction",
+      "content": "For inseparable irreducibles (characteristic p, degree > 1), the Galois group is trivial while natDegree > 1, so the divisibility fails. This shows separability is not merely a proof artifact but the precise necessary condition.",
+      "leanCode": "axiom insep_gal_trivial {F : Type*} [Field F] {p : ℕ} [CharP F p] [hp : Fact p.Prime]\n    {f : F[X]} (hf_irr : Irreducible f) (hf_insep : ¬f.Separable) :\n    Nat.card f.Gal = 1\n\ntheorem natDeg_notDvd_gal_of_insep ... : ¬(f.natDegree ∣ Nat.card f.Gal)"
+    }
+  ],
+  "conclusion": {
+    "statement": "Separability is the exact necessary and sufficient additional hypothesis needed to extend natDegree(p) | |Gal(p)| from CharZero to arbitrary fields.",
+    "significance": "Identifies the precise structural boundary: the theorem holds in any characteristic for separable irreducibles, fails for inseparable ones.",
+    "openQuestions": [
+      "Can insep_gal_trivial be proved in Lean using Mathlib's purely inseparable extension theory?",
+      "Does the same argument yield a bound natDegree(p) / p^k | |Gal(p)| for inseparable irreducibles of degree p^k · d (separable degree d)?"
+    ]
+  }
+}

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -45,7 +45,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "One axiom: insep_gal_trivial (states that inseparable irreducibles have trivial Galois group). Full proof would require building F_p(t) and computing the automorphism group of a purely inseparable extension. All other theorems are axiom-free.",
-    "lineCount": 155,
+    "lineCount": 165,
     "theoremCount": 5,
     "definitionCount": 0
   },
@@ -54,7 +54,7 @@
     "sorryCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
-    "lineCount": 155
+    "lineCount": 165
   },
   "overview": {
     "historicalContext": "The theorem $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$ for irreducible polynomials follows from the tower law in field theory: if $\\alpha$ is a root of $p$ in the splitting field $E$, then $[E:F] = [E:F(\\alpha)] \\cdot [F(\\alpha):F]$, where $[F(\\alpha):F] = \\deg(p)$. This argument is characteristic-free — it does not use the field's characteristic at all. The CharZero hypothesis in prior formalizations entered only to ensure that the irreducible polynomial $p$ is separable, which is needed for $\\text{Gal}(p)$ to be defined and for $\\text{Gal}(p)$ to have the expected cardinality via `Gal.card_of_separable`. In characteristic $p > 0$, the story splits: separable irreducibles behave exactly as in characteristic 0, but inseparable irreducibles (e.g., $X^p - t$ over $\\mathbb{F}_p(t)$) have trivial Galois groups despite having degree $p$, so the divisibility fails. The boundary between characteristic-0 behavior and characteristic-$p$ pathology is precisely separability.",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "angle-trisection-oq-02-oq-01-oq-01-oq-01",
   "title": "Does the theorem extend beyond CharZero",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -29,11 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Branch pushed, PR #15667 created. 5 theorems, 0 sorries, 1 axiom. Docker build pending (infrastructure congestion).",
+    "builtItems": [
+      "Added import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01 to Proofs.lean",
+      "Fixed lineCount 155→165 in meta.json (both meta and leanFile sections)"
+    ],
+    "insights": [
+      "Branch was never pushed from session 1 — always push immediately after commit",
+      "Proofs.lean import is required for Lake to compile the new file",
+      "Docker builds can queue/hang when daemon is busy with many concurrent builds"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Await Docker build for PR #15667 (AngleTrisectionOQ02OQ01OQ01OQ01)",
+      "Optional: prove insep_gal_trivial using RatFunc/FractionRing over ZMod p"
+    ]
   },
   "tags": [
     "challenging",


### PR DESCRIPTION
## Summary

- Proves `natDegree_dvd_card_gal_of_sep`: separability — not CharZero — is the exact hypothesis for the tower-law divisibility `natDegree(p) ∣ |Gal(p)|`
- Derives the CharZero version as a one-line corollary
- Generalizes 2-group Galois criterion results to any characteristic
- Documents `insep_gal_trivial` (axiom): inseparable irreducibles in char p have trivial Gal group, showing separability is necessary
- Creates gallery entry `angle-trisection-oq-02-oq-01-oq-01-oq-01`

**Theorems**: 5 (0 sorries)  
**Axioms**: 1 (`insep_gal_trivial` — documents the inseparable counterexample)  
**Lines**: 165  

## Test plan

- [ ] Docker build: `Proofs.AngleTrisectionOQ02OQ01OQ01OQ01` (in progress)
- [ ] Gallery entry renders correctly
- [ ] No regressions in parent `AngleTrisectionOQ02OQ01` proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)