### PR TITLE
Enrich Jacobi r₄ (four-square-distribution-oq-01): 9 annotations + crossRef schema fix

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-01/annotations.json
@@ -1,1 +1,110 @@
-[]
+[
+  {
+    "id": "ann-fsq01-header",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 5, "endLine": 59 },
+    "type": "context",
+    "title": "Jacobi's Four-Square Formula as Lean Research Target",
+    "content": "Jacobi's 1834 theorem r₄(n) = 8·σ*(n) (where σ*(n) sums divisors of n that are not divisible by 4) is one of the earliest and most striking applications of modular forms to number theory. This file does *not* prove the formula; instead it sets it up as a precise Lean 4 research target by (i) defining both sides r4Count(n) and 8·σ*(n) computably, (ii) proving they agree for n = 1..10 by `native_decide`, (iii) bridging to the parent FourSquareDistribution's type-decomposition theorems, and (iv) axiomatizing the general statement. The axiom marks exactly which Mathlib infrastructure is missing — q-expansions of `jacobiTheta` and the identification of θ⁴ with weight-2 Eisenstein series on Γ₀(4).",
+    "mathContext": "**Jacobi (1834)**: $r_4(n) = 8 \\sum_{\\substack{d \\mid n \\\\ 4 \\nmid d}} d$ for all $n \\ge 1$.\n\n**r₄(n)** is the integer-tuple count $\\#\\{(a,b,c,d)\\in\\mathbb{Z}^4 : a^2+b^2+c^2+d^2 = n\\}$.\n\n**Classical proof**: $\\theta(q) = \\sum_{k\\in\\mathbb{Z}} q^{k^2}$ has $\\theta(q)^4 = 1 + \\sum_{n\\ge 1} r_4(n) q^n$. Jacobi shows $\\theta^4$ is a weight-2 modular form on $\\Gamma_0(4)$ and matches its q-expansion to $1 + 8\\sum_{n\\ge 1} \\sigma^*(n) q^n$.",
+    "significance": "context",
+    "relatedConcepts": ["sums of squares", "Jacobi theta function", "modular forms", "Eisenstein series", "Γ₀(4)", "q-expansion", "Lagrange's four-square theorem"],
+    "prerequisites": ["sums of squares", "divisor functions", "Lean 4 native_decide"]
+  },
+  {
+    "id": "ann-fsq01-sigmastar",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 65, "endLine": 90 },
+    "type": "definition",
+    "title": "σ*(n): Divisors with 4∤d",
+    "content": "σ*(n) is the sum of divisors of n that are *not* divisible by 4. The function is implemented by folding `Nat.divisors n` with an `if 4 ∣ d then 0 else d` indicator, keeping the entire computation decidable. The 10 small-case theorems (`sigmaStar_1` .. `sigmaStar_10`) are proved by `native_decide` and document the divisor-arithmetic pattern: for example σ*(4) = 1 + 2 = 3 (divisor 4 is dropped), σ*(8) = 1 + 2 = 3 (divisors 4 and 8 are dropped), σ*(6) = 1 + 2 + 3 + 6 = 12 (all four kept).",
+    "mathContext": "$$\\sigma^*(n) \\;=\\; \\sum_{\\substack{d \\,\\mid\\, n \\\\ 4 \\,\\nmid\\, d}} d.$$\n\n| n | divisors | drop 4∤d | σ*(n) |\n|---|---|---|---|\n| 4 | 1,2,4 | 4 | 3 |\n| 6 | 1,2,3,6 | — | 12 |\n| 8 | 1,2,4,8 | 4,8 | 3 |\n| 9 | 1,3,9 | — | 13 |\n| 10 | 1,2,5,10 | — | 18 |",
+    "significance": "key",
+    "relatedConcepts": ["divisor function σ(n)", "Mathlib Nat.divisors", "Finset.sum", "indicator (if-then-else) summand", "native_decide"],
+    "prerequisites": ["Nat.divisors API", "Finset big-operator sums"]
+  },
+  {
+    "id": "ann-fsq01-jacobiR4",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 89, "endLine": 102 },
+    "type": "definition",
+    "title": "Jacobi's Predicted r₄(n) = 8·σ*(n)",
+    "content": "`jacobiR4 n := 8 * sigmaStar n` packages Jacobi's prediction as a computable function. The factor 8 is the heart of the formula's content: it accounts for sign-and-permutation symmetries on a 4-tuple. Concretely, for a 'generic' tuple (a,b,c,d) all non-zero and distinct, the orbit under (sign flips on each coordinate) × (permutations) contributes a multiple of 2⁴·4!/|stabilizer| points; Jacobi's identity says all these orbit-size contributions, summed over n's representations, collapse to 8·σ*(n). The 10 small-n predictions (8, 24, 32, 24, 48, 96, 64, 24, 104, 144) match the classical r₄(n) sequence.",
+    "mathContext": "$$\\text{jacobiR4}(n) \\;=\\; 8 \\cdot \\sigma^*(n).$$\n\nClassical r₄ values: $r_4(1)=8,\\ r_4(2)=24,\\ r_4(3)=32,\\ r_4(4)=24,\\ r_4(5)=48,\\ r_4(6)=96,\\ r_4(7)=64,\\ r_4(8)=24,\\ r_4(9)=104,\\ r_4(10)=144$.",
+    "significance": "key",
+    "relatedConcepts": ["Jacobi's r₄ formula", "sign-permutation symmetry", "OEIS A000118 (r₄ sequence)", "orbit size"],
+    "prerequisites": ["σ*(n) definition", "small-case verification"]
+  },
+  {
+    "id": "ann-fsq01-shiftedrange",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 107, "endLine": 110 },
+    "type": "technique",
+    "title": "shiftedRange: Bounded Enumeration over [-n, n]",
+    "content": "Rather than enumerate over all of ℤ⁴ (impossible) or square-roots-of-n (would require integer square root), the file uses `[-n, n]` as the enumeration window. This is correct but not tight: any solution (a,b,c,d) of a²+b²+c²+d² = n must satisfy |a| ≤ √n ≤ n (since √n ≤ n for n ≥ 1). The shift trick maps List.range(2n+1) = [0,...,2n] into [-n,...,n] by `k ↦ k - n`. The over-counting in the bound (using n instead of ⌊√n⌋) does not affect correctness — every false candidate is rejected by the if-test in r4Count.",
+    "mathContext": "$\\text{shiftedRange}(n) = [-n, -n+1, \\ldots, n-1, n]$, of length $2n+1$.\n\nCorrectness: $a^2 + b^2 + c^2 + d^2 = n \\Rightarrow a^2 \\le n \\Rightarrow |a| \\le \\sqrt{n} \\le n$ (since $\\sqrt{n} \\le n$ for $n \\ge 1$).",
+    "significance": "supporting",
+    "relatedConcepts": ["List.range", "integer square root bound", "decidable enumeration", "ℕ → ℤ coercion"],
+    "prerequisites": ["List.range, List.map", "ℕ-to-ℤ coercion in Lean"]
+  },
+  {
+    "id": "ann-fsq01-r4count",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 111, "endLine": 123 },
+    "type": "technique",
+    "title": "r4Count: Brute-Force ℤ⁴ Enumeration",
+    "content": "`r4Count n` is a 4-fold nested `List.foldl` over `shiftedRange n`, incrementing the accumulator by 1 whenever the current 4-tuple's sum-of-squares equals n. This explicit-fold form is preferred over `Finset.card { (a,b,c,d) | ... }` because it remains in the kernel-decidable fragment that `native_decide` can compile to native code. The total enumeration size is (2n+1)⁴ — for n = 10 that is 21⁴ = 194481 tuples, well within native_decide's compilation envelope. For n = 100 it would be 201⁴ ≈ 1.6×10⁹, beyond practical reach.",
+    "mathContext": "$$r_4(n) \\;=\\; \\#\\{(a,b,c,d) \\in \\mathbb{Z}^4 : a^2+b^2+c^2+d^2 = n\\}.$$\n\nImplementation enumerates over $[-n, n]^4$, total $(2n+1)^4$ candidates. For $n = 10$: $21^4 = 194{,}481$.",
+    "significance": "key",
+    "relatedConcepts": ["List.foldl", "native_decide", "decidable counting", "Finset vs List", "integer 4-tuple"],
+    "prerequisites": ["nested folds", "decidable equality on ℤ"]
+  },
+  {
+    "id": "ann-fsq01-verify",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 125, "endLine": 151 },
+    "type": "insight",
+    "title": "Numerical Verification: 10 Independent Confirmations",
+    "content": "Lines 129–138 prove `r4Count(n) = c_n` for the classical values c_n; lines 142–151 prove `r4Count(n) = jacobiR4(n)` directly. Both sets are discharged by `native_decide`, providing 20 mechanically-verified small-case confirmations of Jacobi's formula. This is the strongest numerical evidence one can encode in Lean 4 short of a full proof: each `native_decide` re-runs the definition through the kernel-trusted compiler. The verification covers all the edge cases — n = 4 and n = 8 (where 4∤d kicks in to drop divisors), n = 9 = 3² (a square), n = 6 = 2·3 (two-prime composite), n = 10 = 2·5 (two-prime, even).",
+    "mathContext": "Verified small-case table (provable by `native_decide`):\n\n| n | r₄(n) | σ*(n) | 8·σ*(n) | match |\n|---|---|---|---|---|\n| 1 | 8 | 1 | 8 | ✓ |\n| 2 | 24 | 3 | 24 | ✓ |\n| 3 | 32 | 4 | 32 | ✓ |\n| 4 | 24 | 3 | 24 | ✓ |\n| 5 | 48 | 6 | 48 | ✓ |\n| 6 | 96 | 12 | 96 | ✓ |\n| 7 | 64 | 8 | 64 | ✓ |\n| 8 | 24 | 3 | 24 | ✓ |\n| 9 | 104 | 13 | 104 | ✓ |\n| 10 | 144 | 18 | 144 | ✓ |",
+    "significance": "key",
+    "relatedConcepts": ["Lean native_decide", "kernel-trusted compilation", "small-case verification", "OEIS A000118"],
+    "prerequisites": ["native_decide tactic", "small-case mathematical confidence"]
+  },
+  {
+    "id": "ann-fsq01-distribution-bridge",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 153, "endLine": 184 },
+    "type": "insight",
+    "title": "Bridge: Type Decomposition Agrees with Jacobi",
+    "content": "Part 4 cross-checks Jacobi against the parent file's combinatorial decomposition of r₄(n) by 'type' — the distinct-by-equality multiset structure of the 4-tuple (a,b,c,d). For *single-type* n ∈ {1, 2, 3, 5, 6, 7}, only one type contributes and `type_n_a.contribution = 8·σ*(n)` is direct. For *multi-type* n ∈ {4, 9, 10}, two types contribute (e.g. n = 9 admits 9 = 3² (single non-zero square) AND 9 = 1+1+1+6 doesn't work, but 9 = 4+4+1+0 = 2²+2²+1²+0² does) and the sum agrees with Jacobi. This is a *third* independent computation of r₄(n), confirming the two definitions and Jacobi's formula agree pointwise for n ≤ 10.",
+    "mathContext": "Two-type decomposition example for $n = 4$: $4 = 2^2 + 0 + 0 + 0$ (type 4_a) and $4 = 1^2+1^2+1^2+1^2$ (type 4_b). Each type's contribution counts its full sign/permutation orbit; their sum equals $r_4(4) = 24 = 8\\sigma^*(4)$.",
+    "significance": "key",
+    "relatedConcepts": ["combinatorial type decomposition", "orbit counting", "FourSquareDistribution types", "cross-validation"],
+    "prerequisites": ["FourSquareDistribution.lean infrastructure", "type-contribution theorems"]
+  },
+  {
+    "id": "ann-fsq01-axiom",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 186, "endLine": 201 },
+    "type": "concept",
+    "title": "Axiom: Jacobi's General Theorem (Open Lean Target)",
+    "content": "The general statement `r4Count n = jacobiR4 n` for all n ≥ 1 is *not* proved here — it is axiomatized as `jacobi_r4_formula`. The general proof requires Mathlib infrastructure that does not yet exist: (i) a concrete q-expansion of `jacobiTheta` (currently defined as a complex function on the upper half-plane without an indexed Fourier coefficient API); (ii) the identification of θ(q)⁴ as a specific weight-2 modular form on Γ₀(4); (iii) the matching of its Fourier coefficients to 8·σ*(n) via the Eisenstein combination E₂(τ) − 4·E₂(4τ). The `Mathlib.NumberTheory.ModularForms.JacobiTheta.OneVariable` module provides the modular S and T transformations of jacobiTheta but does not currently extract Fourier coefficients.",
+    "mathContext": "**Open target**: $\\forall n \\ge 1,\\ r_4(n) = 8\\sigma^*(n)$.\n\n**Proof strategy via modular forms**:\n1. $\\theta(q) = \\sum_{k\\in\\mathbb{Z}} q^{k^2}$ where $q = e^{2\\pi i\\tau}$, $\\tau \\in \\mathbb{H}$.\n2. $\\theta^4$ is a weight-2 modular form on $\\Gamma_0(4)$ (modular invariance + cusp conditions).\n3. The space of such forms is finite-dimensional with explicit Eisenstein basis.\n4. Match $\\theta^4 = 1 + 8\\sum_n \\sigma^*(n) q^n$ to the basis combination $E_2(\\tau) - 4 E_2(4\\tau)$ (up to normalization).\n5. Read off Fourier coefficients of $E_2$ to recover $8\\sigma^*$.",
+    "significance": "key",
+    "relatedConcepts": ["modular form on Γ₀(4)", "weight-2 Eisenstein series E₂", "q-expansion / Fourier coefficients", "Mathlib JacobiTheta", "open Lean formalization target"],
+    "prerequisites": ["modular forms", "upper half-plane", "q-expansion of theta function"]
+  },
+  {
+    "id": "ann-fsq01-boundary",
+    "proofId": "four-square-distribution-oq-01",
+    "range": { "startLine": 203, "endLine": 208 },
+    "type": "context",
+    "title": "Boundary: n = 0 is a Special Case",
+    "content": "Both r4Count(0) and σ*(0) are defined and computed: r₄(0) = 1 (only the all-zero tuple sums to zero) and σ*(0) = 0 (Mathlib's `Nat.divisors 0 = ∅`). Note that 8·σ*(0) = 0 ≠ 1 = r₄(0), so Jacobi's formula does *not* hold at n = 0 — which is why the axiom is restricted to `0 < n`. This matches the modular-form convention: the constant Fourier coefficient of θ⁴ is 1 and is *not* counted by 8·σ*; the formula relates only n ≥ 1 coefficients.",
+    "mathContext": "$r_4(0) = 1$ (tuple $(0,0,0,0)$ only); $\\sigma^*(0) = 0$ (Mathlib convention: `divisors 0 = ∅`).\n\n$\\theta(q)^4 = \\underbrace{1}_{\\text{constant term}} + \\underbrace{8 \\sum_{n\\ge 1} \\sigma^*(n) q^n}_{\\text{non-constant}}$.\n\nThe constant term 1 is not in the form $8\\sigma^*$; the formula applies only to $n \\ge 1$.",
+    "significance": "context",
+    "relatedConcepts": ["empty divisor set", "constant Fourier coefficient", "boundary convention", "Mathlib Nat.divisors"],
+    "prerequisites": ["Nat.divisors of 0"]
+  }
+]

