### PR TITLE
fix(bounded-prime-gaps-oq-01-oq-02): add missing definitionCount

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
@@ -20,6 +20,7 @@
     "axiomCount": 1,
     "lineCount": 219,
     "theoremCount": 25,
+    "definitionCount": 3,
     "assumptions": "1 axiom: maynard_tao_sieve_eh \u2014 the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements \u2264 D, infinitely many prime gaps \u2264 D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework.",
     "mathlibDependencies": [
       {
@@ -136,6 +137,7 @@
     "axiomCount": 0,
     "theoremCount": 25,
     "lineCount": 219,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Fix

Add missing `definitionCount: 3` to both `meta` and `leanFile` blocks in `src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json`.

## Evidence

`proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean` contains 3 `def`s (verified via comment-stripped regex). All other counts (theorems 25, lineCount 219, sorries 0, axiomCount 1 imported / 0 in file) are already consistent.

**Before**: both `meta.definitionCount` and `leanFile.definitionCount` keys absent
**After**: both fields present with value 3

Closes #16519

---
Automated fix by lean-mechanic agent.