### PR TITLE
fix(meta): correct stale lineCount/theoremCount in 12 gallery entries

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
@@ -19,11 +19,11 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 205,
+    "lineCount": 256,
     "assumptions": "0 axioms, 0 sorries. All results proved from Mathlib's Cardinal.mk_set, Cardinal.beth_succ, and Cardinal.cantor, plus the parent file CantorsTheoremOQ01.lean.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-04",
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 1,
     "originalContributions": [
       "card_powerSet_powerSet_real_eq_beth_three: |𝒫(𝒫(ℝ))| = ℶ₃",
@@ -157,8 +157,8 @@
     "path": "Proofs/CantorsTheoremOQ01OQ02.lean",
     "sorryCount": 0,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 1,
-    "lineCount": 205
+    "lineCount": 256
   }
 }

--- a/src/data/proofs/erdos-1006-oq-04/meta.json
+++ b/src/data/proofs/erdos-1006-oq-04/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1006",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 163,
-    "theoremCount": 11,
-    "assumptions": "None. All 11 theorems are fully proved. Builds on coloringOrientation definition and acyclicity results from OQ03.",
+    "lineCount": 193,
+    "theoremCount": 15,
+    "assumptions": "None. All 15 theorems are fully proved. Builds on coloringOrientation definition and acyclicity results from OQ03.",
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",
@@ -117,9 +117,9 @@
     ],
     "opens": ["SimpleGraph"],
     "namespace": "Erdos1006OQ04",
-    "lineCount": 163,
+    "lineCount": 193,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 15,
     "definitionCount": 0,
     "path": "Proofs/Erdos1006OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-106-oq-02/meta.json
+++ b/src/data/proofs/erdos-106-oq-02/meta.json
@@ -26,8 +26,8 @@
     "erdosProblemStatus": "open",
     "axiomCount": 5,
     "assumptions": "5 axiom declarations: rotated_square_area (rotation preserves area), f_rot_bounded (Cauchy-Schwarz √n bound), f_rot_mono (monotone), bku_theorem_ap (BKU 2024 result), f_rot_2 (Erdős f_rot(2)=1). ELIMINATED: g_ap_perfect_square (proved via k×k grid construction + g_ap_bounded upper bound), g_ap_bounded (proved from f_rot_bounded + g_ap≤f_rot), f_rot_perfect_square (proved from g_ap_perfect_square + f_rot_bounded + g_ap≤f_rot). 0 sorries.",
-    "lineCount": 619,
-    "theoremCount": 26
+    "lineCount": 664,
+    "theoremCount": 23
   },
   "overview": {
     "historicalContext": "**From Axis-Parallel to Rotated: The Last Barrier in Square Packing**\n\nThe 2024 breakthrough by Baek, Koizumi, and Ueoro completely resolved the axis-parallel case of Erdős's square packing conjecture, proving g(k²+1) = k. This leaves one fundamental question: can rotated squares do better?\n\nIn the axis-parallel formulation, all packed squares have sides parallel to the unit square. When rotation is allowed, the packing space is richer — a rotated square occupies a diamond-shaped region that could potentially fill space more efficiently.\n\nNo example is known where rotation helps. At perfect squares n = k², both f_rot(k²) = g(k²) = k, since the k×k grid (which is axis-parallel) is already optimal by Cauchy-Schwarz. The question is whether rotation helps at non-perfect-square values of n.",
@@ -177,9 +177,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 619,
+    "lineCount": 664,
     "axiomCount": 5,
-    "theoremCount": 26,
+    "theoremCount": 23,
     "substantiveTheoremCount": 8,
     "sorryTheorems": 0,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/1100",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 328,
+    "lineCount": 331,
     "assumptions": "3 axioms: tau_perp_lower_bound (\u03c4\u22a5(n) \u2265 \u03c9(n), basic coprimality bound requiring intricate sorted-divisor reasoning), erdos_hall_max_lower_bound (max_{n<x} \u03c4\u22a5(n) > exp((log log x)^(2\u2212\u03b5)), Erd\u0151s-Hall 1978), and erdos_simonovits_bounds (exponential bounds on g(k), Erd\u0151s-Simonovits).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10
+    "theoremCount": 3
   },
   "overview": {
     "historicalContext": "This problem was posed by Erd\u0151s and R. R. Hall in their 1978 paper *On some unconventional problems on the divisors of integers* (Acta Arithmetica). Hall was a specialist in multiplicative number theory at York, and this collaboration produced several problems exploring the fine structure of divisor sequences. The function $\\tau^{\\perp}(n)$ measures how often consecutive divisors in the increasing sequence $1 = d_1 < d_2 < \\cdots < d_{\\tau(n)} = n$ are coprime \u2014 a surprisingly subtle invariant. The trivial lower bound $\\tau^{\\perp}(n) \\geq \\omega(n)$ is immediate (each prime $p \\mid n$ contributes at least one coprime transition in the divisor list), and is tight infinitely often. The deeper questions concern whether $\\tau^{\\perp}(n)$ typically exceeds $\\omega(n)$ by a large factor. The exponential bounds on $g(k)$ are due to Erd\u0151s and Simonovits, who showed $\\sqrt{2}^k \\lesssim g(k) \\lesssim (2-c)^k$, revealing that the combinatorics of coprime transitions in divisor lattices is genuinely exponential but sub-maximal.",
@@ -240,9 +240,9 @@
       "Finset"
     ],
     "namespace": "Erdos1100",
