### PR TITLE
research(sperner-simplicial-bridge): add gallery entry for simplicial bridge proof

### DIFF
--- a/src/data/proofs/sperner-simplicial-bridge/annotations.json
+++ b/src/data/proofs/sperner-simplicial-bridge/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-vertex-enum",
+    "type": "definition",
+    "label": "vertexEnum",
+    "title": "Canonical Vertex Enumeration via Sorting",
+    "body": "vertexEnum s hs k returns the k-th vertex of simplex s in sorted order, using Finset.sort with the LinearOrder on E. This converts unordered finset data into ordered arrays compatible with the abstract CellComplex/Sperner framework, where cells have Fin(d+1)-indexed vertices.",
+    "location": { "line": 65 },
+    "tags": ["definition", "sorting", "vertex", "finset"]
+  },
+  {
+    "id": "ann-vertex-inj",
+    "type": "theorem",
+    "label": "vertexEnum_injective",
+    "title": "Vertex Enumeration Is Injective",
+    "body": "For a simplex s with d+1 vertices, vertexEnum s hs is injective as a function Fin(d+1) → E. This follows from Nodup property of Finset.sort: since the sorted list has no duplicate elements, distinct indices give distinct vertices.",
+    "location": { "line": 80 },
+    "tags": ["injectivity", "sorting", "nodup"]
+  },
+  {
+    "id": "ann-face-machinery",
+    "type": "theorem",
+    "label": "vertexEnum_image_erase",
+    "title": "Face Image Equals Simplex with Vertex Erased",
+    "body": "The image of Fin(d+1) \\ {k} under vertexEnum equals s.erase (vertexEnum s hs k). This is the core identity connecting the abstract face notion (removing index k) to the geometric face notion (removing a specific vertex from the finset).",
+    "location": { "line": 134 },
+    "tags": ["face", "erase", "image", "geometric"]
+  },
+  {
+    "id": "ann-containers",
+    "type": "definition",
+    "label": "containersOf",
+    "title": "Container Cells for a Face",
+    "body": "containersOf topCells f returns the finset of top-dimensional cells in topCells that contain the face f as a subset. The pseudomanifold condition requires containersOf f to have cardinality at most 2 for every codimension-1 face f.",
+    "location": { "line": 0 },
+    "tags": ["definition", "containers", "pseudomanifold"]
+  },
+  {
+    "id": "ann-containers-le-two",
+    "type": "theorem",
+    "label": "containersOf_card_le_two",
+    "title": "Pseudomanifold: At Most 2 Containers per Face",
+    "body": "Under the pseudomanifold hypothesis, every d-element face has at most 2 cells containing it. This is the direct formalization of the pseudomanifold condition and is the key premise for all adjacency lemmas.",
+    "location": { "line": 304 },
+    "tags": ["pseudomanifold", "containers", "cardinality"]
+  },
+  {
+    "id": "ann-adjfn",
+    "type": "definition",
+    "label": "adjFn",
+    "title": "Adjacency Function for Simplicial Data",
+    "body": "adjFn topCells hcard s k looks up the face opposite vertex k in cell s (via the erased-vertex construction), finds all cells containing that face, and returns Some(s', k') where s' is the other cell and k' is the index of the shared face vertex in s'. Returns None if the face is on the boundary (only 1 container).",
+    "location": { "line": 0 },
+    "tags": ["definition", "adjacency", "simplicial"]
+  },
+  {
+    "id": "ann-adjfn-symm",
+    "type": "theorem",
+    "label": "adjFn_symm",
+    "title": "Adjacency Is Symmetric",
+    "body": "If adjFn s k = Some(s', k'), then adjFn s' k' = Some(s, k). This is the first adjacency axiom needed for the abstract Sperner framework. The proof uses the symmetric structure of containersOf: if s and s' both contain the face, then s' is the other cell when looking from s, and vice versa.",
+    "location": { "line": 447 },
+    "tags": ["adjacency", "symmetry", "axiom"]
+  },
+  {
+    "id": "ann-adjfn-vertex",
+    "type": "theorem",
+    "label": "adjFn_vertex",
+    "title": "Adjacent Cells Share a Codimension-1 Face",
+    "body": "If adjFn s k = Some(s', k'), then the vertex images of Fin(d+1) \\ {k} under vertexEnum for s equals the vertex image of Fin(d+1) \\ {k'} for s'. This is the second adjacency axiom: adjacent cells share their common (d-1)-face. The proof uses vertexEnum_image_erase to convert between the abstract and geometric face representations.",
+    "location": { "line": 347 },
+    "tags": ["adjacency", "shared-face", "axiom"]
+  },
+  {
+    "id": "ann-adjfn-ne",
+    "type": "theorem",
+    "label": "adjFn_ne",
+    "title": "Adjacent Cells Are Distinct",
+    "body": "If adjFn s k = Some(s', k'), then s ≠ s' (as finsets). This is the third adjacency axiom. The proof uses adjFn_s': the other container is specifically a cell DIFFERENT from s, enforced by Finset.exists_ne.",
+    "location": { "line": 384 },
+    "tags": ["adjacency", "distinctness", "axiom"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "type": "theorem",
+    "label": "exists_panchromatic",
+    "title": "Sperner's Lemma for Pseudomanifold Simplicial Complexes",
+    "body": "Given a finite set topCells of (d+1)-vertex simplices satisfying the pseudomanifold condition, a vertex coloring c, and an odd count of boundary door-face pairs, there exists a panchromatic cell—one whose vertices collectively receive all d+1 colors. The proof instantiates Sperner.exists_panchromatic from SpernerMathlib by providing adjFn and the three verified adjacency axioms.",
+    "location": { "line": 564 },
+    "tags": ["sperner", "existence", "panchromatic", "main-result"]
+  }
+]

