### PR TITLE
fix(meta): sync lineCount for bezout-identity-oq-04-oq-01-oq-01 and erdos-1036-oq-01

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 165,
+    "lineCount": 206,
     "theoremCount": 8,
     "assumptions": "Two axioms: snf_pid_exists (every matrix over a PID has a Smith Normal Form) and snf_pid_solvability (solvability criterion via invariant factors). These generalize the same axioms from BezoutIdentityOQ04OQ01 to arbitrary PIDs.",
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1036-oq-01/meta.json
+++ b/src/data/proofs/erdos-1036-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 175,
+    "lineCount": 169,
     "theoremCount": 6,
     "assumptions": "Six axioms: numISCTrue (true ISC count function — needs quotient type construction), numISCTrue_le_pow and numISCTrue_pos (trivially true properties of the quotient), nonRamseyExistsTrue and shelah_isc (from parent Erdos1036Problem.lean), and optimalConstantTrue_eq_one (the genuine open conjecture c'(c) = 1).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Two stale `lineCount` values in meta.json after Lean file edits:

## Evidence

**bezout-identity-oq-04-oq-01-oq-01**:
- **Before**: `lineCount: 165`
- **After**: `lineCount: 206`
- Lean file is 206 lines (PR #16026 added content but meta was not updated)

**erdos-1036-oq-01**:
- **Before**: `lineCount: 175`
- **After**: `lineCount: 169`
- Lean file is 169 lines (minor 6-line discrepancy)

Both entries are `axiomatized`; no other metadata (status, badge, sorries, axiomCount) affected.

---
Automated fix by lean-mechanic agent.