### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-01-oq-01): prove iteratedIntervalIntegral_perm_tail

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01.lean
@@ -59,10 +59,11 @@ theorem intervalIntegral_swap {f : ℝ → ℝ → ℝ}
   -- RHS = ∫ x ∂(vol.restrict (Ioc a b)), ∫ y ∂(vol.restrict (Ioc c d)), f x y
   -- Step 3: Derive integrability on Ioc product from Icc integrability
   have hf_int' : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
-      ((volume.restrict (Set.Ioc a b)).prod (volume.restrict (Set.Ioc c d))) :=
-    hf_int.mono_measure (Measure.prod_mono
-      (Measure.restrict_mono Set.Ioc_subset_Icc_self le_rfl)
-      (Measure.restrict_mono Set.Ioc_subset_Icc_self le_rfl))
+      ((volume.restrict (Set.Ioc a b)).prod (volume.restrict (Set.Ioc c d))) := by
+    apply hf_int.mono_measure
+    simp only [Measure.prod_restrict]
+    exact Measure.restrict_mono
+        (Set.prod_mono Set.Ioc_subset_Icc_self Set.Ioc_subset_Icc_self) le_rfl
   -- Step 4: Apply Fubini (integral_integral_swap)
   -- integral_integral_swap: ∫ x ∂μ, ∫ y ∂ν, g x y = ∫ y ∂ν, ∫ x ∂μ, g x y
   -- With μ = vol.restrict (Ioc a b), ν = vol.restrict (Ioc c d), g = f:
@@ -117,7 +118,11 @@ theorem fubini_of_continuous {f : ℝ × ℝ → ℝ}
   have hint : IntegrableOn f (Set.Icc a b ×ˢ Set.Icc c d) volume :=
     hf.continuousOn.integrableOn_compact hcpt
   -- Convert: IntegrableOn f (S ×ˢ T) vol = Integrable f (vol.restrict S).prod (vol.restrict T)
-  rwa [Measure.restrict_prod_eq_prod_restrict measurableSet_Icc measurableSet_Icc] at hint
+  -- Measure.prod_restrict: (μ.restrict s).prod (ν.restrict t) = (μ.prod ν).restrict (s ×ˢ t)
+  -- volume (ℝ × ℝ) = volume (ℝ) × volume (ℝ) definitionally
+  have : Integrable f ((volume.restrict (Set.Icc a b)).prod (volume.restrict (Set.Icc c d))) := by
+    rw [Measure.prod_restrict]; exact hint
+  exact this
 
 /-- Spelling out: for C¹ vector fields (P, Q), the Fubini hypothesis
     in Green's theorem is always satisfied. -/

--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
@@ -12,30 +12,16 @@
         iteratedIntervalIntegral a b f =
         iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i)))
 
-  This file proves that axiom by induction on n, using the following strategy.
+  ## Proof Structure
 
-  ## Proof Strategy
+  Building blocks:
+  - B1 (swap_outer_two): swap positions 0,1 via Fubini
+  - B2 (perm_tail): permuting tail positions uses IH inside outer integral
+  - Main: induction on n, using decomposeFin decomposition
 
-  The proof uses two building blocks:
-
-  **B1 (`swap_outer_two`)**: Swapping positions 0 and 1 preserves the integral.
-    - Expand LHS: ∫_{a₀..b₀} ∫_{a₁..b₁} G(x₀,x₁) dx₁ dx₀
-    - Apply Fubini (integral_integral_swap) to swap the order
-    - Show RHS expands to: ∫_{a₁..b₁} ∫_{a₀..b₀} G(x₀,x₁) dx₀ dx₁
-    The key computation: f((cons x₁ (cons x₀ rest)) ∘ swap 0 1)
-      = f(cons x₀ (cons x₁ rest)) by explicit Fin arithmetic.
-
-  **B2 (`iteratedIntervalIntegral_perm_tail`)**: Permuting only positions 1,...,n-1
-    reduces to applying IH inside the outer integral via integral_congr.
-
-  **Main**: Any σ ∈ Perm(Fin n) decomposes via `Equiv.Perm.induction_on'`
-    into products of transpositions, each handled by B1+B2.
-
-  ## Status
-  - `swap_outer_two`: proved modulo integrability helper and rhs-expansion computation
-  - `order_independent_2d`: fully proved using swap_outer_two
-  - General theorem: structure ready, key missing steps documented
-  ## Sorries: 4
+  ## Sorries: 3
+  1. integrable_swap_pair: bound + integrability in dominated convergence
+  2. Main theorem: case σ(0) ≠ 0 (swap_outer_two needs generalization to swap(0,k))
 -/
 
 import Mathlib
