### PR TITLE
audit(tracker): mark 7 proofs clean — derangements, combinations, denumerability, godel-second-inc, erdos-1129/130/1217

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2158,9 +2158,9 @@
       "result": "clean"
     },
     "combinations-formula-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T08:43:07Z",
       "result": "clean"
     },
     "continuum-hypothesis": {
@@ -2303,9 +2303,9 @@
       "result": "clean"
     },
     "denumerability-rationals-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T08:42:47Z",
       "result": "clean"
     },
     "denumerability-rationals-oq-03": {
@@ -2375,9 +2375,9 @@
       "result": "clean"
     },
     "derangements-oq-03-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:50Z",
+      "lastAudited": "2026-05-07T08:42:01Z",
       "result": "clean"
     },
     "derangements-oq-03-oq-02": {
@@ -4072,9 +4072,9 @@
       "result": "clean"
     },
     "erdos-1129-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:51Z",
+      "lastAudited": "2026-05-07T08:44:45Z",
       "result": "clean"
     },
     "erdos-113": {
@@ -4580,9 +4580,9 @@
       "result": "clean"
     },
     "erdos-1217": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
+      "lastAudited": "2026-05-07T08:44:45Z",
       "result": "clean"
     },
     "erdos-122": {
@@ -4658,9 +4658,9 @@
       "result": "clean"
     },
     "erdos-130-wip-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:52Z",
+      "lastAudited": "2026-05-07T08:44:45Z",
       "result": "clean"
     },
     "erdos-131": {
@@ -11603,9 +11603,9 @@
       "result": "clean"
     },
     "godel-second-incompleteness-oq02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:25Z",
+      "lastAudited": "2026-05-07T08:44:45Z",
       "result": "clean"
     },
     "greens-theorem": {


### PR DESCRIPTION
## Summary

Re-audited 7 gallery entries last audited 2026-04-23 (auditCount 1→2). All structural counts verified against the Lean source; no drift detected.

| slug | status/badge | lc | thm | def | ax | sor |
|---|---|---|---|---|---|---|
| combinations-formula-oq-02 | verified/original | 312 | 22 | 2 | 0 | 0 |
| denumerability-rationals-oq-02-oq-02 | verified/mathlib | 216 | 15 | 2 | 0 | 0 |
| derangements-oq-03-oq-01-oq-02 | verified/original | 412 | 24 | 3 | 0 | 0 |
| erdos-1129-oq-02 | verified/original | 260 | 15 | 6 | 0 | 0 |
| erdos-130-wip-01 | axiomatized/wip | 201 | 13 | 0 | 0 | 0 |
| erdos-1217 | axiomatized/axiom | 56 | 1 | 2 | 1 | 0 |
| godel-second-incompleteness-oq02 | axiomatized/axiom | 258 | 3 | 2 | 1 (lf) / 6 (meta total incl. GodelFirstOQ01) | 0 |

## Audit methodology

For each entry:
- Read `meta.json` (top + meta + leanFile blocks) and the Lean source.
- Re-counted theorems, definitions, axioms, sorries, lines using a regex-based scanner that strips nested block comments and line comments before counting, and that allows `@[attr]`, `private`, `protected`, `noncomputable` prefixes.
- Cross-checked meta vs leanFile values for each numeric field.
- For axioms: verified `meta.axiomCount` either matches `lf.axiomCount` (single-file) or correctly aggregates the import chain (godel-second).
- Spot-checked Aristotle companion files referenced in `additionalFiles`.
- Sampled `originalContributions` and `assumptions` against actual decl heads.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` shows audited count incremented
- [x] All 7 entries removed from "never audited / 2026-04-23 last audited" cohort
- [x] `git diff --stat` is exactly 14+/14- on `audit-tracker.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)