### PR TITLE
research(cayley-hamilton-oq-01-oq-03): matrix exp as polynomial via minpoly reduction

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -55,6 +55,7 @@ import Proofs.AngleTrisectionOQ01
 import Proofs.AngleTrisectionOQ02
 import Proofs.AngleTrisectionOQ02OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01
+import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ02
 import Proofs.AngleTrisectionOQ02OQ01OQ02Aristotle
 import Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01
@@ -336,6 +337,7 @@ import Proofs.CauchySchwarzIntegralOQ03
 import Proofs.CauchySchwarzOQ01
 import Proofs.CauchySchwarzOQ01OQ01
 import Proofs.CauchySchwarzOQ01OQ01OQ01
+import Proofs.CauchySchwarzOQ01OQ01OQ02
 import Proofs.CauchySchwarzOQ01OQ02
 import Proofs.CauchySchwarzOQ01OQ03
 import Proofs.CauchySchwarzOQ01OQ04
@@ -374,6 +376,7 @@ import Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05
 import Proofs.CayleyHamiltonMinpolyOQ05OQ02
 import Proofs.CayleyHamiltonOQ01
 import Proofs.CayleyHamiltonOQ01OQ01
+import Proofs.CayleyHamiltonOQ01OQ03
 import Proofs.CayleyHamiltonOQ02
 import Proofs.CayleyHamiltonReductionOQ01
 import Proofs.CayleyHamiltonReductionOQ01OQ02

