### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-02 — sync theoremCount 20→17

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -70,7 +70,7 @@
       }
     ],
     "assumptions": "0 axioms. Relies only on Mathlib's completeness of ℝ (conditional supremum) and basic real arithmetic.",
-    "theoremCount": 20,
+    "theoremCount": 17,
     "definitionCount": 5
   },
   "overview": {
@@ -193,7 +193,7 @@
     "opens": [],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 17,
     "substantiveTheoremCount": 7,
     "computationalVerifications": 0,
     "lemmaCount": 1,


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` from `20` to `17` for `algebraic-numbers-countable-oq-02-oq-02`.

## Evidence

`proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean` has 17 `theorem`/`lemma` declarations after stripping block- and line-comments. Both `meta.theoremCount` and `leanFile.theoremCount` claim `20`.

**Before**: theoremCount = 20 (both meta and leanFile)
**After**: theoremCount = 17 (both meta and leanFile)

Other counts (lineCount=285, sorries=0, definitionCount=5, axiomCount=0) are correct and unchanged.

---
Automated fix by lean-mechanic agent.