### PR TITLE
fix(meta): add missing leanFile blocks and fix stale counts in 7 gallery entries

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -17,34 +17,62 @@
       "Mathlib.Data.List.Basic",
       "Mathlib.Tactic"
     ],
-    "tags": ["number-theory", "geometry", "lattice", "picks-theorem", "triangulation"],
+    "tags": [
+      "number-theory",
+      "geometry",
+      "lattice",
+      "picks-theorem",
+      "triangulation"
+    ],
     "assumptions": [],
-    "sorries": 0
+    "sorries": 0,
+    "proofRepoPath": "Proofs/PicksTheoremOQ01OQ01.lean"
   },
   "sections": [
     {
       "id": "definitions",
       "title": "Lattice Triangle Definitions",
       "description": "LatticeTriangle (three ℤ² vertices), LatticeTriangle.det (signed determinant = twice signed area), LatticeTriangle.IsPrimitive (|det|=1), LatticeTriangle.NonDegenerate (det≠0), splitLeft and splitRight (subdivide a triangle by introducing a midpoint on an edge).",
-      "theorems": ["LatticeTriangle", "LatticeTriangle.det", "LatticeTriangle.IsPrimitive", "LatticeTriangle.NonDegenerate", "splitLeft", "splitRight"]
+      "theorems": [
+        "LatticeTriangle",
+        "LatticeTriangle.det",
+        "LatticeTriangle.IsPrimitive",
+        "LatticeTriangle.NonDegenerate",
+        "splitLeft",
+        "splitRight"
+      ]
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties and Concrete Examples",
       "description": "Primitivity implies non-degeneracy (IsPrimitive.nonDegenerate), verification that the standard unit triangle {(0,0),(1,0),(0,1)} and the other unit triangle {(0,0),(1,0),(1,1)} are primitive (unit_triangle_primitive, second_unit_triangle_primitive), plus concrete examples for triangles with det=2 and det=12.",
-      "theorems": ["IsPrimitive.nonDegenerate", "unit_triangle_primitive", "second_unit_triangle_primitive", "det2_split_correct", "det12_two_splits", "det_add_example"]
+      "theorems": [
+        "IsPrimitive.nonDegenerate",
+        "unit_triangle_primitive",
+        "second_unit_triangle_primitive",
+        "det2_split_correct",
+        "det12_two_splits",
+        "det_add_example"
+      ]
     },
     {
       "id": "det-additivity",
       "title": "Edge-Splitting Det Additivity",
       "description": "When a triangle is split by a midpoint M on edge v1-v2 with gcd(v2-v1)=g: det(left)+det(right) = det(original) (edge_split_det_add), and natAbs(det(left))+natAbs(det(right)) = natAbs(det(original)) when g divides det (edge_split_det_natAbs_sum). This additivity is the key invariant for the inductive step.",
-      "theorems": ["edge_split_det_add", "edge_split_det_natAbs_sum"]
+      "theorems": [
+        "edge_split_det_add",
+        "edge_split_det_natAbs_sum"
+      ]
     },
     {
       "id": "main-theorem",
       "title": "Primitive Triangulation Existence",
       "description": "The main results: exists_reduction (for |det|>1, one edge-split reduces |det| strictly — proved via the Euclidean algorithm on edge GCDs), exists_primitive_triangulation (strong induction on |det|: a triangle with |det|=n has a primitive triangulation of size n), and has_primitive_triangulation (any non-degenerate lattice triangle has a primitive triangulation).",
-      "theorems": ["exists_reduction", "exists_primitive_triangulation", "has_primitive_triangulation"]
+      "theorems": [
+        "exists_reduction",
+        "exists_primitive_triangulation",
+        "has_primitive_triangulation"
+      ]
     }
   ],
   "overview": {
@@ -67,5 +95,13 @@
       "description": "Provides the primitive triangulation ingredient for the constructive proof of Pick's theorem"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/PicksTheoremOQ01OQ01.lean",
+    "lineCount": 215,
+    "theoremCount": 11,
+    "definitionCount": 5,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -12,35 +12,62 @@
     "definitionCount": 3,
     "lineCount": 897,
     "leanFile": "proofs/Proofs/SpernerMathlib.lean",
-    "imports": ["Mathlib"],
-    "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex"],
+    "imports": [
+      "Mathlib"
+    ],
+    "tags": [
+      "combinatorics",
+      "topology",
+      "sperner",
+      "parity",
+      "cell-complex"
+    ],
     "assumptions": [],
