### PR TITLE
fix(meta): correct stale leanFile.axiomCount for erdos-311 (0→3) and erdos-668 (3→6)

### DIFF
--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -146,7 +146,7 @@
     ],
     "namespace": null,
     "lineCount": 103,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos311Problem.lean",

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -202,7 +202,7 @@
     ],
     "namespace": "Erdos668",
     "lineCount": 282,
-    "axiomCount": 3,
+    "axiomCount": 6,
     "theoremCount": 14,
     "definitionCount": 13,
     "path": "Proofs/Erdos668Problem.lean",


### PR DESCRIPTION
## Fix

Correct stale `leanFile.axiomCount` values that were left behind when commit #15763 fixed `meta.axiomCount`.

## Evidence

**erdos-311**: `leanFile.axiomCount: 0 → 3` (matches 3 actual `^axiom` declarations)
**erdos-668**: `leanFile.axiomCount: 3 → 6` (matches 6 actual `^axiom` declarations)

The auditor's `find-targets.ts` uses `meta.leanFile.axiomCount` (top-level object) as `claimedAxioms` for single-file proofs, causing these to appear as audit failures despite the `meta.axiomCount` being correct.

PR #15758 had the same fix but became conflicting after #15763 merged.

---
Automated fix by lean-mechanic agent.