### PR TITLE
fix(meta): move leanFile block to top-level for lagrange-theorem-oq-02-oq-01

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
@@ -23,14 +23,6 @@
     "theoremCount": 6,
     "definitionCount": 2,
     "dateAdded": "2026-05-04",
-    "leanFile": {
-      "lineCount": 226,
-      "sorries": 0,
-      "axiomCount": 0,
-      "theoremCount": 6,
-      "definitionCount": 2,
-      "imports": ["Mathlib", "Proofs.LagrangeTheoremOQ02"]
-    },
     "mathlibDependencies": [
       {
         "theorem": "MulAction.card_orbit_mul_card_stabilizer_eq_card_group",
@@ -126,6 +118,24 @@
       "Does the double-counting bijection sigma_fixedBy_equiv_sigma_stabilizer generalize to monoid actions (where stabilizers are not necessarily subgroups)?",
       "Can the Burnside formula be used in Lean 4 to give a machine-verified proof of Pólya's enumeration theorem, which counts equivalence classes of colorings under group symmetry?"
     ]
+  },
+  "leanFile": {
+    "path": "Proofs/LagrangeTheoremOQ02OQ01.lean",
+    "namespace": "LagrangeTheoremOQ02OQ01",
+    "imports": [
+      "Mathlib",
+      "Proofs.LagrangeTheoremOQ02"
+    ],
+    "opens": [
+      "MulAction",
+      "Finset",
+      "BigOperators"
+    ],
+    "lineCount": 226,
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

The `leanFile` block for `lagrange-theorem-oq-02-oq-01` was nested inside `meta{}` instead of being a top-level field, causing `find-targets.ts` to see `leanFile: null` for this entry.

## Changes

- Moves `leanFile` block from `meta.leanFile` to top-level `leanFile`
- Adds missing `path`, `namespace`, and `opens` fields to the block

## Evidence

```bash
# Before:
python3 -c "import json; d=json.load(open('meta.json')); print(d.get('leanFile'))"
# → None (null)

# After:
# → {'path': 'Proofs/LagrangeTheoremOQ02OQ01.lean', 'namespace': '...', 'lineCount': 226, ...}
```

Discovered during gallery integrity audit (2026-05-05 session).