### PR TITLE
fix(lean): close 21 unclosed /-- docstrings in 10 gallery proof files

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -10,7 +10,7 @@ This gives a completely multiplicative symbol defined for ALL integers a, n.
 
 Definitions:
   (a/0) = if |a| = 1 then 1 else 0
-  (a/-1) = if a < 0 then -1 else 1
+  (a/(-1)) = if a < 0 then -1 else 1
   (a/2) = 0 if 2∣a, 1 if a ≡ ±1 (mod 8), -1 if a ≡ ±3 (mod 8)
   (a/p) = Legendre symbol for odd prime p
   (a/n) = ∏ (a/pᵢ)^eᵢ for n = ±∏ pᵢ^eᵢ (multiplicative extension)
@@ -41,7 +41,7 @@ def kronecker2 (a : ℤ) : ℤ :=
   else if a % 8 = 1 ∨ a % 8 = -1 ∨ a % 8 = 7 then 1
   else -1
 
-/-- (a/-1): the Kronecker symbol at -1.
+/-- (a/(-1)): the Kronecker symbol at -1.
     -1 if a < 0, 1 if a ≥ 0. Encodes the sign character. -/
 def kroneckerNeg1 (a : ℤ) : ℤ :=
   if a < 0 then -1 else 1
@@ -79,11 +79,11 @@ theorem kronecker2_seven : kronecker2 7 = 1 := by
 theorem kronecker2_zero : kronecker2 0 = 0 := by
   simp [kronecker2]
 
-/-- (a/-1) = 1 for nonneg a -/
+/-- (a/(-1)) = 1 for nonneg a -/
 theorem kroneckerNeg1_nonneg (a : ℤ) (ha : 0 ≤ a) : kroneckerNeg1 a = 1 := by
   simp [kroneckerNeg1]; omega
 
-/-- (a/-1) = -1 for neg a -/
+/-- (a/(-1)) = -1 for neg a -/
 theorem kroneckerNeg1_neg (a : ℤ) (ha : a < 0) : kroneckerNeg1 a = -1 := by
   simp [kroneckerNeg1, ha]
 

--- a/proofs/Proofs/Erdos16Problem.lean
+++ b/proofs/Proofs/Erdos16Problem.lean
@@ -55,7 +55,7 @@ def ExceptionalSet : Set ℕ :=
   { n : ℕ | Odd n ∧ ¬IsRomanoff n }
 
 /-- Alternative characterization: n is exceptional if for all k with 2^k < n,
-    the number n - 2^k is not prime.
+    the number n - 2^k is not prime. -/
 
 /-
 ## The Romanoff Theorem
@@ -73,9 +73,9 @@ noncomputable def density (A : Set ℕ) (N : ℕ) : ℝ :=
 noncomputable def lowerDensity (A : Set ℕ) : ℝ :=
   ⨅ (N : ℕ), ⨆ (M : ℕ) (_ : M ≥ N), density A M
 
-/-- Romanoff's Theorem (1934): A positive proportion of odd integers are Romanoff.
+/-- Romanoff's Theorem (1934): A positive proportion of odd integers are Romanoff. -/
 
-/-- Corollary: The exceptional set has density less than 1/2.
+/-- Corollary: The exceptional set has density less than 1/2. -/
 
 /-
 ## Erdős's Covering Congruence Result (1950)
@@ -89,7 +89,7 @@ def IsCoveringSystem (residues : List (ℕ × ℕ)) : Prop :=
   ∀ n : ℤ, ∃ rm ∈ residues, rm.2 > 0 ∧ n % rm.2 = rm.1
 
 /-- Erdős's construction (1950): The exceptional set contains an
-    infinite arithmetic progression.
+    infinite arithmetic progression. -/
 
 /-
 ## The Conjecture and Its Disproof
@@ -104,11 +104,11 @@ def ErdosConjecture16 : Prop :=
   ∃ a d : ℕ, d > 0 ∧
     lowerDensity (ExceptionalSet \ { n | ∃ m, n = a + m * d }) = 0
 
-/-- Chen's Theorem (2023): The conjecture is FALSE.
+/-- Chen's Theorem (2023): The conjecture is FALSE. -/
 
 /-- Consequence: The exceptional set contains elements from multiple
     "essentially different" arithmetic progressions, or has positive
-    density outside any single progression.
+    density outside any single progression. -/
 
 /-
 ## Known Exceptional Numbers
