### PR TITLE
audit(greens-theorem-oq-01-oq-01-oq-01-oq-01): sync sorries 1→0, lineCount 471→516

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -19,9 +19,9 @@
       "greens-theorem"
     ],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "1 sorry remains: algebraic verification of the swap decomposition for k ≥ 2 in `iter_integral_swap_zero` (the succ m' case requires chaining three swap applications via swap(0,k) = swap(k₀,k) ∘ swap(0,k₀) ∘ swap(k₀,k)). `integrable_swap_pair` is proved (continuity of parameterized integrals + compact box). The main theorem `iteratedIntervalIntegral_order_independent` is proved via swap_induction_on (PR #16323).",
+    "assumptions": "0 sorries remaining in this file. `integrable_swap_pair` is proved (continuity of parameterized integrals + compact box). The main theorem `iteratedIntervalIntegral_order_independent` is proved via swap_induction_on (PR #16323), and the swap decomposition for k ≥ 2 in `iter_integral_swap_zero` is proved (PR #16359). This file imports `Proofs.GreensTheoremOQ01OQ01OQ01`, which still declares `iteratedIntervalIntegral_order_independent` as an axiom (now redundant, since this file proves the same statement).",
     "dateAdded": "2026-05-06",
     "openQuestions": [
       {
@@ -59,7 +59,7 @@
       "Inductive proof structure: decomposition into inner-permutation + adjacent-swap building blocks",
       "Eliminates the axiom iteratedIntervalIntegral_order_independent from greens-theorem-oq-01-oq-01-oq-01"
     ],
-    "lineCount": 471,
+    "lineCount": 516,
     "theoremCount": 10,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -77,18 +77,18 @@
       "Topology"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ01OQ01",
-    "lineCount": 471,
+    "lineCount": 516,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "sections": [
     {
       "id": "integrability",
       "title": "Integrability for the Fubini Swap",
-      "content": "The key technical lemma for the Fubini argument: for continuous f on a compact (n+2)-dimensional box, the function (x₀,x₁) ↦ [iterated integral over remaining variables x₂,...,xₙ₊₁] is integrable on Ioc(a₀,b₀) × Ioc(a₁,b₁). This follows from continuity of the parameterized integral + compact domain. Currently stated with sorry pending the continuity-of-parameterized-integral induction.",
+      "content": "The key technical lemma for the Fubini argument: for continuous f on a compact (n+2)-dimensional box, the function (x₀,x₁) ↦ [iterated integral over remaining variables x₂,...,xₙ₊₁] is integrable on Ioc(a₀,b₀) × Ioc(a₁,b₁). This follows from continuity of the parameterized integral + compact domain.",
       "theorems": ["integrable_swap_pair"]
     },
     {
@@ -116,9 +116,9 @@
     "proofStrategy": "Induction on n with two building blocks: swap_outer_two (Fubini for positions 0,1) and inner permutation reduction (IH applied inside outer integral). Any permutation σ decomposes as (move σ⁻¹(0) to position 0) ∘ (inner permutation fixing position 0), and each step uses one of the two building blocks."
   },
   "conclusion": {
-    "summary": "Partially eliminates axiom iteratedIntervalIntegral_order_independent. The main theorem iteratedIntervalIntegral_order_independent is proved via swap_induction_on (PR #16323). One sorry remains: the algebraic swap decomposition for k ≥ 2 in iter_integral_swap_zero.",
-    "significance": "The main theorem structure is complete. The single remaining sorry is a combinatorial verification that swap(0,k) = swap(k₀,k) ∘ swap(0,k₀) ∘ swap(k₀,k) for k ≥ 2.",
-    "limitations": "1 sorry remains. The full axiom elimination requires proving the swap decomposition identity for k ≥ 2 in iter_integral_swap_zero, at which point greens-theorem-oq-01-oq-01-oq-01 would have axiomCount=0."
+    "summary": "Eliminates axiom iteratedIntervalIntegral_order_independent. The main theorem iteratedIntervalIntegral_order_independent is proved via swap_induction_on (PR #16323), and the swap decomposition for k ≥ 2 in iter_integral_swap_zero is proved (PR #16359). This file has 0 sorries and 0 axioms.",
+    "significance": "The main theorem structure is complete and the combinatorial verification that swap(0,k) = swap(k₀,k) ∘ swap(0,k₀) ∘ swap(k₀,k) for k ≥ 2 is proved.",
+    "limitations": "0 sorries remain in this file. The parent module `Proofs.GreensTheoremOQ01OQ01OQ01` still declares `iteratedIntervalIntegral_order_independent` as an axiom; that declaration is now redundant given this file's proof of the same statement, and a follow-up should remove it from the parent."
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Sync `meta.json` for `greens-theorem-oq-01-oq-01-oq-01-oq-01` after PR #16359 (a5b3b0d2102) proved the remaining sorry in `iter_integral_swap_zero` for k ≥ 2.

- `sorries`: 1 → 0 (top-level, `meta` sub-object, `leanFile` sub-object)
- `lineCount`: 471 → 516 (`meta` sub-object and `leanFile` sub-object)
- `assumptions`, `conclusion.summary`, `conclusion.significance`, `conclusion.limitations`, and `sections.integrability` content updated to reflect that no sorries remain.

The `meta.axiomCount = 0` is preserved (the file itself declares no axioms). The parent module `Proofs.GreensTheoremOQ01OQ01OQ01` still contains the now-redundant `axiom iteratedIntervalIntegral_order_independent`; the `limitations` field flags it for follow-up cleanup.

## Verified

- `git show origin/main:proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` → 0 sorries (after stripping comments), 516 lines, 10 theorems, 0 defs, 0 axioms.
- Matches `npx tsx scripts/auditor/find-targets.ts --issues` output: `sorry mismatch: claims 1, actual 0`.

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`).
- [x] Diff is surgical (10 insertions / 10 deletions in one file).
- [x] No structural changes — `formalized` status retained pending separate decision on parent-axiom cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)