### PR TITLE
audit(greens-theorem-oq-01-oq-01-oq-01-oq-01): sync theoremCount 6→7

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Eliminates the axiom iteratedIntervalIntegral_order_independent from greens-theorem-oq-01-oq-01-oq-01"
     ],
     "lineCount": 333,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   },
@@ -79,7 +79,7 @@
     "namespace": "GreensTheoremOQ01OQ01OQ01OQ01",
     "lineCount": 333,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean",
     "sorries": 3


### PR DESCRIPTION
## Integrity fix

`src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json` claims `theoremCount: 6` (in both `meta` and `leanFile` blocks), but the Lean source has 7 theorem-like declarations.

## Evidence

`proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` (333 lines) declares:

**Public theorems (4):**
- `swap_outer_two`
- `iteratedIntervalIntegral_order_independent`
- `order_independent_2d`
- `order_independent_3d_swap01`

**Private lemmas (3):**
- `integrable_swap_pair`
- `swap01_cons_eq`
- `iteratedIntervalIntegral_perm_tail`

Total: 7 theorem-like declarations.

## Convention

The mechanic counts theorems by including private lemmas (`theorem + lemma + private theorem + private lemma` after stripping comments). Sampled `proofs/Proofs/AbelRuffiniOQ09.lean`: 21 public theorems + 3 private lemmas = `theoremCount: 24` ✓.

## Cause

PR #16248 merged the file with `theoremCount: 6` set by hand; off-by-one against the actual count.

## Fix

Sync both `meta.theoremCount` and `leanFile.theoremCount` from 6 to 7. No other fields touched.

---
Discovered during gallery integrity audit cycle.