### PR TITLE
fix(meta): replace invalid badge='verified' in 54 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -16,7 +16,7 @@
       "finite-groups",
       "abel-ruffini"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
@@ -15,7 +15,7 @@
       "unification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 138,

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "open-question",
       "unification"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 1072,

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
@@ -15,7 +15,7 @@
       "irreducibility",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 434,

--- a/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
@@ -14,7 +14,7 @@
       "angle trisection",
       "group theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 163,

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "dimension"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 18,

--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -17,7 +17,7 @@
       "measure-theory"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All 10 theorems fully verified with 0 sorries and 0 axioms. The polar_integral_factorization sorry was resolved via Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst.",

--- a/src/data/proofs/arithmetic-series-oq-00-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00-oq-02/meta.json
@@ -17,7 +17,7 @@
       "nicomachus"
     ],
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ00OQ02.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 11,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "vandermonde",
       "quantum-calculus"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "zmod",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 30,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
@@ -14,7 +14,7 @@
       "f-vector",
       "binomial coefficients"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 372,

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -18,7 +18,7 @@
       "lattice-paths",
       "research"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
@@ -17,7 +17,7 @@
       "recurrence",
       "convolution"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "originalContributions": [
       "Bridge cn_eq_catalan: LatticePathLGV.Cn n = catalan n (Mathlib root namespace) via centralBinom characterization",

--- a/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
@@ -15,7 +15,7 @@
       "open-problem",
       "irrationality"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "assumptions": "0 sorries, 0 axioms. All theorems are fully proved. The main results — apery_criterion, geometric_decay_tendsto, and all conditional theorems — contain no mathematical assumptions beyond the hypotheses stated.",
     "dateAdded": "2026-04-04",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "probability"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ01.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-26",
     "axiomCount": 0,

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -14,7 +14,7 @@
       "binomial theorem",
       "combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 222,

--- a/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 207,

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
@@ -17,7 +17,7 @@
       "logarithm",
       "research"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -13,7 +13,7 @@
       "radon-nikodym",
       "measure-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 1077,

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "cauchy-schwarz",
       "orthogonalization"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -18,7 +18,7 @@
             "finite-fields",
             "minimal-polynomial"
         ],
-        "badge": "verified",
+        "badge": "mathlib",
         "sorries": 0,
         "axiomCount": 0,
         "theoremCount": 3,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
@@ -16,7 +16,7 @@
       "krylov-method",
       "polynomial-ideals"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 265,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
@@ -18,7 +18,7 @@
       "primary-decomposition",
       "wip"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 359,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
@@ -18,7 +18,7 @@
       "axiom-elimination",
       "wip"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 549,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -17,7 +17,7 @@
       "finite-fields",
       "module-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 287,

--- a/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
       "extension",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 210,

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "characteristic-function",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 176,

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "signed-ratios",
       "sin"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
@@ -17,7 +17,7 @@
       "transversal",
       "signed-ratios"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -13,7 +13,7 @@
       "Chebyshev",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 210,

--- a/src/data/proofs/chebyshev-pnt-bridge/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/meta.json
@@ -15,7 +15,7 @@
       "prime-number-theorem",
       "analytic-number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -15,7 +15,7 @@
       "binomial-coefficients",
       "central-binomial"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -18,7 +18,7 @@
       "permutations",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked. The derangements_rate lemma delegates to derangements_convergence_rate from DerangementsConvergence.lean, which proves |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-25",

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -18,7 +18,7 @@
       "scissors-congruence",
       "irrational-angles"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "modular-arithmetic"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 sorries, 0 axioms. Fully machine-checked.",

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -14,7 +14,7 @@
       "algorithms"
     ],
     "proofRepoPath": "Proofs/DivisibilityRulesOQ02.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 534,

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -16,7 +16,7 @@
       "distinct-subset-sums",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. Conway-Guy optimality for n=1..5 is computationally proved via native_decide. The minDSSBound sorry was closed by Erdos1Wip01.dss_existence.",

--- a/src/data/proofs/erdos-1129-oq-02/meta.json
+++ b/src/data/proofs/erdos-1129-oq-02/meta.json
@@ -15,7 +15,7 @@
       "lebesgue-constant",
       "chebyshev-nodes"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -16,7 +16,7 @@
       "absorbing-method",
       "regular-graphs"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 386,

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "expectation",
       "sequential-analysis"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,

--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -16,7 +16,7 @@
       "doob",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 330,

--- a/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02/meta.json
@@ -15,7 +15,7 @@
       "isoperimetric-inequality",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-29",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "algorithms",
       "hierholzer"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
@@ -18,7 +18,7 @@
       "borel-sets",
       "real-analysis"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 240,

--- a/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "computational verification",
       "q-series"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No axioms. Computational verification via native_decide. Depends on PartitionTheoremOQ01 for definitions (rr1GapPartitions, rr1Mod5Partitions, rr2GapPartitions, rr2Mod5Partitions).",

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -17,7 +17,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/PtolemysTheoremOQ01Incomplete01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -17,7 +17,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/shapley-folkman-oq-03/meta.json
+++ b/src/data/proofs/shapley-folkman-oq-03/meta.json
@@ -15,7 +15,7 @@
       "game-theory",
       "epsilon-equilibrium"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-23",
     "dateUpdated": "2026-04-24",

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -15,7 +15,7 @@
       "combinatorics",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -18,7 +18,7 @@
       "fixed-point-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "originalContributions": [
       "n-dimensional displacement coloring definition via barycentric coordinates",

--- a/src/data/proofs/szemeredi-regularity-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02/meta.json
@@ -18,7 +18,7 @@
       "cut-norm",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-04-26",

--- a/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
@@ -17,7 +17,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 assumptions. The full general remainder bound (x < 0 case) is proved via reflection g(t) = f(-t) using Mathlib's iteratedDeriv_comp_neg. The linear_combo_bound is proved via linearity of iteratedDeriv.",


### PR DESCRIPTION
## Fix

Replace invalid `badge: "verified"` with correct `badge: "original"` or `badge: "mathlib"` across 54 gallery entries.

## Root Cause

`"verified"` is not a valid value for the `ProofBadge` type in `src/types/proof.ts`. The `proof-badge.tsx` component returns `null` for unknown badge values, meaning all 54 entries showed **no badge** in the gallery UI despite being fully proved.

Valid badge values: `original`, `mathlib`, `pedagogical`, `from-axioms`, `fallacy`, `wip`, `ai-solved`, `axiom`, `infrastructure`

## Fix Heuristic

- `badge: "mathlib"` — if `meta.imports` contains any `Mathlib.*` import (38 entries)
- `badge: "original"` — if only `Proofs.*` imports or no imports (16 entries)

All 54 entries have `status: "verified"`, 0 sorries, 0 axioms — mathematically correct, only the badge display label was wrong.

## Sample entries fixed

- `abel-ruffini-galois-extensions-oq-04`: `verified` → `mathlib`
- `ballot-problem-oq-01-oq-04`: `verified` → `original`
- `shapley-folkman`: `verified` → `mathlib`
- `sperner-ndim-oq-03`: `verified` → `mathlib`
- `combinations-formula-oq-02`: `verified` → `original`
- ... (54 total)

---
Automated fix by lean-mechanic agent.