### PR TITLE
fix(meta): newton-inductive-step-oq-02 — remove phantom axiom, axiomCount 1→0

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-02/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-02/meta.json
@@ -42,10 +42,8 @@
       "Quadratic-nonneg reduction: both k=1 and k=n cases via linear_combination ring identity"
     ],
     "proofStrategy": "Induction on list length. Two boundary cases: k=1 (quadratic in new element x with discriminant from 2·C(n,2)=n·(n-1)) and k=n (quadratic via 2·C(n+1,n-1)=n·(n+1)). Interior cases: esymm_cross_condition plus newton_cleared_denom_inductive_step from AmgmInequalityOQ02OQ02.",
-    "axiomCount": 1,
-    "assumptions": [
-      "newton_cleared_denom_inductive_step: degree-6 polynomial nonnegativity in 9 variables (interior inductive step)"
-    ]
+    "axiomCount": 0,
+    "assumptions": []
   },
   "leanFile": {
     "imports": [
@@ -55,7 +53,7 @@
     "opens": ["List", "Nat"],
     "namespace": "NewtonInductiveStepOQ02",
     "lineCount": 584,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/NewtonInductiveStepOQ02.lean",


### PR DESCRIPTION
## Fix

Remove phantom `newton_cleared_denom_inductive_step` axiom from `meta.json`. This identifier is a **fully-proved theorem** in `AmgmInequalityOQ02OQ02.lean:395`, not an axiom.

## Evidence

**Before**: `meta.axiomCount: 1`, `leanFile.axiomCount: 1`, `assumptions: ["newton_cleared_denom_inductive_step: ..."]`

**After**: `meta.axiomCount: 0`, `leanFile.axiomCount: 0`, `assumptions: []`

Zero `axiom` declarations in `NewtonInductiveStepOQ02.lean` or `AmgmInequalityOQ02OQ02.lean`. The file header states "Main results (0 axioms, 0 sorries)". `status: verified` and `badge: original` unchanged.

Note: `lineCount`/`theoremCount` drift handled by in-flight PR #16329.

Closes #16338

---
Automated fix by lean-mechanic agent.