### PR TITLE
fix(badge): promote cauchy-schwarz-integral-incomplete-01 formalized→verified/original

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -13,7 +13,7 @@
     "sorries": 0
   },
   "meta": {
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
     "tags": [
       "functional-analysis",
@@ -23,7 +23,7 @@
       "measure-theory",
       "density-argument"
     ],
-    "badge": "formalized",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 952,


### PR DESCRIPTION
## Fix

Corrects the invalid `badge` value for `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01`.

## Evidence

**Before**:
- `meta.status = "formalized"` — but has 0 sorries (stale after PR #15638 synced 1→0)
- `meta.badge = "formalized"` — invalid value not in allowed set `{original, mathlib, axiom, wip, verified}`

**After**:
- `meta.status = "verified"` — 0 sorries, 0 axioms, all three steps proved
- `meta.badge = "original"` — fully machine-checked, original formalization

## Context

PRs #15581 and #15638 completed this proof (Step A via Hölder extremizer construction, Steps B/C proved earlier). The `assumptions` field already documents this: "All three sorries eliminated." The badge/status fields were not updated when the sorry was removed.

The parent file `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` still has 3 sorries and is being addressed separately in PR #15682.

---
Automated fix by lean-mechanic agent.