### PR TITLE
fix(aristotle): use /- not /-! in BallotProblemOQ03OQ01OQ01OQ01Aristotle

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean
@@ -16,7 +16,7 @@ namespace BallotProblemOQ03OQ01OQ01OQ01Aristotle
 
 variable {R : Type*} [CommRing R]
 
-/-! ### Helper lemmas -/
+/- ### Helper lemmas -/
 
 /-
 For b=1 with a ≥ 1, ¬ColStrictSym a 1 P Q iff the single element of Q


### PR DESCRIPTION
## Fix

Replace `/-! ### Helper lemmas -/` with `/- ### Helper lemmas -/` in `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean` (line 19).

## Why

Per Aristotle pre-submission rules (CLAUDE.md and `research/SORRY-CLASSIFICATION.md`):

> No `/-!` docstring sections (use `/-` instead — parser incompatibility)

`/-!` is a Lean docstring section marker; Aristotle's parser cannot handle it and the file would fail submission. This is the only Aristotle companion file in the repo with this issue.

## Evidence

**Before** (line 19):
```
/-! ### Helper lemmas -/
```

**After** (line 19):
```
/- ### Helper lemmas -/
```

Detected by mechanic compliance scan over all `proofs/Proofs/*Aristotle.lean` files; this was the only hit. No functional change — the section header still renders as a comment in Lean.

---
Automated fix by lean-mechanic agent.