### PR TITLE
research(liouville-theorem-oq-04): S10 discharge bridge ingredient (1) + fix Lean 4.26 drift

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ04.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ04.lean
@@ -187,7 +187,8 @@ theorem padicNorm_poly_eval_bound (f : ℤ[X]) (r s : ℤ) (hs : s ≠ 0)
     exact_mod_cast hs'
   have hHdpos : (0 : ℚ) < max (r.natAbs : ℚ) (s.natAbs : ℚ) ^ f.natDegree := pow_pos hHpos_q _
   have hxpos : (0 : ℚ) < padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ) / s)) :=
-    padicNorm.pos heval
+    -- Lean 4.26: `padicNorm.pos` removed; combine `nonneg` and `nonzero`.
+    (padicNorm.nonneg _).lt_of_ne (Ne.symm <| padicNorm.nonzero heval)
   refine ⟨padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ) / s)) *
     max (r.natAbs : ℚ) (s.natAbs : ℚ) ^ f.natDegree, mul_pos hxpos hHdpos, ?_⟩
   have hne : max (r.natAbs : ℚ) (s.natAbs : ℚ) ^ f.natDegree ≠ 0 := ne_of_gt hHdpos
@@ -226,6 +227,55 @@ theorem isPadicLiouville_forall (β : ℚ_[p]) (h : IsPadicLiouville p β) :
   fun n => let ⟨r, s, hs, _, _, hpos, happrox⟩ := h n; ⟨r, s, hs, hpos, happrox⟩
 
 /-! ═══════════════════════════════════════════════════════════════════════════
+PART IV.5: NORM TRANSPORT BETWEEN ℚ AND ℚ_[p]
+Discharges ingredient (1) of the original bridge axiom: rational-embedding norm
+compatibility. Built on Mathlib's `padicNormE.eq_padicNorm`.
+═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Norm Compatibility on ℚ**: For q : ℚ, the ℚ_[p] norm of (q : ℚ_[p]) equals
+    the rational p-adic norm padicNorm p q.
+
+    This is `padicNormE.eq_padicNorm` from Mathlib.NumberTheory.Padics.PadicNumbers,
+    re-exposed in our namespace. Discharges ingredient (1) of the original bridge:
+    `‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q`. -/
+theorem norm_rat_eq_padicNorm (q : ℚ) : ‖((q : ℚ_[p]))‖ = padicNorm p q :=
+  -- In v4.26 Mathlib, this lemma lives in namespace `Padic` (was `padicNormE` historically).
+  Padic.eq_padicNorm q
+
+/-- **Polynomial Evaluation Cast**: For f : ℤ[X] and q : ℚ, evaluating f at
+    (q : ℚ_[p]) (after embedding integer coefficients into ℚ_[p]) equals embedding
+    the rational evaluation. Follows from `Polynomial.aeval_algHom_apply` applied to
+    the ℤ-algebra hom `(Rat.castHom ℚ_[p]).toIntAlgHom : ℚ →ₐ[ℤ] ℚ_[p]`. -/
+theorem padic_eval_int_poly_cast (f : ℤ[X]) (q : ℚ) :
+    (f.map (algebraMap ℤ ℚ_[p])).eval ((q : ℚ_[p])) =
+      (((f.map (algebraMap ℤ ℚ)).eval q : ℚ) : ℚ_[p]) := by
+  -- Recast both sides through aeval over ℤ[X]
+  have h_pp : (f.map (algebraMap ℤ ℚ_[p])).eval ((q : ℚ_[p])) =
+      Polynomial.aeval ((q : ℚ_[p])) f := by
+    rw [Polynomial.aeval_def, ← Polynomial.eval_map]
+  have h_q : (f.map (algebraMap ℤ ℚ)).eval q = Polynomial.aeval q f := by
+    rw [Polynomial.aeval_def, ← Polynomial.eval_map]
+  rw [h_pp, h_q]
+  -- Apply aeval_algHom_apply with the ℤ-algHom Rat.castHom : ℚ →ₐ[ℤ] ℚ_[p]
+  have happly : Polynomial.aeval ((q : ℚ_[p])) f =
+      (Rat.castHom ℚ_[p]).toIntAlgHom (Polynomial.aeval q f) := by
+    have := Polynomial.aeval_algHom_apply (R := ℤ) (Rat.castHom ℚ_[p]).toIntAlgHom q f
+    convert this using 2
+  rw [happly]
+  rfl
+
+/-- **Integer Polynomial Norm Transport**: For f : ℤ[X] and q : ℚ, the ℚ_[p] norm of
+    the p-adic evaluation equals the rational p-adic norm of the rational evaluation.
+    Combines `padic_eval_int_poly_cast` with `norm_rat_eq_padicNorm`.
+
+    This discharges the rational-embedding-norm half of the original bridge axiom,
+    reducing the residual obstruction to the cofactor evaluation bound only. -/
+theorem padic_norm_int_poly_eval (f : ℤ[X]) (q : ℚ) :
+    ‖(f.map (algebraMap ℤ ℚ_[p])).eval ((q : ℚ_[p]))‖ =
+      padicNorm p ((f.map (algebraMap ℤ ℚ)).eval q) := by
+  rw [padic_eval_int_poly_cast, norm_rat_eq_padicNorm]
+
+/-! ═══════════════════════════════════════════════════════════════════════════
 PART V: MAIN THEOREM
 P-adic algebraic numbers are not p-adically Liouville
 ═══════════════════════════════════════════════════════════════════════════ -/
