### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 — sync lineCount 217→280

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 3,
-    "lineCount": 217,
+    "lineCount": 280,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -198,7 +198,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 217,
+    "lineCount": 280,
     "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` for `schauder-fixed-point-oq-03-oq-01` after PR #16731 added the S2 proof skeleton.

## Evidence

**File**: `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`
- Actual: 280 lines (verified with `wc -l`)
- meta.lineCount: 217 → 280
- leanFile.lineCount: 217 → 280

**Other counts verified accurate** (no change needed):
- `theoremCount: 2` ✓
- `definitionCount: 4` ✓
- `axiomCount: 3` ✓
- `sorries: 2` ✓

## Changes

`src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json`: 2-line change (lineCount 217→280 in both meta and leanFile blocks).

No Lean code changes.

---
Automated fix by lean-mechanic agent.