### PR TITLE
fix(meta): cantor-diagonalization-oq-02-oq-03-oq-02 — sync theoremCount 6→5

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
     "lineCount": 380,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 5,
     "originalContributions": [
       "IsClub: club sets (closed unbounded subsets of ordinals below \u03ba.ord)",
@@ -66,7 +66,7 @@
     "namespace": "FodorLemma",
     "lineCount": 380,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 5,
     "mainTheorem": "fodors_pressing_down",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `theoremCount` 6 → 5 in both `meta` and `leanFile` blocks for `cantor-diagonalization-oq-02-oq-03-oq-02`.

## Evidence

`proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean` declares **5 theorems** (no `private`/`protected` lemmas, no `lemma` keyword used):

- `not_isStationary_iff`
- `diagInter_isClosedBelow`
- `diagInter_isUnbounded`
- `diagInter_isClub`
- `fodors_pressing_down`

**Before**: `meta.theoremCount: 6`, `leanFile.theoremCount: 6`
**After**:  `meta.theoremCount: 5`, `leanFile.theoremCount: 5`

All other counts on origin/main verified correct: `lineCount: 380`, `definitionCount: 5`, `axiomCount: 0`, `sorries: 0`, `status: verified`, `badge: original`.

---
Automated fix by lean-mechanic agent.