### PR TITLE
Enrich 6 proofs: overview, sections, annotations, index.ts fixes

### DIFF
--- a/src/data/proofs/fodor-pressing-down/annotations.json
+++ b/src/data/proofs/fodor-pressing-down/annotations.json
@@ -1,56 +1,62 @@
 [
   {
     "id": "ann-club",
+    "proofId": "fodor-pressing-down",
+    "range": { "startLine": 39, "endLine": 86 },
     "type": "definition",
-    "label": "IsClubBelow",
-    "title": "Club Set Below an Ordinal",
-    "body": "A club (closed unbounded) set below ordinal o is S ⊆ Iio o that is closed (every limit ordinal below o that is a limit point of S belongs to S) and unbounded (S is cofinal in Iio o). Clubs form a filter that is countably complete for uncountable regular cardinals.",
-    "location": { "line": 53 },
-    "tags": ["definition", "club", "ordinal", "set-theory"]
-  },
-  {
-    "id": "ann-stationary",
-    "type": "definition",
-    "label": "IsStationaryBelow",
-    "title": "Stationary Set",
-    "body": "S is stationary below o if it meets every club below o. Stationary sets cannot be 'avoided' by a club — they are the natural domain of regressive functions in Fodor's lemma.",
-    "location": { "line": 59 },
-    "tags": ["definition", "stationary", "ordinal"]
+    "title": "Club and Stationary Sets: Set-Theoretic Infrastructure",
+    "content": "IsClubBelow S o is a structure with two fields: mem_lt (S ⊆ Iio o — bounded below o) and mem_of_isAcc (S is closed: every accumulation point of S below o is in S). IsUnboundedBelow S o says S is cofinal below o. IsClubBelow requires both closedness AND unboundedness. IsStationaryBelow S o says S meets every club below o. These definitions formalize concepts missing from Mathlib's set theory library.",
+    "mathContext": "$S$ is a **club** (closed unbounded set) below $o$ if: (1) $S \\subseteq \\{\\alpha < o\\}$, (2) every limit ordinal $\\gamma < o$ with $\\sup(S \\cap \\gamma) = \\gamma$ satisfies $\\gamma \\in S$, (3) $S$ is cofinal in $o$. $S$ is **stationary** below $o$ if $S \\cap C \\neq \\emptyset$ for every club $C$ below $o$.",
+    "significance": "key",
+    "relatedConcepts": ["club filter", "stationary set", "closed unbounded", "ordinal accumulation point"],
+    "prerequisites": ["Ordinal.IsAcc", "Set.Iio", "Ordinal.IsSuccLimit"]
   },
   {
     "id": "ann-diag-inter",
+    "proofId": "fodor-pressing-down",
+    "range": { "startLine": 87, "endLine": 107 },
     "type": "definition",
-    "label": "diagInter",
-    "title": "Diagonal Intersection",
-    "body": "Δ_{α<o}(f α) = {γ < o | ∀ α < γ, γ ∈ f α}. Unlike ordinary intersection which demands membership for all α, the diagonal intersection only requires membership in f(α) for those α BELOW γ, respecting the ordinal structure.",
-    "location": { "line": 0 },
-    "tags": ["definition", "diagonal-intersection", "ordinal"]
+    "title": "Diagonal Intersection: The Key Tool",
+    "content": "diagInter f o = {γ ∈ Iio o | ∀ α < γ, γ ∈ f α}. Unlike ordinary intersection which requires γ ∈ f(α) for ALL α, the diagonal intersection only requires γ ∈ f(α) for those α BELOW γ — this respects the ordinal order. Intuitively, γ 'knows' about f(α) only for α that came before it. The iff characterization mem_diagInter and the subset lemma diagInter_subset_Iio are proved first.",
+    "mathContext": "$\\Delta_{\\alpha < o}(f(\\alpha)) = \\{\\gamma < o \\mid \\forall \\alpha < \\gamma,\\ \\gamma \\in f(\\alpha)\\}$. Compare: $\\bigcap_{\\alpha < o} f(\\alpha) = \\{\\gamma \\mid \\forall \\alpha,\\ \\gamma \\in f(\\alpha)\\}$ (ordinary intersection, stronger).",
+    "significance": "key",
+    "relatedConcepts": ["diagonal intersection", "normal filter", "ordinal membership", "set comprehension"],
+    "prerequisites": ["Set.sep_def", "Ordinal.lt_iff_le_and_ne"]
   },
   {
     "id": "ann-diag-club",
-    "type": "theorem",
-    "label": "diagInter_isClubBelow",
-    "title": "Diagonal Intersection of Clubs Is a Club",
-    "body": "If f(α) is a club below κ for every α < κ (κ regular uncountable), then diagInter f is a club. The two-part proof: (1) diagInter_isClosedBelow via closure of each f(α); (2) diagInter_isUnboundedBelow via a zipper argument interleaving elements from each f(α).",
-    "location": { "line": 0 },
-    "tags": ["diagonal-intersection", "club", "key-lemma"]
+    "proofId": "fodor-pressing-down",
+    "range": { "startLine": 108, "endLine": 258 },
+    "type": "technique",
+    "title": "Diagonal Intersection of Clubs Is a Club: Zipper Construction",
+    "content": "diagInter_isClubBelow proves the key set-theoretic fact: if f(α) is a club below κ for every α < κ (κ regular uncountable), then diagInter f κ is a club. Two-part proof: (1) diagInter_isClosedBelow: if γ is an accumulation point of Δ(f) below κ, then for each α < γ, γ is also an accumulation point of f(α), so γ ∈ f(α) by closedness of f(α). (2) diagInter_isUnboundedBelow: the 'zipper' argument — given any δ < κ, build an increasing sequence δ < γ_0 < γ_1 < ... where γ_{n+1} is the least element of f(γ_n) above γ_n. By regularity of κ, this sequence is bounded, and the supremum γ_ω lies in every f(α) for α < γ_ω.",
+    "mathContext": "Zipper: $\\delta < \\gamma_0 \\in f(\\delta)$, $\\gamma_n < \\gamma_{n+1} \\in f(\\gamma_n)$. By regularity: $\\gamma_\\omega = \\sup_n \\gamma_n < \\kappa$. For $\\alpha < \\gamma_\\omega$: $\\alpha < \\gamma_n$ for some $n$, so $\\gamma_\\omega$ is an acc. pt. of $f(\\alpha) \\ni \\gamma_n$, hence $\\gamma_\\omega \\in f(\\alpha)$.",
+    "significance": "key",
+    "relatedConcepts": ["club filter normality", "diagonal intersection", "zipper construction", "regular cardinals"],
+    "prerequisites": ["Cardinal.IsRegular", "diagInter_isClosedBelow", "diagInter_isUnboundedBelow", "Ordinal.iSup"]
   },
   {
     "id": "ann-fodor",
-    "type": "theorem",
-    "label": "fodor",
-    "title": "Fodor's Pressing-Down Lemma",
-    "body": "For regular uncountable κ, stationary S ⊆ κ.ord, and regressive f : S → κ.ord (f(α) < α): ∃ β, ∃ T ⊆ S stationary, ∀ α ∈ T, f(α) = β. Proof by contradiction: choose clubs C_β avoiding each fiber, form their diagonal intersection D (a club), derive a contradiction from any γ ∈ S ∩ D.",
-    "location": { "line": 0 },
-    "tags": ["fodor", "pressing-down", "main-theorem"]
+    "proofId": "fodor-pressing-down",
+    "range": { "startLine": 259, "endLine": 333 },
+    "type": "insight",
+    "title": "Fodor's Lemma: Proof by Diagonal Intersection",
+    "content": "fodor proves: for regular uncountable κ, stationary S ⊆ κ.ord, and regressive f (f(α) < α for α ∈ S): ∃ β, f⁻¹(β) ∩ S is stationary. By contradiction: if no f⁻¹(β) ∩ S is stationary, choose clubs C_β with C_β ∩ f⁻¹(β) ∩ S = ∅. Form D = Δ_{β<κ}(C_β) (a club by diagInter_isClubBelow). Take γ ∈ S ∩ D (nonempty since S is stationary and D is a club). Since f is regressive, β = f(γ) < γ, so γ ∈ C_β (because γ ∈ D = Δ C and β < γ). But then f(γ) = β ∈ C_β ∩ f⁻¹(β) ∩ S — contradiction.",
+    "mathContext": "Proof structure: assume $\\forall \\beta,\\ f^{-1}(\\beta) \\cap S$ non-stationary. Choose clubs $C_\\beta$ with $C_\\beta \\cap S \\cap f^{-1}(\\beta) = \\emptyset$. Form $D = \\Delta_{\\beta<\\kappa}(C_\\beta)$ (club). Take $\\gamma \\in S \\cap D$. Then $f(\\gamma) = \\beta < \\gamma$, so $\\gamma \\in C_\\beta$. But $C_\\beta \\cap S \\cap f^{-1}(\\beta) = \\emptyset$. Contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["Fodor's lemma", "regressive function", "diagonal intersection", "proof by contradiction"],
+    "prerequisites": ["diagInter_isClubBelow", "IsStationaryBelow", "IsRegular", "fodor_aleph1"]
   },
   {
     "id": "ann-aleph1",
-    "type": "theorem",
-    "label": "fodor_aleph1",
-    "title": "Fodor's Lemma for ℵ₁",
-    "body": "The ℵ₁ specialization: any regressive function on a stationary subset of ω₁ is constant on some stationary subset. The most commonly used instance in combinatorial and descriptive set theory.",
-    "location": { "line": 0 },
-    "tags": ["fodor", "aleph1", "corollary"]
+    "proofId": "fodor-pressing-down",
+    "range": { "startLine": 320, "endLine": 333 },
+    "type": "context",
+    "title": "Fodor's Lemma for ℵ₁: The Canonical Application",
+    "content": "fodor_aleph1 specializes to κ = ℵ₁: any regressive function on a stationary subset of ω₁ is constant on some stationary subset. This is the most commonly used instance in descriptive set theory, forcing arguments, and the study of ω₁-trees. The ℵ₁ corollary is what most textbooks call 'Fodor's Lemma' without qualification.",
+    "mathContext": "Specialization of `fodor` to $\\kappa = \\aleph_1$ (the first uncountable cardinal). $\\aleph_1$ is regular (every countable union of countable sets is countable), and $|\\aleph_1|$ is uncountable by definition.",
+    "significance": "supporting",
+    "relatedConcepts": ["ℵ₁", "ω₁", "Aronszajn trees", "regressive function", "countable cofinality"],
+    "prerequisites": ["Cardinal.aleph_regularCard", "Cardinal.aleph_pos", "fodor"]
   }
 ]

