### PR TITLE
fix(meta): amgm-inequality-oq-02 — sync theoremCount 26→25

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -99,7 +99,7 @@
     "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 3
   },
   "crossReferences": [
@@ -303,7 +303,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 26,
+    "theoremCount": 25,
     "substantiveTheoremCount": 17,
     "privateHelperCount": 6,
     "axiomDeclCount": 2,


### PR DESCRIPTION
## Fix

Sync drifted theoremCount in `src/data/proofs/amgm-inequality-oq-02/meta.json`.

## Evidence

`proofs/Proofs/AmgmInequalityOQ02.lean` (origin/main) has **25** `theorem`/`lemma` declarations after stripping comments. Both `meta.theoremCount` and `leanFile.theoremCount` claimed 26.

Other counts (lineCount=543, sorries=0, definitionCount=3, axiomCount=2) are unchanged.

---
Automated fix by lean-mechanic agent.