### PR TITLE
research(stirling-formula-oq-01-wip-01): close final sorry — Taylor remainder via Real.exp_bound

### DIFF
--- a/proofs/Proofs/StirlingExpansion.lean
+++ b/proofs/Proofs/StirlingExpansion.lean
@@ -664,9 +664,65 @@ theorem stirling_first_correction :
             rw [h_eq]; apply div_nonneg
             · nlinarith [sq_nonneg ((n:ℝ)-1), mul_pos hn_pos hn1_pos]
             · positivity
-    -- |exp(L) - (1+L)| ≤ L² * exp(L) / 2 ≤ (1/n)² * exp(1/n) / 2 ≤ 1/n²
-    -- exp(L) - (1 + 1/(12n)) = (exp(L) - (1+L)) + (L - 1/(12n)) ≤ L²*exp(L)/2 + C/n²
-    sorry -- HARD: needs |exp(L) - (1+L)| ≤ L²/2 * exp(L) and L ≤ 1/n, exp(L) ≤ 2
+    -- Taylor bound from Mathlib: |exp L - (1 + L)| ≤ 3·L²/4 since |L| ≤ 1.
+    -- Combine with L - 1/(12n) ≤ 1/(2n²) to get exp(L) - (1+1/(12n)) ≤ 5/(4n²) ≤ 2/n².
+    have hL_abs : |L| ≤ 1 := by
+      rw [abs_of_nonneg hL_nn]
+      calc L ≤ 1 / (n : ℝ) := hL_ub
+        _ ≤ 1 := by rw [div_le_one hn_pos]; linarith
+    have htay : |Real.exp L - ∑ m ∈ Finset.range 2, L ^ m / (m.factorial : ℝ)| ≤
+        |L| ^ 2 * ((Nat.succ 2 : ℝ) / ((Nat.factorial 2 : ℝ) * 2)) :=
+      Real.exp_bound hL_abs (n := 2) (by norm_num)
+    -- Simplify Σ_{m<2} L^m/m! = 1 + L
+    have hsum_eq : (∑ m ∈ Finset.range 2, L ^ m / (m.factorial : ℝ)) = 1 + L := by
+      simp [Finset.sum_range_succ, Nat.factorial]
+    -- Simplify |L|² · 3 / (2! · 2) = 3·L² / 4
+    have hbnd_eq : |L| ^ 2 * ((Nat.succ 2 : ℝ) / ((Nat.factorial 2 : ℝ) * 2)) =
+        3 * L ^ 2 / 4 := by
+      rw [sq_abs]; simp [Nat.factorial]; ring
+    rw [hsum_eq, hbnd_eq] at htay
+    have htay_ub : Real.exp L - (1 + L) ≤ 3 * L ^ 2 / 4 := by
+      have := abs_le.mp htay
+      linarith [this.2]
+    -- L² ≤ 1/n²  (using 0 ≤ L ≤ 1/n)
+    have hL_sq : L ^ 2 ≤ 1 / (n : ℝ) ^ 2 := by
+      have hLL : L * L ≤ (1 / (n : ℝ)) * (1 / (n : ℝ)) :=
+        mul_self_le_mul_self hL_nn hL_ub
+      have hL2 : L ^ 2 = L * L := by ring
+      have hn2 : (1 / (n : ℝ)) * (1 / (n : ℝ)) = 1 / (n : ℝ) ^ 2 := by
+        field_simp
+      linarith
+    -- L - 1/(12n) ≤ 1/(2n²) using hL_upper
+    have hL_minus : L - 1 / (12 * (n : ℝ)) ≤ 1 / (2 * (n : ℝ) ^ 2) := by
+      suffices hkey : 1 / (12 * ((n : ℝ) - 1)) + 1 / (12 * ((n : ℝ) - 1) ^ 2) -
+          1 / (12 * (n : ℝ)) ≤ 1 / (2 * (n : ℝ) ^ 2) by linarith [hL_upper]
+      suffices hpos : 0 ≤ 1 / (2 * (n : ℝ) ^ 2) -
+          (1 / (12 * ((n : ℝ) - 1)) + 1 / (12 * ((n : ℝ) - 1) ^ 2) -
+           1 / (12 * (n : ℝ))) by linarith
+      have h_eq : 1 / (2 * (n : ℝ) ^ 2) -
+          (1 / (12 * ((n : ℝ) - 1)) + 1 / (12 * ((n : ℝ) - 1) ^ 2) -
+           1 / (12 * (n : ℝ))) =
+          ((n : ℝ) - 2) * (4 * (n : ℝ) - 3) /
+            (12 * (n : ℝ) ^ 2 * ((n : ℝ) - 1) ^ 2) := by
+        field_simp
+        ring
+      rw [h_eq]
+      apply div_nonneg
+      · exact mul_nonneg (by linarith) (by linarith)
+      · positivity
+    -- Combine: exp(L) - (1 + 1/(12n)) = (exp(L) - (1+L)) + (L - 1/(12n)) ≤ 3L²/4 + 1/(2n²)
+    --       ≤ 3/(4n²) + 1/(2n²) = 5/(4n²) ≤ 2/n²
+    have hnsq_pos : (0 : ℝ) < (n : ℝ) ^ 2 := by positivity
+    calc Real.exp L - (1 + 1 / (12 * (n : ℝ)))
+        = (Real.exp L - (1 + L)) + (L - 1 / (12 * (n : ℝ))) := by ring
+      _ ≤ 3 * L ^ 2 / 4 + 1 / (2 * (n : ℝ) ^ 2) := by linarith [htay_ub, hL_minus]
+      _ ≤ 3 * (1 / (n : ℝ) ^ 2) / 4 + 1 / (2 * (n : ℝ) ^ 2) := by linarith [hL_sq]
+      _ = 5 / (4 * (n : ℝ) ^ 2) := by ring
+      _ ≤ 2 / (n : ℝ) ^ 2 := by
+          have h_eq : (2 : ℝ) / (n : ℝ) ^ 2 - 5 / (4 * (n : ℝ) ^ 2) =
+              3 / (4 * (n : ℝ) ^ 2) := by field_simp; ring
+          have hpos : (0 : ℝ) < 4 * (n : ℝ) ^ 2 := by positivity
+          linarith [div_pos (by norm_num : (0 : ℝ) < 3) hpos]
 
 /-- **Stirling Expansion (Two Terms).**
 
