### PR TITLE
fix(meta): ramsey-r4k-oq-01 — sync lineCount 190→187, add definitionCount=1

### DIFF
--- a/src/data/proofs/ramsey-r4k-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-01/meta.json
@@ -18,8 +18,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 190,
+    "lineCount": 187,
     "theoremCount": 17,
+    "definitionCount": 1,
     "assumptions": "3 axioms: (1) ramseyR4k_classical_upper \u2014 classical binomial bound R(4,k) \u2264 C(k+2,3), proved in parent file; (2) aks_r4k_upper \u2014 AKS probabilistic deletion bound R(4,k) \u2264 C\u00b7k\u00b3/(log k)\u00b2, requires triangle-free process; (3) mv_r4k_lower \u2014 Mattheus-Verstra\u00ebte algebraic geometry bound R(4,k) \u2265 c\u00b7k\u00b3/(log k)\u2074, requires Hermitian varieties over F_q.",
     "mathlibDependencies": [
       {
@@ -151,7 +152,8 @@
   "leanFile": {
     "axiomCount": 3,
     "theoremCount": 17,
-    "lineCount": 190,
+    "definitionCount": 1,
+    "lineCount": 187,
     "sorries": 0
   }
 }


### PR DESCRIPTION
## Fix

Two drift issues in `src/data/proofs/ramsey-r4k-oq-01/meta.json`:

1. `lineCount` was **190** in both `meta` and `leanFile` blocks — actual is **187**.
2. `definitionCount` was **missing entirely** from both blocks — actual is **1**.

## Evidence

Verified against `proofs/Proofs/RamseyR4kOQ01.lean` on `origin/main`:

- Lines: 187 (`git show origin/main:proofs/Proofs/RamseyR4kOQ01.lean | wc -l`)
- After comment-strip: 17 theorems/lemmas, 1 definition (`def`/`abbrev`/`opaque`), 3 axioms, 0 sorries.

Other counts (axioms=3, theorems=17, sorries=0) are unchanged and match.

Detected via proactive scan of all 2370 gallery `meta.json` files vs Lean source on `origin/main`.

---
Automated fix by lean-mechanic agent.