### PR TITLE
research(circumference-via-differentiation): add gallery entry for C=dA/dr

### DIFF
--- a/src/data/proofs/circumference-via-differentiation/annotations.json
+++ b/src/data/proofs/circumference-via-differentiation/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "annotation-area-fn",
+    "type": "definition",
+    "label": "areaFn",
+    "body": "areaFn r = π · r²",
+    "note": "The area of a disk of radius r. Defined as a real-valued function so that differentiation is well-defined everywhere.",
+    "location": { "section": "area-function" }
+  },
+  {
+    "id": "annotation-circumference-fn",
+    "type": "definition",
+    "label": "circumferenceFn",
+    "body": "circumferenceFn r = 2 · π · r",
+    "note": "The circumference of a circle of radius r. The main theorem shows this equals the derivative of areaFn.",
+    "location": { "section": "area-function" }
+  },
+  {
+    "id": "annotation-area-has-deriv-at",
+    "type": "theorem",
+    "label": "area_hasDerivAt",
+    "body": "HasDerivAt areaFn (2 * π * r) r",
+    "note": "The derivative of πr² at each point r is 2πr. Proved using Mathlib's HasDerivAt framework for polynomial differentiation: d/dr(π·r²) = π·(2r) = 2πr.",
+    "location": { "section": "area-function" }
+  },
+  {
+    "id": "annotation-deriv-area",
+    "type": "theorem",
+    "label": "deriv_area",
+    "body": "deriv areaFn r = 2 * π * r",
+    "note": "Connects HasDerivAt to Mathlib's deriv function: since areaFn has a derivative at r, deriv areaFn r equals 2πr.",
+    "location": { "section": "area-function" }
+  },
+  {
+    "id": "annotation-area-fn-differentiable",
+    "type": "theorem",
+    "label": "areaFn_differentiable",
+    "body": "Differentiable ℝ areaFn",
+    "note": "areaFn = π·r² is differentiable everywhere on ℝ, needed to apply FTC and other calculus theorems.",
+    "location": { "section": "area-function" }
+  },
+  {
+    "id": "annotation-measure-disk",
+    "type": "theorem",
+    "label": "measure_disk_eq_areaFn",
+    "body": "MeasureTheory.volume {x : ℝ × ℝ | ‖x‖ ≤ r} = ENNReal.ofReal (areaFn r)",
+    "note": "Mathlib's Lebesgue measure of the closed disk of radius r in ℝ² equals πr². Uses MeasureTheory.Measure.Lebesgue.VolumeOfBalls which establishes the volume of Euclidean balls.",
+    "location": { "section": "main-theorems" }
+  },
+  {
+    "id": "annotation-circumference-eq",
+    "type": "theorem",
+    "label": "circumference_eq",
+    "body": "circumferenceFn r = deriv areaFn r",
+    "note": "The central result: C(r) = dA/dr. The circumference formula 2πr is exactly the derivative of the area formula πr². This formalizes the geometric intuition that a thin annular shell of width dr has area ≈ C(r)·dr.",
+    "location": { "section": "main-theorems" }
+  },
+  {
+    "id": "annotation-circumference-unit",
+    "type": "theorem",
+    "label": "circumference_unit_circle",
+    "body": "circumferenceFn 1 = 2 * π",
+    "note": "The unit circle has circumference 2π. A direct computation from the definition circumferenceFn 1 = 2·π·1 = 2π.",
+    "location": { "section": "main-theorems" }
+  },
+  {
+    "id": "annotation-circumference-scaling",
+    "type": "theorem",
+    "label": "circumference_scaling",
+    "body": "∀ λ ≥ 0, circumferenceFn (λ * r) = λ * circumferenceFn r",
+    "note": "Circumference scales linearly: C(λr) = λ·C(r). Follows immediately from linearity of 2πr. This is the 1-dimensional scaling law for 1-dimensional boundary.",
+    "location": { "section": "geometric-properties" }
+  },
+  {
+    "id": "annotation-circumference-zero",
+    "type": "theorem",
+    "label": "circumference_zero",
+    "body": "circumferenceFn 0 = 0",
+    "note": "A degenerate circle of radius 0 has circumference 0.",
+    "location": { "section": "geometric-properties" }
+  },
+  {
+    "id": "annotation-area-second-deriv",
+    "type": "theorem",
+    "label": "area_second_deriv",
+    "body": "deriv (deriv areaFn) r = 2 * π",
+    "note": "The second derivative of area with respect to radius is the constant 2π. Since C(r) = 2πr is linear, its derivative is constant. This means area grows quadratically and circumference grows linearly.",
+    "location": { "section": "geometric-properties" }
+  },
+  {
+    "id": "annotation-area-fn-mono",
+    "type": "theorem",
+    "label": "areaFn_mono",
+    "body": "∀ r₁ r₂ > 0, r₁ < r₂ → areaFn r₁ < areaFn r₂",
+    "note": "Area is strictly increasing for positive radii: larger disks have larger area.",
+    "location": { "section": "geometric-properties" }
+  },
+  {
+    "id": "annotation-area-fn-zero",
+    "type": "theorem",
+    "label": "areaFn_eq_zero_iff",
+    "body": "areaFn r = 0 ↔ r = 0",
+    "note": "Area is zero if and only if the radius is zero. Since πr² = 0 ↔ r = 0 (as π > 0).",
+    "location": { "section": "geometric-properties" }
+  },
+  {
+    "id": "annotation-measure-disk-scaling",
+    "type": "theorem",
+    "label": "measure_disk_scaling",
+    "body": "volume {x : ℝ × ℝ | ‖x‖ ≤ λ * r} = λ² * volume {x | ‖x‖ ≤ r}",
+    "note": "Scaling a disk by λ scales its area by λ². This is the 2D scaling law: area is a 2-homogeneous function of radius.",
+    "location": { "section": "geometric-properties" }
+  },
+  {
+    "id": "annotation-duality",
+    "type": "theorem",
+    "label": "area_circumference_duality",
+    "body": "areaFn r = ∫ t in Set.Icc 0 r, circumferenceFn t",
+    "note": "Area equals the integral of circumference: A(r) = ∫₀ʳ C(t) dt. This is the inverse relationship to C = dA/dr, proved via the Fundamental Theorem of Calculus. Geometrically: the disk of radius r is filled by concentric circles of all radii from 0 to r.",
+    "location": { "section": "geometric-properties" }
+  }
+]

