### PR TITLE
research(e-transcendental-oq-02): reconcile JSON with merged digit-extension + axiom-elimination work

### DIFF
--- a/src/data/research/problems/e-transcendental-oq-02.json
+++ b/src/data/research/problems/e-transcendental-oq-02.json
@@ -43,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Gallery entry ETranscendentalOQ02.lean created (237 lines, 0 sorries, 4 axioms, 21 theorems, 3 defs). Key achievements: rigorous normality definitions, machine-verified first 6 decimal digits of e, and axiomatized normal_imp_irrational + e_absolutely_normal.",
+    "progressSummary": "COMPLETE: Gallery entry ETranscendentalOQ02.lean (origin/main 2026-05-07: 300 lines, 0 sorries, 3 axioms, 28 theorems, 3 defs). #15637 extended decimal digit proofs to 9 digits. #15750 proved periodic_has_missing_ktuple (axioms 4→3). Remaining axioms: rational_digits_eventually_periodic, normal_imp_irrational, e_absolutely_normal (the open conjecture). Key achievements: rigorous normality definitions, machine-verified first 9 decimal digits of e, and axiomatized e_absolutely_normal.",
     "builtItems": [
       "ETranscendentalOQ02.lean: nthDigit, IsNormalInBase, IsAbsolutelyNormal definitions",
       "ETranscendentalOQ02.lean: e_floor=2, e_floor_10=27, e_floor_100=271, e_floor_1000=2718, e_floor_10000=27182, e_floor_100000=271828, e_floor_1000000=2718281 all proved",
@@ -97,14 +97,14 @@
     ]
   },
   "started": "2026-05-04T00:00:00.000Z",
-  "lastUpdate": "2026-05-04T00:00:00.000Z",
+  "lastUpdate": "2026-05-07T17:35:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/ETranscendentalOQ01.lean",
       "filename": "ETranscendentalOQ01.lean",
-      "lineCount": 539,
+      "lineCount": 538,
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 2,
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/ETranscendentalOQ01OQ01.lean",
       "filename": "ETranscendentalOQ01OQ01.lean",
-      "lineCount": 342,
+      "lineCount": 341,
       "theoremCount": 9,
       "axiomCount": 1,
       "defCount": 0,
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/ETranscendentalOQ03.lean",
       "filename": "ETranscendentalOQ03.lean",
-      "lineCount": 220,
+      "lineCount": 219,
       "theoremCount": 4,
       "axiomCount": 2,
       "defCount": 0,


### PR DESCRIPTION
## Summary

The research-side JSON was last updated 2026-05-04 with progressSummary "237 lines, 0 sorries, 4 axioms, 21 theorems, 3 defs" but two PRs landed since: #15637 extended digit proofs to 9 digits (theorems 21→28), and #15750 proved `periodic_has_missing_ktuple` (axioms 4→3). The leanFiles entry for ETranscendentalOQ02.lean is already current (300/28/3/3); only the progressSummary text and three sibling lineCount values are stale.

## Changes

- `knowledge.progressSummary`: rewrite with origin/main snapshot (300 lines, 28 thm, 3 ax, 3 def); name #15637 and #15750 explicitly; list remaining axioms (`rational_digits_eventually_periodic`, `normal_imp_irrational`, `e_absolutely_normal`); update "first 6 digits" → "first 9 digits"
- `leanFiles[OQ01].lineCount`: 539 → 538
- `leanFiles[OQ01OQ01].lineCount`: 342 → 341
- `leanFiles[OQ03].lineCount`: 220 → 219
- `lastUpdate`: 2026-05-04 → 2026-05-07

## Verification

Comment-stripped Python regex against `git show origin/main:proofs/Proofs/ETranscendentalOQ02.lean`:
- 300 lines, 28 theorems/lemmas, 3 axioms (`rational_digits_eventually_periodic`, `normal_imp_irrational`, `e_absolutely_normal`), 3 defs (`nthDigit`, `IsNormalInBase`, `IsAbsolutelyNormal`), 0 sorries

Sibling files OQ01.lean=538, OQ01OQ01.lean=341, OQ03.lean=219 confirmed likewise. OQ02.lean leanFiles entry was already current.

No Lean changes; pure JSON metadata reconcile.

## Test plan

- [x] No Lean files changed; no Docker build required
- [x] JSON validates (single file edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)