### PR TITLE
audit: tracker sync — 17 clean entries audited

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14251,6 +14251,108 @@
       "lastAudited": "2026-05-04T10:28:50Z",
       "result": "issues-found",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:54:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:54:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-00-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:54:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "brouwer-fixed-point-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:54:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:55:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq-01-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:55:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-100-oq-01-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:55:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1009-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:55:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos101-problem": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:55:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-polyhedral-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:55:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-polyhedral-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:57:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inclusion-exclusion-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:57:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-a5": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:57:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "perfect-numbers-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:57:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "puiseux-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:57:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "roth-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:57:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sperner-simplicial-instance": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-04T12:57:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
Audit tracker update: bulk clean pass on newly-added gallery entries.

## Entries audited (all clean)
- amgm-inequality-oq-02-oq-02
- angle-trisection-oq-02-oq-01-oq-01-oq-01
- arithmetic-series-oq-00-oq-02-oq-01
- birthday-problem-oq-01-oq-01 *(skipped — untracked, in-flight PR)*
- brouwer-fixed-point-oq-02-oq-01
- cauchy-schwarz-oq-01-oq-01-oq-02
- central-limit-theorem-oq-01-oq-01-oq-04
- erdos-100-oq-01-wip-01
- erdos-1009-oq-01
- erdos101-problem
- euler-polyhedral-oq-01
- euler-polyhedral-oq-02-oq-01 *(structure-encoded axioms correctly counted)*
- inclusion-exclusion-oq-03
- inverse-galois-a5
- perfect-numbers-oq-03
- puiseux-theorem-oq-02
- roth-theorem
- sperner-simplicial-instance

Separate tracker update for hilbert-13-oq-04 (issues-found, fix in #15693): see #15694.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)