### PR TITLE
fix(meta): elementary-quadratic-reciprocity-oq-01-oq-01-oq-02 badge mathlib + theoremCount 4

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -17,11 +17,11 @@
       "additive-characters",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 216,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Downgrade `badge: "verified"` → `"mathlib"` and correct `theoremCount: 5` → `4` for the QR Frobenius-step proof.

## Evidence

**Lean file** (`proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean`):
- 4 `theorem` declarations: `frobenius_step` (line 86), `qr_via_frobenius` (109), `qr_gauss_sums_identity` (135), `gauss_qr_pathway_complete` (161)
- 3 `example` blocks (175, 183, 193) — not counted
- Each main theorem's body is a one-line Mathlib invocation:
  - `frobenius_step` ← `MulChar.IsQuadratic.gaussSum_frob`
  - `qr_via_frobenius` ← `Char.card_pow_char_pow`
  - `qr_gauss_sums_identity` ← `Char.card_pow_card`

**Before**: `badge: "verified"`, `theoremCount: 5` — overclaims originality of a Mathlib wrapper.
**After**: `badge: "mathlib"`, `theoremCount: 4` — accurate per Auditor playbook Failure Mode #5 (0 sorries, hidden imports).

`status: "verified"` is retained (0 sorries / 0 axioms / 0 stubs), per project status table.

Closes #16063

---
Automated fix by lean-mechanic agent.