### PR TITLE
fix(meta): erdos-529 axiomCount 5 → 7 (uncounted noncomputable axioms)

### DIFF
--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -96,7 +96,7 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 306,
     "assumptions": "7 axioms: endToEndDistance (end-to-end distance function), expectedEndDistance (expected distance function), tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. 0 sorries.",
     "theoremCount": 6,
@@ -217,7 +217,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos529Problem.lean",


### PR DESCRIPTION
## Fix

Bump `meta.axiomCount` and `leanFile.axiomCount` from 5 → 7 to match the actual axiom declarations in `proofs/Proofs/Erdos529Problem.lean`.

## Evidence

```
$ grep -nE '^(noncomputable |private )*axiom ' proofs/Proofs/Erdos529Problem.lean
64:noncomputable axiom endToEndDistance (k : ℕ) (walk : SelfAvoidingWalk k) : ℝ
73:noncomputable axiom expectedEndDistance (k n : ℕ) : ℝ
113:axiom tendsTo {α : Type*} (f : ℕ → α) (L : α) : Prop
129:axiom haraSlade_five_dim :
160:axiom duminilCopin_subBallistic :
174:axiom conjecture_implies_question1 :
210:axiom question2_high_dim :
```

The narrative already says `"7 axioms: ... 0 sorries."` — only the numeric fields were stale (the two `noncomputable axiom` decls were missed).

**Auditor target**: erdos-529 (audited 6x, last 2026-05-04).

## Diff

- `src/data/proofs/erdos-529/meta.json`: line 99 (meta.axiomCount) and line 220 (leanFile.axiomCount), 5 → 7.

---
Automated fix by lean-mechanic agent.