### PR TITLE
Enrich Gauss Sum Squared Identity τ²=χ(-1)·p: add 7 annotations, deepen overview

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-gauss-intro",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "Gauss's Approach to Quadratic Reciprocity",
+    "content": "Carl Friedrich Gauss (1777–1855) gave **eight distinct proofs** of the Law of Quadratic Reciprocity over his lifetime — a testament to the theorem's depth and his fascination with it. Among them, his **Gauss sum proof** (third proof, 1808) is the most analytically powerful and far-reaching.\n\nThe strategy has four steps: (1) define the Gauss sum τ = Σ_{a=0}^{p-1} (a/p)·e^{2πia/p} in ℂ; (2) prove τ² = χ(-1)·p (**this file handles step 2**); (3) prove τ^q ≡ (p/q)·τ (mod q) via the Frobenius endomorphism; (4) compare two formulas for τ^q to derive QR. The analytic work is concentrated in step 2 — once it is established, steps 3 and 4 are essentially algebraic.\n\nThis approach eventually influenced the development of algebraic number theory, Hecke Grössencharacters, and Tate's thesis. The **complex plane is essential**: no analogous integer identity holds since ±p is never a perfect square for prime p > 2.",
+    "mathContext": "$\\tau = \\sum_{a=0}^{p-1} \\left(\\frac{a}{p}\\right) e^{2\\pi i a/p}, \\quad \\tau^2 = \\chi(-1) \\cdot p$",
+    "significance": "key",
+    "relatedConcepts": ["Quadratic Reciprocity", "Gauss sum", "Legendre symbol", "Frobenius endomorphism", "analytic number theory"],
+    "prerequisites": ["complex exponentials", "Legendre symbol", "multiplicative characters"]
+  },
+  {
+    "id": "ann-quad-char-def",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 70 },
+    "type": "definition",
+    "title": "The Legendre Symbol as a ℂ-Valued Multiplicative Character",
+    "content": "`quadCharC` is the **Legendre symbol promoted to a ℂ-valued multiplicative character** via `Int.castRingHom`. The standard Mathlib `quadraticChar` takes values in ℤ; Mathlib's `gaussSum_sq` requires a `MulChar (ZMod p) ℂ`, so this bridging definition is an essential step.\n\nThe construction uses `ringHomComp`: it first applies `quadraticChar` (ℤ-valued), then applies `Int.cast : ℤ → ℂ`. This composition **automatically inherits multiplicativity** — a key advantage of the `MulChar` abstraction, which tracks this property in the type. The companion lemma `quadCharC_isQuadratic` confirms that χ(a)² ∈ {0, 1} for all a, which is the defining property of a quadratic character.",
+    "mathContext": "$\\chi = \\text{quadCharC}: (\\mathbb{Z}/p\\mathbb{Z}) \\to \\mathbb{C}, \\quad \\chi(a) = \\text{Int.cast}\\!\\left(\\left(\\frac{a}{p}\\right)_{\\mathbb{Z}}\\right) \\in \\{-1,\\, 0,\\, 1\\}$",
+    "significance": "key",
+    "relatedConcepts": ["MulChar", "Legendre symbol", "ring homomorphism", "quadratic character", "ZMod"],
+    "prerequisites": ["multiplicative characters (MulChar)", "Int.castRingHom", "quadraticChar in Mathlib"]
+  },
+  {
+    "id": "ann-nontriviality",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 88 },
+    "type": "technique",
+    "title": "Nontriviality via Int.cast Injectivity",
+    "content": "Proving `quadCharC ≠ 1` requires care because quadCharC takes values in ℂ while the underlying `quadraticChar` takes values in ℤ. A naive appeal to `quadraticChar_ne_one` does not directly transfer across the cast.\n\nThe argument proceeds by **contrapositive via injectivity**: assume `quadCharC = 1`, meaning `Int.cast (quadraticChar a) = 1` for all a. Since `Int.cast : ℤ → ℂ` is **injective** (ℂ has characteristic 0), this forces `quadraticChar a = 1` for all a, i.e., `quadraticChar = 1`. But `quadraticChar_ne_one` (a Mathlib theorem) rules this out for an odd prime p. The injectivity step is the key bridge between the ℤ-valued and ℂ-valued worlds.",
+    "mathContext": "quadCharC $= 1 \\Rightarrow$ Int.cast$(\\chi_{\\mathbb{Z}}(a)) = 1$ for all $a \\Rightarrow \\chi_{\\mathbb{Z}} = 1$ (by injectivity) $\\Rightarrow$ contradiction",
+    "significance": "supporting",
+    "relatedConcepts": ["Int.cast injectivity", "MulChar nontriviality", "characteristic zero", "quadraticChar_ne_one"],
+    "prerequisites": ["Int.cast : ℤ → ℂ", "characteristic zero fields", "quadraticChar_ne_one (Mathlib)"]
+  },
+  {
+    "id": "ann-classical-gauss-sum",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 97 },
+    "type": "definition",
+    "title": "Assembling the Classical Gauss Sum",
+    "content": "`classicalGaussSum` assembles the two ingredients: the **multiplicative character** `quadCharC` (Legendre symbol in ℂ) and the **additive character** `ZMod.stdAddChar` (which maps a ↦ exp(2πia/p)). Mathlib's bilinear `gaussSum` combines them as Σ_{a} χ(a)·ψ(a).\n\nThe key fact consumed in the main theorem is `ZMod.isPrimitive_stdAddChar`: the standard additive character of ZMod p is **primitive** — it does not factor through any proper subgroup. This is a non-trivial result from the theory of exponential sums; it is what prevents the Gauss sum from vanishing due to character orthogonality, and it is a required hypothesis of `gaussSum_sq`.",
+    "mathContext": "$\\tau_p = \\text{classicalGaussSum}(p) = \\sum_{a \\in \\mathbb{Z}/p\\mathbb{Z}} \\left(\\frac{a}{p}\\right) e^{2\\pi i a/p} \\in \\mathbb{C}$",
+    "significance": "key",
+    "relatedConcepts": ["gaussSum (Mathlib)", "additive characters", "ZMod.stdAddChar", "primitive character", "ZMod.isPrimitive_stdAddChar"],
+    "prerequisites": ["AddChar (Mathlib)", "ZMod.stdAddChar", "primitive additive characters"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 99, "endLine": 141 },
+    "type": "technique",
+    "title": "Three-Step Proof of τ² = χ(-1)·p",
+    "content": "The main theorem `gauss_sum_squared` follows a clean **three-step chain** through Mathlib:\n\n**Step 1** — `gaussSum_sq` (Mathlib.NumberTheory.GaussSum): for a nontrivial quadratic character χ and a primitive additive character ψ over a finite abelian group G, `(gaussSum χ ψ)² = χ(-1) · |G|`. Both nontriviality (established above via Int.cast injectivity) and primitivity (ZMod.isPrimitive_stdAddChar) are required.\n\n**Step 2** — `ZMod.card`: the cardinality of ZMod p as a Fintype is p, converting |G| to the prime integer.\n\n**Step 3** — `legendreSym.at_neg_one` + `χ₄_eq_neg_one_pow`: the first supplementary law evaluates χ(-1) = (-1)^(p/2), connecting the abstract character value to a concrete sign formula. This step encodes the theorem that -1 is a QR mod p iff p ≡ 1 (mod 4).",
+    "mathContext": "$\\tau^2 = \\chi(-1) \\cdot |\\mathbb{Z}/p\\mathbb{Z}| = \\chi(-1) \\cdot p = (-1)^{\\lfloor p/2 \\rfloor} \\cdot p$",
+    "significance": "key",
+    "relatedConcepts": ["gaussSum_sq", "ZMod.card", "legendreSym.at_neg_one", "χ₄_eq_neg_one_pow", "first supplementary law"],
+    "prerequisites": ["gaussSum_sq (Mathlib)", "ZMod.card", "legendreSym.at_neg_one", "first supplementary law of QR"]
+  },
+  {
+    "id": "ann-sign-corollaries",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 143, "endLine": 173 },
+    "type": "insight",
+    "title": "Sign of τ² Depends Only on p mod 4",
+    "content": "The corollaries split `gauss_sum_squared` into two cases based on the residue of p modulo 4. This is not merely a computational detail — it reflects the deep theorem that **-1 is a quadratic residue mod p if and only if p ≡ 1 (mod 4)**.\n\n- If p ≡ 1 (mod 4): then p/2 is even, so (-1)^(p/2) = 1, and τ² = **p** (positive integer).\n- If p ≡ 3 (mod 4): then p/2 is odd, so (-1)^(p/2) = -1, and τ² = **-p** (negative integer).\n\nThe **existential form** `gauss_sum_squared_exists` provides the explicit complex witness needed to fulfill the axiom in the parent entry `ElementaryQuadraticReciprocityOQ01OQ01`. This exemplifies a key formalization pattern: **axiomatize first to unblock dependent results, then prove later once the infrastructure is in place**.",
+    "mathContext": "$\\tau^2 = \\begin{cases} p & \\text{if } p \\equiv 1 \\pmod{4} \\\\ -p & \\text{if } p \\equiv 3 \\pmod{4} \\end{cases}$",
+    "significance": "supporting",
+    "relatedConcepts": ["first supplementary law", "quadratic residue", "Even.neg_one_pow", "Odd.neg_one_pow", "axiom elimination"],
+    "prerequisites": ["p mod 4 arithmetic", "Even/Odd.neg_one_pow (Mathlib)", "quadratic residue criterion for -1"]
+  },
+  {
+    "id": "ann-concrete-instances",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 175, "endLine": 212 },
+    "type": "context",
+    "title": "Verification for Small Primes",
+    "content": "The concrete instances for p = 3, 5, 7, 13 serve as **existential sanity checks** for the abstract theorem. They assert the existence of a complex number τ with τ² = ±p, not a specific value of τ.\n\nThe actual Gauss sums for small primes are: τ(3) = e^{2πi/3} - e^{4πi/3} ≈ i√3 (so τ² = -3); τ(5) = 2cos(2π/5) - 2cos(4π/5) = √5 (so τ² = 5); τ(7) ≈ i√7 (so τ² = -7); τ(13) = √13 (so τ² = 13). These values illustrate the general pattern: τ ∈ {±√p, ±i√p} depending on p mod 4, and τ² is always a **rational integer** despite τ itself being a transcendental complex number.\n\nThe closing summary table confirms **7 theorems proved with 0 sorries and 0 axioms**, fully discharging the goal stated in the opening docstring.",
+    "mathContext": "$\\tau(3) = e^{2\\pi i/3} - e^{4\\pi i/3}, \\quad \\tau(5) = 2\\cos(2\\pi/5) - 2\\cos(4\\pi/5) = \\sqrt{5}$",
+    "significance": "context",
+    "relatedConcepts": ["concrete verification", "Gauss sum values", "existential witnesses", "small prime examples"],
+    "prerequisites": ["complex exponentials", "QR mod small primes"]
+  }
+]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+  "title": "Gauss Sum Squared Identity τ² = χ(-1)·p",
+  "slug": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+  "description": "Proves the central identity in the Gauss sum proof of Quadratic Reciprocity: for odd prime p, the classical Gauss sum τ = Σ_a (a/p)·exp(2πia/p) satisfies τ² = (-1)^((p-1)/2)·p in ℂ. This fills the key gap in the Gauss pathway outlined in ElementaryQuadraticReciprocityOQ01OQ01, converting an axiomatized identity into a theorem. The proof uses Mathlib's gaussSum_sq with the quadratic character of ZMod p and the standard additive character, then computes χ(-1) via the first supplementary law.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-05-05",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "gauss-sums",
+      "legendre-symbol",
+      "additive-characters",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 212,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "dateAdded": "2026-05-05",
+    "mathlibDependencies": [
+      {
+        "theorem": "gaussSum_sq",
+        "description": "For nontrivial quadratic χ and primitive ψ: (gaussSum χ ψ)² = χ(-1)·|G|",
+        "module": "Mathlib.NumberTheory.GaussSum"
+      },
+      {
+        "theorem": "legendreSym.at_neg_one",
+        "description": "First supplementary law: legendreSym p (-1) = χ₄ p",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "χ₄_eq_neg_one_pow",
+        "description": "χ₄ p = (-1)^(p/2) for odd p",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.isPrimitive_stdAddChar",
+        "description": "The standard additive character of ZMod p is primitive",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.CircleAddChar"
+      },
+      {
+        "theorem": "ZMod.exists_sq_eq_neg_one_iff",
+        "description": "IsSquare(-1:ZMod p) ↔ p % 4 ≠ 3 (for prime p)",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.ZMod"
+      }
+    ],
+    "originalContributions": [
+      "gauss_sum_squared: proves τ² = (-1)^(p/2)·p in ℂ using gaussSum_sq instantiation",
+      "gauss_sum_sq_pos_case: τ² = p when p ≡ 1 (mod 4) via Even.neg_one_pow",
+      "gauss_sum_sq_neg_case: τ² = -p when p ≡ 3 (mod 4) via Odd.neg_one_pow",
+      "quadCharC: explicit definition of the Legendre symbol as a ℂ-valued MulChar"
+    ]
+  },
+  "sections": [
+    {
+      "id": "intro",
+      "title": "Introduction and QR Pathway",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Opening docstring, imports, namespace setup, and variable declarations. Explains the four-step Gauss sum proof strategy for QR and states this file proves Step 2: τ² = χ(-1)·p.",
+      "mathContext": "The four-step pathway: (1) Define $\\tau = \\sum_a \\left(\\frac{a}{p}\\right) e^{2\\pi i a/p}$; (2) Prove $\\tau^2 = \\chi(-1) \\cdot p$; (3) Prove $\\tau^q \\equiv \\left(\\frac{p}{q}\\right) \\tau \\pmod{q}$ via Frobenius; (4) Derive QR by comparing two formulas for $\\tau^q$."
+    },
+    {
+      "id": "quad-char-setup",
+      "title": "Quadratic Character Setup",
+      "startLine": 57,
+      "endLine": 88,
+      "summary": "Defines quadCharC as the Legendre symbol promoted to a ℂ-valued multiplicative character, proves it is quadratic (quadCharC_isQuadratic) and nontrivial (quadCharC_ne_one). Both properties are required by Mathlib's gaussSum_sq.",
+      "mathContext": "$\\chi = $ quadCharC $: (\\mathbb{Z}/p\\mathbb{Z}) \\to \\mathbb{C}$, $\\quad \\chi(a) = \\text{Int.cast}\\left(\\left(\\frac{a}{p}\\right)_{\\mathbb{Z}}\\right)$. IsQuadratic means $\\chi(a)^2 = \\chi(a^2) = 1$ or $0$."
+    },
+    {
+      "id": "gauss-sum-def",
+      "title": "Classical Gauss Sum Definition",
+      "startLine": 90,
+      "endLine": 97,
+      "summary": "Defines classicalGaussSum p as gaussSum(quadCharC p)(ZMod.stdAddChar), the ℂ-valued sum Σ_a (a/p)·exp(2πia/p).",
+      "mathContext": "$\\tau_p = \\text{classicalGaussSum}(p) = \\sum_{a \\in \\mathbb{Z}/p\\mathbb{Z}} \\left(\\frac{a}{p}\\right) e^{2\\pi i a/p} \\in \\mathbb{C}$"
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Identity: τ² = χ(-1)·p",
+      "startLine": 99,
+      "endLine": 141,
+      "summary": "Proves gauss_sum_squared via: gaussSum_sq → τ² = χ(-1)·|ZMod p|, then ZMod.card gives |ZMod p| = p, then legendreSym.at_neg_one gives χ(-1) = (-1)^(p/2).",
+      "mathContext": "$\\tau^2 = \\chi(-1) \\cdot |\\mathbb{Z}/p\\mathbb{Z}| = (-1)^{\\lfloor p/2 \\rfloor} \\cdot p$"
+    },
+    {
+      "id": "corollaries",
+      "title": "Sign Corollaries and Existential Form",
+      "startLine": 143,
+      "endLine": 173,
+      "summary": "Derives: (1) gauss_sum_squared_exists — explicit witness for the parent axiom; (2) neg_one_quadratic_residue_iff — first supplement; (3) gauss_sum_sq_pos_case (p≡1 mod 4: τ²=p); (4) gauss_sum_sq_neg_case (p≡3 mod 4: τ²=-p).",
+      "mathContext": "$\\tau^2 = p$ when $p \\equiv 1 \\pmod{4}$, $\\quad \\tau^2 = -p$ when $p \\equiv 3 \\pmod{4}$"
+    },
+    {
+      "id": "concrete-instances",
+      "title": "Concrete Instances and Results Summary",
+      "startLine": 175,
+      "endLine": 212,
+      "summary": "Verifies the identity for p=3,5,7,13 via gauss_sum_squared_exists. Closing table summarizes all five theorems proved with 0 sorries and 0 axioms.",
+      "mathContext": "$p=3$: $\\tau^2 = -3$; $p=5$: $\\tau^2 = 5$; $p=7$: $\\tau^2 = -7$; $p=13$: $\\tau^2 = 13$"
+    }
+  ],
+  "overview": {
+    "summary": "Proves the Gauss sum squared identity τ² = χ(-1)·p in ℂ, the analytic heart of the Gauss sum proof of Quadratic Reciprocity. Uses Mathlib's gaussSum_sq with the Legendre symbol character and the standard additive character.",
+    "historicalContext": "Carl Friedrich Gauss (1777–1855) devoted remarkable attention to the Law of Quadratic Reciprocity, providing eight distinct proofs over his lifetime — a measure of the theorem's depth and his fascination with it. His third proof (1808) introduced the **Gauss sum** τ = Σ_{a=0}^{p-1} (a/p)·e^{2πia/p} as the central object. The key insight, formalized here, is that τ² = χ(-1)·p in ℂ — a clean algebraic identity in the complex plane that immediately encodes information about quadratic residues. The proof strategy is then: compute τ^q in two ways (using the Frobenius endomorphism and the definition), compare them, and read off QR. This approach influenced the development of algebraic number theory, eventually leading to Hecke's generalization using Hecke Grössencharacters and Tate's thesis. The domain ℂ is essential — the analogous statement fails in ℤ, since ±p is not a perfect square for any prime p > 2.",
+    "problemStatement": "For an odd prime $p$, the classical Gauss sum $\\tau = \\sum_{a=0}^{p-1} \\left(\\frac{a}{p}\\right) e^{2\\pi i a/p} \\in \\mathbb{C}$ satisfies $\\tau^2 = \\chi(-1) \\cdot p$, where $\\chi(-1) = \\left(\\frac{-1}{p}\\right) = (-1)^{(p-1)/2}$. Equivalently, $\\tau^2 = p$ if $p \\equiv 1 \\pmod{4}$ and $\\tau^2 = -p$ if $p \\equiv 3 \\pmod{4}$.",
+    "proofStrategy": "Three-step chain via Mathlib: (1) Apply `gaussSum_sq` (Mathlib.NumberTheory.GaussSum) — for nontrivial quadratic χ and primitive ψ over a finite group G, (gaussSum χ ψ)² = χ(-1)·|G|. Both hypotheses are non-trivial: nontriviality requires ruling out the zero character via Int.cast injectivity, and primitivity of ZMod.stdAddChar is a deep fact about exponential characters. (2) Instantiate |G| = |ZMod p| = p using `ZMod.card`. (3) Evaluate χ(-1) via the **first supplementary law** `legendreSym.at_neg_one`, which converts the Legendre symbol at -1 to (-1)^(p/2) via the χ₄ character formula.",
+    "keyInsights": [
+      "The identity τ² = χ(-1)·p lives necessarily in ℂ. For any odd prime p, ±p is not a perfect square in ℤ, so there is no integer Gauss sum satisfying this identity. The complex plane is the minimal domain where the proof works.",
+      "Mathlib's `gaussSum_sq` distills decades of analytic number theory into a single theorem. Its hypotheses — χ nontrivial and ψ primitive — are exactly the conditions that prevent the sum from collapsing to 0 via character orthogonality.",
+      "The first supplementary law (legendreSym p (-1) = (-1)^(p/2)) is equivalent to Euler's criterion for -1: -1 is a quadratic residue mod p iff p ≡ 1 (mod 4). This is why the sign of τ² depends only on p mod 4, not on the specific prime.",
+      "The proof converts an **axiom** (in ElementaryQuadraticReciprocityOQ01OQ01) into a **theorem** with explicit witness. This exemplifies a key pattern in formalization: axiomatize first to unblock dependent results, then prove later when the infrastructure catches up.",
+      "The `noncomputable` keyword reflects a deep truth: while τ² = χ(-1)·p is decidable as a mathematical proposition, computing the actual complex value of τ requires transcendental functions (exponentials) that Lean cannot reduce computationally."
+    ],
+    "difficulty": "intermediate",
+    "prerequisites": [
+      "Multiplicative characters (MulChar)",
+      "Additive characters (AddChar)",
+      "Legendre symbol and quadratic characters",
+      "First supplementary law of QR"
+    ]
+  },
+  "conclusion": {
+    "summary": "YES — the Gauss sum squared identity τ² = χ(-1)·p is fully provable in Lean 4 using Mathlib's gaussSum_sq theorem. The proof has 0 sorries and 0 new axioms, converting the parent OQ02's axiomatized version into a genuine theorem with explicit witness.",
+    "openQuestions": [
+      "Can the Frobenius step τ^q ≡ (p/q)·τ (mod q) be formalized? (OQ-01-OQ-01-OQ-02)",
+      "Does the full Gauss sum QR proof (all four steps) assemble into a single Lean proof?"
+    ],
+    "implications": "The formalization of τ² = χ(-1)·p establishes the hardest intermediate step in the Gauss sum proof of Quadratic Reciprocity. The remaining open step — formalizing the Frobenius argument τ^q ≡ (p/q)·τ (mod q) — would complete a full Lean machine-checked proof of QR via the Gauss sum method, complementing the Eisenstein lattice-point proof already in the gallery. Beyond QR, Gauss sums of this form appear throughout algebraic and analytic number theory: in Dirichlet L-function computations, in Weil's proof of the Riemann hypothesis for curves over finite fields (via Weil sums), and in Hecke's generalization of the functional equation. The ℂ-valued formulation also connects to the theory of Hecke Grössencharacters and Tate's thesis, which reformulates class field theory in terms of characters."
+  },
+  "crossReferences": [
+    {
+      "id": "elementary-quadratic-reciprocity-oq-01-oq-01",
+      "relationship": "parent — outlines the full Gauss sum pathway for QR"
+    },
+    {
+      "id": "elementary-quadratic-reciprocity-oq-02-oq-01",
+      "relationship": "sibling — proves the same identity from the OQ02 parent's axiom perspective"
+    },
+    {
+      "id": "elementary-quadratic-reciprocity",
+      "relationship": "root — the Eisenstein lattice-point proof of QR"
+    }
+  ]
+}


