### PR TITLE
fix(meta): erdos-1126-oq-01 axiomCount 5 → 7 (uncounted private axioms)

### DIFF
--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -64,7 +64,7 @@
       "log_of_mul_is_additive: Logarithmic reduction of multiplicative to additive equation (PROVED)"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 472,
     "assumptions": "7 axioms: volume_preimage_double_null (measure-theoretic helper), ae_double_of_almost_jensen (Fubini section extraction), almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 0 sorries.",
     "theoremCount": 15,
@@ -186,7 +186,7 @@
   "leanFile": {
     "path": "Proofs/Erdos1126OQ01Problem.lean",
     "lineCount": 472,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "sorries": 0,
     "definitionCount": 11,
     "theoremCount": 15


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1126-oq-01
**Problem**: axiomCount undercount (claims 5, actual 7)

## Evidence

`proofs/Proofs/Erdos1126OQ01Problem.lean` has 7 axiom declarations:

| Line | Declaration |
|------|-------------|
| 187  | \`private axiom volume_preimage_double_null\` |
| 217  | \`private axiom ae_double_of_almost_jensen\` |
| 344  | \`axiom almost_multiplicative_stability\` |
| 354  | \`axiom almost_jensen_stability\` |
| 419  | \`axiom almost_derivation_stability\` |
| 454  | \`axiom measurable_multiplicative_is_power\` |
| 462  | \`axiom measurable_derivation_is_zero\` |

The two \`private axiom\` declarations are missed by the standard \`^axiom \` regex.

\`grep -cE \"^(private |protected |noncomputable )*axiom \"\` reports 7. The \`assumptions\` field already enumerated all 7 axioms by name — only the integer counts lagged.

## Fix

Bump \`leanFile.axiomCount\` and \`meta.axiomCount\` from 5 → 7.

---
Discovered during gallery integrity audit.