### PR TITLE
research(lagrange-theorem-oq-02-oq-02): complete class equation proof, 0 sorries

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ02OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ02.lean
@@ -126,10 +126,15 @@ theorem conj_stabilizer_eq_centralizer (x : G) :
 theorem card_conjClass_eq_centralizer_index [Fintype G] (x : G) :
     Nat.card (ConjClasses.mk x).carrier = (centralizer {x}).index := by
   rw [← conj_orbit_eq_carrier]
-  -- orbit-stabilizer: Nat.card orbit * Nat.card stabilizer = Nat.card G
-  -- with stabilizer (via toConjAct) = centralizer {x}
-  -- so Nat.card orbit = centralizer index
-  sorry -- HARD: finalize via Nat.card orbit-stabilizer and index arithmetic
+  -- Step 1: orbit card = stabilizer index (orbit-stabilizer theorem)
+  have horb : Nat.card (MulAction.orbit (ConjAct G) x) =
+      (MulAction.stabilizer (ConjAct G) x).index := by
+    rw [Subgroup.index_eq_card]
+    exact Nat.card_congr (MulAction.orbitEquivQuotientStabilizer (ConjAct G) x)
+  -- Step 2: stabilizer index = centralizer index via ConjAct.toConjAct isomorphism
+  rw [horb, ← conj_stabilizer_eq_centralizer]
+  exact (Subgroup.index_comap_of_surjective _
+    (ConjAct.toConjAct (G := G)).surjective).symm
 
 /-- A conjugacy class is a singleton iff the element is central. -/
 theorem card_conjClass_eq_one_iff_mem_center [Fintype G] (x : G) :
@@ -240,7 +245,7 @@ end A4
   | `class_equation_symm` | \|G\| = \|Z(G)\| + Σ_{noncenter} \|c\| | Proved |
   | `conj_orbit_eq_carrier` | orbit (ConjAct G) x = conjugacy class carrier | Proved |
   | `conj_stabilizer_eq_centralizer` | stabilizer of conjugation = centralizer | Proved |
-  | `card_conjClass_eq_centralizer_index` | \|[x]\| = [G : C\_G(x)] | 1 sorry (HARD) |
+  | `card_conjClass_eq_centralizer_index` | \|[x]\| = [G : C\_G(x)] | Proved (index\_comap\_of\_surjective) |
   | `card_conjClass_eq_one_iff_mem_center` | \|[x]\| = 1 ↔ x ∈ Z(G) | Proved |
   | `pgroup_fixed_point` | \|X\| ≡ \|Fix(G,X)\| (mod p) | Proved (Mathlib) |
   | `center_nontrivial_of_pgroup` | Z(nontrivial p-group) ≠ \{1\} | Proved (Mathlib) |
@@ -250,7 +255,7 @@ end A4
   | `card_center_A4` | \|Z(A₄)\| = 1 | native\_decide |
   | `A4_not_comm` | A₄ is not abelian | decide |
 
-  **Sorries**: 1 (HARD: orbit-to-index connection for card_conjClass_eq_centralizer_index)
+  **Sorries**: 0
   **Axioms**: 0
 -/
 

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
@@ -2,11 +2,11 @@
   "id": "lagrange-theorem-oq-02-oq-02",
   "title": "The Class Equation for Finite Groups",
   "slug": "lagrange-theorem-oq-02-oq-02",
-  "description": "Formalizes the class equation |G| = |Z(G)| + Σ [G : C_G(x)] for finite groups. The sum is over representatives of non-central conjugacy classes, and each term [G : C_G(x)] equals the conjugacy class size by the orbit-stabilizer theorem. The file proves the class equation directly from Mathlib's `Group.nat_card_center_add_sum_card_noncenter_eq_card`, establishes the orbit-centralizer formula (modulo one technical connection), and verifies key corollaries: center nontriviality for p-groups, groups of order p² are abelian, and concrete computations for A₄.",
+  "description": "Formalizes the class equation |G| = |Z(G)| + Σ [G : C_G(x)] for finite groups. The sum is over representatives of non-central conjugacy classes, and each term [G : C_G(x)] equals the conjugacy class size by the orbit-stabilizer theorem. The file proves the class equation directly from Mathlib's `Group.nat_card_center_add_sum_card_noncenter_eq_card`, establishes the complete orbit-centralizer formula via Subgroup.index_comap_of_surjective applied to ConjAct.toConjAct, and verifies key corollaries: center nontriviality for p-groups, groups of order p² are abelian, and concrete computations for A₄.",
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-05",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02.lean",
     "tags": [
       "group-theory",
@@ -17,10 +17,10 @@
       "orbit-stabilizer",
       "research"
     ],
