### PR TITLE
research(derangements-convergence-oq-01-oq-01): reconcile stale leanFiles drift

### DIFF
--- a/src/data/research/problems/derangements-convergence-oq-01-oq-01.json
+++ b/src/data/research/problems/derangements-convergence-oq-01-oq-01.json
@@ -11,7 +11,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 7 theorems proved, 0 sorries, 0 axioms. Fixed DerangementsConvergence.lean syntax and proved the nearest integer theorem.",
+    "progressSummary": "COMPLETE: 7 theorems proved, 0 sorries, 0 axioms in DerangementsConvergenceOQ01OQ01.lean (nearest integer theorem). Reconciled stale leanFiles drift (DerangementsConvergenceOQ01.lean: sorryCount 4→0, lineCount 153→152) — those 'sorries' were comment mentions, the file actually has 0 real sorries.",
     "builtItems": [
       "derangements_rate_scaled: |D(n) - n!/e| ≤ 1/(n+1) for all n",
       "derangements_nearest_integer: |D(n) - n!/e| < 1/2 for n ≥ 2",
@@ -44,11 +44,11 @@
     {
       "path": "Proofs/DerangementsConvergenceOQ01.lean",
       "filename": "DerangementsConvergenceOQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/derangements-convergence-oq-01.json
+++ b/src/data/research/problems/derangements-convergence-oq-01.json
@@ -75,11 +75,11 @@
     {
       "path": "Proofs/DerangementsConvergenceOQ01.lean",
       "filename": "DerangementsConvergenceOQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },


### PR DESCRIPTION
## Summary

Pool listed `derangements-convergence-oq-01-oq-01` as `in-progress`, but origin/main shows the work is fully complete:

- `proofs/Proofs/DerangementsConvergenceOQ01OQ01.lean`: 7 theorems, 0 sorries, 0 axioms (147 lines)
- `src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json`: `status: verified`, `axiomCount: 0`, `sorries: 0`

This PR reconciles research-side metadata that lagged the gallery (the pattern documented in `feedback_research_json_lags_gallery.md`).

## Drift fixed

`DerangementsConvergenceOQ01.lean` (the parent file imported by the OQ-01-OQ-01 entry):

| Field | Was | Actual | Note |
|---|---|---|---|
| `sorryCount` | 4 | 0 | The 4 grep-matches are docstring/comment mentions of the word "sorry" — not actual `sorry` tactics. Verified with a comment-stripping pass. |
| `lineCount` | 153 | 152 | Off-by-one drift |

Both occurrences updated:
- `src/data/research/problems/derangements-convergence-oq-01-oq-01.json`
- `src/data/research/problems/derangements-convergence-oq-01.json`

`progressSummary` annotated to record the reconcile.

Pool status updated to `completed` via `claim-problem.sh update`.

## Verification

```
$ python3 strip-comments-and-count-sorries.py proofs/Proofs/DerangementsConvergenceOQ01.lean
sorry count: 0
axiom count: 0

$ wc -l proofs/Proofs/DerangementsConvergenceOQ01.lean
     152 proofs/Proofs/DerangementsConvergenceOQ01.lean
```

## Status

**Outcome**: completed (research JSON reconcile)
**Next Steps**: pool/research metadata for this slug is now consistent with main

🤖 Generated by researcher-1