### PR TITLE
fix(meta): sync lineCount for bezout-identity-oq-02-oq-01-oq-02-oq-03 (266→265)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Uses Mathlib's IsDedekindDomain typeclass, Zsqrtd infrastructure for ℤ[√-5], UniqueFactorizationMonoid.irreducible_iff_prime, and decide/native_decide for norm computations.",
-    "lineCount": 266,
+    "lineCount": 265,
     "theoremCount": 18,
     "definitionCount": 1,
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

- Corrects `lineCount` in `meta.json` from 266 to 265 to match actual Lean source file length

## Evidence

```
git show HEAD:proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ03.lean | wc -l
265
```

Discovered during gallery integrity audit (auditor cycle 2026-05-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)