### PR TITLE
fix(meta): sync lineCount and theoremCount for fundamental-theorem-calculus-oq-01-oq-04

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-04/meta.json
@@ -10,8 +10,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 253,
-    "theoremCount": 7,
+    "lineCount": 311,
+    "theoremCount": 8,
     "assumptions": "None. All theorems hold for arbitrary NormedAddCommGroup E with no axioms beyond Mathlib's standard library.",
     "tags": [
       "analysis",
@@ -107,8 +107,8 @@
     "path": "Proofs/FundamentalTheoremCalculusLebesgueOQ04.lean",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 253,
-    "theoremCount": 7,
+    "lineCount": 311,
+    "theoremCount": 8,
     "defCount": 1
   }
 }


### PR DESCRIPTION
## Integrity Fix

Auditor found count discrepancies in `fundamental-theorem-calculus-oq-01-oq-04`:

| Field | Claimed | Actual |
|-------|---------|--------|
| `lineCount` | 253 | 311 |
| `theoremCount` | 7 | 8 |

The undercounted theorem is `real_ac_implies_normed_ac` (line 121), which was present in the file but not listed in the module docstring's theorem count.

All critical checks passed: 0 sorries, 0 axioms, no True stubs. Status `verified` / badge `original` are appropriate — all 8 theorems have complete proofs, private helpers not counted.

---
Discovered during gallery integrity audit.