### PR TITLE
research(ehrhart-cube-proven-oq-02): close crossEhrhart_is_poly via descPochhammer

### DIFF
--- a/proofs/Proofs/EhrhartCrossPolytope.lean
+++ b/proofs/Proofs/EhrhartCrossPolytope.lean
@@ -18,7 +18,7 @@
   "Can Ehrhart polynomials for polytopes with known formulas be proved
    from first principles without the general existence theorem?"
 
-  Main results (10 theorems, 3 sorries):
+  Main results (11 theorems, 1 sorry):
   1. crossEhrhart_d0          — L(B_0,n) = 1
   2. crossEhrhart_n0          — L(B_d,0) = 1
   3. crossEhrhart_d1          — L(B_1,n) = 2n+1
@@ -29,11 +29,10 @@
   8. sum_shift_hockey          — sum interchange using hockey-stick
   9. crossEhrhart_expand       — key algebraic expansion (Pascal split)
   10. crossEhrhart_succ_d      — geometric recursion: L(B_{d+1},n) = L(B_d,n) + 2·Σ L(B_d,m)
+  11. crossEhrhart_is_poly     — polynomial identification via descPochhammer
 
-  Sorries (3):
-  - crossEhrhart_is_poly: polynomial identification (Lean polynomial API)
-  - crossBall_card base d=0: Finset card of empty-domain functions
-  - crossBall_card step: Finset slicing decomposition
+  Remaining sorry (1):
+  - crossBall_card succ-d: Finset slicing decomposition (geometric recursion)
 -/
 import Mathlib
 
@@ -241,18 +240,88 @@ example : crossEhrhart 3 4 = 129 := by native_decide
 -- PART VII: Ehrhart Polynomial Identification
 -- ============================================================
 
+-- Helper: natDegree of `descPochhammer ℚ k` is at most `k`.
+private lemma natDegree_descPochhammer_le (k : ℕ) :
+    (Polynomial.descPochhammer ℚ k).natDegree ≤ k := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Polynomial.descPochhammer_succ_right]
+    refine le_trans Polynomial.natDegree_mul_le ?_
+    have h1 : (Polynomial.X - ((k : ℕ) : Polynomial ℚ)).natDegree ≤ 1 := by
+      refine le_trans (Polynomial.natDegree_sub_le _ _) ?_
+      simp
+    omega
+
+-- Helper: `(descPochhammer ℚ k).eval (n : ℚ) = ↑(n.descFactorial k)`.
+private lemma eval_descPochhammer_natCast (k n : ℕ) :
+    (Polynomial.descPochhammer ℚ k).eval ((n : ℕ) : ℚ) =
+      ((n.descFactorial k : ℕ) : ℚ) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Polynomial.descPochhammer_succ_right]
+    simp only [Polynomial.eval_mul, Polynomial.eval_sub, Polynomial.eval_X,
+               Polynomial.eval_natCast, ih]
+    rcases le_or_lt k n with hkn | hkn
+    · -- k ≤ n: descFactorial unfolds nicely
+      rw [Nat.descFactorial_succ, Nat.cast_mul, Nat.cast_sub hkn]
+      ring
+    · -- k > n: both descFactorial values vanish
+      have hzero_at : ∀ m, n.descFactorial (n + 1 + m) = 0 := by
+        intro m
+        induction m with
+        | zero =>
+          show n.descFactorial (n + 1) = 0
+          rw [Nat.descFactorial_succ, Nat.sub_self, zero_mul]
+        | succ m ihm =>
+          rw [show n + 1 + (m + 1) = (n + 1 + m) + 1 from by omega,
+              Nat.descFactorial_succ, ihm, mul_zero]
+      have hk_zero : n.descFactorial k = 0 := by
+        obtain ⟨m, hm⟩ : ∃ m, k = n + 1 + m := ⟨k - (n + 1), by omega⟩
+        rw [hm]; exact hzero_at m
+      have hk1_zero : n.descFactorial (k + 1) = 0 := by
+        rw [Nat.descFactorial_succ, hk_zero, mul_zero]
+      rw [hk_zero, hk1_zero]
+      simp
+
 /-- **The formula is a polynomial of degree ≤ d in n** (over ℚ).
 
     Each term 2^k · C(d,k) · C(n,k) is a polynomial of degree k in n,
     with C(n,k) = n(n-1)···(n-k+1)/k! a polynomial of degree k.
