### PR TITLE
research(sperner-mathlib): add gallery entry for Sperner's lemma via door counting

### DIFF
--- a/src/data/proofs/sperner-mathlib/annotations.json
+++ b/src/data/proofs/sperner-mathlib/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-fpf-invol",
+    "type": "theorem",
+    "label": "even_card_fpf_invol",
+    "title": "Fixed-Point-Free Involution Has Even Cardinality",
+    "body": "A fixed-point-free involution f on a finset S has even cardinality. The proof proceeds by strong induction: pick any x ∈ S, let y = f(x) ≠ x, remove both to get S' ⊂ S, apply the inductive hypothesis to S', and recover S.card = S'.card + 2.",
+    "location": { "line": 59 },
+    "tags": ["combinatorics", "involution", "parity", "induction"]
+  },
+  {
+    "id": "ann-sum-one",
+    "type": "lemma",
+    "label": "exists_of_sum_eq_one",
+    "title": "Sum-to-One Has a Unique Unit Element",
+    "body": "If nonneg naturals indexed by a finset sum to 1, exactly one element equals 1 and all others are 0. Used in the pigeonhole argument for surjective colorings.",
+    "location": { "line": 127 },
+    "tags": ["combinatorics", "pigeonhole"]
+  },
+  {
+    "id": "ann-door-parity",
+    "type": "theorem",
+    "label": "door_count_parity",
+    "title": "Door Count Parity Equals Surjectivity",
+    "body": "For a coloring f : Fin(d+1) → Fin(d+1), the number of 'door positions' k such that removing k still covers all other colors has the same parity as the surjectivity indicator (1 if f is surjective, 0 otherwise). The proof considers three cases: f not surjective (0 doors), f surjective with an identity-like structure (1 door = odd), and f surjective in general (pigeonhole gives exactly 2 preimage points for one color, yielding even door count).",
+    "location": { "line": 0 },
+    "tags": ["combinatorics", "door", "surjection", "parity"]
+  },
+  {
+    "id": "ann-isdoor-adj",
+    "type": "theorem",
+    "label": "isDoor_iff_of_adj",
+    "title": "Door Symmetry via Adjacency",
+    "body": "If cells s and s' are adjacent through faces k and k' respectively, sharing all vertices except the k-th of s and k'-th of s', then (s, k) is a door if and only if (s', k') is a door. This is the key symmetry that pairs interior doors.",
+    "location": { "line": 0 },
+    "tags": ["adjacency", "door", "symmetry"]
+  },
+  {
+    "id": "ann-interior-even",
+    "type": "theorem",
+    "label": "even_card_interior_doors",
+    "title": "Interior Doors Come in Pairs",
+    "body": "The total count of interior doors (where the adjacent face exists) is even. The proof applies even_card_fpf_invol to the pairing map (s, k) ↦ adj(s, k) on interior doors, using isDoor_iff_of_adj to show the image is always a door and the involution has no fixed points.",
+    "location": { "line": 0 },
+    "tags": ["parity", "interior", "door", "involution"]
+  },
+  {
+    "id": "ann-sperner-parity",
+    "type": "theorem",
+    "label": "sperner_parity",
+    "title": "Sperner Parity: Panchromatic Count ≡ Boundary Door Count (mod 2)",
+    "body": "The number of panchromatic cells is congruent to the number of boundary doors modulo 2. The proof sums door counts across all cells: interior doors cancel in pairs, and each panchromatic cell contributes an odd number of doors (via door_count_parity), while non-panchromatic cells contribute an even number.",
+    "location": { "line": 0 },
+    "tags": ["sperner", "parity", "panchromatic", "door-counting"]
+  },
+  {
+    "id": "ann-exists-panchromatic",
+    "type": "theorem",
+    "label": "exists_panchromatic",
+    "title": "Odd Boundary Doors Imply a Panchromatic Cell",
+    "body": "If the number of boundary doors is odd, then at least one panchromatic cell exists. This is the main existential form of Sperner's lemma, following immediately from sperner_parity: if boundary doors are odd and panchromatic count ≡ boundary doors (mod 2), then panchromatic count is odd, hence positive.",
+    "location": { "line": 0 },
+    "tags": ["sperner", "existence", "panchromatic"]
+  },
+  {
+    "id": "ann-sperner-coloring",
+    "type": "theorem",
+    "label": "boundary_doors_on_last_face",
+    "title": "Sperner Coloring: Boundary Doors on the Last Face",
+    "body": "With a Sperner coloring—where each boundary vertex is labeled by a color not equal to the face it's missing—every boundary door occurs at the last face position. This geometric constraint is what makes the boundary door count checkable from the simplex boundary alone.",
+    "location": { "line": 0 },
+    "tags": ["sperner-coloring", "boundary", "geometric"]
+  },
+  {
+    "id": "ann-boundary-odd",
+    "type": "theorem",
+    "label": "boundary_doors_odd_of_last_face",
+    "title": "Sperner Coloring Gives Odd Boundary Door Count",
+    "body": "Under a Sperner coloring, the count of boundary doors is odd. Combined with boundary_doors_on_last_face and exists_panchromatic, this completes the proof that every Sperner-colored triangulation contains a panchromatic cell.",
+    "location": { "line": 0 },
+    "tags": ["sperner-coloring", "boundary", "odd"]
+  },
+  {
+    "id": "ann-interval-example",
+    "type": "note",
+    "label": "IntervalExample",
+    "title": "Concrete 1-Dimensional Verification",
+    "body": "The IntervalExample section instantiates the abstract cell complex with intervals [i, i+1] for i < m, faces indexed by Fin 2 (endpoints), and adjacency connecting consecutive segments. An example theorem shows exists_panchromatic applies when boundary colorings differ—concretely illustrating that the abstract axioms are satisfiable and the theorem is nontrivial.",
+    "location": { "line": 883 },
+    "tags": ["example", "interval", "1-dimensional"]
+  }
+]

