### PR TITLE
research(elementary-quadratic-reciprocity-oq-01-oq-02): reconcile JSON with completed gallery state

### DIFF
--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "elementary-quadratic-reciprocity-oq-01-oq-02",
   "title": "Can the character uniqueness argument be generalized to prove cubic or quarti...",
-  "phase": "NEW",
+  "phase": "COMPLETE",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-03T11:41:44.693Z",
+    "phase": "COMPLETE",
+    "since": "2026-05-04T00:42:55.000Z",
     "iteration": 1,
-    "focus": "Cubic and quartic character construction complete; awaiting Docker build",
+    "focus": "All work merged: 27 theorems / 0 sorries / 2 axioms (Eisenstein integers Mathlib gap)",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Closed pending Mathlib upstream of Eisenstein integers ℤ[ω].",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -29,32 +29,35 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Constructed cubic/quartic characters as group homs; proved easy Euler criterion; axiomatized hard direction and cubic reciprocity. File in PR.",
+    "progressSummary": "COMPLETE: Cubic + quartic characters fully developed in Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean (562 lines, 27 theorems, 6 defs, 0 sorries, 2 axioms). Both Euler criteria proved (easy + hard via discrete log); both kernel cardinalities |ker χ| = (p-1)/k proved via IsCyclic.card_pow_eq_one_le sandwich. The 2 remaining axioms (cubicResidueSymbol, cubic_reciprocity) are documented Mathlib gaps requiring Eisenstein integers ℤ[ω], not solvable here. Merged across PRs #15291 (construction), #15322 (cubicEuler_hard), #15334 (True-stub removal), #15356/#15357 (cubicChar_kernel_card), #15360 (API drift), #15414 (Session 2: quarticEuler_hard + quarticChar_kernel_card), #16616 (leanFiles drift sync).",
     "builtItems": [
-      "cubicChar : (ZMod p)ˣ →* (ZMod p)ˣ in ElementaryQuadraticReciprocityOQ01OQ02.lean:83",
-      "cubicChar_pow_three_eq_one : χ₃(a)³ = 1 via Fermat in :105",
-      "cubicChar_eq_one_of_cube : easy Euler criterion direction in :156",
-      "isCubicResidue_iff_cubicChar_one : cubic Euler iff (mod axiom) in :188",
-      "quarticChar : (ZMod p)ˣ →* (ZMod p)ˣ in :257",
-      "cubic_character_package + quartic_character_package : summary theorems in :376-391"
+      "cubicChar : (ZMod p)ˣ →* (ZMod p)ˣ in ElementaryQuadraticReciprocityOQ01OQ02.lean:84",
+      "cubicChar_pow_three_eq_one : χ₃(a)³ = 1 via Fermat in :106",
+      "cubicChar_eq_one_of_cube : easy Euler criterion direction in :157",
+      "cubicEuler_hard : χ₃(a)=1 → IsCubicResidue via discrete log in :182",
+      "isCubicResidue_iff_cubicChar_one : full cubic Euler biconditional in :234",
+      "cubicChar_kernel_card : |ker χ₃| = (p-1)/3 via IsCyclic.card_pow_eq_one_le in :273",
+      "quarticChar : (ZMod p)ˣ →* (ZMod p)ˣ in :326",
+      "quarticChar_pow_four_eq_one : χ₄(a)⁴ = 1 via Fermat in :333",
+      "quarticChar_eq_one_of_quarticResidue : easy quartic Euler in :344",
+      "quarticEuler_hard : χ₄(a)=1 → IsQuarticResidue via discrete log in :370",
+      "isQuarticResidue_iff_quarticChar_one : full quartic Euler biconditional in :412",
+      "quarticChar_kernel_card : |ker χ₄| = (p-1)/4 in :421",
+      "cubic_character_package + quartic_character_package : summary theorems in :540, :553"
     ],
     "insights": [
       "cubicChar = powMonoidHom((p-1)/3) is a well-typed group hom (ZMod p)ˣ →* (ZMod p)ˣ using CommMonoid instance",
       "Easy Euler criterion: x³=a → a^((p-1)/3)=1 proved via Units.mk0 lift + pow_mul + units_pow_card_sub_one_eq_one",
-      "Cyclic kernel cardinality API (IsCyclic.exists_unique_subgroup_of_dvd) missing from Mathlib 4.26",
-      "Eisenstein integers ℤ[ω] not in Mathlib 4.26 — cubic reciprocity must be axiomatized",
-      "Quartic character χ₄ = powMonoidHom((p-1)/4) has identical proof structure to χ₃"
+      "Hard Euler criterion (cubic + quartic): discrete log via IsCyclic.exists_generator + Subgroup.mem_zpowers_iff + orderOf_dvd_iff_zpow_eq_one.mpr; cubExp_mul / quartExp_mul rewrites convert (p-1) | k·cubExp into 3 | k (resp. 4 | k)",
+      "Kernel cardinality (cubic + quartic): IsCyclic.card_pow_eq_one_le gives upper bound k; lower bound via Finset.le_card_of_inj_on_range with k ↦ (g^3)^k (resp. g^4) using pow_injOn_Iio_orderOf",
+      "Eisenstein integers ℤ[ω] not in Mathlib 4.26 — cubic reciprocity must remain axiomatized until upstream",
+      "Quartic character χ₄ = powMonoidHom((p-1)/4) has identical proof structure to χ₃; both kernel-card proofs share the IsCyclic sandwich argument"
     ],
     "mathlibGaps": [
-      "Cyclic group kernel cardinality: Fintype.card {x : G | x^k=1} = gcd(k,|G|) for cyclic G",
-      "Eisenstein integers ℤ[ω] structure and prime theory not in Mathlib 4.26",
-      "Cubic residue symbol (ρ/π)₃ definition requires ℤ[ω] units"
+      "Eisenstein integers ℤ[ω] structure and prime theory not in Mathlib 4.26 (blocks cubic_reciprocity proof)",
+      "Cubic residue symbol (ρ/π)₃ definition requires ℤ[ω] units (blocks cubicResidueSymbol axiom removal)"
     ],
