### PR TITLE
prove(erdos-895): fill 3 sorries in Erdos895ProblemAristotle

### DIFF
--- a/proofs/Proofs/Erdos895ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos895ProblemAristotle.lean
@@ -64,7 +64,10 @@ theorem triangleFree_neighbor_disjoint {n : ℕ} (G : GraphOnInterval n)
     [DecidableRel G.Adj] (hG : IsTriangleFree G)
     (u v : Fin n) (huv : G.Adj u v) :
     Disjoint (G.neighborFinset u) (G.neighborFinset v) := by
-  sorry
+  rw [Finset.disjoint_left]
+  intro w hwu hwv
+  rw [SimpleGraph.mem_neighborFinset] at hwu hwv
+  exact hG u w v ⟨hwu, G.symm hwv, huv⟩
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 3: Degree Sum Bound (Key Step for Mantel)
@@ -78,7 +81,10 @@ theorem triangleFree_degree_sum_bound {n : ℕ} (G : GraphOnInterval n)
     [DecidableRel G.Adj] (hG : IsTriangleFree G)
     (u v : Fin n) (huv : G.Adj u v) :
     (G.neighborFinset u).card + (G.neighborFinset v).card ≤ n := by
-  sorry
+  have hdisj := triangleFree_neighbor_disjoint G hG u v huv
+  have hunion_le : (G.neighborFinset u ∪ G.neighborFinset v).card ≤ n :=
+    (Finset.card_le_card (Finset.subset_univ _)).trans_eq (Finset.card_fin n)
+  linarith [Finset.card_union_of_disjoint hdisj]
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 4: Mantel's Theorem
@@ -94,7 +100,26 @@ theorem triangleFree_degree_sum_bound {n : ℕ} (G : GraphOnInterval n)
 theorem mantel_theorem {n : ℕ} (G : GraphOnInterval n) [DecidableRel G.Adj]
     (hG : IsTriangleFree G) :
     G.edgeFinset.card ≤ n ^ 2 / 4 := by
-  sorry
+  have hcf : G.CliqueFree (2 + 1) := by
+    intro t ht
+    rw [SimpleGraph.isNClique_iff] at ht
+    obtain ⟨hclique_set, hcard⟩ := ht
+    obtain ⟨a, b, c, hab, hac, hbc, rfl⟩ := Finset.card_eq_three.mp hcard
+    exact hG a b c ⟨
+      hclique_set (by simp) (by simp) hab,
+      hclique_set (by simp) (by simp) hbc,
+      hclique_set (by simp) (by simp) hac⟩
+  have hbound : G.edgeFinset.card ≤
+      (n ^ 2 - (n % 2) ^ 2) * (2 - 1) / (2 * 2) + (n % 2).choose 2 := by
+    have key := CliqueFree.card_edgeFinset_le hcf
+    simp only [Fintype.card_fin] at key
+    exact key
+  have hchoose : (n % 2).choose 2 = 0 :=
+    Nat.choose_eq_zero_of_lt (Nat.mod_lt n (by norm_num))
+  calc G.edgeFinset.card
+      ≤ (n ^ 2 - (n % 2) ^ 2) * (2 - 1) / (2 * 2) + (n % 2).choose 2 := hbound
+    _ = (n ^ 2 - (n % 2) ^ 2) / 4 + 0 := by rw [hchoose]; norm_num
+    _ ≤ n ^ 2 / 4 := by simp only [add_zero]; exact Nat.div_le_div_right (Nat.sub_le _ _)
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 5: Simple Utility Facts

