### PR TITLE
audit(sum-of-kth-powers-oq-04): sync sorries 2→0, lineCount 193→227

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "sum-of-kth-powers-oq-04",
   "title": "Euler-Maclaurin Asymptotics for Power Sums",
   "slug": "sum-of-kth-powers-oq-04",
-  "description": "Asymptotic formula for power sums: sum_{i=0}^{n-1} i^k / n^{k+1} -> 1/(k+1) as n -> infinity. Proves Bernoulli polynomial leading behavior and monic polynomial asymptotics (0 axioms). 2 routine sorries remain. Includes exact k=0 and k=1 special cases.",
+  "description": "Asymptotic formula for power sums: sum_{i=0}^{n-1} i^k / n^{k+1} -> 1/(k+1) as n -> infinity. Proves Bernoulli polynomial leading behavior and monic polynomial asymptotics (0 axioms, 0 sorries). Includes exact k=0 and k=1 special cases.",
   "meta": {
     "author": "Euler (1738), Maclaurin (1742), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%E2%80%93Maclaurin_formula",
@@ -17,9 +17,9 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 2 routine sorries: (1) low_degree_poly_ratio_tendsto_zero (polynomial of degree < d divided by n^d \u2192 0); (2) natDegree_sub_leading (natDegree of p - X^d < d when p is monic of degree d, routine algebra). Both are standard analysis/algebra, suitable for Aristotle. Note: monic_poly_ratio_tendsto was previously an axiom but was proved in V3.",
+    "assumptions": "0 axioms, 0 sorries. The two previously routine sorries (low_degree_poly_ratio_tendsto_zero and the natDegree bound inside monic_poly_ratio_tendsto) are now fully proved. monic_poly_ratio_tendsto was previously an axiom but was proved in V3.",
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.bernoulli",
@@ -40,7 +40,7 @@
       "powerSumRatio_tendsto proof: general asymptotic 1/(k+1) via Faulhaber + filter limits"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 193,
+    "lineCount": 227,
     "theoremCount": 9,
     "definitionCount": 1,
     "prerequisites": [
@@ -145,12 +145,12 @@
       "Filter"
     ],
     "namespace": "SumOfKthPowersAsymptotic",
-    "lineCount": 193,
+    "lineCount": 227,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 1,
     "path": "Proofs/SumOfKthPowersOQ04.lean",
-    "sorries": 2,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/SumOfKthPowersOQ04Aristotle.lean"
     ]
@@ -169,5 +169,5 @@
       "leanType": "powerSumRatio 1 n = (n - 1) / (2 * n)"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Integrity Issue

**Proof**: sum-of-kth-powers-oq-04 (Euler-Maclaurin Asymptotics for Power Sums)

**meta.json claims**: 2 sorries, lineCount 193

**Lean file (origin/main:proofs/Proofs/SumOfKthPowersOQ04.lean) shows**: 0 sorries (after stripping comments), 227 lines

## Evidence

```
$ git show origin/main:proofs/Proofs/SumOfKthPowersOQ04.lean | wc -l
227

$ git show origin/main:proofs/Proofs/SumOfKthPowersOQ04.lean \
    | python3 -c "import sys, re; c=sys.stdin.read(); \
        c=re.sub(r'/-(.*?)-/','',c,flags=re.DOTALL); \
        c=re.sub(r'--.*','',c); print(c.count('sorry'))"
0
```

The two previously-sorry'd lemmas (`low_degree_poly_ratio_tendsto_zero` and the
`natDegree` bound feeding `monic_poly_ratio_tendsto`) are now fully proved in
the file (lines 72-93 and 97-141 respectively). The `axiom` was already removed
in V3; this PR brings the meta.json narrative and counts in line.

## Changes

- `description` — drop "2 routine sorries remain", add "(0 axioms, 0 sorries)"
- `meta.sorries`: 2 → 0 (top-level, meta sub-object, leanFile sub-object — all 3 sites)
- `meta.lineCount` / `leanFile.lineCount`: 193 → 227
- `assumptions`: rewrote to reflect 0 sorries (kept the V3 axiom-elimination note)

No code changes; `axiomCount=0`, `theoremCount=9`, `definitionCount=1`,
`additionalFiles`, badge `wip`, and status `formalized` are unchanged.

---
Discovered during gallery integrity audit.