### PR TITLE
research(erdos-1201): reconcile state.md with merged gallery state (NEW → COMPLETED)

### DIFF
--- a/research/problems/erdos-1201/state.md
+++ b/research/problems/erdos-1201/state.md
@@ -1,27 +1,44 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-16T17:08:10.920Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-05-04T00:00:00Z
+**Iteration**: 19
 
 ## Current Focus
 
-Initial exploration of the problem.
+Gallery entry merged (PR #15109 and follow-ups through session 19): 1651 lines,
+116 theorems/lemmas, 8 defs, 1 axiom (`erdos_1201_half_case` for $\varepsilon = 1/2$
+partial result), 0 sorries. Status: `axiomatized`, badge: `axiom`. The full
+conjecture remains open at the research level; the axiom encodes Erdős's claimed
+$\varepsilon = 1/2$ partial result.
 
 ## Active Approach
 
-None yet.
+None — work complete at this slug. Sessions 1–19 built out the full window-GPF
+algebra (recursive max formula, window-concat, smooth-window duality, density
+monotonicity, lower-density infrastructure, lowerDensity_compl identity), the
+ε-monotonicity reduction `erdos_1201_equiv_small_eps` (open frontier formally
+restricted to $\varepsilon \in (0, 1/2)$), and the conditional reduction
+`erdos_1201_smooth_decay_implies_conjecture` (full conjecture follows from
+Dickman-ρ-style smooth-window decay).
 
 ## Blockers
 
-None.
+None at this slug. The remaining open research direction (eliminate
+`erdos_1201_half_case` for $\varepsilon \in (0, 1/2)$) requires Dickman-ρ
+smooth-number density estimates — at least 1000 lines of foundational Mathlib
+infrastructure — and is genuinely BLOCKED upstream until that infrastructure
+lands. See session-19 note: *"erdos-1201 is mature; researcher time better spent
+on different problems."*
 
 ## Next Action
 
-Begin problem exploration.
+None at this slug. Open research direction: prove `erdos_1201_half_case`
+(Erdős's claimed $\varepsilon = 1/2$ partial result), which would convert the
+axiom into a theorem; this is a multi-month undertaking blocked on Dickman ρ.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 19
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 19


### PR DESCRIPTION
## Summary

PR [#16600](https://github.com/rjwalters/lean-genius/pull/16600) (merged 2026-05-07) reconciled `src/data/research/problems/erdos-1201.json` to `phase: COMPLETED` and populated knowledge with the merged-gallery snapshot, but **`research/problems/erdos-1201/state.md` was left at `Phase: NEW / Iteration: 1`**.

`scripts/research/build.ts` parses `state.md` to populate `currentState.phase` in the regenerated JSON, so the next sync would silently revert PR #16600's `COMPLETED` back to `NEW`. This PR aligns the markdown source-of-truth with the already-merged JSON state.

**No Lean changes. Pure markdown reconciliation.**

### Verified gallery state (origin/main)

| Metric | Value |
|---|---|
| `proofs/Proofs/Erdos1201Problem.lean` lines | 1651 |
| Theorems / lemmas | 116 |
| Definitions | 8 |
| Axioms | 1 (`erdos_1201_half_case` — ε=1/2 partial result) |
| Sorries | 0 |
| Gallery status | `axiomatized` |
| Badge | `axiom` |

### Why this is the right phase

Sessions 1–19 (per `knowledge.md`) built out:
- the full window-GPF algebra (recursive max formula, window-concat, smooth-window duality);
- density monotonicity in both $k$ and $\varepsilon$, lower-density infrastructure, `lowerDensity_compl` identity;
- the ε-monotonicity reduction `erdos_1201_equiv_small_eps`, formally restricting the open frontier to $\varepsilon \in (0, 1/2)$;
- the conditional reduction `erdos_1201_smooth_decay_implies_conjecture` (full conjecture follows from Dickman-ρ-style smooth-window decay).

Remaining research direction (eliminate `erdos_1201_half_case` for $\varepsilon \in (0, 1/2)$) is genuinely BLOCKED upstream on Mathlib Dickman-ρ smooth-number density infrastructure (>1000 lines). Per the session-19 note: *"erdos-1201 is mature; researcher time better spent on different problems."*

## Test plan

- [ ] No build needed — documentation-only.
- [ ] Confirm next `scripts/research/build.ts` run leaves `currentState.phase = "COMPLETED"` (no longer regressing to NEW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)