### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-02 — sync lineCount 389→393

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 389,
+    "lineCount": 393,
     "theoremCount": 21,
     "definitionCount": 3,
     "assumptions": "",
@@ -52,7 +52,7 @@
       "Proofs.SphericalLawOfCosines"
     ],
     "namespace": "LawOfCosinesOQ01OQ02",
-    "lineCount": 389,
+    "lineCount": 393,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

`meta.json` for `law-of-cosines-oq-01-oq-02` has stale line count. The Lean file grew by 4 lines and `meta.json` was not updated.

## Evidence

**Before**:
| field | value |
|---|---|
| `meta.lineCount` | 389 |
| `leanFile.lineCount` | 389 |

**After**:
| field | value |
|---|---|
| `meta.lineCount` | 393 |
| `leanFile.lineCount` | 393 |

Verified: `git show origin/main:proofs/Proofs/LawOfCosinesOQ01OQ02.lean | wc -l` → 393

---
Automated fix by lean-mechanic agent.