### PR TITLE
research(wilsons-theorem-oq-02-ext): Gauss-Wilson non-cyclic product via two-involution trick

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-02-ext/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-gauss-wilson-abstract",
+    "type": "theorem",
+    "label": "gaussWilson_abstract_ext",
+    "title": "Gauss-Wilson Theorem (Complete Characterization)",
+    "body": "gaussWilson_abstract_ext: for n ≥ 3, ∏(ZMod n)ˣ = -1 ↔ IsCyclic (ZMod n)ˣ. This is the complete group-theoretic characterization of the Gauss-Wilson product. The cyclic case (∏ = -1) uses Mathlib's Wilson theorem infrastructure; the non-cyclic case (∏ = 1 ≠ -1) is proved via the two-involution trick. Together they show that the product distinguishes cyclic from non-cyclic unit groups.",
+    "location": { "line": 490 },
+    "tags": ["main-theorem", "gauss-wilson", "characterization"]
+  },
+  {
+    "id": "ann-prod-non-cyclic",
+    "type": "theorem",
+    "label": "prod_units_one_of_not_cyclic_ext",
+    "title": "Product of Units is 1 When Non-Cyclic",
+    "body": "prod_units_one_of_not_cyclic_ext: for n ≥ 3 with (ZMod n)× non-cyclic, ∏(ZMod n)ˣ = 1. The proof: (1) reduce to ∏S where S = {x | x²=1} via pairing non-square-root units with their inverses; (2) apply the two-involution trick: FPF involution x↦cx gives ∏S = c^(|S|/2); FPF involution x↦cdx gives ∏S = (cd)^(|S|/2); comparing forces d^(|S|/2) = 1 and then c^(|S|/2) = 1, so ∏S = 1.",
+    "location": { "line": 362 },
+    "tags": ["non-cyclic", "product", "two-involution"]
+  },
+  {
+    "id": "ann-prod-involution",
+    "type": "theorem",
+    "label": "prod_involution_const",
+    "title": "FPF Involution with Constant Pair Product",
+    "body": "prod_involution_const: in a finite commutative group G with FPF involution σ satisfying x·σ(x) = c for all x, ∏G = c^(|G|/2). This is the abstract engine of the two-involution trick. Proved by telescoping: pair each x with σ(x), each pair contributes c, and there are |G|/2 pairs. Works for any commutative group, not just ZMod.",
+    "location": { "line": 99 },
+    "tags": ["involution", "product", "abstract-algebra"]
+  },
+  {
+    "id": "ann-fpf-even",
+    "type": "theorem",
+    "label": "even_card_of_fpf_involution",
+    "title": "FPF Involution Implies Even Cardinality",
+    "body": "even_card_of_fpf_involution: a fixed-point-free involution on a finite set implies even cardinality. Proved by constructing an explicit bijection between the set and pairs. Required for prod_involution_const (to make sense of c^(|G|/2) for natural number exponents).",
+    "location": { "line": 59 },
+    "tags": ["involution", "cardinality", "even"]
+  },
+  {
+    "id": "ann-card-s-ge3",
+    "type": "theorem",
+    "label": "card_sq_eq_one_ge_three_of_not_cyclic_zmod",
+    "title": "Non-Cyclic 2-Torsion Has Size ≥ 3",
+    "body": "card_sq_eq_one_ge_three_of_not_cyclic_zmod: for n ≥ 3 with (ZMod n)× non-cyclic, |{x : (ZMod n)ˣ | x² = 1}| ≥ 3. This follows directly from GaussWilsonNonCyclic, which proves ∃ x with x²=1, x ≠ ±1. The three elements are 1, -1, and that third root, giving cardinality ≥ 3 and allowing the two-involution trick to pick distinct c, d.",
+    "location": { "line": 278 },
+    "tags": ["2-torsion", "cardinality", "non-cyclic"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/WilsonsTheoremOQ02Ext.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
@@ -1,0 +1,82 @@
+{
+  "id": "wilsons-theorem-oq-02-ext",
+  "title": "Gauss-Wilson Theorem: Non-Cyclic Product via Two-Involution Trick",
+  "slug": "wilsons-theorem-oq-02-ext",
+  "description": "Proves the non-cyclic case of the Gauss-Wilson theorem: when (ZMod n)× is not cyclic (n ≥ 3), the product of all units is 1 rather than -1. The key tool is the two-involution trick on the 2-torsion subgroup S = {x | x²=1}: two distinct FPF involutions on S both compute ∏S, forcing ∏S = 1. Combined with the cyclic case, this gives gaussWilson_abstract_ext: ∏(ZMod n)× = -1 iff (ZMod n)× is cyclic.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "lineCount": 539,
+    "leanFile": "proofs/Proofs/WilsonsTheoremOQ02Ext.lean",
+    "imports": [
+      "Mathlib.NumberTheory.Wilson",
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.RingTheory.ZMod.UnitsCyclic",
+      "Mathlib.GroupTheory.SpecificGroups.Cyclic",
+      "Mathlib.FieldTheory.Finite.Basic",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Data.Nat.PrimeFin",
+      "Mathlib.Tactic",
+      "Proofs.GaussWilsonNonCyclic"
+    ],
+    "tags": ["number-theory", "group-theory", "wilson", "gauss-wilson", "cyclic-groups", "zmod"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "group-lemmas",
+      "title": "Group-Theoretic Lemmas",
+      "description": "Two foundational lemmas for commutative groups: mul_sq_eq_one (x² = 1 implies x = x⁻¹), and even_card_of_fpf_involution (a fixed-point-free involution on a finite set implies even cardinality). These are the building blocks for the two-involution trick.",
+      "theorems": ["mul_sq_eq_one", "even_card_of_fpf_involution"]
+    },
+    {
+      "id": "involution-product",
+      "title": "Product via FPF Involutions",
+      "description": "The core algebraic machinery: prod_involution_const shows that if σ is a FPF involution on a finite commutative group G with x·σ(x) = c for all x (a constant), then ∏G = c^(|G|/2). This is the abstract version of pairing each unit with its partner under the involution.",
+      "theorems": ["prod_involution_const"]
+    },
+    {
+      "id": "non-cyclic-case",
+      "title": "Non-Cyclic Units Have Trivial Product",
+      "description": "Three results building to the main theorem: card_sq_eq_one_ge_three_of_not_cyclic_zmod (imports GaussWilsonNonCyclic to get |S| ≥ 3), prod_eq_prod_sq_eq_one (reduces ∏(ZMod n)× to ∏S via involution pairing with -1), and prod_units_one_of_not_cyclic_ext (the two-involution argument: apply involution x↦cx and x↦cdx for distinct c,d ∈ S\\{1} to force ∏S = 1).",
+      "theorems": ["card_sq_eq_one_ge_three_of_not_cyclic_zmod", "prod_eq_prod_sq_eq_one", "prod_units_one_of_not_cyclic_ext"]
+    },
+    {
+      "id": "main-theorem",
+      "title": "Gauss-Wilson Characterization",
+      "description": "gaussWilson_abstract_ext: for n ≥ 3, ∏(ZMod n)ˣ = -1 ↔ (ZMod n)ˣ is cyclic. The two directions: (→) if (ZMod n)× is non-cyclic, the previous section gives ∏ = 1 ≠ -1; (←) the cyclic case follows from Mathlib's Wilson theorem infrastructure. This gives a complete group-theoretic characterization of the Gauss-Wilson product.",
+      "theorems": ["gaussWilson_abstract_ext"]
+    }
+  ],
+  "overview": {
+    "summary": "The Gauss-Wilson theorem (1801) characterizes when the product of all units mod n equals -1: exactly when n ∈ {1, 2, 4, p^k, 2p^k} for odd primes p — the same condition that makes (ZMod n)× cyclic. This file proves the harder direction: when (ZMod n)× is non-cyclic, the product is 1 (not -1). The key insight is the two-involution trick on the 2-torsion subgroup.",
+    "approach": "The two-involution trick: let S = {x ∈ (ZMod n)× | x² = 1}. By GaussWilsonNonCyclic, |S| ≥ 3 when non-cyclic. Pick distinct c, d ∈ S \\ {1}. The involution x ↦ cx is FPF on S with pair product x·cx = c (since c² = 1), so ∏S = c^(|S|/2). The involution x ↦ cdx is also FPF with pair product cd, so ∏S = (cd)^(|S|/2) = c^(|S|/2)·d^(|S|/2). Combining: d^(|S|/2) = 1. By symmetry c^(|S|/2) = 1, so ∏S = c^(|S|/2) = 1. Since ∏(ZMod n)× = ∏S · (product of units with x² ≠ 1 paired via x ↦ x⁻¹) = ∏S · 1 = 1.",
+    "significance": "The Gauss-Wilson theorem characterizes which moduli n have the property that the product of all invertible residues mod n is ≡ -1 (mod n). It is a generalization of Wilson's theorem (n prime: (p-1)! ≡ -1 mod p) and connects the group structure of (ZMod n)× to elementary number theory. The two-involution trick is a beautiful example of using group structure to compute a product without explicit enumeration."
+  },
+  "conclusion": {
+    "summary": "The non-cyclic case of the Gauss-Wilson theorem is machine-checked using the two-involution trick on the 2-torsion subgroup, giving a complete characterization: ∏(ZMod n)× = -1 iff (ZMod n)× is cyclic.",
+    "openQuestions": [
+      "Can the full Gauss-Wilson product formula (∏(ZMod n)× = -1 for n ∈ {1,2,4,p^k,2p^k} and 1 otherwise) be derived as a corollary?",
+      "Does the two-involution trick generalize to other finite abelian groups — is there a general criterion for when ∏G = 1 based on the 2-torsion structure?",
+      "Can this result be used to give a direct Lean 4 proof of quadratic reciprocity via the structure of (ZMod p)×?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "gauss-wilson-non-cyclic",
+      "relationship": "uses",
+      "description": "Imports GaussWilsonNonCyclic to obtain |{x | x²=1}| ≥ 3 in the non-cyclic case"
+    },
+    {
+      "targetId": "wilsons-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Extends the cyclic case infrastructure to prove the complete Gauss-Wilson characterization"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `WilsonsTheoremOQ02Ext.lean` (539 lines, 0 axioms, 0 sorries).

**Theorem**: For n ≥ 3, ∏(ZMod n)ˣ = -1 ↔ (ZMod n)ˣ is cyclic (gaussWilson_abstract_ext). The non-cyclic direction is proved via the two-involution trick: when |S| = |{x | x²=1}| ≥ 3, pick distinct c,d ∈ S\{1}, then the FPF involutions x↦cx and x↦cdx both compute ∏S but force ∏S = c^(|S|/2) = (cd)^(|S|/2), so d^(|S|/2) = 1 and ultimately ∏S = 1.

**Key results**:
- `even_card_of_fpf_involution`: FPF involution implies even cardinality
- `prod_involution_const`: FPF involution with constant pair product → ∏G = c^(|G|/2)
- `card_sq_eq_one_ge_three_of_not_cyclic_zmod`: imports GaussWilsonNonCyclic for |S| ≥ 3
- `prod_units_one_of_not_cyclic_ext`: ∏(ZMod n)× = 1 when non-cyclic
- `gaussWilson_abstract_ext`: complete characterization ∏ = -1 ↔ cyclic

## Files
- `src/data/proofs/wilsons-theorem-oq-02-ext/meta.json`
- `src/data/proofs/wilsons-theorem-oq-02-ext/annotations.json`
- `src/data/proofs/wilsons-theorem-oq-02-ext/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)