### PR TITLE
research(binary-gcd-oq-03-oq-02): row-output composition under `mul` (Session 12)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -774,6 +774,143 @@ theorem row_product_with_invariant (M : CofactorMatrix)
          by linear_combination (2 : ℤ) ^ s * hinv₂⟩
 
 -- ═══════════════════════════════════════════════════════════════
+-- PART VIIc: ROW-OUTPUT COMPOSITION FOR `mul` (Session 12)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### Row-output composition under matrix multiplication
+
+The PART IX docstring on `hgcdMatrix_row_output_le` identifies the
+structural obstacle blocking the recursive case: the IH for the inner
+matrix is at `(aHi, bHi)`, but we need the row output of the inner
+matrix on a *different* pair (the row output of the outer matrix on
+`(a, b)`). This subsection records the algebraic identity that lets
+us substitute one row-output computation for another, plus a clean
+`natAbs` triangle bound that combines an *input*-side bound on the
+outer matrix's row output with an *entry*-side bound on the inner
+matrix.
+
+Key identity (`cofactor_mul_row_output`):
+
+  `a · (M.mul N).α + b · (M.mul N).γ`
+    `= N.α · (a · M.α + b · M.γ) + N.γ · (a · M.β + b · M.δ)`
+  `a · (M.mul N).β + b · (M.mul N).δ`
+    `= N.β · (a · M.α + b · M.γ) + N.δ · (a · M.β + b · M.δ)`
+
+i.e. the row output of `M.mul N` on `(a, b)` equals the row output of
+`N` evaluated at the row output of `M` on `(a, b)`.  This is the
+"row-convention" analogue of `cofactor_mul_apply` (column convention).
+
+Combined with entry bounds for `N` (Step 2b: `entry_bound_of_even/odd`)
+and a row-output bound for `M` (the IH being applied at the outer
+matrix's *own* inputs), this yields a row-output bound for `M.mul N`
+without ever needing a row-output bound for `N` at the outer
+matrix's row output. -/
+
+/-- Triangle bound for row products of a single cofactor matrix.
+
+    `(a · M.α + b · M.γ).natAbs ≤ |a| · |M.α| + |b| · |M.γ|`
+    `(a · M.β + b · M.δ).natAbs ≤ |a| · |M.β| + |b| · |M.δ|`
+
+    This is the row-convention analogue of `cofactor_apply_natAbs_le`
+    (which applies to the column convention `M.α · a + M.β · b`,
+    `M.γ · a + M.δ · b`). The two row products use a different pair
+    of entries, so a separate lemma is needed. -/
+theorem cofactor_row_natAbs_le (M : CofactorMatrix) (a b : ℤ) :
+    (a * M.α + b * M.γ).natAbs ≤ a.natAbs * M.α.natAbs + b.natAbs * M.γ.natAbs ∧
+    (a * M.β + b * M.δ).natAbs ≤ a.natAbs * M.β.natAbs + b.natAbs * M.δ.natAbs := by
+  refine ⟨?_, ?_⟩
+  · calc (a * M.α + b * M.γ).natAbs
+        ≤ (a * M.α).natAbs + (b * M.γ).natAbs := Int.natAbs_add_le _ _
+      _ = a.natAbs * M.α.natAbs + b.natAbs * M.γ.natAbs := by
+            simp [Int.natAbs_mul]
+  · calc (a * M.β + b * M.δ).natAbs
+        ≤ (a * M.β).natAbs + (b * M.δ).natAbs := Int.natAbs_add_le _ _
+      _ = a.natAbs * M.β.natAbs + b.natAbs * M.δ.natAbs := by
+            simp [Int.natAbs_mul]
+
+/-- Row-output bound from entry bounds and input bounds.
+
+    If every entry of `M` is bounded in absolute value by `E`, and the
+    inputs `a, b` are bounded in absolute value by `R`, then both row
+    products of `M` on `(a, b)` are bounded by `2 · E · R`. -/
+theorem cofactor_row_natAbs_le_of_entry_bounds (M : CofactorMatrix) (a b : ℤ)
+    (E R : ℕ)
+    (hα : M.α.natAbs ≤ E) (hβ : M.β.natAbs ≤ E)
+    (hγ : M.γ.natAbs ≤ E) (hδ : M.δ.natAbs ≤ E)
+    (ha : a.natAbs ≤ R) (hb : b.natAbs ≤ R) :
+    (a * M.α + b * M.γ).natAbs ≤ 2 * E * R ∧
+    (a * M.β + b * M.δ).natAbs ≤ 2 * E * R := by
+  obtain ⟨h1, h2⟩ := cofactor_row_natAbs_le M a b
+  refine ⟨?_, ?_⟩
+  · calc (a * M.α + b * M.γ).natAbs
+        ≤ a.natAbs * M.α.natAbs + b.natAbs * M.γ.natAbs := h1
+      _ ≤ R * E + R * E :=
+            Nat.add_le_add (Nat.mul_le_mul ha hα) (Nat.mul_le_mul hb hγ)
+      _ = 2 * E * R := by ring
+  · calc (a * M.β + b * M.δ).natAbs
+        ≤ a.natAbs * M.β.natAbs + b.natAbs * M.δ.natAbs := h2
+      _ ≤ R * E + R * E :=
+            Nat.add_le_add (Nat.mul_le_mul ha hβ) (Nat.mul_le_mul hb hδ)
+      _ = 2 * E * R := by ring
+
+/-- Row-output composition under `CofactorMatrix.mul`.
+
+    The row output of `M.mul N` on `(a, b)` equals the row output of
+    `N` evaluated at the row output of `M` on `(a, b)`. Pure algebra
+    (`ring`); this is the row-convention dual of `cofactor_mul_apply`. -/
+theorem cofactor_mul_row_output (M N : CofactorMatrix) (a b : ℤ) :
+    a * (M.mul N).α + b * (M.mul N).γ =
+      N.α * (a * M.α + b * M.γ) + N.γ * (a * M.β + b * M.δ) ∧
+    a * (M.mul N).β + b * (M.mul N).δ =
+      N.β * (a * M.α + b * M.γ) + N.δ * (a * M.β + b * M.δ) := by
+  simp only [CofactorMatrix.mul]
+  refine ⟨?_, ?_⟩ <;> ring
+
+/-- Row-output bound for `M.mul N` from a row-output bound on `M` and
+    entry bounds on `N`.
+
+    If both row products of `M` on `(a, b)` have `natAbs ≤ R`, and every
+    entry of `N` has `natAbs ≤ E`, then both row products of `M.mul N`
+    on `(a, b)` have `natAbs ≤ 2 · E · R`.
+
+    Combining `cofactor_mul_row_output` (rewrite to row-of-N applied to
+    row-of-M) with the row-natAbs triangle bound, factoring out `N`'s
+    entry bounds. This is the central infrastructure lemma for the
+    joint-induction approach to `hgcdMatrix_row_output_le`: the IH for
+    the inner matrix supplies the entry bounds on `N`, the IH for the
+    outer matrix supplies the row-output bound on `M`. -/
+theorem cofactor_mul_row_output_natAbs_le {M N : CofactorMatrix} {a b : ℤ}
+    {R E : ℕ}
+    (hM₁ : (a * M.α + b * M.γ).natAbs ≤ R)
+    (hM₂ : (a * M.β + b * M.δ).natAbs ≤ R)
+    (hNα : N.α.natAbs ≤ E) (hNβ : N.β.natAbs ≤ E)
+    (hNγ : N.γ.natAbs ≤ E) (hNδ : N.δ.natAbs ≤ E) :
+    (a * (M.mul N).α + b * (M.mul N).γ).natAbs ≤ 2 * E * R ∧
+    (a * (M.mul N).β + b * (M.mul N).δ).natAbs ≤ 2 * E * R := by
+  obtain ⟨hα_eq, hβ_eq⟩ := cofactor_mul_row_output M N a b
+  refine ⟨?_, ?_⟩
+  · rw [hα_eq]
+    calc (N.α * (a * M.α + b * M.γ) + N.γ * (a * M.β + b * M.δ)).natAbs
+        ≤ (N.α * (a * M.α + b * M.γ)).natAbs
+            + (N.γ * (a * M.β + b * M.δ)).natAbs := Int.natAbs_add_le _ _
+      _ = N.α.natAbs * (a * M.α + b * M.γ).natAbs
+            + N.γ.natAbs * (a * M.β + b * M.δ).natAbs := by
+              simp [Int.natAbs_mul]
+      _ ≤ E * R + E * R :=
+            Nat.add_le_add (Nat.mul_le_mul hNα hM₁) (Nat.mul_le_mul hNγ hM₂)
+      _ = 2 * E * R := by ring
+  · rw [hβ_eq]
+    calc (N.β * (a * M.α + b * M.γ) + N.δ * (a * M.β + b * M.δ)).natAbs
+        ≤ (N.β * (a * M.α + b * M.γ)).natAbs
+            + (N.δ * (a * M.β + b * M.δ)).natAbs := Int.natAbs_add_le _ _
+      _ = N.β.natAbs * (a * M.α + b * M.γ).natAbs
+            + N.δ.natAbs * (a * M.β + b * M.δ).natAbs := by
+              simp [Int.natAbs_mul]
+      _ ≤ E * R + E * R :=
+            Nat.add_le_add (Nat.mul_le_mul hNβ hM₁) (Nat.mul_le_mul hNδ hM₂)
+      _ = 2 * E * R := by ring
+
+-- ═══════════════════════════════════════════════════════════════
 -- PART VIII: SIZE REDUCTION PREREQUISITES (Step 4 foundations)
 -- ═══════════════════════════════════════════════════════════════
 
@@ -1003,14 +1140,33 @@ theorem hgcdMatrix_row_output_le (fuel a b : ℕ) :
     of `hgcdMatrix (fuel+1) a b` is ≤ `max a b`. Proved using `hgcdMatrix_small`
     and `lehmerCofactors_id_apply_le`.
 
+15. **Row-output composition under `mul`** (PART VIIc, Session 12):
+    - `cofactor_row_natAbs_le`: row-convention triangle bound,
+      `(a·M.α + b·M.γ).natAbs ≤ |a|·|M.α| + |b|·|M.γ|` (and symmetrically).
+    - `cofactor_row_natAbs_le_of_entry_bounds`: combined bound, given
+      `|M.•| ≤ E` and `|a|, |b| ≤ R`, both row products are ≤ `2·E·R`.
+    - `cofactor_mul_row_output`: the algebraic identity
+      `a·(M.mul N).α + b·(M.mul N).γ = N.α·(a·M.α + b·M.γ) + N.γ·(a·M.β + b·M.δ)`
+      (and symmetrically). Row output of `M.mul N` on `(a, b)` equals the row
+      output of `N` evaluated at the row output of `M` on `(a, b)`. This is
+      the row-convention dual of `cofactor_mul_apply`. Proved by `ring`.
+    - `cofactor_mul_row_output_natAbs_le`: from a row-output bound on `M`
+      (`R`) and entry bounds on `N` (`E`), the row output of `M.mul N` is
+      bounded by `2·E·R`. This decouples the IH for the inner matrix
+      (entries) from the IH for the outer matrix (row output), avoiding the
+      Session 11 obstacle where M₂'s IH was at the wrong inputs.
+
 **Remaining for size reduction (1 sorry):**
 - `hgcdMatrix_row_output_le` (PART IX): the full row-output bound for all fuel.
   Base cases (fuel=0 and threshold case) are proved; the **missing piece** is the
-  recursive case. Session 11 sign-pattern analysis: individual entries of M₁ and M₂
-  are bounded by `max(aHi,bHi)`, but `rowOut(M₂, rowOut(M₁))` can reach `2·max(a,b)`
-  because M₂'s IH is at its column-output inputs (from M₁), not the row-output.
-  The proof requires joint induction tracking both row and column output bounds
-  (Stehlé–Zimmermann 2004 §4 approach).
+  recursive case. The Session 12 infrastructure (PART VIIc) reframes the
+  recursive case so that the inner subproblem `M_inner = hgcdMatrix f aHi bHi`
+  contributes via *entry* bounds (still to be derived from
+  `lehmerCofactors_has_pattern` + `entry_bound_of_even/odd`, lifted to
+  arbitrary fuel) rather than via its row-output bound at the wrong inputs.
+  The remaining gap is a `hgcdMatrix_entry_bound` lemma (analogue of
+  `entry_bound_of_even/odd` for HGCD), which will need a sign-pattern
+  invariant for `hgcdMatrix` extending the Lehmer-only argument.
 
 **Out of scope (deferred):**
 - Bit-complexity bound O(M(n)·log n): requires Mathlib infrastructure

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -18,20 +18,20 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-01T00:00:00.000Z",
-    "iteration": 5,
-    "focus": "Step 2b complete (Session 4): Cramer identity + sign pattern + entry bounds in PART VI. Next: Session 5 Step 3 perturbation bound.",
+    "iteration": 12,
+    "focus": "Session 12 (2026-05-07): row-output composition under `mul` (PART VIIc). Reframed the recursive-case obstacle of hgcdMatrix_row_output_le by adding cofactor_mul_row_output (algebraic identity) + cofactor_mul_row_output_natAbs_le (entry-bound × row-output combiner). Next: hgcdMatrix_entry_bound (sign-pattern lifted across HGCD recursion).",
     "blockers": [
       "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication. Genuinely blocked; not a blocker on size-reduction work."
     ],
-    "nextAction": "Session 4: Cramer-inversion entry bound. From the row-vector invariant (a₀, b₀) · M = (ahat', bhat') and det M = ±1, invert to (a₀, b₀) = (ahat', bhat') · M⁻¹ and bound entries of M.",
+    "nextAction": "Session 13: prove hgcdMatrix_entry_bound — extend lehmerCofactors_has_pattern + entry_bound_of_even/odd through the HGCD recursion. With this lemma plus PART VIIc Session 12 infrastructure (cofactor_mul_row_output_natAbs_le), the recursive case of hgcdMatrix_row_output_le closes by joint induction.",
     "attemptCounts": {
-      "total": 4,
+      "total": 12,
       "currentApproach": 1,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "Session 7 (2026-05-03): CORRECTION + PROGRESS — discovered hgcdMatrix_joint_bound is FALSE (column convention output is not bounded). Replaced with correct row-output bound. Proved base case hgcdMatrix_small_row_output_le. hgcdMatrix_row_output_le has 1 sorry (recursive case) requiring new invariant infrastructure.",
+    "progressSummary": "Session 12 (2026-05-07): row-output composition under `mul` (PART VIIc, +155 lines, 4 lemmas, 0 new sorries). Added cofactor_row_natAbs_le, cofactor_row_natAbs_le_of_entry_bounds, cofactor_mul_row_output (algebraic identity: row-out of M.mul N on (a,b) = row-out of N at row-out of M on (a,b)), and cofactor_mul_row_output_natAbs_le (combines a row-output bound on M with entry bounds on N). Decouples the IH for the inner subproblem (entries) from the IH for the outer subproblem (row output), avoiding the Session 11 obstacle. Remaining: 1 sorry (recursive case) now reduced to a hgcdMatrix_entry_bound lemma — sign-pattern across HGCD recursion. | Session 7 (2026-05-03): discovered hgcdMatrix_joint_bound is FALSE (column convention output is not bounded). Replaced with correct row-output bound. Proved base case hgcdMatrix_small_row_output_le.",
     "builtItems": [
       "BinaryGcdOQ03OQ02.lean: hgcdMatrix def — fuel-indexed recursive HGCD (Schönhage). Threshold-based bottoming via lehmerCofactors; otherwise top-half-shift recursion + apply + bottom-half recursion + matrix product.",
       "BinaryGcdOQ03OQ02.lean: cofactor_mul_apply — proves CofactorMatrix.mul corresponds to composition of CofactorMatrix.apply. Algebraic kernel justifying the M₂.mul M₁ return.",
@@ -57,7 +57,11 @@
       "BinaryGcdOQ03OQ02.lean PART VII: cofactor_apply_err_bound_snd — same bound for second component using |M.γ|,|M.δ|.",
       "hgcdMatrix_small_row_output_le (proved): for max a b < hgcdThreshold, row output of hgcdMatrix (fuel+1) a b is bounded by max a b. Proved via hgcdMatrix_small + lehmerCofactors_id_apply_le. BinaryGcdOQ03OQ02.lean:824",
       "hgcdMatrix_row_output_le (1 sorry): full statement that row output of hgcdMatrix fuel a b <= max a b. Base cases proved; recursive case sorry. BinaryGcdOQ03OQ02.lean:850",
-      "native_decide counterexample: (hgcdMatrix 1 37 5).apply(37,5).2.natAbs = 184 and 2^(hgcdShift 37 5 + 3) = 64. Confirms falsity of joint-bound column statement."
+      "native_decide counterexample: (hgcdMatrix 1 37 5).apply(37,5).2.natAbs = 184 and 2^(hgcdShift 37 5 + 3) = 64. Confirms falsity of joint-bound column statement.",
+      "BinaryGcdOQ03OQ02.lean PART VIIc (Session 12): cofactor_row_natAbs_le — row-convention triangle bound, |a*M.α + b*M.γ| ≤ |a|*|M.α| + |b|*|M.γ| (and symmetrically). Dual of cofactor_apply_natAbs_le (column).",
+      "BinaryGcdOQ03OQ02.lean PART VIIc (Session 12): cofactor_row_natAbs_le_of_entry_bounds — given |M.•| ≤ E and |a|, |b| ≤ R, both row products of M on (a, b) are ≤ 2*E*R.",
+      "BinaryGcdOQ03OQ02.lean PART VIIc (Session 12): cofactor_mul_row_output — pure-algebra identity (ring) showing the row output of (M.mul N) on (a,b) equals the row output of N evaluated at the row output of M on (a,b). Row-convention dual of cofactor_mul_apply.",
+      "BinaryGcdOQ03OQ02.lean PART VIIc (Session 12): cofactor_mul_row_output_natAbs_le — given (a*M.α+b*M.γ).natAbs ≤ R, (a*M.β+b*M.δ).natAbs ≤ R, and entry bounds |N.•| ≤ E, both row products of (M.mul N) on (a,b) are ≤ 2*E*R. The infrastructure lemma decoupling outer-row-bound IH from inner-entry-bound IH for the joint induction in hgcdMatrix_row_output_le."
     ],
     "insights": [
       "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
@@ -76,7 +80,8 @@
       "Step 3 algebraic split is clean: apply(aHi·2^s+ea, bHi·2^s+eb) = 2^s·apply(aHi,bHi) + apply(ea,eb). Proved by ring. This reduces Step 3 to bounding the error apply(ea,eb) using Step 2b entry bounds (|M.α|,|M.β| ≤ max(aHi,bHi)) and the fact ea,eb < 2^s.",
       "The MISSING piece for closing hgcdMatrix_size_reduction is inductive: need to show hgcdMatrix fuel aHi bHi reduces max(aHi,bHi) by at least half. This is an induction on bitsize that requires fuel to track depth — genuinely recursive and multi-session.",
       "hgcdMatrix_joint_bound is FALSE: for a=37,b=5, column output component has natAbs=184 > 64=2^(hgcdShift 37 5+3). Root cause: right-accumulated Lehmer matrix satisfies row convention, NOT column convention. Column output = M.alpha*a + M.beta*b is NOT bounded by max a b.",
-      "Correct bound is on ROW output: (a*M.alpha + b*M.gamma, a*M.beta + b*M.delta) gives Euclidean residues bounded by max a b. This is the content of lehmerCofactors_id_apply_le, extended to hgcdMatrix."
+      "Correct bound is on ROW output: (a*M.alpha + b*M.gamma, a*M.beta + b*M.delta) gives Euclidean residues bounded by max a b. This is the content of lehmerCofactors_id_apply_le, extended to hgcdMatrix.",
+      "Session 12 reframing: the row output of (M.mul N) on (a,b) is the row output of N at the row output of M on (a,b). This algebraic identity (cofactor_mul_row_output, proved by ring) lets the joint induction substitute entry bounds for N (independent of (a,b)) in place of a row-output bound for N at the wrong inputs. The recursive case of hgcdMatrix_row_output_le now reduces to: (a) a row-output bound for the outer matrix (M_outer's IH at its own column-output inputs feeds in via cofactor_mul_row_output_natAbs_le), and (b) entry bounds for the inner matrix (still to be derived from a hgcdMatrix-wide sign-pattern invariant)."
     ],
     "mathlibGaps": [
       "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
@@ -85,9 +90,8 @@
       "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
     ],
     "nextSteps": [
-      "Recursive case of hgcdMatrix_row_output_le: need invariant tracking that hgcdMatrix f a b was constructed for inputs (a,b), so rowOut(M2*M1,a,b) feeds correctly into the IH for M2.",
-      "Specifically: hgcdMatrix_succ defines M1=hgcdMatrix f (a/2^s) (b/2^s) and M2=hgcdMatrix f (rowOut M1 applied to a/2^s,b/2^s). Prove rowOut(M2*M1, a, b) = rowOut(M1, rowOut(M2, a/2^s, b/2^s)) * 2^s + small-correction.",
-      "Alternative: prove stronger invariant that rowOut(hgcdMatrix fuel a b, a, b) <= max a b by tracking the Euclidean algorithm relation explicitly rather than via matrix IH."
+      "Session 13 — hgcdMatrix_entry_bound: prove that every entry of `hgcdMatrix fuel a b` has natAbs ≤ max a b (or some uniform bound parameterized by max a b). Strategy: lift the EvenPattern/OddPattern invariant from `lehmerCofactors_has_pattern` to hgcdMatrix by tracking the sign pattern across the threshold/recursive cases, then apply entry_bound_of_even/odd at each level. Combined with the Session 12 cofactor_mul_row_output_natAbs_le, the recursive case of hgcdMatrix_row_output_le closes via joint induction.",
+      "Alternative path: build a typeclass-style 'admissible matrix' predicate carrying both (1) row-output bound at constructor inputs and (2) entry bounds, prove hgcdMatrix preserves it inductively, then read off both halves of hgcdMatrix_row_output_le as corollaries."
     ]
   },
   "tags": [
@@ -109,7 +113,7 @@
     "mathlib": []
   },
   "started": "2026-04-26T08:56:57.650Z",
-  "lastUpdate": "2026-05-02T00:00:00.000Z",
+  "lastUpdate": "2026-05-07T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -182,8 +186,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
-      "lineCount": 1021,
-      "theoremCount": 33,
+      "lineCount": 1176,
+      "theoremCount": 37,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary

Session 12 of binary-gcd-oq-03-oq-02 (Schönhage's recursive HGCD correctness layer). Adds **PART VIIc** to `BinaryGcdOQ03OQ02.lean` — pure-algebra row-output composition infrastructure that **reframes** the recursive case of `hgcdMatrix_row_output_le` (the file's lone remaining sorry).

The Session 11 obstacle was: M_inner's IH gives a row-output bound at `(aHi, bHi)`, but we need a row-output bound at the row output of M_outer on `(a, b)` — the wrong inputs.

The Session 12 reframing: row output of `M.mul N` on `(a, b)` equals row output of `N` evaluated at row output of `M` on `(a, b)`. So the inner subproblem can contribute via *entry* bounds (independent of inputs) instead of via a row-output bound at the wrong inputs.

## What's added (PART VIIc, 4 theorems, +155 lines, 0 new sorries)

- `cofactor_row_natAbs_le` — row-convention triangle bound (dual of `cofactor_apply_natAbs_le`).
- `cofactor_row_natAbs_le_of_entry_bounds` — row output bounded by `2·E·R` from entry bounds and input bounds.
- `cofactor_mul_row_output` — algebraic identity (proved by `ring`):
  ```
  a · (M.mul N).α + b · (M.mul N).γ
    = N.α · (a · M.α + b · M.γ) + N.γ · (a · M.β + b · M.δ)
  ```
  Row-convention dual of the existing `cofactor_mul_apply` (column convention).
- `cofactor_mul_row_output_natAbs_le` — combined bound: from a row-output bound on `M` (`R`) and entry bounds on `N` (`E`), the row output of `M.mul N` on `(a, b)` is `≤ 2·E·R`. **Decouples** the IH for the inner subproblem (entries) from the IH for the outer subproblem (row output).

## Remaining gap (1 sorry, unchanged)

`hgcdMatrix_row_output_le` still has a sorry in the recursive case. The remaining missing piece is now identified concretely: a `hgcdMatrix_entry_bound` lemma extending `lehmerCofactors_has_pattern` + `entry_bound_of_even/odd` across the HGCD recursion. With that, the Session 12 `cofactor_mul_row_output_natAbs_le` closes the recursive case via joint induction.

## Metadata sync

- `iteration` 5 → 12, `focus`/`nextAction` updated.
- 4 new `builtItems`, 1 new `insight`, refreshed `nextSteps`.
- `leanFiles` `BinaryGcdOQ03OQ02.lean`: `lineCount` 1021 → 1176, `theoremCount` 33 → 37 (sorryCount still 1).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ03OQ02` succeeds (in progress at PR-creation time; new lemmas are pure `ring` / `Int.natAbs_add_le` / `Nat.mul_le_mul` and should compile cleanly).
- [ ] CI build passes on PR.
- [ ] Sorry count unchanged: still exactly 1, on `hgcdMatrix_row_output_le` recursive case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)