### PR TITLE
audit(hilbert-10-oq-04): sync definitionCount 7→6

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 5,
     "lineCount": 250,
     "theoremCount": 10,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary
- meta.json claims `definitionCount: 7` but the Lean source has 6 `def` declarations.
- Definitions in `proofs/Proofs/Hilbert10OQ04.lean`: `DiophantineN`, `hasSolutionN`, `H10_n_decidable`, `H10_n_undecidable`, `LinearForm.eval`, `hasLinearSolution`.

## Test plan
- [x] meta sub-object `definitionCount` (7→6) matches grep on `^\s*(def|abbrev|opaque)\s` (6).
- [x] All other counts already match: 250 lines, 0 sorries, 5 axioms, 10 theorems.
- [x] No other meta fields touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)