### PR TITLE
research(sperner-mathlib4): add gallery entry for abstract Sperner's lemma

### DIFF
--- a/src/data/proofs/sperner-mathlib4/annotations.json
+++ b/src/data/proofs/sperner-mathlib4/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-fpf-invol",
+    "type": "theorem",
+    "label": "Finset.even_card_of_fpf_invol",
+    "title": "Fixed-Point-Free Involution Has Even Cardinality",
+    "body": "Proved using Finset.sum_involution over ZMod 2: summing 1 for each element, the involution pairs show the sum is 0 mod 2, hence the cardinality is even. This ZMod 2 approach is more concise than the strong-induction proof in SpernerMathlib.lean.",
+    "location": { "line": 60 },
+    "tags": ["combinatorics", "involution", "parity", "ZMod"]
+  },
+  {
+    "id": "ann-door-parity",
+    "type": "theorem",
+    "label": "door_count_parity",
+    "title": "Door Count Parity Equals Surjectivity Indicator",
+    "body": "For a coloring f : Fin(d+1) → Fin(d+1), the number of door positions k (where removing k still covers all lower colors 0..d-1) is odd iff f is surjective (hence bijective). Cases: (1) f not surjective → 0 doors (even); (2) f surjective as Fin(d+1) → Fin(d+1) → exactly 1 door (odd); (3) f viewed as Fin(d+1) → Fin(d) is surjective → exactly 2 doors from the duplicated fiber (even).",
+    "location": { "line": 386 },
+    "tags": ["combinatorics", "door", "surjection", "parity"]
+  },
+  {
+    "id": "ann-cell-complex",
+    "type": "definition",
+    "label": "CellComplex",
+    "title": "Abstract Cell Complex Structure",
+    "body": "CellComplex V d packages the minimal data for Sperner's lemma: a finite Cell type, a vertex function Cell → Fin(d+1) → V, and an adjacency map Cell → Fin(d+1) → Option(Cell × Fin(d+1)) satisfying: (1) adj_symm: if adj s k = some(s',k') then adj s' k' = some(s,k); (2) adj_vertex: adjacent cells share a codimension-1 face; (3) adj_ne: adjacent cells are distinct. These three axioms are exactly what the door-counting proof needs.",
+    "location": { "line": 404 },
+    "tags": ["structure", "cell-complex", "adjacency", "mathlib"]
+  },
+  {
+    "id": "ann-is-panchromatic",
+    "type": "definition",
+    "label": "IsPanchromatic",
+    "title": "Panchromatic Cell",
+    "body": "A cell s is panchromatic if the composition of the coloring c : V → Fin(d+1) with the vertex function K.vertex s : Fin(d+1) → V is surjective. Equivalently, all d+1 colors appear among the cell's vertices.",
+    "location": { "line": 440 },
+    "tags": ["panchromatic", "surjective", "coloring"]
+  },
+  {
+    "id": "ann-is-door",
+    "type": "definition",
+    "label": "IsDoor",
+    "title": "Door (Codimension-1 Face)",
+    "body": "A face (s, k) is a door if removing vertex k from cell s, the remaining d vertices cover all colors 0..d-1 (in Fin(d)). This is the key combinatorial notion bridging the door-count parity and Sperner's lemma.",
+    "location": { "line": 446 },
+    "tags": ["door", "face", "coloring"]
+  },
+  {
+    "id": "ann-interior-even",
+    "type": "theorem",
+    "label": "even_card_interiorDoors",
+    "title": "Interior Doors Pair via Adjacency",
+    "body": "The set of interior doors—pairs (s,k) where adj s k ≠ none and (s,k) is a door—has even cardinality. The proof applies Finset.even_card_of_fpf_invol to the adjacency map: each interior door maps to its neighbor door, forming fixed-point-free pairs.",
+    "location": { "line": 0 },
+    "tags": ["parity", "interior", "involution", "adjacency"]
+  },
+  {
+    "id": "ann-sperner-parity",
+    "type": "theorem",
+    "label": "sperner_parity",
+    "title": "Sperner Parity Theorem",
+    "body": "The panchromatic cell count is congruent to the boundary door count modulo 2. The proof chains: (1) sum door counts per cell equals total doors (card_doors_eq_sum); (2) total doors splits into interior (even, by even_card_interiorDoors) plus boundary; (3) per-cell door count parity equals the panchromatic indicator (door_count_parity). The interior even term cancels, leaving the congruence.",
+    "location": { "line": 652 },
+    "tags": ["sperner", "parity", "panchromatic", "door-counting"]
+  },
+  {
+    "id": "ann-sperner",
+    "type": "theorem",
+    "label": "sperner",
+    "title": "Sperner's Lemma",
+    "body": "If the boundary door count is odd, then a panchromatic cell exists. Follows immediately from sperner_parity: odd boundary doors → odd panchromatic count → at least one panchromatic cell.",
+    "location": { "line": 714 },
+    "tags": ["sperner", "existence", "panchromatic", "main-result"]
+  }
+]

