### PR TITLE
fix(meta): sync lineCount for navier-stokes (21111→21110) + bezout-identity-oq-04-oq-01 (474→473)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 2,
-    "lineCount": 474,
+    "lineCount": 473,
     "assumptions": "Two axioms: snf_exists (every integer matrix has a Smith Normal Form) and snf_solvability_criterion (system Ax=b solvable iff invariant factors divide transformed RHS). Both are well-known theorems; constructive proofs would require implementing the full row/column reduction algorithm for ℤ-matrices. The zero-matrix special case (snf_exists_zero) is proved directly without these axioms.",
     "mathlib_version": "4.26.0",
     "theoremCount": 17,
@@ -193,7 +193,7 @@
       "Matrix"
     ],
     "namespace": "BezoutIdentityOQ04OQ01",
-    "lineCount": 474,
+    "lineCount": 473,
     "axiomCount": 2,
     "theoremCount": 17,
     "definitionCount": 5,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "theoremCount": 611,
     "definitionCount": 100
   },
@@ -365,7 +365,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 611,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for two slugs whose Lean files were touched by recent merges, but whose meta.json was left out of step.

## Evidence

| slug | shared file | actual lines | claimed (both blocks) |
|------|-------------|--------------|------------------------|
| `navier-stokes` | `Proofs/NavierStokes.lean` | 21110 | 21111 |
| `bezout-identity-oq-04-oq-01` | `Proofs/BezoutIdentityOQ04OQ01.lean` | 473 | 474 |

### navier-stokes

PR #16534 (`fix(meta): sync lineCount 21111→21110 for 4 navier-stokes entries`) synced `navier-stokes-existence`, `navier-stokes-oq-01`, and `navier-stokes-oq-02` — all three sharing `Proofs/NavierStokes.lean` — but left the base `navier-stokes` slug behind. Confirmed via `gh pr view 16534 --json files`.

### bezout-identity-oq-04-oq-01

PR #16567 (`research(bezout-identity-oq-04-oq-01): strengthen unimodular & null-space closure`) trimmed one line from the Lean file. find-targets.ts didn't flag it because `lf.theoremCount`, `lf.definitionCount`, `lf.axiomCount`, and `lf.sorries` are all still correct — only the lineCount lagged.

## Verification

```
$ wc -l proofs/Proofs/NavierStokes.lean
   21110 proofs/Proofs/NavierStokes.lean
$ wc -l proofs/Proofs/BezoutIdentityOQ04OQ01.lean
     473 proofs/Proofs/BezoutIdentityOQ04OQ01.lean
```

This is a pure metadata sync — no Lean changes.

---
Automated fix by lean-mechanic agent.