### PR TITLE
research(bertrands-postulate-oq-03-oq-04-oq-01): Cramér implies all positive-exponent prime gap conjectures

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -161,6 +161,7 @@ import Proofs.BertrandsPostulate
 import Proofs.BertrandsPostulateOQ03
 import Proofs.BertrandsPostulateOQ03OQ04
 import Proofs.BertrandsPostulateOQ03OQ04Aristotle
+import Proofs.BertrandsPostulateOQ03OQ04OQ01
 import Proofs.BertrandsPostulateOQ03OQ04OQ03
 import Proofs.BezoutIdentity
 import Proofs.BezoutIdentityOQ01

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 60 },
+    "type": "concept",
+    "title": "Cramér's Conjecture as a Universal Gap Bound",
+    "content": "This file answers: if Cramér's conjecture holds (prime gaps are $O(\\log^2 p)$), does this force a prime into every interval $[x, x + x^\\varepsilon]$ for any $\\varepsilon > 0$?\n\nThe answer is **yes**, and the proof has a single analytic core: $\\log^2(x) = o(x^\\varepsilon)$ for every $\\varepsilon > 0$. This asymptotic — proved rigorously from `isLittleO_log_rpow_atTop` — is what converts a *logarithmic* gap bound into a *power* gap guarantee.\n\nThe structure is:\n1. Prove $C \\cdot \\log^2(n) < n^\\varepsilon$ eventually for any $C, \\varepsilon > 0$ (analytic)\n2. Apply a single bridge axiom to convert Cramér's nth-prime formulation to an interval bound\n3. Chain: Cramér gap ≤ C·log² < x^ε → prime exists in [x, x+x^ε]\n4. Cover small x with BHP (unconditional ε = 0.525)",
+    "mathContext": "The PrimeGapConjecture(ε) predicate asserts: for all $x \\geq 2$, there exists a prime $p$ with $x \\leq p \\leq x + x^\\varepsilon$. Baker-Harman-Pintz (2001) proved this for $\\varepsilon = 0.525$; under Cramér it holds for all $\\varepsilon > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Cramér's conjecture", "PrimeGapConjecture", "isLittleO", "Baker-Harman-Pintz"],
+    "prerequisites": ["BertrandsPostulateOQ03", "BertrandsPostulateOQ03OQ04", "PrimeNumberTheorem"]
+  },
+  {
+    "id": "ann-log-sq-asymptotic",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-01",
+    "range": { "startLine": 70, "endLine": 119 },
+    "type": "technique",
+    "title": "Proving log²(n) = o(n^ε) via isLittleO Squaring",
+    "content": "The lemma `log_sq_lt_rpow_eventually` proves: for any $C > 0$ and $\\varepsilon > 0$,\n$$C \\cdot \\log(n)^2 < n^\\varepsilon \\quad \\text{for all sufficiently large } n.$$\n\nThe proof uses Mathlib's `isLittleO_log_rpow_atTop` with exponent $\\varepsilon/4$: $\\log(n) = O(n^{\\varepsilon/4})$, so $|\\log(n)| \\leq \\frac{1}{2} n^{\\varepsilon/4}$ eventually. Squaring gives $\\log(n)^2 \\leq \\frac{1}{4} n^{\\varepsilon/2}$. For large $n$, $n^{\\varepsilon/2} \\geq C$, so $C \\cdot \\log^2(n) \\leq \\frac{C}{4} \\cdot n^{\\varepsilon/2} < n^{\\varepsilon/2} \\cdot n^{\\varepsilon/2} = n^\\varepsilon$.\n\nThe `max` threshold combines: the little-o threshold $N_1$ and $\\lceil C^{2/\\varepsilon} \\rceil$ (ensuring $n^{\\varepsilon/2} \\geq C$).",
+    "mathContext": "$\\log(n) = o(n^{\\varepsilon/4})$ is `isLittleO_log_rpow_atTop hε4`. Squaring: $\\log^2 = o(n^{\\varepsilon/2})$. Since $n^{\\varepsilon/2} \\to \\infty$, it exceeds $C$ eventually. Then $C\\log^2 < n^{\\varepsilon/2} \\cdot n^{\\varepsilon/2} = n^\\varepsilon$.",
+    "significance": "key",
+    "relatedConcepts": ["isLittleO_log_rpow_atTop", "rpow_add", "Nat.ceil", "Filter.eventually_atTop"],
+    "prerequisites": ["Real.isLittleO_log_rpow_atTop", "rpow_le_rpow", "mul_le_mul"]
+  },
+  {
+    "id": "ann-bridge-axiom",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-01",
+    "range": { "startLine": 121, "endLine": 163 },
+    "type": "concept",
+    "title": "The Bridge Axiom: nth-Prime Formulation → Interval Formulation",
+    "content": "Cramér's conjecture is naturally stated in terms of the *nth prime*: $p_{n+1} - p_n = O(\\log^2 p_n)$. The `PrimeGapConjecture` predicate is an *interval* statement: $\\exists$ prime in $[x, x+x^\\varepsilon]$.\n\nThe bridge axiom `cramer_implies_nextPrime_bound` converts between these. Mathematically, if $p_n \\leq x < p_{n+1}$ then nextPrime$(x) = p_{n+1}$ and:\n$$p_{n+1} - x \\leq p_{n+1} - p_n \\leq C \\cdot \\log^2(p_n) \\leq C \\cdot \\log^2(x).$$\nSo nextPrime$(x) \\leq x + C\\log^2(x)$.\n\nThis is axiomatized rather than proved because formalizing the index $n = \\#\\{\\text{primes} \\leq x\\}$ as a function of $x$ requires `Nat.count`/`Nat.nth` API that is technically involved but mathematically routine.",
+    "mathContext": "The axiom takes the Cramér hypothesis as a $\\exists C > 0$ quantified statement over `Nat.nth Nat.Prime` and produces the nextPrimeFrom bound. This is a consequence of monotonicity of primes and the inequality $p_n \\leq x$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.nth", "Nat.Prime", "cramer_conjecture", "nextPrimeFrom"],
+    "prerequisites": ["Nat.infinite_setOf_prime", "Nat.find_spec"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-01",
+    "range": { "startLine": 165, "endLine": 230 },
+    "type": "technique",
+    "title": "Chaining Bounds: Cramér → Existence in [x, x+x^ε]",
+    "content": "The main proof of `cramer_implies_primeGapConjecture` combines three ingredients:\n\n1. **Cramér bound**: nextPrime$(x) \\leq x + C\\log^2(x)$ (bridge axiom, for $x \\geq 2$)\n2. **Asymptotic**: $C\\log^2(x) < x^\\varepsilon$ for $x \\geq N$ (log-sq lemma)\n3. **BHP base case**: PrimeGapConjecture$(0.525)$ unconditionally (parent entry)\n\nFor $\\varepsilon \\geq 0.525$: `prime_gap_conjecture_monotone` gives the result directly from BHP.\n\nFor $\\varepsilon < 0.525$: `cramer_implies_primeGapConjecture_eventually` gives a threshold $N$ beyond which Cramér works. Below $N$, BHP covers all $x \\geq 2$. The case split on `x ≥ N` joins these two halves.\n\nThe proof of the eventual form is a direct `calc`:\n$$\\text{nextPrime}(x) \\leq x + C\\log^2(x) \\leq x + x^\\varepsilon.$$",
+    "mathContext": "The combination `by_cases h : ε ≥ 0.525` splits into two proofs. For the sub-0.525 case, `Filter.eventually_atTop` extracts threshold $N$; `by_cases hxN : x ≥ N` handles the two regions.",
+    "significance": "key",
+    "relatedConcepts": ["prime_gap_conjecture_monotone", "prime_gap_conjecture_bhp", "Filter.eventually_atTop", "by_cases"],
+    "prerequisites": ["cramer_conjecture", "BertrandsPostulateOQ03.prime_gap_conjecture_bhp"]
+  },
+  {
+    "id": "ann-density-gap",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-01",
+    "range": { "startLine": 232, "endLine": 257 },
+    "type": "concept",
+    "title": "Existence vs Density: The Gap That Cramér Cannot Close",
+    "content": "The `cramer_hierarchy` theorem crystallizes what is known and unknown:\n\n- **Proved (BHP)**: PrimeGapConjecture(0.525) — unconditional\n- **Proved here (Cramér)**: PrimeGapConjecture(ε) for all ε > 0 — conditional on Cramér\n- **Open**: PrimeGapConjecture(0) — constant-sized gaps (twin prime conjecture territory)\n- **Open**: ShortIntervalPNT(ε) for ε < 1 — even under Cramér's conjecture\n\nThe key gap: `existence_is_weaker_than_density` shows ShortIntervalPNT → PrimeGapConjecture eventually (from the parent), but NOT the converse. Gap bounds control the *maximum* spacing but not the *equidistribution* of primes. Proving density in $[x, x+x^\\varepsilon]$ requires Montgomery-type conjectures on the pair correlation of zeros of ζ(s).",
+    "mathContext": "ShortIntervalPNT(ε) asserts $\\pi(x+x^\\varepsilon) - \\pi(x) \\sim x^\\varepsilon/\\log(x)$. PrimeGapConjecture(ε) asserts only that the count is $\\geq 1$. The ratio can be as small as 0 in the weaker statement.",
+    "significance": "supporting",
+    "relatedConcepts": ["ShortIntervalPNT", "PrimeGapConjecture", "cramer_hierarchy", "density vs existence"],
+    "prerequisites": ["shortIntervalPNT_implies_primeGapConjecture_eventually", "BertrandsPostulateOQ03OQ04"]
+  }
+]

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/index.ts
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BertrandsPostulateOQ03OQ04OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bertrandsPostulateOQ03OQ04OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bertrandsPostulateOQ03OQ04OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bertrandsPostulateOQ03OQ04OQ01Data: ProofData = {
+  proof: bertrandsPostulateOQ03OQ04OQ01Proof,
+  annotations: bertrandsPostulateOQ03OQ04OQ01Annotations,
+}
+
+export default bertrandsPostulateOQ03OQ04OQ01Data

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/meta.json
@@ -1,0 +1,81 @@
+{
+  "id": "bertrands-postulate-oq-03-oq-04-oq-01",
+  "title": "Cramér's Conjecture Implies All Positive-Exponent Prime Gap Conjectures",
+  "slug": "bertrands-postulate-oq-03-oq-04-oq-01",
+  "description": "Proves that Cramér's conjecture (prime gaps are O(log² p)) implies PrimeGapConjecture(ε) for every ε > 0: for any positive exponent, the interval [x, x + x^ε] eventually contains a prime. The key asymptotic is log²(x) = o(x^ε), proved rigorously via `isLittleO_log_rpow_atTop`. Combined with Baker-Harman-Pintz (BHP 2001) for small x, this yields an unconditional result for ε ≥ 0.525 and a Cramér-conditional result for all ε > 0. The file also establishes the density gap: PrimeGapConjecture (existence) is strictly weaker than ShortIntervalPNT (density).",
+  "meta": {
+    "author": "Cramér (1936), Baker-Harman-Pintz (2001)",
+    "date": "2026-05-04",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/BertrandsPostulateOQ03OQ04OQ01.lean",
+    "tags": [
+      "number-theory",
+      "prime-numbers",
+      "prime-gaps",
+      "analytic-number-theory",
+      "cramer-conjecture",
+      "prime-gap-conjecture",
+      "asymptotics",
+      "open-question",
+      "conditional"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-05-04",
+    "axiomCount": 1,
+    "assumptions": "cramer_implies_nextPrime_bound: The bridge from Cramér's nth-prime gap formulation to the interval formulation. Mathematically routine but technically involved: if gap p_{n+1}-p_n ≤ C·log(p_n)² then nextPrime(x) ≤ x + C·log(x)². Deferred to avoid Nat.nth/Nat.count index arithmetic.",
+    "lineCount": 257,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "originalContributions": [
+      "log_sq_lt_rpow_eventually: ∀ε>0, ∀C>0, C·log(n)² < n^ε eventually — proved via isLittleO_log_rpow_atTop",
+      "nextPrimeFrom: definition of the next prime ≥ x using Nat.infinite_setOf_prime.exists_gt",
+      "cramer_implies_primeGapConjecture_eventually: Cramér → ∃ prime in [x, x+x^ε] for all sufficiently large x",
+      "cramer_implies_primeGapConjecture: full result combining eventual Cramér bound with BHP for small x",
+      "existence_is_weaker_than_density: ShortIntervalPNT → PrimeGapConjecture eventually (one-way implication)",
+      "cramer_hierarchy: summary theorem consolidating BHP, Cramér, and RH conditional density results"
+    ],
+    "proofStrategy": "The central asymptotic log²(x) = o(x^ε) is established via isLittleO_log_rpow_atTop: log(x) = o(x^(ε/4)), squaring gives log²(x) = o(x^(ε/2)), then for large x the factor x^(ε/2) dominates C. A single bridge axiom converts Cramér's nth-prime gap bound to an interval bound on nextPrime(x). Combining: nextPrime(x) ≤ x + C·log²(x) < x + x^ε for large x. For small x (below the eventual threshold), BHP guarantees a prime in [x, x+x^0.525] ⊆ [x, x+x^ε] for ε ≥ 0.525; for ε < 0.525, BHP covers small x and Cramér covers large x.",
+    "openQuestions": [
+      "Can Cramér's conjecture itself be proved in Lean, or is it accessible via probabilistic models of prime gaps?",
+      "Can ShortIntervalPNT(ε) for ε < 1 be proved, even conditionally on RH? (Currently only ε > 1/2 is known under RH.)",
+      "Does the converse hold: does PrimeGapConjecture(ε) for all ε > 0 imply Cramér's conjecture?"
+    ],
+    "sections": [
+      {
+        "title": "Key Asymptotic: log² = o(x^ε)",
+        "content": "For any ε > 0 and constant C > 0, the bound C · log(n)² eventually falls below n^ε. The proof uses `isLittleO_log_rpow_atTop` from Mathlib: log = o(x^(ε/4)), so log² = o(x^(ε/2)). For large n, the factor n^(ε/2) exceeds C, giving C · log²(n) < n^ε. This is the analytic engine for the main theorem.",
+        "startLine": 62,
+        "endLine": 119,
+        "theorems": ["log_sq_lt_rpow_eventually"]
+      },
+      {
+        "title": "Next-Prime Definition and Bridge Axiom",
+        "content": "nextPrimeFrom(x) is the smallest prime ≥ x, defined via Nat.infinite_setOf_prime.exists_gt. The bridge axiom cramer_implies_nextPrime_bound converts Cramér's nth-prime formulation to an interval bound: Cramér gap p_{n+1}-p_n ≤ C·log²(p_n) implies nextPrime(x) ≤ x + C·log²(x). This avoids technical Nat.nth index manipulation while preserving mathematical substance.",
+        "startLine": 121,
+        "endLine": 163,
+        "theorems": ["nextPrimeFrom_prime", "nextPrimeFrom_ge", "cramer_implies_nextPrime_bound"]
+      },
+      {
+        "title": "Main Theorem: Cramér → PrimeGapConjecture(ε) for All ε > 0",
+        "content": "cramer_implies_primeGapConjecture_eventually proves existence eventually: for any ε > 0, for all large enough x, there is a prime in [x, x+x^ε]. The proof chains the bridge axiom with the log² asymptotic: nextPrime(x) ≤ x + C·log²(x) < x + x^ε for large x. The full cramer_implies_primeGapConjecture extends this to ALL x ≥ 2 by using BHP (0.525 unconditional) for small x.",
+        "startLine": 165,
+        "endLine": 230,
+        "theorems": ["cramer_implies_primeGapConjecture_eventually", "cramer_implies_primeGapConjecture"]
+      },
+      {
+        "title": "The Density Gap and Hierarchy",
+        "content": "PrimeGapConjecture(ε) guarantees EXISTENCE of a prime in [x, x+x^ε]; ShortIntervalPNT(ε) requires COUNT ≈ x^ε/log(x). The converse of existence_is_weaker_than_density is not known: gap bounds alone do not control density. cramer_hierarchy summarizes: BHP gives ε ≥ 0.525 unconditionally; Cramér gives all ε > 0; RH gives density for ε > 0 (from parent entry).",
+        "startLine": 232,
+        "endLine": 257,
+        "theorems": ["existence_is_weaker_than_density", "cramer_hierarchy"]
+      }
+    ],
+    "mathContext": {
+      "field": "Analytic Number Theory",
+      "keyTheorem": "Cramér (1936): Prime gaps satisfy p_{n+1} - p_n = O(log² p_n), conjecturally. This implies the interval [x, x+x^ε] contains a prime for any ε > 0 and sufficiently large x.",
+      "historicalBackground": "Cramér (1936) proposed the probabilistic model treating primes as independent Bernoulli trials with probability 1/log(p), predicting maximum prime gaps of size O(log² p). Baker-Harman-Pintz (2001) proved unconditionally that gaps are O(x^0.525). The combination: unconditional up to ε = 0.525, Cramér-conditional for all ε > 0.",
+      "significance": "Fills the gap between the BHP unconditional exponent (0.525) and the conjectured optimal (ε → 0). Shows that Cramér's conjecture — widely believed but unproved — would resolve all positive-exponent prime gap questions simultaneously."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds gallery entry for an existing proof (already on main) that was missing its gallery metadata.

**Proof file**: `BertrandsPostulateOQ03OQ04OQ01.lean` (already on `origin/main`, 257 lines)  
**Gallery**: `src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/` (new)  
**Status**: `axiomatized` | 1 axiom | 0 sorries | 7 theorems | 1 definition

### Mathematical Content

**Central result**: Cramér's conjecture (prime gaps are $O(\log^2 p)$) implies PrimeGapConjecture(ε) for **every** ε > 0.

Key theorems:
- `log_sq_lt_rpow_eventually`: $C \cdot \log^2(n) < n^\varepsilon$ eventually — proved via `isLittleO_log_rpow_atTop`
- `cramer_implies_primeGapConjecture_eventually`: Cramér → ∃ prime in $[x, x+x^\varepsilon]$ for all large $x$
- `cramer_implies_primeGapConjecture`: full result using BHP (0.525 unconditional) for small $x$
- `cramer_hierarchy`: consolidates BHP / Cramér / RH conditional density hierarchy
- `existence_is_weaker_than_density`: ShortIntervalPNT → PrimeGapConjecture (not converse)

### Single Axiom

`cramer_implies_nextPrime_bound`: converts Cramér's nth-prime formulation to an interval bound on nextPrime(x). Mathematically routine (follows from $p_n \leq x < p_{n+1}$ and gap bound), deferred to avoid `Nat.nth`/`Nat.count` index API complexity.

### Changes

- `proofs/Proofs.lean`: added `import Proofs.BertrandsPostulateOQ03OQ04OQ01`
- `src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/meta.json`: full metadata
- `src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/annotations.json`: 5 annotations
- `src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/index.ts`: TypeScript exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)