### PR TITLE
fix(daemon): respawn agents stuck in failure loops; pin herald model

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -501,8 +501,14 @@ run_claude_once() {
     local tmpfile
     tmpfile=$(mktemp)
 
-    # Run in background so we can monitor for startup hangs
-    timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude -p --dangerously-skip-permissions "$PROMPT" < /dev/null > "$tmpfile" 2>&1 &
+    # Run in background so we can monitor for startup hangs.
+    # CLAUDE_MODEL env var pins a specific model (e.g. to avoid 1M-context auto-
+    # selection on accounts that lack the entitlement). Empty/unset → CLI default.
+    local model_arg=()
+    if [[ -n "${CLAUDE_MODEL:-}" ]]; then
+        model_arg=(--model "$CLAUDE_MODEL")
+    fi
+    timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude -p --dangerously-skip-permissions "${model_arg[@]}" "$PROMPT" < /dev/null > "$tmpfile" 2>&1 &
     local timeout_pid=$!
 
     # Find the actual claude child process (timeout -> claude)

--- a/scripts/herald/launch-agent.sh
+++ b/scripts/herald/launch-agent.sh
@@ -340,10 +340,13 @@ launch_agent() {
     print_info "Interval: ${INTERVAL}m (${interval_hours}h)"
     print_info "State: $STATE_FILE"
 
-    # Launch in tmux — no worktree needed (read-only agent)
+    # Launch in tmux — no worktree needed (read-only agent).
+    # Pin standard-context Opus 4.7: herald's prompt + state file can trigger 1M
+    # auto-selection, which fails on accounts without the 1M-context entitlement.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    local herald_model="${HERALD_CLAUDE_MODEL:-claude-opus-4-7}"
     tmux new-session -d -s "$SESSION_NAME" -c "$REPO_ROOT" \
-        "ENHANCER_ID=herald REPO_ROOT=$REPO_ROOT $wrapper_script --daemon --prompt 'You are the herald agent. Read $prompt_file for your instructions, then start the scan loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=herald REPO_ROOT=$REPO_ROOT CLAUDE_MODEL=$herald_model $wrapper_script --daemon --prompt 'You are the herald agent. Read $prompt_file for your instructions, then start the scan loop.' --log '$LOG_FILE'"
 
     print_success "Launched herald agent"
     echo ""

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1843,6 +1843,29 @@ cmd_daemon() {
             local status
             status=$(get_agent_status "$session")
 
+            # Failure-loop check: wrapper retries on its own (e.g. 5min cooldown),
+            # so an agent can stay RUNNING/IDLE while every cycle errors. Force a
+            # respawn once consecutive_failures crosses the threshold.
+            local failures
+            failures=$(get_consecutive_failures "$session")
+            if [[ "$status" == "RUNNING" || "$status" == "IDLE" ]] && \
+               [[ "$failures" -ge "$CONSECUTIVE_FAILURE_THRESHOLD" ]]; then
+                if is_cooldown_elapsed "$session"; then
+                    daemon_log "WARN" "Agent $session FAILING (${failures} consecutive failures), killing and respawning..."
+                    if kill_and_respawn "$session"; then
+                        cycle_respawns=$((cycle_respawns + 1))
+                    fi
+                    continue
+                else
+                    local last_f
+                    last_f=$(get_last_respawn "$session")
+                    local now_f
+                    now_f=$(date +%s)
+                    local remaining_f=$(( RESPAWN_COOLDOWN_SECONDS - (now_f - last_f) ))
+                    daemon_log "WARN" "Agent $session FAILING (${failures}) but in cooldown (${remaining_f}s remaining)"
+                fi
+            fi
+
             case "$status" in
                 RUNNING)
                     running_count=$((running_count + 1))


### PR DESCRIPTION
## Summary
- **Daemon auto-respawn for failure loops.** `scripts/lean/launch.sh` already tracks `consecutive_failures` (line 874) and renders `FAILING` in the `health` command, but the daemon loop's `case` statement only acted on RUNNING/IDLE/COMPLETED/STUCK and never on FAILING. Wrappers retry on a cooldown, so a broken agent can stay RUNNING while every cycle errors. Adds a check: if `failures >= CONSECUTIVE_FAILURE_THRESHOLD` (10) and respawn cooldown has elapsed, `kill_and_respawn`. Mirrors the STUCK branch.
- **Herald: pin standard-context Opus 4.7.** Herald has been failing every cycle for 24h+ with `API Error: Extra usage is required for 1M context`. The wrapper invokes plain `claude -p` (no `--model`), so the CLI auto-selects the 1M-context Opus 4.7 model, which the OAuth account herald is on doesn't have the entitlement for. Adds `CLAUDE_MODEL` env var support to `scripts/agents/claude-wrapper.sh` and pins herald to `claude-opus-4-7` (override via `HERALD_CLAUDE_MODEL`).

## Why now
Last successful Mathstodon post: 2026-05-06 09:31 UTC. Herald's daemon log shows 255 consecutive failed cycles since then. The same auto-respawn change would have caught this on cycle 11 instead of cycle 255.

## Test plan
- [x] `bash -n` clean on all three modified scripts
- [x] Verified `claude -p --model claude-opus-4-7 …` works on this account (smoke test returned `OK`)
- [ ] After merge: restart herald via `./scripts/herald/launch-agent.sh --start`, watch `.loom/logs/herald.log` for a clean cycle, confirm a Mathstodon post lands within ~6h

🤖 Generated with [Claude Code](https://claude.com/claude-code)