### PR TITLE
fix(meta): batch sync definitionCount drift (8 proofs)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -45,7 +45,7 @@
     "assumptions": "No axioms. Fully verified — all sorries eliminated including the generalized counting formula via binomial coefficient identities.",
     "mathlib_version": "4.26.0",
     "theoremCount": 57,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "The classical Ballot Problem was posed by Joseph Bertrand in 1887 in the *Comptes Rendus*: if candidate A receives $p$ votes and B receives $q$ votes ($p > q$), the probability that A leads throughout counting is $(p-q)/(p+q)$. Désiré André gave the first proof using the **reflection principle** (1887), mapping unfavorable sequences to their reflections across the axis. W.A. Whitworth independently discovered the result using a direct combinatorial argument. In 1947, Aryeh Dvoretzky and Theodore Motzkin proved the **Cycle Lemma** in the *Proceedings of the National Academy of Sciences*, which gives a far more general and elegant proof: for any integer sequence with positive sum $S$ and length $n$, exactly $S$ of its $n$ cyclic rotations have all positive prefix sums. This immediately implies the ballot theorem and its $k$-fold generalization. The cycle lemma has since found applications in lattice path enumeration, queueing theory, and the analysis of random trees (Raney's theorem).",
@@ -284,7 +284,7 @@
     "lineCount": 789,
     "axiomCount": 0,
     "theoremCount": 57,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "mainTheorems": [
       {
         "name": "cycle_lemma",

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -25,7 +25,7 @@
         "lineCount": 475,
         "theoremCount": 37,
         "assumptions": "0 axioms, 0 sorries. gFunc_exists proved constructively via Kummer's theorem (carry-free base-p arithmetic). gFunc defined via Nat.find; gFunc_gt, gFunc_spec, gFunc_minimal proved as theorems. Concrete values g(1)=3, g(2)=6, g(3)=7, g(4)=7, g(5)=23, g(6)=62 all verified. Open conjecture; supporting lemmas fully verified.",
-        "definitionCount": 4
+        "definitionCount": 5
     },
     "overview": {
         "historicalContext": "The function $g(k)$ — the smallest $n > k+1$ such that every prime factor of $\\binom{n}{k}$ exceeds $k$ — was introduced by Ecklund, Erdős, and Selfridge in their 1974 paper on smooth binomial coefficients. They established the initial bounds $k^{1+c} < g(k) \\leq \\exp((1+o(1))k)$, showing that $g(k)$ grows faster than any polynomial but no faster than exponential.\n\nThe lower bound was substantially improved by Konyagin, who proved $g(k) \\gg \\exp(c(\\log k)^2)$ using estimates on smooth numbers (integers whose prime factors are all below a given bound). The key insight is that $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$, and avoiding all primes $\\leq k$ requires $n$ to be chosen so that the prime factorization of the numerator $n(n-1)\\cdots(n-k+1)$ has no small prime factors surviving the cancellation with $k!$.\n\nErdős, Lacampagne, and Selfridge conjectured that $\\log g(k) \\sim c \\cdot k / \\log k$ for some positive constant $c$, which would place $g(k)$ at a precise intermediate growth rate between polynomial and exponential. Computational evidence by Sorenson, Sorenson, and Webster supports this conjecture, but it remains open. The problem connects to smooth number theory, sieve methods, and the distribution of prime factors in products of consecutive integers.",
@@ -151,7 +151,7 @@
         "lineCount": 475,
         "axiomCount": 0,
         "theoremCount": 37,
-        "definitionCount": 4,
+        "definitionCount": 5,
         "path": "Proofs/Erdos1095OQ01Problem.lean",
         "sorries": 0
     },

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -67,7 +67,7 @@
     "lineCount": 723,
     "assumptions": "Fully verified: 0 axioms, 0 sorries. vose_bounded_sequence proved via trivial witness (constant sequence n_k = 2, h_α(2) = 1). All 34 theorems machine-checked.",
     "theoremCount": 36,
-    "definitionCount": 7
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1099** was posed by Erdős in 1981 as part of his study of divisor structure. The problem asks about the regularity of divisor gaps: can we find integers whose consecutive divisor ratios are all close to 1?\n\n**Historical Development:**\n- **1981 (Erdős [Er81h]):** Posed the problem, noting that n! and lcm{1,...,n} seem like good candidates.\n- **1984 (Vose [Vo84]):** Resolved the problem affirmatively by constructing a specific sequence with bounded h_α.\n\n**Key Insight:** The question is about how \"smooth\" the divisor structure of integers can be. While primes have terrible divisor gaps (ratio = p), and even powers of 2 grow linearly in h_α, Vose showed there exist numbers with much smoother divisor distributions.",
@@ -323,7 +323,7 @@
     "lineCount": 723,
     "axiomCount": 0,
     "theoremCount": 36,
-    "definitionCount": 7,
+    "definitionCount": 10,
     "path": "Proofs/Erdos1099Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "1 axiom: gerver_ramsey_2d (Gerver-Ramsey 2D theorem, published result). Proved: erdos193_rank_le_2 (reduction to 2D via projection + Gerver-Ramsey), plus 17 other theorems including collinearity properties, dimension-1 case, singleton/parallel step sets, and dimension reduction framework.",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Joseph Gerver and L. Thomas Ramsey posed this problem in 1979 while studying self-avoiding walks on integer lattices with bounded step sets. They proved that in $\\mathbb{Z}^2$, every infinite injective $S$-walk must contain three collinear points, using a pigeonhole argument on the finitely many directions determined by the step set. The argument exploits the fact that in two dimensions, finitely many step directions constrain visited points to finitely many slopes from the origin, forcing three points to lie on a common line. Erdős recorded the problem and highlighted the open three-dimensional case, where the vastly larger direction space ($S^2$ vs. $S^1$) prevents the same pigeonhole approach. The problem connects to broader questions about unavoidable geometric patterns in discrete walks, a theme running through Erdős's work on combinatorial geometry from the 1970s onward. The 3D case has resisted all approaches for over 40 years and remains one of the most accessible yet stubbornly open problems in lattice combinatorics.",
@@ -164,7 +164,7 @@
     "lineCount": 403,
     "axiomCount": 1,
     "theoremCount": 19,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos193Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-513/meta.json
+++ b/src/data/proofs/erdos-513/meta.json
@@ -31,7 +31,7 @@
     "assumptions": "4 axioms: maxTerm_le_maxModulus, kovari_lower_bound, clunie_hayman_upper_bound, erdos_513_exact_value. maxModulus and maxModulus_nonneg were proved from Mathlib. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 3
+    "definitionCount": 5
   },
   "crossReferences": [
     {
@@ -132,7 +132,7 @@
     "lineCount": 167,
     "axiomCount": 4,
     "theoremCount": 11,
-    "definitionCount": 3,
+    "definitionCount": 5,
     "path": "Proofs/Erdos513Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -63,7 +63,7 @@
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 11
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "The pinned distance problem is a stronger variant of the famous Erdős distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErdős posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,√n} × {1,...,√n} shows the answer cannot exceed O(n/√log n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal Ω(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} ≈ n^{0.864} in 2004 using entropy methods.",
@@ -189,7 +189,7 @@
     "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos604Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -65,7 +65,7 @@
     "assumptions": "4 axiom declarations (cpq_lower_ramsey, cpq_upper_ramsey, cpq_at_max, efrs_bound) encoding deep mathematical results. Previously 8 axioms; 4 eliminated by defining cpq via Filter.liminf and proving cpq_nonneg, cpq_le_one, cpq_mono_q from the definition.",
     "mathlib_version": "4.26.0",
     "theoremCount": 36,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "crossReferences": [
     {
@@ -198,7 +198,7 @@
     "lineCount": 515,
     "axiomCount": 4,
     "theoremCount": 36,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos667Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -82,7 +82,7 @@
     "lineCount": 271,
     "assumptions": "2 axioms: korshunov_theorem (Hamiltonicity a.a.s. above (1/2+ε)n log n) and komlos_szemeredi_theorem (limiting probability e^{-e^{-2c}}). Probabilistic statements use opaque AlmostSurely/ProbInGnm predicates since full formalization requires a measure space on graphs.",
     "theoremCount": 7,
-    "definitionCount": 17
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "**The Erdős-Rényi Random Graph Revolution**\n\nErdős and Rényi's 1959–1966 papers on random graphs $G(n, m)$ revolutionized combinatorics by introducing probabilistic methods to study graph properties. They discovered that many graph properties exhibit **sharp thresholds**: the property jumps from almost surely absent to almost surely present as $m$ crosses a critical value.\n\n**The Matching-Hamiltonicity Connection**\n\nIn 1966, Erdős and Rényi proved that $G(n, m)$ with $m \\ge (1/2 + \\varepsilon) n \\log n$ almost surely has a perfect matching. Since a Hamiltonian cycle decomposes into two perfect matchings, they conjectured the same threshold for Hamiltonicity — one of the most natural questions in random graph theory.\n\n**The Path to Resolution**\n\nPósa (1976) proved Hamiltonicity for $Cn \\log n$ edges using his **rotation-extension technique**, a landmark method that became central to probabilistic combinatorics. Korshunov (1977) established the sharp threshold as $(1/2) n \\log n + (1/2) n \\log \\log n + o(n)$, confirming Erdős-Rényi's conjecture. Finally, Komlós and Szemerédi (1983) determined the precise limiting distribution: with $m = (1/2) n \\log n + (1/2) n \\log \\log n + cn$ edges, $\\Pr[\\text{Hamiltonian}] \\to e^{-e^{-2c}}$ — a **Gumbel (double exponential)** distribution.\n\n**The Threshold Coincidence**\n\nRemarkably, the Hamiltonicity threshold coincides with the connectivity threshold. Both are controlled by the same bottleneck: vertices of degree 0 or 1. The factor 2 in the Gumbel exponent $e^{-2c}$ reflects the two failure modes (degree 0 and degree 1) at the critical edge count.",
@@ -229,7 +229,7 @@
     "lineCount": 271,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 17,
+    "definitionCount": 19,
     "path": "Proofs/Erdos746Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` (both `meta.definitionCount` and `leanFile.definitionCount`) to actual counts in 8 gallery proofs. `find-targets.ts` only flags True-stubs/sorry/axiom drift; `definitionCount` drift slips through.

Counting convention from PR #15533: strip block `/- ... -/` and `--` line comments, then match `\b(def|abbrev|opaque)\s+\w+` (with optional `@[..]` / `private` / `protected` / `noncomputable` prefixes).

## Evidence

| slug | old | new |
|------|----:|----:|
| ballot-problem-oq-01 | 8 | 9 |
| erdos-1099 | 7 | 10 |
| erdos-193 | 10 | 11 |
| erdos-513 | 3 | 5 |
| erdos-604 | 11 | 10 |
| erdos-667 | 5 | 6 |
| erdos-746 | 17 | 19 |
| erdos-1095-oq-01 | 4 | 5 |

Two-line surgical diffs per file (meta sub-block + `leanFile` block). No `additionalFiles` in any of these entries; primary file count is the entire definitionCount.

Distinct from PR #16407 (different 9 proofs).

---
Automated fix by lean-mechanic agent.
