### PR TITLE
fix(meta): sync lineCount/theoremCount for angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean
@@ -50,7 +50,7 @@
 
   Axioms: 1 (counterexample_gal_card)
   Sorries: 2 (IsPurelyInseparable API; char-p sign identity)
-  Theorems: 7
+  Theorems: 6
 -/
 
 import Mathlib

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -46,15 +46,15 @@
     ],
     "axiomCount": 1,
     "assumptions": "One axiom: counterexample_gal_card (|Gal(f_target)| = 2 for the char-2 counterexample). The main theorem algEquiv_eq_refl_of_isPurelyInseparable has 2 sorries pending Mathlib API alignment for char-p power identities.",
-    "lineCount": 278,
-    "theoremCount": 7,
+    "lineCount": 219,
+    "theoremCount": 6,
     "definitionCount": 4
   },
   "leanFile": {
     "axiomCount": 1,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 4,
-    "lineCount": 278,
+    "lineCount": 219,
     "sorries": 2
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync stale `lineCount` and `theoremCount` in
`src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json`
to match the actual Lean file as merged in #16106.

## Evidence

`proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean` on
origin/main:
- 219 lines (`wc -l`)
- 6 theorem/lemma declarations (3 `theorem` + 3 `lemma`)
- 4 `noncomputable def`
- 1 `axiom`
- 2 `sorry`

**Before** (meta.json):
- `meta.lineCount: 278`, `leanFile.lineCount: 278`
- `meta.theoremCount: 7`, `leanFile.theoremCount: 7`
- header docstring: `Theorems: 7`

**After** (this PR):
- `meta.lineCount: 219`, `leanFile.lineCount: 219`
- `meta.theoremCount: 6`, `leanFile.theoremCount: 6`
- header docstring: `Theorems: 6`

`sorries` (2), `axiomCount` (1), and `definitionCount` (4) were
already correct.

Closes #16132

---
Automated fix by lean-mechanic agent.