### PR TITLE
research: Binary GCD extended to integers with Bézout identity

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ03.lean
@@ -354,19 +354,20 @@ theorem harmonic_mean_le_geom_mean_via_power
     (∑ i ∈ s, w i * (z i)⁻¹)⁻¹ ≤ weightedGeomMean s w z :=
   harmonic_mean_le_geom_mean_direct s w z hw hw' hz
 
-/-- **Summary: The Interpolation Chain**.
+/-
+Summary: The Interpolation Chain.
 
 The power means M_r form a continuous monotone family in r ∈ [-∞, +∞]:
 
     min(z) ≤ ... ≤ HM = M_{-1} ≤ GM = M_0 ≤ AM = M_1 ≤ M_2 ≤ ... ≤ max(z)
 
 Key proved relationships:
-- [✓] GM ≤ AM  (`geom_mean_le_arith_mean` — from Mathlib)
-- [✓] AM ≤ M_p for p ≥ 1  (`arith_mean_le_power_mean` — from Mathlib)
-- [✓] GM ≤ M_p for p ≥ 1  (`geom_mean_le_power_mean_of_one_le`)
-- [✓] Jensen's inequality  (`jensen_pow_ineq` — from Mathlib)
-- [✓] HM ≤ GM  (`harmonic_mean_le_geom_mean_direct` — proved here)
-- [✓] M_r ≤ M_s for 0 < r ≤ s  (`power_mean_monotone_pos` — proved here)
-- [✓] M_r ≤ M_s for r ≤ s < 0  (`power_mean_monotone_neg` — proved here via dual argument)
-- [axiom] Mixed-sign case (r < 0 < s, crossing the geometric mean limit) -/
--- Summary above; see individual theorems for formal proofs.
+- GM ≤ AM  (geom_mean_le_arith_mean — from Mathlib)
+- AM ≤ M_p for p ≥ 1  (arith_mean_le_power_mean — from Mathlib)
+- GM ≤ M_p for p ≥ 1  (geom_mean_le_power_mean_of_one_le)
+- Jensen's inequality  (jensen_pow_ineq — from Mathlib)
+- HM ≤ GM  (harmonic_mean_le_geom_mean_direct — proved here)
+- M_r ≤ M_s for 0 < r ≤ s  (power_mean_monotone_pos — proved here)
+- M_r ≤ M_s for r ≤ s < 0  (power_mean_monotone_neg — proved here via dual argument)
+- Mixed-sign case (r < 0 < s, crossing the geometric mean limit) is an axiom.
+-/