@@ -52,19 +38,12 @@ open GreensTheoremOQ01OQ01OQ01 (iteratedIntervalIntegral
 -- Section 1: Integrability for the Fubini Swap
 -- ═══════════════════════════════════════════════════
 
-/-- For continuous f, the function (x₀,x₁) ↦ [iterated integral over remaining
-    variables x₂,...,xₙ₊₁] is integrable on Ioc(a₀,b₀) × Ioc(a₁,b₁).
+/-- For continuous f, the function (x₀,x₁) ↦ [iterated integral over remaining variables]
+    is integrable on Ioc(a₀,b₀) × Ioc(a₁,b₁).
 
-    Proof: The map h(x₀,x₁) is continuous in (x₀,x₁) for fixed remaining
-    variables (by continuity of the iterated integral as a function of its
-    parameter, proved inductively using dominated convergence / Leibniz rule).
-    IntegrableOn then follows from compactness of [a₀,b₀] × [a₁,b₁].
-    Ioc version uses mono_measure since Ioc ⊆ Icc.
-
-    NOTE: The continuity of `iteratedIntervalIntegral` as a function of the
-    outermost parameter requires a separate inductive argument using
-    `intervalIntegral.continuous_of_dominated` or similar Mathlib results.
-    This is the main sorry to resolve. -/
+    The key step uses `continuous_of_dominated_interval`: the integrand is continuous in (x₀,x₁)
+    for each fixed inner variable (by induction), and bounded by a constant on compact sets.
+    Then `ContinuousOn.integrableOn_compact` + `Measure.prod_restrict` give the result. -/
 private lemma integrable_swap_pair {n : ℕ} {a b : Fin (n + 2) → ℝ}
     (hab : ∀ i, a i ≤ b i)
     {f : (Fin (n + 2) → ℝ) → ℝ} (hf : Continuous f) :
@@ -74,16 +53,46 @@ private lemma integrable_swap_pair {n : ℕ} {a b : Fin (n + 2) → ℝ}
           (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
           (fun rest => f (Fin.cons p.1 (Fin.cons p.2 rest))))
       ((volume.restrict (Ioc (a 0) (b 0))).prod (volume.restrict (Ioc (a 1) (b 1)))) := by
-  sorry
+  -- The integrand G(p) is continuous by induction on n (using dominated convergence
+  -- at each step). This follows from:
+  -- (1) For n=0: G(p) = f(cons p.1 (cons p.2 Fin.elim0)), continuous by hf.
+  -- (2) For n+1: G(p) = ∫_{a₂..b₂} [n-dim integral](p, x₂) dx₂, continuous by
+  --     continuous_of_dominated_interval since:
+  --     - The integrand is continuous in p for each x₂ (IH)
+  --     - Bounded by the max of ‖f‖ on the compact box times ∏(b_i - a_i)
+  have hcont : Continuous (fun p : ℝ × ℝ =>
+      iteratedIntervalIntegral
+        (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
+        (fun rest => f (Fin.cons p.1 (Fin.cons p.2 rest)))) := by
+    -- The proof is by induction on n (the tail dimension after removing first two vars)
+    -- For now, leave as sorry (the mathematical argument is clear, formalization technical)
+    sorry
+  -- From continuity, G is IntegrableOn the compact Icc × Icc
+  have hint : IntegrableOn
+      (fun p : ℝ × ℝ =>
+        iteratedIntervalIntegral (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
+        (fun rest => f (Fin.cons p.1 (Fin.cons p.2 rest))))
+      (Icc (a 0) (b 0) ×ˢ Icc (a 1) (b 1))
+      (volume.prod volume) :=
+    hcont.continuousOn.integrableOn_compact (isCompact_Icc.prod isCompact_Icc)
+  -- Restrict to Ioc × Ioc ⊆ Icc × Icc
+  have hint_ioc : IntegrableOn
+      (fun p : ℝ × ℝ =>
+        iteratedIntervalIntegral (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
+        (fun rest => f (Fin.cons p.1 (Fin.cons p.2 rest))))
+      (Ioc (a 0) (b 0) ×ˢ Ioc (a 1) (b 1))
+      (volume.prod volume) :=
+    hint.mono_set (Set.prod_mono Ioc_subset_Icc_self Ioc_subset_Icc_self)
+  -- Convert via prod_restrict: (vol.restrict Ioc) × (vol.restrict Ioc) = vol × vol restricted to Ioc × Ioc
+  rw [← Measure.prod_restrict]
+  exact hint_ioc
 
 -- ═══════════════════════════════════════════════════
 -- Section 2: Key Swap Computation
 -- ═══════════════════════════════════════════════════
 
 /-- For σ = swap 0 1 in Fin(n+2), applying σ permutes the first two positions.
-    Specifically: f((cons x₁ (cons x₀ rest)) ∘ σ) = f(cons x₀ (cons x₁ rest)).
-
-    This is the core Fin-arithmetic calculation underlying swap_outer_two. -/
+    Specifically: (cons x₁ (cons x₀ rest)) ∘ σ.symm = cons x₀ (cons x₁ rest). -/
 private lemma swap01_cons_eq {n : ℕ} {f : (Fin (n + 2) → ℝ) → ℝ}
     (x₀ x₁ : ℝ) (rest : Fin n → ℝ) :
     let σ := Equiv.swap (0 : Fin (n + 2)) 1
@@ -94,41 +103,18 @@ private lemma swap01_cons_eq {n : ℕ} {f : (Fin (n + 2) → ℝ) → ℝ}
   congr 1
   ext i
   refine Fin.cases ?_ (fun j => ?_) i
-  · -- i = 0: (cons x₁ (cons x₀ rest)) (swap 0 1 0)
-    --       = (cons x₁ (cons x₀ rest)) 1 = x₀ = (cons x₀ (cons x₁ rest)) 0
-    simp [Equiv.swap_apply_left, Fin.cons_zero, Fin.cons_succ]
+  · simp [Equiv.swap_apply_left, Fin.cons_zero, Fin.cons_succ]
   · refine Fin.cases ?_ (fun k => ?_) j
-    · -- i = 1 (j = 0): (cons x₁ (cons x₀ rest)) (swap 0 1 1)
-      --       = (cons x₁ (cons x₀ rest)) 0 = x₁ = (cons x₀ (cons x₁ rest)) 1
-      simp [Equiv.swap_apply_right, Fin.cons_zero, Fin.cons_succ]
-    · -- i = k+2 (j = k+1): swap 0 1 doesn't move this position
-      have hne0 : k.succ.succ ≠ (0 : Fin (n + 2)) := Fin.succ_ne_zero _
+    · simp [Equiv.swap_apply_right, Fin.cons_zero, Fin.cons_succ]
+    · have hne0 : k.succ.succ ≠ (0 : Fin (n + 2)) := Fin.succ_ne_zero _
       have hne1 : k.succ.succ ≠ (1 : Fin (n + 2)) := by
-        intro h
-        have hv := congr_arg Fin.val h
-        simp [Fin.val_succ] at hv
-        omega
-      simp [Equiv.swap_apply_of_ne hne0 hne1,
-            Fin.cons_zero, Fin.cons_succ]
+        intro h; have hv := congr_arg Fin.val h; simp [Fin.val_succ] at hv; omega
+      simp [Equiv.swap_apply_of_ne hne0 hne1, Fin.cons_zero, Fin.cons_succ]
 
 -- ═══════════════════════════════════════════════════
 -- Section 3: Swapping Positions 0 and 1
 -- ═══════════════════════════════════════════════════
 
-/-- **Swap positions 0 and 1** in the iterated integral.
-
-    For σ = Equiv.swap 0 1 in Fin(n+2) and continuous f:
-
-      iteratedIntervalIntegral a b f
-        = iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i)))
-
-    Proof:
-    - LHS = ∫_{a₀..b₀} ∫_{a₁..b₁} G dx₁ dx₀       [by definition]
-    - = ∫_{a₁..b₁} ∫_{a₀..b₀} G dx₀ dx₁             [by Fubini]
-    - = RHS                                            [by swap computation + definition]
-
-    where G(x₀,x₁) = iteratedIntervalIntegral (tail(tail a)) (tail(tail b))
-                       (fun rest => f (cons x₀ (cons x₁ rest))) -/
 theorem swap_outer_two {n : ℕ} {a b : Fin (n + 2) → ℝ}
     (hab : ∀ i, a i ≤ b i)
     {f : (Fin (n + 2) → ℝ) → ℝ} (hf : Continuous f) :
@@ -136,16 +122,12 @@ theorem swap_outer_two {n : ℕ} {a b : Fin (n + 2) → ℝ}
     iteratedIntervalIntegral a b f =
     iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i))) := by
   intro σ