-    "lineCount": 328,
+    "lineCount": 331,
     "axiomCount": 3,
-    "theoremCount": 10,
+    "theoremCount": 3,
     "definitionCount": 7,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/153",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 494,
+    "lineCount": 542,
     "assumptions": "1 axiom(s) and 0 sorry(s). Axioms: erdos_153_conjecture (main open conjecture). Proved: sidon_sumset_card (exact cardinality), sidon_sumset_card_eq, sidon_distinct_differences (B₂ distinct differences), sidon_density_bound (√N density), sidon_sumset_range, average_gap_bounded, ess_1994_result, infinite_sidon_gap_from_finite.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 18
+    "theoremCount": 14
   },
   "overview": {
     "historicalContext": "Sidon sets originate from Simon Sidon's 1932 question to Erdős about sets of natural numbers whose pairwise sums are all distinct. Erdős and Turán (1941) proved the foundational density bound: a Sidon set in $\\{1,\\ldots,N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, and perfect difference set constructions (Singer 1938, using projective planes over finite fields) show this is essentially tight. Problem 153 was posed by Erdős, Sárközy, and Sós in their 1994 paper 'On Sum Sets of Sidon Sets, I', where they initiated a systematic study of the fine structure of sumsets $A+A$ for Sidon sets $A$. While the average gap in such sumsets is bounded ($\\Theta(1)$ for maximal Sidon sets), they conjectured that the second moment — the mean squared gap — must diverge. This question sits at the intersection of additive combinatorics and the statistical theory of gap distributions, connecting to broader phenomena like the pair correlation conjecture for zeros of the Riemann zeta function and the study of level spacing in random matrix theory.",
@@ -140,9 +140,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 494,
+    "lineCount": 542,
     "axiomCount": 1,
-    "theoremCount": 18,
+    "theoremCount": 14,
     "definitionCount": 8,
     "path": "Proofs/Erdos153Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -55,9 +55,9 @@
       "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erdős's question about individual divergence"
     ],
     "axiomCount": 1,
-    "lineCount": 291,
+    "lineCount": 327,
     "assumptions": "2 axioms: eggleton_erdos_selfridge (deep result), filtered_sum_implies_full. sieve_greedy proved from constructive definition (with hactive guard for sentinel case). sieve_conjectured_bound demoted to def. filtered_sum_implies_full converted from axiom to theorem-with-sorry (axiom integrity).",
