### PR TITLE
audit(laws-of-large-numbers-oq-04-oq-03): remove True-stub doc anchor

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean
@@ -138,20 +138,21 @@ theorem empiricalCDF_pointwise_convergence_no_axiom
 -- Axiom Status Summary
 -- ============================================================================
 
-/-- Summary: the Glivenko-Cantelli axiom count has been reduced from 3 to 1.
+/-
+Summary: the Glivenko-Cantelli axiom count has been reduced from 3 to 1.
 
-    - ✓ `thresholdIndicator_integrable` → proved as `thresholdIndicator_integrable_proved`
-    - ✓ `integral_thresholdIndicator_eq_cdf` → proved as `integral_thresholdIndicator_eq_cdf_proved`
-    - ✗ `glivenko_cantelli_uniform` → remains axiomatic (finite bracketing argument,
-          not yet in Mathlib 4.26)
+  - ✓ `thresholdIndicator_integrable` → proved as `thresholdIndicator_integrable_proved`
+  - ✓ `integral_thresholdIndicator_eq_cdf` → proved as `integral_thresholdIndicator_eq_cdf_proved`
+  - ✗ `glivenko_cantelli_uniform` → remains axiomatic (finite bracketing argument,
+        not yet in Mathlib 4.26)
 
-    The one remaining axiom is mathematically genuine: the uniformity step requires
-    choosing finitely many continuity points of F with controlled jump sizes, then
-    applying finite intersection of pointwise convergence events. This requires
-    infrastructure for CDF continuity points that Mathlib 4.26 does not yet provide.
+The one remaining axiom is mathematically genuine: the uniformity step requires
+choosing finitely many continuity points of F with controlled jump sizes, then
+applying finite intersection of pointwise convergence events. This requires
+infrastructure for CDF continuity points that Mathlib 4.26 does not yet provide.
 
-    The pointwise convergence theorem (`empiricalCDF_pointwise_convergence_no_axiom`)
-    is now fully proved from Mathlib without any integration axioms. -/
-theorem axiom_status_reduction : True := trivial
+The pointwise convergence theorem (`empiricalCDF_pointwise_convergence_no_axiom`)
+is now fully proved from Mathlib without any integration axioms.
+-/
 
 end GlivenkoCantelli

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -19,8 +19,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 128,
-    "theoremCount": 4,
+    "lineCount": 158,
+    "theoremCount": 3,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
@@ -96,10 +96,10 @@
       "ProbabilityTheory",
       "Set"
     ],
-    "lineCount": 128,
+    "lineCount": 158,
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "sorries": 0,


### PR DESCRIPTION
## Integrity Issue (CRITICAL → fixed)

**Proof**: `laws-of-large-numbers-oq-04-oq-03`
**Problem**: A `theorem axiom_status_reduction : True := trivial` placeholder served only as an anchor for a docstring summarizing axiom status. This triggered the auditor's CRITICAL True-stub flag against a `status: verified` / `badge: original` entry.

## Fix

- Convert the doc-anchor theorem to a plain `/- ... -/` comment block. The text is identical; nothing depended on the symbol.
- Update `theoremCount` 4 → 3 in both `meta` and `leanFile` blocks (the file now has 3 `theorem` declarations + 1 private `lemma`).
- Update `lineCount` 128 → 158 in both blocks (already drifted from prior edits; recomputed to match the file as committed).

## Verification

- `grep -cE "^theorem |^lemma "` on the new file → 4 (3 theorems + 1 lemma).
- `grep -cE ":= trivial|: True :="` on the new file → 0.
- Three real theorems are unchanged: `thresholdIndicator_integrable_proved`, `integral_thresholdIndicator_eq_cdf_proved`, `empiricalCDF_pointwise_convergence_no_axiom`. Private supporting lemma `thresholdIndicator_eq_preimage_indicator_fun` also unchanged.

Discovered during gallery integrity audit.