### PR TITLE
audit(tracker): mark 4 proofs clean — 2026-05-07 cycle 3

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3169,9 +3169,9 @@
       "result": "clean"
     },
     "erdos-1027-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T01:34:18Z",
       "result": "clean"
     },
     "erdos-1027-oq-03": {
@@ -3338,9 +3338,9 @@
       "result": "clean"
     },
     "erdos-105-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T01:34:18Z",
       "result": "clean"
     },
     "erdos-105-oq-05": {
@@ -3422,9 +3422,9 @@
       "result": "clean"
     },
     "erdos-1059-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T01:34:18Z",
       "result": "clean"
     },
     "erdos-1059-oq-02": {
@@ -3648,9 +3648,9 @@
       "result": "clean"
     },
     "erdos-1083-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T01:34:18Z",
       "result": "clean"
     },
     "erdos-1084": {


### PR DESCRIPTION
## Summary

Mark 4 gallery entries `clean` in `src/data/proofs/audit-tracker.json` after
manual integrity verification on `origin/main`.

| Proof                  | Status / Badge       | Lean counts (s/ax/thm/def/lc) | Result |
|------------------------|----------------------|-------------------------------|--------|
| erdos-1083-oq-02       | axiomatized / axiom  | 0/6/47/0/556                  | clean  |
| erdos-1059-oq-01-oq-01 | axiomatized / axiom  | 2/2/10/3/434                  | clean  |
| erdos-105-oq-02        | axiomatized / axiom  | 0/3/20/8/288                  | clean  |
| erdos-1027-oq-01       | verified / original  | 0/0/5/0/183                   | clean  |

All counts match `meta.meta` AND `meta.leanFile` blocks.

## Axiom narrative cross-check (phantom-axiom guard)

For axiomatized entries, the `meta.assumptions` prose lists the same axiom
names that appear as `axiom` declarations in the Lean file:

- **erdos-1083-oq-02**: `f`, `erdos_lower`, `grid_upper`, `solymosi_vu`, `erdos_1083_conjecture`, `guth_katz` (6 = axiomCount)
- **erdos-1059-oq-01-oq-01**: `strong_selberg_density`, `primes_growth_in_levels` (2 = axiomCount)
- **erdos-105-oq-02**: `threshold_lower_bound`, `threshold_upper_bound`, `threshold_gap_axiom` (3 = axiomCount)

`erdos-1027-oq-01` is `verified/original`: 0 axioms, 0 sorries, 0 True stubs.

## Test plan

- [x] JSON validates (`python3 -c 'import json; json.load(open(...))'`)
- [x] Only `audit-tracker.json` modified (8 lines: auditCount 1→2, lastAudited refresh × 4)
- [x] No meta.json or Lean changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)