### PR TITLE
audit(bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03): clean reaudit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -854,9 +854,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:48Z",
+      "lastAudited": "2026-05-06T21:07:08Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02": {


### PR DESCRIPTION
## Summary
Clean reaudit of ℤ[√-2] Euclidean Domain proof. All meta.json counts match the Lean source.

## Verification
- lineCount: 323 ✓
- theoremCount: 20 ✓
- definitionCount: 2 (1 def + 1 abbrev) ✓
- sorries: 0 ✓
- axiomCount: 0 ✓
- True stubs: 0 ✓

Badge "original" / status "verified" defensible: builds EuclideanDomain instance from first principles (3/4 norm bound) and proves inert prime classification via mod-8 obstruction. Uses Mathlib infrastructure (Zsqrtd, EuclideanDomain typeclass) but core results are independently proved.

## Test plan
- [x] Counts cross-checked
- [x] No True-stubs / Mathlib wrapper claims
- [x] Tracker bumped (auditCount 1→2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)