### PR TITLE
Research: yang-mills-lattice-oq-01 — SU(N) string tension + Migdal correlation length

### DIFF
--- a/proofs/Proofs/YangMillsLatticeOQ01.lean
+++ b/proofs/Proofs/YangMillsLatticeOQ01.lean
@@ -361,6 +361,85 @@ theorem su2_string_tension_pos (g_sq : ℝ) (hg : g_sq > 0) :
   rw [su2_string_tension g_sq hg]
   linarith
 
+/-- SU(2) adjoint representation: dim R = 3, C₂ = 2 (= N for adjoint of SU(N)).
+    String tension: σ = g² · 2 / (2 · 3) = g²/3.
+    Distinct from the fundamental: gluons (adjoint) get a different mass scale. -/
+def su2AdjointMigdalData (g_sq : ℝ) (hg : g_sq > 0) : MigdalData :=
+  { coupling := g_sq
+    coupling_pos := hg
+    casimir := 2
+    casimir_pos := by norm_num
+    repDim := 3
+    repDim_pos := by norm_num }
+
+/-- SU(2) adjoint string tension equals g²/3.
+    The adjoint Casimir for SU(N) is C₂(adj) = N, so SU(2) adjoint has C₂ = 2. -/
+theorem su2_adjoint_string_tension (g_sq : ℝ) (hg : g_sq > 0) :
+    stringTension (su2AdjointMigdalData g_sq hg) = g_sq / 3 := by
+  unfold stringTension su2AdjointMigdalData
+  ring
+
+/-- The SU(2) adjoint string tension is positive. -/
+theorem su2_adjoint_string_tension_pos (g_sq : ℝ) (hg : g_sq > 0) :
+    0 < stringTension (su2AdjointMigdalData g_sq hg) := by
+  rw [su2_adjoint_string_tension g_sq hg]
+  linarith
+
+/-- SU(N) fundamental representation: dim R = N, C₂ = (N²-1)/(2N).
+    String tension: σ = g²(N²-1)/(4N²).
+    Generalizes su2FundamentalMigdalData (N=2 yields σ = 3g²/16).
+    Requires N ≥ 2 (SU(1) is trivial; SU(N) for N ≥ 2 is the non-abelian regime). -/
+def suNFundamentalMigdalData (N : ℝ) (hN : 2 ≤ N) (g_sq : ℝ) (hg : g_sq > 0) :
+    MigdalData :=
+  { coupling := g_sq
+    coupling_pos := hg
+    casimir := (N^2 - 1) / (2 * N)
+    casimir_pos := by
+      have hN_pos : (0:ℝ) < N := by linarith
+      have hNN : (1:ℝ) < N^2 := by nlinarith
+      apply div_pos (by linarith) (by linarith)
+    repDim := N
+    repDim_pos := by linarith }
+
+/-- SU(N) fundamental string tension equals g²(N²-1)/(4N²).
+    For large N, σ → g²/4 (the 't Hooft limit gives a finite mass scale at fixed g²N). -/
+theorem suN_fundamental_string_tension (N : ℝ) (hN : 2 ≤ N) (g_sq : ℝ) (hg : g_sq > 0) :
+    stringTension (suNFundamentalMigdalData N hN g_sq hg) = g_sq * (N^2 - 1) / (4 * N^2) := by
+  unfold stringTension suNFundamentalMigdalData
+  have hN_pos : (0:ℝ) < N := by linarith
+  have hN_ne : N ≠ 0 := ne_of_gt hN_pos
+  field_simp
+  ring
+
+/-- The SU(N) fundamental string tension is positive (for N ≥ 2). -/
+theorem suN_fundamental_string_tension_pos (N : ℝ) (hN : 2 ≤ N)
+    (g_sq : ℝ) (hg : g_sq > 0) :
+    0 < stringTension (suNFundamentalMigdalData N hN g_sq hg) :=
+  stringTension_pos _
+
+/-- **Consistency**: at N = 2, the SU(N) fundamental formula reproduces the SU(2) value
+    σ = 3g²/16. -/
+theorem suN_fundamental_at_two (g_sq : ℝ) (hg : g_sq > 0) :
+    stringTension (suNFundamentalMigdalData 2 (le_refl 2) g_sq hg) = 3 * g_sq / 16 := by
+  rw [suN_fundamental_string_tension 2 (le_refl 2) g_sq hg]
+  ring
+
+/-- The Migdal correlation length ξ = 1/σ: the reciprocal of the string tension.
+    In the 2D lattice gauge theory, ξ controls the spatial decay of the 2-point function:
+    |S₂(t)| ≤ S₂(0) · exp(-t/ξ). -/
+noncomputable def migdalCorrelationLength (f : MigdalData) : ℝ :=
+  1 / stringTension f
+
+/-- The Migdal correlation length is strictly positive. -/
+theorem migdalCorrelationLength_pos (f : MigdalData) : 0 < migdalCorrelationLength f :=
+  div_pos one_pos (stringTension_pos f)
+
+/-- **Reciprocity**: the Migdal mass gap and correlation length satisfy σ · ξ = 1. -/
+theorem migdal_gap_times_corr_length (f : MigdalData) :
+    stringTension f * migdalCorrelationLength f = 1 := by
+  unfold migdalCorrelationLength
+  exact mul_one_div_cancel (ne_of_gt (stringTension_pos f))
+
 /- ═══════════════════════════════════════════════════════════════════════════
 PART V: THE MILLENNIUM PROBLEM — PRECISE LEAN STATEMENT
 ═══════════════════════════════════════════════════════════════════════════ -/

--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "assumptions": "2 axioms: (1) os_reconstruction — the GNS construction from reflection-positive lattice OS data producing a WightmanQFT; this is mathematically proven (Osterwalder-Schrader 1973, Osterwalder-Seiler 1978) but requires functional analysis (Bochner's theorem, GNS construction) beyond current Mathlib. (2) os_mass_gap_transfer — that exponential decay of Schwinger functions implies a spectral gap in the reconstructed Hilbert space via the Kallen-Lehmann representation; similarly proven but requires the full OS machinery. The 2D results (Migdal formula, string tension, SU(2) computation) are fully proved with 0 axioms.",
-    "lineCount": 500,
+    "lineCount": 579,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_neg",
@@ -46,13 +46,16 @@
       "The key conditional theorem: lattice OS data with exponential decay → Wightman QFT with mass gap",
       "MigdalData structure with explicit exponential decay proof for 2D Yang-Mills",
       "SU(2) string tension computed exactly: σ = 3g²/16",
+      "SU(N) fundamental string tension formula: σ = g²(N²-1)/(4N²) for all N ≥ 2",
+      "SU(2) adjoint string tension: σ = g²/3 (gluon channel)",
+      "Migdal correlation length ξ = 1/σ with reciprocity σ·ξ = 1",
       "YangMillsContinuumLimitProblem: precise Lean formulation of the 4D Millennium Prize problem",
       "Proof that the 4D Millennium Problem implies existence of a finite-lattice Wightman QFT with mass gap"
     ],
     "dateAdded": "2026-04-21",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
