### PR TITLE
fix(meta): correct top-level sorries field type/value in 5 entries

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
@@ -141,5 +141,5 @@
     "sorryCount": 0,
     "sorries": 0
   },
-  "sorries": []
+  "sorries": 0
 }

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
@@ -115,5 +115,5 @@
       "Can the converse of irrational_of_degree_gt_one be proved: if \u03b1 is irrational and algebraic, does [\u211a(\u03b1):\u211a] > 1? (Yes, by definition of minimal polynomial degree \u2265 2 for irrational algebraic numbers.)"
     ]
   },
-  "sorries": []
+  "sorries": 0
 }

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
@@ -119,5 +119,5 @@
             "note": "If p | q and q ≠ 0 then natDegree p ≤ natDegree q"
         }
     ],
-    "sorries": []
+    "sorries": 0
 }

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -301,5 +301,5 @@
     "Proof of the 1-edge threshold gap via `omega`",
     "Definition of `completeBipartite` on `Fin m \u2295 Fin n` with adjacency between parts"
   ],
-  "sorries": 0
+  "sorries": 1
 }

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-01/meta.json
@@ -108,5 +108,5 @@
       "note": "eVariationOn, BoundedVariationOn, and Icc_add_Icc used in this proof"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Corrects the top-level `sorries` field in 5 gallery entries where the value was either the wrong type (array instead of number) or the wrong value.

The TypeScript schema defines `sorries?: number`. Having `sorries: []` causes `sorries === 0` comparisons in the UI (proof-badge.tsx, ErdosPage.tsx) to return false, silently hiding the "Complete" badge for zero-sorry proofs.

## Evidence

| Entry | Before | After | Reason |
|-------|--------|-------|--------|
| `bounded-prime-gaps-oq-01-oq-03` | `[]` | `0` | Type error: array instead of number |
| `cube-root-3-irrational-oq-02-oq-01` | `[]` | `0` | Type error: array instead of number |
| `cube-root-3-irrational-oq-02-oq-02` | `[]` | `0` | Type error: array instead of number |
| `fundamental-theorem-calculus-oq-01-oq-01` | `[]` | `0` | Type error: array instead of number |
| `erdos-1019` | `0` | `1` | Value error: meta.sorries=1 and leanFile.sorries=1 both confirm 1 sorry remains (K4_saturated_planar edge count, line 267) |

All other sorries fields (meta.sorries, leanFile.sorries) were already correct.

---
Automated fix by lean-mechanic agent.