### PR TITLE
fix(meta): declare missing Core/Helpers siblings in additionalFiles (17 entries)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
@@ -81,7 +81,10 @@
     "theoremCount": 20,
     "definitionCount": 3,
     "path": "Proofs/BallotProblemOQ01OQ04OQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ01OQ04Core.lean"
+    ]
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1011/meta.json
+++ b/src/data/proofs/erdos-1011/meta.json
@@ -223,7 +223,10 @@
     "theoremCount": 0,
     "definitionCount": 9,
     "path": "Proofs/Erdos1011Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -178,6 +178,9 @@
     "sorries": 0,
     "path": "Proofs/Erdos1091Problem.lean",
     "definitionCount": 7,
-    "theoremCount": 4
+    "theoremCount": 4,
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ]
   }
 }

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -218,7 +218,8 @@
     "path": "Proofs/Erdos626Problem.lean",
     "sorries": 15,
     "additionalFiles": [
-      "Proofs/Erdos626ProblemAristotle.lean"
+      "Proofs/Erdos626ProblemAristotle.lean",
+      "Proofs/GraphCore.lean"
     ]
   },
   "sorries": 15

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -198,7 +198,8 @@
     "path": "Proofs/Erdos627Problem.lean",
     "sorries": 16,
     "additionalFiles": [
-      "Proofs/Erdos627ProblemAristotle.lean"
+      "Proofs/Erdos627ProblemAristotle.lean",
+      "Proofs/GraphCore.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -221,7 +221,8 @@
     "path": "Proofs/Erdos628Problem.lean",
     "sorries": 12,
     "additionalFiles": [
-      "Proofs/Erdos628ProblemAristotle.lean"
+      "Proofs/Erdos628ProblemAristotle.lean",
+      "Proofs/GraphCore.lean"
     ]
   },
   "sorries": 12

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -213,7 +213,8 @@
     "path": "Proofs/Erdos630Problem.lean",
     "sorries": 15,
     "additionalFiles": [
-      "Proofs/Erdos630ProblemAristotle.lean"
+      "Proofs/Erdos630ProblemAristotle.lean",
+      "Proofs/GraphCore.lean"
     ]
   },
   "sorries": 15

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -212,7 +212,8 @@
     "path": "Proofs/Erdos631Problem.lean",
     "sorries": 10,
     "additionalFiles": [
-      "Proofs/Erdos631ProblemAristotle.lean"
+      "Proofs/Erdos631ProblemAristotle.lean",
+      "Proofs/GraphCore.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -134,7 +134,10 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/Erdos640Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-641/meta.json
+++ b/src/data/proofs/erdos-641/meta.json
@@ -169,7 +169,10 @@
     "theoremCount": 4,
     "definitionCount": 15,
     "path": "Proofs/Erdos641Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-923/meta.json
+++ b/src/data/proofs/erdos-923/meta.json
@@ -181,7 +181,10 @@
     "theoremCount": 3,
     "definitionCount": 6,
     "path": "Proofs/Erdos923Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -130,7 +130,10 @@
     "axiomCount": 205,
     "sorries": 0,
     "definitionCount": 150,
-    "theoremCount": 302
+    "theoremCount": 302,
+    "additionalFiles": [
+      "Proofs/ComplexityCore.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The P vs NP problem is one of the most important unsolved problems in mathematics and computer science, designated a Clay Mathematics Institute Millennium Prize Problem in 2000 with a $1,000,000 reward.\n\nThe foundations were laid by Alan Turing (1936) with the formalization of computation, and by Juris Hartmanis and Richard Stearns (1965) who established computational complexity theory with the Time Hierarchy Theorem. Stephen Cook (1971) formulated the P vs NP question and proved the Cook-Levin theorem, showing that the Boolean satisfiability problem (SAT) is NP-complete — the first problem shown to have this property. Leonid Levin independently proved the same result in 1973 in the Soviet Union.\n\nRichard Karp (1972) demonstrated the practical significance by showing 21 natural combinatorial problems are NP-complete via reduction chains from SAT, including CLIQUE, VERTEX COVER, HAMILTONIAN PATH, and SUBSET SUM. Russell Ladner (1975) proved that if P ≠ NP, then NP-intermediate problems must exist — problems in NP that are neither in P nor NP-complete.\n\nDespite over 50 years of effort, the problem remains open. Three major 'barrier results' explain why traditional proof techniques have failed: relativization (Baker-Gill-Solovay, 1975), natural proofs (Razborov-Rudich, 1994), and algebrization (Aaronson-Wigderson, 2009). Any proof must circumvent all three barriers simultaneously.",

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -118,7 +118,8 @@
     ],
     "namespace": "Szemeredi.EnergyIncrement",
     "additionalFiles": [
-      "Proofs/SzemerediCoreOQ01Aristotle.lean"
+      "Proofs/SzemerediCoreOQ01Aristotle.lean",
+      "Proofs/SzemerediCore.lean"
     ]
   },
   "sorries": 0

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -183,7 +183,10 @@
     "theoremCount": 14,
     "definitionCount": 7,
     "path": "Proofs/SzemerediCounting.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/SzemerediCore.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -172,7 +172,10 @@
     "theoremCount": 14,
     "definitionCount": 6,
     "path": "Proofs/SzemerediHypergraphGowers.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/SzemerediHypergraphCore.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/szemeredi-regularity-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02/meta.json
