### PR TITLE
fix(meta): correct stale leanFile.lineCount in 15 gallery entries

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
@@ -142,7 +142,7 @@
   ],
   "leanFile": {
     "namespace": "BezoutIdentityOQ01OQ01",
-    "lineCount": 189,
+    "lineCount": 188,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
-  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes in principle \u2014 the key Lp approximation ingredient (spanning-set truncation) is partially formalized, with the full generalization reduced to three HARD (not OPEN) sorries.",
+  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes in principle — the key Lp approximation ingredient (spanning-set truncation) is partially formalized, with the full generalization reduced to three HARD (not OPEN) sorries.",
   "meta": {
     "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",
@@ -25,18 +25,18 @@
   "overview": {
     "problemStatement": "Can Mathlib's sigma-finite infrastructure (`spanningSets`, `SigmaFinite`) be composed with the finite-measure Riesz representation proof to eliminate the `IsFiniteMeasure` hypothesis?",
     "text": "The parent file (CauchySchwarzIntegralOQ01OQ01OQ02OQ01) proves the Riesz representation theorem for $L^p$ duality under $[\\mathrm{IsFiniteMeasure}\\, \\mu]$. This file explores the generalization to purely sigma-finite measures, identifying the key new analytic ingredient: for $f \\in L^p(\\mu)$ with $\\mu$ sigma-finite, the spanning-set truncations $f \\cdot \\mathbf{1}_{S_n}$ converge to $f$ in $L^p$ norm. Two foundational results are proved; the full theorem is reduced to three HARD (non-OPEN) sorries.",
-    "historicalContext": "The $L^p$ Riesz representation theorem \u2014 identifying $(L^p(\\mu))^*$ with $L^q(\\mu)$ for $1/p + 1/q = 1$ \u2014 is one of the central results of functional analysis. The $p = 2$ case (Hilbert space duality) goes back to Riesz (1907) and Fr\u00e9chet (1907). The general $1 < p < \\infty$ case for finite measures was established in the 1920s\u201330s (Banach 1932). The sigma-finite extension required the development of abstract measure theory in the 1940s\u201350s, particularly Halmos's 1950 *Measure Theory* and the Radon-Nikodym approach via the Lebesgue decomposition.\n\nThe classical proof strategy (Folland, Real Analysis 2nd ed., Theorem 6.15; Rudin, Real and Complex Analysis 3rd ed., Theorem 6.16) localizes via a sigma-finite exhaustion: restrict to the spanning sets $S_n$, apply the finite-measure result on each to get $g_n \\in L^q(\\mu|_{S_n})$, prove consistency of the $g_n$ via $L^q$ uniqueness, and glue via MCT. The key analytic subtlety \u2014 that $L^p$ truncations $f \\cdot \\mathbf{1}_{S_n}$ converge in $L^p$ norm \u2014 is the sigma-finite analogue of measure continuity and uses Vitali's convergence theorem.\n\nIn Lean's Mathlib, the finite-measure case was formalized in the parent gallery entry. The present file identifies the three specific Lean infrastructure gaps that remain for the sigma-finite case and establishes two foundational pointwise convergence results (proved without sorry). The HARD sorries are blocked by Lp restriction map infrastructure and Vitali's API verbosity, estimated at ~280 total lines \u2014 all known classical mathematics.",
-    "proofStrategy": "**Step A \u2014 Localization** (HARD sorry, ~150 lines): Fix the sigma-finite exhaustion $S_0 \\subseteq S_1 \\subseteq \\cdots$ with $\\mu(S_n) < \\infty$ and $\\bigcup_n S_n = \\alpha$. For each $n$, the restriction $\\mu|_{S_n}$ is finite; apply the parent's 7-step Radon-Nikodym proof to get $g_n \\in L^q(\\mu|_{S_n})$ with $\\varphi(f \\cdot \\mathbf{1}_{S_n}) = \\int f g_n \\,d(\\mu|_{S_n})$. Consistency $g_{n+1}|_{S_n} = g_n$ a.e. follows from $L^q$ uniqueness. Set $g = \\lim_n g_n \\cdot \\mathbf{1}_{S_n \\setminus S_{n-1}}$; then $g \\in L^q(\\mu)$ by MCT and $\\|g\\|_q \\leq \\|\\varphi\\|$. **Step B \u2014 Lp approximation** (HARD sorry, ~80 lines): For $f \\in L^p(\\mu)$, let $\\Delta_n = f - f \\cdot \\mathbf{1}_{S_n}$. Apply Vitali's theorem (`tendsto_Lp_of_tendsto_ae`): (i) a.e. convergence $\\Delta_n \\to 0$ from `pointwise_mul_indicator_tendsto`; (ii) UnifIntegrable from $|\\Delta_n| \\leq 2|f|$ via `unifIntegrable_of`; (iii) UnifTight from `unifTight_const` on dominator $2|f| \\in L^p$. Gives $\\|\\Delta_n\\|_p \\to 0$. **Step C \u2014 Density extension** (HARD sorry, ~50 lines): The functional $\\psi = \\varphi - (f \\mapsto \\int fg \\,d\\mu)$ vanishes on $\\{\\mathbf{1}_E : \\mu(E) < \\infty\\}$ (by Step A). Since this set spans a dense subspace of $L^p(\\mu)$ for sigma-finite $\\mu$ (via `Lp.induction`), continuity gives $\\psi \\equiv 0$, completing the proof.",
+    "historicalContext": "The $L^p$ Riesz representation theorem — identifying $(L^p(\\mu))^*$ with $L^q(\\mu)$ for $1/p + 1/q = 1$ — is one of the central results of functional analysis. The $p = 2$ case (Hilbert space duality) goes back to Riesz (1907) and Fréchet (1907). The general $1 < p < \\infty$ case for finite measures was established in the 1920s–30s (Banach 1932). The sigma-finite extension required the development of abstract measure theory in the 1940s–50s, particularly Halmos's 1950 *Measure Theory* and the Radon-Nikodym approach via the Lebesgue decomposition.\n\nThe classical proof strategy (Folland, Real Analysis 2nd ed., Theorem 6.15; Rudin, Real and Complex Analysis 3rd ed., Theorem 6.16) localizes via a sigma-finite exhaustion: restrict to the spanning sets $S_n$, apply the finite-measure result on each to get $g_n \\in L^q(\\mu|_{S_n})$, prove consistency of the $g_n$ via $L^q$ uniqueness, and glue via MCT. The key analytic subtlety — that $L^p$ truncations $f \\cdot \\mathbf{1}_{S_n}$ converge in $L^p$ norm — is the sigma-finite analogue of measure continuity and uses Vitali's convergence theorem.\n\nIn Lean's Mathlib, the finite-measure case was formalized in the parent gallery entry. The present file identifies the three specific Lean infrastructure gaps that remain for the sigma-finite case and establishes two foundational pointwise convergence results (proved without sorry). The HARD sorries are blocked by Lp restriction map infrastructure and Vitali's API verbosity, estimated at ~280 total lines — all known classical mathematics.",
+    "proofStrategy": "**Step A — Localization** (HARD sorry, ~150 lines): Fix the sigma-finite exhaustion $S_0 \\subseteq S_1 \\subseteq \\cdots$ with $\\mu(S_n) < \\infty$ and $\\bigcup_n S_n = \\alpha$. For each $n$, the restriction $\\mu|_{S_n}$ is finite; apply the parent's 7-step Radon-Nikodym proof to get $g_n \\in L^q(\\mu|_{S_n})$ with $\\varphi(f \\cdot \\mathbf{1}_{S_n}) = \\int f g_n \\,d(\\mu|_{S_n})$. Consistency $g_{n+1}|_{S_n} = g_n$ a.e. follows from $L^q$ uniqueness. Set $g = \\lim_n g_n \\cdot \\mathbf{1}_{S_n \\setminus S_{n-1}}$; then $g \\in L^q(\\mu)$ by MCT and $\\|g\\|_q \\leq \\|\\varphi\\|$. **Step B — Lp approximation** (HARD sorry, ~80 lines): For $f \\in L^p(\\mu)$, let $\\Delta_n = f - f \\cdot \\mathbf{1}_{S_n}$. Apply Vitali's theorem (`tendsto_Lp_of_tendsto_ae`): (i) a.e. convergence $\\Delta_n \\to 0$ from `pointwise_mul_indicator_tendsto`; (ii) UnifIntegrable from $|\\Delta_n| \\leq 2|f|$ via `unifIntegrable_of`; (iii) UnifTight from `unifTight_const` on dominator $2|f| \\in L^p$. Gives $\\|\\Delta_n\\|_p \\to 0$. **Step C — Density extension** (HARD sorry, ~50 lines): The functional $\\psi = \\varphi - (f \\mapsto \\int fg \\,d\\mu)$ vanishes on $\\{\\mathbf{1}_E : \\mu(E) < \\infty\\}$ (by Step A). Since this set spans a dense subspace of $L^p(\\mu)$ for sigma-finite $\\mu$ (via `Lp.induction`), continuity gives $\\psi \\equiv 0$, completing the proof.",
     "keyInsights": [
-      "The spanning-set exhaustion (`spanningSets_eventually_mem`) gives pointwise convergence of truncations; this is proved without sorry \u2014 it is the set-theoretic input to all three steps.",
-      "UnifTight for the truncation sequence follows from `unifTight_const` applied to the dominator $2|f| \\in L^p$, combined with `eLpNorm_mono`. Crucially, `unifTight_const` does NOT require `IsFiniteMeasure` \u2014 this is precisely the point where the generalization from finite to sigma-finite measures becomes possible.",
-      "Vitali's convergence theorem (`tendsto_Lp_of_tendsto_ae`) is the correct Mathlib API for Step B \u2014 there is no `tendsto_Lp_of_dominated_convergence` in Mathlib. Vitali's theorem requires UnifIntegrable AND UnifTight (not just a dominator), but is available for sigma-finite measures.",
-      "The density extension step (Step C) is a direct port of the parent proof: `Lp.induction` does not use `IsFiniteMeasure` \u2014 it only requires `SigmaFinite`. This makes Step C the cheapest of the three sorries (~50 lines) and confirms that sigma-finiteness is the right generality for the full theorem.",
-      "The Lp restriction map infrastructure (`Lp(\u03bc) \u2192 Lp(\u03bc.restrict S)` isometric embedding and its adjoint) is the main Lean gap for Step A (~150 lines). This gap is not a mathematics problem but a Mathlib API coverage problem \u2014 the restriction map exists conceptually but is not yet in Mathlib as an isometric linear map.",
+      "The spanning-set exhaustion (`spanningSets_eventually_mem`) gives pointwise convergence of truncations; this is proved without sorry — it is the set-theoretic input to all three steps.",
+      "UnifTight for the truncation sequence follows from `unifTight_const` applied to the dominator $2|f| \\in L^p$, combined with `eLpNorm_mono`. Crucially, `unifTight_const` does NOT require `IsFiniteMeasure` — this is precisely the point where the generalization from finite to sigma-finite measures becomes possible.",
+      "Vitali's convergence theorem (`tendsto_Lp_of_tendsto_ae`) is the correct Mathlib API for Step B — there is no `tendsto_Lp_of_dominated_convergence` in Mathlib. Vitali's theorem requires UnifIntegrable AND UnifTight (not just a dominator), but is available for sigma-finite measures.",
+      "The density extension step (Step C) is a direct port of the parent proof: `Lp.induction` does not use `IsFiniteMeasure` — it only requires `SigmaFinite`. This makes Step C the cheapest of the three sorries (~50 lines) and confirms that sigma-finiteness is the right generality for the full theorem.",
+      "The Lp restriction map infrastructure (`Lp(μ) → Lp(μ.restrict S)` isometric embedding and its adjoint) is the main Lean gap for Step A (~150 lines). This gap is not a mathematics problem but a Mathlib API coverage problem — the restriction map exists conceptually but is not yet in Mathlib as an isometric linear map.",
       "The sorry classification ('HARD not OPEN') is a mathematical contribution in its own right: it distinguishes between missing Lean infrastructure (a bounded, finite coding task) and genuinely unsolved mathematics. This taxonomy is essential for the gallery's curation of 'what's left to formalize' vs 'what's known to be unsolved'.",
-      "The `noncomputable` annotation is required because `Lp` spaces use `Classical.choice` in their construction \u2014 the Lp equivalence classes are defined via propositional choice. This is a recurring pattern in Mathlib's measure theory and is purely a definitional necessity, not a constructive weakness.",
-      "**Radon-Nikodym as the mathematical engine**: The Lp Riesz representation theorem is essentially a corollary of the Radon-Nikodym theorem. Every continuous linear functional \u03c6 on Lp(\u03bc) defines a signed measure \u03bd via \u03bd(E) = \u03c6(1_E), absolutely continuous with respect to \u03bc for E with \u03bc(E) < \u221e. Radon-Nikodym yields a density g = d\u03bd/d\u03bc, which is then identified as the representing function in Lq via the H\u00f6lder bound ||\u03c6|| \u2264 ||g||_q. The sigma-finite extension in this file is precisely the step where the Radon-Nikodym argument must be glued over the exhaustion {S\u2099}.",
-      "**p = 2 and Hilbert space duality**: For p = 2 (so q = 2), the Riesz representation for L\u00b2(\u03bc) becomes the Riesz-Fr\u00e9chet theorem for Hilbert spaces: every continuous linear functional on a Hilbert space H is of the form x \u21a6 \u27e8x, y\u27e9 for a unique y \u2208 H. The L\u00b2 case is the starting point from which the general Lp theory was developed (Riesz 1907, Fr\u00e9chet 1907). Formalizing the sigma-finite L\u00b2 case is strictly easier since the inner product structure gives self-duality directly, without needing the H\u00f6lder conjugate asymmetry."
+      "The `noncomputable` annotation is required because `Lp` spaces use `Classical.choice` in their construction — the Lp equivalence classes are defined via propositional choice. This is a recurring pattern in Mathlib's measure theory and is purely a definitional necessity, not a constructive weakness.",
+      "**Radon-Nikodym as the mathematical engine**: The Lp Riesz representation theorem is essentially a corollary of the Radon-Nikodym theorem. Every continuous linear functional φ on Lp(μ) defines a signed measure ν via ν(E) = φ(1_E), absolutely continuous with respect to μ for E with μ(E) < ∞. Radon-Nikodym yields a density g = dν/dμ, which is then identified as the representing function in Lq via the Hölder bound ||φ|| ≤ ||g||_q. The sigma-finite extension in this file is precisely the step where the Radon-Nikodym argument must be glued over the exhaustion {Sₙ}.",
+      "**p = 2 and Hilbert space duality**: For p = 2 (so q = 2), the Riesz representation for L²(μ) becomes the Riesz-Fréchet theorem for Hilbert spaces: every continuous linear functional on a Hilbert space H is of the form x ↦ ⟨x, y⟩ for a unique y ∈ H. The L² case is the starting point from which the general Lp theory was developed (Riesz 1907, Fréchet 1907). Formalizing the sigma-finite L² case is strictly easier since the inner product structure gives self-duality directly, without needing the Hölder conjugate asymmetry."
     ]
   },
   "sections": [
@@ -46,14 +46,14 @@
       "startLine": 1,
       "endLine": 66,
       "summary": "The header doc-comment lays out the three-step proof architecture (localization, Lp approximation, density extension), explains why each step requires a sorry, and identifies which ingredients are proved. Lines 58-66 are imports and namespace setup.",
-      "mathContext": "The three-step architecture mirrors the classical proof in Folland \u00a76.2 / Rudin Theorem 6.16: (A) restrict to finite-measure sub-problems, (B) Lp truncation convergence via Vitali, (C) extend by density. The header explicitly distinguishes HARD sorries (known proofs, bounded coding effort) from OPEN questions (no known proof), establishing the gallery's sorry taxonomy for the entry."
+      "mathContext": "The three-step architecture mirrors the classical proof in Folland §6.2 / Rudin Theorem 6.16: (A) restrict to finite-measure sub-problems, (B) Lp truncation convergence via Vitali, (C) extend by density. The header explicitly distinguishes HARD sorries (known proofs, bounded coding effort) from OPEN questions (no known proof), establishing the gallery's sorry taxonomy for the entry."
     },
     {
       "id": "spanning-set-pointwise",
       "title": "Spanning-Set Pointwise Convergence (Proved)",
       "startLine": 67,
       "endLine": 86,
-      "summary": "Proves mem_spanningSets_eventually and pointwise_mul_indicator_tendsto: every point eventually enters the sigma-finite exhaustion, so f(a)\u00b71_{S\u2099}(a) \u2192 f(a) pointwise.",
+      "summary": "Proves mem_spanningSets_eventually and pointwise_mul_indicator_tendsto: every point eventually enters the sigma-finite exhaustion, so f(a)·1_{Sₙ}(a) → f(a) pointwise.",
       "mathContext": "$\\forall a \\in \\alpha, \\forall^{\\infty} n, a \\in S_n$ (proven), hence $f(a) \\cdot \\mathbf{1}_{S_n}(a) \\to f(a)$ (proven). Uses `iUnion_spanningSets`, `spanningSets_mono`, `tendsto_nhds_of_eventually_eq`."
     },
     {
@@ -61,7 +61,7 @@
       "title": "Step B: Lp Truncation Convergence (HARD sorry)",
       "startLine": 87,
       "endLine": 130,
-      "summary": "HARD sorry: f\u00b71_{S\u2099} \u2192 f in Lp norm. Proof via tendsto_Lp_of_tendsto_ae (Vitali) with UnifIntegrable/UnifTight from domination by 2|f| \u2208 Lp.",
+      "summary": "HARD sorry: f·1_{Sₙ} → f in Lp norm. Proof via tendsto_Lp_of_tendsto_ae (Vitali) with UnifIntegrable/UnifTight from domination by 2|f| ∈ Lp.",
       "mathContext": "$\\|f - f \\cdot \\mathbf{1}_{S_n}\\|_p \\to 0$. Strategy: Vitali's theorem with $|\\Delta_n| \\leq 2|f|$ giving UnifIntegrable (cutoff) + UnifTight (unifTight_const). No IsFiniteMeasure needed."
     },
     {
@@ -69,7 +69,7 @@
       "title": "Step A: Localization Construction (HARD sorry)",
       "startLine": 132,
       "endLine": 165,
-      "summary": "HARD sorry (~150 lines): constructs g \u2208 Lq(\u03bc) from localizations to \u03bc.restrict S\u2099 using the parent's finite-measure proof. Blocked by Lp restriction map infrastructure.",
+      "summary": "HARD sorry (~150 lines): constructs g ∈ Lq(μ) from localizations to μ.restrict Sₙ using the parent's finite-measure proof. Blocked by Lp restriction map infrastructure.",
       "mathContext": "Constructs $g \\in L^q(\\mu)$ with $\\phi(\\mathbf{1}_E) = \\int_E g \\,d\\mu$ for $\\mu(E) < \\infty$. Uses parent's proof on $\\mu|_{S_n}$ + consistency ($L^q$ uniqueness) + MCT gluing. Gap: Lp restriction isometry in Mathlib."
     },
     {
@@ -82,11 +82,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Two foundational lemmas are proved (spanning-set pointwise convergence). The full sigma-finite Riesz representation is reduced to three HARD sorries totaling ~280 lines \u2014 all known classical mathematics, none involving unsolved problems.",
+    "summary": "Two foundational lemmas are proved (spanning-set pointwise convergence). The full sigma-finite Riesz representation is reduced to three HARD sorries totaling ~280 lines — all known classical mathematics, none involving unsolved problems.",
     "implications": "Once the three sorries are filled, this completes the Riesz representation theorem for all sigma-finite measures in Lean 4, matching the classical scope of Folland Theorem 6.15 / Rudin Theorem 6.16. The two proved lemmas (`mem_spanningSets_eventually`, `pointwise_mul_indicator_tendsto`) are reusable infrastructure for other sigma-finite results in the gallery. The sorry taxonomy (HARD vs OPEN) is itself a contribution: it maps the gap between the current Mathlib infrastructure and the full classical theorem.",
     "openQuestions": [
       "Does the proof extend to complex-valued Lp spaces? The Riesz representation for $(L^p(\\mu, \\mathbb{C}))^*$ is analogous but requires complex conjugation in the inner product, adding one extra step to the density extension.",
-      "Can the localization argument be abstracted into a general 'finite-to-sigma-finite lifting' tactic for Lp results? The pattern (restrict \u2192 apply \u2192 glue via MCT) appears in Tonelli's theorem, the sigma-finite Fubini\u2013Tonelli, and dominated convergence for sigma-finite measures.",
+      "Can the localization argument be abstracted into a general 'finite-to-sigma-finite lifting' tactic for Lp results? The pattern (restrict → apply → glue via MCT) appears in Tonelli's theorem, the sigma-finite Fubini–Tonelli, and dominated convergence for sigma-finite measures.",
       "Fill the Lp restriction map gap in Mathlib. The isometric embedding $L^p(\\mu|_S) \\hookrightarrow L^p(\\mu)$ (extend by zero) and its adjoint are needed here and for many other localization arguments. A dedicated Mathlib PR for this infrastructure would unblock Step A.",
       "What is the Lean proof complexity for the $p = 1$ case? The Riesz representation for $(L^1(\\mu))^* \\cong L^\\infty(\\mu)$ requires a separate argument (the dual of $L^\\infty$ is strictly larger than $L^1$ without sigma-finiteness, but they coincide for sigma-finite $\\mu$ under the essential boundedness characterization).",
       "Can `lp_truncation_tendsto_zero` (Step B) be contributed to Mathlib directly? The sigma-finite Lp truncation convergence is a general-purpose tool needed for many Lp density arguments and would belong in `Mathlib.MeasureTheory.Function.LpSpace`."
@@ -106,29 +106,29 @@
     {
       "targetId": "cauchy-schwarz-integral-oq-01-oq-01",
       "relationship": "foundational",
-      "description": "H\u00f6lder's inequality in eLpNorm form is the key analytic bound underlying the Lp Riesz representation: the integral estimate |\u222bfg d\u03bc| \u2264 ||f||_p \u00b7 ||g||_q bounds the operator norm of the representing functional, establishing ||\u03c6|| \u2264 ||g||_q. Without H\u00f6lder, the identification of the dual space with Lq has no quantitative content."
+      "description": "Hölder's inequality in eLpNorm form is the key analytic bound underlying the Lp Riesz representation: the integral estimate |∫fg dμ| ≤ ||f||_p · ||g||_q bounds the operator norm of the representing functional, establishing ||φ|| ≤ ||g||_q. Without Hölder, the identification of the dual space with Lq has no quantitative content."
     },
     {
       "targetId": "cauchy-schwarz-integral-oq-01-oq-03",
       "relationship": "related",
-      "description": "Complex-valued H\u00f6lder inequality (Nnnorm form): directly relevant to the open question about extending the sigma-finite Riesz representation to complex-valued Lp spaces. The real-valued argument in this file requires replacing absolute values with norms and tracking conjugates \u2014 the complex H\u00f6lder entry formalizes exactly the tools needed."
+      "description": "Complex-valued Hölder inequality (Nnnorm form): directly relevant to the open question about extending the sigma-finite Riesz representation to complex-valued Lp spaces. The real-valued argument in this file requires replacing absolute values with norms and tracking conjugates — the complex Hölder entry formalizes exactly the tools needed."
     },
     {
       "targetId": "cauchy-schwarz-integral-oq-01-oq-02",
       "relationship": "related",
-      "description": "Riesz-Thorin interpolation theorem (from H\u00f6lder's inequality): connects to the Lp duality framework by showing that operators bounded on Lp and Lq are bounded on all Lr for r between p and q. The sigma-finite Riesz representation is compatible with Riesz-Thorin: once the dual of Lp is identified with Lq for all p > 1, interpolation applies to the operator \u03b9: Lq \u2192 (Lp)* = Lq."
+      "description": "Riesz-Thorin interpolation theorem (from Hölder's inequality): connects to the Lp duality framework by showing that operators bounded on Lp and Lq are bounded on all Lr for r between p and q. The sigma-finite Riesz representation is compatible with Riesz-Thorin: once the dual of Lp is identified with Lq for all p > 1, interpolation applies to the operator ι: Lq → (Lp)* = Lq."
     },
     {
       "targetId": "cauchy-schwarz-integral-oq-02",
       "relationship": "related",
-      "description": "Minkowski integral inequality (Lp triangle inequality): part of the Lp space infrastructure that underpins the Riesz representation. The Lp norm itself satisfies the triangle inequality via Minkowski's inequality \u2014 this is needed to verify that the representing functional g \u21a6 \u222bfg is well-defined and continuous on the Banach space Lp(\u03bc)."
+      "description": "Minkowski integral inequality (Lp triangle inequality): part of the Lp space infrastructure that underpins the Riesz representation. The Lp norm itself satisfies the triangle inequality via Minkowski's inequality — this is needed to verify that the representing functional g ↦ ∫fg is well-defined and continuous on the Banach space Lp(μ)."
     }
   ],
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 209,
+    "lineCount": 208,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
@@ -141,22 +141,22 @@
       {
         "name": "pointwise_mul_indicator_tendsto",
         "type": "proved",
-        "description": "f(a)\u00b71_{S\u2099}(a) \u2192 f(a) pointwise as n \u2192 \u221e"
+        "description": "f(a)·1_{Sₙ}(a) → f(a) pointwise as n → ∞"
       },
       {
         "name": "lp_truncation_tendsto_zero",
         "type": "sorry",
-        "description": "HARD: f\u00b71_{S\u2099} \u2192 f in Lp norm via Vitali's convergence theorem"
+        "description": "HARD: f·1_{Sₙ} → f in Lp norm via Vitali's convergence theorem"
       },
       {
         "name": "localization_existence",
         "type": "sorry",
-        "description": "HARD: constructs representing function g \u2208 Lq via localization to spanning sets"
+        "description": "HARD: constructs representing function g ∈ Lq via localization to spanning sets"
       },
       {
         "name": "riesz_lp_surjective_sigma_finite",
         "type": "sorry",
-        "description": "HARD: main sigma-finite Riesz representation \u2014 assembles localization + density extension"
+        "description": "HARD: main sigma-finite Riesz representation — assembles localization + density extension"
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -137,7 +137,7 @@
   ],
   "leanFile": {
     "namespace": "CevasTheoremNonEuclideanOQ02OQ01",
-    "lineCount": 273,
+    "lineCount": 272,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1,

--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -115,7 +115,7 @@
   ],
   "leanFile": {
     "namespace": "RouthTheorem",
-    "lineCount": 231,
+    "lineCount": 230,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 3,

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
@@ -98,7 +98,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 96,
+    "lineCount": 104,
     "path": "Proofs/CubeRoot3IrrationalOQ02OQ02.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -147,7 +147,7 @@
   ],
   "leanFile": {
     "namespace": "MoultonPlane",
-    "lineCount": 298,
+    "lineCount": 297,
     "axiomCount": 0,
     "theoremCount": 29,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1151",
-  "title": "Erd\u0151s Problem #1151: Limit Points of Lagrange Interpolation at Chebyshev Nodes",
+  "title": "Erdős Problem #1151: Limit Points of Lagrange Interpolation at Chebyshev Nodes",
   "slug": "erdos-1151",
   "description": "For Lagrange interpolation at Chebyshev nodes, prove that for any closed set A in [-1,1], there exists a continuous function f such that A is the set of limit points of the interpolation values.",
   "meta": {
-    "author": "Erd\u0151s (1941), V\u00e9rtesi (1999)",
+    "author": "Erdős (1941), Vértesi (1999)",
     "sourceUrl": "https://erdosproblems.com/1151",
     "date": "1941",
     "status": "axiomatized",
@@ -35,14 +35,14 @@
       }
     ],
     "originalContributions": [
-      "Formalization of Chebyshev nodes as cos((2k+1)\u03c0/(2n))",
+      "Formalization of Chebyshev nodes as cos((2k+1)π/(2n))",
       "Proof that Chebyshev nodes lie in [-1,1]",
       "Lagrange interpolation operator using basis polynomials",
       "Definition of limit point sets for sequences",
       "Formal statement of the full conjecture with special cases derived"
     ],
     "axiomCount": 2,
-    "assumptions": "2 axioms: erdos_1941_divergence (Erd\u0151s 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
+    "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
     "lineCount": 216,
     "prerequisites": [
       "Polynomial interpolation (Lagrange basis)",
@@ -52,16 +52,16 @@
     "theoremCount": 7
   },
   "overview": {
-    "historicalContext": "Lagrange interpolation has a troubled history: Runge (1901) famously showed that interpolation at equally-spaced nodes for f(x) = 1/(1+25x\u00b2) diverges as n \u2192 \u221e, despite f being analytic. Chebyshev nodes were introduced precisely to avoid this: by placing nodes at the roots of the Chebyshev polynomials, the interpolation error for smooth functions is dramatically reduced. Chebyshev (1854) showed these nodes minimize the \u221e-norm of the Lebesgue function among all choices of n nodes. However, Erd\u0151s (1941) proved something deeper and disturbing: even at Chebyshev nodes, Lagrange interpolation can diverge for continuous (not just analytic) functions. Specifically, for x = cos(\u03c0p/q) with odd p, q, there exists a continuous f whose interpolation values diverge to \u221e. Erd\u0151s (1943) then claimed \u2014 without proof \u2014 that the limit-point behavior is completely flexible: any closed subset of [\u22121, 1] can arise as the set of limit points of \ud835\udcdb\u207ff(x) for some continuous f. This conjecture was listed as open by V\u00e9rtesi in his 1999 problem compilation [Va99, Problem 2.41]. As of 2026, it remains unresolved.",
-    "problemStatement": "Prove that for any closed A \u2286 [-1,1] and suitable x, there exists continuous f such that A is the set of limit points of \ud835\udcdb\u207ff(x).",
+    "historicalContext": "Lagrange interpolation has a troubled history: Runge (1901) famously showed that interpolation at equally-spaced nodes for f(x) = 1/(1+25x²) diverges as n → ∞, despite f being analytic. Chebyshev nodes were introduced precisely to avoid this: by placing nodes at the roots of the Chebyshev polynomials, the interpolation error for smooth functions is dramatically reduced. Chebyshev (1854) showed these nodes minimize the ∞-norm of the Lebesgue function among all choices of n nodes. However, Erdős (1941) proved something deeper and disturbing: even at Chebyshev nodes, Lagrange interpolation can diverge for continuous (not just analytic) functions. Specifically, for x = cos(πp/q) with odd p, q, there exists a continuous f whose interpolation values diverge to ∞. Erdős (1943) then claimed — without proof — that the limit-point behavior is completely flexible: any closed subset of [−1, 1] can arise as the set of limit points of 𝓛ⁿf(x) for some continuous f. This conjecture was listed as open by Vértesi in his 1999 problem compilation [Va99, Problem 2.41]. As of 2026, it remains unresolved.",
+    "problemStatement": "Prove that for any closed A ⊆ [-1,1] and suitable x, there exists continuous f such that A is the set of limit points of 𝓛ⁿf(x).",
     "text": "We formalize the problem, defining Chebyshev nodes, Lagrange interpolation, and limit point sets.",
     "proofStrategy": "Define the mathematical objects and state the conjecture. Derive special cases from it.",
     "keyInsights": [
-      "Chebyshev nodes x\u2096 = cos((2k+1)\u03c0/(2n)) minimize the Lebesgue function \u2016\u03a3|\u2113\u2096|\u2016_\u221e among all node choices, making them optimal for polynomial interpolation of smooth functions",
-      "Injectivity of Chebyshev nodes is proved via strictAntiOn_cos: cosine is strictly decreasing on [0, \u03c0], and all node arguments lie there; equal node values imply equal indices",
+      "Chebyshev nodes xₖ = cos((2k+1)π/(2n)) minimize the Lebesgue function ‖Σ|ℓₖ|‖_∞ among all node choices, making them optimal for polynomial interpolation of smooth functions",
+      "Injectivity of Chebyshev nodes is proved via strictAntiOn_cos: cosine is strictly decreasing on [0, π], and all node arguments lie there; equal node values imply equal indices",
       "The limit point set of any bounded sequence is closed (proved here); the conjecture claims the converse: every closed set is the limit point set of some Chebyshev interpolation sequence",
-      "Erd\u0151s's 1941 divergence result shows Chebyshev interpolation can fail for continuous functions at rational cosines \u2014 this axiom captures the boundary of what is known",
-      "Special cases bound the behavioral spectrum: A = {y} (convergence) and A = [\u22121, 1] (dense orbit), both derived in one line from the conjecture axiom"
+      "Erdős's 1941 divergence result shows Chebyshev interpolation can fail for continuous functions at rational cosines — this axiom captures the boundary of what is known",
+      "Special cases bound the behavioral spectrum: A = {y} (convergence) and A = [−1, 1] (dense orbit), both derived in one line from the conjecture axiom"
     ],
     "prerequisites": [
       "Polynomial interpolation",
@@ -75,7 +75,7 @@
       "title": "Part I: Chebyshev Nodes",
       "startLine": 39,
       "endLine": 81,
-      "summary": "Defines chebyshevNode and chebyshevNodes. Proves chebyshevNode_mem_Icc (nodes lie in [\u22121,1]) and chebyshevNodes_injective (nodes are distinct via strictAntiOn_cos).",
+      "summary": "Defines chebyshevNode and chebyshevNodes. Proves chebyshevNode_mem_Icc (nodes lie in [−1,1]) and chebyshevNodes_injective (nodes are distinct via strictAntiOn_cos).",
       "mathContext": "$x_k^{(n)} = \\cos\\left(\\frac{(2k+1)\\pi}{2n}\\right) \\in [-1,1]$; all $n$ nodes distinct"
     },
     {
@@ -83,7 +83,7 @@
       "title": "Part II: Lagrange Interpolation Operator",
       "startLine": 83,
       "endLine": 100,
-      "summary": "Defines lagrangeBasis (\u2113\u2096(x) = \u220f_{i\u2260k} (x\u2212x\u1d62)/(x\u2096\u2212x\u1d62)), lagrangeInterp (\ud835\udcdb\u207ff(x) = \u03a3\u2096 f(x\u2096)\u2113\u2096(x)), and chebyshevInterp (specialization to Chebyshev nodes).",
+      "summary": "Defines lagrangeBasis (ℓₖ(x) = ∏_{i≠k} (x−xᵢ)/(xₖ−xᵢ)), lagrangeInterp (𝓛ⁿf(x) = Σₖ f(xₖ)ℓₖ(x)), and chebyshevInterp (specialization to Chebyshev nodes).",
       "mathContext": "$\\ell_k(x) = \\prod_{i \\neq k} \\frac{x - x_i}{x_k - x_i}$; $\\mathcal{L}^n f(x) = \\sum_{k=0}^{n-1} f(x_k^{(n)}) \\ell_k(x)$"
     },
     {
@@ -91,15 +91,15 @@
       "title": "Part III: Limit Points of Sequences",
       "startLine": 102,
       "endLine": 132,
-      "summary": "Defines IsLimitPoint and limitPointSet. Proves limitPointSet_isClosed: for bounded sequences, the limit point set is closed (complement is open by \u03b5/2 argument).",
+      "summary": "Defines IsLimitPoint and limitPointSet. Proves limitPointSet_isClosed: for bounded sequences, the limit point set is closed (complement is open by ε/2 argument).",
       "mathContext": "$y \\in \\text{limitPointSet}(a_n) \\iff \\forall \\varepsilon > 0,\\; \\forall N,\\; \\exists n \\geq N: |a_n - y| < \\varepsilon$"
     },
     {
       "id": "main-conjecture",
-      "title": "Part IV: The Erd\u0151s Conjecture (Axiomatized)",
+      "title": "Part IV: The Erdős Conjecture (Axiomatized)",
       "startLine": 134,
       "endLine": 164,
-      "summary": "Defines chebyshevInterpSeq. Axiomatizes erdos_1941_divergence (Erd\u0151s 1941: divergence at rational cosines) and erdos_1151_conjecture (open: every closed A \u2286 [\u22121,1] is realizable as a limit point set).",
+      "summary": "Defines chebyshevInterpSeq. Axiomatizes erdos_1941_divergence (Erdős 1941: divergence at rational cosines) and erdos_1151_conjecture (open: every closed A ⊆ [−1,1] is realizable as a limit point set).",
       "mathContext": "$\\forall A \\subseteq [-1,1]$ closed, $\\exists f \\in C[-1,1]: \\text{limitPointSet}(\\mathcal{L}^n f(x)) = A$ (open conjecture)"
     },
     {
@@ -107,17 +107,17 @@
       "title": "Part V: Special Cases",
       "startLine": 166,
       "endLine": 183,
-      "summary": "Derives erdos_1151_convergent_case (A = {y}: convergence) and erdos_1151_dense_case (A = [\u22121,1]: dense orbit) as one-line corollaries of the conjecture axiom.",
+      "summary": "Derives erdos_1151_convergent_case (A = {y}: convergence) and erdos_1151_dense_case (A = [−1,1]: dense orbit) as one-line corollaries of the conjecture axiom.",
       "mathContext": "$A = \\{y\\}$: $\\mathcal{L}^n f(x) \\to y$; $A = [-1,1]$: orbit is dense in $[-1,1]$"
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erd\u0151s Problem #1151 in 184 lines with 2 axioms. Defines Chebyshev nodes (with injectivity), Lagrange interpolation, limit point sets, and the full conjecture. Derives two extreme special cases: singleton limit sets (convergent behavior) and the full interval (everywhere-dense orbit).",
-    "implications": "If proved, the conjecture would give a complete topological classification of Lagrange interpolation behavior at Chebyshev nodes: the map f \u21a6 limitPointSet(\ud835\udcdb\u207ff(x)) would be surjective onto the closed subsets of [\u22121, 1] for appropriate x. This would be a remarkable flexibility result \u2014 any pattern of convergence, divergence, and oscillation can be engineered via choice of continuous f. The formalization also demonstrates that the limit point set of any bounded sequence is closed, which is the forward direction: realizable limit point sets must be closed.",
+    "summary": "Formalizes Erdős Problem #1151 in 184 lines with 2 axioms. Defines Chebyshev nodes (with injectivity), Lagrange interpolation, limit point sets, and the full conjecture. Derives two extreme special cases: singleton limit sets (convergent behavior) and the full interval (everywhere-dense orbit).",
+    "implications": "If proved, the conjecture would give a complete topological classification of Lagrange interpolation behavior at Chebyshev nodes: the map f ↦ limitPointSet(𝓛ⁿf(x)) would be surjective onto the closed subsets of [−1, 1] for appropriate x. This would be a remarkable flexibility result — any pattern of convergence, divergence, and oscillation can be engineered via choice of continuous f. The formalization also demonstrates that the limit point set of any bounded sequence is closed, which is the forward direction: realizable limit point sets must be closed.",
     "openQuestions": [
-      "Is erdos_1151_conjecture true for all x \u2208 [\u22121, 1], or only for certain x (like rational cosines)?",
-      "Can Baire category methods prove existence? A 'generic' continuous function argument might show the set of f with prescribed limit points is dense in C[\u22121, 1]",
-      "What is the relationship to the Lebesgue function \u039b\u2099(x) = \u03a3|\u2113\u2096(x)|? The divergence of \ud835\udcdb\u207ff(x) is controlled by \u039b\u2099(x) via \u2016\ud835\udcdb\u207f\u2016 \u2264 \u039b\u2099",
+      "Is erdos_1151_conjecture true for all x ∈ [−1, 1], or only for certain x (like rational cosines)?",
+      "Can Baire category methods prove existence? A 'generic' continuous function argument might show the set of f with prescribed limit points is dense in C[−1, 1]",
+      "What is the relationship to the Lebesgue function Λₙ(x) = Σ|ℓₖ(x)|? The divergence of 𝓛ⁿf(x) is controlled by Λₙ(x) via ‖𝓛ⁿ‖ ≤ Λₙ",
       "Can the axiom erdos_1941_divergence be proved in Lean by formalizing the Lebesgue function growth rate for Chebyshev nodes at rational cosine points?"
     ]
   },
@@ -125,18 +125,18 @@
     {
       "targetId": "erdos-1153",
       "relationship": "related",
-      "description": "Erd\u0151s #1153 also studies Lagrange interpolation convergence; the lagrangeBasis definition in this file is reused from that formalization"
+      "description": "Erdős #1153 also studies Lagrange interpolation convergence; the lagrangeBasis definition in this file is reused from that formalization"
     }
   ],
   "references": [
     {
       "key": "Er41",
-      "citation": "P. Erd\u0151s, On divergence properties of the Lagrange interpolation parabolas, Ann. of Math. 42 (1941), 309-315.",
+      "citation": "P. Erdős, On divergence properties of the Lagrange interpolation parabolas, Ann. of Math. 42 (1941), 309-315.",
       "url": ""
     },
     {
       "key": "Va99",
-      "citation": "P. V\u00e9rtesi, Problems on interpolation, Problem 2.41, 1999.",
+      "citation": "P. Vértesi, Problems on interpolation, Problem 2.41, 1999.",
       "url": ""
     }
   ],
@@ -153,7 +153,7 @@
       "Real"
     ],
     "namespace": "Erdos1151",
-    "lineCount": 216,
+    "lineCount": 215,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-395-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01-incomplete-01/meta.json
@@ -96,7 +96,7 @@
   },
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 119,
+    "lineCount": 118,
     "path": "Proofs/Erdos395OQ01Incomplete01.lean",
     "sorries": 0,
     "definitionCount": 0,

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -8,7 +8,13 @@
     "date": "2026-05-04",
     "status": "verified",
     "proofRepoPath": "Proofs/FrobeniusNumber.lean",
-    "tags": ["number-theory", "combinatorics", "frobenius", "coin-problem", "coprime"],
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "frobenius",
+      "coin-problem",
+      "coprime"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -93,7 +99,7 @@
     "path": "Proofs/FrobeniusNumber.lean",
     "axiomCount": 0,
     "sorryCount": 0,
-    "lineCount": 317,
+    "lineCount": 316,
     "theoremCount": 13,
     "definitionCount": 3
   }

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -110,7 +110,7 @@
     "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
     "namespace": "FundamentalArithmeticOQ01OQ01",
     "axiomCount": 0,
