### PR TITLE
fix(meta): batch sync definitionCount drift (28 proofs)

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
@@ -52,7 +52,7 @@
       }
     ],
     "theoremCount": 32,
-    "definitionCount": 0
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The Galois group computation for cos(π/7) is a classical exercise in algebraic number theory, first implicit in Gauss's 1801 *Disquisitiones Arithmeticae* where he characterized constructible regular polygons. The regular heptagon (7-gon) is not constructible by straightedge and compass because [ℚ(cos(2π/7)):ℚ] = 3, which is not a power of 2 — precisely the fact this proof establishes. The minimal polynomial 8X³−4X²−4X+1 arises from the 14th cyclotomic field: cos(π/7) = (ζ₁₄ + ζ₁₄⁻¹)/2 where ζ₁₄ = e^{2πi/14}, and the maximal real subfield ℚ(ζ₁₄)⁺ = ℚ(cos(π/7)) has degree φ(14)/2 = 3 over ℚ. The three roots cos(π/7), cos(3π/7), cos(5π/7) form a single Galois orbit under the automorphism α ↦ 1−2α² (corresponding to ζ₁₄ ↦ ζ₁₄⁵), giving the cyclic Galois group ℤ/3ℤ. This computation is a key example in the theory of totally real abelian extensions.",
@@ -183,7 +183,7 @@
     "lineCount": 416,
     "axiomCount": 0,
     "theoremCount": 32,
-    "definitionCount": 0,
+    "definitionCount": 4,
     "sorries": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ01.lean"
   }

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
@@ -66,7 +66,7 @@
       }
     ],
     "theoremCount": 28,
-    "definitionCount": 0
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The minimal polynomial of cos(2π/5) = cos(72°) is 4X²+2X−1, derived from the 5th cyclotomic polynomial Φ₅(X) = X⁴+X³+X²+X+1: substituting X = e^{2πi/5} and taking real parts gives cos(2π/5) + cos(4π/5) = −1/2 and cos(2π/5)·cos(4π/5) = −1/4 (Vieta's formulas on the degree-2 real subpolynomial). Clearing denominators yields 4α²+2α−1=0.\n\nThe constructibility of the regular pentagon is ancient: Euclid's *Elements* Book IV gives an explicit ruler-and-compass construction (Proposition 11). But WHY it is constructible — and what distinguishes the pentagon from the heptagon — was first explained algebraically by Carl Friedrich Gauss in 1801. In *Disquisitiones Arithmeticae* §365–366, Gauss proved the extraordinary result that the regular 17-gon (heptadecagon) is constructible by ruler and compass, after 2,000 years of apparent impossibility. His general criterion: a regular n-gon is constructible if and only if n = 2^a · p₁ · p₂ · ··· · pₖ where each pᵢ is a distinct Fermat prime (of the form 2^{2^m}+1). For n = p prime: the p-gon is constructible iff p = 2^{2^m}+1 is a Fermat prime. The regular pentagon (p=5=2^{2^1}+1) is constructible; the regular heptagon (p=7, not a Fermat prime) is not.\n\nThe impossibility of angle trisection was settled by Pierre Wantzel in 1837: to trisect a general angle of 60°, one would need cos(20°) to be constructible, but [ℚ(cos(20°)):ℚ] = 3 (not a power of 2), so it is impossible. Wantzel's proof used the same degree criterion that Gauss had employed positively. This formalization establishes the degree-2 base case: |Gal(4X²+2X−1/ℚ)| = 2 confirms [ℚ(cos(72°)):ℚ] = 2 = 2¹, making the regular pentagon constructible — the algebraic explanation of Euclid's 2,300-year-old construction.",
@@ -238,7 +238,7 @@
     "lineCount": 462,
     "axiomCount": 0,
     "theoremCount": 28,
-    "definitionCount": 0,
+    "definitionCount": 4,
     "sorries": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ03OQ01.lean"
   }

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
@@ -30,7 +30,7 @@
       "Main theorem: |Gal(8X³−6X+1/ℚ)| = 3"
     ],
     "theoremCount": 32,
