### PR TITLE
audit(chebyshev-pnt-bridge-oq-01): remove stale sorry references in prose

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -55,14 +55,14 @@
       "title": "p-adic Valuation Infrastructure",
       "startLine": 26,
       "endLine": 68,
-      "summary": "Establishes the carry-counting framework: Legendre's formula for $v_p(n!)$ (sorry), the carry bound $\\lfloor 2n/p^i \\rfloor - 2\\lfloor n/p^i \\rfloor \\leq 1$ (proved), vanishing of carries for $p^i > 2n$ (proved), and existence of a truncation point $k \\leq 2n$ with $p^k > 2n$ (proved by induction on $2^{2n} > 2n$)."
+      "summary": "Establishes the carry-counting framework: Legendre's formula for $v_p(n!)$ (proved via `Nat.Prime.multiplicity_factorial`), the carry bound $\\lfloor 2n/p^i \\rfloor - 2\\lfloor n/p^i \\rfloor \\leq 1$ (proved), vanishing of carries for $p^i > 2n$ (proved), and existence of a truncation point $k \\leq 2n$ with $p^k > 2n$ (proved by induction on $2^{2n} > 2n$)."
     },
     {
       "id": "main-bound",
       "title": "Main Factorization Bound",
       "startLine": 70,
       "endLine": 86,
-      "summary": "Proves the main theorem $p^{v_p\\binom{2n}{n}} \\leq 2n$ via Mathlib's `Nat.pow_factorization_choose_le`. States the corollary $\\binom{2n}{n} \\leq (2n)^{\\pi(2n)}$ (sorry)."
+      "summary": "Proves the main theorem $p^{v_p\\binom{2n}{n}} \\leq 2n$ via Mathlib's `Nat.pow_factorization_choose_le`. Proves the corollary $\\binom{2n}{n} \\leq (2n)^{\\pi(2n)}$ by reconstructing the central binomial from its prime factorization via `Nat.factorization_prod_pow_eq_self`."
     },
     {
       "id": "chebyshev-connection",
@@ -80,11 +80,9 @@
     }
   ],
   "conclusion": {
-    "summary": "Establishes the key factorization bound $p^{v_p\\binom{2n}{n}} \\leq 2n$ for Chebyshev's argument, proved in one line via Mathlib's `Nat.pow_factorization_choose_le`. Also proves the central binomial lower bound $(2n+1)\\binom{2n}{n} \\geq 4^n$ and synthesizes Chebyshev's combined inequality. The carry-counting infrastructure (carry bound, vanishing for large powers, digit count bound) is fully proved, though 2 sorries remain in the Legendre formula connection and the product bound corollary.",
-    "implications": "This factorization bound is the combinatorial core of Chebyshev's elementary approach to prime distribution. Combined with the central binomial lower bound, it gives $\\pi(x) \\geq c \\cdot x/\\ln x$ without any analytic machinery — a remarkable result that predated the Prime Number Theorem by nearly 50 years. Closing the 2 remaining sorries would complete the formal chain from Kummer's theorem to Chebyshev's bound.",
+    "summary": "Establishes the key factorization bound $p^{v_p\\binom{2n}{n}} \\leq 2n$ for Chebyshev's argument, proved in one line via Mathlib's `Nat.pow_factorization_choose_le`. Also proves the central binomial lower bound $(2n+1)\\binom{2n}{n} \\geq 4^n$ and synthesizes Chebyshev's combined inequality. The carry-counting infrastructure (Legendre formula, carry bound, vanishing for large powers) and the product bound corollary are fully proved with 0 axioms and 0 sorries.",
+    "implications": "This factorization bound is the combinatorial core of Chebyshev's elementary approach to prime distribution. Combined with the central binomial lower bound, it gives $\\pi(x) \\geq c \\cdot x/\\ln x$ without any analytic machinery — a remarkable result that predated the Prime Number Theorem by nearly 50 years. The complete formal chain from Kummer's theorem to Chebyshev's bound is now established.",
     "openQuestions": [
-      "Can the sorry in `legendre_factorial_val` be closed by connecting `Nat.factorization` to the floor-sum representation, possibly via `Nat.Prime.factorization_factorial`?",
-      "Can the product bound `central_binom_le_pow_prime_counting` be proved using `Nat.factorization_prod_pow_eq_self` to reconstruct the central binomial from its prime factorization?",
       "Can this be extended to prove Bertrand's postulate ($\\exists$ prime $p$ with $n < p \\leq 2n$) by refining the upper bound on $\\binom{2n}{n}$ to exclude primes in $(\\sqrt{2n}, 2n/3)$?"
     ]
   },


### PR DESCRIPTION
## Summary

`chebyshev-pnt-bridge-oq-01/meta.json` has structurally correct counts (sorries=0, axiomCount=0) and the assumptions field correctly states "0 axioms, 0 sorries. Fully proved", but section summaries, conclusion, and openQuestions still describe the pre-#10539 state when 2 sorries remained.

The Lean file `ChebyshevPNTBridgeOQ01.lean` was upgraded from 2 sorries to 0 in #10539 (Research: chebyshev-pnt-bridge-oq-01 complete (2→0 sorries)). The narrative was never refreshed.

## Verification

- `git show origin/main:proofs/Proofs/ChebyshevPNTBridgeOQ01.lean | grep sorry` → no matches
- `legendre_factorial_val` (line 32): fully proved using `hp.multiplicity_factorial`
- `central_binom_le_pow_prime_counting` (line 111): fully proved using `factorization_prod_pow_eq_self`

## Changes

- Section "p-adic Valuation Infrastructure" summary: `(sorry)` → `(proved via Nat.Prime.multiplicity_factorial)` for `legendre_factorial_val`
- Section "Main Factorization Bound" summary: `States the corollary ... (sorry)` → `Proves the corollary ... via factorization_prod_pow_eq_self`
- `conclusion.summary`: removed contradiction "carry-counting infrastructure ... is fully proved, though 2 sorries remain..."
- `conclusion.implications`: removed "Closing the 2 remaining sorries..."
- Dropped two stale openQuestions about closing the now-proved sorries; kept the Bertrand's postulate question

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(...)"`)
- [x] Counts unchanged (sorries=0, axiomCount=0, lineCount=210, theoremCount=11, definitionCount=0)
- [x] No Lean changes; pure prose drift fix

Discovered during gallery integrity audit (find-targets misses prose drift).