### PR TITLE
audit: mark borsuk-ulam-oq-02-oq-01-oq-03-oq-02 as clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14995,6 +14995,12 @@
       "lastAudited": "2026-05-07T19:11:54Z",
       "result": "clean",
       "issues": []
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-07T23:43:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- Verified counts against `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean`: lineCount=241, axiomCount=1, sorries=0, defs=1, theorems=10 (8 substantive)
- Status `axiomatized` + badge `axiom` correct for the single conjectural equality `symBUDim_eq_largestPrime` (Tier C)
- Adds tracker entry marking the proof as clean

## Test plan
- [x] Counted axioms / sorries / defs / theorems against Lean source
- [x] Verified `meta.json` claims match `leanFile` block and Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)