### PR TITLE
fix(meta): sync theoremCount for 4 proofs — batch-fix regression and convention

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01/meta.json
@@ -55,7 +55,7 @@
         "note": "Pedagogical scaffold using Provable := fun _ => False; this file makes the proofs non-vacuous"
       }
     ],
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 6
   },
   "overview": {
@@ -172,6 +172,6 @@
     "sorries": 0,
     "path": "Proofs/GodelFirstIncompletenessOQ01.lean",
     "definitionCount": 6,
-    "theoremCount": 7
+    "theoremCount": 5
   }
 }

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
@@ -52,7 +52,7 @@
       "Axiomatized general n-dim order independence for arbitrary permutations"
     ],
     "lineCount": 275,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -71,7 +71,7 @@
     "namespace": "GreensTheoremOQ01OQ01OQ01",
     "lineCount": 275,
     "axiomCount": 1,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/GreensTheoremOQ01OQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -57,7 +57,7 @@
     "dateAdded": "2026-04-04",
     "lineCount": 507,
     "assumptions": "1 axiom (greens_theorem_l1curl — Whitney's 1957 theorem). 19 theorems with 0 sorries. Supporting results are fully proved using Mathlib's LipschitzWith, MeasureTheory, and trigonometric libraries.",
-    "theoremCount": 22,
+    "theoremCount": 19,
     "definitionCount": 4
   },
   "overview": {
@@ -217,7 +217,7 @@
     "namespace": "GreensTheoremOQ02",
     "lineCount": 507,
     "axiomCount": 1,
-    "theoremCount": 22,
+    "theoremCount": 19,
     "definitionCount": 4,
     "path": "Proofs/GreensTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -48,7 +48,7 @@
     "axiomCount": 1,
     "lineCount": 1230,
     "assumptions": "One deliberate axiom: `silence : True` (TLP 7) — a trivially true but axiomatic declaration that enacts Wittgenstein's silence as a formal gesture. All theorems are fully proved with 0 sorries. Uses classical logic (Classical.em) throughout. The companion file TractatusQuantifiers.lean has no sorries or axioms.",
-    "theoremCount": 47,
+    "theoremCount": 41,
     "definitionCount": 26
   },
   "overview": {
@@ -266,7 +266,7 @@
     "namespace": "Tractatus",
     "lineCount": 1230,
     "axiomCount": 1,
-    "theoremCount": 47,
+    "theoremCount": 41,
     "definitionCount": 26,
     "path": "Proofs/TractatusOntology.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Correct `theoremCount` in 4 gallery proofs where batch fixes (PRs #15953, #16012) introduced incorrect counts.

## Evidence

**`godel-first-incompleteness-oq01`**: 7→5
- PR #15274 correctly fixed this to 5 (stripping comment false positives)
- PR #16012 (batch) reverted it to 7
- Actual file has 5 theorem/lemma declarations after comment stripping

**`tractatus-ontology`**: 47→41
- PR #15953 increased from 41→47 by counting theorem mentions inside block comments
- Actual file has 41 theorem/lemma declarations after comment stripping

**`greens-theorem-oq-02`**: 22→19
- Batch fixes overcounted by including 3 `theorem` references inside docstring comments
- `assumptions` field itself says "19 theorems with 0 sorries" — self-documenting error
- Actual file has 19 theorem/lemma declarations after comment stripping

**`greens-theorem-oq-01-oq-01-oq-01`**: 8→10
- PR #16200 set to 8 excluding 2 private lemmas ("2 private lemmas excluded per convention")
- Current convention: 98.7% of gallery proofs include private declarations (per PR #16357 analysis)
- Actual file has 10 declarations (8 public + 2 private)

Both `meta.theoremCount` and `leanFile.theoremCount` updated in each file.

---
Automated fix by lean-mechanic agent.