### PR TITLE
research(sperner-ndim-mathlib-oq-01): reconcile meta with 0-axiom state

### DIFF
--- a/proofs/Proofs/SpernerNDimMathlibOQ01.lean
+++ b/proofs/Proofs/SpernerNDimMathlibOQ01.lean
@@ -19,7 +19,7 @@ Answers **OQ-01** from `sperner-ndim-mathlib`: which concrete structures instant
 The bridge `toAbstractCellComplex` projects them away, and `SpernerAbstract.sperner` applies.
 For Sperner colorings, both boundary conditions agree by `boundary_door_is_last_face`.
 
-## Part II: Freudenthal CellComplex (4 axioms)
+## Part II: Freudenthal CellComplex (0 axioms, fully proved)
 
 The Freudenthal triangulation of [0,1]^n gives `CellComplex (Finset (Fin n)) n`:
 - **Simplex**: nodup lists of `Fin n` of length `n` (permutations)
@@ -27,14 +27,22 @@ The Freudenthal triangulation of [0,1]^n gives `CellComplex (Finset (Fin n)) n`:
 - **Interior adjacency** (0 < k < n): swap positions k-1 and k in the permutation list
 - **Boundary** (k = 0 or k = n): `none`
 
-Four facts are axiomatized (each a ~40-line list-element argument):
-1. `freud_simplex_fintype`: `FreudSimplex n` is Fintype (bijects with `Equiv.Perm (Fin n)`)
-2. `swapAdj_nodup`: adjacent swap preserves `Nodup` (same multiset of elements)
-3. `swapAdj_prefixSet_ne_pos_eq`: prefix sets agree at index ≠ k (key for `adj_vertices`)
-4. `swapAdj_ne_self`: swapping adjacent distinct elements yields a different list
+Four facts (originally axiomatized, all eliminated as theorems):
+1. `freud_simplex_fintype` (instance, line 279): `FreudSimplex n` is Fintype, proved via
+   the `listToPerm`/`permList` round-trip with `Equiv.Perm (Fin n)`.
+2. `swapAdj_nodup` (line 190): adjacent swap preserves `Nodup`, proved from
+   `swapAdj_perm.nodup_iff`.
+3. `swapAdj_prefixSet_eq` (line 196): prefix sets agree at index ≠ k, proved by
+   `take` casework + `List.Perm.swap` for the interior split.
+4. `swapAdj_ne_self` (line 238): adjacent swap produces a different list, proved
+   from `Nodup.getElem_inj_iff` at the swapped positions.
 
-Proved: `adj_symm` (involution), `adj_vertices` (axiom 3), `adj_ne` (axiom 4),
-`vertices_injective` (prefix cardinality), and the main `freudenthal_sperner` theorem.
+The supporting list-permutation infrastructure (`swapAdj_perm`, `swapAdj_eq_split`,
+`listToPerm`, `listToPermFun_injective`) lives in this file as private lemmas.
+
+Proved at the CellComplex level: `adj_symm` (involution), `adj_vertices` (uses
+axiom-3-now-theorem), `adj_ne` (uses axiom-4-now-theorem), `vertices_injective`
+(prefix cardinality), and the main `freudenthal_sperner` theorem.
 
 ## Tags
 

