### PR TITLE
enrich(greens-theorem-oq-03-oq-04): restructure to standard schema, add annotations/overview/conclusion

### DIFF
--- a/src/data/proofs/greens-theorem-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-03-oq-04/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-oq04-header",
+    "proofId": "greens-theorem-oq-03-oq-04",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "OQ-04: Can Stokes' Theorem Derive Green's Theorem for TypeI Regions?",
+    "content": "OQ-04 arises from OQ-03's open question: since Green's theorem is a special case of Stokes' theorem, can Mathlib's existing Stokes machinery (implemented as the divergence theorem for rectangles) directly yield Green's theorem? The answer is YES for rectangular regions — Mathlib's `integral2_divergence_prod_of_hasFDerivWithinAt_off_countable` gives Green's theorem for rectangles via the algebraic substitution F=(Q,-P). For general TypeI regions with curved boundaries, Mathlib v4.26.0 lacks the necessary Stokes theorem for smooth manifolds with boundary, so the OQ-03 FTC approach remains the right path. The file imports `Proofs.GreensTheoremOQ03` to access the `TypeIRegion` structure and `greens_theorem_typeI` axiom.",
+    "mathContext": "Green's theorem as Stokes: $\\oint_{\\partial D}(P\\,dx + Q\\,dy) = \\iint_D \\left(\\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}\\right)dA$ is the Stokes theorem $\\int_M d\\omega = \\int_{\\partial M} \\omega$ applied to $\\omega = P\\,dx + Q\\,dy$ and $d\\omega = (\\partial Q/\\partial x - \\partial P/\\partial y)\\,dx \\wedge dy$. For $F=(Q,-P)$: $\\text{div}(F) = \\partial Q/\\partial x - \\partial P/\\partial y$ and $\\oint F \\cdot n\\,ds = \\oint P\\,dx + Q\\,dy$.",
+    "significance": "key",
+    "relatedConcepts": ["Stokes theorem", "Green's theorem", "divergence theorem", "TypeIRegion", "greens-theorem-oq-03"],
+    "prerequisites": ["Green's theorem", "Stokes theorem on manifolds", "TypeI regions from OQ-03", "Mathlib measure theory"]
+  },
+  {
     "id": "ann-stokes-setup",
     "proofId": "greens-theorem-oq-03-oq-04",
     "range": { "startLine": 63, "endLine": 102 },
@@ -46,5 +58,17 @@
     "significance": "key",
     "relatedConcepts": ["Stokes theorem on manifolds", "differential forms", "Mathlib roadmap", "exterior derivative"],
     "prerequisites": ["differential geometry", "manifolds with boundary", "differential forms"]
+  },
+  {
+    "id": "ann-stokes-green-abstract",
+    "proofId": "greens-theorem-oq-03-oq-04",
+    "range": { "startLine": 205, "endLine": 250 },
+    "type": "insight",
+    "title": "Abstract Equivalence: Divergence Theorem IS Stokes' Theorem",
+    "content": "The summary section documents that Mathlib's `integral2_divergence_prod_of_hasFDerivWithinAt_off_countable` is not merely analogous to Stokes' theorem — it IS Stokes' theorem for the special case of a rectangular 2D manifold. The identification: ω = P dx + Q dy (a 1-form on ℝ²), dω = (∂Q/∂x − ∂P/∂y) dx∧dy (the exterior derivative), M = rectangular region [a₁,b₁]×[a₂,b₂], ∂M = counterclockwise boundary. This means OQ-03's FTC proof and this divergence-theorem proof are two formalizations of the same mathematical theorem, differing only in which Mathlib tools they invoke. The rectangle is the paradigm case where all three approaches (FTC, divergence theorem, Stokes) are simultaneously available.",
+    "mathContext": "Abstract Stokes: $\\int_M d\\omega = \\int_{\\partial M} \\omega$ with $\\omega = P\\,dx + Q\\,dy$, $d\\omega = (\\partial Q/\\partial x - \\partial P/\\partial y)\\,dx \\wedge dy$. Instantiated to rectangle: $\\iint_{[a_1,b_1]\\times[a_2,b_2]} (\\partial Q/\\partial x - \\partial P/\\partial y) = \\oint_{\\text{rect}} P\\,dx + Q\\,dy$. The **three equivalent proofs**: (1) FTC iterated integration (OQ-01, OQ-03), (2) divergence theorem substitution (this entry), (3) general Stokes on manifolds with boundary (future Mathlib).",
+    "significance": "key",
+    "relatedConcepts": ["exterior derivative", "differential forms", "Stokes theorem", "divergence theorem", "Fundamental Theorem of Calculus"],
+    "prerequisites": ["exterior algebra", "differential geometry", "Stokes theorem on manifolds", "Green's theorem classical proof"]
   }
 ]

