### PR TITLE
fix(meta): batch sync definitionCount drift (9 proofs)

### DIFF
--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -26,7 +26,7 @@
     "lineCount": 1651,
     "mathlib_version": "4.26.0",
     "theoremCount": 116,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about the greatest prime factor of products of consecutive integers. The greatest prime factor P(n) satisfies P(n) → ∞ as n → ∞, but its distribution among products of consecutive integers is much subtler. The ε=1/2 case was established by Erdős himself: there exist arbitrarily long windows of consecutive integers containing a prime exceeding √n. This connects to the Sylvester-Schur theorem (1892), which implies P(n,k) ≥ n+k when k < n — a stronger statement than Bertrand's postulate. The full conjecture — that large prime factors dominate for almost all starting points n, for any threshold n^(1-ε) — remains open and is believed to require new tools from analytic number theory, likely Dickman's ρ-function for smooth number counts in intervals.",
@@ -209,7 +209,7 @@
     "lineCount": 1651,
     "axiomCount": 1,
     "theoremCount": 116,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos1201Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 979,
     "theoremCount": 34,
     "assumptions": "2 axioms: erdos_268_solved (main interior result for all dimensions), harmonicPointSet_path_connected_large (path-connectedness for d ≥ 2, Kovač-Tao structural analysis). 0 sorries. Proved: shifted_summable (decomposition at n=0), harmonicPointSet_nonempty (powers-of-2 witness), harmonicPointSet_dense_somewhere (directly from interior axiom), coordinate_decreasing (tsum_lt_tsum; requires 0 ∉ A), first_coordinate_largest (from coordinate_decreasing), squares_convergent (bijection + p-series), powers_convergent (bijection + geometric series), harmonicPointSet_one_eq (X₁ = positive half-line via greedy construction), harmonicSubseriesSum_surjective_on_pos (every s > 0 is achievable).",
-    "definitionCount": 16
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "**Erdős Problem #268: Interior of Harmonic Subseries Points**\n\nThis problem lies at the intersection of harmonic analysis, number theory, and point-set topology. It originates from a classical question about which real numbers can be represented as sums of distinct unit fractions — a topic with roots in ancient Egyptian mathematics (the Rhind Papyrus, c. 1650 BCE, contains tables of such decompositions, now called Ahmes series or Egyptian fractions).\n\nThe modern formulation involves the set of all infinite subsets A ⊆ ℕ with convergent harmonic subseries Σ_{n∈A} 1/n < ∞. Such sets must be very 'thin' — the harmonic series diverges (proved by Nicole Oresme c. 1350), so A cannot contain too many elements. Examples include {n²} (with sum π²/6, the Basel problem solved by Euler in 1734) and {2ᵏ} (with sum 2, a geometric series).\n\nThe twist in Problem #268 is the passage to higher dimensions: for each qualifying set A, form the d-dimensional point (Σ 1/n, Σ 1/(n+1), ..., Σ 1/(n+d-1)). The set X of all such points is the object of study. Erdős asked: does X have nonempty interior?\n\n**Timeline:**\n- 1950s–60s: Erdős poses the problem, motivated by his work on thin sets and additive number theory\n- Erdős-Straus: Prove the d=2 case using properties of the digamma function ψ(x) and telescoping sum representations\n- Decades of partial results on the 1-dimensional structure of achievable harmonic subseries sums\n- 2024: Kovač proves d=3 with an explicit construction of an open ball inside X₃, giving quantitative geometric information\n- 2024: Kovač and Tao prove the full result for all d ≥ 1, connecting the problem to the theory of Ahmes series and showing that the richness of Egyptian fraction representations guarantees interior in every dimension\n\nThe result is surprising: despite the severe sparsity constraint on A, the resulting points fill out an open region in ℝᵈ. This reflects a deep phenomenon — the space of 'thin' infinite subsets of ℕ is itself rich enough to parameterize open sets in arbitrary dimension.",
@@ -214,7 +214,7 @@
     "lineCount": 979,
     "axiomCount": 2,
     "theoremCount": 34,
