### PR TITLE
audit(tracker): intermediate-value-theorem — issues-fixed (#16327)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11936,10 +11936,10 @@
       "result": "clean"
     },
     "intermediate-value-theorem": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:24:52Z",
-      "result": "clean"
+      "lastAudited": "2026-05-06T18:23:10Z",
+      "result": "issues-fixed"
     },
     "intermediate-value-theorem-oq-01": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Tracker bump after fixing theoremCount drift in intermediate-value-theorem (PR #16327).

Drift was missed on prior audits (last clean on 2026-05-03) because the structural drift checker in `find-targets.ts` only flags sorry/axiom mismatches, not theoremCount mismatches.

## Test plan

- [x] auditCount 3 → 4
- [x] result clean → issues-fixed (linked to PR #16327)
- [x] lastAudited bumped to 2026-05-06