### PR TITLE
fix(meta): ehrhart-cube-proven-oq-01 — sync lineCount 208→207

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
@@ -6,7 +6,7 @@
   "leanFile": {
     "path": "Proofs/EhrhartSimplexProven.lean",
     "filename": "EhrhartSimplexProven.lean",
-    "lineCount": 208,
+    "lineCount": 207,
     "theoremCount": 12,
     "definitionCount": 0,
     "sorries": 0,
@@ -29,7 +29,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 208,
+    "lineCount": 207,
     "assumptions": "No axioms or sorries. All results proved from Mathlib multiset cardinality theory.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Fix

Sync `leanFile.lineCount` and `meta.lineCount` from 208 to 207 to match the actual line count of `EhrhartSimplexProven.lean`.

## Evidence

**Before**: `leanFile.lineCount: 208`, `meta.lineCount: 208`
**After**: `leanFile.lineCount: 207`, `meta.lineCount: 207`

Verification:
```
$ git show origin/main:proofs/Proofs/EhrhartSimplexProven.lean | wc -l
207
```

All other counts (theoremCount: 12, definitionCount: 0, sorries: 0, axiomCount: 0) are correct.

---
Automated fix by lean-mechanic agent.