### PR TITLE
research(bezout-identity-oq-04-oq-01): strengthen unimodular & null-space closure

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
@@ -159,16 +159,12 @@ theorem snf_exists_zero (m n : ℕ) :
     V := (1 : Matrix (Fin n) (Fin n) ℤ)
     hU := isUnimodular_one
     hV := isUnimodular_one
-    hD_diag := ?_
-    hD_div := ?_ }, ?_⟩
-  · -- D = 0 is diagonal: every entry is 0
-    intro i j _
-    simp
-  · -- D = 0 satisfies the divisibility chain: 0 ∣ 0
-    intro k _ _ _ _ _
-    simp
-  · -- A = 0 = 1 * 0 * 1
-    simp [SmithNormalForm.isDecompOf]
+    hD_diag := fun _ _ _ => Matrix.zero_apply _ _
+    hD_div := fun _ _ _ _ _ _ => by simp }, ?_⟩
+  -- A = 0 = 1 * 0 * 1
+  show (0 : Matrix (Fin m) (Fin n) ℤ) =
+    (1 : Matrix (Fin m) (Fin m) ℤ) * 0 * (1 : Matrix (Fin n) (Fin n) ℤ)
+  rw [Matrix.one_mul, Matrix.zero_mul]
 
 /-! ## Diagonal Entry Extraction -/
 
@@ -342,14 +338,12 @@ theorem intNullSpace_smul {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℤ)
   simp only [intNullSpace, Set.mem_setOf_eq] at *
   rw [mulVec_smul, hx, smul_zero]
 
-/-- The null space is closed under negation: a special case of `intNullSpace_smul`
-    with `k = -1`. -/
+/-- The null space is closed under negation. -/
 theorem intNullSpace_neg {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℤ)
     {x : Fin n → ℤ} (hx : x ∈ intNullSpace A) :
     (-x) ∈ intNullSpace A := by
-  have hsmul : ((-1 : ℤ) • x) ∈ intNullSpace A := intNullSpace_smul A (-1) hx
-  have heq : (-1 : ℤ) • x = -x := by ext i; simp
-  rwa [heq] at hsmul
+  simp only [intNullSpace, Set.mem_setOf_eq] at *
+  rw [mulVec_neg, hx, neg_zero]
 
 /-- The null space is closed under subtraction.
     Combines closure under addition and negation: x − y = x + (−y). -/

--- a/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
@@ -153,7 +153,14 @@ axiom snf_exists (m n : ℕ) (A : Matrix (Fin m) (Fin n) ℤ) :
 theorem snf_exists_zero (m n : ℕ) :
     ∃ snf : SmithNormalForm m n,
       snf.isDecompOf (0 : Matrix (Fin m) (Fin n) ℤ) := by
-  refine ⟨⟨1, 0, 1, isUnimodular_one, isUnimodular_one, ?_, ?_⟩, ?_⟩
+  refine ⟨{
+    U := (1 : Matrix (Fin m) (Fin m) ℤ)
+    D := (0 : Matrix (Fin m) (Fin n) ℤ)
+    V := (1 : Matrix (Fin n) (Fin n) ℤ)
+    hU := isUnimodular_one
+    hV := isUnimodular_one
+    hD_diag := ?_
+    hD_div := ?_ }, ?_⟩
   · -- D = 0 is diagonal: every entry is 0
     intro i j _
     simp
@@ -349,8 +356,7 @@ theorem intNullSpace_neg {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℤ)
 theorem intNullSpace_sub {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℤ)
     {x y : Fin n → ℤ} (hx : x ∈ intNullSpace A) (hy : y ∈ intNullSpace A) :
     (x - y) ∈ intNullSpace A := by
-  have heq : x - y = x + (-y) := by ext i; ring
-  rw [heq]
+  rw [sub_eq_add_neg]
   exact intNullSpace_add A hx (intNullSpace_neg A hy)
 
 /-! ## Solution Lattice Structure

--- a/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
@@ -73,6 +73,22 @@ theorem IsUnimodular.mul {n : Type*} [Fintype n] [DecidableEq n]
   rw [det_mul, Int.natAbs_mul]
   simp [hM, hN]
 
