### PR TITLE
audit(tracker): mark 3 proofs clean — 2026-05-07 cycle 2

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1791,9 +1791,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:49Z",
+      "lastAudited": "2026-05-07T01:08:49Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-04": {
@@ -1874,9 +1874,9 @@
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:49Z",
+      "lastAudited": "2026-05-07T01:08:49Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-02": {
@@ -1924,9 +1924,9 @@
       "result": "clean"
     },
     "central-limit-theorem-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:49Z",
+      "lastAudited": "2026-05-07T01:07:11Z",
       "result": "clean"
     },
     "central-limit-theorem-oq-01-oq-03": {


### PR DESCRIPTION
## Summary

Mark 3 proofs `clean` in `src/data/proofs/audit-tracker.json` after manual verification on `origin/main`.

| Proof | Result |
|-------|--------|
| central-limit-theorem-oq-01-oq-02-oq-01-oq-01 | clean |
| cayley-hamilton-reduction-oq-01-oq-02 | clean |
| cayley-hamilton-minpoly-oq-03-oq-01 | clean |

## Verification

For each proof, stripped block/line comments and counted `sorry`/`axiom`/`(theorem|lemma)`/`(def|abbrev|opaque)` declarations. All counts match the meta.json `meta` block AND the `leanFile` block.

E.g. central-limit-theorem-oq-01-oq-02-oq-01-oq-01:
- meta says: 176 lines, 0 sorries, 0 axioms, 14 theorems, 2 defs
- file shows: 176 lines, 0 sorries, 0 axioms, 14 theorems, 2 defs

No meta.json or Lean changes — tracker-only.

## Test plan

- [x] JSON validates
- [x] Only `audit-tracker.json` modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)