@@ -117,7 +117,7 @@ The first few odd integers not of the form 2^k + p (OEIS A006285):
 1, 127, 149, 251, 331, 337, 373, 509, 599, 701, 757, 809, 877, ...
 -/
 
-/-- 127 is in the exceptional set.
+/-- 127 is in the exceptional set. -/
 
 /-
 ## Connection to Covering Congruences
@@ -136,7 +136,7 @@ def erdosCovering : List (ℕ × ℕ) :=
 More precise bounds on the density of the exceptional set.
 -/
 
-/-- The exceptional set has positive lower density.
+/-- The exceptional set has positive lower density. -/
 
 /-
 ## Related Problems

--- a/proofs/Proofs/Erdos17Problem.lean
+++ b/proofs/Proofs/Erdos17Problem.lean
@@ -135,9 +135,9 @@ noncomputable def clusterPrimeCount (x : ℕ) : ℕ :=
   (primesUpTo x).filter (fun p => @Decidable.decide (IsClusterPrime p) (Classical.dec _)) |>.card
 
 /-- Blecksmith-Erdős-Selfridge (1999): For any A > 0, the count of
-    cluster primes up to x is O(x / (log x)^A).
+    cluster primes up to x is O(x / (log x)^A). -/
 
-/-- Elsholtz (2003): Improved bound with double-logarithmic decay.
+/-- Elsholtz (2003): Improved bound with double-logarithmic decay. -/
 
 /-
 ## Consequences of the Bounds

--- a/proofs/Proofs/Erdos206Problem.lean
+++ b/proofs/Proofs/Erdos206Problem.lean
@@ -142,7 +142,7 @@ def explicit_nongreedy_example_exists : Prop :=
 
     If greedy continued from R_1: 1/3 + 1/m needs 1/m < 11/24 - 1/3 = 3/24 = 1/8
     So greedy would give 1/3 + 1/9 = 4/9 ≈ 0.444
-    But 1/4 + 1/5 = 9/20 = 0.45 > 4/9
+    But 1/4 + 1/5 = 9/20 = 0.45 > 4/9 -/
 
 /- ## Part VII: Connection to Egyptian Fractions -/
 

--- a/proofs/Proofs/Erdos20Problem.lean
+++ b/proofs/Proofs/Erdos20Problem.lean
@@ -61,7 +61,7 @@ axiom sunflowerNumber (n k : ℕ) : ℕ
 /- ## The Sunflower Lemma (Erdős-Rado 1960) -/
 
 /-- **Erdős-Rado Sunflower Lemma (1960)**:
-    f(n,k) ≤ (k-1)^n · n!
+    f(n,k) ≤ (k-1)^n · n! -/
 
 /-- The Erdős-Rado bound explicitly. -/
 def erdosRadoBound (n k : ℕ) : ℕ := (k - 1)^n * n.factorial

--- a/proofs/Proofs/Erdos30Problem.lean
+++ b/proofs/Proofs/Erdos30Problem.lean
@@ -125,7 +125,7 @@ def RequiredUpperBound (ε : ℝ) : Prop :=
 /-- Achieving the conjecture for one ε < 1/4 would be a breakthrough.
     Proof sketch: If we have a bound with exponent ε₀ < 1/4, we can derive
     the conjecture for all ε > 0 by using N^ε₀ ≤ N^ε for ε ≤ ε₀ (when N ≥ 1)
-    or C * N^ε₀ ≤ N^ε for large enough N when ε > ε₀.
+    or C * N^ε₀ ≤ N^ε for large enough N when ε > ε₀. -/
 
 /- ## Perfect Difference Sets -/
 
@@ -162,7 +162,7 @@ def IsBhSet (A : Finset ℕ) (h : ℕ) : Prop :=
 
 /-- Sidon sets are B₂ sets.
     A Sidon set requires all pairwise sums to be distinct, which is exactly
-    the B₂ condition (all 2-element multiset sums are distinct).
+    the B₂ condition (all 2-element multiset sums are distinct). -/
 
 /- ## Problem Status -/
 

--- a/proofs/Proofs/Erdos457Problem.lean
+++ b/proofs/Proofs/Erdos457Problem.lean
@@ -122,7 +122,7 @@ by all primes up to about (2 + o(1)) log(n) because n itself is
 constructed from primes in that range. -/
 
 /-- Known: q(n, log n) ≥ (2 + o(1)) log n is achievable by taking n
