### PR TITLE
fix(meta): correct theoremCount 15→14 for law-of-cosines-oq-03-oq-02

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ02.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ02.lean
@@ -26,7 +26,7 @@ we derive: the triple-ratio form, cross-multiplication identities, the isoceles
 theorem (a = b ↔ A = B) via arccos injectivity on [0, π], and right-angle
 and equilateral specializations.
 
-## Summary: 15 theorems, 0 sorries, 6 structure-encoded axioms
+## Summary: 14 theorems, 0 sorries, 6 structure-encoded axioms
 
 Tags: hyperbolic-geometry, law-of-sines, trigonometry, real-analysis
 

--- a/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "law-of-cosines-oq-03-oq-02",
   "title": "Hyperbolic Law of Sines",
   "slug": "law-of-cosines-oq-03-oq-02",
-  "description": "Formalizes the hyperbolic law of sines sin(A)/sinh(a) = sin(B)/sinh(b) = sin(C)/sinh(c) for hyperbolic triangles. Packages the law as a HyperbolicSineTriangle structure with 6 axiom fields. Derives cross-multiplication forms, the isoceles theorem (a=b ↔ A=B) via arccos injectivity on [0,π], and right-angle specialization. 15 theorems, 6 structure-encoded axioms, 0 sorries.",
+  "description": "Formalizes the hyperbolic law of sines sin(A)/sinh(a) = sin(B)/sinh(b) = sin(C)/sinh(c) for hyperbolic triangles. Packages the law as a HyperbolicSineTriangle structure with 6 axiom fields. Derives cross-multiplication forms, the isoceles theorem (a=b ↔ A=B) via arccos injectivity on [0,π], and right-angle specialization. 14 theorems, 6 structure-encoded axioms, 0 sorries.",
   "leanFile": {
     "path": "Proofs/LawOfCosinesOQ03OQ02.lean",
     "namespace": "HyperbolicLawOfSines",
@@ -17,7 +17,7 @@
     "axiomCount": 6,
     "sorries": 0,
     "lineCount": 264,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -178,7 +178,7 @@
     "sorries": 0,
     "axiomCount": 6,
     "lineCount": 264,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 1,
     "originalContributions": [
       "HyperbolicSineTriangle structure with 6 axiom fields encoding the hyperbolic law of sines",


### PR DESCRIPTION
## Fix

`law-of-cosines-oq-03-oq-02` reports `theoremCount: 15` but the Lean file has only 14 theorem/lemma declarations.

## Evidence

**Before**: `theoremCount: 15`
**After**: `theoremCount: 14`

14 named declarations after comment stripping: sinh_pos_of_pos, sinh_pos_ne_zero, law_sines_ac, law_sines_all, law_sines_cross_ab, law_sines_cross_bc, law_sines_cross_ac, angle_sum_lt_pi, angular_defect_pos, sin_eq_of_lt_pi, isoceles_iff, right_angle_sines, equilateral_angles, ratio_pos.

The off-by-one arose because the header block comment contains 'theorem (a = b ↔ A = B)' in narrative text, counted without comment stripping.

Changes: leanFile.theoremCount, meta.theoremCount, description text, and Lean file header summary comment — all updated 15→14.

---
Automated fix by lean-mechanic agent.