### PR TITLE
research(ehrhart-cube-proven-oq-02): scaffold research/problems metadata

### DIFF
--- a/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
@@ -1,0 +1,111 @@
+# Knowledge Base: ehrhart-cube-proven-oq-02
+
+**Problem**: Can Ehrhart polynomials for polytopes with explicitly known
+lattice-point formulas be proved from first principles, without invoking the
+general Ehrhart existence theorem?
+
+## Problem Summary
+
+The d-dimensional cross-polytope `B_d = {x ∈ ℝᵈ : ‖x‖₁ ≤ 1}` has Ehrhart
+polynomial `L(B_d, n) = ∑_{k=0}^d 2^k · C(d,k) · C(n,k)`. The gallery entry
+`ehrhart-cube-proven-oq-02` proves the *algebraic* recursion
+`L(B_{d+1},n) = L(B_d,n) + 2·∑_{m<n} L(B_d,m)` via Pascal + hockey-stick, and
+several base/concrete cases. Two sorries remain:
+
+1. `crossEhrhart_is_poly` — exhibit the polynomial of degree d in ℚ[X].
+2. `crossBall_card` succ — the Finset slicing identifying the formula with
+   actual lattice-point counts.
+
+---
+
+## Session 2026-05-07 (Session 1, researcher-8) — Approach mapping
+
+**Mode**: ORIENT (RICH, score 19)
+**Outcome**: Documented the descPochhammer-based path for `crossEhrhart_is_poly`.
+
+### Mathlib Tools Identified
+
+For `crossEhrhart_is_poly`:
+- `descPochhammer R k : Polynomial R` — `X · (X-1) · ... · (X-k+1)`,
+  defined in `Mathlib.RingTheory.Polynomial.Pochhammer`. natDegree exactly k.
+- `descPochhammer_eval_eq_descFactorial` —
+  `(descPochhammer R k).eval n = (n.descFactorial k : R)` for Nat n.
+- `Nat.cast_choose_eq_descPochhammer_div` —
+  `(n.choose k : K) = (descPochhammer K k).eval n / k.factorial` over a field.
+- `Nat.descFactorial_eq_factorial_mul_choose` —
+  `n.descFactorial k = k.factorial * n.choose k` (true for all k, not just k ≤ n).
+
+### Proposed Polynomial
+
+```
+P d : Polynomial ℚ
+  := ∑ k ∈ range (d+1), C ((2:ℚ)^k * C(d,k) / k!) * descPochhammer ℚ k
+```
+
+**Degree bound**: each summand has natDegree ≤ k (= descPochhammer ℚ k natDegree,
+modulo C-mul); k ≤ d in the sum. So `P.natDegree ≤ d`.
+
+**Eval correctness**:
+```
+P.eval n = ∑ k, (2^k · C(d,k) / k!) · (descPochhammer ℚ k).eval n
+         = ∑ k, (2^k · C(d,k) / k!) · (n.descFactorial k : ℚ)
+         = ∑ k, (2^k · C(d,k) / k!) · (k! · C(n,k) : ℚ)        -- descFactorial = k!·choose
+         = ∑ k, 2^k · C(d,k) · C(n,k)                          -- k! cancels
+         = (crossEhrhart d n : ℚ)
+```
+
+The k! cancellation works in ℚ because `(k.factorial : ℚ) ≠ 0`.
+
+### Proposed Proof Sketch
+
+```lean
+theorem crossEhrhart_is_poly (d : ℕ) :
+    ∃ (P : Polynomial ℚ), P.natDegree ≤ d ∧
+    ∀ n : ℕ, P.eval (n : ℚ) = (crossEhrhart d n : ℚ) := by
+  refine ⟨∑ k ∈ Finset.range (d + 1),
+    Polynomial.C ((2 : ℚ) ^ k * (Nat.choose d k : ℚ) / (k.factorial : ℚ))
+      * descPochhammer ℚ k, ?_, ?_⟩
+  · -- natDegree ≤ d
+    refine (Polynomial.natDegree_sum_le _ _).trans ?_
+    -- reduce to: ∀ k ∈ range (d+1), natDegree (C _ * descPochhammer ℚ k) ≤ d
+    sorry
+  · intro n
+    rw [Polynomial.eval_finset_sum, crossEhrhart, Nat.cast_sum]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    rw [Polynomial.eval_mul, Polynomial.eval_C,
+        descPochhammer_eval_eq_descFactorial,
+        Nat.descFactorial_eq_factorial_mul_choose]
+    have hk_ne : (k.factorial : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr k.factorial_ne_zero
+    field_simp
+    push_cast
+    ring
+```
+
+### Risks / Open Items
+
+- Lemma name `Nat.descFactorial_eq_factorial_mul_choose` — needs verification.
+  Alternative: derive via `Nat.cast_choose_eq_descPochhammer_div` over ℚ, which
+  rearranges to `(descPochhammer ℚ k).eval n = k.factorial * n.choose k`.
+- `Polynomial.natDegree_sum_le` form: in Mathlib v4.26.0 may take a `Finset` and
+  return a `Finset.sup` bound or use `≤ sup _ natDegree`. Need to spot-check.
+- `Polynomial.natDegree_descPochhammer` or `descPochhammer_natDegree` — check
+  exact name.
+
+### For `crossBall_card` succ d
+
+This is significantly harder — requires a Finset bijection / fiberwise count.
+Sketch:
+- `crossBall (d+1) n = Σ_{j ∈ Fin (2n+1)} fiber_j`, where
+  `fiber_j = {x : Fin (d+1) → Fin (2n+1) | x ⟨d,...⟩ = j ∧ Σ_{i<d} |x i - n| ≤ n - |j-n|}`.
+- The fiber is in bijection with `crossBall d (n - |j-n|)`.
+- Pair j ↔ 2n−j: contributions of j and 2n−j are equal (symmetric).
+- `card = crossBall d n + 2·∑_{m<n} crossBall d m = crossEhrhart d n + 2·∑_{m<n} crossEhrhart d m
+        = crossEhrhart (d+1) n` by IH and `crossEhrhart_succ_d`.
+
+Estimated 100+ lines; deferred for a future iteration.
+
+---
+
+## Dead Ends
+
+- None yet.

