### PR TITLE
fix(meta): correct leanFile.theoremCount/definitionCount for erdos-671

### DIFF
--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -70,7 +70,7 @@
     "axiomCount": 3,
     "lineCount": 397,
     "assumptions": "3 axiom(s) and 7 sorry(s). See the Lean source for details.",
-    "theoremCount": 18
+    "theoremCount": 14
   },
   "overview": {
     "historicalContext": "**Erdos Problem #671**\n\nThis is a deep problem in approximation theory about the relationship between the Lebesgue function and Lagrange interpolation convergence.\n\n**Key History:**\n- 1931: Bernstein proves lambda_n(x) diverges at some point for any interpolation scheme\n- 1980: Erdos and Vertesi prove that for any points, some continuous f has |L^n f(x)| -> infinity a.e.\n- Present: Questions 1 and 2 remain open with $250 prize\n\n**Mathematical Context:**\nThe Lebesgue function lambda_n(x) = sum |p_i^n(x)| controls interpolation error: the error is bounded by (1 + Lambda_n) times the best polynomial approximation. When Lambda_n grows, uniform convergence fails. The questions ask whether *pointwise* convergence can still occur when lambda_n diverges.",
@@ -152,8 +152,8 @@
     "namespace": null,
     "lineCount": 397,
     "axiomCount": 3,
-    "theoremCount": 18,
-    "definitionCount": 11,
+    "theoremCount": 14,
+    "definitionCount": 12,
     "sorries": 7,
     "path": "Proofs/Erdos671Problem.lean",
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Corrects two stale leanFile counts in `src/data/proofs/erdos-671/meta.json`.

## Evidence

**theoremCount**
- Before: 18
- After: 14
- Verification: `grep -c "^theorem \|^lemma " proofs/Proofs/Erdos671Problem.lean` = 14
- Root cause: research PR #15458 set an incorrect value; the file has always had 14 public theorems

**definitionCount**
- Before: 11
- After: 12
- Verification: `grep -c "^def \|^noncomputable def \|^abbrev \|^opaque " proofs/Proofs/Erdos671Problem.lean` = 12
- Root cause: three new definitions were added in research PRs (#15444, #15458) but definitionCount was only updated to 11 instead of 12

Note: `meta.theoremCount` (line 73) also corrected to match `leanFile.theoremCount`.

---
Automated fix by lean-mechanic agent.