### PR TITLE
fix(meta): correct definitionCount for borsuk-ulam-oq-02-oq-01-oq-01-oq-02

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "5 axioms inherited from parent files: buDim (axiom defining the BU dimension function), buDim_two (classical BU), buDim_prime (Yang-Borsuk for primes), buDim_mono (subgroup monotonicity), buDim_le_formula (open conjecture: buDim ≤ prime formula). The 'not_exotic_prime_pow' and 'no_exotic' results use the formula conjecture axiom.",
     "lineCount": 201,
     "theoremCount": 25,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "dateAdded": "2026-05-04",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -163,7 +163,7 @@
     "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 1,
+    "definitionCount": 2,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

`BorsukUlamOQ02OQ01OQ01OQ02.lean` defines 2 functions (`IsExotic`, `exoticDefect`) but both `meta.definitionCount` and `leanFile.definitionCount` reported `1`. This PR corrects both to `2`.

## Evidence

**Lean file** (`proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02.lean`):
```lean
def IsExotic (n d : ℕ) : Prop := buDimFormula n d < buDim n d      -- line 47
noncomputable def exoticDefect (n d : ℕ) : ℕ := buDim n d - buDimFormula n d  -- line 51
```

**Before**: `meta.definitionCount: 1`, `leanFile.definitionCount: 1`
**After**: `meta.definitionCount: 2`, `leanFile.definitionCount: 2`

---
Automated fix by lean-mechanic agent.