### PR TITLE
research(cauchy-schwarz-oq-02-oq-02): Bessel's inequality in infinite dimensions

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ02OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzOQ02OQ02.lean
@@ -1,0 +1,161 @@
+/-
+  Bessel's Inequality in Infinite Dimensions
+  (cauchy-schwarz-oq-02-oq-02)
+
+  For any orthonormal system {vᵢ}ᵢ in a real inner product space F and any x ∈ F:
+    ∑' i, ⟨vᵢ, x⟩² ≤ ‖x‖²
+
+  Key results proved:
+  1. Finite Bessel: ∑ i ∈ s, ⟨vᵢ, x⟩² ≤ ‖x‖² for any finite index set s
+  2. Summability: the Bessel series ∑' i, ⟨vᵢ, x⟩² converges
+  3. Infinite Bessel: the tsum is bounded by ‖x‖²
+  4. Monotone partial sums: adding more terms only increases the sum
+  5. General RCLike: norm version works for any field
+  6. Parseval's identity: equality for complete orthonormal systems (Hilbert bases)
+
+  Proof strategy:
+  - Finite Bessel follows from ‖x - ∑ᵢ∈s ⟨vᵢ,x⟩ vᵢ‖² ≥ 0, which by Pythagoras
+    expands to ‖x‖² - ∑ᵢ∈s ⟨vᵢ,x⟩² ≥ 0.
+  - Summability: partial sums are non-decreasing (non-negative terms) and
+    bounded above by ‖x‖² (finite Bessel), so by monotone convergence the series converges.
+  - Parseval: from `HilbertBasis.tsum_inner_mul_inner`, ∑ᵢ ⟨x,bᵢ⟩⟨bᵢ,x⟩ = ⟨x,x⟩.
+    Real symmetry ⟨x,bᵢ⟩ = ⟨bᵢ,x⟩ converts the product to ⟨bᵢ,x⟩².
+    And ⟨x,x⟩_ℝ = ‖x‖².
+
+  All results delegate to Mathlib's inner product space library.
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.l2Space
+import Mathlib.Tactic
+
+-- Opens notation ⟪x, y⟫ for the real inner product @inner ℝ _ _ x y
+open scoped RealInnerProductSpace
+
+namespace BesselInequality
+
+-- ============================================================
+-- Real inner product space: we use ⟪x, y⟫ for the inner product.
+-- ============================================================
+
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+
+-- ============================================================
+-- Section 1: Finite Bessel Inequality
+-- ============================================================
+
+/-- **Bessel's inequality (finite)**: For a real orthonormal family v and any finite
+    index set s, the sum of squared Fourier coefficients is bounded by ‖x‖². -/
+theorem bessel_finite {ι : Type*} {v : ι → F} (hv : Orthonormal ℝ v)
+    (x : F) (s : Finset ι) :
+    ∑ i ∈ s, ⟪v i, x⟫ ^ 2 ≤ ‖x‖ ^ 2 := by
+  have h := hv.sum_inner_products_le x (s := s)
+  simp only [Real.norm_eq_abs, sq_abs] at h
+  exact h
+
+/-- Each Bessel term ⟨vᵢ, x⟩² is non-negative. -/
+theorem bessel_term_nonneg {ι : Type*} {v : ι → F} (x : F) (i : ι) :
+    0 ≤ ⟪v i, x⟫ ^ 2 := sq_nonneg _
+
+-- ============================================================
+-- Section 2: Summability and Convergence
+-- ============================================================
+
+/-- **Summability**: The Bessel series ∑' i, ⟨vᵢ, x⟩² converges for any
+    real orthonormal family v and x ∈ F. -/
+theorem bessel_summable {ι : Type*} {v : ι → F} (hv : Orthonormal ℝ v) (x : F) :
+    Summable (fun i => ⟪v i, x⟫ ^ 2) := by
+  have h : Summable (fun i => ‖⟪v i, x⟫‖ ^ 2) := hv.inner_products_summable x
+  simp only [Real.norm_eq_abs, sq_abs] at h
+  exact h
+
+/-- The Bessel series HasSum to its tsum — precise convergence. -/
+theorem bessel_hasSum {ι : Type*} {v : ι → F} (hv : Orthonormal ℝ v) (x : F) :
+    HasSum (fun i => ⟪v i, x⟫ ^ 2) (∑' i, ⟪v i, x⟫ ^ 2) :=
+  (bessel_summable hv x).hasSum
+
+/-- Partial sums of the Bessel series are monotone non-decreasing. -/
+theorem bessel_partial_sums_mono {ι : Type*} {v : ι → F} (x : F)
+    {s t : Finset ι} (hst : s ⊆ t) :
+    ∑ i ∈ s, ⟪v i, x⟫ ^ 2 ≤ ∑ i ∈ t, ⟪v i, x⟫ ^ 2 :=
+  Finset.sum_le_sum_of_subset_of_nonneg hst fun _ _ _ => sq_nonneg _
+
+-- ============================================================
+-- Section 3: Infinite Bessel Inequality (main theorem)
+-- ============================================================
+
+/-- **Bessel's inequality**: For any real orthonormal family {vᵢ} and x ∈ F,
+    ∑' i, ⟨vᵢ, x⟩² ≤ ‖x‖². -/
+theorem bessel_inequality {ι : Type*} {v : ι → F} (hv : Orthonormal ℝ v) (x : F) :
+    ∑' i, ⟪v i, x⟫ ^ 2 ≤ ‖x‖ ^ 2 := by
+  have h := hv.tsum_inner_products_le x
+  simp only [Real.norm_eq_abs, sq_abs] at h
+  exact h
+
+-- ============================================================
+-- Section 4: General RCLike Field (norm-squared form)
+-- ============================================================
+
+/-- **Bessel's inequality (general, finite)**: For an orthonormal family over any
+    RCLike field 𝕜, ∑ i ∈ s, ‖⟨vᵢ, x⟩_𝕜‖² ≤ ‖x‖². -/
+theorem bessel_general_finite {𝕜 : Type*} [RCLike 𝕜]
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    {ι : Type*} {v : ι → E} (hv : Orthonormal 𝕜 v) (x : E) (s : Finset ι) :
+    ∑ i ∈ s, ‖@inner 𝕜 E _ (v i) x‖ ^ 2 ≤ ‖x‖ ^ 2 :=
+  hv.sum_inner_products_le x
+
+/-- **Bessel's inequality (general, infinite)**: For an orthonormal family over any
+    RCLike field 𝕜, ∑' i, ‖⟨vᵢ, x⟩_𝕜‖² ≤ ‖x‖². -/
+theorem bessel_general {𝕜 : Type*} [RCLike 𝕜]
+    {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    {ι : Type*} {v : ι → E} (hv : Orthonormal 𝕜 v) (x : E) :
+    ∑' i, ‖@inner 𝕜 E _ (v i) x‖ ^ 2 ≤ ‖x‖ ^ 2 :=
+  hv.tsum_inner_products_le x
+
+-- ============================================================
+-- Section 5: Parseval's Identity
+-- ============================================================
+
+/-- **Parseval's identity (real)**: For a real Hilbert basis {bᵢ} and x ∈ F,
+    ∑' i, ⟨bᵢ, x⟩² = ‖x‖². -/
+theorem parseval_real {ι : Type*} [CompleteSpace F] (b : HilbertBasis ι ℝ F) (x : F) :
+    (∑' i, ⟪b i, x⟫ ^ 2) = ‖x‖ ^ 2 := by
+  have h := b.tsum_inner_mul_inner x x
+  -- ⟪x, b i⟫ = ⟪b i, x⟫ by real symmetry, so ⟪x, b i⟫ * ⟪b i, x⟫ = ⟪b i, x⟫^2
+  have key : ∀ i, (⟪x, b i⟫ : ℝ) * ⟪b i, x⟫ = ⟪b i, x⟫ ^ 2 := fun i => by
+    rw [real_inner_comm (b i) x]; ring
+  simp_rw [key, real_inner_self_eq_norm_sq] at h
+  exact h
+
+/-- Corollary: for a real Hilbert basis, Bessel inequality is an equality. -/
+theorem bessel_tight {ι : Type*} [CompleteSpace F] (b : HilbertBasis ι ℝ F) (x : F) :
+    (∑' i, ⟪b i, x⟫ ^ 2) = ‖x‖ ^ 2 :=
+  parseval_real b x
+
+end BesselInequality
+
+-- ============================================================
+-- Examples
+-- ============================================================
+
+section Examples
+
+open BesselInequality
+
+-- Example: The single-vector Bessel inequality is Cauchy-Schwarz.
+-- For any unit vector v ∈ F, we have ⟨v, x⟩² ≤ ‖x‖² for all x.
+example {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+    {v : F} (hv : ‖v‖ = 1) (x : F) : ⟪v, x⟫ ^ 2 ≤ ‖x‖ ^ 2 := by
+  have horth : Orthonormal ℝ (fun _ : Fin 1 => v) := by
+    refine ⟨fun i => by simp [hv], fun i j hij => ?_⟩
+    exact absurd (Subsingleton.elim i j) hij
+  have h := bessel_finite horth x Finset.univ
+  simp only [Finset.univ_unique, Finset.sum_singleton] at h
+  simpa using h
+
+end Examples
+
+#check @BesselInequality.bessel_inequality
+#check @BesselInequality.parseval_real
+#check @BesselInequality.bessel_general

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "cauchy-schwarz-oq-02-oq-02",
+  "title": "Bessel's Inequality in Infinite Dimensions",
+  "slug": "cauchy-schwarz-oq-02-oq-02",
+  "description": "For any orthonormal system {vᵢ} in a real inner product space F and any x ∈ F, the sum of squared Fourier coefficients is bounded by the squared norm: ∑' i, ⟨vᵢ, x⟩² ≤ ‖x‖². The Bessel series is summable, partial sums converge monotonically upward, and equality holds for complete orthonormal systems (Parseval's identity: ∑' i, ⟨bᵢ, x⟩² = ‖x‖²). 10 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ02.lean",
+    "tags": [
+      "inner-product-spaces",
+      "functional-analysis",
+      "hilbert-spaces",
+      "orthonormal",
+      "bessel",
+      "parseval",
+      "verified"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 161,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "assumptions": "None. All theorems proved from Mathlib's Orthonormal.sum_inner_products_le, Orthonormal.tsum_inner_products_le, and HilbertBasis.tsum_inner_mul_inner.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Orthonormal.sum_inner_products_le",
+        "description": "Finite Bessel inequality: ∑ i ∈ s, ‖⟪vᵢ, x⟫‖² ≤ ‖x‖²",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "Orthonormal.tsum_inner_products_le",
+        "description": "Infinite Bessel inequality: ∑' i, ‖⟪vᵢ, x⟫‖² ≤ ‖x‖²",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "Orthonormal.inner_products_summable",
+        "description": "Summability of the Bessel series",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "HilbertBasis.tsum_inner_mul_inner",
+        "description": "Parseval's identity: ∑' i, ⟪x, bᵢ⟫ · ⟪bᵢ, y⟫ = ⟪x, y⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.l2Space"
+      }
+    ],
+    "originalContributions": [
+      "Bessel's inequality for infinite orthonormal systems in real Hilbert spaces",
+      "Summability of the Bessel series with monotone convergence",
+      "Parseval's identity derived from HilbertBasis.tsum_inner_mul_inner via real symmetry",
+      "General RCLike version (norm-squared form) via @inner directly"
+    ],
+    "dateAdded": "2026-05-06",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Bessel's inequality was first stated by Friedrich Bessel in the context of Fourier series (1817). It generalizes to arbitrary inner product spaces: the squared projections of a vector onto an orthonormal system sum to at most the squared norm of the vector. The inequality is tight precisely when the system is complete (a Hilbert basis), in which case equality is Parseval's identity. Together these are fundamental to the theory of Hilbert spaces and Fourier analysis.",
+    "problemStatement": "For an orthonormal family $\\{v_i\\}_{i \\in \\iota}$ in a real inner product space $F$ and any $x \\in F$, prove:\n$$\\sum_{i}^{\\infty} \\langle v_i, x \\rangle^2 \\leq \\|x\\|^2$$\nwith equality (Parseval's identity) when $\\{v_i\\}$ is a Hilbert basis.",
+    "proofStrategy": "The finite case follows from the **Pythagorean residual formula**: the projection $p = \\sum_{i \\in s} \\langle v_i, x \\rangle v_i$ satisfies $\\|x - p\\|^2 = \\|x\\|^2 - \\sum_{i \\in s} \\langle v_i, x \\rangle^2 \\geq 0$. Summability of the infinite series follows because the partial sums are monotone (all terms non-negative) and bounded above by $\\|x\\|^2$. For Parseval, the Hilbert basis representation $x = \\sum_i \\langle b_i, x \\rangle b_i$ combined with continuity of the inner product gives $\\|x\\|^2 = \\langle x, x \\rangle = \\sum_i \\langle x, b_i \\rangle \\langle b_i, x \\rangle = \\sum_i \\langle b_i, x \\rangle^2$ (the last step using real symmetry).",
+    "keyInsights": [
+      "**Pythagoras drives the finite case**: The residual $\\|x - \\sum_{i \\in s} \\langle v_i, x \\rangle v_i\\|^2 \\geq 0$ is the key identity; non-negativity immediately gives Bessel.",
+      "**Monotone convergence gives summability**: Each new term adds a non-negative quantity, and the partial sums are bounded by $\\|x\\|^2$, so the series converges by the monotone convergence principle.",
+      "**Real symmetry converts Parseval to a norm identity**: $\\langle x, b_i \\rangle = \\langle b_i, x \\rangle$ for real inner products, turning the bilinear Parseval identity into the norm identity $\\sum_i \\langle b_i, x \\rangle^2 = \\|x\\|^2$.",
+      "**Bessel ≤ Parseval**: Bessel's inequality is the general form (any ONS), while Parseval's identity is the special case (complete ONS = Hilbert basis). The gap measures how much of $\\|x\\|^2$ is 'missed' by the orthonormal system."
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-finite",
+      "title": "Finite Bessel Inequality",
+      "startLine": 47,
+      "endLine": 65,
+      "summary": "`bessel_finite`: For any finite index set s and orthonormal family v, ∑ i ∈ s, ⟨vᵢ,x⟩² ≤ ‖x‖². Derived from Mathlib's `Orthonormal.sum_inner_products_le` via `Real.norm_eq_abs` + `sq_abs`.",
+      "mathContext": "∑ i ∈ s, ⟪v i, x⟫ ^ 2 ≤ ‖x‖ ^ 2, where ‖⟪v i, x⟫‖² = ⟪v i, x⟫² for real inner products."
+    },
+    {
+      "id": "section-summability",
+      "title": "Summability and Convergence",
+      "startLine": 66,
+      "endLine": 89,
+      "summary": "`bessel_summable`, `bessel_hasSum`, `bessel_partial_sums_mono`: The Bessel series converges (Summable/HasSum), and partial sums are monotone non-decreasing.",
+      "mathContext": "Summable (fun i => ⟨vᵢ, x⟩²); HasSum (fun i => ⟨vᵢ, x⟩²) (∑' i, ⟨vᵢ, x⟩²)"
+    },
+    {
+      "id": "section-infinite",
+      "title": "Infinite Bessel Inequality",
+      "startLine": 90,
+      "endLine": 100,
+      "summary": "`bessel_inequality`: The main theorem — ∑' i, ⟨vᵢ, x⟩² ≤ ‖x‖² for any real orthonormal system.",
+      "mathContext": "∑' i, ⟪v i, x⟫ ^ 2 ≤ ‖x‖ ^ 2"
+    },
+    {
+      "id": "section-general",
+      "title": "General RCLike Version",
+      "startLine": 101,
+      "endLine": 120,
+      "summary": "`bessel_general_finite`, `bessel_general`: For any RCLike field 𝕜, the norm-squared form ∑ ‖⟨vᵢ,x⟩‖² ≤ ‖x‖² holds.",
+      "mathContext": "∑' i, ‖inner 𝕜 (v i) x‖ ^ 2 ≤ ‖x‖ ^ 2"
+    },
+    {
+      "id": "section-parseval",
+      "title": "Parseval's Identity",
+      "startLine": 121,
+      "endLine": 137,
+      "summary": "`parseval_real`, `bessel_tight`: For a real Hilbert basis, Bessel is tight: ∑' i, ⟨bᵢ, x⟩² = ‖x‖².",
+      "mathContext": "(∑' i, ⟪b i, x⟫ ^ 2) = ‖x‖ ^ 2"
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "title": "Completeness Characterization",
+      "description": "Prove that an orthonormal system {vᵢ} is a Hilbert basis (complete) if and only if Bessel's inequality is an equality for all x: ∑' i, ⟨vᵢ, x⟩² = ‖x‖². This would give a concrete internal characterization of completeness.",
+      "difficulty": "moderate"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "ancestor",
+      "description": "Cauchy-Schwarz inequality — the single-term Bessel inequality |⟨v, x⟩| ≤ ‖v‖·‖x‖ is a special case"
+    },
+    {
+      "id": "cauchy-schwarz-oq-02",
+      "relationship": "parent",
+      "description": "Hölder and L² theory — this file extends the inner product space framework"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CauchySchwarzOQ02OQ02.lean",
+    "filename": "CauchySchwarzOQ02OQ02.lean",
+    "lineCount": 161,
+    "theoremCount": 10,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ02OQ02.lean"
+  }
+}


### PR DESCRIPTION
## Summary

- Proves Bessel's inequality ∑' i, ⟨vᵢ, x⟩² ≤ ‖x‖² for real orthonormal systems in infinite-dimensional Hilbert spaces
- Shows the Bessel series is summable with monotone convergence: partial sums increase to the bound
- Proves Parseval's identity (∑' i, ⟨bᵢ, x⟩² = ‖x‖²) for complete orthonormal systems (Hilbert bases)
- Includes general RCLike version (norm-squared form) for arbitrary fields
- 10 theorems, 0 sorries, 0 axioms, 161 lines

🤖 Generated with Claude Code