### PR TITLE
research(ehrhart-cube-proven-oq-02): reconcile JSON with merged state (correct file)

### DIFF
--- a/src/data/research/problems/ehrhart-cube-proven-oq-02.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-02.json
@@ -19,9 +19,9 @@
     "phase": "ACT",
     "since": "2026-05-06T13:49:03.933Z",
     "iteration": 1,
-    "focus": "PR #16339 pending Docker build. Algebraic core proved (expand, succ_d, hockey-stick).",
+    "focus": "PR #16339 merged 2026-05-06. EhrhartCrossPolytope.lean is at 12 theorems / 2 sorries / 0 axioms / 330 lines. Algebraic core (crossEhrhart_expand, crossEhrhart_succ_d, sum_choose_range / hockey-stick, base cases d0/d1/n0) all proved. Two sorries remain: crossEhrhart_is_poly (no Mathlib API for evaluating falling factorial at ℕ values) and crossBall_card succ d step (Finset.card_biUnion slicing).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Discharge crossEhrhart_is_poly via Nat.descFactorial or an explicit polynomial coefficient formula. Discharge crossBall_card succ d via Finset.card_biUnion over the |x_d| = j slices and a bijection with crossBall (d, n - j).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-05-06): algebraic proof framework complete. crossEhrhart_expand (Pascal) + crossEhrhart_succ_d (geometric recursion) + sum_choose_range (hockey-stick) all proved. PR #16339 pending build.",
+    "progressSummary": "PROGRESS. PR #16339 merged 2026-05-06: algebraic proof framework complete. crossEhrhart_expand (Pascal split), crossEhrhart_succ_d (geometric recursion), sum_choose_range (hockey-stick), and the base cases (crossEhrhart_d0 / d1 / n0 / d2 / pos / mono) are all proved. EhrhartCrossPolytope.lean: 12 theorems / 2 sorries / 0 axioms / 0 unwanted constructions / 330 lines. Two open sorries (crossEhrhart_is_poly polynomial existence; crossBall_card succ d geometric step) remain.",
     "builtItems": [
       "sum_choose_range: hockey-stick \u03a3 C(m,k) = C(n,k+1) at EhrhartCrossPolytope.lean:131",
       "sum_shift_hockey: sum interchange at EhrhartCrossPolytope.lean:143",
@@ -54,10 +54,8 @@
       "No lemma for eval of falling factorial at \u2115 values (needed for crossEhrhart_is_poly)"
     ],
     "nextSteps": [
-      "If Docker build fails: debug crossEhrhart_expand proof (sum distribute step)",
-      "Prove crossEhrhart_is_poly without sorry using Nat.descFactorial or falling factorial",
-      "Prove crossBall_card d=0 using Fintype.card (Fin 0 \u2192 \u03b2) = 1",
-      "Prove crossBall_card inductive step via Finset.card_biUnion slicing"
+      "Prove crossEhrhart_is_poly without sorry using Nat.descFactorial or an explicit polynomial coefficient formula",
+      "Prove crossBall_card succ d step via Finset.card_biUnion over the |x_d| = j slices, with a bijection to crossBall (d, n - j)"
     ]
   },
   "tags": [
@@ -75,20 +73,20 @@
     "mathlib": []
   },
   "started": "2026-05-06T13:49:03.933Z",
-  "lastUpdate": "2026-05-06T13:49:03.933Z",
+  "lastUpdate": "2026-05-07T00:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
-      "path": "Proofs/EhrhartCubeProven.lean",
-      "filename": "EhrhartCubeProven.lean",
-      "lineCount": 297,
-      "theoremCount": 26,
+      "path": "Proofs/EhrhartCrossPolytope.lean",
+      "filename": "EhrhartCrossPolytope.lean",
+      "lineCount": 330,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
+      "defCount": 2,
+      "sorryCount": 2,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCubeProven.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCrossPolytope.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Brings \`src/data/research/problems/ehrhart-cube-proven-oq-02.json\` in line with the gallery and Lean source after PR #16339 merged 2026-05-06.

The headline fix: \`leanFiles[0]\` was tracking the wrong file. It referenced the parent slug's \`EhrhartCubeProven.lean\` (296 lines, 26 theorems) instead of this slug's actual file \`EhrhartCrossPolytope.lean\` (330 lines, 12 theorems, 2 sorries). All the \`builtItems\` and \`insights\` already talk about the cross-polytope file, so this was a tracking bug.

This entry is **not** complete — 2 sorries remain (\`crossEhrhart_is_poly\` polynomial existence; \`crossBall_card\` \`succ d\` step) — so \`status\` stays \`active\`, \`phase\` stays \`ACT\`.

## Changes

- \`currentState.focus\`: "PR #16339 pending Docker build" → "PR #16339 merged 2026-05-06" with concrete state and named sorries
- \`currentState.nextAction\`: "Begin problem exploration" → concrete attack plan for the two remaining sorries (Nat.descFactorial / explicit polynomial coeffs; Finset.card_biUnion slicing)
- \`progressSummary\`: rewrite to reflect merged + remaining-sorry state
- \`nextSteps\`: remove the now-irrelevant "If Docker build fails…" and "Prove crossBall_card d=0" items
- \`leanFiles[0]\`: **replace** \`EhrhartCubeProven.lean\` (parent file, wrongly listed) with \`EhrhartCrossPolytope.lean\` (this slug's primary file). Counts: 26→12 theorems, 297→330 lines, 1→2 defs, 0→2 sorries. Matches gallery \`meta.json\` \`leanFile\` (\`lineCount: 330\`, \`theoremCount: 12\`, \`sorries: 2\`, \`axiomCount: 0\`, \`definitionCount: 2\`) exactly.
- \`lastUpdate\` → 2026-05-07

## Verification

Verified \`EhrhartCrossPolytope.lean\` against \`git show origin/main\` with comment-stripped declaration regex: 12 theorems / 2 sorries / 0 axioms / 2 defs / 330 lines. Sorries are named: \`crossEhrhart_is_poly\` (line 255) and \`crossBall_card\` \`succ d\` step (line 283).

## Test plan

- [x] JSON validates
- [x] Counts cross-checked against \`EhrhartCrossPolytope.lean\` and gallery meta.json
- [x] Pure metadata change — no Lean source modified
- [ ] Gallery build remains green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)