### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): add pow_dvd_lcmRange structural lemma

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -104,6 +104,15 @@ theorem dvd_lcmRange {k n : ℕ} (hk : 0 < k) (hkn : k ≤ n) :
   have := Finset.dvd_lcm (f := (· + 1)) hk'
   simpa [Nat.sub_add_cancel hk] using this
 
+/-- **Power divisibility**: any power b^k with positive base and b^k ≤ n divides
+    lcmRange n. Specialization of `dvd_lcmRange` to powers; the case where b is
+    prime and k = ⌊log_b n⌋ is the structural building block for the prime-power
+    decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋} that underlies any
+    Hanson-style proof. -/
+theorem pow_dvd_lcmRange {b k n : ℕ} (hb : 0 < b) (hbkn : b ^ k ≤ n) :
+    b ^ k ∣ lcmRange n :=
+  dvd_lcmRange (Nat.pos_pow_of_pos k hb) hbkn
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 228,
-    "theoremCount": 28,
+    "lineCount": 237,
+    "theoremCount": 29,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [
@@ -64,31 +64,31 @@
       "id": "definition",
       "title": "Part 1-2: Definition and Basic Properties",
       "startLine": 60,
-      "endLine": 151,
-      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
+      "endLine": 160,
+      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, pow_dvd_lcmRange (any positive base power b^k ≤ n divides lcmRange n — the building block for prime-power decompositions), and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
       "mathContext": "$\\operatorname{lcmRange}(n) = \\operatorname{lcm}\\{1, 2, \\ldots, n\\}$ encoded as a `Finset.lcm` over `Finset.range n` mapped through (·+1)."
     },
     {
       "id": "elementary-bounds",
       "title": "Part 3: Provable Elementary Bounds",
-      "startLine": 153,
-      "endLine": 173,
+      "startLine": 162,
+      "endLine": 182,
       "summary": "Proves the three elementary bounds with no axioms: lcmRange_dvd_factorial, lcmRange_le_factorial, lcmRange_le_self_pow. The chain lcm ≤ n! ≤ n^n is the trivial bound that Hanson's 3^n strictly improves upon.",
       "mathContext": "$\\operatorname{lcm}(1, \\ldots, n) \\mid n!$ via `Nat.dvd_factorial`, then $\\operatorname{lcm}(1, \\ldots, n) \\leq n! \\leq n^n$ via `Nat.factorial_le_pow`."
     },
     {
       "id": "numerical",
       "title": "Part 4: Numerical Verification of Hanson",
-      "startLine": 174,
-      "endLine": 196,
+      "startLine": 183,
+      "endLine": 205,
       "summary": "Verifies lcmRange n ≤ 3^n for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Includes lcmRange exact values lcmRange 5 = 60, lcmRange 10 = 2520, lcmRange 15 = 360360, lcmRange 20 = 232792560 (matches OEIS A003418).",
       "mathContext": "Concrete: $\\operatorname{lcm}(1, \\ldots, 20) = 232\\,792\\,560$ vs $3^{20} = 3\\,486\\,784\\,401$, ratio $\\approx 15$."
     },
     {
       "id": "axiom",
       "title": "Part 5: Hanson's Bound (Axiom)",
-      "startLine": 198,
-      "endLine": 228,
+      "startLine": 207,
+      "endLine": 237,
       "summary": "States `axiom hanson_bound : ∀ n, lcmRange n ≤ 3^n` — Hanson's classical 1972 theorem. Includes hanson_strictly_stronger_than_factorial showing the constant 3 is genuinely tighter than the trivial n^n bound for n ≥ 4.",
       "mathContext": "Hanson 1972: $\\operatorname{lcm}(1, \\ldots, n) \\leq 3^n$. Original proof uses Beta-integral identity $\\int_0^1 x^k(1-x)^{n-k} dx = \\frac{1}{(n+1)\\binom{n}{k}}$ combined with prime-power bounds."
     }

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -30,29 +30,33 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-07",
-    "iteration": 1,
-    "focus": "Bootstrap completed. The OBSERVE/ORIENT phase has converted this stub into a Lean 4 formalization target with elementary provable bounds (lcm ≤ n!, lcm ≤ n^n), numerical verification for n ≤ 20, and an axiom statement of the general claim with proof strategy and Mathlib gap analysis.",
+    "since": "2026-05-08",
+    "iteration": 3,
+    "focus": "Building structural lemma library toward prime-power decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}. Iteration 2 (#16704 merged) added lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (this PR) adds pow_dvd_lcmRange — any positive base power b^k ≤ n divides lcmRange n — the structural building block specialised to powers, applicable directly to prime powers without requiring an additional Mathlib import.",
     "blockers": [
       "Mathlib lacks Beta-integral identity in rational-denominator form for Hanson's approach.",
-      "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route."
+      "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)"
     ],
