### PR TITLE
fix(erdos-340): remove orphaned docstring comments causing parse failure

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidon.lean
+++ b/proofs/Proofs/Erdos340GreedySidon.lean
@@ -488,7 +488,7 @@ could provide insights into its growth rate. -/
 def greedySidonDiffSet : Set ℤ :=
   {d : ℤ | ∃ a b : ℕ, a ∈ Set.range greedySidon ∧ b ∈ Set.range greedySidon ∧ d = a - b}
 
-/-- **Axiom**: 22 is in the difference set: 204 - 182 = 22.
+/- **Note**: 22 is in the difference set: 204 - 182 = 22.
 
 From OEIS A005282 (Mian-Chowla sequence):
 - greedySidon 13 = 182
@@ -497,7 +497,7 @@ From OEIS A005282 (Mian-Chowla sequence):
 
 This could be proved by adding axioms for greedySidon_13 and greedySidon_14. -/
 
-/-- **Axiom**: 33 is in the difference set (value uncertain).
+/- **Note**: 33 is in the difference set (value uncertain).
 
 This requires computing more of the greedy Sidon sequence to verify.
 The statement "↔ True" is a placeholder indicating the question is open. -/


### PR DESCRIPTION
## Summary

Fixes a syntax error in `Proofs/Erdos340GreedySidon.lean` that blocks builds of any file importing it (including `Erdos28AdditiveBases.lean`).

**Root cause:** Two `/-- ... -/` docstring comments appear at lines 491 and 500 without any following declaration. In Lean 4, `/-- ... -/` is a declaration docstring and MUST precede a `theorem`, `def`, `axiom`, etc. Without one, the parser errors:
```
error: unexpected token '/--'; expected 'lemma'
error: unexpected token 'end'; expected 'lemma'
```

**Fix:** Change orphaned `/-- ... -/` docstrings to `/- ... -/` regular block comments, which can appear anywhere.

The affected comments describe planned-but-not-yet-implemented axioms for `greedySidon_13` and `greedySidon_14` (values from the Mian-Chowla sequence).

**Impact:** Unblocks builds of:
- `Proofs.Erdos340GreedySidon`
- `Proofs.Erdos28AdditiveBases` (imports the above)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)