### PR TITLE
audit(konigsberg-oq-01-oq-02): sorries 6→4, lineCount 848→958

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14018,9 +14018,9 @@
       "issues": []
     },
     "konigsberg-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-03T18:24:21Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-05-06T15:00:00Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "lebesgue-measure-oq-01-oq-03": {

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -17,11 +17,11 @@
       "degree-sequences"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 4,
     "dateAdded": "2026-05-03",
     "axiomCount": 2,
     "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer's algorithm for directed graph Eulerian circuit — requires graph connectivity infrastructure) and directed_euler_path_iff (Eulerian path degree characterization). All other results (handshaking, necessity, concrete examples, consequences) are proved from first principles.",
-    "lineCount": 848,
+    "lineCount": 958,
     "theoremCount": 25,
     "definitionCount": 13,
     "originalContributions": [
@@ -126,12 +126,12 @@
   },
   "leanFile": {
     "namespace": "KonigsbergOQ01OQ02",
-    "lineCount": 848,
+    "lineCount": 958,
     "axiomCount": 2,
     "theoremCount": 25,
     "definitionCount": 13,
     "path": "Proofs/KonigsbergOQ01OQ02.lean",
-    "sorries": 6
+    "sorries": 4
   },
   "crossReferences": [
     {
@@ -150,5 +150,5 @@
       "description": "Original Königsberg bridges problem — Euler 1736; the undirected Eulerian theorem whose directed analogue is formalized here."
     }
   ],
-  "sorries": 6
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

- meta.sorries / leanFile.sorries / top-level sorries: 6 → 4
- meta.lineCount / leanFile.lineCount: 848 → 958
- audit-tracker.json updated (auditCount 2→3, result issues-fixed)

## Evidence

`proofs/Proofs/KonigsbergOQ01OQ02.lean` currently contains 4 sorries (after stripping comments):

| Line | Lemma | Status |
|------|-------|--------|
| 578 | `maxTrail_used_eq` | private helper, deferred |
| 588 | `maxTrail_last_exhausted` | private helper, deferred |
| 900 | `remove_circuit_balanced` | infrastructure for Hierholzer |
| 954 | `euler_path_implies_degree_balance` | open-walk necessity |

The HierholzerInfrastructure section (Part VII) was added since the last meta-update, growing the file from 848 to 958 lines and reducing the sorry count from 6 to 4. axiomCount remains 2.

## Test plan

- [x] JSON validates (`jq -e .`)
- [x] All three sorries fields agree (top, meta, leanFile)
- [x] Line count matches `wc -l`
- [x] Detected by `find-targets --issues` and clears the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)