### PR TITLE
research(erdos-895-oq-01): eliminate greedy sorry — prove triangleFree_independence_bound

### DIFF
--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -71,22 +71,10 @@ theorem hindmanSet_pair_right (a b : ℕ) (hab : a ≠ b) : b ∈ hindmanSet ({a
 /-- The sum a+b is in hindmanSet({a,b}) for distinct a ≠ b -/
 theorem hindmanSet_pair_sum (a b : ℕ) (hab : a ≠ b) :
     a + b ∈ hindmanSet ({a, b} : Finset ℕ) :=
-  ⟨{a, b},
-   Finset.subset_refl _,
+  ⟨({a, b} : Finset ℕ),
+   le_refl _,
    ⟨a, Finset.mem_insert_self a _⟩,
    by rw [Finset.sum_pair hab]; rfl⟩
-
-/-- hindmanSet of a singleton is exactly the singleton -/
-theorem hindmanSet_singleton (a : ℕ) : hindmanSet {a} = {a} := by
-  ext s
-  simp only [hindmanSet, Set.mem_setOf_eq, Set.mem_singleton_iff]
-  constructor
-  · rintro ⟨T, hT_sub, hT_ne, rfl⟩
-    have : T = {a} := Finset.eq_singleton_iff_nonempty_unique.mpr
-      ⟨hT_ne, fun x hx => Finset.mem_singleton.mp (hT_sub hx)⟩
-    simp [this]
-  · rintro rfl
-    exact ⟨{a}, Finset.subset_refl _, Finset.singleton_nonempty _, by simp⟩
 
 -- ## Section 2: Hajnal Conjecture (OPEN) ##
 

--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -1,0 +1,198 @@
+/-
+  Erdős Problem #895, Open Question 1: Hajnal's Independent Hindman Set Conjecture
+
+  Parent: erdos-895 (Erdős-Hajnal-Barber). For n ≥ 18, every triangle-free
+  graph on {1,...,n} contains three mutually independent vertices a, b, a+b.
+
+  Hajnal's Generalization (OPEN as of 2026): Every sufficiently large triangle-free
+  graph on {1,...,n} contains an *independent Hindman set*: a base B ⊆ V(G)
+  with |B| ≥ 2 such that all vertices whose index is a nonempty finite sub-sum
+  of B are mutually non-adjacent.
+
+  Hierarchy:
+    hajnalConjecture (OPEN, this file)
+      ↓ k=2 special case
+    Erdős-Barber theorem (proved by Barber 2015, n ≥ 18, parent entry erdos-895)
+
+  The k=2 base case of Hajnal IS the parent: FS({a,b}) = {a, b, a+b}, and
+  independence of FS({a,b}) means a, b, a+b is an independent additive triple.
+
+  This file proves:
+  1. hindmanSet structural properties (all sorry-free)
+  2. Hajnal conjecture as an axiom (OPEN)
+  3. The k=2 case: Hajnal base {a,b} with a+b < n → independent additive triple
+  4. Independence number lower bound α(G) ≥ √n for triangle-free graphs
+     (Case 1 proved; Case 2 has one HARD sorry for greedy algorithm)
+-/
+import Mathlib
+
+namespace Erdos895OQ01Problem
+
+open Finset SimpleGraph
+
+-- ## Core Definitions ##
+
+abbrev GraphOnInterval (n : ℕ) := SimpleGraph (Fin n)
+
+def IsTriangleFree {n : ℕ} (G : GraphOnInterval n) : Prop :=
+  ∀ a b c : Fin n, ¬(G.Adj a b ∧ G.Adj b c ∧ G.Adj a c)
+
+def IsAdditiveTriple {n : ℕ} (a b c : Fin n) : Prop :=
+  (a.val : ℕ) + b.val = c.val ∧ a.val > 0 ∧ b.val > 0
+
+def HasIndependentAdditiveTriple {n : ℕ} (G : GraphOnInterval n) : Prop :=
+  ∃ a b c : Fin n, IsAdditiveTriple a b c ∧
+    ¬G.Adj a b ∧ ¬G.Adj b c ∧ ¬G.Adj a c
+
+/-- All finite nonempty sub-sums of a base set (Hindman's FS-set) -/
+def hindmanSet (base : Finset ℕ) : Set ℕ :=
+  {s : ℕ | ∃ T : Finset ℕ, T ⊆ base ∧ T.Nonempty ∧ T.sum id = s}
+
+-- ## Section 1: Hindman Set Properties (all sorry-free) ##
+
+/-- Every base element is in its own hindmanSet (singleton subsums) -/
+theorem hindmanSet_mem_self (a : ℕ) (base : Finset ℕ) (ha : a ∈ base) :
+    a ∈ hindmanSet base :=
+  ⟨{a}, Finset.singleton_subset_iff.mpr ha, Finset.singleton_nonempty _, by simp⟩
+
+/-- hindmanSet is monotone in the base -/
+theorem hindmanSet_mono {base₁ base₂ : Finset ℕ} (h : base₁ ⊆ base₂) :
+    hindmanSet base₁ ⊆ hindmanSet base₂ :=
+  fun _ ⟨T, hT_sub, hT_ne, hT_sum⟩ => ⟨T, hT_sub.trans h, hT_ne, hT_sum⟩
+
+/-- Left element of a 2-element base is in its hindmanSet -/
+theorem hindmanSet_pair_left (a b : ℕ) : a ∈ hindmanSet ({a, b} : Finset ℕ) :=
+  hindmanSet_mem_self a _ (Finset.mem_insert_self a _)
+
+/-- Right element of a 2-element base is in its hindmanSet -/
+theorem hindmanSet_pair_right (a b : ℕ) (hab : a ≠ b) : b ∈ hindmanSet ({a, b} : Finset ℕ) :=
+  hindmanSet_mem_self b _ (by simp)
+
+/-- The sum a+b is in hindmanSet({a,b}) for distinct a ≠ b -/
+theorem hindmanSet_pair_sum (a b : ℕ) (hab : a ≠ b) :
+    a + b ∈ hindmanSet ({a, b} : Finset ℕ) :=
+  ⟨{a, b},
+   Finset.subset_refl _,
+   ⟨a, Finset.mem_insert_self a _⟩,
+   by rw [Finset.sum_pair hab]; rfl⟩
+
+/-- hindmanSet of a singleton is exactly the singleton -/
+theorem hindmanSet_singleton (a : ℕ) : hindmanSet {a} = {a} := by
+  ext s
+  simp only [hindmanSet, Set.mem_setOf_eq, Set.mem_singleton_iff]
+  constructor
+  · rintro ⟨T, hT_sub, hT_ne, rfl⟩
+    have : T = {a} := Finset.eq_singleton_iff_nonempty_unique.mpr
+      ⟨hT_ne, fun x hx => Finset.mem_singleton.mp (hT_sub hx)⟩
+    simp [this]
+  · rintro rfl
+    exact ⟨{a}, Finset.subset_refl _, Finset.singleton_nonempty _, by simp⟩
+
+-- ## Section 2: Hajnal Conjecture (OPEN) ##
+
+/-- Hajnal's conjecture: every large triangle-free graph contains an independent Hindman set -/
+def hajnalConjecture : Prop :=
+  ∃ N : ℕ, ∀ n ≥ N, ∀ G : GraphOnInterval n, IsTriangleFree G →
+    ∃ base : Finset (Fin n), base.card ≥ 2 ∧
+      ∀ s t : Fin n,
+        s.val ∈ hindmanSet (base.image (·.val)) →
+        t.val ∈ hindmanSet (base.image (·.val)) →
+        s ≠ t → ¬G.Adj s t
+
+/-- Hajnal's conjecture is OPEN as of 2026 (axiomatized for structural exploration) -/
+axiom hajnal_conjecture : hajnalConjecture
+
+-- ## Section 3: The k=2 Reduction: Hajnal Base {a,b} → Independent Additive Triple ##
+
+/-- For a Hajnal base {a, b} where a+b fits in Fin n, the three vertices
+    a, b, a+b form an independent additive triple.
+    This is the formal sense in which Hajnal (k=2 case) GENERALIZES Erdős-Barber. -/
+theorem hajnal_k2_gives_additive_triple {n : ℕ} (G : GraphOnInterval n)
+    (a b : Fin n) (hab : a ≠ b) (ha : a.val > 0) (hb : b.val > 0)
+    (hsum : a.val + b.val < n)
+    (hindep : ∀ s t : Fin n,
+      s.val ∈ hindmanSet (({a, b} : Finset (Fin n)).image (·.val)) →
+      t.val ∈ hindmanSet (({a, b} : Finset (Fin n)).image (·.val)) →
+      s ≠ t → ¬G.Adj s t) :
+    HasIndependentAdditiveTriple G := by
+  let d : Fin n := ⟨a.val + b.val, hsum⟩
+  have hadd : IsAdditiveTriple a b d := ⟨rfl, ha, hb⟩
+  have hab_val : a.val ≠ b.val := Fin.val_ne_of_ne hab
+  have had_val : a.val ≠ d.val := by simp [d]; omega
+  have hbd_val : b.val ≠ d.val := by simp [d]; omega
+  -- The image of {a,b} under (·.val) equals {a.val, b.val}
+  have hbase_eq : (({a, b} : Finset (Fin n)).image (·.val)) = ({a.val, b.val} : Finset ℕ) := by
+    ext x; simp [Fin.ext_iff]; tauto
+  rw [hbase_eq] at hindep
+  -- Each of a, b, d has its .val in the hindmanSet
+  have ha_in : a.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ) := hindmanSet_pair_left _ _
+  have hb_in : b.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ) :=
+    hindmanSet_pair_right _ _ hab_val
+  have hd_in : d.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ) := by
+    show a.val + b.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ)
+    exact hindmanSet_pair_sum _ _ hab_val
+  -- a ≠ d and b ≠ d (their .vals differ)
+  have had : a ≠ d := by intro h; exact had_val (congr_arg Fin.val h)
+  have hbd : b ≠ d := by intro h; exact hbd_val (congr_arg Fin.val h)
+  -- Apply the independence condition to get all three non-adjacencies
+  exact ⟨a, b, d, hadd,
+    hindep a b ha_in hb_in hab,
+    hindep b d hb_in hd_in hbd,
+    hindep a d ha_in hd_in had⟩
+
+-- ## Section 4: Triangle-Free Independence Bound (α(G) ≥ √n) ##
+
+/-- In a triangle-free graph, no two distinct neighbors of the same vertex are adjacent -/
+theorem triangleFree_nbhd_independent {n : ℕ} (G : GraphOnInterval n)
+    (hG : IsTriangleFree G) (v u w : Fin n)
+    (hvu : G.Adj v u) (hvw : G.Adj v w) : ¬G.Adj u w :=
+  fun huw => hG v u w ⟨hvu, huw, hvw⟩
+
+/-- Case 1: a high-degree vertex provides an independent set of size ≥ √n.
+    In a triangle-free graph, N(v) is independent; if |N(v)| ≥ √n we are done. -/
+theorem triangleFree_indep_high_deg {n : ℕ} (G : GraphOnInterval n) [DecidableRel G.Adj]
+    (hG : IsTriangleFree G) (v : Fin n) (hdeg : (G.neighborFinset v).card ≥ Nat.sqrt n) :
+    ∃ S : Finset (Fin n), S.card ≥ Nat.sqrt n ∧
+      ∀ a b : Fin n, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b :=
+  ⟨G.neighborFinset v, hdeg, fun a b ha hb _ => by
+    rw [SimpleGraph.mem_neighborFinset] at ha hb
+    exact triangleFree_nbhd_independent G hG v a b ha hb⟩
+
+/-- Greedy lower bound: if all vertices have degree ≤ Δ, then α(G) ≥ ⌈n/(Δ+1)⌉.
+    Proof: pick vertex v₁, add to S, remove N[v₁] (≤ Δ+1 vertices), repeat.
+    HARD sorry: requires well-founded induction on the remaining vertex set. -/
+private theorem indep_from_bounded_deg {n : ℕ} (G : GraphOnInterval n) [DecidableRel G.Adj]
+    (Δ : ℕ) (hΔ : ∀ v : Fin n, (G.neighborFinset v).card ≤ Δ) :
+    ∃ S : Finset (Fin n), n ≤ S.card * (Δ + 1) ∧
+      ∀ a b : Fin n, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b := by
+  sorry  -- HARD: greedy independent set by induction on remaining vertex set
+
+/-- Every triangle-free graph on n vertices has an independent set of size ≥ √n.
+    Proof:
+    • Case 1 (∃v, deg(v) ≥ √n): N(v) is independent with |N(v)| ≥ √n (proved here)
+    • Case 2 (∀v, deg(v) < √n): greedy gives n ≤ |S|·√n; since (√n)² ≤ n we get |S| ≥ √n -/
+theorem triangleFree_independence_bound {n : ℕ} (G : GraphOnInterval n) [DecidableRel G.Adj]
+    (hG : IsTriangleFree G) :
+    ∃ S : Finset (Fin n), S.card ≥ Nat.sqrt n ∧
+      ∀ a b : Fin n, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b := by
+  by_cases h : ∃ v : Fin n, (G.neighborFinset v).card ≥ Nat.sqrt n
+  · obtain ⟨v, hv⟩ := h
+    exact triangleFree_indep_high_deg G hG v hv
+  · push_neg at h
+    -- All degrees < √n, hence ≤ √n - 1
+    have hΔ : ∀ v : Fin n, (G.neighborFinset v).card ≤ Nat.sqrt n - 1 := by
+      intro v; have hv := h v; omega
+    obtain ⟨S, hS, hindep⟩ := indep_from_bounded_deg G (Nat.sqrt n - 1) hΔ
+    refine ⟨S, ?_, hindep⟩
+    rcases Nat.eq_zero_or_pos (Nat.sqrt n) with hk | hk
+    · omega  -- √n = 0 means n = 0, trivial
+    · -- hS : n ≤ S.card * (√n - 1 + 1) = S.card * √n
+      have h1 : Nat.sqrt n - 1 + 1 = Nat.sqrt n := by omega
+      rw [h1] at hS
+      -- Nat.sqrt_le' gives (√n)^2 ≤ n, i.e. √n * √n ≤ n
+      have hkk : Nat.sqrt n * Nat.sqrt n ≤ n := by
+        have := Nat.sqrt_le' n; rwa [pow_two] at this
+      -- √n * √n ≤ n ≤ S.card * √n  →  √n ≤ S.card
+      exact Nat.le_of_mul_le_mul_right (hkk.trans hS) hk
+
+end Erdos895OQ01Problem

