### PR TITLE
research(hurwitz-theorem-wip-01): S02 OBSERVE — populate JSON + problem/state from Lean files

### DIFF
--- a/research/problems/hurwitz-theorem-wip-01/problem.md
+++ b/research/problems/hurwitz-theorem-wip-01/problem.md
@@ -1,0 +1,150 @@
+# Problem: Complete Hurwitz's Theorem (close the last sorry)
+
+**Slug**: hurwitz-theorem-wip-01
+**Created**: 2026-05-06T14:18:33Z
+**Status**: Blocked on Mathlib (clean localization)
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Plain Language
+
+The gallery entry `hurwitz-theorem` formalizes Hurwitz's theorem on $n$-square
+identities and is mostly done: $n=1, 2, 3, 4, 8$ and the entire odd $n$ case are
+fully proved. **One sorry remains** — `HurwitzTheorem.lean:1937` — covering even
+$n \notin \{2, 4, 8\}$. Closing this sorry promotes the entry from `badge=wip`
+to fully verified.
+
+### Formal Statement
+
+```lean
+-- HurwitzTheorem.lean (line 1947)
+theorem hurwitz_theorem (n : ℕ) (hn : n > 0) :
+    Nonempty (NSquareIdentity n) ↔ n ∈ admissibleDimensions
+```
+
+The remaining open subgoal (line 1937 in `hurwitz_only_if`):
+```lean
+-- For even n = 2k with n ∉ {2, 4, 8}, given an NSquareIdentity n, derive False.
+-- Equivalently: show no real n-dimensional faithful module exists for Cl(0, n-1).
+```
+
+### Why This Matters
+
+- **Closes the only outstanding sorry** in `HurwitzTheorem.lean` (currently
+  `sorries=1`, `badge=wip`).
+- **Forces a Mathlib-level construction** (real Clifford algebra periodicity /
+  Artin-Wedderburn for real semisimple algebras) that is broadly useful beyond
+  Hurwitz — Bott periodicity, KO-theory, the Hopf invariant one theorem, the
+  Radon-Hurwitz numbers, and the parallelizability of $S^{n-1}$ all need it.
+- **Unblocks** the parallel sorry in `HurwitzOnlyIf.lean:111`
+  (`hurwitz_only_if_ring`, the `NormedDivisionRing` formulation).
+
+## What Is Already Proved
+
+All upstream infrastructure is in place; the gap is **purely** in Clifford
+structure theory.
+
+| Lemma | File:line | Status |
+|-------|-----------|--------|
+| `oneSquareIdentity` | HurwitzTheorem.lean:119 | proved |
+| `twoSquareIdentity` | HurwitzTheorem.lean (Brahmagupta-Fibonacci) | proved |
+| `fourSquareIdentity` | HurwitzTheorem.lean (Euler quaternion) | proved |
+| `eight_square_identity_exists` | HurwitzTheorem.lean (Cayley-Dickson) | proved |
+| `no_three_square_identity` | HurwitzTheorem.lean | proved (Parseval, ~800 lines) |
+| `no_odd_nsquare` | HurwitzTheorem.lean:1880 | proved (det parity) |
+| `crossMat_skewSym` | HurwitzTheorem.lean:1788 | proved |
+| `crossMat_transMul` | HurwitzTheorem.lean:1779 | proved |
+| `crossMat_sq_neg_one` | HurwitzTheorem.lean:1869 | proved (M² = -I) |
+| `crossMat_anticommute` | HurwitzTheorem.lean:1822 | proved (M_j M_k + M_k M_j = 0) |
+| `hurwitz_only_if` (n∈2k∩∉{2,4,8}) | HurwitzTheorem.lean:1937 | **sorry** |
+| `hurwitz_field_case` | HurwitzOnlyIf.lean | proved (Gelfand-Mazur) |
+| `hurwitz_only_if_ring` (non-comm) | HurwitzOnlyIf.lean:111 | **sorry** |
+
+## What Is Missing
+
+The `crossMat_*` infrastructure proves: from any `NSquareIdentity n`, the matrices
+$M_j := \text{crossMat}(j_0, j)$ for $j \neq j_0$ are $n - 1$ anti-commuting orthogonal
+$n \times n$ real matrices with $M_j^2 = -I$. These give a **real $n$-dimensional
+representation of $\mathrm{Cl}(0, n-1)$**.
+
+To finish, one needs:
+
+1. **Real Clifford structure classification.** Bott periodicity table:
+   $\mathrm{Cl}(0, n+8) \cong \mathrm{Cl}(0, n) \otimes M_{16}(\mathbb{R})$, plus the
+   small-$n$ identifications $\mathrm{Cl}(0, 1) \cong \mathbb{C}$, $\mathrm{Cl}(0, 3) \cong \mathbb{H}$,
+   $\mathrm{Cl}(0, 5) \cong M_2(\mathbb{H})$, $\mathrm{Cl}(0, 7) \cong M_8(\mathbb{R}) \oplus M_8(\mathbb{R})$, etc.
+
+2. **Minimum faithful real representation dimension.** From the Wedderburn
+   decomposition $A \cong \prod_i M_{n_i}(D_i)$ with $D_i \in \{\mathbb{R}, \mathbb{C}, \mathbb{H}\}$,
+   read off the smallest $n_i \dim_{\mathbb{R}} D_i$.
+
+3. **Apply** to $n - 1$ in the failing-even-case branch:
+   - $n = 6$: $\mathrm{Cl}(0, 5) \cong M_2(\mathbb{H})$, min dim $= 2 \cdot 4 = 8 > 6$ → contradiction.
+   - $n = 10$: $\mathrm{Cl}(0, 9) \cong M_{16}(\mathbb{R})$, min dim $= 16 > 10$ → contradiction.
+   - General $n = 2k \notin \{2, 4, 8\}$: similar dimension count.
+
+**None of (1)–(2) are in Mathlib v4.26.0.** The CliffordAlgebra namespace has
+the universal property and basic operations but no structure classification.
+
+## Tractability
+
+**Difficulty**: HIGH — estimated ~1000 lines of new Mathlib infrastructure.
+**Per-session work**: nearly zero in the gallery; the bottleneck is upstream.
+
+## Approaches
+
+1. **Wait for Mathlib.** Track Clifford-algebra PRs in the Mathlib repository.
+   Re-attempt when `CliffordAlgebra.equivOfBottPeriodicity` (or analogue) lands.
+
+2. **Small-case decomposition.** Prove $n = 6$ and $n = 10$ directly using
+   ad-hoc Wedderburn structure (hand-coded matrix algebra over $\mathbb{R}, \mathbb{C}, \mathbb{H}$),
+   leaving only the asymptotic case as sorry. This narrows the open scope but
+   does not eliminate it; estimated 200–400 lines per case.
+
+3. **Algebra-level refactor (HurwitzOnlyIf only).** Split
+   `hurwitz_only_if_ring` into a concrete bridge lemma
+   `nsquareIdentity_of_normedDivisionRing` (provable in ~80 lines using
+   Mathlib's `Module.Finite.finBasis` + isometry) plus the call to
+   `HurwitzTheorem.hurwitz_only_if`. Sorry count unchanged but sorry localized
+   to one place — reduces duplication.
+
+4. **Submit Mathlib RFC.** Request a Clifford classification API. Long horizon.
+
+## Metadata
+
+```yaml
+tags:
+  - seeker-selected
+  - wip
+  - algebra
+  - number-theory
+  - clifford-algebras
+  - blocked-on-mathlib
+related_proofs:
+  - hurwitz-theorem
+  - hurwitz-impossibility
+  - hurwitz-three-square-impossibility
+difficulty: high
+source: gallery-gap
+created: 2026-05-06T14:18:33Z
+```
+
+**Significance**: 7/10 — closes the last sorry in a high-prestige gallery entry.
+**Tractability**: 3/10 — requires Mathlib infrastructure not currently available.
+
+## References
+
+- A. Hurwitz, *Über die Composition der quadratischen Formen*, Math. Ann. 88
+  (1923), 1–25 (posthumous; original 1898).
+- J. Baez, *The Octonions*, Bull. Amer. Math. Soc. 39 (2002), 145–205.
+- Bott & Milnor, *On the parallelizability of the spheres*, Bull. Amer. Math. Soc.
+  64 (1958), 87–89.
+- M.F. Atiyah, *K-theory and reality*, Quart. J. Math. Oxford 17 (1966), 367–386.
+
+### Mathlib
+
+- `Mathlib.Algebra.Quaternion` — `Quaternion.normSq_mul`.
+- `Mathlib.Analysis.Normed.Algebra.GelfandMazur` — used in the field subcase.
+- `Mathlib.LinearAlgebra.CliffordAlgebra.*` — universal property only;
+  **no** structure classification as of v4.26.0.

--- a/research/problems/hurwitz-theorem-wip-01/sessions/2026-05-07-s02.md
+++ b/research/problems/hurwitz-theorem-wip-01/sessions/2026-05-07-s02.md
@@ -1,0 +1,77 @@
+## Session 2026-05-07 (Session 2) — OBSERVE: enrich problem from authoritative Lean files
+
+**Mode**: SURVEY (knowledge tier WEAK on entry; tier RICH on exit)
+**Outcome**: progress (documentation only — JSON, problem.md, state.md);
+no Lean changes; no sorry/axiom delta.
+
+### What I Did
+
+1. **Verified the actual Lean state.** `HurwitzTheorem.lean` has **0 axioms**
+   and **1 sorry** at line 1937 (even $n \notin \{2, 4, 8\}$). `HurwitzOnlyIf.lean`
+   has **0 axioms** and **1 sorry** at line 111 (`hurwitz_only_if_ring`,
+   non-commutative subcase). Both block on the same downstream gap: real
+   Clifford algebra structure classification (Bott periodicity, Artin-
+   Wedderburn for real semisimple algebras), which is **not in Mathlib v4.26.0**.
+
+2. **Catalogued upstream infrastructure.** All linear-algebra prerequisites
+   are proved: `crossMat_skewSym`, `crossMat_transMul`, `crossMat_sq_neg_one`,
+   `crossMat_anticommute`. From any `NSquareIdentity n`, these construct
+   $n - 1$ anti-commuting orthogonal $n \times n$ real matrices $M_j$ with
+   $M_j^2 = -I$ — a real $n$-dim representation of $\mathrm{Cl}(0, n-1)$. The
+   gap is **purely** the structure classification step.
+
+3. **Rewrote problem.md and state.md** with the formal statement, full
+   proof-status table, the precise Mathlib gap (Bott periodicity table,
+   small-$n$ identifications, minimum-faithful-rep-dim bound), and four
+   ranked next-action options.
+
+4. **Replaced placeholder JSON** (`src/data/research/problems/hurwitz-theorem-wip-01.json`).
+   Pre-existing JSON had `formalStatement = "(formal statement to be added)"`,
+   empty `whyMatters`, empty `knownResults`, empty `references`. New JSON
+   has 6 insights, 4 mathlibGaps, 5 ranked nextSteps, and a complete
+   refs/papers/mathlib block. `currentState.phase` advanced NEW → OBSERVE,
+   `iteration` 1 → 2, `tractability` revised down 6 → 3 (correctly reflects
+   the Mathlib block).
+
+### Key Findings
+
+- **The blocker is single-point and clean.** Both sorries (HurwitzTheorem.lean
+  and HurwitzOnlyIf.lean) reduce to: *"min faithful real rep dim of
+  $\mathrm{Cl}(0, n-1)$ exceeds $n$ for even $n \notin \{2, 4, 8\}$"*. Nothing
+  else stands between us and a complete Hurwitz formalization.
+
+- **Mathlib's CliffordAlgebra namespace covers the universal property and
+  conjugation but not the structure theorem.** Searched for Bott periodicity /
+  Wedderburn classification: none in v4.26.0.
+
+- **Two viable forward paths exist** (option A: small-case decomposition for
+  $n = 6, 10$; option B: refactor `hurwitz_only_if_ring` to localize the gap).
+  Both leave the underlying Mathlib block in place.
+
+### Files Modified
+
+- `src/data/research/problems/hurwitz-theorem-wip-01.json` — replaced
+  placeholder; phase NEW → OBSERVE; tractability 6 → 3; complete
+  knownResults / insights / mathlibGaps / nextSteps / references.
+- `research/problems/hurwitz-theorem-wip-01/problem.md` — rewrote from
+  template-stub to full survey with status table.
+- `research/problems/hurwitz-theorem-wip-01/state.md` — new (was previously
+  template-stub in main repo, untracked).
+- `research/problems/hurwitz-theorem-wip-01/sessions/2026-05-07-s02.md` — this
+  session report.
+
+### Build Verification
+
+Not attempted. Session is documentation-only; no Lean files modified, so no
+build needed. The pre-existing 1+1 sorries are unchanged.
+
+### Next Steps
+
+1. **Future session**: pick option B (HurwitzOnlyIf refactor) for a concrete
+   ~80-line ACT contribution that localizes the blocker.
+2. **Watch Mathlib**: periodically check
+   `Mathlib.LinearAlgebra.CliffordAlgebra.*` for new structure-classification
+   content.
+3. **Do NOT** submit the OPEN sorries to Aristotle.
+
+---

--- a/research/problems/hurwitz-theorem-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-wip-01/state.md
@@ -1,0 +1,58 @@
+# Research State: hurwitz-theorem-wip-01
+
+## Current State
+
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-05-07T18:10:00Z
+**Iteration**: 2
+
+## Current Focus
+
+Survey complete: full inventory of what is proved upstream of the blocking
+sorry, mapping the gap to the missing Mathlib API. Problem confirmed BLOCKED
+on real Clifford algebra structure classification (~1000 lines of upstream
+Mathlib infrastructure needed).
+
+## Active Approach
+
+**Wait** — until Mathlib gains Clifford structure / Bott periodicity API.
+Localized 2 sorries (HurwitzTheorem.lean:1937, HurwitzOnlyIf.lean:111) both
+collapse to the same blocker.
+
+## Attempt Count
+
+- Total attempts: 1
+- Approaches tried:
+  1. (S2 — this session) OBSERVE / SURVEY: enumerate proved infrastructure,
+     classify what's left, identify Mathlib gap precisely.
+
+## Blockers
+
+1. Mathlib has no real Clifford algebra periodicity / structure classification.
+2. Mathlib has no Artin-Wedderburn for real semisimple algebras.
+3. No minimum-faithful-real-rep-dimension lemma derivable from current
+   `Mathlib.LinearAlgebra.CliffordAlgebra.*` (which only provides the universal
+   property and basic conjugation).
+
+## Next Action
+
+Highest-EV options, in order:
+
+1. **(option B) Refactor `HurwitzOnlyIf.hurwitz_only_if_ring`** into a concrete
+   bridge lemma (`nsquareIdentity_of_normedDivisionRing`, ~80 lines) plus the
+   call to `HurwitzTheorem.hurwitz_only_if`. Sorry count unchanged but the
+   non-Mathlib part of the proof becomes provable. Net effect: same total
+   axioms/sorries but one of the two sorries becomes "calls a sorry-axiom"
+   instead of "needs new infra". Future-blocked by the same Cl gap.
+
+2. **(option D) Wait** for Mathlib upstream. Re-check
+   `Mathlib.LinearAlgebra.CliffordAlgebra.*` periodically.
+
+3. **(option A) Small-case decomposition** for $n = 6, 10$. ~400 lines per
+   case, hand-coded Wedderburn structure of $\mathrm{Cl}(0, 5)$ and $\mathrm{Cl}(0, 9)$.
+   Narrows but does not eliminate the open sorry; arguably not worth the work
+   if Mathlib will land it eventually.
+
+4. **(do NOT)** Submit to Aristotle. Sorry is OPEN (genuine missing infra),
+   not a routine lemma — Aristotle is the wrong tool.

--- a/src/data/research/problems/hurwitz-theorem-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-wip-01.json
@@ -1,0 +1,107 @@
+{
+  "slug": "hurwitz-theorem-wip-01",
+  "title": "Complete Hurwitz's Theorem (Work in Progress)",
+  "phase": "OBSERVE",
+  "status": "blocked",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall n > 0, \\text{Nonempty}(\\text{NSquareIdentity}\\ n) \\iff n \\in \\{1,2,4,8\\}",
+    "plain": "Eliminate the single remaining sorry in HurwitzTheorem.lean: prove that no n-square identity exists for even n with n notin {2,4,8}. Equivalently, finish the only-if direction of Hurwitz's theorem at the NormedDivisionRing level (HurwitzOnlyIf.lean: hurwitz_only_if_ring).",
+    "whyMatters": [
+      "Closes the only outstanding sorry in HurwitzTheorem.lean (currently formalized as 'wip', sorries=1).",
+      "Promotes hurwitz-theorem from 'wip' (badge=wip, sorries=1) to a fully verified gallery entry.",
+      "Forces a Mathlib-level construction (CliffordAlgebra structure / Bott periodicity / Artin-Wedderburn for real semisimple algebras) that is broadly useful beyond Hurwitz."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "n in {1,2,4,8}: Nonempty(NSquareIdentity n) — explicit constructions in HurwitzTheorem.lean (oneSquareIdentity, twoSquareIdentity, fourSquareIdentity, eight_square_identity_exists).",
+      "n = 3 impossibility: no_three_square_identity (Parseval + matrix invertibility, ~800 lines).",
+      "All odd n >= 3 impossibility: no_odd_nsquare via det(M)^2 = (-1)^n contradiction (line 1880).",
+      "Cross-matrix infrastructure for the even case: crossMat_skewSym, crossMat_transMul, crossMat_sq_neg_one, crossMat_anticommute (HurwitzTheorem.lean lines 1700-1879). These show that any NSquareIdentity n yields n-1 anti-commuting orthogonal complex structures on R^n — i.e., a real representation of Cl(0,n-1) on R^n.",
+      "hurwitz_field_case (HurwitzOnlyIf.lean): commutative subcase via Mathlib Gelfand-Mazur (NormedAlgebra.Real.nonempty_algEquiv_or)."
+    ],
+    "open": [
+      "HurwitzTheorem.lean:1937 — even n=2k with n notin {2,4,8}: from the n-1 anti-commuting orthogonal complex structures, conclude n in {1,2,4,8}. Requires lower bound on the dimension of any faithful real Cl(0,n-1)-module.",
+      "HurwitzOnlyIf.lean:111 — non-commutative subcase of hurwitz_only_if_ring: build NSquareIdentity (finrank R A) from a NormedDivisionRing instance, then apply HurwitzTheorem.hurwitz_only_if. The bridge construction (orthonormal basis -> bilinear mul preserving normSq) is itself doable; the bottleneck is the same downstream Cl-classification step."
+    ],
+    "goal": "Reduce HurwitzTheorem.lean sorry count from 1 to 0 (and HurwitzOnlyIf.lean from 1 to 0), promoting hurwitz-theorem from badge='wip' to badge='verified' (or 'original')."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-05-07T18:10:00Z",
+    "iteration": 2,
+    "focus": "Survey: full enumeration of what is proved upstream of the blocking sorry, mapping the gap to the missing Mathlib API.",
+    "blockers": [
+      "Mathlib has no classification of real Clifford algebras Cl(0,n-1) (Bott periodicity).",
+      "Mathlib has no Artin-Wedderburn structure theorem usable to compute the minimum faithful real representation dimension of a real semisimple algebra."
+    ],
+    "nextAction": "Either (a) wait for Mathlib Clifford-classification PRs to land, or (b) attempt the small-case decomposition: prove n=6 and n=10 directly (without Bott periodicity) using ad-hoc trace/determinant arguments, then leave only the asymptotic case as sorry. See nextSteps for a concrete decomposition.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "BLOCKED but cleanly localized. HurwitzTheorem.lean has a single sorry (line 1937) for even n notin {2,4,8}. All structural infrastructure is in place: crossMat_anticommute proves that an NSquareIdentity n yields n-1 anti-commuting orthogonal n x n real matrices M_j with M_j^2 = -I, i.e., a real n-dim representation of Cl(0,n-1). Closing the sorry requires the Clifford structure theorem (Bott periodicity for real Cl(0,k)) plus a minimum-rep-dim bound, neither of which is in Mathlib v4.26.0. HurwitzOnlyIf.lean has a parallel sorry for hurwitz_only_if_ring (the NormedDivisionRing formulation). 0 axioms in either file.",
+    "builtItems": [],
+    "insights": [
+      "All the linear algebra that the impossibility proof needs is already done in HurwitzTheorem.lean. The blocker is purely a Clifford-algebra structure theorem — there is no remaining 'analysis' or 'matrix' work to do at the gallery level.",
+      "Per-n decomposition is viable: the case n=6 reduces to showing that 5 anti-commuting orthogonal 6x6 real matrices cannot exist. A direct trace/dimension counting argument (Cl(0,5) has dim 32 over R; a faithful R-module needs dim >= 8) avoids invoking Bott periodicity, but still needs the Wedderburn structure of Cl(0,5).",
+      "n=10 has the same obstruction (Cl(0,9) ~= M(16,R)). For n=12,14,16,... the gap widens, so any 'finite case enumeration' approach saturates without a uniform argument.",
+      "HurwitzOnlyIf.lean line 109's 'orthonormal basis -> NSquareIdentity n' bridge is concrete linear algebra (no Clifford theory): expressible in ~80 lines using existing Mathlib LinearMap.IsometryEquiv + Module.Finite.finBasis. Decomposing hurwitz_only_if_ring along this seam would isolate the same blocker into one place.",
+      "Mathlib's Mathlib.LinearAlgebra.CliffordAlgebra.* (as of v4.26.0) provides the universal property and basic conjugation, but does NOT provide the periodicity/structure classification needed here (search Mathlib for 'CliffordAlgebra equivalent matrix' confirms no decomposition theorems).",
+      "The companion gallery entry hurwitz-theorem (badge='wip', sorries=1) sits on this exact blocker; closing it would graduate that entry to verified."
+    ],
+    "mathlibGaps": [
+      "Real Clifford algebra periodicity: Cl(0,n+8) ~= Cl(0,n) tensor M_{16}(R).",
+      "Artin-Wedderburn for real semisimple algebras: A ~= prod_i M_{n_i}(D_i), D_i in {R, C, H}.",
+      "Minimum-faithful-real-representation-dimension lemma for real semisimple algebras (lower bound on simple module dimension).",
+      "(Equivalent path) Atiyah's K-theory proof via Bott periodicity for KO-theory of S^{n-1}: requires KO-theory of spheres + parallelizability obstruction, which is even further from Mathlib's current scope."
+    ],
+    "nextSteps": [
+      "Decomposition option A (small cases): introduce private lemma `no_six_square_identity` and `no_ten_square_identity` covering the next two even cases via ad-hoc Cl(0,5), Cl(0,9) Wedderburn structure (hand-coded if needed). Localizes the open sorry to 'even n >= 12 with n notin {16}'.",
+      "Decomposition option B (algebra refactor): split HurwitzOnlyIf.hurwitz_only_if_ring into two lemmas — (1) `nsquareIdentity_of_normedDivisionRing` (concrete, no Clifford), (2) the existing axiom call to HurwitzTheorem.hurwitz_only_if. This eliminates the second sorry without adding/removing any total assumption.",
+      "Survey option C: open a Mathlib-side feature request / RFC for the Clifford classification API needed here, with a precise wishlist (CliffordAlgebra.equivOfBottPeriodicity, ClassicalLieAlgebra.realClassification, ...). Tracking issue, not Lean work.",
+      "Wait option D: monitor Mathlib master for CliffordAlgebra structure theorems; revisit when CliffordAlgebra.equiv* lemmas appear.",
+      "Aristotle option E: do NOT submit. The sorry is OPEN (genuinely missing infrastructure), not a routine lemma — Aristotle is the wrong tool."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "wip",
+    "algebra",
+    "number-theory",
+    "clifford-algebras",
+    "blocked-on-mathlib"
+  ],
+  "relatedProofs": [
+    "hurwitz-theorem",
+    "hurwitz-impossibility",
+    "hurwitz-three-square-impossibility"
+  ],
+  "references": {
+    "papers": [
+      "A. Hurwitz, Über die Composition der quadratischen Formen, Math. Ann. 88 (1923), 1-25 (posthumous; original 1898).",
+      "J. Baez, The Octonions, Bull. Amer. Math. Soc. 39 (2002), 145-205.",
+      "Bott & Milnor, On the parallelizability of the spheres, Bull. Amer. Math. Soc. 64 (1958), 87-89.",
+      "M.F. Atiyah, K-theory and reality, Quart. J. Math. Oxford 17 (1966), 367-386 — KO-theoretic proof."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Hurwitz%27s_theorem_(composition_algebras)",
+      "https://en.wikipedia.org/wiki/Bott_periodicity_theorem"
+    ],
+    "mathlib": [
+      "Mathlib.Algebra.Quaternion (Quaternion.normSq_mul, used for n=4 existence).",
+      "Mathlib.Analysis.Normed.Algebra.GelfandMazur (NormedAlgebra.Real.nonempty_algEquiv_or, used in HurwitzOnlyIf.hurwitz_field_case).",
+      "Mathlib.LinearAlgebra.CliffordAlgebra.Basic (universal property; does NOT include periodicity/structure classification as of v4.26.0).",
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic (Matrix.det, used in no_odd_nsquare)."
+    ]
+  },
+  "started": "2026-05-06T14:18:33.487Z",
+  "lastUpdate": "2026-05-07T18:10:00Z",
+  "significance": 7,
+  "tractability": 3
+}


### PR DESCRIPTION
## Summary

Session 2 (OBSERVE) of `hurwitz-theorem-wip-01` (the meta-problem to close
the last sorry in `hurwitz-theorem`).

The pre-existing JSON for this problem was a placeholder (`formalStatement = '(formal statement to be added)'`,
empty `knownResults`/`whyMatters`/`insights`/`references`). The problem
existed in the candidate pool but had no concrete content, so future
researchers were re-discovering the situation from scratch each session.

This PR replaces all placeholders with verified content mined from the
authoritative Lean files (`HurwitzTheorem.lean`, `HurwitzOnlyIf.lean`),
turning the problem from EMPTY (knowledge_score 3, WEAK) into RICH —
ready for productive follow-up sessions.

## What I verified

- `HurwitzTheorem.lean`: **0 axioms**, **1 sorry** at line 1937 (even $n \notin \{2, 4, 8\}$).
- `HurwitzOnlyIf.lean`: **0 axioms**, **1 sorry** at line 111 (`hurwitz_only_if_ring`, non-comm subcase).
- Both block on the same downstream Mathlib gap: real Clifford algebra structure classification (Bott periodicity + Artin-Wedderburn for real semisimple algebras), absent from Mathlib v4.26.0.

## What is NOT changing

- No Lean changes; sorry/axiom counts unchanged.
- No `meta.json` changes for the gallery entry `hurwitz-theorem`.

## Files

- `src/data/research/problems/hurwitz-theorem-wip-01.json` — replaced placeholder; phase NEW → OBSERVE; tractability 6 → 3 (correctly reflects Mathlib block); 6 insights, 4 mathlibGaps, 5 ranked nextSteps, full refs.
- `research/problems/hurwitz-theorem-wip-01/problem.md` — rewrote with formal statement, full proof-status table, precise Mathlib gap, 4 ranked next-action options.
- `research/problems/hurwitz-theorem-wip-01/state.md` — new (was previously a template stub, untracked in main).
- `research/problems/hurwitz-theorem-wip-01/sessions/2026-05-07-s02.md` — session report.

## Test plan

- [x] Counts manually verified by reading the Lean files (line numbers cited in docs).
- [x] No build needed (documentation-only).
- [x] No conflict with PR #14958 (different branch, different files).

## Notes for reviewers

- This is a SURVEY iteration, not an ACT. Per the researcher role's BLOCKED category: "Document blocker."
- Two future-work options surfaced: option B (refactor `hurwitz_only_if_ring` to localize the gap, ~80 lines, sorry count unchanged) and option A (small-case decomposition for $n = 6, 10$, ~400 lines per case). Both leave the underlying Mathlib block in place but make the situation cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)