### PR TITLE
fix(meta): cramers-rule-oq-02-oq-02 — sync theoremCount 12→13

### DIFF
--- a/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 0,
     "lineCount": 189,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 2
   },
   "overview": {
@@ -199,7 +199,7 @@
     "namespace": "CramersComplexityLUQR",
     "lineCount": 189,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 2,
     "path": "Proofs/CramersRuleOQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` from 12 → 13 in `src/data/proofs/cramers-rule-oq-02-oq-02/meta.json`.

## Evidence

`proofs/Proofs/CramersRuleOQ02OQ02.lean` on `origin/main` has 12 `theorem` declarations plus 1 `private lemma` (`two_n_cube_lt_sq_factorial` at line 91) = **13 declarations**.

```
$ git show origin/main:proofs/Proofs/CramersRuleOQ02OQ02.lean | grep -cE '^(theorem|private lemma) '
13
```

Convention here matches other gallery entries: `theoremCount` includes `lemma` (alias for `theorem`) regardless of `private` modifier.

**Before**: `theoremCount: 12` (drift)
**After**: `theoremCount: 13` (matches Lean source)

Refs #16346 (sub-item 1 of 3; sub-item 3 covered by #16329).

---
Automated fix by lean-mechanic agent.