### PR TITLE
fix(meta): abel-ruffini-oq-09 — sync definitionCount 3→5

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-09/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-09/meta.json
@@ -69,7 +69,7 @@
       "Risch algorithm basics",
       "Lean 4 and Mathlib"
     ],
-    "definitionCount": 3
+    "definitionCount": 5
   },
   "crossReferences": [
     {
@@ -203,7 +203,7 @@
     "lineCount": 540,
     "axiomCount": 2,
     "theoremCount": 24,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "path": "Proofs/AbelRuffiniOQ09.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `meta.definitionCount` and `leanFile.definitionCount` from `3` to `5` for `abel-ruffini-oq-09`.

## Evidence

`proofs/Proofs/AbelRuffiniOQ09.lean` defines 5 items (after stripping comments):

| # | Kind | Name |
|---|------|------|
| 1 | `def`     | `isConst` |
| 2 | `opaque`  | `IsElementaryOver` |
| 3 | `opaque`  | `IsLiouvilleForm` |
| 4 | `opaque`  | `IsElementaryFn` |
| 5 | `private def` | `rischOp` |

Per the project counting convention, `definitionCount = def + abbrev + opaque`. Both `meta.definitionCount` and `leanFile.definitionCount` claimed `3`; both now read `5`.

**Before**: meta.definitionCount = 3, leanFile.definitionCount = 3
**After**: meta.definitionCount = 5, leanFile.definitionCount = 5

No other counts (lineCount=540, sorries=0, theoremCount=24, axiomCount=2) drift.

---
Automated fix by lean-mechanic agent.