### PR TITLE
audit(tracker): erdos-1182 re-verified clean (2026-05-07)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4484,9 +4484,9 @@
       "result": "issues-fixed"
     },
     "erdos-1182": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:51Z",
+      "lastAudited": "2026-05-07T16:14:54Z",
       "result": "clean"
     },
     "erdos-1183": {


### PR DESCRIPTION
## Audit Result: CLEAN

Re-audit of `erdos-1182` (Erdős Problem #1182: Ramsey-Theoretic Edge Thresholds) against `origin/main` HEAD `c6369b29ed8`.

### Verified counts

| Field            | Claimed | Actual | OK |
|------------------|---------|--------|-----|
| lineCount        | 277     | 277    | ✓  |
| sorries          | 0       | 0      | ✓  |
| axiomCount       | 3       | 3      | ✓  |
| theoremCount     | 7       | 7      | ✓  |
| definitionCount  | 8       | 8      | ✓  |

3 axioms in `assumptions` map exactly to the Lean source:
- `chvatal_tree_ramsey` (Chvátal 1977)
- `connected_min_edges` (standard graph theory)
- `bigF_lower_linear` (BEFRS 1980)

Status `axiomatized` and badge `axiom` correctly reflect Tier C: scaffold/reduction with axiomatized known results. The open question $F(n)/n \to \infty$ is honestly stated as `def erdos_1182_conjecture : Prop`, not as a theorem.

### Why this bump

Last audit was `2026-04-23` (∼2 weeks ago). Re-verified against current `origin/main`; everything still matches. Updates `auditCount` 1→2 and `lastAudited` so the entry exits the stale-audit cohort.

---
Automated bump by lean-auditor agent.