### PR TITLE
research(erdos-1201): prime-window automatic goodness (session 18, 100→103 theorems)

### DIFF
--- a/proofs/Proofs/Erdos1201Problem.lean
+++ b/proofs/Proofs/Erdos1201Problem.lean
@@ -1612,4 +1612,40 @@ theorem erdos_1201_strong_iff_smooth_decay :
       simp only [upperDensity] at hk; exact hk
     linarith [h_limsup_le, h_subadd, h_1N_zero, h_dbad_le]
 
+/-
+## Prime-Window Automatic Goodness
+-/
+
+/-- **Automatic Goodness**: If the window [n, n+k] contains any prime n+i (i ≤ k),
+    then n is automatically good for any ε ∈ (0,1).
+    Unlike `erdos_1201_good_of_prime_in_window`, no condition on the prime's size is needed:
+    since n ≥ 2, every prime in the window satisfies n+i ≥ n > n^(1-ε). -/
+theorem erdos_1201_good_of_any_prime_in_window (n k i : ℕ) (ε : ℝ)
+    (hn : 2 ≤ n) (hi : i ≤ k) (hprime : (n + i).Prime)
+    (hε₀ : 0 < ε) (hε₁ : ε < 1) :
+    (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ) := by
+  apply erdos_1201_good_of_prime_in_window n k i ε hn hi hprime
+  have hn1 : (1 : ℝ) < n := by exact_mod_cast show 1 < n from by omega
+  calc (n : ℝ) ^ (1 - ε)
+      < (n : ℝ) ^ (1 : ℝ) := Real.rpow_lt_rpow_of_exponent_lt hn1 (by linarith)
+    _ = (n : ℝ) := Real.rpow_one _
+    _ ≤ (n : ℝ) + (i : ℝ) := le_add_of_nonneg_right (Nat.cast_nonneg i)
+
+/-- **Prime Start → Good (any k)**: If n is prime, then n is good for any window width k
+    and any ε ∈ (0,1). Generalizes `erdos_1201_good_prime_k0` from k=0 to all k ≥ 0.
+    Proof: n is a prime in the window [n, n+k] at position i=0. -/
+theorem erdos_1201_good_prime_any_k (n k : ℕ) (hn_prime : n.Prime) (ε : ℝ)
+    (hε₀ : 0 < ε) (hε₁ : ε < 1) :
+    (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ) :=
+  erdos_1201_good_of_any_prime_in_window n k 0 ε hn_prime.two_le (Nat.zero_le k)
+    (by simpa using hn_prime) hε₀ hε₁
+
+/-- **Prime Right Endpoint → Good**: If n+k is prime, then n is good for window k
+    and any ε ∈ (0,1). When the right endpoint of the window is prime, P(n,k) = n+k ≥ n > n^(1-ε).
+    Proof: n+k is a prime in the window at position i=k. -/
+theorem erdos_1201_good_prime_endpoint (n k : ℕ) (hn : 2 ≤ n)
+    (hprime : (n + k).Prime) (ε : ℝ) (hε₀ : 0 < ε) (hε₁ : ε < 1) :
+    (n : ℝ) ^ (1 - ε) < (gpfConsecutive n k : ℝ) :=
+  erdos_1201_good_of_any_prime_in_window n k k ε hn le_rfl hprime hε₀ hε₁
+
 end Erdos1201

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1201",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture, lowerDensity with exact complement duality, full equivalence ErdosProblem1201Strong \u2194 smooth-decay (session 17, 0 sorries).",
-    "lineCount": 1615,
+    "assumptions": "1 axiom: erdos_1201_half_case (the \u03b5=1/2 partial result, proved by Erd\u0151s). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, \u03b5/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 \u2190 smooth-decay conjecture, lowerDensity with exact complement duality, full equivalence ErdosProblem1201Strong \u2194 smooth-decay, prime-window automatic goodness (session 18, 0 sorries).",
+    "lineCount": 1651,
     "mathlib_version": "4.26.0",
-    "theoremCount": 100
+    "theoremCount": 103
   },
   "overview": {
     "historicalContext": "Erd\u0151s posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) \u2192 \u221e as n \u2192 \u221e, but its distribution among products of consecutive integers is much subtler. The \u03b5=1/2 case was established by Erd\u0151s himself: there exist arbitrarily long windows of consecutive integers containing a prime exceeding \u221an. This connects to the Sylvester-Schur theorem (1892), which implies P(n,k) \u2265 n+k when k < n \u2014 a stronger statement than Bertrand's postulate. The full conjecture \u2014 that large prime factors dominate for almost all starting points n, for any threshold n^(1-\u03b5) \u2014 remains open and is believed to require new tools from analytic number theory, likely Dickman's \u03c1-function for smooth number counts in intervals.",


### PR DESCRIPTION
## Summary

Three new theorems completing the prime-in-window characterization for Erdős #1201:

1. **`erdos_1201_good_of_any_prime_in_window`** — the main theorem: if any prime n+i lies in the window [n,n+k], then n is automatically good for ALL ε∈(0,1). Drops the manual size-check from `erdos_1201_good_of_prime_in_window`: since n≥2 implies n > n^(1-ε) for any ε>0, every window prime is automatically large enough.

2. **`erdos_1201_good_prime_any_k`** — prime start n is good for ANY window width k (not just k=0). Generalizes `erdos_1201_good_prime_k0`.

3. **`erdos_1201_good_prime_endpoint`** — prime right endpoint n+k makes n good. The simplest witness: one line using the main theorem.

Together these give a clean, unified characterization: **n is automatically good whenever any term in the window is prime**.

## Mathematical value

The existing `erdos_1201_good_of_prime_in_window` required verifying `(n:ℝ)^(1-ε) < n+i` for the prime. The new theorem eliminates this check by proving it automatically from n≥2 and ε>0: n^(1-ε) < n^1 = n ≤ n+i. This makes the theorems much easier to use in proofs that need to invoke goodness from primality.

## Status

- 103 theorems, 0 sorries, 1 axiom (erdos_1201_half_case)
- Docker build pending (file is 1651 lines, has been timing out at 60min in recent sessions)

## Test plan

- [ ] Docker build via `./proofs/scripts/docker-build.sh Proofs.Erdos1201Problem`
- [ ] Verify theorem count 103 in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)