### PR TITLE
fix(erdos-524): add axiom for main conjecture, fix badge wip→axiom, axiomCount 0→1

### DIFF
--- a/proofs/Proofs/Erdos524Problem.lean
+++ b/proofs/Proofs/Erdos524Problem.lean
@@ -315,3 +315,8 @@ theorem polyMax_two (t : ℝ) : polyMax t 2 = 2 := by
     · -- ε₁=-1, ε₂=-1: P₂(t,1) = -2
       suffices h : |randSignPoly t 2 1| = 2 by linarith [polyMax_ge_eval t 2 h1_mem]
       simp [randSignPoly, Finset.sum_range_succ, Finset.sum_range_one, h1, h2]; norm_num
+
+/-- **Erdős Problem #524 (OPEN)**: The correct order of magnitude of M_n(t) for
+    almost all t ∈ (0,1) is √n, i.e. erdos_524_order_of_magnitude holds with f n = √n.
+    This is the Salem–Zygmund question for random sign polynomials. [OPEN] -/
+axiom erdos_524_main : erdos_524_order_of_magnitude

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos524Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/524",
     "erdosUrl": "https://erdosproblems.com/524",
@@ -34,9 +34,9 @@
         "relation": "Distribution of arithmetic functions: both study 'almost everywhere' behavior of number-theoretic/analytic quantities under measure-theoretic frameworks"
       }
     ],
-    "axiomCount": 0,
-    "lineCount": 317,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "axiomCount": 1,
+    "lineCount": 322,
+    "assumptions": "1 axiom: erdos_524_main (the Salem–Zygmund order-of-magnitude conjecture: M_n(t) ~ C√n a.e. — OPEN). 0 sorries. The 22 structural theorems about polyMax are fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22
   },
@@ -144,8 +144,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 317,
-    "axiomCount": 0,
+    "lineCount": 322,
+    "axiomCount": 1,
     "theoremCount": 22,
     "definitionCount": 4,
     "path": "Proofs/Erdos524Problem.lean",


### PR DESCRIPTION
## Summary
- `status=axiomatized` + `axiomCount=0` + `badge=wip` was a three-way inconsistency
- `erdos_524_order_of_magnitude` was defined as a `Prop` but never axiomatized — added `axiom erdos_524_main : erdos_524_order_of_magnitude` to the Lean file
- Fixed `badge: "wip"` (invalid taxonomy) → `badge: "axiom"`
- Updated `axiomCount: 0 → 1` and `lineCount: 317 → 322` in both meta locations
- Updated `assumptions` field to properly describe the axiom

## Test plan
- [x] `grep "^axiom " Erdos524Problem.lean` confirms the axiom is declared
- [x] `wc -l Erdos524Problem.lean` = 322
- [x] JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)