### PR TITLE
audit(tracker): area-of-circle-oq-03-oq-02-oq-02-oq-01 — re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -486,9 +486,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:47Z",
+      "lastAudited": "2026-05-06T12:22:48Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-03": {


### PR DESCRIPTION
## Summary

- Re-audited `area-of-circle-oq-03-oq-02-oq-02-oq-01` (Generalized Dalzell Integral, π > 47171/15015) two weeks after the previous audit.
- Tracker bumped: `auditCount` 1→2, `lastAudited` updated, result remains `clean`.

## Audit verification

- meta vs `proofs/Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean` (origin/main):
  - lineCount 254 ✓
  - theoremCount 15 ✓
  - definitionCount 2 ✓ (2× `noncomputable def`)
  - axiomCount 0 ✓
  - sorries 0 ✓
- All four claimed `originalContributions` theorems exist (`dalzell2_polynomial_identity`, `dalzell2_integral`, `pi_gt_lower_bound`, `pi_rational_sandwich`).
- Numeric claim verified symbolically (sympy):
  - `x⁸(1-x)⁸ = (1+x²)·Q(x) + 16` ✓ (R = 16 matches)
  - `∫₀¹ Q(x) dx = -188684/15015` ✓ (exact rational match)
  - `47171/15015 < π < 22/7` ✓
- Status `verified` / badge `original` is consistent with 0 axioms, 0 sorries, no Mathlib bridge.

## Test plan

- [x] Counts match Lean source on origin/main
- [x] Theorem names referenced in `originalContributions` exist
- [x] Numeric polynomial identity and rational bound verified symbolically
- [ ] Tracker JSON validates (single-entry, 2-line diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)