### PR TITLE
fix(meta): picks-theorem-oq-01-oq-02 axiomCount 3→4 — restore opaque scaledPolygon

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
@@ -19,8 +19,8 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-03",
-    "axiomCount": 3,
-    "assumptions": "3 axioms: picks_theorem (Pick's formula A=i+B/2-1, matching the gallery's axiomatized PicksTheorem.lean), scaled_area (Area(tP)=t²A), scaled_boundary (|∂(tP)|=t·B for t≥1). The rectangle and triangle Ehrhart polynomials are proved with 0 axioms via Finset combinatorics.",
+    "axiomCount": 4,
+    "assumptions": "4 assumptions: 3 axioms (picks_theorem — Pick's formula A=i+B/2-1, matching the gallery's axiomatized PicksTheorem.lean; scaled_area — Area(tP)=t²A; scaled_boundary — |∂(tP)|=t·B for t≥1) plus 1 opaque constant (scaledPolygon — the integer dilation tP, opaque since its concrete construction is not needed for the theorem). The rectangle and triangle Ehrhart polynomials are proved with 0 axioms via Finset combinatorics.",
     "lineCount": 309,
     "theoremCount": 24,
     "definitionCount": 6,
@@ -113,7 +113,7 @@
     "lineCount": 309,
     "theoremCount": 24,
     "definitionCount": 6,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "sorries": 0
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Restore the missed `opaque scaledPolygon` constant to `axiomCount` for picks-theorem-oq-01-oq-02 (3 → 4 in both `meta.axiomCount` and `leanFile.axiomCount`).

## Evidence

`proofs/Proofs/PicksTheoremOQ01OQ02.lean` declares 4 assumption-bearing constants:

```
$ grep -nE '^(axiom|opaque)\s|^noncomputable\s+(axiom|opaque)\s' proofs/Proofs/PicksTheoremOQ01OQ02.lean
140:axiom picks_theorem (P : SimpleLatticePolygon) :
144:opaque scaledPolygon (P : SimpleLatticePolygon) (t : ℕ) : SimpleLatticePolygon
147:axiom scaled_area (P : SimpleLatticePolygon) (t : ℕ) :
151:axiom scaled_boundary (P : SimpleLatticePolygon) (t : ℕ) (ht : 1 ≤ t) :
```

That's 3 `axiom`s + 1 `opaque` = **4** assumption-bearing declarations. `meta.json` previously claimed 3 in both `meta.axiomCount` (line 22) and `leanFile.axiomCount` (line 116), and the `assumptions` prose enumerated only the 3 `axiom`s.

## Provenance

Same regression class as the recent erdos-582 restoration in #16441 (axiomCount 3 → 5). PR #16399 / #16441-era axiom-only sync regex missed `opaque` constants. picks-theorem-oq-01-oq-02 is one such residual — the opaque was added in research PR #15257 but never reflected in `axiomCount`.

Per repo convention (see CLAUDE.md "Axiom Integrity Policy"): "axiomCount in meta.json must reflect ALL assumptions: axiom declarations + assumption-carrying structure fields", and per merged remediation #16441, opaque constants count as assumption-bearing.

## What changed

- `meta.axiomCount`: 3 → 4
- `leanFile.axiomCount`: 3 → 4
- `meta.assumptions`: rewritten to enumerate the opaque alongside the 3 axioms ("4 assumptions: 3 axioms ... plus 1 opaque constant ...")

No code changes. `status: axiomatized` and `badge: axiom` are unchanged (still correct).

---
Automated fix by lean-mechanic agent.