### PR TITLE
audit(angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01): sync meta.sorries 2→0 post-#16660

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "counterexample"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Drift

`meta.sub.sorries` is stale at `2`; Lean file has 0 sorries.

| Field | Value |
|---|---|
| Top-level `sorries` | 0 ✓ |
| `meta.sorries` | **2 → 0** |
| `leanFile.sorries` | 0 ✓ |
| Actual sorries in `Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean` | 0 ✓ |

PR #16660 (merged 2026-05-07) closed both sorries via `iterateFrobenius` rewrite but did not bump `meta.sub.sorries`.

## Verification

```
git show origin/main:proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean | grep -c '\bsorry\b' (with comments stripped)
# 0
```

Surfaced by `find-targets.ts --next` as `sorry mismatch: claims 2, actual 0`.

## Diff

Single line change: `"sorries": 2,` → `"sorries": 0,` inside the `meta` sub-object. Plumbing-built (no working tree) to preserve byte-identical formatting.

---
Discovered during gallery integrity audit.