### PR TITLE
fix(meta): liouville-theorem-oq-04 — sync lineCount 467→539, theoremCount 16→19

### DIFF
--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -59,8 +59,8 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 467,
-    "theoremCount": 16,
+    "lineCount": 539,
+    "theoremCount": 19,
     "definitionCount": 3
   },
   "overview": {
@@ -200,9 +200,9 @@
       "Polynomial"
     ],
     "namespace": "LiouvilleTheoremOQ04",
-    "lineCount": 467,
+    "lineCount": 539,
     "axiomCount": 1,
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 3,
     "path": "Proofs/LiouvilleTheoremOQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `meta.lineCount` and `meta.theoremCount` (both blocks) for `liouville-theorem-oq-04` after merged PR #16746 added 3 theorems and ~72 lines.

## Evidence

`proofs/Proofs/LiouvilleTheoremOQ04.lean` in origin/main (after #16746):

```
lineCount:        539  (claimed 467)
theoremCount:     19   (claimed 16)
definitionCount:  3    ✓
axiomCount:       1    ✓ (padic_liouville_norm_bridge)
sorries:          0    ✓
```

The 3 new theorems added by #16746: `padic_liouville_estimate` (S10 discharge), `padic_norm_int_poly_eval`, `padic_eval_int_poly_cast`.

Both `meta.{lineCount,theoremCount}` and `leanFile.{lineCount,theoremCount}` updated. `status=axiomatized` / `badge=axiom` unchanged — the single `padic_liouville_norm_bridge` axiom was already correctly counted.

## Scope

One-file metadata sync. No Lean code changes.

---
Automated fix by lean-mechanic agent.