### PR TITLE
fix(meta): greens-theorem-oq-01-oq-01-oq-01 — sync lineCount 354→275, theoremCount 11→8

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
@@ -51,8 +51,8 @@
       "Key technique: Integrable.integral_prod_right avoids separate measurability lemmas",
       "Axiomatized general n-dim order independence for arbitrary permutations"
     ],
-    "lineCount": 354,
-    "theoremCount": 11,
+    "lineCount": 275,
+    "theoremCount": 8,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -69,9 +69,9 @@
       "Topology"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ01",
-    "lineCount": 354,
+    "lineCount": 275,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/GreensTheoremOQ01OQ01OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync meta.json count fields for `greens-theorem-oq-01-oq-01-oq-01` to match actual Lean source on `origin/main`.

## Evidence

**Entry**: `greens-theorem-oq-01-oq-01-oq-01` (`Proofs/GreensTheoremOQ01OQ01OQ01.lean`)

**Before**:
- `lineCount`: 354 (both `meta` and `leanFile` blocks)
- `theoremCount`: 11 (both blocks)

**After**:
- `lineCount`: 275 ✓ (verified: `git show origin/main:proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean | wc -l = 275`)
- `theoremCount`: 8 ✓ (verified: 4 theorems + 4 lemmas; 2 private lemmas excluded per convention)
- `definitionCount`: 1 ✓ (already correct — `noncomputable def iteratedIntervalIntegral`)
- `axiomCount`: 1 ✓ (already correct — `axiom iteratedIntervalIntegral_order_independent`)

**Non-private theorem/lemma declarations** (8):
1. `theorem triple_fubini_of_continuous`
2. `theorem triple_fubini_yxz_eq_xyz`
3. `theorem triple_fubini_all_equal`
4. `theorem fubini_n2`
5. `lemma iteratedIntervalIntegral_zero`
6. `lemma iteratedIntervalIntegral_succ`
7. `lemma iteratedIntervalIntegral_one`
8. `lemma iteratedIntervalIntegral_two`

Private (excluded): `integrable_3d_zx_y`, `integrable_3d_xy_z`

**Blocking PRs resolved**: In-flight PRs #16091 and #16112 both have `CONFLICTING` merge state and will not auto-merge. Origin/main state is authoritative.

Closes #16156

---
Automated fix by lean-mechanic agent.