### PR TITLE
fix(meta): add/correct top-level `sorries` field in 33 gallery entries

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
@@ -105,7 +105,7 @@
     "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
     "sorries": 0
   },
-  "sorries": 1,
+  "sorries": 0,
   "crossReferences": [
     {
       "targetId": "angle-trisection-cos-20-gal",

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -124,5 +124,6 @@
       "Can insep_gal_trivial be proved in Lean using Mathlib's purely inseparable extension theory?",
       "Does the same argument yield a bound natDegree(p) / p^k | |Gal(p)| for inseparable irreducibles of degree p^k · d (separable degree d)?"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -188,5 +188,6 @@
       "relationship": "related",
       "description": "Origami constructibility: multi-fold origami strictly dominates marked ruler, extending the constructibility hierarchy"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -126,5 +126,6 @@
       "relationship": "related",
       "description": "OQ-04 analyzes generalized constructibility with additional tools (neusis, origami); the halvings complexity result contextualizes why simple compass-straightedge constructibility is decidable in O(log d) and tight"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
@@ -148,5 +148,6 @@
     "definitionCount": 1,
     "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -154,5 +154,6 @@
     "sorryCount": 3,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01OQ01.lean"
-  }
+  },
+  "sorries": 3
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -133,5 +133,6 @@
       "Could an alternative approach via the Radon-Nikodym derivative (Halmos-Savage representation) avoid the Lp restriction map entirely, giving a direct construction of g ∈ Lq without localizing?",
       "Would a Mathlib lemma `Lp.restrict_comap : Lp p (μ.restrict S) →L[𝕜] Lp p μ` (the isometric Lp restriction map) be accepted as a standalone Mathlib contribution, resolving the only remaining sorry in this file?"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -143,5 +143,6 @@
     "definitionCount": 1,
     "path": "Proofs/CevasTheoremNonEuclideanOQ02OQ01.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -121,5 +121,6 @@
     "definitionCount": 3,
     "path": "Proofs/CevasTheoremOQ01OQ03.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -119,5 +119,6 @@
       "Prove the analogous result for k-cycles: P(σ has exactly m k-cycles) → Pois(1/k)^m (derangements-convergence-oq-01-oq-02)",
       "Quantify the total variation convergence rate TV(X_n, Pois(1)) ≤ C/n via Chen-Stein method"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -153,5 +153,6 @@
     "definitionCount": 2,
     "path": "Proofs/DesarguesTheoremOQ01OQ01.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
@@ -120,5 +120,6 @@
     "Three-tier hierarchy theorem: GRH → SZC (standard range) → Nonvanishing in one clean proof",
     "siegel_zero_distance_lower_bound: MVT + Siegel combination showing (1-β)·M > C(ε)/N^ε",
     "state_of_knowledge: summary theorem cataloging proved vs open results"
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -156,5 +156,6 @@
       "summary": "Proves oq02_rate_not_sharp: |S(N,A,c) - f(A,c)| = o(A log N / N).",
       "mathContext": "The main theorem combines: (1) the sharp rate axiom $|S-f| = O(A(\\log N)^{2/3}(\\log\\log N)^{4/3}/N)$, and (2) the comparison $(\\log N)^{2/3}(\\log\\log N)^{4/3}/N = o(\\log N/N)$, via $\\texttt{IsBigO.trans\\_isLittleO}$. This yields $|S-f| = o(A \\log N/N)$ — strictly better convergence than OQ-02's O bound."
     }
-  ]
+  ],
+  "sorries": 4
 }

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -55,5 +55,6 @@
       "Can the normal filter characterization (the club filter is κ-complete and normal) be derived from this infrastructure?"
     ]
   },
-  "crossReferences": []
+  "crossReferences": [],
+  "sorries": 0
 }

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -49,5 +49,6 @@
       "Can the count of non-representable numbers ((a-1)(b-1)/2) be proved as a corollary in this framework?"
     ]
   },
-  "crossReferences": []
+  "crossReferences": [],
+  "sorries": 0
 }

--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -55,5 +55,6 @@
       "Can these results give a Lean 4 proof of quadratic reciprocity via the structure of (ZMod p)×?"
     ]
   },
-  "crossReferences": []
+  "crossReferences": [],
+  "sorries": 0
 }

--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-01/meta.json
@@ -136,5 +136,6 @@
       "endLine": 276,
       "summary": "Proves four_set_inclusion_exclusion by composing the three-set and two-set formulas with four intersection distributivity steps, closed by linarith. Includes three concrete examples verified by native_decide."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/inclusion-exclusion-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03/meta.json
@@ -154,5 +154,6 @@
       "venue": "STOC 2007",
       "note": "O(n·2ⁿ) fast subset convolution algorithm; zetaStep is the fundamental building block"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -131,5 +131,6 @@
     "definitionCount": 0,
     "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
@@ -144,5 +144,6 @@
       "relationship": "related",
       "description": "Companion bisection formalization focusing on algorithmic aspects; compare with the oracle-parameterized approach here"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/inverse-galois-d4/meta.json
