### PR TITLE
fix(meta): cantor-diagonalization-oq-04-oq-01 — add missing lineCount/theoremCount/definitionCount

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
@@ -37,6 +37,9 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
+    "lineCount": 166,
+    "theoremCount": 8,
+    "definitionCount": 3,
     "badge": "original"
   },
   "conclusion": "If a type Y with setoid equivalence ≈ codes its own endomorphisms up to ≈ (via encode/decode with decode(encode(f))(y) ≈ f(y)), then for every function f : Y → Y there exists p : Y with f(p) ≈ p. The Type version (exact equality) is the special case of the discrete setoid. Bool and ℕ-mod-2 cannot code their endomorphisms, witnessing the theorem's nontriviality.",


### PR DESCRIPTION
## Fix

Add missing `lineCount`, `theoremCount`, and `definitionCount` fields to the `meta` sub-object.

## Evidence

**Before**: `meta` sub-object contained only `axiomCount`, `sorries`, `badge` — no dimensional counts.

**After**: `meta.lineCount: 166`, `meta.theoremCount: 8`, `meta.definitionCount: 3` — values synced from the `leanFile` block which already had them correct.

**Verification**:
- Actual Lean file: `CantorDiagonalizationOQ04OQ01.lean` has 166 lines, 8 theorems, 3 definitions, 0 sorries
- `leanFile.lineCount: 166`, `leanFile.theoremCount: 8`, `leanFile.definitionCount: 3` already correct

---
Automated fix by lean-mechanic agent.