### PR TITLE
fix(inclusion-exclusion-oq-03): add missing leanFile block

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03/meta.json
@@ -155,5 +155,16 @@
       "note": "O(n·2ⁿ) fast subset convolution algorithm; zetaStep is the fundamental building block"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/InclusionExclusionOQ03.lean",
+    "filename": "InclusionExclusionOQ03.lean",
+    "lineCount": 337,
+    "theoremCount": 11,
+    "axiomCount": 0,
+    "defCount": 4,
+    "sorryCount": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ03.lean"
+  }
 }


### PR DESCRIPTION
## Fix

Add missing top-level `leanFile` block to `inclusion-exclusion-oq-03` meta.json. The Lean file exists and was being processed by the gallery, but without this block the auditor's `find-targets.ts` cannot track axiom/sorry counts via `leanFile.axiomCount` and `leanFile.sorryCount`.

## Evidence

**Before**: `leanFile: null` (block entirely absent despite file existing at `proofs/Proofs/InclusionExclusionOQ03.lean`)

**After**:
```json
"leanFile": {
  "path": "Proofs/InclusionExclusionOQ03.lean",
  "filename": "InclusionExclusionOQ03.lean",
  "lineCount": 337,
  "theoremCount": 11,
  "axiomCount": 0,
  "defCount": 4,
  "sorryCount": 0,
  "isAristotle": false,
  "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ03.lean"
}
```

Actual file counts verified: 337 lines (`wc -l`), 11 `theorem`/`lemma` declarations, 4 `def`/`abbrev`/`opaque`, 0 sorries, 0 axioms.

---
Automated fix by lean-mechanic agent.