### PR TITLE
audit(tracker): batch — 2 clean (area-of-circle, bezout) + 2 issues-found (buffons, borsuk)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -498,9 +498,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-03-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:47Z",
+      "lastAudited": "2026-05-06T14:37:12Z",
       "result": "clean"
     },
     "area-of-circle-oq-05": {
@@ -878,9 +878,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:48Z",
+      "lastAudited": "2026-05-06T14:37:43Z",
       "result": "clean"
     },
     "bezout-identity-oq-03": {
@@ -1365,10 +1365,10 @@
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T01:39:50Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-06T14:34:38Z",
+      "result": "issues-found"
     },
     "buffons-needle-oq-01-oq-02": {
       "auditCount": 3,
@@ -14884,6 +14884,12 @@
     "sperner-ndim-mathlib-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-05-06T14:46:33Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T14:36:05Z",
       "result": "issues-found",
       "issues": []
     }


### PR DESCRIPTION
## Summary
Records 4 audit results in audit-tracker.json:

- **area-of-circle-oq-03-oq-03-oq-02 — clean**: verified/original; theoremCount=12, defs=1, sorries=0, axiomCount=0, lineCount=189 all match Lean source.
- **bezout-identity-oq-02-oq-04 — clean**: verified/mathlib (Tier B) correctly badged for Mathlib's Gauss lemma reliance; theoremCount=7, defs=0, sorries=0, axiomCount=0, lineCount=170 all match.
- **buffons-needle-oq-01-oq-01-oq-04 — issues-found**: meta claims sorries=1 but Lean source has 0 (after #16214). Already tracked by in-flight PRs #16224, #16225, #16226. Tracker entry was previously `issues-fixed` from earlier audit; restored to `issues-found` since meta drift on origin/main has reappeared.
- **borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02 — issues-found**: status `verified/verified` but the entry's own `assumptions` field admits 5 inherited axioms (buDim, buDim_two, buDim_prime, buDim_mono, buDim_le_formula). Per CLAUDE.md axiom integrity policy, this should be `axiomatized/axiom`. Already tracked by in-flight PR #16228.

## Test plan
- [ ] CI passes (data-only change to audit-tracker.json)
- [ ] No conflicts with other open auditor tracker PRs (#16232, #16242, #16243, #16247) — these touch the same file; either merge order resolves naturally or rebase will be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)