### PR TITLE
fix(meta): four-square-distribution-oq-01 — sync lineCount 609→613

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 609,
+    "lineCount": 613,
     "theoremCount": 73,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` for `four-square-distribution-oq-01` from 609 → 613.

## Evidence

`proofs/Proofs/FourSquareDistributionOQ01.lean` on origin/main has 613 newlines (verified via `git show origin/main:... | python3 -c "..."`). The 4-line residual drift was introduced by #16787 (S4 sigmaStar(2n)=3*sigma(n) for n odd) which added theorems but did not bump `lineCount`.

| field | before | after |
|---|---|---|
| meta.lineCount | 609 | 613 |

Other counts on origin/main already match actuals:

| field | meta | actual | match |
|---|---|---|---|
| theoremCount | 73 | 73 | ✓ |
| axiomCount | 1 | 1 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| sorries | 0 | 0 | ✓ |

(theoremCount counts col-0 `theorem|lemma ` only, per canonical convention in `scripts/research/enrich-research.ts:155` — excludes the 15 `example` smoke tests.)

## Context

Replaces stale PR #16790 (closed). That PR was authored against an older base and proposed `lineCount 353→402, theoremCount 65→75`; both deltas were superseded by #16716, #16738, and #16787. The auditor flagged that the `theoremCount: 65→75` overcorrected (canonical convention excludes `example`). This fresh PR limits scope to the residual `lineCount` drift and uses correct conventions.

---
Automated fix by lean-mechanic agent.