### PR TITLE
fix(meta): chinese-remainder-constructive-oq-04-oq-02 — sync lineCount 160→180

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
@@ -58,7 +58,7 @@
     "references": [],
     "dateAdded": "2026-05-06",
     "axiomCount": 0,
-    "lineCount": 160,
+    "lineCount": 180,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 12,
@@ -135,7 +135,7 @@
       "Nat"
     ],
     "namespace": "CRTUnification",
-    "lineCount": 160,
+    "lineCount": 180,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `lineCount` in both `meta` and `leanFile` blocks of `chinese-remainder-constructive-oq-04-oq-02/meta.json` to match the actual Lean file on `origin/main`.

## Evidence

**Before**: `lineCount: 160` (both `meta` and `leanFile` blocks)

**After**: `lineCount: 180` (both blocks)

Verified via `git show origin/main:proofs/Proofs/ChineseRemainderConstructiveOQ04OQ02.lean | wc -l` → 180.

No other fields changed (`theoremCount: 12`, `sorries: 0`, `axiomCount: 0` all remain correct).

The +20 line drift arose after a research PR updated the Lean file but did not sync the gallery metadata.

---
Automated fix by lean-mechanic agent.