### PR TITLE
fix(meta): sync meta.theoremCount for 6 entries — private/protected declarations missed

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 959,
-    "theoremCount": 12,
+    "theoremCount": 17,
     "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },
@@ -72,7 +72,7 @@
     "namespace": "NewtonLogConcavity",
     "lineCount": 959,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 17,
     "definitionCount": 3,
     "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
         "axiomCount": 0,
         "dateAdded": "2026-05-03",
         "lineCount": 188,
-        "theoremCount": 6,
+        "theoremCount": 14,
         "assumptions": "None. Fully machine-verified.",
         "originalContributions": [
             "binaryGcd: Stein's binary GCD algorithm — terminates by well-founded recursion on a+b with 7 case branches",

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -21,7 +21,7 @@
         "badge": "mathlib",
         "sorries": 0,
         "axiomCount": 0,
-        "theoremCount": 3,
+        "theoremCount": 8,
         "lineCount": 268,
         "assumptions": "",
         "mathlib_version": "4.26.0",

--- a/src/data/proofs/chebyshev-bounds-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04/meta.json
@@ -22,7 +22,7 @@
         "axiomCount": 2,
         "assumptions": "2 axioms: (1) chebyshevPsi_asymptotic — ψ(n)/n → 1, the Prime Number Theorem for ψ; (2) pnt_equivalence — ψ(n)/n → 1 ↔ π(n) ~ n/log n. chebyshevPsi_upper_bound is now proved (strong induction via psi_odd_le_log_choose + Nat.choose_middle_le_pow).",
         "lineCount": 386,
-        "theoremCount": 10,
+        "theoremCount": 14,
         "definitionCount": 2,
         "originalContributions": [
             "Definition of the second Chebyshev function ψ(n) = Σ_{k ≤ n} Λ(k) using Mathlib's vonMangoldt function",

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -23,7 +23,7 @@
         "erdosProblemStatus": "open",
         "axiomCount": 0,
         "lineCount": 475,
-        "theoremCount": 21,
+        "theoremCount": 37,
         "assumptions": "0 axioms, 0 sorries. gFunc_exists proved constructively via Kummer's theorem (carry-free base-p arithmetic). gFunc defined via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 all verified. Open conjecture; supporting lemmas fully verified."
     },
     "overview": {

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
@@ -27,7 +27,7 @@
         "axiomCount": 0,
         "lineCount": 240,
         "assumptions": "0 axioms, 0 sorries. Fully verified.",
-        "theoremCount": 6,
+        "theoremCount": 11,
         "originalContributions": [
             "thomae_continuous_at_irrational: ContinuousAt thomae x for every irrational x",
             "thomae_discontinuous_at_rat: ¬ContinuousAt thomae (q : ℝ) for every rational q",


### PR DESCRIPTION
## Fix

Corrects stale `meta.theoremCount` values in 6 gallery entries where the `meta` block only counted public `theorem`/`lemma` declarations and missed `private`/`protected` ones. This is the same regression class as PR #15882.

Note: `leanFile.theoremCount` was already correct for 5 of 6 entries (previously fixed); only `meta.theoremCount` lagged behind. `amgm-inequality-oq-02-oq-02` had both fields wrong.

## Evidence

| Entry | Before | After | Missing |
|-------|--------|-------|---------|
| `erdos-1095-oq-01` | 21 | 37 | 16 private theorem/lemma declarations |
| `bezout-identity-oq-01-oq-01` | 6 | 14 | 8 private lemma declarations |
| `lebesgue-measure-oq-01-oq-01-oq-02` | 6 | 11 | 5 private lemma declarations |
| `cayley-hamilton-cyclic-vector-all-fields` | 3 | 8 | 5 private lemma declarations |
| `amgm-inequality-oq-02-oq-02` | 12 | 17 | 5 private lemma/theorem declarations |
| `chebyshev-bounds-oq-04` | 10 | 14 | 4 private lemma declarations |

All counts verified via canonical grep:
\`\`\`
grep -c "^\(private \|protected \|noncomputable \)*\(theorem\|lemma\) " proofs/Proofs/<file>.lean
\`\`\`

---
Automated fix by lean-mechanic agent.