### PR TITLE
research(sperner-ndim-mathlib-oq-02): swap to panchromatic axiom (Lipschitz-free)

### DIFF
--- a/proofs/Proofs/SpernerNDimMathlibOQ02.lean
+++ b/proofs/Proofs/SpernerNDimMathlibOQ02.lean
@@ -23,20 +23,37 @@ where `supp(v) = {i : vᵢ > 0}`. This is well-defined (some index in `supp(v)` 
 condition (`c(v) ∈ supp(v)`, so if `vⱼ = 0` then `c(v) ≠ j`).
 
 **Step 2 (axiom)**: By Sperner's lemma applied to the Nth grid triangulation of `Δⁿ`,
-each subdivision has a fully-colored simplex, yielding a near-fixed-point `x ∈ Δⁿ`
-with `|f(x)ᵢ - xᵢ| ≤ (n+1)/(N+1)` for all `i`.
+each subdivision yields a *panchromatic* simplex — `n+1` vertices `v₀, ..., vₙ`,
+one per color, each satisfying `f(vᵢ)ᵢ ≤ (vᵢ)ᵢ`, with all vertices within
+diameter `(n+1)/(N+1)` of each other.
 
-**Step 3 (proved here)**: By compactness of `Δⁿ`, the sequence of near-fixed-points has a
-convergent subsequence. By continuity of `f`, the limit is an exact fixed point.
+**Step 3 (proved here)**: By compactness of `Δⁿ`, the first vertices of the
+sequence of panchromatic tuples have a convergent subsequence with limit `x*`.
+The diameter bound forces every vertex of the same tuple to converge to the
+same limit. The per-color inequalities pass to the limit by continuity:
+`f(x*)ᵢ ≤ x*ᵢ` for all `i`. Summing and using `Σ f(x*)ᵢ = 1 = Σ x*ᵢ`, all
+inequalities must be equalities, giving `f(x*) = x*`.
+
+## Why panchromatic, not single near-fixed-point
+
+A "near-fixed-point" formulation `∃ x, ∀ i, |f(x)ᵢ - xᵢ| ≤ ε` would require
+**Lipschitz continuity** of `f` to derive: extracting a per-coordinate bound
+at a single `x` from a fully-colored simplex requires comparing `f(x)` to
+`f(vᵢ)` for each color-`i` vertex `vᵢ`, which costs a Lipschitz factor. The
+panchromatic formulation gives the *raw* Sperner output: one inequality per
+distinct vertex, with a diameter bound. Continuity alone (no Lipschitz)
+suffices to derive the fixed point.
 
 ## Axiom justification (1 remaining)
 
-`sperner_near_fixed_point`: Follows from (a) the Nth grid triangulation of `Δⁿ`
+`sperner_panchromatic`: Follows from (a) the Nth grid triangulation of `Δⁿ`
   (vertices `{(a₀/N,...,aₙ/N) : Σaᵢ=N, aᵢ ∈ ℕ}`, simplices from ordered chains),
-  (b) the proved Sperner boundary condition `spernerColor_ne_of_zero`, and
-  (c) abstract Sperner's lemma (`SpernerAbstract.sperner` in SpernerNDimMathlib.lean).
-  The grid CellComplex instance is structurally identical to `SpernerGrid.lean` but with
-  a fixed adjacency that correctly handles cross-miss neighbors.
+  (b) the proved Sperner boundary condition `spernerColor_ne_of_zero` /
+  `spernerColorMap_boundary`, and (c) abstract Sperner's lemma
+  (`SpernerAbstract.sperner` in SpernerNDimMathlib.lean).
+  The output is `n+1` distinct grid vertices of the panchromatic top-simplex,
+  one per color, with the color-`i` inequality at vertex `i` and diameter
+  bounded by the grid mesh `(n+1)/(N+1)`.
 
 ## Main results
 
@@ -46,8 +63,8 @@ convergent subsequence. By continuity of `f`, the limit is an exact fixed point.
 * `SpernerBrouwer.spernerColor_in_supp`: color lies in support (Sperner condition)
 * `SpernerBrouwer.spernerColor_le`: the coloring index satisfies `f(v)ᵢ ≤ vᵢ`
 * `SpernerBrouwer.spernerColor_ne_of_zero`: face boundary condition
-* `SpernerBrouwer.sperner_near_fixed_point`: near-fixed-point from Sperner (axiom)
-* `SpernerBrouwer.fixed_point_from_approx`: exact fixed point from approximations (proved)
+* `SpernerBrouwer.sperner_panchromatic`: panchromatic tuple from grid Sperner (axiom)
+* `SpernerBrouwer.brouwer_from_panchromatic`: fixed point from panchromatic tuples (proved)
 * `SpernerBrouwer.brouwer_fixed_point_simplex`: **Brouwer's theorem for `Δⁿ`**
 
 ## Tags
@@ -186,101 +203,141 @@ theorem spernerColorMap_boundary
   spernerColor_ne_of_zero hv (hf_map v hv) hvj
 
 -- ============================================================
--- SECTION IV: From Sperner to Brouwer
+-- SECTION IV: From Sperner to Brouwer (via panchromatic tuples)
 -- ============================================================
 
-/-- **Axiom (Grid Sperner → Near-Fixed-Point)**: For each `N`, the Nth grid
-    triangulation of `Δⁿ` with the Sperner coloring derived from `f` yields a near-fixed-point
-    with `|f(x)ᵢ - xᵢ| ≤ (n+1)/(N+1)` for all `i`.
+/-- **Axiom (Grid Sperner → Panchromatic Tuple)**: For each `N`, the Nth grid
+    triangulation of `Δⁿ` with the Sperner coloring derived from `f` yields a
+    *panchromatic simplex*: `n+1` vertices in `Δⁿ`, one per color, each
+    satisfying its color-`i` inequality `f(vᵢ)ᵢ ≤ (vᵢ)ᵢ`, and all within
+    pairwise coordinate gap `(n+1)/(N+1)`.
 
     **Justification**: Partition `Δⁿ` into small simplices with vertices
       `{(a₀/N,...,aₙ/N) : aᵢ ∈ ℕ, Σaᵢ = N}` (the Nth grid triangulation).
     Apply the Sperner coloring `c(v) = spernerColorMap f hf_map v hv`.
     By `spernerColorMap_boundary`, this satisfies the Sperner boundary condition.
     By abstract Sperner's lemma (`SpernerAbstract.sperner` in SpernerNDimMathlib.lean),
-    a fully-colored simplex exists with near-fixed-point bound (n+1)/(N+1). -/
-axiom sperner_near_fixed_point (n N : ℕ)
+    a fully-colored (panchromatic) simplex exists. Two grid vertices share a
+    grid simplex of edge length `1/N`, so each pairwise coordinate gap is
+    bounded by `1/N ≤ (n+1)/(N+1)` (loose bound used here for convenience).
+
+    **Why panchromatic, not single-point**: extracting per-coordinate bounds
+    `|f(x)ᵢ - xᵢ| ≤ ε` at a single `x` from a fully-colored simplex requires
+    Lipschitz continuity (to relate `f` at different vertices to `f` at one
+    point). The panchromatic formulation provides the *raw* Sperner output:
+    one one-sided inequality per vertex. The diameter bound + continuity is
+    enough to derive a fixed point without Lipschitz. -/
+axiom sperner_panchromatic (n N : ℕ)
     (f : (Fin (n + 1) → ℝ) → Fin (n + 1) → ℝ)
     (hf_map : ∀ v, InSimplex v → InSimplex (f v)) :
-    ∃ x : Fin (n + 1) → ℝ, InSimplex x ∧
-      ∀ i : Fin (n + 1), |f x i - x i| ≤ (n + 1 : ℝ) / (N + 1)
+    ∃ v : Fin (n + 1) → Fin (n + 1) → ℝ,
+      (∀ i, InSimplex (v i)) ∧
+      (∀ i : Fin (n + 1), f (v i) i ≤ v i i) ∧
+      (∀ (i j : Fin (n + 1)) (l : Fin (n + 1)),
+          |v i l - v j l| ≤ (n + 1 : ℝ) / ((N : ℝ) + 1))
 
-/-- **Theorem (Compactness → Fixed Point)**: Given approximate fixed points with error → 0,
-    there exists an exact fixed point.
+/-- **Theorem (Panchromatic → Fixed Point)**: Given a sequence of panchromatic
+    tuples whose pairwise diameter shrinks to 0, there exists a fixed point of `f`.
 
-    **Proof**: The simplex `Δⁿ` is compact (closed subset of `[0,1]^(n+1)`). The sequence
-    of approximate fixed points has a convergent subsequence `xφ(k) → x*` by sequential
-    compactness (`IsCompact.tendsto_subseq`). By continuity of `f`, `f(xφ(k)) → f(x*)`.
-    Also `f(xφ(k)) → x*` because `|f(xφ(k))ᵢ - xφ(k)ᵢ| ≤ (n+1)/(φ(k)+1) → 0` (squeeze).
-    By uniqueness of limits (`tendsto_nhds_unique`), `f(x*) = x*`. -/
-theorem fixed_point_from_approx {n : ℕ}
+    **Proof**: The simplex `Δⁿ` is compact. Take the first vertex of each
+    panchromatic tuple to form a sequence in `Δⁿ`; extract a convergent
+    subsequence `v_{φ(k)}⁰ → x*` (sequential compactness). By the diameter
+    bound, every other vertex `v_{φ(k)}ⁱ` of the same tuple converges to the
+    same limit `x*`. By continuity, `f(v_{φ(k)}ⁱ) → f(x*)`. The Sperner
+    inequality `f(v_{φ(k)}ⁱ)ᵢ ≤ (v_{φ(k)}ⁱ)ᵢ` passes to the limit:
+    `f(x*)ᵢ ≤ x*ᵢ` for all `i`. Summing over `i`: `Σ f(x*)ᵢ ≤ Σ x*ᵢ`. But
+    both sums equal `1` (since `f(x*), x* ∈ Δⁿ`), so all inequalities are
+    equalities, i.e., `f(x*) = x*`. -/
+theorem brouwer_from_panchromatic {n : ℕ}
     (f : (Fin (n + 1) → ℝ) → Fin (n + 1) → ℝ)
     (hf_cont : Continuous f)
     (hf_map : ∀ v, InSimplex v → InSimplex (f v))
-    (happrox : ∀ N : ℕ, ∃ x : Fin (n + 1) → ℝ,
-        InSimplex x ∧ ∀ i : Fin (n + 1), |f x i - x i| ≤ (n + 1 : ℝ) / (N + 1)) :
+    (happrox : ∀ N : ℕ, ∃ v : Fin (n + 1) → Fin (n + 1) → ℝ,
+        (∀ i, InSimplex (v i)) ∧
+        (∀ i : Fin (n + 1), f (v i) i ≤ v i i) ∧
+        (∀ (i j : Fin (n + 1)) (l : Fin (n + 1)),
+            |v i l - v j l| ≤ (n + 1 : ℝ) / ((N : ℝ) + 1))) :
     ∃ x : Fin (n + 1) → ℝ, InSimplex x ∧ f x = x := by
-  -- Step 1: The simplex Δⁿ is compact
+  -- Step 1: The simplex Δⁿ is compact (closed subset of [0,1]^(n+1))
   have hS_compact : IsCompact {v : Fin (n + 1) → ℝ | InSimplex v} := by
     apply IsCompact.of_isClosed_subset (isCompact_univ_pi (fun _ => isCompact_Icc))
-    · -- Closed: ⋂ᵢ{v | 0 ≤ vᵢ} ∩ {v | Σvᵢ = 1}
-      have heq : {v : Fin (n + 1) → ℝ | InSimplex v} =
+    · have heq : {v : Fin (n + 1) → ℝ | InSimplex v} =
           (⋂ i, {v | (0 : ℝ) ≤ v i}) ∩ {v | ∑ i : Fin (n + 1), v i = 1} := by
         ext v; simp [InSimplex, Set.mem_iInter]
       rw [heq]
       exact (isClosed_iInter fun i =>
         isClosed_le continuous_const (continuous_apply i)).inter
         (isClosed_eq (continuous_finset_sum _ fun i _ => continuous_apply i) continuous_const)
-    · -- Subset of [0,1]^(n+1): vᵢ ≥ 0 and vᵢ ≤ Σvⱼ = 1
-      intro v ⟨hnn, hsum⟩
+    · intro v ⟨hnn, hsum⟩
       simp only [Set.mem_pi, Set.mem_univ, Set.mem_Icc, forall_const]
       exact fun i => ⟨hnn i,
         (Finset.single_le_sum (fun j _ => hnn j) (Finset.mem_univ i)).trans hsum.le⟩
-  -- Step 2: Approximate fixed point sequence u N = (happrox N).choose
-  let u : ℕ → Fin (n + 1) → ℝ := fun N => (happrox N).choose
-  have hu_mem : ∀ N, u N ∈ {v : Fin (n + 1) → ℝ | InSimplex v} :=
-    fun N => (happrox N).choose_spec.1
-  have hu_bound : ∀ N i, |f (u N) i - u N i| ≤ (n + 1 : ℝ) / ((N : ℝ) + 1) :=
-    fun N i => (happrox N).choose_spec.2 i
-  -- Step 3: Sequential compactness → convergent subsequence u ∘ φ → x
-  obtain ⟨x, hx_mem, φ, hφ_mono, hφ_conv⟩ := hS_compact.tendsto_subseq hu_mem
+  -- Step 2: Choose a panchromatic tuple for each N
+  let u : ℕ → Fin (n + 1) → Fin (n + 1) → ℝ := fun N => (happrox N).choose
+  have hu_mem : ∀ N i, InSimplex (u N i) := fun N i => (happrox N).choose_spec.1 i
+  have hu_color : ∀ N i, f (u N i) i ≤ u N i i :=
+    fun N i => (happrox N).choose_spec.2.1 i
+  have hu_diam : ∀ N i j l,
+      |u N i l - u N j l| ≤ (n + 1 : ℝ) / ((N : ℝ) + 1) :=
+    fun N i j l => (happrox N).choose_spec.2.2 i j l
+  -- Step 3: First vertices live in compact Δⁿ — extract convergent subsequence
+  let v0 : ℕ → Fin (n + 1) → ℝ := fun N => u N 0
+  have hv0_mem : ∀ N, v0 N ∈ {v : Fin (n + 1) → ℝ | InSimplex v} :=
+    fun N => hu_mem N 0
+  obtain ⟨x, hx_mem, φ, hφ_mono, hφ_conv⟩ := hS_compact.tendsto_subseq hv0_mem
   refine ⟨x, hx_mem, ?_⟩
-  -- Step 4a: f(u(φk)) → f(x) by continuity
-  have hfconv : Filter.Tendsto (fun k => f (u (φ k))) Filter.atTop (nhds (f x)) :=
-    (hf_cont.tendsto x).comp hφ_conv
-  -- Step 4b: f(u(φk)) → x via squeeze (|f - id| bounded by (n+1)/(φk+1) → 0)
-  have hfconv2 : Filter.Tendsto (fun k => f (u (φ k))) Filter.atTop (nhds x) := by
-    -- (φk + 1) → ∞ since φ strictly monotone implies φk ≥ k
-    have h_phi_atTop : Filter.Tendsto (fun k : ℕ => (φ k : ℝ) + 1)
-        Filter.atTop Filter.atTop := by
-      apply Filter.tendsto_atTop_atTop.mpr
-      intro b
-      exact ⟨⌈b⌉₊, fun k hk => by
-        have hkphi : (k : ℝ) ≤ φ k := by exact_mod_cast hφ_mono.id_le k
-        linarith [Nat.le_ceil b, show (⌈b⌉₊ : ℝ) ≤ k from by exact_mod_cast hk]⟩
-    -- (n+1)/(φk+1) → 0 since denominator → ∞
-    have h_bound_zero : Filter.Tendsto (fun k => (n + 1 : ℝ) / ((φ k : ℝ) + 1))
-        Filter.atTop (nhds 0) :=
-      tendsto_const_nhds.div_atTop h_phi_atTop
-    -- f(u(φk)) - u(φk) → 0 coordinatewise by squeeze
-    have h_diff_zero : Filter.Tendsto (fun k => f (u (φ k)) - u (φ k))
+  -- Step 4: (n+1)/(φk+1) → 0 since φ is strictly monotone (so φk ≥ k → ∞)
+  have h_phi_atTop : Filter.Tendsto (fun k : ℕ => (φ k : ℝ) + 1)
+      Filter.atTop Filter.atTop := by
+    apply Filter.tendsto_atTop_atTop.mpr
+    intro b
+    exact ⟨⌈b⌉₊, fun k hk => by
+      have hkphi : (k : ℝ) ≤ φ k := by exact_mod_cast hφ_mono.id_le k
+      linarith [Nat.le_ceil b, show (⌈b⌉₊ : ℝ) ≤ k from by exact_mod_cast hk]⟩
+  have h_bound_zero : Filter.Tendsto (fun k => (n + 1 : ℝ) / ((φ k : ℝ) + 1))
+      Filter.atTop (nhds 0) :=
+    tendsto_const_nhds.div_atTop h_phi_atTop
+  -- Step 5: For each i, u(φk) i → x via diameter bound applied to v0(φk) → x
+  have hu_conv : ∀ i,
+      Filter.Tendsto (fun k => u (φ k) i) Filter.atTop (nhds x) := by
+    intro i
+    have h_diff : Filter.Tendsto (fun k => u (φ k) i - u (φ k) 0)
         Filter.atTop (nhds 0) := by
       rw [tendsto_pi_nhds]
-      intro i
+      intro l
       simp only [Pi.sub_apply, Pi.zero_apply]
       exact squeeze_zero_norm
-        (fun k => by rw [Real.norm_eq_abs]; exact hu_bound (φ k) i)
+        (fun k => by rw [Real.norm_eq_abs]; exact hu_diam (φ k) i 0 l)
         h_bound_zero
-    -- u(φk) + (f(u(φk)) - u(φk)) = f(u(φk)) → x + 0 = x
-    have hsum := hφ_conv.add h_diff_zero
+    have hsum := hφ_conv.add h_diff
     rw [add_zero] at hsum
-    exact hsum.congr' (by
-      filter_upwards with k
-      funext i
-      simp only [Function.comp, Pi.add_apply, Pi.sub_apply]
+    exact hsum.congr (fun k => by
+      funext l
+      simp only [Function.comp_apply, Pi.add_apply, Pi.sub_apply, v0]
       ring)
-  -- Step 5: Uniqueness of limits gives f(x) = x
-  exact tendsto_nhds_unique hfconv hfconv2
+  -- Step 6: For each i, f(u(φk) i) i ≤ u(φk) i i, pass to limit ⇒ f(x) i ≤ x i
+  have hf_le : ∀ i, f x i ≤ x i := by
+    intro i
+    have h_apply_i : Continuous (fun y : Fin (n + 1) → ℝ => y i) := continuous_apply i
+    have hf_apply : Continuous (fun y : Fin (n + 1) → ℝ => f y i) :=
+      h_apply_i.comp hf_cont
+    have hfconv : Filter.Tendsto (fun k => f (u (φ k) i) i)
+        Filter.atTop (nhds (f x i)) :=
+      (hf_apply.tendsto x).comp (hu_conv i)
+    have hxconv : Filter.Tendsto (fun k => u (φ k) i i)
+        Filter.atTop (nhds (x i)) :=
+      (h_apply_i.tendsto x).comp (hu_conv i)
+    exact le_of_tendsto_of_tendsto' hfconv hxconv (fun k => hu_color (φ k) i)
+  -- Step 7: Σ f(x) i ≤ Σ x i, both sums equal 1, so all inequalities are equalities
+  have hfx_mem : InSimplex (f x) := hf_map x hx_mem
+  have hsum_eq : ∑ i, f x i = ∑ i, x i := by rw [hfx_mem.2, hx_mem.2]
+  funext i
+  by_contra hne
+  have hlt : f x i < x i := lt_of_le_of_ne (hf_le i) hne
+  have : ∑ j, f x j < ∑ j, x j :=
+    Finset.sum_lt_sum (fun j _ => hf_le j) ⟨i, Finset.mem_univ i, hlt⟩
+  rw [hsum_eq] at this
+  exact lt_irrefl _ this
 
 -- ============================================================
 -- SECTION V: Main Theorem
@@ -293,7 +350,7 @@ theorem brouwer_fixed_point_simplex {n : ℕ}
     (hf_cont : Continuous f)
     (hf_map : ∀ v, InSimplex v → InSimplex (f v)) :
     ∃ x : Fin (n + 1) → ℝ, InSimplex x ∧ f x = x :=
-  fixed_point_from_approx f hf_cont hf_map
-    (fun N => sperner_near_fixed_point n N f hf_map)
+  brouwer_from_panchromatic f hf_cont hf_map
+    (fun N => sperner_panchromatic n N f hf_map)
 
 end SpernerBrouwer

--- a/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "sperner-ndim-mathlib-oq-02",
   "title": "Brouwer's Fixed-Point Theorem via Sperner's Lemma",
   "slug": "sperner-ndim-mathlib-oq-02",
-  "description": "Answers OQ-02 from sperner-ndim-mathlib: prove Brouwer's fixed-point theorem for the standard n-simplex using Sperner's lemma. The Sperner coloring well-definedness and boundary condition are fully proved. The compactness convergence step (Δⁿ compact → convergent subsequence → exact fixed point) is proved via IsCompact.tendsto_subseq + squeeze. Only the grid triangulation application of Sperner remains axiomatized.",
+  "description": "Answers OQ-02 from sperner-ndim-mathlib: prove Brouwer's fixed-point theorem for the standard n-simplex using Sperner's lemma. The Sperner coloring well-definedness and boundary condition are fully proved. The single remaining axiom (sperner_panchromatic) provides the raw output of grid Sperner — n+1 vertices, one per color, with diameter bound — exactly what Sperner's lemma supplies. The fixed-point extraction (brouwer_from_panchromatic) is fully proved using compactness, the diameter bound, and one-sided limit passage; no Lipschitz hypothesis is needed.",
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
@@ -20,8 +20,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 299,
-    "assumptions": "One axiom: sperner_near_fixed_point — for each N, the Nth grid triangulation of Δⁿ with the Sperner coloring (proved to satisfy the boundary condition) yields a near-fixed-point with error ≤ (n+1)/(N+1). The compactness convergence step (fixed_point_from_approx) is now fully proved using IsCompact.tendsto_subseq + squeeze_zero_norm + tendsto_nhds_unique.",
+    "lineCount": 356,
+    "assumptions": "One axiom: sperner_panchromatic — for each N, the Nth grid triangulation of Δⁿ with the proved Sperner coloring yields a panchromatic simplex: n+1 vertices in Δⁿ, one per color, each satisfying its color-i inequality f(vᵢ)ᵢ ≤ (vᵢ)ᵢ, with all vertices within pairwise coordinate gap (n+1)/(N+1). This is the raw output of grid Sperner; no Lipschitz hypothesis is needed because brouwer_from_panchromatic uses one-sided per-vertex bounds plus a diameter bound, not per-coordinate bounds at a single point.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -35,7 +35,7 @@
       "spernerColor_ne_of_zero: Sperner boundary condition — c(v) ≠ j if v j = 0 (proved)",
       "spernerColorMap_boundary: boundary condition for the full coloring map (proved)",
       "brouwer_fixed_point_simplex: Brouwer's fixed-point theorem for Δⁿ (proved from 1 axiom)",
-      "fixed_point_from_approx: compactness argument proved via IsCompact.tendsto_subseq + squeeze_zero_norm + tendsto_nhds_unique"
+      "brouwer_from_panchromatic: Lipschitz-free fixed-point extraction from panchromatic tuples — compactness + diameter bound + one-sided limit passage + sum equality"
     ],
     "theoremCount": 13,
     "definitionCount": 5
