### PR TITLE
chore(audit): track laws-of-large-numbers-oq-01-oq-01 + angle-trisection-cos-20 re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12200,6 +12200,12 @@
       "lastAudited": "2026-05-03T22:58:02Z",
       "result": "clean"
     },
+    "laws-of-large-numbers-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T06:54:23Z",
+      "result": "clean",
+      "issues": []
+    },
     "laws-of-large-numbers-oq-03": {
       "auditCount": 1,
       "issues": [],
@@ -14716,8 +14722,8 @@
       "issues": []
     },
     "angle-trisection-cos-20-gal-oq-01-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-05T06:04:15Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-06T06:55:33Z",
       "result": "issues-fixed",
       "issues": []
     },


### PR DESCRIPTION
## Summary
Audit-tracker updates from this session:

- **laws-of-large-numbers-oq-01-oq-01** — new entry, audited clean.
  - 74 lines, 1 theorem, 0 sorries, 0 axioms (matches meta).
  - Wrapper delegates to `LawsOfLargeNumbersOQ01Aristotle.slln_necessity_statement` (proved via Borel-Cantelli + Cesàro contradiction). Tier-A `verified`/`original` claim is justified.

- **angle-trisection-cos-20-gal-oq-01-oq-02-oq-02** — auditCount 2→3, lastAudited refreshed.
  - find-targets flagged a sorry mismatch, but the discrepancy comes from another agent's uncommitted edits in the main repo working tree. On `origin/main`, meta sorries=1 matches Lean file sorries=1. PR #16028 will resolve the in-flight reduction to 0 sorries.

## Test plan
- [x] `git show origin/main:src/data/proofs/audit-tracker.json` re-verified — diff is exactly the two intended changes.
- [x] No unicode-encoding churn (used `ensure_ascii=False`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)