### PR TITLE
audit(tracker): mark 5 entries as issues-fixed (drift resolved on origin/main)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14837,9 +14837,10 @@
     },
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-03": {
       "auditCount": 1,
-      "lastAudited": "2026-05-06T11:12:53Z",
-      "result": "issues-found",
-      "issues": []
+      "lastAudited": "2026-05-07T20:00:00Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "erdos-895-oq-01": {
       "auditCount": 2,
@@ -14867,9 +14868,10 @@
     },
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-05-06T11:59:15Z",
-      "result": "issues-found",
-      "issues": []
+      "lastAudited": "2026-05-07T20:00:00Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "laws-of-large-numbers-oq-01-oq-02": {
       "auditCount": 1,
@@ -14921,15 +14923,17 @@
     },
     "hilbert-10-oq-04": {
       "auditCount": 1,
-      "lastAudited": "2026-05-06T17:55:36Z",
-      "result": "issues-found",
-      "issues": []
+      "lastAudited": "2026-05-07T20:00:00Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "cauchy-schwarz-oq-02-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-05-06T18:57:39Z",
-      "result": "issues-found",
-      "issues": []
+      "lastAudited": "2026-05-07T20:00:00Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "ehrhart-cube-proven-oq-02": {
       "auditCount": 2,
@@ -14939,9 +14943,10 @@
     },
     "greens-theorem-oq-01-oq-01-oq-01-oq-01": {
       "auditCount": 2,
-      "lastAudited": "2026-05-06T21:30:31Z",
-      "result": "issues-found",
-      "issues": []
+      "lastAudited": "2026-05-07T20:00:00Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "chinese-remainder-constructive-oq-04-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

Re-audit confirms 5 stale "issues-found" tracker entries are now clean on origin/main. find-targets reports no issues for any of them.

Entries bumped to `issues-fixed`:

| Slug | Status | Notes |
|------|--------|-------|
| elementary-quadratic-reciprocity-oq-01-oq-01-oq-03 | sorries=0, axioms=0, badge=mathlib | clean |
| cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01 | sorries=0, axioms=1, badge=axiom | clean |
| hilbert-10-oq-04 | sorries=0, axioms=5, badge=axiom | recently fixed by #16490 |
| cauchy-schwarz-oq-02-oq-02 | sorries=0, axioms=0, badge=mathlib | clean |
| greens-theorem-oq-01-oq-01-oq-01-oq-01 | sorries=0, axioms=0, badge=verified | clean |

Pattern follows recent #16510 ("mark 6 entries as issues-fixed") and #16507.

## Test plan

- [x] `python3 -c "json.load(open('audit-tracker.json'))"` parses cleanly
- [x] `npx tsx scripts/auditor/find-targets.ts --issues` shows only erdos-998-oq-04 (untracked-files pollution, unrelated)
- [x] Diff is surgical — 5 entries only, +20/-15 lines, no whole-file reformat

🤖 Generated with [Claude Code](https://claude.com/claude-code)