### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-01-oq-01): eliminate last sorry via swap(0,k) 3-step chain (0 sorries)

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean
@@ -68,22 +68,19 @@ private lemma integrable_3d_zx_y {f : ℝ → ℝ → ℝ → ℝ}
   -- G((z,x),y) = f(x,y,z) is continuous: hf ∘ (q ↦ (q.1.2, q.2, q.1.1))
   -- where q.1.2=x, q.2=y, q.1.1=z for q=((z,x),y)
   have hG : Continuous (fun q : (ℝ × ℝ) × ℝ => f q.1.2 q.2 q.1.1) :=
-    hf.comp (continuous_fst.snd.prod_mk (continuous_snd.prod_mk continuous_fst.fst))
+    hf.comp (show Continuous (fun q : (ℝ × ℝ) × ℝ => (q.1.2, q.2, q.1.1)) from by fun_prop)
   have hcpt : IsCompact ((Icc e f' ×ˢ Icc a b) ×ˢ Icc c d) :=
     (isCompact_Icc.prod isCompact_Icc).prod isCompact_Icc
   have hint : IntegrableOn (fun q : (ℝ × ℝ) × ℝ => f q.1.2 q.2 q.1.1)
               ((Icc e f' ×ˢ Icc a b) ×ˢ Icc c d) volume :=
     hG.continuousOn.integrableOn_compact hcpt
-  -- Two restrict_prod_eq_prod_restrict rewrites convert IntegrableOn to Integrable on Icc product
-  rw [Measure.restrict_prod_eq_prod_restrict
-        (measurableSet_Icc.prod measurableSet_Icc) measurableSet_Icc,
-      Measure.restrict_prod_eq_prod_restrict measurableSet_Icc measurableSet_Icc] at hint
-  -- Transfer from Icc to Ioc product measure (Ioc ⊆ Icc ⟹ vol.restrict Ioc ≤ vol.restrict Icc)
-  exact hint.mono_measure (Measure.prod_mono
-    (Measure.prod_mono
-      (Measure.restrict_mono Ioc_subset_Icc_self le_rfl)
-      (Measure.restrict_mono Ioc_subset_Icc_self le_rfl))
-    (Measure.restrict_mono Ioc_subset_Icc_self le_rfl))
+  -- Transfer to Ioc subset, then convert measure via prod_restrict (twice)
+  have hint2 : IntegrableOn (fun q : (ℝ × ℝ) × ℝ => f q.1.2 q.2 q.1.1)
+               ((Ioc e f' ×ˢ Ioc a b) ×ˢ Ioc c d) volume :=
+    hint.mono_set (Set.prod_mono (Set.prod_mono Ioc_subset_Icc_self Ioc_subset_Icc_self)
+                    Ioc_subset_Icc_self)
+  rw [Measure.prod_restrict, Measure.prod_restrict]
+  exact hint2
 
 /-- For continuous f, G((x,y),z) = f(x,y,z) is integrable on the Ioc-product measure.
     Used for the (y,x,z) ↔ (x,y,z) swap. -/
@@ -95,20 +92,18 @@ private lemma integrable_3d_xy_z {f : ℝ → ℝ → ℝ → ℝ}
        (volume.restrict (Ioc e f'))) := by
   -- G((x,y),z) = f(x,y,z) is continuous: hf ∘ (q ↦ (q.1.1, q.1.2, q.2))
   have hG : Continuous (fun q : (ℝ × ℝ) × ℝ => f q.1.1 q.1.2 q.2) :=
-    hf.comp (continuous_fst.fst.prod_mk (continuous_fst.snd.prod_mk continuous_snd))
+    hf.comp (show Continuous (fun q : (ℝ × ℝ) × ℝ => (q.1.1, q.1.2, q.2)) from by fun_prop)
   have hcpt : IsCompact ((Icc a b ×ˢ Icc c d) ×ˢ Icc e f') :=
     (isCompact_Icc.prod isCompact_Icc).prod isCompact_Icc
   have hint : IntegrableOn (fun q : (ℝ × ℝ) × ℝ => f q.1.1 q.1.2 q.2)
               ((Icc a b ×ˢ Icc c d) ×ˢ Icc e f') volume :=
     hG.continuousOn.integrableOn_compact hcpt
-  rw [Measure.restrict_prod_eq_prod_restrict
-        (measurableSet_Icc.prod measurableSet_Icc) measurableSet_Icc,
-      Measure.restrict_prod_eq_prod_restrict measurableSet_Icc measurableSet_Icc] at hint
-  exact hint.mono_measure (Measure.prod_mono
-    (Measure.prod_mono
-      (Measure.restrict_mono Ioc_subset_Icc_self le_rfl)
-      (Measure.restrict_mono Ioc_subset_Icc_self le_rfl))
-    (Measure.restrict_mono Ioc_subset_Icc_self le_rfl))
+  have hint2 : IntegrableOn (fun q : (ℝ × ℝ) × ℝ => f q.1.1 q.1.2 q.2)
+               ((Ioc a b ×ˢ Ioc c d) ×ˢ Ioc e f') volume :=
+    hint.mono_set (Set.prod_mono (Set.prod_mono Ioc_subset_Icc_self Ioc_subset_Icc_self)
+                    Ioc_subset_Icc_self)
+  rw [Measure.prod_restrict, Measure.prod_restrict]
+  exact hint2
 
 -- ═══════════════════════════════════════════════════
 -- Section 2: The Triple Fubini Theorem
@@ -139,25 +134,20 @@ theorem triple_fubini_of_continuous {f : ℝ → ℝ → ℝ → ℝ}
     apply intervalIntegral.integral_congr
     intro z _
     exact GreensTheoremOQ01OQ01.fubini_of_continuous a b c d hab hcd
-      (hf.comp (continuous_fst.prod_mk (continuous_snd.prod_mk continuous_const)))
+      (hf.comp (show Continuous (fun q : ℝ × ℝ => (q.1, q.2, z)) from by fun_prop))
   -- Step 2: Swap outer (z,x) via integral_integral_swap on Ioc set integrals.
   have step2 : ∫ z in e..f', ∫ x in a..b, ∫ y in c..d, f x y z =
                ∫ x in a..b, ∫ z in e..f', ∫ y in c..d, f x y z := by
     simp_rw [integral_of_le hab, integral_of_le hef, integral_of_le hcd]
-    -- After simp_rw: ∫z∂ρ, ∫x∂μ, ∫y∂ν, f x y z = ∫x∂μ, ∫z∂ρ, ∫y∂ν, f x y z
-    -- (ρ = vol.restrict Ioc e f', μ = vol.restrict Ioc a b, ν = vol.restrict Ioc c d)
     apply MeasureTheory.integral_integral_swap
-    -- The integrand for integral_integral_swap is (z,x) ↦ ∫y∂ν, f x y z.
-    -- integral_prod_right applied to integrable_3d_zx_y gives exactly this integrability.
-    exact (integrable_3d_zx_y hf a b c d e f').integral_prod_right
+    exact (integrable_3d_zx_y hf a b c d e f').integral_prod_left
   -- Step 3: For each fixed x, swap (y,z) using 2D Fubini.
-  -- The function (y,z) ↦ f(x,y,z) is continuous: hf composed with fixing x in position 1.
   have step3 : ∫ x in a..b, ∫ z in e..f', ∫ y in c..d, f x y z =
                ∫ x in a..b, ∫ y in c..d, ∫ z in e..f', f x y z := by
     apply intervalIntegral.integral_congr
     intro x _
     exact GreensTheoremOQ01OQ01.fubini_of_continuous c d e f' hcd hef
-      (hf.comp (continuous_const.prod_mk continuous_id))
+      (hf.comp (show Continuous (fun q : ℝ × ℝ => (x, q.1, q.2)) from by fun_prop))
   rw [step1, step2, step3]
 
 /-- The (y,x,z) ordering equals (x,y,z): swap the outer (y,x) pair.
@@ -176,7 +166,7 @@ theorem triple_fubini_yxz_eq_xyz {f : ℝ → ℝ → ℝ → ℝ}
   apply MeasureTheory.integral_integral_swap
   -- Need: Integrable (fun p => ∫z∂μ_e, f p.1 p.2 z) (μ_a.prod μ_c)
   -- Get this from integrable_3d_xy_z + integral_prod_right
-  exact (integrable_3d_xy_z hf a b c d e f').integral_prod_right
+  exact (integrable_3d_xy_z hf a b c d e f').integral_prod_left
 
 -- ═══════════════════════════════════════════════════
 -- Section 3: All Key Orderings Are Equal
@@ -196,7 +186,7 @@ theorem triple_fubini_all_equal {f : ℝ → ℝ → ℝ → ℝ}
          apply intervalIntegral.integral_congr
          intro z _; symm
          exact GreensTheoremOQ01OQ01.fubini_of_continuous a b c d hab hcd
-           (hf.comp (continuous_fst.prod_mk (continuous_snd.prod_mk continuous_const)))
+           (hf.comp (show Continuous (fun q : ℝ × ℝ => (q.1, q.2, z)) from by fun_prop))
      _ = ∫ x in a..b, ∫ y in c..d, ∫ z in e..f', f x y z :=
          triple_fubini_of_continuous hab hcd hef hf,
    triple_fubini_yxz_eq_xyz hab hcd hef hf⟩
@@ -238,7 +228,8 @@ lemma iteratedIntervalIntegral_two {a b : Fin 2 → ℝ} {f : (Fin 2 → ℝ) �
     iteratedIntervalIntegral a b f =
     ∫ x in (a 0)..(b 0), ∫ y in (a 1)..(b 1),
       f (Fin.cons x (Fin.cons y Fin.elim0)) := by
-  simp only [iteratedIntervalIntegral_succ, iteratedIntervalIntegral_zero]
+  simp only [iteratedIntervalIntegral_succ, iteratedIntervalIntegral_zero, Fin.tail,
+             show (Fin.succ (0 : Fin 1) : Fin 2) = 1 from rfl]
 
 /-- **N-Dimensional Order Independence** (axiomatized for n ≥ 4).
 

--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
@@ -21,9 +21,7 @@
   - B3 (iter_integral_swap_any): swap(x,y) by combining B1+B2
   - Main: induction on n, using swap_induction_on
 
-  ## Sorries: 2
-  1. continuous_param (succ step): compact bound for continuousAt_of_dominated_interval
-  2. iter_integral_swap_zero (k ≥ 2): decomposition of swap(0,k) into products of swaps
+  ## Sorries: 0 (all resolved)
 -/
 
 import Mathlib
@@ -316,17 +314,64 @@ private lemma iter_integral_swap_zero {n : ℕ}
       · rfl
       · simp [Equiv.swap_comm]
     | succ m' =>
-      -- k = m'+2 ≥ 2
-      -- Let k₀ = ⟨m'+1, ...⟩ (predecessor of k)
-      -- Decomposition: swap(0, k) = swap(k₀, k) * swap(0, k₀) * swap(k₀, k)
-      -- from swap_mul_swap_mul_swap with x=0, y=k₀, z=k:
-      --   swap(k₀, k) * swap(0, k₀) * swap(k₀, k) = swap(k, 0) = swap(0, k)
-      -- So we chain 3 applications:
-      -- 1. Apply ihm (swap(0, k₀)) for a, b, f
-      -- 2. Apply perm_tail for swap(k₀, k) [which fixes 0] to the result of step 1
-      -- 3. Apply ihm (swap(0, k₀)) again to the result of step 2
-      -- Currently sorry; the algebraic verification is non-trivial
-      sorry
+      -- k = ⟨m'+2, hm⟩, k₀ = ⟨m'+1, hm0⟩
+      have hm0 : m' + 1 < n + 1 := Nat.lt_of_succ_lt hm
+      let k₀ : Fin (n + 1) := ⟨m' + 1, hm0⟩
+      let k  : Fin (n + 1) := ⟨m' + 2, hm⟩
+      -- Distinctness
+      have hk₀_ne_0 : k₀ ≠ (0 : Fin (n + 1)) := by simp [k₀, Fin.ext_iff]
+      have hk_ne_0  : k  ≠ (0 : Fin (n + 1)) := by simp [k, Fin.ext_iff]
+      have hk₀_ne_k : k₀ ≠ k := by simp [k₀, k, Fin.ext_iff]
+      -- Pointwise identity: swap(0,k₀)(swap(k₀,k)(swap(0,k₀) i)) = swap(0,k) i
+      -- This is the function form of swap(k₀,k)*swap(0,k₀)*swap(k₀,k) = swap(0,k)
+      have hcomp : ∀ i : Fin (n + 1),
+          Equiv.swap 0 k₀ (Equiv.swap k₀ k (Equiv.swap 0 k₀ i)) = Equiv.swap 0 k i := by
+        intro i
+        simp only [Equiv.swap_apply_def, k₀, k, Fin.mk.injEq]
+        split_ifs <;> simp_all [Fin.ext_iff] <;> omega
+      -- Step 1: apply IH for k₀
+      have step1 := ihm hm0 hab hf
+      -- Step 2: apply perm_tail for swap(k₀,k) (fixes 0)
+      have hfixes0 : Equiv.swap k₀ k (0 : Fin (n+1)) = 0 :=
+        Equiv.swap_apply_of_ne (Ne.symm hk₀_ne_0) (Ne.symm hk_ne_0)
+      have hab₁ : ∀ i, (a ∘ Equiv.swap 0 k₀) i ≤ (b ∘ Equiv.swap 0 k₀) i :=
+        fun i => hab _
+      have hf₁ : Continuous (fun v : Fin (n+1) → ℝ =>
+            f (fun i => v ((Equiv.swap 0 k₀).symm i))) :=
+        hf.comp (continuous_pi_iff.mpr fun i => continuous_apply _)
+      have step2 :=
+        iteratedIntervalIntegral_perm_tail hab₁ hf₁ (Equiv.swap k₀ k) hfixes0 ih_perm
+      -- Step 3: apply IH for k₀ again on the new bounds
+      have hab₂ : ∀ i, (a ∘ Equiv.swap 0 k₀ ∘ Equiv.swap k₀ k) i ≤
+                       (b ∘ Equiv.swap 0 k₀ ∘ Equiv.swap k₀ k) i :=
+        fun i => hab _
+      have hf₂ : Continuous (fun v : Fin (n+1) → ℝ =>
+            f (fun i => v ((Equiv.swap k₀ k).symm ((Equiv.swap 0 k₀).symm i)))) :=
+        hf.comp (continuous_pi_iff.mpr fun i => continuous_apply _)
+      have step3 := ihm hm0 hab₂ hf₂
+      -- Chain the three steps into one equality
+      have chain : iteratedIntervalIntegral a b f =
+          iteratedIntervalIntegral
+            (a ∘ Equiv.swap 0 k₀ ∘ Equiv.swap k₀ k ∘ Equiv.swap 0 k₀)
+            (b ∘ Equiv.swap 0 k₀ ∘ Equiv.swap k₀ k ∘ Equiv.swap 0 k₀)
+            (fun v => f (fun i => v ((Equiv.swap 0 k₀).symm
+                ((Equiv.swap k₀ k).symm ((Equiv.swap 0 k₀).symm i))))) :=
+        step1.trans (step2.trans step3)
+      -- Rewrite using hcomp: the composition equals swap(0,k)
+      have ha_eq : a ∘ Equiv.swap 0 k₀ ∘ Equiv.swap k₀ k ∘ Equiv.swap 0 k₀ =
+                   a ∘ Equiv.swap 0 k :=
+        funext fun i => congr_arg a (hcomp i)
+      have hb_eq : b ∘ Equiv.swap 0 k₀ ∘ Equiv.swap k₀ k ∘ Equiv.swap 0 k₀ =
+                   b ∘ Equiv.swap 0 k :=
+        funext fun i => congr_arg b (hcomp i)
+      have hf_eq : (fun v : Fin (n+1) → ℝ =>
+              f (fun i => v ((Equiv.swap 0 k₀).symm
+                  ((Equiv.swap k₀ k).symm ((Equiv.swap 0 k₀).symm i))))) =
+            fun v => f (fun i => v ((Equiv.swap 0 k).symm i)) := by
+        ext v; congr 1; ext i
+        simp only [Equiv.swap_symm]
+        exact hcomp i
+      rw [chain, ha_eq, hb_eq, hf_eq]
 
 -- ═══════════════════════════════════════════════════
 -- Section 6: Integral Identity for any swap
@@ -348,13 +393,13 @@ private lemma iter_integral_swap_any {n : ℕ}
     iteratedIntervalIntegral a b f =
     iteratedIntervalIntegral (a ∘ Equiv.swap x y) (b ∘ Equiv.swap x y)
       (fun v => f (fun i => v ((Equiv.swap x y).symm i))) := by
-  rcases Fin.eq_or_ne x y with rfl | hxy
+  rcases eq_or_ne x y with rfl | hxy
   · simp [Equiv.swap_self, Function.comp]
   · -- Case: x ≠ y
-    rcases Fin.eq_or_ne x 0 with rfl | hx0
+    rcases eq_or_ne x 0 with rfl | hx0
     · -- x = 0: use iter_integral_swap_zero
       exact iter_integral_swap_zero ih y.val y.isLt hab hf
-    · rcases Fin.eq_or_ne y 0 with rfl | hy0
+    · rcases eq_or_ne y 0 with rfl | hy0
       · -- y = 0: swap(x, 0) = swap(0, x) by swap_comm
         rw [Equiv.swap_comm x 0]
         exact iter_integral_swap_zero ih x.val x.isLt hab hf
@@ -390,15 +435,15 @@ theorem iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → �
         ∀ τ : Equiv.Perm (Fin n),
         iteratedIntervalIntegral a' b' g =
         iteratedIntervalIntegral (a' ∘ τ) (b' ∘ τ) (fun x => g (fun i => x (τ.symm i))) :=
-      fun a' b' g hg hab' τ => ih a' b' hab' hg τ
+      fun a' b' g hg hab' τ => ih hab' hg τ
     -- Prove by swap induction on σ
     -- P(σ) = ∀ a b hab f hf, integral a b f = integral (a∘σ) (b∘σ) (f∘σ.symm)
     -- We prove the SPECIFIC instance with our a, b, f by using induction on σ
     -- via swap_induction_on (reduces to P(1) and P(swap(x,y) * τ) from P(τ))
     induction σ using Equiv.Perm.swap_induction_on with
-    | h1 =>
+    | one =>
       simp [Function.comp]
-    | hmul_swap τ x y hxy hPτ =>
+    | swap_mul τ x y hxy hPτ =>
       -- hPτ : integral a b f = integral (a∘τ) (b∘τ) (fun v => f(v∘τ.symm))
       -- Goal: integral a b f = integral (a∘(swap*τ)) (b∘(swap*τ)) (fun v => f(v∘(swap*τ).symm))
       have hab_τ : ∀ i, (a ∘ τ) i ≤ (b ∘ τ) i := fun i => hab _


### PR DESCRIPTION
## Summary

- Proves `iter_integral_swap_zero` for k≥2 using a 3-step chain decomposition, eliminating the last sorry in `GreensTheoremOQ01OQ01OQ01OQ01.lean`
- Fixes Mathlib 4.26 API drift in parent file `GreensTheoremOQ01OQ01OQ01.lean`

## Proof of iter_integral_swap_zero (k≥2 case)

The key insight: swap(0,k) = swap(0,k₀) ∘ swap(k₀,k) ∘ swap(0,k₀) where k₀ = ⟨k.val-1, ...⟩.

The 3-step chain:
1. Apply IH (for smaller k₀) to get bounds/function transformed by swap(0,k₀)
2. Apply perm_tail for swap(k₀,k) (which fixes 0, since k₀,k ≠ 0)
3. Apply IH again for swap(0,k₀)

The composition identity swap(0,k₀) ∘ swap(k₀,k) ∘ swap(0,k₀) = swap(0,k) is proved
by pointwise case analysis via split_ifs + omega on Fin values.

## Parent file API drift fixes

The parent file GreensTheoremOQ01OQ01OQ01.lean (merged in #16097) uses Mathlib APIs
that changed since merging:

- Measure.restrict_prod_eq_prod_restrict removed: replaced with Measure.prod_restrict
- Continuous.prod_mk dot notation: replaced with show Continuous (...) from by fun_prop
- Integrable.integral_prod_right: replaced with integral_prod_left (correct direction)
- swap_induction_on case names: h1/hmul_swap replaced with one/swap_mul
- Fin.tail simp: added show (Fin.succ (0:Fin 1):Fin 2) = 1 from rfl hint

## Test plan

- [x] grep shows 0 sorries in GreensTheoremOQ01OQ01OQ01OQ01.lean
- [ ] Docker build: ./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ01OQ01

🤖 Generated with [Claude Code](https://claude.com/claude-code)