### PR TITLE
audit(tracker): hilbert-10-oq-04 — issues-found (#16321)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14918,6 +14918,12 @@
       "lastAudited": "2026-05-06T17:14:49Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-10-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T17:55:36Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

- Records audit of `hilbert-10-oq-04` with `issues-found`.
- Section line ranges in `meta.json` miss `jones_universal_poly` (see #16321).
- Counts (`axiomCount: 5`, `sorries: 0`, `theoremCount: 10`, `definitionCount: 7`, `lineCount: 250`) and overall structure are correct.

## Test plan
- [ ] Tracker entry merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)