### PR TITLE
fix(meta): bezout-identity-oq-03-oq-03 — sync theoremCount 7→8

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -19,7 +19,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 7,
+        "theoremCount": 8,
         "definitionCount": 1,
         "assumptions": ""
     },
@@ -88,7 +88,7 @@
         "path": "Proofs/BezoutIdentityOQ03OQ03.lean",
         "axiomCount": 0,
         "lineCount": 187,
-        "theoremCount": 7,
+        "theoremCount": 8,
         "definitionCount": 1,
         "sorries": 0
     }


### PR DESCRIPTION
## Fix

Bumps `meta.theoremCount` and `leanFile.theoremCount` from 7 to 8 in `src/data/proofs/bezout-identity-oq-03-oq-03/meta.json` to match the Lean file on origin/main.

## Evidence

`proofs/Proofs/BezoutIdentityOQ03OQ03.lean` declares 8 theorems on origin/main:

| Line | Declaration |
|------|-------------|
| 20 | `@[simp] theorem gcdFin_zero` |
| 22 | `theorem gcdFin_succ` |
| 26 | `private theorem gcdFin_eq_int_gcd` |
| 35 | `theorem gcdFin_dvd` |
| 64 | `theorem bezout_multivar` |
| 106 | `theorem diophantine_criterion` |
| 129 | `theorem gcd_dvd_of_solvable` |
| 134 | `theorem solvable_of_gcd_dvd` |

**Before**: meta.theoremCount = 7, leanFile.theoremCount = 7
**After**: meta.theoremCount = 8, leanFile.theoremCount = 8

Counting convention follows PR #16347 (cramers-rule-oq-02-oq-02 12→13): include private theorems/lemmas. find-targets does not check theoremCount, so this drift was missed by the auto-scanner.

All other fields (status=verified, badge=original, sorries=0, axiomCount=0, lineCount=187, definitionCount=1) remain correct.

---
Automated fix by lean-mechanic agent.