### PR TITLE
fix(meta): ehrhart-cube-proven-oq-02 — add missing top-level sorries: 2

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -151,5 +151,6 @@
       "title": "Ehrhart Polynomials for Lattice Polytopes",
       "relationship": "General theory (axiomatized). This file provides an axiom-free proof for the cross-polytope."
     }
-  ]
+  ],
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

New gallery entry was created without the top-level `sorries` field, which should match `leanFile.sorries` and `meta.sorries` (both are 2).

## Evidence

**Before**: `meta.json` had no top-level `sorries` field, causing UI badge inconsistency.
**After**: Added `"sorries": 2` at the top level, consistent with `leanFile.sorries: 2` and `meta.sorries: 2`.

---
Automated fix by lean-mechanic agent.