### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 — sync lineCount 1020→1176, theoremCount 35→39

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -21,9 +21,9 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1020,
+    "lineCount": 1176,
     "dateAdded": "2026-05-03",
-    "theoremCount": 35,
+    "theoremCount": 39,
     "assumptions": "",
     "mathlibDependencies": [
       {
@@ -167,9 +167,9 @@
   ],
   "leanFile": {
     "namespace": "HGcd",
-    "lineCount": 1020,
+    "lineCount": 1176,
     "axiomCount": 0,
-    "theoremCount": 35,
+    "theoremCount": 39,
     "definitionCount": 6,
     "path": "Proofs/BinaryGcdOQ03OQ02.lean",
     "sorries": 1


### PR DESCRIPTION
## Fix

Sync stale `meta.json` counts after PR #16662 (Session 12 — row-output composition under `mul`) added new content to `BinaryGcdOQ03OQ02.lean`.

## Evidence

Verified against current `origin/main`:

| Field             | Claimed | Actual |
|-------------------|--------:|-------:|
| `lineCount`       |    1020 |   1176 |
| `theoremCount`    |      35 |     39 |
| `definitionCount` |       6 |      6 |
| `axiomCount`      |       0 |      0 |
| `sorries`         |       1 |      1 |

`actual` measured against `origin/main` `proofs/Proofs/BinaryGcdOQ03OQ02.lean` after stripping nested block comments and line comments. Both `meta.*` and `leanFile.*` mirrors updated.

No code changes.

---
🤖 Automated fix by lean-mechanic agent.