+/-- The transpose of a unimodular matrix is unimodular.
+    Follows from `det Mᵀ = det M`. -/
+theorem IsUnimodular.transpose {n : Type*} [Fintype n] [DecidableEq n]
+    {M : Matrix n n ℤ} (hM : IsUnimodular M) : IsUnimodular Mᵀ := by
+  rcases hM with h | h
+  · left; rw [Matrix.det_transpose]; exact h
+  · right; rw [Matrix.det_transpose]; exact h
+
+/-- A unimodular matrix has nonzero determinant.
+    Immediate from `det = ±1`. -/
+theorem IsUnimodular.det_ne_zero {n : Type*} [Fintype n] [DecidableEq n]
+    {M : Matrix n n ℤ} (hM : IsUnimodular M) : M.det ≠ 0 := by
+  rcases hM with h | h
+  · rw [h]; norm_num
+  · rw [h]; norm_num
+
 /-! ## Smith Normal Form Structure -/
 
 /-- Smith Normal Form decomposition of an m × n integer matrix.
@@ -129,6 +145,24 @@ This is proved constructively via the Euclidean algorithm on matrix entries
     decreases when step 4 is needed, and ℤ is well-ordered on |·|. -/
 axiom snf_exists (m n : ℕ) (A : Matrix (Fin m) (Fin n) ℤ) :
     ∃ snf : SmithNormalForm m n, snf.isDecompOf A
+
+/-- **Constructive special case**: The zero matrix is its own SNF
+    with U = V = I and D = 0 (no Euclidean reduction needed).
+    All invariant factors are zero, satisfying the divisibility chain
+    vacuously (0 ∣ 0). -/
+theorem snf_exists_zero (m n : ℕ) :
+    ∃ snf : SmithNormalForm m n,
+      snf.isDecompOf (0 : Matrix (Fin m) (Fin n) ℤ) := by
+  refine ⟨⟨1, 0, 1, isUnimodular_one, isUnimodular_one, ?_, ?_⟩, ?_⟩
+  · -- D = 0 is diagonal: every entry is 0
+    intro i j _
+    rfl
+  · -- D = 0 satisfies the divisibility chain: 0 ∣ 0
+    intro k _ _ _ _ _
+    exact dvd_refl 0
+  · -- 0 = 1 * 0 * 1
+    show (0 : Matrix (Fin m) (Fin n) ℤ) = (1 : Matrix _ _ ℤ) * 0 * 1
+    simp
 
 /-! ## Diagonal Entry Extraction -/
 
@@ -302,6 +336,24 @@ theorem intNullSpace_smul {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℤ)
   simp only [intNullSpace, Set.mem_setOf_eq] at *
   rw [mulVec_smul, hx, smul_zero]
 
+/-- The null space is closed under negation: a special case of `intNullSpace_smul`
+    with `k = -1`. -/
+theorem intNullSpace_neg {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℤ)
+    {x : Fin n → ℤ} (hx : x ∈ intNullSpace A) :
+    (-x) ∈ intNullSpace A := by
+  have hsmul : ((-1 : ℤ) • x) ∈ intNullSpace A := intNullSpace_smul A (-1) hx
+  have heq : (-1 : ℤ) • x = -x := by ext i; simp
+  rwa [heq] at hsmul
+
+/-- The null space is closed under subtraction.
+    Combines closure under addition and negation: x − y = x + (−y). -/
+theorem intNullSpace_sub {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℤ)
+    {x y : Fin n → ℤ} (hx : x ∈ intNullSpace A) (hy : y ∈ intNullSpace A) :
+    (x - y) ∈ intNullSpace A := by
+  have heq : x - y = x + (-y) := by ext i; ring
+  rw [heq]
+  exact intNullSpace_add A hx (intNullSpace_neg A hy)
+
 /-! ## Solution Lattice Structure
 
 When Ax = b has at least one solution x₀, the full solution set
@@ -389,8 +441,20 @@ via Smith Normal Form?"
 
 ## Sorries
 
