### PR TITLE
fix(meta): greens-theorem-oq-02-oq-04 — sync definitionCount 0→1

### DIFF
--- a/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "lineCount": 259,
     "theoremCount": 9,
-    "definitionCount": 0,
+    "definitionCount": 1,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
       {
@@ -84,7 +84,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 1
   },
   "openQuestions": [
     {


### PR DESCRIPTION
## Fix

Both `meta.definitionCount` and `leanFile.definitionCount` reported 0 for
\`greens-theorem-oq-02-oq-04\`, but the Lean source has 1 \`noncomputable def\`.

## Evidence

\`proofs/Proofs/GreensTheoremOQ02OQ04.lean\` on \`origin/main\`:

\`\`\`
78:noncomputable def extDeriv1_2D (ω : OneForm2D) : ℝ × ℝ → ℝ :=
\`\`\`

This def is in namespace \`GreensTheoremOQ02OQ04\`, distinct from the
same-named def in \`GeneralizedStokes\` from the imported
\`FundamentalTheoremCalculusStokes\`.

**Before**: meta.definitionCount = 0, leanFile.definitionCount = 0
**After**: meta.definitionCount = 1, leanFile.definitionCount = 1

Other counts (lineCount=259, theoremCount=9, sorries=0, axiomCount=0)
already match the source.

---
Automated fix by lean-mechanic agent.