### PR TITLE
fix(meta): correct counts and restore additionalFiles for ballot-problem-oq-03-oq-01-oq-02

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -27,8 +27,8 @@
     "axiomCount": 0,
     "assumptions": "1 open sorry in GNW infrastructure (BallotProblemOQ03OQ01OQ02Helpers.lean): gnwProb_key — the GNW 1979 probabilistic identity for ≥10-row, ≥10-col, non-rectangular shapes (hard combinatorial identity). The supporting lemmas gnwProb_sum_corners, strictHookCells_card, strictHookCells_nonempty, and strictHookCells_hookLen_lt were proved in PR #14960. hook_walk_identity_gnw (the dispatcher in the gallery face) calls gnwProb_key and is otherwise complete. hookProd_ratio_formula is sorry-free. Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row through 9-row, ≤9-col (transpose duality), all rectangles.",
     "lineCount": 398,
-    "theoremCount": 489,
-    "definitionCount": 24,
+    "theoremCount": 16,
+    "definitionCount": 1,
     "originalContributions": [
       "hookLength: hook length at cell (i,j) = armLen + legLen + 1 using YoungDiagram.rowLen and colLen",
       "hookLength_pos: hook lengths are always positive (arm + leg + 1 ≥ 1) — unconditional",
@@ -98,10 +98,11 @@
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 2,
+    "theoremCount": 16,
     "definitionCount": 1,
     "additionalFiles": [
-      "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean"
+      "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
+      "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Three metadata fixes for `ballot-problem-oq-03-oq-01-oq-02`:

1. **`meta.theoremCount: 489 → 16`** — stale value from a different (much larger) file was carried over
2. **`meta.definitionCount: 24 → 1`** — same stale value issue
3. **`lf.theoremCount: 2 → 16`** — PR #15448 used `^theorem|^lemma` grep, missing the 14 `private lemma` declarations in this file
4. **`lf.additionalFiles`** — restore `BallotProblemOQ03OQ01OQ02Helpers.lean` (dropped by batch lineCount fix #15740)

## Evidence

**Actual counts** in `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean`:
- 14 `private lemma` declarations + 2 public `theorem` declarations = **16 total**
- 1 `private def rectYD` = **1 definition**

**Helpers file**: `BallotProblemOQ03OQ01OQ02Helpers.lean` has 1 sorry (`gnwProb_key`) and must be in `additionalFiles` so the auditor can track it. This was previously fixed in PR #15816 (closed without merging) and the regression was caused by batch fix #15740.

---
Automated fix by lean-mechanic agent.