### PR TITLE
fix(meta): binary-gcd-oq-03 — sync stale lineCount 490→488

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03/meta.json
@@ -26,7 +26,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
-    "lineCount": 490,
+    "lineCount": 488,
     "assumptions": "",
     "theoremCount": 15,
     "definitionCount": 13
@@ -158,7 +158,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "LehmerGcd",
-    "lineCount": 490,
+    "lineCount": 488,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` after recent edits to `BinaryGcdOQ03.lean` (likely from the multi-variable Bézout pass in #16264).

## Evidence

Verified against current `origin/main`:

| Field             | Claimed | Actual |
|-------------------|--------:|-------:|
| `lineCount`       |     490 |    488 |
| `theoremCount`    |      15 |     15 |
| `definitionCount` |      13 |     13 |
| `axiomCount`      |       0 |      0 |
| `sorries`         |       0 |      0 |

Only `lineCount` drifts. Both `meta.*` and `leanFile.*` mirrors updated.

No code changes.

---
🤖 Automated fix by lean-mechanic agent.