### PR TITLE
research(mean-value-theorem-oq-04): FTC via MVT — 14 calculus theorems

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-04/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-04/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-ftc-implies-mvt",
+    "type": "theorem",
+    "label": "ftc_implies_mvt",
+    "title": "FTC Implies MVT (via IVT)",
+    "body": "ftc_implies_mvt: for C¹ function f on [a,b], ∃ c ∈ (a,b), f'(c) = (f(b)-f(a))/(b-a). Proof: by FTC, ∫ₐᵇ f' = f(b)-f(a). The integral mean ∫f'/(b-a) lies between min f' and max f' on [a,b] (by the integral monotonicity). By IVT applied to f', there exists c with f'(c) equal to that mean. This derivation shows MVT is a strict consequence of FTC+IVT.",
+    "location": { "line": 165 },
+    "tags": ["mvt", "ftc", "ivt", "structural-connection"]
+  },
+  {
+    "id": "ann-newton-leibniz",
+    "type": "theorem",
+    "label": "newton_leibniz",
+    "title": "Newton-Leibniz Formula",
+    "body": "newton_leibniz: for continuously differentiable F on [a,b], ∫ₐᵇ F' = F(b) - F(a). The fundamental formula connecting integration and differentiation. Used in: ftc_implies_mvt (the integral mean equals (f(b)-f(a))/(b-a)), integration_by_parts (via product rule), and diff_then_integrate.",
+    "location": { "line": 75 },
+    "tags": ["newton-leibniz", "integration", "fundamental"]
+  },
+  {
+    "id": "ann-integration-by-parts",
+    "type": "theorem",
+    "label": "integration_by_parts",
+    "title": "Integration by Parts",
+    "body": "integration_by_parts: for C¹ functions f, g on [a,b]: ∫ₐᵇ f'·g = f(b)·g(b) - f(a)·g(a) - ∫ₐᵇ f·g'. Proved by applying Newton-Leibniz to the product rule: (fg)' = f'g + fg' → ∫(fg)' = ∫f'g + ∫fg', and ∫(fg)' = f(b)g(b) - f(a)g(a) by Newton-Leibniz.",
+    "location": { "line": 200 },
+    "tags": ["integration-by-parts", "product-rule"]
+  },
+  {
+    "id": "ann-ftc-uniqueness",
+    "type": "theorem",
+    "label": "ftc_uniqueness",
+    "title": "Antiderivatives Unique Up to Constant",
+    "body": "ftc_uniqueness: if F' = G' on [a,b] and both are continuous, then F - G is constant. The standard uniqueness theorem for antiderivatives: the derivative being zero everywhere implies constant (by MVT). Together with FTC Part 1, this means ∫ₐˣ f is the unique antiderivative vanishing at a.",
+    "location": { "line": 240 },
+    "tags": ["uniqueness", "antiderivative", "constant"]
+  },
+  {
+    "id": "ann-ftc-part1",
+    "type": "theorem",
+    "label": "ftc_part1",
+    "title": "FTC Part 1: Integral as Antiderivative",
+    "body": "ftc_part1: if f is continuous on [a,b], then x ↦ ∫ₐˣ f is continuously differentiable with derivative f. This is the 'differentiation undoes integration' direction of FTC. Proved from Mathlib's intervalIntegral.integral_hasDerivAt_right, which gives HasDerivAt at each interior point.",
+    "location": { "line": 30 },
+    "tags": ["ftc", "antiderivative", "differentiation"]
+  }
+]