--- a/src/data/proofs/greens-theorem-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-03-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-stokes-setup",
+    "proofId": "greens-theorem-oq-03-oq-04",
+    "range": { "startLine": 63, "endLine": 102 },
+    "type": "technique",
+    "title": "Green's Theorem for Rectangles: The F=(Q,-P) Substitution",
+    "content": "The central insight is the substitution F = (Q, -P): for this vector field, div(F) = ∂Q/∂x + ∂(-P)/∂y = ∂Q/∂x - ∂P/∂y, which is exactly the Green's theorem integrand. Mathlib's integral2_divergence_prod_of_hasFDerivWithinAt_off_countable is applied with f=Q (first component) and g=-P (negated second component). The hypotheses require ContinuousOn for P and Q on the closed rectangle, HasFDerivAt on the open interior minus a countable exceptional set s (for piecewise-C¹ fields), and integrability of the curl ∂Q/∂x - ∂P/∂y.",
+    "mathContext": "For $F = (Q, -P)$: $$\\text{div}(F) = \\frac{\\partial Q}{\\partial x} + \\frac{\\partial(-P)}{\\partial y} = \\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}$$ and the divergence theorem $\\iint_D \\text{div}(F)\\,dA = \\oint_{\\partial D} F \\cdot n\\,ds$ becomes exactly Green's theorem.",
+    "significance": "key",
+    "relatedConcepts": ["divergence theorem", "Green's theorem", "vector field substitution", "integral2_divergence_prod_of_hasFDerivWithinAt_off_countable"],
+    "prerequisites": ["vector calculus", "divergence theorem", "Lean measure theory"]
+  },
+  {
+    "id": "ann-boundary-decomposition",
+    "proofId": "greens-theorem-oq-03-oq-04",
+    "range": { "startLine": 111, "endLine": 135 },
+    "type": "technique",
+    "title": "Boundary Identity: Ring Arithmetic Recovers ∮ P dx + Q dy",
+    "content": "The two boundary theorems prove that Mathlib's divergence theorem output — expressed in terms of boundary integrals of (Q, -P) — algebraically equals the counterclockwise line integral ∮ P dx + Q dy. boundary_integral_decomposition rewrites the Mathlib output into a sum of P-contributions (bottom minus top) and Q-contributions (right minus left). boundary_eq_line_integral_parts consolidates via interval integral linearity. Both proofs are by `ring` or `simp [intervalIntegral.integral_sub]` — purely algebraic.",
+    "mathContext": "Mathlib's divergence theorem with $F=(Q,-P)$ gives boundary terms: $$\\underbrace{\\int_{a_1}^{b_1}[(-P)(x,b_2) - (-P)(x,a_2)]\\,dx}_{P\\text{-terms}} + \\underbrace{\\int_{a_2}^{b_2}[Q(b_1,y) - Q(a_1,y)]\\,dy}_{Q\\text{-terms}}$$ which equals $\\int_{a_1}^{b_1}[P(x,a_2) - P(x,b_2)]\\,dx + \\int_{a_2}^{b_2}[Q(b_1,y)-Q(a_1,y)]\\,dy = \\oint P\\,dx + Q\\,dy$.",
+    "significance": "key",
+    "relatedConcepts": ["counterclockwise orientation", "boundary integral", "line integral", "intervalIntegral.integral_sub"],
+    "prerequisites": ["line integrals", "Green's theorem boundary orientation", "Lean interval integrals"]
+  },
+  {
+    "id": "ann-typeI-consistency",
+    "proofId": "greens-theorem-oq-03-oq-04",
+    "range": { "startLine": 149, "endLine": 164 },
+    "type": "insight",
+    "title": "Sign Convention Consistency: OQ-03 and Stokes Agree",
+    "content": "rect_greens_consistent_with_typeI verifies that the P-contribution sign conventions in OQ-03 (TypeI FTC approach) and this file (Stokes/divergence approach) agree for rectangular TypeI regions. OQ-03 uses '∫(P(x,d) - P(x,c)) dx' (top minus bottom) with a sign; the Stokes approach uses '(-P)(x,d) - (-P)(x,c)' which after negation gives the same expression. This confirms the two formulations are consistent — proved by simp and neg_sub.",
+    "mathContext": "OQ-03 convention: $-\\int_a^b [P(x,d) - P(x,c)]\\,dx$. Stokes convention: $\\int_a^b [(-P)(x,a_2) - (-P)(x,b_2)]\\,dx = \\int_a^b [P(x,c) - P(x,d)]\\,dx$. These are equal: $-\\int_a^b [P(x,d) - P(x,c)]\\,dx = \\int_a^b [P(x,c) - P(x,d)]\\,dx$.",
+    "significance": "supporting",
+    "relatedConcepts": ["TypeI regions", "boundary orientation", "sign conventions", "OQ-03"],
+    "prerequisites": ["Green's theorem", "TypeI regions", "integration conventions"]
+  },
+  {
+    "id": "ann-typeI-via-stokes",
+    "proofId": "greens-theorem-oq-03-oq-04",
+    "range": { "startLine": 179, "endLine": 204 },
+    "type": "context",
+    "title": "General TypeI: OQ-03 Axiom and the Mathlib Gap",
+    "content": "greens_theorem_typeI_via_stokes shows that the general TypeI case is already handled by OQ-03's greens_theorem_typeI — the proof is simply a delegation. The documentation axiom `stokes_for_curved_domains_not_in_mathlib_4_26 : True` records the Mathlib gap: as of v4.26.0, Mathlib has the divergence theorem for rectangular boxes but lacks a general Stokes theorem for 2D manifolds with piecewise-smooth curved boundaries. This is documented as True (not a mathematical axiom) to make the gap explicit.",
+    "mathContext": "The full Stokes theorem on a manifold with boundary states: $\\int_M d\\omega = \\int_{\\partial M} \\omega$. For $\\omega = P\\,dx + Q\\,dy$ and $M$ a TypeI region, this gives Green's theorem. The required differential-forms framework (smooth manifolds with boundary, exterior derivatives, integration of $n$-forms) is not yet in Mathlib v4.26.0, explaining the OQ-03 detour via FTC.",
+    "significance": "key",
+    "relatedConcepts": ["Stokes theorem on manifolds", "differential forms", "Mathlib roadmap", "exterior derivative"],
+    "prerequisites": ["differential geometry", "manifolds with boundary", "differential forms"]
+  }
+]

