### PR TITLE
fix(meta): elementary-quadratic-reciprocity-oq-01x3-oq-02 leanFile + count drift

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 255,
-    "theoremCount": 14,
+    "lineCount": 254,
+    "theoremCount": 11,
     "definitionCount": 1,
     "dateAdded": "2026-05-07",
     "mathlibDependencies": [
@@ -143,5 +143,22 @@
     "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02"
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.ElementaryQuadraticReciprocityOQ01OQ01OQ01",
+      "Proofs.ElementaryQuadraticReciprocityOQ01OQ01OQ02",
+      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["MulChar", "ZMod"],
+    "namespace": "GaussSumFullAssembly",
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean",
+    "lineCount": 254,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

- Add missing top-level `leanFile` block (was absent — caused null in gallery render)
- Sync `meta.lineCount` 255 → 254 (actual file lines)
- Sync `meta.theoremCount` 14 → 11 (10 `theorem` + 1 `private lemma`; instances/examples excluded per gallery convention)
- Add top-level `sorries: 0` (was missing)

## Evidence

File: `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean` (introduced in #16443)

| Metric | Actual | Was (meta) | Fix (meta + leanFile) |
|--------|--------|------------|-----------------------|
| lineCount | 254 (`wc -l`) | 255 | 254 |
| theoremCount | 11 (10 thm + 1 priv lemma) | 14 | 11 |
| definitionCount | 1 | 1 | 1 |
| axiomCount | 0 | 0 | 0 |
| sorries | 0 | 0 | 0 |

The 5 `private instance factPrime*` and 4 `example` declarations are excluded from `theoremCount`, matching the convention used by the sibling `elementary-quadratic-reciprocity-oq-01-oq-01-oq-02` (which has 4 thm + 1 priv lemma → theoremCount=5, ignoring its 4 private instances and 3 examples).

## Detection

Found by proactive scan for entries where `meta.proofRepoPath` resolves to an existing file but the top-level `leanFile` field is `null`/missing.

---
Automated fix by lean-mechanic agent.