-  -- Step 1: Expand LHS to ∫_{a₀..b₀} ∫_{a₁..b₁} G dx₁ dx₀
   have lhs_expand : iteratedIntervalIntegral a b f =
       ∫ x₀ in (a 0)..(b 0), ∫ x₁ in (a 1)..(b 1),
         iteratedIntervalIntegral
           (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
           (fun rest => f (Fin.cons x₀ (Fin.cons x₁ rest))) := by
     simp only [iteratedIntervalIntegral_succ, Fin.tail]
-  -- Step 2: Fubini to swap the two outermost integrals.
-  -- After converting to measure integrals, apply integral_integral_swap.
-  -- Integrability: integrable_swap_pair provides the required hypothesis.
   have fubini_step :
       ∫ x₀ in (a 0)..(b 0), ∫ x₁ in (a 1)..(b 1),
         iteratedIntervalIntegral
@@ -155,31 +137,18 @@ theorem swap_outer_two {n : ℕ} {a b : Fin (n + 2) → ℝ}
         iteratedIntervalIntegral
           (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
           (fun rest => f (Fin.cons x₀ (Fin.cons x₁ rest))) := by
-    -- Convert interval integrals to measure integrals for Fubini
     simp_rw [integral_of_le (hab 0), integral_of_le (hab 1)]
-    -- Apply Fubini: ∫ x₀ ∂μ₀, ∫ x₁ ∂μ₁, G x₀ x₁ = ∫ x₁ ∂μ₁, ∫ x₀ ∂μ₀, G x₀ x₁
-    -- where μ₀ = vol.restrict Ioc(a₀,b₀), μ₁ = vol.restrict Ioc(a₁,b₁)
     exact MeasureTheory.integral_integral_swap (integrable_swap_pair hab hf)
-  -- Step 3: Show RHS equals ∫_{a₁..b₁} ∫_{a₀..b₀} G dx₀ dx₁
-  -- Key: (a ∘ σ) 0 = a 1, (Fin.tail (a ∘ σ)) 0 = a 0,
-  --      and the function simplifies via swap01_cons_eq.
   have rhs_eq :
       iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i))) =
       ∫ x₁ in (a 1)..(b 1), ∫ x₀ in (a 0)..(b 0),
         iteratedIntervalIntegral
           (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
           (fun rest => f (Fin.cons x₀ (Fin.cons x₁ rest))) := by
-    -- Unfold once: outer integral is over (a ∘ σ) 0 = a (swap 0 1 0) = a 1
-    simp only [iteratedIntervalIntegral_succ, σ, Function.comp,
-               Equiv.swap_apply_left]
-    -- After first unfolding: ∫_{a1..b1} [inner with Fin.tail (a∘σ)]
+    simp only [iteratedIntervalIntegral_succ, σ, Function.comp, Equiv.swap_apply_left]
     congr 1; ext x₁
-    -- Unfold second time: (Fin.tail (a ∘ σ)) 0 = a (swap 0 1 1) = a 0
-    simp only [iteratedIntervalIntegral_succ, Fin.tail, σ,
-               Function.comp, Equiv.swap_apply_right]
-    -- After second unfolding: ∫_{a0..b0} [inner with Fin.tail(Fin.tail(a∘σ))]
+    simp only [iteratedIntervalIntegral_succ, Fin.tail, σ, Function.comp, Equiv.swap_apply_right]
     congr 1; ext x₀
-    -- The inner function: use swap01_cons_eq
     congr 1; ext rest
     exact swap01_cons_eq x₀ x₁ rest
   rw [lhs_expand, fubini_step, ← rhs_eq]
@@ -188,14 +157,7 @@ theorem swap_outer_two {n : ℕ} {a b : Fin (n + 2) → ℝ}
 -- Section 4: Inner Permutation Reduction
 -- ═══════════════════════════════════════════════════
 
-/-- Permuting only positions 1,...,n (fixing position 0) reduces to applying the
-    tail permutation inside the outer integral.
-
-    If σ(0) = 0, then σ = Fin.cons_permOfFin σ' for some σ' : Perm (Fin n),
-    and the result follows by applying IH to the inner integral.
-
-    The key Lean step: `intervalIntegral.integral_congr` to push the permutation
-    inside the outer integral, then apply the (n-1)-dimensional result. -/
+/-- When σ fixes 0, reduce to a permutation of the tail by `Equiv.Perm.decomposeFin`. -/
 private lemma iteratedIntervalIntegral_perm_tail {n : ℕ} {a b : Fin (n + 1) → ℝ}
     (hab : ∀ i, a i ≤ b i) {f : (Fin (n + 1) → ℝ) → ℝ} (hf : Continuous f)
     (σ : Equiv.Perm (Fin (n + 1))) (hσ0 : σ 0 = 0)
@@ -206,29 +168,79 @@ private lemma iteratedIntervalIntegral_perm_tail {n : ℕ} {a b : Fin (n + 1) �
           iteratedIntervalIntegral (a' ∘ τ) (b' ∘ τ) (fun x => g (fun i => x (τ.symm i)))) :
     iteratedIntervalIntegral a b f =
     iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i))) := by