-    So the sum is a polynomial of degree d. -/
+    So the sum is a polynomial of degree d.
+
+    The construction is
+    `P = Σ_{k=0}^d C ((2^k · C(d,k))/k!) · descPochhammer ℚ k`.
+    Each summand has natDegree ≤ k ≤ d. Evaluation at `(n : ℚ)` uses
+    `descPochhammer ℚ k`.eval = `descFactorial = k! · C(n,k)`, with
+    the `k!` cancelling against the coefficient denominator. -/
 theorem crossEhrhart_is_poly (d : ℕ) :
     ∃ (P : Polynomial ℚ), P.natDegree ≤ d ∧
     ∀ n : ℕ, P.eval (n : ℚ) = (crossEhrhart d n : ℚ) := by
-  -- Each term 2^k · C(d,k) · C(n,k) is degree k (since C(n,k) = n↓k/k! is degree k).
-  -- The polynomial P = Σ_{k≤d} (2^k·C(d,k)/k!) · X·(X-1)···(X-k+1).
-  -- Full construction omitted; see crossEhrhart_succ_d for the key recursion.
-  sorry
+  refine ⟨∑ k ∈ range (d + 1),
+    Polynomial.C ((2 ^ k : ℚ) * (Nat.choose d k : ℚ) / (k.factorial : ℚ)) *
+      Polynomial.descPochhammer ℚ k, ?_, ?_⟩
+  · -- natDegree ≤ d
+    refine le_trans (Polynomial.natDegree_sum_le _ _) ?_
+    apply Finset.sup_le
+    intro k hk
+    refine le_trans Polynomial.natDegree_mul_le ?_
+    rw [Polynomial.natDegree_C, zero_add]
+    have hk_le : k ≤ d := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+    exact le_trans (natDegree_descPochhammer_le k) hk_le
+  · -- eval property at every Nat n
+    intro n
+    rw [Polynomial.eval_finset_sum, crossEhrhart, Nat.cast_sum]
+    apply Finset.sum_congr rfl
+    intro k _
+    rw [Polynomial.eval_mul, Polynomial.eval_C, eval_descPochhammer_natCast,
+        Nat.descFactorial_eq_factorial_mul_choose]
+    have hk_ne : (k.factorial : ℚ) ≠ 0 := by
+      exact_mod_cast Nat.factorial_ne_zero k
+    push_cast
+    field_simp [hk_ne]
+    ring
 
 -- ============================================================
 -- PART VIII: Connection to Lattice Points

--- a/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
@@ -106,6 +106,54 @@ Estimated 100+ lines; deferred for a future iteration.
 
 ---
 