-    "definitionCount": 0
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The impossibility of angle trisection by compass and straightedge was proved by Wantzel (1837), using the then-new theory of algebraic extensions. The key insight: a 60° angle cannot be trisected because 20° has cosine satisfying the irreducible cubic 8X³−6X−1 = 0, and [ℚ(cos(20°)):ℚ] = 3 is not a power of 2. Galois theory, developed by Évariste Galois before his death in 1832 (but published posthumously in 1846), gave a more conceptual framework: the Galois group of the minimal polynomial determines constructibility.\n\nThe polynomial 8X³−6X+1 is the minimal polynomial of cos(40°) = cos(2π/9) over ℚ. Its three roots are cos(40°), cos(80°), cos(160°), arising from the triple-angle identity cos(3·40°) = cos(120°) = −1/2. The Eisenstein irreducibility argument uses the shift Y=2X−2, which transforms the polynomial into Y³+6Y²+9Y+3 — Eisenstein at p=3. The analogous shift Y=2X+2 works for the cos(20°) polynomial 8X³−6X−1. Both shifts are discovered by looking at where the polynomial takes the value 0: the roots of 8X³−6X±1 are close to ±1/2, and centering the variable near these values produces the p-divisibility structure needed for Eisenstein.\n\nThis result is part of a family: the Galois groups of 8X³−6X−1 (cos(20°)/cos(π/9)), 8X³−6X+1 (cos(40°)/cos(2π/9)), and 8X³−4X²−4X+1 (cos(π/7)) all have order 3. In all three cases, the splitting field is a cyclic extension of degree 3 over ℚ, and the Galois group is ℤ/3ℤ. This is the minimal non-trivial case of the general pattern for cos(2π/p) with odd prime p: the Galois group is cyclic of order (p−1)/2 = 1, 3, 5, ... for p = 3, 7, 11, ...",
@@ -144,7 +144,7 @@
     "lineCount": 434,
     "axiomCount": 0,
     "theoremCount": 32,
-    "definitionCount": 0,
+    "definitionCount": 4,
     "path": "Proofs/AngleTrisectionCos20GalOQ03.lean",
     "sorries": 0
   },

--- a/src/data/proofs/angle-trisection-cos-20-gal/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 474,
     "theoremCount": 33,
-    "definitionCount": 0,
+    "definitionCount": 4,
     "originalContributions": [
       "root_image_beta and root_image_gamma: algebraic identities showing all three roots lie in ℚ(α)",
       "Irreducibility of 8X³-6X-1 via Eisenstein at 3 on the shifted polynomial X³-6X²+9X-3",
@@ -169,7 +169,7 @@
     "path": "Proofs/AngleTrisectionCos20Gal.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 0,
+    "definitionCount": 4,
     "theoremCount": 33
   },
   "sorries": 0

--- a/src/data/proofs/ehrhart-cube-proven/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven/meta.json
@@ -48,7 +48,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 3
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Eugène Ehrhart (1912–2000) was a French mathematician who, while teaching at a lycée, spent the 1950s and 1960s studying lattice points in dilated polytopes. His key discovery — published in the 1962 paper *Sur les polyèdres rationnels homothétiques à n dimensions* — was that for any convex lattice polytope $P$, the function $n \\mapsto |nP \\cap \\mathbb{Z}^d|$ is a polynomial in $n$ of degree $\\dim P$, now called the **Ehrhart polynomial** $L(P, n)$.\n\nThe story of the unit cube is elementary: $n \\cdot [0,1]^d = [0,n]^d$ contains exactly $\\{0, 1, \\ldots, n\\}^d$ integer points, giving $(n+1)^d$. This is the simplest instance of Ehrhart's theorem — a polynomial of degree $d$ with leading coefficient $\\text{vol}([0,1]^d) = 1$ (the normalized volume), constant term 1, and all coefficients given by the binomial formula $\\binom{d}{k}$. The formula $(n+1)^d = \\sum_{k=0}^d \\binom{d}{k} n^k$ is just the binomial theorem.\n\nThe deeper structural results for the cube follow equally directly. The **interior lattice point polynomial** $L^*([0,1]^d, n) = (n-1)^d$ is the Ehrhart polynomial evaluated at $-n$ with a sign: $(-1)^d(1-n)^d = (n-1)^d$, confirming **Ehrhart-Macdonald reciprocity** (1971), which Ian Macdonald proved for all lattice polytopes. **Pick's theorem** (1899), Georg Pick's classical formula Area $= I + B/2 - 1$ for lattice polygons, appears as a specialization to $d=2$: the Ehrhart polynomial $(n+1)^2 = n^2 + 2n + 1$ encodes area (leading coefficient $n^2$), boundary (linear term $2n$, contributing $B/2 = 2n/2 = n$ boundary points per unit dilation), and Euler characteristic (constant 1).\n\nEhrhart's work was initially largely ignored — he was not in an academic research position and published primarily in the *Comptes Rendus*. Recognition came slowly: Richard Stanley's 1980 connection of Ehrhart theory to commutative algebra (via the Hilbert series of the associated graded ring), and Barvinok's 1994 polynomial-time algorithm for counting lattice points in polytopes of fixed dimension, transformed Ehrhart theory into a central tool in combinatorics, optimization, and algebraic geometry. Today it underpins integer programming via the theory of Ehrhart $h^*$-polynomials and applications to scheduling, network flows, and the geometry of numbers.",
@@ -142,7 +142,7 @@
     "lineCount": 296,
     "axiomCount": 0,
     "theoremCount": 26,
