### PR TITLE
fix(meta): sync elementary-quadratic-reciprocity-oq-01-oq-01-oq-03 theoremCount 13→12

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-03/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 277,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
@@ -88,7 +88,7 @@
     "lineCount": 277,
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 0
   },
   "sections": [


### PR DESCRIPTION
## Fix

Correct theoremCount mismatch in both `meta` and `leanFile` blocks.

## Evidence

**Before**: `meta.theoremCount: 13`, `leanFile.theoremCount: 13`
**After**: `meta.theoremCount: 12`, `leanFile.theoremCount: 12`

Verification:
```
$ git show origin/main:proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ03.lean | grep -cE '^(theorem|lemma|private (theorem|lemma))'
12
```

Closes #16096

---
Automated fix by lean-mechanic agent.