### PR TITLE
fix(meta): bezout-identity-oq-04-oq-01-oq-01 theoremCount 8 → 6

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "lineCount": 206,
-    "theoremCount": 8,
+    "theoremCount": 6,
     "assumptions": "Two axioms: snf_pid_exists (every matrix over a PID has a Smith Normal Form) and snf_pid_solvability (solvability criterion via invariant factors). These generalize the same axioms from BezoutIdentityOQ04OQ01 to arbitrary PIDs.",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Sync stale `meta.theoremCount` to match the actual file.

## Evidence

`proofs/Proofs/BezoutIdentityOQ04OQ01OQ01.lean` declares 6 top-level theorems:
- `theorem isUnimodularPID_one` (line 23)
- `theorem IsUnimodularPID.mul` (line 27)
- `theorem isUnimodularPID_int_iff` (line 33)
- `theorem snf_1x2_invariant_factor_pid` (line 65)
- `theorem bezout_pid_forward` (line 152)
- `theorem bezout_int_backward` (line 160)

`meta.theoremCount` was set to `8` at creation (PR #16026) and never reconciled. Inspection of the original commit shows the file already had 6 theorems — the count was incorrect from day one.

**Before**: `"theoremCount": 8`
**After**: `"theoremCount": 6`

No other fields touched. find-targets does not catch theoremCount drift; surfaced via manual scan.

---
Automated fix by lean-mechanic agent.