-    "lineCount": 221,
+    "lineCount": 220,
     "theoremCount": 12,
     "sorries": 0
   },

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
@@ -163,7 +163,7 @@
   "sorries": 0,
   "leanFile": {
     "namespace": "GodelDiagonal",
-    "lineCount": 242,
+    "lineCount": 241,
     "axiomCount": 5,
     "theoremCount": 9,
     "definitionCount": 6,

--- a/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03/meta.json
@@ -125,7 +125,7 @@
   ],
   "leanFile": {
     "namespace": "InfinitudePrimes4k3OQ03",
-    "lineCount": 104,
+    "lineCount": 103,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/perfect-numbers-oq-03/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-03/meta.json
@@ -68,7 +68,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "MersennePrimeDist",
-    "lineCount": 260,
+    "lineCount": 259,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 5,

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -175,7 +175,7 @@
   },
   "leanFile": {
     "namespace": "QRAlgorithm",
-    "lineCount": 119,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
@@ -117,7 +117,7 @@
   ],
   "leanFile": {
     "namespace": "WilsonPrimesOQ01",
-    "lineCount": 124,
+    "lineCount": 123,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.lineCount` in 15 gallery entries where the Lean source file was edited (research proofs extended, trailing lines cleaned) but meta.json was not updated.

## Evidence

| Entry | Before | After |
|---|---|---|
| bezout-identity-oq-01-oq-01 | 189 | 188 |
| cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01 | 209 | 208 |
| cevas-theorem-non-euclidean-oq-02-oq-01 | 273 | 272 |
| cevas-theorem-oq-01-oq-03 | 231 | 230 |
| cube-root-3-irrational-oq-02-oq-02 | 96 | 104 |
| desargues-theorem-oq-01-oq-01 | 298 | 297 |
| erdos-1151 | 216 | 215 |
| erdos-395-oq-01-incomplete-01 | 119 | 118 |
| frobenius-number | 317 | 316 |
| fundamental-arithmetic-oq-01-oq-01 | 221 | 220 |
| godel-first-incompleteness-oq01-oq-04 | 242 | 241 |
| infinitude-primes-4k3-oq-03 | 104 | 103 |
| perfect-numbers-oq-03 | 260 | 259 |
| quadratic-reciprocity-oq-03 | 119 | 118 |
| wilsons-theorem-oq-01-oq-01 | 124 | 123 |

All counts verified by `len(content.splitlines())` on the current Lean source file.
No overlap with PR #15847 (which fixes a separate set of entries).

---
Automated fix by lean-mechanic agent.