### PR TITLE
enrich(law-of-cosines-oq-01-oq-01): add sections, conclusion, cross-refs; enrich annotations

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/index.ts
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/index.ts
@@ -5,5 +5,5 @@ import sourceRaw from '../../../../proofs/Proofs/LawOfCosinesOQ01OQ01.lean?raw'
 const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
 export const lawOfCosinesOQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
 export const lawOfCosinesOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
-export const lawOfCosinesOQ01OQ01Data: ProofData = { proof: lawOfCosinesOQ01OQ01Proof, annotations: lawOfCosinesOQ01OQ01Annotations, tacticStates: [] }
+export const lawOfCosinesOQ01OQ01Data: ProofData = { proof: lawOfCosinesOQ01OQ01Proof, annotations: lawOfCosinesOQ01OQ01Annotations }
 export default lawOfCosinesOQ01OQ01Data


### PR DESCRIPTION
## Summary

Enrichment pass for `law-of-cosines-oq-01-oq-01` (Dual Spherical Law of Cosines — axiom-free, quality 20→estimated 80+).

**meta.json:**
- Added 10 top-level `sections` (Parts I–X) with `id`, `title`, `startLine`, `endLine`, `summary` covering all 334 lines
- Added `conclusion` with mathematical implications (celestial mechanics, geodesy, crystallography) and 2 open questions
- Added `crossReferences` to 3 related entries: spherical-law-of-cosines (prerequisite), law-of-cosines-oq-01 (sibling), law-of-cosines (Euclidean analogy)
- Enriched `historicalContext`: explains why Gram determinant approach was preferred over polar triangle construction for Lean 4 formalization

**annotations.json:**
- Converted from `{source, version, annotations: [...]}` wrapper format to top-level array (fixing the index.ts mismatch where `annotationsJson as unknown as Annotation[]` was treating the wrapper object as an array)
- Added `mathContext` (LaTeX formulas) to all 9 annotations covering: dihedral angle definition formula, inner product decomposition, projection norm computation, Gram matrix determinant, Cauchy-Schwarz reformulation, cosine formula derivation, sine squared formula, nonneg square root argument, 90-90-90 triangle verification
- Added `significance`, `relatedConcepts`, `prerequisites`, `proofId` to all annotations

**index.ts:**
- Removed non-standard `tacticStates: []` field from ProofData export