### PR TITLE
fix(meta): remove duplicate JSON keys in 3 meta files

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
@@ -143,8 +143,7 @@
       "startLine": 44,
       "endLine": 51,
       "summary": "abelian_isSolvable: CommGroup G → IsSolvable G via inferInstance. One line. Covers all 17 prime-order cyclic groups below 60 and the trivial group of order 1.",
-      "mathContext": "`abelian_isSolvable (G : Type*) [CommGroup G] [Fintype G] : IsSolvable G := inferInstance`. In Lean, `CommGroup G` implies `IsSolvable G` via the typeclass `isSolvable_of_comm`: the derived series $G \\supseteq [G,G] = 1$ terminates at length 1 (since abelian groups have trivial commutator subgroup). Covers: order 1 (trivial, $|G| = 1$), and all 17 prime orders $\\{2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59\\}$ below 60 (cyclic groups $\\mathbb{Z}/p\\mathbb{Z}$ are abelian). Combined with `pGroup_isSolvable`, this handles $26$ of the $59$ orders below $60$.",
-      "mathContext": "For abelian $G$: the commutator subgroup $[G,G] = 1$, so the derived series $G \\supseteq 1$ has length 1, confirming solvability. Mathlib's `isSolvable_of_comm` provides the typeclass instance."
+      "mathContext": "`abelian_isSolvable (G : Type*) [CommGroup G] [Fintype G] : IsSolvable G := inferInstance`. In Lean, `CommGroup G` implies `IsSolvable G` via the typeclass `isSolvable_of_comm`: the derived series $G \\supseteq [G,G] = 1$ terminates at length 1 (since abelian groups have trivial commutator subgroup). Covers: order 1 (trivial, $|G| = 1$), and all 17 prime orders $\\{2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59\\}$ below 60 (cyclic groups $\\mathbb{Z}/p\\mathbb{Z}$ are abelian). Combined with `pGroup_isSolvable`, this handles $26$ of the $59$ orders below $60$."
     },
     {
       "id": "sec-classification",

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
@@ -133,7 +133,6 @@
   ],
   "leanFile": {
     "namespace": "ChebyshevPNTBridgeOQ01OQ02",
-    "lineCount": 65,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -21,7 +21,6 @@
     "erdosUrl": "https://erdosproblems.com/852",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "theoremCount": 20,
     "lineCount": 247,
     "assumptions": "3 axioms: brun_sieve_divergence (Brun's sieve result), erdos852_lower_bound (OPEN conjecture), erdos852_upper_bound (OPEN conjecture). The function h(x) = maxDistinctRun and its properties (witness, optimality, bound) are now fully defined and proved.",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Summary
Three meta.json files have duplicate keys. JSON parsers use last-wins semantics, so the dead duplicates are silently dropped — but in one case (`abel-ruffini-oq-04-oq-02-oq-03`) the dropped duplicate was the *better* content, masking real value.

- `erdos-852`: drop dead `theoremCount: 20` in meta block (kept 25, matches actual count of 25)
- `chebyshev-pnt-bridge-oq-01-oq-02`: drop dead `lineCount: 65` in leanFile (kept 79, matches actual)
- `abel-ruffini-oq-04-oq-02-oq-03`: drop the shorter duplicate `mathContext` in `sec-abelian-solvable`. The richer mathContext (with `pGroup_isSolvable` coverage detail and the prime orders list) was being silently overwritten by a shorter recap.

## Discovery
Found during gallery integrity audit of `chebyshev-pnt-bridge-oq-01-oq-02`. A scan with Python's `object_pairs_hook` over all 2,382 meta.json files surfaced exactly 3 with duplicate keys — fixed all three in one PR.

## Verification
All three files re-parse with no duplicate keys. The string replacements preserve original formatting (per `feedback_mechanic_plumbing_json_format.md`).

## Test plan
- [x] All three files parse cleanly with no duplicate keys
- [ ] Site build still succeeds (no schema regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)