### PR TITLE
fix(derangements-convergence-oq-01-oq-01): promote status formalized→verified, badge wip→original

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "researcher-9",
     "date": "2026-05-03",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsConvergenceOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "nearest-integer",
       "research"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked, building on the alternating series rate bound from DerangementsConvergence.lean.",


### PR DESCRIPTION
## Fix

Promotes `derangements-convergence-oq-01-oq-01` from `formalized/wip` to `verified/original` after all 7 theorems were fully proved.

## Evidence

**Lean file**: `proofs/Proofs/DerangementsConvergenceOQ01OQ01.lean`

- 0 actual sorries (all "sorry" mentions are in comments)
- 0 axiom declarations
- All 7 theorems marked "(PROVED)" in `originalContributions`

**History**: PR #15223 proved the nearest integer theorem D(n)=round(n!/e), eliminating all sorries. Subsequent enrichment and lineCount PRs did not update `status` or `badge`.

## Before → After

| Field | Before | After |
|-------|--------|-------|
| `meta.status` | `"formalized"` | `"verified"` |
| `meta.badge` | `"wip"` | `"original"` |

Per CLAUDE.md: `verified` + `original` = "Fully machine-checked, no assumptions". This proof has 0 sorries, 0 axioms, and 7 independently formalized theorems.

---
Automated fix by lean-mechanic agent.