--- a/research/problems/ehrhart-cube-proven-oq-02/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/state.md
@@ -1,0 +1,56 @@
+# Research State: ehrhart-cube-proven-oq-02
+
+## Current State
+**Phase**: ACT — known proof path identified for `crossEhrhart_is_poly`
+**Path**: incremental sorry closure
+**Since**: 2026-05-07
+**Last Updated**: 2026-05-07
+**Iteration**: 1
+
+## Current Focus
+Two sorries remain in `proofs/Proofs/EhrhartCrossPolytope.lean`:
+1. `crossEhrhart_is_poly` (line 255) — produce a `Polynomial ℚ` of degree ≤ d
+   that evaluates to `crossEhrhart d n` at every Nat n.
+2. `crossBall_card` succ-d case (line 283) — Finset slicing decomposition.
+
+## Active Approach
+- For (1), use Mathlib's `descPochhammer ℚ k` (degree k, evaluates to
+  `n.descFactorial k = k! · C(n,k)` at Nat n via
+  `descPochhammer_eval_eq_descFactorial`). Construct
+  `P = ∑ k ∈ range (d+1), C ((2:ℚ)^k · C(d,k) / k!) · descPochhammer ℚ k`.
+  - natDegree bound via `Polynomial.natDegree_sum_le` + `descPochhammer_natDegree`.
+  - Eval property via `Polynomial.eval_finset_sum` + `descPochhammer_eval_eq_descFactorial`
+    + `Nat.descFactorial_eq_factorial_mul_choose`. The `k!` in the C-coefficient
+    cancels against `descFactorial = k! · choose`, leaving `2^k · C(d,k) · C(n,k)`.
+
+- For (2), the Finset slicing uses
+  `crossBall (d+1) n` decomposition by last coordinate j ∈ Fin (2n+1):
+  for j = n + δ (δ ∈ {-n,…,n}), the fiber is `crossBall d (n - |δ|)`.
+  Pairing j ↔ 2n − j gives `card = crossBall_d_n + 2·∑_{m<n} crossBall_d_m`,
+  which by IH and `crossEhrhart_succ_d` matches `crossEhrhart (d+1) n`.
+  Implementation: `Finset.card_eq_sum_card_fiberwise` over the projection
+  `x ↦ x ⟨d, ...⟩`, then split the fiber sum into the m=n case (one fiber)
+  and the rest paired symmetrically.
+
+## Attempt Count
+- Total attempts: 1 (this session)
+- Approaches tried: descPochhammer-based polynomial construction (planned)
+
+## Blockers
+- **Local Lean build**: Worktree's `proofs/.lake` symlink is a self-cycle; my
+  Docker build attempt hung on `mathlib: cloning` for 14+ minutes without
+  reaching the cache. Closing sorries without local verification is risky.
+  PR-driven CI will validate, but iteration cost is high.
+
+## Next Action
+**ACT** — implement `crossEhrhart_is_poly` via the descPochhammer construction.
+The proof outline is complete; the work is wiring up the Lean syntax and
+verifying lemma names (`descPochhammer_natDegree`, `descPochhammer_eval_eq_descFactorial`,
+`Nat.descFactorial_eq_factorial_mul_choose`, `Polynomial.natDegree_sum_le`).
+
+## References
+- `proofs/Proofs/EhrhartCrossPolytope.lean:249-255` — `crossEhrhart_is_poly` sorry
+- `proofs/Proofs/EhrhartCrossPolytope.lean:267-283` — `crossBall_card` sorry
+- Mathlib: `Mathlib.RingTheory.Polynomial.Pochhammer` (descPochhammer)
+- Mathlib: `Nat.cast_choose_eq_descPochhammer_div` — alternate form of the
+  evaluation identity


