### PR TITLE
audit(konigsberg-oq-01-oq-02): correct sorries (6→4) and lineCount (848→958)

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -116,7 +116,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the directed Eulerian theorem. Key proved results: directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg, via double-counting), necessity direction (Eulerian circuit → balanced degrees, via walk position bijection and closed-walk degree balance). 8 theorems proved from first principles, 2 axioms (Hierholzer sufficiency and Eulerian path characterization), 6 sorries (Hierholzer infrastructure helpers deferred), 848 lines.",
+    "summary": "Formalizes the directed Eulerian theorem. Key proved results: directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg, via double-counting), necessity direction (Eulerian circuit → balanced degrees, via walk position bijection and closed-walk degree balance). 8 theorems proved from first principles, 2 axioms (Hierholzer sufficiency and Eulerian path characterization), 4 sorries (Hierholzer infrastructure helpers deferred), 958 lines.",
     "implications": "The directed Eulerian theorem underpins de Bruijn sequence construction (a de Bruijn graph is Eulerian), DNA fragment assembly algorithms, and Eulerian circuit algorithms in network flow. The degree-balance characterization is also the basis for Hierholzer's O(|E|) directed Eulerian circuit algorithm.",
     "openQuestions": [
       "Formalize Hierholzer's algorithm for constructing directed Eulerian circuits (eliminate directed_eulerian_iff axiom)",


### PR DESCRIPTION
## Summary

Gallery integrity audit found stale counts in `src/data/proofs/konigsberg-oq-01-oq-02/meta.json`:

- `sorries` (3 places: top-level, `meta`, `leanFile`): 6 → **4**
- `lineCount` (2 places: `meta`, `leanFile`): 848 → **958**
- `conclusion.summary`: "6 sorries... 848 lines" → "4 sorries... 958 lines"

`axiomCount` (2), `theoremCount` (25), `definitionCount` (13) verified accurate.

## Evidence

`origin/main:proofs/Proofs/KonigsbergOQ01OQ02.lean`:

- 958 lines (raw `wc -l`)
- 4 `sorry` occurrences after stripping comments (lines 478, 487, 772, 817)
- 2 `axiom ` declarations
- 25 `theorem`/`lemma` (12 public + 13 private)
- 11 `def` + 2 `structure` = 13 definitions

## Test plan

- [x] JSON parses
- [x] All three `sorries` fields agree (4)
- [x] Both `lineCount` fields agree (958)
- [x] `conclusion.summary` text matches new counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)