### PR TITLE
research(schauder-oq03-oq01-incomplete-01): S2 document proof skeleton + Mathlib API plan

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -139,11 +139,42 @@ theorem kakutani_from_brouwer {n : ℕ}
     (hF_convex : ∀ x, Convex ℝ (F x))
     (hF_uhc : IsUpperHemicontinuous F) :
     ∃ x : ↥S, IsFixedPoint F x := by
-  -- Step 1: For each k ≥ 1, get an approximate selection and its fixed point
-  -- This is the core reduction: Kakutani → sequence of Brouwer applications
-  -- Step 2: Extract convergent subsequence
-  -- Step 3: Show limit is a fixed point
-  -- Full formal proof requires metric space calculations in the subtype
+  -- Planned reduction to `approx_fixedpoint_implies_fixedpoint` (defined in Part V):
+  --
+  -- Step A: For each ε > 0, obtain a continuous ε-approximate selection f_ε of F
+  --         using axiom `approx_selection_exists`.
+  -- Step B: Apply axiom `brouwer_fpt` to f_ε on the compact convex S to get
+  --         x_0 with f_ε(x_0) = x_0.
+  -- Step C: The approximate-selection property at x_0 yields y ∈ F(x_0) with
+  --         dist(f_ε(x_0), y) < ε. Since f_ε(x_0) = x_0, this gives dist(x_0, y) < ε.
+  -- Step D: Hand the family of ε-witnesses to `approx_fixedpoint_implies_fixedpoint`,
+  --         which uses sequential compactness + closedness + UHC of F to extract a
+  --         genuine fixed point.
+  --
+  -- The subtype `↥S` inherits a PseudoMetricSpace; `hS_compact` yields
+  -- `CompactSpace ↥S` so `Set.univ : Set ↥S` is compact in the subtype topology.
+  --
+  -- Wiring (requires moving `approx_fixedpoint_implies_fixedpoint` above this theorem
+  -- since Lean 4 forbids forward references within a single file):
+  --
+  --   have hUniv : IsCompact (Set.univ : Set ↥S) := by
+  --     haveI : CompactSpace ↥S := isCompact_iff_compactSpace.mp hS_compact
+  --     exact isCompact_univ
+  --   have hF_closed' : ∀ x ∈ (Set.univ : Set ↥S), IsClosed (F x) :=
+  --     fun x _ => hF_closed x
+  --   have happrox : ∀ ε > 0, ∃ x ∈ (Set.univ : Set ↥S),
+  --       ∃ y ∈ F x, dist x y < ε := by
+  --     intro ε hε
+  --     obtain ⟨f, hf_cont, hf_approx⟩ :=
+  --       approx_selection_exists S hS_ne hS_compact hS_convex F
+  --         hF_ne hF_convex hF_uhc ε hε
+  --     obtain ⟨x0, hx0⟩ := brouwer_fpt S hS_ne hS_compact hS_convex f hf_cont
+  --     obtain ⟨y, hy_F, hy_dist⟩ := hf_approx x0
+  --     exact ⟨x0, Set.mem_univ _, y, hy_F, by simpa [hx0] using hy_dist⟩
+  --   obtain ⟨x_star, _, hfp⟩ :=
+  --     approx_fixedpoint_implies_fixedpoint (Set.univ : Set ↥S) hUniv F
+  --       hF_closed' hF_uhc happrox
+  --   exact ⟨x_star, hfp⟩
   sorry
 
 /-
@@ -178,7 +209,39 @@ of Nash equilibrium existence in game theory.
     for all ε > 0 has a true fixed point (when the target is closed).
 
     This captures the limit argument: if we can get "almost" fixed points
