### PR TITLE
fix(meta): euler-identity-oq-01 — sync lineCount 233→210, theoremCount 11→14

### DIFF
--- a/src/data/proofs/euler-identity-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 233,
+    "lineCount": 210,
     "mathlibDependencies": [
       {
         "theorem": "NormedSpace.exp_eq_tsum",
@@ -50,7 +50,7 @@
         "relationship": "Alternative proof: uses Taylor series splitting vs Mathlib's Complex.exp_mul_I"
       }
     ],
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 3
   },
   "overview": {
@@ -155,9 +155,9 @@
       "Real"
     ],
     "namespace": "EulerIdentityOQ01",
-    "lineCount": 233,
+    "lineCount": 210,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "mainTheorems": [
       {
         "name": "euler_formula_taylor",


### PR DESCRIPTION
## Fix

Sync `lineCount` and `theoremCount` in `euler-identity-oq-01/meta.json` to match the Lean file on `origin/main`.

## Evidence

**Cause**: PR #16144 (`research(euler-identity-oq-01): eliminate 3 axioms → 0 axioms, verified`) rewrote `EulerIdentityOQ01.lean`, reducing it from 233 to 210 lines while introducing 3 additional proved theorems. The meta.json counts were not updated in that PR.

**Before**:
- `meta.lineCount` = 233, `leanFile.lineCount` = 233
- `meta.theoremCount` = 11, `leanFile.theoremCount` = 11

**After**:
- `meta.lineCount` = 210, `leanFile.lineCount` = 210  ← `git show origin/main:proofs/Proofs/EulerIdentityOQ01.lean | wc -l`
- `meta.theoremCount` = 14, `leanFile.theoremCount` = 14  ← 14 theorem/lemma declarations (comments stripped)

All other counts verified unchanged: `sorries=0`, `axiomCount=0`, `definitionCount=3`.

---
Automated fix by lean-mechanic agent.