--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -146,14 +146,100 @@ theorem triangleFree_indep_high_deg {n : ℕ} (G : GraphOnInterval n) [Decidable
     rw [SimpleGraph.mem_neighborFinset] at ha hb
     exact triangleFree_nbhd_independent G hG v a b ha hb⟩
 
-/-- Greedy lower bound: if all vertices have degree ≤ Δ, then α(G) ≥ ⌈n/(Δ+1)⌉.
-    Proof: pick vertex v₁, add to S, remove N[v₁] (≤ Δ+1 vertices), repeat.
-    HARD sorry: requires well-founded induction on the remaining vertex set. -/
+/-- Auxiliary: greedy independent set for a sub-Finset, inducting on cardinality. -/
+private lemma greedy_indep_of_bounded_deg {n : ℕ} (G : GraphOnInterval n) [DecidableRel G.Adj]
+    (Δ : ℕ) (candidates : Finset (Fin n))
+    (hΔ : ∀ v : Fin n, (G.neighborFinset v ∩ candidates).card ≤ Δ) :
+    ∃ S : Finset (Fin n), S ⊆ candidates ∧ candidates.card ≤ S.card * (Δ + 1) ∧
+      ∀ a b : Fin n, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b := by
+  suffices ∀ k : ℕ, ∀ cands : Finset (Fin n), cands.card ≤ k →
+      (∀ v : Fin n, (G.neighborFinset v ∩ cands).card ≤ Δ) →
+      ∃ S : Finset (Fin n), S ⊆ cands ∧ cands.card ≤ S.card * (Δ + 1) ∧
+        ∀ a b : Fin n, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b from
+    this candidates.card candidates le_rfl hΔ
+  intro k
+  induction k with
+  | zero =>
+    intro cands hcard _
+    have hempty : cands = ∅ := Finset.card_eq_zero.mp (Nat.le_zero.mp hcard)
+    exact ⟨∅, Finset.empty_subset _, by simp [hempty],
+      fun a b ha _ _ _ => absurd ha (Finset.not_mem_empty a)⟩
+  | succ k ih =>
+    intro cands hcard hΔ'
+    rcases cands.eq_empty_or_nonempty with rfl | ⟨v, hv⟩
+    · exact ⟨∅, Finset.Subset.refl _, by simp,
+        fun a b ha _ _ _ => absurd ha (Finset.not_mem_empty a)⟩
+    · -- Greedily pick v; let removed = N[v] ∩ cands, cands' = cands \ removed
+      let removed := insert v (G.neighborFinset v ∩ cands)
+      let cands' := cands \ removed
+      -- removed ⊆ cands (v ∈ cands; G.neighborFinset v ∩ cands ⊆ cands)
+      have hremoved_sub : removed ⊆ cands :=
+        Finset.insert_subset_iff.mpr ⟨hv, Finset.inter_subset_right⟩
+      -- cands'.card + removed.card = cands.card
+      have hcard_eq : cands'.card + removed.card = cands.card := by
+        -- Finset.card_sdiff : (s \ t).card = s.card - (t ∩ s).card (no subset hypothesis)
+        have h1 : cands'.card = cands.card - (removed ∩ cands).card := Finset.card_sdiff
+        have h2 : removed ∩ cands = removed := Finset.inter_eq_left.mpr hremoved_sub
+        have h3 : removed.card ≤ cands.card := Finset.card_le_card hremoved_sub
+        rw [h2] at h1; omega
+      -- removed.card ≥ 1 (contains v) so cands'.card ≤ k
+      have hremoved_pos : 1 ≤ removed.card :=
+        Finset.card_pos.mpr ⟨v, Finset.mem_insert_self v _⟩
+      have hcands'_le : cands'.card ≤ k := by omega
+      -- |removed| ≤ Δ + 1 (v plus at most Δ neighbors in cands)
+      have hremoved_card : removed.card ≤ Δ + 1 :=
+        (Finset.card_insert_le v _).trans (Nat.add_le_add_right (hΔ' v) 1)
+      -- Degree bound restricts to cands' (cands' ⊆ cands)
+      have hΔ'' : ∀ u : Fin n, (G.neighborFinset u ∩ cands').card ≤ Δ :=
+        fun u => (Finset.card_le_card (fun x hx =>
+          Finset.mem_inter.mpr ⟨(Finset.mem_inter.mp hx).1,
+            Finset.sdiff_subset (Finset.mem_inter.mp hx).2⟩)).trans (hΔ' u)
+      obtain ⟨S', hS'_sub, hS'_size, hS'_indep⟩ := ih cands' hcands'_le hΔ''
+      -- v ∉ S' (S' ⊆ cands', v ∉ cands' since v ∈ removed)
+      have hv_not_S' : v ∉ S' :=
+        fun h => (Finset.mem_sdiff.mp (hS'_sub h)).2 (Finset.mem_insert_self v _)
+      refine ⟨insert v S', ?_, ?_, ?_⟩
+      · -- insert v S' ⊆ cands
+        intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx'
+        · exact hv
+        · exact Finset.sdiff_subset (hS'_sub hx')
+      · -- cands.card ≤ (S'.card + 1) * (Δ + 1)
+        rw [Finset.card_insert_of_notMem hv_not_S', add_mul, one_mul]
+        linarith [hS'_size, hremoved_card]
+      · -- independence of insert v S'
+        intro a b ha hb hab hAdj
+        rcases Finset.mem_insert.mp ha with rfl | ha'
+        · rcases Finset.mem_insert.mp hb with rfl | hb'
+          · exact hab rfl
+          · -- a = v, b ∈ S' ⊆ cands'; show b ∉ removed via ¬(G.Adj v b)
+            have hb_mem := hS'_sub hb'
+            have hb_not_rem : b ∉ removed := (Finset.mem_sdiff.mp hb_mem).2
+            apply hb_not_rem
+            apply Finset.mem_insert.mpr; right
+            apply Finset.mem_inter.mpr
+            exact ⟨by rwa [SimpleGraph.mem_neighborFinset], (Finset.mem_sdiff.mp hb_mem).1⟩
+        · rcases Finset.mem_insert.mp hb with rfl | hb'
+          · -- b = v, a ∈ S' ⊆ cands'; show a ∉ removed via ¬(G.Adj v a)
+            have ha_mem := hS'_sub ha'
+            have ha_not_rem : a ∉ removed := (Finset.mem_sdiff.mp ha_mem).2
+            apply ha_not_rem
+            apply Finset.mem_insert.mpr; right
+            apply Finset.mem_inter.mpr
+            exact ⟨by rw [SimpleGraph.mem_neighborFinset]; exact G.symm hAdj,
+                   (Finset.mem_sdiff.mp ha_mem).1⟩
+          · exact hS'_indep a b ha' hb' hab hAdj
+
+/-- Greedy lower bound: if all vertex degrees ≤ Δ, then α(G) ≥ ⌈n/(Δ+1)⌉. -/
 private theorem indep_from_bounded_deg {n : ℕ} (G : GraphOnInterval n) [DecidableRel G.Adj]
     (Δ : ℕ) (hΔ : ∀ v : Fin n, (G.neighborFinset v).card ≤ Δ) :
     ∃ S : Finset (Fin n), n ≤ S.card * (Δ + 1) ∧
       ∀ a b : Fin n, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b := by
-  sorry  -- HARD: greedy independent set by induction on remaining vertex set
+  have hΔ' : ∀ v : Fin n, (G.neighborFinset v ∩ Finset.univ).card ≤ Δ := by
+    intro v; rw [Finset.inter_univ]; exact hΔ v
+  obtain ⟨S, _, hS_size, hS_indep⟩ := greedy_indep_of_bounded_deg G Δ Finset.univ hΔ'
+  simp only [Finset.card_univ, Fintype.card_fin] at hS_size
+  exact ⟨S, hS_size, hS_indep⟩
 
 /-- Every triangle-free graph on n vertices has an independent set of size ≥ √n.
     Proof:

--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -122,7 +122,7 @@ theorem hajnal_k2_gives_additive_triple {n : ℕ} (G : GraphOnInterval n)
   have hbd_val : b.val ≠ d.val := by simp [d]; omega
   -- The image of {a,b} under (·.val) equals {a.val, b.val}
   have hbase_eq : (({a, b} : Finset (Fin n)).image (·.val)) = ({a.val, b.val} : Finset ℕ) := by
-    ext x; simp [Fin.ext_iff]; tauto
+    simp [Finset.image_insert, Finset.image_singleton]
   rw [hbase_eq] at hindep
   -- Each of a, b, d has its .val in the hindmanSet
   have ha_in : a.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ) := hindmanSet_pair_left _ _

--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -65,14 +65,14 @@ theorem hindmanSet_pair_left (a b : ℕ) : a ∈ hindmanSet ({a, b} : Finset ℕ
   hindmanSet_mem_self a _ (Finset.mem_insert_self a _)
 
 /-- Right element of a 2-element base is in its hindmanSet -/
-theorem hindmanSet_pair_right (a b : ℕ) (hab : a ≠ b) : b ∈ hindmanSet ({a, b} : Finset ℕ) :=
+theorem hindmanSet_pair_right (a b : ℕ) : b ∈ hindmanSet ({a, b} : Finset ℕ) :=
   hindmanSet_mem_self b _ (by simp)
 
 /-- The sum a+b is in hindmanSet({a,b}) for distinct a ≠ b -/
 theorem hindmanSet_pair_sum (a b : ℕ) (hab : a ≠ b) :
     a + b ∈ hindmanSet ({a, b} : Finset ℕ) :=
   ⟨({a, b} : Finset ℕ),
-   le_refl _,
+   fun _ h => h,
    ⟨a, Finset.mem_insert_self a _⟩,
    by rw [Finset.sum_pair hab]; rfl⟩
 
@@ -115,7 +115,7 @@ theorem hajnal_k2_gives_additive_triple {n : ℕ} (G : GraphOnInterval n)
   -- Each of a, b, d has its .val in the hindmanSet
   have ha_in : a.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ) := hindmanSet_pair_left _ _
   have hb_in : b.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ) :=
-    hindmanSet_pair_right _ _ hab_val
+    hindmanSet_pair_right _ _
   have hd_in : d.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ) := by
     show a.val + b.val ∈ hindmanSet ({a.val, b.val} : Finset ℕ)
     exact hindmanSet_pair_sum _ _ hab_val

--- a/research/problems/erdos-895-oq-01/knowledge.md
+++ b/research/problems/erdos-895-oq-01/knowledge.md
@@ -1,0 +1,43 @@
+# Hajnal's Independent Hindman Set Conjecture (erdos-895-oq-01)
+
+## Problem Summary
+
+Hajnal's generalization of Erdős #895: for n ≥ N, every triangle-free graph on {1,...,n}
+contains an independent Hindman set — a base B with |B| ≥ 2 such that all finite nonempty
+sub-sums of B form a mutually non-adjacent set in G.
+
+**Status**: OPEN (unsolved as of 2026). The k=2 base case is Barber's 2015 result (parent).
+
+---
+
+## Session 2026-05-06 (Session 1) — Gallery Entry + Hajnal Formalization
+
+**Mode**: FRESH
+**Outcome**: Progress — created gallery entry, new Lean file, PR #16112 open
+
+### What I Did
+- Created `proofs/Proofs/Erdos895OQ01Problem.lean` with:
+  - `hindmanSet_mem_self`, `hindmanSet_mono`, `hindmanSet_pair_left`, `hindmanSet_pair_right`, `hindmanSet_pair_sum` (all proved)
+  - `hajnalConjecture` (defined + axiomatized)
+  - `hajnal_k2_gives_additive_triple`: proved — Hajnal k=2 base {a,b} with a+b<n → independent additive triple
+  - `triangleFree_indep_high_deg`: proved (Case 1 of α≥√n)
+  - `triangleFree_independence_bound`: proved with 1 HARD sorry for greedy case
+- Created gallery entry `src/data/proofs/erdos-895-oq-01/meta.json` (axiomatized, 1 axiom)
+- Submitted PR #16112
+
+### Key Findings
+- `hajnal_k2_gives_additive_triple` is the key formal reduction: k=2 Hajnal → Erdős-Barber
+- `triangleFree_indep_high_deg` (Case 1 of α≥√n) is fully proved via N(v) independence
+- `Nat.sqrt_le' n : Nat.sqrt n ^ 2 ≤ n` exists in Mathlib (found in Erdos840Aristotle.lean)
+- `Finset.sum_pair` exists and is widely used in the codebase
+- PR #16105 from researcher-9 handles fixes to Erdos895Problem.lean (no conflict)
+
+### Files Modified
+- `proofs/Proofs/Erdos895OQ01Problem.lean` (new, 185 lines after fixes)
+- `src/data/proofs/erdos-895-oq-01/meta.json` (new gallery entry)
+- `src/data/research/problems/erdos-895-oq-01.json` (knowledge updated)
+
+### Next Steps
+- Wait for PR #16112 Docker build result; fix any Lean errors
+- Submit `indep_from_bounded_deg` sorry to Aristotle (HARD: greedy independence bound)
+- Monitor PR #16105 — when merged, Erdos895Problem.lean will be updated

--- a/research/problems/erdos-895-oq-01/knowledge.md
+++ b/research/problems/erdos-895-oq-01/knowledge.md
@@ -1,43 +1,168 @@
-# Hajnal's Independent Hindman Set Conjecture (erdos-895-oq-01)
+# Erdős #895 OQ-01: Hajnal's Triangle-Free Independent Hindman Set Conjecture
+
+**Problem**: Do large triangle-free graphs always contain an independent Hindman set?
+**Status**: OPEN — Hajnal conjecture is unsolved. Working on support infrastructure.
+**Gallery entry**: `erdos-895` (parent), `Erdos895Problem.lean`
 
 ## Problem Summary
 
-Hajnal's generalization of Erdős #895: for n ≥ N, every triangle-free graph on {1,...,n}
-contains an independent Hindman set — a base B with |B| ≥ 2 such that all finite nonempty
-sub-sums of B form a mutually non-adjacent set in G.
+The Hajnal conjecture asks: for sufficiently large n, every triangle-free graph on {1,...,n}
+contains an independent set that forms a Hindman set (all finite sums of some base set).
+The parent Erdős problem #895 (Barber 2015) shows such graphs always have an independent
+additive triple (a, b, a+b); this generalizes to Hindman sets.
 
-**Status**: OPEN (unsolved as of 2026). The k=2 base case is Barber's 2015 result (parent).
+Main file: `Erdos895Problem.lean` — 3 sorries remain (schur_2 proved in Session 5). `Erdos895OQ01Problem.lean` at 0 sorries, awaiting gallery entry + PR.
 
----
+## Session 2026-05-06 (Session 5) — Fix schurNumber definition + prove schur_2
 
-## Session 2026-05-06 (Session 1) — Gallery Entry + Hajnal Formalization
-
-**Mode**: FRESH
-**Outcome**: Progress — created gallery entry, new Lean file, PR #16112 open
+**Mode**: FRESH (re-claim)
+**Outcome**: progress — schur_2 proved, PR #16121 submitted
 
 ### What I Did
-- Created `proofs/Proofs/Erdos895OQ01Problem.lean` with:
-  - `hindmanSet_mem_self`, `hindmanSet_mono`, `hindmanSet_pair_left`, `hindmanSet_pair_right`, `hindmanSet_pair_sum` (all proved)
-  - `hajnalConjecture` (defined + axiomatized)
-  - `hajnal_k2_gives_additive_triple`: proved — Hajnal k=2 base {a,b} with a+b<n → independent additive triple
-  - `triangleFree_indep_high_deg`: proved (Case 1 of α≥√n)
-  - `triangleFree_independence_bound`: proved with 1 HARD sorry for greedy case
-- Created gallery entry `src/data/proofs/erdos-895-oq-01/meta.json` (axiomatized, 1 axiom)
-- Submitted PR #16112
+
+- Identified root cause of `schur_2` unprovability: the `schurNumber` definition allowed
+  `a = b = 0`, making `¬(c 0 = c 0 ∧ c 0 = c 0)` = False for all colorings → set empty → sSup = 0.
+- Fixed definition: added `1 ≤ a → 1 ≤ b →` constraints.
+- Proved `schur_2 : schurNumber 2 = 4` via:
+  - `schur_4_colorable` (native_decide, 32 cases): coloring 1→0, 2→1, 3→1, 4→0 works for n=4
+  - `schur_5_forced` (native_decide, 64 cases): every 2-coloring of {1,...,5} has a mono triple
+  - sSup argument: `hSle4` (any n ≥ 5 → 5 ∈ S → contradiction) + `hmem4` → sSup = 4
+- Docker build verified: build completed successfully (7743 jobs)
+- PR #16121 submitted
 
 ### Key Findings
-- `hajnal_k2_gives_additive_triple` is the key formal reduction: k=2 Hajnal → Erdős-Barber
-- `triangleFree_indep_high_deg` (Case 1 of α≥√n) is fully proved via N(v) independence
-- `Nat.sqrt_le' n : Nat.sqrt n ^ 2 ≤ n` exists in Mathlib (found in Erdos840Aristotle.lean)
-- `Finset.sum_pair` exists and is widely used in the codebase
-- PR #16105 from researcher-9 handles fixes to Erdos895Problem.lean (no conflict)
+- Definition bug: `a ≤ n → b ≤ n → a + b ≤ n` WITHOUT `1 ≤ a → 1 ≤ b →` means a=b=0 always satisfies, making set empty
+- `native_decide` is ideal for small finite Schur number checks (2^5=32 and 2^6=64 cases)
+- sSup proof pattern: show 4 ∈ S, show 5 ∉ S, prove downward closure, conclude sSup = 4
+- `dif_pos` rewrites `if h : P then f h else g` → `f ha` when `ha : P`
 
 ### Files Modified
-- `proofs/Proofs/Erdos895OQ01Problem.lean` (new, 185 lines after fixes)
-- `src/data/proofs/erdos-895-oq-01/meta.json` (new gallery entry)
-- `src/data/research/problems/erdos-895-oq-01.json` (knowledge updated)
+- `proofs/Proofs/Erdos895Problem.lean`: +55 lines (definition fix + 2 private lemmas + proof)
+- PR: #16121
+
+### Remaining Sorries in Erdos895Problem.lean (3)
+- `barber_theorem`: SAT-based (Barber 2015), BLOCKED
+- `counterexample_17`: explicit n=17 construction needed, BLOCKED
+- `erdos895_sat_verified`: computational over Fin 100, BLOCKED
 
 ### Next Steps
-- Wait for PR #16112 Docker build result; fix any Lean errors
-- Submit `indep_from_bounded_deg` sorry to Aristotle (HARD: greedy independence bound)
-- Monitor PR #16105 — when merged, Erdos895Problem.lean will be updated
+- `Erdos895OQ01Problem.lean` (265 lines, 0 sorries) needs: Docker build verification + gallery entry + PR
+- The `erdos-895-oq-01` pool entry should be moved to `completed` once gallery entry is created
+
+## Session 2026-05-06 (Session 4) — Greedy Independence Bound (eliminates last sorry)
+
+**Mode**: FRESH (re-claim from available pool)
+**Outcome**: completed — 0 sorries remaining in OQ01 file
+
+### What I Did
+
+Proved `greedy_indep_of_bounded_deg` by induction on Finset cardinality:
+- Strategy: pick v ∈ candidates, remove v ∪ (N(v) ∩ candidates) from working set
+- `removed ⊆ cands` established first; then `cands'.card + removed.card = cands.card`
+  via `Finset.card_sdiff hremoved_sub` + omega
+- Since `removed.card ≥ 1` (contains v), `cands'.card ≤ k` follows by omega
+- `|removed| ≤ Δ + 1`: via `Finset.card_insert_le` + adjacency bound
+- Independence of `insert v S'`: b ∈ S' ⊆ cands' = cands \ removed →
+  b ∉ N(v) ∩ cands → ¬G.Adj v b; symmetry via `G.symm`
+
+The `indep_from_bounded_deg` wrapper applies the helper with `candidates = Finset.univ`
+and uses `Finset.card_univ` / `simpa` to get the `n ≤ S.card * (Δ+1)` conclusion.
+
+`triangleFree_independence_bound` was already complete (no sorries).
+
+### Files Modified
+- `proofs/Proofs/Erdos895OQ01Problem.lean`: replaced sorry with 80-line proof (+67 lines)
+- `src/data/proofs/erdos-895-oq-01/meta.json`: sorries 1→0, lineCount 198→265
+
+### Next Steps
+- Docker build pending; PR to be created after verification
+- OQ01 file now: 0 sorries, 1 axiom (hajnal_conjecture — open problem)
+
+## Session 2026-05-06 (Session 3) — Dense Independence via Max-Degree Vertex
+
+**Mode**: FRESH (re-claim)
+**Outcome**: progress — 1 sorry proved
+
+### What I Did
+
+Proved `dense_triangleFree_independence`: triangle-free graphs with ≥ n²/5 edges
+have an independent set of size ≥ n/3. PR #16114.
+
+**Proof strategy**: max-degree vertex v has deg(v) ≥ n/3.
+- Handshake: n·deg(v) ≥ Σdeg = 2|E| ≥ 2·(n²/5)
+- Key chain (n ≥ 5): (n/3)·n·15 ≤ 5n² ≤ 6n²-24 ≤ 30·(n²/5) ≤ deg(v)·n·15
+- For n < 5: handled by `interval_cases n <;> omega` using density constraint
+- N(v) is independent by triangle-freeness: ¬(G.Adj a b) for a,b ∈ N(v) since that would form a triangle with v
+
+**Key API used**: `Finset.exists_max_image`, `SimpleGraph.sum_degrees_eq_twice_card_edges`,
+`SimpleGraph.card_neighborFinset_eq_degree`, `SimpleGraph.mem_neighborFinset`
+
+### Files Modified
+- `proofs/Proofs/Erdos895Problem.lean`: +46 lines
+- PR: #16114
+
+### Remaining Sorries (4)
+- `barber_theorem`: SAT-based (Barber 2015), BLOCKED
+- `counterexample_17`: needs explicit n=17 construction, BLOCKED
+- `schur_2`: definition uses sSup (noncomputable), hard; also possible definition bug (a,b=0)
+- `erdos895_sat_verified`: computational over Fin 100, BLOCKED
+
+## Session 2026-05-06 (Session 2) — Independence Bound + Schur Variant
+
+**Mode**: FRESH (re-claim from available pool)
+**Outcome**: progress — 2 sorries proved
+
+### What I Did
+
+1. **Proved `erdos895_implies_schur_variant`**: The theorem is stated with a disjunction
+   where the left side only needs `c a = c b` (no distinctness of a,b). The triple
+   (a=b=1, d=2) trivially satisfies this since c(1) = c(1) by rfl.
+   Note: the statement is weaker than expected — allows a=b in the triple.
+
+2. **Proved `triangleFree_independence_bound`** (√n independence lower bound):
+   - Added private helper `exists_large_indep_of_bounded_degree` via `Finset.strongInduction`
+   - Case 1: Some vertex with degree ≥ √n → N(v) is independent (triangle-free property)
+   - Case 2: All degrees < √n → greedy algorithm: pick v, remove {v} ∪ N_S(v) (≤ √n verts),
+     recurse on S'. Gives |I|·√n ≥ n, so |I| ≥ √n since (√n)² ≤ n.
+   - Key API: `Nat.sqrt_lt'` for the (√n)² ≤ n derivation (by contradiction)
+
+3. **Discovered `schur_2` definition bug**: The `schurNumber` definition allows a=b=0,
+   making the sSup set always empty (0+0=0 gives monochromatic triple with any coloring).
+   So as written, `schurNumber 2 = 0`, not 4. The definition needs a,b ≥ 1 constraint.
+
+### Files Modified
+- `proofs/Proofs/Erdos895Problem.lean`: +108 lines (helper lemma + 2 proofs)
+- PR: #16105
+
+### Key Findings
+
+- `triangleFree_independence_bound`: proved with greedy + max-degree case split
+- `erdos895_implies_schur_variant`: trivially true (degenerate a=b case); statement is weak
+- `schur_2`: unprovable as stated — definition has a,b=0 bug
+- Docker unavailable during session; build verification pending in CI
+
+### Remaining Sorries (5)
+- `barber_theorem`: SAT-based (Barber 2015), blocked
+- `counterexample_17`: SAT-constructed graph on Fin 17, blocked
+- `schur_2`: definition bug makes it false as stated
+- `dense_triangleFree_independence`: density + independence argument, significant work
+- `erdos895_sat_verified`: computational over Fin 100, blocked
+
+### Next Steps
+- Fix `schurNumber` definition (add a, b ≥ 1 constraint) — then `schur_2` becomes provable
+- `dense_triangleFree_independence`: the density bound + greedy should give n/3 independent set
+- Consider filing an issue about the `schur_2` definition bug
+
+## Session 2026-05-04 (Session 1) — Aristotle Companion Lemmas
+
+**Mode**: FRESH
+**Outcome**: progress — 3 Aristotle companion sorries proved
+
+### What Was Done
+
+Proved supporting lemmas for the Aristotle companion file:
+- `triangleFree_neighbor_disjoint`: N(u) ∩ N(v) = ∅ for adjacent u,v in triangle-free G
+- `triangleFree_degree_sum_bound`: deg(u) + deg(v) ≤ n for adjacent u,v
+- `mantel_theorem`: triangle-free graph has ≤ n²/4 edges (via CliqueFree.card_edgeFinset_le)
+
+Main `barber_theorem` confirmed blocked (SAT-based, Barber 2015 via external tool).

--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "erdos-895-oq-01",
+  "title": "Hajnal's Independent Hindman Set Conjecture",
+  "slug": "erdos-895-oq-01",
+  "description": "Hajnal's open generalization of Erdős #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set — a base B with all finite sub-sums forming a mutually non-adjacent set.",
+  "meta": {
+    "author": "Erdős-Hajnal (conjectured)",
+    "sourceUrl": "https://erdosproblems.com/895",
+    "date": "1995",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos895OQ01Problem.lean",
+    "tags": [
+      "erdos",
+      "open-problem",
+      "graph-theory",
+      "additive-combinatorics",
+      "hindman-theory",
+      "triangle-free",
+      "ramsey-theory"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 1,
+    "erdosNumber": 895,
+    "erdosUrl": "https://erdosproblems.com/895",
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph",
+        "description": "Simple graph structure",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "Finset",
+        "description": "Finite sets and sums",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.sqrt",
+        "description": "Integer square root for independence bound",
+        "module": "Mathlib.Data.Nat.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "Formal definition of hindmanSet as all finite nonempty sub-sums of a base",
+      "Monotonicity and structural lemmas for hindmanSet (sorry-free)",
+      "Axiomatization of Hajnal's conjecture as an open problem",
+      "Proof that Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple",
+      "Proved Case 1 of α(G) ≥ √n bound: high-degree vertex N(v) is independent",
+      "Proof structure for α(G) ≥ √n via case split (1 HARD sorry for greedy algorithm)"
+    ],
+    "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 1 sorry: greedy independent set construction (HARD, to be proved by induction).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 6,
+    "lineCount": 198
+  },
+  "overview": {
+    "historicalContext": "**Hajnal's Generalization of Erdős Problem #895**\n\nThe parent problem, Erdős #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by András Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** — a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting — a fundamentally different kind of constraint.",
+    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ — proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
+    "text": "Hajnal's open generalization of Erdős #895: does every large triangle-free graph contain an independent Hindman set?",
+    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base → independent additive triple\n5. Proves `triangleFree_independence_bound` (α ≥ √n) with one HARD sorry for the greedy case",
+    "keyInsights": [
+      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erdős #895 — the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements.",
+      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erdős-Barber structure.",
+      "**Independence number bound:** Triangle-free graphs satisfy α(G) ≥ √n. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
+      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent — giving exactly the Erdős-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
+      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k≥3 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics."
+    ],
+    "prerequisites": [
+      "Graph theory: triangle-free graphs, independent sets, neighborhood sets",
+      "Additive combinatorics: sumsets, Schur triples, Hindman sets",
+      "Ramsey theory: R(3,3)=6, triangle-free graph structure",
+      "Parent result: Erdős #895 (Barber 2015)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "hindman-structure",
+      "title": "Hindman Set Structure",
+      "summary": "Monotonicity, pair membership, and singleton characterization of hindmanSet",
+      "startLine": 58,
+      "endLine": 100,
+      "mathContext": "Pure combinatorial lemmas about finite sums of base sets"
+    },
+    {
+      "id": "hajnal-conjecture",
+      "title": "Hajnal's Conjecture",
+      "summary": "Formal statement and axiomatization of the open conjecture",
+      "startLine": 103,
+      "endLine": 125,
+      "mathContext": "Open problem: axiom hajnal_conjecture states the conjecture"
+    },
+    {
+      "id": "k2-reduction",
+      "title": "The k=2 Reduction",
+      "summary": "Hajnal k=2 base {a,b} with a+b < n gives an independent additive triple",
+      "startLine": 128,
+      "endLine": 172,
+      "mathContext": "Key theorem connecting Hajnal to Erdős-Barber; uses hindmanSet_pair_sum"
+    },
+    {
+      "id": "independence-bound",
+      "title": "Independence Number Bound",
+      "summary": "Every triangle-free graph has α(G) ≥ √n",
+      "startLine": 175,
+      "endLine": 198,
+      "mathContext": "Case 1 (proved): high-degree vertex N(v) independent; Case 2 (1 HARD sorry): greedy algorithm"
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "hajnal-k3",
+      "title": "Hajnal conjecture for k=3",
+      "question": "Does every triangle-free graph on {1,...,n} for large n contain an independent FS({a,b,c}) = {a,b,c,a+b,a+c,b+c,a+b+c}?",
+      "difficulty": "open",
+      "notes": "The k=2 case follows from Barber. For k=3, the 7 elements of FS({a,b,c}) must all fit in {1,...,n} and be mutually non-adjacent."
+    },
+    {
+      "id": "greedy-independence",
+      "title": "Greedy independence number bound",
+      "question": "Can the HARD sorry in indep_from_bounded_deg be closed? Prove α(G) ≥ n/(Δ+1) for max-degree-Δ graphs by induction on vertex count.",
+      "difficulty": "hard",
+      "notes": "Standard textbook result; requires well-founded induction on the vertex removal greedy algorithm."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/Erdos895OQ01Problem.lean",
+    "lineCount": 198,
+    "theoremCount": 11,
+    "definitionCount": 6,
+    "axiomCount": 1,
+    "sorries": 1,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos895OQ01Problem.lean"
+  }
+}

--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-895-oq-01",
   "title": "Hajnal's Independent Hindman Set Conjecture",
   "slug": "erdos-895-oq-01",
-  "description": "Hajnal's open generalization of Erdős #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set — a base B with all finite sub-sums forming a mutually non-adjacent set.",
+  "description": "Hajnal's open generalization of Erd\u0151s #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set \u2014 a base B with all finite sub-sums forming a mutually non-adjacent set.",
   "meta": {
-    "author": "Erdős-Hajnal (conjectured)",
+    "author": "Erd\u0151s-Hajnal (conjectured)",
     "sourceUrl": "https://erdosproblems.com/895",
     "date": "1995",
     "status": "axiomatized",
@@ -19,7 +19,7 @@
       "ramsey-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 1,
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",
@@ -46,32 +46,32 @@
       "Monotonicity and structural lemmas for hindmanSet (sorry-free)",
       "Axiomatization of Hajnal's conjecture as an open problem",
       "Proof that Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple",
-      "Proved Case 1 of α(G) ≥ √n bound: high-degree vertex N(v) is independent",
-      "Proof structure for α(G) ≥ √n via case split (1 HARD sorry for greedy algorithm)"
+      "Proved Case 1 of \u03b1(G) \u2265 \u221an bound: high-degree vertex N(v) is independent",
+      "Proof structure for \u03b1(G) \u2265 \u221an via case split (1 HARD sorry for greedy algorithm)"
     ],
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 1 sorry: greedy independent set construction (HARD, to be proved by induction).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 6,
-    "lineCount": 198
+    "lineCount": 265
   },
   "overview": {
-    "historicalContext": "**Hajnal's Generalization of Erdős Problem #895**\n\nThe parent problem, Erdős #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by András Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** — a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting — a fundamentally different kind of constraint.",
-    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ — proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
-    "text": "Hajnal's open generalization of Erdős #895: does every large triangle-free graph contain an independent Hindman set?",
-    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base → independent additive triple\n5. Proves `triangleFree_independence_bound` (α ≥ √n) with one HARD sorry for the greedy case",
+    "historicalContext": "**Hajnal's Generalization of Erd\u0151s Problem #895**\n\nThe parent problem, Erd\u0151s #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by Andr\u00e1s Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** \u2014 a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting \u2014 a fundamentally different kind of constraint.",
+    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ \u2014 proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
+    "text": "Hajnal's open generalization of Erd\u0151s #895: does every large triangle-free graph contain an independent Hindman set?",
+    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base \u2192 independent additive triple\n5. Proves `triangleFree_independence_bound` (\u03b1 \u2265 \u221an) with one HARD sorry for the greedy case",
     "keyInsights": [
-      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erdős #895 — the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements.",
-      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erdős-Barber structure.",
-      "**Independence number bound:** Triangle-free graphs satisfy α(G) ≥ √n. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
-      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent — giving exactly the Erdős-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
-      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k≥3 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics."
+      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erd\u0151s #895 \u2014 the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements.",
+      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erd\u0151s-Barber structure.",
+      "**Independence number bound:** Triangle-free graphs satisfy \u03b1(G) \u2265 \u221an. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
+      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent \u2014 giving exactly the Erd\u0151s-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
+      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k\u22653 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics."
     ],
     "prerequisites": [
       "Graph theory: triangle-free graphs, independent sets, neighborhood sets",
       "Additive combinatorics: sumsets, Schur triples, Hindman sets",
       "Ramsey theory: R(3,3)=6, triangle-free graph structure",
-      "Parent result: Erdős #895 (Barber 2015)"
+      "Parent result: Erd\u0151s #895 (Barber 2015)"
     ]
   },
   "sections": [
@@ -97,12 +97,12 @@
       "summary": "Hajnal k=2 base {a,b} with a+b < n gives an independent additive triple",
       "startLine": 128,
       "endLine": 172,
-      "mathContext": "Key theorem connecting Hajnal to Erdős-Barber; uses hindmanSet_pair_sum"
+      "mathContext": "Key theorem connecting Hajnal to Erd\u0151s-Barber; uses hindmanSet_pair_sum"
     },
     {
       "id": "independence-bound",
       "title": "Independence Number Bound",
-      "summary": "Every triangle-free graph has α(G) ≥ √n",
+      "summary": "Every triangle-free graph has \u03b1(G) \u2265 \u221an",
       "startLine": 175,
       "endLine": 198,
       "mathContext": "Case 1 (proved): high-degree vertex N(v) independent; Case 2 (1 HARD sorry): greedy algorithm"
@@ -119,18 +119,18 @@
     {
       "id": "greedy-independence",
       "title": "Greedy independence number bound",
-      "question": "Can the HARD sorry in indep_from_bounded_deg be closed? Prove α(G) ≥ n/(Δ+1) for max-degree-Δ graphs by induction on vertex count.",
+      "question": "Can the HARD sorry in indep_from_bounded_deg be closed? Prove \u03b1(G) \u2265 n/(\u0394+1) for max-degree-\u0394 graphs by induction on vertex count.",
       "difficulty": "hard",
       "notes": "Standard textbook result; requires well-founded induction on the vertex removal greedy algorithm."
     }
   ],
   "leanFile": {
     "path": "Proofs/Erdos895OQ01Problem.lean",
-    "lineCount": 198,
-    "theoremCount": 11,
+    "lineCount": 265,
+    "theoremCount": 12,
     "definitionCount": 6,
     "axiomCount": 1,
-    "sorries": 1,
+    "sorries": 0,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos895OQ01Problem.lean"
   }

--- a/src/data/research/problems/erdos-895-oq-01.json
+++ b/src/data/research/problems/erdos-895-oq-01.json
@@ -19,9 +19,9 @@
     "phase": "ACT",
     "since": "2026-05-04T17:47:35.844Z",
     "iteration": 1,
-    "focus": "PR #16112 open: gallery entry + Lean file builds clean",
+    "focus": "Supporting lemmas proved; Hajnal conjecture is open",
     "blockers": [],
-    "nextAction": "Merge PR #16112 and submit indep_from_bounded_deg to Aristotle",
+    "nextAction": "Investigate triangleFree_independence_bound or Hajnal conjecture approaches",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,28 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: PR #16112 merged-pending. Gallery entry created (axiomatized, 1 axiom). Erdos895OQ01Problem.lean builds successfully (7743 jobs, 1 expected HARD sorry for greedy algorithm).",
+    "progressSummary": "PROGRESS: Proved 3 Aristotle lemmas (triangleFree_neighbor_disjoint, triangleFree_degree_sum_bound, mantel_theorem). Aristotle file now 0 sorries. Main file barber_theorem blocked (SAT-based).",
     "builtItems": [
       "Erdos895ProblemAristotle.lean:67 triangleFree_neighbor_disjoint \u2014 0 sorries",
       "Erdos895ProblemAristotle.lean:80 triangleFree_degree_sum_bound \u2014 0 sorries",
-      "Erdos895ProblemAristotle.lean:100 mantel_theorem \u2014 0 sorries",
-      "Erdos895OQ01Problem.lean: 6 hindmanSet structural lemmas (sorry-free)",
-      "Erdos895OQ01Problem.lean: hajnal_k2_gives_additive_triple \u2014 reduces k=2 Hajnal to independent additive triple",
-      "Erdos895OQ01Problem.lean: triangleFree_independence_bound \u2014 \u03b1(G)\u2265\u221an with 1 HARD sorry for greedy case",
-      "src/data/proofs/erdos-895-oq-01/meta.json \u2014 gallery entry created (status: axiomatized, 1 axiom)"
+      "Erdos895ProblemAristotle.lean:100 mantel_theorem \u2014 0 sorries"
     ],
     "insights": [
       "triangleFree_neighbor_disjoint proved: adjacent vertices in triangle-free graph have disjoint neighborhoods, via Finset.disjoint_left + G.symm",
       "triangleFree_degree_sum_bound proved: deg(u)+deg(v) \u2264 n for adjacent u,v, via card_union_of_disjoint + Finset.subset_univ + card_fin",
-      "mantel_theorem proved in Aristotle file: IsTriangleFree \u2192 CliqueFree 3 \u2192 CliqueFree.card_edgeFinset_le gives n\u00b2/4 edge bound; mirrors proof pattern in Erdos895Problem.lean",
-      "hajnal_k2_gives_additive_triple proved: if Hajnal base {a,b} has a+b < n, then a,b,a+b form independent additive triple; key reduction showing k=2 Hajnal \u2192 Erd\u0151s-Barber",
-      "triangleFree_indep_high_deg proved: if any vertex has deg \u2265 \u221an, its neighborhood is independent of size \u2265 \u221an (Case 1 of \u03b1(G)\u2265\u221an bound)"
+      "mantel_theorem proved in Aristotle file: IsTriangleFree \u2192 CliqueFree 3 \u2192 CliqueFree.card_edgeFinset_le gives n\u00b2/4 edge bound; mirrors proof pattern in Erdos895Problem.lean"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Close greedy sorry in indep_from_bounded_deg via Aristotle submission",
-      "Submit PR for new gallery entry + Erdos895OQ01Problem.lean",
-      "Check if PR #16105 is merged before deciding whether to close erdos895_implies_schur_variant"
+      "Main barber_theorem and counterexample_17 require SAT-based proof \u2014 blocked without external tool",
+      "triangleFree_independence_bound (\u221an independent set) could be proved via Ramsey/greedy but requires significant Mathlib API work",
+      "Hajnal conjecture (Hindman sets in triangle-free graphs) remains open \u2014 no known Lean formalization path"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-895-oq-01.json
+++ b/src/data/research/problems/erdos-895-oq-01.json
@@ -19,9 +19,9 @@
     "phase": "ACT",
     "since": "2026-05-04T17:47:35.844Z",
     "iteration": 1,
-    "focus": "Supporting lemmas proved; Hajnal conjecture is open",
+    "focus": "PR #16112 open: gallery entry + Lean file builds clean",
     "blockers": [],
-    "nextAction": "Investigate triangleFree_independence_bound or Hajnal conjecture approaches",
+    "nextAction": "Merge PR #16112 and submit indep_from_bounded_deg to Aristotle",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created gallery entry for erdos-895-oq-01 (axiomatized). Added Erdos895OQ01Problem.lean with hindmanSet lemmas + hajnal_k2_gives_additive_triple + \u03b1(G)\u2265\u221an proof structure (1 HARD greedy sorry remains)",
+    "progressSummary": "PROGRESS: PR #16112 merged-pending. Gallery entry created (axiomatized, 1 axiom). Erdos895OQ01Problem.lean builds successfully (7743 jobs, 1 expected HARD sorry for greedy algorithm).",
     "builtItems": [
       "Erdos895ProblemAristotle.lean:67 triangleFree_neighbor_disjoint \u2014 0 sorries",
       "Erdos895ProblemAristotle.lean:80 triangleFree_degree_sum_bound \u2014 0 sorries",

--- a/src/data/research/problems/erdos-895-oq-01.json
+++ b/src/data/research/problems/erdos-895-oq-01.json
@@ -29,22 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 3 Aristotle lemmas (triangleFree_neighbor_disjoint, triangleFree_degree_sum_bound, mantel_theorem). Aristotle file now 0 sorries. Main file barber_theorem blocked (SAT-based).",
+    "progressSummary": "PROGRESS: Created gallery entry for erdos-895-oq-01 (axiomatized). Added Erdos895OQ01Problem.lean with hindmanSet lemmas + hajnal_k2_gives_additive_triple + \u03b1(G)\u2265\u221an proof structure (1 HARD greedy sorry remains)",
     "builtItems": [
       "Erdos895ProblemAristotle.lean:67 triangleFree_neighbor_disjoint \u2014 0 sorries",
       "Erdos895ProblemAristotle.lean:80 triangleFree_degree_sum_bound \u2014 0 sorries",
-      "Erdos895ProblemAristotle.lean:100 mantel_theorem \u2014 0 sorries"
+      "Erdos895ProblemAristotle.lean:100 mantel_theorem \u2014 0 sorries",
+      "Erdos895OQ01Problem.lean: 6 hindmanSet structural lemmas (sorry-free)",
+      "Erdos895OQ01Problem.lean: hajnal_k2_gives_additive_triple \u2014 reduces k=2 Hajnal to independent additive triple",
+      "Erdos895OQ01Problem.lean: triangleFree_independence_bound \u2014 \u03b1(G)\u2265\u221an with 1 HARD sorry for greedy case",
+      "src/data/proofs/erdos-895-oq-01/meta.json \u2014 gallery entry created (status: axiomatized, 1 axiom)"
     ],
     "insights": [
       "triangleFree_neighbor_disjoint proved: adjacent vertices in triangle-free graph have disjoint neighborhoods, via Finset.disjoint_left + G.symm",
       "triangleFree_degree_sum_bound proved: deg(u)+deg(v) \u2264 n for adjacent u,v, via card_union_of_disjoint + Finset.subset_univ + card_fin",
-      "mantel_theorem proved in Aristotle file: IsTriangleFree \u2192 CliqueFree 3 \u2192 CliqueFree.card_edgeFinset_le gives n\u00b2/4 edge bound; mirrors proof pattern in Erdos895Problem.lean"
+      "mantel_theorem proved in Aristotle file: IsTriangleFree \u2192 CliqueFree 3 \u2192 CliqueFree.card_edgeFinset_le gives n\u00b2/4 edge bound; mirrors proof pattern in Erdos895Problem.lean",
+      "hajnal_k2_gives_additive_triple proved: if Hajnal base {a,b} has a+b < n, then a,b,a+b form independent additive triple; key reduction showing k=2 Hajnal \u2192 Erd\u0151s-Barber",
+      "triangleFree_indep_high_deg proved: if any vertex has deg \u2265 \u221an, its neighborhood is independent of size \u2265 \u221an (Case 1 of \u03b1(G)\u2265\u221an bound)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Main barber_theorem and counterexample_17 require SAT-based proof \u2014 blocked without external tool",
-      "triangleFree_independence_bound (\u221an independent set) could be proved via Ramsey/greedy but requires significant Mathlib API work",
-      "Hajnal conjecture (Hindman sets in triangle-free graphs) remains open \u2014 no known Lean formalization path"
+      "Close greedy sorry in indep_from_bounded_deg via Aristotle submission",
+      "Submit PR for new gallery entry + Erdos895OQ01Problem.lean",
+      "Check if PR #16105 is merged before deciding whether to close erdos895_implies_schur_variant"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Proves `greedy_indep_of_bounded_deg` (new private lemma): for any `candidates : Finset (Fin n)` with all vertex degrees ≤ Δ, there exists an independent set S ⊆ candidates with `candidates.card ≤ S.card * (Δ + 1)`.
- Fills the last sorry in `Erdos895OQ01Problem.lean`: the file now has **0 sorries**, 1 axiom (the open Hajnal conjecture), 12 theorems.
- `triangleFree_independence_bound`: every triangle-free graph on n vertices has an independent set of size ≥ √n — fully proved.

## Proof technique

Induction on `candidates.card`:
1. Pick v ∈ candidates; let `removed = {v} ∪ (N(v) ∩ candidates)`, `cands' = candidates \ removed`
2. `removed ⊆ candidates` → card identity via `Finset.card_sdiff + omega`
3. `removed.card ≥ 1` (contains v) → `cands'.card ≤ k` by omega
4. `|removed| ≤ Δ + 1` via `Finset.card_insert_le`
5. Independence of `insert v S'`: any b ∈ S' ⊆ cands' satisfies b ∉ G.neighborFinset v; symmetry via `G.symm`

## Test plan

- [x] Docker build verified: 7743 jobs, 355s, Build succeeded (deprecation warnings only)
- [x] 0 actual sorries in Erdos895OQ01Problem.lean
- [x] meta.json updated: sorries 1→0, lineCount 198→265, theoremCount 11→12

🤖 Generated with [Claude Code](https://claude.com/claude-code)