### PR TITLE
research(law-of-cosines-oq-01-oq-01-oq-03): eliminate projperp_dot_sinsincos axiom + repair Mathlib API drift (axioms 2→1)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
@@ -69,7 +69,7 @@ theorem cross_dot_eq_neg_projperp (A B C : Fin 3 → ℝ) (hC : IsUnit3 C) :
 /-- For unit B, C: normSq(B×C) = normSq(projPerp B C) = 1 - (dot B C)². -/
 theorem normSq_cross_eq_projperp (B C : Fin 3 → ℝ) (hB : IsUnit3 B) (hC : IsUnit3 C) :
     normSq (B ×₃ C) = normSq (projPerp B C) := by
-  rw [lagrange_identity, normSq_projPerp B C hC, hB]; ring
+  rw [lagrange_identity, normSq_projPerp B C hC, hB, hC]; ring
 
 /-- normSq(projPerp A B) = normSq(projPerp B A) for unit A and B.
     Both equal 1 - (dot A B)² from normSq_projPerp. -/
@@ -123,6 +123,7 @@ theorem isUnit3_normalize3 (v : Fin 3 → ℝ) (hv : 0 < normSq v) :
 -- Part III: Polar Triangle — Principal Result
 -- ============================================================================
 
+set_option maxHeartbeats 400000 in
 /-- **Polar side formula** — the principal theorem of this entry.
 
     The arc-length from A' = normalize(B×C) to B' = normalize(C×A) equals
@@ -135,7 +136,6 @@ theorem isUnit3_normalize3 (v : Fin 3 → ℝ) (hv : 0 < normSq v) :
                                                               [normSq_cross_eq_projperp, normSq_cross_CA]
     4. Therefore dot(A', B') = -cos(dihedralAngle C A B)      [definition of dihedral angle]
     5. arcLen = arccos(-cos(γ)) = π - γ                       [Real.arccos_neg] -/
-set_option maxHeartbeats 400000 in
 theorem polar_side_eq_pi_minus_angle (A B C : Fin 3 → ℝ)
     (hA : IsUnit3 A) (hB : IsUnit3 B) (hC : IsUnit3 C)
     (hBC : 0 < normSq (B ×₃ C))
@@ -154,7 +154,7 @@ theorem polar_side_eq_pi_minus_angle (A B C : Fin 3 → ℝ)
     Real.sqrt_ne_zero'.mpr (lt_of_le_of_ne (normSq_nonneg _) (Ne.symm hpAC))
   have hp2 : Real.sqrt (normSq (projPerp B C)) ≠ 0 :=
     Real.sqrt_ne_zero'.mpr (lt_of_le_of_ne (normSq_nonneg _) (Ne.symm hpBC))
-  rw [arcLen, hdot]
+  rw [arcLen, hdot, neg_div]
   unfold dihedralAngle
   rw [if_neg (by push_neg; exact ⟨hp1, hp2⟩)]
   exact Real.arccos_neg _

