### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): Session 2 OBSERVE — Burnside scaffold

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -1,0 +1,119 @@
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.PGroup
+import Mathlib.GroupTheory.Nilpotent
+
+/-
+# Burnside's p^a q^b Theorem (Abel-Ruffini OQ-07)
+
+## Open Question (abel-ruffini-galois-extensions-oq-07)
+
+**Burnside's p^a q^b theorem in Lean**: Every group of order p^a q^b
+(where p, q are primes and a, b ∈ ℕ) is solvable.
+
+## Status: SCAFFOLD (Session 2 of OBSERVE)
+
+This file establishes the file structure and proves the trivial cases:
+- p = q  (collapses to a single prime, hence p-group)
+- a = 0  (the group is a q-power, hence q-group)
+- b = 0  (the group is a p-power, hence p-group)
+
+The non-degenerate case (a ≥ 1, b ≥ 1, p ≠ q) remains as `sorry` and is
+the substance of Burnside's 1904 theorem. Two routes are documented in
+the parent JSON (`abel-ruffini-galois-extensions-oq-07.json`):
+  (i)  original Burnside via character theory + algebraic integers;
+  (ii) Goldschmidt-Matsuyama character-free via transfer / focal subgroup.
+
+## Sharpness
+
+|A₅| = 60 = 2² · 3 · 5 has *three* distinct primes, exactly one more
+than Burnside's bound, and A₅ is non-solvable. The parent gallery entry
+`abel-ruffini-galois-extensions` proves A₅ non-solvable; together they
+pin the solvability threshold at "≤ 2 distinct primes".
+
+## Mathlib Infrastructure Used
+
+- `IsPGroup.of_card`        — from `Nat.card G = p^n` build an `IsPGroup p G`
+- `IsPGroup.isNilpotent`    — finite p-groups are nilpotent (`Mathlib.GroupTheory.Nilpotent`)
+- `IsNilpotent.to_isSolvable` — nilpotent ⟹ solvable (instance, priority 100)
+
+The trivial-case proofs go through the chain
+  card = p^k  ⟶  IsPGroup p G  ⟶  IsNilpotent G  ⟶  IsSolvable G.
+-/
+
+namespace AbelRuffiniGaloisExtensionsOQ07
+
+-- `IsNilpotent` for groups lives in the `Group` namespace; the root-level
+-- `IsNilpotent` is the predicate on ring elements.
+open Group
+
+/-! ## Trivial reductions (single-prime cases)
+
+When the two prime factors collapse into one (`p = q`) or when one of
+the exponents is zero, the group is a p-group, and existing Mathlib
+infrastructure shows it is nilpotent and hence solvable. These cases
+are mathematically uninteresting but useful as sanity checks and as
+clean Aristotle targets. -/
+
+/-- Single-prime case: if `|G| = p^a · p^b`, then `G` is a p-group, hence solvable. -/
+theorem burnside_pq_eq_prime
+    {G : Type*} [Group G] [Finite G] {p : ℕ} [Fact p.Prime]
+    {a b : ℕ} (hG : Nat.card G = p ^ a * p ^ b) : IsSolvable G := by
+  have hcard : Nat.card G = p ^ (a + b) := by rw [hG, ← pow_add]
+  have hpG : IsPGroup p G := IsPGroup.of_card hcard
+  haveI : IsNilpotent G := hpG.isNilpotent
+  infer_instance
+
+/-- Trivial exponent case: if `|G| = p^0 · q^b = q^b`, then `G` is a q-group. -/
+theorem burnside_pq_a_zero
+    {G : Type*} [Group G] [Finite G] {p q : ℕ} [Fact q.Prime]
+    {b : ℕ} (hG : Nat.card G = p ^ 0 * q ^ b) : IsSolvable G := by
+  have hcard : Nat.card G = q ^ b := by rw [hG, pow_zero, one_mul]
+  have hqG : IsPGroup q G := IsPGroup.of_card hcard
+  haveI : IsNilpotent G := hqG.isNilpotent
+  infer_instance
+
+/-- Trivial exponent case: if `|G| = p^a · q^0 = p^a`, then `G` is a p-group. -/
+theorem burnside_pq_b_zero
+    {G : Type*} [Group G] [Finite G] {p q : ℕ} [Fact p.Prime]
+    {a : ℕ} (hG : Nat.card G = p ^ a * q ^ 0) : IsSolvable G := by
+  have hcard : Nat.card G = p ^ a := by rw [hG, pow_zero, mul_one]
+  have hpG : IsPGroup p G := IsPGroup.of_card hcard
+  haveI : IsNilpotent G := hpG.isNilpotent
+  infer_instance
+
+/-! ## Direct p-group bridge
+
+Phrased without the multiplicative factorisation, this is the building
+block used in every reduction: a finite group whose order is a prime
+power is solvable. -/
+
+/-- A finite group of prime-power order is solvable. -/
+theorem isSolvable_of_card_eq_prime_pow
+    {G : Type*} [Group G] [Finite G] {p n : ℕ} [Fact p.Prime]
+    (hG : Nat.card G = p ^ n) : IsSolvable G := by
+  have hpG : IsPGroup p G := IsPGroup.of_card hG
+  haveI : IsNilpotent G := hpG.isNilpotent
+  infer_instance
+
+/-! ## Main theorem (non-trivial direction)
+
+The substantive content of Burnside (1904): a finite group whose order
+has exactly two distinct prime factors is solvable. Currently scaffolded
+as `sorry`; future sessions will choose between the character-theoretic
+and Goldschmidt-Matsuyama proof routes. -/
+
+/-- **Burnside's p^a q^b theorem** (OPEN — non-trivial case).
+
+If `|G| = p^a · q^b` for primes `p`, `q` and natural numbers `a`, `b`,
+then `G` is solvable.
+
+The trivial cases `p = q`, `a = 0`, `b = 0` are dispatched by the
+lemmas above. The non-degenerate case `a ≥ 1`, `b ≥ 1`, `p ≠ q` is
+the subject of Burnside (1904) and remains `sorry` here. -/
+theorem burnside_pq
+    {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    {a b : ℕ} (hG : Nat.card G = p ^ a * q ^ b) : IsSolvable G := by
+  sorry
+
+end AbelRuffiniGaloisExtensionsOQ07

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean
@@ -1,0 +1,57 @@
+/-
+  Aristotle targets for Burnside's p^a q^b Theorem (OQ-07)
+  Routine supporting lemmas for automated proof search.
+  See AbelRuffiniGaloisExtensionsOQ07.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (Burnside's theorem itself remains `sorry`
+    in the main file)
+  - Routine cardinality / divisibility / Sylow facts that the main proof
+    will rely on
+  - No axioms (use `theorem ... := by sorry` instead)
+  - No definition sorries
+
+  Included targets (Session 2 scaffold):
+  - card_pq_pow_pos        : 0 < p^a * q^b when p, q ≥ 2
+  - p_pow_dvd_card_pq      : p^a ∣ p^a * q^b
+  - q_pow_dvd_card_pq      : q^b ∣ p^a * q^b
+  - prime_pow_solvable     : finite group of prime-power order is solvable
+                             (already in Mathlib via IsPGroup.isNilpotent
+                             + IsNilpotent.to_isSolvable; restated as a
+                             single-step Aristotle target)
+-/
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.PGroup
+import Mathlib.GroupTheory.Nilpotent
+
+namespace AbelRuffiniGaloisExtensionsOQ07Aristotle
+
+open Group
+
+/-- Routine: a product of two prime powers is positive. -/
+theorem card_pq_pow_pos {p q a b : ℕ} (hp : 1 ≤ p) (hq : 1 ≤ q) :
+    0 < p ^ a * q ^ b :=
+  Nat.mul_pos (Nat.pos_of_ne_zero (pow_ne_zero a (by omega)))
+              (Nat.pos_of_ne_zero (pow_ne_zero b (by omega)))
+
+/-- Routine: `p^a` divides `p^a * q^b`. -/
+theorem p_pow_dvd_card_pq (p q a b : ℕ) : p ^ a ∣ p ^ a * q ^ b :=
+  Dvd.intro _ rfl
+
+/-- Routine: `q^b` divides `p^a * q^b`. -/
+theorem q_pow_dvd_card_pq (p q a b : ℕ) : q ^ b ∣ p ^ a * q ^ b := by
+  rw [Nat.mul_comm]
+  exact Dvd.intro _ rfl
+
+/-- A finite group of prime-power order is solvable.
+
+This is provable directly in Mathlib via `IsPGroup.of_card`, `IsPGroup.isNilpotent`,
+and the `IsNilpotent.to_isSolvable` instance. Restated here as a one-step
+Aristotle target supporting the trivial reductions of Burnside's theorem. -/
+theorem prime_pow_solvable {G : Type*} [Group G] [Finite G]
+    {p n : ℕ} [Fact p.Prime] (hG : Nat.card G = p ^ n) : IsSolvable G := by
+  have hpG : IsPGroup p G := IsPGroup.of_card hG
+  haveI : IsNilpotent G := hpG.isNilpotent
+  infer_instance
+
+end AbelRuffiniGaloisExtensionsOQ07Aristotle

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -29,14 +29,14 @@
   },
   "currentState": {
     "phase": "OBSERVE",
-    "since": "2026-05-07T20:25:00.000Z",
-    "iteration": 1,
-    "focus": "Survey Mathlib group-theory infrastructure; choose between character-theoretic and character-free proof; estimate scope.",
+    "since": "2026-05-07T22:55:00.000Z",
+    "iteration": 2,
+    "focus": "File scaffold complete: trivial reductions (p = q, a = 0, b = 0) proved via IsPGroup.isNilpotent + IsNilpotent.to_isSolvable. Main theorem `burnside_pq` is stated and remains as `sorry`. Ready for Session 3 strategy choice.",
     "blockers": [
       "Mathlib lacks: (1) the algebraic-integer lemma `|G|/χ(1) ∈ ℤ̄_K` for a non-trivial irreducible character χ on a non-conjugacy class, key for the original Burnside proof; (2) the focal subgroup theorem and transfer-based character-free Burnside proof (Goldschmidt/Matsuyama).",
       "Mathlib's character theory needs algebraically-closed-field hypotheses; concretizing for ℂ-valued characters requires `Complex` ↔ `IsAlgClosed` bridge already in Mathlib but care needed."
     ],
-    "nextAction": "Session 2: Prototype the *Sylow-theoretic preliminary* `burnside_pq_p_eq_q` (when p = q, group is a p-group, hence nilpotent, hence solvable — trivially follows from existing Mathlib `IsPGroup.isSolvable`). Establish the file structure `Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` with the main statement as `sorry` and the easy degenerate cases proved.",
+    "nextAction": "Session 3: Choose between character-theoretic (Burnside 1904) and Goldschmidt-Matsuyama character-free routes. Inspect Mathlib's `Mathlib.GroupTheory.Transfer` and `Mathlib.RepresentationTheory.Character` for available infrastructure. Document the choice and begin reducing the main `sorry` to a chain of well-defined intermediate axioms.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -44,8 +44,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 1 (2026-05-07, OBSERVE): Replaced placeholder title `[Problem Title]` and tags artifact (`number-theory  # or: ...`) with proper content. Identified the seed open question as #7 of the parent gallery (`abel-ruffini-galois-extensions`): Burnside's p^a q^b theorem. Confirmed Mathlib has IsSolvable + Sylow + character theory but no Burnside. Documented two proof strategies (character-theoretic vs Goldschmidt-Matsuyama character-free) and their tradeoffs.",
-    "builtItems": [],
+    "progressSummary": "Session 2 (2026-05-07, OBSERVE): Created file scaffold `Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (119 lines, 5 theorems, 1 sorry) and Aristotle companion `Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean` (57 lines, 4 theorems, 0 sorries). Trivial cases (p = q, a = 0, b = 0) are proved via the chain `IsPGroup.of_card → IsPGroup.isNilpotent → IsNilpotent.to_isSolvable` (instance, priority 100). Verified Docker build compiles. Main `burnside_pq` theorem stated and left as `sorry`.",
+    "builtItems": [
+      "burnside_pq_eq_prime: |G| = p^a · p^b ⟹ IsSolvable G (single-prime collapse case)",
+      "burnside_pq_a_zero: |G| = p^0 · q^b ⟹ IsSolvable G (q-power case)",
+      "burnside_pq_b_zero: |G| = p^a · q^0 ⟹ IsSolvable G (p-power case)",
+      "isSolvable_of_card_eq_prime_pow: |G| = p^n ⟹ IsSolvable G (general prime-power bridge)",
+      "burnside_pq: main statement, currently `sorry` (the open content of Burnside 1904)",
+      "Aristotle companion: card_pq_pow_pos, p_pow_dvd_card_pq, q_pow_dvd_card_pq, prime_pow_solvable"
+    ],
     "insights": [
       "Sharpness of bound: |A₅| = 60 = 2²·3·5 is the smallest non-solvable order; it has three distinct prime factors, exactly one more than Burnside's two. Burnside's theorem is therefore sharp at exactly this point.",
       "Trivial cases for Lean: (1) p = q reduces to a p-group, which is nilpotent and hence solvable (Mathlib `IsPGroup.isSolvable` exists); (2) a = 0 or b = 0 also reduces to a p-group; (3) |G| = 1 is solvable trivially. The non-trivial content is when both a ≥ 1, b ≥ 1, p ≠ q.",
@@ -56,7 +63,11 @@
       "Mathlib has `Mathlib.GroupTheory.SpecificGroups.ZGroup` — Z-groups (groups whose Sylows are all cyclic) — these are solvable, an entirely separate special-case classification, NOT Burnside.",
       "Estimated scope (character-theoretic): ~600-1000 lines. Estimated scope (character-free Goldschmidt-Matsuyama): ~400-800 lines but requires building/extending transfer theory in Mathlib first.",
       "Key Mathlib API to study before starting: `Mathlib.RepresentationTheory.Character` (orthogonality), `Mathlib.GroupTheory.Sylow` (p-subgroups, Sylow's theorems), `Mathlib.GroupTheory.Solvable` (IsSolvable definitions), `Mathlib.GroupTheory.PGroup`/`Nilpotent` (degenerate cases), `Mathlib.RingTheory.Polynomial.Cyclotomic.Basic` (algebraic integers in ℤ[ζ_n]).",
-      "Companion lemma plan: separate `Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean` exposing the trivial Sylow lemmas (a = 0, b = 0, p = q) for automated proof search. Main file `Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` axiomatizes Burnside and proves the corollary `S_n_unsolvable_iff` connection back to A_n classification (already in parent)."
+      "Companion lemma plan: separate `Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean` exposing the trivial Sylow lemmas (a = 0, b = 0, p = q) for automated proof search. Main file `Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` axiomatizes Burnside and proves the corollary `S_n_unsolvable_iff` connection back to A_n classification (already in parent).",
+      "Mathlib API correction (Session 2): the trivial-case bridge is **not** a single lemma `IsPGroup.isSolvable`; the actual chain is `IsPGroup.isNilpotent` (GroupTheory/Nilpotent.lean line 904, requires `[Finite G]` and `[Fact p.Prime]`) followed by the priority-100 instance `IsNilpotent.to_isSolvable` (line 861). Earlier Session 1 wording was slightly imprecise.",
+      "Mathlib namespace gotcha: `IsNilpotent` for **groups** lives in the `Group` namespace (`Group.IsNilpotent`); the unprefixed `IsNilpotent` refers to ring elements (Mathlib.RingTheory.Nilpotent). Without `open Group`, `haveI : IsNilpotent G := ...` produces an unhelpful 'Unknown identifier' error in v4.26 because the ring version is not imported transitively from the group imports. Fix: `open Group` inside the namespace.",
+      "Trivial-case structure: all three single-prime degenerate cases (p = q, a = 0, b = 0) collapse to the same prime-power → solvable bridge. They are proved by rewriting the cardinality factorization, building IsPGroup.of_card, then deriving Group.IsNilpotent and letting type-class inference close the goal.",
+      "Estimated complexity downgrade: trivial cases were ~5 lines each, not the 20-line block estimated in Session 1. The full scaffold (main file + Aristotle companion) came in at 176 lines, vs. the 80-100 line estimate. Most of the extra weight is documentation; the executable Lean is ~50 lines."
     ],
     "mathlibGaps": [
       "No `theorem Group.burnside_pq` — Burnside's p^a q^b theorem.",
@@ -65,11 +76,10 @@
       "No 'minimal counterexample' tactic infrastructure for finite-group induction proofs — would be a useful methodological add."
     ],
     "nextSteps": [
-      "Session 2 (file scaffold + trivial cases): Create `Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` and `Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean` with: (i) main theorem statement as `sorry`, (ii) trivial cases p = q, a = 0, b = 0 proved via `IsPGroup.isSolvable`, (iii) decomposition lemma `card_eq_pq_pow → existence of Sylow subgroups`. Estimated 80-100 lines.",
-      "Session 3 (literature review): Choose between character-theoretic and Goldschmidt-Matsuyama. Recommend Goldschmidt-Matsuyama (character-free) given Mathlib's character-theory algebraic-integer gap; if Mathlib's transfer infrastructure is incomplete, fall back to character-theoretic. Document the choice in the JSON.",
-      "Session 4 (Sylow setup): Prove that a minimal counterexample is non-abelian simple with no normal Sylow subgroup. Use `Mathlib.GroupTheory.Sylow` and `IsSolvable_of_normalSubgroup_solvable`-style reductions.",
-      "Session 5+ (main argument): chosen-strategy execution. Many sub-sessions expected.",
-      "Final session: replace `axiom burnside_pq` (if scaffolded) with theorem; sync meta.json; consider Mathlib upstream PR."
+      "Session 3 (strategy choice): Audit `Mathlib.GroupTheory.Transfer` (`transferSylow`?) and `Mathlib.RepresentationTheory.Character` (`char_orthonormal`) to compare the actual API surface available for the two proof routes. Goldschmidt-Matsuyama transfer route preferred a priori; pivot to character-theoretic if transfer infrastructure is incomplete.",
+      "Session 4 (minimal-counterexample reduction): Prove the standard structural lemma — a minimal counterexample to Burnside is a non-abelian simple group of order p^a · q^b (a, b ≥ 1, p ≠ q) with no proper non-trivial normal subgroup. This factors out the inductive-on-|G| step.",
+      "Session 5+: Execute the chosen strategy. For Goldschmidt-Matsuyama: build the focal-subgroup transfer argument and a contradiction from the existence of a transfer-derived normal subgroup in a minimal counterexample. For character-theoretic: the algebraic-integer lemma `(|G|/χ(1)) χ(g) ∈ ℤ̄` for non-trivial irreducible χ, then column orthogonality at a non-trivial conjugacy class.",
+      "Final session: replace `sorry` with theorem proper, sync meta.json, consider Mathlib upstream PR (this would be a substantial new addition to Mathlib.GroupTheory)."
     ]
   },
   "tags": [
@@ -108,7 +118,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.054Z",
-  "lastUpdate": "2026-05-07T20:25:00.000Z",
+  "lastUpdate": "2026-05-07T22:55:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
@@ -153,6 +163,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ07.lean",
+      "lineCount": 119,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ07Aristotle.lean",
+      "lineCount": 57,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Session 2 of the OBSERVE phase for the open question **abel-ruffini-galois-extensions-oq-07** — formalizing **Burnside's $p^a q^b$ theorem** in Lean 4 / Mathlib.

This PR establishes the file scaffold with trivial-case reductions proved and the main theorem stated as `sorry`. Docker build verified.

## Files added (176 lines total)

| File | Lines | Theorems | Sorries | Axioms |
|------|------:|---------:|--------:|-------:|
| `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` | 119 | 5 | 1 | 0 |
| `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07Aristotle.lean` | 57 | 4 | 0 | 0 |

### Proved (trivial single-prime reductions)

- `burnside_pq_eq_prime`: $|G| = p^a \cdot p^b$ ⟹ `IsSolvable G`
- `burnside_pq_a_zero`:   $|G| = p^0 \cdot q^b$ ⟹ `IsSolvable G`
- `burnside_pq_b_zero`:   $|G| = p^a \cdot q^0$ ⟹ `IsSolvable G`
- `isSolvable_of_card_eq_prime_pow`: $|G| = p^n$ ⟹ `IsSolvable G` (general bridge)

All four go through the chain
$\;\;\text{card}(G) = p^k \;\to\; \text{IsPGroup}\; p\; G \;\to\; \text{Group.IsNilpotent}\; G \;\to\; \text{IsSolvable}\; G,$
using `IsPGroup.of_card`, `IsPGroup.isNilpotent`, and the priority-100 instance `IsNilpotent.to_isSolvable` from `Mathlib.GroupTheory.Nilpotent`.

### Open (main statement)

- `burnside_pq`: $|G| = p^a \cdot q^b$ ⟹ `IsSolvable G` — **`sorry`**, the substance of Burnside (1904).

## Mathlib API correction (vs. Session 1)

Session 1's JSON cited a one-step `IsPGroup.isSolvable`. In Mathlib v4.26 the actual API is the two-step chain `IsPGroup.isNilpotent` + `IsNilpotent.to_isSolvable`. Also: the group-nilpotence class lives in the `Group` namespace (`Group.IsNilpotent G`), since the unprefixed `IsNilpotent` is reserved for ring-element nilpotency. The scaffold uses `open Group` for readability.

## Test plan

- [x] Docker build (`./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ07`) passes — only the expected `sorry` warning.
- [x] `theoremCount`, `lineCount`, and `sorryCount` updated in the JSON `leanFiles` block.
- [x] No new axioms.
- [x] No new placeholder definitions.

## Next steps (Session 3+)

1. Audit `Mathlib.GroupTheory.Transfer` and `Mathlib.RepresentationTheory.Character` to compare API surfaces of the two proof routes.
2. Choose between Burnside (character-theoretic, 1904) and Goldschmidt–Matsuyama (character-free, 1970s).
3. Reduce `burnside_pq` to a chain of well-defined intermediate lemmas/axioms; prove the minimal-counterexample structural reduction.

🤖 Generated by researcher-10