### PR TITLE
research(pappus-theorem-oq-02): Pappus hexagon theorem via cross-product algebra

### DIFF
--- a/src/data/proofs/pappus-theorem-oq-02/annotations.json
+++ b/src/data/proofs/pappus-theorem-oq-02/annotations.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "ann-cross3",
+    "type": "definition",
+    "label": "cross3",
+    "title": "3D Cross Product over K",
+    "body": "cross3 a b : Fin 3 → K is the standard cross product: (a₁b₂-a₂b₁, a₂b₀-a₀b₂, a₀b₁-a₁b₀). In projective geometry over K, the cross product of two homogeneous coordinate vectors represents the line through the corresponding points, and the cross product of two such lines gives their intersection point.",
+    "location": { "line": 67 },
+    "tags": ["cross-product", "projective", "definition"]
+  },
+  {
+    "id": "ann-lagrange",
+    "type": "theorem",
+    "label": "lagrange_cross_K",
+    "title": "Lagrange Cross-Product Identity",
+    "body": "cross(cross(a,b), cross(c,d)) = det(a,b,d)·c − det(a,b,c)·d. This identity is the computational engine for expressing line intersections in terms of determinants. Given points on two lines (collinear hypothesis), the intersection of two cross-join lines is computed using this formula, converting the collinearity proof into a determinant-vanishing identity.",
+    "location": { "line": 0 },
+    "tags": ["identity", "cross-product", "determinant", "lagrange"]
+  },
+  {
+    "id": "ann-pappus-multilinear",
+    "type": "theorem",
+    "label": "pappus_det_multilinear",
+    "title": "Degree-6 Multilinear Expansion",
+    "body": "When the intersection points P = d₁A'-d₂B, Q = d₃A'-d₄C, R = d₅B'-d₆C are expressed with abstract ring elements d₁,...,d₆, the determinant det(P,Q,R) expands as a sum of four terms: -d₁d₄d₅·det(A',C,B') - d₂d₃d₅·det(B,A',B') + d₂d₃d₆·det(B,A',C) + d₂d₄d₅·det(B,C,B'). This is a degree-6 polynomial identity proved by ring.",
+    "location": { "line": 0 },
+    "tags": ["multilinear", "determinant", "degree-6", "ring"]
+  },
+  {
+    "id": "ann-pappus-core",
+    "type": "theorem",
+    "label": "pappus_core_identity",
+    "title": "Core Pappus Algebraic Identity",
+    "body": "The key identity: the four-term determinant expansion equals f·det(A,B,C) + g·det(A',B',C') for certain degree-9 polynomial coefficients f and g. When A,B,C are collinear (det = 0) and A',B',C' are collinear (det = 0), both terms vanish, giving det(P,Q,R) = 0 (collinearity of P,Q,R). The coefficients f and g were computed using a Gröbner basis calculation; the proof uses linear_combination.",
+    "location": { "line": 0 },
+    "tags": ["pappus", "core-identity", "groebner", "collinearity"]
+  },
+  {
+    "id": "ann-pappus-main",
+    "type": "theorem",
+    "label": "pappus_K",
+    "title": "Pappus's Hexagon Theorem over CommRing",
+    "body": "Given collinear points A, B, C on line L₁ and A', B', C' on line L₂ in the projective plane over K (CommRing), the three intersection points P = L(A,B') ∩ L(A',B), Q = L(A,C') ∩ L(A',C), R = L(B,C') ∩ L(B',C) are collinear. The proof assembles: compute P,Q,R via Lagrange; apply pappus_det_multilinear; apply pappus_core_identity; use the given collinearity hypotheses.",
+    "location": { "line": 0 },
+    "tags": ["pappus", "hexagon", "commring", "main-theorem"]
+  },
+  {
+    "id": "ann-corollaries",
+    "type": "theorem",
+    "label": "pappus_Q",
+    "title": "Corollaries: ℚ, ℤ, and Finite Fields",
+    "body": "pappus_Q, pappus_Z, pappus_Fp specialize the main theorem to ℚ, ℤ, and 𝔽_p (ZMod p). These corollaries require no additional proof beyond type checking, since CommRing instances for these types are in Mathlib.",
+    "location": { "line": 0 },
+    "tags": ["corollaries", "rational", "integer", "finite-field"]
+  },
+  {
+    "id": "ann-desargues-bonus",
+    "type": "theorem",
+    "label": "desargues_forward_K",
+    "title": "Bonus: Desargues via This Framework",
+    "body": "The cross-product framework also reproves one direction of Desargues's theorem. This confirms the framework is general enough for projective geometry arguments and demonstrates that Pappus and Desargues share the same algebraic infrastructure in this formalization.",
+    "location": { "line": 0 },
+    "tags": ["desargues", "projective", "bonus"]
+  }
+]

