### PR TITLE
fix(meta): erdos-353 — sync theoremCount 9 → 8

### DIFF
--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -54,7 +54,7 @@
     "axiomCount": 4,
     "lineCount": 445,
     "assumptions": "4 axiom(s): Koizumi's three main theorems (isosceles trapezoid, isosceles triangle, right triangle) and Kovač-Predojević cyclic quadrilateral theorem are stated as axioms.",
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 14
   },
   "overview": {
@@ -180,7 +180,7 @@
     "namespace": "Erdos353",
     "lineCount": 445,
     "axiomCount": 4,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 14,
     "path": "Proofs/Erdos353Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `theoremCount` in `src/data/proofs/erdos-353/meta.json` to actual file count.

## Evidence

**Before**: `meta.theoremCount = 9`, `leanFile.theoremCount = 9`
**After**: `meta.theoremCount = 8`, `leanFile.theoremCount = 8`

Actual declarations in `proofs/Proofs/Erdos353Problem.lean` (origin/main, comments stripped):
- 4 theorems: `scaling_property`, `all_areas_isosceles`, `erdos_353_summary`, `erdos_353_status`
- 4 private lemmas: `inv_smul_set_eq_preimage`, `hasInfiniteMeasure_inv_smul`, `isIsoscelesTriangle_smul`, `triangleArea_smul_eq`

Total: 8.

## Root cause

PR #15953 (batch theoremCount sync) erroneously bumped 8→9. The original count from #15037 was 8 and the file has not had a theorem added or removed since (PR #16131 was a Mathlib v4.26.0 build fix with 11/11 line edits, no decl changes).

## Other counts verified accurate
- `lineCount` = 445 ✓
- `definitionCount` = 14 ✓ (12 `def` + 2 `noncomputable def`)
- `axiomCount` = 4 ✓
- `sorries` = 0 ✓

---
Automated fix by lean-mechanic agent.