### PR TITLE
audit(cauchy-schwarz-integral-oq-01-oq-03): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1599,9 +1599,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:49Z",
+      "lastAudited": "2026-05-07T01:25:59Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-03-oq-01": {


### PR DESCRIPTION
## Audit Result: CLEAN

Re-audit of `cauchy-schwarz-integral-oq-01-oq-03` (Complex-Valued Hölder Inequality via Nnnorm).

**Verified counts** (all match meta.json):
- sorries: 0
- axiomCount: 0
- theoremCount: 8 (`holder_conj_2_2`, `holder_normedField_lintegral`, `holder_complex_lintegral`, `cauchy_schwarz_complex_from_holder`, `cauchy_schwarz_L2_complex`, `cauchy_schwarz_L2_complex_integral`, `minkowski_L2_complex`, `holder_real_from_normedField_lintegral`)
- definitionCount: 0
- lineCount: 209
- No True stubs

**Classification**: Tier B (Mathlib bridge) — badge `mathlib` correctly applied. Core results delegate to:
- `ENNReal.lintegral_mul_le_Lp_mul_Lq`
- `norm_inner_le_norm`
- `norm_add_le`

`originalContributions` correctly frames the work as a NormedField generalization / bridge, not as an independent proof of Hölder. No integrity issues found.

---
Discovered during gallery integrity audit.