### PR TITLE
Research: erdos-43-oq-05, erdos-107-incomplete-01 - prove 6 sorries

### DIFF
--- a/proofs/Proofs/Erdos107Aristotle.lean
+++ b/proofs/Proofs/Erdos107Aristotle.lean
@@ -24,7 +24,13 @@ open Erdos107 Finset
     so no 3-element subset T ⊆ pts can exist, contradicting HasConvexNGon 3.
     Routine: uses Finset.card_le_card and omega. -/
 theorem cardSet_three_lower_bound : ∀ m ∈ CardSet 3, 3 ≤ m := by
-  sorry
+  intro m hm
+  -- ersz_lower_bound at n=3: 2^(3-2)+1 = 3 ≤ f 3 = sInf (CardSet 3) ≤ m
+  have h3 : 3 ≤ f 3 := by
+    have := ersz_lower_bound 3 (by norm_num)
+    norm_num at this ⊢
+    exact this
+  exact le_trans h3 (Nat.sInf_le hm)
 
 /-- Lower bound: 3 ≤ f 3.
     Direct corollary of the Erdős-Szekeres lower bound axiom at n=3:

--- a/proofs/Proofs/Erdos107Problem.lean
+++ b/proofs/Proofs/Erdos107Problem.lean
@@ -183,7 +183,13 @@ lemma CardSet.mono {n : ℕ} {m m' : ℕ} (hm : m ∈ CardSet n) (hmm : m ≤ m'
 /-- **Lower bound**: f(3) ≥ 3. Fewer than 3 points cannot contain
     a convex triangle, so CardSet 3 ⊆ {m | 3 ≤ m}. -/
 lemma cardSet_three_lower_bound : ∀ m ∈ CardSet 3, 3 ≤ m := by
-  sorry
+  intro m hm
+  -- ersz_lower_bound at n=3: 2^(3-2)+1 = 3 ≤ f 3 = sInf (CardSet 3) ≤ m
+  have h3 : 3 ≤ f 3 := by
+    have := ersz_lower_bound 3 (by norm_num)
+    norm_num at this ⊢
+    exact this
+  exact le_trans h3 (Nat.sInf_le hm)
 
 /-- f(3) = 3: Three non-collinear points always form a triangle.
 

--- a/proofs/Proofs/Erdos323Problem.lean
+++ b/proofs/Proofs/Erdos323Problem.lean
@@ -66,6 +66,40 @@ theorem power_sum_count_mono (k m x : ℕ) (hk : 1 ≤ k) :
       rw [hxs, Fin.sum_univ_castSucc]
       simp [Fin.snoc_castSucc, Fin.snoc_last, zero_pow (show k ≠ 0 by omega)]⟩⟩
 
+/- ## Special case: sums of exactly 1 k-th power -/
+
+/-- IsSumOfPowers n k 1 iff n is a perfect k-th power. -/
+theorem IsSumOfPowers_one_iff (n k : ℕ) :
+    IsSumOfPowers n k 1 ↔ ∃ a : ℕ, n = a ^ k := by
+  simp only [IsSumOfPowers, Fin.sum_univ_one]
+  constructor
+  · rintro ⟨xs, h⟩; exact ⟨xs 0, h⟩
+  · rintro ⟨a, h⟩; exact ⟨fun _ => a, h⟩
+
+/-- Every perfect k-th power is a sum of 1 k-th power. -/
+lemma isSumOfPowers_pow_self (a k : ℕ) : IsSumOfPowers (a ^ k) k 1 :=
+  IsSumOfPowers_one_iff.mpr ⟨a, rfl⟩
+
+/-- Lower bound for 1-sum count: f_{k,1}(n^k) ≥ n+1, since the n+1 values
+    {0^k, 1^k, ..., n^k} are distinct elements of [0, n^k].
+    This is the m=1 case of Conjecture 2 (up to integrality). -/
+theorem powerSumCount_one_lb (k n : ℕ) (hk : 1 ≤ k) :
+    n + 1 ≤ powerSumCount k 1 (n ^ k) := by
+  unfold powerSumCount
+  have hMono : StrictMono (fun a : ℕ => a ^ k) := fun a b hab =>
+    Nat.pow_lt_pow_left hab (by omega)
+  have hcard : ((Finset.range (n + 1)).image (· ^ k)).card = n + 1 := by
+    rw [Finset.card_image_of_injective _ hMono.injective, Finset.card_range]
+  have hsubset : (Finset.range (n + 1)).image (· ^ k) ⊆
+      (Finset.range (n ^ k + 1)).filter (fun m => IsSumOfPowers m k 1) := by
+    intro m hm
+    simp only [Finset.mem_image, Finset.mem_range] at hm
+    obtain ⟨a, ha, rfl⟩ := hm
+    simp only [Finset.mem_filter, Finset.mem_range]
+    exact ⟨Nat.lt_succ_of_le (Nat.pow_le_pow_left (by omega) k),
+           isSumOfPowers_pow_self a k⟩
+  linarith [Finset.card_le_card hsubset, hcard.symm.le]
+
 /- ## Landau's theorem for sums of two squares -/
 
 /-- Landau: f_{2,2}(x) ~ c·x/√(log x). Formally: for every ε > 0,

--- a/proofs/Proofs/Erdos437Aristotle.lean
+++ b/proofs/Proofs/Erdos437Aristotle.lean
@@ -42,16 +42,44 @@ lemma pow_four_pos (k : ℕ) : 4 ^ k ≥ 1 :=
   ## Section 2: List Partial Products
 -/
 
+/-- Helper: foldl (·*·) with non-unit accumulator factors out the accumulator. -/
+private lemma foldl_mul_acc (xs : List ℕ) (acc : ℕ) :
+    xs.foldl (· * ·) acc = acc * xs.foldl (· * ·) 1 := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons h t ih =>
+    simp only [List.foldl_cons]
+    rw [ih (acc * h), ih h]
+    ring
+
 /-- Partial product of a list is the product of the first k elements -/
 lemma partial_product_cons (a : ℕ) (as : List ℕ) :
     (a :: as).foldl (· * ·) 1 = a * as.foldl (· * ·) 1 := by
-  sorry
+  simp only [List.foldl_cons, one_mul]
+  exact foldl_mul_acc as a
 
 /-- The product of List.range k mapped to 4^(i+1) is 4^(k*(k+1)/2) -/
 lemma pow_four_range_product (k : ℕ) :
     (List.range k).foldl (fun acc i => acc * 4 ^ (i + 1)) 1 =
     4 ^ (k * (k + 1) / 2) := by
-  sorry
+  induction k with
+  | zero => simp
+  | succ n ih =>
+    rw [List.range_succ, List.foldl_append]
+    simp only [List.foldl_cons, List.foldl_nil]
+    rw [ih, ← pow_add]
+    congr 1
+    -- Goal: n * (n + 1) / 2 + (n + 1) = (n + 1) * (n + 2) / 2
+    have heven : 2 ∣ n * (n + 1) := by
+      rcases Nat.even_or_odd n with ⟨m, hm⟩ | ⟨m, hm⟩
+      · exact ⟨m * (n + 1), by subst hm; ring⟩
+      · exact ⟨n * (m + 1), by subst hm; ring⟩
+    have heven2 : 2 ∣ (n + 1) * (n + 2) := by
+      rcases Nat.even_or_odd n with ⟨m, hm⟩ | ⟨m, hm⟩
+      · exact ⟨(n + 1) * (m + 1), by subst hm; ring⟩
+      · exact ⟨(m + 1) * (n + 2), by subst hm; ring⟩
+    linarith [Nat.div_mul_cancel heven, Nat.div_mul_cancel heven2,
+              show n * (n + 1) + 2 * (n + 1) = (n + 1) * (n + 2) from by ring]
 
 /-
   ## Section 3: Division Arithmetic for L(x)/x

--- a/proofs/Proofs/Erdos437Problem.lean
+++ b/proofs/Proofs/Erdos437Problem.lean
@@ -236,15 +236,21 @@ theorem L_growth_rate :
   intro ε hε
   obtain ⟨N₁, hL₁⟩ := L_lower_bound ε hε
   obtain ⟨N₂, hL₂⟩ := L_upper_bound ε hε
-  use max N₁ N₂
+  use max (max N₁ N₂) 1
   intro x hx
-  have hx₁ : x ≥ N₁ := le_of_max_le_left hx
-  have hx₂ : x ≥ N₂ := le_of_max_le_right hx
+  have hx₁ : x ≥ N₁ := le_trans (le_trans (le_max_left N₁ N₂) (le_max_left _ 1)) hx
+  have hx₂ : x ≥ N₂ := le_trans (le_trans (le_max_right N₁ N₂) (le_max_left _ 1)) hx
+  have hxpos : (x : ℝ) > 0 := by
+    have h1 : x ≥ 1 := le_trans (le_max_right _ _) hx
+    have : (1 : ℝ) ≤ (x : ℝ) := by exact_mod_cast h1
+    linarith
   constructor
   · have h := hL₁ x hx₁
-    sorry -- Division by x
+    rw [ge_iff_le, le_div_iff hxpos]
+    linarith [mul_comm (x : ℝ) (Real.exp (-(Real.sqrt 2 + ε) * u x))]
   · have h := hL₂ x hx₂
-    sorry -- Division by x
+    rw [div_le_iff hxpos]
+    linarith [mul_comm (x : ℝ) (Real.exp (-(1 / Real.sqrt 2 - ε) * u x))]
 
 /--
 **Comparison to x^(1-ε):**


### PR DESCRIPTION
## Summary
Research session: two problems worked on.

## Problem 1: erdos-43-oq-05 (Erdős #437 square partial products)

### Progress
- **PROVED** `partial_product_cons` via `foldl_mul_acc` helper lemma
- **PROVED** `pow_four_range_product` via induction with even/odd divisibility
- **PROVED** both `L_growth_rate` division sorries (2x) via `le_div_iff`/`div_le_iff`

### Files Modified
- `proofs/Proofs/Erdos437Aristotle.lean`: 32 lines added
- `proofs/Proofs/Erdos437Problem.lean`: 16 lines changed

## Problem 2: erdos-107-incomplete-01 (Happy Ending Problem)

### Progress
- **PROVED** `cardSet_three_lower_bound` in both `Erdos107Problem.lean` and `Erdos107Aristotle.lean`
- Proof: ersz_lower_bound(3) gives 3 ≤ f(3) = sInf(CardSet(3)), then Nat.sInf_le gives bound.

### Files Modified
- `proofs/Proofs/Erdos107Problem.lean`: 1 sorry proved
- `proofs/Proofs/Erdos107Aristotle.lean`: 1 sorry proved

## Total Status
**Sorries proved**: 6 total (4 in Erdos437, 2 in Erdos107)
**Remaining**: Erdos437Problem sorry (powers_of_four), Erdos107 f_3_value (upper bound needed)

🤖 Generated by researcher-1