### PR TITLE
enrich(abel-ruffini-galois-extensions-oq-05): add index.ts, annotations, restructure meta

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-module-doc",
+    "proofId": "abel-ruffini-galois-extensions-oq-05",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "Shafarevich's Theorem: The Converse of Abel-Ruffini",
+    "content": "This module formalizes the converse direction of the Abel-Ruffini framework. The parent file `AbelRuffiniGaloisExtensions.lean` shows that solvability by radicals *requires* the Galois group to be solvable (Abel-Ruffini's theorem). Shafarevich's theorem (1954) proves the converse: every finite solvable group actually *arises* as a Galois group over ℚ.\n\nTogether, these give a sharp characterization: a finite group G is the Galois group of a radical extension over ℚ if and only if G is solvable. The theorem is axiomatized because its proof requires class field theory, cohomological embedding problem theory, and Brauer groups — deep tools not yet in Mathlib.\n\nThe 7 corollaries (cyclic, abelian, S₃, S₄, subgroups, quotients, S₅ obstruction) are all *proved* from the axiom using Mathlib's existing group theory infrastructure.",
+    "mathContext": "Shafarevich (1954): $\\forall G$ finite solvable, $\\exists L/\\mathbb{Q}$ Galois with $\\mathrm{Gal}(L/\\mathbb{Q}) \\cong G$.\n\nWith Abel-Ruffini: $G$ is a radical Galois group over $\\mathbb{Q}$ $\\iff$ $G$ is solvable.\n\nThe proof uses the derived series $G = G^{(0)} \\supset G^{(1)} \\supset \\cdots \\supset G^{(k)} = 1$, building the extension inductively using class field theory for each abelian quotient $G^{(i)}/G^{(i+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Galois theory", "solvable groups", "inverse Galois problem", "Abel-Ruffini theorem"],
+    "prerequisites": ["Galois extensions", "solvable groups", "AbelRuffiniGaloisExtensions.lean"]
+  },
+  {
+    "id": "ann-axiom",
+    "proofId": "abel-ruffini-galois-extensions-oq-05",
+    "range": { "startLine": 72, "endLine": 83 },
+    "type": "definition",
+    "title": "The Core Axiom: Shafarevich's Inverse Galois Theorem",
+    "content": "The `shafarevich_inverse_galois` axiom states that for any finite solvable group G, there exists a Galois extension L of ℚ and an isomorphism G ≃* Gal(L/ℚ). In Lean, `Gal(L/ℚ)` is represented as `L ≃ₐ[ℚ] L` (the type of ℚ-algebra automorphisms of L), which forms a group under composition.\n\nThe proof of Shafarevich's theorem (Neukirch-Schmidt-Wingberg §9.5) requires:\n1. Local class field theory for the abelian base case\n2. Cohomological embedding problems to lift from abelian to solvable groups\n3. Brauer group and local-global principles\n\nThis is estimated to require ~500+ pages of algebraic number theory, making it a realistic target for Lean formalization only after substantial Mathlib development.",
+    "mathContext": "$\\text{axiom: }\\forall G$ [finite solvable], $\\exists L/\\mathbb{Q}$ Galois, $G \\cong \\mathrm{Gal}(L/\\mathbb{Q})$.\n\nIn Lean: `L ≃ₐ[ℚ] L` is the group of $\\mathbb{Q}$-algebra automorphisms, forming $\\mathrm{Gal}(L/\\mathbb{Q})$ when $L/\\mathbb{Q}$ is Galois.",
+    "significance": "key",
+    "relatedConcepts": ["Galois group", "AlgEquiv", "IsGalois", "class field theory"],
+    "prerequisites": ["IsGalois in Mathlib", "AlgEquiv group structure", "IsSolvable"]
+  },
+  {
+    "id": "ann-cyclic-abelian",
+    "proofId": "abel-ruffini-galois-extensions-oq-05",
+    "range": { "startLine": 94, "endLine": 111 },
+    "type": "insight",
+    "title": "Cyclic and Abelian Groups via inferInstance",
+    "content": "The two most classical corollaries use Lean's typeclass inference directly:\n\n- **Cyclic groups**: `IsSolvable (ZMod n)` is inferred by `inferInstance` — Mathlib knows all abelian groups are solvable via `CommGroup.isSolvable`. The `NeZero n` typeclass is needed to give `ZMod n` the correct group structure for `n > 0`.\n\n- **Abelian groups**: `IsSolvable G` for a `CommGroup G` is again `inferInstance`. The proof is literally two lines: construct the `IsSolvable` instance, then apply Shafarevich.\n\nThese corollaries have concrete classical counterparts: ℤ/nℤ arises as `Gal(ℚ(ζₙ)/ℚ)` via cyclotomic extensions, but Shafarevich gives a more general existential that works without constructing the field explicitly.",
+    "mathContext": "For abelian $G$: $G^{(1)} = [G,G] = 1$, so $G$ is solvable of length 1. Shafarevich applies.\n\nClassically: $\\mathbb{Z}/n\\mathbb{Z} \\cong \\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ for $n \\geq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["CommGroup.isSolvable", "ZMod", "NeZero", "cyclotomic extensions"],
+    "prerequisites": ["ZMod group structure", "abelian implies solvable", "inferInstance typeclass search"]
+  },
+  {
+    "id": "ann-symmetric-groups",
+    "proofId": "abel-ruffini-galois-extensions-oq-05",
+    "range": { "startLine": 113, "endLine": 131 },
+    "type": "insight",
+    "title": "S₃ and S₄: Solvable Symmetric Groups",
+    "content": "The S₃ and S₄ corollaries both use `symmetric_solvable_of_le_four` from the parent file, which proves `Equiv.Perm (Fin n)` is solvable when `n ≤ 4`. The proofs are essentially identical: invoke the parent lemma with `norm_num`, then apply Shafarevich.\n\nThese cases are historically important:\n- S₃ ≅ Gal(x³ + px + q over ℚ) for discriminant-related cubics\n- S₄ ≅ Gal(x⁴ + px² + qx + r over ℚ) for generic quartics\n\nThe sharp threshold at n=4 vs n=5 is precisely the Abel-Ruffini boundary: S₅ is the first symmetric group that is NOT solvable, so Shafarevich's theorem does not apply to it (though S₅ IS realizable over ℚ by other means — e.g., as Gal(x⁵ - 2x - 5)).",
+    "mathContext": "$S_n = \\text{Sym}(n)$ is solvable $\\iff n \\leq 4$.\n\n$S_3$ has derived series $S_3 \\supset A_3 \\cong \\mathbb{Z}/3\\mathbb{Z} \\supset 1$.\n$S_4$ has derived series $S_4 \\supset A_4 \\supset V_4 \\supset 1$, where $V_4 = \\{e, (12)(34), (13)(24), (14)(23)\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["symmetric group", "symmetric_solvable_of_le_four", "Equiv.Perm", "derived series"],
+    "prerequisites": ["AbelRuffiniGaloisExtensions.lean", "Equiv.Perm Fin n", "IsSolvable"]
+  },
+  {
+    "id": "ann-closure",
+    "proofId": "abel-ruffini-galois-extensions-oq-05",
+    "range": { "startLine": 145, "endLine": 163 },
+    "type": "technique",
+    "title": "Closure Under Subgroups and Quotients",
+    "content": "The two closure theorems show that the class of Shafarevich-realizable groups is closed under subgroups and quotients. Both proofs follow the same pattern: use `subgroup_solvable_of_solvable` (resp. `quotient_solvable_of_solvable`) from the parent file to show the subgroup (resp. quotient) is solvable, then apply `shafarevich_inverse_galois`.\n\nIn Galois-theoretic terms, these correspond to the fundamental correspondence:\n- Subgroups of Gal(L/K) correspond to intermediate fields\n- Quotients correspond to Galois sub-extensions\n\nHowever, the Lean statements are purely group-theoretic: they guarantee *some* Galois extension realizing the subgroup/quotient, not necessarily a subextension of L.",
+    "mathContext": "If $G$ is solvable and $H \\leq G$: $H$ is solvable (subgroup of solvable is solvable) $\\Rightarrow$ $H$ is realizable.\n\nIf $N \\trianglelefteq G$ and $G$ is solvable: $G/N$ is solvable $\\Rightarrow$ $G/N$ is realizable.",
+    "significance": "supporting",
+    "relatedConcepts": ["subgroup_solvable_of_solvable", "quotient_solvable_of_solvable", "Subgroup", "Group quotient"],
+    "prerequisites": ["Subgroup in Lean 4", "Normal subgroup", "quotient group G ⧸ N"]
+  },
+  {
+    "id": "ann-s5-obstruction",
+    "proofId": "abel-ruffini-galois-extensions-oq-05",
+    "range": { "startLine": 178, "endLine": 184 },
+    "type": "insight",
+    "title": "S₅: Non-Solvability as Obstruction",
+    "content": "The `s5_not_solvable_obstruction` theorem is just `s5_not_solvable` from the parent file, renamed to emphasize its role as an obstruction to Shafarevich's theorem.\n\nCrucially, S₅ NOT being solvable does not mean S₅ is not realizable over ℚ. S₅ IS in fact realizable — for example, as the Galois group of the splitting field of x⁵ - 2x - 5 over ℚ (a result of Hilbert). The point is that this realization cannot use Shafarevich's theorem; it requires different methods.\n\nThis is a subtle but important distinction for the inverse Galois problem: Shafarevich solves it for all solvable groups, but the full problem (every finite group is realizable over ℚ) remains open.",
+    "mathContext": "$S_5 = \\text{Sym}(5)$ is not solvable: $A_5 = [S_5, S_5]$ is simple and non-abelian, so the derived series does not reach 1.\n\n$S_5 \\cong \\mathrm{Gal}(x^5 - 2x - 5 / \\mathbb{Q})$ (Hilbert, explicitly computable), but this is outside Shafarevich's scope.",
+    "significance": "key",
+    "relatedConcepts": ["s5_not_solvable", "simple group", "A₅", "inverse Galois problem"],
+    "prerequisites": ["IsSolvable definition", "A₅ simplicity", "AbelRuffiniGaloisExtensions.lean"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "abel-ruffini-galois-extensions-oq-05",
+    "range": { "startLine": 190, "endLine": 214 },
+    "type": "context",
+    "title": "Proof Status and Mathematical Significance",
+    "content": "The summary comment in the file highlights the key achievement: 7 theorems proved with 0 sorries, relying on exactly 1 axiom (Shafarevich's theorem). All the logical work — applying solvability closure properties, invoking Shafarevich, destructuring the existential — is fully formalized.\n\nThe connection to Abel-Ruffini is precise: this file completes the 'if and only if' characterization. Abel-Ruffini shows solvability is *necessary*; Shafarevich shows it is *sufficient*. The combination gives a complete group-theoretic characterization of which groups arise as Galois groups of radical extensions.",
+    "mathContext": "The full characterization:\n\n$G$ is solvable $\\iff$ $G \\cong \\mathrm{Gal}(L/\\mathbb{Q})$ for some radical extension $L/\\mathbb{Q}$\n\n$\\Leftarrow$: Abel-Ruffini (parent file)\n$\\Rightarrow$: Shafarevich (this file, axiomatized)",
+    "significance": "supporting",
+    "relatedConcepts": ["Abel-Ruffini theorem", "radical extensions", "Galois correspondence"],
+    "prerequisites": ["AbelRuffiniGaloisExtensions.lean", "shafarevich_inverse_galois"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/index.ts
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniGaloisExtensionsOQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniGaloisExtensionsOQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniGaloisExtensionsOQ05Data: ProofData = {
+  proof: abelRuffiniGaloisExtensionsOQ05Proof,
+  annotations: abelRuffiniGaloisExtensionsOQ05Annotations,
+}
+
+export default abelRuffiniGaloisExtensionsOQ05Data

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
     "assumptions": "shafarevich_inverse_galois: Every finite solvable group G is the Galois group of some number field extension L/ℚ. Shafarevich (1954, Izv. Akad. Nauk). Proof requires class field theory, embedding problems, and Brauer group theory — not currently in Mathlib.",
-    "lineCount": 175,
+    "lineCount": 214,
     "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
@@ -35,40 +35,95 @@
       "quotient_of_solvable_realizable: quotients of solvable groups are realizable",
       "s5_not_solvable_obstruction: S₅ fails solvability criterion (not solvable)"
     ],
-    "proofStrategy": "Shafarevich's theorem is axiomatized. Corollaries are proved via solvability closure properties from the parent file (AbelRuffiniGaloisExtensions.lean): CommGroup.isSolvable for abelian/cyclic, symmetric_solvable_of_le_four for S₃,S₄, subgroup_solvable_of_solvable and quotient_solvable_of_solvable for closure. S₅ non-realizability follows from s5_not_solvable.",
-    "openQuestions": [
-      "Can Shafarevich's theorem be proved in Lean using Mathlib's class field theory?",
-      "Is every finite group (not just solvable) realizable over ℚ? (The Inverse Galois Problem — open)",
-      "Can the specific Galois extensions for S₃ and S₄ be constructed explicitly in Lean?"
-    ],
-    "sections": [
+    "relatedProblems": [
       {
-        "title": "Shafarevich's Core Axiom",
-        "content": "For any finite solvable group G, there exists a Galois extension L/ℚ with Gal(L/ℚ) ≅ G. The proof uses class field theory for abelian steps, then an inductive construction along the derived series using embedding problem theory.",
-        "theorems": ["shafarevich_inverse_galois"]
+        "id": "abel-ruffini-galois-extensions",
+        "relationship": "Parent file: proves S_n solvable ↔ n ≤ 4 and provides symmetric_solvable_of_le_four, s5_not_solvable used here"
       },
       {
-        "title": "Cyclic and Abelian Corollaries",
-        "content": "Cyclic groups ℤ/nℤ and all finite abelian groups are realizable over ℚ. Proof: CommGroup.isSolvable + Shafarevich. For cyclic groups, the classical construction via cyclotomic extensions ℚ(ζₙ) gives explicit realizations, but Shafarevich applies generally.",
-        "theorems": ["cyclic_group_realizable", "abelian_group_realizable"]
-      },
-      {
-        "title": "Symmetric Group Cases",
-        "content": "S₃ and S₄ are both realizable (solvable groups, apply Shafarevich). S₅ fails the solvability criterion — it is the smallest symmetric group that is not solvable, corresponding to the impossibility of solving degree-5 polynomials by radicals.",
-        "theorems": ["s3_realizable", "s4_realizable", "s5_not_solvable_obstruction"]
-      },
-      {
-        "title": "Closure Properties",
-        "content": "The class of groups realizable over ℚ via Shafarevich's theorem is closed under taking subgroups and quotients (since both preserve solvability). This gives a structural picture of the solvable part of the inverse Galois problem.",
-        "theorems": ["subgroup_of_solvable_realizable", "quotient_of_solvable_realizable"]
+        "id": "abel-ruffini",
+        "relationship": "Foundational file: proves polynomials solvable by radicals ↔ Galois group solvable — Abel-Ruffini's theorem"
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Igor Shafarevich proved in 1954 (Izv. Akad. Nauk SSSR) that every finite solvable group is realizable as the Galois group of some number field extension of ℚ. This was a landmark result in inverse Galois theory — the problem of determining which finite groups can arise as Galois groups over ℚ.\n\nShafarevich's theorem completes the Abel-Ruffini framework: Abel (1824) and Ruffini (1799) showed that a polynomial equation is solvable by radicals if and only if its Galois group is solvable. Shafarevich showed the converse: every solvable group actually occurs. The full proof (detailed in Neukirch-Schmidt-Wingberg \"Cohomology of Number Fields\" §9.5) uses class field theory for the abelian base case, then an inductive construction on the derived series using cohomological embedding problem theory and Brauer groups.\n\nThe general inverse Galois problem — whether every finite group (not just solvable ones) arises as a Galois group over ℚ — remains open, despite being settled for many specific families of groups.",
+    "problemStatement": "Can Shafarevich's theorem (every finite solvable group is a Galois group over ℚ) be stated in Lean as a companion to the solvability classification in AbelRuffiniGaloisExtensions.lean?",
+    "proofStrategy": "Axiomatize shafarevich_inverse_galois with the existential statement ∃ (L : Type*) [Field L] [Algebra ℚ L] [IsGalois ℚ L], Nonempty (G ≃* (L ≃ₐ[ℚ] L)). All corollaries follow the same template: (1) construct IsSolvable instance via typeclass inference or parent-file lemmas, (2) apply @shafarevich_inverse_galois via obtain to destructure the existential, (3) package the result. The S₅ obstruction is imported directly from the parent file as s5_not_solvable.",
+    "keyInsights": [
+      "**Converse of Abel-Ruffini**: Shafarevich's theorem makes the solvability criterion an if-and-only-if: G is a radical Galois group over ℚ if and only if G is solvable. This file proves the ← direction; the parent file proves the → direction.",
+      "**Axiomatization depth**: The single axiom `shafarevich_inverse_galois` encapsulates roughly 500+ pages of algebraic number theory (class field theory, profinite groups, Brauer groups). All 7 corollaries are fully proved from this one assumption.",
+      "**inferInstance power**: The cyclic and abelian corollaries are essentially trivial in Lean — `IsSolvable (ZMod n)` and `IsSolvable G` for abelian G are automatically inferred via `CommGroup.isSolvable`. Shafarevich converts this trivial algebraic fact into a deep number-theoretic conclusion.",
+      "**S₅ nuance**: S₅ is not realizable via Shafarevich (non-solvable), but S₅ IS realizable over ℚ by other means (e.g., as Gal(x⁵-2x-5/ℚ)). The obstruction is not to realizability, but to realizability via the solvable-group pathway.",
+      "**Lean representation of Gal(L/ℚ)**: The Galois group is represented as `L ≃ₐ[ℚ] L` — the type of ℚ-algebra automorphisms — which naturally forms a group under composition. `IsGalois ℚ L` ensures this matches the classical Galois group."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-doc",
+      "title": "Imports and Mathematical Background",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports Mathlib field theory, group theory, Galois basics, and the parent file. The module docstring explains the relationship between Abel-Ruffini and Shafarevich's theorem, and lists the four deep ingredients of Shafarevich's proof.",
+      "mathContext": "$G$ solvable $\\Rightarrow$ $\\exists L/\\mathbb{Q}$ Galois with $\\mathrm{Gal}(L/\\mathbb{Q}) \\cong G$ (Shafarevich 1954)."
+    },
+    {
+      "id": "core-axiom",
+      "title": "Shafarevich's Theorem (Axiomatized)",
+      "startLine": 56,
+      "endLine": 83,
+      "summary": "The single axiom shafarevich_inverse_galois: for any [IsSolvable G], there exists a Galois extension L/ℚ with G ≃* Gal(L/ℚ). Comments explain the proof sketch (class field theory, embedding problems, Brauer groups).",
+      "mathContext": "$\\forall G$ finite solvable, $\\exists L/\\mathbb{Q}$ Galois: $G \\cong \\mathrm{Gal}(L/\\mathbb{Q})$."
+    },
+    {
+      "id": "specific-corollaries",
+      "title": "Corollaries: Cyclic, Abelian, S₃, S₄",
+      "startLine": 88,
+      "endLine": 131,
+      "summary": "Four proved corollaries: cyclic_group_realizable (ZMod n via CommGroup.isSolvable), abelian_group_realizable (all CommGroups), s3_realizable and s4_realizable (via symmetric_solvable_of_le_four from parent file).",
+      "mathContext": "$\\mathbb{Z}/n\\mathbb{Z}, A, S_3, S_4$ are all solvable, hence realizable over $\\mathbb{Q}$ by Shafarevich."
+    },
+    {
+      "id": "closure-properties",
+      "title": "Closure Under Subgroups and Quotients",
+      "startLine": 133,
+      "endLine": 163,
+      "summary": "solvable_iff_shafarevich_realizable, subgroup_of_solvable_realizable (subgroup preserves solvability), quotient_of_solvable_realizable (quotient by normal subgroup preserves solvability). All proved from Shafarevich + parent lemmas.",
+      "mathContext": "Solvability is closed under subgroups and quotients: if $G$ is solvable and $H \\leq G$ or $H = G/N$, then $H$ is solvable, hence realizable."
+    },
+    {
+      "id": "s5-obstruction",
+      "title": "S₅ Non-Solvability Obstruction",
+      "startLine": 165,
+      "endLine": 214,
+      "summary": "shafarevich_implies_converse (alias of solvable_iff_shafarevich_realizable), s5_not_solvable_obstruction (imported from parent as s5_not_solvable). The summary comment documents the proof status and connection to Abel-Ruffini.",
+      "mathContext": "$S_5$ is not solvable ($A_5$ is simple non-abelian), so Shafarevich does not apply — though $S_5$ is realizable over $\\mathbb{Q}$ by other means."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file axiomatizes Shafarevich's 1954 theorem and formally derives 7 corollaries: cyclic groups, all abelian groups, S₃ and S₄ are realizable over ℚ; the class of realizable solvable groups is closed under subgroups and quotients; and S₅ fails the solvability criterion. All 7 theorems are fully proved from the single axiom using Mathlib's group theory.",
+    "implications": "Together with AbelRuffiniGaloisExtensions.lean, this file completes a formal framework for the solvable inverse Galois problem: a finite group G is the Galois group of a radical extension of ℚ if and only if G is solvable. This is the group-theoretic content of the classical quintic insolvability story. The axiomatization is mathematically honest: it correctly identifies the single deep theorem (Shafarevich's) that requires substantial algebraic number theory, while formalizing all the group-theoretic consequences in full Lean.",
+    "openQuestions": [
+      "Can Shafarevich's theorem be proved in Lean using Mathlib's developing class field theory? The abelian case (realizing ZMod n via cyclotomic extensions) is within reach; the full proof requires embedding problem theory.",
+      "Can the specific Galois extensions for S₃ and S₄ be constructed explicitly in Lean, not just their existence asserted? E.g., x³ + px + q for S₃ and a generic quartic for S₄.",
+      "Is every finite group (not just solvable) realizable as a Galois group over ℚ? This is the full inverse Galois problem — one of the deepest open problems in number theory, settled for many families (symmetric groups, simple groups of Lie type, sporadic groups)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "abel-ruffini-galois-extensions",
+      "relationship": "Parent file: provides symmetric_solvable_of_le_four, s5_not_solvable, and other group-theory lemmas used in the corollaries"
+    },
+    {
+      "proofId": "abel-ruffini",
+      "relationship": "Grandparent: proves the polynomial-theoretic side (solvable by radicals ↔ solvable Galois group), completing the bidirectional characterization"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05.lean",
     "axiomCount": 1,
     "sorryCount": 0,
-    "lineCount": 175,
+    "lineCount": 214,
     "theoremCount": 8,
     "definitionCount": 0
   }


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions-oq-05 (Shafarevich's Theorem).

## What was missing

- **index.ts**: completely absent — proof page showed "proof not found" on the live site
- **annotations.json**: completely absent — no inline annotations
- **meta.json**: had wrong sections format (content/theorems fields instead of id/startLine/endLine/summary), missing overview/conclusion/crossReferences, wrong lineCount (175 vs actual 214)

## Quality improvements

**Created index.ts** — enables the proof page to load on the site.

**Created annotations.json** with 6 deep annotations:
- Module overview: explains the converse-of-Abel-Ruffini framing
- Core axiom: Lean representation of Gal(L/ℚ) as AlgEquiv, proof sketch for Shafarevich
- Cyclic/abelian corollaries: explains inferInstance power + classical cyclotomic connection
- Symmetric groups S₃/S₄: derived series context and sharp n=4 threshold
- Closure properties: group-theoretic content of subgroup/quotient theorems
- S₅ obstruction: subtle distinction between Shafarevich non-applicability and non-realizability

**Restructured meta.json**:
- Fixed sections format to id/title/startLine/endLine/summary/mathContext
- Fixed lineCount 175→214
- Added top-level overview with historicalContext (Shafarevich 1954 + Neukirch-Schmidt-Wingberg), proofStrategy, 5 keyInsights
- Added conclusion with summary, implications, 3 open questions
- Added crossReferences to parent abel-ruffini-galois-extensions and grandparent abel-ruffini