### PR TITLE
Research: erdos-695 + erdos-107 + erdos-323 - prove 16+ sorries

### DIFF
--- a/proofs/Proofs/Erdos107Aristotle.lean
+++ b/proofs/Proofs/Erdos107Aristotle.lean
@@ -24,7 +24,13 @@ open Erdos107 Finset
     so no 3-element subset T ⊆ pts can exist, contradicting HasConvexNGon 3.
     Routine: uses Finset.card_le_card and omega. -/
 theorem cardSet_three_lower_bound : ∀ m ∈ CardSet 3, 3 ≤ m := by
-  sorry
+  intro m hm
+  -- ersz_lower_bound at n=3: 2^(3-2)+1 = 3 ≤ f 3 = sInf (CardSet 3) ≤ m
+  have h3 : 3 ≤ f 3 := by
+    have := ersz_lower_bound 3 (by norm_num)
+    norm_num at this ⊢
+    exact this
+  exact le_trans h3 (Nat.sInf_le hm)
 
 /-- Lower bound: 3 ≤ f 3.
     Direct corollary of the Erdős-Szekeres lower bound axiom at n=3:

--- a/proofs/Proofs/Erdos107Problem.lean
+++ b/proofs/Proofs/Erdos107Problem.lean
@@ -198,7 +198,13 @@ lemma cardSet_three_lower_bound : ∀ m ∈ CardSet 3, 3 ≤ m := by
     This follows from the fact that the convex hull of 2 points is a line segment, and
     a non-collinear third point cannot lie in this segment. -/
 theorem f_3_value : f 3 = 3 := by
-  sorry
+  apply Nat.le_antisymm
+  · -- f 3 ≤ 3: from Erdős-Szekeres upper bound C(2,1)+1 = 3
+    have h := ersz_upper_bound 3 (by norm_num)
+    norm_num at h; exact h
+  · -- 3 ≤ f 3: from Erdős-Szekeres lower bound 2^1+1 = 3
+    have h := ersz_lower_bound 3 (by norm_num)
+    norm_num at h; exact h
 
 /-- Lower bound for f(4): f(4) > 4.
     Proof: Immediate from Klein's theorem f(4) = 5. -/

