### PR TITLE
audit(erdos-895): mark clean; fix tracker unicode escaping

### DIFF
--- a/scripts/auditor/claim-target.sh
+++ b/scripts/auditor/claim-target.sh
@@ -161,7 +161,8 @@ entry['result'] = '$result'
 tracker['entries']['$id'] = entry
 
 with open(tracker_file, 'w') as f:
-    json.dump(tracker, f, indent=2)
+    json.dump(tracker, f, indent=2, ensure_ascii=False)
+    f.write('\n')
 "
 
     # Remove claim

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10394,9 +10394,10 @@
     },
     "erdos-895": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:16:39Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-06T09:46:05Z",
+      "result": "clean",
+      "notes": "Verified vs origin/main: 260 lines, 7 sorries — matches meta.json. Working-tree mismatch is unmerged researcher WIP."
     },
     "erdos-896": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- **erdos-895 audited clean.** meta.json (260 lines, 7 sorries) matches `origin/main`. The find-targets sorry-mismatch (claims 7, actual 6) is from an unmerged researcher WIP commit (`fa14e1bcdb41` on `feature/researcher-11`) sitting in the main repo working tree, not an actual integrity issue.
- **Fix unicode-escape bug in claim-target.sh.** `do_complete` used Python's default `json.dump(..., indent=2)` (which has `ensure_ascii=True`), so every call rewrote every existing em-dash and arrow in `audit-tracker.json` as `\uXXXX`. Switching to `ensure_ascii=False` (plus a trailing newline) keeps diffs scoped to the entry actually being touched.

## Test plan

- [x] `git diff src/data/proofs/audit-tracker.json` shows only the erdos-895 entry changed (no spurious unicode escapes elsewhere).
- [x] Script change is a single-line addition; behavior preserved for ASCII-only entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)