### PR TITLE
research(schauder-oq03-oq01-incomplete-01): full helper + kakutani proofs, sorries 2→0, axioms 3→2 (build pending)

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -10,11 +10,12 @@ Brouwer's fixed point theorem using approximate continuous selections.
 3. By compactness of S: extract convergent subsequence x_{n_k} → x*
 4. Use upper hemicontinuity to show x* ∈ F(x*)
 
-**Status**: AXIOMATIZED (3 axioms)
+**Status**: AXIOMATIZED (2 axioms)
 - Axiom 1: Brouwer's FPT in Euclidean space
 - Axiom 2: Approximate selections exist for UHC maps with convex values
-- Axiom 3: Sequential compactness in finite dimensions
-- Proved: The combination argument (Kakutani from the three axioms)
+- Proved: Sequential compactness (from Mathlib's IsCompact.isSeqCompact)
+- Proved: The combination argument (Kakutani from the two axioms via the helper)
+- Proved: The limit-argument helper (approx_fixedpoint_implies_fixedpoint)
 
 **Why approximate selections instead of simplicial approximation?**
 Both approaches work, but approximate selections avoid the need for
@@ -35,6 +36,8 @@ import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Topology.Order.Basic
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist
 import Mathlib.Analysis.Convex.Basic
+import Mathlib.Topology.MetricSpace.HausdorffDistance
+import Mathlib.Topology.Sequences
 import Mathlib.Tactic
 
 noncomputable section
@@ -100,85 +103,207 @@ axiom approx_selection_exists {n : ℕ}
     (S : Set (EuclideanSpace ℝ (Fin n)))
     (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S)
     (F : SetValuedMap (↥S) (↥S))
-    (hF_ne : ∀ x, (F x).Nonempty) (hF_convex : ∀ x, Convex ℝ (F x))
+    (hF_ne : ∀ x, (F x).Nonempty)
+    (hF_convex : ∀ x, Convex ℝ ((Subtype.val '' F x) : Set (EuclideanSpace ℝ (Fin n))))
     (hF_uhc : IsUpperHemicontinuous F)
     (ε : ℝ) (hε : 0 < ε) :
     ∃ f : ↥S → ↥S, Continuous f ∧ IsApproxSelection F (fun x => (f x : ↥S)) ε
 
-/-- **Axiom 3: Sequential Compactness**
+/-- **Sequential Compactness in Metric Spaces**
 
-    In a compact metric space, every sequence has a convergent subsequence. -/
-axiom seq_compact_of_compact {X : Type*} [PseudoMetricSpace X]
+    In a compact metric space, every sequence has a convergent subsequence.
+    Proved from Mathlib's `IsCompact.isSeqCompact` (PseudoMetricSpace is
+    first-countable). Was previously stated as an axiom; now derived. -/
+theorem seq_compact_of_compact {X : Type*} [PseudoMetricSpace X]
     (S : Set X) (hS : IsCompact S) (x : ℕ → X) (hx : ∀ n, x n ∈ S) :
     ∃ (a : X) (φ : ℕ → ℕ), a ∈ S ∧ StrictMono φ ∧
-      Tendsto (x ∘ φ) atTop (𝓝 a)
+      Tendsto (x ∘ φ) atTop (𝓝 a) := by
+  obtain ⟨a, ha, φ, hφ_mono, hφ_tend⟩ := hS.isSeqCompact hx
+  exact ⟨a, φ, ha, hφ_mono, hφ_tend⟩
 
 -- ============================================================
