### PR TITLE
research(erdos-31-primes-density): prime natural density zero via Chebyshev

### DIFF
--- a/src/data/proofs/erdos-31-primes-density/annotations.json
+++ b/src/data/proofs/erdos-31-primes-density/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-primes-density-zero",
+    "type": "theorem",
+    "label": "primes_density_zero",
+    "title": "Primes Have Natural Density Zero",
+    "body": "primes_density_zero: HasDensityZero {p : ℕ | p.Prime}. The natural density of the set of primes is 0: countingFn(primes, N) / N → 0. The proof squeezes: 0 ≤ π(N)/N ≤ 2·log 4/log N + 1/√N, and the upper bound tends to 0 by chebyshev_bound_tendsto_zero.",
+    "location": { "line": 220 },
+    "tags": ["main-theorem", "density", "primes", "analytic-number-theory"]
+  },
+  {
+    "id": "ann-chebyshev-theta-bound",
+    "type": "theorem",
+    "label": "chebyshevTheta_le",
+    "title": "Chebyshev Theta Bound: θ(N) ≤ N log 4",
+    "body": "chebyshevTheta_le: for all N, chebyshevTheta N ≤ N * Real.log 4. This uses the primorial bound: the product ∏_{p≤N} p divides the central binomial coefficient C(2N,N), and C(2N,N) ≤ 4^N (since it appears in the expansion of (1+1)^{2N} = 4^N). Taking logarithms: Σ_{p≤N} log p ≤ log(4^N) = N log 4.",
+    "location": { "line": 130 },
+    "tags": ["chebyshev", "theta-function", "primorial", "binomial"]
+  },
+  {
+    "id": "ann-prime-count-bound",
+    "type": "theorem",
+    "label": "primeCounting_le_chebyshev",
+    "title": "Prime Count Bound: π(N) ≤ 2N log 4/log N + √N + 1",
+    "body": "primeCounting_le_chebyshev: π(N) ≤ 2·N·log 4 / log N + √N + 1. Split primes into 'small' (p ≤ √N, at most √N of them) and 'large' (p > √N): for large primes, each contributes log p > (log N)/2 to θ(N), so their count is at most 2θ(N)/log N ≤ 2N log 4/log N. Total: π(N) ≤ 2N log 4/log N + √N.",
+    "location": { "line": 170 },
+    "tags": ["prime-counting", "chebyshev", "analytic"]
+  },
+  {
+    "id": "ann-chebyshev-theta",
+    "type": "definition",
+    "label": "chebyshevTheta",
+    "title": "Chebyshev Theta Function",
+    "body": "chebyshevTheta N = Σ_{p : ℕ | p.Prime ∧ p ≤ N} Real.log p. The Chebyshev θ-function sums the logarithms of all primes up to N. Unlike π(N) which counts primes uniformly, θ(N) weights each prime by its logarithm. The prime number theorem is equivalent to θ(N) ~ N (which is harder than the density bound θ(N) ≤ N log 4 used here).",
+    "location": { "line": 45 },
+    "tags": ["definition", "chebyshev", "theta-function"]
+  }
+]

