### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-02-oq-01): n=3 fixed P→1 corollary (Session 7, build pending)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
@@ -596,10 +596,47 @@ theorem p_no_triple_n3 (d : ℕ) (hd : 1 ≤ d) :
   have hne : (d : ℝ) ≠ 0 := hd_pos.ne'
   field_simp
 
+/-- For n=3 fixed, P(no triple|n=3, d days) → 1 as d → ∞.
+    Direct corollary of `p_no_triple_n3`: `1 − 1/d² → 1`.
+
+    This is a concrete sanity check on Lemma B's limit: with n held fixed at 3,
+    `λ(d) = C(3,3)/d² = 1/d² → 0`, so `exp(-λ(d)) → 1`. The full Lemma C
+    (`p_no_triple_tendsto`) is the *qualitative Poisson convergence* along
+    the threshold scaling `n_c(d) = ⌊c · d^(2/3)⌋` — a strictly stronger
+    statement requiring method-of-factorial-moments infrastructure absent
+    from Mathlib 4.26. This corollary covers only the n-fixed regime
+    (c → 0), but verifies internal consistency. -/
+theorem p_no_triple_n3_tendsto :
+    Filter.Tendsto
+      (fun d : ℕ =>
+        ((Finset.univ.filter (fun f : Fin 3 → Fin d =>
+          ¬(f 0 = f 1 ∧ f 1 = f 2))).card : ℝ) /
+        (Fintype.card (Fin 3 → Fin d) : ℝ))
+      Filter.atTop (nhds 1) := by
+  have h_d_atTop : Filter.Tendsto (fun d : ℕ => (d : ℝ)) Filter.atTop Filter.atTop :=
+    tendsto_natCast_atTop_atTop
+  have h_d2_atTop : Filter.Tendsto (fun d : ℕ => (d : ℝ) ^ 2)
+      Filter.atTop Filter.atTop := by
+    have heq : (fun d : ℕ => (d : ℝ) ^ 2) = (fun d : ℕ => (d : ℝ) * (d : ℝ)) := by
+      funext d; ring
+    rw [heq]
+    exact h_d_atTop.atTop_mul_atTop₀ h_d_atTop
+  have h_inv : Filter.Tendsto (fun d : ℕ => (1 : ℝ) / (d : ℝ) ^ 2)
+      Filter.atTop (nhds 0) := by
+    have h := tendsto_inv_atTop_zero.comp h_d2_atTop
+    refine h.congr' ?_
+    filter_upwards with d using (one_div _).symm
+  have h_target : Filter.Tendsto (fun d : ℕ => 1 - (1 : ℝ) / (d : ℝ) ^ 2)
+      Filter.atTop (nhds (1 - 0 : ℝ)) := tendsto_const_nhds.sub h_inv
+  simp only [sub_zero] at h_target
+  refine h_target.congr' ?_
+  filter_upwards [Filter.eventually_ge_atTop (1 : ℕ)] with d hd
+  exact (p_no_triple_n3 d hd).symm
+
 /-
   ## Summary
 
-  **Proved (13 theorems, 1 axiom):**
+  **Proved (14 theorems, 1 axiom):**
   1. `choose3_ub`/`choose3_lb`: C(n,3) ∈ [(n-2)³/6, n³/6]
   2. `asympThreshold_cubed`: (asympThreshold d)³ = 6d² ln 2 (exact characterization)
   3. `asympThreshold_ratio`: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} (PROVED)
@@ -613,6 +650,7 @@ theorem p_no_triple_n3 (d : ℕ) (hd : 1 ≤ d) :
   11. `exp_lambda_tendsto` (Lemma B): exp(-C(n_c(d),3)/d²) → exp(-c³/6) (Session 4)
   12. `poisson_approx_birthday3` (Session 5): PROVED from Lemma B + Lemma C using Tendsto.sub
   13. `p_no_triple_n3` (Session 6): P(no triple|n=3) = 1 − 1/d² as a real number
+  14. `p_no_triple_n3_tendsto` (Session 7): P(no triple|n=3) → 1 as d → ∞
 
   **Axioms (1):** `p_no_triple_tendsto` (Lemma C) — pure Poisson limit:
     P_no_triple(n_c(d), d) → exp(-c³/6) (Lemma A+B proved; `poisson_approx_birthday3` derived from B+C)
