### PR TITLE
fix(meta): batch-sync lf.axiomCount for 8 entries (opaque counts missed)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -15,7 +15,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 17,
+    "axiomCount": 38,
     "assumptions": "17 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) regulator positivity. Previously 21 axioms; reductions: BSD_CM_rank_zero subsumed by Kolyvagin general result, gross_zagier_formula_detail dead code, one_not_congruent proved as theorem (BSD_rank_zero_axiom + curveMinusX_L_nonzero with curveMinusX = congruentNumberCurve 1 by coefficient equality + EllipticCurveQ.ext), and most recently greenberg_stevens converted from axiom to theorem since both conjuncts (q_E > 0, L_invariant ≠ 0) are already encoded as ExceptionalZero structure fields hq_pos and hL_ne_zero. 0 sorries. Also: 3 definitions vacuously return Prop := True as stubs pending rigorous formalization: p_adic_L_function (line 5626), HeegnerPointExists (line 5642), p_adic_height_pairing (line 5676). Additionally, sha_is_square := True appears in 4 data record fields (lines 4484, 4495, 4506, 4518). Note: ExceptionalZero structure fields (hq_pos, hL_ne_zero) constitute structural assumptions; the elimination removes a duplicate axiom but the structural data remains.",
     "mathlibDependencies": [
       {
@@ -718,7 +718,7 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 17,
+    "axiomCount": 38,
     "lineCount": 7435,
     "sorries": 0,
     "path": "Proofs/BirchSwinnertonDyer.lean",

--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -69,7 +69,7 @@
       "Easton-Konig characterization: complete picture of ZFC constraints on 2^aleph_0"
     ],
     "dateAdded": "2026-03-27",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 584,
     "assumptions": "2 axioms: bounding_number_uncountable, MA_implies_b_eq_continuum. 0 sorries.",
     "mathlib_version": "4.26.0",
@@ -182,7 +182,7 @@
     ],
     "namespace": "ContinuumHypothesisOQ02",
     "lineCount": 584,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 32,
     "definitionCount": 7,
     "path": "Proofs/ContinuumHypothesisOQ02.lean",

--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -59,7 +59,7 @@
       "no_4AP_in_squares axiom (classical)",
       "squares_contain_3AP: PROVED by explicit construction {1,25,49}={1²,5²,7²} with d=24 (was axiom)"
     ],
-    "axiomCount": 3,
+    "axiomCount": 4,
     "lineCount": 328,
     "assumptions": "3 axioms: no_4AP_in_squares (Euler), question1_implies_question2 (Ramsey-type), cilleruelo_granville (conditional). BombieriLangConjecture converted to opaque Prop (not an axiom). squares_contain_3AP proved by explicit construction {1,25,49}.",
     "theoremCount": 10,
