### PR TITLE
audit(tracker): bump angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01 auditCount post-#16660

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14778,8 +14778,8 @@
       "issues": []
     },
     "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T11:11:52Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-07T19:07:34Z",
       "result": "issues-fixed",
       "issues": []
     },


### PR DESCRIPTION
## Tracker bump

Audited `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01` after #16660 closed both sorries; meta.sub.sorries was stale. Fix filed in #16680. This PR bumps the tracker:

- `auditCount`: 1 → 2
- `lastAudited`: 2026-05-06T11:11:52Z → 2026-05-07T19:07:34Z
- `result`: issues-fixed (re-confirmed)

Plumbing-built from origin/main; surgical 2-line replacement preserves formatting exactly.