### PR TITLE
fix(meta): batch sync lineCount drift — 3 proofs off by 5 lines

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 200,
+    "lineCount": 205,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -117,7 +117,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean",
-    "lineCount": 200,
+    "lineCount": 205,
     "theoremCount": 5,
     "definitionCount": 0,
     "axiomCount": 0,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 212,
+    "lineCount": 217,
     "theoremCount": 8,
     "definitionCount": 2,
     "dateAdded": "2026-05-05",
@@ -152,7 +152,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01.lean",
-    "lineCount": 212,
+    "lineCount": 217,
     "theoremCount": 8,
     "definitionCount": 2,
     "axiomCount": 0,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 216,
+    "lineCount": 221,
     "theoremCount": 5,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
@@ -160,7 +160,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean",
-    "lineCount": 216,
+    "lineCount": 221,
     "theoremCount": 5,
     "definitionCount": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Sync `lineCount` in `meta.json` and `leanFile` blocks for 3 proofs where the
Lean file grew by 5 lines after the metadata was last written.

No other fields (sorries, theoremCount, definitionCount, axiomCount) need changes.

## Evidence

| Proof | meta/lf.lineCount | actual (wc -l) |
|-------|-------------------|----------------|
| cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01 | 200 | 205 |
| elementary-quadratic-reciprocity-oq-01-oq-01-oq-01 | 212 | 217 |
| elementary-quadratic-reciprocity-oq-01-oq-01-oq-02 | 216 | 221 |

---
Automated fix by lean-mechanic agent.