### PR TITLE
research(ballot-oq-03-oq-01-oq-02): S45 corner-distinctness coordinate lemmas

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -4767,6 +4767,50 @@ private lemma corner_row_lt_of_col_lt {μ : YoungDiagram} {c c' : ℕ × ℕ}
     have hc'_row : c'.2 < μ.rowLen c'.1 := YoungDiagram.mem_iff_lt_rowLen.mp hc'.1
     rw [← heq, hrl] at hc'_row; omega
 
+/-- Distinct corners of μ have distinct first coordinates: each row of μ has at
+    most one corner (namely the rightmost cell of the row, if any).
+    Useful in the GNW exchange argument when reasoning about hookLength shifts:
+    distinct corners c, c' never share a row, so the arm of c and the arm of c'
+    are disjoint apart from the doubly-affected cell. -/
+private lemma corners_fst_ne {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    c.1 ≠ c'.1 := by
+  intro heq
+  -- Same row ⇒ both have rowLen at row c.1 = c.2 + 1 = c'.2 + 1, hence c = c'.
+  have h1 : μ.rowLen c.1 = c.2 + 1 := rowLen_of_isCorner hc
+  have h2 : μ.rowLen c'.1 = c'.2 + 1 := rowLen_of_isCorner hc'
+  rw [← heq] at h2
+  have hsnd : c.2 = c'.2 := by omega
+  exact hne (Prod.ext heq hsnd)
+
+/-- Distinct corners of μ have distinct second coordinates: each column of μ has
+    at most one corner (namely the bottom cell of the column, if any). -/
+private lemma corners_snd_ne {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    c.2 ≠ c'.2 := by
+  intro heq
+  have h1 : μ.colLen c.2 = c.1 + 1 := colLen_of_isCorner hc
+  have h2 : μ.colLen c'.2 = c'.1 + 1 := colLen_of_isCorner hc'
+  rw [← heq] at h2
+  have hfst : c.1 = c'.1 := by omega
+  exact hne (Prod.ext hfst heq)
+
+/-- Trichotomy for distinct corners (collapses to dichotomy): either `c` is
+    strictly above-and-to-the-right of `c'`, or vice versa. The middle case
+    (`c.1 = c'.1`) is impossible by `corners_fst_ne`.
+
+    This packages the existing `corner_col_lt_of_row_lt` for use in case
+    analysis without re-deriving the row-coordinate dichotomy at each call site.
+    Used in the GNW exchange identity to split on the relative orientation of
+    `c` and `c'`. -/
+private lemma distinct_corners_dichotomy {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    (c.1 < c'.1 ∧ c'.2 < c.2) ∨ (c'.1 < c.1 ∧ c.2 < c'.2) := by
+  have h_fst_ne : c.1 ≠ c'.1 := corners_fst_ne hc hc' hne
+  rcases lt_or_gt_of_ne h_fst_ne with hlt | hgt
+  · exact Or.inl ⟨hlt, corner_col_lt_of_row_lt hc hc' hlt⟩
+  · exact Or.inr ⟨hgt, corner_col_lt_of_row_lt hc' hc hgt⟩
+
 /-- For two distinct corners `c, c'` of μ with `c.1 < c'.1`, the cell `(c.1, c'.2)`
     lies in μ. It is the unique cell in the arm of `c` and leg of `c'`, and plays
     a key role in the GNW 1979 exchange identity. -/

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -1032,3 +1032,95 @@ Estimated proof length: ~100 lines of arm/leg case analysis + arithmetic.
 3. **Alternative: deterministic weighted-walk recasting** (~400 lines self-contained)
    could avoid `gnwProb_exchange` entirely if the GNW 1979 argument resists
    formalization.
+
+## Session 2026-05-07 (Session 45) — Corner-distinctness coordinate lemmas
+
+**Mode**: ACT (RICH, score 192). Builds on session 44 (PR #16648 anti-monotone
+corner helpers) and PR #16665 (F-domain bridge `sum_gnwProb_eq_removeCorner_cells`).
+
+**Outcome**: PROGRESS — added three small structural lemmas; sorry count
+unchanged (still 1: `gnwProb_exchange`).
+
+### What I Did
+
+Added three private lemmas in
+`BallotProblemOQ03OQ01OQ02Helpers.lean` immediately after
+`corner_row_lt_of_col_lt` (~line 4768), promoting the geometric
+anti-monotonicity of session 44 to clean coordinate-distinctness predicates:
+
+1. **`corners_fst_ne`**: `c ≠ c' → c.1 ≠ c'.1` for distinct corners c, c'.
+   Proof: same first coordinate ⇒ both have `rowLen c.1 = c.2 + 1 = c'.2 + 1`
+   via `rowLen_of_isCorner` ⇒ `c.2 = c'.2` ⇒ `c = c'`. Contradiction.
+
+2. **`corners_snd_ne`**: `c ≠ c' → c.2 ≠ c'.2` (symmetric, via `colLen_of_isCorner`).
+
+3. **`distinct_corners_dichotomy`**: packages the geometric anti-monotonicity
+   into a single dichotomy
+   `(c.1 < c'.1 ∧ c'.2 < c.2) ∨ (c'.1 < c.1 ∧ c.2 < c'.2)`,
+   ready for `rcases` case analysis. Proof: `corners_fst_ne` gives
+   `c.1 ≠ c'.1`; `lt_or_gt_of_ne` splits; either branch invokes
+   `corner_col_lt_of_row_lt` (in the appropriate orientation).
+
+### Why This Helps `gnwProb_exchange`
+
+The remaining `gnwProb_exchange` proof requires reasoning about how
+`gnwProb μ c K x` for cells `x ≠ c'` relates to `gnwProb (μ\c') c K' x`.
+The natural case split is on the relative orientation of c and c':
+
+- Case `c.1 < c'.1 ∧ c'.2 < c.2`: c is northeast of c'.
+- Case `c'.1 < c.1 ∧ c.2 < c'.2`: c is southwest of c'.
+
+Without `distinct_corners_dichotomy`, every call site had to:
+1. Derive `c.1 ≠ c'.1` from `c ≠ c'` (re-deriving the rowLen argument).
+2. Use `lt_or_gt_of_ne` to split.
+3. Invoke `corner_col_lt_of_row_lt` in each branch.
+
+The new lemma collapses this pattern into a single `rcases distinct_corners_dichotomy hc hc' hne with ⟨hi, hj⟩ | ⟨hi, hj⟩`,
+eliminating roughly 6–8 lines of bookkeeping per case-split site. Similarly
+`corners_fst_ne` and `corners_snd_ne` are useful when only the inequality
+side (not the orientation) is needed, e.g., for arm/leg disjointness arguments.
+
+### Why This Is Distinct From Session 44
+
+Session 44 (PR #16648) added three GEOMETRIC lemmas:
+
+- `corner_col_lt_of_row_lt`: `c.1 < c'.1 → c'.2 < c.2`.
+- `corner_row_lt_of_col_lt`: `c.2 < c'.2 → c'.1 < c.1`.
+- `doubly_affected_cell_mem`: `(c.1, c'.2) ∈ μ` when `c.1 < c'.1`.
+
+These take the strict inequality as a hypothesis. Session 45 adds the
+COORDINATE-DISTINCTNESS lemmas which take only `c ≠ c'` as a hypothesis
+and provide either bare ≠ predicates or the packaged dichotomy. They sit
+on top of session 44 (and `rowLen_of_isCorner`/`colLen_of_isCorner`) but
+present a different API surface useful for downstream proofs that don't
+already have the anti-monotone hypothesis available.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (14354 → 14398
+  lines): +44 lines, three new private lemmas after
+  `corner_row_lt_of_col_lt`.
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md`
+  (iteration 44 → 45, attempt #8 added).
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md`
+  (this session entry).
+
+### Sorry Count: 1 → 1
+
+- REMAINING: `gnwProb_exchange` (Helpers, line ~13871) — GNW 1979 hook-weight
+  shift identity, ~100 lines, three pieces of infrastructure now ready
+  (sessions 44, 45, plus PR #16665 F-domain bridge).
+
+### Next Steps
+
+1. **Prove `gnwProb_exchange`.** With `distinct_corners_dichotomy` plus
+   the F-domain bridge from #16665 (`sum_gnwProb_eq_removeCorner_cells`)
+   and `gnwProb_at_other_corner`, the remaining proof can be structured:
+   - Apply F-domain bridge to rewrite LHS sum over μ.cells as sum over
+     `(μ\c').cells` (the c' contribution is 0).
+   - Case-split via `distinct_corners_dichotomy` on whether c is NE or
+     SW of c'.
+   - In each case, decompose the sum using arm/leg of c' classification
+     and apply `hookLength_removeCorner_arm`/`leg`.
+2. **Verify build under Docker** once gnwProb_exchange is closed (file
+   will be ~14250+ lines).

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (GNW exchange-step framework wired up; anti-monotone corner helpers added)
+**Phase**: ACT (GNW exchange-step framework wired up; corner-distinctness coordinate lemmas added)
 **Path**: full
 **Since**: 2026-04-21T20:08:44+02:00
 **Last Updated**: 2026-05-07
-**Iteration**: 44
+**Iteration**: 45
 
 ## Current Focus
 Close `gnwProb_exchange` (Helpers, line 13871) — the GNW 1979 exchange identity
@@ -60,6 +60,15 @@ in place:
      These reduce the upcoming `gnwProb_exchange` case analysis: given two
      distinct corners with `c.1 < c'.1`, the unique doubly-affected cell
      `(c.1, c'.2)` is in `μ` and lies in the arm of c and leg of c'.
+  8. Corner-distinctness coordinate lemmas (session 45) — added three more
+     structural lemmas after `corner_row_lt_of_col_lt`:
+     `corners_fst_ne`, `corners_snd_ne`, `distinct_corners_dichotomy`.
+     These promote the geometric anti-monotonicity of session 44 to clean
+     coordinate-distinctness predicates: `c ≠ c' → c.1 ≠ c'.1 ∧ c.2 ≠ c'.2`
+     and a packaged dichotomy `(c.1 < c'.1 ∧ c'.2 < c.2) ∨
+     (c'.1 < c.1 ∧ c.2 < c'.2)` for downstream case analysis. They eliminate
+     repeated `rowLen_of_isCorner` / `colLen_of_isCorner` boilerplate in the
+     upcoming `gnwProb_exchange` proof.
 
 ## Blockers
 - **`gnwProb_exchange` proof.** This is the GNW 1979 hook-weight shift argument.
@@ -98,7 +107,9 @@ exchange step entirely (count weighted walks of every length, divide by
 - `knowledge.md` §Session 37 — GNW infrastructure: `gnwProb`, `gnwProb_sum_corners`
 - `knowledge.md` §Session 38 — `gnwProb_step` and stability
 - `knowledge.md` §Session 40-42 — single-corner case proof, exchange framework
-- `knowledge.md` §Session 43 — strong induction wrapper (this session)
+- `knowledge.md` §Session 43 — strong induction wrapper
+- `knowledge.md` §Session 44 — anti-monotone corner helpers (PR #16648)
+- `knowledge.md` §Session 45 — corner-distinctness coordinate lemmas (this session)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:13871` — `gnwProb_exchange`
   (sorry'd, target of next session)
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:13884` — `gnwProb_key`


### PR DESCRIPTION
## Summary

Session 45 of the GNW hook-length formula research adds three small structural lemmas in `BallotProblemOQ03OQ01OQ02Helpers.lean`, layered on top of session 44 (PR #16648 anti-monotone helpers) and PR #16665 (F-domain bridge):

- **`corners_fst_ne`**: distinct corners of μ have distinct first coordinates (each row has at most one corner). Proof via `rowLen_of_isCorner`.
- **`corners_snd_ne`**: symmetric — distinct corners have distinct second coordinates.
- **`distinct_corners_dichotomy`**: packages session 44's anti-monotonicity into a clean dichotomy `(c.1 < c'.1 ∧ c'.2 < c.2) ∨ (c'.1 < c.1 ∧ c.2 < c'.2)`, ready for `rcases` case analysis.

Inserted after `corner_row_lt_of_col_lt` (~line 4768).

## Why

Session 44 added the geometric anti-monotone helpers but they take a strict inequality (`c.1 < c'.1`) as input. Session 45 promotes those to coordinate-distinctness predicates that take only `c ≠ c'` as input, eliminating the boilerplate of re-deriving rowLen/colLen-based ≠ at every case-split site in the upcoming `gnwProb_exchange` proof.

With these in place, the proof skeleton for the sole remaining sorry (`gnwProb_exchange`) becomes:

1. Apply F-domain bridge (`sum_gnwProb_eq_removeCorner_cells` from #16665) to rewrite the LHS sum.
2. `rcases distinct_corners_dichotomy hc hc' hne with ⟨hi, hj⟩ | ⟨hi, hj⟩` to split on c-vs-c' orientation.
3. In each branch, decompose using arm/leg of c' classification via `hookLength_removeCorner_{arm,leg}`.

## Sorry Count

- Helpers file: **1 → 1** (still `gnwProb_exchange` at line ~13871). No sorries closed; this is structural infrastructure.

## File Changes

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean`: 14354 → 14398 lines (+44).
- `research/problems/.../state.md`: iteration 44 → 45, attempt #8 added.
- `research/problems/.../knowledge.md`: Session 45 entry.

## Test Plan

- [ ] Lean build under Docker passes (CI).
- [ ] No regressions in dependent files (Main `BallotProblemOQ03OQ01OQ02.lean` only imports the Helpers module — should be unaffected).
- [ ] Three new lemmas are reachable from `gnwProb_exchange` (Helpers, line ~13871 — same module, no namespace barrier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)