### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): structural lemmas for lcmRange

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -104,6 +104,51 @@ theorem dvd_lcmRange {k n : ℕ} (hk : 0 < k) (hkn : k ≤ n) :
   have := Finset.dvd_lcm (f := (· + 1)) hk'
   simpa [Nat.sub_add_cancel hk] using this
 
+/-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
+
+    The inductive step that any inductive proof of Hanson's bound
+    (or any bound on `lcmRange`) needs. Foundational structural
+    lemma for future ACT-phase work on this OQ. -/
+theorem lcmRange_succ (n : ℕ) :
+    lcmRange (n + 1) = Nat.lcm (lcmRange n) (n + 1) := by
+  apply Nat.dvd_antisymm
+  · unfold lcmRange
+    apply Finset.lcm_dvd
+    intro i hi
+    have hi_lt : i < n + 1 := Finset.mem_range.mp hi
+    rcases Nat.lt_succ_iff_lt_or_eq.mp hi_lt with hi' | hi'
+    · exact dvd_trans (Finset.dvd_lcm (Finset.mem_range.mpr hi'))
+        (Nat.dvd_lcm_left _ _)
+    · subst hi'; exact Nat.dvd_lcm_right _ _
+  · apply Nat.lcm_dvd
+    · unfold lcmRange
+      apply Finset.lcm_dvd
+      intro i hi
+      have : i < n + 1 :=
+        lt_of_lt_of_le (Finset.mem_range.mp hi) (Nat.le_succ n)
+      exact Finset.dvd_lcm (Finset.mem_range.mpr this)
+    · exact dvd_lcmRange (Nat.succ_pos n) (Nat.le_refl _)
+
+/-- **Divisibility monotonicity**: m ≤ n → lcm(1,...,m) ∣ lcm(1,...,n).
+
+    Every divisor of the smaller LCM appears in the larger one. -/
+theorem lcmRange_dvd_lcmRange_of_le {m n : ℕ} (h : m ≤ n) :
+    lcmRange m ∣ lcmRange n := by
+  unfold lcmRange
+  apply Finset.lcm_dvd
+  intro i hi
+  have hi_lt : i < n :=
+    lt_of_lt_of_le (Finset.mem_range.mp hi) h
+  exact Finset.dvd_lcm (Finset.mem_range.mpr hi_lt)
+
+/-- **Numerical monotonicity**: m ≤ n → lcm(1,...,m) ≤ lcm(1,...,n). -/
+theorem lcmRange_monotone : Monotone lcmRange := by
+  intro m n h
+  apply Nat.le_of_dvd _ (lcmRange_dvd_lcmRange_of_le h)
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · rw [lcmRange_zero]; exact Nat.one_pos
+  · exact lcmRange_pos n hn
+
 -- =====================================================================
 -- PART 3: Provable bounds (no axioms)
 -- =====================================================================

--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -116,10 +116,11 @@ theorem lcmRange_succ (n : ℕ) :
     apply Finset.lcm_dvd
     intro i hi
     have hi_lt : i < n + 1 := Finset.mem_range.mp hi
-    rcases Nat.lt_succ_iff_lt_or_eq.mp hi_lt with hi' | hi'
-    · exact dvd_trans (Finset.dvd_lcm (Finset.mem_range.mpr hi'))
+    by_cases hi_eq : i = n
+    · subst hi_eq; exact Nat.dvd_lcm_right _ _
+    · have hi' : i < n := by omega
+      exact dvd_trans (Finset.dvd_lcm (Finset.mem_range.mpr hi'))
         (Nat.dvd_lcm_left _ _)
-    · subst hi'; exact Nat.dvd_lcm_right _ _
   · apply Nat.lcm_dvd
     · unfold lcmRange
       apply Finset.lcm_dvd

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -1,15 +1,21 @@
 # Research State: basel-problem-oq-01-oq-01-oq-02-oq-03
 
 ## Current State
-**Phase**: ACT (bootstrap complete; full proof requires Mathlib upstream)
+**Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
 **Last Updated**: 2026-05-07
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Bootstrap completed. The OBSERVE/ORIENT phase converted this stub
-problem into a Lean 4 formalization target with:
+Iteration 2 (2026-05-07): added foundational structural lemmas required
+by every subsequent proof attempt:
+- `lcmRange_succ`: lcm(1,...,n+1) = Nat.lcm (lcmRange n) (n+1) — the
+  recursive structure inducting along `n` will use.
+- `lcmRange_dvd_lcmRange_of_le`: divisibility monotonicity.
+- `lcmRange_monotone`: numerical monotonicity (with `n=0` boundary).
+
+Iteration 1 (bootstrap, completed 2026-05-07):
 - Provable elementary bounds: lcmRange n ≤ n!, lcmRange n ≤ n^n.
 - Numerical verification of Hanson's bound for n ∈ {1..10, 12, 15, 20}.
 - Axiom statement of the general claim with documentation of proof
@@ -30,9 +36,10 @@ Currently blocked on:
   `4^n` intermediate.
 
 ## Attempt Count
-- Total attempts: 1 (this session: OBSERVE/ORIENT bootstrap).
+- Total attempts: 2.
 - Current approach attempts: 0 (Approach 1 not started; awaits Mathlib).
-- Approaches tried: bootstrap with elementary bounds + axiom.
+- Approaches tried: bootstrap with elementary bounds + axiom (iter 1);
+  structural-lemma layer for inductive proofs (iter 2).
 
 ## Blockers
 - **Mathlib Beta-integral over ℚ**: not in usable form.

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 182,
-    "theoremCount": 22,
+    "lineCount": 227,
+    "theoremCount": 25,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 227,
+    "lineCount": 228,
     "theoremCount": 25,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
@@ -64,31 +64,31 @@
       "id": "definition",
       "title": "Part 1-2: Definition and Basic Properties",
       "startLine": 60,
-      "endLine": 150,
-      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, and dvd_lcmRange (each k ∈ {1,...,n} divides lcmRange n).",
+      "endLine": 151,
+      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
       "mathContext": "$\\operatorname{lcmRange}(n) = \\operatorname{lcm}\\{1, 2, \\ldots, n\\}$ encoded as a `Finset.lcm` over `Finset.range n` mapped through (·+1)."
     },
     {
       "id": "elementary-bounds",
       "title": "Part 3: Provable Elementary Bounds",
-      "startLine": 152,
-      "endLine": 172,
+      "startLine": 153,
+      "endLine": 173,
       "summary": "Proves the three elementary bounds with no axioms: lcmRange_dvd_factorial, lcmRange_le_factorial, lcmRange_le_self_pow. The chain lcm ≤ n! ≤ n^n is the trivial bound that Hanson's 3^n strictly improves upon.",
       "mathContext": "$\\operatorname{lcm}(1, \\ldots, n) \\mid n!$ via `Nat.dvd_factorial`, then $\\operatorname{lcm}(1, \\ldots, n) \\leq n! \\leq n^n$ via `Nat.factorial_le_pow`."
     },
     {
       "id": "numerical",
       "title": "Part 4: Numerical Verification of Hanson",
-      "startLine": 173,
-      "endLine": 195,
+      "startLine": 174,
+      "endLine": 196,
       "summary": "Verifies lcmRange n ≤ 3^n for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Includes lcmRange exact values lcmRange 5 = 60, lcmRange 10 = 2520, lcmRange 15 = 360360, lcmRange 20 = 232792560 (matches OEIS A003418).",
       "mathContext": "Concrete: $\\operatorname{lcm}(1, \\ldots, 20) = 232\\,792\\,560$ vs $3^{20} = 3\\,486\\,784\\,401$, ratio $\\approx 15$."
     },
     {
       "id": "axiom",
       "title": "Part 5: Hanson's Bound (Axiom)",
-      "startLine": 197,
-      "endLine": 227,
+      "startLine": 198,
+      "endLine": 228,
       "summary": "States `axiom hanson_bound : ∀ n, lcmRange n ≤ 3^n` — Hanson's classical 1972 theorem. Includes hanson_strictly_stronger_than_factorial showing the constant 3 is genuinely tighter than the trivial n^n bound for n ≥ 4.",
       "mathContext": "Hanson 1972: $\\operatorname{lcm}(1, \\ldots, n) \\leq 3^n$. Original proof uses Beta-integral identity $\\int_0^1 x^k(1-x)^{n-k} dx = \\frac{1}{(n+1)\\binom{n}{k}}$ combined with prime-power bounds."
     }

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -64,31 +64,31 @@
       "id": "definition",
       "title": "Part 1-2: Definition and Basic Properties",
       "startLine": 60,
-      "endLine": 100,
+      "endLine": 150,
       "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, and dvd_lcmRange (each k ∈ {1,...,n} divides lcmRange n).",
       "mathContext": "$\\operatorname{lcmRange}(n) = \\operatorname{lcm}\\{1, 2, \\ldots, n\\}$ encoded as a `Finset.lcm` over `Finset.range n` mapped through (·+1)."
     },
     {
       "id": "elementary-bounds",
       "title": "Part 3: Provable Elementary Bounds",
-      "startLine": 105,
-      "endLine": 130,
+      "startLine": 152,
+      "endLine": 172,
       "summary": "Proves the three elementary bounds with no axioms: lcmRange_dvd_factorial, lcmRange_le_factorial, lcmRange_le_self_pow. The chain lcm ≤ n! ≤ n^n is the trivial bound that Hanson's 3^n strictly improves upon.",
       "mathContext": "$\\operatorname{lcm}(1, \\ldots, n) \\mid n!$ via `Nat.dvd_factorial`, then $\\operatorname{lcm}(1, \\ldots, n) \\leq n! \\leq n^n$ via `Nat.factorial_le_pow`."
     },
     {
       "id": "numerical",
       "title": "Part 4: Numerical Verification of Hanson",
-      "startLine": 132,
-      "endLine": 160,
+      "startLine": 173,
+      "endLine": 195,
       "summary": "Verifies lcmRange n ≤ 3^n for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Includes lcmRange exact values lcmRange 5 = 60, lcmRange 10 = 2520, lcmRange 15 = 360360, lcmRange 20 = 232792560 (matches OEIS A003418).",
       "mathContext": "Concrete: $\\operatorname{lcm}(1, \\ldots, 20) = 232\\,792\\,560$ vs $3^{20} = 3\\,486\\,784\\,401$, ratio $\\approx 15$."
     },
     {
       "id": "axiom",
       "title": "Part 5: Hanson's Bound (Axiom)",
-      "startLine": 162,
-      "endLine": 182,
+      "startLine": 197,
+      "endLine": 227,
       "summary": "States `axiom hanson_bound : ∀ n, lcmRange n ≤ 3^n` — Hanson's classical 1972 theorem. Includes hanson_strictly_stronger_than_factorial showing the constant 3 is genuinely tighter than the trivial n^n bound for n ≥ 4.",
       "mathContext": "Hanson 1972: $\\operatorname{lcm}(1, \\ldots, n) \\leq 3^n$. Original proof uses Beta-integral identity $\\int_0^1 x^k(1-x)^{n-k} dx = \\frac{1}{(n+1)\\binom{n}{k}}$ combined with prime-power bounds."
     }


### PR DESCRIPTION
## Summary

Add three foundational structural lemmas to `BaselProblemOQ01OQ01OQ02OQ03.lean`, the bootstrap file for **Hanson's bound** `lcm(1,...,n) ≤ 3^n` (basel-problem-oq-01-oq-01-oq-02-oq-03 / OQ-04 of the Basel/Apéry chain).

These are the recursion + monotonicity infrastructure any future proof of Hanson's bound (or the easier intermediate `4^n` bound via primorial bridge) will need.

## What's added

1. **`lcmRange_succ`**: `lcm(1,...,n+1) = Nat.lcm (lcmRange n) (n+1)`.
   The recursive structure for inducting on `n`. Proved by `Nat.dvd_antisymm` with both directions reducing to `Finset.lcm_dvd` + `Finset.dvd_lcm`. Uses `by_cases hi_eq : i = n` + `omega` for the index-range split (robust against Mathlib API drift).

2. **`lcmRange_dvd_lcmRange_of_le`**: `m ≤ n → lcmRange m ∣ lcmRange n`.
   Divisibility monotonicity — every divisor of the smaller LCM appears in the larger.

3. **`lcmRange_monotone : Monotone lcmRange`**.
   Numerical monotonicity from divisibility via `Nat.le_of_dvd`, with a positivity boundary case for `n = 0` (`lcmRange 0 = 1 > 0`).

## Why this matters

`research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md` lists two follow-up paths:

1. Intermediate `lcm(1..n) ≤ 4^n` via the primorial bridge.
2. Full Hanson `lcm(1..n) ≤ 3^n` via Beta-integral identities.

Both are inductive on `n` and start with `lcmRange (n+1) = Nat.lcm (lcmRange n) (n+1)`. Without it, every approach must rebuild the recursion from `Finset.range_succ` / `Finset.lcm_insert`. This PR provides that infrastructure.

## Status

- **Axioms unchanged**: `hanson_bound` is still the only axiom (count: 1).
- **No new sorries**.
- **Phase**: ACT iteration 2 (per `state.md`).

## Build

Local Docker build (`./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ03`) was started but is queued behind ~6 other concurrent builds on the shared `lean-mathlib-cache` volume; left running to completion. The proof uses only standard Mathlib lemmas already used elsewhere in this file (`Nat.dvd_antisymm`, `Nat.lcm_dvd`, `Nat.dvd_lcm_left/right`, `Finset.lcm_dvd`, `Finset.dvd_lcm`, `Nat.le_of_dvd`, `Nat.eq_zero_or_pos`, `omega`).

## Files changed

- `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`: +46 lines (3 new theorems with docstrings).
- `src/data/proofs/.../meta.json`: lineCount 182→228, theoremCount 22→25, section line-range bumps.
- `research/problems/.../state.md`: iteration bump and progress note.

## Test plan

- [x] `git fetch origin main && git diff main..HEAD --stat` shows only the intended files.
- [x] meta.json valid JSON, section ranges align with file structure.
- [ ] `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ03` (running, build cache contention).