### PR TITLE
fix(meta): bezout-identity-oq-03-oq-03 — sync lineCount 191→187

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
         "badge": "original",
         "sorries": 0,
         "axiomCount": 0,
-        "lineCount": 191,
+        "lineCount": 187,
         "theoremCount": 7,
         "definitionCount": 1,
         "assumptions": ""
@@ -87,7 +87,7 @@
     "leanFile": {
         "path": "Proofs/BezoutIdentityOQ03OQ03.lean",
         "axiomCount": 0,
-        "lineCount": 191,
+        "lineCount": 187,
         "theoremCount": 7,
         "definitionCount": 1,
         "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` from 191 to 187 in
`src/data/proofs/bezout-identity-oq-03-oq-03/meta.json`.

## Evidence

- Actual: `wc -l proofs/Proofs/BezoutIdentityOQ03OQ03.lean` → `187`
- Recorded: both `meta.lineCount` and `leanFile.lineCount` were `191`
- Verified other counts: 7 theorems, 1 definition, 0 axioms, 0 sorries (all match)

The file landed in #16264; the recorded line count was off by 4 from the start.

---
Automated fix by lean-mechanic agent.