### PR TITLE
fix(meta): batch sync theoremCount/definitionCount drift (11 entries)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -99,7 +99,7 @@
     "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 3
   },
   "crossReferences": [
@@ -303,7 +303,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "substantiveTheoremCount": 17,
     "privateHelperCount": 6,
     "axiomDeclCount": 2,

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
@@ -43,7 +43,7 @@
     "axiomCount": 0,
     "assumptions": "No axioms. Uses natDegree_dvd_card_gal from parent file (also 0 axioms). The theorem prime_degree_dvd_card_from_general is fully proved.",
     "lineCount": 123,
-    "theoremCount": 1,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "overview": {
@@ -167,7 +167,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 1,
+    "theoremCount": 3,
     "imports": [
       "Proofs.AngleTrisectionOQ02OQ01"
     ]

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms. tmul_infinite_order_ne_zero (flatness of \u211d over \u2124) is proved in DissectionOfCubesOQ02OQ02.lean via Mathlib Module.Flat \u2124 \u211d (B\u00e9zout + NoZeroSMulDivisors) and lTensor_preserves_injective_linearMap. icoAngle_irrational (arccos(-\u221a5/3)/\u03c0 irrational) is proved here via Chebyshev integer sequence for arccos(1/9). DissectionOfCubesOQ04.lean has 0 axiom declarations and 0 sorries; OQ02OQ02 import chain is also axiom-free.",
     "lineCount": 561,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 4,
     "mathlibDependencies": [
       {
@@ -186,7 +186,7 @@
   "leanFile": {
     "path": "Proofs/DissectionOfCubesOQ04.lean",
     "lineCount": 561,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 4,
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -29,7 +29,7 @@
     "assumptions": "1 axiom: erdos_1027_solution (Koishi Chan's affirmative answer). 0 sorries remain. — card_constOn_le proved via injection into complement functions.",
     "mathlib_version": "4.29.0",
     "theoremCount": 10,
-    "definitionCount": 14
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Property B, named after Felix Bernstein's 1908 work on set partitions and formally introduced by E.W. Miller (1937), asks whether a family of sets can be 2-colored so that no set is monochromatic. Equivalently: does there exist a subset $B$ of the ground set that intersects every family member but contains none? Such a $B$ is called a 'good' set—its existence is precisely property B.\n\nErdős's 1963 probabilistic bound showed that if $|\\mathcal{F}| < 2^{t-1}$ and all sets have size $\\ge t$, then $\\mathcal{F}$ has property B. The proof is a gem of the probabilistic method: each set of size $s$ is monochromatic under a random 2-coloring with probability $2^{1-s}$, and the union bound gives the result. This bound is tight—Erdős constructed $2^{t-1}$ sets of size $t$ without property B.\n\nProblem #1027 asks a *quantitative* question that goes far beyond mere existence. Given a bounded family ($|\\mathcal{F}| \\le c \\cdot 2^n$, all sets of size $n$), must there be not just one good set but *exponentially many*? Specifically, are there $\\gg_c 2^{|X|}$ good subsets of $X = \\bigcup \\mathcal{F}$, where the implicit constant depends only on $c$? This is a supersaturation phenomenon: once property B holds, it holds abundantly.\n\nThe problem is closely related to Erdős Problem #901, which asks about property B for bounded families. Problem #1027 strengthens #901 from an existential statement (at least one good set) to a quantitative one (a constant fraction of all subsets are good).\n\nKoishi Chan resolved the problem affirmatively. The key insight is an amplification argument: given one good set $B$, local perturbations—flipping elements of $B$ that are 'far' from being critical for any family member—produce exponentially many other good sets. The probabilistic intuition is that a random subset $B \\subseteq X$ satisfies $\\Pr[B \\text{ good}] \\ge (1 - 2^{-n})^{2|\\mathcal{F}|} \\approx e^{-2c}$ for large $n$, giving an expected $e^{-2c} \\cdot 2^{|X|}$ good sets. Making this rigorous requires handling the dependencies between the events '$B$ intersects $A$' and '$A \\not\\subseteq B$' for different $A \\in \\mathcal{F}$.\n\nThe result connects to several areas: the Lovász Local Lemma (handling dependent events), supersaturation in extremal combinatorics (Erdős-Simonovits theory), the entropy method in combinatorics (Shearer's lemma), and the theory of containers (Balogh-Morris-Samotij, Saxton-Thomason), which provides a general framework for counting independent sets in hypergraphs.",
@@ -192,7 +192,7 @@
     "lineCount": 353,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 14,
+    "definitionCount": 11,
     "path": "Proofs/Erdos1027Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 169,
     "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated.",
     "theoremCount": 5,
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "**Erdős-Selfridge and Binomial Divisibility**\n\nErdős Problem #1063 originates from a 1983 paper by Paul Erdős and John Selfridge on the arithmetic structure of binomial coefficients. They observed that the $k$ consecutive integers $n, n-1, \\ldots, n-k+1$ appearing in the numerator of $\\binom{n}{k} = \\frac{n(n-1)\\cdots(n-k+1)}{k!}$ have a subtle divisibility relationship with $\\binom{n}{k}$ itself. Their key result: for $n \\geq 2k$, it is impossible for ALL $k$ of these integers to divide $\\binom{n}{k}$ — the prime factorization of $k!$ cannot simultaneously cancel every factor.\n\n**The threshold question**: The natural follow-up asks for the least $n_k \\geq 2k$ where all but one of these $k$ integers divide $\\binom{n}{k}$. Computed values are $n_2 = 4$ (since $3 \\mid \\binom{4}{2} = 6$ but $4 \\nmid 6$), $n_3 = 6$, $n_4 = 9$, $n_5 = 12$.\n\n**Monier's bound (1985)**: Louis Monier proved $n_k \\leq k!$ by showing that $n = k!$ satisfies the all-but-one condition — the highly composite structure of $k!$ ensures most nearby factors divide $\\binom{k!}{k}$. This was the first non-trivial result but grows super-exponentially.\n\n**Cambie's improvement**: Stijn Cambie dramatically improved the bound to $n_k \\leq k \\cdot \\text{lcm}(2, \\ldots, k-1)$, which by the prime number theorem ($\\log \\text{lcm}(1, \\ldots, m) = \\psi(m) \\sim m$) gives $n_k \\leq e^{(1+o(1))k}$. The gap between $n_k \\geq 2k$ (trivial) and $n_k \\leq e^{(1+o(1))k}$ remains vast — whether $n_k$ grows polynomially or exponentially is the central open question.",
@@ -230,7 +230,7 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1063Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -63,7 +63,7 @@
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The pinned distance problem is a stronger variant of the famous Erdős distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErdős posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,√n} × {1,...,√n} shows the answer cannot exceed O(n/√log n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal Ω(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} ≈ n^{0.864} in 2004 using entropy methods.",
@@ -189,7 +189,7 @@
     "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos604Problem.lean",
     "sorries": 1
   },

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -23,7 +23,7 @@
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 375,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 12
   },
   "sections": [
@@ -155,7 +155,7 @@
     "lineCount": 375,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "lemmaCount": 10,
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20
   },
   "overview": {
@@ -217,7 +217,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0,

--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "2 axiom(s): motivicClassPartialFlagMaps (motivic class of maps to partial flags), partial_flag_extension (conjectured extension to parabolic subgroups). 0 sorries — all algebraic identities (duality, lines, Gaussian binomial) are proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 38,
-    "definitionCount": 14
+    "definitionCount": 16
   },
   "sections": [
     {
@@ -138,7 +138,7 @@
     "lineCount": 635,
     "path": "Proofs/MotivicFlagMapsPartialFlags.lean",
     "sorries": 0,
-    "definitionCount": 14,
+    "definitionCount": 16,
     "theoremCount": 38
   },
   "sorries": 0

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 6,
+    "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 465,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 6,
+    "definitionCount": 3,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -62,7 +62,7 @@
     "assumptions": "No axioms, no sorries. Fully verified. Main theorem roth_density_bound proved via Mathlib's corners-theorem chain (Regularity Lemma → Triangle Removal → Corners → Roth). Fourier-analytic density increment infrastructure (Parts I-V) independently verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 42,
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Roth's theorem, proved by Klaus Friedrich Roth in 1953, was a landmark achievement in number theory and combinatorics. It confirmed the k=3 case of the Erdos-Turan conjecture (1936) that every dense subset of the integers contains arithmetic progressions of any length.\n\nRoth introduced Fourier-analytic methods to additive combinatorics, a revolutionary approach that opened an entirely new toolbox. His key insight was the density increment strategy: if a set A of density delta in [N] has no 3-term AP, then there exists a long arithmetic progression P where A has density at least delta + c*delta^2. Iterating this increment (which can only happen O(1/delta) times before density exceeds 1) yields a contradiction.\n\nThe quantitative bounds have been dramatically improved over the decades: Bourgain (1999, 2008), Sanders (2011), and most recently Bloom and Sisask (2020) achieved r_3(N) = O(N/(log N)^{1+c}). In 2023, Kelley and Meka achieved the breakthrough bound r_3(N) = O(N * exp(-c * (log N)^{1/12})).\n\nRoth's theorem is the natural starting point for the Szemeredi program because it introduces the core techniques (Fourier analysis, density increment) in their simplest setting.",
@@ -221,7 +221,7 @@
     "lineCount": 1401,
     "axiomCount": 0,
     "theoremCount": 42,
-    "definitionCount": 4,
+    "definitionCount": 6,
     "path": "Proofs/RothTheorem.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Sync `meta.<count>` and `leanFile.<count>` for 11 gallery entries where `theoremCount` or `definitionCount` drifted from the actual Lean source. This class of drift slips through find-targets (which only checks True-stubs / sorries / axiomCount), so it required a manual scan.

Both `meta` and `leanFile` sub-objects are corrected in each file.

## Evidence

### theoremCount drift (5)

| slug                                  | meta/lf | actual | new |
|---------------------------------------|---------|--------|-----|
| amgm-inequality-oq-02                 |   25    |   26   |  26 |
| angle-trisection-oq-02-oq-01-oq-01    |    1    |    3   |   3 |
| dissection-of-cubes-oq-04             |   23    |   25   |  25 |
| erdos-662                             |   19    |   21   |  21 |
| lebesgue-measure-oq-06                |   40    |   52   |  52 |

### definitionCount drift (6)

| slug                       | meta/lf | actual | new |
|----------------------------|---------|--------|-----|
| erdos-1027                 |   14    |   11   |  11 |
| erdos-1063                 |    5    |    4   |   4 |
| erdos-604                  |   10    |   11   |  11 |
| motivic-flag-maps-oq-02    |   14    |   16   |  16 |
| roth-theorem-k3            |    4    |    6   |   6 |
| roth-theorem-k3-oq-02      |    6    |    3   |   3 |

`actual` counted with regex tolerant of `@[simp]` / `@[reducible]` prefixes, optional `private/protected/noncomputable` modifiers, and stripping block + line comments before counting `theorem|lemma` / `def|abbrev|opaque`.

No status / badge / narrative changes — pure numeric sync.

---
Automated fix by lean-mechanic agent.