### PR TITLE
fix(cantor-oq-04): correct iff_not_self.mp → iff_not_self

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean
@@ -87,8 +87,8 @@ theorem cantor_constructive {A : Type*} (e : A → A → Prop)
   obtain ⟨d, hd⟩ := he (fun a => ¬e a a)
   -- Step 2: Specialize to x = d to get the self-referential Iff
   have hdd : e d d ↔ ¬e d d := hd d
-  -- Step 3: Direct contradiction — no propext needed
-  exact iff_not_self.mp hdd
+  -- Step 3: Direct contradiction — iff_not_self : ¬(p ↔ ¬p)
+  exact iff_not_self hdd
 
 /-- **Cantor No-Surjection (Constructive)**:
 
@@ -147,8 +147,7 @@ example : True := trivial  -- placeholder comment anchor
 
 -- The constructive theorems use NO non-constructive axioms:
 #print axioms cantor_constructive
--- Expected: no axioms beyond 'propext', 'Quot.sound', 'Classical.choice'
--- (These are Lean 4 kernel axioms — cantor_constructive uses none of them.)
+-- Expected output: 'cantor_constructive' does not depend on any axioms
 
 #print axioms cantor_constructive_explicit
 -- Same: uses no axioms


### PR DESCRIPTION
## Summary

Fixes a type error in #15908 (cantor-diagonalization-oq-03-oq-01-oq-04).

`iff_not_self : ¬(p ↔ ¬p)` is a negation (function type), not an `Iff`.
The merged code used `exact iff_not_self.mp hdd` which would fail with a type error.
The correct call is `exact iff_not_self hdd` (applying the negation directly to `hdd : e d d ↔ ¬e d d`).

The `cantor_constructive_explicit` theorem in the same file already used the correct
explicit form and is unaffected.

## Test plan

- [ ] Docker build for `Proofs.CantorDiagonalizationOQ03OQ01OQ04` succeeds after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)