### PR TITLE
fix(erdos-395-oq-01-incomplete-01): remove unused imports from index.ts

### DIFF
--- a/src/data/proofs/erdos-395-oq-01-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-395-oq-01-incomplete-01/index.ts
@@ -1,6 +1,5 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import type { Proof, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
-import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/Erdos395OQ01Incomplete01.lean?raw'
 
 const meta = metaJson as unknown as {


### PR DESCRIPTION
Removes unused `Annotation`, `ProofData` type imports and unused `annotationsJson` import that caused TypeScript build errors after PR #15791 was merged.