### PR TITLE
fix(tracker): mark angle-trisection-cos-20-gal-oq-01-oq-02-oq-02 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14744,11 +14744,11 @@
       "issues": []
     },
     "angle-trisection-cos-20-gal-oq-01-oq-02-oq-02": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-06T08:50:13Z",
-      "result": "issues-found",
-      "notes": "Reverse mismatch on origin/main (claims 1, actual 0). #16052 eliminated last sorry after #16080/#16081 set meta to 1. Two open meta-sync PRs are MERGEABLE: #16094 (mechanic, badge=verified) and #16101 (audit, badge=original). Both correctly sync to 0 sorries. Awaiting deployer merge — no new PR filed."
+      "lastAudited": "2026-05-07T20:00:00Z",
+      "result": "issues-fixed",
+      "notes": "Drift resolved on origin/main: meta-sync PRs #16094/#16101 (and follow-up #16192) merged. File now sorries=0, lineCount=338, theoremCount=12, axiomCount=0; meta status=verified, badge=verified — all consistent. find-targets.ts --issues no longer flags this entry."
     },
     "lagrange-theorem-oq-01-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Fix

Mark the audit-tracker entry for `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02` as `issues-fixed`. The drift was resolved on `origin/main` after meta-sync PRs #16094 / #16101 (and follow-up #16192) merged.

## Evidence

`git show origin/main:` for the proof file and meta:

| Dimension | meta | leanFile | actual |
|-----------|------|----------|--------|
| sorries | 0 | 0 | 0 |
| lineCount | 338 | 338 | 338 |
| theoremCount | 12 | 12 | 12 |
| axiomCount | 0 | 0 | 0 |
| status | verified | – | – |
| badge | verified | – | – |

`find-targets.ts --issues` reports no issues for this slug. This was the only remaining `result=issues-found` tracker entry not already handled by PR #16528 (the other 5 stale entries were bumped there).

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` parses cleanly
- [x] Diff is surgical — 4-line change in one tracker entry, no whole-file reformat
- [x] Verified file/meta consistency from `git show origin/main:`

---
Automated fix by lean-mechanic agent.