### PR TITLE
fix(meta): erdos-486 — prose claimed 3 axioms, file declares 0

### DIFF
--- a/src/data/proofs/erdos-486/meta.json
+++ b/src/data/proofs/erdos-486/meta.json
@@ -55,11 +55,7 @@
       "Classical logic for decidability instances"
     ],
     "axiomCount": 0,
-    "assumptions": [
-      "erdos486_conjecture: The main open conjecture — every modular avoidance set has a logarithmic density",
-      "davenport_erdos_theorem: The proven special case (Xₙ = {0}) — stated as axiom pending Mathlib formalization",
-      "besicovitch_counterexample: Existence of a set with logarithmic but not natural density — stated as axiom pending formalization"
-    ],
+    "assumptions": "0 axioms declared. The Lean file is a definitional skeleton: 5 definitions (logSum, HasLogDensity, avoidanceSet, zeroAvoidanceSet, HasNaturalDensity) plus docstring placeholders for the open conjecture (Erdős #486), the Davenport-Erdős theorem (1936), and the Besicovitch counterexample (1934). No formal axiom or theorem statements are declared; the conjecture and partial results are documented in prose only.",
     "theoremCount": 0,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

`meta.assumptions` for erdos-486 enumerated three named items as if they
were axiom declarations, but the Lean file `Erdos486Problem.lean` declares
**0 axioms** and **0 theorems** — only 5 `def`s plus docstring placeholders
where the conjecture and partial results live in prose.

## Evidence

`grep -E '^[[:space:]]*(@\[[^]]+\][[:space:]]*)*((private|protected|noncomputable)[[:space:]]+)*axiom[[:space:]]'` returns 0 hits on the file. `meta.axiomCount=0` and `leanFile.axiomCount=0` are already in sync; only the prose was misleading.

**Before**: `"assumptions": [3 entries naming erdos486_conjecture / davenport_erdos_theorem / besicovitch_counterexample as 'stated as axiom pending Mathlib formalization']`

**After**: single-string assumptions accurately describing the file as a definitional skeleton (5 definitions, docstring placeholders only, no formal declarations).

Status remains `axiomatized` (per CLAUDE.md, open Erdős conjectures are always `axiomatized`) and badge remains `wip`.

---
Automated fix by lean-mechanic agent.