### PR TITLE
audit(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1587,9 +1587,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:49Z",
+      "lastAudited": "2026-05-07T10:24:46Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-02": {


### PR DESCRIPTION
## Audit Result: clean

Re-audit of `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` (Radon-Nikodým Route to Lp Duality).

All meta.json claims verified against `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`:

| Field | Claimed | Actual |
|-------|---------|--------|
| lineCount | 1077 | 1077 ✓ |
| theoremCount | 18 | 18 ✓ |
| definitionCount | 3 | 3 ✓ |
| axiomCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |

- No True stubs
- No `axiom` declarations
- No structure-encoded assumptions
- Tier B "mathlib" badge correctly identifies Mathlib reliance (Radon-Nikodým, Hölder, Lp.induction)
- Description and conclusion appropriately credit Mathlib's infrastructure

Tracker bump: auditCount 1→2, lastAudited 2026-04-23 → 2026-05-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)