### PR TITLE
fix(meta): sync theoremCount for fourier-series-oq-02 (18→19)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -27,7 +27,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 18
+    "theoremCount": 19
   },
   "meta": {
     "author": "Classical (Bernstein, Zygmund)",
@@ -102,7 +102,7 @@
     "axiomCount": 0,
     "lineCount": 495,
     "assumptions": "0 axioms — fully proved via Weierstrass lacunary series construction in FourierSeriesOQ02OQ04.lean.",
-    "theoremCount": 18,
+    "theoremCount": 19,
     "additionalFiles": [
       "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "Proofs/FourierSeriesOQ02OQ04.lean"


### PR DESCRIPTION
## Summary

PR #15987 converted `holder_decay_is_optimal_seq` from an axiom to a theorem (by adding `FourierSeriesOQ02OQ04.lean`), but did not update `theoremCount`.

| Field | Before | After | Reason |
|-------|--------|-------|--------|
| `leanFile.theoremCount` | `18` | `19` | file has 19 theorem declarations |
| `meta.theoremCount` | `18` | `19` | matches leanFile |

Verified by counting `^theorem ` in the Lean file: 19 declarations including the newly-proven `holder_decay_is_optimal_seq`.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)