### PR TITLE
fix(birthday-oq01oq01): remove True stub, correct theoremCount/lineCount

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ01OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ01.lean
@@ -270,13 +270,14 @@ theorem variance_bounded_by_mean (n d : ℕ) (hd : 1 ≤ d) :
 theorem mean_positive (n d : ℕ) (hd : 0 < d) (hn : 2 ≤ n) :
     0 < expectedPairs n d := expectedPairs_pos n d hd hn
 
-/-- Summary of the distributional knowledge acquired:
-    For birthday assignment f : Fin n → Fin d:
-    - X(f) ∈ [0, C(n,2)]                              [collisionCount_le_choose_two]
-    - Pr(X = 0) = descFactorial d n / d^n              [zero_collision_fraction]
-    - E[X] = C(n,2)/d                                  [mean_collisionCount]
-    - Var(X) = C(n,2)·(d-1)/d²                        [variancePairs in OQ01]
-    - Var(X) ≤ E[X]                                    [variance_bounded_by_mean] -/
-theorem distribution_summary : True := trivial
+/-
+  Summary of the distributional knowledge acquired:
+  For birthday assignment f : Fin n → Fin d:
+  - X(f) ∈ [0, C(n,2)]                              [collisionCount_le_choose_two]
+  - Pr(X = 0) = descFactorial d n / d^n              [zero_collision_fraction]
+  - E[X] = C(n,2)/d                                  [mean_collisionCount]
+  - Var(X) = C(n,2)·(d-1)/d²                        [variancePairs in OQ01]
+  - Var(X) ≤ E[X]                                    [variance_bounded_by_mean]
+-/
 
 end BirthdayDistribution

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "",
-    "lineCount": 175,
-    "theoremCount": 6,
+    "lineCount": 200,
+    "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [
       "ncard_biUnion_eq_of_uniform: Set-indexed version with PairwiseDisjoint (Mathlib-ready form)",
@@ -133,8 +133,8 @@
     "path": "Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean",
     "axiomCount": 0,
     "sorryCount": 0,
-    "lineCount": 175,
-    "theoremCount": 6,
+    "lineCount": 200,
+    "theoremCount": 5,
     "definitionCount": 0
   }
 }

--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -22,8 +22,8 @@
     "leanFile": "proofs/Proofs/BirthdayProblemOQ01OQ01.lean",
     "sorryCount": 0,
     "definitionCount": 2,
-    "lineCount": 282,
-    "theoremCount": 15,
+    "lineCount": 283,
+    "theoremCount": 14,
     "assumptions": "None. All theorems fully proved including the double counting lemmas: card_ordered_pairs, card_funs_shared_birthday, and sum_collisionCount.",
     "mathlibDependencies": [
       {
@@ -150,8 +150,8 @@
   "leanFile": {
     "path": "Proofs/BirthdayProblemOQ01OQ01.lean",
     "filename": "BirthdayProblemOQ01OQ01.lean",
-    "lineCount": 282,
-    "theoremCount": 15,
+    "lineCount": 283,
+    "theoremCount": 14,
     "axiomCount": 0,
     "defCount": 2,
     "sorryCount": 0,

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
     "assumptions": "buDim_crt_semiprime: For distinct primes p, q, buDim(pq, d) ≤ max(buDim(p,d), buDim(q,d)). Motivated by CRT: ℤ/pqℤ ≅ ℤ/pℤ × ℤ/qℤ for distinct primes. Any ℤ/pqℤ-representation factors through the prime components via CRT. Estimated: ~200 lines using Smith theory for prime-order groups.",
-    "lineCount": 213,
-    "theoremCount": 9,
+    "lineCount": 212,
+    "theoremCount": 10,
     "definitionCount": 0,
     "originalContributions": [
       "buDim_prime_le_semiprime_left/right: lower bounds from buDim_mono (no new axioms)",
@@ -62,8 +62,8 @@
     "path": "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03.lean",
     "axiomCount": 1,
     "sorryCount": 0,
-    "lineCount": 213,
-    "theoremCount": 9,
+    "lineCount": 212,
+    "theoremCount": 10,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
## Summary

Removes the `theorem distribution_summary : True := trivial` placeholder stub from `BirthdayProblemOQ01OQ01.lean` and updates gallery counts.

## Problem

The True stub was triggering a **CRITICAL** integrity flag: `status: "verified"` with a True stub. Per gallery policy, True stubs are placeholders that do not constitute mathematical proofs.

## Fix

- Converted `theorem distribution_summary : True := trivial` to a plain block comment (the summary content itself is useful documentation)
- All 14 mathematical theorems remain fully verified (0 sorries, 0 axioms)
- Updated `meta.theoremCount`: 15 → 14
- Updated `meta.lineCount`: 282 → 283
- Updated `leanFile.theoremCount`: 15 → 14
- Updated `leanFile.lineCount`: 282 → 283

## Note

PR #15707 (audit fix for sorries 0→3) was based on a stale state. That PR should be closed since PR #15770 already proved those sorries, and this PR resolves the remaining True stub issue.

Discovered during gallery integrity audit (auditor cycle 2026-05-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)