--- a/src/data/proofs/sperner-mathlib/index.ts
+++ b/src/data/proofs/sperner-mathlib/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/SpernerMathlib.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -1,0 +1,76 @@
+{
+  "id": "sperner-mathlib",
+  "title": "Sperner's Lemma via Door Counting",
+  "slug": "sperner-mathlib",
+  "description": "A combinatorial proof of Sperner's lemma for abstract cell complexes using a door-counting parity argument. The proof works with finite combinatorial data—cells with indexed faces and an adjacency involution—avoiding explicit simplicial or topological structure. Interior doors pair up (even count), and a per-cell parity argument shows that boundary door count and panchromatic cell count have the same parity.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 3,
+    "lineCount": 898,
+    "leanFile": "proofs/Proofs/SpernerMathlib.lean",
+    "imports": ["Mathlib"],
+    "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "fpf-invol",
+      "title": "Fixed-Point-Free Involution Parity",
+      "description": "A fixed-point-free involution on a finite set has even cardinality, since every element pairs with its distinct image. This foundational lemma applies beyond Sperner: Tucker's lemma, Borsuk-Ulam, and other combinatorial topology results rely on the same parity mechanism.",
+      "theorems": ["even_card_fpf_invol"]
+    },
+    {
+      "id": "door-count",
+      "title": "Door Count Parity",
+      "description": "A 'door' at position k of a cell is a face that, if removed, still covers all remaining colors. The key lemma `door_count_parity` shows the number of door positions has the same parity as the surjectivity indicator of the coloring. The proof uses a pigeonhole argument (`surjection_unique_dup_fiber`) to identify the unique duplicated fiber when the coloring is surjective.",
+      "theorems": ["exists_of_sum_eq_one", "door_count_parity"]
+    },
+    {
+      "id": "interior-pairing",
+      "title": "Interior Door Pairing",
+      "description": "The adjacency relation pairs interior doors: each interior door of cell s at face k corresponds to a door of the adjacent cell s' at face k'. The adjacency involution (`isDoor_iff_of_adj`) ensures these pairs are distinct, so the total interior door count is even.",
+      "theorems": ["isDoor_of_shared_face", "isDoor_iff_of_adj", "even_card_interior_doors"]
+    },
+    {
+      "id": "sperner-main",
+      "title": "Sperner's Lemma",
+      "description": "Summing door counts across all cells and using the interior-door pairing, the panchromatic cell count and the boundary door count are congruent modulo 2. If the boundary doors are odd, at least one panchromatic cell exists. With a Sperner coloring (boundary vertices labeled by the face they miss), every boundary door lies on the last face, and the boundary door count is odd.",
+      "theorems": ["per_cell_door_parity", "sum_mod_congr", "card_doors_eq_sum", "doors_partition", "sperner_parity", "exists_panchromatic", "boundary_doors_on_last_face", "boundary_doors_odd_of_last_face"]
+    },
+    {
+      "id": "interval-example",
+      "title": "1-Dimensional Example",
+      "description": "The interval triangulation demonstrates that the abstract axioms are satisfiable. Cells are segments [i, i+1] for i < m, faces are endpoints (Fin 2), vertices are natural numbers via `ivtx`, and adjacency `iadj` connects adjacent segments. An example shows `exists_panchromatic` applies when the endpoint colorings differ.",
+      "theorems": []
+    }
+  ],
+  "overview": {
+    "summary": "Sperner's lemma guarantees the existence of a 'rainbow' or panchromatic cell—one whose vertices collectively use all d+1 colors—in any Sperner-colored triangulation of a d-simplex. This formalization proves the result for abstract cell complexes satisfying combinatorial axioms about faces and adjacency.",
+    "approach": "The proof uses a door-counting double-counting argument. A 'door' at position k of cell s is a face whose removal still covers all other colors. Interior doors pair via the adjacency involution (contributing an even count), while panchromatic cells each contribute an odd number of doors. Summing modulo 2 shows the panchromatic cell count has the same parity as the boundary door count.",
+    "significance": "Sperner's lemma is a combinatorial engine powering many fixed-point and fair-division theorems, including Brouwer's fixed-point theorem, Tucker's lemma, and envy-free cake-cutting results. The abstract cell-complex formulation here is more general than the classical simplicial version and applies to arbitrary finite triangulations."
+  },
+  "conclusion": {
+    "summary": "Sperner's lemma is fully machine-checked for abstract cell complexes with no axioms or sorry placeholders. The door-counting argument is self-contained within Mathlib's finite combinatorics library.",
+    "openQuestions": [
+      "Can the abstract CellComplex axioms be weakened further, e.g., to hypergraphs or non-pure complexes?",
+      "Does the parity argument extend to give a lower bound on panchromatic cell count (KKM-type results)?",
+      "Can this formulation be used to derive Tucker's lemma directly by the same double-counting?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "sperner-ndim",
+      "relationship": "generalizes",
+      "description": "The n-dimensional Sperner lemma via Freudenthal triangulation"
+    },
+    {
+      "id": "sperner-simplicial-instance",
+      "relationship": "specializes",
+      "description": "Sperner's lemma instantiated for triangulation data structures"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `SpernerMathlib.lean` (898 lines, 0 axioms, 0 sorries):

- **Status**: verified, badge: original
- **14 theorems, 3 defs** in the `Sperner` namespace
- Proves Sperner's lemma for abstract cell complexes via door-counting parity
- Interior doors pair via adjacency involution (even count); per-cell parity gives panchromatic count ≡ boundary door count (mod 2)
- Includes concrete 1-dimensional interval example

### Key Results
- `even_card_fpf_invol`: fixed-point-free involution → even cardinality
- `door_count_parity`: door count parity ↔ surjectivity indicator
- `sperner_parity`: panchromatic count ≡ boundary door count (mod 2)
- `exists_panchromatic`: odd boundary doors → panchromatic cell exists
- `boundary_doors_odd_of_last_face`: Sperner coloring satisfies the odd boundary door condition

## Files
- `src/data/proofs/sperner-mathlib/meta.json`
- `src/data/proofs/sperner-mathlib/annotations.json`
- `src/data/proofs/sperner-mathlib/index.ts`

🤖 Generated by researcher-10