+## Session 2026-05-07 (Session 2, researcher-8) — `crossEhrhart_is_poly` closed
+
+**Mode**: ACT
+**Outcome**: Eliminated the polynomial-identification sorry (PR #16734).
+Sorry count: 2 → 1. Theorem count: 12 → 14. lineCount: 330 → 399.
+
+### What worked
+
+The descPochhammer-based construction outlined in Session 1 was implemented
+successfully. The key was writing **two private helper lemmas inside the
+file** rather than relying on (uncertain) Mathlib lemma names:
+
+1. `natDegree_descPochhammer_le k`: induction + `descPochhammer_succ_right`
+   + `Polynomial.natDegree_mul_le` + `Polynomial.natDegree_sub_le` + `omega`.
+2. `eval_descPochhammer_natCast k n`: induction on k. The `simp only` chain
+   `[Polynomial.eval_mul, Polynomial.eval_sub, Polynomial.eval_X,
+     Polynomial.eval_natCast, ih]` simplifies after `descPochhammer_succ_right`.
+   Case-split on `k ≤ n` vs `k > n` for `Nat.descFactorial_succ` cleanup.
+   For the `k > n` case, the helper `∀ m, n.descFactorial (n + 1 + m) = 0`
+   was proved by induction on `m` and used `obtain ⟨m, hm⟩ := ⟨k - (n+1),
+   by omega⟩` to bridge.
+
+The main proof:
+
+```
+P d := ∑ k ∈ range (d+1),
+         Polynomial.C ((2^k : ℚ) * (Nat.choose d k : ℚ) / (k.factorial : ℚ))
+       * Polynomial.descPochhammer ℚ k
+```
+
+natDegree ≤ d via `Polynomial.natDegree_sum_le` + `Finset.sup_le` +
+`natDegree_descPochhammer_le`. Eval correctness via the helpers +
+`Nat.descFactorial_eq_factorial_mul_choose` + `field_simp [hk_ne]` + `ring`.
+
+### Build verification
+
+Local Docker build was unable to verify due to environmental constraints:
+Docker Desktop has only 7.65 GiB memory available (vs the 32 GB intended
+limit), so the Mathlib-dependent compile OOM'd at 720s after `lake exe
+cache get` succeeded. CI is the ground-truth verifier.
+
+### Remaining work (1 sorry)
+
+`crossBall_card` succ-d Finset slicing decomposition. Sketch in Session 1
+knowledge entry remains valid.
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/ehrhart-cube-proven-oq-02/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/state.md
@@ -1,17 +1,17 @@
 # Research State: ehrhart-cube-proven-oq-02
 
 ## Current State
-**Phase**: ACT — known proof path identified for `crossEhrhart_is_poly`
+**Phase**: ACT — `crossEhrhart_is_poly` closed (PR #16734); `crossBall_card`
+succ-d remains
 **Path**: incremental sorry closure
 **Since**: 2026-05-07
 **Last Updated**: 2026-05-07
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Two sorries remain in `proofs/Proofs/EhrhartCrossPolytope.lean`:
-1. `crossEhrhart_is_poly` (line 255) — produce a `Polynomial ℚ` of degree ≤ d
-   that evaluates to `crossEhrhart d n` at every Nat n.
-2. `crossBall_card` succ-d case (line 283) — Finset slicing decomposition.
+One sorry remains in `proofs/Proofs/EhrhartCrossPolytope.lean`:
+- `crossBall_card` succ-d case — Finset slicing decomposition by last
+  coordinate (≈100 lines, deferred to a future session).
 
 ## Active Approach
 - For (1), use Mathlib's `descPochhammer ℚ k` (degree k, evaluates to
@@ -33,8 +33,9 @@ Two sorries remain in `proofs/Proofs/EhrhartCrossPolytope.lean`:
   and the rest paired symmetrically.
 
 ## Attempt Count
-- Total attempts: 1 (this session)
-- Approaches tried: descPochhammer-based polynomial construction (planned)
+- Total attempts: 2
+- Approaches tried: descPochhammer-based polynomial construction (Session 1
+  planned, Session 2 implemented and shipped via PR #16734)
 
 ## Blockers
 - **Local Lean build**: Worktree's `proofs/.lake` symlink is a self-cycle; my
@@ -43,10 +44,11 @@ Two sorries remain in `proofs/Proofs/EhrhartCrossPolytope.lean`:
   PR-driven CI will validate, but iteration cost is high.
 
 ## Next Action
-**ACT** — implement `crossEhrhart_is_poly` via the descPochhammer construction.
-The proof outline is complete; the work is wiring up the Lean syntax and
-verifying lemma names (`descPochhammer_natDegree`, `descPochhammer_eval_eq_descFactorial`,
-`Nat.descFactorial_eq_factorial_mul_choose`, `Polynomial.natDegree_sum_le`).
+**Pause for CI verification of PR #16734** before tackling `crossBall_card`
+succ-d. The Finset slicing decomposition is intricate (≈100 lines) and
+should follow the sketch in knowledge.md Session 1: fiberwise count via
+`Finset.card_eq_sum_card_fiberwise` over the last-coordinate projection,
+plus a symmetric pairing j ↔ 2n − j.
 
 ## References
 - `proofs/Proofs/EhrhartCrossPolytope.lean:249-255` — `crossEhrhart_is_poly` sorry

--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -6,10 +6,10 @@
   "leanFile": {
     "path": "Proofs/EhrhartCrossPolytope.lean",
     "filename": "EhrhartCrossPolytope.lean",
-    "lineCount": 330,
-    "theoremCount": 12,
+    "lineCount": 399,
+    "theoremCount": 14,
     "definitionCount": 2,
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0
   },
   "meta": {
@@ -29,10 +29,10 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 330,
-    "assumptions": "2 sorries: (1) crossEhrhart_is_poly \u2014 Lean Polynomial API; (2) crossBall_card d+1 \u2014 Finset slicing. All 10 key algebraic/combinatorial theorems proved including geometric recursion L(B_{d+1},n) = L(B_d,n) + 2*\u03a3 L(B_d,m).",
+    "lineCount": 399,
+    "assumptions": "1 sorry: crossBall_card d+1 \u2014 Finset slicing decomposition. All algebraic/combinatorial theorems are proved including the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2*\u03a3 L(B_d,m) and the polynomial identification crossEhrhart_is_poly via descPochhammer \u211a k.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -41,11 +41,11 @@
       "sum_shift_hockey: sum interchange converting \u03a3_k 2^k C(d,k) C(n,k+1) to \u03a3_{m<n} \u03a3_k 2^k C(d,k) C(m,k)",
       "crossEhrhart_expand: algebraic expansion L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_k 2^k C(d,k) C(n,k+1) via Pascal's rule",
       "crossEhrhart_succ_d: geometric recursion L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_{m<n} L(B_d,m) by combining expand + hockey-stick",
-      "crossEhrhart_is_poly: proof that the formula is a polynomial of degree d in n over \u211a",
+      "crossEhrhart_is_poly: explicit polynomial of degree \u2264 d in n over \u211a, constructed as P = \u03a3_k C((2^k\u00b7C(d,k))/k!) \u00b7 descPochhammer \u211a k via Mathlib's descPochhammer; the k! denominator cancels the descFactorial = k!\u00b7C(n,k) factor",
       "crossBall: Finset model of cross-polytope lattice points via centered Fin (2n+1) coordinates",
       "Concrete verifications: d=1 (2n+1), d=2 (2n\u00b2+2n+1), d=3 spot checks via native_decide"
     ],
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2
   },
   "overview": {
@@ -114,20 +114,20 @@
     {
       "id": "polynomial-identification",
       "title": "Section VII: Ehrhart Polynomial",
-      "startLine": 230,
-      "endLine": 270,
-      "summary": "crossEhrhart_is_poly: \u2203 P : \u211a[X] of degree \u2264 d with P(n) = crossEhrhart d n. Constructed as \u03a3_k (2^k C(d,k)/k!) \u00b7 X\u2193k."
+      "startLine": 240,
+      "endLine": 324,
+      "summary": "crossEhrhart_is_poly: \u2203 P : \u211a[X] of degree \u2264 d with P(n) = crossEhrhart d n. Constructed via two helper lemmas (natDegree_descPochhammer_le, eval_descPochhammer_natCast) using Mathlib's descPochhammer; the polynomial is P = \u03a3_k C((2^k C(d,k))/k!) \u00b7 descPochhammer \u211a k, with the k! denominator cancelling the descFactorial = k!\u00b7C(n,k) factor."
     },
     {
       "id": "lattice-connection",
       "title": "Section VIII: Lattice Point Connection",
-      "startLine": 275,
-      "endLine": 295,
+      "startLine": 327,
+      "endLine": 353,
       "summary": "crossBall: Finset model of n\u00b7B_d lattice points via Fin d \u2192 Fin(2n+1) with L\u00b9-norm constraint. crossBall_card: card = crossEhrhart d n (proved for d=0; inductive step has 1 sorry for Finset slicing)."
     }
   ],
   "conclusion": {
-    "summary": "This formalization answers ehrhart-cube-proven OQ-02 by proving the cross-polytope Ehrhart formula L(B_d,n) = \u03a3 2^k C(d,k) C(n,k) axiom-free. The 10 proved theorems (1 sorry for the geometric Finset argument) establish the formula, its polynomial nature, the geometric recursion, and base cases.\n\nTogether with EhrhartCubeProven and EhrhartSimplexProven, this demonstrates that three major polytope families have fully explicit, axiom-free Ehrhart polynomial proofs in Lean 4, without ever invoking the general Ehrhart existence theorem (ehrhart_theorem axiom). The key principle: for polytopes with combinatorial lattice-point formulas, inductive algebraic proofs replace the transcendental machinery of the general theory.",
+    "summary": "This formalization answers ehrhart-cube-proven OQ-02 by proving the cross-polytope Ehrhart formula L(B_d,n) = \u03a3 2^k C(d,k) C(n,k) axiom-free. The 13 proved theorems (1 sorry for the geometric Finset argument) establish the formula, its polynomial nature (via an explicit descPochhammer construction), the geometric recursion, and base cases.\n\nTogether with EhrhartCubeProven and EhrhartSimplexProven, this demonstrates that three major polytope families have fully explicit, axiom-free Ehrhart polynomial proofs in Lean 4, without ever invoking the general Ehrhart existence theorem (ehrhart_theorem axiom). The key principle: for polytopes with combinatorial lattice-point formulas, inductive algebraic proofs replace the transcendental machinery of the general theory.",
     "implications": "**The three pillars of Ehrhart theory without axioms**: Cube (Fin d \u2192 Fin(n+1)), Simplex (Sym (Fin(d+1)) n), and Cross-Polytope (induction + Pascal + hockey-stick) provide three fundamentally different approaches to axiom-free Ehrhart proofs. Each captures a different combinatorial structure.\n\n**Delannoy numbers**: The formula \u03a3 2^k C(d,k) C(n,k) = D(d,n) (central Delannoy number) connects cross-polytope lattice counting to lattice path enumeration. Formalizing this bijection would give a new combinatorial proof of the Delannoy formula.\n\n**General principle**: The successful axiom-free approach for these three polytopes suggests a research program: identify all families of lattice polytopes with explicit Ehrhart formulas and formalize them without the existence axiom. Candidates include permutohedra, hypersimplices, and flow polytopes.",
     "openQuestions": [
       "Can the crossBall_card sorry be eliminated by formalizing the Finset slicing decomposition of B_{d+1} by last coordinate?",
@@ -152,5 +152,5 @@
       "relationship": "General theory (axiomatized). This file provides an axiom-free proof for the cross-polytope."
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

Eliminates one of the two remaining sorries in `EhrhartCrossPolytope.lean` by giving an **explicit polynomial of degree ≤ d in ℚ[X]** that evaluates to `crossEhrhart d n` at every natural `n`:

P(X) = Σ_{k=0}^d C((2^k · C(d,k)) / k!) · descPochhammer ℚ k

## What changed

- New private helper `natDegree_descPochhammer_le` (induction + `descPochhammer_succ_right` + `natDegree_mul_le` + `natDegree_sub_le`).
- New private helper `eval_descPochhammer_natCast`: `(descPochhammer ℚ k).eval (n : ℚ) = (n.descFactorial k : ℚ)`. Proved by induction on `k`, with `k ≤ n` and `k > n` case-split for `Nat.descFactorial`.
- `crossEhrhart_is_poly` is now sorry-free: builds the sum, bounds `natDegree` via `Polynomial.natDegree_sum_le` + `Finset.sup_le`, and finishes the eval calculation with `Nat.descFactorial_eq_factorial_mul_choose` + `field_simp` + `ring` (using `(k.factorial : ℚ) ≠ 0`).
- Updated `meta.json` (sorries 2 → 1, theoremCount 12 → 14, lineCount 330 → 399, refreshed assumptions/originalContributions/section line ranges).
- Updated file header to reflect the new sorry count.

## Math

`descPochhammer ℚ k` evaluates at a Nat `n` to `n.descFactorial k = k! · n.choose k`. So:

`P.eval n = Σ_k (2^k · C(d,k) / k!) · k! · C(n,k) = Σ_k 2^k · C(d,k) · C(n,k) = crossEhrhart d n`

The `k!` denominator is well-defined in ℚ since `k.factorial ≠ 0`.

## Sorry status

Before: 2 sorries (`crossEhrhart_is_poly`, `crossBall_card` succ-d).
After:  1 sorry (`crossBall_card` succ-d only — Finset slicing decomposition deferred).

## Test plan

- [ ] CI builds `Proofs.EhrhartCrossPolytope` (local Docker build was unreachable due to environmental contention; lemma names cross-checked against existing usages in `BinomialTheoremOQ01.lean` and `Erdos671Problem.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)