### PR TITLE
fix(meta): correct stale lineCount/theoremCount in buffons-needle-oq-01-oq-01-oq-04-oq-01

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
@@ -21,15 +21,15 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 165,
-    "theoremCount": 11,
+    "lineCount": 188,
+    "theoremCount": 10,
     "definitionCount": 2,
     "leanFile": {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean",
       "axiomCount": 1,
       "sorryCount": 0,
-      "lineCount": 165,
-      "theoremCount": 11,
+      "lineCount": 188,
+      "theoremCount": 10,
       "definitionCount": 2
     }
   },


### PR DESCRIPTION
## Summary

- Corrects stale `lineCount` (165→188) and `theoremCount` (11→10) in both `meta` and `leanFile` blocks
- Discrepancy found during gallery integrity audit: Part V (Positivity and Monotonicity) added 23 lines post-initial commit but metadata wasn't updated
- Axiom count (1) and sorry count (0) are correct and unchanged

## Test plan

- [x] Verified actual Lean file has 188 lines via `git show origin/main:proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean | wc -l`
- [x] Verified 10 public theorems via grep
- [x] Status/badge/axiomCount unchanged (axiomatized/axiom/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)