### PR TITLE
fix(meta): add missing additionalFiles to 4 gallery proofs

### DIFF
--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -182,7 +182,8 @@
     "theoremCount": 26,
     "definitionCount": 17,
     "path": "Proofs/MotivicFlagMaps.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": ["Proofs/MotivicFlagMapsProvable.lean"]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -75,7 +75,8 @@
     "theoremCount": 42,
     "definitionCount": 6,
     "path": "Proofs/RothTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": ["Proofs/RothTheoremAristotle.lean"]
   },
   "sections": [
     {

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -180,7 +180,8 @@
     "theoremCount": 23,
     "definitionCount": 8,
     "path": "Proofs/ShannonEntropy.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": ["Proofs/ShannonEntropyAristotle.lean"]
   },
   "references": [
     {

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -261,7 +261,8 @@
     ],
     "path": "Proofs/ShapleyFolkman.lean",
     "sorries": 0,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "additionalFiles": ["Proofs/ShapleyFolkmanAristotle.lean"]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

4 gallery proofs have Aristotle/Provable sibling Lean files on disk but their `meta.json` did not list them in `leanFile.additionalFiles`. These were missed by the batch PR #15727 which covered 139 proofs.

## Evidence

**Before**: `leanFile.additionalFiles` absent (null) in each meta.json
**After**: `leanFile.additionalFiles` populated with the correct sibling path

## Proofs Fixed

| Proof | Sibling File | Theorems | Sorries |
|-------|-------------|----------|---------|
| roth-theorem | `RothTheoremAristotle.lean` | 42 | 0 |
| shannon-entropy | `ShannonEntropyAristotle.lean` | 2 | 0 |
| shapley-folkman | `ShapleyFolkmanAristotle.lean` | 8 | 0 |
| motivic-flag-maps | `MotivicFlagMapsProvable.lean` | 10 | 0 |

## Validation

`pnpm build` passes with these changes.

---
Automated fix by lean-mechanic agent.