### PR TITLE
fix(meta): add missing leanFile objects to 19 gallery proofs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
@@ -115,5 +115,20 @@
       "relationship": "related",
       "description": "Schönhage's HGCD algorithm — a more sophisticated recursive GCD with better asymptotic complexity"
     }
-  ]
+  ],
+  "leanFile": {
+    "path": "Proofs/BezoutIdentityOQ01OQ01OQ01.lean",
+    "lineCount": 242,
+    "theoremCount": 3,
+    "axiomCount": 2,
+    "definitionCount": 2,
+    "sorries": 0,
+    "namespace": "BezoutIdentityOQ01OQ01OQ01",
+    "imports": [
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Data.Nat.Log",
+      "Mathlib.Tactic",
+      "Proofs.BezoutIdentityOQ01OQ01"
+    ]
+  }
 }


### PR DESCRIPTION
## Fix

19 gallery proofs had `leanFile: null` in meta.json despite having valid Lean source files on disk. Added the missing `leanFile` object to each, populated with actual file stats.

## Evidence

**Before**: `"leanFile": null` (top-level field missing/null)
**After**: `"leanFile": { "path": "...", "lineCount": N, "theoremCount": N, ... }` (populated from actual source)

Each `leanFile` object was built by:
1. Reading the actual `.lean` file for `lineCount`, `theoremCount`, `axiomCount`, `sorries`, `namespace`, `imports`
2. Using the existing `meta.definitionCount` for `definitionCount` (more accurate for `noncomputable def` etc.)

All 19 proofs build cleanly (`pnpm build` passes).

## Proofs Fixed

- ballot-problem-oq-02-oq-02
- bezout-identity-oq-01-oq-01-oq-01 (2 axioms, status=axiomatized ✓)
- binomial-theorem-oq-04-oq-04
- borsuk-ulam-oq-03-oq-04
- circumference-via-differentiation
- erdos-31-primes-density
- fodor-pressing-down
- frobenius-number
- gauss-wilson-non-cyclic
- inclusion-exclusion-oq-03
- mean-value-theorem-oq-04
- minkowski-theorem-oq-02-oq-01
- pappus-theorem-oq-02
- picks-theorem-oq-01-oq-01
- sperner-mathlib
- sperner-mathlib4
- sperner-simplicial-bridge
- szemeredi-core-oq-01
- wilsons-theorem-oq-02-ext

---
Automated fix by lean-mechanic agent. Follows same pattern as #15497.