### PR TITLE
research(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01): reconcile JSON to completed (Lp Riesz sigma-finite)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -2,8 +2,8 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures",
   "tractability": 6,
-  "status": "in-progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "knowledge": {
     "insights": [
       "Mathlib uses tendsto_Lp_of_tendsto_ae (Vitali theorem) not tendsto_Lp_of_dominated_convergence — the latter does not exist",
@@ -16,18 +16,16 @@
     "builtItems": [
       "mem_spanningSets_eventually (proved): every point eventually in spanning sets",
       "pointwise_mul_indicator_tendsto (proved): f(a)*1_{Sn}(a) -> f(a) pointwise",
-      "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean created with 3 HARD sorries"
+      "lp_truncation_tendsto_zero (proved, PR #14906/#15755): truncation tends to 0 in Lp via Vitali (tendsto_Lp_of_tendsto_ae) + UnifIntegrable + UnifTight",
+      "localization_existence (proved): localization construction via Lp restriction map",
+      "riesz_lp_surjective_sigma_finite (proved): main theorem — Riesz representation extended from finite to sigma-finite measures"
     ],
     "mathlibGaps": [
       "No tendsto_Lp_of_dominated_convergence — must use Vitali theorem (tendsto_Lp_of_tendsto_ae) + UnifIntegrable/UnifTight",
       "Lp restriction map Lp(mu) -> Lp(mu.restrict S) not found as standalone infrastructure"
     ],
-    "nextSteps": [
-      "Prove lp_truncation_tendsto_zero using tendsto_Lp_of_tendsto_ae + unifIntegrable_of + unifTight_const (~80 lines)",
-      "Port parent integral_representation to SigmaFinite case for density extension step (~50 lines)",
-      "Build localization construction via Lp restriction map (~150 lines)"
-    ],
-    "progressSummary": "ACT: 2 lemmas proved (pointwise convergence), 3 HARD sorries identified and blueprinted. Gallery entry created."
+    "nextSteps": [],
+    "progressSummary": "COMPLETE: CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean has 5 theorems, 0 sorries, 0 axioms (208 lines). Gallery status=verified, badge=original. The three HARD sorries (lp_truncation_tendsto_zero, density-extension/integral_representation, localization construction) were closed across PR #14906 (initial 3→1 reduction) and PR #15755 (final sorry eliminated)."
   },
   "leanFiles": [
     {
@@ -121,11 +119,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",
-      "lineCount": 221,
+      "lineCount": 208,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 14,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean"
     },


### PR DESCRIPTION
## Summary

- The Lean file \`CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean\` is sorry- and axiom-free on \`origin/main\` (5 theorems, 208 lines), and the gallery \`meta.json\` already shows \`status: verified\` / \`badge: original\` / 0 sorries / 0 axioms. The three HARD sorries (\`lp_truncation_tendsto_zero\`, density-extension / \`integral_representation\` port, localization construction) were closed by PR #14906 (initial 3→1 reduction) and PR #15755 (final sorry eliminated).
- Companion \`src/data/research/problems/<slug>.json\` wasn't reconciled and still reads \`status: in-progress\` / \`phase: ACT\`, with \`builtItems\` listing only the early pointwise-convergence helpers and "file created with 3 HARD sorries", \`nextSteps\` listing the three now-closed sorry tasks as pending, and \`leanFiles[<target>].sorryCount: 14\` / \`lineCount: 221\` (actual: 0 / 208).
- This PR is the pure-text reconciliation: \`status\` → completed, \`phase\` → COMPLETED, \`progressSummary\` rewritten with PR pointers, \`builtItems\` extended with the three closed-sorry lemmas (\`lp_truncation_tendsto_zero\`, \`localization_existence\`, \`riesz_lp_surjective_sigma_finite\`), \`nextSteps\` emptied, target leanFile counts corrected. \`insights\` and \`mathlibGaps\` preserved verbatim.

## Test plan

- [x] \`jq -e\` validates the modified JSON.
- [x] No Lean files touched; gallery meta untouched.
- [x] \`gh pr list\` shows no in-flight PRs targeting this slug (\`#15301\` targets the sibling \`-incomplete-01\` slug; \`#16612\` targets a different sibling).