### PR TITLE
fix(meta): sync liouville-theorem-oq-04 meta.theoremCount 15→16

### DIFF
--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -60,7 +60,7 @@
     ],
     "mathlib_version": "4.26.0",
     "lineCount": 467,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 3
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` for `liouville-theorem-oq-04` to match `leanFile.theoremCount` and the actual count in `proofs/Proofs/LiouvilleTheoremOQ04.lean`.

## Evidence

PR #15992 updated `leanFile.theoremCount` from 15 → 16 to reflect the actual Lean file (16 `theorem` declarations after stripping comments) but missed the parallel `meta.theoremCount` field on the same `meta.json`.

**Verified counts in `proofs/Proofs/LiouvilleTheoremOQ04.lean`:**
- `theorem`/`lemma` declarations (comment-stripped): **16**
- `def`/`abbrev`/`opaque`: 3
- `axiom`: 1
- 467 lines

**Before**: `meta.theoremCount = 15`, `leanFile.theoremCount = 16` (drift)
**After**: `meta.theoremCount = 16`, `leanFile.theoremCount = 16` (consistent)

This is the canonical "drift between meta sub-object and leanFile block" pattern — both blocks need to be updated in lockstep when the source file changes.

---
Automated fix by lean-mechanic agent.