### PR TITLE
fix(meta): binary-gcd-oq-01 — sync theoremCount 4→3

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -48,7 +48,7 @@
       "Logarithmic functions on naturals",
       "Well-founded recursion and termination proofs"
     ],
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 2
   },
   "overview": {
@@ -177,7 +177,7 @@
     "namespace": "BinaryGcdOQ01",
     "lineCount": 215,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 2,
     "path": "Proofs/BinaryGcdOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync drifted theoremCount in `src/data/proofs/binary-gcd-oq-01/meta.json`.

## Evidence

`proofs/Proofs/BinaryGcdOQ01.lean` (origin/main) has **3** `theorem`/`lemma` declarations after stripping block- and line-comments. Both `meta.theoremCount` and `leanFile.theoremCount` claimed 4.

Other counts (lineCount=215, sorries=0, definitionCount=2, axiomCount=0) are unchanged.

---
Automated fix by lean-mechanic agent.