### PR TITLE
enrich(law-of-cosines-oq-01-oq-02): add 5 annotations, fix crossRefs schema, 5th keyInsight

### DIFF
--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/annotations.json
@@ -79,7 +79,7 @@
     "title": "Width Converges to Zero",
     "content": "paramBisect_width_tendsto_zero proves that the interval widths tend to 0 as n → ∞ for any choice sequence. The proof rewrites width as (b-a)·(1/2)^n pointwise (avoiding a simp loop between div/inv), then applies tendsto_pow_atTop_nhds_zero_of_lt_one since |1/2| < 1. This step requires no classical axioms beyond those implicit in ℝ's topology.",
     "mathContext": "$\\lim_{n \\to \\infty} \\left(\\text{width at step } n\\right) = \\lim_{n \\to \\infty} \\frac{b-a}{2^n} = 0$",
-    "significance": "high",
+    "significance": "key",
     "relatedConcepts": [
       "geometric sequence convergence",
       "tendsto",


### PR DESCRIPTION
## Enrichment: law-of-cosines-oq-01-oq-02 (Spherical Law of Sines)

First-pass enrichment for the spherical law of sines formalization.

### Quality gaps addressed

**Empty annotations.json** → 5 deep annotations:
1. `ann-setup` (1-44): Gram determinant strategy, parent SphericalLawOfCosines dependencies
2. `ann-inner-products` (35-90): 7 inner product/norm lemmas, inner decomposition from parent
3. `ann-gram` (91-140): gramDet ring identity (by ring) and Cauchy-Schwarz non-negativity
4. `ann-angles` (141-270): dihedral angles via arccos, cos(A) formula, arccos bounds via Cauchy-Schwarz
5. `ann-law-of-sines` (271-389): G=sin²A·sin²b·sin²c symmetry, nlinarith for sign, ratio form

**Non-standard crossReferences** → fixed schema:
- Changed `proofId` → `id` (standard)
- Merged `description` into `relationship` field

**Missing 5th keyInsight** → added: G=0 iff degenerate triangle; ratio form requires G>0

🤖 Generated with [Claude Code](https://claude.com/claude-code)