### PR TITLE
fix(auditor): handle sorryCount field name as fallback for sorries in find-targets

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -296,7 +296,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     meta: {
       status: proofMeta.status || 'unknown',
       badge: proofMeta.badge || 'unknown',
-      claimedSorries: proofMeta.sorries ?? -1,
+      claimedSorries: proofMeta.sorries ?? proofMeta.sorryCount ?? -1,
       // leanFile.axiomCount counts only the main file; meta.axiomCount counts the
       // full import chain. When we aggregate detection across additionalFiles or
       // followed imports, compare against meta.axiomCount to avoid false-positive


### PR DESCRIPTION
## Summary

- One-line fix to `scripts/auditor/find-targets.ts:299`: add `proofMeta.sorryCount` as a fallback when `proofMeta.sorries` is absent.
- Eliminates false-positive `sorry mismatch: claims -1, actual 0` reports on 10 verified, 0-sorry proofs whose `meta.json` files use the newer `sorryCount` field name.

## Problem

`analyzeProof` reads the proof's claimed sorry count from `meta.meta.sorries`, defaulting to `-1` when missing. Ten recently-created proofs store the same value under `meta.meta.sorryCount` instead, so every audit cycle re-flags them with a phantom mismatch.

Affected proofs (all `status: verified`, `sorryCount: 0`):

- fodor-pressing-down
- frobenius-number
- gauss-wilson-non-cyclic
- pappus-theorem-oq-02
- picks-theorem-oq-01-oq-01
- sperner-mathlib
- sperner-mathlib4
- sperner-simplicial-bridge
- szemeredi-core-oq-01
- wilsons-theorem-oq-02-ext

## Fix

```diff
-      claimedSorries: proofMeta.sorries ?? -1,
+      claimedSorries: proofMeta.sorries ?? proofMeta.sorryCount ?? -1,
```

The reader now falls back to `sorryCount` when `sorries` is absent, matching the actual structure of the newer meta.json files. `proofMeta` is typed `any`, so no type changes are needed.

## Test plan

- [ ] Run `pnpm tsx scripts/auditor/find-targets.ts` (or the existing entrypoint) and confirm none of the 10 listed proofs report `sorry mismatch: claims -1, actual 0`.
- [ ] Confirm previously-detected real mismatches (claims N >= 0, actual differs) still surface.
- [ ] Spot-check that proofs with the older `sorries` field continue to report the correct claimed count.