### PR TITLE
audit(law-of-cosines-oq-01-oq-05): mark clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11112,7 +11112,7 @@
     },
     "euler-identity-oq-01-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-05-07T20:22:22Z",
+      "lastAudited": "2026-05-07T20:29:30Z",
       "result": "clean",
       "issues": []
     },
@@ -12141,9 +12141,9 @@
       "result": "clean"
     },
     "law-of-cosines-oq-01-oq-05": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:27Z",
+      "lastAudited": "2026-05-07T21:25:55Z",
       "result": "clean"
     },
     "law-of-cosines-oq-03": {
@@ -14993,12 +14993,6 @@
     "basel-problem-oq-01-oq-01-oq-02-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-05-07T19:11:54Z",
-      "result": "clean",
-      "issues": []
-    },
-    "euler-identity-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-07T20:29:30Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

Re-audited `law-of-cosines-oq-01-oq-05` (Unified Curvature-Parametrized Law of Cosines). All gallery claims verify against the Lean source.

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| `lineCount` | 693 | 693 | ✓ |
| `sorries` | 0 | 0 | ✓ |
| `axiomCount` | 0 | 0 | ✓ |
| `theoremCount` | 28 | 28 | ✓ |
| `definitionCount` | 2 | 2 (curvatureCos, curvatureSin) | ✓ |
| `status` | verified | 0 sorries, 0 axioms | ✓ |
| `badge` | mathlib | Tier B (relies on Mathlib trig) | ✓ |

`euclidean_limit_holds` is fully proved (no sorries) via the 280-line Taylor-bound argument described in `keyInsights`. Tier B badge `mathlib` is appropriate since the core proof obtains its identities from Mathlib's circular and hyperbolic trigonometry.

## Cosmetic note (not a gallery issue)

The Lean source's docstring at lines 43, 51 is stale — it still says "0 axioms, 1 sorry" / `[ ] Euclidean limit ... (sorry — requires analysis)`. The proof is actually complete; `meta.json` reflects the correct state. This is a documentation cleanup opportunity inside `LawOfCosinesOQ05.lean` itself, not a gallery integrity concern.

## Tracker change

- `auditCount`: 1 → 2
- `lastAudited`: 2026-04-23T18:43:27Z → 2026-05-07T21:25:55Z
- `result`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)