### PR TITLE
audit(cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01): lineCount 240→241, theoremCount 7→6

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -60,8 +60,8 @@
       "conjugate_iff_same_image: symmetry of the conjugation relation",
       "Infrastructure audit: identified 5 Mathlib v4.26 building blocks sufficient to prove the axiom"
     ],
-    "lineCount": 240,
-    "theoremCount": 7,
+    "lineCount": 241,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -157,9 +157,9 @@
     ],
     "opens": [],
     "namespace": "SkolemNoetherCSA",
-    "lineCount": 240,
+    "lineCount": 241,
     "axiomCount": 1,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/SkolemNoetherCSA.lean"


### PR DESCRIPTION
## Audit fix

Both `meta` and `leanFile` blocks claimed `lineCount=240` and `theoremCount=7`. The Lean source `proofs/Proofs/SkolemNoetherCSA.lean` actually has:

- **241 lines** (`wc -l`)
- **6 `^theorem` declarations**:
  1. `rightBLinear_is_leftMul`
  2. `rightBLinear_symm_is_leftMul`
  3. `isUnit_of_rightBLinear_equiv`
  4. `skolemNoether_general`
  5. `aut_is_inner`
  6. `conjugate_iff_same_image`
- **1 axiom** (`skolemNoether_module_iso`)
- **0 sorries**, **0 defs**

The 7th entry in `originalContributions` ("Infrastructure audit: identified 5 Mathlib v4.26 building blocks") is descriptive narrative, not a `^theorem` declaration.

## Unchanged (already correct)

- `axiomCount: 1`
- `sorries: 0`
- `definitionCount: 0`
- `status: axiomatized`
- `badge: axiom`
- `originalContributions` text (kept as-is)

## Severity

LOW — counts off by 1 each on `lineCount` and `theoremCount`. No claim inflation; status/badge already correctly say `axiomatized/axiom`.

---
Discovered during gallery integrity audit.