### PR TITLE
fix(meta): correct phantom axioms/theorems in GreensTheoremOQ03OQ04 docstring

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ03OQ04.lean
+++ b/proofs/Proofs/GreensTheoremOQ03OQ04.lean
@@ -29,17 +29,17 @@ For vector field F = (Q, -P), the divergence theorem gives:
 where the last equality uses the outward normal relation (dy, -dx) for a positively-oriented
 boundary. This IS Green's theorem.
 
-## Status: 0 sorries, 2 axioms (general TypeI and Stokes framework connection)
+## Status: 0 sorries, 1 axiom (Mathlib gap: curved-boundary Stokes)
 
 Theorems proved:
 - `greens_theorem_rect_via_stokes`: Green's theorem for rectangles via Mathlib's divergence theorem
-- `rect_greens_consistent_with_typeI`: Consistency with GreensTheoremOQ03's TypeI approach
 - `boundary_integral_decomposition`: Boundary integral = P-boundary + Q-boundary
-- `stokes_implies_green_scalar`: Abstract form: divergence theorem implies Green's theorem
+- `boundary_eq_line_integral_parts`: Line integral parts consolidate
+- `rect_greens_consistent_with_typeI`: Consistency with GreensTheoremOQ03's TypeI approach
+- `greens_theorem_typeI_via_stokes`: TypeI via OQ-03 axiom (delegates)
 
 Axioms:
-- `greens_theorem_typeI_via_stokes`: General TypeI via Stokes (needs curved-boundary Stokes in Mathlib)
-- `stokes_framework_equivalence`: Formal equivalence of Stokes and Green's theorem formalisms
+- `stokes_for_curved_domains_not_in_mathlib_4_26`: Documents Mathlib gap — general Stokes for piecewise-smooth curved 2D boundaries not yet in Mathlib v4.26.0
 
 Tags: green, stokes, divergence-theorem, typeI, rectangle
 -/


### PR DESCRIPTION
## Fix

The header docstring of `proofs/Proofs/GreensTheoremOQ03OQ04.lean` (lines 32-42) listed axiom and theorem names that don't match the actual file:

**Phantom claims removed**:
- `greens_theorem_typeI_via_stokes` listed as **axiom** — actually a **theorem** (line 184, delegates to OQ-03)
- `stokes_framework_equivalence` listed as **axiom** — does not exist
- `stokes_implies_green_scalar` listed as **theorem** — does not exist

**Missing actual entities added**:
- Real axiom: `stokes_for_curved_domains_not_in_mathlib_4_26` (line 204)
- Real theorems: `boundary_eq_line_integral_parts` (line 127), `greens_theorem_typeI_via_stokes` (line 184)

**Status line corrected**: "0 sorries, 2 axioms" → "0 sorries, 1 axiom".

## Evidence

Line 239-240 of the same file already had the correct summary ("Theorems proved: 5 (0 sorries) / Axioms: 1"). meta.json also has the correct counts (theoremCount: 5, axiomCount: 1). Only the header at lines 32-42 was inconsistent.

Line count preserved (250 → 250). Body of all theorems and the one axiom is unchanged — pure docstring repair.

Closes the audit-tracker `issues-found` flag for `greens-theorem-oq-03-oq-04` (lastAudited 2026-05-05).

---
Automated fix by lean-mechanic agent.