### PR TITLE
fix(meta): sync leanFile.theoremCount for 14 entries — private/protected count (batch 2)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
@@ -1,153 +1,153 @@
 {
-  "id": "bezout-identity-oq-01-oq-01",
-  "title": "Stein's Binary GCD Algorithm: Correctness Without Division",
-  "slug": "bezout-identity-oq-01-oq-01",
-  "description": "Formalizes Stein's binary GCD algorithm (1967), which computes gcd(a,b) using only subtraction, halving, and parity tests — avoiding modular division entirely. Proves correctness (binaryGcd = Nat.gcd), symmetry, the divisibility properties, and the Bézout corollary, all via well-founded recursion on a+b.",
-  "meta": {
-    "author": "Josef Stein (1967), formalized in Lean 4",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
-    "date": "1967",
-    "status": "verified",
-    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ01.lean",
-    "parentProofId": "bezout-identity-oq-01",
-    "tags": [
-      "number-theory",
-      "algorithms",
-      "gcd",
-      "binary-arithmetic",
-      "well-founded-recursion",
-      "research"
+    "id": "bezout-identity-oq-01-oq-01",
+    "title": "Stein's Binary GCD Algorithm: Correctness Without Division",
+    "slug": "bezout-identity-oq-01-oq-01",
+    "description": "Formalizes Stein's binary GCD algorithm (1967), which computes gcd(a,b) using only subtraction, halving, and parity tests — avoiding modular division entirely. Proves correctness (binaryGcd = Nat.gcd), symmetry, the divisibility properties, and the Bézout corollary, all via well-founded recursion on a+b.",
+    "meta": {
+        "author": "Josef Stein (1967), formalized in Lean 4",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+        "date": "1967",
+        "status": "verified",
+        "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ01.lean",
+        "parentProofId": "bezout-identity-oq-01",
+        "tags": [
+            "number-theory",
+            "algorithms",
+            "gcd",
+            "binary-arithmetic",
+            "well-founded-recursion",
+            "research"
+        ],
+        "badge": "mathlib",
+        "sorries": 0,
+        "axiomCount": 0,
+        "dateAdded": "2026-05-03",
+        "lineCount": 188,
+        "theoremCount": 6,
+        "assumptions": "None. Fully machine-verified.",
+        "originalContributions": [
+            "binaryGcd: Stein's binary GCD algorithm — terminates by well-founded recursion on a+b with 7 case branches",
+            "binaryGcd_eq_gcd: correctness — binaryGcd a b = Nat.gcd a b, proved by well-founded induction matching all 7 algorithm branches",
+            "binaryGcd_comm: symmetry — binaryGcd a b = binaryGcd b a",
+            "binaryGcd_dvd_left / binaryGcd_dvd_right: binaryGcd a b divides both a and b",
+            "dvd_binaryGcd: universality — any common divisor k | a, k | b implies k | binaryGcd a b",
+            "bezout_via_binaryGcd: Bézout corollary — ∃ x y : ℤ, binaryGcd a b = a*x + b*y, via Int.gcdA/gcdB"
+        ],
+        "mathlibDependencies": [
+            {
+                "theorem": "Nat.gcd_mul_left",
+                "description": "gcd(k*a, k*b) = k * gcd(a,b)",
+                "module": "Mathlib.Data.Nat.GCD.Basic"
+            },
+            {
+                "theorem": "Nat.Coprime.gcd_mul_left_cancel",
+                "description": "If k is coprime to b, gcd(k*a, b) = gcd(a,b)",
+                "module": "Mathlib.Data.Nat.GCD.Basic"
+            },
+            {
+                "theorem": "Nat.coprime_two_right",
+                "description": "2 is coprime to n iff n is odd",
+                "module": "Mathlib.Data.Nat.GCD.Basic"
+            },
+            {
+                "theorem": "Int.gcd_eq_gcd_ab",
+                "description": "Bézout identity: gcd(a,b) = a * gcdA + b * gcdB",
+                "module": "Mathlib.Data.Int.GCD"
+            }
+        ],
+        "mathlib_version": "4.26.0"
+    },
+    "overview": {
+        "historicalContext": "Josef Stein published the binary GCD algorithm in 1967 while working on FORTRAN numerical programs. The algorithm predates Stein — binary GCD procedures appear in ancient Chinese mathematics (《九章算術》, ~1st century BCE) — but Stein's 1967 paper gave the first rigorous modern analysis and popularized the method for digital computers. The key motivation: on binary computers, integer division requires multiple clock cycles, while right-shift (halving) and subtraction are single-cycle O(1) operations. Stein's algorithm replaces every modular reduction step in Euclid's algorithm with a subtraction and at least one halving. Donald Knuth analyzed the algorithm's complexity in TAOCP (Vol. 2): it runs in O(log²(max(a,b))) bit operations, matching Euclid but with smaller constants in hardware implementations.",
+        "problemStatement": "Can Stein's binary GCD algorithm — which computes $\\gcd(a,b)$ using only subtraction and right-shifts, without modular division — be formalized in Lean 4 and proved equal to Nat.gcd? The parent entry `bezout-identity-oq-01` formalizes the extended Euclidean algorithm with explicit Bézout coefficients. This entry shows that a division-free implementation satisfies the same mathematical properties: $\\text{binaryGcd}(a,b) = \\gcd(a,b)$, with symmetry, divisibility, universality, and the Bézout identity $\\exists x,y \\in \\mathbb{Z}, \\gcd(a,b) = ax+by$.",
+        "proofStrategy": "Eight private helper lemmas handle the key GCD reductions: factoring out 2 from even inputs (Nat.gcd_mul_left), stripping even factors against odd arguments via coprimality of 2 (Nat.Coprime.gcd_mul_left_cancel), modular subtraction (Nat.gcd_rec), and the both-odd halving step. The main correctness theorem `binaryGcd_eq_gcd` is proved by well-founded induction on a+b: `unfold binaryGcd; split_ifs` creates seven goals matching the algorithm's branches, each closed by applying the induction hypothesis and the corresponding helper lemma. Once correctness is established, four GCD properties and the Bézout corollary follow in one line each by substituting binaryGcd = Nat.gcd and appealing to Mathlib.",
+        "keyInsights": [
+            "Termination by a+b: in all seven branches, the recursive call uses strictly smaller arguments — in the both-even case a/2+b/2 = (a+b)/2 < a+b; in the both-odd subtraction cases (b-a)/2+a < a+b — and omega closes all seven termination obligations automatically",
+            "Coprimality is the engine: if b is odd then gcd(2,b)=1, so gcd(2a,b)=gcd(a,b) — this is Nat.Coprime.gcd_mul_left_cancel, the key lemma that lets the algorithm safely discard factors of 2 when the other argument is odd",
+            "Odd minus odd is always even: when both a and b are odd, b-a is even, so b-a = 2k and gcd(a,k) = gcd(a,b) via gcd_of_odd_two_mul and gcd_sub_right — this is the subtle chain that justifies the halving step in the both-odd case",
+            "Correctness unlocks all properties for free: once binaryGcd = Nat.gcd is established, symmetry/divisibility/universality/Bézout all become one-liners that just rewrite binaryGcd as Nat.gcd and cite Mathlib — no separate proofs needed",
+            "Division-free but complete: Stein's algorithm computes the exact same GCD as Euclid's and satisfies the same algebraic theory (including Bézout's theorem), demonstrating that the mathematical content is independent of the computation strategy used"
+        ]
+    },
+    "sections": [
+        {
+            "id": "helpers",
+            "title": "GCD Reduction Lemmas",
+            "startLine": 32,
+            "endLine": 81,
+            "summary": "Eight private helper lemmas establishing the key GCD identities used in each algorithm branch: gcd(2a,2b)=2·gcd(a,b); if b odd then gcd(2a,b)=gcd(a,b); if a odd then gcd(a,2b)=gcd(a,b); gcd(a,b−a)=gcd(a,b) for a≤b; and the two odd-subtraction lemmas gcd(a,(b−a)/2)=gcd(a,b) and gcd((a−b)/2,b)=gcd(a,b)."
+        },
+        {
+            "id": "definition",
+            "title": "Binary GCD Definition (Stein's Algorithm)",
+            "startLine": 82,
+            "endLine": 98,
+            "summary": "Defines binaryGcd : ℕ → ℕ → ℕ with seven branches corresponding to Stein's algorithm. Termination is by well-founded recursion on a+b, with the termination proof fully automated by omega."
+        },
+        {
+            "id": "correctness",
+            "title": "Main Correctness Theorem",
+            "startLine": 100,
+            "endLine": 146,
+            "summary": "binaryGcd_eq_gcd : ∀ a b, binaryGcd a b = Nat.gcd a b. Proved by well-founded induction on a+b matching the seven branches; each case delegates to the corresponding helper lemma."
+        },
+        {
+            "id": "properties",
+            "title": "GCD Properties",
+            "startLine": 148,
+            "endLine": 167,
+            "summary": "Four derived theorems establishing that binaryGcd inherits all GCD properties from Nat.gcd: symmetry (binaryGcd_comm), left and right divisibility, and universality (any common divisor k divides binaryGcd a b)."
+        },
+        {
+            "id": "bezout",
+            "title": "Bézout Corollary",
+            "startLine": 168,
+            "endLine": 177,
+            "summary": "bezout_via_binaryGcd : ∀ a b, ∃ x y : ℤ, binaryGcd a b = a*x + b*y. After reducing to Nat.gcd via binaryGcd_eq_gcd, applies Int.gcd_eq_gcd_ab to obtain the Bézout coefficients Int.gcdA and Int.gcdB."
+        },
+        {
+            "id": "examples",
+            "title": "Computational Verification",
+            "startLine": 181,
+            "endLine": 186,
+            "summary": "Five native_decide examples verifying the algorithm on concrete inputs: gcd(12,8)=4, gcd(35,15)=5, gcd(17,5)=1, gcd(252,198)=18, and equality with Nat.gcd on gcd(1071,462)."
+        }
     ],
-    "badge": "mathlib",
-    "sorries": 0,
-    "axiomCount": 0,
-    "dateAdded": "2026-05-03",
-    "lineCount": 188,
-    "theoremCount": 6,
-    "assumptions": "None. Fully machine-verified.",
-    "originalContributions": [
-      "binaryGcd: Stein's binary GCD algorithm — terminates by well-founded recursion on a+b with 7 case branches",
-      "binaryGcd_eq_gcd: correctness — binaryGcd a b = Nat.gcd a b, proved by well-founded induction matching all 7 algorithm branches",
-      "binaryGcd_comm: symmetry — binaryGcd a b = binaryGcd b a",
-      "binaryGcd_dvd_left / binaryGcd_dvd_right: binaryGcd a b divides both a and b",
-      "dvd_binaryGcd: universality — any common divisor k | a, k | b implies k | binaryGcd a b",
-      "bezout_via_binaryGcd: Bézout corollary — ∃ x y : ℤ, binaryGcd a b = a*x + b*y, via Int.gcdA/gcdB"
+    "conclusion": {
+        "summary": "This entry fully formalizes Stein's binary GCD algorithm in Lean 4, proving it equivalent to Nat.gcd via well-founded induction on a+b. The algorithm avoids modular division entirely, using only parity tests, subtractions, and right-shifts. Eight private helper lemmas establish the key GCD reductions; the main correctness theorem then proves equivalence by mirroring the algorithm's recursive structure. Five concrete `native_decide` examples verify the algorithm on ground-truth inputs. Once correctness is established, symmetry, divisibility, universality, and the Bézout identity follow in one line each.",
+        "implications": "Stein's algorithm demonstrates that the Euclidean algorithm is not the only mathematically correct way to compute GCD — an important result for algorithm design on hardware where division is expensive. The formalization proves that an implementation-level optimization (replacing modular reduction with bit-shifts) preserves mathematical correctness exactly, including the existence of Bézout coefficients. This has direct applications to hardware GCD circuits and cryptographic implementations such as modular inverse computation in RSA key generation. The Lean 4 proof also showcases the power of well-founded recursion: `termination_by a + b` combined with `all_goals omega` fully automates the termination proof across all seven branches.",
+        "openQuestions": [
+            "Can the O(log²(max(a,b))) bit-operation complexity bound be formalized in Lean 4? This would require a bit-length measure and tracking how many halvings occur in each recursive call.",
+            "Can binaryGcd be extended to integers? The natural extension handles signs separately: binaryGcd |a| |b| gives the GCD magnitude. Does this compose cleanly with Int.gcdA/gcdB to give a complete binary extended GCD returning explicit Bézout coefficients?",
+            "Can the algorithm be parallelized? The binary GCD has variants (Lehmer's, binary extended GCD) that admit parallel execution. Can these be formalized in Lean 4 with concurrent semantics?"
+        ]
+    },
+    "crossReferences": [
+        {
+            "proofId": "bezout-identity",
+            "relationship": "grandparent — Bézout identity statement and its basic Mathlib proof"
+        },
+        {
+            "proofId": "bezout-identity-oq-01",
+            "relationship": "parent — extended Euclidean algorithm with explicit Bézout coefficient computation using modular division"
+        },
+        {
+            "proofId": "binary-gcd-oq-01",
+            "relationship": "sibling — open questions about binary GCD algorithm variants and complexity"
+        },
+        {
+            "proofId": "binary-gcd-oq-01-oq-03",
+            "relationship": "sibling — further binary GCD variants and extended algorithms"
+        }
     ],
-    "mathlibDependencies": [
-      {
-        "theorem": "Nat.gcd_mul_left",
-        "description": "gcd(k*a, k*b) = k * gcd(a,b)",
-        "module": "Mathlib.Data.Nat.GCD.Basic"
-      },
-      {
-        "theorem": "Nat.Coprime.gcd_mul_left_cancel",
-        "description": "If k is coprime to b, gcd(k*a, b) = gcd(a,b)",
-        "module": "Mathlib.Data.Nat.GCD.Basic"
-      },
-      {
-        "theorem": "Nat.coprime_two_right",
-        "description": "2 is coprime to n iff n is odd",
-        "module": "Mathlib.Data.Nat.GCD.Basic"
-      },
-      {
-        "theorem": "Int.gcd_eq_gcd_ab",
-        "description": "Bézout identity: gcd(a,b) = a * gcdA + b * gcdB",
-        "module": "Mathlib.Data.Int.GCD"
-      }
-    ],
-    "mathlib_version": "4.26.0"
-  },
-  "overview": {
-    "historicalContext": "Josef Stein published the binary GCD algorithm in 1967 while working on FORTRAN numerical programs. The algorithm predates Stein — binary GCD procedures appear in ancient Chinese mathematics (《九章算術》, ~1st century BCE) — but Stein's 1967 paper gave the first rigorous modern analysis and popularized the method for digital computers. The key motivation: on binary computers, integer division requires multiple clock cycles, while right-shift (halving) and subtraction are single-cycle O(1) operations. Stein's algorithm replaces every modular reduction step in Euclid's algorithm with a subtraction and at least one halving. Donald Knuth analyzed the algorithm's complexity in TAOCP (Vol. 2): it runs in O(log²(max(a,b))) bit operations, matching Euclid but with smaller constants in hardware implementations.",
-    "problemStatement": "Can Stein's binary GCD algorithm — which computes $\\gcd(a,b)$ using only subtraction and right-shifts, without modular division — be formalized in Lean 4 and proved equal to Nat.gcd? The parent entry `bezout-identity-oq-01` formalizes the extended Euclidean algorithm with explicit Bézout coefficients. This entry shows that a division-free implementation satisfies the same mathematical properties: $\\text{binaryGcd}(a,b) = \\gcd(a,b)$, with symmetry, divisibility, universality, and the Bézout identity $\\exists x,y \\in \\mathbb{Z}, \\gcd(a,b) = ax+by$.",
-    "proofStrategy": "Eight private helper lemmas handle the key GCD reductions: factoring out 2 from even inputs (Nat.gcd_mul_left), stripping even factors against odd arguments via coprimality of 2 (Nat.Coprime.gcd_mul_left_cancel), modular subtraction (Nat.gcd_rec), and the both-odd halving step. The main correctness theorem `binaryGcd_eq_gcd` is proved by well-founded induction on a+b: `unfold binaryGcd; split_ifs` creates seven goals matching the algorithm's branches, each closed by applying the induction hypothesis and the corresponding helper lemma. Once correctness is established, four GCD properties and the Bézout corollary follow in one line each by substituting binaryGcd = Nat.gcd and appealing to Mathlib.",
-    "keyInsights": [
-      "Termination by a+b: in all seven branches, the recursive call uses strictly smaller arguments — in the both-even case a/2+b/2 = (a+b)/2 < a+b; in the both-odd subtraction cases (b-a)/2+a < a+b — and omega closes all seven termination obligations automatically",
-      "Coprimality is the engine: if b is odd then gcd(2,b)=1, so gcd(2a,b)=gcd(a,b) — this is Nat.Coprime.gcd_mul_left_cancel, the key lemma that lets the algorithm safely discard factors of 2 when the other argument is odd",
-      "Odd minus odd is always even: when both a and b are odd, b-a is even, so b-a = 2k and gcd(a,k) = gcd(a,b) via gcd_of_odd_two_mul and gcd_sub_right — this is the subtle chain that justifies the halving step in the both-odd case",
-      "Correctness unlocks all properties for free: once binaryGcd = Nat.gcd is established, symmetry/divisibility/universality/Bézout all become one-liners that just rewrite binaryGcd as Nat.gcd and cite Mathlib — no separate proofs needed",
-      "Division-free but complete: Stein's algorithm computes the exact same GCD as Euclid's and satisfies the same algebraic theory (including Bézout's theorem), demonstrating that the mathematical content is independent of the computation strategy used"
-    ]
-  },
-  "sections": [
-    {
-      "id": "helpers",
-      "title": "GCD Reduction Lemmas",
-      "startLine": 32,
-      "endLine": 81,
-      "summary": "Eight private helper lemmas establishing the key GCD identities used in each algorithm branch: gcd(2a,2b)=2·gcd(a,b); if b odd then gcd(2a,b)=gcd(a,b); if a odd then gcd(a,2b)=gcd(a,b); gcd(a,b−a)=gcd(a,b) for a≤b; and the two odd-subtraction lemmas gcd(a,(b−a)/2)=gcd(a,b) and gcd((a−b)/2,b)=gcd(a,b)."
+    "leanFile": {
+        "namespace": "BezoutIdentityOQ01OQ01",
+        "lineCount": 188,
+        "axiomCount": 0,
+        "theoremCount": 14,
+        "definitionCount": 1,
+        "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+        "sorries": 0
     },
-    {
-      "id": "definition",
-      "title": "Binary GCD Definition (Stein's Algorithm)",
-      "startLine": 82,
-      "endLine": 98,
-      "summary": "Defines binaryGcd : ℕ → ℕ → ℕ with seven branches corresponding to Stein's algorithm. Termination is by well-founded recursion on a+b, with the termination proof fully automated by omega."
-    },
-    {
-      "id": "correctness",
-      "title": "Main Correctness Theorem",
-      "startLine": 100,
-      "endLine": 146,
-      "summary": "binaryGcd_eq_gcd : ∀ a b, binaryGcd a b = Nat.gcd a b. Proved by well-founded induction on a+b matching the seven branches; each case delegates to the corresponding helper lemma."
-    },
-    {
-      "id": "properties",
-      "title": "GCD Properties",
-      "startLine": 148,
-      "endLine": 167,
-      "summary": "Four derived theorems establishing that binaryGcd inherits all GCD properties from Nat.gcd: symmetry (binaryGcd_comm), left and right divisibility, and universality (any common divisor k divides binaryGcd a b)."
-    },
-    {
-      "id": "bezout",
-      "title": "Bézout Corollary",
-      "startLine": 168,
-      "endLine": 177,
-      "summary": "bezout_via_binaryGcd : ∀ a b, ∃ x y : ℤ, binaryGcd a b = a*x + b*y. After reducing to Nat.gcd via binaryGcd_eq_gcd, applies Int.gcd_eq_gcd_ab to obtain the Bézout coefficients Int.gcdA and Int.gcdB."
-    },
-    {
-      "id": "examples",
-      "title": "Computational Verification",
-      "startLine": 181,
-      "endLine": 186,
-      "summary": "Five native_decide examples verifying the algorithm on concrete inputs: gcd(12,8)=4, gcd(35,15)=5, gcd(17,5)=1, gcd(252,198)=18, and equality with Nat.gcd on gcd(1071,462)."
-    }
-  ],
-  "conclusion": {
-    "summary": "This entry fully formalizes Stein's binary GCD algorithm in Lean 4, proving it equivalent to Nat.gcd via well-founded induction on a+b. The algorithm avoids modular division entirely, using only parity tests, subtractions, and right-shifts. Eight private helper lemmas establish the key GCD reductions; the main correctness theorem then proves equivalence by mirroring the algorithm's recursive structure. Five concrete `native_decide` examples verify the algorithm on ground-truth inputs. Once correctness is established, symmetry, divisibility, universality, and the Bézout identity follow in one line each.",
-    "implications": "Stein's algorithm demonstrates that the Euclidean algorithm is not the only mathematically correct way to compute GCD — an important result for algorithm design on hardware where division is expensive. The formalization proves that an implementation-level optimization (replacing modular reduction with bit-shifts) preserves mathematical correctness exactly, including the existence of Bézout coefficients. This has direct applications to hardware GCD circuits and cryptographic implementations such as modular inverse computation in RSA key generation. The Lean 4 proof also showcases the power of well-founded recursion: `termination_by a + b` combined with `all_goals omega` fully automates the termination proof across all seven branches.",
-    "openQuestions": [
-      "Can the O(log²(max(a,b))) bit-operation complexity bound be formalized in Lean 4? This would require a bit-length measure and tracking how many halvings occur in each recursive call.",
-      "Can binaryGcd be extended to integers? The natural extension handles signs separately: binaryGcd |a| |b| gives the GCD magnitude. Does this compose cleanly with Int.gcdA/gcdB to give a complete binary extended GCD returning explicit Bézout coefficients?",
-      "Can the algorithm be parallelized? The binary GCD has variants (Lehmer's, binary extended GCD) that admit parallel execution. Can these be formalized in Lean 4 with concurrent semantics?"
-    ]
-  },
-  "crossReferences": [
-    {
-      "proofId": "bezout-identity",
-      "relationship": "grandparent — Bézout identity statement and its basic Mathlib proof"
-    },
-    {
-      "proofId": "bezout-identity-oq-01",
-      "relationship": "parent — extended Euclidean algorithm with explicit Bézout coefficient computation using modular division"
-    },
-    {
-      "proofId": "binary-gcd-oq-01",
-      "relationship": "sibling — open questions about binary GCD algorithm variants and complexity"
-    },
-    {
-      "proofId": "binary-gcd-oq-01-oq-03",
-      "relationship": "sibling — further binary GCD variants and extended algorithms"
-    }
-  ],
-  "leanFile": {
-    "namespace": "BezoutIdentityOQ01OQ01",
-    "lineCount": 188,
-    "axiomCount": 0,
-    "theoremCount": 6,
-    "definitionCount": 1,
-    "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
     "sorries": 0
-  },
-  "sorries": 0
 }

--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -1,176 +1,185 @@
 {
-  "id": "binary-gcd-oq-03-oq-02",
-  "title": "Schönhage's Recursive HGCD: GCD Preservation and Matrix Invariants",
-  "slug": "binary-gcd-oq-03-oq-02",
-  "description": "Formalizes Schönhage's recursive half-GCD (HGCD) in Lean 4, extending the Lehmer hybrid (BinaryGcdOQ03) with the full recursive structure. Proves GCD preservation, the determinant invariant, the matrix-vector row convention, entry bounds via Cramer's rule, and perturbation infrastructure toward size reduction. One sorry remains for the recursive case of the row-output size-reduction bound.",
-  "sorries": 1,
-  "meta": {
-    "author": "Schönhage (1971), formalized in Lean 4",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Half-GCD_algorithm",
-    "date": "1971",
-    "status": "formalized",
-    "tags": [
-      "algorithms",
-      "number-theory",
-      "gcd",
-      "computational-algebra",
-      "complexity",
-      "matrices"
-    ],
-    "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02.lean",
-    "badge": "wip",
+    "id": "binary-gcd-oq-03-oq-02",
+    "title": "Schönhage's Recursive HGCD: GCD Preservation and Matrix Invariants",
+    "slug": "binary-gcd-oq-03-oq-02",
+    "description": "Formalizes Schönhage's recursive half-GCD (HGCD) in Lean 4, extending the Lehmer hybrid (BinaryGcdOQ03) with the full recursive structure. Proves GCD preservation, the determinant invariant, the matrix-vector row convention, entry bounds via Cramer's rule, and perturbation infrastructure toward size reduction. One sorry remains for the recursive case of the row-output size-reduction bound.",
     "sorries": 1,
-    "axiomCount": 0,
-    "lineCount": 1020,
-    "dateAdded": "2026-05-03",
-    "theoremCount": 33,
-    "assumptions": "",
-    "mathlibDependencies": [
-      {
-        "theorem": "Nat.log_mono_right",
-        "description": "Monotonicity of Nat.log used in hgcdShift bounds",
-        "module": "Mathlib.Data.Nat.Log"
-      },
-      {
-        "theorem": "Int.natAbs_add_le",
-        "description": "Triangle inequality for Int.natAbs in perturbation bounds",
-        "module": "Mathlib.Data.Int.Order"
-      },
-      {
-        "theorem": "Nat.div_lt_self",
-        "description": "Top-half inputs strictly smaller than original",
-        "module": "Mathlib.Data.Nat.Basic"
-      }
+    "meta": {
+        "author": "Schönhage (1971), formalized in Lean 4",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Half-GCD_algorithm",
+        "date": "1971",
+        "status": "formalized",
+        "tags": [
+            "algorithms",
+            "number-theory",
+            "gcd",
+            "computational-algebra",
+            "complexity",
+            "matrices"
+        ],
+        "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02.lean",
+        "badge": "wip",
+        "sorries": 1,
+        "axiomCount": 0,
+        "lineCount": 1020,
+        "dateAdded": "2026-05-03",
+        "theoremCount": 33,
+        "assumptions": "",
+        "mathlibDependencies": [
+            {
+                "theorem": "Nat.log_mono_right",
+                "description": "Monotonicity of Nat.log used in hgcdShift bounds",
+                "module": "Mathlib.Data.Nat.Log"
+            },
+            {
+                "theorem": "Int.natAbs_add_le",
+                "description": "Triangle inequality for Int.natAbs in perturbation bounds",
+                "module": "Mathlib.Data.Int.Order"
+            },
+            {
+                "theorem": "Nat.div_lt_self",
+                "description": "Top-half inputs strictly smaller than original",
+                "module": "Mathlib.Data.Nat.Basic"
+            }
+        ],
+        "originalContributions": [
+            "cofactor_mul_apply: cofactor multiplication composes the apply action — M.mul N applied to (a,b) equals M applied to (N.apply a b)",
+            "hgcdMatrix_det_unit: the recursive HGCD matrix always has determinant ±1, proved by induction on fuel using lehmerCofactors_det_unit at leaves and det_mul at recursive steps",
+            "hgcdMatrix_preserves_gcd: applying the HGCD matrix to (a,b) yields a pair with the same GCD — the operational correctness theorem of Schönhage's algorithm",
+            "lehmerCofactors_invariant: row-vector invariant (a₀,b₀)·M = (current pair) is preserved across all Lehmer cofactor steps, establishing the row convention needed for size-reduction",
+            "lehmerCofactors_id_apply_le: residue monotonicity — max of the Lehmer row output is ≤ max of the original inputs",
+            "row_vec_cramer: Cramer identity — from (a₀,b₀)·M = (ahat,bhat) and det = ±1, derives a₀·det = ahat·M.δ − bhat·M.γ",
+            "entry_bound_of_even/odd: all matrix entries of lehmerCofactors are bounded in absolute value by the initial inputs, proved via Cramer + alternating sign pattern",
+            "cofactor_apply_shift_decomp: apply(aHi·2^s + ea, bHi·2^s + eb) = 2^s·apply(aHi,bHi) + apply(ea,eb) — the key algebraic identity for the Lehmer perturbation argument",
+            "cofactor_apply_err_bound: given |entries| ≤ C and |errors| ≤ B, the perturbation component is ≤ 2·C·B",
+            "hgcdShift_top_lt: the top-half truncation a/2^s is strictly less than a — the induction-measure decrease for Step 4 strong induction"
+        ]
+    },
+    "overview": {
+        "historicalContext": "Arnold Schönhage (1971) extended Lehmer's hybrid GCD to achieve optimal O(M(n)·log n) bit complexity, where M(n) is the cost of multiplying n-bit integers. The key innovation is recursion: instead of running Lehmer's single-level approximation once, HGCD recurses on the top half of the bits to compute a cofactor matrix M₁, applies M₁ to the full inputs to get a half-size pair, then recurses again. This two-level recursion gives O(log n) levels, each costing O(M(n)), for total O(M(n)·log n). The algorithm underlies GMP's mpn_hgcd implementation and is the standard GCD algorithm for cryptographic-size integers (thousands of bits).",
+        "problemStatement": "Can Schönhage's recursive HGCD (half-GCD) be formalized in Lean 4, establishing the GCD-preservation correctness proof and making progress toward the O(M(n)·log n) bit complexity bound?",
+        "proofStrategy": "The formalization is structured in nine parts. Parts I–IV establish the core correctness: the composition law for cofactor matrices, the fuel-indexed recursive definition of hgcdMatrix, the determinant invariant (proved by induction on fuel), and GCD preservation (a corollary via gcd_cofactor_eq from BinaryGcdOQ03). Parts V–VI build the size-reduction infrastructure: the row-convention matrix-vector invariant for Lehmer cofactors, residue monotonicity, the Cramer identity, and entry bounds via the alternating sign pattern (EvenPattern/OddPattern). Part VII adds the perturbation decomposition (apply distributes over shifts). Part VIII proves the induction prerequisites (shift ≥ 1, top-half strictly smaller). Part IX states the remaining size-reduction bound with one sorry for the recursive case, which requires a quotient stability lemma connecting top-half quotients to full-precision Euclidean quotients.",
+        "keyInsights": [
+            "Fuel-indexed totality decouples correctness from termination: hgcdMatrix is total by construction and GCD preservation holds for all fuel values, independently of whether the fuel is sufficient for the algorithm to run to completion.",
+            "The convention dichotomy is a genuine obstruction: the apply action (column convention M·(a,b)ᵀ) tracks a different intermediate state from the row convention (a,b)·M. GCD preservation uses the column convention; size reduction requires the row convention. These agree on determinant-based theorems but diverge on state tracking.",
+            "The composition law cofactor_mul_apply is the algebraic key: it states that M.mul N applied columnwise is M applied to N's output. This chains the two HGCD recursive calls into a single correct reduction.",
+            "Entry bounds arise from Cramer inversion: if (a₀,b₀)·M = (ahat,bhat), then by unimodularity, each entry of M is a linear combination of ahat and bhat with coefficients ±1. With the alternating sign pattern from lehmerInnerStep, all entries are bounded by max(a₀,b₀).",
+            "The remaining sorry (recursive size-reduction) requires quotient stability: showing that the Euclidean quotients computed from the top-half approximation (a/2^s, b/2^s) match those from the full-precision (a,b) for the relevant number of steps. This is proved in Stehlé–Zimmermann (2004) but requires ≈200 lines of new Lean infrastructure."
+        ]
+    },
+    "sections": [
+        {
+            "id": "composition-law",
+            "title": "Part I: Composition of Cofactor Matrices",
+            "startLine": 61,
+            "endLine": 73,
+            "summary": "Proves cofactor_mul_apply: (M.mul N).apply a b = M.apply (N.apply a b). One-line proof by ring.",
+            "mathContext": "If $N$ transforms $(a,b)$ to $(u,v)$ and $M$ transforms $(u,v)$ to $(p,q)$, then $M \\cdot N$ transforms $(a,b)$ to $(p,q)$ directly. This is the standard matrix composition law, proved by ring arithmetic over the four entries."
+        },
+        {
+            "id": "hgcd-definition",
+            "title": "Part II: Recursive HGCD Matrix Definition",
+            "startLine": 74,
+            "endLine": 159,
+            "summary": "Defines hgcdMatrix, hgcdThreshold (64), hgcdShift (⌈bits/2⌉), hgcdMatrixOf (top-level entry). Provides hgcdMatrix_succ and hgcdMatrix_zero reduction lemmas for proof rewrites.",
+            "mathContext": "The fuel-indexed definition avoids well-founded recursion complications. At fuel 0 it returns the identity. At fuel $f+1$: if $\\max(a,b) < 64$, fall back to Lehmer cofactor accumulation; otherwise set $s = \\lceil \\log_2(\\max(a,b))/2 \\rceil$, compute $M_1 = \\mathrm{hgcd}(a/2^s, b/2^s)$, apply $M_1$ to $(a,b)$ to get $(a',b')$, compute $M_2 = \\mathrm{hgcd}(a',b')$, return $M_2 \\cdot M_1$."
+        },
+        {
+            "id": "det-invariant",
+            "title": "Part III: Determinant Is ±1",
+            "startLine": 160,
+            "endLine": 199,
+            "summary": "Proves hgcdMatrix_det_unit: det(hgcdMatrix fuel a b) = 1 or -1 for all fuel, a, b. Induction: base gives identity (det 1); leaf uses lehmerCofactors_det_unit; recursive case uses det_mul and IH twice.",
+            "mathContext": "The unimodularity $\\det(M) = \\pm 1$ is the invariant that makes cofactor matrices GCD-preserving. For $M_2 \\cdot M_1$: $\\det(M_2 \\cdot M_1) = \\det(M_2) \\cdot \\det(M_1) = (\\pm 1)(\\pm 1) = \\pm 1$."
+        },
+        {
+            "id": "gcd-preservation",
+            "title": "Part IV: GCD Preservation",
+            "startLine": 200,
+            "endLine": 245,
+            "summary": "Proves hgcdMatrix_preserves_gcd and hgcdMatrixOf_preserves_gcd: applying the HGCD matrix to (a,b) yields a pair with the same GCD. Corollary of gcd_cofactor_eq from BinaryGcdOQ03 and the det invariant.",
+            "mathContext": "Since $\\det(M) = \\pm 1$, Cramer's rule shows any common divisor of $M \\cdot (a,b)^T$ divides $(a,b)$ and vice versa, so $\\gcd(M \\cdot (a,b)^T) = \\gcd(a,b)$. This is the operational correctness statement of the HGCD algorithm."
+        },
+        {
+            "id": "row-vector-invariant",
+            "title": "Part V.5: Matrix-Vector Row Convention Invariant",
+            "startLine": 246,
+            "endLine": 438,
+            "summary": "Eight theorems establishing the row-convention invariant (a₀,b₀)·M = (current pair) across Lehmer steps. Key results: lehmerCofactors_invariant, lehmerCofactors_id_apply_le (residue ≤ max input).",
+            "mathContext": "The Lehmer inner step appends $M' = M \\cdot S$ by right-multiplication, where $S = \\begin{pmatrix}0&1\\\\1&-q\\end{pmatrix}$. The row-convention relation $(a_0, b_0) \\cdot M = (\\hat{a}, \\hat{b})$ is preserved because right-multiplication shifts exactly the right column. This gives $\\max(\\hat{a}', \\hat{b}') \\le \\max(\\hat{a}, \\hat{b})$ at each step, proving residue monotonicity."
+        },
+        {
+            "id": "entry-bounds",
+            "title": "Part VI: Cramer Identity, Sign Patterns, and Entry Bounds",
+            "startLine": 439,
+            "endLine": 622,
+            "summary": "Proves row_vec_cramer (Cramer identity), EvenPattern/OddPattern definitions, alternation lemmas for lehmerInnerStep, and entry_bound_of_even/odd: all matrix entries ≤ max(a₀,b₀).",
+            "mathContext": "From $(a_0,b_0) \\cdot M = (\\hat{a},\\hat{b})$ with $\\det M = \\pm 1$, Cramer inversion gives $a_0 = \\pm(\\hat{a} \\cdot M.\\delta - \\hat{b} \\cdot M.\\gamma)$. With the sign pattern enforcing positive residues, each matrix entry is $\\le \\max(a_0, b_0)$. This is Step 2b of the Stehlé–Zimmermann size-reduction proof."
+        },
+        {
+            "id": "perturbation",
+            "title": "Part VII: Perturbation Infrastructure",
+            "startLine": 623,
+            "endLine": 735,
+            "summary": "Six theorems: apply distributes over addition and scalar multiplication; apply(aHi·2^s + ea, bHi·2^s + eb) = 2^s·apply(aHi,bHi) + apply(ea,eb); error bounds |apply(ea,eb)| ≤ 2·C·B given |entries|≤C, |errors|≤B.",
+            "mathContext": "The key identity $M(a_H \\cdot 2^s + e_a, b_H \\cdot 2^s + e_b) = 2^s \\cdot M(a_H,b_H) + M(e_a,e_b)$ separates signal (the top-half HGCD output) from noise (the low-bit contribution). With entry bounds $|M_{ij}| \\le C$ and $|e| \\le 2^s$, the error satisfies $|M(e_a,e_b)| \\le 2C \\cdot 2^s$."
+        },
+        {
+            "id": "shift-bounds",
+            "title": "Part VIII: Shift Bounds for Step 4 Induction",
+            "startLine": 736,
+            "endLine": 785,
+            "summary": "Proves hgcdShift_pos (shift ≥ 1 for inputs ≥ 4) and hgcdShift_top_lt (top-half input a/2^s < a). These are the induction-measure decrease lemmas needed for strong induction on input size.",
+            "mathContext": "$s = \\lceil \\log_2(\\max(a,b)) / 2 \\rceil \\ge 1$ when $\\max(a,b) \\ge 4$, so $2^s \\ge 2$ and $a/2^s < a$ by Nat.div_lt_self. This strict decrease enables the Step 4 strong induction on bitsize."
+        },
+        {
+            "id": "size-reduction",
+            "title": "Part IX: Size Reduction (1 sorry — recursive case)",
+            "startLine": 786,
+            "endLine": 935,
+            "summary": "States hgcdMatrix_joint_bound: for sufficient fuel, output and entries are bounded by 2^(hgcdShift+3). Base cases and column-convention counterexample proved; recursive case has 1 sorry awaiting quotient stability infrastructure.",
+            "mathContext": "The missing piece is quotient stability: showing the Euclidean quotients from $(a/2^s, b/2^s)$ match those from $(a,b)$ for the first $O(n/2)$ steps. Proved in Stehlé–Zimmermann (2004) §3–4 using the approximation quality bound; requires ≈200 lines of Lean infrastructure not yet formalized."
+        }
     ],
-    "originalContributions": [
-      "cofactor_mul_apply: cofactor multiplication composes the apply action — M.mul N applied to (a,b) equals M applied to (N.apply a b)",
-      "hgcdMatrix_det_unit: the recursive HGCD matrix always has determinant ±1, proved by induction on fuel using lehmerCofactors_det_unit at leaves and det_mul at recursive steps",
-      "hgcdMatrix_preserves_gcd: applying the HGCD matrix to (a,b) yields a pair with the same GCD — the operational correctness theorem of Schönhage's algorithm",
-      "lehmerCofactors_invariant: row-vector invariant (a₀,b₀)·M = (current pair) is preserved across all Lehmer cofactor steps, establishing the row convention needed for size-reduction",
-      "lehmerCofactors_id_apply_le: residue monotonicity — max of the Lehmer row output is ≤ max of the original inputs",
-      "row_vec_cramer: Cramer identity — from (a₀,b₀)·M = (ahat,bhat) and det = ±1, derives a₀·det = ahat·M.δ − bhat·M.γ",
-      "entry_bound_of_even/odd: all matrix entries of lehmerCofactors are bounded in absolute value by the initial inputs, proved via Cramer + alternating sign pattern",
-      "cofactor_apply_shift_decomp: apply(aHi·2^s + ea, bHi·2^s + eb) = 2^s·apply(aHi,bHi) + apply(ea,eb) — the key algebraic identity for the Lehmer perturbation argument",
-      "cofactor_apply_err_bound: given |entries| ≤ C and |errors| ≤ B, the perturbation component is ≤ 2·C·B",
-      "hgcdShift_top_lt: the top-half truncation a/2^s is strictly less than a — the induction-measure decrease for Step 4 strong induction"
-    ]
-  },
-  "overview": {
-    "historicalContext": "Arnold Schönhage (1971) extended Lehmer's hybrid GCD to achieve optimal O(M(n)·log n) bit complexity, where M(n) is the cost of multiplying n-bit integers. The key innovation is recursion: instead of running Lehmer's single-level approximation once, HGCD recurses on the top half of the bits to compute a cofactor matrix M₁, applies M₁ to the full inputs to get a half-size pair, then recurses again. This two-level recursion gives O(log n) levels, each costing O(M(n)), for total O(M(n)·log n). The algorithm underlies GMP's mpn_hgcd implementation and is the standard GCD algorithm for cryptographic-size integers (thousands of bits).",
-    "problemStatement": "Can Schönhage's recursive HGCD (half-GCD) be formalized in Lean 4, establishing the GCD-preservation correctness proof and making progress toward the O(M(n)·log n) bit complexity bound?",
-    "proofStrategy": "The formalization is structured in nine parts. Parts I–IV establish the core correctness: the composition law for cofactor matrices, the fuel-indexed recursive definition of hgcdMatrix, the determinant invariant (proved by induction on fuel), and GCD preservation (a corollary via gcd_cofactor_eq from BinaryGcdOQ03). Parts V–VI build the size-reduction infrastructure: the row-convention matrix-vector invariant for Lehmer cofactors, residue monotonicity, the Cramer identity, and entry bounds via the alternating sign pattern (EvenPattern/OddPattern). Part VII adds the perturbation decomposition (apply distributes over shifts). Part VIII proves the induction prerequisites (shift ≥ 1, top-half strictly smaller). Part IX states the remaining size-reduction bound with one sorry for the recursive case, which requires a quotient stability lemma connecting top-half quotients to full-precision Euclidean quotients.",
-    "keyInsights": [
-      "Fuel-indexed totality decouples correctness from termination: hgcdMatrix is total by construction and GCD preservation holds for all fuel values, independently of whether the fuel is sufficient for the algorithm to run to completion.",
-      "The convention dichotomy is a genuine obstruction: the apply action (column convention M·(a,b)ᵀ) tracks a different intermediate state from the row convention (a,b)·M. GCD preservation uses the column convention; size reduction requires the row convention. These agree on determinant-based theorems but diverge on state tracking.",
-      "The composition law cofactor_mul_apply is the algebraic key: it states that M.mul N applied columnwise is M applied to N's output. This chains the two HGCD recursive calls into a single correct reduction.",
-      "Entry bounds arise from Cramer inversion: if (a₀,b₀)·M = (ahat,bhat), then by unimodularity, each entry of M is a linear combination of ahat and bhat with coefficients ±1. With the alternating sign pattern from lehmerInnerStep, all entries are bounded by max(a₀,b₀).",
-      "The remaining sorry (recursive size-reduction) requires quotient stability: showing that the Euclidean quotients computed from the top-half approximation (a/2^s, b/2^s) match those from the full-precision (a,b) for the relevant number of steps. This is proved in Stehlé–Zimmermann (2004) but requires ≈200 lines of new Lean infrastructure."
-    ]
-  },
-  "sections": [
-    {
-      "id": "composition-law",
-      "title": "Part I: Composition of Cofactor Matrices",
-      "startLine": 61,
-      "endLine": 73,
-      "summary": "Proves cofactor_mul_apply: (M.mul N).apply a b = M.apply (N.apply a b). One-line proof by ring.",
-      "mathContext": "If $N$ transforms $(a,b)$ to $(u,v)$ and $M$ transforms $(u,v)$ to $(p,q)$, then $M \\cdot N$ transforms $(a,b)$ to $(p,q)$ directly. This is the standard matrix composition law, proved by ring arithmetic over the four entries."
-    },
-    {
-      "id": "hgcd-definition",
-      "title": "Part II: Recursive HGCD Matrix Definition",
-      "startLine": 74,
-      "endLine": 159,
-      "summary": "Defines hgcdMatrix, hgcdThreshold (64), hgcdShift (⌈bits/2⌉), hgcdMatrixOf (top-level entry). Provides hgcdMatrix_succ and hgcdMatrix_zero reduction lemmas for proof rewrites.",
-      "mathContext": "The fuel-indexed definition avoids well-founded recursion complications. At fuel 0 it returns the identity. At fuel $f+1$: if $\\max(a,b) < 64$, fall back to Lehmer cofactor accumulation; otherwise set $s = \\lceil \\log_2(\\max(a,b))/2 \\rceil$, compute $M_1 = \\mathrm{hgcd}(a/2^s, b/2^s)$, apply $M_1$ to $(a,b)$ to get $(a',b')$, compute $M_2 = \\mathrm{hgcd}(a',b')$, return $M_2 \\cdot M_1$."
-    },
-    {
-      "id": "det-invariant",
-      "title": "Part III: Determinant Is ±1",
-      "startLine": 160,
-      "endLine": 199,
-      "summary": "Proves hgcdMatrix_det_unit: det(hgcdMatrix fuel a b) = 1 or -1 for all fuel, a, b. Induction: base gives identity (det 1); leaf uses lehmerCofactors_det_unit; recursive case uses det_mul and IH twice.",
-      "mathContext": "The unimodularity $\\det(M) = \\pm 1$ is the invariant that makes cofactor matrices GCD-preserving. For $M_2 \\cdot M_1$: $\\det(M_2 \\cdot M_1) = \\det(M_2) \\cdot \\det(M_1) = (\\pm 1)(\\pm 1) = \\pm 1$."
-    },
-    {
-      "id": "gcd-preservation",
-      "title": "Part IV: GCD Preservation",
-      "startLine": 200,
-      "endLine": 245,
-      "summary": "Proves hgcdMatrix_preserves_gcd and hgcdMatrixOf_preserves_gcd: applying the HGCD matrix to (a,b) yields a pair with the same GCD. Corollary of gcd_cofactor_eq from BinaryGcdOQ03 and the det invariant.",
-      "mathContext": "Since $\\det(M) = \\pm 1$, Cramer's rule shows any common divisor of $M \\cdot (a,b)^T$ divides $(a,b)$ and vice versa, so $\\gcd(M \\cdot (a,b)^T) = \\gcd(a,b)$. This is the operational correctness statement of the HGCD algorithm."
-    },
-    {
-      "id": "row-vector-invariant",
-      "title": "Part V.5: Matrix-Vector Row Convention Invariant",
-      "startLine": 246,
-      "endLine": 438,
-      "summary": "Eight theorems establishing the row-convention invariant (a₀,b₀)·M = (current pair) across Lehmer steps. Key results: lehmerCofactors_invariant, lehmerCofactors_id_apply_le (residue ≤ max input).",
-      "mathContext": "The Lehmer inner step appends $M' = M \\cdot S$ by right-multiplication, where $S = \\begin{pmatrix}0&1\\\\1&-q\\end{pmatrix}$. The row-convention relation $(a_0, b_0) \\cdot M = (\\hat{a}, \\hat{b})$ is preserved because right-multiplication shifts exactly the right column. This gives $\\max(\\hat{a}', \\hat{b}') \\le \\max(\\hat{a}, \\hat{b})$ at each step, proving residue monotonicity."
-    },
-    {
-      "id": "entry-bounds",
-      "title": "Part VI: Cramer Identity, Sign Patterns, and Entry Bounds",
-      "startLine": 439,
-      "endLine": 622,
-      "summary": "Proves row_vec_cramer (Cramer identity), EvenPattern/OddPattern definitions, alternation lemmas for lehmerInnerStep, and entry_bound_of_even/odd: all matrix entries ≤ max(a₀,b₀).",
-      "mathContext": "From $(a_0,b_0) \\cdot M = (\\hat{a},\\hat{b})$ with $\\det M = \\pm 1$, Cramer inversion gives $a_0 = \\pm(\\hat{a} \\cdot M.\\delta - \\hat{b} \\cdot M.\\gamma)$. With the sign pattern enforcing positive residues, each matrix entry is $\\le \\max(a_0, b_0)$. This is Step 2b of the Stehlé–Zimmermann size-reduction proof."
-    },
-    {
-      "id": "perturbation",
-      "title": "Part VII: Perturbation Infrastructure",
-      "startLine": 623,
-      "endLine": 735,
-      "summary": "Six theorems: apply distributes over addition and scalar multiplication; apply(aHi·2^s + ea, bHi·2^s + eb) = 2^s·apply(aHi,bHi) + apply(ea,eb); error bounds |apply(ea,eb)| ≤ 2·C·B given |entries|≤C, |errors|≤B.",
-      "mathContext": "The key identity $M(a_H \\cdot 2^s + e_a, b_H \\cdot 2^s + e_b) = 2^s \\cdot M(a_H,b_H) + M(e_a,e_b)$ separates signal (the top-half HGCD output) from noise (the low-bit contribution). With entry bounds $|M_{ij}| \\le C$ and $|e| \\le 2^s$, the error satisfies $|M(e_a,e_b)| \\le 2C \\cdot 2^s$."
-    },
-    {
-      "id": "shift-bounds",
-      "title": "Part VIII: Shift Bounds for Step 4 Induction",
-      "startLine": 736,
-      "endLine": 785,
-      "summary": "Proves hgcdShift_pos (shift ≥ 1 for inputs ≥ 4) and hgcdShift_top_lt (top-half input a/2^s < a). These are the induction-measure decrease lemmas needed for strong induction on input size.",
-      "mathContext": "$s = \\lceil \\log_2(\\max(a,b)) / 2 \\rceil \\ge 1$ when $\\max(a,b) \\ge 4$, so $2^s \\ge 2$ and $a/2^s < a$ by Nat.div_lt_self. This strict decrease enables the Step 4 strong induction on bitsize."
-    },
-    {
-      "id": "size-reduction",
-      "title": "Part IX: Size Reduction (1 sorry — recursive case)",
-      "startLine": 786,
-      "endLine": 935,
-      "summary": "States hgcdMatrix_joint_bound: for sufficient fuel, output and entries are bounded by 2^(hgcdShift+3). Base cases and column-convention counterexample proved; recursive case has 1 sorry awaiting quotient stability infrastructure.",
-      "mathContext": "The missing piece is quotient stability: showing the Euclidean quotients from $(a/2^s, b/2^s)$ match those from $(a,b)$ for the first $O(n/2)$ steps. Proved in Stehlé–Zimmermann (2004) §3–4 using the approximation quality bound; requires ≈200 lines of Lean infrastructure not yet formalized."
-    }
-  ],
-  "openQuestions": [
-    {
-      "id": "oq-01",
-      "question": "Can the recursive case of hgcdMatrix_joint_bound be closed by formalizing quotient stability (≈200 lines of Lean infrastructure from Stehlé–Zimmermann §3–4)?",
-      "difficulty": "hard",
-      "tags": ["size-reduction", "quotient-stability", "lean4"]
-    },
-    {
-      "id": "oq-02",
-      "question": "Can the O(M(n)·log n) bit complexity bound be stated and proved once Mathlib gains a model for fast multiplication and bit-operation costs?",
-      "difficulty": "very-hard",
-      "tags": ["complexity", "bit-complexity", "fast-multiplication", "mathlib"]
-    }
-  ],
-  "leanFile": {
-    "namespace": "HGcd",
-    "lineCount": 1020,
-    "axiomCount": 0,
-    "theoremCount": 33,
-    "definitionCount": 6,
-    "path": "Proofs/BinaryGcdOQ03OQ02.lean",
-    "sorries": 1
-  },
-  "conclusion": {
-    "summary": "This formalization of Schönhage's recursive HGCD establishes the core correctness layer in 936 lines with a single sorry. The three main theorems — `cofactor_mul_apply` (compositional algebra), `hgcdMatrix_det_unit` (unimodularity by fuel induction), and `hgcdMatrix_preserves_gcd` (operational correctness) — formally verify that Schönhage's two-level recursion produces a GCD-preserving matrix. The size-reduction infrastructure (row-convention invariant, Cramer identity, entry bounds, perturbation decomposition) is complete except for the quotient stability lemma needed for the recursive size bound. Together with `BinaryGcdOQ03` (the Lehmer hybrid), this represents the first Lean formalization of the HGCD algorithm's correctness structure.",
-    "implications": "Schönhage's HGCD is the inner loop of every modern number theory computation involving large integers: RSA key generation, elliptic curve scalar multiplication, polynomial GCD in computer algebra systems, and lattice basis reduction (LLL algorithm). Formalizing its correctness in Lean 4 provides a verified foundation for future cryptographic algorithm verification. The quotient stability sorry (≈200 lines remaining) is the only gap between this formalization and a complete proof of size reduction — once closed, the file would establish the full recursive structure needed to state the $O(M(n)\\log n)$ complexity claim. The GMP library's `mpn_hgcd` implements exactly this algorithm for production GCD computation; a Lean verification would enable formal auditing of such production code.",
     "openQuestions": [
-      "Can the quotient stability lemma (Stehlé–Zimmermann §3–4) be formalized in ≈200 lines to close the sorry in `hgcdMatrix_joint_bound`? The key is Theorem 4 of Stehlé–Zimmermann 2004: 'if $2^s > 4\\max(a,b)/\\gcd(a,b)$, the first $k$ Euclidean quotients of $(a_H, b_H)$ and $(a,b)$ agree.' Lean infrastructure needed: remainder sequence properties, divisibility bounds for continued fraction convergents.",
-      "Once Mathlib includes a formal model of fast multiplication (FFT-based or Karatsuba), can the $O(M(n)\\log n)$ bit-complexity bound be formally stated and proved? This would require defining 'arithmetic circuit complexity' or a comparable cost model in Lean 4, connecting `hgcdMatrix_joint_bound` to a recursion tree analysis.",
-      "Can the verified GCD algorithm be connected to applications? E.g., a formally verified RSA key generation procedure that relies on `hgcdMatrixOf_preserves_gcd` for its correctness guarantee."
-    ]
-  }
+        {
+            "id": "oq-01",
+            "question": "Can the recursive case of hgcdMatrix_joint_bound be closed by formalizing quotient stability (≈200 lines of Lean infrastructure from Stehlé–Zimmermann §3–4)?",
+            "difficulty": "hard",
+            "tags": [
+                "size-reduction",
+                "quotient-stability",
+                "lean4"
+            ]
+        },
+        {
+            "id": "oq-02",
+            "question": "Can the O(M(n)·log n) bit complexity bound be stated and proved once Mathlib gains a model for fast multiplication and bit-operation costs?",
+            "difficulty": "very-hard",
+            "tags": [
+                "complexity",
+                "bit-complexity",
+                "fast-multiplication",
+                "mathlib"
+            ]
+        }
+    ],
+    "leanFile": {
+        "namespace": "HGcd",
+        "lineCount": 1020,
+        "axiomCount": 0,
+        "theoremCount": 35,
+        "definitionCount": 6,
+        "path": "Proofs/BinaryGcdOQ03OQ02.lean",
+        "sorries": 1
+    },
+    "conclusion": {
+        "summary": "This formalization of Schönhage's recursive HGCD establishes the core correctness layer in 936 lines with a single sorry. The three main theorems — `cofactor_mul_apply` (compositional algebra), `hgcdMatrix_det_unit` (unimodularity by fuel induction), and `hgcdMatrix_preserves_gcd` (operational correctness) — formally verify that Schönhage's two-level recursion produces a GCD-preserving matrix. The size-reduction infrastructure (row-convention invariant, Cramer identity, entry bounds, perturbation decomposition) is complete except for the quotient stability lemma needed for the recursive size bound. Together with `BinaryGcdOQ03` (the Lehmer hybrid), this represents the first Lean formalization of the HGCD algorithm's correctness structure.",
+        "implications": "Schönhage's HGCD is the inner loop of every modern number theory computation involving large integers: RSA key generation, elliptic curve scalar multiplication, polynomial GCD in computer algebra systems, and lattice basis reduction (LLL algorithm). Formalizing its correctness in Lean 4 provides a verified foundation for future cryptographic algorithm verification. The quotient stability sorry (≈200 lines remaining) is the only gap between this formalization and a complete proof of size reduction — once closed, the file would establish the full recursive structure needed to state the $O(M(n)\\log n)$ complexity claim. The GMP library's `mpn_hgcd` implements exactly this algorithm for production GCD computation; a Lean verification would enable formal auditing of such production code.",
+        "openQuestions": [
+            "Can the quotient stability lemma (Stehlé–Zimmermann §3–4) be formalized in ≈200 lines to close the sorry in `hgcdMatrix_joint_bound`? The key is Theorem 4 of Stehlé–Zimmermann 2004: 'if $2^s > 4\\max(a,b)/\\gcd(a,b)$, the first $k$ Euclidean quotients of $(a_H, b_H)$ and $(a,b)$ agree.' Lean infrastructure needed: remainder sequence properties, divisibility bounds for continued fraction convergents.",
+            "Once Mathlib includes a formal model of fast multiplication (FFT-based or Karatsuba), can the $O(M(n)\\log n)$ bit-complexity bound be formally stated and proved? This would require defining 'arithmetic circuit complexity' or a comparable cost model in Lean 4, connecting `hgcdMatrix_joint_bound` to a recursion tree analysis.",
+            "Can the verified GCD algorithm be connected to applications? E.g., a formally verified RSA key generation procedure that relies on `hgcdMatrixOf_preserves_gcd` for its correctness guarantee."
+        ]
+    }
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -1,171 +1,181 @@
 {
-  "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03",
-  "title": "Weighted Power Mean Chain: WHM ≤ WGM ≤ WAM ≤ WQM",
-  "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03",
-  "description": "The unweighted power mean chain HM ≤ GM ≤ AM ≤ QM generalizes fully to weighted means. For any positive reals a, b and weights w₁, w₂ > 0 with w₁ + w₂ = 1, the weighted harmonic, geometric, arithmetic, and quadratic means satisfy WHM ≤ WGM ≤ WAM ≤ WQM.",
-  "meta": {
-    "author": "Formal verification",
-    "date": "2026",
-    "status": "verified",
-    "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03.lean",
-    "parentProofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
-    "tags": [
-      "inequalities",
-      "power-means",
-      "weighted",
-      "AM-GM",
-      "Jensen",
-      "research"
+    "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03",
+    "title": "Weighted Power Mean Chain: WHM ≤ WGM ≤ WAM ≤ WQM",
+    "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03",
+    "description": "The unweighted power mean chain HM ≤ GM ≤ AM ≤ QM generalizes fully to weighted means. For any positive reals a, b and weights w₁, w₂ > 0 with w₁ + w₂ = 1, the weighted harmonic, geometric, arithmetic, and quadratic means satisfy WHM ≤ WGM ≤ WAM ≤ WQM.",
+    "meta": {
+        "author": "Formal verification",
+        "date": "2026",
+        "status": "verified",
+        "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03.lean",
+        "parentProofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+        "tags": [
+            "inequalities",
+            "power-means",
+            "weighted",
+            "AM-GM",
+            "Jensen",
+            "research"
+        ],
+        "badge": "original",
+        "sorries": 0,
+        "axiomCount": 0,
+        "lineCount": 210,
+        "assumptions": "No axioms or sorries. All results proved from first principles using Mathlib's weighted AM-GM.",
+        "dateAdded": "2026-05-04",
+        "mathlib_version": "4.26.0",
+        "mathlibDependencies": [
+            {
+                "theorem": "Real.geom_mean_le_arith_mean2_weighted",
+                "description": "Weighted 2-variable AM-GM: a^w₁ · b^w₂ ≤ w₁·a + w₂·b",
+                "module": "Mathlib.Analysis.MeanInequalities"
+            },
+            {
+                "theorem": "Real.sqrt_le_sqrt",
+                "description": "Monotonicity of square root",
+                "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+            },
+            {
+                "theorem": "inv_le_comm₀",
+                "description": "Inversion reverses order for positives: x⁻¹ ≤ y ↔ y⁻¹ ≤ x",
+                "module": "Mathlib.Algebra.Order.Field.Basic"
+            }
+        ],
+        "originalContributions": [
+            "Proves the weighted power mean chain WHM ≤ WGM ≤ WAM ≤ WQM for all weights w₁ + w₂ = 1",
+            "WGM ≤ WAM: direct from Mathlib's Real.geom_mean_le_arith_mean2_weighted",
+            "WAM ≤ WQM: Jensen's inequality via algebraic identity w₁·a² + w₂·b² - (w₁·a + w₂·b)² = w₁·w₂·(a-b)² ≥ 0",
+            "WHM ≤ WGM: applies WGM ≤ WAM to (1/a, 1/b) then uses inv_le_comm₀ (inversion reverses order)",
+            "Shows unweighted chain HM ≤ GM ≤ AM ≤ QM is the special case w₁ = w₂ = 1/2"
+        ],
+        "theoremCount": 14,
+        "definitionCount": 4
+    },
+    "overview": {
+        "historicalContext": "The power mean $M_p(a,b) = ((a^p + b^p)/2)^{1/p}$ and its weighted generalization $M_p^w(a,b) = (w_1 a^p + w_2 b^p)^{1/p}$ (for $w_1 + w_2 = 1$, $w_i > 0$) are central objects in classical analysis. Hardy, Littlewood, and Pólya proved that $M_p^w$ is monotone increasing in $p$ in their landmark 1934 treatise *Inequalities*. The four classical means HM, GM, AM, QM correspond to $p = -1, 0, 1, 2$ respectively (with GM as the $p \\to 0$ limit). Weighted versions arise naturally in probability (expectations) and information theory (Rényi entropy).\n\nThe weighted AM-GM inequality $a^{w_1} b^{w_2} \\le w_1 a + w_2 b$ is one of the most applied inequalities in mathematics, with proofs via Jensen's inequality (log-concavity), Young's inequality, and algebraic identities. Mathlib formalizes it as `Real.geom_mean_le_arith_mean2_weighted`.",
+        "problemStatement": "Does the power mean chain HM ≤ GM ≤ AM ≤ QM generalize to weighted means WHM ≤ WGM ≤ WAM ≤ WQM for weights w₁, w₂ > 0 with w₁ + w₂ = 1?",
+        "text": "For positive reals a, b and weights w₁ + w₂ = 1, the weighted harmonic, geometric, arithmetic, and quadratic means satisfy WHM ≤ WGM ≤ WAM ≤ WQM. The parent file proved the unweighted case (w₁ = w₂ = 1/2). This file proves the full weighted generalization.",
+        "proofStrategy": "Three-step chain: (1) WGM ≤ WAM is Mathlib's geom_mean_le_arith_mean2_weighted. (2) WAM ≤ WQM follows from Jensen: the algebraic identity w₁a² + w₂b² - (w₁a + w₂b)² = w₁w₂(a-b)² ≥ 0 gives (WAM)² ≤ (WQM)², and sqrt monotonicity closes. (3) WHM ≤ WGM applies WGM ≤ WAM to (1/a, 1/b) to get WGM(a,b)⁻¹ ≤ WHM(a,b)⁻¹, then uses inversion-antitone (inv_le_comm₀) to flip.",
+        "keyInsights": [
+            "WGM ≤ WAM: one-liner via Mathlib's Real.geom_mean_le_arith_mean2_weighted, which handles all the real-rpow bookkeeping",
+            "WAM ≤ WQM: Jensen via the identity w₁a² + w₂b² - (w₁a + w₂b)² = w₁w₂(a-b)². Proved by substituting w₂ = 1 - w₁ and calling ring.",
+            "WHM ≤ WGM: Applying WGM ≤ WAM to reciprocals (1/a, 1/b) gives WGM⁻¹ ≤ WHM⁻¹. Inversion reverses the inequality: WHM ≤ WGM. Key: inv_le_comm₀ encodes x⁻¹ ≤ y ↔ y⁻¹ ≤ x for positives.",
+            "The substitution w₂ = 1 - w₁ (from w₁ + w₂ = 1) enables ring to verify the Jensen identity algebraically.",
+            "Specialization to w₁ = w₂ = 1/2 recovers the unweighted chain as a pure corollary."
+        ],
+        "prerequisites": [
+            "Basic real analysis",
+            "Lean 4 rpow (Real.rpow) for irrational exponents",
+            "Mathlib: Analysis.MeanInequalities"
+        ]
+    },
+    "sections": [
+        {
+            "id": "definitions",
+            "title": "Weighted Mean Definitions",
+            "summary": "Four noncomputable defs: WHM, WGM, WAM, WQM",
+            "startLine": 40,
+            "endLine": 55,
+            "mathContext": "$\\text{WHM}(a,b) = (w_1/a + w_2/b)^{-1}$, $\\text{WGM}(a,b) = a^{w_1} b^{w_2}$, $\\text{WAM}(a,b) = w_1 a + w_2 b$, $\\text{WQM}(a,b) = \\sqrt{w_1 a^2 + w_2 b^2}$."
+        },
+        {
+            "id": "wgm-le-wam",
+            "title": "WGM ≤ WAM (Weighted AM-GM)",
+            "summary": "One-liner from Mathlib's Real.geom_mean_le_arith_mean2_weighted",
+            "startLine": 76,
+            "endLine": 84,
+            "mathContext": "$a^{w_1} b^{w_2} \\le w_1 a + w_2 b$ for $a,b \\ge 0$, $w_1,w_2 \\ge 0$, $w_1+w_2=1$."
+        },
+        {
+            "id": "wam-le-wqm",
+            "title": "WAM ≤ WQM (Jensen for f(x) = x²)",
+            "summary": "Jensen identity: w₁a² + w₂b² - (w₁a + w₂b)² = w₁w₂(a-b)² ≥ 0",
+            "startLine": 87,
+            "endLine": 110,
+            "mathContext": "$w_1 a + w_2 b \\le \\sqrt{w_1 a^2 + w_2 b^2}$. Key: $(w_1 a + w_2 b)^2 \\le w_1 a^2 + w_2 b^2$ with gap $w_1 w_2 (a-b)^2 \\ge 0$."
+        },
+        {
+            "id": "whm-le-wgm",
+            "title": "WHM ≤ WGM (Reciprocal + Inversion)",
+            "summary": "Apply WGM ≤ WAM to (1/a, 1/b); use inv_le_comm₀ to flip",
+            "startLine": 113,
+            "endLine": 145,
+            "mathContext": "$(w_1/a + w_2/b)^{-1} \\le a^{w_1} b^{w_2}$. Apply AM-GM to $(1/a, 1/b)$: $(1/a)^{w_1}(1/b)^{w_2} \\le w_1/a + w_2/b$, i.e., $\\text{WGM}^{-1} \\le \\text{WHM}^{-1}$. Inversion reverses: $\\text{WHM} \\le \\text{WGM}$."
+        },
+        {
+            "id": "main-chain",
+            "title": "Main Chain Theorem",
+            "summary": "WHM ≤ WGM ≤ WAM ≤ WQM combined",
+            "startLine": 148,
+            "endLine": 156,
+            "mathContext": "Full weighted power mean chain for $a,b > 0$ and $w_1, w_2 > 0$ with $w_1 + w_2 = 1$."
+        },
+        {
+            "id": "specialization",
+            "title": "Unweighted Chain as Special Case",
+            "summary": "w₁ = w₂ = 1/2 recovers HM ≤ GM ≤ AM ≤ QM",
+            "startLine": 159,
+            "endLine": 210,
+            "mathContext": "At $w_1 = w_2 = 1/2$: $\\text{WHM} = 2ab/(a+b)$, $\\text{WGM} = \\sqrt{ab}$, $\\text{WAM} = (a+b)/2$, $\\text{WQM} = \\sqrt{(a^2+b^2)/2}$."
+        }
     ],
-    "badge": "original",
-    "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 210,
-    "assumptions": "No axioms or sorries. All results proved from first principles using Mathlib's weighted AM-GM.",
-    "dateAdded": "2026-05-04",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "Real.geom_mean_le_arith_mean2_weighted",
-        "description": "Weighted 2-variable AM-GM: a^w₁ · b^w₂ ≤ w₁·a + w₂·b",
-        "module": "Mathlib.Analysis.MeanInequalities"
-      },
-      {
-        "theorem": "Real.sqrt_le_sqrt",
-        "description": "Monotonicity of square root",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
-      },
-      {
-        "theorem": "inv_le_comm₀",
-        "description": "Inversion reverses order for positives: x⁻¹ ≤ y ↔ y⁻¹ ≤ x",
-        "module": "Mathlib.Algebra.Order.Field.Basic"
-      }
+    "conclusion": {
+        "summary": "The weighted power mean chain WHM ≤ WGM ≤ WAM ≤ WQM holds for all positive weights w₁ + w₂ = 1. The key tool is Mathlib's Real.geom_mean_le_arith_mean2_weighted for the central WGM ≤ WAM step. The WHM ≤ WGM step via reciprocal inversion (inv_le_comm₀) is the most interesting Lean-specific technique.",
+        "implications": "The weighted generalization subsumes the unweighted chain as the special case w₁ = w₂ = 1/2. It also connects to probability theory: if a, b are outcomes with probabilities w₁, w₂, then WAM is the expected value E[X], WGM is exp(E[log X]), and WQM is √(E[X²]). The chain becomes E[X]² ≤ E[X²] (Cauchy-Schwarz / Jensen) as a special case.",
+        "openQuestions": [
+            "Can the monotonicity M_r^w ≤ M_s^w for all r ≤ s (not just -1, 0, 1, 2) be formalized in Lean? This requires Jensen's inequality for general convex functions.",
+            "Does the equality case WHM = WGM = WAM = WQM ↔ a = b extend to the weighted setting?",
+            "Can the n-variable weighted power mean chain be proved using Finset.sum and Real.geom_mean_le_arith_mean_weighted?"
+        ]
+    },
+    "references": [
+        {
+            "authors": [
+                "G. H. Hardy",
+                "J. E. Littlewood",
+                "G. Pólya"
+            ],
+            "title": "Inequalities",
+            "year": "1934",
+            "venue": "Cambridge University Press",
+            "note": "Seminal reference establishing the theory of power means including the monotonicity M_r^w ≤ M_s^w for r ≤ s."
+        },
+        {
+            "authors": [
+                "A.-L. Cauchy"
+            ],
+            "title": "Cours d'Analyse de l'École Royale Polytechnique",
+            "year": "1821",
+            "venue": "École Polytechnique",
+            "note": "First systematic algebraic treatment of the AM-GM inequality."
+        }
     ],
-    "originalContributions": [
-      "Proves the weighted power mean chain WHM ≤ WGM ≤ WAM ≤ WQM for all weights w₁ + w₂ = 1",
-      "WGM ≤ WAM: direct from Mathlib's Real.geom_mean_le_arith_mean2_weighted",
-      "WAM ≤ WQM: Jensen's inequality via algebraic identity w₁·a² + w₂·b² - (w₁·a + w₂·b)² = w₁·w₂·(a-b)² ≥ 0",
-      "WHM ≤ WGM: applies WGM ≤ WAM to (1/a, 1/b) then uses inv_le_comm₀ (inversion reverses order)",
-      "Shows unweighted chain HM ≤ GM ≤ AM ≤ QM is the special case w₁ = w₂ = 1/2"
+    "crossReferences": [
+        {
+            "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+            "relationship": "parent",
+            "description": "Parent file with unweighted HM ≤ GM ≤ AM ≤ QM chain — this file proves the weighted generalization"
+        },
+        {
+            "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-02",
+            "relationship": "sibling",
+            "description": "OQ02: showed ring + positivity automation for the same unweighted chain"
+        }
     ],
-    "theoremCount": 14,
-    "definitionCount": 4
-  },
-  "overview": {
-    "historicalContext": "The power mean $M_p(a,b) = ((a^p + b^p)/2)^{1/p}$ and its weighted generalization $M_p^w(a,b) = (w_1 a^p + w_2 b^p)^{1/p}$ (for $w_1 + w_2 = 1$, $w_i > 0$) are central objects in classical analysis. Hardy, Littlewood, and Pólya proved that $M_p^w$ is monotone increasing in $p$ in their landmark 1934 treatise *Inequalities*. The four classical means HM, GM, AM, QM correspond to $p = -1, 0, 1, 2$ respectively (with GM as the $p \\to 0$ limit). Weighted versions arise naturally in probability (expectations) and information theory (Rényi entropy).\n\nThe weighted AM-GM inequality $a^{w_1} b^{w_2} \\le w_1 a + w_2 b$ is one of the most applied inequalities in mathematics, with proofs via Jensen's inequality (log-concavity), Young's inequality, and algebraic identities. Mathlib formalizes it as `Real.geom_mean_le_arith_mean2_weighted`.",
-    "problemStatement": "Does the power mean chain HM ≤ GM ≤ AM ≤ QM generalize to weighted means WHM ≤ WGM ≤ WAM ≤ WQM for weights w₁, w₂ > 0 with w₁ + w₂ = 1?",
-    "text": "For positive reals a, b and weights w₁ + w₂ = 1, the weighted harmonic, geometric, arithmetic, and quadratic means satisfy WHM ≤ WGM ≤ WAM ≤ WQM. The parent file proved the unweighted case (w₁ = w₂ = 1/2). This file proves the full weighted generalization.",
-    "proofStrategy": "Three-step chain: (1) WGM ≤ WAM is Mathlib's geom_mean_le_arith_mean2_weighted. (2) WAM ≤ WQM follows from Jensen: the algebraic identity w₁a² + w₂b² - (w₁a + w₂b)² = w₁w₂(a-b)² ≥ 0 gives (WAM)² ≤ (WQM)², and sqrt monotonicity closes. (3) WHM ≤ WGM applies WGM ≤ WAM to (1/a, 1/b) to get WGM(a,b)⁻¹ ≤ WHM(a,b)⁻¹, then uses inversion-antitone (inv_le_comm₀) to flip.",
-    "keyInsights": [
-      "WGM ≤ WAM: one-liner via Mathlib's Real.geom_mean_le_arith_mean2_weighted, which handles all the real-rpow bookkeeping",
-      "WAM ≤ WQM: Jensen via the identity w₁a² + w₂b² - (w₁a + w₂b)² = w₁w₂(a-b)². Proved by substituting w₂ = 1 - w₁ and calling ring.",
-      "WHM ≤ WGM: Applying WGM ≤ WAM to reciprocals (1/a, 1/b) gives WGM⁻¹ ≤ WHM⁻¹. Inversion reverses the inequality: WHM ≤ WGM. Key: inv_le_comm₀ encodes x⁻¹ ≤ y ↔ y⁻¹ ≤ x for positives.",
-      "The substitution w₂ = 1 - w₁ (from w₁ + w₂ = 1) enables ring to verify the Jensen identity algebraically.",
-      "Specialization to w₁ = w₂ = 1/2 recovers the unweighted chain as a pure corollary."
-    ],
-    "prerequisites": [
-      "Basic real analysis",
-      "Lean 4 rpow (Real.rpow) for irrational exponents",
-      "Mathlib: Analysis.MeanInequalities"
-    ]
-  },
-  "sections": [
-    {
-      "id": "definitions",
-      "title": "Weighted Mean Definitions",
-      "summary": "Four noncomputable defs: WHM, WGM, WAM, WQM",
-      "startLine": 40,
-      "endLine": 55,
-      "mathContext": "$\\text{WHM}(a,b) = (w_1/a + w_2/b)^{-1}$, $\\text{WGM}(a,b) = a^{w_1} b^{w_2}$, $\\text{WAM}(a,b) = w_1 a + w_2 b$, $\\text{WQM}(a,b) = \\sqrt{w_1 a^2 + w_2 b^2}$."
+    "leanFile": {
+        "imports": [
+            "Mathlib"
+        ],
+        "opens": [
+            "Real"
+        ],
+        "namespace": "WeightedPowerMeanChain",
+        "lineCount": 210,
+        "axiomCount": 0,
+        "theoremCount": 15,
+        "definitionCount": 4,
+        "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03.lean",
+        "sorries": 0
     },
-    {
-      "id": "wgm-le-wam",
-      "title": "WGM ≤ WAM (Weighted AM-GM)",
-      "summary": "One-liner from Mathlib's Real.geom_mean_le_arith_mean2_weighted",
-      "startLine": 76,
-      "endLine": 84,
-      "mathContext": "$a^{w_1} b^{w_2} \\le w_1 a + w_2 b$ for $a,b \\ge 0$, $w_1,w_2 \\ge 0$, $w_1+w_2=1$."
-    },
-    {
-      "id": "wam-le-wqm",
-      "title": "WAM ≤ WQM (Jensen for f(x) = x²)",
-      "summary": "Jensen identity: w₁a² + w₂b² - (w₁a + w₂b)² = w₁w₂(a-b)² ≥ 0",
-      "startLine": 87,
-      "endLine": 110,
-      "mathContext": "$w_1 a + w_2 b \\le \\sqrt{w_1 a^2 + w_2 b^2}$. Key: $(w_1 a + w_2 b)^2 \\le w_1 a^2 + w_2 b^2$ with gap $w_1 w_2 (a-b)^2 \\ge 0$."
-    },
-    {
-      "id": "whm-le-wgm",
-      "title": "WHM ≤ WGM (Reciprocal + Inversion)",
-      "summary": "Apply WGM ≤ WAM to (1/a, 1/b); use inv_le_comm₀ to flip",
-      "startLine": 113,
-      "endLine": 145,
-      "mathContext": "$(w_1/a + w_2/b)^{-1} \\le a^{w_1} b^{w_2}$. Apply AM-GM to $(1/a, 1/b)$: $(1/a)^{w_1}(1/b)^{w_2} \\le w_1/a + w_2/b$, i.e., $\\text{WGM}^{-1} \\le \\text{WHM}^{-1}$. Inversion reverses: $\\text{WHM} \\le \\text{WGM}$."
-    },
-    {
-      "id": "main-chain",
-      "title": "Main Chain Theorem",
-      "summary": "WHM ≤ WGM ≤ WAM ≤ WQM combined",
-      "startLine": 148,
-      "endLine": 156,
-      "mathContext": "Full weighted power mean chain for $a,b > 0$ and $w_1, w_2 > 0$ with $w_1 + w_2 = 1$."
-    },
-    {
-      "id": "specialization",
-      "title": "Unweighted Chain as Special Case",
-      "summary": "w₁ = w₂ = 1/2 recovers HM ≤ GM ≤ AM ≤ QM",
-      "startLine": 159,
-      "endLine": 210,
-      "mathContext": "At $w_1 = w_2 = 1/2$: $\\text{WHM} = 2ab/(a+b)$, $\\text{WGM} = \\sqrt{ab}$, $\\text{WAM} = (a+b)/2$, $\\text{WQM} = \\sqrt{(a^2+b^2)/2}$."
-    }
-  ],
-  "conclusion": {
-    "summary": "The weighted power mean chain WHM ≤ WGM ≤ WAM ≤ WQM holds for all positive weights w₁ + w₂ = 1. The key tool is Mathlib's Real.geom_mean_le_arith_mean2_weighted for the central WGM ≤ WAM step. The WHM ≤ WGM step via reciprocal inversion (inv_le_comm₀) is the most interesting Lean-specific technique.",
-    "implications": "The weighted generalization subsumes the unweighted chain as the special case w₁ = w₂ = 1/2. It also connects to probability theory: if a, b are outcomes with probabilities w₁, w₂, then WAM is the expected value E[X], WGM is exp(E[log X]), and WQM is √(E[X²]). The chain becomes E[X]² ≤ E[X²] (Cauchy-Schwarz / Jensen) as a special case.",
-    "openQuestions": [
-      "Can the monotonicity M_r^w ≤ M_s^w for all r ≤ s (not just -1, 0, 1, 2) be formalized in Lean? This requires Jensen's inequality for general convex functions.",
-      "Does the equality case WHM = WGM = WAM = WQM ↔ a = b extend to the weighted setting?",
-      "Can the n-variable weighted power mean chain be proved using Finset.sum and Real.geom_mean_le_arith_mean_weighted?"
-    ]
-  },
-  "references": [
-    {
-      "authors": ["G. H. Hardy", "J. E. Littlewood", "G. Pólya"],
-      "title": "Inequalities",
-      "year": "1934",
-      "venue": "Cambridge University Press",
-      "note": "Seminal reference establishing the theory of power means including the monotonicity M_r^w ≤ M_s^w for r ≤ s."
-    },
-    {
-      "authors": ["A.-L. Cauchy"],
-      "title": "Cours d'Analyse de l'École Royale Polytechnique",
-      "year": "1821",
-      "venue": "École Polytechnique",
-      "note": "First systematic algebraic treatment of the AM-GM inequality."
-    }
-  ],
-  "crossReferences": [
-    {
-      "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
-      "relationship": "parent",
-      "description": "Parent file with unweighted HM ≤ GM ≤ AM ≤ QM chain — this file proves the weighted generalization"
-    },
-    {
-      "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-02",
-      "relationship": "sibling",
-      "description": "OQ02: showed ring + positivity automation for the same unweighted chain"
-    }
-  ],
-  "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real"],
-    "namespace": "WeightedPowerMeanChain",
-    "lineCount": 210,
-    "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 4,
-    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03.lean",
     "sorries": 0
-  },
-  "sorries": 0
 }

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/meta.json
@@ -1,190 +1,190 @@
 {
-  "id": "cauchy-schwarz-oq-01-oq-01-oq-02",
-  "title": "Robertson's Uncertainty Inequality from Cauchy-Schwarz",
-  "slug": "cauchy-schwarz-oq-01-oq-01-oq-02",
-  "description": "Derives the Heisenberg uncertainty principle for symmetric operators on complex inner product spaces via Robertson's inequality (1929): ΔA(ψ)·ΔB(ψ) ≥ (1/2)|⟨ψ|[A,B]|ψ⟩|. Follows directly from applying Cauchy-Schwarz to the centered vectors Aψ − ⟨A⟩ψ and Bψ − ⟨B⟩ψ.",
-  "meta": {
-    "author": "Lean Genius",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Uncertainty_principle#Robertson%E2%80%93Schr%C3%B6dinger_uncertainty_relations",
-    "date": "1929",
-    "status": "verified",
-    "tags": [
-      "analysis",
-      "inner-product-spaces",
-      "functional-analysis",
-      "quantum-mechanics",
-      "cauchy-schwarz",
-      "operators",
-      "research"
-    ],
-    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ01OQ02.lean",
-    "badge": "original",
-    "sorries": 0,
-    "dateAdded": "2026-05-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 148,
-    "theoremCount": 6,
-    "definitionCount": 3,
-    "mathlibDependencies": [
-      {
-        "theorem": "norm_inner_le_norm",
-        "description": "Cauchy-Schwarz inequality: ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖",
-        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
-      },
-      {
-        "theorem": "inner_conj_symm",
-        "description": "Conjugate symmetry: star⟪x,y⟫ = ⟪y,x⟫",
-        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
-      },
-      {
-        "theorem": "RCLike.norm_conj",
-        "description": "Complex conjugation preserves norm: ‖star z‖ = ‖z‖",
-        "module": "Mathlib.Analysis.RCLike.Basic"
-      },
-      {
-        "theorem": "LinearMap.IsSymmetric",
-        "description": "Self-adjoint operators: ⟪Ax,y⟫ = ⟪x,Ay⟫",
-        "module": "Mathlib.Analysis.InnerProductSpace.Symmetric"
-      },
-      {
-        "theorem": "inner_self_eq_norm_sq_to_K",
-        "description": "Self-inner product: ⟪ψ,ψ⟫ = ‖ψ‖² as a scalar",
-        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
-      }
-    ],
-    "originalContributions": [
-      "expVal: definition of quantum expectation value ⟪ψ,Aψ⟫_ℂ for linear operators",
-      "expVal_im_zero: symmetric operators have real expectation values (imaginary part = 0)",
-      "expVal_self_conj: expectation value equals its complex conjugate for symmetric A",
-      "stdDev: standard deviation ‖Aψ − ⟨A⟩ψ‖ of operator A in state ψ",
-      "commutatorEV: commutator expectation value ⟪ψ,[A,B]ψ⟫_ℂ",
-      "centered_antisymmetric_eq_commutator: the antisymmetric part of ⟪Aψ−⟨A⟩ψ, Bψ−⟨B⟩ψ⟫ equals the commutator expectation value",
-      "robertson_inequality: ΔA·ΔB ≥ (1/2)|⟨ψ|[A,B]|ψ⟩| for symmetric operators",
-      "heisenberg_constant_commutator: ΔA·ΔB ≥ |c|/2 when [A,B] = c·id"
-    ],
-    "mathlib_version": "4.26.0"
-  },
-  "overview": {
-    "historicalContext": "**Robertson's Uncertainty Principle (1929)**\n\nThe Heisenberg uncertainty principle (1927) originally stated that position and momentum cannot be simultaneously determined with arbitrary precision. Werner Heisenberg derived it using wave packet arguments, but the precise mathematical formulation was given by Howard Percy Robertson in 1929.\n\nRobertson showed that for *any* two symmetric (self-adjoint) operators A and B on a Hilbert space, and any unit state vector ψ:\n$$\\Delta A(\\psi) \\cdot \\Delta B(\\psi) \\geq \\frac{1}{2} |\\langle \\psi | [A, B] | \\psi \\rangle|$$\nwhere $\\Delta A(\\psi) = \\|A\\psi - \\langle A \\rangle_\\psi \\psi\\|$ is the standard deviation, and $[A,B] = AB - BA$ is the commutator.\n\nThe standard Heisenberg relation $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is the special case where $[\\hat{x}, \\hat{p}] = i\\hbar \\cdot \\text{id}$, giving $|\\langle \\psi | i\\hbar | \\psi \\rangle| = \\hbar$ for unit states.\n\nThe proof is a direct application of the Cauchy-Schwarz inequality to the centered vectors $u = A\\psi - \\langle A \\rangle \\psi$ and $v = B\\psi - \\langle B \\rangle \\psi$, making this a beautiful illustration of how a general analytical inequality gives rise to a foundational result in quantum physics.",
-    "problemStatement": "**Robertson's Uncertainty Inequality**\n\nFor symmetric operators A, B on a complex inner product space E, and any unit vector ψ ∈ E (‖ψ‖ = 1):\n$$\\Delta A(\\psi) \\cdot \\Delta B(\\psi) \\geq \\frac{1}{2} |\\langle \\psi, (AB - BA)\\psi \\rangle|$$\nwhere $\\Delta A(\\psi) = \\|A\\psi - \\langle\\psi, A\\psi\\rangle \\cdot \\psi\\|$.\n\nSpecial case: if [A,B] = c·id for constant c ∈ ℂ, then ΔA·ΔB ≥ |c|/2.",
-    "text": "The Heisenberg uncertainty principle, in its abstract Robertson form, follows from Cauchy-Schwarz applied to centered vectors from symmetric operators on a complex Hilbert space.",
-    "proofStrategy": "1. **CS antisymmetric bound** (Part I): For any u,v ∈ E, (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖. Proof: ‖z − star(z)‖ ≤ 2‖z‖ + RCLike.norm_conj + norm_inner_le_norm.\n2. **Real expectation values** (Part II): expVal A ψ = ⟪ψ,Aψ⟫ is real for symmetric A. Proof: star(⟪ψ,Aψ⟫) = ⟪Aψ,ψ⟫ = ⟪ψ,Aψ⟫ by IsSymmetric.\n3. **Commutator identity** (Part III): For centered u = Aψ − ⟨A⟩ψ and v = Bψ − ⟨B⟩ψ, ⟪u,v⟫ − ⟪v,u⟫ = commutatorEV A B ψ = ⟪ψ,(AB−BA)ψ⟫. Proof: expand, use real expectation values to cancel cross terms, use ⟪ψ,ψ⟫ = 1.\n4. **Assemble** (Part IV): stdDev A · stdDev B = ‖u‖·‖v‖ ≥ (1/2)|⟪u,v⟫ − ⟪v,u⟫| = (1/2)|commutatorEV A B ψ|.\n5. **Special case** (Part V): [A,B] = c·id → commutatorEV = c·⟪ψ,ψ⟫ = c → ΔA·ΔB ≥ |c|/2.",
-    "keyInsights": [
-      "**The antisymmetric inner product is the quantum-mechanical key**: ⟪u,v⟫ − ⟪v,u⟫ = 2i·Im⟪u,v⟫ is purely imaginary, and its magnitude is bounded by 2‖u‖·‖v‖ via CS + triangle inequality.",
-      "**Expectation values of symmetric operators are real**: ⟨A⟩ = ⟪ψ,Aψ⟫ satisfies star(⟨A⟩) = ⟨A⟩ because star⟪ψ,Aψ⟫ = ⟪Aψ,ψ⟫ = ⟪ψ,Aψ⟫ by symmetry. This is why cross terms cancel.",
-      "**The commutator identity is purely algebraic**: After expanding ⟪Aψ−⟨A⟩ψ, Bψ−⟨B⟩ψ⟫ − ⟪Bψ−⟨B⟩ψ, Aψ−⟨A⟩ψ⟫, the ⟨A⟩·⟨B⟩ terms cancel and the remaining terms reduce to ⟪ψ,ABψ⟫ − ⟪ψ,BAψ⟫.",
-      "**Unit state normalization**: The requirement ‖ψ‖ = 1 is used when simplifying ⟪ψ,ψ⟫ = 1 in the cross-term cancellation. For non-unit states, the inequality scales as ‖ψ‖².",
-      "**The Heisenberg relation is [x̂,p̂] = iħ special case**: Setting A = x̂, B = p̂, c = iħ gives |c| = ħ, so ΔxΔp ≥ ħ/2 — the standard Heisenberg bound."
-    ],
-    "prerequisites": [
-      "Complex inner product spaces",
-      "Linear operators",
-      "Cauchy-Schwarz inequality",
-      "Quantum mechanics (for motivation)"
-    ]
-  },
-  "sections": [
-    {
-      "id": "antisymmetric-bound",
-      "title": "Part I: CS Antisymmetric Bound",
-      "summary": "Proves (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖ via triangle inequality and norm_inner_le_norm. Private helper norm_sub_conj_le shows ‖z − star(z)‖ ≤ 2‖z‖; main theorem cs_antisymmetric_bound composes with CS.",
-      "startLine": 22,
-      "endLine": 43,
-      "mathContext": "The antisymmetric part $z - \\overline{z}$ has $\\|z - \\overline{z}\\| \\leq 2\\|z\\|$ by triangle inequality + $\\|\\overline{z}\\| = \\|z\\|$. Applied to $z = \\langle u,v\\rangle$: $\\frac{1}{2}\\|\\langle u,v\\rangle - \\langle v,u\\rangle\\| \\leq \\|\\langle u,v\\rangle\\| \\leq \\|u\\|\\cdot\\|v\\|$ (Cauchy-Schwarz)."
+    "id": "cauchy-schwarz-oq-01-oq-01-oq-02",
+    "title": "Robertson's Uncertainty Inequality from Cauchy-Schwarz",
+    "slug": "cauchy-schwarz-oq-01-oq-01-oq-02",
+    "description": "Derives the Heisenberg uncertainty principle for symmetric operators on complex inner product spaces via Robertson's inequality (1929): ΔA(ψ)·ΔB(ψ) ≥ (1/2)|⟨ψ|[A,B]|ψ⟩|. Follows directly from applying Cauchy-Schwarz to the centered vectors Aψ − ⟨A⟩ψ and Bψ − ⟨B⟩ψ.",
+    "meta": {
+        "author": "Lean Genius",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Uncertainty_principle#Robertson%E2%80%93Schr%C3%B6dinger_uncertainty_relations",
+        "date": "1929",
+        "status": "verified",
+        "tags": [
+            "analysis",
+            "inner-product-spaces",
+            "functional-analysis",
+            "quantum-mechanics",
+            "cauchy-schwarz",
+            "operators",
+            "research"
+        ],
+        "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ01OQ02.lean",
+        "badge": "original",
+        "sorries": 0,
+        "dateAdded": "2026-05-04",
+        "axiomCount": 0,
+        "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+        "lineCount": 148,
+        "theoremCount": 6,
+        "definitionCount": 3,
+        "mathlibDependencies": [
+            {
+                "theorem": "norm_inner_le_norm",
+                "description": "Cauchy-Schwarz inequality: ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖",
+                "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+            },
+            {
+                "theorem": "inner_conj_symm",
+                "description": "Conjugate symmetry: star⟪x,y⟫ = ⟪y,x⟫",
+                "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+            },
+            {
+                "theorem": "RCLike.norm_conj",
+                "description": "Complex conjugation preserves norm: ‖star z‖ = ‖z‖",
+                "module": "Mathlib.Analysis.RCLike.Basic"
+            },
+            {
+                "theorem": "LinearMap.IsSymmetric",
+                "description": "Self-adjoint operators: ⟪Ax,y⟫ = ⟪x,Ay⟫",
+                "module": "Mathlib.Analysis.InnerProductSpace.Symmetric"
+            },
+            {
+                "theorem": "inner_self_eq_norm_sq_to_K",
+                "description": "Self-inner product: ⟪ψ,ψ⟫ = ‖ψ‖² as a scalar",
+                "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+            }
+        ],
+        "originalContributions": [
+            "expVal: definition of quantum expectation value ⟪ψ,Aψ⟫_ℂ for linear operators",
+            "expVal_im_zero: symmetric operators have real expectation values (imaginary part = 0)",
+            "expVal_self_conj: expectation value equals its complex conjugate for symmetric A",
+            "stdDev: standard deviation ‖Aψ − ⟨A⟩ψ‖ of operator A in state ψ",
+            "commutatorEV: commutator expectation value ⟪ψ,[A,B]ψ⟫_ℂ",
+            "centered_antisymmetric_eq_commutator: the antisymmetric part of ⟪Aψ−⟨A⟩ψ, Bψ−⟨B⟩ψ⟫ equals the commutator expectation value",
+            "robertson_inequality: ΔA·ΔB ≥ (1/2)|⟨ψ|[A,B]|ψ⟩| for symmetric operators",
+            "heisenberg_constant_commutator: ΔA·ΔB ≥ |c|/2 when [A,B] = c·id"
+        ],
+        "mathlib_version": "4.26.0"
     },
-    {
-      "id": "symmetric-operators",
-      "title": "Part II: Symmetric Operators and Real Expectation Values",
-      "summary": "Defines expVal A ψ = ⟪ψ,Aψ⟫_ℂ. Proves expVal_im_zero (im part = 0 for symmetric A) and expVal_self_conj (expectation value = its conjugate, i.e., expVal is real).",
-      "startLine": 44,
-      "endLine": 66,
-      "mathContext": "By `A.IsSymmetric`: $\\overline{\\langle\\psi, A\\psi\\rangle} = \\langle A\\psi,\\psi\\rangle = \\langle\\psi,A\\psi\\rangle$. This forces $\\text{Im}(\\langle A\\rangle) = 0$, making expectation values real-valued — essential for the cross-term cancellation in Part III."
+    "overview": {
+        "historicalContext": "**Robertson's Uncertainty Principle (1929)**\n\nThe Heisenberg uncertainty principle (1927) originally stated that position and momentum cannot be simultaneously determined with arbitrary precision. Werner Heisenberg derived it using wave packet arguments, but the precise mathematical formulation was given by Howard Percy Robertson in 1929.\n\nRobertson showed that for *any* two symmetric (self-adjoint) operators A and B on a Hilbert space, and any unit state vector ψ:\n$$\\Delta A(\\psi) \\cdot \\Delta B(\\psi) \\geq \\frac{1}{2} |\\langle \\psi | [A, B] | \\psi \\rangle|$$\nwhere $\\Delta A(\\psi) = \\|A\\psi - \\langle A \\rangle_\\psi \\psi\\|$ is the standard deviation, and $[A,B] = AB - BA$ is the commutator.\n\nThe standard Heisenberg relation $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is the special case where $[\\hat{x}, \\hat{p}] = i\\hbar \\cdot \\text{id}$, giving $|\\langle \\psi | i\\hbar | \\psi \\rangle| = \\hbar$ for unit states.\n\nThe proof is a direct application of the Cauchy-Schwarz inequality to the centered vectors $u = A\\psi - \\langle A \\rangle \\psi$ and $v = B\\psi - \\langle B \\rangle \\psi$, making this a beautiful illustration of how a general analytical inequality gives rise to a foundational result in quantum physics.",
+        "problemStatement": "**Robertson's Uncertainty Inequality**\n\nFor symmetric operators A, B on a complex inner product space E, and any unit vector ψ ∈ E (‖ψ‖ = 1):\n$$\\Delta A(\\psi) \\cdot \\Delta B(\\psi) \\geq \\frac{1}{2} |\\langle \\psi, (AB - BA)\\psi \\rangle|$$\nwhere $\\Delta A(\\psi) = \\|A\\psi - \\langle\\psi, A\\psi\\rangle \\cdot \\psi\\|$.\n\nSpecial case: if [A,B] = c·id for constant c ∈ ℂ, then ΔA·ΔB ≥ |c|/2.",
+        "text": "The Heisenberg uncertainty principle, in its abstract Robertson form, follows from Cauchy-Schwarz applied to centered vectors from symmetric operators on a complex Hilbert space.",
+        "proofStrategy": "1. **CS antisymmetric bound** (Part I): For any u,v ∈ E, (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖. Proof: ‖z − star(z)‖ ≤ 2‖z‖ + RCLike.norm_conj + norm_inner_le_norm.\n2. **Real expectation values** (Part II): expVal A ψ = ⟪ψ,Aψ⟫ is real for symmetric A. Proof: star(⟪ψ,Aψ⟫) = ⟪Aψ,ψ⟫ = ⟪ψ,Aψ⟫ by IsSymmetric.\n3. **Commutator identity** (Part III): For centered u = Aψ − ⟨A⟩ψ and v = Bψ − ⟨B⟩ψ, ⟪u,v⟫ − ⟪v,u⟫ = commutatorEV A B ψ = ⟪ψ,(AB−BA)ψ⟫. Proof: expand, use real expectation values to cancel cross terms, use ⟪ψ,ψ⟫ = 1.\n4. **Assemble** (Part IV): stdDev A · stdDev B = ‖u‖·‖v‖ ≥ (1/2)|⟪u,v⟫ − ⟪v,u⟫| = (1/2)|commutatorEV A B ψ|.\n5. **Special case** (Part V): [A,B] = c·id → commutatorEV = c·⟪ψ,ψ⟫ = c → ΔA·ΔB ≥ |c|/2.",
+        "keyInsights": [
+            "**The antisymmetric inner product is the quantum-mechanical key**: ⟪u,v⟫ − ⟪v,u⟫ = 2i·Im⟪u,v⟫ is purely imaginary, and its magnitude is bounded by 2‖u‖·‖v‖ via CS + triangle inequality.",
+            "**Expectation values of symmetric operators are real**: ⟨A⟩ = ⟪ψ,Aψ⟫ satisfies star(⟨A⟩) = ⟨A⟩ because star⟪ψ,Aψ⟫ = ⟪Aψ,ψ⟫ = ⟪ψ,Aψ⟫ by symmetry. This is why cross terms cancel.",
+            "**The commutator identity is purely algebraic**: After expanding ⟪Aψ−⟨A⟩ψ, Bψ−⟨B⟩ψ⟫ − ⟪Bψ−⟨B⟩ψ, Aψ−⟨A⟩ψ⟫, the ⟨A⟩·⟨B⟩ terms cancel and the remaining terms reduce to ⟪ψ,ABψ⟫ − ⟪ψ,BAψ⟫.",
+            "**Unit state normalization**: The requirement ‖ψ‖ = 1 is used when simplifying ⟪ψ,ψ⟫ = 1 in the cross-term cancellation. For non-unit states, the inequality scales as ‖ψ‖².",
+            "**The Heisenberg relation is [x̂,p̂] = iħ special case**: Setting A = x̂, B = p̂, c = iħ gives |c| = ħ, so ΔxΔp ≥ ħ/2 — the standard Heisenberg bound."
+        ],
+        "prerequisites": [
+            "Complex inner product spaces",
+            "Linear operators",
+            "Cauchy-Schwarz inequality",
+            "Quantum mechanics (for motivation)"
+        ]
     },
-    {
-      "id": "commutator-identity",
-      "title": "Part III: Commutator Identity via inner_centered_eq",
-      "summary": "Defines commutatorEV A B ψ = ⟪ψ,(AB−BA)ψ⟫ and stdDev A ψ = ‖Aψ − ⟨A⟩ψ‖. Proves centered_antisymmetric_eq_commutator: for centered u = Aψ − ⟨A⟩ψ and v = Bψ − ⟨B⟩ψ, ⟪u,v⟫ − ⟪v,u⟫ equals commutatorEV A B ψ.",
-      "startLine": 67,
-      "endLine": 110,
-      "mathContext": "Private helper `inner_centered_eq` expands $\\langle Xψ - c\\psi, Yψ - d\\psi\\rangle = \\langle\\psi, X(Yψ)\\rangle - c \\cdot d$ using `A.IsSymmetric`, $\\langle\\psi,\\psi\\rangle=1$, and reality of $c = \\langle A\\rangle$. Then $\\langle u,v\\rangle - \\langle v,u\\rangle = (\\langle\\psi,ABψ\\rangle - cd) - (\\langle\\psi,BAψ\\rangle - cd) = \\langle\\psi,(AB-BA)\\psi\\rangle$."
-    },
-    {
-      "id": "robertson",
-      "title": "Part IV: Robertson's Inequality",
-      "summary": "Proves robertson_inequality: stdDev A ψ · stdDev B ψ ≥ (1/2)‖commutatorEV A B ψ‖. Directly composes Part I (cs_antisymmetric_bound on centered u,v) with Part III (antisymmetric part = commutator EV) via linarith.",
-      "startLine": 111,
-      "endLine": 129,
-      "mathContext": "$\\Delta A \\cdot \\Delta B = \\|u\\|\\cdot\\|v\\| \\geq \\frac{1}{2}|\\langle u,v\\rangle - \\langle v,u\\rangle| = \\frac{1}{2}|\\text{commutatorEV}(A,B,\\psi)|$. Assembly: `cs_antisymmetric_bound` + `centered_antisymmetric_eq_commutator` + `linarith`."
-    },
-    {
-      "id": "heisenberg",
-      "title": "Part V: Heisenberg for Constant Commutator",
-      "summary": "Proves heisenberg_constant_commutator: if [A,B] = c·id, then ΔA·ΔB ≥ |c|/2. Simplifies commutatorEV A B ψ = ⟪ψ,c·ψ⟫ = c·1 = c using hψ: ‖ψ‖=1, then applies robertson_inequality.",
-      "startLine": 130,
-      "endLine": 148,
-      "mathContext": "When $A(B\\psi) - B(A\\psi) = c\\psi$ for all $\\psi$: $\\text{commutatorEV}(A,B,\\psi) = \\langle\\psi, c\\psi\\rangle = c\\cdot\\langle\\psi,\\psi\\rangle = c\\cdot 1 = c$. So Robertson gives $\\Delta A \\cdot \\Delta B \\geq |c|/2$. Setting $c = i\\hbar$ for $[\\hat{x},\\hat{p}] = i\\hbar$: $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$."
-    }
-  ],
-  "conclusion": {
-    "summary": "Robertson's uncertainty inequality is proved with 0 sorries and 0 axioms, answering affirmatively: yes, the Heisenberg uncertainty principle can be derived from Cauchy-Schwarz in Lean 4.",
-    "implications": "This formalization bridges abstract functional analysis and quantum physics in Lean 4. The Heisenberg uncertainty principle emerges as a pure consequence of linear algebra (Cauchy-Schwarz) and the definition of symmetric operators — no physics axioms required. The general Robertson form covers all physical observables simultaneously.",
-    "openQuestions": [
-      "Can the Schrödinger uncertainty relation (tighter form including covariance) be formalized in Lean 4?",
-      "Can the AKLT spin chain ground state be characterized via these uncertainty bounds?"
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Analysis.InnerProductSpace.Basic",
-      "Mathlib.Analysis.InnerProductSpace.Symmetric",
-      "Mathlib.Analysis.RCLike.Basic",
-      "Mathlib.Tactic"
+    "sections": [
+        {
+            "id": "antisymmetric-bound",
+            "title": "Part I: CS Antisymmetric Bound",
+            "summary": "Proves (1/2)|⟪u,v⟫ − ⟪v,u⟫| ≤ ‖u‖·‖v‖ via triangle inequality and norm_inner_le_norm. Private helper norm_sub_conj_le shows ‖z − star(z)‖ ≤ 2‖z‖; main theorem cs_antisymmetric_bound composes with CS.",
+            "startLine": 22,
+            "endLine": 43,
+            "mathContext": "The antisymmetric part $z - \\overline{z}$ has $\\|z - \\overline{z}\\| \\leq 2\\|z\\|$ by triangle inequality + $\\|\\overline{z}\\| = \\|z\\|$. Applied to $z = \\langle u,v\\rangle$: $\\frac{1}{2}\\|\\langle u,v\\rangle - \\langle v,u\\rangle\\| \\leq \\|\\langle u,v\\rangle\\| \\leq \\|u\\|\\cdot\\|v\\|$ (Cauchy-Schwarz)."
+        },
+        {
+            "id": "symmetric-operators",
+            "title": "Part II: Symmetric Operators and Real Expectation Values",
+            "summary": "Defines expVal A ψ = ⟪ψ,Aψ⟫_ℂ. Proves expVal_im_zero (im part = 0 for symmetric A) and expVal_self_conj (expectation value = its conjugate, i.e., expVal is real).",
+            "startLine": 44,
+            "endLine": 66,
+            "mathContext": "By `A.IsSymmetric`: $\\overline{\\langle\\psi, A\\psi\\rangle} = \\langle A\\psi,\\psi\\rangle = \\langle\\psi,A\\psi\\rangle$. This forces $\\text{Im}(\\langle A\\rangle) = 0$, making expectation values real-valued — essential for the cross-term cancellation in Part III."
+        },
+        {
+            "id": "commutator-identity",
+            "title": "Part III: Commutator Identity via inner_centered_eq",
+            "summary": "Defines commutatorEV A B ψ = ⟪ψ,(AB−BA)ψ⟫ and stdDev A ψ = ‖Aψ − ⟨A⟩ψ‖. Proves centered_antisymmetric_eq_commutator: for centered u = Aψ − ⟨A⟩ψ and v = Bψ − ⟨B⟩ψ, ⟪u,v⟫ − ⟪v,u⟫ equals commutatorEV A B ψ.",
+            "startLine": 67,
+            "endLine": 110,
+            "mathContext": "Private helper `inner_centered_eq` expands $\\langle Xψ - c\\psi, Yψ - d\\psi\\rangle = \\langle\\psi, X(Yψ)\\rangle - c \\cdot d$ using `A.IsSymmetric`, $\\langle\\psi,\\psi\\rangle=1$, and reality of $c = \\langle A\\rangle$. Then $\\langle u,v\\rangle - \\langle v,u\\rangle = (\\langle\\psi,ABψ\\rangle - cd) - (\\langle\\psi,BAψ\\rangle - cd) = \\langle\\psi,(AB-BA)\\psi\\rangle$."
+        },
+        {
+            "id": "robertson",
+            "title": "Part IV: Robertson's Inequality",
+            "summary": "Proves robertson_inequality: stdDev A ψ · stdDev B ψ ≥ (1/2)‖commutatorEV A B ψ‖. Directly composes Part I (cs_antisymmetric_bound on centered u,v) with Part III (antisymmetric part = commutator EV) via linarith.",
+            "startLine": 111,
+            "endLine": 129,
+            "mathContext": "$\\Delta A \\cdot \\Delta B = \\|u\\|\\cdot\\|v\\| \\geq \\frac{1}{2}|\\langle u,v\\rangle - \\langle v,u\\rangle| = \\frac{1}{2}|\\text{commutatorEV}(A,B,\\psi)|$. Assembly: `cs_antisymmetric_bound` + `centered_antisymmetric_eq_commutator` + `linarith`."
+        },
+        {
+            "id": "heisenberg",
+            "title": "Part V: Heisenberg for Constant Commutator",
+            "summary": "Proves heisenberg_constant_commutator: if [A,B] = c·id, then ΔA·ΔB ≥ |c|/2. Simplifies commutatorEV A B ψ = ⟪ψ,c·ψ⟫ = c·1 = c using hψ: ‖ψ‖=1, then applies robertson_inequality.",
+            "startLine": 130,
+            "endLine": 148,
+            "mathContext": "When $A(B\\psi) - B(A\\psi) = c\\psi$ for all $\\psi$: $\\text{commutatorEV}(A,B,\\psi) = \\langle\\psi, c\\psi\\rangle = c\\cdot\\langle\\psi,\\psi\\rangle = c\\cdot 1 = c$. So Robertson gives $\\Delta A \\cdot \\Delta B \\geq |c|/2$. Setting $c = i\\hbar$ for $[\\hat{x},\\hat{p}] = i\\hbar$: $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$."
+        }
     ],
-    "opens": [
-      "InnerProductSpace",
-      "Complex"
+    "conclusion": {
+        "summary": "Robertson's uncertainty inequality is proved with 0 sorries and 0 axioms, answering affirmatively: yes, the Heisenberg uncertainty principle can be derived from Cauchy-Schwarz in Lean 4.",
+        "implications": "This formalization bridges abstract functional analysis and quantum physics in Lean 4. The Heisenberg uncertainty principle emerges as a pure consequence of linear algebra (Cauchy-Schwarz) and the definition of symmetric operators — no physics axioms required. The general Robertson form covers all physical observables simultaneously.",
+        "openQuestions": [
+            "Can the Schrödinger uncertainty relation (tighter form including covariance) be formalized in Lean 4?",
+            "Can the AKLT spin chain ground state be characterized via these uncertainty bounds?"
+        ]
+    },
+    "leanFile": {
+        "imports": [
+            "Mathlib.Analysis.InnerProductSpace.Basic",
+            "Mathlib.Analysis.InnerProductSpace.Symmetric",
+            "Mathlib.Analysis.RCLike.Basic",
+            "Mathlib.Tactic"
+        ],
+        "opens": [
+            "InnerProductSpace",
+            "Complex"
+        ],
+        "namespace": "CauchySchwarzOQ01OQ01OQ02",
+        "lineCount": 148,
+        "axiomCount": 0,
+        "theoremCount": 8,
+        "definitionCount": 3,
+        "path": "Proofs/CauchySchwarzOQ01OQ01OQ02.lean",
+        "sorries": 0
+    },
+    "references": [
+        {
+            "authors": "H. P. Robertson",
+            "title": "The Uncertainty Principle",
+            "year": "1929",
+            "venue": "Physical Review 34(1):163–164",
+            "note": "Original derivation of the general uncertainty inequality from Cauchy-Schwarz"
+        },
+        {
+            "authors": "W. Heisenberg",
+            "title": "Über den anschaulichen Inhalt der quantentheoretischen Kinematik und Mechanik",
+            "year": "1927",
+            "venue": "Zeitschrift für Physik 43(3-4):172–198",
+            "note": "Original Heisenberg uncertainty paper"
+        }
     ],
-    "namespace": "CauchySchwarzOQ01OQ01OQ02",
-    "lineCount": 148,
-    "axiomCount": 0,
-    "theoremCount": 6,
-    "definitionCount": 3,
-    "path": "Proofs/CauchySchwarzOQ01OQ01OQ02.lean",
+    "crossReferences": [
+        {
+            "targetId": "cauchy-schwarz-oq-01-oq-01",
+            "relationship": "extends",
+            "description": "Parent: Cauchy-Schwarz equality characterization. This entry applies CS to derive Robertson's inequality."
+        },
+        {
+            "targetId": "cauchy-schwarz",
+            "relationship": "uses",
+            "description": "The core CS inequality ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖ is the key analytic input."
+        },
+        {
+            "targetId": "cauchy-schwarz-oq-01-oq-01-oq-01",
+            "relationship": "sibling",
+            "description": "Sibling OQ: Gram-Schmidt orthogonalization from CS equality. Both explore consequences of Cauchy-Schwarz for linear operators."
+        }
+    ],
     "sorries": 0
-  },
-  "references": [
-    {
-      "authors": "H. P. Robertson",
-      "title": "The Uncertainty Principle",
-      "year": "1929",
-      "venue": "Physical Review 34(1):163–164",
-      "note": "Original derivation of the general uncertainty inequality from Cauchy-Schwarz"
-    },
-    {
-      "authors": "W. Heisenberg",
-      "title": "Über den anschaulichen Inhalt der quantentheoretischen Kinematik und Mechanik",
-      "year": "1927",
-      "venue": "Zeitschrift für Physik 43(3-4):172–198",
-      "note": "Original Heisenberg uncertainty paper"
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "cauchy-schwarz-oq-01-oq-01",
-      "relationship": "extends",
-      "description": "Parent: Cauchy-Schwarz equality characterization. This entry applies CS to derive Robertson's inequality."
-    },
-    {
-      "targetId": "cauchy-schwarz",
-      "relationship": "uses",
-      "description": "The core CS inequality ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖ is the key analytic input."
-    },
-    {
-      "targetId": "cauchy-schwarz-oq-01-oq-01-oq-01",
-      "relationship": "sibling",
-      "description": "Sibling OQ: Gram-Schmidt orthogonalization from CS equality. Both explore consequences of Cauchy-Schwarz for linear operators."
-    }
-  ],
-  "sorries": 0
 }

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -124,7 +124,7 @@
         "namespace": "CayleyHamiltonCyclicVectorAllFields",
         "lineCount": 268,
         "axiomCount": 0,
-        "theoremCount": 3,
+        "theoremCount": 8,
         "definitionCount": 2,
         "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
         "sorries": 0,

--- a/src/data/proofs/chebyshev-bounds-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04/meta.json
@@ -1,147 +1,147 @@
 {
-  "id": "chebyshev-bounds-oq-04",
-  "title": "Chebyshev's Second Function: \u03c8(n) Bounds",
-  "slug": "chebyshev-bounds-oq-04",
-  "description": "The second Chebyshev function \u03c8(n) = \u03a3_{k \u2264 n} \u039b(k) sums the von Mangoldt function \u039b over all integers up to n. Unlike the first Chebyshev function \u03b8 which sums log p over primes, \u03c8 includes all prime powers p^j. This entry proves \u03b8(n) \u2264 \u03c8(n) (directly from the subset structure), derives the lower bound \u03c8(2n) - \u03c8(n) \u2265 log(n+1) from Bertrand's postulate, and axiomatizes the upper bound \u03c8(n) \u2264 2n\u00b7log 2 and the Prime Number Theorem equivalence \u03c8(n)/n \u2192 1.",
-  "meta": {
-    "author": "Lean Genius",
-    "date": "2026-05-03",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/ChebyshevBoundsOQ04.lean",
-    "tags": [
-      "number-theory",
-      "chebyshev-bounds",
-      "von-mangoldt",
-      "prime-number-theorem",
-      "bertrand-postulate",
-      "analytic-number-theory"
+    "id": "chebyshev-bounds-oq-04",
+    "title": "Chebyshev's Second Function: ψ(n) Bounds",
+    "slug": "chebyshev-bounds-oq-04",
+    "description": "The second Chebyshev function ψ(n) = Σ_{k ≤ n} Λ(k) sums the von Mangoldt function Λ over all integers up to n. Unlike the first Chebyshev function θ which sums log p over primes, ψ includes all prime powers p^j. This entry proves θ(n) ≤ ψ(n) (directly from the subset structure), derives the lower bound ψ(2n) - ψ(n) ≥ log(n+1) from Bertrand's postulate, and axiomatizes the upper bound ψ(n) ≤ 2n·log 2 and the Prime Number Theorem equivalence ψ(n)/n → 1.",
+    "meta": {
+        "author": "Lean Genius",
+        "date": "2026-05-03",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/ChebyshevBoundsOQ04.lean",
+        "tags": [
+            "number-theory",
+            "chebyshev-bounds",
+            "von-mangoldt",
+            "prime-number-theorem",
+            "bertrand-postulate",
+            "analytic-number-theory"
+        ],
+        "badge": "axiom",
+        "sorries": 0,
+        "dateAdded": "2026-05-03",
+        "axiomCount": 2,
+        "assumptions": "2 axioms: (1) chebyshevPsi_asymptotic — ψ(n)/n → 1, the Prime Number Theorem for ψ; (2) pnt_equivalence — ψ(n)/n → 1 ↔ π(n) ~ n/log n. chebyshevPsi_upper_bound is now proved (strong induction via psi_odd_le_log_choose + Nat.choose_middle_le_pow).",
+        "lineCount": 386,
+        "theoremCount": 10,
+        "definitionCount": 2,
+        "originalContributions": [
+            "Definition of the second Chebyshev function ψ(n) = Σ_{k ≤ n} Λ(k) using Mathlib's vonMangoldt function",
+            "Proof that θ(n) ≤ ψ(n): rewrites log p as vonMangoldt p for primes (chebyshevThetaOQ_eq_sumVonMangoldt), then uses subset sum monotonicity",
+            "Proof of chebyshevPsi_doubling_lower: ψ(2n) − ψ(n) ≥ log(n+1) from Bertrand's postulate — the Bertrand prime p in (n, 2n] contributes Λ(p) = log p ≥ log(n+1) to the difference",
+            "Summary theorem chebyshevPsi_bounds combining θ ≤ ψ and the Bertrand lower bound",
+            "Proof of log_factorial_vonMangoldt (Fubini step): log(m!) = Σ_{d ∈ range(m+1)} Λ(d)·⌊m/d⌋ via vonMangoldt_sum, Finset.sum_comm', and Nat.card_multiples'",
+            "Proof of psi_doubling_le_log_centralBinom: ψ(2n)−ψ(n) ≤ log C(2n,n) via Fubini identity on log factorials, floor coefficients 1 for d ∈ (n,2n] (Nat.div_eq_of_lt_le), and Hermite inequality for d ≤ n (Nat.mul_div_le_mul_div_assoc)",
+            "Proof of chebyshevPsi_doubling_le: chains psi_doubling_le_log_centralBinom with log C(2n,n) ≤ 2n·log 2 via Nat.centralBinom_le_four_pow + Real.log_pow",
+            "Proof of psi_odd_le_log_choose: ψ(2m+1)−ψ(m+1) ≤ log C(2m+1,m) via Hermite floor inequality — for d ∈ (m+1,2m+1], ⌊(2m+1)/d⌋=1 and ⌊m/d⌋=⌊(m+1)/d⌋=0",
+            "Proof of chebyshevPsi_upper_bound: strong induction with even case via chebyshevPsi_doubling_le and odd case via Nat.choose_middle_le_pow (C(2m+1,m) ≤ 4^m) — axiomCount 3→2"
+        ]
+    },
+    "overview": {
+        "historicalContext": "The second Chebyshev function ψ(x) = Σ_{p^k ≤ x} log p was introduced by Chebyshev alongside θ(x) = Σ_{p ≤ x} log p. While θ counts primes with logarithmic weight, ψ also counts prime powers, making it analytic ally more tractable: ψ(x) = Σ_p ⌊log_p(x)⌋ · log p, which connects to the logarithmic derivative of the Riemann zeta function via ψ(x) = -Σ_ρ x^ρ/ρ + x - log(2π) - ½log(1 - x^{-2}) (Riemann's explicit formula). The Prime Number Theorem — proved independently by Hadamard and de la Vallée Poussin in 1896 — is equivalent to ψ(x) ~ x.",
+        "problemStatement": "Define the second Chebyshev function ψ(n) = Σ_{k ≤ n} Λ(k) where Λ is the von Mangoldt function, and prove:\n\n1. **θ(n) ≤ ψ(n)**: the first Chebyshev function is bounded by the second\n2. **ψ(2n) − ψ(n) ≥ log(n+1)** for n ≥ 1: the Bertrand lower bound on increments\n3. **ψ(n) ≤ 2n·log 2**: the Chebyshev upper bound (axiomatized)\n4. **ψ(n)/n → 1**: the Prime Number Theorem for ψ (axiomatized)",
+        "proofStrategy": "The bound θ(n) ≤ ψ(n) follows cleanly: for any prime p ≤ n, Λ(p) = log p, so the sum defining θ is a sub-sum of ψ with the same summand (after rewriting via vonMangoldt_apply_prime). Since Λ(k) ≥ 0 for all k, adding more terms only increases the sum.\n\nThe lower bound ψ(2n) − ψ(n) ≥ log(n+1) uses Bertrand's postulate: there exists a prime p with n < p ≤ 2n (Mathlib's Nat.exists_prime_lt_and_le_two_mul_add_one). Since p > n, we have log p ≥ log(n+1). Since p ∈ range(2n+1) but p ∉ range(n+1), its contribution Λ(p) = log p appears in ψ(2n) but not ψ(n), giving ψ(2n) − ψ(n) ≥ Λ(p) ≥ log(n+1).\n\nThe upper bound ψ(n) ≤ 2n·log 2 follows by telescoping: applying the doubling lemma ψ(m) − ψ(m/2) ≤ m·log 2 repeatedly, the geometric series Σ m·2^{-k} converges to 2m. The doubling lemma itself follows from the central binomial estimate: prime powers in (m/2, m] divide C(m, ⌊m/2⌋) ≤ 2^m.",
+        "keyInsights": [
+            "The key identity vonMangoldt_apply_prime (Λ(p) = log p for primes) allows rewriting θ as a sum of vonMangoldt values over primes, making the θ ≤ ψ comparison immediate via Finset.sum_le_sum_of_subset_of_nonneg",
+            "Bertrand's postulate gives a concrete witness for the gap ψ(2n) − ψ(n): the Bertrand prime p falls in range(2n+1) \\ range(n+1), contributing Λ(p) = log p ≥ log(n+1) to the difference",
+            "The difference ψ(n) − θ(n) consists of contributions from prime powers p^j with j ≥ 2, each contributing log p. The total O(√n·log n) is asymptotically negligible compared to ψ(n) ~ n",
+            "The equivalence ψ(n) ~ n ↔ π(n) ~ n/log n (the two forms of PNT) is a classical result via Abel summation / Mertens' theorem; axiomatizing it captures the statement without the analytic machinery",
+            "The central binomial coefficient C(2n,n) ≤ 4^n (i.e., log C(2n,n) ≤ 2n·log 2) is the key combinatorial bound for the upper estimate: every prime power p^k in (n,2n] divides C(2n,n), so the product of such prime powers is at most C(2n,n) ≤ 4^n, giving ψ(2n) − ψ(n) ≤ log(4^n) = 2n·log 2"
+        ],
+        "prerequisites": [
+            "Number theory (von Mangoldt function, prime powers, primorial)",
+            "Real analysis (logarithms, summation by parts)",
+            "Bertrand's postulate",
+            "Mathlib: ArithmeticFunction.vonMangoldt, vonMangoldt_apply_prime, vonMangoldt_nonneg"
+        ]
+    },
+    "conclusion": {
+        "summary": "This entry defines the second Chebyshev function ψ(n) in Lean 4 using Mathlib's von Mangoldt function, proves the key inequality θ(n) ≤ ψ(n) from the subset structure of the defining sums, and establishes the Bertrand lower bound ψ(2n) − ψ(n) ≥ log(n+1). The Chebyshev upper bound and PNT equivalence are axiomatized with proof sketches.",
+        "implications": "The second Chebyshev function ψ is the most analytically tractable of the prime-counting functions: its explicit formula connects it directly to zeros of the Riemann zeta function. Proving ψ(n) ~ n is equivalent to proving the Prime Number Theorem, and the Riemann Hypothesis is equivalent to the error term |ψ(n) − n| = O(√n · log²n).",
+        "openQuestions": [
+            "Prove the full PNT ψ(n)/n → 1 from scratch in Lean 4 — currently requires either complex analysis of ζ(s) or an elementary proof (Selberg/Erdős 1949 style)",
+            "Formalize the explicit formula ψ(x) = x − Σ_ρ x^ρ/ρ − log(2π) connecting ψ to nontrivial zeros of ζ(s)"
+        ]
+    },
+    "sections": [
+        {
+            "id": "sec-psi-definition",
+            "title": "Definitions: ψ(n) and θ(n)",
+            "startLine": 36,
+            "endLine": 77,
+            "summary": "Defines chebyshevPsi n = Σ_{k ∈ range(n+1)} vonMangoldt k and chebyshevThetaOQ n = Σ_{p prime ≤ n} log p. Proves non-negativity of both (chebyshevPsi_nonneg, chebyshevThetaOQ_nonneg) and the key identity vonMangoldt_prime_eq: Λ(p) = log p for primes."
+        },
+        {
+            "id": "sec-theta-le-psi",
+            "title": "θ(n) ≤ ψ(n)",
+            "startLine": 78,
+            "endLine": 124,
+            "summary": "Proves chebyshevTheta_le_chebyshevPsi via two steps: (1) chebyshevThetaOQ_eq_sumVonMangoldt rewrites log p as vonMangoldt p for primes using Finset.sum_congr; (2) theta_le_psi_via_vonMangoldt applies Finset.sum_le_sum_of_subset_of_nonneg since the prime filter is a subset of the full range."
+        },
+        {
+            "id": "sec-upper-bound",
+            "title": "Upper Bound ψ(n) ≤ 2n·log 2",
+            "startLine": 125,
+            "endLine": 160,
+            "summary": "Axiomatizes chebyshevPsi_doubling_le (the key step: ψ(2n) − ψ(n) ≤ 2n·log 2 from the central binomial coefficient C(2n,n) ≤ 4^n) and chebyshevPsi_upper_bound (the full bound by geometric series telescoping)."
+        },
+        {
+            "id": "sec-lower-bound",
+            "title": "Lower Bound from Bertrand's Postulate",
+            "startLine": 161,
+            "endLine": 187,
+            "summary": "Proves chebyshevPsi_doubling_lower: ψ(2n) − ψ(n) ≥ log(n+1) for n ≥ 1. Uses Bertrand's postulate (Nat.exists_prime_lt_and_le_two_mul_add_one) to find a prime p ∈ (n, 2n]. The prime p contributes vonMangoldt p = log p ≥ log(n+1) to ψ(2n) but not to ψ(n), so the difference is bounded below by Finset.single_le_sum."
+        },
+        {
+            "id": "sec-pnt",
+            "title": "PNT Equivalence (Axiomatized)",
+            "startLine": 188,
+            "endLine": 219,
+            "summary": "Axiomatizes chebyshevPsi_asymptotic (ψ(n)/n → 1, the PNT for ψ) and pnt_equivalence (ψ(n)/n → 1 ↔ π(n) ~ n/log n). Summary theorem chebyshevPsi_bounds packages θ ≤ ψ and the Bertrand lower bound."
+        }
     ],
-    "badge": "axiom",
-    "sorries": 0,
-    "dateAdded": "2026-05-03",
-    "axiomCount": 2,
-    "assumptions": "2 axioms: (1) chebyshevPsi_asymptotic \u2014 \u03c8(n)/n \u2192 1, the Prime Number Theorem for \u03c8; (2) pnt_equivalence \u2014 \u03c8(n)/n \u2192 1 \u2194 \u03c0(n) ~ n/log n. chebyshevPsi_upper_bound is now proved (strong induction via psi_odd_le_log_choose + Nat.choose_middle_le_pow).",
-    "lineCount": 386,
-    "theoremCount": 10,
-    "definitionCount": 2,
-    "originalContributions": [
-      "Definition of the second Chebyshev function \u03c8(n) = \u03a3_{k \u2264 n} \u039b(k) using Mathlib's vonMangoldt function",
-      "Proof that \u03b8(n) \u2264 \u03c8(n): rewrites log p as vonMangoldt p for primes (chebyshevThetaOQ_eq_sumVonMangoldt), then uses subset sum monotonicity",
-      "Proof of chebyshevPsi_doubling_lower: \u03c8(2n) \u2212 \u03c8(n) \u2265 log(n+1) from Bertrand's postulate \u2014 the Bertrand prime p in (n, 2n] contributes \u039b(p) = log p \u2265 log(n+1) to the difference",
-      "Summary theorem chebyshevPsi_bounds combining \u03b8 \u2264 \u03c8 and the Bertrand lower bound",
-      "Proof of log_factorial_vonMangoldt (Fubini step): log(m!) = \u03a3_{d \u2208 range(m+1)} \u039b(d)\u00b7\u230am/d\u230b via vonMangoldt_sum, Finset.sum_comm', and Nat.card_multiples'",
-      "Proof of psi_doubling_le_log_centralBinom: \u03c8(2n)\u2212\u03c8(n) \u2264 log C(2n,n) via Fubini identity on log factorials, floor coefficients 1 for d \u2208 (n,2n] (Nat.div_eq_of_lt_le), and Hermite inequality for d \u2264 n (Nat.mul_div_le_mul_div_assoc)",
-      "Proof of chebyshevPsi_doubling_le: chains psi_doubling_le_log_centralBinom with log C(2n,n) \u2264 2n\u00b7log 2 via Nat.centralBinom_le_four_pow + Real.log_pow",
-      "Proof of psi_odd_le_log_choose: \u03c8(2m+1)\u2212\u03c8(m+1) \u2264 log C(2m+1,m) via Hermite floor inequality \u2014 for d \u2208 (m+1,2m+1], \u230a(2m+1)/d\u230b=1 and \u230am/d\u230b=\u230a(m+1)/d\u230b=0",
-      "Proof of chebyshevPsi_upper_bound: strong induction with even case via chebyshevPsi_doubling_le and odd case via Nat.choose_middle_le_pow (C(2m+1,m) \u2264 4^m) \u2014 axiomCount 3\u21922"
-    ]
-  },
-  "overview": {
-    "historicalContext": "The second Chebyshev function \u03c8(x) = \u03a3_{p^k \u2264 x} log p was introduced by Chebyshev alongside \u03b8(x) = \u03a3_{p \u2264 x} log p. While \u03b8 counts primes with logarithmic weight, \u03c8 also counts prime powers, making it analytic ally more tractable: \u03c8(x) = \u03a3_p \u230alog_p(x)\u230b \u00b7 log p, which connects to the logarithmic derivative of the Riemann zeta function via \u03c8(x) = -\u03a3_\u03c1 x^\u03c1/\u03c1 + x - log(2\u03c0) - \u00bdlog(1 - x^{-2}) (Riemann's explicit formula). The Prime Number Theorem \u2014 proved independently by Hadamard and de la Vall\u00e9e Poussin in 1896 \u2014 is equivalent to \u03c8(x) ~ x.",
-    "problemStatement": "Define the second Chebyshev function \u03c8(n) = \u03a3_{k \u2264 n} \u039b(k) where \u039b is the von Mangoldt function, and prove:\n\n1. **\u03b8(n) \u2264 \u03c8(n)**: the first Chebyshev function is bounded by the second\n2. **\u03c8(2n) \u2212 \u03c8(n) \u2265 log(n+1)** for n \u2265 1: the Bertrand lower bound on increments\n3. **\u03c8(n) \u2264 2n\u00b7log 2**: the Chebyshev upper bound (axiomatized)\n4. **\u03c8(n)/n \u2192 1**: the Prime Number Theorem for \u03c8 (axiomatized)",
-    "proofStrategy": "The bound \u03b8(n) \u2264 \u03c8(n) follows cleanly: for any prime p \u2264 n, \u039b(p) = log p, so the sum defining \u03b8 is a sub-sum of \u03c8 with the same summand (after rewriting via vonMangoldt_apply_prime). Since \u039b(k) \u2265 0 for all k, adding more terms only increases the sum.\n\nThe lower bound \u03c8(2n) \u2212 \u03c8(n) \u2265 log(n+1) uses Bertrand's postulate: there exists a prime p with n < p \u2264 2n (Mathlib's Nat.exists_prime_lt_and_le_two_mul_add_one). Since p > n, we have log p \u2265 log(n+1). Since p \u2208 range(2n+1) but p \u2209 range(n+1), its contribution \u039b(p) = log p appears in \u03c8(2n) but not \u03c8(n), giving \u03c8(2n) \u2212 \u03c8(n) \u2265 \u039b(p) \u2265 log(n+1).\n\nThe upper bound \u03c8(n) \u2264 2n\u00b7log 2 follows by telescoping: applying the doubling lemma \u03c8(m) \u2212 \u03c8(m/2) \u2264 m\u00b7log 2 repeatedly, the geometric series \u03a3 m\u00b72^{-k} converges to 2m. The doubling lemma itself follows from the central binomial estimate: prime powers in (m/2, m] divide C(m, \u230am/2\u230b) \u2264 2^m.",
-    "keyInsights": [
-      "The key identity vonMangoldt_apply_prime (\u039b(p) = log p for primes) allows rewriting \u03b8 as a sum of vonMangoldt values over primes, making the \u03b8 \u2264 \u03c8 comparison immediate via Finset.sum_le_sum_of_subset_of_nonneg",
-      "Bertrand's postulate gives a concrete witness for the gap \u03c8(2n) \u2212 \u03c8(n): the Bertrand prime p falls in range(2n+1) \\ range(n+1), contributing \u039b(p) = log p \u2265 log(n+1) to the difference",
-      "The difference \u03c8(n) \u2212 \u03b8(n) consists of contributions from prime powers p^j with j \u2265 2, each contributing log p. The total O(\u221an\u00b7log n) is asymptotically negligible compared to \u03c8(n) ~ n",
-      "The equivalence \u03c8(n) ~ n \u2194 \u03c0(n) ~ n/log n (the two forms of PNT) is a classical result via Abel summation / Mertens' theorem; axiomatizing it captures the statement without the analytic machinery",
-      "The central binomial coefficient C(2n,n) \u2264 4^n (i.e., log C(2n,n) \u2264 2n\u00b7log 2) is the key combinatorial bound for the upper estimate: every prime power p^k in (n,2n] divides C(2n,n), so the product of such prime powers is at most C(2n,n) \u2264 4^n, giving \u03c8(2n) \u2212 \u03c8(n) \u2264 log(4^n) = 2n\u00b7log 2"
+    "crossReferences": [
+        {
+            "targetId": "chebyshev-bounds",
+            "relationship": "extends",
+            "description": "ChebyshevBounds proves bounds on the first Chebyshev function θ(n) and π(n); this entry introduces the second Chebyshev function ψ(n) which extends θ by including prime powers"
+        },
+        {
+            "targetId": "chebyshev-pnt-bridge",
+            "relationship": "related",
+            "description": "The PNT Bridge connects Chebyshev bounds toward the full Prime Number Theorem; the PNT equivalence axiomatized here (ψ(n)/n → 1 ↔ π(n) ~ n/log n) is central to that bridge"
+        },
+        {
+            "targetId": "bertrands-postulate",
+            "relationship": "uses",
+            "description": "Bertrand's postulate (existence of a prime in (n, 2n]) is the key tool for the lower bound proof"
+        }
     ],
-    "prerequisites": [
-      "Number theory (von Mangoldt function, prime powers, primorial)",
-      "Real analysis (logarithms, summation by parts)",
-      "Bertrand's postulate",
-      "Mathlib: ArithmeticFunction.vonMangoldt, vonMangoldt_apply_prime, vonMangoldt_nonneg"
-    ]
-  },
-  "conclusion": {
-    "summary": "This entry defines the second Chebyshev function \u03c8(n) in Lean 4 using Mathlib's von Mangoldt function, proves the key inequality \u03b8(n) \u2264 \u03c8(n) from the subset structure of the defining sums, and establishes the Bertrand lower bound \u03c8(2n) \u2212 \u03c8(n) \u2265 log(n+1). The Chebyshev upper bound and PNT equivalence are axiomatized with proof sketches.",
-    "implications": "The second Chebyshev function \u03c8 is the most analytically tractable of the prime-counting functions: its explicit formula connects it directly to zeros of the Riemann zeta function. Proving \u03c8(n) ~ n is equivalent to proving the Prime Number Theorem, and the Riemann Hypothesis is equivalent to the error term |\u03c8(n) \u2212 n| = O(\u221an \u00b7 log\u00b2n).",
-    "openQuestions": [
-      "Prove the full PNT \u03c8(n)/n \u2192 1 from scratch in Lean 4 \u2014 currently requires either complex analysis of \u03b6(s) or an elementary proof (Selberg/Erd\u0151s 1949 style)",
-      "Formalize the explicit formula \u03c8(x) = x \u2212 \u03a3_\u03c1 x^\u03c1/\u03c1 \u2212 log(2\u03c0) connecting \u03c8 to nontrivial zeros of \u03b6(s)"
-    ]
-  },
-  "sections": [
-    {
-      "id": "sec-psi-definition",
-      "title": "Definitions: \u03c8(n) and \u03b8(n)",
-      "startLine": 36,
-      "endLine": 77,
-      "summary": "Defines chebyshevPsi n = \u03a3_{k \u2208 range(n+1)} vonMangoldt k and chebyshevThetaOQ n = \u03a3_{p prime \u2264 n} log p. Proves non-negativity of both (chebyshevPsi_nonneg, chebyshevThetaOQ_nonneg) and the key identity vonMangoldt_prime_eq: \u039b(p) = log p for primes."
+    "leanFile": {
+        "namespace": "ChebyshevBoundsOQ04",
+        "lineCount": 386,
+        "path": "Proofs/ChebyshevBoundsOQ04.lean",
+        "axiomCount": 2,
+        "theoremCount": 14,
+        "definitionCount": 2,
+        "sorries": 0,
+        "imports": [
+            "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt",
+            "Mathlib.NumberTheory.Primorial",
+            "Mathlib.NumberTheory.PrimeCounting",
+            "Mathlib.NumberTheory.Bertrand",
+            "Mathlib.Data.Nat.Choose.Central",
+            "Mathlib.Data.Nat.Factorization.Basic",
+            "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+            "Mathlib.Tactic"
+        ],
+        "opens": [
+            "Nat",
+            "Finset",
+            "ArithmeticFunction"
+        ],
+        "additionalFiles": [
+            "Proofs/ChebyshevBoundsOQ04Aristotle.lean"
+        ]
     },
-    {
-      "id": "sec-theta-le-psi",
-      "title": "\u03b8(n) \u2264 \u03c8(n)",
-      "startLine": 78,
-      "endLine": 124,
-      "summary": "Proves chebyshevTheta_le_chebyshevPsi via two steps: (1) chebyshevThetaOQ_eq_sumVonMangoldt rewrites log p as vonMangoldt p for primes using Finset.sum_congr; (2) theta_le_psi_via_vonMangoldt applies Finset.sum_le_sum_of_subset_of_nonneg since the prime filter is a subset of the full range."
-    },
-    {
-      "id": "sec-upper-bound",
-      "title": "Upper Bound \u03c8(n) \u2264 2n\u00b7log 2",
-      "startLine": 125,
-      "endLine": 160,
-      "summary": "Axiomatizes chebyshevPsi_doubling_le (the key step: \u03c8(2n) \u2212 \u03c8(n) \u2264 2n\u00b7log 2 from the central binomial coefficient C(2n,n) \u2264 4^n) and chebyshevPsi_upper_bound (the full bound by geometric series telescoping)."
-    },
-    {
-      "id": "sec-lower-bound",
-      "title": "Lower Bound from Bertrand's Postulate",
-      "startLine": 161,
-      "endLine": 187,
-      "summary": "Proves chebyshevPsi_doubling_lower: \u03c8(2n) \u2212 \u03c8(n) \u2265 log(n+1) for n \u2265 1. Uses Bertrand's postulate (Nat.exists_prime_lt_and_le_two_mul_add_one) to find a prime p \u2208 (n, 2n]. The prime p contributes vonMangoldt p = log p \u2265 log(n+1) to \u03c8(2n) but not to \u03c8(n), so the difference is bounded below by Finset.single_le_sum."
-    },
-    {
-      "id": "sec-pnt",
-      "title": "PNT Equivalence (Axiomatized)",
-      "startLine": 188,
-      "endLine": 219,
-      "summary": "Axiomatizes chebyshevPsi_asymptotic (\u03c8(n)/n \u2192 1, the PNT for \u03c8) and pnt_equivalence (\u03c8(n)/n \u2192 1 \u2194 \u03c0(n) ~ n/log n). Summary theorem chebyshevPsi_bounds packages \u03b8 \u2264 \u03c8 and the Bertrand lower bound."
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "chebyshev-bounds",
-      "relationship": "extends",
-      "description": "ChebyshevBounds proves bounds on the first Chebyshev function \u03b8(n) and \u03c0(n); this entry introduces the second Chebyshev function \u03c8(n) which extends \u03b8 by including prime powers"
-    },
-    {
-      "targetId": "chebyshev-pnt-bridge",
-      "relationship": "related",
-      "description": "The PNT Bridge connects Chebyshev bounds toward the full Prime Number Theorem; the PNT equivalence axiomatized here (\u03c8(n)/n \u2192 1 \u2194 \u03c0(n) ~ n/log n) is central to that bridge"
-    },
-    {
-      "targetId": "bertrands-postulate",
-      "relationship": "uses",
-      "description": "Bertrand's postulate (existence of a prime in (n, 2n]) is the key tool for the lower bound proof"
-    }
-  ],
-  "leanFile": {
-    "namespace": "ChebyshevBoundsOQ04",
-    "lineCount": 386,
-    "path": "Proofs/ChebyshevBoundsOQ04.lean",
-    "axiomCount": 2,
-    "theoremCount": 10,
-    "definitionCount": 2,
-    "sorries": 0,
-    "imports": [
-      "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt",
-      "Mathlib.NumberTheory.Primorial",
-      "Mathlib.NumberTheory.PrimeCounting",
-      "Mathlib.NumberTheory.Bertrand",
-      "Mathlib.Data.Nat.Choose.Central",
-      "Mathlib.Data.Nat.Factorization.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "Nat",
-      "Finset",
-      "ArithmeticFunction"
-    ],
-    "additionalFiles": [
-      "Proofs/ChebyshevBoundsOQ04Aristotle.lean"
-    ]
-  },
-  "sorries": 0
+    "sorries": 0
 }

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
@@ -1,123 +1,123 @@
 {
-  "id": "cube-root-3-irrational-oq-02-oq-02",
-  "title": "Linear Independence of {1, \u221b3, (\u221b3)\u00b2} over \u211a",
-  "slug": "cube-root-3-irrational-oq-02-oq-02",
-  "description": "Proves {1, \u221b3, (\u221b3)\u00b2} is linearly independent over \u211a via a minimal polynomial degree argument: any \u211a-linear combination aeval \u03b1 p = 0 forces the degree-\u22642 polynomial p to be divisible by minpoly \u211a \u03b1 (degree 3), hence p = 0 and all coefficients vanish.",
-  "meta": {
-    "author": "Formalized in Lean 4 with Mathlib",
-    "date": "2026-05-04",
-    "status": "verified",
-    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ02OQ02.lean",
-    "tags": [
-      "linear-independence",
-      "field-extensions",
-      "minimal-polynomial",
-      "algebraic-numbers",
-      "cube-roots",
-      "eisenstein"
+    "id": "cube-root-3-irrational-oq-02-oq-02",
+    "title": "Linear Independence of {1, ∛3, (∛3)²} over ℚ",
+    "slug": "cube-root-3-irrational-oq-02-oq-02",
+    "description": "Proves {1, ∛3, (∛3)²} is linearly independent over ℚ via a minimal polynomial degree argument: any ℚ-linear combination aeval α p = 0 forces the degree-≤2 polynomial p to be divisible by minpoly ℚ α (degree 3), hence p = 0 and all coefficients vanish.",
+    "meta": {
+        "author": "Formalized in Lean 4 with Mathlib",
+        "date": "2026-05-04",
+        "status": "verified",
+        "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ02OQ02.lean",
+        "tags": [
+            "linear-independence",
+            "field-extensions",
+            "minimal-polynomial",
+            "algebraic-numbers",
+            "cube-roots",
+            "eisenstein"
+        ],
+        "badge": "original",
+        "sorries": 0,
+        "dateAdded": "2026-05-04",
+        "axiomCount": 0,
+        "assumptions": "None — fully verified. Depends on CubeRoot2IrrationalOQ03 for minpoly_nthRoot_natDegree.",
+        "lineCount": 104,
+        "theoremCount": 2,
+        "definitionCount": 0,
+        "originalContributions": [
+            "cbrt3_powers_linearIndependent: {α^0, α^1, α^2} linearly independent over ℚ via minpoly divisibility",
+            "one_cbrt3_cbrt3_sq_linearIndependent: explicit form using ![1, α, α²]"
+        ]
+    },
+    "overview": {
+        "historicalContext": "Linear independence of {1, ∛3, (∛3)²} over ℚ is a classical consequence of algebraic number theory. It expresses that ∛3 has degree exactly 3 over ℚ — meaning ∛3 satisfies no polynomial equation over ℚ of degree less than 3. This was known in principle from Galois theory (Eisenstein, 1850s), though the explicit linear independence statement became a standard exercise once field extension theory was systematized by Dedekind and Kronecker in the latter half of the 19th century.",
+        "problemStatement": "**Open Question OQ-02 from cube-root-3-irrational-oq-02:**\n\nThe parent entry proves ∛3 is irrational via Eisenstein's irreducibility criterion: X³-3 is irreducible over ℚ, so it has no rational roots. The natural follow-up: can we prove the stronger statement that {1, ∛3, (∛3)²} is linearly independent over ℚ?\n\n**This file answers yes.** The key is that linear independence of {α^0, α^1, α^2} is equivalent to: the only ℚ-polynomial of degree ≤ 2 with α as a root is the zero polynomial. This follows immediately from minpoly ℚ α having degree 3.",
+        "proofStrategy": "**Core argument** (by contradiction):\n\nSuppose Σᵢ cᵢ · αⁱ = 0 for c₀, c₁, c₂ : ℚ. Define p = C(c₀) + C(c₁)X + C(c₂)X² ∈ ℚ[X]. Then:\n\n1. **aeval α p = 0** (by unfolding the polynomial evaluation).\n2. **minpoly ℚ α ∣ p** (by `minpoly.dvd`, since aeval α p = 0).\n3. **natDegree(minpoly ℚ α) = 3** (from `minpoly_nthRoot_natDegree 3 3 3`, Eisenstein at p=3).\n4. **natDegree(p) ≤ 2** (p has terms at positions 0, 1, 2 only).\n5. If p ≠ 0: `natDegree_le_of_dvd` gives 3 = natDegree(minpoly) ≤ natDegree(p) ≤ 2. Contradiction.\n6. So p = 0, hence c₀ = coeff(p, 0) = 0, c₁ = coeff(p, 1) = 0, c₂ = coeff(p, 2) = 0.",
+        "keyInsights": [
+            "The minpoly divisibility `minpoly.dvd ℚ α h` converts the evaluation condition aeval α p = 0 into the algebraic divisibility condition minpoly ℚ α | p",
+            "The degree bound natDegree(p) ≤ 2 uses natDegree_add_le + natDegree_mul_le + natDegree_C = 0 + natDegree_X_pow = n iteratively",
+            "natDegree_le_of_dvd gives the critical inequality: if q | p and p ≠ 0 then natDegree q ≤ natDegree p",
+            "The coefficient extraction coeff(p, i) = cᵢ is verified by fin_cases + simp: the polynomial C(c₀) + C(c₁)X + C(c₂)X² has exactly cᵢ at position i for i ∈ {0,1,2}",
+            "Fintype.linearIndependent_iff reformulates the goal as: ∀ c : Fin 3 → ℚ, (Σ cᵢ • αⁱ = 0) → (∀ i, cᵢ = 0), cleanly separating construction from extraction"
+        ],
+        "prerequisites": [
+            "CubeRoot2IrrationalOQ03.lean: minpoly_nthRoot_natDegree (Eisenstein → degree = n)",
+            "Mathlib: minpoly.dvd, natDegree_le_of_dvd, Fintype.linearIndependent_iff",
+            "Polynomial natDegree bounds: natDegree_add_le, natDegree_mul_le, natDegree_C, natDegree_X_pow"
+        ]
+    },
+    "sections": [
+        {
+            "id": "sec-setup",
+            "title": "Setup and Helper Lemma",
+            "startLine": 38,
+            "endLine": 48,
+            "summary": "Defines α = (3:ℝ)^(1/3) and establishes α_minpoly_deg: natDegree(minpoly ℚ α) = 3, as a one-line application of minpoly_nthRoot_natDegree 3 3 3 from CubeRoot2IrrationalOQ03.",
+            "mathContext": "The Eisenstein conditions for n=3, m=3, p=3: 2 ≤ 3 (by norm_num), Prime 3 (by norm_num), 3|3 (by norm_num), ¬9|3 (by norm_num), 0<3 (by norm_num). All five conditions hold, giving minpoly ℚ α = X³-3 of degree 3."
+        },
+        {
+            "id": "sec-main-proof",
+            "title": "Main Theorem: Linear Independence",
+            "startLine": 50,
+            "endLine": 86,
+            "summary": "cbrt3_powers_linearIndependent proves LinearIndependent ℚ (fun i : Fin 3 => α^i). Uses Fintype.linearIndependent_iff, builds polynomial p from coefficients c, shows aeval α p = 0 via ring, deduces minpoly ℚ α | p, proves p = 0 by degree comparison (3 > 2), extracts cᵢ = 0 via coefficient computation.",
+            "mathContext": "Key chain: aeval α p = 0 (ring) → minpoly ℚ α | p (minpoly.dvd) → natDeg(minpoly) ≤ natDeg(p) if p≠0 (natDegree_le_of_dvd) → 3 ≤ 2 (contradiction). Coefficient extraction: coeff(C(c₀) + C(c₁)X + C(c₂)X², i) = cᵢ by polynomial arithmetic."
+        },
+        {
+            "id": "sec-explicit",
+            "title": "Explicit Form: ![1, α, α²]",
+            "startLine": 88,
+            "endLine": 96,
+            "summary": "one_cbrt3_cbrt3_sq_linearIndependent gives the same result for the explicit vector ![1, α, α²] : Fin 3 → ℝ. Proved by convert + fin_cases + simp from the main theorem.",
+            "mathContext": "![1, α, α²] i = α^(i:ℕ) for i ∈ {0,1,2}: at i=0, α^0=1; at i=1, α^1=α; at i=2, α^2. The convert step rewrites the goal using this equality."
+        }
     ],
-    "badge": "original",
-    "sorries": 0,
-    "dateAdded": "2026-05-04",
-    "axiomCount": 0,
-    "assumptions": "None \u2014 fully verified. Depends on CubeRoot2IrrationalOQ03 for minpoly_nthRoot_natDegree.",
-    "lineCount": 104,
-    "theoremCount": 2,
-    "definitionCount": 0,
-    "originalContributions": [
-      "cbrt3_powers_linearIndependent: {\u03b1^0, \u03b1^1, \u03b1^2} linearly independent over \u211a via minpoly divisibility",
-      "one_cbrt3_cbrt3_sq_linearIndependent: explicit form using ![1, \u03b1, \u03b1\u00b2]"
-    ]
-  },
-  "overview": {
-    "historicalContext": "Linear independence of {1, \u221b3, (\u221b3)\u00b2} over \u211a is a classical consequence of algebraic number theory. It expresses that \u221b3 has degree exactly 3 over \u211a \u2014 meaning \u221b3 satisfies no polynomial equation over \u211a of degree less than 3. This was known in principle from Galois theory (Eisenstein, 1850s), though the explicit linear independence statement became a standard exercise once field extension theory was systematized by Dedekind and Kronecker in the latter half of the 19th century.",
-    "problemStatement": "**Open Question OQ-02 from cube-root-3-irrational-oq-02:**\n\nThe parent entry proves \u221b3 is irrational via Eisenstein's irreducibility criterion: X\u00b3-3 is irreducible over \u211a, so it has no rational roots. The natural follow-up: can we prove the stronger statement that {1, \u221b3, (\u221b3)\u00b2} is linearly independent over \u211a?\n\n**This file answers yes.** The key is that linear independence of {\u03b1^0, \u03b1^1, \u03b1^2} is equivalent to: the only \u211a-polynomial of degree \u2264 2 with \u03b1 as a root is the zero polynomial. This follows immediately from minpoly \u211a \u03b1 having degree 3.",
-    "proofStrategy": "**Core argument** (by contradiction):\n\nSuppose \u03a3\u1d62 c\u1d62 \u00b7 \u03b1\u2071 = 0 for c\u2080, c\u2081, c\u2082 : \u211a. Define p = C(c\u2080) + C(c\u2081)X + C(c\u2082)X\u00b2 \u2208 \u211a[X]. Then:\n\n1. **aeval \u03b1 p = 0** (by unfolding the polynomial evaluation).\n2. **minpoly \u211a \u03b1 \u2223 p** (by `minpoly.dvd`, since aeval \u03b1 p = 0).\n3. **natDegree(minpoly \u211a \u03b1) = 3** (from `minpoly_nthRoot_natDegree 3 3 3`, Eisenstein at p=3).\n4. **natDegree(p) \u2264 2** (p has terms at positions 0, 1, 2 only).\n5. If p \u2260 0: `natDegree_le_of_dvd` gives 3 = natDegree(minpoly) \u2264 natDegree(p) \u2264 2. Contradiction.\n6. So p = 0, hence c\u2080 = coeff(p, 0) = 0, c\u2081 = coeff(p, 1) = 0, c\u2082 = coeff(p, 2) = 0.",
-    "keyInsights": [
-      "The minpoly divisibility `minpoly.dvd \u211a \u03b1 h` converts the evaluation condition aeval \u03b1 p = 0 into the algebraic divisibility condition minpoly \u211a \u03b1 | p",
-      "The degree bound natDegree(p) \u2264 2 uses natDegree_add_le + natDegree_mul_le + natDegree_C = 0 + natDegree_X_pow = n iteratively",
-      "natDegree_le_of_dvd gives the critical inequality: if q | p and p \u2260 0 then natDegree q \u2264 natDegree p",
-      "The coefficient extraction coeff(p, i) = c\u1d62 is verified by fin_cases + simp: the polynomial C(c\u2080) + C(c\u2081)X + C(c\u2082)X\u00b2 has exactly c\u1d62 at position i for i \u2208 {0,1,2}",
-      "Fintype.linearIndependent_iff reformulates the goal as: \u2200 c : Fin 3 \u2192 \u211a, (\u03a3 c\u1d62 \u2022 \u03b1\u2071 = 0) \u2192 (\u2200 i, c\u1d62 = 0), cleanly separating construction from extraction"
+    "crossReferences": [
+        {
+            "targetId": "cube-root-3-irrational-oq-02",
+            "relationship": "extends",
+            "description": "Parent proof via Eisenstein. This file uses minpoly_nthRoot_natDegree from CubeRoot2IrrationalOQ03 (which the parent also depends on) to get deg(minpoly ℚ α) = 3."
+        },
+        {
+            "targetId": "cube-root-3-irrational-oq-02-oq-01",
+            "relationship": "related",
+            "description": "Sibling entry proving [ℚ(∛3):ℚ] = 3 via adjoin_nthRoot_finrank. Linear independence of {1, α, α²} is a consequence of this degree-3 extension, but this file proves it directly without invoking the full field extension machinery."
+        },
+        {
+            "targetId": "cube-root-2-irrational-oq-03",
+            "relationship": "depends",
+            "description": "Source of minpoly_nthRoot_natDegree, the key lemma giving natDegree(minpoly ℚ α) = 3."
+        }
     ],
-    "prerequisites": [
-      "CubeRoot2IrrationalOQ03.lean: minpoly_nthRoot_natDegree (Eisenstein \u2192 degree = n)",
-      "Mathlib: minpoly.dvd, natDegree_le_of_dvd, Fintype.linearIndependent_iff",
-      "Polynomial natDegree bounds: natDegree_add_le, natDegree_mul_le, natDegree_C, natDegree_X_pow"
-    ]
-  },
-  "sections": [
-    {
-      "id": "sec-setup",
-      "title": "Setup and Helper Lemma",
-      "startLine": 38,
-      "endLine": 48,
-      "summary": "Defines \u03b1 = (3:\u211d)^(1/3) and establishes \u03b1_minpoly_deg: natDegree(minpoly \u211a \u03b1) = 3, as a one-line application of minpoly_nthRoot_natDegree 3 3 3 from CubeRoot2IrrationalOQ03.",
-      "mathContext": "The Eisenstein conditions for n=3, m=3, p=3: 2 \u2264 3 (by norm_num), Prime 3 (by norm_num), 3|3 (by norm_num), \u00ac9|3 (by norm_num), 0<3 (by norm_num). All five conditions hold, giving minpoly \u211a \u03b1 = X\u00b3-3 of degree 3."
+    "conclusion": {
+        "summary": "{1, ∛3, (∛3)²} is ℚ-linearly independent via minpoly divisibility. 2 theorems, 0 sorries, 0 axioms.",
+        "implications": "**Stronger than irrationality**: ∛3 ∉ ℚ says the degree-1 polynomial X - ∛3 has no ℚ coefficients. Linear independence says no nonzero degree-≤2 polynomial over ℚ has ∛3 as a root. This is equivalent to minpoly ℚ (∛3) having degree exactly 3.\n\n**Basis for the degree-3 extension**: Together with (∛3)³ = 3 ∈ ℚ, linear independence shows {1, ∛3, (∛3)²} spans ℚ(∛3) over ℚ. So {1, ∛3, (∛3)²} is a ℚ-basis for ℚ(∛3), giving an alternative proof of [ℚ(∛3):ℚ] = 3.\n\n**Generalizes**: The same minpoly divisibility argument works for any α with natDegree(minpoly ℚ α) = n: the set {1, α, ..., α^(n-1)} is ℚ-linearly independent.",
+        "openQuestions": [
+            "Can the same argument prove {1, ∛m, (∛m)²} is linearly independent for any m with a squarefree prime factor? (Yes: minpoly_nthRoot_natDegree from CubeRoot2IrrationalOQ03 gives the same degree-3 bound.)",
+            "Is {1, α, ..., α^(n-1)} linearly independent whenever natDegree(minpoly ℚ α) = n? (Yes, by the same argument — this is essentially the definition of having degree-n minimal polynomial.)"
+        ]
     },
-    {
-      "id": "sec-main-proof",
-      "title": "Main Theorem: Linear Independence",
-      "startLine": 50,
-      "endLine": 86,
-      "summary": "cbrt3_powers_linearIndependent proves LinearIndependent \u211a (fun i : Fin 3 => \u03b1^i). Uses Fintype.linearIndependent_iff, builds polynomial p from coefficients c, shows aeval \u03b1 p = 0 via ring, deduces minpoly \u211a \u03b1 | p, proves p = 0 by degree comparison (3 > 2), extracts c\u1d62 = 0 via coefficient computation.",
-      "mathContext": "Key chain: aeval \u03b1 p = 0 (ring) \u2192 minpoly \u211a \u03b1 | p (minpoly.dvd) \u2192 natDeg(minpoly) \u2264 natDeg(p) if p\u22600 (natDegree_le_of_dvd) \u2192 3 \u2264 2 (contradiction). Coefficient extraction: coeff(C(c\u2080) + C(c\u2081)X + C(c\u2082)X\u00b2, i) = c\u1d62 by polynomial arithmetic."
+    "leanFile": {
+        "lineCount": 104,
+        "path": "Proofs/CubeRoot3IrrationalOQ02OQ02.lean",
+        "axiomCount": 0,
+        "sorries": 0,
+        "definitionCount": 0,
+        "theoremCount": 3
     },
-    {
-      "id": "sec-explicit",
-      "title": "Explicit Form: ![1, \u03b1, \u03b1\u00b2]",
-      "startLine": 88,
-      "endLine": 96,
-      "summary": "one_cbrt3_cbrt3_sq_linearIndependent gives the same result for the explicit vector ![1, \u03b1, \u03b1\u00b2] : Fin 3 \u2192 \u211d. Proved by convert + fin_cases + simp from the main theorem.",
-      "mathContext": "![1, \u03b1, \u03b1\u00b2] i = \u03b1^(i:\u2115) for i \u2208 {0,1,2}: at i=0, \u03b1^0=1; at i=1, \u03b1^1=\u03b1; at i=2, \u03b1^2. The convert step rewrites the goal using this equality."
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "cube-root-3-irrational-oq-02",
-      "relationship": "extends",
-      "description": "Parent proof via Eisenstein. This file uses minpoly_nthRoot_natDegree from CubeRoot2IrrationalOQ03 (which the parent also depends on) to get deg(minpoly \u211a \u03b1) = 3."
-    },
-    {
-      "targetId": "cube-root-3-irrational-oq-02-oq-01",
-      "relationship": "related",
-      "description": "Sibling entry proving [\u211a(\u221b3):\u211a] = 3 via adjoin_nthRoot_finrank. Linear independence of {1, \u03b1, \u03b1\u00b2} is a consequence of this degree-3 extension, but this file proves it directly without invoking the full field extension machinery."
-    },
-    {
-      "targetId": "cube-root-2-irrational-oq-03",
-      "relationship": "depends",
-      "description": "Source of minpoly_nthRoot_natDegree, the key lemma giving natDegree(minpoly \u211a \u03b1) = 3."
-    }
-  ],
-  "conclusion": {
-    "summary": "{1, \u221b3, (\u221b3)\u00b2} is \u211a-linearly independent via minpoly divisibility. 2 theorems, 0 sorries, 0 axioms.",
-    "implications": "**Stronger than irrationality**: \u221b3 \u2209 \u211a says the degree-1 polynomial X - \u221b3 has no \u211a coefficients. Linear independence says no nonzero degree-\u22642 polynomial over \u211a has \u221b3 as a root. This is equivalent to minpoly \u211a (\u221b3) having degree exactly 3.\n\n**Basis for the degree-3 extension**: Together with (\u221b3)\u00b3 = 3 \u2208 \u211a, linear independence shows {1, \u221b3, (\u221b3)\u00b2} spans \u211a(\u221b3) over \u211a. So {1, \u221b3, (\u221b3)\u00b2} is a \u211a-basis for \u211a(\u221b3), giving an alternative proof of [\u211a(\u221b3):\u211a] = 3.\n\n**Generalizes**: The same minpoly divisibility argument works for any \u03b1 with natDegree(minpoly \u211a \u03b1) = n: the set {1, \u03b1, ..., \u03b1^(n-1)} is \u211a-linearly independent.",
-    "openQuestions": [
-      "Can the same argument prove {1, \u221bm, (\u221bm)\u00b2} is linearly independent for any m with a squarefree prime factor? (Yes: minpoly_nthRoot_natDegree from CubeRoot2IrrationalOQ03 gives the same degree-3 bound.)",
-      "Is {1, \u03b1, ..., \u03b1^(n-1)} linearly independent whenever natDegree(minpoly \u211a \u03b1) = n? (Yes, by the same argument \u2014 this is essentially the definition of having degree-n minimal polynomial.)"
-    ]
-  },
-  "leanFile": {
-    "lineCount": 104,
-    "path": "Proofs/CubeRoot3IrrationalOQ02OQ02.lean",
-    "axiomCount": 0,
-    "sorries": 0,
-    "definitionCount": 0,
-    "theoremCount": 2
-  },
-  "references": [
-    {
-      "authors": "Mathlib Contributors",
-      "title": "Polynomial.minpoly.dvd",
-      "year": "2024",
-      "note": "Mathlib lemma: if aeval x p = 0 then minpoly K x | p"
-    },
-    {
-      "authors": "Mathlib Contributors",
-      "title": "Polynomial.natDegree_le_of_dvd",
-      "year": "2024",
-      "note": "If p | q and q \u2260 0 then natDegree p \u2264 natDegree q"
-    }
-  ],
-  "sorries": []
+    "references": [
+        {
+            "authors": "Mathlib Contributors",
+            "title": "Polynomial.minpoly.dvd",
+            "year": "2024",
+            "note": "Mathlib lemma: if aeval x p = 0 then minpoly K x | p"
+        },
+        {
+            "authors": "Mathlib Contributors",
+            "title": "Polynomial.natDegree_le_of_dvd",
+            "year": "2024",
+            "note": "If p | q and q ≠ 0 then natDegree p ≤ natDegree q"
+        }
+    ],
+    "sorries": []
 }

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -1,158 +1,158 @@
 {
-  "id": "desargues-theorem-oq-01-oq-01",
-  "title": "Non-Desarguesian Planes: The Moulton Plane Counterexample",
-  "slug": "desargues-theorem-oq-01-oq-01",
-  "description": "Formalizes the Moulton plane (1902) — a non-Desarguesian affine plane over ℝ — and provides an explicit rational-coordinate counterexample showing that Desargues's theorem fails. Two triangles are in perspective from a point yet their corresponding-side intersections are not Moulton-collinear.",
-  "meta": {
-    "author": "F. R. Moulton (1902); Lean formalization here",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Moulton_plane",
-    "date": "1902",
-    "status": "verified",
-    "proofRepoPath": "Proofs/DesarguesTheoremOQ01OQ01.lean",
-    "tags": [
-      "projective-geometry",
-      "non-desarguesian",
-      "moulton-plane",
-      "affine-geometry",
-      "counterexample",
-      "triangles",
-      "perspective",
-      "collinearity",
-      "research"
+    "id": "desargues-theorem-oq-01-oq-01",
+    "title": "Non-Desarguesian Planes: The Moulton Plane Counterexample",
+    "slug": "desargues-theorem-oq-01-oq-01",
+    "description": "Formalizes the Moulton plane (1902) — a non-Desarguesian affine plane over ℝ — and provides an explicit rational-coordinate counterexample showing that Desargues's theorem fails. Two triangles are in perspective from a point yet their corresponding-side intersections are not Moulton-collinear.",
+    "meta": {
+        "author": "F. R. Moulton (1902); Lean formalization here",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Moulton_plane",
+        "date": "1902",
+        "status": "verified",
+        "proofRepoPath": "Proofs/DesarguesTheoremOQ01OQ01.lean",
+        "tags": [
+            "projective-geometry",
+            "non-desarguesian",
+            "moulton-plane",
+            "affine-geometry",
+            "counterexample",
+            "triangles",
+            "perspective",
+            "collinearity",
+            "research"
+        ],
+        "badge": "original",
+        "sorries": 0,
+        "axiomCount": 0,
+        "lineCount": 297,
+        "theoremCount": 30,
+        "definitionCount": 12,
+        "mathlibDependencies": [
+            {
+                "theorem": "Classical.propDecidable",
+                "description": "Enables if-then-else on Prop for the piecewise Moulton line definition",
+                "module": "Mathlib.Data.Real.Basic"
+            },
+            {
+                "theorem": "norm_num / linarith",
+                "description": "Arithmetic verification of all incidence conditions and the non-collinearity contradiction",
+                "module": "Mathlib.Tactic"
+            }
+        ],
+        "originalContributions": [
+            "onMoultonLine: Piecewise definition of Moulton lines (slope halved on positive half-plane for m > 0)",
+            "MoultonCollinear: Three-point collinearity in the Moulton affine plane",
+            "collinear_OAA', collinear_OBB', collinear_OCC': Explicit perspectivity of the counterexample triangles from O = (0,0)",
+            "desargues_fails: ¬ MoultonCollinear P Q R — formal proof that the intersection points are not Moulton-collinear",
+            "moulton_counterexample: Full Desargues-counterexample certificate with all incidence data verified"
+        ],
+        "dateAdded": "2026-05-03",
+        "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+        "mathlib_version": "4.26.0"
+    },
+    "overview": {
+        "historicalContext": "Desargues's theorem was proved in 1639 and holds in all projective spaces of dimension ≥ 3. For projective planes (2-dimensional), however, the theorem is not a consequence of the projective plane axioms alone. In 1902, Forest Ray Moulton constructed the first simple counterexample: a modified affine plane over ℝ where lines with positive slope are 'bent' at the y-axis (the right half-plane portion has slope halved). This plane satisfies all affine plane axioms but fails Desargues. It established that Desargues's theorem characterises precisely the planes that can be coordinatised by a skew field (division ring).",
+        "problemStatement": "Can we formalize non-Desarguesian projective planes in Lean to show when Desargues's theorem fails? Desargues's theorem asserts: if triangles $ABC$ and $A'B'C'$ are in perspective from a point (i.e., lines $OAA'$, $OBB'$, $OCC'$ are concurrent at $O$), then the corresponding-side intersections $P = AB \\cap A'B'$, $Q = BC \\cap B'C'$, $R = CA \\cap C'A'$ are collinear. The Moulton plane (1902) satisfies all affine plane axioms but violates Desargues: `desargues_fails : ¬ MoultonCollinear P_pt Q_pt R_pt`.",
+        "proofStrategy": "1. **Definition**: `onMoultonLine m b P` is a piecewise predicate — ordinary line for m ≤ 0, bent line (slope m left, m/2 right) for m > 0. `MoultonCollinear` quantifies over all Moulton lines.\n2. **Perspectivity**: Three direct incidence checks (each by norm_num) establish OAA', OBB', OCC' Moulton-collinear.\n3. **Non-collinearity**: Proof by contradiction. Case m ≤ 0: slope PQ = 2/11 > 0, immediate linarith. Case m > 0: P and R equations determine m = 16/61 and b = 821/61 uniquely; plugging into R's equation gives 725/61 ≠ 671/61, contradiction by linarith.",
+        "keyInsights": [
+            "The bending rule (slope halved on x>0 for m>0) is the minimal perturbation to standard Euclidean lines that breaks Desargues while preserving all affine plane axioms — Moulton's 1902 insight was that the bend must be exactly this piecewise form",
+            "P and R are ordinary: sides AB, A'B', CA, C'A' all have negative slope, so they are unmodified Moulton lines — P and R are computed by ordinary linear algebra, and the bending is only visible when testing collinearity of P, Q, R",
+            "The contradiction is purely algebraic: assuming Moulton collinearity of P=(-17,9), Q=(27,17), R=(-6,11) forces m=16/61 (from P and Q equations) and m=2/11 (from P and R equations) simultaneously — 16/61 ≠ 2/11 gives the numeric contradiction closed by linarith",
+            "P, Q, R ARE Euclidean-collinear (slope 2/11), confirming classical Desargues holds in ℝ² — only the Moulton plane's piecewise bent lines reveal the failure",
+            "Characterisation: Desargues's theorem holds in a projective plane iff the plane is coordinatizable by a skew field (division ring) — the Moulton plane's bent coordinatization is not associative, blocking this coordinatization"
+        ]
+    },
+    "sections": [
+        {
+            "id": "moulton-line-definition",
+            "title": "Moulton Line Definition and Helpers",
+            "startLine": 44,
+            "endLine": 88,
+            "summary": "Defines onMoultonLine (piecewise: m≤0 → ordinary y=mx+b; m>0, x≤0 → same; m>0, x>0 → y=(m/2)x+b) and MoultonCollinear (vertical or on a shared Moulton line). Six helper lemmas provide convenient constructors and extractors for each case."
+        },
+        {
+            "id": "counterexample-points",
+            "title": "Counterexample Data Points",
+            "startLine": 90,
+            "endLine": 101,
+            "summary": "Defines O=(0,0), triangles ABC and A'B'C' (A'=2A, B'=3B, C'=4C as scalar multiples from O), and intersection points P=(-17,9), Q=(27,17), R=(-6,11). All private defs with rational coordinates."
+        },
+        {
+            "id": "perspectivity",
+            "title": "Part III: Perspectivity from O",
+            "startLine": 103,
+            "endLine": 129,
+            "summary": "Proves MoultonCollinear O A A', O B B', O C C': slope -3/2 for OAA' (ordinary); left-slope 2/3 for OBB' (bent, O at boundary, B/B' on right half); vertical x=0 for OCC'."
+        },
+        {
+            "id": "intersection-points",
+            "title": "Part IV: Intersection Points",
+            "startLine": 131,
+            "endLine": 210,
+            "summary": "18 lemmas: P on AB (slope -2/5) and A'B' (slope -3/13); Q on BC (left-slope 4/3) and B'C' (left-slope 14/9), both at x=27>0 using onML_pos_right; R on CA (slope -2) and C'A' (slope -5/2). All ordinary lines for P,R; bent lines for Q."
+        },
+        {
+            "id": "desargues-fails",
+            "title": "Part V: Desargues Fails — ¬ MoultonCollinear P Q R",
+            "startLine": 226,
+            "endLine": 261,
+            "summary": "desargues_fails : ¬ MoultonCollinear P Q R. Three-case contradiction: vertical (x distinct); m≤0 (forces m=2/11>0 by linarith); m>0 (P,R on left, Q on right: linear_combination gives m=2/11 and m=16/61 simultaneously, contradiction by linarith)."
+        },
+        {
+            "id": "full-counterexample",
+            "title": "Part VI: Full Desargues Counterexample Certificate",
+            "startLine": 263,
+            "endLine": 296,
+            "summary": "moulton_counterexample packages 21-component conjunction: 3 perspectivity facts + 18 incidence facts (P/Q/R on respective side pairs) + desargues_fails. Term-mode proof via anonymous constructor ⟨...⟩."
+        }
     ],
-    "badge": "original",
-    "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 297,
-    "theoremCount": 30,
-    "definitionCount": 12,
-    "mathlibDependencies": [
-      {
-        "theorem": "Classical.propDecidable",
-        "description": "Enables if-then-else on Prop for the piecewise Moulton line definition",
-        "module": "Mathlib.Data.Real.Basic"
-      },
-      {
-        "theorem": "norm_num / linarith",
-        "description": "Arithmetic verification of all incidence conditions and the non-collinearity contradiction",
-        "module": "Mathlib.Tactic"
-      }
+    "conclusion": {
+        "summary": "The Moulton plane provides a fully formalized, axiom-free counterexample to Desargues's theorem in an affine plane over ℝ. The explicit rational-coordinate construction (Moulton, 1902) proves that Desargues is NOT derivable from the affine plane axioms alone — it requires that the coordinatizing structure be a field or division ring. The formalization uses only Mathlib real arithmetic (norm_num, linarith, linear_combination) — no topology, continuity, or algebraic geometry.",
+        "implications": "The failure of Desargues's theorem characterises non-Desarguesian planes — those not coordinatizable by a skew field. Moulton's 1902 counterexample was historically surprising: most known plane geometries satisfied Desargues, and it had been assumed to follow from the affine axioms. Combined with desargues-theorem-oq-01 (which proves Desargues over any commutative ring via homogeneous coordinates), this entry provides the complete picture: Desargues holds in coordinate planes over fields, and fails in planes with weaker coordinatization. The Lean 4 proof at the 300-line scale demonstrates that such combinatorial-geometric counterexamples are tractable with modern tactic automation.",
+        "openQuestions": [
+            "Can the Moulton plane be extended to a full projective plane (with a line at infinity) and Desargues's failure proved in the projective completion?",
+            "Can the smallest finite non-Desarguesian projective plane (order 9, the Hall plane) be formalized in Lean? Finite non-Desarguesian planes require nearfield coordinatization.",
+            "Can the converse be formalized: Desargues holds iff the plane is coordinatizable by a skew field (Veblen-Young theorem)? This would require formalizing the Hilbert-Moufang loop construction."
+        ]
+    },
+    "crossReferences": [
+        {
+            "proofId": "desargues-theorem",
+            "relationship": "parent — original Desargues theorem formalization using ℝ³ homogeneous coordinates"
+        },
+        {
+            "proofId": "desargues-theorem-oq-01",
+            "relationship": "sibling — algebraic proof over any commutative ring K (proves Desargues where this entry shows it fails)"
+        },
+        {
+            "proofId": "desargues-theorem-oq-02",
+            "relationship": "sibling — duality of Desargues's theorem"
+        }
     ],
-    "originalContributions": [
-      "onMoultonLine: Piecewise definition of Moulton lines (slope halved on positive half-plane for m > 0)",
-      "MoultonCollinear: Three-point collinearity in the Moulton affine plane",
-      "collinear_OAA', collinear_OBB', collinear_OCC': Explicit perspectivity of the counterexample triangles from O = (0,0)",
-      "desargues_fails: ¬ MoultonCollinear P Q R — formal proof that the intersection points are not Moulton-collinear",
-      "moulton_counterexample: Full Desargues-counterexample certificate with all incidence data verified"
+    "references": [
+        {
+            "type": "paper",
+            "title": "A Simple Non-Desarguesian Plane Geometry",
+            "author": "Forest Ray Moulton",
+            "year": 1902,
+            "journal": "Transactions of the American Mathematical Society",
+            "volume": 3,
+            "pages": "192-195"
+        },
+        {
+            "type": "book",
+            "title": "Projective Planes",
+            "author": "Hughes and Piper",
+            "year": 1973
+        }
     ],
-    "dateAdded": "2026-05-03",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "mathlib_version": "4.26.0"
-  },
-  "overview": {
-    "historicalContext": "Desargues's theorem was proved in 1639 and holds in all projective spaces of dimension ≥ 3. For projective planes (2-dimensional), however, the theorem is not a consequence of the projective plane axioms alone. In 1902, Forest Ray Moulton constructed the first simple counterexample: a modified affine plane over ℝ where lines with positive slope are 'bent' at the y-axis (the right half-plane portion has slope halved). This plane satisfies all affine plane axioms but fails Desargues. It established that Desargues's theorem characterises precisely the planes that can be coordinatised by a skew field (division ring).",
-    "problemStatement": "Can we formalize non-Desarguesian projective planes in Lean to show when Desargues's theorem fails? Desargues's theorem asserts: if triangles $ABC$ and $A'B'C'$ are in perspective from a point (i.e., lines $OAA'$, $OBB'$, $OCC'$ are concurrent at $O$), then the corresponding-side intersections $P = AB \\cap A'B'$, $Q = BC \\cap B'C'$, $R = CA \\cap C'A'$ are collinear. The Moulton plane (1902) satisfies all affine plane axioms but violates Desargues: `desargues_fails : ¬ MoultonCollinear P_pt Q_pt R_pt`.",
-    "proofStrategy": "1. **Definition**: `onMoultonLine m b P` is a piecewise predicate — ordinary line for m ≤ 0, bent line (slope m left, m/2 right) for m > 0. `MoultonCollinear` quantifies over all Moulton lines.\n2. **Perspectivity**: Three direct incidence checks (each by norm_num) establish OAA', OBB', OCC' Moulton-collinear.\n3. **Non-collinearity**: Proof by contradiction. Case m ≤ 0: slope PQ = 2/11 > 0, immediate linarith. Case m > 0: P and R equations determine m = 16/61 and b = 821/61 uniquely; plugging into R's equation gives 725/61 ≠ 671/61, contradiction by linarith.",
-    "keyInsights": [
-      "The bending rule (slope halved on x>0 for m>0) is the minimal perturbation to standard Euclidean lines that breaks Desargues while preserving all affine plane axioms — Moulton's 1902 insight was that the bend must be exactly this piecewise form",
-      "P and R are ordinary: sides AB, A'B', CA, C'A' all have negative slope, so they are unmodified Moulton lines — P and R are computed by ordinary linear algebra, and the bending is only visible when testing collinearity of P, Q, R",
-      "The contradiction is purely algebraic: assuming Moulton collinearity of P=(-17,9), Q=(27,17), R=(-6,11) forces m=16/61 (from P and Q equations) and m=2/11 (from P and R equations) simultaneously — 16/61 ≠ 2/11 gives the numeric contradiction closed by linarith",
-      "P, Q, R ARE Euclidean-collinear (slope 2/11), confirming classical Desargues holds in ℝ² — only the Moulton plane's piecewise bent lines reveal the failure",
-      "Characterisation: Desargues's theorem holds in a projective plane iff the plane is coordinatizable by a skew field (division ring) — the Moulton plane's bent coordinatization is not associative, blocking this coordinatization"
-    ]
-  },
-  "sections": [
-    {
-      "id": "moulton-line-definition",
-      "title": "Moulton Line Definition and Helpers",
-      "startLine": 44,
-      "endLine": 88,
-      "summary": "Defines onMoultonLine (piecewise: m≤0 → ordinary y=mx+b; m>0, x≤0 → same; m>0, x>0 → y=(m/2)x+b) and MoultonCollinear (vertical or on a shared Moulton line). Six helper lemmas provide convenient constructors and extractors for each case."
+    "leanFile": {
+        "namespace": "MoultonPlane",
+        "lineCount": 297,
+        "axiomCount": 0,
+        "theoremCount": 30,
+        "definitionCount": 2,
+        "path": "Proofs/DesarguesTheoremOQ01OQ01.lean",
+        "sorries": 0
     },
-    {
-      "id": "counterexample-points",
-      "title": "Counterexample Data Points",
-      "startLine": 90,
-      "endLine": 101,
-      "summary": "Defines O=(0,0), triangles ABC and A'B'C' (A'=2A, B'=3B, C'=4C as scalar multiples from O), and intersection points P=(-17,9), Q=(27,17), R=(-6,11). All private defs with rational coordinates."
-    },
-    {
-      "id": "perspectivity",
-      "title": "Part III: Perspectivity from O",
-      "startLine": 103,
-      "endLine": 129,
-      "summary": "Proves MoultonCollinear O A A', O B B', O C C': slope -3/2 for OAA' (ordinary); left-slope 2/3 for OBB' (bent, O at boundary, B/B' on right half); vertical x=0 for OCC'."
-    },
-    {
-      "id": "intersection-points",
-      "title": "Part IV: Intersection Points",
-      "startLine": 131,
-      "endLine": 210,
-      "summary": "18 lemmas: P on AB (slope -2/5) and A'B' (slope -3/13); Q on BC (left-slope 4/3) and B'C' (left-slope 14/9), both at x=27>0 using onML_pos_right; R on CA (slope -2) and C'A' (slope -5/2). All ordinary lines for P,R; bent lines for Q."
-    },
-    {
-      "id": "desargues-fails",
-      "title": "Part V: Desargues Fails — ¬ MoultonCollinear P Q R",
-      "startLine": 226,
-      "endLine": 261,
-      "summary": "desargues_fails : ¬ MoultonCollinear P Q R. Three-case contradiction: vertical (x distinct); m≤0 (forces m=2/11>0 by linarith); m>0 (P,R on left, Q on right: linear_combination gives m=2/11 and m=16/61 simultaneously, contradiction by linarith)."
-    },
-    {
-      "id": "full-counterexample",
-      "title": "Part VI: Full Desargues Counterexample Certificate",
-      "startLine": 263,
-      "endLine": 296,
-      "summary": "moulton_counterexample packages 21-component conjunction: 3 perspectivity facts + 18 incidence facts (P/Q/R on respective side pairs) + desargues_fails. Term-mode proof via anonymous constructor ⟨...⟩."
-    }
-  ],
-  "conclusion": {
-    "summary": "The Moulton plane provides a fully formalized, axiom-free counterexample to Desargues's theorem in an affine plane over ℝ. The explicit rational-coordinate construction (Moulton, 1902) proves that Desargues is NOT derivable from the affine plane axioms alone — it requires that the coordinatizing structure be a field or division ring. The formalization uses only Mathlib real arithmetic (norm_num, linarith, linear_combination) — no topology, continuity, or algebraic geometry.",
-    "implications": "The failure of Desargues's theorem characterises non-Desarguesian planes — those not coordinatizable by a skew field. Moulton's 1902 counterexample was historically surprising: most known plane geometries satisfied Desargues, and it had been assumed to follow from the affine axioms. Combined with desargues-theorem-oq-01 (which proves Desargues over any commutative ring via homogeneous coordinates), this entry provides the complete picture: Desargues holds in coordinate planes over fields, and fails in planes with weaker coordinatization. The Lean 4 proof at the 300-line scale demonstrates that such combinatorial-geometric counterexamples are tractable with modern tactic automation.",
-    "openQuestions": [
-      "Can the Moulton plane be extended to a full projective plane (with a line at infinity) and Desargues's failure proved in the projective completion?",
-      "Can the smallest finite non-Desarguesian projective plane (order 9, the Hall plane) be formalized in Lean? Finite non-Desarguesian planes require nearfield coordinatization.",
-      "Can the converse be formalized: Desargues holds iff the plane is coordinatizable by a skew field (Veblen-Young theorem)? This would require formalizing the Hilbert-Moufang loop construction."
-    ]
-  },
-  "crossReferences": [
-    {
-      "proofId": "desargues-theorem",
-      "relationship": "parent — original Desargues theorem formalization using ℝ³ homogeneous coordinates"
-    },
-    {
-      "proofId": "desargues-theorem-oq-01",
-      "relationship": "sibling — algebraic proof over any commutative ring K (proves Desargues where this entry shows it fails)"
-    },
-    {
-      "proofId": "desargues-theorem-oq-02",
-      "relationship": "sibling — duality of Desargues's theorem"
-    }
-  ],
-  "references": [
-    {
-      "type": "paper",
-      "title": "A Simple Non-Desarguesian Plane Geometry",
-      "author": "Forest Ray Moulton",
-      "year": 1902,
-      "journal": "Transactions of the American Mathematical Society",
-      "volume": 3,
-      "pages": "192-195"
-    },
-    {
-      "type": "book",
-      "title": "Projective Planes",
-      "author": "Hughes and Piper",
-      "year": 1973
-    }
-  ],
-  "leanFile": {
-    "namespace": "MoultonPlane",
-    "lineCount": 297,
-    "axiomCount": 0,
-    "theoremCount": 29,
-    "definitionCount": 2,
-    "path": "Proofs/DesarguesTheoremOQ01OQ01.lean",
     "sorries": 0
-  },
-  "sorries": 0
 }

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -1,215 +1,215 @@
 {
-  "id": "erdos-1095-oq-01",
-  "title": "Erdős #1095 OQ01: Asymptotics of g(k) — Smooth Binomial Coefficients",
-  "slug": "erdos-1095-oq-01",
-  "description": "Is log g(k) ~ c·k/log k, where g(k) is the smallest n > k+1 with all prime factors of C(n,k) exceeding k?",
-  "meta": {
-    "author": "Erdős",
-    "sourceUrl": "https://erdosproblems.com/1095",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos1095OQ01Problem.lean",
-    "tags": [
-      "erdos",
-      "number-theory",
-      "binomial-coefficients",
-      "prime-factors",
-      "smooth-numbers",
-      "asymptotics"
+    "id": "erdos-1095-oq-01",
+    "title": "Erdős #1095 OQ01: Asymptotics of g(k) — Smooth Binomial Coefficients",
+    "slug": "erdos-1095-oq-01",
+    "description": "Is log g(k) ~ c·k/log k, where g(k) is the smallest n > k+1 with all prime factors of C(n,k) exceeding k?",
+    "meta": {
+        "author": "Erdős",
+        "sourceUrl": "https://erdosproblems.com/1095",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/Erdos1095OQ01Problem.lean",
+        "tags": [
+            "erdos",
+            "number-theory",
+            "binomial-coefficients",
+            "prime-factors",
+            "smooth-numbers",
+            "asymptotics"
+        ],
+        "badge": "wip",
+        "sorries": 0,
+        "erdosNumber": 1095,
+        "erdosUrl": "https://erdosproblems.com/1095",
+        "erdosProblemStatus": "open",
+        "axiomCount": 0,
+        "lineCount": 475,
+        "theoremCount": 21,
+        "assumptions": "0 axioms, 0 sorries. gFunc_exists proved constructively via Kummer's theorem (carry-free base-p arithmetic). gFunc defined via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 all verified. Open conjecture; supporting lemmas fully verified."
+    },
+    "overview": {
+        "historicalContext": "The function $g(k)$ — the smallest $n > k+1$ such that every prime factor of $\\binom{n}{k}$ exceeds $k$ — was introduced by Ecklund, Erdős, and Selfridge in their 1974 paper on smooth binomial coefficients. They established the initial bounds $k^{1+c} < g(k) \\leq \\exp((1+o(1))k)$, showing that $g(k)$ grows faster than any polynomial but no faster than exponential.\n\nThe lower bound was substantially improved by Konyagin, who proved $g(k) \\gg \\exp(c(\\log k)^2)$ using estimates on smooth numbers (integers whose prime factors are all below a given bound). The key insight is that $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$, and avoiding all primes $\\leq k$ requires $n$ to be chosen so that the prime factorization of the numerator $n(n-1)\\cdots(n-k+1)$ has no small prime factors surviving the cancellation with $k!$.\n\nErdős, Lacampagne, and Selfridge conjectured that $\\log g(k) \\sim c \\cdot k / \\log k$ for some positive constant $c$, which would place $g(k)$ at a precise intermediate growth rate between polynomial and exponential. Computational evidence by Sorenson, Sorenson, and Webster supports this conjecture, but it remains open. The problem connects to smooth number theory, sieve methods, and the distribution of prime factors in products of consecutive integers.",
+        "problemStatement": "Let g(k) > k+1 be the smallest n such that all prime factors of C(n,k) exceed k. Is log g(k) ~ c·k/log k for some constant c > 0?",
+        "text": "Is log g(k) asymptotically equivalent to c·k/log k for some constant c?",
+        "proofStrategy": "The formalization axiomatizes $g(k)$ with four declarations: the function itself (`gFunc`), the bound $g(k) > k+1$ (`gFunc_gt`), the specification that all prime factors of $\\binom{g(k)}{k}$ exceed $k$ (`gFunc_spec`), and minimality (`gFunc_minimal`). From these, 11 theorems are proved:\n\n1. **Structural lemmas** (Part 3): `AllPrimesExceed` holds for 1 (vacuously), is inherited by divisors (transitivity of divisibility), is monotone in $k$ (strengthening threshold), and has a negation lemma for exhibiting witnesses.\n\n2. **Parity constraint** (Part 4): For $k \\geq 2$, $\\binom{g(k)}{k}$ must be odd, since $2 \\leq k$ and $2$ is prime. By Kummer's theorem, this means no carries in binary addition of $k$ and $g(k)-k$.\n\n3. **Concrete computations** (Part 5): $g(1) = 3$ ($\\binom{3}{1} = 3$, prime), $g(2) = 6$ ($\\binom{6}{2} = 15 = 3 \\times 5$). Verified by `decide`.\n\n4. **Growth bound** (Part 6): $g(k) \\geq k+2$ from the axiom.\n\n5. **Open statement** (Part 7): The weakened conjecture $\\exists c > 0,\\; g(k) > k^c$ is formally stated; the full asymptotic conjecture requires `Filter.Tendsto` and is described informally.",
+        "keyInsights": [
+            "**AllPrimesExceed predicate**: The core notion — all prime factors of m exceed k — is clean to formalize",
+            "**Even binomial coefficients**: For k ≥ 2, g(k) must produce odd C(n,k), severely constraining possible n",
+            "**Growth rate**: The conjecture places g(k) between polynomial and exponential growth",
+            "**Kummer's theorem connection**: C(n,k) is odd iff there are no carries in binary addition of k and n-k",
+            "**Wide gap between known bounds**: The gap between the best lower bound $\\exp(c(\\log k)^2)$ (Konyagin) and the conjectured $\\exp(c \\cdot k/\\log k)$ is enormous — the exponent differs by a factor of $k/(\\log k)^3$. Closing this gap is a major open problem in analytic number theory",
+            "**Bertrand's postulate inversion**: Erdős' 1932 proof of Bertrand's postulate showed that $\\binom{2n}{n}$ always has prime factors in $(n, 2n]$; the $g(k)$ problem inverts this by asking when binomial coefficients *avoid* all primes $\\leq k$ — a much rarer phenomenon"
+        ],
+        "prerequisites": [
+            "Number theory basics",
+            "Prime factorization",
+            "Binomial coefficients"
+        ]
+    },
+    "sections": [
+        {
+            "id": "header",
+            "title": "Module Header and Imports",
+            "startLine": 1,
+            "endLine": 28,
+            "summary": "Module docstring describing the problem, known bounds (Ecklund-Erdős-Selfridge, Konyagin), concrete values, and imports from Mathlib (Nat.Choose.Basic, Nat.Prime.Basic, Tactic).",
+            "mathContext": "Bound: Module docstring describing the problem, known bounds (Ecklund-Erdős-Selfridge, Konyagin), concrete values, and imports from Mathlib (Nat.Choose.Basic, Nat.Prime.Basic, Tactic)."
+        },
+        {
+            "id": "core-definitions",
+            "title": "Part 1: Core Definitions",
+            "startLine": 30,
+            "endLine": 38,
+            "summary": "`AllPrimesExceed m k`: all prime factors of $m$ exceed $k$. Defines the $k$-smooth-free predicate central to the problem.",
+            "mathContext": "Formal definition: `AllPrimesExceed m k`: all prime factors of $m$ exceed $k$. Defines the $k$-smooth-free predicate central to the problem."
+        },
+        {
+            "id": "gfunc-axiomatization",
+            "title": "Part 2: g(k) Axiomatization",
+            "startLine": 40,
+            "endLine": 56,
+            "summary": "Four axiom declarations: `gFunc : ℕ → ℕ`, `gFunc_gt` ($g(k) > k+1$), `gFunc_spec` (all primes in $\\binom{g(k)}{k}$ exceed $k$), `gFunc_minimal` (minimality).",
+            "mathContext": "Four axiom declarations: `gFunc : $\\mathbb{N}$ $\\to$ $\\mathbb{N}$`, `gFunc_gt` ($g(k) > k+1$), `gFunc_spec` (all primes in $\\binom{g(k)}{k}$ exceed $k$), `gFunc_minimal` (minimality)."
+        },
+        {
+            "id": "basic-lemmas",
+            "title": "Part 3: Basic Lemmas about AllPrimesExceed",
+            "startLine": 58,
+            "endLine": 82,
+            "summary": "Four structural lemmas: `allPrimesExceed_one` (vacuous for 1), `allPrimesExceed_of_dvd` (inherited by divisors), `allPrimesExceed_mono` (monotone in $k$), `not_allPrimesExceed_of_prime_dvd` (negation witness).",
+            "mathContext": "Four structural lemmas: `allPrimesExceed_one` (vacuous for 1), `allPrimesExceed_of_dvd` (inherited by divisors), `allPrimesExceed_mono` (monotone in $k$), `not_allPrimesExceed_of_prime_dvd` (negation witness)."
+        },
+        {
+            "id": "even-binomials",
+            "title": "Part 4: Even Binomial Coefficients",
+            "startLine": 84,
+            "endLine": 99,
+            "summary": "`choose_eq_zero_of_lt` ($\\binom{n}{k} = 0$ when $k > n$) and `choose_odd_of_allPrimesExceed` (for $k \\geq 2$, $\\binom{n}{k}$ at $g(k)$ must be odd since $2 \\leq k$).",
+            "mathContext": "Mathematical content: `choose_eq_zero_of_lt` ($\\binom{n}{k} = 0$ when $k > n$) and `choose_odd_of_allPrimesExceed` (for $k \\geq 2$, $\\binom{n}{k}$ at $g(k)$ must be odd since $2 \\leq k$)."
+        },
+        {
+            "id": "concrete-computations",
+            "title": "Part 5: Concrete Computations",
+            "startLine": 101,
+            "endLine": 116,
+            "summary": "Verified by `decide`: $\\binom{3}{1} = 3$, $\\binom{6}{2} = 15$, $\\binom{4}{2} = 6$, $\\binom{5}{2} = 10$. These confirm $g(1) = 3$ and $g(2) = 6$.",
+            "mathContext": "Mathematical content: Verified by `decide`: $\\binom{3}{1} = 3$, $\\binom{6}{2} = 15$, $\\binom{4}{2} = 6$, $\\binom{5}{2} = 10$. These confirm $g(1) = 3$ and $g(2) = 6$."
+        },
+        {
+            "id": "g5-computation",
+            "title": "Part 5c: Computing g(5) = 23",
+            "startLine": 216,
+            "endLine": 243,
+            "summary": "`gFunc_five`: $g(5) = 23$, proved by showing $\\binom{23}{5} = 33649 = 7 \\cdot 11 \\cdot 19 \\cdot 23$ has no prime $\\leq 5$, and eliminating $n = 7, \\ldots, 22$ via `interval_cases`.",
+            "mathContext": "Mathematical content: $g(5) = 23$ via exhaustive check: $\\binom{n}{5}$ is even for most $n \\in [7,22]$, and divisible by 3 for the odd cases ($n = 7, 13, 15, 21$)."
+        },
+        {
+            "id": "g6-computation",
+            "title": "Part 5d: Computing g(6) = 62",
+            "startLine": 245,
+            "endLine": 272,
+            "summary": "`gFunc_six`: $g(6) = 62$, proved by showing $\\binom{62}{6} = 61474519 = 19 \\cdot 29 \\cdot 31 \\cdot 59 \\cdot 61$ has no prime $\\leq 6$, and eliminating $n = 8, \\ldots, 61$ via `interval_cases`.",
+            "mathContext": "Mathematical content: $g(6) = 62$ via exhaustive check of 54 candidate values. Every $\\binom{n}{6}$ for $n \\in [8,61]$ has a prime factor in $\\{2, 3, 5\\}$."
+        },
+        {
+            "id": "structural-properties",
+            "title": "Part 6: Structural Properties of g(k)",
+            "startLine": 274,
+            "endLine": 283,
+            "summary": "`gFunc_ge_k_plus_two`: $g(k) \\geq k+2$ from the axiom $g(k) > k+1$, via `omega`. The weakest formal lower bound on $g$.",
+            "mathContext": "Axiomatized: `gFunc_ge_k_plus_two`: $g(k) \\geq k+2$ from the axiom $g(k) > k+1$, via `omega`. The weakest formal lower bound on $g$."
+        },
+        {
+            "id": "problem-statement",
+            "title": "Part 7: Problem Statement (Open)",
+            "startLine": 288,
+            "endLine": 318,
+            "summary": "The open conjecture (informally: $\\log g(k) \\sim c \\cdot k/\\log k$) and its weakened formal version `ErdosProblem1095OQ01`: $\\exists c > 0,\\; \\forall k > 0,\\; g(k) > k^c$ (super-polynomial growth).",
+            "mathContext": "Mathematical content: The open conjecture (informally: $\\log g(k) \\sim c \\cdot k/\\log k$) and its weakened formal version `ErdosProblem1095OQ01`: $\\exists c > 0,\\; \\forall k > 0,\\; g(k) > k^c$ (super-polynomial growth)."
+        }
     ],
-    "badge": "wip",
-    "sorries": 0,
-    "erdosNumber": 1095,
-    "erdosUrl": "https://erdosproblems.com/1095",
-    "erdosProblemStatus": "open",
-    "axiomCount": 0,
-    "lineCount": 475,
-    "theoremCount": 21,
-    "assumptions": "0 axioms, 0 sorries. gFunc_exists proved constructively via Kummer's theorem (carry-free base-p arithmetic). gFunc defined via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 all verified. Open conjecture; supporting lemmas fully verified."
-  },
-  "overview": {
-    "historicalContext": "The function $g(k)$ — the smallest $n > k+1$ such that every prime factor of $\\binom{n}{k}$ exceeds $k$ — was introduced by Ecklund, Erdős, and Selfridge in their 1974 paper on smooth binomial coefficients. They established the initial bounds $k^{1+c} < g(k) \\leq \\exp((1+o(1))k)$, showing that $g(k)$ grows faster than any polynomial but no faster than exponential.\n\nThe lower bound was substantially improved by Konyagin, who proved $g(k) \\gg \\exp(c(\\log k)^2)$ using estimates on smooth numbers (integers whose prime factors are all below a given bound). The key insight is that $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$, and avoiding all primes $\\leq k$ requires $n$ to be chosen so that the prime factorization of the numerator $n(n-1)\\cdots(n-k+1)$ has no small prime factors surviving the cancellation with $k!$.\n\nErdős, Lacampagne, and Selfridge conjectured that $\\log g(k) \\sim c \\cdot k / \\log k$ for some positive constant $c$, which would place $g(k)$ at a precise intermediate growth rate between polynomial and exponential. Computational evidence by Sorenson, Sorenson, and Webster supports this conjecture, but it remains open. The problem connects to smooth number theory, sieve methods, and the distribution of prime factors in products of consecutive integers.",
-    "problemStatement": "Let g(k) > k+1 be the smallest n such that all prime factors of C(n,k) exceed k. Is log g(k) ~ c·k/log k for some constant c > 0?",
-    "text": "Is log g(k) asymptotically equivalent to c·k/log k for some constant c?",
-    "proofStrategy": "The formalization axiomatizes $g(k)$ with four declarations: the function itself (`gFunc`), the bound $g(k) > k+1$ (`gFunc_gt`), the specification that all prime factors of $\\binom{g(k)}{k}$ exceed $k$ (`gFunc_spec`), and minimality (`gFunc_minimal`). From these, 11 theorems are proved:\n\n1. **Structural lemmas** (Part 3): `AllPrimesExceed` holds for 1 (vacuously), is inherited by divisors (transitivity of divisibility), is monotone in $k$ (strengthening threshold), and has a negation lemma for exhibiting witnesses.\n\n2. **Parity constraint** (Part 4): For $k \\geq 2$, $\\binom{g(k)}{k}$ must be odd, since $2 \\leq k$ and $2$ is prime. By Kummer's theorem, this means no carries in binary addition of $k$ and $g(k)-k$.\n\n3. **Concrete computations** (Part 5): $g(1) = 3$ ($\\binom{3}{1} = 3$, prime), $g(2) = 6$ ($\\binom{6}{2} = 15 = 3 \\times 5$). Verified by `decide`.\n\n4. **Growth bound** (Part 6): $g(k) \\geq k+2$ from the axiom.\n\n5. **Open statement** (Part 7): The weakened conjecture $\\exists c > 0,\\; g(k) > k^c$ is formally stated; the full asymptotic conjecture requires `Filter.Tendsto` and is described informally.",
-    "keyInsights": [
-      "**AllPrimesExceed predicate**: The core notion — all prime factors of m exceed k — is clean to formalize",
-      "**Even binomial coefficients**: For k ≥ 2, g(k) must produce odd C(n,k), severely constraining possible n",
-      "**Growth rate**: The conjecture places g(k) between polynomial and exponential growth",
-      "**Kummer's theorem connection**: C(n,k) is odd iff there are no carries in binary addition of k and n-k",
-      "**Wide gap between known bounds**: The gap between the best lower bound $\\exp(c(\\log k)^2)$ (Konyagin) and the conjectured $\\exp(c \\cdot k/\\log k)$ is enormous — the exponent differs by a factor of $k/(\\log k)^3$. Closing this gap is a major open problem in analytic number theory",
-      "**Bertrand's postulate inversion**: Erdős' 1932 proof of Bertrand's postulate showed that $\\binom{2n}{n}$ always has prime factors in $(n, 2n]$; the $g(k)$ problem inverts this by asking when binomial coefficients *avoid* all primes $\\leq k$ — a much rarer phenomenon"
+    "conclusion": {
+        "summary": "This formalization establishes the framework for Erdős problem #1095 OQ01 about the growth rate of g(k). We prove structural lemmas about the AllPrimesExceed predicate and connect it to parity of binomial coefficients.",
+        "implications": "A resolution would precisely characterize how rare it is for large binomial coefficients to avoid all small prime factors. The answer has implications for smooth number theory: since $\\binom{n}{k} = \\prod_{i=1}^{k} \\frac{n-k+i}{i}$, understanding when this product avoids small primes connects to the distribution of smooth numbers among products of consecutive integers. The function $g(k)$ also relates to Grimm's conjecture (that if $n+1, n+2, \\ldots, n+k$ are all composite, they can be assigned distinct prime divisors) and to the Erdős-Selfridge conjecture on the largest prime factor of products of consecutive integers.",
+        "openQuestions": [
+            "Is log g(k) ~ c·k/log k for some constant c > 0?",
+            "What is the exact value of c if it exists?",
+            "Does g(k) < lcm(1,...,k) for large k?"
+        ]
+    },
+    "leanFile": {
+        "imports": [
+            "Mathlib.Data.Nat.Choose.Basic",
+            "Mathlib.Data.Nat.Prime.Basic",
+            "Mathlib.Tactic",
+            "Proofs.KummerTheoremOQ03"
+        ],
+        "opens": [
+            "Nat"
+        ],
+        "namespace": "Erdos1095OQ01",
+        "lineCount": 475,
+        "axiomCount": 0,
+        "theoremCount": 37,
+        "definitionCount": 4,
+        "path": "Proofs/Erdos1095OQ01Problem.lean",
+        "sorries": 0
+    },
+    "crossReferences": [
+        {
+            "targetId": "erdos-1095",
+            "relationship": "parent",
+            "description": "Open question derived from Erdős #1095 on g(k)"
+        },
+        {
+            "targetId": "kummer-theorem",
+            "relationship": "foundational",
+            "description": "Kummer's theorem characterizes $\\nu_p(\\binom{n}{k})$ as the number of carries when adding $k$ and $n-k$ in base $p$. This directly constrains which $n$ satisfy AllPrimesExceed: $\\binom{n}{k}$ is odd iff there are no carries in binary addition of $k$ and $n-k$"
+        },
+        {
+            "targetId": "binomial-theorem",
+            "relationship": "foundational",
+            "description": "Provides the algebraic framework for binomial coefficients $\\binom{n}{k}$ central to this problem"
+        },
+        {
+            "targetId": "bertrands-postulate",
+            "relationship": "related",
+            "description": "Bertrand's postulate guarantees primes in $(k, 2k]$, relevant to understanding the prime factorization of $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$ — primes in $(k, n]$ divide the numerator but not $k!$"
+        },
+        {
+            "targetId": "infinitude-primes",
+            "relationship": "foundational",
+            "description": "The infinitude of primes ensures that for any $k$, there exist primes exceeding $k$ that could divide $\\binom{n}{k}$, making the AllPrimesExceed condition achievable"
+        }
     ],
-    "prerequisites": [
-      "Number theory basics",
-      "Prime factorization",
-      "Binomial coefficients"
-    ]
-  },
-  "sections": [
-    {
-      "id": "header",
-      "title": "Module Header and Imports",
-      "startLine": 1,
-      "endLine": 28,
-      "summary": "Module docstring describing the problem, known bounds (Ecklund-Erdős-Selfridge, Konyagin), concrete values, and imports from Mathlib (Nat.Choose.Basic, Nat.Prime.Basic, Tactic).",
-      "mathContext": "Bound: Module docstring describing the problem, known bounds (Ecklund-Erdős-Selfridge, Konyagin), concrete values, and imports from Mathlib (Nat.Choose.Basic, Nat.Prime.Basic, Tactic)."
-    },
-    {
-      "id": "core-definitions",
-      "title": "Part 1: Core Definitions",
-      "startLine": 30,
-      "endLine": 38,
-      "summary": "`AllPrimesExceed m k`: all prime factors of $m$ exceed $k$. Defines the $k$-smooth-free predicate central to the problem.",
-      "mathContext": "Formal definition: `AllPrimesExceed m k`: all prime factors of $m$ exceed $k$. Defines the $k$-smooth-free predicate central to the problem."
-    },
-    {
-      "id": "gfunc-axiomatization",
-      "title": "Part 2: g(k) Axiomatization",
-      "startLine": 40,
-      "endLine": 56,
-      "summary": "Four axiom declarations: `gFunc : ℕ → ℕ`, `gFunc_gt` ($g(k) > k+1$), `gFunc_spec` (all primes in $\\binom{g(k)}{k}$ exceed $k$), `gFunc_minimal` (minimality).",
-      "mathContext": "Four axiom declarations: `gFunc : $\\mathbb{N}$ $\\to$ $\\mathbb{N}$`, `gFunc_gt` ($g(k) > k+1$), `gFunc_spec` (all primes in $\\binom{g(k)}{k}$ exceed $k$), `gFunc_minimal` (minimality)."
-    },
-    {
-      "id": "basic-lemmas",
-      "title": "Part 3: Basic Lemmas about AllPrimesExceed",
-      "startLine": 58,
-      "endLine": 82,
-      "summary": "Four structural lemmas: `allPrimesExceed_one` (vacuous for 1), `allPrimesExceed_of_dvd` (inherited by divisors), `allPrimesExceed_mono` (monotone in $k$), `not_allPrimesExceed_of_prime_dvd` (negation witness).",
-      "mathContext": "Four structural lemmas: `allPrimesExceed_one` (vacuous for 1), `allPrimesExceed_of_dvd` (inherited by divisors), `allPrimesExceed_mono` (monotone in $k$), `not_allPrimesExceed_of_prime_dvd` (negation witness)."
-    },
-    {
-      "id": "even-binomials",
-      "title": "Part 4: Even Binomial Coefficients",
-      "startLine": 84,
-      "endLine": 99,
-      "summary": "`choose_eq_zero_of_lt` ($\\binom{n}{k} = 0$ when $k > n$) and `choose_odd_of_allPrimesExceed` (for $k \\geq 2$, $\\binom{n}{k}$ at $g(k)$ must be odd since $2 \\leq k$).",
-      "mathContext": "Mathematical content: `choose_eq_zero_of_lt` ($\\binom{n}{k} = 0$ when $k > n$) and `choose_odd_of_allPrimesExceed` (for $k \\geq 2$, $\\binom{n}{k}$ at $g(k)$ must be odd since $2 \\leq k$)."
-    },
-    {
-      "id": "concrete-computations",
-      "title": "Part 5: Concrete Computations",
-      "startLine": 101,
-      "endLine": 116,
-      "summary": "Verified by `decide`: $\\binom{3}{1} = 3$, $\\binom{6}{2} = 15$, $\\binom{4}{2} = 6$, $\\binom{5}{2} = 10$. These confirm $g(1) = 3$ and $g(2) = 6$.",
-      "mathContext": "Mathematical content: Verified by `decide`: $\\binom{3}{1} = 3$, $\\binom{6}{2} = 15$, $\\binom{4}{2} = 6$, $\\binom{5}{2} = 10$. These confirm $g(1) = 3$ and $g(2) = 6$."
-    },
-    {
-      "id": "g5-computation",
-      "title": "Part 5c: Computing g(5) = 23",
-      "startLine": 216,
-      "endLine": 243,
-      "summary": "`gFunc_five`: $g(5) = 23$, proved by showing $\\binom{23}{5} = 33649 = 7 \\cdot 11 \\cdot 19 \\cdot 23$ has no prime $\\leq 5$, and eliminating $n = 7, \\ldots, 22$ via `interval_cases`.",
-      "mathContext": "Mathematical content: $g(5) = 23$ via exhaustive check: $\\binom{n}{5}$ is even for most $n \\in [7,22]$, and divisible by 3 for the odd cases ($n = 7, 13, 15, 21$)."
-    },
-    {
-      "id": "g6-computation",
-      "title": "Part 5d: Computing g(6) = 62",
-      "startLine": 245,
-      "endLine": 272,
-      "summary": "`gFunc_six`: $g(6) = 62$, proved by showing $\\binom{62}{6} = 61474519 = 19 \\cdot 29 \\cdot 31 \\cdot 59 \\cdot 61$ has no prime $\\leq 6$, and eliminating $n = 8, \\ldots, 61$ via `interval_cases`.",
-      "mathContext": "Mathematical content: $g(6) = 62$ via exhaustive check of 54 candidate values. Every $\\binom{n}{6}$ for $n \\in [8,61]$ has a prime factor in $\\{2, 3, 5\\}$."
-    },
-    {
-      "id": "structural-properties",
-      "title": "Part 6: Structural Properties of g(k)",
-      "startLine": 274,
-      "endLine": 283,
-      "summary": "`gFunc_ge_k_plus_two`: $g(k) \\geq k+2$ from the axiom $g(k) > k+1$, via `omega`. The weakest formal lower bound on $g$.",
-      "mathContext": "Axiomatized: `gFunc_ge_k_plus_two`: $g(k) \\geq k+2$ from the axiom $g(k) > k+1$, via `omega`. The weakest formal lower bound on $g$."
-    },
-    {
-      "id": "problem-statement",
-      "title": "Part 7: Problem Statement (Open)",
-      "startLine": 288,
-      "endLine": 318,
-      "summary": "The open conjecture (informally: $\\log g(k) \\sim c \\cdot k/\\log k$) and its weakened formal version `ErdosProblem1095OQ01`: $\\exists c > 0,\\; \\forall k > 0,\\; g(k) > k^c$ (super-polynomial growth).",
-      "mathContext": "Mathematical content: The open conjecture (informally: $\\log g(k) \\sim c \\cdot k/\\log k$) and its weakened formal version `ErdosProblem1095OQ01`: $\\exists c > 0,\\; \\forall k > 0,\\; g(k) > k^c$ (super-polynomial growth)."
-    }
-  ],
-  "conclusion": {
-    "summary": "This formalization establishes the framework for Erdős problem #1095 OQ01 about the growth rate of g(k). We prove structural lemmas about the AllPrimesExceed predicate and connect it to parity of binomial coefficients.",
-    "implications": "A resolution would precisely characterize how rare it is for large binomial coefficients to avoid all small prime factors. The answer has implications for smooth number theory: since $\\binom{n}{k} = \\prod_{i=1}^{k} \\frac{n-k+i}{i}$, understanding when this product avoids small primes connects to the distribution of smooth numbers among products of consecutive integers. The function $g(k)$ also relates to Grimm's conjecture (that if $n+1, n+2, \\ldots, n+k$ are all composite, they can be assigned distinct prime divisors) and to the Erdős-Selfridge conjecture on the largest prime factor of products of consecutive integers.",
-    "openQuestions": [
-      "Is log g(k) ~ c·k/log k for some constant c > 0?",
-      "What is the exact value of c if it exists?",
-      "Does g(k) < lcm(1,...,k) for large k?"
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Data.Nat.Choose.Basic",
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Tactic",
-      "Proofs.KummerTheoremOQ03"
+    "references": [
+        {
+            "authors": "Ecklund, Earl F.; Erdős, Paul; Selfridge, John L.",
+            "title": "A new function associated with the prime factors of $\\binom{n}{k}$",
+            "year": "1974",
+            "venue": "Mathematics of Computation, vol. 28, no. 125, pp. 647–649",
+            "note": "Introduced g(k) and established the initial bounds k^{1+c} < g(k) ≤ exp((1+o(1))k)"
+        },
+        {
+            "authors": "Konyagin, Sergei V.",
+            "title": "On the number of solutions of an equation with a prime divisor",
+            "year": "1999",
+            "venue": "Izvestiya: Mathematics",
+            "note": "Improved the lower bound to g(k) ≫ exp(c(log k)²) using smooth number estimates"
+        },
+        {
+            "authors": "Erdős, Paul; Lacampagne, C. B.; Selfridge, John L.",
+            "title": "Estimates of the least prime factor of a binomial coefficient",
+            "year": "1993",
+            "venue": "Mathematics of Computation, vol. 61, no. 203, pp. 215–224",
+            "note": "Conjectured log g(k) ~ c·k/log k and established refined bounds on the least prime factor of binomial coefficients"
+        },
+        {
+            "authors": "Sorenson, Jonathan; Sorenson, Jared; Webster, Jonathan",
+            "title": "Computing the first instances of the Erdős-Selfridge function",
+            "year": "2013",
+            "venue": "arXiv preprint",
+            "note": "Computed g(k) for small k values, providing heuristic evidence for the conjecture log g(k) ~ c·k/log k"
+        }
     ],
-    "opens": [
-      "Nat"
-    ],
-    "namespace": "Erdos1095OQ01",
-    "lineCount": 475,
-    "axiomCount": 0,
-    "theoremCount": 21,
-    "definitionCount": 4,
-    "path": "Proofs/Erdos1095OQ01Problem.lean",
     "sorries": 0
-  },
-  "crossReferences": [
-    {
-      "targetId": "erdos-1095",
-      "relationship": "parent",
-      "description": "Open question derived from Erdős #1095 on g(k)"
-    },
-    {
-      "targetId": "kummer-theorem",
-      "relationship": "foundational",
-      "description": "Kummer's theorem characterizes $\\nu_p(\\binom{n}{k})$ as the number of carries when adding $k$ and $n-k$ in base $p$. This directly constrains which $n$ satisfy AllPrimesExceed: $\\binom{n}{k}$ is odd iff there are no carries in binary addition of $k$ and $n-k$"
-    },
-    {
-      "targetId": "binomial-theorem",
-      "relationship": "foundational",
-      "description": "Provides the algebraic framework for binomial coefficients $\\binom{n}{k}$ central to this problem"
-    },
-    {
-      "targetId": "bertrands-postulate",
-      "relationship": "related",
-      "description": "Bertrand's postulate guarantees primes in $(k, 2k]$, relevant to understanding the prime factorization of $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$ — primes in $(k, n]$ divide the numerator but not $k!$"
-    },
-    {
-      "targetId": "infinitude-primes",
-      "relationship": "foundational",
-      "description": "The infinitude of primes ensures that for any $k$, there exist primes exceeding $k$ that could divide $\\binom{n}{k}$, making the AllPrimesExceed condition achievable"
-    }
-  ],
-  "references": [
-    {
-      "authors": "Ecklund, Earl F.; Erdős, Paul; Selfridge, John L.",
-      "title": "A new function associated with the prime factors of $\\binom{n}{k}$",
-      "year": "1974",
-      "venue": "Mathematics of Computation, vol. 28, no. 125, pp. 647–649",
-      "note": "Introduced g(k) and established the initial bounds k^{1+c} < g(k) ≤ exp((1+o(1))k)"
-    },
-    {
-      "authors": "Konyagin, Sergei V.",
-      "title": "On the number of solutions of an equation with a prime divisor",
-      "year": "1999",
-      "venue": "Izvestiya: Mathematics",
-      "note": "Improved the lower bound to g(k) ≫ exp(c(log k)²) using smooth number estimates"
-    },
-    {
-      "authors": "Erdős, Paul; Lacampagne, C. B.; Selfridge, John L.",
-      "title": "Estimates of the least prime factor of a binomial coefficient",
-      "year": "1993",
-      "venue": "Mathematics of Computation, vol. 61, no. 203, pp. 215–224",
-      "note": "Conjectured log g(k) ~ c·k/log k and established refined bounds on the least prime factor of binomial coefficients"
-    },
-    {
-      "authors": "Sorenson, Jonathan; Sorenson, Jared; Webster, Jonathan",
-      "title": "Computing the first instances of the Erdős-Selfridge function",
-      "year": "2013",
-      "venue": "arXiv preprint",
-      "note": "Computed g(k) for small k values, providing heuristic evidence for the conjecture log g(k) ~ c·k/log k"
-    }
-  ],
-  "sorries": 0
 }

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -1,107 +1,107 @@
 {
-  "id": "frobenius-number",
-  "title": "Frobenius Number for Two Coprime Integers",
-  "slug": "frobenius-number",
-  "description": "A complete proof of Sylvester's 1884 theorem: for coprime positive integers a and b, the Frobenius number (largest non-representable integer) is g(a,b) = ab - a - b. Also known as the Chicken McNugget Theorem or Coin Problem. The proof establishes the representability structure via the Bezout identity and shows exactly (a-1)(b-1)/2 non-representable positive integers exist.",
-  "meta": {
-    "author": "Lean Genius",
-    "date": "2026-05-04",
-    "status": "verified",
-    "proofRepoPath": "Proofs/FrobeniusNumber.lean",
-    "tags": [
-      "number-theory",
-      "combinatorics",
-      "frobenius",
-      "coin-problem",
-      "coprime"
+    "id": "frobenius-number",
+    "title": "Frobenius Number for Two Coprime Integers",
+    "slug": "frobenius-number",
+    "description": "A complete proof of Sylvester's 1884 theorem: for coprime positive integers a and b, the Frobenius number (largest non-representable integer) is g(a,b) = ab - a - b. Also known as the Chicken McNugget Theorem or Coin Problem. The proof establishes the representability structure via the Bezout identity and shows exactly (a-1)(b-1)/2 non-representable positive integers exist.",
+    "meta": {
+        "author": "Lean Genius",
+        "date": "2026-05-04",
+        "status": "verified",
+        "proofRepoPath": "Proofs/FrobeniusNumber.lean",
+        "tags": [
+            "number-theory",
+            "combinatorics",
+            "frobenius",
+            "coin-problem",
+            "coprime"
+        ],
+        "badge": "original",
+        "sorries": 0,
+        "axiomCount": 0,
+        "lineCount": 317,
+        "theoremCount": 13,
+        "definitionCount": 3,
+        "assumptions": ""
+    },
+    "overview": {
+        "historicalContext": "J.J. Sylvester posed the Frobenius coin problem in 1882 and solved the two-generator case in 1884: for coprime positive integers $a$ and $b$, the largest amount that cannot be made using only $a$-cent and $b$-cent coins is $ab - a - b$. The result was independently rediscovered multiple times (Frobenius discussed it in lectures, giving it his name). The popular 'Chicken McNugget Theorem' refers to the claim that with 6- and 9-piece boxes you can't make exactly 43 pieces, but since gcd(6,9)=3, the actual coprime example is {3,5} or {5,7}. The n-generator generalization ($n \\geq 3$) is NP-hard, making this two-generator formula doubly remarkable: it is both explicit and proves the maximum exists (a non-trivial fact — when gcd > 1 there is no largest non-representable number).",
+        "problemStatement": "For coprime positive integers $a, b$ (i.e., $\\gcd(a,b) = 1$), define $g(a,b) = ab - a - b$. Prove: (1) $g(a,b)$ is NOT representable as $ax + by$ with $x, y \\geq 0$; (2) every integer $n > g(a,b)$ IS representable. Additionally, there are exactly $(a-1)(b-1)/2$ positive non-representable integers.",
+        "proofStrategy": "The key is that the map $k \\mapsto kb \\bmod a$ is a bijection on $\\{0, 1, \\ldots, a-1\\}$ when $\\gcd(a,b) = 1$ (proved via injectivity → surjectivity on a finite set). Given $n > ab - a - b$, find $k < a$ with $kb \\equiv n \\pmod{a}$. Then $a \\mid (n - kb)$, giving $n - kb = aq$ for some $q \\geq 0$, so $n = aq + kb$. The bound $n > ab - a - b = (a-1)(b-1) - 1$ ensures $n \\geq (a-1)(b-1)$ which, combined with $k < a$, forces $q \\geq 0$. For the non-representability of $ab - a - b$: any representation $ax + by = ab - a - b$ leads to $a(x+1) + b(y+1) = ab$; coprimality then forces $a \\mid (y+1)$ and $b \\mid (x+1)$, giving $x+1 \\geq b$ and $y+1 \\geq a$, so $a(x+1) + b(y+1) \\geq 2ab > ab$, contradiction.",
+        "keyInsights": [
+            "The injectivity of $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$ is the bridge between the number theory (coprimality) and the combinatorics (surjectivity needed to find representations). In Lean 4 this uses `Finite.injective_iff_surjective` on `Fin a`.",
+            "The bound $(a-1)(b-1) \\leq n$ is equivalent to $n > ab - a - b$ by a simple omega computation: $(a-1)(b-1) = ab - a - b + 1$. This rewriting is the key step connecting the theorem's two formulations.",
+            "The non-representability proof uses a `nlinarith`-friendly formulation: any representation $ax + by = ab - a - b$ would give $a(x+1) + b(y+1) = ab$ with $a \\mid (y+1)$ and $b \\mid (x+1)$, forcing both terms to be at least $ab$ — but their sum is $ab$. Contradiction by linear arithmetic.",
+            "Consecutive integers $(a, a+1)$ always have $\\gcd = 1$, giving the family $g(a, a+1) = a^2 - a - 1$. For $a = 2$: only 1 is non-representable in $\\{2, 3\\}$; for $a = 3$: only $\\{1, 2, 4, 5\\}$ are non-representable in $\\{3, 4\\}$ with max 5.",
+            "The count $(a-1)(b-1)/2$ of non-representable positive integers is proved implicitly via examples but not by a general theorem in this file — it is an open question whether this gallery proof can be extended to include the exact count."
+        ]
+    },
+    "sections": [
+        {
+            "id": "representability",
+            "title": "Representability: Definition and Closure Properties",
+            "startLine": 38,
+            "endLine": 68,
+            "summary": "Defines `Representable a b n := ∃ x y : ℕ, n = a*x + b*y` and proves closure: 0, a, b are representable; if n is representable so are n+a and n+b. These closure properties bootstrap the inductive structure used in the main theorem."
+        },
+        {
+            "id": "frobenius-def",
+            "title": "Frobenius Number and Count Definitions",
+            "startLine": 70,
+            "endLine": 89,
+            "summary": "Defines `frobeniusNumber a b := a*b - a - b` (the conjectured threshold) and `numNonRepresentable a b := (a-1)*(b-1)/2` (the count of non-representable positives). Proves the alternative form `frobeniusNumber = (a-1)*(b-1) - 1` for a,b ≥ 2."
+        },
+        {
+            "id": "key-lemma",
+            "title": "Key Lemma: Bijection k ↦ kb mod a on Fin a",
+            "startLine": 90,
+            "endLine": 132,
+            "summary": "The private lemma `mul_mod_injective` proves injectivity of k ↦ k*b mod a on Fin a (when gcd(a,b) = 1) via coprimality. Then `exists_mul_mod` inverts this: every residue r < a is achieved as k*b mod a for some k < a. This bijection is the number-theoretic engine of the Frobenius theorem."
+        },
+        {
+            "id": "main-theorem",
+            "title": "Main Theorem: Large Numbers Are Representable",
+            "startLine": 134,
+            "endLine": 233,
+            "summary": "Two key theorems: `large_representable` (every n ≥ (a-1)(b-1) is representable, proved by finding k < a with k*b ≡ n mod a) and `frobenius_not_representable` (ab-a-b is not representable, by coprimality forcing x+1 ≥ b and y+1 ≥ a). Combined in `sylvester_frobenius`."
+        },
+        {
+            "id": "examples",
+            "title": "Verified Numeric Examples",
+            "startLine": 235,
+            "endLine": 263,
+            "summary": "Concrete computations using native_decide: frobeniusNumber(3,5)=7, (3,7)=11, (5,8)=27. Explicit representations for 8 through 12 in {3,5}. numNonRepresentable(3,5)=4 (values: 1,2,4,7) and (3,7)=6."
+        },
+        {
+            "id": "corollaries",
+            "title": "Corollaries and Special Cases",
+            "startLine": 265,
+            "endLine": 316,
+            "summary": "eventually_all_representable (quantitative: all n ≥ (a-1)(b-1) work), closure theorems as one-line aliases, frobenius_consecutive (special case: g(a,a+1) = a²-a-1), and Chicken McNugget examples (g(2,3)=1, g(3,4)=5, g(4,5)=11)."
+        }
     ],
-    "badge": "original",
-    "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 317,
-    "theoremCount": 13,
-    "definitionCount": 3,
-    "assumptions": ""
-  },
-  "overview": {
-    "historicalContext": "J.J. Sylvester posed the Frobenius coin problem in 1882 and solved the two-generator case in 1884: for coprime positive integers $a$ and $b$, the largest amount that cannot be made using only $a$-cent and $b$-cent coins is $ab - a - b$. The result was independently rediscovered multiple times (Frobenius discussed it in lectures, giving it his name). The popular 'Chicken McNugget Theorem' refers to the claim that with 6- and 9-piece boxes you can't make exactly 43 pieces, but since gcd(6,9)=3, the actual coprime example is {3,5} or {5,7}. The n-generator generalization ($n \\geq 3$) is NP-hard, making this two-generator formula doubly remarkable: it is both explicit and proves the maximum exists (a non-trivial fact — when gcd > 1 there is no largest non-representable number).",
-    "problemStatement": "For coprime positive integers $a, b$ (i.e., $\\gcd(a,b) = 1$), define $g(a,b) = ab - a - b$. Prove: (1) $g(a,b)$ is NOT representable as $ax + by$ with $x, y \\geq 0$; (2) every integer $n > g(a,b)$ IS representable. Additionally, there are exactly $(a-1)(b-1)/2$ positive non-representable integers.",
-    "proofStrategy": "The key is that the map $k \\mapsto kb \\bmod a$ is a bijection on $\\{0, 1, \\ldots, a-1\\}$ when $\\gcd(a,b) = 1$ (proved via injectivity → surjectivity on a finite set). Given $n > ab - a - b$, find $k < a$ with $kb \\equiv n \\pmod{a}$. Then $a \\mid (n - kb)$, giving $n - kb = aq$ for some $q \\geq 0$, so $n = aq + kb$. The bound $n > ab - a - b = (a-1)(b-1) - 1$ ensures $n \\geq (a-1)(b-1)$ which, combined with $k < a$, forces $q \\geq 0$. For the non-representability of $ab - a - b$: any representation $ax + by = ab - a - b$ leads to $a(x+1) + b(y+1) = ab$; coprimality then forces $a \\mid (y+1)$ and $b \\mid (x+1)$, giving $x+1 \\geq b$ and $y+1 \\geq a$, so $a(x+1) + b(y+1) \\geq 2ab > ab$, contradiction.",
-    "keyInsights": [
-      "The injectivity of $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$ is the bridge between the number theory (coprimality) and the combinatorics (surjectivity needed to find representations). In Lean 4 this uses `Finite.injective_iff_surjective` on `Fin a`.",
-      "The bound $(a-1)(b-1) \\leq n$ is equivalent to $n > ab - a - b$ by a simple omega computation: $(a-1)(b-1) = ab - a - b + 1$. This rewriting is the key step connecting the theorem's two formulations.",
-      "The non-representability proof uses a `nlinarith`-friendly formulation: any representation $ax + by = ab - a - b$ would give $a(x+1) + b(y+1) = ab$ with $a \\mid (y+1)$ and $b \\mid (x+1)$, forcing both terms to be at least $ab$ — but their sum is $ab$. Contradiction by linear arithmetic.",
-      "Consecutive integers $(a, a+1)$ always have $\\gcd = 1$, giving the family $g(a, a+1) = a^2 - a - 1$. For $a = 2$: only 1 is non-representable in $\\{2, 3\\}$; for $a = 3$: only $\\{1, 2, 4, 5\\}$ are non-representable in $\\{3, 4\\}$ with max 5.",
-      "The count $(a-1)(b-1)/2$ of non-representable positive integers is proved implicitly via examples but not by a general theorem in this file — it is an open question whether this gallery proof can be extended to include the exact count."
-    ]
-  },
-  "sections": [
-    {
-      "id": "representability",
-      "title": "Representability: Definition and Closure Properties",
-      "startLine": 38,
-      "endLine": 68,
-      "summary": "Defines `Representable a b n := ∃ x y : ℕ, n = a*x + b*y` and proves closure: 0, a, b are representable; if n is representable so are n+a and n+b. These closure properties bootstrap the inductive structure used in the main theorem."
+    "conclusion": {
+        "summary": "The Frobenius number formula g(a,b) = ab - a - b is machine-checked for all coprime positive integers a and b, with no axioms or sorries. The proof uses the bijection k ↦ kb mod a on Fin a as the key number-theoretic tool.",
+        "implications": "This is the complete two-variable solution to the Frobenius coin problem. The n-variable version (n ≥ 3 generators) is NP-hard in general, so this entry captures the full extent of what is computationally tractable. The bijection approach (injectivity → surjectivity on a finite set) is a pattern that reappears in many discrete math arguments: coprimality + finiteness → existence. The result also implies that the set of non-representable numbers is exactly a symmetric set: n is non-representable iff ab - a - b - n is non-representable (when 1 ≤ n ≤ ab - a - b - 1), a beautiful duality not proved here.",
+        "openQuestions": [
+            "Can the count of non-representable numbers ((a-1)(b-1)/2) be proved as a theorem in this framework, not just verified for examples?",
+            "The symmetry of non-representable numbers (n is non-representable iff g(a,b) - n is non-representable, when both are positive) — can this be formalized here?",
+            "Can the proof be extended to the 3-generator case g(a,b,c) with explicit formulas for specific families (arithmetic progressions, Fibonacci triples)?"
+        ]
     },
-    {
-      "id": "frobenius-def",
-      "title": "Frobenius Number and Count Definitions",
-      "startLine": 70,
-      "endLine": 89,
-      "summary": "Defines `frobeniusNumber a b := a*b - a - b` (the conjectured threshold) and `numNonRepresentable a b := (a-1)*(b-1)/2` (the count of non-representable positives). Proves the alternative form `frobeniusNumber = (a-1)*(b-1) - 1` for a,b ≥ 2."
-    },
-    {
-      "id": "key-lemma",
-      "title": "Key Lemma: Bijection k ↦ kb mod a on Fin a",
-      "startLine": 90,
-      "endLine": 132,
-      "summary": "The private lemma `mul_mod_injective` proves injectivity of k ↦ k*b mod a on Fin a (when gcd(a,b) = 1) via coprimality. Then `exists_mul_mod` inverts this: every residue r < a is achieved as k*b mod a for some k < a. This bijection is the number-theoretic engine of the Frobenius theorem."
-    },
-    {
-      "id": "main-theorem",
-      "title": "Main Theorem: Large Numbers Are Representable",
-      "startLine": 134,
-      "endLine": 233,
-      "summary": "Two key theorems: `large_representable` (every n ≥ (a-1)(b-1) is representable, proved by finding k < a with k*b ≡ n mod a) and `frobenius_not_representable` (ab-a-b is not representable, by coprimality forcing x+1 ≥ b and y+1 ≥ a). Combined in `sylvester_frobenius`."
-    },
-    {
-      "id": "examples",
-      "title": "Verified Numeric Examples",
-      "startLine": 235,
-      "endLine": 263,
-      "summary": "Concrete computations using native_decide: frobeniusNumber(3,5)=7, (3,7)=11, (5,8)=27. Explicit representations for 8 through 12 in {3,5}. numNonRepresentable(3,5)=4 (values: 1,2,4,7) and (3,7)=6."
-    },
-    {
-      "id": "corollaries",
-      "title": "Corollaries and Special Cases",
-      "startLine": 265,
-      "endLine": 316,
-      "summary": "eventually_all_representable (quantitative: all n ≥ (a-1)(b-1) work), closure theorems as one-line aliases, frobenius_consecutive (special case: g(a,a+1) = a²-a-1), and Chicken McNugget examples (g(2,3)=1, g(3,4)=5, g(4,5)=11)."
+    "crossReferences": [
+        {
+            "proofId": "infinitude-primes",
+            "relationship": "related",
+            "description": "Both proofs make fundamental use of prime and coprimality properties from Mathlib's Nat.GCD infrastructure"
+        }
+    ],
+    "leanFile": {
+        "path": "Proofs/FrobeniusNumber.lean",
+        "axiomCount": 0,
+        "sorryCount": 0,
+        "lineCount": 316,
+        "theoremCount": 15,
+        "definitionCount": 3,
+        "sorries": 0
     }
-  ],
-  "conclusion": {
-    "summary": "The Frobenius number formula g(a,b) = ab - a - b is machine-checked for all coprime positive integers a and b, with no axioms or sorries. The proof uses the bijection k ↦ kb mod a on Fin a as the key number-theoretic tool.",
-    "implications": "This is the complete two-variable solution to the Frobenius coin problem. The n-variable version (n ≥ 3 generators) is NP-hard in general, so this entry captures the full extent of what is computationally tractable. The bijection approach (injectivity → surjectivity on a finite set) is a pattern that reappears in many discrete math arguments: coprimality + finiteness → existence. The result also implies that the set of non-representable numbers is exactly a symmetric set: n is non-representable iff ab - a - b - n is non-representable (when 1 ≤ n ≤ ab - a - b - 1), a beautiful duality not proved here.",
-    "openQuestions": [
-      "Can the count of non-representable numbers ((a-1)(b-1)/2) be proved as a theorem in this framework, not just verified for examples?",
-      "The symmetry of non-representable numbers (n is non-representable iff g(a,b) - n is non-representable, when both are positive) — can this be formalized here?",
-      "Can the proof be extended to the 3-generator case g(a,b,c) with explicit formulas for specific families (arithmetic progressions, Fibonacci triples)?"
-    ]
-  },
-  "crossReferences": [
-    {
-      "proofId": "infinitude-primes",
-      "relationship": "related",
-      "description": "Both proofs make fundamental use of prime and coprimality properties from Mathlib's Nat.GCD infrastructure"
-    }
-  ],
-  "leanFile": {
-    "path": "Proofs/FrobeniusNumber.lean",
-    "axiomCount": 0,
-    "sorryCount": 0,
-    "lineCount": 316,
-    "theoremCount": 13,
-    "definitionCount": 3,
-    "sorries": 0
-  }
 }

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -1,135 +1,135 @@
 {
-  "id": "fundamental-arithmetic-oq-01-oq-01",
-  "title": "Self-Contained FTA via Finsupp Prime Exponent Maps",
-  "slug": "fundamental-arithmetic-oq-01-oq-01",
-  "description": "Proves the Fundamental Theorem of Arithmetic using Mathlib's Nat.factorization (the prime exponent map approach), entirely self-contained without importing the parent file. The key result is a uniqueness theorem: if f : ℕ →₀ ℕ has prime support and f.prod (·^·) = n, then f = n.factorization. This algebraic formulation complements the sorted-list approach of FundamentalArithmetic.lean.",
-  "meta": {
-    "author": "Lean Genius",
-    "date": "2026-05-03",
-    "status": "verified",
-    "proofRepoPath": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
-    "tags": [
-      "number-theory",
-      "factorization",
-      "finsupp",
-      "p-adic-valuation",
-      "unique-factorization",
-      "research"
+    "id": "fundamental-arithmetic-oq-01-oq-01",
+    "title": "Self-Contained FTA via Finsupp Prime Exponent Maps",
+    "slug": "fundamental-arithmetic-oq-01-oq-01",
+    "description": "Proves the Fundamental Theorem of Arithmetic using Mathlib's Nat.factorization (the prime exponent map approach), entirely self-contained without importing the parent file. The key result is a uniqueness theorem: if f : ℕ →₀ ℕ has prime support and f.prod (·^·) = n, then f = n.factorization. This algebraic formulation complements the sorted-list approach of FundamentalArithmetic.lean.",
+    "meta": {
+        "author": "Lean Genius",
+        "date": "2026-05-03",
+        "status": "verified",
+        "proofRepoPath": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
+        "tags": [
+            "number-theory",
+            "factorization",
+            "finsupp",
+            "p-adic-valuation",
+            "unique-factorization",
+            "research"
+        ],
+        "badge": "mathlib",
+        "sorries": 0,
+        "dateAdded": "2026-05-03",
+        "axiomCount": 0,
+        "assumptions": "None. Fully machine-verified.",
+        "lineCount": 221,
+        "theoremCount": 12,
+        "originalContributions": [
+            "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
+            "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",
+            "fundamental_theorem_of_arithmetic: ∃! f : ℕ →₀ ℕ with prime support and f.prod (·^·) = n (existence via Nat.factorization_prod_pow_eq_self; uniqueness via finsupp_prime_prod_factorization)",
+            "factorization_determines_number: factorization injectivity — equal factorizations imply equal numbers",
+            "factorization_eq_iff_valuations: m = n iff ∀ p, m.factorization p = n.factorization p",
+            "factorization_eq_zero_iff_one: n.factorization = 0 iff n = 1",
+            "fta_mem_support_iff_dvd: prime p divides n iff p ∈ n.factorization.support",
+            "coprime_factorization_disjoint: coprime numbers have disjoint factorization supports"
+        ],
+        "mathlib_version": "4.26.0"
+    },
+    "overview": {
+        "historicalContext": "The Fundamental Theorem of Arithmetic — every positive integer has a unique prime factorization — was known to Euclid (Elements Book IX, ~300 BCE) in the form that a prime dividing a product divides one of the factors. The fully explicit existence+uniqueness statement was first given by Gauss in Disquisitiones Arithmeticae (1801). Hilbert and Dedekind later generalized it: in any Unique Factorization Domain (UFD), every element factors uniquely into irreducibles. The FTA is the prototype for all UFD theory.\n\nModern algebra has two equivalent formulations: (1) the **list** form — $n = p_1 p_2 \\cdots p_k$ as a multiset of primes sorted in non-decreasing order (used in `FundamentalArithmetic.lean`); and (2) the **exponent map** form — $n = \\prod_p p^{v_p(n)}$ where $v_p(n)$ is the $p$-adic valuation (used here). The exponent map form is preferred in algebraic number theory because $v_p : \\mathbb{N}^\\times \\to \\mathbb{N}$ is a group homomorphism and the valuations add under multiplication. Mathlib's `Nat.factorization` implements the exponent map as a Finsupp (finite support function), making this algebraic structure available in Lean 4.",
+        "problemStatement": "Can the unique factorization theorem be proved in a self-contained way that avoids importing the parent FundamentalArithmetic.lean, using only Mathlib's Nat.factorization primitives? Specifically: does every positive natural n admit a UNIQUE representation as f.prod (·^·) where f : ℕ →₀ ℕ has prime support?",
+        "text": "Yes. The Finsupp-based FTA states: for every n ≠ 0, there exists a unique f : ℕ →₀ ℕ with (∀ p ∈ f.support, p.Prime) and f.prod (·^·) = n. The canonical witness is n.factorization, the Mathlib prime exponent map. The key algebraic lemma is: (f.prod (·^·)).factorization = f when f has prime support — proving that factorization and reconstruction are mutual inverses.",
+        "proofStrategy": "The proof proceeds in three stages: (1) Existence: Nat.factorization_prod_pow_eq_self gives n.factorization.prod (·^·) = n directly. (2) Key lemma: To show (f.prod (·^·)).factorization = f, apply Finsupp.ext and compute the a-component. Distribute factorization over the product using factorization_finset_prod, then use factorization_pow and Prime.factorization to reduce each term to an indicator function. Collapse with Finset.sum_ite_eq. (3) Uniqueness: Any g with g.prod (·^·) = n satisfies g = (g.prod (·^·)).factorization = n.factorization.",
+        "keyInsights": [
+            "Nat.factorization and Finsupp.prod (·^·) are mutual inverses on the space of prime-supported Finsupps — establishing a bijection between positive naturals and prime exponent maps",
+            "The factorization distributes over products: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization (for nonzero m), proved by induction using Nat.factorization_mul",
+            "For prime p, p.factorization = Finsupp.single p 1 — so (p^k).factorization a = if p = a then k else 0, making the indicator-sum argument clean",
+            "The Finsupp representation is algebraically cleaner than the list representation: factorization(m·n) = factorization(m) + factorization(n) in the Finsupp sense, and coprimality is disjoint support",
+            "The uniqueness proof is a single two-step calculation: g = (g.prod (·^·)).factorization (by the key lemma) = n.factorization (by the hypothesis g.prod (·^·) = n). This is the Finsupp analogue of saying the factorization map is injective — the only preimage of n under f ↦ f.prod (·^·) is n.factorization itself."
+        ],
+        "prerequisites": [
+            "Finsupp: Lean 4 type for finitely-supported functions α →₀ M",
+            "Nat.factorization: the prime exponent map n ↦ (p ↦ v_p(n))",
+            "Nat.primeFactors: the finite set of prime divisors of n",
+            "Finsupp.prod: ∏ p ∈ f.support, g p (f p)"
+        ]
+    },
+    "sections": [
+        {
+            "id": "helper",
+            "title": "Helper: Factorization Distributes Over Products",
+            "startLine": 34,
+            "endLine": 50,
+            "summary": "Proves factorization distributes over Finset products of nonzero naturals: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization. Proof by induction on s using Nat.factorization_mul."
+        },
+        {
+            "id": "existence",
+            "title": "Existence: Reconstruction and Support",
+            "startLine": 52,
+            "endLine": 81,
+            "summary": "Proves fta_reconstruction (n.factorization.prod (·^·) = n), fta_support_eq_primeFactors, fta_support_prime, and fta_mem_support_iff_dvd — establishing n.factorization as the canonical prime exponent map."
+        },
+        {
+            "id": "key-lemma",
+            "title": "Key Algebraic Lemma",
+            "startLine": 83,
+            "endLine": 118,
+            "summary": "For any f : ℕ →₀ ℕ with prime support: (f.prod (·^·)).factorization = f. Applies Finsupp.ext, distributes factorization over the product, and uses factorization_pow + Prime.factorization to reduce to an indicator-sum argument."
+        },
+        {
+            "id": "uniqueness",
+            "title": "Uniqueness of the Representation",
+            "startLine": 120,
+            "endLine": 131,
+            "summary": "If g has prime support and g.prod (·^·) = n, then g = n.factorization. Follows directly from the key lemma via a two-step calc."
+        },
+        {
+            "id": "fta",
+            "title": "Full FTA Statement",
+            "startLine": 133,
+            "endLine": 154,
+            "summary": "∃! f : ℕ →₀ ℕ, (∀ p ∈ f.support, p.Prime) ∧ f.prod (·^·) = n. The canonical witness is n.factorization; uniqueness follows from the key lemma."
+        },
+        {
+            "id": "corollaries",
+            "title": "Corollaries and Examples",
+            "startLine": 156,
+            "endLine": 219,
+            "summary": "Injectivity of factorization on positive naturals; m = n iff factorizations agree at every prime; n = 1 iff factorization is zero; coprime numbers have disjoint factorization supports. Includes native_decide examples for 12, 30, and coprimality."
+        }
     ],
-    "badge": "mathlib",
-    "sorries": 0,
-    "dateAdded": "2026-05-03",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
-    "lineCount": 221,
-    "theoremCount": 12,
-    "originalContributions": [
-      "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
-      "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",
-      "fundamental_theorem_of_arithmetic: ∃! f : ℕ →₀ ℕ with prime support and f.prod (·^·) = n (existence via Nat.factorization_prod_pow_eq_self; uniqueness via finsupp_prime_prod_factorization)",
-      "factorization_determines_number: factorization injectivity — equal factorizations imply equal numbers",
-      "factorization_eq_iff_valuations: m = n iff ∀ p, m.factorization p = n.factorization p",
-      "factorization_eq_zero_iff_one: n.factorization = 0 iff n = 1",
-      "fta_mem_support_iff_dvd: prime p divides n iff p ∈ n.factorization.support",
-      "coprime_factorization_disjoint: coprime numbers have disjoint factorization supports"
+    "conclusion": {
+        "summary": "The FTA has a clean algebraic formulation via Finsupp: every positive natural has a unique prime exponent map. This self-contained proof avoids the parent file entirely, demonstrating that Mathlib's Nat.factorization machinery is sufficient to prove both existence and uniqueness from scratch.",
+        "implications": "The key insight is that factorization and reconstruction are mutual inverses — a consequence of Nat.factorization_prod_pow_eq_self combined with the distribution of factorization over products. This algebraic approach complements the sorted-list FTA: the Finsupp formulation has cleaner multiplicative structure (factorization is a monoid homomorphism) while the list formulation is more computationally explicit.",
+        "openQuestions": [
+            "Can the Finsupp FTA be extended to prove the Euler product formula ζ(s) = ∏(1-p^{-s})^{-1}?",
+            "Does the Finsupp approach simplify the proof of unique factorization in number fields via Dedekind domains?"
+        ]
+    },
+    "leanFile": {
+        "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
+        "namespace": "FundamentalArithmeticOQ01OQ01",
+        "axiomCount": 0,
+        "lineCount": 220,
+        "theoremCount": 13,
+        "sorries": 0
+    },
+    "crossReferences": [
+        {
+            "id": "fundamental-arithmetic",
+            "relationship": "parent",
+            "description": "Parent proof using the sorted-list approach (Nat.primeFactorsList)"
+        },
+        {
+            "id": "fundamental-arithmetic-oq-01",
+            "relationship": "sibling",
+            "description": "Multiplicative property of factorization — factorization(m·n) = factorization(m) + factorization(n)"
+        },
+        {
+            "id": "fundamental-arithmetic-oq-02",
+            "relationship": "sibling",
+            "description": "Failure of unique factorization in ℤ[√(-5)]"
+        }
     ],
-    "mathlib_version": "4.26.0"
-  },
-  "overview": {
-    "historicalContext": "The Fundamental Theorem of Arithmetic — every positive integer has a unique prime factorization — was known to Euclid (Elements Book IX, ~300 BCE) in the form that a prime dividing a product divides one of the factors. The fully explicit existence+uniqueness statement was first given by Gauss in Disquisitiones Arithmeticae (1801). Hilbert and Dedekind later generalized it: in any Unique Factorization Domain (UFD), every element factors uniquely into irreducibles. The FTA is the prototype for all UFD theory.\n\nModern algebra has two equivalent formulations: (1) the **list** form — $n = p_1 p_2 \\cdots p_k$ as a multiset of primes sorted in non-decreasing order (used in `FundamentalArithmetic.lean`); and (2) the **exponent map** form — $n = \\prod_p p^{v_p(n)}$ where $v_p(n)$ is the $p$-adic valuation (used here). The exponent map form is preferred in algebraic number theory because $v_p : \\mathbb{N}^\\times \\to \\mathbb{N}$ is a group homomorphism and the valuations add under multiplication. Mathlib's `Nat.factorization` implements the exponent map as a Finsupp (finite support function), making this algebraic structure available in Lean 4.",
-    "problemStatement": "Can the unique factorization theorem be proved in a self-contained way that avoids importing the parent FundamentalArithmetic.lean, using only Mathlib's Nat.factorization primitives? Specifically: does every positive natural n admit a UNIQUE representation as f.prod (·^·) where f : ℕ →₀ ℕ has prime support?",
-    "text": "Yes. The Finsupp-based FTA states: for every n ≠ 0, there exists a unique f : ℕ →₀ ℕ with (∀ p ∈ f.support, p.Prime) and f.prod (·^·) = n. The canonical witness is n.factorization, the Mathlib prime exponent map. The key algebraic lemma is: (f.prod (·^·)).factorization = f when f has prime support — proving that factorization and reconstruction are mutual inverses.",
-    "proofStrategy": "The proof proceeds in three stages: (1) Existence: Nat.factorization_prod_pow_eq_self gives n.factorization.prod (·^·) = n directly. (2) Key lemma: To show (f.prod (·^·)).factorization = f, apply Finsupp.ext and compute the a-component. Distribute factorization over the product using factorization_finset_prod, then use factorization_pow and Prime.factorization to reduce each term to an indicator function. Collapse with Finset.sum_ite_eq. (3) Uniqueness: Any g with g.prod (·^·) = n satisfies g = (g.prod (·^·)).factorization = n.factorization.",
-    "keyInsights": [
-      "Nat.factorization and Finsupp.prod (·^·) are mutual inverses on the space of prime-supported Finsupps — establishing a bijection between positive naturals and prime exponent maps",
-      "The factorization distributes over products: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization (for nonzero m), proved by induction using Nat.factorization_mul",
-      "For prime p, p.factorization = Finsupp.single p 1 — so (p^k).factorization a = if p = a then k else 0, making the indicator-sum argument clean",
-      "The Finsupp representation is algebraically cleaner than the list representation: factorization(m·n) = factorization(m) + factorization(n) in the Finsupp sense, and coprimality is disjoint support",
-      "The uniqueness proof is a single two-step calculation: g = (g.prod (·^·)).factorization (by the key lemma) = n.factorization (by the hypothesis g.prod (·^·) = n). This is the Finsupp analogue of saying the factorization map is injective — the only preimage of n under f ↦ f.prod (·^·) is n.factorization itself."
-    ],
-    "prerequisites": [
-      "Finsupp: Lean 4 type for finitely-supported functions α →₀ M",
-      "Nat.factorization: the prime exponent map n ↦ (p ↦ v_p(n))",
-      "Nat.primeFactors: the finite set of prime divisors of n",
-      "Finsupp.prod: ∏ p ∈ f.support, g p (f p)"
-    ]
-  },
-  "sections": [
-    {
-      "id": "helper",
-      "title": "Helper: Factorization Distributes Over Products",
-      "startLine": 34,
-      "endLine": 50,
-      "summary": "Proves factorization distributes over Finset products of nonzero naturals: (∏ m ∈ s, m).factorization = ∑ m ∈ s, m.factorization. Proof by induction on s using Nat.factorization_mul."
-    },
-    {
-      "id": "existence",
-      "title": "Existence: Reconstruction and Support",
-      "startLine": 52,
-      "endLine": 81,
-      "summary": "Proves fta_reconstruction (n.factorization.prod (·^·) = n), fta_support_eq_primeFactors, fta_support_prime, and fta_mem_support_iff_dvd — establishing n.factorization as the canonical prime exponent map."
-    },
-    {
-      "id": "key-lemma",
-      "title": "Key Algebraic Lemma",
-      "startLine": 83,
-      "endLine": 118,
-      "summary": "For any f : ℕ →₀ ℕ with prime support: (f.prod (·^·)).factorization = f. Applies Finsupp.ext, distributes factorization over the product, and uses factorization_pow + Prime.factorization to reduce to an indicator-sum argument."
-    },
-    {
-      "id": "uniqueness",
-      "title": "Uniqueness of the Representation",
-      "startLine": 120,
-      "endLine": 131,
-      "summary": "If g has prime support and g.prod (·^·) = n, then g = n.factorization. Follows directly from the key lemma via a two-step calc."
-    },
-    {
-      "id": "fta",
-      "title": "Full FTA Statement",
-      "startLine": 133,
-      "endLine": 154,
-      "summary": "∃! f : ℕ →₀ ℕ, (∀ p ∈ f.support, p.Prime) ∧ f.prod (·^·) = n. The canonical witness is n.factorization; uniqueness follows from the key lemma."
-    },
-    {
-      "id": "corollaries",
-      "title": "Corollaries and Examples",
-      "startLine": 156,
-      "endLine": 219,
-      "summary": "Injectivity of factorization on positive naturals; m = n iff factorizations agree at every prime; n = 1 iff factorization is zero; coprime numbers have disjoint factorization supports. Includes native_decide examples for 12, 30, and coprimality."
-    }
-  ],
-  "conclusion": {
-    "summary": "The FTA has a clean algebraic formulation via Finsupp: every positive natural has a unique prime exponent map. This self-contained proof avoids the parent file entirely, demonstrating that Mathlib's Nat.factorization machinery is sufficient to prove both existence and uniqueness from scratch.",
-    "implications": "The key insight is that factorization and reconstruction are mutual inverses — a consequence of Nat.factorization_prod_pow_eq_self combined with the distribution of factorization over products. This algebraic approach complements the sorted-list FTA: the Finsupp formulation has cleaner multiplicative structure (factorization is a monoid homomorphism) while the list formulation is more computationally explicit.",
-    "openQuestions": [
-      "Can the Finsupp FTA be extended to prove the Euler product formula ζ(s) = ∏(1-p^{-s})^{-1}?",
-      "Does the Finsupp approach simplify the proof of unique factorization in number fields via Dedekind domains?"
-    ]
-  },
-  "leanFile": {
-    "path": "Proofs/FundamentalArithmeticOQ01OQ01.lean",
-    "namespace": "FundamentalArithmeticOQ01OQ01",
-    "axiomCount": 0,
-    "lineCount": 220,
-    "theoremCount": 12,
     "sorries": 0
-  },
-  "crossReferences": [
-    {
-      "id": "fundamental-arithmetic",
-      "relationship": "parent",
-      "description": "Parent proof using the sorted-list approach (Nat.primeFactorsList)"
-    },
-    {
-      "id": "fundamental-arithmetic-oq-01",
-      "relationship": "sibling",
-      "description": "Multiplicative property of factorization — factorization(m·n) = factorization(m) + factorization(n)"
-    },
-    {
-      "id": "fundamental-arithmetic-oq-02",
-      "relationship": "sibling",
-      "description": "Failure of unique factorization in ℤ[√(-5)]"
-    }
-  ],
-  "sorries": 0
 }

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -1,154 +1,154 @@
 {
-  "id": "konigsberg-oq-01-oq-02",
-  "title": "Eulerian Paths in Directed Graphs",
-  "slug": "konigsberg-oq-01-oq-02",
-  "description": "Extends the Eulerian circuit characterization to directed graphs. A weakly connected digraph has an Eulerian circuit iff every vertex has equal in-degree and out-degree; it has an Eulerian path from s to t iff outdeg(s)=indeg(s)+1, indeg(t)=outdeg(t)+1, and all other vertices are balanced. The directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg) and necessity direction (Eulerian circuit → balanced) are proved from first principles. 12 theorems proved, 2 axioms (Hierholzer sufficiency and path characterization).",
-  "meta": {
-    "author": "Lean Genius",
-    "date": "2026-05-03",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/KonigsbergOQ01OQ02.lean",
-    "tags": [
-      "graph-theory",
-      "eulerian-paths",
-      "directed-graphs",
-      "konigsberg",
-      "combinatorics",
-      "degree-sequences"
+    "id": "konigsberg-oq-01-oq-02",
+    "title": "Eulerian Paths in Directed Graphs",
+    "slug": "konigsberg-oq-01-oq-02",
+    "description": "Extends the Eulerian circuit characterization to directed graphs. A weakly connected digraph has an Eulerian circuit iff every vertex has equal in-degree and out-degree; it has an Eulerian path from s to t iff outdeg(s)=indeg(s)+1, indeg(t)=outdeg(t)+1, and all other vertices are balanced. The directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg) and necessity direction (Eulerian circuit → balanced) are proved from first principles. 12 theorems proved, 2 axioms (Hierholzer sufficiency and path characterization).",
+    "meta": {
+        "author": "Lean Genius",
+        "date": "2026-05-03",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/KonigsbergOQ01OQ02.lean",
+        "tags": [
+            "graph-theory",
+            "eulerian-paths",
+            "directed-graphs",
+            "konigsberg",
+            "combinatorics",
+            "degree-sequences"
+        ],
+        "badge": "axiom",
+        "sorries": 6,
+        "dateAdded": "2026-05-03",
+        "axiomCount": 2,
+        "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer's algorithm for directed graph Eulerian circuit — requires graph connectivity infrastructure) and directed_euler_path_iff (Eulerian path degree characterization). All other results (handshaking, necessity, concrete examples, consequences) are proved from first principles.",
+        "lineCount": 848,
+        "theoremCount": 12,
+        "definitionCount": 8,
+        "originalContributions": [
+            "sum_outDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.1=v}| = |E| by double-counting via Finset.sum_comm + Finset.sum_ite_eq'",
+            "sum_inDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.2=v}| = |E| by same double-counting argument",
+            "closed_walk_balance: private lemma — for a closed walk [v0,...,vn] with v0=vn, source-count at any vertex v equals target-count, via circular shift bijection i ↦ (i=0 ? n-1 : i-1)",
+            "walk_source_eq_outDegree / walk_target_eq_inDegree: private lemmas — the walk position bijection identifies source-counts and target-counts with outDegree and inDegree respectively",
+            "eulerian_circuit_implies_balanced: proved — necessity direction of Eulerian theorem, combining handshaking and walk bijection arguments",
+            "directedTriangle_balanced: the directed 3-cycle is Eulerian-balanced, verified by native_decide",
+            "directedPath_path_degrees: the directed path 0→1→2 satisfies Eulerian path degree conditions, verified by native_decide/case analysis",
+            "eulerian_balanced_sum_zero / eulerian_balanced_implies_degree_balance: structural consequences proved from main theorem"
+        ]
+    },
+    "overview": {
+        "historicalContext": "Euler's 1736 paper 'Solutio problematis ad geometriam situs pertinentis' on the Königsberg bridges introduced graph theory and proved the necessity direction of the Eulerian theorem for undirected graphs: an Eulerian circuit exists only if every vertex has even degree. The directed analogue emerged naturally: in a directed graph (digraph), an Eulerian circuit requires that each vertex has equal in-degree and out-degree — one outgoing edge consumed for each incoming edge at every visit. **Hierholzer's algorithm** (1873) proved sufficiency constructively: start any closed walk; if edges remain, splice in subcircuits at the first repeated vertex. The algorithm runs in O(|E|) and directly applies to directed graphs with the same degree balance condition.\n\nThe theory gained surprising new depth with **de Bruijn sequences** (Nicolaas de Bruijn, 1946). A de Bruijn sequence of order n over alphabet Σ is a cyclic sequence in which every length-n string over Σ appears exactly once. De Bruijn (and independently Good, 1946) observed that such sequences correspond to **Eulerian circuits in de Bruijn graphs**: vertices are length-(n-1) words, edges are length-n words, with the edge $(w_1\\ldots w_{n-1})\\to(w_2\\ldots w_n)$ representing the word $w_1\\ldots w_n$. The de Bruijn graph is regular (each vertex has in-degree = out-degree = |Σ|), so Eulerian circuits always exist, proving de Bruijn sequences always exist and giving an efficient construction via Hierholzer's algorithm.\n\nThe **BEST theorem** (van Aardenne-Ehrenfest and de Bruijn 1951; Smith and Tutte 1941–1948) counts Eulerian circuits in directed graphs: the number of distinct Eulerian circuits starting at vertex $w$ is $t_w(G) \\times \\prod_{v} (\\text{outDeg}(v)-1)!$, where $t_w(G)$ is the number of arborescences (spanning directed trees rooted at $w$). This remarkable formula connects Eulerian counting to the Matrix-Tree theorem.\n\nIn computational biology, **Eulerian path algorithms on de Bruijn graphs** became the basis for next-generation sequencing assembly. Pevzner, Tang, and Waterman (2001) introduced the EULER assembler: decompose a genome into overlapping k-mers, construct the de Bruijn graph, and find an Eulerian path. The genome is the sequence spelled by the Eulerian path — a dramatic application of 18th-century graph theory to 21st-century genomics.",
+        "problemStatement": "Extend the Eulerian circuit characterization (from undirected graphs) to directed graphs: characterize when a directed graph has an Eulerian circuit or path in terms of in-degrees and out-degrees.",
+        "text": "For a weakly connected directed graph G: (1) G has an Eulerian circuit iff every vertex v satisfies inDeg(v) = outDeg(v). (2) G has an Eulerian path from s to t (s≠t) iff outDeg(s)=inDeg(s)+1, inDeg(t)=outDeg(t)+1, and all other vertices v have inDeg(v)=outDeg(v).",
+        "proofStrategy": "Define DiGraph V as a Finset of directed edges with no self-loops. Define outDegree and inDegree by filtering edges. Prove the directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg) from first principles via double-counting: swap ∑_v and ∑_e using Finset.sum_comm, then apply Finset.sum_ite_eq'. Prove necessity (HasEulerianCircuit → IsEulerianBalanced) via a walk-position bijection argument: use the unique-coverage property to biject edges with walk positions, then show source-count = target-count using the closed walk property (walk[0] = walk[n] implies a circular shift bijection). Axiomatize the remaining directions (Hierholzer sufficiency, path characterization). Verify concrete examples (directed triangle, directed path) by native_decide.",
+        "keyInsights": [
+            "The directed handshaking lemma is proved by Finset.sum_comm: ∑_v |{e : e.1=v}| = ∑_e ∑_v [e.1=v] = ∑_e 1 = |E|. No Finset.card_biUnion needed.",
+            "Necessity requires a bijection between G.edges and walk positions. The key insight is to strengthen HasEulerianCircuit with ∃! (unique position per edge) and an hsteps condition (every walk step is an edge), enabling use of ExistsUnique.unique for injectivity.",
+            "The closed walk balance is proved by a bijection i ↦ (i=0 ? n-1 : i-1) from source positions {i < n : walk[i] = v} to target positions {i < n : walk[i+1] = v}, using the closed walk condition walk[0] = walk[n].",
+            "The directed triangle A→B→C→A is the canonical Eulerian circuit example: all three vertices have in-degree = out-degree = 1, verified by native_decide over Fin 3.",
+            "For the Eulerian path characterization, the source s has one more outgoing edge than incoming (to start the path), and the sink t has one more incoming edge than outgoing (to end the path). All intermediate vertices are balanced.",
+            "Weak connectivity (underlying undirected graph is connected) is the correct connectivity notion for directed Eulerian theory — strong connectivity is not required for the equivalence.",
+            "De Bruijn sequence connection: the de Bruijn graph B(n, Σ) is a digraph on length-(n-1) strings where each vertex has in-degree = out-degree = |Σ|. The directed Eulerian theorem guarantees Eulerian circuits exist in any such balanced weakly-connected digraph, proving de Bruijn sequences of every order exist over every alphabet — and Hierholzer's algorithm constructs them in O(|Σ|^n) time.",
+            "BEST theorem: the number of Eulerian circuits starting at vertex w in a directed Eulerian graph equals t_w(G) × ∏_v (outDeg(v)-1)!, where t_w(G) is the number of arborescences (spanning in-trees) rooted at w. This connects Eulerian circuit counting to the Matrix-Tree theorem (Kirchhoff 1847) — a deep result in algebraic graph theory.",
+            "Flow conservation interpretation: the directed handshaking equality ∑ outDeg = ∑ inDeg is equivalent to Kirchhoff's current law (KCL) in electrical networks and conservation of flow in network flow problems. An Eulerian graph (every vertex balanced) is one where a unit of 'flow' entering each vertex also leaves — the combinatorial version of a conservative vector field."
+        ],
+        "prerequisites": [
+            "Eulerian circuits and paths in undirected graphs (konigsberg-oq-01)",
+            "Directed graph degree sequences: in-degree, out-degree",
+            "Handshaking lemma for directed graphs: ∑ outDeg = |E| = ∑ inDeg"
+        ]
+    },
+    "sections": [
+        {
+            "id": "definitions",
+            "title": "Directed Graph Basics",
+            "startLine": 50,
+            "endLine": 70,
+            "summary": "Defines DiGraph V (edges: Finset (V×V), noSelfLoops), outDegree, inDegree, IsBalanced, IsEulerianBalanced.",
+            "mathContext": "$\\text{outDeg}(v) = |\\{e \\in E : e.1 = v\\}|$. $\\text{inDeg}(v) = |\\{e \\in E : e.2 = v\\}|$. $\\text{IsBalanced}(v)$: $\\text{inDeg}(v) = \\text{outDeg}(v)$."
+        },
+        {
+            "id": "handshaking",
+            "title": "Directed Handshaking Lemma (Proved)",
+            "startLine": 77,
+            "endLine": 105,
+            "summary": "Proves sum_outDegree_eq_edgeCount and sum_inDegree_eq_edgeCount from first principles via double-counting (swap ∑_v ∑_e with ∑_e ∑_v). Derives sum_outDegree_eq_sum_inDegree by transitivity.",
+            "mathContext": "$\\sum_{v} \\text{outDeg}(v) = |E| = \\sum_{v} \\text{inDeg}(v)$. Proof: $\\sum_v |\\{e: e.1=v\\}| = \\sum_v \\sum_{e \\in E} [e.1=v] = \\sum_{e \\in E} 1 = |E|$."
+        },
+        {
+            "id": "necessity",
+            "title": "Necessity: Eulerian Circuit Implies Balanced (Proved)",
+            "startLine": 112,
+            "endLine": 311,
+            "summary": "Defines HasEulerianCircuit with unique coverage (∃!) and step constraint. Three helper lemmas establish the bijection between walk positions and edges. Main theorem eulerian_circuit_implies_balanced proved: outDeg = source-count = target-count = inDeg, where middle equality uses the closed walk.",
+            "mathContext": "If $G$ has an Eulerian circuit with walk $[v_0,...,v_n]$ ($v_0 = v_n$), then $|\\{i < n : v_i = w\\}| = |\\{i < n : v_{i+1} = w\\}|$ for all $w$ (bijection: $i \\mapsto i-1 \\pmod{n}$). Combined with the edge-position bijection: $\\text{outDeg}(w) = \\text{inDeg}(w)$."
+        },
+        {
+            "id": "characterization",
+            "title": "Directed Eulerian Theorem and Path Characterization",
+            "startLine": 314,
+            "endLine": 341,
+            "summary": "Defines IsWeaklyConnected and HasEulerianPath. Axiomatizes directed_eulerian_iff (Hierholzer) and directed_euler_path_iff.",
+            "mathContext": "$G$ has an Eulerian circuit $\\iff$ $\\text{IsEulerianBalanced}(G)$ (weak connectivity required). $G$ has Eulerian path $s \\to t$ $\\iff$ $\\text{outDeg}(s) = \\text{inDeg}(s)+1$, $\\text{inDeg}(t) = \\text{outDeg}(t)+1$, and all others balanced."
+        },
+        {
+            "id": "examples",
+            "title": "Concrete Examples",
+            "startLine": 348,
+            "endLine": 371,
+            "summary": "Defines directedTriangle (Fin 3, edges {(0,1),(1,2),(2,0)}) and directedPath (Fin 3, edges {(0,1),(1,2)}). Proves balance properties by native_decide.",
+            "mathContext": "Directed 3-cycle: all vertices balanced ($\\text{in} = \\text{out} = 1$). Directed path $0 \\to 1 \\to 2$: $\\text{outDeg}(0) = 1 = \\text{inDeg}(0)+1$, $\\text{inDeg}(2) = 1 = \\text{outDeg}(2)+1$, vertex 1 balanced."
+        },
+        {
+            "id": "consequences",
+            "title": "Consequences",
+            "startLine": 373,
+            "endLine": 389,
+            "summary": "Proves eulerian_balanced_sum_zero and eulerian_balanced_implies_degree_balance from the main theorem.",
+            "mathContext": "Eulerian circuit $\\Rightarrow$ $\\sum_v \\text{outDeg}(v) = \\sum_v \\text{inDeg}(v)$ (as integers). Eulerian circuit $\\Rightarrow$ $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
+        },
+        {
+            "id": "hierholzer-infrastructure",
+            "title": "Hierholzer Infrastructure: Greedy Trail and Circuit Existence",
+            "startLine": 390,
+            "endLine": 848,
+            "summary": "Develops the mathematical infrastructure for Hierholzer's directed Eulerian algorithm in 6 steps. (1) Open-walk counting: for an open walk u→w (u≠w), target-count(w) = source-count(w)+1. (2) maxTrail: a greedy trail following outgoing edges, terminating since |E| decreases by 1 per step. (3) maxTrail_closed: in a balanced digraph, the greedy trail is always a closed circuit. (4) circuit_exists: every non-empty balanced digraph contains a directed circuit. (5) remove_circuit_balanced (sorry): removing a circuit preserves balance. (6) euler_path_implies_degree_balance (sorry): Eulerian path implies asymmetric degree conditions at start/end. Steps 1–4 are proved; steps 5–6 are sorry'd pending Finset sdiff API work.",
+            "mathContext": "Key theorem: $G$ balanced + $G.edges \\neq \\emptyset$ $\\Rightarrow$ $\\exists$ directed circuit in $G$. Proof: run greedy trail from any vertex $v$ with an outgoing edge; by balance, the trail closes (proof by contradiction using open-walk counting). Removing the circuit preserves balance (each vertex appears equally often as trail source and target)."
+        }
     ],
-    "badge": "axiom",
-    "sorries": 6,
-    "dateAdded": "2026-05-03",
-    "axiomCount": 2,
-    "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer's algorithm for directed graph Eulerian circuit — requires graph connectivity infrastructure) and directed_euler_path_iff (Eulerian path degree characterization). All other results (handshaking, necessity, concrete examples, consequences) are proved from first principles.",
-    "lineCount": 848,
-    "theoremCount": 12,
-    "definitionCount": 8,
-    "originalContributions": [
-      "sum_outDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.1=v}| = |E| by double-counting via Finset.sum_comm + Finset.sum_ite_eq'",
-      "sum_inDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.2=v}| = |E| by same double-counting argument",
-      "closed_walk_balance: private lemma — for a closed walk [v0,...,vn] with v0=vn, source-count at any vertex v equals target-count, via circular shift bijection i ↦ (i=0 ? n-1 : i-1)",
-      "walk_source_eq_outDegree / walk_target_eq_inDegree: private lemmas — the walk position bijection identifies source-counts and target-counts with outDegree and inDegree respectively",
-      "eulerian_circuit_implies_balanced: proved — necessity direction of Eulerian theorem, combining handshaking and walk bijection arguments",
-      "directedTriangle_balanced: the directed 3-cycle is Eulerian-balanced, verified by native_decide",
-      "directedPath_path_degrees: the directed path 0→1→2 satisfies Eulerian path degree conditions, verified by native_decide/case analysis",
-      "eulerian_balanced_sum_zero / eulerian_balanced_implies_degree_balance: structural consequences proved from main theorem"
-    ]
-  },
-  "overview": {
-    "historicalContext": "Euler's 1736 paper 'Solutio problematis ad geometriam situs pertinentis' on the Königsberg bridges introduced graph theory and proved the necessity direction of the Eulerian theorem for undirected graphs: an Eulerian circuit exists only if every vertex has even degree. The directed analogue emerged naturally: in a directed graph (digraph), an Eulerian circuit requires that each vertex has equal in-degree and out-degree — one outgoing edge consumed for each incoming edge at every visit. **Hierholzer's algorithm** (1873) proved sufficiency constructively: start any closed walk; if edges remain, splice in subcircuits at the first repeated vertex. The algorithm runs in O(|E|) and directly applies to directed graphs with the same degree balance condition.\n\nThe theory gained surprising new depth with **de Bruijn sequences** (Nicolaas de Bruijn, 1946). A de Bruijn sequence of order n over alphabet Σ is a cyclic sequence in which every length-n string over Σ appears exactly once. De Bruijn (and independently Good, 1946) observed that such sequences correspond to **Eulerian circuits in de Bruijn graphs**: vertices are length-(n-1) words, edges are length-n words, with the edge $(w_1\\ldots w_{n-1})\\to(w_2\\ldots w_n)$ representing the word $w_1\\ldots w_n$. The de Bruijn graph is regular (each vertex has in-degree = out-degree = |Σ|), so Eulerian circuits always exist, proving de Bruijn sequences always exist and giving an efficient construction via Hierholzer's algorithm.\n\nThe **BEST theorem** (van Aardenne-Ehrenfest and de Bruijn 1951; Smith and Tutte 1941–1948) counts Eulerian circuits in directed graphs: the number of distinct Eulerian circuits starting at vertex $w$ is $t_w(G) \\times \\prod_{v} (\\text{outDeg}(v)-1)!$, where $t_w(G)$ is the number of arborescences (spanning directed trees rooted at $w$). This remarkable formula connects Eulerian counting to the Matrix-Tree theorem.\n\nIn computational biology, **Eulerian path algorithms on de Bruijn graphs** became the basis for next-generation sequencing assembly. Pevzner, Tang, and Waterman (2001) introduced the EULER assembler: decompose a genome into overlapping k-mers, construct the de Bruijn graph, and find an Eulerian path. The genome is the sequence spelled by the Eulerian path — a dramatic application of 18th-century graph theory to 21st-century genomics.",
-    "problemStatement": "Extend the Eulerian circuit characterization (from undirected graphs) to directed graphs: characterize when a directed graph has an Eulerian circuit or path in terms of in-degrees and out-degrees.",
-    "text": "For a weakly connected directed graph G: (1) G has an Eulerian circuit iff every vertex v satisfies inDeg(v) = outDeg(v). (2) G has an Eulerian path from s to t (s≠t) iff outDeg(s)=inDeg(s)+1, inDeg(t)=outDeg(t)+1, and all other vertices v have inDeg(v)=outDeg(v).",
-    "proofStrategy": "Define DiGraph V as a Finset of directed edges with no self-loops. Define outDegree and inDegree by filtering edges. Prove the directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg) from first principles via double-counting: swap ∑_v and ∑_e using Finset.sum_comm, then apply Finset.sum_ite_eq'. Prove necessity (HasEulerianCircuit → IsEulerianBalanced) via a walk-position bijection argument: use the unique-coverage property to biject edges with walk positions, then show source-count = target-count using the closed walk property (walk[0] = walk[n] implies a circular shift bijection). Axiomatize the remaining directions (Hierholzer sufficiency, path characterization). Verify concrete examples (directed triangle, directed path) by native_decide.",
-    "keyInsights": [
-      "The directed handshaking lemma is proved by Finset.sum_comm: ∑_v |{e : e.1=v}| = ∑_e ∑_v [e.1=v] = ∑_e 1 = |E|. No Finset.card_biUnion needed.",
-      "Necessity requires a bijection between G.edges and walk positions. The key insight is to strengthen HasEulerianCircuit with ∃! (unique position per edge) and an hsteps condition (every walk step is an edge), enabling use of ExistsUnique.unique for injectivity.",
-      "The closed walk balance is proved by a bijection i ↦ (i=0 ? n-1 : i-1) from source positions {i < n : walk[i] = v} to target positions {i < n : walk[i+1] = v}, using the closed walk condition walk[0] = walk[n].",
-      "The directed triangle A→B→C→A is the canonical Eulerian circuit example: all three vertices have in-degree = out-degree = 1, verified by native_decide over Fin 3.",
-      "For the Eulerian path characterization, the source s has one more outgoing edge than incoming (to start the path), and the sink t has one more incoming edge than outgoing (to end the path). All intermediate vertices are balanced.",
-      "Weak connectivity (underlying undirected graph is connected) is the correct connectivity notion for directed Eulerian theory — strong connectivity is not required for the equivalence.",
-      "De Bruijn sequence connection: the de Bruijn graph B(n, Σ) is a digraph on length-(n-1) strings where each vertex has in-degree = out-degree = |Σ|. The directed Eulerian theorem guarantees Eulerian circuits exist in any such balanced weakly-connected digraph, proving de Bruijn sequences of every order exist over every alphabet — and Hierholzer's algorithm constructs them in O(|Σ|^n) time.",
-      "BEST theorem: the number of Eulerian circuits starting at vertex w in a directed Eulerian graph equals t_w(G) × ∏_v (outDeg(v)-1)!, where t_w(G) is the number of arborescences (spanning in-trees) rooted at w. This connects Eulerian circuit counting to the Matrix-Tree theorem (Kirchhoff 1847) — a deep result in algebraic graph theory.",
-      "Flow conservation interpretation: the directed handshaking equality ∑ outDeg = ∑ inDeg is equivalent to Kirchhoff's current law (KCL) in electrical networks and conservation of flow in network flow problems. An Eulerian graph (every vertex balanced) is one where a unit of 'flow' entering each vertex also leaves — the combinatorial version of a conservative vector field."
+    "conclusion": {
+        "summary": "Formalizes the directed Eulerian theorem. Key proved results: directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg, via double-counting), necessity direction (Eulerian circuit → balanced degrees, via walk position bijection and closed-walk degree balance). 8 theorems proved from first principles, 2 axioms (Hierholzer sufficiency and Eulerian path characterization), 6 sorries (Hierholzer infrastructure helpers deferred), 848 lines.",
+        "implications": "The directed Eulerian theorem underpins de Bruijn sequence construction (a de Bruijn graph is Eulerian), DNA fragment assembly algorithms, and Eulerian circuit algorithms in network flow. The degree-balance characterization is also the basis for Hierholzer's O(|E|) directed Eulerian circuit algorithm.",
+        "openQuestions": [
+            "Formalize Hierholzer's algorithm for constructing directed Eulerian circuits (eliminate directed_eulerian_iff axiom)",
+            "Prove directed_euler_path_iff: Eulerian path from s to t iff degree conditions hold at s, t and all others balanced",
+            "Count Eulerian circuits via the BEST theorem: t_w(G) · ∏_v (outDeg(v)-1)! where t_w(G) is the number of arborescences rooted at w"
+        ]
+    },
+    "leanFile": {
+        "namespace": "KonigsbergOQ01OQ02",
+        "lineCount": 848,
+        "axiomCount": 2,
+        "theoremCount": 25,
+        "definitionCount": 10,
+        "path": "Proofs/KonigsbergOQ01OQ02.lean",
+        "sorries": 6
+    },
+    "crossReferences": [
+        {
+            "targetId": "konigsberg-oq-01",
+            "relationship": "parent",
+            "description": "Eulerian Circuits in Concrete Graph Families — the undirected Eulerian theory that this file extends to the directed setting."
+        },
+        {
+            "targetId": "konigsberg-oq-02",
+            "relationship": "sibling",
+            "description": "Directed Euler Paths: In-Degree/Out-Degree Characterization — related directed graph Eulerian theory."
+        },
+        {
+            "targetId": "konigsberg",
+            "relationship": "ancestor",
+            "description": "Original Königsberg bridges problem — Euler 1736; the undirected Eulerian theorem whose directed analogue is formalized here."
+        }
     ],
-    "prerequisites": [
-      "Eulerian circuits and paths in undirected graphs (konigsberg-oq-01)",
-      "Directed graph degree sequences: in-degree, out-degree",
-      "Handshaking lemma for directed graphs: ∑ outDeg = |E| = ∑ inDeg"
-    ]
-  },
-  "sections": [
-    {
-      "id": "definitions",
-      "title": "Directed Graph Basics",
-      "startLine": 50,
-      "endLine": 70,
-      "summary": "Defines DiGraph V (edges: Finset (V×V), noSelfLoops), outDegree, inDegree, IsBalanced, IsEulerianBalanced.",
-      "mathContext": "$\\text{outDeg}(v) = |\\{e \\in E : e.1 = v\\}|$. $\\text{inDeg}(v) = |\\{e \\in E : e.2 = v\\}|$. $\\text{IsBalanced}(v)$: $\\text{inDeg}(v) = \\text{outDeg}(v)$."
-    },
-    {
-      "id": "handshaking",
-      "title": "Directed Handshaking Lemma (Proved)",
-      "startLine": 77,
-      "endLine": 105,
-      "summary": "Proves sum_outDegree_eq_edgeCount and sum_inDegree_eq_edgeCount from first principles via double-counting (swap ∑_v ∑_e with ∑_e ∑_v). Derives sum_outDegree_eq_sum_inDegree by transitivity.",
-      "mathContext": "$\\sum_{v} \\text{outDeg}(v) = |E| = \\sum_{v} \\text{inDeg}(v)$. Proof: $\\sum_v |\\{e: e.1=v\\}| = \\sum_v \\sum_{e \\in E} [e.1=v] = \\sum_{e \\in E} 1 = |E|$."
-    },
-    {
-      "id": "necessity",
-      "title": "Necessity: Eulerian Circuit Implies Balanced (Proved)",
-      "startLine": 112,
-      "endLine": 311,
-      "summary": "Defines HasEulerianCircuit with unique coverage (∃!) and step constraint. Three helper lemmas establish the bijection between walk positions and edges. Main theorem eulerian_circuit_implies_balanced proved: outDeg = source-count = target-count = inDeg, where middle equality uses the closed walk.",
-      "mathContext": "If $G$ has an Eulerian circuit with walk $[v_0,...,v_n]$ ($v_0 = v_n$), then $|\\{i < n : v_i = w\\}| = |\\{i < n : v_{i+1} = w\\}|$ for all $w$ (bijection: $i \\mapsto i-1 \\pmod{n}$). Combined with the edge-position bijection: $\\text{outDeg}(w) = \\text{inDeg}(w)$."
-    },
-    {
-      "id": "characterization",
-      "title": "Directed Eulerian Theorem and Path Characterization",
-      "startLine": 314,
-      "endLine": 341,
-      "summary": "Defines IsWeaklyConnected and HasEulerianPath. Axiomatizes directed_eulerian_iff (Hierholzer) and directed_euler_path_iff.",
-      "mathContext": "$G$ has an Eulerian circuit $\\iff$ $\\text{IsEulerianBalanced}(G)$ (weak connectivity required). $G$ has Eulerian path $s \\to t$ $\\iff$ $\\text{outDeg}(s) = \\text{inDeg}(s)+1$, $\\text{inDeg}(t) = \\text{outDeg}(t)+1$, and all others balanced."
-    },
-    {
-      "id": "examples",
-      "title": "Concrete Examples",
-      "startLine": 348,
-      "endLine": 371,
-      "summary": "Defines directedTriangle (Fin 3, edges {(0,1),(1,2),(2,0)}) and directedPath (Fin 3, edges {(0,1),(1,2)}). Proves balance properties by native_decide.",
-      "mathContext": "Directed 3-cycle: all vertices balanced ($\\text{in} = \\text{out} = 1$). Directed path $0 \\to 1 \\to 2$: $\\text{outDeg}(0) = 1 = \\text{inDeg}(0)+1$, $\\text{inDeg}(2) = 1 = \\text{outDeg}(2)+1$, vertex 1 balanced."
-    },
-    {
-      "id": "consequences",
-      "title": "Consequences",
-      "startLine": 373,
-      "endLine": 389,
-      "summary": "Proves eulerian_balanced_sum_zero and eulerian_balanced_implies_degree_balance from the main theorem.",
-      "mathContext": "Eulerian circuit $\\Rightarrow$ $\\sum_v \\text{outDeg}(v) = \\sum_v \\text{inDeg}(v)$ (as integers). Eulerian circuit $\\Rightarrow$ $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
-    },
-    {
-      "id": "hierholzer-infrastructure",
-      "title": "Hierholzer Infrastructure: Greedy Trail and Circuit Existence",
-      "startLine": 390,
-      "endLine": 848,
-      "summary": "Develops the mathematical infrastructure for Hierholzer's directed Eulerian algorithm in 6 steps. (1) Open-walk counting: for an open walk u→w (u≠w), target-count(w) = source-count(w)+1. (2) maxTrail: a greedy trail following outgoing edges, terminating since |E| decreases by 1 per step. (3) maxTrail_closed: in a balanced digraph, the greedy trail is always a closed circuit. (4) circuit_exists: every non-empty balanced digraph contains a directed circuit. (5) remove_circuit_balanced (sorry): removing a circuit preserves balance. (6) euler_path_implies_degree_balance (sorry): Eulerian path implies asymmetric degree conditions at start/end. Steps 1–4 are proved; steps 5–6 are sorry'd pending Finset sdiff API work.",
-      "mathContext": "Key theorem: $G$ balanced + $G.edges \\neq \\emptyset$ $\\Rightarrow$ $\\exists$ directed circuit in $G$. Proof: run greedy trail from any vertex $v$ with an outgoing edge; by balance, the trail closes (proof by contradiction using open-walk counting). Removing the circuit preserves balance (each vertex appears equally often as trail source and target)."
-    }
-  ],
-  "conclusion": {
-    "summary": "Formalizes the directed Eulerian theorem. Key proved results: directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg, via double-counting), necessity direction (Eulerian circuit → balanced degrees, via walk position bijection and closed-walk degree balance). 8 theorems proved from first principles, 2 axioms (Hierholzer sufficiency and Eulerian path characterization), 6 sorries (Hierholzer infrastructure helpers deferred), 848 lines.",
-    "implications": "The directed Eulerian theorem underpins de Bruijn sequence construction (a de Bruijn graph is Eulerian), DNA fragment assembly algorithms, and Eulerian circuit algorithms in network flow. The degree-balance characterization is also the basis for Hierholzer's O(|E|) directed Eulerian circuit algorithm.",
-    "openQuestions": [
-      "Formalize Hierholzer's algorithm for constructing directed Eulerian circuits (eliminate directed_eulerian_iff axiom)",
-      "Prove directed_euler_path_iff: Eulerian path from s to t iff degree conditions hold at s, t and all others balanced",
-      "Count Eulerian circuits via the BEST theorem: t_w(G) · ∏_v (outDeg(v)-1)! where t_w(G) is the number of arborescences rooted at w"
-    ]
-  },
-  "leanFile": {
-    "namespace": "KonigsbergOQ01OQ02",
-    "lineCount": 848,
-    "axiomCount": 2,
-    "theoremCount": 12,
-    "definitionCount": 10,
-    "path": "Proofs/KonigsbergOQ01OQ02.lean",
     "sorries": 6
-  },
-  "crossReferences": [
-    {
-      "targetId": "konigsberg-oq-01",
-      "relationship": "parent",
-      "description": "Eulerian Circuits in Concrete Graph Families — the undirected Eulerian theory that this file extends to the directed setting."
-    },
-    {
-      "targetId": "konigsberg-oq-02",
-      "relationship": "sibling",
-      "description": "Directed Euler Paths: In-Degree/Out-Degree Characterization — related directed graph Eulerian theory."
-    },
-    {
-      "targetId": "konigsberg",
-      "relationship": "ancestor",
-      "description": "Original Königsberg bridges problem — Euler 1736; the undirected Eulerian theorem whose directed analogue is formalized here."
-    }
-  ],
-  "sorries": 6
 }

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
@@ -1,176 +1,176 @@
 {
-  "id": "lebesgue-measure-oq-01-oq-01-oq-02",
-  "title": "Thomae's Function: Continuous at Irrationals, Discontinuous at Rationals",
-  "slug": "lebesgue-measure-oq-01-oq-01-oq-02",
-  "description": "Proves the complete continuity characterization of Thomae's function (popcorn function): it is continuous at every irrational and discontinuous at every rational. The discontinuity proof uses a sequential argument via irrational sequences converging to each rational. The continuity proof uses an epsilon-delta argument relying on the finiteness of low-denominator rationals in any bounded interval.",
-  "meta": {
-    "author": "Formalized in Lean 4 (Mathlib)",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Thomae%27s_function",
-    "date": "2026",
-    "status": "verified",
-    "proofRepoPath": "Proofs/LebesgueMeasureOQ01OQ01OQ02.lean",
-    "tags": [
-      "thomae-function",
-      "popcorn-function",
-      "continuity",
-      "real-analysis",
-      "irrationals",
-      "epsilon-delta",
-      "sequential-continuity",
-      "rational-approximation",
-      "research"
-    ],
-    "badge": "original",
-    "sorries": 0,
-    "dateAdded": "2026-05-03",
-    "mathlib_version": "4.26.0",
-    "axiomCount": 0,
-    "lineCount": 240,
-    "assumptions": "0 axioms, 0 sorries. Fully verified.",
-    "theoremCount": 6,
-    "originalContributions": [
-      "thomae_continuous_at_irrational: ContinuousAt thomae x for every irrational x",
-      "thomae_discontinuous_at_rat: ¬ContinuousAt thomae (q : ℝ) for every rational q",
-      "thomae_continuous_iff: ContinuousAt thomae x ↔ Irrational x",
-      "finite_rat_bounded: finiteness of rationals with bounded denominator in a bounded interval",
-      "pos_min_dist: positive minimum distance from an irrational to any finite set of rationals"
-    ],
-    "historicalContext": "Thomae's function (also called the popcorn function or ruler function) was introduced by Carl Johannes Thomae in 1875. It is defined as f(p/q) = 1/q for rationals in reduced form, and f(x) = 0 for irrationals. It became a landmark example in real analysis, being the first known function that is Riemann integrable yet discontinuous on a dense set — namely all rationals. The continuity characterization (continuous at irrationals, discontinuous at rationals) was a key historical insight. It showed that the set of discontinuities can be dense yet have measure zero, which is exactly the Lebesgue criterion for Riemann integrability. The parent proof (lebesgue-measure-oq-01-oq-01) showed the Lebesgue integral is 0; this proof characterizes the exact set of continuity points."
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Real",
-      "Set",
-      "Filter"
-    ],
-    "namespace": "LebesgueMeasureOQ01OQ01OQ02",
-    "lineCount": 240,
-    "axiomCount": 0,
-    "theoremCount": 6,
-    "definitionCount": 1,
-    "path": "Proofs/LebesgueMeasureOQ01OQ01OQ02.lean",
-    "mainTheorems": [
-      {
-        "name": "thomae_continuous_at_irrational",
-        "statement": "∀ {x : ℝ}, Irrational x → ContinuousAt thomae x",
-        "description": "Thomae's function is continuous at every irrational via epsilon-delta using finiteness of low-denominator rationals"
-      },
-      {
-        "name": "thomae_discontinuous_at_rat",
-        "statement": "∀ (r : ℚ), ¬ContinuousAt thomae (r : ℝ)",
-        "description": "Thomae's function is discontinuous at every rational via sequential argument"
-      },
-      {
-        "name": "thomae_continuous_iff",
-        "statement": "∀ (x : ℝ), ContinuousAt thomae x ↔ Irrational x",
-        "description": "The complete characterization: Thomae's function is continuous exactly at the irrationals"
-      }
-    ],
-    "sorries": 0
-  },
-  "overview": {
-    "historicalContext": "**A Function Continuous Exactly at the Irrationals**\n\nThomaes's function $f : \\mathbb{R} \\to \\mathbb{R}$, introduced in 1875, is defined by:\n$$f(x) = \\begin{cases} \\frac{1}{q} & x = \\frac{p}{q} \\text{ in lowest terms, } q > 0, \\\\ 0 & x \\in \\mathbb{R} \\setminus \\mathbb{Q}. \\end{cases}$$\nThe function is historically significant as the first example of a Riemann-integrable function that is discontinuous on a dense set (the rationals). The key property is that $f$ is continuous at every irrational and discontinuous at every rational — making its continuity set a dense $G_\\delta$ set (the irrationals) and its discontinuity set a dense $F_\\sigma$ set (the rationals).",
-    "problemStatement": "**The Open Question**\n\nCan we prove that Thomae's function is continuous at every irrational and discontinuous at every rational in Lean?\n\n**Answer: YES**\n\nThe full characterization holds:\n$$\\text{ContinuousAt}\\, f\\, x \\iff x \\in \\mathbb{R} \\setminus \\mathbb{Q}$$",
-    "proofStrategy": "**Two-Part Argument**\n\n**Discontinuity at rationals** (sequential): Given rational $r = p/q$, construct the sequence $y_n = r + \\frac{\\sqrt{2}}{n+1} \\to r$. Each $y_n$ is irrational (since $\\sqrt{2}$ is irrational), so $f(y_n) = 0 \\to 0 \\neq \\frac{1}{q} = f(r)$. By the sequential characterization of continuity, $f$ is discontinuous at $r$.\n\n**Continuity at irrationals** (epsilon-delta): Given irrational $x$ and $\\varepsilon > 0$:\n1. Choose $N$ large enough that $\\frac{1}{N+1} < \\varepsilon$.\n2. The set $S = \\{q \\in \\mathbb{Q} : |q - x| \\leq 1,\\, q.\\mathrm{den} \\leq N\\}$ is **finite** (each denominator $d \\leq N$ contributes a bounded integer range for the numerator).\n3. Since $x$ is irrational, it differs from each element of $S$; take $\\delta = \\min_{q \\in S} |x - q| > 0$.\n4. For $|y - x| < \\delta$: if $y$ is irrational, $f(y) = 0 < \\varepsilon$; if $y = p'/q'$ rational, then $q' > N$ (else $y \\in S$, contradicting $|y-x| < \\delta$), so $f(y) = 1/q' \\leq 1/(N+1) < \\varepsilon$.",
-    "keyInsights": [
-      "**Finite low-denominator rationals**: The key lemma `finite_rat_bounded` shows that for any $x$ and $N$, there are only finitely many rationals $p/q$ with $|p/q - x| \\leq 1$ and $q \\leq N$. This follows because for fixed denominator $d$, the numerators are bounded by a finite integer range.",
-      "**Sequential discontinuity via irrationals**: The sequence $r + \\sqrt{2}/(n+1)$ is irrational because $\\sqrt{2}$ is irrational and rationals are closed under arithmetic. Lean's `irrational_sqrt_two` and field arithmetic close this directly.",
-      "**Positive minimum distance from finite set**: The lemma `pos_min_dist` shows an irrational point has positive distance to every finite set of rationals, enabling the crucial $\\delta$ choice in the continuity proof.",
-      "**Classical choice extracts denominator**: The definition `thomae` uses `h.choose.den` — classical choice on the existential `∃ q : ℚ, (q : ℝ) = x`. Lean's `Rat.cast_inj` then shows uniqueness, giving the correct denominator.",
-      "**`by_cases hirr : Irrational y`**: The continuity proof case-splits on whether the nearby point $y$ is irrational or rational, handling each case cleanly."
-    ],
-    "prerequisites": [
-      "Real analysis: epsilon-delta definition of continuity",
-      "Sequential characterization of continuity",
-      "Irrationality of √2",
-      "Rational numbers and reduced fractions"
-    ]
-  },
-  "sections": [
-    {
-      "id": "thomae-def",
-      "title": "Part I: The Thomae Function",
-      "startLine": 38,
-      "endLine": 68,
-      "summary": "Defines `thomae : ℝ → ℝ` via classical choice: returns 1/q.den if x is rational q, else 0. Proves basic properties: zero at irrationals, value 1/q.den at rationals, nonnegativity.",
-      "mathContext": "$$f(x) = \\begin{cases} 1/q & x = p/q \\text{ reduced}, \\\\ 0 & x \\notin \\mathbb{Q}. \\end{cases}$$\nKey: `Rat.cast_inj.mp` ensures `h.choose = q` for uniqueness of the rational representative."
+    "id": "lebesgue-measure-oq-01-oq-01-oq-02",
+    "title": "Thomae's Function: Continuous at Irrationals, Discontinuous at Rationals",
+    "slug": "lebesgue-measure-oq-01-oq-01-oq-02",
+    "description": "Proves the complete continuity characterization of Thomae's function (popcorn function): it is continuous at every irrational and discontinuous at every rational. The discontinuity proof uses a sequential argument via irrational sequences converging to each rational. The continuity proof uses an epsilon-delta argument relying on the finiteness of low-denominator rationals in any bounded interval.",
+    "meta": {
+        "author": "Formalized in Lean 4 (Mathlib)",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Thomae%27s_function",
+        "date": "2026",
+        "status": "verified",
+        "proofRepoPath": "Proofs/LebesgueMeasureOQ01OQ01OQ02.lean",
+        "tags": [
+            "thomae-function",
+            "popcorn-function",
+            "continuity",
+            "real-analysis",
+            "irrationals",
+            "epsilon-delta",
+            "sequential-continuity",
+            "rational-approximation",
+            "research"
+        ],
+        "badge": "original",
+        "sorries": 0,
+        "dateAdded": "2026-05-03",
+        "mathlib_version": "4.26.0",
+        "axiomCount": 0,
+        "lineCount": 240,
+        "assumptions": "0 axioms, 0 sorries. Fully verified.",
+        "theoremCount": 6,
+        "originalContributions": [
+            "thomae_continuous_at_irrational: ContinuousAt thomae x for every irrational x",
+            "thomae_discontinuous_at_rat: ¬ContinuousAt thomae (q : ℝ) for every rational q",
+            "thomae_continuous_iff: ContinuousAt thomae x ↔ Irrational x",
+            "finite_rat_bounded: finiteness of rationals with bounded denominator in a bounded interval",
+            "pos_min_dist: positive minimum distance from an irrational to any finite set of rationals"
+        ],
+        "historicalContext": "Thomae's function (also called the popcorn function or ruler function) was introduced by Carl Johannes Thomae in 1875. It is defined as f(p/q) = 1/q for rationals in reduced form, and f(x) = 0 for irrationals. It became a landmark example in real analysis, being the first known function that is Riemann integrable yet discontinuous on a dense set — namely all rationals. The continuity characterization (continuous at irrationals, discontinuous at rationals) was a key historical insight. It showed that the set of discontinuities can be dense yet have measure zero, which is exactly the Lebesgue criterion for Riemann integrability. The parent proof (lebesgue-measure-oq-01-oq-01) showed the Lebesgue integral is 0; this proof characterizes the exact set of continuity points."
     },
-    {
-      "id": "discontinuity",
-      "title": "Part II: Discontinuity at Rationals",
-      "startLine": 69,
-      "endLine": 113,
-      "summary": "Proves ¬ContinuousAt thomae (q : ℝ) for all q : ℚ via sequential argument: the sequence q + √2/(n+1) → q consists of irrationals with thomae = 0, but thomae(q) = 1/q.den > 0.",
-      "mathContext": "**Sequential argument**: The sequence $y_n = q + \\frac{\\sqrt{2}}{n+1}$ satisfies $y_n \\to q$ and $f(y_n) = 0$ for all $n$, while $f(q) = 1/q.\\mathrm{den} > 0$. So $f(y_n) \\not\\to f(q)$."
+    "leanFile": {
+        "imports": [
+            "Mathlib"
+        ],
+        "opens": [
+            "Real",
+            "Set",
+            "Filter"
+        ],
+        "namespace": "LebesgueMeasureOQ01OQ01OQ02",
+        "lineCount": 240,
+        "axiomCount": 0,
+        "theoremCount": 11,
+        "definitionCount": 1,
+        "path": "Proofs/LebesgueMeasureOQ01OQ01OQ02.lean",
+        "mainTheorems": [
+            {
+                "name": "thomae_continuous_at_irrational",
+                "statement": "∀ {x : ℝ}, Irrational x → ContinuousAt thomae x",
+                "description": "Thomae's function is continuous at every irrational via epsilon-delta using finiteness of low-denominator rationals"
+            },
+            {
+                "name": "thomae_discontinuous_at_rat",
+                "statement": "∀ (r : ℚ), ¬ContinuousAt thomae (r : ℝ)",
+                "description": "Thomae's function is discontinuous at every rational via sequential argument"
+            },
+            {
+                "name": "thomae_continuous_iff",
+                "statement": "∀ (x : ℝ), ContinuousAt thomae x ↔ Irrational x",
+                "description": "The complete characterization: Thomae's function is continuous exactly at the irrationals"
+            }
+        ],
+        "sorries": 0
     },
-    {
-      "id": "finite-rationals",
-      "title": "Part III: Finiteness of Low-Denominator Rationals",
-      "startLine": 114,
-      "endLine": 163,
-      "summary": "Key infrastructure: `finite_rat_bounded` shows {q : ℚ | |q - x| ≤ 1 ∧ q.den ≤ N} is finite for any x and N. `pos_min_dist` gives positive minimum distance from an irrational to any finite set of rationals.",
-      "mathContext": "For fixed $d \\leq N$: numerators $p$ with $|p/d - x| \\leq 1$ lie in $[\\lfloor(x-1)d\\rfloor, \\lceil(x+1)d\\rceil]$ — a finite integer interval. Union over $d = 1, \\ldots, N$ is finite. Key Lean tool: `Finset.biUnion` over denominator range."
+    "overview": {
+        "historicalContext": "**A Function Continuous Exactly at the Irrationals**\n\nThomaes's function $f : \\mathbb{R} \\to \\mathbb{R}$, introduced in 1875, is defined by:\n$$f(x) = \\begin{cases} \\frac{1}{q} & x = \\frac{p}{q} \\text{ in lowest terms, } q > 0, \\\\ 0 & x \\in \\mathbb{R} \\setminus \\mathbb{Q}. \\end{cases}$$\nThe function is historically significant as the first example of a Riemann-integrable function that is discontinuous on a dense set (the rationals). The key property is that $f$ is continuous at every irrational and discontinuous at every rational — making its continuity set a dense $G_\\delta$ set (the irrationals) and its discontinuity set a dense $F_\\sigma$ set (the rationals).",
+        "problemStatement": "**The Open Question**\n\nCan we prove that Thomae's function is continuous at every irrational and discontinuous at every rational in Lean?\n\n**Answer: YES**\n\nThe full characterization holds:\n$$\\text{ContinuousAt}\\, f\\, x \\iff x \\in \\mathbb{R} \\setminus \\mathbb{Q}$$",
+        "proofStrategy": "**Two-Part Argument**\n\n**Discontinuity at rationals** (sequential): Given rational $r = p/q$, construct the sequence $y_n = r + \\frac{\\sqrt{2}}{n+1} \\to r$. Each $y_n$ is irrational (since $\\sqrt{2}$ is irrational), so $f(y_n) = 0 \\to 0 \\neq \\frac{1}{q} = f(r)$. By the sequential characterization of continuity, $f$ is discontinuous at $r$.\n\n**Continuity at irrationals** (epsilon-delta): Given irrational $x$ and $\\varepsilon > 0$:\n1. Choose $N$ large enough that $\\frac{1}{N+1} < \\varepsilon$.\n2. The set $S = \\{q \\in \\mathbb{Q} : |q - x| \\leq 1,\\, q.\\mathrm{den} \\leq N\\}$ is **finite** (each denominator $d \\leq N$ contributes a bounded integer range for the numerator).\n3. Since $x$ is irrational, it differs from each element of $S$; take $\\delta = \\min_{q \\in S} |x - q| > 0$.\n4. For $|y - x| < \\delta$: if $y$ is irrational, $f(y) = 0 < \\varepsilon$; if $y = p'/q'$ rational, then $q' > N$ (else $y \\in S$, contradicting $|y-x| < \\delta$), so $f(y) = 1/q' \\leq 1/(N+1) < \\varepsilon$.",
+        "keyInsights": [
+            "**Finite low-denominator rationals**: The key lemma `finite_rat_bounded` shows that for any $x$ and $N$, there are only finitely many rationals $p/q$ with $|p/q - x| \\leq 1$ and $q \\leq N$. This follows because for fixed denominator $d$, the numerators are bounded by a finite integer range.",
+            "**Sequential discontinuity via irrationals**: The sequence $r + \\sqrt{2}/(n+1)$ is irrational because $\\sqrt{2}$ is irrational and rationals are closed under arithmetic. Lean's `irrational_sqrt_two` and field arithmetic close this directly.",
+            "**Positive minimum distance from finite set**: The lemma `pos_min_dist` shows an irrational point has positive distance to every finite set of rationals, enabling the crucial $\\delta$ choice in the continuity proof.",
+            "**Classical choice extracts denominator**: The definition `thomae` uses `h.choose.den` — classical choice on the existential `∃ q : ℚ, (q : ℝ) = x`. Lean's `Rat.cast_inj` then shows uniqueness, giving the correct denominator.",
+            "**`by_cases hirr : Irrational y`**: The continuity proof case-splits on whether the nearby point $y$ is irrational or rational, handling each case cleanly."
+        ],
+        "prerequisites": [
+            "Real analysis: epsilon-delta definition of continuity",
+            "Sequential characterization of continuity",
+            "Irrationality of √2",
+            "Rational numbers and reduced fractions"
+        ]
     },
-    {
-      "id": "continuity",
-      "title": "Part IV: Continuity at Irrationals",
-      "startLine": 164,
-      "endLine": 222,
-      "summary": "Main result: ContinuousAt thomae x for every irrational x. Choose N with 1/(N+1) < ε; let δ = min distance from x to the finite set of nearby rationals with denominator ≤ N. For |y - x| < δ: f(y) = 0 (irrational) or f(y) = 1/q.den ≤ 1/(N+1) < ε (rational with large denominator).",
-      "mathContext": "The epsilon-delta proof has two cases after choosing $\\delta$:\n1. $y$ irrational: $f(y) = 0 < \\varepsilon$ ✓\n2. $y = p/q$ rational with $|y - x| < \\delta$: then $q.\\mathrm{den} > N$ (else $y$ is in the finite set), giving $f(y) = 1/q.\\mathrm{den} < 1/(N+1) < \\varepsilon$ ✓"
-    },
-    {
-      "id": "iff",
-      "title": "Part V: Characterization",
-      "startLine": 224,
-      "endLine": 239,
-      "summary": "The biconditional thomae_continuous_iff: ContinuousAt thomae x ↔ Irrational x. Combines discontinuity (→ direction by contraposition) and continuity (← direction) into the complete characterization.",
-      "mathContext": "$$\\text{ContinuousAt}\\, f\\, x \\iff x \\notin \\mathbb{Q}$$\nThe irrationals form a dense $G_\\delta$ set in $\\mathbb{R}$; Thomae's function witnesses that a function can be continuous on a dense set yet nowhere coincide with a continuous function."
-    }
-  ],
-  "openQuestions": [
-    {
-      "id": "thomae-riemann",
-      "question": "Is Thomae's function Riemann integrable on [0,1], and can this be formally derived from the continuity characterization?",
-      "context": "The Lebesgue criterion for Riemann integrability states that a bounded function is Riemann integrable if and only if its set of discontinuities has Lebesgue measure zero. The continuity characterization just proved shows Thomae's function is discontinuous exactly at the rationals, which have measure zero. Hence Thomae's function is Riemann integrable on [0,1] with integral 0. Mathlib has the Lebesgue criterion (intervalIntegral.integrableOn_iff_ae) — can this chain be formalized?",
-      "difficulty": "medium",
-      "tags": [
-        "riemann-integration",
-        "lebesgue-criterion",
-        "measure-zero"
-      ]
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "lebesgue-measure-oq-01-oq-01",
-      "relationship": "parent",
-      "description": "The parent proof showing the Lebesgue integral of Thomae's function is 0; this file proves the continuity characterization that explains why (discontinuities form a null set)."
-    },
-    {
-      "targetId": "erdos-1054-oq-01-fnorm",
-      "relationship": "thematic",
-      "description": "Both define functions by number-theoretic properties of rationals (denominator structure) and study their analytic behavior; Thomae's function and the partial-divisor-sum function share the theme of arithmetic-defined real functions."
-    },
-    {
-      "targetId": "derangements-convergence-oq-01-oq-01",
-      "relationship": "thematic",
-      "description": "Both use the real-analytic epsilon-delta framework in Lean 4 and both concern the interface between combinatorial/number-theoretic definitions and real analysis — Thomae's discontinuity set vs derangements' rounding theorem."
-    }
-  ],
-  "conclusion": {
-    "summary": "The complete continuity characterization of Thomae's function is formally verified in Lean 4. The proof demonstrates that a formally verified epsilon-delta argument can cleanly handle the key challenge — using finiteness of low-denominator rationals to control the function value near irrationals. The biconditional `thomae_continuous_iff` is the main result: ContinuousAt thomae x ↔ Irrational x.",
-    "significance": "This formalization adds a landmark real analysis example to the gallery. Thomae's function is historically significant as the prototype for understanding Riemann integrability beyond continuous functions, and its continuity characterization is a standard theorem in any real analysis course.",
-    "limitations": "The proof uses classical logic (noncomputable definition via `h.choose`). A constructive formalization would require a constructive characterization of the rational/irrational dichotomy.",
-    "implications": "The epsilon-delta approach — bounding the function by a threshold ε/2 and exploiting finiteness of the rational obstruction set — is a reusable pattern for other functions with countable discontinuity sets. The proof that Thomae's function is Riemann integrable (all discontinuities form a null set) follows directly from this continuity characterization. This formalization validates that Mathlib's `Irrational` API is expressive enough for density arguments in real analysis.",
+    "sections": [
+        {
+            "id": "thomae-def",
+            "title": "Part I: The Thomae Function",
+            "startLine": 38,
+            "endLine": 68,
+            "summary": "Defines `thomae : ℝ → ℝ` via classical choice: returns 1/q.den if x is rational q, else 0. Proves basic properties: zero at irrationals, value 1/q.den at rationals, nonnegativity.",
+            "mathContext": "$$f(x) = \\begin{cases} 1/q & x = p/q \\text{ reduced}, \\\\ 0 & x \\notin \\mathbb{Q}. \\end{cases}$$\nKey: `Rat.cast_inj.mp` ensures `h.choose = q` for uniqueness of the rational representative."
+        },
+        {
+            "id": "discontinuity",
+            "title": "Part II: Discontinuity at Rationals",
+            "startLine": 69,
+            "endLine": 113,
+            "summary": "Proves ¬ContinuousAt thomae (q : ℝ) for all q : ℚ via sequential argument: the sequence q + √2/(n+1) → q consists of irrationals with thomae = 0, but thomae(q) = 1/q.den > 0.",
+            "mathContext": "**Sequential argument**: The sequence $y_n = q + \\frac{\\sqrt{2}}{n+1}$ satisfies $y_n \\to q$ and $f(y_n) = 0$ for all $n$, while $f(q) = 1/q.\\mathrm{den} > 0$. So $f(y_n) \\not\\to f(q)$."
+        },
+        {
+            "id": "finite-rationals",
+            "title": "Part III: Finiteness of Low-Denominator Rationals",
+            "startLine": 114,
+            "endLine": 163,
+            "summary": "Key infrastructure: `finite_rat_bounded` shows {q : ℚ | |q - x| ≤ 1 ∧ q.den ≤ N} is finite for any x and N. `pos_min_dist` gives positive minimum distance from an irrational to any finite set of rationals.",
+            "mathContext": "For fixed $d \\leq N$: numerators $p$ with $|p/d - x| \\leq 1$ lie in $[\\lfloor(x-1)d\\rfloor, \\lceil(x+1)d\\rceil]$ — a finite integer interval. Union over $d = 1, \\ldots, N$ is finite. Key Lean tool: `Finset.biUnion` over denominator range."
+        },
+        {
+            "id": "continuity",
+            "title": "Part IV: Continuity at Irrationals",
+            "startLine": 164,
+            "endLine": 222,
+            "summary": "Main result: ContinuousAt thomae x for every irrational x. Choose N with 1/(N+1) < ε; let δ = min distance from x to the finite set of nearby rationals with denominator ≤ N. For |y - x| < δ: f(y) = 0 (irrational) or f(y) = 1/q.den ≤ 1/(N+1) < ε (rational with large denominator).",
+            "mathContext": "The epsilon-delta proof has two cases after choosing $\\delta$:\n1. $y$ irrational: $f(y) = 0 < \\varepsilon$ ✓\n2. $y = p/q$ rational with $|y - x| < \\delta$: then $q.\\mathrm{den} > N$ (else $y$ is in the finite set), giving $f(y) = 1/q.\\mathrm{den} < 1/(N+1) < \\varepsilon$ ✓"
+        },
+        {
+            "id": "iff",
+            "title": "Part V: Characterization",
+            "startLine": 224,
+            "endLine": 239,
+            "summary": "The biconditional thomae_continuous_iff: ContinuousAt thomae x ↔ Irrational x. Combines discontinuity (→ direction by contraposition) and continuity (← direction) into the complete characterization.",
+            "mathContext": "$$\\text{ContinuousAt}\\, f\\, x \\iff x \\notin \\mathbb{Q}$$\nThe irrationals form a dense $G_\\delta$ set in $\\mathbb{R}$; Thomae's function witnesses that a function can be continuous on a dense set yet nowhere coincide with a continuous function."
+        }
+    ],
     "openQuestions": [
-      "Can Thomae's function be shown to be Riemann integrable in Lean 4, using the continuity-almost-everywhere result proved here together with the Lebesgue criterion?",
-      "Can a constructive proof be given for `thomae_irrational_continuous` that avoids classical choice (`h.choose`), using a computable approximation to the irrational?",
-      "Can the pattern (finite obstruction set → epsilon-delta continuity) be abstracted to a general Mathlib lemma about functions with countable jump discontinuities?"
-    ]
-  },
-  "sorries": 0
+        {
+            "id": "thomae-riemann",
+            "question": "Is Thomae's function Riemann integrable on [0,1], and can this be formally derived from the continuity characterization?",
+            "context": "The Lebesgue criterion for Riemann integrability states that a bounded function is Riemann integrable if and only if its set of discontinuities has Lebesgue measure zero. The continuity characterization just proved shows Thomae's function is discontinuous exactly at the rationals, which have measure zero. Hence Thomae's function is Riemann integrable on [0,1] with integral 0. Mathlib has the Lebesgue criterion (intervalIntegral.integrableOn_iff_ae) — can this chain be formalized?",
+            "difficulty": "medium",
+            "tags": [
+                "riemann-integration",
+                "lebesgue-criterion",
+                "measure-zero"
+            ]
+        }
+    ],
+    "crossReferences": [
+        {
+            "targetId": "lebesgue-measure-oq-01-oq-01",
+            "relationship": "parent",
+            "description": "The parent proof showing the Lebesgue integral of Thomae's function is 0; this file proves the continuity characterization that explains why (discontinuities form a null set)."
+        },
+        {
+            "targetId": "erdos-1054-oq-01-fnorm",
+            "relationship": "thematic",
+            "description": "Both define functions by number-theoretic properties of rationals (denominator structure) and study their analytic behavior; Thomae's function and the partial-divisor-sum function share the theme of arithmetic-defined real functions."
+        },
+        {
+            "targetId": "derangements-convergence-oq-01-oq-01",
+            "relationship": "thematic",
+            "description": "Both use the real-analytic epsilon-delta framework in Lean 4 and both concern the interface between combinatorial/number-theoretic definitions and real analysis — Thomae's discontinuity set vs derangements' rounding theorem."
+        }
+    ],
+    "conclusion": {
+        "summary": "The complete continuity characterization of Thomae's function is formally verified in Lean 4. The proof demonstrates that a formally verified epsilon-delta argument can cleanly handle the key challenge — using finiteness of low-denominator rationals to control the function value near irrationals. The biconditional `thomae_continuous_iff` is the main result: ContinuousAt thomae x ↔ Irrational x.",
+        "significance": "This formalization adds a landmark real analysis example to the gallery. Thomae's function is historically significant as the prototype for understanding Riemann integrability beyond continuous functions, and its continuity characterization is a standard theorem in any real analysis course.",
+        "limitations": "The proof uses classical logic (noncomputable definition via `h.choose`). A constructive formalization would require a constructive characterization of the rational/irrational dichotomy.",
+        "implications": "The epsilon-delta approach — bounding the function by a threshold ε/2 and exploiting finiteness of the rational obstruction set — is a reusable pattern for other functions with countable discontinuity sets. The proof that Thomae's function is Riemann integrable (all discontinuities form a null set) follows directly from this continuity characterization. This formalization validates that Mathlib's `Irrational` API is expressive enough for density arguments in real analysis.",
+        "openQuestions": [
+            "Can Thomae's function be shown to be Riemann integrable in Lean 4, using the continuity-almost-everywhere result proved here together with the Lebesgue criterion?",
+            "Can a constructive proof be given for `thomae_irrational_continuous` that avoids classical choice (`h.choose`), using a computable approximation to the irrational?",
+            "Can the pattern (finite obstruction set → epsilon-delta continuity) be abstracted to a general Mathlib lemma about functions with countable jump discontinuities?"
+        ]
+    },
+    "sorries": 0
 }

--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -1,225 +1,231 @@
 {
-  "id": "shannon-source-coding-oq-03",
-  "title": "Asymptotic Equipartition Property (AEP)",
-  "slug": "shannon-source-coding-oq-03",
-  "description": "The AEP formalizes -1/n log P(X₁,...,Xₙ) → H(p) in probability for i.i.d. sources, proved via Chebyshev's inequality. Typical set size upper bound also proved.",
-  "meta": {
-    "author": "Claude Shannon (1948), Brockway McMillan (1953), formalized in Lean 4",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Asymptotic_equipartition_property",
-    "date": "1953",
-    "status": "verified",
-    "proofRepoPath": "Proofs/ShannonSourceCodingOQ03.lean",
-    "tags": [
-      "information-theory",
-      "probability",
-      "analysis",
-      "coding-theory",
-      "advanced"
+    "id": "shannon-source-coding-oq-03",
+    "title": "Asymptotic Equipartition Property (AEP)",
+    "slug": "shannon-source-coding-oq-03",
+    "description": "The AEP formalizes -1/n log P(X₁,...,Xₙ) → H(p) in probability for i.i.d. sources, proved via Chebyshev's inequality. Typical set size upper bound also proved.",
+    "meta": {
+        "author": "Claude Shannon (1948), Brockway McMillan (1953), formalized in Lean 4",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Asymptotic_equipartition_property",
+        "date": "1953",
+        "status": "verified",
+        "proofRepoPath": "Proofs/ShannonSourceCodingOQ03.lean",
+        "tags": [
+            "information-theory",
+            "probability",
+            "analysis",
+            "coding-theory",
+            "advanced"
+        ],
+        "badge": "original",
+        "sorries": 0,
+        "mathlibDependencies": [
+            {
+                "theorem": "Algebra.BigOperators.Pi",
+                "description": "Fintype.prod_sum: ∏ a, ∑ b, f a b = ∑ g : α → β, ∏ a, f a (g a) — key to marginal factorization",
+                "module": "Mathlib.Algebra.BigOperators.Pi"
+            },
+            {
+                "theorem": "Analysis.SpecialFunctions.Log.Basic",
+                "description": "Real logarithm: log_prod, log_nonpos, exp_log",
+                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+            },
+            {
+                "theorem": "Topology.Algebra.Order.LiminfLimsup",
+                "description": "Real exponential monotonicity for typical set bounds",
+                "module": "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
+            }
+        ],
+        "originalContributions": [
+            "Marginal factorization lemma: expVal_marginal proves E[g(Xⱼ)] = ∑ p(a)*g(a) via Fintype.prod_sum",
+            "Proved expVal_empEnt: expected empirical entropy equals Shannon entropy, using expVal_marginal across all coordinates",
+            "Proved aep_concentration: Chebyshev bound P(|empEnt - H| > ε) ≤ logVar/(n·ε²) (fixed bug in prior version)",
+            "Proved typical_set_size_upper: |T_ε^(n)| ≤ exp(n·(H+ε)) without any axioms",
+            "2D bilinear marginal factorization (expVal_marginal_product): E[g₁(Xⱼ₁)·g₂(Xⱼ₂)] = E[g₁]·E[g₂] for j₁ ≠ j₂, extending expVal_marginal via Fintype.prod_sum with two active coordinates",
+            "Proved empEnt_variance = logVar/n: diagonal terms contribute logVar D each via expVal_marginal, cross terms are zero via expVal_marginal_product + mean-centering. Fully closes AEP formalization."
+        ],
+        "assumptions": [],
+        "dateAdded": "2026-05-03",
+        "axiomCount": 0,
+        "lineCount": 476,
+        "prerequisites": [
+            "Shannon entropy H(X) = -∑ p(x) log p(x)",
+            "Chebyshev's inequality for finite probability spaces",
+            "Product of marginal probabilities (i.i.d. model)",
+            "Fintype.prod_sum (bigoperators sum-product exchange)"
+        ],
+        "mathlib_version": "4.26.0"
+    },
+    "overview": {
+        "historicalContext": "The Asymptotic Equipartition Property (AEP) is the information-theoretic analogue of the Law of Large Numbers. Shannon (1948) observed informally that for i.i.d. sources, -1/n log P(X₁,...,Xₙ) → H(X) in probability, concentrating probability mass on roughly 2^(nH) 'typical' sequences. McMillan (1953) gave the first rigorous proof (showing convergence almost surely), and Breiman (1957) extended it to ergodic sources. The finitary version via Chebyshev's inequality provides explicit concentration rates.",
+        "problemStatement": "For a discrete memoryless source with alphabet Fin k and distribution p = (p₁,...,p_k):\n\nLet X₁,...,Xₙ be i.i.d. with P(Xᵢ = a) = p(a). The empirical entropy is:\n  empEnt(x₁,...,xₙ) := -(1/n) ∑ᵢ log p(xᵢ)\n\n**AEP**: For all ε > 0,\n  P(|empEnt(X₁,...,Xₙ) - H(p)| > ε) ≤ Var[-log p(X)] / (n·ε²)\n\nIn particular, this probability → 0 as n → ∞.\n\n**Typical set**: T_ε^(n) = {x : |empEnt(x) - H(p)| ≤ ε} has |T_ε^(n)| ≤ exp(n·(H+ε)).",
+        "text": "The AEP proves that empirical entropy concentrates around Shannon entropy for long i.i.d. sequences, with explicit Chebyshev bounds.",
+        "proofStrategy": "The AEP is proved in three steps:\n\n1. **Marginal factorization** (`expVal_marginal`): The joint expectation E[g(Xⱼ)] over i.i.d. sequences factors as ∑_a p(a)*g(a), independent of j. This uses `Fintype.prod_sum` to exchange sum-over-sequences with product-over-coordinates.\n\n2. **Mean** (`expVal_empEnt`): E[empEnt] = H(p). Expand empEnt = -(1/n)∑ᵢ log p(Xᵢ), linearity + marginal factorization gives E[-log p(Xᵢ)] = ∑_a p(a)(-log p(a)) = H(p) for each i, and summing n equal terms and dividing by n gives H(p).\n\n3. **Concentration** (`aep_concentration`): Chebyshev applied to the variance bound Var[empEnt] = logVar/n gives P(|empEnt - H| > ε) ≤ logVar/(n·ε²).\n\nThe typical set size bound follows from: each x ∈ T_ε^(n) satisfies P(x) ≥ exp(-n(H+ε)), so |T_ε^(n)| * exp(-n(H+ε)) ≤ ∑_{x ∈ T} P(x) ≤ 1.",
+        "keyInsights": [
+            "The `Fintype.prod_sum` identity is the algebraic core: it converts a sum over all n-length sequences into a product of independent per-symbol sums, formalizing the i.i.d. assumption",
+            "empEnt is a sum of n i.i.d. random variables Zᵢ = -log p(Xᵢ), each with E[Zᵢ] = H(p). The LLN character of empEnt → H follows immediately from this representation",
+            "The Chebyshev approach gives explicit finite-n bounds (not just asymptotic convergence), making it ideal for source coding applications where blocklength matters",
+            "The typical set size bound |T_ε^(n)| ≤ exp(n(H+ε)) is the achievability half of Shannon's source coding theorem: sequences outside T_ε have vanishing probability, so compressing only typical sequences suffices",
+            "**Variance not mean drives Chebyshev**: The crucial proof repair was that `aep_concentration` requires `empEnt_variance` (rewriting E[(empEnt−H)²] = logVar/n) rather than `expVal_empEnt` (which rewrites E[empEnt] = H). Chebyshev bounds variance — using the mean rewrite produces a tautology that never establishes concentration"
+        ],
+        "prerequisites": [
+            "Shannon entropy H(X) = -∑ p(x) log p(x)",
+            "Chebyshev's inequality for finite probability spaces",
+            "Product of marginal probabilities (i.i.d. model)",
+            "Fintype.prod_sum (bigoperators sum-product exchange)"
+        ]
+    },
+    "sections": [
+        {
+            "id": "module-header",
+            "title": "Module Header: Problem Statement and Proof Architecture",
+            "startLine": 1,
+            "endLine": 54,
+            "summary": "Module docstring states OQ-03, defines AEP and empirical entropy, outlines Chebyshev proof strategy, and explains connection to source coding. Historical note: Mathematical Status section records the original sorry structure before variance proof was completed.",
+            "mathContext": "AEP: $P\\left(\\left|\\frac{-\\log P(\\mathbf{X})}{n} - H(p)\\right| > \\varepsilon\\right) \\leq \\frac{\\mathrm{Var}_p[-\\log p(X)]}{n\\varepsilon^2} \\to 0$. Typical set: $T_\\varepsilon^{(n)} = \\{\\mathbf{x} : |\\mathrm{empEnt}(\\mathbf{x}) - H| \\leq \\varepsilon\\}$, $|T_\\varepsilon^{(n)}| \\leq e^{n(H+\\varepsilon)}$."
+        },
+        {
+            "id": "distributions",
+            "title": "Probability Distributions",
+            "startLine": 55,
+            "endLine": 90,
+            "summary": "DiscreteDist structure, shannonH definition, shannonH_nonneg.",
+            "mathContext": "A discrete probability distribution on Fin k with normalization constraint."
+        },
+        {
+            "id": "joint",
+            "title": "Joint Distribution and Empirical Entropy",
+            "startLine": 95,
+            "endLine": 135,
+            "summary": "jointProb (product measure), empEnt (empirical entropy), jointProb_sum_one.",
+            "mathContext": "The i.i.d. joint distribution P(x) = ∏ p(xᵢ) and the empirical entropy -(1/n) log P(x)."
+        },
+        {
+            "id": "expval",
+            "title": "Expected Value and Marginal Factorization",
+            "startLine": 140,
+            "endLine": 205,
+            "summary": "expVal definition, expVal_marginal (Fintype.prod_sum factorization), expVal_empEnt = H(p).",
+            "mathContext": "The key lemma: ∑_x P(x)*g(x_j) = ∑_a p(a)*g(a) via sum-product exchange."
+        },
+        {
+            "id": "chebyshev",
+            "title": "Chebyshev's Inequality",
+            "startLine": 210,
+            "endLine": 240,
+            "summary": "chebyshev_finite: P(|f-μ| > ε) ≤ E[(f-μ)²]/ε² for finite distributions.",
+            "mathContext": "Elementary proof via pointwise bound ε² ≤ (f(x)-μ)² when |f(x)-μ| > ε."
+        },
+        {
+            "id": "aep",
+            "title": "AEP Concentration: Variance and Chebyshev Bound",
+            "startLine": 244,
+            "endLine": 380,
+            "summary": "logVar, expVal_marginal_product (2D bilinear), empEnt_variance = logVar/n (fully proved via diagonal/off-diagonal split), aep_concentration: P(|empEnt - H| > ε) ≤ logVar/(n·ε²).",
+            "mathContext": "The variance computation is the deepest result: $\\text{Var}[\\text{empEnt}] = \\text{logVar}/n$. Diagonal terms $E[(Z_j - H)^2] = \\text{logVar}$ use $\\texttt{expVal\\_marginal}$; off-diagonal cross terms $E[(Z_{j_1}-H)(Z_{j_2}-H)] = 0$ use $\\texttt{expVal\\_marginal\\_product}$ (independence) + mean-centering. Chebyshev then gives the explicit bound."
+        },
+        {
+            "id": "typical-set",
+            "title": "Typical Set: Definition and Size Upper Bound",
+            "startLine": 382,
+            "endLine": 421,
+            "summary": "typicalSet definition, typical_set_size_upper: |T_ε^(n)| ≤ exp(n·(H+ε)).",
+            "mathContext": "The typical set $T_\\varepsilon^{(n)} = \\{x : |\\text{empEnt}(x) - H(p)| \\leq \\varepsilon\\}$. Each $x \\in T_\\varepsilon^{(n)}$ satisfies $P(x) = e^{-n \\cdot \\text{empEnt}(x)} \\geq e^{-n(H+\\varepsilon)}$, so $|T_\\varepsilon^{(n)}| \\cdot e^{-n(H+\\varepsilon)} \\leq \\sum_{x \\in T} P(x) \\leq 1$, giving $|T_\\varepsilon^{(n)}| \\leq e^{n(H+\\varepsilon)}$. This is the achievability half of Shannon's source coding theorem."
+        },
+        {
+            "id": "concrete",
+            "title": "Concrete Verification: Fair Coin Sanity Check",
+            "startLine": 426,
+            "endLine": 445,
+            "summary": "uniformBin (fair Bernoulli), uniformBin_entropy: H(uniformBin) = log 2. Concrete instance confirming abstract definitions.",
+            "mathContext": "The fair coin distribution $p(0) = p(1) = 1/2$ on $\\text{Fin}\\,2$ satisfies $H = -2 \\cdot (1/2) \\log(1/2) = \\log 2 \\approx 0.693$. The $\\texttt{native\\_decide}$ verification confirms the discrete probability axioms and gives a sanity check that the abstract AEP applies to the simplest non-trivial example."
+        },
+        {
+            "id": "aep-summary",
+            "title": "Section VIII: AEP Summary and Bug Fix Record",
+            "startLine": 446,
+            "endLine": 476,
+            "summary": "Closing summary enumerates all 7 proved theorems. Records key bug fix: aep_concentration originally used rw [expVal_empEnt] (wrong — rewrites E[empEnt]=H) but required rw [empEnt_variance] (correct — rewrites E[(empEnt-H)²]=logVar/n).",
+            "mathContext": "Bug: `rw [expVal_empEnt]` rewrites $\\mathbb{E}[\\mathrm{empEnt}] = H$ (the mean). Fix: `rw [empEnt_variance]` rewrites $\\mathbb{E}[(\\mathrm{empEnt}-H)^2] = \\mathrm{logVar}/n$ (the variance). Chebyshev's inequality requires the variance, not the mean."
+        }
     ],
-    "badge": "original",
-    "sorries": 0,
-    "mathlibDependencies": [
-      {
-        "theorem": "Algebra.BigOperators.Pi",
-        "description": "Fintype.prod_sum: ∏ a, ∑ b, f a b = ∑ g : α → β, ∏ a, f a (g a) — key to marginal factorization",
-        "module": "Mathlib.Algebra.BigOperators.Pi"
-      },
-      {
-        "theorem": "Analysis.SpecialFunctions.Log.Basic",
-        "description": "Real logarithm: log_prod, log_nonpos, exp_log",
-        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-      },
-      {
-        "theorem": "Topology.Algebra.Order.LiminfLimsup",
-        "description": "Real exponential monotonicity for typical set bounds",
-        "module": "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
-      }
+    "crossReferences": [
+        {
+            "targetId": "shannon-source-coding",
+            "relationship": "depends-on",
+            "description": "The AEP is the probabilistic foundation of the source coding theorem"
+        },
+        {
+            "targetId": "shannon-entropy",
+            "relationship": "depends-on",
+            "description": "Uses Shannon entropy H(p) = -∑ p log p throughout"
+        },
+        {
+            "targetId": "laws-of-large-numbers",
+            "relationship": "related",
+            "description": "The AEP is the information-theoretic LLN: -log P(X₁,...,Xₙ)/n → H(X)"
+        },
+        {
+            "targetId": "shannon-source-coding-oq-01",
+            "relationship": "sibling",
+            "description": "OQ-01 addresses the converse of the source coding theorem; AEP provides the achievability direction"
+        },
+        {
+            "targetId": "shannon-source-coding-oq-04",
+            "relationship": "sibling",
+            "description": "OQ-04 extends AEP to variable-length codes; this file provides the fixed-length foundation"
+        },
+        {
+            "targetId": "shannon-channel-coding",
+            "relationship": "related",
+            "description": "The AEP technique (typical sequences) is the core proof technique for Shannon's channel coding theorem"
+        }
     ],
-    "originalContributions": [
-      "Marginal factorization lemma: expVal_marginal proves E[g(Xⱼ)] = ∑ p(a)*g(a) via Fintype.prod_sum",
-      "Proved expVal_empEnt: expected empirical entropy equals Shannon entropy, using expVal_marginal across all coordinates",
-      "Proved aep_concentration: Chebyshev bound P(|empEnt - H| > ε) ≤ logVar/(n·ε²) (fixed bug in prior version)",
-      "Proved typical_set_size_upper: |T_ε^(n)| ≤ exp(n·(H+ε)) without any axioms",
-      "2D bilinear marginal factorization (expVal_marginal_product): E[g₁(Xⱼ₁)·g₂(Xⱼ₂)] = E[g₁]·E[g₂] for j₁ ≠ j₂, extending expVal_marginal via Fintype.prod_sum with two active coordinates",
-      "Proved empEnt_variance = logVar/n: diagonal terms contribute logVar D each via expVal_marginal, cross terms are zero via expVal_marginal_product + mean-centering. Fully closes AEP formalization."
+    "conclusion": {
+        "summary": "The AEP is fully formalized for finite discrete memoryless sources: empirical entropy concentrates around H(p) with explicit Chebyshev bounds, and the typical set has size at most exp(n(H+ε)). Zero sorries, zero axioms — complete machine-checked proof.",
+        "implications": "The AEP is the cornerstone of information theory: it operationalizes entropy as the compression limit, provides the probability-1 characterization of typical sequences, and underpins both the achievability and converse of Shannon's source coding theorem.",
+        "openQuestions": [
+            "Can the AEP be extended to ergodic (non-i.i.d.) sources using Mathlib's ergodic theory?",
+            "Can the concentration bound logVar/(n·ε²) be tightened to an exact large-deviations rate using Cramér's theorem?",
+            "Can the lower bound |T_ε^(n)| ≥ (1-δ)·exp(n·(H-ε)) for large n (the converse typical set bound) be formalized in Lean, closing the achievability–converse gap for the source coding theorem?"
+        ]
+    },
+    "leanFile": {
+        "imports": [
+            "Mathlib"
+        ],
+        "opens": [
+            "Real",
+            "Finset",
+            "BigOperators"
+        ],
+        "namespace": "AEPFormalization",
+        "lineCount": 476,
+        "axiomCount": 0,
+        "theoremCount": 13,
+        "definitionCount": 7,
+        "path": "Proofs/ShannonSourceCodingOQ03.lean",
+        "sorries": 0
+    },
+    "references": [
+        {
+            "authors": "Shannon, Claude E.",
+            "title": "A Mathematical Theory of Communication",
+            "year": "1948",
+            "venue": "Bell System Technical Journal 27(3-4), 379-423, 623-656"
+        },
+        {
+            "authors": "McMillan, Brockway",
+            "title": "The Basic Theorems of Information Theory",
+            "year": "1953",
+            "venue": "Annals of Mathematical Statistics 24(2), 196-219"
+        },
+        {
+            "authors": "Cover, Thomas M.; Thomas, Joy A.",
+            "title": "Elements of Information Theory",
+            "year": "2006",
+            "venue": "Wiley, 2nd edition",
+            "note": "AEP and typical sequences: Chapter 3"
+        }
     ],
-    "assumptions": [],
-    "dateAdded": "2026-05-03",
-    "axiomCount": 0,
-    "lineCount": 476,
-    "prerequisites": [
-      "Shannon entropy H(X) = -∑ p(x) log p(x)",
-      "Chebyshev's inequality for finite probability spaces",
-      "Product of marginal probabilities (i.i.d. model)",
-      "Fintype.prod_sum (bigoperators sum-product exchange)"
-    ],
-    "mathlib_version": "4.26.0"
-  },
-  "overview": {
-    "historicalContext": "The Asymptotic Equipartition Property (AEP) is the information-theoretic analogue of the Law of Large Numbers. Shannon (1948) observed informally that for i.i.d. sources, -1/n log P(X₁,...,Xₙ) → H(X) in probability, concentrating probability mass on roughly 2^(nH) 'typical' sequences. McMillan (1953) gave the first rigorous proof (showing convergence almost surely), and Breiman (1957) extended it to ergodic sources. The finitary version via Chebyshev's inequality provides explicit concentration rates.",
-    "problemStatement": "For a discrete memoryless source with alphabet Fin k and distribution p = (p₁,...,p_k):\n\nLet X₁,...,Xₙ be i.i.d. with P(Xᵢ = a) = p(a). The empirical entropy is:\n  empEnt(x₁,...,xₙ) := -(1/n) ∑ᵢ log p(xᵢ)\n\n**AEP**: For all ε > 0,\n  P(|empEnt(X₁,...,Xₙ) - H(p)| > ε) ≤ Var[-log p(X)] / (n·ε²)\n\nIn particular, this probability → 0 as n → ∞.\n\n**Typical set**: T_ε^(n) = {x : |empEnt(x) - H(p)| ≤ ε} has |T_ε^(n)| ≤ exp(n·(H+ε)).",
-    "text": "The AEP proves that empirical entropy concentrates around Shannon entropy for long i.i.d. sequences, with explicit Chebyshev bounds.",
-    "proofStrategy": "The AEP is proved in three steps:\n\n1. **Marginal factorization** (`expVal_marginal`): The joint expectation E[g(Xⱼ)] over i.i.d. sequences factors as ∑_a p(a)*g(a), independent of j. This uses `Fintype.prod_sum` to exchange sum-over-sequences with product-over-coordinates.\n\n2. **Mean** (`expVal_empEnt`): E[empEnt] = H(p). Expand empEnt = -(1/n)∑ᵢ log p(Xᵢ), linearity + marginal factorization gives E[-log p(Xᵢ)] = ∑_a p(a)(-log p(a)) = H(p) for each i, and summing n equal terms and dividing by n gives H(p).\n\n3. **Concentration** (`aep_concentration`): Chebyshev applied to the variance bound Var[empEnt] = logVar/n gives P(|empEnt - H| > ε) ≤ logVar/(n·ε²).\n\nThe typical set size bound follows from: each x ∈ T_ε^(n) satisfies P(x) ≥ exp(-n(H+ε)), so |T_ε^(n)| * exp(-n(H+ε)) ≤ ∑_{x ∈ T} P(x) ≤ 1.",
-    "keyInsights": [
-      "The `Fintype.prod_sum` identity is the algebraic core: it converts a sum over all n-length sequences into a product of independent per-symbol sums, formalizing the i.i.d. assumption",
-      "empEnt is a sum of n i.i.d. random variables Zᵢ = -log p(Xᵢ), each with E[Zᵢ] = H(p). The LLN character of empEnt → H follows immediately from this representation",
-      "The Chebyshev approach gives explicit finite-n bounds (not just asymptotic convergence), making it ideal for source coding applications where blocklength matters",
-      "The typical set size bound |T_ε^(n)| ≤ exp(n(H+ε)) is the achievability half of Shannon's source coding theorem: sequences outside T_ε have vanishing probability, so compressing only typical sequences suffices",
-      "**Variance not mean drives Chebyshev**: The crucial proof repair was that `aep_concentration` requires `empEnt_variance` (rewriting E[(empEnt−H)²] = logVar/n) rather than `expVal_empEnt` (which rewrites E[empEnt] = H). Chebyshev bounds variance — using the mean rewrite produces a tautology that never establishes concentration"
-    ],
-    "prerequisites": [
-      "Shannon entropy H(X) = -∑ p(x) log p(x)",
-      "Chebyshev's inequality for finite probability spaces",
-      "Product of marginal probabilities (i.i.d. model)",
-      "Fintype.prod_sum (bigoperators sum-product exchange)"
-    ]
-  },
-  "sections": [
-    {
-      "id": "module-header",
-      "title": "Module Header: Problem Statement and Proof Architecture",
-      "startLine": 1,
-      "endLine": 54,
-      "summary": "Module docstring states OQ-03, defines AEP and empirical entropy, outlines Chebyshev proof strategy, and explains connection to source coding. Historical note: Mathematical Status section records the original sorry structure before variance proof was completed.",
-      "mathContext": "AEP: $P\\left(\\left|\\frac{-\\log P(\\mathbf{X})}{n} - H(p)\\right| > \\varepsilon\\right) \\leq \\frac{\\mathrm{Var}_p[-\\log p(X)]}{n\\varepsilon^2} \\to 0$. Typical set: $T_\\varepsilon^{(n)} = \\{\\mathbf{x} : |\\mathrm{empEnt}(\\mathbf{x}) - H| \\leq \\varepsilon\\}$, $|T_\\varepsilon^{(n)}| \\leq e^{n(H+\\varepsilon)}$."
-    },
-    {
-      "id": "distributions",
-      "title": "Probability Distributions",
-      "startLine": 55,
-      "endLine": 90,
-      "summary": "DiscreteDist structure, shannonH definition, shannonH_nonneg.",
-      "mathContext": "A discrete probability distribution on Fin k with normalization constraint."
-    },
-    {
-      "id": "joint",
-      "title": "Joint Distribution and Empirical Entropy",
-      "startLine": 95,
-      "endLine": 135,
-      "summary": "jointProb (product measure), empEnt (empirical entropy), jointProb_sum_one.",
-      "mathContext": "The i.i.d. joint distribution P(x) = ∏ p(xᵢ) and the empirical entropy -(1/n) log P(x)."
-    },
-    {
-      "id": "expval",
-      "title": "Expected Value and Marginal Factorization",
-      "startLine": 140,
-      "endLine": 205,
-      "summary": "expVal definition, expVal_marginal (Fintype.prod_sum factorization), expVal_empEnt = H(p).",
-      "mathContext": "The key lemma: ∑_x P(x)*g(x_j) = ∑_a p(a)*g(a) via sum-product exchange."
-    },
-    {
-      "id": "chebyshev",
-      "title": "Chebyshev's Inequality",
-      "startLine": 210,
-      "endLine": 240,
-      "summary": "chebyshev_finite: P(|f-μ| > ε) ≤ E[(f-μ)²]/ε² for finite distributions.",
-      "mathContext": "Elementary proof via pointwise bound ε² ≤ (f(x)-μ)² when |f(x)-μ| > ε."
-    },
-    {
-      "id": "aep",
-      "title": "AEP Concentration: Variance and Chebyshev Bound",
-      "startLine": 244,
-      "endLine": 380,
-      "summary": "logVar, expVal_marginal_product (2D bilinear), empEnt_variance = logVar/n (fully proved via diagonal/off-diagonal split), aep_concentration: P(|empEnt - H| > ε) ≤ logVar/(n·ε²).",
-      "mathContext": "The variance computation is the deepest result: $\\text{Var}[\\text{empEnt}] = \\text{logVar}/n$. Diagonal terms $E[(Z_j - H)^2] = \\text{logVar}$ use $\\texttt{expVal\\_marginal}$; off-diagonal cross terms $E[(Z_{j_1}-H)(Z_{j_2}-H)] = 0$ use $\\texttt{expVal\\_marginal\\_product}$ (independence) + mean-centering. Chebyshev then gives the explicit bound."
-    },
-    {
-      "id": "typical-set",
-      "title": "Typical Set: Definition and Size Upper Bound",
-      "startLine": 382,
-      "endLine": 421,
-      "summary": "typicalSet definition, typical_set_size_upper: |T_ε^(n)| ≤ exp(n·(H+ε)).",
-      "mathContext": "The typical set $T_\\varepsilon^{(n)} = \\{x : |\\text{empEnt}(x) - H(p)| \\leq \\varepsilon\\}$. Each $x \\in T_\\varepsilon^{(n)}$ satisfies $P(x) = e^{-n \\cdot \\text{empEnt}(x)} \\geq e^{-n(H+\\varepsilon)}$, so $|T_\\varepsilon^{(n)}| \\cdot e^{-n(H+\\varepsilon)} \\leq \\sum_{x \\in T} P(x) \\leq 1$, giving $|T_\\varepsilon^{(n)}| \\leq e^{n(H+\\varepsilon)}$. This is the achievability half of Shannon's source coding theorem."
-    },
-    {
-      "id": "concrete",
-      "title": "Concrete Verification: Fair Coin Sanity Check",
-      "startLine": 426,
-      "endLine": 445,
-      "summary": "uniformBin (fair Bernoulli), uniformBin_entropy: H(uniformBin) = log 2. Concrete instance confirming abstract definitions.",
-      "mathContext": "The fair coin distribution $p(0) = p(1) = 1/2$ on $\\text{Fin}\\,2$ satisfies $H = -2 \\cdot (1/2) \\log(1/2) = \\log 2 \\approx 0.693$. The $\\texttt{native\\_decide}$ verification confirms the discrete probability axioms and gives a sanity check that the abstract AEP applies to the simplest non-trivial example."
-    },
-    {
-      "id": "aep-summary",
-      "title": "Section VIII: AEP Summary and Bug Fix Record",
-      "startLine": 446,
-      "endLine": 476,
-      "summary": "Closing summary enumerates all 7 proved theorems. Records key bug fix: aep_concentration originally used rw [expVal_empEnt] (wrong — rewrites E[empEnt]=H) but required rw [empEnt_variance] (correct — rewrites E[(empEnt-H)²]=logVar/n).",
-      "mathContext": "Bug: `rw [expVal_empEnt]` rewrites $\\mathbb{E}[\\mathrm{empEnt}] = H$ (the mean). Fix: `rw [empEnt_variance]` rewrites $\\mathbb{E}[(\\mathrm{empEnt}-H)^2] = \\mathrm{logVar}/n$ (the variance). Chebyshev's inequality requires the variance, not the mean."
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "shannon-source-coding",
-      "relationship": "depends-on",
-      "description": "The AEP is the probabilistic foundation of the source coding theorem"
-    },
-    {
-      "targetId": "shannon-entropy",
-      "relationship": "depends-on",
-      "description": "Uses Shannon entropy H(p) = -∑ p log p throughout"
-    },
-    {
-      "targetId": "laws-of-large-numbers",
-      "relationship": "related",
-      "description": "The AEP is the information-theoretic LLN: -log P(X₁,...,Xₙ)/n → H(X)"
-    },
-    {
-      "targetId": "shannon-source-coding-oq-01",
-      "relationship": "sibling",
-      "description": "OQ-01 addresses the converse of the source coding theorem; AEP provides the achievability direction"
-    },
-    {
-      "targetId": "shannon-source-coding-oq-04",
-      "relationship": "sibling",
-      "description": "OQ-04 extends AEP to variable-length codes; this file provides the fixed-length foundation"
-    },
-    {
-      "targetId": "shannon-channel-coding",
-      "relationship": "related",
-      "description": "The AEP technique (typical sequences) is the core proof technique for Shannon's channel coding theorem"
-    }
-  ],
-  "conclusion": {
-    "summary": "The AEP is fully formalized for finite discrete memoryless sources: empirical entropy concentrates around H(p) with explicit Chebyshev bounds, and the typical set has size at most exp(n(H+ε)). Zero sorries, zero axioms — complete machine-checked proof.",
-    "implications": "The AEP is the cornerstone of information theory: it operationalizes entropy as the compression limit, provides the probability-1 characterization of typical sequences, and underpins both the achievability and converse of Shannon's source coding theorem.",
-    "openQuestions": [
-      "Can the AEP be extended to ergodic (non-i.i.d.) sources using Mathlib's ergodic theory?",
-      "Can the concentration bound logVar/(n·ε²) be tightened to an exact large-deviations rate using Cramér's theorem?",
-      "Can the lower bound |T_ε^(n)| ≥ (1-δ)·exp(n·(H-ε)) for large n (the converse typical set bound) be formalized in Lean, closing the achievability–converse gap for the source coding theorem?"
-    ]
-  },
-  "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real", "Finset", "BigOperators"],
-    "namespace": "AEPFormalization",
-    "lineCount": 476,
-    "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 7,
-    "path": "Proofs/ShannonSourceCodingOQ03.lean",
     "sorries": 0
-  },
-  "references": [
-    {
-      "authors": "Shannon, Claude E.",
-      "title": "A Mathematical Theory of Communication",
-      "year": "1948",
-      "venue": "Bell System Technical Journal 27(3-4), 379-423, 623-656"
-    },
-    {
-      "authors": "McMillan, Brockway",
-      "title": "The Basic Theorems of Information Theory",
-      "year": "1953",
-      "venue": "Annals of Mathematical Statistics 24(2), 196-219"
-    },
-    {
-      "authors": "Cover, Thomas M.; Thomas, Joy A.",
-      "title": "Elements of Information Theory",
-      "year": "2006",
-      "venue": "Wiley, 2nd edition",
-      "note": "AEP and typical sequences: Chapter 3"
-    }
-  ],
-  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Restores correct `leanFile.theoremCount` values using the "all declarations including private/protected" convention established in PR #15867. These entries were missed by that batch and subsequent audits.

## Changes

| Entry | Before | After | Private Declarations Added |
|-------|--------|-------|---------------------------|
| `bezout-identity-oq-01-oq-01` | 6 | 14 | +8 |
| `binary-gcd-oq-03-oq-02` | 33 | 35 | +2 |
| `erdos-1095-oq-01` | 21 | 37 | +16 |
| `konigsberg-oq-01-oq-02` | 12 | 25 | +13 |
| `cayley-hamilton-cyclic-vector-all-fields` | 3 | 8 | +5 |
| `lebesgue-measure-oq-01-oq-01-oq-02` | 6 | 11 | +5 |
| `chebyshev-bounds-oq-04` | 10 | 14 | +4 |
| `cauchy-schwarz-oq-01-oq-01-oq-02` | 6 | 8 | +2 |
| `frobenius-number` | 13 | 15 | +2 |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03` | 14 | 15 | +1 |
| `cube-root-3-irrational-oq-02-oq-02` | 2 | 3 | +1 |
| `desargues-theorem-oq-01-oq-01` | 29 | 30 | +1 |
| `fundamental-arithmetic-oq-01-oq-01` | 12 | 13 | +1 |
| `shannon-source-coding-oq-03` | 12 | 13 | +1 |

**Method**: Comment-aware declaration scan (handles nested `/-...-/` blocks). In each case, `meta.leanFile.theoremCount` matched the count of `^(theorem|lemma)` (public only), while actual count including `^private theorem`, `^private lemma`, etc. was higher.

Companion to PR #15882 which fixed 5 similar entries.

---
Automated fix by lean-mechanic agent.