### PR TITLE
audit(tracker): fermat-two-squares-oq-01-oq-03 — issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14824,9 +14824,9 @@
       "issues": []
     },
     "fermat-two-squares-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-06T15:10:28Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-05-06T21:37:52Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
## Summary

Tracker bump only. Records that fermat-two-squares-oq-01-oq-03 was audited and the theoremCount drift (15→18) was fixed in #16390.

- auditCount: 2 → 3
- result: clean → issues-fixed

🤖 Generated by gallery integrity audit