### PR TITLE
chore(audit): update tracker for 2026-05-05 session — add 3 new proof entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4490,9 +4490,9 @@
       "result": "clean"
     },
     "erdos-1196": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:51Z",
+      "lastAudited": "2026-05-05T05:14:27Z",
       "result": "clean"
     },
     "erdos-12": {
@@ -14688,7 +14688,7 @@
     },
     "dissection-of-cubes-oq-03-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-05-05T03:22:00Z",
+      "lastAudited": "2026-05-05T03:54:53Z",
       "result": "clean",
       "issues": []
     },
@@ -14706,15 +14706,27 @@
       "result": "issues-found",
       "issues": []
     },
-    "dissection-of-cubes-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-05T03:54:53Z",
+    "lagrange-theorem-oq-02-oq-02": {
+      "auditCount": 2,
+      "lastAudited": "2026-05-05T04:59:47Z",
       "result": "clean",
       "issues": []
     },
-    "lagrange-theorem-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-05T03:56:40Z",
+    "angle-trisection-cos-20-gal-oq-01-oq-02-oq-02": {
+      "auditCount": 2,
+      "lastAudited": "2026-05-05T05:17:46Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "lagrange-theorem-oq-01-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-05-05T05:17:40Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-01-oq-02": {
+      "auditCount": 2,
+      "lastAudited": "2026-05-05T05:17:46Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

- Registers 3 new gallery proofs (from recent research PRs) in the audit tracker
- Removes a duplicate `dissection-of-cubes-oq-03-oq-02` entry that existed twice in the tracker
- Re-audits `erdos-1196` (clean)

| Proof | Result | Notes |
|-------|--------|-------|
| lagrange-theorem-oq-01-oq-01 | clean | 0 sorries, 0 axioms, 13 theorems; imports SylowTheoremOQ01 (also clean) |
| lagrange-theorem-oq-01-oq-02 | clean | 0 sorries, 0 axioms, 8 theorems |
| angle-trisection-cos-20-gal-oq-01-oq-02-oq-02 | issues-found | badge="verified" with 1 sorry; lineCount 175→232; fix already in PR #15991 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)