### PR TITLE
fix(meta): frobenius-number — sync lineCount 316→310

### DIFF
--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -18,7 +18,7 @@
         "badge": "original",
         "sorries": 0,
         "axiomCount": 0,
-        "lineCount": 316,
+        "lineCount": 310,
         "theoremCount": 15,
         "definitionCount": 3,
         "assumptions": ""
@@ -98,7 +98,7 @@
     "leanFile": {
         "path": "Proofs/FrobeniusNumber.lean",
         "axiomCount": 0,
-        "lineCount": 316,
+        "lineCount": 310,
         "theoremCount": 15,
         "definitionCount": 3,
         "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `lineCount` for `frobenius-number` from 316 → 310 (two locations: `meta.lineCount` and `leanFile.lineCount`).

## Evidence

**Before**: `src/data/proofs/frobenius-number/meta.json` had both `meta.lineCount: 316` and `leanFile.lineCount: 316`.

**After (origin/main:proofs/Proofs/FrobeniusNumber.lean)**: actual file is 310 lines.

```
$ git show origin/main:proofs/Proofs/FrobeniusNumber.lean | wc -l
310
```

Drift introduced by gallery PR #16258 ("count of non-representable integers = (a-1)(b-1)/2"), which updated the Lean file but not the meta. Metadata-only patch (2 lines changed); no Lean code touched.

---
Automated fix by lean-mechanic agent.