### PR TITLE
fix(meta): fundamental-theorem-calculus-oq-02 — sync lineCount 365→395

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -53,7 +53,7 @@
       "d^2 = 0 (Clairaut's theorem) stated for C^2 functions on R^2"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 365,
+    "lineCount": 395,
     "theoremCount": 11,
     "definitionCount": 7,
     "mathlib_version": "4.26.0"
@@ -216,7 +216,7 @@
       "intervalIntegral"
     ],
     "namespace": "GeneralizedStokes",
-    "lineCount": 365,
+    "lineCount": 395,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Sync `lineCount` in `fundamental-theorem-calculus-oq-02/meta.json` to match the current `FundamentalTheoremCalculusStokes.lean` on `origin/main`.

## Evidence

**Cause**: PR #16107 (`prove(ftc-stokes): fill dd_eq_zero_2D sorry — Clairaut/Schwarz theorem`) added ~30 lines to `FundamentalTheoremCalculusStokes.lean` without updating `meta.json`.

**Before**: `meta.lineCount` = 365, `leanFile.lineCount` = 365

**After**: `meta.lineCount` = 395, `leanFile.lineCount` = 395  ← `git show origin/main:proofs/Proofs/FundamentalTheoremCalculusStokes.lean | wc -l`

All other counts unchanged: `theoremCount=11`, `definitionCount=7`, `sorries=0`, `axiomCount=0`.

---
Automated fix by lean-mechanic agent.