### PR TITLE
research(bezout-identity-oq-01-oq-01-oq-01): O(log² n) bit complexity gallery entry

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -163,6 +163,7 @@ import Proofs.BezoutIdentity
 import Proofs.BezoutIdentityOQ01
 import Proofs.BezoutIdentityOQ01Aristotle
 import Proofs.BezoutIdentityOQ01OQ01
+import Proofs.BezoutIdentityOQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ02
 import Proofs.BezoutIdentityOQ02OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "step-counter-design",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 66
+    },
+    "type": "concept",
+    "title": "Mirroring the Algorithm to Count Its Steps",
+    "content": "binaryGcdSteps is defined with exactly the same seven if-then-else branches as binaryGcd. This is deliberate: the step counter must mirror the algorithm's control flow so that the inductive proof can match each algorithm step to a corresponding decrease in the log measure. Any discrepancy between the step counter and the algorithm would make the bound unprovable. Termination uses the same a+b measure as the algorithm, automated by omega.",
+    "mathContext": "$\\text{binaryGcdSteps}(a,b)$ counts the number of recursive calls. Its definition mirrors all 7 branches of Stein's algorithm: base cases (a=0 or b=0), both-even, a-even-b-odd, a-odd-b-even, both-odd with $a \\leq b$, both-odd with $a > b$.",
+    "significance": "key",
+    "prerequisites": [
+      "Stein's binary GCD algorithm (BezoutIdentityOQ01OQ01)",
+      "well-founded recursion in Lean 4",
+      "termination_by and decreasing_by tactics"
+    ],
+    "relatedConcepts": [
+      "step counting in algorithm analysis",
+      "mirror induction",
+      "well-founded recursion on natural numbers"
+    ]
+  },
+  {
+    "id": "log-helper-log-div-two",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 67,
+      "endLine": 75
+    },
+    "type": "technique",
+    "title": "log₂(n/2) = log₂ n − 1: Stripping One Bit",
+    "content": "The lemma log_div_two proves Nat.log 2 (n/2) = Nat.log 2 n − 1 for n ≥ 2. This is the fundamental bit-stripping step: halving n removes exactly one bit from its binary representation. In the context of the complexity proof, it says that whenever the algorithm takes a branch that halves one of its arguments, the log measure strictly decreases. Mathlib's Nat.log_div_two handles this directly.",
+    "mathContext": "$\\lfloor \\log_2(n/2) \\rfloor = \\lfloor \\log_2 n \\rfloor - 1$ for $n \\geq 2$. In binary: if $n$ has $k+1$ bits, then $\\lfloor n/2 \\rfloor$ has $k$ bits.",
+    "significance": "key",
+    "prerequisites": [
+      "Nat.log in Mathlib",
+      "integer division",
+      "binary representation"
+    ],
+    "relatedConcepts": [
+      "bit-length of a number",
+      "Nat.log_div_two in Mathlib",
+      "right shift as halving"
+    ]
+  },
+  {
+    "id": "log-odd-sub-half",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 103
+    },
+    "type": "technique",
+    "title": "The Delicate Case: Odd-Minus-Odd Drops log₂ b",
+    "content": "When both a and b are odd with a < b, the algorithm sets the new b to (b−a)/2. The lemma log_odd_sub_half proves log₂((b−a)/2) + 1 ≤ log₂ b. Why? Because b is odd and a ≥ 1, we have b−a ≤ b−1 < b. Since b−a is even (odd minus odd is even), (b−a)/2 ≤ (b−1)/2 < b/2. So (b−a)/2 < b/2, giving log₂((b−a)/2) ≤ log₂(b/2) = log₂ b − 1. This is the most subtle case in the complexity proof: the argument is not just that we halved b, but that the subtraction also shrinks the value before halving.",
+    "mathContext": "Let $b$ be odd, $0 < a < b$. Then $b - a$ is even (odd − odd), so $(b-a)/2 \\in \\mathbb{N}$. We have $(b-a)/2 \\leq (b-1)/2 < b/2$, so $\\lfloor\\log_2((b-a)/2)\\rfloor \\leq \\lfloor\\log_2(b/2)\\rfloor = \\lfloor\\log_2 b\\rfloor - 1$.",
+    "significance": "key",
+    "prerequisites": [
+      "odd minus odd is even",
+      "Nat.log monotonicity",
+      "log_div_two"
+    ],
+    "relatedConcepts": [
+      "subtraction before halving",
+      "integer subtraction bounds",
+      "symmetric case log_odd_sub_half_left"
+    ]
+  },
+  {
+    "id": "main-induction",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 188
+    },
+    "type": "technique",
+    "title": "Strong Induction Over All Seven Algorithm Branches",
+    "content": "binaryGcdSteps_le_log is proved by strong induction on a+b (the same measure used for termination). The proof sets la = Nat.log 2 a and lb = Nat.log 2 b, then proceeds by cases over the algorithm's seven branches. Each case shows that the step count for the recursive call is bounded by 2·(la' + lb') + 2 (induction hypothesis), where la' and lb' are the logs of the new arguments. The key calculation in each branch: the new logs are at most la−1 and lb (or la and lb−1), so la' + lb' ≤ la + lb − 1. Adding 1 for the current step gives ≤ 2·(la + lb) + 2. The base cases (a=0 or b=0) are trivially 0.",
+    "mathContext": "Strong induction on $a+b$: assume $\\forall a' < a, b' < b, \\text{steps}(a',b') \\leq 2(\\log_2 a' + \\log_2 b') + 2$. In each branch, the recursive call has smaller $a+b$, so IH applies. The log measure drops by $\\geq 1$, giving $\\text{steps}(a,b) \\leq 1 + 2((\\log_2 a + \\log_2 b - 1)) + 2 = 2(\\log_2 a + \\log_2 b) + 1 \\leq 2(\\log_2 a + \\log_2 b) + 2$.",
+    "significance": "key",
+    "prerequisites": [
+      "strong induction in Lean 4 (Nat.rec with ih)",
+      "log_div_two",
+      "log_odd_sub_half",
+      "log_odd_sub_half_left"
+    ],
+    "relatedConcepts": [
+      "Lyapunov function for algorithm termination",
+      "seven-case analysis of binary GCD",
+      "logarithm measure decrease"
+    ]
+  },
+  {
+    "id": "bit-cost-axiom",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 190,
+      "endLine": 197
+    },
+    "type": "concept",
+    "title": "Axiomatizing the Per-Step Bit Cost",
+    "content": "The two axioms stepBitOps and stepBitOps_le model the bit-RAM cost of each algorithm step. Each step performs: (1) one comparison of a and b (O(log n) bits), (2) one subtraction or right-shift (O(log n) bits), (3) one parity test — LSB check (O(1)). The constant C=3 is conservative. This axiomatization is standard in algorithm analysis: the combinatorial step-count argument is independent of the machine model, so separating the two makes the formalization modular. The step count is fully proved; only the machine-level cost model is axiomatized.",
+    "mathContext": "Axioms: $\\text{stepBitOps}(a,b) : \\mathbb{N}$ and $\\text{stepBitOps}(a,b) \\leq 3(\\lfloor\\log_2(\\max a b)\\rfloor + 1)$. This models the bit-RAM cost where word operations (comparison, subtraction, parity test) each cost $O(\\log n)$ bit operations when $n = \\max(a,b)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "bit-RAM vs word-RAM models",
+      "logarithmic cost of word operations",
+      "Lean 4 axiom declarations"
+    ],
+    "relatedConcepts": [
+      "bit complexity model",
+      "word-RAM vs bit-RAM",
+      "machine model in algorithm analysis"
+    ]
+  },
+  {
+    "id": "log-sq-bound",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 199,
+      "endLine": 242
+    },
+    "type": "concept",
+    "title": "O(log² n) Total Bit Complexity",
+    "content": "totalBitOps combines the step count and per-step cost: binaryGcdSteps × 3·(log₂(max a b)+1). The main theorem binaryGcd_log_sq_complexity gives the explicit bound (2·(log₂ a + log₂ b) + 2)·(3·(log₂(max a b)+1)). The corollary binaryGcd_log_sq_bound simplifies using log₂ a + log₂ b ≤ 2·log₂(max a b) to obtain ≤ 6·(log₂(max a b)+1)², which is O(log²(max a b)). Three worked examples with native_decide verify the step counter on specific inputs.",
+    "mathContext": "$\\text{totalBitOps}(a,b) \\leq (2(\\log_2 a + \\log_2 b) + 2) \\cdot 3(\\log_2(\\max a b)+1) \\leq 6(\\log_2(\\max a b)+1)^2 = O(\\log^2 n)$ where $n = \\max(a,b)$. The simplification uses $\\log_2 a + \\log_2 b \\leq 2\\log_2(\\max a b)$.",
+    "significance": "key",
+    "prerequisites": [
+      "binaryGcdSteps_le_log",
+      "stepBitOps_le axiom",
+      "Nat.log monotonicity",
+      "Nat.mul_le_mul"
+    ],
+    "relatedConcepts": [
+      "big-O notation",
+      "product of logarithms",
+      "native_decide for ground-truth verification"
+    ]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,19 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[]
+}
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug, description: meta.description,
+  meta: meta.meta, sections: meta.sections, source: sourceRaw,
+  overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "bezout-identity-oq-01-oq-01-oq-01",
+  "title": "Binary GCD O(log² n) Bit Complexity",
+  "slug": "bezout-identity-oq-01-oq-01-oq-01",
+  "description": "Formalizes the O(log²(max(a,b))) bit-operation complexity bound for Stein's binary GCD algorithm. Proves that the step count is at most 2·(log₂ a + log₂ b) + 2, then combines with an axiomatized per-step bit cost to derive the O(log²) total bound.",
+  "meta": {
+    "author": "Josef Stein (1967), complexity analysis formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "1967",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ01OQ01.lean",
+    "parentProofId": "bezout-identity-oq-01-oq-01",
+    "tags": [
+      "number-theory",
+      "algorithms",
+      "complexity",
+      "logarithm",
+      "binary-arithmetic",
+      "well-founded-recursion",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 2,
+    "dateAdded": "2026-05-04",
+    "lineCount": 242,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "assumptions": "stepBitOps_le: each recursive step uses at most 3·(log₂(max a b)+1) bit operations (one comparison, one subtraction or shift, one parity test). This models the idealized bit-RAM cost; it is independent of Lean's actual computation.",
+    "originalContributions": [
+      "binaryGcdSteps: counts recursive calls, mirrors binaryGcd branching exactly, terminates by well-founded recursion on a+b",
+      "binaryGcdSteps_le_log: step count ≤ 2·(log₂ a + log₂ b) + 2 — proved by strong induction, each branch peels one bit from log₂ a or log₂ b via log_div_two and log_odd_sub_half",
+      "totalBitOps: noncomputable definition — binaryGcdSteps a b × (3·(log₂(max a b)+1))",
+      "binaryGcd_log_sq_complexity: total bit ops ≤ (2·(log₂ a + log₂ b) + 2)·(3·(log₂(max a b)+1))",
+      "binaryGcd_log_sq_bound: O(log²) corollary — total bit ops ≤ 6·(log₂(max a b)+1)²"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.log_div_two",
+        "description": "log₂(n/2) = log₂ n - 1 for n ≥ 2",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Nat.log_mono",
+        "description": "m ≤ n → log₂ m ≤ log₂ n",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Nat.log_pos",
+        "description": "1 < b → 1 < n → 0 < log b n",
+        "module": "Mathlib.Data.Nat.Log"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Knuth analyzed Stein's binary GCD algorithm in TAOCP Vol. 2, §4.5.2, establishing that it runs in O(log²(max(a,b))) bit operations. The analysis proceeds in two stages: first, bounding the number of recursive calls by O(log(max(a,b))); second, bounding the bit cost of each call by O(log(max(a,b))). Combining these gives the O(log²) total. The step-count bound is elementary — each call strips at least one bit from one of the inputs — but formalizing it requires careful case analysis across all seven branches of the algorithm. The per-step bit cost is more subtle and depends on the machine model: on a word-RAM with O(1) arithmetic, each step is O(1); on a bit-RAM where word operations cost proportional to the word length, each step costs O(log n) bits.",
+    "problemStatement": "The parent entry `bezout-identity-oq-01-oq-01` proved that Stein's binary GCD is correct: $\\text{binaryGcd}(a,b) = \\gcd(a,b)$. A natural follow-up is whether the $O(\\log^2(\\max(a,b)))$ complexity bound can be formalized in Lean 4. This entry answers YES: the step-count bound $\\text{steps}(a,b) \\leq 2(\\log_2 a + \\log_2 b) + 2$ is fully proved. The per-step bit cost is axiomatized as $\\text{stepBitOps}(a,b) \\leq 3(\\log_2(\\max a b) + 1)$, giving a total bound of $6(\\log_2(\\max a b)+1)^2 = O(\\log^2 n)$.",
+    "proofStrategy": "The main theorem `binaryGcdSteps_le_log` uses strong induction on the sum a+b (matching the termination measure of the algorithm). In each of the seven branches, the proof shows that the logarithm measure decreases by at least 1: in the both-even branch, each argument loses one bit (log₂(a/2) = log₂ a − 1); in the even-one-odd branches, the even argument loses one bit; in the both-odd branches, the subtraction (b−a)/2 loses one bit from b since b−a is even and strictly less than 2b, so log₂((b−a)/2) ≤ log₂ b − 1. The helper lemmas log_div_two and log_odd_sub_half formalize these bit-dropping steps. Once the step bound is proved, `binaryGcd_log_sq_complexity` multiplies by the per-step cost axiom and `binaryGcd_log_sq_bound` simplifies using log₂ a + log₂ b ≤ 2·log₂(max a b).",
+    "keyInsights": [
+      "Step-count bound via bit measure: the invariant M(a,b) = log₂ a + log₂ b drops by ≥ 1 per recursive call, bounding the total steps by 2·(log₂ a + log₂ b) + 2 — this is the discrete analog of a Lyapunov function argument",
+      "Odd-minus-odd halves the log: if b is odd and a < b, then (b−a) is even and (b−a)/2 < b/2, so log₂((b−a)/2) ≤ log₂ b − 1 — this is the most delicate case, formalized in log_odd_sub_half",
+      "Two-stage complexity: step count × per-step cost = O(log n) × O(log n) = O(log² n); the separation into two stages makes the argument modular and allows the per-step model to be replaced without re-proving the step count",
+      "Per-step axiomatization: the bit cost of each step (one comparison + one shift/subtraction + one parity test) is axiomatized as 3·(log₂(max a b)+1); this is the only non-constructive element — the step count itself is fully proved",
+      "Verification by native_decide: three concrete examples (binaryGcdSteps 12 8 = 5, etc.) serve as sanity checks that the step counter matches the algorithm's actual behavior"
+    ]
+  },
+  "sections": [
+    {
+      "id": "step-counter",
+      "title": "Step Counter Definition",
+      "startLine": 44,
+      "endLine": 66,
+      "summary": "Defines binaryGcdSteps : ℕ → ℕ → ℕ mirroring all seven branches of binaryGcd exactly. Terminates by well-founded recursion on a+b via the same argument as the algorithm itself."
+    },
+    {
+      "id": "log-helpers",
+      "title": "Logarithm Helper Lemmas",
+      "startLine": 67,
+      "endLine": 103,
+      "summary": "Four private lemmas: log_div_two (log₂(n/2) = log₂ n − 1 for n ≥ 2), log_mono (log monotone), log_odd_sub_half ((b−a)/2 drops log₂ b by 1 when b is odd and a < b), log_odd_sub_half_left (symmetric case)."
+    },
+    {
+      "id": "step-bound",
+      "title": "Step Count Bound",
+      "startLine": 105,
+      "endLine": 188,
+      "summary": "binaryGcdSteps_le_log: binaryGcdSteps a b ≤ 2·(log₂ a + log₂ b) + 2. Proved by strong induction on a+b with case analysis over the seven algorithm branches, each peeling one bit from the logarithm measure."
+    },
+    {
+      "id": "bit-complexity",
+      "title": "Bit Complexity Model and O(log² n) Bound",
+      "startLine": 190,
+      "endLine": 242,
+      "summary": "Axiomatizes the per-step bit cost (stepBitOps, stepBitOps_le). Defines totalBitOps and proves binaryGcd_log_sq_complexity (explicit bound) and binaryGcd_log_sq_bound (O(log²) corollary: ≤ 6·(log₂(max a b)+1)²)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Binary GCD runs in O(log²(max(a,b))) bit operations.",
+    "significance": "The formalization separates the combinatorial step-count argument (fully proved) from the per-step bit-cost model (axiomatized). The step count bound is the non-trivial part: it requires showing that every branch of Stein's algorithm strictly decreases the logarithm measure, including the delicate odd-minus-odd halving case. The result confirms that binary GCD has the same asymptotic bit complexity as Euclid's algorithm.",
+    "openQuestions": [
+      "Can stepBitOps_le be eliminated by defining a more explicit bit-level computation model in Lean 4?",
+      "Does the analysis extend to the HGCD (half-GCD) algorithm of Schönhage, giving O(M(n) log n) complexity where M(n) is the multiplication cost?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "bezout-identity-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Correctness of Stein's binary GCD algorithm — this entry extends it with complexity analysis"
+    },
+    {
+      "id": "binary-gcd-oq-03-oq-02",
+      "relationship": "related",
+      "description": "Schönhage's HGCD algorithm — a more sophisticated recursive GCD with better asymptotic complexity"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Registers `BezoutIdentityOQ01OQ01OQ01.lean` in the build (import was missing from `Proofs.lean`)
- Creates gallery entry for `bezout-identity-oq-01-oq-01-oq-01`
- File was committed to main in 978cc5535b6 but never imported or given a gallery entry

## What's Formalized

The O(log²(max(a,b))) bit complexity bound for Stein's binary GCD algorithm:

1. **Step count bound** (fully proved, 0 sorries): `binaryGcdSteps a b ≤ 2·(log₂ a + log₂ b) + 2`
   - Proved by strong induction on `a+b`, 7 cases matching algorithm branches
   - Each branch peels one bit from the log measure (`log_div_two`, `log_odd_sub_half`)
2. **Per-step bit cost** (axiomatized): each step ≤ `3·(log₂(max a b)+1)` bit ops
3. **O(log²) total bound**: `totalBitOps ≤ 6·(log₂(max a b)+1)²`

## Status

- `status: "axiomatized"`, `axiomCount: 2` (`stepBitOps`, `stepBitOps_le`)
- `sorries: 0`
- 3 theorems + 2 definitions (242 lines)

## Test plan

- [ ] Gallery builds (`pnpm build` or CI)
- [ ] Lean proof compiles (`Proofs.BezoutIdentityOQ01OQ01OQ01` — file was already on main)
- [ ] Gallery entry appears at `/bezout-identity-oq-01-oq-01-oq-01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)