### PR TITLE
chore(audit): mark laws-of-large-numbers-oq-01-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12200,6 +12200,12 @@
       "lastAudited": "2026-05-03T22:58:02Z",
       "result": "clean"
     },
+    "laws-of-large-numbers-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-05-06T06:26:00Z",
+      "result": "clean"
+    },
     "laws-of-large-numbers-oq-03": {
       "auditCount": 1,
       "issues": [],


### PR DESCRIPTION
## Summary
- Marks `laws-of-large-numbers-oq-01-oq-01` as clean in the audit tracker.

## Audit findings
- Gallery file `Proofs/LawsOfLargeNumbersOQ01OQ01.lean`: 0 sorries, 0 axioms, 74 lines, 1 theorem, 0 defs (matches `meta.json`).
- Aristotle companion `Proofs/LawsOfLargeNumbersOQ01Aristotle.lean`: 0 sorries, 0 axioms; provides a genuine variance-Chebyshev proof of BC2 for pairwise independence — not a wrapper around `ProbabilityTheory.measure_limsup_eq_one`.
- Tier A classification (`status: verified`, `badge: original`) is justified.
- Cross-reference to parent `laws-of-large-numbers-oq-01` is accurate (parent has `axiom slln_necessity` at line 145; this entry supplies a proven `slln_necessity_statement`).

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(...)"`).
- [x] Diff is +6 lines (single new tracker entry, no churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)