### PR TITLE
fix(meta): erdos-183 — sync counts after research PR #16378

### DIFF
--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -50,8 +50,8 @@
       "Connection between Schur numbers and Ramsey numbers",
       "Growth rate bounds and limit formulations"
     ],
-    "axiomCount": 1,
-    "lineCount": 613,
+    "axiomCount": 0,
+    "lineCount": 770,
     "references": [
       {
         "title": "Some remarks on the theory of graphs",
@@ -77,8 +77,8 @@
       }
     ],
     "assumptions": "1 axiom: R3k_exponential_lower (c^k lower bound from Schur numbers). R3k_factorial_upper PROVED from R3k_le_three_factorial (induction on pigeonhole recurrence). R3k_inductive_upper PROVED from extracted pigeonhole step. forcing_set_nonempty PROVED via pigeonhole induction. R3k_one, R3k_two PROVED. Monotonicity PROVED.",
-    "theoremCount": 18,
-    "definitionCount": 14
+    "theoremCount": 26,
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) ≤ ⌈e·k!⌉ follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) ≥ 380^{k/5} - O(1).\n\nErdős offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
@@ -186,10 +186,10 @@
       "Classical"
     ],
     "namespace": "Erdos183",
-    "lineCount": 613,
-    "axiomCount": 1,
-    "theoremCount": 18,
-    "definitionCount": 14,
+    "lineCount": 770,
+    "axiomCount": 0,
+    "theoremCount": 26,
+    "definitionCount": 15,
     "path": "Proofs/Erdos183Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Research PR #16378 proved `R3k_exponential_lower` via a doubling construction (eliminating the last axiom) and added substantial supporting lemmas, but did not update `meta.json`. Syncing factual count fields.

## Evidence

**Before** (meta.json claims from before #16378):
- `lineCount`: 613
- `theoremCount`: 18
- `definitionCount`: 14
- `axiomCount`: 1

**After** (actual file state post-#16378):
- `lineCount`: 770 (file grew by 157 lines)
- `theoremCount`: 26 (13 new private lemmas for the doubling proof added)
- `definitionCount`: 15 (`doubleColoring` added)
- `axiomCount`: 0 (`R3k_exponential_lower` is now a theorem, not an axiom)

Both `meta` sub-object and `leanFile` block updated.

Note: `status`/`badge` intentionally kept as `axiomatized`/`axiom` per policy — Erdős open problems always remain `axiomatized`.

---
Automated fix by lean-mechanic agent.