### PR TITLE
research(minkowski-theorem-oq-02-oq-01): axiom-free Dirichlet approximation via Minkowski

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-02-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-dirichlet-main",
+    "type": "theorem",
+    "label": "dirichlet_from_minkowski_axiom_free",
+    "title": "Dirichlet's Approximation Theorem (Axiom-Free)",
+    "body": "dirichlet_from_minkowski_axiom_free: for any α : ℝ and Q : ℕ with Q ≥ 1, ∃ p q : ℤ, 0 < q ∧ q ≤ Q ∧ |q*α - p| < 1/Q. Proved fully from first principles: the Dirichlet parallelogram S is open (measurable), convex, has volume 4(Q+1)/Q > 4, so Minkowski's theorem gives a nonzero lattice point (p,q) ∈ S, which exactly witnesses the approximation.",
+    "location": { "line": 260 },
+    "tags": ["main-theorem", "dirichlet", "approximation", "axiom-free"]
+  },
+  {
+    "id": "ann-volume-computation",
+    "type": "theorem",
+    "label": "dirichletSet_volume",
+    "title": "Volume of the Dirichlet Parallelogram",
+    "body": "dirichletSet_volume: volume(dirichletSet α Q) = 4*(Q+1)/Q. Proved via the shear map T(x,y) = (x, αx-y), which has |det T| = 1 (the matrix [[1,0],[α,-1]] has det = -1). T maps the parallelogram S to the axis-aligned rectangle (-Q-1,Q+1)×(-1/Q,1/Q) (area = 2(Q+1)×2/Q = 4(Q+1)/Q). Since T is a measure-preserving bijection, vol(S) = vol(rectangle).",
+    "location": { "line": 170 },
+    "tags": ["volume", "measure-theory", "shear-map"]
+  },
+  {
+    "id": "ann-convexity",
+    "type": "theorem",
+    "label": "dirichletSet_convex",
+    "title": "Convexity of the Dirichlet Parallelogram",
+    "body": "dirichletSet_convex: the set {(x,y) : |x| < Q+1 ∧ |αx-y| < 1/Q} is convex. Proved by showing each of the two conditions defines a convex set: |f(v)| < c is the preimage of Ioo(-c,c) under the continuous linear functional f, and intersections of convex sets are convex.",
+    "location": { "line": 130 },
+    "tags": ["convexity", "geometry", "linear-functional"]
+  },
+  {
+    "id": "ann-dirichlet-set",
+    "type": "definition",
+    "label": "dirichletSet",
+    "title": "The Dirichlet Parallelogram",
+    "body": "dirichletSet α Q = {v : Fin 2 → ℝ | |v 0| < Q+1 ∧ |α*(v 0) - v 1| < 1/Q}. This is the set of real pairs (x,y) satisfying both: x is within Q+1 of the origin, and y is within 1/Q of αx. Geometrically, it is a parallelogram (a sheared rectangle) symmetric about the origin with area 4(Q+1)/Q.",
+    "location": { "line": 42 },
+    "tags": ["definition", "dirichlet", "parallelogram"]
+  }
+]

