### PR TITLE
fix(meta): batch sync definitionCount drift (24 proofs)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -100,7 +100,7 @@
       }
     ],
     "theoremCount": 64,
-    "definitionCount": 7
+    "definitionCount": 15
   },
   "crossReferences": [
     {
@@ -474,7 +474,7 @@
     "lineCount": 1498,
     "axiomCount": 0,
     "theoremCount": 64,
-    "definitionCount": 7,
+    "definitionCount": 15,
     "mainTheorems": [
       {
         "name": "p_irreducible",

--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 7,
     "lineCount": 242,
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "assumptions": "7 axioms: ellipticK (function), ellipticE (function), K_eq_pi_div_2M (Gauss's AGM theorem for k=1/√2), legendre_relation (Legendre's relation for k=1/√2), ellipticE_agm (E via AGM iteration), bs_summable (series convergence from quadratic AGM convergence), S_lt_half (series sum bound). The algebraic derivation π = 4M²/(1-2S) is machine-verified from these axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -153,7 +153,7 @@
     "lineCount": 242,
     "axiomCount": 7,
     "theoremCount": 8,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "path": "Proofs/AmgmInequalityOQ04OQ05.lean",
     "sorries": 0
   },

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -60,7 +60,7 @@
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 68,
-    "definitionCount": 11
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "The isoperimetric problem — find the shape of maximum area for a given perimeter — is one of the oldest optimization problems in mathematics, traced to ancient Dido of Carthage (~900 BCE). The problem asks: among all closed curves of length $L$, which encloses the most area? The answer is a circle, and the isoperimetric inequality $C^2 \\geq 4\\pi A$ quantifies how much any curve falls short. Archimedes knew the result informally (~250 BCE), but a rigorous proof waited until the 19th century. Steiner (1838) gave an elegant proof using symmetrization, but didn't prove existence of the maximizer. Weierstrass (1870s) gave the first complete proof using calculus of variations. The most elegant proof is due to Hurwitz (1901), who used Fourier series and the Wirtinger inequality.",
@@ -273,7 +273,7 @@
     "lineCount": 1938,
     "axiomCount": 0,
     "theoremCount": 68,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "mainTheorems": [
       {
         "name": "isoperimetric_inequality_smooth",

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -88,7 +88,7 @@
       "Gessel-Viennot involution theory"
     ],
     "assumptions": [],
-    "definitionCount": 30
+    "definitionCount": 45
   },
   "overview": {
     "historicalContext": "The Lindström-Gessel-Viennot (LGV) lemma is one of the most versatile tools in enumerative combinatorics. Bernt Lindström proved a general version for vector matroids in 1973, building on ideas from Karlin and McGregor's 1959 work on coincidence probabilities of Markov chains. Ira Gessel and Gérard Viennot independently rediscovered and popularized the result in their influential 1985 paper, providing the elegant sign-reversing involution proof that has become the standard approach. The lemma connects non-intersecting lattice paths to determinants: the number of $r$-tuples of pairwise non-intersecting paths equals $\\det[e(A_i, B_j)]_{i,j}$. This determinantal structure has profound consequences—it underlies the Jacobi-Trudi identity for Schur polynomials, the Cauchy-Binet identity in linear algebra, and the Kasteleyn method for perfect matchings. The GV involution is a paradigmatic example of the 'cancellation via involution' technique that pervades algebraic combinatorics.",
@@ -290,7 +290,7 @@
     "lineCount": 2511,
     "axiomCount": 0,
     "theoremCount": 92,
-    "definitionCount": 30,
+    "definitionCount": 45,
     "path": "Proofs/BallotProblemOQ03OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -83,7 +83,7 @@
     "lineCount": 7435,
     "mathlib_version": "4.26.0",
     "theoremCount": 254,
-    "definitionCount": 143
+    "definitionCount": 164
   },
   "overview": {
     "historicalContext": "The BSD conjecture arose from pioneering computational experiments by Bryan Birch and Peter Swinnerton-Dyer at Cambridge in the early 1960s. Using the EDSAC computer, they computed the product of local factors $N_p/p$ for many elliptic curves and observed that the growth rate as $p \\to \\infty$ correlated with the number of rational points. In 1965, they published their conjecture: the rank of the Mordell-Weil group $E(\\mathbb{Q})$ equals the order of vanishing of $L(E, s)$ at $s = 1$.\n\nThe first major progress came from Coates and Wiles (1977), who proved BSD for elliptic curves with complex multiplication when $L(E, 1) \\neq 0$. The breakthrough decade was the 1980s-90s: Gross and Zagier (1986) established their celebrated formula relating $L'(E, 1)$ to the height of Heegner points, and Kolyvagin (1990) introduced Euler systems to prove the rank 0 and rank 1 cases. These results established that if $L(E, 1) \\neq 0$ then rank $= 0$, and if $L(E, 1) = 0$ but $L'(E, 1) \\neq 0$ then rank $= 1$, with the Shafarevich-Tate group finite in both cases.\n\nWiles' proof of the modularity theorem for semistable curves (1995) -- which famously proved Fermat's Last Theorem as a corollary -- was essential for BSD because it guaranteed that $L(E, s)$ has analytic continuation, making the order of vanishing at $s = 1$ well-defined. Breuil-Conrad-Diamond-Taylor (2001) completed the modularity theorem for all elliptic curves over $\\mathbb{Q}$.\n\nIn 2000, the Clay Mathematics Institute designated BSD as one of seven Millennium Prize Problems, carrying a $1,000,000 prize. Despite massive computational evidence (verified for all curves with conductor $\\leq 500{,}000$ with no counterexamples), the conjecture remains open for rank $\\geq 2$. Bhargava and Shankar (2015) showed the average rank of elliptic curves is at most 7/6, providing statistical evidence that BSD is 'usually true', but a proof for individual curves of higher rank remains elusive.",
@@ -722,7 +722,7 @@
     "lineCount": 7435,
     "sorries": 0,
     "path": "Proofs/BirchSwinnertonDyer.lean",
-    "definitionCount": 143,
+    "definitionCount": 164,
     "theoremCount": 254,
     "additionalFiles": [
       "Proofs/BirchSwinnertonDyerAristotle.lean"

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "1 axiom inherited from BorsukUlam.lean: no_continuous_odd_nonzero_on_sphere (no continuous odd function from sphere is everywhere nonzero — the Borsuk-Ulam theorem). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
-    "definitionCount": 8
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The Borsuk-Ulam theorem (1933) asserts that every continuous map $S^n \\to \\mathbb{R}^n$ identifies a pair of antipodal points. Karol Borsuk posed the conjecture in 1933 and Stanisław Ulam is credited with the original formulation. The covering space proof, developed in the 1950s-60s through the work of algebraic topologists including Eilenberg and Steenrod, reduces the problem to showing no continuous odd map $S^n \\to S^{n-1}$ exists. The key idea is descent: an odd map $g$ induces $\\bar{g}: \\mathbb{R}P^n \\to \\mathbb{R}P^{n-1}$, and the induced homomorphism $\\pi_1(\\mathbb{R}P^n) \\to \\pi_1(\\mathbb{R}P^{n-1})$, i.e., $\\mathbb{Z}/2\\mathbb{Z} \\to \\mathbb{Z}/2\\mathbb{Z}$, must be both surjective (by the lifting property) and trivial (by geometric constraints) — contradiction. The higher categorical perspective emerged from Grothendieck's Pursuing Stacks (1983) and was systematized by Lurie in Higher Topos Theory (2009): classical covering spaces are functors $\\Pi_1(X) \\to \\mathbf{Set}$, while $\\infty$-coverings are local systems $\\Pi_\\infty(X) \\to \\mathbf{Space}$, capturing all homotopical information. Whether these higher-categorical tools yield genuinely stronger Borsuk-Ulam-type results remains an active research question, connecting to equivariant stable homotopy theory and the Hill-Hopkins-Ravenel solution of the Kervaire invariant problem (2016).",
@@ -142,7 +142,7 @@
     "lineCount": 448,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 8,
+    "definitionCount": 11,
     "path": "Proofs/BorsukUlamOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01/meta.json
@@ -42,7 +42,7 @@
       }
     ],
     "theoremCount": 7,
-    "definitionCount": 3
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Georges-Louis Leclerc, Comte de Buffon (1707–1788) posed the needle problem in his 1777 *Essai d'arithmétique morale*: drop a needle of length $l$ onto a floor with parallel lines spaced $d$ apart; the probability of crossing a line is $2l/(\\pi d)$. In 1860, Joseph-Émile Barbier extended the result dramatically: *any* planar curve of arc length $L$ has the same expected crossing count $E = 2L/(\\pi d)$, regardless of its shape. This is Barbier's theorem, or the Buffon-Barbier formula for Buffon's Noodle.\n\nThe result is a foundational example of integral geometry — a special case of the Cauchy-Crofton formula (Cauchy 1850, Crofton 1868), which expresses arc length as an integral of crossing counts over all lines: $L = (\\pi d/2) \\cdot E[\\text{crossings}]$.\n\nThe Lean Genius formalization proceeded in stages: the original `BuffonsNoodle.lean` axiomatized the smooth case; `BuffonsNeedleOQ01` and `BuffonsNeedleOQ01OQ01` built the angular-average integration infrastructure; this file completes the chain, eliminating all axioms for a fully machine-checked proof of Barbier's theorem for C¹ curves.",
@@ -169,7 +169,7 @@
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 3,
+    "definitionCount": 1,
     "theoremCount": 7
   },
   "sorries": 0

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -47,7 +47,7 @@
       "gch_decides_all_aleph theorem: GCH gives exact value of all higher continua",
       "gch_continuum_below_aleph_add_two theorem: GCH → 2^ℵₙ < ℵₙ₊₂ (Cardinal.aleph_lt.mpr + omega)"
     ],
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "After Gödel (1940) and Cohen (1963) established CH's independence from ZFC, set theorists naturally asked whether adding large cardinal axioms — the strongest known axioms of infinity — could settle the question. The answer turned out to be nuanced: the Lévy-Solovay theorem (1967) showed that standard large cardinals (measurable, supercompact) are compatible with both CH and ¬CH via small forcing. However, forcing axioms like Martin's Maximum (1988) do decide CH, implying ¬CH. The Woodin Ultimate-L program (2001–present) remains the frontier, potentially canonically settling CH as true. The Generalized Continuum Hypothesis (GCH: 2^ℵₙ = ℵₙ₊₁ for all n) strengthens CH to all infinite cardinals and is the target of the Ultimate-L program.",
@@ -152,7 +152,7 @@
     "lineCount": 306,
     "axiomCount": 7,
     "theoremCount": 14,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/CantorDiagonalizationOQ01OQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -61,7 +61,7 @@
       }
     ],
     "theoremCount": 11,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Companion matrices have been a cornerstone of linear algebra since the 19th century, appearing naturally in the theory of eigenvalues (Cayley, Weierstrass) and the rational canonical form (Frobenius, 1879). The nonderogatory property — that the minimal polynomial equals the characteristic polynomial — was identified as the condition for a matrix to have a single invariant factor, making K^n a cyclic module over K[X]. The equivalence 'nonderogatory ↔ similar to companion matrix' is the central theorem of rational canonical form theory, but its proof requires the structure theorem for finitely generated modules over K[X], a principal ideal domain. Unlike the Jordan canonical form (valid only over algebraically closed fields), the rational canonical form works over any field. Despite its classical status, the PID structure theorem for K[X]-modules had not been formalized in Mathlib as of version 4.26. The parent file CayleyHamiltonMinpolyOQ05OQ01OQ04.lean attempts the general theorem via the module-theoretic route but carries a sorry at the key step. This WIP file pursues a companion-matrix-first strategy: the Krylov orbit C^k e0 = e_k is a concrete, purely computational fact about matrix powers that can be verified without any abstract module theory, providing an unconditional proof of the companion matrix half.",
