### PR TITLE
fix(meta): ballot-problem-oq-01-oq-04 — sync theoremCount 2→1

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -67,7 +67,7 @@
     "lineCount": 73,
     "assumptions": "0 axioms, 0 sorries. The previously stated axiom chung_feller_uniform is now a theorem re-exporting ChungFellerBijection.chung_feller_uniform' from BallotProblemOQ01OQ04OQ01.lean. The full proof spans three files: BallotProblemOQ01OQ04Core.lean (definitions and cycle-lemma bridge), BallotProblemOQ01OQ04OQ01.lean (explicit bijection), and BallotProblemOQ01OQ04.lean (gallery face).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 2,
+    "theoremCount": 1,
     "definitionCount": 0
   },
   "overview": {
@@ -190,7 +190,7 @@
     "namespace": "ChungFeller",
     "lineCount": 73,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 1,
     "substantiveTheoremCount": 1,
     "trivialPlaceholders": 0,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync drifted theoremCount in `src/data/proofs/ballot-problem-oq-01-oq-04/meta.json`.

## Evidence

`proofs/Proofs/BallotProblemOQ01OQ04.lean` (origin/main) has **1** `theorem`/`lemma` declaration after stripping comments. Both `meta.theoremCount` and `leanFile.theoremCount` claimed 2.

Other counts (lineCount=73, sorries=0, definitionCount=0, axiomCount=0) are unchanged.

---
Automated fix by lean-mechanic agent.