### PR TITLE
fix(meta): hilbert-10-oq-04 — sync section line ranges (#16321)

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04/meta.json
@@ -85,14 +85,14 @@
       "id": "axioms",
       "title": "Axioms from Literature",
       "startLine": 144,
-      "endLine": 195,
+      "endLine": 200,
       "summary": "mrdp_finite_var, jones_matiyasevich_bound, nine_var_h10_undecidable, linear_bezout_n, jones_universal_poly.",
       "mathContext": "These axioms represent classical results: MRDP (1970), Jones-Matiyasevich 9-variable bound (1982), and the corresponding undecidability. linear_bezout_n is the general Bézout theorem for n-variable linear equations."
     },
     {
       "id": "consequences",
       "title": "Consequences and Summary",
-      "startLine": 197,
+      "startLine": 202,
       "endLine": 250,
       "summary": "ten_var_h10_undecidable (monotonicity), eleven_var_h10_undecidable, complexity_gap_summary, and open questions documentation.",
       "mathContext": "By H10_undecidable_monotone applied to nine_var_h10_undecidable, both 10- and 11-variable H10 are undecidable. The complexity_gap_summary assembles the main boundary result."


### PR DESCRIPTION
## Fix

Adjust `sections` line ranges in `src/data/proofs/hilbert-10-oq-04/meta.json` so the `axioms` section contains all 5 axioms (including `jones_universal_poly`, lines 196–200), and the `consequences` section starts at the "Part V" comment header.

## Evidence

In `proofs/Proofs/Hilbert10OQ04.lean`:
- `axiom jones_universal_poly` at line **196**, body extends through line **200**
- `-- Part V: Consequences` comment header at line **202**

Before:
- `sections[3]` (axioms): `startLine: 144, endLine: 195` — excluded `jones_universal_poly`
- `sections[4]` (consequences): `startLine: 197, endLine: 250` — started inside the axiom body

After:
- `sections[3].endLine`: 195 → 200
- `sections[4].startLine`: 197 → 202

Counts (`axiomCount: 5`, `sorries: 0`, `theoremCount: 10`) were already correct and unchanged. Metadata-only fix.

Closes #16321

---
Automated fix by lean-mechanic agent.