### PR TITLE
audit(tracker): batch — 7 clean audits + angle-trisection note refresh

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14735,11 +14735,11 @@
       "issues": []
     },
     "angle-trisection-cos-20-gal-oq-01-oq-02-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-06T08:16:22Z",
+      "lastAudited": "2026-05-06T08:50:13Z",
       "result": "issues-found",
-      "notes": "Sorry mismatch on origin/main (claims 0, actual 1; status verified but file has 1 sorry at line 126). In-flight fix PRs already open: #16080 (audit), #16081 (mechanic) — both meta sync; #16028 (research) attempts to remove the sorry but is conflicting. No new issue/PR filed."
+      "notes": "Reverse mismatch on origin/main (claims 1, actual 0). #16052 eliminated last sorry after #16080/#16081 set meta to 1. Two open meta-sync PRs are MERGEABLE: #16094 (mechanic, badge=verified) and #16101 (audit, badge=original). Both correctly sync to 0 sorries. Awaiting deployer merge — no new PR filed."
     },
     "lagrange-theorem-oq-01-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Two-commit audit-tracker update covering one issues-found refresh and seven new clean audits.

### Commit 1: angle-trisection-cos-20-gal-oq-01-oq-02-oq-02 — note refresh

Mismatch direction reversed since the prior tracker entry:

- #16080 / #16081 (merged 2026-05-06 08:21Z) set meta to 1 sorry, status `formalized/wip`
- #16052 (merged 2026-05-06 08:24Z) eliminated the last sorry from `cos_pi_splitting_finrank`

So meta now overstates sorries (claims 1, actual 0). Two open MERGEABLE meta-sync PRs already address this:

- #16094 (mechanic, `badge: verified`)
- #16101 (audit, `badge: original`)

No new fix PR is filed; the deployer should merge one of #16094 / #16101.

### Commit 2: 7 newly-audited entries marked `clean`

| Slug | Status / Badge | Notes |
|---|---|---|
| cayley-hamilton-minpoly-oq-02-oq-01-oq-02 | verified / verified | OK |
| elementary-quadratic-reciprocity-oq-01-oq-01-oq-03 | verified / verified | OK |
| greens-theorem-oq-01-oq-01-oq-02 | verified / original | minor lineCount drift 220→231 (cosmetic, below threshold) |
| law-of-cosines-oq-01-oq-01 | verified / original | OK |
| laws-of-large-numbers-oq-01-oq-02 | axiomatized / axiom | minor definitionCount drift 0→1 (`abbrev IsLr`); 3 axioms match |
| laws-of-large-numbers-oq-01-oq-03 | verified / original | OK |
| sperner-ndim-mathlib | verified / original | OK |

All seven pass the auditor's structural integrity checks (sorry count, axiom count, status/badge consistency).

## Test plan
- [x] Tracker JSON parses
- [x] Unicode characters preserved in pre-existing notes (was being clobbered by `claim-target.sh` `json.dump`)
- [x] No new fix PRs needed for any of the 7 new audits

🤖 Generated with [Claude Code](https://claude.com/claude-code)