### PR TITLE
fix(meta): erdos-741 — lineCount 336→337 after PR #16483

### DIFF
--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -66,7 +66,7 @@
       "part2_contradicts_part1_for_basis: proved Part 2 implies Part 1 tension"
     ],
     "axiomCount": 0,
-    "lineCount": 336,
+    "lineCount": 337,
     "assumptions": "0 axioms, 0 sorries. cofinite_density_one proved as a theorem in PR #16461.",
     "theoremCount": 27,
     "definitionCount": 8
@@ -163,7 +163,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 336,
+    "lineCount": 337,
     "axiomCount": 0,
     "theoremCount": 27,
     "definitionCount": 8,


### PR DESCRIPTION
## Drift

PR #16483 added one line to `proofs/Proofs/Erdos741Problem.lean` (compile-error fix: `Finset.card_Iic` → `range`, `Filter.Eventually.of_forall`). The earlier metadata sync PR #16485 set `lineCount` to 336, which is now off by one.

## Fix

Both `meta.lineCount` (line 69) and `leanFile.lineCount` (line 166) → **337**.

## Verification

| Field | meta.json | actual | status |
|-------|-----------|--------|--------|
| lineCount | 336 → **337** | 337 | fixed |
| theoremCount | 27 | 27 | ok |
| definitionCount | 8 | 8 | ok |
| axiomCount | 0 | 0 | ok |
| sorries | 0 | 0 | ok |

Found by manual lineCount drift scanner; find-targets.ts only checks structural counts (sorry/axiom/True-stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)