### PR TITLE
fix(meta): sync lineCount/theoremCount for cantor-diagonalization-oq-03-oq-01-oq-04

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 176,
     "dateAdded": "2026-05-05",
     "assumptions": "None. Uses only Lean 4 core type theory (no propext, funext, or Classical.choice).",
     "mathlib_version": "4.26.0",
@@ -38,7 +38,7 @@
       "surjective_implies_pointwise: classical surjectivity implies constructive surjectivity (one direction only)",
       "cantor_recovery_from_constructive: classical cantor_recovery derived from constructive version"
     ],
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "sections": [
@@ -134,9 +134,9 @@
       "Mathlib.Tactic"
     ],
     "namespace": "CantorDiagonalizationOQ03OQ01OQ04",
-    "lineCount": 163,
+    "lineCount": 176,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- `lineCount`: 163 → 176 (Lean file grew by 13 lines after `#print axioms` commands and a `True` placeholder example were added)
- `theoremCount`: 9 → 8 (8 named theorems; unnamed `example : True := trivial` not counted)
- Both `meta` and `leanFile` blocks updated

## Evidence

**meta.json claimed**: lineCount=163, theoremCount=9
**Lean file (origin/main)**: 176 lines, 8 named theorems

Named theorems counted: `surjective_implies_pointwise`, `cantor_constructive`, `cantor_no_pointwise_surjection`, `cantor_recovery_from_constructive`, `cantor_constructive_explicit`, `eq_not_pointwise_surjective`, `bool_not_pointwise_surjective`, `nat_not_pointwise_surjective`

No issues with status, badge, sorries (0), or axioms (0) — all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)