### PR TITLE
fix(meta): divisibility-by-3-oq-03-oq-02 — sync theoremCount 21→20

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 211,
-    "theoremCount": 21,
+    "theoremCount": 20,
     "definitionCount": 1,
     "assumptions": [],
     "dateAdded": "2026-04-12",
@@ -177,7 +177,7 @@
     "namespace": "DigitalRootBase",
     "lineCount": 211,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 20,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/DivisibilityBy3OQ03OQ02.lean"


### PR DESCRIPTION
## Fix

Sync `theoremCount` (both `meta.theoremCount` and `leanFile.theoremCount`) from 21 to 20 to match the actual count of theorem/lemma declarations in `proofs/Proofs/DivisibilityBy3OQ03OQ02.lean`.

## Evidence

**Before**: `meta.theoremCount: 21`, `leanFile.theoremCount: 21`
**After**:  `meta.theoremCount: 20`, `leanFile.theoremCount: 20`

```
$ grep -cE '^\s*(private |protected |noncomputable )*(theorem|lemma) ' \
    proofs/Proofs/DivisibilityBy3OQ03OQ02.lean
20
```

Breakdown: 1 private lemma (`base_mod_pred`) + 19 theorems.

No other counts (lineCount=211, definitionCount=1, sorries=0, axiomCount=0) are drifted. Status remains `verified`/`original`.

Discovered during gallery integrity scan (mechanic, 2026-05-07).

---
Automated fix by lean-mechanic agent.