### PR TITLE
research(borsuk-ulam-oq-03-oq-04): quantitative 1D Borsuk-Ulam with bisection

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-04/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-quantitative-bu",
+    "type": "theorem",
+    "label": "quantitative_borsuk_ulam_1d",
+    "title": "Quantitative 1D Borsuk-Ulam",
+    "body": "quantitative_borsuk_ulam_1d: for K-Lipschitz f and any antipodal zero x₀ (f(x₀)=f(-x₀)) with |f(1)-f(-1)| = δ, we have |x₀| ≤ 1 - δ/(2K). The proof: antiDiff g = f(x) - f(-x) is 2K-Lipschitz with g(1)=δ, g(x₀)=0. Then δ = |g(1)-g(x₀)| ≤ 2K·|1-x₀| = 2K·(1-x₀), giving x₀ ≤ 1-δ/(2K). By symmetry (antiDiff antisymmetry), also x₀ ≥ -1+δ/(2K).",
+    "location": { "line": 100 },
+    "tags": ["main-theorem", "borsuk-ulam", "quantitative", "lipschitz"]
+  },
+  {
+    "id": "ann-anti-diff-lipschitz",
+    "type": "theorem",
+    "label": "antisymm_diff_lipschitz_two",
+    "title": "Antisymmetric Difference is 2K-Lipschitz",
+    "body": "antisymm_diff_lipschitz_two: if f is K-Lipschitz, then antiDiff f (= f(x) - f(-x)) is 2K-Lipschitz. This is the key amplification: the Lipschitz constant doubles because negating x contributes another factor of K. The factor of 2 is tight — for f(x) = Kx, antiDiff(x) = 2Kx has constant 2K.",
+    "location": { "line": 65 },
+    "tags": ["lipschitz", "anti-diff", "amplification"]
+  },
+  {
+    "id": "ann-bisection",
+    "type": "theorem",
+    "label": "antipodal_within_epsilon",
+    "title": "Bisection Finds Antipodal Pair Within ε",
+    "body": "antipodal_within_epsilon: for K-Lipschitz f with δ>0 and any ε>0, the bisection algorithm finds x' with |x' - x₀| < ε (where x₀ is an antipodal zero) in O(log(1/ε)) steps. The algorithm maintains a bracket [a,b] containing a zero of antiDiff, halving at each step. After n steps, the bracket has length ≤ 2/2ⁿ, giving the midpoint error ≤ 1/2ⁿ.",
+    "location": { "line": 195 },
+    "tags": ["bisection", "algorithm", "effective"]
+  },
+  {
+    "id": "ann-anti-diff-def",
+    "type": "definition",
+    "label": "antiDiff",
+    "title": "Antisymmetric Difference",
+    "body": "antiDiff f = fun x => f x - f (-x). This is the antisymmetric part of f: antiDiff(-x) = -antiDiff(x). Antipodal zeros of f (where f(x₀) = f(-x₀)) correspond exactly to zeros of antiDiff. The IVT applies because antiDiff(-1) = f(-1)-f(1) and antiDiff(1) = f(1)-f(-1) have opposite signs when δ > 0.",
+    "location": { "line": 25 },
+    "tags": ["definition", "antisymmetric", "antipodal"]
+  }
+]

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-04/index.ts
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-04/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/BorsukUlamOQ03OQ04.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
@@ -1,0 +1,61 @@
+{
+  "id": "borsuk-ulam-oq-03-oq-04",
+  "title": "Quantitative 1D Borsuk-Ulam: Effective Bounds on Antipodal Pairs",
+  "slug": "borsuk-ulam-oq-03-oq-04",
+  "description": "For a K-Lipschitz function f : [-1,1] → ℝ with |f(1) - f(-1)| = δ > 0, any antipodal zero x₀ (where f(x₀) = f(-x₀)) satisfies -1 + δ/(2K) ≤ x₀ ≤ 1 - δ/(2K). This gives an effective, computable location bound for antipodal pairs beyond the mere existence guaranteed by the classical 1D Borsuk-Ulam theorem.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "lineCount": 235,
+    "leanFile": "proofs/Proofs/BorsukUlamOQ03OQ04.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "tags": ["topology", "borsuk-ulam", "lipschitz", "quantitative", "antipodal"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "anti-diff",
+      "title": "Antisymmetric Difference",
+      "description": "antiDiff f = f(x) - f(-x) is the antisymmetric part of f. Key properties: antiDiff_antisymm (antiDiff(-x) = -antiDiff(x)), antiDiff_at_one_sum (antiDiff(-1) + antiDiff(1) = 0), antiDiff_at_one_eq_diff (antiDiff(1) = f(1) - f(-1) = δ), antiDiff_zero_iff (antiDiff(x₀) = 0 iff f(x₀) = f(-x₀)), and antisymm_diff_lipschitz_two (antiDiff is 2K-Lipschitz when f is K-Lipschitz).",
+      "theorems": ["antiDiff_antisymm", "antiDiff_at_one_sum", "antiDiff_at_one_eq_diff", "antiDiff_zero_iff", "antisymm_diff_lipschitz_two"]
+    },
+    {
+      "id": "existence-and-bounds",
+      "title": "Existence and Location Bounds",
+      "description": "antiDiff_has_zero: antiDiff has a zero in [-1,1] (follows from IVT — antiDiff changes sign since antiDiff(-1) = -δ, antiDiff(1) = δ). quantitative_borsuk_ulam_1d: the zero x₀ satisfies |x₀| ≤ 1 - δ/(2K). antipodal_location_tight: the full two-sided bound -1 + δ/(2K) ≤ x₀ ≤ 1 - δ/(2K).",
+      "theorems": ["antiDiff_has_zero", "quantitative_borsuk_ulam_1d", "antipodal_location_tight"]
+    },
+    {
+      "id": "bisection",
+      "title": "Bisection Localization",
+      "description": "A constructive bisection algorithm to locate antipodal pairs within ε: bisection_bracket_induction (the bisection invariant — at each step the interval contains a zero), antipodal_bisection_localization (after n steps, the interval has length ≤ 2/(2^n)), antipodal_midpoint_error (midpoint error ≤ 2/(2^n)), antipodal_within_epsilon (given tolerance ε, achieve |x - x₀| < ε in ⌈log₂(2/ε)⌉ steps), and quantitative_bu_summary (complete summary theorem).",
+      "theorems": ["bisection_bracket_induction", "antipodal_bisection_localization", "antipodal_midpoint_error", "antipodal_within_epsilon", "quantitative_bu_summary"]
+    }
+  ],
+  "overview": {
+    "summary": "The 1D Borsuk-Ulam theorem says every continuous f : [-1,1] → ℝ has an antipodal pair (f(x) = f(-x)). This file adds quantitative information: if f is K-Lipschitz, the antipodal pair can't be too close to the endpoints, and there's a bisection algorithm that finds it within ε in O(log(1/ε)) steps.",
+    "approach": "Define g(x) = f(x) - f(-x) (the antisymmetric part). Note g(-1) = f(-1) - f(1) = -δ and g(1) = δ. By IVT, g has a zero x₀. Since g is 2K-Lipschitz and g(1) = δ, the Lipschitz condition forces |g(1) - g(x₀)| = δ ≤ 2K·(1 - x₀), giving x₀ ≤ 1 - δ/(2K). Similarly x₀ ≥ -1 + δ/(2K). The bisection algorithm uses this two-sided bound at each step.",
+    "significance": "Quantitative Borsuk-Ulam bounds have applications in computational topology (finding antipodal pairs algorithmically), approximation theory (understanding where continuous functions must take equal values on antipodal points), and optimization (determining how far from endpoints the optimal antipodal pair can be)."
+  },
+  "conclusion": {
+    "summary": "The quantitative 1D Borsuk-Ulam theorem and a bisection algorithm for locating antipodal pairs within ε are machine-checked, extending the classical existence result with effective location bounds.",
+    "openQuestions": [
+      "Can the bound δ/(2K) be shown to be tight — is there a K-Lipschitz f where the antipodal pair is exactly at ±(1 - δ/(2K))?",
+      "Can the higher-dimensional Borsuk-Ulam theorem (f : S^n → ℝ^n always has an antipodal pair) be strengthened with similar quantitative bounds via Lipschitz assumptions?",
+      "Does the bisection algorithm extend to higher dimensions via a Sperner-type recursive decomposition?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "borsuk-ulam-oq-03",
+      "relationship": "extends",
+      "description": "Adds quantitative location bounds to the 1D Borsuk-Ulam existence result"
+    }
+  ]
+}


### PR DESCRIPTION
Quantitative 1D Borsuk-Ulam bounds + bisection algorithm. 235 lines, 13 theorems, 0 axioms, 0 sorries.