### PR TITLE
enrich(erdos-1036-oq-01): add 6 annotations, conclusion, 5th keyInsight, crossRefs

### DIFF
--- a/src/data/proofs/erdos-1036-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1036-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "erdos-1036-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "The ISC Distinction: Labeled vs Unlabeled Induced Subgraphs",
+    "content": "The header establishes why this file is needed: the parent `Erdos1036Problem.lean` uses a placeholder `numInducedSubgraphClasses G = 2^n` (counting ALL vertex subsets, not isomorphism classes). This makes the optimal constant c' = 1 trivially for any graph.\n\nThe correct question counts **isomorphism classes**: S ~ T iff G.induce(S) ≅g G.induce(T). The true count numISCTrue G satisfies 1 ≤ numISCTrue G ≤ 2^n. The imports set up all prerequisites: `SimpleGraph.Basic`, `Clique` (for cliqueFree), and real analysis for logarithmic bounds.",
+    "mathContext": "Labeled: $\\#\\{S \\subseteq V\\} = 2^n$. Unlabeled (ISC): $|\\{S \\subseteq V\\}| / {\\cong}|$ where $S \\sim T \\Leftrightarrow G[S] \\cong G[T]$.",
+    "significance": "key",
+    "relatedConcepts": ["graph isomorphism quotient", "labeled vs unlabeled counting", "Shelah's theorem 1998"],
+    "prerequisites": ["graph isomorphism", "induced subgraphs", "Ramsey theory"]
+  },
+  {
+    "id": "ann-isc-interface",
+    "proofId": "erdos-1036-oq-01",
+    "range": { "startLine": 42, "endLine": 62 },
+    "type": "technique",
+    "title": "Axiomatizing numISCTrue: Three Properties Without Full Quotient",
+    "content": "Rather than constructing the Quotient type (~200 lines), three axioms capture what's needed:\n\n**numISCTrue**: The function exists (maps SimpleGraph V → ℕ). Full construction: Fintype.card(Quotient ≈) where S ≈ T ↔ G.induce S ≅g G.induce T.\n\n**numISCTrue_le_pow**: numISCTrue G ≤ 2^n (ISC classes ≤ vertex subsets).\n\n**numISCTrue_pos**: numISCTrue G > 0 (∅ gives one ISC class).\n\nThese are 'trivially true' axioms (not genuine assumptions) that could be eliminated with a Fintype quotient construction.",
+    "mathContext": "$\\mathrm{numISCTrue}(G) = |\\{S \\subseteq V\\}/\\sim|$, where $\\sim$ is graph isomorphism equivalence. Requires Setoid + Fintype on quotient.",
+    "significance": "supporting",
+    "relatedConcepts": ["Quotient type in Lean 4", "Fintype on quotient", "axiom interface pattern"],
+    "prerequisites": ["quotient types", "Fintype instances", "graph isomorphism (≅g)"]
+  },
+  {
+    "id": "ann-non-ramsey",
+    "proofId": "erdos-1036-oq-01",
+    "range": { "startLine": 63, "endLine": 90 },
+    "type": "concept",
+    "title": "Non-Ramsey Graphs and Shelah's Theorem",
+    "content": "**IsNonRamsey**: Both G and G^c are clique-free of size ⌈c·log n⌉. Non-Ramsey(c) graphs have no clique or independent set of size c·log n.\n\n**nonRamseyExistsTrue**: Axiom — non-Ramsey(c) graphs exist on all large vertex sets. Witness: G(n,1/2) for c < 2/log 2 (both ω(G) and α(G) are ~ 2log₂n a.s.).\n\n**shelah_isc**: Axiom — for c > 0, ∃ c' > 0 such that every non-Ramsey(c) graph has ≥ 2^{c'n} ISC classes. This is Shelah's 1998 theorem — the mathematical content.",
+    "mathContext": "Non-Ramsey$(c)$: $\\omega(G), \\alpha(G) \\leq c\\log n$ (no large clique or independent set). Random graph $G(n,1/2)$ satisfies this for $c < 2/\\log 2 \\approx 2.885$.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey numbers R(k,k)", "clique and independence numbers", "Shelah 1998", "random graph G(n,1/2)"],
+    "prerequisites": ["Ramsey theory", "clique-free graphs", "SimpleGraph complement"]
+  },
+  {
+    "id": "ann-optimal-def",
+    "proofId": "erdos-1036-oq-01",
+    "range": { "startLine": 91, "endLine": 120 },
+    "type": "technique",
+    "title": "Optimal Constant as Supremum + Auxiliary Setup",
+    "content": "**optimalConstantTrue c = sSup { c' | ∀ G non-Ramsey(c): numISCTrue G ≥ 2^{c'n} }** — the optimal exponent as a conditionally complete lattice supremum.\n\n**optimalSet_nonempty**: c' = 0 ∈ S since 2^0 = 1 ≤ numISCTrue (by numISCTrue_pos).\n\n**optimalSet_le_one**: Every c' ∈ S satisfies c' ≤ 1. Proof by contradiction: if c' > 1, get G with n≥1 vertices and numISCTrue G ≥ 2^{c'n} > 2^n ≥ numISCTrue G — contradiction via `Real.rpow_lt_rpow_of_exponent_lt`.",
+    "mathContext": "$\\mathrm{optimalConstantTrue}(c) = \\sup\\{c' \\mid \\forall G$ non-Ramsey$(c)$: $\\mathrm{numISCTrue}(G) \\geq 2^{c'n}\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sSup / csSup", "Real.rpow_lt_rpow_of_exponent_lt", "proof by contradiction"],
+    "prerequisites": ["conditionally complete lattice", "real power function"]
+  },
+  {
+    "id": "ann-bounds",
+    "proofId": "erdos-1036-oq-01",
+    "range": { "startLine": 121, "endLine": 142 },
+    "type": "insight",
+    "title": "c'(c) ∈ (0,1]: Two-Sided Bound via csSup API",
+    "content": "Three theorems:\n\n**optimalConstantTrue_le_one**: `csSup_le ⟨0, nonempty⟩ bound_fn` — sSup ≤ 1.\n\n**optimalConstantTrue_pos**: From shelah_isc get c'' > 0. Show c'' ∈ S. Use `le_csSup ⟨1,bound⟩ hmem` to get c'' ≤ sSup. Chain: 0 < c'' ≤ optimalConstantTrue.\n\n**optimalConstantTrue_bounds**: Conjunction ⟨pos, le_one⟩.",
+    "mathContext": "csSup API: $s \\in S \\Rightarrow s \\leq \\mathrm{sSup}\\, S$ (le_csSup), $\\mathrm{sSup}\\, S \\leq b$ when all elements $\\leq b$ (csSup_le). Conclusion: $c'(c) \\in (0, 1]$.",
+    "significance": "key",
+    "relatedConcepts": ["csSup_le", "le_csSup", "optimalConstantTrue_pos via Shelah"],
+    "prerequisites": ["conditional supremum theory", "csSup/csInf Mathlib API"]
+  },
+  {
+    "id": "ann-conjecture",
+    "proofId": "erdos-1036-oq-01",
+    "range": { "startLine": 143, "endLine": 175 },
+    "type": "insight",
+    "title": "The Open Conjecture c'(c) = 1 and the Random Graph Witness",
+    "content": "**optimalConstantTrue_eq_one**: Axiom — ∀ c > 0, optimalConstantTrue c = 1. This is the genuine open conjecture.\n\n**Mathematical witness**: G(n,1/2) is non-Ramsey(c) for c < 2/log 2, AND has numISCTrue G = 2^n a.s. (almost all vertex subsets give non-isomorphic induced subgraphs — related to graph reconstruction). This would put c' = 1 in the set and prove the conjecture.\n\n**optimalConstantTrue_random**: Corollary at c = 2/log 2.\n\nThe summary comment accounts for all 6 axioms: 3 'trivially true' (ISC interface), 2 from parent (Shelah), 1 genuine conjecture.",
+    "mathContext": "Conjecture: $c'(c) = 1$, i.e., non-Ramsey graphs achieve maximal ISC diversity $\\sim 2^n$. Witness: $G(n,1/2)$ has $\\mathrm{numISCTrue}(G(n,1/2)) = 2^n$ a.s.",
+    "significance": "key",
+    "relatedConcepts": ["random graph G(n,1/2)", "graph reconstruction conjecture", "optimal constants in extremal graph theory"],
+    "prerequisites": ["random graph theory", "probabilistic method", "ISC count for random graphs"]
+  }
+]

