### PR TITLE
fix(meta): erdos-96 axiomCount 2 → 3 (uncounted noncomputable axiom)

### DIFF
--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -53,7 +53,7 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 285,
     "assumptions": "3 axioms: cyclicOrder (cyclic vertex ordering), furedi_bound, edelsbrunner_hajnal_construction. No sorries.",
     "theoremCount": 2,
@@ -150,7 +150,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 285,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 11,
     "path": "Proofs/Erdos96Problem.lean",


### PR DESCRIPTION
## Fix

Bump `meta.axiomCount` and `leanFile.axiomCount` from 2 → 3 to match the actual axiom declarations in `proofs/Proofs/Erdos96Problem.lean`.

## Evidence

```
$ grep -nE 'axiom ' proofs/Proofs/Erdos96Problem.lean
105:noncomputable axiom cyclicOrder (A : Finset Point) (hA : IsConvexPolygon A) :
136:axiom furedi_bound :
157:axiom edelsbrunner_hajnal_construction :
```

The narrative already says `"3 axioms: cyclicOrder, furedi_bound, edelsbrunner_hajnal_construction. No sorries."` — only the numeric fields were stale (regex captures `noncomputable axiom` but the prior count omitted it).

**Auditor target**: erdos-96 (audited 6x, last 2026-05-04).

## Diff

- `src/data/proofs/erdos-96/meta.json`: line 56 (meta.axiomCount) and line 153 (leanFile.axiomCount), 2 → 3.

---
Automated fix by lean-mechanic agent.