-    "nextSteps": [
-      "Submit cubicEuler_hard sorry to Aristotle for cyclic group kernel argument",
-      "Monitor Mathlib PRs for Eisenstein integer additions",
-      "Try proving cubicChar_kernel_card via Subgroup.card_eq_iff_eq_top or orderOf arguments"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "number-theory",
@@ -85,7 +88,8 @@
     "mathlib": []
   },
   "started": "2026-05-03T11:41:44.693Z",
-  "lastUpdate": "2026-05-07T17:45:00.000Z",
+  "completed": "2026-05-04T00:42:55.000Z",
+  "lastUpdate": "2026-05-07T19:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Reconciles the research JSON for `elementary-quadratic-reciprocity-oq-01-oq-02` with the actual on-main gallery state.

The research is **complete**: `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` is on `origin/main` at 562 lines / 27 theorems / 6 defs / 0 sorries / 2 axioms. The 2 axioms (`cubicResidueSymbol`, `cubic_reciprocity`) are documented Mathlib gaps requiring Eisenstein integers ℤ[ω]. But the JSON still showed:
- `phase: "NEW"` and `currentState.phase: "ACT"`
- `progressSummary` claiming the hard Euler direction was axiomatized (it is **proved** at `:182` via discrete log; full biconditional at `:234`)
- `nextSteps` suggesting Aristotle submission of `cubicEuler_hard` (already proved) and proving `cubicChar_kernel_card` (already proved at `:273` in PR #15356)
- `builtItems` listing only 6 entries (should be 13)

This is the "research/problems JSON lags gallery meta.json" pattern (memory `feedback_research_json_lags_gallery.md`).

## Changes (one file)

`src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json`:
- `phase: NEW → COMPLETE`
- `currentState.phase: ACT → COMPLETE`; `since` / `focus` / `nextAction` reflect closed state
- `progressSummary` rewritten with final metrics + PR provenance
- `builtItems` expanded 6 → 13 entries; line numbers verified against current file
- `insights`: replaced stale claim about missing kernel-card API with the actual hard-direction strategy and the `IsCyclic.card_pow_eq_one_le` sandwich
- `mathlibGaps`: dropped the now-irrelevant cyclic kernel-cardinality entry; kept the two Eisenstein-integer entries that still block axiom removal
- `nextSteps`: cleared (Aristotle submission no longer applies; Mathlib upstream is the only remaining lever, tracked in `mathlibGaps`)
- `completed` timestamp set to PR #15414 final commit (`2026-05-04T00:42:55Z`)
- `lastUpdate` bumped

No code changes; the Lean proof is unchanged.

## Provenance

Work merged across PRs:
- #15291 — initial cubic/quartic character construction
- #15322 — `cubicEuler_hard` via discrete log
- #15334 — True-stub theorem removal
- #15356 / #15357 — `cubicChar_kernel_card` proof
- #15360 — API drift repair (`G→α`, `hord3 rfl`, examples)
- #15414 — Session 2: `quarticEuler_hard` + `quarticChar_kernel_card` (still **OPEN**, conflicting/dirty; superseded by direct merges of its commits)
- #16616 — `leanFiles` drift sync

Note: PR #15414 is `OPEN` but `mergeStateStatus: DIRTY`. Its substantive contents have already been merged through other PRs (compare `27` theorems on main vs the `27 theorems / 0 sorries / 2 axioms` claim in #15414). Closing it is out of scope here; this PR only reconciles the per-problem research JSON.

## Test plan
- [x] JSON validates (`python3 -m json.tool`)
- [x] `phase` / `currentState.phase` updated to `COMPLETE`
- [x] All `builtItems` line numbers cross-checked against `git show origin/main:proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean`
- [x] Lean file confirmed at 0 sorries / 2 axioms / 27 theorems on `origin/main`
- [x] Diff is JSON-only; no Lean / build artifacts touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)