### PR TITLE
fix(meta): sync stale counts after research PRs — 5 gallery entries

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-05-04",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "probability",
       "information-theory",
@@ -16,12 +16,12 @@
       "combinatorics"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean",
-    "badge": "wip",
-    "sorries": 2,
+    "badge": "verified",
+    "sorries": 0,
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
-    "lineCount": 261,
-    "assumptions": "No axioms. 2 sorries remain: source entropy recovery (H(Multinomial(1,p)) = -∑ pᵢ log pᵢ) and the log upper bound H ≤ log|Comp(s,n)|. The non-negativity and zero-trial theorems are fully proved.",
+    "lineCount": 380,
+    "assumptions": "No axioms, no sorries. Fully verified: non-negativity, zero-trial determinism, source entropy recovery at n=1, and the Gibbs-inequality upper bound H ≤ log|Comp(s,n)|.",
     "originalContributions": [
       "multinomialEntropy: Shannon entropy definition for multinomial distribution",
       "multinomialEntropy_nonneg: H(X) ≥ 0 for valid probability vectors (fully proved)",
@@ -147,14 +147,14 @@
       "BinomialTheoremOQ02OQ01"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ02",
-    "lineCount": 316,
+    "lineCount": 380,
     "axiomCount": 0,
-    "theoremCount": 9,
-    "substantiveTheoremCount": 7,
+    "theoremCount": 8,
+    "substantiveTheoremCount": 5,
     "duplicateTheorems": 0,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "mainTheorems": [
     {
@@ -176,5 +176,5 @@
       "leanType": "multinomialProb s p 1 (fun i => if i = j then 1 else 0) = p j"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "None — fully verified. Depends on CubeRoot2IrrationalOQ03 for adjoin_nthRoot_finrank and related lemmas.",
-    "lineCount": 91,
+    "lineCount": 133,
     "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [
@@ -33,7 +33,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 91,
+    "lineCount": 133,
     "path": "Proofs/CubeRoot3IrrationalOQ02OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -16,7 +16,7 @@
       "convex-geometry"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 107,
     "erdosUrl": "https://erdosproblems.com/107",
     "erdosProblemStatus": "open",
@@ -63,8 +63,8 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 6,
-    "lineCount": 243,
-    "assumptions": "6 axioms (deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds). 2 sorries (f_3_value and cardSet_three_lower_bound require EuclideanSpace API beyond current scope). f_finite proved from ersz_lower_bound by contradiction.",
+    "lineCount": 249,
+    "assumptions": "6 axioms (deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds). 1 sorry: f_3_value (requires EuclideanSpace API beyond current scope). f_finite proved from ersz_lower_bound by contradiction.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12
   },
@@ -209,8 +209,8 @@
   "sorries": 2,
   "leanFile": {
     "axiomCount": 6,
-    "lineCount": 243,
-    "sorries": 2,
+    "lineCount": 249,
+    "sorries": 1,
     "path": "Proofs/Erdos107Problem.lean",
     "definitionCount": 6,
     "theoremCount": 12

--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 437,
     "erdosUrl": "https://erdosproblems.com/437",
     "erdosProblemStatus": "solved",
@@ -63,8 +63,8 @@
       "hyperelliptic_connection: link to algebraic curves"
     ],
     "axiomCount": 4,
-    "lineCount": 284,
-    "assumptions": "4 axioms: L_little_o_x, erdos_437, L_lower_bound, L_upper_bound. 3 sorries.",
+    "lineCount": 290,
+    "assumptions": "4 axioms: L_little_o_x, erdos_437, L_lower_bound, L_upper_bound. 1 sorry: powers_of_four_all_squares.",
     "theoremCount": 5
   },
   "overview": {
@@ -240,12 +240,12 @@
       "Finset"
     ],
     "namespace": "Erdos437",
-    "lineCount": 284,
+    "lineCount": 290,
     "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 9,
     "path": "Proofs/Erdos437Problem.lean",
-    "sorries": 3
+    "sorries": 1
   },
   "sorries": 3
 }

--- a/src/data/proofs/law-of-cosines-oq-04-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-02/meta.json
@@ -13,8 +13,8 @@
     "opens": ["StewartsTheorem"],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 163,
-    "theoremCount": 7,
+    "lineCount": 173,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "openQuestion": {
@@ -58,8 +58,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 163,
-    "theoremCount": 7,
+    "lineCount": 173,
+    "theoremCount": 9,
     "definitionCount": 0,
     "originalContributions": [
       "bisector_ratio_m: m·(b+c) = a·c from angle bisector ratio — proved via linear_combination",


### PR DESCRIPTION
## Fix

Corrects stale gallery metadata in 5 entries after researchers added/completed proofs without updating meta.json.

## Evidence

| Entry | Field | Before | After |
|---|---|---|---|
| binomial-theorem-oq-02-oq-01-oq-01-oq-02 | lineCount | 316 | 380 |
| binomial-theorem-oq-02-oq-01-oq-01-oq-02 | sorries | 1 | 0 |
| binomial-theorem-oq-02-oq-01-oq-01-oq-02 | status | formalized | verified |
| binomial-theorem-oq-02-oq-01-oq-01-oq-02 | badge | wip | verified |
| cube-root-3-irrational-oq-02-oq-01 | lineCount | 91 | 133 |
| erdos-107 | lineCount | 243 | 249 |
| erdos-107 | sorries | 2 | 1 |
| erdos-437 | lineCount | 284 | 290 |
| erdos-437 | sorries | 3 | 1 |
| law-of-cosines-oq-04-oq-02 | lineCount | 163 | 173 |
| law-of-cosines-oq-04-oq-02 | theoremCount | 7 | 9 |

**binomial-theorem (multinomialEntropy)**: PRs #15784 and #15822 together proved all 6 theorems. Both `multinomialEntropy_n1_eq_source` (n=1 source entropy recovery) and `multinomialEntropy_upper_bound` (Gibbs inequality via t·log t ≥ t-1) are now fully proved. No axioms, no sorries → promoted to verified.

**cube-root-3-irrational-oq-02-oq-01**: PR #15827 extended the file by 42 lines (adding proofs) but did not update meta lineCount.

**erdos-107**: PR #15825 proved `cardSet_three_lower_bound`, reducing sorries from 2→1. Remaining sorry: `f_3_value`.

**erdos-437**: PR #15825 proved 2 sorries, reducing from 3→1. Remaining sorry: `powers_of_four_all_squares`.

**law-of-cosines-oq-04-oq-02**: PR #15834 added 2 new theorems (`angle_bisector_equilateral`, `angle_bisector_isoceles`) but meta still claims theoremCount=7.

---
Automated fix by lean-mechanic agent.