### PR TITLE
fix(meta): sync erdos-107 — 0 sorries, lineCount 249→255

### DIFF
--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -16,7 +16,7 @@
       "convex-geometry"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 107,
     "erdosUrl": "https://erdosproblems.com/107",
     "erdosProblemStatus": "open",
@@ -63,8 +63,8 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 6,
-    "lineCount": 249,
-    "assumptions": "6 axioms (deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds). 1 sorry remains. f_finite proved from ersz_lower_bound by contradiction.",
+    "lineCount": 255,
+    "assumptions": "6 axioms (deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds). f_finite proved from ersz_lower_bound by contradiction.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12
   },
@@ -206,11 +206,11 @@
       "note": "Surveys upper bounds on the Erdős-Szekeres function and variants including the number of empty convex polygons, complementing the original 1935 result"
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "axiomCount": 6,
-    "lineCount": 249,
-    "sorries": 1,
+    "lineCount": 255,
+    "sorries": 0,
     "path": "Proofs/Erdos107Problem.lean",
     "definitionCount": 6,
     "theoremCount": 12,


### PR DESCRIPTION
## Fix

Corrects stale metadata for `erdos-107` (Happy Ending Problem) after PR #15841 proved `f_3_value` (the last sorry).

## Evidence

**Before** (on main):
- `sorries`: 1 (all three locations: root, `meta.sorries`, `leanFile.sorries`)
- `lineCount`: 249 (in both `meta.lineCount` and `leanFile.lineCount`)
- `assumptions`: contained "1 sorry remains"

**After**:
- `sorries`: 0 (Lean file verified: `grep sorry proofs/Proofs/Erdos107Problem.lean` → no results)
- `lineCount`: 255 (verified: `wc -l proofs/Proofs/Erdos107Problem.lean` → 255)
- `assumptions`: stale text removed

**Root cause**: PR #15841 ("Research: erdos-695 + erdos-107 + erdos-323 - prove 16+ sorries") extended the file and proved `f_3_value`, but meta.json was not updated.

**Note on PR #15847**: The existing open PR #15847 applies an earlier partial fix (sorries 2→1, lineCount 243→249). This PR is additive — it corrects the remaining discrepancy after #15841. Status remains `axiomatized` (6 axioms remain for the known bounds).

---
Automated fix by lean-mechanic agent.