--- a/src/data/proofs/fodor-pressing-down/index.ts
+++ b/src/data/proofs/fodor-pressing-down/index.ts
@@ -1,31 +1,8 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
-
+import sourceRaw from '../../../../proofs/Proofs/FodorPressingDown.lean?raw'
 const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
-
-const leanSource = () => import('../../../../proofs/Proofs/FodorPressingDown.lean?raw')
-
-export const proof: Proof = {
-  id: meta.id,
-  title: meta.title,
-  slug: meta.slug,
-  description: meta.description,
-  meta: meta.meta,
-  sections: meta.sections,
-  source: '',
-  overview: meta.overview,
-  conclusion: meta.conclusion,
-  crossReferences: meta.crossReferences
-}
-
-export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
-
-export const proofData: ProofData = { proof, annotations }
-
-export async function getProofSource(): Promise<string> {
-  const module = await leanSource()
-  return module.default
-}
-
-export default proofData
+export const fodorPressingDownProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const fodorPressingDownAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const fodorPressingDownData: ProofData = { proof: fodorPressingDownProof, annotations: fodorPressingDownAnnotations, tacticStates: [] }

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -4,58 +4,69 @@
   "slug": "fodor-pressing-down",
   "description": "A complete formalization of Fodor's Pressing-Down Lemma (1956): any regressive function on a stationary subset of a regular uncountable cardinal is constant on some stationary subset. The proof uses the diagonal intersection technique—defining infrastructure for club sets, stationary sets, and diagonal intersections that is not yet in Mathlib.",
   "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-05-04",
     "status": "verified",
     "badge": "original",
