### PR TITLE
fix(meta): sync meta.theoremCount for erdos-668 and abel-ruffini-galois-extensions-oq-05

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 1,
     "assumptions": "shafarevich_inverse_galois: Every finite solvable group G is the Galois group of some number field extension L/ℚ. Shafarevich (1954, Izv. Akad. Nauk). Proof requires class field theory, embedding problems, and Brauer group theory — not currently in Mathlib.",
     "lineCount": 214,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0,
     "originalContributions": [
       "shafarevich_inverse_galois: core axiom — Gal(L/ℚ) ≅ G for every finite solvable G",

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -63,7 +63,7 @@
     "axiomCount": 6,
     "lineCount": 334,
     "assumptions": "6 axioms: f_one/f_two/f_three/f_four (base values f(1)=f(2)=f(3)=f(4)=1), four_config_unique (uniqueness of the 4-point extremal configuration), extremalQuotient_finite (finite count of extremal configurations). No sorries.",
-    "theoremCount": 14
+    "theoremCount": 18
   },
   "overview": {
     "historicalContext": "**Erdos Problem #668**\n\nThis problem explores the structure of extremal configurations for the classical unit distance problem in the plane.\n\n**Background:**\nThe unit distance problem (Erdos Problem #90) asks: what is the maximum number u(n) of unit distances among n points in the plane? Problem #668 goes further, asking about the UNIQUENESS of configurations achieving this maximum.\n\n**Historical Development:**\n- The unit distance problem was posed by Erdos in 1946\n- The case n=4 is fully understood: exactly one configuration (the double triangle)\n- Computational work by Engel, Hammond-Lee, Su, Varga, Zsamboki [EHSVZ25] and Alexeev, Mixon, Parshall [AMP25] suggests uniqueness for 5 <= n <= 21\n\n**Status:** OPEN",


### PR DESCRIPTION
## Fix

Both proofs had `meta.theoremCount` out of sync with `leanFile.theoremCount` after PR #15867 synced `leanFile` counts to include private/protected lemmas.

## Evidence

**erdos-668**
- **Before**: `meta.theoremCount: 14`, `leanFile.theoremCount: 18`
- **After**: `meta.theoremCount: 18`
- 4 `private lemma` declarations were counted in leanFile but not reflected in meta

**abel-ruffini-galois-extensions-oq-05**
- **Before**: `meta.theoremCount: 8`, `leanFile.theoremCount: 9`
- **After**: `meta.theoremCount: 9`
- 1 additional theorem counted in leanFile but not reflected in meta

## Integrity Impact

LOW — status, badge, and all other fields correct. Only `meta.theoremCount` was stale.

---
Automated fix by lean-mechanic agent.