-    "definitionCount": 16,
+    "definitionCount": 17,
     "sorries": 0,
     "path": "Proofs/Erdos268Problem.lean",
     "additionalFiles": [

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 6 sorries: congruent_implies_similar (sorry pending), squares_dissectable, two_squares_dissectable, three_squares_dissectable, six_squares_dissectable, sum_squares_dissectable (all pending explicit dissection constructions with Heron-formula area equality). The Dissection structure was strengthened from a placeholder positivity condition to a proper area-partition requirement via Heron's formula — removing a prior internal inconsistency where trivial constant-function witnesses made IsDissectable provable for all n ≥ 1, contradicting the Beeson axioms.",
     "lineCount": 331,
     "theoremCount": 16,
-    "definitionCount": 17
+    "definitionCount": 18
   },
   "overview": {
     "historicalContext": "**Triangle Dissection Problem — A Bridge Between Geometry and Number Theory**\n\nPaul Erdős posed this problem with a $25 prize, asking for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The problem appears in Erdős and Graham's 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*.\n\n**Known Positive Results**: The most natural construction uses **grid subdivision**: dividing each side of a triangle into $k$ equal parts produces $k^2$ congruent triangles. More sophisticated constructions yield $2k^2$ (via right triangle reflections), $3k^2$ (via equilateral triangle trisections), $6k^2$ (combining both), and $k^2 + m^2$ (via a two-scale grid). The special case $n = 27$ also works via an equilateral triangle construction that does not fit any of these parametric families.\n\n**Known Negative Results**: Michael Beeson proved in 2012 that no triangle can be dissected into exactly 7 or 11 congruent triangles, using exhaustive geometric case analysis of the possible edge-matching patterns at vertices. Both 7 and 11 are primes of the form $4k + 3$, which led to the conjecture that all such primes (except 3, which is $3 \\cdot 1^2$) are non-dissectable.\n\n**The Similar Case**: Alexander Soifer completely solved the analogous problem for *similar* (rather than congruent) triangles in his 1990 book *How Does One Cut a Triangle?*: all $n \\geq 1$ except 2, 3, and 5 admit similar dissections. The stark contrast between the similar and congruent cases highlights how rigidity (disallowing scaling) fundamentally changes the combinatorics.\n\n**Open**: The case $n = 19$ (the next prime of form $4k + 3$) remains unknown, and the complete characterization is still open with the $25 prize unclaimed.",
@@ -199,7 +199,7 @@
     "lineCount": 331,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 17,
+    "definitionCount": 18,
     "sorries": 6,
     "path": "Proofs/Erdos634Problem.lean"
   },

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
-    "definitionCount": 7
+    "definitionCount": 9
   },
   "sections": [
     {
@@ -125,7 +125,7 @@
     "lineCount": 164,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 7,
+    "definitionCount": 9,
     "path": "Proofs/Erdos661Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 286,
     "assumptions": "2 axioms: nk_exists_witness (existence of threshold n_k for k≥3) and martinez_roldan_pensado (polynomial bound n_k≪k⁹). minimalNk is now a derived noncomputable definition via sInf; minimalNk_valid and minimalNk_sharp are proved theorems.",
     "theoremCount": 17,
-    "definitionCount": 11
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "**Erdős Problem #827: Distinct Circumradii in General Position**\n\nErdős posed this problem in 1975, asking a Ramsey-type question in discrete geometry: how many points in general position are needed to guarantee a $k$-element subset where all $\\binom{k}{3}$ triples have distinct circumradii? This is a geometric analog of classical Ramsey problems — instead of coloring edges, we seek 'rainbow' configurations where all circumradii are distinct.\n\n**General Position:** The 'no three collinear' assumption ensures every triple determines a unique circumscribed circle with a well-defined radius. Without this, degenerate triples could have infinite circumradius, making the problem ill-defined.\n\n**Erdős's Error (1978):** Erdős claimed a bound of $n_k \\leq k + 2\\binom{k-1}{2}\\binom{k-1}{3} = \\Theta(k^6)$, but the proof contained errors. The argument used a greedy/Ramsey approach to select points with increasingly constrained circumradii, but incorrectly counted the number of constraints.\n\n**Correction by Martinez-Roldán-Pensado:** They salvaged the approach, correcting the counting argument to establish $n_k \\ll k^9$. The increased exponent (9 vs 6) reflects the need to account for more complex interactions between triples.\n\n**The Gap:** The trivial lower bound $n_k \\geq k$ (need at least $k$ points for a $k$-subset) leaves a gap of 8 orders of magnitude in the exponent. Determining the true growth rate — is it closer to $k$, $k^2$, or $k^9$? — is the central open question.\n\n**Connection to Distinct Distances:** This problem is spiritually related to Erdős's 1946 distinct distances problem (how many distinct distances must $n$ points determine?), solved by Guth-Katz (2015). Both ask about the 'diversity' of geometric measurements from point configurations.",
@@ -160,7 +160,7 @@
     "lineCount": 286,
     "axiomCount": 2,
     "theoremCount": 17,
-    "definitionCount": 11,
+    "definitionCount": 13,
     "path": "Proofs/Erdos827Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 717,
     "assumptions": "1 axiom: erdos_831_growing (h(n) → ∞ as n → ∞ — the central open question). h(4)=1 (corrected), h_upper_bound, and h_three all proved. 23 theorems, 0 sorries.",
     "theoremCount": 23,
-    "definitionCount": 13
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "**Erdős Problem #831**\n\nThis geometric extremal problem was posed by Erdős in the 1970s and revisited in the 1990s, documented in [Er75h] and [Er92e].\n\n**Key History:**\n- Erdős asked about the minimum number of distinct circumradii from point configurations\n- Related to classical problems about point-line and point-circle incidences\n- Connects to the unit distance problem and orchard problem\n\n**Mathematical Setting:**\nGiven n points in general position (no three collinear, no four concyclic), each triple determines a unique circumcircle. The question is: over all such configurations, what is the minimum number of distinct radii among these circles?",
@@ -189,7 +189,7 @@
     "lineCount": 717,
     "axiomCount": 1,
     "theoremCount": 23,
-    "definitionCount": 13,
+    "definitionCount": 17,
     "path": "Proofs/Erdos831Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-01/meta.json
@@ -62,7 +62,7 @@
       }
     ],
     "theoremCount": 11,
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Gödel's 1931 incompleteness theorem used ω-consistency as a hypothesis: if the system proves ∃n P(n), then the system is not ω-consistent if it also proves ¬P(n̄) for every specific n. Many logicians felt this was an 'unnatural' or overly strong assumption. J. Barkley Rosser (1936) addressed this by constructing a different self-referential sentence that makes the unprovability argument work under plain consistency alone.\n\nRosser's modification is now the standard form of the First Incompleteness Theorem. Every modern statement of Gödel's theorem uses 'consistent' rather than 'ω-consistent' — Rosser's improvement is invisible in the standard formulation but is mathematically essential.",
@@ -191,7 +191,7 @@
     "lineCount": 308,
     "sorries": 0,
     "path": "Proofs/GodelFirstIncompletenessOQ01OQ01.lean",
