### PR TITLE
fix(meta): batch sync theoremCount drift (12 proofs)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -70,7 +70,7 @@
       }
     ],
     "assumptions": "0 axioms. Relies only on Mathlib's completeness of ℝ (conditional supremum) and basic real arithmetic.",
-    "theoremCount": 17,
+    "theoremCount": 20,
     "definitionCount": 5
   },
   "overview": {
@@ -193,7 +193,7 @@
     "opens": [],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 20,
     "substantiveTheoremCount": 7,
     "computationalVerifications": 0,
     "lemmaCount": 1,

--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -55,7 +55,7 @@
     "axiomCount": 2,
     "lineCount": 505,
     "assumptions": "2 axioms: kakutani_fixed_point_axiom (Kakutani fixed-point theorem for compact convex sets in ℝⁿ) and brouwer_pi_compact_convex (Brouwer FPT for products of compact convex sets — requires Schoenflies-type theorem not yet in Mathlib). 0 sorries.",
-    "theoremCount": 23,
+    "theoremCount": 22,
     "definitionCount": 11
   },
   "overview": {
@@ -208,7 +208,7 @@
     "namespace": "KakutaniFPT",
     "lineCount": 505,
     "axiomCount": 2,
-    "theoremCount": 23,
+    "theoremCount": 22,
     "definitionCount": 11,
     "path": "Proofs/BrouwerFixedPointOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -49,7 +49,7 @@
     "lineCount": 442,
     "assumptions": "2 axioms. No sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 5
   },
   "overview": {
@@ -229,7 +229,7 @@
     "namespace": "CantorDiagonalizationOQ01",
     "lineCount": 442,
     "axiomCount": 2,
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
     "lineCount": 380,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 5,
     "originalContributions": [
       "IsClub: club sets (closed unbounded subsets of ordinals below \u03ba.ord)",
@@ -66,7 +66,7 @@
     "namespace": "FodorLemma",
     "lineCount": 380,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 5,
     "mainTheorem": "fodors_pressing_down",
     "sorries": 0,

--- a/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
@@ -48,7 +48,7 @@
     "axiomCount": 0,
     "lineCount": 104,
     "assumptions": "0 own axioms. Inherits 2 axioms from Erdos100Problem.lean: guthKatz_distinct_distances (Guth-Katz 2015) and piepmeyer_construction. Uses diam_ge_n_over_log_n (proved theorem in parent). 0 sorries.",
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 0
   },
   "sections": [
@@ -137,7 +137,7 @@
     "namespace": "Erdos100OQ02OQ02",
     "lineCount": 104,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 0,
     "path": "Proofs/Erdos100OQ02OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-688/meta.json
+++ b/src/data/proofs/erdos-688/meta.json
@@ -28,7 +28,7 @@
     "axiomCount": 0,
     "lineCount": 126,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 4
   },
   "sections": [
@@ -140,7 +140,7 @@
     "namespace": null,
     "lineCount": 126,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 4,
     "path": "Proofs/Erdos688Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-721/meta.json
+++ b/src/data/proofs/erdos-721/meta.json
@@ -59,7 +59,7 @@
     "axiomCount": 6,
     "lineCount": 240,
     "assumptions": "6 axioms: W, graham_conjecture_false, green_lower_bound, hunter_lower_bound, schoen_upper_bound, bloom_sisask_upper_bound. 0 sorries.",
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 2
   },
   "overview": {
@@ -178,7 +178,7 @@
     "namespace": "Erdos721",
     "lineCount": 240,
     "axiomCount": 6,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 2,
     "path": "Proofs/Erdos721Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-881/meta.json
+++ b/src/data/proofs/erdos-881/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 1,
     "lineCount": 243,
     "assumptions": "1 axiom: erdos_881 (the open conjecture). Reduced from 2 by proving squares_basis_order_4 from Mathlib's Nat.sum_four_squares. Also fixed definition to use Multiset (was incorrectly using Finset, which disallows repeated elements needed for additive bases).",
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 6
   },
   "overview": {
@@ -170,7 +170,7 @@
     "namespace": "Erdos881",
     "lineCount": 243,
     "axiomCount": 1,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 6,
     "path": "Proofs/Erdos881Problem.lean",
     "sorries": 0

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -58,7 +58,7 @@
     "lineCount": 135,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 0
   },
   "overview": {
@@ -200,7 +200,7 @@
     "namespace": "EulerTotient",
     "lineCount": 135,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/EulerTotient.lean",
     "sorries": 0

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -78,7 +78,7 @@
     "millenniumProblem": "poincare",
     "lineCount": 17675,
     "mathlib_version": "4.26.0",
-    "theoremCount": 943,
+    "theoremCount": 941,
     "definitionCount": 373
   },
   "overview": {
@@ -347,7 +347,7 @@
     "lineCount": 17675,
     "axiomCount": 32,
     "sorries": 0,
-    "theoremCount": 943,
+    "theoremCount": 941,
     "definitionCount": 373,
     "lemmaCount": 0
   }

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -60,7 +60,7 @@
     "proofRepoPath": "Proofs/SchauderFixedPoint.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 601,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 2
   },
   "overview": {
@@ -219,7 +219,7 @@
     "lineCount": 601,
     "structureCount": 0,
     "axiomCount": 5,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "lemmaCount": 0,
     "imports": [
       "Mathlib.Topology.Basic",

--- a/src/data/proofs/schroeder-bernstein-oq-02/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02/meta.json
@@ -48,7 +48,7 @@
     "lineCount": 223,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 5
   },
   "overview": {
@@ -161,7 +161,7 @@
     "namespace": "KnasterTarskiCBS",
     "lineCount": 223,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 5,
     "path": "Proofs/SchroederBernsteinOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `theoremCount` (both `leanFile.theoremCount` and the meta sub-block) to actual
counts in 12 gallery proofs.

Counting convention: theorem/lemma declarations after stripping comments,
including `private`, `protected`, `noncomputable`, and `@[attr]`-decorated forms
(current 98.7% gallery convention; see PR #16382).

## Evidence

| slug | old | new |
|------|----:|----:|
| algebraic-numbers-countable-oq-02-oq-02 | 17 | 20 |
| brouwer-fixed-point-oq-04 | 23 | 22 |
| cantor-diagonalization-oq-01 | 27 | 28 |
| cantor-diagonalization-oq-02-oq-03-oq-02 | 5 | 6 |
| erdos-100-oq-02-oq-02 | 3 | 2 |
| erdos-688 | 4 | 3 |
| erdos-721 | 4 | 3 |
| erdos-881 | 9 | 8 |
| euler-totient | 6 | 5 |
| poincare-conjecture | 943 | 941 |
| schauder-fixed-point | 10 | 9 |
| schroeder-bernstein-oq-02 | 15 | 14 |

Two-line diffs per file (meta sub-block + leanFile block) preserve all other
formatting via surgical string replacement.

Discovered during gallery integrity scan (mechanic, 2026-05-07).

---
Automated fix by lean-mechanic agent.