### PR TITLE
fix(meta): angle-trisection-oq-02-oq-01-oq-01 — sync theoremCount 3→1

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
@@ -43,7 +43,7 @@
     "axiomCount": 0,
     "assumptions": "No axioms. Uses natDegree_dvd_card_gal from parent file (also 0 axioms). The theorem prime_degree_dvd_card_from_general is fully proved.",
     "lineCount": 123,
-    "theoremCount": 3,
+    "theoremCount": 1,
     "definitionCount": 0
   },
   "overview": {
@@ -167,7 +167,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 1,
     "imports": [
       "Proofs.AngleTrisectionOQ02OQ01"
     ]


### PR DESCRIPTION
## Fix

Sync `theoremCount` drift in `src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json` (both `meta` and `leanFile` blocks).

## Evidence

`proofs/Proofs/AngleTrisectionOQ02OQ01OQ01.lean` defines exactly one theorem at the declaration level:

- `prime_degree_dvd_card_from_general`

The two remaining `theorem` keywords in the file are inside `/- ... -/` docstring code blocks documenting the proposed Mathlib contribution (`natDegree_dvd_card`) and a deprecated wrapper (`prime_degree_dvd_card`). These are documentation examples, not actual Lean declarations.

**Before**: `theoremCount: 3` (in both `meta` and `leanFile` blocks)
**After**:  `theoremCount: 1`

Verified by stripping nested block comments and counting `theorem`/`lemma` declarations at line start. The `originalContributions` list (1 theorem + 2 prose contributions) is consistent with the corrected count.

---
Automated fix by lean-mechanic agent.