@@ -633,5 +671,6 @@ theorem p_no_triple_n3 (d : ℕ) (hd : 1 ≤ d) :
 #check @p_no_triple_tendsto
 #check @poisson_approx_birthday3
 #check @p_no_triple_n3
+#check @p_no_triple_n3_tendsto
 
 end BirthdayThreshold3

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
@@ -487,3 +487,59 @@ introduced after PR #16150 merged on 2026-05-06 — Mathlib upgrade drift in the
 
 The PR repairs 4 build-breaking errors plus adds the n=3 base case theorem. Local rebuild
 verification is pending capacity; the deployer/auditor should re-build to confirm.
+
+---
+
+## Session 2026-05-07 (Session 7, researcher-10) — n=3 Tendsto Corollary
+
+**Mode**: REVISIT (extending Session 6's `p_no_triple_n3`)
+**Outcome**: progress — added `p_no_triple_n3_tendsto` (P → 1 as d → ∞ for n=3 fixed)
+
+### What I Did
+
+- Added `p_no_triple_n3_tendsto` after `p_no_triple_n3` in `BirthdayProblemOQ03OQ01OQ02.lean`
+- Updated summary block (Session 7 entry) and `#check` directive
+- Five-step proof composing standard Mathlib lemmas:
+  1. `(d:ℝ) → ∞` via `tendsto_natCast_atTop_atTop`
+  2. `(d:ℝ)^2 → ∞` via `Tendsto.atTop_mul_atTop₀` (post-rename API)
+  3. `1/d² → 0` via `tendsto_inv_atTop_zero.comp` + `one_div` rewrite
+  4. `1 - 1/d² → 1` via `tendsto_const_nhds.sub`
+  5. `congr'` with `p_no_triple_n3` (eventually d ≥ 1 via `Filter.eventually_ge_atTop`)
+- File: 635 → 676 lines (+40); theorems 28 → 29
+
+### Mathematical Significance
+
+The full Lemma C (`p_no_triple_tendsto`) is the qualitative Poisson convergence
+**along the threshold scaling** `n_c(d) = ⌊c · d^(2/3)⌋` — it asserts
+`P_no_triple(n_c(d), d) → exp(-c³/6)` as d → ∞, where n grows with d.
+
+`p_no_triple_n3_tendsto` covers a **strictly weaker regime**: n is held fixed at 3.
+This corresponds to the c → 0 specialization of the threshold scaling: along the
+threshold curve, fixing n = 3 forces c · d^(2/3) ∈ [3, 4), giving c → 0 as d → ∞.
+The limits match: as c → 0, exp(-c³/6) → 1, and `p_no_triple_n3_tendsto` confirms
+P_no_triple(3, d) → 1.
+
+This corollary is **internal-consistency**, not a step toward Lemma C itself.
+It demonstrates the clean qualitative limit reasoning that Lemma C will require
+— a sanity check + warm-up.
+
+### Files Modified
+
+- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` (635 → 676 lines, +1 theorem)
+- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md` (iteration 6 → 7)
+- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` (lineCount, theoremCount)
+- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json` (Session 7 entries)
+
+### Verification
+
+PR #16777 opened as **draft** pending Docker build (cold-cache; Mathlib clone in
+progress at session end). Build verification deferred to a follow-up agent.
+
+### Next Steps
+
+1. **Verify build** (Session 8): confirm Docker compilation succeeds.
+2. **Lemma C** (open): the substantive remaining work. Either:
+   - Build method-of-factorial-moments → Poisson convergence locally (~500 lines)
+   - Contribute upstream to Mathlib's Probability.Distributions.Poisson
+3. **Smaller wins**: union bound `P_no_triple(n,d) ≥ 1 - C(n,3)/d²` for general n
+   (Bonferroni r=1) — quantitative complement to Lemma C.

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
@@ -4,41 +4,49 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-29T00:00:00Z
-**Iteration**: 3
+**Iteration**: 7
 
 ## Current Focus
-Lemma A's foundation is in source (`nc_div_pow_tendsto`); next is the
-remainder of Lemma A (cubing + falling-factorial correction) and Lemma B.
+Lemmas A and B proved (Sessions 4-5). `poisson_approx_birthday3` derived from
+Lemma B + Lemma C. n=3 base case proved as a real number (Session 6) and
+extended to a Tendsto statement (Session 7). The remaining axiom is Lemma C
+(`p_no_triple_tendsto`) — qualitative Poisson convergence along the threshold
+scaling — which requires method-of-factorial-moments infrastructure absent
+from Mathlib 4.26.
 
 ## Active Approach
 Decomposition strategy:
