### PR TITLE
fix(binomial-theorem-oq-02-oq-01-oq-01): correct sorry count 7→5, lineCount 247→264

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -16,11 +16,11 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "badge": "wip",
-    "sorries": 7,
+    "sorries": 5,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 247,
-    "assumptions": "No axioms. 7 sorries for: Fintype instance, ENNReal normalization, support characterization, marginal distributions, mean, covariance, and concrete example.",
+    "lineCount": 264,
+    "assumptions": "No axioms. 5 sorries for: ENNReal normalization, support characterization, marginal distributions, mean, and covariance. The Fintype instance and concrete dice example are fully proved.",
     "originalContributions": [
       "Composition type as support of multinomial distribution",
       "PMF construction via multinomialPMFVal in ENNReal",
@@ -160,14 +160,14 @@
       "MeasureTheory"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01",
-    "lineCount": 247,
+    "lineCount": 264,
     "axiomCount": 0,
     "theoremCount": 7,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 2,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
-    "sorries": 7
+    "sorries": 5
   },
   "mainTheorems": [
     {
@@ -189,5 +189,5 @@
       "leanType": "covariance_sum = -n*pi*pj"
     }
   ],
-  "sorries": 7
+  "sorries": 5
 }


### PR DESCRIPTION
## Fix

Correct stale sorry count and line count in `binomial-theorem-oq-02-oq-01-oq-01` meta.json.

## Evidence

The Lean file (`BinomialTheoremOQ02OQ01OQ01.lean`) contains only **5 `sorry` tokens** — not 7 as claimed.

Verified by stripping block/line comments and counting `\bsorry\b`:
```
multinomialPMF_sum_eq_one     (line 102) — sorry
multinomialPMF_support        (line 136) — sorry
multinomial_marginal_binomial (line 157) — sorry
multinomial_mean              (line 172) — sorry
multinomial_covariance        (line 185) — sorry
```

The two items in the stale "Sorries (7)" comment that are NOT sorries:
- Fintype instance (lines 58–69): fully proved via Fintype.ofEquiv with piAntidiag.
- dice_six_rolls_all_different (line 228–231): proved by native_decide.

Line count was also stale: actual file is 264 lines, meta claimed 247.

**Before**: sorries=7, lineCount=247 (in meta, leanFile, and root)
**After**: sorries=5, lineCount=264 (in all three locations)

Flagged by find-targets.ts (1x, 2026-04-23).

---
Automated fix by lean-mechanic agent.