### PR TITLE
Research: erdos-638 - sharp threshold for cardinal Ramsey on K_ω

### DIFF
--- a/proofs/Proofs/Erdos638Problem.lean
+++ b/proofs/Proofs/Erdos638Problem.lean
@@ -240,3 +240,60 @@ theorem complete_graphs_ramsey :
   intro n hn
   obtain ⟨N, hN⟩ := ramsey_triangle n hn
   exact ⟨N, ⊤, Set.mem_singleton _, hN⟩
+
+/- ## Partial results toward Erdős Problem #638
+
+These lemmas locate the precise threshold at which the cardinal-Ramsey question
+becomes nontrivial. For the complete-graph family, the answer is YES whenever the
+colour count is finite (sec. complete_omega_finite_ramsey, immediate from the
+finite Ramsey theorem) but NO for ω vertices and ℵ₀ colours (sec.
+complete_omega_no_nat_ramsey, via an explicit min-coloring counterexample). The
+Erdős–Rado theorem `(2^ℵ₀)⁺ → (ℵ₁)²_ℵ₀` would establish the conjecture for the
+complete-graph family at every infinite cardinal κ, but the required vertex set
+must be at least `(2^|κ|)⁺` — strictly more than κ. Bridging the finite/infinite
+threshold for general Ramsey families is what makes Problem #638 open.
+-/
+
+/-- **Positive partial result**: The complete graph on ℕ has the n-colour
+    triangle Ramsey property for any n ≥ 1.
+
+    This is an immediate corollary of the finite Ramsey theorem: the first
+    R(n) values of ℕ form a copy of K_{R(n)}, so any n-colouring of K_ℕ
+    restricted there yields a monochromatic triangle. Establishes that the
+    finite Ramsey theorem lifts to ω vertices whenever the colour count is
+    finite. -/
+theorem complete_omega_finite_ramsey (n : ℕ) (hn : 1 ≤ n) :
+    HasTriangleRamsey (⊤ : SimpleGraph ℕ) n := by
+  intro c
+  obtain ⟨N, hN⟩ := ramsey_triangle n hn
+  obtain ⟨a, b, d, hab, hbd, had, _, _, _, hc1, hc2⟩ :=
+    hN (fun i j => c i.val j.val)
+  refine ⟨a.val, b.val, d.val, ?_, ?_, ?_, ?_, ?_, ?_, hc1, hc2⟩
+  · exact fun h => hab (Fin.ext h)
+  · exact fun h => hbd (Fin.ext h)
+  · exact fun h => had (Fin.ext h)
+  · exact top_adj.mpr (fun h => hab (Fin.ext h))
+  · exact top_adj.mpr (fun h => hbd (Fin.ext h))
+  · exact top_adj.mpr (fun h => had (Fin.ext h))
+
+/-- **Negative partial result**: The complete graph on ℕ does NOT have the
+    ℕ-cardinal triangle Ramsey property.
+
+    The symmetric coloring `c i j = min i j` admits no monochromatic triangle:
+    for any three distinct vertices a, b, d, two of the three pairwise mins
+    equal the smallest of the trio while the third is strictly larger, so all
+    three colours cannot coincide.
+
+    This identifies the precise obstruction in Erdős Problem #638: at the
+    countable cardinal threshold, ω vertices are insufficient to force
+    monochromatic triangles. The Erdős–Rado theorem requires at least
+    `(2^ℵ₀)⁺` vertices for the ℵ₀-colour case. -/
+theorem complete_omega_no_nat_ramsey :
+    ¬ HasCardinalTriangleRamsey (⊤ : SimpleGraph ℕ) ℕ := by
+  intro h
+  obtain ⟨a, b, d, hab, hbd, had, _, _, _, hc1, hc2⟩ :=
+    h (fun i j => min i j)
+  -- hc1 : min a b = min b d, hc2 : min b d = min a d
+  -- Three distinct naturals cannot have all three pairwise mins equal.
+  simp only at hc1 hc2
+  omega

--- a/proofs/Proofs/Erdos638Problem.lean
+++ b/proofs/Proofs/Erdos638Problem.lean
@@ -111,7 +111,7 @@ private theorem shrinkFin_injective {m : ℕ} (i₀ : Fin (m + 1))
   have hv2 : j₂.val ≠ i₀.val := Fin.val_ne_of_ne hj₂
   have heq' := congrArg Fin.val heq
   unfold shrinkFin at heq'
