### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): OBSERVE → ORIENT

### DIFF
--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
@@ -1,0 +1,137 @@
+# Knowledge Base: binomial-theorem-oq-02-oq-01-oq-01-oq-03
+
+**Problem**: Multinomial CLT in Lean — does
+`(Xᵢ - npᵢ) / √(npᵢ(1−pᵢ)) → N(0, 1)` (in distribution) for the i-th
+coordinate of `(X₁, …, Xₖ) ~ Multinomial(n, p₁, …, pₖ)` as `n → ∞`?
+
+---
+
+## Session 2026-05-07 (Session 1, researcher-8) — OBSERVE → ORIENT
+
+**Mode**: FRESH (no prior research dir; the problem JSON exists)
+**Outcome**: Inventoried the existing scaffolding, identified a clean
+two-step reduction, and recorded the Mathlib gap that determines whether
+the proof is mostly mechanical or requires new infrastructure.
+
+### What's Already Done in the Gallery
+
+The structural reduction `multinomial → binomial` is FORMALIZED in
+`proofs/Proofs/BinomialTheoremOQ02OQ01OQ02.lean`:
+
+- `multinomial_marginal_pgf` (line 96): the marginal PGF
+  `∑ₖ P(X=k) · t^{k(i₀)} = (p(i₀)·t + (1−p(i₀)))^n`.
+- `multinomial_marginal_pgf_eq_binomial` (line 133): identifies the PGF
+  with the binomial PGF.
+- `multinomial_marginal_pmf` (line 167): extracts the marginal PMF
+  `P(X_{i₀} = j) = C(n,j)·p^j·(1−p)^{n−j}`.
+
+So the marginal of `Multinomial(n, p₁, …, pₖ)` along coordinate `i₀` is
+**provably** `Binomial(n, p_{i₀})` — this part of OQ-03 is solved.
+
+### What This Problem Reduces To
+
+Given the marginal-is-binomial result, the CLT for the i-th coordinate
+reduces to **the Binomial CLT (de Moivre–Laplace, 1733/1812)**:
+
+> If `Y_n ~ Binomial(n, p)` with `0 < p < 1`, then
+> `(Y_n − np) / √(np(1−p)) → N(0, 1)` in distribution as `n → ∞`.
+
+So the Mathlib question is: is the binomial CLT — or a path to it —
+already available?
+
+### Mathlib / Local Infrastructure Found
+
+#### General CLT (axiomatized in this repo)
+
+`proofs/Proofs/CentralLimitTheorem.lean:375` defines a general
+`central_limit_theorem` for an arbitrary probability measure `μ` on `ℝ`
+with finite mean, variance, and third absolute moment. The proof reduces
+to a `clt_general_case_axiom` that connects general distributions to the
+standardised case proved in `charFun_converges_to_gaussian`.
+
+**Form**: `Filter.Tendsto (fun n => (charFun μ ((t − n·mean) / (√var · √n)))^n)
+                 atTop (nhds (Complex.exp (−t²/2)))`.
+
+This is a **characteristic-function** statement, not a direct
+distribution-convergence statement, but is sufficient to extract weak
+convergence (Lévy's continuity theorem).
+
+#### `Mathlib.Probability.Distributions.Binomial`
+
+The PMF and `binomialMeasure` are defined; no CLT is named.
+
+#### Mathlib's i.i.d. CLT
+
+`Mathlib.Probability.CentralLimitTheorem` provides Lindeberg–Lévy–style
+CLT scaffolding. The key ingredient is `ProbabilityTheory.tendsto_clt`
+or the equivalent for sums of i.i.d. variables.
+
+The Bernoulli-sum representation
+  `Y_n = Σⱼ₌₁ⁿ B_j`,  `B_j ~ Bernoulli(p)` i.i.d.
+makes `(Y_n − np)/√(np(1−p)) = (Σⱼ B_j − n·E[B])/(√Var[B] · √n)`,
+which is exactly the form Mathlib's i.i.d. CLT gives.
+
+**Likely path**: apply Mathlib's i.i.d. CLT to Bernoulli summands. The
+representation step (binomial = sum of i.i.d. Bernoullis) may need to be
+formalised — this is folklore in probability but I have not yet
+confirmed a named Mathlib lemma.
+
+### Recommended Decomposition
+
+Mirror the Session-2 approach used for `birthday-problem-oq-03-oq-01-oq-02-oq-01`:
+break the target into named sublemmas and tackle the easy ones first.
+
+1. **Sublemma A (mostly mechanical)**: `marginal-is-Binomial`.
+   - Already in `BinomialTheoremOQ02OQ01OQ02.lean` as
+     `multinomial_marginal_pmf`. Re-export or wrap in the precise form
+     the CLT statement consumes.
+
+2. **Sublemma B (Mathlib lookup)**: `Binomial = ∑ Bernoulli i.i.d.`.
+   - Look for an existing Mathlib statement; if none, build it directly
+     using the explicit i.i.d. construction (Mathlib has product
+     measures and i.i.d. samples).
+
+3. **Sublemma C (Mathlib application)**: i.i.d. CLT to Bernoulli.
+   - Given Mathlib's i.i.d. CLT, plug in the Bernoulli case.
+   - The third absolute moment is finite (Bernoulli is bounded), so the
+     general CLT preconditions are trivially satisfied.
+
+4. **Sublemma D (assembly)**: combine A + B + C → marginal CLT.
+
+### Risks / Open Items
+
+- **Probability spaces parameterised by n**: standard formalisation
+  headache (the sample space is `Fin n → {0,1}` for a different `n` per
+  iteration). Mathlib handles this with `Filter.Tendsto` over the index
+  `n` plus `Pi.measureTheory`-style infinite product measures, but this
+  is non-trivial wiring. This is the most likely place for substantial
+  Lean work.
+
+- **Vector-valued joint CLT (out of scope for this OQ)**: requires
+  Cramér–Wold (linear-combination characterisation of multivariate
+  weak convergence). Joint multinomial CLT is the next OQ in the chain
+  and is intentionally deferred.
+
+### Next Action (ORIENT → ACT)
+
+In a future session:
+
+1. Confirm whether Mathlib has a named binomial CLT or i.i.d. CLT in the
+   exact form required (read `Mathlib.Probability.CentralLimitTheorem`
+   and the binomial section).
+2. Scaffold `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with:
+   - `import Proofs.BinomialTheoremOQ02OQ01OQ02`
+   - `import Mathlib.Probability.CentralLimitTheorem`
+   - The marginal-CLT statement as a theorem.
+   - At minimum, an axiomatised version that names the gap, plus the
+     reduction lemmas A and D as fully proved theorems.
+3. If Mathlib's i.i.d. CLT is directly applicable, complete the proof.
+   Otherwise, axiomatise sublemma C and ship A + B + D, isolating the
+   Mathlib gap to a single statement (cf. the
+   `birthday-problem-oq-03-oq-01-oq-02-oq-01` Lemma C pattern).
+
+---
+
+## Dead Ends
+
+- None yet.

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -1,0 +1,49 @@
+# Research State: binomial-theorem-oq-02-oq-01-oq-01-oq-03
+
+## Current State
+**Phase**: ORIENT (advanced from OBSERVE this session)
+**Path**: full
+**Since**: 2026-05-07
+**Last Updated**: 2026-05-07
+**Iteration**: 1
+
+## Current Focus
+Reduce the marginal Multinomial CLT to the Binomial CLT (de Moivre–Laplace)
+via the already-formalised `multinomial_marginal_pmf` and Mathlib's i.i.d.
+CLT applied to the Bernoulli-sum representation of `Binomial(n, p)`.
+
+## Active Approach
+Decomposition (see knowledge.md for details):
+- **Sublemma A**: marginal-is-Binomial (DONE in `BinomialTheoremOQ02OQ01OQ02.lean`).
+- **Sublemma B**: `Binomial = ∑ Bernoulli i.i.d.` (Mathlib lookup needed).
+- **Sublemma C**: i.i.d. CLT to Bernoulli (likely a Mathlib one-liner; the
+  genuine Mathlib gap if missing).
+- **Sublemma D**: assembly A + B + C → marginal CLT.
+
+## Attempt Count
+- Total attempts: 1 (this session)
+- Approaches tried: 1 (decomposition path documented; no Lean code yet)
+
+## Blockers
+- Local Docker build has limited memory (~7.65 GiB), making large
+  Mathlib-dependent files risky to verify locally. CI is the ground truth.
+- Mathlib's i.i.d. CLT availability in v4.26.0 needs concrete confirmation
+  before scaffolding the new file.
+
+## Next Action
+**ACT — scaffold new Lean file** in a future session:
+1. Confirm Mathlib's i.i.d. CLT signature.
+2. Create `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with the
+   marginal-CLT statement and sublemmas A + D as fully proved theorems.
+3. If Mathlib's i.i.d. CLT applies directly, complete sublemma C.
+   Otherwise, axiomatise sublemma C and isolate the Mathlib gap.
+
+## References
+- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ02.lean:167` —
+  `multinomial_marginal_pmf` (sublemma A, already proved).
+- `proofs/Proofs/CentralLimitTheorem.lean:375` — local general CLT
+  (axiomatised at the standardisation step; characteristic-function form).
+- Mathlib: `Mathlib.Probability.Distributions.Binomial` — PMF only,
+  no CLT.
+- Mathlib: `Mathlib.Probability.CentralLimitTheorem` — i.i.d. CLT
+  scaffolding (signature to be verified).

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -34,16 +34,18 @@
     "goal": "Phase-2: produce `Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with (a) a precise Lean statement of the marginal CLT for the i-th coordinate of Multinomial(n, p₁,…,pₖ), (b) either a proof via Mathlib's `ProbabilityTheory.iid_central_limit_theorem` applied to the indicator variables Yⱼ = 𝟙[trial j → outcome i] (which are Bernoulli(pᵢ) i.i.d.), or an axiomatized statement with full proof sketch, and (c) a coordinate-free version using Cramér-Wold for the joint vector CLT."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-07T19:20:00.000Z",
+    "phase": "ORIENT",
+    "since": "2026-05-07T20:30:00.000Z",
     "iteration": 1,
-    "focus": "Phase-1 observation. The multinomial-to-binomial-marginal reduction is FORMALIZED in `Proofs/BinomialTheoremOQ02OQ01OQ02.lean`. The remaining content of OQ-02-OQ-01-OQ-01-OQ-03 is to combine that with a Lean-stated binomial CLT (which is standard but not yet a named theorem of Mathlib in the form we need).",
-    "blockers": [],
-    "nextAction": "Phase 2 (ORIENT): inventory Mathlib's CLT infrastructure (`Mathlib.Probability.CentralLimitTheorem`, `tendsto_central_limit_lemma`, characteristic-function tools). Decide whether the binomial CLT can be EXTRACTED via the Bernoulli-sum representation Xⱼ = ∑ᵢ₌₁ⁿ Bᵢⱼ where Bᵢⱼ ~ Bernoulli(pⱼ) i.i.d. Phase 3 (Lean): scaffold `Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with statement + proof sketch.",
+    "focus": "Phase-2 orientation: decomposition (A/B/C/D) recorded in research/problems/<slug>/knowledge.md. Sublemma A is DONE in BinomialTheoremOQ02OQ01OQ02.lean (`multinomial_marginal_pmf`). Next ACT session: confirm Mathlib's i.i.d. CLT signature and scaffold the new Lean file.",
+    "blockers": [
+      "Local Docker build memory is ~7.65 GiB — risky for a new Mathlib-dependent file. CI verification only."
+    ],
+    "nextAction": "Phase 3 (ACT) in a future session: scaffold `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with sublemma A re-export, the marginal-CLT statement, and either a full proof via Mathlib's i.i.d. CLT applied to the Bernoulli-sum representation or a one-axiom isolation (axiomatise sublemma C only).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {


### PR DESCRIPTION
## Summary

Phase advance for the new "Multinomial CLT" open question
`binomial-theorem-oq-02-oq-01-oq-01-oq-03`. The pool JSON existed but
there was no `research/problems/<slug>/` directory.

## What changed

- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md` (new)
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md` (new)
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json`:
  phase OBSERVE → ORIENT; iteration 0 → 1.

No Lean code changes in this PR.

## Key Finding

Sublemma A (marginal-is-Binomial) is **already proved** in
`proofs/Proofs/BinomialTheoremOQ02OQ01OQ02.lean:167` (`multinomial_marginal_pmf`).
The marginal CLT therefore reduces to the **de Moivre–Laplace binomial
CLT**, attackable via the Bernoulli-sum representation `Y_n = Σⱼ Bernoulli(p)`
i.i.d. + Mathlib's i.i.d. CLT.

## Recommended Decomposition (for the next ACT session)

- **A** marginal-is-Binomial — DONE.
- **B** `Binomial = ∑ Bernoulli` i.i.d. — Mathlib lookup.
- **C** i.i.d. CLT applied to Bernoulli — likely a Mathlib one-liner; the
  genuine Mathlib gap if missing.
- **D** assembly A + B + C → marginal CLT.

This pattern mirrors the successful Session 2 reframing for
`birthday-problem-oq-03-oq-01-oq-02-oq-01` (single isolated axiom for
the Mathlib gap).

## Test plan

- [ ] No code changes; CI smoke-tests should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)