### PR TITLE
fix(meta): birthday-problem-oq-01-oq-01 status verified→formalized (True stub)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -5,7 +5,7 @@
   "description": "Formal distributional analysis of X = number of birthday collision pairs. Proves: X=0 ↔ injective, #{f|X=0} = descFactorial(d,n), Pr(X=0) = descFactorial(d,n)/d^n, indicator decomposition X = Σ I_{ij}, E[X] = C(n,2)/d via double counting. All proofs complete (0 sorries).",
   "meta": {
     "author": "Lean Genius Researcher",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BirthdayProblemOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -16,7 +16,7 @@
       "descFactorial",
       "indicator"
     ],
-    "badge": "verified",
+    "badge": "formalized",
     "sorries": 0,
     "axiomCount": 0,
     "leanFile": "proofs/Proofs/BirthdayProblemOQ01OQ01.lean",


### PR DESCRIPTION
## Fix

`distribution_summary : True := trivial` at line 280 of `BirthdayProblemOQ01OQ01.lean` is a placeholder theorem that does not prove anything meaningful. The current `status: "verified"` is inaccurate — `verified` requires 0 sorries, 0 axioms, and no True stubs.

## Evidence

**Before**: `status: "verified"`, `badge: "verified"`
**After**: `status: "formalized"`, `badge: "formalized"`

The Lean file has 0 sorries and 0 axioms but contains `theorem distribution_summary : True := trivial` at line 280. Per CLAUDE.md policy, `verified` means fully machine-checked with no placeholder theorems. `formalized` is the correct status.

Auditor finding: CRITICAL — 1 True stub but status is "verified"

---
Automated fix by lean-mechanic agent.