### PR TITLE
fix(audit-tracker): add dissection-of-cubes-oq-03-oq-02 audit result

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14686,6 +14686,12 @@
         "lineCount mismatch: claims 221, actual 226; theoremCount mismatch: claims 10, actual 12 \u2014 fixed in this PR"
       ]
     },
+    "dissection-of-cubes-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-05T03:22:00Z",
+      "result": "clean",
+      "issues": []
+    },
     "fundamental-theorem-calculus-oq-01-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-05-05T03:05:00Z",


### PR DESCRIPTION
## Summary

- Adds `dissection-of-cubes-oq-03-oq-02` to audit tracker as **clean**

Verified against `git show origin/main:proofs/Proofs/DissectionOfCubesOQ03OQ02.lean`:
- lineCount: 208 ✓
- sorries: 0 ✓
- axiomCount: 0 ✓
- theoremCount: 6 ✓ (6 public theorems, no private)
- definitionCount: 0 ✓
- Status "verified", badge "verified" ✓

All 6 theorems are genuine proofs (no True stubs, no Mathlib wrappers for core results).

---
Discovered during gallery integrity audit.