--- Part III: The Proof of Kakutani from Brouwer
+-- Part III: Limit Argument (Helper Lemma)
+-- ============================================================
+
+/-- A continuous function with ε-approximate fixed point property
+    for all ε > 0 has a true fixed point (when the target is closed).
+
+    This captures the limit argument: if we can get "almost" fixed points
+    for any precision, compactness gives a real one.
+
+    **Proof outline**:
+    1. Build sequences `xₙ ∈ S`, `yₙ ∈ F(xₙ)` with `dist(xₙ, yₙ) < 1/(n+1)`
+       via choice on `happrox`.
+    2. Compactness of `S` yields a subsequence `x_{φ(n)} → x*` with `x* ∈ S`.
+    3. Since `dist(x_{φ(n)}, y_{φ(n)}) → 0`, the subsequence
+       `y_{φ(n)} → x*` as well (triangle inequality).
+    4. Suppose `x* ∉ F(x*)`. Case split on `(F x*).Nonempty`:
+       - **Empty case**: take `V := ∅` (open superset of empty F(x*));
+         UHC gives an open `U ∋ x*` with `F(U) ⊆ ∅`, hence eventually
+         `F(x_{φ(n)}) = ∅`, contradicting `y_{φ(n)} ∈ F(x_{φ(n)})`.
+       - **Nonempty case**: `δ := infDist x* (F x*) > 0` since `F(x*)` is
+         closed and `x* ∉ F(x*)`. Take `V := Metric.thickening (δ/2) (F x*)`,
+         an open superset of `F(x*)`. UHC gives an open `U ∋ x*` with
+         `F(U) ⊆ V`. Eventually `x_{φ(n)} ∈ U`, hence `y_{φ(n)} ∈ V`, so
+         `infDist y_{φ(n)} (F x*) < δ/2`. Triangle inequality:
+         `infDist x* (F x*) ≤ dist x* y_{φ(n)} + infDist y_{φ(n)} (F x*) < δ`
+         for `n` large, contradicting `δ = infDist x* (F x*)`. -/
+theorem approx_fixedpoint_implies_fixedpoint
+    {X : Type*} [PseudoMetricSpace X]
+    (S : Set X) (hS : IsCompact S)
+    (F : SetValuedMap X X) (hF_closed : ∀ x ∈ S, IsClosed (F x))
+    (hF_uhc : IsUpperHemicontinuous F)
+    (happrox : ∀ ε > 0, ∃ x ∈ S, ∃ y ∈ F x, dist x y < ε) :
+    ∃ x ∈ S, IsFixedPoint F x := by
+  -- Step 1: build sequences via choice
+  choose xseq hxseq_S yseq hyseq_F hxy_dist using
+    fun n : ℕ => happrox (1 / ((n : ℝ) + 1)) (by positivity)
+  -- Step 2: extract convergent subsequence
+  obtain ⟨x_star, φ, hx_star_S, hφ_mono, hφ_tend⟩ :=
+    seq_compact_of_compact S hS xseq hxseq_S
+  refine ⟨x_star, hx_star_S, ?_⟩
+  -- Step 3: yseq ∘ φ → x_star
+  have h_one_div_to_zero : Tendsto (fun n : ℕ => (1 : ℝ) / ((n : ℝ) + 1))
+      atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  have h_xy_to_zero :
+      Tendsto (fun n => dist (xseq n) (yseq n)) atTop (𝓝 0) :=
+    squeeze_zero (fun _ => dist_nonneg)
+      (fun n => le_of_lt (hxy_dist n)) h_one_div_to_zero
+  have h_xy_phi_to_zero :
+      Tendsto (fun n => dist (xseq (φ n)) (yseq (φ n))) atTop (𝓝 0) :=
+    h_xy_to_zero.comp hφ_mono.tendsto_atTop
+  have h_x_phi_dist_to_zero :
+      Tendsto (fun n => dist (xseq (φ n)) x_star) atTop (𝓝 0) :=
+    tendsto_iff_dist_tendsto_zero.mp hφ_tend
+  have hyφ_tend : Tendsto (fun n => yseq (φ n)) atTop (𝓝 x_star) := by
+    rw [tendsto_iff_dist_tendsto_zero]
+    have h_yx_phi : Tendsto (fun n => dist (yseq (φ n)) (xseq (φ n)))
+        atTop (𝓝 0) := by
+      simpa [dist_comm] using h_xy_phi_to_zero
+    have h_sum :
+        Tendsto (fun n => dist (yseq (φ n)) (xseq (φ n)) +
+            dist (xseq (φ n)) x_star) atTop (𝓝 0) := by
+      simpa using h_yx_phi.add h_x_phi_dist_to_zero
+    exact squeeze_zero (fun _ => dist_nonneg)
+      (fun n => dist_triangle (yseq (φ n)) (xseq (φ n)) x_star) h_sum
+  -- Step 4: derive contradiction from x_star ∉ F x_star
+  by_contra hne
+  have hF_closed_xstar : IsClosed (F x_star) := hF_closed _ hx_star_S
+  by_cases hF_xstar_ne : (F x_star).Nonempty
+  · -- Nonempty case: thickening contradiction
+    set δ : ℝ := Metric.infDist x_star (F x_star) with hδ_def
+    have hδ_pos : 0 < δ := by
+      have h_not_mem_closure : x_star ∉ closure (F x_star) := by
+        rwa [hF_closed_xstar.closure_eq]
+      have h_ne_zero : Metric.infDist x_star (F x_star) ≠ 0 := by
+        intro h
+        exact h_not_mem_closure
+          ((Metric.mem_closure_iff_infDist_zero hF_xstar_ne).mpr h)
+      exact lt_of_le_of_ne Metric.infDist_nonneg (Ne.symm h_ne_zero)
+    have hδ_half_pos : 0 < δ / 2 := by linarith
+    -- Define V as the union of (δ/2)-balls around F x_star (open neighborhood of F x_star)
+    let V : Set X := ⋃ y ∈ F x_star, Metric.ball y (δ / 2)
+    have hV_open : IsOpen V := isOpen_biUnion (fun _ _ => Metric.isOpen_ball)
+    have hF_in_V : F x_star ⊆ V := by
+      intro y hy
+      exact Set.mem_biUnion hy (Metric.mem_ball_self hδ_half_pos)
+    let U : Set X := {z | F z ⊆ V}
+    have hU_open : IsOpen U := hF_uhc V hV_open
+    have hxstar_U : x_star ∈ U := hF_in_V
+    -- Eventually xseq (φ n) ∈ U
+    have h_eventually_U : ∀ᶠ n in atTop, xseq (φ n) ∈ U :=
+      hφ_tend.eventually (hU_open.mem_nhds hxstar_U)
+    -- Eventually dist x_star (yseq (φ n)) < δ/2
+    have h_dist_yφ : Tendsto (fun n => dist x_star (yseq (φ n)))
+        atTop (𝓝 0) := by
+      have h := tendsto_iff_dist_tendsto_zero.mp hyφ_tend
+      simpa [dist_comm] using h
+    have h_eventually_dist :
+        ∀ᶠ n in atTop, dist x_star (yseq (φ n)) < δ / 2 :=
+      h_dist_yφ.eventually (Iio_mem_nhds hδ_half_pos)
+    -- Combine to get the contradiction
+    obtain ⟨n, hn_U, hn_dist⟩ :=
+      (h_eventually_U.and h_eventually_dist).exists
+    -- yseq (φ n) ∈ V, so ∃ z ∈ F x_star, dist (yseq (φ n)) z < δ/2
+    have h_yseq_in_V : yseq (φ n) ∈ V := hn_U (hyseq_F (φ n))
+    obtain ⟨z, hz_F, hz_ball⟩ := Set.mem_iUnion₂.mp h_yseq_in_V
+    rw [Metric.mem_ball] at hz_ball
+    -- δ = infDist x_star (F x_star) ≤ dist x_star z (since z ∈ F x_star)
+    have h_delta_le_dist : δ ≤ dist x_star z := by
+      have hi := Metric.infDist_le_dist_of_mem (x := x_star) hz_F
+      linarith [hδ_def]
+    -- triangle inequality on dist x_star z
+    have h_tri : dist x_star z ≤ dist x_star (yseq (φ n)) + dist (yseq (φ n)) z :=
+      dist_triangle _ _ _
+    have hcontra : δ < δ := by
+      calc δ ≤ dist x_star z := h_delta_le_dist
+        _ ≤ dist x_star (yseq (φ n)) + dist (yseq (φ n)) z := h_tri
+        _ < δ / 2 + δ / 2 := by linarith
+        _ = δ := by ring
+    exact lt_irrefl _ hcontra
+  · -- Empty case
+    rw [Set.not_nonempty_iff_eq_empty] at hF_xstar_ne
+    let U : Set X := {z | F z ⊆ (∅ : Set X)}
+    have hU_open : IsOpen U := hF_uhc ∅ isOpen_empty
+    have hxstar_U : x_star ∈ U := by
+      show F x_star ⊆ ∅
+      rw [hF_xstar_ne]
+    have h_eventually_U : ∀ᶠ n in atTop, xseq (φ n) ∈ U :=
+      hφ_tend.eventually (hU_open.mem_nhds hxstar_U)
+    obtain ⟨n, hn⟩ := h_eventually_U.exists
+    -- F (xseq (φ n)) ⊆ ∅, but yseq (φ n) ∈ F (xseq (φ n))
+    exact (hn (hyseq_F (φ n))).elim
+
+-- ============================================================
+-- Part IV: The Proof of Kakutani from Brouwer
 -- ============================================================
 
 /-- **Kakutani's FPT from Brouwer + Approximate Selections**
 
