### PR TITLE
fix(meta): correct stale status/sorries in ballot-problem-oq-03-oq-01-oq-02

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean"
@@ -21,11 +21,11 @@
       "determinants",
       "representation-theory"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Axiom-free: all theorems fully proved with 0 sorries and 0 axiom declarations.",
+    "assumptions": "1 open sorry: gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners). Axiom-free; all axiom declarations are 0.",
     "lineCount": 398,
     "theoremCount": 16,
     "definitionCount": 1,
@@ -170,7 +170,7 @@
       "file": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "startLine": 180,
       "endLine": 210,
-      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry), card_SYT_twoRectYD (sorry — SYT count for 2-row rect = C_m).",
+      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03). LGV-approach sorry'd theorems (ni_count_eq_syt_count, lgv_det_factors_as_hook_quotient, card_SYT_twoRectYD) moved to BallotProblemOQ03OQ01OQ02Aristotle.lean companion for Aristotle proof search.",
       "mathContext": "Main theorem: card(SYT(μ)) × hookProd μ = μ.card!. The two sorry components require ~200 lines each."
     },
     {
@@ -215,5 +215,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

The meta.json for `ballot-problem-oq-03-oq-01-oq-02` (Hook-Length Formula via LGV) claimed `status=verified`, `badge=verified`, `sorries=0`, but `BallotProblemOQ03OQ01OQ02Helpers.lean` (declared in `meta.additionalFiles`) contains a real `sorry` at line 14024 in `gnwProb_key` (multi-corner GNW 1979 exchange case).

The narrative fields (`description`, `conclusion.summary`) already correctly state "1 open sorry remains in GNW infrastructure: gnwProb_key". Only the structured status/badge/sorries fields were stale.

## Changes

- `meta.status`: `verified` -> `formalized`
- `meta.badge`: `verified` -> `wip`
- `meta.sorries`: `0` -> `1`
- top-level `sorries`: `0` -> `1`
- `meta.assumptions`: rewritten to mention the `gnwProb_key` open sorry
- `sec-main-theorem` summary: refreshed (LGV-approach sorry'd theorems moved to Aristotle companion)

`leanFile.sorries` is intentionally left at `0` — that field counts only the main face file (`Proofs/BallotProblemOQ03OQ01OQ02.lean`), which is sorry-free. The open sorry lives in the Helpers file (an `additionalFiles` import).

## Evidence

In `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` line 14024:

```lean
    · -- Multi-corner case: GNW 1979 exchange argument.
      -- For |corners(μ)| ≥ 2, the proof requires the exchange principle from GNW 1979:
      -- induction on μ.card, using that for any other corner c', the walk probability
      -- sum satisfies F(μ,c) = F(μ\c',c) by exchanging hook weights in the random walk.
      -- The invariance H(μ)/H(μ\c) = H(μ\{c,c'}) then closes the induction.
      sorry
```

## Test plan

- [x] JSON validates with `python3 -c 'import json; json.load(open(...))'`
- [x] `leanFile.sorries` left at 0 (matches main face which has 0 sorries)
- [x] `meta.sorries` and top-level `sorries` updated to 1 (matches Helpers actual sorry count)
- [x] No code changes; metadata-only.