### PR TITLE
audit(tracker): mark bezout-identity-oq-01-oq-01-oq-02 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15002,6 +15002,12 @@
       "lastAudited": "2026-05-07T00:16:58Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T02:09:14Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Records that `bezout-identity-oq-01-oq-01-oq-02` was audited and theoremCount drift was fixed in PR #16488. This was the only remaining unaudited entry in the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)