### PR TITLE
fix(meta): fundamental-theorem-algebra-oq-04-oq-04 — sync theoremCount 14→15

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 2,
     "assumptions": "Two axioms: (1) Xn_sub_p_irred_Qp — X^n - p is irreducible over ℚ_p (Newton polygon: single segment slope -1/n, gcd(1,n)=1; equivalently Eisenstein at the maximal ideal of ℤ_p). (2) padic_alg_closure_infinite_dim — the algebraic closure of ℚ_p is not finite-dimensional over ℚ_p (follows from unbounded extension degrees, but connecting to Module.Finite on AlgebraicClosure requires additional infrastructure).",
     "lineCount": 214,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 0,
     "originalContributions": [
       "Xn_sub_p_irred_Z: X^n - p irreducible over ℤ (standalone Eisenstein proof, independent of parent)",
@@ -182,7 +182,7 @@
     "namespace": "PadicAlgClosureContrast",
     "lineCount": 214,
     "axiomCount": 2,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 0,
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `theoremCount` in `fundamental-theorem-algebra-oq-04-oq-04/meta.json` to match the Lean file.

## Evidence

**Cause**: PR #16031 (enricher adding `FundamentalTheoremAlgebraOQ04OQ04.lean`) set `theoremCount=14`, but the file contains 15 theorem/lemma declarations. The `private theorem p_prime` was not counted.

**Before**: `meta.theoremCount` = 14, `leanFile.theoremCount` = 14

**After**: `meta.theoremCount` = 15, `leanFile.theoremCount` = 15

The 15 declarations (comments stripped): `p_prime` (private), `real_complex_finrank`, `real_complex_module_finite`, `Xn_sub_p_irred_Z`, `Xn_sub_p_irred_Q`, `Xn_sub_p_ne_zero_Qp`, `natDegree_Xn_sub_p`, `padic_root_extension_finrank`, `padic_quadratic_extension`, `padic_cubic_extension`, `padic_quartic_extension`, `real_padic_closure_contrast`, `padic_extensions_unbounded`, `padic_extensions_strictly_unbounded`, `degree_contrast_summary`.

Convention: private declarations are included in `theoremCount`.

All other counts unchanged: `lineCount=214`, `sorries=0`, `axiomCount=2`, `definitionCount=0`.

---
Automated fix by lean-mechanic agent.