### PR TITLE
fix(meta): erdos-750 — axiomCount 0→1, lineCount 110→117, theoremCount 2→1

### DIFF
--- a/src/data/proofs/erdos-750/meta.json
+++ b/src/data/proofs/erdos-750/meta.json
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/750",
     "erdosUrl": "https://erdosproblems.com/750",
@@ -41,16 +41,14 @@
       "HasInfiniteChromatic: no finite proper coloring exists",
       "maxIndSetSize: maximum independent set in induced subgraph",
       "AlmostBipartite: f-deviation from bipartite independence",
-      "erdos_750_conjecture: full conjecture for any f → ∞",
-      "erdos_hajnal_1967 and erdos_hajnal_szemeredi_1982: known results",
-      "sqrt_case and log_case: specific open sublinear instances",
-      "problem_75_connection and bipartite_benchmark: structural context"
+      "erdos_750 (axiom): full conjecture for any f → ∞",
+      "bipartite_benchmark: bipartite graphs on m vertices have independence ≥ ⌊m/2⌋"
     ],
-    "axiomCount": 0,
-    "lineCount": 110,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "axiomCount": 1,
+    "lineCount": 117,
+    "assumptions": "1 axiom: erdos_750 (the main conjecture — for any f(m) → ∞, there exists an infinite-chromatic f-almost-bipartite graph). Known results (Erdős–Hajnal 1967, Erdős–Hajnal–Szemerédi 1982) and open sublinear cases are documented as comments.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 2,
+    "theoremCount": 1,
     "definitionCount": 3
   },
   "overview": {
@@ -139,9 +137,9 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 110,
-    "axiomCount": 0,
-    "theoremCount": 2,
+    "lineCount": 117,
+    "axiomCount": 1,
+    "theoremCount": 1,
     "definitionCount": 3,
     "path": "Proofs/Erdos750Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`meta.json` for `erdos-750` was not updated after PR #16223 added `axiom erdos_750` to the Lean file. The auditor flagged `axiom undercount: claims 0, actual declarations 1`.

## Evidence

**Lean file** (`origin/main:proofs/Proofs/Erdos750Problem.lean`):
- `axiom erdos_750 : ∀ f : ℕ → ℕ, ...` — 1 axiom declaration
- `private theorem fin2_ne_zero_eq_one` — private (excluded from count)
- `theorem bipartite_benchmark` — 1 public theorem
- 3 definitions: `HasInfiniteChromatic`, `maxIndSetSize`, `AlmostBipartite`
- 117 lines

**Before** (stale):
| field | value |
|---|---|
| meta.axiomCount | 0 |
| leanFile.axiomCount | 0 |
| meta.lineCount | 110 |
| leanFile.lineCount | 110 |
| meta.theoremCount | 2 |
| leanFile.theoremCount | 2 |
| badge | "wip" |

**After** (corrected):
| field | value |
|---|---|
| meta.axiomCount | 1 |
| leanFile.axiomCount | 1 |
| meta.lineCount | 117 |
| leanFile.lineCount | 117 |
| meta.theoremCount | 1 |
| leanFile.theoremCount | 1 |
| badge | "axiom" |

`status` stays `axiomatized` (correct for an open problem with a declared axiom).

---
Automated fix by lean-mechanic agent.