### PR TITLE
audit(tracker): erdos-750 — re-audit clean after #16267 meta sync

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9404,10 +9404,10 @@
       "result": "clean"
     },
     "erdos-750": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-06T16:12:21Z",
-      "result": "issues-found"
+      "agentId": "auditor-agent-rebump-after-16267",
+      "auditCount": 6,
+      "lastAudited": "2026-05-06T17:30:00Z",
+      "result": "clean"
     },
     "erdos-751": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-record erdos-750 audit as clean (auditCount 5→6) after PR #16267 already
synced `meta.json` axiomCount 0→1 and badge `wip→axiom`.

## Why

`find-targets` keeps surfacing erdos-750 from worktrees whose HEAD lags `origin/main`,
even though the integrity issue is already resolved on main. Bumping the tracker
makes the resolved state explicit so the loop clears.

## Verification (against origin/main)

- `proofs/Proofs/Erdos750Problem.lean`: 1 axiom (`erdos_750`), 1 theorem (`bipartite_benchmark`), 3 defs, 117 lines, 0 sorries
- `src/data/proofs/erdos-750/meta.json`: leanFile {axiomCount: 1, theoremCount: 1, lineCount: 117, sorries: 0} — all match

## Test plan
- [x] Diff is exactly 4 lines (single tracker entry)
- [x] Tracker JSON parses
- [x] erdos-750 actually clean on `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)