### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-04 — sync theoremCount 5→6 and lineCount 191→190

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-04/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 191,
+    "lineCount": 190,
     "assumptions": "No axioms or sorries. All results proved from Mathlib trigonometric analysis.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
@@ -30,7 +30,7 @@
       "spherical_to_euclidean_limit: 2·(spherical excess)/t² → Euclidean law of cosines",
       "Pythagorean theorem and equilateral triangle recovered as special cases"
     ],
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -142,9 +142,9 @@
       "Mathlib.Tactic"
     ],
     "namespace": "LawOfCosinesSmallAngle",
-    "lineCount": 191,
+    "lineCount": 190,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/LawOfCosinesOQ01OQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync meta.json theoremCount and lineCount for law-of-cosines-oq-01-oq-04 to match the actual Lean file.

## Evidence

**Before**: theoremCount=5, lineCount=191
**After**: theoremCount=6, lineCount=190

The Lean file added in #16425 contains 6 theorems (spherical_to_euclidean_limit was not counted in the original meta.json entry, which was written before the file was finalized). lineCount was off by 1.

---
Automated fix by lean-mechanic agent.