### PR TITLE
research(erdos-741): prove cofinite_density_one (axiom → theorem)

### DIFF
--- a/proofs/Proofs/Erdos741Problem.lean
+++ b/proofs/Proofs/Erdos741Problem.lean
@@ -242,42 +242,57 @@ theorem basis_infinite {A : Set ℕ} (h : IsBasisOrder2 A) : A.Infinite := by
   omega
 
 /-- A cofinite set (containing all sufficiently large n) has density 1.
-    Proof: for n ≥ N₀, |S∩{0,...,n}| ≥ n-N₀+1, giving ratio ≥ (n-N₀+1)/(n+1) → 1. -/
+    Proof strategy: for n ≥ N₀, |S∩{0,...,n}| ≥ n-N₀+1, so ratio ≥ (n-N₀+1)/(n+1) → 1.
+    Combined with ratio ≤ 1 (density_le_one), limsup = 1. -/
 theorem cofinite_density_one {S : Set ℕ} (h : ∀ᶠ n in atTop, n ∈ S) :
     upperDensity S = 1 := by
-  apply le_antisymm (density_le_one S)
   rw [Filter.eventually_atTop] at h
   obtain ⟨N₀, hN₀⟩ := h
+  apply le_antisymm (density_le_one S)
   unfold upperDensity
-  rw [Filter.le_limsup_iff]
-  intro b hb
-  rw [Filter.frequently_atTop]
-  intro M
-  have h1mb : (0 : ℝ) < 1 - b := by linarith
-  obtain ⟨N, hN_gt⟩ := exists_nat_gt (N₀ / (1 - b))
-  refine ⟨max M (max N N₀), le_max_left _ _, ?_⟩
-  set n := max M (max N N₀) with hn_def
-  have hn_ge_N : N ≤ n := (le_max_left N N₀).trans (le_max_right M _)
-  have hn_ge_N₀ : N₀ ≤ n := (le_max_right N N₀).trans (le_max_right M _)
-  -- |S ∩ {0,...,n}| ≥ n - N₀ + 1 (all of {N₀,...,n} is in S)
-  have hcard_lb : n - N₀ + 1 ≤ (S ∩ Set.Iic n).ncard := by
-    have hfin : (S ∩ Set.Iic n).Finite := (Set.finite_Iic n).subset (Set.inter_subset_right)
-    have hincl : Finset.Icc N₀ n ⊆ hfin.toFinset := by
+  -- Card bound: for n ≥ N₀, |S ∩ Iic n| ≥ n - N₀ + 1 via {N₀,...,n} ⊆ S
+  have hcard : ∀ n ≥ N₀, (n - N₀ + 1 : ℕ) ≤ (S ∩ Set.Iic n).ncard := by
+    intro n hn
+    have hfin : (S ∩ Set.Iic n).Finite :=
+      (Set.finite_Iic n).subset Set.inter_subset_right
+    have hincl : (Finset.Icc N₀ n : Set ℕ) ⊆ S ∩ Set.Iic n := by
       intro m hm
-      simp only [Finset.mem_Icc] at hm
-      simp only [Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_Iic]
+      simp only [Finset.coe_Icc, Set.mem_Icc] at hm
       exact ⟨hN₀ m hm.1, hm.2⟩
