### PR TITLE
fix(meta): erdos-105-oq-05 — sync definitionCount 12→13

### DIFF
--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 206,
     "assumptions": "2 axioms inherited from Erdos105Problem.lean: xichuan_counterexample (Xichuan's counterexample), beck_szemeredi_trotter_positive (positive result via Szemerédi-Trotter). 0 own axioms. 0 sorries. The previous transitive `axiom thresholdFunction` was replaced with a real `noncomputable def` in the parent Erdos105Problem.lean.",
     "theoremCount": 4,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "Erdős Problem #105 asks about rich lines avoiding obstacle points in R². A line through at least 2 points of a configuration A is 'rich'; a set B of obstacle points 'blocks' all rich lines if every rich line contains at least one obstacle. The conjecture that n−4 obstacles suffice was disproved by Xichuan (2024), showing that the threshold function f(n) (minimum obstacles needed to block all rich lines) satisfies cn ≤ f(n) ≤ n−4, but its exact asymptotics remain unknown.\n\nThe Szemerédi-Trotter theorem (1983) bounds the number of incidences between n points and m lines in R² to O(n^{2/3}m^{2/3} + n + m), implying that any point configuration has many 'ordinary' lines (through exactly 2 points). This structural result is the backdrop for #105: obstacles need to cover enough of the rich-line structure. The natural higher-dimensional question — do rich k-flats in R^d exhibit similar blocking behavior? — requires understanding how incidence bounds change when lines and planes replace each other.",
@@ -188,7 +188,7 @@
     "lineCount": 206,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 12,
+    "definitionCount": 13,
     "path": "Proofs/Erdos105OQ05.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` 12 → 13 in both `meta` and `leanFile` blocks for `erdos-105-oq-05`.

## Evidence

`proofs/Proofs/Erdos105OQ05.lean` declares 13 definitions (`def + abbrev + opaque`):
- `abbrev PointD` (line 37)
- `def LineD.contains` (46), `def LineD.isRich` (50), `def LineD.unblocked` (54), `def LineD.richAndUnblocked` (58)
- `def NonDegenerateD` (65), `def NonCollinearD` (70)
- `def higherDimLineConjecture` (96)
- `def TwoFlat.contains` (127), `def TwoFlat.isRich` (131), `def TwoFlat.unblocked` (139)
- `def richTwoFlatConjecture` (149)
- `def counterexample_lifts` (184)

**Before**: `meta.definitionCount: 12`, `leanFile.definitionCount: 12`
**After**:  `meta.definitionCount: 13`, `leanFile.definitionCount: 13`

All other counts on origin/main verified correct: lineCount 206, theoremCount 4, lf.axiomCount 0 (2 inherited at meta level), sorries 0.

---
Automated fix by lean-mechanic agent.