### PR TITLE
fix(meta): correct leanFile.sorries=null in 10 entries and ballot-problem garbled text

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -125,6 +125,7 @@
     "sorryCount": 0,
     "lineCount": 214,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -135,6 +135,7 @@
     "sorryCount": 0,
     "lineCount": 200,
     "theoremCount": 5,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -76,7 +76,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b]. hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. hookProd_ratio_formula is proved-free. Part XIV proves hook_length_formula_general via corner induction; hook_walk_identity_gnw dispatcher is complete. 1 open proved remains: gnwProb_key (GNW 1979 probabilistic identity, hard). The supporting strictHookCells_* lemmas and gnwProb_sum_corners were proved in PR #14960.",
+    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b]. hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. hookProd_ratio_formula is sorry-free. Part XIV proves hook_length_formula_general via corner induction; hook_walk_identity_gnw dispatcher is complete. 1 open sorry remains: gnwProb_key (GNW 1979 probabilistic identity, hard). The supporting strictHookCells_* lemmas and gnwProb_sum_corners were proved in PR #14960.",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",

--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -178,7 +178,8 @@
     "additionalFiles": [
       "Proofs/BirthdayProblemOQ01OQ01Aristotle.lean"
     ],
-    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01OQ01.lean"
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01OQ01.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
@@ -138,7 +138,8 @@
     "theoremCount": 9,
     "defCount": 0,
     "axiomCount": 1,
-    "sorryCount": 0
+    "sorryCount": 0,
+    "sorries": 0
   },
   "sorries": []
 }

--- a/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
@@ -159,6 +159,7 @@
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 1,
-    "lineCount": 256
+    "lineCount": 256,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/circumference-via-differentiation/meta.json
+++ b/src/data/proofs/circumference-via-differentiation/meta.json
@@ -8,7 +8,14 @@
     "date": "2026-05-04",
     "status": "verified",
     "proofRepoPath": "Proofs/CircumferenceViaDifferentiation.lean",
-    "tags": ["geometry", "calculus", "circumference", "area", "circle", "differentiation"],
+    "tags": [
+      "geometry",
+      "calculus",
+      "circumference",
+      "area",
+      "circle",
+      "differentiation"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -88,6 +95,7 @@
     "sorryCount": 0,
     "lineCount": 199,
     "theoremCount": 13,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -101,6 +101,7 @@
     "sorryCount": 0,
     "lineCount": 316,
     "theoremCount": 13,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -8,7 +8,13 @@
     "date": "2026-05-04",
     "status": "verified",
     "proofRepoPath": "Proofs/GaussWilsonNonCyclic.lean",
-    "tags": ["number-theory", "group-theory", "cyclic-groups", "zmod", "wilson-gauss"],
+    "tags": [
+      "number-theory",
+      "group-theory",
+      "cyclic-groups",
+      "zmod",
+      "wilson-gauss"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -102,6 +108,7 @@
     "sorryCount": 0,
     "lineCount": 323,
     "theoremCount": 21,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/inclusion-exclusion-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03/meta.json
@@ -165,6 +165,7 @@
     "defCount": 4,
     "sorryCount": 0,
     "isAristotle": false,
-    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ03.lean"
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -8,7 +8,13 @@
     "date": "2026-05-04",
     "status": "verified",
     "proofRepoPath": "Proofs/PappusTheoremOQ02.lean",
-    "tags": ["projective-geometry", "ring-theory", "combinatorics", "cross-product", "pappus"],
+    "tags": [
+      "projective-geometry",
+      "ring-theory",
+      "combinatorics",
+      "cross-product",
+      "pappus"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -109,6 +115,7 @@
     "sorryCount": 0,
     "lineCount": 465,
     "theoremCount": 12,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "sorries": 0
   }
 }


### PR DESCRIPTION
## Fix

Two categories of metadata corrections found during audit tracker review:

### 1. leanFile.sorries=null → 0 (10 entries)

The following gallery entries had `leanFile.sorries: null` (field missing) despite all actual Lean files having 0 sorries. Set to `0` explicitly:

- `abel-ruffini-galois-extensions-oq-05`
- `ballot-problem-oq-01-oq-02-oq-01-oq-01`
- `birthday-problem-oq-01-oq-01`
- `bounded-prime-gaps-oq-01-oq-03`
- `cantors-theorem-oq-01-oq-02`
- `circumference-via-differentiation`
- `frobenius-number`
- `gauss-wilson-non-cyclic`
- `inclusion-exclusion-oq-03`
- `pappus-theorem-oq-02`

### 2. Garbled text in ballot-problem-oq-03-oq-01-oq-02 (conclusion.summary)

Fix two word-swap errors:
- `"hookProd_ratio_formula is proved-free"` → `"hookProd_ratio_formula is sorry-free"`
- `"1 open proved remains"` → `"1 open sorry remains"`

## Evidence

All 10 Lean files verified to have 0 actual sorries (after stripping block/line comments). Garbled text identified from issue #15848.

---
Automated fix by lean-mechanic agent.