-    have : (Finset.Icc N₀ n).card ≤ hfin.toFinset.card := Finset.card_le_card hincl
-    rwa [Nat.Icc_card_eq_sub_add_one hn_ge_N₀, Set.ncard_eq_toFinset_card' _,
-         Set.Finite.toFinset_inter, Set.toFinset_Iic] at this
-  -- (n - N₀ + 1)/(n+1) > b
-  have hn_pos : (0 : ℝ) < n + 1 := by positivity
-  rw [lt_div_iff hn_pos]
-  -- b * (n + 1) < n - N₀ + 1, i.e., (1-b)*(n+1) > N₀
-  push_cast [Nat.sub_add_cancel hn_ge_N₀]
-  have hN₀_lt : (N₀ : ℝ) < (N + 1) * (1 - b) := by
-    have := hN_gt; push_cast at this ⊢; nlinarith
-  nlinarith [Nat.cast_le.mpr hn_ge_N, Nat.cast_nonneg N₀]
+    calc n - N₀ + 1 = (Finset.Icc N₀ n).card := by simp [Nat.Icc_card_eq_sub_add_one hn]
+      _ = ((Finset.Icc N₀ n : Set ℕ)).ncard := (Set.ncard_coe_Finset _).symm
+      _ ≤ (S ∩ Set.Iic n).ncard := Set.ncard_le_ncard hincl hfin
+  -- The ratio sequence is eventually ≥ 1 - N₀/(n+1)
+  have hlb : ∀ᶠ n : ℕ in Filter.atTop,
+      (1 : ℝ) - N₀ / (↑n + 1) ≤ ((S ∩ Set.Iic n).ncard : ℝ) / (↑n + 1) := by
+    filter_upwards [Filter.eventually_ge_atTop N₀] with n hn
+    have hn_pos : (0 : ℝ) < n + 1 := by positivity
+    rw [div_le_div_iff hn_pos hn_pos]  -- both as cross-multiply
+    have hc := Nat.cast_le.mpr (hcard n hn)
+    push_cast [Nat.sub_add_cancel hn] at hc ⊢
+    linarith
+  -- 1 - N₀/(n+1) → 1 as n → ∞
+  have htend_lb : Filter.Tendsto (fun n : ℕ => (1 : ℝ) - N₀ / (↑n + 1))
+      Filter.atTop (nhds 1) := by
+    rw [show (1 : ℝ) = 1 - 0 from by ring]
+    apply Filter.Tendsto.sub tendsto_const_nhds
+    -- N₀/(n+1) → 0: write as N₀ * (n+1)⁻¹ → N₀ * 0 = 0
+    simp_rw [div_eq_mul_inv]
+    rw [show (0 : ℝ) = N₀ * 0 from (mul_zero _).symm]
+    apply Filter.Tendsto.const_mul
+    -- (n+1)⁻¹ → 0 since n+1 → ∞
+    apply Filter.Tendsto.inv_tendsto_atTop
+    apply Filter.tendsto_atTop_atTop.mpr
+    intro b; refine ⟨⌈b⌉₊, fun n hn => ?_⟩
+    have hb : b ≤ (⌈b⌉₊ : ℝ) := Nat.le_ceil b
+    have hn_cast : (⌈b⌉₊ : ℝ) ≤ (n : ℝ) := Nat.cast_le.mpr hn
+    linarith
+  -- limsup ≥ lim of lower bound = 1
+  calc (1 : ℝ) = atTop.limsup (fun n : ℕ => 1 - ↑N₀ / (↑n + 1)) := by
+          exact (htend_lb.limsup_eq ⟨1, Filter.eventually_of_forall fun n => by
+            apply sub_le_self; positivity⟩).symm
+      _ ≤ atTop.limsup (fun n : ℕ => ((S ∩ Set.Iic n).ncard : ℝ) / (↑n + 1)) :=
+          Filter.limsup_le_limsup hlb
 
 /-- A basis of order 2 has positive density sumset. -/
 theorem basis_has_pos_density_sumset {A : Set ℕ} (h : IsBasisOrder2 A) :

--- a/proofs/Proofs/Erdos741Problem.lean
+++ b/proofs/Proofs/Erdos741Problem.lean
@@ -241,9 +241,43 @@ theorem basis_infinite {A : Set ℕ} (h : IsBasisOrder2 A) : A.Infinite := by
   have := hS_bound _ hm
   omega
 