-    "definitionCount": 3,
+    "definitionCount": 1,
     "path": "Proofs/EhrhartCubeProven.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -78,7 +78,7 @@
     ],
     "assumptions": "1 axiom: R3k_exponential_lower (c^k lower bound from Schur numbers). R3k_factorial_upper PROVED from R3k_le_three_factorial (induction on pigeonhole recurrence). R3k_inductive_upper PROVED from extracted pigeonhole step. forcing_set_nonempty PROVED via pigeonhole induction. R3k_one, R3k_two PROVED. Monotonicity PROVED.",
     "theoremCount": 26,
-    "definitionCount": 15
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) ≤ ⌈e·k!⌉ follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) ≥ 380^{k/5} - O(1).\n\nErdős offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
@@ -189,7 +189,7 @@
     "lineCount": 770,
     "axiomCount": 0,
     "theoremCount": 26,
-    "definitionCount": 15,
+    "definitionCount": 16,
     "path": "Proofs/Erdos183Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-582/meta.json
+++ b/src/data/proofs/erdos-582/meta.json
@@ -66,7 +66,7 @@
     "lineCount": 315,
     "assumptions": "5 assumptions: 2 opaque constants (folkmanNumber_2_3_4, folkmanNumber) + 3 axioms (folkman_existence, folkman_lower_bound, folkman_upper_bound). 0 sorries.",
     "theoremCount": 5,
-    "definitionCount": 9
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**Erdos Problem #582: The Folkman Number**\n\nThis problem was first posed by Erdos and Hajnal in 1967 and asks a fundamental question in Ramsey theory: can we have a graph that avoids K4 (no 4-clique) yet still forces monochromatic triangles in every 2-coloring of its edges?\n\n**Historical Timeline:**\n- 1967: Erdos-Hajnal pose the question\n- 1970: Folkman proves existence (with astronomical bounds)\n- 1986: Frankl-Rodl prove f(2,3,4) <= 7x10^11\n- 1988: Spencer proves <= 3x10^9, winning Erdos's $100 prize\n- 2007: Lu gives explicit construction with <= 9697 vertices\n- 2008: Dudek-Rodl prove <= 941 (current record)\n\nThe number f(2,3,4), called the Folkman number, remains one of the most studied parameters in extremal graph theory.",
@@ -196,7 +196,7 @@
     "lineCount": 315,
     "axiomCount": 5,
     "theoremCount": 5,
-    "definitionCount": 9,
+    "definitionCount": 11,
     "path": "Proofs/Erdos582Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -68,7 +68,7 @@
     "assumptions": "2 axiom declarations: kwan_sudakov (Kwan-Sudakov 2021: Ramsey graphs have >= cn^{5/2} distinct signatures), signature_upper_bound (upper bound: <= Cn^{5/2} distinct signatures). 4 sorries: edge_count_range, clique_few_signatures, empty_few_signatures, CountDistinctIsomorphismTypes.",
     "lineCount": 261,
     "theoremCount": 8,
-    "definitionCount": 18
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "**Induced Subgraph Signatures in Ramsey Graphs: From n^(3/2) to n^(5/2)**\n\nThe study of induced subgraph diversity in Ramsey-type graphs connects two fundamental areas: Ramsey theory (how large must a homogeneous subset be?) and graph enumeration (how many structurally distinct induced subgraphs exist?).\n\nA graph is called a 'Ramsey graph' if it has no large clique or independent set — both bounded by $O(\\log n)$. Such graphs exist by Erdős's 1947 probabilistic argument (which launched the probabilistic method in combinatorics): a random graph $G(n, 1/2)$ has $\\omega(G), \\alpha(G) \\le (2 + o(1))\\log_2 n$ with high probability.\n\n**The Signature Concept**: An induced subgraph $G[S]$ has a 'signature' $(|S|, |E(G[S])|)$ — its vertex count and edge count. The question is: how many distinct signatures must exist? For a complete graph $K_n$, there are only $n + 1$ signatures (edge count is determined by vertex count). But Ramsey graphs, lacking such structure, must have many more.\n\n**Erdős-Faudree-Sós**: Proved $|\\text{Sig}(G)| \\ge cn^{3/2}$ for Ramsey graphs. Their argument: for each vertex count $v$, there are $\\Omega(v^{1/2})$ achievable edge counts, and summing gives $\\Omega(n^{3/2})$. They conjectured the optimal bound is $\\Theta(n^{5/2})$.\n\n**Kwan-Sudakov (2021)**: Proved the conjecture. The key insight: for each vertex count $v$, Ramsey graphs actually yield $\\Omega(v^{3/2})$ distinct edge counts (not just $v^{1/2}$), and summing $\\sum_{v=1}^{n} v^{3/2} = \\Theta(n^{5/2})$. The matching upper bound completes the picture.",
@@ -235,7 +235,7 @@
     "lineCount": 261,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 18,