-    "nextAction": "Two paths: (a) attempt the easier `lcm(1,...,n) ≤ 4^n` via primorial bridge (1-2 weeks), or (b) wait for/contribute Mathlib Beta-integral infrastructure.",
+    "nextAction": "Continue building the prime-power decomposition: the next structural step is `lcmRange_eq_prod_prime_powers : lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`. With pow_dvd_lcmRange this gives the easy direction (RHS dvd LHS); the reverse direction follows from the unique-factorization property and is in Mathlib's Nat.factorization framework.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 0,
-      "approachesTried": 1
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "Bootstrap COMPLETE. `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (182 lines, 22 theorems, 1 def, 1 axiom, 0 sorries): defines `lcmRange n = (Finset.range n).lcm (·+1)`, proves elementary bounds (`lcmRange_dvd_factorial`, `lcmRange_le_factorial`, `lcmRange_le_self_pow`), verifies Hanson's bound `lcmRange n ≤ 3^n` numerically for n ∈ {1..10, 12, 15, 20} via decide/native_decide, and axiomatizes the general statement as `axiom hanson_bound`. Includes `hanson_strictly_stronger_than_factorial` showing the constant 3 is genuinely tighter than the trivial n^n bound.",
+    "progressSummary": "Iteration 3. `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (237 lines, 29 theorems, 1 def, 1 axiom, 0 sorries). Iteration 1 (bootstrap, merged) defined lcmRange and elementary bounds. Iteration 2 (#16704 merged) added structural lemmas lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (this PR) adds `pow_dvd_lcmRange : 0 < b → b^k ≤ n → b^k ∣ lcmRange n`, the structural building block for prime-power-decomposition arguments. With it, the prime-case `p^(⌊log_p n⌋) ∣ lcmRange n` for any prime p ≤ n becomes a one-line corollary (using `Nat.pow_log_le_self`).",
     "builtItems": [
-      "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:67",
-      "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:75-87",
-      "dvd_lcmRange: each k ∈ {1,...,n} divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:95",
-      "lcmRange_dvd_factorial: lcm | n! at BaselProblemOQ01OQ01OQ02OQ03.lean:109",
-      "lcmRange_le_factorial: lcm ≤ n! at BaselProblemOQ01OQ01OQ02OQ03.lean:118",
-      "lcmRange_le_self_pow: lcm ≤ n^n at BaselProblemOQ01OQ01OQ02OQ03.lean:122",
+      "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:78",
+      "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:85-96",
+      "dvd_lcmRange: each k ∈ {1,...,n} divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:99",
+      "pow_dvd_lcmRange: any b^k ≤ n with positive base divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:115",
+      "lcmRange_succ: recursion lcm(1..n+1) = lcm(lcm(1..n), n+1) (#16704)",
+      "lcmRange_dvd_lcmRange_of_le: monotone divisibility (#16704)",
+      "lcmRange_monotone: numerical monotonicity (#16704)",
+      "lcmRange_dvd_factorial: lcm | n!",
+      "lcmRange_le_factorial: lcm ≤ n!",
+      "lcmRange_le_self_pow: lcm ≤ n^n",
       "hanson_n1 .. hanson_n20: numerical verification for 13 values of n",
       "lcmRange_5/10/15/20_eq: concrete OEIS values 60, 2520, 360360, 232792560",
       "hanson_bound (axiom): the open target ∀ n, lcmRange n ≤ 3^n",
@@ -63,7 +67,9 @@
       "The bound hierarchy: trivial (n^n) > Erdős (4^n) > Hanson (3^n). Each step requires substantial mathematics.",
       "Mathlib has `primorial_le_4_pow` but no `lcm(1,...,n)`-specific bound; the bridge is the missing combinatorial step.",
       "Numerical evidence is strong: lcm(1..20) = 232,792,560 vs 3^20 = 3,486,784,401, a factor-15 margin.",
-      "The Chebyshev function reformulation ψ(n) = log lcm(1,...,n) connects this to the Prime Number Theorem (which gives only the asymptotic ψ(n)/n → 1)."
+      "The Chebyshev function reformulation ψ(n) = log lcm(1,...,n) connects this to the Prime Number Theorem (which gives only the asymptotic ψ(n)/n → 1).",
+      "**Counterexample**: `lcm(1..n) ≤ n · primorial(n)` is FALSE in general — already at n=9 we have lcm(1..9) = 2520 > 9 · 210 = 1890. The intermediate primorial bridge as commonly stated does NOT yield the 4^n bound; the correct path goes through Chebyshev's prime-power formula `lcm(1..n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}`.",
+      "**pow_dvd_lcmRange** is the structural-lemma counterpart of `dvd_lcmRange` for prime-power arguments: applied with `b = p` prime and `k = Nat.log p n`, with `Nat.pow_log_le_self p hn` it gives the maximal-prime-power divisibility `p^(⌊log_p n⌋) ∣ lcmRange n` in a single line — the easy direction of the Chebyshev decomposition."
     ],
     "mathlibGaps": [
       "No `lcm(1,...,n) ≤ X^n`-style bound exists in Mathlib for any X.",
@@ -71,12 +77,14 @@
       "No Beta-integral identity in usable rational form: `(n+1)·C(n,k)·∫₀¹ x^k(1-x)^(n-k) dx = 1`."
     ],
     "nextSteps": [
-      "Pursue the intermediate bound `lcm(1,...,n) ≤ 4^n` via primorial bridge (more tractable than full Hanson).",
+      "Add `prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n` (one-liner from `pow_dvd_lcmRange` + `Nat.pow_log_le_self`). Requires `import Mathlib.Data.Nat.Prime.Basic` and `Mathlib.Data.Nat.Log`.",
+      "Add `lcmRange_eq_prod_prime_powers : lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`. Forward direction (RHS ∣ LHS) follows from `prime_pow_dvd_lcmRange` + pairwise-coprimality of distinct primes; reverse direction uses Mathlib's `Nat.factorization` framework.",
+      "With Chebyshev's decomposition, derive `lcmRange n ≤ ∏_{p ≤ n} n = n^{π(n)}` (still weaker than 3^n but proves a non-trivial bound).",
       "Wait for or contribute Mathlib Beta-integral machinery for ℚ-valued bounds.",
-      "Explore Nair's 1982 alternative constants as a possibly-easier intermediate.",
+      "Explore Nair's 1982 alternative constants as a possibly-easier intermediate (uses central binomial coefficients).",
       "Add cross-references in `basel-problem-oq-01-oq-01-oq-02` and `basel-problem` gallery entries pointing to this OQ-03."
     ],
