### PR TITLE
fix(erdos-731): correct axiomCount 3→1, lineCount 301→357

### DIFF
--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -20,8 +20,8 @@
     "erdosNumber": 731,
     "erdosUrl": "https://erdosproblems.com/731",
     "erdosProblemStatus": "open",
-    "axiomCount": 3,
-    "lineCount": 301,
+    "axiomCount": 1,
+    "lineCount": 357,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",
@@ -39,9 +39,9 @@
         "module": "Mathlib.Order.WellFounded"
       }
     ],
-    "assumptions": "3 axiom declarations: prime_divides_central_iff (Kummer's carry characterization: p | C(2n,n) iff some base-p digit of n is ≥ ⌈p/2⌉), choose_dvd_lcm (C(N,k) divides lcm(1,...,N+1)), upper_bound_trivial (least non-divisor ≤ 2n+1). Proved: two_divides_central (Pascal+symmetry), bertrand_central (Bertrand+dvd_choose_add), central_binom_lower (binomial sum+max term). Note: small_primes_divide is NOT an axiom — small_primes_divide_false (theorem, line 89) shows 3 ∤ C(6,3)=20, i.e. small primes do NOT always divide C(2n,n).",
+    "assumptions": "1 axiom declaration: prime_divides_central_iff (Kummer's carry characterization: p | C(2n,n) iff some base-p digit of n is ≥ ⌈p/2⌉). Proved: choose_dvd_lcm (C(N,k) divides lcm(1,...,N+1), via Nat.factorization_choose_le_log), upper_bound_trivial (least non-divisor ≤ 2n+1, by contradiction using choose_dvd_lcm), two_divides_central (Pascal+symmetry), bertrand_central (Bertrand+dvd_choose_add), central_binom_lower (binomial sum+max term). Note: choose_dvd_lcm and upper_bound_trivial are NOT axioms — both are fully proved theorems in the file.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21
+    "theoremCount": 23
   },
   "overview": {
     "historicalContext": "Erdős, Graham, Ruzsa, and Straus (1975) studied the divisibility properties of central binomial coefficients $\\binom{2n}{n}$ and observed that the least integer not dividing $\\binom{2n}{n}$ is typically $\\exp((\\log n)^{1/2+o(1)})$. This observation connects deeply to Kummer's theorem (1852), which states that $v_p(\\binom{m+n}{m})$ equals the number of carries in base-$p$ addition of $m$ and $n$. For $\\binom{2n}{n}$, the carries arise when doubling $n$ in base $p$, which happens precisely when some base-$p$ digit of $n$ is $\\geq \\lceil p/2 \\rceil$. The heuristic is that a random $n$ has each base-$p$ digit independently uniform, so the probability of no carry (and hence $p \\nmid \\binom{2n}{n}$) is approximately $(1/2)^{\\log n/\\log p}$, which transitions from negligible to significant when $\\log p \\approx (\\log n)^{1/2}$. The sequence of least non-divisors appears as OEIS A006197.",
@@ -144,9 +144,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 301,
-    "axiomCount": 3,
-    "theoremCount": 21,
+    "lineCount": 357,
+    "axiomCount": 1,
+    "theoremCount": 23,
     "definitionCount": 3,
     "path": "Proofs/Erdos731Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Correct three metadata fields in `src/data/proofs/erdos-731/meta.json` that have drifted from the actual Lean file.

## Evidence

**axiomCount: 3 → 1**

The `assumptions` field claimed three "axiom declarations": `prime_divides_central_iff`, `choose_dvd_lcm`, and `upper_bound_trivial`. However, inspecting `proofs/Proofs/Erdos731Problem.lean`:

- `prime_divides_central_iff` — IS an axiom (line 82: `axiom prime_divides_central_iff ...`)
- `choose_dvd_lcm` — IS a **proved theorem** (line 75, proof via `Nat.factorization_choose_le_log`)
- `upper_bound_trivial` — IS a **proved theorem** (line 115, proof by contradiction using `choose_dvd_lcm`)

Grep confirms: `grep -n '\baxiom\b' Erdos731Problem.lean` yields exactly 1 result.

**lineCount: 301 → 357**

The file grew as more theorems were added since the metadata was last set. Current `wc -l` = 357.

**theoremCount: 21 → 23**

Two additional theorems were added after metadata generation. Current count (non-private `theorem`/`lemma` declarations) = 23.

## Summary

| Field | Before | After |
|-------|--------|-------|
| `meta.axiomCount` | 3 | 1 |
| `meta.lineCount` | 301 | 357 |
| `meta.theoremCount` | 21 | 23 |
| `leanFile.axiomCount` | 3 | 1 |
| `leanFile.lineCount` | 301 | 357 |
| `leanFile.theoremCount` | 21 | 23 |
| `assumptions` | Claims 3 axioms | Correctly names 1 axiom; clarifies choose_dvd_lcm and upper_bound_trivial are proved |

---
Automated fix by lean-mechanic agent.