--- a/src/data/proofs/sperner-mathlib4/index.ts
+++ b/src/data/proofs/sperner-mathlib4/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/SpernerMathlib4.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -1,0 +1,80 @@
+{
+  "id": "sperner-mathlib4",
+  "title": "Abstract Sperner's Lemma (Mathlib-Style)",
+  "slug": "sperner-mathlib4",
+  "description": "A Mathlib-contribution-ready formalization of Sperner's lemma for abstract cell complexes. The CellComplex structure encapsulates exactly the adjacency axioms needed for the door-counting proof, without any geometric embedding. This follows the approach suggested by Mathlib maintainer Yaël Dillies: prove the combinatorial core abstractly, then verify that concrete triangulations satisfy the axioms as a separate step.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "lineCount": 733,
+    "leanFile": "proofs/Proofs/SpernerMathlib4.lean",
+    "imports": [
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset",
+      "Mathlib.Algebra.Ring.Parity",
+      "Mathlib.Data.Fintype.BigOperators",
+      "Mathlib.Data.ZMod.Basic"
+    ],
+    "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex", "mathlib"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "fpf-invol",
+      "title": "Fixed-Point-Free Involution Parity",
+      "description": "The theorem Finset.even_card_of_fpf_invol proves that any fixed-point-free involution on a finite set has even cardinality. The proof uses Finset.sum_involution over ZMod 2, giving a concise algebraic argument. This is proposed for Mathlib as it appears useful for Tucker's lemma, Borsuk-Ulam, and related combinatorial topology results.",
+      "theorems": ["Finset.even_card_of_fpf_invol"]
+    },
+    {
+      "id": "door-count",
+      "title": "Door Count Parity",
+      "description": "The theorem door_count_parity characterizes the parity of the number of 'door positions' for a coloring f : Fin(d+1) → Fin(d+1): it equals 1 if f is surjective (hence bijective by finiteness), and 0 otherwise. The proof uses a pigeonhole argument to find the unique duplicated fiber when f is surjective over Fin(d).",
+      "theorems": ["door_count_parity"]
+    },
+    {
+      "id": "cell-complex",
+      "title": "Abstract Cell Complex",
+      "description": "The CellComplex V d structure abstracts the combinatorial data needed for Sperner's lemma: a finite type of top-dimensional cells, a vertex function, and an adjacency map satisfying symmetry, shared-face, and distinctness axioms. The definitions IsPanchromatic (surjective vertex coloring) and IsDoor (codimension-1 face covering all lower colors) are stated in terms of this structure.",
+      "theorems": []
+    },
+    {
+      "id": "sperner-main",
+      "title": "Sperner's Lemma",
+      "description": "The main results: sperner_parity shows the panchromatic cell count is congruent to the boundary door count modulo 2, via a double-counting argument using interior door pairing and per-cell parity. The theorem sperner derives existence of a panchromatic cell from an odd boundary door count.",
+      "theorems": ["even_card_interiorDoors", "sperner_parity", "sperner"]
+    }
+  ],
+  "overview": {
+    "summary": "Sperner's lemma guarantees a 'rainbow' cell exists in any Sperner-colored triangulation of a simplex. This formalization targets Mathlib 4 contribution: it proves the theorem for the abstract CellComplex structure, following guidance from Mathlib maintainer Yaël Dillies (Mathlib4 PR #25231).",
+    "approach": "The proof uses the door-counting parity argument in an abstract setting. Interior doors pair via the adjacency involution (contributing an even count by even_card_interiorDoors). The per-cell parity theorem (door_count_parity) shows panchromatic cells contribute odd door counts and non-panchromatic cells even. Summing modulo 2 gives the parity congruence.",
+    "significance": "This file is designed as a Mathlib contribution. The CellComplex structure is minimal: only three axioms (adjacency symmetry, shared-face property, distinctness) are needed. Concrete instantiations—simplicial complexes, triangulations, interval cells—can be verified separately, separating abstract from geometric concerns."
+  },
+  "conclusion": {
+    "summary": "Sperner's lemma is machine-checked for abstract cell complexes with no axioms or sorries. The file uses only four targeted Mathlib imports, making it suitable for Mathlib contribution without full import Mathlib.",
+    "openQuestions": [
+      "Does CellComplex admit a Mathlib typeclass hierarchy connecting to existing SimplicialComplex machinery?",
+      "Can the door-counting argument be combined with the Tucker-style antipodal labeling to prove Tucker's lemma in this framework?",
+      "Is the abstract cell complex formulation sufficient to derive fair-division (envy-free cake-cutting) results directly?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "sperner-mathlib",
+      "relationship": "variants",
+      "description": "Alternative door-counting proof with more explicit combinatorial lemmas"
+    },
+    {
+      "id": "sperner-simplicial-instance",
+      "relationship": "specializes",
+      "description": "Concrete triangulation instantiation of the CellComplex axioms"
+    },
+    {
+      "id": "sperner-ndim",
+      "relationship": "related",
+      "description": "n-dimensional Sperner via Freudenthal triangulation"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `SpernerMathlib4.lean` (733 lines, 0 axioms, 0 sorries):

- **Status**: verified, badge: original
- **5 theorems, 2 defs** in the `CellComplex` namespace
- Mathlib-contribution-ready proof targeting mathlib4#25231 (Yaël Dillies guidance)
- Uses only 4 targeted Mathlib imports (no `import Mathlib`)
- CellComplex structure encodes exactly 3 adjacency axioms needed for door-counting

### Key Results
- `Finset.even_card_of_fpf_invol`: FPF involution → even cardinality (via ZMod 2)
- `door_count_parity`: door count parity ↔ surjectivity indicator
- `even_card_interiorDoors`: interior doors pair via adjacency
- `sperner_parity`: panchromatic count ≡ boundary door count (mod 2)
- `sperner`: Sperner's lemma for abstract cell complexes

## Files
- `src/data/proofs/sperner-mathlib4/meta.json`
- `src/data/proofs/sperner-mathlib4/annotations.json`
- `src/data/proofs/sperner-mathlib4/index.ts`

🤖 Generated by researcher-10