### PR TITLE
fix(meta): erdos-741 — sync axiomCount/badge/lineCount/theoremCount after axiom→theorem (PR #16461)

### DIFF
--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -17,7 +17,7 @@
       "open",
       "partition-regularity"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 741,
     "erdosUrl": "https://erdosproblems.com/741",
@@ -59,16 +59,16 @@
       "trivial_partition, complement_partition, partition_membership: 3 proved partition results",
       "nat_syndetic, empty_not_syndetic, syndetic_nonempty, syndetic_mono, syndetic_infinite: 5 proved syndetic results",
       "density_empty, density_univ, density_mono, density_le_one: 4 proved density theorems",
-      "cofinite_density_one axiom: cofinite sets have density 1",
+      "cofinite_density_one (proved theorem): cofinite sets have density 1",
       "basis_infinite: proved bases are infinite (contradiction via bounded sumsets)",
       "basis_has_pos_density_sumset: proved bases have positive density sumsets",
       "part2_gives_non_syndetic: proved Part 2 implies non-syndetic partition exists",
       "part2_contradicts_part1_for_basis: proved Part 2 implies Part 1 tension"
     ],
-    "axiomCount": 1,
-    "lineCount": 284,
-    "assumptions": "1 axiom: cofinite_density_one. 0 sorries.",
-    "theoremCount": 26,
+    "axiomCount": 0,
+    "lineCount": 336,
+    "assumptions": "0 axioms, 0 sorries. cofinite_density_one proved as a theorem in PR #16461.",
+    "theoremCount": 27,
     "definitionCount": 8
   },
   "overview": {
@@ -163,9 +163,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 284,
-    "axiomCount": 1,
-    "theoremCount": 26,
+    "lineCount": 336,
+    "axiomCount": 0,
+    "theoremCount": 27,
     "definitionCount": 8,
     "path": "Proofs/Erdos741Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync meta.json after PR #16461 proved `cofinite_density_one` (axiom → theorem) without updating the gallery metadata.

## Evidence

**Before** (stale post-#16461):
- `meta.axiomCount: 1`, `meta.badge: "axiom"`
- `meta.lineCount: 284`, `meta.theoremCount: 26`
- `leanFile.axiomCount: 1`, `leanFile.lineCount: 284`, `leanFile.theoremCount: 26`
- `assumptions: "1 axiom: cofinite_density_one. 0 sorries."`

**After** (synced to current Lean file):
- `meta.axiomCount: 0`, `meta.badge: "wip"` (open problem, consistent with erdos-1 pattern)
- `meta.lineCount: 336`, `meta.theoremCount: 27`
- `leanFile.axiomCount: 0`, `leanFile.lineCount: 336`, `leanFile.theoremCount: 27`
- `assumptions: "0 axioms, 0 sorries."`

**Verification**:
- `git show origin/main:proofs/Proofs/Erdos741Problem.lean | grep "axiom\|opaque"` → no matches
- Actual file: 336 lines, 27 theorems, 0 axioms, 0 sorries

---
Automated fix by lean-mechanic agent.