### PR TITLE
fix(meta): circumference-via-differentiation-oq-01 — section line ranges + drop n=1 narrative

### DIFF
--- a/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
@@ -56,7 +56,7 @@
     "keyInsights": [
       "**Power rule is the engine**: The entire proof reduces to `hasDerivAt_pow n r`. All the geometry is encoded in the constant ω_n — differentiation is pure calculus.",
       "**Gamma recursion connects volume and surface**: The identity Γ(x+1) = x·Γ(x) is the key to showing n·ω_n = 2π^(n/2)/Γ(n/2). Without it, the surface area formula would appear unrelated to the volume formula.",
-      "**Uniform framework across dimensions**: The same three definitions (nBallVolumeFn, nSphereSurfaceConst, nSphereSurfaceFn) work for all n. The n=1 case gives the 2-point boundary, n=2 gives the circumference, n=3 gives the sphere surface.",
+      "**Uniform framework across dimensions**: The same three definitions (nBallVolumeFn, nSphereSurfaceConst, nSphereSurfaceFn) work for all n. The n=2 case gives the circumference, n=3 gives the sphere surface.",
       "**Parent theorem is a special case**: disk_area_matches_parent shows that CircumferenceViaDifferentiation.area_hasDerivAt follows from the general theorem for n=2."
     ]
   },
@@ -64,32 +64,32 @@
     {
       "id": "section-main-deriv",
       "title": "Main Derivative Theorem",
-      "startLine": 50,
-      "endLine": 80,
+      "startLine": 92,
+      "endLine": 117,
       "summary": "`nBallVolumeFn_hasDerivAt`: The n-ball volume V_n(r) = ω_n·rⁿ has derivative n·ω_n·r^(n-1) at every r. Uses `hasDerivAt_pow` + `const_mul` + ring.",
       "mathContext": "HasDerivAt (nBallVolumeFn n) (nSphereSurfaceFn n r) r, proved by combining the power rule with scalar multiplication."
     },
     {
       "id": "section-gamma",
       "title": "Gamma Recursion for Surface Area",
-      "startLine": 82,
-      "endLine": 104,
+      "startLine": 119,
+      "endLine": 134,
       "summary": "`nSphereSurfaceConst_eq_gamma`: For n ≥ 1, the surface constant n·ω_n = 2π^(n/2)/Γ(n/2). Uses `Gamma_add_one` and `field_simp`.",
       "mathContext": "The Gamma recursion Γ(x+1) = x·Γ(x) allows cancellation: n / Γ(n/2+1) = n / ((n/2)·Γ(n/2)) = 2/Γ(n/2)."
     },
     {
       "id": "section-special",
-      "title": "Special Cases (n=1,2,3)",
-      "startLine": 106,
-      "endLine": 145,
-      "summary": "Surface constants: n=1 gives 2 (two points), n=2 gives 2π (circumference), n=3 gives 4π (sphere surface). Verified using unitBallVolume_one/two/three.",
-      "mathContext": "nSphereSurfaceConst 1 = 2, nSphereSurfaceConst 2 = 2π, nSphereSurfaceConst 3 = 4π."
+      "title": "Special Cases (n=2,3)",
+      "startLine": 136,
+      "endLine": 168,
+      "summary": "Surface constants: n=2 gives 2π (circumference), n=3 gives 4π (sphere surface). Verified using unitBallVolume_two/three.",
+      "mathContext": "nSphereSurfaceConst 2 = 2π, nSphereSurfaceConst 3 = 4π."
     },
     {
       "id": "section-connection",
       "title": "Connection to Parent Theorem",
-      "startLine": 147,
-      "endLine": 175,
+      "startLine": 170,
+      "endLine": 190,
       "summary": "`nBallVolumeFn_two_eq_areaFn` and `disk_area_matches_parent` show that the n=2 case recovers the parent file's circumference derivation.",
       "mathContext": "nBallVolumeFn 2 = CircumferenceViaDifferentiation.areaFn, so the parent theorem is a special case."
     }


### PR DESCRIPTION
## Fix

Closes #16285.

Two-part metadata fix for `circumference-via-differentiation-oq-01`:

### 1. Section line ranges drift (~40-45 lines)

`sections[*].startLine`/`endLine` predated the Lean file's current layout. Updated to match actual `-- Part N` header positions (240-line file):

| Section | Before | After |
|---|---|---|
| `section-main-deriv` (Part 1) | 50–80 | 92–117 |
| `section-gamma` (Part 2) | 82–104 | 119–134 |
| `section-special` (Parts 3+4) | 106–145 | 136–168 |
| `section-connection` (Part 5) | 147–175 | 170–190 |

### 2. n=1 narrative overstatement

`section-special.summary` claimed verification "using `unitBallVolume_one/two/three`", `section-special.mathContext` claimed `nSphereSurfaceConst 1 = 2`, and `overview.keyInsights[2]` mentioned "the n=1 case gives the 2-point boundary". The Lean file has no `unitBallVolume_one` or `nSphereSurfaceConst_one` theorem — only `_two` and `_three`. Removed n=1 from all three locations, and updated `section-special.title` from "Special Cases (n=1,2,3)" to "(n=2,3)".

## Evidence

**Before**: `meta.json` claimed sections at lines 50-80, 82-104, 106-145, 147-175 and three n=1 references with no Lean theorem backing them.
**After**: Sections match `grep -n '^-- Part'` output (Parts 1-5 at lines 93/120/137/153/171); n=1 references removed.

Counts unchanged (240 lines / 16 theorems / 4 defs / 0 axioms / 0 sorries / `verified`/`original` is appropriate).

---
Automated fix by lean-mechanic agent.