### PR TITLE
fix(meta): sync meta.definitionCount for 23 entries — align with lf.definitionCount

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "1 axiom: nball_volume_scaling — Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)). This is a standard measure theory fact requiring careful handling of EuclideanSpace/PiLp volume isomorphism in Mathlib.",
     "lineCount": 211,
     "theoremCount": 17,
-    "definitionCount": 3,
+    "definitionCount": 1,
     "originalContributions": [
       "unitBallVolume: definition of Vol(Bⁿ(1)) = πⁿ/² / Γ(n/2+1)",
       "unitBallVolume_one: Vol(B¹(1)) = 2 (from Real.volume_ball)",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "2 sorries remain: (1) jdt_weight_sum b≥2 — the general JDT seam bijection (~150-200 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
     "lineCount": 850,
     "theoremCount": 10,
-    "definitionCount": 8,
+    "definitionCount": 6,
     "originalContributions": [
       "jacobiTrudiMatrix: the k×k matrix with entries h_{sh_i + j - i} (or 0 for negative index) — first Lean 4 Jacobi-Trudi matrix definition",
       "schurPolynomial: det(jacobiTrudiMatrix) as the primary definition of Schur polynomials in Lean 4",

--- a/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "3 axioms inherited from BoundedPrimeGaps.lean: maynard_tao_m_tuples (Maynard-Tao sieve for k-tuples), maynard_tao_sieve (unconditional H≤246 bound from 50-tuple), maynard_tao_sieve_eh (conditional H≤12 under Elliott-Halberstam). 0 own axioms. 0 sorries.",
     "lineCount": 438,
     "theoremCount": 26,
-    "definitionCount": 5,
+    "definitionCount": 1,
     "originalContributions": [
       "parity_constraint: admissible sets containing 0 must be all-even",
       "not_admissible_0_2_4: {0,2,4} is not admissible (fails at p=3)",

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma / h_diag), consistency (h_consistent), reflection principle (h_reflection), and D1 axiom of provability logic (h_D1) — 4 Prop-typed assumptions. StrongGodelModel additionally axiomatizes double-negation elimination (h_dne) — 1 more. Total: 5 structure-encoded mathematical assumptions. These are hypotheses, not global Lean axioms.",
     "lineCount": 256,
     "theoremCount": 7,
-    "definitionCount": 5,
+    "definitionCount": 1,
     "originalContributions": [
       "diagonal_lemma: abstract Lawvere version of the Gödel-Carnap diagonal lemma",
       "godel_sentence: existence of the Gödel sentence G = Neg(PrSent G) via Lawvere fixed-point",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "1 axiom: nonderogatory_has_cyclic_vector — the converse direction: if M is nonderogatory (minpoly = charpoly), then there exists a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis. This requires constructing the cyclic vector from the rational canonical form, which is not yet fully formalized in Mathlib.",
     "lineCount": 316,
     "theoremCount": 8,
-    "definitionCount": 0,
+    "definitionCount": 3,
     "originalContributions": [
       "IsCyclicVector: predicate — v is cyclic for M if {v,Mv,...,M^{n-1}v} spans K^n",
       "IsNonderogatory: predicate — minpoly M = charpoly M",

--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) \u2014 the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 3 sorries: (1) nested ciSup of zeros = 0 for independent sequences, (2) i.i.d. Lindeberg condition via dominated convergence for truncated moments, (3) i.i.d. Lyapunov condition via rpow moment decay.",
     "lineCount": 729,
     "theoremCount": 20,
-    "definitionCount": 6,
+    "definitionCount": 11,
     "originalContributions": [
       "MartingaleDiffArray: triangular array {X_{n,k}} with martingale difference property and square integrability",
       "lindebergCondition: Lindeberg criterion \u2014 sum of truncated second moments vanishes",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "None. Fully verified from Mathlib.",
     "lineCount": 309,
     "theoremCount": 10,
-    "definitionCount": 8,
+    "definitionCount": 5,
     "originalContributions": [
       "GeneralizedMenelausConfig: signed ratio framework for Menelaus theorem",
       "generalized_menelaus: algebraic core (product = -1 iff numerator = -denominator)",

--- a/src/data/proofs/cevas-theorem-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 907,
     "theoremCount": 39,
-    "definitionCount": 20,
+    "definitionCount": 23,
     "originalContributions": [
       "GeomCevianConfig: concrete cevian configuration in ℝ² with parametric line representation",
       "cevaCondition: algebraic predicate d·e·f = (1-d)·(1-e)·(1-f)",

--- a/src/data/proofs/collatz-structured-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-03/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 1,
     "lineCount": 149,
     "theoremCount": 2,
-    "definitionCount": 10,
+    "definitionCount": 13,
     "assumptions": "1 axiom (terras_density): Terras's 1976 density-1 result that almost all positive integers eventually reach 1 under Collatz iteration. The main asymptotic question (S(N) ~ c·log N) is an open conjecture formalized as a Lean Prop.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",

--- a/src/data/proofs/denumerability-rationals-oq-02/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "Core results (cantor_characterization, countable_dense_linear_orders_iso, rationals_selfsimilar) derived directly from Mathlib's Order.iso_of_countable_dense. Bridge and infrastructure formalization only.",
     "lineCount": 237,
     "theoremCount": 18,
-    "definitionCount": 0,
+    "definitionCount": 3,
     "originalContributions": [
       "integers_embed: ℤ embeds strictly monotonically into ℚ (as n ↦ n : ℚ) — independent proof",
       "fin_embeds: any finite ordered set Fin n embeds into ℚ — independent proof",

--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 282,
     "theoremCount": 14,
-    "definitionCount": 4,
+    "definitionCount": 2,
     "originalContributions": [
       "numDerangements_eq_factorial_mul_altSum: identity D(n) = n! · ∑_{k≤n} (-1)^k/k! proved by strong induction",
       "alternating_tail_bound: sharp bound |∑_{k≥n+1} (-1)^k/k!| ≤ 1/(n+1)! via alternating series analysis",

--- a/src/data/proofs/dissection-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "2 axioms inherited from DissectionOfCubes.lean: smaller_cube_above_axiom, all_different_implies_long_chains_axiom. 2 sorries for geometric confinement lemmas (smallest_above_is_smaller, global_min_not_reaching_top).",
     "lineCount": 599,
     "theoremCount": 17,
-    "definitionCount": 13,
+    "definitionCount": 11,
     "originalContributions": [
       "CubePacking: structure for disjoint contained cubes (relaxation of dissection)",
       "IsReciprocalPacking: packing with all distinct reciprocal-of-integer side lengths",

--- a/src/data/proofs/erdos-1012-oq-02/meta.json
+++ b/src/data/proofs/erdos-1012-oq-02/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "2 axioms: bondy_vertex_pancyclic (Bondy 1971: n≥3, dense Hamiltonian graph → every vertex is on cycles of all lengths 3..n, unless bipartite), woodall_vertex_pancyclic (Woodall extension: dense graphs are vertex-pancyclic from 3 to n-k).",
     "lineCount": 389,
     "theoremCount": 12,
-    "definitionCount": 5,
+    "definitionCount": 8,
     "originalContributions": [
       "isVertexPancyclic: every vertex v lies on a cycle of length l for all l ∈ [3,n]",
       "isVertexPancyclicFrom: vertex-pancyclic from length a to b",

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 323,
     "theoremCount": 12,
-    "definitionCount": 5,
+    "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
     "lineCount": 2042,
     "theoremCount": 45,
-    "definitionCount": 15,
+    "definitionCount": 18,
     "originalContributions": [
       "NSquareIdentity: structure for bilinear n-square composition identities",
       "admissibleDimensions: Finset {1,2,4,8} — the four normed division algebra dimensions",

--- a/src/data/proofs/konigsberg-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "2 axioms: directed_euler_circuit_sufficient (balanced digraph → Eulerian circuit exists) and directed_euler_path_sufficient (exactly one source + one sink → Eulerian path exists). The necessary conditions are fully proved; the sufficiency requires an Eulerian circuit construction algorithm (e.g., Hierholzer's algorithm) not yet in Mathlib.",
     "lineCount": 813,
     "theoremCount": 35,
-    "definitionCount": 8,
+    "definitionCount": 11,
     "originalContributions": [
       "Digraph: directed graph definition with finite vertex and edge types",
       "inDegree/outDegree: in-degree and out-degree for each vertex",

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "lineCount": 192,
     "theoremCount": 11,
-    "definitionCount": 3,
+    "definitionCount": 1,
     "dateAdded": "2026-04-24",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/ramsey-r4k-extensions/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "15 axioms covering: erdos_probabilistic_lower_bound (R(k,k)≥2^(k/2) via first moment method), aks_r3k_upper_bound and kim_r3k_lower_bound (R(3,k) bounds), r4k_upper_bound and r4k_lower_bound (R(4,k) bounds), spencer_diagonal_lower_bound (Spencer's improvement), r4k_quadratic_lower (Ω(k²/log k) lower bound), cgms_diagonal_upper_bound and cgms_epsilon_estimate (Conlon-Fox-Sudakov 2009), book_algorithm_structure, and several supporting analytic bounds. These represent the state of the art in Ramsey theory, proofs of which require probabilistic method machinery not yet in Mathlib.",
     "lineCount": 1142,
     "theoremCount": 74,
-    "definitionCount": 10,
+    "definitionCount": 13,
     "originalContributions": [
       "IsRamseyColoring: 2-coloring of K_n edges avoiding monochromatic K_r or K_s",
       "ramsey_number_bound: R(r,s) ≤ C(r+s-2, r-1) (Pascal triangle bound, proved)",

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/stirling-formula-oq-02/meta.json
+++ b/src/data/proofs/stirling-formula-oq-02/meta.json
@@ -39,7 +39,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "lineCount": 601,
     "theoremCount": 26,
-    "definitionCount": 4,
+    "definitionCount": 2,
     "originalContributions": [
       "Mathlib bridge: gamma_isEquivalent_stirling delegates directly to Stirling.factorial_isEquivalent_stirling via Γ(n+1)=n!; the primary asymptotic result is Mathlib's",
       "gamma_lower_bound: Γ(n+1) ≥ √(2πn)·(n/e)^n for n ≥ 1 (from stirlingSeq antitonicity, original packaging)",

--- a/src/data/proofs/taylor-theorem-oq-03/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-03/meta.json
@@ -59,7 +59,7 @@
     "axiomCount": 0,
     "lineCount": 268,
     "theoremCount": 17,
-    "definitionCount": 2,
+    "definitionCount": 0,
     "assumptions": "0 axioms, 0 sorries. Core Taylor remainder estimates (taylor_mean_remainder_lagrange, taylor_mean_remainder_cauchy) from Mathlib; original work is exponential convergence analysis.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/three-place-identity-oq-02/meta.json
+++ b/src/data/proofs/three-place-identity-oq-02/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-03-30",
     "lineCount": 175,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Three-place (relative) identity was introduced by Peter Geach in his 1967 paper 'Identity' (Review of Metaphysics), where he argued against the absoluteness of identity: the same object can be 'the same F' but 'a different G' for sortals F and G. This challenged Leibniz's law and sparked decades of philosophical debate between Geach and W.V.O. Quine, who insisted that numerical identity must be absolute. Tom Etter, working at the Boundary Institute, proposed a formal reconciliation in his 2001 paper 'Equalities and Quine Identities': two equivalence relations ('stereo equality', by analogy with stereoscopic vision) suffice to model relative identity, providing a two-predicate foundation that avoids Quine's objections. This formalization proves Etter's theorem in Lean 4, establishing both the forward construction (stereo pair → relative identity) and the reverse (relative identity → stereo pair), along with the negative result that a single equivalence relation is insufficient — it produces only a 'flat' (viewpoint-independent) identity.",

--- a/src/data/proofs/unit-distance-independence/meta.json
+++ b/src/data/proofs/unit-distance-independence/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "2 axioms: hadwiger_nelson_lower_bound (χ(ℝ²) ≥ 5) and hadwiger_nelson_upper_bound (χ(ℝ²) ≤ 7). The lower bound was improved to 5 by de Grey (2018) using a 1581-vertex graph; the upper bound follows from a 7-coloring of the plane using hexagonal tiling. These require substantial geometric computation.",
     "lineCount": 948,
     "theoremCount": 65,
-    "definitionCount": 8,
+    "definitionCount": 12,
     "originalContributions": [
       "IsIndepSet/IsIndepFinset: independence set predicates for abstract simple graphs",
       "isIndepFinset_empty: empty set is independent",


### PR DESCRIPTION
## Fix

Corrects stale `meta.definitionCount` in 23 gallery entries where the field lagged behind the already-correct `leanFile.definitionCount`. Convention: count `def + abbrev + opaque` declarations after comment stripping (established by PR #15533).

## Evidence

All 23 entries had `leanFile.definitionCount` already set to the correct value; only `meta.definitionCount` was stale.

| Entry | Before | After |
|-------|--------|-------|
| `central-limit-theorem-oq-02` | 6 | 11 |
| `unit-distance-independence` | 8 | 12 |
| `cantor-diagonalization-oq-03-oq-01-oq-03` | 5 | 1 |
| `bounded-prime-gaps-oq-01` | 5 | 1 |
| `erdos-1012-oq-02` | 5 | 8 |
| `collatz-structured-oq-03` | 10 | 13 |
| `cevas-theorem-non-euclidean-oq-02` | 8 | 5 |
| `cayley-hamilton-minpoly-oq-04` | 0 | 3 |
| `denumerability-rationals-oq-02` | 0 | 3 |
| `hurwitz-theorem-oq-03` | 15 | 18 |
| `ramsey-r4k-extensions` | 10 | 13 |
| `cevas-theorem-oq-01` | 20 | 23 |
| `konigsberg-oq-02` | 8 | 11 |
| `dissection-of-cubes-oq-03` | 13 | 11 |
| `roth-theorem-k3-oq-02` | 4 | 6 |
| `stirling-formula-oq-02` | 4 | 2 |
| `minkowski-fundamental-theorem-oq-04` | 3 | 1 |
| `hilbert-14-oq-01` | 5 | 3 |
| `derangements-convergence` | 4 | 2 |
| `three-place-identity-oq-02` | 5 | 3 |
| `taylor-theorem-oq-03` | 2 | 0 |
| `ballot-problem-oq-03-oq-01-oq-01-oq-01` | 8 | 6 |
| `area-of-circle-oq-02` | 3 | 1 |

---
Automated fix by lean-mechanic agent.