### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-01-oq-01 — sync theoremCount 20→22

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum b≥2 — strategy refined in S19 to weight factorization + ballot counting identity (S18 diagnosed naive insert-violation bijection as non-injective for b≥2); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S19 added weight_eq_total_multiset helper: prod(P)*prod(Q) = prod(P+Q) via Multiset.map_add+prod_add. jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
     "lineCount": 992,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 6,
     "originalContributions": [
       "jacobiTrudiMatrix: the k×k matrix with entries h_{sh_i + j - i} (or 0 for negative index) — first Lean 4 Jacobi-Trudi matrix definition",
@@ -80,7 +80,7 @@
     "namespace": "JacobiTrudi",
     "lineCount": 992,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 6,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,


### PR DESCRIPTION
## Fix

Sync stale `meta.json` `theoremCount` after PRs #16637 and #16712 added net +2 theorems to `BallotProblemOQ03OQ01OQ01OQ01.lean` without resyncing the counter.

## Evidence

Verified against `origin/main`:

| Field             | Claimed | Actual |
|-------------------|--------:|-------:|
| `lineCount`       |     992 |    992 |
| `theoremCount`    |      20 |     22 |
| `definitionCount` |       6 |      6 |
| `axiomCount`      |       0 |      0 |
| `sorries`         |       2 |      2 |

`actual` measured by listing decls in the comment-stripped Lean source matching `(@[..])* (private|protected|noncomputable)* (theorem|lemma)` regex (with stacked-modifier fix per `feedback_auditor_drift_scan_regex.md`):

```
 1. schurPolynomial_empty
 2. schurPolynomial_one_row
 ...
21. ssytSchurFin_two_row
22. jacobi_trudi_ssyt_eq
```

Both `meta.theoremCount` and `leanFile.theoremCount` mirrors updated.

No code changes.

(Aside: the prior in-flight #16683 attempted lineCount 878→1010 + theoremCount 20→23 and was closed; subsequent direct edits landed lineCount=992 + theoremCount=20 in main. This PR completes the count sync — actual now equals 22 after #16712 removed a duplicate.)

---
Automated fix by lean-mechanic agent.