### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-03): Ioo integrability suffices for Fubini interval swap

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ03.lean
@@ -1,0 +1,228 @@
+/-
+  Weakened Integrability for Interval Integral Swap (greens-theorem-oq-01-oq-01-oq-03)
+
+  Open Question from greens-theorem-oq-01-oq-01:
+  "The integrability hypothesis uses the product of Icc-restricted measures.
+  Can this be weakened to just L¹ integrability on the open rectangle
+  Ioo a b × Ioo c d, and does Mathlib provide the necessary tools?"
+
+  ## Answer: YES.
+
+  For the Lebesgue measure on ℝ, vol.restrict (Icc a b) = vol.restrict (Ioo a b)
+  because the boundary {a, b} has Lebesgue measure zero (singletons are countable).
+  Therefore:
+    Integrable f (vol.restrict Icc × vol.restrict Icc) ↔
+    Integrable f (vol.restrict Ioo × vol.restrict Ioo)
+
+  The integrability hypothesis can be weakened to the open rectangle without
+  changing the theorem. The proof proceeds in three steps:
+
+  1. vol (Icc a b \ Ioo a b) = 0  (boundary has measure zero)
+  2. vol.restrict (Icc a b) = vol.restrict (Ioo a b)  (measures agree)
+  3. Apply existing Fubini theorem after converting Ioo → Icc integrability
+
+  ## Mathlib Tools
+
+  - Set.Countable.measure_zero: countable sets have measure zero
+  - measure_mono_null: subsets of null sets are null
+  - measure_union_null: union of null sets is null
+  - measure_union_le: subadditivity of measure
+  - Measure.ext: extensionality for measures
+  - MeasureTheory.integral_integral_swap: Fubini for Lebesgue integrals
+
+  ## Status: 0 sorries, 0 axioms
+-/
+import Mathlib
+
+open MeasureTheory intervalIntegral Set Measure Filter Topology
+
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+
+namespace GreensTheoremOQ01OQ01OQ03
+
+/-! ### Part I: Null Boundary Lemmas -/
+
+/-- The left boundary point of [a,b] has Lebesgue measure zero. -/
+private lemma volume_singleton_zero (a : ℝ) : volume ({a} : Set ℝ) = 0 :=
+  (Set.countable_singleton a).measure_zero volume
+
+/-- The closed-open difference Icc a b \ Ioo a b is contained in {a, b},
+    so it has Lebesgue measure zero. -/
+lemma volume_Icc_sdiff_Ioo (a b : ℝ) :
+    MeasureTheory.volume (Set.Icc a b \ Set.Ioo a b) = 0 :=
+  measure_mono_null
+    (fun x hx => by
+      rw [Set.mem_diff, Set.mem_Icc, Set.mem_Ioo] at hx
+      simp only [Set.mem_union, Set.mem_singleton_iff]
+      obtain ⟨⟨ha, hb⟩, hlt⟩ := hx
+      push_neg at hlt
+      -- hlt : a < x → b ≤ x; combined with ha : a ≤ x and hb : x ≤ b
+      rcases lt_or_eq_of_le ha with ha' | ha'
+      · right; exact le_antisymm hb (hlt ha')
+      · left; exact ha'.symm)
+    (measure_union_null (volume_singleton_zero a) (volume_singleton_zero b))
+
+/-! ### Part II: Restriction Equality -/
+
+/-- For Lebesgue measure on ℝ, the restriction to a closed interval equals the
+    restriction to the corresponding open interval. The boundary has measure zero,
+    so no mass is lost or gained when switching between Icc and Ioo. -/
+theorem volume_restrict_Icc_eq_Ioo (a b : ℝ) :
+    MeasureTheory.volume.restrict (Set.Icc a b) =
+    MeasureTheory.volume.restrict (Set.Ioo a b) := by
+  ext s hs
+  simp only [Measure.restrict_apply hs]
+  apply le_antisymm
+  · -- volume (s ∩ Icc a b) ≤ volume (s ∩ Ioo a b)
+    -- Because s ∩ Icc ⊆ (s ∩ Ioo) ∪ (Icc \ Ioo), and (Icc \ Ioo) is null
+    have h1 : s ∩ Set.Icc a b ⊆ s ∩ Set.Ioo a b ∪ (Set.Icc a b \ Set.Ioo a b) := by
+      intro x ⟨hxs, hxIcc⟩
+      by_cases hx' : x ∈ Set.Ioo a b
+      · exact Or.inl ⟨hxs, hx'⟩
+      · exact Or.inr ⟨hxIcc, hx'⟩
+    calc MeasureTheory.volume (s ∩ Set.Icc a b)
+        ≤ MeasureTheory.volume (s ∩ Set.Ioo a b ∪ (Set.Icc a b \ Set.Ioo a b)) :=
+            measure_mono h1
+      _ ≤ MeasureTheory.volume (s ∩ Set.Ioo a b) +
+          MeasureTheory.volume (Set.Icc a b \ Set.Ioo a b) :=
+            measure_union_le _ _
+      _ = MeasureTheory.volume (s ∩ Set.Ioo a b) := by
+            rw [volume_Icc_sdiff_Ioo, add_zero]
+  · -- volume (s ∩ Ioo a b) ≤ volume (s ∩ Icc a b)  (Ioo ⊆ Icc)
+    exact measure_mono (Set.inter_subset_inter_right s Set.Ioo_subset_Icc_self)
+
+/-- The product of Icc-restricted measures equals the product of Ioo-restricted
+    measures, for all pairs of endpoints. -/
+theorem volume_prod_restrict_Icc_eq_Ioo (a b c d : ℝ) :
+    (MeasureTheory.volume.restrict (Set.Icc a b)).prod
+      (MeasureTheory.volume.restrict (Set.Icc c d)) =
+    (MeasureTheory.volume.restrict (Set.Ioo a b)).prod
+      (MeasureTheory.volume.restrict (Set.Ioo c d)) := by
+  rw [volume_restrict_Icc_eq_Ioo a b, volume_restrict_Icc_eq_Ioo c d]
+
+/-! ### Part III: Core Fubini Step (inline from OQ-01-OQ-01) -/
+
+/-- The core Fubini step for ordered intervals with Icc integrability.
+    Converts interval integrals to set integrals and applies Mathlib's
+    abstract Fubini theorem for Lebesgue integrals. -/
+private theorem fubini_core {f : ℝ → ℝ → ℝ}
+    (a b c d : ℝ) (hab : a ≤ b) (hcd : c ≤ d)
+    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
+    (hf_int : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
+      ((MeasureTheory.volume.restrict (Set.Icc a b)).prod
+       (MeasureTheory.volume.restrict (Set.Icc c d)))) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
+  rw [intervalIntegral.integral_of_le hcd]
+  conv_rhs => rw [intervalIntegral.integral_of_le hab]
+  simp_rw [intervalIntegral.integral_of_le hab, intervalIntegral.integral_of_le hcd]
+  have hf_int' : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
+      ((MeasureTheory.volume.restrict (Set.Ioc a b)).prod
+       (MeasureTheory.volume.restrict (Set.Ioc c d))) :=
+    hf_int.mono_measure (Measure.prod_mono
+      (Measure.restrict_mono Set.Ioc_subset_Icc_self le_rfl)
+      (Measure.restrict_mono Set.Ioc_subset_Icc_self le_rfl))
+  exact (MeasureTheory.integral_integral_swap hf_int').symm
+
+/-! ### Part IV: Main Theorems -/
+
+/-- **Fubini for Interval Integrals with Open Rectangle Integrability (Ordered)**
+
+    The integrability hypothesis can be weakened from the closed rectangle
+    [a,b] × [c,d] to the open rectangle (a,b) × (c,d).
+
+    For Lebesgue measure, these are equivalent: vol.restrict Icc = vol.restrict Ioo
+    since the boundary {a,b} and {c,d} have measure zero.
+
+    This answers the open question from greens-theorem-oq-01-oq-01:
+    "YES — the Icc integrability hypothesis is equivalent to Ioo integrability." -/
+theorem intervalIntegral_swap_of_Ioo_integrable {f : ℝ → ℝ → ℝ}
+    (a b c d : ℝ) (hab : a ≤ b) (hcd : c ≤ d)
+    (hf_meas : Measurable (fun p : ℝ × ℝ => f p.1 p.2))
+    (hf_int : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
+      ((MeasureTheory.volume.restrict (Set.Ioo a b)).prod
+       (MeasureTheory.volume.restrict (Set.Ioo c d)))) :
+    ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y := by
+  apply fubini_core a b c d hab hcd hf_meas
+  rw [volume_restrict_Icc_eq_Ioo a b, volume_restrict_Icc_eq_Ioo c d]
+  exact hf_int
+
+/-- **Equivalence**: Icc integrability ↔ Ioo integrability for Lebesgue measure.
+
+    This makes the equivalence explicit: the integrability conditions are
+    identical for Lebesgue measure. -/
+theorem integrable_Icc_iff_Ioo {f : ℝ × ℝ → ℝ} (a b c d : ℝ) :
+    Integrable f ((MeasureTheory.volume.restrict (Set.Icc a b)).prod
+                   (MeasureTheory.volume.restrict (Set.Icc c d))) ↔
+    Integrable f ((MeasureTheory.volume.restrict (Set.Ioo a b)).prod
+                   (MeasureTheory.volume.restrict (Set.Ioo c d))) := by
+  rw [volume_prod_restrict_Icc_eq_Ioo]
+
+/-! ### Part V: Application to Green's Theorem -/
+
+/-- For Green's theorem: the hFubini hypothesis can use either open or closed
+    rectangle integrability. For continuous partial derivatives, both hold
+    automatically (compact rectangle ⊆ open rectangle via integrability). -/
+theorem greens_fubini_open_rectangle
+    (dPdy : ℝ × ℝ → ℝ) (a b c d : ℝ) (hab : a ≤ b) (hcd : c ≤ d)
+    (hf_meas : Measurable dPdy)
+    (hf_int : Integrable dPdy
+      ((MeasureTheory.volume.restrict (Set.Ioo a b)).prod
+       (MeasureTheory.volume.restrict (Set.Ioo c d)))) :
+    ∫ y in c..d, ∫ x in a..b, dPdy (x, y) =
+    ∫ x in a..b, ∫ y in c..d, dPdy (x, y) :=
+  -- fun p => dPdy (p.1, p.2) and dPdy are definitionally equal
+  intervalIntegral_swap_of_Ioo_integrable a b c d hab hcd hf_meas hf_int
+
+/-! ### Part VI: Mathlib Gap Analysis -/
+
+/-
+## Mathlib Gap Analysis
+
+**Search results** (mathlib4 current):
+
+The key tools used here are ALL in Mathlib:
+- `Set.Countable.measure_zero`: countable sets have measure zero
+- `measure_mono_null`: monotonicity of null sets
+- `measure_union_null`: union of null sets is null
+- `measure_union_le`: subadditivity of measure
+- `Measure.restrict_apply`: restriction measure on measurable sets
+- `Set.inter_subset_inter_right`: intersection monotonicity
+- `Set.Ioo_subset_Icc_self`: Ioo ⊆ Icc
+
+The key THEOREM proved here:
+  `volume.restrict (Icc a b) = volume.restrict (Ioo a b)`
+This is NOT in Mathlib as a standalone lemma (as of current revision).
+
+**Why this is not in Mathlib**:
+  Mathlib tends to work with `Ioc` (half-open intervals) as the canonical
+  interval for Lebesgue measure theory (since `Ioc a b` is a π-system for
+  standard Borel measure construction). The Icc = Ioo equivalence under
+  Lebesgue measure is derivable but not prominently featured.
+
+**Contribution path**:
+  `volume_restrict_Icc_eq_Ioo` could be contributed to
+  `Mathlib.MeasureTheory.Measure.Lebesgue.Basic` as a @[simp] lemma.
+  More generally: for any atomless Borel measure, restricting to any of
+  Ioo, Ioc, Ico, Icc gives the same result (boundaries are null).
+
+## Summary
+
+| Theorem | Description | Status |
+|---------|-------------|--------|
+| `volume_Icc_sdiff_Ioo` | vol(Icc \ Ioo) = 0 | PROVED |
+| `volume_restrict_Icc_eq_Ioo` | Restriction equality | PROVED |
+| `volume_prod_restrict_Icc_eq_Ioo` | Product measure equality | PROVED |
+| `intervalIntegral_swap_of_Ioo_integrable` | Main Fubini with Ioo | PROVED |
+| `integrable_Icc_iff_Ioo` | Equivalence of conditions | PROVED |
+| `greens_fubini_open_rectangle` | Application to Green's | PROVED |
+
+**Answer to OQ-03**: YES. The Icc integrability hypothesis can be replaced by
+Ioo integrability (or any boundary variant: Ioc, Ico) because for Lebesgue
+measure these restrictions are identical. Mathlib provides all needed tools.
+
+Sorries: 0
+Axioms: 0
+-/
+
+end GreensTheoremOQ01OQ01OQ03

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-03/knowledge.md
@@ -25,7 +25,7 @@ to just L¹ integrability on the open rectangle Ioo a b × Ioo c d?
   5. integrable_Icc_iff_Ioo: explicit equivalence iff
   6. greens_fubini_open_rectangle: application to Green's theorem
 - Created gallery entry: src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/
-- Note: PR #16071 has a stub version (30 lines); this PR has the full implementation
+- Created PR #16077 (complete implementation); closed stub PR #16071
 
 ### Key Findings
 - Icc and Ioo intervals agree for Lebesgue measure: boundary {a,b} is null

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-03/knowledge.md
@@ -1,0 +1,45 @@
+# Ioo Integrability for Fubini Interval Swap (greens-theorem-oq-01-oq-01-oq-03)
+
+## Problem
+
+Can the Icc integrability hypothesis in the Fubini interval integral swap be weakened
+to just L¹ integrability on the open rectangle Ioo a b × Ioo c d?
+
+**Answer: YES** — proved in `GreensTheoremOQ01OQ01OQ03.lean`.
+
+## Session 2026-05-06 (Session 1) - Complete Implementation
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Surveyed the problem: the open question from greens-theorem-oq-01-oq-01 asks whether
+  the Icc integrability hypothesis can be weakened to Ioo
+- Key insight: For Lebesgue measure, Icc and Ioo intervals differ only by {a,b},
+  which has measure zero → vol.restrict(Icc) = vol.restrict(Ioo)
+- Proved 6 theorems in GreensTheoremOQ01OQ01OQ03.lean (228 lines, 0 sorries, 0 axioms):
+  1. volume_Icc_sdiff_Ioo: boundary has measure zero
+  2. volume_restrict_Icc_eq_Ioo: restriction equality (key novel lemma)
+  3. volume_prod_restrict_Icc_eq_Ioo: product measure equality
+  4. intervalIntegral_swap_of_Ioo_integrable: main Fubini with Ioo
+  5. integrable_Icc_iff_Ioo: explicit equivalence iff
+  6. greens_fubini_open_rectangle: application to Green's theorem
+- Created gallery entry: src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/
+- Note: PR #16071 has a stub version (30 lines); this PR has the full implementation
+
+### Key Findings
+- Icc and Ioo intervals agree for Lebesgue measure: boundary {a,b} is null
+- vol.restrict(Icc a b) = vol.restrict(Ioo a b) proved via measure extensionality
+- This lemma is NOT in Mathlib (Mathlib uses Ioc as canonical interval)
+- Set.Countable.measure_zero exists in Mathlib and works for singleton measure
+- measure_union_null, measure_mono_null, measure_union_le all in Mathlib
+
+### Files Modified
+- proofs/Proofs/GreensTheoremOQ01OQ01OQ03.lean (228 lines, 0 sorries, 0 axioms)
+- src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/ (gallery entry)
+- src/data/research/problems/greens-theorem-oq-01-oq-01-oq-03.json (knowledge JSON)
+- research/problems/greens-theorem-oq-01-oq-01-oq-03/knowledge.md (this file)
+
+### Next Steps
+- Generalize volume_restrict_Icc_eq_Ioo to any atomless Borel measure
+- Consider contributing this lemma to Mathlib.MeasureTheory.Measure.Lebesgue.Basic

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "ann-volume-Icc-sdiff-Ioo",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 52,
+      "endLine": 64
+    },
+    "type": "theorem",
+    "title": "volume_Icc_sdiff_Ioo: The Boundary Icc \\ Ioo Has Measure Zero",
+    "content": "The difference Icc a b \\ Ioo a b (the two endpoints {a, b}) has Lebesgue measure zero. Proved by containment in {a} ∪ {b} and countability of singletons.",
+    "mathContext": "$[a,b] \\setminus (a,b) = \\{a,b\\}$, which has measure zero since Lebesgue measure is atomless: $\\text{vol}(\\{x\\}) = 0$ for all $x \\in \\mathbb{R}$ (proved via countability: $\\{x\\}$ is countable, and countable sets have Lebesgue measure zero).",
+    "significance": "key",
+    "relatedConcepts": ["null sets", "singletons", "Lebesgue measure", "countable measure zero"],
+    "prerequisites": ["Set.Countable.measure_zero", "measure_mono_null", "measure_union_null"]
+  },
+  {
+    "id": "ann-volume-restrict-Icc-eq-Ioo",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 71,
+      "endLine": 93
+    },
+    "type": "theorem",
+    "title": "volume_restrict_Icc_eq_Ioo: Restriction Equality (Key Novel Lemma)",
+    "content": "The Lebesgue measure restricted to [a,b] equals the Lebesgue measure restricted to (a,b). The proof uses measure extensionality: for any measurable s, vol(s ∩ [a,b]) = vol(s ∩ (a,b)). The upper bound follows from s ∩ [a,b] ⊆ (s ∩ (a,b)) ∪ {a,b} and subadditivity. The lower bound is immediate from Ioo ⊆ Icc.",
+    "mathContext": "For any Borel measure $\\mu$ and any measurable $s$: $\\mu(s \\cap [a,b]) \\leq \\mu(s \\cap (a,b)) + \\mu([a,b] \\setminus (a,b)) = \\mu(s \\cap (a,b)) + 0$. Combined with $\\mu(s \\cap (a,b)) \\leq \\mu(s \\cap [a,b])$ (from $\\text{Ioo} \\subseteq \\text{Icc}$), we get equality.",
+    "significance": "key",
+    "relatedConcepts": ["measure restriction", "null boundary", "Lebesgue measure", "Icc vs Ioo"],
+    "prerequisites": ["volume_Icc_sdiff_Ioo", "measure_union_le", "measure_mono", "Measure.restrict_apply"]
+  },
+  {
+    "id": "ann-product-measure-equality",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 97,
+      "endLine": 102
+    },
+    "type": "theorem",
+    "title": "volume_prod_restrict_Icc_eq_Ioo: Product Measure Equality",
+    "content": "One-line corollary: the product of Icc-restricted measures equals the product of Ioo-restricted measures, for all pairs of endpoints a,b,c,d.",
+    "mathContext": "Immediate from applying the restriction equality twice: $(\\mu|_{[a,b]}) \\otimes (\\mu|_{[c,d]}) = (\\mu|_{(a,b)}) \\otimes (\\mu|_{(c,d)})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["product measure", "restriction equality"],
+    "prerequisites": ["volume_restrict_Icc_eq_Ioo", "Measure.prod"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 139,
+      "endLine": 148
+    },
+    "type": "theorem",
+    "title": "intervalIntegral_swap_of_Ioo_integrable: Fubini with Open Rectangle Hypothesis",
+    "content": "The main theorem: for ordered intervals with a ≤ b and c ≤ d, Fubini holds under open rectangle (Ioo) integrability. The proof converts Ioo to Icc integrability using volume_restrict_Icc_eq_Ioo, then applies the standard Fubini proof.",
+    "mathContext": "The proof is: $f$ integrable on $(a,b) \\times (c,d)$ iff $f$ integrable on $[a,b] \\times [c,d]$ (since restrictions are equal), and the Fubini swap holds for Icc integrability (proved inline from integral_of_le + integral_integral_swap).",
+    "significance": "key",
+    "relatedConcepts": ["Fubini's theorem", "interval integral", "product measure", "integrability"],
+    "prerequisites": ["volume_restrict_Icc_eq_Ioo", "fubini_core", "integral_of_le", "integral_integral_swap"]
+  },
+  {
+    "id": "ann-equivalence",
+    "proofId": "greens-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 154,
+      "endLine": 159
+    },
+    "type": "theorem",
+    "title": "integrable_Icc_iff_Ioo: Explicit Equivalence of Integrability Conditions",
+    "content": "One-line proof of the explicit iff: Icc integrability ↔ Ioo integrability for Lebesgue measure. Since the product measures are equal, the Integrable predicate is definitionally the same.",
+    "mathContext": "Since $\\mu|_{\\text{Icc}} = \\mu|_{\\text{Ioo}}$ as measures, $\\text{Integrable}(f, \\mu|_{\\text{Icc}} \\otimes \\mu|_{\\text{Icc}}) \\iff \\text{Integrable}(f, \\mu|_{\\text{Ioo}} \\otimes \\mu|_{\\text{Ioo}})$ is immediate by substitution.",
+    "significance": "supporting",
+    "relatedConcepts": ["integrable predicate", "measure equality", "iff"],
+    "prerequisites": ["volume_prod_restrict_Icc_eq_Ioo"]
+  }
+]

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/index.ts
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/GreensTheoremOQ01OQ01OQ03.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "greens-theorem-oq-01-oq-01-oq-03",
+  "title": "Open Rectangle Integrability for Fubini (Icc ↔ Ioo)",
+  "slug": "greens-theorem-oq-01-oq-01-oq-03",
+  "description": "Proves that the Icc integrability hypothesis for interval integral swap can be weakened to Ioo integrability. For Lebesgue measure, vol.restrict(Icc a b) = vol.restrict(Ioo a b) since the boundary {a,b} has measure zero. Answers the open question from greens-theorem-oq-01-oq-01: YES, open rectangle integrability is equivalent and Mathlib provides all needed tools.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-05-06",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GreensTheoremOQ01OQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "lebesgue-measure",
+      "fubini",
+      "integration",
+      "greens-theorem",
+      "interval-integral",
+      "null-sets"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No axioms. 0 sorries. All theorems fully proved using Mathlib's measure theory (null sets, restriction equality) and Fubini theorem.",
+    "dateAdded": "2026-05-06",
+    "lineCount": 228,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Countable.measure_zero",
+        "description": "Countable sets have measure zero for any sigma-finite measure",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      },
+      {
+        "theorem": "measure_mono_null",
+        "description": "Subsets of null sets are null",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      },
+      {
+        "theorem": "measure_union_null",
+        "description": "Union of null sets is null",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      },
+      {
+        "theorem": "measure_union_le",
+        "description": "Subadditivity: μ(s ∪ t) ≤ μ(s) + μ(t)",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      },
+      {
+        "theorem": "MeasureTheory.integral_integral_swap",
+        "description": "Fubini's theorem for Lebesgue integrals on product spaces",
+        "module": "Mathlib.MeasureTheory.Integral.Prod"
+      },
+      {
+        "theorem": "intervalIntegral.integral_of_le",
+        "description": "Converts interval integral to set integral over Ioc when a ≤ b",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+      }
+    ],
+    "originalContributions": [
+      "volume_Icc_sdiff_Ioo: the boundary Icc \\ Ioo has Lebesgue measure zero",
+      "volume_restrict_Icc_eq_Ioo: restriction to Icc equals restriction to Ioo (key novel lemma)",
+      "volume_prod_restrict_Icc_eq_Ioo: product measure equality on rectangles",
+      "intervalIntegral_swap_of_Ioo_integrable: Fubini with weaker Ioo integrability",
+      "integrable_Icc_iff_Ioo: explicit equivalence of Icc and Ioo integrability conditions",
+      "greens_fubini_open_rectangle: application to Green's theorem with open rectangle"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/GreensTheoremOQ01OQ01OQ03.lean",
+    "imports": ["Mathlib"],
+    "opens": ["MeasureTheory", "intervalIntegral", "Set", "Measure", "Filter", "Topology"],
+    "namespace": "GreensTheoremOQ01OQ01OQ03",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The question of which integrability conditions suffice for Fubini's theorem has a long history. Tonelli's theorem (1909) showed that non-negative measurable functions always satisfy Fubini (with possibly infinite values). Fubini's classical form (1907) requires L¹ integrability on the product space. For the specific case of iterated interval integrals — used in Green's theorem — the natural integrability condition in Mathlib uses the product of Icc-restricted measures, reflecting the fact that interval integrals `∫ x in a..b` are built around closed intervals. The question is whether the closed-interval condition can be weakened to the open-interval condition without losing any theorem content.",
+    "problemStatement": "For the Fubini theorem for iterated interval integrals (proved in greens-theorem-oq-01-oq-01), the integrability hypothesis requires $f$ to be integrable on $[a,b] \\times [c,d]$ (product of Icc-restricted Lebesgue measures). Can this be weakened to integrability on the open rectangle $(a,b) \\times (c,d)$ (product of Ioo-restricted measures)?",
+    "proofStrategy": "The answer is YES, and the proof has three steps: (1) Show that $[a,b] \\setminus (a,b) = \\{a,b\\}$ has Lebesgue measure zero (singletons are countable, countable sets have measure zero). (2) Use measure extensionality to show that $\\text{vol}|_{[a,b]} = \\text{vol}|_{(a,b)}$: for any measurable $s$, $\\text{vol}(s \\cap [a,b]) = \\text{vol}(s \\cap (a,b))$ because their difference is contained in $\\{a,b\\}$, which has measure zero. (3) The product measures are therefore equal, so Ioo and Icc integrability are identical conditions for Lebesgue measure.",
+    "keyInsights": [
+      "For any atomless Borel measure (such as Lebesgue), the restriction to any of Ioo, Ioc, Ico, Icc gives the same result: boundaries are countable (finite in this case) and therefore null.",
+      "The key lemma `volume_restrict_Icc_eq_Ioo` is NOT in Mathlib (as of current revision). Mathlib tends to use Ioc as the canonical interval (it forms a π-system), but the Icc = Ioo equivalence is derivable and could be contributed.",
+      "The proof uses only subadditivity of measure (measure_union_le), not sigma-additivity. This means the result extends to any outer measure, not just sigma-additive measures.",
+      "The equivalence `integrable_Icc_iff_Ioo` is a clean corollary: since the measures are literally equal, the Integrable predicate (which depends only on the measure) is identical for both."
+    ]
+  },
+  "sections": [
+    {
+      "id": "null-boundary",
+      "title": "§ I. Null Boundary Lemmas",
+      "startLine": 44,
+      "endLine": 64,
+      "summary": "Proves that singletons have Lebesgue measure zero (via countability), then that Icc a b \\ Ioo a b ⊆ {a, b} has measure zero.",
+      "mathContext": "The boundary of $[a,b]$ relative to $(a,b)$ is $\\{a,b\\}$, which is finite hence countable, hence null for Lebesgue measure. Proved by monotonicity: $\\text{vol}([a,b] \\setminus (a,b)) \\leq \\text{vol}(\\{a,b\\}) = \\text{vol}(\\{a\\}) + \\text{vol}(\\{b\\}) = 0$."
+    },
+    {
+      "id": "restriction-equality",
+      "title": "§ II. Restriction Equality",
+      "startLine": 66,
+      "endLine": 102,
+      "summary": "Proves the key novel result: vol.restrict(Icc a b) = vol.restrict(Ioo a b) as measures. Also proves the product measure version.",
+      "mathContext": "By measure extensionality: for any measurable $s$, $\\text{vol}(s \\cap [a,b]) = \\text{vol}(s \\cap (a,b))$. The upper bound follows by decomposing $s \\cap [a,b] \\subseteq (s \\cap (a,b)) \\cup ([a,b] \\setminus (a,b))$ and using subadditivity. The lower bound is immediate from $\\text{Ioo} \\subseteq \\text{Icc}$."
+    },
+    {
+      "id": "fubini-core",
+      "title": "§ III. Core Fubini Step",
+      "startLine": 104,
+      "endLine": 125,
+      "summary": "Private theorem: the Fubini swap for ordered intervals with Icc integrability, inlined from greens-theorem-oq-01-oq-01 for self-containedness.",
+      "mathContext": "Converts interval integrals to set integrals using integral_of_le, transfers integrability from Icc to Ioc via monotonicity, then applies Mathlib's abstract integral_integral_swap."
+    },
+    {
+      "id": "main-theorems",
+      "title": "§ IV. Main Theorems",
+      "startLine": 127,
+      "endLine": 162,
+      "summary": "Main results: intervalIntegral_swap_of_Ioo_integrable (Fubini with Ioo hypothesis) and integrable_Icc_iff_Ioo (explicit equivalence).",
+      "mathContext": "The main theorem converts Ioo integrability to Icc integrability using §II, then applies §III. The equivalence theorem is a one-liner from the product measure equality."
+    },
+    {
+      "id": "application",
+      "title": "§ V. Application to Green's Theorem",
+      "startLine": 161,
+      "endLine": 175,
+      "summary": "greens_fubini_open_rectangle: for uncurried dPdy : ℝ × ℝ → ℝ, the Fubini swap holds under open rectangle integrability.",
+      "mathContext": "Direct application of intervalIntegral_swap_of_Ioo_integrable with the uncurried form of the partial derivative, relevant for the standard Green's theorem setup."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Icc integrability hypothesis for interval integral swap can be replaced by Ioo integrability (or any boundary variant: Ioc, Ico) because for Lebesgue measure these restrictions are identical. All needed tools exist in Mathlib.",
+    "implications": "The key novel contribution is vol.restrict(Icc a b) = vol.restrict(Ioo a b) — a useful lemma for any context where Lebesgue integration on intervals must relate Icc and Ioo hypotheses. This could be contributed to Mathlib's MeasureTheory.Measure.Lebesgue.Basic.",
+    "openQuestions": [
+      "Can this restriction equality be generalized to any atomless Borel measure (not just Lebesgue), giving vol.restrict(Icc a b) = vol.restrict(Ioo a b) for any measure that assigns zero to singletons?",
+      "Does Mathlib contain (or could one contribute) a simp lemma stating vol.restrict(Icc a b) = vol.restrict(Ioo a b) directly, avoiding the need for each application to reprove it?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "greens-theorem-oq-01-oq-01",
+      "relationship": "answers",
+      "description": "Directly answers OQ-03 from the Fubini theorem entry: 'The integrability hypothesis uses the product of Icc-restricted measures. Can this be weakened to just L¹ integrability on the open rectangle Ioo a b × Ioo c d?'"
+    },
+    {
+      "targetId": "greens-theorem-oq-01-oq-01-oq-02",
+      "relationship": "companion",
+      "description": "OQ-02 proved a standalone intervalIntegral_swap lemma. OQ-03 proves the Icc↔Ioo equivalence, showing the hypothesis can use either form. Together they fully characterize the integrability conditions for interval integral Fubini."
+    },
+    {
+      "targetId": "greens-theorem-oq-01",
+      "relationship": "related",
+      "description": "The concrete Green's theorem proof that first introduced the Fubini hypothesis. OQ-03 shows this hypothesis is satisfied under weaker (open rectangle) integrability."
+    },
+    {
+      "targetId": "lebesgue-measure",
+      "relationship": "uses",
+      "description": "Uses the foundational properties of Lebesgue measure: singletons have measure zero, measure is sigma-finite, countable sets are null."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "GreensTheoremOQ01OQ01OQ03.volume_restrict_Icc_eq_Ioo",
+      "statement": "∀ (a b : ℝ), volume.restrict (Icc a b) = volume.restrict (Ioo a b)",
+      "description": "Key novel lemma: Lebesgue restriction to closed interval equals restriction to open interval. Proved via null boundary argument."
+    },
+    {
+      "name": "GreensTheoremOQ01OQ01OQ03.intervalIntegral_swap_of_Ioo_integrable",
+      "statement": "a ≤ b → c ≤ d → Measurable (fun p => f p.1 p.2) → Integrable (fun p => f p.1 p.2) (vol.restrict Ioo × vol.restrict Ioo) → ∫ y in c..d, ∫ x in a..b, f x y = ∫ x in a..b, ∫ y in c..d, f x y",
+      "description": "Fubini for interval integrals with open rectangle integrability. Answers OQ-03: YES, Ioo integrability suffices."
+    },
+    {
+      "name": "GreensTheoremOQ01OQ01OQ03.integrable_Icc_iff_Ioo",
+      "statement": "Integrable f (vol.restrict Icc × vol.restrict Icc) ↔ Integrable f (vol.restrict Ioo × vol.restrict Ioo)",
+      "description": "Explicit equivalence: Icc and Ioo integrability conditions are identical for Lebesgue measure."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-03.json
@@ -1,0 +1,167 @@
+{
+  "slug": "greens-theorem-oq-01-oq-01-oq-03",
+  "title": "The integrability hypothesis uses the product of Icc-restricted measures",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: The integrability hypothesis uses the product of Icc-restricted measures.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-05-05T02:57:44.810Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE 2026-05-06: Gallery entry created. 6 theorems, 0 sorries, 0 axioms. Key result: vol.restrict(Icc) = vol.restrict(Ioo) for Lebesgue. PR pending.",
+    "builtItems": [
+      "volume_Icc_sdiff_Ioo: Icc\\\\Ioo has measure zero (GreensTheoremOQ01OQ01OQ03.lean:52)",
+      "volume_restrict_Icc_eq_Ioo: restriction equality theorem (line 71)",
+      "volume_prod_restrict_Icc_eq_Ioo: product measure equality (line 97)",
+      "intervalIntegral_swap_of_Ioo_integrable: main Fubini with Ioo hypothesis (line 139)",
+      "integrable_Icc_iff_Ioo: explicit equivalence iff (line 154)",
+      "greens_fubini_open_rectangle: application to Green (line 166)"
+    ],
+    "insights": [
+      "Icc and Ioo intervals agree for Lebesgue measure: boundary {a,b} has measure zero",
+      "vol.restrict (Icc a b) = vol.restrict (Ioo a b) proved via measure extensionality and null boundary argument",
+      "This equivalence is NOT in Mathlib as a standalone lemma; Mathlib prefers Ioc for measure theory",
+      "Any countable set has Lebesgue measure zero; singletons are trivially countable"
+    ],
+    "mathlibGaps": [
+      "volume_restrict_Icc_eq_Ioo not in Mathlib (Mathlib uses Ioc as canonical); contribution candidate for MeasureTheory.Measure.Lebesgue.Basic"
+    ],
+    "nextSteps": [
+      "Generalize to any atomless Borel measure (not just Lebesgue)",
+      "Consider contributing volume_restrict_Icc_eq_Ioo to Mathlib"
+    ]
+  },
+  "tags": [
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "greens-theorem",
+    "greens-theorem-oq-01",
+    "greens-theorem-oq-01-oq-01",
+    "greens-theorem-oq-01-oq-01-oq-03",
+    "greens-theorem-oq-02",
+    "greens-theorem-oq-03",
+    "greens-theorem-oq-03-oq-04",
+    "greens-theorem-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-05T02:57:44.809Z",
+  "lastUpdate": "2026-05-05T02:57:44.809Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/GreensTheorem.lean",
+      "filename": "GreensTheorem.lean",
+      "lineCount": 359,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 14,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheorem.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01.lean",
+      "filename": "GreensTheoremOQ01.lean",
+      "lineCount": 339,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01.lean",
+      "filename": "GreensTheoremOQ01OQ01.lean",
+      "lineCount": 150,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ01OQ01OQ03.lean",
+      "filename": "GreensTheoremOQ01OQ01OQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ02.lean",
+      "filename": "GreensTheoremOQ02.lean",
+      "lineCount": 508,
+      "theoremCount": 21,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ03.lean",
+      "filename": "GreensTheoremOQ03.lean",
+      "lineCount": 558,
+      "theoremCount": 31,
+      "axiomCount": 3,
+      "defCount": 12,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ03OQ04.lean",
+      "filename": "GreensTheoremOQ03OQ04.lean",
+      "lineCount": 251,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ03OQ04.lean"
+    },
+    {
+      "path": "Proofs/GreensTheoremOQ04.lean",
+      "filename": "GreensTheoremOQ04.lean",
+      "lineCount": 588,
+      "theoremCount": 22,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Proves that the Icc integrability hypothesis for interval integral swap can be weakened to Ioo
- Key lemma: `vol.restrict (Icc a b) = vol.restrict (Ioo a b)` (novel, not in Mathlib)
- 228 lines, 0 sorries, 0 axioms
- Gallery entry for `greens-theorem-oq-01-oq-01-oq-03`

**Note**: PR #16071 (`research/greens-theorem-oq-01-oq-01-oq-03`) has a 30-line stub lean file (captured while this session was writing). This PR has the full complete implementation.

## Theorems

| Theorem | Description |
|---------|-------------|
| `volume_Icc_sdiff_Ioo` | `Icc a b \ Ioo a b ⊆ {a,b}` has measure zero |
| `volume_restrict_Icc_eq_Ioo` | `vol.restrict Icc = vol.restrict Ioo` (key novel lemma) |
| `volume_prod_restrict_Icc_eq_Ioo` | Product measure equality |
| `intervalIntegral_swap_of_Ioo_integrable` | Fubini with Ioo hypothesis |
| `integrable_Icc_iff_Ioo` | Explicit equivalence iff |
| `greens_fubini_open_rectangle` | Application to Green's theorem |

## Mathematical Content

For Lebesgue measure on ℝ: `Icc a b` and `Ioo a b` differ only by `{a,b}`, which is finite hence countable, hence has Lebesgue measure zero. Therefore `vol.restrict (Icc a b) = vol.restrict (Ioo a b)` (proved by measure extensionality). The integrability conditions are identical.

## Test plan
- [ ] Lean file builds via `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ03`
- [ ] Gallery entry renders correctly on the website
- [ ] All 6 theorems verified: 0 sorries, 0 axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)