### PR TITLE
fix(meta): angle-trisection-cos-20-gal-oq-01-oq-02-oq-02 — sync lineCount 339→338

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 339,
+    "lineCount": 338,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "historicalContext": "The formula |Gal(minpoly(cos(π/n))/ℚ)| = φ(2n)/2 connects classical angle trisection impossibility to cyclotomic field theory. Individual cases n=5 (|Gal|=2), n=7 (|Gal|=3), n=9 (|Gal|=3) were proved in earlier gallery entries. This file provides the general proof using IsCyclotomicExtension, answering the open question from AngleTrisectionCos20GalOQ01OQ02.",
@@ -54,7 +54,7 @@
       "Proofs.AngleTrisectionCos20GalOQ01OQ02"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ02OQ02",
-    "lineCount": 339,
+    "lineCount": 338,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `lineCount` in `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json` to match the Lean file on `origin/main`.

## Evidence

**Cause**: PR #16052 (`research(angle-trisection): eliminate sorry in cos_pi_gal_card`) removed one line from `AngleTrisectionCos20GalOQ01OQ02OQ02.lean` without updating `meta.json`.

**Before**: `meta.lineCount` = 339, `leanFile.lineCount` = 339

**After**: `meta.lineCount` = 338, `leanFile.lineCount` = 338  ← `git show origin/main:proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean | wc -l`

All other counts unchanged: `theoremCount=12`, `sorries=0`, `axiomCount=0`, `definitionCount=0`.

---
Automated fix by lean-mechanic agent.