### PR TITLE
fix(meta): newton-inductive-step-oq-02 — sync lineCount/theoremCount + add meta sub-object fields

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-02/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-02/meta.json
@@ -43,7 +43,10 @@
     ],
     "proofStrategy": "Induction on list length. Two boundary cases: k=1 (quadratic in new element x with discriminant from 2·C(n,2)=n·(n-1)) and k=n (quadratic via 2·C(n+1,n-1)=n·(n+1)). Interior cases: esymm_cross_condition plus newton_cleared_denom_inductive_step from AmgmInequalityOQ02OQ02.",
     "axiomCount": 0,
-    "assumptions": []
+    "assumptions": [],
+    "lineCount": 611,
+    "theoremCount": 6,
+    "definitionCount": 0
   },
   "leanFile": {
     "imports": [
@@ -52,9 +55,9 @@
     ],
     "opens": ["List", "Nat"],
     "namespace": "NewtonInductiveStepOQ02",
-    "lineCount": 584,
+    "lineCount": 611,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/NewtonInductiveStepOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Closes #16346 (item 3). Supersedes PR #16329 for the leanFile fixes, and adds the missing meta sub-object fields.

## Evidence

**Before**: lf.lineCount=584, lf.theoremCount=5; meta.lineCount/theoremCount/definitionCount absent
**After**: lf.lineCount=611, lf.theoremCount=6; meta.lineCount=611, meta.theoremCount=6, meta.definitionCount=0

The 6 theorems: binom_log_concave, binom_ultra_log_concave, esymm_zero_tail, esymm_log_concave, newton_inequality_binomial + private esymm_cross_condition.

Note: Items 1 and 2 from issue #16346 (cramers-rule theoremCount, law-of-cosines path) are already correct on origin/main.

---
Automated fix by lean-mechanic agent.