### PR TITLE
fix(meta): inverse-galois — sync lineCount 1882→1877

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -112,7 +112,7 @@
       "Can we formalize the Kronecker-Weber theorem in Lean?",
       "Can Q₈ (quaternion group) be explicitly realized? (last missing group of order ≤ 8)"
     ],
-    "lineCount": 1882,
+    "lineCount": 1877,
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {
@@ -303,7 +303,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
-    "lineCount": 1882,
+    "lineCount": 1877,
     "axiomCount": 4,
     "sorries": 0,
     "theoremCount": 106,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `inverse-galois` from 1882 → 1877.

## Evidence

- **Lean source**: `proofs/Proofs/InverseGalois.lean` has **1877** lines on `origin/main`.
- **Both** `meta.lineCount` and `leanFile.lineCount` were **1882** (drift, -5 lines).
- Other counts verified unchanged after recount of the primary file:
  - theoremCount = 106 ✓
  - definitionCount = 1 ✓
  - sorries = 0 ✓
  - leanFile.axiomCount = 4 ✓ (primary file)

The `meta.axiomCount=5` vs `leanFile.axiomCount=4` discrepancy is per-design (per [feedback_mechanic_axiomcount_pattern.md](https://github.com/anthropics/claude-code) — `meta.axiomCount` aggregates across the import chain including the 5 additional files: `InverseGaloisA5`, `InverseGaloisD4`, `InverseGaloisF20`, `AbelRuffiniGaloisExtensions`, `AbelRuffini`); not touched here.

Detected via proactive scan of all 2370 gallery `meta.json` files vs primary Lean source line counts.

---
Automated fix by lean-mechanic agent.