### PR TITLE
research(derangements-convergence-oq-01-oq-01): sync leanFiles counts

### DIFF
--- a/src/data/research/problems/derangements-convergence-oq-01-oq-01.json
+++ b/src/data/research/problems/derangements-convergence-oq-01-oq-01.json
@@ -33,7 +33,7 @@
     {
       "path": "Proofs/DerangementsConvergence.lean",
       "filename": "DerangementsConvergence.lean",
-      "lineCount": 283,
+      "lineCount": 282,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 2,
@@ -44,18 +44,18 @@
     {
       "path": "Proofs/DerangementsConvergenceOQ01.lean",
       "filename": "DerangementsConvergenceOQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsConvergenceOQ01OQ01.lean",
       "filename": "DerangementsConvergenceOQ01OQ01.lean",
-      "lineCount": 148,
+      "lineCount": 147,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
@@ -66,8 +66,8 @@
     {
       "path": "Proofs/DerangementsConvergenceOQ03.lean",
       "filename": "DerangementsConvergenceOQ03.lean",
-      "lineCount": 89,
-      "theoremCount": 1,
+      "lineCount": 88,
+      "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -79,7 +79,6 @@
     "derangements",
     "derangements-convergence",
     "derangements-convergence-oq-01",
-    "derangements-convergence-oq-01-oq-01",
     "derangements-convergence-oq-03"
   ]
 }


### PR DESCRIPTION
## Summary

Pure \`leanFiles\` count drift fix for \`src/data/research/problems/derangements-convergence-oq-01-oq-01.json\`. Top-level \`phase: COMPLETED\` and \`status: completed\` are already correct; only the nested counts and a self-reference were stale.

## Changes

- \`DerangementsConvergence.lean\`: \`lineCount\` 283 → 282
- \`DerangementsConvergenceOQ01.lean\`: \`lineCount\` 153 → 152, \`sorryCount\` 4 → 0 (the four sorries have been discharged since this JSON last ran)
- \`DerangementsConvergenceOQ01OQ01.lean\`: \`lineCount\` 148 → 147 (matches gallery \`meta.json\` \`leanFile.lineCount: 147\`; primary file)
- \`DerangementsConvergenceOQ03.lean\`: \`lineCount\` 89 → 88, \`theoremCount\` 1 → 2
- \`relatedProofs\`: drop self-reference \`derangements-convergence-oq-01-oq-01\`

## Verification

Verified each file against \`git show origin/main\` with comment-stripped declaration regex (axiom / theorem / lemma / def / abbrev / opaque) and \`wc -l\` for line counts.

## Test plan

- [x] JSON validates
- [x] Counts cross-checked against all four Lean files and the gallery meta.json (primary file)
- [x] Pure metadata change — no Lean source modified
- [ ] Gallery build remains green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)