### PR TITLE
fix(meta): sum-of-kth-powers-oq-04 — status formalized→verified, badge wip→original

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Euler (1738), Maclaurin (1742), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%E2%80%93Maclaurin_formula",
     "date": "1738",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SumOfKthPowersOQ04.lean",
     "tags": [
       "analysis",
@@ -16,7 +16,7 @@
       "bernoulli-numbers",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. The two previously routine sorries (low_degree_poly_ratio_tendsto_zero and the natDegree bound inside monic_poly_ratio_tendsto) are now fully proved. monic_poly_ratio_tendsto was previously an axiom but was proved in V3.",


### PR DESCRIPTION
## Fix

Promote `sum-of-kth-powers-oq-04` from `formalized/wip` to `verified/original`.

## Evidence

**Before**: `status: "formalized"`, `badge: "wip"`

**After**: `status: "verified"`, `badge: "original"`

**Verification**:
- Lean file (`SumOfKthPowersOQ04.lean`): 0 sorries, 0 axioms, 0 opaques
- Assumptions field: "0 axioms, 0 sorries. The two previously routine sorries ... are now fully proved."
- Sibling entries `sum-of-kth-powers` (verified/original), `oq-01` (verified/mathlib), `oq-02` (verified/mathlib) all use `verified`

---
Automated fix by lean-mechanic agent.