-    for any precision, compactness gives a real one. -/
+    for any precision, compactness gives a real one.
+
+    **Proof outline**:
+    1. Build sequences `xₙ ∈ S`, `yₙ ∈ F(xₙ)` with `dist(xₙ, yₙ) < 1/(n+1)`
+       via choice on `happrox`.
+    2. Compactness of `S` yields a subsequence `x_{φ(n)} → x*` with `x* ∈ S`
+       (`IsCompact.tendsto_subseq` for first-countable / metric spaces —
+       automatic in a `PseudoMetricSpace`).
+    3. Since `dist(x_{φ(n)}, y_{φ(n)}) → 0` (by squeeze with `1/(φ n + 1) → 0`),
+       the subsequence `y_{φ(n)} → x*` as well.
+    4. Suppose `x* ∉ F(x*)`. Then `F(x*)` is closed (by `hF_closed x* hx_star_S`)
+       and either empty or `δ := infDist x* (F x*) > 0`.
+       - **Empty case**: take `V := ∅` (open and contains `F(x*)`); UHC gives an
+         open `U ∋ x*` with `F(U) ⊆ ∅`, hence eventually `F(x_{φ(n)}) = ∅`,
+         contradicting `y_{φ(n)} ∈ F(x_{φ(n)})`.
+       - **Nonempty case**: take `V := Metric.thickening (δ/2) (F x*)`, an open
+         superset of `F(x*)`. UHC gives an open `U ∋ x*` with `F(U) ⊆ V`.
+         Eventually `x_{φ(n)} ∈ U`, hence `y_{φ(n)} ∈ V`, so
+         `infDist y_{φ(n)} (F x*) < δ/2`. Triangle inequality:
+         `infDist x* (F x*) ≤ dist x* y_{φ(n)} + infDist y_{φ(n)} (F x*) < δ`
+         for `n` large, contradicting `δ = infDist x* (F x*)`.
+
+    **Mathlib API needed** (extra imports beyond current):
+    - `Mathlib.Topology.MetricSpace.HausdorffDistance` for `Metric.infDist`,
+      `Metric.infDist_le_dist_add_infDist`, `Metric.infDist_pos_iff_not_mem_closure`.
+    - `Mathlib.Topology.MetricSpace.Thickening` for `Metric.thickening` and
+      `Metric.isOpen_thickening`.
+    - `Mathlib.Topology.Sequences` for `IsCompact.tendsto_subseq` (often pulled
+      transitively, but explicit import is safer).
+
+    **Status**: Documented; proof body remains a single `sorry`. Steps 1–2 are
+    straightforward (`choose ... using fun n => happrox (1/(n+1)) ...` and
+    `hS.tendsto_subseq`). Step 4's nonempty case is the technical core. -/
 theorem approx_fixedpoint_implies_fixedpoint
     {X : Type*} [PseudoMetricSpace X]
     (S : Set X) (hS : IsCompact S)

--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
@@ -28,30 +28,47 @@
     "goal": "Fill 2 sorries using Mathlib's partition of unity machinery"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-21T00:00:00Z",
-    "iteration": 1,
-    "focus": "Read the 2 sorries in SchauderFixedPointOQ03OQ01.lean",
+    "phase": "PLAN",
+    "since": "2026-05-07T23:10:00Z",
+    "iteration": 2,
+    "focus": "Move approx_fixedpoint_implies_fixedpoint above kakutani_from_brouwer; close limit-argument sorry",
     "blockers": [],
