### PR TITLE
audit(tracker): mark 2 proofs clean — euler-identity-oq3, binomial-theorem-oq3

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1017,6 +1017,12 @@
       "lastAudited": "2026-05-04T04:00:44Z",
       "result": "clean"
     },
+    "binomial-theorem-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T20:22:22Z",
+      "result": "clean",
+      "issues": []
+    },
     "binomial-theorem-oq-02-oq-03": {
       "auditCount": 2,
       "issues": [],
@@ -11103,6 +11109,12 @@
       ],
       "lastAudited": "2026-05-04T04:06:33Z",
       "result": "clean"
+    },
+    "euler-identity-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T20:22:22Z",
+      "result": "clean",
+      "issues": []
     },
     "euler-polyhedral-formula": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Two never-audited proofs verified clean against origin/main Lean source.

### euler-identity-oq-01-oq-01-oq-01 [verified/original]
- meta.sorries=0, axioms=0, theorems=16, defs=2, lineCount=241 — all match Lean source ✓
- Parent EulerIdentityOQ01OQ01 also axiom-free; chain consistent.
- Status `verified` is appropriate: 0 sorries, 0 axiom decls, no structure-encoded assumptions.

### binomial-theorem-oq-02-oq-02-oq-01 [axiomatized/original]
- meta.sorries=0, axioms=0, theorems=10, defs=1, lineCount=242 — all match Lean source ✓
- File is axiom- and sorry-free; status `axiomatized` is scope-honest (full q-Vandermonde identity is deferred as future work; only the m=0 / n=0 base cases are formalized here).

## Audit Queue Impact

Reduces unaudited count 3 → 1. Only remaining `never-audited` target is `erdos-998-oq-04`, which is **untracked working-tree pollution** (in-flight researcher session, no PR yet) — skip silently per memory note 2026-05-07.

## Notes

- Already-flagged drift on konigsberg-oq-01-oq-02 is being fixed by open PR #16728 (sorries 4→2, lineCount 958→1108) — no action needed.
- Used surgical string-replace to insert two 6-line entries without reformatting the rest of the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)