--- a/src/data/proofs/erdos-1036-oq-01/meta.json
+++ b/src/data/proofs/erdos-1036-oq-01/meta.json
@@ -60,7 +60,8 @@
       "**Two ISC notions**: labeled (all 2^n subsets) vs. unlabeled (isomorphism classes ≤ 2^n). The parent uses labeled (trivial). The correct question uses unlabeled.",
       "**Upper bound is tight**: The random graph G(n,1/2) achieves numISCTrue ≈ 2^n, showing c' = 1 is the best possible upper bound.",
       "**Shelah vs. optimal**: Shelah gives SOME c' > 0 (possibly small). The OQ asks whether the optimal c' = 1 (largest possible).",
-      "**Quotient complexity**: Formalizing numISCTrue requires `Quotient` with a `Setoid` on induced subgraph pairs, plus a `Fintype` instance on the quotient — about 200 lines to eliminate axioms 1-3."
+      "**Quotient complexity**: Formalizing numISCTrue requires `Quotient` with a `Setoid` on induced subgraph pairs, plus a `Fintype` instance on the quotient — about 200 lines to eliminate axioms 1-3.",
+      "**Connection to Erdős-Hajnal**: The Erdős-Hajnal conjecture says graphs with forbidden induced subgraph H have polynomial clique/independent sets. Non-Ramsey(c) graphs lack such structure — c'(c)=1 would say they are 'maximally pseudorandom' despite their Ramsey constraints."
     ],
     "prerequisites": [
       "Shelah's theorem (Erdos1036Problem.lean, axiom shelah_1998)",
@@ -95,20 +96,19 @@
       "mathContext": "This asserts that non-Ramsey graphs are 'pseudorandom' enough to maximize ISC diversity. Random graphs G(n,1/2) are the witness: they are non-Ramsey and achieve 2^n ISC classes a.s."
     }
   ],
