### PR TITLE
audit(lebesgue-measure-oq-06): sync meta lineCount 1517→1518, add Aristotle to additionalFiles

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12235,10 +12235,10 @@
       "result": "clean"
     },
     "lebesgue-measure-oq-06": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:28Z",
-      "result": "clean"
+      "lastAudited": "2026-05-08T00:23:33Z",
+      "result": "issues-fixed"
     },
     "legendre-partial": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1517,
+    "lineCount": 1518,
     "assumptions": "1 axiom: banach_tarski main theorem (800+ lines via Hausdorff paradox + Axiom of Choice; provably unprovable in ZF alone — Solovay 1970). Declared as an explicit axiom rather than a placeholder proof so the mathematical assumption is tracked per the axiom integrity policy. All supporting lemmas fully proved: hausdorff_free_subgroup/orbit_ne (inductive proof via irrationality of sqrt 2 + ℤ[√2] invariant), free_group_paradoxical (F₂ is paradoxical under left action), free_group_not_amenable, int_amenable (Cesaro window-shift), banach_tarski_pieces_nonmeasurable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -45,7 +45,10 @@
       "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ],
     "theoremCount": 52,
-    "definitionCount": 20
+    "definitionCount": 20,
+    "additionalFiles": [
+      "Proofs/LebesgueMeasureOQ06Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Banach-Tarski paradox (1924) is one of the most counterintuitive results in mathematics: the closed unit ball in ℝ³ can be decomposed into finitely many pieces (5 suffice) and those pieces reassembled — using only rotations and translations — into two complete copies of the original ball. This appears to violate conservation of volume, but the pieces are non-measurable sets (constructed using the Axiom of Choice) to which Lebesgue measure cannot be assigned.\n\nThe paradox has a precise 1914 predecessor: Felix Hausdorff's *Grundzüge der Mengenlehre* proved that the 2-sphere $S^2$ minus a countable set $D$ admits a paradoxical decomposition under $\\text{SO}(3)$. The key algebraic ingredient was Hausdorff's discovery that $\\text{SO}(3)$ contains a free subgroup of rank 2: rotations $\\varphi$ (by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (by $\\arccos(1/3)$ around the $x$-axis) generate a free group, proved by an algebraic-number-theoretic argument — nontrivial words produce vectors with irrational coordinates that can never equal the identity.\n\nBanach and Tarski extended this in 1924 by handling the exceptional countable set $D$ (via a Hilbert-hotel argument: any countably infinite set under a fixed rotation of infinite order can be rearranged to absorb one more point) and by extending from $S^2$ to the full ball $B^3$ via a cone construction. The Straus–von Neumann optimization later showed 5 pieces suffice; whether 4 pieces can suffice for the full ball remains open (Dougherty–Foreman 1992 showed 4 pieces suffice using sets with the Baire property).\n\nThe conceptual unification came from Alfred Tarski. In 1938 ('Algebraische Fassung des Maßproblems') he proved the fundamental equivalence: a group $G$ is *amenable* — admits a finitely-additive left-invariant probability measure on all its subsets — if and only if no $G$-set is paradoxical. M. M. Day named the property 'amenable' in 1949. The chain $F_2 \\hookrightarrow \\text{SO}(3) \\Rightarrow \\text{SO}(3)$ non-amenable $\\Rightarrow B^3$ paradoxical is then the clean conceptual proof.\n\nThe 2D case is fundamentally different: $\\text{SO}(2)$ is abelian (hence amenable), so no paradoxical decomposition of bounded plane sets can exist using rotations. Robert Solovay proved in 1970 that, assuming an inaccessible cardinal, ZF is consistent with every subset of $\\mathbb{R}$ being Lebesgue measurable — in which model the Banach-Tarski paradox fails, confirming the Axiom of Choice is essential. In 1990, Miklós Laczkovich showed the disk can be 'squared' via translations only, but with infinitely many pieces — a different phenomenon, provable in ZF.",
@@ -215,7 +218,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 1517,
+    "lineCount": 1518,
     "axiomCount": 1,
     "theoremCount": 52,
     "definitionCount": 20,


### PR DESCRIPTION
## Summary

Audit re-run against `origin/main` (last audited 2026-04-23, find-targets ✓ but two minor drifts):

- **lineCount drift**: Lean source has 1518 lines; meta and `leanFile` both claimed 1517 (off-by-one).
- **additionalFiles drift**: `meta.additionalFiles` was absent; `leanFile.additionalFiles` already lists `Proofs/LebesgueMeasureOQ06Aristotle.lean` (76 lines, 0 sorries, 0 axioms — confirmed). Adding the companion to `meta.additionalFiles` keeps the auditor's submodule resolver in sync with the leanFile block.

Counts otherwise verified against `git show origin/main:proofs/Proofs/LebesgueMeasureOQ06.lean`:
- sorries: 0 ✓
- axiomCount: 1 ✓
- theoremCount: 52 ✓
- definitionCount: 20 ✓

Bumps `audit-tracker.json` for this entry: `auditCount` 1→2, `result` `clean` → `issues-fixed`.

## Test plan

- [x] JSON validates
- [x] Surgical 2-file diff (no whole-file reformatting)
- [x] Counts verified against origin/main blob (not working tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)