### PR TITLE
fix(meta): erdos-895 — sync lineCount 260→462, theoremCount 15→18

### DIFF
--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -46,10 +46,10 @@
       "Formalization of Hajnal's open generalization"
     ],
     "axiomCount": 0,
-    "lineCount": 260,
+    "lineCount": 462,
     "assumptions": "No axioms. 3 sorries remain in the formalization.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 14
   },
   "overview": {
@@ -156,9 +156,9 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 260,
+    "lineCount": 462,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 14,
     "sorries": 3,
     "path": "Proofs/Erdos895Problem.lean",


### PR DESCRIPTION
## Fix

Sync `meta.json` count fields for `erdos-895` to match actual Lean source on `origin/main`.

## Evidence

**Entry**: `erdos-895` (`Proofs/Erdos895Problem.lean`)

**Before**:
- `lineCount`: 260 (both `meta` and `leanFile` blocks)
- `theoremCount`: 15 (both blocks)

**After**:
- `lineCount`: 462 ✓ (verified: `git show origin/main:proofs/Proofs/Erdos895Problem.lean | wc -l = 462`)
- `theoremCount`: 18 ✓ (13 public + 5 private/protected)

**Root cause**: Research PRs #16105, #16114, #16121 grew the Lean file from 260 to 462 lines by adding proven lemmas (`exists_large_indep_of_bounded_degree`, `schur_4_colorable`, `schur_5_forced`) and expanding theorem proofs. Fix PR #16148 corrected the `sorries` count (7→3) but did not update `lineCount` or `theoremCount`.

**Theorem count breakdown** (18 total, following convention from old state where 15 = 13 public + 2 private):
- Public (13): `barber_theorem`, `erdos_895`, `counterexample_17`, `threshold_sharp`, `ramsey_3_3`, `triangleFree_independence_bound`, `schur_2`, `erdos895_implies_schur_variant`, `hajnal_conjecture_open`, `mantel_theorem`, `dense_triangleFree_independence`, `erdos895_sat_verified`, `erdos_895_summary`
- Private (5): `pairOf6_edgeIdx6`, `r33_via_edges`, `exists_large_indep_of_bounded_degree`, `schur_4_colorable`, `schur_5_forced`

**Note**: In-flight PR #16194 (`feature/researcher-6-schur2-proof`) also modifies this `meta.json` and will need to be rebased after this lands.

---
Automated fix by lean-mechanic agent.