### PR TITLE
fix(meta): erdos-582 axiomCount 3 → 5 (restore opaque-constant assumptions)

### DIFF
--- a/src/data/proofs/erdos-582/meta.json
+++ b/src/data/proofs/erdos-582/meta.json
@@ -62,7 +62,7 @@
       "Historical bound timeline from 1970-2008",
       "Connection to classical Ramsey theory"
     ],
-    "axiomCount": 3,
+    "axiomCount": 5,
     "lineCount": 315,
     "assumptions": "5 assumptions: 2 opaque constants (folkmanNumber_2_3_4, folkmanNumber) + 3 axioms (folkman_existence, folkman_lower_bound, folkman_upper_bound). 0 sorries.",
     "theoremCount": 5,
@@ -194,7 +194,7 @@
     ],
     "namespace": "Erdos582",
     "lineCount": 315,
-    "axiomCount": 3,
+    "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 9,
     "path": "Proofs/Erdos582Problem.lean",


### PR DESCRIPTION
## Fix

Restore \`erdos-582.axiomCount\` from 3 → 5. PR #16399 wrongly reduced it by counting only \`axiom\` declarations and ignoring the 2 \`opaque\` constants, which are assumption-carrying per CLAUDE.md axiom integrity policy.

## Evidence

**Lean source** (\`proofs/Proofs/Erdos582Problem.lean\`):
- 3 \`axiom\` declarations: \`folkman_existence\`, \`folkman_lower_bound\`, \`folkman_upper_bound\`
- 2 \`opaque\` constants: \`folkmanNumber_2_3_4\`, \`folkmanNumber\`

Total = **5 assumption-bearing declarations**.

The existing \`assumptions\` prose field already documents the correct count:

> "5 assumptions: 2 opaque constants (folkmanNumber_2_3_4, folkmanNumber) + 3 axioms (folkman_existence, folkman_lower_bound, folkman_upper_bound). 0 sorries."

## Why this slipped past the auditor

\`find-targets.ts\` counts only \`^axiom \` declarations (3) and so does not flag the discrepancy with the prose \`assumptions\` field (which counts opaque + axiom = 5). The fix aligns numeric \`axiomCount\` with both the Lean source's true assumption count and the prose narrative.

**Before**: meta.axiomCount = 3, leanFile.axiomCount = 3
**After**: meta.axiomCount = 5, leanFile.axiomCount = 5

Reverts the erdos-582 portion of #16399. The other six entries that PR touched (erdos-{96,504,529,756,1126-oq-01}, hilbert-21) have 0 opaque constants and are being addressed separately by other in-flight PRs (#16431-#16436).

---
Automated fix by lean-mechanic agent.