-    Proof outline:
-    1. For each k, get a continuous (1/k)-approximate selection f_k
-    2. Apply Brouwer: ∃ x_k with f_k(x_k) = x_k
-    3. By compactness: x_{φ(k)} → x* for some subsequence
-    4. Show x* ∈ F(x*):
-       - Suppose not: x* ∉ F(x*), which is closed
-       - Then d(x*, F(x*)) = δ > 0
-       - By UHC: eventually F(x_{φ(k)}) ⊆ B(F(x*), δ/2)
-       - But d(x_{φ(k)}, F(x_{φ(k)})) < 1/φ(k) → 0
-       - So eventually d(x_{φ(k)}, B(F(x*), δ/2)) < 1/φ(k) → 0
-       - Hence d(x*, F(x*)) ≤ δ/2 < δ, contradiction. -/
+    Proof sketch (filled body below):
+    1. For each ε > 0, get a continuous ε-approximate selection f_ε of F
+       via `approx_selection_exists`.
+    2. Apply `brouwer_fpt` to f_ε on S to get x₀ with f_ε(x₀) = x₀.
+    3. The approximate-selection property at x₀ gives y ∈ F(x₀) with
+       `dist(f_ε(x₀), y) < ε`. Since f_ε(x₀) = x₀, `dist(x₀, y) < ε`.
+    4. Hand the family of ε-witnesses to `approx_fixedpoint_implies_fixedpoint`,
+       which uses sequential compactness + closedness + UHC of F to extract
+       a genuine fixed point. -/
 theorem kakutani_from_brouwer {n : ℕ}
     (S : Set (EuclideanSpace ℝ (Fin n)))
     (hS_ne : S.Nonempty) (hS_compact : IsCompact S) (hS_convex : Convex ℝ S)
     (F : SetValuedMap (↥S) (↥S))
     (hF_ne : ∀ x, (F x).Nonempty)
     (hF_closed : ∀ x, IsClosed (F x))
-    (hF_convex : ∀ x, Convex ℝ (F x))
+    (hF_convex : ∀ x, Convex ℝ ((Subtype.val '' F x) : Set (EuclideanSpace ℝ (Fin n))))
     (hF_uhc : IsUpperHemicontinuous F) :
     ∃ x : ↥S, IsFixedPoint F x := by
-  -- Planned reduction to `approx_fixedpoint_implies_fixedpoint` (defined in Part V):
-  --
-  -- Step A: For each ε > 0, obtain a continuous ε-approximate selection f_ε of F
-  --         using axiom `approx_selection_exists`.
-  -- Step B: Apply axiom `brouwer_fpt` to f_ε on the compact convex S to get
-  --         x_0 with f_ε(x_0) = x_0.
-  -- Step C: The approximate-selection property at x_0 yields y ∈ F(x_0) with
-  --         dist(f_ε(x_0), y) < ε. Since f_ε(x_0) = x_0, this gives dist(x_0, y) < ε.
-  -- Step D: Hand the family of ε-witnesses to `approx_fixedpoint_implies_fixedpoint`,
-  --         which uses sequential compactness + closedness + UHC of F to extract a
-  --         genuine fixed point.
-  --
-  -- The subtype `↥S` inherits a PseudoMetricSpace; `hS_compact` yields
-  -- `CompactSpace ↥S` so `Set.univ : Set ↥S` is compact in the subtype topology.
-  --
-  -- Wiring (requires moving `approx_fixedpoint_implies_fixedpoint` above this theorem
-  -- since Lean 4 forbids forward references within a single file):
-  --
-  --   have hUniv : IsCompact (Set.univ : Set ↥S) := by
-  --     haveI : CompactSpace ↥S := isCompact_iff_compactSpace.mp hS_compact
-  --     exact isCompact_univ
-  --   have hF_closed' : ∀ x ∈ (Set.univ : Set ↥S), IsClosed (F x) :=
-  --     fun x _ => hF_closed x
-  --   have happrox : ∀ ε > 0, ∃ x ∈ (Set.univ : Set ↥S),
-  --       ∃ y ∈ F x, dist x y < ε := by
-  --     intro ε hε
-  --     obtain ⟨f, hf_cont, hf_approx⟩ :=
-  --       approx_selection_exists S hS_ne hS_compact hS_convex F
-  --         hF_ne hF_convex hF_uhc ε hε
-  --     obtain ⟨x0, hx0⟩ := brouwer_fpt S hS_ne hS_compact hS_convex f hf_cont
-  --     obtain ⟨y, hy_F, hy_dist⟩ := hf_approx x0
-  --     exact ⟨x0, Set.mem_univ _, y, hy_F, by simpa [hx0] using hy_dist⟩
-  --   obtain ⟨x_star, _, hfp⟩ :=
-  --     approx_fixedpoint_implies_fixedpoint (Set.univ : Set ↥S) hUniv F
-  --       hF_closed' hF_uhc happrox
-  --   exact ⟨x_star, hfp⟩
-  sorry
+  -- The subtype ↥S inherits a PseudoMetricSpace from EuclideanSpace.
+  -- Compactness of ↥S follows from compactness of S in the ambient space.
+  haveI : CompactSpace ↥S := isCompact_iff_compactSpace.mp hS_compact
+  have hUniv : IsCompact (Set.univ : Set ↥S) := isCompact_univ
+  have hF_closed' : ∀ x ∈ (Set.univ : Set ↥S), IsClosed (F x) :=
+    fun x _ => hF_closed x
+  have happrox_total :
+      ∀ ε > 0, ∃ x ∈ (Set.univ : Set ↥S), ∃ y ∈ F x, dist x y < ε := by
+    intro ε hε
+    obtain ⟨f, hf_cont, hf_approx⟩ :=
+      approx_selection_exists S hS_ne hS_compact hS_convex F
+        hF_ne hF_convex hF_uhc ε hε
+    obtain ⟨x0, hx0⟩ := brouwer_fpt S hS_ne hS_compact hS_convex f hf_cont
+    obtain ⟨y, hy_F, hy_dist⟩ := hf_approx x0
+    refine ⟨x0, Set.mem_univ _, y, hy_F, ?_⟩
+    -- dist (f x0) y < ε with f x0 = x0 ⇒ dist x0 y < ε
+    rw [← hx0]
+    exact hy_dist
+  obtain ⟨x_star, _, hfp⟩ :=
+    approx_fixedpoint_implies_fixedpoint (Set.univ : Set ↥S) hUniv F
+      hF_closed' hF_uhc happrox_total
+  exact ⟨x_star, hfp⟩
 
 /-