--- a/src/data/proofs/sperner-simplicial-bridge/index.ts
+++ b/src/data/proofs/sperner-simplicial-bridge/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/SpernerSimplicialBridge.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/sperner-simplicial-bridge/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge/meta.json
@@ -1,0 +1,75 @@
+{
+  "id": "sperner-simplicial-bridge",
+  "title": "Sperner's Lemma for Pseudomanifold Simplicial Complexes",
+  "slug": "sperner-simplicial-bridge",
+  "description": "A bridge proof that derives Sperner's lemma for finite sets of simplices satisfying a pseudomanifold condition from the abstract door-counting theorem in SpernerMathlib. The key construction converts geometric simplicial data—unordered vertex sets, codimension-1 face adjacency—into the abstract CellComplex-style axioms required by the door-counting proof, using vertex ordering via Finset.sort and a full verification of the three adjacency axioms.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 21,
+    "definitionCount": 5,
+    "lineCount": 612,
+    "leanFile": "proofs/Proofs/SpernerSimplicialBridge.lean",
+    "imports": ["Proofs.SpernerMathlib"],
+    "tags": ["combinatorics", "topology", "sperner", "simplicial-complex", "pseudomanifold", "bridge"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "vertex-enum",
+      "title": "Vertex Enumeration",
+      "description": "The definition vertexEnum converts an unordered finset of vertices into an ordered tuple using Finset.sort with the linear order on E. The key properties: vertexEnum_mem (each k-th vertex belongs to the simplex), vertexEnum_injective (the ordering is injective), vertexEnum_image_univ (the image is exactly the simplex). These properties are the foundation for converting finset-based simplices into the cell-complex vertex format.",
+      "theorems": ["vertexEnum_mem", "vertexEnum_injective", "vertexEnum_image_univ"]
+    },
+    {
+      "id": "face-machinery",
+      "title": "Codimension-1 Face Infrastructure",
+      "description": "A codimension-1 face (opposite vertex k) is the image of vertexEnum restricted to Fin(d+1) \\ {k}. The lemmas faceOf_card, faceOf_subset, vertexEnum_image_erase establish that this face has cardinality d, is a subset of the simplex, and equals the simplex with the k-th vertex erased. The helper vertexEnum_not_mem_faceOf_iff characterizes which vertices are NOT in a face.",
+      "theorems": ["faceOf_card", "faceOf_subset", "vertexEnum_image_erase", "vertexEnum_not_mem_faceOf_iff"]
+    },
+    {
+      "id": "containers-adjacency",
+      "title": "Containers and Adjacency",
+      "description": "The containersOf function finds all top-dimensional cells containing a given face. Under the pseudomanifold hypothesis (each codim-1 face in at most 2 cells), containersOf_card_le_two shows each face has at most 2 containers. The adjacency function adjFn maps cell-face pairs to their adjacent cell (if any): if the face has exactly 2 containers, the adjacent cell is the other one; if only 1, it's a boundary face (returns none).",
+      "theorems": ["self_mem_containersOf", "containersOf_card_le_two", "containersOf_card_one_or_two", "containersOf_card_eq_two_of_adjFn", "adjFn_vertex", "adjFn_ne", "adjFn_s", "adjFn_face_eq", "adjFn_symm"]
+    },
+    {
+      "id": "bridge-theorem",
+      "title": "Sperner's Lemma",
+      "description": "The main theorem exists_panchromatic applies abstract Sperner's lemma (from SpernerMathlib) to finite sets of top-dimensional simplices. Given a finite set topCells of (d+1)-vertex simplices, the pseudomanifold property, a vertex coloring, and an odd boundary door count, the theorem produces a panchromatic cell. The proof instantiates Sperner.exists_panchromatic by providing adjFn and verifying all three adjacency axioms (adjFn_symm, adjFn_vertex, adjFn_ne).",
+      "theorems": ["exists_panchromatic"]
+    }
+  ],
+  "overview": {
+    "summary": "This file bridges abstract and geometric Sperner's lemma. The abstract version (SpernerMathlib) works with any adjacency data satisfying three axioms. This bridge verifies that pure pseudomanifold simplicial complexes—finite sets of equal-cardinality simplices where each codimension-1 face belongs to at most 2 simplices—satisfy exactly those axioms.",
+    "approach": "The key challenge is converting unordered finsets (geometric simplices) into ordered vertex arrays (needed for the abstract framework). Finset.sort with a LinearOrder provides a canonical ordering. The pseudomanifold condition directly implies the adjacency axioms: symmetry (sharing a face is symmetric), shared-face property (adjacent cells share the d-face), and distinctness (a cell can't be adjacent to itself).",
+    "significance": "This bridge is the geometric-to-combinatorial interface layer for Sperner's lemma. It connects Mathlib's geometric simplicial complex infrastructure to the abstract door-counting proof, enabling application to any specific triangulation—the standard d-simplex, barycentric subdivisions, etc.—once the pseudomanifold condition is verified."
+  },
+  "conclusion": {
+    "summary": "Sperner's lemma for pseudomanifold simplicial complexes is machine-checked with no axioms or sorries. The bridge relies only on SpernerMathlib (not the full Mathlib import), keeping the dependency chain minimal.",
+    "openQuestions": [
+      "Can the pseudomanifold condition be weakened to allow non-pure complexes (cells of different dimensions)?",
+      "Does this bridge extend to Mathlib's Geometry.SimplicialComplex type by extracting facets and verifying the pseudomanifold condition?",
+      "Can the door-counting framework be adapted to prove Sperner-type results on infinite graphs or locally finite complexes?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "sperner-mathlib",
+      "relationship": "uses",
+      "description": "Abstract Sperner's lemma via door counting (imported directly)"
+    },
+    {
+      "id": "sperner-mathlib4",
+      "relationship": "related",
+      "description": "Alternative abstract formulation using CellComplex structure"
+    },
+    {
+      "id": "sperner-simplicial-instance",
+      "relationship": "related",
+      "description": "Concrete Triangulation instantiation for the same abstract theorem"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `SpernerSimplicialBridge.lean` (612 lines, 0 axioms, 0 sorries):

- **Status**: verified, badge: original
- **21 theorems, 5 defs** in the `Sperner.SimplicialComplex` namespace
- Bridges geometric pseudomanifold simplicial data to abstract Sperner's lemma
- Imports only `Proofs.SpernerMathlib` (no full Mathlib)

### Key Results
- `vertexEnum`: canonical vertex ordering via Finset.sort
- `adjFn`: adjacency function from geometric simplicial data
- `adjFn_symm`, `adjFn_vertex`, `adjFn_ne`: verification of the 3 CellComplex axioms
- `exists_panchromatic`: Sperner's lemma for pure pseudomanifold simplicial complexes

## Files
- `src/data/proofs/sperner-simplicial-bridge/meta.json`
- `src/data/proofs/sperner-simplicial-bridge/annotations.json`
- `src/data/proofs/sperner-simplicial-bridge/index.ts`

🤖 Generated by researcher-10