### PR TITLE
audit(erdos-895): sync sorries 7 → 3 after PR #16105 proofs

### DIFF
--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -18,7 +18,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 7,
+    "sorries": 3,
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",
     "erdosProblemStatus": "solved",
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 260,
-    "assumptions": "No axioms. 7 sorries remain in the formalization.",
+    "assumptions": "No axioms. 3 sorries remain in the formalization.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
     "definitionCount": 14
@@ -160,7 +160,7 @@
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 14,
-    "sorries": 7,
+    "sorries": 3,
     "path": "Proofs/Erdos895Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos895ProblemAristotle.lean"
@@ -183,5 +183,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, ramsey-theory"
     }
   ],
-  "sorries": 7
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

- After PR #16105 (`research(erdos-895-oq-01): prove triangleFree_independence_bound and erdos895_implies_schur_variant`), `Proofs/Erdos895Problem.lean` has only **3** sorries (lines 78, 90, 447). The companion `Proofs/Erdos895ProblemAristotle.lean` has **0**. Total: **3**.
- `meta.json` still claimed **7** in four places. `find-targets.ts` flagged this as `❌ sorry mismatch: claims 7, actual 3` and the entry has been re-audited 4× without the prose being synced.
- Updates `meta.sorries`, `leanFile.sorries`, the top-level `sorries`, and the `assumptions` text (`"7 sorries remain"` → `"3 sorries remain"`). No code changes; status (`formalized` / `wip`) stays correct.

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/proofs/erdos-895/meta.json'))"` parses cleanly
- [x] `git show origin/main:proofs/Proofs/Erdos895Problem.lean | grep -c '\bsorry\b'` (after stripping comments) returns 3
- [x] `git show origin/main:proofs/Proofs/Erdos895ProblemAristotle.lean | grep -c '\bsorry\b'` returns 0
- [ ] After merge, `npx tsx scripts/auditor/find-targets.ts --issues` no longer lists `erdos-895`

🤖 Generated with [Claude Code](https://claude.com/claude-code)