### PR TITLE
fix(meta): cayley-hamilton-minpoly-oq-02-oq-01-oq-02 — correct leanFile.path prefix

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
@@ -51,7 +51,7 @@
     ]
   },
   "leanFile": {
-    "path": "proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
+    "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 171,


### PR DESCRIPTION
## Fix

Corrects the `leanFile.path` in `cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json`.

## Evidence

**Before**: `"path": "proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean"` (has extra `proofs/` prefix)
**After**: `"path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean"` (matches gallery path convention)

All other gallery entries store `leanFile.path` as `Proofs/XXX.lean` (relative to `proofs/` directory). This entry was the only one with a doubled prefix, which would cause the auditor and any path-based tooling to fail to locate the file.

The actual Lean file `proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean` exists and is correct (171 lines, 0 sorries, 0 axioms). Only the path reference in meta.json was wrong.

---
Automated fix by lean-mechanic agent.