@@ -759,15 +815,10 @@ example : (1 : ℝ) + 1 / 1200 = 1201 / 1200 := by norm_num
 - `stirling_step_upper`: d_k ≤ 1/(12k²) + 1/(6k³) [given step formula]
 - `stirling_step_lower`: 1/(12k²) - 1/(8k³) ≤ d_k [given step formula]
 
-**Remaining sorry (1 total):**
-- `stirling_first_correction`: needs the upper-half exp-Taylor bound
-  `|exp L − (1 + L)| ≤ L² · exp L / 2` together with `L ≤ 1/n` and `exp L ≤ 2`.
-  Everything else (step formula, telescoping bounds, partial-sum bounds,
-  the lower half of the absolute value, and the existence of the constant)
-  is proved.
-
-**Sorries at file level:**
-- `stirling_first_correction` (1 sorry, exp Taylor remainder bound)
+**Status:** 0 sorries. The upper-half exp-Taylor bound is now discharged via
+`Real.exp_bound` at degree 2, which yields `|exp L − (1 + L)| ≤ 3·L² / 4`
+under `|L| ≤ 1`. Combined with `L − 1/(12n) ≤ 1/(2n²)` (algebraic) and
+`L² ≤ 1/n²` (from `0 ≤ L ≤ 1/n`), this gives the upper bound `5/(4n²) ≤ 2/n²`.
 -/
 
 end StirlingExpansion

