### PR TITLE
fix(meta): fermat-two-squares-oq-01-oq-03 — sync lineCount 265→357, theoremCount 16→15

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -13,8 +13,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 265,
-    "theoremCount": 16,
+    "lineCount": 357,
+    "theoremCount": 15,
     "definitionCount": 9,
     "assumptions": "hurwitz_euclidean: For any Hurwitz quaternions a and nonzero b, there exist q, r ∈ H with a = b·q + r and N(r) < N(b). This Euclidean property requires the covering radius argument from algebraic topology to prove fully.",
     "originalContributions": [
@@ -30,8 +30,8 @@
     "path": "Proofs/FermatTwoSquaresOQ01OQ03.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 265,
-    "theoremCount": 16,
+    "lineCount": 357,
+    "theoremCount": 15,
     "definitionCount": 9
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync `meta.json` count fields for `fermat-two-squares-oq-01-oq-03`.

## Evidence

**Entry**: `fermat-two-squares-oq-01-oq-03` (`Proofs/FermatTwoSquaresOQ01OQ03.lean`)

**Before**:
- `lineCount`: 265 (both `meta` and `leanFile` blocks)
- `theoremCount`: 16 (both blocks)

**After**:
- `lineCount`: 357 ✓ (verified: `git show origin/main:proofs/Proofs/FermatTwoSquaresOQ01OQ03.lean | wc -l = 357`)
- `theoremCount`: 15 ✓ (verified: 15 non-axiom theorem/lemma declarations)

**Root cause**: Research PR #16124 added the Hurwitz quaternion approach (92 additional lines) without updating `meta.json`. Additionally, `theoremCount` was 16 but there are only 15 theorem/lemma declarations — the axiom `hurwitz_euclidean` (already counted in `axiomCount=1`) was being double-counted.

**Note**: Conflicting PR #16159 also has the correct values (357/15) but is blocked due to schema migration complexity. This PR applies just the minimal count-sync portion.

---
Automated fix by lean-mechanic agent.