### PR TITLE
audit(divisibility-by-3-oq-03-oq-02): mark clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2564,9 +2564,9 @@
       "result": "clean"
     },
     "divisibility-by-3-oq-03-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T06:01:22Z",
       "result": "clean"
     },
     "divisibility-by-3-oq-04": {


### PR DESCRIPTION
## Summary

Re-audit of `divisibility-by-3-oq-03-oq-02` (Base-Parametrized Digital Root). Counts in `meta.json` match the Lean source `proofs/Proofs/DivisibilityBy3OQ03OQ02.lean`:

| Field | Claimed | Actual |
|-------|---------|--------|
| lineCount | 211 | 211 |
| theoremCount | 21 | 21 |
| definitionCount | 1 | 1 |
| sorries | 0 | 0 |
| axiomCount | 0 | 0 |
| True stubs | — | 0 |

`status: verified` / `badge: original` is accurate. The proof builds on Mathlib's `Nat.modEq_digits_sum` and `Nat.dvd_iff_dvd_digits_sum`, both transparently listed in `mathlibDependencies`. The closed-form formula and base-parametrized derivations are original.

Bumps `auditCount` 1→2 in `audit-tracker.json` and updates `lastAudited`.

## Test plan
- [x] Tracker JSON valid (single-key edit, formatting preserved via plumbing)
- [x] No code/meta changes (audit-only)