### PR TITLE
research(euler-identity-oq-01-oq-01-oq-01): Lie group exp ℝ → S¹ as continuous group hom

### DIFF
--- a/proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean
@@ -70,10 +70,8 @@ theorem circleMap_add (a b : ℝ) :
 
 @[simp] theorem circleMap_neg (t : ℝ) :
     circleMap (-t) = (circleMap t)⁻¹ := by
-  have h : circleMap t * circleMap (-t) = 1 := by
-    rw [← circleMap_add, add_neg_cancel, circleMap_zero]
-  field_simp
-  linear_combination h
+  unfold circleMap
+  rw [show ((-t : ℝ) : ℂ) * I = -((t : ℝ) * I) by push_cast; ring, Complex.exp_neg]
 
 theorem circleMap_sub (a b : ℝ) :
     circleMap (a - b) = circleMap a * (circleMap b)⁻¹ := by
@@ -91,8 +89,8 @@ theorem circleMap_eq_cos_add_sin_I (t : ℝ) :
 
 /-- `circleMap` lands on the unit circle: `|exp(it)| = 1`. -/
 theorem norm_circleMap (t : ℝ) : ‖circleMap t‖ = 1 := by
-  rw [circleMap_eq_cos_add_sin_I]
-  exact Complex.norm_cos_add_sin_mul_I t
+  unfold circleMap
+  exact Complex.norm_exp_ofReal_mul_I t
 
 /-- `circleMap t` is a unit in ℂ. -/
 theorem circleMap_ne_zero (t : ℝ) : circleMap t ≠ 0 := by
@@ -185,16 +183,14 @@ theorem circleMap_surjective_unit_circle (z : ℂ) (hz : ‖z‖ = 1) :
     ∃ t : ℝ, circleMap t = z := by
   refine ⟨Complex.arg z, ?_⟩
   rw [circleMap_eq_cos_add_sin_I]
-  -- z = cos(arg z) + sin(arg z) i  when |z| = 1
-  have habs : Complex.abs z = 1 := by
-    rwa [show Complex.abs z = ‖z‖ from rfl]
-  -- Use Complex.abs_mul_cos_add_sin_mul_I-style identity
-  have := Complex.abs_mul_cos_add_sin_mul_I z
-  rw [habs] at this
-  rw [show ((1 : ℝ) : ℂ) * (Real.cos (Complex.arg z) + Real.sin (Complex.arg z) * I) =
-        Real.cos (Complex.arg z) + Real.sin (Complex.arg z) * I from by ring] at this
-  -- this : 1 * (cos (arg z) + sin (arg z) * I) = z
-  exact this.symm
+  have hzne : z ≠ 0 := by
+    intro h; rw [h, norm_zero] at hz; norm_num at hz
+  have hcos : Real.cos (Complex.arg z) = z.re := by
+    rw [Complex.cos_arg hzne, hz, div_one]
+  have hsin : Real.sin (Complex.arg z) = z.im := by
+    rw [Complex.sin_arg, hz, div_one]
+  rw [hcos, hsin]
+  exact Complex.re_add_im z
 
 /-! ## §7. Bonus: De Moivre's Theorem in One Line -/
 
@@ -214,15 +210,11 @@ theorem circleMap_npow (t : ℝ) (n : ℕ) :
 for all `n : ℤ`. The negative-exponent case follows from `circleMap_neg`. -/
 theorem circleMap_zpow (t : ℝ) (n : ℤ) :
     (circleMap t) ^ n = circleMap ((n : ℝ) * t) := by
-  cases n with
-  | ofNat k =>
-    show (circleMap t) ^ (k : ℕ) = circleMap ((k : ℝ) * t)
-    rw [circleMap_npow]
-  | negSucc k =>
-    show (circleMap t) ^ (-(k + 1 : ℤ)) = circleMap ((-(k + 1) : ℝ) * t)
-    rw [zpow_neg, zpow_natCast, circleMap_npow]
-    have : ((-(k + 1 : ℤ) : ℝ) * t) = -((k + 1 : ℕ) * t) := by push_cast; ring
-    rw [this, circleMap_neg]
+  unfold circleMap
+  rw [← Complex.exp_int_mul]
+  congr 1
+  push_cast
+  ring
 
 /-! ## §8. Summary -/
 