--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -103,14 +103,14 @@
   },
   "crossReferences": [
     {
-      "type": "extends",
-      "target": "four-square-distribution",
-      "label": "Parent gallery entry: type-decomposition r₄(n) = ∑ contribution(t)"
+      "targetId": "four-square-distribution",
+      "relationship": "extends",
+      "description": "Parent gallery entry: type-decomposition r₄(n) = ∑ contribution(t). The 'distribution_matches_jacobi_*' theorems in Part 4 cross-check Jacobi's formula against the parent's combinatorial type contributions for n = 1..7, 9, 10."
     },
     {
-      "type": "uses",
-      "target": "lagrange-four-squares",
-      "label": "Lagrange existence theorem (every n ≥ 0 is a sum of four squares)"
+      "targetId": "lagrange-four-squares",
+      "relationship": "uses",
+      "description": "Lagrange's four-square theorem (every n ≥ 0 is a sum of four integer squares). Lagrange gives existence; Jacobi's formula refines this by counting representations exactly. r₄(n) ≥ 1 for all n ≥ 0 from Lagrange, and Jacobi's r₄(n) = 8·σ*(n) > 0 confirms this for n ≥ 1."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `four-square-distribution-oq-01` (Jacobi's four-square formula r₄(n) = 8·σ*(n) as a Lean research target).

**annotations.json: `[]` → 9 deep entries**, covering each of the file's 5 parts plus the boundary case:

1. Header context — Jacobi's 1834 theorem and modular-form proof strategy
2. σ*(n) definition with a divisor-arithmetic table for small n
3. `jacobiR4 = 8·σ*(n)` — why 8 = 2³ matters (sign-permutation symmetry orbit)
4. `shiftedRange` — bounded enumeration over [-n, n], correctness justified
5. `r4Count` — 4-fold `List.foldl` for native_decide-friendly ℤ⁴ enumeration
6. Numerical verification — 20 native_decide checks across edge cases
7. Cross-validation bridge to FourSquareDistribution's type decomposition
8. Axiom — open Lean target with the missing-Mathlib roadmap
9. Boundary n = 0 — why the axiom requires `0 < n`

Each annotation has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Tables walk through divisor structure and the n = 1..10 verification.

**meta.json fix**: `crossReferences` used non-standard `type/target/label` keys that won't render in the gallery's CrossReference component; converted to canonical `targetId/relationship/description` schema and expanded relationship prose.

## Test plan
- [x] `pnpm build` passes (validates annotations.json + meta.json schema)
- [x] No other gallery entries modified
- [x] crossReferences now use schema fields the UI consumes (`targetId`, `relationship`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)