### PR TITLE
audit(cantor-diagonalization-oq-04-oq-03): fix narrative drift — no remaining sorry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1503,10 +1503,10 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-04-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:48Z",
-      "result": "clean"
+      "lastAudited": "2026-05-06T12:43:31Z",
+      "result": "issues-fixed"
     },
     "cantors-theorem": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -96,10 +96,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization reveals that Lawvere's categorical fixed-point theorem, Kleene's domain-theoretic fixed-point theorem, and the Y combinator of \u03bb-calculus are three incarnations of the same self-referential principle. The Kleene chain construction is fully proved with the least-fixed-point property. The Y combinator is shown to be definitionally equal to Lawvere's diagonal construction. The one remaining sorry connects the Lawvere and Kleene constructions in the general lattice setting.",
+    "summary": "This formalization reveals that Lawvere's categorical fixed-point theorem, Kleene's domain-theoretic fixed-point theorem, and the Y combinator of \u03bb-calculus are three incarnations of the same self-referential principle. The Kleene chain construction is fully proved with the least-fixed-point property. The Y combinator is shown to be definitionally equal to Lawvere's diagonal construction. The Lawvere\u2013Kleene connection is captured by `lawvere_is_least_when_eq_kleene`: when the Lawvere and Kleene fixed points coincide, the Lawvere fixed point inherits the least-fixed-point property. The unconditional coincidence (without assuming they are equal) remains an open mathematical question, not a Lean gap.",
     "implications": "The unification of these three perspectives \u2014 categorical (Lawvere), order-theoretic (Kleene/Scott), and type-theoretic (Y combinator) \u2014 provides a foundation for formalizing denotational semantics in Lean 4. The insight that self-application and diagonalization are the same operation connects Cantor's theorem, G\u00f6del's incompleteness, recursive function theory, and domain theory into a single framework.",
     "openQuestions": [
-      "Can the remaining sorry (Lawvere-Kleene coincidence in general lattices) be proved by showing the Lawvere construction is \u03c9-continuous when the retraction maps are continuous?",
+      "Can the unconditional Lawvere\u2013Kleene coincidence (in general lattices, without assuming `lawvereFixpoint = kleeneFix`) be proved by showing the Lawvere construction is \u03c9-continuous when the retraction maps are continuous?",
       "Can Scott's D\u221e construction (the inverse limit D_0 \u2190 D_1 \u2190 ... where D_{n+1} = [D_n \u2192 D_n]) be formalized in Lean 4 with Mathlib's category theory?",
       "Can the connection to G\u00f6del's incompleteness theorem be made formal \u2014 using Lawvere's theorem to derive the diagonal lemma?"
     ]


### PR DESCRIPTION
## Summary

The Lean file `proofs/Proofs/CantorDiagonalizationOQ04OQ03.lean` is fully verified (0 sorries, 0 axioms), but `meta.json`'s `conclusion.summary` and `openQuestions[0]` referenced "the one remaining sorry connecting Lawvere and Kleene constructions in the general lattice setting." This is narrative drift — there is no remaining sorry.

The Lawvere–Kleene connection in the file is captured by `lawvere_is_least_when_eq_kleene` (line 211), which is a **conditional** theorem: it assumes `lawvereFixpoint encode decode f = kleeneFix f` and concludes the least-fixed-point property. The unconditional coincidence is an open mathematical question, not a Lean gap.

## Changes

- `conclusion.summary`: replace "The one remaining sorry connects..." with an accurate description of `lawvere_is_least_when_eq_kleene` and note that the unconditional coincidence is an open math question, not a Lean gap.
- `openQuestions[0]`: reframe to ask about the unconditional coincidence rather than "the remaining sorry".
- `audit-tracker.json`: bump `auditCount` 1 → 2, set `result: issues-fixed`.

## Verification (against `origin/main`)

| Field | meta.json | Lean file | Match |
|---|---|---|---|
| lineCount | 299 | 299 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 12 | 12 | ✓ |
| definitionCount | 6 | 6 (4 `def` + 2 `noncomputable def`) | ✓ |
| sorries | 0 | 0 | ✓ |

`status: verified` and `badge: original` are appropriate.

## Test plan

- [x] Numerical counts re-verified against `origin/main`
- [x] `meta.json` is valid JSON
- [x] No structural changes to Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)