### PR TITLE
fix(meta): batch sync theoremCount/lineCount drift (5 proofs)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -99,7 +99,7 @@
     "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 26,
+    "theoremCount": 25,
     "definitionCount": 3
   },
   "crossReferences": [
@@ -303,7 +303,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 26,
+    "theoremCount": 25,
     "substantiveTheoremCount": 17,
     "privateHelperCount": 6,
     "axiomDeclCount": 2,

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms. tmul_infinite_order_ne_zero (flatness of \u211d over \u2124) is proved in DissectionOfCubesOQ02OQ02.lean via Mathlib Module.Flat \u2124 \u211d (B\u00e9zout + NoZeroSMulDivisors) and lTensor_preserves_injective_linearMap. icoAngle_irrational (arccos(-\u221a5/3)/\u03c0 irrational) is proved here via Chebyshev integer sequence for arccos(1/9). DissectionOfCubesOQ04.lean has 0 axiom declarations and 0 sorries; OQ02OQ02 import chain is also axiom-free.",
     "lineCount": 561,
-    "theoremCount": 25,
+    "theoremCount": 23,
     "definitionCount": 4,
     "mathlibDependencies": [
       {
@@ -186,7 +186,7 @@
   "leanFile": {
     "path": "Proofs/DissectionOfCubesOQ04.lean",
     "lineCount": 561,
-    "theoremCount": 25,
+    "theoremCount": 23,
     "definitionCount": 4,
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -23,7 +23,7 @@
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 375,
-    "theoremCount": 21,
+    "theoremCount": 19,
     "definitionCount": 12
   },
   "sections": [
@@ -155,7 +155,7 @@
     "lineCount": 375,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 19,
     "lemmaCount": 10,
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
@@ -51,7 +51,7 @@
       "Key technique: Integrable.integral_prod_right avoids separate measurability lemmas",
       "Axiomatized general n-dim order independence for arbitrary permutations"
     ],
-    "lineCount": 275,
+    "lineCount": 266,
     "theoremCount": 10,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
@@ -69,7 +69,7 @@
       "Topology"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ01",
-    "lineCount": 275,
+    "lineCount": 266,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 1,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 52,
+    "theoremCount": 40,
     "definitionCount": 20
   },
   "overview": {
@@ -217,7 +217,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 52,
+    "theoremCount": 40,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `theoremCount` (both `meta` sub-block and `leanFile` block) to actual counts verified by regex scan against `origin/main` Lean sources. Also sync one `lineCount` drift.

## Evidence

| slug | field | old | new |
|------|-------|----:|----:|
| amgm-inequality-oq-02 | theoremCount | 26 | 25 |
| dissection-of-cubes-oq-04 | theoremCount | 25 | 23 |
| erdos-662 | theoremCount | 21 | 19 |
| lebesgue-measure-oq-06 | theoremCount | 52 | 40 |
| greens-theorem-oq-01-oq-01-oq-01 | lineCount | 275 | 266 |

Counting convention (from PR #15533): strip block `/- ... -/` and `--` line comments, then match `theorem|lemma` keywords with optional `private/protected/noncomputable/@[attr]` prefixes.

`find-targets.ts` only checks True-stubs/sorry/axiom drift; theoremCount and lineCount drift slips through. Discovered by full-gallery scan (2026-05-07).

---
Automated fix by lean-mechanic agent.