--- a/research/problems/stirling-formula-oq-01-wip-01/knowledge.md
+++ b/research/problems/stirling-formula-oq-01-wip-01/knowledge.md
@@ -10,6 +10,54 @@ The 1/(12n) correction coefficient is the key refinement of Stirling's approxima
 
 ---
 
+## Session 2026-05-08 (Session 3) — CLOSED
+
+**Mode**: REVISIT
+**Outcome**: Problem closed. StirlingExpansion.lean is fully verified (0 axioms, 0 sorries, 819 lines).
+
+### What I Did
+
+Discharged the final sorry on `stirling_first_correction` (StirlingExpansion.lean:669) — the upper-half exp Taylor remainder bound. Strategy: `Real.exp_bound` at degree `n=2`.
+
+### Proof structure (~50 lines)
+
+```
+exp(L) ≤ 1 + L + 3·L²/4         from Real.exp_bound at n=2 (|L| ≤ 1)
+L² ≤ 1/n²                        from 0 ≤ L ≤ 1/n + mul_self_le_mul_self
+L − 1/(12n) ≤ 1/(2n²)            algebraic, from L ≤ 1/(12(n−1)) + 1/(12(n−1)²)
+                                  via the identity 1/(2n²) − [LHS − 1/(12n)] = (n−2)(4n−3)/(12n²(n−1)²)
+exp(L) − (1 + 1/(12n))           = (exp(L) − (1+L)) + (L − 1/(12n))
+                                  ≤ 3·L²/4 + 1/(2n²)
+                                  ≤ 3/(4n²) + 1/(2n²)
+                                  = 5/(4n²) ≤ 2/n²    ✓
+```
+
+The constant `C = 2` was already chosen via `use 2` at the top of the theorem; the proof needed `5/4 ≤ 2`, i.e., slack `3/(4n²)`.
+
+### Key Lean 4.26 API Notes (Session 3)
+
+**`Real.exp_bound (h : |x| ≤ 1) (n : ℕ) (hn : 0 < n)`** — gives `|exp x − Σ_{m<n} x^m/m!| ≤ |x|^n · ((n+1) / (n!·n))`. For `n = 2`: bound is `|x|² · 3/(2!·2) = 3|x|²/4`. The sum `Σ_{m<2} x^m/m! = 1 + x`. Closed via `simp [Finset.sum_range_succ, Nat.factorial]` after `rw [sq_abs]`.
+
+**`div_le_div_iff` is gone in Lean 4.26** (matches MEMORY note). For `5/(4n²) ≤ 2/n²`, sidestep entirely: compute `2/n² − 5/(4n²) = 3/(4n²)` via `field_simp; ring`, then `linarith [div_pos (3>0) (4n² > 0)]`.
+
+**`mul_self_le_mul_self hL_nn hL_ub` gives `L*L ≤ (1/n)*(1/n)` but `nlinarith` can't bridge to `L² ≤ 1/n²`** without explicit `L² = L*L` and `(1/n)*(1/n) = 1/n²` (use `field_simp` for the latter, since `ring` doesn't always simplify field divisions). Then `linarith` closes.
+
+### Build Result
+
+Docker build verified: `Build completed successfully (3083 jobs)`, no errors, only pre-existing style linter warnings. Verified `grep -c "^axiom "` = 0 and stripped-comments-sorry-count = 0.
+
+### Files Modified
+
+- `proofs/Proofs/StirlingExpansion.lean` (line 669 sorry → ~50-line proof; lineCount 773 → 819)
+- `src/data/proofs/stirling-formula-oq-01/meta.json` (status: formalized → verified, badge: wip → original, sorries: 1 → 0, lineCount sync, originalContributions/conclusion rewrites)
+- `src/data/research/problems/stirling-formula-oq-01-wip-01.json` (phase: ACT → COMPLETED, status: active → completed, knowledge.progressSummary, completed timestamp)
+
+### Final Status
+
+The chain `{stirling_first_correction → stirling_two_term_expansion → error_bound_from_correction}` is now closed. Together with the previously-merged StirlingFormula.lean, this gives a complete machine-checked proof of n!/[√(2πn)·(n/e)^n] = 1 + 1/(12n) + O(1/n²) with explicit constant C = 2 for n ≥ 2.
+
+---
+
 ## Session 2026-05-07 (Session 2) — Step Formula Proved + Telescoping Infrastructure
 
 **Mode**: REVISIT

