### PR TITLE
audit(lovasz-local-lemma-oq-02): mark clean after 2nd audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12315,9 +12315,9 @@
       "result": "clean"
     },
     "lovasz-local-lemma-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:28Z",
+      "lastAudited": "2026-05-07T22:19:31Z",
       "result": "clean"
     },
     "mathematical-induction": {


### PR DESCRIPTION
## Summary

Re-audit of `lovasz-local-lemma-oq-02` (last audited 2026-04-23). All structural counts match the Lean source on `origin/main`:

| Field | Claimed | Actual |
|-------|---------|--------|
| lineCount | 240 | 240 |
| theoremCount | 13 | 13 |
| sorries | 1 | 1 |
| axiomCount | 0 | 0 |
| definitionCount | 0 | 0 |

Narrative checks pass:
- Status `formalized` + badge `wip` is consistent with `sorries: 1`
- The single remaining sorry (`lllThreshold_strict_maximum` general AM-GM equality case) is honestly disclosed in the `assumptions` field and flagged in section summaries
- `additionalFiles` correctly declares `Proofs/LovaszLocalLemmaOQ02Aristotle.lean`
- Tier C narrative wording: scope is correctly bounded ("Proved for d=1,2,3 via polynomial factoring") rather than overclaiming general d

No issues. Tracker bumped to auditCount=2.

## Test plan
- [x] Counts verified via `git show origin/main:proofs/Proofs/LovaszLocalLemmaOQ02.lean`
- [x] Narrative checked against Tier C requirements
- [x] No structural drift to fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)