--- a/proofs/Proofs/BezoutIdentityOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ01OQ02.lean
@@ -1,0 +1,146 @@
+import Mathlib.Data.Int.GCD
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Tactic
+import Proofs.BezoutIdentityOQ01OQ01
+
+/-
+# Binary GCD Extended to Integers
+
+## Open Question (bezout-identity-oq-01-oq-01-oq-02)
+
+Can Stein's binary GCD algorithm be extended to handle integer inputs?
+
+## What This Proves
+
+The parent `BezoutIdentityOQ01OQ01` proves that `binaryGcd : ℕ → ℕ → ℕ` (Stein's
+algorithm using subtraction and halving) equals `Nat.gcd`. This file extends to ℤ:
+
+1. `intBinaryGcd` — defines the integer extension via `Int.natAbs`
+2. `intBinaryGcd_eq_gcd` — equals Mathlib's `Int.gcd` (as integers)
+3. `intBinaryGcd_nonneg` — non-negative
+4. `intBinaryGcd_dvd_left/right` — divisibility in ℤ
+5. `intBinaryGcd_comm` — symmetry
+6. `intBinaryGcd_neg_left/right` — sign invariance
+7. `intBinaryGcd_zero_left/right` — boundary cases
+8. `bezout_via_intBinaryGcd` — Bézout identity: ∃ u v, u*a + v*b = intBinaryGcd a b
+9. `dvd_intBinaryGcd` — any common divisor divides intBinaryGcd (via Bézout)
+
+## Key Insight
+
+`Int.gcd a b = Nat.gcd a.natAbs b.natAbs` (definitionally in Mathlib), so the
+extension reduces immediately to the natural number algorithm. Sign does not affect GCD.
+-/
+
+namespace BezoutIdentityOQ01OQ01OQ02
+
+open BezoutIdentityOQ01OQ01
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART I: DEFINITION
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The integer binary GCD: reduce to `natAbs` and apply Stein's algorithm.
+Returns a non-negative integer equal to `(Int.gcd a b : ℤ)`. -/
+def intBinaryGcd (a b : ℤ) : ℤ := ↑(binaryGcd a.natAbs b.natAbs)
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART II: CORE PROPERTIES
+-- ═══════════════════════════════════════════════════════════════
+
+/-- `intBinaryGcd` equals Mathlib's `Int.gcd` (as an integer). -/
+theorem intBinaryGcd_eq_gcd (a b : ℤ) :
+    intBinaryGcd a b = (Int.gcd a b : ℤ) := by
+  unfold intBinaryGcd; rw [binaryGcd_eq_gcd]; rfl
+
+/-- `intBinaryGcd` is non-negative. -/
+theorem intBinaryGcd_nonneg (a b : ℤ) : 0 ≤ intBinaryGcd a b := by
+  simp only [intBinaryGcd]; positivity
+
+/-- `intBinaryGcd a b` divides `a`. -/
+theorem intBinaryGcd_dvd_left (a b : ℤ) : intBinaryGcd a b ∣ a :=
+  intBinaryGcd_eq_gcd a b ▸ Int.gcd_dvd_left a b
+
+/-- `intBinaryGcd a b` divides `b`. -/
+theorem intBinaryGcd_dvd_right (a b : ℤ) : intBinaryGcd a b ∣ b :=
+  intBinaryGcd_eq_gcd a b ▸ Int.gcd_dvd_right a b
+
+/-- `intBinaryGcd` is symmetric. -/
+theorem intBinaryGcd_comm (a b : ℤ) :
+    intBinaryGcd a b = intBinaryGcd b a := by
+  simp [intBinaryGcd, binaryGcd_comm]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART III: SIGN INVARIANCE
+-- ═══════════════════════════════════════════════════════════════
+
+/-- GCD is unaffected by negating the left argument. -/
+theorem intBinaryGcd_neg_left (a b : ℤ) :
+    intBinaryGcd (-a) b = intBinaryGcd a b := by
+  simp [intBinaryGcd, Int.natAbs_neg]
+
+/-- GCD is unaffected by negating the right argument. -/
+theorem intBinaryGcd_neg_right (a b : ℤ) :
+    intBinaryGcd a (-b) = intBinaryGcd a b := by
+  simp [intBinaryGcd, Int.natAbs_neg]
+
+/-- GCD depends only on absolute values. -/
+theorem intBinaryGcd_natAbs (a b : ℤ) :
+    intBinaryGcd a b = intBinaryGcd (a.natAbs : ℤ) (b.natAbs : ℤ) := by
+  simp only [intBinaryGcd, Int.natAbs_natCast]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART IV: BOUNDARY CASES
+-- ═══════════════════════════════════════════════════════════════
+
+/-- `intBinaryGcd 0 b = |b|` (as an integer) -/
+theorem intBinaryGcd_zero_left (b : ℤ) :
+    intBinaryGcd 0 b = (b.natAbs : ℤ) := by
+  unfold intBinaryGcd
+  rw [Int.natAbs_zero, binaryGcd_eq_gcd, Nat.gcd_zero_left]
+
+/-- `intBinaryGcd a 0 = |a|` (as an integer) -/
+theorem intBinaryGcd_zero_right (a : ℤ) :
+    intBinaryGcd a 0 = (a.natAbs : ℤ) := by
+  unfold intBinaryGcd
+  rw [Int.natAbs_zero, binaryGcd_eq_gcd, Nat.gcd_zero_right]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART V: BÉZOUT IDENTITY
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Integer Binary Bézout Identity**: For any `a b : ℤ`, there exist
+`u v : ℤ` such that `u * a + v * b = intBinaryGcd a b`.
+
+Proved via Mathlib's `Int.gcd_eq_gcd_ab` Bézout coefficients. -/
+theorem bezout_via_intBinaryGcd (a b : ℤ) :
+    ∃ u v : ℤ, u * a + v * b = intBinaryGcd a b := by
+  refine ⟨Int.gcdA a b, Int.gcdB a b, ?_⟩
+  have heq : intBinaryGcd a b = (Int.gcd a b : ℤ) := intBinaryGcd_eq_gcd a b
+  have hbez : (Int.gcd a b : ℤ) = a * Int.gcdA a b + b * Int.gcdB a b :=
+    Int.gcd_eq_gcd_ab a b
+  rw [heq, hbez]
+  ring
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART VI: GCD PROPERTY
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Any integer divisor of both `a` and `b` also divides `intBinaryGcd a b`.
+Proved via the Bézout identity: d ∣ a ∧ d ∣ b → d ∣ u*a + v*b = intBinaryGcd a b. -/
+theorem dvd_intBinaryGcd {d a b : ℤ} (ha : d ∣ a) (hb : d ∣ b) :
+    d ∣ intBinaryGcd a b := by
+  obtain ⟨u, v, h⟩ := bezout_via_intBinaryGcd a b
+  rw [← h]
+  exact dvd_add (dvd_mul_of_dvd_right ha u) (dvd_mul_of_dvd_right hb v)
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART VII: COMPUTATIONAL EXAMPLES
+-- ═══════════════════════════════════════════════════════════════
+
+example : intBinaryGcd 12 8 = 4 := by native_decide
+example : intBinaryGcd (-12) 8 = 4 := by native_decide
+example : intBinaryGcd 12 (-8) = 4 := by native_decide
+example : intBinaryGcd (-35) (-15) = 5 := by native_decide
+example : intBinaryGcd 17 5 = 1 := by native_decide
+
+end BezoutIdentityOQ01OQ01OQ02

