### PR TITLE
fix(meta): add missing proofRepoPath to 4 entries

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-04/meta.json
@@ -5,6 +5,7 @@
   "description": "Connects the Lindstr\u00f6m\u2013Gessel\u2013Viennot (LGV) lemma to Vandermonde-type identities. The Vandermonde identity C(m+n,r) = \u03a3 C(m,k)\u00b7C(n,r-k) is the single-path (1\u00d71) degenerate case of the LGV lemma, where no involution is needed because path pairs are automatically non-crossing. Includes a combinatorial proof via Finset.powersetCard partition, the LGV e-function for lattice path counting, and the 2\u00d72 LGV determinant for staircase configurations.",
   "meta": {
     "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ04OQ04.lean",
     "badge": "original",
     "axiomCount": 0,
     "theoremCount": 13,

--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01/meta.json
@@ -7,6 +7,7 @@
     "field": "Analytic Number Theory",
     "difficulty": "research",
     "status": "axiomatized",
+    "proofRepoPath": "Proofs/DirichletsTheoremOQ01OQ01.lean",
     "badge": "axiom",
     "axiomCount": 7,
     "theoremCount": 20,

--- a/src/data/proofs/mean-value-theorem-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04/meta.json
@@ -5,6 +5,7 @@
   "description": "Establishes the Fundamental Theorem of Calculus and its connection to the Mean Value Theorem: MVT (local) gives one value c with f'(c) = (f(b)-f(a))/(b-a), while FTC (global) gives the exact integral formula. Both are proved, along with integration by parts, uniqueness of antiderivatives, MVT as an integral average, and the Lipschitz distance bound.",
   "meta": {
     "status": "verified",
+    "proofRepoPath": "Proofs/MeanValueTheoremOQ04.lean",
     "badge": "original",
     "axiomCount": 0,
     "theoremCount": 14,

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
@@ -5,6 +5,7 @@
   "description": "Proves the non-cyclic case of the Gauss-Wilson theorem: when (ZMod n)\u00d7 is not cyclic (n \u2265 3), the product of all units is 1 rather than -1. The key tool is the two-involution trick on the 2-torsion subgroup S = {x | x\u00b2=1}: two distinct FPF involutions on S both compute \u220fS, forcing \u220fS = 1. Combined with the cyclic case, this gives gaussWilson_abstract_ext: \u220f(ZMod n)\u00d7 = -1 iff (ZMod n)\u00d7 is cyclic.",
   "meta": {
     "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ02Ext.lean",
     "badge": "original",
     "axiomCount": 0,
     "theoremCount": 22,


### PR DESCRIPTION
## Fix

Add `meta.proofRepoPath` to four gallery entries that lack it. All other 2382 entries set this field — these were the only outliers, presumably stripped by an enricher schema rewrite.

## Why It Matters

The auditor's `scripts/auditor/find-targets.ts` uses `proofMeta.proofRepoPath` (i.e., `meta.meta.proofRepoPath`) to locate the Lean source. When absent, the fallback is `proofMeta.leanFile` *as a string* — but in these entries the path is stored under top-level `leanFile.path`, so the auditor resolves to `""`, builds an empty `allLeanFiles` list, and counts 0 sorries / 0 axioms regardless of file content. That's a false-clean signal.

## Evidence

| Slug | proofRepoPath added | Source |
|---|---|---|
| `binomial-theorem-oq-04-oq-04` | `Proofs/BinomialTheoremOQ04OQ04.lean` | `leanFile.path` |
| `dirichlets-theorem-oq-01-oq-01` | `Proofs/DirichletsTheoremOQ01OQ01.lean` | `leanFile.path` |
| `mean-value-theorem-oq-04` | `Proofs/MeanValueTheoremOQ04.lean` | `leanFile.path` |
| `wilsons-theorem-oq-02-ext` | `Proofs/WilsonsTheoremOQ02Ext.lean` | `leanFile.path` |

Each path is copied verbatim from the entry's existing `leanFile.path`. All four `proofs/Proofs/*.lean` files exist on `origin/main`.

## Test plan

- [x] Each `meta.json` validates as JSON post-edit
- [x] Surgical 1-line insertion (4 insertions / 0 deletions total)
- [x] Path matches existing `leanFile.path` exactly
- [x] No other field touched (status, badge, counts, narrative all preserved)
- [x] Convention placement: \`proofRepoPath\` immediately after \`status\` (matches binomial-theorem-oq-03-oq-02, erdos-1096, arithmetic-series-oq-02-oq-02, etc.)

---
Automated fix by lean-mechanic agent.