### PR TITLE
fix(meta): batch — add Aristotle companion to additionalFiles (30 entries)

### DIFF
--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -240,7 +240,10 @@
     "theoremCount": 4,
     "definitionCount": 15,
     "path": "Proofs/Erdos1018Problem.lean",
-    "sorries": 7
+    "sorries": 7,
+    "additionalFiles": [
+      "Proofs/Erdos1018Aristotle.lean"
+    ]
   },
   "sorries": 7
 }

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -283,7 +283,10 @@
     "theoremCount": 13,
     "definitionCount": 22,
     "path": "Proofs/Erdos1019Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/Erdos1019Aristotle.lean"
+    ]
   },
   "mathlibDependencies": [
     "Mathlib.Combinatorics.SimpleGraph.Basic",

--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -259,7 +259,10 @@
     "theoremCount": 5,
     "definitionCount": 17,
     "path": "Proofs/Erdos1021Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos1021Aristotle.lean"
+    ]
   },
   "sorries": 2
 }

--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -194,7 +194,10 @@
     "theoremCount": 10,
     "definitionCount": 14,
     "path": "Proofs/Erdos1027Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1027Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -310,7 +310,10 @@
     "theoremCount": 28,
     "definitionCount": 19,
     "sorries": 0,
-    "path": "Proofs/Erdos1033Problem.lean"
+    "path": "Proofs/Erdos1033Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos1033Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -280,7 +280,10 @@
     "theoremCount": 16,
     "definitionCount": 22,
     "path": "Proofs/Erdos1034Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos1034Aristotle.lean"
+    ]
   },
   "sorries": 3
 }

--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -252,7 +252,10 @@
     "theoremCount": 12,
     "definitionCount": 20,
     "path": "Proofs/Erdos1037Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1037Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -150,7 +150,10 @@
     "theoremCount": 4,
     "definitionCount": 12,
     "path": "Proofs/Erdos104Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos104Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -239,7 +239,10 @@
     "trivialSpecializations": 0,
     "definitionCount": 19,
     "path": "Proofs/Erdos1040Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1040Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -92,7 +92,10 @@
     "theoremCount": 23,
     "definitionCount": 3,
     "path": "Proofs/Erdos1052Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1052Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -199,7 +199,10 @@
     "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/Erdos1056Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1056Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -192,7 +192,10 @@
     "theoremCount": 6,
     "definitionCount": 6,
     "path": "Proofs/Erdos1095Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1095Aristotle.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1105/meta.json
+++ b/src/data/proofs/erdos-1105/meta.json
@@ -296,7 +296,10 @@
     "theoremCount": 9,
     "definitionCount": 26,
     "path": "Proofs/Erdos1105Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1105Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -189,7 +189,10 @@
     "axiomCount": 7,
     "sorries": 0,
     "definitionCount": 11,
-    "theoremCount": 15
+    "theoremCount": 15,
+    "additionalFiles": [
+      "Proofs/Erdos1126OQ01Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1132/meta.json
+++ b/src/data/proofs/erdos-1132/meta.json
@@ -246,7 +246,10 @@
     "theoremCount": 7,
     "definitionCount": 11,
     "path": "Proofs/Erdos1132Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1132Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -241,7 +241,10 @@
     "theoremCount": 18,
     "definitionCount": 5,
     "sorries": 0,
-    "path": "Proofs/Erdos1149Problem.lean"
+    "path": "Proofs/Erdos1149Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos1149Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -136,7 +136,10 @@
     "path": "Proofs/Erdos1168Problem.lean",
     "sorries": 2,
     "definitionCount": 9,
-    "theoremCount": 14
+    "theoremCount": 14,
+    "additionalFiles": [
+      "Proofs/Erdos1168Aristotle.lean"
+    ]
   },
   "sorries": 2
 }

--- a/src/data/proofs/erdos-1196/meta.json
+++ b/src/data/proofs/erdos-1196/meta.json
@@ -208,7 +208,10 @@
     "theoremCount": 5,
     "definitionCount": 5,
     "path": "Proofs/Erdos1196Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/Erdos1196Aristotle.lean"
+    ]
   },
   "sorries": 1
 }

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -115,7 +115,10 @@
     "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Erdos135Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos135Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -143,7 +143,10 @@
     "theoremCount": 4,
     "definitionCount": 9,
     "path": "Proofs/Erdos138Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/Erdos138Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -164,7 +164,10 @@
     "theoremCount": 2,
     "definitionCount": 3,
     "path": "Proofs/Erdos165Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos165Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-211/meta.json
+++ b/src/data/proofs/erdos-211/meta.json
@@ -147,7 +147,10 @@
     "theoremCount": 1,
     "definitionCount": 8,
     "path": "Proofs/Erdos211Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos211Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -144,7 +144,10 @@
     "theoremCount": 3,
     "definitionCount": 14,
     "path": "Proofs/Erdos220Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos220Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-225/meta.json
+++ b/src/data/proofs/erdos-225/meta.json
@@ -128,7 +128,10 @@
     "theoremCount": 8,
     "definitionCount": 8,
     "path": "Proofs/Erdos225Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos225Aristotle.lean"
