### PR TITLE
fix(meta): sync lineCount/theoremCount for buffons-needle-oq04 and hilbert-15-oq03

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
     "assumptions": "2 structure-encoded assumptions in AngularAverageData: angularAvg_eq (the angular average on RP^{n-1} is proportional to norm with constant sigma_{n-2}/(n-1)), angularAvg_nonneg (non-negativity). These encode integration on the unit sphere which Mathlib lacks.",
-    "lineCount": 394,
-    "theoremCount": 25,
+    "lineCount": 437,
+    "theoremCount": 27,
     "definitionCount": 4,
     "originalContributions": [
       "sphereArea: sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) with n=0,1,2 computed",
@@ -109,9 +109,9 @@
   },
   "leanFile": {
     "namespace": "CauchyCrofton",
-    "lineCount": 394,
+    "lineCount": 437,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 4,
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
     "sorries": 1

--- a/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 200,
+    "lineCount": 249,
     "theoremCount": 8,
     "definitionCount": 4,
     "mathlibDependencies": ["Mathlib.Tactic", "Mathlib.Data.Finset.Basic", "Mathlib.Data.Fin.Basic"],
@@ -107,7 +107,7 @@
   "leanFile": {
     "path": "Proofs/Hilbert15OQ02OQ03.lean",
     "axiomCount": 3,
-    "lineCount": 200,
+    "lineCount": 249,
     "theoremCount": 8,
     "definitionCount": 4,
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.json` count fields for two gallery entries after research PRs added content without updating metadata.

## Entry 1: buffons-needle-oq-01-oq-01-oq-04

**Before**: lineCount=394, theoremCount=25 (both meta and leanFile blocks)

**After**: lineCount=437, theoremCount=27

**Root cause**: Research PR #16165 added 43 lines (`cauchyCrofton_product` and `cauchyCroftonConst_tendsto_zero` theorems + supporting content). Meta was not updated.

**Verification**:
- `git show origin/main:proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean | wc -l = 437`
- Theorem count: 27 (including private lemmas per counting convention)

## Entry 2: hilbert-15-oq-02-oq-03

**Before**: lineCount=200 (both meta and leanFile blocks)

**After**: lineCount=249

**Root cause**: Research PR #16189 created the entry with 249 lines but set `lineCount: 200` in meta.json. Theorem count (8) and definition count (4) are already correct.

**Verification**:
- `git show origin/main:proofs/Proofs/Hilbert15OQ02OQ03.lean | wc -l = 249`
- Theorem count: 8 (unchanged — `Partition.zero_weight`, `horn_ineq_swap`, `lr_positivity_reduces_to_lp`, `horn_scale`, `lr_polytime_positivity`, `weyl_inequality`, `admissible_triple_count_bound`, `total_horn_constraints`)

---
Automated fix by lean-mechanic agent.