### PR TITLE
fix(hilbert-13-oq-04): correct axiom count 5→6

### DIFF
--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -21,8 +21,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 5,
-    "assumptions": "5 axioms: unitCube_covDimLE_pos (n≥1 case, upper bound for [0,1]^n), unitCube_covDim_lower_bound (dimension of [0,1]^n), ostrand_separating_maps (Ostrand 1965), generalized_kolmogorov_arnold (generalized KA theorem), sternfeld_characterization (Sternfeld 1985), superposition_2n_plus_1_sharp (optimality of 2n+1). The n=0 case (dim({*})=0) is now fully proved via covDimLE_of_unique. 0 sorries.",
+    "axiomCount": 6,
+    "assumptions": "6 axioms: unitCube_covDimLE_pos (n≥1 case, upper bound for [0,1]^n), unitCube_covDim_lower_bound (dimension of [0,1]^n), ostrand_separating_maps (Ostrand 1965), generalized_kolmogorov_arnold (generalized KA theorem), sternfeld_characterization (Sternfeld 1985), superposition_2n_plus_1_sharp (optimality of 2n+1). The n=0 case (dim({*})=0) is now fully proved via covDimLE_of_unique. 0 sorries.",
     "dateAdded": "2026-03-30",
     "hilbertNumber": 13,
     "mathlibDependencies": [
@@ -188,7 +188,7 @@
   "leanFile": {
     "path": "Proofs/Hilbert13GeneralSpaces.lean",
     "filename": "Hilbert13GeneralSpaces.lean",
-    "axiomCount": 5,
+    "axiomCount": 6,
     "sorries": 0,
     "lineCount": 480,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Correct `axiomCount` mismatch: meta.json claimed 5 axioms, file actually has 6.

## Evidence

PR #15643 claimed to reduce axiomCount from 6 to 5 by proving `covDimLE_of_unique` for the n=0 case. But the restructuring kept 6 axioms — `axiom unitCube_covDimLE` was renamed to `axiom unitCube_covDimLE_pos` (now n≥1 only) rather than eliminated.

Verified by `grep -nE '^axiom\s' proofs/Proofs/Hilbert13GeneralSpaces.lean`:

```
187:axiom unitCube_covDimLE_pos
204:axiom unitCube_covDim_lower_bound
249:axiom ostrand_separating_maps
278:axiom generalized_kolmogorov_arnold
319:axiom sternfeld_characterization
365:axiom superposition_2n_plus_1_sharp
```

The `assumptions` field already enumerated 6 axioms while the leading count read "5 axioms:" — contradiction within the field itself.

**Before**: meta.axiomCount = leanFile.axiomCount = 5; assumptions text "5 axioms:".
**After**: meta.axiomCount = leanFile.axiomCount = 6; assumptions text "6 axioms:".

Re-running `pnpm exec tsx scripts/auditor/find-targets.ts --issues` reports 0 targets after fix.

---
Automated fix by lean-mechanic agent.