+    "definitionCount": 19,
     "path": "Proofs/Erdos636Problem.lean",
     "sorries": 4,
     "additionalFiles": [

--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 328,
     "assumptions": "3 axioms: no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), cilleruelo_granville (conditional). BombieriLangConjecture converted to opaque Prop (not an axiom). squares_contain_3AP proved by explicit construction {1,25,49}.",
     "theoremCount": 10,
-    "definitionCount": 17
+    "definitionCount": 18
   },
   "overview": {
     "historicalContext": "This problem was posed by Brown, Erdős, and Freedman in [BEF90]. It connects classical results about arithmetic progressions in squares with modern questions in additive combinatorics.\n\nThe classical result that squares contain no 4-term APs (related to Fermat's Last Theorem for n=4) motivates asking about weaker structures. Quasi-progressions relax the exact gap requirement to bounded gaps.\n\nSolymosi (2007) conjectured that even combinatorial cubes don't appear in unbounded sizes. Cilleruelo and Granville (2007) showed this would follow from the Bombieri-Lang conjecture in algebraic geometry.",
@@ -188,7 +188,7 @@
     "lineCount": 328,
     "axiomCount": 3,
     "theoremCount": 10,
-    "definitionCount": 17,
+    "definitionCount": 18,
     "path": "Proofs/Erdos782Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives. Includes composite_replacement_improves_product (added 2026-04-27): bridges prime_factor_better_sieve with the product structure of smaller_prime_better, formalizing the improvement step when converting any coprime sieving set toward a prime-only one.",
     "mathlib_version": "4.26.0",
     "theoremCount": 31,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "sections": [
     {
@@ -133,7 +133,7 @@
     "lineCount": 420,
     "axiomCount": 0,
     "theoremCount": 31,
-    "definitionCount": 5,
+    "definitionCount": 6,
     "path": "Proofs/Erdos783Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-839/meta.json
+++ b/src/data/proofs/erdos-839/meta.json
@@ -60,7 +60,7 @@
     "lineCount": 255,
     "assumptions": "1 axiom: freud_density. 0 sorries.",
     "theoremCount": 14,
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's work on additive restrictions in integer sequences, closely related to his broader program on sum-free sets and primitive sets. A 'primitive' set has no element dividing another; here the condition is additive: no term equals the sum of a contiguous block of earlier terms. Erdős posed two questions: whether such sequences must grow super-linearly ($\\limsup a_n/n = \\infty$) and whether their logarithmic density must vanish. He also conjectured the upper density is at most $1/2$, but Freud disproved this by constructing a valid sequence with upper density $19/36 \\approx 0.528$, exploiting the fact that only contiguous block sums (not arbitrary subset sums) are forbidden. The problem connects to Problems #359 (sum-free sets) and #867 in Erdős's catalog. Both growth-rate questions remain open, making this one of the more delicate problems in additive combinatorial number theory. The formalization is notable for including seven fully proved structural theorems about valid sequences, alongside the single axiomatized deep result (Freud's $19/36$ construction).",
@@ -151,7 +151,7 @@
     "lineCount": 255,
     "axiomCount": 1,
     "theoremCount": 14,
-    "definitionCount": 6,
+    "definitionCount": 7,
     "path": "Proofs/Erdos839Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos101-problem/meta.json
+++ b/src/data/proofs/erdos101-problem/meta.json
@@ -37,7 +37,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 757,
     "theoremCount": 23,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -68,7 +68,7 @@
     "lineCount": 757,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "path": "Proofs/Erdos101Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-01/meta.json
@@ -42,7 +42,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 903,
     "theoremCount": 60,
-    "definitionCount": 16,
+    "definitionCount": 12,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -82,7 +82,7 @@
     "lineCount": 903,
     "axiomCount": 0,
     "theoremCount": 60,
-    "definitionCount": 16,
+    "definitionCount": 12,
     "path": "Proofs/EulerPolyhedralOQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/euler-polyhedral-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 786,
     "theoremCount": 60,
-    "definitionCount": 13,
+    "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -76,7 +76,7 @@
     "lineCount": 786,
     "axiomCount": 7,
     "theoremCount": 60,
-    "definitionCount": 13,
+    "definitionCount": 4,
     "path": "Proofs/EulerPolyhedralOQ02OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 8
+    "definitionCount": 22
   },
   "overview": {
     "historicalContext": "Jacobi's four-square theorem (1829) states r₄(n) = 8·Σ_{d|n, 4∤d} d, proved using Jacobi theta functions: r₄(n) is the n-th Fourier coefficient of θ(q)⁴. Lagrange (1770) proved existence; Euler first studied r₄. The '8' factor mystified mathematicians until the group-theoretic perspective: the signed permutation symmetry group acting on a 4-tuple has order 2^k·(4!/∏mᵢ!) by orbit-stabilizer, and the representation count for each type is exactly this orbit size. This file analyzes HOW the total r₄(n) = 8σ*(n) splits among types: contributions range from 8 (single nonzero entry, like (0,0,0,k)) to 384 (all distinct nonzero, like (1,2,3,4)), a 24:1 ratio matching |S₄| = 4!. The connection to modular forms lies deeper: r₄(n) is multiplicative (via θ⁴ being a weight-2 Eisenstein series), which Jacobi's formula makes explicit through σ*.",
@@ -105,7 +105,7 @@
     "lineCount": 400,
     "axiomCount": 0,
     "theoremCount": 38,
-    "definitionCount": 8,
+    "definitionCount": 22,
     "path": "Proofs/FourSquareDistribution.lean",
     "sorries": 0
   },

--- a/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 3,
     "lineCount": 249,
     "theoremCount": 8,
-    "definitionCount": 5,
+    "definitionCount": 3,
     "mathlibDependencies": ["Mathlib.Tactic", "Mathlib.Data.Finset.Basic", "Mathlib.Data.Fin.Basic"],
     "originalContributions": [
       "Formal definition of n-part partitions as sorted Fin n → ℕ functions",
@@ -109,7 +109,7 @@
     "axiomCount": 3,
     "lineCount": 249,
     "theoremCount": 8,
-    "definitionCount": 5,
+    "definitionCount": 3,
     "sorries": 0
   },
   "mainTheorems": [

--- a/src/data/proofs/inverse-galois-a5/meta.json
+++ b/src/data/proofs/inverse-galois-a5/meta.json
@@ -36,7 +36,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 2067,
     "theoremCount": 84,
-    "definitionCount": 8,
+    "definitionCount": 12,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -83,7 +83,7 @@
     "lineCount": 2067,
     "axiomCount": 1,
     "theoremCount": 84,
-    "definitionCount": 8,
+    "definitionCount": 12,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0
   },

--- a/src/data/proofs/inverse-galois-f20/meta.json
+++ b/src/data/proofs/inverse-galois-f20/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 3
+    "definitionCount": 0
   },
   "overview": {
     "historicalContext": "The Inverse Galois Problem asks: which finite groups arise as Galois groups over ℚ? While the full problem is open, many groups are known to be realizable. The Frobenius group F₂₀ = ℤ/5ℤ ⋊ ℤ/4ℤ (order 20) is the Galois group of X⁵−2 over ℚ. This is a classical result: X⁵−2 has roots ⁵√2·ζ₅ᵏ (k=0,...,4), so its splitting field is ℚ(⁵√2, ζ₅) of degree 20. Since X⁵−2 is irreducible (Eisenstein at p=2) and Φ₅ is irreducible (cyclotomic), both 5 and 4 divide |Gal|, giving 20 | |Gal|. The splitting field has degree exactly 20, so |Gal| = 20.",
@@ -112,7 +112,7 @@
     "lineCount": 529,
     "axiomCount": 0,
     "theoremCount": 27,
-    "definitionCount": 3,
+    "definitionCount": 0,
     "path": "Proofs/InverseGaloisF20.lean",
     "sorries": 0
   },

--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 3
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Waring's problem (1770) asks: for each positive integer $k$, what is the smallest $g(k)$ such that every positive integer is a sum of at most $g(k)$ perfect $k$-th powers? For $k=2$ (squares), the answer is $g(2) = 4$.\n\n**Upper bound** ($g(2) \\leq 4$): Lagrange proved in 1770 that every positive integer is a sum of at most 4 squares. This was a major advance over Bachet's 1621 conjecture and Fermat's partial results.\n\n**Lower bound** ($g(2) \\geq 4$): Legendre proved in 1798 that $n$ is NOT a sum of 3 squares if and only if $n = 4^a(8b+7)$ for non-negative integers $a, b$. In particular, $7 = 4^0(8 \\cdot 0 + 7)$ requires exactly 4 squares: $4 + 1 + 1 + 1$.\n\n**Big-G and little-g**: Hilbert (1909) proved $g(k)$ exists for all $k$ (Waring's conjecture). For squares, $G(2) = g(2) = 4$: not only does every number need at most 4 squares, but infinitely many need exactly 4.",
@@ -115,7 +115,7 @@
     "lineCount": 442,
     "axiomCount": 0,
     "theoremCount": 69,
-    "definitionCount": 3,
+    "definitionCount": 8,
     "path": "Proofs/LagrangeFourSquaresWaringG2.lean",
     "sorries": 0
   },

