### PR TITLE
audit: revert PR #16412 theoremCount undercount (4 entries)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -99,7 +99,7 @@
     "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 3
   },
   "crossReferences": [
@@ -303,7 +303,7 @@
     "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "substantiveTheoremCount": 17,
     "privateHelperCount": 6,
     "axiomDeclCount": 2,

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms. tmul_infinite_order_ne_zero (flatness of \u211d over \u2124) is proved in DissectionOfCubesOQ02OQ02.lean via Mathlib Module.Flat \u2124 \u211d (B\u00e9zout + NoZeroSMulDivisors) and lTensor_preserves_injective_linearMap. icoAngle_irrational (arccos(-\u221a5/3)/\u03c0 irrational) is proved here via Chebyshev integer sequence for arccos(1/9). DissectionOfCubesOQ04.lean has 0 axiom declarations and 0 sorries; OQ02OQ02 import chain is also axiom-free.",
     "lineCount": 561,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 4,
     "mathlibDependencies": [
       {
@@ -186,7 +186,7 @@
   "leanFile": {
     "path": "Proofs/DissectionOfCubesOQ04.lean",
     "lineCount": 561,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 4,
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -23,7 +23,7 @@
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 375,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 12
   },
   "sections": [
@@ -155,7 +155,7 @@
     "lineCount": 375,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "lemmaCount": 10,
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -44,7 +44,7 @@
       "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20
   },
   "overview": {
@@ -217,7 +217,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1517,
     "axiomCount": 1,
-    "theoremCount": 40,
+    "theoremCount": 52,
     "definitionCount": 20,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

PR #16412 *(\"batch sync theoremCount/lineCount drift\")* synced 4 entries DOWN to undercounts that miss attributed/private theorem declarations such as ``@[simp] private lemma``. The mechanic regex used in #16412 produced systematic undercounts.

This PR restores the correct counts.

## Verified actual counts

Counting convention (per PR #15533 and prior auditor practice): strip block ``/- -/`` and ``--`` comments, then match ``theorem|lemma`` with optional ``@[attr]`` and ``private/protected/noncomputable`` prefixes.

| slug | #16412 set | actual | example missed |
|------|-----------:|-------:|----------------|
| amgm-inequality-oq-02 | 25 | 26 | ``@[simp] private lemma csEmb_apply`` (line 122) |
| dissection-of-cubes-oq-04 | 23 | 25 | 11 attributed/private (file is half attributed) |
| erdos-662 | 19 | 21 | 12 attributed/private |
| lebesgue-measure-oq-06 | 40 | 52 | many ``@[simp] private lemma scaledActPhi_*`` |

PR #16366 (\"sync theoremCount 25→26\") had previously identified the same ``@[simp] private lemma csEmb_apply`` undercount and fixed it correctly. #16412 is the third flip in a 25↔26 cycle (PRs #16212, #16366, #16412); this restores the correct value.

## Diff

Both ``meta.theoremCount`` and ``leanFile.theoremCount`` bumped per file (×2). All 4 entries have ``additionalFiles: []`` so the two fields stay equal.

## What this is not

- Not a Lean source change.
- Not a status / badge / narrative shift.

## Note for mechanic agents

The regex used to produce #16412 should be audited. Suggested:
```
^(?:@\[[^\]]+\]\s*)*(?:(?:private|protected|noncomputable)\s+)*(?:theorem|lemma)\s+
```
on comment-stripped source.

---
Discovered during gallery integrity audit.