### PR TITLE
fix(meta): erdos-643 — sync theoremCount 42→39, definitionCount 20→16

### DIFF
--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -51,8 +51,8 @@
     "axiomCount": 3,
     "lineCount": 1403,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details.",
-    "theoremCount": 42,
-    "definitionCount": 20
+    "theoremCount": 39,
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration—four edges A,B,C,D where A∪B = C∪D but the pairs {A,B} and {C,D} are both disjoint—generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C₄, connecting to the classical Kővári–Sós–Turán theorem.\n\nFor hypergraphs (t≥3), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstraëte (2009) for 3-uniform hypergraphs, establishing f(n,3) ≤ (13/9)·C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
@@ -190,8 +190,8 @@
     "namespace": "Harmonic.GeneralizeProofs",
     "lineCount": 1403,
     "axiomCount": 3,
-    "theoremCount": 42,
-    "definitionCount": 20,
+    "theoremCount": 39,
+    "definitionCount": 16,
     "path": "Proofs/Erdos643Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Sync `theoremCount` (42 → 39) and `definitionCount` (20 → 16) in both `meta.*` and `leanFile.*` for `erdos-643`.

## Evidence

After stripping nested `/- ... -/` and `--` comments from `proofs/Proofs/Erdos643Problem.lean`:

- 6 `theorem` + 33 `lemma` = **39** declarations
- 15 `def` + 1 `abbrev` + 0 `opaque` = **16** declarations

`definitionCount` was 16 at PR #16012 and was raised to 20 by batch PR #16428 (which used an over-counting regex on this file). The Lean source has not changed since #16012, so the correct value is still 16. `theoremCount` has been 42 since at least #16012 and is also overstated by 3.

| field           | meta | leanFile | actual |
|-----------------|-----:|---------:|-------:|
| theoremCount    | ~~42~~ → 39 | ~~42~~ → 39 | 39 |
| definitionCount | ~~20~~ → 16 | ~~20~~ → 16 | 16 |

No status, badge, axiom, sorry, or narrative changes — pure numeric sync.

---
Automated fix by lean-mechanic agent.