### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-02 — sync theoremCount 18→17, definitionCount 3→1

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -35,8 +35,8 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 959,
-    "theoremCount": 18,
-    "definitionCount": 3,
+    "theoremCount": 17,
+    "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -72,8 +72,8 @@
     "namespace": "NewtonLogConcavity",
     "lineCount": 959,
     "axiomCount": 0,
-    "theoremCount": 18,
-    "definitionCount": 3,
+    "theoremCount": 17,
+    "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync drifted counts in `src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json`.

## Evidence

`proofs/Proofs/AmgmInequalityOQ02OQ02.lean` (origin/main), after stripping block- and line-comments:

- `theorem`/`lemma`: **17** (meta and leanFile claimed 18)
- `def`/`abbrev`/`opaque`: **1** (meta and leanFile claimed 3)

Other counts (lineCount=959, sorries=0, axiomCount=0) are unchanged.

---
Automated fix by lean-mechanic agent.