### PR TITLE
fix(meta): bounded-prime-gaps-oq-04 — sync theoremCount 13→12

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 366,
     "erdosUrl": null,
     "dateAdded": "2026-03-27",
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 10
   },
   "overview": {
@@ -194,7 +194,7 @@
     "namespace": "BoundedPrimeGapsOQ04",
     "lineCount": 366,
     "axiomCount": 1,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 10,
     "path": "Proofs/BoundedPrimeGapsOQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` from 13 to 12 to match the actual count in `Proofs/BoundedPrimeGapsOQ04.lean` at origin/main.

## Evidence

The drift was introduced by batch PR #15953 ("fix(meta): sync theoremCount and lineCount for 102 gallery entries"), which incorrectly bumped the count from 12 to 13. The Lean file at origin/main has exactly **12** top-level theorem declarations:

```
95   theorem chebyshevPsi_zero
100  theorem chebyshevPsiAP_nonneg
107  theorem chebyshevPsiAP_q_one
111  theorem primeCountAP_le
118  theorem totient_one'
121  theorem totient_prime'
125  theorem totient_pos'
178  theorem bv_implies_eventual_bound
186  theorem bv_A2
222  theorem bv_gives_half_level
295  theorem total_effort_estimate
322  theorem pv_uniform_bound
```

No `@[simp]`/attribute-prefixed declarations, no `private`/`protected` declarations. Counted via `^(?:private |protected |noncomputable )*(?:theorem|lemma) ` after stripping comments — same convention as PR #16250 (cantor-diagonalization-oq-01).

## Validation

| Field             | Before | After (actual) |
|-------------------|--------|----------------|
| `meta.theoremCount`     | 13 | **12** ✅ |
| `leanFile.theoremCount` | 13 | **12** ✅ |
| `lineCount`             | 366 | 366 ✓ |
| `axiomCount`            | 1   | 1 ✓ |
| `definitionCount`       | 10  | 10 ✓ |
| `sorries`               | 0   | 0 ✓ |

Status (`axiomatized`) and badge (`axiom`) remain correct (1 axiom: `bombieriVinogradov`).

---
Automated fix by lean-mechanic agent.