-  "openQuestions": [
+  "conclusion": {
+    "summary": "Proves c'(c) ∈ (0,1] for the optimal constant in Shelah's theorem. The machine-checked bounds use 5 axioms for the ISC interface and Shelah's theorem; the conjecture c'(c)=1 is the 6th axiom — the genuine open problem.",
+    "implications": "The conjecture c'(c)=1 would establish that non-Ramsey graphs are 'maximally diverse' in induced subgraph structure, matching random graphs. This connects Ramsey theory to extremal combinatorics. Eliminating the three interface axioms with a Quotient construction would demonstrate a reusable Lean 4 technique for counting isomorphism classes.",
+    "openQuestions": [
+      "Eliminate numISCTrue axioms via Quotient construction: Setoid on induced subgraph pairs, Fintype instance on quotient, cardinality ≤ 2^n",
+      "Prove G(n,1/2) is non-Ramsey and achieves numISCTrue=2^n a.s., eliminating the conjecture axiom",
+      "Is c'(c) monotone in c? Does the conjecture hold for all c>0 or only for specific ranges?"
+    ]
+  },
+  "crossReferences": [
     {
-      "id": "oq-01",
-      "title": "Eliminate numISCTrue axioms via Quotient construction",
-      "description": "Replace axioms 1-3 (numISCTrue interface) with a proper Lean 4 quotient construction. Requires: (1) a Setoid on induced subgraph pairs, (2) Fintype instance on the quotient, (3) proof that Fintype.card of quotient ≤ 2^n.",
-      "difficulty": "medium",
-      "tags": ["axiom-elimination", "quotient-type", "fintype"]
-    },
-    {
-      "id": "oq-02",
-      "title": "Prove random graphs are non-Ramsey and achieve optimal ISC count",
-      "description": "Formalize: (1) G(n,1/2) is non-Ramsey(c) for c < 2/log2 w.h.p., and (2) G(n,1/2) has numISCTrue = 2^n a.s. This would prove optimalConstantTrue_eq_one as a theorem, eliminating axiom 6.",
-      "difficulty": "very-hard",
-      "tags": ["probabilistic-method", "random-graphs", "axiom-elimination"]
+      "id": "erdos-1036",
+      "relationship": "parent: Shelah's theorem (1998) with placeholder ISC count — this entry refines with true ISC and asks for the optimal constant"
     }
   ]
 }


### PR DESCRIPTION
## Enrichment: erdos-1036-oq-01

First-pass enrichment for Optimal Constant in Shelah's Coloring Theorem.

### Quality gaps addressed

**Empty annotations.json** → 6 annotations covering all sections:
1. `ann-preamble`: labeled vs unlabeled ISC distinction, parent placeholder problem
2. `ann-isc-interface`: axiom interface for numISCTrue — why 3 axioms instead of Quotient construction
3. `ann-non-ramsey`: IsNonRamsey, nonRamseyExistsTrue, Shelah's theorem
4. `ann-optimal-def`: sSup definition, nonemptiness and bounded-above lemmas
5. `ann-bounds`: csSup API, c'(c)∈(0,1] proof
6. `ann-conjecture`: open conjecture, random graph witness, 6-axiom accounting

**Non-standard top-level openQuestions** → moved into `conclusion` block

**Missing conclusion** → added summary, implications, 3 openQuestions

**Missing 5th keyInsight** → Erdős-Hajnal connection

**Missing crossReferences** → parent erdos-1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)