### PR TITLE
audit(sperner-ndim-mathlib-oq-01): sync theoremCount 8→7

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
@@ -33,7 +33,7 @@
       "freudenthalCellComplex: concrete CellComplex (Finset (Fin n)) n for the Freudenthal triangulation",
       "freudenthal_sperner: Sperner's lemma for the Freudenthal complex (proved from axioms)"
     ],
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 5
   },
   "leanFile": {
@@ -41,7 +41,7 @@
     "sorries": 0,
     "axiomCount": 4,
     "lineCount": 241,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 5,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerNDimMathlibOQ01.lean"


### PR DESCRIPTION
## Summary

`proofs/Proofs/SpernerNDimMathlibOQ01.lean` (241 lines, origin/main) has **7** `theorem`/`lemma` declarations, but `meta.json` and `leanFile.theoremCount` both claim **8**.

| Line | Declaration |
|------|-------------|
| 73 | theorem isFC_bridge |
| 77 | theorem isDoorAt_bridge |
| 83 | theorem sperner_from_triangulation |
| 92 | theorem boundary_doors_agree |
| 125 | lemma swapAdj_length |
| 131 | lemma swapAdj_invol |
| 232 | theorem freudenthal_sperner |

The 4 `axiom` declarations and 1 `instance` declaration are not theorem/lemma forms and aren't counted.

Companion fix to in-flight PR #16234 (definitionCount 5→4 for the same proof). Both can land independently — they touch different fields.

## Test plan

- [x] Both `meta.theoremCount` and `leanFile.theoremCount` updated to 7
- [x] No other fields modified
- [x] JSON parses cleanly