### PR DESCRIPTION
## Enrichment pass for elementary-quadratic-reciprocity-oq-01-oq-01-oq-01

**Quality before**: 18 (passes: 0, annotations: 0)

### Changes

**annotations.json** — Added 7 rich annotations covering all 212 lines:
- ann-gauss-intro (1–41): Historical context — Gauss's 8 proofs, four-step QR strategy, necessity of ℂ
- ann-quad-char-def (57–70): quadCharC as ℂ-valued MulChar via Int.castRingHom + IsQuadratic
- ann-nontriviality (72–88): Technique — contrapositive via Int.cast injectivity
- ann-classical-gauss-sum (90–97): Assembly of multiplicative + additive characters
- ann-main-theorem (99–141): Three-step chain: gaussSum_sq -> ZMod.card -> legendreSym.at_neg_one
- ann-sign-corollaries (143–173): p mod 4 case split; axiom elimination pattern
- ann-concrete-instances (175–212): p=3,5,7,13 verification with actual Gauss sum values

**meta.json** — Overview and sections enriched:
- Added historicalContext, problemStatement, proofStrategy, keyInsights (5 items) to overview
- Fixed sections format: replaced non-standard content+leanRef with proper id/startLine/endLine/summary/mathContext
- Added implications to conclusion (Frobenius next step, Weil sums, Hecke characters)

**Build**: pnpm build passes

Generated with Claude Code