@@ -186,7 +186,7 @@
     ],
     "namespace": "Erdos782",
     "lineCount": 328,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "theoremCount": 10,
     "definitionCount": 18,
     "path": "Proofs/Erdos782Problem.lean",

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -15,7 +15,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 49,
+    "axiomCount": 57,
     "assumptions": "49 axiom declarations (down from 101) encoding Hodge structures, known cases (Lefschetz 1,1, abelian varieties, K3, top codimension), categorical operations, motives, p-adic Hodge theory, counterexamples (Atiyah-Hirzebruch, Voisin, Totaro), and related conjectures. 3 unused axioms removed (tateTwist, tateStructure, deligne_cycle_class). The Hodge Conjecture itself remains open. 0 sorries remain.",
     "mathlibDependencies": [],
     "originalContributions": [
@@ -261,7 +261,7 @@
   "leanFile": {
     "lineCount": 10517,
     "structureCount": 104,
-    "axiomCount": 49,
+    "axiomCount": 57,
     "theoremCount": 430,
     "lemmaCount": 0,
     "imports": [

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -16,7 +16,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 121,
+    "axiomCount": 205,
     "assumptions": "121 axiom(s). No sorries.",
     "mathlibDependencies": [
       {
@@ -127,7 +127,7 @@
     "opens": [
       "ComplexityCore"
     ],
-    "axiomCount": 121,
+    "axiomCount": 205,
     "sorries": 0,
     "definitionCount": 150,
     "theoremCount": 302

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -16,7 +16,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 32,
+    "axiomCount": 34,
     "assumptions": "32 axioms: perelman_finite_extinction, generalized_poincare_high_dim, poincare_dim_4, poincare_dim_2, sphere_n_simply_connected, ConnectedSum, and 26 more. 0 sorries.",
     "mathlibDependencies": [
       {
@@ -345,7 +345,7 @@
   "leanFile": {
     "path": "Proofs/PoincareConjecture.lean",
     "lineCount": 17675,
-    "axiomCount": 32,
+    "axiomCount": 34,
     "sorries": 0,
     "theoremCount": 941,
     "definitionCount": 382,

--- a/src/data/proofs/rh-consequences/meta.json
+++ b/src/data/proofs/rh-consequences/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 9,
+    "axiomCount": 18,
     "assumptions": "9 axioms for classical RH consequences: rh_implies_mertens_bound (|M(x)| = O(√x)), lis_criterion (LI series criterion), riemann_von_mangoldt_formula, RH_implies_DensityHypothesis, rh_implies_psi_bound, explicit_formula_error, zeta_in_selberg_class, explicit_formula_zero_free, hadamard_product_exists. These are known results not yet formalized in Mathlib.",
     "lineCount": 1735,
     "theoremCount": 122,
@@ -71,7 +71,7 @@
   "leanFile": {
     "namespace": "RHConsequences",
     "lineCount": 1735,
-    "axiomCount": 9,
+    "axiomCount": 18,
     "theoremCount": 122,
     "definitionCount": 17,
     "path": "Proofs/RiemannHypothesisConsequences.lean",

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -17,7 +17,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 32,
+    "axiomCount": 44,
     "assumptions": "32 axiom declarations in main file. Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 6594 lines, 32 axioms, 0 sorries remain. 0 sorries remain.(s) remain.",
     "mathlibDependencies": [
       {
@@ -355,7 +355,7 @@
     "opens": [],
     "namespace": "RiemannHypothesis",
     "lineCount": 6594,
-    "axiomCount": 32,
+    "axiomCount": 44,
     "theoremCount": 363,
     "definitionCount": 50,
     "path": "Proofs/RiemannHypothesis.lean",


### PR DESCRIPTION
## Fix

Per axiom integrity policy, `opaque` declarations are assumption-bearing and count toward `axiomCount`. Eight gallery entries undercount because their meta only counted `axiom` declarations and missed `opaque ... : ...` declarations encoding the same assumption pattern.

## Evidence

Counted by parsing each file with comment-stripped regex matching:
`^\s*(@[...])*\s*(private|protected|noncomputable)*\s+(axiom|opaque)\s+\S`

| Slug | meta claimed | actual (axiom + opaque) |
|------|--------------|--------|
| `birch-swinnerton-dyer` | 17 | 38 (17 + 21) |
| `continuum-hypothesis-oq-02` | 2 | 3 (2 + 1) |
| `erdos-782` | 3 | 4 (3 + 1) |
| `hodge-conjecture` | 49 | 57 (49 + 8) |
| `p-vs-np` | 121 | 205 (121 + 84) |
| `poincare-conjecture` | 32 | 34 (32 + 2) |
| `rh-consequences` | 9 | 18 (9 + 9) |
| `riemann-hypothesis` | 32 | 44 (32 + 12) |

All eight had identical values in `meta.axiomCount` and `leanFile.axiomCount`; both fields are synced.

Examples of opaque declarations now counted:
- `BombieriLangConjecture` in `Erdos782Problem.lean` (its own `assumptions` text already notes this is an opaque Prop encoding an assumption)
- `MartinsAxiom` in `ContinuumHypothesisOQ02.lean`
- `LFunction_axiom`, `regulator_axiom`, etc. in `BirchSwinnertonDyer.lean` — names already self-identify as axioms
- 84 opaques in `PNPBarriersUnified.lean` (`P-vs-NP` entry)

## Scope

- **Counts only.** `assumptions` prose narrative is unchanged in this PR — narrative drift can be a separate fix.
- **Pure JSON edits.** No Lean source modified. Surgical 2-line replace per file via string replacement (preserves formatting per JSON-formatting policy).
- All 8 files validated as parseable JSON after edit.

---
Automated fix by lean-mechanic agent.