-  -- σ fixes position 0, so (a ∘ σ) 0 = a (σ 0) = a 0 (same outermost bound)
-  -- The outer integral is the same; apply IH inside via integral_congr.
-  sorry
+  -- Extract the tail permutation
+  let σ' : Equiv.Perm (Fin n) := (Equiv.Perm.decomposeFin σ).2
+  -- Key: (decomposeFin σ).1 = σ 0 = 0
+  have hfst : (Equiv.Perm.decomposeFin σ).1 = 0 := by
+    have h := @Equiv.Perm.decomposeFin_symm_apply_zero n
+                (Equiv.Perm.decomposeFin σ).1 (Equiv.Perm.decomposeFin σ).2
+    simp only [Prod.mk.eta, Equiv.Perm.decomposeFin.symm_apply_apply] at h
+    exact h.symm.trans hσ0
+  -- σ(i.succ) = (σ' i).succ: from decomposeFin_symm_apply_succ with p = 0
+  have hsucc : ∀ i : Fin n, σ i.succ = (σ' i).succ := by
+    intro i
+    -- σ = decomposeFin.symm (decomposeFin σ)
+    have step : σ i.succ =
+        Equiv.swap 0 ((Equiv.Perm.decomposeFin σ).1) ((Equiv.Perm.decomposeFin σ).2 i).succ := by
+      conv_lhs => rw [show σ = Equiv.Perm.decomposeFin.symm (Equiv.Perm.decomposeFin σ) from
+                         (Equiv.Perm.decomposeFin.symm_apply_apply σ).symm]
+      rw [show (Equiv.Perm.decomposeFin σ) =
+              ((Equiv.Perm.decomposeFin σ).1, (Equiv.Perm.decomposeFin σ).2) from rfl]
+      exact Equiv.Perm.decomposeFin_symm_apply_succ _ _ _
+    rw [step, hfst, Equiv.swap_self]
+    simp [σ']
+  -- σ.symm fixes 0
+  have hσ_symm_0 : σ.symm 0 = 0 := by
+    have h := σ.symm_apply_apply 0; rw [hσ0] at h; exact h
+  -- σ.symm(j.succ) = (σ'.symm j).succ
+  have hsucc_symm : ∀ j : Fin n, σ.symm j.succ = (σ'.symm j).succ := by
+    intro j
+    have hval : σ (σ'.symm j).succ = j.succ := by
+      rw [hsucc (σ'.symm j)]; congr 1; exact σ'.apply_symm_apply j
+    exact (σ.injective (hval.trans (σ.apply_symm_apply j.succ).symm)).symm
+  -- Outer bounds: (a ∘ σ) 0 = a 0 since σ 0 = 0
+  have h0a : (a ∘ σ) 0 = a 0 := by simp [hσ0]
+  have h0b : (b ∘ σ) 0 = b 0 := by simp [hσ0]
+  -- Tail bounds match
+  have htail_a : Fin.tail (a ∘ σ) = Fin.tail a ∘ σ' :=
+    funext fun i => by simp [Fin.tail, Function.comp, hsucc i]
+  have htail_b : Fin.tail (b ∘ σ) = Fin.tail b ∘ σ' :=
+    funext fun i => by simp [Fin.tail, Function.comp, hsucc i]
+  -- Unfold and apply integral_congr
+  rw [iteratedIntervalIntegral_succ, iteratedIntervalIntegral_succ, h0a, h0b]
+  apply intervalIntegral.integral_congr
+  intro x₀ _
+  -- Show the integrand transforms correctly
+  have hfun : ∀ x' : Fin n → ℝ,
+      (fun x => f (fun i => x (σ.symm i))) (Fin.cons x₀ x') =
+      (fun y' => f (Fin.cons x₀ y')) (fun i => x' (σ'.symm i)) := by
+    intro x'
+    simp only []
+    congr 1; ext i
+    refine Fin.cases ?_ (fun j => ?_) i
+    · simp [hσ_symm_0, Fin.cons_zero]
+    · simp [hsucc_symm j, Fin.cons_succ]
+  rw [htail_a, htail_b, funext hfun]
+  -- Apply IH with σ'
+  exact ih (Fin.tail a) (Fin.tail b)
+    (fun y' => f (Fin.cons x₀ y'))
+    (hf.comp (continuous_const.finCons continuous_id))
+    (fun i => hab i.succ)
+    σ'
 
 -- ═══════════════════════════════════════════════════
 -- Section 5: Main Theorem
 -- ═══════════════════════════════════════════════════
 
-/-- **N-Dimensional Order Independence** (eliminating the parent axiom).
+/-- **N-Dimensional Order Independence**.
+    Any permutation of integration variables preserves the iterated integral.
 
-    For continuous f on the box [a,b] = [a₀,b₀]×...×[aₙ₋₁,bₙ₋₁],
-    any permutation of the integration variables preserves the iterated integral.
-
-    ## Proof by induction on n
-
-    - n=0: f Fin.elim0 on both sides.
-    - n=1: Perm(Fin 1) = {id}, trivial.
-    - n+2: Use `Equiv.Perm.induction_on'` to reduce to:
-      (a) σ = id: trivial.
-      (b) σ' = (swap i j) ∘ τ where IH holds for τ:
-          Apply IH for τ, then handle swap (i,j) using the composition
-          of swap_outer_two (for swap of adjacent positions at depth 0)
-          and iteratedIntervalIntegral_perm_tail (for inner permutations). -/
+    Proof by induction on n:
+    - n=0: trivial
+    - n+1, σ 0 = 0: use `iteratedIntervalIntegral_perm_tail` (proved above)
+    - n+1, σ 0 = k ≠ 0: Need to compose `swap_outer_two` for the swap(0,k) step.
+      Currently sorry; fix: prove a generalized swap(0,k) lemma by decomposing
+      swap(0,k) into adjacent transpositions and applying perm_tail + swap_outer_two. -/
 theorem iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → ℝ}
     (hab : ∀ i, a i ≤ b i) {f : (Fin n → ℝ) → ℝ} (hf : Continuous f)
     (σ : Equiv.Perm (Fin n)) :
@@ -236,51 +248,54 @@ theorem iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → �
     iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i))) := by
   induction n with
   | zero =>
-    -- n=0: Perm(Fin 0) = {id}, both sides are f Fin.elim0.
     have : σ = Equiv.refl (Fin 0) := Subsingleton.elim _ _
-    subst this
-    simp [iteratedIntervalIntegral, Function.comp]
+    subst this; simp [iteratedIntervalIntegral, Function.comp]
   | succ n ih =>
-    -- The inductive case uses the two building blocks.
-    -- Full proof requires Equiv.Perm.induction_on' + compositionality.
-    -- See the sorry below for the remaining structure.
-    sorry
+    have ih' : ∀ (a' b' : Fin n → ℝ) (g : (Fin n → ℝ) → ℝ),
+        Continuous g → (∀ i, a' i ≤ b' i) →
+        ∀ τ : Equiv.Perm (Fin n),
+        iteratedIntervalIntegral a' b' g =
+        iteratedIntervalIntegral (a' ∘ τ) (b' ∘ τ) (fun x => g (fun i => x (τ.symm i))) :=
+      fun a' b' g hg hab' τ => ih a' b' hab' hg τ
+    -- Case: σ 0 = 0 (σ fixes 0 → use perm_tail)
+    by_cases h0 : σ 0 = 0
+    · exact iteratedIntervalIntegral_perm_tail hab hf σ h0 ih'
+    · -- Case: σ 0 = k ≠ 0
+      -- Strategy: write σ = (swap 0 k) ∘ σ'' where σ'' = (swap 0 k) ∘ σ fixes 0
+      -- Then: apply perm_tail for σ'', then swap_outer_two for swap(0,k)
+      -- For k=1: swap_outer_two applies directly
+      -- For k>1: need generalization of swap_outer_two (not yet proved)
+      sorry
 
 -- ═══════════════════════════════════════════════════
 -- Section 6: Verified Special Cases (0 sorries)
 -- ═══════════════════════════════════════════════════
 
-/-- The 2D case: full order independence for Fin 2 (both permutations).
-    Perm(Fin 2) = {id, swap 0 1}, both cases handled directly. -/
+/-- Full 2D order independence. Perm(Fin 2) = {id, swap 0 1}. -/
 theorem order_independent_2d {a b : Fin 2 → ℝ}
     (hab : ∀ i, a i ≤ b i) {f : (Fin 2 → ℝ) → ℝ} (hf : Continuous f)
     (σ : Equiv.Perm (Fin 2)) :
     iteratedIntervalIntegral a b f =
     iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i))) := by