@@ -233,14 +283,16 @@ P-adic algebraic numbers are not p-adically Liouville
 /-- **Bridge Axiom**: Given the factorization f = (X - C α) · g in ℚ_[p][X] and the evaluation
     identity f(x) = (x - α) · g(x), the p-adic Liouville estimate holds.
 
-    The proof requires two technical ingredients Mathlib does not yet directly supply:
-    (1) **Norm compatibility**: ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q for q : ℚ.
-        This connects the padicNorm_poly_eval_bound (Part III, working over ℚ) to the
-        ℚ_[p]-norm in the main estimate.
-    (2) **Cofactor evaluation bound**: for g ∈ ℚ_[p][X] with coefficients depending on α,
-        ‖g.eval (r/s : ℚ_[p])‖ ≤ M · H^(deg g) where H = max(|r|, |s|) and M depends on
-        ‖α‖ and the coefficients of f. Follows from ‖r/s‖_p ≤ |s| ≤ H (by Archimedean
-        Complement applied to ‖s‖_p ≥ 1/|s|) and polynomial norm bounds.
+    Status (post Part IV.5):
+    Ingredient (1) (norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q) is now
+    PROVED in Part IV.5 as `norm_rat_eq_padicNorm`, and the integer polynomial transport
+    `padic_norm_int_poly_eval` discharges the full ℚ → ℚ_[p] bridge for `eval`. The only
+    remaining obstacle is ingredient (2) below.
+
+    (2) **Cofactor evaluation bound** (REMAINING): for g ∈ ℚ_[p][X] with coefficients
+        depending on α, ‖g.eval (r/s : ℚ_[p])‖ ≤ M · H^(deg g) where H = max(|r|, |s|)
+        and M depends on ‖α‖ and the coefficients of f. Follows from ‖r/s‖_p ≤ |s| ≤ H
+        (by Archimedean Complement applied to ‖s‖_p ≥ 1/|s|) and polynomial norm bounds.
     Combined: ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ ≥ (C_f/H^d)/(M·H^(d-1)) = C/H^(2d-1) ≥ C/H^(2d). -/
 axiom padic_liouville_norm_bridge
     (α : ℚ_[p]) (f : ℤ[X])
@@ -302,30 +354,35 @@ theorem padic_algebraic_not_liouville
     intro heq
     rw [heq, sub_self, norm_zero] at hpos
     exact lt_irrefl 0 hpos
