### PR TITLE
fix(meta): bounded-prime-gaps-oq-04-oq-02 — sync theoremCount 11→10

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-02/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "axiomCount": 6,
     "lineCount": 599,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "assumptions": "6 axioms: gaussSumBound (|τ(χ)| = √q for primitive characters), polyaVinogradov (|Σ χ(n)| ≤ √q·log q), largeSieve (bilinear exponential sum bound), siegelWalfisz (ψ(x;q,a) = x/φ(q) + O(xe^{-c√log x}) for small q), vaughanIdentity (von Mangoldt decomposition into bilinear sums), zeroDensityEstimate (N(σ,T,χ) ≪ (qT)^{A(1-σ)}). These are proved theorems missing from Mathlib, not mathematical assumptions.",
     "originalContributions": [
       "dirichletGaussSum: definition of τ(χ) = Σ χ(t)·e^{2πit/q}",
@@ -145,7 +145,7 @@
     "namespace": "BoundedPrimeGapsOQ04OQ02",
     "lineCount": 599,
     "axiomCount": 6,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 8,
     "path": "Proofs/BoundedPrimeGapsOQ04OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` from 11 → 10 to match `Proofs/BoundedPrimeGapsOQ04OQ02.lean` at origin/main.

## Evidence

Stripped Lean comments and counted `(?:theorem|lemma)` declarations — 10 found:

```
vonMangoldt_nonneg', chebyshevPsi_mono, chebyshevPsiAP_le_chebyshevPsi,
expectedMainTerm_pos, expectedMainTerm_q_one, bv_error_nonneg_terms,
total_new_code, first_two_independent, bv_from_minimal_additions,
gaussSum_product_structure
```

| Field            | Before | After (actual) |
|------------------|--------|----------------|
| `meta.theoremCount`     | 11 | **10** ✅ |
| `leanFile.theoremCount` | 11 | **10** ✅ |
| `lineCount`             | 599 | 599 ✓ |
| `axiomCount`            | 6   | 6 ✓ |
| `definitionCount`       | 8   | 8 ✓ |
| `sorries`               | 0   | 0 ✓ |

Status (`axiomatized`) and badge (`axiom`) remain correct (6 axioms: gaussSumBound, polyaVinogradov, largeSieve, siegelWalfisz, vaughanIdentity, zeroDensityEstimate).

---
Automated fix by lean-mechanic agent.