### PR TITLE
audit(laws-llnoq04oq03): remove True-stub doc theorem

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean
@@ -138,20 +138,21 @@ theorem empiricalCDF_pointwise_convergence_no_axiom
 -- Axiom Status Summary
 -- ============================================================================
 
-/-- Summary: the Glivenko-Cantelli axiom count has been reduced from 3 to 1.
+/-
+Summary: the Glivenko-Cantelli axiom count has been reduced from 3 to 1.
 
-    - ✓ `thresholdIndicator_integrable` → proved as `thresholdIndicator_integrable_proved`
-    - ✓ `integral_thresholdIndicator_eq_cdf` → proved as `integral_thresholdIndicator_eq_cdf_proved`
-    - ✗ `glivenko_cantelli_uniform` → remains axiomatic (finite bracketing argument,
-          not yet in Mathlib 4.26)
+  - ✓ `thresholdIndicator_integrable` → proved as `thresholdIndicator_integrable_proved`
+  - ✓ `integral_thresholdIndicator_eq_cdf` → proved as `integral_thresholdIndicator_eq_cdf_proved`
+  - ✗ `glivenko_cantelli_uniform` → remains axiomatic (finite bracketing argument,
+        not yet in Mathlib 4.26)
 
-    The one remaining axiom is mathematically genuine: the uniformity step requires
-    choosing finitely many continuity points of F with controlled jump sizes, then
-    applying finite intersection of pointwise convergence events. This requires
-    infrastructure for CDF continuity points that Mathlib 4.26 does not yet provide.
+The one remaining axiom is mathematically genuine: the uniformity step requires
+choosing finitely many continuity points of F with controlled jump sizes, then
+applying finite intersection of pointwise convergence events. This requires
+infrastructure for CDF continuity points that Mathlib 4.26 does not yet provide.
 
-    The pointwise convergence theorem (`empiricalCDF_pointwise_convergence_no_axiom`)
-    is now fully proved from Mathlib without any integration axioms. -/
-theorem axiom_status_reduction : True := trivial
+The pointwise convergence theorem (`empiricalCDF_pointwise_convergence_no_axiom`)
+is now fully proved from Mathlib without any integration axioms.
+-/
 
 end GlivenkoCantelli

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -19,8 +19,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 128,
-    "theoremCount": 4,
+    "lineCount": 158,
+    "theoremCount": 3,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
@@ -96,10 +96,10 @@
       "ProbabilityTheory",
       "Set"
     ],
-    "lineCount": 128,
+    "lineCount": 158,
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "sorries": 0,


### PR DESCRIPTION
## Summary

The file `LawsOfLargeNumbersOQ04OQ03.lean` had `theorem axiom_status_reduction : True := trivial` as a documentation hook. This trips the auditor's True-stub detector and was flagged CRITICAL ("1 True stubs but status is verified") even though the file's three real theorems are genuinely machine-checked.

This PR replaces the doc-attached True theorem with a plain block comment (no mathematical content changes), and syncs `theoremCount` (4→3) and `lineCount` (128→158) in meta.json.

## Changes

- `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean`: replace `/-- ... -/ theorem axiom_status_reduction : True := trivial` with `/- ... -/` block comment
- `src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json`: theoremCount 4→3, lineCount 128→158 (both meta.* and leanFile.*)

## Verification

- Three real theorems remain (thresholdIndicator_integrable_proved, integral_thresholdIndicator_eq_cdf_proved, empiricalCDF_pointwise_convergence_no_axiom) plus 1 private lemma
- 0 sorries, 0 axiom declarations
- No file imports `LawsOfLargeNumbersOQ04OQ03` (verified via repo-wide grep)

## Test plan

- [ ] CI Lean build passes
- [ ] Gallery JSON schema validates
- [ ] No regression in laws-of-large-numbers-oq-04 parent file

🤖 Generated with [Claude Code](https://claude.com/claude-code)