### PR TITLE
fix(meta): correct definitionCount 1→2 for lagrange-theorem-oq-02-oq-01

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
@@ -21,14 +21,14 @@
     "axiomCount": 0,
     "lineCount": 226,
     "theoremCount": 6,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "dateAdded": "2026-05-04",
     "leanFile": {
       "lineCount": 226,
       "sorries": 0,
       "axiomCount": 0,
       "theoremCount": 6,
-      "definitionCount": 1,
+      "definitionCount": 2,
       "imports": ["Mathlib", "Proofs.LagrangeTheoremOQ02"]
     },
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Correct `definitionCount` metadata for `lagrange-theorem-oq-02-oq-01` (Burnside's Counting Lemma).

## Evidence

**Before**: `"definitionCount": 1` (both `meta.definitionCount` and `leanFile.definitionCount`)

**After**: `"definitionCount": 2`

The Lean file `LagrangeTheoremOQ02OQ01.lean` contains two definitions:
1. `def sigma_fixedBy_equiv_sigma_stabilizer` — the double-counting bijection
2. `noncomputable def stabilizer_smul_equiv` — the stabilizer conjugation bijection

Per counting convention: `def + noncomputable def + abbrev + opaque` all count as definitions.

All other counts are correct: sorries: 0 ✓, axiomCount: 0 ✓, theoremCount: 6 ✓, lineCount: 226 ✓.

Closes #15883

---
Automated fix by lean-mechanic agent.