### PR TITLE
fix(meta): sync stale root-level sorries for cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -162,5 +162,5 @@
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",
     "sorries": 0
   },
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Corrects a stale root-level `sorries` field for `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01`.

## Evidence

**Before**: 
- Root-level `sorries: 3` (stale, from when the proof had 3 sorries)
- `leanFile.sorries: 0` (up-to-date)
- `meta.sorries: 0` (up-to-date)

**After**: All three sorries fields are 0, consistent with the actual Lean source file which has 0 sorry terms and is correctly marked `status: verified, badge: original`.

The proof was completed (sorries eliminated) and `leanFile.sorries` and `meta.sorries` were updated at that time, but the root-level `sorries` field was not synced.

---
Automated fix by lean-mechanic agent.