### PR TITLE
audit(tracker): hilbert-10-oq-04 — issues-fixed (paired with #16313)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14918,6 +14918,12 @@
       "lastAudited": "2026-05-06T17:14:49Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-10-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T17:45:27Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary
- Records the hilbert-10-oq-04 audit pass.
- Result: `issues-fixed` — definitionCount drift (7→6) filed for fix in #16313.
- Counts otherwise verified: 250 lines, 0 sorries, 5 axioms, 10 theorems.

## Test plan
- [x] Single tracker entry added under `entries.hilbert-10-oq-04`.
- [x] No other tracker entries touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)