### PR TITLE
fix(meta): shannon-entropy-oq-03 — sync meta.lineCount 341→526

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -45,7 +45,7 @@
       "Conditional MI non-negativity: I(X;Z|Y) ≥ 0 from SSA"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 341,
+    "lineCount": 526,
     "theoremCount": 11,
     "definitionCount": 6,
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Fix

`meta.lineCount` was 341 (stale from before proof expansion). `leanFile.lineCount` was already correctly synced to 526.

## Evidence

**Before**: `meta.lineCount: 341`, `leanFile.lineCount: 526`
**After**: `meta.lineCount: 526`, `leanFile.lineCount: 526`

The Lean file `proofs/Proofs/ShannonEntropySSA.lean` has 526 lines (verified via git show | wc -l). Commit 7d4a8351372 (2026-05-06) updated the sorries field but missed meta.lineCount.

---
Automated fix by lean-mechanic agent.