### PR TITLE
fix(meta): correct stale lineCount/theoremCount for 2 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "",
-    "lineCount": 175,
-    "theoremCount": 6,
+    "lineCount": 200,
+    "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [
       "ncard_biUnion_eq_of_uniform: Set-indexed version with PairwiseDisjoint (Mathlib-ready form)",
@@ -133,8 +133,8 @@
     "path": "Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean",
     "axiomCount": 0,
     "sorryCount": 0,
-    "lineCount": 175,
-    "theoremCount": 6,
+    "lineCount": 200,
+    "theoremCount": 5,
     "definitionCount": 0
   }
 }

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
     "assumptions": "buDim_crt_semiprime: For distinct primes p, q, buDim(pq, d) ≤ max(buDim(p,d), buDim(q,d)). Motivated by CRT: ℤ/pqℤ ≅ ℤ/pℤ × ℤ/qℤ for distinct primes. Any ℤ/pqℤ-representation factors through the prime components via CRT. Estimated: ~200 lines using Smith theory for prime-order groups.",
-    "lineCount": 213,
-    "theoremCount": 9,
+    "lineCount": 212,
+    "theoremCount": 10,
     "definitionCount": 0,
     "originalContributions": [
       "buDim_prime_le_semiprime_left/right: lower bounds from buDim_mono (no new axioms)",
@@ -62,8 +62,8 @@
     "path": "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03.lean",
     "axiomCount": 1,
     "sorryCount": 0,
-    "lineCount": 213,
-    "theoremCount": 9,
+    "lineCount": 212,
+    "theoremCount": 10,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
## Summary

Counts in `meta.json` drifted from the actual Lean source files on `origin/main`. This PR updates both the `meta.*` and `leanFile.*` blocks for each entry to match `git show origin/main:proofs/Proofs/<Name>.lean`.

| Entry | Field | Old | New |
|-------|-------|-----|-----|
| `ballot-problem-oq-01-oq-02-oq-01-oq-01` | `lineCount` | 175 | 200 |
| `ballot-problem-oq-01-oq-02-oq-01-oq-01` | `theoremCount` | 6 | 5 |
| `borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03` | `lineCount` | 213 | 212 |
| `borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03` | `theoremCount` | 9 | 10 |

## Verification

```bash
$ git show origin/main:proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean | wc -l
     200
$ git show origin/main:proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean | grep -cE "^(theorem|lemma) "
5

$ git show origin/main:proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03.lean | wc -l
     212
$ git show origin/main:proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03.lean | grep -cE "^(theorem|lemma) "
10
```

## Test plan

- [x] JSON files validate (`python3 -c "import json; json.load(...)"`)
- [x] No Lean code changes
- [x] Both `meta.*` and `leanFile.*` blocks updated consistently within each file

🤖 Generated with [Claude Code](https://claude.com/claude-code)