### PR TITLE
research(descartes-rule-of-signs-oq-02-oq-01-oq-02): reconcile leanFiles drift across 8 sibling files

### DIFF
--- a/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02.json
@@ -87,14 +87,14 @@
     "mathlib": []
   },
   "started": "2026-04-26T14:43:29.519Z",
-  "lastUpdate": "2026-05-07T16:55:00.000Z",
+  "lastUpdate": "2026-05-07T17:55:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/DescartesRuleOfSigns.lean",
       "filename": "DescartesRuleOfSigns.lean",
-      "lineCount": 577,
+      "lineCount": 576,
       "theoremCount": 35,
       "axiomCount": 8,
       "defCount": 11,
@@ -105,18 +105,18 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ01.lean",
       "filename": "DescartesRuleOfSignsOQ01.lean",
-      "lineCount": 1075,
-      "theoremCount": 30,
+      "lineCount": 1074,
+      "theoremCount": 48,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },
     {
       "path": "Proofs/DescartesRuleOfSignsOQ01OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ01OQ01.lean",
-      "lineCount": 155,
+      "lineCount": 154,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ01OQ02.lean",
       "filename": "DescartesRuleOfSignsOQ01OQ02.lean",
-      "lineCount": 272,
+      "lineCount": 271,
       "theoremCount": 9,
       "axiomCount": 1,
       "defCount": 0,
@@ -138,8 +138,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02.lean",
       "filename": "DescartesRuleOfSignsOQ02.lean",
-      "lineCount": 699,
-      "theoremCount": 30,
+      "lineCount": 698,
+      "theoremCount": 43,
       "axiomCount": 3,
       "defCount": 8,
       "sorryCount": 0,
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
+      "lineCount": 191,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
@@ -171,8 +171,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ03.lean",
       "filename": "DescartesRuleOfSignsOQ03.lean",
-      "lineCount": 441,
-      "theoremCount": 24,
+      "lineCount": 440,
+      "theoremCount": 29,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -182,8 +182,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ04.lean",
       "filename": "DescartesRuleOfSignsOQ04.lean",
-      "lineCount": 496,
-      "theoremCount": 16,
+      "lineCount": 495,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The slug's own file (`DescartesRuleOfSignsOQ02OQ01OQ02.lean`) is in sync. The other 8 sibling `DescartesRuleOfSigns*.lean` files have drifted on main: all 8 lost 1 line (trailing-newline normalization), four grew in theoremCount, and OQ01 had a sorry eliminated.

## Drift summary (claimed → actual)

LineCount drift on all 8 sibling files: 577→576, 1075→1074, 155→154, 272→271, 699→698, 192→191, 441→440, 496→495.

TheoremCount drift on 4 files:
- `DescartesRuleOfSignsOQ01.lean`: 30 → 48 (+18, also sorry 1→0)
- `DescartesRuleOfSignsOQ02.lean`: 30 → 43 (+13)
- `DescartesRuleOfSignsOQ03.lean`: 24 → 29 (+5)
- `DescartesRuleOfSignsOQ04.lean`: 16 → 22 (+6)

OQ02OQ01OQ02.lean entry (the slug's own file) confirmed correct (458 lines, 28 thm, 1 ax, 6 def, 0 sorry); left untouched.

## Verification

Comment-stripped Python regex against `git show origin/main:` for each of the 9 files. After edit, all 9 quintuples match origin/main exactly.

`lastUpdate` bumped 2026-05-07T16:55 → 17:55.

No Lean changes; pure JSON metadata reconcile.

## Test plan

- [x] No Lean files changed; no Docker build required
- [x] JSON validates (single file edit, 14+/14- lines)
- [x] Programmatic verification: all 9 leanFiles entries now match origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)