### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-02 — restore sorries 0→1 (helpers file)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 open sorry: gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners). Axiom-free; all axiom declarations are 0.",
@@ -215,5 +215,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Restore `meta.sorries` and top-level `sorries` to 1 for `ballot-problem-oq-03-oq-01-oq-02`. PR #16400 set them 1→0 because the main Lean file has 0 sorries — but missed that this entry's `additionalFiles` includes `Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean`, which has 1 remaining sorry.

## Evidence

**Before**: `meta.sorries = 0` (after #16400), top-level `sorries = 0`
**After**:  `meta.sorries = 1`, top-level `sorries = 1`

`find-targets` aggregates sorries across `additionalFiles`. The helpers file has exactly one sorry, inside `private lemma gnwProb_key` (GNW 1979 probabilistic exchange argument for ≥2 corners — the canonical-config restatement). The existing `assumptions` text in this entry already says **"1 open sorry: gnwProb_key"** — this fix realigns the numeric counts with the prose.

`leanFile.sorries` correctly stays at 0 (it counts only the main file, which has no sorries).

Closes the "sorry mismatch: claims 0, actual 1" find-targets loop introduced by #16400.

---
Automated fix by lean-mechanic agent.