### PR TITLE
fix(meta): sync continuum-hypothesis-oq-02 theorem/definition counts

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -73,8 +73,8 @@
     "lineCount": 584,
     "assumptions": "2 axioms: bounding_number_uncountable, MA_implies_b_eq_continuum. 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 33,
-    "definitionCount": 6
+    "theoremCount": 32,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "After Cohen's 1963 forcing proof showed the independence of CH, a natural question emerged: what values CAN 2^aleph_0 take? Konig (1905) had already shown a cofinality constraint: cf(2^kappa) > kappa, ruling out singular cardinals. Easton (1970) proved the dramatic result that for regular cardinals, the continuum function is essentially unconstrained by ZFC. Meanwhile, the bounding and dominating numbers (b and d) emerged in the 1970s-80s as intermediate cardinal invariants between aleph_1 and 2^aleph_0, leading to the rich combinatorial study of Cichon's diagram.",
@@ -183,8 +183,8 @@
     "namespace": "ContinuumHypothesisOQ02",
     "lineCount": 584,
     "axiomCount": 2,
-    "theoremCount": 33,
-    "definitionCount": 6,
+    "theoremCount": 32,
+    "definitionCount": 7,
     "path": "Proofs/ContinuumHypothesisOQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync \`meta.json\` counts for \`continuum-hypothesis-oq-02\` to match origin/main Lean file. Both \`meta\` and \`leanFile\` sub-blocks claim 33 theorems and 6 definitions, but the file actually has 32 theorems and 7 definitions.

The drift looks consistent with one ' theorem' having been converted to a \`def\` (the file contains an \`opaque MartinsAxiom : Prop\` at line 267).

## Evidence

```bash
git show origin/main:proofs/Proofs/ContinuumHypothesisOQ02.lean | wc -l
# 584
```

After stripping comments and matching standard Lean keywords (\`theorem\`/\`lemma\` and \`def\`/\`abbrev\`/\`opaque\`):

| Field | Before | After (actual) |
|-------|--------|----------------|
| \`meta.theoremCount\` | 33 | 32 |
| \`meta.definitionCount\` | 6 | 7 |
| \`leanFile.theoremCount\` | 33 | 32 |
| \`leanFile.definitionCount\` | 6 | 7 |

\`lineCount\` (584), \`axiomCount\` (2), \`sorries\` (0) unchanged — already accurate.

---
Automated fix by lean-mechanic agent.