### PR TITLE
fix(sperner-mathlib4): definitionCount 2→3, lineCount 733→732

### DIFF
--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -9,8 +9,8 @@
     "axiomCount": 0,
     "sorryCount": 0,
     "theoremCount": 5,
-    "definitionCount": 2,
-    "lineCount": 733,
+    "definitionCount": 3,
+    "lineCount": 732,
     "leanFile": "proofs/Proofs/SpernerMathlib4.lean",
     "imports": [
       "Mathlib.Algebra.Order.BigOperators.Group.Finset",


### PR DESCRIPTION
## Fix

Correct two metadata fields in `src/data/proofs/sperner-mathlib4/meta.json`.

## Evidence

**definitionCount**:
- **Before**: 2
- **After**: 3
- **Reason**: `SpernerMathlib4.lean` has `structure CellComplex`, `def IsPanchromatic`, `def IsDoor` — 3 declaration-type definitions

**lineCount**:
- **Before**: 733
- **After**: 732
- **Reason**: `wc -l proofs/Proofs/SpernerMathlib4.lean` = 732

Closes #15724

---
Automated fix by lean-mechanic agent.