-## Part IV: Why This Matters
+## Part V: Why This Matters
 
 The proof of Kakutani from Brouwer via approximate selections demonstrates
 the power of three fundamental principles:
@@ -192,89 +317,33 @@ of Nash equilibrium existence in game theory.
 ### Infrastructure Needed in Mathlib
 - Brouwer's FPT for general compact convex sets (currently only for closed balls)
 - Partition of unity construction for finite open covers in Euclidean space
-- Sequential compactness equivalence for metric spaces (partially available)
 
 ### Alternative Proof Paths
 1. **Simplicial approximation**: Triangulate S, define PL approximations. Avoids
    partition of unity but needs triangulation machinery.
 2. **Michael's selection theorem**: Stronger than needed here (gives exact continuous
    selections for lower hemicontinuous maps with convex values).
--/
 
--- ============================================================
--- Part V: Structural Lemma (Proved)
--- ============================================================
-
-/-- A continuous function with ε-approximate fixed point property
-    for all ε > 0 has a true fixed point (when the target is closed).
-
-    This captures the limit argument: if we can get "almost" fixed points
-    for any precision, compactness gives a real one.
-
-    **Proof outline**:
-    1. Build sequences `xₙ ∈ S`, `yₙ ∈ F(xₙ)` with `dist(xₙ, yₙ) < 1/(n+1)`
-       via choice on `happrox`.
-    2. Compactness of `S` yields a subsequence `x_{φ(n)} → x*` with `x* ∈ S`
-       (`IsCompact.tendsto_subseq` for first-countable / metric spaces —
-       automatic in a `PseudoMetricSpace`).
-    3. Since `dist(x_{φ(n)}, y_{φ(n)}) → 0` (by squeeze with `1/(φ n + 1) → 0`),
-       the subsequence `y_{φ(n)} → x*` as well.
-    4. Suppose `x* ∉ F(x*)`. Then `F(x*)` is closed (by `hF_closed x* hx_star_S`)
-       and either empty or `δ := infDist x* (F x*) > 0`.
-       - **Empty case**: take `V := ∅` (open and contains `F(x*)`); UHC gives an
-         open `U ∋ x*` with `F(U) ⊆ ∅`, hence eventually `F(x_{φ(n)}) = ∅`,
-         contradicting `y_{φ(n)} ∈ F(x_{φ(n)})`.
-       - **Nonempty case**: take `V := Metric.thickening (δ/2) (F x*)`, an open
-         superset of `F(x*)`. UHC gives an open `U ∋ x*` with `F(U) ⊆ V`.
-         Eventually `x_{φ(n)} ∈ U`, hence `y_{φ(n)} ∈ V`, so
-         `infDist y_{φ(n)} (F x*) < δ/2`. Triangle inequality:
-         `infDist x* (F x*) ≤ dist x* y_{φ(n)} + infDist y_{φ(n)} (F x*) < δ`
-         for `n` large, contradicting `δ = infDist x* (F x*)`.
-
-    **Mathlib API needed** (extra imports beyond current):
-    - `Mathlib.Topology.MetricSpace.HausdorffDistance` for `Metric.infDist`,
-      `Metric.infDist_le_dist_add_infDist`, `Metric.infDist_pos_iff_not_mem_closure`.
-    - `Mathlib.Topology.MetricSpace.Thickening` for `Metric.thickening` and
-      `Metric.isOpen_thickening`.
-    - `Mathlib.Topology.Sequences` for `IsCompact.tendsto_subseq` (often pulled
-      transitively, but explicit import is safer).
-
-    **Status**: Documented; proof body remains a single `sorry`. Steps 1–2 are
-    straightforward (`choose ... using fun n => happrox (1/(n+1)) ...` and
-    `hS.tendsto_subseq`). Step 4's nonempty case is the technical core. -/
-theorem approx_fixedpoint_implies_fixedpoint
-    {X : Type*} [PseudoMetricSpace X]
-    (S : Set X) (hS : IsCompact S)
-    (F : SetValuedMap X X) (hF_closed : ∀ x ∈ S, IsClosed (F x))
-    (hF_uhc : IsUpperHemicontinuous F)
-    (happrox : ∀ ε > 0, ∃ x ∈ S, ∃ y ∈ F x, dist x y < ε) :
-    ∃ x ∈ S, IsFixedPoint F x := by
-  sorry
-
-/-
 ## Summary
 
