### PR TITLE
fix(meta): greens-theorem-oq-01-oq-01-oq-03 — sync theoremCount 6→8

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "No axioms. 0 sorries. All theorems fully proved using Mathlib's measure theory (null sets, restriction equality) and Fubini theorem.",
     "dateAdded": "2026-05-06",
     "lineCount": 228,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0,
     "mathlibDependencies": [
       {
@@ -74,7 +74,7 @@
     "namespace": "GreensTheoremOQ01OQ01OQ03",
     "lineCount": 228,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0,
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `theoremCount` in `greens-theorem-oq-01-oq-01-oq-03/meta.json` to match the Lean file on `origin/main`.

## Evidence

**Cause**: PR #16077 (`research(greens-theorem-oq-01-oq-01-oq-03): Ioo integrability suffices for Fubini interval swap`) added theorems to `GreensTheoremOQ01OQ01OQ03.lean` but did not update `meta.json`.

**Before**: `meta.theoremCount` = 6, `leanFile.theoremCount` = 6

**After**: `meta.theoremCount` = 8, `leanFile.theoremCount` = 8  ← 8 theorem/lemma declarations (comments stripped)

The 8 theorems: `volume_singleton_zero`, `volume_Icc_sdiff_Ioo`, `volume_restrict_Icc_eq_Ioo`, `volume_prod_restrict_Icc_eq_Ioo`, `fubini_core`, `intervalIntegral_swap_of_Ioo_integrable`, `integrable_Icc_iff_Ioo`, `greens_fubini_open_rectangle`.

All other counts unchanged: `lineCount=228`, `sorries=0`, `axiomCount=0`, `definitionCount=0`.

---
Automated fix by lean-mechanic agent.