@@ -44,7 +44,7 @@
     "path": "Proofs/SpernerNDimMathlibOQ02.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 299,
+    "lineCount": 356,
     "theoremCount": 13,
     "definitionCount": 5,
     "isAristotle": false,
@@ -53,11 +53,12 @@
   "overview": {
     "historicalContext": "Brouwer's fixed-point theorem (1911) is one of the central results of topology. The combinatorial proof via Sperner's lemma, due to various authors in the 1920s–1940s and made widely accessible by Knaster–Kuratowski–Mazurkiewicz (1929), shows that the theorem can be derived from elementary combinatorics without algebraic topology. This formalization follows the simplex version: Δⁿ = {x : Fin(n+1) → ℝ | all xᵢ ≥ 0, Σxᵢ = 1}.",
     "mathematicalSignificance": "The Sperner-based proof is notable because it avoids homology theory and works with the simplex directly. The key insight is the coloring construction: for f: Δⁿ → Δⁿ, color vertex v with c(v) = min{i ∈ supp(v) : f(v)ᵢ ≤ vᵢ}. The well-definedness is a pure arithmetic fact (proved here with 0 sorries), and the Sperner boundary condition follows immediately from the support structure.",
-    "proofStrategy": "1. Define the Sperner coloring c(v) = min{i ∈ supp(v) : f(v)ᵢ ≤ vᵢ} where supp(v) = {i : vᵢ > 0}. 2. Prove well-definedness: since Σf(v)ᵢ = 1 = Σvᵢ and f(v)ᵢ ≥ 0 = vᵢ for i ∉ supp(v), some index in supp(v) must satisfy f(v)ᵢ ≤ vᵢ. 3. Prove Sperner boundary condition: if vⱼ = 0 then j ∉ supp(v), so c(v) ≠ j. 4. Apply abstract Sperner's lemma (SpernerNDimMathlib.lean) to each Nth subdivision to get a fully-colored simplex. 5. Pass to a convergent subsequence (Δⁿ compact) to get an exact fixed point.",
+    "proofStrategy": "1. Define the Sperner coloring c(v) = min{i ∈ supp(v) : f(v)ᵢ ≤ vᵢ} where supp(v) = {i : vᵢ > 0}. 2. Prove well-definedness: since Σf(v)ᵢ = 1 = Σvᵢ and f(v)ᵢ ≥ 0 = vᵢ for i ∉ supp(v), some index in supp(v) must satisfy f(v)ᵢ ≤ vᵢ. 3. Prove Sperner boundary condition: if vⱼ = 0 then j ∉ supp(v), so c(v) ≠ j. 4. (axiom) Apply abstract Sperner's lemma (SpernerNDimMathlib.lean) to the Nth grid triangulation to get a panchromatic simplex — n+1 vertices, one per color, each satisfying its color-i inequality, with diameter ≤ (n+1)/(N+1). 5. Take the first vertex of each tuple as a sequence in Δⁿ; extract a convergent subsequence. The diameter bound forces all vertices of the same tuple to share the same limit x*. By continuity, the per-color inequalities pass to the limit: f(x*)ᵢ ≤ x*ᵢ. Summing and using Σf(x*)ᵢ = 1 = Σx*ᵢ forces all inequalities to be equalities, giving f(x*) = x*.",
     "keyInsights": [
       "The coloring well-definedness is purely algebraic: if f(v)ᵢ > vᵢ for all i ∈ supp(v) and f(v)ᵢ ≥ 0 = vᵢ for i ∉ supp(v), then Σf(v)ᵢ > Σvᵢ = 1, contradicting Σf(v)ᵢ = 1. This is proved rigorously using Finset.sum_lt_sum.",
       "The Sperner boundary condition (c(v) ∈ supp(v)) follows immediately from the definition: the colorSet is a subset of supp(v), so the minimum element lies in supp(v). If vⱼ = 0 then j ∉ supp(v), hence c(v) ≠ j.",
-      "The fully-colored simplex from Sperner gives an approximate fixed point: if vertex vᵢ has color i, then f(vᵢ)ᵢ ≤ (vᵢ)ᵢ. As the subdivision mesh → 0, all vertices of FC simplices converge to a single point, and the inequalities pass to the limit by continuity.",
+      "Use panchromatic tuples, not single near-fixed-points. A 'near-fixed-point' formulation '|f(x)ᵢ - xᵢ| ≤ ε for all i' would require Lipschitz continuity of f to derive from Sperner alone, because extracting a per-coordinate bound at a single x means comparing f(x) to f(vᵢ) at each color-i vertex, costing a Lipschitz factor. The panchromatic formulation gives the raw Sperner output: one one-sided inequality per distinct vertex, plus a diameter bound. Continuity alone suffices.",
+      "The endgame is a sum trick: the per-color inequalities f(x*)ᵢ ≤ x*ᵢ summed give Σf(x*) ≤ Σx*. But both equal 1 (since x*, f(x*) ∈ Δⁿ), so all inequalities must be tight, hence f(x*) = x*. This forcing-by-sum-equality replaces the squeeze-on-difference argument that would otherwise need Lipschitz.",
       "This proof route is genuinely different from the algebraic topology approach (SingularHomology axiom in BrouwerFixedPointOQ01OQ02OQ03.lean). It replaces homology theory with combinatorial parity, at the cost of requiring the construction of a triangulation sequence."
     ],
     "prerequisites": [
@@ -84,13 +85,13 @@
       "lean_ref": "spernerColor"
     },
     {
-      "title": "Compactness → Fixed Point (proved)",
-      "content": "fixed_point_from_approx is now a fully proved theorem (no axiom). Proof: (1) The simplex is compact — it's a closed subset of [0,1]^(n+1), proved via isCompact_univ_pi + isClosed_iInter + isClosed_eq. (2) IsCompact.tendsto_subseq extracts a convergent subsequence x_{φ(k)} → x*. (3) By continuity, f(x_{φ(k)}) → f(x*). (4) By squeeze_zero_norm with bound (n+1)/(φ(k)+1) → 0 (since φ(k) ≥ k), f(x_{φ(k)}) - x_{φ(k)} → 0, so f(x_{φ(k)}) → x*. (5) By tendsto_nhds_unique, f(x*) = x*.",
-      "lean_ref": "fixed_point_from_approx"
+      "title": "Panchromatic Tuples → Fixed Point (proved, no Lipschitz)",
+      "content": "brouwer_from_panchromatic is a fully proved theorem (no axiom). Proof: (1) Δⁿ is compact — closed subset of [0,1]^(n+1) via isCompact_univ_pi + isClosed_iInter + isClosed_eq. (2) Take the first vertex of each panchromatic tuple to form a sequence in Δⁿ; IsCompact.tendsto_subseq extracts a convergent subsequence v_{φ(k)}⁰ → x*. (3) The diameter bound (n+1)/(N+1) → 0 forces every other vertex v_{φ(k)}ⁱ of the same tuple to converge to the same x* (squeeze on coordinatewise differences). (4) For each color i, f(v_{φ(k)}ⁱ)ᵢ ≤ (v_{φ(k)}ⁱ)ᵢ; pass to the limit by continuity using le_of_tendsto_of_tendsto' to get f(x*)ᵢ ≤ x*ᵢ. (5) Sum trick: Σ f(x*)ᵢ ≤ Σ x*ᵢ, but both = 1, so all inequalities are equalities — f(x*) = x*.",
+      "lean_ref": "brouwer_from_panchromatic"
     },
     {
-      "title": "Grid Triangulation → Near-Fixed-Point (axiom)",
-      "content": "sperner_near_fixed_point (1 remaining axiom): the Nth grid triangulation of Δⁿ with the proved Sperner coloring (spernerColorMap_boundary) yields a near-fixed-point with error ≤ (n+1)/(N+1). Follows from abstract Sperner (SpernerNDimMathlib) + boundary condition + grid CellComplex construction. The main theorem brouwer_fixed_point_simplex now depends on only this one axiom.",
+      "title": "Grid Triangulation → Panchromatic Tuple (axiom)",
+      "content": "sperner_panchromatic (1 remaining axiom): the Nth grid triangulation of Δⁿ with the proved Sperner coloring (spernerColorMap_boundary) yields a panchromatic top-simplex — n+1 vertices, one per color, each satisfying its color-i inequality, with pairwise coordinate gap ≤ (n+1)/(N+1). Follows from abstract Sperner (SpernerNDimMathlib) + boundary condition + grid CellComplex construction. This is the raw output of grid Sperner; the choice of panchromatic over single-near-fixed-point eliminates the need for a Lipschitz hypothesis on f. The main theorem brouwer_fixed_point_simplex now depends on only this one axiom.",
       "lean_ref": "brouwer_fixed_point_simplex"
     }
   ],

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -16,20 +16,20 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-06T11:50:53.576Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "REFINE",
+    "since": "2026-05-07T17:30:00.000Z",
+    "iteration": 2,
+    "focus": "Axiom alignment: replace Lipschitz-requiring near-fixed-point axiom with the panchromatic-tuple formulation that matches what Sperner's lemma actually provides.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Build the grid CellComplex for Δⁿ to eliminate sperner_panchromatic axiom (would need ~200 lines of triangulation infrastructure, already partially explored in SpernerGrid.lean).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: axiomCount 2→1; fixed_point_from_approx proved; sperner_near_fixed_point (grid triangulation) remains; boundary_doors_odd is fundamentally broken in SpernerGrid.lean",
+    "progressSummary": "PROGRESS: axiomCount remains 1, but the axiom is now mathematically aligned with Sperner's lemma's actual output. Replaced sperner_near_fixed_point (single point with per-coordinate bound — required Lipschitz to derive from Sperner) with sperner_panchromatic (n+1 vertices, one per color, each with one-sided bound, plus diameter bound). Renamed fixed_point_from_approx → brouwer_from_panchromatic with a new proof using sum-equality forcing instead of squeeze-on-difference; removes the implicit Lipschitz dependency. Build verified.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -37,26 +37,24 @@
       "spernerColor/colorSet: the Sperner coloring construction (proved, 0 sorry)",
       "spernerColor_in_supp: color lies in support — the Sperner boundary condition (proved)",
       "spernerColor_ne_of_zero: coloring avoids faces (proved, the key Sperner condition)",
