### PR TITLE
fix(meta): frobenius-number-oq-01 — list FrobeniusNumberOQ02 in additionalFiles

### DIFF
--- a/src/data/proofs/frobenius-number-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01/meta.json
@@ -101,6 +101,9 @@
     "definitionCount": 0,
     "sorries": 0,
     "isAristotle": false,
-    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FrobeniusNumberOQ01.lean"
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FrobeniusNumberOQ01.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumberOQ02.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Fix

Add `Proofs/FrobeniusNumberOQ02.lean` to `leanFile.additionalFiles` in `src/data/proofs/frobenius-number-oq-01/meta.json` so the auditor's `find-targets.ts` sees the sibling-import dependency.

## Evidence

`proofs/Proofs/FrobeniusNumberOQ01.lean` imports `Proofs.FrobeniusNumberOQ02`, but `FrobeniusNumberOQ02` has no gallery entry of its own. Without an `additionalFiles` entry, this triggers the sibling-import blindspot pattern (auditor cannot see the dependency).

**Before**: `leanFile.additionalFiles` not set.
**After**: `leanFile.additionalFiles = ["Proofs/FrobeniusNumberOQ02.lean"]`.

Surgical 3-line diff; no other content touched.

The auditor also flagged a possible incorrect `frobenius-number-oq-02` problem statement and the option of promoting OQ02 to its own gallery entry — those are out of scope for this minimal repair and can be handled separately (see PR #16188 from the researcher).

Closes #16304

---
Automated fix by lean-mechanic agent.