### PR TITLE
fix(e-transcendental-oq-02): prove periodic_has_missing_ktuple, axiomCount 4→3

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -211,12 +211,46 @@ axiom rational_digits_eventually_periodic (b : ℕ) (hb : 2 ≤ b) (q : ℚ) :
 
 /-- In a sequence with period T, at most T distinct k-tuples appear after the period starts.
     If bᵏ > T, some k-tuple never appears.
-    Proof sketch: the orbit map n ↦ (f(n),...,f(n+k-1)) is periodic with period T on ℕ≥N₀,
-    so its image has cardinality ≤ T. But |Fin k → Fin b| = bᵏ > T, so some tuple is absent. -/
-axiom periodic_has_missing_ktuple (b T k : ℕ) (hb : 2 ≤ b) (hT : 0 < T)
+    Proof: the orbit {(f(N₀+j),...,f(N₀+j+k-1)) : j < T} has card ≤ T < bᵏ = |Fin k → Fin b|,
+    so some tuple s is absent. For n ≥ N₀, periodicity maps n back to N₀ + j (mod T),
+    so f(n+·) matches f(N₀+j+·) ∈ orbit, contradicting s ∉ orbit. -/
+theorem periodic_has_missing_ktuple (b T k : ℕ) (hb : 2 ≤ b) (hT : 0 < T)
     (hk : T < b ^ k) (f : ℕ → Fin b) (N₀ : ℕ)
     (hperiod : ∀ n ≥ N₀, f (n + T) = f n) :
-    ∃ s : Fin k → Fin b, ∀ n ≥ N₀, ∃ i : Fin k, f (n + i.val) ≠ s i
+    ∃ s : Fin k → Fin b, ∀ n ≥ N₀, ∃ i : Fin k, f (n + i.val) ≠ s i := by
+  let orbit : Finset (Fin k → Fin b) :=
+    (Finset.range T).image (fun j => fun i : Fin k => f (N₀ + j + i.val))
+  have horbit_le : orbit.card ≤ T := by
+    calc orbit.card ≤ (Finset.range T).card := Finset.card_image_le
+      _ = T := Finset.card_range T
+  have huniv : (Finset.univ : Finset (Fin k → Fin b)).card = b ^ k := by
+    simp [Finset.card_univ, Fintype.card_fun, Fintype.card_fin]
+  obtain ⟨s, hs⟩ : ∃ s : Fin k → Fin b, s ∉ orbit := by
+    by_contra hall
+    push_neg at hall
+    have : b ^ k ≤ orbit.card := by
+      rw [← huniv]; exact Finset.card_le_card (fun s _ => hall s)
+    linarith
+  exact ⟨s, fun n hn => by
+    by_contra hall
+    push_neg at hall
+    -- Iterated periodicity: f(N₀ + j + m*T + i) = f(N₀ + j + i) for j = (n-N₀)%T
+    have hperiod_rep : ∀ (m i : ℕ),
+        f (N₀ + (n - N₀) % T + m * T + i) = f (N₀ + (n - N₀) % T + i) := by
+      intro m i
+      induction m with
+      | zero => simp
+      | succ p ih =>
+        rw [show N₀ + (n - N₀) % T + (p + 1) * T + i =
+              (N₀ + (n - N₀) % T + p * T + i) + T from by ring,
+            hperiod _ (by omega), ih]
+    -- f(n + i) = f(N₀ + (n-N₀)%T + i) for all i (by reducing mod T)
+    have hfn_eq : ∀ i : Fin k, f (n + i.val) = f (N₀ + (n - N₀) % T + i.val) := fun i => by
+      rw [show n + i.val = N₀ + (n - N₀) % T + (n - N₀) / T * T + i.val from by omega]
+      exact hperiod_rep ((n - N₀) / T) i.val
+    -- So (fun i => f(N₀+(n-N₀)%T+i)) = s, meaning s ∈ orbit: contradiction
+    exact hs (Finset.mem_image.mpr ⟨(n - N₀) % T, Finset.mem_range.mpr (Nat.mod_lt _ hT),
+      funext fun i => (hfn_eq i).symm.trans (hall i)⟩)⟩
 
 /-- Normal numbers must be irrational.
     Proof: if x = p/q is rational, its expansion has period T ≤ q (by rational_digits_eventually_periodic).

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 21,
+    "theoremCount": 28,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -59,14 +59,14 @@
       "Theorems e_digit1..e_digit9: the first 9 decimal digits of e = 2.718281828... proved machine-checkably (saturating the Mathlib lower bound exp_one_gt_d9)",
       "Theorem e_normal_implies_uniform_decimal_digits: IsNormalInBase 10 e → each digit d appears with frequency 1/10 (proved from definition using filter and norm_num)",
       "Axiom rational_digits_eventually_periodic: rationals have eventually periodic base-b expansions (pigeonhole, period divides φ(q))",
