### PR TITLE
fix(meta): angle-trisection-oq-02-oq-01-oq-01 — sync theoremCount 5→1

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
@@ -43,7 +43,7 @@
     "axiomCount": 0,
     "assumptions": "No axioms. Uses natDegree_dvd_card_gal from parent file (also 0 axioms). The theorem prime_degree_dvd_card_from_general is fully proved.",
     "lineCount": 123,
-    "theoremCount": 5,
+    "theoremCount": 1,
     "definitionCount": 0
   },
   "overview": {
@@ -167,7 +167,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 1,
     "imports": [
       "Proofs.AngleTrisectionOQ02OQ01"
     ]


### PR DESCRIPTION
## Fix

Both `meta.theoremCount` and `leanFile.theoremCount` were `5`, but the Lean file `Proofs/AngleTrisectionOQ02OQ01OQ01.lean` contains only **1** actual theorem declaration: `prime_degree_dvd_card_from_general`.

## Evidence

The other 4 "theorems" picked up by older regex passes are **code examples inside Lean docstrings** (`/- ... -/`) demonstrating the planned Mathlib contribution `natDegree_dvd_card`. They are not real declarations.

Verified with the same nested-block-comment-aware stripper (`stripLeanComments`) used by `scripts/auditor/find-targets.ts`:

```python
# After proper nested /-...-/ comment stripping:
theorem prime_degree_dvd_card_from_general
# (only declaration — everything else is documentation)
```

The Lean file structure:
1. L49–55: the only real `theorem prime_degree_dvd_card_from_general`
2. L67–75: `theorem natDegree_dvd_card` — inside `/- ### Changes to Mathlib... -/` docstring
3. L96–100: `theorem prime_degree_dvd_card` (deprecated stub) — also inside the same docstring

A naive `^theorem` regex without nested-comment handling sees these as 3 declarations; the nested `/-- ... -/` doc comment for the real theorem makes the simple version count more.

## Diff

```diff
-    "theoremCount": 5,
+    "theoremCount": 1,
```

(applied to both `meta.theoremCount` and `leanFile.theoremCount`).

Numerical fields `lineCount=123`, `definitionCount=0`, `axiomCount=0`, `sorries=0` are correct.

---
Automated fix by lean-mechanic agent.