### PR TITLE
fix(meta): remove redundant sorryCount field from 38 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -122,7 +122,6 @@
   "leanFile": {
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05.lean",
     "axiomCount": 1,
-    "sorryCount": 0,
     "lineCount": 214,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -132,7 +132,6 @@
   "leanFile": {
     "path": "Proofs/BallotProblemOQ01OQ02OQ01OQ01.lean",
     "axiomCount": 0,
-    "sorryCount": 0,
     "lineCount": 200,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -12,7 +12,6 @@
     "proofRepoPath": "Proofs/BallotProblemOQ02OQ02.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "sorryCount": 0,
     "theoremCount": 11,
     "definitionCount": 2,
     "lineCount": 185,

--- a/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
@@ -7,7 +7,6 @@
     "status": "verified",
     "badge": "original",
     "axiomCount": 0,
-    "sorryCount": 0,
     "theoremCount": 13,
     "definitionCount": 2,
     "lineCount": 228,

--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -19,7 +19,6 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "sorryCount": 0,
     "definitionCount": 2,
     "lineCount": 280,
     "theoremCount": 14,

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
@@ -12,7 +12,6 @@
     "proofRepoPath": "Proofs/BorsukUlamOQ03OQ04.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "sorryCount": 0,
     "theoremCount": 16,
     "definitionCount": 2,
     "lineCount": 235,

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-03/meta.json
@@ -138,7 +138,6 @@
     "theoremCount": 9,
     "defCount": 0,
     "axiomCount": 1,
-    "sorryCount": 0,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
@@ -155,7 +155,6 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/CantorsTheoremOQ01OQ02.lean",
-    "sorryCount": 0,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 1,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
@@ -165,7 +165,6 @@
       "For random matrices (e.g., Gaussian entries), what is the probability that M is nonderogatory? Combined with this result, this would give the probability that a random (M,v) pair has v cyclic for M"
     ]
   },
-  "sorryCount": 0,
   "status": "verified",
   "badge": "mathlib",
   "leanFile": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -154,7 +154,6 @@
       "Connect the annihilator ideal to the spectrum of T in the infinite-dimensional case"
     ]
   },
-  "sorryCount": 0,
   "status": "verified",
   "badge": "mathlib",
   "leanFile": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -186,7 +186,6 @@
       "Over finite fields $\\mathbb{F}_q$ with $q \\leq n$, the union avoidance lemma fails. What is the exact threshold: for which $(n, q)$ pairs does every nonderogatory $M \\in M_n(\\mathbb{F}_q)$ have a cyclic vector?"
     ]
   },
-  "sorryCount": 0,
   "status": "verified",
   "badge": "original",
   "leanFile": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-02/meta.json
@@ -25,7 +25,6 @@
   "lineCount": 262,
   "theoremCount": 16,
   "axiomCount": 0,
-  "sorryCount": 0,
   "assumptions": [],
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
@@ -185,7 +185,6 @@
       "What is the relationship between [L:K] and the degree drop of the minimal polynomial?"
     ]
   },
