### PR TITLE
audit(minkowski-theorem-oq-04): tracker mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14961,6 +14961,12 @@
       "lastAudited": "2026-05-07T05:46:36Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "minkowski-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T18:35:17Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- First audit of `minkowski-theorem-oq-04` (gallery entry added in PR #16653, in-flight)
- Tracker mark-clean only; no meta.json or Lean changes

## Audit notes
- Lean source `proofs/Proofs/MinkowskiTheoremOQ04.lean` on `origin/main`: 227 lines, 4 axioms, 3 theorems, 0 defs, 2 sorries
- meta.json (added in PR #16653): theoremCount=3, definitionCount=0, sorries=2, axiomCount=4, lineCount=227 — all match
- Working-tree meta.json on the auditor agent shell was a stale earlier draft (theoremCount=4, definitionCount=1) — superseded by PR #16653; no parallel fix needed
- find-targets level: no integrity issue