### PR TITLE
fix(meta): sync leanFile.theoremCount for 5 entries — restore private/protected count convention

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -1,600 +1,600 @@
 {
-  "id": "abel-ruffini-oq-04-oq-01",
-  "title": "Concrete Abel-Ruffini: Gal(x⁵ - 4x + 2) ≅ S₅ and Unsolvability by Radicals",
-  "slug": "abel-ruffini-oq-04-oq-01",
-  "description": "Proves that the polynomial x⁵ - 4x + 2 over ℚ has Galois group S₅, completing the Abel-Ruffini proof chain with a concrete witness. The roots of this polynomial cannot be expressed using radicals. Irreducibility proved via Eisenstein at p=2; |Gal|=120 proved axiom-free via Vandermonde discriminant (Gal⊄A₅), complex conjugation (transposition exists), and Sylow theory to rule out orders 5, 10, 15, 20, 30, 40, 60. Realizes S₅ as a Galois group over ℚ.",
-  "meta": {
-    "author": "Abel (1824), Galois (1832)",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem",
-    "date": "1824",
-    "status": "verified",
-    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ01.lean",
-    "tags": [
-      "algebra",
-      "group-theory",
-      "galois-theory",
-      "solvability",
-      "symmetric-group",
-      "eisenstein-criterion",
-      "wiedijk-100"
+    "id": "abel-ruffini-oq-04-oq-01",
+    "title": "Concrete Abel-Ruffini: Gal(x⁵ - 4x + 2) ≅ S₅ and Unsolvability by Radicals",
+    "slug": "abel-ruffini-oq-04-oq-01",
+    "description": "Proves that the polynomial x⁵ - 4x + 2 over ℚ has Galois group S₅, completing the Abel-Ruffini proof chain with a concrete witness. The roots of this polynomial cannot be expressed using radicals. Irreducibility proved via Eisenstein at p=2; |Gal|=120 proved axiom-free via Vandermonde discriminant (Gal⊄A₅), complex conjugation (transposition exists), and Sylow theory to rule out orders 5, 10, 15, 20, 30, 40, 60. Realizes S₅ as a Galois group over ℚ.",
+    "meta": {
+        "author": "Abel (1824), Galois (1832)",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem",
+        "date": "1824",
+        "status": "verified",
+        "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ01.lean",
+        "tags": [
+            "algebra",
+            "group-theory",
+            "galois-theory",
+            "solvability",
+            "symmetric-group",
+            "eisenstein-criterion",
+            "wiedijk-100"
+        ],
+        "badge": "mathlib",
+        "sorries": 0,
+        "axiomCount": 0,
+        "assumptions": "None. Fully verified with 0 axioms and 0 sorries after PR #6856 eliminated all remaining assumptions. Former axioms B1 (disc_p_neg) and B2 (vandermonde_sq_eq_disc_p) are now proved. Axiom A (three_dvd_gal_card) was proved via complex conjugation. All Galois group order exclusions (|Gal|≠10, ≠20, ≠40) are now proved via Sylow theory.",
+        "wiedijkNumber": 16,
+        "dateAdded": "2026-03-25",
+        "mathlibDependencies": [
+            {
+                "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+                "description": "Eisenstein's irreducibility criterion",
+                "module": "Mathlib.RingTheory.EisensteinCriterion"
+            },
+            {
+                "theorem": "Polynomial.Gal.galActionHom_injective",
+                "description": "Galois group embeds into Perm(rootSet)",
+                "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+            },
+            {
+                "theorem": "Polynomial.Gal.prime_degree_dvd_card",
+                "description": "Prime degree divides Galois group order",
+                "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+            },
+            {
+                "theorem": "solvableByRad.isSolvable'",
+                "description": "Solvable by radicals implies solvable Galois group",
+                "module": "Mathlib.FieldTheory.AbelRuffini"
+            },
+            {
+                "theorem": "Equiv.Perm.not_solvable",
+                "description": "Perm(α) not solvable for |α| ≥ 5",
+                "module": "Mathlib.GroupTheory.Solvable"
+            },
+            {
+                "theorem": "Matrix.det_vandermonde",
+                "description": "Vandermonde determinant equals product of differences",
+                "module": "Mathlib.LinearAlgebra.Vandermonde"
+            },
+            {
+                "theorem": "alternatingGroup.isSimpleGroup_five",
+                "description": "A₅ is a simple group",
+                "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
+            }
+        ],
+        "originalContributions": [
+            "Complete proof chain from Eisenstein irreducibility through galActionHom bijectivity to unsolvability by radicals for a specific polynomial x⁵ - 4x + 2",
+            "S₅ realizability theorem: first concrete realization of S₅ as a Galois group over ℚ in the gallery",
+            "Connects existing Abel-Ruffini proof chain (OQ-04) to a concrete witness, addressing the open question about formalizing the generic quintic Galois group"
+        ],
+        "prerequisites": [
+            "Galois theory (splitting fields, Galois groups, radical extensions)",
+            "Eisenstein's irreducibility criterion",
+            "Solvable groups and the derived series"
+        ],
+        "mathlib_version": "4.26.0",
+        "lineCount": 1498,
+        "relatedProblems": [
+            {
+                "id": "abel-ruffini-oq-04",
+                "relationship": "Extends: provides the concrete polynomial witness for the proof chain documented in OQ-04"
+            },
+            {
+                "id": "abel-ruffini",
+                "relationship": "Extends: uses the Galois bridge from the base theorem to conclude unsolvability"
+            },
+            {
+                "id": "inverse-galois",
+                "relationship": "Contributes: realizes S₅ as a Galois group over ℚ"
+            },
+            {
+                "id": "inverse-galois-oq-06",
+                "relationship": "Complementary: the sister computation realizing A₅ as a Galois group over ℚ, using the same Eisenstein + Sylow toolkit"
+            },
+            {
+                "id": "abel-ruffini-oq-04-oq-02",
+                "relationship": "Complementary: proves S₂, S₃, S₄ ARE solvable — the positive half of the solvability boundary that this entry's S₅ non-solvability defines"
+            },
+            {
+                "id": "abel-ruffini-oq-04-oq-03",
+                "relationship": "Foundational: formalizes Galois's full solvability criterion, of which this entry uses the forward direction (solvable by radicals ⇒ solvable Galois group)"
+            }
+        ],
+        "theoremCount": 36
+    },
+    "crossReferences": [
+        {
+            "targetId": "abel-ruffini-oq-04",
+            "relationship": "extends",
+            "description": "Provides the concrete polynomial witness for Step 5 of the proof chain: Gal(x⁵-4x+2/ℚ) ≅ S₅"
+        },
+        {
+            "targetId": "abel-ruffini",
+            "relationship": "extends",
+            "description": "Uses the Galois bridge (solvable by radicals ⇒ solvable Galois group) to conclude unsolvability"
+        },
+        {
+            "targetId": "inverse-galois",
+            "relationship": "contributes",
+            "description": "Realizes S₅ as Gal(x⁵-4x+2/ℚ), complementing S₃ and F₂₀ realizations in the gallery"
+        },
+        {
+            "targetId": "inverse-galois-oq-01",
+            "relationship": "related",
+            "description": "Proves the complete solvability characterization $S_n$ solvable iff $n \\leq 4$, which is the group-theoretic foundation for the non-solvability of $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$"
+        },
+        {
+            "targetId": "general-quartic",
+            "relationship": "complementary",
+            "description": "Ferrari's quartic formula succeeds because $S_4$ is solvable — this entry shows $x^5 - 4x + 2$ fails because $S_5$ is not, illustrating the sharp degree-5 boundary"
+        },
+        {
+            "targetId": "solution-of-cubic",
+            "relationship": "complementary",
+            "description": "Cardano's cubic formula succeeds because $S_3$ is solvable — the positive counterpart to this entry's quintic impossibility"
+        },
+        {
+            "targetId": "fundamental-theorem-algebra",
+            "relationship": "complementary",
+            "description": "FTA guarantees the roots of $x^5-4x+2$ exist in $\\mathbb{C}$; this entry shows those roots cannot be named using radical expressions"
+        },
+        {
+            "targetId": "descartes-rule-of-signs",
+            "relationship": "foundational",
+            "description": "Descartes' rule bounds real root counts by sign changes in coefficients — the same sign-change analysis used in this proof to locate 3 real roots of $x^5 - 4x + 2$, establishing that complex conjugation swaps the 2 non-real roots and thus acts as a transposition in the Galois group"
+        },
+        {
+            "targetId": "solution-of-cubic-oq-03-oq-01",
+            "relationship": "foundational",
+            "description": "Formalizes the discriminant $\\Delta = -4p^3 - 27q^2$ for the depressed cubic and the criterion $\\text{Gal}(f) \\subseteq A_n \\iff \\Delta(f)$ is a perfect square in $F$. The discriminant machinery is the linchpin of this entry's $|\\text{Gal}|=120$ proof: the Vandermonde product identity $\\Delta^2 = \\text{disc}(p)$ and the computed value $\\Delta^2 = -212144 < 0$ together force $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\not\\subseteq A_5$, which eliminates order 60 and is essential to the Sylow elimination cascade. Both entries develop discriminant theory in service of the concrete Abel-Ruffini proof chain."
+        },
+        {
+            "targetId": "sylow-theorems",
+            "relationship": "foundational",
+            "description": "Sylow's theorems are the primary tool for the case elimination in Part V: unique Sylow subgroups force cyclic structure (ruling out order 15), and Sylow counting constrains subgroup existence (ruling out order 30). The Sylow $p$-subgroup machinery directly enables the elimination of candidate Galois group orders"
+        },
+        {
+            "targetId": "lagrange-theorem",
+            "relationship": "foundational",
+            "description": "Lagrange's theorem ($|H|$ divides $|G|$ for $H \\leq G$) underpins the entire order-elimination strategy: $5 \\mid |\\text{Gal}|$ (orbit-stabilizer for transitive action on 5 roots), $|\\text{Gal}| \\mid 120$ (embedding into $S_5$ via `galActionHom`), and the Sylow elimination argument that narrows candidate orders to $\\{15, 30, 60, 120\\}$"
+        },
+        {
+            "targetId": "nth-root-irrational",
+            "relationship": "foundational",
+            "description": "The irrationality of $n$th roots is the base case for radical extensions: each step in a radical tower $K \\to K(\\sqrt[n]{a})$ extends the field because $a^{1/n} \\notin K$. This entry's impossibility result shows that iterating such extensions from $\\mathbb{Q}$ can never reach the roots of $x^5 - 4x + 2$"
+        },
+        {
+            "targetId": "vietas-formulas",
+            "relationship": "foundational",
+            "description": "Vieta's formulas express the coefficients of $x^5 - 4x + 2$ as elementary symmetric functions of its roots — this is why the Galois group permutes roots while preserving coefficients, and why the `galActionHom` maps $\\text{Gal}$ into $\\text{Perm}(\\text{rootSet})$"
+        },
+        {
+            "targetId": "angle-trisection",
+            "relationship": "related",
+            "description": "Both are impossibility results proved via Galois theory: Abel-Ruffini (this entry's concrete instance) shows $x^5-4x+2$ is unsolvable by radicals because $\\text{Gal} \\cong S_5$ is non-solvable, while angle trisection shows the general angle cannot be trisected by compass and straightedge because the minimal polynomial of $\\cos(20°)$ has degree 3 over the constructible field extension. Both reduce geometric/algebraic impossibility to group-theoretic obstructions"
+        },
+        {
+            "targetId": "kummer-theorem",
+            "relationship": "foundational",
+            "description": "Kummer theory provides the mechanism underlying the Galois bridge used in `roots_not_solvable_by_rad`: each radical extraction $K \\to K(\\sqrt[n]{a})$ creates a Kummer extension with cyclic Galois group. The impossibility arises because $S_5$ cannot be decomposed into such cyclic layers — exactly what the contrapositive of `solvableByRad.isSolvable'` captures"
+        },
+        {
+            "targetId": "inverse-galois-oq-06",
+            "relationship": "complementary",
+            "description": "The sister computation to this entry's $S_5$ realization: while this entry proves $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$ via Eisenstein at $p=2$ and Sylow elimination, `inverse-galois-oq-06` proves $A_5 \\cong \\text{Gal}(x^5-5x^4+10x^3-10x^2+25x-5/\\mathbb{Q})$ via Eisenstein at $p=5$ and Sylow theory. Together they realize the two non-solvable groups that appear in $S_5$'s composition series as Galois groups of explicit quintics over $\\mathbb{Q}$. Both entries invoke `not_solvable_by_rad_of_not_solvable_gal` to conclude unsolvability by radicals."
+        },
+        {
+            "targetId": "abel-ruffini-oq-04-oq-02",
+            "relationship": "complementary",
+            "description": "Proves the positive half of the solvability boundary: $S_2, S_3, S_4$ ARE solvable, with the bidirectional theorem $S_n$ solvable $\\iff n \\leq 4$. This entry proves $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$ implies unsolvability; `abel-ruffini-oq-04-oq-02` proves that every polynomial of degree $\\leq 4$ with Galois group $\\leq S_4$ IS solvable, completing the sharp degree-4/5 boundary. The `derived_series_solvable_of_solvable` path through $S_4 \\supset V_4 \\supset \\mathbb{Z}/2 \\supset \\{e\\}$ directly contrasts with the stalled derived series $S_5 \\supset A_5 \\supset A_5$."
+        },
+        {
+            "targetId": "abel-ruffini-oq-04-oq-03",
+            "relationship": "foundational",
+            "description": "Galois's solvability criterion: a root is solvable by radicals if and only if its Galois group is solvable. This entry uses only the forward direction (`solvableByRad.isSolvable'`: solvable by radicals $\\Rightarrow$ solvable Galois group) as a contrapositive; `abel-ruffini-oq-04-oq-03` formalizes the full Galois correspondence including the reverse direction (solvable Galois group $\\Rightarrow$ solvable by radicals, relying on Kummer theory). Together they give the complete biconditional that elevates Abel-Ruffini from a computational fact about $x^5-4x+2$ to a structural theorem about quintics generally."
+        },
+        {
+            "targetId": "abel-ruffini-galois-extensions",
+            "relationship": "foundational",
+            "description": "Houses the extended solvability classification and non-commutativity witnesses used implicitly throughout this proof: $S_0$–$S_4$ solvable, $S_n$ solvable $\\iff n \\leq 4$, $A_5$ simple, and non-commutativity witnesses for $S_3, S_4, S_5, A_4, A_5$. This entry's `s5_not_solvable` relies on `Equiv.Perm.not_solvable`, whose proof in turn rests on $A_5$'s simplicity — the same infrastructure that `abel-ruffini-galois-extensions` develops systematically with 57 theorems. The `solvable_of_surjective` transfer that propagates non-solvability from $S_5$ to $\\text{Gal}(p/\\mathbb{Q})$ also mirrors the solvability transfer lemmas proved there."
+        },
+        {
+            "targetId": "abel-ruffini-oq-04-oq-02-oq-03",
+            "relationship": "related",
+            "description": "Finite Groups of Order $< 60$ Are Solvable: this entry establishes that $|A_5| = 60$ is the precise solvability threshold by proving all groups of order $< 60$ (hence all proper subgroups of $A_5$) are solvable. Complementary to the case $|\\text{Gal}| = 60$ elimination here: if $|\\text{Gal}|$ were 60, the Galois image would be $A_5$ itself — but this entry proves $\\text{Gal} \\not\\subseteq A_5$ via the odd-permutation discriminant argument, so the 60-threshold result is not needed. Together these two entries bracket the non-solvability threshold from both sides."
+        }
     ],
-    "badge": "mathlib",
-    "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries after PR #6856 eliminated all remaining assumptions. Former axioms B1 (disc_p_neg) and B2 (vandermonde_sq_eq_disc_p) are now proved. Axiom A (three_dvd_gal_card) was proved via complex conjugation. All Galois group order exclusions (|Gal|≠10, ≠20, ≠40) are now proved via Sylow theory.",
-    "wiedijkNumber": 16,
-    "dateAdded": "2026-03-25",
-    "mathlibDependencies": [
-      {
-        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
-        "description": "Eisenstein's irreducibility criterion",
-        "module": "Mathlib.RingTheory.EisensteinCriterion"
-      },
-      {
-        "theorem": "Polynomial.Gal.galActionHom_injective",
-        "description": "Galois group embeds into Perm(rootSet)",
-        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
-      },
-      {
-        "theorem": "Polynomial.Gal.prime_degree_dvd_card",
-        "description": "Prime degree divides Galois group order",
-        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
-      },
-      {
-        "theorem": "solvableByRad.isSolvable'",
-        "description": "Solvable by radicals implies solvable Galois group",
-        "module": "Mathlib.FieldTheory.AbelRuffini"
-      },
-      {
-        "theorem": "Equiv.Perm.not_solvable",
-        "description": "Perm(α) not solvable for |α| ≥ 5",
-        "module": "Mathlib.GroupTheory.Solvable"
-      },
-      {
-        "theorem": "Matrix.det_vandermonde",
-        "description": "Vandermonde determinant equals product of differences",
-        "module": "Mathlib.LinearAlgebra.Vandermonde"
-      },
-      {
-        "theorem": "alternatingGroup.isSimpleGroup_five",
-        "description": "A₅ is a simple group",
-        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
-      }
+    "overview": {
+        "historicalContext": "The Abel-Ruffini theorem has a dramatic history. Ruffini (1799) gave the first incomplete proof that the general quintic is unsolvable by radicals, but his argument had gaps in the treatment of permutation groups. Abel (1824) provided the first rigorous proof, showing no universal radical formula exists for degree 5 or higher. Galois (1832, published posthumously after his death in a duel at age 20) gave the definitive framework: a polynomial is solvable by radicals if and only if its Galois group is solvable. Since $S_5$ is not solvable (because $A_5$ is simple and non-abelian), any polynomial with Galois group $S_5$ has unsolvable roots.\n\nThe polynomial $x^5 - 4x + 2$ is a standard textbook example appearing in Dummit-Foote, Artin, and Lang, chosen because Eisenstein's criterion gives easy irreducibility and derivative analysis shows exactly 3 real roots. Eisenstein's criterion itself was published by Gotthold Eisenstein in 1850 in Crelle's Journal — the same journal that published Abel's refined proof in 1826. Eisenstein, who died of tuberculosis at age 29 (like Abel at 26), provided what Gauss called the simplest and most elegant irreducibility test. The criterion that $p$ divides all non-leading coefficients but $p^2$ does not divide the constant term remains the most frequently used irreducibility tool in textbooks.\n\nThe classical textbook approach to computing the Galois group of a specific quintic uses Dedekind's theorem (1882) — the cycle type of the Frobenius automorphism matches the mod-$p$ factorization — to establish divisibility conditions on $|\\text{Gal}|$. This formalization takes a different route: it establishes $\\text{Gal} \\not\\subset A_5$ via the Vandermonde discriminant ($\\Delta^2 = -212144 < 0$, so the Fundamental Theorem of Galois Theory forces an odd permutation), obtains a transposition via complex conjugation (embedding the splitting field into $\\mathbb{C}$ via `IsAlgClosed.lift` and composing with `starRingEnd`), and then eliminates non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$ via Sylow theory. This approach avoids all mod-$p$ arithmetic and works purely within algebraic and group-theoretic methods.\n\nThis formalization bridges abstract impossibility to a concrete witness: these five specific complex numbers cannot be written using radicals.",
+        "problemStatement": "Prove that the polynomial $x^5 - 4x + 2$ has Galois group $S_5$ over $\\mathbb{Q}$, and conclude that its roots cannot be expressed using radicals.",
+        "text": "This file completes the Abel-Ruffini proof chain by providing a concrete polynomial whose roots are provably unsolvable by radicals. The polynomial x⁵ - 4x + 2 is shown irreducible via Eisenstein's criterion at p=2, and its Galois group is identified as S₅ via the galActionHom bijectivity argument. Since S₅ is not solvable, Galois's theorem implies the roots cannot be expressed by radicals.",
+        "proofStrategy": "The proof has four main stages:\n\n**1. Irreducibility** (Part II): Eisenstein's criterion at the prime ideal $(2) \\subset \\mathbb{Z}$ shows $x^5 - 4x + 2$ is irreducible over $\\mathbb{Z}$: all non-leading coefficients $(0, 0, 0, -4, 2)$ are divisible by 2, the constant term 2 is not divisible by 4, and the leading coefficient 1 is coprime to 2. Gauss's lemma (monic $\\Rightarrow$ primitive) transfers irreducibility from $\\mathbb{Z}[X]$ to $\\mathbb{Q}[X]$.\n\n**2. Galois group identification** (Parts III-VI): The `galActionHom` embeds $\\text{Gal}$ into $\\text{Perm}(\\text{rootSet}) \\cong S_5$ (injective by Mathlib). Establishing $|\\text{Gal}| = 120$ proceeds by elimination: (a) $5 \\mid |\\text{Gal}|$ by orbit-stabilizer (irreducible of prime degree gives transitive action), (b) $\\text{Gal} \\not\\subset A_5$ via the discriminant sign argument: the Vandermonde product $\\Delta$ satisfies $\\Delta^2 = \\text{disc}(p) = -212144 < 0$ (proved from the derivative product identity), so by FTGT if all Galois automorphisms were even then $\\Delta \\in \\mathbb{Q}$, contradicting $\\Delta^2 < 0$; thus `gal_has_odd_perm` establishes a transposition in the Galois image, (c) $3 \\mid |\\text{Gal}|$ by eliminating non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$ via Sylow theory: a transposition cannot normalize the unique Sylow 5-subgroup in groups of these orders, (d) Sylow theory eliminates orders 15 (unique $P_3, P_5$ force cyclic, impossible in $S_5$) and 30 ($A_5$ simplicity), (e) order 60 eliminated because $\\text{Gal} \\not\\subset A_5$ by step (b). Only $|\\text{Gal}| = 120$ remains. Bijectivity of `galActionHom` follows by the pigeonhole principle.\n\n**3. Non-solvability transfer** (Part VII): $S_5$ is not solvable (Mathlib's `Equiv.Perm.not_solvable`, since $A_5$ is simple). The isomorphism $\\text{Gal} \\cong S_5$ transfers non-solvability via `solvable_of_surjective`.\n\n**4. Abel-Ruffini conclusion** (Part VIII): By contrapositive of Galois's theorem (`solvableByRad.isSolvable'`), non-solvable Galois group implies roots are not expressible by radicals.",
+        "keyInsights": [
+            "**Eisenstein at p = 2 is elegant**: Coefficients $(1, 0, 0, 0, -4, 2)$ satisfy Eisenstein at $(2)$: non-leading coefficients all divisible by 2, constant term 2 not divisible by 4, leading coefficient coprime to 2. This is the simplest irreducibility argument for a specific quintic.",
+            "**3 real roots give a transposition**: Sign analysis at $f(-2) < 0 < f(-1)$, $f(0) > 0 > f(1)$, $f(1) < 0 < f(2)$ locates 3 real roots. Since $f'(x) = 5x^4 - 4$ has only 2 real critical points, there are exactly 3 real and 2 complex conjugate roots. Complex conjugation acts as a transposition on the 5 roots.",
+            "**Transposition + p-cycle generates $S_p$**: Conjugate the transposition $(i\\;j)$ by powers of the $p$-cycle $(1\\;2\\;\\cdots\\;p)$ to generate all adjacent transpositions $(k\\;k+1)$, which generate $S_p$. This classical result is the group-theoretic bridge from real root analysis to the full symmetric group.",
+            "**Pigeonhole for bijectivity**: With $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$ and the injective galActionHom, bijectivity follows from the pigeonhole principle. This avoids constructing an explicit inverse.",
+            "**Concrete witness matters**: Abel's original theorem proves existence of unsolvable quintics abstractly. This formalization gives a specific polynomial $x^5 - 4x + 2$ whose five roots provably resist all radical expressions, making the impossibility tangible.",
+            "**Sylow elimination as case analysis**: The proof that $|\\text{Gal}| = 120$ is a remarkable case analysis. From $5 \\mid |G|$, $3 \\mid |G|$, and $|G| \\mid 120$, the candidates are $\\{15, 30, 60, 120\\}$. Sylow theory eliminates 15 (unique $P_5$ and $P_3$ would force a cyclic subgroup of order 15, but $S_5$ has none). The simplicity of $A_5$ eliminates 30 (an index-4 subgroup gives $S_5 \\to S_4$, impossible). The odd permutation from discriminant analysis eliminates 60 ($A_5$ is the unique order-60 subgroup, but the Galois image is not contained in $A_5$). Only 120 remains.",
+            "**Complex conjugation as the key to eliminating Dedekind's theorem**: The proof constructs a Galois automorphism from complex conjugation: embed the splitting field $SF \\hookrightarrow \\mathbb{C}$ via `IsAlgClosed.lift`, compose with `starRingEnd \\mathbb{C}` (complex conjugation), then restrict via `restrictNormal` to get $\\sigma \\in \\text{Gal}(p/\\mathbb{Q})$. Since $\\Delta^2 = \\text{disc}(p) = -212144 < 0$, the FTGT forces $\\sigma$ to have odd sign — giving a transposition without needing Dedekind's theorem or mod-$p$ factorization at all. This single construction replaces both the Dedekind axiom and the original real-root-count argument.",
+            "**Sylow elimination as a universal strategy for $3 \\mid |\\text{Gal}|$**: Rather than using Dedekind's theorem (mod-$p$ factorization), the proof establishes $3 \\mid |\\text{Gal}|$ purely from the transposition: candidate orders not divisible by 3 are $\\{5, 10, 20, 40\\}$, and each is eliminated by showing a transposition cannot coexist with the unique normal Sylow 5-subgroup at that order. For orders 10, 20, 40: the transposition from `gal_has_odd_perm` would have to normalize the unique Sylow 5-subgroup, but `native_decide` verifies no transposition in $S_5$ normalizes any 5-cycle. For order 5: any order-5 subgroup of $S_5$ consists entirely of even permutations, contradicting the transposition. This approach is more elementary than Dedekind and avoids all mod-$p$ arithmetic.",
+            "**Why $x^5 - 4x + 2$ rather than $x^5 - x - 1$ or $x^5 + x + 1$**: The polynomial choice trades off three competing constraints. Eisenstein irreducibility forces a prime $p$ dividing all non-leading coefficients but with $p^2 \\nmid$ constant term — the simplest such pattern is $p=2$ with constant term $\\pm 2$ and one nonzero linear coefficient divisible by 2. Three real roots (for the complex-conjugation transposition) requires the discriminant to be negative — the value $\\Delta^2 = -212144 = -2^4 \\cdot 13259$ is small enough that the derivative-product calculation $p(5/8) = -13259/32768$ keeps the arithmetic tractable. Finally, the constant term $+2$ rather than $-2$ (yielding the famous Trinks polynomials with Galois group $D_5$ or $F_{20}$) ensures a transitive action with all 5 roots in distinct orbits, forcing the Galois image to be primitive and hence (by O'Nan-Scott) maximal in $S_5$. Dummit-Foote's choice optimizes Eisenstein simplicity, real-root sign-change visibility, and discriminant computability simultaneously.",
+            "**Bring-Jerrard form as the natural domain**: The polynomial $x^5 - 4x + 2$ is already in *Bring-Jerrard normal form* $x^5 + px + q$ (i.e., the coefficients of $x^4, x^3, x^2$ all vanish). Tschirnhaus (1683) and Bring (1786) showed every quintic can be transformed to this normal form by a polynomial substitution of degree at most 4 — Hermite (1858) used this to express quintic roots via elliptic modular functions. The choice of $p = -4, q = 2$ here is no accident: among Bring-Jerrard quintics with small integer coefficients, this is one of the simplest with a clear non-square discriminant ($\\text{disc} = -212144$) and 3 real roots. Other classical witnesses in the same form include $x^5 - x - 1$ (discriminant $2869 = 19 \\cdot 151$, also non-square, $\\text{Gal} \\cong S_5$) and $x^5 - 6x + 3$ (Eisenstein at $p = 3$). The Bring-Jerrard form is the algebraic 'minimal model' for the quintic — once a quintic is reduced to it, the discriminant computation becomes the simple expression $\\text{disc}(x^5 + px + q) = 256 p^5 + 3125 q^4$ (sometimes written with a sign convention; for our $p=-4, q=2$: $256 \\cdot (-4)^5 + 3125 \\cdot 2^4 = -262144 + 50000 = -212144$, matching the value computed in `vandermondeProduct_sq_val`).",
+            "**Stauduhar's algorithm and computational Galois theory**: The case-elimination structure of this proof mirrors Stauduhar's algorithm (1973), the standard method for computing Galois groups of polynomials over $\\mathbb{Q}$ in computer algebra systems (PARI/GP, Magma, Sage, GAP). Stauduhar starts from the lattice of transitive subgroups of $S_n$ (for $n=5$, there are exactly 5: $S_5, A_5, F_{20}, D_5, C_5$) and uses *resolvent polynomials* — polynomials whose Galois group fixes a chosen subgroup — to descend through the lattice from $S_n$ downward. At each step, one checks whether a particular resolvent has rational roots (yes $\\Rightarrow$ Galois group is contained in the corresponding subgroup; no $\\Rightarrow$ stop). The discriminant is the resolvent for $A_n$ (the discriminant being a square iff $\\text{Gal} \\subseteq A_n$). The proof here essentially implements the first Stauduhar test by hand: $\\sqrt{\\text{disc}(p)} \\notin \\mathbb{Q}$ (because $\\text{disc}(p) = -212144 < 0$) eliminates $A_5$. The Sylow elimination of orders 10, 20, 40 then implicitly handles the resolvents for $D_5, F_{20}, C_5$ — all proper transitive subgroups of $S_5$. A future formalization could extract these as explicit resolvent computations and connect to a general Stauduhar tactic in Mathlib."
+        ],
+        "prerequisites": [
+            "Abstract algebra (groups, solvable groups, symmetric groups)",
+            "Galois theory (field extensions, Galois groups, splitting fields)",
+            "Polynomial algebra (irreducibility criteria, Eisenstein criterion)",
+            "Sylow theory (Sylow subgroup existence, uniqueness, and counting)"
+        ],
+        "relatedConcepts": [
+            "Galois group",
+            "solvability by radicals",
+            "S5",
+            "Eisenstein criterion",
+            "Vandermonde determinant",
+            "Wiedijk theorem 16",
+            "discriminant sign",
+            "Sylow theory"
+        ]
+    },
+    "sections": [
+        {
+            "id": "header",
+            "title": "Problem Overview, Proof Chain, and Pre-Classical Computational Lemmas",
+            "startLine": 1,
+            "endLine": 98,
+            "summary": "Documents the complete Abel-Ruffini proof chain and motivation for choosing $x^5 - 4x + 2$. Lists all 5 steps from $A_5$ simplicity to unsolvability by radicals. Lines 63-91: three computational lemmas proved by `native_decide` that must appear before `open scoped Classical` for decidability — `perm_fin5_order5_order3_not_commute` (used in Sylow order-15 elimination), `perm_fin5_order_dvd5_sign_one` (elements of order dividing 5 in $S_5$ are even), and `transposition_not_normalizing_5cycle` (used in Sylow elimination of orders 10, 20, 40). All three feed into the main proof.",
+            "mathContext": "Proof chain: (1) $A_5$ simple, (2) $S_n$ not solvable for $n \\geq 5$, (3) solvable by radicals $\\Rightarrow$ solvable Gal, (4) $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$, (5) roots not expressible by radicals.",
+            "relatedConcepts": [
+                "Abel-Ruffini theorem",
+                "Galois theory",
+                "native_decide",
+                "solvability by radicals",
+                "proof chain"
+            ]
+        },
+        {
+            "id": "polynomial",
+            "title": "Part I: The Polynomial p = X⁵ - 4X + 2",
+            "startLine": 99,
+            "endLine": 108,
+            "summary": "Defines $p = X^5 - 4X + 2$ over $\\mathbb{Q}$ and its $\\mathbb{Z}[X]$ version `p_int` for Eisenstein criterion application.",
+            "mathContext": "$p(x) = x^5 - 4x + 2 \\in \\mathbb{Q}[X]$, $p_{\\text{int}} = x^5 - 4x + 2 \\in \\mathbb{Z}[X]$.",
+            "relatedConcepts": [
+                "Bring-Jerrard form",
+                "Eisenstein criterion",
+                "Polynomial.C",
+                "rational polynomial",
+                "integer polynomial"
+            ]
+        },
+        {
+            "id": "irreducibility",
+            "title": "Part II: Irreducibility via Eisenstein at p = 2",
+            "startLine": 109,
+            "endLine": 183,
+            "summary": "Proves $p$ is irreducible over $\\mathbb{Q}$. First proves irreducibility over $\\mathbb{Z}$ using Eisenstein's criterion at the prime ideal $(2)$, then transfers to $\\mathbb{Q}$ via Gauss's lemma (monic $\\Rightarrow$ primitive).",
+            "mathContext": "Eisenstein at $(2) \\subset \\mathbb{Z}$: $2 \\nmid 1$, $2 \\mid 0, 0, 0, -4, 2$, $4 \\nmid 2$. Therefore $p$ is irreducible over $\\mathbb{Z}$, hence over $\\mathbb{Q}$ by Gauss's lemma.",
+            "relatedConcepts": [
+                "Eisenstein criterion",
+                "Gauss's lemma",
+                "prime ideal",
+                "p_int_monic",
+                "irreducible_of_eisenstein_criterion"
+            ]
+        },
+        {
+            "id": "structure",
+            "title": "Part III: Basic Structural Properties",
+            "startLine": 184,
+            "endLine": 207,
+            "summary": "Proves $\\deg(p) = 5$, $p$ is monic, $p$ is separable (char 0), and $|\\text{rootSet}(p)| = 5$.",
+            "mathContext": "$\\deg(p) = 5$, $p$ monic and separable. In the splitting field: $|\\{\\alpha : p(\\alpha) = 0\\}| = 5$.",
+            "relatedConcepts": [
+                "separable polynomial",
+                "splitting field",
+                "rootSet",
+                "compute_degree!",
+                "characteristic zero"
+            ]
+        },
+        {
+            "id": "galois-structure",
+            "title": "Part IV: Galois Group Structure",
+            "startLine": 208,
+            "endLine": 231,
+            "summary": "Proves $5 \\mid |\\text{Gal}|$ (prime degree gives transitive action, orbit-stabilizer) and $|\\text{Gal}| \\mid 120$ (galActionHom embeds $\\text{Gal}$ into $S_5$). Together: $|\\text{Gal}| \\in \\{5, 10, 15, 20, 30, 40, 60, 120\\}$.",
+            "mathContext": "$5 \\mid |\\text{Gal}|$ and $|\\text{Gal}| \\mid 5! = 120$. Possible orders: $\\{5, 10, 15, 20, 30, 40, 60, 120\\}$.",
+            "relatedConcepts": [
+                "galActionHom",
+                "orbit-stabilizer theorem",
+                "Lagrange's theorem",
+                "transitive group action",
+                "prime_degree_dvd_card"
+            ]
+        },
+        {
+            "id": "gal-order",
+            "title": "Parts V(a)-(f): Galois Group Order |Gal| = 120 (Theorem)",
+            "startLine": 232,
+            "endLine": 1377,
+            "summary": "The largest section (~1150 lines): proves $|\\text{Gal}| = 120$ via systematic case elimination. (a) Lines 232-264: polynomial evaluations showing 3 sign changes (sign change comment motivates complex conjugation argument). (b) Lines 265-293: `c5` 5-cycle definition and Part V(c) Galois infrastructure header. (c) Lines 306-336: `galToPerm5` injection from $\\text{Gal}$ to $S_5$, injectivity, and `galSign`. (d) Lines 337-507: Sylow elimination of orders 15 and 30 (`no_subgroup_order_15`, `a5_card`, `no_subgroup_order_30`). (e) Lines 508-806: Vandermonde machinery, discriminant computation ($\\Delta^2 = -212144$), and `gal_has_odd_perm`. (e2) Lines 807-1244: complex conjugation gives transposition (`sfEmb`, `conjGalAut`, `gal_has_transposition`), Sylow elimination of non-3-divisible orders (`gal_card_ne_20`, `gal_card_ne_10`, `gal_card_ne_40`), `three_dvd_gal_card`. (f) Lines 1246-1377: case elimination (`gal_card_ne_15`, `gal_card_ne_30`, `gal_card_ne_60`) and `gal_card_eq_120`. Fully proved with 0 axioms.",
+            "mathContext": "Theorem: $|\\text{Gal}(x^5-4x+2/\\mathbb{Q})| = 120$. From $5 \\mid |G|$, $3 \\mid |G|$, $|G| \\mid 120$: $|G| \\in \\{15,30,60,120\\}$. Not 15 (Sylow), not 30 ($A_5$ simple), not 60 ($\\text{Gal} \\not\\subset A_5$ by discriminant sign). All steps fully proved.",
+            "relatedConcepts": [
+                "Vandermonde determinant",
+                "complex conjugation",
+                "Sylow elimination",
+                "discriminant sign",
+                "gal_card_eq_120"
+            ]
+        },
+        {
+            "id": "gal-iso",
+            "title": "Part VI: Gal(p/ℚ) ≅ S₅",
+            "startLine": 1378,
+            "endLine": 1412,
+            "summary": "Proves `gal_iso_s5`: $\\text{Gal} \\cong S_5$ via galActionHom bijectivity. Injective (Mathlib's `galActionHom_injective`) + $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$ from `gal_card_eq_120`. Bijectivity via `Fintype.bijective_iff_injective_and_card`. Transfer from $\\text{Perm}(\\text{rootSet})$ to $\\text{Perm}(\\text{Fin}\\;5)$ via `Equiv.permCongr`.",
+            "mathContext": "$\\text{galActionHom}$ injective + $|\\text{Gal}| = |S_5| = 120$ $\\Rightarrow$ bijective $\\Rightarrow$ $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$.",
+            "relatedConcepts": [
+                "galActionHom",
+                "MulEquiv.ofBijective",
+                "pigeonhole principle",
+                "Equiv.permCongr",
+                "Fintype.bijective_iff_injective_and_card"
+            ]
+        },
+        {
+            "id": "not-solvable",
+            "title": "Part VII: Non-Solvability",
+            "startLine": 1413,
+            "endLine": 1431,
+            "summary": "`s5_not_solvable`: $S_5$ not solvable via `Equiv.Perm.not_solvable` with $5 \\leq |\\text{Fin}\\;5|$. `gal_not_solvable`: transfers non-solvability from $S_5$ to $\\text{Gal}$ via the surjective `MulEquiv` from Part VI using `solvable_of_surjective`.",
+            "mathContext": "$S_5$ not solvable (derived series stalls at $A_5$). $\\text{Gal} \\cong S_5 \\Rightarrow \\text{Gal}$ not solvable.",
+            "relatedConcepts": [
+                "derived series",
+                "A5 simplicity",
+                "solvable_of_surjective",
+                "Equiv.Perm.not_solvable",
+                "group surjection"
+            ]
+        },
+        {
+            "id": "abel-ruffini-conclusion",
+            "title": "Part VIII: Abel-Ruffini Conclusion",
+            "startLine": 1432,
+            "endLine": 1466,
+            "summary": "Main theorem `roots_not_solvable_by_rad`: for any root $\\alpha$ of $x^5 - 4x + 2$, $\\alpha \\notin \\text{solvableByRad}(\\mathbb{Q})$. Proof: assume $\\alpha$ solvable by radicals; by `solvableByRad.isSolvable'` with `p_irreducible` and `hroot`, $\\text{Gal}(p)$ is solvable — contradicting `gal_not_solvable`.",
+            "mathContext": "$\\alpha \\in \\text{Rad}(\\mathbb{Q}) \\Rightarrow \\text{Gal}(p/\\mathbb{Q})$ solvable $\\Rightarrow S_5$ solvable $\\Rightarrow \\bot$.",
+            "relatedConcepts": [
+                "solvableByRad.isSolvable'",
+                "contrapositive",
+                "radical extension",
+                "IsSolvableByRad",
+                "Galois bridge"
+            ]
+        },
+        {
+            "id": "three-dvd-proved",
+            "title": "Part V(e2): three_dvd_gal_card (Eliminating Non-3-Divisible Orders)",
+            "startLine": 1210,
+            "endLine": 1244,
+            "summary": "Proves `three_dvd_gal_card`: $3 \\mid |\\text{Gal}|$ by eliminating all non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$. Order 5 eliminated by sign argument (order-5 permutations in $S_5$ are even). Order 20 eliminated by `gal_card_ne_20` (F₂₀ has no transpositions but Gal does). Orders 10 and 40 eliminated via Sylow theory. All cases fully proved.",
+            "mathContext": "$|\\text{Gal}| \\in \\{5,10,15,20,30,40,60,120\\}$. Not 5 (sign), not 10, 20, 40 (Sylow/transposition arguments). Remaining: $\\{15,30,60,120\\}$ — all divisible by 3.",
+            "relatedConcepts": [
+                "Sylow theory",
+                "transposition normalization",
+                "native_decide",
+                "non-3-divisible order elimination"
+            ]
+        },
+        {
+            "id": "vandermonde-infrastructure",
+            "title": "Part V(e)+(e2): Vandermonde, Complex Conjugation, and Discriminant Infrastructure",
+            "startLine": 508,
+            "endLine": 1244,
+            "summary": "Root enumeration (`rootEnum_p`), Vandermonde product $\\Delta = \\det(V(\\text{roots}))$, Galois permutation of roots, Vandermonde permutation identity ($\\sigma(\\Delta) = \\text{sign}(\\sigma) \\cdot \\Delta$), and `gal_has_odd_perm` proved via the discriminant sign argument ($\\text{disc}(p) < 0$ implies $\\Delta \\notin \\mathbb{Q}$, so some $\\sigma$ has odd sign).",
+            "mathContext": "$\\Delta = \\prod_{i<j}(\\alpha_j - \\alpha_i)$. $\\sigma(\\Delta) = \\text{sign}(\\sigma) \\cdot \\Delta$. If all signs $+1$, $\\Delta \\in \\mathbb{Q}$ but $\\Delta^2 < 0$ — contradiction.",
+            "relatedConcepts": [
+                "Vandermonde determinant",
+                "Matrix.det_permute",
+                "root enumeration",
+                "galToPerm5",
+                "derivative product identity"
+            ]
+        },
+        {
+            "id": "gal-card-120",
+            "title": "Part V(f): |Gal(p/ℚ)| = 120 (Case Elimination)",
+            "startLine": 1246,
+            "endLine": 1377,
+            "summary": "Proves `gal_card_eq_120`: $|\\text{Gal}| = 120$ by combining $15 \\mid |\\text{Gal}|$ (from `five_dvd_gal_card` and `three_dvd_gal_card`) with elimination of orders 15 (Sylow), 30 ($A_5$ simplicity), and 60 (odd permutation). Only 120 remains.",
+            "mathContext": "$15 \\mid |G|$, $|G| \\mid 120$: $|G| \\in \\{15,30,60,120\\}$. Not 15, 30, 60 $\\Rightarrow |G| = 120$.",
+            "relatedConcepts": [
+                "case elimination",
+                "divisibility chain",
+                "Sylow theory",
+                "discriminant sign",
+                "galois group order"
+            ]
+        },
+        {
+            "id": "realizability",
+            "title": "Part IX: $S_5$ Realizability and Verification",
+            "startLine": 1467,
+            "endLine": 1498,
+            "summary": "`s5_realizable`: $S_5$ is realizable as a Galois group over $\\mathbb{Q}$, witnessed by the splitting field of $x^5 - 4x + 2$. Lines 1485-1498: `#check` verification of all 9 key theorems.",
+            "mathContext": "$\\exists K/\\mathbb{Q}$ Galois: $\\text{Gal}(K/\\mathbb{Q}) \\cong S_5$. Witness: $K = $ splitting field of $x^5 - 4x + 2$.",
+            "relatedConcepts": [
+                "inverse Galois problem",
+                "splitting field",
+                "IsGalois",
+                "FiniteDimensional",
+                "s5_realizable"
+            ]
+        }
     ],
-    "originalContributions": [
-      "Complete proof chain from Eisenstein irreducibility through galActionHom bijectivity to unsolvability by radicals for a specific polynomial x⁵ - 4x + 2",
-      "S₅ realizability theorem: first concrete realization of S₅ as a Galois group over ℚ in the gallery",
-      "Connects existing Abel-Ruffini proof chain (OQ-04) to a concrete witness, addressing the open question about formalizing the generic quintic Galois group"
-    ],
-    "prerequisites": [
-      "Galois theory (splitting fields, Galois groups, radical extensions)",
-      "Eisenstein's irreducibility criterion",
-      "Solvable groups and the derived series"
-    ],
-    "mathlib_version": "4.26.0",
-    "lineCount": 1498,
-    "relatedProblems": [
-      {
-        "id": "abel-ruffini-oq-04",
-        "relationship": "Extends: provides the concrete polynomial witness for the proof chain documented in OQ-04"
-      },
-      {
-        "id": "abel-ruffini",
-        "relationship": "Extends: uses the Galois bridge from the base theorem to conclude unsolvability"
-      },
-      {
-        "id": "inverse-galois",
-        "relationship": "Contributes: realizes S₅ as a Galois group over ℚ"
-      },
-      {
-        "id": "inverse-galois-oq-06",
-        "relationship": "Complementary: the sister computation realizing A₅ as a Galois group over ℚ, using the same Eisenstein + Sylow toolkit"
-      },
-      {
-        "id": "abel-ruffini-oq-04-oq-02",
-        "relationship": "Complementary: proves S₂, S₃, S₄ ARE solvable — the positive half of the solvability boundary that this entry's S₅ non-solvability defines"
-      },
-      {
-        "id": "abel-ruffini-oq-04-oq-03",
-        "relationship": "Foundational: formalizes Galois's full solvability criterion, of which this entry uses the forward direction (solvable by radicals ⇒ solvable Galois group)"
-      }
-    ],
-    "theoremCount": 36
-  },
-  "crossReferences": [
-    {
-      "targetId": "abel-ruffini-oq-04",
-      "relationship": "extends",
-      "description": "Provides the concrete polynomial witness for Step 5 of the proof chain: Gal(x⁵-4x+2/ℚ) ≅ S₅"
+    "conclusion": {
+        "summary": "This formalization completes the Abel-Ruffini proof chain by exhibiting a concrete polynomial $x^5 - 4x + 2$ whose roots cannot be expressed by radicals. The proof proceeds from Eisenstein irreducibility through Galois group identification ($\\text{Gal} \\cong S_5$) to the unsolvability conclusion via Galois's theorem. Fully verified with 0 sorries and 0 axioms. The key result $|\\text{Gal}| = 120$ is proved without axioms via three techniques: (1) the Vandermonde product computation proves $\\Delta^2 = -212144$ from the derivative product identity, (2) complex conjugation (`IsAlgClosed.lift` + `starRingEnd`) proves the Galois group contains an odd permutation, and (3) Sylow elimination rules out all candidate orders except 120 — orders $\\{5,10,20,40\\}$ excluded because a transposition cannot normalize the unique Sylow 5-subgroup, orders 15 and 30 by Sylow counting and $A_5$ simplicity, and order 60 because $\\text{Gal} \\not\\subset A_5$.",
+        "implications": "1. **Wiedijk Top-100 (#16)**: This formalization completes Wiedijk theorem #16 (Abel-Ruffini impossibility) with a fully machine-checked proof at the hardest end of the spectrum — a concrete witness rather than an abstract existence statement. The Wiedijk list includes many theorems whose formalizations remain incomplete or axiom-heavy; this entry achieves the gold standard of 0 axioms and 0 sorries for a non-trivial result in algebraic number theory.\n\n2. **Concrete witnesses vs. abstract impossibility**: Abel's original 1824 proof shows no *general* radical formula exists for degree ≥ 5. This formalization goes further: these five specific complex numbers $\\alpha_1, \\ldots, \\alpha_5$ satisfying $x^5 - 4x + 2 = 0$ provably cannot be individually expressed using $+, -, \\times, \\div, \\sqrt[n]{\\cdot}$ starting from $\\mathbb{Q}$. The concreteness transforms an impossibility result into a positive fact about specific numbers.\n\n3. **Discriminant as Galois group algorithm**: The proof's core technique — computing $\\Delta^2 = \\text{disc}(p) = -212144 < 0$ to force $\\text{Gal} \\not\\subseteq A_5$ — is an instance of the discriminant criterion: $\\text{Gal}(f/K) \\subseteq A_n \\iff \\Delta(f) \\in K$. This criterion is the foundation of algorithmic Galois group computation in CAS systems (GAP, Magma, PARI/GP). The negative discriminant sign immediately tells practitioners that Galois group must contain an odd permutation, reducing the full $S_5$ identification to 4 Sylow eliminations.\n\n4. **$S_5$ realizability and the inverse Galois problem**: The `s5_realizable` theorem proves $S_5 \\cong \\text{Gal}(K/\\mathbb{Q})$ for $K = $ splitting field of $x^5-4x+2$, contributing to the Inverse Galois Problem (IGP): which groups appear as Galois groups over $\\mathbb{Q}$? For $S_n$, realizability over $\\mathbb{Q}$ follows from the Hilbert irreducibility theorem — this entry provides a constructive witness for $S_5$, complementing gallery entries for $S_3$ (cubic discriminant) and $F_{20}$ (cyclotomic fields).\n\n5. **Proof technique innovation**: Replacing Dedekind's theorem with complex conjugation (`IsAlgClosed.lift` + `starRingEnd`) is a methodological contribution. Dedekind's theorem (the cycle type of Frobenius at $p$ divides that of $\\text{Gal}$ as a permutation) is the classical textbook approach, but requires mod-$p$ factorization and depends on Dedekind's criterion for discriminants. The complex conjugation approach is self-contained, works over $\\mathbb{Q}$ without any prime reduction, and directly yields the odd permutation needed for $\\text{Gal} \\not\\subseteq A_5$.",
+        "openQuestions": [
+            "What is the simplest quintic with Galois group $S_5$ in terms of coefficient size? $x^5 - x - 1$ is a valid witness — its discriminant is $2869 = 19 \\cdot 151$ (not a square in $\\mathbb{Q}$, so $\\text{Gal} \\not\\subseteq A_5$), it is irreducible (no rational roots by rational root theorem, and a degree-5 polynomial irreducible iff it has no rational roots and no quadratic factor — checkable by computer algebra), and sign analysis shows 3 real roots, giving $\\text{Gal} \\cong S_5$ by the same argument used here. The discriminant formula for Bring-Jerrard $x^5 + px + q$ is $256p^5 + 3125q^4$, which for $(p,q)=(-1,-1)$ gives $-256 + 3125 = 2869$. The advantage of $x^5 - 4x + 2$ over $x^5 - x - 1$ is that the former satisfies Eisenstein at $p = 2$ for trivially mechanical irreducibility, while the latter requires more work",
+            "Can this approach be generalized to realize other transitive subgroups of $S_5$ (e.g., $A_5$, $D_5$, $F_{20}$) as Galois groups of specific quintics?",
+            "Can the repetitive Sylow arguments for `gal_card_ne_10`, `gal_card_ne_20`, and `gal_card_ne_40` be factored into a single generic lemma? All three follow the same pattern: a transposition cannot normalize the unique Sylow 5-subgroup.",
+            "Can Mathlib's growing theory of polynomial Galois groups eventually compute $|\\text{Gal}|$ for specific polynomials via a unified tactic, avoiding the manual case-elimination approach used here?",
+            "The file documents the Key Group Theory Lemma (a transitive subgroup of $S_p$ containing a transposition is $S_p$) in a comment block, and defines the `c5` 5-cycle supporting it, but the formal proof of this classical result is not included. The current proof avoids it via Sylow elimination. Should this classical lemma be formalized for pedagogical completeness?"
+        ]
     },
-    {
-      "targetId": "abel-ruffini",
-      "relationship": "extends",
-      "description": "Uses the Galois bridge (solvable by radicals ⇒ solvable Galois group) to conclude unsolvability"
-    },
-    {
-      "targetId": "inverse-galois",
-      "relationship": "contributes",
-      "description": "Realizes S₅ as Gal(x⁵-4x+2/ℚ), complementing S₃ and F₂₀ realizations in the gallery"
-    },
-    {
-      "targetId": "inverse-galois-oq-01",
-      "relationship": "related",
-      "description": "Proves the complete solvability characterization $S_n$ solvable iff $n \\leq 4$, which is the group-theoretic foundation for the non-solvability of $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$"
-    },
-    {
-      "targetId": "general-quartic",
-      "relationship": "complementary",
-      "description": "Ferrari's quartic formula succeeds because $S_4$ is solvable — this entry shows $x^5 - 4x + 2$ fails because $S_5$ is not, illustrating the sharp degree-5 boundary"
-    },
-    {
-      "targetId": "solution-of-cubic",
-      "relationship": "complementary",
-      "description": "Cardano's cubic formula succeeds because $S_3$ is solvable — the positive counterpart to this entry's quintic impossibility"
-    },
-    {
-      "targetId": "fundamental-theorem-algebra",
-      "relationship": "complementary",
-      "description": "FTA guarantees the roots of $x^5-4x+2$ exist in $\\mathbb{C}$; this entry shows those roots cannot be named using radical expressions"
-    },
-    {
-      "targetId": "descartes-rule-of-signs",
-      "relationship": "foundational",
-      "description": "Descartes' rule bounds real root counts by sign changes in coefficients — the same sign-change analysis used in this proof to locate 3 real roots of $x^5 - 4x + 2$, establishing that complex conjugation swaps the 2 non-real roots and thus acts as a transposition in the Galois group"
-    },
-    {
-      "targetId": "solution-of-cubic-oq-03-oq-01",
-      "relationship": "foundational",
-      "description": "Formalizes the discriminant $\\Delta = -4p^3 - 27q^2$ for the depressed cubic and the criterion $\\text{Gal}(f) \\subseteq A_n \\iff \\Delta(f)$ is a perfect square in $F$. The discriminant machinery is the linchpin of this entry's $|\\text{Gal}|=120$ proof: the Vandermonde product identity $\\Delta^2 = \\text{disc}(p)$ and the computed value $\\Delta^2 = -212144 < 0$ together force $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\not\\subseteq A_5$, which eliminates order 60 and is essential to the Sylow elimination cascade. Both entries develop discriminant theory in service of the concrete Abel-Ruffini proof chain."
-    },
-    {
-      "targetId": "sylow-theorems",
-      "relationship": "foundational",
-      "description": "Sylow's theorems are the primary tool for the case elimination in Part V: unique Sylow subgroups force cyclic structure (ruling out order 15), and Sylow counting constrains subgroup existence (ruling out order 30). The Sylow $p$-subgroup machinery directly enables the elimination of candidate Galois group orders"
-    },
-    {
-      "targetId": "lagrange-theorem",
-      "relationship": "foundational",
-      "description": "Lagrange's theorem ($|H|$ divides $|G|$ for $H \\leq G$) underpins the entire order-elimination strategy: $5 \\mid |\\text{Gal}|$ (orbit-stabilizer for transitive action on 5 roots), $|\\text{Gal}| \\mid 120$ (embedding into $S_5$ via `galActionHom`), and the Sylow elimination argument that narrows candidate orders to $\\{15, 30, 60, 120\\}$"
-    },
-    {
-      "targetId": "nth-root-irrational",
-      "relationship": "foundational",
-      "description": "The irrationality of $n$th roots is the base case for radical extensions: each step in a radical tower $K \\to K(\\sqrt[n]{a})$ extends the field because $a^{1/n} \\notin K$. This entry's impossibility result shows that iterating such extensions from $\\mathbb{Q}$ can never reach the roots of $x^5 - 4x + 2$"
-    },
-    {
-      "targetId": "vietas-formulas",
-      "relationship": "foundational",
-      "description": "Vieta's formulas express the coefficients of $x^5 - 4x + 2$ as elementary symmetric functions of its roots — this is why the Galois group permutes roots while preserving coefficients, and why the `galActionHom` maps $\\text{Gal}$ into $\\text{Perm}(\\text{rootSet})$"
-    },
-    {
-      "targetId": "angle-trisection",
-      "relationship": "related",
-      "description": "Both are impossibility results proved via Galois theory: Abel-Ruffini (this entry's concrete instance) shows $x^5-4x+2$ is unsolvable by radicals because $\\text{Gal} \\cong S_5$ is non-solvable, while angle trisection shows the general angle cannot be trisected by compass and straightedge because the minimal polynomial of $\\cos(20°)$ has degree 3 over the constructible field extension. Both reduce geometric/algebraic impossibility to group-theoretic obstructions"
-    },
-    {
-      "targetId": "kummer-theorem",
-      "relationship": "foundational",
-      "description": "Kummer theory provides the mechanism underlying the Galois bridge used in `roots_not_solvable_by_rad`: each radical extraction $K \\to K(\\sqrt[n]{a})$ creates a Kummer extension with cyclic Galois group. The impossibility arises because $S_5$ cannot be decomposed into such cyclic layers — exactly what the contrapositive of `solvableByRad.isSolvable'` captures"
-    },
-    {
-      "targetId": "inverse-galois-oq-06",
-      "relationship": "complementary",
-      "description": "The sister computation to this entry's $S_5$ realization: while this entry proves $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$ via Eisenstein at $p=2$ and Sylow elimination, `inverse-galois-oq-06` proves $A_5 \\cong \\text{Gal}(x^5-5x^4+10x^3-10x^2+25x-5/\\mathbb{Q})$ via Eisenstein at $p=5$ and Sylow theory. Together they realize the two non-solvable groups that appear in $S_5$'s composition series as Galois groups of explicit quintics over $\\mathbb{Q}$. Both entries invoke `not_solvable_by_rad_of_not_solvable_gal` to conclude unsolvability by radicals."
-    },
-    {
-      "targetId": "abel-ruffini-oq-04-oq-02",
-      "relationship": "complementary",
-      "description": "Proves the positive half of the solvability boundary: $S_2, S_3, S_4$ ARE solvable, with the bidirectional theorem $S_n$ solvable $\\iff n \\leq 4$. This entry proves $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$ implies unsolvability; `abel-ruffini-oq-04-oq-02` proves that every polynomial of degree $\\leq 4$ with Galois group $\\leq S_4$ IS solvable, completing the sharp degree-4/5 boundary. The `derived_series_solvable_of_solvable` path through $S_4 \\supset V_4 \\supset \\mathbb{Z}/2 \\supset \\{e\\}$ directly contrasts with the stalled derived series $S_5 \\supset A_5 \\supset A_5$."
-    },
-    {
-      "targetId": "abel-ruffini-oq-04-oq-03",
-      "relationship": "foundational",
-      "description": "Galois's solvability criterion: a root is solvable by radicals if and only if its Galois group is solvable. This entry uses only the forward direction (`solvableByRad.isSolvable'`: solvable by radicals $\\Rightarrow$ solvable Galois group) as a contrapositive; `abel-ruffini-oq-04-oq-03` formalizes the full Galois correspondence including the reverse direction (solvable Galois group $\\Rightarrow$ solvable by radicals, relying on Kummer theory). Together they give the complete biconditional that elevates Abel-Ruffini from a computational fact about $x^5-4x+2$ to a structural theorem about quintics generally."
-    },
-    {
-      "targetId": "abel-ruffini-galois-extensions",
-      "relationship": "foundational",
-      "description": "Houses the extended solvability classification and non-commutativity witnesses used implicitly throughout this proof: $S_0$–$S_4$ solvable, $S_n$ solvable $\\iff n \\leq 4$, $A_5$ simple, and non-commutativity witnesses for $S_3, S_4, S_5, A_4, A_5$. This entry's `s5_not_solvable` relies on `Equiv.Perm.not_solvable`, whose proof in turn rests on $A_5$'s simplicity — the same infrastructure that `abel-ruffini-galois-extensions` develops systematically with 57 theorems. The `solvable_of_surjective` transfer that propagates non-solvability from $S_5$ to $\\text{Gal}(p/\\mathbb{Q})$ also mirrors the solvability transfer lemmas proved there."
-    },
-    {
-      "targetId": "abel-ruffini-oq-04-oq-02-oq-03",
-      "relationship": "related",
-      "description": "Finite Groups of Order $< 60$ Are Solvable: this entry establishes that $|A_5| = 60$ is the precise solvability threshold by proving all groups of order $< 60$ (hence all proper subgroups of $A_5$) are solvable. Complementary to the case $|\\text{Gal}| = 60$ elimination here: if $|\\text{Gal}|$ were 60, the Galois image would be $A_5$ itself — but this entry proves $\\text{Gal} \\not\\subseteq A_5$ via the odd-permutation discriminant argument, so the 60-threshold result is not needed. Together these two entries bracket the non-solvability threshold from both sides."
-    }
-  ],
-  "overview": {
-    "historicalContext": "The Abel-Ruffini theorem has a dramatic history. Ruffini (1799) gave the first incomplete proof that the general quintic is unsolvable by radicals, but his argument had gaps in the treatment of permutation groups. Abel (1824) provided the first rigorous proof, showing no universal radical formula exists for degree 5 or higher. Galois (1832, published posthumously after his death in a duel at age 20) gave the definitive framework: a polynomial is solvable by radicals if and only if its Galois group is solvable. Since $S_5$ is not solvable (because $A_5$ is simple and non-abelian), any polynomial with Galois group $S_5$ has unsolvable roots.\n\nThe polynomial $x^5 - 4x + 2$ is a standard textbook example appearing in Dummit-Foote, Artin, and Lang, chosen because Eisenstein's criterion gives easy irreducibility and derivative analysis shows exactly 3 real roots. Eisenstein's criterion itself was published by Gotthold Eisenstein in 1850 in Crelle's Journal — the same journal that published Abel's refined proof in 1826. Eisenstein, who died of tuberculosis at age 29 (like Abel at 26), provided what Gauss called the simplest and most elegant irreducibility test. The criterion that $p$ divides all non-leading coefficients but $p^2$ does not divide the constant term remains the most frequently used irreducibility tool in textbooks.\n\nThe classical textbook approach to computing the Galois group of a specific quintic uses Dedekind's theorem (1882) — the cycle type of the Frobenius automorphism matches the mod-$p$ factorization — to establish divisibility conditions on $|\\text{Gal}|$. This formalization takes a different route: it establishes $\\text{Gal} \\not\\subset A_5$ via the Vandermonde discriminant ($\\Delta^2 = -212144 < 0$, so the Fundamental Theorem of Galois Theory forces an odd permutation), obtains a transposition via complex conjugation (embedding the splitting field into $\\mathbb{C}$ via `IsAlgClosed.lift` and composing with `starRingEnd`), and then eliminates non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$ via Sylow theory. This approach avoids all mod-$p$ arithmetic and works purely within algebraic and group-theoretic methods.\n\nThis formalization bridges abstract impossibility to a concrete witness: these five specific complex numbers cannot be written using radicals.",
-    "problemStatement": "Prove that the polynomial $x^5 - 4x + 2$ has Galois group $S_5$ over $\\mathbb{Q}$, and conclude that its roots cannot be expressed using radicals.",
-    "text": "This file completes the Abel-Ruffini proof chain by providing a concrete polynomial whose roots are provably unsolvable by radicals. The polynomial x⁵ - 4x + 2 is shown irreducible via Eisenstein's criterion at p=2, and its Galois group is identified as S₅ via the galActionHom bijectivity argument. Since S₅ is not solvable, Galois's theorem implies the roots cannot be expressed by radicals.",
-    "proofStrategy": "The proof has four main stages:\n\n**1. Irreducibility** (Part II): Eisenstein's criterion at the prime ideal $(2) \\subset \\mathbb{Z}$ shows $x^5 - 4x + 2$ is irreducible over $\\mathbb{Z}$: all non-leading coefficients $(0, 0, 0, -4, 2)$ are divisible by 2, the constant term 2 is not divisible by 4, and the leading coefficient 1 is coprime to 2. Gauss's lemma (monic $\\Rightarrow$ primitive) transfers irreducibility from $\\mathbb{Z}[X]$ to $\\mathbb{Q}[X]$.\n\n**2. Galois group identification** (Parts III-VI): The `galActionHom` embeds $\\text{Gal}$ into $\\text{Perm}(\\text{rootSet}) \\cong S_5$ (injective by Mathlib). Establishing $|\\text{Gal}| = 120$ proceeds by elimination: (a) $5 \\mid |\\text{Gal}|$ by orbit-stabilizer (irreducible of prime degree gives transitive action), (b) $\\text{Gal} \\not\\subset A_5$ via the discriminant sign argument: the Vandermonde product $\\Delta$ satisfies $\\Delta^2 = \\text{disc}(p) = -212144 < 0$ (proved from the derivative product identity), so by FTGT if all Galois automorphisms were even then $\\Delta \\in \\mathbb{Q}$, contradicting $\\Delta^2 < 0$; thus `gal_has_odd_perm` establishes a transposition in the Galois image, (c) $3 \\mid |\\text{Gal}|$ by eliminating non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$ via Sylow theory: a transposition cannot normalize the unique Sylow 5-subgroup in groups of these orders, (d) Sylow theory eliminates orders 15 (unique $P_3, P_5$ force cyclic, impossible in $S_5$) and 30 ($A_5$ simplicity), (e) order 60 eliminated because $\\text{Gal} \\not\\subset A_5$ by step (b). Only $|\\text{Gal}| = 120$ remains. Bijectivity of `galActionHom` follows by the pigeonhole principle.\n\n**3. Non-solvability transfer** (Part VII): $S_5$ is not solvable (Mathlib's `Equiv.Perm.not_solvable`, since $A_5$ is simple). The isomorphism $\\text{Gal} \\cong S_5$ transfers non-solvability via `solvable_of_surjective`.\n\n**4. Abel-Ruffini conclusion** (Part VIII): By contrapositive of Galois's theorem (`solvableByRad.isSolvable'`), non-solvable Galois group implies roots are not expressible by radicals.",
-    "keyInsights": [
-      "**Eisenstein at p = 2 is elegant**: Coefficients $(1, 0, 0, 0, -4, 2)$ satisfy Eisenstein at $(2)$: non-leading coefficients all divisible by 2, constant term 2 not divisible by 4, leading coefficient coprime to 2. This is the simplest irreducibility argument for a specific quintic.",
-      "**3 real roots give a transposition**: Sign analysis at $f(-2) < 0 < f(-1)$, $f(0) > 0 > f(1)$, $f(1) < 0 < f(2)$ locates 3 real roots. Since $f'(x) = 5x^4 - 4$ has only 2 real critical points, there are exactly 3 real and 2 complex conjugate roots. Complex conjugation acts as a transposition on the 5 roots.",
-      "**Transposition + p-cycle generates $S_p$**: Conjugate the transposition $(i\\;j)$ by powers of the $p$-cycle $(1\\;2\\;\\cdots\\;p)$ to generate all adjacent transpositions $(k\\;k+1)$, which generate $S_p$. This classical result is the group-theoretic bridge from real root analysis to the full symmetric group.",
-      "**Pigeonhole for bijectivity**: With $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$ and the injective galActionHom, bijectivity follows from the pigeonhole principle. This avoids constructing an explicit inverse.",
-      "**Concrete witness matters**: Abel's original theorem proves existence of unsolvable quintics abstractly. This formalization gives a specific polynomial $x^5 - 4x + 2$ whose five roots provably resist all radical expressions, making the impossibility tangible.",
-      "**Sylow elimination as case analysis**: The proof that $|\\text{Gal}| = 120$ is a remarkable case analysis. From $5 \\mid |G|$, $3 \\mid |G|$, and $|G| \\mid 120$, the candidates are $\\{15, 30, 60, 120\\}$. Sylow theory eliminates 15 (unique $P_5$ and $P_3$ would force a cyclic subgroup of order 15, but $S_5$ has none). The simplicity of $A_5$ eliminates 30 (an index-4 subgroup gives $S_5 \\to S_4$, impossible). The odd permutation from discriminant analysis eliminates 60 ($A_5$ is the unique order-60 subgroup, but the Galois image is not contained in $A_5$). Only 120 remains.",
-      "**Complex conjugation as the key to eliminating Dedekind's theorem**: The proof constructs a Galois automorphism from complex conjugation: embed the splitting field $SF \\hookrightarrow \\mathbb{C}$ via `IsAlgClosed.lift`, compose with `starRingEnd \\mathbb{C}` (complex conjugation), then restrict via `restrictNormal` to get $\\sigma \\in \\text{Gal}(p/\\mathbb{Q})$. Since $\\Delta^2 = \\text{disc}(p) = -212144 < 0$, the FTGT forces $\\sigma$ to have odd sign — giving a transposition without needing Dedekind's theorem or mod-$p$ factorization at all. This single construction replaces both the Dedekind axiom and the original real-root-count argument.",
-      "**Sylow elimination as a universal strategy for $3 \\mid |\\text{Gal}|$**: Rather than using Dedekind's theorem (mod-$p$ factorization), the proof establishes $3 \\mid |\\text{Gal}|$ purely from the transposition: candidate orders not divisible by 3 are $\\{5, 10, 20, 40\\}$, and each is eliminated by showing a transposition cannot coexist with the unique normal Sylow 5-subgroup at that order. For orders 10, 20, 40: the transposition from `gal_has_odd_perm` would have to normalize the unique Sylow 5-subgroup, but `native_decide` verifies no transposition in $S_5$ normalizes any 5-cycle. For order 5: any order-5 subgroup of $S_5$ consists entirely of even permutations, contradicting the transposition. This approach is more elementary than Dedekind and avoids all mod-$p$ arithmetic.",
-      "**Why $x^5 - 4x + 2$ rather than $x^5 - x - 1$ or $x^5 + x + 1$**: The polynomial choice trades off three competing constraints. Eisenstein irreducibility forces a prime $p$ dividing all non-leading coefficients but with $p^2 \\nmid$ constant term — the simplest such pattern is $p=2$ with constant term $\\pm 2$ and one nonzero linear coefficient divisible by 2. Three real roots (for the complex-conjugation transposition) requires the discriminant to be negative — the value $\\Delta^2 = -212144 = -2^4 \\cdot 13259$ is small enough that the derivative-product calculation $p(5/8) = -13259/32768$ keeps the arithmetic tractable. Finally, the constant term $+2$ rather than $-2$ (yielding the famous Trinks polynomials with Galois group $D_5$ or $F_{20}$) ensures a transitive action with all 5 roots in distinct orbits, forcing the Galois image to be primitive and hence (by O'Nan-Scott) maximal in $S_5$. Dummit-Foote's choice optimizes Eisenstein simplicity, real-root sign-change visibility, and discriminant computability simultaneously.",
-      "**Bring-Jerrard form as the natural domain**: The polynomial $x^5 - 4x + 2$ is already in *Bring-Jerrard normal form* $x^5 + px + q$ (i.e., the coefficients of $x^4, x^3, x^2$ all vanish). Tschirnhaus (1683) and Bring (1786) showed every quintic can be transformed to this normal form by a polynomial substitution of degree at most 4 — Hermite (1858) used this to express quintic roots via elliptic modular functions. The choice of $p = -4, q = 2$ here is no accident: among Bring-Jerrard quintics with small integer coefficients, this is one of the simplest with a clear non-square discriminant ($\\text{disc} = -212144$) and 3 real roots. Other classical witnesses in the same form include $x^5 - x - 1$ (discriminant $2869 = 19 \\cdot 151$, also non-square, $\\text{Gal} \\cong S_5$) and $x^5 - 6x + 3$ (Eisenstein at $p = 3$). The Bring-Jerrard form is the algebraic 'minimal model' for the quintic — once a quintic is reduced to it, the discriminant computation becomes the simple expression $\\text{disc}(x^5 + px + q) = 256 p^5 + 3125 q^4$ (sometimes written with a sign convention; for our $p=-4, q=2$: $256 \\cdot (-4)^5 + 3125 \\cdot 2^4 = -262144 + 50000 = -212144$, matching the value computed in `vandermondeProduct_sq_val`).",
-      "**Stauduhar's algorithm and computational Galois theory**: The case-elimination structure of this proof mirrors Stauduhar's algorithm (1973), the standard method for computing Galois groups of polynomials over $\\mathbb{Q}$ in computer algebra systems (PARI/GP, Magma, Sage, GAP). Stauduhar starts from the lattice of transitive subgroups of $S_n$ (for $n=5$, there are exactly 5: $S_5, A_5, F_{20}, D_5, C_5$) and uses *resolvent polynomials* — polynomials whose Galois group fixes a chosen subgroup — to descend through the lattice from $S_n$ downward. At each step, one checks whether a particular resolvent has rational roots (yes $\\Rightarrow$ Galois group is contained in the corresponding subgroup; no $\\Rightarrow$ stop). The discriminant is the resolvent for $A_n$ (the discriminant being a square iff $\\text{Gal} \\subseteq A_n$). The proof here essentially implements the first Stauduhar test by hand: $\\sqrt{\\text{disc}(p)} \\notin \\mathbb{Q}$ (because $\\text{disc}(p) = -212144 < 0$) eliminates $A_5$. The Sylow elimination of orders 10, 20, 40 then implicitly handles the resolvents for $D_5, F_{20}, C_5$ — all proper transitive subgroups of $S_5$. A future formalization could extract these as explicit resolvent computations and connect to a general Stauduhar tactic in Mathlib."
-    ],
-    "prerequisites": [
-      "Abstract algebra (groups, solvable groups, symmetric groups)",
-      "Galois theory (field extensions, Galois groups, splitting fields)",
-      "Polynomial algebra (irreducibility criteria, Eisenstein criterion)",
-      "Sylow theory (Sylow subgroup existence, uniqueness, and counting)"
-    ],
-    "relatedConcepts": [
-      "Galois group",
-      "solvability by radicals",
-      "S5",
-      "Eisenstein criterion",
-      "Vandermonde determinant",
-      "Wiedijk theorem 16",
-      "discriminant sign",
-      "Sylow theory"
-    ]
-  },
-  "sections": [
-    {
-      "id": "header",
-      "title": "Problem Overview, Proof Chain, and Pre-Classical Computational Lemmas",
-      "startLine": 1,
-      "endLine": 98,
-      "summary": "Documents the complete Abel-Ruffini proof chain and motivation for choosing $x^5 - 4x + 2$. Lists all 5 steps from $A_5$ simplicity to unsolvability by radicals. Lines 63-91: three computational lemmas proved by `native_decide` that must appear before `open scoped Classical` for decidability — `perm_fin5_order5_order3_not_commute` (used in Sylow order-15 elimination), `perm_fin5_order_dvd5_sign_one` (elements of order dividing 5 in $S_5$ are even), and `transposition_not_normalizing_5cycle` (used in Sylow elimination of orders 10, 20, 40). All three feed into the main proof.",
-      "mathContext": "Proof chain: (1) $A_5$ simple, (2) $S_n$ not solvable for $n \\geq 5$, (3) solvable by radicals $\\Rightarrow$ solvable Gal, (4) $\\text{Gal}(x^5-4x+2/\\mathbb{Q}) \\cong S_5$, (5) roots not expressible by radicals.",
-      "relatedConcepts": [
-        "Abel-Ruffini theorem",
-        "Galois theory",
-        "native_decide",
-        "solvability by radicals",
-        "proof chain"
-      ]
-    },
-    {
-      "id": "polynomial",
-      "title": "Part I: The Polynomial p = X⁵ - 4X + 2",
-      "startLine": 99,
-      "endLine": 108,
-      "summary": "Defines $p = X^5 - 4X + 2$ over $\\mathbb{Q}$ and its $\\mathbb{Z}[X]$ version `p_int` for Eisenstein criterion application.",
-      "mathContext": "$p(x) = x^5 - 4x + 2 \\in \\mathbb{Q}[X]$, $p_{\\text{int}} = x^5 - 4x + 2 \\in \\mathbb{Z}[X]$.",
-      "relatedConcepts": [
-        "Bring-Jerrard form",
-        "Eisenstein criterion",
-        "Polynomial.C",
-        "rational polynomial",
-        "integer polynomial"
-      ]
-    },
-    {
-      "id": "irreducibility",
-      "title": "Part II: Irreducibility via Eisenstein at p = 2",
-      "startLine": 109,
-      "endLine": 183,
-      "summary": "Proves $p$ is irreducible over $\\mathbb{Q}$. First proves irreducibility over $\\mathbb{Z}$ using Eisenstein's criterion at the prime ideal $(2)$, then transfers to $\\mathbb{Q}$ via Gauss's lemma (monic $\\Rightarrow$ primitive).",
-      "mathContext": "Eisenstein at $(2) \\subset \\mathbb{Z}$: $2 \\nmid 1$, $2 \\mid 0, 0, 0, -4, 2$, $4 \\nmid 2$. Therefore $p$ is irreducible over $\\mathbb{Z}$, hence over $\\mathbb{Q}$ by Gauss's lemma.",
-      "relatedConcepts": [
-        "Eisenstein criterion",
-        "Gauss's lemma",
-        "prime ideal",
-        "p_int_monic",
-        "irreducible_of_eisenstein_criterion"
-      ]
-    },
-    {
-      "id": "structure",
-      "title": "Part III: Basic Structural Properties",
-      "startLine": 184,
-      "endLine": 207,
-      "summary": "Proves $\\deg(p) = 5$, $p$ is monic, $p$ is separable (char 0), and $|\\text{rootSet}(p)| = 5$.",
-      "mathContext": "$\\deg(p) = 5$, $p$ monic and separable. In the splitting field: $|\\{\\alpha : p(\\alpha) = 0\\}| = 5$.",
-      "relatedConcepts": [
-        "separable polynomial",
-        "splitting field",
-        "rootSet",
-        "compute_degree!",
-        "characteristic zero"
-      ]
-    },
-    {
-      "id": "galois-structure",
-      "title": "Part IV: Galois Group Structure",
-      "startLine": 208,
-      "endLine": 231,
-      "summary": "Proves $5 \\mid |\\text{Gal}|$ (prime degree gives transitive action, orbit-stabilizer) and $|\\text{Gal}| \\mid 120$ (galActionHom embeds $\\text{Gal}$ into $S_5$). Together: $|\\text{Gal}| \\in \\{5, 10, 15, 20, 30, 40, 60, 120\\}$.",
-      "mathContext": "$5 \\mid |\\text{Gal}|$ and $|\\text{Gal}| \\mid 5! = 120$. Possible orders: $\\{5, 10, 15, 20, 30, 40, 60, 120\\}$.",
-      "relatedConcepts": [
-        "galActionHom",
-        "orbit-stabilizer theorem",
-        "Lagrange's theorem",
-        "transitive group action",
-        "prime_degree_dvd_card"
-      ]
-    },
-    {
-      "id": "gal-order",
-      "title": "Parts V(a)-(f): Galois Group Order |Gal| = 120 (Theorem)",
-      "startLine": 232,
-      "endLine": 1377,
-      "summary": "The largest section (~1150 lines): proves $|\\text{Gal}| = 120$ via systematic case elimination. (a) Lines 232-264: polynomial evaluations showing 3 sign changes (sign change comment motivates complex conjugation argument). (b) Lines 265-293: `c5` 5-cycle definition and Part V(c) Galois infrastructure header. (c) Lines 306-336: `galToPerm5` injection from $\\text{Gal}$ to $S_5$, injectivity, and `galSign`. (d) Lines 337-507: Sylow elimination of orders 15 and 30 (`no_subgroup_order_15`, `a5_card`, `no_subgroup_order_30`). (e) Lines 508-806: Vandermonde machinery, discriminant computation ($\\Delta^2 = -212144$), and `gal_has_odd_perm`. (e2) Lines 807-1244: complex conjugation gives transposition (`sfEmb`, `conjGalAut`, `gal_has_transposition`), Sylow elimination of non-3-divisible orders (`gal_card_ne_20`, `gal_card_ne_10`, `gal_card_ne_40`), `three_dvd_gal_card`. (f) Lines 1246-1377: case elimination (`gal_card_ne_15`, `gal_card_ne_30`, `gal_card_ne_60`) and `gal_card_eq_120`. Fully proved with 0 axioms.",
-      "mathContext": "Theorem: $|\\text{Gal}(x^5-4x+2/\\mathbb{Q})| = 120$. From $5 \\mid |G|$, $3 \\mid |G|$, $|G| \\mid 120$: $|G| \\in \\{15,30,60,120\\}$. Not 15 (Sylow), not 30 ($A_5$ simple), not 60 ($\\text{Gal} \\not\\subset A_5$ by discriminant sign). All steps fully proved.",
-      "relatedConcepts": [
-        "Vandermonde determinant",
-        "complex conjugation",
-        "Sylow elimination",
-        "discriminant sign",
-        "gal_card_eq_120"
-      ]
-    },
-    {
-      "id": "gal-iso",
-      "title": "Part VI: Gal(p/ℚ) ≅ S₅",
-      "startLine": 1378,
-      "endLine": 1412,
-      "summary": "Proves `gal_iso_s5`: $\\text{Gal} \\cong S_5$ via galActionHom bijectivity. Injective (Mathlib's `galActionHom_injective`) + $|\\text{Gal}| = |\\text{Perm}(\\text{rootSet})| = 120$ from `gal_card_eq_120`. Bijectivity via `Fintype.bijective_iff_injective_and_card`. Transfer from $\\text{Perm}(\\text{rootSet})$ to $\\text{Perm}(\\text{Fin}\\;5)$ via `Equiv.permCongr`.",
-      "mathContext": "$\\text{galActionHom}$ injective + $|\\text{Gal}| = |S_5| = 120$ $\\Rightarrow$ bijective $\\Rightarrow$ $\\text{Gal}(p/\\mathbb{Q}) \\cong S_5$.",
-      "relatedConcepts": [
-        "galActionHom",
-        "MulEquiv.ofBijective",
-        "pigeonhole principle",
-        "Equiv.permCongr",
-        "Fintype.bijective_iff_injective_and_card"
-      ]
-    },
-    {
-      "id": "not-solvable",
-      "title": "Part VII: Non-Solvability",
-      "startLine": 1413,
-      "endLine": 1431,
-      "summary": "`s5_not_solvable`: $S_5$ not solvable via `Equiv.Perm.not_solvable` with $5 \\leq |\\text{Fin}\\;5|$. `gal_not_solvable`: transfers non-solvability from $S_5$ to $\\text{Gal}$ via the surjective `MulEquiv` from Part VI using `solvable_of_surjective`.",
-      "mathContext": "$S_5$ not solvable (derived series stalls at $A_5$). $\\text{Gal} \\cong S_5 \\Rightarrow \\text{Gal}$ not solvable.",
-      "relatedConcepts": [
-        "derived series",
-        "A5 simplicity",
-        "solvable_of_surjective",
-        "Equiv.Perm.not_solvable",
-        "group surjection"
-      ]
-    },
-    {
-      "id": "abel-ruffini-conclusion",
-      "title": "Part VIII: Abel-Ruffini Conclusion",
-      "startLine": 1432,
-      "endLine": 1466,
-      "summary": "Main theorem `roots_not_solvable_by_rad`: for any root $\\alpha$ of $x^5 - 4x + 2$, $\\alpha \\notin \\text{solvableByRad}(\\mathbb{Q})$. Proof: assume $\\alpha$ solvable by radicals; by `solvableByRad.isSolvable'` with `p_irreducible` and `hroot`, $\\text{Gal}(p)$ is solvable — contradicting `gal_not_solvable`.",
-      "mathContext": "$\\alpha \\in \\text{Rad}(\\mathbb{Q}) \\Rightarrow \\text{Gal}(p/\\mathbb{Q})$ solvable $\\Rightarrow S_5$ solvable $\\Rightarrow \\bot$.",
-      "relatedConcepts": [
-        "solvableByRad.isSolvable'",
-        "contrapositive",
-        "radical extension",
-        "IsSolvableByRad",
-        "Galois bridge"
-      ]
-    },
-    {
-      "id": "three-dvd-proved",
-      "title": "Part V(e2): three_dvd_gal_card (Eliminating Non-3-Divisible Orders)",
-      "startLine": 1210,
-      "endLine": 1244,
-      "summary": "Proves `three_dvd_gal_card`: $3 \\mid |\\text{Gal}|$ by eliminating all non-3-divisible candidate orders $\\{5, 10, 20, 40\\}$. Order 5 eliminated by sign argument (order-5 permutations in $S_5$ are even). Order 20 eliminated by `gal_card_ne_20` (F₂₀ has no transpositions but Gal does). Orders 10 and 40 eliminated via Sylow theory. All cases fully proved.",
-      "mathContext": "$|\\text{Gal}| \\in \\{5,10,15,20,30,40,60,120\\}$. Not 5 (sign), not 10, 20, 40 (Sylow/transposition arguments). Remaining: $\\{15,30,60,120\\}$ — all divisible by 3.",
-      "relatedConcepts": [
-        "Sylow theory",
-        "transposition normalization",
-        "native_decide",
-        "non-3-divisible order elimination"
-      ]
-    },
-    {
-      "id": "vandermonde-infrastructure",
-      "title": "Part V(e)+(e2): Vandermonde, Complex Conjugation, and Discriminant Infrastructure",
-      "startLine": 508,
-      "endLine": 1244,
-      "summary": "Root enumeration (`rootEnum_p`), Vandermonde product $\\Delta = \\det(V(\\text{roots}))$, Galois permutation of roots, Vandermonde permutation identity ($\\sigma(\\Delta) = \\text{sign}(\\sigma) \\cdot \\Delta$), and `gal_has_odd_perm` proved via the discriminant sign argument ($\\text{disc}(p) < 0$ implies $\\Delta \\notin \\mathbb{Q}$, so some $\\sigma$ has odd sign).",
-      "mathContext": "$\\Delta = \\prod_{i<j}(\\alpha_j - \\alpha_i)$. $\\sigma(\\Delta) = \\text{sign}(\\sigma) \\cdot \\Delta$. If all signs $+1$, $\\Delta \\in \\mathbb{Q}$ but $\\Delta^2 < 0$ — contradiction.",
-      "relatedConcepts": [
-        "Vandermonde determinant",
-        "Matrix.det_permute",
-        "root enumeration",
-        "galToPerm5",
-        "derivative product identity"
-      ]
-    },
-    {
-      "id": "gal-card-120",
-      "title": "Part V(f): |Gal(p/ℚ)| = 120 (Case Elimination)",
-      "startLine": 1246,
-      "endLine": 1377,
-      "summary": "Proves `gal_card_eq_120`: $|\\text{Gal}| = 120$ by combining $15 \\mid |\\text{Gal}|$ (from `five_dvd_gal_card` and `three_dvd_gal_card`) with elimination of orders 15 (Sylow), 30 ($A_5$ simplicity), and 60 (odd permutation). Only 120 remains.",
-      "mathContext": "$15 \\mid |G|$, $|G| \\mid 120$: $|G| \\in \\{15,30,60,120\\}$. Not 15, 30, 60 $\\Rightarrow |G| = 120$.",
-      "relatedConcepts": [
-        "case elimination",
-        "divisibility chain",
-        "Sylow theory",
-        "discriminant sign",
-        "galois group order"
-      ]
-    },
-    {
-      "id": "realizability",
-      "title": "Part IX: $S_5$ Realizability and Verification",
-      "startLine": 1467,
-      "endLine": 1498,
-      "summary": "`s5_realizable`: $S_5$ is realizable as a Galois group over $\\mathbb{Q}$, witnessed by the splitting field of $x^5 - 4x + 2$. Lines 1485-1498: `#check` verification of all 9 key theorems.",
-      "mathContext": "$\\exists K/\\mathbb{Q}$ Galois: $\\text{Gal}(K/\\mathbb{Q}) \\cong S_5$. Witness: $K = $ splitting field of $x^5 - 4x + 2$.",
-      "relatedConcepts": [
-        "inverse Galois problem",
-        "splitting field",
-        "IsGalois",
-        "FiniteDimensional",
-        "s5_realizable"
-      ]
-    }
-  ],
-  "conclusion": {
-    "summary": "This formalization completes the Abel-Ruffini proof chain by exhibiting a concrete polynomial $x^5 - 4x + 2$ whose roots cannot be expressed by radicals. The proof proceeds from Eisenstein irreducibility through Galois group identification ($\\text{Gal} \\cong S_5$) to the unsolvability conclusion via Galois's theorem. Fully verified with 0 sorries and 0 axioms. The key result $|\\text{Gal}| = 120$ is proved without axioms via three techniques: (1) the Vandermonde product computation proves $\\Delta^2 = -212144$ from the derivative product identity, (2) complex conjugation (`IsAlgClosed.lift` + `starRingEnd`) proves the Galois group contains an odd permutation, and (3) Sylow elimination rules out all candidate orders except 120 — orders $\\{5,10,20,40\\}$ excluded because a transposition cannot normalize the unique Sylow 5-subgroup, orders 15 and 30 by Sylow counting and $A_5$ simplicity, and order 60 because $\\text{Gal} \\not\\subset A_5$.",
-    "implications": "1. **Wiedijk Top-100 (#16)**: This formalization completes Wiedijk theorem #16 (Abel-Ruffini impossibility) with a fully machine-checked proof at the hardest end of the spectrum — a concrete witness rather than an abstract existence statement. The Wiedijk list includes many theorems whose formalizations remain incomplete or axiom-heavy; this entry achieves the gold standard of 0 axioms and 0 sorries for a non-trivial result in algebraic number theory.\n\n2. **Concrete witnesses vs. abstract impossibility**: Abel's original 1824 proof shows no *general* radical formula exists for degree ≥ 5. This formalization goes further: these five specific complex numbers $\\alpha_1, \\ldots, \\alpha_5$ satisfying $x^5 - 4x + 2 = 0$ provably cannot be individually expressed using $+, -, \\times, \\div, \\sqrt[n]{\\cdot}$ starting from $\\mathbb{Q}$. The concreteness transforms an impossibility result into a positive fact about specific numbers.\n\n3. **Discriminant as Galois group algorithm**: The proof's core technique — computing $\\Delta^2 = \\text{disc}(p) = -212144 < 0$ to force $\\text{Gal} \\not\\subseteq A_5$ — is an instance of the discriminant criterion: $\\text{Gal}(f/K) \\subseteq A_n \\iff \\Delta(f) \\in K$. This criterion is the foundation of algorithmic Galois group computation in CAS systems (GAP, Magma, PARI/GP). The negative discriminant sign immediately tells practitioners that Galois group must contain an odd permutation, reducing the full $S_5$ identification to 4 Sylow eliminations.\n\n4. **$S_5$ realizability and the inverse Galois problem**: The `s5_realizable` theorem proves $S_5 \\cong \\text{Gal}(K/\\mathbb{Q})$ for $K = $ splitting field of $x^5-4x+2$, contributing to the Inverse Galois Problem (IGP): which groups appear as Galois groups over $\\mathbb{Q}$? For $S_n$, realizability over $\\mathbb{Q}$ follows from the Hilbert irreducibility theorem — this entry provides a constructive witness for $S_5$, complementing gallery entries for $S_3$ (cubic discriminant) and $F_{20}$ (cyclotomic fields).\n\n5. **Proof technique innovation**: Replacing Dedekind's theorem with complex conjugation (`IsAlgClosed.lift` + `starRingEnd`) is a methodological contribution. Dedekind's theorem (the cycle type of Frobenius at $p$ divides that of $\\text{Gal}$ as a permutation) is the classical textbook approach, but requires mod-$p$ factorization and depends on Dedekind's criterion for discriminants. The complex conjugation approach is self-contained, works over $\\mathbb{Q}$ without any prime reduction, and directly yields the odd permutation needed for $\\text{Gal} \\not\\subseteq A_5$.",
-    "openQuestions": [
-      "What is the simplest quintic with Galois group $S_5$ in terms of coefficient size? $x^5 - x - 1$ is a valid witness — its discriminant is $2869 = 19 \\cdot 151$ (not a square in $\\mathbb{Q}$, so $\\text{Gal} \\not\\subseteq A_5$), it is irreducible (no rational roots by rational root theorem, and a degree-5 polynomial irreducible iff it has no rational roots and no quadratic factor — checkable by computer algebra), and sign analysis shows 3 real roots, giving $\\text{Gal} \\cong S_5$ by the same argument used here. The discriminant formula for Bring-Jerrard $x^5 + px + q$ is $256p^5 + 3125q^4$, which for $(p,q)=(-1,-1)$ gives $-256 + 3125 = 2869$. The advantage of $x^5 - 4x + 2$ over $x^5 - x - 1$ is that the former satisfies Eisenstein at $p = 2$ for trivially mechanical irreducibility, while the latter requires more work",
-      "Can this approach be generalized to realize other transitive subgroups of $S_5$ (e.g., $A_5$, $D_5$, $F_{20}$) as Galois groups of specific quintics?",
-      "Can the repetitive Sylow arguments for `gal_card_ne_10`, `gal_card_ne_20`, and `gal_card_ne_40` be factored into a single generic lemma? All three follow the same pattern: a transposition cannot normalize the unique Sylow 5-subgroup.",
-      "Can Mathlib's growing theory of polynomial Galois groups eventually compute $|\\text{Gal}|$ for specific polynomials via a unified tactic, avoiding the manual case-elimination approach used here?",
-      "The file documents the Key Group Theory Lemma (a transitive subgroup of $S_p$ containing a transposition is $S_p$) in a comment block, and defines the `c5` 5-cycle supporting it, but the formal proof of this classical result is not included. The current proof avoids it via Sylow elimination. Should this classical lemma be formalized for pedagogical completeness?"
-    ]
-  },
-  "mainTheorems": [
-    {
-      "name": "gal_eq_S5",
-      "type": "core",
-      "description": "The Galois group of x⁵ - 4x + 2 over ℚ is isomorphic to S₅, proved by eliminating all candidate orders except 120 via Sylow theory and discriminant analysis — the heart of the Abel-Ruffini concrete instance."
-    },
-    {
-      "name": "roots_not_solvable_by_rad",
-      "type": "core",
-      "description": "The roots of x⁵ - 4x + 2 cannot be expressed by radicals, concluded by the Galois bridge: solvableByRad.isSolvable' gives solvable Galois group ⟹ solvable by radicals, but Gal ≅ S₅ is not solvable."
-    },
-    {
-      "name": "p_irreducible",
-      "type": "supporting",
-      "description": "x⁵ - 4x + 2 is irreducible over ℚ, proved by Eisenstein's criterion at p = 2: all non-leading coefficients divisible by 2, constant term not divisible by 4."
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Polynomial"
-    ],
-    "namespace": "AbelRuffiniOQ04OQ01",
-    "lineCount": 1498,
-    "axiomCount": 0,
-    "theoremCount": 36,
-    "definitionCount": 7,
     "mainTheorems": [
-      {
-        "name": "p_irreducible",
-        "type": "proved",
-        "description": "x^5 - 4x + 2 is irreducible over Q (Eisenstein at p=2)"
-      },
-      {
-        "name": "closure_cycle_swap_eq_top",
-        "type": "proved",
-        "description": "5-cycle + transposition generates all of S_5"
-      },
-      {
-        "name": "no_subgroup_order_15",
-        "type": "proved",
-        "description": "No subgroup of S_5 has order 15 (Sylow theory)"
-      },
-      {
-        "name": "no_subgroup_order_30",
-        "type": "proved",
-        "description": "No subgroup of S_5 has order 30 (A_5 simplicity)"
-      },
-      {
-        "name": "three_dvd_gal_card",
-        "type": "proved",
-        "description": "3 divides |Gal(p)| (proved by eliminating non-3-divisible orders 5, 10, 20, 40)"
-      },
-      {
-        "name": "gal_has_odd_perm",
-        "type": "proved",
-        "description": "Galois group contains an odd permutation (proved via discriminant sign and Vandermonde identity)"
-      },
-      {
-        "name": "gal_card_eq_120",
-        "type": "proved",
-        "description": "|Gal(x^5-4x+2/Q)| = 120 (fully proved via Sylow elimination of all other candidate orders)"
-      },
-      {
-        "name": "gal_iso_s5",
-        "type": "proved",
-        "description": "Gal(x^5-4x+2/Q) isomorphic to S_5 via galActionHom bijectivity"
-      },
-      {
-        "name": "roots_not_solvable_by_rad",
-        "type": "proved",
-        "description": "Roots of x^5-4x+2 cannot be expressed by radicals (contrapositive of Galois bridge)"
-      },
-      {
-        "name": "s5_realizable",
-        "type": "proved",
-        "description": "S_5 is realizable as a Galois group over Q"
-      }
+        {
+            "name": "gal_eq_S5",
+            "type": "core",
+            "description": "The Galois group of x⁵ - 4x + 2 over ℚ is isomorphic to S₅, proved by eliminating all candidate orders except 120 via Sylow theory and discriminant analysis — the heart of the Abel-Ruffini concrete instance."
+        },
+        {
+            "name": "roots_not_solvable_by_rad",
+            "type": "core",
+            "description": "The roots of x⁵ - 4x + 2 cannot be expressed by radicals, concluded by the Galois bridge: solvableByRad.isSolvable' gives solvable Galois group ⟹ solvable by radicals, but Gal ≅ S₅ is not solvable."
+        },
+        {
+            "name": "p_irreducible",
+            "type": "supporting",
+            "description": "x⁵ - 4x + 2 is irreducible over ℚ, proved by Eisenstein's criterion at p = 2: all non-leading coefficients divisible by 2, constant term not divisible by 4."
+        }
     ],
-    "sorries": 0,
-    "path": "Proofs/AbelRuffiniOQ04OQ01.lean"
-  },
-  "references": [
-    {
-      "key": "Ru99",
-      "citation": "Ruffini, P., Teoria generale delle equazioni in cui si dimostra impossibile la soluzione algebraica delle equazioni generali di grado superiore al quarto, Bologna (1799). The first (incomplete) proof of the unsolvability of the general quintic; the gap concerned permutation group theory not yet developed.",
-      "type": "book"
+    "leanFile": {
+        "imports": [
+            "Mathlib"
+        ],
+        "opens": [
+            "Polynomial"
+        ],
+        "namespace": "AbelRuffiniOQ04OQ01",
+        "lineCount": 1498,
+        "axiomCount": 0,
+        "theoremCount": 64,
+        "definitionCount": 7,
+        "mainTheorems": [
+            {
+                "name": "p_irreducible",
+                "type": "proved",
+                "description": "x^5 - 4x + 2 is irreducible over Q (Eisenstein at p=2)"
+            },
+            {
+                "name": "closure_cycle_swap_eq_top",
+                "type": "proved",
+                "description": "5-cycle + transposition generates all of S_5"
+            },
+            {
+                "name": "no_subgroup_order_15",
+                "type": "proved",
+                "description": "No subgroup of S_5 has order 15 (Sylow theory)"
+            },
+            {
+                "name": "no_subgroup_order_30",
+                "type": "proved",
+                "description": "No subgroup of S_5 has order 30 (A_5 simplicity)"
+            },
+            {
+                "name": "three_dvd_gal_card",
+                "type": "proved",
+                "description": "3 divides |Gal(p)| (proved by eliminating non-3-divisible orders 5, 10, 20, 40)"
+            },
+            {
+                "name": "gal_has_odd_perm",
+                "type": "proved",
+                "description": "Galois group contains an odd permutation (proved via discriminant sign and Vandermonde identity)"
+            },
+            {
+                "name": "gal_card_eq_120",
+                "type": "proved",
+                "description": "|Gal(x^5-4x+2/Q)| = 120 (fully proved via Sylow elimination of all other candidate orders)"
+            },
+            {
+                "name": "gal_iso_s5",
+                "type": "proved",
+                "description": "Gal(x^5-4x+2/Q) isomorphic to S_5 via galActionHom bijectivity"
+            },
+            {
+                "name": "roots_not_solvable_by_rad",
+                "type": "proved",
+                "description": "Roots of x^5-4x+2 cannot be expressed by radicals (contrapositive of Galois bridge)"
+            },
+            {
+                "name": "s5_realizable",
+                "type": "proved",
+                "description": "S_5 is realizable as a Galois group over Q"
+            }
+        ],
+        "sorries": 0,
+        "path": "Proofs/AbelRuffiniOQ04OQ01.lean"
     },
-    {
-      "key": "Ab24",
-      "citation": "Abel, N.H., Mémoire sur les équations algébriques, où l'on démontre l'impossibilité de la résolution de l'équation générale du cinquième degré (1824).",
-      "type": "paper"
-    },
-    {
-      "key": "Ga32",
-      "citation": "Galois, É., Mémoire sur les conditions de résolubilité des équations par radicaux (1832).",
-      "type": "paper"
-    },
-    {
-      "key": "Hi92",
-      "citation": "Hilbert, D., Über die Irreducibilität ganzer rationaler Functionen mit ganzzahligen Coefficienten, Journal für die reine und angewandte Mathematik 110 (1892), pp. 104-129. Hilbert's irreducibility theorem, foundational for the inverse Galois problem: $S_n$ and $A_n$ are realizable as Galois groups over $\\mathbb{Q}$.",
-      "type": "paper"
-    },
-    {
-      "key": "Ed84",
-      "citation": "Edwards, H.M., Galois Theory, Springer GTM 101 (1984). Faithful exposition of Galois's original 1832 memoir, including the historical development of the radical-solvability criterion and the role of the discriminant in Galois group computations.",
-      "type": "book"
-    },
-    {
-      "key": "Ar42",
-      "citation": "Artin, E., Galois Theory, Notre Dame Mathematical Lectures 2 (1942).",
-      "type": "book"
-    },
-    {
-      "key": "DF04",
-      "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004). Section 14.6: example of x^5-4x+2 with Galois group S_5.",
-      "type": "book"
-    },
-    {
-      "key": "La02",
-      "citation": "Lang, S., Algebra, 3rd ed., Springer GTM 211 (2002). Chapter VI: Galois theory, with standard examples of quintics with Galois group S_5.",
-      "type": "book"
-    },
-    {
-      "key": "St15",
-      "citation": "Stewart, I., Galois Theory, 4th ed., Chapman & Hall/CRC (2015). Chapters 22-23: explicit Galois group computations for specific polynomials.",
-      "type": "book"
-    },
-    {
-      "key": "Ei50",
-      "citation": "Eisenstein, G., Über die Irreductibilität und einige andere Eigenschaften der Gleichung..., Journal für die reine und angewandte Mathematik 39 (1850), pp. 160-179. The irreducibility criterion used to prove x^5-4x+2 is irreducible.",
-      "type": "paper"
-    },
-    {
-      "key": "St73",
-      "citation": "Stauduhar, R.P., The determination of Galois groups, Mathematics of Computation 27(124) (1973), pp. 981-996. Foundational algorithm for computing Galois groups of polynomials over Q via resolvent polynomials and the lattice of transitive subgroups; standard method in PARI/GP, Magma, and Sage.",
-      "type": "paper"
-    },
-    {
-      "key": "Br86",
-      "citation": "Bring, E.S., Meletemata quaedam mathematica circa transformationem aequationum algebraicarum, Promotionschrift, Lund (1786). Introduced the Tschirnhaus transformation that reduces every quintic to the form x^5 + px + q (Bring-Jerrard normal form), foundational for the Hermite-Klein elliptic-modular solution of the quintic.",
-      "type": "paper"
-    },
-    {
-      "key": "He58",
-      "citation": "Hermite, C., Sur la résolution de l'équation du cinquième degré, Comptes Rendus de l'Académie des Sciences 46 (1858), pp. 508-515. Solved the general quintic in Bring-Jerrard form using elliptic modular functions, complementing Abel-Ruffini: while no radical formula exists, transcendental closed-form solutions do.",
-      "type": "paper"
-    }
-  ],
-  "sorries": 0
+    "references": [
+        {
+            "key": "Ru99",
+            "citation": "Ruffini, P., Teoria generale delle equazioni in cui si dimostra impossibile la soluzione algebraica delle equazioni generali di grado superiore al quarto, Bologna (1799). The first (incomplete) proof of the unsolvability of the general quintic; the gap concerned permutation group theory not yet developed.",
+            "type": "book"
+        },
+        {
+            "key": "Ab24",
+            "citation": "Abel, N.H., Mémoire sur les équations algébriques, où l'on démontre l'impossibilité de la résolution de l'équation générale du cinquième degré (1824).",
+            "type": "paper"
+        },
+        {
+            "key": "Ga32",
+            "citation": "Galois, É., Mémoire sur les conditions de résolubilité des équations par radicaux (1832).",
+            "type": "paper"
+        },
+        {
+            "key": "Hi92",
+            "citation": "Hilbert, D., Über die Irreducibilität ganzer rationaler Functionen mit ganzzahligen Coefficienten, Journal für die reine und angewandte Mathematik 110 (1892), pp. 104-129. Hilbert's irreducibility theorem, foundational for the inverse Galois problem: $S_n$ and $A_n$ are realizable as Galois groups over $\\mathbb{Q}$.",
+            "type": "paper"
+        },
+        {
+            "key": "Ed84",
+            "citation": "Edwards, H.M., Galois Theory, Springer GTM 101 (1984). Faithful exposition of Galois's original 1832 memoir, including the historical development of the radical-solvability criterion and the role of the discriminant in Galois group computations.",
+            "type": "book"
+        },
+        {
+            "key": "Ar42",
+            "citation": "Artin, E., Galois Theory, Notre Dame Mathematical Lectures 2 (1942).",
+            "type": "book"
+        },
+        {
+            "key": "DF04",
+            "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004). Section 14.6: example of x^5-4x+2 with Galois group S_5.",
+            "type": "book"
+        },
+        {
+            "key": "La02",
+            "citation": "Lang, S., Algebra, 3rd ed., Springer GTM 211 (2002). Chapter VI: Galois theory, with standard examples of quintics with Galois group S_5.",
+            "type": "book"
+        },
+        {
+            "key": "St15",
+            "citation": "Stewart, I., Galois Theory, 4th ed., Chapman & Hall/CRC (2015). Chapters 22-23: explicit Galois group computations for specific polynomials.",
+            "type": "book"
+        },
+        {
+            "key": "Ei50",
+            "citation": "Eisenstein, G., Über die Irreductibilität und einige andere Eigenschaften der Gleichung..., Journal für die reine und angewandte Mathematik 39 (1850), pp. 160-179. The irreducibility criterion used to prove x^5-4x+2 is irreducible.",
+            "type": "paper"
+        },
+        {
+            "key": "St73",
+            "citation": "Stauduhar, R.P., The determination of Galois groups, Mathematics of Computation 27(124) (1973), pp. 981-996. Foundational algorithm for computing Galois groups of polynomials over Q via resolvent polynomials and the lattice of transitive subgroups; standard method in PARI/GP, Magma, and Sage.",
+            "type": "paper"
+        },
+        {
+            "key": "Br86",
+            "citation": "Bring, E.S., Meletemata quaedam mathematica circa transformationem aequationum algebraicarum, Promotionschrift, Lund (1786). Introduced the Tschirnhaus transformation that reduces every quintic to the form x^5 + px + q (Bring-Jerrard normal form), foundational for the Hermite-Klein elliptic-modular solution of the quintic.",
+            "type": "paper"
+        },
+        {
+            "key": "He58",
+            "citation": "Hermite, C., Sur la résolution de l'équation du cinquième degré, Comptes Rendus de l'Académie des Sciences 46 (1858), pp. 508-515. Solved the general quintic in Bring-Jerrard form using elliptic modular functions, complementing Abel-Ruffini: while no radical formula exists, transcendental closed-form solutions do.",
+            "type": "paper"
+        }
+    ],
+    "sorries": 0
 }

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
@@ -1,189 +1,189 @@
 {
-  "id": "angle-trisection-cos-20-gal-oq-01",
-  "title": "Galois Group of cos(π/7): |Gal(8X³−4X²−4X+1/ℚ)| = 3",
-  "slug": "angle-trisection-cos-20-gal-oq-01",
-  "description": "Proves that the Galois group of 8X³−4X²−4X+1 over ℚ has cardinality 3. This polynomial is the minimal polynomial of cos(π/7), with roots cos(π/7), cos(3π/7), cos(5π/7). Mirrors the AngleTrisectionCos20Gal approach (which handled cos(20°) = cos(π/9)), using Eisenstein at 7 (Y³−7Y²+14Y−7) instead of Eisenstein at 3. 0 sorries, 0 axioms.",
-  "meta": {
-    "author": "Lean Genius Research",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(field_theory)",
-    "date": "2026",
-    "status": "verified",
-    "proofRepoPath": "Proofs/AngleTrisectionCos20GalOQ01.lean",
-    "tags": [
-      "galois-theory",
-      "algebra",
-      "polynomials",
-      "angle-trisection",
-      "research"
+    "id": "angle-trisection-cos-20-gal-oq-01",
+    "title": "Galois Group of cos(π/7): |Gal(8X³−4X²−4X+1/ℚ)| = 3",
+    "slug": "angle-trisection-cos-20-gal-oq-01",
+    "description": "Proves that the Galois group of 8X³−4X²−4X+1 over ℚ has cardinality 3. This polynomial is the minimal polynomial of cos(π/7), with roots cos(π/7), cos(3π/7), cos(5π/7). Mirrors the AngleTrisectionCos20Gal approach (which handled cos(20°) = cos(π/9)), using Eisenstein at 7 (Y³−7Y²+14Y−7) instead of Eisenstein at 3. 0 sorries, 0 axioms.",
+    "meta": {
+        "author": "Lean Genius Research",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(field_theory)",
+        "date": "2026",
+        "status": "verified",
+        "proofRepoPath": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+        "tags": [
+            "galois-theory",
+            "algebra",
+            "polynomials",
+            "angle-trisection",
+            "research"
+        ],
+        "badge": "original",
+        "sorries": 0,
+        "axiomCount": 0,
+        "lineCount": 416,
+        "assumptions": "None. 0 axioms and 0 sorries. All results follow from Mathlib's Galois theory (Polynomial.Gal) and Eisenstein's criterion.",
+        "mathlib_version": "4.26.0",
+        "originalContributions": [
+            "cos_pi_7_gal_card: |Gal(8X³−4X²−4X+1/ℚ)| = 3 (main theorem)",
+            "cos_pi_7_poly_irreducible: 8X³−4X²−4X+1 is irreducible over ℚ (via Eisenstein at 7)",
+            "root_image_gamma: if 8a³−4a²−4a+1=0 then so does 8(1−2a²)³−... (γ = cos(5π/7) formula)",
+            "root_image_beta: if 8a³−4a²−4a+1=0 then so does 8(2a²−a−1/2)³−... (β = cos(3π/7) formula)",
+            "splitting_finrank: [SplittingField(8X³−4X²−4X+1):ℚ] = 3"
+        ],
+        "prerequisites": [
+            "AngleTrisectionCos20Gal: same approach for 8X³−6X−1 (cos(20°))",
+            "Eisenstein criterion (Polynomial.irreducible_of_eisenstein_criterion)",
+            "Polynomial.Gal.card_of_separable and splitting field machinery"
+        ],
+        "mathlibDependencies": [
+            {
+                "theorem": "Polynomial.Gal.card_of_separable",
+                "description": "|Gal| = [SplittingField:ℚ] for separable polynomials",
+                "module": "Mathlib.FieldTheory.Galois.Basic"
+            },
+            {
+                "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+                "description": "Eisenstein's criterion for irreducibility",
+                "module": "Mathlib.RingTheory.Eisenstein.Basic"
+            },
+            {
+                "theorem": "Polynomial.Gal.prime_degree_dvd_card",
+                "description": "If p is irreducible and deg p is prime, then deg p divides |Gal|",
+                "module": "Mathlib.FieldTheory.Galois.Basic"
+            }
+        ],
+        "theoremCount": 5
+    },
+    "overview": {
+        "historicalContext": "The Galois group computation for cos(π/7) is a classical exercise in algebraic number theory, first implicit in Gauss's 1801 *Disquisitiones Arithmeticae* where he characterized constructible regular polygons. The regular heptagon (7-gon) is not constructible by straightedge and compass because [ℚ(cos(2π/7)):ℚ] = 3, which is not a power of 2 — precisely the fact this proof establishes. The minimal polynomial 8X³−4X²−4X+1 arises from the 14th cyclotomic field: cos(π/7) = (ζ₁₄ + ζ₁₄⁻¹)/2 where ζ₁₄ = e^{2πi/14}, and the maximal real subfield ℚ(ζ₁₄)⁺ = ℚ(cos(π/7)) has degree φ(14)/2 = 3 over ℚ. The three roots cos(π/7), cos(3π/7), cos(5π/7) form a single Galois orbit under the automorphism α ↦ 1−2α² (corresponding to ζ₁₄ ↦ ζ₁₄⁵), giving the cyclic Galois group ℤ/3ℤ. This computation is a key example in the theory of totally real abelian extensions.",
+        "problemStatement": "Prove that $|\\mathrm{Gal}(8X^3-4X^2-4X+1 / \\mathbb{Q})| = 3$. The polynomial $8X^3-4X^2-4X+1$ is the minimal polynomial of $\\cos(\\pi/7)$ over $\\mathbb{Q}$, with roots $\\cos(\\pi/7)$, $\\cos(3\\pi/7)$, $\\cos(5\\pi/7)$.",
+        "mathContext": "The Galois group is cyclic: $\\mathrm{Gal}(p/\\mathbb{Q}) \\cong \\mathbb{Z}/3\\mathbb{Z}$, generated by $\\cos(\\pi/7) \\mapsto \\cos(3\\pi/7)$. Cyclotomic interpretation: $\\cos(\\pi/7) = (\\zeta_{14} + \\zeta_{14}^{-1})/2$ where $\\zeta_{14} = e^{2\\pi i/14}$; the automorphism corresponds to $\\zeta_{14} \\mapsto \\zeta_{14}^5$.",
+        "proofStrategy": "**Step 1 — Irreducibility** (§2): Y³−7Y²+14Y−7 is Eisenstein at p=7. The substitution Y = 2X+2 maps it to 8X³−4X²−4X+1, so the latter is irreducible.\n\n**Step 2 — All roots in ℚ(α)** (§4): If α is a root, then γ = 1−2α² satisfies p(γ) = 0 (integer arithmetic), and β = 2α²−α−1/2 satisfies p(β) = 0 (via field arithmetic). So the splitting field equals ℚ(α).\n\n**Step 3 — Degree** (§4): [SplittingField:ℚ] = [ℚ(α):ℚ] = deg(minpoly α) = 3.\n\n**Step 4 — Main theorem** (§5): |Gal| = [SplittingField:ℚ] = 3 (since p is separable).",
+        "keyInsights": [
+            "The same substitution Y = 2X+2 used for cos(20°) works here too: the Eisenstein polynomial is Y³−7Y²+14Y−7 (at prime 7, vs Y³−6Y²+9Y−3 at prime 3 for cos(20°)).",
+            "The root formulas are: cos(5π/7) = 1−2cos²(π/7) (same as cos(100°) in the 20° case) and cos(3π/7) = 4cos³(π/7)−3cos(π/7) ≡ 2cos²(π/7)−cos(π/7)−1/2 modulo the minimal polynomial.",
+            "The factored form identity 8a³−4a²−4a+1 = 8(a−α)(a−β)(a−γ) holds as an algebraic identity when 8α³−4α²−4α+1=0, with factor (4αa−4α²+1) for the remainder.",
+            "The proof uses maximally general hypotheses: root_image_gamma works in any CommRing (pure ring arithmetic), while root_image_beta requires a CharZero field because cos(3π/7) = 2α²−α−1/2 involves the fraction 1/2. This CharZero distinction cleanly separates which algebraic facts are characteristic-free from those genuinely requiring ℚ-algebra structure.",
+            "The Galois group ℤ/3ℤ has a cyclotomic interpretation: cos(π/7) = (ζ₁₄ + ζ₁₄⁻¹)/2 where ζ₁₄ = e^{2πi/14}. The automorphism α ↦ 1−2α² corresponds to the Frobenius ζ₁₄ ↦ ζ₁₄⁵, generating the Galois group of ℚ(cos(π/7)) = ℚ(ζ₁₄)⁺ — the maximal real subfield of the 14th cyclotomic field."
+        ],
+        "prerequisites": [
+            "AngleTrisectionCos20Gal (Proofs/AngleTrisectionCos20Gal.lean): identical proof structure for 8X³−6X−1",
+            "Galois theory machinery in Mathlib: SplittingField, Polynomial.Gal",
+            "Eisenstein's criterion: Polynomial.irreducible_of_eisenstein_criterion"
+        ],
+        "furtherWork": [
+            "Compute |Gal| for cos(π/n) for general n (cyclotomic fields)",
+            "Prove that the Galois group is cyclic of order φ(2n)/2 in general",
+            "Unify the cos(20°) and cos(π/7) computations into a single parameterized theorem"
+        ]
+    },
+    "sections": [
+        {
+            "id": "preamble-imports",
+            "title": "Module Documentation and Imports",
+            "startLine": 1,
+            "endLine": 25,
+            "summary": "Module docstring documenting the Galois group computation for cos(π/7), the relationship to AngleTrisectionCos20Gal (cos(20°)), and the Eisenstein at 7 approach. Imports Galois theory machinery, Eisenstein criterion, and general Mathlib tactics."
+        },
+        {
+            "id": "algebraic-identities",
+            "title": "§1: Algebraic Identities",
+            "startLine": 26,
+            "endLine": 65,
+            "summary": "root_image_gamma (over CommRing): 1−2α² is a root when α is. root_image_beta (over CharZero Field): 2α²−α−1/2 is a root when α is.",
+            "mathContext": "Factor identities: 8(1−2a²)³−... = (−8a³−4a²+4a+1)·(8a³−4a²−4a+1) and 8(2a²−a−1/2)³−... = (8a³−8a²−2a+1)·(8a³−4a²−4a+1)."
+        },
+        {
+            "id": "irreducibility",
+            "title": "§2: Irreducibility via Eisenstein at 7",
+            "startLine": 68,
+            "endLine": 218,
+            "summary": "r = Y³−7Y²+14Y−7 is Eisenstein at 7 (irreducible over ℤ and ℚ). The substitution Y=2X+2 maps r to pCos7 = 8X³−4X²−4X+1, proving irreducibility.",
+            "mathContext": "Eisenstein conditions: leading coeff 1 ∉ (7), coefficients −7, 14, −7 are all divisible by 7, constant −7 not divisible by 49."
+        },
+        {
+            "id": "splitting-field",
+            "title": "§3-4: Splitting Field Has Degree 3",
+            "startLine": 220,
+            "endLine": 410,
+            "summary": "factored_eval_eq shows 8a³−4a²−4a+1 = 8(a−α)(a−β)(a−γ) when α is a root (CharZero Field). rootSet_subset_adjoin: every root lies in ℚ(α). adjoin_root_eq_top: ℚ(α) = SplittingField.",
+            "mathContext": "The key algebraic identity: 8a³−4a²−4a+1 − 8(a−α)(a−β)(a−γ) = (4αa−4α²+1)(8α³−4α²−4α+1). When the second factor vanishes (α a root), the polynomial factors completely over ℚ(α)."
+        },
+        {
+            "id": "main-theorem",
+            "title": "§5: Main Theorem",
+            "startLine": 411,
+            "endLine": 416,
+            "summary": "cos_pi_7_gal_card: |Gal(8X³−4X²−4X+1/ℚ)| = 3. The Galois group of the minimal polynomial of cos(π/7) has order 3.",
+            "mathContext": "By Polynomial.Gal.card_of_separable: |Gal| = [SplittingField:ℚ] = 3."
+        }
     ],
-    "badge": "original",
+    "conclusion": {
+        "summary": "This formalization proves |Gal(8X³−4X²−4X+1/ℚ)| = 3, completing the Galois group computation for the minimal polynomial of cos(π/7). The proof exactly mirrors AngleTrisectionCos20Gal but with Eisenstein prime 7 instead of 3, and the root formula for cos(3π/7) requiring CharZero arithmetic (1/2 appears explicitly). 0 sorries, 0 axioms.",
+        "implications": "Together with AngleTrisectionCos20Gal (cos(20°) = cos(π/9)), this establishes the Galois group pattern for cos(kπ/n) when the degree-3 minimal polynomial arises. The technique — expressing all roots as polynomial functions of one root, then applying the factored form identity — is a clean Lean 4 approach to splitting field degree computations.",
+        "openQuestions": [
+            "Can the cos(20°) and cos(π/7) results be unified into a single theorem parameterized by the Eisenstein prime?",
+            "What is |Gal(minpoly(cos(π/n))/ℚ)| for general n, and can this be proved in Lean 4 via cyclotomic field theory?",
+            "For which primes p does the minimal polynomial of cos(π/p) have Eisenstein form after a linear substitution? The cases p=3 (cos(20°)) and p=7 suggest a pattern: the substituted polynomial Y³−pY²+... has coefficients divisible by p."
+        ]
+    },
+    "crossReferences": [
+        {
+            "targetId": "angle-trisection-cos-20-gal",
+            "relationship": "parent",
+            "description": "Parent proof: same structure for 8X³−6X−1 (minimal polynomial of cos(20°))"
+        },
+        {
+            "targetId": "angle-trisection",
+            "relationship": "related",
+            "description": "Angle trisection impossibility using these Galois group computations"
+        },
+        {
+            "targetId": "abel-ruffini-galois-extensions",
+            "relationship": "related",
+            "description": "Broader Galois theory machinery for field extensions and solvability"
+        },
+        {
+            "targetId": "inverse-galois",
+            "relationship": "related",
+            "description": "The inverse Galois problem — ℤ/3ℤ is realized here as Gal(cos(π/7) minpoly/ℚ)"
+        }
+    ],
+    "references": [
+        {
+            "authors": [
+                "I. Stewart"
+            ],
+            "title": "Galois Theory",
+            "year": "2015",
+            "venue": "Chapman & Hall/CRC, 4th edition",
+            "note": "Chapter 17: constructibility and Galois groups. The Galois group computation for cos(π/n) minimal polynomials follows the pattern developed here: irreducibility via Eisenstein, splitting field degree from explicit root formulas, and |Gal| = [K:ℚ] by separability."
+        },
+        {
+            "authors": [
+                "I. M. Niven"
+            ],
+            "title": "Irrational Numbers",
+            "year": "1956",
+            "venue": "Carus Mathematical Monographs #11, MAA",
+            "note": "Chapter 3: algebraic properties of trigonometric values at rational multiples of π. Establishes the minimal polynomial of cos(2π/n) via cyclotomic polynomials and Chebyshev substitutions."
+        }
+    ],
     "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 416,
-    "assumptions": "None. 0 axioms and 0 sorries. All results follow from Mathlib's Galois theory (Polynomial.Gal) and Eisenstein's criterion.",
-    "mathlib_version": "4.26.0",
-    "originalContributions": [
-      "cos_pi_7_gal_card: |Gal(8X³−4X²−4X+1/ℚ)| = 3 (main theorem)",
-      "cos_pi_7_poly_irreducible: 8X³−4X²−4X+1 is irreducible over ℚ (via Eisenstein at 7)",
-      "root_image_gamma: if 8a³−4a²−4a+1=0 then so does 8(1−2a²)³−... (γ = cos(5π/7) formula)",
-      "root_image_beta: if 8a³−4a²−4a+1=0 then so does 8(2a²−a−1/2)³−... (β = cos(3π/7) formula)",
-      "splitting_finrank: [SplittingField(8X³−4X²−4X+1):ℚ] = 3"
-    ],
-    "prerequisites": [
-      "AngleTrisectionCos20Gal: same approach for 8X³−6X−1 (cos(20°))",
-      "Eisenstein criterion (Polynomial.irreducible_of_eisenstein_criterion)",
-      "Polynomial.Gal.card_of_separable and splitting field machinery"
-    ],
-    "mathlibDependencies": [
-      {
-        "theorem": "Polynomial.Gal.card_of_separable",
-        "description": "|Gal| = [SplittingField:ℚ] for separable polynomials",
-        "module": "Mathlib.FieldTheory.Galois.Basic"
-      },
-      {
-        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
-        "description": "Eisenstein's criterion for irreducibility",
-        "module": "Mathlib.RingTheory.Eisenstein.Basic"
-      },
-      {
-        "theorem": "Polynomial.Gal.prime_degree_dvd_card",
-        "description": "If p is irreducible and deg p is prime, then deg p divides |Gal|",
-        "module": "Mathlib.FieldTheory.Galois.Basic"
-      }
-    ],
-    "theoremCount": 5
-  },
-  "overview": {
-    "historicalContext": "The Galois group computation for cos(π/7) is a classical exercise in algebraic number theory, first implicit in Gauss's 1801 *Disquisitiones Arithmeticae* where he characterized constructible regular polygons. The regular heptagon (7-gon) is not constructible by straightedge and compass because [ℚ(cos(2π/7)):ℚ] = 3, which is not a power of 2 — precisely the fact this proof establishes. The minimal polynomial 8X³−4X²−4X+1 arises from the 14th cyclotomic field: cos(π/7) = (ζ₁₄ + ζ₁₄⁻¹)/2 where ζ₁₄ = e^{2πi/14}, and the maximal real subfield ℚ(ζ₁₄)⁺ = ℚ(cos(π/7)) has degree φ(14)/2 = 3 over ℚ. The three roots cos(π/7), cos(3π/7), cos(5π/7) form a single Galois orbit under the automorphism α ↦ 1−2α² (corresponding to ζ₁₄ ↦ ζ₁₄⁵), giving the cyclic Galois group ℤ/3ℤ. This computation is a key example in the theory of totally real abelian extensions.",
-    "problemStatement": "Prove that $|\\mathrm{Gal}(8X^3-4X^2-4X+1 / \\mathbb{Q})| = 3$. The polynomial $8X^3-4X^2-4X+1$ is the minimal polynomial of $\\cos(\\pi/7)$ over $\\mathbb{Q}$, with roots $\\cos(\\pi/7)$, $\\cos(3\\pi/7)$, $\\cos(5\\pi/7)$.",
-    "mathContext": "The Galois group is cyclic: $\\mathrm{Gal}(p/\\mathbb{Q}) \\cong \\mathbb{Z}/3\\mathbb{Z}$, generated by $\\cos(\\pi/7) \\mapsto \\cos(3\\pi/7)$. Cyclotomic interpretation: $\\cos(\\pi/7) = (\\zeta_{14} + \\zeta_{14}^{-1})/2$ where $\\zeta_{14} = e^{2\\pi i/14}$; the automorphism corresponds to $\\zeta_{14} \\mapsto \\zeta_{14}^5$.",
-    "proofStrategy": "**Step 1 — Irreducibility** (§2): Y³−7Y²+14Y−7 is Eisenstein at p=7. The substitution Y = 2X+2 maps it to 8X³−4X²−4X+1, so the latter is irreducible.\n\n**Step 2 — All roots in ℚ(α)** (§4): If α is a root, then γ = 1−2α² satisfies p(γ) = 0 (integer arithmetic), and β = 2α²−α−1/2 satisfies p(β) = 0 (via field arithmetic). So the splitting field equals ℚ(α).\n\n**Step 3 — Degree** (§4): [SplittingField:ℚ] = [ℚ(α):ℚ] = deg(minpoly α) = 3.\n\n**Step 4 — Main theorem** (§5): |Gal| = [SplittingField:ℚ] = 3 (since p is separable).",
-    "keyInsights": [
-      "The same substitution Y = 2X+2 used for cos(20°) works here too: the Eisenstein polynomial is Y³−7Y²+14Y−7 (at prime 7, vs Y³−6Y²+9Y−3 at prime 3 for cos(20°)).",
-      "The root formulas are: cos(5π/7) = 1−2cos²(π/7) (same as cos(100°) in the 20° case) and cos(3π/7) = 4cos³(π/7)−3cos(π/7) ≡ 2cos²(π/7)−cos(π/7)−1/2 modulo the minimal polynomial.",
-      "The factored form identity 8a³−4a²−4a+1 = 8(a−α)(a−β)(a−γ) holds as an algebraic identity when 8α³−4α²−4α+1=0, with factor (4αa−4α²+1) for the remainder.",
-      "The proof uses maximally general hypotheses: root_image_gamma works in any CommRing (pure ring arithmetic), while root_image_beta requires a CharZero field because cos(3π/7) = 2α²−α−1/2 involves the fraction 1/2. This CharZero distinction cleanly separates which algebraic facts are characteristic-free from those genuinely requiring ℚ-algebra structure.",
-      "The Galois group ℤ/3ℤ has a cyclotomic interpretation: cos(π/7) = (ζ₁₄ + ζ₁₄⁻¹)/2 where ζ₁₄ = e^{2πi/14}. The automorphism α ↦ 1−2α² corresponds to the Frobenius ζ₁₄ ↦ ζ₁₄⁵, generating the Galois group of ℚ(cos(π/7)) = ℚ(ζ₁₄)⁺ — the maximal real subfield of the 14th cyclotomic field."
-    ],
-    "prerequisites": [
-      "AngleTrisectionCos20Gal (Proofs/AngleTrisectionCos20Gal.lean): identical proof structure for 8X³−6X−1",
-      "Galois theory machinery in Mathlib: SplittingField, Polynomial.Gal",
-      "Eisenstein's criterion: Polynomial.irreducible_of_eisenstein_criterion"
-    ],
-    "furtherWork": [
-      "Compute |Gal| for cos(π/n) for general n (cyclotomic fields)",
-      "Prove that the Galois group is cyclic of order φ(2n)/2 in general",
-      "Unify the cos(20°) and cos(π/7) computations into a single parameterized theorem"
-    ]
-  },
-  "sections": [
-    {
-      "id": "preamble-imports",
-      "title": "Module Documentation and Imports",
-      "startLine": 1,
-      "endLine": 25,
-      "summary": "Module docstring documenting the Galois group computation for cos(π/7), the relationship to AngleTrisectionCos20Gal (cos(20°)), and the Eisenstein at 7 approach. Imports Galois theory machinery, Eisenstein criterion, and general Mathlib tactics."
-    },
-    {
-      "id": "algebraic-identities",
-      "title": "§1: Algebraic Identities",
-      "startLine": 26,
-      "endLine": 65,
-      "summary": "root_image_gamma (over CommRing): 1−2α² is a root when α is. root_image_beta (over CharZero Field): 2α²−α−1/2 is a root when α is.",
-      "mathContext": "Factor identities: 8(1−2a²)³−... = (−8a³−4a²+4a+1)·(8a³−4a²−4a+1) and 8(2a²−a−1/2)³−... = (8a³−8a²−2a+1)·(8a³−4a²−4a+1)."
-    },
-    {
-      "id": "irreducibility",
-      "title": "§2: Irreducibility via Eisenstein at 7",
-      "startLine": 68,
-      "endLine": 218,
-      "summary": "r = Y³−7Y²+14Y−7 is Eisenstein at 7 (irreducible over ℤ and ℚ). The substitution Y=2X+2 maps r to pCos7 = 8X³−4X²−4X+1, proving irreducibility.",
-      "mathContext": "Eisenstein conditions: leading coeff 1 ∉ (7), coefficients −7, 14, −7 are all divisible by 7, constant −7 not divisible by 49."
-    },
-    {
-      "id": "splitting-field",
-      "title": "§3-4: Splitting Field Has Degree 3",
-      "startLine": 220,
-      "endLine": 410,
-      "summary": "factored_eval_eq shows 8a³−4a²−4a+1 = 8(a−α)(a−β)(a−γ) when α is a root (CharZero Field). rootSet_subset_adjoin: every root lies in ℚ(α). adjoin_root_eq_top: ℚ(α) = SplittingField.",
-      "mathContext": "The key algebraic identity: 8a³−4a²−4a+1 − 8(a−α)(a−β)(a−γ) = (4αa−4α²+1)(8α³−4α²−4α+1). When the second factor vanishes (α a root), the polynomial factors completely over ℚ(α)."
-    },
-    {
-      "id": "main-theorem",
-      "title": "§5: Main Theorem",
-      "startLine": 411,
-      "endLine": 416,
-      "summary": "cos_pi_7_gal_card: |Gal(8X³−4X²−4X+1/ℚ)| = 3. The Galois group of the minimal polynomial of cos(π/7) has order 3.",
-      "mathContext": "By Polynomial.Gal.card_of_separable: |Gal| = [SplittingField:ℚ] = 3."
+    "leanFile": {
+        "imports": [
+            "Mathlib"
+        ],
+        "opens": [
+            "Polynomial",
+            "IntermediateField",
+            "FiniteDimensional"
+        ],
+        "namespace": "AngleTrisectionCos20GalOQ01",
+        "lineCount": 416,
+        "axiomCount": 0,
+        "theoremCount": 32,
+        "definitionCount": 0,
+        "sorries": 0,
+        "path": "Proofs/AngleTrisectionCos20GalOQ01.lean"
     }
-  ],
-  "conclusion": {
-    "summary": "This formalization proves |Gal(8X³−4X²−4X+1/ℚ)| = 3, completing the Galois group computation for the minimal polynomial of cos(π/7). The proof exactly mirrors AngleTrisectionCos20Gal but with Eisenstein prime 7 instead of 3, and the root formula for cos(3π/7) requiring CharZero arithmetic (1/2 appears explicitly). 0 sorries, 0 axioms.",
-    "implications": "Together with AngleTrisectionCos20Gal (cos(20°) = cos(π/9)), this establishes the Galois group pattern for cos(kπ/n) when the degree-3 minimal polynomial arises. The technique — expressing all roots as polynomial functions of one root, then applying the factored form identity — is a clean Lean 4 approach to splitting field degree computations.",
-    "openQuestions": [
-      "Can the cos(20°) and cos(π/7) results be unified into a single theorem parameterized by the Eisenstein prime?",
-      "What is |Gal(minpoly(cos(π/n))/ℚ)| for general n, and can this be proved in Lean 4 via cyclotomic field theory?",
-      "For which primes p does the minimal polynomial of cos(π/p) have Eisenstein form after a linear substitution? The cases p=3 (cos(20°)) and p=7 suggest a pattern: the substituted polynomial Y³−pY²+... has coefficients divisible by p."
-    ]
-  },
-  "crossReferences": [
-    {
-      "targetId": "angle-trisection-cos-20-gal",
-      "relationship": "parent",
-      "description": "Parent proof: same structure for 8X³−6X−1 (minimal polynomial of cos(20°))"
-    },
-    {
-      "targetId": "angle-trisection",
-      "relationship": "related",
-      "description": "Angle trisection impossibility using these Galois group computations"
-    },
-    {
-      "targetId": "abel-ruffini-galois-extensions",
-      "relationship": "related",
-      "description": "Broader Galois theory machinery for field extensions and solvability"
-    },
-    {
-      "targetId": "inverse-galois",
-      "relationship": "related",
-      "description": "The inverse Galois problem — ℤ/3ℤ is realized here as Gal(cos(π/7) minpoly/ℚ)"
-    }
-  ],
-  "references": [
-    {
-      "authors": [
-        "I. Stewart"
-      ],
-      "title": "Galois Theory",
-      "year": "2015",
-      "venue": "Chapman & Hall/CRC, 4th edition",
-      "note": "Chapter 17: constructibility and Galois groups. The Galois group computation for cos(π/n) minimal polynomials follows the pattern developed here: irreducibility via Eisenstein, splitting field degree from explicit root formulas, and |Gal| = [K:ℚ] by separability."
-    },
-    {
-      "authors": [
-        "I. M. Niven"
-      ],
-      "title": "Irrational Numbers",
-      "year": "1956",
-      "venue": "Carus Mathematical Monographs #11, MAA",
-      "note": "Chapter 3: algebraic properties of trigonometric values at rational multiples of π. Establishes the minimal polynomial of cos(2π/n) via cyclotomic polynomials and Chebyshev substitutions."
-    }
-  ],
-  "sorries": 0,
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Polynomial",
-      "IntermediateField",
-      "FiniteDimensional"
-    ],
-    "namespace": "AngleTrisectionCos20GalOQ01",
-    "lineCount": 416,
-    "axiomCount": 0,
-    "theoremCount": 5,
-    "definitionCount": 0,
-    "sorries": 0,
-    "path": "Proofs/AngleTrisectionCos20GalOQ01.lean"
-  }
 }

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
@@ -1,151 +1,151 @@
 {
-  "id": "angle-trisection-cos-20-gal-oq-03",
-  "title": "Galois Group of cos(40°) Minimal Polynomial has Order 3",
-  "slug": "angle-trisection-cos-20-gal-oq-03",
-  "description": "Proves that the Galois group of 8X³−6X+1 over ℚ has cardinality 3. This polynomial is the minimal polynomial of cos(40°) = cos(2π/9), with roots cos(40°), cos(80°), cos(160°). Mirrors the AngleTrisectionCos20Gal approach (which handled cos(20°) = cos(π/9)), using Eisenstein at 3 via the substitution Y=2X−2 (shifting to Y³+6Y²+9Y+3) instead of Y=2X+2. 0 sorries, 0 axioms.",
-  "meta": {
-    "author": "Researcher-13",
-    "date": "2026",
-    "status": "verified",
-    "proofRepoPath": "Proofs/AngleTrisectionCos20GalOQ03.lean",
-    "tags": [
-      "galois-theory",
-      "field-extensions",
-      "angle-trisection",
-      "irreducibility",
-      "research"
+    "id": "angle-trisection-cos-20-gal-oq-03",
+    "title": "Galois Group of cos(40°) Minimal Polynomial has Order 3",
+    "slug": "angle-trisection-cos-20-gal-oq-03",
+    "description": "Proves that the Galois group of 8X³−6X+1 over ℚ has cardinality 3. This polynomial is the minimal polynomial of cos(40°) = cos(2π/9), with roots cos(40°), cos(80°), cos(160°). Mirrors the AngleTrisectionCos20Gal approach (which handled cos(20°) = cos(π/9)), using Eisenstein at 3 via the substitution Y=2X−2 (shifting to Y³+6Y²+9Y+3) instead of Y=2X+2. 0 sorries, 0 axioms.",
+    "meta": {
+        "author": "Researcher-13",
+        "date": "2026",
+        "status": "verified",
+        "proofRepoPath": "Proofs/AngleTrisectionCos20GalOQ03.lean",
+        "tags": [
+            "galois-theory",
+            "field-extensions",
+            "angle-trisection",
+            "irreducibility",
+            "research"
+        ],
+        "badge": "mathlib",
+        "sorries": 0,
+        "axiomCount": 0,
+        "lineCount": 434,
+        "assumptions": "None. All results proved from Mathlib axioms only.",
+        "dateAdded": "2026-04-13",
+        "mathlib_version": "4.26.0",
+        "originalContributions": [
+            "Proof that 8X³−6X+1 is irreducible over ℚ via Eisenstein criterion on Y³+6Y²+9Y+3",
+            "Root images: β=2α²−1 (cos 80°), γ=−2α²−α+1 (cos 160°) proved as ring identities",
+            "Factored form identity: 8a³−6a+1 = 8(a−α)(a−β)(a−γ) when 8α³−6α+1=0",
+            "Splitting field degree 3 theorem for 8X³−6X+1",
+            "Main theorem: |Gal(8X³−6X+1/ℚ)| = 3"
+        ],
+        "theoremCount": 5
+    },
+    "overview": {
+        "historicalContext": "The impossibility of angle trisection by compass and straightedge was proved by Wantzel (1837), using the then-new theory of algebraic extensions. The key insight: a 60° angle cannot be trisected because 20° has cosine satisfying the irreducible cubic 8X³−6X−1 = 0, and [ℚ(cos(20°)):ℚ] = 3 is not a power of 2. Galois theory, developed by Évariste Galois before his death in 1832 (but published posthumously in 1846), gave a more conceptual framework: the Galois group of the minimal polynomial determines constructibility.\n\nThe polynomial 8X³−6X+1 is the minimal polynomial of cos(40°) = cos(2π/9) over ℚ. Its three roots are cos(40°), cos(80°), cos(160°), arising from the triple-angle identity cos(3·40°) = cos(120°) = −1/2. The Eisenstein irreducibility argument uses the shift Y=2X−2, which transforms the polynomial into Y³+6Y²+9Y+3 — Eisenstein at p=3. The analogous shift Y=2X+2 works for the cos(20°) polynomial 8X³−6X−1. Both shifts are discovered by looking at where the polynomial takes the value 0: the roots of 8X³−6X±1 are close to ±1/2, and centering the variable near these values produces the p-divisibility structure needed for Eisenstein.\n\nThis result is part of a family: the Galois groups of 8X³−6X−1 (cos(20°)/cos(π/9)), 8X³−6X+1 (cos(40°)/cos(2π/9)), and 8X³−4X²−4X+1 (cos(π/7)) all have order 3. In all three cases, the splitting field is a cyclic extension of degree 3 over ℚ, and the Galois group is ℤ/3ℤ. This is the minimal non-trivial case of the general pattern for cos(2π/p) with odd prime p: the Galois group is cyclic of order (p−1)/2 = 1, 3, 5, ... for p = 3, 7, 11, ...",
+        "problemStatement": "Prove that the Galois group of 8X³−6X+1 over ℚ has cardinality 3. Equivalently, the splitting field of 8X³−6X+1 has degree 3 over ℚ, and the extension is cyclic of order 3.",
+        "proofStrategy": "1. Prove root_image_beta and root_image_gamma: if 8α³−6α+1=0, then β=2α²−1 and γ=−2α²−α+1 are also roots (pure ring identities). 2. Prove 8X³−6X+1 irreducible by Eisenstein: the substitution Y=2X−2 gives Y³+6Y²+9Y+3 which is Eisenstein at 3. 3. Show all roots lie in ℚ(α) via the factored form identity. 4. Conclude [SplittingField:ℚ]=3, hence |Gal|=3.",
+        "keyInsights": [
+            "The double-angle formula cos(80°)=2cos²(40°)−1 directly gives β=2α²−1 as a polynomial in α.",
+            "Since α+β+γ=0 by Vieta (the X² coefficient of 8X³−6X+1 is 0), γ=−α−β=−2α²−α+1.",
+            "The Eisenstein shift uses Y=2X−2 (not Y=2X+2 as for cos(20°)), reflecting the sign change in the constant term: (2X−2)³+6(2X−2)²+9(2X−2)+3 = 8X³−6X+1.",
+            "The factored form identity 8a³−6a+1=8(a−α)(a−β)(a−γ) has ring-theory cofactor ((4α+2)·a+(−4α²−2α+1))·(8α³−6α+1), enabling the splitting field argument.",
+            "The `CommRing R` generality in `root_image_beta/gamma` is not just elegance: it enables direct application in the splitting field (a field extension of ℚ), and in polynomial quotient rings ℚ[X]/(p), where abstract roots live without needing real number coordinates."
+        ],
+        "prerequisites": [
+            "AngleTrisectionCos20Gal.lean (structural template)",
+            "Polynomial.irreducible_of_eisenstein_criterion (Mathlib)",
+            "Polynomial.Gal.card_of_separable (Mathlib)",
+            "IntermediateField.adjoin.finrank (Mathlib)"
+        ]
+    },
+    "sections": [
+        {
+            "id": "ring-identities",
+            "title": "§1: Root Images",
+            "startLine": 34,
+            "endLine": 58,
+            "summary": "Ring identities showing β=2α²−1 and γ=−2α²−α+1 are roots when α is.",
+            "mathContext": "If $8\\alpha^3-6\\alpha+1=0$, then $\\beta=2\\alpha^2-1$ satisfies $8(2\\alpha^2-1)^3-6(2\\alpha^2-1)+1=(8\\alpha^3-6\\alpha-1)(8\\alpha^3-6\\alpha+1)=0$. Similarly for $\\gamma=-2\\alpha^2-\\alpha+1$ with cofactor $-8\\alpha^3-12\\alpha^2+3$."
+        },
+        {
+            "id": "irreducibility",
+            "title": "§2: Irreducibility via Eisenstein",
+            "startLine": 62,
+            "endLine": 200,
+            "summary": "8X³−6X+1 is irreducible over ℚ via Eisenstein criterion on Y³+6Y²+9Y+3.",
+            "mathContext": "The substitution $Y=2X-2$ (inverse $X=(Y+2)/2$) transforms $r(Y)=Y^3+6Y^2+9Y+3$ to $8X^3-6X+1$. Since $r$ is Eisenstein at $p=3$ (with $3|6,3|9,3|3$ and $9\\nmid 3$), it is irreducible over $\\mathbb{Z}$, hence over $\\mathbb{Q}$ by Gauss's lemma."
+        },
+        {
+            "id": "splitting-field-structure",
+            "title": "§3-4: Splitting Field Structure",
+            "startLine": 204,
+            "endLine": 310,
+            "summary": "Factorization over ℚ(α): shows β and γ are the other two roots, all roots lie in ℚ(α), and establishes the splitting field equals ℚ(α).",
+            "mathContext": "The factored form $8a^3-6a+1=8(a-\\alpha)(a-\\beta)(a-\\gamma)$ shows every root of $p$ lies in $\\mathbb{Q}(\\alpha)$, so $\\text{SplittingField}(p) = \\mathbb{Q}(\\alpha)$."
+        },
+        {
+            "id": "splitting-field-degree",
+            "title": "§5: Galois Degree Bounds",
+            "startLine": 311,
+            "endLine": 395,
+            "summary": "Galois group order bounds: |Gal| divides and equals [SplittingField:ℚ] = 3. Combines finrank tower law with deg-p = 3 and splitting field degree argument.",
+            "mathContext": "$[\\mathbb{Q}(\\alpha):\\mathbb{Q}]=3$ equals $[\\text{SplittingField}:\\mathbb{Q}]$, so $|\\text{Gal}(p)|=3$."
+        },
+        {
+            "id": "main-theorem",
+            "title": "§6: Main Theorem",
+            "startLine": 397,
+            "endLine": 434,
+            "summary": "cos40_gal_card: |Gal(8X³−6X+1/ℚ)| = 3.",
+            "mathContext": "$|\\text{Gal}(p)|=\\text{finrank}_{\\mathbb{Q}}(\\text{SplittingField})=3$."
+        }
     ],
-    "badge": "mathlib",
-    "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 434,
-    "assumptions": "None. All results proved from Mathlib axioms only.",
-    "dateAdded": "2026-04-13",
-    "mathlib_version": "4.26.0",
-    "originalContributions": [
-      "Proof that 8X³−6X+1 is irreducible over ℚ via Eisenstein criterion on Y³+6Y²+9Y+3",
-      "Root images: β=2α²−1 (cos 80°), γ=−2α²−α+1 (cos 160°) proved as ring identities",
-      "Factored form identity: 8a³−6a+1 = 8(a−α)(a−β)(a−γ) when 8α³−6α+1=0",
-      "Splitting field degree 3 theorem for 8X³−6X+1",
-      "Main theorem: |Gal(8X³−6X+1/ℚ)| = 3"
+    "conclusion": {
+        "summary": "The Galois group of 8X³−6X+1 (minimal polynomial of cos(40°)) over ℚ has order exactly 3. The proof uses Eisenstein irreducibility and the splitting field structure theorem. This completes the Galois group computation for all three polynomials arising from cos(3θ)=±1/2: the θ=20° case (8X³−6X−1, already in gallery), the θ=40° case (8X³−6X+1, this entry), and the cos(π/7) case (8X³−4X²−4X+1).",
+        "openQuestions": [
+            "Can the Galois group computation be generalized to cos(2π/p) for all odd primes p, showing |Gal| = (p-1)/2 and the group is cyclic?",
+            "Is there a uniform Lean proof template that handles all cos(π/p) cases simultaneously via cyclotomic field theory?"
+        ],
+        "implications": "Together with AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01, this establishes the Galois group for three classical cubic polynomials arising from angle trisection. All three have |Gal|=3 (cyclic of order 3), confirming the general pattern for irreducible cubics with three real roots and square discriminant."
+    },
+    "crossReferences": [
+        {
+            "targetId": "angle-trisection-cos-20-gal",
+            "relationship": "sibling",
+            "description": "cos(20°) = cos(π/9) case: 8X³−6X−1, same method, |Gal|=3"
+        },
+        {
+            "targetId": "angle-trisection-cos-20-gal-oq-01",
+            "relationship": "sibling",
+            "description": "cos(π/7) case: 8X³−4X²−4X+1, same method, |Gal|=3"
+        },
+        {
+            "targetId": "angle-trisection",
+            "relationship": "application",
+            "description": "The Galois group order 3 proves non-constructibility for 40° trisection"
+        },
+        {
+            "targetId": "angle-trisection-oq-02-oq-04-oq-01",
+            "relationship": "related",
+            "description": "Tower-Galois Equivalence: proves abstractly that constructibility requires a Galois 2-group; this file provides a concrete order-3 obstruction demonstrating the non-2-group case that the abstract theory characterizes as non-constructible"
+        }
     ],
-    "theoremCount": 5
-  },
-  "overview": {
-    "historicalContext": "The impossibility of angle trisection by compass and straightedge was proved by Wantzel (1837), using the then-new theory of algebraic extensions. The key insight: a 60° angle cannot be trisected because 20° has cosine satisfying the irreducible cubic 8X³−6X−1 = 0, and [ℚ(cos(20°)):ℚ] = 3 is not a power of 2. Galois theory, developed by Évariste Galois before his death in 1832 (but published posthumously in 1846), gave a more conceptual framework: the Galois group of the minimal polynomial determines constructibility.\n\nThe polynomial 8X³−6X+1 is the minimal polynomial of cos(40°) = cos(2π/9) over ℚ. Its three roots are cos(40°), cos(80°), cos(160°), arising from the triple-angle identity cos(3·40°) = cos(120°) = −1/2. The Eisenstein irreducibility argument uses the shift Y=2X−2, which transforms the polynomial into Y³+6Y²+9Y+3 — Eisenstein at p=3. The analogous shift Y=2X+2 works for the cos(20°) polynomial 8X³−6X−1. Both shifts are discovered by looking at where the polynomial takes the value 0: the roots of 8X³−6X±1 are close to ±1/2, and centering the variable near these values produces the p-divisibility structure needed for Eisenstein.\n\nThis result is part of a family: the Galois groups of 8X³−6X−1 (cos(20°)/cos(π/9)), 8X³−6X+1 (cos(40°)/cos(2π/9)), and 8X³−4X²−4X+1 (cos(π/7)) all have order 3. In all three cases, the splitting field is a cyclic extension of degree 3 over ℚ, and the Galois group is ℤ/3ℤ. This is the minimal non-trivial case of the general pattern for cos(2π/p) with odd prime p: the Galois group is cyclic of order (p−1)/2 = 1, 3, 5, ... for p = 3, 7, 11, ...",
-    "problemStatement": "Prove that the Galois group of 8X³−6X+1 over ℚ has cardinality 3. Equivalently, the splitting field of 8X³−6X+1 has degree 3 over ℚ, and the extension is cyclic of order 3.",
-    "proofStrategy": "1. Prove root_image_beta and root_image_gamma: if 8α³−6α+1=0, then β=2α²−1 and γ=−2α²−α+1 are also roots (pure ring identities). 2. Prove 8X³−6X+1 irreducible by Eisenstein: the substitution Y=2X−2 gives Y³+6Y²+9Y+3 which is Eisenstein at 3. 3. Show all roots lie in ℚ(α) via the factored form identity. 4. Conclude [SplittingField:ℚ]=3, hence |Gal|=3.",
-    "keyInsights": [
-      "The double-angle formula cos(80°)=2cos²(40°)−1 directly gives β=2α²−1 as a polynomial in α.",
-      "Since α+β+γ=0 by Vieta (the X² coefficient of 8X³−6X+1 is 0), γ=−α−β=−2α²−α+1.",
-      "The Eisenstein shift uses Y=2X−2 (not Y=2X+2 as for cos(20°)), reflecting the sign change in the constant term: (2X−2)³+6(2X−2)²+9(2X−2)+3 = 8X³−6X+1.",
-      "The factored form identity 8a³−6a+1=8(a−α)(a−β)(a−γ) has ring-theory cofactor ((4α+2)·a+(−4α²−2α+1))·(8α³−6α+1), enabling the splitting field argument.",
-      "The `CommRing R` generality in `root_image_beta/gamma` is not just elegance: it enables direct application in the splitting field (a field extension of ℚ), and in polynomial quotient rings ℚ[X]/(p), where abstract roots live without needing real number coordinates."
+    "references": [
+        {
+            "author": "Wantzel, P.L.",
+            "title": "Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas",
+            "year": 1837,
+            "note": "First proof of impossibility of angle trisection; degree argument"
+        },
+        {
+            "author": "Cox, D.A.",
+            "title": "Galois Theory",
+            "year": 2004,
+            "note": "Chapter on constructibility and Galois groups of cubic polynomials"
+        }
     ],
-    "prerequisites": [
-      "AngleTrisectionCos20Gal.lean (structural template)",
-      "Polynomial.irreducible_of_eisenstein_criterion (Mathlib)",
-      "Polynomial.Gal.card_of_separable (Mathlib)",
-      "IntermediateField.adjoin.finrank (Mathlib)"
-    ]
-  },
-  "sections": [
-    {
-      "id": "ring-identities",
-      "title": "§1: Root Images",
-      "startLine": 34,
-      "endLine": 58,
-      "summary": "Ring identities showing β=2α²−1 and γ=−2α²−α+1 are roots when α is.",
-      "mathContext": "If $8\\alpha^3-6\\alpha+1=0$, then $\\beta=2\\alpha^2-1$ satisfies $8(2\\alpha^2-1)^3-6(2\\alpha^2-1)+1=(8\\alpha^3-6\\alpha-1)(8\\alpha^3-6\\alpha+1)=0$. Similarly for $\\gamma=-2\\alpha^2-\\alpha+1$ with cofactor $-8\\alpha^3-12\\alpha^2+3$."
+    "leanFile": {
+        "imports": [
+            "Mathlib"
+        ],
+        "namespace": "AngleTrisectionCos20GalOQ03",
+        "lineCount": 434,
+        "axiomCount": 0,
+        "theoremCount": 32,
+        "definitionCount": 0,
+        "path": "Proofs/AngleTrisectionCos20GalOQ03.lean",
+        "sorries": 0
     },
-    {
-      "id": "irreducibility",
-      "title": "§2: Irreducibility via Eisenstein",
-      "startLine": 62,
-      "endLine": 200,
-      "summary": "8X³−6X+1 is irreducible over ℚ via Eisenstein criterion on Y³+6Y²+9Y+3.",
-      "mathContext": "The substitution $Y=2X-2$ (inverse $X=(Y+2)/2$) transforms $r(Y)=Y^3+6Y^2+9Y+3$ to $8X^3-6X+1$. Since $r$ is Eisenstein at $p=3$ (with $3|6,3|9,3|3$ and $9\\nmid 3$), it is irreducible over $\\mathbb{Z}$, hence over $\\mathbb{Q}$ by Gauss's lemma."
-    },
-    {
-      "id": "splitting-field-structure",
-      "title": "§3-4: Splitting Field Structure",
-      "startLine": 204,
-      "endLine": 310,
-      "summary": "Factorization over ℚ(α): shows β and γ are the other two roots, all roots lie in ℚ(α), and establishes the splitting field equals ℚ(α).",
-      "mathContext": "The factored form $8a^3-6a+1=8(a-\\alpha)(a-\\beta)(a-\\gamma)$ shows every root of $p$ lies in $\\mathbb{Q}(\\alpha)$, so $\\text{SplittingField}(p) = \\mathbb{Q}(\\alpha)$."
-    },
-    {
-      "id": "splitting-field-degree",
-      "title": "§5: Galois Degree Bounds",
-      "startLine": 311,
-      "endLine": 395,
-      "summary": "Galois group order bounds: |Gal| divides and equals [SplittingField:ℚ] = 3. Combines finrank tower law with deg-p = 3 and splitting field degree argument.",
-      "mathContext": "$[\\mathbb{Q}(\\alpha):\\mathbb{Q}]=3$ equals $[\\text{SplittingField}:\\mathbb{Q}]$, so $|\\text{Gal}(p)|=3$."
-    },
-    {
-      "id": "main-theorem",
-      "title": "§6: Main Theorem",
-      "startLine": 397,
-      "endLine": 434,
-      "summary": "cos40_gal_card: |Gal(8X³−6X+1/ℚ)| = 3.",
-      "mathContext": "$|\\text{Gal}(p)|=\\text{finrank}_{\\mathbb{Q}}(\\text{SplittingField})=3$."
-    }
-  ],
-  "conclusion": {
-    "summary": "The Galois group of 8X³−6X+1 (minimal polynomial of cos(40°)) over ℚ has order exactly 3. The proof uses Eisenstein irreducibility and the splitting field structure theorem. This completes the Galois group computation for all three polynomials arising from cos(3θ)=±1/2: the θ=20° case (8X³−6X−1, already in gallery), the θ=40° case (8X³−6X+1, this entry), and the cos(π/7) case (8X³−4X²−4X+1).",
-    "openQuestions": [
-      "Can the Galois group computation be generalized to cos(2π/p) for all odd primes p, showing |Gal| = (p-1)/2 and the group is cyclic?",
-      "Is there a uniform Lean proof template that handles all cos(π/p) cases simultaneously via cyclotomic field theory?"
-    ],
-    "implications": "Together with AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01, this establishes the Galois group for three classical cubic polynomials arising from angle trisection. All three have |Gal|=3 (cyclic of order 3), confirming the general pattern for irreducible cubics with three real roots and square discriminant."
-  },
-  "crossReferences": [
-    {
-      "targetId": "angle-trisection-cos-20-gal",
-      "relationship": "sibling",
-      "description": "cos(20°) = cos(π/9) case: 8X³−6X−1, same method, |Gal|=3"
-    },
-    {
-      "targetId": "angle-trisection-cos-20-gal-oq-01",
-      "relationship": "sibling",
-      "description": "cos(π/7) case: 8X³−4X²−4X+1, same method, |Gal|=3"
-    },
-    {
-      "targetId": "angle-trisection",
-      "relationship": "application",
-      "description": "The Galois group order 3 proves non-constructibility for 40° trisection"
-    },
-    {
-      "targetId": "angle-trisection-oq-02-oq-04-oq-01",
-      "relationship": "related",
-      "description": "Tower-Galois Equivalence: proves abstractly that constructibility requires a Galois 2-group; this file provides a concrete order-3 obstruction demonstrating the non-2-group case that the abstract theory characterizes as non-constructible"
-    }
-  ],
-  "references": [
-    {
-      "author": "Wantzel, P.L.",
-      "title": "Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas",
-      "year": 1837,
-      "note": "First proof of impossibility of angle trisection; degree argument"
-    },
-    {
-      "author": "Cox, D.A.",
-      "title": "Galois Theory",
-      "year": 2004,
-      "note": "Chapter on constructibility and Galois groups of cubic polynomials"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "namespace": "AngleTrisectionCos20GalOQ03",
-    "lineCount": 434,
-    "axiomCount": 0,
-    "theoremCount": 5,
-    "definitionCount": 0,
-    "path": "Proofs/AngleTrisectionCos20GalOQ03.lean",
     "sorries": 0
-  },
-  "sorries": 0
 }

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -1,323 +1,323 @@
 {
-  "id": "ballot-problem-oq-01",
-  "title": "Generalized Ballot Problem: k-Fold Dominance",
-  "slug": "ballot-problem-oq-01",
-  "description": "The generalized ballot problem: in an election where candidate A must maintain more than k times the votes of candidate B throughout counting, the probability is (a - kb)/(a + b). Formalized using lattice paths and cyclic rotations.",
-  "meta": {
-    "author": "Bertrand (1887), generalized by Dvoretzky-Motzkin (1947)",
-    "sourceUrl": "https://github.com/leanprover-community/mathlib4/blob/master/Archive/Wiedijk100Theorems/BallotProblem.lean",
-    "date": "1947",
-    "status": "verified",
-    "proofRepoPath": "Proofs/BallotProblemOQ01.lean",
-    "tags": [
-      "combinatorics",
-      "probability",
-      "lattice-paths",
-      "cycle-lemma",
-      "generalization",
-      "research"
+    "id": "ballot-problem-oq-01",
+    "title": "Generalized Ballot Problem: k-Fold Dominance",
+    "slug": "ballot-problem-oq-01",
+    "description": "The generalized ballot problem: in an election where candidate A must maintain more than k times the votes of candidate B throughout counting, the probability is (a - kb)/(a + b). Formalized using lattice paths and cyclic rotations.",
+    "meta": {
+        "author": "Bertrand (1887), generalized by Dvoretzky-Motzkin (1947)",
+        "sourceUrl": "https://github.com/leanprover-community/mathlib4/blob/master/Archive/Wiedijk100Theorems/BallotProblem.lean",
+        "date": "1947",
+        "status": "verified",
+        "proofRepoPath": "Proofs/BallotProblemOQ01.lean",
+        "tags": [
+            "combinatorics",
+            "probability",
+            "lattice-paths",
+            "cycle-lemma",
+            "generalization",
+            "research"
+        ],
+        "badge": "mathlib",
+        "sorries": 0,
+        "mathlibDependencies": [
+            {
+                "theorem": "Ballot.countedSequence",
+                "description": "Classical ballot sequence definition (k=1 case)",
+                "module": "Archive.Wiedijk100Theorems.BallotProblem"
+            },
+            {
+                "theorem": "List.perm_iff_count",
+                "description": "Permutation characterized by equal counts",
+                "module": "Mathlib.Data.List.Perm"
+            }
+        ],
+        "originalContributions": [
+            "Generalized ballot sequence definition for arbitrary k-fold dominance",
+            "Lattice path model with +1 upsteps and -k downsteps",
+            "Cyclic rotation infrastructure: sum/length/membership preservation",
+            "Prefix sum relation for cyclic rotations (both wrapping and non-wrapping cases)",
+            "Connection to classical ballot problem (k=1 reduction)",
+            "Permutation characterization of ballot sequences"
+        ],
+        "dateAdded": "2026-02-10",
+        "axiomCount": 0,
+        "lineCount": 789,
+        "assumptions": "No axioms. Fully verified — all sorries eliminated including the generalized counting formula via binomial coefficient identities.",
+        "mathlib_version": "4.26.0",
+        "theoremCount": 44
+    },
+    "overview": {
+        "historicalContext": "The classical Ballot Problem was posed by Joseph Bertrand in 1887 in the *Comptes Rendus*: if candidate A receives $p$ votes and B receives $q$ votes ($p > q$), the probability that A leads throughout counting is $(p-q)/(p+q)$. Désiré André gave the first proof using the **reflection principle** (1887), mapping unfavorable sequences to their reflections across the axis. W.A. Whitworth independently discovered the result using a direct combinatorial argument. In 1947, Aryeh Dvoretzky and Theodore Motzkin proved the **Cycle Lemma** in the *Proceedings of the National Academy of Sciences*, which gives a far more general and elegant proof: for any integer sequence with positive sum $S$ and length $n$, exactly $S$ of its $n$ cyclic rotations have all positive prefix sums. This immediately implies the ballot theorem and its $k$-fold generalization. The cycle lemma has since found applications in lattice path enumeration, queueing theory, and the analysis of random trees (Raney's theorem).",
+        "problemStatement": "**Generalized Ballot Theorem**: In an election where candidate A receives $a$ votes and candidate B receives $b$ votes, with $a > kb$ for a positive integer $k$, the probability that A always has more than $k$ times as many votes as B throughout the counting is:\n\n$$P = \\frac{a - kb}{a + b}$$\n\nWhen $k = 1$, this reduces to the classical formula $P = (p-q)/(p+q)$.",
+        "text": "A 789-line fully verified formalization of the generalized ballot problem for $k$-fold dominance, proving the Dvoretzky-Motzkin cycle lemma and the generalized counting formula. The file models vote counting as a lattice path with $+1$ upsteps (A-votes) and $-k$ downsteps (B-votes), defines $\\text{kCountedSequence}(k,a,b)$ as the set of valid sequences, and characterizes them as permutations of $[1,\\ldots,1,-k,\\ldots,-k]$. The core infrastructure develops cyclic rotations $\\text{rotate}(l,i) = l[i:] \\| l[:i]$, proves the prefix sum relation $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$, and defines $\\text{goodRotations}$ (rotations with all positive prefix sums). The cycle lemma $|\\text{goodRotations}| = a - kb$ is proved by injection ($i \\mapsto \\sigma(i) - \\min(\\sigma)$ into $\\{0,\\ldots,S-1\\}$) for the upper bound and by `levelPos` surjection (a discrete IVT exploiting $+1$ steps) for the lower bound. The generalized counting formula is proved via binomial coefficient identities: $b \\cdot C(a+b,a) = (a+b) \\cdot C(a+b-1,a)$ and $a \\cdot C(a+b-1,a) = b \\cdot C(a+b-1,a-1)$, establishing divisibility and the closed form. Validates against Mathlib's Wiedijk #30 via $\\text{kCountedSequence}(1,a,b) = \\text{Ballot.countedSequence}(a,b)$.",
+        "proofStrategy": "**Lattice Path Model + Cycle Lemma**:\n\n1. Model vote counting as a lattice path: each A-vote is a +1 step, each B-vote is a $-k$ step\n2. The condition 'A has > k times B's votes' equals the path staying strictly above the x-axis\n3. Use the Dvoretzky-Motzkin Cycle Lemma: for a sequence with positive sum $S$ and length $n$, exactly $S$ of the $n$ cyclic rotations have all positive prefix sums\n4. Apply to ballot sequences: $S = a - kb$, $n = a + b$, giving the fraction of good orderings",
+        "keyInsights": [
+            "The **Dvoretzky-Motzkin cycle lemma** unifies all ballot-type results: exactly $S$ of $n$ cyclic rotations have all positive prefix sums, immediately giving $P = S/n = (a - kb)/(a + b)$",
+            "**Cyclic rotation preserves** the multiset of values, so all rotations of a ballot sequence remain in $\\text{kCountedSequence}(k, a, b)$ — a crucial invariant enabling the counting argument",
+            "The **prefix sum relation** $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$ (non-wrapping) connects rotated prefix sums to original ones, reducing good rotation analysis to prefix sum arithmetic",
+            "The proof uses a **sandwich argument**: an injection into $\\{0, \\ldots, S-1\\}$ gives $|\\text{goodRotations}| \\leq S$, while a surjection via `levelPos` (a discrete IVT argument exploiting $+1$ steps) gives $|\\text{goodRotations}| \\geq S$",
+            "The **rightmost minimum** of the prefix sum sequence is always a good rotation, providing the existence base case that bootstraps the full counting argument",
+            "**Catalan number connection**: When $k = 1$ and $a = b + 1$, the number of good sequences equals $\\frac{1}{a+b} \\binom{a+b}{a} = \\frac{1}{2b+1} \\binom{2b+1}{b} = C_b$ (the $b$th Catalan number). The cycle lemma provides the cleanest proof of the Catalan number formula: out of $2n+1$ cyclic rotations of a sequence with sum 1, exactly 1 has all positive prefix sums, so $C_n = \\frac{1}{2n+1} \\binom{2n+1}{n}$",
+            "**The $k$-fold generalization changes the geometry**: For $k = 1$, the barrier is the $x$-axis and downsteps are $-1$ (Dyck paths). For $k > 1$, downsteps are $-k$, making the path drop steeply — this is why $a > kb$ is required for positive probability, not just $a > b$. The ratio $(a - kb)/(a + b)$ decreases as $k$ increases, reflecting the increasingly stringent dominance condition"
+        ],
+        "prerequisites": [
+            "List combinatorics (List.count, List.perm, List.take, List.drop)",
+            "Integer arithmetic and prefix sums",
+            "Finset theory (Finset.card, Finset.filter, injections/surjections for cardinality bounds)",
+            "Basic probability (counting favorable outcomes over total outcomes)",
+            "Cycle lemma / cyclic permutation arguments"
+        ]
+    },
+    "sections": [
+        {
+            "id": "preamble",
+            "title": "Problem Statement and Imports",
+            "startLine": 1,
+            "endLine": 60,
+            "summary": "Module docstring establishing the generalized ballot problem for $k$-fold dominance, imports from `Archive.Wiedijk100Theorems.BallotProblem` and `Mathlib.Tactic`",
+            "mathContext": "Imports Mathlib's Wiedijk #30 (Ballot Problem) for the classical $k=1$ case and validation. The generalization: probability of $k$-fold dominance is $(a - kb)/(a + b)$ rather than $(p-q)/(p+q)$."
+        },
+        {
+            "id": "definitions",
+            "title": "Part I: Generalized Ballot Sequences",
+            "startLine": 61,
+            "endLine": 68,
+            "summary": "Defines $\\text{kCountedSequence}(k,a,b)$ (lists with $a$ copies of $+1$ and $b$ copies of $-k$) and $\\text{kStaysPositive}$ (all prefix sums positive)",
+            "mathContext": "$\\text{kCountedSequence}(k,a,b) = \\{l : l.\\text{count}(1) = a,\\, l.\\text{count}(-k) = b\\}$. The lattice path model: $+1$ steps for A-votes, $-k$ steps for B-votes. The condition $\\text{kStaysPositive}$ means all prefix sums $\\sigma(j) = \\sum_{i=1}^{j} l_i > 0$ for $j = 1, \\ldots, n$."
+        },
+        {
+            "id": "algebraic-lemmas",
+            "title": "Part II: Core Algebraic Lemmas",
+            "startLine": 69,
+            "endLine": 102,
+            "summary": "Proves $\\sum l = \\text{count}(1) - k \\cdot \\text{count}(-k)$ and $|l| = \\text{count}(1) + \\text{count}(-k)$ by list induction",
+            "mathContext": "$S = \\sum l = a - kb$ (net displacement), $n = |l| = a + b$ (total steps). These identities are the algebraic backbone: the cycle lemma counts exactly $S$ good rotations out of $n$ total, giving $P = S/n = (a-kb)/(a+b)$."
+        },
+        {
+            "id": "basic-properties",
+            "title": "Part III: Basic Properties",
+            "startLine": 103,
+            "endLine": 149,
+            "summary": "Derives sum $= a - kb$, length $= a + b$, permutation characterization $l \\sim \\text{replicate}(a,1) \\mathbin{\\|} \\text{replicate}(b,-k)$, finiteness, and nonemptiness",
+            "mathContext": "A $k$-ballot sequence $l$ is fully determined by its permutation class: $l \\sim [\\underbrace{1,\\ldots,1}_{a}, \\underbrace{-k,\\ldots,-k}_{b}]$. The finiteness proof uses the permutation characterization to bound the set size by $\\binom{a+b}{a}$ (the multinomial coefficient)."
+        },
+        {
+            "id": "classical-connection",
+            "title": "Part IV: Connection to Classical Ballot Problem",
+            "startLine": 150,
+            "endLine": 159,
+            "summary": "Shows $\\text{kCountedSequence}(1, a, b) = \\text{Ballot.countedSequence}(a, b)$ via `simpa`, validating against Wiedijk #30",
+            "mathContext": "When $k = 1$: a $+1/-1$ lattice path with $a$ up-steps and $b$ down-steps reduces to the classical ballot sequence. The formula $(a - 1 \\cdot b)/(a+b) = (p-q)/(p+q)$ recovers Bertrand's 1887 result."
+        },
+        {
+            "id": "ballot-theorem",
+            "title": "Part V: The Generalized Ballot Theorem",
+            "startLine": 160,
+            "endLine": 182,
+            "summary": "Proves the generalized counting formula via binomial coefficient identities and establishes $P = (a - kb)/(a + b) > 0$; verified examples with `norm_num`",
+            "mathContext": "The counting formula: $\\exists\\, g,\\; g \\cdot (a+b) = (a-kb) \\cdot \\binom{a+b}{a}$, proved via the identities $b \\cdot \\binom{a+b}{a} = (a+b) \\cdot \\binom{a+b-1}{a}$ and $a \\cdot \\binom{a+b-1}{a} = b \\cdot \\binom{a+b-1}{a-1}$ (both from `Nat.succ_mul_choose_eq`), establishing that $b \\mid (a-kb) \\cdot \\binom{a+b-1}{a}$ and yielding the witness $g = (a-kb) \\cdot \\binom{a+b-1}{a} / b$."
+        },
+        {
+            "id": "cyclic-rotations",
+            "title": "Part VII: Cyclic Rotation Infrastructure",
+            "startLine": 183,
+            "endLine": 236,
+            "summary": "Defines $\\text{rotate}(l, i) = l[i:] \\mathbin{\\|} l[:i]$ and proves sum/length preservation, identity, membership in kCountedSequence, and composition",
+            "mathContext": "The cyclic rotation $\\text{rot}(l, i) = l[i:] \\mathbin{\\|} l[:i]$ is the key symmetry operation. Invariant: $\\text{rot}(l, i)$ has the same multiset of values as $l$, so it remains in $\\text{kCountedSequence}(k, a, b)$. The $n$ rotations of $l$ partition into 'good' (all prefix sums positive) and 'bad' — the cycle lemma counts exactly $S = a - kb$ good ones."
+        },
+        {
+            "id": "prefix-sums",
+            "title": "Prefix Sum Relations",
+            "startLine": 237,
+            "endLine": 334,
+            "summary": "Proves the key relation $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$ (non-wrapping) or $\\sigma(i+j-n) + S - \\sigma(i)$ (wrapping); defines `prefixSum`, doubled periodicity, `isGoodRotation`, and `goodRotations`",
+            "mathContext": "The prefix sum relation is the technical heart: $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$ for $i+j \\leq n$, and $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j-n) + S - \\sigma(i)$ for $i+j > n$. This converts the problem of counting good rotations into prefix sum arithmetic on the original sequence."
+        },
+        {
+            "id": "rightmost-minimum",
+            "title": "Rightmost Minimum Infrastructure",
+            "startLine": 335,
+            "endLine": 420,
+            "summary": "Defines `rightmostMinPos` as the last position achieving $\\min(\\sigma)$; proves it is a good rotation when $S > 0$, giving $|\\text{goodRotations}| \\geq 1$",
+            "mathContext": "The rightmost minimum $i^* = \\max\\{i : \\sigma(i) = \\min_j \\sigma(j)\\}$ is always a good rotation: rotating to start after $i^*$ places the minimum at the beginning, so all subsequent prefix sums exceed it. This existence argument bootstraps the cycle lemma's lower bound."
+        },
+        {
+            "id": "upper-bound",
+            "title": "Cycle Lemma Upper Bound",
+            "startLine": 421,
+            "endLine": 515,
+            "summary": "Proves $|\\text{goodRotations}| \\leq S$ via an injection $i \\mapsto \\sigma(i) - \\min(\\sigma)$ from good rotations into $\\{0, \\ldots, S-1\\}$, using prefix sum strict monotonicity and injectivity",
+            "mathContext": "The injection $f(i) = \\sigma(i) - \\min(\\sigma)$ maps good rotations to $\\{0, \\ldots, S-1\\}$. Injectivity: if $f(i_1) = f(i_2)$, then $\\sigma(i_1) = \\sigma(i_2)$, and good rotation uniqueness forces $i_1 = i_2$. Image bound: $0 \\leq f(i) < S$ by definition of $\\min(\\sigma)$ and the total sum constraint."
+        },
+        {
+            "id": "lower-bound",
+            "title": "Cycle Lemma Lower Bound and Main Theorem",
+            "startLine": 516,
+            "endLine": 774,
+            "summary": "Proves $|\\text{goodRotations}| \\geq S$ via `levelPos` surjection (discrete IVT exploiting $+1$ steps); combines with upper bound to prove the **cycle lemma**: $|\\text{goodRotations}| = a - kb$; includes `native_decide` verification examples; culminates in `cycle_lemma`: $|\\text{goodRotations}| = a - kb$ via `le_antisymm`",
+            "mathContext": "The sandwich: injection gives $|\\text{goodRotations}| \\leq S$, surjection gives $|\\text{goodRotations}| \\geq S$, so $|\\text{goodRotations}| = S = a - kb$. The surjection uses a discrete IVT: for each level $v \\in [\\min(\\sigma), \\min(\\sigma)+S)$, find position $i$ with $\\sigma(i) = v$ (exploiting that $+1$ steps can only increase by 1), and this position gives a good rotation."
+        },
+        {
+            "id": "lattice-paths",
+            "title": "Part VIII: Lattice Path Interpretation",
+            "startLine": 781,
+            "endLine": 789,
+            "summary": "Interprets prefix sums as lattice path heights: A-vote $= (+1)$ step, B-vote $= (-k)$ step; path stays above $x$-axis iff all prefix sums are positive",
+            "mathContext": "The lattice path interpretation: a ballot sequence $l = [l_1, \\ldots, l_n]$ defines a path in $\\mathbb{Z}^2$ from $(0,0)$ to $(n, a-kb)$, with height at time $j$ equal to $\\sigma(j) = \\sum_{i=1}^{j} l_i$. The $k$-fold dominance condition 'A always has > k times B's votes' translates to $\\sigma(j) > 0$ for all $j$, i.e., the path stays strictly above the $x$-axis."
+        },
+        {
+            "id": "verification",
+            "title": "Verification Examples",
+            "startLine": 776,
+            "endLine": 779,
+            "summary": "Three `native_decide` examples verifying the cycle lemma for small ballot sequences: $[1,1,-1]$, $[1,1,1,-1,-1]$, $[1,1,1,-1]$",
+            "mathContext": "Brute-force verification of $|\\text{goodRotations}| = a - kb$ for concrete sequences, independent of the cycle lemma proof."
+        }
     ],
-    "badge": "mathlib",
-    "sorries": 0,
-    "mathlibDependencies": [
-      {
-        "theorem": "Ballot.countedSequence",
-        "description": "Classical ballot sequence definition (k=1 case)",
-        "module": "Archive.Wiedijk100Theorems.BallotProblem"
-      },
-      {
-        "theorem": "List.perm_iff_count",
-        "description": "Permutation characterized by equal counts",
-        "module": "Mathlib.Data.List.Perm"
-      }
+    "conclusion": {
+        "summary": "A fully verified 789-line formalization of the generalized ballot problem for k-fold dominance. The proof builds from list combinatorics through cyclic rotation infrastructure to a complete proof of the Dvoretzky-Motzkin cycle lemma (|goodRotations| = a - kb) via a sandwich argument: an injection into {0,...,S-1} for the upper bound and a levelPos surjection (discrete IVT) for the lower bound. The generalized counting formula is proved via binomial coefficient identities, and the k=1 case is validated against Mathlib's Wiedijk #30.",
+        "implications": "**Theoretical Significance**: The Dvoretzky-Motzkin cycle lemma is one of the most powerful tools in lattice path combinatorics. It unifies the classical ballot problem, Catalan number identities, and Raney's theorem under a single rotational symmetry argument.\n\n**Applications**:\n1. **Voting theory**: Probability of sustained dominance in elections with weighted votes\n2. **Queueing theory**: Probability that a $k$-server queue never empties — the ballot condition models server utilization exceeding demand\n3. **Random walks**: Paths with asymmetric step sizes ($+1$ and $-k$) staying above a barrier, generalizing Dyck paths ($k=1$)\n4. **Lattice path enumeration**: Counting paths with generalized step constraints, with connections to Catalan numbers ($C_n = \\frac{1}{n+1}\\binom{2n}{n}$ counts Dyck paths of length $2n$)\n5. **Random trees**: Raney's theorem (a corollary of the cycle lemma) counts the number of labeled plane trees, connecting ballot sequences to tree enumeration",
+        "openQuestions": [
+            "**Multi-candidate generalization**: For $m \\geq 3$ candidates with vote counts $a_1 > a_2 > \\cdots > a_m$, what is the probability that candidate 1 leads all others throughout counting? The $m$-candidate ballot problem requires higher-dimensional lattice path analysis — the path must stay in a Weyl chamber rather than above a single line",
+            "**Continuous-time analogue**: The discrete ballot problem has a Brownian motion limit: as $a, b \\to \\infty$ with $a/(a+b) \\to p$, the vote counting process converges to a Brownian bridge. The cycle lemma's rotational argument should have a continuous analog via the arcsine law for Brownian motion",
+            "Can the Catalan number identity $C_n = \\frac{1}{n+1}\\binom{2n}{n}$ be derived directly from the cycle lemma formalization (setting $k=1$, $a=n+1$, $b=n$)? This would connect the ballot problem to tree enumeration via Raney's theorem",
+            "Can the cycle lemma be applied to prove the Chung-Feller theorem: the number of lattice paths from $(0,0)$ to $(2n,0)$ with exactly $k$ upsteps above the $x$-axis is $\\binom{2n}{n}/(n+1)$, independent of $k$?"
+        ]
+    },
+    "crossReferences": [
+        {
+            "targetId": "ballot-problem",
+            "relationship": "extends",
+            "description": "Generalizes the classical ballot problem from 1-fold dominance (p>q always) to k-fold dominance (candidate A always has ≥k× candidate B's votes at every stage)"
+        },
+        {
+            "targetId": "combinations-formula",
+            "relationship": "foundational",
+            "description": "The counting formula for k-ballot sequences uses generalized binomial coefficients — the number of lattice paths with asymmetric step sizes"
+        },
+        {
+            "targetId": "erdos-szekeres",
+            "relationship": "related",
+            "description": "Both are combinatorial results on sequences: Erdős-Szekeres guarantees monotone subsequences, the generalized ballot problem counts sequences satisfying a dominance constraint"
+        },
+        {
+            "targetId": "ballot-problem-oq-01-oq-01",
+            "relationship": "extended-by",
+            "description": "Applies the Dvoretzky-Motzkin cycle lemma with a discrete intermediate value theorem to analyze ballot sequences — extending the k-fold dominance criterion from this file with a rotational symmetry argument that counts favorable cyclic permutations"
+        },
+        {
+            "targetId": "binomial-theorem",
+            "relationship": "foundational",
+            "description": "The binomial coefficient $\\binom{a+b}{a}$ counts the total number of ballot sequences (permutations of $a$ up-steps and $b$ down-steps). The generalized counting formula $|\\text{good}| = \\frac{a-kb}{a+b} \\binom{a+b}{a}$ is proved via the identities $b \\binom{a+b}{a} = (a+b) \\binom{a+b-1}{a}$ and $a \\binom{a+b-1}{a} = b \\binom{a+b-1}{a-1}$, both consequences of the binomial coefficient recursion"
+        },
+        {
+            "targetId": "ballot-problem-oq-02",
+            "relationship": "related",
+            "description": "A companion open question from the ballot problem, extending the classical result along a different dimension"
+        },
+        {
+            "targetId": "ballot-problem-oq-03",
+            "relationship": "related",
+            "description": "Another companion open question from the ballot problem"
+        },
+        {
+            "targetId": "stirling-formula",
+            "relationship": "related",
+            "description": "Stirling's formula $n! \\sim \\sqrt{2\\pi n}(n/e)^n$ gives the asymptotic behavior of the binomial coefficients in the ballot counting formula: $\\binom{a+b}{a} \\sim \\frac{2^{a+b}}{\\sqrt{\\pi(a+b)/2}}$ when $a \\approx b$, connecting the discrete ballot problem to its continuous Brownian motion limit"
+        }
     ],
-    "originalContributions": [
-      "Generalized ballot sequence definition for arbitrary k-fold dominance",
-      "Lattice path model with +1 upsteps and -k downsteps",
-      "Cyclic rotation infrastructure: sum/length/membership preservation",
-      "Prefix sum relation for cyclic rotations (both wrapping and non-wrapping cases)",
-      "Connection to classical ballot problem (k=1 reduction)",
-      "Permutation characterization of ballot sequences"
+    "references": [
+        {
+            "authors": "Bertrand, Joseph",
+            "title": "Solution d'un problème",
+            "year": "1887",
+            "venue": "Comptes Rendus de l'Académie des Sciences, Paris, vol. 105, pp. 369",
+            "note": "Original statement of the classical ballot problem: if A receives p votes and B receives q votes (p > q), the probability that A leads throughout is (p-q)/(p+q)"
+        },
+        {
+            "authors": "André, Désiré",
+            "title": "Solution directe du problème résolu par M. Bertrand",
+            "year": "1887",
+            "venue": "Comptes Rendus de l'Académie des Sciences, Paris, vol. 105, pp. 436–437",
+            "note": "First proof of Bertrand's ballot theorem using the reflection principle — mapping unfavorable sequences to their reflections across the axis"
+        },
+        {
+            "authors": "Dvoretzky, Aryeh; Motzkin, Theodore",
+            "title": "A problem of arrangements",
+            "year": "1947",
+            "venue": "Duke Mathematical Journal, vol. 14, no. 2, pp. 305–313",
+            "note": "Proved the Cycle Lemma: for any integer sequence with positive sum S and length n, exactly S of its n cyclic rotations have all positive prefix sums. This is the central result formalized in this file"
+        },
+        {
+            "authors": "Raney, George N.",
+            "title": "Functional composition patterns and power series reversion",
+            "year": "1960",
+            "venue": "Transactions of the American Mathematical Society, vol. 94, no. 3, pp. 441–451",
+            "note": "Extended the cycle lemma to count labeled plane trees, establishing the connection between ballot sequences and tree enumeration"
+        },
+        {
+            "authors": "Renault, Marc",
+            "title": "Four proofs of the ballot theorem",
+            "year": "2007",
+            "venue": "Mathematics Magazine, vol. 80, no. 5, pp. 345–352",
+            "note": "Survey of four distinct proof techniques for the ballot theorem: André's reflection principle, cyclic permutation (cycle lemma), induction, and the time-reversal argument"
+        },
+        {
+            "authors": "Flajolet, Philippe; Sedgewick, Robert",
+            "title": "Analytic Combinatorics",
+            "year": "2009",
+            "venue": "Cambridge University Press, Chapter II",
+            "note": "Modern treatment of lattice path combinatorics and generating functions, with the cycle lemma as a key tool for counting paths with constraints"
+        }
     ],
-    "dateAdded": "2026-02-10",
-    "axiomCount": 0,
-    "lineCount": 789,
-    "assumptions": "No axioms. Fully verified — all sorries eliminated including the generalized counting formula via binomial coefficient identities.",
-    "mathlib_version": "4.26.0",
-    "theoremCount": 44
-  },
-  "overview": {
-    "historicalContext": "The classical Ballot Problem was posed by Joseph Bertrand in 1887 in the *Comptes Rendus*: if candidate A receives $p$ votes and B receives $q$ votes ($p > q$), the probability that A leads throughout counting is $(p-q)/(p+q)$. Désiré André gave the first proof using the **reflection principle** (1887), mapping unfavorable sequences to their reflections across the axis. W.A. Whitworth independently discovered the result using a direct combinatorial argument. In 1947, Aryeh Dvoretzky and Theodore Motzkin proved the **Cycle Lemma** in the *Proceedings of the National Academy of Sciences*, which gives a far more general and elegant proof: for any integer sequence with positive sum $S$ and length $n$, exactly $S$ of its $n$ cyclic rotations have all positive prefix sums. This immediately implies the ballot theorem and its $k$-fold generalization. The cycle lemma has since found applications in lattice path enumeration, queueing theory, and the analysis of random trees (Raney's theorem).",
-    "problemStatement": "**Generalized Ballot Theorem**: In an election where candidate A receives $a$ votes and candidate B receives $b$ votes, with $a > kb$ for a positive integer $k$, the probability that A always has more than $k$ times as many votes as B throughout the counting is:\n\n$$P = \\frac{a - kb}{a + b}$$\n\nWhen $k = 1$, this reduces to the classical formula $P = (p-q)/(p+q)$.",
-    "text": "A 789-line fully verified formalization of the generalized ballot problem for $k$-fold dominance, proving the Dvoretzky-Motzkin cycle lemma and the generalized counting formula. The file models vote counting as a lattice path with $+1$ upsteps (A-votes) and $-k$ downsteps (B-votes), defines $\\text{kCountedSequence}(k,a,b)$ as the set of valid sequences, and characterizes them as permutations of $[1,\\ldots,1,-k,\\ldots,-k]$. The core infrastructure develops cyclic rotations $\\text{rotate}(l,i) = l[i:] \\| l[:i]$, proves the prefix sum relation $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$, and defines $\\text{goodRotations}$ (rotations with all positive prefix sums). The cycle lemma $|\\text{goodRotations}| = a - kb$ is proved by injection ($i \\mapsto \\sigma(i) - \\min(\\sigma)$ into $\\{0,\\ldots,S-1\\}$) for the upper bound and by `levelPos` surjection (a discrete IVT exploiting $+1$ steps) for the lower bound. The generalized counting formula is proved via binomial coefficient identities: $b \\cdot C(a+b,a) = (a+b) \\cdot C(a+b-1,a)$ and $a \\cdot C(a+b-1,a) = b \\cdot C(a+b-1,a-1)$, establishing divisibility and the closed form. Validates against Mathlib's Wiedijk #30 via $\\text{kCountedSequence}(1,a,b) = \\text{Ballot.countedSequence}(a,b)$.",
-    "proofStrategy": "**Lattice Path Model + Cycle Lemma**:\n\n1. Model vote counting as a lattice path: each A-vote is a +1 step, each B-vote is a $-k$ step\n2. The condition 'A has > k times B's votes' equals the path staying strictly above the x-axis\n3. Use the Dvoretzky-Motzkin Cycle Lemma: for a sequence with positive sum $S$ and length $n$, exactly $S$ of the $n$ cyclic rotations have all positive prefix sums\n4. Apply to ballot sequences: $S = a - kb$, $n = a + b$, giving the fraction of good orderings",
-    "keyInsights": [
-      "The **Dvoretzky-Motzkin cycle lemma** unifies all ballot-type results: exactly $S$ of $n$ cyclic rotations have all positive prefix sums, immediately giving $P = S/n = (a - kb)/(a + b)$",
-      "**Cyclic rotation preserves** the multiset of values, so all rotations of a ballot sequence remain in $\\text{kCountedSequence}(k, a, b)$ — a crucial invariant enabling the counting argument",
-      "The **prefix sum relation** $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$ (non-wrapping) connects rotated prefix sums to original ones, reducing good rotation analysis to prefix sum arithmetic",
-      "The proof uses a **sandwich argument**: an injection into $\\{0, \\ldots, S-1\\}$ gives $|\\text{goodRotations}| \\leq S$, while a surjection via `levelPos` (a discrete IVT argument exploiting $+1$ steps) gives $|\\text{goodRotations}| \\geq S$",
-      "The **rightmost minimum** of the prefix sum sequence is always a good rotation, providing the existence base case that bootstraps the full counting argument",
-      "**Catalan number connection**: When $k = 1$ and $a = b + 1$, the number of good sequences equals $\\frac{1}{a+b} \\binom{a+b}{a} = \\frac{1}{2b+1} \\binom{2b+1}{b} = C_b$ (the $b$th Catalan number). The cycle lemma provides the cleanest proof of the Catalan number formula: out of $2n+1$ cyclic rotations of a sequence with sum 1, exactly 1 has all positive prefix sums, so $C_n = \\frac{1}{2n+1} \\binom{2n+1}{n}$",
-      "**The $k$-fold generalization changes the geometry**: For $k = 1$, the barrier is the $x$-axis and downsteps are $-1$ (Dyck paths). For $k > 1$, downsteps are $-k$, making the path drop steeply — this is why $a > kb$ is required for positive probability, not just $a > b$. The ratio $(a - kb)/(a + b)$ decreases as $k$ increases, reflecting the increasingly stringent dominance condition"
-    ],
-    "prerequisites": [
-      "List combinatorics (List.count, List.perm, List.take, List.drop)",
-      "Integer arithmetic and prefix sums",
-      "Finset theory (Finset.card, Finset.filter, injections/surjections for cardinality bounds)",
-      "Basic probability (counting favorable outcomes over total outcomes)",
-      "Cycle lemma / cyclic permutation arguments"
-    ]
-  },
-  "sections": [
-    {
-      "id": "preamble",
-      "title": "Problem Statement and Imports",
-      "startLine": 1,
-      "endLine": 60,
-      "summary": "Module docstring establishing the generalized ballot problem for $k$-fold dominance, imports from `Archive.Wiedijk100Theorems.BallotProblem` and `Mathlib.Tactic`",
-      "mathContext": "Imports Mathlib's Wiedijk #30 (Ballot Problem) for the classical $k=1$ case and validation. The generalization: probability of $k$-fold dominance is $(a - kb)/(a + b)$ rather than $(p-q)/(p+q)$."
+    "leanFile": {
+        "imports": [
+            "Archive.Wiedijk100Theorems.BallotProblem",
+            "Mathlib.Tactic"
+        ],
+        "opens": [
+            "List",
+            "Set"
+        ],
+        "namespace": "GeneralizedBallot",
+        "lineCount": 789,
+        "axiomCount": 0,
+        "theoremCount": 57,
+        "definitionCount": 8,
+        "mainTheorems": [
+            {
+                "name": "cycle_lemma",
+                "line": 764,
+                "statement": "(goodRotations l).card = a - k * b",
+                "description": "The Dvoretzky-Motzkin Cycle Lemma: for a ballot sequence l in kCountedSequence(k,a,b) with a > kb, exactly a - kb of its a + b cyclic rotations have all positive prefix sums"
+            },
+            {
+                "name": "generalized_ballot_count",
+                "line": 226,
+                "statement": "∃ good_count, good_count * (a + b) = (a - k * b) * (a + b).choose a",
+                "description": "The generalized counting formula: the number of favorable ballot orderings times (a+b) equals (a-kb) times the binomial coefficient C(a+b, a)"
+            },
+            {
+                "name": "generalized_ballot_prob",
+                "line": 246,
+                "statement": "((a : ℚ) - k * b) / (a + b) > 0",
+                "description": "The probability of k-fold dominance throughout counting is strictly positive when a > kb"
+            },
+            {
+                "name": "kCountedSequence_eq_countedSequence",
+                "line": 152,
+                "statement": "kCountedSequence 1 a b = Ballot.countedSequence a b",
+                "description": "When k=1, the generalized ballot sequence reduces to Mathlib's classical ballot sequence (Wiedijk #30)"
+            },
+            {
+                "name": "path_height_interpretation",
+                "line": 783,
+                "statement": "(l.take i).sum = (l.take i).count 1 - (k : ℤ) * (l.take i).count (-(k : ℤ))",
+                "description": "The lattice path height at step i equals the count of A-votes minus k times the count of B-votes up to that point"
+            }
+        ],
+        "path": "Proofs/BallotProblemOQ01.lean",
+        "sorries": 0
     },
-    {
-      "id": "definitions",
-      "title": "Part I: Generalized Ballot Sequences",
-      "startLine": 61,
-      "endLine": 68,
-      "summary": "Defines $\\text{kCountedSequence}(k,a,b)$ (lists with $a$ copies of $+1$ and $b$ copies of $-k$) and $\\text{kStaysPositive}$ (all prefix sums positive)",
-      "mathContext": "$\\text{kCountedSequence}(k,a,b) = \\{l : l.\\text{count}(1) = a,\\, l.\\text{count}(-k) = b\\}$. The lattice path model: $+1$ steps for A-votes, $-k$ steps for B-votes. The condition $\\text{kStaysPositive}$ means all prefix sums $\\sigma(j) = \\sum_{i=1}^{j} l_i > 0$ for $j = 1, \\ldots, n$."
-    },
-    {
-      "id": "algebraic-lemmas",
-      "title": "Part II: Core Algebraic Lemmas",
-      "startLine": 69,
-      "endLine": 102,
-      "summary": "Proves $\\sum l = \\text{count}(1) - k \\cdot \\text{count}(-k)$ and $|l| = \\text{count}(1) + \\text{count}(-k)$ by list induction",
-      "mathContext": "$S = \\sum l = a - kb$ (net displacement), $n = |l| = a + b$ (total steps). These identities are the algebraic backbone: the cycle lemma counts exactly $S$ good rotations out of $n$ total, giving $P = S/n = (a-kb)/(a+b)$."
-    },
-    {
-      "id": "basic-properties",
-      "title": "Part III: Basic Properties",
-      "startLine": 103,
-      "endLine": 149,
-      "summary": "Derives sum $= a - kb$, length $= a + b$, permutation characterization $l \\sim \\text{replicate}(a,1) \\mathbin{\\|} \\text{replicate}(b,-k)$, finiteness, and nonemptiness",
-      "mathContext": "A $k$-ballot sequence $l$ is fully determined by its permutation class: $l \\sim [\\underbrace{1,\\ldots,1}_{a}, \\underbrace{-k,\\ldots,-k}_{b}]$. The finiteness proof uses the permutation characterization to bound the set size by $\\binom{a+b}{a}$ (the multinomial coefficient)."
-    },
-    {
-      "id": "classical-connection",
-      "title": "Part IV: Connection to Classical Ballot Problem",
-      "startLine": 150,
-      "endLine": 159,
-      "summary": "Shows $\\text{kCountedSequence}(1, a, b) = \\text{Ballot.countedSequence}(a, b)$ via `simpa`, validating against Wiedijk #30",
-      "mathContext": "When $k = 1$: a $+1/-1$ lattice path with $a$ up-steps and $b$ down-steps reduces to the classical ballot sequence. The formula $(a - 1 \\cdot b)/(a+b) = (p-q)/(p+q)$ recovers Bertrand's 1887 result."
-    },
-    {
-      "id": "ballot-theorem",
-      "title": "Part V: The Generalized Ballot Theorem",
-      "startLine": 160,
-      "endLine": 182,
-      "summary": "Proves the generalized counting formula via binomial coefficient identities and establishes $P = (a - kb)/(a + b) > 0$; verified examples with `norm_num`",
-      "mathContext": "The counting formula: $\\exists\\, g,\\; g \\cdot (a+b) = (a-kb) \\cdot \\binom{a+b}{a}$, proved via the identities $b \\cdot \\binom{a+b}{a} = (a+b) \\cdot \\binom{a+b-1}{a}$ and $a \\cdot \\binom{a+b-1}{a} = b \\cdot \\binom{a+b-1}{a-1}$ (both from `Nat.succ_mul_choose_eq`), establishing that $b \\mid (a-kb) \\cdot \\binom{a+b-1}{a}$ and yielding the witness $g = (a-kb) \\cdot \\binom{a+b-1}{a} / b$."
-    },
-    {
-      "id": "cyclic-rotations",
-      "title": "Part VII: Cyclic Rotation Infrastructure",
-      "startLine": 183,
-      "endLine": 236,
-      "summary": "Defines $\\text{rotate}(l, i) = l[i:] \\mathbin{\\|} l[:i]$ and proves sum/length preservation, identity, membership in kCountedSequence, and composition",
-      "mathContext": "The cyclic rotation $\\text{rot}(l, i) = l[i:] \\mathbin{\\|} l[:i]$ is the key symmetry operation. Invariant: $\\text{rot}(l, i)$ has the same multiset of values as $l$, so it remains in $\\text{kCountedSequence}(k, a, b)$. The $n$ rotations of $l$ partition into 'good' (all prefix sums positive) and 'bad' — the cycle lemma counts exactly $S = a - kb$ good ones."
-    },
-    {
-      "id": "prefix-sums",
-      "title": "Prefix Sum Relations",
-      "startLine": 237,
-      "endLine": 334,
-      "summary": "Proves the key relation $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$ (non-wrapping) or $\\sigma(i+j-n) + S - \\sigma(i)$ (wrapping); defines `prefixSum`, doubled periodicity, `isGoodRotation`, and `goodRotations`",
-      "mathContext": "The prefix sum relation is the technical heart: $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j) - \\sigma(i)$ for $i+j \\leq n$, and $\\sigma_{\\text{rot}(i)}(j) = \\sigma(i+j-n) + S - \\sigma(i)$ for $i+j > n$. This converts the problem of counting good rotations into prefix sum arithmetic on the original sequence."
-    },
-    {
-      "id": "rightmost-minimum",
-      "title": "Rightmost Minimum Infrastructure",
-      "startLine": 335,
-      "endLine": 420,
-      "summary": "Defines `rightmostMinPos` as the last position achieving $\\min(\\sigma)$; proves it is a good rotation when $S > 0$, giving $|\\text{goodRotations}| \\geq 1$",
-      "mathContext": "The rightmost minimum $i^* = \\max\\{i : \\sigma(i) = \\min_j \\sigma(j)\\}$ is always a good rotation: rotating to start after $i^*$ places the minimum at the beginning, so all subsequent prefix sums exceed it. This existence argument bootstraps the cycle lemma's lower bound."
-    },
-    {
-      "id": "upper-bound",
-      "title": "Cycle Lemma Upper Bound",
-      "startLine": 421,
-      "endLine": 515,
-      "summary": "Proves $|\\text{goodRotations}| \\leq S$ via an injection $i \\mapsto \\sigma(i) - \\min(\\sigma)$ from good rotations into $\\{0, \\ldots, S-1\\}$, using prefix sum strict monotonicity and injectivity",
-      "mathContext": "The injection $f(i) = \\sigma(i) - \\min(\\sigma)$ maps good rotations to $\\{0, \\ldots, S-1\\}$. Injectivity: if $f(i_1) = f(i_2)$, then $\\sigma(i_1) = \\sigma(i_2)$, and good rotation uniqueness forces $i_1 = i_2$. Image bound: $0 \\leq f(i) < S$ by definition of $\\min(\\sigma)$ and the total sum constraint."
-    },
-    {
-      "id": "lower-bound",
-      "title": "Cycle Lemma Lower Bound and Main Theorem",
-      "startLine": 516,
-      "endLine": 774,
-      "summary": "Proves $|\\text{goodRotations}| \\geq S$ via `levelPos` surjection (discrete IVT exploiting $+1$ steps); combines with upper bound to prove the **cycle lemma**: $|\\text{goodRotations}| = a - kb$; includes `native_decide` verification examples; culminates in `cycle_lemma`: $|\\text{goodRotations}| = a - kb$ via `le_antisymm`",
-      "mathContext": "The sandwich: injection gives $|\\text{goodRotations}| \\leq S$, surjection gives $|\\text{goodRotations}| \\geq S$, so $|\\text{goodRotations}| = S = a - kb$. The surjection uses a discrete IVT: for each level $v \\in [\\min(\\sigma), \\min(\\sigma)+S)$, find position $i$ with $\\sigma(i) = v$ (exploiting that $+1$ steps can only increase by 1), and this position gives a good rotation."
-    },
-    {
-      "id": "lattice-paths",
-      "title": "Part VIII: Lattice Path Interpretation",
-      "startLine": 781,
-      "endLine": 789,
-      "summary": "Interprets prefix sums as lattice path heights: A-vote $= (+1)$ step, B-vote $= (-k)$ step; path stays above $x$-axis iff all prefix sums are positive",
-      "mathContext": "The lattice path interpretation: a ballot sequence $l = [l_1, \\ldots, l_n]$ defines a path in $\\mathbb{Z}^2$ from $(0,0)$ to $(n, a-kb)$, with height at time $j$ equal to $\\sigma(j) = \\sum_{i=1}^{j} l_i$. The $k$-fold dominance condition 'A always has > k times B's votes' translates to $\\sigma(j) > 0$ for all $j$, i.e., the path stays strictly above the $x$-axis."
-    },
-    {
-      "id": "verification",
-      "title": "Verification Examples",
-      "startLine": 776,
-      "endLine": 779,
-      "summary": "Three `native_decide` examples verifying the cycle lemma for small ballot sequences: $[1,1,-1]$, $[1,1,1,-1,-1]$, $[1,1,1,-1]$",
-      "mathContext": "Brute-force verification of $|\\text{goodRotations}| = a - kb$ for concrete sequences, independent of the cycle lemma proof."
-    }
-  ],
-  "conclusion": {
-    "summary": "A fully verified 789-line formalization of the generalized ballot problem for k-fold dominance. The proof builds from list combinatorics through cyclic rotation infrastructure to a complete proof of the Dvoretzky-Motzkin cycle lemma (|goodRotations| = a - kb) via a sandwich argument: an injection into {0,...,S-1} for the upper bound and a levelPos surjection (discrete IVT) for the lower bound. The generalized counting formula is proved via binomial coefficient identities, and the k=1 case is validated against Mathlib's Wiedijk #30.",
-    "implications": "**Theoretical Significance**: The Dvoretzky-Motzkin cycle lemma is one of the most powerful tools in lattice path combinatorics. It unifies the classical ballot problem, Catalan number identities, and Raney's theorem under a single rotational symmetry argument.\n\n**Applications**:\n1. **Voting theory**: Probability of sustained dominance in elections with weighted votes\n2. **Queueing theory**: Probability that a $k$-server queue never empties — the ballot condition models server utilization exceeding demand\n3. **Random walks**: Paths with asymmetric step sizes ($+1$ and $-k$) staying above a barrier, generalizing Dyck paths ($k=1$)\n4. **Lattice path enumeration**: Counting paths with generalized step constraints, with connections to Catalan numbers ($C_n = \\frac{1}{n+1}\\binom{2n}{n}$ counts Dyck paths of length $2n$)\n5. **Random trees**: Raney's theorem (a corollary of the cycle lemma) counts the number of labeled plane trees, connecting ballot sequences to tree enumeration",
-    "openQuestions": [
-      "**Multi-candidate generalization**: For $m \\geq 3$ candidates with vote counts $a_1 > a_2 > \\cdots > a_m$, what is the probability that candidate 1 leads all others throughout counting? The $m$-candidate ballot problem requires higher-dimensional lattice path analysis — the path must stay in a Weyl chamber rather than above a single line",
-      "**Continuous-time analogue**: The discrete ballot problem has a Brownian motion limit: as $a, b \\to \\infty$ with $a/(a+b) \\to p$, the vote counting process converges to a Brownian bridge. The cycle lemma's rotational argument should have a continuous analog via the arcsine law for Brownian motion",
-      "Can the Catalan number identity $C_n = \\frac{1}{n+1}\\binom{2n}{n}$ be derived directly from the cycle lemma formalization (setting $k=1$, $a=n+1$, $b=n$)? This would connect the ballot problem to tree enumeration via Raney's theorem",
-      "Can the cycle lemma be applied to prove the Chung-Feller theorem: the number of lattice paths from $(0,0)$ to $(2n,0)$ with exactly $k$ upsteps above the $x$-axis is $\\binom{2n}{n}/(n+1)$, independent of $k$?"
-    ]
-  },
-  "crossReferences": [
-    {
-      "targetId": "ballot-problem",
-      "relationship": "extends",
-      "description": "Generalizes the classical ballot problem from 1-fold dominance (p>q always) to k-fold dominance (candidate A always has ≥k× candidate B's votes at every stage)"
-    },
-    {
-      "targetId": "combinations-formula",
-      "relationship": "foundational",
-      "description": "The counting formula for k-ballot sequences uses generalized binomial coefficients — the number of lattice paths with asymmetric step sizes"
-    },
-    {
-      "targetId": "erdos-szekeres",
-      "relationship": "related",
-      "description": "Both are combinatorial results on sequences: Erdős-Szekeres guarantees monotone subsequences, the generalized ballot problem counts sequences satisfying a dominance constraint"
-    },
-    {
-      "targetId": "ballot-problem-oq-01-oq-01",
-      "relationship": "extended-by",
-      "description": "Applies the Dvoretzky-Motzkin cycle lemma with a discrete intermediate value theorem to analyze ballot sequences — extending the k-fold dominance criterion from this file with a rotational symmetry argument that counts favorable cyclic permutations"
-    },
-    {
-      "targetId": "binomial-theorem",
-      "relationship": "foundational",
-      "description": "The binomial coefficient $\\binom{a+b}{a}$ counts the total number of ballot sequences (permutations of $a$ up-steps and $b$ down-steps). The generalized counting formula $|\\text{good}| = \\frac{a-kb}{a+b} \\binom{a+b}{a}$ is proved via the identities $b \\binom{a+b}{a} = (a+b) \\binom{a+b-1}{a}$ and $a \\binom{a+b-1}{a} = b \\binom{a+b-1}{a-1}$, both consequences of the binomial coefficient recursion"
-    },
-    {
-      "targetId": "ballot-problem-oq-02",
-      "relationship": "related",
-      "description": "A companion open question from the ballot problem, extending the classical result along a different dimension"
-    },
-    {
-      "targetId": "ballot-problem-oq-03",
-      "relationship": "related",
-      "description": "Another companion open question from the ballot problem"
-    },
-    {
-      "targetId": "stirling-formula",
-      "relationship": "related",
-      "description": "Stirling's formula $n! \\sim \\sqrt{2\\pi n}(n/e)^n$ gives the asymptotic behavior of the binomial coefficients in the ballot counting formula: $\\binom{a+b}{a} \\sim \\frac{2^{a+b}}{\\sqrt{\\pi(a+b)/2}}$ when $a \\approx b$, connecting the discrete ballot problem to its continuous Brownian motion limit"
-    }
-  ],
-  "references": [
-    {
-      "authors": "Bertrand, Joseph",
-      "title": "Solution d'un problème",
-      "year": "1887",
-      "venue": "Comptes Rendus de l'Académie des Sciences, Paris, vol. 105, pp. 369",
-      "note": "Original statement of the classical ballot problem: if A receives p votes and B receives q votes (p > q), the probability that A leads throughout is (p-q)/(p+q)"
-    },
-    {
-      "authors": "André, Désiré",
-      "title": "Solution directe du problème résolu par M. Bertrand",
-      "year": "1887",
-      "venue": "Comptes Rendus de l'Académie des Sciences, Paris, vol. 105, pp. 436–437",
-      "note": "First proof of Bertrand's ballot theorem using the reflection principle — mapping unfavorable sequences to their reflections across the axis"
-    },
-    {
-      "authors": "Dvoretzky, Aryeh; Motzkin, Theodore",
-      "title": "A problem of arrangements",
-      "year": "1947",
-      "venue": "Duke Mathematical Journal, vol. 14, no. 2, pp. 305–313",
-      "note": "Proved the Cycle Lemma: for any integer sequence with positive sum S and length n, exactly S of its n cyclic rotations have all positive prefix sums. This is the central result formalized in this file"
-    },
-    {
-      "authors": "Raney, George N.",
-      "title": "Functional composition patterns and power series reversion",
-      "year": "1960",
-      "venue": "Transactions of the American Mathematical Society, vol. 94, no. 3, pp. 441–451",
-      "note": "Extended the cycle lemma to count labeled plane trees, establishing the connection between ballot sequences and tree enumeration"
-    },
-    {
-      "authors": "Renault, Marc",
-      "title": "Four proofs of the ballot theorem",
-      "year": "2007",
-      "venue": "Mathematics Magazine, vol. 80, no. 5, pp. 345–352",
-      "note": "Survey of four distinct proof techniques for the ballot theorem: André's reflection principle, cyclic permutation (cycle lemma), induction, and the time-reversal argument"
-    },
-    {
-      "authors": "Flajolet, Philippe; Sedgewick, Robert",
-      "title": "Analytic Combinatorics",
-      "year": "2009",
-      "venue": "Cambridge University Press, Chapter II",
-      "note": "Modern treatment of lattice path combinatorics and generating functions, with the cycle lemma as a key tool for counting paths with constraints"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Archive.Wiedijk100Theorems.BallotProblem",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "List",
-      "Set"
-    ],
-    "namespace": "GeneralizedBallot",
-    "lineCount": 789,
-    "axiomCount": 0,
-    "theoremCount": 44,
-    "definitionCount": 8,
-    "mainTheorems": [
-      {
-        "name": "cycle_lemma",
-        "line": 764,
-        "statement": "(goodRotations l).card = a - k * b",
-        "description": "The Dvoretzky-Motzkin Cycle Lemma: for a ballot sequence l in kCountedSequence(k,a,b) with a > kb, exactly a - kb of its a + b cyclic rotations have all positive prefix sums"
-      },
-      {
-        "name": "generalized_ballot_count",
-        "line": 226,
-        "statement": "∃ good_count, good_count * (a + b) = (a - k * b) * (a + b).choose a",
-        "description": "The generalized counting formula: the number of favorable ballot orderings times (a+b) equals (a-kb) times the binomial coefficient C(a+b, a)"
-      },
-      {
-        "name": "generalized_ballot_prob",
-        "line": 246,
-        "statement": "((a : ℚ) - k * b) / (a + b) > 0",
-        "description": "The probability of k-fold dominance throughout counting is strictly positive when a > kb"
-      },
-      {
-        "name": "kCountedSequence_eq_countedSequence",
-        "line": 152,
-        "statement": "kCountedSequence 1 a b = Ballot.countedSequence a b",
-        "description": "When k=1, the generalized ballot sequence reduces to Mathlib's classical ballot sequence (Wiedijk #30)"
-      },
-      {
-        "name": "path_height_interpretation",
-        "line": 783,
-        "statement": "(l.take i).sum = (l.take i).count 1 - (k : ℤ) * (l.take i).count (-(k : ℤ))",
-        "description": "The lattice path height at step i equals the count of A-votes minus k times the count of B-votes up to that point"
-      }
-    ],
-    "path": "Proofs/BallotProblemOQ01.lean",
     "sorries": 0
-  },
-  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Restores correct `leanFile.theoremCount` values using the "all declarations including private/protected" convention established in PR #15867.

## Evidence

**Regressions from PR #15480** (incorrectly downgraded to public-only counts):

| Entry | Before | After | Missing |
|-------|--------|-------|---------|
| `abel-ruffini-oq-04-oq-01` | 36 | 64 | 28 `private theorem` declarations |
| `ballot-problem-oq-01` | 44 | 57 | 13 `private theorem` declarations |

**Siblings missed by PR #15867** (same structure as `angle-trisection-cos-20-gal` which was fixed 6→33):

| Entry | Before | After | Missing |
|-------|--------|-------|---------|
| `angle-trisection-cos-20-gal-oq-01` | 5 | 32 | 27 private theorems |
| `angle-trisection-cos-20-gal-oq-03` | 5 | 32 | 27 private theorems |
| `angle-trisection-cos-20-gal-oq-03-oq-01` | 5 | 28 | 23 private theorems |

All Lean files verified by comment-aware declaration count (handles nested `/-...-/` blocks correctly).

---
Automated fix by lean-mechanic agent.