### PR TITLE
research(descartes-oq-02-oq-01-oq-02): reconcile JSON with merged state

### DIFF
--- a/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-04-26T14:43:29.520Z",
     "iteration": 1,
-    "focus": "Formalized Sturm sequence and key structural lemmas. Main axiom to be proved in follow-up sessions.",
+    "focus": "Gallery entry merged: 458 lines, 28 theorems/lemmas, 6 defs, 1 axiom (sturm_exact_count_axiom), 0 sorries — gallery status: axiomatized, badge: axiom. Sturm sequence + key structural lemmas (mod_eval_at_root, sturm_neighbors_opposite_at_root, sturmVariations_antitone, squarefree_no_common_roots, linear specialization) are fully proved; the main count theorem remains axiomatized.",
     "blockers": [],
-    "nextAction": "Prove sturm_exact_count_axiom by formalizing sign-count monotonicity",
+    "nextAction": "Open follow-up: prove sturm_exact_count_axiom (sign-count piecewise constancy + decrease analysis). Tracked as future research, not blocking this entry.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,9 +29,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: PR #14919 — 1 axiom, 0 sorries, Docker build passes. 22 theorems proved, full gallery entry.",
+    "progressSummary": "COMPLETE: PR #14919 — 1 axiom (sturm_exact_count_axiom), 0 sorries, Docker build passes. 28 theorems/lemmas proved across 458 lines, 6 noncomputable defs, full gallery entry at status: axiomatized.",
     "builtItems": [
-      "DescartesRuleOfSignsOQ02OQ01OQ02.lean (448 lines, 1 axiom, 0 sorries)",
+      "DescartesRuleOfSignsOQ02OQ01OQ02.lean (458 lines, 1 axiom, 0 sorries)",
       "sturmSeqAux: fuel-based Sturm sequence construction via EuclideanDomain.mod",
       "sturmSeq p: the complete Sturm sequence starting from [p, p']",
       "signVariations, countSignAlts: sign change counting for real lists",
@@ -78,7 +78,6 @@
     "descartes-rule-of-signs-oq-01-oq-02",
     "descartes-rule-of-signs-oq-02",
     "descartes-rule-of-signs-oq-02-oq-01",
-    "descartes-rule-of-signs-oq-02-oq-01-oq-02",
     "descartes-rule-of-signs-oq-03",
     "descartes-rule-of-signs-oq-04"
   ],
@@ -88,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-04-26T14:43:29.519Z",
-  "lastUpdate": "2026-04-26T14:43:29.519Z",
+  "lastUpdate": "2026-05-07T16:55:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -161,8 +160,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01OQ02.lean",
-      "lineCount": 459,
-      "theoremCount": 26,
+      "lineCount": 458,
+      "theoremCount": 28,
       "axiomCount": 1,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Brings `src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02.json` in line with the gallery `meta.json` and Lean source on `origin/main` for the Sturm Theorem entry (PR #14919).

The gallery has been at `status: axiomatized` / `badge: axiom` (458 lines, 28 theorems/lemmas, 6 defs, 1 axiom, 0 sorries) but the research-side JSON was stuck with `currentState.phase: ACT`, stale `progressSummary` ("22 theorems proved", "448 lines"), and stale `leanFiles` counts (`lineCount: 459`, `theoremCount: 26`).

## Changes

- `currentState.phase`: `ACT` → `COMPLETED` (consistent with top-level `phase: COMPLETED`)
- `currentState.focus`: replace prior-session log with concrete final state + list of proved structural lemmas
- `currentState.nextAction`: reframe as an open follow-up (the axiom is genuine future research), not an active task
- `progressSummary`: 22 theorems → 28, 448 lines → 458, add axiom + def context
- `builtItems[0]`: 448 → 458 lines
- `relatedProofs`: drop self-reference `descartes-rule-of-signs-oq-02-oq-01-oq-02`
- `leanFiles[OQ02OQ01OQ02].lineCount`: 459 → 458
- `leanFiles[OQ02OQ01OQ02].theoremCount`: 26 → 28 (regex missed `@[simp] theorem countSignAlts_nil` and `@[simp] theorem countSignAlts_singleton`)
- `lastUpdate` → 2026-05-07T16:55:00.000Z

## Verification

Counts cross-checked against `git show origin/main:proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean`:

- 1 \`axiom\` declaration: \`sturm_exact_count_axiom\`
- 0 sorries
- 28 theorem/lemma declarations (26 at column 0 plus 2 with \`@[simp]\` attribute prefix)
- 6 \`def\` declarations: \`countSignAlts\`, \`signVariations\`, \`rootsInInterval\`, \`sturmSeqAux\`, \`sturmSeq\`, \`sturmVariations\`
- 458 lines

Matches `src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json` (`status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `theoremCount: 28`, `definitionCount: 6`, `lineCount: 458`, `sorries: 0`) exactly.

## Test plan

- [x] JSON validates
- [x] Counts cross-checked against Lean file and gallery meta.json
- [x] Pure metadata change — no Lean source modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)