### PR TITLE
fix(batch): correct axiomCount erdos-311 (0→3) and erdos-668 (3→6)

### DIFF
--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -16,7 +16,7 @@
       "approximation",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 311,
     "erdosUrl": "https://erdosproblems.com/311",
@@ -50,9 +50,9 @@
       "tang_upper_bound axiom (subexponential upper bound)",
       "erdos_311_conjecture axiom (ε-N₀ form)"
     ],
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 103,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "assumptions": "3 axioms: delta_lower_bound_pnt (PNT-based lower bound e^{-(1+ε)N}), tang_upper_bound (Tang's subexponential upper bound), erdos_311_conjecture (the main open conjecture: log δ(N)/N → -c for c ∈ (0,1)). No sorries.",
     "theoremCount": 6
   },
   "sections": [

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -60,9 +60,9 @@
         "relationship": "Erdős Problem #90 (maximum unit distances u(n)) is the prerequisite problem — #668 studies uniqueness of configurations achieving u(n)"
       }
     ],
-    "axiomCount": 3,
+    "axiomCount": 6,
     "lineCount": 282,
-    "assumptions": "3 axioms (f_four, four_config_unique, extremalQuotient_finite — all used by proved theorems), 0 sorries. Previously 7 axioms — removed 4 unused axioms.",
+    "assumptions": "6 axioms: f_one/f_two/f_three/f_four (base values f(1)=f(2)=f(3)=f(4)=1), four_config_unique (uniqueness of the 4-point extremal configuration), extremalQuotient_finite (finite count of extremal configurations). No sorries.",
     "theoremCount": 14
   },
   "overview": {


### PR DESCRIPTION
## Fix

Corrects stale `axiomCount` values in two Erdős problem meta.json files where the Lean source has more axiom declarations than the metadata claims.

## Evidence

### erdos-311

**Before**: `axiomCount: 0`, `badge: "wip"`, `assumptions: "0 axioms, 0 sorries..."`
**After**: `axiomCount: 3`, `badge: "axiom"`, `assumptions: corrected`

Lean file has 3 `axiom` declarations:
- `delta_lower_bound_pnt` (PNT-based exponential lower bound)
- `tang_upper_bound` (Tang's subexponential upper bound)
- `erdos_311_conjecture` (the main open conjecture)

The `assumptions` text had a stale note "Previously cited axiom names have been removed from the Lean source" — the axioms were NOT removed.

### erdos-668

**Before**: `axiomCount: 3`, `assumptions: "3 axioms (f_four, four_config_unique, extremalQuotient_finite)"`
**After**: `axiomCount: 6`, `assumptions: corrected`

Lean file has 6 `axiom` declarations:
- `f_one`, `f_two`, `f_three`, `f_four` (base values f(1)=f(2)=f(3)=f(4)=1)
- `four_config_unique` (uniqueness of 4-point extremal config)
- `extremalQuotient_finite` (finite count of extremal configs)

The meta counted only the last 3; the 4 base-value axioms were added later without updating the count.

---
Automated fix by lean-mechanic agent.