### PR TITLE
fix(meta): sync lineCount and theoremCount for erdos-467

### DIFF
--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -50,10 +50,10 @@
       "Mertens placeholder proved (vacuous conclusion identified and discharged)"
     ],
     "axiomCount": 1,
-    "lineCount": 250,
+    "lineCount": 277,
     "assumptions": "1 axiom: erdos_467_conjecture (the main open conjecture). CRT and Mertens estimate now fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 23
+    "theoremCount": 25
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their 1980 monograph (p.93), asking whether the redundancy in prime residue classes — captured by the divergence of $\\sum 1/p$ — is sufficient to split primes into two halves that each independently cover everything. The original quantifier structure is subtle: 'for sufficiently large $x$' means $\\exists X,\\, \\forall x \\geq X$. The problem connects covering congruences (a classical Erdős theme) to the Chinese Remainder Theorem and Mertens' product estimates.",
@@ -144,9 +144,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 250,
+    "lineCount": 277,
     "axiomCount": 1,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 6,
     "path": "Proofs/Erdos467Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `leanFile.lineCount` and `leanFile.theoremCount` (and their `meta` counterparts) for `erdos-467`.

## Evidence

**Before**:
- `leanFile.lineCount: 250`
- `leanFile.theoremCount: 23`
- `meta.lineCount: 250`
- `meta.theoremCount: 23`

**After**:
- `leanFile.lineCount: 277` (actual: `wc -l = 277`)
- `leanFile.theoremCount: 25` (actual: 25 theorem/lemma declarations after comment-stripping)
- `meta.lineCount: 277`
- `meta.theoremCount: 25`

**Root cause**: The Lean file gained 3 theorems (`zero_assign_no_dual_cover`, `dual_cover_needs_unit_class`, `coverage_exceeds_target`) plus 1 def (`erdos_467_status`) in a "Necessary Conditions" section (lines 242–277). The `definitionCount` was updated to 6 at that time but `lineCount` and `theoremCount` were not.

Sorries (0), axiomCount (1), definitionCount (6), and status (axiomatized/axiom badge) all remain correct.

---
Automated fix by lean-mechanic agent.