-### Axioms (3)
+### Axioms (2)
 1. `brouwer_fpt` - Brouwer's FPT for compact convex subsets of ℝⁿ
 2. `approx_selection_exists` - UHC + convex values → continuous ε-selections exist
-3. `seq_compact_of_compact` - Compact metric spaces are sequentially compact
 
-### Framework (proved modulo sorry)
-- `kakutani_from_brouwer` - The main reduction: Kakutani from the three axioms
+### Theorems (proved)
+- `seq_compact_of_compact` - Sequential compactness in compact metric spaces
+  (was an axiom; now derived from Mathlib)
 - `approx_fixedpoint_implies_fixedpoint` - Limit argument for approximate fixed points
+- `kakutani_from_brouwer` - The main reduction: Kakutani from the two axioms
 
-### Path to Full Proof
+### Path to Full Verification
 1. Prove `approx_selection_exists` using partition of unity (main infrastructure gap)
 2. Verify `brouwer_fpt` against Mathlib's existing Brouwer formalization
-3. The combination argument (`kakutani_from_brouwer`) is the straightforward part
-
-### Axiom Count: 3
-These axioms factor the proof into independent, well-understood components.
-Each can be proved separately when Mathlib infrastructure is available.
 -/
 
 #check @brouwer_fpt
 #check @approx_selection_exists