-  split_ifs at heq' with h₁ h₂ h₁ h₂
+  split_ifs at heq' with h₁ h₂ h₁ h₂ <;> dsimp only at heq'
   · exact Fin.ext heq'
   · omega
   · omega
@@ -151,7 +151,8 @@ private theorem ramsey_inductive_step
   -- Step 2: Non-v₀ vertices, colored by edge to v₀
   set S := Finset.univ.erase v₀
   have hS_card : S.card = N - 1 := by
-    simp [Finset.card_erase_of_mem (Finset.mem_univ v₀)]
+    show (Finset.univ.erase v₀).card = N - 1
+    rw [Finset.card_erase_of_mem (Finset.mem_univ v₀), Finset.card_univ, Fintype.card_fin]
   -- Step 3: Pigeonhole — some color class has > M-1 (i.e. ≥ M) vertices
   have hpig : (Finset.univ : Finset (Fin (n + 2))).card * (M - 1) < S.card := by
     simp [Finset.card_fin, hS_card]; omega
@@ -170,9 +171,9 @@ private theorem ramsey_inductive_step
     obtain ⟨a₁, ha₁, a₂, ha₂, hne, hcol⟩ := hcase
     exact ⟨v₀, a₁, a₂,
       (hA_ne a₁ ha₁).symm, hne, (hA_ne a₂ ha₂).symm,
-      top_adj.mpr (hA_ne a₁ ha₁).symm,
-      top_adj.mpr hne,
-      top_adj.mpr (hA_ne a₂ ha₂).symm,
+      (hA_ne a₁ ha₁).symm,
+      hne,
+      (hA_ne a₂ ha₂).symm,
       by rw [hA_color a₁ ha₁, hcol],
       by rw [hcol, hA_color a₂ ha₂]⟩
   · -- Case 2: No pair in A has color i₀ → restricted to n+1 colors → use IH
@@ -209,7 +210,7 @@ private theorem ramsey_inductive_step
     rw [hc'_bd, hc'_ad] at hc2'
     exact ⟨(emb a).val, (emb b).val, (emb d).val,
       hab', hbd', had',
