### PR TITLE
fix(meta): add missing definitionCount to 7 gallery entries

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -22,6 +22,7 @@
     "axiomCount": 2,
     "lineCount": 206,
     "theoremCount": 6,
+    "definitionCount": 3,
     "assumptions": "Two axioms: snf_pid_exists (every matrix over a PID has a Smith Normal Form) and snf_pid_solvability (solvability criterion via invariant factors). These generalize the same axioms from BezoutIdentityOQ04OQ01 to arbitrary PIDs.",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
@@ -20,6 +20,7 @@
     "axiomCount": 1,
     "lineCount": 219,
     "theoremCount": 25,
+    "definitionCount": 3,
     "assumptions": "1 axiom: maynard_tao_sieve_eh \u2014 the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements \u2264 D, infinitely many prime gaps \u2264 D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework.",
     "mathlibDependencies": [
       {
@@ -136,6 +137,7 @@
     "axiomCount": 0,
     "theoremCount": 25,
     "lineCount": 219,
-    "sorries": 0
+    "sorries": 0,
+    "definitionCount": 3
   }
 }

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
@@ -37,6 +37,9 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
+    "lineCount": 166,
+    "theoremCount": 8,
+    "definitionCount": 3,
     "badge": "original"
   },
   "conclusion": "If a type Y with setoid equivalence ≈ codes its own endomorphisms up to ≈ (via encode/decode with decode(encode(f))(y) ≈ f(y)), then for every function f : Y → Y there exists p : Y with f(p) ≈ p. The Type version (exact equality) is the special case of the discrete setoid. Bool and ℕ-mod-2 cannot code their endomorphisms, witnessing the theorem's nontriviality.",

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -26,6 +26,7 @@
     "axiomCount": 0,
     "lineCount": 10,
     "theoremCount": 0,
+    "definitionCount": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.rpow_add",
@@ -184,7 +185,8 @@
     "path": "Proofs/Erdos1155OQ01OQ06.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 0
+    "theoremCount": 0,
+    "definitionCount": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -38,6 +38,7 @@
     "axiomCount": 0,
     "lineCount": 120,
     "theoremCount": 0,
+    "definitionCount": 0,
     "assumptions": "0 axioms. Lean source contains only typeclass definitions (IsKVertexCritical, IsErdos944Graph) used as abstract predicates with no declared instances; the known results of Brown, Lattanzio, Jensen, and Martinsson-Steiner are described in comments only, not formally axiomatized. Open conjecture (k = 4 case unsolved)."
   },
   "overview": {
@@ -121,7 +122,8 @@
     "lineCount": 120,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 0
+    "theoremCount": 0,
+    "definitionCount": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01-oq-01/meta.json
@@ -23,6 +23,7 @@
         "assumptions": "None. Fully machine-verified.",
         "lineCount": 220,
         "theoremCount": 13,
+        "definitionCount": 0,
         "originalContributions": [
             "finsupp_prime_prod_factorization: key identity — (f.prod (·^·)).factorization = f when f has prime support",
             "fta_uniqueness: uniqueness — only n.factorization satisfies prime support + Finsupp product = n",
@@ -112,7 +113,8 @@
         "axiomCount": 0,
         "lineCount": 220,
         "theoremCount": 13,
-        "sorries": 0
+        "sorries": 0,
+        "definitionCount": 0
     },
     "crossReferences": [
         {

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -59,7 +59,8 @@
     "assumptions": "0 axioms. 0 sorries (core result via Mathlib bridge). Relies on Mathlib's EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical for the Euclidean Ptolemy step. Assumes: Cospherical condition (points on common circle), angle conditions for diagonal crossing, unit sphere (‖a‖=‖b‖=‖c‖=‖d‖=1).",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01",
-    "theoremCount": 3
+    "theoremCount": 3,
+    "definitionCount": 0
   },
   "sections": [
     {
@@ -242,6 +243,7 @@
     "axiomCount": 0,
     "theoremCount": 3,
     "sorries": 0,
+    "definitionCount": 0,
     "path": "Proofs/PtolemysTheoremOQ01OQ02.lean"
   }
 }


### PR DESCRIPTION
## Fix

Adds missing `definitionCount` field to both `meta` and `leanFile` blocks for 7 gallery entries. This is a schema completeness gap — the field was absent while all other count fields were present.

## Evidence

**Counts verified** against comment-stripped Lean source via Python regex.

| Entry | definitionCount |
|-------|----------------|
| bounded-prime-gaps-oq-01-oq-02 | 3 (bvLevel, ehLevel, OpenQuestion01OQ02) |
| bezout-identity-oq-04-oq-01-oq-01 | 3 (IsUnimodularPID, isDecompOf, invariantFactor) |
| cantor-diagonalization-oq-04-oq-01 | 3 (discreteSetoid, typeToSetoidCoding, paritySetoidN) |
| erdos-1155-oq-01-oq-06 | 0 |
| erdos-944 | 0 |
| fundamental-arithmetic-oq-01-oq-01 | 0 |
| ptolemys-theorem-oq-01-oq-02 | 0 |

Closes #16519.

---
Automated fix by lean-mechanic agent.