### PR TITLE
fix(meta): chebyshev-pnt-bridge-oq-01-oq-02 badge original→mathlib (#16395)

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
@@ -16,11 +16,11 @@
       "factorization",
       "central-binomial"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 sorries and 0 axioms.",
+    "assumptions": "None. 0 sorries and 0 axioms — core argument calls Mathlib's prod_pow_factorization_centralBinom and pow_factorization_choose_le.",
     "lineCount": 79,
     "theoremCount": 1,
     "definitionCount": 0,
@@ -47,7 +47,7 @@
       }
     ],
     "originalContributions": [
-      "centralBinom_le_pow_primeCounting_via_factorization: C(2n,n) ≤ (2n)^π(2n), alternative proof (0 sorries) — answers chebyshev-pnt-bridge-oq-01-oq-02"
+      "centralBinom_le_pow_primeCounting_via_factorization: alternative 4-step calc proof of C(2n,n) ≤ (2n)^π(2n) via Mathlib's prod_pow_factorization_centralBinom (no hcb_ne hypothesis required, vs. 6-step factorization_prod_pow_eq_self approach in ChebyshevPNTBridge.lean) — answers chebyshev-pnt-bridge-oq-01-oq-02"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Fix

Per auditor finding (#16395), `chebyshev-pnt-bridge-oq-01-oq-02` is Tier B (formalized using a Mathlib theorem) — its single 4-step calc theorem wraps `Nat.prod_pow_factorization_centralBinom` and `Nat.pow_factorization_choose_le` (Legendre's bound, the deepest content). Badge `original` overstated the contribution.

Inconsistency: parent `chebyshev-pnt-bridge-oq-01` proves the same theorem from scratch (11 theorems, including Legendre via multiplicity) and is correctly labeled `verified/mathlib`. The 1-theorem child should not claim a stronger badge than the parent.

## Evidence

`meta.json` edits (only):
- `"badge": "original"` → `"badge": "mathlib"`
- `assumptions`: note Mathlib dependency on `prod_pow_factorization_centralBinom` and `pow_factorization_choose_le`
- `originalContributions`: scope to the alternative 4-step calc + absence of `hcb_ne` hypothesis (vs. 6-step `factorization_prod_pow_eq_self` approach in `ChebyshevPNTBridge.lean`)

Numerical fields (`sorries=0`, `axiomCount=0`, `lineCount=79`, `theoremCount=1`, `definitionCount=0`) unchanged.

Closes #16395

---
Automated fix by lean-mechanic agent.