--- a/research/problems/stirling-formula-oq-01-wip-01/state.md
+++ b/research/problems/stirling-formula-oq-01-wip-01/state.md
@@ -1,16 +1,16 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-05-06T14:18:33.488Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-05-08T01:30:00.000Z
+**Iteration**: 4
 
 ## Current Focus
 
-Initial exploration of the problem.
+Closed. StirlingExpansion.lean is fully verified (0 axioms, 0 sorries, 819 lines).
 
 ## Active Approach
 
-None yet.
+None — final sorry discharged via Real.exp_bound at degree 2.
 
 ## Blockers
 
@@ -18,10 +18,10 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+None — problem complete.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 4
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Stirling (1730), de Moivre (1733)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Stirling%27s_approximation#Speed_of_convergence_and_error_estimates",
     "date": "1730",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/StirlingExpansion.lean",
     "tags": [
       "analysis",
@@ -16,10 +16,10 @@
       "factorials",
       "bernoulli-numbers"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 1 sorry: stirling_first_correction needs the upper-half exp-Taylor bound |exp L − (1+L)| ≤ L²·exp L/2 with L ≤ 1/n (line 669). All other steps proved: log_one_plus_le_cubic, log_one_plus_ge_quartic, stirling_step_formula, stirling_step_upper, stirling_step_lower, telescoping bounds (inv_sq_le_telescope, inv_cube_le_telescope, inv_harmonic_le_sq, inv_cube_le_telescope2, inv_quad_le_telescope), partial-sum bounds (log_stirlingSeq_partial_upper/lower), the lower half of the abs-value bound, and the existence of the constant.",
+    "assumptions": "None. 0 axioms, 0 sorries. The full chain {log_one_plus_le_cubic, log_one_plus_ge_quartic, stirling_step_formula, stirling_step_upper, stirling_step_lower, telescoping helpers (inv_sq_le_telescope, inv_cube_le_telescope, inv_harmonic_le_sq, inv_cube_le_telescope2, inv_quad_le_telescope), partial-sum bounds (log_stirlingSeq_partial_upper/lower), stirling_first_correction, stirling_two_term_expansion, error_bound_from_correction} is fully proved. The final upper-half exp-Taylor bound is discharged via Real.exp_bound at degree n=2 (|L|≤1 → |exp L − (1+L)| ≤ 3·L²/4), combined with L² ≤ 1/n² (from 0 ≤ L ≤ 1/n) and the algebraic identity L − 1/(12n) ≤ 1/(2n²) (from L ≤ 1/(12(n−1)) + 1/(12(n−1)²)).",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -42,9 +42,12 @@
       "log_one_plus_le_cubic: proved log(1+x) \u2264 x-x\u00b2/2+x\u00b3/3 for x>0 (derivative monotonicity)",
       "log_one_plus_ge_quartic: proved x-x\u00b2/2+x\u00b3/3-x\u2074/4 \u2264 log(1+x) for x>0 (derivative monotonicity)",
       "stirling_step_upper: d_k \u2264 1/(12k\u00b2)+1/(6k\u00b3) (conditional on step formula)",
-      "stirling_step_lower: 1/(12k\u00b2)-1/(12k\u00b3)-1/(8k\u2074) \u2264 d_k (conditional on step formula)"
+      "stirling_step_lower: 1/(12k\u00b2)-1/(12k\u00b3)-1/(8k\u2074) \u2264 d_k (conditional on step formula)",
+      "Telescoping helpers (inv_sq_le_telescope, inv_cube_le_telescope, inv_harmonic_le_sq, inv_cube_le_telescope2, inv_quad_le_telescope) and partial-sum bounds (log_stirlingSeq_partial_upper/lower)",
+      "stirling_first_correction (fully proved): combines the partial-sum bounds with two limits (htend_diff for L = log(stirlingSeq n) \u2212 log(\u221a\u03c0), htend_Gn for the lower-tail residual via Tendsto.div_atTop on each tail term), Real.exp_bound at degree 2 for the upper-half Taylor remainder |exp L \u2212 (1+L)| \u2264 3\u00b7L\u00b2/4, and the algebraic comparisons (n\u22122)(4n\u22123) \u2265 0 (for L \u2212 1/(12n) \u2264 1/(2n\u00b2)) and (12(n\u22121)\u00b3 \u2212 n\u00b3) \u2265 0 (for the lower half). Yields C = 2.",
+      "stirling_two_term_expansion (fully proved from stirling_first_correction via the \u221a(2\u03c0n) = \u221a(2n)\u00b7\u221a\u03c0 split)"
     ],
