### PR TITLE
fix(meta): angle-trisection-oq-02-oq-03-ext — sync definitionCount 2→1

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-ext/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-ext/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 2
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Gauss announced in 1796 (at age 18) that the regular 17-gon is constructible with compass and straightedge, proving it in his 1801 Disquisitiones Arithmeticae. He identified the criterion: the n-gon is constructible iff n = 2^a × (distinct Fermat primes), where Fermat primes are primes of the form 2^{2^j}+1. Pierre Wantzel (1837) proved the converse (necessity), completing the characterization now called the Gauss-Wantzel theorem. The algebraic proof proceeds through three equivalences: (1) n-gon constructible iff [ℚ(cos 2π/n):ℚ] is a power of 2 (constructibility criterion); (2) [ℚ(cos 2π/n):ℚ] = φ(n)/2 (real subfield degree); (3) φ(n)/2 = 2^k iff φ(n) = 2^{k+1} (arithmetic step — proved here using Nat.totient_even). The arithmetic bridge in step (3) requires that φ(n) is always even for n ≥ 3, since -1 ∈ (ℤ/nℤ)* has order 2. Only 5 Fermat primes are known (3, 5, 17, 257, 65537); whether infinitely many exist remains open.",
@@ -110,7 +110,7 @@
     "lineCount": 297,
     "axiomCount": 0,
     "theoremCount": 55,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ02OQ03Ext.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` 2 → 1 in both `meta` and `leanFile` blocks for `angle-trisection-oq-02-oq-03-ext`.

## Evidence

`proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean` declares **1 definition** (`def + abbrev + opaque` convention):

- `def TotientIsPow2 (n : ℕ) : Prop := ∃ k : ℕ, Nat.totient n = 2 ^ k` (line 84)

No other `def`/`abbrev`/`opaque` declarations (verified by `grep -nE "^\s*(?:private\s+|protected\s+|noncomputable\s+)*(def|abbrev|opaque)\s+\w" proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean`).

**Before**: `meta.definitionCount: 2`, `leanFile.definitionCount: 2`
**After**:  `meta.definitionCount: 1`, `leanFile.definitionCount: 1`

All other counts on origin/main verified correct: `lineCount: 297`, `theoremCount: 55`, `axiomCount: 0`, `sorries: 0`, `status: verified`, `badge: original`.

---
Automated fix by lean-mechanic agent.