### PR TITLE
fix(meta): frobenius-number-oq-01 — sync theoremCount 6→3

### DIFF
--- a/src/data/proofs/frobenius-number-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "frobenius-number-oq-01",
   "title": "Frobenius Number: Count of Non-Representable Integers = (a-1)(b-1)/2",
   "slug": "frobenius-number-oq-01",
-  "description": "For coprime positive integers a, b ≥ 2, exactly (a-1)(b-1)/2 positive integers in {1,...,g(a,b)} cannot be represented as non-negative linear combinations of a and b. Proved via the Frobenius Symmetry (OQ-02): the involution k ↦ g-k bijects non-representable numbers in {1,...,g-1} onto representable numbers in {1,...,g-1}, giving equal counts. With g non-representable and 0 representable, the total is (g-1)/2 + 1 = (g+1)/2 = (a-1)(b-1)/2. 6 theorems, 0 sorries, 0 axioms.",
+  "description": "For coprime positive integers a, b ≥ 2, exactly (a-1)(b-1)/2 positive integers in {1,...,g(a,b)} cannot be represented as non-negative linear combinations of a and b. Proved via the Frobenius Symmetry (OQ-02): the involution k ↦ g-k bijects non-representable numbers in {1,...,g-1} onto representable numbers in {1,...,g-1}, giving equal counts. With g non-representable and 0 representable, the total is (g-1)/2 + 1 = (g+1)/2 = (a-1)(b-1)/2. 3 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -18,7 +18,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 159,
-    "theoremCount": 6,
+    "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "None. All theorems proved from first principles using Mathlib's Finset.card_bij and the Frobenius Symmetry result (OQ-02).",
     "mathlibDependencies": [
@@ -96,7 +96,7 @@
     "path": "Proofs/FrobeniusNumberOQ01.lean",
     "filename": "FrobeniusNumberOQ01.lean",
     "lineCount": 159,
-    "theoremCount": 6,
+    "theoremCount": 3,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Summary

`frobenius-number-oq-01` claims `theoremCount: 6` but the Lean file has 3 theorem-like declarations (2 private lemmas + 1 public theorem). The 10 `example` declarations are not counted as theorems.

## Changes

- `description`: "6 theorems" → "3 theorems"
- `meta.theoremCount`: 6 → 3
- `leanFile.theoremCount`: 6 → 3

Other counts verified clean: `lineCount: 159` ✓, `sorries: 0` ✓, `axiomCount: 0` ✓ (no `axiom` declarations), `definitionCount: 0` ✓ (no `def`).

Status `verified` / badge `original` is correct: file builds substantive bijection argument on top of OQ-02 symmetry, not a Mathlib wrapper.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)