### PR TITLE
fix(meta): sync lineCount and theoremCount for arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-05-05",
     "axiomCount": 0,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
-    "lineCount": 221,
-    "theoremCount": 10,
+    "lineCount": 226,
+    "theoremCount": 12,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -118,8 +118,8 @@
     "namespace": "QMultichooseCoefficients",
     "imports": ["Mathlib", "Proofs.CombinationsFormulaOQ03"],
     "axiomCount": 0,
-    "lineCount": 221,
-    "theoremCount": 10,
+    "lineCount": 226,
+    "theoremCount": 12,
     "definitionCount": 1,
     "sorries": 0
   },


### PR DESCRIPTION
## Integrity Fix

Auditor found count discrepancies in `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03`:

| Field | Claimed | Actual |
|-------|---------|--------|
| `lineCount` | 221 | 226 |
| `theoremCount` | 10 | 12 |

All critical checks passed: 0 sorries, 0 axioms, no True stubs. Status `verified` / badge `original` are appropriate.

The 2 undercounted theorems are `qMultichoose_two_left` and `qMultichoose_recovers_classical_int` in sections VII and VIII.

---
Discovered during gallery integrity audit.