### PR TITLE
fix(meta): sync buffons-needle-oq-01-oq-01-oq-04 counts after PR #16214

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -17,12 +17,12 @@
       "gamma-function"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
     "assumptions": "2 structure-encoded assumptions in AngularAverageData: angularAvg_eq (the angular average on RP^{n-1} is proportional to norm with constant sigma_{n-2}/(n-1)), angularAvg_nonneg (non-negativity). These encode integration on the unit sphere which Mathlib lacks.",
-    "lineCount": 437,
-    "theoremCount": 27,
+    "lineCount": 568,
+    "theoremCount": 30,
     "definitionCount": 4,
     "originalContributions": [
       "sphereArea: sigma_n = 2*pi^{(n+1)/2}/Gamma((n+1)/2) with n=0,1,2 computed",
@@ -109,12 +109,12 @@
   },
   "leanFile": {
     "namespace": "CauchyCrofton",
-    "lineCount": 437,
+    "lineCount": 568,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 30,
     "definitionCount": 4,
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -133,5 +133,5 @@
       "description": "N-ball volumes use the same Gamma function framework as sphere surface areas"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Sync stale meta.json counts in `src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/` after PR #16214 proved `cauchyCroftonConst_tendsto_zero`, eliminating the last sorry.

## Evidence

**Before** (stale):
- `sorries`: 1 (top-level, meta, leanFile)
- `lineCount`: 437 (meta, leanFile)
- `theoremCount`: 27 (meta, leanFile)

**After** (matches `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean`):
- `sorries`: 0
- `lineCount`: 568 (verified via `wc -l`)
- `theoremCount`: 30 (+3: `cauchyCrofton_recurrence`, `cauchyCrofton_even_sq_bound`, `cauchyCrofton_odd_sq_bound` introduced by #16214)

Resolves auditor finding: `sorry mismatch: claims 1, actual 0` (top of `find-targets` priority list).

---
Automated fix by lean-mechanic agent.