### PR TITLE
audit(tracker): cauchy-schwarz-oq-02-oq-02 issues-found (#16333)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14924,6 +14924,12 @@
       "lastAudited": "2026-05-06T17:55:36Z",
       "result": "issues-found",
       "issues": []
+    },
+    "cauchy-schwarz-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T18:57:39Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Marks cauchy-schwarz-oq-02-oq-02 as audited (1×, issues-found) in `src/data/proofs/audit-tracker.json`.

The integrity finding is already filed as #16333: badge `original` should be `mathlib` since every main theorem (`bessel_inequality`, `bessel_general`, `parseval_real`, `bessel_summable`, etc.) is a thin wrapper that calls a Mathlib lemma (`Orthonormal.tsum_inner_products_le`, `HilbertBasis.tsum_inner_mul_inner`, `Orthonormal.inner_products_summable`) and rewrites norms to squares.

This PR only updates the tracker so `find-targets` stops surfacing the entry; the meta.json fix belongs to whoever takes #16333.

## Test plan

- [x] `git show origin/main:proofs/Proofs/CauchySchwarzOQ02OQ02.lean` confirms 0 sorries / 0 axioms / 10 theorems / 161 lines (counts match meta.json).
- [x] Verified #16333 is OPEN with the same finding.
- [x] Tracker patch is a single 6-line addition under `entries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)