### PR TITLE
fix(meta): continuum-hypothesis-oq-02 — assumptions text count opaque MartinsAxiom

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -71,7 +71,7 @@
     "dateAdded": "2026-03-27",
     "axiomCount": 3,
     "lineCount": 584,
-    "assumptions": "2 axioms: bounding_number_uncountable, MA_implies_b_eq_continuum. 0 sorries.",
+    "assumptions": "3 assumptions: 2 axioms (bounding_number_uncountable, MA_implies_b_eq_continuum) + 1 opaque constant (MartinsAxiom — declared opaque since the full forcing-axiom statement is not formalized). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 32,
     "definitionCount": 7


### PR DESCRIPTION
## Fix

Update `assumptions` text in continuum-hypothesis-oq-02/meta.json to count the opaque `MartinsAxiom` constant alongside the 2 explicit axioms.

## Evidence

**Before**: `"2 axioms: bounding_number_uncountable, MA_implies_b_eq_continuum. 0 sorries."`

**After**: `"3 assumptions: 2 axioms (...) + 1 opaque constant (MartinsAxiom — ...). 0 sorries."`

The `axiomCount: 3` field is already correct (2 `axiom` decls + 1 `opaque` decl = 3 assumptions per the project's axiom integrity policy where `opaque` counts toward `axiomCount`).

Verified via grep on `proofs/Proofs/ContinuumHypothesisOQ02.lean`:
- `axiom bounding_number_uncountable`
- `axiom MA_implies_b_eq_continuum`  
- `opaque MartinsAxiom`

The new prose follows the convention used in erdos-582 and erdos-746 (`"N assumptions: X opaque + Y axioms"`).

Pure narrative drift fix; no Lean changes; 1 line replaced.

---
Automated fix by lean-mechanic agent.