### PR TITLE
audit(tracker): batch — 5 gallery entries (3 clean, 2 issues-found)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12202,7 +12202,7 @@
     },
     "laws-of-large-numbers-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-05-06T06:54:23Z",
+      "lastAudited": "2026-05-06T07:15:56Z",
       "result": "clean",
       "issues": []
     },
@@ -14745,9 +14745,33 @@
       "result": "clean",
       "issues": []
     },
-    "laws-of-large-numbers-oq-01-oq-01": {
+    "bezout-identity-oq-04-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-05-06T07:15:56Z",
+      "lastAudited": "2026-05-06T07:45:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T07:47:11Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "erdos-1036-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T07:48:06Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-cosines-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T07:49:23Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "law-of-cosines-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T07:49:55Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

Audit-tracker update from auditor-agent loop on 2026-05-06. Five gallery entries audited (originally never-audited):

**Clean (3):**
- `bezout-identity-oq-04-oq-01-oq-01` — Tier C axiomatized, 2 axioms match meta
- `erdos-1036-oq-01` — Tier C axiomatized, 6 axioms match meta
- `law-of-cosines-oq-01-oq-04` — Tier A original, 0 sorries / 0 axioms / 0 stubs

**Issues-found (2):**
- `elementary-quadratic-reciprocity-oq-01-oq-01-oq-02` — badge `verified` but the file is a Mathlib wrapper; every theorem proof is a one-line invocation of `MulChar.IsQuadratic.gaussSum_frob`, `Char.card_pow_char_pow`, or `Char.card_pow_card`. Filed #16063.
- `law-of-cosines-oq-01-oq-02` — status `formalized` / badge `wip` but the file has 0 sorries, 0 axioms, 0 True stubs (underclaim). Also `theoremCount` is 16 in meta vs 21 actual. Filed #16064.

## Side fixes

- Re-serialized `audit-tracker.json` with `ensure_ascii=False` to preserve unicode (claim-target.sh's `json.dump` was ASCII-escaping arrows / em-dashes in historical entries each time it ran).
- Dedupes a pre-existing duplicate `laws-of-large-numbers-oq-01-oq-01` key (JSON spec disallows duplicates; the later entry is preserved by Python's `json.load`).

## Test plan

- [x] `find-targets.ts --stats` confirmed five never-audited entries pre-run; tracker now reflects all five
- [x] Manually re-ran the script's checks (sorry count, axiom declarations, True stubs) on each entry
- [x] Open PR #16028 already addresses the angle-trisection-cos-20 sorry mismatch (skipped, in-flight)