### PR TITLE
fix(meta): batch-sync stale lineCount for 4 gallery entries

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 2,
-    "lineCount": 474,
+    "lineCount": 473,
     "assumptions": "Two axioms: snf_exists (every integer matrix has a Smith Normal Form) and snf_solvability_criterion (system Ax=b solvable iff invariant factors divide transformed RHS). Both are well-known theorems; constructive proofs would require implementing the full row/column reduction algorithm for ℤ-matrices. The zero-matrix special case (snf_exists_zero) is proved directly without these axioms.",
     "mathlib_version": "4.26.0",
     "theoremCount": 17,
@@ -193,7 +193,7 @@
       "Matrix"
     ],
     "namespace": "BezoutIdentityOQ04OQ01",
-    "lineCount": 474,
+    "lineCount": 473,
     "axiomCount": 2,
     "theoremCount": 17,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/638",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 299,
+    "lineCount": 300,
     "assumptions": "0 axioms, 0 sorries. The finite Ramsey theorem for triangles and all supporting lemmas are fully proved by induction with the pigeonhole principle. Two complementary partial results bound the cardinal-Ramsey question: K_ℕ has finite-colour triangle Ramsey (immediate from finite Ramsey) but does NOT have ℕ-cardinal Ramsey (min-coloring counterexample). The infinite-cardinal open conjecture is not formalized as an axiom; badge updated from 'axiom' to 'wip'.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
@@ -126,7 +126,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 299,
+    "lineCount": 300,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -58,7 +58,7 @@
       "Proved distinctSizes_card_le_n_sub_two: antichain over Fin n (n≥4) has ≤ n-2 distinct sizes"
     ],
     "axiomCount": 3,
-    "lineCount": 410,
+    "lineCount": 487,
     "assumptions": "3 axioms: erdos_trotter_r1_achievable (achievability for r=1, known), erdos_trotter_upper (known), erdos_trotter_achievable (known). erdos_trotter_r1 now proved from upper bound theorem + achievability axiom. erdos_776_threshold proved from erdos_trotter_exact via Nat.find.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
@@ -172,7 +172,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 410,
+    "lineCount": 487,
     "axiomCount": 3,
     "theoremCount": 14,
     "definitionCount": 6,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "theoremCount": 611,
     "definitionCount": 100
   },
@@ -365,7 +365,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 611,


### PR DESCRIPTION
## Summary

Sync `leanFile.lineCount` and `meta.<sub>.lineCount` in 4 entries to match `wc -l` of the source Lean file.

| Entry | Old | New | Source file | Likely cause |
|-------|-----|-----|-------------|--------------|
| bezout-identity-oq-04-oq-01 | 474 | 473 | BezoutIdentityOQ04OQ01.lean | post-#16567 |
| erdos-638 | 299 | 300 | Erdos638Problem.lean | post-#16565 |
| erdos-776 | 410 | 487 | Erdos776Problem.lean | post-#16571 |
| navier-stokes | 21111 | 21110 | NavierStokes.lean | navier-stokes-existence/oq-01/oq-02 are already at 21110 on main |

Each meta.json has two `lineCount` fields (one in the `meta.<sub>` block, one in the `leanFile` block); both are updated.

## Test plan

- [x] `wc -l` of each Lean file confirmed against the new value
- [x] Each meta.json had matching old/old pair pre-fix; new/new pair post-fix
- [x] Plumbing-only edit; no whitespace or formatting changes