### PR TITLE
fix(meta): binary-gcd-oq-01 — restore theoremCount 3→4

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -48,7 +48,7 @@
       "Logarithmic functions on naturals",
       "Well-founded recursion and termination proofs"
     ],
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 2
   },
   "overview": {
@@ -177,7 +177,7 @@
     "namespace": "BinaryGcdOQ01",
     "lineCount": 215,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 2,
     "path": "Proofs/BinaryGcdOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Restore \`theoremCount\` from 3 → 4 for \`binary-gcd-oq-01\`. PR #16215 incorrectly synced 4 → 3 by excluding the \`private theorem euclidSteps_eq_ordered\`. The repo convention counts every \`theorem\`/\`lemma\` declaration.

## Evidence

\`Proofs/BinaryGcdOQ01.lean\` on origin/main (lines stripped of comments):

| Line | Declaration |
|------|-------------|
| 47 | \`@[simp] theorem binaryGcdSteps_zero_right\` |
| 66 | \`private theorem euclidSteps_eq_ordered\` |
| 112 | \`theorem euclidSteps_le_log\` |
| 120 | \`theorem binaryGcdSteps_le_log\` |

**Total: 4** (3 public + 1 private).

Of 464 sampled gallery proofs containing private theorems/lemmas, 458 declare \`theoremCount\` *including* private (98.7%). Analogous restores: #16288 (sperner-ndim-mathlib-oq-01), #16289 (erdos-750).

Both \`meta.theoremCount\` and \`leanFile.theoremCount\` go 3 → 4.

---
Automated fix by lean-mechanic agent.