### PR TITLE
fix(meta): sync lineCount/theoremCount for cantor-diag-oq-03-oq-01-oq-04 and eqr-oq-02-oq-01

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 176,
     "dateAdded": "2026-05-05",
     "assumptions": "None. Uses only Lean 4 core type theory (no propext, funext, or Classical.choice).",
     "mathlib_version": "4.26.0",
@@ -38,7 +38,7 @@
       "surjective_implies_pointwise: classical surjectivity implies constructive surjectivity (one direction only)",
       "cantor_recovery_from_constructive: classical cantor_recovery derived from constructive version"
     ],
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "sections": [
@@ -134,9 +134,9 @@
       "Mathlib.Tactic"
     ],
     "namespace": "CantorDiagonalizationOQ03OQ01OQ04",
-    "lineCount": 163,
+    "lineCount": 176,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-05-05",
     "axiomCount": 0,
     "assumptions": "None. This proof uses only Mathlib theorems: gaussSum_sq, quadraticChar_isQuadratic, quadraticChar_ne_one, ZMod.isPrimitive_stdAddChar, legendreSym.at_neg_one, χ₄_eq_neg_one_pow.",
-    "lineCount": 122,
+    "lineCount": 199,
     "theoremCount": 5,
     "definitionCount": 1,
     "originalContributions": [
@@ -37,7 +37,7 @@
   "leanFile": {
     "namespace": "GaussSumQRCyclotomic",
     "path": "Proofs/ElementaryQuadraticReciprocityOQ02OQ01.lean",
-    "lineCount": 122,
+    "lineCount": 199,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Syncs stale metadata for two gallery entries where research PRs updated the Lean files without updating meta.json.

## Evidence

**cantor-diagonalization-oq-03-oq-01-oq-04** (closes #15915):

| Field | Before | After |
|-------|--------|-------|
| `meta.lineCount` | 163 | 176 |
| `meta.theoremCount` | 9 | 8 |
| `leanFile.lineCount` | 163 | 176 |
| `leanFile.theoremCount` | 9 | 8 |

File grew to 176 lines in PR #15908. The count of 9 incorrectly included `example : True := trivial` (a placeholder, not a theorem). The 8 actual named theorems are: `surjective_implies_pointwise`, `cantor_constructive`, `cantor_no_pointwise_surjection`, `cantor_recovery_from_constructive`, `cantor_constructive_explicit`, `eq_not_pointwise_surjective`, `bool_not_pointwise_surjective`, `nat_not_pointwise_surjective`.

**elementary-quadratic-reciprocity-oq-02-oq-01** (addresses #15916, lineCount only):

| Field | Before | After |
|-------|--------|-------|
| `meta.lineCount` | 122 | 199 |
| `leanFile.lineCount` | 122 | 199 |
| `meta.theoremCount` | 5 | 5 (unchanged) |
| `leanFile.theoremCount` | 5 | 5 (unchanged) |

File grew to 199 lines in PR #15909. theoremCount=5 is **correct**: 4 public theorems + 1 `private lemma char_ZMod_ne_two`, per the private/protected inclusion convention established in PR #15867 and #15882. The auditor's recommendation of 4 would exclude the private lemma, which is contrary to established convention.

---
Automated fix by lean-mechanic agent.