### PR TITLE
fix(erdos-347): correct lineCount 125→195, theoremCount 7→13

### DIFF
--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -51,9 +51,9 @@
       "Cofinite sets and subsequences: strictly monotone reindexing with cofinite range, robustness under finite deletions",
       "Lean 4 and Mathlib: Finset.sum, StrictMono, Set.Finite, and noncomputable definitions"
     ],
-    "lineCount": 125,
+    "lineCount": 195,
     "mathlib_version": "4.26.0",
-    "theoremCount": 7
+    "theoremCount": 13
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this in their 1980 monograph, asking about the interplay between multiplicative growth rates and additive completeness. The ratio limit 2 is the critical threshold for subset sum completeness: powers of 2 give every natural number via binary representation ($P(\\{1,2,4,8,\\ldots\\}) = \\mathbb{N}$), but small perturbations can destroy this. The question asks whether a sequence growing at rate 2 can be made 'robustly complete' — not just complete, but maintaining density-1 subset sums even after removing finitely many terms. This robustness requirement is much stronger than simple completeness and connects to the stability theory of additive representations. The problem was solved affirmatively by ebarschkis, building on ideas from Terence Tao and Wouter van Doorn. The construction carefully perturbs powers of 2 to create controlled redundancy: each integer has many different subset sum representations, so deleting finitely many terms still leaves enough representations to cover almost all integers.",
@@ -157,9 +157,9 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 125,
+    "lineCount": 195,
     "axiomCount": 1,
-    "theoremCount": 7,
+    "theoremCount": 13,
     "definitionCount": 8,
     "path": "Proofs/Erdos347Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Update stale `leanFile.lineCount` and `leanFile.theoremCount` (and matching `meta.lineCount`/`meta.theoremCount`) for `erdos-347`.

## Evidence

**Lean file**: `proofs/Proofs/Erdos347Problem.lean`

**Before**:
- `meta.lineCount`: 125
- `meta.theoremCount`: 7
- `leanFile.lineCount`: 125
- `leanFile.theoremCount`: 7

**After**:
- `meta.lineCount`: 195
- `meta.theoremCount`: 13
- `leanFile.lineCount`: 195
- `leanFile.theoremCount`: 13

The file grew from ~125 lines to 195 lines, gaining 6 additional proved theorems:
`countIn_mono`, `countIn_le`, `hasDensity_one_of_superset`, `erdos347_range_density_one`,
`subsetSums_cofiniteImage_subset`, `erdos347_cofinite_density_via_superset`.

All other fields (axiomCount: 1, sorries: 0, definitionCount: 8) are correct and unchanged.

---
Automated fix by lean-mechanic agent.