### PR TITLE
fix(meta): sync badge/lineCount/theoremCount for angle-trisection-cos-20-gal-oq-01-oq-02-oq-02

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -19,15 +19,15 @@
       "chebyshev",
       "general-formula"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 175,
+    "lineCount": 232,
     "assumptions": "1 sorry on: finrank ℚ (SplittingField (minpoly ℚ (cos(π/n)))) = φ(2n)/2. This step requires formalizing that ℚ(cos(π/n)) is Galois over ℚ (fixed field of a normal subgroup of an abelian Galois group), hence minpoly splits completely over it. The degree theorem natDegree = φ(2n)/2 is fully proved with 0 sorries.",
     "mathlib_version": "4.26.0",
     "historicalContext": "The formula |Gal(minpoly(cos(π/n))/ℚ)| = φ(2n)/2 connects classical angle trisection impossibility to cyclotomic field theory. Individual cases n=5 (|Gal|=2), n=7 (|Gal|=3), n=9 (|Gal|=3) were proved in earlier gallery entries. This file provides the general proof using IsCyclotomicExtension, answering the open question from AngleTrisectionCos20GalOQ01OQ02.",
     "proofStrategy": "The key observation is cos(π/n) = cos(2π/(2n)). This reduces the problem to the cos(2π/m) family handled by AngleTrisectionOQ02OQ03OQ01 (which formalizes the (m)-th cyclotomic field machinery). Applying that infrastructure with m = 2n gives: natDegree(minpoly(cos(π/n))) = φ(2n)/2. The full Galois order = degree requires additionally showing the splitting field has degree φ(2n)/2, which follows from normality of ℚ(cos(π/n))/ℚ (conjSubgroup is normal in the abelian Galois group).",
-    "theoremCount": 11
+    "theoremCount": 12
   },
   "overview": {
     "problemStatement": "For n ≥ 3, does the Galois group of the minimal polynomial of cos(π/n) over ℚ have order φ(2n)/2? Can this be proved using IsCyclotomicExtension?",
@@ -53,9 +53,9 @@
       "Proofs.AngleTrisectionCos20GalOQ01OQ02"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ02OQ02",
-    "lineCount": 175,
+    "lineCount": 232,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean",
     "sorries": 1


### PR DESCRIPTION
## Summary

Three meta.json integrity issues for `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02` — discovered during gallery integrity audit.

| Field | Before | After | Reason |
|---|---|---|---|
| `meta.badge` | `"verified"` | `"wip"` | proof has 1 documented sorry; `"verified"` requires 0 |
| `meta.lineCount` | `175` | `232` | actual Lean file is 232 lines |
| `leanFile.lineCount` | `175` | `232` | matches actual |
| `meta.theoremCount` | `11` | `12` | file has 1 lemma + 11 theorems = 12 declarations |
| `leanFile.theoremCount` | `11` | `12` | matches actual |

## Verification

```
$ git show origin/main:proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean | wc -l
232
$ git show origin/main:proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean | grep -cE "^(theorem|lemma) "
12
```

The 1 documented sorry is in `cos_pi_splitting_finrank` (normality of ℚ(cos(π/n))/ℚ — fixed field of conjSubgroup in the abelian Galois group).

## Related PRs

- #15984 — overlapping badge-only fix (same `meta.badge` line). If that PR merges first, this PR will need a trivial rebase; if this merges first, #15984 becomes a no-op.

Diff is exactly 5 lines, scoped to `src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json`.