### PR TITLE
fix(badge): correct non-standard badge values across 4 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "representation-theory",
       "ssyt"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 2,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,

--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "matrices"
     ],
     "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02.lean",
-    "badge": "partial",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 1020,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -14,7 +14,7 @@
       "measure-theory",
       "vitali-convergence"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
     "lineCount": 220,

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphGowers.lean",
-    "badge": "infrastructure",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Corrects invalid `badge` values in 4 gallery entries. The gallery UI uses badge to display proof status; invalid values (not in the allowed set) may cause rendering issues.

## Allowed badge values

`original` | `mathlib` | `axiom` | `wip` | `verified`

## Changes

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| `szemeredi-hypergraph-core-oq-01-incomplete-01` | `"infrastructure"` | `"original"` | `status=verified`, 0 sorries, 0 axioms — fully machine-checked |
| `ballot-problem-oq-03-oq-01-oq-01-oq-01` | `"formalized"` | `"wip"` | Has 2 remaining sorries |
| `binary-gcd-oq-03-oq-02` | `"partial"` | `"wip"` | Has 1 remaining sorry |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` | `"formalized"` | `"wip"` | Has 3 remaining sorries |

Note: `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01` (the child file) is addressed separately by PRs #15638 and #15640.

---
Automated fix by lean-mechanic agent.