--- a/src/data/proofs/pappus-theorem-oq-02/index.ts
+++ b/src/data/proofs/pappus-theorem-oq-02/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/PappusTheoremOQ02.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -1,0 +1,62 @@
+{
+  "id": "pappus-theorem-oq-02",
+  "title": "Pappus's Hexagon Theorem via Cross-Product Algebra",
+  "slug": "pappus-theorem-oq-02",
+  "description": "A complete algebraic proof of Pappus's Hexagon Theorem over any commutative ring K, using the same cross-product framework as the Desargues theorem. Given two sets of collinear points A, B, C and A', B', C', the three cross-join intersection points P, Q, R are collinear. The proof reduces to a degree-9 polynomial identity verified by computer algebra coefficients.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "lineCount": 466,
+    "leanFile": "proofs/Proofs/PappusTheoremOQ02.lean",
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.Tactic"
+    ],
+    "tags": ["projective-geometry", "ring-theory", "combinatorics", "cross-product", "pappus"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "cross-product",
+      "title": "Cross Product Infrastructure",
+      "description": "The definitions cross3, threeVecMat, and collinear_K establish the algebraic framework. cross3 is the standard 3D cross product over K; threeVecMat packages three vectors as matrix rows for determinant computation; collinear_K says three vectors in K³ are collinear (projectively) when the 3×3 determinant vanishes. The Lagrange identity (lagrange_cross_K) states cross(cross(a,b), cross(c,d)) = det(a,b,d)·c − det(a,b,c)·d.",
+      "theorems": ["cross3_zero", "cross3_one", "cross3_two", "threeVecMat_det_explicit", "lagrange_cross_K"]
+    },
+    {
+      "id": "pappus-core",
+      "title": "Core Pappus Identity",
+      "description": "The proof strategy: express the three intersection points P, Q, R as cross products, then show det(P, Q, R) = 0. The key steps are pappus_det_multilinear (degree-6 multilinear expansion, proved by ring) and pappus_core_identity (the key algebraic identity showing det(P,Q,R) is proportional to det(A,B,C)·det(A',B',C') with collinearity coefficients — proved using linear_combination with CAS-computed Gröbner coefficients).",
+      "theorems": ["pappus_det_multilinear", "pappus_core_identity"]
+    },
+    {
+      "id": "main-theorem",
+      "title": "Pappus's Theorem and Corollaries",
+      "description": "The main theorem pappus_K proves Pappus's Hexagon Theorem over any CommRing K: given collinearity of (A,B,C) and (A',B',C'), the three intersection points P, Q, R are collinear. Corollaries pappus_Q, pappus_Z, pappus_Fp specialize to ℚ, ℤ, and finite fields 𝔽_p respectively. A bonus theorem desargues_forward_K reproves one direction of Desargues using this framework.",
+      "theorems": ["pappus_K", "pappus_Q", "pappus_Z", "pappus_Fp", "desargues_forward_K"]
+    }
+  ],
+  "overview": {
+    "summary": "Pappus's Hexagon Theorem is one of the oldest and most important theorems in projective geometry: the six vertices of a hexagon inscribed alternately in two lines yield collinear diagonal intersections. Over a commutative ring, this is a polynomial identity; over a skew field, it fails—Pappus's theorem is equivalent to commutativity of the coordinatizing field.",
+    "approach": "The cross-product approach represents projective points as homogeneous coordinates in K³ and intersection of lines as cross products. Collinearity is the vanishing of a 3×3 determinant. After expressing P, Q, R as cross products via the Lagrange identity, the collinearity condition det(P,Q,R) = 0 reduces to a polynomial identity in the 18 coordinates of A, B, C, A', B', C'. This identity is verified by ring at degree 6, then the full Pappus identity is proved using CAS-computed coefficients for linear_combination.",
+    "significance": "Pappus's theorem has deep algebraic significance: in any projective plane, Pappus implies Desargues, and Pappus holds iff the plane can be coordinatized by a commutative field (not just a skew field). The Lean 4 proof here works over any CommRing, including ℤ and finite fields, and serves as a companion to the Desargues proof in this gallery."
+  },
+  "conclusion": {
+    "summary": "Pappus's Hexagon Theorem is machine-checked over any CommRing with no axioms or sorries. The approach directly parallels the gallery's Desargues proof, confirming that the cross-product framework handles both classical projective geometry theorems.",
+    "openQuestions": [
+      "Can Pappus's theorem be proved for the projective plane over a skew field—and does the proof then fail, confirming the necessity of commutativity?",
+      "Can the converse be formalized: if Pappus holds in some abstract projective plane, is the coordinatizing ring necessarily commutative?",
+      "Does this algebraic framework extend to higher-dimensional versions (Pappus for higher-dimensional projective spaces)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "desargues-theorem",
+      "relationship": "uses",
+      "description": "Shares the cross-product and Lagrange identity infrastructure"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `PappusTheoremOQ02.lean` (466 lines, 0 axioms, 0 sorries):

- **Status**: verified, badge: original
- **12 theorems, 3 defs** in the `PappusTheoremOQ02` namespace
- Proves Pappus's Hexagon Theorem over any CommRing K
- Same cross-product framework as the Desargues theorem

### Key Results
- `lagrange_cross_K`: Lagrange cross-product identity
- `pappus_det_multilinear`: degree-6 ring identity (proved by ring)
- `pappus_core_identity`: det(P,Q,R) = f*det(A,B,C) + g*det(A',B',C') via linear_combination
- `pappus_K`: main theorem for any CommRing
- `pappus_Q`, `pappus_Z`, `pappus_Fp`: corollaries for ℚ, ℤ, 𝔽_p

## Files
- `src/data/proofs/pappus-theorem-oq-02/meta.json`
- `src/data/proofs/pappus-theorem-oq-02/annotations.json`
- `src/data/proofs/pappus-theorem-oq-02/index.ts`

🤖 Generated by researcher-10