### PR TITLE
fix(meta): erdos-1034 — sync theoremCount 17→16

### DIFF
--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -29,7 +29,7 @@
     "lineCount": 779,
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 17,
+    "theoremCount": 16,
     "definitionCount": 22
   },
   "overview": {
@@ -277,7 +277,7 @@
     "namespace": "Erdos1034",
     "lineCount": 779,
     "axiomCount": 1,
-    "theoremCount": 17,
+    "theoremCount": 16,
     "definitionCount": 22,
     "path": "Proofs/Erdos1034Problem.lean",
     "sorries": 3


### PR DESCRIPTION
## Fix

Sync `theoremCount` in both `meta.theoremCount` and `leanFile.theoremCount` from 17 → 16 for `erdos-1034`.

## Evidence

**Before**: `meta.theoremCount = 17`, `leanFile.theoremCount = 17`
**After**: both = 16

Counted theorems in `proofs/Proofs/Erdos1034Problem.lean` after stripping nested block comments:

| line | declaration |
|------|-------------|
| 134 | `theorem Triangle.card_vertices` |
| ~~290~~ | ~~`theorem erdos_faudree_false` (inside `/- Aristotle ... -/` block)~~ |
| 300 | `theorem erdos_faudree_false` |
| 336 | `theorem maTang_approx` |
| 351 | `theorem h_upper_bound` |
| 425 | `theorem book_pages_are_good` |
| 444 | `theorem h_lower_bound` |
| 470 | `theorem h_bounds` |
| 481 | `theorem gap_value` |
| 502 | `theorem k4Free_approx` |
| 510 | `theorem k4free_worse` |
| 550 | `theorem stronger_than_905` |
| 628 | `theorem erdos_1034_partial` |
| 638 | `theorem erdos_1034_disproved` |
| 663 | `theorem triangle_vertex_adjacent` |
| 693 | `theorem fully_adjacent_is_good` |
| 734 | `theorem book_subset_good` |

The first `theorem erdos_faudree_false` at line 290 lives inside a nested `/- Aristotle found this block to be false. ... -/` block comment that wraps a discarded automated proof attempt. Counting theorems naively (e.g. `grep -c "^theorem "`) overcounts by 1.

This drift came in via PR #15037 (a batch `theoremCount` fix). The Lean source file has not changed since.

---
Automated fix by lean-mechanic agent.