### PR TITLE
fix(meta): sync meta.theoremCount for 3 entries — private lemmas undercounted

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
@@ -22,7 +22,7 @@
         "axiomCount": 0,
         "assumptions": "None — fully verified. Depends on CubeRoot2IrrationalOQ03 for minpoly_nthRoot_natDegree.",
         "lineCount": 104,
-        "theoremCount": 2,
+        "theoremCount": 3,
         "definitionCount": 0,
         "originalContributions": [
             "cbrt3_powers_linearIndependent: {α^0, α^1, α^2} linearly independent over ℚ via minpoly divisibility",

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -19,7 +19,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "lineCount": 316,
-        "theoremCount": 13,
+        "theoremCount": 15,
         "definitionCount": 3,
         "assumptions": ""
     },

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
         "axiomCount": 0,
         "assumptions": "None. Fully machine-verified.",
         "lineCount": 220,
-        "theoremCount": 12,
+        "theoremCount": 13,
         "originalContributions": [
             "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
             "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` in the `meta` sub-object for 3 entries where private lemmas were not counted when metadata was originally written. The `leanFile.theoremCount` was already correct in all three cases.

## Evidence

| Entry | meta.theoremCount (before) | leanFile.theoremCount | meta.theoremCount (after) | Missing private lemma(s) |
|-------|--------------------------|----------------------|--------------------------|--------------------------|
| cube-root-3-irrational-oq-02-oq-02 | 2 | 3 | 3 | `α_minpoly_deg` |
| frobenius-number | 13 | 15 | 15 | `mul_mod_injective`, `exists_mul_mod` |
| fundamental-arithmetic-oq-01-oq-01 | 12 | 13 | 13 | `factorization_finset_prod` |

The counting convention for `theoremCount` includes all named `theorem`/`lemma` declarations including `private` ones (consistent with `leanFile.theoremCount` which already counted them).

---
Automated fix by lean-mechanic agent.