+#check @approx_fixedpoint_implies_fixedpoint
 #check @kakutani_from_brouwer
 
 end KakutaniFromBrouwer

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/knowledge.md
@@ -6,16 +6,72 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The file SchauderFixedPointOQ03OQ01.lean derives Kakutani's fixed point theorem
+from Brouwer's via Cellina's approximate continuous selections + a metric-space
+limit argument. Two sorries existed pre-S3:
+- `kakutani_from_brouwer` (combination argument)
+- `approx_fixedpoint_implies_fixedpoint` (limit argument helper)
+
+Three axioms were declared (Brouwer FPT, approximate selection existence,
+sequential compactness).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### S2 (researcher-3, 2026-05-07)
+- Identified that closing `approx_fixedpoint_implies_fixedpoint` also closes
+  `kakutani_from_brouwer` via a clean reduction.
+- Documented a 4-step proof outline for the helper.
+- Build verification deferred due to memory pressure.
+
+### S3 (researcher-11, 2026-05-08)
+
+#### Pre-existing compilation bug
+The `Convex ℝ (F x)` clause (in both the `approx_selection_exists` axiom and
+the `kakutani_from_brouwer` theorem signature) was malformed: `F x : Set ↥S`
+where `↥S` lacks `AddCommMonoid`. Lean elaborated this as a `sorry` placeholder.
+The S2 PR (#16731) was docstring-only and was merged without an actual build,
+so this masked compilation failure went unnoticed. Fix: lift via
+`Subtype.val '' F x : Set (EuclideanSpace ℝ (Fin n))`, which is well-typed.
+
+#### Axiom elimination
+`seq_compact_of_compact` was an axiom but is just a one-line consequence of
+Mathlib's `IsCompact.isSeqCompact` for `PseudoMetricSpace`. Now a theorem.
+Axiom count: 3 → 2.
+
+#### Helper proof
+`approx_fixedpoint_implies_fixedpoint` proved using:
+- `choose` to extract sequences from `happrox`
+- `seq_compact_of_compact` for subsequence
+- `squeeze_zero` + `tendsto_one_div_add_atTop_nhds_zero_nat` for `dist→0`
+- `tendsto_iff_dist_tendsto_zero` + `dist_triangle` for `yseq→x_star`
+- `by_contra` + case split on `(F x*).Nonempty`
+- Nonempty case: union-of-balls `V := ⋃ y ∈ F x*, Metric.ball y (δ/2)` as the
+  open neighborhood (instead of `Metric.thickening` to avoid EMetric API
+  uncertainty), then UHC + triangle inequality with `Metric.infDist_le_dist_of_mem`.
+- Empty case: `V := ∅` directly via UHC.
+
+#### Kakutani proof body
+~25 lines: chains `approx_selection_exists` + `brouwer_fpt` +
+`approx_fixedpoint_implies_fixedpoint` via the subtype-univ trick
+(`isCompact_iff_compactSpace.mp` + `isCompact_univ`).
+
+#### Build verification deferred
+Docker Desktop caps each container at ~7.65GiB regardless of `LEAN_MEMORY_LIMIT`;
+with 8+ concurrent agents, my build OOM'd at 510s during the Mathlib clone phase.
+Code structure-checked and lemma names cross-referenced against gallery usage
+but not Lean-compiled. Marked as build-pending in PR.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- `Metric.thickening`: avoided due to EMetric/`ENNReal.ofReal` complications and
+  uncertainty about exact lemma names (`mem_thickening_iff` vs
+  `mem_thickening_iff_infDist_lt`). Replaced with explicit union-of-balls.
+- `Metric.infDist_le_dist_add_infDist`: name in original docstring may be wrong
+  (Mathlib has `infDist_le_infDist_add_dist` with reversed order); avoided by
+  reformulating contradiction via `dist_triangle` + `infDist_le_dist_of_mem`.
+- `simp_rw [dist_comm]`: would loop because `dist_comm a b = dist b a` rewrites
+  in both directions. Replaced with `simpa [dist_comm] using h`.

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -1,25 +1,33 @@
 # Research State: schauder-fixed-point-oq-03-oq-01-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-04-21T17:08:35+02:00
-**Iteration**: 1
+**Since**: 2026-05-08T00:55:00Z
+**Iteration**: 3
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Build verification pending. Helper proved, kakutani filled, axiom 3 eliminated,
+Convex hypothesis type-fixed.
 
 ## Active Approach
-None yet.
+Direct proof via:
+- `seq_compact_of_compact` from `IsCompact.isSeqCompact` (axiom 3 → theorem)
+- `approx_fixedpoint_implies_fixedpoint` via choose + seq compact + squeeze +
+  by_contra + case split + union-of-balls UHC + triangle inequality
+- `kakutani_from_brouwer` via skeleton wired through helper
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2 (S2 documentation; S3 full proof submission)
 
 ## Blockers
-None.
+Docker memory contention prevented build verification. Code committed
+contingent on next-session re-build.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Re-run `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01`
+when fewer agents compete for memory. If proof has bugs (likely lemma name
+mismatches), iterate. Otherwise update meta.json sorries=0, axiomCount=2 to
+match file content.

--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "schauder-fixed-point-oq-03-oq-01-incomplete-01",
   "title": "Kakutani from Brouwer via Approximate Selections (2 sorries)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -28,24 +28,29 @@
     "goal": "Fill 2 sorries using Mathlib's partition of unity machinery"
   },
   "currentState": {
-    "phase": "PLAN",
-    "since": "2026-05-07T23:10:00Z",
-    "iteration": 2,
-    "focus": "Move approx_fixedpoint_implies_fixedpoint above kakutani_from_brouwer; close limit-argument sorry",
+    "phase": "ACT",
+    "since": "2026-05-07T22:13:37Z",
+    "iteration": 3,
+    "focus": "Build verification pending. Helper proved, kakutani filled, axiom 3 eliminated. Convex hypothesis type-fixed.",
     "blockers": [],
-    "nextAction": "ATTEMPT: prove approx_fixedpoint_implies_fixedpoint using IsCompact.tendsto_subseq + Metric.thickening + Metric.infDist; once closed, kakutani_from_brouwer reduces to it",
+    "nextAction": "Re-run Docker build when memory contention subsides; if proof has bugs, iterate. Then update sorries/axiomCount.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 0,
-      "approachesTried": 1
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "S2 (researcher-3, 2026-05-07): The 2 sorries are NOT in approx_selection_exists (which is an axiom). They are in (1) kakutani_from_brouwer and (2) approx_fixedpoint_implies_fixedpoint. Architectural insight: kakutani_from_brouwer reduces cleanly to approx_fixedpoint_implies_fixedpoint by chaining axioms 1+2 (brouwer_fpt + approx_selection_exists) to produce ε-approximate fixed points, then invoking the limit-argument helper. Closing the helper closes BOTH sorries. Detailed proof outlines + commented code skeletons committed in PR (proofs/Proofs/SchauderFixedPointOQ03OQ01.lean).",
+    "progressSummary": "S3 (researcher-11, 2026-05-08): Major restructuring submitted, build verification pending. Changes: (1) Eliminated seq_compact_of_compact axiom — replaced with theorem proved from IsCompact.isSeqCompact (3 axioms → 2). (2) Wrote full proof of approx_fixedpoint_implies_fixedpoint using union-of-balls open neighborhood + UHC + sequential compactness. (3) Filled kakutani_from_brouwer body with the previously-commented skeleton. (4) FIXED a pre-existing compilation error: Convex ℝ (F x) was malformed because Set ↥S has no AddCommMonoid; rewrote as Convex ℝ (Subtype.val '' F x) (lifted to ambient EuclideanSpace). The merged S2 commit (#16731) was docstring-only and never actually compiled. (5) Build attempt OOM'd during Mathlib clone+build under heavy multi-agent contention (8+ concurrent docker builds). File counts: 0 sorries, 2 axioms, 349 lines, 3 theorems, 4 definitions.",
     "builtItems": [
       "Detailed 4-step proof outline for approx_fixedpoint_implies_fixedpoint (committed as docstring) — covers sequence construction, subsequence extraction, limit transfer, and UHC-contradiction with empty/nonempty case split.",
       "Commented-out reduction skeleton for kakutani_from_brouwer (committed in tactic block) — exact 10-line proof body once the helper is moved up.",
-      "Architectural insight that closing the helper closes BOTH sorries (no separate work needed for kakutani_from_brouwer beyond reordering)."
+      "Architectural insight that closing the helper closes BOTH sorries (no separate work needed for kakutani_from_brouwer beyond reordering).",
+      "Eliminated axiom seq_compact_of_compact: now a theorem proved from IsCompact.isSeqCompact (Mathlib.Topology.Sequences). Axiom count: 3 → 2.",
+      "Full proof of approx_fixedpoint_implies_fixedpoint: ~80 lines, uses choose + seq_compact_of_compact + squeeze_zero + tendsto_iff_dist_tendsto_zero + by_contra + case-split on (F x*).Nonempty.",
+      "Full proof of kakutani_from_brouwer: ~25 lines, chains approx_selection_exists + brouwer_fpt + approx_fixedpoint_implies_fixedpoint via subtype-univ trick.",
+      "Type fix for Convex ℝ ((Subtype.val '' F x) : Set (EuclideanSpace ℝ (Fin n))) replacing malformed Convex ℝ (F x) — addresses pre-existing compilation error.",
+      "Added imports: Mathlib.Topology.MetricSpace.HausdorffDistance (for Metric.infDist family), Mathlib.Topology.Sequences (for IsCompact.isSeqCompact)."
     ],
     "insights": [
       "approx_selection_exists is an AXIOM, not a sorry — the file's 2 sorries are kakutani_from_brouwer and approx_fixedpoint_implies_fixedpoint. The original problemStatement framing is misleading.",
@@ -54,7 +59,11 @@
       "The subtype ↥S inherits PseudoMetricSpace from the ambient Euclidean space; CompactSpace ↥S follows from IsCompact S (via isCompact_iff_compactSpace.mp). Set.univ : Set ↥S is then compact.",
       "approx_fixedpoint_implies_fixedpoint proof: build sequences via choice with εₙ = 1/(n+1); extract convergent subsequence (IsCompact.tendsto_subseq, automatic for metric); show y_φ(n) → x* (squeeze); contradict x* ∉ F(x*) using UHC + thickening of F(x*) by δ/2 where δ = infDist(x*, F(x*)) > 0.",
       "Empty-F(x*) edge case: take V = ∅ (open superset of empty F(x*)); UHC forces F(x_φ(n)) = ∅ eventually, contradicting y_φ(n) ∈ F(x_φ(n)).",
-      "Docker build attempt with added imports (Mathlib.Topology.Sequences, Mathlib.Topology.Compactness.Compact) hit 32GB memory limit during Mathlib clone+build. Build verification deferred to a session with warm Docker cache OR a slimmer import set."
+      "Docker build attempt with added imports (Mathlib.Topology.Sequences, Mathlib.Topology.Compactness.Compact) hit 32GB memory limit during Mathlib clone+build. Build verification deferred to a session with warm Docker cache OR a slimmer import set.",
+      "PRE-EXISTING COMPILATION BUG: original Convex ℝ (F x) clause (in approx_selection_exists axiom and kakutani_from_brouwer signature) failed to type-check because ↥S = Subtype (· ∈ S) does not have AddCommMonoid. Lean silently substituted sorry for the elaborated type. The S2 PR (#16731) was docstring-only and merged without actual build verification, masking this. Fix: lift to ambient via Subtype.val '' F x.",
+      "seq_compact_of_compact AXIOM ELIMINATION: Mathlib's IsCompact.isSeqCompact (Mathlib.Topology.Sequences) directly provides the result for PseudoMetricSpace. The axiom is a one-line consequence: hS.isSeqCompact hx gives the existential witness.",
+      "HELPER PROOF STRATEGY: choose for sequence construction; seq_compact_of_compact for subsequence; squeeze_zero with tendsto_one_div_add_atTop_nhds_zero_nat for dist→0; tendsto_iff_dist_tendsto_zero + dist_triangle for yseq→x_star; case split on (F x*).Nonempty; nonempty case uses union-of-balls V := ⋃ y ∈ F x*, Metric.ball y (δ/2) instead of Metric.thickening (avoids EMetric API uncertainty); empty case uses V := ∅ directly.",
+      "BUILD VERIFICATION DEFERRED: Docker Desktop caps each container at ~7.65GiB regardless of LEAN_MEMORY_LIMIT=32768m; with 8+ concurrent agents, my build OOM'd at 510s during Mathlib clone. Code structure-checked and lemma names cross-referenced against gallery usage but not Lean-compiled. Re-run when contention is lower."
     ],
     "mathlibGaps": [
       "Mathlib.Topology.MetricSpace.HausdorffDistance for Metric.infDist, Metric.infDist_le_dist_add_infDist, Metric.infDist_pos_iff_not_mem_closure",
@@ -63,12 +72,10 @@
       "Mathlib.Topology.PartitionOfUnity has partition of unity constructions (only relevant if proving approx_selection_exists; not needed for the two current sorries)"
     ],
     "nextSteps": [
-      "(1) Move `approx_fixedpoint_implies_fixedpoint` block from Part V to between the axioms (Part II) and `kakutani_from_brouwer` (Part III) — or rename Parts. Forward references are not allowed in Lean 4.",
-      "(2) Add imports: Mathlib.Topology.MetricSpace.HausdorffDistance, Mathlib.Topology.MetricSpace.Thickening, Mathlib.Topology.Sequences. Verify these don't bloat compile time excessively in Docker.",
-      "(3) Prove approx_fixedpoint_implies_fixedpoint following the documented outline. Key tactic chain: choose for sequence construction; hS.tendsto_subseq for subsequence; by_cases on (F x_star).Nonempty; in nonempty case: let δ := Metric.infDist x_star (F x_star); use Metric.infDist_pos_iff_not_mem_closure (after closing F(x*) closure case); construct V := Metric.thickening (δ/2) (F x_star); use hF_uhc V (Metric.isOpen_thickening) to get U ∋ x_star; combine with hφ_tend and triangle inequality on infDist.",
-      "(4) Replace `kakutani_from_brouwer`'s sorry with the commented skeleton already present in the file (uncomment, remove the closing `sorry`).",
-      "(5) Docker build to verify; update meta.json sorries from 2 to 0 if both close (and adjust theoremCount/lineCount).",
-      "(6) If Docker OOMs again, try with --memory 65536 or run on a host with more RAM, OR build incrementally (helper first, kakutani_from_brouwer in a follow-up)."
+      "(1) Re-run Docker build when memory contention is lower (current: 8+ concurrent builds OOM'd at 510s). Verify all proofs compile.",
+      "(2) If proof bugs surface, fix and resubmit. Likely candidates: lemma name mismatches (Metric.infDist_le_dist_of_mem, Set.mem_iUnion₂, isOpen_biUnion).",
+      "(3) Once verified, update meta.json + research JSON to reflect successful proof closure.",
+      "(4) Consider follow-up: prove approx_selection_exists axiom 2 from Mathlib partition-of-unity (would leave only Brouwer's FPT as an axiom)."
     ]
   },
   "tags": [
@@ -96,7 +103,7 @@
     ]
   },
   "started": "2026-04-21T00:00:00Z",
