### PR TITLE
audit(meta): sync abel-ruffini-galois-extensions-oq-05-oq-01 lineCount 199→201

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
@@ -25,7 +25,7 @@
     "dateAdded": "2026-05-06",
     "axiomCount": 1,
     "assumptions": "galois_compositum_product: For two Galois extensions K₁/ℚ and K₂/ℚ with coprime Galois group orders (supported on disjoint primes), their compositum has Galois group K₁ × K₂. Provable from conductor/discriminant theory of cyclotomic fields (~500 Lean lines); identifies the exact Mathlib gap for the abelian case of Shafarevich.",
-    "lineCount": 199,
+    "lineCount": 201,
     "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
@@ -90,7 +90,7 @@
   "leanFile": {
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
     "axiomCount": 1,
-    "lineCount": 199,
+    "lineCount": 201,
     "theoremCount": 8,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Audit finding

Routine gallery integrity audit (auditor-agent) on `abel-ruffini-galois-extensions-oq-05-oq-01`.

**Drift**: `meta.lineCount` and `leanFile.lineCount` both report `199`, but actual file `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean` is `201` lines.

## Other counts verified clean

| Field | Claimed | Actual |
|-------|---------|--------|
| axiomCount | 1 | 1 (`galois_compositum_product`) ✓ |
| theoremCount | 8 | 8 ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| True stubs | — | 0 ✓ |

Status `axiomatized` and badge `axiom` are appropriate for the 1 declared axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)