### PR TITLE
research(binary-gcd-oq-03-oq-02): correct sorryCount drift 3 → 1

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -186,7 +186,7 @@
       "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }


### PR DESCRIPTION
## Summary

`leanFiles[BinaryGcdOQ03OQ02.lean].sorryCount` was **3** but the file has only **1** real \`sorry\`:

- Line 924: \`hgcdMatrix_row_output_le\` recursive case — the genuine remaining sorry.
- Line 36: docstring text *\"\`hgcdMatrix_joint_bound\` is stated as a sorry\"* — comment, not code.
- Line 1006: summary text *\"(1 sorry)\"* — comment, not code.

A regex-only \`sorry\` counter would catch all three; verified by stripping block (\`/- ... -/\`) + line (\`-- ...\`) comments and counting bare \`sorry\` tokens — yields **1**.

The gallery \`meta.json\` already correctly says 1 sorry; this just brings the \`research/problems\` JSON into sync.

## Test plan

- [x] Stripped-comment Python scan: \`Real sorry count: 1\`
- [x] Manual line check: only line 924 is \`· sorry\` (real); lines 36 and 1006 are inside comments.
- [x] \`python3 -c \"import json; json.load(open(...))\"\` — valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)