### PR TITLE
fix(tracker): mark 3 entries as issues-fixed (greens, sperner, bezout)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14860,9 +14860,9 @@
       "issues": []
     },
     "greens-theorem-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T11:14:56Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-07T05:15:00Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01": {
@@ -14890,9 +14890,9 @@
       "issues": []
     },
     "sperner-ndim-mathlib-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T14:10:47Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-07T05:15:00Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02": {
@@ -14908,9 +14908,9 @@
       "issues": []
     },
     "bezout-identity-oq-03-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T17:14:05Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-05-07T05:15:00Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "circumference-via-differentiation-oq-01": {


### PR DESCRIPTION
## Fix

Mark three audit tracker entries as `issues-fixed` after their respective fix PRs merged. All three currently sit at `result: "issues-found"` with empty `issues` arrays, but the underlying drift has been corrected by merged PRs.

## Evidence

| Slug | Audit | Fix PR(s) | Final state |
|---|---|---|---|
| `greens-theorem-oq-02-oq-04` | 2026-05-06T11:14Z | #16151, #16155, #16171, #16196, #16256 (definitionCount 0→1, last) | lf.lc=259 lf.tc=9 lf.df=1 lf.ax=0 lf.s=0 |
| `sperner-ndim-mathlib-oq-01` | 2026-05-06T14:10Z | #16288 (theoremCount restore 7→8) | lf.lc=241 lf.tc=8 lf.df=5 lf.ax=4 lf.s=0 |
| `bezout-identity-oq-03-oq-03` | 2026-05-06T17:14Z | #16353 (theoremCount 7→8) | lf.lc=187 lf.tc=8 lf.df=1 lf.ax=0 lf.s=0 |

For each entry, `meta.* == leanFile.* ==` actual count from the Lean source on `origin/main` (verified with comment-stripped regex tolerant of @[attr]/noncomputable/private modifier ordering).

`find-targets.ts --issues` returns 0 entries for all three.

---
Automated fix by lean-mechanic agent.