### PR TITLE
fix(lean): repair 36 Aristotle template comments unterminated by /-! prose (#16540)

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ04OQ01Aristotle.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ04OQ01Aristotle.lean
@@ -8,7 +8,7 @@
   - NOT the abstract tower-Galois equivalence
   - Concrete example: ℚ(√2) as an explicit quadratic tower of height 1
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (1):
   - sqrt2_constructible_tower_ari: √2 lies in a quadratic tower of height 1 over ℚ

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean
@@ -9,7 +9,7 @@
   - NOT the marginal, mean, or covariance theorems (statistical theory)
   - Computational examples and product nonzero characterizations
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (2):
   - dice_six_rolls_all_different_ari: multinomial({0..5}, fun _ => 1) * 1 = 6!

--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean
@@ -7,7 +7,7 @@
   - Routine derivation from ω-continuity: monotonicity via a step chain
   - The chain construction a, b, b, b, ... connects ω-continuity to monotonicity
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (1):
   - omega_continuous_monotone_ari: ω-continuous functions are monotone

--- a/proofs/Proofs/Erdos1043Aristotle.lean
+++ b/proofs/Proofs/Erdos1043Aristotle.lean
@@ -7,7 +7,7 @@
   - NOT the main hard results (disk projection measure, level set compactness)
   - Routine order/lattice facts: iInf ≤ iSup, ENNReal arithmetic contradictions
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos1050ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos1050ProblemAristotle.lean
@@ -8,7 +8,7 @@
   - Routine: arithmetic about 2^n ± 3, convergence setup, logical implications
   - Transcendence → irrationality (follows from Mathlib's Transcendental.irrational)
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos160ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos160ProblemAristotle.lean
@@ -9,7 +9,7 @@
   - Derivable consequences of the known axiomatized bounds
   - Standard real analysis: rpow monotonicity, exp/log Filter.Tendsto facts
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (2):
   - h_sublinear_ari: for ε ∈ (0, 1/3), h(n) ≤ n^(1-ε) for large n

--- a/proofs/Proofs/Erdos179ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos179ProblemAristotle.lean
@@ -10,7 +10,7 @@
   - Membership and containment lemmas
   - Supporting infrastructure for AP_free_has_2APs and F_2_well_defined
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos207ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos207ProblemAristotle.lean
@@ -8,7 +8,7 @@
   - NOT girth_3_iff_pasch_free: complex combinatorial equivalence
   - Girth ≥ 2 for any Steiner triple system: provable from STS uniqueness
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (1):
   - sts_has_girth_at_least_2_ari: every STS has girth ≥ 2

--- a/proofs/Proofs/Erdos240Aristotle.lean
+++ b/proofs/Proofs/Erdos240Aristotle.lean
@@ -9,7 +9,7 @@
   - singleton_large_gaps: follows directly from finite_P_unbounded_gaps axiom
   - Simple P-smooth membership lemmas provable from definitions
   - No new axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets:
   - singleton_large_gaps_ari: gapsTendToInfinity {p} for prime p

--- a/proofs/Proofs/Erdos260Aristotle.lean
+++ b/proofs/Proofs/Erdos260Aristotle.lean
@@ -8,7 +8,7 @@
   - Routine analysis facts: n/2^n summability, exponential domination, limit comparisons
   - Helper lemmas for series_converges, fastGrowth_of_gapsToInfinity, fastGrowth_of_superlogarithmic
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos360Aristotle.lean
+++ b/proofs/Proofs/Erdos360Aristotle.lean
@@ -8,7 +8,7 @@
   - Concrete small cases: f(2) = 1 and f(4) = 2, which are decidable computations
   - Helper lemmas for sum-free partition witnesses
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets:
   - set1_is_2sum_free_ari: {1} is 2-sum-free (no subset sums to 2)

--- a/proofs/Proofs/Erdos381ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos381ProblemAristotle.lean
@@ -7,7 +7,7 @@
   - NOT open conjectures (the problem is DISPROVED — Nicolas 1971)
   - All theorems follow from axioms already in Erdos381Problem.lean
   - No definition sorries, no axiom declarations, no True placeholders
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Background:
   - erdos_lower_bound (axiom): Q(x) ≥ K(log x)^{1+c} for some c > 0

--- a/proofs/Proofs/Erdos441Aristotle.lean
+++ b/proofs/Proofs/Erdos441Aristotle.lean
@@ -9,7 +9,7 @@
   - Membership and interval lemmas for ErdosFirstPart and ErdosSecondPart
   - LCM bound supporting lemmas using Nat.lcm API
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 
   Excluded (too deep for Aristotle):
   - construction_gives_lower_bound: requires LCM bound proof for full construction

--- a/proofs/Proofs/Erdos57ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos57ProblemAristotle.lean
@@ -8,7 +8,7 @@
   - NOT UpperDensityConjecture / HalfDensityConjecture: open conjectures
   - Bipartite characterization lemmas, classical graph theory
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (2):
   - colorable_two_no_odd_cycles_ari: IsColorable G 2 → oddCycleLengths G = ∅

--- a/proofs/Proofs/Erdos625ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos625ProblemAristotle.lean
@@ -9,7 +9,7 @@
   - AlmostSurely-based theorems (AlmostSurely unfolds to ∀ ε > 0, ∃ N, ∀ n ≥ N, True — trivial)
   - Logical implication and structural theorems
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 -/
 import Proofs.Erdos625Problem
 import Mathlib

--- a/proofs/Proofs/Erdos626Aristotle.lean
+++ b/proofs/Proofs/Erdos626Aristotle.lean
@@ -11,7 +11,7 @@
   - Positivity of coefficient gap
   - Logical deduction from probabilistic method axiom
   - No axioms, no definition sorries, no open conjectures
-  - No /- ! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 -/
 import Proofs.Erdos626Problem
 import Mathlib

--- a/proofs/Proofs/Erdos631Aristotle.lean
+++ b/proofs/Proofs/Erdos631Aristotle.lean
@@ -8,7 +8,7 @@
   - NOT deep results about planar graphs or list coloring conjecture
   - Monotonicity of k-choosability: a well-defined predicate about list colorings
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (1):
   - choosable_monotone_ari: IsKChoosable G k → IsKChoosable G (k+1)

--- a/proofs/Proofs/Erdos642Aristotle.lean
+++ b/proofs/Proofs/Erdos642Aristotle.lean
@@ -8,7 +8,7 @@
   - NOT the axiomatized bounds (chen_erdos_staton, dmms_2024)
   - Routine arithmetic and graph-theoretic facts supporting the sorry theorems
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos660ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos660ProblemAristotle.lean
@@ -12,7 +12,7 @@
   - Symmetry: pairwiseDistances is symmetric in the two arguments
   - Monotonicity: adding a point can only increase or maintain distinctDistances
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (3):
   - trivial_lower_bound_ari: S.card ≥ 2 → distinctDistances S ≥ 1

--- a/proofs/Proofs/Erdos671ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos671ProblemAristotle.lean
@@ -10,7 +10,7 @@
   - Routine polynomial evaluation lemmas (basis at nodes)
   - Logical implication between question formulations
   - No axioms, no definition sorries, no open conjectures
-  - No /- ! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 -/
 import Proofs.Erdos671Problem
 import Mathlib

--- a/proofs/Proofs/Erdos679ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos679ProblemAristotle.lean
@@ -10,7 +10,7 @@
   - NOT the open dichotomy conjecture
   - Factored sub-lemmas for omega_primorial (structural induction steps)
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 -/
 import Proofs.Erdos679Problem
 import Mathlib

--- a/proofs/Proofs/Erdos715ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos715ProblemAristotle.lean
@@ -10,7 +10,7 @@
   - Finite decidable instances: K4 regularity and minimality
   - Combinatorial parity argument: regularity implies even degree sum
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (3):
   - K4_is_3_regular_ari: every vertex of K4 has degree 3 (decidable on Fin 4)

--- a/proofs/Proofs/Erdos73Aristotle.lean
+++ b/proofs/Proofs/Erdos73Aristotle.lean
@@ -8,7 +8,7 @@
   - Routine graph-theoretic facts: K₃ properties, bipartiteness
   - Constructive examples: K₃ independence number, K₃ almost-bipartite
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos79ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos79ProblemAristotle.lean
@@ -10,7 +10,7 @@
   - Computational result: K4 has exactly 6 edges (decidable)
   - Logical argument: minimal non-linear graphs form an antichain
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (2):
   - K4_edge_count_ari: edgeCount (completeGraph 4) = 6 (by decide)

--- a/proofs/Proofs/Erdos817Aristotle.lean
+++ b/proofs/Proofs/Erdos817Aristotle.lean
@@ -8,7 +8,7 @@
   - NOT the Erdős-Sárközy partial result (deep sieve argument)
   - Routine combinatorics: subset sum cardinalities, AP-free small sets, Icc bounds
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos876ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos876ProblemAristotle.lean
@@ -13,7 +13,7 @@
   - NOT open gap questions (ErdosQuestion876, graham_result)
   - Routine arithmetic facts about powers of 2 and Finset sums
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos877Aristotle.lean
+++ b/proofs/Proofs/Erdos877Aristotle.lean
@@ -8,7 +8,7 @@
   - NOT the open counting asymptotics (f_m(n) ~ 2^{n/4})
   - Routine sum-free set arithmetic: parity, filter bounds
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Erdos901ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos901ProblemAristotle.lean
@@ -12,7 +12,7 @@
   - Arithmetic identities (probability of monochromatic event)
   - Concrete finite instance (hypergraph_m2 lacks Property B)
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (3):
   - propertyB_dichotomy_ari: HasPropertyB ↔ ¬LacksPropertyB (definitional iff)

--- a/proofs/Proofs/Erdos933ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos933ProblemAristotle.lean
@@ -9,7 +9,7 @@
   - Factorization additivity lemmas: power of prime p in n*(n+1)
     equals sum of powers in n and n+1 (from Nat.factorization_mul)
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (2):
   - power2_consecutive_ari: v_2(n*(n+1)) = v_2(n) + v_2(n+1)

--- a/proofs/Proofs/Erdos977ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos977ProblemAristotle.lean
@@ -9,7 +9,7 @@
   - GPF definition lemmas derivable from Mathlib's primeFactors API
   - Conditional derivations given deep results as hypotheses
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/Hilbert20OQ01OQ03Aristotle.lean
+++ b/proofs/Proofs/Hilbert20OQ01OQ03Aristotle.lean
@@ -9,7 +9,7 @@
   - Algebraic helper: product of complex numbers with zero imaginary parts
   - Algebraic helper: finite products of real-embedded complex monomials
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (2):
   - prod_im_eq_zero_ari: finite product of complex numbers with zero im has zero im

--- a/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean
@@ -9,7 +9,7 @@
   - NOT the maximal ergodic lemma (axiom — sunrise lemma)
   - Only the mixing → ergodic implication (theorem sorry, standard argument)
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (1):
   - mixing_implies_ergodic_ari: IsMixing T μ → Ergodic T μ

--- a/proofs/Proofs/LeibnizPiOQ02Aristotle.lean
+++ b/proofs/Proofs/LeibnizPiOQ02Aristotle.lean
@@ -9,7 +9,7 @@
   - NOT numerical bounds on infinite sums (catalan_bounds — too complex for Aristotle)
   - Convergence theorems accessible via Mathlib's alternating series results
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 
   Included targets (5):
   - alternating_harmonic_series_ari: altHarmonicPartialSum → log 2

--- a/proofs/Proofs/LovaszLocalLemmaOQ02Aristotle.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ02Aristotle.lean
@@ -13,7 +13,7 @@
   - Equality characterizations for d = 1, 2, 3
   - d = 4 maximum bound (extending the d=1,2,3 pattern from parent)
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/SpernerFreudenthalAristotle.lean
+++ b/proofs/Proofs/SpernerFreudenthalAristotle.lean
@@ -17,7 +17,7 @@
   - finsetToNat_injective is a standalone theorem about binary sums
   - The fact follows from: distinct powers of 2 are Z-linearly independent
   - No axioms, no definition sorries, no open conjectures
-  - No /-! docstring sections
+  - Use only block comments, not module docstrings
 -/
 import Mathlib
 

--- a/proofs/Proofs/UnitDistanceHN7Aristotle.lean
+++ b/proofs/Proofs/UnitDistanceHN7Aristotle.lean
@@ -11,7 +11,7 @@
   - NOT the main Hadwiger-Nelson theorem (follows from the supporting lemmas above)
   - Standalone theorems (sorries at theorem level, not buried in proofs)
   - No definition sorries, no axiom declarations, no open conjectures
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
 -/
 import Proofs.UnitDistanceHN7
 import Mathlib


### PR DESCRIPTION
## Summary

Closes #16540 — 36 Aristotle companion `.lean` files in `proofs/Proofs/` were build-broken with `error: unterminated comment` because their preamble docstring contained the prose line:

```
- No /-! docstring sections (use /- instead)
```

Lean 4's lexer **nests block comments on every `/-`**, including the `/-!` and `/-` substrings inside this prose. Those embedded `/-` openers were not unwound by the preamble's closing `-/`, leaving every declaration in each file buried inside an open comment.

## Fix

Single-line per-file replacement of the offending prose with a phrase that contains no `/-`:

```diff
-  - No /-! docstring sections (use /- instead)
+  - Use only block comments, not module docstrings
```

Two files used `- No /- ! docstring sections (use /- instead)` (with a space) and one variant lacked the `(use /- instead)` parenthetical; all are handled with the same replacement target.

## Verification

Ran the unclosed-depth function from the issue against each file:

| State | Files at depth 0 | Files at depth ≥ 1 |
|---|---|---|
| Before | 0 | 36 |
| After  | 36 | 0 |

Pre-counts matched the issue's table exactly (13 at depth 1, 23 at depth 2 → all → 0).

## Test plan

- [x] All 36 files now have unclosed-depth = 0 (Python check from issue)
- [x] Diff is exactly 36 single-line text replacements (`36 files changed, 36 insertions(+), 36 deletions(-)`)
- [ ] Optional: `lake build` Aristotle modules locally — not run here (Docker wrapper required, out of scope for a prose-only fix)

## Notes

- No tracker changes: once merged the slugs are correctly classified as clean.
- The "template / generator" recommendation in the issue does not apply; there is no generator script in-tree — the prose is convention from `research/SORRY-CLASSIFICATION.md`. That doc itself does not contain the offending substring outside of code blocks (verified).
- Companion to #16539 (10 different files, unclosed `/--` docstrings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)