### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-01-oq-01 — sync theoremCount 20→22

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum b≥2 — strategy refined in S19 to weight factorization + ballot counting identity (S18 diagnosed naive insert-violation bijection as non-injective for b≥2); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S19 added weight_eq_total_multiset helper: prod(P)*prod(Q) = prod(P+Q) via Multiset.map_add+prod_add. jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
     "lineCount": 992,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 6,
     "originalContributions": [
       "jacobiTrudiMatrix: the k×k matrix with entries h_{sh_i + j - i} (or 0 for negative index) — first Lean 4 Jacobi-Trudi matrix definition",
@@ -80,7 +80,7 @@
     "namespace": "JacobiTrudi",
     "lineCount": 992,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 6,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,


### PR DESCRIPTION
## Fix

Sync `meta.theoremCount` and `leanFile.theoremCount` for
`ballot-problem-oq-03-oq-01-oq-01-oq-01` from 20 to 22.

After session-18/19 work added two private lemmas to
`proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`, the theorem/lemma
count drifted from 20 to 22 but neither block was resynced.

`find-targets` only checks True-stubs / sorry / axiom, so this slips
through automation.

## Evidence

`origin/main:proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (HEAD = d4e6533fce2):

After stripping nested block + line comments and matching
`^\s*(@\[…\])* (private|protected|noncomputable)* (theorem|lemma) <name>`,
22 declarations are present:

- 8 public theorems: `schurPolynomial_empty`, `schurPolynomial_one_row`,
  `jacobiTrudiMatrix_entry_isSymmetric`, `schurPolynomial_isSymmetric`,
  `schurPolynomial_two_row`, `schurPolynomial_one_row_at_one`,
  `ssytSchurFin_empty`, `ssytSchurFin_one_row`
- 12 private lemmas: `sum_all_sym_pairs`, `jdt_weight_preserved`,
  `weight_eq_total_multiset`, `sym_one_sort_head_singleton`,
  `colStrictSym_a_one_iff_phead_lt_qhead`,
  `not_colStrictSym_a_one_iff_qhead_le_phead`, `jdt_weight_sum_b_one`,
  `min_ab_pos_of_not_colStrict`, `exists_first_violation_idx`,
  `jdt_weight_sum`, `ssytFin_two_row_eq_sum_colstrict`,
  `sym_pair_sum_partition`
- 2 final public theorems: `ssytSchurFin_two_row`, `jacobi_trudi_ssyt_eq`

Total = 22, claimed = 20, drift = +2.

Related history: #16617 (S17 research JSON sync, theoremCount 10→19) only
touched `src/data/research/problems/...json`; the gallery
`src/data/proofs/...json` was left at the older value and has since drifted
by another +2 from S18/S19 work.

## Scope

Pure metadata; surgical 2-line diff via Python `.replace()`. No `sorries`,
`axiomCount`, `definitionCount`, `lineCount`, or any other field touched.
File ends-with-newline → `lineCount: 992` is already correct under the
canonical convention (`raw.count('\n') + (1 if not endswith '\n' else 0)`).

---
Automated fix by lean-mechanic agent.