### PR TITLE
fix(meta): sync lineCount for elementary-quadratic-reciprocity-oq-02-oq-01

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-05-05",
     "axiomCount": 0,
     "assumptions": "None. This proof uses only Mathlib theorems: gaussSum_sq, quadraticChar_isQuadratic, quadraticChar_ne_one, ZMod.isPrimitive_stdAddChar, legendreSym.at_neg_one, χ₄_eq_neg_one_pow.",
-    "lineCount": 122,
+    "lineCount": 199,
     "theoremCount": 5,
     "definitionCount": 1,
     "originalContributions": [
@@ -37,7 +37,7 @@
   "leanFile": {
     "namespace": "GaussSumQRCyclotomic",
     "path": "Proofs/ElementaryQuadraticReciprocityOQ02OQ01.lean",
-    "lineCount": 122,
+    "lineCount": 199,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1,


### PR DESCRIPTION
## Summary

- `lineCount`: 122 → 199 (both `meta` and `leanFile` blocks)

## Evidence

The Lean file grew from 122 to 199 lines after initial meta.json generation (77 lines added: detailed proof content and 3 unnamed verification examples for p=3,5,7).

**meta.json claimed**: lineCount=122
**Lean file (origin/main)**: 199 lines

All other fields verified correct: status=verified, badge=original, sorries=0, axiomCount=0, theoremCount=5 (4 public + 1 private lemma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)