### PR TITLE
research(fodor-pressing-down): add gallery entry for Fodor's pressing-down lemma

### DIFF
--- a/src/data/proofs/fodor-pressing-down/annotations.json
+++ b/src/data/proofs/fodor-pressing-down/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-club",
+    "type": "definition",
+    "label": "IsClubBelow",
+    "title": "Club Set Below an Ordinal",
+    "body": "A club (closed unbounded) set below ordinal o is S ⊆ Iio o that is closed (every limit ordinal below o that is a limit point of S belongs to S) and unbounded (S is cofinal in Iio o). Clubs form a filter that is countably complete for uncountable regular cardinals.",
+    "location": { "line": 53 },
+    "tags": ["definition", "club", "ordinal", "set-theory"]
+  },
+  {
+    "id": "ann-stationary",
+    "type": "definition",
+    "label": "IsStationaryBelow",
+    "title": "Stationary Set",
+    "body": "S is stationary below o if it meets every club below o. Stationary sets cannot be 'avoided' by a club — they are the natural domain of regressive functions in Fodor's lemma.",
+    "location": { "line": 59 },
+    "tags": ["definition", "stationary", "ordinal"]
+  },
+  {
+    "id": "ann-diag-inter",
+    "type": "definition",
+    "label": "diagInter",
+    "title": "Diagonal Intersection",
+    "body": "Δ_{α<o}(f α) = {γ < o | ∀ α < γ, γ ∈ f α}. Unlike ordinary intersection which demands membership for all α, the diagonal intersection only requires membership in f(α) for those α BELOW γ, respecting the ordinal structure.",
+    "location": { "line": 0 },
+    "tags": ["definition", "diagonal-intersection", "ordinal"]
+  },
+  {
+    "id": "ann-diag-club",
+    "type": "theorem",
+    "label": "diagInter_isClubBelow",
+    "title": "Diagonal Intersection of Clubs Is a Club",
+    "body": "If f(α) is a club below κ for every α < κ (κ regular uncountable), then diagInter f is a club. The two-part proof: (1) diagInter_isClosedBelow via closure of each f(α); (2) diagInter_isUnboundedBelow via a zipper argument interleaving elements from each f(α).",
+    "location": { "line": 0 },
+    "tags": ["diagonal-intersection", "club", "key-lemma"]
+  },
+  {
+    "id": "ann-fodor",
+    "type": "theorem",
+    "label": "fodor",
+    "title": "Fodor's Pressing-Down Lemma",
+    "body": "For regular uncountable κ, stationary S ⊆ κ.ord, and regressive f : S → κ.ord (f(α) < α): ∃ β, ∃ T ⊆ S stationary, ∀ α ∈ T, f(α) = β. Proof by contradiction: choose clubs C_β avoiding each fiber, form their diagonal intersection D (a club), derive a contradiction from any γ ∈ S ∩ D.",
+    "location": { "line": 0 },
+    "tags": ["fodor", "pressing-down", "main-theorem"]
+  },
+  {
+    "id": "ann-aleph1",
+    "type": "theorem",
+    "label": "fodor_aleph1",
+    "title": "Fodor's Lemma for ℵ₁",
+    "body": "The ℵ₁ specialization: any regressive function on a stationary subset of ω₁ is constant on some stationary subset. The most commonly used instance in combinatorial and descriptive set theory.",
+    "location": { "line": 0 },
+    "tags": ["fodor", "aleph1", "corollary"]
+  }
+]

