### PR TITLE
research(hilbert-11-oq-02): recover orphan wip — Selmer cubic Hasse-principle framework

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2271,6 +2271,7 @@ import Proofs.Hilbert11OQ01
 import Proofs.Hilbert11OQ01Aristotle
 import Proofs.Hilbert11OQ01OQ01
 import Proofs.Hilbert11OQ01OQ01Aristotle
+import Proofs.Hilbert11OQ02
 import Proofs.Hilbert11_QuadraticForms
 import Proofs.Hilbert13GeneralSpaces
 import Proofs.Hilbert13Superposition

--- a/proofs/Proofs/Hilbert11OQ02.lean
+++ b/proofs/Proofs/Hilbert11OQ02.lean
@@ -1,0 +1,264 @@
+import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.Topology.Algebra.Order.IntermediateValue
+import Mathlib.Topology.Order.Bornology
+import Mathlib.Analysis.Polynomial.Basic
+import Mathlib.Tactic
+
+/-
+# Hilbert's 11th Problem OQ-02: When Does the Hasse Principle Fail for Higher-Degree Forms?
+
+## Open Question: hilbert-11-oq-02
+
+Hasse-Minkowski (formalized in `Hilbert11_QuadraticForms.lean` and `Hilbert11OQ01.lean`)
+shows the Hasse principle holds for quadratic forms over ℚ. Selmer (1951) showed it
+fails for the cubic 3x³ + 4y³ + 5z³ = 0, which has solutions over ℝ and every ℚₚ but
+not over ℚ. The OPEN question asks for an exact characterization of when the Hasse
+principle fails for higher-degree forms.
+
+The Brauer-Manin obstruction (Manin 1971) explains many failures. The Colliot-Thélène
+conjecture states that for smooth proper geometrically rationally connected varieties,
+the Brauer-Manin obstruction is the only obstruction; this is known for several
+families (conic bundles, del Pezzo surfaces of degree ≥ 5) but is open in general.
+
+## What This File Contributes
+
+1. **PROVED**: The Selmer cubic has a nontrivial **real** solution (constructed via IVT,
+   witnessing local solubility over ℝ — the part of Selmer's theorem that is elementary).
+2. **PROVED**: The "easy direction" of the Hasse principle for the Selmer cubic over ℝ
+   (any rational solution gives a real solution, via the embedding ℚ ↪ ℝ).
+3. **PROVED**: The "easy direction" over ℚₚ (rational ⇒ p-adic, via ℚ ↪ ℚₚ).
+4. **AXIOMATIZED**: Selmer's theorem (no rational solutions). The full proof requires
+   3-descent on a genus-1 curve, beyond present formalization.
+5. **DEFINED**: A precise predicate `selmerHassePrinciple` capturing the local-global
+   property for the Selmer cubic, plus the open conjecture statement.
+
+## Status: 1 axiom (Selmer 1951), 0 sorries
+
+## References
+- Selmer, E. (1951). "The Diophantine equation ax³ + by³ + cz³ = 0", Acta Math. 85.
+- Manin, Yu. I. (1971). "Le groupe de Brauer-Grothendieck en géométrie diophantienne",
+  Actes du Congrès International des Mathématiciens, Nice.
+- Colliot-Thélène, J.-L. (2003). "Points rationnels sur les fibrations".
+- Skorobogatov, A. N. (2001). "Torsors and Rational Points", Cambridge.
+-/
+
+set_option linter.unusedVariables false
+
+namespace Hilbert11OQ02
+
+open Set
+
+/-! ## Section 1: The Selmer Cubic Polynomial -/
+
+/-- The Selmer cubic polynomial: f(x, y, z) = 3x³ + 4y³ + 5z³ over a commutative ring R. -/
+def selmerPoly {R : Type*} [CommRing R] (x y z : R) : R :=
+  3 * x ^ 3 + 4 * y ^ 3 + 5 * z ^ 3
+
+/-! ## Section 2: Real Solubility (PROVED via IVT) -/
+
+/-- The Selmer cubic 3x³ + 4y³ + 5z³ = 0 has a nontrivial real solution.
+
+    **Construction**: Set y = 1, z = 0. Then we need a real x with 3x³ + 4 = 0, i.e.,
+    x³ = -4/3. The function g(x) = 3x³ + 4 satisfies g(-2) = -20 < 0 and g(0) = 4 > 0,
+    so the Intermediate Value Theorem gives an x₀ ∈ [-2, 0] with g(x₀) = 0.
+    The triple (x₀, 1, 0) is then a nontrivial real solution since the second
+    coordinate is 1 ≠ 0.
+
+    This gives the **real solubility** half of the Selmer counterexample concretely;
+    combined with axiomatized p-adic solubility, this would witness the Hasse principle
+    failure (modulo the deep theorem that there are no rational solutions). -/
+theorem selmerCubic_real_solution :
+    ∃ (x y z : ℝ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 := by
+  -- Define g(x) = 3x³ + 4
+  let g : ℝ → ℝ := fun x => 3 * x ^ 3 + 4
+  have hg_cont : Continuous g := by
+    show Continuous (fun x : ℝ => 3 * x ^ 3 + 4)
+    fun_prop
+  have hg_neg : g (-2) = -20 := by show 3 * (-2 : ℝ) ^ 3 + 4 = -20; norm_num
+  have hg_pos : g 0 = 4 := by show 3 * (0 : ℝ) ^ 3 + 4 = 4; norm_num
+  have h_le : (-2 : ℝ) ≤ 0 := by norm_num
+  have hmem : (0 : ℝ) ∈ Icc (g (-2)) (g 0) := by
+    rw [hg_neg, hg_pos]
+    exact ⟨by norm_num, by norm_num⟩
+  obtain ⟨x₀, _hx_mem, hx_zero⟩ :=
+    intermediate_value_Icc h_le hg_cont.continuousOn hmem
+  refine ⟨x₀, 1, 0, Or.inr (Or.inl one_ne_zero), ?_⟩
+  -- hx_zero : g x₀ = 0, i.e. 3 * x₀^3 + 4 = 0
+  -- Goal: selmerPoly x₀ 1 0 = 0
+  have hg_eval : g x₀ = 3 * x₀ ^ 3 + 4 := rfl
+  have hsum : 3 * x₀ ^ 3 + 4 = 0 := hg_eval ▸ hx_zero
+  show 3 * x₀ ^ 3 + 4 * (1 : ℝ) ^ 3 + 5 * (0 : ℝ) ^ 3 = 0
+  linear_combination hsum
+
+/-! ## Section 3: Easy Direction of the Hasse Principle (PROVED) -/
+
+/-- **Easy direction over ℝ**: every rational solution of the Selmer cubic gives a real solution.
+
+    Trivial via the embedding ℚ ↪ ℝ. -/
+theorem selmer_rat_implies_real
+    (h : ∃ (x y z : ℚ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) :
+    ∃ (x y z : ℝ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 := by
+  obtain ⟨x, y, z, hne, heq⟩ := h
+  refine ⟨(x : ℝ), (y : ℝ), (z : ℝ), ?_, ?_⟩
+  · rcases hne with hx | hy | hz
+    · exact Or.inl (by exact_mod_cast hx)
+    · exact Or.inr (Or.inl (by exact_mod_cast hy))
+    · exact Or.inr (Or.inr (by exact_mod_cast hz))
+  · show (3 : ℝ) * (x : ℝ) ^ 3 + 4 * (y : ℝ) ^ 3 + 5 * (z : ℝ) ^ 3 = 0
+    have hcast : (3 : ℝ) * (x : ℝ) ^ 3 + 4 * (y : ℝ) ^ 3 + 5 * (z : ℝ) ^ 3 =
+                 (((3 * x ^ 3 + 4 * y ^ 3 + 5 * z ^ 3 : ℚ)) : ℝ) := by
+      push_cast; ring
+    rw [hcast]
+    have hheq : (3 * x ^ 3 + 4 * y ^ 3 + 5 * z ^ 3 : ℚ) = 0 := heq
+    rw [hheq]
+    norm_num
+
+/-- **Easy direction over ℚₚ**: every rational solution of the Selmer cubic gives a
+    p-adic solution. Trivial via the embedding ℚ ↪ ℚₚ. -/
+theorem selmer_rat_implies_padic (p : ℕ) [Fact (Nat.Prime p)]
+    (h : ∃ (x y z : ℚ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) :
+    ∃ (x y z : ℚ_[p]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 := by
+  obtain ⟨x, y, z, hne, heq⟩ := h
+  refine ⟨(x : ℚ_[p]), (y : ℚ_[p]), (z : ℚ_[p]), ?_, ?_⟩
+  · rcases hne with hx | hy | hz
+    · exact Or.inl (by exact_mod_cast hx)
+    · exact Or.inr (Or.inl (by exact_mod_cast hy))
+    · exact Or.inr (Or.inr (by exact_mod_cast hz))
+  · show (3 : ℚ_[p]) * (x : ℚ_[p]) ^ 3 + 4 * (y : ℚ_[p]) ^ 3 + 5 * (z : ℚ_[p]) ^ 3 = 0
+    have hcast : (3 : ℚ_[p]) * (x : ℚ_[p]) ^ 3 + 4 * (y : ℚ_[p]) ^ 3 + 5 * (z : ℚ_[p]) ^ 3 =
+                 (((3 * x ^ 3 + 4 * y ^ 3 + 5 * z ^ 3 : ℚ)) : ℚ_[p]) := by
+      push_cast; ring
+    rw [hcast]
+    have hheq : (3 * x ^ 3 + 4 * y ^ 3 + 5 * z ^ 3 : ℚ) = 0 := heq
+    rw [hheq]
+    norm_num
+
+/-! ## Section 4: Selmer's Theorem (Axiomatized) -/
+
+/-- **Selmer's Theorem (1951)**: The cubic 3x³ + 4y³ + 5z³ = 0 has no nontrivial
+    rational solutions.
+
+    **Why axiomatized**: Selmer's proof uses:
+    - 3-descent on the associated elliptic curve E: y² = x³ - 432·15².
+    - Computation of the 3-Selmer group via class field theory of ℚ(ζ₃, ∛15).
+    - Local non-existence of certain 3-coverings at the primes 3 and 5.
+
+    These tools are not yet available in Mathlib; the proof would require
+    substantial development of the arithmetic of elliptic curves with complex
+    multiplication and the theory of Selmer groups.
+
+    Combined with `selmerCubic_real_solution` (proved above) and the standard
+    fact that the cubic is solvable over ℚₚ for every prime p (provable via Hensel
+    for p ∉ {2, 3, 5}, requiring direct verification at small primes), Selmer's
+    theorem establishes the **first known counterexample to the Hasse principle**. -/
+axiom selmer_no_rational_solution :
+    ¬∃ (x y z : ℚ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0
+
+/-! ## Section 5: The Hasse Principle Predicate -/
+
+/-- The **Hasse principle holds for the Selmer cubic** if rational solubility is
+    equivalent to local solubility over ℝ AND over every ℚₚ.
+
+    For the Selmer cubic specifically, the Hasse principle FAILS:
+    - Local solubility over ℝ: PROVED (via IVT).
+    - Local solubility over ℚₚ: standard (Hensel + small-prime check, axiomatized below).
+    - Rational solubility: false by Selmer 1951 (axiomatized above).
+
+    This predicate generalizes naturally to other cubic forms; the open question
+    asks for an exact characterization of which cubics satisfy it. -/
+def selmerHassePrinciple : Prop :=
+  (∃ (x y z : ℚ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) ↔
+    ((∃ (x y z : ℝ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) ∧
+      ∀ (p : ℕ) [Fact (Nat.Prime p)],
+        ∃ (x y z : ℚ_[p]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0)
+
+/-- **Axiom: p-adic solubility of the Selmer cubic** at every prime p.
+
+    For p ∉ {2, 3, 5}, this follows from Hensel's lemma applied to the reduction mod p.
+    For p ∈ {2, 3, 5}, direct construction at low precision suffices. The full
+    formalization in Lean would require Hensel infrastructure for ℚₚ. -/
+axiom selmer_padic_solubility (p : ℕ) [Fact (Nat.Prime p)] :
+    ∃ (x y z : ℚ_[p]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0
+
+/-- **Theorem**: The Selmer cubic has local solutions everywhere (real and p-adic).
+    This combines the proved `selmerCubic_real_solution` with the axiomatized
+    `selmer_padic_solubility`. -/
+theorem selmer_locally_soluble_everywhere :
+    (∃ (x y z : ℝ), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0) ∧
+      ∀ (p : ℕ) [Fact (Nat.Prime p)],
+        ∃ (x y z : ℚ_[p]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  ⟨selmerCubic_real_solution, fun p _ => selmer_padic_solubility p⟩
+
+/-- **Theorem**: The Hasse principle FAILS for the Selmer cubic.
+
+    Local solubility holds everywhere (`selmer_locally_soluble_everywhere`), yet there
+    is no rational solution (`selmer_no_rational_solution`). This is the famous
+    counterexample of Selmer (1951), demonstrating that the local-global principle of
+    Hasse-Minkowski does NOT extend from quadratic to cubic forms. -/
+theorem selmer_hasse_principle_fails : ¬ selmerHassePrinciple := by
+  intro h
+  -- h : rational ↔ (real ∧ ∀ p, p-adic)
+  -- We have local everywhere (selmer_locally_soluble_everywhere)
+  -- but no rational (selmer_no_rational_solution)
+  exact selmer_no_rational_solution (h.mpr selmer_locally_soluble_everywhere)
+
+/-! ## Section 6: The Open Question -/
+
+/-- **Open Question (Hilbert 11 OQ-02)**: For which polynomial systems over ℚ does the
+    Hasse principle hold?
+
+    For quadratic forms: ALWAYS (Hasse-Minkowski 1923).
+    For cubic forms: SOMETIMES — fails for the Selmer cubic.
+    In general: governed (conjecturally) by the Brauer-Manin obstruction.
+
+    **Colliot-Thélène's conjecture**: For smooth proper geometrically rationally
+    connected varieties X over ℚ, the Brauer-Manin set X(𝔸_ℚ)^{Br(X)} is dense in
+    the set of adelic points; equivalently, the Brauer-Manin obstruction is the only
+    obstruction to the Hasse principle.
+
+    Known cases of the conjecture:
+    - Quadratic forms (no obstruction needed) — Hasse-Minkowski 1923.
+    - Conic bundles over ℙ¹ — Colliot-Thélène, Sansuc, Salberger.
+    - del Pezzo surfaces of degree ≥ 5.
+    - Some Châtelet surfaces.
+
+    Open cases:
+    - General cubic surfaces (del Pezzo of degree 3).
+    - K3 surfaces.
+    - Higher-dimensional Fano varieties.
+
+    **Status**: Predicate `True` (informal statement). Full formal statement requires
+    algebraic geometry infrastructure (étale cohomology, Brauer groups of schemes,
+    adelic points) not yet in Mathlib. -/
+def colliot_thelene_conjecture : Prop := True
+
+/-! ## Section 7: Status Summary -/
+
+/-!
+| Component | Status |
+|-----------|--------|
+| `selmerCubic_real_solution` | **PROVED** (via IVT) |
+| `selmer_rat_implies_real` | **PROVED** (via embedding) |
+| `selmer_rat_implies_padic` | **PROVED** (via embedding) |
+| `selmer_no_rational_solution` | **AXIOMATIZED** (Selmer 1951, deep) |
+| `selmer_padic_solubility` | **AXIOMATIZED** (Hensel — could be proved with infrastructure) |
+| `selmer_locally_soluble_everywhere` | **PROVED** (from above) |
+| `selmer_hasse_principle_fails` | **PROVED** (assuming the two axioms) |
+| `colliot_thelene_conjecture` | **DEFINED** (informal, open in general) |
+
+### Axiom count: 2
+- `selmer_no_rational_solution` (Selmer 1951)
+- `selmer_padic_solubility` (Hensel infrastructure pending)
+
+### Sorry count: 0
+-/
+
+#check @selmerCubic_real_solution
+#check @selmer_rat_implies_real
+#check @selmer_rat_implies_padic
+#check @selmer_no_rational_solution
+#check @selmer_padic_solubility
+#check @selmer_locally_soluble_everywhere
+#check @selmer_hasse_principle_fails
+
+end Hilbert11OQ02

--- a/research/problems/hilbert-11-oq-02/knowledge.md
+++ b/research/problems/hilbert-11-oq-02/knowledge.md
@@ -1,0 +1,105 @@
+# hilbert-11-oq-02
+## When does the Hasse Principle Fail for Higher-Degree Forms? — Selmer Counterexample Framework
+
+**Status: IN PROGRESS** — First iteration: proved the Selmer cubic has nontrivial real
+solutions (via IVT), proved the easy direction of the Hasse principle (rational ⇒
+local) over both ℝ and ℚₚ, and laid out the framework for the open question.
+
+---
+
+## Summary
+
+`Hilbert11OQ02.lean` establishes a precise Lean framework for the open question
+"when does the Hasse principle fail for higher-degree forms?".
+
+**File stats**: ~210 lines, 7 theorems/defs, 2 axioms (Selmer 1951 + p-adic Hensel
+infrastructure), 0 sorries.
+
+---
+
+## What Was Proved
+
+### `selmerCubic_real_solution` (PROVED via IVT)
+The Selmer cubic 3x³ + 4y³ + 5z³ = 0 has a nontrivial real solution.
+
+**Proof sketch**: Set y = 1, z = 0. Need x ∈ ℝ with 3x³ + 4 = 0. The polynomial
+g(x) = 3x³ + 4 satisfies g(-2) = -20 < 0 and g(0) = 4 > 0, so by `intermediate_value_Icc`
+there exists x₀ ∈ [-2, 0] with g(x₀) = 0. Witness (x₀, 1, 0); nontrivial since 1 ≠ 0.
+
+### `selmer_rat_implies_real` (PROVED)
+Every rational solution of the Selmer cubic gives a real solution.
+Trivial via `Rat.cast : ℚ → ℝ`. Uses `push_cast; ring` to convert.
+
+### `selmer_rat_implies_padic` (PROVED)
+Every rational solution gives a p-adic solution at every prime p.
+Same idea: cast through `Rat.cast : ℚ → ℚ_[p]`.
+
+### `selmer_locally_soluble_everywhere` (PROVED, modulo `selmer_padic_solubility` axiom)
+Combines real solubility (proved) with p-adic solubility (axiomatized).
+
+### `selmer_hasse_principle_fails` (PROVED, modulo two axioms)
+Local solubility everywhere + no rational solution = Hasse principle fails.
+
+---
+
+## Axioms Introduced
+
+### `selmer_no_rational_solution` (Selmer 1951, deep)
+The cubic 3x³ + 4y³ + 5z³ = 0 has no nontrivial rational solutions.
+**Why axiomatized**: Requires 3-descent on associated elliptic curve, computation of
+Selmer groups via class field theory of ℚ(ζ₃, ∛15), local non-existence at primes
+3 and 5. Far beyond present Mathlib infrastructure.
+
+### `selmer_padic_solubility` (Hensel infrastructure pending)
+For each prime p, the cubic has a nontrivial p-adic solution.
+**Why axiomatized**: For p ∉ {2, 3, 5}, follows from Hensel applied to the reduction
+mod p; for p ∈ {2, 3, 5}, requires direct construction at low precision. This could
+be formalized in future work via ℚₚ Hensel infrastructure.
+
+---
+
+## Session Log
+
+### Session 2026-05-07 (Session 1, researcher-9)
+**Mode**: FRESH
+**Outcome**: progress
+
+**What Was Done**:
+1. Created new gallery file `Hilbert11OQ02.lean` (~210 lines) addressing the open
+   question "when does the Hasse principle fail for higher-degree forms?".
+2. Proved `selmerCubic_real_solution` via Intermediate Value Theorem on g(x) = 3x³ + 4
+   over [-2, 0]; witness (x₀, 1, 0) where g(x₀) = 0.
+3. Proved easy directions `selmer_rat_implies_real` and `selmer_rat_implies_padic`
+   via `Rat.cast` and `push_cast; ring`.
+4. Defined `selmerHassePrinciple` predicate capturing local-global property.
+5. Proved `selmer_hasse_principle_fails` from the two axioms.
+6. Stated the Colliot-Thélène conjecture informally (`colliot_thelene_conjecture := True`)
+   and documented known cases vs. open cases.
+
+**Key Lean techniques**:
+- `intermediate_value_Icc h_le hg_cont.continuousOn hmem` for IVT.
+- `linear_combination hsum` for ring-based equality from a hypothesis.
+- `push_cast; ring` for ℚ → ℝ / ℚ → ℚₚ embedding via casting.
+- `hg_eval ▸ hx_zero` for rewriting via equational hypothesis.
+
+---
+
+## Key Mathematical Insights
+
+1. **Real solubility is constructive**: Unlike the deep p-adic and rational
+   non-existence arguments, real solubility for the Selmer cubic admits an
+   elementary IVT-based proof. This is the "low-hanging fruit" of the
+   counterexample story.
+
+2. **The hard part is rational non-existence**: The Hasse principle's failure for
+   the Selmer cubic depends entirely on `selmer_no_rational_solution` (Selmer 1951).
+   This is a deep theorem requiring elliptic curve 3-descent — far beyond present
+   Mathlib infrastructure.
+
+3. **Brauer-Manin captures many failures**: The conjecture (Colliot-Thélène) is that
+   for nice varieties, Brauer-Manin is the only obstruction. Known for several families
+   (conic bundles, del Pezzo deg ≥ 5) but open for cubic surfaces and K3 surfaces.
+
+4. **Tractability gradient**: Real solubility (PROVED) → p-adic solubility (axiomatizable
+   via Hensel) → rational non-existence (deep, far) → general characterization (open
+   research question).

--- a/research/problems/hilbert-11-oq-02/problem.md
+++ b/research/problems/hilbert-11-oq-02/problem.md
@@ -1,0 +1,71 @@
+# Problem: When exactly does the Hasse principle fail for higher-degree forms?
+
+## Statement
+
+### Plain Language
+
+The Hasse-Minkowski theorem (formalized in `Hilbert11_QuadraticForms.lean` and refined in
+`Hilbert11OQ01.lean`) shows that the Hasse principle (local-global principle) holds for
+quadratic forms over ℚ: a quadratic form represents zero rationally iff it does so over ℝ
+and over every ℚₚ.
+
+For higher-degree forms (cubic and beyond) the principle FAILS in general. The Selmer
+curve `3x³ + 4y³ + 5z³ = 0` (Selmer 1951) is the classical counterexample: it has
+solutions over ℝ and every ℚₚ but no nontrivial rational solutions.
+
+The OPEN question asks for an exact characterization of when the Hasse principle fails.
+
+### Formal Statement
+
+For a smooth proper geometrically rationally connected variety `X` over `ℚ`:
+
+$$
+X(\mathbb{Q}) \neq \emptyset \iff X(\mathbb{A}_\mathbb{Q})^{\mathrm{Br}(X)} \neq \emptyset
+$$
+
+i.e. the Brauer-Manin obstruction is the only obstruction to the Hasse principle.
+
+This is the **Colliot-Thélène conjecture**. It is known for several families
+(quadratic forms, conic bundles over ℙ¹, del Pezzo surfaces of degree ≥ 5, some
+Châtelet surfaces) but open in general — including for cubic surfaces (del Pezzo
+of degree 3) and K3 surfaces.
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 4
+tags:
+  - seeker-selected
+  - number-theory
+  - hasse-principle
+  - cubic-forms
+  - brauer-manin
+```
+
+**Significance**: 7/10 — A central question in arithmetic geometry, governing the
+local-global behavior of varieties.
+
+**Tractability**: 4/10 — The full conjecture is far beyond current Lean infrastructure.
+Concrete sub-results (e.g., real solubility of the Selmer cubic) are tractable.
+
+## Why This Matters
+
+1. **Foundational arithmetic geometry** — The Hasse principle is the prototypical
+   local-global principle. Understanding when it fails drives the theory of
+   obstructions, descent, and Brauer-Manin / étale obstructions.
+2. **Application to Diophantine equations** — A characterization tells us which
+   polynomial systems can be solved by purely local computations.
+3. **Interaction with class field theory and étale cohomology** — Modern proofs use
+   class field theory, étale cohomology, Galois cohomology, and the arithmetic of
+   torsors.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `hilbert-11` | Parent: Hasse-Minkowski for quadratic forms (the principle holds) |
+| `hilbert-11-oq-01` | Sister: tensor-product formalization of local conditions |
+| `quadratic-reciprocity` | Foundational: governs binary quadratic forms over ℚₚ |
+| `lagrange-four-squares` | Special case: the form x²+y²+z²+w² represents all naturals |

--- a/research/problems/hilbert-11-oq-02/state.md
+++ b/research/problems/hilbert-11-oq-02/state.md
@@ -1,0 +1,40 @@
+# Current State
+
+**Phase**: ITERATING
+**Since**: 2026-05-07T22:45:00Z
+**Iteration**: 1
+
+## Current Focus
+
+First iteration: established a Lean framework around the Selmer cubic counterexample,
+proved real solubility constructively via IVT, and proved the easy direction of the
+Hasse principle for the Selmer cubic over ℝ and ℚₚ (rational ⇒ local).
+
+## Active Approach
+
+Concrete decomposition: rather than attempting the full Colliot-Thélène conjecture,
+build out specific provable pieces of the Selmer counterexample story.
+
+## Blockers
+
+The full Colliot-Thélène conjecture requires:
+- Algebraic geometry infrastructure (smooth proper varieties, geometrically integral)
+- Brauer groups of schemes via étale cohomology
+- Adelic points and the Brauer-Manin pairing
+- 3-descent on elliptic curves
+
+None of these are present in Mathlib at sufficient depth.
+
+## Next Action
+
+Future iterations could:
+1. Prove p-adic solubility of the Selmer cubic at primes ≠ 2, 3, 5 via Hensel
+   (currently axiomatized as `selmer_padic_solubility`)
+2. Formalize the explicit p-adic constructions at p ∈ {2, 3, 5}
+3. Develop Brauer-Manin obstruction infrastructure
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/research/problems/hilbert-11-oq-02.json
+++ b/src/data/research/problems/hilbert-11-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "hilbert-11-oq-02",
   "title": "When exactly does the Hasse principle fail for higher-degree forms",
-  "phase": "OBSERVE",
+  "phase": "ITERATING",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -40,28 +40,39 @@
     "goal": "Three layers of partial answers: (1) For each degree n and number of variables k, give a sharp bound below which Hasse can fail and above which it must hold (cubic forms: Davenport bound). (2) Identify a uniform obstruction theory (Brauer-Manin / étale-Brauer-Manin) and prove it is the ONLY obstruction for natural classes. (3) Make this effective/algorithmic for explicit families (cubic surfaces, del Pezzo, K3)."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-07T19:10:00.000Z",
+    "phase": "ITERATING",
+    "since": "2026-05-07T22:45:00.000Z",
     "iteration": 1,
-    "focus": "Phase-1 observation: enumerate the known counterexamples (Selmer, Cassels-Guy, Iskovskih, Skorobogatov, Poonen) and the obstruction-theoretic framework (Brauer-Manin, étale-Brauer-Manin). Map what already exists in `Proofs/Hilbert11_QuadraticForms.lean` (which has `axiom selmer_curve_no_rational_points : SelmerCurve` and a placeholder `BrauerManinObstruction`).",
+    "focus": "Iteration 1: established a Lean framework around the Selmer cubic counterexample. Proved real solubility constructively via IVT, proved the easy direction of the Hasse principle (rational ⇒ local) over both ℝ and ℚₚ, axiomatized Selmer 1951 (no rational solutions) and p-adic solubility, and proved that the Hasse principle FAILS for the Selmer cubic from these.",
     "blockers": [],
-    "nextAction": "Phase 2 (ORIENT): create `Proofs/Hilbert11OQ02.lean` with rigorous definitions of (a) `IsHigherDegreeForm n` for n ≥ 3, (b) `HassePrinciple F` and `HasseFails F`, (c) `IsBrauerManinObstructed X`, (d) the Selmer cubic as a specific instance. Lift the `selmer_curve_no_rational_points` axiom out of the parent file and make it the centerpiece of the OQ-02 entry.",
+    "nextAction": "Future iteration: prove p-adic solubility of the Selmer cubic at primes p ∉ {2,3,5} via Hensel's lemma applied to the reduction mod p (currently axiomatized as `selmer_padic_solubility`). At p ∈ {2,3,5} requires direct construction at low precision. Replacing this axiom is the most accessible next step toward reducing the axiom count.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "OBSERVE phase. Parent file `Proofs/Hilbert11_QuadraticForms.lean` already contains: `def SelmerCurve` (line ~345), `axiom selmer_curve_no_rational_points` (line ~364), `def BrauerManinObstruction` (placeholder), and the doc-level discussion of Hasse failures (PART VII). No Lean file `Hilbert11OQ02.lean` exists yet. The mathematical content is well-established (Selmer 1951, Manin 1970, Skorobogatov 1999, Poonen 2010) — the OQ-02 task is to formalize a rigorous gallery entry stating the known failures and the precise open characterization questions.",
-    "builtItems": [],
+    "progressSummary": "ITERATING (iter 1). Created `proofs/Proofs/Hilbert11OQ02.lean` (264 lines, 7 theorems/defs, 2 axioms, 0 sorries) framing the Selmer cubic as the canonical Hasse-principle-failure example. Proved nontrivial real solubility constructively via IVT on g(x)=3x³+4 over [-2,0]; proved easy directions ℚ⇒ℝ and ℚ⇒ℚ_p via Rat.cast; axiomatized Selmer 1951 (no rational solutions, deep) and p-adic solubility (Hensel pending); proved `selmer_hasse_principle_fails` from the two axioms. Defined `colliot_thelene_conjecture` as a documented placeholder. Recovers and extends prior researcher-9 unpushed wip session.",
+    "builtItems": [
+      "selmerPoly definition in Hilbert11OQ02.lean (3x³+4y³+5z³ over CommRing)",
+      "selmerCubic_real_solution in Hilbert11OQ02.lean — nontrivial real solution constructed via IVT on g(x)=3x³+4 over [-2,0]",
+      "selmer_rat_implies_real in Hilbert11OQ02.lean — easy direction ℚ⇒ℝ via Rat.cast embedding",
+      "selmer_rat_implies_padic in Hilbert11OQ02.lean — easy direction ℚ⇒ℚ_p via Rat.cast embedding (parametric in prime p)",
+      "selmer_locally_soluble_everywhere in Hilbert11OQ02.lean — combines proved real solubility with axiomatized p-adic solubility",
+      "selmer_hasse_principle_fails in Hilbert11OQ02.lean — derives Hasse failure from selmer_no_rational_solution + local everywhere",
+      "selmerHassePrinciple definition in Hilbert11OQ02.lean — local-global predicate for the Selmer cubic"
+    ],
     "insights": [
       "Hilbert11_QuadraticForms.lean already AXIOMATIZES the Selmer counterexample (`selmer_curve_no_rational_points`) — OQ-02 should LIFT this axiom into a dedicated entry and frame it as the canonical example of Hasse failure rather than burying it in the quadratic-forms parent",
       "The natural Lean type for 'higher-degree form' is `MvPolynomial (Fin k) ℚ` filtered by `IsHomogeneous F n`, with `n ≥ 3`; Mathlib has `MvPolynomial.IsHomogeneous`",
       "The Brauer-Manin obstruction is naturally stated for projective varieties; a phase-2 Lean formalization should at minimum state it as an axiom on `Type*` with the witness Brauer class abstracted, mirroring how `Hilbert11OQ01.lean` axiomatized `hasse_minkowski_refined`",
       "Three flavors of the open question give three sub-OQs: (a) decidability for explicit forms; (b) Brauer-Manin sufficiency for natural classes; (c) sharp threshold theorems (Davenport-style)",
       "Cubic curves, cubic surfaces, and del Pezzo surfaces are the three natural test cases; Mathlib has `EllipticCurve` (relevant for cubic curves of genus 1) but no `CubicSurface` or `delPezzo` typeclass — likely a Mathlib gap",
-      "The Selmer cubic 3x³+4y³+5z³=0 in ℙ² has genus 1 and is in fact a principal homogeneous space for an elliptic curve E: y² = x³ - 432 (a twist of E_60); this connects to the Tate-Shafarevich group Ш(E/ℚ)"
+      "The Selmer cubic 3x³+4y³+5z³=0 in ℙ² has genus 1 and is in fact a principal homogeneous space for an elliptic curve E: y² = x³ - 432 (a twist of E_60); this connects to the Tate-Shafarevich group Ш(E/ℚ)",
+      "Real solubility of 3x³+4y³+5z³=0 has a one-line constructive proof: fix y=1, z=0, then need x with 3x³+4=0, supplied by IVT on g(x)=3x³+4 over [-2,0] since g(-2)=-20, g(0)=4. This makes the 'real local soluble' direction provable in Lean with no number-theory machinery beyond `intermediate_value_Icc`.",
+      "The easy direction of the Hasse principle (rational ⇒ local) is purely formal in Lean: `Rat.cast : ℚ → ℝ` and `Rat.cast : ℚ → ℚ_[p]` are ring homomorphisms, so `push_cast; ring` closes the polynomial-equation-preservation goal. This is the same pattern used for any ℚ-rational point of any ℚ-variety — generalizable to a future `RatPoint_to_LocalPoint` framework.",
+      "Selmer's deep theorem `selmer_no_rational_solution` is irreducibly axiomatized: 3-descent on the associated elliptic curve E: y²=x³-432·15² is required, and Mathlib v4.26 has no Selmer-group infrastructure. p-adic solubility at p ∉ {2,3,5} could be proved via Hensel applied to the reduction; this is the most accessible axiom-elimination path."
     ],
     "mathlibGaps": [
       "No formal definition of Brauer-Manin obstruction in Mathlib (would require Brauer group of a scheme + adelic points)",
@@ -71,12 +82,12 @@
       "`MvPolynomial.IsHomogeneous` exists but there is no specialized theory of 'rational-points predicate' for homogeneous forms over number fields"
     ],
     "nextSteps": [
-      "Phase-2: scaffold `proofs/Proofs/Hilbert11OQ02.lean` with `IsHigherDegreeForm`, `HasNontrivialRationalSolution`, `HasNontrivialLocalSolutionEverywhere`, `HasseFails` definitions and import them from `MvPolynomial.IsHomogeneous` + `Mathlib.NumberTheory.Padics`",
-      "Phase-2: re-state the Selmer cubic as a specific witness `selmer_cubic_fails_hasse` and reuse the existing `selmer_curve_no_rational_points` axiom from the parent file via `import Proofs.Hilbert11_QuadraticForms`",
-      "Phase-2: state the conjectural `brauer_manin_only_obstruction_for_rationally_connected` as an axiomatized open conjecture, mirroring the `e_absolutely_normal` pattern from e-transcendental-oq-02",
-      "Phase-3: create the gallery entry `src/data/proofs/hilbert-11-oq-02/` with `meta.json`, `annotations.json`, `index.ts`",
-      "Phase-3: cross-reference the entry to `hilbert-11`, `hilbert-11-oq-01`, and (once it exists) the elliptic-curve infrastructure",
-      "Stretch: prove the Selmer cubic axiom for one specific reduction (e.g. mod 5 or mod 9 obstruction) without invoking the full descent argument — the local mod-9 obstruction at p=3 is classical and may be in scope"
+      "Replace `selmer_padic_solubility` axiom with a Hensel-based proof for primes p ∉ {2,3,5}: reduce 3x³+4y³+5z³ mod p, find a smooth ℤ/p-point, lift via Hensel. Mathlib v4.26 has `Polynomial.IsHensel` and `PadicNumbers.Hensel` lemmas applicable.",
+      "Direct construction of p-adic solutions at p ∈ {2,3,5}: low-precision lifts (e.g. 2-adic Hensel needs reduction mod 8 to find a smooth point).",
+      "Promote to gallery: create `src/data/proofs/hilbert-11-oq-02/` with meta.json, annotations.json, index.ts cross-referencing `hilbert-11`, `hilbert-11-oq-01`, and `e-transcendental-oq-02` (similar axiomatization-of-deep-result pattern).",
+      "Long-term: develop generic `IsHigherDegreeForm n` / `HassePrincipleFails F` predicates over `MvPolynomial (Fin k) ℚ` filtered by `IsHomogeneous F n`; restate Selmer as the canonical instance of the generic predicate.",
+      "Stretch: state the Brauer-Manin obstruction conjecture (`brauer_manin_only_obstruction_for_rationally_connected`) as an axiomatized open problem, mirroring the `e_absolutely_normal` pattern.",
+      "Survey: add other classical Hasse failures (Cassels-Guy 1966 cubic surface, Iskovskih 1971 del Pezzo) as parallel `*_hasse_principle_fails` instances, axiomatizing the no-rational-solution part for each."
     ]
   },
   "tags": [
@@ -117,7 +128,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.056Z",
-  "lastUpdate": "2026-05-07T19:10:00.000Z",
+  "lastUpdate": "2026-05-07T22:45:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -175,6 +186,17 @@
       "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ01OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Hilbert11OQ02.lean",
+      "filename": "Hilbert11OQ02.lean",
+      "lineCount": 264,
+      "theoremCount": 5,
+      "axiomCount": 2,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ02.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Recovers orphan wip-r9 work for **hilbert-11-oq-02** (RICH score 17). The substantive
264-line Lean file plus 3 research markdown docs were sitting on a local branch
(`research/hilbert-11-oq-02-wip-r9-1778184738`, commit `c9adc566dcd`) that was never
pushed or PR'd. This PR brings that work to `main` cleanly off the current head.

## What it adds

### `proofs/Proofs/Hilbert11OQ02.lean` (264 lines, 5 theorems, 3 defs, 2 axioms, 0 sorries)

A precise Lean framework around the Selmer cubic counterexample to the Hasse principle.

**Proved (no sorry)**:
- `selmerPoly`: 3x³ + 4y³ + 5z³ over any CommRing
- `selmerCubic_real_solution`: nontrivial real solution via IVT on g(x) = 3x³ + 4 over [-2, 0] (g(-2) = -20 < 0, g(0) = 4 > 0)
- `selmer_rat_implies_real` / `selmer_rat_implies_padic`: easy directions ℚ ⇒ ℝ and ℚ ⇒ ℚ_p via `Rat.cast` embedding (`push_cast; ring`)
- `selmer_locally_soluble_everywhere`: real + p-adic local solubility combined
- `selmer_hasse_principle_fails`: Hasse failure derived from the two axioms

**Axioms (2, both well-justified deep results)**:
- `selmer_no_rational_solution` (Selmer 1951): 3-descent on E: y² = x³ - 432·15², beyond present Mathlib infrastructure
- `selmer_padic_solubility`: Hensel infrastructure pending; provable for p ∉ {2, 3, 5} via reduction + Hensel

**Defined**:
- `selmerHassePrinciple`: local-global predicate for the Selmer cubic
- `colliot_thelene_conjecture`: documented placeholder for the open conjecture

### Research docs and JSON sync

- `research/problems/hilbert-11-oq-02/{problem,state,knowledge}.md`: 216 lines documenting the open question, iteration state, contributions
- `src/data/research/problems/hilbert-11-oq-02.json`: phase OBSERVE → ITERATING, progressSummary updated, 7 builtItems added, 3 new insights, 6 nextSteps reframed around axiom-elimination, lastUpdate refreshed, leanFiles entry added for Hilbert11OQ02.lean

## Provenance / why a recovery PR

Per `feedback_researcher_local_unpushed_wip.md` (memory entry from 2026-05-08), hilbert-11-oq-02 was the canonical example of the orphaned-wip trap. Researcher-9's wip session finished with 0 sorries and 2 axioms but never created a PR. Without recovery, this work would be lost or duplicated by a future session that re-discovered the same Selmer cubic construction.

The wip commit (c9adc566dcd) was based on a stale main and shows large diff against current main due to deletions of files since merged elsewhere — those deletions are NOT in this recovery PR, which contains only the 5 net-new files plus the one-line import addition to `proofs/Proofs.lean`.

## Test plan

- [ ] Docker build clean: `./proofs/scripts/docker-build.sh Proofs.Hilbert11OQ02` (running concurrently; may OOM under contention)
- [x] No Lean 4.26 API drift patterns (Nat.Prime.neZero / atTop_mul_atTop / abs_add / Nat.harmonic / Even.not_odd all absent)
- [x] JSON valid (`jq -e .`)
- [x] Counts match file (264 lines, 5 theorems, 3 defs, 2 axioms, 0 sorries)
- [x] Import added to `proofs/Proofs.lean` (sorted alphabetically among Hilbert11* siblings)

## Future work (recorded in updated nextSteps)

1. Replace `selmer_padic_solubility` with Hensel-based proof for p ∉ {2,3,5}
2. Direct construction of p-adic solutions at p ∈ {2,3,5}
3. Promote to gallery (`src/data/proofs/hilbert-11-oq-02/`)
4. Generic `IsHigherDegreeForm n` + `HassePrincipleFails F` predicates
5. Survey: Cassels-Guy 1966 + Iskovskih 1971 parallel instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)