--- a/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "lineCount": 264,
     "theoremCount": 14,
-    "definitionCount": 1
+    "definitionCount": 0
   },
   "openQuestion": {
     "id": "law-of-cosines-oq-03-oq-02",
@@ -181,7 +181,7 @@
     "axiomCount": 6,
     "lineCount": 264,
     "theoremCount": 14,
-    "definitionCount": 1,
+    "definitionCount": 0,
     "originalContributions": [
       "HyperbolicSineTriangle structure with 6 axiom fields encoding the hyperbolic law of sines",
       "law_sines_ac: sin A / sinh a = sin C / sinh c by transitivity",

--- a/src/data/proofs/pappus-theorem-oq-02/meta.json
+++ b/src/data/proofs/pappus-theorem-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "lineCount": 465,
     "theoremCount": 12,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "assumptions": ""
   },
   "overview": {
@@ -114,7 +114,7 @@
     "axiomCount": 0,
     "lineCount": 465,
     "theoremCount": 12,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "sorries": 0
   }
 }

--- a/src/data/proofs/picks-theorem-oq-03-cross-poly/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-cross-poly/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 10
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "The cross-polytope β_d is the convex hull of ±e₁, ..., ±e_d in ℝ^d, equivalently the unit ball in the ℓ¹ norm. For d=1 it is a segment, d=2 a square (rotated 45°), d=3 a regular octahedron. Ehrhart theory (1962) computes the number of integer lattice points L(t) in the t-th dilate tβ_d; L(t) is always a polynomial in t. The cross-polytope is a reflexive polytope (the unique interior lattice point is the origin), which makes its h*-vector palindromic. The beautiful identity h*(z) = (1+z)^d connects cross-polytopes to the binomial theorem.",
@@ -121,7 +121,7 @@
     "lineCount": 695,
     "axiomCount": 0,
     "theoremCount": 69,