-- **`nc_div_pow_tendsto` (foundation, Session 3)**: `n_c(d) / d^(2/3) → c` —
-  direct corollary of `tendsto_nat_floor_mul_div_atTop` ∘ `tendsto_rpow_atTop`.
-  In source as of 2026-04-29 (build verification deferred — Docker
-  unresponsive during session).
-- Lemma A `lambda_tendsto`: `λ(d) := C(⌊c·d^(2/3)⌋, 3)/d² → c³/6` — pending,
-  builds on `nc_div_pow_tendsto` via `.pow 3` + falling-factorial correction.
-- Lemma B `exp_lambda_tendsto`: `exp(−λ(d)) → exp(−c³/6)` — pending one-liner
-  once Lemma A is in.
-- Lemma C `p_no_triple_tendsto`: `P_no_triple(n d, d) → exp(−c³/6)` (Poisson
-  convergence — only sublemma requiring new Mathlib infrastructure).
+- **`nc_div_pow_tendsto` (foundation, Session 3)**: PROVED
+- **Lemma A `lambda_tendsto` (Session 4)**: PROVED via squeeze
+- **Lemma B `exp_lambda_tendsto` (Session 4)**: PROVED via Real.continuous_exp.tendsto
+- **Lemma C `p_no_triple_tendsto` (axiom)**: pure Poisson limit; requires
+  qualitative method-of-factorial-moments → Poisson convergence (≈500 lines,
+  not in Mathlib 4.26). Either build locally for this entry, contribute upstream,
+  or accept as axiomatized.
+- **`poisson_approx_birthday3` (Session 5)**: PROVED via Tendsto.sub from Lemma B + Lemma C
+- **`p_no_triple_n3` (Session 6)**: P(no triple|n=3, d) = 1 − 1/d² real-number form
+- **`p_no_triple_n3_tendsto` (Session 7)**: P(no triple|n=3) → 1 as d → ∞ (build pending)
 
 ## Attempt Count
-- Total attempts: 2 (Session 1 BLOCKED; Session 2 ORIENT decomposition; Session 3 ACT-partial)
-- Current approach attempts: 1 (Session 3 added Lemma A foundation)
+- Total attempts: 7 (Session 1 BLOCKED; Sessions 2-7 progress)
+- Current approach attempts: 1 (Session 7 added n=3 fixed Tendsto corollary)
 - Approaches tried: 1
 
 ## Blockers
-- Docker build was unresponsive during Session 3 — verification of the new
-  lemma is deferred to a later session. The proof body is two lines composing
-  Mathlib lemmas whose signatures were verified by direct file read.
 - Lemma C still requires method-of-factorial-moments → Poisson convergence,
-  which is not in Mathlib but is substantially smaller than full Chen-Stein.
+  which is not in Mathlib 4.26. Alternative: contribute upstream to
+  `Mathlib.Probability.Distributions.Poisson` (currently exposes only PMF/measure
+  constructors, no convergence theorems).
+- Smaller incremental contributions remaining: union bound on triple count
+  (general n), factorial moment definitions, Bonferroni r=1 bound — but each is
+  ≪Lemma C in effect.
 
 ## Next Action
