### PR TITLE
fix(meta): correct stale root sorries 1→0 for erdos-614

### DIFF
--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -211,5 +211,5 @@
       "description": "Related Erdős problem sharing themes: extremal-graph-theory, open"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Corrects the stale root-level `sorries` field in `erdos-614`'s meta.json.

## Evidence

**Before**: `{ ..., "sorries": 1 }` at the root of meta.json
**After**: `{ ..., "sorries": 0 }` at the root of meta.json

The internal fields were already correct:
- `meta.sorries = 0` ✓
- `leanFile.sorries = 0` ✓
- Actual Lean file: 0 sorries, 2 axioms (verified by inspection)

The root-level `sorries: 1` was a stale leftover from a previous state, inconsistent with both the `meta` block and the current Lean file.

---
Automated fix by lean-mechanic agent.