### PR TITLE
audit(tracker): mark 6 proofs clean — gcd, dissection, konigsberg, hurwitz, lebesgue-measure, napoleons

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2534,9 +2534,9 @@
       "result": "clean"
     },
     "dissection-of-cubes-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:25Z",
+      "lastAudited": "2026-05-07T10:30:00Z",
       "result": "issues-fixed"
     },
     "divisibility-by-3": {
@@ -11537,9 +11537,9 @@
       "result": "clean"
     },
     "gcd-algorithm-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:25Z",
+      "lastAudited": "2026-05-07T10:30:00Z",
       "result": "clean"
     },
     "gelfond-schneider": {
@@ -11888,9 +11888,9 @@
       "result": "clean"
     },
     "hurwitz-theorem-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:26Z",
+      "lastAudited": "2026-05-07T10:30:00Z",
       "result": "clean"
     },
     "hurwitz-theorem-oq-04": {
@@ -12065,9 +12065,9 @@
       "result": "clean"
     },
     "konigsberg-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:26Z",
+      "lastAudited": "2026-05-07T10:30:00Z",
       "result": "clean"
     },
     "kroneckers-jugendtraum": {
@@ -12263,9 +12263,9 @@
       "result": "clean"
     },
     "lebesgue-measure-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:27Z",
+      "lastAudited": "2026-05-07T10:30:00Z",
       "result": "clean"
     },
     "lebesgue-measure-oq-06": {
@@ -12445,9 +12445,9 @@
       "result": "clean"
     },
     "napoleons-theorem-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:29Z",
+      "lastAudited": "2026-05-07T10:30:00Z",
       "result": "clean"
     },
     "navier-stokes": {


### PR DESCRIPTION
## Summary

Re-audited 6 gallery entries last audited 2026-04-23 (auditCount 1→2). All structural counts verified against the Lean source on origin/main; no drift detected.

| slug | status/badge | lc | thm | def | ax | sor |
|---|---|---|---|---|---|---|
| gcd-algorithm-oq-04 | verified/original | 186 | 10 | 0 | 0 | 0 |
| dissection-of-cubes-oq-04 | verified/original | 561 | 25 | 4 | 0 | 0 |
| konigsberg-oq-04 | axiomatized/axiom | 338 | 9 | 10 | 1 | 0 |
| hurwitz-theorem-oq-03-oq-01 | formalized/wip | 113 | 3 | 1 | 0 | 1 |
| lebesgue-measure-oq-03-oq-01 | verified/original | 282 | 9 | 1 | 0 | 0 |
| napoleons-theorem-oq-02 | verified/original | 346 | 11 | 2 | 0 | 0 |

## Audit methodology

For each entry:
- Read `meta.json` (top + meta + leanFile blocks) and the Lean source from origin/main.
- Re-counted theorems, definitions, axioms, sorries, lines using a regex-based scanner that strips nested `/- ... -/` block comments + `--` line comments + `/-- ... -/` docstrings (handled per Lean 4 lexer: `/--` does not nest).
- Regex allows `@[attr]`, `private`, `protected`, `noncomputable`, `partial`, `unsafe` prefixes for theorem/lemma/def/abbrev/opaque.
- Cross-checked `meta.*` vs `leanFile.*` numeric fields.
- For axiomatized entries: confirmed `axiomCount` matches a real `axiom` declaration count.
- Spot-checked status/badge consistency (Tier classification per `.claude/commands/lean-auditor.md`).

## Test plan

- [x] `python3 -c "import json; json.load(open('audit-tracker.json'))"` parses cleanly
- [x] Diff is exactly 12 lines (2 per entry × 6 entries) — no whole-file reformat
- [x] None of the 6 entries had a competing in-flight tracker PR (checked via `gh pr list --search`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)