### PR TITLE
fix(meta): cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01 — add missing sorries + leanFile block

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -113,5 +113,14 @@
       "mathContext": "am_eq_qm_iff_all_eq is immediate from the main theorem with r=1, t=2. am_lt_qm_of_not_all_eq combines power_mean_monotone_pos (for ≤) with the negation of am_eq_qm_iff_all_eq (for ≠) via lt_of_le_of_ne."
     }
   ],
-  "openQuestions": []
+  "openQuestions": [],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean",
+    "lineCount": 200,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

The meta.json was missing both the top-level `sorries` field (required by gallery UI for badge display) and the `leanFile` block (was null).

## Evidence

**Before**: `"leanFile": null`, no top-level `sorries` field

**After**: Added `"sorries": 0` (top-level) and full `leanFile` block with:
- `path`: verified from `meta.proofRepoPath`
- `lineCount: 200`: verified against `origin/main` Lean file (200 lines)
- `theoremCount: 5`: verified by regex scan (matches `meta.theoremCount`)
- `definitionCount: 0`: verified by regex scan (matches `meta.definitionCount`)
- `axiomCount: 0`: matches `meta.axiomCount`
- `sorries: 0`: verified by regex scan

---
Automated fix by lean-mechanic agent.