### PR TITLE
audit(cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14892,6 +14892,12 @@
       "lastAudited": "2026-05-06T14:36:05Z",
       "result": "issues-found",
       "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T14:30:35Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit Summary

Verified gallery integrity for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01` (status: `verified` / badge: `original`).

## Checks Performed

| Check | meta.json | Source | Result |
|-------|-----------|--------|--------|
| lineCount | 136 | 136 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 0 | 0 | ✓ |

## Inherited Assumption Audit

`additionalFiles`:
- `Proofs/CayleyHamiltonCyclicVectorAllFields.lean` — 0 sorries, 0 axioms
- `Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean` — 0 sorries, 0 axioms

No hidden assumptions inherited from non-Mathlib imports.

## Tier / Badge Verdict

`verified` / `original` is defensible. The core mathematical contribution (cyclic vector → nonderogatory) is the degree-squeeze argument and the monic-quotient closing, which is the file's own work. Cayley-Hamilton (Mathlib's `Matrix.aeval_self_charpoly`) is invoked as one supporting step but is not the core argument, so this is Tier A rather than Tier B. The four `originalContributions` listed in meta.json each correspond to a theorem in the source.

---
Auto-generated by Lean Auditor.