@@ -147,7 +147,7 @@
     "lineCount": 306,
     "axiomCount": 1,
     "theoremCount": 11,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "None. Fully verified from Mathlib.",
     "lineCount": 340,
     "theoremCount": 11,
-    "definitionCount": 4,
+    "definitionCount": 3,
     "originalContributions": [
       "menelaus_algebraic_core: unified algebraic core for all three geometries (product = -1 iff numerator = -denominator)",
       "SphericalMenelausConfig: signed arc framework with sin non-degeneracy constraints",
@@ -120,7 +120,7 @@
     "lineCount": 340,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 4,
+    "definitionCount": 3,
     "path": "Proofs/CevasTheoremNonEuclideanOQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 230,
     "theoremCount": 19,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "parentProofId": "cevas-theorem-oq-01",
     "originalContributions": [
       "routh_theorem_std: Routh's area formula — signedArea(P,Q,R) = routhRatio(d,e,f) * signedArea(A,B,C) for general parameters",
@@ -118,7 +118,7 @@
     "lineCount": 230,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "path": "Proofs/CevasTheoremOQ01OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-03/meta.json
@@ -24,7 +24,7 @@
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
     "dateAdded": "2026-05-03",
-    "definitionCount": 3
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Residue Number Systems were introduced by Harvey Garner in 1959 for parallel computer arithmetic. The question of which moduli to use is critical for hardware efficiency. Power-of-2 moduli are attractive because x mod 2^k reduces to a bitwise AND operation (x &&& (2^k - 1)), requiring a single hardware instruction. However, the CRT foundation requires pairwise coprimality, which limits how many powers of 2 can appear in a base. This entry resolves the question by proving that exactly one power of 2 can appear alongside any collection of pairwise coprime odd moduli.",
@@ -105,7 +105,7 @@
     "path": "Proofs/ChineseRemainderConstructiveOQ03OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "theoremCount": 19
   },
   "sorries": 0

--- a/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
@@ -12,7 +12,7 @@
     "axiomCount": 0,
     "lineCount": 241,
     "theoremCount": 11,
-    "definitionCount": 1,
+    "definitionCount": 0,
     "assumptions": "None. All theorems proved for arbitrary CommRing k with parameter q : k. The VermaData structure is abstract (universal); no invertibility hypotheses needed for the Verma module action proofs.",
     "tags": [
       "quantum-groups",
@@ -38,7 +38,7 @@
     "axiomCount": 0,
     "lineCount": 241,
     "theoremCount": 11,
-    "definitionCount": 1
+    "definitionCount": 0
   },
   "overview": {
     "historicalContext": "Quantum groups were introduced by Drinfeld and Jimbo in 1985-1986, arising from the study of integrable systems and the quantum Yang-Baxter equation. The quantum group U_q(𝔰𝔩₂) is the prototypical example: a one-parameter deformation of the universal enveloping algebra of 𝔰𝔩₂ that reduces to the classical case when q=1. Verma modules for quantum groups were studied extensively in the 1990s; their structure — particularly the divided power formula F^n·v₀ = [n]_q!·vₙ — is foundational for quantum representation theory and connects to knot invariants, quantum topology, and the Jones polynomial. This formalization uses the q-number (qNumber) and q-factorial (qFactorial) infrastructure from combinations-formula-oq-03.",

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01/meta.json
@@ -45,7 +45,7 @@
       "Proved qdet3_recurrence_summary: the complete recurrence theorem in one conjunction"
     ],
     "theoremCount": 30,
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "sections": [
     {
@@ -155,7 +155,7 @@
     "lineCount": 313,
     "axiomCount": 0,
     "theoremCount": 30,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "path": "Proofs/CramersRuleOQ01OQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -35,7 +35,7 @@
       }
     ],
     "theoremCount": 28,
-    "definitionCount": 8
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Jacques Charles François Sturm (1829) published the theorem bearing his name as a response to a challenge: given a polynomial equation with real coefficients, how many real roots does it have in a given interval? His elegant answer used a GCD-based sequence (now called the Sturm sequence) to give an exact count via sign-variation differences — the first constructive, computable solution to this classical problem. The theorem appeared in Sturm's 1829 paper 'Mémoire sur la résolution des équations numériques' and immediately became the standard tool for real root counting. It was later extended by Sylvester (1853) and connected to the Hermite quadratic forms theory, which gives the number of real roots via the signature of a quadratic form over ℚ — a bridge between polynomial analysis and number theory.",
@@ -113,7 +113,7 @@
       }
     ],
     "path": "Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean",
