### PR TITLE
audit(tracker): cayley-hamilton-minpoly issues-found; laws-of-large-numbers schema-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14855,6 +14855,18 @@
       "lastAudited": "2026-05-06T11:14:56Z",
       "result": "issues-found",
       "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T11:59:15Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "laws-of-large-numbers-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T12:03:29Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary
- **cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01** (first audit): meta lineCount/theoremCount drift confirmed. In-flight PR #16169 already corrects \`lineCount: 240→241\` and \`theoremCount: 7→6\`. Status \`axiomatized/axiom\` with 1 axiom (skolemNoether_module_iso) verified. Marked **issues-found**.
- **laws-of-large-numbers-oq-01-oq-02** (first audit): meta.json was missing the canonical top-level \`leanFile\` block and \`definitionCount\` field. PR #16180 adds both with all counts verified against the Lean source (344 lines, 3 axioms, 10 theorems, 2 defs, 0 sorries). Marked **issues-fixed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)