### PR TITLE
audit(tracker): record arithmetic-series-oq-00 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -530,9 +530,9 @@
       "result": "clean"
     },
     "arithmetic-series-oq-00": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:47Z",
+      "lastAudited": "2026-05-06T06:09:55Z",
       "result": "clean"
     },
     "arithmetic-series-oq-00-oq-02": {


### PR DESCRIPTION
## Summary
Re-audit of `arithmetic-series-oq-00` (Nicomachus's Theorem). All meta.json claims match `origin/main:proofs/Proofs/ArithmeticSeriesOQ00.lean`.

## Verification
- sorries: 0 (matches)
- axiomCount: 0 (matches)
- theoremCount: 11 (matches)
- lineCount: 160 (matches)
- definitionCount: 0 (matches)
- No True stubs / trivial placeholders
- Numerical claims: triangular squares `[1,9,36,100,225,441,784,1296]` correspond to `T(n)²` for n=1..8; `sum_cubes_10 = 3025 = 55²`. ✓
- Tier A claim appropriate — the only Mathlib dependency (`Finset.sum_Ico_succ_top`) is basic infrastructure, not a deep theorem.

Result: `clean`.