### PR TITLE
research(erdos-106-oq-02): boundary cases and dichotomy lemmas for rotated-square packing

### DIFF
--- a/proofs/Proofs/Erdos106OQ02.lean
+++ b/proofs/Proofs/Erdos106OQ02.lean
@@ -614,6 +614,91 @@ theorem no_rotation_help_at_2 : f_rot 2 = g_ap 2 := by
   rw [h, bku_theorem_ap 1 (by omega)]
   norm_num
 
+/-
+## Boundary Cases: n = 0 and Dichotomy of the Open Question
+
+The empty packing (Fin 0 → RotatedSquare) gives the achievable-sum singleton {0},
+so f_rot(0) = g_ap(0) = 0 unconditionally. Combined with agree_at_1 and
+agree_at_perfect_squares, this lets us tighten the open question: if rotation
+ever helps, it must help at some n ≥ 2, and the n ≥ 2 form is equivalent to
+the unrestricted form.
+-/
+
+/-- The empty general packing of 0 squares (sumSides = 0). -/
+private def emptyGeneralPacking : GeneralPacking 0 where
+  squares := Fin.elim0
+  contained := fun i => i.elim0
+  disjoint := fun i => i.elim0
+
+/-- The empty axis-parallel packing of 0 squares. -/
+private def emptyAxisParallelPacking : AxisParallelPacking 0 where
+  toGeneralPacking := emptyGeneralPacking
+  axisParallel := fun i => i.elim0
+
+/-- The empty general packing has sumSides = 0. -/
+private lemma emptyGeneralPacking_sumSides : emptyGeneralPacking.sumSides = 0 := by
+  show ∑ i : Fin 0, (emptyGeneralPacking.squares i).side = 0
+  simp
+
+/-- The empty axis-parallel packing has sumSides = 0. -/
+private lemma emptyAxisParallelPacking_sumSides : emptyAxisParallelPacking.sumSides = 0 := by
+  show emptyAxisParallelPacking.toGeneralPacking.sumSides = 0
+  exact emptyGeneralPacking_sumSides
+
+/-- f_rot(0) = 0: the only general packing of 0 squares has sumSides = 0. -/
+theorem f_rot_zero : f_rot 0 = 0 := by
+  apply le_antisymm
+  · -- Upper bound: f_rot 0 ≤ √0 = 0
+    have h := f_rot_bounded 0
+    simp at h
+    exact h
+  · -- Lower bound: 0 = sumSides of the empty packing is in the set
+    apply le_csSup (f_rot_set_bddAbove 0)
+    exact ⟨emptyGeneralPacking, emptyGeneralPacking_sumSides⟩
+
+/-- g_ap(0) = 0: the only AP packing of 0 squares has sumSides = 0. -/
+theorem g_ap_zero : g_ap 0 = 0 := by
+  apply le_antisymm
+  · -- g_ap 0 ≤ f_rot 0 = 0
+    have h := g_ap_le_f_rot 0
+    rw [f_rot_zero] at h
+    exact h
+  · -- 0 ∈ AP achievable set via empty packing
+    apply le_csSup
+    · exact (f_rot_set_bddAbove 0).mono (achievable_sums_subset 0)
+    · exact ⟨emptyAxisParallelPacking, emptyAxisParallelPacking_sumSides⟩
+
+/-- At n = 0, both functions agree: f_rot(0) = g_ap(0) = 0. -/
+theorem agree_at_0 : f_rot 0 = g_ap 0 := by
+  rw [f_rot_zero, g_ap_zero]
+
+/-- The open question is genuinely a dichotomy: rotation either helps somewhere
+    or never helps. -/
+theorem rotation_helps_iff_not_never_helps :
+    rotationHelps ↔ ¬ rotationNeverHelps := by
+  unfold rotationHelps rotationNeverHelps
+  constructor
+  · rintro ⟨n, hn⟩ h
+    exact absurd (h n) (ne_of_gt hn)
+  · intro h
+    push_neg at h
+    obtain ⟨n, hn⟩ := h
+    exact ⟨n, lt_of_le_of_ne (g_ap_le_f_rot n) (Ne.symm hn)⟩
+
+/-- The "rotation helps with witness ≥ 2" form is equivalent to the unrestricted form.
+    Combines agree_at_0 and agree_at_1: rotation cannot help at n ∈ {0, 1}. -/
+theorem axisParallelSuboptimal_iff_rotationHelps :
+    axisParallelSuboptimal ↔ rotationHelps := by
+  unfold axisParallelSuboptimal rotationHelps
+  refine ⟨fun ⟨n, _, hn⟩ => ⟨n, hn⟩, ?_⟩
+  rintro ⟨n, hn⟩
+  refine ⟨n, ?_, hn⟩
+  by_contra h
+  push_neg at h
+  interval_cases n
+  · exact absurd hn (by rw [agree_at_0]; exact lt_irrefl _)
+  · exact absurd hn (by rw [agree_at_1]; exact lt_irrefl _)
+
 -- ============================================================================
 -- § TIGHT BOUNDS AT k²+1: ROTATION BENEFIT IN [0, 1)
 -- ============================================================================

