### PR TITLE
fix(meta): correct stale lineCount/theoremCount/defCount in bounded-prime-gaps-oq-01-oq-03

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
@@ -9,9 +9,9 @@
     "status": "axiomatized",
     "badge": "axiom",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ01OQ03.lean",
-    "lineCount": 245,
-    "theoremCount": 14,
-    "defCount": 1,
+    "lineCount": 155,
+    "theoremCount": 9,
+    "defCount": 0,
     "axiomCount": 1,
     "sorries": 0,
     "tags": [
@@ -158,9 +158,9 @@
   ],
   "leanFile": {
     "path": "Proofs/BoundedPrimeGapsOQ01OQ03.lean",
-    "lineCount": 245,
-    "theoremCount": 14,
-    "defCount": 1,
+    "lineCount": 155,
+    "theoremCount": 9,
+    "defCount": 0,
     "axiomCount": 1,
     "sorryCount": 0
   },


### PR DESCRIPTION
## Summary

- Corrects stale metadata in `bounded-prime-gaps-oq-01-oq-03/meta.json`
- `lineCount`: 245 → 155 (actual line count of `BoundedPrimeGapsOQ01OQ03.lean`)
- `theoremCount`: 14 → 9 (actual theorem count)
- `defCount`: 1 → 0 (file has no `def` declarations)
- Changes apply to both `meta` block and `leanFile` block

## Evidence

```
$ git show origin/main:proofs/Proofs/BoundedPrimeGapsOQ01OQ03.lean | wc -l
155

$ git show origin/main:proofs/Proofs/BoundedPrimeGapsOQ01OQ03.lean | grep -c "^theorem "
9
```

Critical claims remain correct: `status: axiomatized`, `badge: axiom`, `sorries: 0`, `axiomCount: 1` (via inherited `engelsma_lower_bound` from `BoundedPrimeGapsOQ03`).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)