### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-02 — sync sorries 1→0

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 open sorry: gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners). Axiom-free; all axiom declarations are 0.",
@@ -215,5 +215,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

The `gnwProb_key` sorry was proved at some point (lf.sorries already reflects 0), but `meta.sub.sorries` and the top-level `sorries` field still claimed 1.

## Evidence

**Before**: `meta.sorries: 1`, `sorries: 1` (top-level), `lf.sorries: 0`
**After**: All three fields are `0`, matching the actual Lean file.

Verified: `BallotProblemOQ03OQ01OQ02.lean` has 0 sorries after stripping comments.

---
Automated fix by lean-mechanic agent.