### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-02 — restore theoremCount 17→18

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 959,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -72,7 +72,7 @@
     "namespace": "NewtonLogConcavity",
     "lineCount": 959,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Restore \`theoremCount\` from 17 → 18 for \`amgm-inequality-oq-02-oq-02\`. PR #16211 incorrectly synced 18 → 17 by excluding private \`lemma\` declarations. The repo convention counts every \`theorem\`/\`lemma\` declaration.

## Evidence

\`Proofs/AmgmInequalityOQ02OQ02.lean\` on origin/main (lines stripped of comments):

- **15 public** theorem/lemma declarations:
  - \`elemSymm_zero_implies_higher_zero\` (L13)
  - \`@[simp] lemma normESym_zero\` (L48), \`normESym_nonneg\` (L51), \`normESym_eq_zero_iff\` (L55), \`normESym_zero_implies_higher_zero\` (L64)
  - \`cross_product_of_log_concave\` (L74), \`elemSymm_log_concave\` (L110)
  - \`binom_log_concave\` (L241), \`newton_cleared_denom_inductive_step\` (L292)
  - \`newton_cleared_denom\` (L419), \`newton_log_concavity_proved\` (L707)
  - \`normESym_log_concave\` (L733), \`power_ineq_of_log_concave\` (L739)
  - \`rpow_ineq_of_pow_ineq\` (L789), \`maclaurin_step_derived\` (L810)
- **3 private** lemma declarations:
  - \`elemSymm_zero_castSucc\` (L105)
  - \`choose_mul_succ\` (L223)
  - \`choose_mul_pred\` (L231)

**Total: 18** (15 public + 3 private).

Of 464 sampled gallery proofs containing private theorems/lemmas, 458 declare \`theoremCount\` *including* private (98.7%). The pre-#16211 value (18) and the convention-restoring PRs #15893 / #16288 / #16289 all corroborate.

Both \`meta.theoremCount\` and \`leanFile.theoremCount\` go 17 → 18.

---
Automated fix by lean-mechanic agent.