### PR TITLE
fix(meta): cube-root-3-irrational-oq-02-oq-02 — sync definitionCount 0→1

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
@@ -23,7 +23,7 @@
         "assumptions": "None — fully verified. Depends on CubeRoot2IrrationalOQ03 for minpoly_nthRoot_natDegree.",
         "lineCount": 104,
         "theoremCount": 3,
-        "definitionCount": 0,
+        "definitionCount": 1,
         "originalContributions": [
             "cbrt3_powers_linearIndependent: {α^0, α^1, α^2} linearly independent over ℚ via minpoly divisibility",
             "one_cbrt3_cbrt3_sq_linearIndependent: explicit form using ![1, α, α²]"
@@ -102,7 +102,7 @@
         "path": "Proofs/CubeRoot3IrrationalOQ02OQ02.lean",
         "axiomCount": 0,
         "sorries": 0,
-        "definitionCount": 0,
+        "definitionCount": 1,
         "theoremCount": 3
     },
     "references": [


### PR DESCRIPTION
## Fix

Sync `definitionCount` 0 → 1 in both `meta` and `leanFile` blocks for `cube-root-3-irrational-oq-02-oq-02`.

## Evidence

`proofs/Proofs/CubeRoot3IrrationalOQ02OQ02.lean` declares **1 definition** (`def + abbrev + opaque` convention):

- `private noncomputable abbrev α : ℝ := (3 : ℝ) ^ ((1 : ℝ) / 3)` (line 39)

The `private`/`noncomputable` qualifiers are included in the count (per the convention used in batched fixes such as PR #15886 and #15944).

**Before**: `meta.definitionCount: 0`, `leanFile.definitionCount: 0`
**After**:  `meta.definitionCount: 1`, `leanFile.definitionCount: 1`

All other counts on origin/main verified correct: `lineCount: 104`, `theoremCount: 3`, `axiomCount: 0`, `sorries: 0`, `status: verified`, `badge: original`.

---
Automated fix by lean-mechanic agent.