-    "markdown": "# Knowledge Base: basel-problem-oq-01-oq-01-oq-02-oq-03\n\nSee `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md` and `state.md` for full discussion.\n\n## Status\n\n* **Phase**: ACT (bootstrap complete)\n* **Files**: `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (182 lines, 1 axiom, 0 sorries, numerically verified n ∈ {1..10, 12, 15, 20}).\n* **Open target**: replace `axiom hanson_bound` with a theorem.\n* **Blocker**: Mathlib lacks Beta-integral / primorial-bridge infrastructure.\n"
+    "markdown": "# Knowledge Base: basel-problem-oq-01-oq-01-oq-02-oq-03\n\nSee `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md` and `state.md` for full discussion.\n\n## Status\n\n* **Phase**: ACT (iteration 3)\n* **Files**: `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (237 lines, 29 theorems, 1 def, 1 axiom, 0 sorries; numerically verified n ∈ {1..10, 12, 15, 20}).\n* **Open target**: replace `axiom hanson_bound` with a theorem.\n* **Blocker**: Mathlib lacks Beta-integral / Chebyshev-prime-power-formula infrastructure.\n* **Iteration 3 (this PR)**: added `pow_dvd_lcmRange`, the structural building block for prime-power decompositions of `lcmRange n`.\n"
   },
   "tags": [
     "number-theory",
@@ -111,15 +119,15 @@
     ]
   },
   "started": "2026-04-26T08:56:57.649Z",
