### PR TITLE
fix(meta): hilbert-15-oq-02 axiomCount 3→0, status verified, badge original (#16699)

### DIFF
--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Hilbert15OQ02.lean",
     "tags": [
       "algebraic-geometry",
@@ -16,9 +16,9 @@
       "schubert-calculus",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "lineCount": 506,
     "assumptions": "Three complexity-theoretic theorems (lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete) prove `True` as explicit placeholders — the complexity theory formalism is not available in Lean/Mathlib. The 2-row LR coefficient computation (lrCoeff2) and full Gr(2,4) multiplication table are fully verified via native_decide.",
     "dateAdded": "2026-04-12",


### PR DESCRIPTION
## Fix

Apply auditor's recommended Option A: `meta.axiomCount` overclaimed 3 axioms in `hilbert-15-oq-02`, but `proofs/Proofs/Hilbert15OQ02.lean` declares **0 axioms** and 0 opaques.

## Evidence

```
$ git show origin/main:proofs/Proofs/Hilbert15OQ02.lean | grep -cE '^axiom |^opaque '
0
```

The three theorems flagged as "axioms" in the existing prose:

| Line | Theorem | Body |
|---|---|---|
| 326 | `lr_saturation_theorem` | `True := trivial` |
| 338 | `lr_positivity_in_P` | `True := ⟨fun _ _ _ => false, trivial⟩` |
| 355 | `lr_counting_sharp_P_complete` | `True := ⟨fun l => (l, l, l), trivial⟩` |

These are vacuous placeholders, not formal axioms — they prove `True`, which the kernel verifies with no hypotheses.

## Changes

| Field | Before | After | Rationale |
|---|---|---|---|
| `meta.axiomCount` | 3 | **0** | Matches `leanFile.axiomCount=0` (already correct) |
| `meta.status` | `axiomatized` | **`verified`** | Per CLAUDE.md: 0 sorries + 0 axioms + 0 structure-encoded assumptions = `verified` |
| `meta.badge` | `axiom` | **`original`** | Substantive verified content: lrCoeff2, Gr(2,4) multiplication table, multiplicity-free property |

The `assumptions` field is preserved verbatim — it accurately documents the True-placeholders so readers understand the complexity claims are conceptual, pending Mathlib complexity-theory infrastructure. Other counts (`lineCount=506`, `theoremCount=25`, `definitionCount=5`) verified correct against the Lean file and unchanged.

## Why find-targets did not catch this

`find-targets.ts` compares against `leanFile.axiomCount` (which was already `0`); the drift hides in the `meta.axiomCount` field. This is the documented "meta vs leanFile two-block axiom drift" pattern.

Closes #16699

---
Automated fix by lean-mechanic agent.