### PR TITLE
fix(meta): add missing leanFile.path in 7 proofs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -51,6 +51,7 @@
     "definitionCount": 4
   },
   "leanFile": {
+    "path": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean",
     "axiomCount": 1,
     "theoremCount": 6,
     "definitionCount": 4,

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -50,6 +50,7 @@
     "definitionCount": 0
   },
   "leanFile": {
+    "path": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean",
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
@@ -121,6 +121,7 @@
     }
   ],
   "leanFile": {
+    "path": "Proofs/BirchSwinnertonDyerOQ06OQ02.lean",
     "sorries": 0,
     "axiomCount": 2,
     "theoremCount": 26,

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
@@ -132,6 +132,7 @@
   ],
   "sorries": 0,
   "leanFile": {
+    "path": "Proofs/BoundedPrimeGapsOQ01OQ02.lean",
     "axiomCount": 0,
     "theoremCount": 25,
     "lineCount": 219,

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
@@ -171,6 +171,7 @@
     }
   ],
   "leanFile": {
+    "path": "Proofs/FundamentalTheoremAlgebraOQ04OQ04.lean",
     "filePath": "Proofs/FundamentalTheoremAlgebraOQ04OQ04.lean",
     "imports": [
       "Mathlib",

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
@@ -67,6 +67,7 @@
     ]
   },
   "leanFile": {
+    "path": "Proofs/LebesgueMeasureOQ01OQ03.lean",
     "namespace": "LebesgueMeasureOQ01OQ03",
     "lineCount": 244,
     "axiomCount": 0,

--- a/src/data/proofs/ramsey-r4k-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-01/meta.json
@@ -150,6 +150,7 @@
   ],
   "sorries": 0,
   "leanFile": {
+    "path": "Proofs/RamseyR4kOQ01.lean",
     "axiomCount": 3,
     "theoremCount": 17,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

7 gallery proofs had a populated `leanFile` block but were missing the `path` field, which is required for the gallery to link to the Lean source.

## Evidence

**Before**: `"leanFile": { "axiomCount": ..., ... }` (no path)
**After**: `"leanFile": { "path": "Proofs/Foo.lean", "axiomCount": ..., ... }`

All 7 paths sourced from the existing `meta.proofRepoPath` field; all other leanFile fields (lineCount, sorries, theoremCount, etc.) verified correct against the actual files.

**Affected proofs:**
- `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01`
- `angle-trisection-oq-02-oq-01-oq-01-oq-01`
- `birch-swinnerton-dyer-oq-06-oq-02`
- `bounded-prime-gaps-oq-01-oq-02`
- `fundamental-theorem-algebra-oq-04-oq-04`
- `lebesgue-measure-oq-01-oq-03`
- `ramsey-r4k-oq-01`

---
Automated fix by lean-mechanic agent.