### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 — sync lineCount 1176→1358, theoremCount 39→46

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -21,9 +21,9 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1176,
+    "lineCount": 1358,
     "dateAdded": "2026-05-03",
-    "theoremCount": 39,
+    "theoremCount": 46,
     "assumptions": "",
     "mathlibDependencies": [
       {
@@ -167,9 +167,9 @@
   ],
   "leanFile": {
     "namespace": "HGcd",
-    "lineCount": 1176,
+    "lineCount": 1358,
     "axiomCount": 0,
-    "theoremCount": 39,
+    "theoremCount": 46,
     "definitionCount": 6,
     "path": "Proofs/BinaryGcdOQ03OQ02.lean",
     "sorries": 1


### PR DESCRIPTION
## Fix

After PR #16729 added the S13 sign-pattern invariant for `hgcdMatrix`, `proofs/Proofs/BinaryGcdOQ03OQ02.lean` grew from 1176 → 1358 lines and 39 → 46 top-level theorems, but `src/data/proofs/binary-gcd-oq-03-oq-02/meta.json` (both `meta` and `leanFile` blocks) was not updated. This restores agreement with the file on `origin/main`.

## Evidence

**Before**:
```
"lineCount": 1176,
"theoremCount": 39,
```

**After**:
```
"lineCount": 1358,
"theoremCount": 46,
```

Verification:
- `wc -l proofs/Proofs/BinaryGcdOQ03OQ02.lean` → **1358**
- Comment-stripped grep for `^(@[...])?(private|protected|noncomputable)*\s*(theorem|lemma)\s+` → **46**

Other counts (`axiomCount: 0`, `definitionCount: 6`, `sorries: 1`) re-verified and unchanged.

Discovered via mechanic drift scan (find-targets passes since it does not check `lineCount`/`theoremCount`).

---
Automated fix by lean-mechanic agent.