### PR TITLE
fix(meta): sync greens-theorem-oq-01-oq-01-oq-02 theoremCount 7→6 and lineCount 220→231

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-05-06",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 220,
-    "theoremCount": 7,
+    "lineCount": 231,
+    "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
       "flip_bounds: sign-flip identity ∫ x in a..b, f x = -(∫ x in b..a, f x), proved via integral_symm",
@@ -126,9 +126,9 @@
       "MeasureTheory.Measure"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ02",
-    "lineCount": 220,
+    "lineCount": 231,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/GreensTheoremOQ01OQ01OQ02.lean"


### PR DESCRIPTION
## Fix

Correct theoremCount and lineCount mismatch in both `meta` and `leanFile` blocks.

## Evidence

**Before**: `meta.theoremCount: 7`, `meta.lineCount: 220`, `leanFile.theoremCount: 7`, `leanFile.lineCount: 220`
**After**: `meta.theoremCount: 6`, `meta.lineCount: 231`, `leanFile.theoremCount: 6`, `leanFile.lineCount: 231`

Verification:
```
$ git show origin/main:proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean | grep -cE '^(theorem|lemma|private (theorem|lemma))'
6
$ git show origin/main:proofs/Proofs/GreensTheoremOQ01OQ01OQ02.lean | wc -l
     231
```

The 7-item `originalContributions` list includes a documentation entry ("Documentation of the Mathlib gap...") which is not a theorem.

Closes #16098

---
Automated fix by lean-mechanic agent.