-  -- Perm(Fin 2) = {id, swap 0 1}: any permutation either fixes 0 or swaps 0 and 1.
-  -- Case split on σ 0:
   rcases Fin.eq_zero_or_eq_succ (σ 0) with h | ⟨k, hk⟩
-  · -- σ 0 = 0: σ is identity (since also σ 1 = 1 by bijectivity)
+  · -- σ 0 = 0: σ is identity
     have hσ : σ = 1 := by
       ext i; fin_cases i
       · simpa using h
       · have h1 : σ 1 ≠ 0 := by
-          intro heq
-          have := σ.injective (heq.trans h.symm)
-          simp at this
+          intro heq; exact absurd (σ.injective (heq.trans h.symm)) (by simp)
         fin_cases σ 1 <;> simp_all
     subst hσ; simp [Function.comp]
-  · -- σ 0 = 1: σ is the swap (since also σ 1 = 0)
+  · -- σ 0 = 1: σ is the swap
     have hk0 : k = 0 := by
       have : k < 1 := Fin.succ_lt_succ_iff.mp (hk ▸ σ 0 |>.isLt)
       exact Nat.eq_zero_of_lt_one this |> Fin.val_fin_lt.mpr |>.antisymm (Fin.zero_le _)
-    have hσ0 : σ 0 = 1 := by rw [hk, hk0]; rfl
     have hσ : σ = Equiv.swap 0 1 := by
       ext i; fin_cases i
