### PR TITLE
fix(meta): correct stale lineCount/theoremCount in 3 gallery entries

### DIFF
--- a/src/data/proofs/binary-gcd-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
-    "lineCount": 163,
+    "lineCount": 176,
     "theoremCount": 7,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
@@ -120,7 +120,7 @@
     "namespace": "BinaryGcdBit",
     "imports": ["Mathlib", "Proofs.GCDAlgorithmOQ02"],
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 176,
     "theoremCount": 7,
     "definitionCount": 1,
     "sorries": 0

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
@@ -21,15 +21,15 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 165,
-    "theoremCount": 11,
+    "lineCount": 188,
+    "theoremCount": 10,
     "definitionCount": 2,
     "leanFile": {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean",
       "axiomCount": 1,
       "sorryCount": 0,
-      "lineCount": 165,
-      "theoremCount": 11,
+      "lineCount": 188,
+      "theoremCount": 10,
       "definitionCount": 2
     }
   },

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "",
     "lineCount": 266,
-    "theoremCount": 9,
+    "theoremCount": 13,
     "definitionCount": 1,
     "originalContributions": [
       "expPolyCoeff: defines p_k(t) = ∑_{m≥0} t^m/m! · coeff_k(X^m mod μ_M)",
@@ -65,7 +65,7 @@
     "namespace": "CayleyHamiltonOQ01OQ03",
     "lineCount": 266,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/CayleyHamiltonOQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Corrects stale `lineCount` and `theoremCount` metadata in 3 gallery entries where `meta.json` no longer matched the actual Lean source files. Counts were verified with `wc -l` for lines and the standard regex for theorem declarations (including `private`/`protected`/`noncomputable` per PR #15802 convention):

```
^\s*(private |protected |noncomputable )*(theorem|lemma) 
```

## Changes

| Entry | Field | Before | After | Lean file |
|---|---|---|---|---|
| `buffons-needle-oq-01-oq-01-oq-04-oq-01` | `lineCount` | 165 | **188** | `BuffonsNeedleOQ01OQ01OQ04OQ01.lean` |
| `buffons-needle-oq-01-oq-01-oq-04-oq-01` | `theoremCount` | 11 | **10** | `BuffonsNeedleOQ01OQ01OQ04OQ01.lean` |
| `cayley-hamilton-oq-01-oq-03` | `theoremCount` | 9 | **13** | `CayleyHamiltonOQ01OQ03.lean` |
| `binary-gcd-oq-02-oq-01` | `lineCount` | 163 | **176** | `BinaryGcdOQ02OQ01.lean` |

For `cayley-hamilton-oq-01-oq-03` and `binary-gcd-oq-02-oq-01`, both the inner `meta.*` block and the top-level `leanFile.*` block were updated so all sources of truth agree. For `buffons-needle-oq-01-oq-01-oq-04-oq-01`, the `meta.lineCount`/`meta.theoremCount` and the nested `meta.leanFile.lineCount`/`meta.leanFile.theoremCount` were both updated.

The Cayley-Hamilton bump (9 -> 13) recovers 4 `private lemma` declarations that the prior PR setting it to 9 had missed (it only counted public theorems).

## Verification

```bash
$ wc -l proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean proofs/Proofs/BinaryGcdOQ02OQ01.lean proofs/Proofs/CayleyHamiltonOQ01OQ03.lean
     188 proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean
     176 proofs/Proofs/BinaryGcdOQ02OQ01.lean
     266 proofs/Proofs/CayleyHamiltonOQ01OQ03.lean

# theorem/lemma declarations (incl. private/protected/noncomputable)
$ grep -c '^\s*\(private \|protected \|noncomputable \)*\(theorem\|lemma\) ' \
    proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean    # -> 10
    proofs/Proofs/BinaryGcdOQ02OQ01.lean                 # -> 7  (already correct)
    proofs/Proofs/CayleyHamiltonOQ01OQ03.lean            # -> 13
```

All 3 modified `meta.json` files validate as JSON.

## Test plan

- [x] All 3 `meta.json` files parse as valid JSON
- [x] `lineCount` matches `wc -l` of the corresponding `.lean` file
- [x] `theoremCount` matches the standard mechanic regex against the source

Automated fix by lean-mechanic agent.