### PR TITLE
audit(kummer-theorem-oq-01-oq-01): mark clean — re-audit 2026-05-07

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12043,9 +12043,9 @@
       "result": "clean"
     },
     "kummer-theorem-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:26Z",
+      "lastAudited": "2026-05-07T22:50:00Z",
       "result": "clean"
     },
     "kummer-theorem-oq-02": {


### PR DESCRIPTION
## Audit Result

Re-audit of `kummer-theorem-oq-01-oq-01` confirms all counts and tier classification match the Lean source.

### Verification

| Field | Claimed | Actual |
|---|---|---|
| status | verified | — |
| badge | mathlib (Tier B) | — |
| top-level sorries | 0 | 0 |
| lf.sorries | 0 | 0 |
| lf.axiomCount | 0 | 0 |
| lf.theoremCount | 10 | 10 |
| lf.definitionCount | 0 | 0 |
| lf.lineCount | 201 | 201 |

`proofRepoPath: Proofs/KummerTheoremOQ01OQ01.lean`. Sibling import `KummerTheoremOQ01.lean` also clean (0 sorries, 0 axioms).

The badge `mathlib` is appropriate: the file derives v_p of multinomials by combining OQ-01's binomial decomposition with Mathlib's `Nat.factorization_choose'` (Kummer). No tier-overclaim.

### Result

`clean` — no drift. Tracker bumps `auditCount: 1 → 2`, `lastAudited` to 2026-05-07.