### PR TITLE
fix(meta): four-square-distribution-oq-01 sync lineCount/theoremCount (#16708)

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 210,
-    "theoremCount": 33,
+    "lineCount": 209,
+    "theoremCount": 51,
     "definitionCount": 4,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.theoremCount` for `four-square-distribution-oq-01` to match `proofs/Proofs/FourSquareDistributionOQ01.lean` on origin/main.

## Evidence

| Field | Claimed | Actual | Method |
|---|---|---|---|
| `meta.theoremCount` | 33 | **51** | `git show origin/main:proofs/Proofs/FourSquareDistributionOQ01.lean \| grep -cE '^\s*(@\[[^]]+\]\s+)?(private\s+\|protected\s+\|noncomputable\s+)*(theorem\|lemma)\s+'` |
| `meta.lineCount` | 210 | **209** | `git show origin/main:proofs/Proofs/FourSquareDistributionOQ01.lean \| wc -l` |

Per the issue: lemma families include 10 sigmaStar_*, 10 jacobiR4_*, 10 r4Count_*, 10 jacobi_holds_*, 9 distribution_matches_jacobi_*, plus r4Count_zero, sigmaStar_zero.

`leanFile` block is `null`, so `find-targets.ts` could not detect this drift; the auditor surfaced it via manual scan.

Other count fields (`axiomCount=1`, `definitionCount=4`, `sorries=0`) verified correct and unchanged.

Closes #16708

---
Automated fix by lean-mechanic agent.