### PR TITLE
audit(bezout-identity-oq-01-oq-01-oq-02): fix theoremCount 10 → 12

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
@@ -57,14 +57,14 @@
         "module": "Mathlib.Data.Int.GCD"
       }
     ],
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "leanFile": {
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "openQuestions": [


### PR DESCRIPTION
## Summary

`meta.theoremCount` and `leanFile.theoremCount` both claimed 10 for `bezout-identity-oq-01-oq-01-oq-02`, but the Lean source file `Proofs/BezoutIdentityOQ01OQ01OQ02.lean` declares 12 top-level `theorem`s.

The three theorems missing from the count were the auxiliary properties:
- `intBinaryGcd_nonneg`
- `intBinaryGcd_comm`
- `intBinaryGcd_natAbs`

Other counts (lineCount=146, definitionCount=1, sorries=0, axiomCount=0) verified clean. Status `verified/original` is appropriate: parent file `BezoutIdentityOQ01OQ01` proves Stein's binary GCD = `Nat.gcd` independently; this file extends to ℤ via `natAbs`.

## Test plan
- [x] `wc -l` confirms 146 lines
- [x] `grep '^theorem '` returns 12 results
- [x] No sorries / axioms in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)