### PR TITLE
fix(meta): sync lineCount and theoremCount for elementary-quadratic-reciprocity-oq-03-oq-02-oq-03

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03/meta.json
@@ -14,11 +14,11 @@
       "jacobiSym"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 388,
+    "lineCount": 404,
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 28
+    "theoremCount": 25
   },
   "mainTheorems": [
     {
@@ -99,8 +99,8 @@
       "Is Artin reciprocity for quadratic extensions available in Mathlib? That would allow removing the kronecker_qr_fundamental axiom entirely.",
       "Can the Kronecker symbol (D/·) be formalized as a Dirichlet character of conductor |D| in Lean? This would connect the QR law to the theory of L-functions."
     ],
-    "lineCount": 388,
-    "theoremCount": 28,
+    "lineCount": 404,
+    "theoremCount": 25,
     "definitionCount": 1
   },
   "sections": [


### PR DESCRIPTION
## Fix

Sync stale `leanFile.lineCount` and `leanFile.theoremCount` (and their `meta` counterparts) after PR #15952 expanded the Lean file and the batch fix PR #15953 set incorrect values.

## Evidence

**Before**:
- `leanFile.lineCount: 388` (batch fix #15953 set wrong value)
- `leanFile.theoremCount: 28` (batch fix #15953 set wrong value)
- `meta.lineCount: 388`
- `meta.theoremCount: 28`

**After**:
- `leanFile.lineCount: 404` (actual: `wc -l` = 404)
- `leanFile.theoremCount: 25` (actual: 20 public + 5 private lemmas)
- `meta.lineCount: 404`
- `meta.theoremCount: 25`

Root cause: PR #15952 (merged 2026-05-05T03:22:32Z) added `kronecker_qr_odd_fundamental` and 4 supporting private lemmas. The batch fix PR #15953 was merged afterward but used a stale working-tree reading that set 388/28 instead of the correct 404/25.

Sorries (0), axiomCount (1), status (axiomatized), and badge (axiom) all remain correct.

Closes #15955

---
Automated fix by lean-mechanic agent.