-    "definitionCount": 8
+    "theoremCount": 28,
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "The Osterwalder-Schrader (OS) reconstruction theorem (1973, 1975) is the rigorous mathematical bridge between Euclidean field theory and physical quantum field theory. It states: a system of Schwinger functions (Euclidean correlators) satisfying five axioms — Euclidean covariance (OS1), reflection positivity (OS2), regularity (OS3), symmetry (OS4), and cluster decomposition (OS5) — can be analytically continued via Wick rotation $\\tau \\mapsto it$ to produce a system of Wightman distributions satisfying all Wightman axioms. The Hilbert space is constructed by the GNS (Gelfand-Naimark-Segal) procedure from the reflection-positive bilinear form. The key axiom is OS2: without reflection positivity, the inner product on the GNS Hilbert space might not be positive definite, and unitarity would be lost. In the lattice context, Osterwalder and Seiler (1978) showed that reflection positivity of the lattice action is equivalent to the transfer matrix $T$ being a positive semi-definite operator on the gauge-invariant Hilbert space. The Clay Millennium Prize ($1M) asks whether 4D lattice Yang-Mills theory satisfies all five OS axioms in the continuum limit $a \\to 0$, and whether the resulting Wightman QFT has a positive mass gap.",
@@ -150,10 +153,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 500,
+    "lineCount": 579,
     "structureCount": 7,
     "axiomCount": 2,
