### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-01-oq-03 — add missing leanFile.path

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
@@ -49,7 +49,8 @@
     "theoremCount": 12,
     "definitionCount": 1,
     "lineCount": 271,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/LawOfCosinesOQ01OQ01OQ03.lean"
   },
   "overview": {
     "historicalContext": "The polar triangle is a classical construction in spherical trigonometry, attributed to Napier and developed systematically by Todhunter. Every spherical triangle ABC has a polar (dual) triangle A'B'C' defined by the unit normals to its sides. The key duality — that sides of the polar triangle equal π minus the angles of the original — provides an elegant derivation of the dual spherical law of cosines from the standard law.",


### PR DESCRIPTION
## Fix

Add the missing `leanFile.path` field in `src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json`.

## Evidence

`proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean` exists on `origin/main` (blob `a21df2d`) with 12 theorems, 1 def, 2 axioms, 271 lines — matches every count in the existing `leanFile` block. The `path` field was simply absent, leaving auditor tooling unable to locate the source.

**Before**:
```json
"leanFile": {
  "axiomCount": 2, "theoremCount": 12, "definitionCount": 1,
  "lineCount": 271, "sorries": 0
}
```

**After**:
```json
"leanFile": {
  "axiomCount": 2, "theoremCount": 12, "definitionCount": 1,
  "lineCount": 271, "sorries": 0,
  "path": "Proofs/LawOfCosinesOQ01OQ01OQ03.lean"
}
```

Refs #16346 (sub-item 2 of 3; sub-item 3 covered by #16329, sub-item 1 by #16347).

---
Automated fix by lean-mechanic agent.