### PR TITLE
fix(meta): erdos-895-oq-01 — sync definitionCount 4→6 and theoremCount 9→11

### DIFF
--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -51,7 +51,7 @@
     ],
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 0 sorries: all structural lemmas and the greedy independence bound are fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 6,
     "lineCount": 272
   },
@@ -140,7 +140,7 @@
     "imports": ["Mathlib"],
     "opens": ["Finset", "SimpleGraph"],
     "lineCount": 272,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 6,
     "axiomCount": 1,
     "sorries": 0,

--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -52,7 +52,7 @@
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 0 sorries: all structural lemmas and the greedy independence bound are fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "lineCount": 272
   },
   "overview": {
@@ -141,7 +141,7 @@
     "opens": ["Finset", "SimpleGraph"],
     "lineCount": 272,
     "theoremCount": 9,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "axiomCount": 1,
     "sorries": 0,
     "isAristotle": false,


### PR DESCRIPTION
## Fix

Correct stale counts in `erdos-895-oq-01/meta.json` after research PRs #16091 / #16112 / #16139 landed.

## Evidence

**Entry**: `erdos-895-oq-01` (`Proofs/Erdos895OQ01Problem.lean`)

| field | meta.json (before) | actual | meta.json (after) |
|-------|--------------------|--------|--------------------|
| `definitionCount` | 4 | 6 | 6 |
| `theoremCount`    | 9 | 11 | 11 |

Both `meta` and `leanFile` blocks updated.

### Definitions (def + abbrev + opaque, comment-stripped) = 6
- `abbrev GraphOnInterval`
- `def IsTriangleFree`, `def IsAdditiveTriple`, `def HasIndependentAdditiveTriple`
- `def hindmanSet`, `def hajnalConjecture`

### Theorems (theorem + lemma incl. private, comment-stripped) = 11
- `hindmanSet_mem_self`, `hindmanSet_mono`, `hindmanSet_pair_left`, `hindmanSet_pair_right`, `hindmanSet_pair_sum`
- `hajnal_k2_gives_additive_triple`
- `triangleFree_nbhd_independent`, `triangleFree_indep_high_deg`
- `private lemma greedy_indep_of_bounded_deg`, `private theorem indep_from_bounded_deg`
- `triangleFree_independence_bound`

`lineCount=272`, `axiomCount=1`, `sorries=0` are already correct.

Closes the erdos-895-oq-01 component of #16156. The greens-theorem-oq-01-oq-01-oq-01 component remains blocked pending PR #16091.

---
Automated fix by lean-mechanic agent.