### PR TITLE
fix(meta): correct stale lineCount/theoremCount in erdos-395-oq-01-incomplete-01

### DIFF
--- a/src/data/proofs/erdos-395-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01-incomplete-01/meta.json
@@ -24,7 +24,7 @@
     "erdosProblemStatus": "open-question",
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
-    "lineCount": 164,
+    "lineCount": 119,
     "prerequisites": [
       "Erdős Problem #395 parent formalization",
       "Complex numbers and norms",
@@ -38,7 +38,7 @@
       "counterexample_always_large_proved: |sum| ≥ √2 for all sign vectors, 0 axioms",
       "erdos_original_false_proved: original threshold-1 problem is false, 0 axioms"
     ],
-    "theoremCount": 4
+    "theoremCount": 5
   },
   "crossReferences": [
     {
@@ -96,11 +96,11 @@
   },
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 164,
+    "lineCount": 119,
     "path": "Proofs/Erdos395OQ01Incomplete01.lean",
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 4
+    "theoremCount": 5
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

- Corrects stale metadata in `erdos-395-oq-01-incomplete-01/meta.json`
- `lineCount`: 164 → 119 (actual line count of `Erdos395OQ01Incomplete01.lean` after PR #15791)
- `theoremCount`: 4 → 5 (file has 4 private lemmas + 1 public theorem)
- Changes apply to both `meta` block and `leanFile` block

## Evidence

```
$ wc -l proofs/Proofs/Erdos395OQ01Incomplete01.lean
119

$ grep -cE "^(private\s+)?(theorem|lemma)\s+" proofs/Proofs/Erdos395OQ01Incomplete01.lean
5
```

All critical claims remain correct: `sorries: 0`, `axiomCount: 0`, `badge: original`, `status: verified`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)