### PR TITLE
fix(meta): correct badge for angle-trisection-cos-20-gal-oq-01-oq-02-oq-02

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -19,7 +19,7 @@
       "chebyshev",
       "general-formula"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 175,


### PR DESCRIPTION
## Summary

- `badge` was `\"verified\"` despite `sorries: 1` — a HIGH severity integrity violation
- Corrected badge to `\"wip\"` to accurately reflect the proof has 1 documented sorry (normality of ℚ(cos(π/n))/ℚ)
- `status: \"formalized\"` and `sorries: 1` fields were already correct

## Evidence

**meta.json claimed**: `badge: "verified"`, `sorries: 1`
**Lean file shows**: 1 sorry in `cos_pi_splitting_finrank` (documented, on normality of conjSubgroup)

The `"verified"` badge requires 0 sorries. Badge changed to `"wip"` which correctly indicates proof-in-progress.

## Test plan
- [ ] Verify meta.json badge field reads `"wip"`
- [ ] Confirm no other fields changed

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)