--- a/src/data/proofs/fodor-pressing-down/index.ts
+++ b/src/data/proofs/fodor-pressing-down/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/FodorPressingDown.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -1,0 +1,59 @@
+{
+  "id": "fodor-pressing-down",
+  "title": "Fodor's Pressing-Down Lemma",
+  "slug": "fodor-pressing-down",
+  "description": "A complete formalization of Fodor's Pressing-Down Lemma (1956): any regressive function on a stationary subset of a regular uncountable cardinal is constant on some stationary subset. The proof uses the diagonal intersection technique—defining infrastructure for club sets, stationary sets, and diagonal intersections that is not yet in Mathlib.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "lineCount": 386,
+    "leanFile": "proofs/Proofs/FodorPressingDown.lean",
+    "imports": [
+      "Mathlib.SetTheory.Cardinal.Ordinal",
+      "Mathlib.SetTheory.Cardinal.Cofinality",
+      "Mathlib.SetTheory.Cardinal.Regular",
+      "Mathlib.SetTheory.Ordinal.Arithmetic",
+      "Mathlib.SetTheory.Ordinal.Topology"
+    ],
+    "tags": ["set-theory", "ordinals", "cardinals", "clubs", "stationary", "fodor"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "club-sets",
+      "title": "Club and Stationary Sets",
+      "description": "Definitions for the combinatorial core: IsUnboundedBelow (cofinally dense), IsClubBelow (closed and unbounded — a club set), and IsStationaryBelow (intersects every club). The structure IsClubBelow captures the topologically closed, cofinal condition. These are standard set-theoretic notions not yet formalized in Mathlib.",
+      "theorems": ["isClubBelow_Iio_of_isSuccLimit"]
+    },
+    {
+      "id": "diagonal-intersection",
+      "title": "Diagonal Intersection",
+      "description": "The diagonal intersection Δ_{α<κ}(f α) = {γ | ∀ α < γ, γ ∈ f α} simultaneously intersects all club sets indexed below κ while respecting the ordinal structure. The lemmas diagInter_isClosedBelow and diagInter_isUnboundedBelow (a zipper construction) together give diagInter_isClubBelow: the diagonal intersection of clubs is a club.",
+      "theorems": ["mem_diagInter", "diagInter_subset_Iio", "diagInter_isClosedBelow", "diagInter_isUnboundedBelow", "diagInter_isClubBelow"]
+    },
+    {
+      "id": "fodors-lemma",
+      "title": "Fodor's Lemma",
+      "description": "The main theorem fodor: for a regular uncountable cardinal κ with stationary set S and regressive function f (f(α) < α for all α ∈ S), some constant value is achieved on a stationary subset. Proof by contradiction using diagonal intersection. The corollary fodor_aleph1 specializes to κ = ℵ₁.",
+      "theorems": ["fodor", "fodor_aleph1"]
+    }
+  ],
+  "overview": {
+    "summary": "Fodor's Pressing-Down Lemma (also called the Fodor-Neumer theorem) is one of the fundamental tools of infinitary combinatorics. It asserts that any regressive function on a stationary set cannot 'press down' all values—some single value must be achieved on a stationary subset.",
+    "approach": "The proof uses diagonal intersection: the diagonal intersection of clubs C_β (for β < κ) is itself a club. If the conclusion failed, we could build clubs C_β avoiding each fiber f⁻¹(β), and their diagonal intersection would contradict the stationarity of S.",
+    "significance": "Fodor's lemma is used throughout combinatorial set theory: in the proof that the club filter is normal, in cardinal arithmetic, in the Erdős-Hajnal theorem on partition calculus, and in many reflection principles. The diagonal intersection construction formalized here is reusable infrastructure absent from Mathlib."
+  },
+  "conclusion": {
+    "summary": "Fodor's Pressing-Down Lemma is machine-checked with no axioms or sorries. The proof builds club and stationary set infrastructure currently missing from Mathlib.",
+    "openQuestions": [
+      "Can the club and stationary set infrastructure be contributed to Mathlib as a standalone library?",
+      "Does the formalization extend to Shelah-style combinatorial principles (e.g., Diamond ◇)?",
+      "Can the normal filter characterization (the club filter is κ-complete and normal) be derived from this infrastructure?"
+    ]
+  },
+  "crossReferences": []
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `FodorPressingDown.lean` (386 lines, 0 axioms, 0 sorries).

**Theorem (Fodor's Pressing-Down Lemma)**: For a regular uncountable cardinal κ, if S ⊆ κ.ord is stationary and f : S → κ.ord is regressive (f(α) < α for all α ∈ S), then f is constant on some stationary subset T ⊆ S.

This proof formalizes key set-theoretic infrastructure not in Mathlib 4: club sets (`IsClubBelow`), stationary sets (`IsStationaryBelow`), diagonal intersection (`diagInter`), and the proof of Fodor's lemma by contradiction via diagonal intersection of clubs.

**Key results**:
- `IsClubBelow` / `IsStationaryBelow`: Club and stationary set definitions
- `diagInter_isClubBelow`: Diagonal intersection of clubs is a club (closure + zipper argument)
- `fodor`: Fodor's pressing-down lemma for regular uncountable κ
- `fodor_aleph1`: The ℵ₁ specialization (most commonly cited form)

## Files
- `src/data/proofs/fodor-pressing-down/meta.json`
- `src/data/proofs/fodor-pressing-down/annotations.json`
- `src/data/proofs/fodor-pressing-down/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)