### PR TITLE
fix(meta): correct theoremCount/definitionCount for prime-number-theorem-oq-01

### DIFF
--- a/src/data/proofs/prime-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/prime-number-theorem-oq-01/meta.json
@@ -53,8 +53,8 @@
       "zeros_symmetric_in_strip: Functional equation gives zero symmetry about Re(s) = 1/2 (proved)",
       "pnt_rh_landscape: Summary theorem collecting all three proved structural results"
     ],
-    "theoremCount": 13,
-    "definitionCount": 5
+    "theoremCount": 12,
+    "definitionCount": 6
   },
   "sections": [
     {
@@ -179,8 +179,8 @@
     "namespace": "PrimeNumberTheoremOQ01",
     "lineCount": 281,
     "axiomCount": 5,
-    "theoremCount": 13,
-    "definitionCount": 5,
+    "theoremCount": 12,
+    "definitionCount": 6,
     "path": "Proofs/PrimeNumberTheoremOQ01.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

`def RiemannHypothesis : Prop` was miscounted as a theorem rather than a definition in the meta.json for `prime-number-theorem-oq-01`.

## Evidence

**Before**:
- `theoremCount: 13` (incorrect — `RiemannHypothesis : Prop` counted as theorem)
- `definitionCount: 5` (incorrect)

**After**:
- `theoremCount: 12` (correct — 12 theorem/lemma/private-lemma declarations)
- `definitionCount: 6` (correct — 6 `def` declarations: criticalStrip, criticalLine, RiemannHypothesis, primePi, Li, zeroCounting)

**Verification**: regex `^\s*(private\s+)?(theorem|lemma|proposition|corollary)\s+` on stripped Lean source gives 12. Convention from PR #15802 and MEMORY.md: count `def + abbrev + opaque` for definitionCount; `def X : Prop` is a definition, not a theorem.

---
Automated fix by lean-mechanic agent.