-  -- Work with H : ℕ := max r.natAbs s.natAbs
-  set H : ℕ := max r.natAbs s.natAbs with hH_def
-  -- H ≥ 2 (from Liouville condition), so (H : ℝ) ≥ 2
-  have hH_ge2 : (2 : ℝ) ≤ (H : ℝ) := by exact_mod_cast hH2
-  have hH_pos : (0 : ℝ) < (H : ℝ) := lt_of_lt_of_le (by norm_num) hH_ge2
-  have hH2d_pos : (0 : ℝ) < (H : ℝ) ^ (2 * f.natDegree) := pow_pos hH_pos _
+  -- Work with H : ℝ := max ↑r.natAbs ↑s.natAbs (real-valued max to match `hbound`/`happrox`)
+  set H : ℝ := max (r.natAbs : ℝ) (s.natAbs : ℝ) with hH_def
+  -- H ≥ 2 (from Liouville condition Nat-form `hH2 : 2 ≤ max r.natAbs s.natAbs`)
+  have hH_ge2 : (2 : ℝ) ≤ H := by
+    rw [hH_def]; exact_mod_cast hH2
+  have hH_pos : (0 : ℝ) < H := lt_of_lt_of_le (by norm_num) hH_ge2
+  have hH2d_pos : (0 : ℝ) < H ^ (2 * f.natDegree) := pow_pos hH_pos _
   -- Lower bound from estimate: C / H^(2d) ≤ ‖α - r/s‖
-  have hlower : C / (H : ℝ) ^ (2 * f.natDegree) ≤ ‖α - (r : ℚ_[p]) / s‖ :=
+  have hlower : C / H ^ (2 * f.natDegree) ≤ ‖α - (r : ℚ_[p]) / s‖ :=
     hbound r s hs hne
   -- Combine with Liouville upper bound: C / H^(2d) < 1 / H^(n₀ + 2d)
-  have hcomb : C / (H : ℝ) ^ (2 * f.natDegree) < 1 / (H : ℝ) ^ (n₀ + 2 * f.natDegree) :=
+  have hcomb : C / H ^ (2 * f.natDegree) < 1 / H ^ (n₀ + 2 * f.natDegree) :=
     lt_of_le_of_lt hlower happrox
   -- H^(n₀+2d) = H^n₀ * H^(2d), so 1/H^(n₀+2d) = (1/H^n₀) / H^(2d)
   rw [pow_add, ← div_div] at hcomb
   -- Cancel H^(2d) from both sides: C < 1/H^n₀
-  have hC_lt : C < 1 / (H : ℝ) ^ n₀ := (div_lt_div_right hH2d_pos).mp hcomb
+  -- (Lean 4.26: `div_lt_div_right` renamed to `div_lt_div_iff_of_pos_right`.)
+  have hC_lt : C < 1 / H ^ n₀ :=
+    (div_lt_div_iff_of_pos_right hH2d_pos).mp hcomb
   -- H ≥ 2 implies H^n₀ ≥ 2^n₀, so 1/H^n₀ ≤ 1/2^n₀
-  have h2n0_le : (2 : ℝ) ^ n₀ ≤ (H : ℝ) ^ n₀ :=
-    pow_le_pow_left (by norm_num) hH_ge2 n₀
-  have h_mono : 1 / (H : ℝ) ^ n₀ ≤ 1 / (2 : ℝ) ^ n₀ :=
+  -- (Lean 4.26: `pow_le_pow_left` renamed to `pow_le_pow_left₀`.)
+  have h2n0_le : (2 : ℝ) ^ n₀ ≤ H ^ n₀ :=
+    pow_le_pow_left₀ (by norm_num) hH_ge2 n₀
+  have h_mono : 1 / H ^ n₀ ≤ 1 / (2 : ℝ) ^ n₀ :=
     one_div_le_one_div_of_le (pow_pos (by norm_num : (0:ℝ) < 2) n₀) h2n0_le
   -- hn₀ : (1/2)^n₀ < C. Rewrite as 1/2^n₀ < C.
   have h_2n0_lt : 1 / (2 : ℝ) ^ n₀ < C := by
