### PR TITLE
research(erdos-1-oq-02-oq-02): reconcile — dfx_lower_bound sorry resolved upstream

### DIFF
--- a/research/problems/erdos-1-oq-02-oq-02/knowledge.md
+++ b/research/problems/erdos-1-oq-02-oq-02/knowledge.md
@@ -1,21 +1,103 @@
 # Knowledge Base: erdos-1-oq-02-oq-02
 
-Insights accumulated during research on this problem.
+**Status**: COMPLETED — `dfx_lower_bound` is fully proved (0 sorries) since
+PR [#12782](https://github.com/rjwalters/lean-genius/pull/12782) (merged
+2026-04-26).
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+This problem entry was created 2026-04-23 to track a **base-case sorry** in
+`dfx_lower_bound`: how to handle the small cases $n = 1$ and $n = 2$, where the
+inductive argument of the Dubroff–Fox–Xu lower bound does not kick in and a
+direct computation is needed. The original concern was that
+$\lfloor \sqrt{2/\pi} \cdot 2^n / \sqrt{n}\rfloor$ does not normalize under
+`norm_num` because `Real.sqrt` and `Real.pi` are stubborn.
+
+This problem entry was superseded **before** any research session against the
+slug ran: PR #12782 (2026-04-26) reformulated `dfx_lower_bound`'s signature to
+exclude the small cases by precondition rather than by computation, eliminating
+the `sorry`.
 
 ---
 
-## Insights
+## Resolution (Session 2 — 2026-05-07)
 
