### PR TITLE
fix(meta): four-square-distribution-oq-01 — sync lineCount 353→402, theoremCount 65→75

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 353,
-    "theoremCount": 65,
+    "lineCount": 402,
+    "theoremCount": 75,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync stale `meta.lineCount` and `meta.theoremCount` for `four-square-distribution-oq-01` after PRs #16738 (S2 σ* identity) and #16768 (S3 odd prime powers) added theorems and lines without updating the metadata.

## Evidence

Counts verified against `proofs/Proofs/FourSquareDistributionOQ01.lean` on origin/main (commit 7c9b9da):

```
$ wc -l proofs/Proofs/FourSquareDistributionOQ01.lean
402

$ python3  # nested-comment-aware strip + decl regex
theorems/lemmas/examples: 75
defs: 6
axioms: 1
sorries: 0
```

**Before**: `lineCount: 353`, `theoremCount: 65`
**After**:  `lineCount: 402`, `theoremCount: 75`

Other meta fields (`axiomCount: 1`, `sorries: 0`, `definitionCount: 6`) already match actuals — left untouched.

Closes audit-tracker entry `four-square-distribution-oq-01` (issues-found, lastAudited 2026-05-07T22:30Z).

---
Automated fix by lean-mechanic agent.