### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): sync leanFiles drift after S17 PRs

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -169,7 +169,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-05-02T06:50:00Z",
+  "lastUpdate": "2026-05-07T17:35:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",
@@ -350,11 +350,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 851,
-      "theoremCount": 10,
+      "lineCount": 850,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },


### PR DESCRIPTION
## Summary

Session 17 PRs #14882 (research) and #14896 (feat-side helpers), both merged 2026-05-02, reduced sorries in `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` from 4 to 2 and added 9+ helper lemmas. The research JSON's progressSummary correctly mentions S18 / "2 sorries remain", but the structural metadata in `leanFiles[BallotProblemOQ03OQ01OQ01OQ01].*` was not resynced.

## Changes (one file)

`src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`, leanFiles entry for BallotProblemOQ03OQ01OQ01OQ01.lean:
- `lineCount: 851 → 850`
- `theoremCount: 10 → 19`
- `sorryCount: 4 → 2`
- Top-level `lastUpdate` bumped

The mathematical state is unchanged. S18 (already documented in the JSON) is the current research frontier: the insert-violation-element bijection is non-injective for b≥2; the recovery plan is weight-factorization + counting-identity.

## Test plan
- [x] JSON validates
- [x] Comment-stripped sorry count = 2 (Python re scan after `/-…-/` and `--` removal)
- [x] Comment-stripped theorem count = 19 (regex matches `(@[…])* (private/protected/noncomputable)* (theorem/lemma) <name>`)
- [x] Line count via `wc -l` = 850
- [x] PRs #14882 and #14896 confirmed merged 2026-05-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)