### PR TITLE
audit(tracker): batch 4 — 3 clean + 1 issues-found (2026-05-07)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11545,9 +11545,9 @@
       "result": "clean"
     },
     "godel-first-incompleteness-oq01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:25Z",
+      "lastAudited": "2026-05-07T19:26:16Z",
       "result": "clean"
     },
     "godel-incompleteness": {
@@ -11713,10 +11713,10 @@
       "result": "clean"
     },
     "hilbert-15-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:26Z",
-      "result": "clean"
+      "lastAudited": "2026-05-07T19:26:16Z",
+      "result": "issues-found"
     },
     "hilbert-16": {
       "agentId": "auditor-cycle-20-batch",
@@ -12151,9 +12151,9 @@
       "result": "clean"
     },
     "law-of-sines-oq-06": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:27Z",
+      "lastAudited": "2026-05-07T19:26:16Z",
       "result": "clean"
     },
     "laws-of-large-numbers": {
@@ -12175,9 +12175,9 @@
       "issues": []
     },
     "laws-of-large-numbers-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:27Z",
+      "lastAudited": "2026-05-07T19:26:16Z",
       "result": "clean"
     },
     "laws-of-large-numbers-oq-04": {


### PR DESCRIPTION
## Audit Batch — 2026-05-07

Re-audit pass on 4 never-audited / 1x-audited entries. All structural counts re-verified against the Lean source on origin/main HEAD.

### Clean (3)

| Slug | axiomCount | theoremCount | defCount | sorries | lineCount |
|---|---|---|---|---|---|
| godel-first-incompleteness-oq01 | 5/5 ✓ | 5/5 ✓ | 6/6 ✓ | 0/0 ✓ | 271/271 ✓ |
| laws-of-large-numbers-oq-03 | 4/4 ✓ | 9/9 ✓ | 5/5 ✓ | 0/0 ✓ | 404/404 ✓ |
| law-of-sines-oq-06 | 0/0 ✓ | 24/24 ✓ | 9/9 ✓ | 0/0 ✓ | 309/309 ✓ |

### Issues-found (1)

**hilbert-15-oq-02** — `meta.axiomCount=3` but the Lean file declares **0** axioms. Three theorems are weakened to `True := trivial` as documented placeholders:

- `lr_saturation_theorem` (line 326)
- `lr_positivity_in_P` (line 338)
- `lr_counting_sharp_P_complete` (line 355)

`lf.axiomCount=0` is already correct (matches reality), so `find-targets` did not surface this. The discrepancy between `meta.axiomCount` and `lf.axiomCount` is the drift. Issue filed separately to discuss whether the canonical fix is to set `meta.axiomCount=0` (treating True-stubs as vacuous, not assumptions per project's Axiom Integrity Policy) or to promote the placeholders to actual `axiom` declarations.

---
Discovered during gallery integrity audit.