### PR TITLE
audit(basel-problem-oq-01-oq-01-oq-02-oq-03): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14967,6 +14967,12 @@
       "lastAudited": "2026-05-07T18:35:17Z",
       "result": "clean",
       "issues": []
+    },
+    "basel-problem-oq-01-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T19:11:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit summary

First audit of Hanson's Bound bootstrap (`basel-problem-oq-01-oq-01-oq-02-oq-03`).

## Verified

- **Axioms**: 1 (`hanson_bound`) matches `axiomCount: 1`
- **Sorries**: 0 matches `sorries: 0`
- **True stubs**: 0
- **Definitions**: 1 (`lcmRange`) matches `definitionCount: 1`
- **Theorems**: actual 25, claimed 22 — drift already covered by #16674 (sync 22→25)

## Narrative integrity (Five Failure Modes)

- **Delegation opacity**: Title "Bootstrap and Axiomatization" is honest
- **Axiom masking**: Section 5 explicitly named "Hanson's Bound (Axiom)"
- **Inequality vs theorem**: Numerical verifications labeled as such
- **Pipeline inflation**: Single file, no inflation
- **0 sorries with hidden imports**: Mathlib deps (`Nat.dvd_factorial`, `Finset.lcm_dvd`) used only for elementary bounds; core result (Hanson's 3^n) openly axiomatized

## Risk: LOW

Status `axiomatized` + badge `axiom` accurately reflect the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)