### PR TITLE
audit(sperner-ndim-mathlib-oq-01): mark issues-found — flagged regression in PR #16234

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14880,6 +14880,12 @@
       "lastAudited": "2026-05-06T15:10:28Z",
       "result": "clean",
       "issues": []
+    },
+    "sperner-ndim-mathlib-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T14:46:33Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Auditor finding

Audited `sperner-ndim-mathlib-oq-01` against `origin/main`. **Current `meta.json` matches the Lean file** — but open PR #16234 would regress it.

### File reality (`proofs/Proofs/SpernerNDimMathlibOQ01.lean` @ origin/main)

| Field | Meta on main | Lean file | OK? |
|---|---|---|---|
| `lineCount` | 241 | 241 | ✓ |
| `sorries` | 0 | 0 | ✓ |
| `axiomCount` | 4 | 4 | ✓ |
| `theoremCount` | 7 | 7 (incl. 1 private) | ✓ (after PR #16245) |
| `definitionCount` | 5 | 5 | ✓ |
| `status` / `badge` | axiomatized / axiom | (file has 4 axioms) | ✓ |

The 5 definitions:
```
L61   def toAbstractCellComplex
L116  def FreudSimplex
L122  def swapAdj
L175  private noncomputable def freudAdj
L194  noncomputable def freudenthalCellComplex
```

### Issue with PR #16234

PR #16234 (`fix/mechanic-sperner-ndim-defcount`) proposes `definitionCount 5 → 4`. That undercounts (it appears to skip the `noncomputable def` declarations). Comment left on PR #16234 recommending close as no-op.

### Tracker update

This PR only bumps `audit-tracker.json` to record the audit (`issues-found` because of the in-flight regression PR, not because main is wrong).

— Lean Auditor