+    "proofRepoPath": "Proofs/FodorPressingDown.lean",
+    "tags": ["set-theory", "ordinals", "cardinals", "clubs", "stationary", "fodor"],
+    "sorries": 0,
     "axiomCount": 0,
-    "sorryCount": 0,
+    "lineCount": 386,
     "theoremCount": 12,
     "definitionCount": 3,
-    "lineCount": 386,
-    "leanFile": "proofs/Proofs/FodorPressingDown.lean",
-    "imports": [
-      "Mathlib.SetTheory.Cardinal.Ordinal",
-      "Mathlib.SetTheory.Cardinal.Cofinality",
-      "Mathlib.SetTheory.Cardinal.Regular",
-      "Mathlib.SetTheory.Ordinal.Arithmetic",
-      "Mathlib.SetTheory.Ordinal.Topology"
-    ],
-    "tags": ["set-theory", "ordinals", "cardinals", "clubs", "stationary", "fodor"],
-    "assumptions": [],
-    "sorries": 0
+    "leanFile": {
+      "path": "Proofs/FodorPressingDown.lean",
+      "axiomCount": 0,
+      "sorryCount": 0,
+      "lineCount": 386,
+      "theoremCount": 12,
+      "definitionCount": 3
+    }
+  },
+  "overview": {
+    "historicalContext": "Fodor's Pressing-Down Lemma was proved by Géza Fodor in 1956, and is sometimes also called the Fodor-Neumer theorem. It is one of the most useful tools in combinatorial and descriptive set theory. The lemma asserts that any regressive function (f(α) < α) on a stationary subset of a regular uncountable cardinal κ must be constant on some stationary subset — the function cannot 'press down' uniformly. The key technique is the **diagonal intersection**: if f⁻¹(β) is non-stationary for every β, we can find clubs C_β avoiding each fiber, and their diagonal intersection Δ_{β<κ}(C_β) is still a club (since diagonal intersections of clubs are clubs), contradicting the stationarity of the domain.",
+    "problemStatement": "Let $\\kappa$ be a regular uncountable cardinal. Let $S \\subseteq \\kappa$ be a stationary set, and let $f : S \\to \\kappa$ be regressive (meaning $f(\\alpha) < \\alpha$ for all $\\alpha \\in S$ with $\\alpha > 0$). **Prove**: there exists $\\beta < \\kappa$ such that $f^{-1}(\\beta) \\cap S$ is stationary.",
+    "proofStrategy": "Proof by contradiction. Assume f⁻¹(β) ∩ S is non-stationary for every β < κ. Then for each β, there exists a club C_β ⊆ κ with C_β ∩ f⁻¹(β) ∩ S = ∅, i.e., f(α) ≠ β for all α ∈ C_β ∩ S. Form the diagonal intersection D = Δ_{β<κ}(C_β) = {γ | ∀ β < γ, γ ∈ C_β}. Since each C_β is a club and κ is regular uncountable, D is a club (by diagInter_isClubBelow). Take any γ ∈ S ∩ D. By regressiveness, f(γ) = β < γ. Since γ ∈ D, γ ∈ C_β, so f(γ) ≠ β — contradiction.",
+    "keyInsights": [
+      "The diagonal intersection Δ_{α<o}(f α) = {γ | ∀ α < γ, γ ∈ f α} is the key new concept: unlike the ordinary intersection (membership required for ALL α), diagonal intersection only requires membership in f(α) for α BELOW γ — this respects the ordinal order",
+      "diagInter_isClubBelow: the diagonal intersection of κ-many clubs is still a club (for regular uncountable κ). This requires both a closure argument and a 'zipper' construction to prove unboundedness",
+      "The zipper construction for unboundedness: to find a large element of Δ(C_α), build an increasing sequence γ_0 < γ_1 < ... where γ_{n+1} ∈ C_{γ_n} (each step is inside the club for the previous ordinal), then the limit is in the diagonal intersection by closure",
+      "This infrastructure (IsClubBelow, IsStationaryBelow, diagInter) is not yet formalized in Mathlib, making this a genuine contribution to the set-theoretic library",
+      "The ℵ₁ corollary (fodor_aleph1) is the most commonly used instance: regressive functions on stationary subsets of ω₁ are constant on a stationary subset"
+    ]
   },
   "sections": [
     {
       "id": "club-sets",
-      "title": "Club and Stationary Sets",
-      "description": "Definitions for the combinatorial core: IsUnboundedBelow (cofinally dense), IsClubBelow (closed and unbounded — a club set), and IsStationaryBelow (intersects every club). The structure IsClubBelow captures the topologically closed, cofinal condition. These are standard set-theoretic notions not yet formalized in Mathlib.",
-      "theorems": ["isClubBelow_Iio_of_isSuccLimit"]
+      "title": "Club and Stationary Set Infrastructure",
+      "startLine": 39,
+      "endLine": 86,
+      "summary": "Defines IsUnboundedBelow (cofinal below o), IsClubBelow (structure: closed and unbounded), IsStationaryBelow (meets every club). Basic lemmas: IsClubBelow.mem_lt, mem_of_isAcc, isClubBelow_Iio_of_isSuccLimit. These are missing from Mathlib."
     },
     {
       "id": "diagonal-intersection",
-      "title": "Diagonal Intersection",
-      "description": "The diagonal intersection Δ_{α<κ}(f α) = {γ | ∀ α < γ, γ ∈ f α} simultaneously intersects all club sets indexed below κ while respecting the ordinal structure. The lemmas diagInter_isClosedBelow and diagInter_isUnboundedBelow (a zipper construction) together give diagInter_isClubBelow: the diagonal intersection of clubs is a club.",
-      "theorems": ["mem_diagInter", "diagInter_subset_Iio", "diagInter_isClosedBelow", "diagInter_isUnboundedBelow", "diagInter_isClubBelow"]
+      "title": "Diagonal Intersection Definition and Properties",
+      "startLine": 87,
+      "endLine": 258,
+      "summary": "Defines diagInter f o = {γ < o | ∀ α < γ, γ ∈ f α}. Lemmas: mem_diagInter (iff characterization), diagInter_subset_Iio (stays below o), diagInter_isClosedBelow (closure from closedness of each f α), diagInter_isUnboundedBelow (zipper construction), diagInter_isClubBelow (main: diagonal intersection of clubs is a club)."
     },
     {
       "id": "fodors-lemma",
-      "title": "Fodor's Lemma",
-      "description": "The main theorem fodor: for a regular uncountable cardinal κ with stationary set S and regressive function f (f(α) < α for all α ∈ S), some constant value is achieved on a stationary subset. Proof by contradiction using diagonal intersection. The corollary fodor_aleph1 specializes to κ = ℵ₁.",
-      "theorems": ["fodor", "fodor_aleph1"]
+      "title": "Fodor's Pressing-Down Lemma",
+      "startLine": 259,
+      "endLine": 386,
+      "summary": "fodor: main theorem for regular uncountable κ. fodor_aleph1: corollary for κ = ℵ₁. Additional lemmas: IsStationaryBelow.nonempty, IsStationaryBelow.of_subset."
     }
   ],
