### PR TITLE
research(ballot-gnw-key): close IH sorry via well-founded recursion on μ.card

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -13861,6 +13861,74 @@ private lemma gnwProb_stable (μ : YoungDiagram) (c : ℕ × ℕ) (x : ℕ × �
     rw [Nat.add_succ, gnwProb_step μ c (hookLength μ x.1 x.2 + d) x hx (Nat.le_add_right _ _)]
     exact ihd
 
+/-- Removing corner c' from μ deletes c' from the strict hook cells of every other cell.
+    For x ∈ μ\c': strictHookCells (μ\c') x = strictHookCells μ x \ {c'}.
+
+    Proof by case analysis on whether x shares a row/column with c':
+    - If x.1 = c'.1 (same row, x left of c'): rowLen drops by 1, so c' is removed from arm.
+    - If x.2 = c'.2 (same column, x above c'): colLen drops by 1, so c' is removed from leg.
+    - Otherwise: row/col lengths unchanged, and c' was never in arm/leg of x. -/
+private lemma strictHookCells_removeCorner_eq {μ : YoungDiagram} {c' : ℕ × ℕ}
+    (hc' : isCorner μ c') (i j : ℕ) :
+    strictHookCells (removeCorner μ c' hc') i j =
+      strictHookCells μ i j \ {c'} := by
+  set ν := removeCorner μ c' hc'
+  ext y
+  simp only [strictHookCells, Finset.mem_union, Finset.mem_image, Finset.mem_Ico,
+             Finset.mem_sdiff, Finset.mem_singleton]
+  constructor
+  · -- (⊆) cells in strict hook of (i,j) inside ν are in strict hook inside μ and ≠ c'.
+    rintro (⟨s, ⟨hjs, hsr⟩, hy_eq⟩ | ⟨r, ⟨hir, hrc⟩, hy_eq⟩)
+    · subst hy_eq
+      have hsν : (i, s) ∈ ν := YoungDiagram.mem_iff_lt_rowLen.mpr hsr
+      have hsμ : (i, s) ∈ μ := ((mem_removeCorner hc').mp hsν).1
+      have hsr_μ : s < μ.rowLen i := YoungDiagram.mem_iff_lt_rowLen.mp hsμ
+      refine ⟨Or.inl ⟨s, ⟨hjs, hsr_μ⟩, rfl⟩, ?_⟩
+      intro hy_eq
+      have h1 : i = c'.1 := congr_arg Prod.fst hy_eq
+      have h2 : s = c'.2 := congr_arg Prod.snd hy_eq
+      have hrl : ν.rowLen c'.1 = c'.2 := rowLen_removeCorner_self hc'
+      rw [← h1, ← h2] at hrl
+      omega
+    · subst hy_eq
+      have hrν : (r, j) ∈ ν := YoungDiagram.mem_iff_lt_colLen.mpr hrc
+      have hrμ : (r, j) ∈ μ := ((mem_removeCorner hc').mp hrν).1
+      have hrc_μ : r < μ.colLen j := YoungDiagram.mem_iff_lt_colLen.mp hrμ
+      refine ⟨Or.inr ⟨r, ⟨hir, hrc_μ⟩, rfl⟩, ?_⟩
+      intro hy_eq
+      have h1 : r = c'.1 := congr_arg Prod.fst hy_eq
+      have h2 : j = c'.2 := congr_arg Prod.snd hy_eq
+      have hcl : ν.colLen c'.2 = c'.1 := colLen_removeCorner_self hc'
+      rw [← h1, ← h2] at hcl
+      omega
+  · -- (⊇) cells in strict hook of (i,j) inside μ that are ≠ c' lift to ν.
+    rintro ⟨h_or, hyne⟩
+    rcases h_or with ⟨s, ⟨hjs, hsr⟩, hy_eq⟩ | ⟨r, ⟨hir, hrc⟩, hy_eq⟩
+    · subst hy_eq
+      by_cases hii' : i = c'.1
+      · -- Same row as c': must have s ≠ c'.2 (else (i,s) = c') and s < rowLen μ i = c'.2 + 1.
+        have hsj' : s ≠ c'.2 := fun hsj => hyne (Prod.ext hii' hsj)
+        have hr_μ : μ.rowLen i = c'.2 + 1 := by
+          rw [hii']; exact rowLen_of_isCorner hc'
+        have hr_ν : ν.rowLen i = c'.2 := by
+          rw [hii']; exact rowLen_removeCorner_self hc'
+        have hs_lt : s < c'.2 := by omega
+        exact Or.inl ⟨s, ⟨hjs, by rw [hr_ν]; exact hs_lt⟩, rfl⟩
+      · -- Different row: rowLen unchanged.
+        have hr_eq : ν.rowLen i = μ.rowLen i := rowLen_removeCorner_other hc' hii'
+        exact Or.inl ⟨s, ⟨hjs, by rw [hr_eq]; exact hsr⟩, rfl⟩
+    · subst hy_eq
+      by_cases hjj' : j = c'.2
+      · have hri' : r ≠ c'.1 := fun hri => hyne (Prod.ext hri hjj')
+        have hc_μ : μ.colLen j = c'.1 + 1 := by
+          rw [hjj']; exact colLen_of_isCorner hc'
+        have hc_ν : ν.colLen j = c'.1 := by
+          rw [hjj']; exact colLen_removeCorner_self hc'
+        have hr_lt : r < c'.1 := by omega
+        exact Or.inr ⟨r, ⟨hir, by rw [hc_ν]; exact hr_lt⟩, rfl⟩
+      · have hc_eq : ν.colLen j = μ.colLen j := colLen_removeCorner_other hc' hjj'
+        exact Or.inr ⟨r, ⟨hir, by rw [hc_eq]; exact hrc⟩, rfl⟩
+
 /-- GNW 1979 exchange identity (core inductive step, product form — no division).
     For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
       F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14062,14 +14062,9 @@ private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ
     -- c is a corner of removeCorner μ c' hc' (distinct corners survive removal).
     have hc_in_rc' : isCorner (removeCorner μ c' hc') c :=
       isCorner_removeCorner_of_ne hc' hc hne.symm
-    -- (a) IH: gnwProb_key holds for removeCorner μ c' hc' and corner c.
-    -- (Requires strong induction; removeCorner μ c' hc' has card < μ.card.)
-    have h_IH : ∑ x ∈ (removeCorner μ c' hc').cells,
-        gnwProb (removeCorner μ c' hc') c
-          (hookLength (removeCorner μ c' hc') x.1 x.2) x =
-        (hookProd (removeCorner μ c' hc') : ℚ) /
-          hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') := by
-      sorry  -- IH from strong induction on μ.card; removeCorner_card gives card < μ.card
+    -- (a) IH: gnwProb_key holds for removeCorner μ c' hc' and corner c
+    -- (well-founded recursion on μ.card; removeCorner_card hc' gives card - 1 < card).
+    have h_IH := gnwProb_key (removeCorner μ c' hc') hc_in_rc'
     -- Rearrange IH: F(μ\c',c) * H((μ\c')\c) = H(μ\c')
     have hHrc' : (0 : ℚ) < hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') :=
       Nat.cast_pos.mpr (Finset.prod_pos (fun x _ => hookLength_pos _ _ _))
@@ -14098,6 +14093,11 @@ private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ
       mul_right_cancel₀ h_Hc' h_exch
     rw [eq_div_iff (ne_of_gt hHrc)]
     linarith [h_main_prod]
+termination_by μ.card
+decreasing_by
+  have hμpos : 0 < μ.card := Finset.card_pos.mpr ⟨c', hc'.1⟩
+  simp only [removeCorner_card hc']
+  omega
 
 /-- Hook-walk identity for arbitrary non-empty Young diagrams via GNW walk.
     Proof: rewrite each ratio using gnwProb_key, swap the double sum, and apply

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -4362,6 +4362,17 @@ lemma mem_removeCorner {μ : YoungDiagram} {c x : ℕ × ℕ} (hc : isCorner μ 
   simp only [removeCorner, YoungDiagram.mem_mk, Finset.mem_erase, YoungDiagram.mem_cells]
   tauto
 
+/-- A corner of μ distinct from c₁ remains a corner of removeCorner μ c₁. -/
+private lemma isCorner_removeCorner_of_ne {μ : YoungDiagram} {c₁ c₂ : ℕ × ℕ}
+    (hc₁ : isCorner μ c₁) (hc₂ : isCorner μ c₂) (hne : c₁ ≠ c₂) :
+    isCorner (removeCorner μ c₁ hc₁) c₂ := by
+  obtain ⟨hc₂mem, hc₂right, hc₂below⟩ := hc₂
+  refine ⟨(mem_removeCorner hc₁).mpr ⟨hc₂mem, hne.symm⟩, ?_, ?_⟩
+  · intro hmem
+    exact hc₂right ((mem_removeCorner hc₁).mp hmem).1
+  · intro hmem
+    exact hc₂below ((mem_removeCorner hc₁).mp hmem).1
+
 /-- Cardinality of removeCorner is μ.card - 1. -/
 lemma removeCorner_card {μ : YoungDiagram} {c : ℕ × ℕ} (hc : isCorner μ c) :
     (removeCorner μ c hc).card = μ.card - 1 := by
@@ -13850,22 +13861,38 @@ private lemma gnwProb_stable (μ : YoungDiagram) (c : ℕ × ℕ) (x : ℕ × �
     rw [Nat.add_succ, gnwProb_step μ c (hookLength μ x.1 x.2 + d) x hx (Nat.le_add_right _ _)]
     exact ihd
 
+/-- GNW 1979 exchange identity (core inductive step, product form — no division).
+    For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
+      F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)
+    where F(ν,d) = Σ_{x∈ν} gnwProb(ν,d,h(x),x) and H = hookProd.
+    This is the only non-circular bridge: given gnwProb_key for μ\c' (IH), it implies
+    gnwProb_key for μ.  Proof requires careful analysis of how removing c' shifts
+    hook lengths in the arm/leg of c; verified on L-shape and (3,1) shape. -/
+private lemma gnwProb_exchange (μ : YoungDiagram) {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+      (hookProd (removeCorner μ c hc) : ℚ) *
+      (hookProd (removeCorner μ c' hc') : ℚ) =
+    (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+      (hookProd (removeCorner (removeCorner μ c' hc') c
+          (isCorner_removeCorner_of_ne hc' hc hne.symm)) : ℚ) *
+      (hookProd μ : ℚ) := by
+  sorry
+
 /-- GNW KEY theorem (Greene-Nijenhuis-Wilf 1979):
     The sum of GNW walk probabilities over all cells in μ equals the hookProd ratio.
     This is the hard combinatorial core of the GNW 1979 proof.
 
-    Prerequisites now proved:
-    - hookLength_isCorner_one: corners have hookLength 1
-    - gnwProb_step: gnwProb (K+1) x = gnwProb K x for K ≥ hookLength x
-    - gnwProb_stable: gnwProb K x = gnwProb (hookLength x) x for K ≥ hookLength x
-
-    Proof strategy (GNW 1979 induction on |μ|):
-    For |μ|=1, μ={c}: sum = 1, ratio = hookProd({c})/hookProd(∅) = 1. ✓
-    Inductive step: split sum into corners (contribute 1 for c, 0 for c'≠c) and non-corners.
-    For non-corner x: gnwProb (hookLength x) x = (1/|H*(x)|)*Σ_{y∈H*(x)} gnwProb (hookLength y) y
-    (using gnwProb_stable to replace gnwProb (hookLength x - 1) y with gnwProb (hookLength y) y).
-    The resulting double sum telescopes using the hook product formula:
-    hookProd(μ)/hookProd(μ\c) = Π_{y∈preHook(c)} hookLength(y)/(hookLength(y)-1). -/
+    Proof: by strong induction on μ.card.
+    Base (single-corner, μ is a rectangle): gnwProb = 1 everywhere; ratio = μ.card.
+    Step (multi-corner): pick any c' ≠ c.  gnwProb_exchange gives:
+      F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ).
+    By IH on μ\c' (using isCorner_removeCorner_of_ne):
+      F(μ\c',c) · H((μ\c')\c) = H(μ\c').
+    Substituting: F(μ,c) · H(μ\c) · H(μ\c') = H(μ\c') · H(μ),
+    so F(μ,c) = H(μ)/H(μ\c)  (dividing by H(μ\c') > 0). -/
 private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ c) :
     ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x =
     (hookProd μ : ℚ) / hookProd (removeCorner μ c hc) := by
@@ -14016,12 +14043,61 @@ private lemma gnwProb_key (μ : YoungDiagram) {c : ℕ × ℕ} (hc : isCorner μ
       rw [h_arm_prod, h_leg_prod]
       push_cast [h_card]; ring
     rw [h_sum_card, h_ratio_card]
-  · -- Multi-corner case: GNW 1979 exchange argument.
-    -- For |corners(μ)| ≥ 2, the proof requires the exchange principle from GNW 1979:
-    -- induction on μ.card, using that for any other corner c', the walk probability
-    -- sum satisfies F(μ,c) = F(μ\c',c) by exchanging hook weights in the random walk.
-    -- The invariance H(μ)/H(μ\c) = H(μ\c')/H(μ\{c,c'}) then closes the induction.
-    sorry
+  · -- Multi-corner case (|corners μ| ≥ 2), using gnwProb_exchange + strong induction.
+    -- The proof below is CORRECT MODULO two sorry'd steps:
+    --   (a) setting up strong induction on μ.card so the IH is available, and
+    --   (b) gnwProb_exchange (which requires the GNW 1979 hook-weight shift argument).
+    -- Once both are proved, the remaining algebraic steps close immediately.
+    --
+    -- Pick a second corner c' ≠ c.
+    have h_card_ge2 : 2 ≤ (corners μ).card := by
+      have hpos : 0 < (corners μ).card := Finset.card_pos.mpr ⟨c, hcmem⟩
+      omega
+    obtain ⟨c', hc'mem, hne⟩ : ∃ c' ∈ corners μ, c' ≠ c := by
+      obtain ⟨c₁, hc₁, c₂, hc₂, hne12⟩ := Finset.one_lt_card.mp (by omega)
+      by_cases h : c₁ = c
+      · exact ⟨c₂, hc₂, fun h2 => hne12 (h.trans h2.symm)⟩
+      · exact ⟨c₁, hc₁, h⟩
+    have hc' : isCorner μ c' := mem_corners.mp hc'mem
+    -- c is a corner of removeCorner μ c' hc' (distinct corners survive removal).
+    have hc_in_rc' : isCorner (removeCorner μ c' hc') c :=
+      isCorner_removeCorner_of_ne hc' hc hne.symm
+    -- (a) IH: gnwProb_key holds for removeCorner μ c' hc' and corner c.
+    -- (Requires strong induction; removeCorner μ c' hc' has card < μ.card.)
+    have h_IH : ∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x =
+        (hookProd (removeCorner μ c' hc') : ℚ) /
+          hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') := by
+      sorry  -- IH from strong induction on μ.card; removeCorner_card gives card < μ.card
+    -- Rearrange IH: F(μ\c',c) * H((μ\c')\c) = H(μ\c')
+    have hHrc' : (0 : ℚ) < hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') :=
+      Nat.cast_pos.mpr (Finset.prod_pos (fun x _ => hookLength_pos _ _ _))
+    have hHc' : (0 : ℚ) < hookProd (removeCorner μ c' hc') :=
+      Nat.cast_pos.mpr (Finset.prod_pos (fun x _ => hookLength_pos _ _ _))
+    have h_IH_prod : (∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb (removeCorner μ c' hc') c
+          (hookLength (removeCorner μ c' hc') x.1 x.2) x) *
+        (hookProd (removeCorner (removeCorner μ c' hc') c hc_in_rc') : ℚ) =
+        hookProd (removeCorner μ c' hc') := by
+      rw [h_IH, div_mul_cancel₀ _ (ne_of_gt hHrc')]
+    -- (b) Exchange identity: F(μ,c)*H(μ\c)*H(μ\c') = F(μ\c',c)*H((μ\c')\c)*H(μ)
+    have h_exch := gnwProb_exchange μ hc hc' hne
+    -- Substitute IH into exchange RHS: F'*H_cc' → H_c'
+    rw [h_IH_prod] at h_exch
+    -- h_exch now: F(μ,c)*H(μ\c)*H(μ\c') = H(μ\c')*H(μ)
+    -- Normalize commutativity so H(μ\c') is on the right
+    rw [mul_comm (hookProd (removeCorner μ c' hc') : ℚ) (hookProd μ : ℚ)] at h_exch
+    -- h_exch: F(μ,c)*H(μ\c)*H(μ\c') = H(μ)*H(μ\c')
+    -- Cancel H(μ\c') to get F(μ,c)*H(μ\c) = H(μ)
+    have hHrc : (0 : ℚ) < hookProd (removeCorner μ c hc) :=
+      Nat.cast_pos.mpr (Finset.prod_pos (fun x _ => hookLength_pos _ _ _))
+    have h_Hc' : (hookProd (removeCorner μ c' hc') : ℚ) ≠ 0 := ne_of_gt hHc'
+    have h_main_prod : (∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x) *
+        (hookProd (removeCorner μ c hc) : ℚ) = hookProd μ :=
+      mul_right_cancel₀ h_Hc' h_exch
+    rw [eq_div_iff (ne_of_gt hHrc)]
+    linarith [h_main_prod]
 
 /-- Hook-walk identity for arbitrary non-empty Young diagrams via GNW walk.
     Proof: rewrite each ratio using gnwProb_key, swap the double sum, and apply

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -13747,6 +13747,41 @@ private lemma strictHookCells_hookLen_lt {μ : YoungDiagram} {i j : ℕ}
     have hrow_anti : μ.rowLen r ≤ μ.rowLen i := μ.rowLen_anti i r (by omega : i ≤ r)
     change hookLength μ r j < hookLength μ i j; omega
 
+/-- Membership characterization for `strictHookCells`: a cell `(p, q)` is in the strict
+    hook of `(i, j)` iff it is on the same row to the right (arm) or same column below
+    (leg), within μ. -/
+private lemma mem_strictHookCells_iff {μ : YoungDiagram} {i j p q : ℕ} :
+    (p, q) ∈ strictHookCells μ i j ↔
+      (p = i ∧ j < q ∧ q < μ.rowLen i) ∨ (i < p ∧ q = j ∧ p < μ.colLen j) := by
+  simp only [strictHookCells, Finset.mem_union, Finset.mem_image, Finset.mem_Ico,
+             Prod.mk.injEq]
+  constructor
+  · rintro (⟨s, ⟨hjs, hsr⟩, hps, hqs⟩ | ⟨r, ⟨hir, hrc⟩, hpr, hqr⟩)
+    · exact Or.inl ⟨hps.symm, by omega, by omega⟩
+    · exact Or.inr ⟨by omega, hqr.symm, by omega⟩
+  · rintro (⟨hpi, hjq, hqr⟩ | ⟨hip, hqj, hpc⟩)
+    · exact Or.inl ⟨q, ⟨by omega, hqr⟩, hpi.symm, rfl⟩
+    · exact Or.inr ⟨p, ⟨by omega, hpc⟩, rfl, hqj.symm⟩
+
+/-- For a corner `c'` of μ, membership in `strictHookCells μ i j` simplifies to a clean
+    arm/leg disjunction (the upper bounds `c'.2 < μ.rowLen c'.1` and `c'.1 < μ.colLen c'.2`
+    follow automatically from cornerhood). -/
+private lemma mem_strictHookCells_of_isCorner {μ : YoungDiagram} {c' : ℕ × ℕ}
+    (hc' : isCorner μ c') (i j : ℕ) :
+    c' ∈ strictHookCells μ i j ↔
+      (i = c'.1 ∧ j < c'.2) ∨ (i < c'.1 ∧ j = c'.2) := by
+  obtain ⟨p, q⟩ := c'
+  rw [mem_strictHookCells_iff]
+  have hrl : μ.rowLen p = q + 1 := rowLen_of_isCorner hc'
+  have hcl : μ.colLen q = p + 1 := colLen_of_isCorner hc'
+  constructor
+  · rintro (⟨hpi, hjq, _⟩ | ⟨hip, hqj, _⟩)
+    · exact Or.inl ⟨hpi.symm, hjq⟩
+    · exact Or.inr ⟨hip, hqj.symm⟩
+  · rintro (⟨hip, hjq⟩ | ⟨hip, hjq⟩)
+    · refine Or.inl ⟨hip.symm, hjq, ?_⟩; rw [← hip, hrl]; omega
+    · refine Or.inr ⟨hip, hjq.symm, ?_⟩; rw [hjq, hcl]; omega
+
 /-- GNW walk probability: gnwProb μ c K x = probability that a GNW walk started at
     x ends at corner c, with K as a termination bound (correct when hookLen(x) ≤ K). -/
 noncomputable private def gnwProb (μ : YoungDiagram) (c : ℕ × ℕ) : ℕ → ℕ × ℕ → ℚ

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -924,3 +924,111 @@ File at 14022 lines remains beyond practical Docker 32GB build envelope. The edi
 2. Submit sorries 3–5 to Aristotle (likely fast proofs)
 3. Tackle `gnwProb_sum_corners` manually (standard induction on K, ~50 lines)
 4. `gnwProb_key` is the remaining hard mathematical content (GNW 1979)
+
+---
+
+## Session 2026-05-07 (Session 43) — Strong-induction wrapper closes IH sorry
+
+**Mode**: REVISIT (RICH, score 189; main has single-sorry gnwProb_key, fix/ballot-gnw-key has structural framework with two sub-sorries)
+**Outcome**: PROGRESS — strong induction wrapper proved; sorry count 1 → 1 but better-structured.
+
+### What I Did
+
+1. **Discovered `origin/fix/ballot-gnw-key`** — an unmerged branch with structural
+   improvements to `gnwProb_key` (commit `6590609fa80`):
+   - Adds `isCorner_removeCorner_of_ne`: distinct corners survive corner removal.
+   - Adds `gnwProb_exchange` (named sorry): the GNW 1979 exchange identity in
+     product form `F(μ,c)·H(μ\c)·H(μ\c') = F(μ\c',c)·H((μ\c')\c)·H(μ)`.
+   - Restructures multi-corner branch of `gnwProb_key` to use exchange + IH,
+     replacing one anonymous sorry with two named sub-sorries.
+
+2. **Cherry-picked the structural commit** onto `research/ballot-gnw-strong-induction`
+   from `origin/main`.
+
+3. **Closed the IH sorry** (line 14072 on the cherry-picked branch): replaced
+   ```
+   have h_IH : ... := by sorry  -- IH from strong induction
+   ```
+   with
+   ```
+   have h_IH := gnwProb_key (removeCorner μ c' hc') hc_in_rc'
+   ```
+   plus
+   ```
+   termination_by μ.card
+   decreasing_by
+     have hμpos : 0 < μ.card := Finset.card_pos.mpr ⟨c', hc'.1⟩
+     simp only [removeCorner_card hc']
+     omega
+   ```
+   The recursion is well-founded because `removeCorner μ c' hc'` has card `μ.card - 1`
+   (`removeCorner_card`), and `μ.card > 0` follows from `c' ∈ μ.cells` (via `hc'.1`).
+
+### Key Findings
+
+- The `termination_by`/`decreasing_by` pattern matches `hook_length_formula_Q`
+  in the main file (line 371-375): both use well-founded recursion on `μ.card`
+  via `removeCorner_card`. This is the canonical Lean 4 pattern for corner-recursion
+  proofs in this gallery.
+- After this session, the GNW route's structural framework is complete:
+  `hook_walk_identity_gnw → gnwProb_key → gnwProb_exchange (sorry)`.
+  Any future progress on `gnwProb_exchange` immediately closes the entire
+  hook-length formula sorry.
+- Sorry count remains 1 (gnwProb_exchange replaces the multi-corner sorry of
+  gnwProb_key). The structural quality is better: the remaining gap is now a
+  precisely-stated mathematical lemma (GNW exchange identity) rather than an
+  anonymous "TODO" inside a case-split.
+
+### gnwProb_exchange — what's still needed
+
+The single remaining sorry is `gnwProb_exchange`:
+```
+F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)
+```
+where `F(ν,d) = ∑_{x∈ν.cells} gnwProb ν d (h(x)) x` and `H = hookProd`.
+
+**Proof strategy** (from GNW 1979):
+1. Hook lengths under removeCorner: removing c' = (r', s') changes only the
+   hook lengths of cells in the arm of c' (row r', columns < s') by `-1` and
+   cells in the leg of c' (column s', rows < r') by `-1`. Other cells unchanged.
+2. F(μ,c) splits as the c' term + sum over `(removeCorner μ c').cells`.
+   The c' term is `gnwProb μ c (h_μ(c')) c'` (the gnwProb starting at c' itself).
+3. For x ≠ c', `gnwProb μ c (h_μ(x)) x` and
+   `gnwProb (μ\c') c (h_{μ\c'}(x)) x` differ only when x is in the arm or leg
+   of c' (where the hook length and strict-hook structure changes).
+4. Product form avoids division: H(μ\c)·H(μ\c') vs H((μ\c')\c)·H(μ) — both
+   sides equal H(μ \ {c, c'}) · (something). The "something" is the same on
+   both sides by hook-length parity (each cell's hook is either changed by 0,
+   -1, or -2 depending on whether it's affected by c, c', or both).
+5. Verified on small examples: L-shape {(0,0),(0,1),(1,0)} and (3,1).
+
+Estimated proof length: ~100 lines of arm/leg case analysis + arithmetic.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (14050 → 14126 lines):
+  - Cherry-picked structural framework from `origin/fix/ballot-gnw-key` (+94 lines)
+  - Replaced IH sorry with recursive call (-7 lines net)
+  - Added `termination_by`/`decreasing_by` clauses (+5 lines)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (rewrite for session 43)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (this entry)
+
+### Sorry Count: 1 → 1
+
+- ✓ CLOSED: IH from strong induction (now `gnwProb_key (removeCorner μ c' hc') hc_in_rc'`)
+- ✓ CLOSED: anonymous multi-corner sorry of gnwProb_key (now structurally proved
+  modulo `gnwProb_exchange`)
+- REMAINING: `gnwProb_exchange` (line 13871) — GNW 1979 hook-weight shift
+  identity, ~100 lines
+
+### Next Steps
+
+1. **Prove `gnwProb_exchange`.** This is now the sole obstacle to a complete
+   GNW proof of the hook-length formula. Strategy: arm/leg decomposition +
+   product-form telescoping (avoids division and probability theory imports).
+2. **Verify build under Docker.** Helpers file is at 14126 lines (was 14022
+   pre-modularization where Docker OOM'd at 32GB). Modular split should make
+   this buildable; CI on the PR will confirm.
+3. **Alternative: deterministic weighted-walk recasting** (~400 lines self-contained)
+   could avoid `gnwProb_exchange` entirely if the GNW 1979 argument resists
+   formalization.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,99 +1,99 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (GNW proof ready to implement)
+**Phase**: ACT (GNW exchange-step framework wired up)
 **Path**: full
 **Since**: 2026-04-21T20:08:44+02:00
-**Last Updated**: 2026-05-02
-**Iteration**: 35
+**Last Updated**: 2026-05-07
+**Iteration**: 43
 
 ## Current Focus
-Close the sole remaining `sorry` in `BallotProblemOQ03OQ01OQ02.lean` — the
-`hook_walk_identity` dispatcher branch covering Young diagrams with **≥10 rows
-AND ≥10 cols AND non-rectangular** (line 302 of the NEW 392-line file).
-
-**Modularization completed (session 35):** The 14022-line file has been split:
-- `BallotProblemOQ03OQ01OQ02Helpers.lean` (13645 lines, PARTS I-XXIV, 0 sorries)
-- `BallotProblemOQ03OQ01OQ02.lean` (392 lines, PART XXV + dispatcher + HLF, 1 sorry)
-
-The Docker build envelope is no longer a blocker. GNW Route A can be added
-directly to the 392-line Main file.
+Close `gnwProb_exchange` (Helpers, line 13871) — the GNW 1979 exchange identity
+in product form. This is now the SOLE remaining sorry-bearing lemma; the
+`hook_length_formula_general` dispatcher is sorry-free, and `gnwProb_key` for the
+multi-corner case is now structurally proved by well-founded recursion on
+`μ.card`, modulo `gnwProb_exchange` and `isCorner_removeCorner_of_ne`.
 
 ## Active Approach
-Three routes are characterised in
-`literature/closing-the-final-sorry.md` (session 33, 2026-04-27):
+Route A (GNW probabilistic hook-walk) is the chosen path; the proof skeleton is
+in place:
 
-- **Route A — Greene–Nijenhuis–Wilf probabilistic hook walk** (~300–400 lines).
-  Recommended path. Closes all remaining shapes in one argument and replaces
-  the row-by-row tower if reformulated. A deterministic recasting (counting
-  weighted hook walks) avoids `ProbabilityTheory` imports.
-- **Route B — Fomin growth diagrams / RSK**. Heavier infrastructure;
-  contributes the SYT ↔ NI-paths bijection separately documented as the
-  canonical-config LGV path in PART V comments.
-- **Route C — Continue row-by-row** (PART XXVII = exactly-10-row, ~2300 more
-  lines). Mechanical but rejected: each new row pushes the file further beyond
-  the build envelope; reaching ≥50 rows would require ~90 K lines.
-
-**Pre-requisite for ANY route:** modularize the file. Sessions 31–32 confirmed
-that PARTS XII–XXIII (~10 000 lines of row-by-row coverage) can be split into a
-dedicated module without disturbing PARTS I–XI (definitions, hook-product
-infrastructure) or the corner-recursion / `hook_length_formula_general` plumbing
-in PARTS XIII–XIV.
+1. **Single-corner case** of `gnwProb_key` (rectangles): PROVED (~144 lines,
+   arm/leg telescoping via `hookProd_ratio_formula`).
+2. **Multi-corner case** of `gnwProb_key`: PROVED modulo `gnwProb_exchange`,
+   using strong induction on `μ.card` (`termination_by μ.card`,
+   `decreasing_by removeCorner_card hc'; omega`).
+3. **`gnwProb_exchange`** (~100 lines, sorry'd): the GNW 1979 exchange
+   identity in product form
+   `F(μ,c)·H(μ\c)·H(μ\c') = F(μ\c',c)·H((μ\c')\c)·H(μ)`
+   for distinct corners c, c'. Proof requires careful analysis of how removing
+   c' shifts hook lengths in the arm/leg of c. Verified on small examples
+   (L-shape, (3,1)).
 
 ## Attempt Count
-- Total attempts: 33 (sessions 1–33; sessions 1–4 archived to
-  `sessions/`; sessions 5–33 in `knowledge.md`)
-- Current approach attempts: 0 (GNW route not yet attempted)
+- Total attempts: 43 (sessions 1–43; sessions 1–4 archived to
+  `sessions/`; sessions 5–43 in `knowledge.md`)
+- Current approach attempts: 7 (sessions 37–43 on GNW)
 - Approaches tried:
   1. LGV-determinant via `lgv_lemma_rxr` + Jacobi–Trudi (sessions 1–10) —
-     blocked on `ni_count_eq_syt_count` and `lgv_det_factors_as_hook_quotient`;
-     deleted as dead scaffolding in session 32.
+     dead scaffolding deleted in session 32.
   2. Corner recursion via `card_SYT_corner_step` + `hook_walk_identity`
      (sessions 11–14) — successful: gave `hook_length_formula_general`
-     modulo a single `hook_walk_identity` sorry.
+     modulo `hook_walk_identity`.
   3. Row-by-row dispatch on `hook_walk_identity` (sessions 15–30) —
      successful for ≤9 rows / ≤9 cols (transpose duality) / all rectangles;
      hit file-size wall at session 30.
-  4. Housekeeping: dead-code removal and LGV restatement as comments
-     (sessions 31–33).
+  4. Modularization (session 35) — split monolithic file into
+     `BallotProblemOQ03OQ01OQ02.lean` (main, 398 lines, 0 sorries) +
+     `BallotProblemOQ03OQ01OQ02Helpers.lean` (~14000 lines, 1 sorry) +
+     `BallotProblemOQ03OQ01OQ02Aristotle.lean` (companion, 113 lines).
+  5. GNW infrastructure (sessions 37–42) — added `strictHookCells`, `gnwProb`,
+     `gnwProb_step`, `gnwProb_stable`, `gnwProb_sum_corners`. Proved single-corner
+     case of `gnwProb_key`. Stated `gnwProb_exchange` and
+     `isCorner_removeCorner_of_ne`.
+  6. Strong induction wrapper (session 43) — wired `gnwProb_key` multi-corner
+     to `gnwProb_exchange` via `termination_by μ.card`; reduces remaining work
+     to a single sorry on `gnwProb_exchange`.
 
 ## Blockers
-- **File size beyond Docker envelope.** At 14022 lines
-  `BallotProblemOQ03OQ01OQ02.lean` cannot be type-checked under the standard
-  `./proofs/scripts/docker-build.sh` invocation (32 GB memory limit). All
-  edits since session 27 are *unverified by the build*. Modularization is
-  required before any further large additions.
-- **No probabilistic toolkit imported.** Route A in its classical form leans
-  on uniform sampling and conditional probability machinery from
-  `Mathlib.MeasureTheory` / `Mathlib.ProbabilityTheory`. Transitive import
-  weight may further worsen the build envelope problem; a deterministic
-  weighted-walk recasting is preferred.
+- **`gnwProb_exchange` proof.** This is the GNW 1979 hook-weight shift argument.
+  The proof requires showing that hookProd and the gnwProb sum transform
+  predictably when one corner c' is removed. Estimated ~100 lines of careful
+  case analysis on arm/leg of c vs c'.
+- **Build verification.** Helpers file is at 14126 lines; whether it
+  type-checks under Docker's 32GB memory limit (post-modularization) is
+  not yet confirmed in this session. CI will verify the PR.
 
 ## Next Action
-**OBSERVE → PLAN — file modularization, then GNW.**
+**ACT — prove `gnwProb_exchange`.**
 
-1. Map the dependency graph between PARTS in `BallotProblemOQ03OQ01OQ02.lean`
-   to identify a clean cut-line. Candidate split:
-   - `BallotProblemOQ03OQ01OQ02Core.lean` ← PARTS I–XI + XIII–XIV
-     (definitions, `hookProd`, `hookProd_ratio_formula`, corner recursion,
-     `hook_length_formula_general` modulo `hook_walk_identity`).
-   - `BallotProblemOQ03OQ01OQ02RowCases.lean` ← PARTS XII + XV–XXIII
-     (per-row dispatchers and `hook_walk_identity_*Row` lemmas).
-   - `BallotProblemOQ03OQ01OQ02.lean` (top-level): imports the two above,
-     re-exports `hook_length_formula` and `hook_length_formula_general`.
-2. Verify each part compiles independently (or at least the Core file does)
-   under Docker.
-3. Once the Core file builds, attempt Route A (deterministic GNW recasting)
-   in a fresh `BallotProblemOQ03OQ01OQ02HookWalk.lean` companion.
+1. Decompose `μ.cells = (removeCorner μ c').cells ∪ {c'}` and split the LHS sum
+   into the c' contribution + the rest.
+2. For x ≠ c', relate `gnwProb μ c (h(x)) x` to `gnwProb (μ\c') c (h(x)) x`
+   by analyzing how `strictHookCells x` changes when c' is removed
+   (changes only when x is in the arm/leg of c').
+3. The hook lengths satisfy:
+   - `h_{μ\c'}(r,c'.2) = h_μ(r,c'.2) - 1` for r < c'.1 (leg of c')
+   - `h_{μ\c'}(c'.1,s) = h_μ(c'.1,s) - 1` for s < c'.2 (arm of c')
+   - `h_{μ\c'}(x) = h_μ(x)` elsewhere
+4. The product
+   `H(μ)·H((μ\c')\c) = H(μ\c)·H(μ\c')` follows from a careful tally of the
+   doubly-affected cell `(c'.1,c.2)` (or similar boundary cells if c, c'
+   are adjacent in the appropriate sense).
 
-If modularization itself proves to be larger than a single session, scope down
-to extracting only the `hook_walk_identity_*Row` lemmas (PARTS XV–XXIII) into
-the row-cases module; the dispatcher itself stays in the main file as a thin
-case split.
+Alternative: a deterministic weighted-path recasting of GNW that avoids the
+exchange step entirely (count weighted walks of every length, divide by
+`μ.card · ∏ |strict hook|`); ~400 lines self-contained.
 
 ## References
 
 - `literature/closing-the-final-sorry.md` — three-route comparison (session 33)
-- `knowledge.md` §Session 32 — dead-code removal and LGV restatement
-- `knowledge.md` §Session 31 — file-size wall first hit
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean:13932` — the sole remaining sorry
+- `knowledge.md` §Session 35 — modularization decision and split
+- `knowledge.md` §Session 37 — GNW infrastructure: `gnwProb`, `gnwProb_sum_corners`
+- `knowledge.md` §Session 38 — `gnwProb_step` and stability
+- `knowledge.md` §Session 40-42 — single-corner case proof, exchange framework
+- `knowledge.md` §Session 43 — strong induction wrapper (this session)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:13871` — `gnwProb_exchange`
+  (sorry'd, target of next session)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:13884` — `gnwProb_key`
+  (proved modulo `gnwProb_exchange`)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS session 38: gnwProb_sum_corners, gnwProb_step, gnwProb_stable, hookLength_isCorner_one all PROVED (PR #15288). hook_walk_identity_gnw complete. Sole remaining sorry: gnwProb_key (GNW 1979 KEY theorem, hard combinatorial induction). Estimated 200-300 lines.",
+    "progressSummary": "PROGRESS session 43: GNW exchange-step framework complete. gnwProb_key multi-corner case now PROVED via well-founded recursion on μ.card (termination_by μ.card; decreasing_by removeCorner_card). Sole remaining sorry: gnwProb_exchange (GNW 1979 hook-weight shift identity in product form, ~100 lines). hook_walk_identity_gnw → gnwProb_key → gnwProb_exchange chain is structurally complete.",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -142,7 +142,9 @@
       "gnwProb_step proved in BallotProblemOQ03OQ01OQ02Helpers.lean:13822-13839 (PR #15288)",
       "gnwProb_stable proved in BallotProblemOQ03OQ01OQ02Helpers.lean:13843-13851 (PR #15288)",
       "hook_walk_identity_gnw proved in BallotProblemOQ03OQ01OQ02Helpers.lean:13877-13896 (uses gnwProb_key which is sorry)",
-      "strictHookCells_card proved: cardinality = hookLength - 1, using Finset.Ico image + disjointness argument (PR #15288)"
+      "strictHookCells_card proved: cardinality = hookLength - 1, using Finset.Ico image + disjointness argument (PR #15288)",
+      "Cherry-picked exchange framework (isCorner_removeCorner_of_ne, gnwProb_exchange, multi-corner proof skeleton) from origin/fix/ballot-gnw-key onto research/ballot-gnw-strong-induction.",
+      "Closed IH sorry in gnwProb_key by replacing 'have h_IH := by sorry' with 'have h_IH := gnwProb_key (removeCorner μ c' hc') hc_in_rc'' + termination_by μ.card / decreasing_by clause."
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -232,7 +234,10 @@
       "gnwProb_key is the SOLE remaining sorry -- the GNW 1979 KEY theorem -- requires exchange argument or direct induction on |mu|",
       "gnwProb_key for rectangles (single corner): gnwProb_sum_corners gives gnwProb=1 for all x, so sum = |mu| = hookProd(mu)/hookProd(mu\\c) by hook_walk_identity_rectYD",
       "gnwProb_key for non-rectangles requires the GNW exchange argument: estimated 200-300 lines of Lean, needs careful study of GNW 1979 paper",
-      "Exchange identity attempt disproved: gnwProb_mu(c,K,x) != gnwProb_{mu\\c'}(c,K,x) in general -- counterexample on {(0,0),(0,1),(1,0)} with c=(1,0),c'=(0,1): mu gives 1/2, mu\\c' gives 1"
+      "Exchange identity attempt disproved: gnwProb_mu(c,K,x) != gnwProb_{mu\\c'}(c,K,x) in general -- counterexample on {(0,0),(0,1),(1,0)} with c=(1,0),c'=(0,1): mu gives 1/2, mu\\c' gives 1",
+      "gnwProb_key multi-corner case reduces to gnwProb_exchange + IH on μ\\c'; well-founded recursion via termination_by μ.card matches the hook_length_formula_Q pattern in the main file.",
+      "gnwProb_exchange product form F(μ,c)·H(μ\\c)·H(μ\\c') = F(μ\\c',c)·H((μ\\c')\\c)·H(μ) avoids division and probability theory imports; provable by arm/leg decomposition + hook-length shift.",
+      "Cherry-picking origin/fix/ballot-gnw-key (commit 6590609fa80) gives the structural framework; the IH sorry then closes via direct recursive call once termination_by μ.card is added."
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
@@ -240,11 +245,9 @@
       "BallotProblemOQ03.lean regression (omega failure near minSharedStepIdx_preserved) blocks all builds"
     ],
     "nextSteps": [
-      "Study GNW 1979 paper (Greene-Nijenhuis-Wilf, J. Combin. Theory Ser. A 1979) for the actual exchange argument proof",
-      "Prove gnwProb_key for rectangles using: gnwProb_sum_corners (corners(mu)={c} -> gnwProb=1) + hook_walk_identity_rectYD",
-      "Prove gnwProb_key for non-rectangles: formalize GNW 1979 induction on |mu| using corners(mu) has >=2 elements",
-      "Key lemma needed: hookProd ratio formula -- hookProd(mu)/hookProd(mu\\c) = Pi_{y in preHook(c)} hookLen(y)/(hookLen(y)-1)",
-      "Consider Aristotle submission for gnwProb_key -- it is a HARD sorry with known proof"
+      "Prove gnwProb_exchange (Helpers line 13871): GNW 1979 hook-weight shift identity. ~100 lines via arm/leg decomposition + hookProd product-form analysis.",
+      "Verify Docker build on the modular file structure (Helpers at 14126 lines, was 14022 pre-modularization at OOM threshold). CI on the session-43 PR will confirm buildability.",
+      "Consider deterministic weighted-walk recasting (~400 lines self-contained) as alternative to gnwProb_exchange if direct proof is intractable."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Wires up strong induction on `μ.card` for `gnwProb_key`'s multi-corner case,
closing the IH sub-sorry. The GNW route's structural framework is now complete:

```
hook_walk_identity_gnw → gnwProb_key → gnwProb_exchange (sorry)
```

The remaining single sorry — `gnwProb_exchange` — is the GNW 1979 hook-weight
shift identity in product form (~100 lines via arm/leg decomposition).

## Changes

This branch contains two commits:

1. **`feat(ballot-gnw): add exchange lemma + structured multi-corner proof framework`**
   — cherry-picked from `origin/fix/ballot-gnw-key` (commit `6590609fa80`).
   Adds `isCorner_removeCorner_of_ne`, `gnwProb_exchange` (sorry'd), and
   restructures `gnwProb_key`'s multi-corner branch to use exchange + IH.

2. **`research(ballot-gnw-key): close IH sorry via well-founded recursion on μ.card`**
   (this session's contribution) — replaces the IH sub-sorry with a recursive
   call to `gnwProb_key (removeCorner μ c' hc') hc_in_rc'` and adds
   `termination_by μ.card` / `decreasing_by` clauses.

## Pattern

The decreasing-by clause matches `hook_length_formula_Q` in the main file
(`BallotProblemOQ03OQ01OQ02.lean:371-375`):

```lean
termination_by μ.card
decreasing_by
  have hμpos : 0 < μ.card := Finset.card_pos.mpr ⟨c', hc'.1⟩
  simp only [removeCorner_card hc']
  omega
```

`hc'.1 : c' ∈ μ.cells` (from `isCorner μ c'`) gives `μ.card > 0`, then
`removeCorner_card hc'` rewrites `(removeCorner μ c' hc').card` to `μ.card - 1`.

## Sorry Accounting

- Before: 1 sorry (`gnwProb_key` multi-corner case, anonymous TODO).
- After: 1 sorry (`gnwProb_exchange` — precisely-stated GNW 1979 identity).

Net count is unchanged; structural quality improved.

## Files

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (14050 → 14126 lines, +76)
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (refresh for session 43)
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (session 43 entry)
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json`
  (progressSummary, insights, builtItems, nextSteps)

## Verification

This session did **not** run a Docker build; the Helpers file at 14126 lines
is at the boundary of the 32 GB build envelope (the pre-modularization
14022-line monolith OOM'd; whether the post-modularization Helpers file
type-checks alone is the question). CI on this PR will confirm.

## Next Steps

1. Prove `gnwProb_exchange` (Helpers `:13871`) — the sole remaining sorry.
   Strategy: arm/leg decomposition + hookProd product-form analysis.
2. Or pursue a deterministic weighted-walk recasting (~400 lines self-contained)
   that bypasses `gnwProb_exchange`.

## Test plan

- [ ] CI Docker build of `Proofs.BallotProblemOQ03OQ01OQ02Helpers` succeeds
- [ ] `pnpm build` succeeds with updated meta.json
- [ ] No regressions in other proof files

🤖 Generated by researcher-4 (Claude Opus 4.7)