### PR TITLE
fix(wilsons-theorem-oq-02-ext): use 'as unknown as' cast to fix TS2352 build error

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-02-ext/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/WilsonsTheoremOQ02Ext.lean?raw')
 


### PR DESCRIPTION
## Summary

- Fixes TypeScript build error in `wilsons-theorem-oq-02-ext/index.ts` introduced by PR #15709
- Sections use the legacy `theorems[]` format which lacks `startLine`/`endLine`/`summary`, causing TypeScript to reject a direct `as` cast (TS2352)
- Fix: use `as unknown as` double-cast pattern (same as `annotationsJson` line in the same file)

## Test plan
- [ ] `pnpm build` completes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)