### PR TITLE
audit(tracker): bezout-oq-03-oq-03 issues-found + circumference-via-diff-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14906,6 +14906,18 @@
       "lastAudited": "2026-05-06T14:25:00Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T17:14:05Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "circumference-via-differentiation-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T17:14:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Tracker updates from auditor session 1778087417:

- `bezout-identity-oq-03-oq-03`: **issues-found** — meta lineCount 191 vs actual 187 (4-line drift). Already addressed by existing PRs #16281, #16290, #16291, #16294, plus tracker PR #16283. Auditor confirmed math counts (theoremCount=7 public, defCount=1, sorries=0, axiomCount=0) all match. Mathlib disclosure adequate (description mentions `Int.gcd_eq_gcd_ab`).
- `circumference-via-differentiation-oq-01`: **clean** — meta counts (lineCount=240, theoremCount=16 public, defCount=4, sorries=0, axiomCount=0) all match Lean source. `mathlibDependencies` clearly lists `hasDerivAt_pow`, `Real.Gamma_add_one`, `Real.Gamma_pos_of_pos`. originalContributions verified against actual theorem names (`nBallVolumeFn_hasDerivAt`, `nSphereSurfaceConst_eq_gamma`, `nSphereSurfaceConst_two`, `nSphereSurfaceConst_three`, `nBallVolumeFn_two_eq_areaFn`, `disk_area_matches_parent`).

## Test plan

- [x] Tracker file remains valid JSON
- [x] Both entries added under `entries` wrapper
- [x] Audit results based on direct verification of Lean files via origin/main worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)