### PR TITLE
enrich(fundamental-theorem-calculus-oq-01-oq-01): add annotations.json with 6 deep annotations

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-01/annotations.json
@@ -1,1 +1,136 @@
-[]
+[
+  {
+    "id": "ann-ftc-oq01-header",
+    "proofId": "fundamental-theorem-calculus-oq-01-oq-01",
+    "range": { "startLine": 23, "endLine": 35 },
+    "type": "context",
+    "title": "Module Setup: AC → BV in Lean 4",
+    "content": "The module imports:\n1. `Proofs.FundamentalTheoremCalculusLebesgue` — the parent file containing `AbsolutelyContinuousOn` (ε-δ definition) and the Lebesgue FTC statement\n2. `Mathlib.Analysis.BoundedVariation` — provides `eVariationOn`, `BoundedVariationOn`, and `eVariationOn.Icc_add_Icc`\n3. `Mathlib.Topology.EMetricSpace.BoundedVariation` — extended metric space version for `edist`\n\nThe `open` declarations bring into scope: `FTCLebesgue` (parent namespace), `Set` (for `Icc`, `mem_Icc`), `ENNReal` (for `ofReal`, arithmetic), `Finset` (for sums). The `maxHeartbeats 800000` setting is needed for the longer proofs in this file — the default heartbeat limit would time out.\n\nThis file answers OQ-01 from `fundamental-theorem-calculus-oq-01`: the implication Absolutely Continuous → Bounded Variation can indeed be proved from scratch using Mathlib's `eVariationOn` infrastructure.",
+    "mathContext": "The chain connecting this result to the Lebesgue FTC: $\\mathrm{AC} \\Rightarrow \\mathrm{BV}$ (this file) $\\Rightarrow$ Jordan decomposition ($f = g - h$ with $g, h$ monotone) $\\Rightarrow$ $f' $ exists a.e. $\\Rightarrow$ $\\int_a^b f'(x)dx = f(b) - f(a)$ (Lebesgue FTC). The `eVariationOn` function $V_f[a,b] = \\sup \\sum_{k} d(f(u_{k+1}), f(u_k))$ is defined as a supremum over all monotone sequences in $[a,b]$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "AbsolutelyContinuousOn",
+      "eVariationOn",
+      "BoundedVariationOn",
+      "Lebesgue FTC chain",
+      "maxHeartbeats"
+    ],
+    "prerequisites": [
+      "absolute continuity (ε-δ definition)",
+      "bounded variation (eVariationOn)",
+      "ENNReal (extended non-negative reals)"
+    ]
+  },
+  {
+    "id": "ann-ftc-oq01-edist",
+    "proofId": "fundamental-theorem-calculus-oq-01-oq-01",
+    "range": { "startLine": 36, "endLine": 52 },
+    "type": "technique",
+    "title": "Lemma 1 & 2: edist Identity and eVariationOn Upper Bound Criterion",
+    "content": "**`edist_real_ofReal`**: On ℝ, `edist x y = ENNReal.ofReal |x - y|`. Proof: `edist_dist + Real.dist_eq` — combining the fact that edist on ℝ equals its distance function, and the distance function is |x-y|. This bridging lemma converts between edist (extended metric space) and ENNReal.ofReal (which handles real-valued absolute differences).\n\n**`eVariationOn_le_of_forall`**: The key upper-bound criterion: if for every monotone sequence `u` in `s`, the partition sum `∑ edist(f(u(i+1)), f(u(i)))` is ≤ C, then `eVariationOn f s ≤ C`. Proof: unfold `eVariationOn` as a supremum over pairs (n, u), then apply `iSup_le` — to bound a supremum, it suffices to bound every value it takes.\n\nThis lemma encapsulates the universal quantifier hidden in the `iSup`: instead of directly manipulating `iSup`, callers can provide a universal bound and let `iSup_le` do the work. It is the technical heart of how local AC bounds propagate to global variation bounds.",
+    "mathContext": "The `eVariationOn` definition (Mathlib): $V_f[s] = \\sup_{n, u} \\sum_{i<n} d(f(u_{i+1}), f(u_i))$ where the sup is over all $n$ and all monotone $u : \\mathbb{N} \\to s$. The proof of `eVariationOn_le_of_forall` uses `iSup_le` (if every term in a sup is ≤ C, then the sup is ≤ C). The `rintro ⟨n, ⟨u, hu, hus⟩⟩` pattern destructures the supremum index: each index is a pair of a length `n` and a monotone sequence `u` with `u i ∈ s`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "iSup_le",
+      "edist and ENNReal.ofReal",
+      "eVariationOn definition",
+      "monotone sequences"
+    ],
+    "prerequisites": [
+      "edist_dist",
+      "Real.dist_eq",
+      "iSup in OrderedSemiring",
+      "ENNReal.ofReal"
+    ]
+  },
+  {
+    "id": "ann-ftc-oq01-telescoping",
+    "proofId": "fundamental-theorem-calculus-oq-01-oq-01",
+    "range": { "startLine": 53, "endLine": 63 },
+    "type": "technique",
+    "title": "Lemma 3: Telescoping Sum for Fin n",
+    "content": "`fin_telescoping`: $\\sum_{k < n} (u(k+1) - u(k)) = u(n) - u(0)$ for any $u : \\mathbb{N} \\to \\mathbb{R}$.\n\nThe proof is by induction on `n`:\n- Base (`n=0`): empty sum = 0 = u(0) - u(0), by `simp`.\n- Step (`n = m+1`): Use `Fin.sum_univ_castSucc` to peel off the last term `(u(m+1) - u(m))`, then the IH gives the sum over `Fin m` equals `u(m) - u(0)`. Adding: `(u(m) - u(0)) + (u(m+1) - u(m)) = u(m+1) - u(0)` by `linarith`.\n\nThe telescoping sum is used in `eVariationOn_le_one_of_short`: the total length of a partition `[u(0), u(1)], ..., [u(n-1), u(n)]` equals `∑ (u(k+1) - u(k)) = u(n) - u(0) ≤ d - c < δ`. This single inequality is what allows applying the AC condition to the whole partition.",
+    "mathContext": "$\\sum_{k=0}^{n-1}(u_{k+1} - u_k) = u_n - u_0$ (telescoping series). The Lean proof uses `Fin.sum_univ_castSucc` which rewrites $\\sum_{k : \\mathrm{Fin}(n+1)} f(k) = (\\sum_{k : \\mathrm{Fin}\\, n} f(\\mathrm{castSucc}(k))) + f(\\mathrm{last}\\, n)$, separating the last term. The `linarith` at the end performs the arithmetic $u(m) - u(0) + u(m+1) - u(m) = u(m+1) - u(0)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "telescoping series",
+      "Fin.sum_univ_castSucc",
+      "Finset.sum induction",
+      "partition length bound"
+    ],
+    "prerequisites": [
+      "Fin type in Lean 4",
+      "Finset.sum",
+      "induction tactic",
+      "linarith for arithmetic"
+    ]
+  },
+  {
+    "id": "ann-ftc-oq01-short-interval",
+    "proofId": "fundamental-theorem-calculus-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 93 },
+    "type": "insight",
+    "title": "Key Lemma: Short Intervals Have Variation ≤ 1",
+    "content": "**`eVariationOn_le_one_of_short`**: If `[c,d]` has length `d-c < δ` (the AC modulus), then `eVariationOn F (Icc c d) ≤ 1`.\n\nThis is the central lemma — it converts the AC condition on short intervals into a variation bound. The proof applies `eVariationOn_le_of_forall`, reducing to: for every monotone sequence `u` in `[c,d]` of length `n`, the partition sum `∑ edist(F(u(i+1)), F(u(i))) ≤ 1`.\n\n**The AC application**: given the AC condition `hac` (with parameter δ), we construct the intervals `[u(k), u(k+1)]` for k < n as disjoint intervals in `[a,b]`. Their total length is `∑(u(k+1)-u(k)) = u(n)-u(0) ≤ d-c < δ` (telescoping sum). The AC condition then gives `∑|F(u(k+1))-F(u(k))| < 1`.\n\n**The ENNReal conversion**: The sum `∑ edist(F(u(i+1)), F(u(i)))` is in `ℝ≥0∞`. Using `edist_real_ofReal` to convert each edist, then `ENNReal.ofReal_sum_of_nonneg` to convert the sum, and `ENNReal.ofReal_le_ofReal` to convert the inequality, we reduce to the real-valued bound from AC.\n\nNote the disjointness condition: `∀ j k, j ≠ k → bs j ≤ as k ∨ bs k ≤ as j` — this encodes that the intervals `[u(k), u(k+1)]` are disjoint (as `[as k, bs k]` pairs). Since `u` is monotone, consecutive intervals are disjoint: `u(k+1) ≤ u(k+1)` trivially gives `bs j = u(j+1) ≤ u(k) = as k` when `j < k`.",
+    "mathContext": "The AC condition: $\\forall n, \\forall$ disjoint intervals $[a_k, b_k] \\subset [a,b]$ with $\\sum (b_k - a_k) < \\delta$, we have $\\sum |F(b_k) - F(a_k)| < 1$. Applied to partition intervals $[u(k), u(k+1)]$: total length $\\sum (u(k+1) - u(k)) = u(n) - u(0) \\leq d - c < \\delta$, so $\\sum |F(u(k+1)) - F(u(k))| < 1$. Converting via $\\mathrm{ofReal}$: $\\sum \\mathrm{edist}(F(u(k+1)), F(u(k))) \\leq 1 \\in \\mathbb{R}_{\\geq 0}^\\infty$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "AbsolutelyContinuousOn",
+      "eVariationOn_le_of_forall",
+      "ENNReal.ofReal_sum_of_nonneg",
+      "disjoint intervals",
+      "telescoping sum"
+    ],
+    "prerequisites": [
+      "AbsolutelyContinuousOn (ε-δ definition)",
+      "eVariationOn_le_of_forall",
+      "fin_telescoping",
+      "ENNReal arithmetic"
+    ]
+  },
+  {
+    "id": "ann-ftc-oq01-inductive",
+    "proofId": "fundamental-theorem-calculus-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 133 },
+    "type": "technique",
+    "title": "Lemma 5: Inductive Splitting via Icc_add_Icc",
+    "content": "**`eVariationOn_le_n`**: If each of the `n` pieces `[a+k*step, a+(k+1)*step]` has variation ≤ 1, then `eVariationOn F (Icc a (a+n*step)) ≤ n`.\n\nProof by induction on `n`:\n- **Base** (`n=0`): interval `[a,a]` is a point. `eVariationOn.eq_zero_iff` shows variation = 0 (any two points in a singleton are equal, so all edists are 0). `0 ≤ 0 = n`.\n- **Step** (`n = m+1`): Use `eVariationOn.Icc_add_Icc F hm_le hmid` to split:\n  `eVar[a, a+m*step] + eVar[a+m*step, a+(m+1)*step] = eVar[a, a+(m+1)*step]`\n  By IH: left piece ≤ m; by `hpieces`: right piece ≤ 1; total ≤ m+1.\n\nThe key Mathlib lemma `eVariationOn.Icc_add_Icc` says: if `a ≤ b ≤ c`, then `eVar[a,b] + eVar[b,c] = eVar[a,c]`. This additivity of variation over adjacent intervals is what enables the inductive decomposition.",
+    "mathContext": "$V_F[a, b] = V_F[a, c] + V_F[c, b]$ for $a \\leq c \\leq b$ (additivity of bounded variation). Lean form: `eVariationOn.Icc_add_Icc F (h_a_le_c : a ≤ c) (h_c_le_b : c ≤ b) (hc : c ∈ Set.univ) : eVariationOn F (Icc a c) + eVariationOn F (Icc c b) = eVariationOn F (Icc a b)`. The inductive step's `calc` block: `eVar[a, a+m*step] + eVar[a+m*step, a+(m+1)*step] ≤ m + 1 = m+1`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "eVariationOn.Icc_add_Icc",
+      "eVariationOn.eq_zero_iff",
+      "additivity of variation",
+      "induction on ℕ"
+    ],
+    "prerequisites": [
+      "eVariationOn.Icc_add_Icc",
+      "eVariationOn.eq_zero_iff",
+      "ENNReal addition and comparison",
+      "Nat.cast"
+    ]
+  },
+  {
+    "id": "ann-ftc-oq01-main",
+    "proofId": "fundamental-theorem-calculus-oq-01-oq-01",
+    "range": { "startLine": 135, "endLine": 185 },
+    "type": "insight",
+    "title": "Main Theorem: AC → BV from the ε-δ Definition",
+    "content": "**`ac_implies_bv`**: If `F` is absolutely continuous on `[a,b]`, then `F` has bounded variation on `[a,b]`.\n\n**The degenerate case** `a = b`: the interval `[a,a]` is a point, variation = 0 ≠ ⊤. Handled by `eVariationOn.eq_zero_iff` and `ENNReal.zero_ne_top`.\n\n**The main case** `a < b`:\n1. **Get δ**: Apply `hF 1 one_pos` to get `δ > 0` and the AC bound `hac` (for `∑ lengths < δ → ∑ oscillations < 1`).\n2. **Choose n**: `n = ⌈(b-a)/δ⌉₊ + 1` ensures `step = (b-a)/n < δ`. The `+1` makes the ceiling strict. Proved by `nlinarith` using the ceiling inequality.\n3. **Exact cover**: `a + n * step = b` — the `n` pieces exactly cover `[a,b]`. Proved by `mul_div_cancel₀`.\n4. **Piece bounds**: Each `[a+k*step, a+(k+1)*step]` has variation ≤ 1, by applying `eVariationOn_le_one_of_short` with the AC condition.\n5. **Global bound**: `eVariationOn_le_n` gives `eVariationOn F (Icc a b) ≤ n`. Since `n : ℕ`, `ENNReal.natCast_ne_top` gives `n ≠ ⊤`, so the variation is bounded.\n\nThe final `ne_top_of_le_ne_top` concludes: `eVariationOn F (Icc a b) ≠ ⊤`, which is the definition of `BoundedVariationOn`.",
+    "mathContext": "The choosing of $n$: we need $\\frac{b-a}{n} < \\delta$, i.e., $n > \\frac{b-a}{\\delta}$. So $n = \\lceil \\frac{b-a}{\\delta} \\rceil + 1$ works. The Lean natural number ceiling $\\lceil x \\rceil_+ = \\mathrm{Nat.ceil}$ satisfies $x \\leq \\mathrm{ceil}(x)$, so $b-a \\leq \\lceil \\frac{b-a}{\\delta} \\rceil \\cdot \\delta < n \\cdot \\delta$, giving $\\frac{b-a}{n} < \\delta$. `BoundedVariationOn F s` is defined as `eVariationOn F s ≠ ⊤` in Mathlib.",
+    "significance": "key",
+    "relatedConcepts": [
+      "AbsolutelyContinuousOn (ε-δ)",
+      "Nat.ceil",
+      "ENNReal.natCast_ne_top",
+      "ne_top_of_le_ne_top",
+      "BoundedVariationOn"
+    ],
+    "prerequisites": [
+      "eVariationOn_le_one_of_short",
+      "eVariationOn_le_n",
+      "ENNReal.natCast_ne_top",
+      "Nat.ceil arithmetic"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for fundamental-theorem-calculus-oq-01-oq-01

**Entry**: AC → BV: Absolutely Continuous implies Bounded Variation

### What was added

**Created annotations.json** replacing the empty `[]` (6 annotations covering all 185 lines):

1. **Header** (lines 23-35): module imports, Lebesgue FTC chain (AC→BV→Jordan→FTC), maxHeartbeats context
2. **edist + upper-bound criterion** (lines 36-52): `iSup_le` pattern for bounding eVariationOn, ENNReal.ofReal bridging identity
3. **Telescoping sum** (lines 53-63): `Fin.sum_univ_castSucc` induction pattern, role in bounding partition total length
4. **Short-interval key lemma** (lines 64-93): The central lemma — AC condition → eVar ≤ 1, with ENNReal.ofReal conversion chain and disjointness argument
5. **Inductive splitting** (lines 95-133): `eVariationOn.Icc_add_Icc` additivity, n-piece inductive bound
6. **Main theorem** (lines 135-185): Complete δ→n→step<δ→pieces→global bound argument annotated, with `Nat.ceil` arithmetic and `ne_top_of_le_ne_top` conclusion

### Entry state
- `overview`, `conclusion`, `crossReferences`, `sections` were already present in meta.json
- `annotations.json` was `[]` (empty array) — this caused quality: 38