-    "definitionCount": 8
+    "definitionCount": 6
   },
   "sections": [
     {

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
@@ -52,7 +52,7 @@
     "axiomCount": 0,
     "lineCount": 256,
     "theoremCount": 14,
-    "definitionCount": 2
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "The base Wiedijk #82 formalization uses covers_unit_cube : True as a placeholder — it records that cubes should cover the unit cube but does not enforce it. OQ-01 asked whether every nonempty dissection has a collision pair (same-size distinct cubes); the answer is YES. OQ-01-OQ-03 asks: can we incorporate the geometric covering condition — specifically, that the volumes sum to 1 — into the structure?",
@@ -127,7 +127,7 @@
     "lineCount": 256,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "path": "Proofs/DissectionOfCubesOQ01OQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
@@ -34,7 +34,7 @@
     "lineCount": 705,
     "assumptions": "One axiom: `innerSum_log_bound` \u2014 for badly approximable irrational \u03b1 (bounded partial quotients), |S(\u03b1,n)| \u2264 C\u00b7log n. This requires continued fraction theory not yet in Mathlib. One sorry: `equidist_approx` (density of trig polynomials in L\u221e \u2014 Stone-Weierstrass for periodic functions). Three previously open sorries (`continuous_comp_fract` integer case and two integral bounds for `deviation_sandwich`) are now fully proved. Both main theorems (weyl_equidist_continuous, weyl_fract_average_zero) are proved modulo equidist_approx.",
     "theoremCount": 16,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Hermann Weyl's 1916 paper '\u00dcber die Gleichverteilung von Zahlen mod. Eins' (On the distribution of numbers mod one) is one of the foundational results of analytic number theory and ergodic theory. Weyl proved that for irrational \u03b1, the sequence {n\u03b1} of fractional parts is equidistributed modulo 1 \u2014 meaning any subinterval [a,b] \u2282 [0,1) contains exactly (b-a) fraction of the sequence in the long run. His key innovation was the exponential sum criterion: {n\u03b1} is equidistributed if and only if (1/N)\u03a3 e^{2\u03c0ikn\u03b1} \u2192 0 for every nonzero integer k. This reduces equidistribution to estimates on exponential sums, which can be bounded by the geometry of the unit circle.\n\nThe connection to Erd\u0151s Problem #1002 comes through Kesten's 1960 theorem: the normalized inner sum (1/log n) S(\u03b1,n) = (1/log n) \u03a3_{k=1}^n (1/2 - {\u03b1k}) converges in distribution to a standard Cauchy distribution for badly approximable irrational \u03b1. The Ces\u00e0ro mean result proved here (weyl_cesaro_zero) is the key ingredient showing that the unnormalized average (1/n) S(\u03b1,n) \u2192 0, consistent with the 1/log n normalization in Kesten's theorem.\n\nWeyl's criterion has become a versatile tool throughout mathematics. It underlies the three-distance theorem (Steinhaus), the equidistribution of \u221an mod 1 (which Weyl's polynomial extension handles), and is the prototype for modern analytic approaches in ergodic theory. The exponential sum bound 2/\u2016r-1\u2016 proved in weyl_cesaro_bound is optimal \u2014 it cannot be improved without additional information about \u03b1.",
@@ -151,7 +151,7 @@
     "lineCount": 705,
     "sorries": 1,
     "path": "Proofs/Erdos1002OQ01OQ01.lean",
-    "definitionCount": 4,
+    "definitionCount": 6,
     "theoremCount": 16,
     "additionalFiles": [
       "Proofs/Erdos1002OQ01OQ01Aristotle.lean"

--- a/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
@@ -48,7 +48,7 @@
     "dateAdded": "2026-05-03",
     "lineCount": 256,
     "assumptions": "2 axioms: (1) cover_graph_recognition_in_p — the open conjecture that cover recognition is in P; (2) comparability_recognition_in_p — Golumbic's 1977 theorem that comparability graphs are recognized in polynomial time.",
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The recognition problem for **cover graphs** (Hasse diagrams of finite posets) has a rich history intertwined with the theory of comparability graphs and computational complexity.\n\n**Comparability graphs** — where edges represent all related pairs $u < v$ or $v < u$ — have been studied since the 1950s. Dilworth (1950) characterized them via transitive orientations. Golumbic (1977) gave a linear-time algorithm using *implication classes* (a 2-SAT-like structure): for each edge $\\{u,v\\}$, assign $u \\to v$ or $v \\to u$, propagate implications via transitivity, and check for consistency.\n\n**Cover graphs** are more restrictive: edges correspond only to direct covers $u \\lessdot v$ (no intermediate element). Determining when a graph is a Hasse diagram is harder because the shortcut-free condition (no arc $u \\to v$ with an alternative path $u \\to w \\to v$) is not captured by the implication-class method. The Golumbic algorithm for comparability may produce an orientation with shortcuts that cannot be fixed without changing the orientation entirely.\n\nPretzel (1985) and Brightwell (1988) established the structural characterization: $G$ is a cover graph if and only if $G$ has a **robustly acyclic orientation** (Pretzel's term) or equivalently a **Hasse orientation** (acyclic + shortcut-free). This connection to orientations is what makes the problem accessible to computational analysis.\n\nThe open question — whether cover recognition is in P — was raised by Erdős in problem #1006. The NP membership is trivial (the poset is a certificate). The P-time algorithm for comparability (Golumbic 1977) does not extend directly. As of 2025, neither a polynomial algorithm nor an NP-hardness proof is known.",
@@ -144,7 +144,7 @@
     "path": "Proofs/Erdos1006OQ01OQ02.lean",
     "axiomCount": 2,
     "sorries": 0,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "theoremCount": 9
   },
   "sorries": 0

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -57,7 +57,7 @@
       "directed_hamiltonian_threshold (fully proved): arc count > (n-1)² + SC implies Hamiltonicity via probabilistic union bound over n! permutations (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le)"
     ],
     "theoremCount": 25,
-    "definitionCount": 9
+    "definitionCount": 13
   },
   "overview": {
     "prerequisites": [
@@ -264,7 +264,7 @@
     "sorries": 0,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 25,
-    "definitionCount": 9,
+    "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos1012OQ03Aristotle.lean"
     ]

--- a/src/data/proofs/erdos-1017-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-01/meta.json
@@ -22,7 +22,7 @@
     "lineCount": 696,
     "axiomCount": 2,
     "sorries": 0,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "theoremCount": 37
   },
   "meta": {
@@ -79,7 +79,7 @@
       "Axiom reduction: eliminated redundant gyori_keszegh_triangles axiom (m distinct 3-cliques, logically weaker than the partition formula and unused in the file)"
     ],
     "theoremCount": 37,
-    "definitionCount": 6
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "The clique partition problem — decomposing a graph's edges into complete subgraphs — emerged from the interplay of extremal graph theory and combinatorial optimization. Erdős, Goodman, and Pósa (1966) proved the foundational bound $\\text{cp}(G) \\leq \\lfloor n^2/4 \\rfloor$ using a greedy triangle extraction followed by Turán's theorem on the triangle-free remainder. This was connected to earlier work by Mantel (1907) on triangle-free graphs and Turán (1941) on extremal graph density.\n\nThe bound is tight for $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$, which is triangle-free and needs one clique per edge. Erdős asked whether dense graphs (with more than $\\lfloor n^2/4 \\rfloor$ edges) — which must contain triangles by Turán's theorem — allow improvement. Győri and Keszegh (2017) resolved the $K_4$-free case by proving that every excess edge yields an edge-disjoint triangle, reducing the partition count by exactly 1 per excess edge. The general case, when $K_4$ and larger cliques are present, remains open and connects to NP-hard optimization problems in graph decomposition.",

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "2 axioms inherited from Erdos1017OQ01.lean: egp_theorem (Erdős-Gallai-type partitioning theorem), k4free_partition_number (K₄-free partition number bound). gyori_keszegh_triangles was removed. 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 37,
-    "definitionCount": 6
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "The clique partition problem has roots in the early days of graph decomposition theory. The fundamental question—how many complete subgraphs are needed to partition all edges of a graph?—connects to classical work of König (1931) on bipartite matching, Dilworth (1950) on chain decompositions, and the broader program of decomposing combinatorial structures into 'simple' pieces.\n\nErdős, Goodman, and Pósa (1966) proved the elegant theorem that $f(n,k) \\le \\lfloor n^2/4 \\rfloor$ for all $n$ and $k$, where $f(n,k)$ is the minimum number of complete subgraphs needed to partition any graph with $n$ vertices and $k$ edges. Their proof uses only edges ($K_2$'s) and triangles ($K_3$'s)—larger cliques are never required. The key insight is that a maximal set of edge-disjoint triangles leaves behind a triangle-free graph, which by Ramsey theory (or equivalently König's theorem) is bipartite. The triangle-free part then needs at most $\\lfloor n^2/4 \\rfloor$ individual edges for its partition, by Turán's theorem applied to its complement.\n\nThe bound $\\lfloor n^2/4 \\rfloor$ is tight: the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$ (the Turán graph $T(n,2)$) has exactly $\\lfloor n^2/4 \\rfloor$ edges and no triangles, so every edge must be its own clique in any partition. This extremal example is sparse—it has the maximum number of edges a triangle-free graph can have, by Turán's theorem.\n\nErdős then asked the natural follow-up: when $k > n^2/4$ (more edges than any triangle-free graph), the graph *must* contain triangles. Can these triangles be exploited to bring the partition count *below* $n^2/4$? This is the core of Problem #1017.\n\nThe major partial result came from Győri and Keszegh (2017), who completely resolved the $K_4$-free case. They proved: if $G$ is $K_4$-free with $\\lfloor n^2/4 \\rfloor + m$ edges, then $G$ contains $m$ edge-disjoint triangles. Since each triangle replaces 3 edges with 1 clique (saving 2 from the count), the clique partition number drops to $\\lfloor n^2/4 \\rfloor - m$ for such graphs. Their proof uses a sophisticated induction on $m$, combined with the Kruskal-Katona theorem to control the triangle distribution.\n\nThe general case—when $K_4$ and larger cliques are allowed—remains open. The difficulty is combinatorial: larger cliques offer bigger savings ($K_r$ replaces $\\binom{r}{2}$ edges with 1 piece), but edges may belong to multiple overlapping cliques, creating a complex optimization problem related to fractional relaxations and potentially NP-hard in the worst case.",
@@ -192,7 +192,7 @@
     "lineCount": 696,
     "axiomCount": 2,
     "theoremCount": 37,
-    "definitionCount": 6,
+    "definitionCount": 8,
     "path": "Proofs/Erdos1017OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1023-oq-01-problem/meta.json
+++ b/src/data/proofs/erdos-1023-oq-01-problem/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 5
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Erdős problem #1023 asks: what is the maximum size $F(n)$ of a **union-free** family $\\mathcal{F} \\subseteq 2^{[n]}$ — a family where no member $A$ equals the union of other members $B_1 \\cup B_2$? The answer, $F(n) = \\binom{n}{\\lfloor n/2 \\rfloor}$, is achieved by the middle layer (all sets of size $\\lfloor n/2 \\rfloor$), which is a maximum antichain. The key tool is the **LYM inequality** (Lubell 1966, Yamamoto 1954, Meshalkin 1963): for any antichain $\\mathcal{F} \\subseteq 2^{[n]}$, $\\sum_{A \\in \\mathcal{F}} 1/\\binom{n}{|A|} \\leq 1$, which gives $|\\mathcal{F}| \\leq \\binom{n}{\\lfloor n/2 \\rfloor}$.\n\nThe concept of antichains in $2^{[n]}$ was studied by Dilworth (1950), who proved that the maximum antichain has size $\\binom{n}{\\lfloor n/2 \\rfloor}$ — the same bound. Sperner (1928) had already proved this for the specific case of the boolean lattice. The **Bollobás two-families theorem** (1965) generalized this: if $(A_i, B_i)_{i=1}^m$ are pairs with $A_i \\cap B_j = \\emptyset$ iff $i = j$, then $\\sum_{i=1}^m \\binom{|A_i|+|B_i|}{|A_i|}^{-1} \\leq 1$. This is a far-reaching generalization of Sperner's theorem.\n\nOQ-01 extends Erdős #1023 in two directions: **k-union-free** families (forbid $A = B_1 \\cup \\cdots \\cup B_k$ for exactly $k$ sets — more restrictive than plain union-free when $k$ is fixed) and the dual notion of **intersection-free** families ($A \\neq B_1 \\cap \\cdots \\cap B_m$). In the Boolean lattice $2^{[n]}$, these notions are dual via the complement map $A \\mapsto [n] \\setminus A$: a family is union-free if and only if its complement family is intersection-free (De Morgan's law for set families).\n\nThe formalization shows that the same maximum antichain witnesses optimality for all these constrained families simultaneously: middle-layer antichains are k-union-free for all $k$ and intersection-free, establishing the middle layer as a universal extremal object for constrained-coverage families.",
@@ -125,7 +125,7 @@
     "lineCount": 244,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 5,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1023OQ01Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -104,7 +104,7 @@
     ],
     "assumptions": "1 axiom: density_one_conjecture — asserts that the natural density of qualifying primes among all primes equals 1. Formally: for every k, there exists X such that for all x ≥ X, qualifyingPrimeCount(x) * (k+1) ≥ primeCount(x) * k.",
     "theoremCount": 35,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős Problem #1059 asks whether infinitely many primes p satisfy the 'factorial-subtraction' property: every p - k! (with k! < p) is composite. The natural follow-up (OQ-01) asks: what fraction of all primes satisfy this property?\n\nThe probabilistic heuristic gives a compelling answer. For a prime p ∈ (l!, (l+1)!], exactly l+1 factorial differences must be checked. By the Prime Number Theorem, each p - k! is independently prime with probability ≈ 1/ln(p). Since l+1 = O(log p / log log p) and ln(p) grows faster, the expected number of 'bad' differences is O(log p / (log p · log log p)) = O(1/log log p) → 0. This suggests not just infinitely many qualifying primes, but density 1 among all primes.\n\nComputational evidence confirms this picture: among primes up to 769, six satisfy the property (101, 211, 461, 557, 673, 769). The first five are in the 'level 5' range (120, 720) = (5!, 6!], requiring 5–6 checks; the sixth (p = 769) is the first 'level 6' witness in (720, 5040) = (6!, 7!], requiring 7 checks. The formal bound factorialCheckCount(n) ≤ ⌊log₂ n⌋ + 2 proves that the number of checks grows only logarithmically.",
@@ -209,7 +209,7 @@
     ],
     "path": "Proofs/Erdos1059OQ01.lean",
     "sorries": 0,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 169,
     "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated.",
     "theoremCount": 5,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "**Erdős-Selfridge and Binomial Divisibility**\n\nErdős Problem #1063 originates from a 1983 paper by Paul Erdős and John Selfridge on the arithmetic structure of binomial coefficients. They observed that the $k$ consecutive integers $n, n-1, \\ldots, n-k+1$ appearing in the numerator of $\\binom{n}{k} = \\frac{n(n-1)\\cdots(n-k+1)}{k!}$ have a subtle divisibility relationship with $\\binom{n}{k}$ itself. Their key result: for $n \\geq 2k$, it is impossible for ALL $k$ of these integers to divide $\\binom{n}{k}$ — the prime factorization of $k!$ cannot simultaneously cancel every factor.\n\n**The threshold question**: The natural follow-up asks for the least $n_k \\geq 2k$ where all but one of these $k$ integers divide $\\binom{n}{k}$. Computed values are $n_2 = 4$ (since $3 \\mid \\binom{4}{2} = 6$ but $4 \\nmid 6$), $n_3 = 6$, $n_4 = 9$, $n_5 = 12$.\n\n**Monier's bound (1985)**: Louis Monier proved $n_k \\leq k!$ by showing that $n = k!$ satisfies the all-but-one condition — the highly composite structure of $k!$ ensures most nearby factors divide $\\binom{k!}{k}$. This was the first non-trivial result but grows super-exponentially.\n\n**Cambie's improvement**: Stijn Cambie dramatically improved the bound to $n_k \\leq k \\cdot \\text{lcm}(2, \\ldots, k-1)$, which by the prime number theorem ($\\log \\text{lcm}(1, \\ldots, m) = \\psi(m) \\sim m$) gives $n_k \\leq e^{(1+o(1))k}$. The gap between $n_k \\geq 2k$ (trivial) and $n_k \\leq e^{(1+o(1))k}$ remains vast — whether $n_k$ grows polynomially or exponentially is the central open question.",
