### PR TITLE
research(law-of-cosines-oq-01-oq-01): add gallery entry for dual spherical law of cosines

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/annotations.json
@@ -1,0 +1,103 @@
+{
+  "source": "lean-genius-research",
+  "version": "1.0",
+  "proofId": "law-of-cosines-oq-01-oq-01",
+  "annotations": [
+    {
+      "id": "ann-001",
+      "type": "definition",
+      "line": 42,
+      "title": "Dihedral Angle at Vertex A",
+      "body": "The dihedral angle A at vertex V_A is defined as arccos of the normalized inner product of the perpendicular projections of V_B and V_C onto the plane perpendicular to V_A. When either projection has zero norm (degenerate triangle), the angle defaults to 0.",
+      "tags": ["definition", "dihedral-angle", "perpendicular-projection"]
+    },
+    {
+      "id": "ann-002",
+      "type": "definition",
+      "line": 48,
+      "title": "Dihedral Angle at Vertex B",
+      "body": "The dihedral angle B at vertex V_B is defined analogously to angleAtA, using perpendicular projections of V_A and V_C onto the plane perpendicular to V_B.",
+      "tags": ["definition", "dihedral-angle"]
+    },
+    {
+      "id": "ann-003",
+      "type": "theorem",
+      "line": 58,
+      "title": "Inner Product of Perpendicular Projections at A",
+      "body": "⟨prj(B,A), prj(C,A)⟩ = cos(a) − cos(b)·cos(c). This is the key cosine formula relating the inner product of projections at vertex A to the side cosines. It follows directly from the inner_decomposition lemma in SphericalLawOfCosines, which states ⟨u,v⟩ = ⟨u,n⟩⟨v,n⟩ + ⟨prj(u,n), prj(v,n)⟩.",
+      "tags": ["theorem", "inner-product", "cosine-formula"]
+    },
+    {
+      "id": "ann-004",
+      "type": "theorem",
+      "line": 86,
+      "title": "Norm of Projection: ‖prj(B,A)‖ = sin(c)",
+      "body": "The perpendicular projection of V_B onto the plane ⊥ V_A has norm sin(c), where c is the arc-length from A to B. This uses norm_projectPerp_eq_sin from SphericalLawOfCosines together with the symmetry of arc length (arcLength is commutative).",
+      "tags": ["theorem", "norm", "sine", "projection"]
+    },
+    {
+      "id": "ann-005",
+      "type": "definition",
+      "line": 108,
+      "title": "Gram Determinant",
+      "body": "gramDet(t) = 1 − cos²a − cos²b − cos²c + 2cos(a)cos(b)cos(c). This is the 3×3 Gram determinant of the unit vectors V_A, V_B, V_C forming the spherical triangle. It equals (det[V_A V_B V_C])², measuring the signed volume squared of the parallelepiped they span.",
+      "tags": ["definition", "gram-determinant", "volume"]
+    },
+    {
+      "id": "ann-006",
+      "type": "theorem",
+      "line": 112,
+      "title": "Gram Determinant is Nonneg",
+      "body": "gramDet t ≥ 0. Proof: gramDet = ‖prj(B,A)‖²·‖prj(C,A)‖² − ⟨prj(B,A),prj(C,A)⟩², which is nonneg by the Cauchy-Schwarz inequality (|⟨u,v⟩| ≤ ‖u‖·‖v‖). This is the spherical analogue of saying the triple product is real.",
+      "tags": ["theorem", "cauchy-schwarz", "nonnegativity"]
+    },
+    {
+      "id": "ann-007",
+      "type": "theorem",
+      "line": 136,
+      "title": "Cosine Formula: cos(A)·sin(b)·sin(c) = cos(a) − cos(b)·cos(c)",
+      "body": "Assumes sin(b) > 0 and sin(c) > 0 (nondegenerate triangle). The formula is derived by: (1) showing the projections are nonzero (since their norms are sin(c) and sin(b)), (2) unfolding arccos, (3) applying inner_proj_A, norm_B_wrt_A, norm_C_wrt_A, and field_simp to clear the denominators.",
+      "tags": ["theorem", "cosine-formula", "angle-side-relation"]
+    },
+    {
+      "id": "ann-008",
+      "type": "theorem",
+      "line": 170,
+      "title": "sin²(A)·sin²(b)·sin²(c) = gramDet",
+      "body": "Uses sin²(A) = 1 − cos²(A) (Pythagorean identity), then substitutes cos(A)·sin(b)·sin(c) = cos(a)−cos(b)cos(c) from cos_A_mul, and simplifies the resulting polynomial to gramDet using nlinarith and sin_sq identities.",
+      "tags": ["theorem", "sine-squared", "gram-determinant"]
+    },
+    {
+      "id": "ann-009",
+      "type": "theorem",
+      "line": 221,
+      "title": "Key Product Identity: sin(A)·sin(B)·sin(a)·sin(b)·sin²(c) = gramDet",
+      "body": "This is the most technically delicate step. Strategy: (1) Show the product squared equals gramDet² (by factoring and using sinA_sq_gramDet and sinB_sq_gramDet). (2) Factor the difference-of-squares: (product − gramDet)(product + gramDet) = product² − gramDet² = 0. (3) Since the product is nonneg and gramDet is nonneg, both factors must be nonneg, so product − gramDet = 0.",
+      "tags": ["theorem", "nonneg-square-root", "gram-determinant", "key-step"]
+    },
+    {
+      "id": "ann-010",
+      "type": "theorem",
+      "line": 274,
+      "title": "Main Theorem: Dual Spherical Law of Cosines",
+      "body": "cos(C) = −cos(A)·cos(B) + sin(A)·sin(B)·cos(c). The proof multiplies both sides by sin(a)·sin(b)·sin²(c) (nonzero by nondegeneracy) and reduces to a polynomial identity. With h_cA, h_cB, h_cC (the three cosine formulas), h_pΔ (the product identity), and sin²+cos²=1, the identity follows by `ring` after algebraic expansion.",
+      "tags": ["theorem", "main-result", "dual-law", "polynomial-identity"]
+    },
+    {
+      "id": "ann-011",
+      "type": "example",
+      "line": 317,
+      "title": "Right-Angle Verification",
+      "body": "For angles A = B = C = π/2 (right angles), the dual law gives 0 = −0·0 + 1·1·0 = 0. This is the degenerate case of the 90-90-90 spherical triangle (an octant of the sphere), where all three angles and all three sides are π/2.",
+      "tags": ["example", "right-angle", "verification"]
+    },
+    {
+      "id": "ann-012",
+      "type": "example",
+      "line": 329,
+      "title": "Equilateral 90-90-90 Verification",
+      "body": "A second verification for the all-right-angle triangle. cos(arccos(0)) = 0 by Real.cos_arccos (since |0| ≤ 1), and the identity reduces to 0 = 0 by simp.",
+      "tags": ["example", "verification"]
+    }
+  ]
+}

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/index.ts
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/index.ts
@@ -1,0 +1,9 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LawOfCosinesOQ01OQ01.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const lawOfCosinesOQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const lawOfCosinesOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const lawOfCosinesOQ01OQ01Data: ProofData = { proof: lawOfCosinesOQ01OQ01Proof, annotations: lawOfCosinesOQ01OQ01Annotations, tacticStates: [] }
+export default lawOfCosinesOQ01OQ01Data

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
@@ -1,0 +1,68 @@
+{
+  "id": "law-of-cosines-oq-01-oq-01",
+  "title": "Dual Spherical Law of Cosines",
+  "slug": "law-of-cosines-oq-01-oq-01",
+  "description": "Proves the dual spherical law of cosines: for a non-degenerate spherical triangle with arc-length sides a, b, c and dihedral angles A, B, C, we have cos(C) = −cos(A)·cos(B) + sin(A)·sin(B)·cos(c). This is the polar dual of the standard spherical law of cosines, exchanging the roles of sides and angles via the polar triangle construction.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "spherical-geometry",
+      "law-of-cosines",
+      "dihedral-angles",
+      "gram-determinant",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 334,
+    "assumptions": "No axioms or sorries. All results proved from Mathlib inner product space theory.",
+    "dateAdded": "2026-05-06",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "angleAtA, angleAtB: dihedral angles at vertices via arccos of normalized inner product of perpendicular projections",
+      "gramDet: Gram determinant 1 − cos²a − cos²b − cos²c + 2cos(a)cos(b)cos(c) proved nonneg via Cauchy-Schwarz",
+      "sinA_sq_gramDet: sin²(A)·sin²(b)·sin²(c) = gramDet by double-angle identity and the cosine formula",
+      "sinAB_product: sin(A)·sin(B)·sin(a)·sin(b)·sin²(c) = gramDet via nonneg square-root extraction",
+      "dual_spherical_law_of_cosines: cos(C) = −cos(A)cos(B) + sin(A)sin(B)cos(c) via polynomial identity after clearing denominators"
+    ],
+    "theoremCount": 22,
+    "definitionCount": 3
+  },
+  "leanFile": {
+    "path": "Proofs/LawOfCosinesOQ01OQ01.lean",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 334,
+    "theoremCount": 22,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The dual spherical law of cosines, cos(C) = −cos(A)·cos(B) + sin(A)·sin(B)·cos(c), is obtained from the standard law cos(c) = cos(a)·cos(b) + sin(a)·sin(b)·cos(C) by applying the polar triangle construction: replace each side by π minus the opposite angle and vice versa. The duality was known to Euler and appears in Todhunter's 1886 treatise as a direct consequence of the polar triangle, but the direct algebraic proof via the Gram determinant avoids the polar construction and works at the level of unit vectors in ℝ³.",
+    "problemStatement": "For a spherical triangle on S² with arc-length sides a, b, c and dihedral angles A, B, C (with all side sines positive), prove:\n\n$$\\cos C = -\\cos A \\cdot \\cos B + \\sin A \\cdot \\sin B \\cdot \\cos c$$\n\nwhere A = angleAtA and B = angleAtB are the dihedral angles at vertices A and B, defined as arccos of the normalized inner product of the perpendicular projections of adjacent vertex vectors.",
+    "text": "Proves the dual spherical law of cosines by a direct algebraic route via the Gram determinant, circumventing the polar triangle construction.",
+    "proofStrategy": "1. Define dihedral angles A, B at vertices as arccos of normalized inner products of perpendicular projections. 2. Prove cos(A)·sin(b)·sin(c) = cos(a) − cos(b)·cos(c) (and analogously for B, C) from the inner product decomposition lemma in SphericalLawOfCosines. 3. Define gramDet = 1 − cos²a − cos²b − cos²c + 2cos(a)cos(b)cos(c) and prove it is nonneg via the Cauchy-Schwarz inequality on perpendicular projections. 4. Show sin²(A)·sin²(b)·sin²(c) = gramDet by combining the sin²+cos²=1 identity with the cosine formula. 5. Deduce sin(A)·sin(B)·sin(a)·sin(b)·sin²(c) = gramDet: the product squares to gramDet² (from step 4) and is nonneg, so equals gramDet by nonneg square-root extraction. 6. Multiply both sides of the target equation by sin(a)·sin(b)·sin²(c) and use the polynomial identity (verified by `ring`) to complete the proof.",
+    "keyInsights": [
+      "The Gram determinant gramDet = 1 − cos²a − cos²b − cos²c + 2cos(a)cos(b)cos(c) equals ‖prj(B,A)‖²·‖prj(C,A)‖² − ⟨prj(B,A),prj(C,A)⟩², which is nonneg by Cauchy-Schwarz. This is the key positivity result underlying both the standard and dual laws.",
+      "The identity sin²(A)·sin²(b)·sin²(c) = gramDet follows from sin²+cos²=1 applied to angle A, then substituting the cosine formula. This connects the angular sine to the Gram determinant.",
+      "The product sin(A)·sin(B)·sin(a)·sin(b)·sin²(c) = gramDet is extracted from sin²(A)·sin²(b)·sin²(c) = gramDet and sin²(B)·sin²(a)·sin²(c) = gramDet by showing the product squares to gramDet² and using nonnegativity to take the square root.",
+      "The dual law is equivalent to a polynomial identity after multiplying through by sin(a)·sin(b)·sin²(c). With all five cosine/product formulas in hand, this identity reduces to 0=0 by `ring`, making the algebraic verification automatic.",
+      "Dihedral angles at A and B are defined via perpendicular projection: the angle between the planes A-B and A-C at edge A is arccos(⟨prj(B,A), prj(C,A)⟩ / (‖prj(B,A)‖·‖prj(C,A)‖)). The nondegenerate condition (positive sine of all sides) ensures the projections are nonzero."
+    ],
+    "prerequisites": [
+      "Spherical law of cosines: cos(c) = cos(a)·cos(b) + sin(a)·sin(b)·cos(C) (Proofs/SphericalLawOfCosines.lean)",
+      "Inner product decomposition: ⟨u, v⟩ = ⟨u, n⟩⟨v, n⟩ + ⟨prj⊥(u,n), prj⊥(v,n)⟩ for unit normal n",
+      "Cauchy-Schwarz inequality: |⟨u, v⟩| ≤ ‖u‖·‖v‖",
+      "sin²θ + cos²θ = 1 (Pythagorean identity)",
+      "arccos properties: arccos is in [0, π] and cos(arccos(x)) = x for x ∈ [−1,1]"
+    ],
+    "openQuestions": [
+      "Can the Gram determinant argument be generalized to prove the full sine rule sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c)?",
+      "Does the dual law remain true for degenerate triangles (sides of measure 0 or π)?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds gallery entry for `law-of-cosines-oq-01-oq-01` (dual spherical law of cosines)
- The Lean proof (`LawOfCosinesOQ01OQ01.lean`) was already on `main` with 0 sorries and 0 axioms
- Adds `meta.json`, `annotations.json`, and `index.ts` for the gallery

## Proof

Proves the **dual spherical law of cosines**:

$$\cos C = -\cos A \cdot \cos B + \sin A \cdot \sin B \cdot \cos c$$

(polar dual of the standard cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C))

Key techniques:
- Define dihedral angles A, B via `arccos` of normalized inner products of perpendicular projections
- `gramDet` = 1 − cos²a − cos²b − cos²c + 2cos(a)cos(b)cos(c) ≥ 0 by Cauchy-Schwarz
- `sin²(A)·sin²(b)·sin²(c) = gramDet` via the cosine formula + sin²+cos²=1
- `sin(A)·sin(B)·sin(a)·sin(b)·sin²(c) = gramDet` via nonneg square-root extraction
- Dual law follows from a polynomial identity verified by `ring`

## Status
- sorries: 0
- axiomCount: 0
- theoremCount: 22
- definitionCount: 3
- lineCount: 334
- badge: original
- Imports: `Proofs.SphericalLawOfCosines`

🤖 Generated with [Claude Code](https://claude.com/claude-code)