### PR TITLE
chore(audit): update tracker for 2026-05-05 audit session

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14693,6 +14693,24 @@
       "issues": [
         "lineCount mismatch: claims 253, actual 311; theoremCount mismatch: claims 7, actual 8 (real_ac_implies_normed_ac undercounted) \u2014 fixed in PR #15948"
       ]
+    },
+    "greens-theorem-oq-03-oq-04": {
+      "auditCount": 4,
+      "lastAudited": "2026-05-05T04:08:48Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "dissection-of-cubes-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-05T03:54:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-05T03:56:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

- `greens-theorem-oq-03-oq-04`: **issues-found** — meta.json uses flat structure instead of standard nested `meta` wrapper, causing find-targets.ts to report `claimedSorries = -1` (reads `meta.meta` which is undefined). Fix PRs #15968 and #15972 are in flight. Lean source is correct: 0 sorries, 1 axiom, 250 lines.
- `dissection-of-cubes-oq-03-oq-02`: clean
- `lagrange-theorem-oq-02-oq-02`: clean

Note: This supersedes PR #15976 which incorrectly marked greens-theorem-oq-03-oq-04 as clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)