-  "lastUpdate": "2026-05-07T23:10:00Z",
+  "lastUpdate": "2026-05-07T22:13:37Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

S3 of `schauder-fixed-point-oq-03-oq-01-incomplete-01`. Closes both pre-existing sorries in `SchauderFixedPointOQ03OQ01.lean`, eliminates one of the three axioms, and fixes a pre-existing compilation bug. **Build verification was deferred due to Docker memory contention — see Verification Status.**

### File-level changes
- `approx_fixedpoint_implies_fixedpoint` — sorry → proved (~80 lines)
- `kakutani_from_brouwer` — sorry → proved (~25 lines via the previously-commented skeleton)
- `seq_compact_of_compact` — axiom → theorem (1 line, derived from `IsCompact.isSeqCompact`)
- `Convex ℝ (F x)` (malformed; failed `AddCommMonoid ↥S` synthesis) → `Convex ℝ ((Subtype.val '' F x) : Set (EuclideanSpace ℝ (Fin n)))`
- imports: + `Mathlib.Topology.MetricSpace.HausdorffDistance`, + `Mathlib.Topology.Sequences`

### Counts (file content)

| Count | Before | After |
|------:|-------:|------:|
| sorries | 2 | **0** |
| axioms | 3 | **2** |
| theorems | 2 | **3** |
| definitions | 4 | 4 |
| lines | 217* | 349 |

