### PR TITLE
Enrich ∛3 field-degree proof: deeper history, fixed sections, +2 annotations

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/annotations.json
@@ -1,11 +1,24 @@
 [
   {
+    "id": "ann-setup",
+    "proofId": "cube-root-3-irrational-oq-02-oq-01",
+    "range": { "startLine": 40, "endLine": 44 },
+    "type": "context",
+    "title": "Imports and Open Namespaces",
+    "content": "The file imports `Proofs.CubeRoot2IrrationalOQ03`, the parametric n-th root file containing the heavy-duty lemmas adjoin_nthRoot_finrank, minpoly_nthRoot_natDegree, and isIntegral_nthRoot. Three namespaces are opened: `Polynomial` (for X, C, natDegree, X_sub_C), `CubeRoot2IrrationalOQ03` (to use the unqualified parametric lemma names), and `IntermediateField` (to enable the ℚ⟮α⟯ syntax via Unicode brackets). The whole file's brevity (5 theorems in ~80 lines of code) is a direct consequence of this aggressive abstraction in the parent file.",
+    "mathContext": "Notation: $\\mathbb{Q}\\langle\\!\\langle\\alpha\\rangle\\!\\rangle$ in Lean denotes $\\texttt{IntermediateField.adjoin}\\,\\mathbb{Q}\\,\\{\\alpha\\}$ — the smallest sub-$\\mathbb{R}$-field containing $\\mathbb{Q}$ and $\\alpha$. By Mathlib's $\\texttt{IntermediateField.adjoin.finrank}$, $\\dim_{\\mathbb{Q}} \\mathbb{Q}(\\alpha) = \\text{natDegree}(\\text{minpoly}\\,\\mathbb{Q}\\,\\alpha)$ for any algebraic integer $\\alpha$.",
+    "significance": "context",
+    "relatedConcepts": ["IntermediateField.adjoin", "Mathlib namespace mechanics", "code reuse", "parametric lemmas"],
+    "prerequisites": ["Lean 4 imports/namespaces", "Mathlib field theory"],
+    "tags": ["setup", "imports", "namespaces"]
+  },
+  {
     "id": "ann-field-degree",
     "proofId": "cube-root-3-irrational-oq-02-oq-01",
-    "range": { "startLine": 44, "endLine": 62 },
+    "range": { "startLine": 46, "endLine": 62 },
     "type": "result",
     "title": "[ℚ(∛3):ℚ] = 3 via One-Line Corollary",
-    "content": "cbrt3_fieldExtDegree proves Module.finrank ℚ ℚ⟮∛3⟯ = 3 as a direct one-line corollary of adjoin_nthRoot_finrank 3 3 3. The five norm_num calls discharge: 2 ≤ 3 (n ≥ 2), Prime 3, 3|3 (p|m), ¬9|3 (p²∤m), and 0 < 3. The proof elegantly reduces a nontrivial algebraic statement to five arithmetic inequalities, all handled by norm_num's decision procedure.",
+    "content": "cbrt3_fieldExtDegree proves Module.finrank ℚ ℚ⟮∛3⟯ = 3 as a direct one-line corollary of adjoin_nthRoot_finrank 3 3 3. The five norm_num calls discharge: 2 ≤ 3 (n ≥ 2), Prime 3, 3|3 (p|m), ¬9|3 (p²∤m), and 0 < 3. The proof elegantly reduces a nontrivial algebraic statement to five arithmetic inequalities, all handled by norm_num's decision procedure. The mathematical content (Eisenstein irreducibility, integral closure of ℤ in ℝ, primitive element theorem for simple algebraic extensions) is fully amortized into the helper file.",
     "mathContext": "$[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = \\text{Module.finrank}\\, \\mathbb{Q}\\, \\mathbb{Q}\\!\\left[\\!\\left[(3:\\mathbb{R})^{1/3}\\right]\\!\\right] = 3$. From $\\texttt{adjoin\\_nthRoot\\_finrank}(n{=}3, m{=}3, p{=}3)$: Eisenstein conditions $3 \\mid 3$ and $9 \\nmid 3$ confirm $X^3 - 3$ is irreducible, so $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = \\deg(X^3-3) = 3$.",
     "significance": "key",
     "relatedConcepts": ["field extension degree", "adjoin_nthRoot_finrank", "Eisenstein criterion", "minimal polynomial"],
@@ -31,7 +44,7 @@
     "range": { "startLine": 77, "endLine": 101 },
     "type": "technique",
     "title": "Third Proof of ∛3 Irrationality: Degree Argument",
-    "content": "cbrt3_irrational_from_degree provides a third proof of ∛3 ∉ ℚ via field degree. The argument: assume ∛3 = q ∈ ℚ. Then minpoly.eq_X_sub_C ℚ q gives minpoly ℚ ∛3 = X - C q (degree 1). But minpoly_cbrt3_natDeg says degree = 3. Rewriting hmin into hdeg3 and comparing with natDegree_X_sub_C = 1 gives 3 = 1, a contradiction discharged by norm_num.",
+    "content": "cbrt3_irrational_from_degree provides a third proof of ∛3 ∉ ℚ via field degree. The argument: assume ∛3 = q ∈ ℚ. Then minpoly.eq_X_sub_C ℚ q gives minpoly ℚ ∛3 = X - C q (degree 1). But minpoly_cbrt3_natDeg says degree = 3. Rewriting hmin into hdeg3 and comparing with natDegree_X_sub_C = 1 gives 3 = 1, a contradiction discharged by norm_num. This is the third independent proof of ∛3 irrationality in the gallery: the others are the elementary integer-bounds proof (CubeRoot3Irrational) and the Eisenstein-irreducibility proof (CubeRoot3IrrationalOQ02).",
     "mathContext": "Proof by contradiction: $\\sqrt[3]{3} = q \\in \\mathbb{Q} \\Rightarrow \\text{minpoly}\\, \\mathbb{Q}\\, \\sqrt[3]{3} = X - Cq$ (by $\\texttt{minpoly.eq\\_X\\_sub\\_C}$) $\\Rightarrow \\text{natDegree} = 1$. But $\\text{natDegree}(\\text{minpoly}\\, \\mathbb{Q}\\, \\sqrt[3]{3}) = 3$. Contradiction: $3 = 1$.",
     "significance": "key",
     "relatedConcepts": ["minpoly.eq_X_sub_C", "irrationality", "proof by contradiction", "degree argument"],
@@ -41,14 +54,27 @@
   {
     "id": "ann-general-principle",
     "proofId": "cube-root-3-irrational-oq-02-oq-01",
-    "range": { "startLine": 103, "endLine": 133 },
+    "range": { "startLine": 103, "endLine": 124 },
     "type": "insight",
     "title": "General Principle: Degree > 1 Implies Irrationality",
-    "content": "irrational_of_degree_gt_one captures the fundamental algebraic fact: for any algebraic α : ℝ over ℚ, α ∈ ℚ ↔ [ℚ(α):ℚ] = 1. The proof applies the same minpoly.eq_X_sub_C argument but in full generality, using IntermediateField.adjoin.finrank to connect the degree to natDegree(minpoly). cbrt3_irrational_via_principle then applies this to ∛3 in two lines: isIntegral_nthRoot gives integrality, and cbrt3_fieldExtDegree gives degree 3 > 1.",
-    "mathContext": "General principle: $\\alpha \\in \\mathbb{Q} \\Leftrightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 1$. Proof of $\\Rightarrow$: $\\alpha = q \\Rightarrow \\text{minpoly}\\, \\mathbb{Q}\\, \\alpha = X - Cq \\Rightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\text{natDegree}(X-Cq) = 1$ via $\\texttt{IntermediateField.adjoin.finrank}$. Application: $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = 3 > 1 \\Rightarrow \\sqrt[3]{3} \\notin \\mathbb{Q}$.",
+    "content": "irrational_of_degree_gt_one captures the fundamental algebraic fact: for any algebraic α : ℝ over ℚ with [ℚ(α):ℚ] > 1, α is irrational. The proof is the same minpoly.eq_X_sub_C argument lifted to full generality. The hypothesis IsIntegral ℚ α (algebraicity over ℚ) is required because adjoin.finrank only computes the extension degree as natDegree(minpoly) when α is integral; for transcendental elements, ℚ(α) is infinite-dimensional. The contradiction is finished with linarith because Module.finrank lands in ℕ.",
+    "mathContext": "General principle: $\\alpha \\in \\mathbb{Q} \\Leftrightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 1$. Proof of $\\Rightarrow$: $\\alpha = q \\Rightarrow \\text{minpoly}\\, \\mathbb{Q}\\, \\alpha = X - Cq \\Rightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\text{natDegree}(X-Cq) = 1$ via $\\texttt{IntermediateField.adjoin.finrank}$. Note: integrality (algebraicity) is required — for transcendental $\\alpha$, $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\infty$ and the statement holds vacuously.",
     "significance": "key",
-    "relatedConcepts": ["IntermediateField.adjoin.finrank", "isIntegral_nthRoot", "rationality criterion", "algebraic degree"],
+    "relatedConcepts": ["IntermediateField.adjoin.finrank", "minpoly.eq_X_sub_C", "rationality criterion", "algebraic vs transcendental"],
     "prerequisites": ["algebraic integers", "field extensions", "Lean 4 linarith tactic"],
     "tags": ["general-principle", "degree-one-iff-rational", "algebraic-number-theory"]
+  },
+  {
+    "id": "ann-via-principle",
+    "proofId": "cube-root-3-irrational-oq-02-oq-01",
+    "range": { "startLine": 126, "endLine": 131 },
+    "type": "result",
+    "title": "Two-Line Application: ∛3 Irrationality via the General Principle",
+    "content": "cbrt3_irrational_via_principle is a two-line proof showcasing the power of the general lemma. The first hypothesis (isIntegral_nthRoot 3 3) supplies algebraicity, derived from the fact that ∛3 is a root of X³ - 3 ∈ ℚ[X]. The second hypothesis (cbrt3_fieldExtDegree, used inside `by rw [...]` to convert `1 < 3` from `Module.finrank ℚ ℚ⟮∛3⟯ > 1`) supplies the degree bound. This is the cleanest of the three irrationality proofs in the gallery: it makes essential use of degree as a single quantitative invariant, avoiding both integer arithmetic (CubeRoot3Irrational) and explicit polynomial irreducibility manipulation (CubeRoot3IrrationalOQ02 and PART III above).",
+    "mathContext": "Direct application: $\\sqrt[3]{3}$ is a root of $X^3 - 3 \\in \\mathbb{Q}[X]$, hence $\\texttt{IsIntegral}\\,\\mathbb{Q}\\,\\sqrt[3]{3}$. By cbrt3_fieldExtDegree, $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = 3 > 1$. Therefore by $\\texttt{irrational\\_of\\_degree\\_gt\\_one}$, $\\sqrt[3]{3}$ is irrational. Total: 2 lines, 0 manual arithmetic.",
+    "significance": "supporting",
+    "relatedConcepts": ["isIntegral_nthRoot", "lemma-instantiation", "API design"],
+    "prerequisites": ["the general principle (irrational_of_degree_gt_one)"],
+    "tags": ["application", "lemma-reuse", "two-line-proof"]
   }
 ]

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "cube-root-3-irrational-oq-02-oq-01",
-  "title": "\u221b3 Field Extension Degree: [\u211a(\u221b3):\u211a] = 3",
+  "title": "∛3 Field Extension Degree: [ℚ(∛3):ℚ] = 3",
   "slug": "cube-root-3-irrational-oq-02-oq-01",
-  "description": "Derives [\u211a(\u221b3):\u211a] = 3 as a corollary of the Eisenstein criterion approach. Uses the general theorem adjoin_nthRoot_finrank from CubeRoot2IrrationalOQ03. Also re-derives \u221b3's irrationality from degree > 1, and establishes the general principle: algebraic elements with [\u211a(\u03b1):\u211a] > 1 are irrational.",
+  "description": "Derives [ℚ(∛3):ℚ] = 3 as a corollary of the Eisenstein criterion approach. Uses the general theorem adjoin_nthRoot_finrank from CubeRoot2IrrationalOQ03. Also re-derives ∛3's irrationality from degree > 1, and establishes the general principle: algebraic elements with [ℚ(α):ℚ] > 1 are irrational.",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-05-04",
@@ -20,16 +20,16 @@
     "sorries": 0,
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
-    "assumptions": "None \u2014 fully verified. Depends on CubeRoot2IrrationalOQ03 for adjoin_nthRoot_finrank and related lemmas.",
+    "assumptions": "None — fully verified. Depends on CubeRoot2IrrationalOQ03 for adjoin_nthRoot_finrank and related lemmas.",
     "lineCount": 133,
     "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [
-      "cbrt3_fieldExtDegree: [\u211a(\u221b3):\u211a] = 3 as one-line corollary of adjoin_nthRoot_finrank",
-      "minpoly_cbrt3_natDeg: natDegree(minpoly \u211a \u221b3) = 3 as corollary",
-      "cbrt3_irrational_from_degree: \u221b3 is irrational via minpoly degree argument (third proof)",
-      "irrational_of_degree_gt_one: general principle \u2014 [\u211a(\u03b1):\u211a] > 1 implies \u03b1 \u2209 \u211a",
-      "cbrt3_irrational_via_principle: applies the general principle to \u221b3"
+      "cbrt3_fieldExtDegree: [ℚ(∛3):ℚ] = 3 as one-line corollary of adjoin_nthRoot_finrank",
+      "minpoly_cbrt3_natDeg: natDegree(minpoly ℚ ∛3) = 3 as corollary",
+      "cbrt3_irrational_from_degree: ∛3 is irrational via minpoly degree argument (third proof)",
+      "irrational_of_degree_gt_one: general principle — [ℚ(α):ℚ] > 1 implies α ∉ ℚ",
+      "cbrt3_irrational_via_principle: applies the general principle to ∛3"
     ]
   },
   "leanFile": {
@@ -41,15 +41,16 @@
     "theoremCount": 5
   },
   "overview": {
-    "historicalContext": "The degree [\u211a(\u221b3):\u211a] = 3 is a classical result in algebraic number theory. While \u221b3's irrationality was known to antiquity, the field-extension perspective emerged with Galois and Dedekind in the 19th century. The key insight: an algebraic number \u03b1 lies in \u211a if and only if its minimal polynomial has degree 1. This connects the qualitative fact '\u03b1 \u2209 \u211a' to the quantitative measurement '[\u211a(\u03b1):\u211a] > 1', and the full degree [\u211a(\u221b3):\u211a] = 3 tells us precisely how far \u221b3 is from being rational.",
-    "problemStatement": "**Open Question OQ-01 from cube-root-3-irrational-oq-02**:\n\nThe parent file proves \u221b3 is irrational via Eisenstein irreducibility. Can [\u211a(\u221b3):\u211a] = 3 be derived as a corollary? The hint from the gallery: `CubeRoot2IrrationalOQ03` already proves `adjoin_nthRoot_finrank 3 3 3 = 3`.\n\n**This file answers yes**: one-line corollary, plus three additional theorems connecting degree to irrationality.",
-    "proofStrategy": "**Core argument**: The general theorem `adjoin_nthRoot_finrank n m p hn hp hdvd hndvd hm` from `CubeRoot2IrrationalOQ03` proves `Module.finrank \u211a \u211a\u27ee(m:\u211d)^(1/n)\u27ef = n` when `p | m` but `p\u00b2 \u2224 m`. Specializing to `n=3, m=3, p=3` gives [\u211a(\u221b3):\u211a] = 3 immediately.\n\n**Irrationality from degree**: If \u221b3 = q \u2208 \u211a, then `minpoly \u211a \u221b3 = X - C q` (Mathlib's `minpoly.eq_X_sub_C`), which has degree 1. But `adjoin.finrank` says `[\u211a(\u221b3):\u211a] = natDegree(minpoly \u211a \u221b3) = 1`. This contradicts [\u211a(\u221b3):\u211a] = 3.\n\n**General principle**: The same argument works for any algebraic \u03b1 with [\u211a(\u03b1):\u211a] > 1.",
+    "historicalContext": "The fact that ∛3 is irrational was known to the Greeks (Theodorus of Cyrene, c. 425 BCE, proved the irrationality of √n for non-square integers up to 17), but the *quantitative refinement* expressed by the field extension degree [ℚ(∛3):ℚ] = 3 belongs to the modern algebraic tradition. The vocabulary of field extensions emerged from Évariste Galois's posthumously published memoir (1846) on the solvability of polynomial equations, where the degree of an extension measures the algebraic complexity of an element. Richard Dedekind's 1871 supplement to Dirichlet's *Vorlesungen über Zahlentheorie* gave field theory its modern form, treating ℚ(∛3) as the smallest field containing ℚ and ∛3, and recognizing it as a 3-dimensional ℚ-vector space. Ferdinand Eisenstein's 1850 irreducibility criterion — published in *Crelle's Journal* the year of his death — provides the cleanest route to proving X³−3 irreducible over ℚ, since 3 is prime, divides the constant term once, and does not divide the leading coefficient. Together, these threads (Galois's degree, Dedekind's adjunction, Eisenstein's irreducibility) give the modern formulation: [ℚ(∛3):ℚ] equals the degree of the minimal polynomial of ∛3, which equals 3 because X³−3 is Eisenstein-irreducible.",
+    "problemStatement": "**Open Question OQ-01 from cube-root-3-irrational-oq-02**:\n\nThe parent file proves ∛3 is irrational via Eisenstein irreducibility. Can [ℚ(∛3):ℚ] = 3 be derived as a corollary? The hint from the gallery: `CubeRoot2IrrationalOQ03` already proves `adjoin_nthRoot_finrank 3 3 3 = 3`.\n\n**This file answers yes**: one-line corollary, plus three additional theorems connecting degree to irrationality.",
+    "proofStrategy": "**Core argument**: The general theorem `adjoin_nthRoot_finrank n m p hn hp hdvd hndvd hm` from `CubeRoot2IrrationalOQ03` proves `Module.finrank ℚ ℚ⟮(m:ℝ)^(1/n)⟯ = n` when `p | m` but `p² ∤ m`. Specializing to `n=3, m=3, p=3` gives [ℚ(∛3):ℚ] = 3 immediately.\n\n**Irrationality from degree**: If ∛3 = q ∈ ℚ, then `minpoly ℚ ∛3 = X - C q` (Mathlib's `minpoly.eq_X_sub_C`), which has degree 1. But `adjoin.finrank` says `[ℚ(∛3):ℚ] = natDegree(minpoly ℚ ∛3) = 1`. This contradicts [ℚ(∛3):ℚ] = 3.\n\n**General principle**: The same argument works for any algebraic α with [ℚ(α):ℚ] > 1.",
     "keyInsights": [
-      "The entire proof reduces to a five-argument norm_num call: adjoin_nthRoot_finrank 3 3 3 (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)",
-      "Irrationality follows from degree > 1 via a two-step chain: (1) q \u2208 \u211a implies minpoly = X - C q (degree 1), (2) adjoin.finrank says degree = 1, contradicting degree = 3",
-      "The key Mathlib lemma minpoly.eq_X_sub_C gives: if \u03b1 = algebraMap K L a, then minpoly K \u03b1 = X - C a",
-      "IntermediateField.adjoin.finrank connects Module.finrank with natDegree(minpoly): Module.finrank K K\u27ee\u03b1\u27ef = (minpoly K \u03b1).natDegree",
-      "The general principle irrational_of_degree_gt_one captures the fundamental algebraic fact: an element is in the base field iff it satisfies a degree-1 minimal polynomial"
+      "The entire degree proof reduces to a five-argument norm_num call: adjoin_nthRoot_finrank 3 3 3 (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num). The mathematical content (Eisenstein irreducibility, integral closure, primitive element theorem) is fully amortized into the helper file.",
+      "Irrationality follows from degree > 1 via a two-step chain: (1) q ∈ ℚ implies minpoly = X - C q (degree 1) by minpoly.eq_X_sub_C; (2) IntermediateField.adjoin.finrank says [ℚ(α):ℚ] = natDegree(minpoly), forcing degree = 1 and contradicting degree = 3.",
+      "The Mathlib lemma minpoly.eq_X_sub_C is the algebraic shadow of the trivial fact that elements of the base field have themselves as their minimal polynomial root: if α = algebraMap K L a, then minpoly K α = X - C a. This single API call transfers the entire 'rational ⇔ degree-1' equivalence into Lean.",
+      "The general principle irrational_of_degree_gt_one factors into a clean rationality criterion: an algebraic element α lies in the base field K if and only if [K(α):K] = 1. Equivalently, the rationals form the kernel of the rank function dim_ℚ ℚ(·) when restricted to algebraic numbers.",
+      "Degree-3 is strictly stronger than degree-2-or-more: it rules out any ℚ-linear relation a + b·∛3 = (∛3)² with a, b ∈ ℚ (such a relation would give a degree-≤2 polynomial vanishing at ∛3, contradicting natDegree(minpoly) = 3). This is exactly the linear independence of {1, ∛3, (∛3)²} formalized in OQ-02.",
+      "By Galois theory, [ℚ(∛3):ℚ] = 3 (a prime degree) implies that the Galois closure ℚ(∛3, ζ₃) has degree 6 over ℚ, with Galois group S₃ — the smallest non-abelian group. The proof that ∛3 is *not* constructible by ruler and compass follows immediately: 3 does not divide any power of 2, so [ℚ(∛3):ℚ] cannot embed into a tower of quadratic extensions."
     ],
     "prerequisites": [
       "CubeRoot2IrrationalOQ03.lean: adjoin_nthRoot_finrank, isIntegral_nthRoot, minpoly_nthRoot_natDegree",
@@ -58,35 +59,43 @@
   },
   "sections": [
     {
+      "id": "sec-setup",
+      "title": "Setup: Imports and Namespace",
+      "startLine": 40,
+      "endLine": 44,
+      "summary": "Imports CubeRoot2IrrationalOQ03 (the parametric n-th root file) and opens the Polynomial, CubeRoot2IrrationalOQ03, and IntermediateField namespaces. The IntermediateField namespace is essential for the ℚ⟮α⟯ syntax used throughout.",
+      "mathContext": "The file is built on top of $\\texttt{adjoin\\_nthRoot\\_finrank}$ and related lemmas in the parent. Notation: $\\mathbb{Q}\\langle\\!\\langle\\alpha\\rangle\\!\\rangle$ unicode brackets denote $\\texttt{IntermediateField.adjoin}\\,\\mathbb{Q}\\,\\{\\alpha\\}$ — the smallest intermediate field containing $\\alpha$."
+    },
+    {
       "id": "sec-field-degree",
-      "title": "PART I: Field Extension Degree [\u211a(\u221b3):\u211a] = 3",
-      "startLine": 36,
-      "endLine": 47,
-      "summary": "cbrt3_fieldExtDegree proves Module.finrank \u211a \u211a\u27ee(3:\u211d)^(1/3)\u27ef = 3 as a direct one-line corollary of adjoin_nthRoot_finrank 3 3 3 with five norm_num side conditions.",
+      "title": "PART I: Field Extension Degree [ℚ(∛3):ℚ] = 3",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "cbrt3_fieldExtDegree proves Module.finrank ℚ ℚ⟮(3:ℝ)^(1/3)⟯ = 3 as a direct one-line corollary of adjoin_nthRoot_finrank 3 3 3 with five norm_num side conditions.",
       "mathContext": "Specializes $\\texttt{adjoin\\_nthRoot\\_finrank}(n{=}3, m{=}3, p{=}3)$: checks $2 \\leq 3$, $\\text{Prime}\\,3$, $3 \\mid 3$, $\\neg\\,9 \\mid 3$, $0 < 3$. All by `norm_num`. Result: $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = 3$."
     },
     {
       "id": "sec-minpoly-degree",
       "title": "PART II: Minimal Polynomial Degree",
-      "startLine": 49,
-      "endLine": 57,
-      "summary": "minpoly_cbrt3_natDeg proves natDegree(minpoly \u211a \u221b3) = 3 as a corollary of minpoly_nthRoot_natDegree 3 3 3. The minimal polynomial is X\u00b3\u22123 (Eisenstein at p=3).",
+      "startLine": 64,
+      "endLine": 75,
+      "summary": "minpoly_cbrt3_natDeg proves natDegree(minpoly ℚ ∛3) = 3 as a corollary of minpoly_nthRoot_natDegree 3 3 3. The minimal polynomial is X³−3 (Eisenstein at p=3).",
       "mathContext": "$\\text{minpoly}\\,\\mathbb{Q}\\,(\\sqrt[3]{3}) = X^3 - 3$ (irreducible by Eisenstein, monic, vanishes at $\\sqrt[3]{3}$). Its $\\text{natDegree} = 3$."
     },
     {
       "id": "sec-irrational-from-degree",
       "title": "PART III: Irrationality from Degree",
-      "startLine": 59,
-      "endLine": 76,
-      "summary": "cbrt3_irrational_from_degree proves Irrational ((3:\u211d)^(1/3)) via degree: if \u221b3 = q \u2208 \u211a, then minpoly \u211a \u221b3 = X - C q (degree 1) by minpoly.eq_X_sub_C, contradicting minpoly degree 3.",
+      "startLine": 77,
+      "endLine": 101,
+      "summary": "cbrt3_irrational_from_degree proves Irrational ((3:ℝ)^(1/3)) via degree: if ∛3 = q ∈ ℚ, then minpoly ℚ ∛3 = X - C q (degree 1) by minpoly.eq_X_sub_C, contradicting minpoly degree 3.",
       "mathContext": "Key steps: (1) $q \\in \\mathbb{Q} \\Rightarrow \\text{minpoly}\\,\\mathbb{Q}\\,q = X - Cq$ by `minpoly.eq_X_sub_C`. (2) $\\text{natDegree}(X - Cq) = 1 \\neq 3$. Uses `rw [\\leftarrow hq]` to rewrite $\\sqrt[3]{3}$ as $(\\uparrow q : \\mathbb{R})$ in the goal."
     },
     {
       "id": "sec-general-principle",
       "title": "PART IV: General Principle",
-      "startLine": 78,
-      "endLine": 91,
-      "summary": "irrational_of_degree_gt_one proves: for algebraic \u03b1 : \u211d with Module.finrank \u211a \u211a\u27ee\u03b1\u27ef > 1, \u03b1 is irrational. Uses the same argument: \u03b1 = q \u2208 \u211a forces finrank = 1 via adjoin.finrank + minpoly.eq_X_sub_C, contradicting the hypothesis. cbrt3_irrational_via_principle applies this to \u221b3.",
+      "startLine": 103,
+      "endLine": 131,
+      "summary": "irrational_of_degree_gt_one proves: for algebraic α : ℝ with Module.finrank ℚ ℚ⟮α⟯ > 1, α is irrational. Uses the same argument: α = q ∈ ℚ forces finrank = 1 via adjoin.finrank + minpoly.eq_X_sub_C, contradicting the hypothesis. cbrt3_irrational_via_principle then applies this to ∛3 in two lines: isIntegral_nthRoot gives integrality, and cbrt3_fieldExtDegree gives degree 3 > 1.",
       "mathContext": "General fact: $\\alpha \\in \\mathbb{Q} \\Leftrightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 1$. Proof of $\\Rightarrow$: $\\alpha = q \\Rightarrow \\text{minpoly}\\,\\mathbb{Q}\\,\\alpha = X - Cq \\Rightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\text{natDegree}(X-Cq) = 1$ by `adjoin.finrank`."
     }
   ],
@@ -104,15 +113,17 @@
     {
       "targetId": "cube-root-3-irrational-oq-02-oq-02",
       "relationship": "motivates",
-      "description": "OQ-02 proves {1, \u221b3, (\u221b3)\u00b2} linearly independent over \u211a \u2014 a consequence of [\u211a(\u221b3):\u211a] = 3."
+      "description": "OQ-02 proves {1, ∛3, (∛3)²} linearly independent over ℚ — a consequence of [ℚ(∛3):ℚ] = 3."
     }
   ],
   "conclusion": {
-    "summary": "[\u211a(\u221b3):\u211a] = 3 via adjoin_nthRoot_finrank. 5 theorems, 0 sorries, 0 axioms.",
-    "implications": "**Degree as strength**: [\u211a(\u221b3):\u211a] = 3 is strictly stronger than \u221b3 \u2209 \u211a. It rules out any \u211a-linear relation of degree < 3. In particular, (\u221b3)\u00b2 cannot be expressed as a + b\u00b7\u221b3 for any a, b \u2208 \u211a \u2014 a fact that OQ-02 makes precise via linear independence.\n\n**The general principle**: `irrational_of_degree_gt_one` formalizes the fundamental algebraic fact that rational elements are exactly the degree-1 algebraic numbers. This has immediate applications to any algebraic number whose minimal polynomial degree is established.",
+    "summary": "[ℚ(∛3):ℚ] = 3 via adjoin_nthRoot_finrank. 5 theorems, 0 sorries, 0 axioms.",
+    "implications": "**Degree as strength**: [ℚ(∛3):ℚ] = 3 is strictly stronger than ∛3 ∉ ℚ. It rules out any ℚ-linear relation of degree < 3. In particular, (∛3)² cannot be expressed as a + b·∛3 for any a, b ∈ ℚ — a fact that OQ-02 makes precise via linear independence.\n\n**The general principle**: `irrational_of_degree_gt_one` formalizes the fundamental algebraic fact that rational elements are exactly the degree-1 algebraic numbers. This has immediate applications to any algebraic number whose minimal polynomial degree is established.\n\n**Constructibility consequence**: [ℚ(∛3):ℚ] = 3 also implies ∛3 is *not constructible by ruler and compass*, since constructible numbers lie in towers of quadratic extensions, and 3 does not divide any power of 2. This connects directly to the classical Greek problem of *duplicating the cube* — if ∛2 had been rational (or even constructible), the Delian altar problem would have a straightedge-and-compass solution. The same argument with 3 in place of 2 confirms the broader phenomenon.\n\n**Galois group**: The splitting field of X³−3 over ℚ is ℚ(∛3, ζ₃), with Galois group S₃ (order 6, the smallest non-abelian group). This is the canonical example of a non-abelian Galois extension and a benchmark for inverse Galois theory.",
     "openQuestions": [
-      "Is {1, \u221b3, (\u221b3)\u00b2} linearly independent over \u211a? (Addressed in OQ-02: the three basis vectors of the degree-3 extension.)",
-      "Can the converse of irrational_of_degree_gt_one be proved: if \u03b1 is irrational and algebraic, does [\u211a(\u03b1):\u211a] > 1? (Yes, by definition of minimal polynomial degree \u2265 2 for irrational algebraic numbers.)"
+      "Is {1, ∛3, (∛3)²} linearly independent over ℚ? (Addressed in OQ-02: the three basis vectors of the degree-3 extension.)",
+      "Can the converse of irrational_of_degree_gt_one be proved: if α is irrational and algebraic, does [ℚ(α):ℚ] > 1? (Yes, by definition of minimal polynomial degree ≥ 2 for irrational algebraic numbers.)",
+      "Can the proof be generalized to compute [ℚ(ⁿ√m):ℚ] = n whenever m has a prime factor p with p¹ ∥ m (i.e. p|m and p²∤m)? The helper file already proves this; the gallery could surface it as a stand-alone result with examples for ⁿ√2, ⁿ√3, ⁿ√5.",
+      "What is the structure of the subfield lattice of the Galois closure ℚ(∛3, ζ₃)? By the fundamental theorem of Galois theory, the subgroups of S₃ (one of order 1, three of order 2, one of order 3, one of order 6) correspond bijectively to intermediate fields, giving exactly four nontrivial subfields including ℚ(∛3) and ℚ(ζ₃)."
     ]
   },
   "sorries": 0