--- a/src/data/research/problems/erdos-895-oq-01.json
+++ b/src/data/research/problems/erdos-895-oq-01.json
@@ -1,0 +1,103 @@
+{
+  "slug": "erdos-895-oq-01",
+  "title": "Prove Hajnal's generalization: do large triangle-free graphs always contain a...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: Prove Hajnal's generalization: do large triangle-free graphs always contain a....",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-05-04T17:47:35.844Z",
+    "iteration": 1,
+    "focus": "Supporting lemmas proved; Hajnal conjecture is open",
+    "blockers": [],
+    "nextAction": "Investigate triangleFree_independence_bound or Hajnal conjecture approaches",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Proved 3 Aristotle lemmas (triangleFree_neighbor_disjoint, triangleFree_degree_sum_bound, mantel_theorem). Aristotle file now 0 sorries. Main file barber_theorem blocked (SAT-based).",
+    "builtItems": [
+      "Erdos895ProblemAristotle.lean:67 triangleFree_neighbor_disjoint \u2014 0 sorries",
+      "Erdos895ProblemAristotle.lean:80 triangleFree_degree_sum_bound \u2014 0 sorries",
+      "Erdos895ProblemAristotle.lean:100 mantel_theorem \u2014 0 sorries"
+    ],
+    "insights": [
+      "triangleFree_neighbor_disjoint proved: adjacent vertices in triangle-free graph have disjoint neighborhoods, via Finset.disjoint_left + G.symm",
+      "triangleFree_degree_sum_bound proved: deg(u)+deg(v) \u2264 n for adjacent u,v, via card_union_of_disjoint + Finset.subset_univ + card_fin",
+      "mantel_theorem proved in Aristotle file: IsTriangleFree \u2192 CliqueFree 3 \u2192 CliqueFree.card_edgeFinset_le gives n\u00b2/4 edge bound; mirrors proof pattern in Erdos895Problem.lean"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Main barber_theorem and counterexample_17 require SAT-based proof \u2014 blocked without external tool",
+      "triangleFree_independence_bound (\u221an independent set) could be proved via Ramsey/greedy but requires significant Mathlib API work",
+      "Hajnal conjecture (Hindman sets in triangle-free graphs) remains open \u2014 no known Lean formalization path"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "erdos-8",
+    "erdos-89",
+    "erdos-895"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-04T17:47:35.844Z",
+  "lastUpdate": "2026-05-04T17:47:35.844Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos895Aristotle.lean",
+      "filename": "Erdos895Aristotle.lean",
+      "lineCount": 171,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos895Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos895Problem.lean",
+      "filename": "Erdos895Problem.lean",
+      "lineCount": 261,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 11,
+      "sorryCount": 7,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos895Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos895ProblemAristotle.lean",
+      "filename": "Erdos895ProblemAristotle.lean",
+      "lineCount": 118,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 3,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos895ProblemAristotle.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves all 3 sorries in `Erdos895ProblemAristotle.lean`, completing the Aristotle companion file for Erdős Problem #895 (independent additive triples in triangle-free graphs).

**Lemmas proved:**

1. **`triangleFree_neighbor_disjoint`**: In a triangle-free graph, the neighborhoods of adjacent vertices u, v are disjoint. Any common neighbor w would form triangle u-w-v, contradicting `IsTriangleFree`. Proved using `Finset.disjoint_left`, `SimpleGraph.mem_neighborFinset`, and `G.symm`.

2. **`triangleFree_degree_sum_bound`**: For adjacent u, v in a triangle-free graph, deg(u) + deg(v) ≤ n. Follows from neighbor disjointness: |N(u)| + |N(v)| = |N(u) ∪ N(v)| ≤ |Fin n| = n, via `Finset.card_union_of_disjoint`.

3. **`mantel_theorem`** (Aristotle file): A triangle-free graph on n vertices has at most ⌊n²/4⌋ edges. `IsTriangleFree → CliqueFree 3 → CliqueFree.card_edgeFinset_le` gives the Turán bound; arithmetic closes to n²/4. Mirrors the completed proof in `Erdos895Problem.lean`.

**What remains blocked:** `barber_theorem` (SAT-verified result for threshold n=18) and `counterexample_17` require external SAT verification beyond Lean's tactic provers.

## Test plan
- [ ] Verify `proofs/Proofs/Erdos895ProblemAristotle.lean` has 0 sorries (confirmed via Python comment-stripped grep)
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos895ProblemAristotle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)