### PR TITLE
fix(meta): sync meta.theoremCount for 60 entries — align with leanFile.theoremCount

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -59,7 +59,7 @@
     "axiomCount": 1,
     "lineCount": 1163,
     "assumptions": "1 axiom (Tucker's lemma in 2D axiomatized). No sorries.",
-    "theoremCount": 47
+    "theoremCount": 46
   },
   "overview": {
     "historicalContext": "**Tucker's Lemma and the 1D Borsuk-Ulam Theorem**\n\nTucker's lemma (1946) is the combinatorial analog of Borsuk-Ulam: any signed labeling of a triangulated interval with antipodal boundary condition must have a complementary edge (adjacent vertices with opposite labels). In 1D, Tucker's lemma and BU are equivalent.\n\n**Important caveat**: On the interval [-1,1], many Borsuk-Ulam-style statements are degenerate because x = 0 is self-antipodal (0 = -0). Results like \"there exist x, y with f(x) = f(y) and x + y = 0\" are trivially satisfied by x = y = 0, and do not extract hidden structure from any existence theorem. The genuinely nontrivial Borsuk-Ulam topology begins on S^1, where the antipodal map has no fixed points.\n\nThis file's strongest content is the Tucker 1D proof via discrete IVT, the circle BU proof, and the sign-change parity infrastructure. The interval-level quantitative bounds (Lipschitz, oscillation, bisection) are correct but elementary consequences of continuity and compactness, not deep Borsuk-Ulam phenomena.\n\nThe higher-dimensional Tucker's lemma (triangulated disks B^n with labels from {+-1,...,+-n}) implies the full n-dimensional Borsuk-Ulam theorem. The 2D and n-D cases are axiomatized here.",
@@ -191,7 +191,7 @@
     "namespace": "BorsukUlamOQ03OQ01",
     "lineCount": 1163,
     "axiomCount": 1,
-    "theoremCount": 47,
+    "theoremCount": 46,
     "definitionCount": 4,
     "path": "Proofs/BorsukUlamOQ03OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -73,7 +73,7 @@
     "axiomCount": 0,
     "lineCount": 390,
     "mathlib_version": "4.26.0",
-    "theoremCount": 10
+    "theoremCount": 9
   },
   "overview": {
     "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector γ'(t), the integral of |crossings contribution| over all angles θ gives exactly 2‖γ'(t)‖. Integrating over t gives 2L/(πd).\n\nThe proof uses Complex.arg to find the rotation angle φ such that a sin θ + b cos θ = √(a²+b²) · sin(θ + φ), then applies the rotation-invariant identity ∫_0^π |sin(θ + c)| dθ = 2.",
@@ -198,7 +198,7 @@
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 2,
     "path": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.lt_power_cof",
@@ -116,7 +116,7 @@
     "namespace": "CantorDiagOQ01OQ01OQ02",
     "lineCount": 255,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "definitionCount": 0,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 2,
     "assumptions": "ClassicalRiceModel encodes 2 mathematical assumptions as structure fields: (1) h_compile — every behavior has a canonical code (universality); (2) kleene_rec — Kleene's recursion theorem (every code transformer has a semantic fixed point). These are hypotheses to classical_rice_abstract, not global Lean axioms. The 5 abstract theorems (abstract_rice through no_halting_model) are fully axiom-free.",
     "lineCount": 275,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 3,
     "originalContributions": [
       "abstract_rice: no Bool-evaluation structure can be point-surjective (direct from Lawvere)",
@@ -122,7 +122,7 @@
     "namespace": "CantorDiagonalizationOQ03OQ01OQ02",
     "lineCount": 275,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 3,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/meta.json
@@ -57,7 +57,7 @@
         "relationship": "The Bool variant (cantor_bool) mirrors the diagonal pattern used in Turing's halting argument, though this file formalizes the algebraic structure rather than the full computational undecidability result"
       }
     ],
-    "theoremCount": 10
+    "theoremCount": 9
   },
   "overview": {
     "problemStatement": "Prove the Lawvere fixed-point theorem as a categorical generalization of Cantor's diagonal argument: if a surjection $e : A \\to (A \\to B)$ exists, then every endomorphism $f : B \\to B$ has a fixed point. Derive Cantor's theorem as a corollary.",
@@ -184,7 +184,7 @@
     "namespace": "LawvereCantor",
     "lineCount": 149,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/CantorDiagonalizationOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
     "lineCount": 151,
     "assumptions": "1 axiom: riesz_lp_surjective (the hard direction requiring Radon-Nikodym). L2 case fully proved via InnerProductSpace.toDual. Embedding direction proved via Hölder.",
     "dateAdded": "2026-03-26",
-    "theoremCount": 8
+    "theoremCount": 7
   },
   "overview": {
     "problemStatement": "Can the Riesz representation theorem $(L^p)^* \\cong L^q$ be derived from the $\\mathrm{eLpNorm}$ Hölder inequality?",
@@ -108,7 +108,7 @@
     ],
     "lineCount": 151,
     "axiomCount": 1,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 600,
     "assumptions": "2 axiom(s): hadamard_three_lines, riesz_thorin. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 29
