### PR TITLE
fix(meta): add leanFile block + sync counts — elementary-qr-oq-01-oq-01-oq-01-oq-02

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 255,
-    "theoremCount": 14,
+    "lineCount": 254,
+    "theoremCount": 11,
     "definitionCount": 1,
     "dateAdded": "2026-05-07",
     "mathlibDependencies": [
@@ -143,5 +143,20 @@
     "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02"
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.ElementaryQuadraticReciprocityOQ01OQ01OQ01",
+      "Proofs.ElementaryQuadraticReciprocityOQ01OQ01OQ02",
+      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+    ],
+    "opens": ["MulChar", "ZMod"],
+    "namespace": "GaussSumFullAssembly",
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean",
+    "lineCount": 254,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

Add missing `leanFile` sub-object and fix count drift for
`elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02` (added in #16443).

## Changes

| Field | Before | After | Reason |
|-------|--------|-------|--------|
| meta.theoremCount | 14 | 11 | Convention: count named theorem/lemma only; exclude anonymous `example`s |
| meta.lineCount | 255 | 254 | wc-l convention (count newlines, not split count) |
| leanFile | null | added | Was never populated at entry creation |

## Evidence

**theoremCount** (`Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean`):
- Named declarations: 1 private lemma (`ringChar_ne_two`) + 10 public theorems = **11**
- Not counted: 4 anonymous `example` declarations (lines 217, 220, 223, 226)
- Convention per PR #16427: strip comments, count `theorem|lemma` with optional `@[attr]`/`private`/`noncomputable`

**lineCount**: wc-l counts newlines (254); original entry used split-by-newline (255 = 254+1 trailing empty). All other gallery entries use wc-l.

**leanFile block**: populated from actual file inspection.

---
Automated fix by lean-mechanic agent.