### PR TITLE
research(ballot-gnw-exchange): F-domain bridge sum_gnwProb_eq_removeCorner_cells

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -13964,6 +13964,56 @@ private lemma strictHookCells_removeCorner_eq {μ : YoungDiagram} {c' : ℕ × �
       · have hc_eq : ν.colLen j = μ.colLen j := colLen_removeCorner_other hc' hjj'
         exact Or.inr ⟨r, ⟨hir, by rw [hc_eq]; exact hrc⟩, rfl⟩
 
+/-- For distinct corners `c` and `c'` of `μ`, `gnwProb μ c K c' = 0` for every termination
+    bound `K`.  At `K = 0` the function is identically zero; at `K + 1` the corner branch
+    fires and yields `if c' = c then 1 else 0 = 0`. -/
+private lemma gnwProb_at_other_corner {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc' : isCorner μ c') (hne : c ≠ c') (K : ℕ) :
+    gnwProb μ c K c' = 0 := by
+  cases K with
+  | zero => rfl
+  | succ K =>
+    have h_unfold : gnwProb μ c (K + 1) c' =
+        if isCorner μ c' then (if c' = c then (1 : ℚ) else 0)
+        else (1 / ↑(strictHookCells μ c'.1 c'.2).card : ℚ) *
+             ∑ y ∈ strictHookCells μ c'.1 c'.2, gnwProb μ c K y := rfl
+    rw [h_unfold, if_pos hc', if_neg (fun h : c' = c => hne h.symm)]
+
+/-- When `c'` is not in the strict hook of `(i, j)`, removing `c'` leaves the strict hook
+    unchanged.  Direct corollary of `strictHookCells_removeCorner_eq`. -/
+private lemma strictHookCells_removeCorner_eq_of_not_mem
+    {μ : YoungDiagram} {c' : ℕ × ℕ} (hc' : isCorner μ c') {i j : ℕ}
+    (hnotmem : c' ∉ strictHookCells μ i j) :
+    strictHookCells (removeCorner μ c' hc') i j = strictHookCells μ i j := by
+  rw [strictHookCells_removeCorner_eq hc' i j, ← Finset.erase_eq,
+      Finset.erase_eq_of_notMem hnotmem]
+
+/-- Bridge lemma: for distinct corners `c ≠ c'` of `μ`, summing `gnwProb μ c K` over the
+    strict hook of any cell `(i, j)` is the same as summing it over the strict hook of
+    that cell in `μ \ c'`.  This is because the two strict-hook sets differ at most by
+    `c'`, and `gnwProb μ c K c' = 0` (`gnwProb_at_other_corner`).
+
+    Why this matters for `gnwProb_exchange`: the sum over `strictHookCells μ` appearing
+    in the recursive step of `gnwProb μ c (K+1) x` can be rewritten as a sum over
+    `strictHookCells (μ\c') x.1 x.2`.  Crucially, this lifts the recursive comparison
+    between `gnwProb μ` and `gnwProb (μ\c')` from "different summation domains" to "same
+    summation domain", isolating the remaining comparison to the integrand. -/
+private lemma sum_gnwProb_strictHookCells_eq_removeCorner
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc' : isCorner μ c') (hne : c ≠ c') (i j K : ℕ) :
+    ∑ y ∈ strictHookCells μ i j, gnwProb μ c K y =
+    ∑ y ∈ strictHookCells (removeCorner μ c' hc') i j, gnwProb μ c K y := by
+  have h0 : gnwProb μ c K c' = 0 := gnwProb_at_other_corner hc' hne K
+  rw [strictHookCells_removeCorner_eq hc' i j, ← Finset.erase_eq]
+  by_cases hc'mem : c' ∈ strictHookCells μ i j
+  · -- c' is in the strict hook: split off via Finset.sum_erase_add and use h0.
+    have hsum := Finset.sum_erase_add (strictHookCells μ i j)
+      (fun y => gnwProb μ c K y) hc'mem
+    -- hsum : ∑ y ∈ S.erase c', gnwProb μ c K y + gnwProb μ c K c' = ∑ y ∈ S, gnwProb μ c K y
+    linarith [hsum, h0]
+  · -- c' is not in the strict hook: S.erase c' = S.
+    rw [Finset.erase_eq_of_notMem hc'mem]
+
 /-- GNW 1979 exchange identity (core inductive step, product form — no division).
     For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
       F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -14014,6 +14014,34 @@ private lemma sum_gnwProb_strictHookCells_eq_removeCorner
   · -- c' is not in the strict hook: S.erase c' = S.
     rw [Finset.erase_eq_of_notMem hc'mem]
 
+/-- F-domain bridge for `gnwProb_exchange`: For distinct corners `c ≠ c'` of `μ`, the
+    sum of `gnwProb μ c (hookLength μ x.1 x.2) x` over `μ.cells` equals the same sum
+    restricted to `(removeCorner μ c' hc').cells`.
+
+    Why this matters: in `gnwProb_exchange`, the LHS sum runs over `μ.cells` while the
+    RHS sum runs over `(μ\c').cells = μ.cells.erase c'`.  This lemma rewrites the LHS
+    domain to match the RHS, isolating the remaining comparison to integrands alone
+    (`gnwProb μ` vs `gnwProb (μ\c')`, and `hookLength μ` vs `hookLength (μ\c')`).
+
+    Proof: `(μ\c').cells = μ.cells.erase c'` definitionally; the only term dropped is
+    the `c'` term itself, which contributes `0` by `gnwProb_at_other_corner`. -/
+private lemma sum_gnwProb_eq_removeCorner_cells
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc' : isCorner μ c') (hne : c ≠ c') :
+    ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x =
+    ∑ x ∈ (removeCorner μ c' hc').cells,
+        gnwProb μ c (hookLength μ x.1 x.2) x := by
+  have hc'_mem : c' ∈ μ.cells := YoungDiagram.mem_cells.mpr hc'.1
+  -- Goal RHS: (removeCorner μ c' hc').cells is definitionally μ.cells.erase c'.
+  show ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x =
+       ∑ x ∈ μ.cells.erase c', gnwProb μ c (hookLength μ x.1 x.2) x
+  -- Split off c' from the LHS via Finset.sum_erase_add and use h0.
+  have hsum := Finset.sum_erase_add μ.cells
+    (fun x => gnwProb μ c (hookLength μ x.1 x.2) x) hc'_mem
+  have h0 : gnwProb μ c (hookLength μ c'.1 c'.2) c' = 0 :=
+    gnwProb_at_other_corner hc' hne (hookLength μ c'.1 c'.2)
+  linarith [hsum, h0]
+
 /-- GNW 1979 exchange identity (core inductive step, product form — no division).
     For distinct corners c and c' of μ, removing c' preserves the normalized walk probability:
       F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)


### PR DESCRIPTION
## Summary

Adds **one** structural building block toward closing `gnwProb_exchange` (the remaining sorry in `BallotProblemOQ03OQ01OQ02Helpers.lean`).

### Lemma added

```lean
private lemma sum_gnwProb_eq_removeCorner_cells
    {μ : YoungDiagram} {c c' : ℕ × ℕ}
    (hc' : isCorner μ c') (hne : c ≠ c') :
    ∑ x ∈ μ.cells, gnwProb μ c (hookLength μ x.1 x.2) x =
    ∑ x ∈ (removeCorner μ c' hc').cells,
        gnwProb μ c (hookLength μ x.1 x.2) x
```

### Why this matters for `gnwProb_exchange`

The exchange identity has the form
```
F(μ, c) · H(μ\c) · H(μ\c') = F(μ\c', c) · H((μ\c')\c) · H(μ)
```
with `F(ν, d) = ∑ x ∈ ν.cells, gnwProb ν d (h x) x` and `H = hookProd`.

Crucially, the **two sums run over different domains**: `F(μ, c)` over `μ.cells`, while the RHS sum is over `(μ\c').cells = μ.cells.erase c'`.

This lemma rewrites `F(μ, c)` over the **same domain** `(μ\c').cells`:

```
∑ x ∈ μ.cells, gnwProb μ c (h x) x = ∑ x ∈ (μ\c').cells, gnwProb μ c (h x) x
```

After this rewrite, the only remaining comparison in `gnwProb_exchange` is between **integrands on a common domain**: `gnwProb μ` vs `gnwProb (μ\c')`, and `hookLength μ` vs `hookLength (μ\c')`. That isolates the analytic core.

### Proof (7 lines)

The `c'` term contributes 0 by `gnwProb_at_other_corner` (added in PR #16652). Apply `Finset.sum_erase_add` to peel it off the LHS.

```lean
  have hc'_mem : c' ∈ μ.cells := YoungDiagram.mem_cells.mpr hc'.1
  show ∑ x ∈ μ.cells, ... = ∑ x ∈ μ.cells.erase c', ...
  have hsum := Finset.sum_erase_add μ.cells
    (fun x => gnwProb μ c (hookLength μ x.1 x.2) x) hc'_mem
  have h0 : gnwProb μ c (hookLength μ c'.1 c'.2) c' = 0 :=
    gnwProb_at_other_corner hc' hne (hookLength μ c'.1 c'.2)
  linarith [hsum, h0]
```

Pattern matches `sum_gnwProb_strictHookCells_eq_removeCorner` (an analogous use of `Finset.sum_erase_add` + `gnwProb_at_other_corner` for the strict-hook sums).

### Dependency

Built on top of PR #16652 (which adds `gnwProb_at_other_corner`). Will rebase on `main` automatically once #16652 merges; no conflict expected.

### Building blocks status

| Block | Status |
|-------|--------|
| `strictHookCells_removeCorner_eq` (set diff = {c'}) | merged |
| `mem_strictHookCells_iff` (membership) | merged |
| `corner_col_lt_of_row_lt`, `doubly_affected_cell_mem` | PR #16648 (open) |
| `gnwProb_at_other_corner` | PR #16652 (open) |
| `sum_gnwProb_strictHookCells_eq_removeCorner` (strict-hook sum bridge) | PR #16652 (open) |
| `sum_gnwProb_eq_removeCorner_cells` (F-domain bridge) | **this PR** |
| `hookLength_removeCorner_arm/leg`, `hookProd_ratio_formula` | merged |

## Test plan

- [x] Lemma signature and proof skeleton mirror `sum_gnwProb_strictHookCells_eq_removeCorner` exactly
- [x] All Mathlib API used (`Finset.sum_erase_add`, `YoungDiagram.mem_cells`) is already in use elsewhere in the file
- [ ] Docker build verification blocked by pre-existing API drift errors in `Proofs/BallotProblemOQ03.lean` (omega/take/min, separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)