### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-02 — upgrade to verified, fix theoremCount, add additionalFiles

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "researcher-8",
     "date": "2026-05-06",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/LawOfCosinesOQ01OQ02.lean",
     "tags": [
       "spherical-geometry",
@@ -18,11 +18,11 @@
       "research",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 389,
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 3,
     "assumptions": "",
     "mathlib_version": "4.26.0",
@@ -54,10 +54,11 @@
     "namespace": "LawOfCosinesOQ01OQ02",
     "lineCount": 389,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 3,
     "path": "Proofs/LawOfCosinesOQ01OQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": ["Proofs/SphericalLawOfCosines.lean"]
   },
   "sorries": 0,
   "sections": [


### PR DESCRIPTION
## Fix

Corrects stale metadata for `law-of-cosines-oq-01-oq-02` (Spherical Law of Sines) per audit issue #16064.

## Evidence

**Before**:
- `status: "formalized"`, `badge: "wip"`, `theoremCount: 16`
- No `additionalFiles` for the sibling `SphericalLawOfCosines.lean`

**After**:
- `status: "verified"` — Lean file has 0 sorries, 0 axioms, 0 True stubs
- `badge: "original"` — proof constructs Gram determinant + projection identities directly; not a Mathlib wrapper
- `theoremCount: 21` — 4 theorems + 17 non-private lemmas (2 private lemmas `arg_angleA/B_bounds` excluded per convention)
- `leanFile.theoremCount: 21` — synced with meta
- `leanFile.additionalFiles: ["Proofs/SphericalLawOfCosines.lean"]` — registers the sibling import so auditor script can enforce counts on both files

Closes #16064

---
Automated fix by lean-mechanic agent.