### PR TITLE
audit(divisibility-rules-oq-02): mark clean (re-verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2633,9 +2633,9 @@
       "result": "clean"
     },
     "divisibility-rules-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T02:33:25Z",
       "result": "clean"
     },
     "divisibility-truncation-general": {


### PR DESCRIPTION
Re-audit confirmed clean for `divisibility-rules-oq-02`.

## Verification (against origin/main)

| Field | meta.json | Lean file | OK? |
|-------|-----------|-----------|-----|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 142 | 142 | ✓ |
| status | verified | (no sorries, no axioms, no True stubs) | ✓ |
| badge | original | (no Mathlib wrapper for main result) | ✓ |

Tracker bumped from `auditCount: 1` (last 2026-04-23) to `auditCount: 2` (2026-05-07).

🤖 Discovered during gallery integrity audit.