### PR TITLE
audit(erdos-749): fix lineCount 826→321

### DIFF
--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -84,7 +84,7 @@
       "erdos_749_upper_variant: upper density version (proved via by_cases)"
     ],
     "axiomCount": 1,
-    "lineCount": 826,
+    "lineCount": 321,
     "assumptions": "1 axiom: erdos_turan_conjecture_28 (Erdős-Turán conjecture #28, open). sidon_set_density_zero is now a fully proved theorem via Sidon counting bound.",
     "theoremCount": 20
   },
@@ -168,7 +168,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 826,
+    "lineCount": 321,
     "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary
- `meta.lineCount` and `leanFile.lineCount` were set to 826, the combined total of the imported file `Erdos340GreedySidon.lean` (505 lines) plus `Erdos749Problem.lean` (321 lines)
- Fixed both occurrences to report only this file's actual 321 lines

## Test plan
- [x] `wc -l proofs/Proofs/Erdos749Problem.lean` confirms 321 lines
- [x] `wc -l proofs/Proofs/Erdos340GreedySidon.lean` confirms 505 lines (505+321=826 = old wrong value)
- [x] JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)