### PR TITLE
audit(chinese-remainder-non-coprime-oq-01-oq-01): clean reaudit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2083,9 +2083,9 @@
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:49Z",
+      "lastAudited": "2026-05-06T21:22:24Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-02": {


### PR DESCRIPTION
## Summary
Clean reaudit of the k-moduli CRT extension proof. All counts in meta.json match the Lean source.

## Verification
- lineCount: 249 ✓
- theoremCount: 22 ✓ (includes 2 `@[simp]`-annotated theorems `kLCM_empty`, `kLCM_singleton`)
- definitionCount: 1 ✓
- sorries: 0 ✓
- axiomCount: 0 ✓
- True stubs: 0 ✓

Badge `original` / status `verified` defensible: extends the 2-moduli CRT efficiency result to k arbitrary moduli using Mathlib's `Finset.lcm` + ℤ `GCDMonoid` as infrastructure. Original kModuli_* periodicity, canonical form, efficiency, iterative construction, and necessity theorems are independently proved.

## Test plan
- [x] Counts cross-checked against `proofs/Proofs/ChineseRemainderNonCoprimeOQ01OQ01.lean`
- [x] No True-stubs / Mathlib wrapper claims
- [x] Tracker bumped (auditCount 1→2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)