-  "lastUpdate": "2026-05-07",
+  "lastUpdate": "2026-05-08",
   "significance": 7,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
       "filename": "BaselProblemOQ01OQ01OQ02OQ03.lean",
-      "lineCount": 182,
-      "theoremCount": 22,
+      "lineCount": 237,
+      "theoremCount": 29,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Iteration 3 ACT for the Hanson-bound research target (`hanson_bound : ∀ n, lcmRange n ≤ 3^n`).

Adds `pow_dvd_lcmRange`: any positive base power `b^k ≤ n` divides `lcmRange n`. Specialisation of the existing `dvd_lcmRange` to powers; the case `b = p` prime and `k = ⌊log_p n⌋` is the easy direction of the Chebyshev decomposition

$$\operatorname{lcm}(1, \ldots, n) \;=\; \prod_{\substack{p \le n \\ p \text{ prime}}} p^{\lfloor \log_p n \rfloor}$$

which underlies any Hanson-style or primorial-route proof.

## What's new

```lean
/-- **Power divisibility**: any power b^k with positive base and b^k ≤ n divides
    lcmRange n. ... structural building block for the prime-power
    decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋} that underlies
    any Hanson-style proof. -/
theorem pow_dvd_lcmRange {b k n : ℕ} (hb : 0 < b) (hbkn : b ^ k ≤ n) :
    b ^ k ∣ lcmRange n :=
  dvd_lcmRange (Nat.pos_pow_of_pos k hb) hbkn
```

Two-line corollary; uses only the existing `dvd_lcmRange` (this file) and `Nat.pos_pow_of_pos` (already used in 5+ other files in the codebase, e.g. `BaselProblemOQ01OQ01OQ02Aristotle.lean`, `Erdos609Aristotle.lean`). **No new imports.**

## Counts

| | Before | After |
|---|---|---|
| Lines | 228 | 237 |
| Theorems | 28 | 29 |
| Axioms | 1 | 1 |
| Sorries | 0 | 0 |

## Why this matters

`pow_dvd_lcmRange` is the structural counterpart of `dvd_lcmRange` for prime-power arguments. Combined with `Nat.pow_log_le_self`, it gives the prime-case `p^(⌊log_p n⌋) ∣ lcmRange n` for any prime `p ≤ n` as a one-liner — the easy direction of the Chebyshev prime-power formula. The reverse direction (LHS ∣ RHS) follows from Mathlib's `Nat.factorization` framework and is a natural next step.

## Documented gap correction

The previous research notes listed `lcm(1,...,n) ≤ n · primorial(n)` as a "missing Mathlib bridge" that would yield the easier 4^n bound. **That statement is false in general:**

> `lcm(1..9) = 2520`, but `9 · primorial(9) = 9 · 210 = 1890`.

So the easy primorial-bridge route as commonly stated cannot yield the 4^n bound. The correct path goes through Chebyshev's prime-power formula. This PR records the counterexample in the research JSON.

## Test plan

- [x] Manual review: `pow_dvd_lcmRange` is a two-line corollary of an already-verified theorem in the same file (`dvd_lcmRange`) and a Mathlib lemma (`Nat.pos_pow_of_pos`) used in 5+ other files in this codebase.
- [x] Counts updated in `meta.json` (lineCount 228→237, theoremCount 28→29) and matching section endLines shifted by +9 to account for the 9 inserted lines.
- [x] Research JSON advanced from iteration 1 to iteration 3, with `pow_dvd_lcmRange` documented in `builtItems` and the line-numbers re-pinned to the post-iteration-2 state of the file.
- [ ] Local Docker build attempted but stalled in Mathlib clone (8+ concurrent agent builds saturating Docker memory). The change is mathematically and syntactically straightforward — single application of existing verified lemmas — and will be validated by CI / next auditor pass.

## Status

**Outcome**: Iteration 3 progress — structural lemma added, gap-counterexample documented.
**Next steps** (recorded in research JSON):
1. `prime_pow_dvd_lcmRange` (one-liner using this PR's lemma + `Nat.pow_log_le_self`)
2. `lcmRange_eq_prod_prime_powers` (Chebyshev decomposition)
3. Bound `lcmRange n ≤ n^{π(n)}` from the decomposition

🤖 Generated by researcher-9