### PR TITLE
fix(meta): sync definitionCount for 36 entries — align meta/lf with actual

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "",
     "lineCount": 234,
     "theoremCount": 3,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "originalContributions": [
       "IsMaxNorm: predicate for maximal normal subgroup H in K (relative normality + maximality)",
       "GroupQuotIso: quotient isomorphism predicate with Normal instance evidence",

--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 7,
     "lineCount": 242,
     "theoremCount": 8,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "assumptions": "7 axioms: ellipticK (function), ellipticE (function), K_eq_pi_div_2M (Gauss's AGM theorem for k=1/√2), legendre_relation (Legendre's relation for k=1/√2), ellipticE_agm (E via AGM iteration), bs_summable (series convergence from quadratic AGM convergence), S_lt_half (series sum bound). The algebraic derivation π = 4M²/(1-2S) is machine-verified from these axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -153,7 +153,7 @@
     "lineCount": 242,
     "axiomCount": 7,
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "path": "Proofs/AmgmInequalityOQ04OQ05.lean",
     "sorries": 0
   },

--- a/src/data/proofs/angle-trisection-oq-05-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-03/meta.json
@@ -165,7 +165,7 @@
     "lineCount": 272,
     "axiomCount": 0,
     "theoremCount": 21,
-    "definitionCount": 3,
+    "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ05OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "None. All axioms eliminated: fiber_card_uniform proved via fiberSwap bijection, uniformOn_fiber_transfer proved via cross-multiplication bijection showing |(MCS ∩ MSP)| · |CS| = |(CS ∩ SP)| · |MCS|.",
     "lineCount": 1047,
     "theoremCount": 40,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "originalContributions": [
       "projectToSign: projection from multi-candidate sequences to ±1 sequences",
       "prefixSumPreservation: prefix sums are preserved under projection (leadsAllCombined ↔ positive prefix sums)",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "lineCount": 2922,
     "theoremCount": 138,
-    "definitionCount": 31,
+    "definitionCount": 32,
     "originalContributions": [
       "northBeforeEast: key function counting North steps before the k-th East step (y-coordinate when entering column k)",
       "Crossing Lemma: fully proved — if P₁ starts lower but ends higher than P₂, they share a lattice point",

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -24,7 +24,7 @@
     "dateAdded": "2026-04-24",
     "lineCount": 192,
     "theoremCount": 10,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "mathlibDependencies": [
       {
         "theorem": "MvPolynomial.constantCoeff",

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Proved from first principles using Mathlib's Zsqrtd and EuclideanDomain infrastructure.",
     "lineCount": 323,
     "theoremCount": 20,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "originalContributions": [
       "norm_pos_of_ne_zero: N(z) > 0 for z ≠ 0 in ℤ[√-2] (key for Euclidean algorithm)",
       "normSq_div_sub_div_lt_one: rounding error has normSq ≤ 3/4 < 1 (tighter than ℤ[i]'s 1/2)",

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "3 axiom declarations: (1) BSD_rank2_Lderiv2: rank-2 BSD formula (L''(E,1)/2 = BSDConstant), encoding the strong BSD conjecture for rank-2 curves; (2) curve389a_second_L_derivative: the second L-derivative of 389a at s=1, whose existence is established by the Buhler-Gross-Zagier computation; (3) curve389a_BGZ_computation: bounds 0.7557 < L''(389a,1)/2 < 0.7558, from the numerical verification of Buhler-Gross-Zagier (1985). The main BSD axioms (analyticRank, L-function, regulator positivity) are inherited from the parent BirchSwinnertonDyer.lean.",
     "lineCount": 273,
     "theoremCount": 27,
-    "definitionCount": 2
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Curve 389a1 (Cremona label) — the elliptic curve y² + y = x³ + x² - 2x — holds the distinction of being the smallest-conductor elliptic curve with algebraic rank 2 (conductor N = 389, a prime). Established by Cremona's systematic enumeration of elliptic curves by conductor. The Birch and Swinnerton-Dyer conjecture predicts a deep relationship between the arithmetic structure of the curve (Mordell-Weil group, regulator, Shafarevich-Tate group) and the analytic behavior of its L-function L(E, s) at s = 1. For a rank-2 curve, L(E, 1) = L'(E, 1) = 0, and BSD predicts: L''(E, 1)/2 = Ω · R · |Ш| · ∏cₚ / |tors|². Buhler, Gross, and Zagier (Math. Comp. 44, 1985) computed L''(389a, 1) to high precision and confirmed that L''(389a, 1)/2 ≈ 0.7558 matches the predicted value 4.959 × 0.1524 × 1 × 1 / 1 ≈ 0.7558, providing the first explicit numerical verification of BSD for a rank-2 curve.",

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -38,7 +38,7 @@
     "axiomCount": 1,
     "lineCount": 519,
     "theoremCount": 15,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Nash's original 1950 proof of equilibrium existence occupies only a paragraph in his 2-page PNAS paper. The key idea: define a continuous map on the product of mixed strategy simplices whose fixed points are Nash equilibria. Each player shifts weight toward pure strategies that offer improvement over their current mixed strategy. The normalization ensures the result is a valid mixed strategy. Brouwer's fixed point theorem guarantees a fixed point, and the algebra of the fixed-point equation implies all players are in equilibrium. Nash later gave a Kakutani-based proof in his 1951 Annals paper, but the Brouwer version is more direct and avoids upper hemicontinuity.",

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "2 structure-encoded assumptions in AngularAverageData: angularAvg_eq (the angular average on RP^{n-1} is proportional to norm with constant sigma_{n-2}/(n-1)), angularAvg_nonneg (non-negativity). These encode integration on the unit sphere which Mathlib lacks.",
     "lineCount": 394,
     "theoremCount": 25,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "originalContributions": [
       "sphereArea: sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) with n=0,1,2 computed",
       "cauchyCroftonConst: c_n = 2*sigma_{n-2}/((n-1)*sigma_{n-1})",

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-04-04",
     "lineCount": 404,
     "theoremCount": 18,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "ZMod.addOrderOf_coe",

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "ClassicalRiceModel encodes 2 mathematical assumptions as structure fields: (1) h_compile — every behavior has a canonical code (universality); (2) kleene_rec — Kleene's recursion theorem (every code transformer has a semantic fixed point). These are hypotheses to classical_rice_abstract, not global Lean axioms. The 5 abstract theorems (abstract_rice through no_halting_model) are fully axiom-free.",
     "lineCount": 275,
     "theoremCount": 8,
-    "definitionCount": 4,
+    "definitionCount": 3,
     "originalContributions": [
       "abstract_rice: no Bool-evaluation structure can be point-surjective (direct from Lawvere)",
       "rice_induced_obstruction: any d : Val → Bool applied to a point-surjective structure gives a non-surjective Bool structure",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "None. Fully verified from Mathlib.",
     "lineCount": 272,
     "theoremCount": 10,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "originalContributions": [
       "sin_is_odd: sin(-x) = -sin(x) — key for signed spherical arc length ratios",
       "sin_pos_of_proper_arc: sin > 0 for arc lengths in (0,π)",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 301,
     "theoremCount": 13,
-    "definitionCount": 4,
+    "definitionCount": 3,
     "originalContributions": [
       "HyperbolicCevianConfig: cevian weight structure (α, β) with sinh distance model",
       "hyp_sinh_BD / hyp_sinh_DC: sinh distance ratios for cevian points in hyperboloid model",

--- a/src/data/proofs/collatz-cycles-oq-04/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-04/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 209,
     "theoremCount": 13,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "originalContributions": [
       "CycleConfig structure: encodes j-step Collatz cycle with odd elements, halving counts, and step relation 2^mᵢ · n_{i+1} = 3nᵢ + 1",
       "cycle_product_equation: ∏ᵢ(3nᵢ+1) = 2^M · ∏ᵢnᵢ via cyclic permutation (σ is bijection on Fin j)",

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -150,7 +150,7 @@
         "lineCount": 297,
         "axiomCount": 0,
         "theoremCount": 30,
-        "definitionCount": 2,
+        "definitionCount": 12,
         "path": "Proofs/DesarguesTheoremOQ01OQ01.lean",
         "sorries": 0
     },

--- a/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "lineCount": 440,
     "theoremCount": 29,
-    "definitionCount": 4,
+    "definitionCount": 3,
     "originalContributions": [
       "root_in_cauchy_interval: all real roots lie in (-cauchyBound p, cauchyBound p)",
       "no_pos_roots_of_zero_variations: if signVariations(p.coeffList) = 0, no positive roots",

--- a/src/data/proofs/erdos-1009-oq-01/meta.json
+++ b/src/data/proofs/erdos-1009-oq-01/meta.json
@@ -128,7 +128,7 @@
     "axiomCount": 3,
     "lineCount": 160,
     "sorries": 0,
-    "definitionCount": 3
+    "definitionCount": 4
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "2 axioms: infinitely_many_in_each_class (infinitely many primes per class, OPEN), class_density_subpolynomial (class-r primes have n^o(1) density, known but hard to formalize). The competing Erdős (p_r^{1/r} → ∞) and Selfridge (p_r^{1/r} bounded) conjectures are stated as defs with a proved mutual exclusivity theorem.",
     "lineCount": 254,
     "theoremCount": 35,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "mathlib_version": "4.26.0",
     "relatedProblems": [
       {

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -226,7 +226,7 @@
     "lineCount": 709,
     "axiomCount": 0,
     "theoremCount": 28,
-    "definitionCount": 5,
+    "definitionCount": 7,
     "sorries": 0,
     "path": "Proofs/Erdos1179OQ01.lean"
   }

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "assumptions": "0 axioms. All 13 theorems fully proved including selfridge_example (explicit {0 mod 2, 1 mod 4, 3 mod 4} construction), covering_reciprocal_sum (LCM/product counting argument), difficulty_even_coverage, min_modulus_ge_4, moduli_even, and the easyPrimes reciprocal sum bounds. Open conjecture; supporting lemmas fully verified.",
     "lineCount": 303,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -55,7 +55,7 @@
     "dateAdded": "2026-03-30",
     "lineCount": 365,
     "theoremCount": 11,
-    "definitionCount": 8,
+    "definitionCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/herons-formula-oq-04/meta.json
+++ b/src/data/proofs/herons-formula-oq-04/meta.json
@@ -45,7 +45,7 @@
     "dateAdded": "2026-04-04",
     "lineCount": 362,
     "theoremCount": 15,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "prerequisites": [
       "Heron's formula for triangles",
       "Three-variable AM-GM inequality",

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "0 sorries, 0 axioms. All 7 Fano upper-triangular residuals (F43, F53, F63, F65, F73, F75, F76) in derEval14_injective were closed by PR #13632 via explicit Fano-line Leibniz proofs using fin_cases, simp, antisymmetry constraints, and linarith. G2_der_dimension is a proved theorem (not an axiom): finrank ℝ Der(𝕆) = 14 via upper bound (injective derEval14 map) and lower bound (derBasis14_linearIndependent, proved in PR #13121).",
     "lineCount": 1646,
     "theoremCount": 27,
-    "definitionCount": 19,
+    "definitionCount": 31,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
       "alg_aut_preserves_norm: automorphisms preserve the norm (proved via polarization and imaginary decomposition)",
@@ -140,7 +140,7 @@
     "lineCount": 1646,
     "axiomCount": 0,
     "theoremCount": 65,
-    "definitionCount": 15,
+    "definitionCount": 31,
     "sorries": 0,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },

--- a/src/data/proofs/inverse-galois-oq-06/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "1 axiom: three_dvd_gal_card — 3 divides |Gal(q/ℚ)|. This follows from Dedekind's theorem applied to q mod 7 (which factors as (1-cycle)(1-cycle)(3-cycle)), implying the Galois group contains an element of order divisible by 3. Axiomatized because Mathlib lacks Dedekind's theorem for polynomial Galois groups.",
     "lineCount": 2067,
     "theoremCount": 85,
-    "definitionCount": 7,
+    "definitionCount": 12,
     "originalContributions": [
       "q: the polynomial x⁵-5x⁴+10x³-10x²+25x-5 (translate of x⁵+20x+16)",
       "q_eisenstein: q satisfies Eisenstein's criterion at p=5 (PROVED, hence irreducible over ℚ)",
@@ -88,7 +88,7 @@
     "lineCount": 2067,
     "axiomCount": 1,
     "theoremCount": 85,
-    "definitionCount": 8,
+    "definitionCount": 12,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0
   },

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
         "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer's algorithm for directed graph Eulerian circuit — requires graph connectivity infrastructure) and directed_euler_path_iff (Eulerian path degree characterization). All other results (handshaking, necessity, concrete examples, consequences) are proved from first principles.",
         "lineCount": 848,
         "theoremCount": 12,
-        "definitionCount": 8,
+        "definitionCount": 13,
         "originalContributions": [
             "sum_outDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.1=v}| = |E| by double-counting via Finset.sum_comm + Finset.sum_ite_eq'",
             "sum_inDegree_eq_edgeCount: proved from first principles — ∑_v |{e: e.2=v}| = |E| by same double-counting argument",
@@ -129,7 +129,7 @@
         "lineCount": 848,
         "axiomCount": 2,
         "theoremCount": 25,
-        "definitionCount": 10,
+        "definitionCount": 13,
         "path": "Proofs/KonigsbergOQ01OQ02.lean",
         "sorries": 6
     },

--- a/src/data/proofs/lagrange-four-squares-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 651,
     "theoremCount": 105,
-    "definitionCount": 17,
+    "definitionCount": 16,
     "originalContributions": [
       "RepresentationType: structure encoding the multiplicity pattern and sign of a 4-tuple (a,b,c,d)",
       "trivialType: type (0,0,0,k) with contribution 8 (proved for all k>0)",

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-03-30",
     "lineCount": 206,
     "theoremCount": 9,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "lineCount": 228,
     "theoremCount": 6,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "assumptions": "None.",
     "originalContributions": [
       "Dimension-independent proof of the chord quadratic equation in any real inner product space",

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -52,7 +52,7 @@
     ],
     "lineCount": 288,
     "theoremCount": 8,
-    "definitionCount": 2
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Ptolemy's theorem (c. 150 AD) states that for a cyclic quadrilateral ABCD in convex position, AC·BD = AB·CD + BC·DA. The question of whether equality alone characterizes concyclic order — the *converse* — was implicit in Ptolemy's work but requires careful proof. In modern terms, it follows from the cross-ratio characterization: for four points on a circle, the cross-ratio R = (z₂-z₃)(z₁-z₄)/((z₁-z₂)(z₃-z₄)) is always real, and R > 0 precisely when the points are in CCW or CW order. This file provides the Lean 4 formalization of the converse direction, completing the full biconditional characterization.",

--- a/src/data/proofs/rh-consequences/meta.json
+++ b/src/data/proofs/rh-consequences/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "9 axioms for classical RH consequences: rh_implies_mertens_bound (|M(x)| = O(√x)), lis_criterion (LI series criterion), riemann_von_mangoldt_formula, RH_implies_DensityHypothesis, rh_implies_psi_bound, explicit_formula_error, zeta_in_selberg_class, explicit_formula_zero_free, hadamard_product_exists. These are known results not yet formalized in Mathlib.",
     "lineCount": 1735,
     "theoremCount": 122,
-    "definitionCount": 7,
+    "definitionCount": 17,
     "originalContributions": [
       "mertens: Mertens function M(n) = Σ_{k≤n} μ(k) (defined and computed for n up to 100)",
       "chebyshevTheta: θ(x) = Σ_{p≤x prime} log p",
@@ -73,7 +73,7 @@
     "lineCount": 1735,
     "axiomCount": 9,
     "theoremCount": 122,
-    "definitionCount": 9,
+    "definitionCount": 17,
     "path": "Proofs/RiemannHypothesisConsequences.lean",
     "sorries": 0
   },

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -47,7 +47,7 @@
     "dateAdded": "2026-03-30",
     "lineCount": 341,
     "theoremCount": 11,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/spherical-law-of-cosines/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 341,
     "theoremCount": 24,
-    "definitionCount": 9,
+    "definitionCount": 8,
     "originalContributions": [
       "IsUnitVec predicate and inner product properties: inner_unit_self, inner_unit_le_one, inner_unit_ge_neg_one",
       "arcLength definition via Real.arccos and properties: nonneg, le_pi, cos_arcLength recovery theorem, self-distance, symmetry",

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 323,
     "theoremCount": 21,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "originalContributions": [
       "dot, normSq, arcLen, tripleProduct, projPerp definitions using Fin 3 → ℝ framework (compatible with Mathlib's crossProduct)",
       "Lagrange's identity: |u×v|² = |u|²|v|² − (u·v)², proved via simp+ring over Fin.sum_univ_three",

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified using Mathlib's ArithmeticFunction.sigma.",
     "lineCount": 549,
     "theoremCount": 81,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "originalContributions": [
       "IsDeficient / IsPerfect / IsAbundant: classification predicates (new definitions)",
       "six_is_perfect / twenty_eight_is_perfect: first two perfect numbers verified",

--- a/src/data/proofs/sylow-theorem-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-01/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 387,
     "theoremCount": 21,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "originalContributions": [
       "cyclic_of_both_sylow_normal: full original proof that normal Sylow subgroups of coprime order make G cyclic",
       "sylow_q_count_constraint: explicit derivation of n_q | p and n_q ≡ 1 (mod q) for pq-groups",


### PR DESCRIPTION
## Fix

Corrects `definitionCount` discrepancies across 36 gallery entries. All counts verified against actual Lean source files (counting `def`, `abbrev`, and `opaque` declarations after stripping comments).

Three categories of fixes:

**Category 1 — meta stale, lf correct (27 entries):**
meta.definitionCount lagged behind already-correct lf.definitionCount.

| Entry | Before | After |
|-------|--------|-------|
| `abel-ruffini-galois-extensions-oq-04` | meta=3 | meta=2 |
| `ballot-problem-oq-01-oq-02` | meta=18 | meta=19 |
| `ballot-problem-oq-03-oq-01` | meta=31 | meta=32 |
| `bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01` | meta=3 | meta=4 |
| `bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03` | meta=3 | meta=2 |
| `birch-swinnerton-dyer-oq-06` | meta=2 | meta=1 |
| `brouwer-fixed-point-oq-04-oq-02` | meta=8 | meta=9 |
| `buffons-needle-oq-01-oq-01-oq-04` | meta=5 | meta=4 |
| `burnside-counting-oq-03` | meta=2 | meta=1 |
| `cantor-diagonalization-oq-03-oq-01-oq-02` | meta=4 | meta=3 |
| `cevas-theorem-non-euclidean-oq-02-oq-01` | meta=2 | meta=1 |
| `cevas-theorem-oq-02-oq-01-oq-02` | meta=4 | meta=3 |
| `collatz-cycles-oq-04` | meta=3 | meta=2 |
| `descartes-rule-of-signs-oq-03` | meta=4 | meta=3 |
| `erdos-1055` | meta=4 | meta=5 |
| `erdos-273` | meta=7 | meta=6 |
| `fundamental-theorem-calculus-oq-02` | meta=8 | meta=7 |
| `herons-formula-oq-04` | meta=3 | meta=2 |
| `lagrange-four-squares-oq-02` | meta=17 | meta=16 |
| `picks-theorem-oq-01` | meta=3 | meta=2 |
| `product-of-segments-of-chords-oq-01` | meta=2 | meta=1 |
| `ptolemys-theorem-oq-01-oq-01` | meta=2 | meta=1 |
| `shannon-entropy-oq-03` | meta=5 | meta=6 |
| `spherical-law-of-cosines` | meta=9 | meta=8 |
| `spherical-law-of-sines` | meta=6 | meta=7 |
| `sum-of-divisors` | meta=4 | meta=5 |
| `sylow-theorem-oq-01` | meta=3 | meta=2 |

**Category 2 — lf wrong, meta correct (4 entries):**

| Entry | lf.definitionCount | Corrected |
|-------|---------------------|-----------|
| `angle-trisection-oq-05-oq-03` | 3 → 1 | |
| `desargues-theorem-oq-01-oq-01` | 2 → 12 | |
| `erdos-1009-oq-01` | 3 → 4 | |
| `erdos-1179-oq-01` | 5 → 7 | |

**Category 3 — both wrong (5 entries):**

| Entry | meta before | lf before | Actual |
|-------|-------------|-----------|--------|
| `amgm-inequality-oq-04-oq-05` | 5 | 3 | 6 |
| `hurwitz-theorem-oq-04` | 19 | 15 | 31 |
| `inverse-galois-oq-06` | 7 | 8 | 12 |
| `konigsberg-oq-01-oq-02` | 8 | 10 | 13 |
| `rh-consequences` | 7 | 9 | 17 |

---
Automated fix by lean-mechanic agent.