### PR TITLE
fix(meta): sync sorries and lineCount for lagrange-theorem-oq-01-oq-03

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
@@ -18,10 +18,10 @@
       "schur-zassenhaus"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-05-05",
     "axiomCount": 2,
-    "lineCount": 224,
+    "lineCount": 211,
     "theoremCount": 14,
     "definitionCount": 2,
     "assumptions": "hall_solvable: Hall's theorem for solvable groups (requires Schur–Zassenhaus + minimal normal subgroup theory not yet in Mathlib). hall_characterizes_solvability: Hall's converse (requires Feit–Thompson odd-order theorem).",
@@ -48,9 +48,9 @@
       "Fintype"
     ],
     "namespace": "LagrangeOQ01OQ03",
-    "lineCount": 224,
+    "lineCount": 211,
     "axiomCount": 2,
-    "sorries": 1,
+    "sorries": 0,
     "definitionCount": 2,
     "theoremCount": 14
   },


### PR DESCRIPTION
## Summary
- `sorries`: 1 → 0 (file has 2 `axiom` declarations, 0 `sorry` keywords)
- `lineCount`: 224 → 211 (actual file length)
- Both `meta` and `leanFile` blocks corrected

## Evidence
```
$ git show origin/main:proofs/Proofs/LagrangeTheoremOQ01OQ03.lean | wc -l
211
$ git show origin/main:proofs/Proofs/LagrangeTheoremOQ01OQ03.lean | grep -c sorry
0
```

File has `axiom hall_solvable` and `axiom hall_characterizes_solvability` — these are counted in `axiomCount: 2`, correctly. The `sorries: 1` was a metadata artifact from initial entry creation.

## Test plan
- [ ] Verify `sorries: 0` and `lineCount: 211` match the Lean source
- [ ] Status `axiomatized` / badge `axiom` remain correct (2 axiom declarations)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)