### PR TITLE
audit(cantor-diagonalization-oq-04-oq-01): sync meta drift (sorries+thm+lineCount)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
@@ -13,9 +13,9 @@
     ],
     "opens": [],
     "namespace": "CantorDiagonalizationOQ04OQ01",
-    "lineCount": 163,
+    "lineCount": 166,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 8,
     "definitionCount": 3,
     "path": "Proofs/CantorDiagonalizationOQ04OQ01.lean",
     "sorries": 0
@@ -36,6 +36,7 @@
       "generalization"
     ],
     "axiomCount": 0,
+    "sorries": 0,
     "badge": "original"
   },
   "conclusion": "If a type Y with setoid equivalence ≈ codes its own endomorphisms up to ≈ (via encode/decode with decode(encode(f))(y) ≈ f(y)), then for every function f : Y → Y there exists p : Y with f(p) ≈ p. The Type version (exact equality) is the special case of the discrete setoid. Bool and ℕ-mod-2 cannot code their endomorphisms, witnessing the theorem's nontriviality.",


### PR DESCRIPTION
## Summary

Auditor's `find-targets` was looping on `cantor-diagonalization-oq-04-oq-01` with `sorry mismatch: claims -1, actual 0`. PR #16393 (merged yesterday) added the entry but the `meta` sub-object was created without the `sorries` field that `find-targets` reads. Two adjacent count fields were also wrong at creation time.

## Fix

Three surgical edits to `src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json`:

| Field | Before | After | Source of truth |
|---|---|---|---|
| `meta.sorries` | (missing) | `0` | actual Lean file (0 sorries) |
| `leanFile.theoremCount` | `11` | `8` | 8 top-level `theorem` declarations |
| `leanFile.lineCount` | `163` | `166` | `wc -l` on origin/main file |

No Lean source changes. The proof is genuinely 0-sorry, 0-axiom, 0-True-stub — the `verified` / `original` badge is correct. This is a metadata-only drift fix.

Built via plumbing (no working tree) to avoid index contention with concurrent agents.

## Test plan
- [x] Diff verified: 3-line surgical change, no formatting churn
- [ ] After merge: `find-targets --issues` should report 0 issues for this slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)