### PR TITLE
audit(tracker): mark cayley-hamilton-minpoly-oq-02-oq-01-oq-02 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1760,6 +1760,12 @@
       "lastAudited": "2026-05-03T18:32:27Z",
       "result": "clean"
     },
+    "cayley-hamilton-minpoly-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-05-06T09:52:10Z",
+      "result": "clean"
+    },
     "cayley-hamilton-minpoly-oq-02-oq-02": {
       "auditCount": 3,
       "issues": [],


### PR DESCRIPTION
## Summary

- Marks `cayley-hamilton-minpoly-oq-02-oq-01-oq-02` as audited (`clean`) in the audit tracker.

## Audit findings

- meta.json claims: status=`verified`, badge=`verified`, sorries=0, axioms=0, theorems=9, defs=0
- Lean file (`Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean` on origin/main): 0 sorries, 0 axioms, 9 theorems/lemmas — matches
- No True stubs; no overclaimed Mathlib delegation
- Description correctly says "generalizes Mathlib's `minpoly.algHom_eq`"
- Tier-A: builds a complete iff characterization (`minpoly_eq_iff_aeval_zero`) from Mathlib primitives (`minpoly.dvd`, `minpoly.algHom_eq`, `eq_of_monic_of_associated`)

## Test plan

- [x] Verified counts against origin/main (`git show origin/main:proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean`)
- [x] Confirmed no True stubs, no axioms, no sorries via comment-stripped scan
- [x] Tracker entry inserted alphabetically inside `entries.*`, no other lines touched

🤖 Generated with [Claude Code](https://claude.ai/claude-code)