### PR TITLE
chore(audit): update tracker for fourier-series-oq-02 — theoremCount fix

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11364,10 +11364,10 @@
       "result": "clean"
     },
     "fourier-series-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:48Z",
-      "result": "clean"
+      "lastAudited": "2026-05-05T05:31:13Z",
+      "result": "issues-fixed"
     },
     "fourier-series-oq-02-incomplete-01": {
       "auditCount": 4,


### PR DESCRIPTION
## Summary

Updates audit tracker after finding theoremCount mismatch in `fourier-series-oq-02` (18→19). Fix is in PR #16001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)