-      "Axiom periodic_has_missing_ktuple: periodic sequences with period T have missing k-tuples when bᵏ > T (orbit cardinality argument)",
+      "Theorem periodic_has_missing_ktuple: proved — T-periodic Fin-b sequences have missing k-tuples when bᵏ > T (orbit cardinality: image of range T has card ≤ T < bᵏ = |univ|; periodicity maps any n ≥ N₀ to orbit entry)",
       "Axiom normal_imp_irrational: normality in any base implies irrationality (uses the two combinatorial axioms)",
       "Axiom e_absolutely_normal: e is absolutely normal — the main open conjecture (2026)"
     ],
     "dateAdded": "2026-05-04",
-    "axiomCount": 4,
-    "lineCount": 266,
-    "assumptions": "4 axioms: (1) rational_digits_eventually_periodic — rationals have eventually periodic base-b digit expansions (pigeonhole principle, period T | φ(q)); (2) periodic_has_missing_ktuple — a T-periodic sequence on Fin b has at most T distinct k-tuples, so some k-tuple is absent when bᵏ > T; (3) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (uses axioms 1-2 + Tendsto formalism); (4) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026). 27 theorems including first 9 decimal digits of e proved from exp_one bounds.",
+    "axiomCount": 3,
+    "lineCount": 300,
+    "assumptions": "3 axioms: (1) rational_digits_eventually_periodic — rationals have eventually periodic base-b digit expansions (pigeonhole principle, period T | φ(q)); (2) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (uses axiom 1 + periodic_has_missing_ktuple + Tendsto formalism); (3) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026). periodic_has_missing_ktuple is now a proved theorem (orbit cardinality argument). 28 theorems including first 9 decimal digits of e proved from exp_one bounds.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -168,9 +168,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 266,
-    "axiomCount": 4,
-    "theoremCount": 27,
+    "lineCount": 300,
+    "axiomCount": 3,
+    "theoremCount": 28,
     "definitionCount": 3,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Converts `periodic_has_missing_ktuple` from an `axiom` declaration to a fully proved `theorem` in `ETranscendentalOQ02.lean`.

## Proof Sketch

The orbit `{(f(N₀+j), ..., f(N₀+j+k-1)) : j < T}` has cardinality ≤ T (image of `range T`), which is strictly less than bᵏ = `|Finset.univ : Finset (Fin k → Fin b)|`. By pigeonhole some k-tuple `s` is absent from the orbit. For any `n ≥ N₀`, periodicity maps `f(n+·)` to `f(N₀ + (n-N₀)%T + ·)` which is in the orbit — contradicting `s ∉ orbit`. So `s` works as the missing k-tuple.

## Evidence

**Before**: `axiom periodic_has_missing_ktuple ...` (4 total axioms)
**After**: `theorem periodic_has_missing_ktuple ... := by ...` (3 total axioms)

| Field | Before | After |
|-------|--------|-------|
| `axiomCount` | 4 | 3 |
| `lineCount` | 266 | 300 |
| `theoremCount` | 27 | 28 |

---
Automated fix by lean-mechanic agent.