### PR TITLE
audit(laws-of-large-numbers-oq-01-oq-02): add missing leanFile block + definitionCount

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02/meta.json
@@ -24,6 +24,7 @@
     "sorries": 0,
     "axiomCount": 3,
     "theoremCount": 10,
+    "definitionCount": 2,
     "lineCount": 344,
     "mathlibDependencies": [
       {
@@ -62,6 +63,32 @@
     "dateAdded": "2026-05-06",
     "assumptions": "3 axioms: marcinkiewicz_zygmund_slln (truncation argument, Feller Vol.II Thm IX.4.1), pareto_in_lr_iff (improper integral computation), stable_clt_attraction (characteristic function/stable law theory). All other results proved from Mathlib + these axioms.",
     "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.StrongLaw",
+      "Mathlib.Probability.Moments.Variance",
+      "Mathlib.Probability.Independence.Basic",
+      "Mathlib.Probability.Notation",
+      "Mathlib.MeasureTheory.Function.ConvergenceInMeasure",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Tactic",
+      "Proofs.LawsOfLargeNumbersOQ01"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Filter",
+      "Real",
+      "Finset"
+    ],
+    "namespace": "LawsOfLargeNumbersOQ01OQ02",
+    "lineCount": 344,
+    "axiomCount": 3,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/LawsOfLargeNumbersOQ01OQ02.lean",
+    "sorries": 0
   },
   "overview": {
     "historicalContext": "The question of how fast sample means converge has been central to probability theory for over a century. Kolmogorov's 1933 Strong Law of Large Numbers guarantees almost sure convergence for integrable random variables, but gives no rate. For finite-variance distributions, the Berry-Esseen theorem (1941–1942) quantifies the Gaussian CLT rate as O(1/√n). The gap for heavy-tailed distributions — where variance is infinite — was filled by Józef Marcinkiewicz and Antoni Zygmund in their 1937 paper 'Sur les fonctions indépendantes' (On Independent Functions): if E[|X|^r] < ∞ for r ∈ (1,2), then deviations scale as o(n^{1/r}). The corresponding limiting distributions — α-stable laws — were characterized by Paul Lévy in the 1920s–1930s, and the full generalized CLT (domain of attraction theory) was developed by Gnedenko and Kolmogorov in their 1954 monograph 'Limit Distributions for Sums of Independent Random Variables'. The Pareto distribution, introduced by Vilfredo Pareto in 1897 to model income inequality, became the canonical example of the heavy-tail regime: its tail index α ∈ (1,2) places it exactly in the M-Z zone, with finite mean but infinite variance.",


### PR DESCRIPTION
## Summary
Schema migration for \`laws-of-large-numbers-oq-01-oq-02/meta.json\`:
- Add top-level \`leanFile\` block (was missing entirely)
- Add \`definitionCount: 2\` to meta block (was missing)

Without the \`leanFile\` block, \`scripts/auditor/find-targets.ts\` cannot detect count drift on this entry — it shows up as \`[unknown/unknown]\` in find-targets output.

## Counts (verified from \`git show HEAD:proofs/Proofs/LawsOfLargeNumbersOQ01OQ02.lean\`)

| Field | Value |
|-------|-------|
| lineCount | 344 |
| axiomCount | 3 (\`marcinkiewicz_zygmund_slln\`, \`pareto_in_lr_iff\`, \`stable_clt_attraction\`) |
| theoremCount | 10 |
| definitionCount | 2 |
| sorries | 0 |

Status \`axiomatized/axiom\` and existing meta count fields are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)