### PR TITLE
fix(meta): amgm-inequality-oq-04-oq-05 — sync definitionCount 6→3

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 7,
     "lineCount": 242,
     "theoremCount": 8,
-    "definitionCount": 6,
+    "definitionCount": 3,
     "assumptions": "7 axioms: ellipticK (function), ellipticE (function), K_eq_pi_div_2M (Gauss's AGM theorem for k=1/√2), legendre_relation (Legendre's relation for k=1/√2), ellipticE_agm (E via AGM iteration), bs_summable (series convergence from quadratic AGM convergence), S_lt_half (series sum bound). The algebraic derivation π = 4M²/(1-2S) is machine-verified from these axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -153,7 +153,7 @@
     "lineCount": 242,
     "axiomCount": 7,
     "theoremCount": 8,
-    "definitionCount": 6,
+    "definitionCount": 3,
     "path": "Proofs/AmgmInequalityOQ04OQ05.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync drifted definitionCount in `src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json`.

## Evidence

`proofs/Proofs/AmgmInequalityOQ04OQ05.lean` (origin/main) has **3** `def`/`abbrev`/`opaque` declarations after stripping comments. Both `meta.definitionCount` and `leanFile.definitionCount` claimed 6.

Other counts (lineCount=242, sorries=0, theoremCount=8, axiomCount=7) are unchanged.

---
Automated fix by lean-mechanic agent.