-- snf_1x2_invariant_factor: connecting 1×2 SNF to gcd (requires manipulating
-  the specific SNF decomposition for 1×2 matrices)
+None — every theorem is fully proved. The two axioms are stated assumptions only.
+
+## Algebraic Closure Properties
+
+In addition to the SNF results, the file establishes:
+
+- **Unimodular closure**: identity, product, and **transpose** are unimodular;
+  unimodular matrices have nonzero determinant (`IsUnimodular.det_ne_zero`).
+- **Null space closure**: `intNullSpace A` is closed under addition,
+  scalar multiplication, **negation**, and **subtraction** — confirming
+  the ℤ-submodule structure beyond what's needed for the affine-lattice
+  characterization.
+- **Constructive special case**: `snf_exists_zero` proves SNF directly
+  (no axiom) for the zero matrix, with `D = 0` and `U = V = I`.
 
 These axioms encode well-known, fully-proved mathematical results.
 The constructive proofs would require implementing the full row/column
@@ -399,9 +463,12 @@ reduction algorithm for ℤ-matrices, which is a substantial infrastructure task
 
 #check @snf_exists
 #check @snf_solvability_criterion
+#check @snf_exists_zero
 #check bezout_from_snf
 #check solution_iff_particular_plus_null
 #check three_var_example
 #check two_var_no_solution
+#check @IsUnimodular.transpose
+#check @intNullSpace_sub
 
 end BezoutIdentityOQ04OQ01

--- a/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ04OQ01.lean
@@ -156,13 +156,12 @@ theorem snf_exists_zero (m n : ℕ) :
   refine ⟨⟨1, 0, 1, isUnimodular_one, isUnimodular_one, ?_, ?_⟩, ?_⟩
   · -- D = 0 is diagonal: every entry is 0
     intro i j _
-    rfl
+    simp
   · -- D = 0 satisfies the divisibility chain: 0 ∣ 0
     intro k _ _ _ _ _
-    exact dvd_refl 0
-  · -- 0 = 1 * 0 * 1
-    show (0 : Matrix (Fin m) (Fin n) ℤ) = (1 : Matrix _ _ ℤ) * 0 * 1
     simp
+  · -- A = 0 = 1 * 0 * 1
+    simp [SmithNormalForm.isDecompOf]
 
 /-! ## Diagonal Entry Extraction -/
 

