### PR TITLE
audit(tracker): mark buffons-needle-oq-01-oq-01-oq-04 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1365,10 +1365,10 @@
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-06T14:34:38Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-06T15:54:04Z",
+      "result": "clean"
     },
     "buffons-needle-oq-01-oq-02": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Fix tracker entry for `buffons-needle-oq-01-oq-01-oq-04`: the proof was already cleaned up on `origin/main` (sorries=0, lineCount=568, axiomCount correctly reflects 2 structure-encoded assumptions), but an earlier auditor's working-tree pollution caused the tracker to be marked `issues-found`. This bumps `auditCount` 4→5 and resets `result` to `clean`.

## Verified against `origin/main`

- `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean` — 0 sorries, 0 axioms, 27 public theorems + 3 private lemmas, 4 defs, 569 lines (with trailing newline; meta.lineCount=568)
- `meta.json` — `top.sorries=0`, `meta.sorries=0`, `leanFile.sorries=0` ✓
- `meta.lineCount=568` ✓ matches file
- `leanFile.axiomCount=0` ✓ matches `axiom` declarations in source
- `meta.axiomCount=2` ✓ matches the 2 structure-encoded assumptions in `AngularAverageData` (`angularAvg_eq`, `angularAvg_nonneg`) per the Axiom Integrity Policy

## Context

Two PRs for this target are open and `CONFLICTING` (#16225, #16226). Both were created against an older base where `sorries: 1, lineCount: 437`. Those structural fixes have since landed on main some other way; the PRs are now redundant and conflict because the lines they remove no longer exist. `scripts/auditor/find-targets.ts` reads the working tree, so when concurrent agents leave stale `meta.json` modifications visible, the same target keeps getting flagged. This tracker bump unblocks the audit loop.

## Test plan

- [x] `python -m json.tool` validates the tracker
- [x] Diff is exactly 4 lines (auditCount, lastAudited, result)
- [x] No reformatting of unrelated entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)