### PR TITLE
fix(audit-tracker): remove 6 orphan entries for non-existent gallery slugs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16,12 +16,6 @@
     "result": "issues-fixed"
   },
   "entries": {
-    "No unclaimed targets available": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T16:57:29Z",
-      "result": "clean"
-    },
     "abel-ruffini": {
       "auditCount": 5,
       "issues": [],
@@ -2193,12 +2187,6 @@
       "lastAudited": "2026-05-03T16:38:30Z",
       "result": "clean"
     },
-    "cramers-rule-oq-01-oq-01": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-04-04T12:16:35Z",
-      "result": "clean"
-    },
     "cramers-rule-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [],
@@ -2745,12 +2733,6 @@
       "lastAudited": "2026-04-26T15:26:52Z",
       "result": "clean"
     },
-    "equivariant-borsuk-ulam-compact-lie": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-04-03T14:46:12Z",
-      "result": "clean"
-    },
     "erdos-1": {
       "auditCount": 3,
       "issues": [],
@@ -2960,12 +2942,6 @@
       "lastAudited": "2026-05-04T04:03:25Z",
       "result": "clean"
     },
-    "erdos-1010-oq-01": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-04-03T21:49:49Z",
-      "result": "clean"
-    },
     "erdos-1010-oq-02": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -2978,12 +2954,6 @@
       "auditCount": 6,
       "issues": [],
       "lastAudited": "2026-05-04T04:08:19Z",
-      "result": "clean"
-    },
-    "erdos-1011-oq-01": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-04-03T21:49:49Z",
       "result": "clean"
     },
     "erdos-1012": {
@@ -13539,12 +13509,6 @@
       "auditCount": 2,
       "issues": [],
       "lastAudited": "2026-05-04T04:08:03Z",
-      "result": "clean"
-    },
-    "triangular-number-reciprocals": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-04-03T22:03:34Z",
       "result": "clean"
     },
     "triangular-reciprocals": {


### PR DESCRIPTION
## Fix

Remove six orphan entries from `src/data/proofs/audit-tracker.json`. Each key references a gallery directory that does not exist under `src/data/proofs/`, so the entry produces no useful audit signal — it just clutters the tracker and can confuse `find-targets`.

## Removed entries

| Key | Reason |
|-----|--------|
| `"No unclaimed targets available"` | Parsing bug — an auditor script captured a stderr/UI message as a slug |
| `cramers-rule-oq-01-oq-01` | No gallery dir; only sibling `cramers-rule-oq-01-oq-02-oq-01` exists |
| `equivariant-borsuk-ulam-compact-lie` | No gallery dir |
| `erdos-1010-oq-01` | No gallery dir; sibling `erdos-1010-oq-02` exists |
| `erdos-1011-oq-01` | No gallery dir |
| `triangular-number-reciprocals` | Renamed → `triangular-reciprocals` (already tracked) |

All six are in the `entries` wrapper, all `result: clean`, all with empty `issues`.

## Detection

```python
existing = {p.name for p in Path('src/data/proofs').iterdir() if p.is_dir()}
tracker = json.load(open('src/data/proofs/audit-tracker.json'))
orphans = [k for k in tracker['entries'] if k not in existing]
```

Returns these six. Surgical line-based removal (preserves rest of file formatting); JSON re-validated post-edit (`json.loads` succeeds).

## Evidence

**Before**: `entries` count = 2392; six keys reference missing gallery dirs.
**After**: `entries` count = 2386; every remaining key has a matching `src/data/proofs/<slug>/` directory.

```
$ git diff --stat
 src/data/proofs/audit-tracker.json | 36 ------------------------------------
 1 file changed, 36 deletions(-)
```

---
Automated fix by lean-mechanic agent.