### PR TITLE
fix(meta): sync theoremCount for angle-trisection-oq-02-oq-01-oq-02-incomplete-01

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 22,
     "lineCount": 639,
     "mathlibDependencies": [
       {
@@ -138,7 +138,7 @@
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
     "lineCount": 639,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 22,
     "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Syncs `theoremCount` in `meta` and `leanFile` blocks for the angle-trisection incomplete proof.

## Evidence

| Field | Before | After |
|-------|--------|-------|
| `meta.theoremCount` | 21 | 22 |
| `leanFile.theoremCount` | 21 | 22 |

**Actual count** (grep of `AngleTrisectionOQ02OQ01OQ02Incomplete01.lean`):
- 16 theorems (4 public constructibility + 1 private theorem + 11 impossibility results)
- 6 lemmas (1 public + 5 private: `isConstructible_algebraic`, `finrank_sup_quadratic_dvd_two`, `isConstructible_sup_degree`, `isConstructible_algebraic_degree`, `three_ne_two_pow`)
- **Total: 22** per the private/protected inclusion convention (PR #15867)

The count of 21 predates the hjoin_dvd elimination work in PR #15128, which likely added or restructured a theorem without updating theoremCount.

---
Automated fix by lean-mechanic agent.