### PR TITLE
audit(lagrange-four-squares-oq-04): mark clean + drop orphan tracker dup

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11112,7 +11112,7 @@
     },
     "euler-identity-oq-01-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-05-07T20:22:22Z",
+      "lastAudited": "2026-05-07T20:29:30Z",
       "result": "clean",
       "issues": []
     },
@@ -12093,9 +12093,9 @@
       "result": "clean"
     },
     "lagrange-four-squares-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:27Z",
+      "lastAudited": "2026-05-07T21:39:35Z",
       "result": "clean"
     },
     "lagrange-theorem": {
@@ -14993,12 +14993,6 @@
     "basel-problem-oq-01-oq-01-oq-02-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-05-07T19:11:54Z",
-      "result": "clean",
-      "issues": []
-    },
-    "euler-identity-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-07T20:29:30Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

- Re-audited `lagrange-four-squares-oq-04` against `origin/main`. All meta.json claims match the Lean source `proofs/Proofs/LagrangeFourSquaresOQ04.lean`:
  - 226 lines, 0 sorries, 1 axiom (`not_obstructed_is_three_squares`), 11 theorems, 0 defs
  - Status `axiomatized`, badge `axiom` correctly classify the file (1 declared backward-direction axiom; forward direction proved from first principles)
  - `originalContributions` accurately describe what is proved
- Tracker change: `auditCount` 1→2, `lastAudited` 2026-04-23 → 2026-05-07
- Drops a duplicate orphan tracker entry for `euler-identity-oq-01-oq-01-oq-01` outside the `entries` wrapper (canonical entry preserved with the newer timestamp from the orphan)

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --next` returned `law-of-cosines-oq-01-oq-05` (already covered by #16751/#16757) and then `lagrange-four-squares-oq-04` as next priority
- [x] Cross-checked Lean source counts against meta.json
- [x] Verified axiom name matches the declaration in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)