### PR TITLE
research(four-square-distribution-oq-01): fix crossRef schema + parent back-refs

### DIFF
--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -129,6 +129,11 @@
       "targetId": "prime-number-theorem",
       "relationship": "related",
       "description": "Jacobi's formula r₄(n) = 8σ*(n) and the multiplicativity of σ* are tied to prime distribution; the average order σ*(n) ~ (π²/12)n from PNT gives the asymptotic growth rate r₄(n) ~ (2π²/3)n"
+    },
+    {
+      "targetId": "four-square-distribution-oq-01",
+      "relationship": "extended-by",
+      "description": "OQ-01 bootstraps Jacobi's closed form r₄(n) = 8·σ*(n) as a Lean 4 research target: defines σ*(n) and a brute-force r₄(n), verifies the formula numerically for n = 1..10 by native_decide (cross-checking the type-decomposition theorems here), and axiomatizes the general formula as the precise open target awaiting Mathlib q-expansion infrastructure for jacobiTheta"
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -162,6 +162,11 @@
       "targetId": "chinese-remainder-non-coprime",
       "relationship": "foundational",
       "description": "The Chinese Remainder Theorem allows the four-squares problem to be decomposed by prime powers: proving $p = a^2+b^2+c^2+d^2$ for each prime $p$ and extending via Euler's multiplicative identity. CRT provides the algebraic framework for this prime-by-prime analysis"
+    },
+    {
+      "targetId": "four-square-distribution-oq-01",
+      "relationship": "extended-by",
+      "description": "OQ-01 sharpens Lagrange's qualitative existence theorem ($r_4(n) \\geq 1$) to Jacobi's exact 1834 count $r_4(n) = 8 \\sigma^*(n) = 8 \\sum_{d \\mid n,\\ 4 \\nmid d} d$. The OQ-01 entry verifies the formula numerically for $n = 1..10$ via native_decide and axiomatizes the general statement, identifying the precise Mathlib gap (q-expansion of jacobiTheta + Eisenstein-coefficient identification) that blocks a full Lean proof"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Three small JSON edits — no Lean changes.

The `four-square-distribution-oq-01` gallery entry had its `crossReferences` written with a non-canonical schema (`{type, target, label}`) instead of the schema the UI actually reads (`{proofId|targetId, relationship, description}`, see `src/types/proof.ts` and `src/components/proof/Proof{Overview,Conclusion}.tsx`). The result was that none of OQ-01's outgoing related-proof links rendered in the gallery.

This PR:

1. **Fixes the schema** in `four-square-distribution-oq-01/meta.json` (3 refs):
   - → `four-square-distribution` (extends, parent type-decomposition)
   - → `lagrange-four-squares` (uses, qualitative existence)
   - → `lagrange-four-squares-waring-g2` (related, Waring g(2)=4)

2. **Adds back-references** in the two parents:
   - `four-square-distribution/meta.json` ← OQ-01 (extended-by)
   - `lagrange-four-squares/meta.json` ← OQ-01 (extended-by)

3. **Updates research JSON** for `four-square-distribution-oq-01`:
   - Adds the schema fix as an insight + 3 builtItems
   - Removes the matching item from `nextSteps`

## Why

This was the first item in the OQ-01 problem JSON `nextSteps`: "Add cross-references in `four-square-distribution` and `lagrange-four-squares` gallery entries pointing to this OQ-01." The schema discrepancy was caught while drafting the back-refs.

## Verification

- `jq empty` on all 3 modified meta.json files → valid JSON.
- Cross-ref targets exist in the gallery: `lagrange-four-squares-waring-g2/`, `four-square-distribution/`, `lagrange-four-squares/`, `four-square-distribution-oq-01/` all have `meta.json + index.ts`.
- Symmetric back-refs: each parent now points forward to OQ-01, and OQ-01 points back to both.

## Test plan

- [ ] `pnpm build` succeeds (TypeScript + Vite).
- [ ] Gallery page for `/proof/four-square-distribution-oq-01` now shows 3 Related Proofs (was 0 — none rendered due to schema mismatch).
- [ ] Gallery pages for `/proof/four-square-distribution` and `/proof/lagrange-four-squares` show the OQ-01 link in Related Proofs.

🤖 Generated by researcher-4 (session 48)