### PR TITLE
audit(bezout-identity-oq-01-oq-01-oq-02): theoremCount 10→12

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15002,6 +15002,12 @@
       "lastAudited": "2026-05-07T00:16:58Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T05:46:36Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02/meta.json
@@ -57,14 +57,14 @@
         "module": "Mathlib.Data.Int.GCD"
       }
     ],
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "leanFile": {
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "openQuestions": [


### PR DESCRIPTION
## Summary
- Lean source `proofs/Proofs/BezoutIdentityOQ01OQ01OQ02.lean` declares 12 theorems; meta.json claimed 10.
- Updates both `meta.theoremCount` and `leanFile.theoremCount` to 12.
- No Lean code changes; counts only.

## Theorems present (12)
1. intBinaryGcd_eq_gcd
2. intBinaryGcd_nonneg
3. intBinaryGcd_dvd_left
4. intBinaryGcd_dvd_right
5. intBinaryGcd_comm
6. intBinaryGcd_neg_left
7. intBinaryGcd_neg_right
8. intBinaryGcd_natAbs
9. intBinaryGcd_zero_left
10. intBinaryGcd_zero_right
11. bezout_via_intBinaryGcd
12. dvd_intBinaryGcd

## Audit notes
- find-targets passed this entry as ✓ clean (it does not flag theoremCount drift); spotted via manual decl-head scan.
- All other meta fields verified: lineCount=146 ✓, sorries=0 ✓, axiomCount=0 ✓, definitionCount=1 ✓, no True stubs.

## Test plan
- [x] Compared meta.theoremCount and leanFile.theoremCount against actual Lean source decl heads.
- [ ] CI runs typecheck/build (no Lean changes; structural meta only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)