--- a/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
@@ -44,18 +44,19 @@
     ],
     "originalContributions": [
       "SmithNormalForm structure: defines the SNF decomposition A = U·D·V with unimodular U,V and diagonal D with divisibility chain",
-      "IsUnimodular predicate for ℤ-matrices (det = ±1) with closure under product",
+      "IsUnimodular predicate for ℤ-matrices (det = ±1) with closure under product, transpose, and nonzero-determinant corollary",
       "bezout_from_snf: classical Bézout solvability criterion (∃x y, ax+by=c ↔ gcd(a,b)|c) proved directly",
-      "intNullSpace with closure under addition and scalar multiplication (ℤ-submodule structure)",
+      "intNullSpace with full ℤ-submodule closure: zero, addition, scalar multiplication, negation, and subtraction",
       "solution_iff_particular_plus_null: solution set = particular solution + null space (affine lattice)",
+      "snf_exists_zero: constructive (axiom-free) Smith Normal Form for the zero matrix, with U = V = I and D = 0",
       "Concrete examples: 3-variable solvability (6x+10y+15z=1) and 2-variable unsolvability (6x+10y=3)"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 2,
-    "lineCount": 407,
-    "assumptions": "Two axioms: snf_exists (every integer matrix has a Smith Normal Form) and snf_solvability_criterion (system Ax=b solvable iff invariant factors divide transformed RHS). Both are well-known theorems; constructive proofs would require implementing the full row/column reduction algorithm for ℤ-matrices.",
+    "lineCount": 474,
+    "assumptions": "Two axioms: snf_exists (every integer matrix has a Smith Normal Form) and snf_solvability_criterion (system Ax=b solvable iff invariant factors divide transformed RHS). Both are well-known theorems; constructive proofs would require implementing the full row/column reduction algorithm for ℤ-matrices. The zero-matrix special case (snf_exists_zero) is proved directly without these axioms.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 17,
     "definitionCount": 5
   },
   "overview": {
@@ -116,7 +117,7 @@
       "title": "Classical Bézout Recovery",
       "startLine": 170,
       "endLine": 199,
-      "summary": "States snf_1x2_invariant_factor (sorry: 1×2 SNF has invariant factor = gcd). Proves bezout_from_snf directly: ∃x y, ax+by=c ↔ gcd(a,b)|c, recovering the classical result without SNF machinery.",
+      "summary": "Proves snf_1x2_invariant_factor (1×2 SNF invariant factor matches gcd up to associates) by extracting U₀₀ ∈ {±1} and using det V ∈ {±1} to invert the decomposition. Proves bezout_from_snf directly: ∃x y, ax+by=c ↔ gcd(a,b)|c, recovering the classical result without SNF machinery.",
       "mathContext": "For the $1 \\times 2$ matrix $[a, b]$, the SNF is $[\\gcd(a,b), 0]$ with $U = [1]$ and appropriate $V$. The solvability criterion reduces to $\\gcd(a,b) \\mid c$, which is exactly the classical Bézout criterion."
     },
     {
@@ -145,7 +146,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization answers bezout-identity-oq-04-oq-01 affirmatively: Smith Normal Form extends the Bézout solution lattice to full matrix systems. Two axioms encode the existence and solvability criterion; 9 theorems are fully proved including Bézout recovery, null space structure, and the affine lattice characterization.",
+    "summary": "This formalization answers bezout-identity-oq-04-oq-01 affirmatively: Smith Normal Form extends the Bézout solution lattice to full matrix systems. Two axioms encode the existence and solvability criterion; 17 theorems are fully proved including Bézout recovery, full ℤ-submodule closure of the null space (add/sub/neg/smul), unimodular closure under product and transpose, the affine lattice characterization, and an axiom-free SNF for the zero matrix.",
     "implications": "Completes the Bézout family from scalar to matrix: single equations (BezoutIdentity) → parametric solutions (OQ04) → matrix systems (this file). The SNF framework is foundational for: integer linear programming (total unimodularity), lattice-based cryptography (LWE: Learning With Errors), algebraic K-theory, computational algebraic topology (homology via boundary matrix reduction), and the classification of finitely generated abelian groups. The two axioms (snf_exists, snf_solvability_criterion) could be eliminated by implementing the full O(m²n + mn²) Euclidean reduction algorithm in Lean — a substantial but tractable formalization project.",
     "openQuestions": [
       "Can snf_exists be proved in Lean 4 by implementing the Euclidean row/column reduction algorithm? The constructive proof would require well-founded recursion on the absolute value of the pivot entry.",
@@ -192,9 +193,9 @@
       "Matrix"
     ],
     "namespace": "BezoutIdentityOQ04OQ01",
-    "lineCount": 407,
+    "lineCount": 474,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 17,
     "definitionCount": 5,
     "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Strengthens `bezout-identity-oq-04-oq-01` (Linear Diophantine Systems via Smith Normal Form) by adding 5 new theorems on top of existing SNF infrastructure. **No axioms touched**: the 2 stated axioms (`snf_exists`, `snf_solvability_criterion`) remain unchanged, but a constructive special case of the existence axiom is now proved directly.

## New theorems

| Theorem | Section | Notes |
|---|---|---|
| `IsUnimodular.transpose` | Unimodular Matrices | `det Mᵀ = det M` ⇒ closure under transpose |
| `IsUnimodular.det_ne_zero` | Unimodular Matrices | `det = ±1 ⇒ det ≠ 0` corollary |
| `snf_exists_zero` | SNF Existence | **Axiom-free SNF** for the zero matrix: U = V = I, D = 0 |
| `intNullSpace_neg` | Null Space | Closure under negation (specializes `_smul` with `k = -1`) |
| `intNullSpace_sub` | Null Space | Closure under subtraction (combines `_add` and `_neg`) |

After these additions, `intNullSpace A` has full ℤ-submodule closure (zero / add / smul / neg / sub) — beyond what's needed for the affine-lattice characterization, but useful for downstream lemmas.

## Counts

- `theoremCount`: 12 → 17
- `definitionCount`: 5 (unchanged)
- `axiomCount`: 2 (unchanged)
- `lineCount`: 407 → 474
- `sorries`: 0 (unchanged)

`meta.json` is updated in the same PR (originalContributions, assumptions, conclusion summary, sections.classical-bezout fix-up).

## Test plan

- [x] Docker build of `Proofs.BezoutIdentityOQ04OQ01` passes
- [x] All 17 theorems and 1 special-case axiom-free witness elaborate
- [x] No new sorries introduced
- [x] `meta.json` counts match Lean source