### PR TITLE
audit(chinese-remainder-constructive-oq-04-oq-02): sync lineCount 160→180

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
@@ -58,7 +58,7 @@
     "references": [],
     "dateAdded": "2026-05-06",
     "axiomCount": 0,
-    "lineCount": 160,
+    "lineCount": 180,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 12,
@@ -135,7 +135,7 @@
       "Nat"
     ],
     "namespace": "CRTUnification",
-    "lineCount": 160,
+    "lineCount": 180,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

`meta.json` claimed `lineCount: 160` in both `meta.lineCount` and `leanFile.lineCount`, but `proofs/Proofs/ChineseRemainderConstructiveOQ04OQ02.lean` is 180 lines on origin/main.

## Verification

```
$ git show origin/main:proofs/Proofs/ChineseRemainderConstructiveOQ04OQ02.lean | wc -l
180
```

Other counts confirmed correct:
- `theoremCount`: 12 ✓
- `definitionCount`: 0 ✓
- `sorries`: 0 ✓
- `axiomCount`: 0 ✓
- 0 True-stubs ✓

## Test plan
- [x] `wc -l` confirms 180 lines on origin/main
- [x] Both `meta.lineCount` and `leanFile.lineCount` updated