-    have : (1 / 2 : ℝ) ^ n₀ = 1 / (2 : ℝ) ^ n₀ := by ring
+    have hpow : (1 / 2 : ℝ) ^ n₀ = 1 / (2 : ℝ) ^ n₀ := by
+      rw [div_pow, one_pow]
     linarith
   -- Chain: C < 1/H^n₀ ≤ 1/2^n₀ < C. Contradiction.
   linarith
@@ -453,14 +510,29 @@ PART IX: SORRY SUMMARY
 - All three examples (2|6, 5|25, 3∤7)
 
 **Axiom** (`padic_liouville_norm_bridge`): Connects the factorization/evaluation identity
-to the final norm estimate. Requires:
-1. Norm compatibility ℚ → ℚ_[p]: `‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q`
-2. Uniform cofactor bound: ‖g.eval (r/s)‖_p ≤ M · H^(d-1)
+to the final norm estimate. Originally required two ingredients; ingredient (1) is now
+proved in Part IV.5:
+1. Norm compatibility ℚ → ℚ_[p]: ✓ PROVED via `padicNormE.eq_padicNorm` (Mathlib).
+   Wrapper theorems: `norm_rat_eq_padicNorm`, `padic_eval_int_poly_cast`,
+   `padic_norm_int_poly_eval`.
+2. Uniform cofactor bound: ‖g.eval (r/s)‖_p ≤ M · H^(d-1) (REMAINING).
 
 **Session 9 changes (2026-05-03)**:
 - Replaced `sorry` in `padic_liouville_estimate` with bridge axiom `padic_liouville_norm_bridge`.
   The proof now establishes the factorization and evaluation identity, then delegates the
   norm-compatibility step to the axiom. This converts sorry 1 → axiom 1, giving 0 sorries.
+
+**Session 10 changes (2026-05-07)**:
+- Added Part IV.5 (norm transport) discharging ingredient (1) of the bridge:
+  - `norm_rat_eq_padicNorm`: ‖(q : ℚ_[p])‖ = padicNorm p q (wraps Mathlib's
+    `padicNormE.eq_padicNorm`).
+  - `padic_eval_int_poly_cast`: integer polynomial evaluation transports through
+    ratCast (proved via `Polynomial.aeval_algHom_apply`).
+  - `padic_norm_int_poly_eval`: combines the two — the ℚ_[p]-norm of an integer
+    polynomial evaluated at a rational equals the rational p-adic norm of the
+    rational evaluation. This is exactly the connection
+    `padicNorm_poly_eval_bound` (Part III) needs to bridge to ℚ_[p].
+  Net: bridge axiom now blocked only by ingredient (2) (cofactor evaluation bound).
 
 -/
 

