### PR TITLE
audit(borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02): correct status to axiomatized (5 imported axioms)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-06",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ02.lean",
     "tags": [
       "borsuk-ulam",
@@ -18,9 +18,9 @@
       "squarefree",
       "research"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "lineCount": 247,
     "theoremCount": 13,
     "definitionCount": 0,
@@ -58,7 +58,7 @@
       "buDim_prod_primes_eq: CRT formula for k distinct primes — buDim(∏ S) d = S.sup(buDim · d)",
       "Concrete cases: buDim(30,d), buDim(210,d), buDim(2310,d) via native_decide for primeFactors computation"
     ],
-    "assumptions": "0 sorries. 0 new axiom declarations. All 13 theorems fully machine-checked. Results are verified conditional on the base framework: buDim (function axiom), buDim_mono (monotonicity axiom), and buDim_le_formula (formula conjecture axiom) from parent files.",
+    "assumptions": "0 sorries. 0 new axiom declarations in this file. All 13 theorems fully machine-checked relative to 5 imported axioms from parent files: buDim (function axiom), buDim_two, buDim_prime, buDim_mono (monotonicity axiom) from BorsukUlamOQ02OQ01, and buDim_le_formula (formula conjecture axiom) from BorsukUlamOQ02OQ01OQ01.",
     "additionalFiles": []
   },
   "overview": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02
**Problem**: Status overstated as `verified/verified` while the result depends on 5 imported axioms.

## Evidence

**meta.json claimed:**
- status: `verified`
- badge: `verified`
- axiomCount: `0`

**Lean source shows:**
- `BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ02.lean` has 0 own axioms (correct).
- But it imports `Proofs.BorsukUlamOQ02OQ01` (4 axioms: `buDim`, `buDim_two`, `buDim_prime`, `buDim_mono`) and `Proofs.BorsukUlamOQ02OQ01OQ01` (1 axiom: `buDim_le_formula`).
- Total transitive axioms: **5**.
- The `assumptions` field already acknowledged 3 of these (`buDim`, `buDim_mono`, `buDim_le_formula`) but the count and status didn't reflect that.

**Convention in sibling proofs** (same import chain):
- `borsuk-ulam-oq-02-oq-01-oq-01-oq-02`: `axiomCount=5`, `status=axiomatized`, `badge=axiom` ✓

## Fix

- `status`: verified → axiomatized
- `badge`: verified → axiom
- `axiomCount`: 0 → 5 (full transitive import chain)
- `assumptions`: enumerate all 5 imported axioms (was 3)

`leanFile.axiomCount` left at 0 (correct: this file declares no axioms). Other counts unchanged.

Per `CLAUDE.md` Axiom Integrity Policy:
> `verified`: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions
> Has axiom declarations OR structure-encoded assumptions: `axiomatized`
> When in doubt, use `axiomatized` — overclaiming `verified` damages credibility.

---
Discovered during gallery integrity audit.