### PR TITLE
fix(meta): erdos-210 — sync theoremCount 4→3

### DIFF
--- a/src/data/proofs/erdos-210/meta.json
+++ b/src/data/proofs/erdos-210/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 9,
     "lineCount": 196,
     "assumptions": "9 axioms: OrdinaryLineCount, f, sylvester_gallai, motzkin_theorem, kelly_moser, csima_sawyer, green_tao_even, green_tao_odd, LiesOnCubic. 0 sorries.",
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 8
   },
   "overview": {
@@ -183,7 +183,7 @@
     "namespace": "Erdos210",
     "lineCount": 196,
     "axiomCount": 9,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Erdos210Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `theoremCount` 4 → 3 in both `meta` and `leanFile` blocks for `erdos-210`.

## Evidence

`proofs/Proofs/Erdos210Problem.lean` declares **3 theorems**:

- `f_tends_to_infinity` (line 113)
- `erdos_210` (line 181)
- `erdos_210_summary` (line 189)

No `lemma` keyword is used; no private/protected theorems.

**Before**: `meta.theoremCount: 4`, `leanFile.theoremCount: 4`
**After**:  `meta.theoremCount: 3`, `leanFile.theoremCount: 3`

All other counts on origin/main verified correct: `lineCount: 196`, `definitionCount: 8`, `axiomCount: 9`, `sorries: 0`, `status: axiomatized`, `badge: axiom`.

---
Automated fix by lean-mechanic agent.