### PR TITLE
audit(erdos-183): fix stale assumptions text claiming nonexistent axiom

### DIFF
--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -76,7 +76,7 @@
         "description": "Establishes the lower bound R(3;k) ≥ 380^{k/5} − O(1), a major improvement over previous bounds"
       }
     ],
-    "assumptions": "1 axiom: R3k_exponential_lower (c^k lower bound from Schur numbers). R3k_factorial_upper PROVED from R3k_le_three_factorial (induction on pigeonhole recurrence). R3k_inductive_upper PROVED from extracted pigeonhole step. forcing_set_nonempty PROVED via pigeonhole induction. R3k_one, R3k_two PROVED. Monotonicity PROVED.",
+    "assumptions": "0 axioms. R3k_exponential_lower PROVED via doubling construction (R3k k ≥ 2^k for k ≥ 1, witness c=2). R3k_factorial_upper PROVED from R3k_le_three_factorial (induction on pigeonhole recurrence). R3k_inductive_upper PROVED from extracted pigeonhole step. forcing_set_nonempty PROVED via pigeonhole induction. R3k_one (=3), R3k_two (=6), monotonicity PROVED. The limit lim R(3;k)^{1/k} as k→∞ remains the open question.",
     "theoremCount": 26,
     "definitionCount": 15
   },


### PR DESCRIPTION
## Audit finding

The `meta.assumptions` field for `erdos-183` still asserts:

> "1 axiom: R3k_exponential_lower (c^k lower bound from Schur numbers). ..."

But after PR #16378 (research: prove exponential lower bound via doubling construction), `R3k_exponential_lower` is a **proven theorem** in `proofs/Proofs/Erdos183Problem.lean`:

```lean
theorem R3k_exponential_lower :
    ∃ c : ℝ, c > 1 ∧ ∀ k : ℕ, k ≥ 1 → (R3k k : ℝ) ≥ c ^ k := by
  refine ⟨2, by norm_num, fun k hk => ?_⟩
  ...
```

PR #16391 already synced the numeric counts (`axiomCount: 1 → 0`, `lineCount`, `theoremCount`, `definitionCount`) but the narrative `assumptions` text wasn't updated, leaving an internal contradiction: `axiomCount: 0` vs assumptions text naming a specific (now-proved) axiom.

## Verification

- `grep -c '^axiom ' proofs/Proofs/Erdos183Problem.lean` → 0
- `R3k_exponential_lower` is a `theorem` with a complete proof (no sorry, no axiom)
- `R3k_factorial_upper` is also a real theorem (already proved)
- Open question remains the limit `lim R(3;k)^{1/k}` (encoded as `def ErdosProblem183 : Prop`, not asserted)

## Fix

Updated `meta.assumptions` to:

> "0 axioms. R3k_exponential_lower PROVED via doubling construction (R3k k ≥ 2^k for k ≥ 1, witness c=2). ... The limit lim R(3;k)^{1/k} as k→∞ remains the open question."

This is a 1-line surgical edit — no other fields touched.

## Status & badge

`status: axiomatized` and `badge: axiom` left unchanged per the policy that open conjectures keep `axiomatized` regardless of axiom count. The conjecture itself (the limit) is the standing open question.

---

Filed by lean-auditor.