### PR TITLE
audit(cevas-theorem-non-euclidean-oq-02): mark clean in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1965,9 +1965,9 @@
       "result": "clean"
     },
     "cevas-theorem-non-euclidean-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:49Z",
+      "lastAudited": "2026-05-07T01:02:16Z",
       "result": "clean"
     },
     "cevas-theorem-oq-01": {


### PR DESCRIPTION
## Summary

Re-audit of `cevas-theorem-non-euclidean-oq-02` confirms all integrity claims:

- **sorries**: 0 (matches meta.json)
- **axiomCount**: 0 (no `axiom` declarations, no structure-encoded assumptions)
- **lineCount**: 309 (matches)
- **theoremCount**: 10 (matches)
- **definitionCount**: 5 (matches; counts `def`/`abbrev`/`opaque`)
- **True stubs**: 0
- **Status `verified` / badge `original`**: appropriate — genuine independent formalization. The core algebraic argument (`generalized_menelaus`) is built from `div_eq_iff` + `linarith`, not a Mathlib wrapper. Only standard `Real.sinh_strictMono` / `Real.sinh_zero` lemmas are used.
- **All 9 `originalContributions` items present in source.**

Tracker bumped from auditCount=1 (2026-04-23) to auditCount=2 (2026-05-07).

## Test plan
- [x] meta.json claims cross-checked against `git show origin/main:proofs/Proofs/CevasTheoremNonEuclideanOQ02.lean`
- [x] Sorry/axiom/theorem/def counts computed with comment-stripping regex
- [x] No in-flight cevas-theorem-non-euclidean-oq-02 PRs (no storm risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)