-      · simp [hσ0, Equiv.swap_apply_left]
+      · simp [show σ 0 = 1 by rw [hk, hk0]; rfl, Equiv.swap_apply_left]
       · have h1 : σ 1 = 0 := by
           have hne : σ 1 ≠ 1 := fun heq =>
-            absurd (σ.injective (hσ0.trans heq.symm)) (by simp)
+            absurd (σ.injective (show σ 0 = σ 1 by rw [hk, hk0]; simp [heq])) (by simp)
           fin_cases σ 1 <;> simp_all
         simp [h1, Equiv.swap_apply_right]
     subst hσ; exact swap_outer_two hab hf
@@ -296,38 +311,31 @@ theorem order_independent_3d_swap01 {a b : Fin 3 → ℝ}
 /-
 ## Research Outcome
 
-**Problem**: Eliminate `iteratedIntervalIntegral_order_independent` axiom from parent.
-
-**Proved** (0 sorries in these):
-- `swap01_cons_eq`: Key Fin arithmetic for the swap computation
-- `swap_outer_two`: The primitive Fubini swap of positions 0 and 1 (modulo integrability)
+**Proved** (0 sorries):
+- `swap01_cons_eq`: Fin arithmetic for the swap computation
+- `swap_outer_two`: Fubini swap of positions 0 and 1 (modulo integrable_swap_pair)
 - `order_independent_2d`: Full 2D order independence
 - `order_independent_3d_swap01`: 3D swap(0,1) case
+- `iteratedIntervalIntegral_perm_tail`: Inner permutation reduction.
+  Uses Equiv.Perm.decomposeFin to extract σ' : Perm(Fin n) with σ(i.succ)=(σ' i).succ,
+  then applies IH via integral_congr.
 
-**Remaining sorries** (4 total):
-1. `integrable_swap_pair` (1 sorry): Integrability of parameterized inner integral.
-   Fix: Prove Continuous (fun p => iteratedIntervalIntegral ... (fun rest => f(cons p.1 (cons p.2 rest))))
-   by induction using `intervalIntegral.continuous_of_dominated`, then integrableOn_compact.
+**Remaining sorries** (3 total):
 
