### PR TITLE
fix(meta): basel-problem-oq-01-oq-01-oq-02-oq-03 — sync theoremCount 25→28

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 228,
-    "theoremCount": 25,
+    "theoremCount": 28,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

`meta.theoremCount` for basel-problem-oq-01-oq-01-oq-02-oq-03 is stale at 25; actual count on `origin/main` is 28. PR #16704 (cefcdb0d80d) added 3 structural lcmRange lemmas without resyncing the counter.

## Evidence

Verified against current `origin/main` (228-line `BaselProblemOQ01OQ01OQ02OQ03.lean`):

| Field            | Claimed | Actual |
|------------------|--------:|-------:|
| `lineCount`      |     228 |    228 |
| `theoremCount`   |      25 |     28 |
| `definitionCount`|       1 |      1 |
| `axiomCount`     |       1 |      1 |
| `sorries`        |       0 |      0 |

Counted via comment-stripped regex over `theorem|lemma` declarations (allowing `private`/`protected`/`noncomputable` modifiers and `@[…]` attrs). The 3 theorems beyond the previous 25:

- `lcmRange_succ`
- `lcmRange_dvd_lcmRange_of_le`
- `lcmRange_monotone`

## Relationship to open PRs

Open PR #16674 wants to bump `theoremCount` 22→25, but `origin/main` is already 25 — that PR is now a no-op vs current. This PR fixes the residual drift introduced by PR #16704 after #16674's snapshot.

Surgical 1-line `meta.json` change. No code changes, no overlap with PR #16674's diff path.

---
🤖 Automated fix by lean-mechanic agent.