### PR TITLE
research(elementary-quadratic-reciprocity-oq-01-oq-02): reconcile leanFiles drift across 13 files

### DIFF
--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
@@ -85,15 +85,15 @@
     "mathlib": []
   },
   "started": "2026-05-03T11:41:44.693Z",
-  "lastUpdate": "2026-05-03T11:41:44.693Z",
+  "lastUpdate": "2026-05-07T17:45:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/ElementaryQuadraticReciprocity.lean",
       "filename": "ElementaryQuadraticReciprocity.lean",
-      "lineCount": 358,
-      "theoremCount": 9,
+      "lineCount": 357,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ01.lean",
       "filename": "ElementaryQuadraticReciprocityOQ01.lean",
-      "lineCount": 629,
+      "lineCount": 628,
       "theoremCount": 31,
       "axiomCount": 0,
       "defCount": 5,
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
       "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
-      "lineCount": 167,
+      "lineCount": 166,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean",
       "filename": "ElementaryQuadraticReciprocityOQ01OQ02.lean",
-      "lineCount": 563,
+      "lineCount": 562,
       "theoremCount": 27,
       "axiomCount": 2,
       "defCount": 6,
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",
       "filename": "ElementaryQuadraticReciprocityOQ02.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 0,
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03.lean",
-      "lineCount": 200,
-      "theoremCount": 7,
+      "lineCount": 199,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03OQ01.lean",
-      "lineCount": 312,
+      "lineCount": 311,
       "theoremCount": 24,
       "axiomCount": 0,
       "defCount": 0,
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean",
-      "lineCount": 165,
+      "lineCount": 164,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 5,
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean",
-      "lineCount": 148,
+      "lineCount": 147,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean",
-      "lineCount": 190,
+      "lineCount": 189,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 2,
@@ -202,8 +202,8 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03OQ02.lean",
-      "lineCount": 224,
-      "theoremCount": 14,
+      "lineCount": 223,
+      "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -213,8 +213,8 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02OQ01.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03OQ02OQ01.lean",
-      "lineCount": 268,
-      "theoremCount": 4,
+      "lineCount": 267,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean",
       "filename": "ElementaryQuadraticReciprocityOQ03OQ03.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 3,
       "axiomCount": 1,
       "defCount": 0,


### PR DESCRIPTION
## Summary

The research-side JSON for the cubic/quartic reciprocity slug has not been reconciled since 2026-05-03. Since then the entire family of 13 `ElementaryQuadraticReciprocity*.lean` files has drifted by one line (typically trailing-newline normalization), and four files have grown in theoremCount as additional lemmas were added on main.

## Drift summary (claimed → actual)

LineCount drift on all 13 files: -1 each (358→357, 629→628, 167→166, 563→562, 176→175, 200→199, 312→311, 165→164, 148→147, 190→189, 224→223, 268→267, 103→102).

TheoremCount drift on 4 files:
- `ElementaryQuadraticReciprocity.lean`: 9 → 11 (+2)
- `ElementaryQuadraticReciprocityOQ03.lean`: 7 → 10 (+3)
- `ElementaryQuadraticReciprocityOQ03OQ02.lean`: 14 → 16 (+2)
- `ElementaryQuadraticReciprocityOQ03OQ02OQ01.lean`: 4 → 6 (+2)

`axiomCount`, `defCount`, `sorryCount` all confirmed correct against origin/main; left untouched.

## Verification

Comment-stripped Python regex against `git show origin/main:` for each of the 13 files; all 65 quintuples (lines, thm, ax, def, sorry) now match the leanFiles entries exactly.

`lastUpdate` bumped to 2026-05-07T17:45:00.000Z.

No Lean changes; pure JSON metadata reconcile.

## Test plan

- [x] No Lean files changed; no Docker build required
- [x] JSON validates (single file edit, 18+/18- lines)
- [x] Programmatic verification: all 13 leanFiles entries now match origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)