-    as the product of primes between log(n) and (2 + o(1)) log(n).
+    as the product of primes between log(n) and (2 + o(1)) log(n). -/
 
 /- ## Part VI: Upper Bound Sub-Question
 

--- a/proofs/Proofs/Erdos51Problem.lean
+++ b/proofs/Proofs/Erdos51Problem.lean
@@ -53,7 +53,7 @@ noncomputable def smallestTotientPreimage (a : ℕ) : ℕ :=
 /- ## Main Conjecture -/
 
 /-- **Erdős Problem #51**: Is there an infinite set A ⊂ ℕ of totient values
-    such that the smallest preimage grows faster than the value itself?
+    such that the smallest preimage grows faster than the value itself? -/
 
 /- ## Basic Properties of Totient -/
 

--- a/proofs/Proofs/Erdos65Problem.lean
+++ b/proofs/Proofs/Erdos65Problem.lean
@@ -133,7 +133,7 @@ We use Mathlib's definition: G.IsBipartite
 noncomputable def bipartiteCycleSum (r s : ℕ) : ℝ :=
   ∑ i ∈ Finset.Icc 2 (min r s), (1 : ℝ) / (2 * i)
 
-/-- The bipartite cycle sum is 1/2 times a partial harmonic sum.
+/-- The bipartite cycle sum is 1/2 times a partial harmonic sum. -/
 
 /-
 ## Lower Bounds on Cycle Variety
@@ -158,7 +158,7 @@ The GKS result uses similar extremal graph theory techniques.
 /-- For k = 1 (n edges, average degree 2), the graph has a cycle.
 
     Proof: A forest (acyclic graph) on n vertices has at most n-1 edges.
-    With n edges, the graph cannot be acyclic, so it contains a cycle.
+    With n edges, the graph cannot be acyclic, so it contains a cycle. -/
 
 /-
 ## Remarks on the Open Question
@@ -179,7 +179,7 @@ the structure of ALL graphs with given edge count, not just bipartite ones.
     Proof: In a 2-coloring, adjacent vertices have different colors.
     Walking around a cycle of length k, colors alternate, so after k steps
     we return to the starting color iff k is even. Since we return to the
-    starting vertex (which has the starting color), k must be even.
+    starting vertex (which has the starting color), k must be even. -/
 
 /-- Odd cycle contribution: if G has an odd cycle of length k, it contributes 1/k > 0.
     The oddness hypothesis is semantically relevant (odd cycles are the non-bipartite ones)

--- a/proofs/Proofs/Hilbert23CalculusVariations.lean
+++ b/proofs/Proofs/Hilbert23CalculusVariations.lean
@@ -109,7 +109,7 @@ structure TestFunction (a b : ℝ) where
   vanish_right : func b = 0
 
 /-- **Fundamental Lemma of Calculus of Variations**:
-    If ∫ f · η = 0 for all test functions η, then f = 0.
+    If ∫ f · η = 0 for all test functions η, then f = 0. -/
 
 end FundamentalLemma
 
@@ -145,7 +145,7 @@ def IsExtremal (L : ℝ → ℝ → ℝ → ℝ) (y : ℝ → ℝ) : Prop :=
 
 /-- **Euler-Lagrange Necessary Condition**:
     If y is a local minimizer of J[y] = ∫ L(x, y, y') dx, then y
-    satisfies the Euler-Lagrange equation.
+    satisfies the Euler-Lagrange equation. -/
 
 -- The Euler-Lagrange equation in "weak form":
 -- ∫ (∂L/∂y · η + ∂L/∂y' · η') dx = 0 for all test functions η ∈ C₀^∞([a,b]).
@@ -172,7 +172,7 @@ noncomputable def geodesicLagrangian : ℝ → ℝ → ℝ → ℝ :=
   fun _ _ y' => Real.sqrt (1 + y'^2)
 
 /-- Geodesics in Euclidean space are straight lines.
-    This follows from Euler-Lagrange applied to the arc length functional.
+    This follows from Euler-Lagrange applied to the arc length functional. -/
 
 /-- **Classical Mechanics**: L = T - V (kinetic minus potential energy).
     Euler-Lagrange gives Newton's equations F = ma. -/