--- a/src/data/proofs/sperner-ndim-mathlib-oq-01/annotations.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01/annotations.json
@@ -2,10 +2,10 @@
   {
     "id": "ann-sperner-mathlib-oq01-context",
     "proofId": "sperner-ndim-mathlib-oq-01",
-    "range": { "startLine": 1, "endLine": 42 },
+    "range": { "startLine": 1, "endLine": 50 },
     "type": "context",
     "title": "Two Concrete CellComplex Instances Closing OQ-01",
-    "content": "**Open question OQ-01** from `sperner-ndim-mathlib`: which concrete structures instantiate the abstract `SpernerAbstract.CellComplex` so that the abstract Sperner theorem recovers the standard $n$-dimensional Sperner lemma? This file gives **two instances**. **Part I (0 axioms)**: a *bridge* showing every `SpernerNDim.SpernerTriangulation` is a `CellComplex`, so the abstract Sperner theorem subsumes the concrete one. **Part II (4 axioms)**: the **Freudenthal triangulation** of $[0,1]^n$ as a `CellComplex (Finset (Fin n)) n` — simplices are permutations of $\\text{Fin}(n)$, vertices are prefix sets, and adjacency is the adjacent transposition $(k-1, k)$. Total: 0 sorries, 4 axioms (each ~40-line element-level list arguments).",
+    "content": "**Open question OQ-01** from `sperner-ndim-mathlib`: which concrete structures instantiate the abstract `SpernerAbstract.CellComplex` so that the abstract Sperner theorem recovers the standard $n$-dimensional Sperner lemma? This file gives **two instances**. **Part I (0 axioms)**: a *bridge* showing every `SpernerNDim.SpernerTriangulation` is a `CellComplex`, so the abstract Sperner theorem subsumes the concrete one. **Part II (0 axioms)**: the **Freudenthal triangulation** of $[0,1]^n$ as a `CellComplex (Finset (Fin n)) n` — simplices are permutations of $\\text{Fin}(n)$, vertices are prefix sets, and adjacency is the adjacent transposition $(k-1, k)$. Total: 0 sorries, 0 axioms. The four originally-axiomatized swapAdj facts (Nodup-preservation, prefix-set invariance at $i \\neq k$, distinctness from original, and FreudSimplex Fintype) are now proved as private theorems — three of them via a single `List.Perm` lemma (`swapAdj_perm`) and the Fintype instance via a `listToPerm`/`permList` round-trip with `Equiv.Perm (\\text{Fin}(n))`.",
     "mathContext": "**Sperner's lemma** (Emanuel Sperner, 1928): in any triangulation of an $n$-simplex with a *Sperner coloring* (vertex $i$ of the $n$-simplex labelled $i$, and any vertex on a face is labelled with one of the face's vertices), there are an *odd* number of *fully colored* small simplices (one of each color $0, 1, \\ldots, n$). The standard proof is the **door-counting parity argument**: each fully-colored simplex has exactly one face containing $\\{0, 1, \\ldots, n-1\\}$, and parity propagates to the boundary. The `SpernerAbstract.CellComplex` framework axiomatizes this parity argument independently of the underlying triangulation, and this file shows the abstraction is witnessed by two concrete examples — the existing `SpernerTriangulation` and the new Freudenthal triangulation.",
     "significance": "key",
     "relatedConcepts": [
@@ -26,7 +26,7 @@
   {
     "id": "ann-sperner-mathlib-oq01-bridge",
     "proofId": "sperner-ndim-mathlib-oq-01",
-    "range": { "startLine": 51, "endLine": 105 },
+    "range": { "startLine": 59, "endLine": 113 },
     "type": "technique",
     "title": "Part I: SpernerTriangulation → CellComplex Bridge (0 axioms)",
     "content": "**`toAbstractCellComplex K`**: every `SpernerNDim.SpernerTriangulation d N` projects to a `CellComplex (Vertex d N) d` by *forgetting* the two boundary-specific fields `adj_unique_facet` and `boundary_face`. The remaining fields (`Simplex`, `vertices`, `vertices_injective`, `adj`, `adj_symm`, `adj_vertices`, `adj_ne`) are exactly `CellComplex`'s. **`isFC_bridge`** and **`isDoorAt_bridge`** are `rfl` — the abstract and concrete `IsFC` / `isDoorAt` predicates are definitionally equal across the projection. **`sperner_from_triangulation`** is then a one-line application of `SpernerAbstract.sperner`. **`boundary_doors_agree`**: for *Sperner colorings*, the abstract boundary-door count equals the concrete one (which restricts to face $d$) — this is the bridge that lets the abstract parity argument recover the classical statement.",
@@ -47,7 +47,7 @@
   {
     "id": "ann-sperner-mathlib-oq01-freud-defs",
     "proofId": "sperner-ndim-mathlib-oq-01",
-    "range": { "startLine": 115, "endLine": 142 },
+    "range": { "startLine": 115, "endLine": 150 },
     "type": "definition",
     "title": "FreudSimplex and swapAdj: Permutations and Adjacent Transposition",
     "content": "**`FreudSimplex n`**: the subtype of `List (Fin n)` consisting of *nodup* lists of length $n$ — i.e., **permutations of $\\text{Fin}(n)$** in list form. Equipped with `DecidableEq` via the underlying list equality. **`swapAdj l hk0 hkn`**: swaps positions $k-1$ and $k$ in $l$ via two `List.set` operations, defined for any list (not just permutations). **`swapAdj_length`**: `set` doesn't change length (one-line `simp`). **`swapAdj_invol`**: applying `swapAdj` twice is the identity — the proof uses `List.ext_getElem` to compare element-by-element, with four `by_cases` branches on whether $i = k - 1$, $i = k$. The branch $i = k - 1, i = k$ is impossible (handled by `omega`); the other three branches simp through.",
@@ -68,28 +68,30 @@
   {
     "id": "ann-sperner-mathlib-oq01-axioms",
     "proofId": "sperner-ndim-mathlib-oq-01",
-    "range": { "startLine": 144, "endLine": 167 },
-    "type": "context",
-    "title": "Four Axioms: Why and What They Cost",
-    "content": "**Four axioms about `swapAdj`**, each provable by ~40-line element-level list arguments: **(1) `freud_simplex_fintype`** — `FreudSimplex n` is `Fintype` (bijects with `Equiv.Perm (Fin n)` via $\\sigma \\mapsto \\text{List.ofFn} \\, \\sigma$). **(2) `swapAdj_nodup`** — adjacent swap preserves `Nodup` (the result is a permutation of the original, same multiset). **(3) `swapAdj_prefixSet_eq`** — for $i \\neq k$, the prefix set $(\\text{swapAdj} \\, l)[0..i].\\text{toFinset} = l[0..i].\\text{toFinset}$ (for $i < k$ the lists agree on $[0, i)$; for $i > k$ they agree as multisets). **(4) `swapAdj_ne_self`** — when $l$ is nodup, swapping at indices $k-1, k$ produces a different list (because the elements at positions $k-1, k$ differ). The axioms are **provable by routine but tedious case-splits** on `List.set` and `List.toFinset` operations; their formalization would expand the file by ~160 lines of pure list combinatorics.",
-    "mathContext": "**The cost-benefit calculation for axiomatization** in Lean formalization: closing each axiom would add ~40 lines of `List.set` casework, with no new mathematical insight — the *content* is the cell-complex structure, not the list-bookkeeping. **Pattern is standard**: when the missing facts are 'algebraically obvious but combinatorially tedious', and Mathlib's `List` API provides no high-level abstraction (e.g., for `prefixSet` after a swap), the file ships with explicit axioms identifying *exactly* what's left. This **localizes the technical debt** and makes the gap actionable: the next iteration (`OQ-01-OQ-01-...`) can target these four axioms in isolation. **Status integrity**: meta.json correctly reports `axiomatized` / 4 axioms / badge `axiom`.",
-    "significance": "supporting",
+    "range": { "startLine": 152, "endLine": 302 },
+    "type": "insight",
+    "title": "From Four Axioms to Four Theorems: One Permutation Lemma Does Three of Them",
+    "content": "**The four originally-axiomatized facts about `swapAdj` are now proved as private theorems**, factored through a single `List.Perm` lemma. **`swapAdj_eq_split`** rewrites $\\text{swapAdj}\\,l$ as $l.\\text{take}(k-1) \\mathbin{\\text{++}} l_k :: l_{k-1} :: l.\\text{drop}(k+1)$, exposing the swap as a `List.Perm.swap` inside an append. **`swapAdj_perm`** proves $\\text{swapAdj}\\,l \\sim l$ as a `List.Perm` by combining the split with `List.Perm.append_left` and `List.Perm.swap`. From this single lemma: **`swapAdj_nodup`** (was axiom 2) is one line — `swapAdj_perm.nodup_iff.mpr`. **`swapAdj_prefixSet_eq`** (was axiom 3) splits on $i < k$ vs $i > k$: the first branch is literal equality via `take_set_of_le`; the second branch reduces to `List.Perm.swap` on the swapped pair via the same `take/drop` split. **`swapAdj_ne_self`** (was axiom 4) is independent — proved by extracting positions $k-1, k$ via `Nodup.getElem_inj_iff` and noting they hold distinct values in the swap. Finally, **`freud_simplex_fintype`** (was axiom 1) is built from `listToPerm` (using `Equiv.ofBijective` + `Finite.injective_iff_surjective`) round-tripped through `FreudenthalAdjacency.permList` via `Fintype.ofSurjective`.",
+    "mathContext": "**Right factoring discovers structure.** The original axiomatization parked four list-bookkeeping facts to keep the cell-complex construction lean. The right factoring is `swapAdj_perm`: an adjacent swap is a permutation of the underlying list. Once that single fact is in hand, three of the four axioms collapse to one-line corollaries from Mathlib's `List.Perm` API — the fourth is independent (a `getElem`-level distinctness, not a permutation fact). The cost is ~136 added lines (file 241 → 377), well under the originally projected ~160-line expansion, because the factoring shares one proof across three goals. **Lesson for axiom-elimination**: before grinding through casework, look for a single algebraic structure that subsumes multiple axioms — `List.Perm` is the right one here.",
+    "significance": "key",
     "relatedConcepts": [
-      "axiomatization as technical-debt localization",
-      "List.toFinset of a prefix",
-      "Equiv.Perm as nodup list",
-      "List.set Nodup preservation"
+      "List.Perm as a unifying structure",
+      "Perm.nodup_iff, Perm.append_left, List.Perm.swap",
+      "Nodup.getElem_inj_iff for distinctness",
+      "Equiv.ofBijective + Finite.injective_iff_surjective",
+      "Fintype.ofSurjective via listToPerm/permList round-trip"
     ],
     "prerequisites": [
-      "axiom keyword in Lean 4",
-      "attribute [instance] on axioms",
-      "Mathlib List.Nodup, List.toFinset"
+      "List.Perm (Mathlib.Data.List.Perm)",
+      "Mathlib List.Nodup, List.toFinset, List.set",
+      "Equiv.Perm (Fin n)",
+      "Fin.ext, congr_arg, omega"
     ]
   },
   {
     "id": "ann-sperner-mathlib-oq01-prefix-inj",
     "proofId": "sperner-ndim-mathlib-oq-01",
-    "range": { "startLine": 170, "endLine": 192 },
+    "range": { "startLine": 304, "endLine": 328 },
     "type": "technique",
     "title": "Prefix-Set Injectivity via Cardinality",
     "content": "**`prefixSet_inj`** (private lemma): for a Freudenthal simplex $l$, the map $k \\mapsto \\text{prefixSet}(l, k.\\text{val})$ from $\\text{Fin}(n+1)$ to $\\text{Finset}(\\text{Fin}(n))$ is **injective**. Proof: `prefixSet_card_eq` (from the parent `SpernerNDim.lean`) says $|\\text{prefixSet}(l, i)| = i$ when $l$ is nodup, so different indices yield different cardinalities, hence different sets. The proof is three lines: extract cardinality from each side via `prefixSet_card_eq`, apply `congr_arg Finset.card` to the hypothesis, then `linarith` closes.",
@@ -110,21 +112,22 @@
   {
     "id": "ann-sperner-mathlib-oq01-cellcomplex",
     "proofId": "sperner-ndim-mathlib-oq-01",
-    "range": { "startLine": 193, "endLine": 229 },
+    "range": { "startLine": 330, "endLine": 366 },
     "type": "insight",
     "title": "freudenthalCellComplex: Assembling the Eight Fields",
-    "content": "**`freudenthalCellComplex n : CellComplex (Finset (Fin n)) n`** — the second concrete instance, with eight structure fields wired together: **Simplex** = `FreudSimplex n`. **simplex_decidableEq** = `inferInstance`. **simplex_fintype** = axiom 1. **vertices** = $\\lambda l \\, k. \\text{prefixSet}(l.1, k.\\text{val})$. **vertices_injective** = `prefixSet_inj`. **adj** = `freudAdj` (using axioms 2 + length lemma). **adj_symm** = `swapAdj_invol` (the involution lemma above) — wired through `Subtype.ext` because `FreudSimplex` is a subtype. **adj_vertices** = axiom 3. **adj_ne** = axiom 4 + `congr_arg Subtype.val`. **`freudenthal_sperner`** is then a one-line application of the abstract `sperner` to this complex.",
-    "mathContext": "**The structure-assembly pattern**: each `CellComplex` field is satisfied by either an axiom, a routine lemma (`prefixSet_inj`), or the involution lemma `swapAdj_invol`. The non-routine creative step is the **construction of `freudAdj`** as a *partial function*: returns `some (swapAdj l, k)` when $0 < k < n$, returns `none` at the boundary $k = 0$ or $k = n$. This 'optional adjacency' encoding is what makes the Freudenthal complex a true cell complex with a boundary, rather than a pure pseudomanifold. The boundary cases are precisely where Sperner's parity argument 'leaks' to give the parity of fully-colored simplices = parity of boundary doors.",
+    "content": "**`freudenthalCellComplex n : CellComplex (Finset (Fin n)) n`** — the second concrete instance, with eight structure fields wired together: **Simplex** = `FreudSimplex n`. **simplex_decidableEq** = `inferInstance`. **simplex_fintype** = `freud_simplex_fintype n` (instance, proved). **vertices** = $\\lambda l \\, k. \\text{prefixSet}(l.1, k.\\text{val})$. **vertices_injective** = `prefixSet_inj`. **adj** = `freudAdj` (partial function). **adj_symm** = `swapAdj_invol` (the involution lemma above) — wired through `Subtype.ext` because `FreudSimplex` is a subtype. **adj_vertices** = `swapAdj_prefixSet_eq` (theorem). **adj_ne** = `swapAdj_ne_self` (theorem) + `congr_arg Subtype.val`. **`freudenthal_sperner`** is then a one-line application of the abstract `sperner` to this complex.",
+    "mathContext": "**The structure-assembly pattern**: each `CellComplex` field is satisfied by a definition, an instance, or a proved lemma — no axioms remain after the elimination pass. The non-routine creative step is the **construction of `freudAdj`** as a *partial function*: returns `some (swapAdj l, k)` when $0 < k < n$, returns `none` at the boundary $k = 0$ or $k = n$. This 'optional adjacency' encoding is what makes the Freudenthal complex a true cell complex with a boundary, rather than a pure pseudomanifold. The boundary cases are precisely where Sperner's parity argument 'leaks' to give the parity of fully-colored simplices = parity of boundary doors.",
     "significance": "key",
     "relatedConcepts": [
-      "structure assembly with axioms",
+      "structure assembly without axioms",
       "Option-valued adjacency for boundary",
       "Subtype.ext for FreudSimplex equality",
       "freudAdj as partial function"
     ],
     "prerequisites": [
       "FreudSimplex, swapAdj, swapAdj_invol",
-      "all four axioms",
+      "swapAdj_nodup, swapAdj_prefixSet_eq, swapAdj_ne_self (theorems)",
+      "freud_simplex_fintype (instance)",
       "prefixSet_inj",
       "freudAdj definition"
     ]
@@ -132,7 +135,7 @@
   {
     "id": "ann-sperner-mathlib-oq01-main",
     "proofId": "sperner-ndim-mathlib-oq-01",
-    "range": { "startLine": 231, "endLine": 241 },
+    "range": { "startLine": 368, "endLine": 377 },
     "type": "insight",
     "title": "freudenthal_sperner: Sperner's Lemma on the n-Cube",
     "content": "**`freudenthal_sperner`** (final theorem): for the Freudenthal triangulation of $[0,1]^n$ with any coloring $c : \\text{Finset}(\\text{Fin}(n)) \\to \\text{Fin}(n+1)$, if the boundary-door count is *odd*, then $\\exists s$ a fully-colored simplex. The proof is one line: `sperner c (freudenthalCellComplex n) hbdry`, applying the abstract theorem to the constructed cell complex. **This closes OQ-01 affirmatively**: the abstract `CellComplex` framework genuinely captures the Freudenthal triangulation, not just the simpler grid triangulation.",

--- a/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SpernerNDimMathlibOQ01.lean",
     "tags": [
       "combinatorics",
@@ -17,11 +17,11 @@
       "bridge-theorem",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 4,
-    "lineCount": 369,
-    "assumptions": "Four axioms: (1) FreudSimplex n is Fintype (bijects with Equiv.Perm (Fin n)); (2) swapAdj preserves Nodup; (3) prefix sets unchanged at index ≠ k after adjacent swap; (4) adjacent swap produces a different list. All are provable by ~40-line element-level list arguments.",
+    "axiomCount": 0,
+    "lineCount": 377,
+    "assumptions": "None. All four originally-axiomatized swapAdj facts (freud_simplex_fintype, swapAdj_nodup, swapAdj_prefixSet_eq, swapAdj_ne_self) are now proved as private theorems via List.Perm-based arguments and a listToPerm/permList round-trip with Equiv.Perm (Fin n). The freudenthalCellComplex instance is constructed with all CellComplex fields proved (no structure-encoded assumptions).",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -29,12 +29,17 @@
       "sperner_from_triangulation: the abstract Sperner theorem applies to every SpernerTriangulation",
       "boundary_doors_agree: for Sperner colorings, abstract and concrete boundary conditions coincide",
       "FreudSimplex: subtype of nodup lists of Fin n with length n (permutations)",
-      "swapAdj: adjacent transposition (swap positions k-1 and k) with involution lemma proved",
-      "freudenthalCellComplex: concrete CellComplex (Finset (Fin n)) n for the Freudenthal triangulation",
-      "freudenthal_sperner: Sperner's lemma for the Freudenthal complex (proved from abstract sperner + 4 axioms)"
+      "swapAdj: adjacent transposition (swap positions k-1 and k) with swapAdj_invol involution lemma",
+      "swapAdj_perm: swapAdj produces a List.Perm of the original (proved via take/drop split + List.Perm.swap)",
+      "swapAdj_nodup: swapAdj preserves Nodup (theorem, proved from swapAdj_perm.nodup_iff — was axiom 2)",
+      "swapAdj_prefixSet_eq: prefix sets unchanged at index ≠ k (theorem, take casework + Perm.swap — was axiom 3)",
+      "swapAdj_ne_self: swapAdj produces a different list (theorem, Nodup.getElem_inj_iff — was axiom 4)",
+      "listToPerm: noncomputable bijection FreudSimplex n ↔ Equiv.Perm (Fin n) used to derive Fintype (was axiom 1)",
+      "freudenthalCellComplex: concrete CellComplex (Finset (Fin n)) n for the Freudenthal triangulation, all eight fields proved",
+      "freudenthal_sperner: Sperner's lemma for the Freudenthal complex (proved from abstract sperner + 0 axioms)"
     ],
-    "theoremCount": 8,
-    "definitionCount": 5,
+    "theoremCount": 14,
+    "definitionCount": 7,
     "prerequisites": [
       "SpernerNDimMathlib (abstract CellComplex framework)",
       "SpernerNDim (concrete grid triangulation)",
@@ -68,10 +73,10 @@
     ],
     "namespace": "SpernerConcrete",
     "sorries": 0,
-    "axiomCount": 4,
-    "lineCount": 369,
-    "theoremCount": 8,
-    "definitionCount": 5,
+    "axiomCount": 0,
+    "lineCount": 377,
+    "theoremCount": 14,
+    "definitionCount": 7,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerNDimMathlibOQ01.lean"
   },
@@ -79,12 +84,12 @@
     "historicalContext": "**Sperner's lemma** (Emanuel Sperner, *Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes*, Abh. Math. Sem. Univ. Hamburg 6 (1928), 265–272): in any triangulation of an $n$-simplex with a Sperner coloring, an *odd* number of small simplices receive all $n+1$ colors. Sperner's original motivation was a combinatorial proof of **Brouwer's fixed-point theorem** that avoids algebraic topology, and his lemma has remained the simplest path to Brouwer ever since. Modern applications include the **Knaster–Kuratowski–Mazurkiewicz** lemma, **Borsuk–Ulam** via signed Sperner / Tucker, **fair division** (Su's envy-free cake-cutting algorithm, 1999), and **simplicial fixed-point algorithms** in computational economics (Scarf 1967, Eaves 1972, Merrill 1972).\n\nThe **Freudenthal triangulation** of $[0,1]^n$ — discovered by Hans Freudenthal in his work on covering dimension — is the unique triangulation where simplices are indexed by *permutations of the coordinate axes* and vertices by *prefix sets*. It is the workhorse mesh of simplicial fixed-point algorithms because the pivot rule (swap adjacent positions in a permutation) is concrete and combinatorially regular. The parent file `sperner-ndim-mathlib` introduced an **abstract `CellComplex` framework** to capture the door-counting parity argument independently of the underlying triangulation; this file closes the implicit OQ-01 by providing two concrete instances — the existing `SpernerTriangulation` (via a structural projection bridge) and the Freudenthal triangulation (built from scratch in 200 lines), demonstrating that the abstraction is genuinely useful.",
     "problemStatement": "**OQ-01 (from `sperner-ndim-mathlib`)**: which concrete structures instantiate `SpernerAbstract.CellComplex (V : Type) (d : ℕ)` so that the abstract Sperner theorem `SpernerAbstract.sperner` recovers the standard $n$-dimensional Sperner lemma?\n\n**Two instances**:\n\n**(1) Bridge instance** — for every `SpernerNDim.SpernerTriangulation d N`, construct a `CellComplex (Vertex d N) d` by structural projection (forgetting the boundary-specific fields `adj_unique_facet` and `boundary_face`). Show that the abstract `IsFC` and `isDoorAt` predicates definitionally equal their concrete counterparts (`rfl`), and that for Sperner colorings the abstract boundary-door count agrees with the concrete one.\n\n**(2) Freudenthal instance** — construct `freudenthalCellComplex n : CellComplex (Finset (Fin n)) n` where:\n- $\\text{Simplex}$ = `FreudSimplex n` = subtype of nodup lists of $\\text{Fin}(n)$ of length $n$\n- $\\text{vertices}(l, k)$ = $(l.\\text{take } k).\\text{toFinset}$ (prefix set)\n- $\\text{adj}(l, k)$ = if $0 < k < n$ then `some (swapAdj l, k)` else `none`\n\nProve `freudenthal_sperner`: for any coloring $c$, odd boundary-door count implies $\\exists s$ fully-colored. Allow up to 4 axioms about `swapAdj` (Nodup-preservation, prefix-set invariance at $i \\neq k$, distinctness from original).",
     "text": "Closes OQ-01 from sperner-ndim-mathlib by providing two concrete CellComplex instances: a structural-projection bridge from any SpernerTriangulation, and the Freudenthal triangulation of [0,1]^n built from permutation lists and prefix sets.",
-    "proofStrategy": "**Two parts.** **Part I (bridge, 0 axioms)**: define `toAbstractCellComplex` as a record-with-fewer-fields projection. The non-trivial lemma `boundary_doors_agree` is proved by `Finset.congr` on the filter, then `simp` with the bridge equalities + `boundary_door_is_last_face` from the parent. Application of `SpernerAbstract.sperner` is one line. **Part II (Freudenthal, 4 axioms)**: define `FreudSimplex` and `swapAdj`, prove `swapAdj_invol` by `List.ext_getElem` with four `by_cases` branches. Define `freudAdj` as a partial function returning `some` only when $0 < k < n$. Prove `prefixSet_inj` from cardinality of prefix sets. Assemble `freudenthalCellComplex` field-by-field. Three of four axioms (`swapAdj_nodup`, `swapAdj_prefixSet_eq`, `swapAdj_ne_self`) are direct routine list arguments; the fourth (`freud_simplex_fintype`) bijects with `Equiv.Perm (Fin n)` via `List.ofFn`. Final `freudenthal_sperner` is a one-line application of `SpernerAbstract.sperner`.",
+    "proofStrategy": "**Two parts.** **Part I (bridge, 0 axioms)**: define `toAbstractCellComplex` as a record-with-fewer-fields projection. The non-trivial lemma `boundary_doors_agree` is proved by `Finset.congr` on the filter, then `simp` with the bridge equalities + `boundary_door_is_last_face` from the parent. Application of `SpernerAbstract.sperner` is one line. **Part II (Freudenthal, 0 axioms)**: define `FreudSimplex` and `swapAdj`, prove `swapAdj_invol` by `List.ext_getElem` with four `by_cases` branches. Prove `swapAdj_perm` by splitting `l = take(k-1) ++ x :: y :: drop(k+1)` and applying `List.Perm.swap`; this single permutation lemma drives `swapAdj_nodup` (via `nodup_iff`) and the `i > k` branch of `swapAdj_prefixSet_eq` (via `Perm.append_left`). The `i < k` branch of `swapAdj_prefixSet_eq` is literal equality through `take_set_of_le`. Prove `swapAdj_ne_self` from `Nodup.getElem_inj_iff` at the swapped positions. Define `freudAdj` as a partial function returning `some` only when $0 < k < n$. Prove `prefixSet_inj` from cardinality of prefix sets. Build `listToPerm` (using `Equiv.ofBijective` + `Finite.injective_iff_surjective`) for the `freud_simplex_fintype` instance via `Fintype.ofSurjective`. Assemble `freudenthalCellComplex` field-by-field. Final `freudenthal_sperner` is a one-line application of `SpernerAbstract.sperner`.",
     "keyInsights": [
       "**The bridge pattern is 'free' theorem transfer.** When the abstract structure is a *subset* of the concrete structure's fields, the bridge map is a structural projection and the abstract/concrete derived predicates are *definitionally equal* (`rfl`). This makes the abstract Sperner theorem instantly applicable to every existing `SpernerTriangulation` — a one-line proof using `SpernerAbstract.sperner`.",
       "**Freudenthal simplices are permutations, vertices are prefix sets.** The Freudenthal triangulation of $[0,1]^n$ has $n!$ small simplices indexed by permutations $\\sigma \\in S_n$, with vertex $k$ of simplex $\\sigma$ at the lattice point $\\sum_{j < k} e_{\\sigma(j)}$. In `Finset (Fin n)` form this becomes the prefix set $\\{\\sigma(0), \\ldots, \\sigma(k-1)\\}$ — a clean Lean encoding that exposes $|\\text{vertex}_k| = k$ as a one-line cardinality fact, automatically yielding `vertices_injective`.",
       "**Adjacency = adjacent transposition.** Two Freudenthal simplices share a face exactly when their permutations differ by a single adjacent transposition $(k-1, k)$ for some $0 < k < n$. The swap is its own inverse (`swapAdj_invol`), giving `adj_symm` immediately. The boundary cases $k = 0$ and $k = n$ return `none`, encoding the cube's geometric boundary as a *partial-function* adjacency.",
-      "**The four axioms localize technical debt.** `swapAdj_nodup`, `swapAdj_prefixSet_eq`, `swapAdj_ne_self`, and `freud_simplex_fintype` are each provable by routine ~40-line `List.set` + `List.toFinset` casework, with no new mathematical insight. Axiomatizing them keeps the file at 241 lines focused on the cell-complex structure rather than 400+ lines of list-bookkeeping. Status `axiomatized` is honest — the next iteration will close them.",
+      "**One permutation lemma replaces four axioms.** The right factoring is `swapAdj_perm`: `swapAdj l ~ l` as `List.Perm`. From this single fact: (a) `swapAdj_nodup` follows by `Perm.nodup_iff`, (b) the `i > k` branch of `swapAdj_prefixSet_eq` follows by `Perm.append_left` after splitting both lists at index `k-1`, (c) the `i < k` branch is just `take_set_of_le` (literal equality, no permutation needed), (d) `swapAdj_ne_self` is independent — proved by extracting positions `k-1, k` via `Nodup.getElem_inj_iff`. The Fintype instance is then a separate `listToPerm`/`permList` round-trip through `Equiv.Perm (Fin n)`. The original four-axiom formulation localized technical debt; the one-permutation formulation reveals that the debt collapses to a single combinatorial fact about adjacent transpositions.",
       "**Sperner on the n-cube unlocks downstream applications.** The Freudenthal triangulation is the standard mesh in simplicial fixed-point algorithms (Scarf, Eaves, Merrill) — formalizing Sperner on Freudenthal is the *right* abstraction layer for verified Brouwer fixed-point algorithms, KKM-based equilibrium computation, and Su's envy-free cake-cutting. The grid-triangulation case (in `SpernerNDim.lean`) doesn't suffice because the grid simplices aren't indexed by permutations.",
       "**Cardinality witnesses geometric monotonicity.** `prefixSet_inj` exploits the fact that $|\\text{prefix}_k(l)| = k$ when $l$ is nodup. The vertex map is then *strictly increasing* in cardinality, so it's automatically injective. This is the **combinatorial counterpart** of the topological fact that the Freudenthal staircase $\\emptyset \\subset \\{e_{\\sigma(0)}\\} \\subset \\cdots \\subset \\{e_0, \\ldots, e_{n-1}\\}$ is a strictly ascending chain of subsets — the geometric reason Freudenthal triangulations *are* triangulations."
     ],
@@ -103,72 +108,72 @@
       "id": "module-header",
       "title": "Module Header: OQ-01 and the Two Instances",
       "startLine": 1,
-      "endLine": 46,
-      "summary": "Documentation comment posing OQ-01 (concrete CellComplex instances) and outlining the two-part answer: bridge from SpernerTriangulation (0 axioms), Freudenthal triangulation (4 axioms). Lists the four axioms and the proved lemmas.",
+      "endLine": 57,
+      "summary": "Documentation comment posing OQ-01 (concrete CellComplex instances) and outlining the two-part answer: bridge from SpernerTriangulation (0 axioms), Freudenthal triangulation (0 axioms). Itemizes the four originally-axiomatized facts (now all proved as private theorems) with their line citations.",
       "mathContext": "The abstract `CellComplex` framework captures the door-counting parity argument; this file shows the abstraction is witnessed by both an existing concrete structure (via bridge) and a new one (Freudenthal)."
     },
     {
       "id": "part-i-bridge",
       "title": "Part I: SpernerTriangulation → CellComplex Bridge (0 axioms)",
-      "startLine": 51,
-      "endLine": 105,
+      "startLine": 59,
+      "endLine": 113,
       "summary": "toAbstractCellComplex: structural projection. isFC_bridge / isDoorAt_bridge: rfl-equalities. sperner_from_triangulation: one-line application of abstract theorem. boundary_doors_agree: for Sperner colorings, abstract boundary-door count = concrete count restricted to face d.",
       "mathContext": "**The bridge pattern** is the standard idiom for 'every concrete X is also an abstract Y' in Lean: structural projection forgets extra fields, and definitional equality of derived predicates lets `rfl` propagate everywhere."
     },
     {
       "id": "freudsimplex-defs",
       "title": "Part II.A: FreudSimplex and swapAdj Definitions",
-      "startLine": 113,
-      "endLine": 142,
+      "startLine": 115,
+      "endLine": 150,
       "summary": "FreudSimplex n: subtype of nodup lists of Fin n with length n. swapAdj: swap positions k-1 and k via two List.set. swapAdj_length: trivial. swapAdj_invol: swap is its own inverse (List.ext_getElem with 4 by_cases).",
       "mathContext": "Adjacent transpositions are Coxeter generators of $S_n$. The involution lemma is the minimal property needed for the cell complex's `adj_symm` field."
     },
     {
       "id": "axioms",
-      "title": "Part II.B: Four Axioms about swapAdj",
-      "startLine": 144,
-      "endLine": 167,
-      "summary": "Four axioms: (1) FreudSimplex Fintype via Equiv.Perm bijection. (2) swapAdj preserves Nodup. (3) swapAdj prefix sets unchanged at index ≠ k. (4) swapAdj ≠ original list. Each ~40-line list argument deferred for brevity.",
-      "mathContext": "**Localized technical debt**: each axiom is provable by routine `List.set` + `List.toFinset` casework. Axiomatizing keeps the cell-complex construction at 241 readable lines."
+      "title": "Part II.B: List-Permutation Helpers (swapAdj_eq_split, swapAdj_perm)",
+      "startLine": 152,
+      "endLine": 191,
+      "summary": "swapAdj_eq_split: rewrites swapAdj l as `take(k-1) ++ l[k] :: l[k-1] :: drop(k+1)`, exposing the swap as a List.Perm.swap inside an append. swapAdj_perm: swapAdj l ~ l as List.Perm, derived by combining swapAdj_eq_split with `List.Perm.append_left` and `List.Perm.swap`. This single permutation lemma is the workhorse that drives swapAdj_nodup and the i > k branch of swapAdj_prefixSet_eq.",
+      "mathContext": "**The right factoring**: an adjacent swap is a permutation of the underlying list; once that is captured as `List.Perm`, three of the original four axioms collapse to one-line corollaries (Perm.nodup_iff, Perm.append_left). The remaining axiom-4-now-theorem (swapAdj_ne_self) is independent — it's a getElem-level distinctness, not a permutation fact."
     },
     {
       "id": "freudadj-and-prefix-inj",
-      "title": "Part II.C: freudAdj Partial Function and prefixSet_inj",
-      "startLine": 168,
-      "endLine": 192,
-      "summary": "freudAdj: returns some(swapAdj l, k) when 0 < k < n, else none. prefixSet_inj: prefix sets are injective in k by cardinality (from prefixSet_card_eq).",
-      "mathContext": "The 'optional adjacency' encoding represents the cube's geometric boundary. Cardinality argument for injectivity exploits the strictly ascending nature of prefix sets on a nodup list."
+      "title": "Part II.C: Eliminated Axioms Are Now Theorems (and the listToPerm Round-Trip)",
+      "startLine": 193,
+      "endLine": 302,
+      "summary": "swapAdj_nodup: Nodup-preservation, proved from swapAdj_perm.nodup_iff. swapAdj_prefixSet_eq: prefix sets unchanged at i ≠ k, proved by splitting i < k (literal equality via take_set_of_le) vs i > k (List.Perm.swap on the swapped pair after take/drop split). swapAdj_ne_self: swapAdj produces a different list, proved from Nodup.getElem_inj_iff at the swapped positions. listToPermFun / listToPermFun_injective / listToPerm: noncomputable round-trip from a length-n nodup list to Equiv.Perm (Fin n) via Equiv.ofBijective + Finite.injective_iff_surjective. freud_simplex_fintype: instance Fintype (FreudSimplex n) via Fintype.ofSurjective from listToPerm and FreudenthalAdjacency.permList.",
+      "mathContext": "**Closing the four axioms.** The original axiomatization parked four list-bookkeeping facts to keep the cell-complex construction lean. This section discharges all four with a single permutation lemma (swapAdj_perm), one direct casework (swapAdj_ne_self), and the listToPerm round-trip (freud_simplex_fintype). The Equiv.Perm bridge uses the standard injection-implies-surjection trick on a finite type."
     },
     {
       "id": "freudenthal-cellcomplex",
-      "title": "Part II.D: freudenthalCellComplex Assembly",
-      "startLine": 193,
-      "endLine": 229,
-      "summary": "Assembles the eight CellComplex fields: Simplex, decidableEq, fintype (axiom 1), vertices (prefix sets), vertices_injective (prefixSet_inj), adj (freudAdj), adj_symm (swapAdj_invol), adj_vertices (axiom 3), adj_ne (axiom 4).",
-      "mathContext": "The structure-assembly pattern: each field is an axiom, a routine lemma, or `inferInstance`. Subtype.ext bridges FreudSimplex equality through the underlying list."
+      "title": "Part II.D: freudAdj, prefixSet_inj, and freudenthalCellComplex Assembly",
+      "startLine": 304,
+      "endLine": 366,
+      "summary": "freudAdj: returns some(swapAdj l, k) when 0 < k < n, else none — the 'optional adjacency' that encodes the cube's geometric boundary. prefixSet_inj: prefix sets are injective in k by cardinality (from prefixSet_card_eq). freudenthalCellComplex: assembles the eight CellComplex fields — Simplex (FreudSimplex), decidableEq (inferInstance), fintype (freud_simplex_fintype), vertices (prefix sets), vertices_injective (prefixSet_inj), adj (freudAdj), adj_symm (swapAdj_invol), adj_vertices (swapAdj_prefixSet_eq), adj_ne (swapAdj_ne_self).",
+      "mathContext": "The structure-assembly pattern: each field is a routine lemma, an instance, or `inferInstance`. Subtype.ext bridges FreudSimplex equality through the underlying list. With all helper lemmas proved, the assembly is purely mechanical wiring."
     },
     {
       "id": "freudenthal-sperner",
       "title": "Part II.E: freudenthal_sperner (Main Theorem)",
-      "startLine": 231,
-      "endLine": 237,
+      "startLine": 368,
+      "endLine": 373,
       "summary": "freudenthal_sperner: Sperner's lemma for the Freudenthal triangulation of [0,1]^n. One-line proof: apply SpernerAbstract.sperner to freudenthalCellComplex.",
       "mathContext": "**Sperner on the n-cube**: the combinatorial heart of Brouwer's fixed-point theorem (via KKM), Borsuk–Ulam (via signed Sperner / Tucker), and Su's envy-free cake-cutting algorithm."
     },
     {
       "id": "namespace-end",
       "title": "Namespace End",
-      "startLine": 239,
-      "endLine": 241,
+      "startLine": 375,
+      "endLine": 377,
       "summary": "Closes the FreudenthalInstance section and SpernerConcrete namespace.",
-      "mathContext": "8 theorems, 5 definitions, 4 axioms, 0 sorries, 241 lines — answers OQ-01 with two concrete CellComplex instances."
+      "mathContext": "14 theorems, 7 definitions, 0 axioms, 0 sorries, 377 lines — answers OQ-01 with two concrete CellComplex instances, all originally-axiomatized facts now proved."
     }
   ],
   "conclusion": {
-    "summary": "Closes OQ-01 from `sperner-ndim-mathlib` with two concrete `CellComplex` instances. **Part I (bridge)**: `toAbstractCellComplex` projects every existing `SpernerTriangulation` to a `CellComplex`, with abstract and concrete predicates `rfl`-equal, so `SpernerAbstract.sperner` applies directly. **Part II (Freudenthal)**: 200 lines of construction yield `freudenthalCellComplex n : CellComplex (Finset (Fin n)) n` with permutation-list simplices and prefix-set vertices. `freudenthal_sperner` is a one-line corollary. 8 theorems, 5 definitions, 4 axioms, 0 sorries — the four axioms are routine list-set arguments deferred for brevity, with a precise specification in the file's docstring.",
+    "summary": "Closes OQ-01 from `sperner-ndim-mathlib` with two concrete `CellComplex` instances and zero remaining axioms. **Part I (bridge)**: `toAbstractCellComplex` projects every existing `SpernerTriangulation` to a `CellComplex`, with abstract and concrete predicates `rfl`-equal, so `SpernerAbstract.sperner` applies directly. **Part II (Freudenthal)**: yields `freudenthalCellComplex n : CellComplex (Finset (Fin n)) n` with permutation-list simplices and prefix-set vertices. `freudenthal_sperner` is a one-line corollary. 14 theorems, 7 definitions, 0 axioms, 0 sorries, 377 lines — all four originally-axiomatized swapAdj facts are now proved as private theorems, three of them via a single `List.Perm` lemma (`swapAdj_perm`), and the Fintype instance via a `listToPerm`/`permList` round-trip with `Equiv.Perm (Fin n)`.",
     "implications": "**The Freudenthal triangulation is the workhorse mesh of simplicial fixed-point algorithms** (Scarf 1967, Eaves 1972, Merrill 1972, van der Laan–Talman 1979) — the entire computational-economics literature on Walrasian-equilibrium computation, market-clearing, and KKT-system solving uses Freudenthal triangulations or close variants. Formalizing Sperner's lemma at this abstraction level is therefore the **correct prerequisite** for any verified Brouwer / Kakutani fixed-point algorithm, KKM-based existence proof for Nash equilibria, or Su-style envy-free fair-division algorithm. The bridge instance also gives a clean refactor path for the existing `SpernerNDim` infrastructure: future theorems can target the abstract `CellComplex` once and apply to every concrete triangulation. **Pedagogically**, the file demonstrates a useful **two-instance pattern** for closing 'is this abstraction non-vacuous' open questions: pair a *trivial* bridge instance (showing the abstraction subsumes existing structures) with a *substantive new* instance (showing the abstraction extends beyond them). Both are needed: the bridge proves no expressive power is lost, the new instance proves new expressive power is gained.",
     "openQuestions": [
-      "Close the four `swapAdj` axioms by ~160 lines of routine `List.set` / `List.toFinset` casework. Each axiom has a clear ~40-line element-level proof; the technical debt is localized but the file size grows. **Estimated effort**: one focused PR.",
+      "**Closed.** The four `swapAdj` axioms (`swapAdj_nodup`, `swapAdj_prefixSet_eq`, `swapAdj_ne_self`, `freud_simplex_fintype`) are now proved as private theorems via `swapAdj_perm` + `Nodup.getElem_inj_iff` + a `listToPerm`/`permList` round-trip. Total cost: ~136 added lines (file 241 → 377), much less than the 400+ originally projected because the `List.Perm` factoring discharges three of the four axioms from one shared lemma.",
       "Extend the Freudenthal `CellComplex` to a **simplicial fixed-point algorithm**: prove that an exhaustive search through Freudenthal simplices terminates with a fully-colored simplex (the constructive content of Sperner). This is the **Scarf algorithm** in disguise — formalizing it would give the first verified Brouwer-via-Sperner.",
       "Build the **Freudenthal CellComplex with the cardinality coloring** $c(S) = |S|$. Does this give an *odd* boundary-door count for some natural boundary condition (e.g., the $n$-simplex face)? If yes, $\\exists$ a fully-colored Freudenthal simplex by `freudenthal_sperner` — but does this simplex have a natural geometric interpretation?",
       "Generalize the `CellComplex` framework to **signed cell complexes** (orientations on $d$-cells), enabling formalization of **Tucker's lemma** and the **Borsuk–Ulam theorem** as sibling Sperner-style parity arguments.",
@@ -250,7 +255,7 @@
   "openQuestions": [
     {
       "id": "sperner-ndim-mathlib-oq-01-oq-01",
-      "question": "Can swapAdj_nodup, swapAdj_prefixSet_eq, and swapAdj_ne_self be proved without axioms using Mathlib's List.Perm infrastructure?",
+      "question": "ANSWERED YES (closed in this entry, 2026-05-07): swapAdj_nodup, swapAdj_prefixSet_eq, and swapAdj_ne_self are proved without axioms. The `List.Perm` infrastructure (List.Perm.swap, Perm.append_left, Perm.nodup_iff) handles the first two; swapAdj_ne_self is independent (Nodup.getElem_inj_iff). All four originally-axiomatized facts now live as private theorems.",
       "significance": "medium"
     },
     {


### PR DESCRIPTION
## Summary

Pure metadata + docstring reconciliation. The four originally-axiomatized swapAdj facts (`freud_simplex_fintype`, `swapAdj_nodup`, `swapAdj_prefixSet_eq`, `swapAdj_ne_self`) were eliminated as private theorems in earlier work, but the gallery entry for `sperner-ndim-mathlib-oq-01` still claimed `status: axiomatized`, `badge: axiom`, `axiomCount: 4`.

The Lean file itself has 0 axioms, 0 sorries, and 377 lines on `origin/main` — no Lean code changes are introduced here.

## Drift fixed

| Field | Before | After |
|---|---|---|
| `meta.status` | `axiomatized` | `verified` |
| `meta.badge` | `axiom` | `original` |
| `meta.axiomCount` (and `leanFile.axiomCount`) | 4 | 0 |
| `meta.theoremCount` (and `leanFile.theoremCount`) | 8 | 14 |
| `meta.definitionCount` (and `leanFile.definitionCount`) | 5 | 7 |
| `meta.lineCount` (and `leanFile.lineCount`) | 369 | 377 |
| `meta.assumptions` | "Four axioms..." | "None. All four ... now proved..." |
| Lean docstring lines 22-37 | "Part II: Freudenthal CellComplex (4 axioms) ... Four facts are axiomatized" | "Part II: Freudenthal CellComplex (0 axioms, fully proved) ... Four facts (originally axiomatized, all eliminated as theorems)" with line citations |

The 8 sections in `meta.sections` were also re-ranged from the 241-line snapshot they came from to the current 377-line file. Two sections were repurposed (IDs kept stable for link compatibility):

- `axioms` → "Part II.B: List-Permutation Helpers (swapAdj_eq_split, swapAdj_perm)"
- `freudadj-and-prefix-inj` → "Part II.C: Eliminated Axioms Are Now Theorems (and the listToPerm Round-Trip)" (now covers the entire eliminated-axiom area + listToPerm machinery)

The 7 annotations in `annotations.json` had their ranges shifted (+8 from the docstring growth, plus the section consolidation), and three of them had content drift fixed:

- `ann-...-context` removed "Total: 0 sorries, 4 axioms" claim
- `ann-...-axioms` rewritten as "From Four Axioms to Four Theorems: One Permutation Lemma Does Three of Them" — explains how `swapAdj_perm` discharges three of the four originally-axiomatized facts via Mathlib's existing `List.Perm` API. The old text "Status integrity: meta.json correctly reports axiomatized / 4 axioms / badge axiom" is removed (it became false after the elimination work)
- `ann-...-cellcomplex` removes per-field "axiom 1", "axiom 3", "axiom 4" labels and replaces them with theorem citations

`overview.proofStrategy` and `overview.keyInsights[3]` are rewritten to describe the actual proof method (one `List.Perm` lemma + one `getElem` distinctness + one `Equiv.Perm` round-trip) rather than the original four-axiom localized-technical-debt framing. `conclusion.openQuestions[0]` and `openQuestions[sperner-ndim-mathlib-oq-01-oq-01]` are marked closed/answered.

## Verification

- [x] `jq empty` clean on both JSON files.
- [x] `wc -l proofs/Proofs/SpernerNDimMathlibOQ01.lean` returns 377.
- [x] `grep -c "^axiom "` returns 0.
- [x] Decl counts match new meta values: 14 theorems/lemmas, 7 defs, 0 axioms.
- [x] No Lean code changes — only docstring comment block at lines 22-37 was rewritten (now 22-50). The file compiled on origin/main as of `fb31005` (last untouched origin/main of OQ-01 files).
- [ ] Docker build attempted but OOM-killed during Mathlib dependency clone phase (multi-agent contention). The Lean diff is comment-only so there is no compile-error risk; relying on the existing main-branch build.

## Scope

- **Not OQ-02 work.** researcher-4 had `sperner-ndim-mathlib-oq-02` claimed, but the OQ-02 axiom-elimination is currently blocked on PR #16308 (researcher-11). This PR addresses the dependency proof's gallery drift, which is independent and untouched by any open PR.
- **Not a research advance.** The axiom-elimination work itself was already on `origin/main` (PR #16235 / earlier sessions). This PR only updates meta/annotations/docstring to match.
- **No conflicts.** No open PR touches `proofs/Proofs/SpernerNDimMathlibOQ01.lean`, `src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json`, or `src/data/proofs/sperner-ndim-mathlib-oq-01/annotations.json` (verified via `gh pr list` + `gh pr view <#> --json files`).

## Test plan

- [x] `jq empty` clean on both JSON files
- [x] `wc -l` confirms 377 lines, matching `lineCount: 377`
- [x] `grep -c "^axiom "` returns 0, matching `axiomCount: 0`
- [x] Decl counts match: 14 theorems, 7 definitions
- [x] No Lean code changes — only docstring + JSON metadata
- [ ] Build verification — will succeed via deployer's batch build since the Lean diff is comment-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)