### PR TITLE
fix(meta): sync meta.lineCount with lf.lineCount in 12 entries

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 220,
+    "lineCount": 208,
     "assumptions": "0 axioms, 0 sorries. All 3 sorries eliminated by importing proofs from CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean (namespace RieszSigmaFiniteComplete). The theorems have identical signatures; delegation via exact calls.",
     "dateAdded": "2026-05-03",
     "theoremCount": 5

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "None \u2014 fully verified. Depends on CubeRoot2IrrationalOQ03 for adjoin_nthRoot_finrank and related lemmas.",
-    "lineCount": 91,
+    "lineCount": 133,
     "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [

--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -43,7 +43,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
-    "lineCount": 216,
+    "lineCount": 215,
     "prerequisites": [
       "Polynomial interpolation (Lagrange basis)",
       "Trigonometric functions (Chebyshev nodes)",

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-03-29",
     "axiomCount": 3,
-    "lineCount": 499,
+    "lineCount": 232,
     "prerequisites": [
       "Covering systems and congruence classes",
       "Well-ordering principle for natural numbers",

--- a/src/data/proofs/erdos-395-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01-incomplete-01/meta.json
@@ -24,7 +24,7 @@
     "erdosProblemStatus": "open-question",
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
-    "lineCount": 119,
+    "lineCount": 118,
     "prerequisites": [
       "Erdős Problem #395 parent formalization",
       "Complex numbers and norms",

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -18,7 +18,7 @@
         "badge": "original",
         "sorries": 0,
         "axiomCount": 0,
-        "lineCount": 317,
+        "lineCount": 316,
         "theoremCount": 13,
         "definitionCount": 3,
         "assumptions": ""

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
         "dateAdded": "2026-05-03",
         "axiomCount": 0,
         "assumptions": "None. Fully machine-verified.",
-        "lineCount": 221,
+        "lineCount": 220,
         "theoremCount": 12,
         "originalContributions": [
             "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -74,7 +74,7 @@
       "de-rham",
       "research"
     ],
-    "lineCount": 1144,
+    "lineCount": 587,
     "prerequisites": [
       "Green's theorem for simply-connected regions (OQ-01, OQ-03)",
       "TypeI regions and iterated integrals",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -38,7 +38,7 @@
         "relationship": "Parent entry stating the Inverse Galois Problem and axiomatizing Shafarevich's theorem for solvable groups"
       }
     ],
-    "lineCount": 4822,
+    "lineCount": 723,
     "mathlib_version": "4.26.0",
     "theoremCount": 40
   },

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 240,
+    "lineCount": 244,
     "theoremCount": 15,
     "definitionCount": 0,
     "assumptions": "0 axioms, 0 sorries. Fully machine-verified.",

--- a/src/data/proofs/perfect-numbers-oq-03/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-03/meta.json
@@ -29,7 +29,7 @@
       "Small case computations: M(2), M(3), M(5), M(7) prime; M(1), M(4), M(11) composite"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 260,
+    "lineCount": 259,
     "theoremCount": 14,
     "definitionCount": 5,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
     "assumptions": "infinitely_many_wilson_primes: there are infinitely many Wilson primes — the main open conjecture (open since ~1900). Most theorems beyond the three known Wilson primes depend on this axiom.",
-    "lineCount": 124,
+    "lineCount": 123,
     "theoremCount": 9,
     "definitionCount": 3,
     "originalContributions": [


### PR DESCRIPTION
## Fix

Syncs `meta.lineCount` (the gallery-visible field) with `lf.lineCount` (the auditor-verified field) across 12 gallery entries. All `lf.lineCount` values were previously updated by audits to match the actual Lean files, but `meta.lineCount` remained stale.

## Evidence

| Entry | Before | After | Delta |
|-------|--------|-------|-------|
| `inverse-galois-oq-01` | 4822 | 723 | −4099 |
| `greens-theorem-oq-04` | 1144 | 587 | −557 |
| `erdos-2-oq-01` | 499 | 232 | −267 |
| `cube-root-3-irrational-oq-02-oq-01` | 91 | 133 | +42 |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` | 220 | 208 | −12 |
| `lebesgue-measure-oq-01-oq-03` | 240 | 244 | +4 |
| `erdos-1151` | 216 | 215 | −1 |
| `erdos-395-oq-01-incomplete-01` | 119 | 118 | −1 |
| `frobenius-number` | 317 | 316 | −1 |
| `fundamental-arithmetic-oq-01-oq-01` | 221 | 220 | −1 |
| `perfect-numbers-oq-03` | 260 | 259 | −1 |
| `wilsons-theorem-oq-01-oq-01` | 124 | 123 | −1 |

All new values verified against actual file line counts.

---
Automated fix by lean-mechanic agent.