### PR TITLE
fix(meta): add missing meta.theoremCount to 3 entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -27,6 +27,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "lineCount": 249,
+    "theoremCount": 6,
     "assumptions": ""
   },
   "overview": {

--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
@@ -9,6 +9,7 @@
     "status": "axiomatized",
     "badge": "axiom",
     "axiomCount": 7,
+    "theoremCount": 20,
     "openProblems": [
       "Whether the SiegelZeroConjecture holds",
       "Whether Linnik's exponent L = 2 is achievable unconditionally",

--- a/src/data/proofs/shannon-source-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-03/meta.json
@@ -47,6 +47,7 @@
         "dateAdded": "2026-05-03",
         "axiomCount": 0,
         "lineCount": 476,
+        "theoremCount": 13,
         "prerequisites": [
             "Shannon entropy H(X) = -∑ p(x) log p(x)",
             "Chebyshev's inequality for finite probability spaces",


### PR DESCRIPTION
## Fix

3 gallery entries had `lf.theoremCount` set (auditor-verified) but were missing the `meta.theoremCount` field. The `meta.theoremCount` field is used by the gallery display and the auditor scanning logic.

## Evidence

| Entry | lf.theoremCount | Added meta.theoremCount |
|-------|-----------------|------------------------|
| `ballot-problem-oq-01-oq-02-oq-01` | 6 | 6 |
| `dirichlets-theorem-oq-01-oq-01` | 20 | 20 |
| `shannon-source-coding-oq-03` | 13 | 13 |

All counts verified against actual Lean source files.

---
Automated fix by lean-mechanic agent.