-    "nextAction": "OBSERVE: Read proofs/Proofs/SchauderFixedPointOQ03OQ01.lean to understand the 2 sorry contexts",
+    "nextAction": "ATTEMPT: prove approx_fixedpoint_implies_fixedpoint using IsCompact.tendsto_subseq + Metric.thickening + Metric.infDist; once closed, kakutani_from_brouwer reduces to it",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "S2 (researcher-3, 2026-05-07): The 2 sorries are NOT in approx_selection_exists (which is an axiom). They are in (1) kakutani_from_brouwer and (2) approx_fixedpoint_implies_fixedpoint. Architectural insight: kakutani_from_brouwer reduces cleanly to approx_fixedpoint_implies_fixedpoint by chaining axioms 1+2 (brouwer_fpt + approx_selection_exists) to produce ε-approximate fixed points, then invoking the limit-argument helper. Closing the helper closes BOTH sorries. Detailed proof outlines + commented code skeletons committed in PR (proofs/Proofs/SchauderFixedPointOQ03OQ01.lean).",
+    "builtItems": [
+      "Detailed 4-step proof outline for approx_fixedpoint_implies_fixedpoint (committed as docstring) — covers sequence construction, subsequence extraction, limit transfer, and UHC-contradiction with empty/nonempty case split.",
+      "Commented-out reduction skeleton for kakutani_from_brouwer (committed in tactic block) — exact 10-line proof body once the helper is moved up.",
+      "Architectural insight that closing the helper closes BOTH sorries (no separate work needed for kakutani_from_brouwer beyond reordering)."
+    ],
+    "insights": [
+      "approx_selection_exists is an AXIOM, not a sorry — the file's 2 sorries are kakutani_from_brouwer and approx_fixedpoint_implies_fixedpoint. The original problemStatement framing is misleading.",
+      "kakutani_from_brouwer reduces in ~10 lines to approx_fixedpoint_implies_fixedpoint after pulling the helper above the main theorem (Lean 4 disallows forward references). Closing the helper closes BOTH sorries.",
+      "The reduction in kakutani_from_brouwer: for each ε, get continuous f_ε via approx_selection_exists, get fixed point x_0 = f_ε(x_0) via brouwer_fpt, extract y ∈ F(x_0) with dist(f_ε(x_0), y) < ε, conclude dist(x_0, y) < ε. Hand the family of ε-witnesses to the helper.",
+      "The subtype ↥S inherits PseudoMetricSpace from the ambient Euclidean space; CompactSpace ↥S follows from IsCompact S (via isCompact_iff_compactSpace.mp). Set.univ : Set ↥S is then compact.",
+      "approx_fixedpoint_implies_fixedpoint proof: build sequences via choice with εₙ = 1/(n+1); extract convergent subsequence (IsCompact.tendsto_subseq, automatic for metric); show y_φ(n) → x* (squeeze); contradict x* ∉ F(x*) using UHC + thickening of F(x*) by δ/2 where δ = infDist(x*, F(x*)) > 0.",
+      "Empty-F(x*) edge case: take V = ∅ (open superset of empty F(x*)); UHC forces F(x_φ(n)) = ∅ eventually, contradicting y_φ(n) ∈ F(x_φ(n)).",
+      "Docker build attempt with added imports (Mathlib.Topology.Sequences, Mathlib.Topology.Compactness.Compact) hit 32GB memory limit during Mathlib clone+build. Build verification deferred to a session with warm Docker cache OR a slimmer import set."
+    ],
     "mathlibGaps": [
-      "Mathlib.Topology.PartitionOfUnity has partition of unity constructions",
-      "Check Mathlib.Analysis.Convex.Basic for convex-valued map infrastructure"
+      "Mathlib.Topology.MetricSpace.HausdorffDistance for Metric.infDist, Metric.infDist_le_dist_add_infDist, Metric.infDist_pos_iff_not_mem_closure",
+      "Mathlib.Topology.MetricSpace.Thickening for Metric.thickening, Metric.isOpen_thickening (alternatively use Metric.ball_iUnion or compose Metric.ball arguments)",
+      "Mathlib.Topology.Sequences for IsCompact.tendsto_subseq (often pulled transitively but explicit import is safer)",
+      "Mathlib.Topology.PartitionOfUnity has partition of unity constructions (only relevant if proving approx_selection_exists; not needed for the two current sorries)"
     ],
     "nextSteps": [
-      "Read SchauderFixedPointOQ03OQ01.lean for sorry context",
-      "Search Mathlib for PartitionOfUnity.exists_continuous_sum_one",
-      "Plan approximate selection construction from partition of unity"
+      "(1) Move `approx_fixedpoint_implies_fixedpoint` block from Part V to between the axioms (Part II) and `kakutani_from_brouwer` (Part III) — or rename Parts. Forward references are not allowed in Lean 4.",
+      "(2) Add imports: Mathlib.Topology.MetricSpace.HausdorffDistance, Mathlib.Topology.MetricSpace.Thickening, Mathlib.Topology.Sequences. Verify these don't bloat compile time excessively in Docker.",
+      "(3) Prove approx_fixedpoint_implies_fixedpoint following the documented outline. Key tactic chain: choose for sequence construction; hS.tendsto_subseq for subsequence; by_cases on (F x_star).Nonempty; in nonempty case: let δ := Metric.infDist x_star (F x_star); use Metric.infDist_pos_iff_not_mem_closure (after closing F(x*) closure case); construct V := Metric.thickening (δ/2) (F x_star); use hF_uhc V (Metric.isOpen_thickening) to get U ∋ x_star; combine with hφ_tend and triangle inequality on infDist.",
+      "(4) Replace `kakutani_from_brouwer`'s sorry with the commented skeleton already present in the file (uncomment, remove the closing `sorry`).",
+      "(5) Docker build to verify; update meta.json sorries from 2 to 0 if both close (and adjust theoremCount/lineCount).",
+      "(6) If Docker OOMs again, try with --memory 65536 or run on a host with more RAM, OR build incrementally (helper first, kakutani_from_brouwer in a follow-up)."
     ]
   },
   "tags": [
@@ -79,7 +96,7 @@
     ]
   },
   "started": "2026-04-21T00:00:00Z",
