### PR TITLE
fix(batch): add sorries=0 to 17 verified proofs, fix TS2352 in 7 index.ts

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02-oq-02/index.ts
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/BallotProblemOQ02OQ02.lean?raw')
 

--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -19,7 +19,8 @@
       "Mathlib.Tactic"
     ],
     "tags": ["probability", "stochastic-processes", "brownian-motion", "first-passage-time", "intermediate-value-theorem", "ballot-problem"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/binomial-theorem-oq-04-oq-04/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-04/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/BinomialTheoremOQ04OQ04.lean?raw')
 

--- a/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
@@ -16,7 +16,8 @@
       "Mathlib"
     ],
     "tags": ["combinatorics", "lattice-paths", "vandermonde", "lgv-lemma", "binomial-coefficients"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-04/index.ts
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-04/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/BorsukUlamOQ03OQ04.lean?raw')
 

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
@@ -16,7 +16,8 @@
       "Mathlib"
     ],
     "tags": ["topology", "borsuk-ulam", "lipschitz", "quantitative", "antipodal"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/circumference-via-differentiation/index.ts
+++ b/src/data/proofs/circumference-via-differentiation/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/CircumferenceViaDifferentiation.lean?raw')
 

--- a/src/data/proofs/circumference-via-differentiation/meta.json
+++ b/src/data/proofs/circumference-via-differentiation/meta.json
@@ -19,7 +19,8 @@
       "Mathlib.Tactic"
     ],
     "tags": ["geometry", "calculus", "circumference", "area", "circle", "differentiation"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-31-primes-density/index.ts
+++ b/src/data/proofs/erdos-31-primes-density/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/Erdos31PrimesDensity.lean?raw')
 

--- a/src/data/proofs/erdos-31-primes-density/meta.json
+++ b/src/data/proofs/erdos-31-primes-density/meta.json
@@ -16,7 +16,8 @@
       "Mathlib"
     ],
     "tags": ["number-theory", "prime-numbers", "density", "chebyshev", "analytic-number-theory"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -20,7 +20,8 @@
       "Mathlib.SetTheory.Ordinal.Topology"
     ],
     "tags": ["set-theory", "ordinals", "cardinals", "clubs", "stationary", "fodor"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -14,7 +14,8 @@
     "leanFile": "proofs/Proofs/FrobeniusNumber.lean",
     "imports": ["Mathlib.Data.Nat.GCD.Basic", "Mathlib.Tactic"],
     "tags": ["number-theory", "combinatorics", "frobenius", "coin-problem", "coprime"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -20,7 +20,8 @@
       "Mathlib.FieldTheory.Finite.Basic"
     ],
     "tags": ["number-theory", "group-theory", "cyclic-groups", "zmod", "wilson-gauss"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/mean-value-theorem-oq-04/index.ts
+++ b/src/data/proofs/mean-value-theorem-oq-04/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/MeanValueTheoremOQ04.lean?raw')
 

--- a/src/data/proofs/mean-value-theorem-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04/meta.json
@@ -16,7 +16,8 @@
       "Mathlib"
     ],
     "tags": ["calculus", "mean-value-theorem", "fundamental-theorem-calculus", "integration", "analysis"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/minkowski-theorem-oq-02-oq-01/index.ts
+++ b/src/data/proofs/minkowski-theorem-oq-02-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 
 const leanSource = () => import('../../../../proofs/Proofs/MinkowskiTheoremOQ02OQ01.lean?raw')
 

--- a/src/data/proofs/minkowski-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-02-oq-01/meta.json
@@ -22,7 +22,8 @@
       "Mathlib.Tactic"
     ],
     "tags": ["number-theory", "dirichlet", "minkowski", "approximation", "measure-theory", "geometry-of-numbers"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -17,7 +17,8 @@
       "Mathlib.Tactic"
     ],
     "tags": ["projective-geometry", "ring-theory", "combinatorics", "cross-product", "pappus"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -18,7 +18,8 @@
       "Mathlib.Tactic"
     ],
     "tags": ["number-theory", "geometry", "lattice", "picks-theorem", "triangulation"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -14,7 +14,8 @@
     "leanFile": "proofs/Proofs/SpernerMathlib.lean",
     "imports": ["Mathlib"],
     "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -19,7 +19,8 @@
       "Mathlib.Data.ZMod.Basic"
     ],
     "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex", "mathlib"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/sperner-simplicial-bridge/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge/meta.json
@@ -14,7 +14,8 @@
     "leanFile": "proofs/Proofs/SpernerSimplicialBridge.lean",
     "imports": ["Proofs.SpernerMathlib"],
     "tags": ["combinatorics", "topology", "sperner", "simplicial-complex", "pseudomanifold", "bridge"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -18,7 +18,8 @@
       "Proofs.SzemerediRegularity"
     ],
     "tags": ["combinatorics", "szemer-edi", "regularity", "energy-increment", "graph-theory"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
@@ -26,7 +26,8 @@
       "Proofs.GaussWilsonNonCyclic"
     ],
     "tags": ["number-theory", "group-theory", "wilson", "gauss-wilson", "cyclic-groups", "zmod"],
-    "assumptions": []
+    "assumptions": [],
+    "sorries": 0
   },
   "sections": [
     {


### PR DESCRIPTION
## Fix

**Root cause**: 17 gallery proofs with `verified/original` status had `sorryCount: 0` in their meta blocks, but were missing the `sorries` field that `find-targets.ts` uses to determine claimed sorry count. The auditor code computes `claimedSorries = proofMeta.sorries ?? -1`, so null/absent `sorries` yields -1, triggering a false mismatch against actual 0.

**Metadata fix**: Added `"sorries": 0` to each affected meta block (minimal 2-line diff per file).

**Build fix**: 7 of the affected index.ts files had a bare `metaJson as { ... }` cast that triggered TS2352. Applied the `as unknown as` pattern.

## Evidence

**Before** (all 17): `sorry mismatch: claims -1, actual 0`
**After**: auditor validation passes (0 !== 0 no longer triggered)

Affected proofs (17):
- ballot-problem-oq-02-oq-02
- binomial-theorem-oq-04-oq-04
- borsuk-ulam-oq-03-oq-04
- circumference-via-differentiation
- erdos-31-primes-density
- gauss-wilson-non-cyclic
- mean-value-theorem-oq-04
- minkowski-theorem-oq-02-oq-01
- pappus-theorem-oq-02
- picks-theorem-oq-01-oq-01
- sperner-mathlib, sperner-mathlib4, sperner-simplicial-bridge
- szemeredi-core-oq-01
- wilsons-theorem-oq-02-ext
- fodor-pressing-down
- frobenius-number

---
Automated fix by lean-mechanic agent.