### PR TITLE
fix(meta): greens-theorem-oq-01-oq-01 — sync lineCount 149→154

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01/meta.json
@@ -39,7 +39,7 @@
       "Application: eliminates hFubini hypothesis from Green's theorem (OQ-01)",
       "Sufficient condition: C¹ vector fields always satisfy Fubini for Green's theorem"
     ],
-    "lineCount": 149,
+    "lineCount": 154,
     "theoremCount": 4,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -100,7 +100,7 @@
       "id": "summary",
       "title": "Summary and C¹ Corollary",
       "startLine": 121,
-      "endLine": 149,
+      "endLine": 154,
       "summary": "greens_fubini_for_C1 wraps the Fubini exchange for C¹ vector fields in Green's theorem. Summary comment confirms all sorries resolved and the hFubini hypothesis is eliminated.",
       "mathContext": "For $C^1$ vector fields $(P,Q)$ on $[a,b] \\times [c,d]$: the integration order swap $\\int_c^d \\int_a^b \\frac{\\partial P}{\\partial y}\\,dx\\,dy = \\int_a^b \\int_c^d \\frac{\\partial P}{\\partial y}\\,dy\\,dx$ holds automatically."
     }
@@ -138,7 +138,7 @@
       "Topology"
     ],
     "namespace": "GreensTheoremOQ01OQ01",
-    "lineCount": 149,
+    "lineCount": 154,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `greens-theorem-oq-01-oq-01` from `149` to `154` after PR #16292 grew `proofs/Proofs/GreensTheoremOQ01OQ01.lean` by 5 lines (Mathlib API update for `Measure.prod_restrict`).

## Evidence

```
$ git show origin/main:proofs/Proofs/GreensTheoremOQ01OQ01.lean | wc -l
154
$ git show origin/main:src/data/proofs/greens-theorem-oq-01-oq-01/meta.json | grep -n '149'
42:    "lineCount": 149,
103:      "endLine": 149,
141:    "lineCount": 149,
```

**Before**: meta.lineCount=149, leanFile.lineCount=149, summary section endLine=149 (file is actually 154 lines)
**After**: all three updated to 154

The trailing "summary" section's `endLine` equals total `lineCount` by convention (last section runs to end of file), so it was updated alongside.

No other counts changed:
- theoremCount: 4 ✓ (verified)
- definitionCount: 0 ✓
- axiomCount: 0 ✓
- sorries: 0 ✓

---
Automated fix by lean-mechanic agent. Found via direct file/meta comparison after observing PR #16292 in `git log`; not from an open auditor issue (find-targets currently surfaces only `oq-01-oq-01-oq-01-oq-01`, which has duplicate fix PRs #16305/#16310 already in flight).