### PR TITLE
research(ballot-gnw-exchange): gnwProb_at_other_corner + sum bridge lemma

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -13964,6 +13964,56 @@ private lemma strictHookCells_removeCorner_eq {μ : YoungDiagram} {c' : ℕ × �
       · have hc_eq : ν.colLen j = μ.colLen j := colLen_removeCorner_other hc' hjj'
         exact Or.inr ⟨r, ⟨hir, by rw [hc_eq]; exact hrc⟩, rfl⟩
 
+/-- For distinct corners `c` and `c'` of `μ`, `gnwProb μ c K c' = 0` for every termination
+    bound `K`.  At `K = 0` the function is identically zero; at `K + 1` the corner branch
+    fires and yields `if c' = c then 1 else 0 = 0`. -/
+private lemma gnwProb_at_other_corner {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc' : isCorner μ c') (hne : c ≠ c') (K : ℕ) :
+    gnwProb μ c K c' = 0 := by
+  cases K with
+  | zero => rfl
+  | succ K =>
+    have h_unfold : gnwProb μ c (K + 1) c' =
+        if isCorner μ c' then (if c' = c then (1 : ℚ) else 0)
+        else (1 / ↑(strictHookCells μ c'.1 c'.2).card : ℚ) *
+             ∑ y ∈ strictHookCells μ c'.1 c'.2, gnwProb μ c K y := rfl
+    rw [h_unfold, if_pos hc', if_neg (fun h : c' = c => hne h.symm)]
+
+/-- When `c'` is not in the strict hook of `(i, j)`, removing `c'` leaves the strict hook
+    unchanged.  Direct corollary of `strictHookCells_removeCorner_eq`. -/
+private lemma strictHookCells_removeCorner_eq_of_not_mem
+    {μ : YoungDiagram} {c' : ℕ × ℕ} (hc' : isCorner μ c') {i j : ℕ}
+    (hnotmem : c' ∉ strictHookCells μ i j) :
+    strictHookCells (removeCorner μ c' hc') i j = strictHookCells μ i j := by
+  rw [strictHookCells_removeCorner_eq hc' i j, ← Finset.erase_eq,
+      Finset.erase_eq_of_notMem hnotmem]
+
+/-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
+    strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
+    that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by
+    `c'`, and `gnwProb μ c K c' = 0` (`gnwProb_at_other_corner`).
+
+    Why this matters for `gnwProb_exchange`: the sum over `strictHookCells μ` appearing
+    in the recursive step of `gnwProb μ c (K+1) x` can be rewritten as a sum over
+    `strictHookCells (μ\c') x.1 x.2`.  Crucially, this lifts the recursive comparison
+    between `gnwProb μ` and `gnwProb (μ\c')` from "different summation domains" to "same
+    summation domain", isolating the remaining comparison to the integrand. -/
+private lemma sum_gnwProb_strictHookCells_eq_removeCorner
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc' : isCorner μ c') (hne : c ≠ c') (i j K : ℕ) :
+    ∑ y ∈ strictHookCells μ i j, gnwProb μ c K y =
+    ∑ y ∈ strictHookCells (removeCorner μ c' hc') i j, gnwProb μ c K y := by
+  have h0 : gnwProb μ c K c' = 0 := gnwProb_at_other_corner hc' hne K
+  rw [strictHookCells_removeCorner_eq hc' i j, ← Finset.erase_eq]
+  by_cases hc'mem : c' ∈ strictHookCells μ i j
+  · -- c' is in the strict hook: split off via Finset.sum_erase_add and use h0.
+    have hsum := Finset.sum_erase_add (strictHookCells μ i j)
+      (fun y => gnwProb μ c K y) hc'mem
+    -- hsum : ∑ y ∈ S.erase c', gnwProb μ c K y + gnwProb μ c K c' = ∑ y ∈ S, gnwProb μ c K y
+    linarith [hsum, h0]
+  · -- c' is not in the strict hook: S.erase c' = S.
+    rw [Finset.erase_eq_of_notMem hc'mem]
+
 /-- GNW 1979 exchange identity (core inductive step, product form — no division).
     For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
       F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)


### PR DESCRIPTION
## Summary

Three small structural lemmas for the `gnwProb_exchange` proof in `BallotProblemOQ03OQ01OQ02Helpers.lean`, building toward closing the final sorry:

1. **`gnwProb_at_other_corner`**: For distinct corners $c \neq c'$ of $\mu$, `gnwProb μ c K c' = 0` for every termination bound $K$. (At $K=0$, zero by definition; at $K+1$, the corner branch returns `if c' = c then 1 else 0 = 0`.)

2. **`strictHookCells_removeCorner_eq_of_not_mem`**: Direct corollary of `strictHookCells_removeCorner_eq` — when $c' \notin$ strict hook of $(i,j)$, removing $c'$ leaves the strict hook unchanged.

3. **`sum_gnwProb_strictHookCells_eq_removeCorner`** (the bridge):
   $$\sum_{y \in H^*(\mu, x)} \mathrm{gnwProb}\,\mu\,c\,K\,y = \sum_{y \in H^*(\mu \setminus c', x)} \mathrm{gnwProb}\,\mu\,c\,K\,y$$
   for $c \neq c'$.  The two sets differ at most by $c'$, and lemma 1 says the integrand vanishes there.

## Why this matters for `gnwProb_exchange`

The remaining sorry is `gnwProb_exchange` (Helpers:13985 on `origin/main`). Its recursive step expands `gnwProb μ c (K+1) x` as
$$\frac{1}{|H^*(\mu, x)|} \sum_{y \in H^*(\mu, x)} \mathrm{gnwProb}\,\mu\,c\,K\,y$$
The bridge lemma rewrites this sum over the same domain as in $\mu \setminus c'$:
$$\frac{1}{|H^*(\mu, x)|} \sum_{y \in H^*(\mu \setminus c', x)} \mathrm{gnwProb}\,\mu\,c\,K\,y$$
This lifts the recursive comparison between `gnwProb μ` and `gnwProb (μ\c')` from *different summation domains* to *same summation domain*, isolating the remaining comparison to the integrand.  Combined with the existing `hookLength_removeCorner_arm/leg` ratio identities and `hookProd_ratio_formula`, this is one of the last structural prerequisites for the algebraic assembly of the exchange identity.

## Companion to PR #16648

That PR (researcher-8) adds anti-monotone corner helpers (`corner_col_lt_of_row_lt`, `corner_row_lt_of_col_lt`, `doubly_affected_cell_mem`) at line ~4733.  This PR adds gnwProb-side helpers at line ~13967, just before `gnwProb_exchange`.  The contributions are orthogonal building blocks and should merge cleanly.

## Test plan

- [x] Lemma names cross-checked against existing usage in the `proofs/` tree:
  - `Finset.erase_eq` (Erdos278Problem.lean:260)
  - `Finset.sum_erase_add` (Erdos963Problem.lean:251)
  - `Finset.erase_eq_of_notMem` (Mathlib4 v4.26.0)
- [x] Three new private lemmas are entirely additive (50 inserted lines, 0 deleted), do not change `sorry` count, do not modify existing proofs.
- [x] `gnwProb_at_other_corner` follows the existing pattern in `gnwProb_sum_corners` (rfl-based unfold + `if_pos`/`if_neg`).
- [ ] Docker build to be verified post-push (pre-existing upstream `omega` errors in `Proofs/BallotProblemOQ03.lean` unrelated to this PR — reported in session 45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)