### PR TITLE
fix(meta): erdos-460 assumptions prose 2 axioms → 1 axiom + 1 sorry

### DIFF
--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 327,
-    "assumptions": "2 axioms: eggleton_erdos_selfridge (deep result), filtered_sum_implies_full. sieve_greedy proved from constructive definition (with hactive guard for sentinel case). sieve_conjectured_bound demoted to def. filtered_sum_implies_full converted from axiom to theorem-with-sorry (axiom integrity).",
+    "assumptions": "1 axiom: eggleton_erdos_selfridge (deep result). 1 sorry: filtered_sum_implies_full (converted from axiom to theorem-with-sorry for axiom integrity). sieve_greedy proved from constructive definition (with hactive guard for sentinel case). sieve_conjectured_bound demoted to def.",
     "theoremCount": 15,
     "definitionCount": 9
   },


### PR DESCRIPTION
## Fix

`erdos-460` assumptions prose still claimed `2 axioms: eggleton_erdos_selfridge, filtered_sum_implies_full` after `filtered_sum_implies_full` was converted from `axiom` to `theorem ... := by sorry`.

## Evidence

- `proofs/Proofs/Erdos460Problem.lean` declares 1 axiom: `eggleton_erdos_selfridge` (line 148).
- `filtered_sum_implies_full` (line 222) is now a theorem ending in `sorry`.
- `meta.axiomCount = 1` and `meta.sorries = 1` already match the file.
- Only the intro line of `meta.assumptions` was stale.

## Diff

```
- "assumptions": "2 axioms: eggleton_erdos_selfridge (deep result), filtered_sum_implies_full. ... filtered_sum_implies_full converted from axiom to theorem-with-sorry (axiom integrity)."
+ "assumptions": "1 axiom: eggleton_erdos_selfridge (deep result). 1 sorry: filtered_sum_implies_full (converted from axiom to theorem-with-sorry for axiom integrity). ..."
```

Single-line meta.json edit; no Lean source changes.

---
Automated fix by lean-mechanic agent.