### PR TITLE
fix: untrack .loom/tokens self-referential symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ package-lock.json
 aristotle-results/
 .loom/signals/
 .loom/state/
+.loom/tokens
 .loom/tokens/
 .loom-in-use
 .loom/.daemon.pid

--- a/.loom/tokens
+++ b/.loom/tokens
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/lean-genius/.loom/tokens


### PR DESCRIPTION
## Summary
- Untrack `.loom/tokens`, which was committed as a symlink whose target is the path itself (`/Users/rwalters/GitHub/lean-genius/.loom/tokens` → same path). Every `git checkout`, `git reset`, or worktree creation restored this broken self-loop.
- Add `.loom/tokens` (no trailing slash) to `.gitignore`. The previous entry `.loom/tokens/` only ignored *contents* of a directory — when the path is a symlink it doesn't match. Keep the existing trailing-slash entry too so contents stay ignored after the bootstrap creates a real dir.

## Why
Discovered while diagnosing why all 9 OAuth accounts in `.env` were reporting "exhausted" simultaneously and load-balancing wasn't kicking in.

`claude-wrapper.sh` has a bootstrap path that materializes `.token` files from `.env`'s `ACCOUNT_KEY_*` entries when `.loom/tokens` is missing/broken. The bootstrap runs per-agent at startup, but git keeps reintroducing the self-loop, and the `.ranking` file (written by `check-accounts.sh --ranking` to tell wrappers which accounts still have weekly capacity) cannot persist across the churn. Wrappers fall back to **random** selection across all 9 accounts — including known-exhausted ones — so the fleet's combined quota burns out faster than rotation can avoid it.

```
$ git cat-file -p HEAD:.loom/tokens
/Users/rwalters/GitHub/lean-genius/.loom/tokens

$ test -d .loom/tokens && echo dir || echo "not a directory"
not a directory
```

## After merge
- Existing checkouts: run `git rm .loom/tokens` (or `unlink .loom/tokens`) once locally to drop the broken symlink. Next `claude-wrapper.sh` invocation will create a real dir and bootstrap tokens from `.env`. From then on the directory persists.
- Run `./scripts/agents/check-accounts.sh --ranking` to seed the ranking file so wrappers prefer accounts with remaining capacity.

Follow-up to #16547 (which addressed a related cascade where the daemon never auto-respawned agents stuck in API-error loops).

## Test plan
- [x] `git ls-files .loom/tokens` empty after the deletion
- [x] `git check-ignore -v .loom/tokens` matches the new line
- [ ] After merge + local cleanup: `claude-wrapper.sh` creates a real `.loom/tokens/` dir, `ls .loom/tokens/*.token` returns 9 files, `check-accounts.sh --ranking` writes a non-empty `.ranking` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)