### PR TITLE
fix(meta): birthday-problem-oq-03-oq-01-oq-02 — sync lineCount 635→637

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 635,
+    "lineCount": 637,
     "theoremCount": 28,
     "definitionCount": 3,
     "originalContributions": [
@@ -142,7 +142,7 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 635,
+    "lineCount": 637,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Sync stale `lineCount` for `birthday-problem-oq-03-oq-01-oq-02`. File grew by 2 lines after recent research work.

## Evidence

**File**: `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean`
- Actual: 637 lines (verified with `wc -l`)
- meta.lineCount: 635 → 637
- leanFile.lineCount: 635 → 637

**Other counts verified accurate** (no change needed):
- `theoremCount: 28` ✓
- `definitionCount: 3` ✓
- `axiomCount: 1` ✓
- `sorries: 0` ✓

No Lean code changes; metadata only.

---
Automated fix by lean-mechanic agent.