### PR TITLE
fix(meta): sync erdos-589 sorries 3→2 and lineCount 339→344

### DIFF
--- a/src/data/proofs/erdos-589/meta.json
+++ b/src/data/proofs/erdos-589/meta.json
@@ -19,13 +19,13 @@
       "partially-resolved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 589,
     "erdosUrl": "https://erdosproblems.com/589",
     "erdosProblemStatus": "solved",
     "axiomCount": 4,
     "lineCount": 339,
-    "assumptions": "4 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7
   },
@@ -152,12 +152,12 @@
       "Real"
     ],
     "namespace": "Erdos589",
-    "lineCount": 339,
+    "lineCount": 344,
     "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos589Problem.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

**Before**: `leanFile.sorries: 3`, `leanFile.lineCount: 339`, `meta.sorries: 3`, assumptions mentions "3 sorry(s)"

**After**: `leanFile.sorries: 2`, `leanFile.lineCount: 344`, `meta.sorries: 2`, assumptions mentions "2 sorry(s)"

## Evidence

Actual file verification (excluding comments):
- `Erdos589Problem.lean` has 344 lines and 2 real sorries (line 159: `trivial_lower_bound` needs Nat.sqrt→Real.rpow coercion; line 271: `g_kl` definition sorry)
- Meta.json claimed 3 sorries — one was proved since the last metadata sync

---
Automated fix by lean-mechanic agent.