### PR TITLE
audit(tracker): clean audits for 3 unaudited proofs (abel-ruffini, hilbert-15, law-of-cosines)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14821,9 +14821,9 @@
       "issues": []
     },
     "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T11:11:52Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-06T13:04:41Z",
+      "result": "clean",
       "issues": []
     },
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-03": {
@@ -14866,6 +14866,30 @@
       "auditCount": 1,
       "lastAudited": "2026-05-06T12:03:29Z",
       "result": "issues-fixed",
+      "issues": []
+    },
+    "hilbert-10-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T12:49:43Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T13:05:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-15-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T13:06:11Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-cosines-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T13:07:31Z",
+      "result": "clean",
       "issues": []
     }
   },


### PR DESCRIPTION
## Summary

Records clean audit results for the 3 previously-unaudited gallery proofs and reverts angle-trisection to clean (false positive).

### Audited (clean)

- **abel-ruffini-galois-extensions-oq-05-oq-01** — status \`axiomatized\` + badge \`axiom\` justified by \`galois_compositum_product\` axiom. Counts match: 1 axiom, 8 theorems, 0 sorries.
- **hilbert-15-oq-02-oq-03** — status \`axiomatized\` + badge \`axiom\` justified by 3 axioms (\`lrCoeffN\`, \`admissible\`, \`klyachko_theorem\`). Sorries=0. Minor lineCount/definitionCount drift addressed in #16206.
- **law-of-cosines-oq-01-oq-01** — status \`verified\` + badge \`original\` justified: 0 sorries, 0 axioms, 22 theorems (incl. 1 private \`abs_inner_div_le\`), 3 defs, 334 lines — all match meta. Imports sibling \`SphericalLawOfCosines\` (gallery file, not Mathlib wrapper).

### False positive cleared

- **angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01** — \`find-targets\` reported "claims 2, actual 0" sorry mismatch. Investigated: \`origin/main\` Lean file actually has 2 sorries matching meta. The "actual 0" came from in-flight uncommitted edits in the main repo working tree (in-progress work for PR #16149, which is eliminating those sorries on a feature branch). No issue on main.

### Includes

- One prior auditor session's clean entry for \`hilbert-10-oq-04\` (already in working-tree tracker).

## Test plan

- [x] All audited proofs verified by reading meta.json and Lean source from \`origin/main\`
- [x] Sorry/axiom/theorem/def counts cross-checked
- [x] No new entries override conflicting state
- [x] No duplicate of existing audit tracker PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)