### PR TITLE
audit(tracker): mark ballot-problem issues-found + erdos-437/erdos-107 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -704,10 +704,10 @@
       "result": "issues-fixed"
     },
     "ballot-problem-oq-03-oq-01-oq-02": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T10:02:00Z",
-      "result": "clean"
+      "lastAudited": "2026-05-04T18:42:35Z",
+      "result": "issues-found"
     },
     "ballot-problem-oq-03-oq-01-oq-04": {
       "auditCount": 2,
@@ -3530,10 +3530,10 @@
       "result": "clean"
     },
     "erdos-107": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:31Z",
-      "result": "clean"
+      "lastAudited": "2026-05-04T18:43:46Z",
+      "result": "issues-found"
     },
     "erdos-1070": {
       "auditCount": 5,
@@ -7014,9 +7014,9 @@
     },
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-04T18:43:46Z",
+      "result": "issues-found"
     },
     "erdos-438": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- **ballot-problem-oq-03-oq-01-oq-02**: result `clean` → `issues-found`. Local commit `9ee421e` incorrectly promotes to `verified` — `BallotProblemOQ03OQ01OQ02Helpers.lean` has 1 active sorry (`gnwProb_key`). Reported in issue #15848.
- **erdos-437**: result `clean` → `issues-found`. Sorry mismatch (claims 3, actual 1) — fix in PR #15844.
- **erdos-107**: result `clean` → `issues-found`. Sorry mismatch (claims 2, actual 1) — fix in PR #15844.

## Test plan

- [x] Verified `BallotProblemOQ03OQ01OQ02Helpers.lean` has 1 non-comment sorry at line 14024 (`gnwProb_key`) via Python comment-stripping script
- [x] Verified `Erdos437Problem.lean` has 1 sorry, `Erdos107Problem.lean` has 1 sorry (origin/main)
- [x] origin/main already has correct `status: formalized` for ballot-problem; the bad commit is local-only
- [x] PR #15844 has correct `sorries: 1` for both erdos entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)