### PR TITLE
Enrich laws-of-large-numbers-oq-04-oq-03 (Glivenko–Cantelli): conclusion + 2 annotations

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "laws-of-large-numbers-oq-04-oq-03",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "concept",
+    "title": "Header: Eliminating Two Glivenko–Cantelli Axioms",
+    "content": "The opening docstring positions this file as the *axiom-reduction* follow-up to the parent `LawsOfLargeNumbersOQ04` formalization of the Glivenko–Cantelli theorem. The parent file carries three axioms; this file proves two of them (`thresholdIndicator_integrable` and `integral_thresholdIndicator_eq_cdf`), reducing the axiom count to one. The remaining axiom — `glivenko_cantelli_uniform`, the finite-bracketing uniformity step — is the genuinely hard part requiring CDF continuity-point density infrastructure not yet available in Mathlib 4.26. The four enumerated Mathlib lemmas (`Integrable.mono'`, `integral_indicator`, `integral_const`, `restrict_apply`) are the tools that make the elimination possible — each replaces what was previously an unproved assumption with a chain of standard measure-theoretic moves.",
+    "mathContext": "Glivenko–Cantelli (1933): $\\sup_x |F_n(x) - F(x)| \\to 0$ a.s. Axiom reduction: 3 → 1, leaving only the bracketing uniformity step from pointwise to uniform convergence.",
+    "significance": "context",
+    "relatedConcepts": ["Glivenko-Cantelli theorem", "axiom reduction", "empirical CDF", "uniform convergence"],
+    "prerequisites": ["LawsOfLargeNumbersOQ04 parent", "probability measure", "indicator function"]
+  },
+  {
     "id": "ann-axiom-1-proof",
     "proofId": "laws-of-large-numbers-oq-04-oq-03",
     "range": { "startLine": 37, "endLine": 55 },
@@ -46,6 +58,18 @@
       "Measure.restrict_apply",
       "trueCDF"
     ]
+  },
+  {
+    "id": "ann-pointwise-convergence",
+    "proofId": "laws-of-large-numbers-oq-04-oq-03",
+    "range": { "startLine": 105, "endLine": 136 },
+    "type": "concept",
+    "title": "Corollary: Axiom-Free Pointwise Convergence of the Empirical CDF",
+    "content": "`empiricalCDF_pointwise_convergence_no_axiom` is the file's payoff: assuming the SLLN-applicable hypotheses (i.i.d., identically distributed, measurable) plus a probability measure, the empirical CDF converges pointwise to the true CDF a.s., and the proof now invokes *zero* integration axioms. The chain of steps inside the proof body is illuminating: (1) get integrability of the threshold indicator from `thresholdIndicator_integrable_proved` (this file), (2) get pairwise independence and identical distribution from the parent file (these are *not* integration axioms — they're structural lifts of independence/identity from $X$ to indicators, provable from definitions), (3) apply `strong_law_ae_real` (Mathlib's SLLN), (4) substitute the integral identity from `integral_thresholdIndicator_eq_cdf_proved` to identify the SLLN limit as $F(x)$, (5) `convert hω using 1; ext n; simp` extracts the empirical-mean form. Pointwise GC is now a chain of theorems with no holes; only the uniform-bracketing step remains.",
+    "mathContext": "$\\forall x \\in \\mathbb{R}: \\quad F_n(x) := \\frac{1}{n} \\sum_{i=1}^n \\mathbf{1}_{X_i \\leq x} \\to F(x) := \\mu(X_0 \\leq x) \\quad \\text{a.s.}$ The SLLN applied to the indicator sequence $\\{\\mathbf{1}_{X_i \\leq x}\\}_i$ — independent (from i.i.d. of $X_i$) and identically distributed (from i.d. of $X_i$) — gives the empirical mean converging to the expectation, which is exactly $F(x)$ by the integral identity.",
+    "significance": "key",
+    "relatedConcepts": ["strong law of large numbers", "empirical CDF", "pointwise convergence", "iIndepFun"],
+    "prerequisites": ["thresholdIndicator_integrable_proved", "integral_thresholdIndicator_eq_cdf_proved", "strong_law_ae_real"]
   },
   {
     "id": "ann-remaining-axiom",

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -103,6 +103,15 @@
     "definitionCount": 0
   },
   "sorries": 0,
