### PR TITLE
Enrich ballot-problem-oq-01-oq-02-oq-01-oq-01: add overview, annotations, index.ts

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-gap-analysis",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "Identifying the Mathlib Gap",
+    "content": "The header documents a precise gap in Mathlib4: Set.ncard_biUnion gives |union i in I, s i| = sum i in I.toFinset, |s i| for pairwise disjoint finite sets, but there is no corollary for the uniform case where every |s i| = k. The gap is small (10-line proof) but the result is ubiquitous. This file answers the open question from ballot-problem-oq-01-oq-02-oq-01: yes, the lemma extracted from the ballot fiber analysis is Mathlib-ready.",
+    "mathContext": "Mathlib has: $\\left|\\bigcup_{i \\in I} s_i\\right| = \\sum_{i \\in I} |s_i|$ (when pairwise disjoint, finite). Missing: the corollary $\\forall i.\\, |s_i| = k \\Rightarrow \\left|\\bigcup_{i \\in I} s_i\\right| = k \\cdot |I|$.",
+    "significance": "context",
+    "relatedConcepts": ["Set.ncard_biUnion", "Finset.sum_const", "PairwiseDisjoint", "uniform fiber"],
+    "prerequisites": ["Lean 4 set cardinality (Set.ncard)", "Mathlib BigOperators"]
+  },
+  {
+    "id": "ann-core-lemma",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 78 },
+    "type": "technique",
+    "title": "Core Proof: sum_congr + sum_const Collapse",
+    "content": "The proof reduces in two steps. First, Set.ncard_biUnion rewrites the union cardinality as a Finset sum over I.toFinset. Second, Finset.sum_congr replaces each summand (s i).ncard by the constant k, and Finset.sum_const collapses the sum to I.toFinset.card * k. A final mul_comm and hI.toFinset_card yield k * I.ncard. The use of Set.PairwiseDisjoint instead of the nested forall form makes the lemma directly composable with Mathlib infrastructure.",
+    "mathContext": "$$\\left|\\bigcup_{i \\in I} s_i\\right| \\xrightarrow{\\text{ncard\\_biUnion}} \\sum_{i \\in I} |s_i| \\xrightarrow{\\text{sum\\_congr}} \\sum_{i \\in I} k \\xrightarrow{\\text{sum\\_const}} |I| \\cdot k$$",
+    "significance": "key",
+    "relatedConcepts": ["Set.ncard_biUnion", "Finset.sum_congr", "Finset.sum_const", "Set.PairwiseDisjoint"],
+    "prerequisites": ["Finset sum algebra", "Set.ncard vs Finset.card coercions"]
+  },
+  {
+    "id": "ann-finset-variant",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 93 },
+    "type": "technique",
+    "title": "Finset Index: Cleaner Membership Coercion",
+    "content": "When the index set is a Finset rather than a Set.Finite, membership coercion via Finset.mem_coe bridges between the membership hypotheses. The Set.ncard_coe_Finset lemma identifies |(I : Set ι).ncard| = I.card, keeping the conclusion in terms of Finset.card which is more natural for discrete combinatorics.",
+    "mathContext": "Coercion chain: $I : \\text{Finset}\\,\\iota \\to (I : \\text{Set}\\,\\iota)$, with $|(I : \\text{Set}\\,\\iota)| = |I|$ via `Set.ncard_coe_Finset`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.mem_coe", "Set.ncard_coe_Finset", "Set.Finite coercion"],
+    "prerequisites": ["Lean 4 coercion", "Finset vs Set distinction"]
+  },
+  {
+    "id": "ann-fintype-version",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 99, "endLine": 109 },
+    "type": "technique",
+    "title": "Fintype Version: Universe Union via biUnion_univ",
+    "content": "When the index type ι is Fintype, the union covers all elements with no index set restriction. The proof rewrites the unindexed union as a biUnion over Set.univ via Set.biUnion_univ, applies the core lemma, then uses Set.ncard_univ to identify the index set size as Fintype.card ι. The hypothesis Pairwise (Disjoint on s) with no membership condition is equivalent to Set.univ.PairwiseDisjoint s.",
+    "mathContext": "$\\left|\\bigcup_{i : \\iota} s_i\\right| = \\left|\\bigcup_{i \\in \\text{univ}} s_i\\right| = k \\cdot |\\text{univ}| = k \\cdot \\text{Fintype.card}\\,\\iota$",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.biUnion_univ", "Fintype.card", "Pairwise Disjoint", "Set.ncard_univ"],
+    "prerequisites": ["Lean 4 Fintype typeclass", "Set.univ"]
+  },
+  {
+    "id": "ann-fiber-consequence",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 131 },
+    "type": "insight",
+    "title": "Fiber Decomposition: |A| = k × |f(A)| for Uniform Surjections",
+    "content": "This theorem is the combinatorial heart of the ballot probability transfer. If a set A decomposes as a disjoint union of fibers f⁻¹{b} ∩ A over values b in B, and every fiber has size k, then |A| = k × |B|. This is the discrete analogue of the fiber integral formula from measure theory. In the ballot problem, A is the set of all multi-candidate sequences and B is the set of election outcomes, with k being the number of orderings within each outcome.",
+    "mathContext": "$A = \\bigsqcup_{b \\in B} (f^{-1}\\{b\\} \\cap A), \\quad |f^{-1}\\{b\\} \\cap A| = k \\;\\forall b \\Rightarrow |A| = k \\cdot |B|$",
+    "significance": "key",
+    "relatedConcepts": ["preimage fiber", "uniform surjection", "ballot fiber transfer", "discrete fiber integral"],
+    "prerequisites": ["function preimage", "ncard_biUnion_eq_of_uniform", "set decomposition"]
+  },
+  {
+    "id": "ann-compatibility",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 145 },
+    "type": "technique",
+    "title": "API Compatibility: PairwiseDisjoint from Explicit Forall",
+    "content": "The parent file BallotProblemOQ01OQ02OQ01.lean used the explicit forall-forall form for disjointness. This compatibility lemma shows that the PairwiseDisjoint reformulation is strictly more general: the explicit form follows by simple eta-expansion. The result validates that upgrading the API to PairwiseDisjoint is purely additive with no loss of coverage.",
+    "mathContext": "$(\\forall i \\in I,\\, \\forall j \\in I,\\, i \\neq j \\to \\text{Disjoint}\\, s_i\\, s_j) \\Rightarrow I.\\text{PairwiseDisjoint}\\, s$",
+    "significance": "technical",
+    "relatedConcepts": ["Set.PairwiseDisjoint", "Disjoint predicate", "API design"],
+    "prerequisites": ["Set.PairwiseDisjoint definition", "Lean 4 function application"]
+  },
+  {
+    "id": "ann-concrete-example",
+    "proofId": "ballot-problem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 150, "endLine": 169 },
+    "type": "insight",
+    "title": "Verification: Three Disjoint Pairs by omega",
+    "content": "The example proves that {0,1} union {2,3} union {4,5} has 6 elements using the Finset variant. The disjointness of {2i, 2i+1} for distinct i is established by omega reasoning over set membership: when i ≠ j, the arithmetic ranges [2i, 2i+1] and [2j, 2j+1] do not overlap. The size-2 claim uses Set.ncard_pair which requires proving 2i ≠ 2i+1 (trivially by omega). This demonstrates that omega handles both combinatorial and arithmetic parts of concrete finite set reasoning.",
+    "mathContext": "For $i \\in \\{0,1,2\\}$: $|\\{2i, 2i+1\\}| = 2$, sets pairwise disjoint $\\Rightarrow \\left|\\bigcup_{i=0}^{2}\\{2i,2i+1\\}\\right| = 2 \\times 3 = 6$.",
+    "significance": "context",
+    "relatedConcepts": ["Set.ncard_pair", "omega tactic", "Finset.PairwiseDisjoint", "concrete verification"],
+    "prerequisites": ["Lean 4 omega tactic", "Set.ncard_pair lemma"]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const ballotProblemOq01Oq02Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const ballotProblemOq01Oq02Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const ballotProblemOq01Oq02Oq01Oq01Data: ProofData = {
+  proof: ballotProblemOq01Oq02Oq01Oq01Proof,
+  annotations: ballotProblemOq01Oq02Oq01Oq01Annotations,
+}

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -31,26 +31,104 @@
       "ncard_eq_mul_of_uniform_fibers: consequence for function fibers over image",
       "ncard_biUnion_eq_of_uniform_compat: compatibility with parent file's explicit ∀ form",
       "Disjoint-pairs example: three pairs {2i, 2i+1} for i=0,1,2"
-    ],
-    "proofStrategy": "All lemmas reduce to Set.ncard_biUnion + Finset.sum_const + sum_congr. The PairwiseDisjoint form matches Mathlib conventions. The Fintype version uses biUnion_univ + ncard_univ to reduce to the Set case.",
-    "openQuestions": [
-      "What is the Mathlib PR process for contributing Set.ncard lemmas?",
-      "Should the lemma be stated for ncard or for Nat.card (more general)?",
-      "Is there a version for Multiset or Finsupp fibers?"
-    ],
-    "sections": [
-      {
-        "title": "Core Lemma (Mathlib-Ready)",
-        "content": "ncard_biUnion_eq_of_uniform uses Set.PairwiseDisjoint (Mathlib standard) instead of the explicit ∀∀ form. The proof is 6 lines from Set.ncard_biUnion + Finset.sum_congr + sum_const.",
-        "theorems": ["ncard_biUnion_eq_of_uniform"]
-      },
-      {
-        "title": "Specializations",
-        "content": "Three variants: Finset-indexed (cleaner for discrete problems), Fintype-indexed (universal union via biUnion_univ), and function-fiber version (connects to preimage counting). All reduce to the core lemma.",
-        "theorems": ["ncard_biUnion_eq_of_uniform_finset", "ncard_iUnion_eq_of_uniform", "ncard_eq_mul_of_uniform_fibers"]
-      }
     ]
   },