--- a/research/problems/bezout-identity-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/bezout-identity-oq-01-oq-01-oq-02/knowledge.md
@@ -1,0 +1,46 @@
+# Binary GCD Extended to Integers
+
+**Problem ID**: bezout-identity-oq-01-oq-01-oq-02
+**Parent**: bezout-identity-oq-01-oq-01 (Stein's binary GCD for ℕ)
+
+## Problem Statement
+
+Can Stein's binary GCD algorithm, which computes `gcd(a, b)` for natural numbers
+using only subtraction, halving, and parity tests, be extended to integers?
+
+## Session 2026-05-07 (Session 1) — Complete Proof
+
+**Mode**: FRESH
+**Outcome**: completed — full proof written, Docker build confirmed
+
+### What I Did
+
+1. Claimed problem; surveyed parent proof `BezoutIdentityOQ01OQ01`
+2. Defined `intBinaryGcd (a b : ℤ) : ℤ := ↑(binaryGcd a.natAbs b.natAbs)` — reduces to ℕ algorithm via `Int.natAbs`
+3. Proved 10 theorems + 5 computational examples, 0 sorries, 0 axioms:
+   - `intBinaryGcd_eq_gcd`: equals `Int.gcd` (Mathlib's integer GCD)
+   - `intBinaryGcd_dvd_left/right`: divisibility in ℤ via `▸ Int.gcd_dvd_left/right`
+   - `intBinaryGcd_comm`: symmetry (from `binaryGcd_comm`)
+   - `intBinaryGcd_neg_left/right`: sign invariance (natAbs strips signs)
+   - `intBinaryGcd_zero_left/right`: boundary cases (= |b| and |a|)
+   - `bezout_via_intBinaryGcd`: ∃ u v, u*a + v*b = intBinaryGcd a b
+   - `dvd_intBinaryGcd`: any common divisor divides intBinaryGcd (via Bézout)
+4. Fixed `AmgmInequalityOQ03.lean` trailing docstring bug (needed for build to succeed)
+
+### Key Findings
+
+- The extension is trivial mathematically: `Int.gcd a b = Nat.gcd a.natAbs b.natAbs` definitionally, so `intBinaryGcd` just reduces to the ℕ algorithm.
+- Lean 4.26 API issues:
+  - `Int.gcd_dvd_left` requires explicit arguments and uses `↑(a.gcd b)` dot notation — use `▸` for the dvd proofs
+  - `linear_combination` for Bézout produces residual `binaryGcd a.natAbs = binaryGcd |a|.natAbs` goals — use explicit `rw [heq, hbez]; ring` instead
+  - `dvd_intBinaryGcd` better proved via Bézout (d ∣ a ∧ d ∣ b → d ∣ u*a+v*b) than via `Int.dvd_gcd` (API changed)
+- Build: 3059 jobs, 0 errors — confirmed via Docker build
+
+### Files Created
+
+- `proofs/Proofs/BezoutIdentityOQ01OQ01OQ02.lean` (146 lines)
+- `src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json`
+- `research/problems/bezout-identity-oq-01-oq-01-oq-02/knowledge.md` (this file)
+- Also fixed `proofs/Proofs/AmgmInequalityOQ03.lean` (trailing `/--` docstring bug)
+
+### Phase: COMPLETED

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,77 @@
+{
+  "id": "bezout-identity-oq-01-oq-01-oq-02",
+  "title": "Binary GCD Extended to Integers: intBinaryGcd",
+  "slug": "bezout-identity-oq-01-oq-01-oq-02",
+  "description": "Extends Stein's binary GCD algorithm from natural numbers to integers by reducing via Int.natAbs. Proves the extension equals Mathlib's Int.gcd, satisfies divisibility and GCD properties, is sign-invariant, and yields explicit B\u00e9zout coefficients: \u2203 u v : \u2124, u*a + v*b = intBinaryGcd a b. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "algorithm",
+      "gcd",
+      "integers",
+      "bezout",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 146,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "intBinaryGcd: integer binary GCD via natAbs reduction",
+      "intBinaryGcd_eq_gcd: equals Mathlib Int.gcd",
+      "intBinaryGcd_dvd_left/right: divisibility in \u2124",
+      "dvd_intBinaryGcd: GCD property for integers",
+      "intBinaryGcd_neg_left/right: sign invariance",
+      "intBinaryGcd_zero_left/right: boundary cases (|b|, |a|)",
+      "bezout_via_intBinaryGcd: integer B\u00e9zout identity via binary GCD"
+    ],
+    "prerequisites": [
+      "BezoutIdentityOQ01OQ01 (Proofs/BezoutIdentityOQ01OQ01.lean): binaryGcd for \u2115, binaryGcd_eq_gcd, bezout_via_binaryGcd"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.gcd",
+        "description": "Integer GCD via natAbs: Int.gcd a b = Nat.gcd a.natAbs b.natAbs",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.gcd_dvd_left",
+        "description": "Int.gcd a b (as \u2124) divides a",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.dvd_gcd",
+        "description": "Common divisor divides Int.gcd",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.gcd_eq_gcd_ab",
+        "description": "B\u00e9zout identity: Int.gcd a b = a * gcdA + b * gcdB",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ],
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 146,
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "openQuestions": [
+    {
+      "id": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+      "question": "Can the integer binary GCD be extended to compute B\u00e9zout coefficients directly by tracking the algorithm's steps, analogous to the extended Euclidean algorithm?",
+      "significance": "medium"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends Stein's binary GCD algorithm from natural numbers to all integers by defining:

```
def intBinaryGcd (a b : ℤ) : ℤ := ↑(binaryGcd a.natAbs b.natAbs)
```

This reduces via `Int.natAbs` to the already-proved `binaryGcd` for ℕ (from `bezout-identity-oq-01-oq-01`).

## Theorems Proved

- `intBinaryGcd_eq_gcd`: equals Mathlib's `Int.gcd` (definitionally, via `rfl`)
- `intBinaryGcd_nonneg`: non-negative (it's a ℕ cast)
- `intBinaryGcd_dvd_left/right`: divisibility in ℤ (via `▸ Int.gcd_dvd_left/right`)
- `intBinaryGcd_comm`: symmetry
- `intBinaryGcd_neg_left/right`: sign invariance — gcd(a,b) = gcd(-a,b) = gcd(a,-b)
- `intBinaryGcd_zero_left/right`: gcd(0,b) = |b|, gcd(a,0) = |a|
- `bezout_via_intBinaryGcd`: **∃ u v : ℤ, u*a + v*b = intBinaryGcd a b** (Bézout)
- `dvd_intBinaryGcd`: if d ∣ a and d ∣ b, then d ∣ intBinaryGcd a b

## Key Technique

`dvd_intBinaryGcd` is proved via the Bézout identity (not `Int.dvd_gcd`, whose API changed in Lean 4.26): if `d ∣ a` and `d ∣ b`, then `d ∣ u*a + v*b = intBinaryGcd a b`.

## Build Status

✅ 3059 jobs, 0 errors, 0 sorries, 0 axioms (Docker build confirmed)

Also fixes `AmgmInequalityOQ03.lean` trailing `/--` docstring bug (same fix as in PR #16419 — duplicated here since that PR hasn't merged to main yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)