-      "brouwer_fixed_point_simplex: Brouwer for Δⁿ from 2 axioms (proved, 0 sorry)",
-      "fixed_point_from_approx: proved compactness convergence theorem (IsCompact.tendsto_subseq + squeeze_zero_norm + tendsto_nhds_unique) in SpernerNDimMathlibOQ02.lean:204-293"
+      "brouwer_fixed_point_simplex: Brouwer for Δⁿ from 1 axiom (proved, 0 sorry)",
+      "brouwer_from_panchromatic: Lipschitz-free fixed-point extraction from panchromatic tuples (compactness + diameter bound + one-sided limit passage + sum equality) in SpernerNDimMathlibOQ02.lean:248-340"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
       "Sperner boundary condition follows immediately from supp structure: c(v) = min colorSet ⊆ supp(v), so c(v) ≠ j if v_j = 0 (then j ∉ supp(v)).",
-      "Two axioms suffice: (1) grid triangulation + Sperner → near-fixed-point, (2) compactness → convergence to exact fixed point.",
+      "Use panchromatic tuples, not single near-fixed-points. A 'near-fixed-point' formulation '|f(x)ᵢ - xᵢ| ≤ ε for all i' would require Lipschitz continuity of f to derive from Sperner alone, since extracting a per-coordinate bound at a single x means comparing f at different vertices to f(x), which costs a Lipschitz factor. The panchromatic formulation gives the raw Sperner output and only needs continuity.",
+      "The endgame is a sum trick: per-color inequalities f(x*)ᵢ ≤ x*ᵢ summed give Σf(x*) ≤ Σx*. But both equal 1 (since x*, f(x*) ∈ Δⁿ), so all inequalities are equalities. Replaces the squeeze-on-difference argument that needs Lipschitz.",
       "The proof route is fundamentally different from the algebraic topology approach (singular homology) in BrouwerFixedPointOQ01OQ02OQ03.lean — pure combinatorics replaces homology theory.",
