### PR TITLE
fix(meta): correct lineCount in amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-05-04",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 182,
+    "lineCount": 186,
     "theoremCount": 3,
     "definitionCount": 1,
     "assumptions": "No sorries, no axiom declarations. All results proved from Mathlib foundations via induction. Imports AmgmInequalityOQ02 for the elemSymm definition and elemSymm_succ (variable-adding recurrence).",
@@ -152,7 +152,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean",
-    "lineCount": 182,
+    "lineCount": 186,
     "theoremCount": 3,
     "definitionCount": 1,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

- Corrects `meta.lineCount` and `leanFile.lineCount` from 182 to 186 in `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json`
- The actual Lean file (`AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean`) has 186 lines; meta.json was stale at 182

## Evidence

```
$ git show origin/research/amgm-newton-girard-independent:proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean | wc -l
186
```

All critical claims remain correct: `sorries: 0`, `axiomCount: 0`, `badge: original`, `status: verified`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)