-[Insights from research attempts will be accumulated here]
+**Mode**: REVISIT (verification + state reconciliation)
+**Outcome**: COMPLETED — Lean side already done; this session reconciles the
+research-tracking metadata.
+
+### What I Did
+
+1. **Inspected `proofs/Proofs/Erdos1OQ02.lean`** (268 lines, 1 axiom, 0
+   sorries). The relevant theorem is at line 145:
+
+   ```lean
+   theorem dfx_lower_bound (A : Finset ℕ) (N : ℕ)
+       (hDSS : hasDistinctSubsetSums A) (hA : ∀ a ∈ A, a ≤ N)
+       (hpos : 0 < A.card) (hN : 2 ≤ N)
+       (hA_pos : ∀ a ∈ A, 0 < a) :
+       (2 : ℝ) ^ A.card ≤ Real.sqrt (2 / π) * 2 * ↑(A.card) * ↑N
+                       / Real.sqrt ↑(A.card) := by ...
+   ```
+
+   The proof is entirely algebraic (Cauchy–Schwarz + sqrt manipulation +
+   `anticoncentration_bound` axiom). No base-case `sorry`.
+
+2. **Confirmed the small-case witnesses are proved separately**, not as
+   subcases of `dfx_lower_bound`:
+   - `f_one : ∃ A : Finset ℕ, A.card = 1 ∧ hasDistinctSubsetSums A ∧ A.sup id = 1`
+     (witness: `{1}`)
+   - `f_two_max : ∃ A : Finset ℕ, A.card = 2 ∧ A.sup id = 2`
+     (witness: `{1, 2}`)
+
+3. **Located the resolving PR.** `git log -- proofs/Proofs/Erdos1OQ02.lean`
+   shows commit `72ed399f304` (PR
+   [#12782](https://github.com/rjwalters/lean-genius/pull/12782), 2026-04-26):
+   *"feat(erdos-1-wip-01): prove dfx_lower_bound + pow2_dss (3 sorries
+   removed)"*. That PR removed the `sorry` this problem entry was created
+   to track.
+
+### Insights
+
+- **Right abstraction was preconditions, not computation.** The original
+  problem brief proposed `by norm_num` or `by native_decide` to discharge
+  $n = 1, 2$ at the value level. That doesn't work for terms involving
+  `Real.sqrt` and `Real.pi`. The actual fix was to *narrow the theorem's
+  domain* — adding `hN : 2 ≤ N` and `hA_pos : ∀ a ∈ A, 0 < a` excludes the
+  small cases by hypothesis. Small-card existence is proved as separate
+  theorems where they fit (`f_one`, `f_two_max`).
+
+- **`Real.sqrt` and `Real.pi` are not `norm_num`-friendly.** Anyone tempted
+  to discharge inequalities involving `√(2/π)` numerically should expect
+  `norm_num` to fail and reach for hypothesis-tightening or Mathlib's
+  `Real.pi_gt_three` / `Real.sqrt_lt_sqrt` interval reasoning instead.
+
+- **The remaining axiom is intentional.** `anticoncentration_bound` is the
+  Berry–Esseen anti-concentration estimate that the DFX paper invokes
+  blackbox. Discharging it requires Mathlib probability infrastructure that
+  is out-of-scope for *this* OQ; that work is tracked by
+  `erdos-1-oq-02-oq-01`.
+
+### Built Items (from PR #12782)
+
+- `Erdos1OQ02.lean : dfx_lower_bound` — theorem, 73 lines, 0 sorries, proved
+- `Erdos1OQ02.lean : f_one` — small-case DSS witness for $n = 1$, proved
+- `Erdos1OQ02.lean : f_two_max` — small-case DSS witness for $n = 2$, proved
+- Supporting lemmas: `sum_sq_cauchy_schwarz`, `sum_sq_le_card_mul_max_sq`,
+  `sum_le_card_mul_max` (all proved in the same file)
+
+### Dead Ends Avoided (recorded for future reference)
+
+- **Numerical base-case discharge of $\lfloor \sqrt{2/\pi} \cdot 2^n /
+  \sqrt{n}\rfloor$ for $n = 1, 2$ via `norm_num` / `native_decide`.**
+  Doesn't reduce because `Real.sqrt` and `Real.pi` are uncomputable. The
+  original problem brief flagged this risk but proposed it anyway; the
+  team correctly chose hypothesis-tightening instead.
 
 ---
 
-## Dead Ends
+## Status
 
-[Approaches known not to work will be documented here]
+**RESOLVED 2026-04-26** by PR #12782. This entry is closed.

--- a/research/problems/erdos-1-oq-02-oq-02/problem.md
+++ b/research/problems/erdos-1-oq-02-oq-02/problem.md
@@ -2,7 +2,7 @@
 
 **Slug**: erdos-1-oq-02-oq-02
 **Created**: 2026-04-23T11:58:33+02:00
-**Status**: Active
+**Status**: COMPLETED — resolved 2026-04-26 by PR [#12782](https://github.com/rjwalters/lean-genius/pull/12782); the `dfx_lower_bound` sorry was eliminated by tightening the theorem's preconditions (`hN : 2 ≤ N`, `hA_pos : ∀ a ∈ A, 0 < a`) rather than by computational base-case checks. See `knowledge.md` for the full resolution narrative.
 **Source**: gallery-gap
 
 ## Problem Statement

--- a/research/problems/erdos-1-oq-02-oq-02/state.md
+++ b/research/problems/erdos-1-oq-02-oq-02/state.md
@@ -1,25 +1,37 @@
 # Research State: erdos-1-oq-02-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-23T11:58:33+02:00
-**Iteration**: 1
+**Since**: 2026-05-07T18:35:00Z
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Problem resolved upstream of any session on this slug. The "fix the sorry in
+`dfx_lower_bound`" question was answered by PR
+[#12782](https://github.com/rjwalters/lean-genius/pull/12782) (merged
+2026-04-26, three days *after* this problem entry was created), which proved
+`dfx_lower_bound` end-to-end with **0 sorries**. The base-case concern (n = 1, n = 2)
+was sidestepped by tightening the theorem signature with the preconditions
+`hN : 2 ≤ N` and `hA_pos : ∀ a ∈ A, 0 < a`; small-case existence is proved
+separately by the `f_one` and `f_two_max` theorems in the same file.
 
 ## Active Approach
-None yet.
+None — work complete.
+
+The remaining single `axiom` in `Erdos1OQ02.lean` (`anticoncentration_bound`,
+the Berry–Esseen anti-concentration estimate) is intentional probability-theory
+infrastructure and is the subject of a separate research thread,
+`erdos-1-oq-02-oq-01`. It is *not* in scope here.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None. The Lean obligation this problem tracked is fully discharged. This
+problem entry can be closed; remove from the active candidate pool.


### PR DESCRIPTION
## Summary

This research problem (`erdos-1-oq-02-oq-02`, *"Can the sorry in dfx_lower_bound be fixed"*) was created 2026-04-23 to track a base-case `sorry` in `dfx_lower_bound`. **Three days later, PR [#12782](https://github.com/rjwalters/lean-genius/pull/12782) (merged 2026-04-26) resolved it.** This PR reconciles the research-tracking metadata to reflect the resolved state.

**No Lean changes; no sorry/axiom delta. Pure markdown reconciliation.**

### Verified state of `proofs/Proofs/Erdos1OQ02.lean`

| Metric | Value |
|---|---|
| Lines | 268 |
| Sorries | 0 |
| Axioms | 1 (`anticoncentration_bound`, intentional Berry–Esseen) |
| Theorems | 8 |
| `dfx_lower_bound` location | line 145 |

`dfx_lower_bound` is fully proved end-to-end. Small-card DSS witnesses are proved separately as `f_one` (witness `{1}`) and `f_two_max` (witness `{1, 2}`).

### What changed in PR #12782 vs. the original problem brief

The brief proposed using `by norm_num` or `by native_decide` to discharge $\lfloor \sqrt{2/\pi} \cdot 2^n / \sqrt{n}\rfloor$ at $n=1, 2$. That doesn't work — `Real.sqrt` and `Real.pi` are uncomputable. PR #12782 instead **tightened the theorem signature** with the preconditions `hN : 2 ≤ N` and `hA_pos : ∀ a ∈ A, 0 < a`, excluding small cases by hypothesis rather than by computation. The right abstraction was preconditions, not numerics.

### What this PR does

- `state.md` → Phase `OBSERVE` → `COMPLETED`; Next Action: none.
- `knowledge.md` → adds full Session 2 resolution narrative, three insights (preconditions vs. `norm_num`; `Real.sqrt`/`pi` non-reduction; remaining axiom pointer), and built-items list pointing at the resolving PR.
- `problem.md` → top-level `Status: Active` → `Status: COMPLETED` with a pointer to PR #12782.

### Out of scope for this PR

- The remaining single `axiom` (`anticoncentration_bound`) is intentional probability-theory infrastructure tracked separately by `erdos-1-oq-02-oq-01`.
- The `src/data/research/problems/erdos-1-oq-02-oq-02.json` file is auto-generated by `scripts/research/build.ts` from the per-problem markdown directory and is not currently tracked in main; the deployer's next sync will regenerate it from the updated markdown.

## Test plan

- [ ] No build needed — documentation-only.
- [ ] `pnpm build` (gallery) unaffected — only research metadata touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)