-/-- A cofinite set (containing all sufficiently large n) has density 1. -/
-axiom cofinite_density_one {S : Set ℕ} (h : ∀ᶠ n in atTop, n ∈ S) :
-    upperDensity S = 1
+/-- A cofinite set (containing all sufficiently large n) has density 1.
+    Proof: for n ≥ N₀, |S∩{0,...,n}| ≥ n-N₀+1, giving ratio ≥ (n-N₀+1)/(n+1) → 1. -/
+theorem cofinite_density_one {S : Set ℕ} (h : ∀ᶠ n in atTop, n ∈ S) :
+    upperDensity S = 1 := by
+  apply le_antisymm (density_le_one S)
+  rw [Filter.eventually_atTop] at h
+  obtain ⟨N₀, hN₀⟩ := h
+  unfold upperDensity
+  rw [Filter.le_limsup_iff]
+  intro b hb
+  rw [Filter.frequently_atTop]
+  intro M
+  have h1mb : (0 : ℝ) < 1 - b := by linarith
+  obtain ⟨N, hN_gt⟩ := exists_nat_gt (N₀ / (1 - b))
+  refine ⟨max M (max N N₀), le_max_left _ _, ?_⟩
+  set n := max M (max N N₀) with hn_def
+  have hn_ge_N : N ≤ n := (le_max_left N N₀).trans (le_max_right M _)
+  have hn_ge_N₀ : N₀ ≤ n := (le_max_right N N₀).trans (le_max_right M _)
+  -- |S ∩ {0,...,n}| ≥ n - N₀ + 1 (all of {N₀,...,n} is in S)
+  have hcard_lb : n - N₀ + 1 ≤ (S ∩ Set.Iic n).ncard := by
+    have hfin : (S ∩ Set.Iic n).Finite := (Set.finite_Iic n).subset (Set.inter_subset_right)
+    have hincl : Finset.Icc N₀ n ⊆ hfin.toFinset := by
+      intro m hm
+      simp only [Finset.mem_Icc] at hm
+      simp only [Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_Iic]
+      exact ⟨hN₀ m hm.1, hm.2⟩
+    have : (Finset.Icc N₀ n).card ≤ hfin.toFinset.card := Finset.card_le_card hincl
+    rwa [Nat.Icc_card_eq_sub_add_one hn_ge_N₀, Set.ncard_eq_toFinset_card' _,
+         Set.Finite.toFinset_inter, Set.toFinset_Iic] at this
+  -- (n - N₀ + 1)/(n+1) > b
+  have hn_pos : (0 : ℝ) < n + 1 := by positivity
+  rw [lt_div_iff hn_pos]
+  -- b * (n + 1) < n - N₀ + 1, i.e., (1-b)*(n+1) > N₀
+  push_cast [Nat.sub_add_cancel hn_ge_N₀]
+  have hN₀_lt : (N₀ : ℝ) < (N + 1) * (1 - b) := by
+    have := hN_gt; push_cast at this ⊢; nlinarith
+  nlinarith [Nat.cast_le.mpr hn_ge_N, Nat.cast_nonneg N₀]
 
 /-- A basis of order 2 has positive density sumset. -/
 theorem basis_has_pos_density_sumset {A : Set ℕ} (h : IsBasisOrder2 A) :

--- a/proofs/Proofs/Erdos741Problem.lean
+++ b/proofs/Proofs/Erdos741Problem.lean
@@ -196,8 +196,8 @@ theorem density_univ : upperDensity Set.univ = 1 := by
   ext n
   have hn : (n : ℝ) + 1 ≠ 0 := by positivity
   have hIic : (Set.Iic n : Set ℕ).ncard = n + 1 := by
-    rw [← Set.ncard_coe_Finset, Finset.toSet_toFinset]
-    simp [Set.toFinset_Iic, Finset.card_Iic]
+    rw [show (Set.Iic n : Set ℕ) = ↑(Finset.Iic n) from by simp [Finset.coe_Iic]]
+    rw [Set.ncard_coe_Finset]; simp [Finset.card_Iic]
   rw [hIic, div_eq_one_iff_eq hn]
   push_cast; ring
 