-      "Lean API: use hf_cont.tendsto x not hf_cont.continuousAt.comp for Filter.Tendsto.comp with continuous function",
-      "Lean API: Finset.single_le_sum takes (fun j _ => h j) (Finset.mem_univ i) with no extra _ argument",
-      "Lean API: congr step needs simp [Function.comp, Pi.add_apply, Pi.sub_apply] to unfold function composition before ring"
+      "Lean API: le_of_tendsto_of_tendsto' for passing pointwise inequalities to limits.",
+      "Lean API: Finset.sum_lt_sum (with a witnessing strict inequality) to derive sum strict inequality contradiction."
     ],
     "mathlibGaps": [
-      "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
-      "Sequential compactness of stdSimplex in Lean 4 (needed for fixed_point_from_approx axiom)"
+      "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_panchromatic axiom — significant work ~200 lines, output is a panchromatic top-simplex with diameter bound)"
     ],
     "nextSteps": [
       "Prove swapAdj_nodup, swapAdj_prefixSet_eq, swapAdj_ne_self to eliminate OQ-01 axioms (Aristotle candidates)",
-      "Build the grid CellComplex for Δⁿ to eliminate sperner_near_fixed_point axiom",
-      "Use Mathlib compactness infrastructure (IsCompact.tendsto_subseq) to prove fixed_point_from_approx"
+      "Build the grid CellComplex for Δⁿ to eliminate sperner_panchromatic axiom (would need to extract n+1 panchromatic vertices from CellComplex.sperner output and prove diameter bound)"
     ]
   },
   "tags": [
@@ -76,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-06T11:50:53.576Z",
+  "lastUpdate": "2026-05-07T17:35:00.000Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Replaces the single remaining axiom in `SpernerNDimMathlibOQ02.lean` with the
correct one for the Sperner→Brouwer reduction.

The previous axiom, `sperner_near_fixed_point`, asserted a single point
`x ∈ Δⁿ` with **per-coordinate** bound `|f(x)ᵢ - xᵢ| ≤ ε` for all `i`. This is
a stronger statement than what Sperner's lemma actually delivers — extracting
such a single-point bound from a fully-colored simplex requires comparing `f`
at different vertices to `f(x)`, which costs a Lipschitz factor on `f`. As an
axiom, it silently smuggled in Lipschitz continuity.

The new axiom, `sperner_panchromatic`, gives the **raw** output of Sperner +
grid:
- `n+1` distinct vertices `v₀, …, vₙ`, one per color, all in `Δⁿ`,
- each satisfying its color-`i` one-sided inequality `f(vᵢ)ᵢ ≤ (vᵢ)ᵢ`,
- with pairwise coordinate gap bounded by `(n+1)/(N+1)`.

This is exactly what abstract Sperner provides on the `N`th grid
triangulation, with no continuity assumption.

`brouwer_from_panchromatic` (replaces `fixed_point_from_approx`) extracts a
fixed point from a sequence of such tuples using only **continuity** of `f`:
1. Compactness of `Δⁿ` gives a convergent subsequence `v_{φ(k)}⁰ → x*` of
   first vertices.
2. The diameter bound forces every other vertex `v_{φ(k)}ⁱ` of the same tuple
   to converge to the same `x*`.
3. By continuity, `f(v_{φ(k)}ⁱ)ᵢ → f(x*)ᵢ`. Pass the per-color inequalities
   to the limit: `f(x*)ᵢ ≤ x*ᵢ` for all `i`.
4. **Sum trick**: `Σ f(x*)ᵢ ≤ Σ x*ᵢ`. But both equal `1`, so all
   inequalities are equalities, hence `f(x*) = x*`.

The sum-equality forcing in step 4 is what eliminates the Lipschitz
dependency.

`brouwer_fixed_point_simplex` is now `brouwer_from_panchromatic` ∘
`sperner_panchromatic` and depends on exactly one axiom.

## Counts (unchanged)

- sorries: 0
- axiomCount: 1
- theoremCount: 13 (8 lemma + 5 theorem)
- definitionCount: 5
- lineCount: 299 → 356

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.SpernerNDimMathlibOQ02` — passed (`✔ [7743/7743] Built Proofs.SpernerNDimMathlibOQ02`)
- [x] meta.json + research JSON updated with new axiom name, narrative, and counts
- [x] All proved lemmas/theorems unchanged through `spernerColorMap_boundary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)