### PR TITLE
fix(meta): erdos-100-oq-02-oq-02 axiomCount 0→2 (inherits Guth-Katz axioms)

### DIFF
--- a/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
@@ -45,7 +45,7 @@
     "dateAdded": "2026-04-12",
     "erdosNumber": 100,
     "proofRepoPath": "Proofs/Erdos100OQ02OQ02.lean",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 104,
     "assumptions": "0 own axioms. Inherits 2 axioms from Erdos100Problem.lean: guthKatz_distinct_distances (Guth-Katz 2015) and piepmeyer_construction. Uses diam_ge_n_over_log_n (proved theorem in parent). 0 sorries.",
     "theoremCount": 2,


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-100-oq-02-oq-02/meta.json` had `meta.axiomCount: 0` despite `status: axiomatized` and `assumptions` prose correctly stating the entry inherits 2 axioms from the parent (`guthKatz_distinct_distances`, `piepmeyer_construction`).

## Evidence

**Before**:
```jsonc
"status": "axiomatized",
"axiomCount": 0,                  // <-- undercount
"assumptions": "0 own axioms. Inherits 2 axioms from Erdos100Problem.lean: guthKatz_distinct_distances (Guth-Katz 2015) and piepmeyer_construction. ..."
```

**After**:
```jsonc
"status": "axiomatized",
"axiomCount": 2,                  // <-- now matches inherited count
"assumptions": "0 own axioms. Inherits 2 axioms from Erdos100Problem.lean: ..."
```

`leanFile.axiomCount` remains `0` (this file declares no own axioms; the `axiomCount: 2` represents the full import chain, matching the convention used by the sibling `erdos-100-oq-02` which already had `meta.axiomCount: 2 / leanFile.axiomCount: 0`).

Per the Axiom Integrity Policy in `CLAUDE.md`: "axiomCount in meta.json must reflect ALL assumptions: axiom declarations + assumption-carrying structure fields". And per the `find-targets.ts` comment: "leanFile.axiomCount counts only the main file; meta.axiomCount counts the full import chain."

Confirmed `proofs/Proofs/Erdos100Problem.lean` declares exactly 2 axioms (`guthKatz_distinct_distances` line 311, `piepmeyer_construction` line 360); `Erdos100OQ02OQ02.lean` imports it.

---
Automated fix by lean-mechanic agent.