+    "theoremCount": 28
   },
   "overview": {
     "historicalContext": "**Riesz-Thorin Interpolation (1927/1948)**\n\nMarcel Riesz proved the first interpolation theorem for bilinear forms in 1927. Olof Thorin simplified and extended the proof in 1948 using the Hadamard three-lines lemma from complex analysis.\n\nThe theorem states: if a linear operator T is bounded from $L^{p_0}$ to $L^{q_0}$ with norm $M_0$, and from $L^{p_1}$ to $L^{q_1}$ with norm $M_1$, then for any $\\theta \\in [0,1]$, T is bounded from $L^{p_\\theta}$ to $L^{q_\\theta}$ with norm $\\leq M_0^{1-\\theta} \\cdot M_1^\\theta$, where the interpolated exponents satisfy $1/p_\\theta = (1-\\theta)/p_0 + \\theta/p_1$.\n\n**Connection to Hölder**: Hölder's inequality provides the endpoint estimates (the $M_0$ and $M_1$ bounds), while the three-lines lemma provides the interpolation between endpoints.",
@@ -205,7 +205,7 @@
     "namespace": "RieszThorinInterpolation",
     "lineCount": 600,
     "axiomCount": 2,
-    "theoremCount": 29,
+    "theoremCount": 28,
     "definitionCount": 7,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/cevas-theorem-non-euclidean/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 527,
-    "theoremCount": 19,
+    "theoremCount": 18,
     "definitionCount": 7,
     "originalContributions": [
       "GeneralizedCevianConfig structure unifying Euclidean, spherical, and hyperbolic configurations",
@@ -140,7 +140,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 7,
-    "theoremCount": 19
+    "theoremCount": 18
   },
   "sorries": 0
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-04/meta.json
@@ -66,7 +66,7 @@
     "lineCount": 495,
     "assumptions": "None — fully verified with 0 axioms and 0 sorries",
     "mathlib_version": "4.26.0",
-    "theoremCount": 23
+    "theoremCount": 22
   },
   "overview": {
     "historicalContext": "René Descartes stated his rule of signs in *La Géométrie* (1637), the appendix to the *Discours de la méthode* that founded analytic geometry. The rule bounds the number of positive real roots of a polynomial by the number of sign changes in its coefficient sequence. Descartes gave no proof — he stated the result as evident. The first rigorous proof was given by Carl Friedrich Gauss (1828) using Rolle's theorem: between consecutive roots of $p$, the derivative $p'$ has a root, so the number of roots of $p$ is bounded by the number of sign changes in the coefficients of $p'$, which equals the number of sign changes of $p$ minus 1.\n\nSandy Grabiner published a remarkable alternative proof in the *American Mathematical Monthly* (1999), showing the rule can be proved without Rolle's theorem or any calculus beyond the Intermediate Value Theorem. The key insight is purely algebraic: when a polynomial $p(x)$ is factored as $p(x) = (x - r)q(x)$ with $r > 0$, the sign variation count of $p$'s coefficients exceeds that of $q$'s by at least 1. This enables a clean induction on the number of positive roots. Grabiner's approach is more elementary and constructive than the Rolle-based proof, making it particularly suitable for formalization in Lean 4.",
@@ -192,7 +192,7 @@
     "namespace": "DescartesAlgebraic",
     "lineCount": 495,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 22,
     "definitionCount": 0,
     "path": "Proofs/DescartesRuleOfSignsOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1001-oq-02/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02/meta.json
@@ -68,7 +68,7 @@
       "three_distance_connection: connects rate to three-distance theorem"
     ],
     "lineCount": 315,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "defCount": 5
   },
   "overview": {
@@ -167,7 +167,7 @@
     "namespace": "Erdos1001OQ02",
     "lineCount": 315,
     "axiomCount": 3,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 10,
     "path": "Proofs/Erdos1001OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1015-oq-05/meta.json
+++ b/src/data/proofs/erdos-1015-oq-05/meta.json
@@ -25,7 +25,7 @@
     "lineCount": 353,
     "assumptions": "No axioms in this file. All theorems proved from RamseysTheorem.lean. Eliminates 2 of the 8 parent axioms (ramseyNumber definition and ramsey_upper_bound).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14
+    "theoremCount": 13
   },
   "crossReferences": [
     {
@@ -135,7 +135,7 @@
     "namespace": "Erdos1015OQ05",
     "lineCount": 353,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/Erdos1015OQ05.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -24,7 +24,7 @@
     "lineCount": 89,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 1
+    "theoremCount": 0
   },
   "overview": {
     "historicalContext": "Erdős and Simonovits posed this problem in 1982 as part of their systematic investigation of extremal functions for graph families. The question sits at the crossroads of two regimes in extremal graph theory. For non-bipartite forbidden graphs, the Erdős–Stone–Simonovits theorem (1966) determines ex(n; H) up to the o(n²) error, and the answer depends only on the chromatic number χ(H). But when the forbidden family contains a bipartite graph, the extremal function drops to o(n²) and the precise order of growth depends on the fine structure of the forbidden graph — a much harder problem. Simonovits had earlier (1966) shown that for a single forbidden bipartite graph the extremal function exhibits polynomial growth n^{1+c} for some c < 1, but determining this exponent remains open in most cases. Problem #575 asks whether, for families, the analysis reduces to a single bipartite member: a powerful structural simplification if true. The conjecture has been verified for families of complete bipartite graphs and certain degenerate families, but the general case remains open after four decades.",
@@ -103,7 +103,7 @@
     "namespace": null,
     "lineCount": 89,
     "axiomCount": 0,
-    "theoremCount": 1,
+    "theoremCount": 0,
     "definitionCount": 3,
     "path": "Proofs/Erdos575Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -25,7 +25,7 @@
     "lineCount": 499,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14
+    "theoremCount": 13
   },
   "overview": {
     "historicalContext": "Erdős introduced the function $g(n)$ in a 1966 paper 'Remarks on number theory V' published in Matematikai Lapok, as part of his broader program studying multiplicative structures in sets of integers. The problem arose naturally from the observation that the set of all primes up to $n$ has distinct subset products (by unique factorization), giving $g(n) \\geq \\pi(n)$. Erdős proved the first non-trivial upper bound $g(n) \\leq \\pi(n) + O(\\sqrt{n}/\\ln n)$ in the same paper, showing that at most $O(\\pi(\\sqrt{n}))$ non-prime elements could participate. The gap between the lower bound $\\pi(n)$ and upper bound $\\pi(n) + O(\\pi(\\sqrt{n}))$ suggested that squares of small primes (contributing $\\pi(\\sqrt{n})$ additional elements) might close the gap. This remained open for nearly 60 years until Raghavan's 2025 resolution. The problem is the multiplicative counterpart of Erdős Problem #1 on distinct subset sums, where $f(n, N) = \\max\\{|A| : A \\subseteq \\{1,\\ldots,N\\},\\; \\text{all subset sums distinct}\\}$ and the Conway-Guy conjecture similarly identifies optimal sets. The distinct products problem connects to Sidon sets in multiplicative groups, $B_h$ sequences, and the broader study of sum-free and product-free sets in additive combinatorics.",
@@ -170,7 +170,7 @@
     "namespace": "Erdos795",
     "lineCount": 499,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 7,
     "path": "Proofs/Erdos795Problem.lean",
     "sorries": 14,

--- a/src/data/proofs/fair-games-theorem-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-01/meta.json
@@ -52,7 +52,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 51
+    "theoremCount": 49
   },
   "overview": {
     "historicalContext": "The Gambler's Ruin problem is one of the oldest problems in probability theory, dating to correspondence between Pascal and Fermat in 1654. The modern treatment uses martingale theory developed by Doob (1953). The Optional Stopping Theorem provides the key tool: by applying it to the identity martingale X_n and the quadratic martingale X_n² - n, one extracts both ruin probabilities and expected ruin times. The biased case was analyzed by Feller (1968) using the exponential martingale r^X_n where r = q/p.",
@@ -163,7 +163,7 @@
     "namespace": "FairGamesOQ01",
     "lineCount": 632,
     "axiomCount": 0,
-    "theoremCount": 51,
+    "theoremCount": 49,
     "definitionCount": 12,
     "path": "Proofs/FairGamesTheoremOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 201,
     "assumptions": "2 axioms with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p) and fermatLastTheoremFive (FermatLastTheoremFor 5). The n=3 and n=4 cases are fully proved via Mathlib. FreyCurve_is_semistable and RibetTheorem were placeholder True-stubs and have been replaced with documentation comments. 2 with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p, the consequence of Modularity+Ribet) and fermatLastTheorem (the full FLT statement: ∀ n ≥ 3, FermatLastTheoremFor n). 3 placeholder axioms concluding with True (FreyCurve_is_semistable, ModularityTheorem_semistable, RibetTheorem) — these serve as proof-structure markers documenting the Frey-Ribet-Wiles chain without encoding actual mathematical statements. The n=3 and n=4 cases are fully proved via Mathlib (fermatLastTheoremThree, fermatLastTheoremFour).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7
+    "theoremCount": 6
   },
   "overview": {
     "historicalContext": "In 1637, Pierre de Fermat wrote in the margin of his copy of Diophantus's *Arithmetica*: \"I have discovered a truly marvelous proof of this, which this margin is too narrow to contain.\" This tantalizing note launched 358 years of mathematical obsession.\n\nGenerations of mathematicians attacked the problem. Euler proved the case n=3 (1770). Sophie Germain developed techniques for certain primes (1823). Ernst Kummer's work on ideal class groups proved it for all regular primes (1850), but infinitely many cases remained.\n\nThe modern breakthrough came from an unexpected direction. In 1984, Gerhard Frey proposed that a counterexample to Fermat would yield an elliptic curve with impossible properties. Jean-Pierre Serre refined this, and in 1986, Ken Ribet proved the key connection: if Fermat's Last Theorem were false, it would contradict the Taniyama-Shimura-Weil conjecture about modular forms.\n\nAndrew Wiles, who had dreamed of proving FLT since childhood, worked in secret for seven years. In June 1993, he announced his proof of enough of the modularity conjecture to imply FLT. But a gap was found. After a year of anguish, Wiles and Richard Taylor patched the proof using a brilliant new technique. On October 25, 1994, the proof was complete. It was published in 1995, ending the longest-standing unsolved problem in mathematics.",
@@ -287,7 +287,7 @@
     "namespace": "FermatsLastTheorem",
     "lineCount": 201,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/FermatsLastTheorem.lean",
     "sorries": 0

--- a/src/data/proofs/friendship-theorem-oq-03/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-03/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 6,
-    "theoremCount": 12
+    "theoremCount": 11
   },
   "mainTheorems": [
     {
@@ -97,7 +97,7 @@
       "fano_edge_count: exactly 7 triples"
     ],
     "lineCount": 307,
-    "theoremCount": 12
+    "theoremCount": 11
   },
   "references": [
     {

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -42,7 +42,7 @@
     "lineCount": 390,
     "assumptions": "1 axiom: hermite_lindemann (deep analytic number theory, not in Mathlib). All corollaries (e transcendence, π transcendence) are now proved from this single axiom via Euler's identity and algebraic closure properties.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5
+    "theoremCount": 4
   },
   "overview": {
     "historicalContext": "Charles Hermite's 1873 paper \"Sur la fonction exponentielle\" proved $e$ is transcendental, introducing the **auxiliary polynomial method** that became the foundation of transcendence theory. Hermite's key innovation was constructing a polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ whose integral against $e^x$ yields simultaneously a nonzero integer and a quantity less than 1 — a contradiction. Ferdinand von Lindemann generalized this in his 1882 paper \"Über die Zahl $\\pi$\" to show $e^\\alpha$ is transcendental for any nonzero algebraic $\\alpha$, immediately proving $\\pi$ transcendental via Euler's identity and settling the ancient circle-squaring problem. Karl Weierstrass published the definitive generalization in 1885: if $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers, then $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent. This hierarchy — Hermite to Lindemann to Weierstrass — established the template that Gelfond, Schneider, and Baker would later extend.",
@@ -203,7 +203,7 @@
     "namespace": "HermiteLindemann",
     "lineCount": 390,
     "axiomCount": 1,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 1,
     "path": "Proofs/HermiteLindemann.lean",
     "sorries": 0

--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -26,7 +26,7 @@
       "Enriques-Kodaira surface classification",
       "Analogy table: 1D uniformization → higher-dim Kodaira"
     ],
-    "theoremCount": 2
+    "theoremCount": 1
   },
   "overview": {
     "historicalContext": "The uniformization theorem — proved independently by Poincaré and Koebe in 1907 — gives a complete classification of simply connected Riemann surfaces: every one is biholomorphic to the sphere S², the complex plane ℂ, or the unit disk 𝔻. This trichotomy corresponds to positive, zero, and negative curvature. In higher dimensions, no single theorem achieves a comparable classification. The Kodaira dimension κ(X) — introduced by Kunihiko Kodaira in a landmark series of papers (1960–1969) — provides the right invariant: it measures the growth rate of pluricanonical sections and takes values in {-∞, 0, 1, ..., dim X}. For complex surfaces (dim 2), Kodaira completed the Enriques classification into 8 topological-algebraic classes. In 1977, Shing-Tung Yau proved the Calabi conjecture (Fields Medal 1982), establishing existence of Kähler-Einstein metrics on manifolds with non-positive first Chern class — the higher-dimensional 'hyperbolic metric' analogue. Shoshichi Kobayashi introduced his eponymous hyperbolicity in 1967 as the direct generalization of the 'hyperbolic type' in uniformization: a manifold is Kobayashi hyperbolic if every entire holomorphic curve is constant. The Lang conjecture (1986) predicts that manifolds of general type (κ = dim) are Kobayashi hyperbolic.",
@@ -108,7 +108,7 @@
     "namespace": "Hilbert22OQ01",
     "lineCount": 155,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 1,
     "definitionCount": 3,
     "path": "Proofs/Hilbert22OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -40,7 +40,7 @@
     "proofRepoPath": "Proofs/HodgeConjecture.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 10517,
-    "theoremCount": 433
+    "theoremCount": 430
   },
   "overview": {
     "historicalContext": "The Hodge Conjecture was proposed by Sir William Vallance Douglas Hodge at the 1950 International Congress of Mathematicians in Cambridge. Hodge developed his theory of harmonic integrals in the 1930s–1940s, building on Solomon Lefschetz's 1924 theorem that every (1,1) integral Hodge class is algebraic (the Lefschetz theorem on (1,1) classes). Hodge conjectured this should extend to all codimensions p.\n\nFor over 70 years the conjecture has resisted resolution. Key milestones: Atiyah–Hirzebruch (1962) disproved the integral version using topological K-theory and Steenrod operations, showing rational coefficients are essential. Grothendieck (1968) proposed his Standard Conjectures, which would imply the Hodge Conjecture as a corollary; they also remain open. Deligne proved the Weil conjectures (1974), which are related but distinct. Voisin (2002) proved the conjecture fails for compact Kähler manifolds that are not projective, confirming projectivity is an essential hypothesis.\n\nIn 2000, the Clay Mathematics Institute designated the Hodge Conjecture as one of seven Millennium Prize Problems with a $1,000,000 prize. The only proven cases are: divisors on any variety (Lefschetz (1,1)), curves, surfaces, and special abelian varieties (Deligne, Hazama). The conjecture stands as one of the deepest open questions in mathematics.",
@@ -261,7 +261,7 @@
     "lineCount": 10517,
     "structureCount": 104,
     "axiomCount": 49,
-    "theoremCount": 433,
+    "theoremCount": 430,
     "lemmaCount": 0,
     "imports": [
       "Mathlib.Geometry.Manifold.Algebra.SmoothFunctions",

--- a/src/data/proofs/lagrange-theorem-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 207,
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. All results follow from Mathlib's group action theory.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16
+    "theoremCount": 15
   },
   "overview": {
     "historicalContext": "The orbit-stabilizer theorem emerged from the work of Cauchy, Jordan, and Frobenius on permutation groups in the 19th century. Cauchy (1845) proved that primes dividing |G| yield elements of that order. Frobenius developed the theory of group actions systematically, leading to the orbit-stabilizer decomposition. The theorem unifies Lagrange's theorem, Burnside's counting lemma, the class equation, and the fixed-point theorems for p-groups into a single principle This file (OQ-02) formalizes the orbit-stabilizer theorem as a follow-up open question: given the Lean 4 proof of Lagrange's theorem in the parent file, can the orbit-stabilizer identity be derived cleanly using the same coset machinery? The answer is yes, using Mathlib's Subgroup.card_eq_card_quotient_mul_card and MulAction.orbit_eq_univ.",
@@ -210,7 +210,7 @@
     "namespace": "LagrangeTheoremOQ02",
     "lineCount": 207,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "definitionCount": 1,
     "path": "Proofs/LagrangeTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/lebesgue-measure-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-02/meta.json
@@ -67,7 +67,7 @@
     "axiomCount": 0,
     "lineCount": 224,
     "assumptions": "0 axioms, 0 sorries. Core inequalities (Hölder's inequality, Young's inequality) from Mathlib; original work is the Lp space infrastructure and applications.",
-    "theoremCount": 11
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "**Cauchy** (1821) proved $|\\sum a_i b_i|^2 \\leq \\sum a_i^2 \\cdot \\sum b_i^2$ for finite sums. **Schwarz** (1885) and **Bunyakovsky** (1859) extended this to integrals. **Hölder** (1889) generalized both to arbitrary conjugate exponents $1/p + 1/q = 1$, creating a family of inequalities parameterized by $p \\in (1, \\infty)$. **Young** (1912) isolated the pointwise inequality $ab \\leq a^p/p + b^q/q$ from the concavity of $\\log$, providing the cleanest proof. **Riesz** (1910) lifted Hölder to measure-theoretic integrals, founding $L^p$ space theory. **Minkowski** used Hölder to prove the $L^p$ triangle inequality, completing the normed space structure. The chain Young $\\to$ Hölder $\\to$ Minkowski is one of the most important deduction sequences in analysis.",
@@ -180,7 +180,7 @@
     "namespace": "LebesgueMeasureOQ02",
     "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/LebesgueMeasureOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/minpoly-charpoly/meta.json
+++ b/src/data/proofs/minpoly-charpoly/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 246,
-    "theoremCount": 18,
+    "theoremCount": 17,
     "assumptions": "None. All 17 theorems proved.",
     "mathlibDependencies": [
       {
@@ -109,7 +109,7 @@
     "namespace": "MinpolyCharpoly",
     "lineCount": 246,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 17,
     "definitionCount": 0,
     "path": "Proofs/MinpolyCharpoly.lean",
     "sorries": 0

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -65,7 +65,7 @@
     "relatedProblems": [],
     "lineCount": 21111,
     "mathlib_version": "4.26.0",
-    "theoremCount": 846
+    "theoremCount": 845
   },
   "overview": {
     "historicalContext": "**Navier-Stokes Existence and Smoothness (Millennium Prize Problem)**\n\nThe Navier-Stokes equations describe fluid motion: $\\partial_t u + (u \\cdot \\nabla)u = \\nu\\Delta u - \\nabla p + f$ with $\\nabla \\cdot u = 0$. The Millennium Prize asks whether smooth solutions exist globally in 3D. Leray (1934) proved weak solutions exist; Ladyzhenskaya (1962/1969) solved the 2D case; Caffarelli-Kohn-Nirenberg (1982) showed the 3D singular set has Hausdorff dimension at most 1. The 3D problem remains open after 90+ years.\n\nThis formalization is the largest single proof file in the gallery at 20,000+ lines across 110 parts, containing 1200+ definitions/theorems with 0 sorries. The 3D conditional result uses the NSAxioms structure (5 structure-encoded assumptions).",
@@ -267,7 +267,7 @@
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
     "axiomCount": 0,
-    "theoremCount": 846,
+    "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -69,7 +69,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 846
+    "theoremCount": 845
   },
   "overview": {
     "historicalContext": "The two-dimensional Navier-Stokes equations have been known to have global smooth solutions since Ladyzhenskaya's work in 1969. The key is that vortex stretching — the primary mechanism that might cause blowup in 3D — is absent in 2D. In 2D, the vorticity ω satisfies a transport-diffusion equation without the dangerous (ω·∇)u stretching term.\n\nThe enstrophy E(t) = ∫|ω(x,t)|² dx is the squared L² norm of vorticity. In 2D, enstrophy satisfies the ODE dE/dt = -2νP where P = ∫|∇ω|² is the palinstrophy. Under a Poincaré inequality P ≥ μ₁E (where μ₁ is the first eigenvalue of -Δ on the domain), this becomes dE/dt ≤ -2νμ₁E, giving exponential decay.\n\nThis formalization extends the existing NavierStokes.lean (which already proved the asymptotic bound E(t) ≤ E(0)·exp(-2νμ₁t)) with new quantitative results: decay between arbitrary times, exact FTC integration of the enstrophy ODE, and total dissipation bounds.",
@@ -184,7 +184,7 @@
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
     "axiomCount": 0,
-    "theoremCount": 846,
+    "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 21111,
     "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t), the core PDE estimate — mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0",
-    "theoremCount": 846
+    "theoremCount": 845
   },
   "overview": {
     "historicalContext": "The theory of well-posedness for 2D Navier-Stokes equations has a rich history beginning with Jean Leray's pioneering 1934 paper, which established the existence of weak solutions in both 2D and 3D. For 2D, Leray showed that solutions remain regular for all time — a result that fails (or at least remains unproven) in 3D.\n\nThe concept of well-posedness itself was formalized by Jacques Hadamard in his 1902 lectures: a problem is well-posed if it has (1) existence, (2) uniqueness, and (3) continuous dependence on data. Hadamard argued that physically meaningful problems should satisfy all three criteria.\n\nOlga Ladyzhenskaya's landmark 1969 monograph 'The Mathematical Theory of Viscous Incompressible Flow' provided the definitive treatment of 2D well-posedness. Her key contribution was the Ladyzhenskaya inequality in 2D: $\\|u\\|_{L^4(\\mathbb{R}^2)} \\leq C \\|u\\|_{L^2}^{1/2} \\|\\nabla u\\|_{L^2}^{1/2}$, which gives the stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$ for the difference energy $W(t) = \\|u_1 - u_2\\|_{L^2}^2$. The critical feature of 2D: enstrophy $E(t) = \\|\\nabla u\\|_{L^2}^2$ is bounded by its initial value $E(0)$, making the Gronwall growth rate $K = C \\cdot E(0)$ finite.\n\nThomas Gronwall's 1919 inequality — if $u'(t) \\leq \\beta(t) u(t)$ then $u(t) \\leq u(0) \\exp(\\int_0^t \\beta)$ — is the analytic engine of the proof. Combined with bounded enstrophy, it yields exponential stability $W(t) \\leq W(0) e^{CE(0)t}$ and hence uniqueness.\n\nIn 3D, enstrophy could potentially blow up ($E(t) \\to \\infty$), making $K(t) = C \\cdot E(t)$ unbounded and the Gronwall argument ineffective. This is precisely the obstruction at the heart of the Clay Millennium Prize Problem: proving or disproving 3D global regularity. The 2D well-posedness result formalized here serves as a template showing exactly where the 3D argument breaks down.\n\nThis formalization in Lean 4 is novel: the `NSSolutionPair2D` structure encodes the Ladyzhenskaya stability estimate as a structural hypothesis, abstracting away the PDE-specific Sobolev space analysis (not yet available in Mathlib) and focusing on the Gronwall argument itself.",
@@ -205,7 +205,7 @@
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
     "axiomCount": 0,
-    "theoremCount": 846,
+    "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",
     "sorries": 0

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -74,7 +74,7 @@
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 21111,
-    "theoremCount": 846
+    "theoremCount": 845
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",
@@ -367,7 +367,7 @@
     "lineCount": 21111,
     "structureCount": 249,
     "axiomCount": 0,
-    "theoremCount": 846,
+    "theoremCount": 845,
     "lemmaCount": 14,
     "imports": [
       "Mathlib.Analysis.Calculus.Deriv.Basic",

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -41,7 +41,7 @@
     "millenniumProblem": "p-vs-np",
     "lineCount": 6370,
     "mathlib_version": "4.26.0",
-    "theoremCount": 303
+    "theoremCount": 302
   },
   "leanFile": {
     "path": "Proofs/PNPBarriersUnified.lean",
@@ -129,7 +129,7 @@
     "axiomCount": 121,
     "sorries": 0,
     "definitionCount": 66,
-    "theoremCount": 303
+    "theoremCount": 302
   },
   "overview": {
     "historicalContext": "The P vs NP problem is one of the most important unsolved problems in mathematics and computer science, designated a Clay Mathematics Institute Millennium Prize Problem in 2000 with a $1,000,000 reward.\n\nThe foundations were laid by Alan Turing (1936) with the formalization of computation, and by Juris Hartmanis and Richard Stearns (1965) who established computational complexity theory with the Time Hierarchy Theorem. Stephen Cook (1971) formulated the P vs NP question and proved the Cook-Levin theorem, showing that the Boolean satisfiability problem (SAT) is NP-complete — the first problem shown to have this property. Leonid Levin independently proved the same result in 1973 in the Soviet Union.\n\nRichard Karp (1972) demonstrated the practical significance by showing 21 natural combinatorial problems are NP-complete via reduction chains from SAT, including CLIQUE, VERTEX COVER, HAMILTONIAN PATH, and SUBSET SUM. Russell Ladner (1975) proved that if P ≠ NP, then NP-intermediate problems must exist — problems in NP that are neither in P nor NP-complete.\n\nDespite over 50 years of effort, the problem remains open. Three major 'barrier results' explain why traditional proof techniques have failed: relativization (Baker-Gill-Solovay, 1975), natural proofs (Razborov-Rudich, 1994), and algebrization (Aaronson-Wigderson, 2009). Any proof must circumvent all three barriers simultaneously.",

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -66,7 +66,7 @@
     ],
     "mathlib_version": "4.26.0",
     "lineCount": 6594,
-    "theoremCount": 365
+    "theoremCount": 363
   },
   "overview": {
     "historicalContext": "The Riemann zeta function $\\zeta(s) = \\sum n^{-s}$ was first studied by Euler (1737), who discovered the Euler product $\\zeta(s) = \\prod_p (1-p^{-s})^{-1}$ — the key link between $\\zeta$ and prime numbers. But it was Bernhard Riemann who, in his extraordinary 1859 paper 'Ueber die Anzahl der Primzahlen unter einer gegebenen Grösse' (just 8 pages), transformed the subject by extending $\\zeta$ to a meromorphic function on all of $\\mathbb{C}$, establishing the functional equation $\\xi(s) = \\xi(1-s)$, and stating the hypothesis that all non-trivial zeros have $\\text{Re}(s) = 1/2$.\n\nRiemann's paper was revolutionary: he showed that the distribution of primes is governed by the zeros of $\\zeta(s)$ through his explicit formula $\\psi(x) = x - \\sum_\\rho x^\\rho/\\rho - \\log(2\\pi) - \\frac{1}{2}\\log(1-x^{-2})$. The Prime Number Theorem — proved independently by Hadamard and de la Vallée Poussin in 1896 — is equivalent to $\\zeta(s) \\neq 0$ on $\\text{Re}(s) = 1$, while RH is the far stronger assertion that the zero-free region extends to $\\text{Re}(s) > 1/2$.\n\nHardy (1914) proved infinitely many zeros lie on the critical line, using the Hardy Z-function $Z(t) = e^{i\\theta(t)}\\zeta(1/2+it)$ which is real for real $t$. Selberg (1942) showed a positive proportion of zeros are on the critical line, Levinson (1974) proved $>1/3$, and Conrey (1989) improved this to $>40\\%$ — the current record. Montgomery (1973) discovered that the pair correlation of zeta zeros matches that of eigenvalues of random GUE matrices, inaugurating the deep connection to random matrix theory (Keating-Snaith 2000). Rodgers and Tao (2018) proved the de Bruijn-Newman constant $\\Lambda \\geq 0$, establishing that RH, if true, is 'just barely' true.\n\nIn 2000, the Clay Mathematics Institute designated RH as one of seven Millennium Prize Problems, offering $1,000,000 for its resolution. Despite 166 years of effort and the verification of the first $10^{13}$ zeros (Platt 2004, Gourdon 2004), the hypothesis remains open. Hilbert listed it as the 8th of his 23 problems (1900), and it appears on virtually every list of the most important open problems in mathematics.",
@@ -355,7 +355,7 @@
     "namespace": "RiemannHypothesis",
     "lineCount": 6594,
     "axiomCount": 32,
-    "theoremCount": 365,
+    "theoremCount": 363,
     "definitionCount": 38,
     "path": "Proofs/RiemannHypothesis.lean",
     "sorries": 0

--- a/src/data/proofs/schauder-fixed-point-oq-03/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03/meta.json
@@ -28,7 +28,7 @@
       "Brouwer from Kakutani corollary",
       "Nash equilibrium existence sketch"
     ],
-    "theoremCount": 4
+    "theoremCount": 3
   },
   "overview": {
     "historicalContext": "Shizuo Kakutani's 1941 paper 'A Generalization of Brouwer's Fixed Point Theorem' (Duke Mathematical Journal) extended Brouwer's theorem to set-valued maps (correspondences), replacing the continuity requirement with upper hemicontinuity. Kakutani's motivation was to provide a cleaner proof of the minimax theorem (von Neumann 1928) for zero-sum games. The theorem became famous nine years later when John Nash (1950) used it to prove the existence of Nash equilibria in finite n-player games, for which Nash received the 1994 Nobel Prize in Economics. The key insight of Nash's proof is that the 'best response correspondence' — mapping each strategy profile to the set of profiles where every player is best-responding — satisfies exactly the Kakutani conditions when strategy spaces are taken to be simplices of mixed strategies. The Kakutani fixed point theorem was itself later generalized to infinite-dimensional spaces by Glicksberg (1952) and Fan (1952), and to locally convex topological vector spaces by the Fan-Kakutani theorem. In modern mathematics, it appears in general equilibrium theory (Arrow-Debreu model, 1954), mechanism design, and social choice theory.",
@@ -127,7 +127,7 @@
     "namespace": "KakutaniFixedPoint",
     "lineCount": 168,
     "axiomCount": 1,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 7,
     "path": "Proofs/SchauderFixedPointOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/schroeder-bernstein/meta.json
+++ b/src/data/proofs/schroeder-bernstein/meta.json
@@ -52,7 +52,7 @@
     "lineCount": 198,
     "assumptions": "0 axioms, 0 sorries. Core Schröder-Bernstein theorem (Function.Embedding.schroeder_bernstein, antisymm) from Mathlib; original work is corollaries and pedagogical infrastructure.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6
+    "theoremCount": 5
   },
   "overview": {
     "historicalContext": "The Schroeder-Bernstein theorem has a rich and tangled history, with at least four independent discoveries spanning two decades of foundational set theory.\n\n**Georg Cantor (1887)** stated the result without proof in a letter to Dedekind, recognizing its importance for his theory of transfinite cardinals. He relied on the well-ordering principle but sought a proof independent of this assumption.\n\n**Richard Dedekind (1887)** provided the first correct proof, using his chain theory (*Kettentheorie*): given injections $f: A \\to B$ and $g: B \\to A$, consider the chain $C = \\bigcup_{n=0}^{\\infty} (g \\circ f)^n(A \\setminus g(B))$. Then $h(a) = f(a)$ if $a \\in C$, $h(a) = g^{-1}(a)$ otherwise. Dedekind communicated this to Cantor but never published it; it was found in his *Nachlass* and published posthumously.\n\n**Ernst Schroder (1896)** published a proof that contained a gap identified by Alwin Korselt in 1902. Schroder's name persists in the theorem's attribution despite the flawed proof.\n\n**Felix Bernstein (1898)**, then a 19-year-old student of Cantor at Halle, presented a correct proof using the orbit decomposition that has become the standard textbook approach. His proof was published in Borel's *Lecons sur la theorie des fonctions* (1898).\n\nThe theorem holds in ZF (without choice), unlike many other results in cardinal arithmetic. The name varies by tradition: Cantor-Bernstein (Germany), Schroder-Bernstein (English-speaking countries), or Cantor-Bernstein-Schroder.",
@@ -240,7 +240,7 @@
     "namespace": "SchroederBernstein",
     "lineCount": 198,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 3,
     "path": "Proofs/SchroederBernstein.lean",
     "sorries": 0

--- a/src/data/proofs/sqrt2-from-axioms-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms-oq-01/meta.json
@@ -44,7 +44,7 @@
     "lineCount": 365,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 19
+    "theoremCount": 18
   },
   "overview": {
     "historicalContext": "The irrationality of $\\sqrt{2}$ was first proved by the ancient Greeks, traditionally attributed to Hippasus of Metapontum (~500 BCE). According to legend, Hippasus was drowned at sea by fellow Pythagoreans for revealing that $\\sqrt{2}$ is incommensurable with 1, shattering their belief that all quantities are ratios of whole numbers.\n\nThe proof by contradiction—assuming $\\sqrt{2} = a/b$ in lowest terms and deriving that both $a$ and $b$ must be even—is one of the most celebrated arguments in mathematics. Theodorus of Cyrene (~465–398 BCE) extended the result to $\\sqrt{3}, \\sqrt{5}, \\ldots, \\sqrt{17}$ (as reported in Plato's *Theaetetus*), though his methods are debated. His student Theaetetus provided a general classification: $\\sqrt{n}$ is irrational whenever $n$ is not a perfect square.\n\nThe key insight enabling the generalization is Euclid's lemma (Elements VII.30, ~300 BCE): if a prime divides a product, it divides one of the factors. This property was used implicitly in the $\\sqrt{2}$ proof (the \"even/odd\" trick) but Euclid recognized it as a general property of primes. In modern algebra, this multiplicative property is taken as the *definition* of a prime element in a ring, distinguishing it from the weaker notion of irreducibility.\n\nThis formalization makes the connection explicit by defining primality via Euclid's criterion rather than the divisor property, revealing why the $\\sqrt{2}$ proof generalizes immediately to all primes.",
@@ -164,7 +164,7 @@
     "namespace": "SqrtPrimeFromAxioms",
     "lineCount": 365,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/Sqrt2FromAxiomsOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/sqrt2-from-axioms/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms/meta.json
@@ -40,7 +40,7 @@
     "lineCount": 235,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 15
+    "theoremCount": 14
   },
   "overview": {
     "historicalContext": "This proof is attributed to Hippasus of Metapontum (~500 BCE), a member of the Pythagorean school who discovered that the diagonal of a unit square cannot be expressed as a ratio of integers. According to legend, Hippasus was thrown overboard while at sea for revealing this truth, which shook the Pythagorean doctrine that 'all is number' — meaning rational number.\n\nThe Greeks called such lengths *incommensurable* with the side: no common unit of measurement can divide both exactly. The result appears formally in Euclid's *Elements* Book X (c. 300 BCE). Theaetetus (~400 BCE) extended it, proving √n is irrational for any non-perfect-square n.\n\nThe proof exemplifies *infinite descent*: assuming √2 = a/b in lowest terms forces both a and b to be even, contradicting 'lowest terms'. This parity argument became a template replicated across number theory — the same structure proves √p irrational for any prime p.",
@@ -118,7 +118,7 @@
     "namespace": "Sqrt2FromAxioms",
     "lineCount": 235,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 3,
     "path": "Proofs/Sqrt2IrrationalFromAxioms.lean",
     "sorries": 0

--- a/src/data/proofs/subset-count-oq-02-oq-01/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Uses Multiset.card_Iic (Mathlib.Data.Multiset.Interval), Multiset.nodup_iff_count_le_one, Multiset.count_pos, Multiset.toFinset_card_of_nodup, Finset.disjoint_left, Multiset.count_eq_zero.",
     "lineCount": 159,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 0,
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-12"
@@ -122,7 +122,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 11
+    "theoremCount": 10
   },
   "sorries": 0
 }

--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -25,7 +25,7 @@
     "lineCount": 382,
     "assumptions": "gb_local (local Gauss-Bonnet: angle excess = integrated curvature, for each geodesic triangle), spherical/flat/hyperbolic curvature formulas (K=1/r², K=0, K=-1 respectively), discrete_gb (discrete Gauss-Bonnet for triangulations: total excess = 2π·χ). All are classical theorems of differential geometry requiring Riemannian geometry infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 26
+    "theoremCount": 25
   },
   "overview": {
     "historicalContext": "The triangle angle sum theorem (α+β+γ=π) has been known since antiquity as a characterization of Euclidean geometry. Its failure in curved geometries was gradually recognized: Girard (1629) proved the spherical excess formula for triangles on a sphere, and Lambert (1761) noted that in hyperbolic geometry the angle sum is less than π, with the defect proportional to area.\n\nGauss (1827) unified these observations via the concept of Gaussian curvature: the angle excess of a geodesic triangle equals the integral of Gaussian curvature over the triangle. This local version of what we now call the Gauss-Bonnet theorem shows that the flat case (K=0, excess=0, sum=π) is a special instance of a deeper principle.\n\nBonnet (1848) extended this to the global theorem: for a closed orientable Riemannian surface, the integral of Gaussian curvature equals 2π times the Euler characteristic. This fundamentally connects geometry (curvature) to topology (Euler characteristic).",
@@ -142,7 +142,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ02.lean",
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 2
   },
   "references": [

--- a/src/data/proofs/triangle-angle-sum-oq-03/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-03/meta.json
@@ -49,7 +49,7 @@
       "Fully degenerate case: when p₁ = p₂ = p₃, sum = 3π/2 (unique exceptional configuration)",
       "Unconditional formula using Classical.em (no DecidableEq hypothesis needed)"
     ],
-    "theoremCount": 7
+    "theoremCount": 6
   },
   "overview": {
     "historicalContext": "Euclid proved the triangle angle sum theorem in Book I, Proposition 32 of the *Elements* (c. 300 BCE): the interior angles of a triangle sum to two right angles. This was a cornerstone of Euclidean geometry and its failure in non-Euclidean settings — where the sum exceeds $\\pi$ on a sphere and falls short in hyperbolic geometry — became the defining diagnostic for these geometries in the 19th century. Legendre attempted to prove the Parallel Postulate using this theorem; Gauss and Bolyai–Lobachevsky independently showed it was independent.\n\nIn formal mathematics, angle functions must handle degenerate inputs gracefully. The Mathlib definition `EuclideanGeometry.angle p₁ p₂ p₃` measures the angle at vertex $p_2$ between directions to $p_1$ and $p_3$. It is defined via `InnerProductGeometry.angle`, using $\\arccos(\\langle u,v\\rangle / (\\|u\\| \\cdot \\|v\\|))$. When a direction vector is zero (i.e., when a non-vertex argument equals the vertex), the inner product ratio is $0/0 = 0$ by Lean's convention, so $\\arccos(0) = \\pi/2$.\n\nThis junk-value convention was chosen by Mathlib for analytic cleanliness — the function is defined everywhere without case analysis. The consequence is a beautiful and somewhat surprising theorem discovered during systematic exploration: the angle sum formula extends far beyond its original non-degenerate domain, and the Mathlib theorem `angle_add_angle_add_angle_eq_pi` has a weaker hypothesis than previously documented (only $p_2 \\neq p_1$ is needed, not both $p_2 \\neq p_1$ and $p_3 \\neq p_1$).",
@@ -181,7 +181,7 @@
     "namespace": "TriangleAngleSumOQ03",
     "lineCount": 140,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ03.lean"


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `lf.theoremCount` for 35 gallery entries where both fields were stale after PR #15953 introduced an overcount (+1 to +3) for entries that PR #15867 had previously corrected.

## Evidence

**Root cause**: PR #15953 used an extended counting convention (including `@[simp]`-prefixed and `proposition`/`corollary` keywords) that overcounted vs the actual `theorem|lemma` declarations in the Lean files. This reverted PR #15867's corrections.

**Fix**: Both `lf.theoremCount` and `meta.theoremCount` now match the actual comment-stripped Lean file counts.

**Notable corrections**:
- `fair-games-theorem-oq-01`: 51→49 (was overcounted by 2)
- `riemann-hypothesis`: 365→363 (overcounted by 2)  
- `hodge-conjecture`: 433→430 (overcounted by 3)
- 32 other entries: each corrected by 1

**Conflict resolution**: Three files (`fair-games-theorem-oq-01`, `hodge-conjecture`, `riemann-hypothesis`) had merge conflicts with main — all resolved by taking the actual file counts (our values were correct; main's values were the overcounted ones from #15953).

## Validation

All 35 entries: `meta.theoremCount == lf.theoremCount == actual theorem+lemma count in Lean file (comment-stripped)`.

---
Automated fix by lean-mechanic agent.