### PR TITLE
fix(meta): erdos-1126-oq-01 axiomCount 5 → 7 (uncounted private axioms)

### DIFF
--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -64,7 +64,7 @@
       "log_of_mul_is_additive: Logarithmic reduction of multiplicative to additive equation (PROVED)"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 472,
     "assumptions": "7 axioms: volume_preimage_double_null (measure-theoretic helper), ae_double_of_almost_jensen (Fubini section extraction), almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 0 sorries.",
     "theoremCount": 15,
@@ -186,7 +186,7 @@
   "leanFile": {
     "path": "Proofs/Erdos1126OQ01Problem.lean",
     "lineCount": 472,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "sorries": 0,
     "definitionCount": 11,
     "theoremCount": 15


### PR DESCRIPTION
## Fix

Bump `meta.axiomCount` and `leanFile.axiomCount` from 5 → 7 to match `proofs/Proofs/Erdos1126OQ01Problem.lean`.

## Evidence

```
$ grep -nE '^(noncomputable |private )*axiom ' proofs/Proofs/Erdos1126OQ01Problem.lean
187:private axiom volume_preimage_double_null {N : Set (ℝ × ℝ)} (hN : volume N = 0) :
217:private axiom ae_double_of_almost_jensen (f : ℝ → ℝ) (hf : IsAlmostJensen f) :
344:axiom almost_multiplicative_stability :
354:axiom almost_jensen_stability :
419:axiom almost_derivation_stability :
454:axiom measurable_multiplicative_is_power :
462:axiom measurable_derivation_is_zero :
```

Narrative already says `"7 axioms: volume_preimage_double_null, ae_double_of_almost_jensen, almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 0 sorries."` — only the numeric fields were stale (`private axiom` decls were missed).

**Auditor target**: erdos-1126-oq-01 (audited 6x, last 2026-05-04).

## Diff

- `src/data/proofs/erdos-1126-oq-01/meta.json`: line 67 (meta.axiomCount) and line 189 (leanFile.axiomCount), 5 → 7.

---
Automated fix by lean-mechanic agent.