-1. **Verify** `nc_div_pow_tendsto` builds cleanly (Docker)
-2. **Add Lemma A** proper (`lambda_tendsto`) using `nc_div_pow_tendsto.pow 3` +
-   the `(C(n,3) : ℝ) - n³/6` correction → 0 lemma
-3. **Add Lemma B** as a one-liner via `Real.continuous_exp.tendsto`
-4. **Restate the axiom** as the strictly weaker Lemma C alone, isolating the
-   genuine Mathlib gap to one statement
+1. **Build verification** (Session 7): confirm `p_no_triple_n3_tendsto` compiles
+   under Docker (build in progress, cold-cache).
+2. **Lemma C** (open): prove `p_no_triple_tendsto` via qualitative
+   method-of-factorial-moments → Poisson convergence (≈500 lines).
+3. **Alternative**: contribute factorial-moments → Poisson convergence upstream
+   to Mathlib.
+4. **Smaller wins**: union bound `P_no_triple(n,d) ≥ 1 - C(n,3)/d²` for general n
+   (Bonferroni r=1, complementary quantitative bound).

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
@@ -32,8 +32,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-06T13:21:41Z",
-    "iteration": 6,
-    "focus": "Session 6 (2026-05-07): added p_no_triple_n3 — real-number form P(no triple|n=3) = 1 − 1/d² as a corollary of good_count_n3. Concrete base-case sanity check connecting the elementary count (Session 1) to the Lemma C target. Lemma C itself remains the only axiom; its proof requires method-of-factorial-moments → Poisson convergence (≈500 lines, absent from Mathlib 4.26).",
+    "iteration": 7,
+    "focus": "Session 7 (2026-05-07): added p_no_triple_n3_tendsto — Filter.Tendsto form of Session 6's p_no_triple_n3, P(no triple|n=3, d) → 1 as d → ∞. Five-step proof composing tendsto_natCast_atTop_atTop, Tendsto.atTop_mul_atTop₀, tendsto_inv_atTop_zero.comp, Tendsto.sub, congr'. Internal-consistency check on Lemma B (c → 0 specialization). Lemma C itself remains the only axiom; requires method-of-factorial-moments → Poisson convergence (≈500 lines, absent from Mathlib 4.26).",
     "blockers": [],
     "nextAction": "Lemma C requires substantial Mathlib infrastructure (qualitative method-of-factorial-moments → Poisson convergence, ≈500 lines). Either build it locally for this entry, contribute upstream to Mathlib, or accept the entry as axiomatized. Smaller incremental contributions: union bound on triple count (general n), factorial moment definitions, Bonferroni r=1 bound — but each is ≪Lemma C in effect.",
     "attemptCounts": {
@@ -43,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 6, 2026-05-07): added p_no_triple_n3 — real-number form of n=3 base case, P(no triple) = 1 − 1/d² for d ≥ 1. Built directly on good_count_n3 (Session 1, exact triple-free count |good| = d³ − d). Small concrete addition; the principal remaining gap is unchanged: Lemma C (p_no_triple_tendsto axiom) — qualitative Poisson convergence P_no_triple(n_c(d), d) → exp(-c³/6), requiring method-of-factorial-moments infrastructure (~500 lines) absent from Mathlib 4.26. PRIOR (Session 5, PR #16150 merged 2026-05-06): poisson_approx_birthday3 is no longer an axiom — restated as a theorem proved by Filter.Tendsto.sub from Lemma B (exp_lambda_tendsto) and Lemma C (axiom). Lemmas A+B (lambda_tendsto, exp_lambda_tendsto) had been proved in Session 4 (2026-05-03).",
+    "progressSummary": "PROGRESS (Session 7, 2026-05-07): added p_no_triple_n3_tendsto — Filter.Tendsto corollary of Session 6's p_no_triple_n3, asserting P(no triple|n=3, d) → 1 as d → ∞. Five-step proof composes standard Mathlib lemmas (tendsto_natCast_atTop_atTop, Tendsto.atTop_mul_atTop₀, tendsto_inv_atTop_zero.comp, Tendsto.sub, congr'). Internal-consistency sanity check: along the threshold scaling, fixing n=3 forces c → 0 (since c·d^(2/3) ∈ [3,4)), and indeed P → 1 = exp(-0³/6). Build verification deferred (cold-cache Docker still cloning Mathlib at session end). PR #16777 opened as draft. PRIOR (Session 6, PR #16730 merged 2026-05-07): added p_no_triple_n3 — real-number form of n=3 base case, P(no triple) = 1 − 1/d² for d ≥ 1, plus 4 Mathlib API drift fixes. PRIOR (Session 5, PR #16150 merged 2026-05-06): poisson_approx_birthday3 restated as theorem proved by Filter.Tendsto.sub from Lemma B + Lemma C (axiom). Lemmas A+B proved Session 4.",
     "builtItems": [
       "Corrected JSON `problemStatement.formal` to match actual Lean axiom signature (qualitative Tendsto, not |...| ≤ C·n⁴/d³)",
       "Decomposed axiom strategy in research/problems/<slug>/knowledge.md into sublemmas A/B/C",
@@ -55,7 +55,8 @@
       "two_div_rpow23_tendsto_zero: private helper 2/d^(2/3) → 0 (Session 4, line ~380)",
       "Session 5, PR #16150 (2026-05-06): poisson_approx_birthday3 axiom replaced by axiom p_no_triple_tendsto (Lemma C only); original statement is now `theorem poisson_approx_birthday3` derived via `(p_no_triple_tendsto c hc).sub (exp_lambda_tendsto c hc)` + `simpa`",
       "Session 6 (2026-05-07): p_no_triple_n3 in BirthdayProblemOQ03OQ01OQ02.lean (line ~585) — real-number form of n=3 base case: ((|good_n=3|) : ℝ) / (d^3 : ℝ) = 1 − 1/d² for d ≥ 1, proved via good_count_n3, Nat.cast_sub, push_cast, field_simp.",
-      "Session 6 (2026-05-07): repaired 4 Mathlib API drift errors in lambda_tendsto, bad_count_n3, good_count_n3 (introduced upstream after PR #16150 merged on 2026-05-06): tendsto_..._of_le_of_le → primed eventual variant; div_le_div_right → div_le_div_iff_of_pos_right; ← Fintype.card_coe inserted to bridge Finset.card ↔ Fintype.card; explicit predicate passed to filter_card_add_filter_neg_card_eq_card to satisfy DecidablePred synthesis."
+      "Session 6 (2026-05-07): repaired 4 Mathlib API drift errors in lambda_tendsto, bad_count_n3, good_count_n3 (introduced upstream after PR #16150 merged on 2026-05-06): tendsto_..._of_le_of_le → primed eventual variant; div_le_div_right → div_le_div_iff_of_pos_right; ← Fintype.card_coe inserted to bridge Finset.card ↔ Fintype.card; explicit predicate passed to filter_card_add_filter_neg_card_eq_card to satisfy DecidablePred synthesis.",
+      "Session 7, PR #16777 (2026-05-07): added p_no_triple_n3_tendsto in BirthdayProblemOQ03OQ01OQ02.lean (line ~609) — Filter.Tendsto form of Session 6's p_no_triple_n3 asserting P(no triple|n=3, d) → 1 as d → ∞. Proof composes tendsto_natCast_atTop_atTop, Tendsto.atTop_mul_atTop₀ (post-rename API), tendsto_inv_atTop_zero.comp + one_div rewrite, tendsto_const_nhds.sub, and congr' with p_no_triple_n3 (eventually d ≥ 1). File 635 → 676 lines, theorems 28 → 29. Build verification deferred (cold-cache Docker; PR opened as draft)."
     ],
     "insights": [
       "JSON `formal` field drifted from actual Lean axiom: JSON claimed quantitative |triple_prob − (1−exp(−λ))| ≤ C·n⁴/d³, but the Lean axiom is qualitative Tendsto along the threshold scaling — discrepancy was the cause of Session 1's BLOCKED conclusion",


### PR DESCRIPTION
## Summary

Adds `p_no_triple_n3_tendsto`: P(no triple|n=3) → 1 as d → ∞.

A direct corollary of Session 6's `p_no_triple_n3` (which proved P(no triple|n=3, d) = 1 - 1/d² as a real number): since 1/d² → 0, the probability tends to 1.

## Context

Small, complementary contribution to the in-progress Lemma C work. The full Lemma C (`p_no_triple_tendsto`) is the qualitative Poisson convergence along the threshold scaling n_c(d) = ⌊c·d^(2/3)⌋ — strictly stronger, requires method-of-factorial-moments infrastructure absent from Mathlib 4.26.

This corollary covers only the n-fixed regime (c → 0 along the threshold scaling) but verifies internal consistency: as d → ∞ with n held fixed at 3, both sides of the Poisson approximation tend to 1 (P_no_triple → 1, exp(-C(3,3)/d²) = exp(-1/d²) → 1).

## Proof structure

Five-step composition of standard Mathlib lemmas:
1. `(d:ℝ) → ∞` via `tendsto_natCast_atTop_atTop`
2. `(d:ℝ)^2 → ∞` via `Tendsto.atTop_mul_atTop₀` (post-rename API)
3. `1/d² → 0` via `tendsto_inv_atTop_zero.comp`
4. `1 - 1/d² → 1` via `Tendsto.sub` of constants
5. `congr'` with `p_no_triple_n3` (eventually d ≥ 1)

## Status

- [x] Theorem added
- [x] Summary block updated (Session 7 entry)
- [x] \`#check\` directive added
- [ ] Docker build verification (in progress; cold-cache build, Mathlib clone phase)
- [ ] meta.json sync
- [ ] knowledge.md / state.md updates
- [ ] research JSON updates

Draft until Docker build confirms compilation. Build may take 10–15 min from cold cache. If it succeeds, metadata updates will follow.

## Files Modified

- \`proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean\` (+40 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)