### PR TITLE
fix(meta): sync sorries/lineCount for laws-of-large-numbers-oq-03

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ03.lean",
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "MeasureTheory.MeasurePreserving",
@@ -43,8 +43,8 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
     "theoremCount": 9,
-    "lineCount": 375,
-    "assumptions": "4 axioms: Birkhoff ergodic theorem (general and ergodic case), maximal ergodic lemma, von Neumann mean ergodic theorem. These are deep analytical results requiring substantial proof infrastructure. 1 sorry: mixing \u2192 ergodic.",
+    "lineCount": 404,
+    "assumptions": "4 axioms: Birkhoff ergodic theorem (general and ergodic case), maximal ergodic lemma, von Neumann mean ergodic theorem. These are deep analytical results requiring substantial proof infrastructure.",
     "originalContributions": [
       "Complete formalization of Birkhoff sums and ergodic averages with algebraic properties",
       "Proof that iterates of measure-preserving maps are measure-preserving",
@@ -180,14 +180,14 @@
       "Topology"
     ],
     "namespace": "LawsOfLargeNumbersOQ03",
-    "lineCount": 375,
+    "lineCount": 404,
     "axiomCount": 4,
     "theoremCount": 9,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 5,
     "path": "Proofs/LawsOfLargeNumbersOQ03.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/LawsOfLargeNumbersOQ03Aristotle.lean"
     ]
@@ -218,5 +218,5 @@
       "leanType": "(T : \u03a9 \u2192 \u03a9) \u2192 MeasurePreserving T \u03bc \u03bc \u2192 (n : \u2115) \u2192 MeasurePreserving (T^[n]) \u03bc \u03bc"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Syncs stale metadata fields in `laws-of-large-numbers-oq-03/meta.json` after `mixing_implies_ergodic` was fully proved and the file grew by 29 lines.

## Evidence

**Lean file** (`proofs/Proofs/LawsOfLargeNumbersOQ03.lean`): 0 `sorry` keywords, 404 lines

**Before**:
- `meta.sorries`: 1
- `meta.lineCount`: 375
- `leanFile.sorries`: 1
- `leanFile.lineCount`: 375
- `assumptions`: mentions "1 sorry: mixing → ergodic"

**After**:
- `meta.sorries`: 0
- `meta.lineCount`: 404
- `leanFile.sorries`: 0
- `leanFile.lineCount`: 404
- `assumptions`: stale sorry note removed

Detected by gallery integrity audit (sorry mismatch: claims 1, actual 0).

---
Automated fix by lean-mechanic agent.