### PR TITLE
research(szemeredi-core-oq-01): add gallery entry for energy increment lemma

### DIFF
--- a/src/data/proofs/szemeredi-core-oq-01/annotations.json
+++ b/src/data/proofs/szemeredi-core-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-energy-increment-step",
+    "type": "theorem",
+    "label": "energy_increment_step",
+    "title": "Energy Increment Step (Main Theorem)",
+    "body": "energy_increment_step: given ε-irregular pair (A,B) in a partition where every part has size ≥ εn, there exists a refined partition with energy ≥ E(current) + ε⁶. The proof: witnesses A'⊆A, B'⊆B give |A'|≥ε|A|≥ε²n and |B'|≥ε²n and |d(A',B')-d(A,B)|>ε, so |A'|·|B'|·δ²>ε²n·ε²n·ε²=ε⁶n². The refined partition is (parts∖{A,B})∪{A',A∖A',B',B∖B'}.",
+    "location": { "line": 742 },
+    "tags": ["main-theorem", "energy-increment", "szemer-edi"]
+  },
+  {
+    "id": "ann-energy-increment-packaging",
+    "type": "theorem",
+    "label": "energy_increment_packaging",
+    "title": "Block-Decomposition Core Lemma",
+    "body": "energy_increment_packaging: separates the block-energy accounting from the ε⁶ lower bound. Given the split A={A',A\\A'} and B={B',B\\B'}, the refined partition's energy exceeds the original by at least 2/n²·|A'|·|B'|·(d(A',B')-d(A,B))². The argument decomposes partition energy into S×S (same), S×T and T×S (non-negative by convexity), and T×T (positive increment from irregularity).",
+    "location": { "line": 406 },
+    "tags": ["packaging", "block-decomposition", "energy-increment"]
+  },
+  {
+    "id": "ann-four-subpair-excess",
+    "type": "theorem",
+    "label": "four_subpair_excess_lb",
+    "title": "Per-Pair Energy Excess Lower Bound",
+    "body": "four_subpair_excess_lb: the energy of the four subpairs {A',A\\A'}×{B',B\\B'} exceeds the energy of A×B by at least 2·|A'|·|B'|·(d(A',B')-d(A,B))²/n². This is the key quantitative step converting a density deviation δ into an energy increment proportional to δ². Proved via four_subpair_deviation_identity (variance formula) and the non-negativity of squared terms.",
+    "location": { "line": 373 },
+    "tags": ["variance", "four-subpairs", "energy"]
+  },
+  {
+    "id": "ann-variance-decomposition",
+    "type": "theorem",
+    "label": "four_subpair_deviation_identity",
+    "title": "Variance Decomposition (δ-Identity)",
+    "body": "four_subpair_deviation_identity: the energy of the four subpairs equals the energy of A×B plus a non-negative variance term. Formally: Σ_{i,j} |Aᵢ||Bⱼ|d(Aᵢ,Bⱼ)² = |A||B|d(A,B)² + Σ |Aᵢ||Bⱼ|(d(Aᵢ,Bⱼ)-d(A,B))². The identity is the 2D analog of the parallel axis theorem: Var(X) = E[X²] - E[X]².",
+    "location": { "line": 348 },
+    "tags": ["variance", "identity", "algebra"]
+  },
+  {
+    "id": "ann-density-convexity",
+    "type": "theorem",
+    "label": "density_sq_convex_right",
+    "title": "Convexity of d² Under Splitting",
+    "body": "density_sq_convex_right: for B = B₁∪B₂ disjoint, |B|·d(A,B)² ≤ |B₁|·d(A,B₁)² + |B₂|·d(A,B₂)². This says d² is convex under weighted splits of one argument. Combined with edgeDensity_symm, it implies splitting EITHER argument is non-decreasing in total energy, which ensures the refinement never loses energy on the non-T×T blocks.",
+    "location": { "line": 78 },
+    "tags": ["convexity", "edge-density", "splitting"]
+  }
+]

