### PR TITLE
fix(meta): stirling-formula-oq-01 sorries 2→1, lineCount 413→462

### DIFF
--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -17,9 +17,9 @@
       "bernoulli-numbers"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 2 sorries: (1) stirling_step_formula (private, pure algebraic computation from stirlingSeq def); (2) stirling_first_correction (depends on step formula + sum bounds). New in this session: proved log_one_plus_le_cubic, log_one_plus_ge_quartic, stirling_step_upper, stirling_step_lower.",
+    "assumptions": "0 axioms, 1 sorry: stirling_first_correction (depends on the still-stated step-formula derivation and sum bounds; see line 350). stirling_step_formula is now fully proved. Supporting lemmas in place: log_one_plus_le_cubic, log_one_plus_ge_quartic, stirling_step_upper, stirling_step_lower.",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -44,7 +44,7 @@
       "stirling_step_upper: d_k \u2264 1/(12k\u00b2)+1/(6k\u00b3) (conditional on step formula)",
       "stirling_step_lower: 1/(12k\u00b2)-1/(12k\u00b3)-1/(8k\u2074) \u2264 d_k (conditional on step formula)"
     ],
-    "lineCount": 413,
+    "lineCount": 462,
     "theoremCount": 13,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -137,15 +137,15 @@
       "Filter"
     ],
     "namespace": "StirlingExpansion",
-    "lineCount": 413,
+    "lineCount": 462,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 2,
     "path": "Proofs/StirlingExpansion.lean",
-    "sorries": 2,
+    "sorries": 1,
     "additionalFiles": [
       "Proofs/StirlingExpansionAristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Sync meta.json count fields and `assumptions` narrative to current
`proofs/Proofs/StirlingExpansion.lean` on main.

## Evidence

```
$ git show origin/main:proofs/Proofs/StirlingExpansion.lean | wc -l
462
$ git show origin/main:proofs/Proofs/StirlingExpansion.lean \
    | python3 -c "import sys,re; c=sys.stdin.read(); \
        c=re.sub(r'/-(.*?)-/','',c,flags=re.DOTALL); \
        c=re.sub(r'--.*','',c); print(c.count('sorry'))"
1
```

The single real `sorry` is at line 350 inside `theorem stirling_first_correction`. The other 4 textual occurrences are inside `/- ... -/` block comments (lines 446/452/458/459). `stirling_step_formula` is fully proved in current main (PR #16414, merged 2026-05-07).

**Before**:
- top-level `sorries`: 2
- `meta.sorries`: 2
- `meta.lineCount`: 413
- `leanFile.sorries`: 2
- `leanFile.lineCount`: 413
- `meta.assumptions`: claims "0 axioms, 2 sorries"

**After**:
- top-level `sorries`: 1
- `meta.sorries`: 1
- `meta.lineCount`: 462
- `leanFile.sorries`: 1
- `leanFile.lineCount`: 462
- `meta.assumptions`: rewritten to reflect 1 remaining sorry

## Provenance

Drift introduced by mechanic count-sync PR #16387 (which over-counted block-comment occurrences as live sorries) and subsequent research churn that grew the file from 413 to 462 lines. `theoremCount` and `definitionCount` are still correct.

No code changes. `status: formalized`, `badge: wip` are correct.

Closes #16448

---
Automated fix by lean-mechanic agent.