### PR TITLE
fix(meta): add missing top-level sorries: 0 to 62 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -126,5 +126,6 @@
     "theoremCount": 9,
     "definitionCount": 0,
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/abel-ruffini-oq-10/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-10/meta.json
@@ -182,5 +182,6 @@
     "definitionCount": 1,
     "path": "Proofs/AbelRuffiniOQ10.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -136,5 +136,6 @@
     "theoremCount": 5,
     "definitionCount": 0,
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02/meta.json
@@ -108,5 +108,6 @@
       "MeasureTheory"
     ],
     "namespace": "BallotFPT"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/meta.json
@@ -161,5 +161,6 @@
       "Can ShortIntervalPNT(ε) for ε < 1 be proved, even conditionally on RH? (Currently only ε > 1/2 is known under RH.)",
       "Does the converse hold: does PrimeGapConjecture(ε) for all ε > 0 imply Cramér's conjecture?"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
@@ -130,5 +130,6 @@
       "Mathlib.Tactic",
       "Proofs.BezoutIdentityOQ01OQ01"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
@@ -123,5 +123,6 @@
       "Can Mathlib's ideal FTA be applied concretely to ℤ[√-5] to write out the prime ideal factorization (6) = (2,1+√-5)²·(3,1+√-5)·(3,1-√-5), making the connection between element and ideal factorizations computationally tangible?",
       "For which values of d does ℤ[√d] have class number 1 (i.e., is a UFD/PID), and can Lean verify these computationally? The Stark-Heegner theorem says there are exactly 9 such negative d: -1,-2,-3,-7,-11,-19,-43,-67,-163."
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-03/meta.json
@@ -91,5 +91,6 @@
         "theoremCount": 8,
         "definitionCount": 1,
         "sorries": 0
-    }
+    },
+  "sorries": 0
 }

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -127,5 +127,6 @@
       "id": "bezout-identity",
       "relationship": "root: Bezout's identity — the foundational result formalized in the main entry"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
@@ -119,5 +119,6 @@
       "BigOperators"
     ],
     "namespace": "LGVVandermonde"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
@@ -127,5 +127,6 @@
     "theoremCount": 26,
     "definitionCount": 1,
     "lineCount": 249
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
@@ -147,5 +147,6 @@
     "summary": "The CRT compatibility buDim(n,d) = sup_{prime p|n} buDim(p,d) holds for ALL n ≥ 2 (proved), not just squarefree numbers. For squarefree n = p₁·…·pₖ with distinct primes, this gives buDim(n,d) = max(buDim(pᵢ,d)). The proof uses 0 new axioms beyond the base framework (buDim, buDim_mono, buDim_le_formula). The squarefree generalization to k primes is proved by induction on the Finset of prime factors.",
     "implications": "The CRT compatibility was previously established case-by-case (semiprime n=pq in OQ03, then proved from formula in OQ03-OQ01). This entry shows the result is not special to 2-prime products: it holds for any composite n and follows directly from the formula axiom. The key structural insight is that buDimFormula is *defined* as the sup over prime factors, so the CRT property is literally built into the formula.",
     "openQuestions": []
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-04/meta.json
@@ -128,5 +128,6 @@
       "Real"
     ],
     "namespace": "BorsukUlamOQ03OQ04"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
@@ -139,5 +139,6 @@
       "CauchyCrofton"
     ],
     "namespace": "BuffonsNeedleOQ01OQ01OQ04OQ01"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
@@ -78,5 +78,6 @@
       "id": "cantor-diagonalization-oq-03",
       "relationship": "Sibling: surjection version of Lawvere's FPT"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
@@ -134,5 +134,6 @@
     "sorries": 0,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ02OQ02.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01/meta.json
@@ -99,5 +99,6 @@
       "Extend to modules over commutative Noetherian rings (not just fields)",
       "Use the biconditional to give a shorter RCF existence proof"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
@@ -146,5 +146,6 @@
       "title": "Cayley-Hamilton Minpoly (OQ-02)",
       "relationship": "Grandparent open question in the minimal polynomial line of inquiry."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
@@ -122,5 +122,6 @@
     "sorries": 0,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CircumferenceViaDifferentiationOQ01.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/circumference-via-differentiation/meta.json
+++ b/src/data/proofs/circumference-via-differentiation/meta.json
@@ -96,5 +96,6 @@
     "theoremCount": 13,
     "definitionCount": 2,
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/combinations-formula-oq-01-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-04/meta.json
@@ -127,5 +127,6 @@
     "theoremCount": 12,
     "definitionCount": 2,
     "additionalFiles": []
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
@@ -114,5 +114,6 @@
       "id": "combinations-formula-oq-02",
       "relationship": "grandparent — the original combinations formula entry"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/dissection-of-cubes-oq-03-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03-oq-02/meta.json
@@ -123,5 +123,6 @@
       "DissectionOfCubesOQ03"
     ],
     "namespace": "DissectionOfCubesOQ03OQ02"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