-    "definitionCount": 10,
+    "definitionCount": 12,
     "path": "Proofs/PicksTheoremOQ03CrossPoly.lean",
     "sorries": 0
   },

--- a/src/data/proofs/picks-theorem-oq-03-ext/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-ext/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 4
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Ehrhart published his polynomial theory from 1962 to 1977, but the richer structure of h*-vectors was developed later. Richard Stanley (1980) proved that all h*-coefficients are non-negative integers — a deep combinatorial result equivalent to the existence of a regular unimodular triangulation. Takayuki Hibi (1991) characterized reflexive polytopes by h*-palindromy: P is reflexive (dual P° is a lattice polytope with origin in interior) iff h*(P) is palindromic (h*_i = h*_{d-i}). The Ehrhart-Macdonald reciprocity theorem (Macdonald 1971) L*(n) = (-1)^d · L(-n) connects the interior lattice polynomial L* to L at negative integers — a non-obvious algebraic identity. The polynomial interpolation uniqueness principle — that L(P, 0), L(P, 1), ..., L(P, d) determine L(P, n) for all n — was implicit in Ehrhart's original work and follows from the Vandermonde determinant being nonzero at distinct nodes. The simplex Ehrhart L(Δ_d, n) = C(n+d, d) satisfies Pascal-type recurrences exactly like binomial coefficients, reflecting the combinatorial isomorphism between lattice points and multisets.",
@@ -105,7 +105,7 @@
     "lineCount": 288,
     "axiomCount": 0,
     "theoremCount": 30,
-    "definitionCount": 4,
+    "definitionCount": 8,
     "path": "Proofs/PicksTheoremOQ03Ext.lean",
     "sorries": 0
   },

--- a/src/data/proofs/picks-theorem-oq-03-product/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-product/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 8
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Ehrhart theory studies lattice point counting in polytopes. The Ehrhart polynomial L(P, n) = |nP ∩ ℤ^d| was introduced by Eugène Ehrhart in the 1960s; for an integer polytope P of dimension d, L(P, n) is a polynomial in n of degree d with leading coefficient vol(P). The product formula L(P×Q, n) = L(P,n)·L(Q,n) follows from the fact that integer points in a product polytope are products of integer points. Quasipolynomials arise when polytopes have rational (non-integer) vertices: L(P, t) is a quasipolynomial with period equal to the LCM of denominators. Zonotopes (Minkowski sums of line segments) were studied by Zaslavsky and others; their Ehrhart theory is captured by the theory of mixed volumes. The valuation property connects Ehrhart theory to the broader theory of lattice polytope valuations studied by McMullen (1978).",
@@ -105,7 +105,7 @@
     "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 57,