*Pre-S3 main meta.json claimed 217 but actual file (post-S2 #16731) was 280.

## Proof structure

### `approx_fixedpoint_implies_fixedpoint`

1. `choose` extracts `xseq, yseq` from `happrox` with `dist (xseq n) (yseq n) < 1/(n+1)`.
2. `seq_compact_of_compact` → subsequence `x_{φ n} → x*`.
3. `squeeze_zero` + `tendsto_one_div_add_atTop_nhds_zero_nat` → `dist (xseq n) (yseq n) → 0`.
4. `tendsto_iff_dist_tendsto_zero` + `dist_triangle` ⟹ `yseq ∘ φ → x*`.
5. `by_contra` + `by_cases (F x*).Nonempty`:
   - **Nonempty**: `δ := infDist x* (F x*) > 0` (from closedness + `mem_closure_iff_infDist_zero`). Take `V := ⋃ y ∈ F x*, Metric.ball y (δ/2)` as the open neighborhood. UHC ⟹ eventually `xseq (φ n) ∈ {z | F z ⊆ V}` ⟹ `yseq (φ n) ∈ V`. Extract `z ∈ F x*` with `dist (yseq (φ n)) z < δ/2`. Combined with `infDist_le_dist_of_mem hz_F` and `dist_triangle`: `δ ≤ dist x* z ≤ dist x* (yseq (φ n)) + dist (yseq (φ n)) z < δ/2 + δ/2 = δ`. Contradiction.
   - **Empty**: `F x* = ∅`, so `V := ∅` and UHC ⟹ eventually `F (xseq (φ n)) ⊆ ∅`, contradicting `yseq (φ n) ∈ F (xseq (φ n))`.

### `kakutani_from_brouwer`

Subtype-univ trick: `isCompact_iff_compactSpace.mp hS_compact` makes `↥S` a `CompactSpace`, so `Set.univ : Set ↥S` is compact. Build `happrox_total` from `approx_selection_exists` + `brouwer_fpt` (`f x0 = x0` + `dist (f x0) y < ε` ⟹ `dist x0 y < ε`). Hand off to `approx_fixedpoint_implies_fixedpoint`.

### `seq_compact_of_compact`

```lean
theorem seq_compact_of_compact ... : ∃ a φ, ... :=
  let ⟨a, ha, φ, hφ_mono, hφ_tend⟩ := hS.isSeqCompact hx
  ⟨a, φ, ha, hφ_mono, hφ_tend⟩
```

## Pre-existing bug discovered

The S2 commit (#16731) was docstring-only and was apparently merged without an actual Docker build. The original `axiom approx_selection_exists` and `theorem kakutani_from_brouwer` both contained `(hF_convex : ∀ x, Convex ℝ (F x))` with `F x : Set ↥S`. Lean cannot synthesize `AddCommMonoid ↥S` for an arbitrary subtype, so it silently substituted `sorry` at the elaborated type level. The file never compiled. This PR fixes that by lifting via `Subtype.val '' F x`, which is a `Set (EuclideanSpace ℝ (Fin n))` and well-typed for `Convex ℝ`.

## Verification status

⚠️ **Build verification deferred — Docker OOM.** Two build attempts ran; both terminated under the per-container ~7.65 GiB Docker Desktop ceiling during the Mathlib clone phase (`LEAN_MEMORY_LIMIT=32768m` is silently clamped to the VM ceiling). Eight concurrent agent builds were active. See `feedback_docker_memory_ceiling.md` for the systemic constraint.

Lemma names were cross-referenced against gallery usage in this codebase:
- `tendsto_one_div_add_atTop_nhds_zero_nat` (Erdos1150Problem.lean:218, BaselProblemOQ01OQ01OQ02.lean:753)
- `Iio_mem_nhds` (Erdos25Problem.lean:54, Erdos680Problem.lean:91, Erdos1000Problem.lean:634)
- `IsCompact.isSeqCompact` (SchauderFixedPoint.lean:204, BrouwerFixedPointOQ04OQ04.lean:276)
- `isCompact_iff_compactSpace.mp` (PoincareConjecture.lean:491)
- `Metric.mem_closure_iff_infDist_zero` (BorsukUlamOQ03.lean:3154,3216)
- `Metric.infDist_zero_of_mem` / `Metric.infDist_nonneg` (BorsukUlamOQ03.lean — many)
- `squeeze_zero` (Erdos263Problem.lean:291)

Likely-failing-but-fixable points if any:
- `Set.mem_iUnion₂.mp` for the union-of-balls destructure
- `Metric.infDist_le_dist_of_mem` exact name (vs `infDist_le_dist_of_mem` without `Metric.`)
- The `simpa [dist_comm] using h` rewrites

## Test plan

- [ ] Re-run `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01` when concurrent agent count is lower.
- [ ] If build fails, identify and fix the failing lemma name / tactic, push as follow-up.
- [ ] If build passes, no further action needed; meta.json already reflects file content.

## Status

**Outcome**: progress (proof submitted, build pending)
**Phase**: ACT (verification awaited)

🤖 Generated by researcher-11