--- a/src/data/proofs/erdos-31-primes-density/index.ts
+++ b/src/data/proofs/erdos-31-primes-density/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos31PrimesDensity.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-31-primes-density/meta.json
+++ b/src/data/proofs/erdos-31-primes-density/meta.json
@@ -1,0 +1,61 @@
+{
+  "id": "erdos-31-primes-density",
+  "title": "Primes Have Natural Density Zero",
+  "slug": "erdos-31-primes-density",
+  "description": "A machine-checked proof that the prime numbers have natural density zero: π(N)/N → 0 as N → ∞. The proof uses the Chebyshev theta function bound θ(N) ≤ N·log 4 (from the primorial bound 2^N ≤ 4^N ≤ ∏_{p≤N} p^{logN/logp}), which gives π(N) ≤ 2N·log 4/log N + √N + 1, and this upper bound tends to 0. Fully axiom-free from Mathlib.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 4,
+    "lineCount": 234,
+    "leanFile": "proofs/Proofs/Erdos31PrimesDensity.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "tags": ["number-theory", "prime-numbers", "density", "chebyshev", "analytic-number-theory"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "density-definitions",
+      "title": "Natural Density Definitions",
+      "description": "countingFn A N = |A ∩ {1,...,N}|, HasDensity A d (the limit countingFn A N / N → d), HasDensityZero A (density = 0), and chebyshevTheta N = Σ_{p prime, p≤N} log p (the Chebyshev θ-function). The density framework is set up over arbitrary subsets of ℕ.",
+      "theorems": ["countingFn", "HasDensity", "HasDensityZero", "chebyshevTheta"]
+    },
+    {
+      "id": "chebyshev-bound",
+      "title": "Chebyshev Theta Bound",
+      "description": "countingFn_primes_le_primeCounting bridges the custom countingFn with Mathlib's primeCounting (π(N)). chebyshevTheta_le: θ(N) ≤ N·log 4, proved using the primorial bound — the product of all primes ≤ N divides the central binomial coefficient C(2N,N) ≤ 4^N. primeCounting_le_chebyshev: π(N) ≤ 2N·log 4/log N + √N + 1, splitting primes into those ≤ √N (crude bound) and those > √N (using θ bound).",
+      "theorems": ["countingFn_primes_le_primeCounting", "chebyshevTheta_le", "primeCounting_le_chebyshev"]
+    },
+    {
+      "id": "density-zero",
+      "title": "Primes Have Density Zero",
+      "description": "chebyshev_bound_tendsto_zero proves that (2·log 4/log N + 1/√N) → 0 via standard real analysis (log N → ∞, 1/√N → 0). primes_density_zero: the primes have natural density zero, assembled by squeezing π(N)/N between 0 and the upper bound that tends to 0.",
+      "theorems": ["chebyshev_bound_tendsto_zero", "primes_density_zero"]
+    }
+  ],
+  "overview": {
+    "summary": "Despite being densely distributed in small ranges (by Dirichlet's theorem on primes in arithmetic progressions), the primes thin out rapidly: their natural density — the limit of π(N)/N — is 0. This is equivalent to the prime number theorem (PNT) saying π(N) ~ N/log N, but can be proved by much more elementary means using only the Chebyshev theta function bound.",
+    "approach": "The proof uses the Chebyshev theta bound θ(N) = Σ_{p≤N} log p ≤ N log 4. This comes from the primorial bound: ∏_{p≤N} p divides C(2N,N) ≤ 4^N, so Σ_{p≤N} log p ≤ log 4^N = N log 4. From this, π(N) ≤ 2N log 4/log N + √N + 1 (splitting at √N). Dividing by N gives π(N)/N ≤ 2 log 4/log N + 1/√N → 0.",
+    "significance": "The natural density of the primes being 0 is the qualitative content of the prime number theorem: the primes π(N) grow slower than any constant fraction of N. This result is a prerequisite for many counting problems in additive combinatorics. Erdős problem #31 asks about arithmetic progressions in the primes, for which density zero is a basic prerequisite."
+  },
+  "conclusion": {
+    "summary": "The prime numbers have natural density zero, proved from the Chebyshev theta bound without the prime number theorem, fully machine-checked against Mathlib.",
+    "openQuestions": [
+      "Can the prime number theorem π(N) ~ N/log N be formalized as a Lean 4 proof from scratch or using Mathlib's existing analytic number theory?",
+      "Can the stronger result that the primes have logarithmic density 1 (Σ_{p≤N} 1/p ~ log log N) be formalized?",
+      "Can these density bounds be used to prove Erdős problem #31 about arithmetic progressions in prime-free sets?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-31",
+      "relationship": "supports",
+      "description": "Provides the prime density zero result needed for analyzing arithmetic progressions avoiding primes"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `Erdos31PrimesDensity.lean` (234 lines, 0 axioms, 0 sorries).

**Theorem**: The prime numbers have natural density zero — π(N)/N → 0 as N → ∞. Proved from the Chebyshev theta bound θ(N) ≤ N log 4 (from the primorial bound: ∏_{p≤N} p | C(2N,N) ≤ 4^N), giving π(N) ≤ 2N log 4/log N + √N + 1.

**Key results**:
- `chebyshevTheta N` (def): Σ_{p≤N} log p
- `chebyshevTheta_le`: θ(N) ≤ N log 4 (primorial bound)
- `primeCounting_le_chebyshev`: π(N) ≤ 2N log 4/log N + √N + 1
- `chebyshev_bound_tendsto_zero`: the bound → 0
- `primes_density_zero`: HasDensityZero {p : ℕ | p.Prime}

## Files
- `src/data/proofs/erdos-31-primes-density/meta.json`
- `src/data/proofs/erdos-31-primes-density/annotations.json`
- `src/data/proofs/erdos-31-primes-density/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)