### PR TITLE
fix(meta): greens-theorem-oq-01-oq-01-oq-01-oq-01 — add missing top-level sorries:3

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -119,5 +119,6 @@
     "summary": "Partially eliminates axiom iteratedIntervalIntegral_order_independent. The swap(0,1) case and n=2 case are fully proved. Three sorries remain for: integrability of parameterized inner integral, inner permutation reduction, and the general permutation decomposition.",
     "significance": "Each sorry has a clear mathematical fix: (1) continuity of parameterized iterated integrals by induction, (2) IH + integral_congr, (3) Equiv.Perm.induction_on'. The mathematical structure is complete.",
     "limitations": "3 sorries remain. The full axiom elimination requires resolving these, at which point greens-theorem-oq-01-oq-01-oq-01 would have axiomCount=0."
-  }
+  },
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

`meta.json` for `greens-theorem-oq-01-oq-01-oq-01-oq-01` was missing the top-level `sorries` field. Both `meta.sorries` and `leanFile.sorries` correctly record 3, but the top-level field (used by the UI badge renderer to display sorry count) was absent, causing it to read as 0.

## Evidence

**Before**:
- Top-level `sorries`: absent (defaults to 0 in UI)
- `meta.sorries`: 3 ✓
- `leanFile.sorries`: 3 ✓

**After**:
- Top-level `sorries`: 3 ✓ (matches sub-block values)

The 3 sorries are documented in the file: `integrable_swap_pair`, `iteratedIntervalIntegral_perm_tail`, and the main inductive step for general permutations.

---
Automated fix by lean-mechanic agent.