### PR TITLE
research(erdos-1201): reconcile JSON currentState with merged state

### DIFF
--- a/src/data/research/problems/erdos-1201.json
+++ b/src/data/research/problems/erdos-1201.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-16T17:08:10.920Z",
+    "phase": "COMPLETED",
+    "since": "2026-04-21T11:09:40.248Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Gallery entry merged (PR #15109): 1651 lines, 116 theorems/lemmas, 8 defs, 1 axiom (erdos_1201_half_case for ε=1/2 partial result), 0 sorries. Status: axiomatized, badge: axiom — full conjecture remains open at the research level.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None at this slug. Open research direction: prove erdos_1201_half_case (Erdős's claimed ε=1/2 partial result), which would convert the axiom into a theorem.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: PR #15109 merged. Gallery entry: 14 theorems, 1 axiom (ε=1/2 partial result), 0 sorries. Formalization covers gpf, consecutiveProduct, upperDensity, gpfConsecutive_mono, gpfConsecutive_large_of_prime_dvd.",
+    "progressSummary": "COMPLETE: PR #15109 merged. Gallery entry (Erdos1201Problem.lean): 1651 lines, 116 theorems/lemmas, 8 defs, 1 axiom (erdos_1201_half_case, ε=1/2 partial result claimed by Erdős), 0 sorries. Formalization covers gpf, consecutiveProduct, upperDensity, gpfConsecutive_mono, gpfConsecutive_large_of_prime_dvd, plus subsequent expansions.",
     "builtItems": [
       "greatestPrimeFactor: gpf via Nat.primeFactors.max' (Proofs/Erdos1201Problem.lean)",
       "consecutiveProduct: ∏ i ∈ range(k+1), (n+i) (Proofs/Erdos1201Problem.lean)",
@@ -61,7 +61,7 @@
     "mathlib": []
   },
   "started": "2026-04-16T17:08:10.939Z",
-  "lastUpdate": "2026-04-21T11:09:40.248Z",
+  "lastUpdate": "2026-05-07T17:10:00.000Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Brings `src/data/research/problems/erdos-1201.json` (Erdős #1201: greatest prime factor of n(n+1)…(n+k)) in line with the gallery on `origin/main`.

The gallery has been at `status: axiomatized` / `badge: axiom` (PR #15109: 1651 lines, 116 theorems/lemmas, 8 defs, 1 axiom `erdos_1201_half_case`, 0 sorries) since April. The research JSON had top-level `phase: COMPLETED` / `status: completed` already but \`currentState.phase\` was still \`NEW\` with prior-session text ("Initial exploration", "Begin problem exploration"), and \`progressSummary\` claimed only "14 theorems" — the file has grown to 116.

## Changes

- `currentState.phase`: NEW → COMPLETED (consistent with top-level)
- `currentState.since`: bumped to merged-PR timestamp 2026-04-21
- `currentState.focus`: "Initial exploration of the problem." → concrete merged state
- `currentState.nextAction`: "Begin problem exploration." → "None at this slug" + note open research direction (prove the axiom)
- `progressSummary`: "14 theorems" → "1651 lines, 116 theorems/lemmas, 8 defs, 1 axiom"
- `lastUpdate` → 2026-05-07T17:10:00.000Z

## Verification

Comment-stripped Python regex against \`git show origin/main:proofs/Proofs/Erdos1201Problem.lean\`:

- 1 \`axiom\` declaration: \`erdos_1201_half_case\`
- 116 theorem/lemma declarations
- 8 \`def\` declarations
- 0 sorries
- 1651 lines

Matches `src/data/proofs/erdos-1201/meta.json` (`status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `theoremCount: 116`, `definitionCount: 8`, `lineCount: 1651`, `sorries: 0`) exactly.

## Test plan

- [x] JSON validates
- [x] Counts cross-checked against Lean file and gallery meta.json
- [x] Pure metadata change — no Lean source modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)