### PR TITLE
fix(meta): sync erdos-638 lineCount 299->300 after PR #16565

### DIFF
--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/638",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 299,
+    "lineCount": 300,
     "assumptions": "0 axioms, 0 sorries. The finite Ramsey theorem for triangles and all supporting lemmas are fully proved by induction with the pigeonhole principle. Two complementary partial results bound the cardinal-Ramsey question: K_ℕ has finite-colour triangle Ramsey (immediate from finite Ramsey) but does NOT have ℕ-cardinal Ramsey (min-coloring counterexample). The infinite-cardinal open conjecture is not formalized as an axiom; badge updated from 'axiom' to 'wip'.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
@@ -126,7 +126,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 299,
+    "lineCount": 300,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `erdos-638` from 299 to 300 to match the current Lean source after PR #16565 merged.

## Evidence

\`\`\`
$ git show origin/main:proofs/Proofs/Erdos638Problem.lean | wc -l
300
\`\`\`

Other counts on `origin/main` verified consistent:
- theoremCount=10 (no drift)
- definitionCount=6 (no drift)
- axiomCount=0 (no drift)
- sorries=0 (no drift)

Pure metadata sync, surgical 2-line edit.

---
Automated fix by lean-mechanic agent.