-    "sorries": 0
+    "sorries": 0,
+    "proofRepoPath": "Proofs/SpernerMathlib.lean"
   },
   "sections": [
     {
       "id": "fpf-invol",
       "title": "Fixed-Point-Free Involution Parity",
       "description": "A fixed-point-free involution on a finite set has even cardinality, since every element pairs with its distinct image. This foundational lemma applies beyond Sperner: Tucker's lemma, Borsuk-Ulam, and other combinatorial topology results rely on the same parity mechanism.",
-      "theorems": ["even_card_fpf_invol"]
+      "theorems": [
+        "even_card_fpf_invol"
+      ]
     },
     {
       "id": "door-count",
       "title": "Door Count Parity",
       "description": "A 'door' at position k of a cell is a face that, if removed, still covers all remaining colors. The key lemma `door_count_parity` shows the number of door positions has the same parity as the surjectivity indicator of the coloring. The proof uses a pigeonhole argument (`surjection_unique_dup_fiber`) to identify the unique duplicated fiber when the coloring is surjective.",
-      "theorems": ["exists_of_sum_eq_one", "door_count_parity"]
+      "theorems": [
+        "exists_of_sum_eq_one",
+        "door_count_parity"
+      ]
     },
     {
       "id": "interior-pairing",
       "title": "Interior Door Pairing",
       "description": "The adjacency relation pairs interior doors: each interior door of cell s at face k corresponds to a door of the adjacent cell s' at face k'. The adjacency involution (`isDoor_iff_of_adj`) ensures these pairs are distinct, so the total interior door count is even.",
-      "theorems": ["isDoor_of_shared_face", "isDoor_iff_of_adj", "even_card_interior_doors"]
+      "theorems": [
+        "isDoor_of_shared_face",
+        "isDoor_iff_of_adj",
+        "even_card_interior_doors"
+      ]
     },
     {
       "id": "sperner-main",
       "title": "Sperner's Lemma",
       "description": "Summing door counts across all cells and using the interior-door pairing, the panchromatic cell count and the boundary door count are congruent modulo 2. If the boundary doors are odd, at least one panchromatic cell exists. With a Sperner coloring (boundary vertices labeled by the face they miss), every boundary door lies on the last face, and the boundary door count is odd.",
-      "theorems": ["per_cell_door_parity", "sum_mod_congr", "card_doors_eq_sum", "doors_partition", "sperner_parity", "exists_panchromatic", "boundary_doors_on_last_face", "boundary_doors_odd_of_last_face"]
+      "theorems": [
+        "per_cell_door_parity",
+        "sum_mod_congr",
+        "card_doors_eq_sum",
+        "doors_partition",
+        "sperner_parity",
+        "exists_panchromatic",
+        "boundary_doors_on_last_face",
+        "boundary_doors_odd_of_last_face"
+      ]
     },
     {
       "id": "interval-example",
@@ -74,5 +101,13 @@
       "description": "Sperner's lemma instantiated for triangulation data structures"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/SpernerMathlib.lean",
+    "lineCount": 897,
+    "theoremCount": 14,
+    "definitionCount": 3,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -18,22 +18,34 @@
       "Mathlib.Data.Fintype.BigOperators",
       "Mathlib.Data.ZMod.Basic"
     ],
-    "tags": ["combinatorics", "topology", "sperner", "parity", "cell-complex", "mathlib"],
+    "tags": [
+      "combinatorics",
+      "topology",
+      "sperner",
+      "parity",
+      "cell-complex",
+      "mathlib"
+    ],
     "assumptions": [],
-    "sorries": 0
+    "sorries": 0,
+    "proofRepoPath": "Proofs/SpernerMathlib4.lean"
   },
   "sections": [
     {
       "id": "fpf-invol",
       "title": "Fixed-Point-Free Involution Parity",
       "description": "The theorem Finset.even_card_of_fpf_invol proves that any fixed-point-free involution on a finite set has even cardinality. The proof uses Finset.sum_involution over ZMod 2, giving a concise algebraic argument. This is proposed for Mathlib as it appears useful for Tucker's lemma, Borsuk-Ulam, and related combinatorial topology results.",
-      "theorems": ["Finset.even_card_of_fpf_invol"]
+      "theorems": [
+        "Finset.even_card_of_fpf_invol"
+      ]
     },
     {
       "id": "door-count",
       "title": "Door Count Parity",
       "description": "The theorem door_count_parity characterizes the parity of the number of 'door positions' for a coloring f : Fin(d+1) → Fin(d+1): it equals 1 if f is surjective (hence bijective by finiteness), and 0 otherwise. The proof uses a pigeonhole argument to find the unique duplicated fiber when f is surjective over Fin(d).",
-      "theorems": ["door_count_parity"]
+      "theorems": [
+        "door_count_parity"
+      ]
     },
     {
       "id": "cell-complex",
@@ -45,7 +57,11 @@
       "id": "sperner-main",
       "title": "Sperner's Lemma",
       "description": "The main results: sperner_parity shows the panchromatic cell count is congruent to the boundary door count modulo 2, via a double-counting argument using interior door pairing and per-cell parity. The theorem sperner derives existence of a panchromatic cell from an odd boundary door count.",
-      "theorems": ["even_card_interiorDoors", "sperner_parity", "sperner"]
+      "theorems": [
+        "even_card_interiorDoors",
+        "sperner_parity",
+        "sperner"
+      ]
     }
   ],
   "overview": {
@@ -78,5 +94,13 @@
       "description": "n-dimensional Sperner via Freudenthal triangulation"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/SpernerMathlib4.lean",
+    "lineCount": 732,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/sperner-simplicial-bridge/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge/meta.json
@@ -12,35 +12,66 @@
     "definitionCount": 5,
     "lineCount": 611,
     "leanFile": "proofs/Proofs/SpernerSimplicialBridge.lean",
-    "imports": ["Proofs.SpernerMathlib"],
-    "tags": ["combinatorics", "topology", "sperner", "simplicial-complex", "pseudomanifold", "bridge"],
+    "imports": [
+      "Proofs.SpernerMathlib"
+    ],
+    "tags": [
+      "combinatorics",
+      "topology",
+      "sperner",
+      "simplicial-complex",
+      "pseudomanifold",
+      "bridge"
+    ],
     "assumptions": [],
-    "sorries": 0
+    "sorries": 0,
+    "proofRepoPath": "Proofs/SpernerSimplicialBridge.lean"
   },
   "sections": [
     {
       "id": "vertex-enum",
       "title": "Vertex Enumeration",
       "description": "The definition vertexEnum converts an unordered finset of vertices into an ordered tuple using Finset.sort with the linear order on E. The key properties: vertexEnum_mem (each k-th vertex belongs to the simplex), vertexEnum_injective (the ordering is injective), vertexEnum_image_univ (the image is exactly the simplex). These properties are the foundation for converting finset-based simplices into the cell-complex vertex format.",
-      "theorems": ["vertexEnum_mem", "vertexEnum_injective", "vertexEnum_image_univ"]
+      "theorems": [
+        "vertexEnum_mem",
+        "vertexEnum_injective",
+        "vertexEnum_image_univ"
+      ]
     },
     {
       "id": "face-machinery",
       "title": "Codimension-1 Face Infrastructure",
       "description": "A codimension-1 face (opposite vertex k) is the image of vertexEnum restricted to Fin(d+1) \\ {k}. The lemmas faceOf_card, faceOf_subset, vertexEnum_image_erase establish that this face has cardinality d, is a subset of the simplex, and equals the simplex with the k-th vertex erased. The helper vertexEnum_not_mem_faceOf_iff characterizes which vertices are NOT in a face.",
-      "theorems": ["faceOf_card", "faceOf_subset", "vertexEnum_image_erase", "vertexEnum_not_mem_faceOf_iff"]
+      "theorems": [
+        "faceOf_card",
+        "faceOf_subset",
+        "vertexEnum_image_erase",
+        "vertexEnum_not_mem_faceOf_iff"
+      ]
     },
     {
       "id": "containers-adjacency",
       "title": "Containers and Adjacency",
       "description": "The containersOf function finds all top-dimensional cells containing a given face. Under the pseudomanifold hypothesis (each codim-1 face in at most 2 cells), containersOf_card_le_two shows each face has at most 2 containers. The adjacency function adjFn maps cell-face pairs to their adjacent cell (if any): if the face has exactly 2 containers, the adjacent cell is the other one; if only 1, it's a boundary face (returns none).",
-      "theorems": ["self_mem_containersOf", "containersOf_card_le_two", "containersOf_card_one_or_two", "containersOf_card_eq_two_of_adjFn", "adjFn_vertex", "adjFn_ne", "adjFn_s", "adjFn_face_eq", "adjFn_symm"]
+      "theorems": [
+        "self_mem_containersOf",
+        "containersOf_card_le_two",
+        "containersOf_card_one_or_two",
+        "containersOf_card_eq_two_of_adjFn",
+        "adjFn_vertex",
+        "adjFn_ne",
+        "adjFn_s",
+        "adjFn_face_eq",
+        "adjFn_symm"
+      ]
     },
     {
       "id": "bridge-theorem",
       "title": "Sperner's Lemma",
       "description": "The main theorem exists_panchromatic applies abstract Sperner's lemma (from SpernerMathlib) to finite sets of top-dimensional simplices. Given a finite set topCells of (d+1)-vertex simplices, the pseudomanifold property, a vertex coloring, and an odd boundary door count, the theorem produces a panchromatic cell. The proof instantiates Sperner.exists_panchromatic by providing adjFn and verifying all three adjacency axioms (adjFn_symm, adjFn_vertex, adjFn_ne).",
-      "theorems": ["exists_panchromatic"]
+      "theorems": [
+        "exists_panchromatic"
+      ]
     }
   ],
   "overview": {
@@ -73,5 +104,13 @@
       "description": "Concrete Triangulation instantiation for the same abstract theorem"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/SpernerSimplicialBridge.lean",
+    "lineCount": 611,
+    "theoremCount": 21,
+    "definitionCount": 5,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -17,28 +17,48 @@
       "Proofs.SzemerediCore",
       "Proofs.SzemerediRegularity"
     ],
