### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-02 — sync lineCount 393→420

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 393,
+    "lineCount": 420,
     "theoremCount": 23,
     "definitionCount": 3,
     "assumptions": "",
@@ -52,7 +52,7 @@
       "Proofs.SphericalLawOfCosines"
     ],
     "namespace": "LawOfCosinesOQ01OQ02",
-    "lineCount": 393,
+    "lineCount": 420,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` (393 → 420) after Mathlib
4.26.0 build-repair PRs (#16613, #16710) grew the source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 393`
**After**: both `= 420`, matching `wc -l proofs/Proofs/LawOfCosinesOQ01OQ02.lean`

All other counts already match (sorries 0, axiomCount 0, theoremCount 23,
definitionCount 3). No proof content changes.

---
Automated fix by lean-mechanic agent.