-    "definitionCount": 5,
+    "definitionCount": 4,
     "theoremCount": 11
   }
 }

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "None. Constructive core (Parts I-V) uses no classical axioms. Endpoint convergence (Part VI) uses Classical.choice via Mathlib's tendsto_atTop_ciSup (completeness of \u211d). Root theorem (Part VII) uses Continuous.tendsto.",
     "lineCount": 308,
     "theoremCount": 13,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "originalContributions": [
       "paramBisect: computable (non-noncomputable) bisection parameterized by explicit choice oracle",
       "paramBisect_width: exact width formula (b-a)/2^n for any choice sequence \u2014 no classical logic",
@@ -148,7 +148,7 @@
   "leanFile": {
     "path": "Proofs/IntermediateValueTheoremOQ02OQ03.lean",
     "theoremCount": 13,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "axiomCount": 0,
     "lineCount": 308,
     "sorries": 0

--- a/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "3 axioms: picks_theorem (Pick's formula A=i+B/2-1, matching the gallery's axiomatized PicksTheorem.lean), scaled_area (Area(tP)=t²A), scaled_boundary (|∂(tP)|=t·B for t≥1). The rectangle and triangle Ehrhart polynomials are proved with 0 axioms via Finset combinatorics.",
     "lineCount": 309,
     "theoremCount": 24,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "originalContributions": [
       "rectangle_ehrhart: L(R_{a,b},t) = (ta+1)(tb+1) via Finset.card_product (0 axioms)",
       "triangle_ehrhart_double: 2·L(Δ_n,t) = (tn+1)(tn+2) via Nat.antidiagonal biUnion + Gauss sum (0 axioms)",
@@ -112,7 +112,7 @@
     "path": "Proofs/PicksTheoremOQ01OQ02.lean",
     "lineCount": 309,
     "theoremCount": 24,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "axiomCount": 3,
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` (both `leanFile.definitionCount` and the meta sub-block) to actual counts in 9 gallery proofs. `find-targets.ts` only flags True-stubs/sorry/axiom drift; `definitionCount` drift slips through.

Counting convention from PR #15533: strip block `/- ... -/` and `--` line comments, then match `\b(def|abbrev|opaque)\s+\w+`.

## Evidence

| slug | old | new |
|------|----:|----:|
| erdos-1201 | 7 | 8 |
| erdos-831 | 13 | 17 |
| erdos-827 | 11 | 13 |
| erdos-634 | 17 | 18 |
| erdos-661 | 7 | 9 |
| erdos-268 | 16 | 17 |
| intermediate-value-theorem-oq-02-oq-03 | 3 | 4 |
| picks-theorem-oq-01-oq-02 | 7 | 6 |
| godel-first-incompleteness-oq01-oq-01 | 5 | 4 |

Two-line surgical diffs per file (meta sub-block + `leanFile` block) preserve all other formatting via anchored regex on `"definitionCount":`.

Discovered during gallery integrity scan over 5-day Lean-file change history (auditor, 2026-05-07).

---
Automated fix by lean-auditor agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)