-    "badge": "research",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 257,
+    "lineCount": 262,
     "theoremCount": 13,
     "definitionCount": 1,
     "dateAdded": "2026-05-05",
@@ -62,12 +62,12 @@
       "card_conjClass_eq_one_iff_mem_center: |[x]| = 1 ↔ x ∈ Z(G) proved from orbit uniqueness and commutativity",
       "A₄ class equation verification: 4 conjugacy classes of sizes 1+3+4+4=12 via native_decide"
     ],
-    "assumptions": "1 sorry (HARD): card_conjClass_eq_centralizer_index needs orbit size to centralizer index connection. 0 axiom declarations. All mathematical content proved or follows from Mathlib.",
+    "assumptions": "0 sorries. 0 axiom declarations. All theorems fully machine-checked. card_conjClass_eq_centralizer_index proved via Subgroup.index_comap_of_surjective applied to the ConjAct.toConjAct isomorphism.",
     "additionalFiles": []
   },
   "overview": {
     "historicalContext": "The class equation is one of the fundamental structural results in finite group theory. Cauchy (1845) proved that prime-order elements exist; this was generalized by Jordan (1871) and Sylow (1872) into the complete conjugacy class decomposition. The equation |G| = |Z(G)| + Σ [G : C_G(xᵢ)] expresses that G is partitioned into conjugacy classes — singleton classes for central elements and non-singleton classes for the rest. The size of each class [G : C_G(x)] follows from the orbit-stabilizer theorem applied to the conjugation action g · x = gxg⁻¹ (stabilizer = centralizer C_G(x), orbit = conjugacy class).\n\nThe class equation is the engine behind p-group theory: since p | |G| and each non-central class has size divisible by p, the equation gives p | |Z(G)|. For nontrivial p-groups, this means Z(G) ≠ {e}. From there, groups of order p² are abelian (G/Z(G) has order 1 or p; if p, then cyclic, making G abelian). This chain ultimately leads to the classification of groups of order pq and the Sylow theorems as the deeper structure behind the equation.",
-    "problemStatement": "**The Open Question**: Can the class equation |G| = |Z(G)| + Σ_{non-central conjugacy classes [x]} [G : C_G(x)] be formally proved in Lean 4, establishing the orbit-centralizer formula and its p-group corollaries?\n\n**Answer**: Largely yes. The class equation itself is directly available from Mathlib's `Group.nat_card_center_add_sum_card_noncenter_eq_card`. The orbit-stabilizer connection `|[x]| = [G : C_G(x)]` is proved up to one technical sorry (connecting Nat.card of an orbit to the centralizer index via division arithmetic). All p-group corollaries are provable from Mathlib.",
+    "problemStatement": "**The Open Question**: Can the class equation |G| = |Z(G)| + Σ_{non-central conjugacy classes [x]} [G : C_G(x)] be formally proved in Lean 4, establishing the orbit-centralizer formula and its p-group corollaries?\n\n**Answer**: Yes, completely. The class equation comes from Mathlib's `Group.nat_card_center_add_sum_card_noncenter_eq_card`. The orbit-centralizer formula `|[x]| = [G : C_G(x)]` is fully proved: orbit ≃ (ConjAct G)/stabilizer by orbit-stabilizer, then (ConjAct G)/stabilizer card equals G/centralizer card via `Subgroup.index_comap_of_surjective` applied to the isomorphism `ConjAct.toConjAct : G ≃* ConjAct G`. All p-group corollaries proved from Mathlib.",
     "text": "The class equation |G| = |Z(G)| + Σ [G : C_G(x)] emerges from the orbit-stabilizer theorem applied to conjugation. The proof chain:\n\n(1) **Partition**: G is partitioned into conjugacy classes via `ConjClasses.mk : G → ConjClasses G`\n(2) **Orbit-stabilizer**: |conjugacy class of x| = [G : C_G(x)] (by orbit-stabilizer with stabilizer = centralizer)\n(3) **Central ↔ singleton**: a conjugacy class has exactly one element iff the element is central (gxg⁻¹ = x for all g iff gx = xg for all g)\n(4) **Split**: |G| = (sum of singleton classes) + (sum of non-singleton classes) = |Z(G)| + Σ [G : C_G(x)]",
     "proofStrategy": "The class equation is extracted directly from Mathlib's `Group.nat_card_center_add_sum_card_noncenter_eq_card` in `Mathlib.GroupTheory.ClassEquation`. The orbit-centralizer formula is established via: (a) `conj_orbit_eq_carrier` connecting orbits under `ConjAct G` to conjugacy class carriers, and (b) `conj_stabilizer_eq_centralizer` identifying the conjugation stabilizer with the centralizer. The connection of orbit size to centralizer index (one sorry) uses the orbit-stabilizer theorem `|orbit| × |stabilizer| = |G|` with the centralizer index = |G|/|centralizer|.",
     "keyInsights": [
@@ -90,8 +90,8 @@
       "ConjClasses",
       "MulAction"
     ],
-    "lineCount": 257,
-    "sorries": 1,
+    "lineCount": 262,
+    "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 1
@@ -99,12 +99,13 @@
   "openQuestions": [
     {
       "id": "oq-01",
-      "question": "Can card_conjClass_eq_centralizer_index be proved without sorry — completing the orbit-to-centralizer-index connection for conjugacy classes?",
+      "question": "Can the class equation be used to give a fully elementary proof of Burnside's lemma (|X/G| = (1/|G|) Σ_g |Fix(g)|) without orbit-counting arguments?",
       "difficulty": "medium",
       "tags": [
         "lean4",
-        "orbit-stabilizer",
-        "subgroup-index"
+        "burnside",
+        "class-equation",
+        "group-actions"
       ]
     },
     {

--- a/src/data/research/problems/lagrange-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/lagrange-theorem-oq-02-oq-02.json
@@ -44,7 +44,10 @@
       "conj_stabilizer_eq_centralizer proved cleanly using group tactic for g*x*g⁻¹ = x ↔ g*x = x*g equivalence",
       "card_conjClass_eq_one_iff_mem_center proved via orbit uniqueness: unique orbit ↔ all elements fixed by conjugation ↔ central",
       "IsPGroup.commGroupOfCardEqPrimeSq gives groups of order p² are abelian directly from Mathlib",
-      "A4 has 4 conjugacy classes (sizes 1,3,4,4) and trivial center — verified by native_decide"
+      "A4 has 4 conjugacy classes (sizes 1,3,4,4) and trivial center — verified by native_decide",
+      "ConjAct.stabilizer_eq_centralizer (Mathlib): stabilizer (ConjAct G) x = centralizer {toConjAct x} — the key lemma connecting stabilizer to centralizer",
+      "MulAction.orbitEquivQuotientStabilizer gives orbit ≃ G ⧸ stabilizer — use for card_conjClass_eq_centralizer_index",
+      "ConjAct G is definitionally G as a type synonym, so ConjAct.toConjAct x = x by rfl — closes the centralizer equality"
     ],
     "mathlibGaps": [
       "card_conjClass_eq_centralizer_index needs orbit Nat.card to centralizer index connection — technical gap in orbit-stabilizer API"


### PR DESCRIPTION
## Summary

- Resolves the remaining sorry in `card_conjClass_eq_centralizer_index` in `LagrangeTheoremOQ02OQ02.lean`
- The proof uses `Subgroup.index_comap_of_surjective` applied to `ConjAct.toConjAct : G ≃* ConjAct G`
- Result: 13 theorems, 0 sorries, 0 axioms — fully machine-checkable
- Gallery status upgraded: `formalized` (1 sorry) → `verified` (0 sorries), badge `research` → `verified`

## Proof Strategy

The sorry was `card_conjClass_eq_centralizer_index`:
```
|ConjClasses.mk x).carrier| = (centralizer {x}).index
```

Proved in two steps:
1. **Orbit-stabilizer**: `Nat.card (orbit (ConjAct G) x) = (stabilizer (ConjAct G) x).index`
   via `orbitEquivQuotientStabilizer` + `Subgroup.index_eq_card`
2. **Index transfer**: `(stabilizer (ConjAct G) x).index = (centralizer {x}).index`
   via `Subgroup.index_comap_of_surjective` applied to `ConjAct.toConjAct : G ≃* ConjAct G`
   (surjective), combined with `conj_stabilizer_eq_centralizer` (which gives the comap equality)

## Files Changed

- `proofs/Proofs/LagrangeTheoremOQ02OQ02.lean` — sorry resolved (+11 lines of proof)
- `src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json` — status/badge/sorries/lineCount updated
- `src/data/research/problems/lagrange-theorem-oq-02-oq-02.json` — phase COMPLETED, knowledge updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)