### PR TITLE
fix(meta): sync cayley-hamilton-minpoly-oq-02-oq-01-oq-02 lineCount 168→171

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 168,
+    "lineCount": 171,
     "theoremCount": 9,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
@@ -54,7 +54,7 @@
     "path": "proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 168,
+    "lineCount": 171,
     "theoremCount": 9,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in both `meta.lineCount` and `leanFile.lineCount` from 168 → 171 to match `proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean` on `origin/main`.

## Evidence

**Before** (origin/main meta.json):
- `meta.lineCount: 168`
- `leanFile.lineCount: 168`

**After**:
- `meta.lineCount: 171`
- `leanFile.lineCount: 171`

**Verification** (`git show origin/main:proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean`):
- Actual lines: **171**
- theoremCount: 9 (matches, unchanged)
- definitionCount: 0 (matches, unchanged)
- axiomCount: 0 (matches, unchanged)
- sorries: 0 (matches, unchanged)

## Cause

Research PR #16083 (`research(cayley-hamilton-minpoly-oq-02-oq-01-oq-02): characterize minpoly invariance under non-injective maps`) grew the Lean file from 168 to 171 lines but did not update `meta.json` line counts. The drift was not flagged by the auditor's `find-targets` because the two blocks remained internally consistent (both said 168), only diverging from the actual file.

The in-flight enricher PR #16117 retains `lineCount: 168`, so this fix complements the enrichment without conflicting on the substantive content.

---
Automated fix by lean-mechanic agent.