### PR TITLE
fix(meta): sync stale sorries/lineCount for erdos-107 after #15841

### DIFF
--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -16,7 +16,7 @@
       "convex-geometry"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 107,
     "erdosUrl": "https://erdosproblems.com/107",
     "erdosProblemStatus": "open",
@@ -63,8 +63,8 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 6,
-    "lineCount": 249,
-    "assumptions": "6 axioms (deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds). 1 sorry remains. f_finite proved from ersz_lower_bound by contradiction.",
+    "lineCount": 255,
+    "assumptions": "6 axioms (deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds). All theorems proved (0 sorries). f_finite proved from ersz_lower_bound by contradiction.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12
   },
@@ -206,11 +206,11 @@
       "note": "Surveys upper bounds on the Erdős-Szekeres function and variants including the number of empty convex polygons, complementing the original 1935 result"
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "axiomCount": 6,
-    "lineCount": 249,
-    "sorries": 1,
+    "lineCount": 255,
+    "sorries": 0,
     "path": "Proofs/Erdos107Problem.lean",
     "definitionCount": 6,
     "theoremCount": 12,


### PR DESCRIPTION
## Summary

PR #15841 proved the remaining sorry (`f_3_value`) in `Erdos107Problem.lean`, reducing sorries to 0, but `meta.json` was not updated. This is a metadata-only fix.

## Evidence

In `proofs/Proofs/Erdos107Problem.lean` (origin/main after #15841):
```lean
theorem f_3_value : f 3 = 3 := by
  -- fully proved, no sorry
```

`grep -c "sorry" proofs/Proofs/Erdos107Problem.lean` → **0**

## Changes

| Field | Before | After |
|-------|--------|-------|
| `meta.sorries` | 1 | 0 |
| `meta.lineCount` | 249 | 255 |
| `meta.assumptions` | mentions "1 sorry remains" | updated to "0 sorries" |
| `leanFile.sorries` | 1 | 0 |
| `leanFile.lineCount` | 249 | 255 |
| top-level `sorries` | 1 | 0 |

Status remains `axiomatized` / badge `axiom` (6 axioms still present).

## Note

PR #15847 is also open with a stale fix for erdos-107 (`sorries: 2 → 1`). That PR's erdos-107 change conflicts with the current main state (which already has `sorries: 1` after #15844). This PR supersedes the erdos-107 portion of #15847.

## Test plan

- [x] JSON validates: `python3 -c 'import json; json.load(open(...))'`
- [x] Lean file has 0 sorries (verified via `git show origin/main:proofs/Proofs/Erdos107Problem.lean | grep -c sorry`)
- [x] 6 axioms still present — `axiomatized` status correct
- [x] Metadata-only change, no code changes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)