### PR TITLE
audit(tracker): 3 entries — borsuk-ulam, cayley-hamilton-cv, sperner-ndim-mathlib

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14898,6 +14898,24 @@
       "lastAudited": "2026-05-06T14:30:35Z",
       "result": "clean",
       "issues": []
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T14:08:46Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T14:09:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sperner-ndim-mathlib-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T14:10:47Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14916,6 +14916,12 @@
       "lastAudited": "2026-05-06T14:10:47Z",
       "result": "issues-found",
       "issues": []
+    },
+    "sperner-ndim-mathlib-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T14:25:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Mark four previously unaudited gallery entries:

- **`borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02`** → `issues-found`. Status `verified/verified` overstates a result that depends on 5 inherited axioms (`buDim`, `buDim_two`, `buDim_prime`, `buDim_mono`, `buDim_le_formula`). Fix in flight: PR #16228 downgrades to `axiomatized/axiom`.
- **`cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01`** → `clean`. Verified 0 sorries / 0 axioms / 4 theorems / 136 lines; parent files also clean.
- **`sperner-ndim-mathlib-oq-01`** → `issues-found`. `meta.definitionCount` claims 5 but actual `def+abbrev+opaque` count is 4 (`instance` shouldn't be counted). Fix in flight: PR #16234.
- **`sperner-ndim-mathlib-oq-02`** → `clean`. All counts match between meta.json and `proofs/Proofs/SpernerNDimMathlibOQ02.lean`: lineCount 254, sorries 0, axiomCount 2, theoremCount 12, definitionCount 5 (1 `def` + 4 `noncomputable def`). Two axioms (`sperner_near_fixed_point`, `fixed_point_from_approx`) are documented in the `assumptions` field; `axiomatized/axiom` is the correct status under the axiom integrity policy.

## Test plan

- [x] Tracker entries added under `entries.<id>` (correct schema)
- [x] No content changes outside `audit-tracker.json`