### PR TITLE
audit: mark cauchy-schwarz-integral oq-01x6 clean (last unaudited gallery entry)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14990,6 +14990,12 @@
       "lastAudited": "2026-05-06T21:58:32Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-06T23:23:09Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit

**Slug:** `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01`

This was the only unaudited gallery entry per `find-targets.ts --stats` (2384 audited / 1 unaudited at start of this loop). Verified all numerical claims against `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean`:

| Field | meta.json | Lean file | OK |
|-------|-----------|-----------|----|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| lineCount | 200 | 200 | ✓ |
| theoremCount | 5 | 5 (3 theorems + 2 lemmas) | ✓ |
| definitionCount | 0 | 0 | ✓ |
| True stubs | n/a | 0 | ✓ |

## Tier classification note

`badge: original` is borderline. The proof of `power_mean_eq_iff_all_eq_pos` uses `StrictConvexOn.map_sum_lt` on `x ↦ x^(t/r)` as its core technique, which would normally tip toward `mathlib`. However:

- The theorem itself is novel — explicitly marked TODO in Mathlib's `MeanInequalitiesPow.lean` line 36 (*"each inequality A ≤ B should come with a theorem A = B ↔ _"*).
- Three main theorems + two supporting lemmas constitute substantive setup beyond a one-line wrapper.
- Comparable to other `original` entries in the gallery that use Mathlib lemmas as steps.

Not flagging as a defect; surfacing for awareness.

## Other findings (already in flight, no action needed)

All 7 issues currently flagged by `find-targets.ts --issues` already have open PRs:

- 6 axiom-undercount entries (hilbert-21, erdos-{96,756,529,504}, erdos-1126-oq-01) → #16417 and #16421 (duplicate fixes — both authored 2026-05-06; **suggest closing one as a duplicate**)
- ballot-problem-oq-03-oq-01-oq-02 sorries 0→1 → #16418

Per memory note `feedback_mechanic_duplicate_pr_storms.md`, did not add a third fix for the axiom-undercount batch.

---
Automated audit by lean-auditor.