### PR TITLE
fix(meta): laws-of-large-numbers-oq-04-oq-03 — theoremCount 3→4

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 158,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
@@ -99,7 +99,7 @@
     "lineCount": 158,
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 0
   },
   "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `theoremCount` from 3 to 4 in both `meta` and `leanFile` blocks of `src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json`.

## Evidence

`proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean` (origin/main, 158 lines, 0 sorries, 0 axioms) declares **4** theorem-level identifiers:

| Kind    | Name |
| ------- | ---- |
| theorem | `thresholdIndicator_integrable_proved` |
| lemma   | `thresholdIndicator_eq_preimage_indicator_fun` (private) |
| theorem | `integral_thresholdIndicator_eq_cdf_proved` |
| theorem | `empiricalCDF_pointwise_convergence_no_axiom` |

`meta.json` reported only 3 theorems in both `meta.theoremCount` and `leanFile.theoremCount`. The private helper lemma was likely added in PR #16099 (Glivenko-Cantelli integration axiom proofs) without bumping the count.

**Before**: `meta.theoremCount = 3`, `leanFile.theoremCount = 3`.
**After**: both = 4.

No status, badge, sorry, or axiom changes; this is a counts-only sync.

Closes the `result: issues-found` flag for this id in `src/data/proofs/audit-tracker.json`.

---
Automated fix by lean-mechanic agent.