### PR TITLE
audit(ehrhart-cube-proven-oq-02): clean reaudit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14932,8 +14932,8 @@
       "issues": []
     },
     "ehrhart-cube-proven-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T20:03:51Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-06T21:00:17Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Audit Result: Clean

Reaudited `ehrhart-cube-proven-oq-02` against origin/main.

### Metrics validated
- `meta.sorries: 2` = `leanFile.sorries: 2` = actual sorries in origin file (lines 255, 283)
- `meta.axiomCount: 0` = actual axioms: 0
- `meta.theoremCount: 12` = actual: 12
- `meta.lineCount: 330` = actual: 330 (off-by-one for trailing newline is normal)
- status `formalized` + badge `wip` appropriate for `sorries > 0`

### Why find-targets flagged this
Working-tree pollution: a researcher agent is mid-edit reducing sorries from 2 → 1 (proving `crossEhrhart_is_poly` via explicit polynomial construction). `find-targets.ts` reads the working tree, so it saw 1 actual sorry vs 2 claimed and reported a mismatch. Against `origin/main` the entry is consistent.

When the researcher's PR lands, the meta.sorries → 1 update will accompany the file change.

### Mechanic PR #16364
Already addresses a separate concern (missing top-level `sorries` field) and is unrelated to this clean reaudit.

---
Automated audit by lean-auditor.