### PR TITLE
fix(meta): remove stale Aristotle additionalFiles for 7 entries

### DIFF
--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -150,10 +150,7 @@
     "theoremCount": 4,
     "definitionCount": 12,
     "path": "Proofs/Erdos104Problem.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/Erdos104Aristotle.lean"
-    ]
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -192,10 +192,7 @@
     "theoremCount": 6,
     "definitionCount": 6,
     "path": "Proofs/Erdos1095Problem.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/Erdos1095Aristotle.lean"
-    ]
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -115,10 +115,7 @@
     "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Erdos135Problem.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/Erdos135Aristotle.lean"
-    ]
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -143,10 +143,7 @@
     "theoremCount": 4,
     "definitionCount": 9,
     "path": "Proofs/Erdos138Problem.lean",
-    "sorries": 1,
-    "additionalFiles": [
-      "Proofs/Erdos138Aristotle.lean"
-    ]
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -164,10 +164,7 @@
     "theoremCount": 2,
     "definitionCount": 3,
     "path": "Proofs/Erdos165Problem.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/Erdos165Aristotle.lean"
-    ]
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-211/meta.json
+++ b/src/data/proofs/erdos-211/meta.json
@@ -147,10 +147,7 @@
     "theoremCount": 1,
     "definitionCount": 8,
     "path": "Proofs/Erdos211Problem.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/Erdos211Aristotle.lean"
-    ]
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -198,10 +198,7 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "path": "Proofs/Erdos27Problem.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/Erdos27Aristotle.lean"
-    ]
+    "sorries": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Seven gallery entries declared an `*Aristotle.lean` companion file in
`leanFile.additionalFiles` that does **not** exist on `origin/main`.
The dangling reference is removed so `meta.json` describes reality.

## Evidence

```
$ git show origin/main:proofs/Proofs/Erdos104Aristotle.lean
fatal: path 'proofs/Proofs/Erdos104Aristotle.lean' does not exist in 'origin/main'
```

(Repeated for each of the 7 paths below.)

| Slug | Stale path |
|---|---|
| `erdos-104` | `Proofs/Erdos104Aristotle.lean` |
| `erdos-1095` | `Proofs/Erdos1095Aristotle.lean` |
| `erdos-135` | `Proofs/Erdos135Aristotle.lean` |
| `erdos-138` | `Proofs/Erdos138Aristotle.lean` |
| `erdos-165` | `Proofs/Erdos165Aristotle.lean` |
| `erdos-211` | `Proofs/Erdos211Aristotle.lean` |
| `erdos-27` | `Proofs/Erdos27Aristotle.lean` |

## Convention

Across the gallery: 2205 entries omit `additionalFiles`, 0 set it to
`null`, 181 list real companion files. These 7 were the only entries
listing nonexistent paths.

## Scope

- **Pure JSON.** No Lean source modified.
- **No count/status/badge/narrative changes** — only the `additionalFiles`
  block is removed (3 lines per file) plus the trailing comma after
  `"sorries"`.
- **Surgical replace** preserves whitespace and formatting per JSON-formatting
  policy (no `json.dump` reflow).
- All 7 files validate as JSON after edit.
- No open PR for any of the 7 slugs touches `additionalFiles`.

## Test plan

- [x] All 7 meta.json files validate as JSON after edit (`json.loads` round-trip)
- [x] Each missing path verified absent on `origin/main`
- [x] Diff is exactly 7 insertions / 28 deletions across 7 files
- [x] No status, badge, count, or narrative field touched

---
Automated fix by lean-mechanic agent.