### PR TITLE
fix(meta): declare Aristotle companion in leanFile.additionalFiles (2 of 3 entries)

### DIFF
--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -193,7 +193,10 @@
     "theoremCount": 8,
     "definitionCount": 5,
     "path": "Proofs/Erdos433Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos433Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/meta.json
@@ -61,7 +61,10 @@
     "axiomCount": 0,
     "lineCount": 98,
     "theoremCount": 1,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Borel-Cantelli lemmas are among the most fundamental results in probability theory. The first lemma (BC1, proved by Borel in 1909 and Cantelli in 1917) states: if Σ P(Aₙ) < ∞ then P(Aₙ i.o.) = 0 — no independence is needed. The second lemma (BC2) states the converse direction: under full mutual independence and Σ P(Aₙ) = ∞, P(Aₙ i.o.) = 1. The condition of full mutual independence in BC2 seemed necessary until Erdős and Rényi (1959) showed that pairwise independence suffices. Their proof uses the Chebyshev-variance method, originally developed by Chung and Erdős (1952) in the context of convergent series. The result became a key ingredient in Etemadi's (1981) celebrated elementary proof of the strong law of large numbers: Etemadi used pairwise-independent BC2 to establish the necessity direction — if the SLLN holds for some subsequence then E[|X₀|] < ∞. Petrov (2002) showed that mere uncorrelated-ness (Cov(1_{Aᵢ}, 1_{Aⱼ}) = 0 without the joint probability condition) is not sufficient for BC2, confirming pairwise independence as the correct minimal threshold.",


### PR DESCRIPTION
## Fix

Adds the `*Aristotle` companion to `leanFile.additionalFiles` for two entries flagged by #16650:

- `erdos-433` → `Proofs/Erdos433Aristotle.lean`
- `laws-of-large-numbers-oq-01-oq-03` → `Proofs/LawsOfLargeNumbersOQ01Aristotle.lean`

## Evidence

For both entries on `origin/main` (`fa6ad48`):
1. The main `.lean` `import`s `Proofs.<Slug>Aristotle` (verified via `git show`).
2. `proofs/Proofs/<Slug>Aristotle.lean` exists.
3. Pre-fix `meta.json` had `leanFile.additionalFiles` missing/`null`; post-fix it lists the companion.

Auditor `find-targets.ts` sibling-follow (lines 182-186) masked this so axiom/sorry counts were correct — this is a structural metadata-completeness fix only, no count changes.

## Scope

Skipped the third entry `laws-of-large-numbers-oq-01-oq-01` per the issue's coordination note: PR #16005 (`research/slln-necessity`) is OPEN and modifies the same `meta.json`. That entry will be picked up after #16005 lands.

Convention follows PR #16518 and the ~143 entries already declaring their Aristotle companion.

Closes #16650 partially (2 of 3).

---
Automated fix by lean-mechanic agent.