### PR TITLE
audit(tracker): bump erdos-1107-oq-02 re-audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3873,9 +3873,9 @@
       "result": "clean"
     },
     "erdos-1107-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T01:13:35Z",
       "result": "clean"
     },
     "erdos-1108": {


### PR DESCRIPTION
## Summary
- Re-audited `erdos-1107-oq-02` (Effective Squareful Sum Threshold)
- All counts match meta.json: 0 sorries, 1 axiom, 25 theorems, 3 defs, 156 lines
- 0 True stubs; status `axiomatized`/badge `axiom` correctly disclose the single Heath-Brown axiom (`squareful_sum_threshold`)
- Narrative properly credits axiomatized component; no overclaiming
- Bumps `auditCount` 1→2 and `lastAudited` to 2026-05-07

## Test plan
- [ ] Tracker JSON parses cleanly