### PR TITLE
fix(meta): law-of-cosines-oq-01-oq-05 — axiomatize UnifiedTriangle.law (#16750)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ05.lean
+++ b/proofs/Proofs/LawOfCosinesOQ05.lean
@@ -40,7 +40,7 @@ This single formula unifies all three classical laws:
 - K = -1: `cosh(c) = cosh(a)cosh(b) - sinh(a)sinh(b)cos(C)` ✓ (K = -1 gives minus)
 - K → 0: reduces to `c² = a² + b² - 2ab·cos(C)` in the limit ✓
 
-## Status (0 axioms, 1 sorry)
+## Status (0 sorries; UnifiedTriangle.law is a structure-encoded assumption)
 - [x] Definitions: curvatureCos, curvatureSin
 - [x] Special values at K = 0, ±1
 - [x] Unified Pythagorean identity: cs_K² + K·sn_K² = 1 for all K
@@ -48,7 +48,7 @@ This single formula unifies all three classical laws:
 - [x] Recovery theorems: K = ±1 recover spherical/hyperbolic laws
 - [x] Algebraic equivalences for K > 0 and K < 0
 - [x] Scaling family consistency
-- [ ] Euclidean limit: K → 0 expansion (sorry — requires analysis)
+- [x] Euclidean limit: K → 0 expansion (proved via explicit Taylor bounds)
 
 ## References
 - Ratcliffe (2006): "Foundations of Hyperbolic Manifolds"

--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Researcher-10 (lean-genius)",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LawOfCosinesOQ05.lean",
     "tags": [
       "geometry",
@@ -17,11 +17,11 @@
       "unification",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 693,
-    "assumptions": "None. All results fully proved from Mathlib: euclidean_limit_holds completed with explicit K→0 Taylor expansion bounds.",
+    "assumptions": "1 structure-encoded assumption: UnifiedTriangle K.law — the unified law of cosines cs_K(c) = cs_K(a)·cs_K(b) + K·sn_K(a)·sn_K(b)·cos(C) is a structure field (not proved from a Riemannian metric model). All other results — the unified Pythagorean identity, parity properties, K=±1 recovery theorems, algebraic equivalences, and the K→0 Euclidean limit (euclidean_limit_holds) — are fully proved from Mathlib (0 sorries).",
     "dateAdded": "2026-04-21",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -186,13 +186,15 @@
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Series",
       "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
       "Mathlib.Analysis.SpecialFunctions.Sqrt",
       "Mathlib.Tactic"
     ],
     "namespace": "UnifiedLawOfCosines",
     "lineCount": 693,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 28,
     "definitionCount": 2,
     "path": "Proofs/LawOfCosinesOQ05.lean",


### PR DESCRIPTION
## Fix

Reclassify `law-of-cosines-oq-01-oq-05` as `axiomatized` because `UnifiedTriangle K.law` is a propositional structure field (a stored assumption, not derived from a metric model). Per the project's Axiom Integrity Policy in CLAUDE.md, structure-encoded propositional fields count toward `axiomCount`. The sibling `law-of-cosines-oq-03` (`HyperbolicTriangle.law`) is correctly classified for the same pattern.

## Evidence

**Before** (`src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json`):
```
status:     verified
badge:      mathlib
axiomCount: 0   (meta and leanFile both)
assumptions: "None. ..."
imports:    4   (leanFile)
```

**After**:
```
status:     axiomatized
badge:      axiom
axiomCount: 1   (UnifiedTriangle.law)
assumptions: "1 structure-encoded assumption: UnifiedTriangle K.law — ..."
imports:    6   (added Trigonometric.Bounds, Trigonometric.Series)
```

**Stale Lean docstring** (`proofs/Proofs/LawOfCosinesOQ05.lean`):
- Line 43: `## Status (0 axioms, 1 sorry)` → `## Status (0 sorries; UnifiedTriangle.law is a structure-encoded assumption)`
- Line 51: `[ ] Euclidean limit: K → 0 expansion (sorry — requires analysis)` → `[x] Euclidean limit: K → 0 expansion (proved via explicit Taylor bounds)`
  (the Euclidean limit was completed in PR #11036; the docstring was never updated.)

## What does NOT change

- `sorries: 0` (verified — file has no `sorry` strings outside comments)
- `lineCount: 693`, `theoremCount: 28`, `definitionCount: 2` (all correct)
- `originalContributions` (accurate; framing already noted the structure-axiomatization in `keyInsights` and `openQuestions`)

Closes #16750

---
Automated fix by lean-mechanic agent.