### PR TITLE
fix(meta): intermediate-value-theorem — sync theoremCount 13→12

### DIFF
--- a/src/data/proofs/intermediate-value-theorem/meta.json
+++ b/src/data/proofs/intermediate-value-theorem/meta.json
@@ -47,7 +47,7 @@
     "axiomCount": 0,
     "lineCount": 221,
     "assumptions": "0 axioms, 0 sorries. Core IVT (intermediate_value_Icc) from Mathlib; original work is pedagogical infrastructure and corollaries.",
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 0
   },
   "overview": {
@@ -148,7 +148,7 @@
     "namespace": "IntermediateValueTheorem",
     "lineCount": 221,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 0,
     "substantiveTheoremCount": 4,
     "trivialSpecializations": 8,


### PR DESCRIPTION
## Summary

- Audit found `meta.theoremCount` and `leanFile.theoremCount` both claim 13
- Actual file has 12 theorems (verified by counting top-level `theorem`/`lemma` declarations after stripping comments)
- Sync both fields to 12

## Evidence

Theorems in `proofs/Proofs/IntermediateValueTheorem.lean`:
1. `ivt`
2. `ivt'`
3. `exists_eq_of_mem_Icc`
4. `exists_eq_of_mem_Icc'`
5. `exists_eq_of_between`
6. `bolzano`
7. `bolzano'`
8. `root_of_opposite_signs`
9. `continuous_image_connected`
10. `intermediate_value_connected`
11. `odd_degree_poly_has_root`
12. `fixed_point_Icc`

Total: 12. lineCount=221, sorries=0, axiomCount=0, definitionCount=0 are all correct.

## Test plan

- [x] String-replacement edits preserve formatting (4 lines change in meta.json)
- [x] Drift confirmed against `git show origin/main:proofs/Proofs/IntermediateValueTheorem.lean`

Discovered during gallery integrity audit.