-  "sorryCount": 0,
   "status": "verified",
   "badge": "mathlib",
   "leanFile": {

--- a/src/data/proofs/circumference-via-differentiation/meta.json
+++ b/src/data/proofs/circumference-via-differentiation/meta.json
@@ -92,7 +92,6 @@
   "leanFile": {
     "path": "Proofs/CircumferenceViaDifferentiation.lean",
     "axiomCount": 0,
-    "sorryCount": 0,
     "lineCount": 199,
     "theoremCount": 13,
     "definitionCount": 2,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
@@ -27,7 +27,6 @@
   "lineCount": 311,
   "theoremCount": 24,
   "axiomCount": 0,
-  "sorryCount": 0,
   "assumptions": [],
   "meta": {
     "author": "Jacobi / Eisenstein (formalized in Lean 4 with Mathlib)",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
@@ -29,7 +29,6 @@
     "theoremCount": 3,
     "definitionCount": 0
   },
-  "sorryCount": 0,
   "status": "axiomatized",
   "badge": "axiom",
   "leanFile": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -27,7 +27,6 @@
   "lineCount": 199,
   "theoremCount": 10,
   "axiomCount": 0,
-  "sorryCount": 0,
   "assumptions": [],
   "meta": {
     "author": "Jacobi / Eisenstein (formalized in Lean 4 with Mathlib)",

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -28,7 +28,7 @@
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {
-        "sorryCount": 0
+        "sorries": 0
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/erdos-31-primes-density/meta.json
+++ b/src/data/proofs/erdos-31-primes-density/meta.json
@@ -12,7 +12,6 @@
     "proofRepoPath": "Proofs/Erdos31PrimesDensity.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "sorryCount": 0,
     "theoremCount": 5,
     "definitionCount": 4,
     "lineCount": 234,

--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -59,7 +59,6 @@
       "erdos_614_summary theorem: combines existence, complete-graph upper bound, and partial-star tight bound"
     ],
     "axiomCount": 2,
-    "sorryCount": 0,
     "lineCount": 594,
     "assumptions": "2 axioms: f_lower_bound, f_mono_k. f_case_k_eq_1 fully proved (no sorry: existsGraphWithPropertyP uses Fin n canonically, transport-free). f_upper_bound proved via complete graph construction. f_n_minus_2_upper_bound proved via partial-star construction (tight, vs complete-graph bound n*(n-1)/2).",
     "theoremCount": 17,

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -20,7 +20,6 @@
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "sorryCount": 0,
     "lineCount": 427,
     "theoremCount": 14,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -77,7 +77,6 @@
         "theoremCount": 35,
         "axiomCount": 1,
         "defCount": 4,
-        "sorryCount": 0,
         "isAristotle": false
       }
     ],

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -98,7 +98,6 @@
     "leanFile": {
         "path": "Proofs/FrobeniusNumber.lean",
         "axiomCount": 0,
-        "sorryCount": 0,
         "lineCount": 316,
         "theoremCount": 15,
         "definitionCount": 3,

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
@@ -159,7 +159,6 @@
     "namespace": "PadicAlgClosureContrast",
     "lineCount": 215,
     "axiomCount": 2,
-    "sorryCount": 0,
     "theoremCount": 14,
     "definitionCount": 0
   },

--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -105,7 +105,6 @@
   "leanFile": {
     "path": "Proofs/GaussWilsonNonCyclic.lean",
     "axiomCount": 0,
-    "sorryCount": 0,
     "lineCount": 323,
     "theoremCount": 21,
     "definitionCount": 1,

--- a/src/data/proofs/inclusion-exclusion-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03/meta.json
@@ -163,7 +163,6 @@
     "theoremCount": 12,
     "axiomCount": 0,
     "defCount": 4,
-    "sorryCount": 0,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -116,7 +116,6 @@
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {
-        "sorryCount": 0,
         "theoremCount": 106,
         "lineCount": 1882
       }

--- a/src/data/proofs/mean-value-theorem-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04/meta.json
@@ -7,7 +7,6 @@
     "status": "verified",
     "badge": "original",
     "axiomCount": 0,
-    "sorryCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,
     "lineCount": 293,

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -112,7 +112,6 @@
   "leanFile": {
     "path": "Proofs/PappusTheoremOQ02.lean",
     "axiomCount": 0,
-    "sorryCount": 0,
     "lineCount": 465,
     "theoremCount": 12,
     "definitionCount": 3,

--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -12,7 +12,6 @@
     "proofRepoPath": "Proofs/PicksTheoremOQ01OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "sorryCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,
     "lineCount": 215,

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -21,7 +21,6 @@
     "theoremCount": 3,
     "definitionCount": 2
   },
-  "sorryCount": 0,
   "status": "verified",
   "badge": "mathlib",
   "crossReferences": [

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
@@ -29,7 +29,6 @@
   "lineCount": 262,
   "theoremCount": 8,
   "axiomCount": 0,
-  "sorryCount": 0,
   "assumptions": [],
   "meta": {
     "author": "Ferrari / Cardano (formalized in Lean 4)",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
@@ -64,7 +64,6 @@
       "description": "vietas-formulas proves the general Vieta's theorem for degree-n polynomials. This file specializes to degree 3 and works over any CommRing, not just algebraically closed fields."
     }
   ],
-  "sorryCount": 0,
   "status": "verified",
   "badge": "original",
   "leanFile": {

--- a/src/data/proofs/solution-of-cubic-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03/meta.json
@@ -156,7 +156,6 @@
       "Verify Vieta's formulas for the general (non-depressed) cubic x³ + ax² + bx + c = 0, showing σ₁ = -a, σ₂ = b, σ₃ = -c"
     ]
   },
-  "sorryCount": 0,
   "status": "verified",
   "badge": "mathlib",
   "leanFile": {

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -12,7 +12,6 @@
     "proofRepoPath": "Proofs/SpernerMathlib4.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "sorryCount": 0,
     "theoremCount": 17,
     "definitionCount": 3,
     "lineCount": 732,

--- a/src/data/proofs/sperner-simplicial-bridge/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge/meta.json
@@ -7,7 +7,6 @@
     "status": "verified",
     "badge": "original",
     "axiomCount": 0,
-    "sorryCount": 0,
     "theoremCount": 21,
     "definitionCount": 5,
     "lineCount": 611,

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -12,7 +12,6 @@
     "proofRepoPath": "Proofs/SzemerediCoreOQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "sorryCount": 0,
     "theoremCount": 11,
     "definitionCount": 0,
     "lineCount": 843,

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
@@ -7,7 +7,6 @@
     "status": "verified",
     "badge": "original",
     "axiomCount": 0,
-    "sorryCount": 0,
     "theoremCount": 22,
     "definitionCount": 1,
     "lineCount": 539,


### PR DESCRIPTION
## Fix

Removes redundant `sorryCount` field from 38 gallery `meta.json` files. The canonical schema field is `sorries` (per `src/types/proof.ts:352`); `sorryCount` was leftover research-side metadata that duplicated the same value.

## Evidence

- All 38 files had both `sorries: 0` and `sorryCount: 0` (matching values) at one of: top-level, `meta.*`, `leanFile.*`, or `meta.leanFiles[*]`.
- One special case (`erdos-1014-oq-02`): `sorryCount` was the sole property in `meta.leanFiles[0]`, so renamed to `sorries` rather than deleted (preserves array shape).
- `find-targets.ts` (#15742) already treats `sorryCount` as a fallback for `sorries` — no auditor disruption.
- Total diff: 38 files, 1 insertion, 38 deletions.
- `pnpm build` passes (verified locally).

**Before**: 38 entries with redundant `sorryCount` field shadowing `sorries`.
**After**: canonical `sorries` only; gallery JSON schema clean.

Pattern reference: memory note `feedback_mechanic_leanfile_schema_patterns.md` ("sorryCount instead of sorries"); previous batch in PRs #15996/#15998.

---
Automated cleanup by lean-mechanic agent.