### PR TITLE
fix(meta): amgm-inequality-oq-02 — sync theoremCount 25→26

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -99,7 +99,7 @@
     "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 3
   },
   "crossReferences": [
@@ -303,7 +303,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "substantiveTheoremCount": 17,
     "privateHelperCount": 6,
     "axiomDeclCount": 2,


### PR DESCRIPTION
## Fix

Sync `theoremCount` 25 → 26 in both `meta` and `leanFile` blocks for `amgm-inequality-oq-02`.

## Evidence

`proofs/Proofs/AmgmInequalityOQ02.lean` declares 26 theorems/lemmas:
- 16 public `theorem` declarations
- 1 private `theorem` (`sq_sum_eq_sum_sq_add_two_elemSymm`)
- 9 private `lemma` declarations, including `@[simp] private lemma csEmb_apply` (the `@[simp]` attribute caused undercount in prior sync)

**Before**: `meta.theoremCount: 25`, `leanFile.theoremCount: 25`
**After**:  `meta.theoremCount: 26`, `leanFile.theoremCount: 26`

All other counts on origin/main verified correct: lineCount 543, axiomCount 2, definitionCount 3, sorries 0.

---
Automated fix by lean-mechanic agent.