### PR TITLE
fix(wrapper): default to standard-context Opus 4.7

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -502,13 +502,13 @@ run_claude_once() {
     tmpfile=$(mktemp)
 
     # Run in background so we can monitor for startup hangs.
-    # CLAUDE_MODEL env var pins a specific model (e.g. to avoid 1M-context auto-
-    # selection on accounts that lack the entitlement). Empty/unset → CLI default.
-    local model_arg=()
-    if [[ -n "${CLAUDE_MODEL:-}" ]]; then
-        model_arg=(--model "$CLAUDE_MODEL")
-    fi
-    timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude -p --dangerously-skip-permissions "${model_arg[@]}" "$PROMPT" < /dev/null > "$tmpfile" 2>&1 &
+    # Default to standard-context Opus 4.7. Without --model the CLI auto-selects
+    # claude-opus-4-7[1m] when the prompt + system context is large (CLAUDE.md
+    # alone is enough), and accounts without the 1M-context entitlement reject
+    # the request with `API Error: Extra usage is required for 1M context`.
+    # Override via CLAUDE_MODEL=<other-model> for accounts that do have it.
+    local model="${CLAUDE_MODEL:-claude-opus-4-7}"
+    timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude -p --dangerously-skip-permissions --model "$model" "$PROMPT" < /dev/null > "$tmpfile" 2>&1 &
     local timeout_pid=$!
 
     # Find the actual claude child process (timeout -> claude)


### PR DESCRIPTION
## Summary
- Pass `--model claude-opus-4-7` (standard context) by default in `claude-wrapper.sh`. Honor `CLAUDE_MODEL` env var for callers that want a different model.

## Why
Without `--model`, the Claude CLI uses `claude-opus-4-7[1m]` (1M-context Opus 4.7) — even for tiny prompts. None of the 9 OAuth accounts in `.env` have the 1M-context extra-usage entitlement, so **every** wrapper invocation rejects with:

```
API Error: Extra usage is required for 1M context · enable extra usage at claude.ai/settings/usage, or use --model to switch to standard context
```

This was masquerading as quota exhaustion in `tmux capture-pane` output:
```
[wrapper] Daemon cycle N: token quota exhausted — rotating
[wrapper] All tokens exhausted — entering long backoff (300s)
```
The wrapper's rotation heuristic mis-classified the 1M rejection as a quota error. After PR #16550 (token-dir symlink fix) restored real token rotation, the rotation just cycled through accounts that all hit the same rejection.

Verified all 9 accounts work with `--model claude-opus-4-7`:
```
agent-1: OK
agent-2: OK
...
agent-9: OK
```

## Scope
- Affects every agent the daemon spawns (deployer, seeker, all researchers, mechanics, enricher, etc).
- Herald's explicit `CLAUDE_MODEL=claude-opus-4-7` from #16547 becomes the system-wide default and remains as defense-in-depth.

Follow-up to:
- #16547 — added `CLAUDE_MODEL` plumbing and pinned herald only
- #16550 — untracked broken `.loom/tokens` symlink so token rotation could actually work

## Test plan
- [x] Manual smoke test: `--model claude-opus-4-7` succeeds on all 9 accounts
- [x] `bash -n` clean
- [ ] After merge: restart `lean-daemon` tmux session so it re-execs the wrapper for newly-spawned agents; watch deployer/seeker/researcher logs go from `recoverable error: exit 1` to `Claude completed successfully`

🤖 Generated with [Claude Code](https://claude.com/claude-code)