### PR TITLE
fix(meta): revert ballot-problem-oq-03-oq-01-oq-02 false verified promotion

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
@@ -21,11 +21,11 @@
       "determinants",
       "representation-theory"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 open sorry in GNW infrastructure (BallotProblemOQ03OQ01OQ02Helpers.lean): gnwProb_key — the GNW 1979 probabilistic identity for ≥10-row, ≥10-col, non-rectangular shapes (hard combinatorial identity). The supporting lemmas gnwProb_sum_corners, strictHookCells_card, strictHookCells_nonempty, and strictHookCells_hookLen_lt were proved in PR #14960. hook_walk_identity_gnw (the dispatcher in the gallery face) calls gnwProb_key and is otherwise complete. hookProd_ratio_formula is sorry-free. Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row through 9-row, ≤9-col (transpose duality), all rectangles.",
+    "assumptions": "Axiom-free: all theorems fully proved with 0 sorries and 0 axiom declarations.",
     "lineCount": 398,
     "theoremCount": 16,
     "definitionCount": 1,
@@ -76,7 +76,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b]. hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. hookProd_ratio_formula is sorry-free. Part XIV proves hook_length_formula_general via corner induction; hook_walk_identity_gnw dispatcher is complete. 1 open sorry remains: gnwProb_key (GNW 1979 probabilistic identity, hard). The supporting strictHookCells_* lemmas and gnwProb_sum_corners were proved in PR #14960.",
+    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b]. hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. hookProd_ratio_formula is proved-free. Part XIV proves hook_length_formula_general via corner induction; hook_walk_identity_gnw dispatcher is complete. 1 open proved remains: gnwProb_key (GNW 1979 probabilistic identity, hard). The supporting strictHookCells_* lemmas and gnwProb_sum_corners were proved in PR #14960.",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -215,5 +215,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
@@ -21,11 +21,11 @@
       "determinants",
       "representation-theory"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Axiom-free: all theorems fully proved with 0 sorries and 0 axiom declarations.",
+    "assumptions": "1 open sorry in GNW infrastructure (BallotProblemOQ03OQ01OQ02Helpers.lean): gnwProb_key — the GNW 1979 probabilistic identity for ≥10-row, ≥10-col, non-rectangular shapes (hard combinatorial identity). The supporting lemmas gnwProb_sum_corners, strictHookCells_card, strictHookCells_nonempty, and strictHookCells_hookLen_lt were proved in PR #14960. hook_walk_identity_gnw (the dispatcher in the gallery face) calls gnwProb_key and is otherwise complete. hookProd_ratio_formula is sorry-free. Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row through 9-row, ≤9-col (transpose duality), all rectangles.",
     "lineCount": 398,
     "theoremCount": 16,
     "definitionCount": 1,
@@ -76,7 +76,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b]. hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. hookProd_ratio_formula is proved-free. Part XIV proves hook_length_formula_general via corner induction; hook_walk_identity_gnw dispatcher is complete. 1 open proved remains: gnwProb_key (GNW 1979 probabilistic identity, hard). The supporting strictHookCells_* lemmas and gnwProb_sum_corners were proved in PR #14960.",
+    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b]. hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. hookProd_ratio_formula is sorry-free. Part XIV proves hook_length_formula_general via corner induction; hook_walk_identity_gnw dispatcher is complete. 1 open sorry remains: gnwProb_key (GNW 1979 probabilistic identity, hard). The supporting strictHookCells_* lemmas and gnwProb_sum_corners were proved in PR #14960.",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -215,5 +215,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-05-04",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "probability",
       "information-theory",
@@ -16,18 +16,20 @@
       "combinatorics"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean",
