### PR TITLE
fix(meta): cantor-diagonalization-oq-01 — sync theoremCount 28→27

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -49,7 +49,7 @@
     "lineCount": 442,
     "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 28,
+    "theoremCount": 27,
     "definitionCount": 5
   },
   "overview": {
@@ -229,7 +229,7 @@
     "namespace": "CantorDiagonalizationOQ01",
     "lineCount": 442,
     "axiomCount": 2,
-    "theoremCount": 28,
+    "theoremCount": 27,
     "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` from 28 → 27 to match the actual count in `Proofs/CantorDiagonalizationOQ01.lean` at origin/main.

## Evidence

Stripped Lean comments and counted `^(?:private |protected |noncomputable )*(?:theorem|lemma)` declarations in the file:

```
27 theorems
```

| Field            | Before | After (actual) |
|------------------|--------|----------------|
| `meta.theoremCount`     | 28 | **27** ✅ |
| `leanFile.theoremCount` | 28 | **27** ✅ |
| `lineCount`             | 442 | 442 ✓ |
| `axiomCount`            | 2   | 2 ✓ |
| `definitionCount`       | 5   | 5 ✓ |
| `sorries`               | 0   | 0 ✓ |

Other counts already match the source. Status (`axiomatized`) and badge (`axiom`) remain correct (2 axioms: `konig_cofinality_bound`, `aleph_omega_cofinality_is_aleph_zero`).

---
Automated fix by lean-mechanic agent.