### PR TITLE
audit(tracker): mark 6 entries clean after origin/main verification

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10406,10 +10406,11 @@
     },
     "erdos-895": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-06T11:10:42Z",
-      "result": "issues-found",
-      "notes": "Verified vs origin/main: 260 lines, 7 sorries — matches meta.json. Working-tree mismatch is unmerged researcher WIP."
+      "auditCount": 6,
+      "lastAudited": "2026-05-06T15:10:28Z",
+      "result": "clean",
+      "notes": "Verified vs origin/main: 462 lines, 3 sorries — matches meta.json (sorries=3, status=formalized, badge=wip). Earlier \"7 sorries\" notes were stale.",
+      "issues": []
     },
     "erdos-896": {
       "agentId": "auditor-cycle-20-batch",
@@ -11488,10 +11489,10 @@
       "result": "clean"
     },
     "fundamental-theorem-calculus-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-06T11:10:42Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-06T15:10:28Z",
+      "result": "clean"
     },
     "furstenberg-correspondence": {
       "auditCount": 3,
@@ -14815,9 +14816,9 @@
       "issues": []
     },
     "fermat-two-squares-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T11:10:30Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-06T15:10:28Z",
+      "result": "clean",
       "issues": []
     },
     "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01": {
@@ -14833,15 +14834,15 @@
       "issues": []
     },
     "erdos-895-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T11:14:56Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-06T15:10:28Z",
+      "result": "clean",
       "issues": []
     },
     "greens-theorem-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T11:14:56Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-06T15:10:28Z",
+      "result": "clean",
       "issues": []
     },
     "greens-theorem-oq-01-oq-01-oq-02": {
@@ -14889,6 +14890,12 @@
     "law-of-cosines-oq-01-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-05-06T13:07:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T15:10:28Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Audit Result: 6 entries verified CLEAN

Each entry below was verified against `origin/main` with comment-stripped counts. All `meta.json` claims match the actual Lean source. The lingering `issues-found` markers are stale.

| ID | Lines | Sorries (claim/actual) | Axioms (claim/actual) | Status |
|----|-------|------------------------|------------------------|--------|
| fermat-two-squares-oq-01-oq-03 | 357 | 0/0 | 1/1 | axiomatized/axiom |
| cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01 | 136 | 0/0 | 0/0 | verified/original |
| greens-theorem-oq-01-oq-01-oq-01 | 275 | 0/0 | 1/1 | axiomatized/axiom |
| erdos-895-oq-01 | 272 | 0/0 | 1/1 | axiomatized/axiom |
| fundamental-theorem-calculus-oq-02 | 395 | 0/0 | 0/0 | formalized/wip |
| erdos-895 | 462 | 3/3 | 0/0 | formalized/wip |

## Why Stale

`scripts/auditor/find-targets.ts` reads the working tree, not `origin/main`. With many agents running concurrently, the main repo's working tree often holds:
- partial enricher rewrites that drop the `meta.sorries` field (-> "claims -1, actual 0" mismatches)
- re-introduced `True := trivial` doc-anchor stubs that were already removed by merged audit PRs
- mid-flight researcher edits that change line counts before the corresponding meta.json sync

These false positives loop forever unless the tracker is updated to the actually-merged state.

## Notes

For `erdos-895`, refreshed a stale `notes` field that recorded "260 lines, 7 sorries" — the file on `origin/main` is currently 462 lines / 3 sorries.

---
Automated bump by lean-auditor agent. Tree-only edit via plumbing; main repo working tree was not touched.