### PR TITLE
fix(meta): add missing leanFile blocks — 2 bezout entries

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-03/meta.json
@@ -124,5 +124,16 @@
       "For which values of d does ℤ[√d] have class number 1 (i.e., is a UFD/PID), and can Lean verify these computationally? The Stark-Heegner theorem says there are exactly 9 such negative d: -1,-2,-3,-7,-11,-19,-43,-67,-163."
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.BezoutIdentityOQ02OQ01OQ02"],
+    "opens": ["Zsqrtd"],
+    "namespace": "DedekindIdealFTA",
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ03.lean",
+    "lineCount": 265,
+    "axiomCount": 0,
+    "theoremCount": 24,
+    "definitionCount": 1,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -128,5 +128,26 @@
       "relationship": "root: Bezout's identity — the foundational result formalized in the main entry"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.PrincipalIdealDomain",
+      "Mathlib.RingTheory.GCDMonoid.Basic",
+      "Mathlib.Algebra.GCDMonoid.Basic",
+      "Mathlib.Data.Matrix.Basic",
+      "Mathlib.Data.Matrix.Diagonal",
+      "Mathlib.LinearAlgebra.Matrix.Diagonal",
+      "Mathlib.LinearAlgebra.Matrix.IsDiag",
+      "Mathlib.LinearAlgebra.Matrix.Determinant",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Matrix", "GCDMonoid"],
+    "namespace": "BezoutIdentityOQ04OQ01OQ01",
+    "path": "Proofs/BezoutIdentityOQ04OQ01OQ01.lean",
+    "lineCount": 206,
+    "axiomCount": 2,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

Add `leanFile` sub-objects to 2 gallery entries that had `"leanFile": null`.
Both Lean files exist on `main`; counts verified against actual file content.

## Entries fixed

| Slug | lineCount | theoremCount | definitionCount | axiomCount | sorries |
|------|-----------|-------------|-----------------|------------|---------|
| bezout-identity-oq-02-oq-01-oq-02-oq-03 | 265 | 24 | 1 | 0 | 0 |
| bezout-identity-oq-04-oq-01-oq-01 | 206 | 6 | 3 | 2 | 0 |

## Evidence

**bezout-identity-oq-02-oq-01-oq-02-oq-03** (`Proofs/BezoutIdentityOQ02OQ01OQ02OQ03.lean`):
- 24 theorem/lemma declarations (18 public + 6 private: `norm_ne_two`, `norm_ne_three`, `star_mul_re/im`, `mul_star_re/im`)
- 1 definition: `abbrev ZSqrtNeg5`
- theoremCount=24 aligns with PR #16422

**bezout-identity-oq-04-oq-01-oq-01** (`Proofs/BezoutIdentityOQ04OQ01OQ01.lean`):
- 6 theorems: isUnimodularPID_one, IsUnimodularPID.mul, isUnimodularPID_int_iff, snf_1x2_invariant_factor_pid, bezout_pid_forward, bezout_int_backward
- 3 definitions: IsUnimodularPID, SmithNormalFormPID.isDecompOf, SmithNormalFormPID.invariantFactor
- 2 axioms (matches meta.axiomCount=2)
- theoremCount=6 aligns with PR #16424

---
Automated fix by lean-mechanic agent.