### PR TITLE
fix(meta): sync lineCount/theoremCount drift — amgm-oq-03 and sum-of-kth-powers-oq-04

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 372,
+    "lineCount": 373,
     "focusedRange": {
       "startLine": 220,
       "endLine": 343
@@ -151,7 +151,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 372,
+    "lineCount": 373,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 12,

--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -57,7 +57,7 @@
       "Real power function (rpow) arithmetic and monotonicity",
       "Finset product and sum operations"
     ],
-    "lineCount": 372,
+    "lineCount": 373,
     "assumptions": "0 axioms, 0 sorries. Core building blocks (AM-GM, Jensen, AM ≤ M_p) from Mathlib; original proofs for HM ≤ GM, power mean monotonicity (positive and negative exponents), and duality identity.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
@@ -228,7 +228,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 372,
+    "lineCount": 373,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 3,

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -40,8 +40,8 @@
       "powerSumRatio_tendsto proof: general asymptotic 1/(k+1) via Faulhaber + filter limits"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 227,
-    "theoremCount": 9,
+    "lineCount": 254,
+    "theoremCount": 10,
     "definitionCount": 1,
     "prerequisites": [
       "Power sums and Faulhaber's formula",
@@ -145,9 +145,9 @@
       "Filter"
     ],
     "namespace": "SumOfKthPowersAsymptotic",
-    "lineCount": 227,
+    "lineCount": 254,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/SumOfKthPowersOQ04.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync lineCount and theoremCount after research PRs modified Lean files without updating meta.json.

## Evidence

**amgm-inequality-oq-03**
- **Before**: `lineCount: 372` (both meta and leanFile blocks)
- **After**: `lineCount: 373`
- **Cause**: PR #16419 changed trailing `/--` docstring to `/-` block comment (+1 line), counts were not updated.

**sum-of-kth-powers-oq-04**
- **Before**: `lineCount: 227, theoremCount: 9` (both blocks)
- **After**: `lineCount: 254, theoremCount: 10`
- **Cause**: PR #16450 ("fix forward reference bug in polynomial lemmas") expanded the file by 27 lines and added 1 theorem after PR #16447 had synced the counts to 227.

## Verification

Theorem counts verified by stripping comments and counting theorem/lemma/proposition declarations.

---
Automated fix by lean-mechanic agent.