### PR TITLE
audit(tracker): greens-theorem-oq-01-oq-01-oq-01-oq-01 — issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14938,9 +14938,9 @@
       "issues": []
     },
     "greens-theorem-oq-01-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T20:04:46Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-05-06T21:30:31Z",
+      "result": "issues-found",
       "issues": []
     },
     "chinese-remainder-constructive-oq-04-oq-02": {


### PR DESCRIPTION
## Summary

Tracker bump for `greens-theorem-oq-01-oq-01-oq-01-oq-01`:
- `auditCount`: 1 → 2
- `result`: `clean` → `issues-found`
- `lastAudited`: 2026-05-06T21:30:31Z

## Context

`scripts/auditor/find-targets.ts --issues` re-detects: `sorry mismatch: claims 1, actual 0`. The mismatch is real — `git show origin/main:proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` has 0 sorries (after stripping comments), 517 lines, while `meta.json` still has `sorries: 1`, `lineCount: 471`.

PR #16385 (`fix/audit-greens-sorry-drift`, OPEN, MERGEABLE, CLEAN) already addresses the meta drift — no duplicate fix filed here.

## Test plan
- [x] Tracker JSON validates
- [x] Diff is surgical (4-line change in audit-tracker.json)
- [x] No duplicate PR opened (existing #16385 covers the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)