### PR TITLE
fix(meta): sync sorries/lineCount for erdos-589

### DIFF
--- a/src/data/proofs/erdos-589/meta.json
+++ b/src/data/proofs/erdos-589/meta.json
@@ -19,13 +19,13 @@
       "partially-resolved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 589,
     "erdosUrl": "https://erdosproblems.com/589",
     "erdosProblemStatus": "solved",
     "axiomCount": 4,
-    "lineCount": 339,
-    "assumptions": "4 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "lineCount": 344,
+    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7
   },
@@ -152,12 +152,12 @@
       "Real"
     ],
     "namespace": "Erdos589",
-    "lineCount": 339,
+    "lineCount": 344,
     "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos589Problem.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -176,5 +176,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, hales-jewett"
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Syncs stale metadata fields in `erdos-589/meta.json` after one sorry was proved and the file grew by 5 lines.

## Evidence

**Lean file** (`proofs/Proofs/Erdos589Problem.lean`): 2 sorry keywords (lines 159, 271), 344 lines

**Before**:
- `meta.sorries`: 3
- `meta.lineCount`: 339
- `leanFile.sorries`: 3
- `leanFile.lineCount`: 339

**After**:
- `meta.sorries`: 2
- `meta.lineCount`: 344
- `leanFile.sorries`: 2
- `leanFile.lineCount`: 344

Detected by gallery integrity audit (sorry mismatch: claims 3, actual 2).

---
Automated fix by lean-mechanic agent.