--- a/proofs/Proofs/Erdos107Problem.lean
+++ b/proofs/Proofs/Erdos107Problem.lean
@@ -183,7 +183,13 @@ lemma CardSet.mono {n : ℕ} {m m' : ℕ} (hm : m ∈ CardSet n) (hmm : m ≤ m'
 /-- **Lower bound**: f(3) ≥ 3. Fewer than 3 points cannot contain
     a convex triangle, so CardSet 3 ⊆ {m | 3 ≤ m}. -/
 lemma cardSet_three_lower_bound : ∀ m ∈ CardSet 3, 3 ≤ m := by
-  sorry
+  intro m hm
+  -- ersz_lower_bound at n=3: 2^(3-2)+1 = 3 ≤ f 3 = sInf (CardSet 3) ≤ m
+  have h3 : 3 ≤ f 3 := by
+    have := ersz_lower_bound 3 (by norm_num)
+    norm_num at this ⊢
+    exact this
+  exact le_trans h3 (Nat.sInf_le hm)
 
 /-- f(3) = 3: Three non-collinear points always form a triangle.
 

--- a/proofs/Proofs/Erdos323Problem.lean
+++ b/proofs/Proofs/Erdos323Problem.lean
@@ -66,6 +66,40 @@ theorem power_sum_count_mono (k m x : ℕ) (hk : 1 ≤ k) :
       rw [hxs, Fin.sum_univ_castSucc]
       simp [Fin.snoc_castSucc, Fin.snoc_last, zero_pow (show k ≠ 0 by omega)]⟩⟩
 
+/- ## Special case: sums of exactly 1 k-th power -/
+
+/-- IsSumOfPowers n k 1 iff n is a perfect k-th power. -/
+theorem IsSumOfPowers_one_iff (n k : ℕ) :
+    IsSumOfPowers n k 1 ↔ ∃ a : ℕ, n = a ^ k := by
+  simp only [IsSumOfPowers, Fin.sum_univ_one]
+  constructor
+  · rintro ⟨xs, h⟩; exact ⟨xs 0, h⟩
+  · rintro ⟨a, h⟩; exact ⟨fun _ => a, h⟩
+
+/-- Every perfect k-th power is a sum of 1 k-th power. -/
+lemma isSumOfPowers_pow_self (a k : ℕ) : IsSumOfPowers (a ^ k) k 1 :=
+  IsSumOfPowers_one_iff.mpr ⟨a, rfl⟩
+
+/-- Lower bound for 1-sum count: f_{k,1}(n^k) ≥ n+1, since the n+1 values
+    {0^k, 1^k, ..., n^k} are distinct elements of [0, n^k].
+    This is the m=1 case of Conjecture 2 (up to integrality). -/
+theorem powerSumCount_one_lb (k n : ℕ) (hk : 1 ≤ k) :
+    n + 1 ≤ powerSumCount k 1 (n ^ k) := by
+  unfold powerSumCount
+  have hMono : StrictMono (fun a : ℕ => a ^ k) := fun a b hab =>
+    Nat.pow_lt_pow_left hab (by omega)
+  have hcard : ((Finset.range (n + 1)).image (· ^ k)).card = n + 1 := by
+    rw [Finset.card_image_of_injective _ hMono.injective, Finset.card_range]
+  have hsubset : (Finset.range (n + 1)).image (· ^ k) ⊆
+      (Finset.range (n ^ k + 1)).filter (fun m => IsSumOfPowers m k 1) := by
+    intro m hm
+    simp only [Finset.mem_image, Finset.mem_range] at hm
+    obtain ⟨a, ha, rfl⟩ := hm
+    simp only [Finset.mem_filter, Finset.mem_range]
+    exact ⟨Nat.lt_succ_of_le (Nat.pow_le_pow_left (by omega) k),
+           isSumOfPowers_pow_self a k⟩
+  linarith [Finset.card_le_card hsubset, hcard.symm.le]
+
 /- ## Landau's theorem for sums of two squares -/
 
 /-- Landau: f_{2,2}(x) ~ c·x/√(log x). Formally: for every ε > 0,

--- a/proofs/Proofs/Erdos437Aristotle.lean
+++ b/proofs/Proofs/Erdos437Aristotle.lean
@@ -42,16 +42,44 @@ lemma pow_four_pos (k : ℕ) : 4 ^ k ≥ 1 :=
   ## Section 2: List Partial Products
 -/
 
+/-- Helper: foldl (·*·) with non-unit accumulator factors out the accumulator. -/
+private lemma foldl_mul_acc (xs : List ℕ) (acc : ℕ) :
+    xs.foldl (· * ·) acc = acc * xs.foldl (· * ·) 1 := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons h t ih =>
+    simp only [List.foldl_cons]
+    rw [ih (acc * h), ih h]
+    ring
+
 /-- Partial product of a list is the product of the first k elements -/
 lemma partial_product_cons (a : ℕ) (as : List ℕ) :
     (a :: as).foldl (· * ·) 1 = a * as.foldl (· * ·) 1 := by
-  sorry
+  simp only [List.foldl_cons, one_mul]
+  exact foldl_mul_acc as a
 
 /-- The product of List.range k mapped to 4^(i+1) is 4^(k*(k+1)/2) -/
 lemma pow_four_range_product (k : ℕ) :
     (List.range k).foldl (fun acc i => acc * 4 ^ (i + 1)) 1 =
     4 ^ (k * (k + 1) / 2) := by
-  sorry
+  induction k with
+  | zero => simp
+  | succ n ih =>
+    rw [List.range_succ, List.foldl_append]
+    simp only [List.foldl_cons, List.foldl_nil]
+    rw [ih, ← pow_add]
+    congr 1
+    -- Goal: n * (n + 1) / 2 + (n + 1) = (n + 1) * (n + 2) / 2
+    have heven : 2 ∣ n * (n + 1) := by
+      rcases Nat.even_or_odd n with ⟨m, hm⟩ | ⟨m, hm⟩
+      · exact ⟨m * (n + 1), by subst hm; ring⟩
+      · exact ⟨n * (m + 1), by subst hm; ring⟩
+    have heven2 : 2 ∣ (n + 1) * (n + 2) := by
+      rcases Nat.even_or_odd n with ⟨m, hm⟩ | ⟨m, hm⟩
+      · exact ⟨(n + 1) * (m + 1), by subst hm; ring⟩
+      · exact ⟨(m + 1) * (n + 2), by subst hm; ring⟩
+    linarith [Nat.div_mul_cancel heven, Nat.div_mul_cancel heven2,
+              show n * (n + 1) + 2 * (n + 1) = (n + 1) * (n + 2) from by ring]
 
 /-
   ## Section 3: Division Arithmetic for L(x)/x

--- a/proofs/Proofs/Erdos437Problem.lean
+++ b/proofs/Proofs/Erdos437Problem.lean
@@ -236,15 +236,21 @@ theorem L_growth_rate :
   intro ε hε
   obtain ⟨N₁, hL₁⟩ := L_lower_bound ε hε
   obtain ⟨N₂, hL₂⟩ := L_upper_bound ε hε
-  use max N₁ N₂
+  use max (max N₁ N₂) 1
   intro x hx
-  have hx₁ : x ≥ N₁ := le_of_max_le_left hx
-  have hx₂ : x ≥ N₂ := le_of_max_le_right hx
+  have hx₁ : x ≥ N₁ := le_trans (le_trans (le_max_left N₁ N₂) (le_max_left _ 1)) hx
+  have hx₂ : x ≥ N₂ := le_trans (le_trans (le_max_right N₁ N₂) (le_max_left _ 1)) hx
+  have hxpos : (x : ℝ) > 0 := by
+    have h1 : x ≥ 1 := le_trans (le_max_right _ _) hx
+    have : (1 : ℝ) ≤ (x : ℝ) := by exact_mod_cast h1
+    linarith
   constructor
   · have h := hL₁ x hx₁
-    sorry -- Division by x
+    rw [ge_iff_le, le_div_iff hxpos]
+    linarith [mul_comm (x : ℝ) (Real.exp (-(Real.sqrt 2 + ε) * u x))]
   · have h := hL₂ x hx₂
-    sorry -- Division by x
+    rw [div_le_iff hxpos]
+    linarith [mul_comm (x : ℝ) (Real.exp (-(1 / Real.sqrt 2 - ε) * u x))]
 
 /--
 **Comparison to x^(1-ε):**

--- a/proofs/Proofs/Erdos695Aristotle.lean
+++ b/proofs/Proofs/Erdos695Aristotle.lean
@@ -24,25 +24,25 @@ def IsPrimeChain (p : ℕ → ℕ) : Prop :=
   StrictMono p ∧ (∀ i, (p i).Prime) ∧ (∀ i, p (i + 1) % p i = 1)
 
 /-- Prime chains are strictly increasing -/
-lemma primeChain_strictMono (p : ℕ → ℕ) (h : IsPrimeChain p) : StrictMono p := by
-  sorry
+lemma primeChain_strictMono (p : ℕ → ℕ) (h : IsPrimeChain p) : StrictMono p := h.1
 
 /-- All elements of a prime chain are prime -/
-lemma primeChain_all_prime (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : (p i).Prime := by
-  sorry
+lemma primeChain_all_prime (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : (p i).Prime :=
+  h.2.1 i
 
 /-- All elements of a prime chain are ≥ 2 -/
-lemma primeChain_ge_two (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : p i ≥ 2 := by
-  sorry
+lemma primeChain_ge_two (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : p i ≥ 2 :=
+  (h.2.1 i).two_le
 
 /-- p(i+1) > p(i) in a prime chain -/
-lemma primeChain_next_gt (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : p (i + 1) > p i := by
-  sorry
+lemma primeChain_next_gt (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : p (i + 1) > p i :=
+  h.1 (Nat.lt_succ_self i)
 
-/-- p(i+1) ≥ p(i) + p(i) = 2*p(i) in a prime chain (since p(i) | p(i+1)-1) -/
+/-- p(i+1) ≥ p(i) + 1 in a prime chain (StrictMono) -/
 lemma primeChain_next_ge_double (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) :
     p (i + 1) ≥ p i + 1 := by
-  sorry
+  have := h.1 (Nat.lt_succ_self i)
+  omega
 
 /-
   ## Section 2: ChainDivisibility
@@ -53,12 +53,16 @@ def ChainDivisibility (p : ℕ → ℕ) : Prop :=
 
 /-- If p(i+1) % p(i) = 1 then p(i) | p(i+1) - 1 -/
 lemma mod_one_implies_dvd (p q : ℕ) (h : q % p = 1) (hq : q ≥ 1) : p ∣ q - 1 := by
-  sorry
+  refine ⟨q / p, ?_⟩
+  have h1 : q / p * p + 1 = q := by
+    have := Nat.div_add_mod q p; omega
+  have h2 : q / p * p = p * (q / p) := mul_comm _ _
+  omega
 
 /-- Chain congruence implies divisibility -/
 lemma chain_cong_to_dvd (p : ℕ → ℕ) (hprime : ∀ i, (p i).Prime)
-    (hcong : ∀ i, p (i + 1) % p i = 1) : ChainDivisibility p := by
-  sorry
+    (hcong : ∀ i, p (i + 1) % p i = 1) : ChainDivisibility p := fun i =>
+  mod_one_implies_dvd _ _ (hcong i) (hprime (i + 1)).pos.le
 
 /-
   ## Section 3: Real.rpow Helpers for Growth Rate
@@ -72,18 +76,25 @@ lemma rpow_tendsto_atTop_iff (p : ℕ → ℕ) :
 
 /-- For c > 1, c^k → ∞ -/
 lemma pow_tendsto_atTop (c : ℝ) (hc : c > 1) :
-    Filter.Tendsto (fun k : ℕ => c ^ k) Filter.atTop Filter.atTop := by
-  sorry
+    Filter.Tendsto (fun k : ℕ => c ^ k) Filter.atTop Filter.atTop :=
+  tendsto_pow_atTop_atTop_of_one_lt hc
 
 /-- rpow is monotone: if a ≤ b and r ≥ 0 then a^r ≤ b^r -/
 lemma rpow_mono (a b : ℝ) (r : ℝ) (ha : 0 ≤ a) (hr : 0 ≤ r) (h : a ≤ b) :
-    a ^ r ≤ b ^ r := by
-  sorry
+    a ^ r ≤ b ^ r := Real.rpow_le_rpow ha h hr
 
 /-- (p k : ℝ)^(1/k) ≥ 2 for k ≥ 1 when p k ≥ 2^k -/
 lemma rpow_ge_two_of_exp_bound (p : ℕ → ℕ) (k : ℕ) (hk : k ≥ 1)
     (h : p k ≥ 2 ^ k) : (p k : ℝ) ^ (1 / (k : ℝ)) ≥ 2 := by
-  sorry
+  have hpk : (2 : ℝ) ^ k ≤ (p k : ℝ) := by exact_mod_cast h
+  have h2k_rpow : ((2 : ℝ) ^ k) ^ (1 / (k : ℝ)) = 2 := by
+    rw [← Real.rpow_natCast 2 k, ← Real.rpow_mul (by norm_num : (0:ℝ) ≤ 2)]
+    have hk_pos : (k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+    rw [mul_one_div_cancel hk_pos]
+    simp [Real.rpow_one]
+  calc (2 : ℝ) = ((2 : ℝ) ^ k) ^ (1 / (k : ℝ)) := h2k_rpow.symm
+    _ ≤ (p k : ℝ) ^ (1 / (k : ℝ)) :=
+        rpow_mono _ _ _ (by positivity) (by positivity) hpk
 
 /-
   ## Section 4: Dirichlet Consequence
@@ -93,9 +104,16 @@ lemma rpow_ge_two_of_exp_bound (p : ℕ → ℕ) (k : ℕ) (hk : k ≥ 1)
 lemma prime_cong_one_exists (p : ℕ) (hp : p.Prime) : ∃ q : ℕ, q.Prime ∧ q % p = 1 := by
   sorry
 
-/-- The smallest prime ≡ 1 (mod p) is > p -/
+/-- Any prime q ≡ 1 (mod p) satisfies q > p -/
 lemma smallest_cong_prime_gt (p : ℕ) (hp : p.Prime) (q : ℕ) (hq : q.Prime)
     (hmod : q % p = 1) : q > p := by
-  sorry
+  rcases Nat.lt_or_ge q p with hlt | hge
+  · -- q < p → q % p = q → q = 1, not prime
+    rw [Nat.mod_eq_of_lt hlt] at hmod
+    exact absurd hmod hq.one_lt.ne'
+  · -- q ≥ p: need q ≠ p
+    rcases Nat.eq_or_gt_of_le hge with rfl | hgt
+    · simp [Nat.mod_self] at hmod
+    · exact hgt
 
 end Erdos695.Aristotle


### PR DESCRIPTION
## Summary
Research session proving multiple sorries across 3 problems.

## erdos-695 (Prime Chain Growth) — 11 Aristotle sorries proved
- `primeChain_strictMono`, `primeChain_all_prime`, `primeChain_ge_two`: trivial from definition
- `primeChain_next_gt`, `primeChain_next_ge_double`: from StrictMono property
- `mod_one_implies_dvd`: via Nat.div_add_mod + omega
- `chain_cong_to_dvd`: from mod_one_implies_dvd
- `smallest_cong_prime_gt`: case analysis (q<p vs q≥p, q=p case uses Nat.mod_self)
- `pow_tendsto_atTop`: tendsto_pow_atTop_atTop_of_one_lt
- `rpow_mono`: Real.rpow_le_rpow
- `rpow_ge_two_of_exp_bound`: Real.rpow_mul + rpow_mono

2 remain: rpow_tendsto_atTop_iff (complex filter theory) and prime_cong_one_exists (Dirichlet)

## erdos-107-incomplete-01 (Happy Ending) — 2 sorries proved
- `cardSet_three_lower_bound` in both Erdos107Problem.lean and Erdos107Aristotle.lean
- Proof: ersz_lower_bound(3) + Nat.sInf_le

## erdos-323 (Sums of k-th powers) — 3 new theorems
- `IsSumOfPowers_one_iff`, `isSumOfPowers_pow_self`, `powerSumCount_one_lb`
- Proves m=1 case: f_{k,1}(n^k) ≥ n+1

## Status
Total: ~15 sorries proved across 3 problems.

🤖 Generated by researcher-1