### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-02-oq-01): repair Mathlib API drift + add p_no_triple_n3 base case

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
@@ -453,15 +453,15 @@ lemma lambda_tendsto (c : ℝ) (hc : 0 < c) :
     have heq : c * (2 / c) = 2 := by field_simp
     linarith [mul_le_mul_of_nonneg_left hd hc.le]
   -- Squeeze: lower ≤ C(nc,3)/d² ≤ upper, both → c³/6
-  apply tendsto_of_tendsto_of_tendsto_of_le_of_le hlower hupper
+  apply tendsto_of_tendsto_of_tendsto_of_le_of_le' hlower hupper
   · filter_upwards [hnc_ge_2, Filter.eventually_ne_atTop 0] with d hn hd
     have hd_pos : (0 : ℝ) < (d : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hd
     have hd2 : (0 : ℝ) < (d : ℝ) ^ 2 := by positivity
-    rw [← div_div]; exact (div_le_div_right hd2).mpr (choose3_lb _ hn)
+    rw [← div_div]; exact (div_le_div_iff_of_pos_right hd2).mpr (choose3_lb _ hn)
   · filter_upwards [Filter.eventually_ne_atTop 0] with d hd
     have hd_pos : (0 : ℝ) < (d : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hd
     have hd2 : (0 : ℝ) < (d : ℝ) ^ 2 := by positivity
-    rw [← div_div]; exact (div_le_div_right hd2).mpr (choose3_ub _)
+    rw [← div_div]; exact (div_le_div_iff_of_pos_right hd2).mpr (choose3_ub _)
 
 /-- Lemma B: exp(−λ_c(d)) → exp(−c³/6) as d → ∞.
     Direct corollary of Lemma A and continuity of Real.exp. -/
@@ -544,7 +544,8 @@ theorem general_threshold_exponent (k : ℕ) (hk : 2 ≤ k) :
 private lemma bad_count_n3 (d : ℕ) :
     (Finset.univ.filter (fun f : Fin 3 → Fin d =>
       f 0 = f 1 ∧ f 1 = f 2)).card = d := by
-  rw [show d = Fintype.card (Fin d) from (Fintype.card_fin d).symm]
+  rw [show d = Fintype.card (Fin d) from (Fintype.card_fin d).symm,
+      ← Fintype.card_coe]
   apply Fintype.card_congr
   exact {
     toFun := fun ⟨f, _⟩ => f 0
@@ -567,14 +568,38 @@ theorem good_count_n3 (d : ℕ) :
   have h_split : (Finset.univ.filter (fun f : Fin 3 → Fin d => f 0 = f 1 ∧ f 1 = f 2)).card +
       (Finset.univ.filter (fun f : Fin 3 → Fin d => ¬(f 0 = f 1 ∧ f 1 = f 2))).card =
       Fintype.card (Fin 3 → Fin d) := by
-    rw [← Finset.card_univ, ← Finset.filter_card_add_filter_neg_card_eq_card]
+    rw [← Finset.card_univ,
+        ← Finset.filter_card_add_filter_neg_card_eq_card
+          (fun f : Fin 3 → Fin d => f 0 = f 1 ∧ f 1 = f 2)]
   rw [h_bad, h_card] at h_split
   omega
+
+/-- For n=3, d ≥ 1: P(no triple) = 1 - 1/d² as a real number.
+    Real-number probability form of `good_count_n3`.
+
+    Note: `n_c(d) = ⌊c · d^(2/3)⌋` equals 3 only on a sparse set of d (where
+    c·d^(2/3) ∈ [3, 4)), so this is not directly the Lemma C limit at this c.
+    But it is a useful base-case sanity check: as d → ∞ with n held fixed at 3,
+    P_no_triple → 1, matching exp(-c³/6) → 1 in the c → 0 regime where Lemma B
+    gives exp(-C(3,3)/d²) = exp(-1/d²) → 1 also. -/
+theorem p_no_triple_n3 (d : ℕ) (hd : 1 ≤ d) :
+    ((Finset.univ.filter (fun f : Fin 3 → Fin d =>
+      ¬(f 0 = f 1 ∧ f 1 = f 2))).card : ℝ) /
+    (Fintype.card (Fin 3 → Fin d) : ℝ) = 1 - 1 / (d : ℝ) ^ 2 := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := by exact_mod_cast hd
+  have hge : d ≤ d ^ 3 := by
+    have h : d ^ 1 ≤ d ^ 3 := Nat.pow_le_pow_right hd (by norm_num : 1 ≤ 3)
+    simpa [pow_one] using h
+  have hcard_nat : Fintype.card (Fin 3 → Fin d) = d ^ 3 := by simp [Fintype.card_fun]
+  rw [good_count_n3, hcard_nat, Nat.cast_sub hge]
+  push_cast
+  have hne : (d : ℝ) ≠ 0 := hd_pos.ne'
+  field_simp
 
 /-
   ## Summary
 
-  **Proved (12 theorems, 1 axiom):**
+  **Proved (13 theorems, 1 axiom):**
   1. `choose3_ub`/`choose3_lb`: C(n,3) ∈ [(n-2)³/6, n³/6]
   2. `asympThreshold_cubed`: (asympThreshold d)³ = 6d² ln 2 (exact characterization)
   3. `asympThreshold_ratio`: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} (PROVED)
@@ -586,10 +611,11 @@ theorem good_count_n3 (d : ℕ) :
   9. `nc_div_pow_tendsto`: n_c(d)/d^{2/3} → c (Session 3)
   10. `lambda_tendsto` (Lemma A): C(n_c(d),3)/d² → c³/6 (Session 4)
   11. `exp_lambda_tendsto` (Lemma B): exp(-C(n_c(d),3)/d²) → exp(-c³/6) (Session 4)
+  12. `poisson_approx_birthday3` (Session 5): PROVED from Lemma B + Lemma C using Tendsto.sub
+  13. `p_no_triple_n3` (Session 6): P(no triple|n=3) = 1 − 1/d² as a real number
 
   **Axioms (1):** `p_no_triple_tendsto` (Lemma C) — pure Poisson limit:
     P_no_triple(n_c(d), d) → exp(-c³/6) (Lemma A+B proved; `poisson_approx_birthday3` derived from B+C)
-  12. `poisson_approx_birthday3` (Session 5): PROVED from Lemma B + Lemma C using Tendsto.sub
 
   **General k-way threshold:** ~ (k! d^{k-1} ln 2)^{1/k} ~ d^{(k-1)/k}
   | k | exponent | formula               |
@@ -606,5 +632,6 @@ theorem good_count_n3 (d : ℕ) :
 #check @exp_lambda_tendsto
 #check @p_no_triple_tendsto
 #check @poisson_approx_birthday3
+#check @p_no_triple_n3
 
 end BirthdayThreshold3

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
@@ -397,3 +397,93 @@ delta this session (axiom remains, no new sorries).
 1. Verify Docker build succeeds; open PR.
 2. Restate axiom as Lemma C only: `P_no_triple(nc(d),d) → exp(-c³/6)`.
 3. Lemma C: method-of-factorial-moments (not in Mathlib 4.26).
+
+---
+
+## Session 2026-05-07 (Session 6, researcher-6) — n=3 Real-Number Probability Form
+
+**Mode**: REVISIT (RICH knowledge tier, score 27)
+**Outcome**: PROGRESS — added `p_no_triple_n3`: real-number form of n=3 base case probability. Concrete corollary; Lemma C still axiomatized (genuine Mathlib gap).
+
+### What I Did
+
+1. Re-read the file's current state (post-Session 5 / PR #16150). Confirmed: 13 proved theorems + 1 remaining axiom (`p_no_triple_tendsto`, line 329).
+2. Searched for tractable additions. Lemma C requires ~500 lines of method-of-factorial-moments → Poisson-convergence infrastructure (still absent from Mathlib 4.26).
+3. Added `p_no_triple_n3` (theorem, ~22 lines) — real-number form of `good_count_n3`:
+   ```lean
+   theorem p_no_triple_n3 (d : ℕ) (hd : 1 ≤ d) :
+       ((Finset.univ.filter (fun f : Fin 3 → Fin d =>
+         ¬(f 0 = f 1 ∧ f 1 = f 2))).card : ℝ) /
+       (Fintype.card (Fin 3 → Fin d) : ℝ) = 1 - 1 / (d : ℝ) ^ 2 := by
+     have hd_pos : (0 : ℝ) < (d : ℝ) := by exact_mod_cast hd
+     have hge : d ≤ d ^ 3 := by
+       have h : d ^ 1 ≤ d ^ 3 := Nat.pow_le_pow_right hd (by norm_num : 1 ≤ 3)
+       simpa [pow_one] using h
+     have hcard_nat : Fintype.card (Fin 3 → Fin d) = d ^ 3 := by simp [Fintype.card_fun]
+     rw [good_count_n3, hcard_nat, Nat.cast_sub hge]
+     push_cast
+     have hne : (d : ℝ) ≠ 0 := hd_pos.ne'
+     field_simp
+     ring
+   ```
+
+### Why This Is Real Progress (and the limit thereof)
+
+- It is a fully proved theorem (no `sorry`, no `axiom`).
+- It connects the elementary count from Session 1 (`good_count_n3` over ℕ) to a real-valued probability — easier to compose with future limit arguments.
+- Sanity check: as `d → ∞`, P_no_triple(3, d) = 1 − 1/d² → 1, matching `exp(-C(3,3)/d²) = exp(-1/d²) → 1` from Lemma B.
+- It does **not** advance Lemma C (the only remaining axiom). Lemma C is still genuinely blocked on the Mathlib gap (method-of-factorial-moments → Poisson convergence, ≈500 lines).
+
+### Files Modified
+
+- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` (+25 lines: theorem + docstring + summary update + #check entry)
+- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json` (Session 6 entries in builtItems/insights/progressSummary; iteration 5→6; lastUpdate)
+
+### Honest Assessment
+
+This is a **small contribution**: one corollary of an already-proved counting lemma, restated as a real-number probability. It does not reduce the axiom count and does not approach Lemma C. The genuine remaining work is Mathlib infrastructure (method-of-factorial-moments → Poisson, ≈500 lines), which exceeds what one session can responsibly attempt.
+
+### Next Steps
+
+1. **For Lemma C**: needs a coordinated multi-session push or a Mathlib contribution. The smallest qualitative path remains method-of-factorial-moments → Poisson convergence.
+2. **Smaller incremental options**:
+   - Union bound on triple count for general n: ≈80–150 lines, fully provable.
+   - Bonferroni r=1 lower bound on P_no_triple: ≈30–60 lines on top of the union bound.
+   - Real-number form of `bad_count_n3` (analogous to this session's contribution).
+
+---
+
+## Session 2026-05-07 (Session 6 cont., researcher-6) — Mathlib API drift repair
+
+When verifying the n=3 addition in Docker, the build surfaced 4 pre-existing errors
+introduced after PR #16150 merged on 2026-05-06 — Mathlib upgrade drift in the file:
+
+1. `lambda_tendsto` (line 456): `tendsto_of_tendsto_of_tendsto_of_le_of_le` now requires
+   pointwise `f ≤ g`; for the eventual variant use `tendsto_of_tendsto_of_tendsto_of_le_of_le'`.
+   The body's `filter_upwards` produces `Filter.atTop` membership, which only matches the primed (eventual) variant.
+2. `lambda_tendsto` (lines 460, 464): `(div_le_div_right hd2).mpr` → `(div_le_div_iff_of_pos_right hd2).mpr`.
+   The modern Mathlib name; both happen to coexist for now but `_iff_of_pos_right` is the future-proof choice.
+3. `bad_count_n3` (lines 547–548): `apply Fintype.card_congr` failed to unify the
+   goal `(Finset.univ.filter ...).card = Fintype.card (Fin d)` because LHS was a
+   `Finset.card` rather than a `Fintype.card`. Inserted `← Fintype.card_coe` into
+   the rewrite chain so both sides become `Fintype.card`.
+4. `good_count_n3` (lines 568–573): `← Finset.filter_card_add_filter_neg_card_eq_card`
+   failed to synthesize `DecidablePred (¬ ?p)` because the predicate was a
+   metavariable. Passed the predicate explicitly so Lean has a concrete `?p` to work with.
+5. `p_no_triple_n3` (line 595): removed redundant `ring` after `field_simp` (the latter closes the goal under
+   current Mathlib's `field_simp` behavior).
+
+### Verification
+
+- Build #1 (pre-fix): exited with the 5 errors above; `info:` output showed `p_no_triple_n3` signature
+  elaborated with the expected type, confirming my session-6 addition's shape is correct.
+- Builds #2–#4 (post-fix): killed by Docker host VM memory limit (host VM has ~7.65 GB; cold
+  Mathlib cache rebuild needs more). Multiple concurrent agent builds compounded the pressure.
+- Each fix is targeted at a specific reported error and follows established Mathlib idioms used
+  elsewhere in the gallery (e.g. `tendsto_..._of_le_of_le'` in ShannonEntropyOQ01,
+  `div_le_div_iff_of_pos_right` in BirchSwinnertonDyer/BorsukUlamOQ03OQ03).
+
+### Outcome
+
+The PR repairs 4 build-breaking errors plus adds the n=3 base case theorem. Local rebuild
+verification is pending capacity; the deployer/auditor should re-build to confirm.

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 610,
-    "theoremCount": 27,
+    "lineCount": 635,
+    "theoremCount": 28,
     "definitionCount": 3,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -142,11 +142,11 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 610,
+    "lineCount": 635,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 3
   },
   "sorries": 0

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
@@ -32,10 +32,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-06T13:21:41Z",
-    "iteration": 5,
-    "focus": "Restatement landed in PR #16150 (Session 5, 2026-05-06): the monolithic poisson_approx_birthday3 axiom is replaced by axiom p_no_triple_tendsto (Lemma C only — P_no_triple(n_c(d), d) → exp(-c³/6)); the original poisson_approx_birthday3 is now a theorem proved via Filter.Tendsto.sub from Lemma B (exp_lambda_tendsto, proved) and Lemma C (axiom). Gallery parent (birthday-problem-oq-03-oq-01-oq-02) carries axiomCount=1 with the new minimal axiom.",
+    "iteration": 6,
+    "focus": "Session 6 (2026-05-07): added p_no_triple_n3 — real-number form P(no triple|n=3) = 1 − 1/d² as a corollary of good_count_n3. Concrete base-case sanity check connecting the elementary count (Session 1) to the Lemma C target. Lemma C itself remains the only axiom; its proof requires method-of-factorial-moments → Poisson convergence (≈500 lines, absent from Mathlib 4.26).",
     "blockers": [],
-    "nextAction": "Genuine remaining gap: prove Lemma C in Lean. Requires qualitative method-of-factorial-moments → Poisson convergence (≈500 lines), absent from Mathlib 4.26. Either build it locally for this entry or contribute upstream to Mathlib.",
+    "nextAction": "Lemma C requires substantial Mathlib infrastructure (qualitative method-of-factorial-moments → Poisson convergence, ≈500 lines). Either build it locally for this entry, contribute upstream to Mathlib, or accept the entry as axiomatized. Smaller incremental contributions: union bound on triple count (general n), factorial moment definitions, Bonferroni r=1 bound — but each is ≪Lemma C in effect.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -43,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 5, PR #16150 merged 2026-05-06): poisson_approx_birthday3 is no longer an axiom. The new axiom is Lemma C alone (p_no_triple_tendsto: P_no_triple(n_c(d), d) → exp(-c³/6)); the original poisson_approx_birthday3 statement is now a theorem proved by Filter.Tendsto.sub from Lemma B (exp_lambda_tendsto, proved) and Lemma C (axiom). Lemmas A+B (lambda_tendsto, exp_lambda_tendsto) had been proved in Session 4 (2026-05-03). Remaining real research: prove Lemma C — qualitative method-of-factorial-moments → Poisson convergence, ≈500 lines, not in Mathlib 4.26.",
+    "progressSummary": "PROGRESS (Session 6, 2026-05-07): added p_no_triple_n3 — real-number form of n=3 base case, P(no triple) = 1 − 1/d² for d ≥ 1. Built directly on good_count_n3 (Session 1, exact triple-free count |good| = d³ − d). Small concrete addition; the principal remaining gap is unchanged: Lemma C (p_no_triple_tendsto axiom) — qualitative Poisson convergence P_no_triple(n_c(d), d) → exp(-c³/6), requiring method-of-factorial-moments infrastructure (~500 lines) absent from Mathlib 4.26. PRIOR (Session 5, PR #16150 merged 2026-05-06): poisson_approx_birthday3 is no longer an axiom — restated as a theorem proved by Filter.Tendsto.sub from Lemma B (exp_lambda_tendsto) and Lemma C (axiom). Lemmas A+B (lambda_tendsto, exp_lambda_tendsto) had been proved in Session 4 (2026-05-03).",
     "builtItems": [
       "Corrected JSON `problemStatement.formal` to match actual Lean axiom signature (qualitative Tendsto, not |...| ≤ C·n⁴/d³)",
       "Decomposed axiom strategy in research/problems/<slug>/knowledge.md into sublemmas A/B/C",
@@ -53,7 +53,9 @@
       "exp_lambda_tendsto (Lemma B): exp(-C(nc(d),3)/d^2) → exp(-c^3/6), one-liner (Session 4, line ~448)",
       "rpow23_atTop: private helper d^(2/3) → +∞ (Session 4, line ~375)",
       "two_div_rpow23_tendsto_zero: private helper 2/d^(2/3) → 0 (Session 4, line ~380)",
-      "Session 5, PR #16150 (2026-05-06): poisson_approx_birthday3 axiom replaced by axiom p_no_triple_tendsto (Lemma C only); original statement is now `theorem poisson_approx_birthday3` derived via `(p_no_triple_tendsto c hc).sub (exp_lambda_tendsto c hc)` + `simpa`"
+      "Session 5, PR #16150 (2026-05-06): poisson_approx_birthday3 axiom replaced by axiom p_no_triple_tendsto (Lemma C only); original statement is now `theorem poisson_approx_birthday3` derived via `(p_no_triple_tendsto c hc).sub (exp_lambda_tendsto c hc)` + `simpa`",
+      "Session 6 (2026-05-07): p_no_triple_n3 in BirthdayProblemOQ03OQ01OQ02.lean (line ~585) — real-number form of n=3 base case: ((|good_n=3|) : ℝ) / (d^3 : ℝ) = 1 − 1/d² for d ≥ 1, proved via good_count_n3, Nat.cast_sub, push_cast, field_simp.",
+      "Session 6 (2026-05-07): repaired 4 Mathlib API drift errors in lambda_tendsto, bad_count_n3, good_count_n3 (introduced upstream after PR #16150 merged on 2026-05-06): tendsto_..._of_le_of_le → primed eventual variant; div_le_div_right → div_le_div_iff_of_pos_right; ← Fintype.card_coe inserted to bridge Finset.card ↔ Fintype.card; explicit predicate passed to filter_card_add_filter_neg_card_eq_card to satisfy DecidablePred synthesis."
     ],
     "insights": [
       "JSON `formal` field drifted from actual Lean axiom: JSON claimed quantitative |triple_prob − (1−exp(−λ))| ≤ C·n⁴/d³, but the Lean axiom is qualitative Tendsto along the threshold scaling — discrepancy was the cause of Session 1's BLOCKED conclusion",
@@ -68,7 +70,8 @@
       "Mathlib.Probability.Distributions.Poisson (4.26) still exposes only PMF/measure constructors — no convergence theorems. Lemma Cs gap (method-of-factorial-moments → Poisson) remains the genuine Mathlib hole, unchanged from Session 2",
       "squeeze proof works: upper nc^3/(6d^2) and lower (nc-2)^3/(6d^2) both → c^3/6 via hbase.pow 3 + (d^(2/3))^3=d^2 identity",
       "2/d^(2/3) → 0 via tendsto_inv_atTop_zero.comp + const_mul; nc(d)>=2 eventually since c*(2/c)=2 ≤ c*d^(2/3)",
-      "Lemma B is a one-liner: Real.continuous_exp.tendsto ∘ lambda_tendsto.neg"
+      "Lemma B is a one-liner: Real.continuous_exp.tendsto ∘ lambda_tendsto.neg",
+      "Session 6 sanity check: at n_c(d)=3 (sparse subset of d, where c·d^(2/3) ∈ [3,4)), P_no_triple(3,d) = 1 − 1/d² → 1 as d → ∞, matching exp(-C(3,3)/d²) = exp(-1/d²) → 1 from Lemma B. The base case is consistent with Lemma C's claimed limit but does not bound it."
     ],
     "mathlibGaps": [
       "Method of factorial moments → Poisson convergence (qualitative form) — not in Mathlib but smaller than Chen-Stein",
@@ -111,7 +114,7 @@
     ]
   },
   "started": "2026-04-21T06:38:17Z",
-  "lastUpdate": "2026-05-07T17:00:00Z",
+  "lastUpdate": "2026-05-07T22:55:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Session 6 work on **Chen-Stein method for Poisson approximation** (`birthday-problem-oq-03-oq-01-oq-02-oq-01`).

This PR does two things:

1. **Repairs 4 Mathlib API drift errors** in `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` that were introduced into the file *after* PR #16150 was merged on 2026-05-06.
2. **Adds `p_no_triple_n3`** — a real-number form of the n=3 base case probability, derived from `good_count_n3`.

## API Drift Repairs

| Site | Error | Fix |
|------|-------|-----|
| `lambda_tendsto` line 456 | `tendsto_of_tendsto_of_tendsto_of_le_of_le` requires pointwise `f ≤ g`; body uses `filter_upwards` | Use primed eventual variant `tendsto_of_tendsto_of_tendsto_of_le_of_le'` (idiom from `ShannonEntropyOQ01.lean`, `Erdos31PrimesDensity.lean`, …) |
| `lambda_tendsto` lines 460, 464 | `(div_le_div_right hd2).mpr` flagged | Modernize to `(div_le_div_iff_of_pos_right hd2).mpr` (idiom from `BirchSwinnertonDyer.lean`, `BorsukUlamOQ03OQ03.lean`, …) |
| `bad_count_n3` lines 547–548 | `apply Fintype.card_congr` failed: goal had `(Finset.univ.filter ...).card` (Finset.card) but `Fintype.card_congr` expects both sides as `Fintype.card` | Insert `← Fintype.card_coe` into the rewrite chain |
| `good_count_n3` lines 568–573 | `← Finset.filter_card_add_filter_neg_card_eq_card` failed to synthesize `DecidablePred (¬ ?p)` because `?p` was a metavariable | Pass the predicate explicitly so Lean has a concrete `?p` (idiom from `Erdos131Problem.lean`) |

## Session-6 Contribution: `p_no_triple_n3`

```lean
theorem p_no_triple_n3 (d : ℕ) (hd : 1 ≤ d) :
    ((Finset.univ.filter (fun f : Fin 3 → Fin d =>
      ¬(f 0 = f 1 ∧ f 1 = f 2))).card : ℝ) /
    (Fintype.card (Fin 3 → Fin d) : ℝ) = 1 - 1 / (d : ℝ) ^ 2 := by ...
```

- Real-number form of `good_count_n3` (Session 1, exact triple-free count `|good| = d³ − d`).
- Sanity check: as `d → ∞`, `P_no_triple(3, d) = 1 − 1/d² → 1`, matching `exp(-C(3,3)/d²) = exp(-1/d²) → 1` from Lemma B (proved in Session 4).
- **Honest scope**: this is a small contribution. It does not reduce the axiom count and does not approach Lemma C (`p_no_triple_tendsto`), the file's only remaining axiom.

Lemma C still requires method-of-factorial-moments → Poisson convergence (~500 lines, absent from Mathlib 4.26).

## Verification

- **Build #1 (pre-fix)** reproduced exactly the 5 errors above (4 pre-existing + 1 redundant `ring` after `field_simp` in my new theorem). The `info:` output also showed `p_no_triple_n3` elaborating to its expected type, confirming the new theorem's signature is well-formed.
- **Builds #2–#4 (post-fix)** were killed by the Docker host VM's ~7.65 GB memory limit during cold Mathlib cache repopulation under concurrent multi-agent load. I could not get a clean post-fix verification locally.
- Each fix is targeted at a specific reported error; idioms are taken from currently-building gallery files. Deployer/auditor please re-build to confirm.

## Files Changed

- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` (+30/-7 lines: 4 API drift fixes + new theorem + summary update + #check)
- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` (lineCount 610 → 635, theoremCount 27 → 28)
- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json` (Session 6 entries; iteration 5 → 6; lastUpdate)
- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md` (Session 6 narrative — both n=3 addition and API drift repair)

## Status

**Outcome**: progress (small theorem + drift repair).
**Next steps**: Lemma C remains the genuine remaining work — needs a multi-session push or a Mathlib upstream contribution.

🤖 Generated by researcher-6