-    "theoremCount": 21,
+    "theoremCount": 28,
     "lemmaCount": 0,
     "imports": [
       "Proofs.YangMills.Quantum"
@@ -167,7 +170,7 @@
     ],
     "path": "Proofs/YangMillsLatticeOQ01.lean",
     "sorries": 0,
-    "definitionCount": 8
+    "definitionCount": 11
   },
   "references": [
     {

--- a/src/data/research/problems/yang-mills-lattice-oq-01.json
+++ b/src/data/research/problems/yang-mills-lattice-oq-01.json
@@ -13,10 +13,13 @@
       "In 2D, the partition function factorizes (Z = ∏_P Z_P), making RP trivial — the 4D case has non-trivial plaquette interactions preventing factorization",
       "The GNS construction axiom is honest: mathematically proven (OS 1973, Osterwalder-Seiler 1978) but requires Bochner's theorem, spectral theory, Sobolev spaces beyond Mathlib",
       "The Kallen-Lehmann representation is the second axiom — gives the Euclidean-Minkowski mass gap transfer",
-      "SU(2) string tension σ = 3g²/16 is fully proved from definitions with 0 axioms (purely Mathlib)"
+      "SU(2) string tension σ = 3g²/16 is fully proved from definitions with 0 axioms (purely Mathlib)",
+      "SU(N) fundamental Casimir is C₂ = (N²-1)/(2N), giving string tension σ = g²(N²-1)/(4N²); large-N limit: σ → g²/4 (familiar 't Hooft scaling)",
+      "SU(2) adjoint and fundamental have distinct mass scales (σ_adj = g²/3 vs σ_fund = 3g²/16) — the gluon channel sees a different gap",
+      "The Migdal-level reciprocity σ · ξ = 1 holds for any irrep (unit-normalized), mirroring the abstract OS-transfer-matrix Δ · ξ · a = 1"
     ],
     "builtItems": [
-      "YangMillsLatticeOQ01.lean: 492 lines, 2 axioms, 0 sorries",
+      "YangMillsLatticeOQ01.lean: 579 lines, 2 axioms, 0 sorries (28 theorems, 11 defs)",
       "LatticeOSData structure encoding OS1-OS5 for finite 4D hypercubic lattice",
       "OSTransferMatrix extending TransferMatrix with OS2-derived positivity properties",
       "os_hamiltonian_nonneg: OS transfer matrix → H = -ln(T)/a ≥ 0",
@@ -25,6 +28,11 @@
       "lattice_mass_gap_to_wightman: LatticeOSData with decay → hasSomeMassGap",
       "MigdalData structure with stringTension > 0, migdalS2 decay proof",
       "su2_string_tension: σ_{SU(2)} = 3g²/16 proved by ring",
+      "suNFundamentalMigdalData (N : ℝ) (2 ≤ N): general SU(N) fundamental MigdalData with C₂ = (N²-1)/(2N)",
+      "suN_fundamental_string_tension: σ = g²(N²-1)/(4N²) proved by field_simp + ring",
+      "suN_fundamental_at_two: consistency check that N=2 reproduces 3g²/16",
+      "su2AdjointMigdalData + su2_adjoint_string_tension: σ_adj = g²/3 (gluon-channel gap)",
+      "migdalCorrelationLength = 1/σ + migdal_gap_times_corr_length: σ·ξ = 1",
       "YangMillsContinuumLimitProblem: Lean Prop for Clay Millennium Prize (4D)",
       "millennium_implies_os_formulation: the 4D problem → finite-lattice Wightman QFT"
     ],
@@ -34,11 +42,12 @@
       "Fintype instance for Fin 4 → Fin L needed for Finset.univ.sum in RP quadratic form (simplified to Prop)"
     ],
     "nextSteps": [
-      "Await PR merge by deployer",
       "Follow-up: prove RP for free scalar field (simpler than YM) using OSforGFF techniques",
-      "Connect to yang-mills-transfer-matrix gallery entry"
+      "Connect to yang-mills-transfer-matrix gallery entry",
+      "Add SU(N) adjoint generalization (C₂(adj) = N → σ = g²N/(2(N²-1)))",
+      "Add Migdal correlation length large-N scaling: ξ_fund(N) → 4/g² as N → ∞"
     ],
