### PR TITLE
fix(meta): batch sync definitionCount drift — 4 large proofs

### DIFF
--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -41,7 +41,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 10517,
     "theoremCount": 430,
-    "definitionCount": 81
+    "definitionCount": 89
   },
   "overview": {
     "historicalContext": "The Hodge Conjecture was proposed by Sir William Vallance Douglas Hodge at the 1950 International Congress of Mathematicians in Cambridge. Hodge developed his theory of harmonic integrals in the 1930s–1940s, building on Solomon Lefschetz's 1924 theorem that every (1,1) integral Hodge class is algebraic (the Lefschetz theorem on (1,1) classes). Hodge conjectured this should extend to all codimensions p.\n\nFor over 70 years the conjecture has resisted resolution. Key milestones: Atiyah–Hirzebruch (1962) disproved the integral version using topological K-theory and Steenrod operations, showing rational coefficients are essential. Grothendieck (1968) proposed his Standard Conjectures, which would imply the Hodge Conjecture as a corollary; they also remain open. Deligne proved the Weil conjectures (1974), which are related but distinct. Voisin (2002) proved the conjecture fails for compact Kähler manifolds that are not projective, confirming projectivity is an essential hypothesis.\n\nIn 2000, the Clay Mathematics Institute designated the Hodge Conjecture as one of seven Millennium Prize Problems with a $1,000,000 prize. The only proven cases are: divisors on any variety (Lefschetz (1,1)), curves, surfaces, and special abelian varieties (Deligne, Hazama). The conjecture stands as one of the deepest open questions in mathematics.",
@@ -293,7 +293,7 @@
     ],
     "path": "Proofs/HodgeConjecture.lean",
     "sorries": 0,
-    "definitionCount": 81
+    "definitionCount": 89
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -42,7 +42,7 @@
     "lineCount": 6370,
     "mathlib_version": "4.26.0",
     "theoremCount": 302,
-    "definitionCount": 66
+    "definitionCount": 150
   },
   "leanFile": {
     "path": "Proofs/PNPBarriersUnified.lean",
@@ -129,7 +129,7 @@
     ],
     "axiomCount": 121,
     "sorries": 0,
-    "definitionCount": 66,
+    "definitionCount": 150,
     "theoremCount": 302
   },
   "overview": {

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -79,7 +79,7 @@
     "lineCount": 17675,
     "mathlib_version": "4.26.0",
     "theoremCount": 941,
-    "definitionCount": 373
+    "definitionCount": 382
   },
   "overview": {
     "historicalContext": "Henri Poincaré posed the conjecture in 1904 in his fifth complement to Analysis Situs, after discovering that homology alone does not characterize the 3-sphere (the Poincaré homology sphere $\\Sigma(2,3,5)$ has $H_*(M) \\cong H_*(S^3)$ but $|\\pi_1| = 120$). The problem resisted all attempts for nearly a century.\n\nRichard Hamilton introduced Ricci flow in his landmark 1982 paper in J. Differential Geometry, proving that closed 3-manifolds with positive Ricci curvature are diffeomorphic to $S^3$. Grigori Perelman extended this in three arXiv preprints (2002–2003): 'The entropy formula for the Ricci flow' (math/0211159), 'Ricci flow with surgery on three-manifolds' (math/0303109), and 'Finite extinction time for the solutions to the Ricci flow' (math/0307245). His proof also established Thurston's Geometrization Conjecture.\n\nPerelman was awarded the Fields Medal in 2006 (declined) and the Clay Millennium Prize of $1 million in 2010 (also declined), saying 'I'm not interested in money or fame.' The detailed verification was completed by Kleiner–Lott (2008), Morgan–Tian (2007), and Cao–Zhu (2006).",
@@ -348,7 +348,7 @@
     "axiomCount": 32,
     "sorries": 0,
     "theoremCount": 941,
-    "definitionCount": 373,
+    "definitionCount": 382,
     "lemmaCount": 0
   }
 }

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -67,7 +67,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 6594,
     "theoremCount": 363,
-    "definitionCount": 38
+    "definitionCount": 50
   },
   "overview": {
     "historicalContext": "The Riemann zeta function $\\zeta(s) = \\sum n^{-s}$ was first studied by Euler (1737), who discovered the Euler product $\\zeta(s) = \\prod_p (1-p^{-s})^{-1}$ — the key link between $\\zeta$ and prime numbers. But it was Bernhard Riemann who, in his extraordinary 1859 paper 'Ueber die Anzahl der Primzahlen unter einer gegebenen Grösse' (just 8 pages), transformed the subject by extending $\\zeta$ to a meromorphic function on all of $\\mathbb{C}$, establishing the functional equation $\\xi(s) = \\xi(1-s)$, and stating the hypothesis that all non-trivial zeros have $\\text{Re}(s) = 1/2$.\n\nRiemann's paper was revolutionary: he showed that the distribution of primes is governed by the zeros of $\\zeta(s)$ through his explicit formula $\\psi(x) = x - \\sum_\\rho x^\\rho/\\rho - \\log(2\\pi) - \\frac{1}{2}\\log(1-x^{-2})$. The Prime Number Theorem — proved independently by Hadamard and de la Vallée Poussin in 1896 — is equivalent to $\\zeta(s) \\neq 0$ on $\\text{Re}(s) = 1$, while RH is the far stronger assertion that the zero-free region extends to $\\text{Re}(s) > 1/2$.\n\nHardy (1914) proved infinitely many zeros lie on the critical line, using the Hardy Z-function $Z(t) = e^{i\\theta(t)}\\zeta(1/2+it)$ which is real for real $t$. Selberg (1942) showed a positive proportion of zeros are on the critical line, Levinson (1974) proved $>1/3$, and Conrey (1989) improved this to $>40\\%$ — the current record. Montgomery (1973) discovered that the pair correlation of zeta zeros matches that of eigenvalues of random GUE matrices, inaugurating the deep connection to random matrix theory (Keating-Snaith 2000). Rodgers and Tao (2018) proved the de Bruijn-Newman constant $\\Lambda \\geq 0$, establishing that RH, if true, is 'just barely' true.\n\nIn 2000, the Clay Mathematics Institute designated RH as one of seven Millennium Prize Problems, offering $1,000,000 for its resolution. Despite 166 years of effort and the verification of the first $10^{13}$ zeros (Platt 2004, Gourdon 2004), the hypothesis remains open. Hilbert listed it as the 8th of his 23 problems (1900), and it appears on virtually every list of the most important open problems in mathematics.",
@@ -357,7 +357,7 @@
     "lineCount": 6594,
     "axiomCount": 32,
     "theoremCount": 363,
-    "definitionCount": 38,
+    "definitionCount": 50,
     "path": "Proofs/RiemannHypothesis.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `definitionCount` (both `meta` sub-block and `leanFile` block) to actual counts for 4 large gallery proofs that had significant drift (file content grew substantially since meta.json was written).

## Evidence

| slug | old | new | diff |
|------|----:|----:|-----:|
| hodge-conjecture | 81 | 89 | +8 |
| p-vs-np | 66 | 150 | +84 |
| poincare-conjecture | 373 | 382 | +9 |
| riemann-hypothesis | 38 | 50 | +12 |

Verified by regex scan against `origin/main` Lean sources.
Counting convention (from PR #15533): strip block + line comments, match `def|abbrev|opaque` with optional prefixes.

Distinct from PRs #16407, #16409, #16413 (different proofs).

---
Automated fix by lean-mechanic agent.