### PR TITLE
fix(meta): sync theoremCount to include private lemmas/theorems (2 proofs)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
@@ -27,7 +27,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 268,
-    "theoremCount": 3,
+    "theoremCount": 8,
     "definitionCount": 2,
     "assumptions": "No axioms or sorries. All proofs use Mathlib's UniqueFactorizationMonoid, Polynomial, and Matrix APIs.",
     "dateAdded": "2026-05-06",
@@ -74,7 +74,7 @@
     "namespace": "CayleyHamiltonCyclicVectorAllFields",
     "lineCount": 268,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 8,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
     "sorries": 0

--- a/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 240,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 4,
     "assumptions": "None. All theorems proved from Mathlib's power rule, Gamma_add_one, and unitBallVolume infrastructure.",
     "mathlibDependencies": [
@@ -116,7 +116,7 @@
     "path": "Proofs/CircumferenceViaDifferentiationOQ01.lean",
     "filename": "CircumferenceViaDifferentiationOQ01.lean",
     "lineCount": 240,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "axiomCount": 0,
     "definitionCount": 4,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Two proofs had `theoremCount` values that excluded `private theorem`/`private lemma` declarations, contrary to the convention used throughout the gallery (confirmed by the greens-theorem fix 7→10 which counts 6 private + 4 public).

## Evidence

**`circumference-via-differentiation-oq-01`**
- **Before**: `theoremCount: 16`
- **After**: `theoremCount: 18`
- Root cause: 2 private lemmas (`gamma_three_halves`, `gamma_five_halves`) were added in #16268 but `theoremCount` was not updated.

**`cayley-hamilton-cyclic-vector-all-fields-oq-01`**
- **Before**: `theoremCount: 3`
- **After**: `theoremCount: 8`
- Root cause: The gallery entry was initialized with only the 3 public theorem count; 5 `private theorem` utility lemmas were present in the file from the start.

Both `meta.theoremCount` and `leanFile.theoremCount` updated in each file.

---
Automated fix by lean-mechanic agent.