+    ]
   },
   "references": [
     "Erdős (1940, 1957, 1961): early work on trigonometric polynomial norms",

--- a/src/data/proofs/erdos-247-oq-01/meta.json
+++ b/src/data/proofs/erdos-247-oq-01/meta.json
@@ -71,6 +71,9 @@
     "sorries": 0,
     "imports": [
       "Proofs.LiouvilleTheorem"
+    ],
+    "additionalFiles": [
+      "Proofs/Erdos247Aristotle.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-247/meta.json
+++ b/src/data/proofs/erdos-247/meta.json
@@ -140,7 +140,10 @@
     "theoremCount": 27,
     "definitionCount": 7,
     "path": "Proofs/Erdos247Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos247Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -166,7 +166,10 @@
     "theoremCount": 31,
     "definitionCount": 19,
     "path": "Proofs/Erdos263Problem.lean",
-    "sorries": 4
+    "sorries": 4,
+    "additionalFiles": [
+      "Proofs/Erdos263Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -155,7 +155,10 @@
     "theoremCount": 5,
     "definitionCount": 11,
     "path": "Proofs/Erdos265Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos265Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -198,7 +198,10 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "path": "Proofs/Erdos27Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos27Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-302/meta.json
+++ b/src/data/proofs/erdos-302/meta.json
@@ -239,7 +239,10 @@
     "theoremCount": 16,
     "definitionCount": 10,
     "path": "Proofs/Erdos302Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos302Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Add `*Aristotle.lean` companion files to `leanFile.additionalFiles` for **30 gallery entries** where the companion file exists on `origin/main` but was not declared in the meta.json schema.

Follows the convention established by:
- #16502 (shapley-folkman, single entry)
- #16518 (batch of 4 entries)

143+ existing entries already list their Aristotle companion in `leanFile.additionalFiles`. Without this entry, `find-targets` sibling-follow checks miss the companion file and audit coverage is partial.

## Entries

| Slug | Companion file added |
|---|---|
| erdos-104 | Proofs/Erdos104Aristotle.lean |
| erdos-1018 | Proofs/Erdos1018Aristotle.lean |
| erdos-1019 | Proofs/Erdos1019Aristotle.lean |
| erdos-1021 | Proofs/Erdos1021Aristotle.lean |
| erdos-1027 | Proofs/Erdos1027Aristotle.lean |
| erdos-1033 | Proofs/Erdos1033Aristotle.lean |
| erdos-1034 | Proofs/Erdos1034Aristotle.lean |
| erdos-1037 | Proofs/Erdos1037Aristotle.lean |
| erdos-1040 | Proofs/Erdos1040Aristotle.lean |
| erdos-1052 | Proofs/Erdos1052Aristotle.lean |
| erdos-1056 | Proofs/Erdos1056Aristotle.lean |
| erdos-1095 | Proofs/Erdos1095Aristotle.lean |
| erdos-1105 | Proofs/Erdos1105Aristotle.lean |
| erdos-1126-oq-01 | Proofs/Erdos1126OQ01Aristotle.lean |
| erdos-1132 | Proofs/Erdos1132Aristotle.lean |
| erdos-1149 | Proofs/Erdos1149Aristotle.lean |
| erdos-1168 | Proofs/Erdos1168Aristotle.lean |
| erdos-1196 | Proofs/Erdos1196Aristotle.lean |
| erdos-135 | Proofs/Erdos135Aristotle.lean |
| erdos-138 | Proofs/Erdos138Aristotle.lean |
| erdos-165 | Proofs/Erdos165Aristotle.lean |
| erdos-211 | Proofs/Erdos211Aristotle.lean |
| erdos-220 | Proofs/Erdos220Aristotle.lean |
| erdos-225 | Proofs/Erdos225Aristotle.lean |
| erdos-247 | Proofs/Erdos247Aristotle.lean |
| erdos-247-oq-01 | Proofs/Erdos247Aristotle.lean (peer entry) |
| erdos-263 | Proofs/Erdos263Aristotle.lean |
| erdos-265 | Proofs/Erdos265Aristotle.lean |
| erdos-27 | Proofs/Erdos27Aristotle.lean |
| erdos-302 | Proofs/Erdos302Aristotle.lean |

## Validation

- Each companion file is tracked on `origin/main` (verified via `git ls-tree`).
- All companion files are well-formed (comment depth 0 at EOF). The 36 `/-!`-broken Aristotle templates from #16540 (fixed by PR #16542) are **excluded** from this batch.
- Diff is surgical: each entry +4/-1 lines. JSON re-parses cleanly post-edit (`json.loads` on every modified file).
- No status, badge, count, sorries, or narrative changes.

## Why find-targets misses these

`find-targets.ts` sibling-follow uses `lf.additionalFiles` to enumerate proof's Lean files. When the companion isn't listed, the file is invisible to the auditor's drift checks. This batch closes that blind spot for 30 entries.

---
Automated fix by lean-mechanic agent.