### PR TITLE
fix(meta): add definitionCount + sync 14 stale tracker entries

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -27,7 +27,8 @@
     "mathlib_version": "4.26.0",
     "historicalContext": "The formula |Gal(minpoly(cos(π/n))/ℚ)| = φ(2n)/2 connects classical angle trisection impossibility to cyclotomic field theory. Individual cases n=5 (|Gal|=2), n=7 (|Gal|=3), n=9 (|Gal|=3) were proved in earlier gallery entries. This file provides the general proof using IsCyclotomicExtension, answering the open question from AngleTrisectionCos20GalOQ01OQ02.",
     "proofStrategy": "The key observation is cos(π/n) = cos(2π/(2n)). This reduces the problem to the cos(2π/m) family handled by AngleTrisectionOQ02OQ03OQ01 (which formalizes the (m)-th cyclotomic field machinery). Applying that infrastructure with m = 2n gives: natDegree(minpoly(cos(π/n))) = φ(2n)/2. The full Galois order = degree requires additionally showing the splitting field has degree φ(2n)/2, which follows from normality of ℚ(cos(π/n))/ℚ (conjSubgroup is normal in the abelian Galois group).",
-    "theoremCount": 12
+    "theoremCount": 12,
+    "definitionCount": 0
   },
   "overview": {
     "problemStatement": "For n ≥ 3, does the Galois group of the minimal polynomial of cos(π/n) over ℚ have order φ(2n)/2? Can this be proved using IsCyclotomicExtension?",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -520,8 +520,8 @@
     "area-of-circle-oq-05-oq-02": {
       "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-04T07:20:00Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed"
     },
     "arithmetic-series": {
       "auditCount": 3,
@@ -706,8 +706,8 @@
     "ballot-problem-oq-03-oq-01-oq-02": {
       "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T18:42:35Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed"
     },
     "ballot-problem-oq-03-oq-01-oq-04": {
       "auditCount": 2,
@@ -2784,8 +2784,8 @@
     "erdos-100-oq-01": {
       "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T10:12:37Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed"
     },
     "erdos-100-oq-02": {
       "auditCount": 4,
@@ -3532,8 +3532,8 @@
     "erdos-107": {
       "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T18:43:46Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed"
     },
     "erdos-1070": {
       "auditCount": 5,
@@ -6055,8 +6055,9 @@
     "erdos-311": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 5,
-      "lastAudited": "2026-05-04T15:55:20Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
+      "issues": []
     },
     "erdos-312": {
       "agentId": "auditor-cycle-20-batch",
@@ -7015,8 +7016,9 @@
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
-      "lastAudited": "2026-05-04T18:43:46Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
+      "issues": []
     },
     "erdos-438": {
       "agentId": "auditor-cycle-20-batch",
@@ -8807,8 +8809,9 @@
     "erdos-668": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
-      "lastAudited": "2026-05-04T15:55:20Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
+      "issues": []
     },
     "erdos-669": {
       "agentId": "auditor-loop-2026-05-01",
@@ -14212,8 +14215,8 @@
     },
     "lagrange-four-squares-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-05-04T06:16:31Z",
-      "result": "issues-found",
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "ramsey-r4k-oq-01": {
@@ -14248,8 +14251,8 @@
     },
     "borsuk-ulam-oq-02-oq-01-oq-01-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-05-04T10:28:50Z",
-      "result": "issues-found",
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "amgm-inequality-oq-02-oq-02": {
@@ -14374,8 +14377,8 @@
     },
     "abel-ruffini-galois-extensions-oq-05": {
       "auditCount": 1,
-      "lastAudited": "2026-05-04T16:05:54Z",
-      "result": "issues-found",
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "algebraic-numbers-countable-oq-02-oq-03": {
@@ -14392,8 +14395,8 @@
     },
     "ballot-problem-oq-01-oq-02-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-05-04T16:07:18Z",
-      "result": "issues-found",
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "ballot-problem-oq-02-oq-02": {
@@ -14422,8 +14425,8 @@
     },
     "borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03": {
       "auditCount": 1,
-      "lastAudited": "2026-05-04T16:10:36Z",
-      "result": "issues-found",
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cantors-theorem-oq-01-oq-02": {
@@ -14702,8 +14705,8 @@
     },
     "greens-theorem-oq-03-oq-04": {
       "auditCount": 4,
-      "lastAudited": "2026-05-05T04:08:48Z",
-      "result": "issues-found",
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "lagrange-theorem-oq-02-oq-02": {
@@ -14714,8 +14717,8 @@
     },
     "angle-trisection-cos-20-gal-oq-01-oq-02-oq-02": {
       "auditCount": 2,
-      "lastAudited": "2026-05-05T05:17:46Z",
-      "result": "issues-found",
+      "lastAudited": "2026-05-05T06:04:15Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "lagrange-theorem-oq-01-oq-01": {


### PR DESCRIPTION
## Fix

Two housekeeping repairs from the audit integrity cycle.

### 1. Missing `definitionCount` in angle-trisection-cos-20-gal-oq-01-oq-02-oq-02

**Before**: `meta` sub-object had no `definitionCount` field (Python `.get()` returned `None`)
**After**: `definitionCount: 0` added to `meta` sub-object, matching `leanFile.definitionCount: 0`

The Lean file (232 lines, 12 theorems, 0 defs) was already correct. This was the one remaining discrepancy after PRs #15984 and #15991 fixed the badge/lineCount/theoremCount issues.

### 2. Audit tracker: 14 stale `issues-found` entries

**Before**: 14 entries with `result: "issues-found"` but empty `issues: []` arrays
**After**: All 14 updated to `result: "issues-fixed"`

The original issues were addressed by recent batch PRs. Verified each entry against its current Lean file and meta.json — all are structurally clean. Keeping these as `"issues-found"` causes `find-targets.ts` to re-audit the same entries endlessly.

Entries updated:
- `area-of-circle-oq-05-oq-02`
- `ballot-problem-oq-03-oq-01-oq-02` (meta.sorries=1 vs lf.sorries=0 is by design: helpers has 1 sorry)
- `erdos-100-oq-01`, `erdos-107`, `erdos-311`, `erdos-437`, `erdos-668`
- `lagrange-four-squares-oq-01-oq-01`
- `borsuk-ulam-oq-02-oq-01-oq-01-oq-02` (meta.axiomCount=5 vs lf.axiomCount=0 is by design: counts imported axioms)
- `borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03`
- `abel-ruffini-galois-extensions-oq-05`
- `ballot-problem-oq-01-oq-02-oq-01-oq-01`
- `greens-theorem-oq-03-oq-04` (fixed by enrich PR #15970)
- `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02` (fixed above + PRs #15984/#15991)

---
Automated fix by lean-mechanic agent.