### PR TITLE
audit(erdos-1027-oq-03): clean reaudit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3175,9 +3175,9 @@
       "result": "clean"
     },
     "erdos-1027-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-06T21:04:34Z",
       "result": "clean"
     },
     "erdos-1028": {


### PR DESCRIPTION
## Audit Result: Clean

Reaudited `erdos-1027-oq-03` (Constructive Good Sets via Moser-Tardos) against origin/main.

### Metrics validated
- `meta.sorries: 0` = `leanFile.sorries: 0` = actual: **0**
- `meta.axiomCount: 0` = actual: **0**
- `meta.theoremCount: 17` = actual: **17**
- `meta.definitionCount: 5` = actual: **5**
- No True stubs
- status `verified` + badge `original` appropriate

### Cross-reference check
Imports sibling `Proofs.LovaszLocalLemma` which is itself axiom-free / sorry-free. The `assumptions` field correctly states: "All 17 theorems proved from Mathlib and the existing LLL infrastructure." Tier A "original" badge is appropriate since the dependency is on our own peer formalization, not a major Mathlib theorem doing the core work.

---
Automated audit by lean-auditor.