-  "lastUpdate": "2026-04-21T00:00:00Z",
+  "lastUpdate": "2026-05-07T23:10:00Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

S2 (researcher-3) iteration on `schauder-fixed-point-oq-03-oq-01-incomplete-01`. The problem JSON described 2 sorries as living in `approx_selection_exists`, but that's actually an axiom — the real sorries are in `kakutani_from_brouwer` and the helper `approx_fixedpoint_implies_fixedpoint`.

This PR is **documentation only** — sorry count stays at 2. It commits two artifacts that meaningfully de-risk the next iteration:

### `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`
- **`kakutani_from_brouwer`**: explicit 4-step (A–D) reduction explaining how to chain `approx_selection_exists` + `brouwer_fpt` + the helper, with a commented-out 10-line proof skeleton ready to be uncommented after the helper is moved up (Lean 4 forbids forward references).
- **`approx_fixedpoint_implies_fixedpoint`**: full 4-step proof outline including the empty/nonempty case split for `F(x*)`, the `Metric.thickening (δ/2) (F x*)` construction, and the explicit Mathlib API needed (`HausdorffDistance`, `Thickening`, `Sequences`).

### `src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json`
- `currentState.phase`: NEW → PLAN, iteration 1 → 2
- `knowledge.progressSummary`, 7 `insights`, refined `mathlibGaps` with specific lemma names, 6 concrete `nextSteps`, 3 `builtItems`.

### Architectural insight
Closing the helper `approx_fixedpoint_implies_fixedpoint` closes **both** sorries — `kakutani_from_brouwer` reduces to it in ~10 lines once the helper is moved above the main theorem. So the next iteration has a single clear target.

### Notes for next session
- Docker build with extra imports hit 32GB memory limit during fresh Mathlib clone+build. Either run with warmer cache or use `LEAN_MEMORY_LIMIT=65536`.
- The reorder-then-prove approach is incremental: first commit moves the helper up (build-safe, sorries unchanged), second commit closes the helper (sorries 2 → 1 if kakutani_from_brouwer's sorry is also replaced; actually 2 → 0 since the helper unblocks the main theorem too).

## Test plan
- [ ] Docker build (`./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01`) — deferred to next iteration with warmer cache.
- [x] No semantic changes to Lean file; only docstring/comment additions.
- [x] JSON validates as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)