### PR TITLE
fix(erdos-770): add axioms for Q1/Q3, fix badge wip→axiom, axiomCount 0→2

### DIFF
--- a/proofs/Proofs/Erdos770Problem.lean
+++ b/proofs/Proofs/Erdos770Problem.lean
@@ -31,6 +31,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.ZMod.Basic
 import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.RingTheory.Polynomial.Basic
+import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Tactic
 
 open Finset
@@ -529,3 +530,21 @@ theorem hMinK_succ_of_prime {n : ℕ} (hp : Nat.Prime (n + 1)) : hMinK n = n + 1
 theorem hMinK_unbounded (M : ℕ) : ∃ n, M < hMinK n := by
   obtain ⟨p, hp_ge, hp_prime⟩ := Nat.exists_infinite_primes (M + 1)
   exact ⟨p - 1, hMinK_prime_minus_one hp_prime ▸ by omega⟩
+
+/-- **Q1 (OPEN)**: For each prime p, the natural density of {n : ℕ | hMinK n = p}
+    exists. The conjectured density δ_p is the probability that the smallest
+    prime q with q ∤ (q-1)! satisfying some divisibility condition equals p.
+    [OPEN — requires density theory for multiplicative functions] -/
+axiom erdos_770_q1 : ∀ p : ℕ, Nat.Prime p →
+    ∃ δ : ℝ, 0 ≤ δ ∧ Filter.Tendsto
+      (fun N : ℕ => ((Finset.filter (fun n => hMinK n = p) (Finset.range N)).card : ℝ) / N)
+      Filter.atTop (nhds δ)
+
+/-- **Q3 (OPEN)**: The function hMinK is characterized by the dominant prime divisor.
+    Specifically: if p is the largest prime with (p-1) | n, then hMinK n = p
+    for all sufficiently large n satisfying the dominance condition.
+    [OPEN — no proof exists in the literature] -/
+axiom erdos_770_q3 : ∃ N₀ : ℕ, ∀ n : ℕ, N₀ ≤ n →
+    ∀ p : ℕ, Nat.Prime p → (p - 1) ∣ n →
+    (∀ q : ℕ, Nat.Prime q → (q - 1) ∣ n → q ≤ p) →
+    hMinK n = p

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -14,7 +14,7 @@
       "coprimality",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/770",
     "erdosUrl": "https://erdosproblems.com/770",
@@ -55,9 +55,9 @@
       "Proved h_eq_succ_of_prime: h(n) = n+1 when n+1 is prime",
       "Bridge lemma zmod_pow_eq_one_of_dvd: converts nat divisibility to ZMod equality"
     ],
-    "axiomCount": 0,
-    "lineCount": 531,
-    "assumptions": "None. 80 theorems fully verified with 0 axioms and 0 sorries. The open density question (Q1) is stated as a comment only. Open conjecture; supporting lemmas fully verified. New: hMinK_prime_minus_one proves h(p-1)=p for all primes p; hMinK_unbounded proves Q2 (upper half: h(n) is unbounded).",
+    "axiomCount": 2,
+    "lineCount": 550,
+    "assumptions": "2 axioms: erdos_770_q1 (density of {n : hMinK n = p} exists for each prime p — OPEN), erdos_770_q3 (hMinK n = p when p is the largest prime with (p-1)|n, for large n — OPEN). Q2 (h(n) unbounded) is fully proved via hMinK_unbounded. 74 theorems, 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 74
   },
@@ -206,8 +206,8 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 531,
-    "axiomCount": 0,
+    "lineCount": 550,
+    "axiomCount": 2,
     "theoremCount": 74,
     "definitionCount": 2,
     "path": "Proofs/Erdos770Problem.lean",


### PR DESCRIPTION
## Summary
- `status=axiomatized` + `axiomCount=0` + `badge=wip` was a three-way inconsistency  
- Added proper axioms for the two genuinely open questions:
  - `erdos_770_q1`: density of `{n : hMinK n = p}` exists for each prime p (OPEN)
  - `erdos_770_q3`: `hMinK n = p` when p is the largest prime with `(p-1)|n`, for large n (OPEN)
- Note: Q2 (h(n) is unbounded) is already **proved** as `hMinK_unbounded` — not axiomatized
- Fixed `badge: "wip"` → `badge: "axiom"` and `axiomCount: 0 → 2`
- `lineCount: 531 → 550` (18 new lines: 1 import + axiom declarations with docstrings)

## Test plan
- [x] `grep "^axiom " Erdos770Problem.lean` shows 2 axioms
- [x] `wc -l Erdos770Problem.lean` = 550
- [x] JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)