-    "definitionCount": 8,
+    "definitionCount": 12,
     "path": "Proofs/PicksTheoremOQ03Product.lean",
     "sorries": 0
   },

--- a/src/data/proofs/ramsey-r4k/meta.json
+++ b/src/data/proofs/ramsey-r4k/meta.json
@@ -48,7 +48,7 @@
       "Finset operations in Lean 4",
       "Pigeonhole principle"
     ],
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Ramsey theory began with Frank Plumpton Ramsey's 1930 paper 'On a Problem of Formal Logic', which proved that for any $r, s$, there exists a minimum $n = R(r,s)$ such that every 2-coloring of the edges of the complete graph $K_n$ contains a monochromatic red $K_r$ or blue $K_s$. The bound Ramsey gave was doubly exponential. Erdős and Szekeres (1935) improved this to the central Pascal-based bound:\n$$R(r,s) \\leq \\binom{r+s-2}{r-1}$$\nwhich is the bound formalized here. For $r = 4$, this gives $R(4,k) \\leq \\binom{k+2}{3} = O(k^3)$.\n\nThe off-diagonal Ramsey numbers $R(4,k)$ are among the most studied special cases. Exact values include: $R(4,3) = 9$ (Chung 1973), $R(4,4) = 18$ (Chung, Grinstead 1983 — proving $R(4,4) > 17$ was the hard part), $R(4,5) = 25$ (McKay, Radziszowski 1995), $R(4,6) = 36$ (determined rigorously by 2012 through a combination of computational and theoretical work). The formalized binomial bounds (10, 20, 35, 56, 84) are overestimates — the gap widens with $k$.\n\nThe best known asymptotic upper bound is $R(4,k) = O(k^3/\\log^2 k)$, proved by Ajtai, Komlós, and Szemerédi (1980) using a probabilistic deletion argument (a forerunner of the 'Lovász local lemma' method). The best known lower bound is $R(4,k) = \\Omega(k^{5/2}/\\log^2 k)$, proved by Bohman and Keevash (2013) using the 'triangle-free process'. The gap between these bounds remains open and is a major problem in combinatorics.\n\nThis formalization captures the classical structural framework: the Erdős-Szekeres upper bound via Pascal recursion, concrete values for $k = 3$ to $10$, and the cubic growth rate $R(4,k) \\leq (k+2)^3$. The probabilistic lower bound framework (Part VIII) sets up the first-moment method infrastructure for future lower bound work.",
@@ -184,7 +184,7 @@
     "lineCount": 587,
     "axiomCount": 0,
     "theoremCount": 30,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "mainTheorems": [
       {
         "name": "ramsey_recursion",

--- a/src/data/proofs/randomized-maxcut-oq-04/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-04/meta.json
@@ -27,7 +27,7 @@
     "lineCount": 401,
     "assumptions": "No remaining sorries. All theorems fully proved: max_ge_avg, greedyContrib_ge_half, conditional_expectation_method, card_filter_mem, card_filter_mem_nmem, sum_cutWeight_eq, exists_good_partition'.",
     "theoremCount": 15,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "The Max-Cut problem — partitioning a graph's vertices to maximize the weight of crossing edges — is one of Karp's 21 NP-complete problems (1972). Erdős (1965) showed via the probabilistic method that a random partition cuts at least half the total edge weight in expectation, giving a non-constructive $1/2$-approximation. Sahni and Gonzalez (1976) provided the first explicit polynomial-time algorithm achieving this bound via a simple greedy strategy. Spencer (1987) later systematized this as the \"method of conditional expectations\": given a probabilistic proof that some random object has a desired property on average, one can process the random choices one at a time, always picking the option that keeps the conditional expectation favorable. For MaxCut, this reduces to the greedy rule: put each vertex on the side opposite to where it has more edge weight. The $1/2$-approximation stood as the best known until Goemans and Williamson (1995) achieved their celebrated $0.878$-approximation via semidefinite programming. Under the Unique Games Conjecture (Khot 2002), this SDP bound is optimal.",
@@ -152,7 +152,7 @@
     "lineCount": 401,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/RandomizedMaxcutOQ04.lean",
     "sorries": 0
   },

--- a/src/data/proofs/sperner-ndim-mathlib/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib/meta.json
@@ -33,7 +33,7 @@
       "sperner: Sperner's lemma for abstract cell complexes"
     ],
     "theoremCount": 13,