--- a/src/data/proofs/greens-theorem-oq-03-oq-04/index.ts
+++ b/src/data/proofs/greens-theorem-oq-03-oq-04/index.ts
@@ -1,1 +1,36 @@
-export { default } from './meta.json'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GreensTheoremOQ03OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const greensTheoremOQ03OQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const greensTheoremOQ03OQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const greensTheoremOQ03OQ04Data: ProofData = {
+  proof: greensTheoremOQ03OQ04Proof,
+  annotations: greensTheoremOQ03OQ04Annotations,
+}

--- a/src/data/proofs/greens-theorem-oq-03-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03-oq-04/meta.json
@@ -1,66 +1,123 @@
 {
   "id": "greens-theorem-oq-03-oq-04",
   "title": "Green's Theorem via Stokes: TypeI Regions as Manifolds with Boundary",
-  "parentId": "greens-theorem-oq-03",
-  "status": "axiomatized",
-  "badge": "axiom",
-  "summary": "Derives Green's theorem for rectangular regions from Mathlib's divergence theorem, and shows how the OQ-03 TypeI region proof connects to the Stokes theorem framework.",
-  "sorries": 0,
-  "axiomCount": 1,
-  "theoremCount": 5,
-  "lineCount": 250,
-  "leanFile": {
-    "path": "proofs/Proofs/GreensTheoremOQ03OQ04.lean",
+  "slug": "greens-theorem-oq-03-oq-04",
+  "description": "Derives Green's theorem for rectangular regions from Mathlib's 2D divergence theorem via the substitution F=(Q,-P), and connects the TypeI region proof (OQ-03) to the Stokes theorem framework. Documents the gap: Mathlib v4.26.0 has the rectangular divergence theorem but lacks Stokes for curved-boundary domains.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-05-05",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/GreensTheoremOQ03OQ04.lean",
+    "tags": ["green-theorem", "stokes", "divergence-theorem", "typeI-region", "analysis", "measure-theory"],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-05-05",
+    "axiomCount": 1,
+    "lineCount": 250,
     "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "stokes_for_curved_domains_not_in_mathlib_4_26: Mathlib v4.26.0 lacks Stokes theorem for manifolds with piecewise-smooth curved boundaries. (Documented as a True axiom — a Mathlib gap, not a mathematical assumption.)",
+    "originalContributions": [
+      "Proves Green's theorem for rectangles from Mathlib's integral2_divergence_prod_of_hasFDerivWithinAt_off_countable via F=(Q,-P) substitution",
+      "Shows the 4-side boundary decomposition matches counterclockwise ∮(P dx+Q dy) via ring",
+      "Connects OQ-03 FTC proof to Stokes framework: greens_theorem_typeI_via_stokes delegates to OQ-03's greens_theorem_typeI",
+      "Documents Mathlib v4.26.0 gap: rectangular divergence theorem present, curved-boundary Stokes absent"
+    ],
+    "proofStrategy": "Apply MeasureTheory.integral2_divergence_prod_of_hasFDerivWithinAt_off_countable with f=Q, g=-P to derive Green's theorem for rectangles. Show boundary decomposition equals counterclockwise line integral (by ring). For general TypeI regions, delegate to OQ-03's greens_theorem_typeI axiom. Document the curved-domain Stokes gap."
+  },
+  "overview": {
+    "historicalContext": "Green's theorem was stated by George Green in 1828 and published in 'An Essay on the Application of Mathematical Analysis to the Theories of Electricity and Magnetism.' It connects a double integral over a region to a line integral around its boundary, and is one of the fundamental results of vector calculus. The theorem was later recognized as a special case of the general Stokes' theorem on differential forms — specifically, Stokes applied to the 1-form ω = P dx + Q dy on a 2D manifold with boundary gives exactly Green's theorem. This entry explores this connection, showing how Mathlib's 2D divergence theorem (itself a form of Stokes) directly yields Green's theorem for rectangles, while the FTC-based OQ-03 proof handles the general TypeI case where curved-boundary Stokes is not yet in Mathlib.",
+    "problemStatement": "**OQ-04 (from greens-theorem-oq-03)**: Can Mathlib's divergence theorem be used to derive Green's theorem for TypeI regions as a corollary of Stokes' theorem? For the **rectangular case**: given a C¹ vector field $(P, Q)$ on $[a_1, b_1] \\times [a_2, b_2]$, apply Mathlib's `integral2_divergence_prod_of_hasFDerivWithinAt_off_countable` with $F = (Q, -P)$ to obtain $$\\iint_{D} \\left(\\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}\\right) dA = \\oint_{\\partial D} P\\,dx + Q\\,dy$$",
+    "proofStrategy": "The key insight: for $F = (Q, -P)$, $\\text{div}(F) = \\partial Q/\\partial x - \\partial P/\\partial y$ (the Green's theorem integrand), and the divergence theorem boundary output $(F_1 \\text{ top/bottom}) + (F_2 \\text{ right/left})$ matches the counterclockwise line integral $\\oint P\\,dx + Q\\,dy$. The Lean proof chain: (1) apply Mathlib's divergence theorem theorem with F=(Q,-P), (2) identify the boundary output as ∮ P dx+Q dy by ring, (3) for TypeI regions, delegate to OQ-03's greens_theorem_typeI.",
+    "keyInsights": [
+      "The substitution $F = (Q, -P)$ transforms the divergence theorem $\\iint \\text{div}(F) = \\oint F \\cdot n\\,ds$ into Green's theorem $\\iint (\\partial Q/\\partial x - \\partial P/\\partial y) = \\oint P\\,dx + Q\\,dy$ — the connection is purely algebraic",
+      "Mathlib's `integral2_divergence_prod_of_hasFDerivWithinAt_off_countable` is the key Mathlib ingredient: it gives the divergence theorem for arbitrary rectangles (possibly with a countable exceptional set where differentiability can fail)",
+      "The boundary decomposition proof is trivial (`ring`) because the Lean Mathlib divergence theorem produces exactly the 4-side expression that IS the counterclockwise line integral",
+      "The general TypeI case (curved boundaries) does NOT need a curved-boundary Stokes theorem — the OQ-03 FTC approach handles it directly, so the Mathlib gap only matters if one wants a unified differential-forms proof",
+      "The axiom `stokes_for_curved_domains_not_in_mathlib_4_26 : True` is a documentation device — it records a Mathlib gap, not a mathematical hypothesis. The entry has 0 sorries and 1 documentation axiom."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/GreensTheoremOQ03OQ04.lean",
+    "imports": ["Mathlib", "Proofs.GreensTheoremOQ03"],
+    "opens": ["MeasureTheory", "intervalIntegral", "GreensTheoremOQ03"],
+    "namespace": "GreensTheoremOQ03OQ04",
+    "lineCount": 250,
     "axiomCount": 1,
     "sorries": 0,
-    "lineCount": 250,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "theoremCount": 5
   },
-  "assumptions": [
-    "stokes_for_curved_domains_not_in_mathlib_4_26: Mathlib v4.26.0 lacks Stokes theorem for manifolds with piecewise-smooth curved boundaries"
+  "parentId": "greens-theorem-oq-03",
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Will Mathlib eventually add a general Stokes theorem for 2D domains with piecewise-smooth curved boundaries, enabling a unified differential-forms proof of Green's theorem?",
+      "difficulty": "medium",
+      "status": "open"
+    },
+    {
+      "id": "oq-02",
+      "question": "Can the Green's theorem for TypeI regions be extended to multiply-connected domains (with holes), using Stokes' theorem for manifolds with multiple boundary components?",
+      "difficulty": "hard",
+      "status": "open"
+    }
   ],
-  "openQuestions": [],
-  "tags": ["green-theorem", "stokes", "divergence-theorem", "typeI-region", "analysis", "measure-theory"],
-  "mathContext": {
-    "overview": "Green's theorem (∬(∂Q/∂x - ∂P/∂y)dA = ∮(P dx + Q dy)) admits two proof strategies: (1) FTC-based decomposition into TypeI/II regions (OQ-03), and (2) Stokes' theorem for manifolds with boundary. This entry shows that Mathlib's divergence theorem (`integral2_divergence_prod_of_hasFDerivWithinAt_off_countable`) gives the rectangular case via the substitution F=(Q,-P), confirming consistency between the two approaches.",
-    "keyInsights": [
-      "Applying Mathlib's 2D divergence theorem with F=(Q,-P) directly yields Green's theorem for rectangles",
-      "The boundary integral ∮(P dx+Q dy) decomposes as P-contributions + Q-contributions matching Mathlib's boundary output",
-      "TypeI region Green's theorem (OQ-03) is equivalent to Stokes' theorem on manifolds with boundary",
-      "Mathlib v4.26.0 has rectangular divergence theorem but lacks curved-boundary Stokes — this gap explains the OQ-03 FTC approach"
-    ],
-    "mathBackground": "The divergence theorem and Stokes' theorem are equivalent for 2D vector fields. Mathlib's `MeasureTheory.integral2_divergence_prod_of_hasFDerivWithinAt_off_countable` implements the divergence theorem for arbitrary rectangles, which is sufficient for the OQ-04 connection. Full differential-forms Stokes (needed for curved boundaries) is not yet in Mathlib v4.26.0.",
-    "conclusion": "YES — Mathlib's divergence theorem proves Green's theorem for rectangles. The general TypeI case uses OQ-03's FTC approach (bypassing the missing curved-boundary Stokes). The two strategies are mathematically equivalent; Mathlib currently supports the rectangular special case."
+  "conclusion": {
+    "summary": "For rectangular regions, Green's theorem follows directly from Mathlib's divergence theorem via the algebraic substitution F=(Q,-P), with the boundary identity proved by ring. For general TypeI regions, the OQ-03 FTC approach handles curved boundaries without needing the missing Stokes theorem for curved domains. The documentation axiom records the Mathlib gap.",
+    "implications": "This entry clarifies the relationship between three equivalent approaches to Green's theorem: (1) FTC-based direct proof (OQ-03), (2) divergence theorem specialization (this entry), and (3) general Stokes on manifolds with boundary. All three are mathematically equivalent; their Lean formalizability depends on which Mathlib theorems are available. For the rectangular case, Mathlib already has everything needed; for general smooth boundaries, the differential-forms approach is a future milestone.",
+    "openQuestions": [
+      "When Mathlib adds the general Stokes theorem for smooth manifolds with boundary, can Green's theorem for TypeI regions be re-derived with 0 axioms?",
+      "Can the same substitution F=(Q,-P) be used in higher dimensions to connect the divergence theorem with exterior derivative / Stokes in n dimensions?",
+      "Is there a way to formalize Green's theorem for domains with self-intersecting or fractal boundaries using measure-theoretic Stokes?"
+    ]
   },
-  "proofStrategy": "Apply `MeasureTheory.integral2_divergence_prod_of_hasFDerivWithinAt_off_countable` with f=Q, g=-P to derive Green's theorem for rectangles. Show boundary decomposition equals counterclockwise line integral. For general TypeI regions, delegate to OQ-03's `greens_theorem_typeI` axiom. Document the gap: Stokes for curved boundaries is not in Mathlib v4.26.0.",
-  "originalContributions": [
-    "Proves Green's theorem for rectangles directly from Mathlib's divergence theorem via F=(Q,-P) substitution",
-    "Shows the 4-side boundary decomposition matches counterclockwise ∮(P dx+Q dy)",
-    "Connects OQ-03 FTC proof to Stokes framework via `greens_theorem_typeI_via_stokes`",
-    "Documents Mathlib v4.26.0 gap: rectangular divergence present, curved-boundary Stokes absent"
+  "crossReferences": [
+    {
+      "id": "greens-theorem-oq-03",
+      "title": "Green's Theorem for TypeI Regions via FTC",
+      "relationship": "parent"
+    },
+    {
+      "id": "greens-theorem",
+      "title": "Green's Theorem",
+      "relationship": "ancestor"
+    }
   ],
   "sections": [
     {
-      "title": "Rectangles via Divergence Theorem",
-      "description": "Green's theorem for rectangles proved from Mathlib's integral2_divergence_prod_of_hasFDerivWithinAt_off_countable with the substitution F=(Q,-P).",
-      "theorems": ["greens_theorem_rect_via_stokes"]
+      "title": "Green's Theorem for Rectangles via Divergence Theorem",
+      "startLine": 63,
+      "endLine": 102,
+      "summary": "greens_theorem_rect_via_stokes: proves Green's theorem for [a₁,b₁]×[a₂,b₂] by applying Mathlib's integral2_divergence_prod_of_hasFDerivWithinAt_off_countable with F=(Q,-P). Needs ContinuousOn for P and Q, HasFDerivAt on interior minus countable exceptional set, and integrability of ∂Q/∂x - ∂P/∂y.",
+      "mathContext": "$$\\int_{a_1}^{b_1}\\int_{a_2}^{b_2} \\left(\\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}\\right) dy\\,dx = \\text{boundary integral}$$ via Mathlib with $F = (Q, -P)$ so $\\text{div}(F) = \\partial Q/\\partial x - \\partial P/\\partial y$."
     },
     {
-      "title": "Boundary Decomposition",
-      "description": "Shows the divergence theorem's boundary output equals the line integral ∮(P dx+Q dy) around the rectangle.",
-      "theorems": ["boundary_integral_decomposition", "boundary_eq_line_integral_parts"]
+      "title": "Boundary Integral Decomposition",
+      "startLine": 111,
+      "endLine": 135,
+      "summary": "boundary_integral_decomposition and boundary_eq_line_integral_parts: proves the Mathlib divergence theorem output equals ∮(P dx+Q dy) as a sum of 4 oriented segments. Both proofs are by ring and simp.",
+      "mathContext": "The 4-segment counterclockwise boundary: $\\int_{a_1}^{b_1} P(x,a_2)\\,dx$ (bottom) $+ \\int_{a_2}^{b_2} Q(b_1,y)\\,dy$ (right) $- \\int_{a_1}^{b_1} P(x,b_2)\\,dx$ (top, reversed) $- \\int_{a_2}^{b_2} Q(a_1,y)\\,dy$ (left, reversed)."
     },
     {
-      "title": "Consistency with OQ-03",
-      "description": "Confirms that Stokes/divergence and OQ-03's FTC approach give identical results for rectangular TypeI regions.",
-      "theorems": ["rect_greens_consistent_with_typeI"]
+      "title": "Consistency with OQ-03 TypeI Approach",
+      "startLine": 149,
+      "endLine": 164,
+      "summary": "rect_greens_consistent_with_typeI: proves the OQ-03 boundary sign convention for P matches the Stokes boundary term. The P-contribution in OQ-03 (top minus bottom) equals -((-P)(x,d) - (-P)(x,c)), consistent with Stokes' outward normal convention.",
+      "mathContext": "$-(\\int_a^b [P(x,d) - P(x,c)]\\,dx) = \\int_a^b [P(x,c) - P(x,d)]\\,dx$, confirming the sign conventions agree."
     },
     {
-      "title": "General TypeI Regions",
-      "description": "Shows TypeI Green's theorem is equivalent to Stokes on manifolds with boundary; documents Mathlib v4.26.0 gap.",
-      "theorems": ["greens_theorem_typeI_via_stokes"],
-      "axioms": ["stokes_for_curved_domains_not_in_mathlib_4_26"]
+      "title": "General TypeI via OQ-03 Axiom",
+      "startLine": 179,
+      "endLine": 204,
+      "summary": "greens_theorem_typeI_via_stokes: delegates to OQ-03's greens_theorem_typeI, repackaging it as a Stokes statement. The documentation axiom stokes_for_curved_domains_not_in_mathlib_4_26 : True records the Mathlib v4.26.0 gap.",
+      "mathContext": "For TypeI region $D = \\{(x,y) : a \\leq x \\leq b,\\, f(x) \\leq y \\leq g(x)\\}$ with curved boundary, full differential-forms Stokes is needed: $\\int_D d\\omega = \\int_{\\partial D} \\omega$ for $\\omega = P\\,dx + Q\\,dy$. This requires Stokes for 2D manifolds with piecewise-smooth boundary, absent from Mathlib v4.26.0."
+    },
+    {
+      "title": "Summary Table",
+      "startLine": 227,
+      "endLine": 250,
+      "summary": "Documentation section listing all 5 theorems with their proof methods and the answer to OQ-04: YES for rectangles via Mathlib's divergence theorem; general TypeI handled via OQ-03's FTC approach."
     }
   ]
 }

--- a/src/data/proofs/greens-theorem-oq-03-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03-oq-04/meta.json
@@ -35,6 +35,13 @@
       "The boundary decomposition proof is trivial (`ring`) because the Lean Mathlib divergence theorem produces exactly the 4-side expression that IS the counterclockwise line integral",
       "The general TypeI case (curved boundaries) does NOT need a curved-boundary Stokes theorem — the OQ-03 FTC approach handles it directly, so the Mathlib gap only matters if one wants a unified differential-forms proof",
       "The axiom `stokes_for_curved_domains_not_in_mathlib_4_26 : True` is a documentation device — it records a Mathlib gap, not a mathematical hypothesis. The entry has 0 sorries and 1 documentation axiom."
+    ],
+    "prerequisites": [
+      "Green's theorem and its classical proof strategies",
+      "Divergence theorem (Gauss's theorem) in 2D",
+      "Stokes' theorem on manifolds with boundary",
+      "Mathlib's MeasureTheory.intervalIntegral API",
+      "TypeI and TypeII region formalism from greens-theorem-oq-03"
     ]
   },
   "leanFile": {
@@ -74,50 +81,67 @@
   },
   "crossReferences": [
     {
-      "id": "greens-theorem-oq-03",
-      "title": "Green's Theorem for TypeI Regions via FTC",
-      "relationship": "parent"
+      "proofId": "greens-theorem-oq-03",
+      "relationship": "extends",
+      "description": "OQ-04 builds on OQ-03's TypeI region framework, showing its FTC proof connects to Stokes' theorem and proving the rectangular case directly from Mathlib's divergence theorem"
     },
     {
-      "id": "greens-theorem",
-      "title": "Green's Theorem",
-      "relationship": "ancestor"
+      "proofId": "greens-theorem",
+      "relationship": "extends",
+      "description": "Base Green's theorem entry; OQ-04 shows the relationship between Green's theorem and the general Stokes' theorem framework"
+    },
+    {
+      "proofId": "greens-theorem-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 proves Green's theorem for rectangles via FTC; OQ-04 gives an independent proof of the same rectangular case via Mathlib's divergence theorem"
     }
   ],
   "sections": [
     {
+      "id": "sec-oq04-header",
+      "title": "Module Header and OQ-04 Context",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports, namespace declaration, and the OQ-04 problem statement. Identifies the key Mathlib tool (integral2_divergence_prod_of_hasFDerivWithinAt_off_countable) and the F=(Q,-P) substitution strategy."
+    },
+    {
+      "id": "sec-rect-via-stokes",
       "title": "Green's Theorem for Rectangles via Divergence Theorem",
       "startLine": 63,
-      "endLine": 102,
+      "endLine": 110,
       "summary": "greens_theorem_rect_via_stokes: proves Green's theorem for [a₁,b₁]×[a₂,b₂] by applying Mathlib's integral2_divergence_prod_of_hasFDerivWithinAt_off_countable with F=(Q,-P). Needs ContinuousOn for P and Q, HasFDerivAt on interior minus countable exceptional set, and integrability of ∂Q/∂x - ∂P/∂y.",
       "mathContext": "$$\\int_{a_1}^{b_1}\\int_{a_2}^{b_2} \\left(\\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}\\right) dy\\,dx = \\text{boundary integral}$$ via Mathlib with $F = (Q, -P)$ so $\\text{div}(F) = \\partial Q/\\partial x - \\partial P/\\partial y$."
     },
     {
+      "id": "sec-boundary-decomposition",
       "title": "Boundary Integral Decomposition",
       "startLine": 111,
-      "endLine": 135,
+      "endLine": 170,
       "summary": "boundary_integral_decomposition and boundary_eq_line_integral_parts: proves the Mathlib divergence theorem output equals ∮(P dx+Q dy) as a sum of 4 oriented segments. Both proofs are by ring and simp.",
       "mathContext": "The 4-segment counterclockwise boundary: $\\int_{a_1}^{b_1} P(x,a_2)\\,dx$ (bottom) $+ \\int_{a_2}^{b_2} Q(b_1,y)\\,dy$ (right) $- \\int_{a_1}^{b_1} P(x,b_2)\\,dx$ (top, reversed) $- \\int_{a_2}^{b_2} Q(a_1,y)\\,dy$ (left, reversed)."
     },
     {
+      "id": "sec-consistency",
       "title": "Consistency with OQ-03 TypeI Approach",
-      "startLine": 149,
-      "endLine": 164,
+      "startLine": 171,
+      "endLine": 207,
       "summary": "rect_greens_consistent_with_typeI: proves the OQ-03 boundary sign convention for P matches the Stokes boundary term. The P-contribution in OQ-03 (top minus bottom) equals -((-P)(x,d) - (-P)(x,c)), consistent with Stokes' outward normal convention.",
       "mathContext": "$-(\\int_a^b [P(x,d) - P(x,c)]\\,dx) = \\int_a^b [P(x,c) - P(x,d)]\\,dx$, confirming the sign conventions agree."
     },
     {
-      "title": "General TypeI via OQ-03 Axiom",
-      "startLine": 179,
-      "endLine": 204,
+      "id": "sec-typeI-general",
+      "title": "General TypeI Regions via Stokes and Mathlib Gap",
+      "startLine": 208,
+      "endLine": 235,
       "summary": "greens_theorem_typeI_via_stokes: delegates to OQ-03's greens_theorem_typeI, repackaging it as a Stokes statement. The documentation axiom stokes_for_curved_domains_not_in_mathlib_4_26 : True records the Mathlib v4.26.0 gap.",
       "mathContext": "For TypeI region $D = \\{(x,y) : a \\leq x \\leq b,\\, f(x) \\leq y \\leq g(x)\\}$ with curved boundary, full differential-forms Stokes is needed: $\\int_D d\\omega = \\int_{\\partial D} \\omega$ for $\\omega = P\\,dx + Q\\,dy$. This requires Stokes for 2D manifolds with piecewise-smooth boundary, absent from Mathlib v4.26.0."
     },
     {
-      "title": "Summary Table",
-      "startLine": 227,
+      "id": "sec-stokes-green-equivalence",
+      "title": "Stokes–Green Equivalence and Summary",
+      "startLine": 236,
       "endLine": 250,
-      "summary": "Documentation section listing all 5 theorems with their proof methods and the answer to OQ-04: YES for rectangles via Mathlib's divergence theorem; general TypeI handled via OQ-03's FTC approach."
+      "summary": "Documents the abstract equivalence: Mathlib's divergence theorem IS a form of Stokes' theorem with ω = P dx + Q dy, dω = (∂Q/∂x − ∂P/∂y) dx∧dy, M = rectangular region. The summary table lists all 5 theorems with their proof methods and the answer to OQ-04."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `greens-theorem-oq-03-oq-04` (Green's Theorem via Stokes).

## Changes

- **meta.json restructured** to standard schema: proper `meta{}` sub-object with author/status/badge, `overview{}` with historicalContext/problemStatement/proofStrategy/keyInsights, structured `sections[]` with startLine/endLine, `conclusion{}`, `crossReferences`
- **annotations.json created** (was missing entirely) with 4 annotations covering:
  - The F=(Q,-P) substitution that transforms divergence theorem into Green's theorem
  - Boundary decomposition identity (proved by ring)  
  - Sign convention consistency between OQ-03 and Stokes approaches
  - General TypeI delegation to OQ-03 axiom + Mathlib gap documentation
- **index.ts fixed** from bare `export { default } from './meta.json'` to proper typed ProofData export

## Build result
Build succeeded: `Enriched greens-theorem-oq-03-oq-04: 7 lean files, 7 related proofs`