### PR TITLE
fix(meta): cramers-rule-oq-02-oq-02 — sync lineCount 187→189

### DIFF
--- a/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
@@ -55,7 +55,7 @@
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 187,
+    "lineCount": 189,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 12,
     "definitionCount": 2
@@ -197,7 +197,7 @@
       "CramersComplexity"
     ],
     "namespace": "CramersComplexityLUQR",
-    "lineCount": 187,
+    "lineCount": 189,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2,


### PR DESCRIPTION
## Integrity Issue

**Proof**: cramers-rule-oq-02-oq-02
**Problem**: meta.json `lineCount` (and `leanFile.lineCount`) claim 187 lines, but actual `proofs/Proofs/CramersRuleOQ02OQ02.lean` has 189 lines.

## Evidence

```
$ git show origin/main:proofs/Proofs/CramersRuleOQ02OQ02.lean | wc -l
189
```

meta.json (origin/main):
- `meta.lineCount: 187`
- `leanFile.lineCount: 187`

Sorries: 0 (verified). Axioms: 0 (verified). True stubs: 0 (verified). theoremCount/definitionCount consistent under "exclude private lemmas" convention.

## Fix

Update both `lineCount` fields from 187 → 189.

---
Discovered during gallery integrity audit. Built via git plumbing to avoid worktree contention.