+  "overview": {
+    "historicalContext": "The problem of counting a disjoint union of uniform sets arises across combinatorics, group theory, and probability. The classical result that a group $G$ has order $|G| = k \\cdot |G/H|$ when every coset $gH$ has exactly $k$ elements is the prototypical example. In Lean 4's Mathlib, `Set.ncard_biUnion` gives the general sum formula for disjoint unions, but as of Mathlib4 there is no direct corollary for the *uniform* case — the gap this entry fills. The ballot problem chain (initiated in this gallery) provided the immediate motivation: fiber counting under a multi-candidate permutation map reduces exactly to this uniform-union structure, and the extracted lemma is clean enough to stand on its own in Mathlib.",
+    "problemStatement": "Given a finite index set $I$, a family of sets $s : \\iota \\to \\mathrm{Set}\\,\\alpha$ that is pairwise disjoint on $I$, with each $s(i)$ finite and $|s(i)| = k$, prove that $\\left|\\bigcup_{i \\in I} s(i)\\right| = k \\cdot |I|$. Equivalently: a disjoint union of $n$ sets each of size $k$ has total size $kn$.",
+    "proofStrategy": "All lemmas reduce to two Mathlib primitives: `Set.ncard_biUnion` (which expresses |⋃ i ∈ I, s i| as ∑ i ∈ I.toFinset, |s i|) and `Finset.sum_const` (which collapses a constant sum ∑ i ∈ I, k to |I| • k). The key step is `Finset.sum_congr` to replace each `(s i).ncard` by the uniform value `k`. The PairwiseDisjoint form converts the nested ∀∀ disjointness hypothesis to Mathlib's standard predicate, while the specializations (Finset index, Fintype index, fiber version) each peel off one layer of coercion.",
+    "keyInsights": [
+      "The lemma closes a gap in Mathlib: `Set.ncard_biUnion` gives a sum formula but offers no constant-fiber shortcut. This entry provides exactly that shortcut, following the Mathlib naming convention `*_of_uniform`.",
+      "Three index-set variants (Set with Finite, Finset, Fintype) cover the three common programming patterns in Lean 4 proofs. The Fintype form is the cleanest for algorithmic contexts since `biUnion_univ` reduces it to a full-universe union.",
+      "`Set.PairwiseDisjoint` is strictly cleaner than the nested `∀ i ∈ I, ∀ j ∈ I, i ≠ j → Disjoint` form in Lean 4: it composes with `Function.Injective.pairwiseDisjoint` and other Mathlib infrastructure. The compatibility lemma shows both forms are interchangeable.",
+      "The fiber version `ncard_eq_mul_of_uniform_fibers` is the abstract spine of ballot-problem fiber transfer: it says |A| = k × |B| whenever A decomposes as a disjoint union of B-indexed fibers of uniform size k. This is the combinatorial engine behind the probability-preserving surjection result.",
+      "The concrete example (three disjoint pairs $\\{2i, 2i+1\\}$ for $i = 0, 1, 2$) is non-trivial to prove in Lean 4 because `omega` must reason about set membership for specific numeric cases. The example validates that the lemma is usable, not just provable."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-header",
+      "title": "Imports and Mathlib Gap Analysis",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports Mathlib set cardinality and big-operator machinery, then documents the gap in Mathlib4: Set.ncard_biUnion exists but the uniform-fiber specialization does not. Explains the relationship to the parent ballot problem file."
+    },
+    {
+      "id": "core-lemma",
+      "title": "Core Lemma: ncard_biUnion_eq_of_uniform (Mathlib-Ready)",
+      "startLine": 52,
+      "endLine": 78,
+      "summary": "Proves the main theorem: a pairwise-disjoint family of finite sets indexed by a finite set I, all of cardinality k, has union cardinality k * |I|. Uses Set.PairwiseDisjoint (Mathlib standard). Proof: ncard_biUnion then sum_congr + sum_const then mul_comm."
+    },
+    {
+      "id": "finset-specialization",
+      "title": "Finset Index Specialization",
+      "startLine": 80,
+      "endLine": 93,
+      "summary": "Derives the Finset-indexed variant where the index is a Finset rather than a Set.Finite. Reduces to the core lemma via Set.ncard_coe_Finset and coercion of membership."
+    },
+    {
+      "id": "fintype-version",
+      "title": "Fintype Universe Version",
+      "startLine": 95,
+      "endLine": 109,
+      "summary": "The strongest form: when the index type is Fintype, the union over all elements satisfies |union i, s i| = k * Fintype.card ι. Uses biUnion_univ to reduce to the Set version, then ncard_univ to identify the index set size."
+    },
+    {
+      "id": "fiber-consequence",
+      "title": "Fiber Consequence: Domain Size via Image",
+      "startLine": 111,
+      "endLine": 131,
+      "summary": "Applies the core lemma to function fibers: if A decomposes as a disjoint union of fibers of uniform size k over B, then |A| = k * |B|. This is the combinatorial engine of the ballot probability transfer."
+    },
+    {
+      "id": "compatibility",
+      "title": "Compatibility with Parent File's Explicit Form",
+      "startLine": 133,
+      "endLine": 145,
+      "summary": "Shows the explicit forall-forall disjointness form (used in BallotProblemOQ01OQ02OQ01.lean) follows from PairwiseDisjoint by lambda wrapping. Validates that upgrading the API to PairwiseDisjoint is purely additive."
+    },
+    {
+      "id": "concrete-example",
+      "title": "Concrete Example: Disjoint Pairs {2i, 2i+1}",
+      "startLine": 147,
+      "endLine": 169,
+      "summary": "Verifies the lemma on three disjoint pairs {0,1}, {2,3}, {4,5}. Disjointness proved by omega over set membership; uniform size 2 proved by Set.ncard_pair; result confirms 2 * 3 = 6 elements total."
+    },
+    {
+      "id": "mathlib-assessment",
+      "title": "Mathlib Contribution Assessment",
+      "startLine": 171,
+      "endLine": 200,
+      "summary": "Documents why the lemma is Mathlib-ready: not in Mathlib4, proof is ~10 lines, naming follows Mathlib conventions. Lists four use-case categories (ballot, cosets, graphs, probability) and recommends submission as Set.ncard_biUnion_of_uniform."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry extracts and generalizes the uniform-fiber cardinality lemma from the ballot problem chain into a Mathlib-ready standalone result. The six theorems collectively cover all natural index-set flavors (Set with Finite, Finset, Fintype, fiber decomposition) and are verified with 0 axioms and 0 sorries.",
+    "implications": "The ncard_biUnion_eq_of_uniform family is a low-hanging Mathlib contribution: short proofs, clear naming, no new typeclasses, and immediate applications in combinatorics, group theory, and probability. The fiber version ncard_eq_mul_of_uniform_fibers reframes uniform-fiber surjections as a pure cardinality identity, enabling cleaner probability transfer proofs like those in the ballot problem chain.",
+    "openQuestions": [
+      "What is the Mathlib PR process for contributing Set.ncard lemmas, and should the name be ncard_biUnion_of_uniform or ncard_biUnion_const?",
+      "Should the lemma be stated for Set.ncard or for Nat.card (more general, works for infinite types with the right finiteness hypothesis)?",
+      "Is there an analogous uniform version of Set.ncard_iUnion_of_disjoint for countably infinite index sets with the right summability condition?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "ballot-problem-oq-01-oq-02-oq-01",
+      "title": "Uniform Fiber Transfer for Multi-Candidate Ballot Theorem",
+      "relationship": "Parent proof where ncard_biUnion_eq_of_uniform was first developed for ballot fiber counting"
+    },
+    {
+      "id": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
+      "title": "General Uniform Fiber Transfer: uniformOn Preserved for All Events",
+      "relationship": "Sibling that uses uniform fiber cardinality to prove probability preservation for all events simultaneously"
+    },
+    {
+      "id": "ballot-problem-oq-01-oq-02",
+      "title": "Multi-Candidate Ballot Theorem",
+      "relationship": "Grandparent: the multi-candidate ballot result whose fiber structure motivated the uniform cardinality lemma"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean",
     "axiomCount": 0,


### PR DESCRIPTION
## Enrichment Pass: Uniform Fiber Cardinality (Mathlib Contribution)

**Target**: `ballot-problem-oq-01-oq-02-oq-01-oq-01`

### Changes

- **`index.ts` (new)**: Created required Vite entry point — without it the proof page showed "proof not found" on the live site
- **`annotations.json` (new)**: 7 annotations covering all proof sections with mathContext (LaTeX formulas), significance, relatedConcepts, prerequisites
- **`meta.json` (enriched)**:
  - Added `overview` with historicalContext (uniform fiber counting from coset theory to ballot problem), problemStatement, proofStrategy, and 5 keyInsights
  - Added `sections` array with startLine/endLine/summary for all 8 proof sections (imports, core lemma, Finset variant, Fintype version, fiber consequence, compatibility, concrete example, Mathlib assessment)
  - Added `conclusion` with summary, implications, and 3 openQuestions
  - Added `crossReferences` to parent (ballot-problem-oq-01-oq-02-oq-01), sibling (ballot-problem-oq-01-oq-02-oq-01-oq-02), and grandparent (ballot-problem-oq-01-oq-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)