### PR TITLE
fix(meta): erdos-118 — axiomCount 4→2, lineCount 143→139, theoremCount 4→6

### DIFF
--- a/src/data/proofs/erdos-118/meta.json
+++ b/src/data/proofs/erdos-118/meta.json
@@ -23,11 +23,11 @@
     "relatedProblems": [
       592
     ],
-    "axiomCount": 4,
-    "lineCount": 143,
-    "assumptions": "4 axioms: counter_partition_3 (Schipperus), counter_not_partition_5 (Larson), partitionThreshold, threshold_exact. ordPartition now properly defined. partition_monotone_down proved from definition (blue clique restriction). omega_omega2_threshold proved from threshold_exact + monotonicity + counterexamples. relation_to_592 proved directly from counterexamples.",
+    "axiomCount": 2,
+    "lineCount": 139,
+    "assumptions": "2 axioms: counter_partition_3 (Schipperus — ω^(ω²) → (ω^(ω²),3)²) and counter_not_partition_5 (Larson — ω^(ω²) ↛ (ω^(ω²),5)²). Previously axiomatized partitionThreshold and threshold_exact were eliminated by PR #16227: partition_transition_exists proved via strong induction, omega_omega2_threshold derived from the transition theorem.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 4
   },
   "sections": [
@@ -104,9 +104,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 143,
-    "axiomCount": 4,
-    "theoremCount": 4,
+    "lineCount": 139,
+    "axiomCount": 2,
+    "theoremCount": 6,
     "definitionCount": 4,
     "path": "Proofs/Erdos118Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`meta.json` for `erdos-118` was not updated after PR #16227 proved `partition_transition_exists` and `omega_omega2_threshold`, eliminating 2 of 4 axioms.

## Evidence

**Lean file** (`origin/main:proofs/Proofs/Erdos118Problem.lean`):

Axiom declarations (2):
- `axiom counter_partition_3` — Schipperus: ω^(ω²) → (ω^(ω²),3)²
- `axiom counter_not_partition_5` — Larson: ω^(ω²) ↛ (ω^(ω²),5)²

Theorems (6): `erdos_118_disproved`, `partition_monotone_down`, `partition_monotone_up_neg`, `partition_transition_exists`, `omega_omega2_threshold`, `relation_to_592`

Definitions (4): `ordPartition`, `IsPartitionOrd`, `ErdosHajnalConjecture`, `counterexampleOrd`

Lines: 139

**Before** (stale — still counted eliminated axioms):
| field | value |
|---|---|
| meta.axiomCount | 4 |
| leanFile.axiomCount | 4 |
| meta.lineCount | 143 |
| leanFile.lineCount | 143 |
| meta.theoremCount | 4 |
| leanFile.theoremCount | 4 |

**After** (corrected):
| field | value |
|---|---|
| meta.axiomCount | 2 |
| leanFile.axiomCount | 2 |
| meta.lineCount | 139 |
| leanFile.lineCount | 139 |
| meta.theoremCount | 6 |
| leanFile.theoremCount | 6 |

`status` stays `axiomatized` and `badge` stays `axiom` (2 remaining axioms for published results).

---
Automated fix by lean-mechanic agent.