-    "lineCount": 773,
+    "lineCount": 819,
     "theoremCount": 20,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -116,11 +119,11 @@
     }
   ],
   "conclusion": {
-    "summary": "States the first correction term in Stirling's expansion and shows it implies the axiomatized error bound. The correction proof requires Euler-Maclaurin or Wallis product analysis.",
-    "implications": "Completing the first correction proof would eliminate the axiom stirling_error_bound_ge_2 from StirlingFormula.lean, making it fully verified (0 axioms, 0 sorries). The formalization also provides a template for higher-order corrections: the same Euler-Maclaurin approach that proves the 1/(12n) term would yield 1/(288n\u00b2) and the negative third term \u2212139/(51840n\u00b3), giving successively tighter bounds. In probability theory, the first correction is essential for precise approximations of binomial coefficients via the local CLT and for bounding errors in Poisson approximation. The Stirling series (being asymptotic but divergent) is a classical example of an asymptotic expansion with Borel summability properties, connecting to the broader theory of divergent series.",
+    "summary": "Proves the first correction term in Stirling's expansion: |stirlingSeq(n)/\u221a\u03c0 \u2212 (1 + 1/(12n))| \u2264 2/n\u00b2 for n \u2265 2. The proof combines a Wallis-style telescoping argument (avoiding Euler-Maclaurin) with Mathlib's Real.exp_bound for the final exp-Taylor remainder. 0 axioms, 0 sorries.",
+    "implications": "The first correction is fully verified (0 axioms, 0 sorries) and yields stirling_two_term_expansion and error_bound_from_correction by construction; in conjunction with StirlingFormula.lean (already verified) this gives a complete machine-checked proof of n!/[\u221a(2\u03c0n)\u00b7(n/e)^n] = 1 + 1/(12n) + O(1/n\u00b2) with explicit constant C = 2. The proof method (telescoping bounds via the step formula d_k = (k+1/2)\u00b7log(1+1/k) \u2212 1, plus log Taylor bounds via derivative monotonicity, plus Real.exp_bound at degree 2) is reusable: the same scaffolding applies to the next coefficient 1/(288n\u00b2), with one additional log-bound order needed. In probability theory, the first correction is essential for precise approximations of binomial coefficients via the local CLT and for bounding errors in Poisson approximation. The Stirling series (being asymptotic but divergent) is a classical example of an asymptotic expansion with Borel summability properties, connecting to the broader theory of divergent series.",
     "openQuestions": [
-      "Prove the first correction from Euler-Maclaurin or Wallis product analysis",
-      "Formalize the full asymptotic series with arbitrary number of terms",
+      "Formalize the second correction term 1/(288n\u00b2) and the negative third term \u2212139/(51840n\u00b3)",
+      "Formalize the full asymptotic series with arbitrary number of terms (would need Bernoulli-number infrastructure)",
       "Can the Stirling series be connected to Mathlib's Gamma function asymptotics?"
     ]
   },