--- a/src/data/proofs/minkowski-theorem-oq-02-oq-01/index.ts
+++ b/src/data/proofs/minkowski-theorem-oq-02-oq-01/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/MinkowskiTheoremOQ02OQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/minkowski-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-02-oq-01/meta.json
@@ -1,0 +1,67 @@
+{
+  "id": "minkowski-theorem-oq-02-oq-01",
+  "title": "Dirichlet's Approximation Theorem via Minkowski: Axiom-Free Proof",
+  "slug": "minkowski-theorem-oq-02-oq-01",
+  "description": "An axiom-free proof of Dirichlet's approximation theorem using Minkowski's lattice point theorem. Eliminates three geometric axioms from the previous formalization by proving: (1) the Dirichlet parallelogram is open (hence measurable), (2) it is convex (preimage of Ioo under linear functionals), and (3) its volume is 4(Q+1)/Q (via a shear map with determinant 1). Machine-checked with 0 axioms, 0 sorries.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "lineCount": 267,
+    "leanFile": "proofs/Proofs/MinkowskiTheoremOQ02OQ01.lean",
+    "imports": [
+      "Mathlib.Analysis.Convex.Basic",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.MeasureTheory.Group.GeometryOfNumbers",
+      "Mathlib.Algebra.Module.ZLattice.Basic",
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Tactic"
+    ],
+    "tags": ["number-theory", "dirichlet", "minkowski", "approximation", "measure-theory", "geometry-of-numbers"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "dirichlet-set",
+      "title": "The Dirichlet Parallelogram",
+      "description": "Definition of dirichletSet α Q = {(x,y) : |x| < Q+1 ∧ |αx-y| < 1/Q} and proof of central symmetry (dirichletSet_symmetric): if (x,y) ∈ S then (-x,-y) ∈ S.",
+      "theorems": ["dirichletSet", "dirichletSet_symmetric"]
+    },
+    {
+      "id": "geometric-properties",
+      "title": "Measurability, Convexity, and Volume",
+      "description": "Three properties needed for Minkowski's theorem: dirichletSet_measurable (the set is open — preimage of Ioo × Ioo under continuous maps), dirichletSet_convex (convex — each condition is the preimage of Ioo under a linear functional), and dirichletSet_volume (volume = 4(Q+1)/Q, proved by composing with the shear map T(x,y)=(x,αx-y) which has det=1 and maps S to the rectangle (-Q-1,Q+1)×(-1/Q,1/Q)).",
+      "theorems": ["dirichletSet_measurable", "dirichletSet_convex", "dirichletSet_volume"]
+    },
+    {
+      "id": "minkowski-application",
+      "title": "Dirichlet Approximation via Minkowski",
+      "description": "The chain: dirichletSet_volume_gt_four (for Q ≥ 1, volume = 4(Q+1)/Q > 4, satisfying Minkowski's volume condition), then dirichlet_approximation (Minkowski gives a nonzero lattice point (p,q) ∈ S, giving 0 < |q| ≤ Q and |qα-p| < 1/Q), and finally dirichlet_from_minkowski_axiom_free (the clean statement: for α ∈ ℝ and Q ≥ 1, ∃ p q : ℤ, 0 < q ≤ Q ∧ |q*α - p| < 1/Q).",
+      "theorems": ["dirichletSet_volume_gt_four", "dirichlet_approximation", "dirichlet_from_minkowski_axiom_free"]
+    }
+  ],
+  "overview": {
+    "summary": "Dirichlet's approximation theorem (1842) states that for any real α and integer Q ≥ 1, there exist integers p, q with 0 < q ≤ Q and |qα - p| < 1/Q. Equivalently, α can be approximated by rationals p/q with error < 1/(qQ). The Minkowski proof uses the lattice point theorem: the Dirichlet parallelogram S = {|x| < Q+1, |αx-y| < 1/Q} is symmetric, convex, and has volume > 4, so it contains a nonzero lattice point (p,q) which gives the approximation.",
+    "approach": "The previous proof (`minkowski-theorem-oq-02`) had three axioms about the Dirichlet parallelogram. This file eliminates all three: measurability follows because S is open (intersection of two open sets defined by strict inequalities on continuous functions); convexity follows because each inequality defines a convex set (preimage of an open interval under a linear functional); volume uses the shear map T(x,y) = (x, αx-y) with |det T| = 1, which maps S bijectively to the rectangle (-Q-1,Q+1)×(-1/Q,1/Q) with area 4(Q+1)/Q.",
+    "significance": "Dirichlet's approximation theorem is one of the cornerstones of Diophantine approximation. It implies the pigeonhole principle argument for rational approximability, and is the foundation for continued fraction approximation theory. The Minkowski proof is the cleanest — it makes the geometry of approximation explicit and generalizes immediately to simultaneous approximation in higher dimensions. This fully verified version demonstrates that the axiomatic treatment was unnecessary: the geometric facts about the Dirichlet set are provable from Mathlib's existing measure theory and convexity infrastructure."
+  },
+  "conclusion": {
+    "summary": "Dirichlet's approximation theorem is now machine-checked with zero axioms using Minkowski's lattice point theorem, with all three geometric properties of the Dirichlet parallelogram verified from first principles via Mathlib's measure theory.",
+    "openQuestions": [
+      "Can this approach extend to simultaneous Dirichlet approximation: for α₁,...,αₙ ∈ ℝ and Q ≥ 1, ∃ q with 0 < q ≤ Q^n and |qαᵢ - pᵢ| < 1/Q for all i?",
+      "Can the best approximation exponent (Dirichlet exponent μ(α) = 1 for Lebesgue a.e. α) be formalized using this infrastructure?",
+      "The Hurwitz theorem strengthens Dirichlet: for irrational α, infinitely many p/q satisfy |α - p/q| < 1/(√5 · q²). Can the √5 bound be proved using Minkowski's theorem in the appropriate region?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Eliminates the three geometric axioms from the previous axiomatized proof"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `MinkowskiTheoremOQ02OQ01.lean` (267 lines, 0 axioms, 0 sorries).

**Theorem**: Dirichlet's approximation theorem, proven with zero axioms. For any α ∈ ℝ and Q ≥ 1, there exist integers p, q with 0 < q ≤ Q and |qα - p| < 1/Q.

This eliminates three geometric axioms from `minkowski-theorem-oq-02`:
1. `dirichletSet_measurable` — now proved: the set is open (preimage of Ioo × Ioo under continuous maps)
2. `dirichletSet_convex` — now proved: each condition is the preimage of Ioo under a linear functional
3. `dirichletSet_volume` — now proved: shear map T(x,y)=(x,αx-y) has det=1, maps S to the rectangle

**Key results**:
- `dirichletSet_convex`: parallelogram is convex via linear functional preimage
- `dirichletSet_volume`: area = 4(Q+1)/Q via det-1 shear map
- `dirichlet_from_minkowski_axiom_free`: complete axiom-free proof

## Files
- `src/data/proofs/minkowski-theorem-oq-02-oq-01/meta.json`
- `src/data/proofs/minkowski-theorem-oq-02-oq-01/annotations.json`
- `src/data/proofs/minkowski-theorem-oq-02-oq-01/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)