### PR TITLE
fix(meta): correct stale leanFile lineCount/theoremCount in 2 gallery entries

### DIFF
--- a/src/data/proofs/binary-gcd-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
-    "lineCount": 163,
+    "lineCount": 176,
     "theoremCount": 7,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
@@ -120,7 +120,7 @@
     "namespace": "BinaryGcdBit",
     "imports": ["Mathlib", "Proofs.GCDAlgorithmOQ02"],
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 176,
     "theoremCount": 7,
     "definitionCount": 1,
     "sorries": 0

--- a/src/data/proofs/erdos-323/meta.json
+++ b/src/data/proofs/erdos-323/meta.json
@@ -51,9 +51,9 @@
       "DensityQuestion definition"
     ],
     "axiomCount": 1,
-    "lineCount": 105,
+    "lineCount": 139,
     "assumptions": "1 axiom: landau_two_squares. 0 sorries.",
-    "theoremCount": 2
+    "theoremCount": 5
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their 1980 monograph, asking about the counting function f_{k,m}(x) of integers representable as sums of m nonnegative k-th powers. The question is rooted in the classical Waring problem (every integer is a sum of g(k) k-th powers, proved by Hilbert 1909), but shifts focus from representation of all integers to counting how many integers have representations with fewer summands. Landau (1908) completely resolved k = 2 by showing f_{2,2}(x) ~ c·x/√(log x), where c is the Landau-Ramanujan constant arising from the multiplicative structure of sums of two squares (Fermat's theorem). For k > 2, the situation is dramatically different: even whether f_{k,k}(x) = o(x) (zero density) is unknown. The circle method of Hardy-Littlewood-Vinogradov is the primary tool for Waring's problem, but it gives asymptotic formulas only when the number of summands exceeds k. Erdős described the regime m ≤ k as 'unattackable by the methods at our disposal.'",
@@ -153,9 +153,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 105,
+    "lineCount": 139,
     "axiomCount": 1,
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 6,
     "path": "Proofs/Erdos323Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.lineCount` and `leanFile.theoremCount` fields in 2 gallery entries after researchers extended the source files.

## Evidence

| Entry | Field | Before | After |
|---|---|---|---|
| erdos-323 | lineCount | 105 | 139 |
| erdos-323 | theoremCount | 2 | 5 |
| binary-gcd-oq-02-oq-01 | lineCount | 163 | 176 |

**erdos-323**: File grew from 105 to 139 lines; 3 new theorems were added by researchers (IsSumOfPowers_one_iff, isSumOfPowers_pow_self, powerSumCount_one_lb) bringing the total from 2 to 5. Both `meta.lineCount` and `leanFile.lineCount` updated in each file.

**binary-gcd-oq-02-oq-01**: File grew from 163 to 176 lines; theoremCount (7) is already correct.

No status, badge, axiom, or sorry changes.

---
Automated fix by lean-mechanic agent.