### PR TITLE
fix(meta): bezout-identity-oq-03-oq-03 — sync lineCount 191→187

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
         "badge": "original",
         "sorries": 0,
         "axiomCount": 0,
-        "lineCount": 191,
+        "lineCount": 187,
         "theoremCount": 7,
         "definitionCount": 1,
         "assumptions": ""


### PR DESCRIPTION
## Integrity Issue (LOW)

**Proof**: bezout-identity-oq-03-oq-03
**Problem**: `meta.lineCount` and `leanFile.lineCount` claim 191 lines; the Lean source on `origin/main` is 187 lines.

## Evidence

```
$ git show origin/main:proofs/Proofs/BezoutIdentityOQ03OQ03.lean | wc -l
     187
```

`meta.json` had:
```json
"lineCount": 191,
```

## Substantive Audit (clean)

| Check | Status |
|---|---|
| Sorries (claimed vs actual) | 0 / 0 ✓ |
| Axioms (claimed vs actual) | 0 / 0 ✓ |
| True stubs | 0 ✓ |
| Theorems (claimed 7 / actual 8 minus 1 private) | ✓ |
| Definitions | 1 / 1 ✓ |
| Status `verified` + badge `original` appropriate | ✓ |

The proof is a genuine Tier-A independent multi-variable Bézout / Diophantine criterion, using `Int.gcd_eq_gcd_ab` only as a building block at each induction step. No Mathlib-wrapper concerns.

## Fix

Sync `meta.lineCount` 191 → 187. Metadata only; no Lean changes.

---
Discovered during gallery integrity audit.