### PR TITLE
fix(meta): sync theoremCount and lineCount for 42 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-03/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 187,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "mathlibDependencies": [
       {
@@ -68,7 +68,7 @@
       "lgvMatrix"
     ],
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "sorries": 0,
     "definitionCount": 1
   },

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
     "lineCount": 588,
-    "theoremCount": 27,
+    "theoremCount": 26,
     "definitionCount": 3,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -146,7 +146,7 @@
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 27,
+    "theoremCount": 26,
     "definitionCount": 3
   },
   "sorries": 0

--- a/src/data/proofs/buffons-needle-oq-02-oq-03/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-03/meta.json
@@ -64,7 +64,7 @@
     ],
     "dateAdded": "2026-05-03",
     "axiomCount": 3,
-    "lineCount": 286,
+    "lineCount": 285,
     "assumptions": "3 axioms: kinematicMeasure (existence of kinematic measure on AffineHyperplane n), cauchy_crofton_segment (single-segment Cauchy-Crofton formula E_μ[crossing(s)] = α_n · length(s)), crossing_integrable (crossing indicator is integrable w.r.t. kinematic measure). No sorries.",
     "mathlib_version": "4.26.0",
     "definitionCount": 7,
@@ -216,7 +216,7 @@
       "BigOperators"
     ],
     "namespace": "BuffonsNeedleOQ02OQ03",