-2. `iteratedIntervalIntegral_perm_tail` (1 sorry): Inner permutation reduction.
-   Fix: When σ(0) = 0, `(a∘σ) 0 = a 0`, so outer integral unchanged.
-   Use `intervalIntegral.integral_congr` to push σ inside, apply IH with
-   Fin.orderEmbOfFin or σ restricted to tail.
+1. `integrable_swap_pair` (1 sorry for continuity of G(p)):
+   Fix: Prove by induction on n using `continuous_of_dominated_interval`:
+   - n=0: G(p) = f(cons p.1 (cons p.2 Fin.elim0)), continuous by hf.
+   - n+1: G(p) = ∫ x in a₂..b₂, G'(p, x) dx. Bound G' by max(‖f‖) on compact box.
+   Then use ContinuousOn.integrableOn_compact + Measure.prod_restrict.
 
-3. Main theorem inductive step (1 sorry): General permutation via decomposition.
-   Fix: Use `Equiv.Perm.induction_on'` to reduce to products of transpositions.
-   Each transposition (swap i j) is handled by:
-   - Moving positions i and j adjacent via iterated swap_outer_two applications
-   - Then applying the adjacent swap
-   - Then moving back
+2. Main theorem case σ 0 ≠ 0 (1 sorry):
+   Fix: Let k = σ 0, σ'' = (swap 0 k) ∘ σ. Then σ'' 0 = 0, apply perm_tail.
+   Then apply result for swap(0,k). For k=1: swap_outer_two. For k>1: prove
+   general swap(0,k) lemma by adjacent transposition decomposition.
 
-4. `fubini_step` in `swap_outer_two` uses `integral_swap` which may need explicit:
-   `MeasureTheory.integral_integral_swap` with correct argument form.
-   Fix: Verify the exact API in current Mathlib; the argument structure is correct
-   but the exact form of integral_prod_right may need adjustment.
-
-**Impact**: Eliminates 1 axiom from the gallery entry `greens-theorem-oq-01-oq-01-oq-01`,
-reducing it from axiomCount=1 to axiomCount=0 once all sorries are resolved.
+**Impact**: Fully eliminates axiom once all sorries resolved. The perm_tail reduction
+(B2 building block) is now complete. Only the Fubini integrability and the general
+swap(0,k) case remain.
 -/
 
 end GreensTheoremOQ01OQ01OQ01OQ01

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01/knowledge.md
@@ -76,3 +76,45 @@ proves the building blocks to eliminate that axiom.
    Aristotle after resolving the proof outline (the integrability follows from
    continuity + compact domain via standard Mathlib infrastructure).
 
+
+---
+
+## Session 2026-05-06 (Session 2) — Prove perm_tail Building Block
+
+**Mode**: REVISIT (in-progress problem)
+**Outcome**: progress
+
+### What I Did
+
+- Proved `iteratedIntervalIntegral_perm_tail` using `Equiv.Perm.decomposeFin`
+- Restructured `integrable_swap_pair` to use ContinuousOn.integrableOn_compact path
+- Identified `continuous_of_dominated_interval` as the key Mathlib tool
+- Pushed to PR #16248 branch (original PR was merged; new push creates continuation)
+
+### Key Findings
+
+- **decomposeFin decomposition**: `Equiv.Perm.decomposeFin σ = (σ 0, σ')` where σ'
+  is the tail permutation. When σ 0 = 0: `decomposeFin_symm_apply_succ` gives
+  `σ(i.succ) = swap 0 0 (σ' i).succ = (σ' i).succ`. This is the key computation.
+
+- **Integrability path**: `Continuous G → ContinuousOn.integrableOn_compact (Icc×Icc) 
+  → IntegrableOn (Ioc×Ioc) → Integrable w.r.t. (vol.restrict Ioc)×(vol.restrict Ioc)`
+  via `Measure.prod_restrict`.
+
+- **Remaining sorry for continuity**: Need `Continuous (fun p => iteratedIntervalIntegral
+  ... (fun rest => f(cons p.1 (cons p.2 rest))))`. Fix: induction using
+  `continuous_of_dominated_interval`, with bound = max of ‖f‖ on compact box.
+
+- **Main theorem σ(0)≠0**: Write σ''=(swap 0 k)∘σ, then σ'' 0=0. Apply perm_tail
+  to σ''. Need result for swap(0,k): k=1 by swap_outer_two, k>1 needs generalization.
+
+### Files Modified
+
+- `proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` (341 lines, 2 sorries)
+- `src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json` (sorries: 3→2)
+
+### Next Steps
+
+1. Prove continuity of G(p) using continuous_of_dominated_interval induction (1 sorry)
+2. Prove main theorem case σ(0)≠0 using perm_tail + generalized swap(0,k) (1 sorry)
+3. For swap(0,k): prove by induction on k using swap(0,k) = swap(k-1,k)∘swap(0,k-1)∘swap(k-1,k)

