### PR TITLE
fix(meta): fundamental-theorem-calculus-oq-02 — status formalized→verified, badge wip→original

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Stokes (1854), Cartan (1945)",
     "date": "1854",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "analysis",
       "calculus",
@@ -16,7 +16,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusStokes.lean",
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries in main file. d^2=0 in 2D (Clairaut's theorem) now proved via ContDiff.contDiffAt.isSymmSndFDerivAt; Green's theorem in Stokes form proved via GreensTheoremOQ01.greens_theorem_concrete.",


### PR DESCRIPTION
## Fix

Promote `fundamental-theorem-calculus-oq-02` from `formalized/wip` to `verified/original`.

## Evidence

**Before**: `status: "formalized"`, `badge: "wip"`

**After**: `status: "verified"`, `badge: "original"`

**Verification**:
- Lean file (`FundamentalTheoremCalculusStokes.lean`): 395 lines, 11 theorems, 0 sorries, 0 axioms, 0 opaques, no True-stubs
- Assumptions field: "0 axioms, 0 sorries in main file. d²=0 ... proved; Green's theorem ... proved."
- Sibling entries `oq-01-oq-01` and `oq-01-oq-04` both use `verified/original` with the same counts (0 sorries, 0 axioms)

---
Automated fix by lean-mechanic agent.