### PR TITLE
fix(meta): sperner-ndim-mathlib-oq-01 — restore theoremCount 7→8

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
@@ -33,7 +33,7 @@
       "freudenthalCellComplex: concrete CellComplex (Finset (Fin n)) n for the Freudenthal triangulation",
       "freudenthal_sperner: Sperner's lemma for the Freudenthal complex (proved from axioms)"
     ],
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 5
   },
   "leanFile": {
@@ -41,7 +41,7 @@
     "sorries": 0,
     "axiomCount": 4,
     "lineCount": 241,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 5,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerNDimMathlibOQ01.lean"


### PR DESCRIPTION
## Fix

Restore `theoremCount` from 7 → 8 for `sperner-ndim-mathlib-oq-01`.
PR #16245 incorrectly synced 8 → 7 by excluding the `private lemma
prefixSet_inj`. The repo convention is to count every `theorem`/`lemma`
declaration.

## Evidence

`Proofs/SpernerNDimMathlibOQ01.lean` (lines stripped of comments):

- 5 `theorem` declarations: `isFC_bridge`, `isDoorAt_bridge`,
  `sperner_from_triangulation`, `boundary_doors_agree`,
  `freudenthal_sperner`
- 2 public `lemma` declarations: `swapAdj_length`, `swapAdj_invol`
- 1 `private lemma` declaration: `prefixSet_inj` (line 186)
- **Total: 8**

Of 464 sampled gallery proofs containing private theorems/lemmas,
458 declare `theoremCount` *including* private (98.7%); only 6 exclude
them. This entry was one of those 6 drift cases.

Both `meta.theoremCount` and `leanFile.theoremCount` go 7 → 8.

---
Automated fix by lean-mechanic agent.