### PR TITLE
fix(audit-tracker): remove 11 stale top-level legacy entries (duplicated in entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1,20 +1,4 @@
 {
-  "collatz-structured-oq-03": {
-    "agentId": "auditor-cycle-2",
-    "auditCount": 1,
-    "lastAudited": "2026-03-29T18:24:11Z",
-    "result": "issues-fixed"
-  },
-  "descartes-rule-of-signs-oq-02": {
-    "auditCount": 1,
-    "issues": [
-      "sorries 7->5 (code evolved)",
-      "lineCount 418->491",
-      "theoremCount 28->33"
-    ],
-    "lastAudit": "2026-03-24T21:47:21Z",
-    "result": "issues-fixed"
-  },
   "entries": {
     "No unclaimed targets available": {
       "auditCount": 2,
@@ -15015,66 +14999,6 @@
       "issues": []
     }
   },
-  "erdos-1097-oq-01": {
-    "agentId": "auditor-cycle-2",
-    "auditCount": 1,
-    "lastAudited": "2026-03-29T18:24:11Z",
-    "result": "issues-fixed"
-  },
-  "erdos-327-oq-01": {
-    "agentId": "auditor-cycle-3",
-    "auditCount": 1,
-    "lastAudited": "2026-03-29T18:47:33Z",
-    "result": "issues-fixed"
-  },
-  "erdos-648": {
-    "agentId": "auditor-cycle-3",
-    "auditCount": 1,
-    "lastAudited": "2026-03-29T18:47:33Z",
-    "result": "issues-fixed"
-  },
-  "erdos-668": {
-    "auditCount": 1,
-    "issues": [
-      "sorries 1->0 (sorry eliminated)",
-      "axiomCount 7->8",
-      "lineCount 216->228"
-    ],
-    "lastAudit": "2026-03-24T21:47:21Z",
-    "result": "issues-fixed"
-  },
-  "erdos-744": {
-    "agentId": "auditor-cycle-3",
-    "auditCount": 1,
-    "lastAudited": "2026-03-29T18:47:33Z",
-    "result": "issues-fixed"
-  },
-  "inverse-galois": {
-    "agentId": "auditor-cycle-3",
-    "auditCount": 1,
-    "lastAudited": "2026-03-29T18:47:33Z",
-    "result": "clean"
-  },
-  "inverse-galois-oq-01": {
-    "agentId": "auditor-cycle-3",
-    "auditCount": 1,
-    "lastAudited": "2026-03-29T18:47:33Z",
-    "result": "clean"
-  },
   "version": 1,
-  "erdos-933": {
-    "agentId": "auditor-cycle-20-batch",
-    "auditCount": 4,
-    "lastAudited": "2026-04-28T06:06:43Z",
-    "result": "clean"
-  },
-  "bezout-identity-oq-03-oq-02": {
-    "auditCount": 1,
-    "lastAudit": "2026-05-01T08:54:33Z",
-    "lastAudited": "2026-05-01T08:54:33Z",
-    "result": "clean",
-    "agentId": "auditor-fresh-loop",
-    "notes": "Tier A original. lineCount=187, sorries=0, axiomCount=0, no True stubs. crt_finitely_many built inductively on parent crt_iscop via IsCoprime.prod_right and Fin.prod_univ_castSucc."
-  },
   "lastUpdated": "2026-05-06T10:18:00Z"
 }


### PR DESCRIPTION
## Summary

`src/data/proofs/audit-tracker.json` has 13 top-level keys, but its documented schema only allows three: `entries`, `version`, `lastUpdated`. The other 11 are stale legacy slug stubs left over from old auditor scripts (cycle-2 / cycle-3 from 2026-03), each with `auditCount: 1` and a single old timestamp. Every one of them is **already present** under `tracker.entries.<slug>` with current data (auditCount up to 7, last audited as recent as 2026-05-05) — so the top-level copies produce no audit signal.

`scripts/auditor/find-targets.ts` (line 284: `tracker.entries[id]`) and `scripts/auditor/claim-target.sh` (line 152: `tracker['entries'].get(...)`) both read and write only the `entries` map. The top-level keys are dead weight that violates the schema and clutters the file.

## Changes

Removes 11 stale top-level keys via surgical line-block deletion (preserves all other formatting; only the deleted blocks change):

| Top-level key | Top-level result | `entries.<key>` result | `entries` lastAudited |
|---|---|---|---|
| `collatz-structured-oq-03` | issues-fixed (cycle-2, 2026-03-29) | clean | 2026-05-04 |
| `descartes-rule-of-signs-oq-02` | issues-fixed (2026-03-24) | clean | 2026-05-04 |
| `erdos-1097-oq-01` | issues-fixed (cycle-2, 2026-03-29) | clean | 2026-05-04 |
| `erdos-327-oq-01` | issues-fixed (cycle-3, 2026-03-29) | clean | 2026-05-04 |
| `erdos-648` | issues-fixed (cycle-3, 2026-03-29) | clean | 2026-05-04 |
| `erdos-668` | issues-fixed (2026-03-24) | issues-fixed | 2026-05-05 |
| `erdos-744` | issues-fixed (cycle-3, 2026-03-29) | issues-fixed | 2026-04-29 |
| `inverse-galois` | clean (cycle-3, 2026-03-29) | clean | 2026-05-03 |
| `inverse-galois-oq-01` | clean (cycle-3, 2026-03-29) | issues-fixed | 2026-05-03 |
| `erdos-933` | clean (2026-04-28) | clean | 2026-04-28 |
| `bezout-identity-oq-03-oq-02` | clean (2026-05-01) | clean | 2026-05-01 |

After the change, the top level contains only the schema-correct keys:

```
$ jq 'keys' src/data/proofs/audit-tracker.json
[
  "entries",
  "lastUpdated",
  "version"
]
```

## Diff size

```
src/data/proofs/audit-tracker.json | 76 --------------------------------------
1 file changed, 76 deletions(-)
```

`entries` count is unchanged (2392 before and after). No fields outside the deleted blocks are touched.

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` — JSON parses
- [x] All 11 removed slugs still resolve via `tracker.entries.<slug>` with their current results
- [x] `jq '.entries | length'` = 2392 before and after
- [x] Top-level now exactly `{entries, version, lastUpdated}`

## Reference

- Schema convention: `feedback_auditor_tracker_schema_entries.md` — "new audit entries live under `entries.<id>`, not as top-level bare-id keys"
- Tracker readers: `scripts/auditor/find-targets.ts:284` and `scripts/auditor/claim-target.sh:152`
- Companion to PR #16577 (which removed orphan entries from inside the `entries` wrapper); these two PRs touch disjoint regions of the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)