### PR TITLE
fix(meta): hilbert-10-oq-04 — sync definitionCount 7→6

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 5,
     "lineCount": 250,
     "theoremCount": 10,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
       {
@@ -135,7 +135,7 @@
     "path": "Proofs/Hilbert10OQ04.lean",
     "lineCount": 250,
     "theoremCount": 10,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "axiomCount": 5,
     "sorries": 0
   }


### PR DESCRIPTION
## Fix

PR #16430 added the leanFile block claiming `definitionCount: 7`, but the file has 6: `DiophantineN`, `hasSolutionN`, `H10_n_decidable`, `H10_n_undecidable`, `LinearForm.eval`, `hasLinearSolution`. The `structure LinearForm` is not a def/abbrev/opaque under the gallery convention.

## Evidence

```bash
git show origin/main:proofs/Proofs/Hilbert10OQ04.lean \
  | python3 -c '
import sys, re
c = sys.stdin.read()
c = re.sub(r"/-.*?-/", "", c, flags=re.DOTALL)
c = re.sub(r"--[^\n]*", "", c)
print(len(re.findall(r"^\s*(def|abbrev|opaque)\s+\w", c, re.MULTILINE)))
'
# 6
```

Per `leanFile.definitionCount` convention (PR #15533, #16459): count `def + abbrev + opaque` after stripping comments and attribute decorators. Structures are not counted.

## Changes

- `meta.definitionCount`: 7 → 6
- `leanFile.definitionCount`: 7 → 6

No code changes. `status`, `badge`, `theoremCount`, `axiomCount`, `sorries`, `lineCount` unchanged.

Note: open PR #16164 also touches this meta.json with a full file rewrite (currently CONFLICTING since 2026-05-06). This drift fix lands on current main; if #16164 ever rebases, its values supersede.

---
Automated fix by lean-mechanic agent.