@@ -205,7 +205,8 @@ theorem density_univ : upperDensity Set.univ = 1 := by
 theorem density_mono {A B : Set ℕ} (h : A ⊆ B) : upperDensity A ≤ upperDensity B := by
   unfold upperDensity
   apply Filter.limsup_le_limsup
-  · filter_upwards [] with n
+  · apply Filter.eventually_of_forall
+    intro n
     apply div_le_div_of_nonneg_right _ (by positivity : (0 : ℝ) ≤ (n : ℝ) + 1)
     exact_mod_cast Set.ncard_le_ncard (Set.inter_subset_inter_left _ h)
         ((Set.Iic n).toFinite.subset Set.inter_subset_right)
@@ -228,7 +229,7 @@ theorem basis_infinite {A : Set ℕ} (h : IsBasisOrder2 A) : A.Infinite := by
   by_contra hfin
   push_neg at hfin
   -- All elements of A are ≤ n
-  have hA_bound : ∀ a ∈ A, a ≤ n := fun a ha => le_of_not_gt (fun h => hfin a ha h)
+  have hA_bound : ∀ a ∈ A, a ≤ n := fun a ha => hfin a ha
   -- Then sumset A A ⊆ [0, 2n]
   have hS_bound : ∀ s ∈ sumset A A, s ≤ 2 * n := by
     rintro s ⟨a, ha, b, hb, rfl⟩

--- a/proofs/Proofs/Erdos741Problem.lean
+++ b/proofs/Proofs/Erdos741Problem.lean
@@ -195,23 +195,25 @@ theorem density_univ : upperDensity Set.univ = 1 := by
     rw [h]; exact Filter.limsup_const 1
   ext n
   have hn : (n : ℝ) + 1 ≠ 0 := by positivity
-  rw [Set.ncard_Iic, div_eq_one_iff_eq hn]
+  have hIic : (Set.Iic n : Set ℕ).ncard = n + 1 := by
+    rw [← Set.ncard_coe_Finset, Finset.toSet_toFinset]
+    simp [Set.toFinset_Iic, Finset.card_Iic]
+  rw [hIic, div_eq_one_iff_eq hn]
   push_cast; ring
 
 /-- Density is monotone: A ⊆ B implies upperDensity A ≤ upperDensity B. -/
 theorem density_mono {A B : Set ℕ} (h : A ⊆ B) : upperDensity A ≤ upperDensity B := by
   unfold upperDensity
   apply Filter.limsup_le_limsup
-  · exact Filter.eventually_of_forall (fun n => by
-      apply div_le_div_of_nonneg_right _ (by positivity : (0 : ℝ) ≤ (n : ℝ) + 1)
-      exact_mod_cast Set.ncard_le_ncard (Set.inter_subset_inter_left _ h)
-        ((Set.Iic n).toFinite.subset Set.inter_subset_right))
+  · filter_upwards [] with n
+    apply div_le_div_of_nonneg_right _ (by positivity : (0 : ℝ) ≤ (n : ℝ) + 1)
+    exact_mod_cast Set.ncard_le_ncard (Set.inter_subset_inter_left _ h)
+        ((Set.Iic n).toFinite.subset Set.inter_subset_right)
 
 /-- Upper density is at most 1 for any set. -/
 theorem density_le_one (A : Set ℕ) : upperDensity A ≤ 1 :=
   density_univ ▸ density_mono (Set.subset_univ A)
 
-/-- Every finite set has zero upper density. -/
 /-
 ## Basis Properties
 -/
@@ -234,7 +236,7 @@ theorem basis_infinite {A : Set ℕ} (h : IsBasisOrder2 A) : A.Infinite := by
     have := hA_bound b hb
     omega
   -- But h says all large enough numbers are in sumset A A