--- a/src/data/research/problems/liouville-theorem-oq-04.json
+++ b/src/data/research/problems/liouville-theorem-oq-04.json
@@ -17,43 +17,46 @@
   },
   "currentState": {
     "phase": "REFINE",
-    "since": "2026-05-07T17:40:00.000Z",
-    "iteration": 9,
-    "focus": "Single axiom (padic_liouville_norm_bridge) remains; main theorem padic_algebraic_not_liouville is fully proved from it. Next step is to discharge the bridge axiom with the norm-compatibility + cofactor-bound combination.",
+    "since": "2026-05-07T22:50:00.000Z",
+    "iteration": 10,
+    "focus": "Bridge axiom INGREDIENT (1) DISCHARGED: rational-embedding norm compatibility ‖(q:ℚ_[p])‖ = padicNorm p q proved via Mathlib's Padic.eq_padicNorm. New helper Part IV.5 (norm_rat_eq_padicNorm, padic_eval_int_poly_cast, padic_norm_int_poly_eval) establishes the full ℚ → ℚ_[p] eval-norm transport. Remaining obstruction: ingredient (2), the cofactor evaluation bound ‖g.eval(r/s)‖ ≤ M·H^(d-1). Also fixed Lean 4.26 API drift in padic_algebraic_not_liouville and padicNorm_poly_eval_bound (file no longer built before this session).",
     "blockers": [
-      "Need Mathlib lookup for ‖(q : ℚ_[p])‖ = padicNorm p q (rational embedding norm)"
+      "Cofactor evaluation bound: ‖g.eval(r/s : ℚ_[p])‖ ≤ M · H^(deg g) where M depends only on ‖α‖ and coefficients of f. Requires polynomial norm triangle inequality + ‖r/s‖_p ≤ H (from Archimedean Complement applied in the reverse direction)."
     ],
-    "nextAction": "Locate the Mathlib rational-embedding norm lemma; combine with the proved Archimedean Complement Lemma to discharge padic_liouville_norm_bridge.",
+    "nextAction": "Prove the cofactor bound as a standalone theorem and use it (plus padic_norm_int_poly_eval) to discharge padic_liouville_norm_bridge into a proper theorem.",
     "attemptCounts": {
-      "total": 8,
-      "currentApproach": 1,
+      "total": 9,
+      "currentApproach": 2,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 1 axiom (padic_liouville_norm_bridge), 0 sorries — current actual state of LiouvilleTheoremOQ04.lean. Architecture is complete: factorization f = (X - C α) · g via Polynomial.dvd_iff_isRoot, evaluation identity, and main theorem padic_algebraic_not_liouville fully proved from the bridge axiom. The remaining axiom encapsulates two technical ingredients: (1) norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q, and (2) cofactor evaluation bound ‖g.eval(r/s)‖ ≤ M·H^(deg g). Replacing this single axiom with a proof unblocks 0 → 0 axioms.",
+    "progressSummary": "PROGRESS (Session 10, 2026-05-07): Discharged ingredient (1) of the bridge axiom. New Part IV.5 contains three formal lemmas built on Mathlib's Padic.eq_padicNorm: norm_rat_eq_padicNorm (rational-embedding norm compatibility), padic_eval_int_poly_cast (integer polynomial evaluation transport via aeval_algHom_apply), and padic_norm_int_poly_eval (the combined statement that ‖(f.map alg ℤ ℚ_[p]).eval ((q:ℚ_[p]))‖ = padicNorm p ((f.map alg ℤ ℚ).eval q)). This is exactly the connection padicNorm_poly_eval_bound (Part III) needs to bridge from ℚ to ℚ_[p]. Also repaired Lean 4.26 API drift: padicNorm.pos → padicNorm.nonneg + padicNorm.nonzero, padicNormE.eq_padicNorm → Padic.eq_padicNorm, div_lt_div_right → div_lt_div_iff_of_pos_right, pow_le_pow_left → pow_le_pow_left₀, ring → div_pow + one_pow, and switched H : ℕ → H : ℝ to match real-valued max on hbound's RHS. File now builds cleanly (Docker, lean v4.26.0) with 1 axiom, 0 sorries — the remaining axiom now blocks ONLY on ingredient (2) (the cofactor bound).",
     "builtItems": [
       "IsPadicLiouville (LiouvilleTheoremOQ04.lean): definition with strict positivity 0 < ‖β - r/s‖ and height bound 2 ≤ max r.natAbs s.natAbs",
-      "padic_liouville_estimate: proved via factorization + bridge axiom — exposes the standard (C/H^(2d)) lower bound (LiouvilleTheoremOQ04.lean:266)",
-      "padic_algebraic_not_liouville: proved (0 sorries) — closes the main contradiction via exists_pow_lt_of_lt_one + div_lt_div_right + one_div_le_one_div_of_le (LiouvilleTheoremOQ04.lean:289)",
+      "padic_liouville_estimate: proved via factorization + bridge axiom — exposes the standard (C/H^(2d)) lower bound",
+      "padic_algebraic_not_liouville: proved (0 sorries) — closes the main contradiction via exists_pow_lt_of_lt_one + div_lt_div_iff_of_pos_right + one_div_le_one_div_of_le + pow_le_pow_left₀",
       "Archimedean Complement Lemma: padicNorm p n ≥ 1/n for n > 0, proved via pow_padicValNat_dvd (Part I)",
-      "Polynomial evaluation lemmas over ℚ via padicNorm (Part III) — supplies C_f for the bridge axiom"
+      "Polynomial evaluation lemmas over ℚ via padicNorm (Part III) — supplies C_f for the bridge axiom",
+      "norm_rat_eq_padicNorm (Part IV.5, NEW Session 10): ‖(q:ℚ_[p])‖ = padicNorm p q via Padic.eq_padicNorm",
+      "padic_eval_int_poly_cast (Part IV.5, NEW Session 10): polynomial evaluation transport ℚ → ℚ_[p] via aeval_algHom_apply with (Rat.castHom ℚ_[p]).toIntAlgHom",
+      "padic_norm_int_poly_eval (Part IV.5, NEW Session 10): combined ℚ_[p]-norm of integer polynomial evaluation equals rational p-adic norm of the rational evaluation"
     ],
     "insights": [
       "IsPadicLiouville needs both 2 ≤ max(|r|,|s|) and 0 < ‖β - r/s‖. Without H≥2, bound 1/H^n=1 gives no useful constraint. Without strict positivity, every rational is trivially Liouville (r/s = β gives ‖β - r/s‖ = 0).",
       "padic_liouville_estimate is FALSE as originally stated (without α ≠ r/s): taking r/s = α gives ‖α - r/s‖ = 0 < C/H^d. The hne hypothesis is guaranteed by the IsPadicLiouville strict positivity in the main theorem.",
       "Exponent 2d (instead of d) suffices via the simple cofactor bound: ‖g(r/s)‖_p ≤ M_g · H^(d-1) (non-Archimedean + ‖r/s‖_p ≤ H), giving ‖α - r/s‖ ≥ C_f / (M_g · H^(2d-1)) ≥ C / H^(2d). The tight bound d would require an ultrametric case split.",
-      "The bridge axiom is mathematically routine but pulls in ℚ → ℚ_[p] norm transport machinery; resolution is a Mathlib-completeness question, not a math question."
+      "The norm-compatibility lemma sits in namespace Padic in v4.26 (was historically padicNormE) — direct dot-notation `padicNormE.eq_padicNorm` triggers AbsoluteValue field-access; use `Padic.eq_padicNorm` instead.",
+      "Polynomial evaluation transport ℚ → ℚ_[p] is one line via Polynomial.aeval_algHom_apply applied to (Rat.castHom ℚ_[p]).toIntAlgHom : ℚ →ₐ[ℤ] ℚ_[p]; no manual map_map / eval_map gymnastics needed.",
+      "Lean 4.26 API drift in this file: padicNorm.pos removed (use nonneg + nonzero), div_lt_div_right → div_lt_div_iff_of_pos_right, pow_le_pow_left → pow_le_pow_left₀. Also `set H : ℕ` no longer unifies with real-valued max output of `hbound`; switch to `set H : ℝ`."
     ],
     "mathlibGaps": [
-      "Norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q — likely exists in some form in Mathlib.NumberTheory.Padics; needs lookup and adapter lemma",
-      "Uniform polynomial evaluation bound padicNorm p (f.eval (r/s)) ≥ C_f / H^d — needs to be assembled from coefficient bounds + Archimedean Complement"
+      "Cofactor norm bound ‖g.eval (r/s : ℚ_[p])‖ ≤ M · H^(deg g) for polynomial g ∈ ℚ_[p][X] and rational r/s, where M depends only on coefficients — needs to be assembled from triangle inequality + ‖r/s‖_p ≤ H"
     ],
     "nextSteps": [
-      "Locate Mathlib lemma for ‖(q : ℚ_[p])‖ = padicNorm p q (the rational embedding norm); if absent, prove via Padic.coe_rat / padicNormE definitional unfolding",
-      "Prove uniform polynomial evaluation bound: ∃ C_f, ∀ r s (s≠0, f(r/s)≠0), padicNorm p (f(r/s)) ≥ C_f / H^d — apply Archimedean Complement to s.natAbs and combine with coefficient bounds",
-      "Prove cofactor bound: if f.map alg = (X - C α) * g over ℚ_[p][X], then ‖g.eval (r/s)‖ ≤ M_g · H^(d-1) — direct from polynomial-norm triangle inequality + ‖r/s‖_p ≤ |s| ≤ H",
-      "Combine the three lemmas to prove padic_liouville_norm_bridge as a theorem — eliminating the last axiom"
+      "Prove ‖((r:ℚ_[p])/s)‖ ≤ (max r.natAbs s.natAbs : ℝ) using padicNorm_int_le_one for ‖r‖_p and padicNorm_int_ge_inv for 1/‖s‖_p ≤ |s| ≤ H",
+      "Prove polynomial cofactor bound: for g ∈ ℚ_[p][X] of degree d-1, ‖g.eval x‖ ≤ M_g · max(1, ‖x‖)^(d-1) where M_g = max ‖coeff_i‖, via Polynomial.eval over the non-Archimedean norm",
+      "Combine padic_norm_int_poly_eval (Part IV.5) + padicNorm_poly_eval_bound (Part III) + cofactor bound to prove padic_liouville_norm_bridge as a theorem — eliminating the last axiom"
     ]
   },
   "tags": [
@@ -73,7 +76,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.505Z",
-  "lastUpdate": "2026-05-07T17:40:00.000Z",
+  "lastUpdate": "2026-05-07T22:50:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -91,8 +94,8 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ04.lean",
       "filename": "LiouvilleTheoremOQ04.lean",
-      "lineCount": 432,
-      "theoremCount": 15,
+      "lineCount": 539,
+      "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Session 10 progress on `LiouvilleTheoremOQ04.padic_liouville_norm_bridge`:
- **NEW Part IV.5 (Norm Transport)**: discharges ingredient (1) of the bridge axiom (rational-embedding norm compatibility ‖(q:ℚ_[p])‖ = padicNorm p q) via Mathlib's `Padic.eq_padicNorm` and `Polynomial.aeval_algHom_apply`. Three new theorems:
  - `norm_rat_eq_padicNorm`
  - `padic_eval_int_poly_cast`
  - `padic_norm_int_poly_eval`
- **Lean 4.26 API drift repair** (file did not build before this session):
  - `padicNorm.pos` → `padicNorm.nonneg` + `padicNorm.nonzero`
  - `padicNormE.eq_padicNorm` (AbsoluteValue field-access trap) → `Padic.eq_padicNorm`
  - `div_lt_div_right` → `div_lt_div_iff_of_pos_right`
  - `pow_le_pow_left` → `pow_le_pow_left₀`
  - `ring` on `(1/2)^n = 1/2^n` → `rw [div_pow, one_pow]`
  - `set H : ℕ` (no longer unifies with real-valued max) → `set H : ℝ`

## Status

- 539 lines, 19 theorems, **1 axiom**, **0 sorries**
- Bridge axiom now blocks ONLY on ingredient (2) (cofactor evaluation bound `‖g.eval (r/s)‖_p ≤ M·H^(d-1)`)
- File builds cleanly via `./proofs/scripts/docker-build.sh Proofs.LiouvilleTheoremOQ04` on Lean v4.26.0

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.LiouvilleTheoremOQ04` succeeds (3063 jobs)
- [x] `axiom` count unchanged at 1; `sorry` count unchanged at 0
- [x] meta JSON updated: lineCount 432→539, theoremCount 15→19, lastUpdate 2026-05-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)