### PR TITLE
chore(audit): update tracker — elementary-quadratic-reciprocity-oq-03-oq-02-oq-03 clean (audit #2)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14611,8 +14611,8 @@
       "issues": []
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-05T00:51:26Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-05T03:13:06Z",
       "result": "clean",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14685,6 +14685,14 @@
       "issues": [
         "lineCount mismatch: claims 221, actual 226; theoremCount mismatch: claims 10, actual 12 \u2014 fixed in this PR"
       ]
+    },
+    "fundamental-theorem-calculus-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-05T03:05:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "lineCount mismatch: claims 253, actual 311; theoremCount mismatch: claims 7, actual 8 (real_ac_implies_normed_ac undercounted) \u2014 fixed in PR #15948"
+      ]
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit Tracker Update

Marks `elementary-quadratic-reciprocity-oq-03-oq-02-oq-03` as audited (second pass, result: clean).

**Finding**: The `sorry mismatch: claims 0, actual 2` flagged by `find-targets.ts` was a false positive. The script reads working directory files; an uncommitted research session had modified the Lean file with 2 sorries (in-progress work, never committed). The `origin/main` version has 0 sorries, status=axiomatized, badge=axiom — all correct.

**Related**: Filed issue #15955 noting that when PR #15952 merges, `leanFile.lineCount` (242→404) and `leanFile.theoremCount` (19→20) will need updating in meta.json.

Gallery status: 2335/2335 proofs audited (100%).

🤖 Generated with Claude Code