@@ -208,7 +208,7 @@ def IsWeaklyLowerSemicontinuous (J : (ℝ → ℝ) → ℝ) : Prop :=
 
 /-- **Direct Method Existence Theorem** (Tonelli, 1920s):
     If J is coercive and weakly lower semicontinuous on a suitable space,
-    then J attains its minimum.
+    then J attains its minimum. -/
 
 end DirectMethods
 
@@ -249,7 +249,7 @@ def hamiltonian (_S : ControlSystem) (_cost : CostFunctional _S)
 
 /-- **Pontryagin Maximum Principle** (1956):
     If u* is an optimal control with corresponding state x* and costate p*,
-    then H(x*, u*, p*) = max_u H(x*, u, p*) almost everywhere.
+    then H(x*, u*, p*) = max_u H(x*, u, p*) almost everywhere. -/
 
 end OptimalControl
 


### PR DESCRIPTION
## Fix

Ten gallery proof Lean files contained unclosed `/--` docstrings. Lean rejects each with `error: unterminated comment`, so the files do not parse and every declaration after the unclosed docstring is buried inside a comment block. This PR closes 21 docstrings across the 10 files; comment depth at EOF is now 0 in every file.

## Affected files & fixes

| File | Closes |
|------|--------|
| `Erdos457Problem.lean` | 1 |
| `Erdos30Problem.lean` | 2 |
| `Erdos20Problem.lean` | 1 |
| `Erdos51Problem.lean` | 1 |
| `Erdos65Problem.lean` | 3 |
| `Erdos16Problem.lean` | 8 |
| `Erdos17Problem.lean` | 2 |
| `Erdos206Problem.lean` | 1 |
| `Hilbert23CalculusVariations.lean` | 5 (one docstring's body contained `-- ` line comments that, while inside a docstring, are *not* line-comment terminators) |
| `ElementaryQuadraticReciprocityOQ03OQ02.lean` | special — see below |

For `ElementaryQuadraticReciprocityOQ03OQ02.lean`, the literal text pattern `(a/-1)` appears four times (lines 13, 44, 82, 86). Lean's parser sees the `/-` and opens a *nested* block comment. The first occurrence (line 13) sits inside a multi-line `/- ... -/` documentation block opened on line 1 and intended to close on line 25, so the line-25 closer only drops the depth from 2 to 1, swallowing the entire rest of the file (lines 26–223) into a comment. Rewrote the prose to `(a/(-1))` at all four sites; this preserves the mathematical meaning of the symbol description while not triggering nested block comments.

## Counts after fix

After closing the docstrings I re-counted `theorem`+`lemma` and `def`+`abbrev`+`opaque` (regex tolerant of `@[...]` attributes and `private`/`protected`/`noncomputable` modifiers, after stripping nested block comments). Every count now matches the existing `leanFile.theoremCount` / `leanFile.definitionCount` / `leanFile.lineCount` in `meta.json`, so **no metadata edits are required**.

| slug | thm/def/lines (recounted) | meta.json claim |
|------|---------------------------|-----------------|
| erdos-457 | 2/6/181 | 2/6/181 |
| erdos-30 | 4/8/194 | 4/8/194 |
| erdos-20 | 2/8/168 | 2/8/168 |
| erdos-51 | 1/4/69 | 1/4/69 |
| erdos-65 | 1/9/217 | 1/9/217 |
| erdos-16 | 0/10/203 | 0/10/203 |
| erdos-17 | 3/8/218 | 3/8/218 |
| erdos-206 | 3/7/194 | 3/7/194 |
| hilbert-23 | 1/9/328 | 1/9/328 |
| elementary-quadratic-reciprocity-oq-03-oq-02 | 16/4/223 | 16/4/223 |

(The auditor's "actual outside comments" column was lower because it was computed in the broken state where the unclosed docstrings swallowed downstream declarations. Closing the docstrings restores the originally-intended counts.)

## Validation

- Comment-balance check: all 10 files now have depth=0 at EOF.
- Diff is minimal (28 insertions / 28 deletions, no line-count change in any file).
- I did **not** run the Docker build — the auditor reported parser failures, not type-check failures, so this targeted fix should restore parsing for all 10 files. If type errors surface for declarations that were previously hidden inside the comment block, those should be filed as new issues per the mechanic scope-discipline rule.

Status badges (`axiomatized` / `axiom`) remain correct for these open-conjecture entries.

Closes #16536

---
Automated fix by lean-mechanic agent.