### PR TITLE
fix(meta): add leanFile.additionalFiles for Aristotle companions in 8 entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -83,7 +83,10 @@
     "theoremCount": 10,
     "definitionCount": 6,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
@@ -239,7 +239,10 @@
     "sorries": 0,
     "path": "Proofs/BertrandsPostulateOQ03OQ04.lean",
     "theoremCount": 8,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "additionalFiles": [
+      "Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -167,7 +167,10 @@
     "duplicateTheorems": 0,
     "definitionCount": 2,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
-    "sorries": 5
+    "sorries": 5,
+    "additionalFiles": [
+      "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -127,7 +127,10 @@
         "theoremCount": 3,
         "definitionCount": 2,
         "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
-        "sorries": 0
+        "sorries": 0,
+        "additionalFiles": [
+            "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
+        ]
     },
     "crossReferences": [
         {

--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -100,7 +100,10 @@
     "axiomCount": 4,
     "lineCount": 313,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/Erdos1001OQ02OQ01Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**From Rate to Sharp Rate: Mertens (1874) vs. Walfisz (1963)**\n\nThe parent problem OQ-02 established the rate O(A log N / N) for convergence of the diophantine approximation density S(N,A,c) to f(A,c). This rate came from the elementary Mertens error bound: ∑_{n≤x} φ(n) = (3/π²)x² + O(x log x), which dates to 1874 and follows from partial summation with the trivial estimate ∑_{n≤x} μ(n)/n = O(1).\n\nIn 1963, Walfisz proved a substantially sharper error bound: ∑_{n≤x} φ(n) = (3/π²)x² + O(x (log x)^(2/3) (log log x)^(4/3)). This used Vinogradov's method of exponential sums applied to the zero-free region for ζ(s): ζ(σ+it) ≠ 0 for σ > 1 - c/(log t)^(2/3) (log log t)^(1/3). The same exponent 2/3 appears in both the zero-free region and the error bound — a deep connection between zeros of the Riemann zeta function and the distribution of arithmetic functions.\n\nFor the diophantine approximation problem, the Walfisz bound propagates via Abel summation to give a rate O(A (log N)^(2/3) (log log N)^(4/3) / N), which is strictly smaller order than the O(A log N / N) rate from OQ-02. This definitively answers the sharpness question: the OQ-02 rate was not optimal.",

--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -131,7 +131,10 @@
     "theoremCount": 8,
     "path": "Proofs/Erdos1021OQ01.lean",
     "sorries": 4,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "additionalFiles": [
+      "Proofs/Erdos1021OQ01Aristotle.lean"
+    ]
   },
   "sorries": 4
 }

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -215,7 +215,10 @@
     "theoremCount": 34,
     "definitionCount": 16,
     "sorries": 0,
-    "path": "Proofs/Erdos268Problem.lean"
+    "path": "Proofs/Erdos268Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos268ProblemAristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -130,7 +130,10 @@
     "duplicateTheorems": 0,
     "definitionCount": 0,
     "path": "Proofs/LovaszLocalLemmaOQ02.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/LovaszLocalLemmaOQ02Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Adds `leanFile.additionalFiles` entries to 8 gallery proofs whose Aristotle companion files exist on disk but were not listed in the metadata. Without this field, the auditor's `find-targets` cannot detect sorries in companion files.

## Affected entries

| Slug | Missing companion |
|---|---|
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean |
| bertrands-postulate-oq-03-oq-04 | BertrandsPostulateOQ03OQ04Aristotle.lean |
| binomial-theorem-oq-02-oq-01-oq-01 | BinomialTheoremOQ02OQ01OQ01Aristotle.lean |
| cayley-hamilton-cyclic-vector-all-fields | CayleyHamiltonCyclicVectorAllFieldsAristotle.lean |
| erdos-1001-oq-02-oq-01 | Erdos1001OQ02OQ01Aristotle.lean |
| erdos-1021-oq-01 | Erdos1021OQ01Aristotle.lean |
| erdos-268 | Erdos268ProblemAristotle.lean |
| lovasz-local-lemma-oq-02 | LovaszLocalLemmaOQ02Aristotle.lean |

These were omitted from the batch fix in PR #15727 (which covered 139 entries).

No count fields (sorries, theoremCount, etc.) are changed.

---
Automated fix by lean-mechanic agent.