### PR TITLE
fix(meta): cauchy-schwarz-oq-02-oq-02 — badge original→mathlib (#16333)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
@@ -16,7 +16,7 @@
       "parseval",
       "verified"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 161,
@@ -46,10 +46,7 @@
       }
     ],
     "originalContributions": [
-      "Bessel's inequality for infinite orthonormal systems in real Hilbert spaces",
-      "Summability of the Bessel series with monotone convergence",
-      "Parseval's identity derived from HilbertBasis.tsum_inner_mul_inner via real symmetry",
-      "General RCLike version (norm-squared form) via @inner directly"
+      "Parseval's identity derived from HilbertBasis.tsum_inner_mul_inner via real symmetry (⟪x,bᵢ⟫ = ⟪bᵢ,x⟫ converts the complex Parseval identity to the real norm-squared form)"
     ],
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Fix

Corrects the badge and trims overclaimed originalContributions for `cauchy-schwarz-oq-02-oq-02` (Bessel's Inequality in Infinite Dimensions).

## Evidence

**Before**:
- `meta.badge`: `"original"`
- `originalContributions`: 4 items including "Bessel's inequality for infinite orthonormal systems" and "Summability of the Bessel series" — both are thin wrappers around Mathlib's `Orthonormal.tsum_inner_products_le` and `Orthonormal.inner_products_summable`

**After**:
- `meta.badge`: `"mathlib"` — correctly reflects that the core results are one-line Mathlib calls
- `originalContributions`: 1 item — the only genuinely original work: converting the complex Parseval identity to real norm-squared form via real symmetry `⟪x,bᵢ⟫ = ⟪bᵢ,x⟫`

The `assumptions` field already honestly states: "All theorems proved from Mathlib's `Orthonormal.sum_inner_products_le`, `Orthonormal.tsum_inner_products_le`, and `HilbertBasis.tsum_inner_mul_inner`." This fix makes `badge` consistent with that admission.

`status: "verified"`, `sorries: 0`, `axiomCount: 0` remain unchanged.

Closes #16333

---
Automated fix by lean-mechanic agent.