### PR TITLE
chore(audit): mark laws-of-large-numbers-oq-01-oq-01 as clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14738,6 +14738,12 @@
       "lastAudited": "2026-05-06T06:15:20Z",
       "result": "clean",
       "issues": []
+    },
+    "laws-of-large-numbers-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T07:15:56Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Audit of `laws-of-large-numbers-oq-01-oq-01` (SLLN Necessity / converse of Kolmogorov's SLLN) — **clean**.

## Verification

Read at `origin/main` (`f03b53f9b84`):

- **`Proofs/LawsOfLargeNumbersOQ01OQ01.lean`** (main file): 74 lines, 0 sorries, 0 axioms, 1 theorem
- **`Proofs/LawsOfLargeNumbersOQ01Aristotle.lean`** (companion in `additionalFiles`): 0 sorries, 0 axioms; `slln_necessity_statement` is fully proved (real proof body, not `sorry`/`axiom`)
- All counts in `meta.json` match actuals
- `status: "verified"` / `badge: "original"` appropriate: this entry's imports do not depend on the parent's `axiom slln_necessity` in `LawsOfLargeNumbersOQ01.lean`. The main theorem resolves `LawsOfLargeNumbersOQ01.slln_necessity_statement` to the proven Aristotle companion (same namespace).

Tracker queue stats: 2342/2343 audited; this entry was the last unaudited target.

## Test plan
- [x] Counts match meta.json
- [x] Tracker entry added under `entries.<id>` (not at top level)
- [x] Diff is 6 lines (no Unicode re-encoding noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)