-  "overview": {
-    "summary": "Fodor's Pressing-Down Lemma (also called the Fodor-Neumer theorem) is one of the fundamental tools of infinitary combinatorics. It asserts that any regressive function on a stationary set cannot 'press down' all values—some single value must be achieved on a stationary subset.",
-    "approach": "The proof uses diagonal intersection: the diagonal intersection of clubs C_β (for β < κ) is itself a club. If the conclusion failed, we could build clubs C_β avoiding each fiber f⁻¹(β), and their diagonal intersection would contradict the stationarity of S.",
-    "significance": "Fodor's lemma is used throughout combinatorial set theory: in the proof that the club filter is normal, in cardinal arithmetic, in the Erdős-Hajnal theorem on partition calculus, and in many reflection principles. The diagonal intersection construction formalized here is reusable infrastructure absent from Mathlib."
-  },
   "conclusion": {
-    "summary": "Fodor's Pressing-Down Lemma is machine-checked with no axioms or sorries. The proof builds club and stationary set infrastructure currently missing from Mathlib.",
+    "summary": "Fodor's Pressing-Down Lemma is machine-checked with zero axioms and zero sorries. The proof builds club, stationary, and diagonal intersection infrastructure currently absent from Mathlib, forming reusable set-theoretic library code.",
+    "implications": "Fodor's lemma is a foundational tool in infinitary combinatorics. It implies that the club filter on a regular uncountable cardinal is normal (closed under diagonal intersections). It is used in Shelah's proper forcing theory, in the proof of Solovay's theorem that every stationary set can be split into κ stationary pieces, and in many reflection principles. The infrastructure proved here — club sets, stationary sets, diagonal intersections — is directly reusable for these applications.",
     "openQuestions": [
-      "Can the club and stationary set infrastructure be contributed to Mathlib as a standalone library?",
-      "Does the formalization extend to Shelah-style combinatorial principles (e.g., Diamond ◇)?",
-      "Can the normal filter characterization (the club filter is κ-complete and normal) be derived from this infrastructure?"
+      "Can the club and stationary set infrastructure be contributed to Mathlib as a standalone library, analogous to the existing Ordinal.Topology module?",
+      "Can the Diamond principle ◇_κ (a combinatorial statement about predicting functions on ordinals) be proved from club filter normality using this infrastructure?",
+      "Does the formalization extend to the more general Shelah-style reflection principles (e.g., □_κ sequences, which use the non-club structure)?"
     ]
   },
