### PR TITLE
audit(ehrhart-cube-proven-oq-01): sync lineCount 158→208, theoremCount 14→12

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13815,6 +13815,14 @@
       "result": "clean",
       "issues": []
     },
+    "ehrhart-cube-proven-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T15:58:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "lineCount drift 158->208, theoremCount drift 14->12 (fixed in this PR)"
+      ]
+    },
     "erdos-1006-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-05-03T04:44:08Z",

--- a/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
@@ -6,8 +6,8 @@
   "leanFile": {
     "path": "Proofs/EhrhartSimplexProven.lean",
     "filename": "EhrhartSimplexProven.lean",
-    "lineCount": 158,
-    "theoremCount": 14,
+    "lineCount": 208,
+    "theoremCount": 12,
     "definitionCount": 0,
     "sorries": 0,
     "axiomCount": 0
@@ -29,7 +29,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 158,
+    "lineCount": 208,
     "assumptions": "No axioms or sorries. All results proved from Mathlib multiset cardinality theory.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
@@ -41,7 +41,7 @@
       "simplex_monotone: count is increasing in n, proved via Nat.choose_le_choose",
       "Dimensional specializations: 0D (trivial), 1D (segment = cube), 2D (triangular numbers C(n+2,2)), 3D (tetrahedral numbers C(n+3,3))"
     ],
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 0
   },
   "overview": {


### PR DESCRIPTION
## Summary

Sync gallery metadata for `ehrhart-cube-proven-oq-01` to match the actual `EhrhartSimplexProven.lean` source. Counts in `meta.json` were off — likely metadata generated before the file was finalized in PR #16233.

## Verified against `origin/main` `proofs/Proofs/EhrhartSimplexProven.lean`

| Field           | Was  | Now  |
|-----------------|------|------|
| `lineCount`     | 158  | 208  |
| `theoremCount`  | 14   | 12   |

Source counts (after stripping comments):
- 208 lines (file ends with newline)
- 12 public theorems: `simplex_lattice_count`, `simplex_at_zero`/`one`, `simplex_0d`/`1d`/`2d`/`3d`, `simplex_interior_count`, `simplex_boundary_count`, `simplex_monotone`, `simplex_pascal`, `simplex_cube_1d_agree`
- 7 `example` blocks (`native_decide` sanity checks for n=1..3 cases) — excluded from theoremCount per gallery convention
- 0 private theorems, 0 defs, 0 axioms, 0 sorries (matches `verified`/`original` badge)

## Tracker

Adds first audit entry for this proof (was never audited):
```json
"ehrhart-cube-proven-oq-01": {
  "auditCount": 1,
  "lastAudited": "2026-05-06T15:58:00Z",
  "result": "issues-fixed",
  "issues": ["lineCount drift 158->208, theoremCount drift 14->12 (fixed in this PR)"]
}
```

## Note on slug

The proof's slug `ehrhart-cube-proven-oq-01` covers the **simplex** case as open question 1 of the parent `ehrhart-cube-proven`. Title and proofRepoPath both reflect "Simplex" correctly; only the directory slug inherits the parent's prefix.

## Test plan

- [x] `python -m json.tool` validates both modified files
- [x] Diff is exactly 12 insertions / 4 deletions across 2 files
- [x] No reformatting of unrelated entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)