--- a/proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean
@@ -1,0 +1,249 @@
+/-
+# Euler's Formula as a Lie Group Homomorphism (OQ-01-OQ-01-OQ-01)
+
+## Open Question
+
+> Can the proof be extended to prove the Lie group exponential map ℝ → S¹
+> is a homomorphism, viewing Euler's formula as the statement that exp(i·)
+> is a group homomorphism from (ℝ, +) to (S¹, ×)?
+
+## Answer
+
+YES. Euler's formula `exp(it) = cos t + i·sin t`, combined with the
+exponential addition law `exp(z + w) = exp z · exp w`, makes the map
+`circleHom : t ↦ exp(it)` from (ℝ, +) to (ℂˣ, ×) a continuous group
+homomorphism whose image is exactly the unit circle S¹ = {z : ℂ | ‖z‖ = 1}.
+
+This file proves:
+1. `circleHom` is a group homomorphism `Multiplicative ℝ →* ℂˣ`
+2. `circleHom` is continuous (so it's a topological group hom)
+3. `‖circleHom t‖ = 1` for all t (image lies in S¹)
+4. The kernel of `circleHom` is exactly `2π·ℤ`
+5. The image of `circleHom` is exactly the unit circle (surjective onto S¹)
+6. As a bonus: the homomorphism law gives a one-line proof of de Moivre
+
+## Connection to Lie Theory
+
+`circleHom` is the canonical Lie group exponential map for the circle
+group S¹: it is the unique continuous homomorphism `ℝ → S¹` whose
+derivative at 0 sends 1 to the imaginary unit i (the Lie algebra of S¹
+is `iℝ ⊆ ℂ`). The kernel description `2π·ℤ` exhibits S¹ as the quotient
+ℝ/2πℤ as a topological group.
+
+## Foundation
+
+Builds on `EulerIdentityOQ01OQ01.euler_formula`, which proves
+`exp(↑x · I) = ↑(cos x) + ↑(sin x) · I` axiom-free. The homomorphism
+properties then follow from `Complex.exp_add` and standard real analysis.
+
+## Status
+
+0 axioms, 0 sorries.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Series
+import Mathlib.Analysis.SpecialFunctions.Complex.Log
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Topology.Algebra.Group.Basic
+import Mathlib.Topology.ContinuousMap.Basic
+import Mathlib.Tactic
+import Proofs.EulerIdentityOQ01OQ01
+
+open Complex Real
+
+namespace EulerIdentityOQ01OQ01OQ01
+
+/-! ## §1. The Underlying Map: t ↦ exp(it) -/
+
+/-- The complex map `t ↦ exp(it)`, the prototype of a circle parametrization. -/
+noncomputable def circleMap (t : ℝ) : ℂ := Complex.exp ((t : ℂ) * I)
+
+@[simp] theorem circleMap_zero : circleMap 0 = 1 := by
+  simp [circleMap]
+
+theorem circleMap_add (a b : ℝ) :
+    circleMap (a + b) = circleMap a * circleMap b := by
+  simp only [circleMap, ofReal_add]
+  rw [add_mul, Complex.exp_add]
+
+@[simp] theorem circleMap_neg (t : ℝ) :
+    circleMap (-t) = (circleMap t)⁻¹ := by
+  have h : circleMap t * circleMap (-t) = 1 := by
+    rw [← circleMap_add, add_neg_cancel, circleMap_zero]
+  field_simp
+  linear_combination h
+
+theorem circleMap_sub (a b : ℝ) :
+    circleMap (a - b) = circleMap a * (circleMap b)⁻¹ := by
+  rw [sub_eq_add_neg, circleMap_add, circleMap_neg]
+
+/-- **Connection to Euler's formula** (from OQ-01-OQ-01).
+
+`circleMap t = cos t + i · sin t`, the trigonometric form of `exp(it)`. -/
+theorem circleMap_eq_cos_add_sin_I (t : ℝ) :
+    circleMap t = (Real.cos t : ℂ) + (Real.sin t : ℂ) * I := by
+  unfold circleMap
+  exact EulerIdentityOQ01OQ01.euler_formula t
+
+/-! ## §2. Image Lies on the Unit Circle -/
+
+/-- `circleMap` lands on the unit circle: `|exp(it)| = 1`. -/
+theorem norm_circleMap (t : ℝ) : ‖circleMap t‖ = 1 := by
+  rw [circleMap_eq_cos_add_sin_I]
+  exact Complex.norm_cos_add_sin_mul_I t
+
+/-- `circleMap t` is a unit in ℂ. -/
+theorem circleMap_ne_zero (t : ℝ) : circleMap t ≠ 0 := by
+  intro h
+  have : ‖circleMap t‖ = 0 := by rw [h, norm_zero]
+  rw [norm_circleMap] at this
+  norm_num at this
+
+/-! ## §3. Group Homomorphism Structure -/
+
+/-- **Main theorem**: `circleMap` packaged as a multiplicative monoid hom
+from `Multiplicative ℝ` to `ℂˣ`, the units of ℂ.
+
+This is the formal Lie-group statement: `(ℝ, +) → (ℂˣ, ·)` is a group
+homomorphism via the exponential map. -/
+noncomputable def circleHom : Multiplicative ℝ →* ℂˣ where
+  toFun t := Units.mk0 (circleMap (Multiplicative.toAdd t)) (circleMap_ne_zero _)
+  map_one' := by
+    ext
+    show circleMap (Multiplicative.toAdd (1 : Multiplicative ℝ)) = 1
+    show circleMap 0 = 1
+    simp
+  map_mul' a b := by
+    ext
+    show circleMap (Multiplicative.toAdd (a * b)) =
+         circleMap (Multiplicative.toAdd a) * circleMap (Multiplicative.toAdd b)
+    show circleMap (Multiplicative.toAdd a + Multiplicative.toAdd b) =
+         circleMap (Multiplicative.toAdd a) * circleMap (Multiplicative.toAdd b)
+    exact circleMap_add _ _
+
+@[simp] theorem circleHom_apply (t : ℝ) :
+    (circleHom (Multiplicative.ofAdd t) : ℂ) = circleMap t := by
+  rfl
+
+/-- Equivalent additive-style statement: `circleMap` is an additive→multiplicative
+homomorphism, expressed as the composition of `Multiplicative.ofAdd` and `circleHom`. -/
+theorem circleMap_homomorphism (a b : ℝ) :
+    (circleMap (a + b) : ℂ) = (circleMap a : ℂ) * (circleMap b : ℂ) :=
+  circleMap_add a b
+
+/-! ## §4. Continuity (Topological Group Homomorphism) -/
+
+/-- `circleMap` is continuous as a function `ℝ → ℂ`. -/
+theorem continuous_circleMap : Continuous circleMap := by
+  unfold circleMap
+  exact Complex.continuous_exp.comp (Complex.continuous_ofReal.mul continuous_const)
+
+/-- `circleHom` is continuous when ℂˣ has the subspace topology of ℂ.
+Combined with the homomorphism property, this exhibits `circleHom` as a
+continuous group homomorphism — the Lie group exponential map. -/
+theorem continuous_circleHom :
+    Continuous (fun t : ℝ => (circleHom (Multiplicative.ofAdd t) : ℂ)) := by
+  simpa using continuous_circleMap
+
+/-! ## §5. Kernel: `circleMap t = 1 ↔ t ∈ 2π·ℤ` -/
+
+/-- **Kernel of the Lie group exponential**: `circleMap t = 1` exactly when
+`t = 2π·n` for some integer `n`. This identifies the kernel of the
+homomorphism `ℝ → S¹` and exhibits S¹ ≅ ℝ/2πℤ. -/
+theorem circleMap_eq_one_iff (t : ℝ) :
+    circleMap t = 1 ↔ ∃ n : ℤ, t = 2 * π * n := by
+  unfold circleMap
+  rw [Complex.exp_eq_one_iff]
+  constructor
+  · rintro ⟨n, hn⟩
+    refine ⟨n, ?_⟩
+    -- hn : (t : ℂ) * I = n * (2 * π * I)
+    -- Cancel I from both sides, then unwrap reals
+    have hI : (Complex.I : ℂ) ≠ 0 := Complex.I_ne_zero
+    have hcomp : (t : ℂ) = (n : ℂ) * (2 * π) := by
+      have := hn
+      have h2 : (n : ℂ) * (2 * π * Complex.I) = (n * (2 * π)) * Complex.I := by ring
+      rw [h2] at this
+      exact mul_right_cancel₀ hI this
+    have : (t : ℝ) = ((n : ℝ) * (2 * π) : ℝ) := by exact_mod_cast hcomp
+    linarith
+  · rintro ⟨n, rfl⟩
+    refine ⟨n, ?_⟩
+    push_cast
+    ring
+
+/-! ## §6. Surjectivity onto the Unit Circle -/
+
+/-- **Image of the Lie group exponential** is the entire unit circle.
+
+Every complex number on the unit circle has the form `exp(it)` for some
+real `t` (in fact, for any `t = arg z`). This makes S¹ a homogeneous
+space under the additive translation action of ℝ. -/
+theorem circleMap_surjective_unit_circle (z : ℂ) (hz : ‖z‖ = 1) :
+    ∃ t : ℝ, circleMap t = z := by
+  refine ⟨Complex.arg z, ?_⟩
+  rw [circleMap_eq_cos_add_sin_I]
+  -- z = cos(arg z) + sin(arg z) i  when |z| = 1
+  have habs : Complex.abs z = 1 := by
+    rwa [show Complex.abs z = ‖z‖ from rfl]
+  -- Use Complex.abs_mul_cos_add_sin_mul_I-style identity
+  have := Complex.abs_mul_cos_add_sin_mul_I z
+  rw [habs] at this
+  rw [show ((1 : ℝ) : ℂ) * (Real.cos (Complex.arg z) + Real.sin (Complex.arg z) * I) =
+        Real.cos (Complex.arg z) + Real.sin (Complex.arg z) * I from by ring] at this
+  -- this : 1 * (cos (arg z) + sin (arg z) * I) = z
+  exact this.symm
+
+/-! ## §7. Bonus: De Moivre's Theorem in One Line -/
+
+/-- **De Moivre's theorem** as an immediate consequence of the homomorphism
+property: `(circleMap t)^n = circleMap (n·t)` for all `n : ℕ`. -/
+theorem circleMap_npow (t : ℝ) (n : ℕ) :
+    (circleMap t) ^ n = circleMap (n * t) := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [pow_succ, ih, ← circleMap_add]
+    congr 1
+    push_cast
+    ring
+
+/-- **De Moivre's theorem (integer version)**: `(circleMap t)^n = circleMap (n·t)`
+for all `n : ℤ`. The negative-exponent case follows from `circleMap_neg`. -/
+theorem circleMap_zpow (t : ℝ) (n : ℤ) :
+    (circleMap t) ^ n = circleMap ((n : ℝ) * t) := by
+  cases n with
+  | ofNat k =>
+    show (circleMap t) ^ (k : ℕ) = circleMap ((k : ℝ) * t)
+    rw [circleMap_npow]
+  | negSucc k =>
+    show (circleMap t) ^ (-(k + 1 : ℤ)) = circleMap ((-(k + 1) : ℝ) * t)
+    rw [zpow_neg, zpow_natCast, circleMap_npow]
+    have : ((-(k + 1 : ℤ) : ℝ) * t) = -((k + 1 : ℕ) * t) := by push_cast; ring
+    rw [this, circleMap_neg]
+
+/-! ## §8. Summary -/
+
+/-- The Lie group exponential map `ℝ → S¹` is precisely `circleMap`.
+
+Key properties (proved above):
+- `circleMap_add`: homomorphism `(ℝ, +) → (ℂˣ, ·)`
+- `norm_circleMap`: image lies in the unit circle
+- `continuous_circleMap`: continuous (so this is a Lie group hom)
+- `circleMap_eq_one_iff`: kernel is `2π·ℤ` (so S¹ ≅ ℝ/2πℤ)
+- `circleMap_surjective_unit_circle`: surjective onto S¹
+
+This is the rigorous form of "Euler's formula identifies S¹ as a 1-parameter
+Lie group with Lie algebra `iℝ`." -/
+theorem main : ∀ t : ℝ, circleMap t = (Real.cos t : ℂ) + (Real.sin t : ℂ) * I :=
+  circleMap_eq_cos_add_sin_I
+
+#check @circleMap_add
+#check @norm_circleMap
+#check @continuous_circleMap
+#check @circleMap_surjective_unit_circle
+#check @circleMap_npow
+
+end EulerIdentityOQ01OQ01OQ01

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,35 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerIdentityOq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerIdentityOq01Oq01Oq01Annotations: Annotation[] = []
+
+export const eulerIdentityOq01Oq01Oq01Data: ProofData = {
+  proof: eulerIdentityOq01Oq01Oq01Proof,
+  annotations: eulerIdentityOq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,246 @@
+{
+  "id": "euler-identity-oq-01-oq-01-oq-01",
+  "title": "Euler's Formula as a Lie Group Homomorphism ℝ → S¹",
+  "slug": "euler-identity-oq-01-oq-01-oq-01",
+  "description": "Extends the axiom-free Taylor-series proof of Euler's identity (OQ-01-OQ-01) to show that t ↦ exp(it) is a continuous Lie group homomorphism from (ℝ, +) to the unit circle (S¹, ·), with kernel exactly 2π·ℤ. The map is packaged as a MonoidHom from Multiplicative ℝ to ℂˣ; surjectivity onto S¹ follows from the polar decomposition. De Moivre's theorem drops out as a one-line corollary.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerIdentityOQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "complex-analysis",
+      "lie-groups",
+      "topological-groups",
+      "euler-formula",
+      "homomorphism",
+      "unit-circle",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 241,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exp_add",
+        "description": "Exponential addition law: exp(z + w) = exp z * exp w",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "Complex.exp_neg",
+        "description": "exp(-z) = (exp z)⁻¹",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "Complex.exp_eq_one_iff",
+        "description": "exp z = 1 ↔ ∃ n : ℤ, z = n * (2 * π * I)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Log"
+      },
+      {
+        "theorem": "Complex.exp_int_mul",
+        "description": "exp(n * z) = (exp z)^n for n : ℤ",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "Complex.norm_exp_ofReal_mul_I",
+        "description": "‖exp(↑x * I)‖ = 1 for real x",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      },
+      {
+        "theorem": "Complex.cos_arg, Complex.sin_arg",
+        "description": "cos(arg z) = z.re/‖z‖ and sin(arg z) = z.im/‖z‖",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Log"
+      },
+      {
+        "theorem": "Complex.continuous_exp",
+        "description": "Continuity of complex exponential",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "Complex.re_add_im",
+        "description": "↑z.re + ↑z.im * I = z",
+        "module": "Mathlib.Data.Complex.Basic"
+      }
+    ],
+    "originalContributions": [
+      "circleMap : ℝ → ℂ defined as t ↦ exp(it), the natural Lie group exp map",
+      "circleMap_add: homomorphism law circleMap (a + b) = circleMap a * circleMap b",
+      "circleHom : Multiplicative ℝ →* ℂˣ — packaged as a Mathlib MonoidHom",
+      "norm_circleMap: image lies on the unit circle ‖circleMap t‖ = 1",
+      "continuous_circleMap: continuity (so circleHom is a topological group hom — the Lie group exponential)",
+      "circleMap_eq_one_iff: kernel description — circleMap t = 1 ↔ t ∈ 2π·ℤ (so S¹ ≅ ℝ/2πℤ)",
+      "circleMap_surjective_unit_circle: image = unit circle (via cos_arg/sin_arg + re_add_im)",
+      "circleMap_npow / circleMap_zpow: de Moivre's theorem as one-line corollary of homomorphism + Complex.exp_int_mul"
+    ],
+    "dateAdded": "2026-05-07",
+    "prerequisites": [
+      "Euler's formula exp(it) = cos t + i sin t (from EulerIdentityOQ01OQ01)",
+      "Complex exponential addition law and continuity",
+      "Mathlib's MonoidHom and Multiplicative ℝ machinery"
+    ],
+    "assumptions": "0 axioms, 0 sorries. Builds entirely on EulerIdentityOQ01OQ01.euler_formula and Mathlib analysis.",
+    "relatedProblems": [
+      "euler-identity",
+      "euler-identity-oq-01",
+      "euler-identity-oq-01-oq-01",
+      "demoivre"
+    ],
+    "theoremCount": 16,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The identification of $S^1 = \\{z \\in \\mathbb{C} : |z| = 1\\}$ as a Lie group via the exponential map $t \\mapsto e^{it}$ is the prototype of all Lie group exponentials. Sophus Lie's 1880s theory of continuous transformation groups was built around the observation that smooth one-parameter subgroups of a Lie group $G$ correspond to elements of its Lie algebra $\\mathfrak{g}$ via the exponential. For $G = S^1$, the Lie algebra is the imaginary axis $i\\mathbb{R} \\subseteq \\mathbb{C}$, and the exponential map $\\exp : i\\mathbb{R} \\to S^1$, $it \\mapsto e^{it}$, sends additive translation in $\\mathbb{R}$ to multiplicative rotation on the circle.\n\nThis identification has three foundational consequences. First, the kernel description $\\ker(t \\mapsto e^{it}) = 2\\pi\\mathbb{Z}$ exhibits $S^1$ as the topological-group quotient $\\mathbb{R}/2\\pi\\mathbb{Z}$, the simplest non-trivial example of a compact connected Lie group. Second, the homomorphism property $e^{i(s+t)} = e^{is} e^{it}$ generalizes to de Moivre's theorem $(e^{i\\theta})^n = e^{in\\theta}$, which appeared (without a proof using complex exponentials) in de Moivre's 1722 work and was unified with Euler's formula by Euler himself in 1748. Third, the Pontryagin dual $\\widehat{S^1} \\cong \\mathbb{Z}$ via the characters $\\chi_n(\\theta) = e^{in\\theta}$ is the foundation of Fourier analysis on the circle.\n\nThe parent file (EulerIdentityOQ01OQ01) closed all three axioms used in the original Taylor-series proof, yielding an axiom-free formalization of $e^{ix} = \\cos x + i \\sin x$. This file leverages that result to formalize what was historically the next step: showing the map $t \\mapsto e^{it}$ is the Lie group exponential, with all the structural properties (homomorphism, continuity, kernel, surjectivity) explicit.",
+    "problemStatement": "Given Euler's formula $e^{it} = \\cos t + i \\sin t$ (proved axiom-free in OQ-01-OQ-01), show that $\\text{circleMap} : \\mathbb{R} \\to \\mathbb{C}$, $t \\mapsto e^{it}$, is:\n\n1. A group homomorphism: $\\text{circleMap}(a + b) = \\text{circleMap}(a) \\cdot \\text{circleMap}(b)$\n2. Continuous as a function $\\mathbb{R} \\to \\mathbb{C}$\n3. Image lies on the unit circle: $\\|\\text{circleMap}(t)\\| = 1$\n4. Kernel description: $\\text{circleMap}(t) = 1 \\iff t \\in 2\\pi\\mathbb{Z}$\n5. Surjective onto the unit circle\n\nPackage as a Mathlib `MonoidHom (Multiplicative ℝ) ℂˣ`, the formal Lie-group statement.",
+    "text": "Defines circleMap : ℝ → ℂ as t ↦ exp(it) and proves the package of properties that makes it the Lie group exponential ℝ → S¹: homomorphism, continuity, image on the unit circle, kernel exactly 2πℤ, surjectivity. De Moivre's theorem follows as a one-line corollary using Complex.exp_int_mul.",
+    "proofStrategy": "1. circleMap_add: directly from Complex.exp_add, since circleMap (a+b) = exp((a+b)*I) = exp(a*I) * exp(b*I) = circleMap a * circleMap b. 2. norm_circleMap: from Complex.norm_exp_ofReal_mul_I directly. 3. circleMap_neg: from Complex.exp_neg, after rewriting (-t)*I = -(t*I). 4. circleHom : Multiplicative ℝ →* ℂˣ: package using Units.mk0 (since circleMap t ≠ 0 by norm = 1). 5. continuous_circleMap: composition of Complex.continuous_exp with continuous (·*I). 6. circleMap_eq_one_iff: via Complex.exp_eq_one_iff applied to t*I = n*2πI, then cancel I and unwrap reals. 7. circleMap_surjective_unit_circle: take t = arg z, use Complex.cos_arg/sin_arg with ‖z‖ = 1 to show cos(arg z) = z.re, sin(arg z) = z.im, then Complex.re_add_im gives z. 8. circleMap_npow: induction on n, using pow_succ and circleMap_add. 9. circleMap_zpow: clean proof via Complex.exp_int_mul + ring.",
+    "keyInsights": [
+      "The homomorphism $\\mathbb{R} \\xrightarrow{t \\mapsto e^{it}} S^1$ is the prototype of all Lie group exponentials: a smooth (in fact, analytic) homomorphism from a Lie algebra (here $\\mathbb{R}$, the tangent space at $1 \\in S^1$ scaled by $i$) to its Lie group ($S^1$). The kernel $2\\pi\\mathbb{Z}$ measures the topological non-triviality of $S^1$ (its fundamental group $\\pi_1(S^1) \\cong \\mathbb{Z}$).",
+      "In Mathlib, the natural way to state 'additive group $\\to$ multiplicative group homomorphism' is `Multiplicative ℝ →* G`, where `Multiplicative ℝ` is the type-level wrapper carrying the multiplicative structure on the additive group $\\mathbb{R}$. This file uses this idiom, packaging circleMap as `circleHom : Multiplicative ℝ →* ℂˣ`.",
+      "The kernel proof uses `Complex.exp_eq_one_iff`: $e^z = 1 \\iff \\exists n : \\mathbb{Z}, z = n \\cdot 2\\pi i$. Specializing to $z = t \\cdot i$ for real $t$, the equation $t \\cdot i = n \\cdot 2\\pi \\cdot i$ cancels $i$ to give $t = 2\\pi n$.",
+      "Surjectivity uses the polar decomposition of $\\mathbb{C}$: every $z \\in \\mathbb{C}$ satisfies $z = \\|z\\| (\\cos(\\arg z) + i \\sin(\\arg z))$. When $\\|z\\| = 1$, this collapses to $z = \\cos(\\arg z) + i \\sin(\\arg z) = e^{i \\arg z}$, witnessing $\\arg z$ as the preimage.",
+      "De Moivre's theorem $(e^{i\\theta})^n = e^{in\\theta}$ becomes a one-line consequence of `Complex.exp_int_mul`, which factors through the algebraic identity $e^z \\cdot e^z \\cdot \\ldots = e^{z + z + \\ldots}$. This is the cleanest formalization of de Moivre, completely bypassing the trigonometric identities used in the classical proof."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-circle-map",
+      "title": "§1. The Underlying Map t ↦ exp(it)",
+      "startLine": 58,
+      "endLine": 88,
+      "summary": "Defines circleMap and proves the basic algebraic identities: zero, addition (homomorphism), negation, subtraction, and the connection to Euler's formula from EulerIdentityOQ01OQ01.",
+      "concepts": ["complex exponential", "homomorphism", "Euler's formula"]
+    },
+    {
+      "id": "sec-unit-circle",
+      "title": "§2. Image Lies on the Unit Circle",
+      "startLine": 90,
+      "endLine": 102,
+      "summary": "Proves ‖circleMap t‖ = 1 using Complex.norm_exp_ofReal_mul_I, and circleMap t ≠ 0 as a corollary.",
+      "concepts": ["unit circle", "norm", "non-vanishing"]
+    },
+    {
+      "id": "sec-monoid-hom",
+      "title": "§3. Group Homomorphism Structure",
+      "startLine": 104,
+      "endLine": 134,
+      "summary": "Packages circleMap as circleHom : Multiplicative ℝ →* ℂˣ — the formal Lie-group statement that t ↦ exp(it) is a group homomorphism (ℝ,+) → (ℂˣ,·).",
+      "concepts": ["MonoidHom", "Multiplicative", "Lie group homomorphism"]
+    },
+    {
+      "id": "sec-continuity",
+      "title": "§4. Continuity (Topological Group Homomorphism)",
+      "startLine": 136,
+      "endLine": 148,
+      "summary": "Proves continuous_circleMap from continuity of exp composed with continuity of t ↦ ↑t * I.",
+      "concepts": ["continuity", "topological group", "Lie group"]
+    },
+    {
+      "id": "sec-kernel",
+      "title": "§5. Kernel: 2π·ℤ",
+      "startLine": 150,
+      "endLine": 175,
+      "summary": "Proves circleMap_eq_one_iff: the kernel of the homomorphism is exactly 2π·ℤ. Uses Complex.exp_eq_one_iff and cancels the imaginary unit.",
+      "concepts": ["kernel", "quotient group", "ℝ/2πℤ"]
+    },
+    {
+      "id": "sec-surjectivity",
+      "title": "§6. Surjectivity onto the Unit Circle",
+      "startLine": 177,
+      "endLine": 195,
+      "summary": "Proves circleMap_surjective_unit_circle: every z with ‖z‖ = 1 has the form exp(i · arg z). Uses Complex.cos_arg and Complex.sin_arg with the fact ‖z‖ = 1.",
+      "concepts": ["surjectivity", "polar decomposition", "argument"]
+    },
+    {
+      "id": "sec-demoivre",
+      "title": "§7. De Moivre's Theorem as a Corollary",
+      "startLine": 197,
+      "endLine": 220,
+      "summary": "Proves circleMap_npow and circleMap_zpow: (circleMap t)^n = circleMap (n·t) for n : ℕ and ℤ. The integer version drops out from Complex.exp_int_mul in 4 lines.",
+      "concepts": ["de Moivre", "homomorphism corollary"]
+    },
+    {
+      "id": "sec-summary",
+      "title": "§8. Summary",
+      "startLine": 222,
+      "endLine": 241,
+      "summary": "Bundles the main result and lists the proven properties as the rigorous form of 'Euler's formula identifies S¹ as a 1-parameter Lie group with Lie algebra iℝ.'",
+      "concepts": ["summary", "Lie algebra", "1-parameter subgroup"]
+    }
+  ],
+  "conclusion": {
+    "summary": "Euler's formula $e^{it} = \\cos t + i \\sin t$, combined with the exponential addition law, yields the Lie group exponential map $\\mathbb{R} \\to S^1$. This file proves the full structural package: homomorphism, continuity, image on $S^1$, kernel $= 2\\pi\\mathbb{Z}$, surjectivity. De Moivre's theorem becomes a one-line consequence.",
+    "implications": "Closes the open question posed in EulerIdentityOQ01OQ01: yes, the proof extends to identify $t \\mapsto e^{it}$ as a Lie group homomorphism. The kernel description exhibits $S^1 \\cong \\mathbb{R}/2\\pi\\mathbb{Z}$ as topological groups, which is the foundation of Fourier analysis on the circle.",
+    "openQuestions": [
+      "Can the homomorphism property be packaged as a smooth (i.e., $C^\\infty$) Lie group exponential map in Mathlib's `LieGroup` framework, with the imaginary axis $i\\mathbb{R}$ identified as the Lie algebra?",
+      "Does this construction lift to a similar homomorphism description for the Lie group exponential on $SU(2)$ or other compact Lie groups, where Mathlib's representation theory is still developing?"
+    ]
+  },
+  "references": {
+    "papers": [
+      {
+        "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
+        "authors": ["Leonhard Euler"],
+        "year": 1748,
+        "description": "Original derivation of e^(ix) = cos x + i sin x via Taylor series."
+      },
+      {
+        "title": "Theorie der Transformationsgruppen",
+        "authors": ["Sophus Lie", "Friedrich Engel"],
+        "year": 1888,
+        "description": "Foundational text on continuous transformation groups; introduces exponential map for Lie groups."
+      }
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.SpecialFunctions.Complex.Circle",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Log",
+      "Mathlib.Topology.Algebra.Group.Basic"
+    ]
+  },
+  "crossReferences": [
+    {
+      "type": "extends",
+      "id": "euler-identity-oq-01-oq-01",
+      "description": "Builds directly on EulerIdentityOQ01OQ01.euler_formula (axiom-free Taylor proof of exp(ix) = cos x + i sin x) to derive the homomorphism."
+    },
+    {
+      "type": "related",
+      "id": "demoivre",
+      "description": "De Moivre's theorem (circleMap_npow / circleMap_zpow) is a one-line corollary of the homomorphism property + Complex.exp_int_mul."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/EulerIdentityOQ01OQ01OQ01.lean",
+    "filename": "EulerIdentityOQ01OQ01OQ01.lean",
+    "lineCount": 241,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "sorries": 0,
+    "axiomCount": 0,
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Complex.Circle",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Series",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Log",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Topology.Algebra.Group.Basic",
+      "Mathlib.Topology.ContinuousMap.Basic",
+      "Mathlib.Tactic",
+      "Proofs.EulerIdentityOQ01OQ01"
+    ]
+  },
+  "mainTheorems": [
+    "circleMap_add",
+    "norm_circleMap",
+    "circleHom",
+    "continuous_circleMap",
+    "circleMap_eq_one_iff",
+    "circleMap_surjective_unit_circle",
+    "circleMap_npow",
+    "circleMap_zpow"
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/euler-identity-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-identity-oq-01-oq-01-oq-01.json
@@ -1,0 +1,125 @@
+{
+  "slug": "euler-identity-oq-01-oq-01-oq-01",
+  "title": "Can the proof be extended to prove the Lie group exponential map ℝ → S¹ is a ...",
+  "phase": "COMPLETE",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Prove } \\mathbb{R} \\to S^1, \\ t \\mapsto e^{it} \\text{ is a continuous group homomorphism with kernel } 2\\pi\\mathbb{Z}.",
+    "plain": "Extend the axiom-free Taylor-series proof of Euler's identity to show that t ↦ exp(it) is a Lie group homomorphism from (ℝ,+) to the unit circle (S¹,·) — including continuity, kernel = 2π·ℤ, and surjectivity.",
+    "whyMatters": [
+      "Identifies S¹ ≅ ℝ/2πℤ as a topological group — foundation of Fourier analysis on the circle",
+      "Establishes the prototype Lie group exponential map from a Lie algebra (iℝ) to its compact Lie group (S¹)",
+      "Yields de Moivre's theorem (e^{iθ})^n = e^{inθ} as a one-line consequence"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "circleMap_add: (a+b) ↦ exp(i(a+b)) = exp(ia) * exp(ib) — homomorphism law",
+      "norm_circleMap: ‖exp(it)‖ = 1 — image on unit circle",
+      "continuous_circleMap: continuity of t ↦ exp(it)",
+      "circleMap_eq_one_iff: kernel = {2πn : n ∈ ℤ}",
+      "circleMap_surjective_unit_circle: image = S¹",
+      "circleMap_npow / circleMap_zpow: de Moivre as corollary"
+    ],
+    "open": [],
+    "goal": "Continuous Lie group homomorphism ℝ → S¹"
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-05-07T22:30:00Z",
+    "iteration": 1,
+    "focus": "Closed: 0 sorries, 0 axioms, Docker-verified.",
+    "blockers": [],
+    "nextAction": "Open question now answered.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE — Docker-verified 0 sorries / 0 axioms in EulerIdentityOQ01OQ01OQ01.lean (241 lines, 16 theorems, 2 defs). Proves circleMap : ℝ → ℂ, t ↦ exp(it), is a continuous group homomorphism (ℝ,+) → (ℂˣ,·) packaged as a Mathlib MonoidHom from Multiplicative ℝ to ℂˣ; image lies on unit circle; kernel = 2π·ℤ; surjective onto S¹; de Moivre's theorem as one-line corollary via Complex.exp_int_mul. Builds directly on EulerIdentityOQ01OQ01.euler_formula.",
+    "builtItems": [
+      "EulerIdentityOQ01OQ01OQ01.lean:241 lines, 16 theorems, 2 defs, 0 sorries, 0 axioms",
+      "circleMap : ℝ → ℂ, t ↦ exp(it)",
+      "circleHom : Multiplicative ℝ →* ℂˣ (packaged as MonoidHom)",
+      "Gallery entry src/data/proofs/euler-identity-oq-01-oq-01-oq-01/ with meta.json + index.ts"
+    ],
+    "insights": [
+      "Complex.exp_eq_one_iff cleanly gives kernel description: cancel I from t·I = n·2π·I to get t = 2π·n.",
+      "Surjectivity uses polar decomposition: for ‖z‖=1, cos(arg z) = z.re and sin(arg z) = z.im; then re_add_im closes the proof.",
+      "De Moivre's theorem (zpow case) drops out from Complex.exp_int_mul + ring in 4 lines — bypasses all classical trigonometric identity manipulations.",
+      "Multiplicative ℝ →* ℂˣ is the idiomatic Mathlib formulation of '(ℝ,+) → (G,·) homomorphism', avoiding the bundled Lie-group framework."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Smooth (C∞) Lie group exp formulation in Mathlib's LieGroup framework",
+      "Lift to compact Lie groups with non-trivial Lie algebra (e.g., SU(2))"
+    ]
+  },
+  "tags": [
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "euler-identity",
+    "euler-identity-oq-01",
+    "euler-identity-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-05-06T21:20:28.056Z",
+  "lastUpdate": "2026-05-06T21:20:28.056Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerIdentity.lean",
+      "filename": "EulerIdentity.lean",
+      "lineCount": 342,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentity.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01.lean",
+      "filename": "EulerIdentityOQ01.lean",
+      "lineCount": 211,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01OQ01.lean",
+      "filename": "EulerIdentityOQ01OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01OQ01OQ01.lean",
+      "filename": "EulerIdentityOQ01OQ01OQ01.lean",
+      "lineCount": 241,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the OQ-01-OQ-01 open question:

> Can the proof be extended to prove the Lie group exponential map ℝ → S¹ is a homomorphism, viewing Euler's formula as the statement that exp(i·) is a group homomorphism from (ℝ,+) to (S¹,×)?

**Answer: yes, axiom-free.** Adds `proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean` (241 lines, 16 theorems, 2 definitions, **0 sorries, 0 axioms**, Docker-verified).

## Main Results

Building on `EulerIdentityOQ01OQ01.euler_formula`:

- **`circleMap : ℝ → ℂ`** defined as `t ↦ exp(it)`
- **`circleMap_add`**: `circleMap (a + b) = circleMap a · circleMap b` — the homomorphism law
- **`circleHom : Multiplicative ℝ →* ℂˣ`** — packaged as a Mathlib `MonoidHom`
- **`norm_circleMap`**: `‖circleMap t‖ = 1` (image lies on unit circle)
- **`continuous_circleMap`**: Continuity (so `circleHom` is a topological group hom — the Lie group exponential)
- **`circleMap_eq_one_iff`**: kernel description — `circleMap t = 1 ↔ ∃ n : ℤ, t = 2π·n` (so S¹ ≅ ℝ/2πℤ)
- **`circleMap_surjective_unit_circle`**: image is exactly the unit circle (via `Complex.cos_arg`/`sin_arg` + `re_add_im`)
- **`circleMap_npow` / `circleMap_zpow`**: de Moivre's theorem as a one-line corollary using `Complex.exp_int_mul`

## Files

- `proofs/Proofs/EulerIdentityOQ01OQ01OQ01.lean` — main proof file (241 L, 0 sorries, 0 axioms)
- `src/data/proofs/euler-identity-oq-01-oq-01-oq-01/{meta.json, index.ts}` — gallery entry
- `src/data/research/problems/euler-identity-oq-01-oq-01-oq-01.json` — research record (status: COMPLETE)

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.EulerIdentityOQ01OQ01OQ01` succeeds
- [x] 0 sorries, 0 axioms in the file
- [ ] Gallery `pnpm build` (post-merge via deployer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)