### PR TITLE
enrich(elementary-quadratic-reciprocity-oq-01-oq-01-oq-02): 6 annotations, 7 sections, deep overview

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-setup",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "context",
+    "title": "Setup: Four-Step Gauss Sum QR Pathway",
+    "content": "The header establishes where this file fits in the Gauss sum QR proof:\n- Step 1: Define τ = gaussSum χ ψ\n- Step 2: τ² = χ(-1)·p [proved in OQ01OQ01OQ01.lean]\n- Step 3: τ^q = χ(q)·τ [THIS FILE]\n- Step 4: Comparing τ^q two ways gives QR\n\nThe imports are specific: `GaussSum`, `LegendreSymbol.Basic`, `QuadraticChar.Basic`. The `variable {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]` makes p, q implicit primes threaded through all instances.",
+    "mathContext": "$\\tau = \\mathrm{gaussSum}(\\chi, \\psi) = \\sum_{a \\in \\mathbb{Z}/p\\mathbb{Z}} \\chi(a)\\psi(a)$, where $\\chi$ is quadratic (Legendre symbol) and $\\psi$ additive.",
+    "significance": "context",
+    "relatedConcepts": ["Gauss sum definition", "four-step QR proof", "Fact typeclass", "MulChar and AddChar"],
+    "prerequisites": ["Gauss sum", "Legendre symbol", "multiplicative and additive characters"]
+  },
+  {
+    "id": "ann-q-unit",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 68 },
+    "type": "technique",
+    "title": "Auxiliary: Invertibility of q mod p",
+    "content": "The private lemma `q_isUnit_in_ZMod_p` establishes IsUnit(q : ZMod p) for distinct primes p ≠ q.\n\nProof: `ZMod.isUnit_prime_iff_not_dvd` gives IsUnit(q : ZMod p) ↔ ¬(q ∣ p). Since p is prime, q ∣ p implies q = 1 or q = p — both contradicted by `hq.out.one_lt` and `hpq`.",
+    "mathContext": "$\\gcd(p, q) = 1$ for distinct primes, so $q \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod.isUnit_prime_iff_not_dvd", "prime divisibility", "units in ZMod p"],
+    "prerequisites": ["prime numbers", "units in ZMod n"]
+  },
+  {
+    "id": "ann-frobenius",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
+    "range": { "startLine": 69, "endLine": 95 },
+    "type": "key",
+    "title": "The Frobenius Step: τ^q = χ(q)·τ",
+    "content": "The central theorem — one line: `hχ.gaussSum_frob q (q_isUnit_in_ZMod_p hpq) ψ`.\n\nMathematical content:\n1. **Freshman's dream**: (Σ χ(a)ψ(a))^q = Σ (χ(a)ψ(a))^q = Σ χ(a)^q ψ(a)^q (ring hom in char q)\n2. **χ^q = χ**: χ(a) ∈ {0,±1}, and (-1)^q = -1 in char q, so χ(a)^q = χ(a)\n3. **ψ(a)^q = ψ(qa)**: additive character identity\n4. **Reparametrize**: Σ_a χ(a)ψ(qa) = χ(q)·Σ_b χ(b)ψ(b) (substitute b=qa, bijection since q is a unit)\n\nResult: τ^q = χ(q)·τ.",
+    "mathContext": "$\\tau^q = \\sum_a \\chi(a)^q \\psi(a)^q \\underbrace{=}_{\\chi^q=\\chi} \\sum_a \\chi(a)\\psi(qa) \\underbrace{=}_{b=qa} \\chi(q)\\sum_b \\chi(b)\\psi(b) = \\chi(q)\\cdot\\tau.$",
+    "significance": "key",
+    "relatedConcepts": ["Frobenius endomorphism", "MulChar.IsQuadratic.gaussSum_frob", "freshman's dream", "reparametrization bijection"],
+    "prerequisites": ["Frobenius endomorphism in char p", "quadratic characters", "additive characters"]
+  },
+  {
+    "id": "ann-combining",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
+    "range": { "startLine": 96, "endLine": 125 },
+    "type": "technique",
+    "title": "Combining Steps 2 and 3: Key QR Identity",
+    "content": "Theorem `qr_via_frobenius` takes the hypothesis `hτ_sq : gaussSum χ ψ ^ 2 = χ (-1) * Fintype.card (ZMod p)` (Step 2) and derives (χ(-1)·p)^{(q-1)/2} = χ(q).\n\nArgument:\n- τ^q = τ·(τ²)^{(q-1)/2} = τ·(χ(-1)·p)^{(q-1)/2} (exponent arithmetic + hypothesis)\n- τ^q = χ(q)·τ (Frobenius step)\n- Equating: (χ(-1)·p)^{(q-1)/2} = χ(q)\n\nLean uses `Char.card_pow_char_pow`. The `simpa [pow_one]` handles the n=1 special case.",
+    "mathContext": "$\\tau^q = \\tau \\cdot (\\tau^2)^{(q-1)/2} = \\tau \\cdot (\\chi(-1)\\cdot p)^{(q-1)/2}$; with $\\tau^q = \\chi(q)\\cdot\\tau$: $(\\chi(-1)\\cdot p)^{(q-1)/2} = \\chi(q)$.",
+    "significance": "key",
+    "relatedConcepts": ["Char.card_pow_char_pow", "Fintype.card ZMod p", "exponent arithmetic"],
+    "prerequisites": ["Gauss sum squared identity", "exponent arithmetic", "Fintype.card"]
+  },
+  {
+    "id": "ann-qr-identity",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
+    "range": { "startLine": 126, "endLine": 155 },
+    "type": "insight",
+    "title": "QR Identity in ZMod q: Encoding QR via Euler's Criterion",
+    "content": "The main theorem `qr_gauss_sums_identity`: for distinct odd primes p ≠ q and nontrivial quadratic χ,\n\n    (χ(-1) · Fintype.card (ZMod p))^(Fintype.card (ZMod q) / 2) = χ(Fintype.card (ZMod q))\n\nUsing Fintype.card (ZMod n) = n, this reads (χ(-1)·p)^{(q-1)/2} = χ(q) in ZMod q.\n\n**This is QR**: Euler's criterion gives a^{(q-1)/2} ≡ (a/q) mod q. With χ(-1) = (-1/p) = (-1)^{(p-1)/2} and p^{(q-1)/2} ≡ (p/q): the left side is (-1/p)·(p/q); the right is (q/p). So (p/q)(q/p) = (-1)^{((p-1)/2)·((q-1)/2)} — QR.\n\nProved via `Char.card_pow_card` with `rw [ZMod.ringChar_zmod_n]` to handle coercions.",
+    "mathContext": "QR: $(p/q)(q/p) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$.\n\nEquivalently: $(\\chi(-1)\\cdot p)^{(q-1)/2} = \\chi(q)$ in $\\mathbb{Z}/q\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["Char.card_pow_card", "Euler's criterion", "Legendre symbol", "ZMod.ringChar_zmod_n", "quadratic reciprocity"],
+    "prerequisites": ["Euler's criterion", "Legendre symbol", "QR statement"]
+  },
+  {
+    "id": "ann-pathway",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
+    "range": { "startLine": 156, "endLine": 175 },
+    "type": "insight",
+    "title": "Part IV-V: Complete Pathway and Concrete Verifications",
+    "content": "**gauss_qr_pathway_complete**: Existential summary ∃ result = χ(q) = (χ(-1)·p)^{(q-1)/2}. The `⟨_, symm, rfl⟩` proof documents the connection.\n\n**Three concrete examples**:\n- (p=5,q=3): In char 3, (gaussSum χ₅ ψ)³ = χ₅(3)·(gaussSum χ₅ ψ)\n- (p=7,q=5): In char 5, similar\n- (p=11,q=7): QR identity (χ₁₁(-1)·11)³ = χ₁₁(7) in ZMod 7\n\nAll proved by `frobenius_step/qr_gauss_sums_identity χ ... (by norm_num)`.\n\nThe docstring for p=11,q=7 computes: 11 ≡ 4 mod 7 → (11/7)=1; (-1/11)=-1 (since 11≡3 mod 4); QR: (11/7)(7/11) = (-1)^{5·3} = -1 ✓.",
+    "mathContext": "QR for small primes: $(3/5)(5/3) = 1 = (-1)^{1\\cdot 1}$; $(5/7)(7/5) = 1 = (-1)^{3\\cdot 2}$; $(7/11)(11/7) = -1 = (-1)^{5\\cdot 3}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete QR verifications", "norm_num for prime bounds", "existential witness"],
+    "prerequisites": ["QR for small primes", "Legendre symbol values"]
+  }
+]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -55,41 +55,88 @@
   },
   "sections": [
     {
-      "title": "Frobenius Step Setup",
-      "content": "Establishes q_isUnit_in_ZMod_p: for distinct primes p ≠ q, the element q in ZMod p is invertible. Uses ZMod.isUnit_prime_iff_not_dvd: IsUnit(q : ZMod p) ↔ ¬q ∣ p. Since p is prime, q ∣ p implies q = 1 or q = p, both contradicting our assumptions.",
-      "leanRef": "ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean:59-68"
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Header comment with the full Frobenius argument derivation and key Mathlib theorems. Sets up namespace FrobeniusStepQR with primes p, q as implicit Fact instances.",
+      "mathContext": "Setting: $p, q$ distinct odd primes; $\\chi: \\mathbb{Z}/p\\mathbb{Z} \\to F$ quadratic character; $\\psi: \\mathbb{Z}/p\\mathbb{Z} \\to F$ additive character; $\\tau = \\mathrm{gaussSum}(\\chi, \\psi)$."
     },
     {
-      "title": "The Frobenius Step (Main Theorem)",
-      "content": "Proves frobenius_step: in a field F of characteristic q, (gaussSum χ ψ)^q = χ(q) · gaussSum χ ψ for any quadratic χ and additive ψ. The argument: Frobenius endomorphism in char q gives (Σ χ(a)ψ(a))^q = Σ χ(a)^q ψ(a)^q = Σ χ(a)ψ(qa); reparametrizing b = qa yields χ(q)·τ. Lean proof is one line: MulChar.IsQuadratic.gaussSum_frob.",
-      "leanRef": "ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean:83-87"
+      "id": "q-unit-auxiliary",
+      "title": "Auxiliary: q is a Unit in ZMod p",
+      "startLine": 53,
+      "endLine": 68,
+      "summary": "Private lemma q_isUnit_in_ZMod_p: for distinct primes p ≠ q, q is invertible in ZMod p. Uses ZMod.isUnit_prime_iff_not_dvd.",
+      "mathContext": "$\\gcd(p,q) = 1$ for distinct primes, so $q \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times$."
     },
     {
-      "title": "Combining Steps 2 and 3",
-      "content": "Proves qr_via_frobenius: given τ² = χ(-1)·p (Step 2), derive (χ(-1)·p)^{(q-1)/2} = χ(q) in F. The derivation: τ^q = τ · (τ²)^{(q-1)/2} = τ · (χ(-1)·p)^{(q-1)/2}. Equating with Frobenius step and dividing by τ ≠ 0 gives the identity. Uses Mathlib’s Char.card_pow_char_pow.",
-      "leanRef": "ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean:106-113"
+      "id": "frobenius-step",
+      "title": "Part I: The Frobenius Step — τ^q = χ(q)·τ",
+      "startLine": 69,
+      "endLine": 95,
+      "summary": "Main theorem frobenius_step: in any field of characteristic q, (gaussSum χ ψ)^q = χ(q)·gaussSum χ ψ. One-line proof via gaussSum_frob.",
+      "mathContext": "$\\tau^q = \\sum_a \\chi(a)^q \\psi(a)^q = \\sum_a \\chi(a)\\psi(qa) = \\chi(q)\\cdot\\tau$ (Frobenius + reparametrize $b=qa$)."
     },
     {
-      "title": "Full QR Identity in ZMod q",
-      "content": "Proves qr_gauss_sums_identity: for distinct odd primes p ≠ q and nontrivial quadratic χ : ZMod p → ZMod q, we have (χ(-1) · p)^{(q-1)/2} = χ(q). By Euler’s criterion: p^{(q-1)/2} ≡ (p/q) (mod q) and χ(-1) = (-1/p). So this gives (-1)^{((p-1)/2)·((q-1)/2)} · (p/q) = (q/p), i.e., the Law of Quadratic Reciprocity.",
-      "leanRef": "ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean:132-141"
+      "id": "combining-steps",
+      "title": "Part II: Combining Steps 2 and 3",
+      "startLine": 96,
+      "endLine": 125,
+      "summary": "Theorem qr_via_frobenius: given τ²=χ(-1)·p, derives (χ(-1)·p)^{(q-1)/2}=χ(q) via Char.card_pow_char_pow.",
+      "mathContext": "$\\tau^q = \\tau(\\tau^2)^{(q-1)/2} = \\tau(\\chi(-1)\\cdot p)^{(q-1)/2}$; equate with $\\chi(q)\\cdot\\tau$."
+    },
+    {
+      "id": "qr-identity",
+      "title": "Part III: Full QR Identity in ZMod q",
+      "startLine": 126,
+      "endLine": 155,
+      "summary": "Theorem qr_gauss_sums_identity: (χ(-1)·p)^{(q-1)/2}=χ(q) in ZMod q. Encodes QR via Euler’s criterion.",
+      "mathContext": "$(-1/p)\\cdot(p/q) = (q/p)$ in $\\mathbb{Z}/q\\mathbb{Z}$: the Law of Quadratic Reciprocity."
+    },
+    {
+      "id": "pathway-summary",
+      "title": "Part IV: Complete Gauss Sum QR Pathway",
+      "startLine": 156,
+      "endLine": 175,
+      "summary": "Existential theorem gauss_qr_pathway_complete combining all four steps as a summary.",
+      "mathContext": "All four steps: (1) $\\tau$; (2) $\\tau^2 = \\chi(-1)\\cdot p$; (3) $\\tau^q = \\chi(q)\\tau$; (4) QR identity."
+    },
+    {
+      "id": "concrete-examples",
+      "title": "Part V: Concrete Verifications",
+      "startLine": 176,
+      "endLine": 216,
+      "summary": "Three examples for (p=5,q=3), (p=7,q=5), (p=11,q=7). All by norm_num + general theorems.",
+      "mathContext": "For $p=11, q=7$: $(11/7)(7/11) = (-1)^{5\\cdot 3} = -1$ ✓."
     }
   ],
   "overview": {
-    "summary": "Formalizes the Frobenius step τ^q = χ(q)·τ (Step 3 of the Gauss sum QR pathway) and connects it to the full Law of Quadratic Reciprocity. Completes the step explicitly cited as future work in OQ01OQ01OQ01.",
-    "difficulty": "intermediate",
+    "historicalContext": "The Law of Quadratic Reciprocity was conjectured by Euler (1744) and first proved by Gauss at age 18 (1796). Gauss found six distinct proofs over his lifetime. The seventh proof — using Gauss sums — was sketched by Gauss and completed by Eisenstein in 1844. The key step is τ^q = (q/p)·τ, which follows from the Frobenius automorphism in characteristic q. Mathlib’s algebraic formalization makes this generalization from ℂ to any char-q field explicit.",
+    "problemStatement": "**Open Question**: Formalize Step 3 of the Gauss sum QR proof: τ^q = χ(q)·τ in any field F of characteristic q, and derive the full QR identity. **Answer**: YES — `MulChar.IsQuadratic.gaussSum_frob` proves Step 3; `Char.card_pow_card` assembles QR. 0 sorries, 0 axioms.",
+    "proofStrategy": "**Auxiliary**: q_isUnit_in_ZMod_p (q invertible mod p, needed for reparametrization). **Part I** (frobenius_step): Frobenius φ: x↦x^q is a ring hom in char q; τ^q = Σ_a χ(a)ψ(qa) = χ(q)·τ (reparametrize b=qa). **Part II**: Combine with τ²=χ(-1)·p via Char.card_pow_char_pow. **Part III**: Full QR in ZMod q via Char.card_pow_card.",
+    "keyInsights": [
+      "**Frobenius as ring homomorphism**: In characteristic q, x↦x^q distributes over addition (freshman’s dream: all C(q,k) for 0<k<q are divisible by q), making φ a ring homomorphism.",
+      "**χ^q = χ in char q**: Since χ(a) ∈ {0,±1} and (-1)^q = -1 in char q, χ(a)^q = χ(a) — quadratic characters are fixed by Frobenius.",
+      "**Reparametrization by q is a bijection**: b=qa is a bijection on ZMod p (q a unit mod p), allowing Σ_a χ(a)ψ(qa) = χ(q)·Σ_b χ(b)ψ(b) by change of variables.",
+      "**Euler’s criterion encodes QR**: The identity (χ(-1)·p)^{(q-1)/2} = χ(q) in ZMod q encodes (-1/p)·(p/q) = (q/p), i.e., QR, via Euler’s criterion a^{(q-1)/2} ≡ (a/q) mod q.",
+      "**Algebraic generality**: The classical proof uses ψ(a) = e^{2πia/p} in ℂ. Mathlib’s MulChar/AddChar typeclasses generalize to any field F of characteristic q — the same argument works with no changes."
+    ],
     "prerequisites": [
-      "Multiplicative characters (MulChar)",
-      "Additive characters (AddChar)",
+      "Multiplicative characters (MulChar): ZMod p → F, Legendre symbol as algebra",
+      "Additive characters (AddChar): ZMod p → F, exponential character",
       "Frobenius endomorphism in characteristic p",
-      "Gauss sum squared identity (OQ01OQ01OQ01)"
+      "Gauss sum squared identity τ²=χ(-1)·p (from OQ01OQ01OQ01)",
+      "Euler’s criterion: a^{(p-1)/2} ≡ (a/p) mod p"
     ]
   },
   "conclusion": {
-    "summary": "YES — the Frobenius step τ^q = χ(q)·τ is fully formalized in Lean 4. Mathlib’s gaussSum_frob directly proves the step, and Char.card_pow_card derives the full QR identity. Together with OQ01OQ01OQ01 (τ² = χ(-1)·p), all four steps of the Gauss sum QR pathway are now formalized.",
+    "summary": "The Frobenius step τ^q = χ(q)·τ is fully formalized. Mathlib’s gaussSum_frob proves it directly, and Char.card_pow_card assembles the full QR identity in ZMod q. With OQ01OQ01OQ01 (τ²=χ(-1)·p), all four steps of the Gauss sum QR pathway are formalized with 0 sorries and 0 axioms.",
+    "implications": "Mathlib’s algebraic character theory is mature enough for the complete Gauss sum proof of QR. The algebraic Frobenius step generalizes to higher reciprocity laws: for cubic characters, τ^q = J(χ,χ)·τ where J is a Jacobi sum. This opens the path toward formalizing cubic and quartic reciprocity.",
     "openQuestions": [
-      "Can the four steps be assembled into a single self-contained Lean proof of QR?",
-      "Can this approach extend to higher-power reciprocity (cubic, quartic) using Jacobi sums?"
+      "Can the four steps be assembled into a single self-contained proof of the Law of Quadratic Reciprocity without referencing OQ01OQ01OQ01?",
+      "Extend to cubic reciprocity: formalize τ^q = J(χ,χ)·τ for cubic characters using Jacobi sums",
+      "Can the Gauss sum approach yield QR for function fields 𝔽_q[t]?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Enrichment: elementary-quadratic-reciprocity-oq-01-oq-01-oq-02

First-pass enrichment for the Frobenius step in the Gauss sum QR proof.

### Quality gaps addressed

**Empty annotations.json** → 6 annotations:
1. `ann-setup`: four-step QR pathway context, imports
2. `ann-q-unit`: auxiliary invertibility lemma
3. `ann-frobenius`: main Frobenius step theorem — freshman's dream, χ^q=χ, reparametrization
4. `ann-combining`: combining Steps 2 and 3 via Char.card_pow_char_pow
5. `ann-qr-identity`: full QR in ZMod q — Euler's criterion, encoding QR
6. `ann-pathway`: complete pathway summary + concrete (p=5,q=3), (p=7,q=5), (p=11,q=7) examples

**Non-standard sections** → standard format (7 sections, id/startLine/endLine/summary/mathContext)

**Missing overview depth** → added historicalContext (Gauss 1796, Eisenstein 1844), proofStrategy, 5 keyInsights

**Incomplete conclusion** → added implications (higher reciprocity), expanded to 3 openQuestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)