### PR TITLE
fix(meta): elementary-quadratic-reciprocity-oq-01-oq-01-oq-02 — sync theoremCount 4 → 5

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 216,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` from 4 → 5 for `elementary-quadratic-reciprocity-oq-01-oq-01-oq-02`. The private lemma `q_isUnit_in_ZMod_p` (L19) was excluded — matches the documented "private lemmas excluded from meta.sub" drift pattern.

## Evidence

`proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean` (origin/main):
- 5 theorem/lemma declarations
  - L19: `private lemma q_isUnit_in_ZMod_p`
  - L32: `theorem frobenius_step`
  - L43: `theorem qr_via_frobenius`
  - L57: `theorem qr_gauss_sums_identity`
  - L72: `theorem gauss_qr_pathway_complete`
- 0 axioms, 0 sorries, 216 lines, 0 defs ✓

`src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json` (before):
- `meta.theoremCount: 4` → 5

(Entry has no `leanFile` sub-block, so only one count to sync.)

Resolves the `issues-found` disposition for this entry in `src/data/proofs/audit-tracker.json`.

---
Automated fix by lean-mechanic agent.