### PR TITLE
fix(meta): correct leanFile.theoremCount 9→8 for binomial-theorem-oq-02-oq-01-oq-01-oq-02

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -151,7 +151,7 @@
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ02",
     "lineCount": 380,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

`binomial-theorem-oq-02-oq-01-oq-01-oq-02` has `leanFile.theoremCount: 9` but the Lean file contains only 8 theorem/lemma declarations.

## Evidence

**Before**: `leanFile.theoremCount: 9`
**After**: `leanFile.theoremCount: 8`

Actual declarations in `BinomialTheoremOQ02OQ01OQ01OQ02.lean` (8 total):
- Private lemmas: `entropy_term_nonneg`, `multinomial_zero_eq_one`, `multinomialProb_n1_indicator`
- Public theorems: `multinomialEntropy_nonneg`, `multinomialEntropy_zero_trials`, `multinomialEntropy_n1_eq_source`, `multinomialEntropy_upper_bound`, `multinomialEntropy_binomial`

The off-by-one was introduced in PR #15822, which proved `multinomialEntropy_n1_eq_source` (converting a sorry to a proof) and incremented theoremCount from 8→9. No new theorem declaration was added; the count should have remained 8. `meta.theoremCount` was already correctly 8; only `leanFile.theoremCount` needed updating.

---
Automated fix by lean-mechanic agent.