### PR TITLE
fix(meta): batch — add Aristotle companion to additionalFiles (4 entries)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -184,7 +184,10 @@
       "BirthdayProblemOQ01",
       "BigOperators"
     ],
-    "namespace": "BirthdayDistribution"
+    "namespace": "BirthdayDistribution",
+    "additionalFiles": [
+      "Proofs/BirthdayProblemOQ01OQ01Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
@@ -77,7 +77,10 @@
     "theoremCount": 8,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
+    ]
   },
   "sorries": 0,
   "sections": [

--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -133,7 +133,10 @@
     "theoremCount": 9,
     "definitionCount": 7,
     "path": "Proofs/Hilbert20OQ01OQ03.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Hilbert20OQ01OQ03Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -116,7 +116,10 @@
       "Szemeredi.Core",
       "Szemeredi.Regularity"
     ],
-    "namespace": "Szemeredi.EnergyIncrement"
+    "namespace": "Szemeredi.EnergyIncrement",
+    "additionalFiles": [
+      "Proofs/SzemerediCoreOQ01Aristotle.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Add `*Aristotle.lean` companion files to `leanFile.additionalFiles` for four gallery entries where the companion file exists on disk but was not declared in the meta.json schema.

Following the convention established by #16502 (shapley-folkman) and ~143 existing entries that list their Aristotle companion in `leanFile.additionalFiles`.

## Evidence

| Slug | Companion file added |
|---|---|
| `birthday-problem-oq-01-oq-01` | `Proofs/BirthdayProblemOQ01OQ01Aristotle.lean` |
| `cayley-hamilton-cyclic-vector-all-fields-oq-01` | `Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean` |
| `hilbert-20-oq-01-oq-03` | `Proofs/Hilbert20OQ01OQ03Aristotle.lean` |
| `szemeredi-core-oq-01` | `Proofs/SzemerediCoreOQ01Aristotle.lean` |

For each entry I verified on `origin/main` that the companion file exists, is well-formed (0 sorries, 0 axioms), and contains `*Aristotle` namespace re-exports / routine lemmas:

- `BirthdayProblemOQ01OQ01Aristotle.lean`: 34 lines, re-exports `card_ordered_pairs`, `card_funs_shared_birthday`, `sum_collisionCount`.
- `CayleyHamiltonCyclicVectorAllFieldsAristotle.lean`: 132 lines, namespace `CayleyHamiltonCyclicVectorAllFieldsAristotle`, target `monic_factored_form` (UFD bridge).
- `Hilbert20OQ01OQ03Aristotle.lean`: 66 lines.
- `SzemerediCoreOQ01Aristotle.lean`: 379 lines.

For `cayley-hamilton-cyclic-vector-all-fields-oq-01`, the existing `meta.additionalFiles: ["...MinpolyOQ05OQ01OQ04WIP04.lean"]` is preserved — that entry tracks the upstream dependency that the main file imports; this PR adds the Aristotle companion separately to `lf.additionalFiles`.

## Test plan

- [x] All four companion file paths verified to exist on `origin/main`
- [x] Diff is surgical: 4 insertions / 4 deletions across 4 files (16 lines added, 4 removed)
- [x] No status, badge, count, or narrative changes — pure structural metadata sync
- [x] No open PR for any of the 4 slugs (searched `additionalFiles`, `aristotle`, slug+state:open)
- [x] Each meta.json validates as JSON after edit

---
Automated fix by lean-mechanic agent.