@@ -137,15 +140,15 @@
       "Filter"
     ],
     "namespace": "StirlingExpansion",
-    "lineCount": 773,
+    "lineCount": 819,
     "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 2,
     "path": "Proofs/StirlingExpansion.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/StirlingExpansionAristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/stirling-formula-oq-01-wip-01.json
+++ b/src/data/research/problems/stirling-formula-oq-01-wip-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "stirling-formula-oq-01-wip-01",
   "title": "Complete Higher-Order Stirling Expansion (Work in Progress)",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,20 +16,20 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-07T19:55:00.000Z",
-    "iteration": 3,
-    "focus": "Telescoping body of stirling_first_correction in place on PR #16442; only the upper-half exp-Taylor bound remains. Branch resync'd onto current main (post-#16354/#16414/#16614).",
+    "phase": "COMPLETED",
+    "since": "2026-05-08T01:30:00.000Z",
+    "iteration": 4,
+    "focus": "Closed. Final sorry discharged via Real.exp_bound at degree 2.",
     "blockers": [],
-    "nextAction": "Discharge the final sorry on stirling_first_correction (StirlingExpansion.lean:669): need |exp L − (1+L)| ≤ L²·exp L/2 with L ≤ 1/n and exp L ≤ 2.",
+    "nextAction": "None — problem complete.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "IN-PROGRESS (1 sorry remaining in StirlingExpansion.lean:669 — upper-half exp-Taylor bound inside stirling_first_correction). PRs #16354, #16414, #16614, #16677 merged on main; PR #16442 (this branch) carries the full telescoping proof of stirling_first_correction with the htend_Gn (G(n+M) → 0) sub-sorry already discharged. Branch resync'd onto current main 2026-05-07 (4 conflict files; Lean code byte-identical to the previously Docker-verified version, only docstring + JSON metadata updated).",
+    "progressSummary": "COMPLETED 2026-05-08. StirlingExpansion.lean is fully verified (0 axioms, 0 sorries, 819 lines) — the final upper-half exp-Taylor bound was discharged via Real.exp_bound at degree 2. Build verified via Docker (3083 jobs replayed, no errors). Together with the previously-merged StirlingFormula.lean, this gives a complete machine-checked proof of n!/[√(2πn)·(n/e)^n] = 1 + 1/(12n) + O(1/n²) with explicit O(1/n²) constant 2. Prior PRs that built up to this: #16354 (log bounds + step bounds), #16414 (step formula), #16442 (telescoping body + htend_Gn), #16614 + #16677 (JSON sync), and the closing PR (this session).",
     "builtItems": [
       "log_one_plus_le_cubic in StirlingExpansion.lean:92 — log(1+x) ≤ x - x²/2 + x³/3 for x > 0",
       "log_one_plus_ge_quartic in StirlingExpansion.lean:158 — log(1+x) ≥ x - x²/2 + x³/3 - x⁴/4 for x > 0",
@@ -50,12 +50,10 @@
       "Filter.Tendsto.atTop_mul_atTop now requires IsOrderedMonoid (fails for ℝ); use Filter.Tendsto.atTop_mul_atTop₀ for groups-with-zero",
       "Resync onto main needed only conflict resolution in 4 files (StirlingExpansion.lean, knowledge.md, meta.json, this JSON); no new build errors introduced by main's drift"
     ],
