### PR TITLE
fix(meta): erdos-756 axiomCount 2 → 5 (uncounted noncomputable axioms)

### DIFF
--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -73,7 +73,7 @@
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
       "erdos_756 theorem: main result"
     ],
-    "axiomCount": 2,
+    "axiomCount": 5,
     "lineCount": 268,
     "assumptions": "5 axioms: hopf_pannwitz (largest distance multiplicity ≤ n), bhowmick_main (⌊n/4⌋ rich distances for large n), squareGrid (square grid construction), regularPolygon (regular polygon construction), latticeInDisk (lattice points in disk). No sorries.",
     "theoremCount": 8,
@@ -222,7 +222,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 268,
-    "axiomCount": 2,
+    "axiomCount": 5,
     "theoremCount": 8,
     "definitionCount": 17,
     "path": "Proofs/Erdos756Problem.lean",


### PR DESCRIPTION
## Fix

Bump `meta.axiomCount` and `leanFile.axiomCount` from 2 → 5 to match the actual axiom declarations in `proofs/Proofs/Erdos756Problem.lean`.

## Evidence

```
$ grep -nE '^(noncomputable |private )*axiom ' proofs/Proofs/Erdos756Problem.lean
107:axiom hopf_pannwitz (A : PointSet) (hA : A.card ≥ 2) :
123:axiom bhowmick_main (n : ℕ) (hn : n ≥ 4) :
153:noncomputable axiom squareGrid (n : ℕ) : PointSet
209:noncomputable axiom regularPolygon (n : ℕ) : PointSet
213:noncomputable axiom latticeInDisk (r : ℕ) : PointSet
```

The narrative already says `"5 axioms: hopf_pannwitz, bhowmick_main, squareGrid, regularPolygon, latticeInDisk. No sorries."` — only the numeric fields were stale (the three `noncomputable axiom` decls were missed).

**Auditor target**: erdos-756 (audited 6x, last 2026-05-04).

## Diff

- `src/data/proofs/erdos-756/meta.json`: line 76 (meta.axiomCount) and line 225 (leanFile.axiomCount), 2 → 5.

---
Automated fix by lean-mechanic agent.