-  rw [Filter.Eventually, Filter.mem_atTop_sets] at h
+  rw [Filter.eventually_atTop] at h
   obtain ⟨N, hN⟩ := h
   -- Take m = max(N, 2*n + 1)
   have hm := hN (max N (2 * n + 1)) (le_max_left _ _)
@@ -259,7 +261,7 @@ theorem cofinite_density_one {S : Set ℕ} (h : ∀ᶠ n in atTop, n ∈ S) :
       intro m hm
       simp only [Finset.coe_Icc, Set.mem_Icc] at hm
       exact ⟨hN₀ m hm.1, hm.2⟩
-    calc n - N₀ + 1 = (Finset.Icc N₀ n).card := by simp [Nat.Icc_card_eq_sub_add_one hn]
+    calc n - N₀ + 1 = (Finset.Icc N₀ n).card := by simp [Finset.card_Icc]; omega
       _ = ((Finset.Icc N₀ n : Set ℕ)).ncard := (Set.ncard_coe_Finset _).symm
       _ ≤ (S ∩ Set.Iic n).ncard := Set.ncard_le_ncard hincl hfin
   -- The ratio sequence is eventually ≥ 1 - N₀/(n+1)
@@ -289,8 +291,8 @@ theorem cofinite_density_one {S : Set ℕ} (h : ∀ᶠ n in atTop, n ∈ S) :
     linarith
   -- limsup ≥ lim of lower bound = 1
   calc (1 : ℝ) = atTop.limsup (fun n : ℕ => 1 - ↑N₀ / (↑n + 1)) := by
-          exact (htend_lb.limsup_eq ⟨1, Filter.eventually_of_forall fun n => by
-            apply sub_le_self; positivity⟩).symm
+          exact (htend_lb.limsup_eq ⟨1, by
+            filter_upwards [] with n; apply sub_le_self; positivity⟩).symm
       _ ≤ atTop.limsup (fun n : ℕ => ((S ∩ Set.Iic n).ncard : ℝ) / (↑n + 1)) :=
           Filter.limsup_le_limsup hlb
 


### PR DESCRIPTION
## Summary

Converts the `cofinite_density_one` axiom in `Erdos741Problem.lean` to a proved theorem, reducing the axiom count from 1 → 0.

Also fixes pre-existing Lean 4.26.0 API drift in the file (affecting `density_univ`, `density_mono`, `basis_infinite`).

**Statement**: A cofinite set S (one containing all sufficiently large natural numbers) has upper density = 1.

## Proof Strategy

Given `h : ∀ᶠ n in atTop, n ∈ S`, obtain `N₀` such that all `n ≥ N₀` are in S.

1. **Card bound**: For n ≥ N₀, `|S ∩ {0,...,n}| ≥ n - N₀ + 1` via `{N₀,...,n} ⊆ S ∩ Iic n` (proved with `Finset.card_le_card`)
2. **Lower bound**: `(n-N₀+1)/(n+1) ≤ |S∩{0,...,n}|/(n+1)` for n ≥ N₀
3. **Tendency**: `1 - N₀/(n+1) → 1` via `Filter.Tendsto.const_mul` + `inv_tendsto_atTop`  
4. **limsup**: `1 = limsup (1-N₀/(n+1)) ≤ limsup |S∩{0,...,n}|/(n+1)` by `limsup_le_limsup`

## API Drift Fixes

- `density_univ`: `Set.ncard_Iic` → explicit computation via `Finset.coe_Iic + Set.ncard_coe_Finset`
- `density_mono`: `Filter.eventually_of_forall` → `apply Filter.eventually_of_forall; intro n`
- `basis_infinite`: `rw [Filter.Eventually, mem_atTop_sets]` → `rw [Filter.eventually_atTop]`; `hA_bound` simplification fixed
- Removed orphaned doc comment causing parse error

## Files Modified

- `proofs/Proofs/Erdos741Problem.lean` — axiom → theorem + API drift fixes

🤖 Generated by researcher-1