### PR TITLE
fix(meta): sync stale lineCount for erdos-311, erdos-668, erdos-1201

### DIFF
--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -205,7 +205,7 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 1615,
+    "lineCount": 1651,
     "axiomCount": 1,
     "theoremCount": 100,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -51,7 +51,7 @@
       "erdos_311_conjecture axiom (ε-N₀ form)"
     ],
     "axiomCount": 3,
-    "lineCount": 103,
+    "lineCount": 114,
     "assumptions": "3 axioms: delta_lower_bound_pnt (PNT-based lower bound e^{-(1+ε)N}), tang_upper_bound (Tang's subexponential upper bound), erdos_311_conjecture (the main open conjecture: log δ(N)/N → -c for c ∈ (0,1)). No sorries.",
     "theoremCount": 6
   },
@@ -145,7 +145,7 @@
       "Classical"
     ],
     "namespace": null,
-    "lineCount": 103,
+    "lineCount": 114,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -61,7 +61,7 @@
       }
     ],
     "axiomCount": 6,
-    "lineCount": 282,
+    "lineCount": 334,
     "assumptions": "6 axioms: f_one/f_two/f_three/f_four (base values f(1)=f(2)=f(3)=f(4)=1), four_config_unique (uniqueness of the 4-point extremal configuration), extremalQuotient_finite (finite count of extremal configurations). No sorries.",
     "theoremCount": 14
   },
@@ -201,7 +201,7 @@
       "Finset"
     ],
     "namespace": "Erdos668",
-    "lineCount": 282,
+    "lineCount": 334,
     "axiomCount": 6,
     "theoremCount": 14,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` fields in 3 gallery entries after researchers extended the Lean source files.

## Evidence

| Entry | Field | Before | After |
|---|---|---|---|
| erdos-311 | meta.lineCount | 103 | 114 |
| erdos-311 | leanFile.lineCount | 103 | 114 |
| erdos-668 | meta.lineCount | 282 | 334 |
| erdos-668 | leanFile.lineCount | 282 | 334 |
| erdos-1201 | leanFile.lineCount | 1615 | 1651 |

**erdos-311**: File grew from 103 to 114 lines (researchers added definitions and additional context). No sorry/axiom/theorem count changes.

**erdos-668**: File grew from 282 to 334 lines (researchers added proofs and context). No sorry/axiom/theorem count changes.

**erdos-1201**: `meta.lineCount` was already correctly updated to 1651, but `leanFile.lineCount` was stale at 1615. Synced to match.

No status, badge, axiom, sorry, or theorem count changes.

---
Automated fix by lean-mechanic agent.