@@ -223,7 +223,10 @@
       }
     ],
     "path": "Proofs/SzemerediRegularityOQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/SzemerediCore.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -187,7 +187,10 @@
     "theoremCount": 17,
     "definitionCount": 0,
     "path": "Proofs/SzemerediRegularity.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/SzemerediCore.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Declares the `*Core.lean` (and one `*Helpers.lean`) companion file in `leanFile.additionalFiles` for 17 gallery entries that import them.

## Why

`scripts/auditor/find-targets.ts:174-191` only auto-follows single-level `import Proofs.X` when `X` ends in `Aristotle`. Other cross-file dependencies must be declared via `meta.additionalFiles` so the auditor includes their sorries/axioms when validating gallery integrity. The convention is established by ~143 entries with declared Aristotle companions (and recently by mechanic PR #16518, #16655).

## Evidence

For each entry on `origin/main` (HEAD `fa6ad48`):

1. Main `.lean` contains `import Proofs.<Core>` (verified via `grep`).
2. `proofs/Proofs/<Core>.lean` exists.
3. `meta.json`'s `leanFile.additionalFiles` does not include the companion path.

| Slug | Companion declared |
|---|---|
| `ballot-problem-oq-01-oq-04-oq-01` | `BallotProblemOQ01OQ04Core.lean` |
| `erdos-1011` | `GraphCore.lean` |
| `erdos-1091` | `GraphCore.lean` |
| `erdos-626` | `GraphCore.lean` (Aristotle already declared) |
| `erdos-627` | `GraphCore.lean` (Aristotle already declared) |
| `erdos-628` | `GraphCore.lean` (Aristotle already declared) |
| `erdos-630` | `GraphCore.lean` (Aristotle already declared) |
| `erdos-631` | `GraphCore.lean` (Aristotle already declared) |
| `erdos-640` | `GraphCore.lean` |
| `erdos-641` | `GraphCore.lean` |
| `erdos-923` | `GraphCore.lean` |
| `p-vs-np` | `ComplexityCore.lean` |
| `szemeredi-core-oq-01` | `SzemerediCore.lean` (Aristotle already declared) |
| `szemeredi-counting` | `SzemerediCore.lean` |
| `szemeredi-hypergraph-core-oq-01-incomplete-01` | `SzemerediHypergraphCore.lean` |
| `szemeredi-regularity` | `SzemerediCore.lean` |
| `szemeredi-regularity-oq-02` | `SzemerediCore.lean` |

## Count impact

None — these companions have 0 sorries each. `GraphCore.lean`, `SzemerediCore.lean`, `SzemerediHypergraphCore.lean`, `BallotProblemOQ01OQ04Core.lean` carry 0 axioms. `ComplexityCore.lean` has 5 axioms + 1 opaque, but `p-vs-np`'s `axiomCount=205` already accounts for it via import-chain accounting (no claim change needed).

## Coordination

- Verified no open PRs touch any of these 17 `meta.json` files (`gh pr list` cross-check).
- Surgical string-replacement diff (no full-file reformat per `feedback_mechanic_plumbing_json_format.md`).
- All 17 JSON files re-validate with `python3 -c "import json; json.load(...)"`.

---
Automated fix by lean-mechanic agent.