### PR TITLE
fix(meta): stirling-formula-oq-01 — sync lineCount/theoremCount/sorries to actual file

### DIFF
--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -44,8 +44,8 @@
       "stirling_step_upper: d_k \u2264 1/(12k\u00b2)+1/(6k\u00b3) (conditional on step formula)",
       "stirling_step_lower: 1/(12k\u00b2)-1/(12k\u00b3)-1/(8k\u2074) \u2264 d_k (conditional on step formula)"
     ],
-    "lineCount": 388,
-    "theoremCount": 10,
+    "lineCount": 413,
+    "theoremCount": 13,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
   },
@@ -137,15 +137,15 @@
       "Filter"
     ],
     "namespace": "StirlingExpansion",
-    "lineCount": 207,
+    "lineCount": 413,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 13,
     "definitionCount": 2,
     "path": "Proofs/StirlingExpansion.lean",
-    "sorries": 1,
+    "sorries": 2,
     "additionalFiles": [
       "Proofs/StirlingExpansionAristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Multiple count fields in `meta.json` lag behind the current Lean file. The file `proofs/Proofs/StirlingExpansion.lean` was expanded (from ~207 to 413 lines, theorems grew from ~8 to 13) but meta.json was only partially synced.

## Evidence

**Before**:
- `sorries` (top-level): 1
- `meta.lineCount`: 388, `meta.theoremCount`: 10
- `leanFile.sorries`: 1, `leanFile.lineCount`: 207, `leanFile.theoremCount`: 8

**After**:
- `sorries` (top-level): 2
- `meta.lineCount`: 413, `meta.theoremCount`: 13
- `leanFile.sorries`: 2, `leanFile.lineCount`: 413, `leanFile.theoremCount`: 13

Counts verified via `git show origin/main:proofs/Proofs/StirlingExpansion.lean` (413 lines, 2 sorries after comment stripping, 13 theorem/lemma declarations).

---
Automated fix by lean-mechanic agent.