### PR DESCRIPTION
## Summary

Enrichment pass for `cube-root-3-irrational-oq-02-oq-01` — the Eisenstein-corollary derivation of [ℚ(∛3):ℚ] = 3.

### Changes

- **Annotations (4 → 6)**: added `ann-setup` (imports/namespace context) and `ann-via-principle` (the two-line application `cbrt3_irrational_via_principle`); each carries full `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.
- **Section line ranges fixed**: previous sections referenced lines 36–47, 49–57, etc. — these no longer matched the actual source. Now: setup 40–44, Part I 46–62, Part II 64–75, Part III 77–101, Part IV 103–131. Added a fifth (setup) section.
- **Historical context expanded** with named, dated sources: Theodorus of Cyrene (~425 BCE), Galois's 1846 posthumous memoir, Dedekind's 1871 *Vorlesungen* supplement, Eisenstein's 1850 *Crelle's Journal* paper.
- **Key insight added**: by Galois theory, [ℚ(∛3):ℚ] = 3 (prime) implies the Galois closure ℚ(∛3, ζ₃) has Galois group S₃, the smallest non-abelian group; and ∛3 is *not constructible* by ruler and compass (3 ∤ 2^k).
- **Conclusion deepened**: implications now connect to the Delian altar problem (cube duplication) and S₃ Galois structure; two new open questions (general ⁿ√m extension degree, Galois subfield lattice).

### Verification

- `pnpm build` exit 0 (json validates, vite bundle succeeds).
- 0 sorries, 0 axioms (status `verified`, badge `original` unchanged and accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)