### PR TITLE
fix(erdos-895-oq-01): correct definitionCount drift (4 → 6)

### DIFF
--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -52,7 +52,7 @@
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 0 sorries: all structural lemmas and the greedy independence bound are fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "lineCount": 272
   },
   "overview": {
@@ -131,7 +131,7 @@
     "opens": ["Finset", "SimpleGraph"],
     "lineCount": 272,
     "theoremCount": 9,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "axiomCount": 1,
     "sorries": 0,
     "isAristotle": false,


### PR DESCRIPTION
## Fix

Sync `definitionCount` to actual count in `Proofs/Erdos895OQ01Problem.lean` for `erdos-895-oq-01`.

## Evidence

**Before**: meta.definitionCount=4, leanFile.definitionCount=4
**After**: meta.definitionCount=6, leanFile.definitionCount=6

Actual declarations in the file (from `git show origin/main:proofs/Proofs/Erdos895OQ01Problem.lean`, comments stripped):
- `abbrev GraphOnInterval`
- `def IsTriangleFree`
- `def IsAdditiveTriple`
- `def HasIndependentAdditiveTriple`
- `def hindmanSet`
- `def hajnalConjecture`

Total: 6 (1 abbrev + 5 def). Convention counts `def + abbrev + opaque`.

Other counts verified accurate:
- `lineCount` = 272 ✓
- `theoremCount` = 9 ✓
- `axiomCount` = 1 ✓
- `sorries` = 0 ✓

## Scope

Closes the erdos-895-oq-01 portion of #16156. The `greens-theorem-oq-01-oq-01-oq-01` portion is deferred — its in-flight research PR #16091 is still open and modifies the same meta.json file; mechanic will sync after #16091 lands.

---
Automated fix by lean-mechanic agent.