+  "conclusion": {
+    "summary": "Eliminates two of the three axioms in the parent Glivenko–Cantelli formalization (`LawsOfLargeNumbersOQ04`) by proving them from Mathlib's standard integration API. Four theorems, 0 sorries, 0 axioms. The proved facts — integrability of threshold indicators on probability spaces, and the integral-equals-CDF identity — are derived in one short Lean file each, using `Integrable.mono'` (bounded measurable on finite measure → integrable) and the standard `integral_indicator` + `integral_const` + `Measure.restrict_apply` chain. Together with the unchanged independence/identity-of-distribution lifts from the parent, these unlock a fully axiom-free pointwise convergence corollary `empiricalCDF_pointwise_convergence_no_axiom`.",
+    "implications": "The Glivenko–Cantelli theorem is the foundation of nonparametric statistics: it justifies the Kolmogorov–Smirnov test, distribution-free hypothesis testing, and resampling methods (bootstrap). Reducing the axiom count from 3 to 1 means that *only one* genuinely hard mathematical step (the bracketing uniformity) remains as an admitted hypothesis — every other piece is now a Mathlib-derived theorem. This sharpens the formalization's credibility and isolates the remaining work to a well-defined Mathlib-side gap (CDF continuity-point density), making future axiom elimination concretely tractable.\n\nThe pattern demonstrated here — wrapping bounded measurable functions with `Integrable.mono'` and chaining `integral_indicator` for set-membership integrals — applies broadly. Any time a probability formalization carries 'integrability of a 0/1-valued function' as an axiom, the same two-line proof technique applies. We expect this approach to retire several similar axioms across the gallery's probability-theoretic formalizations.",
+    "openQuestions": [
+      "Can the remaining `glivenko_cantelli_uniform` axiom be eliminated by formalizing CDF continuity-point density in Mathlib? Specifically: prove that for any CDF $F$ and $\\varepsilon > 0$, finitely many continuity points of $F$ partition $\\mathbb{R}$ with $F$-mass less than $\\varepsilon$ on each cell.",
+      "Can the integration-axiom elimination technique be applied to other probability formalizations in the gallery — e.g., birthday-problem variants, central-limit-theorem follow-ups — to systematically reduce their axiom counts?",
+      "Does the indicator-integrability + indicator-CDF pair generalize to vector-valued indicators (e.g., $\\mathbf{1}_{X \\in A}$ for measurable $A \\subseteq \\mathbb{R}^d$)? The scalar case proved here is the $d = 1$ instance with $A = (-\\infty, x]$."
+    ]
+  },
   "crossReferences": [
     {
       "id": "laws-of-large-numbers-oq-04",


### PR DESCRIPTION
## Summary
- The proof was already at 76/100 quality with strong existing annotations on the modern schema. The remaining gaps were a missing `conclusion` block (−15 pts) and only 4 annotations (−5 pts).
- Added 2 new annotations: a header annotation positioning the file as the axiom-reduction follow-up to `LawsOfLargeNumbersOQ04`, and a pointwise-convergence corollary annotation walking through the 5-step proof body of `empiricalCDF_pointwise_convergence_no_axiom`.
- Added a full `conclusion` block (summary + implications discussing Glivenko–Cantelli's nonparametric-statistics role and the reusable `Integrable.mono'` + `integral_indicator` pattern + 3 open questions including the path to eliminating the remaining axiom).

## Why this matters
This file is the axiom-reduction story for the parent Glivenko–Cantelli formalization (3→1 axioms). The new `conclusion` makes the broader implications and reusable pattern explicit, and the new annotations cover the headline corollary that ties the two proved theorems together with the SLLN.

## Test plan
- [x] `pnpm build` succeeds (JSON validation + Vite glob registration)
- [x] `index.ts` unchanged — additions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)