### PR TITLE
fix(sperner-simplicial-instance): add SpernerMathlib4 to additionalFiles

### DIFF
--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -79,7 +79,8 @@
     "theoremCount": 24,
     "definitionCount": 11,
     "path": "Proofs/SpernerSimplicialInstance.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": ["Proofs/SpernerMathlib4.lean"]
   },
   "sections": [
     {


### PR DESCRIPTION
## Fix

Add `Proofs/SpernerMathlib4.lean` to `leanFile.additionalFiles` in `src/data/proofs/sperner-simplicial-instance/meta.json`.

## Evidence

**Before**: `"additionalFiles"` key absent from `leanFile` block despite `SpernerSimplicialInstance.lean` importing `Proofs.SpernerMathlib4` at line 2.

**After**: `"additionalFiles": ["Proofs/SpernerMathlib4.lean"]` — auditor's `find-targets.ts` will now scan `SpernerMathlib4.lean` for sorry drift.

Current claim accuracy is unaffected (both files have 0 sorries, 0 axioms). This fix closes a future-drift blind spot.

Closes #15713

---
Automated fix by lean-mechanic agent.