@@ -230,7 +230,7 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1063Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` (both `leanFile.definitionCount` and the meta sub-block) to
actual counts in 24 gallery proofs.

Counting convention from PR #15533: strip block \`/- ... -/\` and \`--\` line
comments, then match \`\b(def|abbrev|opaque)\s+\w+\`. Earlier batch fix #16002
used a regex that missed lines with multiple modifiers (e.g.,
\`private noncomputable def\`), which introduced drift on those entries.

## Evidence

| slug | old | new |
|------|----:|----:|
| abel-ruffini-oq-04-oq-01 | 7 | 15 |
| amgm-inequality-oq-04-oq-05 | 3 | 6 |
| area-of-circle-oq-01-oq-03 | 11 | 13 |
| ballot-problem-oq-03-oq-02 | 30 | 45 |
| birch-swinnerton-dyer | 143 | 164 |
| borsuk-ulam-oq-04 | 8 | 11 |
| buffons-needle-oq-01-oq-01-oq-01 | 3 | 1 |
| cantor-diagonalization-oq-01-oq-02 | 9 | 10 |
| cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01 | 2 | 3 |
| cevas-theorem-non-euclidean-oq-02-oq-01 | 4 | 3 |
| cevas-theorem-oq-01-oq-03 | 3 | 6 |
| chinese-remainder-constructive-oq-03-oq-03 | 3 | 2 |
| combinations-formula-oq-03-oq-06 | 1 | 0 |
| cramers-rule-oq-01-oq-02-oq-01 | 5 | 4 |
| descartes-rule-of-signs-oq-02-oq-01-oq-02 | 8 | 6 |
| dissection-of-cubes-oq-01-oq-03 | 2 | 1 |
| erdos-1002-oq-01-oq-01 | 4 | 6 |
| erdos-1006-oq-01-oq-02 | 5 | 4 |
| erdos-1012-oq-03 | 9 | 13 |
| erdos-1017 | 6 | 8 |
| erdos-1017-oq-01 | 6 | 8 |
| erdos-1023-oq-01-problem | 5 | 14 |
| erdos-1059-oq-01 | 5 | 6 |
| erdos-1063 | 4 | 5 |

Two-line diffs per file (meta sub-block + leanFile block) preserve all other
formatting via surgical string replacement. Each file gets exactly 2 replacements
matched by field name; numeric values are anchored to \`"definitionCount":\`.

Discovered during gallery integrity scan (mechanic, 2026-05-07).

---
Automated fix by lean-mechanic agent.