### PR TITLE
fix(meta): erdos-529 axiomCount 5 → 7 (uncounted noncomputable axioms)

### DIFF
--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -96,7 +96,7 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 306,
     "assumptions": "7 axioms: endToEndDistance (end-to-end distance function), expectedEndDistance (expected distance function), tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. 0 sorries.",
     "theoremCount": 6,
@@ -217,7 +217,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos529Problem.lean",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-529
**Problem**: axiomCount undercount (claims 5, actual 7)

## Evidence

\`proofs/Proofs/Erdos529Problem.lean\` has 7 axiom declarations:

| Line | Declaration |
|------|-------------|
| 64   | \`noncomputable axiom endToEndDistance\` |
| 73   | \`noncomputable axiom expectedEndDistance\` |
| 113  | \`axiom tendsTo\` |
| 129  | \`axiom haraSlade_five_dim\` |
| 160  | \`axiom duminilCopin_subBallistic\` |
| 174  | \`axiom conjecture_implies_question1\` |
| 210  | \`axiom question2_high_dim\` |

The two \`noncomputable axiom\` declarations are missed by the standard \`^axiom \` regex.

\`grep -cE \"^(noncomputable )*axiom \"\` reports 7. The \`assumptions\` field already enumerated all 7 axioms by name — only the integer counts lagged.

## Fix

Bump \`leanFile.axiomCount\` and \`meta.axiomCount\` from 5 → 7.

---
Discovered during gallery integrity audit.