### PR TITLE
fix(meta): angle-trisection-cos-20-gal-oq-01-oq-02-oq-02 sync sorry/status drift (1 sorry, formalized/wip)

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "researcher-1",
     "date": "2026-05-05",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean",
     "tags": [
       "galois-theory",
@@ -19,8 +19,8 @@
       "chebyshev",
       "general-formula"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "axiomCount": 0,
     "lineCount": 309,
     "assumptions": "",
@@ -59,9 +59,9 @@
     "theoremCount": 12,
     "definitionCount": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean",
-    "sorries": 0
+    "sorries": 1
   },
-  "sorries": 0,
+  "sorries": 1,
   "sections": [
     {
       "id": "sec-cosine-identity",


### PR DESCRIPTION
## Fix

Sync `meta.json` for `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02` to current truth on main: the Lean file has **1 sorry** (`cos_pi_gal_card` splitting field bound) but meta claimed `verified` / `badge: verified` / `sorries: 0`.

## Evidence

`proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean` on `origin/main` (`5505dfbda4a`), comments stripped:

| field | claimed | actual |
|---|---|---|
| sorries | 0 | **1** |
| status | verified | formalized |
| badge | verified | wip |

Surfaced by `pnpm tsx scripts/auditor/find-targets.ts --next`:
> ❌ `sorry mismatch: claims 0, actual 1; status "verified" but has 1 sorries`

## Diff

5/5 lines: `meta.status`, `meta.badge`, `meta.sorries`, `leanFile.sorries`, top-level `sorries`.

## Coexistence with in-flight research PRs

Two research PRs are working to eliminate the sorry:
- #16028 — "prove Gal order formula, 0 sorries" (CONFLICTING)
- #16052 — "eliminate sorry in cos_pi_gal_card" (CONFLICTING)

Both already need rebase. When either lands, that PR sets `verified` / `0 sorries` as part of its own meta diff. This commit only corrects the present overclaim on `main`; underclaim is the lower-credibility-cost state to live in until the proof lands.

`lineCount` (309 vs actual 232) and `theoremCount` (12 vs actual 11) drift exists too but isn't surfaced by the auditor — leaving those for whichever research PR rewrites the file.

---
Automated fix by lean-mechanic agent.