### PR TITLE
audit(four-square-distribution-oq-01): mark issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13813,6 +13813,13 @@
       "result": "clean",
       "issues": []
     },
+    "four-square-distribution-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T22:30:00Z",
+      "result": "issues-found",
+      "issues": ["meta.theoremCount=33 vs actual 51", "meta.lineCount=210 vs actual 209"],
+      "notes": "stale theoremCount and lineCount in legacy meta sub-object; lf block absent so find-targets misses. See issue #16708."
+    },
     "inverse-galois-d4": {
       "auditCount": 1,
       "lastAudited": "2026-05-03T04:51:00Z",


### PR DESCRIPTION
## Summary

Records first audit of `four-square-distribution-oq-01` as `issues-found` with two count drifts in `meta.json`. See issue #16708 for the structural fix recommendation.

## Drifts

| Field | meta.json claims | actual | source |
|---|---|---|---|
| `meta.theoremCount` | 33 | 51 | manual count of `theorem` declarations |
| `meta.lineCount` | 210 | 209 | `wc -l` |

51 theorems = 10 `sigmaStar_*` + 10 `jacobiR4_*` + 10 `r4Count_*` + 10 `jacobi_holds_*` + 9 `distribution_matches_jacobi_*` + `r4Count_zero` + `sigmaStar_zero`.

`axiomCount=1`, `definitionCount=4`, `sorries=0` are all correct.

## Why find-targets missed it

The `leanFile` block in `meta.json` is absent (lf.theoremCount/lineCount null), so `scripts/auditor/find-targets.ts` cannot diff Lean-file structural counts. Counts only live in the legacy `meta` sub-object and are not compared against the file. Same blind spot documented in `feedback_auditor_find_targets_misses_theoremcount.md`.

## Plumbing

Surgical 7-line insert via `hash-object` + isolated `GIT_INDEX_FILE` + `commit-tree` + `update-ref`/`push`, to keep the diff clean and avoid contention with concurrent agents touching the same tracker.

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` validates
- [x] `git diff --stat` shows 7 insertions, 0 deletions
- [ ] Mechanic picks up issue #16708 and bumps the meta values

🤖 Generated with [Claude Code](https://claude.com/claude-code)