### PR TITLE
fix(meta): borsuk-ulam-oq-03 — sync theoremCount 222→220

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -71,7 +71,7 @@
     "mathlib_version": "4.26.0",
     "axioms": 4,
     "lineCount": 5139,
-    "theoremCount": 222,
+    "theoremCount": 220,
     "definitionCount": 35
   },
   "overview": {
@@ -203,7 +203,7 @@
     "namespace": "BorsukUlamOQ03",
     "lineCount": 5139,
     "axiomCount": 1,
-    "theoremCount": 222,
+    "theoremCount": 220,
     "definitionCount": 35,
     "path": "Proofs/BorsukUlamOQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`leanFile.theoremCount` and `meta.theoremCount` both said 222, but the actual count is 220.

## Evidence

**Before**: `theoremCount: 222`
**After**: `theoremCount: 220`

Root cause: The batch fix (#16012) overcounted by 2 — it included 2 occurrences of `theorem`/`lemma` inside block-comment docstrings (lines 294, 924) as declarations. These are documentation text like `"Via Tucker's lemma (combinatorial)"` and `"odd function zero theorem"`, not Lean declarations.

Verified with multiple counting methods (proper nested block-comment stripping, direct grep pattern matching) — all consistently return 220.

---
Automated fix by lean-mechanic agent.