### PR TITLE
fix(meta): correct lineCount off-by-one in 3 gallery entries

### DIFF
--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -10,7 +10,7 @@
     "sorryCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
-    "lineCount": 324,
+    "lineCount": 323,
     "leanFile": "proofs/Proofs/GaussWilsonNonCyclic.lean",
     "imports": [
       "Mathlib.Data.ZMod.Basic",

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -10,7 +10,7 @@
     "sorryCount": 0,
     "theoremCount": 12,
     "definitionCount": 3,
-    "lineCount": 466,
+    "lineCount": 465,
     "leanFile": "proofs/Proofs/PappusTheoremOQ02.lean",
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -10,7 +10,7 @@
     "sorryCount": 0,
     "theoremCount": 14,
     "definitionCount": 3,
-    "lineCount": 898,
+    "lineCount": 897,
     "leanFile": "proofs/Proofs/SpernerMathlib.lean",
     "imports": ["Mathlib"],
     "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex"],


### PR DESCRIPTION
## Summary

Corrects stale `lineCount` in 3 gallery `meta.json` files. No Lean code changed.

| Slug | lineCount |
|------|-----------|
| `gauss-wilson-non-cyclic` | 324 → 323 |
| `pappus-theorem-oq-02` | 466 → 465 |
| `sperner-mathlib` | 898 → 897 |

All three files end with a proper newline (`0x0a`). Both `wc -l` and Python `splitlines()` agree on the corrected values.

Discovered during gallery integrity audit (auditor cycle 2026-05-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)