### PR TITLE
fix(meta): cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01 — split corollaries section

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -118,9 +118,17 @@
       "id": "main-theorem",
       "title": "General Skolem-Noether Theorem",
       "startLine": 143,
-      "endLine": 190,
-      "summary": "skolemNoether_general: any two K-algebra homomorphisms f, g : A →ₐ[K] B are conjugate by a unit u ∈ Bˣ. Also proves aut_is_inner (automorphisms of CSA are inner) and conjugate_iff_same_image.",
+      "endLine": 187,
+      "summary": "skolemNoether_general: any two K-algebra homomorphisms f, g : A →ₐ[K] B are conjugate by a unit u ∈ Bˣ.",
       "mathContext": "From the module isomorphism φ: φ(f(a)·b) = g(a)·φ(b) and φ(b·c) = φ(b)·c. Setting b=1: φ(f(a)) = g(a)·φ(1). From left-mul formula: φ(f(a)) = φ(1)·f(a). So φ(1)·f(a) = g(a)·φ(1). With u=φ(1): u·f(a)=g(a)·u, hence f(a)=u⁻¹·g(a)·u."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: Inner Automorphisms and Conjugacy",
+      "startLine": 189,
+      "endLine": 218,
+      "summary": "aut_is_inner: every K-algebra automorphism of a finite-dimensional CSA is inner (specialization A=B of skolemNoether_general). conjugate_iff_same_image: the conjugation relation between AlgHoms is symmetric (u-conjugation on one side ↔ u⁻¹-conjugation on the other).",
+      "mathContext": "Setting A=B and g=id in Skolem-Noether yields Aut_K(B) = Inn(B) — every K-algebra automorphism of a CSA is conjugation by a unit. The conjugacy relation is symmetric: f = u⁻¹·g·u iff g = u·f·u⁻¹, which is just the inverse-unit substitution."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Section drift in \`cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01\`
(\`Proofs/SkolemNoetherCSA.lean\`, 241 lines): the section table only
covered up to line 190, while the file's \`/-! ## Corollaries -/\` block
starts at line 189 and contains two named theorems (\`aut_is_inner\` and
\`conjugate_iff_same_image\`).

The existing \`main-theorem\` section's summary already referenced both
corollaries, so the proof entry was just missing a section row for them.

## Evidence

\`\`\`
$ git show origin/main:proofs/Proofs/SkolemNoetherCSA.lean | grep -n '^/-! '
35:/-! ## Setup -/
41:/-! ## Lemma 1: Right-B-linear maps on B are left multiplication -/
62:/-! ## Lemma 2: Extracting a unit from a right-B-linear equivalence -/
95:/-! ## Key Axiom: Module isomorphism from Wedderburn + Isotypic -/
144:/-! ## Main Theorem: General Skolem-Noether for CSAs -/
189:/-! ## Corollaries -/
\`\`\`

**Before**:
- \`main-theorem\`: 143–190 (overlaps Corollaries marker at 189; summary mentions corollaries but range excludes them)

**After**:
- \`main-theorem\`: 143–187 (skolemNoether_general only)
- New \`corollaries\` section: 189–218 (aut_is_inner and conjugate_iff_same_image)

No other counts touched (lineCount=241, theoremCount=6, sorries=0, axiomCount=1 already match the source).

---
Automated fix by lean-mechanic agent.