-    "theoremCount": 10
+    "theoremCount": 13
   },
   "leanFile": {
     "imports": [
@@ -70,9 +70,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 291,
+    "lineCount": 327,
     "axiomCount": 1,
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 9,
     "path": "Proofs/Erdos460Problem.lean",
     "sorries": 1

--- a/src/data/proofs/erdos-472/meta.json
+++ b/src/data/proofs/erdos-472/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/472",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 263,
+    "lineCount": 327,
     "assumptions": "1 axiom: ulam35_contains_all_odd_primes_conjecture. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 23
+    "theoremCount": 30
   },
   "overview": {
     "historicalContext": "This problem originated with Stanisław Ulam and appears in the Erdős–Graham collection (1980). Ulam studied iterative constructions on number sequences extensively, including his famous Ulam numbers (integers uniquely representable as sums of two earlier terms). Problem 472 applies a related greedy principle specifically to primes: given a finite seed of primes, extend by always choosing the smallest prime of the form q_n + q_i − 1. The shift by −1 (rather than plain addition) creates a subtle parity structure: when both operands are odd, the candidate is odd and hence potentially prime. The seed [3, 5] produces the sequence 3, 5, 7, 11, 13, 17, 19, 23, ... which computationally matches all odd primes through 23. Whether any seed produces an infinite sequence remains open. The problem connects to questions about additive bases among primes, Goldbach-type phenomena, and the distribution of primes in arithmetic progressions.",
@@ -145,9 +145,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 263,
+    "lineCount": 327,
     "axiomCount": 1,
-    "theoremCount": 23,
+    "theoremCount": 30,
     "definitionCount": 8,
     "path": "Proofs/Erdos472Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -23,10 +23,10 @@
     "erdosUrl": "https://erdosproblems.com/854",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 194,
+    "lineCount": 233,
     "assumptions": "4 axioms encoding the Erdős conjectures and known bounds: (1) maxGap_bound (Jacobsthal function bound), (2) lacampagne_selfridge_counterexample (computational disproof for n₆=30030), (3) ErdosProblem854_missing_gap_growth (Part 1, open), (4) ErdosProblem854_many_gaps (Part 2, open). 0 sorries. All supporting infrastructure (primorials, coprime residues, gap sets, gap evenness) formally proved without axioms.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16
+    "theoremCount": 19
   },
   "overview": {
     "historicalContext": "**Erdős** posed this problem about the gap structure of coprime residues modulo primorials. The sequence $1 = a_1 < a_2 < \\cdots < a_{\\varphi(n_k)} = n_k - 1$ of integers coprime to the $k$-th primorial $n_k = p_1 \\cdots p_k$ exhibits a rich gap structure. Erdős initially conjectured that **all even integers** up to the maximal gap appear as consecutive differences, but computational work by **Lacampagne and Selfridge** for $n_6 = 30030$ disproved this strong form. The problem connects to the **Jacobsthal function** $j(n)$, the maximum gap between consecutive integers coprime to $n$, studied by Jacobsthal (1960), Iwaniec (1978), and Pintz (1997). Iwaniec proved $j(n) \\ll (\\log n)^2$, giving the sharpest known upper bound. The two remaining open questions—growth rate of the smallest missing gap and proportionality of distinct gap counts—connect coprimality patterns to distribution of primes in arithmetic progressions.",
@@ -140,9 +140,9 @@
       "Nat"
     ],
     "namespace": "Erdos854",
-    "lineCount": 194,
+    "lineCount": 233,
     "axiomCount": 4,
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 8,
     "path": "Proofs/Erdos854Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Corrects stale `leanFile.lineCount` and `leanFile.theoremCount` (and matching `meta.*` fields) in 12 gallery `meta.json` files. No Lean code changed. No sorries or axioms affected.

| Slug | lineCount | theoremCount |
|------|-----------|--------------|
| `birthday-problem-oq-03-oq-01-oq-02` | 501 → 588 | 23 → 22 |
| `erdos-472` | 263 → 327 | 23 → 30 |
| `erdos-668` | 282 → 334 | (unchanged, 14) |
| `cantors-theorem-oq-01-oq-02` | 205 → 256 | 12 → 15 |
| `erdos-153` | 494 → 542 | 18 → 14 |
| `erdos-106-oq-02` | 619 → 664 | 26 → 23 |
| `erdos-854` | 194 → 233 | 16 → 19 |
| `abel-ruffini-galois-extensions-oq-05` | 175 → 214 | 8 → 9 |
| `erdos-460` | 291 → 327 | 10 → 13 |
| `erdos-1006-oq-04` | 163 → 193 | 11 → 15 |
| `erdos-311` | 103 → 114 | 6 → 3 |
| `erdos-1100` | 328 → 331 | 10 → 3 |

Note: `erdos-668` theoremCount was left at 14 (axiomCount fix is handled separately in PR #15758). `erdos-311` and `erdos-1100` axiomCount fields were not touched.

No Lean code changed. No sorries or axioms affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)