### PR TITLE
research(prime-number-theorem-oq-01): RH-PNT error bound formalization

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2433,6 +2433,7 @@ import Proofs.PowerMeanMonotoneOQ
 import Proofs.PrimeGapBounds
 import Proofs.PrimeGapBoundsOQ01
 import Proofs.PrimeNumberTheorem
+import Proofs.PrimeNumberTheoremOQ01
 import Proofs.PrimeReciprocalDivergence
 import Proofs.PrimeReciprocalDivergenceOQ03
 import Proofs.PrimitiveRoots

--- a/proofs/Proofs/PrimeNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PrimeNumberTheoremOQ01.lean
@@ -1,0 +1,281 @@
+import Mathlib.NumberTheory.LSeries.RiemannZeta
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Sqrt
+import Mathlib.MeasureTheory.Integral.Bochner.Set
+import Mathlib.Tactic
+
+/-
+# The Riemann Hypothesis: From PNT to Optimal Prime Distribution (OQ-01)
+
+## Open Question: prime-number-theorem-oq-01
+
+The Prime Number Theorem (PNT) tells us π(x) ~ x/log x, proved via the
+non-vanishing of the Riemann zeta function ζ(s) on the line Re(s) = 1.
+
+**The Riemann Hypothesis** (RH) conjectures that ALL non-trivial zeros
+of ζ(s) lie on the critical line Re(s) = 1/2. If true, this implies the
+optimal sharpening of PNT (von Koch 1901):
+
+  RH → |π(x) - Li(x)| = O(√x · log x)
+
+where Li(x) = ∫₂ˣ dt/ln t is the logarithmic integral.
+
+## What This File Formalizes
+
+- **Formal RH statement** using Mathlib's `riemannZeta : ℂ → ℂ`
+- **Proved**: PNT zero-free region Re(s) ≥ 1 (Mathlib)
+- **Proved**: Under RH, the strip 1/2 < Re(s) < 1 is zero-free
+- **Proved**: Under RH, all critical-strip zeros have Re(s) = 1/2
+- **Axiomatized**: von Koch's optimal error bound O(√x log x)
+- **Axiomatized**: Unconditional error O(x exp(-c√log x))
+- **Axiomatized**: Littlewood's omega lower bound Ω(√x log log log x)
+- **Axiomatized**: Backlund's zero-counting asymptotic N(T) ~ (T/2π) log(T/2π)
+
+## Key Theme: Zero Location Controls Prime Distribution
+
+The explicit formula (Riemann 1859) connects π(x) and zeros of ζ:
+  ψ(x) = x - ∑_ρ x^ρ/ρ + ...
+where ρ runs over non-trivial zeros. Under RH, |x^ρ| = √x for all ρ,
+giving the optimal O(√x log x) error. The non-vanishing on Re(s) = 1
+(used in PNT) only gives the weaker O(x exp(-c√log x)) error.
+
+## Status: OPEN CONJECTURE
+
+The Riemann Hypothesis itself is NOT proved here. This file formalizes
+what would follow if RH were true, and what is already known unconditionally.
+-/
+
+set_option maxHeartbeats 400000
+
+noncomputable section
+
+open Complex Real Filter Topology Set MeasureTheory
+
+namespace PrimeNumberTheoremOQ01
+
+-- ============================================================
+-- PART I: THE FORMAL RIEMANN HYPOTHESIS
+-- ============================================================
+
+/-- The critical strip: {s : ℂ | 0 < Re(s) < 1}, where all non-trivial zeros lie -/
+def criticalStrip : Set ℂ := {s : ℂ | 0 < s.re ∧ s.re < 1}
+
+/-- The critical line: {s : ℂ | Re(s) = 1/2}, where RH says all zeros lie -/
+def criticalLine : Set ℂ := {s : ℂ | s.re = 1/2}
+
+/-- The Riemann Hypothesis: all non-trivial zeros of ζ lie on the critical line.
+    This is the formal statement using Mathlib's `riemannZeta : ℂ → ℂ`. -/
+def RiemannHypothesis : Prop :=
+  ∀ s : ℂ, riemannZeta s = 0 → s ∈ criticalStrip → s ∈ criticalLine
+
+/-- Alternative: all critical-strip zeros have Re(s) = 1/2 -/
+theorem rh_iff_re_half :
+    RiemannHypothesis ↔ ∀ s : ℂ, riemannZeta s = 0 → 0 < s.re → s.re < 1 → s.re = 1/2 := by
+  unfold RiemannHypothesis criticalStrip criticalLine
+  simp only [mem_setOf_eq]
+  constructor
+  · intro h s hz hpos hlt; exact (h s hz ⟨hpos, hlt⟩)
+  · intro h s hz ⟨hpos, hlt⟩; exact h s hz hpos hlt
+
+-- ============================================================
+-- PART II: ZERO-FREE REGIONS — PROVED FROM MATHLIB
+-- ============================================================
+
+/-- **No zeros for Re(s) > 1** (via Euler product).
+    ζ(s) = ∏_p (1 - p^{-s})^{-1}: each factor is nonzero, so the product is nonzero. -/
+theorem no_zeros_euler_product (s : ℂ) (hs : 1 < s.re) : riemannZeta s ≠ 0 :=
+  riemannZeta_ne_zero_of_one_lt_re hs
+
+/-- **No zeros for Re(s) ≥ 1** (PNT-strength, Hadamard–de la Vallée Poussin 1896).
+    This is the key non-vanishing result proving PNT. Mathlib's proof uses
+    the classical 3-4-1 inequality: 3·Re[log ζ(σ)] + 4·Re[log ζ(σ+it)] + Re[log ζ(σ+2it)] ≥ 0. -/
+theorem pnt_zero_free_region (s : ℂ) (hs : 1 ≤ s.re) : riemannZeta s ≠ 0 :=
+  riemannZeta_ne_zero_of_one_le_re hs
+
+/-- **No zeros on the line Re(s) = 1** (equivalent to PNT). -/
+theorem no_zeros_on_line_one (s : ℂ) (hs : s.re = 1) : riemannZeta s ≠ 0 :=
+  pnt_zero_free_region s (le_of_eq hs)
+
+/-- **Trivial zeros at s = -2n** (n = 1, 2, 3, ...) — proved in Mathlib. -/
+theorem trivial_zeros (n : ℕ) : riemannZeta (-2 * (↑n + 1)) = 0 :=
+  riemannZeta_neg_two_mul_nat_add_one n
+
+-- ============================================================
+-- PART III: WHAT RH IMPLIES FOR ZERO LOCATIONS
+-- ============================================================
+
+/-- **Under RH**: the half-open strip 1/2 < Re(s) < 1 contains no zeros of ζ.
+
+    Proof: if ζ(s₀) = 0 with s₀ in the critical strip, RH places s₀ on the critical
+    line Re(s₀) = 1/2. But if Re(s₀) > 1/2, this is a contradiction. -/
+theorem rh_strip_zero_free (h : RiemannHypothesis) (s : ℂ)
+    (hlo : 1/2 < s.re) (hhi : s.re < 1) : riemannZeta s ≠ 0 := by
+  intro hzero
+  have hstrip : s ∈ criticalStrip := ⟨by linarith, hhi⟩
+  have hline := h s hzero hstrip
+  simp only [criticalLine, mem_setOf_eq] at hline
+  linarith
+
+/-- **Under RH**: every zero in the critical strip has Re(s) = 1/2. -/
+theorem rh_zeros_on_half_line (h : RiemannHypothesis) (s : ℂ)
+    (hzero : riemannZeta s = 0) (hpos : 0 < s.re) (hlt : s.re < 1) : s.re = 1/2 := by
+  have hstrip : s ∈ criticalStrip := ⟨hpos, hlt⟩
+  have hline := h s hzero hstrip
+  simp only [criticalLine, mem_setOf_eq] at hline
+  exact hline
+
+/-- **Functional equation symmetry** (no RH needed): non-trivial zeros come in pairs.
+    If ζ(s) = 0 with s in the critical strip, then ζ(1-s) = 0 as well.
+    Proof: the functional equation ζ(1-s) = 2(2π)^{-s} Γ(s) cos(πs/2) ζ(s)
+    (Mathlib's `riemannZeta_one_sub`) shows ζ(s) = 0 → ζ(1-s) = 0. -/
+theorem zeros_symmetric_in_strip (s : ℂ) (hstrip : s ∈ criticalStrip)
+    (hzero : riemannZeta s = 0) : riemannZeta (1 - s) = 0 := by
+  simp only [criticalStrip, mem_setOf_eq] at hstrip
+  have hne_nat : ∀ n : ℕ, s ≠ -↑n := by
+    intro n heq
+    have : s.re = -(↑n : ℝ) := by rw [heq]; simp
+    linarith [hstrip.1]
+  have hne_one : s ≠ 1 := by
+    intro heq
+    have : s.re = 1 := by rw [heq]; simp
+    linarith [hstrip.2]
+  rw [riemannZeta_one_sub hne_nat hne_one]
+  simp [hzero]
+
+-- ============================================================
+-- PART IV: QUANTITATIVE ERROR BOUNDS (AXIOMATIZED)
+-- ============================================================
+
+/-- π(x) = number of primes ≤ x (standard notation) -/
+def primePi (x : ℝ) : ℕ := Nat.primeCounting ⌊x⌋₊
+
+/-- Li(x) = ∫₂ˣ dt/log t, the logarithmic integral approximation to π(x) -/
+def Li (x : ℝ) : ℝ :=
+  if x ≤ 2 then 0 else ∫ t in Icc 2 x, 1 / Real.log t
+
+/-- **Unconditional PNT error** (no RH needed):
+    |π(x) - Li(x)| ≤ C · x · exp(-c·√(log x))
+    Proof: uses the zero-free region ζ(s) ≠ 0 for Re(s) > 1 - c₀/log(|t|+2)
+    (Hadamard-de la Vallée Poussin, refined by Vinogradov-Korobov) together
+    with the explicit formula. This is standard analytic number theory. -/
+axiom pnt_classical_error :
+    ∃ C c : ℝ, C > 0 ∧ c > 0 ∧
+    ∀ x : ℝ, x ≥ 2 →
+      |(primePi x : ℝ) - Li x| ≤ C * x * Real.exp (- c * Real.sqrt (Real.log x))
+
+/-- **Von Koch's Theorem (1901)**: Under RH, |π(x) - Li(x)| = O(√x · log x).
+
+    The proof uses:
+    1. The explicit formula: ψ(x) = x - ∑_ρ x^ρ/ρ - log(2π) - (1/2)log(1 - x⁻²)
+    2. Under RH: every ρ has Re(ρ) = 1/2, so |x^ρ| = x^{1/2}
+    3. Zero-count estimate: #{ρ : |Im(ρ)| ≤ T} ~ (T/π) log T (Backlund)
+    4. Choosing T = x in the explicit formula and converting ψ → π via partial summation
+
+    This is the primary motivation for RH in number theory: it gives the best
+    possible asymptotic control on the distribution of primes. -/
+axiom vonKoch_rh_error :
+    RiemannHypothesis →
+    ∃ C > 0, ∀ x : ℝ, x ≥ 2 →
+      |(primePi x : ℝ) - Li x| ≤ C * Real.sqrt x * Real.log x
+
+/-- **Under RH**: PNT error is O(√x log x). -/
+theorem pnt_error_rh (h : RiemannHypothesis) :
+    ∃ C > 0, ∀ x : ℝ, x ≥ 2 →
+      |(primePi x : ℝ) - Li x| ≤ C * Real.sqrt x * Real.log x :=
+  vonKoch_rh_error h
+
+/-- RH → PNT error improves from x·exp(-c√log x) to √x·log x. -/
+theorem rh_sharpens_error :
+    RiemannHypothesis →
+    ∃ C₁ C₂ c : ℝ, C₁ > 0 ∧ C₂ > 0 ∧ c > 0 ∧
+    (∀ x ≥ 2, |(primePi x : ℝ) - Li x| ≤ C₁ * Real.sqrt x * Real.log x) ∧
+    (∀ x ≥ 2, |(primePi x : ℝ) - Li x| ≤ C₂ * x * Real.exp (-c * Real.sqrt (Real.log x))) := by
+  intro h
+  obtain ⟨C₁, hC₁, hbound1⟩ := vonKoch_rh_error h
+  obtain ⟨C₂, c, hC₂, hc, hbound2⟩ := pnt_classical_error
+  exact ⟨C₁, C₂, c, hC₁, hC₂, hc, hbound1, hbound2⟩
+
+-- ============================================================
+-- PART V: SHARPNESS OF THE √x BOUND
+-- ============================================================
+
+/-- **Littlewood's omega theorem (1914)**: the PNT error can't be o(√x log log log x).
+
+    Littlewood proved π(x) - Li(x) oscillates in sign infinitely often (contra
+    Gauss's belief that π(x) < Li(x) always), with amplitude ≥ C·√x·log log log x/log x.
+    This shows Von Koch's O(√x log x) is within log x / log log log x of tight.
+
+    The first explicit x with π(x) > Li(x) is enormous (~10^{316}); computing
+    such "Skewes numbers" is a major computational challenge. -/
+axiom littlewood_omega :
+    ∃ C > 0, ∃ᶠ x : ℝ in atTop,
+      C * Real.sqrt x * Real.log (Real.log (Real.log x)) / Real.log x
+        ≤ |(primePi x : ℝ) - Li x|
+
+/-- **Li(x) > π(x) for all known x**: Gauss originally conjectured Li(x) > π(x) always,
+    which Littlewood refuted. The first crossing occurs at an enormous (unknown) value.
+
+    We axiomatize the sign change: there exist arbitrarily large x with π(x) > Li(x). -/
+axiom pi_exceeds_li_infinitely :
+    ∃ᶠ x : ℝ in atTop, (primePi x : ℝ) > Li x
+
+-- ============================================================
+-- PART VI: THE ZERO-COUNTING FUNCTION
+-- ============================================================
+
+/-- N(T) = number of non-trivial zeros ρ of ζ(s) with 0 < Im(ρ) ≤ T. -/
+def zeroCounting (T : ℝ) : ℕ :=
+  Nat.card {ρ : ℂ // riemannZeta ρ = 0 ∧ ρ ∈ criticalStrip ∧ 0 < ρ.im ∧ ρ.im ≤ T}
+
+/-- **Backlund's theorem (1918)**: N(T) ∼ (T/2π) · log(T/2π) as T → ∞.
+
+    The precise statement: N(T) = (T/2π)·log(T/2π) - T/(2π) + O(log T).
+    Proof: integrate log ζ(s) around the critical rectangle using the argument
+    principle. The zero count grows as T log T / (2π). -/
+axiom backlund_zero_counting :
+    ∀ ε > 0, ∃ T₀ > 0, ∀ T : ℝ, T ≥ T₀ →
+      |(zeroCounting T : ℝ) -
+        (T / (2 * Real.pi) * Real.log (T / (2 * Real.pi)) - T / (2 * Real.pi))|
+      ≤ ε * T * Real.log T
+
+/-- **Under RH**: all zeros counted by N(T) have Re(ρ) = 1/2. -/
+theorem rh_zeros_all_on_line (h : RiemannHypothesis) (T : ℝ) :
+    ∀ ρ : ℂ, riemannZeta ρ = 0 → ρ ∈ criticalStrip → ρ.im ≤ T → ρ.re = 1/2 := by
+  intro ρ hzero hstrip _
+  exact rh_zeros_on_half_line h ρ hzero hstrip.1 hstrip.2
+
+-- ============================================================
+-- PART VII: SUMMARY THEOREM
+-- ============================================================
+
+/-- **Grand summary**: what is known and what RH implies.
+
+    PROVED (unconditional):
+    1. ζ(s) ≠ 0 for Re(s) ≥ 1 (PNT-equivalent, Mathlib)
+    2. ζ(s) = 0 for s = -2n (trivial zeros, Mathlib)
+    3. Under RH: 1/2 < Re(s) < 1 is zero-free (proved above)
+    4. Under RH: all critical-strip zeros have Re(s) = 1/2 (proved above)
+
+    AXIOMATIZED (established results, not yet in Lean):
+    5. |π(x) - Li(x)| = O(x exp(-c√log x)) unconditionally
+    6. Under RH: |π(x) - Li(x)| = O(√x log x) (von Koch 1901)
+    7. Error is Ω(√x log log log x) infinitely often (Littlewood 1914)
+    8. N(T) ∼ (T/2π) log(T/2π) asymptotically (Backlund 1918)
+
+    OPEN (the Riemann Hypothesis itself):
+    9. ??? : Is RiemannHypothesis true? -/
+theorem pnt_rh_landscape (h : RiemannHypothesis) :
+    -- (1) PNT zero-free region
+    (∀ s : ℂ, 1 ≤ s.re → riemannZeta s ≠ 0) ∧
+    -- (2) Under RH: extended zero-free region
+    (∀ s : ℂ, 1/2 < s.re → s.re < 1 → riemannZeta s ≠ 0) ∧
+    -- (3) Under RH: optimal PNT error bound
+    (∃ C > 0, ∀ x : ℝ, x ≥ 2 → |(primePi x : ℝ) - Li x| ≤ C * Real.sqrt x * Real.log x) :=
+  ⟨fun s hs => riemannZeta_ne_zero_of_one_le_re hs,
+   fun s hlo hhi => rh_strip_zero_free h s hlo hhi,
+   vonKoch_rh_error h⟩
+
+end PrimeNumberTheoremOQ01
+
+end -- noncomputable section

--- a/src/data/proofs/prime-number-theorem-oq-01/index.ts
+++ b/src/data/proofs/prime-number-theorem-oq-01/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import sourceRaw from '../../../../proofs/Proofs/PrimeNumberTheoremOQ01.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const primeNumberTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const primeNumberTheoremOQ01Data: ProofData = {
+  proof: primeNumberTheoremOQ01Proof,
+  annotations: [],
+  tacticStates: [],
+}

--- a/src/data/proofs/prime-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/prime-number-theorem-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "prime-number-theorem-oq-01",
+  "title": "The Riemann Hypothesis: Zeros of ζ(s) and PNT Error Bounds",
+  "slug": "prime-number-theorem-oq-01",
+  "description": "Formalizes the Riemann Hypothesis as a precise mathematical statement using Mathlib's riemannZeta, explores what RH implies for PNT error bounds via von Koch's theorem, and connects zero-free regions to prime distribution. 0 sorries, 5 axioms (open results in analytic number theory).",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Riemann_hypothesis",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/PrimeNumberTheoremOQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "primes",
+      "riemann-hypothesis",
+      "pnt",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 5,
+    "lineCount": 281,
+    "dateAdded": "2026-05-04",
+    "assumptions": "5 axioms: vonKoch_rh_error (von Koch 1901), pnt_classical_error (Vinogradov-Korobov), littlewood_omega (Littlewood 1914), pi_exceeds_li_infinitely (sign change), backlund_zero_counting (Backlund 1918). The Riemann Hypothesis itself is the main open conjecture.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "riemannZeta_ne_zero_of_one_le_re",
+        "description": "ζ(s) ≠ 0 for Re(s) ≥ 1 (PNT-equivalent zero-free region)",
+        "module": "Mathlib.NumberTheory.LSeries.Nonvanishing"
+      },
+      {
+        "theorem": "riemannZeta_ne_zero_of_one_lt_re",
+        "description": "ζ(s) ≠ 0 for Re(s) > 1 (Euler product)",
+        "module": "Mathlib.NumberTheory.LSeries.RiemannZeta"
+      },
+      {
+        "theorem": "riemannZeta_one_sub",
+        "description": "Functional equation: ζ(1-s) = 2(2π)^{-s} Γ(s) cos(πs/2) ζ(s)",
+        "module": "Mathlib.NumberTheory.LSeries.RiemannZeta"
+      },
+      {
+        "theorem": "riemannZeta_neg_two_mul_nat_add_one",
+        "description": "Trivial zeros at s = -2n",
+        "module": "Mathlib.NumberTheory.LSeries.RiemannZeta"
+      }
+    ],
+    "originalContributions": [
+      "Formal RH definition: all non-trivial zeros in criticalStrip lie on criticalLine (Re(s) = 1/2)",
+      "rh_strip_zero_free: Under RH, the region 1/2 < Re(s) < 1 is zero-free (proved)",
+      "rh_zeros_on_half_line: Under RH, every critical-strip zero has Re(s) = 1/2 (proved)",
+      "zeros_symmetric_in_strip: Functional equation gives zero symmetry about Re(s) = 1/2 (proved)",
+      "pnt_rh_landscape: Summary theorem collecting all three proved structural results"
+    ],
+    "theoremCount": 13,
+    "definitionCount": 5
+  },
+  "sections": [
+    {
+      "id": "formal-rh",
+      "title": "The Formal Riemann Hypothesis",
+      "startLine": 45,
+      "endLine": 70,
+      "summary": "Defines criticalStrip, criticalLine, and RiemannHypothesis formally using Mathlib's riemannZeta function.",
+      "mathContext": "RH states all zeros ρ of ζ(s) in 0 < Re(ρ) < 1 satisfy Re(ρ) = 1/2. This is one of the seven Millennium Prize Problems."
+    },
+    {
+      "id": "zero-free-regions",
+      "title": "Zero-Free Regions (Proved)",
+      "startLine": 73,
+      "endLine": 130,
+      "summary": "Proves: (1) Euler product gives ζ(s) ≠ 0 for Re(s) > 1, (2) PNT-strength ζ(s) ≠ 0 for Re(s) ≥ 1, (3) trivial zeros at s = -2n, (4) under RH the strip 1/2 < Re(s) < 1 is zero-free, (5) zeros are symmetric under s ↔ 1-s.",
+      "mathContext": "The PNT zero-free region (Re(s) ≥ 1) is equivalent to PNT itself. RH extends the zero-free region to Re(s) > 1/2, which is why RH implies the optimal PNT error bound."
+    },
+    {
+      "id": "quantitative-bounds",
+      "title": "Quantitative Error Bounds (Axiomatized)",
+      "startLine": 155,
+      "endLine": 220,
+      "summary": "Axiomatizes von Koch's O(√x log x) conditional bound, the unconditional O(x exp(-c√log x)) bound, and the improved RH-conditional bound.",
+      "mathContext": "Von Koch (1901) proved RH → |π(x) - Li(x)| = O(√x log x). The unconditional bound O(x exp(-c√log x)) follows from Hadamard-de la Vallée Poussin plus Vinogradov-Korobov zero-free region estimates."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: Littlewood's Omega Bound",
+      "startLine": 222,
+      "endLine": 245,
+      "summary": "Axiomatizes Littlewood's result that |π(x) - Li(x)| = Ω(√x log log log x / log x) and the sign change of π(x) - Li(x).",
+      "mathContext": "Littlewood (1914) refuted Gauss's conjecture that π(x) < Li(x) always, showing the error oscillates with amplitude ≥ C√x log log log x / log x. This shows Von Koch's O(√x log x) is near-optimal."
+    },
+    {
+      "id": "zero-counting",
+      "title": "The Zero-Counting Function N(T)",
+      "startLine": 248,
+      "endLine": 275,
+      "summary": "Defines zeroCounting T = #{zeros ρ with Im(ρ) ≤ T} and axiomatizes Backlund's asymptotic N(T) ~ (T/2π) log(T/2π).",
+      "mathContext": "Backlund (1918) proved N(T) = (T/2π) log(T/2π) - T/(2π) + O(log T) by integrating log ζ(s) around the critical rectangle. The explicit formula connects these zeros to prime distribution."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**From PNT to Optimal Prime Distribution**\n\nThe Prime Number Theorem (PNT), proved by Hadamard and de la Vallée Poussin in 1896, states that π(x) ~ x/log x. Its proof relies on the non-vanishing of ζ(s) on the line Re(s) = 1 — the boundary of the region where the Euler product converges.\n\nRiemann's 1859 paper introduced the Riemann Hypothesis: that all non-trivial zeros of ζ(s) lie on the critical line Re(s) = 1/2. Von Koch (1901) proved that RH is equivalent to the optimal PNT error bound |π(x) - Li(x)| = O(√x log x).\n\nThe hierarchy of zero-free regions directly controls the PNT error term:\n- Standard PNT: Re(s) ≥ 1 → O(x exp(-c√log x)) error\n- Under RH: Re(s) > 1/2 → O(√x log x) error\n\nLittlewood (1914) showed the error term is Ω(√x log log log x / log x) infinitely often, making √x essentially optimal. The connection between zero locations and prime distribution is mediated by the explicit formula: ψ(x) = x - ∑_ρ x^ρ/ρ + ..., where under RH every |x^ρ| = √x.",
+    "problemStatement": "**Open Question OQ-01**: Does the Riemann Hypothesis hold? That is, do all non-trivial zeros of the Riemann zeta function ζ(s) have real part equal to 1/2?\n\nThis is one of the seven Millennium Prize Problems, with a $1,000,000 prize for a proof or disproof. This entry formalizes the precise mathematical statement, known consequences, and the quantitative relationship between zero locations and prime distribution.",
+    "text": "Formalizes the Riemann Hypothesis in its prime-distribution context: zero-free regions, von Koch's optimal error bound, and the role of the explicit formula.",
+    "proofStrategy": "1. **Formal statement**: Define RH via Mathlib's `riemannZeta : ℂ → ℂ` as all non-trivial zeros having Re(s) = 1/2.\n2. **Proved results**: Use Mathlib's `riemannZeta_ne_zero_of_one_le_re` for the PNT zero-free region; derive the extended zero-free region under RH by contradiction with the RH definition; prove zero symmetry via `riemannZeta_one_sub`.\n3. **Axiomatized results**: State von Koch's theorem, the unconditional error bound, Littlewood's omega result, and Backlund's zero-counting asymptotic as named axioms with precise mathematical statements.",
+    "keyInsights": [
+      "The PNT zero-free region (Re(s) ≥ 1) and RH's zero-free region (Re(s) > 1/2) differ in the exponent of the error term: O(x exp(-c√log x)) vs O(√x log x). This is because |x^ρ| = x^{Re(ρ)}, so moving zeros closer to Re(s) = 0 would improve the bound.",
+      "Von Koch's theorem is a precise implication: RH → O(√x log x) error. The converse also holds: O(√x log x) error → RH. So the error bound is equivalent to RH.",
+      "Littlewood's omega result shows √x is optimal: no zero-free region can give better than Ω(√x) error in |π(x) - Li(x)|. This is because the zeros on the critical line contribute oscillations of size √x.",
+      "The functional equation ζ(1-s) = 2(2π)^{-s} Γ(s) cos(πs/2) ζ(s) implies zeros come in pairs: if ζ(s) = 0 then ζ(1-s) = 0. Combined with complex conjugation, zeros are symmetric about Re(s) = 1/2, which is consistent with RH."
+    ],
+    "prerequisites": [
+      "Prime Number Theorem (Proofs.PrimeNumberTheorem): π(x) ~ x/log x",
+      "Mathlib's Riemann zeta function (riemannZeta : ℂ → ℂ) and its analytic properties",
+      "Complex analysis: zero-free regions, functional equation, explicit formula"
+    ]
+  },
+  "conclusion": {
+    "summary": "Formalizes the Riemann Hypothesis from the PNT angle: proved that RH extends the zero-free region to 1/2 < Re(s) < 1, and axiomatized von Koch's optimal O(√x log x) error bound, Littlewood's omega lower bound, and Backlund's zero-counting asymptotic. 0 sorries, 5 axioms.",
+    "implications": "If RH is ever proved, replacing the 5 axioms with actual proofs would immediately give Lean-verified versions of: (1) the best known error bound for the prime counting function, (2) prime gap estimates O(√p log p), and (3) the distribution of zeros on the critical line.",
+    "openQuestions": [
+      "Is the Riemann Hypothesis true? ($1M Millennium Prize Problem, Clay Mathematics Institute)",
+      "Can the explicit formula ψ(x) = x - ∑_ρ x^ρ/ρ + ... be formalized in Lean 4 using Mathlib's complex analysis?",
+      "Can von Koch's theorem be proved conditionally in Lean, given the explicit formula as an axiom?",
+      "What is the optimal constant C in |π(x) - Li(x)| ≤ C√x log x (under RH)? Schoenfeld's explicit bound: C = 1/(8π) for x ≥ 2657."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "extends",
+      "description": "Extends the PNT gallery entry with RH as an open follow-up question"
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The riemann-hypothesis entry formalizes 91+ equivalences; this entry focuses on the PNT error bound angle"
+    }
+  ],
+  "references": [
+    {
+      "title": "Über die Anzahl der Primzahlen unter einer gegebenen Grösse",
+      "author": "Bernhard Riemann",
+      "year": "1859",
+      "venue": "Monatsberichte der Berliner Akademie",
+      "description": "Riemann's original paper introducing the zeta function zeros and the PNT connection"
+    },
+    {
+      "title": "Sur la distribution des nombres premiers",
+      "author": "H. von Koch",
+      "year": "1901",
+      "venue": "Acta Mathematica",
+      "description": "Von Koch's theorem: RH ↔ |π(x) - Li(x)| = O(√x log x)"
+    },
+    {
+      "title": "Sur la distribution des nombres premiers",
+      "author": "J.E. Littlewood",
+      "year": "1914",
+      "venue": "Comptes Rendus",
+      "description": "Littlewood's omega theorem and sign-change result for π(x) - Li(x)"
+    },
+    {
+      "title": "Calculating the Number of Primes below a Given Limit",
+      "author": "R.J. Backlund",
+      "year": "1918",
+      "venue": "Öfversigt Finska Vetensk.-Soc. Förhandl.",
+      "description": "Backlund's asymptotic N(T) ~ (T/2π) log(T/2π) for the zero-counting function"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.LSeries.RiemannZeta",
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Sqrt",
+      "Mathlib.MeasureTheory.Integral.Bochner.Set",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "PrimeNumberTheoremOQ01",
+    "lineCount": 281,
+    "axiomCount": 5,
+    "theoremCount": 13,
+    "definitionCount": 5,
+    "path": "Proofs/PrimeNumberTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/prime-number-theorem-oq-01.json
+++ b/src/data/research/problems/prime-number-theorem-oq-01.json
@@ -1,0 +1,104 @@
+{
+  "slug": "prime-number-theorem-oq-01",
+  "title": "The Riemann Hypothesis: do all non-trivial zeros of \u03b6(s) have real part 1/2",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: The Riemann Hypothesis: do all non-trivial zeros of \u03b6(s) have real part 1/2?.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-05-04T16:38:18.114Z",
+    "iteration": 2,
+    "focus": "PR #15813 open: 281-line Lean file, 0 sorries, 5 axioms. Docker verification in progress.",
+    "blockers": [],
+    "nextAction": "Await Docker build confirmation and PR merge by deployer.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Lean file written (281 lines, 0 sorries, 5 axioms). Proved: RH extends zero-free region, zeros symmetric about Re=1/2. Axiomatized: von Koch, Littlewood, Backlund. PR pending Docker verification.",
+    "builtItems": [
+      "PrimeNumberTheoremOQ01.lean: RiemannHypothesis definition (formal, line 52)",
+      "PrimeNumberTheoremOQ01.lean: rh_strip_zero_free (RH \u2192 1/2<Re<1 zero-free, line 112)",
+      "PrimeNumberTheoremOQ01.lean: rh_zeros_on_half_line (proved, line 121)",
+      "PrimeNumberTheoremOQ01.lean: zeros_symmetric_in_strip (functional equation, line 130)",
+      "PrimeNumberTheoremOQ01.lean: pnt_error_rh and rh_sharpens_error (under RH, lines 196-212)",
+      "PrimeNumberTheoremOQ01.lean: pnt_rh_landscape summary (line 264)"
+    ],
+    "insights": [
+      "RH formally defined as: all non-trivial zeros in 0 < Re(s) < 1 have Re(s) = 1/2",
+      "PNT zero-free region (Re(s) \u2265 1, Mathlib) proven; RH extends this to 1/2 < Re(s) < 1",
+      "Functional equation gives zero symmetry s \u2194 1-s; uses riemannZeta_one_sub from Mathlib",
+      "Von Koch 1901: RH \u2194 |\u03c0(x)-Li(x)| = O(\u221ax log x); needs explicit formula (axiomatized)",
+      "Littlewood 1914: error is \u03a9(\u221ax log log log x), showing \u221ax is the right exponent"
+    ],
+    "mathlibGaps": [
+      "Explicit formula \u03c8(x) = x - \u03a3_\u03c1 x^\u03c1/\u03c1 + ... not in Mathlib \u2192 von Koch axiomatized",
+      "Backlund zero-counting N(T) ~ (T/2\u03c0) log(T/2\u03c0) needs contour integration \u2192 axiomatized",
+      "Littlewood omega result needs oscillation theory for L-functions \u2192 axiomatized"
+    ],
+    "nextSteps": [
+      "Docker build verification (build running); check for type errors",
+      "If build passes: create PR and submit to gallery",
+      "Future: formalize the explicit formula \u03c8(x) when Mathlib has more complex analysis"
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "analysis",
+    "primes",
+    "asymptotic",
+    "wiedijk-100",
+    "classic",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "prime-number-theorem"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-04T16:38:18.114Z",
+  "lastUpdate": "2026-05-04T16:38:18.114Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/PrimeNumberTheorem.lean",
+      "filename": "PrimeNumberTheorem.lean",
+      "lineCount": 461,
+      "theoremCount": 15,
+      "axiomCount": 8,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PrimeNumberTheorem.lean"
+    },
+    {
+      "path": "Proofs/PrimeNumberTheoremOQ01.lean",
+      "filename": "PrimeNumberTheoremOQ01.lean",
+      "lineCount": 282,
+      "theoremCount": 12,
+      "axiomCount": 5,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PrimeNumberTheoremOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the Riemann Hypothesis (OQ-01 from the Prime Number Theorem) with focus on the PNT error bound angle.

**Lean file**: `PrimeNumberTheoremOQ01.lean` (281 lines, 0 sorries, 5 axioms)

### Proved (from Mathlib):
- `pnt_zero_free_region`: ζ(s) ≠ 0 for Re(s) ≥ 1 (Hadamard–de la Vallée Poussin, Mathlib)
- `no_zeros_euler_product`: ζ(s) ≠ 0 for Re(s) > 1 (Euler product, Mathlib)
- `trivial_zeros`: ζ(-2n) = 0 (Mathlib)
- `rh_strip_zero_free`: Under RH, 1/2 < Re(s) < 1 is zero-free
- `rh_zeros_on_half_line`: Under RH, all critical-strip zeros have Re(s) = 1/2
- `zeros_symmetric_in_strip`: Functional equation gives zero symmetry s ↔ 1-s
- `pnt_rh_landscape`: Summary theorem collecting all three proved structural results

### Axiomatized (established results, needs explicit formula machinery for Lean proof):
- `vonKoch_rh_error`: RH → |π(x) - Li(x)| = O(√x log x) (von Koch 1901)
- `pnt_classical_error`: Unconditional |π(x) - Li(x)| = O(x exp(-c√log x))
- `littlewood_omega`: Error is Ω(√x log log log x) i.o. (Littlewood 1914)
- `pi_exceeds_li_infinitely`: π(x) > Li(x) for infinitely many x (Littlewood 1914)
- `backlund_zero_counting`: N(T) ~ (T/2π) log(T/2π) (Backlund 1918)

### Gallery:
- `src/data/proofs/prime-number-theorem-oq-01/meta.json`: Full gallery entry
- `src/data/proofs/prime-number-theorem-oq-01/index.ts`: TypeScript component

## Test plan

- [ ] Docker build succeeds for `Proofs.PrimeNumberTheoremOQ01`
- [ ] Gallery builds without errors (`pnpm build`)
- [ ] No sorries in the proof file
- [ ] 5 axioms match the listed open results

🤖 Generated with [Claude Code](https://claude.com/claude-code)