-    "definitionCount": 4
+    "definitionCount": 3
   },
   "leanFile": {
     "path": "Proofs/SpernerNDimMathlib.lean",
@@ -41,7 +41,7 @@
     "axiomCount": 0,
     "lineCount": 521,
     "theoremCount": 13,
-    "definitionCount": 4
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Sperner's lemma (1928) states that any Sperner coloring of a triangulated simplex contains a fully-colored face. The door-counting proof was formalized by Knuth and others; the abstract formulation for arbitrary cell complexes generalizes both the combinatorial (triangulation) and topological (barycentric subdivision) settings. This abstract version is the natural candidate for a Mathlib contribution, since it subsumes all concrete instances.",

--- a/src/data/proofs/zsqrtd-neg-two/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 4
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "The study of which integers are represented by the quadratic form x² + 2y² is classical. Fermat (1640s) first observed that a prime p ≠ 2 is a sum x² + 2y² iff p = 2 or p ≡ 1, 3 (mod 8), but left no proof. Euler (1770) established the supplementary laws for the Legendre symbol, giving (−2/p) = 1 iff p ≡ 1 or 3 (mod 8), which is precisely the splitting condition for p in ℤ[√−2]. Gauss, in the Disquisitiones Arithmeticae (1801), developed the theory of binary quadratic forms and showed that forms with class number 1 (like x² + 2y², which has discriminant −8 and class number h(−8) = 1) represent all primes that split. The algebraic proof via Euclidean domains became canonical after Gauss: ℤ[√−2] is Euclidean with norm N(a+b√−2) = a²+2b², hence a PID and UFD, so every prime that is not irreducible factors as p = N(α) = a²+2b². The three-squares connection—p = a²+b²+b² when p = a²+2b²—gives a partial case of Legendre's three-square theorem (1798): n is a sum of three squares iff n ≠ 4^a(8b+7). Primes p ≡ 3 (mod 8) satisfy 3 ≡ 3 (mod 8), so they are not excluded, confirming the corollary. The Mathlib Zsqrtd library (Mario Carneiro, 2017) provides the foundational ℤ[√d] framework on which this formalization builds.",
@@ -112,7 +112,7 @@
     "lineCount": 476,
     "axiomCount": 0,
     "theoremCount": 20,
-    "definitionCount": 4,
+    "definitionCount": 1,
     "path": "Proofs/ZsqrtdNegTwo.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` (both `meta` sub-block and `leanFile` block) to actual counts in 28 gallery proofs. `find-targets.ts` only checks True-stubs/sorry/axiom drift; `definitionCount` drift slips through.

Counting convention (from PR #15533): strip block `/- ... -/` and `--` line comments, then match `\b(def|abbrev|opaque)\s+\w+` with optional `private/protected/noncomputable/@[attr]` prefixes.

## Evidence

| slug | old | new |
|------|----:|----:|
| angle-trisection-cos-20-gal | 0 | 4 |
| angle-trisection-cos-20-gal-oq-01 | 0 | 4 |
| angle-trisection-cos-20-gal-oq-03 | 0 | 4 |
| angle-trisection-cos-20-gal-oq-03-oq-01 | 0 | 4 |
| ehrhart-cube-proven | 3 | 1 |
| erdos-183 | 15 | 16 |
| erdos-582 | 9 | 11 |
| erdos-636 | 18 | 19 |
| erdos-782 | 17 | 18 |
| erdos-783 | 5 | 6 |
| erdos-839 | 6 | 7 |
| erdos101-problem | 6 | 5 |
| euler-polyhedral-oq-01 | 16 | 12 |
| euler-polyhedral-oq-02-oq-01 | 13 | 4 |
| four-square-distribution | 8 | 22 |
| hilbert-15-oq-02-oq-03 | 5 | 3 |
| inverse-galois-a5 | 8 | 12 |
| inverse-galois-f20 | 3 | 0 |
| lagrange-four-squares-waring-g2 | 3 | 8 |
| law-of-cosines-oq-03-oq-02 | 1 | 0 |
| pappus-theorem-oq-02 | 3 | 4 |
| picks-theorem-oq-03-cross-poly | 10 | 12 |
| picks-theorem-oq-03-ext | 4 | 8 |
| picks-theorem-oq-03-product | 8 | 12 |
| ramsey-r4k | 5 | 4 |
| randomized-maxcut-oq-04 | 4 | 5 |
| sperner-ndim-mathlib | 4 | 3 |
| zsqrtd-neg-two | 4 | 1 |

Distinct from PRs #16407 and #16409 (different 17 proofs).
Discovered by full-gallery scan (2026-05-07).

---
Automated fix by lean-mechanic agent.