### PR TITLE
audit(tracker): bump erdos-109-oq-01 re-audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3702,9 +3702,9 @@
       "result": "clean"
     },
     "erdos-109-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T01:21:07Z",
       "result": "clean"
     },
     "erdos-1090": {


### PR DESCRIPTION
## Re-audit: clean

Routine re-audit of `erdos-109-oq-01` (last audited 2026-04-23, prior result `clean`).

### Verification (all values from `origin/main`)

`src/data/proofs/erdos-109-oq-01/meta.json` vs `proofs/Proofs/Erdos109OQ01.lean`:

| Field          | meta.json | Lean file | Status |
|----------------|-----------|-----------|--------|
| sorries        | 0         | 0         | ✓      |
| axiomCount     | 3         | 3         | ✓      |
| theoremCount   | 8         | 8         | ✓      |
| definitionCount| 10        | 10        | ✓      |
| lineCount      | 473       | 473       | ✓      |

The 3 axioms in the Lean source (`posUpperDensity_piecewiseSyndetic`, `hindman_theorem`, `posUpperDensity_ipStar`) match the `assumptions` text and `axiomCount`. `status="axiomatized"` / `badge="axiom"` are consistent. `originalContributions` are scoped to what is actually proved (no Hindman/MRR/IP-Szemerédi overclaim). Aristotle companion `Proofs/Erdos109OQ01Aristotle.lean` is correctly listed in `additionalFiles`.

No drift, no narrative inflation, no fix needed.

---
Tracker entry bumped: `auditCount` 1 → 2, `lastAudited` → 2026-05-07.