### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): fix 4 section file= refs post-modularization

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -185,6 +185,7 @@
     {
       "id": "sec-corner-induction",
       "title": "Parts XIII-XIV: Corner Recursion + General HLF",
+      "file": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "startLine": 4329,
       "endLine": 4725,
       "summary": "Part XIII proves the corner recursion card_SYT_corner_step. Part XIV proves hook_length_formula_Q in ℚ by WF induction on μ.card using corner step + hook_walk_identity. hook_length_formula_general follows by exact_mod_cast.",
@@ -193,6 +194,7 @@
     {
       "id": "sec-ghookyd",
       "title": "Part VIc: HLF for Generalized Hook Shapes [a, 1ᵇ]",
+      "file": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "startLine": 644,
       "endLine": 1826,
       "summary": "Proves HLF for gHookYD a b (shape [a,1^b]) with 0 sorries. hookProd = (a+b)·(a-1)!·b!, card(SYT) = C(a+b-1,b). Part VIII further proves the hook-shape (m+1,1) via an explicit bijection hookSYT: Fin(m+1) → SYT.",
@@ -201,6 +203,7 @@
     {
       "id": "sec-general-two-row",
       "title": "Parts XI-XII: HLF for General 2-Row [a,b]",
+      "file": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "startLine": 3473,
       "endLine": 4327,
       "summary": "Proves HLF for all 2-row shapes twoRowYD a b. hookProd = (a+1).descFactorial(b)·(a-b)!·b!. card(SYT) = ballotSeqCount(a+1,b) proved via corner recursion. hook_length_formula_atMostTwoRows covers all μ with rowLen 2 = 0.",
@@ -209,6 +212,7 @@
     {
       "id": "sec-transpose-nrow",
       "title": "Parts XV-XXIII: Transpose Duality and N-Row Hook Walk (N=3..9)",
+      "file": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "startLine": 5183,
       "endLine": 13633,
       "summary": "Part XV: hookLength_transpose proves h(μ,i,j)=h(μᵀ,j,i), giving HLF and hook_walk for ≤2-col via duality. Parts XIVc-XXIII prove hook_walk_identity for exactly-3-row through 9-row shapes by computing colLen zones, hookLen polynomials, armProd, and closing with field_simp+ring. ~8,000 lines total.",


### PR DESCRIPTION
## Summary
Adds explicit `file: \"Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean\"` to 4 sections that referenced line numbers beyond the main file's 398 lines.

After session 35 modularized the original 14022-line file into:
- \`BallotProblemOQ03OQ01OQ02.lean\` (398 lines)
- \`BallotProblemOQ03OQ01OQ02Helpers.lean\` (14050 lines)

these 4 sections still pointed at lines 644 / 3473 / 4329 / 5183-13633, with no \`file\` field. The gallery UI defaults to the main \`proofRepoPath\`, so it would render empty / wrong content for them.

## Spot-checks (Helpers.lean)
| Section | startLine | What's actually there |
|---|---|---|
| sec-ghookyd | 644 | gHookYD hook product overview |
| sec-general-two-row | 3473 | twoRowYD definition |
| sec-corner-induction | 4329 | isCorner / corners definitions |
| sec-transpose-nrow | 5183-13633 | transpose lemmas → hook_walk dispatcher tail |

All four match the section summaries.

## Scope
- 1 file changed, 4 insertions, 0 deletions
- Pure metadata fix; no Lean changes
- No sorry / axiom / line / theorem / definition counts touched

## Test plan
- [x] JSON valid (\`python3 -c \"import json; json.load(...)\"\`)
- [x] Spot-checked all 4 line numbers in Helpers.lean
- [x] Surgical 4-line diff (no formatting churn)