### PR TITLE
audit(fermat-two-squares-oq-01-oq-03): sync theoremCount 15→18

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -14,7 +14,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 357,
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 9,
     "assumptions": "hurwitz_euclidean: For any Hurwitz quaternions a and nonzero b, there exist q, r ∈ H with a = b·q + r and N(r) < N(b). This Euclidean property requires the covering radius argument from algebraic topology to prove fully.",
     "originalContributions": [
@@ -31,7 +31,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 357,
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 9
   },
   "overview": {


### PR DESCRIPTION
## Summary

Metadata-only fix. Actual theorem/lemma count in `proofs/Proofs/FermatTwoSquaresOQ01OQ03.lean` is 18, but both `meta.theoremCount` and `leanFile.theoremCount` recorded 15.

The three theorems missed by the original scan all carry an `@[simp]` attribute prefix on the same line:
- `@[simp] theorem hurwitzOmega_normSq4` (line 119)
- `@[simp] theorem hurwitz_i_normSq` (line 131)
- `@[simp] theorem hurwitz_one_normSq` (line 139)

Verified via regex over the on-disk file with block/line comments stripped (per memory `feedback_auditor_simp_attribute_theorems.md`).

## Verification

- `lineCount: 357` ✓
- `axiomCount: 1` ✓ (`hurwitz_euclidean`)
- `definitionCount: 9` ✓
- `sorries: 0` ✓
- `theoremCount: 18` (was 15) — fixed

No Lean source touched.

🤖 Generated by gallery integrity audit