### PR TITLE
fix(meta): erdos-1069 — sync theoremCount 3→2

### DIFF
--- a/src/data/proofs/erdos-1069/meta.json
+++ b/src/data/proofs/erdos-1069/meta.json
@@ -58,7 +58,7 @@
     "axiomCount": 2,
     "lineCount": 179,
     "assumptions": "2 axioms: szemeredi_trotter, kRich_bound. Structure fields are object definitions, not assumptions.",
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 13
   },
   "overview": {
@@ -251,7 +251,7 @@
     "namespace": "Erdos1069",
     "lineCount": 179,
     "axiomCount": 2,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 13,
     "path": "Proofs/Erdos1069Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `theoremCount` 3 → 2 in both `meta` and `leanFile` blocks for `erdos-1069`.

## Evidence

`proofs/Proofs/Erdos1069Problem.lean` declares **2 theorems**:

- `erdos_1069` (line 126)
- `erdos_1069_summary` (line 171)

No `lemma` keyword is used; no private/protected theorems.

**Before**: `meta.theoremCount: 3`, `leanFile.theoremCount: 3`
**After**:  `meta.theoremCount: 2`, `leanFile.theoremCount: 2`

All other counts on origin/main verified correct: `lineCount: 179`, `definitionCount: 13` (1 abbrev `Point` + 12 `def` including namespaced `Point.onLine`), `axiomCount: 2`, `sorries: 0`, `status: axiomatized`, `badge: axiom`.

---
Automated fix by lean-mechanic agent.