### PR TITLE
fix(meta): ehrhart-cube-proven-oq-02 — add missing top-level sorries: 2

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -151,5 +151,6 @@
       "title": "Ehrhart Polynomials for Lattice Polytopes",
       "relationship": "General theory (axiomatized). This file provides an axiom-free proof for the cross-polytope."
     }
-  ]
+  ],
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

The new gallery entry `ehrhart-cube-proven-oq-02` (added in #16339) was created without the top-level `sorries` field. The gallery UI uses this field for the badge display.

## Evidence

**Before**: no `sorries` key at top level
**After**: `"sorries": 2`

The value 2 matches `leanFile.sorries: 2` and `meta.sorries: 2`. The Lean file (`EhrhartCrossPolytope.lean`) has 2 actual sorry tactics at lines 255 and 283 (the `crossEhrhart_is_poly` and `crossBall_card` theorems).

---
Automated fix by lean-mechanic agent.