--- a/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
@@ -75,7 +75,7 @@ theorem normSq_cross_eq_projperp (B C : Fin 3 → ℝ) (hB : IsUnit3 B) (hC : Is
     Both equal 1 - (dot A B)² from normSq_projPerp. -/
 theorem normSq_projPerp_comm (A B : Fin 3 → ℝ) (hA : IsUnit3 A) (hB : IsUnit3 B) :
     normSq (projPerp A B) = normSq (projPerp B A) := by
-  simp only [normSq_projPerp A B hB, normSq_projPerp B A hA, hA, hB, dot_comm]
+  rw [normSq_projPerp A B hB, normSq_projPerp B A hA, hA, hB, dot_comm]
 
 /-- Cross product antisymmetry: C×A = -(A×C). -/
 theorem cross_anticomm (A C : Fin 3 → ℝ) : (C ×₃ A) = -(A ×₃ C) := by
@@ -85,7 +85,10 @@ theorem cross_anticomm (A C : Fin 3 → ℝ) : (C ×₃ A) = -(A ×₃ C) := by
 theorem normSq_cross_CA (A C : Fin 3 → ℝ) (hA : IsUnit3 A) (hC : IsUnit3 C) :
     normSq (C ×₃ A) = normSq (projPerp A C) := by
   rw [cross_anticomm]
-  simp only [normSq, dot, Pi.neg_apply, neg_mul_neg, Fin.sum_univ_three]
+  -- normSq is invariant under negation
+  have hneg : normSq (-(A ×₃ C)) = normSq (A ×₃ C) := by
+    simp only [normSq, dot, Pi.neg_apply, Fin.sum_univ_three]; ring
+  rw [hneg]
   exact normSq_cross_eq_projperp A C hA hC
 
 -- ============================================================================
@@ -132,6 +135,7 @@ theorem isUnit3_normalize3 (v : Fin 3 → ℝ) (hv : 0 < normSq v) :
                                                               [normSq_cross_eq_projperp, normSq_cross_CA]
     4. Therefore dot(A', B') = -cos(dihedralAngle C A B)      [definition of dihedral angle]
     5. arcLen = arccos(-cos(γ)) = π - γ                       [Real.arccos_neg] -/
+set_option maxHeartbeats 400000 in
 theorem polar_side_eq_pi_minus_angle (A B C : Fin 3 → ℝ)
     (hA : IsUnit3 A) (hB : IsUnit3 B) (hC : IsUnit3 C)
     (hBC : 0 < normSq (B ×₃ C))

--- a/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
@@ -78,8 +78,8 @@ theorem normSq_projPerp_comm (A B : Fin 3 → ℝ) (hA : IsUnit3 A) (hB : IsUnit
   simp only [normSq_projPerp A B hB, normSq_projPerp B A hA, hA, hB, dot_comm]
 
 /-- Cross product antisymmetry: C×A = -(A×C). -/
-theorem cross_anticomm (A C : Fin 3 → ℝ) : C ×₃ A = -(A ×₃ C) := by
-  funext i; fin_cases i <;> simp [crossProduct]; ring
+theorem cross_anticomm (A C : Fin 3 → ℝ) : (C ×₃ A) = -(A ×₃ C) := by
+  funext i; fin_cases i <;> simp [crossProduct] <;> ring
 
 /-- For unit A, C: normSq(C×A) = normSq(projPerp A C). -/
 theorem normSq_cross_CA (A C : Fin 3 → ℝ) (hA : IsUnit3 A) (hC : IsUnit3 C) :
@@ -100,7 +100,7 @@ noncomputable def normalize3 (v : Fin 3 → ℝ) : Fin 3 → ℝ :=
 theorem dot_normalize3 (u v : Fin 3 → ℝ) :
     dot (normalize3 u) (normalize3 v) =
       dot u v / (Real.sqrt (normSq u) * Real.sqrt (normSq v)) := by
-  simp only [normalize3, dot, Fin.sum_univ_three]; field_simp; ring
+  simp only [normalize3, dot, Fin.sum_univ_three]; field_simp
 
 /-- Normalization of a nonzero vector gives a unit vector. -/
 theorem isUnit3_normalize3 (v : Fin 3 → ℝ) (hv : 0 < normSq v) :
@@ -108,9 +108,13 @@ theorem isUnit3_normalize3 (v : Fin 3 → ℝ) (hv : 0 < normSq v) :
   unfold IsUnit3 normalize3 normSq dot; simp only [Fin.sum_univ_three]
   have hpos : (0 : ℝ) < v 0 * v 0 + v 1 * v 1 + v 2 * v 2 := by
     simpa [normSq, dot, Fin.sum_univ_three] using hv
+  have hpos' : (0 : ℝ) < v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
+    have : v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 = v 0 * v 0 + v 1 * v 1 + v 2 * v 2 := by ring
+    rw [this]; exact hpos
   have hne : Real.sqrt (v 0 * v 0 + v 1 * v 1 + v 2 * v 2) ≠ 0 :=
     Real.sqrt_ne_zero'.mpr hpos
-  field_simp; rw [Real.sq_sqrt (le_of_lt hpos)]
+  field_simp
+  rw [Real.sq_sqrt (le_of_lt hpos')]
 
 -- ============================================================================
 -- Part III: Polar Triangle — Principal Result
@@ -148,12 +152,7 @@ theorem polar_side_eq_pi_minus_angle (A B C : Fin 3 → ℝ)
     Real.sqrt_ne_zero'.mpr (lt_of_le_of_ne (normSq_nonneg _) (Ne.symm hpBC))
   rw [arcLen, hdot]
   unfold dihedralAngle
-  rw [if_neg (by push_neg; exact ⟨hp2, hp1⟩)]
-  rw [show -(dot (projPerp A C) (projPerp B C)) /
-        (Real.sqrt (normSq (projPerp A C)) * Real.sqrt (normSq (projPerp B C))) =
-      -(dot (projPerp B C) (projPerp A C) /
-        (Real.sqrt (normSq (projPerp B C)) * Real.sqrt (normSq (projPerp A C)))) by
-    rw [dot_comm]; ring]
+  rw [if_neg (by push_neg; exact ⟨hp1, hp2⟩)]
   exact Real.arccos_neg _
 
 -- ============================================================================
@@ -278,8 +277,8 @@ theorem polar_triangle_std_law (A B C : Fin 3 → ℝ)
   have hdec : dot A' B' = dot A' C' * dot B' C' + dot (projPerp A' C') (projPerp B' C') := by
     have h : C' 0 * C' 0 + C' 1 * C' 1 + C' 2 * C' 2 = 1 := unit_sum C' hC'
     simp only [dot, projPerp, Fin.sum_univ_three]
-    linear_combination (A' 0 * C' 0 + A' 1 * C' 1 + A' 2 * C' 2) *
-      (B' 0 * C' 0 + B' 1 * C' 1 + B' 2 * C' 2) * h
+    linear_combination -((A' 0 * C' 0 + A' 1 * C' 1 + A' 2 * C' 2) *
+      (B' 0 * C' 0 + B' 1 * C' 1 + B' 2 * C' 2)) * h
   rw [← hc', ← ha', ← hb', ← hγ']
   rw [cos_arcLen_unit A' B' hA' hB', cos_arcLen_unit A' C' hA' hC',
       cos_arcLen_unit B' C' hB' hC']

--- a/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
@@ -60,7 +60,7 @@ theorem cos_arcLen_unit (u v : Fin 3 → ℝ) (hu : IsUnit3 u) (hv : IsUnit3 v) 
 theorem cross_dot_eq_neg_projperp (A B C : Fin 3 → ℝ) (hC : IsUnit3 C) :
     dot (B ×₃ C) (C ×₃ A) = -dot (projPerp A C) (projPerp B C) := by
   have h : C 0 * C 0 + C 1 * C 1 + C 2 * C 2 = 1 := unit_sum C hC
-  simp only [dot, projPerp, crossProduct, Fin.sum_univ_three]
+  simp [dot, projPerp, crossProduct, Fin.sum_univ_three]
   linear_combination
     (B 0 * A 0 + B 1 * A 1 + B 2 * A 2) * h -
     (A 0 * C 0 + A 1 * C 1 + A 2 * C 2) *

--- a/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean
@@ -22,9 +22,9 @@
   Parent: LawOfCosinesOQ01OQ01
   Answers: law-of-cosines-oq-01-oq-01-oq-03
 
-  Axioms: 2 (polar_angle_eq; projperp_dot_sinsincos)
+  Axioms: 1 (polar_angle_eq)
   Sorries: 0
-  Theorems: 12
+  Theorems: 13
 -/
 
 import Mathlib.LinearAlgebra.CrossProduct
@@ -175,13 +175,66 @@ axiom polar_angle_eq (A B C : Fin 3 → ℝ)
       π - arcLen A B
 
 /-- The projPerp dot product equals sin·sin·cos(angle).
-    Follows from the definition of dihedralAngle and Cauchy-Schwarz inequality.
-    Formally: cos(arccos(x/(a·b))) * a * b = x where a,b are norms of projPerps. -/
-axiom projperp_dot_sinsincos (A B C : Fin 3 → ℝ)
+
+    Proof: unfold dihedralAngle in the non-degenerate case, apply `Real.cos_arccos`
+    using Cauchy–Schwarz `(dot pA pB)² ≤ normSq pA * normSq pB` (from
+    `lagrange_identity` + `normSq_cross_nonneg`), and use
+    `normSq_projPerp_unit` to convert sin²(arcLen) → normSq(projPerp). -/
+theorem projperp_dot_sinsincos (A B C : Fin 3 → ℝ)
     (hA : IsUnit3 A) (hB : IsUnit3 B) (hC : IsUnit3 C)
     (h1 : normSq (projPerp A C) ≠ 0) (h2 : normSq (projPerp B C) ≠ 0) :
     dot (projPerp A C) (projPerp B C) =
-      Real.sin (arcLen A C) * Real.sin (arcLen B C) * Real.cos (dihedralAngle C A B)
+      Real.sin (arcLen A C) * Real.sin (arcLen B C) * Real.cos (dihedralAngle C A B) := by
+  set pA := projPerp A C with hpA_def
+  set pB := projPerp B C with hpB_def
+  have hpA_pos : 0 < normSq pA := lt_of_le_of_ne (normSq_nonneg _) (Ne.symm h1)
+  have hpB_pos : 0 < normSq pB := lt_of_le_of_ne (normSq_nonneg _) (Ne.symm h2)
+  set nA := Real.sqrt (normSq pA) with hnA_def
+  set nB := Real.sqrt (normSq pB) with hnB_def
+  have hnA_pos : 0 < nA := Real.sqrt_pos.mpr hpA_pos
+  have hnB_pos : 0 < nB := Real.sqrt_pos.mpr hpB_pos
+  have hnA_ne : nA ≠ 0 := ne_of_gt hnA_pos
+  have hnB_ne : nB ≠ 0 := ne_of_gt hnB_pos
+  have hnA_sq : nA ^ 2 = normSq pA := Real.sq_sqrt (normSq_nonneg pA)
+  have hnB_sq : nB ^ 2 = normSq pB := Real.sq_sqrt (normSq_nonneg pB)
+  -- sin(arcLen A C) = nA: sin²(arcLen) = normSq(projPerp), then sqrt of both sides (sin ≥ 0)
+  have hsinA_sq : Real.sin (arcLen A C) ^ 2 = normSq pA :=
+    (normSq_projPerp_unit A C hA hC).symm
+  have hsinB_sq : Real.sin (arcLen B C) ^ 2 = normSq pB :=
+    (normSq_projPerp_unit B C hB hC).symm
+  have hsinA_nn : 0 ≤ Real.sin (arcLen A C) := by
+    rw [arcLen, Real.sin_arccos]; exact Real.sqrt_nonneg _
+  have hsinB_nn : 0 ≤ Real.sin (arcLen B C) := by
+    rw [arcLen, Real.sin_arccos]; exact Real.sqrt_nonneg _
+  have hsinA : Real.sin (arcLen A C) = nA := by
+    have h := Real.sqrt_sq hsinA_nn
+    rw [hsinA_sq] at h
+    exact h.symm
+  have hsinB : Real.sin (arcLen B C) = nB := by
+    have h := Real.sqrt_sq hsinB_nn
+    rw [hsinB_sq] at h
+    exact h.symm
+  -- Cauchy–Schwarz: (dot pA pB)² ≤ (nA * nB)²
+  have h_lag := lagrange_identity pA pB
+  have h_cross_nn := normSq_cross_nonneg pA pB
+  have h_cs : (dot pA pB) ^ 2 ≤ (nA * nB) ^ 2 := by
+    rw [mul_pow, hnA_sq, hnB_sq]; linarith
+  have h_prod_pos : 0 < nA * nB := mul_pos hnA_pos hnB_pos
+  have h_prod_ne : nA * nB ≠ 0 := ne_of_gt h_prod_pos
+  -- bounds for arccos
+  have h_lo : -1 ≤ dot pA pB / (nA * nB) := by
+    rw [le_div_iff₀ h_prod_pos]
+    nlinarith [sq_nonneg (dot pA pB + nA * nB), h_cs]
+  have h_hi : dot pA pB / (nA * nB) ≤ 1 := by
+    rw [div_le_iff₀ h_prod_pos]
+    nlinarith [sq_nonneg (nA * nB - dot pA pB), h_cs]
+  -- cos(dihedralAngle C A B) = dot pA pB / (nA * nB)
+  have hcos : Real.cos (dihedralAngle C A B) = dot pA pB / (nA * nB) := by
+    simp only [dihedralAngle]
+    rw [if_neg (by push_neg; exact ⟨hnA_ne, hnB_ne⟩)]
+    exact Real.cos_arccos h_lo h_hi
+  rw [hsinA, hsinB, hcos]
+  field_simp
 
 /-- The algebraic identity underlying the polar substitution.
     cos(π-x) = -cos(x) and sin(π-x) = sin(x) give the result by linear arithmetic. -/

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
@@ -36,19 +36,20 @@
       "Proves the key algebraic identity: dot(B×C, C×A) = -dot(projPerp A C, projPerp B C) for unit C",
       "Proves normSq(B×C) = normSq(projPerp B C) for unit vectors, connecting cross product to projection norms",
       "Fully proves the polar side formula: arcLen(normalize(B×C), normalize(C×A)) = π - dihedralAngle(C, A, B)",
+      "Proves projperp_dot_sinsincos: dot(projPerp A C, projPerp B C) = sin(arcLen A C)·sin(arcLen B C)·cos(dihedralAngle C A B), via Cauchy-Schwarz (Lagrange identity) and Real.cos_arccos",
       "Derives the dual spherical law of cosines via polar triangle substitution"
     ],
-    "axiomCount": 2,
-    "assumptions": "Two axioms: (1) polar_angle_eq — the dihedral angle of the polar triangle equals π minus the corresponding side of the original, proved analogously to the side formula; (2) projperp_dot_sinsincos — the standard identity connecting dot product of perpendicular projections to sin·sin·cos of the dihedral angle (follows from the definition of dihedralAngle and Cauchy-Schwarz).",
-    "lineCount": 271,
-    "theoremCount": 12,
+    "axiomCount": 1,
+    "assumptions": "One axiom: polar_angle_eq — the dihedral angle of the polar triangle equals π minus the corresponding side of the original, proved analogously to the side formula but requiring intricate cross-cross algebra (eliminated in a follow-up).",
+    "lineCount": 321,
+    "theoremCount": 13,
     "definitionCount": 1
   },
   "leanFile": {
-    "axiomCount": 2,
-    "theoremCount": 12,
+    "axiomCount": 1,
+    "theoremCount": 13,
     "definitionCount": 1,
-    "lineCount": 271,
+    "lineCount": 321,
     "sorries": 0,
     "path": "Proofs/LawOfCosinesOQ01OQ01OQ03.lean"
   },
@@ -109,10 +110,9 @@
   ],
   "conclusion": {
     "summary": "The polar triangle construction provides a conceptually clean derivation of the dual spherical law of cosines as a symmetry of the standard law. The key identity dot(B×C, C×A) = -dot(projPerp A C, projPerp B C) bridges the cross product geometry of the polar vertices to the dihedral angle geometry of the original triangle.",
-    "implications": "This establishes the side formula for the polar triangle in Lean 4. The angle formula (dihedralAngle of polar triangle = π minus corresponding side) is axiomatized and follows analogously. Together they provide a complete algebraic proof of the duality principle underlying spherical trigonometry.",
+    "implications": "This establishes the side formula for the polar triangle in Lean 4 (fully proved). The Cauchy-Schwarz/projection-dot identity (projperp_dot_sinsincos) is now also fully proved via Lagrange + Real.cos_arccos. The remaining axiom polar_angle_eq (dihedralAngle of polar triangle = π minus corresponding side) follows analogously to the side formula but requires intricate cross-cross algebra.",
     "openQuestions": [
-      "Can the polar_angle_eq axiom be eliminated by applying cross_dot_eq_neg_projperp to the polar triangle's projections? (the computation is analogous to the side formula)",
-      "Can projperp_dot_sinsincos be proved from cos_arccos and Cauchy-Schwarz (|dot u v| ≤ ‖u‖·‖v‖)?",
+      "Can the polar_angle_eq axiom be eliminated by applying cross_dot_eq_neg_projperp to the polar triangle's projections? (the computation is analogous to the side formula but more intricate due to nested cross products)",
       "Does Mathlib have a direct Cauchy-Schwarz for the dot product on Fin 3 → ℝ?",
       "Generalize the polar-triangle construction to S^n for n ≥ 3 — does the side/angle duality persist in higher-dimensional spherical simplices, and what's the analogue of cross product algebra there (wedge products in ⋀^(n-1)ℝ^(n+1))?",
       "Derive the spherical law of sines from the dual law — does the symmetric form sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ) emerge naturally from the polar duality?"


### PR DESCRIPTION
## Summary

Eliminates the `projperp_dot_sinsincos` axiom in the polar-triangle/dual-spherical-law-of-cosines entry, plus repairs ~6 sites of pre-existing Mathlib API drift that prevented PR #16220's file from compiling against current Mathlib.

**Axiom count: 2 → 1** (only `polar_angle_eq` remains).

## Mathematical content (axiom elimination)

`projperp_dot_sinsincos`: for unit vectors A, B, C with non-degenerate projections,
$$\langle \mathrm{proj}^\perp_C A,\ \mathrm{proj}^\perp_C B\rangle\;=\;\sin(\arc(A,C))\,\sin(\arc(B,C))\,\cos(\angle CAB).$$

The proof goes via:
1. `sqrt(normSq(projPerp u w)) = sin(arcLen u w)` for unit u, w (from `normSq_projPerp_unit` + `sin ≥ 0` on `[0, π]`).
2. Cauchy–Schwarz `(dot pA pB)² ≤ normSq pA · normSq pB` (from Lagrange identity + `normSq_cross_nonneg`) gives the `[-1, 1]` bound for `Real.cos_arccos`.
3. By definition of `dihedralAngle C A B`, `cos(dihedralAngle C A B) = dot(pA, pB) / (|pA| · |pB|)`.

Combining the three gives the identity. This had previously been left as an axiom because the Cauchy–Schwarz bound + sqrt(sin²) = sin manipulation was deemed bookkeeping-heavy; it turns out a direct ~50-line proof is feasible.

## Pre-existing API drift fixes

PR #16220 was committed before recent Mathlib bumps that changed:
1. `cross_anticomm` parses with the local `×₃` notation (parenthesize `(C ×₃ A)` so the equality binds correctly).
2. `dot_normalize3`: `field_simp` now closes without a trailing `ring`.
3. `isUnit3_normalize3`: `field_simp` normalizes `v_i*v_i` to `v_i^2`; rewrite uses the `^2` form.
4. `normSq_projPerp_comm`: `simp only` no longer applies the `IsUnit3 _` ↦ `normSq _ = 1` rewrites at simp scope; switch to plain `rw` chain.
5. `normSq_cross_CA`: prior `simp` expansion of `normSq` blocks the existing `normSq_cross_eq_projperp` step; bridge via an explicit `normSq (-v) = normSq v` lemma.
6. `normSq_cross_eq_projperp`: rewrite chain ends `[..., hB, hC]; ring` (was `[..., hB]; ring`, leaving `1 * normSq C - … = 1 - …` for ring without `normSq C = 1` in scope).
7. `polar_side_eq_pi_minus_angle`: drop the swap-and-rewrite into a `Real.arccos_neg`-shaped form. Add `neg_div` to the rw chain so `arccos((-a)/b) = π - arccos(a/b)` matches `Real.arccos_neg`. Pin `set_option maxHeartbeats 400000 in` BEFORE the docstring (placement matters in current Lean 4 — see commit message of `93a1e7b9376`).
8. `polar_triangle_std_law`: `linear_combination` coefficient sign was wrong; the polynomial residual is `-((A·C)(B·C)) * (C·C - 1)`, so negate the coefficient.
9. `cross_dot_eq_neg_projperp`: switch `simp only [crossProduct, …]` to plain `simp [crossProduct, …]` because current Mathlib wraps `crossProduct` in a `LinearMap.mk₂` that `simp only [crossProduct]` unfolds-but-does-not-beta-reduce; the same pattern works in the file's `cross_anticomm`.

## File metadata

- Lean file: 271 → 321 lines (+50 for the projperp_dot_sinsincos proof + minor)
- axioms: 2 → 1 (only `polar_angle_eq` remains)
- theorems: 12 → 13
- sorries: 0 (unchanged)
- meta.json + leanFile: synced

## Test plan

- [x] Worktree builds against current Mathlib (Docker)
- [x] meta.json/leanFile counts reflect new state
- [ ] Auditor scan after merge

## Follow-up

The remaining `polar_angle_eq` axiom (the polar triangle's vertex angle equals π minus the original side) follows analogously to the side formula, but requires (a) cross-cross identities `(C×A)×(A×B) = (tripleProduct A B C) • A` and `(A×B)×(B×C) = (tripleProduct A B C) • B`, (b) explicit non-degeneracy `tripleProduct A B C ≠ 0`, and (c) sign analysis on `normalize3` of scalar-multiplied unit vectors. ~80–100 lines of Lean; deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
