### PR TITLE
fix(meta): fundamental-theorem-calculus-oq-02 — sync sorries 1 → 0

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -17,9 +17,9 @@
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusStokes.lean",
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 1 sorry: d^2=0 in 2D (Clairaut's theorem) \u2014 needs bridge from Mathlib's iteratedFDeriv to concrete partial derivatives. Green's theorem in Stokes form now proved via GreensTheoremOQ01.greens_theorem_concrete.",
+    "assumptions": "0 axioms, 0 sorries in main file. d^2=0 in 2D (Clairaut's theorem) now proved via ContDiff.contDiffAt.isSymmSndFDerivAt; Green's theorem in Stokes form proved via GreensTheoremOQ01.greens_theorem_concrete.",
     "mathlibDependencies": [
       {
         "theorem": "integral_eq_sub_of_hasDerivAt_of_le",
@@ -221,7 +221,7 @@
     "theoremCount": 11,
     "definitionCount": 7,
     "path": "Proofs/FundamentalTheoremCalculusStokes.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/FundamentalTheoremCalculusStokesAristotle.lean"
     ]
@@ -252,5 +252,5 @@
       "leanType": "Continuous f -> exists F, extDeriv1D F = f"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Sync `sorries` from 1 → 0 in three places (top-level, `meta.sorries`, `leanFile.sorries`) and update the `assumptions` text to reflect that `dd_eq_zero_2D` (Clairaut) is now fully proved.

## Evidence

`proofs/Proofs/FundamentalTheoremCalculusStokes.lean` (origin/main):
- 0 \`sorry\` occurrences (verified via grep)
- 0 axioms
- 11 theorem/lemma + 7 def — both already correct in meta
- The main-text dd_eq_zero_2D theorem (L205) closes with \`exact (hf.contDiffAt.isSymmSndFDerivAt le_rfl) (1, 0) (0, 1)\`

Auditor flag (\`scripts/auditor/find-targets.ts\`): "sorry mismatch: claims 1, actual 0".

The Aristotle companion file (`Proofs/FundamentalTheoremCalculusStokesAristotle.lean`) still contains supporting-lemma sorries, but the auditor's "actual" count is 0 — those are tracked separately as Aristotle work items.

`status` (\`formalized\`) and `badge` (\`wip\`) left as-is — promoting to `verified` is a separate judgment call about whether the entry's claimed scope is fully covered (Aristotle helpers still pending).

---
Automated fix by lean-mechanic agent.