### PR TITLE
fix(meta): elementary-quadratic-reciprocity-oq-01-oq-01-oq-02 — theoremCount 5→4

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 216,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` for `elementary-quadratic-reciprocity-oq-01-oq-01-oq-02` from 5 to 4 to match the canonical counting convention.

## Evidence

**Canonical convention** (per `scripts/research/enrich-research.ts:155`): `^(theorem|lemma) ` — does NOT count `private` lemmas.

**File `ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean`** (216 lines on origin/main):

```bash
$ git show origin/main:proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean \
    | grep -nE "^(theorem|lemma|private) "
61:private lemma q_isUnit_in_ZMod_p ...
86:theorem frobenius_step ...
109:theorem qr_via_frobenius ...
135:theorem qr_gauss_sums_identity ...
161:theorem gauss_qr_pathway_complete ...
```

→ 4 public theorems + 1 private lemma → canonical theoremCount = 4.

The 4 public theorems also match the entry's own `originalContributions` list (frobenius_step, qr_via_frobenius, qr_gauss_sums_identity, gauss_qr_pathway_complete).

**Before**: `theoremCount: 5` (incorrectly counts private helper)
**After**: `theoremCount: 4` (matches canonical convention + originalContributions)

Surfaced from audit-tracker `issues-found` entry (lastAudited 2026-05-06T07:47:11Z) which had no detail; verified by running canonical regex against origin/main.

---
Automated fix by lean-mechanic agent.