--- a/src/data/proofs/mean-value-theorem-oq-04/index.ts
+++ b/src/data/proofs/mean-value-theorem-oq-04/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/MeanValueTheoremOQ04.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/mean-value-theorem-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04/meta.json
@@ -1,0 +1,67 @@
+{
+  "id": "mean-value-theorem-oq-04",
+  "title": "Fundamental Theorem of Calculus via MVT Structure",
+  "slug": "mean-value-theorem-oq-04",
+  "description": "Establishes the Fundamental Theorem of Calculus and its connection to the Mean Value Theorem: MVT (local) gives one value c with f'(c) = (f(b)-f(a))/(b-a), while FTC (global) gives the exact integral formula. Both are proved, along with integration by parts, uniqueness of antiderivatives, MVT as an integral average, and the Lipschitz distance bound.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "lineCount": 293,
+    "leanFile": "proofs/Proofs/MeanValueTheoremOQ04.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "tags": ["calculus", "mean-value-theorem", "fundamental-theorem-calculus", "integration", "analysis"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "ftc-parts",
+      "title": "Fundamental Theorem of Calculus",
+      "description": "The two parts of FTC: ftc_part1 (∫ₐˣ f is differentiable and its derivative is f(x)), ftc_part1_deriv (the derivative is exactly f), and antiderivative_of_integral (the integral function is the canonical antiderivative). The Newton-Leibniz formula ftc_part2: ∫ₐᵇ F' = F(b) - F(a) for continuously differentiable F.",
+      "theorems": ["ftc_part1", "ftc_part1_deriv", "antiderivative_of_integral", "newton_leibniz", "ftc_part2"]
+    },
+    {
+      "id": "mvt-ftc-connection",
+      "title": "MVT-FTC Structural Connection",
+      "description": "The key insight: ftc_implies_mvt shows MVT follows from FTC + IVT — the integral mean value lies between min and max of f', so by IVT some c achieves f'(c) = ∫f'/(b-a). mvt_equals_integral_average: the MVT value is the integral average f'(c) = ∫ₐᵇ f'/(b-a).",
+      "theorems": ["ftc_implies_mvt", "mvt_equals_integral_average"]
+    },
+    {
+      "id": "integral-identities",
+      "title": "Integral Identities and Applications",
+      "description": "integration_by_parts: ∫ₐᵇ f'g = f(b)g(b) - f(a)g(a) - ∫ₐᵇ fg'. ftc_uniqueness: any two antiderivatives of f differ by a constant. diff_then_integrate and integrate_then_diff: the FTC as inverse operations. ftc_no_loss: differentiating ∫ₐˣ f then integrating recovers the original integral.",
+      "theorems": ["integration_by_parts", "ftc_uniqueness", "diff_then_integrate", "integrate_then_diff", "ftc_no_loss"]
+    },
+    {
+      "id": "approximation",
+      "title": "Approximation Bounds",
+      "description": "integral_approx_from_mvt: |∫ₐᵇ f - f(c)·(b-a)| ≤ Lip(f')·(b-a)²/2 for Lipschitz f'. lipschitz_dist_bound: for Lipschitz continuous f, |f(x) - f(y)| ≤ Lip·|x - y|. These give quantitative error bounds for numerical integration via the MVT.",
+      "theorems": ["integral_approx_from_mvt", "lipschitz_dist_bound"]
+    }
+  ],
+  "overview": {
+    "summary": "The MVT and FTC are dual perspectives on the same local-to-global principle: the MVT says there exists a point where the instantaneous rate equals the average rate; the FTC says the exact average rate is the integral divided by the interval length. This file proves both from Mathlib's integration infrastructure and makes the structural connection explicit.",
+    "approach": "All 14 results are proved using Mathlib's IntervalIntegral, HasDerivAt, and ContinuousOn APIs. The FTC Part 1 uses intervalIntegral.integral_hasDerivAt_right; Newton-Leibniz uses intervalIntegral.integral_eq_sub_of_hasDerivAt. The MVT derivation from FTC uses the intermediate value theorem (IVT) applied to f' on [a,b]: the integral mean ∫f'/(b-a) lies in [min f', max f'] by the mean value property of integrals, so IVT gives a point c with f'(c) = ∫f'/(b-a).",
+    "significance": "The FTC is the central theorem of calculus, connecting differential and integral calculus. The proof that MVT is a corollary of FTC+IVT reveals the conceptual hierarchy: integration is more fundamental than differentiation in the sense that FTC implies MVT but not vice versa without additional structure. The inclusion of integration by parts and uniqueness of antiderivatives makes this a self-contained calculus toolkit."
+  },
+  "conclusion": {
+    "summary": "Fourteen calculus theorems — FTC Parts 1 and 2, MVT as FTC corollary, integration by parts, uniqueness of antiderivatives, and approximation bounds — machine-checked against Mathlib.",
+    "openQuestions": [
+      "Can the multivariable FTC (Green's theorem, Stokes' theorem) be derived from this framework using Mathlib's differential forms?",
+      "Can the Lebesgue version of FTC (differentiability a.e. for absolutely continuous functions) be formalized?",
+      "Does the MVT imply FTC (with the right hypotheses)? Can a Lean 4 proof of FTC purely from MVT be constructed?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "mean-value-theorem",
+      "relationship": "extends",
+      "description": "Extends the base MVT formalization with FTC and the MVT-FTC structural connection"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `MeanValueTheoremOQ04.lean` (293 lines, 0 axioms, 0 sorries).

**Theorem**: 14 fundamental calculus results, including FTC Parts 1 and 2 (Newton-Leibniz), MVT as a corollary of FTC+IVT, integration by parts, uniqueness of antiderivatives, and MVT-based approximation bounds.

**Key insight**: MVT (local) and FTC (global) are dual: MVT exists some c, FTC gives the exact integral average. MVT follows from FTC+IVT because the integral mean lies between min and max of f', so IVT gives the c.

**Key results**:
- `ftc_part1`, `newton_leibniz`: the two parts of FTC
- `ftc_implies_mvt`: MVT as corollary of FTC + IVT
- `mvt_equals_integral_average`: MVT value = ∫f'/(b-a)
- `integration_by_parts`: ∫f'g = f(b)g(b) - f(a)g(a) - ∫fg'
- `ftc_uniqueness`: antiderivatives unique up to constant

## Files
- `src/data/proofs/mean-value-theorem-oq-04/meta.json`
- `src/data/proofs/mean-value-theorem-oq-04/annotations.json`
- `src/data/proofs/mean-value-theorem-oq-04/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)