### PR TITLE
enrich(law-of-cosines-oq-01-oq-02): add 7 annotations with mathContext to Spherical Law of Sines

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-02/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-sines-overview",
+    "proofId": "law-of-cosines-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "insight",
+    "title": "The Gram Determinant Strategy",
+    "content": "The proof derives the spherical law of sines via a single symmetric intermediate quantity: the Gram determinant G = 1-cos²a-cos²b-cos²c+2cos(a)cos(b)cos(c). The key: G = sin²(A)·sin²(b)·sin²(c) and also G = sin²(B)·sin²(a)·sin²(c). Cancelling sin²(c) gives sin²(A)·sin²(b) = sin²(B)·sin²(a), from which the law of sines follows. G is never computed explicitly — it appears as a bridge.",
+    "mathContext": "The strategy: prove $G = \\sin^2 A \\cdot \\sin^2 b \\cdot \\sin^2 c$ and $G = \\sin^2 B \\cdot \\sin^2 a \\cdot \\sin^2 c$ independently, then cancel $\\sin^2 c$ to get $\\sin^2 A \\cdot \\sin^2 b = \\sin^2 B \\cdot \\sin^2 a$. Since $\\sin A, \\sin B, \\sin a, \\sin b \\geq 0$ (all in $[0,\\pi]$), the squared equality implies the linear equality $\\sin A \\cdot \\sin b = \\sin B \\cdot \\sin a$.",
+    "significance": "key",
+    "relatedConcepts": ["Gram determinant", "spherical law of sines", "law of cosines", "symmetric function"],
+    "prerequisites": ["spherical law of cosines", "Gram determinant", "non-negative square roots"]
+  },
+  {
+    "id": "ann-inner-products",
+    "proofId": "law-of-cosines-oq-01-oq-02",
+    "range": { "startLine": 42, "endLine": 90 },
+    "type": "technique",
+    "title": "Inner Products of Perpendicular Projections",
+    "content": "Section I establishes the key lemmas linking projection geometry to spherical cosines. proj_inner_eq: ⟨projB_A, projC_A⟩ = cos(a) − cos(b)cos(c), from the inner decomposition of SphericalLawOfCosines. norm_proj_BA: ‖projB_A‖ = sin(c), and similarly for other projections. These are the building blocks for expressing the Gram determinant in terms of projections.",
+    "mathContext": "The inner decomposition: $\\langle v_B, v_C \\rangle = \\langle v_B, v_A \\rangle\\langle v_C, v_A \\rangle + \\langle \\text{prj}_{v_A}^\\perp(v_B), \\text{prj}_{v_A}^\\perp(v_C)\\rangle$. Substituting arc-length cosines: $\\cos a = \\cos b \\cos c + \\langle \\text{prj}_{v_A}^\\perp(v_B), \\text{prj}_{v_A}^\\perp(v_C)\\rangle$. And $\\|\\text{prj}_{v_A}^\\perp(v_B)\\| = \\sin c$ (since the perpendicular component of a unit vector at angle $c$ has norm $\\sqrt{1-\\cos^2 c} = \\sin c$).",
+    "significance": "supporting",
+    "relatedConcepts": ["perpendicular projection", "inner product decomposition", "arc length", "sine rule"],
+    "prerequisites": ["SphericalLawOfCosines infrastructure", "inner product spaces", "perpendicular projection norms"]
+  },
+  {
+    "id": "ann-gram-det",
+    "proofId": "law-of-cosines-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 116 },
+    "type": "technique",
+    "title": "Gram Determinant: Two Representations",
+    "content": "gramDet_expand: G = sin²b·sin²c − (cos(a)−cos(b)cos(c))², proved by pure ring computation using sin²+cos²=1. gramDet_as_proj: G = ‖projB_A‖²·‖projC_A‖² − ⟨projB_A,projC_A⟩², by substituting the projection norms and inner product. gramDet_nonneg: G ≥ 0 by Cauchy-Schwarz (|⟨u,v⟩| ≤ ‖u‖·‖v‖). The ring form and the projection form are equal, giving G ≥ 0.",
+    "mathContext": "Two representations of the Gram determinant $G$: $$G = \\sin^2 b \\sin^2 c - (\\cos a - \\cos b \\cos c)^2$$ (pure algebra, by $\\sin^2 + \\cos^2 = 1$), and $$G = \\|\\text{prj}(v_B, v_A)\\|^2 \\|\\text{prj}(v_C, v_A)\\|^2 - \\langle \\text{prj}(v_B,v_A), \\text{prj}(v_C,v_A)\\rangle^2$$ (projection form). By Cauchy-Schwarz: the projection form $\\geq 0$. So $G \\geq 0$ follows from the ring computation connecting the two.",
+    "significance": "key",
+    "relatedConcepts": ["Gram determinant", "Cauchy-Schwarz inequality", "ring tactic", "nonnegativity"],
+    "prerequisites": ["Cauchy-Schwarz inequality", "Pythagorean identity", "ring tactic in Lean 4"]
+  },
+  {
+    "id": "ann-cosine-formula",
+    "proofId": "law-of-cosines-oq-01-oq-02",
+    "range": { "startLine": 117, "endLine": 215 },
+    "type": "technique",
+    "title": "Cosine Formula for Dihedral Angles",
+    "content": "Section III defines angleA and angleB (dihedral angles at vertices A and B) and proves cos(A)·sin(b)·sin(c) = cos(a)−cos(b)cos(c). The key steps: (1) arccos bounds: the argument ⟨projB_A,projC_A⟩/(‖projB_A‖·‖projC_A‖) lies in [-1,1] by Cauchy-Schwarz; (2) unfolding arccos and using cos(arccos(x)) = x; (3) substituting the projection formulas and field_simp to clear denominators.",
+    "mathContext": "The dihedral angle $A$ at vertex $v_A$: $\\cos A = \\frac{\\langle \\text{prj}(v_B,v_A), \\text{prj}(v_C,v_A)\\rangle}{\\|\\text{prj}(v_B,v_A)\\|\\|\\text{prj}(v_C,v_A)\\|} = \\frac{\\cos a - \\cos b \\cos c}{\\sin b \\sin c}$. Multiplying through: $\\cos A \\cdot \\sin b \\cdot \\sin c = \\cos a - \\cos b \\cos c$. The Lean proof uses `Real.cos_arccos` and `field_simp` to avoid working directly with the fraction.",
+    "significance": "supporting",
+    "relatedConcepts": ["dihedral angle", "arccos", "cosine formula", "Cauchy-Schwarz bounds"],
+    "prerequisites": ["arccos definition", "Cauchy-Schwarz inequality", "perpendicular projection formulas"]
+  },
+  {
+    "id": "ann-sinsin-gram",
+    "proofId": "law-of-cosines-oq-01-oq-02",
+    "range": { "startLine": 216, "endLine": 252 },
+    "type": "technique",
+    "title": "sin²(A)·sin²(b)·sin²(c) = G: The Bridge Identity",
+    "content": "sinA_sq_times_bc: sin²(A)·sin²(b)·sin²(c) = G. Proved by: sin²(A) = 1−cos²(A) (Pythagorean), then sin²(A)·sin²(b)·sin²(c) = (1−cos²A)·sin²b·sin²c = sin²b·sin²c − (cosA·sinb·sinc)² = sin²b·sin²c − (cos(a)−cos(b)cos(c))² = G. The last step uses the ring form of G from gramDet_expand. By symmetry (swapping A↔B and a↔b), sinB_sq_times_ac holds similarly.",
+    "mathContext": "The key derivation: $$\\sin^2 A \\cdot \\sin^2 b \\cdot \\sin^2 c = (1-\\cos^2 A)\\sin^2 b \\sin^2 c = \\sin^2 b\\sin^2 c - (\\cos A \\cdot \\sin b\\sin c)^2$$ $$= \\sin^2 b\\sin^2 c - (\\cos a - \\cos b\\cos c)^2 = G.$$ The substitution $\\cos A \\cdot \\sin b \\sin c = \\cos a - \\cos b\\cos c$ (from `cos_angleA`) and the ring form $G = \\sin^2 b\\sin^2 c - (\\cos a - \\cos b\\cos c)^2$ (from `gramDet_expand`) are the two key ingredients. The Lean proof uses `field_simp` + `ring` or `nlinarith`.",
+    "significance": "key",
+    "relatedConcepts": ["Gram determinant bridge", "Pythagorean identity", "cosine formula", "algebraic manipulation"],
+    "prerequisites": ["Pythagorean identity", "cosine formula for dihedral angles", "gramDet_expand"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "law-of-cosines-oq-01-oq-02",
+    "range": { "startLine": 253, "endLine": 350 },
+    "type": "technique",
+    "title": "Main Theorems: Multiplicative and Ratio Forms",
+    "content": "spherical_law_of_sines_mul: sin(a)·sin(B) = sin(b)·sin(A). Proof: cancel sin²c from the two G expressions to get sin²A·sin²b = sin²B·sin²a; then use nlinarith with squared difference ≥ 0 and non-negativity to extract the linear equality. spherical_law_of_sines: ratio form via div_eq_div_iff. spherical_law_of_sines_all: all three ratios equal by applying the pairwise result twice.",
+    "mathContext": "From $\\sin^2 A \\sin^2 b = \\sin^2 B \\sin^2 a$ and $\\sin A, \\sin B, \\sin a, \\sin b \\geq 0$: $(\\sin A \\sin b - \\sin B \\sin a)(\\sin A \\sin b + \\sin B \\sin a) = \\sin^2 A\\sin^2 b - \\sin^2 B\\sin^2 a = 0$, so either the difference or sum is 0; since both are nonneg, $\\sin A \\sin b = \\sin B \\sin a$. The Lean proof uses `nlinarith` with the squared-difference and squared-sum hints. The ratio form $\\sin a / \\sin A = \\sin b / \\sin B$ follows from `div_eq_div_iff` and the multiplicative form.",
+    "significance": "key",
+    "relatedConcepts": ["spherical law of sines", "multiplicative form", "ratio form", "nlinarith"],
+    "prerequisites": ["sin² bridge identity", "nonnegativity of sines", "div_eq_div_iff"]
+  },
+  {
+    "id": "ann-equilateral",
+    "proofId": "law-of-cosines-oq-01-oq-02",
+    "range": { "startLine": 354, "endLine": 389 },
+    "type": "context",
+    "title": "Application: Equal Sides Imply Equal Opposite Angles",
+    "content": "equilateral_angles_equal: if sin(a) = sin(b) and sin(a), sin(b), sin(c) > 0 and sin(A), sin(B) > 0, then sin(A) = sin(B). Follows immediately from the law of sines: sin(a)/sin(A) = sin(b)/sin(B) and sin(a) = sin(b) gives sin(A) = sin(B). This is the spherical analogue of the Euclidean theorem that equal sides imply equal opposite angles.",
+    "mathContext": "The implication $\\sin a = \\sin b \\Rightarrow \\sin A = \\sin B$ follows from the law of sines: $\\frac{\\sin a}{\\sin A} = \\frac{\\sin b}{\\sin B} \\Rightarrow \\sin B = \\frac{\\sin b}{\\sin a} \\cdot \\sin A = \\sin A$ (when $\\sin a = \\sin b \\neq 0$). Note: $\\sin a = \\sin b$ does NOT imply $a = b$ on the sphere (since $\\sin$ is not injective on $[0, \\pi]$ — both $a$ and $\\pi - a$ give the same sine). So this is a theorem about sines, not side lengths.",
+    "significance": "supporting",
+    "relatedConcepts": ["isoceles spherical triangle", "equal angles", "law of sines application"],
+    "prerequisites": ["spherical law of sines", "sine function properties"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for law-of-cosines-oq-01-oq-02 (Spherical Law of Sines). Annotations were completely empty (1 line: []). Added 7 annotations covering: Gram determinant strategy (overview), inner product projections, Gram determinant computation, cosine formula, sin²·sin²·sin² = G bridge identity, main multiplicative and ratio theorems, equilateral case. All with mathContext (LaTeX), significance, relatedConcepts, prerequisites.