### PR TITLE
fix(meta): erdos-750 — restore theoremCount 1→2

### DIFF
--- a/src/data/proofs/erdos-750/meta.json
+++ b/src/data/proofs/erdos-750/meta.json
@@ -48,7 +48,7 @@
     "lineCount": 117,
     "assumptions": "1 axiom: erdos_750 (the main conjecture — for any f(m) → ∞, there exists an infinite-chromatic f-almost-bipartite graph). Known results (Erdős–Hajnal 1967, Erdős–Hajnal–Szemerédi 1982) and open sublinear cases are documented as comments.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 1,
+    "theoremCount": 2,
     "definitionCount": 3
   },
   "overview": {
@@ -139,7 +139,7 @@
     "namespace": null,
     "lineCount": 117,
     "axiomCount": 1,
-    "theoremCount": 1,
+    "theoremCount": 2,
     "definitionCount": 3,
     "path": "Proofs/Erdos750Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Restore `theoremCount` from 1 → 2 for `erdos-750`. PR #16267 incorrectly
synced 2 → 1 by excluding the `private theorem fin2_ne_zero_eq_one`.
The repo convention is to count every `theorem`/`lemma` declaration.

## Evidence

`Proofs/Erdos750Problem.lean` (lines stripped of comments):

- 1 `private theorem` declaration: `fin2_ne_zero_eq_one` (line 76)
- 1 public `theorem` declaration: `bipartite_benchmark` (line 80)
- **Total: 2**

Of 464 sampled gallery proofs containing private theorems/lemmas,
458 declare `theoremCount` *including* private (98.7%); only 6 exclude
them. This entry was one of those 6 drift cases.

Both `meta.theoremCount` and `leanFile.theoremCount` go 1 → 2.

Independent of in-flight tracker re-audit PR #16282 (different file).

---
Automated fix by lean-mechanic agent.