### PR TITLE
research(sperner-simplicial-instance): SimplicialComplex to CellComplex bridge for Sperner's lemma

### DIFF
--- a/src/data/proofs/sperner-simplicial-instance/annotations.json
+++ b/src/data/proofs/sperner-simplicial-instance/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "si-triangulation-struct",
+    "proofId": "sperner-simplicial-instance",
+    "type": "definition",
+    "range": {
+      "startLine": 81,
+      "endLine": 110
+    },
+    "title": "Triangulation V n: Pseudomanifold Simplicial Complex",
+    "content": "`structure Triangulation (V : Type*) [DecidableEq V] (n : ℕ)` with fields:\n- `Cell`: the type of n-simplices\n- `vertex : Cell → Fin (n+1) → V`: ordered vertex map\n- `vertex_injective`: vertices within each cell are distinct\n- `adj : Cell → Fin (n+1) → Option (Cell × Fin (n+1))`: pseudomanifold adjacency\n- `adj_symm`, `adj_vertex`, `adj_ne`: adjacency axioms\n\nKey design: `Triangulation` has exactly the same fields as `CellComplex` plus `vertex_injective`. The bridge `toCellComplex` simply forgets the extra field — a one-liner.\n\n`adj s k = some (s', k')` means: opposite face k of cell s is shared with cell s', where k' is the face position in s' (the vertex of s' not on the shared face).",
+    "significance": "key",
+    "mathContext": "A pseudomanifold: a pure simplicial complex where each codimension-1 face belongs to at most 2 top simplices. For a triangulation of a simplex, boundary faces belong to exactly 1 top simplex (adj = none) and interior faces to exactly 2 (adj = some (...)).",
+    "relatedConcepts": [
+      "CellComplex",
+      "pseudomanifold",
+      "simplicial complex",
+      "adjacency structure"
+    ],
+    "prerequisites": [
+      "SpernerMathlib4.lean CellComplex structure",
+      "simplicial complex basics"
+    ]
+  },
+  {
+    "id": "si-to-cell-complex",
+    "proofId": "sperner-simplicial-instance",
+    "type": "definition",
+    "range": {
+      "startLine": 122,
+      "endLine": 132
+    },
+    "title": "toCellComplex: Trivial Bridge from Triangulation to CellComplex",
+    "content": "`def toCellComplex (T : Triangulation V n) : CellComplex V n where ...`\n\nEach field of CellComplex is filled by the corresponding Triangulation field: `Cell := T.Cell`, `vertex := T.vertex`, `adj := T.adj`, `adj_symm := T.adj_symm`, `adj_vertex := T.adj_vertex`, `adj_ne := T.adj_ne`.\n\nThe `vertex_injective` field of Triangulation is simply omitted — CellComplex doesn't need it. The bridge is a pure projection, requiring no additional proof.\n\nThis design was intentional: by making Triangulation a strict extension of CellComplex, the bridge is automatic.",
+    "significance": "key",
+    "mathContext": "The bridge pattern: define an abstract interface (CellComplex) that captures the combinatorial essence of Sperner's lemma. Then show that concrete mathematical objects (Triangulation) satisfy the interface. The trivial bridge means any theorem proved for CellComplex automatically applies to Triangulation.",
+    "relatedConcepts": [
+      "structure extension",
+      "bridge construction",
+      "interface design",
+      "CellComplex"
+    ],
+    "prerequisites": [
+      "Triangulation structure",
+      "CellComplex from SpernerMathlib4"
+    ]
+  },
+  {
+    "id": "si-boundary-doors-odd",
+    "proofId": "sperner-simplicial-instance",
+    "type": "theorem",
+    "range": {
+      "startLine": 173,
+      "endLine": 254
+    },
+    "title": "boundary_doors_odd: Sperner Colorings Give Odd Boundary Doors",
+    "content": "`theorem boundary_doors_odd (T : Triangulation V n) (c : V → Fin (n+1)) (onFace : V → Fin (n+1) → Prop) (_hSperner : IsSpernerColoring c onFace) (_hBoundaryOnFace ...) (_hLowerDim ...) (_hLastFace : Odd (...).card) : Odd (...boundary doors...).card`\n\nProof strategy: Show that the total boundary door set equals the boundary doors on the 'last face' (face index n):\n\n1. **S ⊆ S_n**: If door (s,k) is on face faceIdx with faceIdx.val < n, then:\n   - `IsDoor` gives a vertex i ≠ k with color = castSucc(faceIdx) = faceIdx\n   - `hBoundaryOnFace` gives that vertex i is on face faceIdx (since i ≠ k)\n   - Sperner condition: c(vertex i) ≠ faceIdx\n   - Contradiction!\n   So all boundary doors must be on face ⟨n, _⟩.\n\n2. **S_n ⊆ S**: Immediate (drop the extra condition).\n\nSince S = S_n and |S_n| is odd by _hLastFace, |S| is odd.",
+    "significance": "critical",
+    "mathContext": "The boundary door parity is the key lemma for Sperner's lemma: if boundary doors are odd, then interior cells contribute even net door-swaps (0 or 2 per interior cell), so panchromatic cells (1 door each) must exist to make the total odd. `boundary_doors_odd` establishes the 'odd boundary' hypothesis from the Sperner condition.",
+    "relatedConcepts": [
+      "Sperner coloring",
+      "boundary doors",
+      "parity argument",
+      "IsDoor predicate"
+    ],
+    "prerequisites": [
+      "CellComplex.IsDoor definition",
+      "IsSpernerColoring",
+      "pseudomanifold boundary"
+    ]
+  },
+  {
+    "id": "si-abstract-simplicial",
+    "proofId": "sperner-simplicial-instance",
+    "type": "definition",
+    "range": {
+      "startLine": 265,
+      "endLine": 300
+    },
+    "title": "AbstractSimplicialData: Unordered Simplicial Complex Interface",
+    "content": "`structure AbstractSimplicialData (V : Type*) [DecidableEq V] [LinearOrder V] (n : ℕ)` with:\n- `topSimplices : Finset (Finset V)`: the collection of n-simplices\n- `card_eq`: each simplex has exactly n+1 vertices\n- `pseudomanifold`: each codim-1 face (n elements) is in ≤ 2 top simplices\n\nKey derived infrastructure:\n- `vertexEnum s hs k`: the k-th vertex of simplex s in sorted order (`Finset.sort (· ≤ ·)`)\n- `faceOf s hs k`: the codim-1 face obtained by erasing vertex k\n- `containersOf f`: top simplices containing face f\n- `findOppositeIdx t ht f hf hfc`: index of the unique vertex in t \\ f\n- `erase_opposite_eq`: erasing the opposite vertex from t gives back f\n\nThis matches the `Geometry.SimplicialComplex` representation in Mathlib (which uses `Finset V` for simplices).",
+    "significance": "key",
+    "mathContext": "Mathlib's `Geometry.SimplicialComplex` uses unordered `Finset V` simplices. `AbstractSimplicialData` axiomatizes exactly the minimal properties needed: cardinality (pure complex) and pseudomanifold. The `LinearOrder V` is needed to canonically order vertices via `Finset.sort`.",
+    "relatedConcepts": [
+      "Mathlib SimplicialComplex",
+      "Finset.sort",
+      "pseudomanifold condition",
+      "ordered vertex enumeration"
+    ],
+    "prerequisites": [
+      "Finset and LinearOrder in Lean 4",
+      "Finset.sort API"
+    ]
+  },
+  {
+    "id": "si-interval-triangulation",
+    "proofId": "sperner-simplicial-instance",
+    "type": "definition",
+    "range": {
+      "startLine": 957,
+      "endLine": 992
+    },
+    "title": "intervalTriangulation: Verified 1-D Example",
+    "content": "`def intervalTriangulation (m : ℕ) (hm : 0 < m) : Triangulation ℕ 1` with:\n- `Cell := Fin m` (m unit intervals)\n- `vertex := ivtx hm`: `ivtx hm i k = if k.val=0 then i.val else i.val+1` (cell i has vertices {i, i+1})\n- `adj := iadj m`: `iadj m i 0 = some (i+1, 1)` if i+1 < m, else none; `iadj m i 1 = some (i-1, 0)` if i > 0, else none\n\nAll axioms verified:\n- `vertex_injective`: by `fin_cases a <;> fin_cases b <;> simp_all`\n- `adj_symm`: via `iadj_symm'` (case split on iadj_cases)\n- `adj_vertex`: via `iadj_vertex'` (checks that opposite faces match)\n- `adj_ne`: via `iadj_ne'` (adjacent cells have different indices)\n\n`interval_sperner`: 1-d Sperner's lemma is a one-line application of `Triangulation.sperner`.",
+    "significance": "key",
+    "mathContext": "The 1-dimensional Sperner lemma: if a coloring of {0,...,m} assigns 0 to endpoint 0 and 1 to endpoint m (Sperner condition), then some unit interval [i, i+1] is panchromatic (has one endpoint colored 0, one colored 1). This is equivalent to the intermediate value theorem for discrete colorings.",
+    "relatedConcepts": [
+      "1-d Sperner lemma",
+      "interval triangulation",
+      "concrete Triangulation instance",
+      "Fin type in Lean 4"
+    ],
+    "prerequisites": [
+      "Triangulation structure",
+      "iadj_cases lemma",
+      "Triangulation.sperner"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-simplicial-instance/index.ts
+++ b/src/data/proofs/sperner-simplicial-instance/index.ts
@@ -1,0 +1,30 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/SpernerSimplicialInstance.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "sperner-simplicial-instance",
+  "title": "Sperner's Lemma: SimplicialComplex to CellComplex Bridge",
+  "slug": "sperner-simplicial-instance",
+  "description": "Bridges the abstract CellComplex framework (from SpernerMathlib4) to concrete simplicial complexes via the Triangulation structure. Proves Sperner's lemma for any triangulation satisfying the pseudomanifold condition, and constructs a fully verified 1-dimensional interval triangulation as a concrete example. All 24 theorems verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma",
+    "date": "Classical result; formalized 2026",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "sperner-lemma",
+      "simplicial-complex",
+      "triangulation",
+      "pseudomanifold",
+      "cell-complex",
+      "bridge-construction",
+      "topology"
+    ],
+    "proofRepoPath": "Proofs/SpernerSimplicialInstance.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 24 theorems verified with 0 sorries and 0 axioms. Imports SpernerMathlib4.lean (also 0 axioms).",
+    "originalContributions": [
+      "Triangulation V n: structure for finite pure simplicial complexes with pseudomanifold property",
+      "Triangulation.toCellComplex: bridge from Triangulation to abstract CellComplex",
+      "Triangulation.sperner: Sperner's lemma for any triangulation (via CellComplex.sperner)",
+      "boundary_doors_odd: boundary door parity for triangulations with Sperner colorings",
+      "AbstractSimplicialData V n: unordered simplicial data structure (Finset-based)",
+      "AbstractSimplicialData.vertexEnum: ordered vertex enumeration via Finset.sort",
+      "AbstractSimplicialData.findOppositeIdx: locate opposite vertex of a codim-1 face",
+      "AbstractSimplicialData.erase_opposite_eq: erasing opposite vertex recovers the face",
+      "AbstractSimplicialData.vertexEnum_injective: injectivity of vertex enumeration",
+      "AbstractSimplicialData.toTriangulation: constructs Triangulation from unordered data",
+      "intervalTriangulation m hm: concrete 1-d subdivision of [0,m] into m unit intervals",
+      "interval_sperner: 1-d Sperner's lemma for interval triangulation"
+    ],
+    "dateAdded": "2026-05-04",
+    "lineCount": 994,
+    "theoremCount": 24,
+    "definitionCount": 11,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Sperner's lemma (1928) states that any Sperner-colored triangulation of a simplex contains at least one fully colored (panchromatic) cell. The proof uses a parity argument: boundary doors have odd count, and each interior cell contributes 0 or 2 door-swaps. This formalization provides the instance layer connecting abstract combinatorial Sperner (proved in SpernerMathlib4.lean for any CellComplex) to concrete geometric triangulations.\n\nThe `AbstractSimplicialData` structure supports the Mathlib `Geometry.SimplicialComplex` (Finset-based) representation, bridging Mathlib's unordered simplices to the ordered vertex enumeration needed for CellComplex.",
+    "problemStatement": "**Sperner's Lemma for Triangulations**: Given a `Triangulation V n` and a Sperner coloring c : V → Fin (n+1), if the number of boundary doors is odd, then there exists a panchromatic cell.\n\nFormalized as: `Triangulation.sperner (T : Triangulation V n) (c : V → Fin (n+1)) (hbdry : Odd (...).card) : ∃ s : T.Cell, CellComplex.IsPanchromatic c T.toCellComplex s`",
+    "text": "A 994-line bridge construction. Part 1 defines `Triangulation V n` as a finite pure simplicial complex with pseudomanifold adjacency. Part 2 constructs the `toCellComplex` bridge and proves `Triangulation.sperner`. Part 3 develops the `boundary_doors_odd` theorem showing Sperner colorings give odd boundary doors. Part 4 introduces `AbstractSimplicialData` for constructing triangulations from unordered simplices (as in Mathlib). Part 5 provides the concrete `intervalTriangulation m hm` with all axioms fully proved.",
+    "proofStrategy": "**Architecture**: `SpernerMathlib4.lean` proves the abstract `CellComplex.sperner` theorem for any abstract CellComplex. This file provides:\n\n**Step 1 (Triangulation structure)**: Define `Triangulation V n` with fields mirroring `CellComplex` plus `vertex_injective`. The bridge `toCellComplex` simply forgets `vertex_injective`.\n\n**Step 2 (Abstract Sperner)**: `Triangulation.sperner` is a one-line application of `CellComplex.sperner` via the bridge.\n\n**Step 3 (Boundary parity)**: `boundary_doors_odd` proves the boundary door parity hypothesis for any Sperner coloring. Key: if a door (s,k) is on geometric face faceIdx with faceIdx.val < n, then `IsDoor` would require color faceIdx on some non-k vertex, but the Sperner condition forbids it. So all boundary doors must be on the 'last' face, whose count is odd by hypothesis.\n\n**Step 4 (From unordered simplices)**: `AbstractSimplicialData` uses `Finset.sort` to produce ordered vertex enumerations from `Finset V` simplices. Injectivity follows from `List.nodup_iff_injective_get` on the sorted list.\n\n**Step 5 (Interval example)**: `intervalTriangulation m hm` uses vertex map `ivtx hm i k = if k=0 then i else i+1` and adjacency `iadj` connecting consecutive intervals. All adjacency axioms proved by case analysis on `iadj_cases`.",
+    "keyInsights": [
+      "**Trivial bridge**: The `Triangulation` structure is designed to have exactly the same fields as `CellComplex` plus `vertex_injective`, making `toCellComplex` trivial (just field projection). This design choice keeps the bridge one-liner.",
+      "**Boundary door parity via Sperner constraint**: `boundary_doors_odd` reduces the parity question to showing all boundary doors lie on the 'last face'. If a door is on face faceIdx with faceIdx.val < n, the Sperner constraint directly contradicts the door condition — a clean contradiction proof.",
+      "**vertexEnum injectivity via nodup sort**: `AbstractSimplicialData.vertexEnum_injective` uses `List.nodup_iff_injective_get` on the sorted vertex list. Since `Finset.sort` produces a nodup list, `List.get` is injective on it, giving vertex injectivity immediately.",
+      "**Concrete 1-d example fully verified**: `intervalTriangulation m hm` provides a complete worked example with all 4 adjacency axioms proved. The adjacency structure (adj i 0 = i+1 left face, adj i 1 = i-1 right face) is verified by `iadj_cases` splitting into two cases."
+    ],
+    "prerequisites": [
+      "Sperner's lemma and CellComplex (SpernerMathlib4.lean)",
+      "Simplicial complexes and pseudomanifolds",
+      "Finset.sort and linear order",
+      "Lean 4 structures and instances"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-ndim",
+      "relationship": "extends",
+      "description": "This file provides the concrete simplicial complex instance for the abstract n-dimensional Sperner framework"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Finset.Sort",
+      "Proofs.SpernerMathlib4"
+    ],
+    "namespace": "Triangulation",
+    "lineCount": 994,
+    "axiomCount": 0,
+    "theoremCount": 24,
+    "definitionCount": 11,
+    "path": "Proofs/SpernerSimplicialInstance.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "sec-triangulation-struct",
+      "title": "Triangulation Structure and CellComplex Bridge (L64–155)",
+      "startLine": 64,
+      "endLine": 155,
+      "summary": "Triangulation V n: structure with Cell type, vertex map, pseudomanifold adjacency (adj_symm, adj_vertex, adj_ne). toCellComplex: forgets vertex_injective to get CellComplex. IsSpernerColoring: predicate for Sperner colorings.",
+      "mathContext": "A pseudomanifold simplicial complex: each codimension-1 face belongs to at most 2 top-dimensional simplices. The triangulation of a simplex satisfies the stronger 'pseudomanifold with boundary' property: boundary faces belong to exactly 1 top simplex, interior faces to exactly 2."
+    },
+    {
+      "id": "sec-sperner-bdry",
+      "title": "Sperner's Lemma and Boundary Door Parity (L155–254)",
+      "startLine": 155,
+      "endLine": 254,
+      "summary": "Triangulation.sperner: one-line application of CellComplex.sperner via toCellComplex. boundary_doors_odd: given Sperner coloring and that boundary doors decompose by face, total boundary door count is odd. Key: all boundary doors must lie on the 'last' geometric face.",
+      "mathContext": "The boundary door parity is the key hypothesis for applying Sperner's lemma. For the standard simplex triangulation, a Sperner coloring forces all boundary doors onto the face of highest index (the 'last' face), whose door count is odd by induction."
+    },
+    {
+      "id": "sec-abstract-simplicial",
+      "title": "AbstractSimplicialData and Face Library (L254–790)",
+      "startLine": 254,
+      "endLine": 790,
+      "summary": "AbstractSimplicialData V n: Finset-based unordered simplicial data. vertexEnum: ordered vertex enumeration via Finset.sort. faceOf, containersOf: codim-1 face operations. findOppositeIdx, erase_opposite_eq: locate and verify opposite vertex. vertexEnum_injective: injectivity via List.nodup_iff_injective_get. vertexEnum_image_univ, toTriangulation: full bridge to Triangulation.",
+      "mathContext": "Mathlib's `Geometry.SimplicialComplex` uses `Finset V` for simplices. `AbstractSimplicialData` provides the bridge: `Finset.sort (· ≤ ·)` gives a canonical ordering, `List.get` retrieves vertices by index. The pseudomanifold condition (each codim-1 face in ≤ 2 top simplices) is preserved by the bridge."
+    },
+    {
+      "id": "sec-interval-example",
+      "title": "Interval Triangulation Concrete Example (L808–994)",
+      "startLine": 808,
+      "endLine": 994,
+      "summary": "intervalTriangulation m hm: subdivision of [0,m] into m unit intervals (Fin m cells). Vertex map ivtx: i-th cell has vertices {i, i+1}. Adjacency iadj: cell i is adjacent to cell i+1 (via face {i+1}) and to cell i-1 (via face {i}). All 4 adjacency axioms proved by iadj_cases. interval_sperner: 1-d Sperner's lemma for this triangulation.",
+      "mathContext": "The interval [0,m] subdivided into m unit segments is the 1-dimensional standard simplex triangulation. A Sperner coloring of vertices {0,...,m} assigns colors in {0,1} with the boundary condition (0→0, m→1). Any such coloring has an odd number of boundary doors, hence a panchromatic edge (one vertex colored 0, one colored 1)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified 994-line bridge between abstract CellComplex Sperner theory and concrete simplicial complexes. The Triangulation structure abstracts exactly what CellComplex needs plus vertex injectivity; the bridge is trivial. The AbstractSimplicialData machinery connects Mathlib's Finset-based simplicial complexes to the ordered vertex format. The interval triangulation provides a complete worked example.",
+    "implications": "This bridge enables applying the abstract Sperner parity proof to any concrete triangulation meeting the pseudomanifold condition. The design pattern (abstract framework + concrete instance) is reusable for other combinatorial topology results in Lean 4. The interval example verifies the machinery end-to-end and serves as a template for higher-dimensional instances.",
+    "openQuestions": [
+      "Verify the standard 2-simplex triangulation (triangulated triangle) as a concrete Triangulation instance",
+      "Connect AbstractSimplicialData.toTriangulation to Mathlib's Geometry.SimplicialComplex for a fully Mathlib-compatible pipeline",
+      "Prove boundary_doors_odd for the standard n-simplex triangulation from first principles (geometric facts about the barycentric subdivision)"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `sperner-simplicial-instance` — the bridge between abstract CellComplex Sperner theory and concrete simplicial complexes.

**Source**: `proofs/Proofs/SpernerSimplicialInstance.lean` (994 lines, 0 sorries, 0 axioms)
**Imports**: `Proofs.SpernerMathlib4` (also 0 axioms)
**Namespace**: `Triangulation`
**Status**: verified | badge: original

## Key Results (24 theorems, 11 definitions)

- `Triangulation V n`: pseudomanifold simplicial complex structure (mirrors CellComplex + vertex_injective)
- `toCellComplex`: trivial bridge from Triangulation to CellComplex (one-liner)
- `Triangulation.sperner`: Sperner's lemma for any triangulation (via CellComplex.sperner)
- `boundary_doors_odd`: Sperner colorings give odd boundary door counts
- `AbstractSimplicialData V n`: Finset-based unordered simplicial data
- `intervalTriangulation m hm`: concrete 1-d subdivision [0,m] with all axioms proved
- `interval_sperner`: 1-d Sperner's lemma for interval triangulation

## Architecture

The design pattern: `Triangulation` extends `CellComplex` (same fields + `vertex_injective`), so the bridge `toCellComplex` simply forgets the extra field. Any theorem proved for the abstract `CellComplex` applies immediately to `Triangulation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)