-    "tags": ["combinatorics", "szemer-edi", "regularity", "energy-increment", "graph-theory"],
+    "tags": [
+      "combinatorics",
+      "szemer-edi",
+      "regularity",
+      "energy-increment",
+      "graph-theory"
+    ],
     "assumptions": [],
-    "sorries": 0
+    "sorries": 0,
+    "proofRepoPath": "Proofs/SzemerediCoreOQ01.lean"
   },
   "sections": [
     {
       "id": "edge-density-algebra",
       "title": "Edge Density Algebra",
       "description": "Foundational algebraic identities for edge density: symmetry d(A,B)=d(B,A) (edgeDensity_symm), convexity when splitting the second argument (density_sq_convex_right), non-decrease under splitting both parts (sub4pair_energy_lower_bound), weighted-average identity for unions (edgeDensity_union_weighted_avg), and the exact excess formula when A is split into A' and A\\A' (energy_excess_A_split).",
-      "theorems": ["edgeDensity_symm", "density_sq_convex_right", "sub4pair_energy_lower_bound", "edgeDensity_union_weighted_avg", "energy_excess_A_split"]
+      "theorems": [
+        "edgeDensity_symm",
+        "density_sq_convex_right",
+        "sub4pair_energy_lower_bound",
+        "edgeDensity_union_weighted_avg",
+        "energy_excess_A_split"
+      ]
     },
     {
       "id": "variance-decomposition",
       "title": "Variance Decomposition for Four Subpairs",
       "description": "The δ-decomposition of energy over four subpairs {A',A\\A'} × {B',B\\B'}: a 2D weighted-average identity (four_subpair_edge_count_identity), a variance formula expressing the energy excess in terms of squared density deviations (four_subpair_deviation_identity), and the per-pair lower bound showing each irregular pair contributes ≥ 2|A'||B'|(d(A',B')-d(A,B))²/n² to the energy excess (four_subpair_excess_lb).",
-      "theorems": ["four_subpair_edge_count_identity", "four_subpair_deviation_identity", "four_subpair_excess_lb"]
+      "theorems": [
+        "four_subpair_edge_count_identity",
+        "four_subpair_deviation_identity",
+        "four_subpair_excess_lb"
+      ]
     },
     {
       "id": "energy-increment",
       "title": "Energy Increment Theorem",
       "description": "The main results: energy_increment_packaging (block-decomposition core — separates the ε⁶ increment from the block-energy accounting) and energy_increment_step (assembles the full argument from an irregular pair witness, combining the quantitative bound |A'|·|B'|·(d(A',B')-d(A,B))² > ε⁶·n² with the packaging lemma to produce a refined partition with energy ≥ E + ε⁶).",
-      "theorems": ["energy_increment_packaging", "energy_increment_step"]
+      "theorems": [
+        "energy_increment_packaging",
+        "energy_increment_step"
+      ]
     }
   ],
   "overview": {
@@ -71,5 +91,13 @@
       "description": "The energy increment step is the key engine for proving Szemerédi's theorem on arithmetic progressions"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/SzemerediCoreOQ01.lean",
+    "lineCount": 843,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Summary

Batch audit fix for 7 gallery entries.

### erdos-395-oq-01-incomplete-01
- `lineCount`: 164 → 118 (actual Lean file)
- `theoremCount`: 4 → 5 (4 private lemmas + 1 public theorem)
- Add `leanFile` structured block
- Remove false `originalContributions` entry: `erdos_original_false_proved` is mentioned but does not exist in the Lean file

### 6 entries with missing leanFile blocks
All 6 had `meta.leanFile` set as a path string but lacked the structured `leanFile` object needed for automated audit verification. Added `proofRepoPath` and `leanFile` block to each:
- `picks-theorem-oq-01-oq-01` → `PicksTheoremOQ01OQ01.lean` (215 lines, 11 theorems)
- `sperner-mathlib` → `SpernerMathlib.lean` (897 lines, 14 theorems)
- `sperner-mathlib4` → `SpernerMathlib4.lean` (732 lines, 5 theorems)
- `sperner-simplicial-bridge` → `SpernerSimplicialBridge.lean` (611 lines, 21 theorems)
- `szemeredi-core-oq-01` → `SzemerediCoreOQ01.lean` (843 lines, 10 theorems)
- `wilsons-theorem-oq-02-ext` → `WilsonsTheoremOQ02Ext.lean` (539 lines, 7 theorems)

All critical integrity claims (status, badge, sorries, axiomCount) verified correct for all 7 entries.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)