+++ b/src/data/proofs/inverse-galois-d4/meta.json
@@ -115,5 +115,6 @@
     "imports": [
       "Proofs.NthRootIrrationalOQ01"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/lagrange-four-squares-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01-oq-01/meta.json
@@ -153,5 +153,6 @@
     "theoremCount": 19,
     "definitionCount": 3,
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
@@ -171,5 +171,6 @@
       "Can a constructive proof be given for `thomae_irrational_continuous` that avoids classical choice (`h.choose`), using a computable approximation to the irrational?",
       "Can the pattern (finite obstruction set → epsilon-delta continuity) be abstracted to a general Mathlib lemma about functions with countable jump discontinuities?"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -58,5 +58,6 @@
       "relationship": "uses",
       "description": "Shares the cross-product and Lagrange identity infrastructure"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -65,5 +65,6 @@
       "relationship": "supports",
       "description": "Provides the primitive triangulation ingredient for the constructive proof of Pick's theorem"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -181,5 +181,6 @@
     "definitionCount": 0,
     "path": "Proofs/QuadraticReciprocityOQ03.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -220,5 +220,6 @@
       "venue": "Wiley, 2nd edition",
       "note": "AEP and typical sequences: Chapter 3"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -72,5 +72,6 @@
       "relationship": "specializes",
       "description": "Sperner's lemma instantiated for triangulation data structures"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -76,5 +76,6 @@
       "relationship": "related",
       "description": "n-dimensional Sperner via Freudenthal triangulation"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/sperner-simplicial-bridge/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge/meta.json
@@ -71,5 +71,6 @@
       "relationship": "related",
       "description": "Concrete Triangulation instantiation for the same abstract theorem"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -69,5 +69,6 @@
       "relationship": "supports",
       "description": "The energy increment step is the key engine for proving Szemerédi's theorem on arithmetic progressions"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
@@ -123,5 +123,6 @@
     "definitionCount": 3,
     "path": "Proofs/WilsonsTheoremOQ01OQ01.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
@@ -78,5 +78,6 @@
       "relationship": "extends",
       "description": "Extends the cyclic case infrastructure to prove the complete Gauss-Wilson characterization"
     }
-  ]
+  ],
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

The top-level `sorries` field (consumed by gallery website filters at `src/pages/HomePage.tsx:435` and `src/pages/ErdosPage.tsx:108`, typed as `number` in `src/types/proof.ts:449`) was missing or stale in 33 entries. Missing this field causes gallery filters to incorrectly treat proofs as having sorries.

## Changes

| Category | Count | Details |
|----------|-------|---------|
| Stale value corrected | 1 | `angle-trisection-cos-20-gal-oq-01-oq-02`: 1→0 (proof completed in PR #15696 but top-level field not updated) |
| Missing field added | 32 | Newer entries created without this field; value set to match `meta.sorries` |

### Entries with missing field (None → correct value)

- `angle-trisection-oq-02-oq-01-oq-01-oq-01` → 0
- `angle-trisection-oq-03-oq-01` → 0
- `angle-trisection-oq-03-oq-02` → 0
- `bezout-identity-oq-01-oq-01` → 0
- `birthday-problem-oq-01-oq-01` → 3
- `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01` → 0
- `cevas-theorem-non-euclidean-oq-02-oq-01` → 0
- `cevas-theorem-oq-01-oq-03` → 0
- `derangements-convergence-oq-01-oq-01` → 0
- `desargues-theorem-oq-01-oq-01` → 0
- `dirichlets-theorem-oq-01-oq-01` → 0
- `erdos-1001-oq-02-oq-01` → 4
- `fodor-pressing-down` → 0
- `frobenius-number` → 0
- `gauss-wilson-non-cyclic` → 0
- `inclusion-exclusion-oq-01-oq-01` → 0
- `inclusion-exclusion-oq-03` → 0
- `infinitude-primes-4k3-oq-03` → 0
- `intermediate-value-theorem-oq-02-oq-03` → 0
- `inverse-galois-d4` → 0
- `lagrange-four-squares-oq-01-oq-01` → 0
- `lebesgue-measure-oq-01-oq-01-oq-02` → 0
- `pappus-theorem-oq-02` → 0
- `picks-theorem-oq-01-oq-01` → 0
- `quadratic-reciprocity-oq-03` → 0
- `shannon-source-coding-oq-03` → 0
- `sperner-mathlib` → 0
- `sperner-mathlib4` → 0
- `sperner-simplicial-bridge` → 0
- `szemeredi-core-oq-01` → 0
- `wilsons-theorem-oq-01-oq-01` → 0
- `wilsons-theorem-oq-02-ext` → 0

## Method

All values were set to match `meta.sorries` (the source of truth). The fix uses targeted string replacement to avoid JSON reformatting side effects.

---
Automated fix by lean-mechanic agent.