### PR TITLE
fix(meta): sync stale count drift in 3 gallery entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1938,
+    "lineCount": 1937,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 68,
@@ -270,7 +270,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 1937,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 13,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -24,7 +24,7 @@
     "lineCount": 251,
     "assumptions": "2 axiom declarations (easton_permitted_realizable and easton_consistency) state the realizability direction of Easton's 1970 theorem: every regular κ > ℵ₀ is realizable as 2^ℵ₀, and every Easton function is realizable as the continuum function on regular cardinals. Both axioms have True as codomain (placeholder), since a genuine Consistent (ZFC ∪ ⟦...⟧) predicate would require Gödel-encoding ZFC formulas — deferred to a future Phase-3b file. Of 9 supporting theorems, 7 are fully machine-checked from Mathlib (IsPermittedValue scaffold, aleph_one_permitted, aleph_two_permitted, permitted_satisfies_konig, permitted_unbounded, IsEastonFunction structure, isEastonFunction_nonempty). 2 carry sorries pending Phase-3a Mathlib API fixes: aleph_succ_permitted (the ℵ₀ < ℵ_(succ α) step needs the current-Mathlib spelling of the strict aleph0_lt_aleph lemma) and isEastonFunction_continuum.monotone (Cardinal.power_le_power_right now varies the BASE not the exponent in current Mathlib; needs the correct exponent-monotone lemma name).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 7,
     "definitionCount": 1
   },
   "overview": {
@@ -109,7 +109,7 @@
     "namespace": "CantorDiagOQ01OQ01OQ02OQ01",
     "lineCount": 251,
     "axiomCount": 2,
-    "theoremCount": 9,
+    "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean",
     "sorries": 2

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
@@ -41,7 +41,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "One axiom: polar_angle_eq — the dihedral angle of the polar triangle equals π minus the corresponding side of the original, proved analogously to the side formula but requiring intricate cross-cross algebra (eliminated in a follow-up).",
-    "lineCount": 321,
+    "lineCount": 327,
     "theoremCount": 13,
     "definitionCount": 1
   },
@@ -49,7 +49,7 @@
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 1,
-    "lineCount": 321,
+    "lineCount": 327,
     "sorries": 0,
     "path": "Proofs/LawOfCosinesOQ01OQ01OQ03.lean"
   },


### PR DESCRIPTION
## Fix

Sync drifted count fields in three gallery `meta.json` entries to match Lean source.

| Slug | Field | Before | After | Reason |
|------|-------|--------|-------|--------|
| `area-of-circle-oq-01-oq-03` | lineCount | 1938 | 1937 | matches `wc -l` |
| `law-of-cosines-oq-01-oq-01-oq-03` | lineCount | 321 | 327 | grew after axiom-elim PR #16788 |
| `cantor-diagonalization-oq-01-oq-01-oq-02-oq-01` | theoremCount | 9 | 7 | actual `theorem` decls = 7 (def + structure mistakenly counted) |

All fixes apply to BOTH the `meta` sub-object and the `leanFile` sub-object.

## Evidence

**area-of-circle**: `wc -l proofs/Proofs/AreaOfCircleOQ01OQ03.lean` → 1937.

**law-of-cosines**: `wc -l proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean` → 327. Axiom-elimination PR #16788 grew the file from 321 to 327 lines.

**cantor-diagonalization**: regex `^(@\[…\])*(private|protected|noncomputable)*\s*(theorem|lemma)\s+\S` after stripping nested-block + line comments yields 7 declarations (`permitted_satisfies_konig`, `aleph_one_permitted`, `aleph_two_permitted`, `aleph_succ_permitted`, `permitted_unbounded`, `isEastonFunction_continuum`, `isEastonFunction_nonempty`). `def IsPermittedValue` and `structure IsEastonFunction` are not theorems.

Surgical `text.replace()` on stale string preserves JSON formatting (no key reordering, no whitespace churn). Diff: 3 files, 6 insertions, 6 deletions.

The narrative `assumptions` text in cantor still says "Of 9 supporting theorems" — that is auditor-territory narrative drift, intentionally out of scope for this count-sync.

---
Automated fix by lean-mechanic agent.