-    "badge": "wip",
-    "sorries": 2,
+    "badge": "verified",
+    "sorries": 0,
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
-    "lineCount": 261,
-    "assumptions": "No axioms. 2 sorries remain: source entropy recovery (H(Multinomial(1,p)) = -∑ pᵢ log pᵢ) and the log upper bound H ≤ log|Comp(s,n)|. The non-negativity and zero-trial theorems are fully proved.",
+    "lineCount": 380,
+    "assumptions": "Axiom-free: all theorems fully proved with no axiom declarations and no structure-encoded assumptions. Proved: multinomialEntropy_nonneg, multinomialEntropy_zero_trials, multinomialProb_n1_indicator, multinomialEntropy_n1_eq_source, multinomialEntropy_upper_bound, multinomialEntropy_binomial.",
     "originalContributions": [
       "multinomialEntropy: Shannon entropy definition for multinomial distribution",
-      "multinomialEntropy_nonneg: H(X) ≥ 0 for valid probability vectors (fully proved)",
-      "multinomialEntropy_zero_trials: H(Multinomial(0,p)) = 0 (fully proved)",
-      "multinomialProb_n1_indicator: P(indicator_j) = p_j at n=1 (fully proved)",
-      "multinomial_zero_eq_one: Nat.multinomial s 0 = 1 (proved from spec)"
+      "multinomialEntropy_nonneg: H(X) ≥ 0 for valid probability vectors (proved)",
+      "multinomialEntropy_zero_trials: H(Multinomial(0,p)) = 0 (proved)",
+      "multinomialProb_n1_indicator: P(indicator_j) = p_j at n=1 (proved)",
+      "multinomialEntropy_n1_eq_source: H(Multinomial(1,p)) = -∑ pᵢ log pᵢ (proved)",
+      "multinomialEntropy_upper_bound: H(X) ≤ log|Comp(s,n)| via Gibbs inequality (proved)",
+      "multinomialEntropy_binomial: 2-category special case nonneg (proved)"
     ],
     "theoremCount": 8,
     "substantiveTheoremCount": 6,
@@ -81,7 +83,7 @@
       "title": "Source Entropy Recovery at n=1",
       "startLine": 136,
       "endLine": 195,
