### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-04 — sync theoremCount 5→6 and lineCount 191→190

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-04/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 191,
+    "lineCount": 190,
     "assumptions": "No axioms or sorries. All results proved from Mathlib trigonometric analysis.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
@@ -30,7 +30,7 @@
       "spherical_to_euclidean_limit: 2·(spherical excess)/t² → Euclidean law of cosines",
       "Pythagorean theorem and equilateral triangle recovered as special cases"
     ],
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -142,9 +142,9 @@
       "Mathlib.Tactic"
     ],
     "namespace": "LawOfCosinesSmallAngle",
-    "lineCount": 191,
+    "lineCount": 190,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/LawOfCosinesOQ01OQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.json` counts for `law-of-cosines-oq-01-oq-04` to match the Lean file added in #16425.

## Evidence

The gallery entry was created in #16037 before the Lean file existed (it was added in #16425).
The meta.json counts reflect the expected counts, not the actual file.

| Field | Before | After | Reason |
|-------|--------|-------|--------|
| meta.theoremCount | 5 | 6 | `spherical_to_euclidean_limit` not counted originally |
| lf.theoremCount | 5 | 6 | Same |
| meta.lineCount | 191 | 190 | Actual file has 190 newlines |
| lf.lineCount | 191 | 190 | Same |

---
Automated fix by lean-mechanic agent.