### PR TITLE
enrich(cauchy-schwarz-oq-01-oq-01-oq-02): fix counts, add 5 annotations; fix angle-trisection TypeScript error

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -64,33 +64,62 @@
       "The tower-law argument (Gal.card_of_separable + IntermediateField.adjoin.finrank) is entirely characteristic-free once separability is assumed.",
       "Separability is both sufficient (the theorem holds) and necessary (inseparable counterexamples exist in char p) for the divisibility.",
       "The 2-group Galois criterion for constructibility extends verbatim to any characteristic, covering e.g. separable cubic trisection obstructions over finite fields."
-    ]
+    ],
+    "proofStrategy": "1. **Rewrite |Gal(p)| via Gal.card_of_separable**: Apply `Gal.card_of_separable p_sep` to convert |Gal(p)| to Module.finrank F (SplittingField p). This is the only step that uses any characteristic information — it requires p.Separable, not CharZero.\n2. **Pick a root α**: Obtain α : SplittingField p as a root of p (which is nonconstant by irreducibility). Then SplittingField p = F(α) as intermediate fields.\n3. **Apply the tower law**: [SplittingField p : F] = [SplittingField p : F(α)] · [F(α) : F]. The factor [F(α) : F] equals natDegree(minpoly F α) = natDegree(p) (since p is the minimal polynomial of α over F by irreducibility).\n4. **Conclude divisibility**: natDegree(p) | [SplittingField p : F] = |Gal(p)|.\n5. **CharZero corollary**: Over CharZero, `Irreducible.separable` supplies p.Separable for free.\n6. **Counterexample**: Axiomatize that inseparable irreducibles have trivial Galois groups (|Gal| = 1), then natDegree(p) > 1 gives natDegree ∤ |Gal|."
   },
   "sections": [
     {
-      "title": "Main Theorem: Separability Suffices",
-      "content": "The theorem `natDegree_dvd_card_gal_of_sep` proves natDegree(p) | |Gal(p)| for any irreducible separable polynomial over any field. The proof is identical to the CharZero version — rewrite |Gal(p)| = finrank via `Gal.card_of_separable`, pick a root α in the splitting field, apply the tower law, and use irreducibility to show minpoly(F,α) = p.",
-      "leanCode": "theorem natDegree_dvd_card_gal_of_sep {F : Type*} [Field F]\n    {p : F[X]} (p_irr : Irreducible p) (p_sep : p.Separable) :\n    p.natDegree ∣ Nat.card p.Gal"
+      "id": "setup",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring explaining the extension from CharZero to the separable setting. Imports Mathlib and the parent AngleTrisectionOQ02OQ01. Opens the Polynomial and IntermediateField namespaces.",
+      "mathContext": "The key insight stated in the header: $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$ holds for all irreducible SEPARABLE $p$ over any field. CharZero was only used to derive separability from irreducibility."
     },
     {
-      "title": "CharZero Corollary",
-      "content": "Over CharZero, every irreducible is separable (`Irreducible.separable`), so the new theorem subsumes the original one-line corollary.",
-      "leanCode": "theorem natDegree_dvd_card_gal_charZero {F : Type*} [Field F] [CharZero F]\n    {p : F[X]} (p_irr : Irreducible p) :\n    p.natDegree ∣ Nat.card p.Gal :=\n  natDegree_dvd_card_gal_of_sep p_irr p_irr.separable"
+      "id": "main-theorem",
+      "title": "Part I: Main Theorem — Separability Suffices",
+      "startLine": 36,
+      "endLine": 74,
+      "summary": "Proves natDegree_dvd_card_gal_of_sep: for any irreducible separable polynomial over any field, natDegree(p) | |Gal(p)|. Proof: rewrite |Gal(p)| via Gal.card_of_separable, pick root α, apply tower law with minpoly(F,α) = p by irreducibility.",
+      "mathContext": "$|\\text{Gal}(p)| = \\text{finrank}(F, \\text{Split}(p)) = \\text{finrank}(F, F(\\alpha)) \\cdot \\text{finrank}(F(\\alpha), \\text{Split}(p)) = \\text{natDeg}(p) \\cdot [\\text{Split}(p):F(\\alpha)]$"
     },
     {
-      "title": "Galois Criterion in Any Characteristic",
-      "content": "The 2-group Galois criterion results from AngleTrisectionOQ02OQ01 transfer directly: for a separable irreducible over any field, if Gal(p) is a 2-group then natDegree(p) is a power of 2.",
-      "leanCode": "theorem galois_2group_implies_degree_is_pow2_sep {F : Type*} [Field F]\n    {p : F[X]} (p_irr : Irreducible p) (p_sep : p.Separable)\n    (hGal : IsPGroup 2 p.Gal) :\n    ∃ k : ℕ, p.natDegree = 2 ^ k"
+      "id": "charzero-corollary",
+      "title": "Part II: CharZero Corollary",
+      "startLine": 75,
+      "endLine": 85,
+      "summary": "One-line corollary: over CharZero, every irreducible is separable via Irreducible.separable, so natDegree_dvd_card_gal_of_sep applies directly. Recovers the parent theorem as a special case.",
+      "mathContext": "Irreducible.separable: $[\\text{CharZero}\\, F] \\Rightarrow p$ irred $\\Rightarrow p$ sep. So CharZero becomes just one way to supply the separability hypothesis."
     },
     {
-      "title": "The Inseparable Obstruction",
-      "content": "For inseparable irreducibles (characteristic p, degree > 1), the Galois group is trivial while natDegree > 1, so the divisibility fails. This shows separability is not merely a proof artifact but the precise necessary condition.",
-      "leanCode": "axiom insep_gal_trivial {F : Type*} [Field F] {p : ℕ} [CharP F p] [hp : Fact p.Prime]\n    {f : F[X]} (hf_irr : Irreducible f) (hf_insep : ¬f.Separable) :\n    Nat.card f.Gal = 1\n\ntheorem natDeg_notDvd_gal_of_insep ... : ¬(f.natDegree ∣ Nat.card f.Gal)"
+      "id": "galois-criterion",
+      "title": "Part III: Galois 2-Group Criterion in Any Characteristic",
+      "startLine": 86,
+      "endLine": 113,
+      "summary": "Transfers the 2-group Galois criterion from CharZero to any field with separable hypothesis. If Gal(p) is a 2-group then natDegree(p) divides a power of 2, and by dvd_pow_two_is_pow_two, natDegree(p) is itself a power of 2.",
+      "mathContext": "If $|\\text{Gal}(p)| = 2^n$ and $\\text{natDeg}(p) \\mid |\\text{Gal}(p)|$, then $\\text{natDeg}(p) \\mid 2^n$, and since $\\text{natDeg}(p) > 0$, it must equal $2^k$ for some $k \\leq n$."
+    },
+    {
+      "id": "inseparable-obstruction",
+      "title": "Part IV: The Inseparable Obstruction",
+      "startLine": 114,
+      "endLine": 149,
+      "summary": "Axiomatizes that inseparable irreducibles have trivial Galois groups (|Gal| = 1). The concrete example is X^p - t over F_p(t): irreducible (Eisenstein), inseparable (derivative = 0), with only one root t^{1/p} in the purely inseparable splitting field. Proves natDegree ∤ |Gal| when natDegree > 1.",
+      "mathContext": "$f = X^p - t \\in \\mathbb{F}_p(t)[X]$: irred, insep, $|\\text{Gal}| = 1$ (only root $t^{1/p}$, only automorphism is id), $\\text{natDeg} = p$. So $p \\nmid 1$."
+    },
+    {
+      "id": "summary-table",
+      "title": "Summary Table of All Theorems",
+      "startLine": 150,
+      "endLine": 165,
+      "summary": "Summary table: 5 theorems proved with 0 sorries, 1 axiom (insep_gal_trivial). Lists all theorems with their hypotheses and conclusions in tabular form.",
+      "mathContext": "Complete logical picture: sep $\\Rightarrow$ divisibility (proved); CharZero $\\Rightarrow$ sep (Mathlib); insep $+$ deg $> 1$ $\\Rightarrow$ non-divisibility (proved); 2-group Gal $\\Rightarrow$ deg $= 2^k$ (proved)."
     }
   ],
   "conclusion": {
-    "statement": "Separability is the exact necessary and sufficient additional hypothesis needed to extend natDegree(p) | |Gal(p)| from CharZero to arbitrary fields.",
-    "significance": "Identifies the precise structural boundary: the theorem holds in any characteristic for separable irreducibles, fails for inseparable ones.",
+    "summary": "Separability is the exact necessary and sufficient additional hypothesis needed to extend natDegree(p) | |Gal(p)| from CharZero to arbitrary fields.",
+    "implications": "Identifies the precise structural boundary: the theorem holds in any characteristic for separable irreducibles, fails for inseparable ones. The 2-group Galois criterion for angle trisection obstructions now applies in any characteristic, not just CharZero.",
     "openQuestions": [
       "Can insep_gal_trivial be proved in Lean using Mathlib's purely inseparable extension theory?",
       "Does the same argument yield a bound natDegree(p) / p^k | |Gal(p)| for inseparable irreducibles of degree p^k · d (separable degree d)?"

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/annotations.json
@@ -1,1 +1,124 @@
-[]
+[
+  {
+    "id": "cs-rob-01",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 22,
+      "endLine": 43
+    },
+    "type": "technique",
+    "title": "CS Antisymmetric Bound: Triangle Inequality + norm_conj",
+    "content": "The core analytic lemma is `cs_antisymmetric_bound`: (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖. The two-step proof first rewrites ⟪v,u⟫ = star(⟪u,v⟫) using `inner_conj_symm`, then applies the private helper `norm_sub_conj_le z : ‖z − star(z)‖ ≤ 2‖z‖` (proved by triangle inequality + `RCLike.norm_conj`), and finally divides by 2 and applies Cauchy-Schwarz `norm_inner_le_norm`. This gives a bound on the antisymmetric part purely from CS without any complex-number structure beyond ‖star(z)‖ = ‖z‖.",
+    "mathContext": "Private: $\\|z - \\overline{z}\\| \\leq \\|z\\| + \\|\\overline{z}\\| = 2\\|z\\|$ (triangle + norm_conj). Public: $\\frac{1}{2}\\|\\langle u,v\\rangle - \\langle v,u\\rangle\\| \\leq \\frac{1}{2}\\cdot 2\\|\\langle u,v\\rangle\\| \\leq \\|u\\|\\cdot\\|v\\|$. The factor of $\\frac{1}{2}$ comes from the Robertson bound — the full antisymmetric norm gives a factor of 2 that cancels.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy-Schwarz inequality",
+      "antisymmetric part of inner product",
+      "complex conjugation norm invariance",
+      "norm_inner_le_norm"
+    ],
+    "prerequisites": [
+      "norm_inner_le_norm: ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖ from Mathlib.Analysis.InnerProductSpace.Basic",
+      "inner_conj_symm: ⟪v,u⟫ = star(⟪u,v⟫) — conjugate symmetry of inner products",
+      "RCLike.norm_conj: ‖star z‖ = ‖z‖ for complex numbers"
+    ]
+  },
+  {
+    "id": "cs-rob-02",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 66
+    },
+    "type": "concept",
+    "title": "Real Expectation Values: Self-Adjointness Forces Im(⟨A⟩) = 0",
+    "content": "`expVal_im_zero` proves that for a symmetric operator A (satisfying `A.IsSymmetric : ⟪Ax,y⟫ = ⟪x,Ay⟫`), the expectation value expVal A ψ = ⟪ψ,Aψ⟫_ℂ has zero imaginary part. The proof uses the fact that ⟪ψ,Aψ⟫ equals its own conjugate: star(⟪ψ,Aψ⟫) = ⟪Aψ,ψ⟫ (by conjugate symmetry) = ⟪ψ,Aψ⟫ (by symmetry of A). A complex number equal to its conjugate must be real. `expVal_self_conj` packages this as starRingEnd ℂ (expVal A ψ) = expVal A ψ, enabling ring-lemma rewrites in downstream proofs.",
+    "mathContext": "$\\overline{\\langle\\psi, A\\psi\\rangle} = \\langle A\\psi, \\psi\\rangle = \\langle\\psi, A\\psi\\rangle$ (using A.IsSymmetric). So $\\langle A\\rangle_\\psi \\in \\mathbb{R}$. This is the defining property of symmetric (self-adjoint) operators: observables have real eigenvalues, and expectation values in any state are real.",
+    "significance": "key",
+    "relatedConcepts": [
+      "LinearMap.IsSymmetric: ⟪Ax,y⟫ = ⟪x,Ay⟫ for all x,y",
+      "self-adjoint operators in quantum mechanics",
+      "complex conjugation and reality condition",
+      "expVal definition"
+    ],
+    "prerequisites": [
+      "inner_conj_symm: star⟪x,y⟫ = ⟪y,x⟫ in complex inner product spaces",
+      "LinearMap.IsSymmetric: A.IsSymmetric iff ⟪Ax,y⟫ = ⟪x,Ay⟫ for all x,y",
+      "Complex.ext: two complex numbers equal iff real and imaginary parts equal"
+    ]
+  },
+  {
+    "id": "cs-rob-03",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 110
+    },
+    "type": "insight",
+    "title": "The Commutator Identity: Cross Terms Cancel by Reality of Expectation Values",
+    "content": "The key algebraic identity, proved in `centered_antisymmetric_eq_commutator`, states that for unit ψ and symmetric A, B:\n⟪Aψ − ⟨A⟩ψ, Bψ − ⟨B⟩ψ⟫ − ⟪Bψ − ⟨B⟩ψ, Aψ − ⟨A⟩ψ⟫ = ⟪ψ, (AB−BA)ψ⟫\n\nThe private helper `inner_centered_eq` handles one centered product: ⟪Xψ − c·ψ, Yψ − d·ψ⟫ = ⟪ψ,X(Yψ)⟫ − c*d. It uses: (1) X.IsSymmetric to rewrite ⟪Xψ,ψ⟫ = ⟪ψ,Xψ⟫; (2) star(c) = c (reality of ⟨X⟩) to simplify star(c)*d and c*d terms; (3) ⟪ψ,ψ⟫ = 1. The final subtraction cancels the c*d terms: (⟪ψ,ABψ⟫ − ⟨A⟩·⟨B⟩) − (⟪ψ,BAψ⟫ − ⟨B⟩·⟨A⟩) = ⟪ψ,(AB−BA)ψ⟫.",
+    "mathContext": "Key identity: $\\langle u,v\\rangle - \\langle v,u\\rangle = \\langle\\psi,ABψ\\rangle - \\langle A\\rangle\\langle B\\rangle - (\\langle\\psi,BAψ\\rangle - \\langle B\\rangle\\langle A\\rangle) = \\langle\\psi,(AB-BA)\\psi\\rangle$. The cross terms $\\langle A\\rangle\\langle B\\rangle$ cancel because $\\langle A\\rangle,\\langle B\\rangle \\in \\mathbb{R}$ (commutativity of real multiplication).",
+    "significance": "key",
+    "relatedConcepts": [
+      "commutator [A,B] = AB − BA",
+      "inner product bilinearity and sesquilinearity",
+      "reality of expectation values (expVal_self_conj)",
+      "inner_centered_eq private helper"
+    ],
+    "prerequisites": [
+      "inner_smul_left/right: ⟪c·x,y⟫ = star(c)·⟪x,y⟫ and ⟪x,c·y⟫ = c·⟪x,y⟫",
+      "inner_sub_left/right: bilinearity of inner products",
+      "expVal_self_conj: star(⟨A⟩) = ⟨A⟩ — expectation value is its own conjugate",
+      "inner_self_eq_norm_sq_to_K: ⟪ψ,ψ⟫ = ‖ψ‖² = 1 for unit states"
+    ]
+  },
+  {
+    "id": "cs-rob-04",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 111,
+      "endLine": 129
+    },
+    "type": "concept",
+    "title": "Robertson's Inequality: Three-Line Assembly via linarith",
+    "content": "`robertson_inequality` is the culmination: stdDev A ψ · stdDev B ψ ≥ (1/2)‖commutatorEV A B ψ‖. The proof is three lines: (1) `hcs := cs_antisymmetric_bound u v` gives ‖u‖·‖v‖ ≥ (1/2)|⟪u,v⟫ − ⟪v,u⟫|; (2) `hcomm := centered_antisymmetric_eq_commutator A B hA hB ψ hψ` gives ⟪u,v⟫ − ⟪v,u⟫ = commutatorEV A B ψ; (3) `rw [hcomm] at hcs; linarith` closes the goal since stdDev = ‖u‖ and stdDev B = ‖v‖ by definition. The modularity is striking: Parts I–III are completely independent results that compose immediately.",
+    "mathContext": "$\\Delta A \\cdot \\Delta B = \\|u\\|\\cdot\\|v\\| \\geq \\frac{1}{2}|\\langle u,v\\rangle - \\langle v,u\\rangle| = \\frac{1}{2}|\\text{commutatorEV}| = \\frac{1}{2}|\\langle\\psi,[A,B]\\psi\\rangle|$. All three steps close by definition unfolding + `linarith`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Robertson uncertainty principle",
+      "Cauchy-Schwarz equality condition",
+      "coherent states (minimum uncertainty states)",
+      "linarith for linear arithmetic in Lean 4"
+    ],
+    "prerequisites": [
+      "cs_antisymmetric_bound: Part I result",
+      "centered_antisymmetric_eq_commutator: Part III result",
+      "stdDev A ψ = ‖A ψ − (expVal A ψ) • ψ‖ by definition"
+    ]
+  },
+  {
+    "id": "cs-rob-05",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 130,
+      "endLine": 148
+    },
+    "type": "concept",
+    "title": "Heisenberg as Special Case: [A,B] = c·id Simplifies commutatorEV to c",
+    "content": "`heisenberg_constant_commutator` proves ΔA·ΔB ≥ |c|/2 for operators with constant commutator [A,B] = c·id. The proof first computes commutatorEV A B ψ = c: from hcomm (∀ ψ, A(Bψ) − B(Aψ) = c·ψ), unfold commutatorEV to ⟪ψ, A(Bψ) − B(Aψ)⟫_ℂ = ⟪ψ, c·ψ⟫ = c·⟪ψ,ψ⟫ = c·1 = c (using ‖ψ‖=1). Then `robertson_inequality` gives the result directly. The Heisenberg relation ΔxΔp ≥ ħ/2 is the instance with c = iħ (so |c| = ħ).",
+    "mathContext": "commutatorEV $A B \\psi = \\langle\\psi, A(B\\psi) - B(A\\psi)\\rangle = \\langle\\psi, c\\psi\\rangle = c\\cdot\\langle\\psi,\\psi\\rangle = c\\cdot 1 = c$. Robertson then gives $\\Delta A \\cdot \\Delta B \\geq |c|/2$. For $[\\hat{x},\\hat{p}] = i\\hbar$: $\\Delta x \\cdot \\Delta p \\geq |i\\hbar|/2 = \\hbar/2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Heisenberg uncertainty principle",
+      "position-momentum commutator [x̂,p̂] = iħ",
+      "inner_smul_right: ⟪ψ, c·ψ⟫ = c·⟪ψ,ψ⟫",
+      "minimum uncertainty states (coherent states)"
+    ],
+    "prerequisites": [
+      "robertson_inequality: general Robertson bound",
+      "inner_smul_right: ⟪x, c•y⟫ = c • ⟪x,y⟫",
+      "inner_self_eq_norm_sq_to_K: ⟪ψ,ψ⟫ = ‖ψ‖² = 1 for unit ψ",
+      "mul_one: c * 1 = c"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 175,
-    "theoremCount": 10,
+    "lineCount": 148,
+    "theoremCount": 6,
     "definitionCount": 3,
     "mathlibDependencies": [
       {
@@ -69,7 +69,7 @@
     "historicalContext": "**Robertson's Uncertainty Principle (1929)**\n\nThe Heisenberg uncertainty principle (1927) originally stated that position and momentum cannot be simultaneously determined with arbitrary precision. Werner Heisenberg derived it using wave packet arguments, but the precise mathematical formulation was given by Howard Percy Robertson in 1929.\n\nRobertson showed that for *any* two symmetric (self-adjoint) operators A and B on a Hilbert space, and any unit state vector ψ:\n$$\\Delta A(\\psi) \\cdot \\Delta B(\\psi) \\geq \\frac{1}{2} |\\langle \\psi | [A, B] | \\psi \\rangle|$$\nwhere $\\Delta A(\\psi) = \\|A\\psi - \\langle A \\rangle_\\psi \\psi\\|$ is the standard deviation, and $[A,B] = AB - BA$ is the commutator.\n\nThe standard Heisenberg relation $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is the special case where $[\\hat{x}, \\hat{p}] = i\\hbar \\cdot \\text{id}$, giving $|\\langle \\psi | i\\hbar | \\psi \\rangle| = \\hbar$ for unit states.\n\nThe proof is a direct application of the Cauchy-Schwarz inequality to the centered vectors $u = A\\psi - \\langle A \\rangle \\psi$ and $v = B\\psi - \\langle B \\rangle \\psi$, making this a beautiful illustration of how a general analytical inequality gives rise to a foundational result in quantum physics.",
     "problemStatement": "**Robertson's Uncertainty Inequality**\n\nFor symmetric operators A, B on a complex inner product space E, and any unit vector ψ ∈ E (‖ψ‖ = 1):\n$$\\Delta A(\\psi) \\cdot \\Delta B(\\psi) \\geq \\frac{1}{2} |\\langle \\psi, (AB - BA)\\psi \\rangle|$$\nwhere $\\Delta A(\\psi) = \\|A\\psi - \\langle\\psi, A\\psi\\rangle \\cdot \\psi\\|$.\n\nSpecial case: if [A,B] = c·id for constant c ∈ ℂ, then ΔA·ΔB ≥ |c|/2.",
     "text": "The Heisenberg uncertainty principle, in its abstract Robertson form, follows from Cauchy-Schwarz applied to centered vectors from symmetric operators on a complex Hilbert space.",
-    "proofStrategy": "**Proof Strategy: Cauchy-Schwarz on Centered Vectors**\n\n1. **CS antisymmetric bound**: For any u,v ∈ E, (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖ (from CS + triangle inequality)\n2. **Real expectation values**: Symmetric operators have real expectation values (im part = 0 by self-adjointness)\n3. **Key identity**: For centered u = Aψ − ⟨A⟩ψ and v = Bψ − ⟨B⟩ψ, expand ⟪u,v⟫ − ⟪v,u⟫. The cross terms involving ⟨A⟩ and ⟨B⟩ cancel because expectation values are real and ⟪ψ,ψ⟫ = 1. Using symmetry (⟪Aψ,Bψ⟫ = ⟪ψ,A(Bψ)⟫ by A symmetric), we get ⟪u,v⟫ − ⟪v,u⟫ = ⟪ψ,(AB−BA)ψ⟫.\n4. **Compose**: stdDev A · stdDev B = ‖u‖·‖v‖ ≥ (1/2)|⟪u,v⟫ − ⟪v,u⟫| = (1/2)|commutatorEV A B ψ|",
+    "proofStrategy": "1. **CS antisymmetric bound** (Part I): For any u,v ∈ E, (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖. Proof: ‖z − star(z)‖ ≤ 2‖z‖ + RCLike.norm_conj + norm_inner_le_norm.\n2. **Real expectation values** (Part II): expVal A ψ = ⟪ψ,Aψ⟫ is real for symmetric A. Proof: star(⟪ψ,Aψ⟫) = ⟪Aψ,ψ⟫ = ⟪ψ,Aψ⟫ by IsSymmetric.\n3. **Commutator identity** (Part III): For centered u = Aψ − ⟨A⟩ψ and v = Bψ − ⟨B⟩ψ, ⟪u,v⟫ − ⟪v,u⟫ = commutatorEV A B ψ = ⟪ψ,(AB−BA)ψ⟫. Proof: expand, use real expectation values to cancel cross terms, use ⟪ψ,ψ⟫ = 1.\n4. **Assemble** (Part IV): stdDev A · stdDev B = ‖u‖·‖v‖ ≥ (1/2)|⟪u,v⟫ − ⟪v,u⟫| = (1/2)|commutatorEV A B ψ|.\n5. **Special case** (Part V): [A,B] = c·id → commutatorEV = c·⟪ψ,ψ⟫ = c → ΔA·ΔB ≥ |c|/2.",
     "keyInsights": [
       "**The antisymmetric inner product is the quantum-mechanical key**: ⟪u,v⟫ − ⟪v,u⟫ = 2i·Im⟪u,v⟫ is purely imaginary, and its magnitude is bounded by 2‖u‖·‖v‖ via CS + triangle inequality.",
       "**Expectation values of symmetric operators are real**: ⟨A⟩ = ⟪ψ,Aψ⟫ satisfies star(⟨A⟩) = ⟨A⟩ because star⟪ψ,Aψ⟫ = ⟪Aψ,ψ⟫ = ⟪ψ,Aψ⟫ by symmetry. This is why cross terms cancel.",
@@ -88,42 +88,42 @@
     {
       "id": "antisymmetric-bound",
       "title": "Part I: CS Antisymmetric Bound",
-      "summary": "Proves (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖ via triangle inequality and norm_inner_le_norm.",
-      "startLine": 30,
-      "endLine": 55,
-      "mathContext": "The antisymmetric part z − star(z) has norm ≤ 2‖z‖ by triangle inequality. Applied to z = ⟪u,v⟫, combined with CS ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖."
+      "summary": "Proves (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖ via triangle inequality and norm_inner_le_norm. Private helper norm_sub_conj_le shows ‖z − star(z)‖ ≤ 2‖z‖; main theorem cs_antisymmetric_bound composes with CS.",
+      "startLine": 22,
+      "endLine": 43,
+      "mathContext": "The antisymmetric part $z - \\overline{z}$ has $\\|z - \\overline{z}\\| \\leq 2\\|z\\|$ by triangle inequality + $\\|\\overline{z}\\| = \\|z\\|$. Applied to $z = \\langle u,v\\rangle$: $\\frac{1}{2}\\|\\langle u,v\\rangle - \\langle v,u\\rangle\\| \\leq \\|\\langle u,v\\rangle\\| \\leq \\|u\\|\\cdot\\|v\\|$ (Cauchy-Schwarz)."
     },
     {
       "id": "symmetric-operators",
       "title": "Part II: Symmetric Operators and Real Expectation Values",
-      "summary": "Shows expVal A ψ = ⟪ψ,Aψ⟫ is real (im = 0) for symmetric A, and equals its complex conjugate.",
-      "startLine": 57,
-      "endLine": 95,
-      "mathContext": "By A.IsSymmetric: star⟪ψ,Aψ⟫ = ⟪Aψ,ψ⟫ = ⟪ψ,Aψ⟫. This forces Im(⟨A⟩) = 0, making ⟨A⟩ real-valued."
+      "summary": "Defines expVal A ψ = ⟪ψ,Aψ⟫_ℂ. Proves expVal_im_zero (im part = 0 for symmetric A) and expVal_self_conj (expectation value = its conjugate, i.e., expVal is real).",
+      "startLine": 44,
+      "endLine": 66,
+      "mathContext": "By `A.IsSymmetric`: $\\overline{\\langle\\psi, A\\psi\\rangle} = \\langle A\\psi,\\psi\\rangle = \\langle\\psi,A\\psi\\rangle$. This forces $\\text{Im}(\\langle A\\rangle) = 0$, making expectation values real-valued — essential for the cross-term cancellation in Part III."
     },
     {
       "id": "commutator-identity",
-      "title": "Part III: Commutator Identity",
-      "summary": "Proves the centered antisymmetric inner product ⟪u,v⟫ − ⟪v,u⟫ equals the commutator expectation value ⟪ψ,[A,B]ψ⟫.",
-      "startLine": 97,
-      "endLine": 135,
-      "mathContext": "Expand and use: (1) expVal_self_conj for real ⟨A⟩,⟨B⟩; (2) symmetry ⟪Aψ,Bψ⟫ = ⟪ψ,A(Bψ)⟫*; (3) ⟪ψ,ψ⟫ = 1. Cross terms involving ⟨A⟩ and ⟨B⟩ cancel."
+      "title": "Part III: Commutator Identity via inner_centered_eq",
+      "summary": "Defines commutatorEV A B ψ = ⟪ψ,(AB−BA)ψ⟫ and stdDev A ψ = ‖Aψ − ⟨A⟩ψ‖. Proves centered_antisymmetric_eq_commutator: for centered u = Aψ − ⟨A⟩ψ and v = Bψ − ⟨B⟩ψ, ⟪u,v⟫ − ⟪v,u⟫ equals commutatorEV A B ψ.",
+      "startLine": 67,
+      "endLine": 110,
+      "mathContext": "Private helper `inner_centered_eq` expands $\\langle Xψ - c\\psi, Yψ - d\\psi\\rangle = \\langle\\psi, X(Yψ)\\rangle - c \\cdot d$ using `A.IsSymmetric`, $\\langle\\psi,\\psi\\rangle=1$, and reality of $c = \\langle A\\rangle$. Then $\\langle u,v\\rangle - \\langle v,u\\rangle = (\\langle\\psi,ABψ\\rangle - cd) - (\\langle\\psi,BAψ\\rangle - cd) = \\langle\\psi,(AB-BA)\\psi\\rangle$."
     },
     {
       "id": "robertson",
       "title": "Part IV: Robertson's Inequality",
-      "summary": "Combines Parts I–III: stdDev A ψ · stdDev B ψ ≥ (1/2)‖commutatorEV A B ψ‖.",
-      "startLine": 137,
-      "endLine": 155,
-      "mathContext": "CS bound on ‖u‖·‖v‖ = stdDev A · stdDev B, with commutator identity giving the RHS."
+      "summary": "Proves robertson_inequality: stdDev A ψ · stdDev B ψ ≥ (1/2)‖commutatorEV A B ψ‖. Directly composes Part I (cs_antisymmetric_bound on centered u,v) with Part III (antisymmetric part = commutator EV) via linarith.",
+      "startLine": 111,
+      "endLine": 129,
+      "mathContext": "$\\Delta A \\cdot \\Delta B = \\|u\\|\\cdot\\|v\\| \\geq \\frac{1}{2}|\\langle u,v\\rangle - \\langle v,u\\rangle| = \\frac{1}{2}|\\text{commutatorEV}(A,B,\\psi)|$. Assembly: `cs_antisymmetric_bound` + `centered_antisymmetric_eq_commutator` + `linarith`."
     },
     {
       "id": "heisenberg",
       "title": "Part V: Heisenberg for Constant Commutator",
-      "summary": "Special case [A,B] = c·id: commutatorEV simplifies to c, giving ΔA·ΔB ≥ |c|/2.",
-      "startLine": 157,
-      "endLine": 175,
-      "mathContext": "When A(B(ψ)) − B(A(ψ)) = c·ψ for all ψ, then ⟪ψ,c·ψ⟫ = c·‖ψ‖² = c (for unit ψ)."
+      "summary": "Proves heisenberg_constant_commutator: if [A,B] = c·id, then ΔA·ΔB ≥ |c|/2. Simplifies commutatorEV A B ψ = ⟪ψ,c·ψ⟫ = c·1 = c using hψ: ‖ψ‖=1, then applies robertson_inequality.",
+      "startLine": 130,
+      "endLine": 148,
+      "mathContext": "When $A(B\\psi) - B(A\\psi) = c\\psi$ for all $\\psi$: $\\text{commutatorEV}(A,B,\\psi) = \\langle\\psi, c\\psi\\rangle = c\\cdot\\langle\\psi,\\psi\\rangle = c\\cdot 1 = c$. So Robertson gives $\\Delta A \\cdot \\Delta B \\geq |c|/2$. Setting $c = i\\hbar$ for $[\\hat{x},\\hat{p}] = i\\hbar$: $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$."
     }
   ],
   "conclusion": {
@@ -146,9 +146,9 @@
       "Complex"
     ],
     "namespace": "CauchySchwarzOQ01OQ01OQ02",
-    "lineCount": 175,
+    "lineCount": 148,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 6,
     "definitionCount": 3,
     "path": "Proofs/CauchySchwarzOQ01OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

**cauchy-schwarz-oq-01-oq-01-oq-02 (Robertson's Uncertainty Inequality)**
- Fix `meta.json` counts: `lineCount` 175→148, `theoremCount` 10→6 (actual Lean file has 6 public theorems: `cs_antisymmetric_bound`, `expVal_im_zero`, `expVal_self_conj`, `centered_antisymmetric_eq_commutator`, `robertson_inequality`, `heisenberg_constant_commutator`)
- Fix all section `startLine`/`endLine` values (previously based on a 175-line version)
- Add 5 rich annotations covering every section with full mathContext, significance, relatedConcepts, prerequisites

**angle-trisection-oq-02-oq-01-oq-01-oq-01 (separability extension)**
- Fix pre-existing TypeScript build error: `sections` used `{title, content, leanCode}` format instead of required `{id, startLine, endLine, summary, mathContext}`
- Add `overview.proofStrategy` (required field in `ProofOverview` type)
- Fix `conclusion` field names: `statement`→`summary`, `significance`→`implications`

## Test plan

- [x] `pnpm build` passes after both fixes applied
- [x] All 5 annotations have mathContext (LaTeX), significance, relatedConcepts, prerequisites
- [x] Section line numbers verified against actual Lean file (`git show origin/main:proofs/Proofs/CauchySchwarzOQ01OQ01OQ02.lean`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)