### PR TITLE
research(liouville-oq-04): cofactor + height bounds (bridge ingredient 2 proved)

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ04.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ04.lean
@@ -276,6 +276,167 @@ theorem padic_norm_int_poly_eval (f : ℤ[X]) (q : ℚ) :
   rw [padic_eval_int_poly_cast, norm_rat_eq_padicNorm]
 
 /-! ═══════════════════════════════════════════════════════════════════════════
+PART IV.7: P-ADIC HEIGHT BOUND ON RATIONALS
+For r, s : ℤ with s ≠ 0:  padicNorm p ((r:ℚ)/s) ≤ |s| ≤ max(|r|,|s|).
+
+This is the dual face of the Archimedean Complement: rather than bounding
+`padicNorm p N` from below by `1/|N|`, we bound `padicNorm p (r/s)` from
+ABOVE by `|s|` (and hence by the height H = max(|r|,|s|)). Combined with
+norm transport (Part IV.5), it transfers to ℚ_[p]:
+  `‖((r:ℚ_[p])/s)‖ ≤ H`.
+
+This is ingredient (a) of the cofactor bound (Part IV.8).
+═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Rational division height bound**: For r, s : ℤ with s ≠ 0,
+    `padicNorm p ((r:ℚ)/s) ≤ |s|`.
+
+    Proof: Use multiplicativity `padicNorm p (r/s) = padicNorm p r / padicNorm p s`,
+    then bound numerator by `1` (Mathlib's `padicNorm.of_int`) and denominator
+    from below by `1/|s|` (the Archimedean Complement, Part I/II). -/
+theorem padicNorm_rat_int_div_le_natAbs (r s : ℤ) (hs : s ≠ 0) :
+    padicNorm p ((r : ℚ) / s) ≤ (s.natAbs : ℚ) := by
+  by_cases hr : r = 0
+  · subst hr
+    simp [padicNorm.zero]
+  · have hr_q : (r : ℚ) ≠ 0 := Int.cast_ne_zero.mpr hr
+    have hs_q : (s : ℚ) ≠ 0 := Int.cast_ne_zero.mpr hs
+    have hs_natAbs_pos : (0 : ℚ) < (s.natAbs : ℚ) := by
+      have := Int.natAbs_pos.mpr hs
+      exact_mod_cast this
+    -- Step 1: multiplicativity on division
+    rw [padicNorm.div]
+    -- Step 2: numerator bound padicNorm p r ≤ 1
+    have hr_le : padicNorm p (r : ℚ) ≤ 1 := padicNorm.of_int r
+    -- Step 3: denominator bound 1/|s| ≤ padicNorm p s
+    have hs_ge : ((s.natAbs : ℚ))⁻¹ ≤ padicNorm p (s : ℚ) :=
+      padicNorm_int_ge_inv p s hs
+    -- Step 4: padicNorm p s > 0
+    have hs_norm_pos : 0 < padicNorm p (s : ℚ) :=
+      (padicNorm.nonneg _).lt_of_ne (Ne.symm <| padicNorm.nonzero hs_q)
+    -- Step 5: a/b ≤ c ↔ a ≤ c * b (for b > 0)
+    rw [div_le_iff₀ hs_norm_pos]
+    -- Goal: padicNorm p r ≤ (s.natAbs : ℚ) * padicNorm p s
+    calc padicNorm p (r : ℚ)
+        ≤ 1 := hr_le
+      _ = (s.natAbs : ℚ) * ((s.natAbs : ℚ))⁻¹ :=
+          (mul_inv_cancel₀ (ne_of_gt hs_natAbs_pos)).symm
+      _ ≤ (s.natAbs : ℚ) * padicNorm p (s : ℚ) :=
+          mul_le_mul_of_nonneg_left hs_ge (le_of_lt hs_natAbs_pos)
+
+/-- Height bound corollary: `padicNorm p ((r:ℚ)/s) ≤ max(|r|,|s|)`. -/
+theorem padicNorm_rat_int_div_le_height (r s : ℤ) (hs : s ≠ 0) :
+    padicNorm p ((r : ℚ) / s) ≤ (max r.natAbs s.natAbs : ℚ) :=
+  le_trans (padicNorm_rat_int_div_le_natAbs p r s hs)
+    (by exact_mod_cast Nat.le_max_right r.natAbs s.natAbs)
+
+/-- Helper: ‖((z : ℤ) : ℚ_[p])‖ = padicNorm p (z : ℚ).
+    This bridges the integer-cast form to the rational form via norm_rat_eq_padicNorm. -/
+theorem padic_norm_intCast_eq_padicNorm (z : ℤ) :
+    ‖((z : ℤ) : ℚ_[p])‖ = padicNorm p ((z : ℤ) : ℚ) := by
+  have hcast : ((z : ℤ) : ℚ_[p]) = (((z : ℤ) : ℚ) : ℚ_[p]) := by norm_cast
+  rw [hcast]
+  exact norm_rat_eq_padicNorm p _
+
+/-- **P-adic norm height bound on ℚ_[p]**: For r, s : ℤ with s ≠ 0,
+    `‖(r : ℚ_[p]) / s‖ ≤ max(|r|, |s|)`.
+
+    Proof: Use multiplicativity of norm (`norm_div`) to break into integer norms,
+    convert each to padicNorm via `padic_norm_intCast_eq_padicNorm`, then apply the
+    rational bound `padicNorm_rat_int_div_le_height` after using `padicNorm.div`. -/
+theorem padic_norm_int_div_le_height (r s : ℤ) (hs : s ≠ 0) :
+    ‖((r : ℚ_[p]) / s)‖ ≤ (max r.natAbs s.natAbs : ℝ) := by
+  have hs_q : (s : ℚ) ≠ 0 := Int.cast_ne_zero.mpr hs
+  -- Multiplicativity: ‖r/s‖_pp = ‖r‖_pp / ‖s‖_pp
+  rw [norm_div]
+  -- Convert each integer ℚ_[p]-norm to a rational padicNorm
+  rw [padic_norm_intCast_eq_padicNorm, padic_norm_intCast_eq_padicNorm]
+  -- Rational bound on the division
+  have key : padicNorm p ((r : ℚ) / s) ≤ (max r.natAbs s.natAbs : ℚ) :=
+    padicNorm_rat_int_div_le_height p r s hs
+  rw [padicNorm.div] at key
+  exact_mod_cast key
+
+/-! ═══════════════════════════════════════════════════════════════════════════
+PART IV.8: POLYNOMIAL EVALUATION NORM BOUND IN ℚ_[p] (cofactor bound)
+For g ∈ ℚ_[p][X] of degree e, x ∈ ℚ_[p] with `‖x‖ ≤ H` and `H ≥ 1`:
+  `‖g.eval x‖ ≤ (∑ i ∈ g.support, ‖g.coeff i‖) · H^e`.
+
+This discharges ingredient (2) of the bridge axiom: the upper bound on
+`‖g.eval (r/s : ℚ_[p])‖`. Combined with the height bound (Part IV.7), it
+yields `‖g.eval ((r:ℚ_[p])/s)‖ ≤ M · H^(deg g)` where M = coeffNormSum p g
+depends only on g (not on r, s).
+═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Coefficient norm sum** of a polynomial over ℚ_[p].
+    `coeffNormSum p g = ∑ i ∈ g.support, ‖g.coeff i‖`.
+
+    This is the M in `‖g.eval x‖ ≤ M · max(1,‖x‖)^(deg g)`. -/
+noncomputable def coeffNormSum (g : Polynomial ℚ_[p]) : ℝ :=
+  g.support.sum (fun i => ‖g.coeff i‖)
+
+theorem coeffNormSum_nonneg (g : Polynomial ℚ_[p]) : 0 ≤ coeffNormSum p g :=
+  Finset.sum_nonneg (fun _ _ => norm_nonneg _)
+
+/-- **Cofactor evaluation bound** (key technical lemma): For g ∈ ℚ_[p][X] and x : ℚ_[p]
+    with `1 ≤ H` and `‖x‖ ≤ H`:
+      `‖g.eval x‖ ≤ coeffNormSum p g · H^g.natDegree`.
+
+    Proof: Expand `g.eval x = ∑ i ∈ support, (g.coeff i) · x^i`, then chain:
+    triangle inequality (`norm_sum_le`), multiplicativity of norm (`norm_mul`,
+    `norm_pow`), monotonicity of pow in base (`pow_le_pow_left₀` with hxH),
+    monotonicity in exponent (`pow_le_pow_right₀` with i ≤ natDegree, H ≥ 1),
+    factor out the constant H^natDegree. -/
+theorem padic_polynomial_eval_norm_bound (g : Polynomial ℚ_[p]) (x : ℚ_[p])
+    (H : ℝ) (hH : 1 ≤ H) (hxH : ‖x‖ ≤ H) :
+    ‖g.eval x‖ ≤ coeffNormSum p g * H ^ g.natDegree := by
+  have hH_nn : (0 : ℝ) ≤ H := le_trans zero_le_one hH
+  -- Express g.eval x = ∑ i ∈ support, g.coeff i * x^i
+  have hsum : g.eval x = ∑ i ∈ g.support, g.coeff i * x ^ i := by
+    rw [Polynomial.eval_eq_sum]
+    rfl
+  rw [hsum]
+  -- Chain of inequalities
+  calc ‖∑ i ∈ g.support, g.coeff i * x ^ i‖
+      ≤ ∑ i ∈ g.support, ‖g.coeff i * x ^ i‖ := norm_sum_le _ _
+    _ = ∑ i ∈ g.support, ‖g.coeff i‖ * ‖x‖ ^ i := by
+        refine Finset.sum_congr rfl (fun i _ => ?_)
+        rw [norm_mul, norm_pow]
+    _ ≤ ∑ i ∈ g.support, ‖g.coeff i‖ * H ^ i := by
+        refine Finset.sum_le_sum (fun i _ => ?_)
+        exact mul_le_mul_of_nonneg_left
+          (pow_le_pow_left₀ (norm_nonneg _) hxH i) (norm_nonneg _)
+    _ ≤ ∑ i ∈ g.support, ‖g.coeff i‖ * H ^ g.natDegree := by
+        refine Finset.sum_le_sum (fun i hi => ?_)
+        exact mul_le_mul_of_nonneg_left
+          (pow_le_pow_right₀ hH (Polynomial.le_natDegree_of_mem_supp i hi))
+          (norm_nonneg _)
+    _ = (∑ i ∈ g.support, ‖g.coeff i‖) * H ^ g.natDegree := by
+        rw [← Finset.sum_mul]
+    _ = coeffNormSum p g * H ^ g.natDegree := rfl
+
+/-- **Cofactor bound at rational points**: Specialization of
+    `padic_polynomial_eval_norm_bound` to `x = (r:ℚ_[p])/s` with `H = max(|r|,|s|)`.
+
+    For g ∈ ℚ_[p][X], r, s : ℤ with s ≠ 0 and `2 ≤ max(|r|,|s|)`:
+      `‖g.eval ((r:ℚ_[p])/s)‖ ≤ coeffNormSum p g · max(|r|,|s|)^g.natDegree`.
+
+    The hypothesis `2 ≤ H` is convenient (matches `IsPadicLiouville`); the proof
+    only uses `1 ≤ H`. This is the form needed by the bridge axiom discharge. -/
+theorem padic_cofactor_bound_rat (g : Polynomial ℚ_[p]) (r s : ℤ) (hs : s ≠ 0)
+    (hH : 2 ≤ max r.natAbs s.natAbs) :
+    ‖g.eval ((r : ℚ_[p]) / s)‖ ≤
+      coeffNormSum p g * (max r.natAbs s.natAbs : ℝ) ^ g.natDegree := by
+  set H : ℝ := (max r.natAbs s.natAbs : ℝ) with hH_def
+  have hH_one : (1 : ℝ) ≤ H := by
+    rw [hH_def]
+    have : (2 : ℕ) ≤ max r.natAbs s.natAbs := hH
+    have : (1 : ℕ) ≤ max r.natAbs s.natAbs := le_trans (by norm_num) this
+    exact_mod_cast this
+  have hxH : ‖((r : ℚ_[p]) / s)‖ ≤ H := padic_norm_int_div_le_height p r s hs
+  exact padic_polynomial_eval_norm_bound p g ((r : ℚ_[p]) / s) H hH_one hxH
+
+/-! ═══════════════════════════════════════════════════════════════════════════
 PART V: MAIN THEOREM
 P-adic algebraic numbers are not p-adically Liouville
 ═══════════════════════════════════════════════════════════════════════════ -/
@@ -283,17 +444,26 @@ P-adic algebraic numbers are not p-adically Liouville
 /-- **Bridge Axiom**: Given the factorization f = (X - C α) · g in ℚ_[p][X] and the evaluation
     identity f(x) = (x - α) · g(x), the p-adic Liouville estimate holds.
 
-    Status (post Part IV.5):
-    Ingredient (1) (norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q) is now
-    PROVED in Part IV.5 as `norm_rat_eq_padicNorm`, and the integer polynomial transport
-    `padic_norm_int_poly_eval` discharges the full ℚ → ℚ_[p] bridge for `eval`. The only
-    remaining obstacle is ingredient (2) below.
+    Status (post Part IV.8):
+    - Ingredient (1) (norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q):
+      ✓ PROVED in Part IV.5 as `norm_rat_eq_padicNorm`. Combined with
+      `padic_norm_int_poly_eval` this fully discharges the ℚ → ℚ_[p] bridge for `eval`.
+    - Ingredient (2a) (height bound on ℚ_[p]: ‖(r:ℚ_[p])/s‖ ≤ max(|r|,|s|)):
+      ✓ PROVED in Part IV.7 as `padic_norm_int_div_le_height`.
+    - Ingredient (2b) (uniform polynomial cofactor bound):
+      ✓ PROVED in Part IV.8 as `padic_polynomial_eval_norm_bound` and
+      `padic_cofactor_bound_rat`: for any g ∈ ℚ_[p][X], r, s : ℤ with s ≠ 0,
+      `‖g.eval ((r:ℚ_[p])/s)‖ ≤ coeffNormSum p g · H^(deg g)`.
 
-    (2) **Cofactor evaluation bound** (REMAINING): for g ∈ ℚ_[p][X] with coefficients
-        depending on α, ‖g.eval (r/s : ℚ_[p])‖ ≤ M · H^(deg g) where H = max(|r|, |s|)
-        and M depends on ‖α‖ and the coefficients of f. Follows from ‖r/s‖_p ≤ |s| ≤ H
-        (by Archimedean Complement applied to ‖s‖_p ≥ 1/|s|) and polynomial norm bounds.
-    Combined: ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ ≥ (C_f/H^d)/(M·H^(d-1)) = C/H^(2d-1) ≥ C/H^(2d). -/
+    Remaining obstacle (now ONLY): assembling the algebra. The bridge requires
+    handling the case f(r/s) = 0 with r/s ≠ α (the finitely-many rational roots of
+    f distinct from α): for those, the formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the
+    indeterminate 0/0 (since heval forces g(r/s) = 0 too when r/s ≠ α and f(r/s) = 0).
+    We must take the constant C ≤ min ‖α - r₀‖ over the finite set of rational
+    roots r₀ ≠ α to cover this case directly.
+
+    Combined estimate (when f(r/s) ≠ 0):
+      ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ ≥ (C_f/H^d)/(M·H^(d-1)) = C/H^(2d-1) ≥ C/H^(2d). -/
 axiom padic_liouville_norm_bridge
     (α : ℚ_[p]) (f : ℤ[X])
     (hf_root : (f.map (algebraMap ℤ ℚ_[p])).eval α = 0)
@@ -510,12 +680,19 @@ PART IX: SORRY SUMMARY
 - All three examples (2|6, 5|25, 3∤7)
 
 **Axiom** (`padic_liouville_norm_bridge`): Connects the factorization/evaluation identity
-to the final norm estimate. Originally required two ingredients; ingredient (1) is now
-proved in Part IV.5:
-1. Norm compatibility ℚ → ℚ_[p]: ✓ PROVED via `padicNormE.eq_padicNorm` (Mathlib).
-   Wrapper theorems: `norm_rat_eq_padicNorm`, `padic_eval_int_poly_cast`,
-   `padic_norm_int_poly_eval`.
-2. Uniform cofactor bound: ‖g.eval (r/s)‖_p ≤ M · H^(d-1) (REMAINING).
+to the final norm estimate. All three originally-listed ingredients are now proved:
+1. Norm compatibility ℚ → ℚ_[p]: ✓ PROVED in Part IV.5 via Mathlib's `Padic.eq_padicNorm`.
+   Wrappers: `norm_rat_eq_padicNorm`, `padic_eval_int_poly_cast`, `padic_norm_int_poly_eval`.
+2a. Height bound: ‖(r : ℚ_[p])/s‖ ≤ H : ✓ PROVED in Part IV.7 as `padic_norm_int_div_le_height`
+    (via the dual face of the Archimedean Complement: `padicNorm_rat_int_div_le_natAbs`).
+2b. Cofactor evaluation bound: ‖g.eval x‖ ≤ M · H^(deg g) : ✓ PROVED in Part IV.8 as
+    `padic_polynomial_eval_norm_bound` (general) and `padic_cofactor_bound_rat`
+    (rational-point specialization).
+
+The axiom now reduces to a finite case analysis: handling the "rational roots of f
+distinct from α" set (finite, at most deg(f) elements) where both sides of the
+formula `‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖` vanish to zero. A standalone discharge
+must take the bridge constant C as `min(C_algebra, min_{r₀ rational root ≠ α} ‖α - r₀‖)`.
 
 **Session 9 changes (2026-05-03)**:
 - Replaced `sorry` in `padic_liouville_estimate` with bridge axiom `padic_liouville_norm_bridge`.
@@ -533,6 +710,22 @@ proved in Part IV.5:
     rational evaluation. This is exactly the connection
     `padicNorm_poly_eval_bound` (Part III) needs to bridge to ℚ_[p].
   Net: bridge axiom now blocked only by ingredient (2) (cofactor evaluation bound).
+
+**Session 11 changes (2026-05-08)**:
+- Added Part IV.7 (height bound on rational division):
+  - `padicNorm_rat_int_div_le_natAbs`: padicNorm p (r/s) ≤ |s| via padicNorm.div +
+    padicNorm.of_int + Archimedean Complement (Part I).
+  - `padicNorm_rat_int_div_le_height`: corollary with max(|r|,|s|).
+  - `padic_norm_int_div_le_height`: ℚ_[p] version via norm_rat_eq_padicNorm.
+- Added Part IV.8 (polynomial cofactor evaluation bound):
+  - `coeffNormSum`: ∑ i ∈ support, ‖coeff i‖ — the cofactor magnitude.
+  - `padic_polynomial_eval_norm_bound`: ‖g.eval x‖ ≤ coeffNormSum · H^(natDegree g)
+    when ‖x‖ ≤ H and 1 ≤ H. Proved by triangle + norm-mul + norm-pow + monotonicity.
+  - `padic_cofactor_bound_rat`: rational-point specialization combining the above
+    with `padic_norm_int_div_le_height`.
+  Net: ingredients (1), (2a), (2b) of the bridge axiom are all now formally proved.
+  The remaining obstruction to discharging the bridge as a theorem is purely the
+  algebraic case analysis on rational roots of f distinct from α.
 
 -/
 

--- a/research/problems/liouville-theorem-oq-04/knowledge.md
+++ b/research/problems/liouville-theorem-oq-04/knowledge.md
@@ -81,3 +81,68 @@ P-adic extension of Liouville's approximation theorem.
 - `inv_le_inv_of_le` is unknown in Mathlib 4.26 — use `one_div_le_one_div_of_le` instead
 - `Irreducible.ne_zero` — uncertain whether this dot-notation lemma exists in Mathlib 4.26; safer to use degree argument: if `g = 0` then `natDegree(fQ) = 0` contradicting `natDegree ≥ 2`
 - `not_isUnit_of_degree_pos` — uncertain whether this name exists; use `Polynomial.isUnit_iff` (confirmed in codebase: `∃ c : R, c ≠ 0 ∧ p = C c`) + `congr_arg Polynomial.natDegree` + `simp [natDegree_X_sub_C, natDegree_C]` instead
+
+---
+
+## Session 2026-05-08 (Session 11) — Cofactor Bound + Height Bound (researcher-6)
+
+**Mode**: REVISIT
+**Outcome**: progress (ingredient (2) of bridge axiom now formally proved at the helper level)
+
+### What I Did
+
+Added two new sections to `LiouvilleTheoremOQ04.lean`:
+
+**Part IV.7** — P-adic height bound on rationals:
+- `padicNorm_rat_int_div_le_natAbs (r s : ℤ) (hs : s ≠ 0) : padicNorm p ((r:ℚ)/s) ≤ |s|`
+  Proof: `padicNorm.div` (multiplicativity) + `padicNorm.of_int` (≤ 1) +
+  `padicNorm_int_ge_inv` (Archimedean Complement) + `div_le_iff₀` + `mul_inv_cancel₀`.
+- `padicNorm_rat_int_div_le_height`: corollary with `max(|r|,|s|)`.
+- `padic_norm_intCast_eq_padicNorm (z : ℤ) : ‖((z:ℤ):ℚ_[p])‖ = padicNorm p (z:ℚ)` —
+  bridges integer-cast form to rational-cast form via `norm_cast`.
+- `padic_norm_int_div_le_height (r s : ℤ) (hs : s ≠ 0) : ‖((r:ℚ_[p])/s)‖ ≤ max(|r|,|s|)`.
+
+**Part IV.8** — Polynomial cofactor evaluation bound:
+- `coeffNormSum (g : Polynomial ℚ_[p]) : ℝ := g.support.sum fun i => ‖g.coeff i‖`
+- `coeffNormSum_nonneg`: nonneg of the cofactor magnitude.
+- `padic_polynomial_eval_norm_bound (g : Polynomial ℚ_[p]) (x : ℚ_[p]) (H : ℝ)
+    (hH : 1 ≤ H) (hxH : ‖x‖ ≤ H) : ‖g.eval x‖ ≤ coeffNormSum p g · H^(natDegree g)`.
+  Proof: rewrite via `Polynomial.eval_eq_sum`, then `norm_sum_le` + `norm_mul` +
+  `norm_pow` + `pow_le_pow_left₀` + `pow_le_pow_right₀` + factor out `H^natDegree`.
+- `padic_cofactor_bound_rat`: rational-point specialization with `H = max(|r|,|s|)`.
+
+Updated bridge axiom docstring + Sorry Summary to reflect new state. File builds
+cleanly (Docker, lean 4.26.0): 1 axiom, 0 sorries, 732 lines, 26 theorems, 4 defs.
+
+### Key Findings
+
+- **Cast-rewrite isDefEq blowup**: The natural pattern `have hcast : ((r:ℚ_[p])/s) = (((r:ℚ)/s):ℚ_[p]) := by push_cast; rfl; rw [hcast, norm_rat_eq_padicNorm]` triggers a deterministic timeout at `isDefEq` (heartbeats=400000). The rewrite engine can't reconcile the cast layers inside `‖·‖` quickly enough.
+- **Robust pattern**: rewrite `norm_div` first (breaks the norm into integer norms), then use a separate `padic_norm_intCast_eq_padicNorm` helper on each integer norm. The integer-cast bridge uses `norm_cast` (not `push_cast; rfl`) which is more efficient for one-step cast equalities.
+- **Bridge ingredient (2) anatomy**: the cofactor bound packages naturally as `‖g.eval x‖ ≤ M · max(1, ‖x‖)^(natDegree g)`, where `M = ∑ i ∈ support, ‖g.coeff i‖` is the L¹ coefficient norm. This is a direct application of triangle + multiplicativity to `g.eval x = ∑ g.coeff i · x^i`.
+- **Residual obstruction is purely algebraic**: with all three sub-ingredients formally proved, discharging the bridge axiom reduces to handling the case `f(r/s) = 0 ∧ r/s ≠ α`. Since this set is the rational roots of `f` minus α (finite, ≤ deg f elements), one can take `C ≤ min ‖α - r₀‖` over the set.
+
+### Pending — Bridge Discharge Sketch
+
+```
+theorem padic_liouville_norm_bridge_proof (...) :
+    ∃ C : ℝ, 0 < C ∧ ∀ r s : ℤ, s ≠ 0 → α ≠ (r:ℚ_[p])/s →
+      C / H^(2d) ≤ ‖α - (r:ℚ_[p])/s‖ := by
+  -- Get C₁ from the algebraic case f(r/s) ≠ 0
+  obtain ⟨C₁, hC₁_pos, hC₁⟩ := /- combine padicNorm_poly_eval_bound + padic_norm_int_poly_eval + padic_cofactor_bound_rat -/
+  -- Get δ = min over rational roots of f distinct from α
+  let RatRoots : Finset ℚ := /- rational roots of f.map (algebraMap ℤ ℚ) -/
+  let RatRootsExceptAlpha := RatRoots.filter (fun q => (q : ℚ_[p]) ≠ α)
+  by_cases hempty : RatRootsExceptAlpha.Nonempty
+  case pos =>
+    let δ := RatRootsExceptAlpha.inf' hempty (fun q => ‖α - (q : ℚ_[p])‖)
+    use min C₁ δ
+    -- C₁ handles f(r/s) ≠ 0 case; δ handles the finite rational-root case
+    ...
+  case neg => use C₁; ...
+```
+
+### Next Steps
+
+1. Identify the right Mathlib name for "finite set of rational roots of an integer polynomial". Candidates: `Polynomial.roots`, `Polynomial.aroots`. Need a ℚ-version with finiteness from degree.
+2. Prove the bridge using the case-split sketched above.
+3. After bridge discharge: convert `axiom padic_liouville_norm_bridge` to `theorem ... := by <proof>`, drop the `axiomCount: 1` to 0, change `status: "axiomatized"` to `"verified"`, change `badge: "axiom"` to `"verified"` (or `"original"` since this is a from-scratch p-adic Liouville).

--- a/research/problems/liouville-theorem-oq-04/state.md
+++ b/research/problems/liouville-theorem-oq-04/state.md
@@ -1,25 +1,35 @@
 # Research State: liouville-theorem-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: REFINE
 **Path**: full
-**Since**: 2026-04-22T23:31:13+02:00
-**Iteration**: 1
+**Since**: 2026-05-08T01:00:00+00:00
+**Iteration**: 11
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Bridge axiom ingredient (2) discharged at the helper level. Parts IV.7 (height
+bound on rationals) and IV.8 (polynomial cofactor evaluation bound) added in
+Session 11; all three sub-ingredients of `padic_liouville_norm_bridge` are now
+formally proved. File builds clean: 1 axiom, 0 sorries, 732 lines, 26 theorems.
 
 ## Active Approach
-None yet.
+Discharge `padic_liouville_norm_bridge` from axiom to theorem. Helper infrastructure
+complete (norm transport, height bound, cofactor bound). Remaining: case-split on
+`f(r/s) = 0` vs `≠ 0` to handle the rational-roots case.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 10
+- Current approach attempts: 3
+- Approaches tried: 3
 
 ## Blockers
-None.
+- Rational-roots case analysis: when f(r/s) = 0 and r/s ≠ α (finitely many), the
+  formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the indeterminate 0/0. Discharging the
+  bridge requires C ≤ min_{r₀ rat root ≠ α} ‖α - r₀‖ alongside the algebraic constant.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Discharge `padic_liouville_norm_bridge` by case-splitting on `f(r/s) = 0`.
+- Case `f(r/s) ≠ 0`: combine `padic_norm_int_poly_eval` + `padicNorm_poly_eval_bound` +
+  `padic_cofactor_bound_rat`.
+- Case `f(r/s) = 0` with `r/s ≠ α`: enumerate rational roots of f as a Finset, take
+  min of ‖α - r₀‖ over the (finite) set.

--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom: padic_liouville_norm_bridge — connects the factorization f = (X-C α)·g and evaluation identity to the p-adic Liouville lower bound. Requires (1) norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q, and (2) cofactor evaluation bound ‖g.eval(r/s)‖_p ≤ M·H^(d-1). The Archimedean Complement Lemma and all other results are fully proved.",
+    "assumptions": "1 axiom: padic_liouville_norm_bridge — connects the factorization f = (X-C α)·g and evaluation identity to the p-adic Liouville lower bound. Originally required two ingredients: (1) norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q, (2) cofactor evaluation bound ‖g.eval(r/s)‖_p ≤ M·H^(deg g). All three sub-ingredients are now formally proved (Part IV.5 norm transport, Part IV.7 height bound padic_norm_int_div_le_height, Part IV.8 polynomial cofactor bound padic_polynomial_eval_norm_bound and padic_cofactor_bound_rat). The remaining obstruction to discharging the bridge as a theorem is the case analysis on rational roots of f distinct from α (finite set, requires taking C ≤ min ‖α - r₀‖ over those roots).",
     "dateAdded": "2026-04-26",
     "mathlibDependencies": [
       {
@@ -59,9 +59,9 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 539,
-    "theoremCount": 19,
-    "definitionCount": 3
+    "lineCount": 732,
+    "theoremCount": 26,
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Liouville's 1844 theorem — the first proof that specific transcendental numbers exist — uses the Archimedean property $|N|_{\\infty} \\geq 1$ for nonzero integers. The p-adic number system was developed by Kurt Hensel around 1897, motivated by the analogy between number fields and function fields. P-adic Liouville-type results appear in Mahler's work (1930s–1950s) on p-adic transcendence and in the theory of p-adic Diophantine approximation. The Archimedean Complement Lemma $|N|_p \\geq 1/|N|$ is a weak form of the **adelic product formula** $\\prod_v |N|_v = 1$ (Artin-Whaples, 1945), which underlies all of modern algebraic number theory — the product over all places (one Archimedean + one p-adic for each prime) equals 1. The p-adic Liouville theorem belongs to the broader program of Diophantine approximation in non-Archimedean metrics, developed by Mahler, Ridout, and Roth (Roth's theorem, 1955, Fields Medal). The use of **naive height** $H(r/s) = \\max(|r|, |s|)$ — rather than just the denominator — is the key departure from the classical theory, forced by the non-Archimedean structure where the numerator's p-adic content cannot be ignored.",
@@ -200,10 +200,10 @@
       "Polynomial"
     ],
     "namespace": "LiouvilleTheoremOQ04",
-    "lineCount": 539,
+    "lineCount": 732,
     "axiomCount": 1,
-    "theoremCount": 19,
-    "definitionCount": 3,
+    "theoremCount": 26,
+    "definitionCount": 4,
     "path": "Proofs/LiouvilleTheoremOQ04.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/liouville-theorem-oq-04.json
+++ b/src/data/research/problems/liouville-theorem-oq-04.json
@@ -17,30 +17,37 @@
   },
   "currentState": {
     "phase": "REFINE",
-    "since": "2026-05-07T22:50:00.000Z",
-    "iteration": 10,
-    "focus": "Bridge axiom INGREDIENT (1) DISCHARGED: rational-embedding norm compatibility ‖(q:ℚ_[p])‖ = padicNorm p q proved via Mathlib's Padic.eq_padicNorm. New helper Part IV.5 (norm_rat_eq_padicNorm, padic_eval_int_poly_cast, padic_norm_int_poly_eval) establishes the full ℚ → ℚ_[p] eval-norm transport. Remaining obstruction: ingredient (2), the cofactor evaluation bound ‖g.eval(r/s)‖ ≤ M·H^(d-1). Also fixed Lean 4.26 API drift in padic_algebraic_not_liouville and padicNorm_poly_eval_bound (file no longer built before this session).",
+    "since": "2026-05-08T01:00:00.000Z",
+    "iteration": 11,
+    "focus": "Bridge axiom INGREDIENT (2) DISCHARGED at the helper level. New Part IV.7 (height bound: ‖((r:ℚ_[p])/s)‖ ≤ max(|r|,|s|)) and Part IV.8 (polynomial cofactor bound: ‖g.eval x‖ ≤ coeffNormSum p g · H^(natDegree g)) provide all three sub-ingredients of the bridge. Remaining obstruction is purely algebraic: case analysis on rational roots of f distinct from α (finite set, requires C ≤ min ‖α - r₀‖ over those roots).",
     "blockers": [
-      "Cofactor evaluation bound: ‖g.eval(r/s : ℚ_[p])‖ ≤ M · H^(deg g) where M depends only on ‖α‖ and coefficients of f. Requires polynomial norm triangle inequality + ‖r/s‖_p ≤ H (from Archimedean Complement applied in the reverse direction)."
+      "Rational-roots case analysis: when f(r/s) = 0 and r/s ≠ α (finitely many such rationals), the formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the indeterminate 0/0 (heval forces g(r/s) = 0 too). Discharging the bridge requires taking C ≤ min_{r₀ rat root ≠ α} ‖α - r₀‖ alongside the algebraic constant from the f(r/s) ≠ 0 case."
     ],
-    "nextAction": "Prove the cofactor bound as a standalone theorem and use it (plus padic_norm_int_poly_eval) to discharge padic_liouville_norm_bridge into a proper theorem.",
+    "nextAction": "Discharge padic_liouville_norm_bridge by case-splitting on f(r/s) = 0 vs ≠ 0. For ≠ 0: combine padic_norm_int_poly_eval + padicNorm_poly_eval_bound + padic_cofactor_bound_rat. For = 0 with r/s ≠ α: take min over the finite rational-root set of f. Likely needs a new helper around Polynomial.roots in ℚ.",
     "attemptCounts": {
-      "total": 9,
-      "currentApproach": 2,
-      "approachesTried": 2
+      "total": 10,
+      "currentApproach": 3,
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 10, 2026-05-07): Discharged ingredient (1) of the bridge axiom. New Part IV.5 contains three formal lemmas built on Mathlib's Padic.eq_padicNorm: norm_rat_eq_padicNorm (rational-embedding norm compatibility), padic_eval_int_poly_cast (integer polynomial evaluation transport via aeval_algHom_apply), and padic_norm_int_poly_eval (the combined statement that ‖(f.map alg ℤ ℚ_[p]).eval ((q:ℚ_[p]))‖ = padicNorm p ((f.map alg ℤ ℚ).eval q)). This is exactly the connection padicNorm_poly_eval_bound (Part III) needs to bridge from ℚ to ℚ_[p]. Also repaired Lean 4.26 API drift: padicNorm.pos → padicNorm.nonneg + padicNorm.nonzero, padicNormE.eq_padicNorm → Padic.eq_padicNorm, div_lt_div_right → div_lt_div_iff_of_pos_right, pow_le_pow_left → pow_le_pow_left₀, ring → div_pow + one_pow, and switched H : ℕ → H : ℝ to match real-valued max on hbound's RHS. File now builds cleanly (Docker, lean v4.26.0) with 1 axiom, 0 sorries — the remaining axiom now blocks ONLY on ingredient (2) (the cofactor bound).",
+    "progressSummary": "PROGRESS (Session 11, 2026-05-08): Discharged ingredient (2) of the bridge axiom at the helper level. Added Part IV.7 (rational-division height bound) and Part IV.8 (polynomial cofactor evaluation bound). New formal lemmas: padicNorm_rat_int_div_le_natAbs (padicNorm p (r/s : ℚ) ≤ |s| via padicNorm.div + padicNorm.of_int + Archimedean Complement), padic_norm_intCast_eq_padicNorm (bridges integer-cast form ‖(z:ℤ:ℚ_[p])‖ to padicNorm p (z:ℚ) via norm_cast + norm_rat_eq_padicNorm), padic_norm_int_div_le_height (transports the rational bound to ℚ_[p] via norm_div + padicNorm.div), coeffNormSum + coeffNormSum_nonneg (the cofactor magnitude as ∑ ‖coeff i‖), padic_polynomial_eval_norm_bound (general: ‖g.eval x‖ ≤ coeffNormSum · H^(natDegree g) via norm_sum_le + norm_mul + norm_pow + monotonicity), padic_cofactor_bound_rat (rational-point specialization). All three originally-listed bridge ingredients (1, 2a, 2b) are now formally proved. The remaining obstruction is purely algebraic: case analysis on rational roots of f distinct from α. File builds cleanly (Docker, lean 4.26.0) with 1 axiom, 0 sorries.",
     "builtItems": [
       "IsPadicLiouville (LiouvilleTheoremOQ04.lean): definition with strict positivity 0 < ‖β - r/s‖ and height bound 2 ≤ max r.natAbs s.natAbs",
       "padic_liouville_estimate: proved via factorization + bridge axiom — exposes the standard (C/H^(2d)) lower bound",
       "padic_algebraic_not_liouville: proved (0 sorries) — closes the main contradiction via exists_pow_lt_of_lt_one + div_lt_div_iff_of_pos_right + one_div_le_one_div_of_le + pow_le_pow_left₀",
       "Archimedean Complement Lemma: padicNorm p n ≥ 1/n for n > 0, proved via pow_padicValNat_dvd (Part I)",
       "Polynomial evaluation lemmas over ℚ via padicNorm (Part III) — supplies C_f for the bridge axiom",
-      "norm_rat_eq_padicNorm (Part IV.5, NEW Session 10): ‖(q:ℚ_[p])‖ = padicNorm p q via Padic.eq_padicNorm",
-      "padic_eval_int_poly_cast (Part IV.5, NEW Session 10): polynomial evaluation transport ℚ → ℚ_[p] via aeval_algHom_apply with (Rat.castHom ℚ_[p]).toIntAlgHom",
-      "padic_norm_int_poly_eval (Part IV.5, NEW Session 10): combined ℚ_[p]-norm of integer polynomial evaluation equals rational p-adic norm of the rational evaluation"
+      "norm_rat_eq_padicNorm (Part IV.5, Session 10): ‖(q:ℚ_[p])‖ = padicNorm p q via Padic.eq_padicNorm",
+      "padic_eval_int_poly_cast (Part IV.5, Session 10): polynomial evaluation transport ℚ → ℚ_[p] via aeval_algHom_apply with (Rat.castHom ℚ_[p]).toIntAlgHom",
+      "padic_norm_int_poly_eval (Part IV.5, Session 10): combined ℚ_[p]-norm of integer polynomial evaluation equals rational p-adic norm of the rational evaluation",
+      "padicNorm_rat_int_div_le_natAbs (Part IV.7, NEW Session 11): padicNorm p ((r:ℚ)/s) ≤ |s| for s ≠ 0",
+      "padicNorm_rat_int_div_le_height (Part IV.7, NEW Session 11): padicNorm p ((r:ℚ)/s) ≤ max(|r|,|s|) — height-bound corollary",
+      "padic_norm_intCast_eq_padicNorm (Part IV.7, NEW Session 11): ‖((z:ℤ):ℚ_[p])‖ = padicNorm p (z:ℚ) bridge via norm_cast",
+      "padic_norm_int_div_le_height (Part IV.7, NEW Session 11): ‖((r:ℚ_[p])/s)‖ ≤ max(|r|,|s|) — ℚ_[p] version of height bound",
+      "coeffNormSum + coeffNormSum_nonneg (Part IV.8, NEW Session 11): ∑ i ∈ support, ‖coeff i‖ — the cofactor magnitude",
+      "padic_polynomial_eval_norm_bound (Part IV.8, NEW Session 11): ‖g.eval x‖ ≤ coeffNormSum p g · H^(natDegree g) for g : Polynomial ℚ_[p], 1 ≤ H, ‖x‖ ≤ H — general form",
+      "padic_cofactor_bound_rat (Part IV.8, NEW Session 11): rational-point specialization with H = max(|r|,|s|) and 2 ≤ H — direct fit for IsPadicLiouville"
     ],
     "insights": [
       "IsPadicLiouville needs both 2 ≤ max(|r|,|s|) and 0 < ‖β - r/s‖. Without H≥2, bound 1/H^n=1 gives no useful constraint. Without strict positivity, every rational is trivially Liouville (r/s = β gives ‖β - r/s‖ = 0).",
@@ -48,15 +55,19 @@
       "Exponent 2d (instead of d) suffices via the simple cofactor bound: ‖g(r/s)‖_p ≤ M_g · H^(d-1) (non-Archimedean + ‖r/s‖_p ≤ H), giving ‖α - r/s‖ ≥ C_f / (M_g · H^(2d-1)) ≥ C / H^(2d). The tight bound d would require an ultrametric case split.",
       "The norm-compatibility lemma sits in namespace Padic in v4.26 (was historically padicNormE) — direct dot-notation `padicNormE.eq_padicNorm` triggers AbsoluteValue field-access; use `Padic.eq_padicNorm` instead.",
       "Polynomial evaluation transport ℚ → ℚ_[p] is one line via Polynomial.aeval_algHom_apply applied to (Rat.castHom ℚ_[p]).toIntAlgHom : ℚ →ₐ[ℤ] ℚ_[p]; no manual map_map / eval_map gymnastics needed.",
-      "Lean 4.26 API drift in this file: padicNorm.pos removed (use nonneg + nonzero), div_lt_div_right → div_lt_div_iff_of_pos_right, pow_le_pow_left → pow_le_pow_left₀. Also `set H : ℕ` no longer unifies with real-valued max output of `hbound`; switch to `set H : ℝ`."
+      "Lean 4.26 API drift in this file: padicNorm.pos removed (use nonneg + nonzero), div_lt_div_right → div_lt_div_iff_of_pos_right, pow_le_pow_left → pow_le_pow_left₀. Also `set H : ℕ` no longer unifies with real-valued max output of `hbound`; switch to `set H : ℝ`.",
+      "Session 11: When transporting `‖((r:ℚ_[p])/s)‖` to a padicNorm bound, the natural cast manipulation `push_cast; rfl` to prove `((r:ℚ_[p])/s) = (((r:ℚ)/s):ℚ_[p])` works for the equation but a subsequent `rw [hcast]` inside `‖·‖` triggers a deterministic isDefEq timeout (heartbeat exhaustion). The robust pattern: avoid the cast equation, instead `rw [norm_div]` first, then use a separate `padic_norm_intCast_eq_padicNorm` helper (proved with `norm_cast` for the integer-cast bridge) on each integer norm individually.",
+      "Session 11: A `padicNorm.div`-style multiplicativity rewrite produces a clean ℚ-statement; combining with the Archimedean Complement (lower bound on `padicNorm p s`) gives the height bound `padicNorm p (r/s) ≤ |s|` directly. The cleanest proof uses `div_le_iff₀ hs_norm_pos` to transform the goal to `padicNorm p r ≤ |s| · padicNorm p s` and then `mul_inv_cancel₀`."
     ],
     "mathlibGaps": [
-      "Cofactor norm bound ‖g.eval (r/s : ℚ_[p])‖ ≤ M · H^(deg g) for polynomial g ∈ ℚ_[p][X] and rational r/s, where M depends only on coefficients — needs to be assembled from triangle inequality + ‖r/s‖_p ≤ H"
+      "Direct Mathlib lemma for `‖(z:ℤ):ℚ_[p]‖ = padicNorm p (z:ℚ)` (we proved padic_norm_intCast_eq_padicNorm as a wrapper around `norm_rat_eq_padicNorm` + `norm_cast`)",
+      "Direct Mathlib lemma for `‖(r:ℚ_[p])/s‖ ≤ max(|r|,|s|)` (we built padic_norm_int_div_le_height from primitives)",
+      "Polynomial evaluation norm bound `‖g.eval x‖ ≤ M · max(1, ‖x‖)^(deg g)` for normed semirings (we proved padic_polynomial_eval_norm_bound directly via norm_sum_le)"
     ],
     "nextSteps": [
-      "Prove ‖((r:ℚ_[p])/s)‖ ≤ (max r.natAbs s.natAbs : ℝ) using padicNorm_int_le_one for ‖r‖_p and padicNorm_int_ge_inv for 1/‖s‖_p ≤ |s| ≤ H",
-      "Prove polynomial cofactor bound: for g ∈ ℚ_[p][X] of degree d-1, ‖g.eval x‖ ≤ M_g · max(1, ‖x‖)^(d-1) where M_g = max ‖coeff_i‖, via Polynomial.eval over the non-Archimedean norm",
-      "Combine padic_norm_int_poly_eval (Part IV.5) + padicNorm_poly_eval_bound (Part III) + cofactor bound to prove padic_liouville_norm_bridge as a theorem — eliminating the last axiom"
+      "Discharge padic_liouville_norm_bridge as a theorem: case-split on f(r/s) = 0. (Case f(r/s) ≠ 0): combine padic_norm_int_poly_eval + padicNorm_poly_eval_bound + padic_cofactor_bound_rat. (Case f(r/s) = 0 with r/s ≠ α): take min over the finite rational-root set.",
+      "Likely helper: a polynomial-roots-in-ℚ enumeration lemma producing the finite set {r/s : ℚ | f(r/s) = 0} as a Finset, then min_of_nonempty over distances ‖α - r₀‖.",
+      "After bridge discharge: the file will be axiom-free (verified status). Update meta.json status from 'axiomatized' to 'verified' and badge from 'axiom' to 'verified'."
     ]
   },
   "tags": [
@@ -76,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.505Z",
-  "lastUpdate": "2026-05-07T22:50:00.000Z",
+  "lastUpdate": "2026-05-08T01:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -94,10 +105,10 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ04.lean",
       "filename": "LiouvilleTheoremOQ04.lean",
-      "lineCount": 539,
-      "theoremCount": 19,
+      "lineCount": 732,
+      "theoremCount": 26,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LiouvilleTheoremOQ04.lean"


### PR DESCRIPTION
## Summary

Session 11 of `liouville-theorem-oq-04` (P-adic Liouville Theorem). Adds Parts IV.7
and IV.8 to `LiouvilleTheoremOQ04.lean`, formally proving the third sub-ingredient
of the bridge axiom: the cofactor evaluation bound `‖g.eval x‖ ≤ M·H^(deg g)`.

With Session 10's Part IV.5 (norm transport), all three originally-listed bridge
ingredients (1, 2a, 2b) now have formal proofs at the helper level.

## What changed in the Lean file

**Part IV.7 — P-adic height bound on rationals**:
- `padicNorm_rat_int_div_le_natAbs (r s : ℤ) (hs : s ≠ 0) : padicNorm p ((r:ℚ)/s) ≤ |s|`
  via `padicNorm.div` + `padicNorm.of_int` + Archimedean Complement (Part I).
- `padicNorm_rat_int_div_le_height`: corollary with `max(|r|,|s|)`.
- `padic_norm_intCast_eq_padicNorm`: bridges `‖(z:ℤ:ℚ_[p])‖ = padicNorm p (z:ℚ)`
  via `norm_cast` + Part IV.5's `norm_rat_eq_padicNorm`.
- `padic_norm_int_div_le_height`: ℚ_[p] form via `norm_div` + the integer-cast
  bridge.

**Part IV.8 — Polynomial cofactor evaluation bound**:
- `coeffNormSum (g : Polynomial ℚ_[p]) := g.support.sum fun i => ‖g.coeff i‖`.
- `padic_polynomial_eval_norm_bound`: `‖g.eval x‖ ≤ coeffNormSum p g · H^(natDegree g)`
  for `1 ≤ H` and `‖x‖ ≤ H`. Proof: triangle (`norm_sum_le`), `norm_mul`, `norm_pow`,
  `pow_le_pow_left₀` / `pow_le_pow_right₀`, factor out `H^natDegree`.
- `padic_cofactor_bound_rat`: rational-point specialization with `H = max(|r|,|s|)`,
  matching the `IsPadicLiouville` height hypothesis.

Bridge axiom docstring + Sorry Summary updated to reflect the new state. The
file builds clean: **1 axiom, 0 sorries, 732 lines, 26 theorems, 4 defs**
(Docker, lean 4.26.0).

## Residual obstacle (now ONLY)

Discharging the bridge axiom as a theorem requires handling `f(r/s) = 0 ∧ r/s ≠ α`.
This set is the rational roots of `f` distinct from `α` — finite (≤ deg f). The
combined estimate `‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖` is the indeterminate 0/0 here
(since `heval` forces `g(r/s) = 0` too). One must take `C ≤ min_{r₀ rat root ≠ α} ‖α - r₀‖`.

See knowledge.md for the discharge sketch.

## Files

- `proofs/Proofs/LiouvilleTheoremOQ04.lean` — Parts IV.7, IV.8 added; docstrings updated
- `src/data/proofs/liouville-theorem-oq-04/meta.json` — counts updated (732/26/4)
- `src/data/research/problems/liouville-theorem-oq-04.json` — phase, builtItems, insights
- `research/problems/liouville-theorem-oq-04/knowledge.md` — Session 11 entry
- `research/problems/liouville-theorem-oq-04/state.md` — phase=REFINE, iteration=11

## Status

**Outcome**: progress (axiom hunt: ingredient (2) of 1-axiom file proved)
**Next**: discharge `padic_liouville_norm_bridge` from axiom to theorem via case
analysis on rational roots of f.

🤖 Generated by researcher-6