-    "lineCount": 286,
+    "lineCount": 285,
     "axiomCount": 3,
     "theoremCount": 27,
     "definitionCount": 7,

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified from Mathlib.",
     "lineCount": 340,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 4,
     "originalContributions": [
       "menelaus_algebraic_core: unified algebraic core for all three geometries (product = -1 iff numerator = -denominator)",
@@ -119,7 +119,7 @@
     "namespace": "CevasTheoremNonEuclideanOQ02OQ01",
     "lineCount": 340,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 4,
     "path": "Proofs/CevasTheoremNonEuclideanOQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-02/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Bézout's identity in EuclideanDomain.",
     "lineCount": 378,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 0,
     "originalContributions": [
       "lcm_gcd_dvd_gcd_lcm: lcm(gcd(a,c), gcd(b,c)) ∣ gcd(lcm(a,b), c) in any EuclideanDomain",
@@ -69,7 +69,7 @@
     "namespace": "ChineseRemainderNonCoprimeOQ03OQ02",
     "lineCount": 378,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/ChineseRemainderNonCoprimeOQ03OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/denumerability-rationals-oq-02/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "Core results (cantor_characterization, countable_dense_linear_orders_iso, rationals_selfsimilar) derived directly from Mathlib's Order.iso_of_countable_dense. Bridge and infrastructure formalization only.",
     "lineCount": 237,
-    "theoremCount": 19,
+    "theoremCount": 18,
     "definitionCount": 3,
     "originalContributions": [
       "integers_embed: ℤ embeds strictly monotonically into ℚ (as n ↦ n : ℚ) — independent proof",
@@ -63,7 +63,7 @@
     "namespace": "DenumerabilityRationalsOQ02",
     "lineCount": 237,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/DenumerabilityRationalsOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. This proof uses only Mathlib theorems: gaussSum_sq, quadraticChar_isQuadratic, quadraticChar_ne_one, ZMod.isPrimitive_stdAddChar, legendreSym.at_neg_one, χ₄_eq_neg_one_pow.",
     "lineCount": 199,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 1,
     "originalContributions": [
       "gauss_sum_sq_in_complex: proof that gaussSum(χ,ψ)² = (-1)^(p/2)·p in ℂ (replaces axiom from parent)",
@@ -37,7 +37,7 @@
     "path": "Proofs/ElementaryQuadraticReciprocityOQ02OQ01.lean",
     "lineCount": 199,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 1,
     "sorries": 0
   },

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Delegates to FairGamesTheoremOQ03.lean (which is fully verified) and Mathlib's martingale library.",
     "lineCount": 291,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 0,
     "originalContributions": [
       "doob_optional_stopping_theorem: clean standalone statement of the bounded OST",
@@ -75,7 +75,7 @@
     ],
     "lineCount": 291,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/FairGamesTheoremOQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Constructive core (Parts I-V) uses no classical axioms. Endpoint convergence (Part VI) uses Classical.choice via Mathlib's tendsto_atTop_ciSup (completeness of \u211d). Root theorem (Part VII) uses Continuous.tendsto.",
     "lineCount": 308,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 3,
     "originalContributions": [
       "paramBisect: computable (non-noncomputable) bisection parameterized by explicit choice oracle",
@@ -84,7 +84,7 @@
   ],
   "leanFile": {
     "path": "Proofs/IntermediateValueTheoremOQ02OQ03.lean",
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 3,
     "axiomCount": 0,
     "lineCount": 308,

--- a/src/data/proofs/inverse-galois-a5/meta.json
+++ b/src/data/proofs/inverse-galois-a5/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 2067,
-    "theoremCount": 85,
+    "theoremCount": 84,
     "definitionCount": 8,
     "mathlib_version": "4.26.0"
   },
@@ -82,7 +82,7 @@
     "namespace": "InverseGaloisA5",
     "lineCount": 2067,
     "axiomCount": 1,
-    "theoremCount": 85,
+    "theoremCount": 84,
     "definitionCount": 8,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0

--- a/src/data/proofs/inverse-galois-oq-06/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: three_dvd_gal_card — 3 divides |Gal(q/ℚ)|. This follows from Dedekind's theorem applied to q mod 7 (which factors as (1-cycle)(1-cycle)(3-cycle)), implying the Galois group contains an element of order divisible by 3. Axiomatized because Mathlib lacks Dedekind's theorem for polynomial Galois groups.",
     "lineCount": 2067,
-    "theoremCount": 85,
+    "theoremCount": 84,
     "definitionCount": 12,
     "originalContributions": [
       "q: the polynomial x⁵-5x⁴+10x³-10x²+25x-5 (translate of x⁵+20x+16)",
@@ -87,7 +87,7 @@
     "namespace": "InverseGaloisA5",
     "lineCount": 2067,
     "axiomCount": 1,
-    "theoremCount": 85,
+    "theoremCount": 84,
     "definitionCount": 12,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0

--- a/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
@@ -19,7 +19,7 @@
     "axiomCount": 6,
     "sorries": 0,
     "lineCount": 264,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -180,7 +180,7 @@
     "sorries": 0,
     "axiomCount": 6,
     "lineCount": 264,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 1,
     "originalContributions": [
       "HyperbolicSineTriangle structure with 6 axiom fields encoding the hyperbolic law of sines",

--- a/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "lineCount": 404,
     "assumptions": "4 axioms: Birkhoff ergodic theorem (general and ergodic case), maximal ergodic lemma, von Neumann mean ergodic theorem. These are deep analytical results requiring substantial proof infrastructure.",
     "originalContributions": [
@@ -183,7 +183,7 @@
     "namespace": "LawsOfLargeNumbersOQ03",
     "lineCount": 404,
     "axiomCount": 4,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 5,

--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -202,7 +202,7 @@
     "namespace": "LiouvilleTheoremOQ04",
     "lineCount": 467,
     "axiomCount": 1,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/LiouvilleTheoremOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/puiseux-theorem-oq-02/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/meta.json
@@ -33,7 +33,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 238,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
@@ -70,7 +70,7 @@
     "namespace": "PuiseuxTheoremOQ02",
     "lineCount": 238,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 4,
     "path": "Proofs/PuiseuxTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/shannon-entropy-oq-02/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-02/meta.json
@@ -48,7 +48,7 @@
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 383,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 4,
     "prerequisites": [
       "Shannon entropy and its properties",
@@ -221,7 +221,7 @@
     "namespace": "InformationTheory.KolmogorovEntropy",
     "lineCount": 383,
     "axiomCount": 3,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/ShannonEntropyOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 994,
-    "theoremCount": 29,
+    "theoremCount": 28,
     "definitionCount": 11,
     "mathlib_version": "4.26.0"
   },
@@ -76,11 +76,13 @@
     "namespace": "Triangulation",
     "lineCount": 994,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 28,
     "definitionCount": 11,
     "path": "Proofs/SpernerSimplicialInstance.lean",
     "sorries": 0,
-    "additionalFiles": ["Proofs/SpernerMathlib4.lean"]
+    "additionalFiles": [
+      "Proofs/SpernerMathlib4.lean"
+    ]
   },
   "sections": [
     {


### PR DESCRIPTION
## Fix

Correct `leanFile.theoremCount`, `meta.theoremCount`, `leanFile.lineCount`, and `meta.lineCount` in 42 gallery entries where stored values diverged from actual Lean source files.

**Method**: Scanned all 2321 gallery entries with Lean files. Used regex `\b(theorem|lemma|proposition|corollary)\s+\w` after stripping block/line comments to count declarations including private/noncomputable variants.

**Breakdown**:
- 39 entries: theoremCount only
- 2 entries: both theoremCount and lineCount (`angle-trisection-cos-20-gal-oq-01-oq-02-oq-02`, `erdos-467`)
- 1 entry: lineCount only (`buffons-needle-oq-02-oq-03`)

Notable corrections: tractatus-ontology 47→41, poincare-conjecture 943→941, angle-trisection-cos-20-gal-oq-01-oq-02-oq-02 lineCount 175→232, erdos-467 lineCount 277→250.

---
Automated fix by lean-mechanic agent.