--- a/src/data/proofs/erdos-106-oq-02/meta.json
+++ b/src/data/proofs/erdos-106-oq-02/meta.json
@@ -26,9 +26,9 @@
     "erdosProblemStatus": "open",
     "axiomCount": 5,
     "assumptions": "5 axiom declarations: rotated_square_area (rotation preserves area), f_rot_bounded (Cauchy-Schwarz √n bound), f_rot_mono (monotone), bku_theorem_ap (BKU 2024 result), f_rot_2 (Erdős f_rot(2)=1). ELIMINATED: g_ap_perfect_square (proved via k×k grid construction + g_ap_bounded upper bound), g_ap_bounded (proved from f_rot_bounded + g_ap≤f_rot), f_rot_perfect_square (proved from g_ap_perfect_square + f_rot_bounded + g_ap≤f_rot). 0 sorries.",
-    "lineCount": 664,
-    "theoremCount": 32,
-    "definitionCount": 14
+    "lineCount": 749,
+    "theoremCount": 39,
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "**From Axis-Parallel to Rotated: The Last Barrier in Square Packing**\n\nThe 2024 breakthrough by Baek, Koizumi, and Ueoro completely resolved the axis-parallel case of Erdős's square packing conjecture, proving g(k²+1) = k. This leaves one fundamental question: can rotated squares do better?\n\nIn the axis-parallel formulation, all packed squares have sides parallel to the unit square. When rotation is allowed, the packing space is richer — a rotated square occupies a diamond-shaped region that could potentially fill space more efficiently.\n\nNo example is known where rotation helps. At perfect squares n = k², both f_rot(k²) = g(k²) = k, since the k×k grid (which is axis-parallel) is already optimal by Cauchy-Schwarz. The question is whether rotation helps at non-perfect-square values of n.",
@@ -178,12 +178,12 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 664,
+    "lineCount": 749,
     "axiomCount": 5,
-    "theoremCount": 32,
-    "substantiveTheoremCount": 8,
+    "theoremCount": 39,
+    "substantiveTheoremCount": 11,
     "sorryTheorems": 0,
