### PR TITLE
research(cantor-diagonalization-oq-04-oq-01): reconcile JSON to completed

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "cantor-diagonalization-oq-04-oq-01",
   "title": "Lawvere Fixed-Point Theorem for Setoids (CCC Generalization)",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -21,12 +21,12 @@
     "goal": "Proved: Lawvere FPT for Setoids, with full gallery entry"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-06T14:45:58.508Z",
+    "phase": "DONE",
+    "since": "2026-05-07T17:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Lawvere FPT for Setoids: 8 theorems, 3 definitions, 0 sorries, 0 axioms in CantorDiagonalizationOQ04OQ01.lean (166 lines). Gallery status=verified, badge=original. Merged in PR #16393.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — entry complete. Optional follow-on directions tracked in nextSteps (CCC typeclass lift, characterization of admissible setoids).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -34,7 +34,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Lawvere FPT proved for Setoids. 11 theorems, 3 definitions, 0 sorries, 0 axioms. PR pending Docker build.",
+    "progressSummary": "COMPLETED: Lawvere FPT proved for Setoids. CantorDiagonalizationOQ04OQ01.lean has 8 theorems, 3 definitions, 0 sorries, 0 axioms (166 lines). Gallery status=verified, badge=original; merged in PR #16393. The diagonal construction g(y) = f(decode(y)(y)) carries over from the Type-level proof; the retraction condition only needs to hold up to setoid equivalence (decode(encode(f))(y) ≈ f(y)).",
     "builtItems": [
       "CodesEndomorphismsSetoid structure (encode, decode, setoid retraction)",
       "lawvere_fixpoint_setoid: main theorem in CantorDiagonalizationOQ04OQ01.lean",
@@ -92,7 +92,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T14:45:58.508Z",
-  "lastUpdate": "2026-05-06T14:45:58.508Z",
+  "lastUpdate": "2026-05-07T17:00:00Z",
   "significance": 5,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

- Reconcile \`src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json\` to mirror the gallery state. The Lawvere FPT for Setoids was merged in PR #16393 (gallery: \`status: verified\` / \`badge: original\` / 0 sorries / 0 axioms / 8 theorems / 3 definitions / 166 lines), but that PR left the research-side JSON with \`status: active\` and \`currentState.phase: NEW\` / focus="Initial exploration of the problem", in tension with its own top-level \`phase: COMPLETED\` and progressSummary "COMPLETED: Lawvere FPT proved for Setoids".
- Changes: \`status\` active → completed; \`currentState.phase\` NEW → DONE; \`currentState.focus\` / \`nextAction\` rewritten as completion notes (\`since\` bumped to 2026-05-07); \`progressSummary\` corrected (file has 8 theorems + 3 defs, matching the gallery; previous text said "11 theorems") and the stale "PR pending Docker build" remark dropped; \`lastUpdate\` bumped.
- Knowledge arrays (insights, builtItems, mathlibGaps, nextSteps), tags, relatedProofs, references, leanFiles preserved verbatim.

## Test plan

- [x] \`jq -e\` validates the modified JSON.
- [x] No Lean files touched; gallery meta.json untouched.
- [x] \`gh pr list\` shows no in-flight PRs targeting this slug.