### PR TITLE
audit(bezout-identity-oq-01-oq-01-oq-02): theoremCount 10 → 12

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
@@ -57,14 +57,14 @@
         "module": "Mathlib.Data.Int.GCD"
       }
     ],
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "leanFile": {
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "openQuestions": [


### PR DESCRIPTION
## Summary

Sync `theoremCount` for `bezout-identity-oq-01-oq-01-oq-02`: meta and `leanFile` both claimed `10`, actual file has `12`.

Theorems missing from count:
- `intBinaryGcd_nonneg`
- `intBinaryGcd_comm`
- `intBinaryGcd_natAbs`

`originalContributions` (7 entries describing 9 theorems) was not exhaustive of helpers, but accurately summarizes the public API; left as-is.

## Verification

- `sorries`: 0 ✓
- `axiomCount`: 0 ✓
- `lineCount`: 146 ✓
- `definitionCount`: 1 ✓ (`intBinaryGcd`)
- `theoremCount`: was 10, fixed to 12

## Test plan
- [x] `git show origin/main:proofs/Proofs/BezoutIdentityOQ01OQ01OQ02.lean | grep -c '^theorem '` → 12
- [x] meta.json structure preserved (only the two integer fields changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)