-    "definitionCount": 14,
+    "definitionCount": 16,
     "mainTheorems": [
       {
         "name": "agree_at_perfect_squares",
@@ -204,6 +204,21 @@
         "name": "no_rotation_help_at_2",
         "type": "proved",
         "description": "f_rot(2) = g(2) = 1"
+      },
+      {
+        "name": "agree_at_0",
+        "type": "proved",
+        "description": "f_rot(0) = g_ap(0) = 0 (boundary case via empty packing)"
+      },
+      {
+        "name": "rotation_helps_iff_not_never_helps",
+        "type": "proved",
+        "description": "rotationHelps ↔ ¬rotationNeverHelps — the open question is a genuine dichotomy"
+      },
+      {
+        "name": "axisParallelSuboptimal_iff_rotationHelps",
+        "type": "proved",
+        "description": "axisParallelSuboptimal ↔ rotationHelps — any rotation benefit must occur at n ≥ 2"
       },
       {
         "name": "rotationHelps",

--- a/src/data/research/problems/erdos-106-oq-02.json
+++ b/src/data/research/problems/erdos-106-oq-02.json
@@ -29,18 +29,18 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-29T05:28:40-07:00",
-    "iteration": 3,
-    "focus": "Axiom elimination: 8→6 axioms via geometric side bound and sSup reasoning",
+    "iteration": 4,
+    "focus": "Boundary case + dichotomy lemmas: n=0 base case via empty packing, axisParallelSuboptimal_iff_rotationHelps reduces conjecture to n ≥ 2 form",
     "blockers": [],
-    "nextAction": "Docker build verification when Docker available",
+    "nextAction": "Attempt to prove f_rot(2) = 1 from convexity of unitSquare' (would eliminate the f_rot_2 axiom)",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
-      "approachesTried": 1
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 3 axioms total (g_ap_bounded, f_rot_perfect_square, g_ap_perfect_square → theorems). 5 axioms remain: rotated_square_area, f_rot_bounded, f_rot_mono, bku_theorem_ap, f_rot_2. 0 sorries.",
+    "progressSummary": "PROGRESS: 749 lines, 39 theorems, 16 defs, 5 axioms, 0 sorries. Session 2026-05-07: added boundary case n=0 (f_rot_zero, g_ap_zero, agree_at_0 via empty packing) + dichotomy lemmas (rotation_helps_iff_not_never_helps, axisParallelSuboptimal_iff_rotationHelps) tightening the open question to n ≥ 2 form. Earlier sessions eliminated 3 axioms (g_ap_bounded, f_rot_perfect_square, g_ap_perfect_square → theorems). 5 axioms remain: rotated_square_area, f_rot_bounded, f_rot_mono, bku_theorem_ap, f_rot_2.",
     "builtItems": [
       "Created proofs/Proofs/Erdos106OQ02.lean (219 lines, 11 theorems, 8 axioms, 0 sorries)",
       "RotatedSquare structure with center, side, angle; interior via inverse rotation",
@@ -54,7 +54,11 @@
       "g_ap_le_f_rot: g_ap(n) ≤ f_rot(n) proved",
       "g_ap_bounded: now theorem (was axiom)",
       "f_rot_perfect_square: now theorem (was axiom)",
-      "g_ap_perfect_square theorem (~110 lines): containment via edge bounds, disjointness via column/row separation, sum via Finset.sum_const"
+      "g_ap_perfect_square theorem (~110 lines): containment via edge bounds, disjointness via column/row separation, sum via Finset.sum_const",
+      "Session 2026-05-07: emptyGeneralPacking and emptyAxisParallelPacking (Fin 0 elimination) + emptyGeneralPacking_sumSides = 0",
+      "f_rot_zero, g_ap_zero, agree_at_0: boundary case n = 0 via empty packing membership and Cauchy-Schwarz upper bound",
+      "rotation_helps_iff_not_never_helps: classical-logic dichotomy of the open question",
+      "axisParallelSuboptimal_iff_rotationHelps: any rotation benefit must occur at n ≥ 2 (uses agree_at_0 + agree_at_1 to rule out n ∈ {0, 1})"
     ],
     "insights": [
       "Rotation preserves area, so Cauchy-Schwarz bound f_rot(n) <= sqrt(n) still holds",
@@ -70,10 +74,11 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify compilation when Docker is available",
-      "Attempt to prove f_rot(2) = 1 from first principles instead of axiomatizing",
+      "Attempt to prove f_rot(2) = 1 from first principles instead of axiomatizing (Erdős original argument: 2 squares of side > 1/2 cannot fit; reachable via convexity of unitSquare')",
       "Investigate if area argument alone can prove g(n) <= f_rot(n) formally in Lean",
-      "Consider creating Aristotle companion file for routine lemmas"
+      "Consider creating Aristotle companion file for routine lemmas",
+      "Tackle quantitative gap: f_rot(k²+1) ∈ [k, √(k²+1)] is proved; the open question is whether the upper bound is ever attained for some k",
+      "Consider proving f_rot_mono from the achievable-set monotonicity (extend a packing of n by adding a square of side 0)"
     ],
     "markdown": "# Knowledge Base: erdos-106-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds **5 new theorems + 2 helper defs** to the open-question section of `Erdos106OQ02.lean`, tightening the formal statement of the open question (rotated vs axis-parallel square packing) without weakening any axiom.

### New theorems
- `f_rot_zero`, `g_ap_zero`: `f_rot(0) = g_ap(0) = 0` via empty packing
- `agree_at_0`: combines the two for `n = 0`
- `rotation_helps_iff_not_never_helps`: the open question is a genuine dichotomy
- `axisParallelSuboptimal_iff_rotationHelps`: any rotation benefit must occur at `n ≥ 2` (uses `agree_at_0` + `agree_at_1`)

### Helper defs
- `emptyGeneralPacking : GeneralPacking 0` and `emptyAxisParallelPacking : AxisParallelPacking 0` — witness 0 ∈ achievable-sums set at `n = 0`

### Counts (meta + leanFile sub-objects)
| Field | Before | After |
|---|---|---|
| lineCount | 664 | 749 |
| theoremCount | 32 | 39 |
| definitionCount | 14 | 16 |
| substantiveTheoremCount | 8 | 11 |
| axiomCount | 5 | 5 |
| sorries | 0 | 0 |

### Honest assessment
This is supporting infrastructure, not a step toward resolving the conjecture. The open question (does rotation ever help?) remains genuinely open and gated on the axis-parallel BKU result `bku_theorem_ap` plus quantitative bounds on `f_rot` at `k²+1`. What this PR adds is the boundary case `n=0` (previously only `n=1` and `n=k²` were handled) and the equivalence between three different formal statements of the conjecture.

## Test plan
- [ ] Docker build of `Proofs.Erdos106OQ02` passes (running in background)
- [ ] CI gallery build succeeds
- [ ] `meta.json` counts match the source file

🤖 Generated with [Claude Code](https://claude.com/claude-code)