@@ -127,5 +127,6 @@
       "title": "Ehrhart Polynomials for Lattice Polytopes",
       "relationship": "The general Ehrhart theory axiomatizes L_P(n) as a polynomial. This file provides an axiom-free proof for the simplex, complementing the axiomatized framework."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
@@ -148,5 +148,6 @@
       "id": "elementary-quadratic-reciprocity",
       "relationship": "root — the Eisenstein lattice-point proof of QR"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -156,5 +156,6 @@
       "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-03",
       "relationship": "sibling — extends to higher-power reciprocity using Jacobi sums"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-03/meta.json
@@ -164,5 +164,6 @@
       "Ring membership theorem J(χ,χ) ∈ ℤ[ζ_n] — Mathlib has `jacobiSum_mem_algebraAdjoin_of_pow_eq_one`",
       "Quartic reciprocity with explicit Gaussian integer structure — requires ℤ[i] machinery in Mathlib"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
@@ -115,5 +115,6 @@
       "id": "elementary-quadratic-reciprocity",
       "relationship": "grandparent — the main QR formalization"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-1036-oq-01/meta.json
+++ b/src/data/proofs/erdos-1036-oq-01/meta.json
@@ -110,5 +110,6 @@
       "id": "erdos-1036",
       "relationship": "parent: Shelah's theorem (1998) with placeholder ISC count — this entry refines with true ISC and asks for the optimal constant"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-31-primes-density/meta.json
+++ b/src/data/proofs/erdos-31-primes-density/meta.json
@@ -117,5 +117,6 @@
       "Filter"
     ],
     "namespace": "Erdos31PrimesDensity"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -146,5 +146,6 @@
     "sorries": 0,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos895OQ01Problem.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -141,5 +141,6 @@
       "title": "Lagrange Four Squares — Representations via Quaternions",
       "relationship": "Sibling open question exploring representation counts and the role of quaternion arithmetic in the four-squares problem."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -90,5 +90,6 @@
       "Set"
     ],
     "namespace": "FodorPressingDown"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/frobenius-number-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01/meta.json
@@ -105,5 +105,6 @@
     "additionalFiles": [
       "Proofs/FrobeniusNumberOQ02.lean"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -102,5 +102,6 @@
         "theoremCount": 15,
         "definitionCount": 3,
         "sorries": 0
-    }
+    },
+  "sorries": 0
 }

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-04/meta.json
@@ -155,5 +155,6 @@
     "lineCount": 311,
     "theoremCount": 13,
     "definitionCount": 1
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -109,5 +109,6 @@
     "theoremCount": 21,
     "definitionCount": 1,
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
@@ -149,5 +149,6 @@
       "title": "Green's Theorem — Open Questions",
       "relationship": "Grandparent: the Green's theorem open question tree. The Fubini bridge results (this entry and its parent) are foundational infrastructure for Green's theorem in higher dimensions."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-04/meta.json
@@ -161,5 +161,6 @@
       "Can Mathlib's eventual abstract Stokes theorem for manifolds prove greens_theorem_l1curl without Whitney's axiom?",
       "Does the Poincaré lemma extend to the L¹ setting: is every L¹-closed form locally L¹-exact?"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/greens-theorem-oq-03-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03-oq-04/meta.json
@@ -143,5 +143,6 @@
       "endLine": 250,
       "summary": "Documents the abstract equivalence: Mathlib's divergence theorem IS a form of Stokes' theorem with ω = P dx + Q dy, dω = (∂Q/∂x − ∂P/∂y) dx∧dy, M = rectangular region. The summary table lists all 5 theorems with their proof methods and the answer to OQ-04."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/hilbert-10-oq-04/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04/meta.json
@@ -129,5 +129,6 @@
       "relationship": "sibling",
       "description": "Addresses H10 over the rationals (open problem). Related question about decidability thresholds."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
@@ -165,5 +165,6 @@
       "Constructive IVT over computable reals"
     ],
     "goal": "Identify and formalize the exact classical boundary in constructive IVT proofs"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
@@ -128,5 +128,6 @@
       "relationship": "related",
       "description": "Hall's theorem sibling: the positive result (solvable groups have subgroups for every Hall divisor), contrasting with this negative counterexample"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
@@ -188,5 +188,6 @@
       "summary": "Concrete Hall divisor computations for n = 12, 30, and 60, all verified by norm_num. Shows squarefree n (like 30) has all divisors as Hall divisors, while n = 12 has restricted Hall divisors {1, 3, 4, 12}.",
       "mathContext": "Squarefree $n = 30$: all divisors are Hall divisors. $n = 12 = 2^2 \\cdot 3$: Hall divisors are $\\{1, 3, 4, 12\\}$ only; $\\gcd(2, 6) = 2 \\neq 1$ and $\\gcd(6, 2) = 2 \\neq 1$."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01/meta.json