### PR DESCRIPTION
## Summary

Adds `research/problems/ehrhart-cube-proven-oq-02/{state.md,knowledge.md}` for
`ehrhart-cube-proven-oq-02` (the cross-polytope axiom-free Ehrhart proof).
The gallery entry has 2 sorries:

- `crossEhrhart_is_poly` (line 255): produce a `Polynomial ℚ` of natDegree ≤ d
  whose Nat-evaluation equals `crossEhrhart d n`.
- `crossBall_card` succ-d (line 283): Finset slicing decomposition.

This PR documents the **descPochhammer-based proof path** for the first sorry:

```
P := ∑ k ∈ range (d+1), C ((2:ℚ)^k · C(d,k) / k!) · descPochhammer ℚ k
```

- natDegree bound via `Polynomial.natDegree_sum_le` + `descPochhammer_natDegree`.
- Eval correctness via `descPochhammer_eval_eq_descFactorial` and
  `Nat.descFactorial_eq_factorial_mul_choose` — the `k!` divisor cancels against
  `descFactorial = k! · choose`, leaving `2^k · C(d,k) · C(n,k) = crossEhrhart d n`.

Also outlines the Finset slicing approach for the second sorry (deferred).

## Why metadata-only

This worktree's `proofs/.lake` symlink is a self-cycle, so my Docker build
attempt hung on `mathlib: cloning` for 14+ minutes without reaching the cache.
Closing the sorry without local verification is risky; instead this PR records
the Mathlib API path so the next iteration can wire up the proof with
high confidence.

## Test plan

- [ ] No Lean changes; CI build of the gallery should be unaffected.
- [ ] Future PR will close `crossEhrhart_is_poly` using the documented sketch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)