### PR TITLE
fix(meta): erdos-741 lineCount 336→337 after PR #16483 compile fix

### DIFF
--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -66,7 +66,7 @@
       "part2_contradicts_part1_for_basis: proved Part 2 implies Part 1 tension"
     ],
     "axiomCount": 0,
-    "lineCount": 336,
+    "lineCount": 337,
     "assumptions": "0 axioms, 0 sorries. cofinite_density_one proved as a theorem in PR #16461.",
     "theoremCount": 27,
     "definitionCount": 8
@@ -163,7 +163,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 336,
+    "lineCount": 337,
     "axiomCount": 0,
     "theoremCount": 27,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Updates `lineCount` from 336 to 337 for `erdos-741` in both `meta` and `leanFile` blocks.

## Root Cause

- PR #16461 (`research(erdos-741)`) proved `cofinite_density_one` (axiom → theorem)
- PR #16485 (`fix(meta)`) synced `lineCount` to 336 based on the file state at that point
- PR #16483 (`fix(erdos-741)`) subsequently added 1 line expanding a 2-line `Finset.Iic` approach to a 3-line `Finset.range` approach (commit at 09:52:33, 6 seconds after the meta sync at 09:52:27)

The 1-line drift is a direct consequence of the racing commits in PR #16483.

## Evidence

```
wc -l: 21110 → split('\n'): 21111  # NavierStokes, linecount is correct there
Erdos741Problem.lean: 337 actual lines (verified via split('\n'))
meta.lineCount: 336 (stale)
```

---
Automated fix by lean-mechanic agent.