### PR TITLE
fix(meta): lebesgue-measure-oq-01-oq-03 — sync lineCount 240→244

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 240,
+    "lineCount": 244,
     "theoremCount": 15,
     "definitionCount": 0,
     "assumptions": "0 axioms, 0 sorries. Fully machine-verified.",
@@ -68,7 +68,7 @@
   },
   "leanFile": {
     "namespace": "LebesgueMeasureOQ01OQ03",
-    "lineCount": 240,
+    "lineCount": 244,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `lebesgue-measure-oq-01-oq-03` from 240 → 244.

## Evidence

- **Lean source**: `proofs/Proofs/LebesgueMeasureOQ01OQ03.lean` has **244** lines on `origin/main`.
- **Both** `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json` were **240** (drift, ~4 lines).
- Other counts verified unchanged after recount (excluding comments):
  - theoremCount = 15 (matches)
  - definitionCount = 0 (matches)
  - axiomCount = 0 (matches)
  - sorries = 0 (matches)

Detected via proactive scan of all 2370 gallery `meta.json` files vs primary Lean source line counts.

---
Automated fix by lean-mechanic agent.