### PR TITLE
fix(meta): sync definitionCount for fundamental-theorem-calculus-oq-01-oq-04

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-04/meta.json
@@ -12,6 +12,7 @@
     "axiomCount": 0,
     "lineCount": 311,
     "theoremCount": 13,
+    "definitionCount": 1,
     "assumptions": "None. All theorems hold for arbitrary NormedAddCommGroup E with no axioms beyond Mathlib's standard library.",
     "tags": [
       "analysis",
@@ -141,6 +142,6 @@
     "axiomCount": 0,
     "lineCount": 311,
     "theoremCount": 13,
-    "defCount": 1
+    "definitionCount": 1
   }
 }


### PR DESCRIPTION
## Summary

- Add `meta.definitionCount: 1` (was missing from meta object)
- Rename `leanFile.defCount: 1` → `leanFile.definitionCount: 1` (non-standard field name)

The Lean file `FundamentalTheoremCalculusLebesgueOQ04.lean` contains 1 definition (`AbsolutelyContinuousOnNormed`). The meta object was missing `definitionCount` entirely, and the leanFile block used the non-standard key `defCount` instead of `definitionCount`.

All other fields (sorries: 0, axiomCount: 0, lineCount: 311, theoremCount: 13) remain correct.

---
Discovered during gallery integrity audit.