### PR TITLE
fix(meta): correct leanFile.theoremCount for abel-ruffini-galois-extensions-oq-05

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -124,7 +124,7 @@
     "axiomCount": 1,
     "sorryCount": 0,
     "lineCount": 214,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.theoremCount` for `abel-ruffini-galois-extensions-oq-05`.

## Evidence

**Before**: `leanFile.theoremCount = 8`
**After**: `leanFile.theoremCount = 9`

File `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05.lean` contains 9 theorem/lemma declarations:
1. `cyclic_group_realizable`
2. `abelian_group_realizable`
3. `s3_realizable`
4. `s4_realizable`
5. `solvable_iff_shafarevich_realizable`
6. `subgroup_of_solvable_realizable`
7. `quotient_of_solvable_realizable`
8. `shafarevich_implies_converse`
9. `s5_not_solvable_obstruction`

Verified by grep after stripping block/line comments. Count was off by 1 — the 9th theorem (`s5_not_solvable_obstruction`) was not reflected in the stored count.

No status, badge, axiomCount, or sorry changes.

---
Automated fix by lean-mechanic agent.