--- a/src/data/proofs/circumference-via-differentiation/index.ts
+++ b/src/data/proofs/circumference-via-differentiation/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/CircumferenceViaDifferentiation.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/circumference-via-differentiation/meta.json
+++ b/src/data/proofs/circumference-via-differentiation/meta.json
@@ -1,0 +1,58 @@
+{
+  "id": "circumference-via-differentiation",
+  "title": "Circumference Formula via Differentiation of Area",
+  "slug": "circumference-via-differentiation",
+  "description": "The circumference formula C(r) = 2πr is derived by differentiating the disk area A(r) = πr² with respect to radius: C(r) = dA/dr. This formalizes the elegant geometric insight that the rate of change of a disk's area equals its boundary length. Includes the area-circumference duality and scaling laws, machine-checked against Mathlib's integration and differentiation infrastructure.",
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "lineCount": 199,
+    "leanFile": "proofs/Proofs/CircumferenceViaDifferentiation.lean",
+    "imports": [
+      "Mathlib.Analysis.Calculus.Deriv.Polynomial",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls",
+      "Mathlib.Tactic"
+    ],
+    "tags": ["geometry", "calculus", "circumference", "area", "circle", "differentiation"],
+    "assumptions": []
+  },
+  "sections": [
+    {
+      "id": "area-function",
+      "title": "Area and Circumference Functions",
+      "description": "areaFn r = π·r² (area of disk with radius r) and circumferenceFn r = 2·π·r (circumference). Basic properties: area_hasDerivAt (d/dr(πr²) = 2πr via HasDerivAt), deriv_area (the Mathlib deriv equals 2πr), and areaFn_differentiable (areaFn is differentiable everywhere).",
+      "theorems": ["areaFn", "circumferenceFn", "area_hasDerivAt", "deriv_area", "areaFn_differentiable"]
+    },
+    {
+      "id": "main-theorems",
+      "title": "Circumference and Measure Identity",
+      "description": "measure_disk_eq_areaFn: Mathlib's Lebesgue measure of the closed disk {x : ℝ² | ‖x‖ ≤ r} equals areaFn r = πr². circumference_eq: C(r) = dA/dr = 2πr. circumference_unit_circle: C(1) = 2π.",
+      "theorems": ["measure_disk_eq_areaFn", "circumference_eq", "circumference_unit_circle"]
+    },
+    {
+      "id": "geometric-properties",
+      "title": "Scaling and Duality",
+      "description": "circumference_scaling: C(λr) = λ·C(r) for λ ≥ 0. circumference_zero: C(0) = 0. area_second_deriv: d²A/dr² = 2π (constant — the circumference formula is linear). areaFn_mono: area is strictly monotone for positive radii. areaFn_eq_zero_iff: area is zero iff r = 0. area_circumference_duality: A(r) = ∫₀ʳ C(t) dt (area = integral of circumference over radii).",
+      "theorems": ["circumference_scaling", "circumference_zero", "area_second_deriv", "areaFn_mono", "areaFn_eq_zero_iff", "measure_disk_scaling", "area_circumference_duality"]
+    }
+  ],
+  "overview": {
+    "summary": "The area-circumference relationship C(r) = dA/dr has a beautiful geometric interpretation: when a disk of radius r grows by dr, the added area is approximately a thin annular strip of width dr and length C(r), giving dA ≈ C(r)·dr. Since A(r) = πr², we get C(r) = 2πr. The inverse relationship is equally elegant: A(r) = ∫₀ʳ C(t) dt — area is the integral of circumference.",
+    "approach": "The proof uses Mathlib's HasDerivAt for polynomials (d/dr(πr²) = 2πr) and MeasureTheory.Measure.Lebesgue.VolumeOfBalls for the area formula (measure of a ball of radius r in ℝ² = π·r²). The area-circumference duality is proved via FTC: differentiating ∫₀ʳ 2πt dt = πr² gives 2πr, and integrating C from 0 to r gives A(r).",
+    "significance": "This derivation of the circumference formula is one of the most elegant in elementary geometry. It generalizes: the surface area of an n-ball is the derivative of its volume with respect to radius. In n dimensions, V(r) = ωₙ·rⁿ implies S(r) = dV/dr = n·ωₙ·rⁿ⁻¹ = ωₙ₋₁·rⁿ⁻¹ where ωₙ and ωₙ₋₁ are the volume constants. For n=2: V = πr², S = 2πr."
+  },
+  "conclusion": {
+    "summary": "The circumference formula C(r) = 2πr is machine-checked as the derivative of the area formula A(r) = πr², with the duality A(r) = ∫₀ʳ C(t) dt also verified.",
+    "openQuestions": [
+      "Can the n-dimensional analog — surface area of S^(n-1) = d/dr(volume of B^n) — be formalized for arbitrary n using Mathlib's geometric measure theory?",
+      "Can the Weyl tube formula (volume of a tubular neighborhood of a manifold as a polynomial in radius) be derived from this differentiation approach?",
+      "Does the area-circumference duality generalize to Riemannian manifolds via the co-area formula?"
+    ]
+  },
+  "crossReferences": []
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for `CircumferenceViaDifferentiation.lean` — derives the circumference formula C(r) = 2πr by differentiating the disk area A(r) = πr².

- **13 theorems**, 2 defs, 0 axioms, 0 sorries, 199 lines
- `status: verified`, `badge: original`
- Key results: `circumference_eq` (C = dA/dr), `area_circumference_duality` (A = ∫C), `measure_disk_eq_areaFn` (Lebesgue measure = πr²)
- Imports: Mathlib only (Deriv.Polynomial, Trigonometric, VolumeOfBalls)