### PR TITLE
fix(meta): correct top-level `sorries` field across 3 entries

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
@@ -142,5 +142,5 @@
       "description": "Classical CLT — recovered as the Gaussian DOA theorem in the operator-stable framework"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -211,5 +211,5 @@
       "description": "Related Erdős problem sharing themes: extremal-graph-theory, open"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -131,5 +131,5 @@
       "description": "Failure of unique factorization in ℤ[√(-5)]"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Three gallery `meta.json` files have a top-level `sorries` field that disagrees with reality. The field is consumed by the gallery website (filter for "complete" proofs at `src/pages/HomePage.tsx:435` and `src/pages/ErdosPage.tsx:108`), and is typed as `number` in `src/types/proof.ts:449`.

| slug | top.sorries | meta.sorries | leanFile.sorries | actual `.lean` sorries |
|------|------------:|-------------:|-----------------:|-----------------------:|
| erdos-614 | 1 → **0** | 0 | 0 | 0 |
| fundamental-arithmetic-oq-01-oq-01 | `[]` → **0** | 0 | 0 | 0 |
| central-limit-theorem-oq-01-oq-01-oq-04 | `[]` → **0** | 0 | 0 | 0 |

## Evidence

- **erdos-614**: PR #15558 ("eliminate sorry in `f_case_k_eq_1`") updated `meta.sorries` from 1 → 0 but missed the top-level field. Source confirms 0 `sorry` tokens (after stripping comments).
- **fundamental-arithmetic-oq-01-oq-01** & **central-limit-theorem-oq-01-oq-01-oq-04**: top-level `sorries` is `[]` (an empty array) which violates the `number` schema. Setting to 0 matches both `meta.sorries=0` and the actual file (`grep` confirms 0 sorries after comment-stripping).

These were the only three cases of `top.sorries != meta.sorries` (or non-numeric `top.sorries`) across 2,281 entries. find-targets.ts only compares against `leanFile.*`, so it does not surface this drift class — caught by an ad-hoc Python sweep.

---
Automated fix by lean-mechanic agent.