-    "mathlibGaps": [
-      "No direct Mathlib theorem for: |exp(x) - (1+x)| ≤ C·x² for |x| ≤ 1 (Taylor remainder bound)"
-    ],
+    "mathlibGaps": [],
     "nextSteps": [
-      "Discharge the final sorry on stirling_first_correction (line 669): need |exp(L) − (1+L)| ≤ L²·exp L/2 with L ≤ 1/n",
-      "Approaches to try: (a) Real.exp_bound with explicit n=2 instance; (b) Real.add_one_le_exp combined with a hand-rolled quadratic upper bound for x ∈ [0,1]; (c) lift |exp(x) − 1 − x − x²/2| bound from Real.exp.taylor_series"
+      "Optional: formalize the second correction term 1/(288n²) using the same scaffolding (one additional log-bound order needed)",
+      "Optional: connect to Mathlib's Gamma function asymptotics for log Γ(z)"
     ]
   },
   "tags": [
@@ -74,7 +72,8 @@
     "mathlib": []
   },
   "started": "2026-05-06T14:18:33.488Z",
-  "lastUpdate": "2026-05-07T17:25:00.000Z",
+  "lastUpdate": "2026-05-08T01:30:00.000Z",
+  "completed": "2026-05-08T01:30:00.000Z",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

- Discharges the **last sorry** in `stirling_first_correction` (StirlingExpansion.lean:669) — the upper-half exp Taylor remainder bound — via `Real.exp_bound` at degree 2.
- `StirlingExpansion.lean` is now **fully verified** (0 axioms, 0 sorries, 819 lines).
- Closes the chain `{stirling_first_correction → stirling_two_term_expansion → error_bound_from_correction}`. Together with the previously-merged `StirlingFormula.lean`, this is a complete machine-checked proof of `n!/[√(2πn)·(n/e)^n] = 1 + 1/(12n) + O(1/n²)` with explicit constant **C = 2** for n ≥ 2.

## Proof structure (~50 lines)

```
exp(L) ≤ 1 + L + 3·L²/4         from Real.exp_bound at n=2 with |L| ≤ 1
L² ≤ 1/n²                        from 0 ≤ L ≤ 1/n + mul_self_le_mul_self
L − 1/(12n) ≤ 1/(2n²)            via 1/(2n²) − [L − 1/(12n)] = (n−2)(4n−3)/(12n²(n−1)²) ≥ 0
exp(L) − (1 + 1/(12n)) ≤ 3·L²/4 + 1/(2n²) ≤ 5/(4n²) ≤ 2/n²    ✓
```

## Lean 4.26 API notes (recorded in MEMORY)

- `Real.exp_bound (h : |x| ≤ 1) (n : ℕ) (hn : 0 < n)` gives `|exp x − Σ_{m<n} x^m/m!| ≤ |x|^n · ((n+1)/(n!·n))`. For `n = 2`: `3|x|²/4`.
- `div_le_div_iff` is gone in 4.26 — sidestep via `field_simp; ring` identities + `linarith`/`positivity`.
- `mul_self_le_mul_self` gives `L*L ≤ (1/n)*(1/n)`; `nlinarith` needs explicit `L² = L*L` and `(1/n)*(1/n) = 1/n²` hypotheses to bridge to `L² ≤ 1/n²`.

## Gallery + tracker updates

- `src/data/proofs/stirling-formula-oq-01/meta.json`: `status` formalized → verified, `badge` wip → original, `sorries` 1 → 0, `lineCount` 773 → 819 in both `meta.*` and `leanFile.*` blocks. `assumptions` rewritten; `originalContributions` extended; `conclusion.summary`/`implications`/`openQuestions` updated.
- `src/data/research/problems/stirling-formula-oq-01-wip-01.json`: `phase` ACT → COMPLETED, `status` active → completed, `knowledge.progressSummary` updated, `completed` timestamp added.
- `research/problems/stirling-formula-oq-01-wip-01/{state.md,knowledge.md}`: closed; Session 3 log appended.

## Test plan

- [x] `grep -c "^axiom "` on the file = 0
- [x] Stripped-comments sorry count = 0
- [x] `jq empty` on both updated JSON files
- [x] Docker build: `Build completed successfully (3083 jobs)` with no errors and no `declaration uses 'sorry'` warnings (only pre-existing style linter warnings)
- [x] No PR conflicts (branch off origin/main; `git ls-remote` shows no other open `stirling*` PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)