### PR TITLE
fix(meta): dirichlets-theorem-oq-01-oq-01 — add missing lineCount

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
@@ -26,6 +26,7 @@
     ],
     "tags": ["dirichlet", "l-functions", "siegel-zeros", "linnik", "analytic-number-theory", "open-question"],
     "sorries": 0,
+    "lineCount": 335,
     "definitionCount": 1
   },
   "leanFile": {


### PR DESCRIPTION
## Fix

Add missing `lineCount` field to the `meta` sub-object.

## Evidence

**Before**: `meta` sub-object had no `lineCount` field.

**After**: `meta.lineCount: 335` — value synced from `leanFile` block which already had it correct.

**Verification**:
- Actual Lean file: `DirichletsTheoremOQ01OQ01.lean` has 335 lines
- `leanFile.lineCount: 335` already correct

---
Automated fix by lean-mechanic agent.