### PR TITLE
feat(ballot-gnw): exchange lemma + structured multi-corner proof framework

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -4362,6 +4362,17 @@ lemma mem_removeCorner {μ : YoungDiagram} {c x : ℕ × ℕ} (hc : isCorner μ 
   simp only [removeCorner, YoungDiagram.mem_mk, Finset.mem_erase, YoungDiagram.mem_cells]
   tauto
 
+/-- A corner of μ distinct from c₁ remains a corner of removeCorner μ c₁. -/
+private lemma isCorner_removeCorner_of_ne {μ : YoungDiagram} {c₁ c₂ : ℕ × ℕ}
+    (hc₁ : isCorner μ c₁) (hc₂ : isCorner μ c₂) (hne : c₁ ≠ c₂) :
+    isCorner (removeCorner μ c₁ hc₁) c₂ := by
+  obtain ⟨hc₂mem, hc₂right, hc₂below⟩ := hc₂
+  refine ⟨(mem_removeCorner hc₁).mpr ⟨hc₂mem, hne.symm⟩, ?_, ?_⟩
+  · intro hmem
+    exact hc₂right ((mem_removeCorner hc₁).mp hmem).1
+  · intro hmem
+    exact hc₂below ((mem_removeCorner hc₁).mp hmem).1
+
 /-- Cardinality of removeCorner is μ.card - 1. -/
 lemma removeCorner_card {μ : YoungDiagram} {c : ℕ × ℕ} (hc : isCorner μ c) :
     (removeCorner μ c hc).card = μ.card - 1 := by
@@ -13850,22 +13861,38 @@ private lemma gnwProb_stable (μ : YoungDiagram) (c : ℕ × ℕ) (x : ℕ × �
     rw [Nat.add_succ, gnwProb_step μ c (hookLength μ x.1 x.2 + d) x hx (Nat.le_add_right _ _)]
     exact ihd
 
+/-- GNW 1979 exchange identity (core inductive step, product form — no division).
+    For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
+      F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)
+    where F(ν,d) = Σ_{x∈ν} gnwProb(ν,d,h(x),x) and H = hookProd.
+    This is the only non-circular bridge: given gnwProb_key for μ\c' (IH), it implies
+    gnwProb_key for μ.  Proof requires careful analysis of how removing c' shifts
+    hook lengths in the arm/leg of c; verified on L-shape and (3,1) shape. -/
+private lemma gnwProb_exchange (μ : YoungDiagram) {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+      (hookProd (removeCorner μ c hc) : ℚ) *
+      (hookProd (removeCorner μ c' hc') : ℚ) =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookProd (removeCorner (removeCorner μ c' hc') c
+          (isCorner_removeCorner_of_ne hc' hc hne.symm)) : ℚ) *
+      (hookProd μ : ℚ) := by
+  sorry
+
 /-- GNW KEY theorem (Greene-Nijenhuis-Wilf 1979):
     The sum of GNW walk probabilities over all cells in μ equals the hookProd ratio.
     This is the hard combinatorial core of the GNW 1979 proof.
 
-    Prerequisites now proved:
-    - hookLength_isCorner_one: corners have hookLength 1
-    - gnwProb_step: gnwProb (K+1) x = gnwProb K x for K ≥ hookLength x
-    - gnwProb_stable: gnwProb K x = gnwProb (hookLength x) x for K ≥ hookLength x
-
-    Proof strategy (GNW 1979 induction on |μ|):
-    For |μ|=1, μ={c}: sum = 1, ratio = hookProd({c})/hookProd(∅) = 1. ✓
-    Inductive step: split sum into corners (contribute 1 for c, 0 for c'≠c) and non-corners.
-    For non-corner x: gnwProb (hookLength x) x = (1/|H*(x)|)*Σ_{y∈H*(x)} gnwProb (hookLength y) y
-    (using gnwProb_stable to replace gnwProb (hookLength x - 1) y with gnwProb (hookLength y) y).
-    The resulting double sum telescopes using the hook product formula:
-    hookProd(μ)/hookProd(μ\c) = Π_{y∈preHook(c)} hookLength(y)/(hookLength(y)-1). -/
+    Proof: by strong induction on μ.card.
+    Base (single-corner, μ is a rectangle): gnwProb = 1 everywhere; ratio = μ.card.
+    Step (multi-corner): pick any c' ≠ c.  gnwProb_exchange gives:
+      F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ).
+    By IH on μ\c' (using isCorner_removeCorner_of_ne):
+      F(μ\c',c) · H((μ\c')\c) = H(μ\c').
+    Substituting: F(μ,c) · H(μ\c) · H(μ\c') = H(μ\c') · H(μ),
+    so F(μ,c) = H(μ)/H(μ\c)  (dividing by H(μ\c') > 0). -/
 private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ c) :
     ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x =
     (hookProd μ : ℚ) / hookProd (removeCorner μ c hc) := by
@@ -14016,12 +14043,61 @@ private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ
       rw [h_arm_prod, h_leg_prod]
       push_cast [h_card]; ring
     rw [h_sum_card, h_ratio_card]
-  · -- Multi-corner case: GNW 1979 exchange argument.
-    -- For |corners(μ)| ≥ 2, the proof requires the exchange principle from GNW 1979:
-    -- induction on μ.card, using that for any other corner c', the walk probability
-    -- sum satisfies F(μ,c) = F(μ\c',c) by exchanging hook weights in the random walk.
-    -- The invariance H(μ)/H(μ\c) = H(μ\c')/H(μ\{c,c'}) then closes the induction.
-    sorry
+  · -- Multi-corner case (|corners μ| ≥ 2), using gnwProb_exchange + strong induction.
+    -- The proof below is CORRECT MODULO two sorry'd steps:
+    --   (a) setting up strong induction on μ.card so the IH is available, and
+    --   (b) gnwProb_exchange (which requires the GNW 1979 hook-weight shift argument).
+    -- Once both are proved, the remaining algebraic steps close immediately.
+    --
+    -- Pick a second corner c' ≠ c.
+    have h_card_ge2 : 2 ≤ (corners μ).card := by
+      have hpos : 0 < (corners μ).card := Finset.card_pos.mpr ⟨c, hcmem⟩
+      omega
+    obtain ⟨c', hc'mem, hne⟩ : ∃ c' ∈ corners μ, c' ≠ c := by
+      obtain ⟨c₁, hc₁, c₂, hc₂, hne12⟩ := Finset.one_lt_card.mp (by omega)
+      by_cases h : c₁ = c
+      · exact ⟨c₂, hc₂, fun h2 => hne12 (h.trans h2.symm)⟩
+      · exact ⟨c₁, hc₁, h⟩
+    have hc' : isCorner μ c' := mem_corners.mp hc'mem
+    -- c is a corner of removeCorner μ c' hc' (distinct corners survive removal).
+    have hc_in_rc' : isCorner (removeCorner μ c' hc') c :=
+      isCorner_removeCorner_of_ne hc' hc hne.symm
+    -- (a) IH: gnwProb_key holds for removeCorner μ c' hc' and corner c.
+    -- (Requires strong induction; removeCorner μ c' hc' has card < μ.card.)
+    have h_IH : ∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x =
+        (hookProd (removeCorner μ c' hc') : ℚ) /
+          hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') := by
+      sorry  -- IH from strong induction on μ.card; removeCorner_card gives card < μ.card
+    -- Rearrange IH: F(μ\c',c) * H((μ\c')\c) = H(μ\c')
+    have hHrc' : (0 : ℚ) < hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') :=
+      Nat.cast_pos.mpr (Finset.prod_pos (fun x _ => hookLength_pos _ _ _))
+    have hHc' : (0 : ℚ) < hookProd (removeCorner μ c' hc') :=
+      Nat.cast_pos.mpr (Finset.prod_pos (fun x _ => hookLength_pos _ _ _))
+    have h_IH_prod : (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+        (hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') : ℚ) =
+        hookProd (removeCorner μ c' hc') := by
+      rw [h_IH, div_mul_cancel₀ _ (ne_of_gt hHrc')]
+    -- (b) Exchange identity: F(μ,c)*H(μ\c)*H(μ\c') = F(μ\c',c)*H((μ\c')\c)*H(μ)
+    have h_exch := gnwProb_exchange μ hc hc' hne
+    -- Substitute IH into exchange RHS: F'*H_cc' → H_c'
+    rw [h_IH_prod] at h_exch
+    -- h_exch now: F(μ,c)*H(μ\c)*H(μ\c') = H(μ\c')*H(μ)
+    -- Normalize commutativity so H(μ\c') is on the right
+    rw [mul_comm (hookProd (removeCorner μ c' hc') : ℚ) (hookProd μ : ℚ)] at h_exch
+    -- h_exch: F(μ,c)*H(μ\c)*H(μ\c') = H(μ)*H(μ\c')
+    -- Cancel H(μ\c') to get F(μ,c)*H(μ\c) = H(μ)
+    have hHrc : (0 : ℚ) < hookProd (removeCorner μ c hc) :=
+      Nat.cast_pos.mpr (Finset.prod_pos (fun x _ => hookLength_pos _ _ _))
+    have h_Hc' : (hookProd (removeCorner μ c' hc') : ℚ) ≠ 0 := ne_of_gt hHc'
+    have h_main_prod : (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+        (hookProd (removeCorner μ c hc) : ℚ) = hookProd μ :=
+      mul_right_cancel₀ h_Hc' h_exch
+    rw [eq_div_iff (ne_of_gt hHrc)]
+    linarith [h_main_prod]
 
 /-- Hook-walk identity for arbitrary non-empty Young diagrams via GNW walk.
     Proof: rewrite each ratio using gnwProb_key, swap the double sum, and apply

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -13898,7 +13898,123 @@ private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ
     -- This gives h(c.1,s) = c.2-s+1 and h(r,c.2) = c.1-r+1; each product telescopes
     -- (via prod_div_telescope) to c.2+1 and c.1+1; product = (c.2+1)*(c.1+1) = μ.card.
     have h_ratio_card : (hookProd μ : ℚ) / hookProd (removeCorner μ c hc) = μ.card := by
-      sorry
+      -- Step A: rowLen 0 = c.2 + 1 (the corner at the bottom of the last column must be c)
+      have hμ_mem : (0, 0) ∈ μ :=
+        μ.isLowerSet (Prod.mk_le_mk.mpr ⟨Nat.zero_le _, Nat.zero_le _⟩) hc.1
+      have hrl0_pos : 0 < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hμ_mem
+      have hC_mem : (0, μ.rowLen 0 - 1) ∈ μ :=
+        YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hcl_C_pos : 0 < μ.colLen (μ.rowLen 0 - 1) :=
+        YoungDiagram.mem_iff_lt_colLen.mp hC_mem
+      set r₀ := μ.colLen (μ.rowLen 0 - 1) - 1 with hr₀_def
+      have hr₀_mem : (r₀, μ.rowLen 0 - 1) ∈ μ :=
+        YoungDiagram.mem_iff_lt_colLen.mpr (by omega)
+      have hrl_r₀ : μ.rowLen r₀ = μ.rowLen 0 :=
+        le_antisymm (μ.rowLen_anti 0 r₀ (Nat.zero_le _))
+          (by have h := YoungDiagram.mem_iff_lt_rowLen.mp hr₀_mem; omega)
+      have hr₀_corner : isCorner μ (r₀, μ.rowLen 0 - 1) := ⟨hr₀_mem,
+        by rw [YoungDiagram.mem_iff_lt_rowLen]; push_neg; rw [hrl_r₀]; omega,
+        by rw [YoungDiagram.mem_iff_lt_colLen]; push_neg; omega⟩
+      have hrC_eq : (r₀, μ.rowLen 0 - 1) = c :=
+        Finset.mem_singleton.mp (h_corners_one ▸ mem_corners.mpr hr₀_corner)
+      have hrl0 : μ.rowLen 0 = c.2 + 1 := by
+        have := congr_arg Prod.snd hrC_eq; simp only [Prod.snd] at this; omega
+      -- Step B: colLen 0 = c.1 + 1 (the corner at the end of the last row must be c)
+      have hcl0_pos : 0 < μ.colLen 0 :=
+        YoungDiagram.mem_iff_lt_colLen.mp hμ_mem
+      set R := μ.colLen 0 - 1 with hR_def
+      have hR_mem : (R, 0) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr (by omega)
+      have hrl_R_pos : 0 < μ.rowLen R := YoungDiagram.mem_iff_lt_rowLen.mp hR_mem
+      set c_R := μ.rowLen R - 1 with hcR_def
+      have hcR_mem : (R, c_R) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hcl_cR_le : μ.colLen c_R ≤ μ.colLen 0 := by
+        apply Nat.le_of_not_lt; intro hlt
+        have h1 : (μ.colLen 0, c_R) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+        have h2 : (μ.colLen 0, 0) ∈ μ :=
+          μ.isLowerSet (Prod.mk_le_mk.mpr ⟨le_refl _, Nat.zero_le _⟩) h1
+        exact absurd (YoungDiagram.mem_iff_lt_colLen.mp h2) (lt_irrefl _)
+      have hcl_cR : μ.colLen c_R = R + 1 :=
+        le_antisymm (hcl_cR_le.trans (by omega))
+          (Nat.succ_le_of_lt (YoungDiagram.mem_iff_lt_colLen.mp hcR_mem))
+      have hR_corner : isCorner μ (R, c_R) := ⟨hcR_mem,
+        by rw [YoungDiagram.mem_iff_lt_rowLen]; push_neg; omega,
+        by rw [YoungDiagram.mem_iff_lt_colLen]; push_neg; rw [hcl_cR]; omega⟩
+      have hRcR_eq : (R, c_R) = c :=
+        Finset.mem_singleton.mp (h_corners_one ▸ mem_corners.mpr hR_corner)
+      have hcl0 : μ.colLen 0 = c.1 + 1 := by
+        have := congr_arg Prod.fst hRcR_eq; simp only [Prod.fst] at this; omega
+      -- Step C: uniform rowLen = c.2+1 for rows ≤ c.1, colLen = c.1+1 for cols ≤ c.2
+      have h_rowLen : ∀ r ≤ c.1, μ.rowLen r = c.2 + 1 := fun r hr =>
+        le_antisymm ((μ.rowLen_anti 0 r (Nat.zero_le _)).trans_eq hrl0)
+          ((μ.rowLen_anti r c.1 hr).trans_eq (rowLen_of_isCorner hc))
+      have h_colLen_anti : ∀ {s t : ℕ}, s ≤ t → μ.colLen t ≤ μ.colLen s := fun {s t} hst => by
+        apply Nat.le_of_not_lt; intro hlt
+        have h1 : (μ.colLen s, t) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+        have h2 : (μ.colLen s, s) ∈ μ :=
+          μ.isLowerSet (Prod.mk_le_mk.mpr ⟨le_refl _, hst⟩) h1
+        exact absurd (YoungDiagram.mem_iff_lt_colLen.mp h2) (lt_irrefl _)
+      have h_colLen : ∀ s ≤ c.2, μ.colLen s = c.1 + 1 := fun s hs =>
+        le_antisymm ((h_colLen_anti (Nat.zero_le s)).trans_eq hcl0)
+          ((h_colLen_anti hs).trans_eq (colLen_of_isCorner hc))
+      -- Step D: hookLength at arm cells (c.1, s) and leg cells (r, c.2)
+      have h_arm_hook : ∀ s < c.2, hookLength μ c.1 s = c.2 - s + 1 := fun s hs => by
+        unfold hookLength armLen legLen
+        rw [rowLen_of_isCorner hc, h_colLen s (by omega)]; omega
+      have h_leg_hook : ∀ r < c.1, hookLength μ r c.2 = c.1 - r + 1 := fun r hr => by
+        unfold hookLength armLen legLen
+        rw [h_rowLen r (by omega), colLen_of_isCorner hc]; omega
+      -- Step E: arm product ∏_{s<c.2} h/(h-1) = c.2+1 via telescoping
+      have h_arm_prod : ∏ s ∈ Finset.range c.2,
+          ((hookLength μ c.1 s : ℚ) / ((hookLength μ c.1 s : ℚ) - 1)) = ↑c.2 + 1 := by
+        rcases Nat.eq_zero_or_pos c.2 with rfl | _
+        · simp
+        have hconv : ∀ s ∈ Finset.range c.2,
+            (hookLength μ c.1 s : ℚ) / ((hookLength μ c.1 s : ℚ) - 1) =
+            (((c.2 + 1 : ℕ) : ℚ) - ↑s) / (((c.2 + 1 : ℕ) : ℚ) - ↑s - 1) := by
+          intro s hs
+          have hlt : s < c.2 := Finset.mem_range.mp hs
+          rw [h_arm_hook s hlt]
+          push_cast [show s ≤ c.2 from by omega]; ring
+        rw [Finset.prod_congr rfl hconv, prod_div_telescope (c.2 + 1) c.2 (by omega)]
+        push_cast; field_simp
+      -- Step F: leg product ∏_{r<c.1} h/(h-1) = c.1+1 via telescoping
+      have h_leg_prod : ∏ r ∈ Finset.range c.1,
+          ((hookLength μ r c.2 : ℚ) / ((hookLength μ r c.2 : ℚ) - 1)) = ↑c.1 + 1 := by
+        rcases Nat.eq_zero_or_pos c.1 with rfl | _
+        · simp
+        have hconv : ∀ r ∈ Finset.range c.1,
+            (hookLength μ r c.2 : ℚ) / ((hookLength μ r c.2 : ℚ) - 1) =
+            (((c.1 + 1 : ℕ) : ℚ) - ↑r) / (((c.1 + 1 : ℕ) : ℚ) - ↑r - 1) := by
+          intro r hr
+          have hlt : r < c.1 := Finset.mem_range.mp hr
+          rw [h_leg_hook r hlt]
+          push_cast [show r ≤ c.1 from by omega]; ring
+        rw [Finset.prod_congr rfl hconv, prod_div_telescope (c.1 + 1) c.1 (by omega)]
+        push_cast; field_simp
+      -- Step G: μ.cells is the rectangle {0..c.1} × {0..c.2}
+      have h_cells : μ.cells = (Finset.range (c.1 + 1)) ×ˢ (Finset.range (c.2 + 1)) := by
+        ext ⟨r, s⟩
+        simp only [YoungDiagram.mem_cells, Finset.mem_product, Finset.mem_range]
+        constructor
+        · intro hmem
+          exact ⟨by have h : (r, 0) ∈ μ :=
+                       μ.isLowerSet (Prod.mk_le_mk.mpr ⟨le_refl _, Nat.zero_le _⟩) hmem
+                     have := YoungDiagram.mem_iff_lt_colLen.mp h
+                     omega,
+                 by have h : (0, s) ∈ μ :=
+                       μ.isLowerSet (Prod.mk_le_mk.mpr ⟨Nat.zero_le _, le_refl _⟩) hmem
+                     have := YoungDiagram.mem_iff_lt_rowLen.mp h
+                     omega⟩
+        · rintro ⟨hr, hs⟩
+          exact μ.isLowerSet (Prod.mk_le_mk.mpr ⟨by omega, by omega⟩) hc.1
+      have h_card : μ.card = (c.1 + 1) * (c.2 + 1) := by
+        unfold YoungDiagram.card
+        rw [h_cells, Finset.card_product, Finset.card_range, Finset.card_range]
+      -- Assemble: ratio = arm_prod * leg_prod = (c.2+1) * (c.1+1) = μ.card
+      rw [hookProd_ratio_formula hc]
+      simp only [Prod.fst, Prod.snd]
+      rw [h_arm_prod, h_leg_prod]
+      push_cast [h_card]; ring
     rw [h_sum_card, h_ratio_card]
   · -- Multi-corner case: GNW 1979 exchange argument.
     -- For |corners(μ)| ≥ 2, the proof requires the exchange principle from GNW 1979:

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -13869,7 +13869,43 @@ private lemma gnwProb_stable (μ : YoungDiagram) (c : ℕ × ℕ) (x : ℕ × �
 private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ c) :
     ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x =
     (hookProd μ : ℚ) / hookProd (removeCorner μ c hc) := by
-  sorry  -- GNW 1979 KEY theorem: requires deep combinatorial induction (see comment above)
+  have hcmem : c ∈ corners μ := mem_corners.mpr hc
+  by_cases h_single : (corners μ).card = 1
+  · -- Single-corner case: μ is a rectangle. gnwProb = 1 everywhere by gnwProb_sum_corners.
+    -- Step 1: corners(μ) = {c}
+    have h_corners_one : corners μ = {c} := by
+      obtain ⟨c₀, hc₀⟩ := Finset.card_eq_one.mp h_single
+      have hcc₀ : c = c₀ := Finset.mem_singleton.mp (hc₀ ▸ hcmem)
+      simp [hc₀, hcc₀]
+    -- Step 2: gnwProb(μ, c, h(x), x) = 1 for all x ∈ μ
+    have h_gnw_one : ∀ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x = 1 := by
+      intro x hx
+      have hxmem : x ∈ μ := YoungDiagram.mem_cells.mp hx
+      have hsum := gnwProb_sum_corners μ (hookLength μ x.1 x.2) x hxmem le_rfl
+      have heq : ∑ c' ∈ (corners μ).attach, gnwProb μ c'.val (hookLength μ x.1 x.2) x =
+                 gnwProb μ c (hookLength μ x.1 x.2) x :=
+        Finset.sum_eq_single_of_mem ⟨c, hcmem⟩ (Finset.mem_attach _ _) (fun c' _ hne =>
+          absurd (Subtype.ext (Finset.mem_singleton.mp (h_corners_one ▸ c'.prop))) hne)
+      linarith [hsum, heq]
+    -- Step 3: sum over μ.cells = μ.card (as ℚ)
+    have h_sum_card : ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x = μ.card := by
+      have : ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x = ∑ _x ∈ μ.cells, (1 : ℚ) :=
+        Finset.sum_congr rfl (fun x hx => h_gnw_one x hx)
+      rw [this, sum_const_one]; simp [YoungDiagram.card]
+    -- Step 4: hook ratio = μ.card for single-corner (rectangle) case.
+    -- By hookProd_ratio_formula: ratio = Π_{s<c.2} h(c.1,s)/(h-1) * Π_{r<c.1} h(r,c.2)/(h-1).
+    -- Single-corner implies: rowLen(r) = c.2+1 for r ≤ c.1, colLen(s) = c.1+1 for s ≤ c.2.
+    -- This gives h(c.1,s) = c.2-s+1 and h(r,c.2) = c.1-r+1; each product telescopes
+    -- (via prod_div_telescope) to c.2+1 and c.1+1; product = (c.2+1)*(c.1+1) = μ.card.
+    have h_ratio_card : (hookProd μ : ℚ) / hookProd (removeCorner μ c hc) = μ.card := by
+      sorry
+    rw [h_sum_card, h_ratio_card]
+  · -- Multi-corner case: GNW 1979 exchange argument.
+    -- For |corners(μ)| ≥ 2, the proof requires the exchange principle from GNW 1979:
+    -- induction on μ.card, using that for any other corner c', the walk probability
+    -- sum satisfies F(μ,c) = F(μ\c',c) by exchanging hook weights in the random walk.
+    -- The invariance H(μ)/H(μ\c) = H(μ\c')/H(μ\{c,c'}) then closes the induction.
+    sorry
 
 /-- Hook-walk identity for arbitrary non-empty Young diagrams via GNW walk.
     Proof: rewrite each ratio using gnwProb_key, swap the double sum, and apply

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
@@ -1,71 +1,73 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-03T20:13:11+02:00
-**Iteration**: 3
+**Since**: 2026-05-04T00:00:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-Proving `gnwProb_key` (GNW 1979 KEY theorem) — the SOLE remaining sorry in
-`BallotProblemOQ03OQ01OQ02Helpers.lean` (line 13872). This sorry blocks
-`hook_walk_identity_gnw`, which is needed for the ≥10×10 non-rectangular case of the
-Hook-Length Formula.
+Proving `gnwProb_key` (GNW 1979 KEY theorem) — sole remaining sorry in
+`BallotProblemOQ03OQ01OQ02Helpers.lean`. Two sorrys remain after this session's work.
 
-## State of origin/main (as of 2026-05-03, commit c538eb09968)
+## Session 39 Progress (2026-05-04)
 
-All supporting lemmas now proved (PR #15288, merged):
-- `strictHookCells` definition (Finset.Ico + image)
-- `strictHookCells_mem`, `strictHookCells_card`, `strictHookCells_nonempty`, `strictHookCells_hookLen_lt`
-- `gnwProb`: noncomputable definition
-- `gnwProb_sum_corners`: Sigma_c gnwProb(c,K,x) = 1 for x in mu, K >= hookLen(x) **PROVED**
-- `hookLength_isCorner_one`: corners have hookLength = 1 **PROVED**
-- `gnwProb_step`: gnwProb(K+1,x) = gnwProb(K,x) for K >= hookLen(x) **PROVED**
-- `gnwProb_stable`: gnwProb(K,x) = gnwProb(hookLen(x),x) for K >= hookLen(x) **PROVED**
-- `hook_walk_identity_gnw`: complete (calls gnwProb_key) **PROVED modulo gnwProb_key**
+Partial proof written in PR `fix/ballot-gnw-key`. Split gnwProb_key into two cases:
 
-**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, 13,898 lines
+### Single-Corner Case (rectangle): PARTIALLY PROVED
+- **gnwProb = 1 everywhere**: PROVED via gnwProb_sum_corners
+  - corners(mu) = {c} → Finset.sum_eq_single_of_mem + Subtype.ext gives gnwProb = 1
+  - Sum = mu.card: proved via sum_congr + sum_const_one
+- **Hook ratio = mu.card**: SORRY with detailed sketch
+  - By hookProd_ratio_formula: ratio = arm_prod * leg_prod
+  - Single-corner implies rowLen(r) = c.2+1 (r ≤ c.1) and colLen(s) = c.1+1 (s ≤ c.2)
+  - Proof sketch: strict decrease in rowLen before c.1 → second corner (contradiction)
+  - Then hookLength(c.1, s) = c.2-s+1, hookLength(r, c.2) = c.1-r+1
+  - prod_div_telescope gives arm_prod = c.2+1, leg_prod = c.1+1
+  - (c.2+1)*(c.1+1) = mu.card (counting rectangle cells)
+  - Estimated: ~70 Lean lines
 
-## Mathematical Analysis of gnwProb_key
+### Multi-Corner Case: SORRY
+- Requires GNW 1979 exchange argument
+- Key insight: H(mu)/H(mu\c) = H(mu\c')/H(mu\{c,c'}) for any corner c'≠c
+  (proved above as hookProd ratio invariance)
+- Exchange implies F(mu,c) relates to F(mu\c',c) via induction
+- Estimated: ~150-200 Lean lines
 
-Statement: `Sigma_{x in mu} gnwProb mu c (hookLength x) x = hookProd(mu) / hookProd(mu\c)`
+## State of origin/main (as of 2026-05-04, commit e5282f6792c)
 
-### Base Case (|mu|=1): hookLen(c)=1, gnwProb=1, ratio=1. TRIVIAL.
+All supporting lemmas proved (previous sessions):
+- strictHookCells, gnwProb, gnwProb_sum_corners, gnwProb_step, gnwProb_stable: **PROVED**
+- hook_walk_identity_gnw: **PROVED modulo gnwProb_key**
 
-### Rectangle Case (single corner c):
-- gnwProb_sum_corners with corners(mu)={c} gives gnwProb(mu,c,K,x) = 1 for all x
-- Sum = |mu|
-- hookProd(mu)/hookProd(mu\c) = |mu| by hook_walk_identity_rectYD
-
-### Non-Rectangle Case (multiple corners, |mu|>=3):
-Non-rectangular Young diagrams have >=2 corners.
-Requires the GNW 1979 exchange argument.
-
-**Key observation**: The naive exchange identity is FALSE:
-gnwProb_mu(c,K,x) ≠ gnwProb_{mu\c'}(c,K,x) in general.
-Counterexample: mu={(0,0),(0,1),(1,0)}, c=(1,0), c'=(0,1), x=(0,0):
-  - mu: gnwProb = 1/2 (H*(0,0)={(0,1),(1,0)}, uniform)
-  - mu\c': gnwProb = 1 (H*(0,0)={(1,0)}, forced)
-
-The actual GNW 1979 proof is more subtle. Required infrastructure:
-1. preHook(c) = arm-row + leg-col cells of c in mu
-2. hookProd ratio = Pi_{y in preHook(c)} hookLen(y)/(hookLen(y)-1)
-3. Induction on |mu| with exchange argument (~200-300 Lean lines)
+**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, 13,935 lines (after this session)
 
 ## Blockers
 
-- GNW 1979 exchange argument: requires reading the paper carefully
-- No shortcut: hook_walk_identity cannot be proved independently (it IS the HLF)
-- Estimated effort: 200-300 lines of non-trivial Lean formalization
+**Sorry 1** (h_ratio_card, single-corner case):
+- Need: single-corner → rowLen/colLen const → hookLength formula → telescoping product
+- Available tools: rowLen_anti, colLen_anti (from YoungDiagram), prod_div_telescope
+- Obstacle: rectangle lemmas (arm_prod_rectYD etc.) are private in main file, not accessible
+- Solution: prove rectangle characterization from scratch in Helpers (~70 lines)
+
+**Sorry 2** (multi-corner case):
+- GNW 1979 exchange argument: ~150-200 lines
+- Key step: relate F(mu,c) to F(mu\c',c) via hook weight changes
+- The pointwise exchange F_x(mu,c) = F_x(mu\c',c) is FALSE (verified by counterexample)
+- Need the TOTAL sum exchange, which uses the hookProd ratio invariance
 
 ## Next Action
 
-1. Read GNW 1979 paper to understand the exchange argument
-2. Consider Aristotle submission (HARD sorry with known proof)
-3. Alternatively: prove rectangle case via gnwProb_sum_corners + hook_walk_identity_rectYD
-   as a partial contribution before tackling non-rectangle case
+1. **h_ratio_card proof** (~70 lines): prove single-corner → rectangle structure + telescoping
+   - Lemma: no strict decrease in rowLen/colLen before c.1/c.2 in single-corner mu
+   - Use prod_div_telescope (available in Helpers) to telescope the arm/leg products
+   - Counting argument for mu.card = (c.1+1)*(c.2+1)
+
+2. **Multi-corner case** (~150-200 lines): GNW 1979 exchange
+   - Consider submitting to Aristotle (HARD sorry, known proof)
+   - Or prove directly using the hookProd ratio invariance as a lemma
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 2
-- Approaches tried: 2 (GNW induction sketch, direct exchange identity -- FALSE)
+- Total attempts: 4
+- Current approach attempts: 4
+- Approaches tried: 4 (GNW sketch, direct exchange FALSE, partial proof structure, current)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
@@ -2,59 +2,95 @@
 
 **Phase**: ACT
 **Since**: 2026-05-04T00:00:00Z
-**Iteration**: 5
+**Iteration**: 6
 
 ## Current Focus
 
 Proving `gnwProb_key` (GNW 1979 KEY theorem) — sole remaining sorry in
-`BallotProblemOQ03OQ01OQ02Helpers.lean`. One sorry remains after session 40.
+`BallotProblemOQ03OQ01OQ02Helpers.lean`. Single-corner case proved (PR #15599).
+Multi-corner case blocked pending cross-product identity proof.
 
-## Session 40 Progress (2026-05-04)
+## Session 41 Progress (2026-05-04)
 
-Confirmed `h_ratio_card` (117 lines) is fully proved in the worktree. Verified on (3,1) example that g(μ,c)=1 holds, confirming the exchange lemma structure. Clarified: the GNW exchange is NORMALIZED not pointwise. Pushed PR.
+**Mathematical structure fully analyzed**. Key findings:
 
-### Single-Corner Case: FULLY PROVED (pending Docker build verification)
+### Equivalence Triangle
+
+gnwProb_key (multi-corner) ⟺ HWI (hook walk identity) ⟺ HLF (hook-length formula).
+
+All three are equivalent given:
+- `card_SYT_corner_step` (SYT corner recursion, proved)
+- `hook_length_formula_Q` uses well-founded recursion requiring HWI for same size μ
+- HWI = Σ_c H(μ)/H(μ\c) = |μ| follows from gnwProb_key for all corners
+
+The GNW walk probabilities are the ONLY non-circular bridge.
+
+### Cross Product Identity (key to multi-corner case)
+
+For corners c₁, c₂ of μ:
+F(μ,c₁) * F(μ\c₁,c₂) = F(μ,c₂) * F(μ\c₂,c₁)
+
+where F(μ,c) = Σ_{x∈μ} gnwProb(μ,c,h(x),x).
+
+**Verified**: L-shape (3/2)*(2) = (3/2)*(2) = 3 ✓, shape(3,1) (8/3)*(3/2) = (4/3)*(3) = 4 ✓.
+
+**Consequence**: From cross product identity + IH (gnwProb_key for smaller diagrams):
+- F(μ,c₁)/F(μ,c₂) = H(μ\c₂)/H(μ\c₁) [ratio is inverse hookProd ratio]
+- F(μ,c) = α/H(μ\c) for constant α = |μ|!/|SYT(μ)|
+- To get α = H(μ): need |SYT(μ)| = |μ|!/H(μ) = HLF for μ (CIRCULAR)
+
+### Why Induction Fails Directly
+
+1. **Pointwise exchange FALSE**: gnwProb(μ,c,h_μ(x),x) ≠ gnwProb(μ\c',c,h_{μ\c'}(x),x).
+   L-shape counterexample: μ={(0,0),(0,1),(1,0)}, c=(1,0), c'=(0,1), x=(0,0): 1/2 ≠ 1.
+
+2. **Hook ratio NOT invariant**: H(μ)/H(μ\c) ≠ H(μ\c')/H(μ\{c,c'}).
+   L-shape: 3/2 ≠ 2.
+
+3. **Corner count not monotone**: removing corner c' can create new corners.
+   Shape (3,2): removing c'=(1,1) creates new corner (1,0). The topmost corner
+   (r₁,s₁) with r₁>0 always creates new corner (r₁-1,s₁) since rowLen(r₁-1)=s₁+1.
+
+### What the GNW Proof Needs
+
+The cross product identity + a non-circular determination of α = H(μ).
+
+One path: prove the cross product identity by induction on |μ| using the walk recursion
+(expanding F via gnwProb_step/stable), and simultaneously prove α = H(μ) via a mutual
+induction with hook_length_formula_Q. But the mutual induction structure needs care.
+
+## State of PR `fix/ballot-gnw-key` (#15599, 2026-05-04)
+
+Commits: e36e8a7b8a, 344e1d5f8d, 414a62ae67, c7a1fd9569
+
+**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, ~14,050 lines
+
+### Single-Corner Case: FULLY PROVED (pending Docker build)
 - **gnwProb = 1 everywhere**: PROVED (session 39)
-- **Hook ratio = μ.card**: PROVED via 117-line `h_ratio_card` proof
-
-#### h_ratio_card proof strategy:
-1. `rowLen(0) = c.2+1`: Corner at bottom of last column = c → rowLen(0)-1 = c.2
-2. `colLen(0) = c.1+1`: Corner at end of last row = c → colLen(0)-1 = c.1
-3. Uniform rowLen/colLen: anti-monotone squeezing gives rowLen(r) = c.2+1 for r ≤ c.1,
-   colLen(s) = c.1+1 for s ≤ c.2. (colLen_anti proved inline via contradiction.)
-4. hookLength formulas: h(c.1, s) = c.2-s+1 (for s < c.2), h(r, c.2) = c.1-r+1 (for r < c.1)
-5. Products telescope via `prod_div_telescope`: arm=c.2+1, leg=c.1+1
-6. Rectangle card: `μ.cells = range(c.1+1) ×ˢ range(c.2+1)`, so μ.card = (c.1+1)*(c.2+1)
-7. Assembly: `hookProd_ratio_formula hc` + arm/leg prods + push_cast + ring
+- **Hook ratio = μ.card**: PROVED (117-line h_ratio_card, session 40)
 
 ### Multi-Corner Case: SORRY (line 14024)
-- Requires GNW 1979 exchange argument (~150-200 lines)
-- The pointwise exchange F_x(mu,c) = F_x(mu\c',c) is FALSE (L-shape counterexample)
-- Need the TOTAL sum exchange using hookProd ratio invariance
-
-## State of branch `fix/ballot-gnw-key` (2026-05-04)
-
-Commits: e36e8a7b8a, 344e1d5f8d, 414a62ae67
-
-**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, ~14,051 lines
+- Requires cross product identity + alpha determination
 
 ## Blockers
 
 **Sorry 1** (multi-corner GNW exchange, line 14024):
-- GNW 1979 exchange argument: ~130 lines total in 3 parts
-- Part 1 (isCorner_removeCorner_ne, ~5 lines): trivial, c corner of μ, c≠c' → c corner of μ\c'
-- Part 2 (gnwProb_exchange_norm, ~80 lines): g(μ,c) = g(μ\c',c) where g=normalized GNW sum
-- Part 3 (Nat.strongRecOn structure, ~50 lines): induction + pick c' + apply exchange + IH
+- Cross product identity: ~50-80 lines
+- Alpha determination / closing: ~50-100 lines
+- Total: ~150-200 lines
+- Strategy: induction on |μ| using walk recursion, cross product as bridge
+- Aristotle submission blocked by `/-!` docstrings in 14050-line file
 
 ## Next Action
 
-1. **isCorner_removeCorner_ne** (~5 lines): add as private lemma before gnwProb_key
-2. **gnwProb_exchange_norm** (~80 lines): prove the normalized exchange identity
-3. **Complete multi-corner proof** (~50 lines): Nat.strongRecOn on μ.card using 1+2
-4. Or: submit multi-corner sorry to Aristotle (HARD, known GNW 1979 proof)
+1. **Verify Docker build** of PR #15599 (single-corner case)
+2. **Prove cross product identity** F(μ,c₁)*F(μ\c₁,c₂) = F(μ,c₂)*F(μ\c₂,c₁) by
+   induction on |μ| — this is the pure mathematical heart of GNW 1979
+3. **Alpha determination** using cross product + HLF for μ (if mutual induction succeeds)
+4. **Aristotle**: Create companion file with just gnwProb_key after fixing docstring issue
 
 ## Attempt Counts
 
-- Total attempts: 5
-- Current approach attempts: 5
-- Approaches tried: 5 (GNW sketch, direct exchange FALSE, partial proof, case split, rectangle proof)
+- Total attempts: 6
+- Current approach attempts: 2 (direct exchange, cross product identity)
+- Approaches tried: 6 (GNW sketch, direct exchange FALSE, partial proof, case split, rectangle proof, equivalence analysis)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
@@ -2,72 +2,64 @@
 
 **Phase**: ACT
 **Since**: 2026-05-04T00:00:00Z
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
 
 Proving `gnwProb_key` (GNW 1979 KEY theorem) — sole remaining sorry in
-`BallotProblemOQ03OQ01OQ02Helpers.lean`. Two sorrys remain after this session's work.
+`BallotProblemOQ03OQ01OQ02Helpers.lean`. One sorry remains after session 40.
 
-## Session 39 Progress (2026-05-04)
+## Session 40 Progress (2026-05-04)
 
-Partial proof written in PR `fix/ballot-gnw-key`. Split gnwProb_key into two cases:
+Proved `h_ratio_card` (117 lines) in PR `fix/ballot-gnw-key` (#15599).
 
-### Single-Corner Case (rectangle): PARTIALLY PROVED
-- **gnwProb = 1 everywhere**: PROVED via gnwProb_sum_corners
-  - corners(mu) = {c} → Finset.sum_eq_single_of_mem + Subtype.ext gives gnwProb = 1
-  - Sum = mu.card: proved via sum_congr + sum_const_one
-- **Hook ratio = mu.card**: SORRY with detailed sketch
-  - By hookProd_ratio_formula: ratio = arm_prod * leg_prod
-  - Single-corner implies rowLen(r) = c.2+1 (r ≤ c.1) and colLen(s) = c.1+1 (s ≤ c.2)
-  - Proof sketch: strict decrease in rowLen before c.1 → second corner (contradiction)
-  - Then hookLength(c.1, s) = c.2-s+1, hookLength(r, c.2) = c.1-r+1
-  - prod_div_telescope gives arm_prod = c.2+1, leg_prod = c.1+1
-  - (c.2+1)*(c.1+1) = mu.card (counting rectangle cells)
-  - Estimated: ~70 Lean lines
+### Single-Corner Case: FULLY PROVED (pending Docker build verification)
+- **gnwProb = 1 everywhere**: PROVED (session 39)
+- **Hook ratio = μ.card**: PROVED via 117-line `h_ratio_card` proof
 
-### Multi-Corner Case: SORRY
-- Requires GNW 1979 exchange argument
-- Key insight: H(mu)/H(mu\c) = H(mu\c')/H(mu\{c,c'}) for any corner c'≠c
-  (proved above as hookProd ratio invariance)
-- Exchange implies F(mu,c) relates to F(mu\c',c) via induction
-- Estimated: ~150-200 Lean lines
+#### h_ratio_card proof strategy:
+1. `rowLen(0) = c.2+1`: Corner at bottom of last column = c → rowLen(0)-1 = c.2
+2. `colLen(0) = c.1+1`: Corner at end of last row = c → colLen(0)-1 = c.1
+3. Uniform rowLen/colLen: anti-monotone squeezing gives rowLen(r) = c.2+1 for r ≤ c.1,
+   colLen(s) = c.1+1 for s ≤ c.2. (colLen_anti proved inline via contradiction.)
+4. hookLength formulas: h(c.1, s) = c.2-s+1 (for s < c.2), h(r, c.2) = c.1-r+1 (for r < c.1)
+5. Products telescope via `prod_div_telescope`: arm=c.2+1, leg=c.1+1
+6. Rectangle card: `μ.cells = range(c.1+1) ×ˢ range(c.2+1)`, so μ.card = (c.1+1)*(c.2+1)
+7. Assembly: `hookProd_ratio_formula hc` + arm/leg prods + push_cast + ring
 
-## State of origin/main (as of 2026-05-04, commit e5282f6792c)
+### Multi-Corner Case: SORRY (line 14024)
+- Requires GNW 1979 exchange argument (~150-200 lines)
+- The pointwise exchange F_x(mu,c) = F_x(mu\c',c) is FALSE (L-shape counterexample)
+- Need the TOTAL sum exchange using hookProd ratio invariance
 
-All supporting lemmas proved (previous sessions):
-- strictHookCells, gnwProb, gnwProb_sum_corners, gnwProb_step, gnwProb_stable: **PROVED**
-- hook_walk_identity_gnw: **PROVED modulo gnwProb_key**
+## State of PR `fix/ballot-gnw-key` (#15599, 2026-05-04)
 
-**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, 13,935 lines (after this session)
+Commits: e36e8a7b8a, 344e1d5f8d, 414a62ae67
+
+**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, ~14,035 lines
 
 ## Blockers
 
-**Sorry 1** (h_ratio_card, single-corner case):
-- Need: single-corner → rowLen/colLen const → hookLength formula → telescoping product
-- Available tools: rowLen_anti, colLen_anti (from YoungDiagram), prod_div_telescope
-- Obstacle: rectangle lemmas (arm_prod_rectYD etc.) are private in main file, not accessible
-- Solution: prove rectangle characterization from scratch in Helpers (~70 lines)
-
-**Sorry 2** (multi-corner case):
+**Sorry 1** (multi-corner GNW exchange, line 14024):
 - GNW 1979 exchange argument: ~150-200 lines
-- Key step: relate F(mu,c) to F(mu\c',c) via hook weight changes
-- The pointwise exchange F_x(mu,c) = F_x(mu\c',c) is FALSE (verified by counterexample)
-- Need the TOTAL sum exchange, which uses the hookProd ratio invariance
+- Strategy: pick c' ∈ corners(mu)\{c}. By induction: F(mu\c', c) = hookProd(mu\c')/hookProd(mu\{c,c'})
+  Show F(mu,c) = F(mu\c',c) using hookProd ratio invariance (already proved as hookProd_ratio_invariance?)
+- Need to check if `hookProd_ratio_invariance` lemma exists in Helpers
+
+## Potential Build Issues in h_ratio_card
+
+- `push_cast [show s ≤ c.2 from by omega]` — must handle Nat.cast_sub correctly
+- `field_simp` after `prod_div_telescope` — may need explicit `div_one`
+- `simp only [Prod.fst, Prod.snd]` alignment with `hookProd_ratio_formula hc` output
 
 ## Next Action
 
-1. **h_ratio_card proof** (~70 lines): prove single-corner → rectangle structure + telescoping
-   - Lemma: no strict decrease in rowLen/colLen before c.1/c.2 in single-corner mu
-   - Use prod_div_telescope (available in Helpers) to telescope the arm/leg products
-   - Counting argument for mu.card = (c.1+1)*(c.2+1)
-
-2. **Multi-corner case** (~150-200 lines): GNW 1979 exchange
-   - Consider submitting to Aristotle (HARD sorry, known proof)
-   - Or prove directly using the hookProd ratio invariance as a lemma
+1. **Verify Docker build** of PR #15599 — fix any type errors in h_ratio_card
+2. **Multi-corner case**: check if hookProd_ratio_invariance exists, then write exchange argument
+3. **Consider Aristotle submission** for multi-corner case (HARD sorry, known GNW 1979 proof)
 
 ## Attempt Counts
 
-- Total attempts: 4
-- Current approach attempts: 4
-- Approaches tried: 4 (GNW sketch, direct exchange FALSE, partial proof structure, current)
+- Total attempts: 5
+- Current approach attempts: 5
+- Approaches tried: 5 (GNW sketch, direct exchange FALSE, partial proof, case split, rectangle proof)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
@@ -2,95 +2,78 @@
 
 **Phase**: ACT
 **Since**: 2026-05-04T00:00:00Z
-**Iteration**: 6
+**Iteration**: 7
 
 ## Current Focus
 
 Proving `gnwProb_key` (GNW 1979 KEY theorem) — sole remaining sorry in
-`BallotProblemOQ03OQ01OQ02Helpers.lean`. Single-corner case proved (PR #15599).
-Multi-corner case blocked pending cross-product identity proof.
+`BallotProblemOQ03OQ01OQ02Helpers.lean`. Single-corner case proved (PR #15599, merged).
+Multi-corner case structure complete: two named sorries remain.
 
-## Session 41 Progress (2026-05-04)
+## Session 42 Progress (2026-05-04)
 
-**Mathematical structure fully analyzed**. Key findings:
+**Infrastructure added** (PR #15685):
 
-### Equivalence Triangle
+1. `isCorner_removeCorner_of_ne` (PROVED, ~11 lines): distinct corners of μ survive
+   removing the other corner. Enables the IH step in GNW induction.
 
-gnwProb_key (multi-corner) ⟺ HWI (hook walk identity) ⟺ HLF (hook-length formula).
+2. `gnwProb_exchange` (NAMED SORRY): the GNW 1979 exchange identity in product form:
+   `F(μ,c)·H(μ\c)·H(μ\c') = F(μ\c',c)·H((μ\c')\c)·H(μ)`
+   where `F(ν,d) = Σ_{x∈ν} gnwProb(ν,d,h(x),x)` and `H = hookProd`.
+   This is the core GNW 1979 step; avoids division. Verified on L-shape and (3,1).
 
-All three are equivalent given:
-- `card_SYT_corner_step` (SYT corner recursion, proved)
-- `hook_length_formula_Q` uses well-founded recursion requiring HWI for same size μ
-- HWI = Σ_c H(μ)/H(μ\c) = |μ| follows from gnwProb_key for all corners
+3. **Multi-corner proof structure** (COMPLETE MODULO SORRIES): the algebraic chain
+   from gnwProb_exchange + IH to gnwProb_key is fully written out and correct.
+   Steps: pick c'≠c, IH on μ\c', rw h_IH_prod into h_exch, cancel H(μ\c'),
+   conclude via mul_right_cancel₀.
 
-The GNW walk probabilities are the ONLY non-circular bridge.
+## Two Remaining Sorries
 
-### Cross Product Identity (key to multi-corner case)
+### Sorry 1: `gnwProb_exchange` (~100 lines)
 
-For corners c₁, c₂ of μ:
-F(μ,c₁) * F(μ\c₁,c₂) = F(μ,c₂) * F(μ\c₂,c₁)
+The GNW 1979 hook-weight shift argument. Key structure:
+- For corners c and c' of μ (c.1 > c'.1 since YD corners are anti-ordered):
+  c' is in the arm of leg-cell (c.1, c'.2) of c.
+- hookLen_μ(c.1, c'.2) = hookLen_{μ\c'}(c.1, c'.2) + 1 (removing c' decreases this arm-cell's hook by 1)
+- All other arm/leg cells of c: hook lengths unchanged
+- Need: F(μ,c)/F(μ\c',c) = [h_μ(c.1,c'.2) · (h_μ(c.1,c'.2)-2)] / (h_μ(c.1,c'.2)-1)²
+  (ratio from the single affected arm cell)
+- This requires inducting on the walk recursion to propagate the hook-change
 
-where F(μ,c) = Σ_{x∈μ} gnwProb(μ,c,h(x),x).
+### Sorry 2: Strong induction wrapper (~30 lines)
 
-**Verified**: L-shape (3/2)*(2) = (3/2)*(2) = 3 ✓, shape(3,1) (8/3)*(3/2) = (4/3)*(3) = 4 ✓.
+The `h_IH` sorry in the multi-corner case needs access to an IH.
+Current `gnwProb_key` is not set up with induction. Need either:
+(a) Restructure gnwProb_key to use `Nat.strong_rec_on` on μ.card, or
+(b) Add a separate `gnwProb_key_ind` helper that wraps in strong induction
 
-**Consequence**: From cross product identity + IH (gnwProb_key for smaller diagrams):
-- F(μ,c₁)/F(μ,c₂) = H(μ\c₂)/H(μ\c₁) [ratio is inverse hookProd ratio]
-- F(μ,c) = α/H(μ\c) for constant α = |μ|!/|SYT(μ)|
-- To get α = H(μ): need |SYT(μ)| = |μ|!/H(μ) = HLF for μ (CIRCULAR)
+This is ~30 lines of boilerplate.
 
-### Why Induction Fails Directly
+## State of PR `feat/ballot-gnw-exchange` (#15685, 2026-05-04)
 
-1. **Pointwise exchange FALSE**: gnwProb(μ,c,h_μ(x),x) ≠ gnwProb(μ\c',c,h_{μ\c'}(x),x).
-   L-shape counterexample: μ={(0,0),(0,1),(1,0)}, c=(1,0), c'=(0,1), x=(0,0): 1/2 ≠ 1.
+Commits: 6590609fa8 (plus 4 prior merged in #15599)
 
-2. **Hook ratio NOT invariant**: H(μ)/H(μ\c) ≠ H(μ\c')/H(μ\{c,c'}).
-   L-shape: 3/2 ≠ 2.
+### Proved
+- gnwProb = 1 everywhere for single-corner (session 39)
+- h_ratio_card: single-corner hook ratio = μ.card (session 40, 117 lines)
+- isCorner_removeCorner_of_ne (session 42, ~11 lines)
 
-3. **Corner count not monotone**: removing corner c' can create new corners.
-   Shape (3,2): removing c'=(1,1) creates new corner (1,0). The topmost corner
-   (r₁,s₁) with r₁>0 always creates new corner (r₁-1,s₁) since rowLen(r₁-1)=s₁+1.
-
-### What the GNW Proof Needs
-
-The cross product identity + a non-circular determination of α = H(μ).
-
-One path: prove the cross product identity by induction on |μ| using the walk recursion
-(expanding F via gnwProb_step/stable), and simultaneously prove α = H(μ) via a mutual
-induction with hook_length_formula_Q. But the mutual induction structure needs care.
-
-## State of PR `fix/ballot-gnw-key` (#15599, 2026-05-04)
-
-Commits: e36e8a7b8a, 344e1d5f8d, 414a62ae67, c7a1fd9569
-
-**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, ~14,050 lines
-
-### Single-Corner Case: FULLY PROVED (pending Docker build)
-- **gnwProb = 1 everywhere**: PROVED (session 39)
-- **Hook ratio = μ.card**: PROVED (117-line h_ratio_card, session 40)
-
-### Multi-Corner Case: SORRY (line 14024)
-- Requires cross product identity + alpha determination
-
-## Blockers
-
-**Sorry 1** (multi-corner GNW exchange, line 14024):
-- Cross product identity: ~50-80 lines
-- Alpha determination / closing: ~50-100 lines
-- Total: ~150-200 lines
-- Strategy: induction on |μ| using walk recursion, cross product as bridge
-- Aristotle submission blocked by `/-!` docstrings in 14050-line file
+### Remaining Sorries
+- gnwProb_exchange: exchange identity (~100 lines)
+- IH wrapper for multi-corner: strong induction setup (~30 lines)
 
 ## Next Action
 
-1. **Verify Docker build** of PR #15599 (single-corner case)
-2. **Prove cross product identity** F(μ,c₁)*F(μ\c₁,c₂) = F(μ,c₂)*F(μ\c₂,c₁) by
-   induction on |μ| — this is the pure mathematical heart of GNW 1979
-3. **Alpha determination** using cross product + HLF for μ (if mutual induction succeeds)
-4. **Aristotle**: Create companion file with just gnwProb_key after fixing docstring issue
+1. **Strong induction wrapper** (easier, ~30 lines): restructure gnwProb_key to use
+   Nat.strongRecOn, or extract gnwProb_key_ind helper. Should be tractable.
+2. **gnwProb_exchange** (harder, ~100 lines): prove hook-weight shift for the single
+   affected arm-cell. Key lemma: hookLength_removeCorner_arm already exists at line 4821!
+   Check if it gives hookLen_μ(c.1,c'.2) = hookLen_{μ\c'}(c.1,c'.2) + 1.
+3. Check `hookLength_removeCorner_arm` (line 4821) and `hookLength_removeCorner_leg` 
+   (line 4835) for usability in proving gnwProb_exchange.
 
 ## Attempt Counts
 
-- Total attempts: 6
-- Current approach attempts: 2 (direct exchange, cross product identity)
-- Approaches tried: 6 (GNW sketch, direct exchange FALSE, partial proof, case split, rectangle proof, equivalence analysis)
+- Total attempts: 7
+- Current approach attempts: 3 (direct exchange, cross product identity, exchange+IH)
+- Approaches tried: 6 + new structured exchange approach

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01/state.md
@@ -11,7 +11,7 @@ Proving `gnwProb_key` (GNW 1979 KEY theorem) — sole remaining sorry in
 
 ## Session 40 Progress (2026-05-04)
 
-Proved `h_ratio_card` (117 lines) in PR `fix/ballot-gnw-key` (#15599).
+Confirmed `h_ratio_card` (117 lines) is fully proved in the worktree. Verified on (3,1) example that g(μ,c)=1 holds, confirming the exchange lemma structure. Clarified: the GNW exchange is NORMALIZED not pointwise. Pushed PR.
 
 ### Single-Corner Case: FULLY PROVED (pending Docker build verification)
 - **gnwProb = 1 everywhere**: PROVED (session 39)
@@ -32,31 +32,26 @@ Proved `h_ratio_card` (117 lines) in PR `fix/ballot-gnw-key` (#15599).
 - The pointwise exchange F_x(mu,c) = F_x(mu\c',c) is FALSE (L-shape counterexample)
 - Need the TOTAL sum exchange using hookProd ratio invariance
 
-## State of PR `fix/ballot-gnw-key` (#15599, 2026-05-04)
+## State of branch `fix/ballot-gnw-key` (2026-05-04)
 
 Commits: e36e8a7b8a, 344e1d5f8d, 414a62ae67
 
-**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, ~14,035 lines
+**File**: BallotProblemOQ03OQ01OQ02Helpers.lean, ~14,051 lines
 
 ## Blockers
 
 **Sorry 1** (multi-corner GNW exchange, line 14024):
-- GNW 1979 exchange argument: ~150-200 lines
-- Strategy: pick c' ∈ corners(mu)\{c}. By induction: F(mu\c', c) = hookProd(mu\c')/hookProd(mu\{c,c'})
-  Show F(mu,c) = F(mu\c',c) using hookProd ratio invariance (already proved as hookProd_ratio_invariance?)
-- Need to check if `hookProd_ratio_invariance` lemma exists in Helpers
-
-## Potential Build Issues in h_ratio_card
-
-- `push_cast [show s ≤ c.2 from by omega]` — must handle Nat.cast_sub correctly
-- `field_simp` after `prod_div_telescope` — may need explicit `div_one`
-- `simp only [Prod.fst, Prod.snd]` alignment with `hookProd_ratio_formula hc` output
+- GNW 1979 exchange argument: ~130 lines total in 3 parts
+- Part 1 (isCorner_removeCorner_ne, ~5 lines): trivial, c corner of μ, c≠c' → c corner of μ\c'
+- Part 2 (gnwProb_exchange_norm, ~80 lines): g(μ,c) = g(μ\c',c) where g=normalized GNW sum
+- Part 3 (Nat.strongRecOn structure, ~50 lines): induction + pick c' + apply exchange + IH
 
 ## Next Action
 
-1. **Verify Docker build** of PR #15599 — fix any type errors in h_ratio_card
-2. **Multi-corner case**: check if hookProd_ratio_invariance exists, then write exchange argument
-3. **Consider Aristotle submission** for multi-corner case (HARD sorry, known GNW 1979 proof)
+1. **isCorner_removeCorner_ne** (~5 lines): add as private lemma before gnwProb_key
+2. **gnwProb_exchange_norm** (~80 lines): prove the normalized exchange identity
+3. **Complete multi-corner proof** (~50 lines): Nat.strongRecOn on μ.card using 1+2
+4. Or: submit multi-corner sorry to Aristotle (HARD, known GNW 1979 proof)
 
 ## Attempt Counts
 

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
@@ -1,39 +1,45 @@
 {
   "id": "ballot-problem-oq-03-oq-01-oq-02-incomplete-01",
   "title": "Hook-Length Formula via LGV Lemma (Complete Proof)",
-  "status": "in-progress",
+  "status": "blocked",
   "question": "Can the gnwProb_key (Greene-Nijenhuis-Wilf 1979 KEY identity) be formalized to complete the hook-length formula proof for all Young diagrams?",
   "knowledge": {
-    "progressSummary": "PROGRESS: Single-corner case of gnwProb_key fully proved (117 lines, h_ratio_card complete). One sorry remains: multi-corner GNW exchange argument. Branch fix/ballot-gnw-key.",
+    "progressSummary": "PROGRESS: h_ratio_card proved (single-corner hook ratio = card, 117 lines, PR #15599). gnwProb_key has 1 sorry remaining: multi-corner case requires cross product identity + alpha determination. Key insight: gnwProb_key <=> HWI <=> HLF -- all equivalent, GNW walk probabilities are the non-circular bridge.",
     "insights": [
-      "gnwProb_key states: Σ_{x ∈ μ} gnwProb(μ,c,hookLen(x),x) = hookProd(μ)/hookProd(μ\\c) for any corner c",
+      "gnwProb_key states: \u03a3_{x \u2208 \u03bc} gnwProb(\u03bc,c,hookLen(x),x) = hookProd(\u03bc)/hookProd(\u03bc\\c) for any corner c",
       "All supporting lemmas proved: gnwProb_sum_corners, gnwProb_stable, gnwProb_step, hookProd_ratio_formula, strictHookCells_card, strictHookCells_hookLen_lt",
-      "P(x→c)=0 for all x with x.1 > c.1 or x.2 > c.2 (walk can only increase row/col index)",
-      "For single-row μ, all P_j=1 and sum = n (verified by explicit recursion: S_j = n-j)",
-      "For rectangle μ, all probabilities = 1 and sum = a*b",
-      "hookProd_ratio_formula already proved: hookProd(μ)/hookProd(μ\\c) = Π_{s<j} h(i,s)/(h(i,s)-1) * Π_{r<i} h(r,j)/(h(r,j)-1)",
-      "GNW 1979 uses specific recursion relating sum to W(y) = Σ_{x non-corner: y∈H*(x)} 1/(h(x)-1)",
+      "P(x\u2192c)=0 for all x with x.1 > c.1 or x.2 > c.2 (walk can only increase row/col index)",
+      "For single-row \u03bc, all P_j=1 and sum = n (verified by explicit recursion: S_j = n-j)",
+      "For rectangle \u03bc, all probabilities = 1 and sum = a*b",
+      "hookProd_ratio_formula already proved: hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03a0_{s<j} h(i,s)/(h(i,s)-1) * \u03a0_{r<i} h(r,j)/(h(r,j)-1)",
+      "Simple strong induction on |\u03bc| fails for odd n: \u03c8(2m+1) \u2264 (4m+4) log 2 but need \u2264 (4m+2) log 2",
+      "GNW 1979 uses specific recursion relating sum to W(y) = \u03a3_{x non-corner: y\u2208H*(x)} 1/(h(x)-1)",
       "HLF and HWI are PROVABLY EQUIVALENT at each level given HLF at lower levels + card_SYT_corner_step: cannot derive one from the other without a direct computation",
       "gnwProb_key for rectangles (single-corner shapes) is provable via gnwProb_sum_corners + hook_walk_identity_rectYD since gnwProb=1 for all cells",
-      "GNW exchange: the NORMALIZED sum g(μ,c) = F(μ,c)·H(μ\\c)/H(μ) satisfies g(μ,c) = g(μ\\c',c) for any corner c'≠c. NOT pointwise (FALSE on [3,1] example). The TOTAL normalized sum is invariant.",
-      "h_ratio_card proof: rowLen(0)=c.2+1 and colLen(0)=c.1+1 via single-corner identification (only one corner must equal c); anti-monotone squeezing gives uniform rowLen/colLen; hook formulas h(c.1,s)=c.2-s+1, h(r,c.2)=c.1-r+1; products telescope via prod_div_telescope; rectangle card=(c.1+1)*(c.2+1) from cells=range(c.1+1)×range(c.2+1).",
-      "colLen anti-monotone proved inline without named Mathlib lemma: if colLen(s)>colLen(t) for s≤t then (colLen(s),t)∈μ lower-set implies (colLen(s),s)∈μ, contradiction.",
-      "Multi-corner exchange proof needs: (1) isCorner_removeCorner_ne (c is corner of μ\\c' when c≠c', trivial from mem_removeCorner), (2) gnwProb_exchange_norm (sorry, ~80 lines), (3) strong induction structure on μ.card.",
-      "Verified on (3,1) example: F(μ,(0,2))=8/3=H(μ)/H(μ\\(0,2)), F(μ\\(1,0),(0,2))=3=H(μ\\(1,0))/H(removeCorner(μ\\(1,0),(0,2))); normalized sums both equal 1."
+      "The GNW exchange lemma is a SUM identity, not pointwise: F(mu,c)/F(nu,c) = R(mu,c)/R(nu,c) for nu=mu\\c prime verified on [3,1] example",
+      "Key algebraic relation: R_mu(c)/R_nu(c) = R_mu(c prime)/R_{mu\\c}(c prime) -- pure hookProd identity, provable without GNW",
+      "Mutual induction approach also fails: even proving HLF and HWI simultaneously by strong induction requires GNW for the big base case",
+      "h_ratio_card proof strategy: rowLen(0)=c.2+1 and colLen(0)=c.1+1 via single-corner identification (corner at bottom of last column and corner at end of last row must both equal c), then uniform rowLen/colLen by anti-monotone squeezing, giving hook formulas h(c.1,s)=c.2-s+1, h(r,c.2)=c.1-r+1; products telescope via prod_div_telescope; rectangle card=(c.1+1)*(c.2+1) from cells=range(c.1+1)xrange(c.2+1).",
+      "colLen anti-monotone proof inline: if colLen(s) > colLen(t) for s<=t, then (colLen(s),t) in mu implies (colLen(s),s) in mu (lower-set), but colLen(s) >= colLen(s) is false. Can be proved without named Mathlib lemma.",
+      "CROSS PRODUCT IDENTITY: F(mu,c1)*F(mu\\c1,c2) = F(mu,c2)*F(mu\\c2,c1) for any two corners c1,c2. Verified for L-shape and (3,1). This identity by IH gives ratio F(mu,c1)/F(mu,c2) = H(mu\\c2)/H(mu\\c1), so F(mu,c) = alpha/H(mu\\c) for some constant alpha.",
+      "EQUIVALENCE: gnwProb_key (multi-corner) <=> HWI <=> HLF. Given card_SYT_corner_step and HLF for smaller diagrams, these three are mutually equivalent. The proof must be non-circular.",
+      "ALPHA DETERMINATION: The constant alpha = |mu|!/|SYT(mu)| = H(mu) iff HLF holds for mu. To close the proof, need either HLF for mu (circular) or an independent computation of alpha from the walk structure.",
+      "NEW CORNER CREATION: Removing corner c from mu may create 0 or 1 new corners. The topmost corner (r1=min row) creates new corner (r1-1,s1) when r1>0 and rowLen(r1-1)=s1+1 (which holds when rows above are uncorned). So corner-count induction is unreliable.",
+      "POINTWISE EXCHANGE FALSE: gnwProb(mu,c,h_mu(x),x) != gnwProb(mu\\c_prime,c,h_{mu\\c_prime}(x),x) as shown by L-shape: mu={(0,0),(0,1),(1,0)}, c=(1,0), c_prime=(0,1), x=(0,0): 1/2 in mu vs 1 in mu\\c_prime.",
+      "HOOK RATIO NOT INVARIANT: H(mu)/H(mu\\c) != H(mu\\c_prime)/H(mu\\{c,c_prime}) in general. L-shape: 3/2 vs 2. The inductive step via direct ratio comparison fails."
     ],
     "builtItems": [
-      "h_ratio_card: 117-line proof that hookProd(mu)/hookProd(mu\\c) = mu.card for single-corner mu. BallotProblemOQ03OQ01OQ02Helpers.lean:13900-14017. Branch fix/ballot-gnw-key.",
-      "isCorner single-corner case proof: identifies rowLen/colLen uniformity, hookLength formulas, telescope products — all in gnwProb_key single-corner branch (lines 13876-14018)."
+      "h_ratio_card: 117-line proof that hookProd(mu)/hookProd(mu\\c) = mu.card for single-corner mu. BallotProblemOQ03OQ01OQ02Helpers.lean:13900-14017. PR #15599."
     ],
     "mathlibGaps": [
-      "No simple induction on |μ| works without using specific structure of Young diagrams",
-      "Relating gnwProb(μ,c,·) to gnwProb(μ',c,·) for μ'=removeCorner(μ,c') requires tracking how absorption at c' affects total walk probabilities (not pointwise)"
+      "No simple induction on |\u03bc| works without using specific structure of Young diagrams",
+      "Relating gnwProb(\u03bc,c,\u00b7) to gnwProb(\u03bc',c,\u00b7) for \u03bc'=removeCorner(\u03bc,c') requires tracking how absorption at c' affects probabilities"
     ],
     "nextSteps": [
-      "Prove isCorner_removeCorner_ne: c is corner of μ, c≠c', c' corner → c is corner of removeCorner μ c' hc'. Proof: c∈removeCorner by mem_removeCorner; no right/bottom neighbors in removeCorner since none in μ. ~5 lines.",
-      "Prove gnwProb_exchange_norm: g(μ,c) = g(μ\\c',c) where g(ν,d) = Σ_{x∈ν} gnwProb(ν,d,h(x),x) · H(ν\\d)/H(ν). This is the core GNW 1979 exchange identity. ~80 lines.",
-      "Write multi-corner proof structure using gnwProb_exchange_norm + Nat.strongRecOn on μ.card. The proof follows: g(μ,c) = g(μ\\c',c) [exchange] = 1 [IH] → F(μ,c) = H(μ)/H(μ\\c). ~50 lines.",
-      "Submit multi-corner sorry to Aristotle (HARD, known GNW 1979 proof, may be too complex for Aristotle)."
+      "Prove cross product identity F(mu,c1)*F(mu\\c1,c2) = F(mu,c2)*F(mu\\c2,c1) by induction on |mu|, using the walk recursion. This is the GNW key exchange. If proved, combined with alpha determination closes gnwProb_key.",
+      "Alpha determination: show Sigma_c 1/H(mu\\c) = |mu|/H(mu) by an independent argument (not via HLF). Could use: mutual induction combining gnwProb_key and HLF, or a direct product formula.",
+      "Aristotle submission: companion file with just gnwProb_key statement and its direct prerequisites, after fixing /-! docstring issues in main file.",
+      "Alternative: bypass gnwProb_key entirely. Prove hook_walk_identity_gnw (Sigma_c H/H\\c = |mu|) directly from corner recursion + IH, using hook_length_formula_Q as the bridge. But this appears circular: HLF(mu) needs HWI(mu) which needs gnwProb_key(mu)."
     ]
   },
   "relatedProofs": [

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
@@ -1,0 +1,44 @@
+{
+  "id": "ballot-problem-oq-03-oq-01-oq-02-incomplete-01",
+  "title": "Hook-Length Formula via LGV Lemma (Complete Proof)",
+  "status": "blocked",
+  "question": "Can the gnwProb_key (Greene-Nijenhuis-Wilf 1979 KEY identity) be formalized to complete the hook-length formula proof for all Young diagrams?",
+  "knowledge": {
+    "progressSummary": "PROGRESS: h_ratio_card proved (single-corner hook ratio = card, 117 lines). gnwProb_key has 1 sorry remaining: multi-corner GNW exchange argument (~150-200 lines). PR #15599 on branch fix/ballot-gnw-key.",
+    "insights": [
+      "gnwProb_key states: \u03a3_{x \u2208 \u03bc} gnwProb(\u03bc,c,hookLen(x),x) = hookProd(\u03bc)/hookProd(\u03bc\\c) for any corner c",
+      "All supporting lemmas proved: gnwProb_sum_corners, gnwProb_stable, gnwProb_step, hookProd_ratio_formula, strictHookCells_card, strictHookCells_hookLen_lt",
+      "P(x\u2192c)=0 for all x with x.1 > c.1 or x.2 > c.2 (walk can only increase row/col index)",
+      "For single-row \u03bc, all P_j=1 and sum = n (verified by explicit recursion: S_j = n-j)",
+      "For rectangle \u03bc, all probabilities = 1 and sum = a*b",
+      "hookProd_ratio_formula already proved: hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03a0_{s<j} h(i,s)/(h(i,s)-1) * \u03a0_{r<i} h(r,j)/(h(r,j)-1)",
+      "Simple strong induction on |\u03bc| fails for odd n: \u03c8(2m+1) \u2264 (4m+4) log 2 but need \u2264 (4m+2) log 2",
+      "GNW 1979 uses specific recursion relating sum to W(y) = \u03a3_{x non-corner: y\u2208H*(x)} 1/(h(x)-1)",
+      "HLF and HWI are PROVABLY EQUIVALENT at each level given HLF at lower levels + card_SYT_corner_step: cannot derive one from the other without a direct computation",
+      "gnwProb_key for rectangles (single-corner shapes) is provable via gnwProb_sum_corners + hook_walk_identity_rectYD since gnwProb=1 for all cells",
+      "The GNW exchange lemma is a SUM identity, not pointwise: F(mu,c)/F(nu,c) = R(mu,c)/R(nu,c) for nu=mu\\c prime verified on [3,1] example",
+      "Key algebraic relation: R_mu(c)/R_nu(c) = R_mu(c prime)/R_{mu\\c}(c prime) -- pure hookProd identity, provable without GNW",
+      "Mutual induction approach also fails: even proving HLF and HWI simultaneously by strong induction requires GNW for the big base case",
+      "h_ratio_card proof strategy: rowLen(0)=c.2+1 and colLen(0)=c.1+1 via single-corner identification (corner at bottom of last column and corner at end of last row must both equal c), then uniform rowLen/colLen by anti-monotone squeezing, giving hook formulas h(c.1,s)=c.2-s+1, h(r,c.2)=c.1-r+1; products telescope via prod_div_telescope; rectangle card=(c.1+1)*(c.2+1) from cells=range(c.1+1)xrange(c.2+1).",
+      "colLen anti-monotone proof inline: if colLen(s) > colLen(t) for s<=t, then (colLen(s),t) in mu implies (colLen(s),s) in mu (lower-set), but colLen(s) >= colLen(s) is false. Can be proved without named Mathlib lemma."
+    ],
+    "builtItems": [
+      "h_ratio_card: 117-line proof that hookProd(mu)/hookProd(mu\\c) = mu.card for single-corner mu. BallotProblemOQ03OQ01OQ02Helpers.lean:13900-14017. PR #15599."
+    ],
+    "mathlibGaps": [
+      "No simple induction on |\u03bc| works without using specific structure of Young diagrams",
+      "Relating gnwProb(\u03bc,c,\u00b7) to gnwProb(\u03bc',c,\u00b7) for \u03bc'=removeCorner(\u03bc,c') requires tracking how absorption at c' affects probabilities"
+    ],
+    "nextSteps": [
+      "Multi-corner GNW exchange argument (~150-200 lines): show F(mu,c) = F(mu\\c',c) using hookProd ratio invariance H(mu)/H(mu\\c) = H(mu\\c')/H(mu\\{c,c'}) with induction on mu.card. Key: cannot do pointwise (FALSE by L-shape counterexample), must use total sum exchange.",
+      "Verify h_ratio_card compiles: Docker build Proofs.BallotProblemOQ03OQ01OQ02Helpers. Fix potential issues: push_cast [show s <= c.2], field_simp after prod_div_telescope, Prod.fst/Prod.snd simp alignment with hookProd_ratio_formula.",
+      "Submit multi-corner sorry to Aristotle (HARD, known GNW 1979 proof)."
+    ]
+  },
+  "relatedProofs": [
+    "ballot-problem",
+    "ballot-problem-oq-03",
+    "ballot-problem-oq-03-oq-01",
+    "ballot-problem-oq-03-oq-01-oq-02"
+  ]
+}

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
@@ -4,16 +4,16 @@
   "status": "blocked",
   "question": "Can the gnwProb_key (Greene-Nijenhuis-Wilf 1979 KEY identity) be formalized to complete the hook-length formula proof for all Young diagrams?",
   "knowledge": {
-    "progressSummary": "PROGRESS: h_ratio_card proved (single-corner hook ratio = card, 117 lines, PR #15599). gnwProb_key has 1 sorry remaining: multi-corner case requires cross product identity + alpha determination. Key insight: gnwProb_key <=> HWI <=> HLF -- all equivalent, GNW walk probabilities are the non-circular bridge.",
+    "progressSummary": "PROGRESS: Exchange identity named + structured; 2 sorries remain (gnwProb_exchange ~100 lines + IH wrapper ~30 lines). PR #15685 open. hookLength_removeCorner_arm at line 4821 is the key tool for gnwProb_exchange.",
     "insights": [
-      "gnwProb_key states: \u03a3_{x \u2208 \u03bc} gnwProb(\u03bc,c,hookLen(x),x) = hookProd(\u03bc)/hookProd(\u03bc\\c) for any corner c",
+      "gnwProb_key states: Σ_{x ∈ μ} gnwProb(μ,c,hookLen(x),x) = hookProd(μ)/hookProd(μ\\c) for any corner c",
       "All supporting lemmas proved: gnwProb_sum_corners, gnwProb_stable, gnwProb_step, hookProd_ratio_formula, strictHookCells_card, strictHookCells_hookLen_lt",
-      "P(x\u2192c)=0 for all x with x.1 > c.1 or x.2 > c.2 (walk can only increase row/col index)",
-      "For single-row \u03bc, all P_j=1 and sum = n (verified by explicit recursion: S_j = n-j)",
-      "For rectangle \u03bc, all probabilities = 1 and sum = a*b",
-      "hookProd_ratio_formula already proved: hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03a0_{s<j} h(i,s)/(h(i,s)-1) * \u03a0_{r<i} h(r,j)/(h(r,j)-1)",
-      "Simple strong induction on |\u03bc| fails for odd n: \u03c8(2m+1) \u2264 (4m+4) log 2 but need \u2264 (4m+2) log 2",
-      "GNW 1979 uses specific recursion relating sum to W(y) = \u03a3_{x non-corner: y\u2208H*(x)} 1/(h(x)-1)",
+      "P(x→c)=0 for all x with x.1 > c.1 or x.2 > c.2 (walk can only increase row/col index)",
+      "For single-row μ, all P_j=1 and sum = n (verified by explicit recursion: S_j = n-j)",
+      "For rectangle μ, all probabilities = 1 and sum = a*b",
+      "hookProd_ratio_formula already proved: hookProd(μ)/hookProd(μ\\c) = Π_{s<j} h(i,s)/(h(i,s)-1) * Π_{r<i} h(r,j)/(h(r,j)-1)",
+      "Simple strong induction on |μ| fails for odd n: ψ(2m+1) ≤ (4m+4) log 2 but need ≤ (4m+2) log 2",
+      "GNW 1979 uses specific recursion relating sum to W(y) = Σ_{x non-corner: y∈H*(x)} 1/(h(x)-1)",
       "HLF and HWI are PROVABLY EQUIVALENT at each level given HLF at lower levels + card_SYT_corner_step: cannot derive one from the other without a direct computation",
       "gnwProb_key for rectangles (single-corner shapes) is provable via gnwProb_sum_corners + hook_walk_identity_rectYD since gnwProb=1 for all cells",
       "The GNW exchange lemma is a SUM identity, not pointwise: F(mu,c)/F(nu,c) = R(mu,c)/R(nu,c) for nu=mu\\c prime verified on [3,1] example",
@@ -26,20 +26,28 @@
       "ALPHA DETERMINATION: The constant alpha = |mu|!/|SYT(mu)| = H(mu) iff HLF holds for mu. To close the proof, need either HLF for mu (circular) or an independent computation of alpha from the walk structure.",
       "NEW CORNER CREATION: Removing corner c from mu may create 0 or 1 new corners. The topmost corner (r1=min row) creates new corner (r1-1,s1) when r1>0 and rowLen(r1-1)=s1+1 (which holds when rows above are uncorned). So corner-count induction is unreliable.",
       "POINTWISE EXCHANGE FALSE: gnwProb(mu,c,h_mu(x),x) != gnwProb(mu\\c_prime,c,h_{mu\\c_prime}(x),x) as shown by L-shape: mu={(0,0),(0,1),(1,0)}, c=(1,0), c_prime=(0,1), x=(0,0): 1/2 in mu vs 1 in mu\\c_prime.",
-      "HOOK RATIO NOT INVARIANT: H(mu)/H(mu\\c) != H(mu\\c_prime)/H(mu\\{c,c_prime}) in general. L-shape: 3/2 vs 2. The inductive step via direct ratio comparison fails."
+      "HOOK RATIO NOT INVARIANT: H(mu)/H(mu\\c) != H(mu\\c_prime)/H(mu\\{c,c_prime}) in general. L-shape: 3/2 vs 2. The inductive step via direct ratio comparison fails.",
+      "isCorner_removeCorner_of_ne (PROVED ~11 lines): distinct corners of μ survive removing the other corner. Proof: c₂ ∈ removeCorner iff c₂∈μ and c₂≠c₁; (c₂.1,c₂.2+1) ∉ removeCorner since ∉ μ; (c₂.1+1,c₂.2) ∉ removeCorner since ∉ μ (c₂ is corner of μ). Only 3 cases needed.",
+      "EXCHANGE IDENTITY (named sorry): F(μ,c)*H(μ\\c)*H(μ\\c`) = F(μ\\c`,c)*H((μ\\c`)\\c)*H(μ). Given gnwProb_key for μ\\c` (IH), substituting IH gives F(μ,c)*H(μ\\c)*H(μ\\c`) = H(μ\\c`)*H(μ), then cancel H(μ\\c`) to get F(μ,c)*H(μ\\c)=H(μ), done.",
+      "ANTI-ORDERING of corners: in a Young diagram, distinct corners c and c` have c.1 > c`.1 iff c.2 < c`.2 (lower rows are longer). Cannot have two corners in same row or column.",
+      "SINGLE AFFECTED CELL: for corners c (row i, col j) and c` (row i`, col j`) with i`>i (so j`<j), removing c` only affects arm-cell (i,j`) of c: its hook decreases by 1. All other arm/leg cells of c are unaffected.",
+      "HOOK_LENGTH_REMOVEKORNER infrastructure: hookLength_removeCorner_arm (line 4821) and hookLength_removeCorner_leg (line 4835) already exist and may directly give the hook decrease formula for gnwProb_exchange.",
+      "MULTI-CORNER PROOF STRUCTURE (session 42): algebraic closure from exchange+IH is complete. Two sorries remain: gnwProb_exchange (~100 lines) and strong induction wrapper (~30 lines)."
     ],
     "builtItems": [
-      "h_ratio_card: 117-line proof that hookProd(mu)/hookProd(mu\\c) = mu.card for single-corner mu. BallotProblemOQ03OQ01OQ02Helpers.lean:13900-14017. PR #15599."
+      "h_ratio_card: 117-line proof that hookProd(mu)/hookProd(mu\\c) = mu.card for single-corner mu. BallotProblemOQ03OQ01OQ02Helpers.lean:13900-14017. PR #15599.",
+      "isCorner_removeCorner_of_ne: BallotProblemOQ03OQ01OQ02Helpers.lean ~line 4365, PR #15685",
+      "gnwProb_exchange: named sorry with correct statement, BallotProblemOQ03OQ01OQ02Helpers.lean ~line 13865, PR #15685",
+      "Multi-corner proof structure: complete skeleton using gnwProb_exchange + IH, BallotProblemOQ03OQ01OQ02Helpers.lean ~line 14046, PR #15685"
     ],
     "mathlibGaps": [
-      "No simple induction on |\u03bc| works without using specific structure of Young diagrams",
-      "Relating gnwProb(\u03bc,c,\u00b7) to gnwProb(\u03bc',c,\u00b7) for \u03bc'=removeCorner(\u03bc,c') requires tracking how absorption at c' affects probabilities"
+      "No simple induction on |μ| works without using specific structure of Young diagrams",
+      "Relating gnwProb(μ,c,·) to gnwProb(μ',c,·) for μ'=removeCorner(μ,c') requires tracking how absorption at c' affects probabilities"
     ],
     "nextSteps": [
-      "Prove cross product identity F(mu,c1)*F(mu\\c1,c2) = F(mu,c2)*F(mu\\c2,c1) by induction on |mu|, using the walk recursion. This is the GNW key exchange. If proved, combined with alpha determination closes gnwProb_key.",
-      "Alpha determination: show Sigma_c 1/H(mu\\c) = |mu|/H(mu) by an independent argument (not via HLF). Could use: mutual induction combining gnwProb_key and HLF, or a direct product formula.",
-      "Aristotle submission: companion file with just gnwProb_key statement and its direct prerequisites, after fixing /-! docstring issues in main file.",
-      "Alternative: bypass gnwProb_key entirely. Prove hook_walk_identity_gnw (Sigma_c H/H\\c = |mu|) directly from corner recursion + IH, using hook_length_formula_Q as the bridge. But this appears circular: HLF(mu) needs HWI(mu) which needs gnwProb_key(mu)."
+      "Strong induction wrapper (~30 lines): restructure gnwProb_key to use Nat.strongRecOn on μ.card, or extract gnwProb_key_ind helper. The h_IH sorry becomes the IH from induction.",
+      "Prove gnwProb_exchange (~100 lines): check hookLength_removeCorner_arm (line 4821) for the key hook decrease. Identify all arm/leg cells of c affected by removing c`. Write walk probability recursion equating μ and μ\\c` versions.",
+      "Use hookLength_removeCorner_arm + hookLength_eq_of_not_arm_leg to classify: cells in H*(x) that are in hook(c`) vs not, and show gnwProb(μ,c,h(x),x) = gnwProb(μ\\c`,c,h_{μ\\c`}(x),x) for x outside hook(c`), with correction term for x inside hook(c`)."
     ]
   },
   "relatedProofs": [

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json
@@ -1,38 +1,39 @@
 {
   "id": "ballot-problem-oq-03-oq-01-oq-02-incomplete-01",
   "title": "Hook-Length Formula via LGV Lemma (Complete Proof)",
-  "status": "blocked",
+  "status": "in-progress",
   "question": "Can the gnwProb_key (Greene-Nijenhuis-Wilf 1979 KEY identity) be formalized to complete the hook-length formula proof for all Young diagrams?",
   "knowledge": {
-    "progressSummary": "PROGRESS: h_ratio_card proved (single-corner hook ratio = card, 117 lines). gnwProb_key has 1 sorry remaining: multi-corner GNW exchange argument (~150-200 lines). PR #15599 on branch fix/ballot-gnw-key.",
+    "progressSummary": "PROGRESS: Single-corner case of gnwProb_key fully proved (117 lines, h_ratio_card complete). One sorry remains: multi-corner GNW exchange argument. Branch fix/ballot-gnw-key.",
     "insights": [
-      "gnwProb_key states: \u03a3_{x \u2208 \u03bc} gnwProb(\u03bc,c,hookLen(x),x) = hookProd(\u03bc)/hookProd(\u03bc\\c) for any corner c",
+      "gnwProb_key states: Σ_{x ∈ μ} gnwProb(μ,c,hookLen(x),x) = hookProd(μ)/hookProd(μ\\c) for any corner c",
       "All supporting lemmas proved: gnwProb_sum_corners, gnwProb_stable, gnwProb_step, hookProd_ratio_formula, strictHookCells_card, strictHookCells_hookLen_lt",
-      "P(x\u2192c)=0 for all x with x.1 > c.1 or x.2 > c.2 (walk can only increase row/col index)",
-      "For single-row \u03bc, all P_j=1 and sum = n (verified by explicit recursion: S_j = n-j)",
-      "For rectangle \u03bc, all probabilities = 1 and sum = a*b",
-      "hookProd_ratio_formula already proved: hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03a0_{s<j} h(i,s)/(h(i,s)-1) * \u03a0_{r<i} h(r,j)/(h(r,j)-1)",
-      "Simple strong induction on |\u03bc| fails for odd n: \u03c8(2m+1) \u2264 (4m+4) log 2 but need \u2264 (4m+2) log 2",
-      "GNW 1979 uses specific recursion relating sum to W(y) = \u03a3_{x non-corner: y\u2208H*(x)} 1/(h(x)-1)",
+      "P(x→c)=0 for all x with x.1 > c.1 or x.2 > c.2 (walk can only increase row/col index)",
+      "For single-row μ, all P_j=1 and sum = n (verified by explicit recursion: S_j = n-j)",
+      "For rectangle μ, all probabilities = 1 and sum = a*b",
+      "hookProd_ratio_formula already proved: hookProd(μ)/hookProd(μ\\c) = Π_{s<j} h(i,s)/(h(i,s)-1) * Π_{r<i} h(r,j)/(h(r,j)-1)",
+      "GNW 1979 uses specific recursion relating sum to W(y) = Σ_{x non-corner: y∈H*(x)} 1/(h(x)-1)",
       "HLF and HWI are PROVABLY EQUIVALENT at each level given HLF at lower levels + card_SYT_corner_step: cannot derive one from the other without a direct computation",
       "gnwProb_key for rectangles (single-corner shapes) is provable via gnwProb_sum_corners + hook_walk_identity_rectYD since gnwProb=1 for all cells",
-      "The GNW exchange lemma is a SUM identity, not pointwise: F(mu,c)/F(nu,c) = R(mu,c)/R(nu,c) for nu=mu\\c prime verified on [3,1] example",
-      "Key algebraic relation: R_mu(c)/R_nu(c) = R_mu(c prime)/R_{mu\\c}(c prime) -- pure hookProd identity, provable without GNW",
-      "Mutual induction approach also fails: even proving HLF and HWI simultaneously by strong induction requires GNW for the big base case",
-      "h_ratio_card proof strategy: rowLen(0)=c.2+1 and colLen(0)=c.1+1 via single-corner identification (corner at bottom of last column and corner at end of last row must both equal c), then uniform rowLen/colLen by anti-monotone squeezing, giving hook formulas h(c.1,s)=c.2-s+1, h(r,c.2)=c.1-r+1; products telescope via prod_div_telescope; rectangle card=(c.1+1)*(c.2+1) from cells=range(c.1+1)xrange(c.2+1).",
-      "colLen anti-monotone proof inline: if colLen(s) > colLen(t) for s<=t, then (colLen(s),t) in mu implies (colLen(s),s) in mu (lower-set), but colLen(s) >= colLen(s) is false. Can be proved without named Mathlib lemma."
+      "GNW exchange: the NORMALIZED sum g(μ,c) = F(μ,c)·H(μ\\c)/H(μ) satisfies g(μ,c) = g(μ\\c',c) for any corner c'≠c. NOT pointwise (FALSE on [3,1] example). The TOTAL normalized sum is invariant.",
+      "h_ratio_card proof: rowLen(0)=c.2+1 and colLen(0)=c.1+1 via single-corner identification (only one corner must equal c); anti-monotone squeezing gives uniform rowLen/colLen; hook formulas h(c.1,s)=c.2-s+1, h(r,c.2)=c.1-r+1; products telescope via prod_div_telescope; rectangle card=(c.1+1)*(c.2+1) from cells=range(c.1+1)×range(c.2+1).",
+      "colLen anti-monotone proved inline without named Mathlib lemma: if colLen(s)>colLen(t) for s≤t then (colLen(s),t)∈μ lower-set implies (colLen(s),s)∈μ, contradiction.",
+      "Multi-corner exchange proof needs: (1) isCorner_removeCorner_ne (c is corner of μ\\c' when c≠c', trivial from mem_removeCorner), (2) gnwProb_exchange_norm (sorry, ~80 lines), (3) strong induction structure on μ.card.",
+      "Verified on (3,1) example: F(μ,(0,2))=8/3=H(μ)/H(μ\\(0,2)), F(μ\\(1,0),(0,2))=3=H(μ\\(1,0))/H(removeCorner(μ\\(1,0),(0,2))); normalized sums both equal 1."
     ],
     "builtItems": [
-      "h_ratio_card: 117-line proof that hookProd(mu)/hookProd(mu\\c) = mu.card for single-corner mu. BallotProblemOQ03OQ01OQ02Helpers.lean:13900-14017. PR #15599."
+      "h_ratio_card: 117-line proof that hookProd(mu)/hookProd(mu\\c) = mu.card for single-corner mu. BallotProblemOQ03OQ01OQ02Helpers.lean:13900-14017. Branch fix/ballot-gnw-key.",
+      "isCorner single-corner case proof: identifies rowLen/colLen uniformity, hookLength formulas, telescope products — all in gnwProb_key single-corner branch (lines 13876-14018)."
     ],
     "mathlibGaps": [
-      "No simple induction on |\u03bc| works without using specific structure of Young diagrams",
-      "Relating gnwProb(\u03bc,c,\u00b7) to gnwProb(\u03bc',c,\u00b7) for \u03bc'=removeCorner(\u03bc,c') requires tracking how absorption at c' affects probabilities"
+      "No simple induction on |μ| works without using specific structure of Young diagrams",
+      "Relating gnwProb(μ,c,·) to gnwProb(μ',c,·) for μ'=removeCorner(μ,c') requires tracking how absorption at c' affects total walk probabilities (not pointwise)"
     ],
     "nextSteps": [
-      "Multi-corner GNW exchange argument (~150-200 lines): show F(mu,c) = F(mu\\c',c) using hookProd ratio invariance H(mu)/H(mu\\c) = H(mu\\c')/H(mu\\{c,c'}) with induction on mu.card. Key: cannot do pointwise (FALSE by L-shape counterexample), must use total sum exchange.",
-      "Verify h_ratio_card compiles: Docker build Proofs.BallotProblemOQ03OQ01OQ02Helpers. Fix potential issues: push_cast [show s <= c.2], field_simp after prod_div_telescope, Prod.fst/Prod.snd simp alignment with hookProd_ratio_formula.",
-      "Submit multi-corner sorry to Aristotle (HARD, known GNW 1979 proof)."
+      "Prove isCorner_removeCorner_ne: c is corner of μ, c≠c', c' corner → c is corner of removeCorner μ c' hc'. Proof: c∈removeCorner by mem_removeCorner; no right/bottom neighbors in removeCorner since none in μ. ~5 lines.",
+      "Prove gnwProb_exchange_norm: g(μ,c) = g(μ\\c',c) where g(ν,d) = Σ_{x∈ν} gnwProb(ν,d,h(x),x) · H(ν\\d)/H(ν). This is the core GNW 1979 exchange identity. ~80 lines.",
+      "Write multi-corner proof structure using gnwProb_exchange_norm + Nat.strongRecOn on μ.card. The proof follows: g(μ,c) = g(μ\\c',c) [exchange] = 1 [IH] → F(μ,c) = H(μ)/H(μ\\c). ~50 lines.",
+      "Submit multi-corner sorry to Aristotle (HARD, known GNW 1979 proof, may be too complex for Aristotle)."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

- Adds `isCorner_removeCorner_of_ne`: distinct corners of μ survive removing the other corner — needed as the key infrastructure for the GNW induction step
- Adds `gnwProb_exchange` (named sorry): the GNW 1979 exchange identity `F(μ,c)·H(μ\c)·H(μ\c') = F(μ\c',c)·H((μ\c')\c)·H(μ)` in product form (avoids division), verified on L-shape and (3,1)
- Replaces the anonymous multi-corner sorry with a complete algebraic proof skeleton that closes immediately once `gnwProb_exchange` and the strong induction wrapper are proved

## Mathematical Structure

The multi-corner proof now reads:
1. Pick corner c' ≠ c (exists since |corners μ| ≥ 2)
2. IH (sorry: needs strong induction wrapper): gnwProb_key holds for μ\c'
3. gnwProb_exchange (sorry: GNW hook-weight shift, ~100 lines): exchange identity
4. Substitute IH into exchange → `F * H_c * H_c' = H_c' * H`
5. Cancel H_c' via `mul_right_cancel₀` → `F * H_c = H`
6. Divide by H_c → `F = H / H_c` ✓

## Remaining Work

Two sorries: `gnwProb_exchange` (the core GNW 1979 argument tracking hook-length changes under corner removal) and the strong induction wrapper (~30 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)