### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-05 — reclassify as axiomatized (UnifiedTriangle.law)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ05.lean
+++ b/proofs/Proofs/LawOfCosinesOQ05.lean
@@ -40,7 +40,7 @@ This single formula unifies all three classical laws:
 - K = -1: `cosh(c) = cosh(a)cosh(b) - sinh(a)sinh(b)cos(C)` ✓ (K = -1 gives minus)
 - K → 0: reduces to `c² = a² + b² - 2ab·cos(C)` in the limit ✓
 
-## Status (0 axioms, 1 sorry)
+## Status (1 structure-encoded axiom: UnifiedTriangle.law; 0 sorries)
 - [x] Definitions: curvatureCos, curvatureSin
 - [x] Special values at K = 0, ±1
 - [x] Unified Pythagorean identity: cs_K² + K·sn_K² = 1 for all K
@@ -48,7 +48,7 @@ This single formula unifies all three classical laws:
 - [x] Recovery theorems: K = ±1 recover spherical/hyperbolic laws
 - [x] Algebraic equivalences for K > 0 and K < 0
 - [x] Scaling family consistency
-- [ ] Euclidean limit: K → 0 expansion (sorry — requires analysis)
+- [x] Euclidean limit: K → 0 expansion (proved via explicit Taylor bounds)
 
 ## References
 - Ratcliffe (2006): "Foundations of Hyperbolic Manifolds"

--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Researcher-10 (lean-genius)",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LawOfCosinesOQ05.lean",
     "tags": [
       "geometry",
@@ -17,11 +17,11 @@
       "unification",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 693,
-    "assumptions": "None. All results fully proved from Mathlib: euclidean_limit_holds completed with explicit K→0 Taylor expansion bounds.",
+    "assumptions": "1 structure-encoded assumption: UnifiedTriangle K.law — the unified law cs_K(c) = cs_K(a)·cs_K(b) + K·sn_K(a)·sn_K(b)·cos(C) is a structure field (not derived from a Riemannian metric model). Per the project's Axiom Integrity Policy, propositional structure fields are mathematical assumptions and must be counted as axioms. All other results — the unified Pythagorean identity, parity properties, K=±1 recovery theorems, algebraic equivalences for K≠0, and the K→0 Euclidean limit (proved via explicit Taylor expansion bounds) — are fully proved from Mathlib (0 sorries).",
     "dateAdded": "2026-04-21",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -186,13 +186,15 @@
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Series",
       "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
       "Mathlib.Analysis.SpecialFunctions.Sqrt",
       "Mathlib.Tactic"
     ],
     "namespace": "UnifiedLawOfCosines",
     "lineCount": 693,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 28,
     "definitionCount": 2,
     "path": "Proofs/LawOfCosinesOQ05.lean",


### PR DESCRIPTION
## Fix

Reclassifies `law-of-cosines-oq-01-oq-05` from `verified`/`mathlib` to `axiomatized`/`axiom`. Per the project's Axiom Integrity Policy, the propositional `law` field of `structure UnifiedTriangle K` is a mathematical assumption that must be counted in `axiomCount`.

## Evidence

The Lean file (lines 226–237) defines:

```lean
structure UnifiedTriangle (K : ℝ) where
  ...
  law : curvatureCos K c = curvatureCos K a * curvatureCos K b +
          K * curvatureSin K a * curvatureSin K b * Real.cos C
```

The downstream theorems `unified_law_of_cosines`, `unified_K_neg1_gives_hyperbolic`, and `unified_K1_gives_spherical` all extract from `t.law` — they do not derive the unified law from a Riemannian metric model. The sibling proof `law-of-cosines-oq-03` uses the same pattern (`HyperbolicTriangle.law`) and is correctly classified as `axiomatized` with `axiomCount: 3`.

The file's own `keyInsights` already acknowledges: "The structure UnifiedTriangle K **axiomatizes** a triangle in K-geometry via its law field."

## Changes

**Before**: status verified, badge mathlib, axiomCount 0, leanFile.axiomCount 0, assumptions "None…", imports 4, docstring "0 axioms, 1 sorry"
**After**: status axiomatized, badge axiom, axiomCount 1, leanFile.axiomCount 1, assumptions text describing the structure-encoded assumption, imports 6 (added the two used-but-undeclared `Trigonometric.Bounds` and `Trigonometric.Series`), docstring updated to reflect 1 structure-encoded axiom + Euclidean limit completed in PR #11036.

No changes to Lean code; only metadata + a stale docstring inside `/-! ... -/`.

Closes #16750

---
Automated fix by lean-mechanic agent.