-  "crossReferences": [],
-  "sorries": 0
+  "crossReferences": []
 }


### PR DESCRIPTION
Enrichment pass for 5 gallery entries on branch feature/enricher-2.

## law-of-cosines-oq-04-oq-02 (Angle Bisector Length Formula)
Created annotations.json (7 annotations), created index.ts, added full overview/sections/conclusion

## birch-swinnerton-dyer-oq-06-oq-02 (Weierstrass Group Law for Curve 389a)
Added overview (historicalContext: Buhler-Gross-Zagier 1985), 8 sections with line ranges, updated 8 annotations

## borsuk-ulam-oq-03-oq-04 (Quantitative 1D Borsuk-Ulam)
Added overview, fixed sections (startLine/endLine), updated 4 annotations, fixed crossReferences, fixed index.ts

## erdos-31-primes-density (Primes Have Natural Density Zero)
Added overview (historicalContext: Chebyshev 1850), fixed sections, updated 4 annotations, fixed index.ts

## picks-theorem-oq-01-oq-01 (Primitive Triangulation of Lattice Triangles)
Added overview (historicalContext: Pick 1899), fixed sections, updated 4 annotations, fixed index.ts

All enrichments: `pnpm build` passes cleanly.

**Common patterns fixed**: non-standard `body`→`content`, `location.line`→`range`, `targetId`→`id` in crossReferences, async lazy-load index.ts→standard synchronous ?raw import.