--- a/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01.json
@@ -29,20 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Lean file created (333 lines, 3 sorries). swap01_cons_eq and swap_outer_two proved. Full 2D case proved. 3 sorries remain for integrability, inner permutation, and general induction.",
+    "progressSummary": "PROGRESS: perm_tail proved (B2 building block complete); 2 sorries remain",
     "builtItems": [
       "swap01_cons_eq: Fin arithmetic computation proving f(cons x\u2081 (cons x\u2080 rest) \u2218 swap 0 1) = f(cons x\u2080 (cons x\u2081 rest))",
       "swap_outer_two: Fubini swap of positions 0 and 1 for continuous f in any n+2 dimensions",
       "order_independent_2d: Full order independence for n=2 (all of Perm(Fin 2))",
       "order_independent_3d_swap01: 3D case for swap(0,1)",
-      "GreensTheoremOQ01OQ01OQ01OQ01.lean (333 lines, 3 sorries)"
+      "GreensTheoremOQ01OQ01OQ01OQ01.lean (333 lines, 3 sorries)",
+      "iteratedIntervalIntegral_perm_tail: fully proved using decomposeFin (GreensTheoremOQ01OQ01OQ01OQ01.lean)",
+      "integrable_swap_pair: reduced to 1 sorry (continuity of G(p)) + completed ContinuousOn path"
     ],
     "insights": [
       "Core computation is pure Fin arithmetic: swap01_cons_eq handles the positions 0, 1, k+2 cases separately via Fin.cases.",
       "Proof structure: expand both LHS and RHS to a common double integral G(x\u2080,x\u2081) over inner variables, then apply integral_integral_swap (Fubini).",
       "The G function (iterated integral over remaining variables) is identical on both sides after the swap01 computation - the key invariant.",
       "Two building blocks suffice: (1) swap positions 0 and 1 (Fubini), (2) permute inner variables (IH inside outer integral). Any permutation decomposes into these.",
-      "Perm(Fin 2) = {id, swap 0 1} case is fully handled by splitting on where \u03c3 sends 0."
+      "Perm(Fin 2) = {id, swap 0 1} case is fully handled by splitting on where \u03c3 sends 0.",
+      "Equiv.Perm.decomposeFin gives \u03c3(0)=0 \u2192 tail permutation \u03c3' with \u03c3(i.succ)=(\u03c3' i).succ; enables perm_tail proof",
+      "continuous_of_dominated_interval is the key Mathlib tool for continuity of parameterized integrals",
+      "ContinuousOn.integrableOn_compact + Measure.prod_restrict converts continuity to integrability on Ioc\u00d7Ioc"
     ],
     "mathlibGaps": [
       "Continuity of iteratedIntervalIntegral as function of outer parameter (needed for integrable_swap_pair)",
@@ -52,7 +57,10 @@
       "Prove continuity of parameterized iterated integral by induction using intervalIntegral.continuous_of_dominated",
       "Prove iteratedIntervalIntegral_perm_tail using integral_congr + IH on Fin.tail permutation",
       "Prove main theorem using Equiv.Perm.induction_on + swap_outer_two compositionality",
-      "Submit integrable_swap_pair sorry to Aristotle after proof outline is complete"
+      "Submit integrable_swap_pair sorry to Aristotle after proof outline is complete",
+      "Prove continuity of G(p) = iteratedIntervalIntegral... (fun rest => f(cons p.1 (cons p.2 rest))) by induction using continuous_of_dominated_interval with bound from max of f on compact box",
+      "Prove main theorem case \u03c3(0)=k\u22600: define \u03c3''=(swap 0 k)\u2218\u03c3, show \u03c3'' 0=0, apply perm_tail+swap_outer_two",
+      "For k>1: generalize swap_outer_two to swap(0,k) via adjacent transposition decomposition"
     ],
     "markdown": "# Knowledge Base: greens-theorem-oq-01-oq-01-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Continues axiom elimination for `iteratedIntervalIntegral_order_independent` in `greens-theorem-oq-01-oq-01-oq-01`. Reduces sorry count from 3 to 2.

**What was proved in this PR:**

- `iteratedIntervalIntegral_perm_tail` (fully proved): When σ fixes 0, reduces the n+1 dimensional permutation integral to the n-dimensional case via `Equiv.Perm.decomposeFin`. Key steps:
  - `decomposeFin_symm_apply_succ` with p=0 gives σ(i.succ) = (σ' i).succ
  - `integral_congr` pushes the permutation inside
  - IH applied to the tail permutation σ'

- `integrable_swap_pair` improved: Now reduces to proving continuity of G(p) = `iteratedIntervalIntegral ... (fun rest => f(cons p.1 (cons p.2 rest)))`. Uses `ContinuousOn.integrableOn_compact` + `Measure.prod_restrict` path. 1 sorry remains for the continuity induction.

**Remaining sorries (2):**
1. Continuity of G(p) via `continuous_of_dominated_interval` induction with compact bound
2. Main theorem case σ(0)=k≠0: needs swap(0,k) generalization

**Labels:** research

🤖 Generated with [Claude Code](https://claude.com/claude-code)