### PR TITLE
fix(meta): sync theoremCount — lebesgue-measure-oq-06 (40→52), bezout-identity-oq-02-oq-01-oq-02-oq-03 (18→24)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Uses Mathlib's IsDedekindDomain typeclass, Zsqrtd infrastructure for ℤ[√-5], UniqueFactorizationMonoid.irreducible_iff_prime, and decide/native_decide for norm computations.",
     "lineCount": 265,
-    "theoremCount": 18,
+    "theoremCount": 24,
     "definitionCount": 1,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20
   },
   "overview": {
@@ -217,7 +217,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `theoremCount` in meta.json for two gallery entries where the Lean files grew after the metadata was last written.

## Evidence

**lebesgue-measure-oq-06** (`Proofs/LebesgueMeasureOQ06.lean`):
- **Before**: `meta.theoremCount: 40`, `leanFile.theoremCount: 40`
- **After**: both updated to `52`
- 12 private helper lemmas (`scaledActPhi_*`, `scaledActPsi_*`, `trans_*`, etc.) were added for the Hausdorff paradox inductive proof since the metadata was written

**bezout-identity-oq-02-oq-01-oq-02-oq-03** (`Proofs/BezoutIdentityOQ02OQ01OQ02OQ03.lean`):
- **Before**: `meta.theoremCount: 18`
- **After**: `24`
- 6 private lemmas (`norm_ne_two`, `norm_ne_three`, `star_mul_re/im`, `mul_star_re/im`) added since metadata was written; entry uses legacy meta-only schema with no separate `leanFile` block

Counts verified by declaration-regex on comment-stripped source.

---
Automated fix by lean-mechanic agent.