### PR TITLE
audit(szemeredi-regularity): fix lineCount 643→533

### DIFF
--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -55,7 +55,7 @@
       "Cauchy-Schwarz inequality (for density convexity)",
       "Szemerédi core definitions (edgeDensity, IsEpsilonRegular, etc.)"
     ],
-    "lineCount": 643,
+    "lineCount": 533,
     "mathlib_version": "4.26.0",
     "theoremCount": 17
   },
@@ -181,7 +181,7 @@
       "Szemeredi.Core"
     ],
     "namespace": "Szemeredi.Regularity",
-    "lineCount": 643,
+    "lineCount": 533,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary
- `meta.lineCount` and `leanFile.lineCount` were 643 = `SzemerediCore.lean` (110) + `SzemerediRegularity.lean` (533)
- Fixed to report only this file's actual 533 lines

## Test plan
- [x] `wc -l proofs/Proofs/SzemerediRegularity.lean` = 533
- [x] `wc -l proofs/Proofs/SzemerediCore.lean` = 110 (110+533=643 = old wrong value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)