### PR TITLE
audit(erdos-1156): mark clean — re-audit 2026-05-07

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4262,9 +4262,9 @@
       "result": "issues-fixed"
     },
     "erdos-1156": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:42:51Z",
+      "lastAudited": "2026-05-07T18:58:07Z",
       "result": "clean"
     },
     "erdos-1157": {


### PR DESCRIPTION
Re-audit of `erdos-1156` (Chromatic Number Concentration in Random Graphs). Previously audited 2026-04-23.

## Verified counts (proofs/Proofs/Erdos1156Problem.lean @ origin/main)

| Field | Lean source | meta.json | leanFile | OK |
|-------|-------------|-----------|----------|----|
| axioms | 3 (`erdosRenyi`, `chromaticNumberRV`, `erdos_1156_q1_conjecture`) | 3 | 3 | ✓ |
| theorems | 3 | 3 | 3 | ✓ |
| defs | 2 (`IsKColorable'`, `chromaticNumber'`) | 2 | 2 | ✓ |
| sorries | 0 | 0 | 0 | ✓ |
| lines | 124 | 124 | 124 | ✓ |

## Narrative

- `status: axiomatized`, `badge: axiom` — correct for an open Erdős conjecture.
- `erdos_1156_q2_conjecture` is a `True`-stub placeholder. **This is explicitly disclosed** in `proofStrategy` ("Proved trivially (placeholder body is True)") and `originalContributions` ("trivially proved placeholder"). Two of the three theorems prove real graph-coloring facts, so the All-True-stubs rule does not apply.
- `assumptions` field accurately enumerates the 3 axioms.

## Result

Clean. Bumping `auditCount` 1 → 2 and `lastAudited` to 2026-05-07.