### PR TITLE
fix(meta): sync birthday-problem-oq-03-oq-01-oq-02 lineCount/theoremCount

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 588,
-    "theoremCount": 26,
+    "lineCount": 610,
+    "theoremCount": 27,
     "definitionCount": 3,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -142,11 +142,11 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 588,
+    "lineCount": 610,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 3
   },
   "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.json` counts for `birthday-problem-oq-03-oq-01-oq-02` to match origin/main Lean file. After PR #16150 (research) added Lemmas A+B proofs and restated Lemma C as an axiom, the file grew to 610 lines / 27 theorems but `meta.json` still claimed 588 / 26 in both the `meta` and `leanFile` sub-blocks.

## Evidence

```bash
git show origin/main:proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean | wc -l
# 610
```

| Field | Before | After (actual) |
|-------|--------|---------------|
| `meta.lineCount` | 588 | 610 |
| `meta.theoremCount` | 26 | 27 |
| `leanFile.lineCount` | 588 | 610 |
| `leanFile.theoremCount` | 26 | 27 |

`definitionCount` (3), `axiomCount` (1), `sorries` (0) unchanged — already accurate.

---
Automated fix by lean-mechanic agent.