### PR TITLE
fix(birthday-problem-oq-01-oq-01): remove True stub + fix sorries=3→0

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ01OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ01.lean
@@ -270,13 +270,11 @@ theorem variance_bounded_by_mean (n d : ℕ) (hd : 1 ≤ d) :
 theorem mean_positive (n d : ℕ) (hd : 0 < d) (hn : 2 ≤ n) :
     0 < expectedPairs n d := expectedPairs_pos n d hd hn
 
-/-- Summary of the distributional knowledge acquired:
-    For birthday assignment f : Fin n → Fin d:
-    - X(f) ∈ [0, C(n,2)]                              [collisionCount_le_choose_two]
-    - Pr(X = 0) = descFactorial d n / d^n              [zero_collision_fraction]
-    - E[X] = C(n,2)/d                                  [mean_collisionCount]
-    - Var(X) = C(n,2)·(d-1)/d²                        [variancePairs in OQ01]
-    - Var(X) ≤ E[X]                                    [variance_bounded_by_mean] -/
-theorem distribution_summary : True := trivial
+-- Distributional knowledge summary:
+-- X(f) ∈ [0, C(n,2)]                              [collisionCount_le_choose_two]
+-- Pr(X = 0) = descFactorial d n / d^n              [zero_collision_fraction]
+-- E[X] = C(n,2)/d                                  [mean_collisionCount]
+-- Var(X) = C(n,2)·(d-1)/d²                        [variancePairs in OQ01]
+-- Var(X) ≤ E[X]                                    [variance_bounded_by_mean]
 
 end BirthdayDistribution

--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -22,8 +22,8 @@
     "leanFile": "proofs/Proofs/BirthdayProblemOQ01OQ01.lean",
     "sorryCount": 0,
     "definitionCount": 2,
-    "lineCount": 282,
-    "theoremCount": 15,
+    "lineCount": 280,
+    "theoremCount": 14,
     "assumptions": "None. All theorems fully proved including the double counting lemmas: card_ordered_pairs, card_funs_shared_birthday, and sum_collisionCount.",
     "mathlibDependencies": [
       {
@@ -150,8 +150,8 @@
   "leanFile": {
     "path": "Proofs/BirthdayProblemOQ01OQ01.lean",
     "filename": "BirthdayProblemOQ01OQ01.lean",
-    "lineCount": 282,
-    "theoremCount": 15,
+    "lineCount": 280,
+    "theoremCount": 14,
     "axiomCount": 0,
     "defCount": 2,
     "sorryCount": 0,
@@ -161,5 +161,5 @@
     ],
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01OQ01.lean"
   },
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- Remove True stub: `theorem distribution_summary : True := trivial` was a documentation placeholder causing CRITICAL flag (True stub while status: verified). Converted to plain comment block.
- Fix top-level `sorries: 3` → 0 (reflected stale Aristotle companion file sorries, not main proof file).
- Update lineCount 282→280, theoremCount 15→14 to match edited Lean file.

All 14 remaining theorems are fully proved. status: verified is now accurate.
Supersedes conflicting PRs #15707 and #15761 (both in CONFLICTING state against current main).

## Test plan
- [ ] find-targets.ts --issues no longer shows birthday-problem-oq-01-oq-01 as CRITICAL
- [ ] No sorry or `: True` in BirthdayProblemOQ01OQ01.lean
- [ ] pnpm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)