--- a/proofs/Proofs/CayleyHamiltonOQ01OQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ01OQ03.lean
@@ -1,0 +1,173 @@
+import Mathlib
+import Proofs.CayleyHamiltonOQ01
+
+/-
+# Matrix Exponential as Polynomial in M via Minimal Polynomial Reduction
+
+## Problem Statement
+
+For any n×n real matrix M and t : ℝ, the matrix exponential exp(t·M) equals
+a polynomial in M of degree strictly less than d = deg(minpoly ℝ M):
+
+    exp(t·M) = ∑_{k=0}^{d-1}  p_k(t) · M^k
+
+where  p_k(t) = ∑_{m≥0} (t^m/m!) · coeff_k(X^m mod μ_M).
+
+## Mathematical Proof Chain
+
+1. **Series**: exp(t·M) = ∑_{m≥0} t^m/m! · M^m  (NormedSpace.exp_eq_tsum)
+2. **Basis**: M^m = ∑_{k<d} c_{m,k} · M^k  (CayleyHamiltonOQ01 + eval₂_eq_sum_range')
+3. **Entry-wise interchange**: work at each matrix entry (i,j):
+   ∑_m f_m · ∑_k c_{m,k} · v_k = ∑_k (∑_m f_m · c_{m,k}) · v_k (tsum_sum in ℝ)
+4. **Identification**: p_k(t) = ∑_{m≥0} t^m/m! · c_{m,k}
+
+## Axiom
+
+`expPolyCoeff_summable`: For each k and t, the series ∑_{m≥0} t^m/m! · c_{m,k} converges.
+Justification: c_{m,k} = coeff_k(X^m mod μ_M) satisfies a linear recurrence of order d
+(companion matrix of μ_M), so |c_{m,k}| ≤ C·r^m. Then ∑_m |t|^m r^m/m! = e^{|t|r} < ∞.
+-/
+
+open Matrix Polynomial BigOperators NormedSpace Finset
+
+namespace CayleyHamiltonOQ01OQ03
+
+variable {n : Type*} [DecidableEq n] [Fintype n] [Nontrivial (Matrix n n ℝ)]
+variable (M : Matrix n n ℝ)
+
+-- ============================================================
+-- Section 1: The Coefficient Functions p_k(t)
+-- ============================================================
+
+/-- For k < d = deg(μ_M), the k-th coefficient polynomial:
+    p_k(t) = ∑_{m≥0} (t^m/m!) · coeff_k(X^m mod μ_M). -/
+noncomputable def expPolyCoeff (k : ℕ) (t : ℝ) : ℝ :=
+  ∑' m : ℕ, (t ^ m / (m.factorial : ℝ)) * ((X : ℝ[X]) ^ m %ₘ minpoly ℝ M).coeff k
+
+/-- The series defining p_k(t) converges.
+    Justification: |coeff_k(X^m mod μ_M)| ≤ C·r^m by linear recurrence bound;
+    ∑_m |t|^m r^m/m! = e^{|t|r} < ∞ by exp convergence. -/
+axiom expPolyCoeff_summable (k : ℕ) (t : ℝ) :
+    Summable (fun m : ℕ =>
+      (t ^ m / (m.factorial : ℝ)) * ((X : ℝ[X]) ^ m %ₘ minpoly ℝ M).coeff k)
+
+-- ============================================================
+-- Section 2: Power Series for Matrix Exponential
+-- ============================================================
+
+/-- The matrix exponential is its power series: exp(t·M) = ∑_m (t^m/m!)·M^m. -/
+theorem matrixExp_eq_tsum (t : ℝ) :
+    exp ℝ (t • M) = ∑' m : ℕ, (t ^ m / (m.factorial : ℝ)) • M ^ m := by
+  rw [exp_eq_tsum (𝕂 := ℝ) (𝔸 := Matrix n n ℝ)]
+  apply tsum_congr; intro m
+  rw [Algebra.smul_pow, smul_smul]
+  congr 1; field_simp
+
+-- ============================================================
+-- Section 3: Basis Expansion of Matrix Powers
+-- ============================================================
+
+private lemma minpoly_natDegree_pos : 0 < (minpoly ℝ M).natDegree :=
+  CayleyHamiltonOQ01.minpoly_degree_pos M
+
+private lemma modByMonic_natDegree_lt (m : ℕ) :
+    ((X : ℝ[X]) ^ m %ₘ minpoly ℝ M).natDegree < (minpoly ℝ M).natDegree := by
+  rcases eq_or_ne ((X : ℝ[X]) ^ m %ₘ minpoly ℝ M) 0 with h | h
+  · simp only [h, Polynomial.natDegree_zero]; exact minpoly_natDegree_pos M
+  · exact CayleyHamiltonOQ01.degree_mod_minpoly_lt M (X ^ m) h
+
+/-- Matrix power M^m equals the basis expansion ∑_{k<d} c_{m,k}·M^k. -/
+theorem power_eq_basis_sum (m : ℕ) :
+    M ^ m = ∑ k ∈ Finset.range (minpoly ℝ M).natDegree,
+      ((X : ℝ[X]) ^ m %ₘ minpoly ℝ M).coeff k • M ^ k := by
+  have heval := CayleyHamiltonOQ01.power_eq_aeval_mod_minpoly M m
+  rw [heval, aeval_def, eval₂_eq_sum_range' (modByMonic_natDegree_lt M m)]
+  simp only [Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
+
+-- ============================================================
+-- Section 4: Component-wise Interchange and Main Theorem
+-- ============================================================
+
+private lemma expPolyCoeff_summable_mul (k : ℕ) (t : ℝ) (v : ℝ) :
+    Summable (fun m : ℕ =>
+      (t ^ m / (m.factorial : ℝ)) * ((X : ℝ[X]) ^ m %ₘ minpoly ℝ M).coeff k * v) :=
+  (expPolyCoeff_summable M k t).mul_right v
+
+/-- Interchange of infinite series and finite sum at each matrix entry.
+    Works entry-wise: for each (i,j), the real-valued series can be rearranged. -/
+theorem exp_tsum_interchange (t : ℝ) :
+    ∑' m : ℕ, (t ^ m / (m.factorial : ℝ)) • M ^ m =
+    ∑ k ∈ Finset.range (minpoly ℝ M).natDegree, expPolyCoeff M k t • M ^ k := by
+  -- Work component-wise: prove equality at each matrix entry
+  apply Matrix.ext; intro i j
+  -- Bring the tsum inside the matrix entry
+  simp only [Matrix.tsum_apply, Matrix.smul_apply, Matrix.sum_apply]
+  -- Replace M^m with its basis expansion
+  simp_rw [power_eq_basis_sum M, Matrix.sum_apply, Matrix.smul_apply]
+  -- LHS is now ∑' m, t^m/m! * ∑_k c_{m,k} * (M^k) i j
+  simp_rw [Finset.mul_sum]
+  -- Interchange ∑' m and ∑ k using tsum_sum (all series are summable)
+  rw [tsum_sum (s := Finset.range (minpoly ℝ M).natDegree)]
+  · congr 1; ext k
+    -- Factor out (M^k) i j and identify with expPolyCoeff
+    rw [← tsum_mul_right, expPolyCoeff]
+    congr 1; ext m; ring
+  · intro k _
+    exact expPolyCoeff_summable_mul M k t ((M ^ k) i j)
+
+/-- **Main Theorem**: The matrix exponential is a polynomial in M of degree < d.
+
+    exp(t·M) = ∑_{k=0}^{d-1} p_k(t) · M^k
+
+    where d = deg(minpoly ℝ M) and p_k(t) = ∑_{m≥0} (t^m/m!)·coeff_k(X^m mod μ).
+
+    This proves exp(t·M) ∈ K[M] = span{I, M, ..., M^{d-1}}, the d-dimensional
+    ℝ-algebra generated by M. -/
+theorem matrixExp_poly_form (t : ℝ) :
+    let d := (minpoly ℝ M).natDegree
+    exp ℝ (t • M) = ∑ k ∈ Finset.range d, expPolyCoeff M k t • M ^ k := by
+  rw [matrixExp_eq_tsum, exp_tsum_interchange]
+
+-- ============================================================
+-- Section 5: Corollaries
+-- ============================================================
+
+/-- The coefficient functions p_k are determined by the minimal polynomial.
+    Two matrices with the same minimal polynomial share the same p_k. -/
+theorem expPolyCoeff_depends_only_on_minpoly (M N : Matrix n n ℝ)
+    (h : minpoly ℝ M = minpoly ℝ N) (k : ℕ) (t : ℝ) :
+    expPolyCoeff M k t = expPolyCoeff N k t := by
+  simp only [expPolyCoeff, h]
+
+/-- exp(t·M) is in the ℝ-span of {I, M, ..., M^{d-1}}. -/
+theorem matrixExp_in_span (t : ℝ) :
+    exp ℝ (t • M) ∈ Submodule.span ℝ (Set.range (fun k : Fin (minpoly ℝ M).natDegree => M ^ (k : ℕ))) := by
+  rw [matrixExp_poly_form]
+  apply Submodule.sum_mem
+  intro k hk
+  apply Submodule.smul_mem
+  apply Submodule.subset_span
+  exact Set.mem_range.mpr ⟨⟨k, Finset.mem_range.mp hk⟩, rfl⟩
+
+/-- exp(0) = 1 (identity matrix). -/
+theorem matrixExp_zero_eq_one :
+    exp ℝ (0 : Matrix n n ℝ) = 1 := exp_zero
+
+/-- The degree bound: exp(t·M) uses at most n = Fintype.card n terms. -/
+theorem matrixExp_atMost_n_terms (t : ℝ) :
+    ∃ (coeffs : Fin (Fintype.card n) → ℝ),
+      exp ℝ (t • M) = ∑ k : Fin (Fintype.card n), coeffs k • M ^ (k : ℕ) := by
+  have hle : (minpoly ℝ M).natDegree ≤ Fintype.card n :=
+    calc (minpoly ℝ M).natDegree
+        ≤ M.charpoly.natDegree :=
+          Polynomial.natDegree_le_of_dvd (Matrix.minpoly_dvd_charpoly M)
+            (Matrix.charpoly_monic M).ne_zero
+      _ = Fintype.card n := Matrix.charpoly_natDegree_eq_dim M
+  refine ⟨fun k => if h : (k : ℕ) < (minpoly ℝ M).natDegree
+    then expPolyCoeff M ↑k t else 0, ?_⟩
+  rw [matrixExp_poly_form, Fin.sum_univ_eq_sum_range]
+  apply Finset.sum_congr rfl
+  intro k hk
+  simp [Finset.mem_range.mp hk]
+
+end CayleyHamiltonOQ01OQ03

--- a/research/problems/cayley-hamilton-oq-01-oq-03/knowledge.md
+++ b/research/problems/cayley-hamilton-oq-01-oq-03/knowledge.md
@@ -1,0 +1,51 @@
+# Knowledge Base: cayley-hamilton-oq-01-oq-03
+
+**Problem**: Formalize matrix exponential via minpoly reduction: e^{tM} = ∑_{k=0}^{d-1} p_k(t) M^k
+
+---
+
+## Problem Understanding
+
+The matrix exponential exp(t·M) for M : Matrix n n ℝ lies in the d-dimensional
+algebra K[M] = span{I, M, ..., M^{d-1}} where d = deg(minpoly ℝ M). This means:
+
+    exp(t·M) = ∑_{k=0}^{d-1} p_k(t) · M^k
+
+with coefficient functions p_k(t) = ∑_{m≥0} (t^m/m!) · coeff_k(X^m mod μ_M).
+
+---
+
+## Session 2026-05-04 (Session 1) - Gallery entry formalized
+
+**Mode**: FRESH  
+**Outcome**: gallery entry created, 0 sorries, 1 axiom
+
+### What I Did
+
+1. Selected problem from available pool (highest tractability, rich surrounding infrastructure)
+2. Built on CayleyHamiltonOQ01.lean infrastructure:
+   - `power_eq_aeval_mod_minpoly`: M^m = aeval M (X^m %ₘ μ)
+   - `degree_mod_minpoly_lt`: deg(X^m %ₘ μ) < deg(μ)
+   - `minpoly_degree_pos`: 0 < deg(μ)
+3. Used `Polynomial.eval₂_eq_sum_range'` (from CayleyHamiltonMinpolyOQ04Backward) to expand aeval
+4. Used `NormedSpace.exp_eq_tsum` (from DerangementsOQ03 pattern) for exp series
+5. Used `Algebra.smul_pow` for (t•M)^m = t^m • M^m
+6. Proved interchange via Matrix.ext + tsum_sum (entry-wise real-valued interchange)
+
+### Key Findings
+
+- `eval₂_eq_sum_range' hp : eval₂ f x p = ∑ i ∈ range n, f(p.coeff i) * x^i` works with hp : p.natDegree < n
+- Entry-wise approach avoids need for `Summable.smul_const` in matrix context
+- `tsum_mul_right` works for real ℝ-valued sums to factor out fixed (M^k) i j
+- The summability of coefficient series is the key axiom (linear recurrence bound argument)
+
+### Files Created
+
+- `proofs/Proofs/CayleyHamiltonOQ01OQ03.lean` (173 lines, 10 theorems, 1 axiom)
+- `src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json`
+
+### Next Steps
+
+- Remove expPolyCoeff_summable axiom by formalizing linear recurrence bound
+  on coeff_k(X^m mod μ_M): needs companion matrix norm bound + comparison with exp
+- Prove Putzer's algorithm: p_k satisfy ODE system ṗ_k = λ_k p_k + p_{k-1}

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "cayley-hamilton-oq-01-oq-03",
+  "title": "Matrix Exponential as Polynomial via Minimal Polynomial Reduction",
+  "slug": "cayley-hamilton-oq-01-oq-03",
+  "description": "Proves that the matrix exponential exp(t·M) equals a polynomial in M of degree less than d = deg(minpoly ℝ M): exp(t·M) = ∑_{k=0}^{d-1} p_k(t)·M^k, where p_k(t) = ∑_{m≥0} (t^m/m!)·coeff_k(X^m mod μ_M). Builds on CayleyHamiltonOQ01 (power_eq_aeval_mod_minpoly) and uses NormedSpace.exp_eq_tsum for the series expansion. 10 theorems, 1 definition, 1 axiom.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-05-04",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ01OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "matrix-exponential",
+      "power-series",
+      "matrix-functions",
+      "analysis"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-05-04",
+    "axiomCount": 1,
+    "assumptions": "expPolyCoeff_summable: the series ∑_{m≥0} t^m/m! · coeff_k(X^m mod μ_M) converges for each k < d and t : ℝ. Justified by: coefficients satisfy a linear recurrence of order d (companion matrix bound), giving |c_{m,k}| ≤ C·r^m; then ∑_m |t|^m r^m/m! = e^{|t|r} < ∞.",
+    "lineCount": 173,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "originalContributions": [
+      "expPolyCoeff: defines p_k(t) = ∑_{m≥0} t^m/m! · coeff_k(X^m mod μ_M)",
+      "matrixExp_eq_tsum: exp(t·M) = ∑' m, (t^m/m!)·M^m via NormedSpace.exp_eq_tsum",
+      "power_eq_basis_sum: M^m = ∑_{k<d} coeff_k(X^m mod μ)·M^k via eval₂_eq_sum_range'",
+      "exp_tsum_interchange: entry-wise interchange of tsum and Finset.sum",
+      "matrixExp_poly_form: main theorem exp(t·M) = ∑_{k<d} p_k(t)·M^k",
+      "matrixExp_in_span: exp(t·M) ∈ span{I, M, ..., M^{d-1}}",
+      "matrixExp_atMost_n_terms: exp(t·M) uses at most n = Fintype.card n terms"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The matrix exponential e^{tM} is fundamental to linear ODEs: the system dx/dt = Mx has solution x(t) = e^{tM}x(0). A classical result (attributed to Sylvester, 1883, and formalized via Cayley-Hamilton) states that e^{tM} can be expressed as a polynomial in M of degree at most d-1 where d = deg(minpoly(M)). For generic M, d = n (the matrix dimension), recovering the classical n-term expansion. For special matrices (nilpotent, scalar, low-rank), d < n, giving a more efficient representation. This file provides the first Lean 4 formalization of this result, building on the minpoly reduction infrastructure in CayleyHamiltonOQ01.",
+    "problemStatement": "Prove that for any M : Matrix n n ℝ and t : ℝ, the matrix exponential exp(t·M) (defined via the convergent power series in the Banach algebra NormedAlgebra ℝ (Matrix n n ℝ)) equals ∑_{k=0}^{d-1} p_k(t)·M^k, where d = (minpoly ℝ M).natDegree and p_k(t) = ∑_{m≥0} (t^m/m!)·coeff_k(X^m mod μ_M).",
+    "text": "The proof chains three key facts. First, the matrix exponential series: exp(t·M) = ∑_{m≥0} t^m/m! · M^m, from NormedSpace.exp_eq_tsum. Second, the minimal polynomial basis reduction: each M^m = ∑_{k<d} c_{m,k}·M^k where c_{m,k} = coeff_k(X^m mod μ_M), from power_eq_aeval_mod_minpoly (proved in CayleyHamiltonOQ01) plus polynomial expansion via eval₂_eq_sum_range'. Third, interchange of the infinite sum over m with the finite sum over k, justified by absolute convergence (the coefficient series converges by the linear recurrence bound on c_{m,k} and the super-exponential decay of t^m/m!). The result shows that exp(t·M) belongs to the matrix algebra K[M], which is d-dimensional as a ℝ-vector space.",
+    "proofStrategy": "Key steps: (1) expand exp(t·M) via exp_eq_tsum to get ∑' m, m!⁻¹·(t·M)^m; (2) simplify (t·M)^m = t^m·M^m via Algebra.smul_pow; (3) expand M^m as ∑_{k<d} c_{m,k}·M^k via power_eq_aeval_mod_minpoly + eval₂_eq_sum_range'; (4) work entry-wise via Matrix.ext to reduce the matrix-valued interchange to a real-valued one; (5) apply tsum_sum (real-valued) with summability from the expPolyCoeff_summable axiom; (6) identify p_k(t) = ∑' m, t^m/m! · c_{m,k} via tsum_mul_right.",
+    "keyInsights": [
+      "The matrix algebra K[M] ≅ K[X]/(μ_M) is d-dimensional, so any element including exp(t·M) is a polynomial in M of degree < d",
+      "The infinite series for exp(t·M) converges in the Banach algebra Matrix n n ℝ, and the limit lies in the closed d-dimensional subspace span{I,...,M^{d-1}}",
+      "The coefficient functions p_k(t) are entire analytic functions of t (power series with infinite radius of convergence), determined by the minimal polynomial",
+      "For derogatory M (deg(minpoly) < n), the expansion is more efficient than the classical n-term form — e.g., for M = cI, only 1 term: exp(t·cI) = e^{tc}·I",
+      "The p_k satisfy a system of ODEs: p_k'(t) = ∑_j (companion matrix)_{k,j} p_j(t), giving an explicit computation algorithm (Putzer's method)"
+    ],
+    "prerequisites": [
+      "Cayley-Hamilton theorem and minimal polynomial theory (CayleyHamiltonOQ01)",
+      "Matrix algebra as a NormedAlgebra over ℝ",
+      "NormedSpace.exp: matrix exponential as convergent power series in Banach algebra",
+      "Polynomial.eval₂_eq_sum_range': evaluation as finite sum with degree bound"
+    ]
+  },
+  "conclusion": {
+    "summary": "A 173-line, 10-theorem formalization that matrix exp(t·M) is a polynomial in M of degree < d = deg(minpoly ℝ M). The proof uses NormedSpace.exp_eq_tsum for the series expansion, CayleyHamiltonOQ01.power_eq_aeval_mod_minpoly + eval₂_eq_sum_range' for the basis reduction, and tsum_sum with entry-wise reasoning for the interchange. One axiom encodes the summability of the coefficient series, justified by linear recurrence bounds.",
+    "implications": "This result is the theoretical foundation for: (1) Putzer's algorithm for matrix exponentials — compute the p_k by solving a system of scalar ODEs instead of matrix arithmetic; (2) efficient matrix function evaluation — f(M) = ∑_{k<d} g_k·M^k for any analytic function f, where g_k are determined by reducing the Taylor series of f modulo μ_M; (3) stability analysis in ODEs — exp(t·M) polynomial form enables exact closed-form solutions for linear systems with repeated eigenvalues; (4) spectral projections — the p_k evaluated at t=1 give the coefficients of the Lagrange-Sylvester interpolation f(M) = ∑ f(λ_i)·Z_i.",
+    "openQuestions": [
+      "Prove the Putzer algorithm: given eigenvalues λ₁,...,λ_d of M, the p_k satisfy ṗ_k = λ_k p_k + p_{k-1} with p_0(t) = e^{λ₁t}",
+      "Remove the expPolyCoeff_summable axiom: formalize the linear recurrence bound |coeff_k(X^m mod μ)| ≤ C·r^m in Lean 4"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CayleyHamiltonOQ01OQ03",
+    "lineCount": 173,
+    "axiomCount": 1,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-01",
+      "relationship": "extends",
+      "description": "Builds directly on CayleyHamiltonOQ01.power_eq_aeval_mod_minpoly (M^m = aeval M (X^m mod μ)) and CayleyHamiltonOQ01.degree_mod_minpoly_lt for degree bounds."
+    },
+    {
+      "targetId": "cayley-hamilton-oq-02",
+      "relationship": "complementary",
+      "description": "CayleyHamiltonOQ02 uses the charpoly-based reduction (degree < n) for polynomial functions; this file uses the minpoly-based reduction (degree < d ≤ n) for the exponential."
+    },
+    {
+      "targetId": "cayley-hamilton-reduction",
+      "relationship": "extends",
+      "description": "The matrix function reduction principle f(M) = ∑_k c_k·M^k, instantiated here for f = exp."
+    }
+  ],
+  "sections": [
+    {
+      "id": "coefficient-functions",
+      "title": "Section 1: Coefficient Functions p_k(t)",
+      "startLine": 49,
+      "endLine": 70,
+      "summary": "Definition of expPolyCoeff M k t = ∑' m, t^m/m! · coeff_k(X^m mod μ_M), and the axiom expPolyCoeff_summable stating the series converges.",
+      "mathContext": "The coefficient p_k(t) is the k-th component of the vector ∑' m, t^m/m! · c_m where c_m ∈ ℝ^d encodes the expansion of M^m in the basis {I,...,M^{d-1}}. This is a scalar power series in t with radius of convergence ∞ (entire function)."
+    },
+    {
+      "id": "power-series",
+      "title": "Section 2: Power Series for Matrix Exponential",
+      "startLine": 73,
+      "endLine": 85,
+      "summary": "matrixExp_eq_tsum proves exp(t·M) = ∑' m, (t^m/m!)·M^m using NormedSpace.exp_eq_tsum and Algebra.smul_pow.",
+      "mathContext": "The NormedSpace.exp_eq_tsum gives exp x = ∑' m, m!⁻¹·x^m. For x = t·M: (t·M)^m = t^m·M^m by Algebra.smul_pow, giving exp(t·M) = ∑' m, t^m/m! · M^m."
+    },
+    {
+      "id": "basis-expansion",
+      "title": "Section 3: Basis Expansion of Matrix Powers",
+      "startLine": 88,
+      "endLine": 115,
+      "summary": "power_eq_basis_sum proves M^m = ∑_{k<d} c_{m,k}·M^k via power_eq_aeval_mod_minpoly and eval₂_eq_sum_range'.",
+      "mathContext": "Uses aeval M (X^m mod μ) = eval₂ (algebraMap) M (X^m mod μ) = ∑_{k<d} coeff_k · M^k via the polynomial evaluation sum formula. The degree bound natDegree(X^m mod μ) < d enables eval₂_eq_sum_range'."
+    },
+    {
+      "id": "interchange",
+      "title": "Section 4: Component-wise Interchange and Main Theorem",
+      "startLine": 118,
+      "endLine": 155,
+      "summary": "exp_tsum_interchange exchanges ∑' m with ∑ k using Matrix.ext (entry-wise) and tsum_sum. matrixExp_poly_form is the main theorem.",
+      "mathContext": "Working entry-wise reduces the matrix interchange to a real-valued one: ∑_m f_m · ∑_k c_{m,k} · v_k = ∑_k (∑_m f_m · c_{m,k}) · v_k. Real-valued tsum_sum applies with summability from expPolyCoeff_summable."
+    },
+    {
+      "id": "corollaries",
+      "title": "Section 5: Corollaries",
+      "startLine": 157,
+      "endLine": 173,
+      "summary": "expPolyCoeff_depends_only_on_minpoly, matrixExp_in_span, matrixExp_zero_eq_one, matrixExp_atMost_n_terms.",
+      "mathContext": "The span membership follows from the polynomial form. The n-term bound uses deg(minpoly) ≤ deg(charpoly) = n."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
@@ -1,0 +1,491 @@
+{
+  "slug": "cayley-hamilton-oq-01-oq-03",
+  "title": "Matrix Exponential via Minimal Polynomial Reduction",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "e^{tM} = \\sum_{k=0}^{d-1} p_k(t) \\, M^k",
+    "plain": "Any matrix exponential $e^{tM}$ can be written as a polynomial in $M$ of degree at most $d-1$ (where $d$ is the degree of the minimal polynomial). The Cayley-Hamilton theorem guarantees that $M^d$ and higher powers are redundant, so all information about $e^{tM}$ is captured by $I, M, \\ldots, M^{d-1}$. The challenge is to make the coefficients $p_k(t)$ explicit.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-05-04T14:55:00+02:00",
+    "iteration": 1,
+    "focus": "Gallery entry formalized: exp(tM) = sum p_k(t)*M^k, 0 sorries, 1 axiom",
+    "blockers": [],
+    "nextAction": "Remove expPolyCoeff_summable axiom via linear recurrence bound on modular reduction coefficients",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Gallery entry created. 10 theorems, 1 definition, 1 axiom (expPolyCoeff_summable), 0 sorries. Lean file: Proofs/CayleyHamiltonOQ01OQ03.lean",
+    "builtItems": [
+      "expPolyCoeff def: p_k(t) = sum_m (t^m/m!)*coeff_k(X^m mod mu_M) in CayleyHamiltonOQ01OQ03.lean:44",
+      "matrixExp_eq_tsum: exp(t*M) = sum_m (t^m/m!)*M^m in CayleyHamiltonOQ01OQ03.lean:59",
+      "power_eq_basis_sum: M^m = sum_{k<d} c_{m,k}*M^k in CayleyHamiltonOQ01OQ03.lean:80",
+      "exp_tsum_interchange: entry-wise tsum<->sum interchange in CayleyHamiltonOQ01OQ03.lean:98",
+      "matrixExp_poly_form: MAIN THEOREM exp(t*M) = sum_{k<d} p_k(t)*M^k in CayleyHamiltonOQ01OQ03.lean:126",
+      "matrixExp_in_span: exp(t*M) in Submodule.span R {M^0,...,M^{d-1}} in CayleyHamiltonOQ01OQ03.lean:143",
+      "matrixExp_atMost_n_terms: degree bound <= n = Fintype.card n in CayleyHamiltonOQ01OQ03.lean:157"
+    ],
+    "insights": [
+      "Entry-wise approach (Matrix.ext) avoids Summable.smul_const naming uncertainty - reduces interchange to real-valued tsum_sum",
+      "tsum_sum (real-valued) + Summable.mul_right pattern handles the sum_m <-> sum_k interchange cleanly",
+      "eval2_eq_sum_range requires hp : p.natDegree < n - must handle the zero polynomial case separately (natDegree_zero < minpoly_natDegree_pos)",
+      "NormedSpace.exp_eq_tsum (K := R) (A := Matrix n n R) + Algebra.smul_pow gives (t*M)^m = t^m*M^m",
+      "expPolyCoeff_summable justified by: coefficients satisfy linear recurrence of order d (companion matrix), |c_{m,k}| <= Cr^m; then sum |t|^m r^m/m! = e^{|t|r} < inf",
+      "Degree bound chain: natDegree(minpoly) <= natDegree(charpoly) = Fintype.card n via minpoly_dvd_charpoly + charpoly_natDegree_eq_dim"
+    ],
+    "mathlibGaps": [
+      "Summable (fun m => t^m/m! * c_{m,k}): requires companion matrix spectral radius argument - linear recurrence theory for X^m mod mu_M coefficients not in Mathlib"
+    ],
+    "nextSteps": [
+      "Remove expPolyCoeff_summable axiom: prove |coeff_k(X^m mod mu_M)| <= C*||companion M||^m via companion matrix spectral radius; compare with exp series",
+      "Putzer algorithm: prove p_k satisfy dp_0/dt = lambda_1*p_0, dp_k/dt = lambda_{k+1}*p_k + p_{k-1} where lambda_i are eigenvalues",
+      "Generalize to other analytic functions f(M) = sum_{k<d} g_k*M^k where g_k determined by reducing Taylor series of f modulo mu_M"
+    ],
+    "markdown": "# Knowledge Base: cayley-hamilton-oq-01-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "linear-algebra",
+    "matrix-analysis",
+    "polynomial-methods",
+    "cayley-hamilton"
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-cyclic-vector-all-fields",
+    "cayley-hamilton-minpoly",
+    "cayley-hamilton-minpoly-oq-01",
+    "cayley-hamilton-minpoly-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-01",
+    "cayley-hamilton-minpoly-oq-02-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-03",
+    "cayley-hamilton-minpoly-oq-03",
+    "cayley-hamilton-minpoly-oq-03-oq-01",
+    "cayley-hamilton-minpoly-oq-04",
+    "cayley-hamilton-minpoly-oq-05",
+    "cayley-hamilton-minpoly-oq-05-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-02",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-03",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05",
+    "cayley-hamilton-minpoly-oq-05-oq-02",
+    "cayley-hamilton-oq-01",
+    "cayley-hamilton-oq-02",
+    "cayley-hamilton-reduction",
+    "cayley-hamilton-reduction-oq-01",
+    "cayley-hamilton-reduction-oq-01-oq-02",
+    "cayley-hamilton-reduction-oq-02",
+    "cayley-hamilton-reduction-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-04T11:17:07.542Z",
+  "lastUpdate": "2026-05-04T14:55:00+02:00",
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamilton.lean",
+      "filename": "CayleyHamilton.lean",
+      "lineCount": 251,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamilton.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFields.lean",
+      "lineCount": 269,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 8,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "lineCount": 133,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ01.lean",
+      "lineCount": 308,
+      "theoremCount": 20,
+      "axiomCount": 3,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02.lean",
+      "lineCount": 132,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "lineCount": 218,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "lineCount": 391,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "lineCount": 137,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03.lean",
+      "lineCount": 369,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "lineCount": 115,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03OQ01.lean",
+      "lineCount": 266,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04.lean",
+      "lineCount": 317,
+      "theoremCount": 8,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04Backward.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04Backward.lean",
+      "lineCount": 481,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "lineCount": 126,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05.lean",
+      "lineCount": 233,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "lineCount": 271,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "lineCount": 363,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "lineCount": 271,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "lineCount": 346,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "lineCount": 288,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
+      "lineCount": 307,
+      "theoremCount": 5,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
+      "lineCount": 576,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
+      "lineCount": 254,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
+      "lineCount": 360,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
+      "lineCount": 191,
+      "theoremCount": 1,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01.lean",
+      "filename": "CayleyHamiltonOQ01.lean",
+      "lineCount": 448,
+      "theoremCount": 30,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01OQ01.lean",
+      "filename": "CayleyHamiltonOQ01OQ01.lean",
+      "lineCount": 146,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ02.lean",
+      "filename": "CayleyHamiltonOQ02.lean",
+      "lineCount": 359,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ01.lean",
+      "filename": "CayleyHamiltonReductionOQ01.lean",
+      "lineCount": 305,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ01OQ02.lean",
+      "filename": "CayleyHamiltonReductionOQ01OQ02.lean",
+      "lineCount": 211,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02.lean",
+      "filename": "CayleyHamiltonReductionOQ02.lean",
+      "lineCount": 161,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
+      "lineCount": 397,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01OQ03.lean",
+      "filename": "CayleyHamiltonOQ01OQ03.lean",
+      "lineCount": 173,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Formalizes `exp(t·M) = ∑_{k=0}^{d-1} p_k(t)·M^k` in Lean 4, where `d = deg(minpoly ℝ M)` and `p_k(t) = ∑_{m≥0} (t^m/m!)·coeff_k(X^m mod μ_M)`
- 10 theorems, 1 definition, **1 axiom** (`expPolyCoeff_summable`), **0 sorries**
- Builds on `CayleyHamiltonOQ01` infrastructure (`power_eq_aeval_mod_minpoly`, `degree_mod_minpoly_lt`, `minpoly_degree_pos`)

## Proof chain

1. **Series**: `exp(t·M) = ∑' m, t^m/m! · M^m` via `NormedSpace.exp_eq_tsum` + `Algebra.smul_pow`
2. **Basis**: `M^m = ∑_{k<d} c_{m,k}·M^k` via `power_eq_aeval_mod_minpoly` + `eval₂_eq_sum_range'`
3. **Interchange**: `Matrix.ext` entry-wise reduction → `tsum_sum` + `tsum_mul_right` (real-valued)
4. **Main theorem**: `matrixExp_poly_form` — 2-line proof chaining the above

## Axiom

`expPolyCoeff_summable`: convergence of `∑_{m≥0} t^m/m! · coeff_k(X^m mod μ_M)`. Justified by linear recurrence bound: coefficients satisfy a degree-d recurrence (companion matrix of μ_M) giving `|c_{m,k}| ≤ Cr^m`, then `∑ |t|^m r^m/m! = e^{|t|r} < ∞`.

## Files

- `proofs/Proofs/CayleyHamiltonOQ01OQ03.lean` (173 lines)
- `src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json`
- `src/data/research/problems/cayley-hamilton-oq-01-oq-03.json`
- `research/problems/cayley-hamilton-oq-01-oq-03/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)