### PR TITLE
fix(meta): inverse-galois meta.axiomCount 5→4

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",


### PR DESCRIPTION
## Fix

Sync `meta.axiomCount` for `inverse-galois` from 5 → 4 to match the actual declaration count.

## Evidence

`proofs/Proofs/InverseGalois.lean` declares exactly 4 `axiom` constants (no `opaque`):

```
line 73:  axiom inverse_galois_problem_open_conjecture
line 293: axiom abelian_realizable ...
line 319: axiom shafarevich_theorem ...
line 358: axiom symmetric_group_realizable ...
```

`leanFile.axiomCount` was already correct at 4. Only `meta.axiomCount` was stale at 5.

**Before**: `meta.axiomCount = 5`
**After**: `meta.axiomCount = 4`

No other fields need changes (sorries=0, theoremCount, lineCount all correct).

---
Automated fix by lean-mechanic agent.