-      "summary": "multinomialProb_n1_indicator (proved): P(δ_j) = p_j. multinomialEntropy_n1_eq_source (sorry): H(Multinomial(1,p)) = -∑ pᵢ log pᵢ.",
+      "summary": "multinomialProb_n1_indicator (proved): P(δ_j) = p_j. multinomialEntropy_n1_eq_source (proved): H(Multinomial(1,p)) = -∑ pᵢ log pᵢ.",
       "mathContext": "At $n=1$, each composition is an indicator function $\\delta_j$ for some $j \\in s$. The multinomial coefficient $\\text{multinomial}(s, \\delta_j) = 1$ and $\\prod p_i^{\\delta_j(i)} = p_j$. So $H = -\\sum_j p_j \\log p_j = H(p)$."
     },
     {
@@ -89,7 +91,7 @@
       "title": "Entropy Upper Bound",
       "startLine": 198,
       "endLine": 220,
-      "summary": "multinomialEntropy_upper_bound (sorry): H(X) ≤ log|Comp(s,n)| with equality for uniform input.",
+      "summary": "multinomialEntropy_upper_bound (proved): H(X) ≤ log|Comp(s,n)| with equality for uniform input.",
       "mathContext": "By Gibbs inequality applied to uniform Q on Comp(s,n): $H(P) \\leq -\\sum_k P(k)\\log(1/|\\text{Comp}|) = \\log|\\text{Comp}|$."
     },
     {
@@ -124,7 +126,7 @@
     }
   ],
   "conclusion": {
-    "summary": "YES, the Shannon entropy of the multinomial distribution can be formalized in Lean 4. Non-negativity and the zero-trial case are fully proved. The source entropy recovery (n=1) and upper bound require bijection proofs that are structured as sorries.",
+    "summary": "YES, the Shannon entropy of the multinomial distribution can be fully formalized in Lean 4 with 0 axioms and 0 sorries. Non-negativity, zero-trial determinism, source entropy recovery at n=1, and the Gibbs upper bound are all machine-checked.",
     "implications": "The formalization provides a foundation for information-theoretic reasoning about multinomial experiments: entropy bounds for hypothesis testing, channel capacity for categorical channels, and the maximum entropy principle for categorical distributions.",
     "openQuestions": [
       "Can the bijection piAntidiag s 1 ≃ s be expressed cleanly using Finset.sum_nbij or Finset.equiv_of_eq?",
@@ -147,14 +149,14 @@
       "BinomialTheoremOQ02OQ01"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ02",
-    "lineCount": 316,
+    "lineCount": 380,
     "axiomCount": 0,
     "theoremCount": 9,
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "mainTheorems": [
     {
@@ -176,5 +178,5 @@
       "leanType": "multinomialProb s p 1 (fun i => if i = j then 1 else 0) = p j"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-02",
   "title": "Multinomial Entropy Formalization",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 0 sorries, 0 axioms. All 5 theorems proved: nonneg, zero-trial, source-recovery(n=1), upper-bound, binary-case.",
+    "progressSummary": "COMPLETED 2026-05-04: All 6 theorems proved (0 sorries, 0 axioms). multinomialEntropy_nonneg, zero_trials, n1_indicator, n1_eq_source, upper_bound, binomial all machine-checked. Meta.json updated.",
     "builtItems": [
       "Proved Fintype (Composition α s n) in BinomialTheoremOQ02OQ01OQ01.lean via Fintype.ofEquiv + compositionEquiv",
       "Proved dice_six_rolls_all_different by native_decide",
-      "multinomialEntropy_upper_bound: H(X) ≤ log|piAntidiag s n| in BinomialTheoremOQ02OQ01OQ01OQ02.lean via Gibbs inequality (log x ≥ 1 - 1/x from add_one_le_exp)"
+      "multinomialEntropy_upper_bound: H(X) ≤ log|piAntidiag s n| in BinomialTheoremOQ02OQ01OQ01OQ02.lean via Gibbs inequality (log x ≥ 1 - 1/x from add_one_le_exp)",
+      "multinomialEntropy_n1_eq_source: H(Multinomial(1,p)) = -∑ pᵢ log pᵢ (proved via Finset.sum_nbij bijection piAntidiag s 1 ≃ s)",
+      "multinomialEntropy_upper_bound: H(X) ≤ log|Comp(s,n)| (proved via Gibbs inequality: log x ≥ 1 - x⁻¹)"
     ],
     "insights": [
       "Composition α s n is in natural bijection with piAntidiag s n — Finset.mem_piAntidiag gives the exact characterization",
@@ -47,7 +49,9 @@
       "ENNReal version of multinomial theorem for normalization (multinomialPMF_sum_eq_one)",
       "Marginal distribution theory for multinomial (marginal_binomial, mean, covariance)"
     ],
-    "nextSteps": [],
+    "nextSteps": [
+      "DONE: all theorems proved. Consider: multinomial CLT, maximum entropy property for uniform input, or connection to AEP (asymptotic equipartition)"
+    ],
     "markdown": "# Knowledge Base: binomial-theorem-oq-02-oq-01-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],


### PR DESCRIPTION
## Fix

Reverts incorrect promotion of ballot-problem-oq-03-oq-01-oq-02 to `verified` status.

## Evidence

**Before** (bad state from commit 9ee421e in PR #15842):
- `status: "verified"`, `badge: "verified"`, `sorries: 0`
- `assumptions: "Axiom-free: all theorems fully proved..."`
- `conclusion.summary` had garbled text: "proved-free", "1 open proved remains"

**After** (correct state matching origin/main):
- `status: "formalized"`, `badge: "wip"`, `sorries: 1`
- `assumptions`: describes gnwProb_key open sorry in BallotProblemOQ03OQ01OQ02Helpers.lean
- `conclusion.summary`: corrected text ("sorry-free", "1 open sorry remains")

**Root cause**: Commit 9ee421e (in PR #15842) checked only `leanFile.sorries` (main file = 0) but missed the sorry in `additionalFiles`: `BallotProblemOQ03OQ01OQ02Helpers.lean` line 14024 (`gnwProb_key`).

**Verification**: `git show origin/main:proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean | grep -n "sorry"` shows sorry at line 14024.

## Merge order

This PR should be merged **after** PR #15842 (research/binomial-theorem-oq-02-oq-01-oq-01-oq-02 promotion) is merged, to undo the ballot-problem changes that #15842 introduces.

PR #15842 has been labeled `loom:changes-requested` to prevent premature auto-merge.

Closes #15848

---
Automated fix by lean-mechanic agent.