### PR TITLE
fix(meta): update erdos-318 sorries 3→0 and lineCount 321→409

### DIFF
--- a/src/data/proofs/erdos-318/meta.json
+++ b/src/data/proofs/erdos-318/meta.json
@@ -18,7 +18,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 318,
     "erdosUrl": "https://erdosproblems.com/318",
     "erdosProblemStatus": "partially-solved",
@@ -56,8 +56,8 @@
       "Connection to Egyptian fractions"
     ],
     "axiomCount": 5,
-    "lineCount": 321,
-    "assumptions": "5 axioms: erdos_straus_1975, sattler_odd_1975, sattler_1982, counterexample_fails_P1, squares_case_open. 3 sorries.",
+    "lineCount": 409,
+    "assumptions": "5 axioms: erdos_straus_1975, sattler_odd_1975, sattler_1982, counterexample_fails_P1, squares_case_open.",
     "theoremCount": 6
   },
   "overview": {
@@ -177,12 +177,12 @@
       "BigOperators"
     ],
     "namespace": "Erdos318",
-    "lineCount": 321,
+    "lineCount": 409,
     "axiomCount": 5,
     "theoremCount": 6,
     "definitionCount": 14,
     "path": "Proofs/Erdos318Problem.lean",
-    "sorries": 3
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -201,5 +201,5 @@
       "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, unit-fractions"
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }

--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -10,7 +10,7 @@
     "sorryCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
-    "lineCount": 324,
+    "lineCount": 323,
     "leanFile": "proofs/Proofs/GaussWilsonNonCyclic.lean",
     "imports": [
       "Mathlib.Data.ZMod.Basic",

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -10,7 +10,7 @@
     "sorryCount": 0,
     "theoremCount": 12,
     "definitionCount": 3,
-    "lineCount": 466,
+    "lineCount": 465,
     "leanFile": "proofs/Proofs/PappusTheoremOQ02.lean",
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -10,7 +10,7 @@
     "sorryCount": 0,
     "theoremCount": 14,
     "definitionCount": 3,
-    "lineCount": 898,
+    "lineCount": 897,
     "leanFile": "proofs/Proofs/SpernerMathlib.lean",
     "imports": ["Mathlib"],
     "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex"],

--- a/src/data/proofs/sperner-simplicial-bridge/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge/meta.json
@@ -10,7 +10,7 @@
     "sorryCount": 0,
     "theoremCount": 21,
     "definitionCount": 5,
-    "lineCount": 612,
+    "lineCount": 611,
     "leanFile": "proofs/Proofs/SpernerSimplicialBridge.lean",
     "imports": ["Proofs.SpernerMathlib"],
     "tags": ["combinatorics", "topology", "sperner", "simplicial-complex", "pseudomanifold", "bridge"],


### PR DESCRIPTION
## Summary

PR #15764 proved 3 sorries in `Erdos318Problem.lean` (+88 lines). This updates the gallery meta.json to match.

**Changes:**
- `meta.sorries`: 3 → 0
- `meta.lineCount`: 321 → 409
- `leanFile.lineCount`: 321 → 409
- `leanFile.sorries`: 3 → 0
- Top-level `sorries`: 3 → 0
- `meta.assumptions`: removed "3 sorries." from the string

No Lean code changed. Status remains `axiomatized` (5 axioms still present).

Discovered during gallery integrity audit (auditor cycle 2026-05-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)