-      top_adj.mpr hab', top_adj.mpr hbd', top_adj.mpr had',
+      hab', hbd', had',
       shrinkFin_injective i₀ (hA_avoid _ (he_mem a) _ (he_mem b) hab')
         (hA_avoid _ (he_mem b) _ (he_mem d) hbd') hc1',
       shrinkFin_injective i₀ (hA_avoid _ (he_mem b) _ (he_mem d) hbd')
@@ -272,9 +273,9 @@ theorem complete_omega_finite_ramsey (n : ℕ) (hn : 1 ≤ n) :
   · exact fun h => hab (Fin.ext h)
   · exact fun h => hbd (Fin.ext h)
   · exact fun h => had (Fin.ext h)
-  · exact top_adj.mpr (fun h => hab (Fin.ext h))
-  · exact top_adj.mpr (fun h => hbd (Fin.ext h))
-  · exact top_adj.mpr (fun h => had (Fin.ext h))
+  · exact fun h => hab (Fin.ext h)
+  · exact fun h => hbd (Fin.ext h)
+  · exact fun h => had (Fin.ext h)
 
 /-- **Negative partial result**: The complete graph on ℕ does NOT have the
     ℕ-cardinal triangle Ramsey property.

--- a/research/problems/erdos-638/knowledge.md
+++ b/research/problems/erdos-638/knowledge.md
@@ -33,7 +33,29 @@ Let S" role="presentation" style="position: relative;">SSS be a family of finite
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-05-07 (researcher-5): Sharp threshold for cardinal Ramsey on K_ω
+
+Added two complementary theorems framing the difficulty of the open conjecture
+for the simplest Ramsey family (complete graphs):
+
+- **complete_omega_finite_ramsey** (positive): K_ℕ has the n-colour triangle
+  Ramsey property for any n ≥ 1. Proof: restrict to the first R(n) vertices
+  (provided by `ramsey_triangle`) and lift Fin-vertex triangle back to ℕ.
+- **complete_omega_no_nat_ramsey** (negative): K_ℕ does NOT have the
+  ℕ-cardinal triangle Ramsey property. Witness: c(i,j) = min(i,j). Three
+  distinct naturals cannot have all three pairwise mins equal — among the
+  three pairs, two contain the smallest of the trio (so their mins equal that
+  value), while the third pair excludes it (so its min is strictly larger).
+  `omega` discharges this directly.
+
+**Significance**: At the countable cardinal threshold, ω vertices suffice for
+finite colour counts but not for ℵ₀ colours. The Erdős–Rado theorem
+`(2^|κ|)⁺ → (κ⁺)²_κ` provides a positive answer for the complete-graph family
+of Erdős #638 at every infinite κ, but only with strictly more than κ vertices.
+The gap between the negative result on K_ℕ and the positive Erdős–Rado bound
+is precisely where the conjecture for general Ramsey families becomes nontrivial.
+
+**File state after session**: 299 lines, 10 theorems, 0 axioms, 0 sorries.
 
 ---
 

--- a/research/problems/erdos-638/state.md
+++ b/research/problems/erdos-638/state.md
@@ -1,27 +1,36 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: SOLVED (foundation) + PARTIAL RESULTS
 **Since**: 2026-01-13T17:14:37.756Z
-**Iteration**: 1
+**Iteration**: 4
 
 ## Current Focus
 
-Initial exploration of the problem.
+Two complementary partial results toward the open infinite-cardinal conjecture.
 
 ## Active Approach
 
-None yet.
+Sharp threshold characterisation: locate exactly where finite Ramsey breaks
+down for the complete-graph family. Established that K_ℕ has finite-colour
+Ramsey but fails ℕ-cardinal Ramsey; the gap to the Erdős–Rado lower bound
+`(2^|κ|)⁺` is now explicit.
 
 ## Blockers
 
-None.
+The infinite-cardinal Erdős conjecture itself remains open. Formalising
+Erdős–Rado requires significant Mathlib partition-calculus infrastructure.
 
 ## Next Action
 
-Begin problem exploration.
+If a future researcher wishes to advance further, the natural targets are:
+1. Generalise the min-coloring obstruction to show K_κ fails κ-cardinal Ramsey
+   for all infinite κ (likely true).
+2. Formalise an Erdős–Rado-style positive result, even the special case
+   `(2^ℵ₀)⁺ → (3)²_ℵ₀`, which would establish the conjecture for the
+   complete-graph family at κ = ℵ₀.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 4
+- Current approach attempts: 1
+- Approaches tried: 1 (sharp-threshold partial results)

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/638",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 242,
-    "assumptions": "0 axioms, 0 sorries. The finite Ramsey theorem for triangles and all supporting lemmas are fully proved by induction with the pigeonhole principle. The infinite-cardinal open conjecture is not formalized as an axiom; badge updated from 'axiom' to 'wip'.",
+    "lineCount": 299,
+    "assumptions": "0 axioms, 0 sorries. The finite Ramsey theorem for triangles and all supporting lemmas are fully proved by induction with the pigeonhole principle. Two complementary partial results bound the cardinal-Ramsey question: K_ℕ has finite-colour triangle Ramsey (immediate from finite Ramsey) but does NOT have ℕ-cardinal Ramsey (min-coloring counterexample). The infinite-cardinal open conjecture is not formalized as an axiom; badge updated from 'axiom' to 'wip'.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 6
   },
   "overview": {
@@ -94,16 +94,24 @@
       "startLine": 218,
       "endLine": 242,
       "summary": "Proves ramsey_triangle by induction: for every n ≥ 1, there exists N such that every n-colouring of K_N contains a monochromatic triangle. Bound: R(1) = 3, R(n+1) ≤ (n+1)·(R(n)-1) + 2. Derives complete_graphs_ramsey: the family of complete graphs forms a Ramsey family."
+    },
+    {
+      "id": "partial-results-638",
+      "title": "Partial Results toward Erdős Problem #638",
+      "startLine": 244,
+      "endLine": 299,
+      "summary": "Two complementary cardinal-Ramsey results that locate the threshold where finite Ramsey breaks down. complete_omega_finite_ramsey: K_ℕ has the n-colour triangle Ramsey property for any n ≥ 1, by restricting to the first R(n) vertices. complete_omega_no_nat_ramsey: K_ℕ does NOT have the ℕ-cardinal triangle Ramsey property, witnessed by the symmetric coloring c(i,j) = min(i,j) — three distinct naturals cannot have all three pairwise mins equal. Together these show that finite Ramsey lifts to ω vertices for finite colours but breaks at ℵ₀ colours, identifying the gap where the Erdős–Rado theorem (requiring strictly more than ℵ₀ vertices) becomes necessary."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős Problem #638 on lifting Ramsey families to infinite-cardinal colourings. The classical n-colour Ramsey theorem for triangles is fully proved by induction (0 axioms, 0 sorries), establishing the finite foundation. The open conjecture — whether Ramsey families extend to infinite cardinals — is precisely stated. Supporting infrastructure includes monotonicity, the complete graph Ramsey family, and the pigeonhole-based inductive step.",
-    "implications": "An affirmative answer would significantly extend Ramsey theory to infinite settings, establishing a bridge between finite combinatorial Ramsey properties and infinite partition calculus. It would enable the extensions and generalisations Erdős anticipated, potentially yielding new tools for infinite graph colouring problems.",
+    "summary": "Formalizes Erdős Problem #638 on lifting Ramsey families to infinite-cardinal colourings. The classical n-colour Ramsey theorem for triangles is fully proved by induction (0 axioms, 0 sorries), establishing the finite foundation. The open conjecture — whether Ramsey families extend to infinite cardinals — is precisely stated. Two partial results frame the difficulty: K_ℕ inherits finite-colour Ramsey from the finite theorem, but the symmetric min-coloring shows K_ℕ fails the ℵ₀-cardinal version, so the conjecture cannot follow from any K_ℕ-level statement and genuinely requires more vertices than colours. Supporting infrastructure includes monotonicity, the complete graph Ramsey family, and the pigeonhole-based inductive step.",
+    "implications": "An affirmative answer would significantly extend Ramsey theory to infinite settings, establishing a bridge between finite combinatorial Ramsey properties and infinite partition calculus. It would enable the extensions and generalisations Erdős anticipated, potentially yielding new tools for infinite graph colouring problems. The min-coloring obstruction in complete_omega_no_nat_ramsey rules out the simplest naive approach (taking V = ℕ) and aligns with the Erdős–Rado lower bound (2^ℵ₀)⁺ for the complete-graph case.",
     "openQuestions": [
       "Does every Ramsey family extend to infinite cardinals, as Erdős conjectured?",
       "Can compactness-type arguments (ultraproducts, direct limits) resolve the problem, or are new techniques needed?",
       "Is the answer dependent on set-theoretic axioms (GCH, large cardinals)?",
-      "Does the answer change if triangles K₃ are replaced by larger complete graphs K_r?"
+      "Does the answer change if triangles K₃ are replaced by larger complete graphs K_r?",
+      "Is there an explicit ℵ₀-coloring obstruction at every cardinal κ < (2^ℵ₀)⁺, or does the obstruction collapse below the Erdős–Rado bound?"
     ]
   },
   "leanFile": {
@@ -118,9 +126,9 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 242,
+    "lineCount": 299,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 6,
     "path": "Proofs/Erdos638Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-638.json
+++ b/src/data/research/problems/erdos-638.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Eliminated ramsey_triangle axiom. File 0 axioms, 0 sorries. Proved ramsey_inductive_step via pigeonhole + shrinkFin + IH.",
+    "progressSummary": "EXTENDED: Two complementary partial results toward Erdős #638. complete_omega_finite_ramsey: K_ℕ inherits finite-colour Ramsey from finite Ramsey theorem (restrict to first R(n) vertices). complete_omega_no_nat_ramsey: K_ℕ does NOT have ℕ-cardinal Ramsey (counterexample: c(i,j)=min(i,j)). Together establish a sharp threshold: ω vertices suffice for finite colours but fail at ℵ₀ colours, so the conjecture cannot be reduced to a K_ℕ statement. File: 299 lines, 10 theorems, 0 axioms, 0 sorries.",
     "builtItems": [
       "theorem complete_graphs_ramsey: proved from ramsey_triangle via Set.mem_singleton",
       "theorem triangle_ramsey_mono: proved via Fin.castLE injection",
@@ -42,7 +42,9 @@
       "PROVED ramsey_inductive_step: pigeonhole + shrinkFin + Ramsey IH",
       "PROVED shrinkFin_injective",
       "ELIMINATED ramsey_triangle axiom: 0 axioms 0 sorries",
-      "Fixed declaration order: ramsey_triangle_base before ramsey_triangle"
+      "Fixed declaration order: ramsey_triangle_base before ramsey_triangle",
+      "PROVED complete_omega_finite_ramsey: K_ℕ has Fin n triangle Ramsey for n ≥ 1 (corollary of finite Ramsey, embed first R(n) vertices)",
+      "PROVED complete_omega_no_nat_ramsey: K_ℕ has no ℕ-cardinal triangle Ramsey, witnessed by c(i,j)=min(i,j) — three distinct ℕ values cannot have all three pairwise mins equal (omega-checked)"
     ],
     "insights": [
       "complete_graphs_ramsey follows directly from ramsey_triangle: just instantiate with K_N",
@@ -55,7 +57,10 @@
       "ramsey_inductive_step proved: pigeonhole gives large mono neighborhood, case split on same-color edges",
       "shrinkFin helper removes one color from Fin (n+2), with proven injectivity",
       "Key deps: Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to, Finset.orderIsoOfFin",
-      "ramsey_triangle axiom ELIMINATED: fully proved by induction"
+      "ramsey_triangle axiom ELIMINATED: fully proved by induction",
+      "Sharp threshold: K_ℕ has Fin n Ramsey for finite n but fails for ℕ-many colours — finite Ramsey does not lift to infinite cardinals on the same vertex set",
+      "min-coloring c(i,j)=min(i,j) defeats ℕ-cardinal Ramsey on K_ℕ: among 3 distinct naturals, two pairs share the smallest as their min while the third pair is strictly larger",
+      "Erdős–Rado theorem (2^|κ|)⁺ → (κ⁺)²_κ provides the positive answer for the complete-graph family of Erdős #638 — but at strictly more than κ vertices, so K_ℕ at ℵ₀ colours is not a counterexample to the conjecture, only to the naive |V|=|κ| approach"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -82,8 +87,8 @@
     {
       "path": "Proofs/Erdos638Problem.lean",
       "filename": "Erdos638Problem.lean",
-      "lineCount": 243,
-      "theoremCount": 6,
+      "lineCount": 299,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two complementary partial results toward Erdős Problem #638 (cardinal Ramsey for triangle families). The previous state of the file proved the finite n-colour Ramsey theorem (0 axioms, 0 sorries) but said nothing concrete about the open infinite-cardinal extension. This PR adds two theorems that locate the precise threshold where finite Ramsey breaks down.

## Theorems Added

**Positive** — `complete_omega_finite_ramsey`:
> For every n ≥ 1, the complete graph on ℕ has the n-colour triangle Ramsey property.

Proof: restrict any n-colouring of K_ℕ to the first R(n) values supplied by `ramsey_triangle n`, then lift the Fin-vertex monochromatic triangle back to ℕ via `Fin.val`.

**Negative** — `complete_omega_no_nat_ramsey`:
> The complete graph on ℕ does NOT have the ℕ-cardinal triangle Ramsey property.

Counterexample: the symmetric coloring `c(i,j) = min i j`. Among any three distinct naturals `a, b, d`, two of the three pairwise mins equal the smallest of the trio while the third is strictly larger, so the colours cannot coincide. `omega` discharges this directly.

## Mathematical Significance

These results frame the difficulty of Erdős #638 for the simplest Ramsey family (complete graphs):
- Finite Ramsey lifts cleanly to ω vertices when the colour count is finite.
- The lift fails at ℵ₀ colours on ω vertices — a concrete obstruction the Erdős–Rado theorem `(2^|κ|)⁺ → (κ⁺)²_κ` is needed to overcome (with strictly more than |κ| vertices).
- The gap between the negative result on K_ℕ and the positive Erdős–Rado bound is precisely where the conjecture for general Ramsey families becomes nontrivial.

The conjecture for the complete-graph family is known (it follows from Erdős–Rado), but the proof requires partition-calculus infrastructure not yet in Mathlib. Bridging the finite/infinite threshold for *general* Ramsey families is what makes Erdős #638 open.

## Files Modified

- `proofs/Proofs/Erdos638Problem.lean`: 242 → 299 lines, 8 → 10 theorems
- `src/data/proofs/erdos-638/meta.json`: lineCount/theoremCount, new section, expanded conclusion + open question
- `src/data/research/problems/erdos-638.json`: progressSummary, builtItems, insights, leanFile counts
- `research/problems/erdos-638/{state,knowledge}.md`: session log and updated state

## Stats

- Lines: 299 (+57)
- Theorems: 10 (+2)
- Definitions: 6 (unchanged)
- Sorries: 0
- Axioms: 0

## Status

**Outcome**: progress (sharp-threshold partial results, no axioms or sorries added)
**Next Steps**: generalise the min-coloring obstruction to K_κ for all infinite κ; long-term, formalise an Erdős–Rado positive result.

🤖 Generated by researcher-5