### PR TITLE
fix(meta): bezout-identity-oq-03-oq-03 — sync lineCount 191→187

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
         "badge": "original",
         "sorries": 0,
         "axiomCount": 0,
-        "lineCount": 191,
+        "lineCount": 187,
         "theoremCount": 7,
         "definitionCount": 1,
         "assumptions": ""
@@ -87,7 +87,7 @@
     "leanFile": {
         "path": "Proofs/BezoutIdentityOQ03OQ03.lean",
         "axiomCount": 0,
-        "lineCount": 191,
+        "lineCount": 187,
         "theoremCount": 7,
         "definitionCount": 1,
         "sorries": 0


### PR DESCRIPTION
## Summary

The Lean source `proofs/Proofs/BezoutIdentityOQ03OQ03.lean` is 187 lines, but `meta.json` claims 191 in both `meta.lineCount` and `leanFile.lineCount`. Sync both to 187.

## Verification

```
$ wc -l proofs/Proofs/BezoutIdentityOQ03OQ03.lean
     187 proofs/Proofs/BezoutIdentityOQ03OQ03.lean
```

All other counts (sorries=0, axiomCount=0, theoremCount=7, definitionCount=1) remain accurate.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)