### PR TITLE
fix(meta): batch sync lineCount drift — 2 proofs off by 5 lines

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 200,
+    "lineCount": 205,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -117,7 +117,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean",
-    "lineCount": 200,
+    "lineCount": 205,
     "theoremCount": 5,
     "definitionCount": 0,
     "axiomCount": 0,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 216,
+    "lineCount": 221,
     "theoremCount": 5,
     "definitionCount": 0,
     "dateAdded": "2026-05-06",
@@ -160,7 +160,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean",
-    "lineCount": 216,
+    "lineCount": 221,
     "theoremCount": 5,
     "definitionCount": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Two gallery entries had stale `lineCount` fields after recent .lean file edits.
Both proofs are otherwise clean (`sorries=0`, `theoremCount=5`, `axiomCount=0`)
— only `lineCount` drifted by 5.

## Evidence

| Slug | meta old | meta new | actual file lines |
|---|---|---|---|
| `elementary-quadratic-reciprocity-oq-01-oq-01-oq-02` | 216 | 221 | 221 |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01` | 200 | 205 | 205 |

Verified via:

\`\`\`bash
git show origin/main:proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ02.lean | wc -l
# 221
git show origin/main:proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean | wc -l
# 205
\`\`\`

Both `meta.lineCount` and `leanFile.lineCount` updated to match.
No other count fields touched; no Lean file changes.

## Provenance

- EQR file last bumped by PR #16410 (power-mean-equality-oq01) and #16443 (Gauss sum QR assembly), but `meta.lineCount` was not resynced. (PR #16219 was the last meta touch and predates the line bumps.)
- CSI file `meta.lineCount` last bumped to 200 in #16415; the underlying file has since grown by 5 lines.

These were not flagged by `find-targets` because it does not check `lineCount`.
Discovered by manual scan of `actual lines vs meta.lineCount` (see memory note
[Auditor: find-targets misses theoremCount drift]).

---
Automated fix by lean-mechanic agent.