### PR TITLE
fix(meta): sync lineCount/theoremCount for arithmetic-series q-multichoose entry

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-05-05",
     "axiomCount": 0,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
-    "lineCount": 221,
-    "theoremCount": 10,
+    "lineCount": 226,
+    "theoremCount": 12,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -118,8 +118,8 @@
     "namespace": "QMultichooseCoefficients",
     "imports": ["Mathlib", "Proofs.CombinationsFormulaOQ03"],
     "axiomCount": 0,
-    "lineCount": 221,
-    "theoremCount": 10,
+    "lineCount": 226,
+    "theoremCount": 12,
     "definitionCount": 1,
     "sorries": 0
   },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14669,6 +14669,22 @@
       "lastAudited": "2026-05-05T02:03:59Z",
       "result": "clean",
       "issues": []
+    },
+    "lagrange-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-05T02:55:34Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorries mismatch: claims 1, actual 0 (uses axiom declarations not sorry); lineCount mismatch: claims 224, actual 211 \u2014 fixed in PR #15942"
+      ]
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-05T02:55:34Z",
+      "result": "issues-fixed",
+      "issues": [
+        "lineCount mismatch: claims 221, actual 226; theoremCount mismatch: claims 10, actual 12 \u2014 fixed in this PR"
+      ]
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary
- `lineCount`: 221 → 226 (actual file length via `wc -l`)
- `theoremCount`: 10 → 12 (file contains 12 theorems: the 10 originally counted plus `qMultichoose_two_left` and `qMultichoose_recovers_classical_int` in sections VII/VIII)
- Both `meta` and `leanFile` blocks corrected
- Updates `audit-tracker.json` with 2 new audit entries: `lagrange-theorem-oq-01-oq-03` (issues-fixed, PR #15942) and this entry

## Evidence
```
$ git show origin/main:proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean | wc -l
226
$ git show origin/main:proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean | grep -E "^theorem" | wc -l
12
```

Status `verified` / badge `original` remain correct: 0 sorries, 0 axioms, original proofs.

## Test plan
- [ ] Verify `lineCount: 226` and `theoremCount: 12` match the Lean source
- [ ] Confirm no sorries or axioms (status/badge unchanged)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)