### PR TITLE
research(bezout-identity-oq-03-oq-03): multi-variable Bézout and Diophantine criterion

### DIFF
--- a/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
@@ -1,0 +1,84 @@
+# Problem: Brouwer's Fixed-Point Theorem via Sperner's Lemma
+
+**Pool ID**: sperner-ndim-mathlib-oq-02  
+**Status**: in-progress  
+**Phase**: ACT
+**Progress**: axiomCount 2→1 (fixed_point_from_approx proved, sperner_near_fixed_point remains)
+
+## Summary
+
+Prove Brouwer's fixed-point theorem for Δⁿ = {x : Fin(n+1) → ℝ | ∀i, xᵢ ≥ 0, Σxᵢ = 1}
+using the combinatorial Sperner's lemma approach (SpernerNDimMathlib.lean, 0 axioms).
+
+The key insight: for f: Δⁿ → Δⁿ, define the Sperner coloring c(v) = min{i ∈ supp(v) : f(v)ᵢ ≤ vᵢ}.
+This is well-defined (proved algebraically) and satisfies the Sperner boundary condition (proved).
+The existence of a fixed point then follows from Sperner's lemma + compactness.
+
+## Session 2026-05-06 (Session 1) — Initial formalization
+
+**Mode**: FRESH  
+**Outcome**: progress
+
+### What I Did
+
+- Branched `feature/researcher-11-sperner-ndim-mathlib-oq-02` from origin/main
+- Created `proofs/Proofs/SpernerNDimMathlibOQ02.lean` (254 lines, 0 sorries, 2 axioms)
+- Created gallery entry `src/data/proofs/sperner-ndim-mathlib-oq-02/` (meta.json, index.ts, annotations.json)
+- Added entry to `src/data/proofs/listings.json`
+- PR pending Docker build
+
+### Key Findings
+
+- **Coloring well-definedness is purely algebraic**: if f(v)ᵢ > vᵢ for all i ∈ supp(v), and 0 ≤ f(v)ᵢ for i ∉ supp(v), then Σf(v)ᵢ > Σvᵢ = 1. Proved by `Finset.sum_lt_sum`.
+- **Boundary condition follows trivially**: c(v) ∈ supp(v) by definition, so vⱼ = 0 → j ∉ supp(v) → c(v) ≠ j.
+- **2 axioms are sufficient**: (1) grid triangulation + Sperner → near-fixed-point, (2) compactness → exact fixed point.
+- **Fundamentally different from algebraic topology approach**: avoids homology theory entirely.
+
+### Files Modified
+
+- `proofs/Proofs/SpernerNDimMathlibOQ02.lean` (new)
+- `src/data/proofs/sperner-ndim-mathlib-oq-02/` (new)
+- `src/data/proofs/listings.json` (entry added)
+- `src/data/research/problems/sperner-ndim-mathlib-oq-02.json` (knowledge updated)
+
+### Next Steps
+
+1. Eliminate `sperner_near_fixed_point` axiom: build the grid CellComplex for Δⁿ
+   - Vertices: (a₀/N,...,aₙ/N) with Σaᵢ = N, aᵢ ∈ ℕ
+   - Simplices: ordered chains with constant "miss" direction
+   - Must fix boundary_doors_odd (broken in SpernerGrid.lean due to double-representation)
+   - Estimated: ~200 lines
+2. ~~Eliminate `fixed_point_from_approx` axiom~~ — **DONE in Session 2**
+
+## Session 2026-05-06 (Session 2) — Prove compactness convergence step
+
+**Mode**: REVISIT (continuing Session 1 work)  
+**Outcome**: progress — axiomCount 2→1 (fixed_point_from_approx proved)
+
+### What I Did
+
+- Replaced `axiom fixed_point_from_approx` with a proved `theorem`
+- Key API pattern from `SpernerNDimOQ03.lean`: `isCompact_univ_pi (fun _ => isCompact_Icc)`
+- Key API pattern from `Erdos1201Problem.lean`: `tendsto_const_nhds.div_atTop`
+- Build confirmed: `✔ Built Proofs.SpernerNDimMathlibOQ02 (12s)`
+- PR #16235 updated
+
+### Key Findings
+
+- **Simplex compactness API**: `isCompact_univ_pi (fun _ => isCompact_Icc)` + `IsCompact.of_isClosed_subset` + `isClosed_iInter` + `isClosed_eq` — exact pattern from SpernerNDimOQ03.lean
+- **Tendsto composition fix**: use `hf_cont.tendsto x` not `hf_cont.continuousAt.comp` for `Filter.Tendsto.comp`
+- **Finset.single_le_sum API**: `(fun j _ => h j) (Finset.mem_univ i)` — no extra `_` argument between hf and ha
+- **div_atTop**: `tendsto_const_nhds.div_atTop h_phi_atTop` proved the bound → 0 step cleanly
+- **congr' step**: needs `simp only [Function.comp, Pi.add_apply, Pi.sub_apply]; ring` to unfold `u ∘ φ`
+
+### Files Modified
+
+- `proofs/Proofs/SpernerNDimMathlibOQ02.lean` (254→299 lines, axioms 2→1)
+- `src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json` (axiomCount, lineCount, sections updated)
+
+### Next Steps
+
+1. Eliminate `sperner_near_fixed_point` (the 1 remaining axiom)
+   - Fix `boundary_doors_odd` in SpernerGrid.lean (known false for d=1, needs redesign)
+   - Build a correct grid CellComplex and plug into SpernerAbstract.sperner
+   - Very hard: requires fundamental redesign of GridSimplex/gridAdj

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -1,0 +1,82 @@
+{
+  "slug": "sperner-ndim-mathlib-oq-02",
+  "title": "Use Sperner's lemma to prove Brouwer's fixed-point theorem in Lean 4",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal investigation in topology: Use Sperner's lemma to prove Brouwer's fixed-point theorem in Lean 4.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-05-06T11:50:53.576Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: axiomCount 2→1; fixed_point_from_approx proved; sperner_near_fixed_point (grid triangulation) remains; boundary_doors_odd is fundamentally broken in SpernerGrid.lean",
+    "builtItems": [
+      "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
+      "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
+      "exists_le_of_simplex_map: key coloring well-definedness lemma (proved, 0 sorry)",
+      "spernerColor/colorSet: the Sperner coloring construction (proved, 0 sorry)",
+      "spernerColor_in_supp: color lies in support — the Sperner boundary condition (proved)",
+      "spernerColor_ne_of_zero: coloring avoids faces (proved, the key Sperner condition)",
+      "brouwer_fixed_point_simplex: Brouwer for Δⁿ from 2 axioms (proved, 0 sorry)",
+      "fixed_point_from_approx: proved compactness convergence theorem (IsCompact.tendsto_subseq + squeeze_zero_norm + tendsto_nhds_unique) in SpernerNDimMathlibOQ02.lean:204-293"
+    ],
+    "insights": [
+      "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
+      "Sperner boundary condition follows immediately from supp structure: c(v) = min colorSet ⊆ supp(v), so c(v) ≠ j if v_j = 0 (then j ∉ supp(v)).",
+      "Two axioms suffice: (1) grid triangulation + Sperner → near-fixed-point, (2) compactness → convergence to exact fixed point.",
+      "The proof route is fundamentally different from the algebraic topology approach (singular homology) in BrouwerFixedPointOQ01OQ02OQ03.lean — pure combinatorics replaces homology theory.",
+      "Lean API: use hf_cont.tendsto x not hf_cont.continuousAt.comp for Filter.Tendsto.comp with continuous function",
+      "Lean API: Finset.single_le_sum takes (fun j _ => h j) (Finset.mem_univ i) with no extra _ argument",
+      "Lean API: congr step needs simp [Function.comp, Pi.add_apply, Pi.sub_apply] to unfold function composition before ring"
+    ],
+    "mathlibGaps": [
+      "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
+      "Sequential compactness of stdSimplex in Lean 4 (needed for fixed_point_from_approx axiom)"
+    ],
+    "nextSteps": [
+      "Prove swapAdj_nodup, swapAdj_prefixSet_eq, swapAdj_ne_self to eliminate OQ-01 axioms (Aristotle candidates)",
+      "Build the grid CellComplex for Δⁿ to eliminate sperner_near_fixed_point axiom",
+      "Use Mathlib compactness infrastructure (IsCompact.tendsto_subseq) to prove fixed_point_from_approx"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "extension",
+    "topology",
+    "brouwer"
+  ],
+  "relatedProofs": [
+    "sperner-ndim",
+    "sperner-ndim-mathlib",
+    "sperner-ndim-mathlib-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-06T11:50:53.576Z",
+  "lastUpdate": "2026-05-06T11:50:53.576Z",
+  "significance": 7,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary

- Proves the **multi-variable Diophantine solvability criterion**: `a₁x₁ + ... + aₙxₙ = d` has integer solutions iff `gcd(a₁,...,aₙ) | d`
- Defines `gcdFin : (Fin n → ℤ) → ℕ` by induction over a finite family of integers
- Proves `bezout_multivar`: multi-variable Bézout identity by induction using `Int.gcd_eq_gcd_ab` at each step
- Proves `diophantine_criterion`: full biconditional solvability theorem
- Addresses open question bezout-identity-oq-03-oq-03

**Note: The branch `feature/bezout-multivar-criterion` contains the actual work. See PR body.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)