@@ -148,5 +148,6 @@
       "title": "Lagrange's Theorem",
       "relationship": "Grandparent entry. The chain Lagrange → Orbit-Stabilizer → Burnside is formalized in lagrange_orbitstab_burnside_chain, with Lagrange's theorem as the base."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
@@ -185,5 +185,6 @@
       "Can the class equation be used to formally prove the Burnside lemma (number of orbits = average number of fixed points) in Lean 4?",
       "Is the p-group fixed point theorem IsPGroup.card_modEq_card_fixedPoints sufficient to recover the class equation as a special case (conjugation action fixed points = center)?"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
@@ -168,5 +168,6 @@
       "title": "Law of Cosines",
       "relationship": "Planar analogue: c² = a² + b² − 2ab·cos(C). The spherical law of cosines reduces to this as the sphere radius → ∞ (small-angle limit)."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
@@ -259,5 +259,6 @@
       "historicalBackground": "Discovered alongside hyperbolic geometry (Lobachevsky, Bolyai, Gauss, 19th century). The law is the fundamental computational tool for hyperbolic trigonometry, dual to the law of cosines.",
       "significance": "Provides the isoceles criterion and right-angle specialization for hyperbolic triangles, useful in classification and computation in hyperbolic geometry and Thurston's geometrization program."
     }
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/law-of-cosines-oq-04-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-02/meta.json
@@ -179,5 +179,6 @@
       "historicalBackground": "The angle bisector length formula is a classical result in triangle geometry, typically proved via Stewart's Theorem (1746). The angle bisector theorem BD/DC = AB/AC was known to ancient Greek geometers. This formalization makes the algebraic derivation explicit via polynomial witnesses.",
       "significance": "Demonstrates how polynomial linear_combination witnesses can systematically derive non-trivial geometric identities from simpler algebraic hypotheses, providing a model for similar derivations."
     }
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
@@ -155,5 +155,6 @@
       "Does the necessity direction extend to L^p convergence (p > 1)?",
       "Can the layer cake formula be strengthened to give sharp estimates on convergence rates?"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02/meta.json
@@ -172,5 +172,6 @@
       "title": "Central Limit Theorem",
       "relationship": "Complement: the CLT gives rate n^{1/2} and Gaussian limit for L² distributions. M-Z applies when L² fails, giving slower rate n^{1/r} with α-stable (non-Gaussian) limit."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/meta.json
@@ -124,5 +124,6 @@
       "title": "SLLN for Pairwise Independent Random Variables",
       "relationship": "Sibling: explores pairwise independence in the SLLN context more broadly (Etemadi's theorem). BC2 for pairwise independence (this entry) is a lemma in that proof."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/mean-value-theorem-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04/meta.json
@@ -103,5 +103,6 @@
       "Set"
     ],
     "namespace": "MeanValueTheoremOQ04"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/newton-inductive-step-oq-02/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-02/meta.json
@@ -62,5 +62,6 @@
     "path": "Proofs/NewtonInductiveStepOQ02.lean",
     "sorries": 0
   },
-  "openQuestions": null
+  "openQuestions": null,
+  "sorries": 0
 }

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -116,5 +116,6 @@
     "theoremCount": 12,
     "definitionCount": 3,
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -116,5 +116,6 @@
       "import Mathlib.Tactic"
     ],
     "namespace": "PicksTheoremOQ01OQ01"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -122,5 +122,6 @@
     "opens": [
       "Finset"
     ]
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
@@ -67,5 +67,6 @@
       "lean_ref": "freudenthalCellComplex"
     }
   ],
-  "annotations": []
+  "annotations": [],
+  "sorries": 0
 }

--- a/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
@@ -94,5 +94,6 @@
       "lean_ref": "brouwer_fixed_point_simplex"
     }
   ],
-  "annotations": []
+  "annotations": [],
+  "sorries": 0
 }

--- a/src/data/proofs/sperner-ndim-mathlib/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib/meta.json
@@ -149,5 +149,6 @@
       "title": "Sperner Simplicial Bridge",
       "relationship": "Bridges the abstract cell complex version to the concrete simplicial case."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -117,5 +117,6 @@
       "Szemeredi.Regularity"
     ],
     "namespace": "Szemeredi.EnergyIncrement"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
@@ -130,5 +130,6 @@
       "ZMod"
     ],
     "namespace": "WilsonsTheoremOQ02Ext"
-  }
+  },
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

62 gallery entries (mostly created in May 2026) are missing the top-level `sorries` field that the gallery UI reads for badge display. All have `lf.sorries: 0` confirming the correct value is 0.

## Scope

62 entries affected, including recent research additions:
- `bezout-identity-oq-03-oq-03`, `circumference-via-differentiation`, `frobenius-number`, `ehrhart-cube-proven-oq-01`, `newton-inductive-step-oq-02`, `sperner-ndim-mathlib-oq-02`, etc.

## Change

Added `"sorries": 0` as the last field in each top-level JSON object. No other metadata changed. All 62 files parse as valid JSON after the fix.

---
Automated fix by lean-mechanic agent.