### PR TITLE
audit(bezout-identity-oq-01-oq-01-oq-02): theoremCount 10→12

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
@@ -57,14 +57,14 @@
         "module": "Mathlib.Data.Int.GCD"
       }
     ],
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "leanFile": {
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "openQuestions": [


### PR DESCRIPTION
## Audit Finding

`bezout-identity-oq-01-oq-01-oq-02` declares `theoremCount: 10` in both `meta` and `leanFile` blocks, but `Proofs/BezoutIdentityOQ01OQ01OQ02.lean` actually declares **12** theorems:

```
intBinaryGcd_eq_gcd        intBinaryGcd_neg_left      intBinaryGcd_zero_right
intBinaryGcd_nonneg        intBinaryGcd_neg_right     bezout_via_intBinaryGcd
intBinaryGcd_dvd_left      intBinaryGcd_natAbs        dvd_intBinaryGcd
intBinaryGcd_dvd_right     intBinaryGcd_zero_left     intBinaryGcd_comm
```

## Other counts verified clean
- lineCount: 146 ✓
- definitionCount: 1 (`def intBinaryGcd`) ✓
- sorries: 0 ✓
- axiomCount: 0 ✓ (no `axiom` declarations, no True stubs)

## Fix
Bump both `meta.theoremCount` and `leanFile.theoremCount` 10 → 12. Surgical 2-line change via plumbing (preserves formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)