--- a/src/data/proofs/szemeredi-core-oq-01/index.ts
+++ b/src/data/proofs/szemeredi-core-oq-01/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/SzemerediCoreOQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -1,0 +1,73 @@
+{
+  "id": "szemeredi-core-oq-01",
+  "title": "Energy Increment Lemma for Szemerédi Regularity",
+  "slug": "szemeredi-core-oq-01",
+  "description": "The energy increment step at the heart of Szemerédi's regularity lemma: if a partition contains an ε-irregular pair (A, B), the refined partition obtained by splitting A and B using the irregularity witnesses has energy at least ε⁶ larger. Covers edge-density convexity, a 2D variance identity, and the full block-decomposition argument.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "lineCount": 843,
+    "leanFile": "proofs/Proofs/SzemerediCoreOQ01.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.SzemerediCore",
+      "Proofs.SzemerediRegularity"
+    ],
+    "tags": ["combinatorics", "szemer-edi", "regularity", "energy-increment", "graph-theory"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "edge-density-algebra",
+      "title": "Edge Density Algebra",
+      "description": "Foundational algebraic identities for edge density: symmetry d(A,B)=d(B,A) (edgeDensity_symm), convexity when splitting the second argument (density_sq_convex_right), non-decrease under splitting both parts (sub4pair_energy_lower_bound), weighted-average identity for unions (edgeDensity_union_weighted_avg), and the exact excess formula when A is split into A' and A\\A' (energy_excess_A_split).",
+      "theorems": ["edgeDensity_symm", "density_sq_convex_right", "sub4pair_energy_lower_bound", "edgeDensity_union_weighted_avg", "energy_excess_A_split"]
+    },
+    {
+      "id": "variance-decomposition",
+      "title": "Variance Decomposition for Four Subpairs",
+      "description": "The δ-decomposition of energy over four subpairs {A',A\\A'} × {B',B\\B'}: a 2D weighted-average identity (four_subpair_edge_count_identity), a variance formula expressing the energy excess in terms of squared density deviations (four_subpair_deviation_identity), and the per-pair lower bound showing each irregular pair contributes ≥ 2|A'||B'|(d(A',B')-d(A,B))²/n² to the energy excess (four_subpair_excess_lb).",
+      "theorems": ["four_subpair_edge_count_identity", "four_subpair_deviation_identity", "four_subpair_excess_lb"]
+    },
+    {
+      "id": "energy-increment",
+      "title": "Energy Increment Theorem",
+      "description": "The main results: energy_increment_packaging (block-decomposition core — separates the ε⁶ increment from the block-energy accounting) and energy_increment_step (assembles the full argument from an irregular pair witness, combining the quantitative bound |A'|·|B'|·(d(A',B')-d(A,B))² > ε⁶·n² with the packaging lemma to produce a refined partition with energy ≥ E + ε⁶).",
+      "theorems": ["energy_increment_packaging", "energy_increment_step"]
+    }
+  ],
+  "overview": {
+    "summary": "The energy of a partition measures how 'pseudorandom' it is: E(P) = Σ_{A,B∈P} |A||B|d(A,B)²/n². Szemerédi's regularity lemma (1975) shows that every graph has an equipartition where most pairs are ε-regular. The key engine is the energy increment: each refinement step that fixes an irregular pair increases energy by ε⁶. Since energy ≤ 1, this can happen at most ε⁻⁶ times, giving a tower-type bound on partition size.",
+    "approach": "The proof works in four stages: (1) show d² is convex when an argument is split, so splitting a pair never decreases energy; (2) establish the variance formula expressing the energy excess over the four subpairs in terms of squared density deviations; (3) use irregularity witnesses to lower-bound the density deviation, giving |A'|·|B'|·δ² ≥ ε²n · ε²n · ε² = ε⁶n²; (4) convert to an energy increment ≥ ε⁶/n² × n² = ε⁶. The ε⁶ bound is for a single irregular pair; the ε⁵ bound in the standard Szemerédi proof comes from summing over all ≥ ε·k² irregular pairs.",
+    "significance": "Szemerédi's regularity lemma is one of the most powerful tools in combinatorics. It implies Szemerédi's theorem (AP-free sets have density 0), the graph removal lemma, the triangle removal lemma, the Erdős-Stone theorem, and many results in theoretical computer science. The energy increment method introduced by Szemerédi is the prototype for energy methods in higher-order regularity (Gowers 1998, Green-Tao 2008)."
+  },
+  "conclusion": {
+    "summary": "The ε⁶ energy increment for a single irregular pair is machine-checked, giving a formal foundation for the iterative refinement argument in Szemerédi's regularity lemma.",
+    "openQuestions": [
+      "Can the full regularity lemma (existence of an ε-regular equipartition) be formalized by iterating energy_increment_step at most ε⁻⁶ times?",
+      "Does the tower-type bound on partition size (exp(exp(...ε⁻⁵...))) emerge naturally from the formalization?",
+      "Can Gowers' hypergraph regularity and the energy increment for k-uniform hypergraphs be formalized using this infrastructure?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "szemeredi-core",
+      "relationship": "extends",
+      "description": "Imports SzemerediCore which defines edgeDensity, partitionEnergy, and IsEpsilonRegular"
+    },
+    {
+      "targetId": "szemeredi-regularity",
+      "relationship": "extends",
+      "description": "Imports SzemerediRegularity for irregularity witness existence"
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "supports",
+      "description": "The energy increment step is the key engine for proving Szemerédi's theorem on arithmetic progressions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `SzemerediCoreOQ01.lean` (843 lines, 0 axioms, 0 sorries).

**Theorem**: The energy increment step for Szemerédi's regularity lemma: if a partition contains an ε-irregular pair (A, B) with all parts of size ≥ εn, then there exists a refined partition with energy at least ε⁶ larger.

**Key results**:
- `edgeDensity_symm`: d(A,B) = d(B,A) (symmetry)
- `density_sq_convex_right`: d² is convex under weighted splits (splitting never decreases energy)
- `four_subpair_deviation_identity`: 2D variance formula — energy of four subpairs = energy of A×B + Σ deviation²
- `four_subpair_excess_lb`: per-pair lower bound on energy excess ≥ 2|A'||B'|(d(A',B')-d(A,B))²/n²
- `energy_increment_packaging`: block-decomposition core lemma isolating the ε⁶ increment
- `energy_increment_step`: main theorem assembling witnesses to produce refined partition with E ≥ E + ε⁶

The ε⁶ bound is per-pair; the ε⁵ bound in the standard Szemerédi proof comes from summing over all ≥ εk² irregular pairs.

## Files
- `src/data/proofs/szemeredi-core-oq-01/meta.json`
- `src/data/proofs/szemeredi-core-oq-01/annotations.json`
- `src/data/proofs/szemeredi-core-oq-01/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)