### PR TITLE
fix(meta): revert PR #16420 definitionCount undercount (3 entries)

### DIFF
--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -29,7 +29,7 @@
     "assumptions": "1 axiom: erdos_1027_solution (Koishi Chan's affirmative answer). 0 sorries remain. — card_constOn_le proved via injection into complement functions.",
     "mathlib_version": "4.29.0",
     "theoremCount": 10,
-    "definitionCount": 11
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Property B, named after Felix Bernstein's 1908 work on set partitions and formally introduced by E.W. Miller (1937), asks whether a family of sets can be 2-colored so that no set is monochromatic. Equivalently: does there exist a subset $B$ of the ground set that intersects every family member but contains none? Such a $B$ is called a 'good' set—its existence is precisely property B.\n\nErdős's 1963 probabilistic bound showed that if $|\\mathcal{F}| < 2^{t-1}$ and all sets have size $\\ge t$, then $\\mathcal{F}$ has property B. The proof is a gem of the probabilistic method: each set of size $s$ is monochromatic under a random 2-coloring with probability $2^{1-s}$, and the union bound gives the result. This bound is tight—Erdős constructed $2^{t-1}$ sets of size $t$ without property B.\n\nProblem #1027 asks a *quantitative* question that goes far beyond mere existence. Given a bounded family ($|\\mathcal{F}| \\le c \\cdot 2^n$, all sets of size $n$), must there be not just one good set but *exponentially many*? Specifically, are there $\\gg_c 2^{|X|}$ good subsets of $X = \\bigcup \\mathcal{F}$, where the implicit constant depends only on $c$? This is a supersaturation phenomenon: once property B holds, it holds abundantly.\n\nThe problem is closely related to Erdős Problem #901, which asks about property B for bounded families. Problem #1027 strengthens #901 from an existential statement (at least one good set) to a quantitative one (a constant fraction of all subsets are good).\n\nKoishi Chan resolved the problem affirmatively. The key insight is an amplification argument: given one good set $B$, local perturbations—flipping elements of $B$ that are 'far' from being critical for any family member—produce exponentially many other good sets. The probabilistic intuition is that a random subset $B \\subseteq X$ satisfies $\\Pr[B \\text{ good}] \\ge (1 - 2^{-n})^{2|\\mathcal{F}|} \\approx e^{-2c}$ for large $n$, giving an expected $e^{-2c} \\cdot 2^{|X|}$ good sets. Making this rigorous requires handling the dependencies between the events '$B$ intersects $A$' and '$A \\not\\subseteq B$' for different $A \\in \\mathcal{F}$.\n\nThe result connects to several areas: the Lovász Local Lemma (handling dependent events), supersaturation in extremal combinatorics (Erdős-Simonovits theory), the entropy method in combinatorics (Shearer's lemma), and the theory of containers (Balogh-Morris-Samotij, Saxton-Thomason), which provides a general framework for counting independent sets in hypergraphs.",
@@ -192,7 +192,7 @@
     "lineCount": 353,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 11,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1027Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 169,
     "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated.",
     "theoremCount": 5,
-    "definitionCount": 4
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "**Erdős-Selfridge and Binomial Divisibility**\n\nErdős Problem #1063 originates from a 1983 paper by Paul Erdős and John Selfridge on the arithmetic structure of binomial coefficients. They observed that the $k$ consecutive integers $n, n-1, \\ldots, n-k+1$ appearing in the numerator of $\\binom{n}{k} = \\frac{n(n-1)\\cdots(n-k+1)}{k!}$ have a subtle divisibility relationship with $\\binom{n}{k}$ itself. Their key result: for $n \\geq 2k$, it is impossible for ALL $k$ of these integers to divide $\\binom{n}{k}$ — the prime factorization of $k!$ cannot simultaneously cancel every factor.\n\n**The threshold question**: The natural follow-up asks for the least $n_k \\geq 2k$ where all but one of these $k$ integers divide $\\binom{n}{k}$. Computed values are $n_2 = 4$ (since $3 \\mid \\binom{4}{2} = 6$ but $4 \\nmid 6$), $n_3 = 6$, $n_4 = 9$, $n_5 = 12$.\n\n**Monier's bound (1985)**: Louis Monier proved $n_k \\leq k!$ by showing that $n = k!$ satisfies the all-but-one condition — the highly composite structure of $k!$ ensures most nearby factors divide $\\binom{k!}{k}$. This was the first non-trivial result but grows super-exponentially.\n\n**Cambie's improvement**: Stijn Cambie dramatically improved the bound to $n_k \\leq k \\cdot \\text{lcm}(2, \\ldots, k-1)$, which by the prime number theorem ($\\log \\text{lcm}(1, \\ldots, m) = \\psi(m) \\sim m$) gives $n_k \\leq e^{(1+o(1))k}$. The gap between $n_k \\geq 2k$ (trivial) and $n_k \\leq e^{(1+o(1))k}$ remains vast — whether $n_k$ grows polynomially or exponentially is the central open question.",
@@ -230,7 +230,7 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1063Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -49,7 +49,7 @@
     ],
     "lineCount": 465,
     "theoremCount": 16,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -183,7 +183,7 @@
     "lineCount": 465,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 3,
+    "definitionCount": 6,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Fix

PR #16420's regex undercounted definitions prefixed with `@[reducible]`,
mirroring the `@[simp] private lemma` regression from PR #16412 (reverted in #16427).
Restore the pre-#16420 values which correctly counted `def + abbrev + opaque` after
stripping comments and attribute decorators.

## Evidence

| slug | meta/lf was | actual | new | missed by #16420 |
|------|-------------|--------|-----|------------------|
| `erdos-1027` | 11 | 14 | 14 | `@[reducible] def IntersectsAll`, `ContainsNone`, `IsGoodSet` |
| `erdos-1063` | 4  | 5  | 5  | `@[reducible] def AllButOneDivide` |
| `roth-theorem-k3-oq-02` | 3 | 6 | 6 | `@[reducible] def xVert`, `yVert`, `zVert` |

Verification (each Lean file, after stripping `/- … -/` and `--` comments):

```bash
git show origin/main:proofs/Proofs/Erdos1027Problem.lean \
  | grep -cE '\b(def|abbrev|opaque)\s+[A-Za-z]'
# 14

git show origin/main:proofs/Proofs/Erdos1063Problem.lean \
  | grep -cE '\b(def|abbrev|opaque)\s+[A-Za-z]'
# 5

git show origin/main:proofs/Proofs/RothTriangleRemoval.lean \
  | grep -cE '\b(def|abbrev|opaque)\s+[A-Za-z]'
# 6
```

## Convention

Per `leanFile.definitionCount` convention (cross-validated 2026-05-04 PR #15533):
count `def + abbrev + opaque` regardless of `@[reducible]`, `@[simp]`, or other
attribute decorators. PR #16420's body claimed regex tolerance for `@[reducible]`
but the implementation missed it on these 3 entries (X→Y oscillation per the
PR #16412/#16427 pattern).

No code changes; status, badge, theoremCount, axiomCount, sorries, lineCount unchanged.

---
Automated fix by lean-mechanic agent.