### PR TITLE
fix(meta): divisibility-by-3-oq-03-oq-02 — restore theoremCount 20→21

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 211,
-    "theoremCount": 20,
+    "theoremCount": 21,
     "definitionCount": 1,
     "assumptions": [],
     "dateAdded": "2026-04-12",
@@ -177,7 +177,7 @@
     "namespace": "DigitalRootBase",
     "lineCount": 211,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 21,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/DivisibilityBy3OQ03OQ02.lean"


### PR DESCRIPTION
## Fix

PR #16384 lowered `theoremCount` from 21 to 20 for `divisibility-by-3-oq-03-oq-02`, but the actual count is 21. Restoring both `meta.theoremCount` and `leanFile.theoremCount` to 21.

## Evidence

The Lean file `proofs/Proofs/DivisibilityBy3OQ03OQ02.lean` contains:
- 1 `private lemma base_mod_pred` (line 41)
- 1 `@[simp] theorem digitalRootBase_zero` (line 54)  ← missed by previous regex
- 19 plain `theorem`s (lines 57–200)

**Total**: 21 theorem/lemma declarations.

The previous mechanic used regex ``^\(private \)\?\(lemma\|theorem\) `` which does not match the `@[simp] theorem` form, causing the off-by-one undercount.

```bash
# attribute-aware count
$ python3 -c "
import re
s = open('proofs/Proofs/DivisibilityBy3OQ03OQ02.lean').read()
s = re.sub(r'/-.*?-/', '', s, flags=re.S)
s = re.sub(r'--.*', '', s)
pat = re.compile(r'^(?:\s*@\[[^\]]+\]\s*)*(?:private\s+|protected\s+|noncomputable\s+|@\[[^\]]+\]\s+)*(theorem|lemma)\s+', re.M)
print(len(pat.findall(s)))
"
21
```

**Before**: meta.theoremCount=20, lf.theoremCount=20 (post-#16384)
**After**: meta.theoremCount=21, lf.theoremCount=21 (matches file)

This is a regression of yesterday's PR #16384 — see also memory note `feedback_auditor_simp_attribute_theorems.md` (theorem regex must allow `@[simp]`/`@[reducible]`/etc prefixes).

---
Automated fix by lean-mechanic agent.