### PR TITLE
fix(meta): fundamental-theorem-calculus-oq-02 — sync narrative after d²=0 + Green's proofs

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -49,8 +49,8 @@
       "Poincare lemma in 1D: every continuous 1-form is exact (closed => exact on R)",
       "Antiderivative uniqueness: two antiderivatives differ by a constant",
       "De Rham cohomology: H^0(R)=R (constants), H^1(R)=0 (all closed forms exact)",
-      "Green's theorem stated as 2D Stokes theorem with OneForm2D structure",
-      "d^2 = 0 (Clairaut's theorem) stated for C^2 functions on R^2"
+      "Green's theorem proved as 2D Stokes theorem via GreensTheoremOQ01.greens_theorem_concrete",
+      "d^2 = 0 (Clairaut's theorem) proved for C^2 functions on R^2 via ContDiff.contDiffAt.isSymmSndFDerivAt"
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 395,
@@ -61,11 +61,11 @@
   "overview": {
     "historicalContext": "The generalized Stokes theorem is one of the crowning achievements of 19th-century mathematics. George Gabriel Stokes formulated the surface integral version in 1854 (as a Smith's Prize exam question at Cambridge). The 2D version (Green's theorem) was published by George Green in 1828, and the 3D volume version (divergence theorem) by Gauss and Ostrogradsky. The unification of all these into a single identity on differential forms was achieved by Elie Cartan in the 1940s using the exterior calculus he developed. The modern formulation \u2014 for smooth manifolds with boundary, using differential forms and the exterior derivative \u2014 reveals that FTC, Green's theorem, the classical Stokes theorem, and the divergence theorem are all the same theorem in different dimensions.",
     "problemStatement": "Formalize the generalized Stokes theorem $\\int_M d\\omega = \\int_{\\partial M} \\omega$ for manifolds with boundary, showing the Fundamental Theorem of Calculus as the $n=1$ case where $M = [a,b]$, $\\omega = F$, and $d\\omega = F'\\,dx$.",
-    "text": "A 345-line formalization presenting the generalized Stokes theorem as a unifying framework for the fundamental integral theorems of calculus. Defines differential k-forms concretely in dimensions 1 and 2 with exterior derivatives, then proves the key results: Stokes in 1D equals FTC Part 2 (from Mathlib, 0 sorries), the Poincare lemma (closed 1-forms on R are exact), antiderivative uniqueness, de Rham cohomology (H^0=R, H^1=0), and orientation-reversal. States d^2=0 (Clairaut) and Green's theorem in Stokes form. Contains 11 theorems and 8 definitions with 2 sorries (both have clear proof paths).",
-    "proofStrategy": "The formalization proceeds dimension by dimension:\n\n**1D (proved):** Define 0-forms (functions), 1-forms (coefficients of dx), and the exterior derivative d(F) = F'dx. Prove Stokes = FTC using Mathlib's `integral_eq_sub_of_hasDerivAt_of_le`. Prove the Poincare lemma using `integral_hasDerivAt_right` (the integral function is an antiderivative). Prove H^0 = constants using `is_const_of_deriv_eq_zero`.\n\n**2D (stated):** Define OneForm2D = (P,Q) and exterior derivatives d_0(f) = (df/dx, df/dy) and d_1(P,Q) = dQ/dx - dP/dy. State d^2 = 0 (Clairaut) and Green's theorem as \u222b_{partial R} omega = \u222b_R d(omega).\n\n**General (documented):** Describe the requirements for the fully general theorem on manifolds with boundary.",
+    "text": "A 395-line formalization presenting the generalized Stokes theorem as a unifying framework for the fundamental integral theorems of calculus. Defines differential k-forms concretely in dimensions 1 and 2 with exterior derivatives, then proves the key results: Stokes in 1D equals FTC Part 2 (from Mathlib, 0 sorries), the Poincare lemma (closed 1-forms on R are exact), antiderivative uniqueness, de Rham cohomology (H^0=R, H^1=0), orientation-reversal, d^2=0 (Clairaut) via ContDiff.contDiffAt.isSymmSndFDerivAt, and Green's theorem in Stokes form via GreensTheoremOQ01.greens_theorem_concrete. Contains 11 theorems and 7 definitions with 0 sorries.",
+    "proofStrategy": "The formalization proceeds dimension by dimension:\n\n**1D (proved):** Define 0-forms (functions), 1-forms (coefficients of dx), and the exterior derivative d(F) = F'dx. Prove Stokes = FTC using Mathlib's `integral_eq_sub_of_hasDerivAt_of_le`. Prove the Poincare lemma using `integral_hasDerivAt_right` (the integral function is an antiderivative). Prove H^0 = constants using `is_const_of_deriv_eq_zero`.\n\n**2D (proved):** Define OneForm2D = (P,Q) and exterior derivatives d_0(f) = (df/dx, df/dy) and d_1(P,Q) = dQ/dx - dP/dy. Prove d^2 = 0 (Clairaut) via `ContDiff.contDiffAt.isSymmSndFDerivAt`, and Green's theorem as \u222b_{partial R} omega = \u222b_R d(omega) via `GreensTheoremOQ01.greens_theorem_concrete`.\n\n**General (documented):** Describe the requirements for the fully general theorem on manifolds with boundary.",
     "keyInsights": [
       "The Fundamental Theorem of Calculus is the 1D Stokes theorem: M=[a,b] is a 1-manifold with boundary {a,b}, omega=F is a 0-form, and d(omega)=F'dx is a 1-form",
-      "d^2 = 0 (the key structural property enabling de Rham cohomology) corresponds to Clairaut's theorem on equality of mixed partial derivatives; the sorry is explained: bridging Mathlib's iteratedFDeriv symmetry to concrete partial derivative expressions is non-trivial",
+      "d^2 = 0 (the key structural property enabling de Rham cohomology) corresponds to Clairaut's theorem on equality of mixed partial derivatives; this is proved here via ContDiff.contDiffAt.isSymmSndFDerivAt, which bridges Mathlib's iteratedFDeriv symmetry to the concrete partial derivative expressions in OneForm2D",
       "The Poincare lemma (closed => exact on contractible domains) gives H^1_dR(R) = 0, while H^1_dR(S^1) = R shows topology matters \u2014 the angle form d\u03b8 on S^1 is closed but not exact",
       "Orientation-reversal negates the integral \u2014 this is why boundary orientation must be induced consistently from the manifold orientation; `integral_symm` from Mathlib captures this unconditionally",
       "Green's theorem (2D Stokes) decomposes into FTC applied to each partial derivative plus Fubini to swap integration order; the proof delegates to GreensTheoremOQ01 which has 0 sorries",
@@ -115,33 +115,32 @@
     {
       "id": "dd-zero",
       "title": "d-squared = 0 (Clairaut's Theorem)",
-      "startLine": 190,
-      "endLine": 212,
-      "summary": "States that d_1(d_0(f)) = 0 for C^2 functions, which is Clairaut's theorem on equality of mixed partial derivatives. This is the fundamental property enabling de Rham cohomology.",
+      "startLine": 191,
+      "endLine": 244,
+      "summary": "Proves that d_1(d_0(f)) = 0 for C^2 functions via ContDiff.contDiffAt.isSymmSndFDerivAt — Clairaut's theorem on equality of mixed partial derivatives. This is the fundamental property enabling de Rham cohomology.",
       "mathContext": "$d^2 = 0$: $\\partial^2 f/\\partial x \\partial y = \\partial^2 f/\\partial y \\partial x$ for $C^2$ functions (Schwarz/Clairaut theorem)."
     },
     {
       "id": "greens-stokes",
       "title": "Green's Theorem as 2D Stokes",
-      "startLine": 214,
-      "endLine": 256,
-      "summary": "Defines rectangle line integrals and area integrals, then states Green's theorem in the Stokes framework. The full proof exists in GreensTheoremOQ01.lean.",
+      "startLine": 245,
+      "endLine": 307,
+      "summary": "Defines rectangle line integrals and area integrals, then proves Green's theorem in the Stokes framework via GreensTheoremOQ01.greens_theorem_concrete.",
       "mathContext": "$\\oint_{\\partial R} (P\\,dx + Q\\,dy) = \\iint_R (\\partial Q/\\partial x - \\partial P/\\partial y)\\,dA$ via FTC + Fubini."
     },
     {
       "id": "hierarchy",
       "title": "Hierarchy and de Rham Cohomology",
-      "startLine": 283,
-      "endLine": 345,
+      "startLine": 343,
+      "endLine": 395,
       "summary": "Proves the evaluation formula (find antiderivative, evaluate at endpoints), closed = exact in 1D (H^1 = 0), and ker(d) = constants (H^0 = R). Documents the full hierarchy from FTC to general Stokes.",
       "mathContext": "De Rham cohomology of $\\mathbb{R}$: $H^0_{\\text{dR}}(\\mathbb{R}) = \\mathbb{R}$ (connected), $H^1_{\\text{dR}}(\\mathbb{R}) = 0$ (contractible). The evaluation formula $\\int_a^b f = F(b) - F(a)$ when $F' = f$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization presents the generalized Stokes theorem as a unifying framework for the fundamental integral theorems of calculus. The 1D case (FTC) is fully proved from Mathlib, including the Poincare lemma and de Rham cohomology calculations. The 2D case (Green's theorem) is stated in the Stokes framework with the full proof available in GreensTheoremOQ01. The key structural property d^2 = 0 (Clairaut) is stated for C^2 functions. The formalization demonstrates how a single identity \u2014 the integral of the exterior derivative equals the boundary integral \u2014 specializes to all the classical integral theorems.",
+    "summary": "This formalization presents the generalized Stokes theorem as a unifying framework for the fundamental integral theorems of calculus. The 1D case (FTC) is fully proved from Mathlib, including the Poincare lemma and de Rham cohomology calculations. The 2D case (Green's theorem) is proved in the Stokes framework via GreensTheoremOQ01. The key structural property d^2 = 0 (Clairaut) is proved for C^2 functions via ContDiff.contDiffAt.isSymmSndFDerivAt. The formalization demonstrates how a single identity \u2014 the integral of the exterior derivative equals the boundary integral \u2014 specializes to all the classical integral theorems.",
     "implications": "The formalization connects three major threads in mathematics:\n\n1. **Calculus**: FTC, Green's theorem, Stokes' theorem, divergence theorem are all one theorem\n2. **Topology**: De Rham cohomology H^k(M) measures topological obstructions to exactness of closed forms\n3. **Algebra**: The exterior algebra and the de Rham complex Omega^0 -> Omega^1 -> Omega^2 -> ... provide the algebraic framework\n\nA full formalization of the general theorem requires integration of differential forms on manifolds with boundary, an active area of Mathlib development.",
     "openQuestions": [
-      "Can d^2 = 0 be proved by bridging Mathlib's ContDiff.isSymmetric_iteratedFDeriv to concrete partial derivative expressions?",
       "Can the general Stokes theorem be stated using Mathlib's SmoothManifoldWithCorners and ExteriorAlgebra?",
       "What is the minimal smoothness assumption for the Stokes theorem? (Lipschitz forms on Lipschitz domains?)",
       "Can de Rham cohomology be computed for the circle S^1, showing H^1(S^1) = R?"


### PR DESCRIPTION
## Fix

Reconcile narrative fields with the structural counts in `meta` and `leanFile` for `fundamental-theorem-calculus-oq-02` (Generalized Stokes). Audit-tracker has flagged this entry `issues-found` 4 times.

## Evidence

The Lean source (`proofs/Proofs/FundamentalTheoremCalculusStokes.lean`) on `origin/main`:
- 395 lines
- 11 theorems
- 7 defs
- 0 sorries
- 0 axioms
- Proves `dd_eq_zero_2D` via `ContDiff.contDiffAt.isSymmSndFDerivAt`
- Proves `stokes_2d_rectangle` (Green's) via `GreensTheoremOQ01.greens_theorem_concrete`

Structural counts in `meta`/`leanFile` already match. The narrative still describes the pre-proof state.

**Before**:
- `overview.text`: "A 345-line formalization … Contains 11 theorems and 8 definitions with 2 sorries (both have clear proof paths)."
- `overview.proofStrategy`: "**2D (stated):** … State d^2 = 0 (Clairaut) and Green's theorem"
- `overview.keyInsights[1]`: "the sorry is explained: bridging Mathlib's iteratedFDeriv symmetry to concrete partial derivative expressions is non-trivial"
- `originalContributions`: "Green's theorem stated …", "d^2 = 0 (Clairaut's theorem) stated …"
- `conclusion.summary`: "stated in the Stokes framework", "is stated for C^2 functions"
- `conclusion.openQuestions[0]`: "Can d^2 = 0 be proved by …" (already proved)
- `sections[dd-zero].endLine`: 212; `[greens-stokes]`: 214–256; `[hierarchy]`: 283–345 (file is 395 lines)

**After**:
- `overview.text`: 395-line, 7 definitions, 0 sorries; explicit mention that d²=0 and Green's are proved.
- `overview.proofStrategy`: "**2D (proved):**" with the Mathlib lemmas used.
- `overview.keyInsights[1]`: now describes the proof rather than the missing one.
- `originalContributions`: "proved" instead of "stated" for both bullets.
- `conclusion.summary`: "proved" instead of "stated".
- `conclusion.openQuestions`: drop the resolved question.
- Section line ranges aligned with the `═══` PART markers in the source: dd-zero 191–244, greens-stokes 245–307, hierarchy 343–395.

No counts in `meta` or `leanFile` were touched — they were already correct.

---
Automated fix by lean-mechanic agent.