-    "progressSummary": "ACT→PR: YangMillsLatticeOQ01.lean built (0 sorries, 2 axioms). PR #10953 open. OS reconstruction framework + 2D Migdal solution + Clay problem formulation."
+    "progressSummary": "ACT: 2D Migdal infrastructure expanded — SU(N) fundamental + SU(2) adjoint string tensions + Migdal correlation length. 28 theorems, 11 defs, 2 axioms (OS reconstruction + Kallen-Lehmann), 0 sorries. 4D Millennium continues to require functional-analysis machinery beyond Mathlib."
   },
   "relatedProofs": [
     "yang-mills",
@@ -51,10 +60,10 @@
     {
       "path": "Proofs/YangMillsLatticeOQ01.lean",
       "filename": "YangMillsLatticeOQ01.lean",
-      "lineCount": 501,
-      "theoremCount": 21,
+      "lineCount": 579,
+      "theoremCount": 28,
       "axiomCount": 2,
-      "defCount": 8,
+      "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/YangMillsLatticeOQ01.lean"


### PR DESCRIPTION
## Summary

Extends the 2D Migdal section of `YangMillsLatticeOQ01.lean` with general SU(N) and adjoint mass-gap formulas plus correlation length infrastructure. No new axioms; no sorries.

## What was added (7 theorems + 3 defs)

**SU(N) fundamental representation (general N ≥ 2):**
- `suNFundamentalMigdalData (N : ℝ) (hN : 2 ≤ N)`: MigdalData with `casimir = (N²-1)/(2N)`, `repDim = N`
- `suN_fundamental_string_tension`: σ = g²(N²-1)/(4N²)
- `suN_fundamental_string_tension_pos`
- `suN_fundamental_at_two`: consistency check (recovers existing 3g²/16 at N=2)

**SU(2) adjoint representation (gluon channel):**
- `su2AdjointMigdalData`: C₂ = 2, dim = 3
- `su2_adjoint_string_tension`: σ_adj = g²/3
- `su2_adjoint_string_tension_pos`

**Migdal correlation length:**
- `migdalCorrelationLength (f : MigdalData) : ℝ := 1 / stringTension f`
- `migdalCorrelationLength_pos`
- `migdal_gap_times_corr_length`: σ · ξ = 1 (reciprocity)

These mirror the abstract OS-transfer-matrix `correlationLengthLog` / `mass_gap_times_corr_length` already in the file, but at the explicit Migdal level (per-irrep formulas).

## Status delta

| | Before | After |
|---|---|---|
| Lines | 500 | 579 |
| Theorems | 21 | 28 |
| Definitions | 8 | 11 |
| Axioms | 2 | 2 |
| Sorries | 0 | 0 |

The two existing axioms (`os_reconstruction`, `os_mass_gap_transfer`) are unchanged — they remain as conditional axioms for the GNS construction and Kallen-Lehmann representation, both proven mathematically (OS 1973, Osterwalder-Seiler 1978) but requiring functional analysis machinery beyond current Mathlib.

## Honesty notes

- These are 2D-Migdal-level computations, not 4D Yang-Mills mass gap progress. The Clay Millennium problem remains open.
- The SU(N) generalization is a straightforward parameterization: replacing concrete dim/Casimir with N-parameterized expressions. Useful for anyone working with non-SU(2) gauge theories, but not a deep theorem.
- The correlation length theorems are dual to existing OS-level results; they fill a small symmetry gap.

## Test plan
- [ ] Docker build verifies `Proofs.YangMillsLatticeOQ01` compiles
- [ ] No new axioms; sorries remain at 0
- [ ] gallery meta.json count drift checks pass

🤖 Generated by researcher-11