### PR TITLE
research(lagrange-four-squares-oq-01-oq-02): fix wrong volume formula in ThreeSquares.lean

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -639,34 +639,48 @@ theorem dirichletEllipsoid_symmetric (d : ℕ) (R : ℝ) :
   simp only [Pi.neg_apply, neg_sq]
   exact hx
 
-/-- **Axiom: Volume of the Dirichlet ellipsoid**: (4π/3) · R^(3/2) / √d.
+/-- **Axiom: Volume of the Dirichlet ellipsoid**: (4π/3) · R^(3/2) / d.
 
 For the standard ellipsoid x²/a² + y²/b² + z²/c² ≤ 1, the volume is (4π/3)abc.
-Our ellipsoid x² + dy² + dz² ≤ R has a = √R, b = c = √(R/d).
-So volume = (4π/3) · √R · √(R/d) · √(R/d) = (4π/3) · R^(3/2) / √d.
+Our ellipsoid `dirichletEllipsoid d R = {v : v₀² + d v₁² + d v₂² ≤ R}` has
+semi-axes `a = √R`, `b = c = √(R/d)`. So
+  volume = (4π/3) · √R · √(R/d) · √(R/d)
+         = (4π/3) · √R · (R/d)
+         = (4π/3) · R^(3/2) / d.
+
+The denominator is `d`, NOT `√d`. (A prior version of this axiom incorrectly
+used `Real.sqrt d`, off by a factor of √d. Verified 2026-05-08 against the
+standard ellipsoid volume formula and a worked-out instance d = 1, R = 1
+where vol(unit ball in ℝ³) = 4π/3 = (4π/3) · 1^(3/2) / 1.)
 
 **Proof status**: This is a standard calculus result. A full Lean proof would require:
 - Defining the ellipsoid as a measurable set
 - Computing its volume via an integral or linear transformation from the unit ball
-- Using MeasureTheory.volume_ball and affine transformation formulas
+- Using `EuclideanSpace.volume_ball` and `MeasureTheory.Measure.addHaar_image_smul`
 
-Mathlib has `MeasureTheory.Complex.volume_ball` for circles in ℂ, but not yet
-the general n-dimensional ellipsoid volume formula. -/
+Concrete strategy: define `T : (Fin 3 → ℝ) →ₗ[ℝ] (Fin 3 → ℝ)` by `T v 0 = √R · v 0`,
+`T v 1 = √(R/d) · v 1`, `T v 2 = √(R/d) · v 2`. Then `dirichletEllipsoid d R = T '' B(0,1)`.
+The Jacobian is `det T = √R · √(R/d) · √(R/d) = R^(3/2) / d`, and Mathlib's
+`MeasureTheory.Measure.addHaar_image_linearMap` gives the volume formula. -/
 axiom dirichletEllipsoid_volume (d : ℕ) (R : ℝ) (hd : 0 < d) (hR : 0 < R) :
-    MeasureTheory.volume (dirichletEllipsoid d R) = ENNReal.ofReal ((4 * Real.pi / 3) * R ^ (3/2 : ℝ) / Real.sqrt d)
+    MeasureTheory.volume (dirichletEllipsoid d R) =
+      ENNReal.ofReal ((4 * Real.pi / 3) * R ^ (3/2 : ℝ) / d)
 
 /-- **Axiom: Minkowski Application**: When the ellipsoid is large enough, it contains a nonzero integer point.
 
 By Minkowski's convex body theorem, if vol(E) > 2³ · covolume(ℤ³) = 8, then E ∩ ℤ³ ≠ {0}.
 
-For the Dirichlet ellipsoid with vol = (4π/3) · R^(3/2) / √d, the condition 8 < vol gives:
-  R^(3/2) > 6√d / π  ⟺  R > (6√d / π)^(2/3)
+For the Dirichlet ellipsoid with vol = (4π/3) · R^(3/2) / d, the condition 8 < vol gives:
+  R^(3/2) > 6 d / π  ⟺  R > (6 d / π)^(2/3)
 
 The key role this plays:
 - Given n and d with p = dn - 1 prime and -d a QR mod p
 - Choose R appropriately (using n and d) so that volume > 8
 - Minkowski gives integer point (x, y, z) ≠ 0 in ellipsoid
 - The quadratic residue condition allows extracting n = x² + y² + z²
+
+(Threshold corrected 2026-05-08 from `/ √d` to `/ d` to match the corrected
+`dirichletEllipsoid_volume` formula.)
 
 **Proof status**: This follows from Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`
 in `MeasureTheory.Group.GeometryOfNumbers`, applied to:
@@ -682,7 +696,7 @@ The setup requires:
 
 This is mechanical but requires ~100 lines of infrastructure. -/
 axiom minkowski_ellipsoid_has_lattice_point (d : ℕ) (R : ℝ) (hd : 0 < d) (hR : 0 < R)
-    (hvol : 8 < (4 * Real.pi / 3) * R ^ (3/2 : ℝ) / Real.sqrt d) :
+    (hvol : 8 < (4 * Real.pi / 3) * R ^ (3/2 : ℝ) / d) :
     ∃ v : Fin 3 → ℤ, v ≠ 0 ∧ (v 0 : ℝ) ^ 2 + d * (v 1 : ℝ) ^ 2 + d * (v 2 : ℝ) ^ 2 ≤ R
 
 /-- **Sufficiency Axiom**: Numbers NOT of excluded form ARE sums of three squares.

--- a/src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json
+++ b/src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json
@@ -39,25 +39,28 @@
     "goal": "Formalize the full iff-statement `legendre_three_squares` (ThreeSquares.lean:706) axiom-free. The theorem statement already exists; its forward direction is a real proof and its backward direction unfolds to `not_excluded_form_is_sum_three_sq`, the sufficiency axiom."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-08",
-    "iteration": 2,
-    "focus": "S1 (2026-05-08, researcher-8): inventory of `ThreeSquares.lean` (913 lines, 4 sufficiency axioms + 3 secondary r₃-formula axioms), mapping to Mathlib infrastructure (`MeasureTheory.Group.GeometryOfNumbers`, `LSeries.PrimesInAP`, `Zsqrtd.Basic`), and identification of the four-step axiom-elimination sequence.",
+    "phase": "ORIENT",
+    "since": "2026-05-08T03:30:00.000Z",
+    "iteration": 3,
+    "focus": "S3 (2026-05-08, researcher-3): **CORRECTED a wrong volume formula** in two existing axioms. `dirichletEllipsoid_volume` previously claimed vol = (4π/3) · R^(3/2) / √d; correct value is (4π/3) · R^(3/2) / d (off by factor √d). Same correction applied to `minkowski_ellipsoid_has_lattice_point` threshold. Axiom statements remain (still not proved) but now mathematically correct. Verified via standard ellipsoid volume formula V = (4π/3)abc with a = √R, b = c = √(R/d).",
     "blockers": [
       "Mathlib has Minkowski's theorem (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) but no closed-form ellipsoid-volume lemma — must be derived from `MeasureTheory.Measure.addHaar_smul` and `volume_ball` of the unit ball in ℝ³.",
       "Mathlib has Dirichlet's theorem on primes in AP (`Nat.setOf_prime_and_eq_mod_infinite`) but the integer/quadratic-residue compatibility (legendreSym(-d) = 1 for chosen p = dn-1) requires custom case analysis on n mod 8.",
       "The 4-axiom chain interlocks tightly: removing one in isolation does not reduce the assumption count. The minimal unit of progress is the full Minkowski-application argument."
     ],
-    "nextAction": "(Researcher) ACT phase S2: prove `dirichletEllipsoid_volume` axiom-free. Strategy: define the linear isomorphism T : ℝ³ → ℝ³ by T(x,y,z) = (x, √d·y, √d·z); show {v² ≤ R} = T⁻¹(B(0, √R)); use `MeasureTheory.Measure.addHaar_image_smul` and `volume_ball` (Mathlib's `EuclideanSpace.volume_ball`). Estimated 60–100 lines.",
+    "nextAction": "(Researcher) ACT phase S4: prove the (now-correct) `dirichletEllipsoid_volume` axiom. Strategy: define the linear isomorphism T : ℝ³ → ℝ³ via T = diag(√R, √(R/d), √(R/d)); show `dirichletEllipsoid d R = T '' B(0,1)`; use `MeasureTheory.Measure.addHaar_image_linearMap` with `det T = R^(3/2)/d` and `EuclideanSpace.volume_ball`. Estimated 60–100 lines.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE (2026-05-08, researcher-8): completed full inventory of existing infrastructure and gap analysis. The `ThreeSquares.lean` file (913 lines, written prior to this session) already contains all the theorem statements, all the prime-case proofs, the lattice infrastructure, and the ellipsoid convexity/symmetry — but routes the existence half of the proof through 4 unproved axioms (`dirichletEllipsoid_volume`, `minkowski_ellipsoid_has_lattice_point`, `dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`). The forward direction (necessity) is independently formalized in `LagrangeFourSquaresOQ04.lean`. Three additional axioms (`gauss_eisenstein_r3`, `general_r3_formula`, `class_number_positive`) at lines 813, 820, 825 are r₃-counting formulas, not part of the iff statement, so they are out of scope for this sub-problem. The minimal axiom-elimination ordering is: (1) ellipsoid volume → (2) Minkowski lattice point → (3) Dirichlet key lemma → (4) sufficiency. Steps 1 and 2 are pure Mathlib plumbing; step 3 is the QR-extraction argument; step 4 is case analysis on n mod 8 plus Dirichlet PrimesInAP.",
+    "progressSummary": "S3 (researcher-3, 2026-05-08, ORIENT): **Corrected wrong volume formula** in `dirichletEllipsoid_volume` and `minkowski_ellipsoid_has_lattice_point` axioms in `ThreeSquares.lean`. Previously stated `(4π/3) · R^(3/2) / √d`; correct value (verified 2026-05-08 via standard ellipsoid volume `V = (4π/3)abc` with `a = √R, b = c = √(R/d)`) is `(4π/3) · R^(3/2) / d` — off by a factor of √d. The `minkowski_ellipsoid_has_lattice_point` threshold was correspondingly wrong (`8 < ... / √d`); fixed to `8 < ... / d`. Both axioms remain unproved but are now mathematically correct, removing a blocker for future axiom-elimination work. Documented the correction in inline docstrings. Prior session (S1) noted the bug in insights[3] but did not commit a fix; S3 closes that loop.\n\nS1 OBSERVE (2026-05-08, researcher-8): completed full inventory of existing infrastructure and gap analysis. The `ThreeSquares.lean` file (913 lines, written prior to this session) already contains all the theorem statements, all the prime-case proofs, the lattice infrastructure, and the ellipsoid convexity/symmetry — but routes the existence half of the proof through 4 unproved axioms (`dirichletEllipsoid_volume`, `minkowski_ellipsoid_has_lattice_point`, `dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`). The forward direction (necessity) is independently formalized in `LagrangeFourSquaresOQ04.lean`. Three additional axioms (`gauss_eisenstein_r3`, `general_r3_formula`, `class_number_positive`) at lines 813, 820, 825 are r₃-counting formulas, not part of the iff statement, so they are out of scope for this sub-problem. The minimal axiom-elimination ordering is: (1) ellipsoid volume → (2) Minkowski lattice point → (3) Dirichlet key lemma → (4) sufficiency. Steps 1 and 2 are pure Mathlib plumbing; step 3 is the QR-extraction argument; step 4 is case analysis on n mod 8 plus Dirichlet PrimesInAP.",
     "builtItems": [
+      "S3 — Fixed `dirichletEllipsoid_volume` axiom: corrected `/ √d` → `/ d` in the formula `(4π/3) · R^(3/2) / d`. Off by a factor of √d.",
+      "S3 — Fixed `minkowski_ellipsoid_has_lattice_point` threshold: `8 < (4π/3) · R^(3/2) / d` (was `/ √d`). Now consistent with the corrected volume formula.",
+      "S3 — Updated docstrings in both axioms to document the correction and provide the verification.",
       "ThreeSquares.IsExcludedForm (ThreeSquares.lean:66): predicate ∃ a b, n = 4^a(8b+7).",
       "ThreeSquares.excluded_form_not_sum_three_sq (ThreeSquares.lean:182): forward direction, axiom-free.",
       "ThreeSquares.legendre_three_squares (ThreeSquares.lean:706): the full iff statement; backward direction routed through `not_excluded_form_is_sum_three_sq` axiom.",


### PR DESCRIPTION
## Summary

Corrects a **wrong volume formula** in two existing axioms in `proofs/Proofs/ThreeSquares.lean`:

| Axiom | Before | After |
|---|---|---|
| `dirichletEllipsoid_volume` | `(4π/3) · R^(3/2) / √d` | `(4π/3) · R^(3/2) / d` |
| `minkowski_ellipsoid_has_lattice_point` (threshold) | `8 < ... / √d` | `8 < ... / d` |

The previous formula was off by a factor of `√d`.

## Verification

For the ellipsoid `dirichletEllipsoid d R = {v : v₀² + d·v₁² + d·v₂² ≤ R}`, the semi-axes are `a = √R`, `b = c = √(R/d)`. Standard 3D ellipsoid volume gives:

```
V = (4π/3) · a · b · c
  = (4π/3) · √R · √(R/d) · √(R/d)
  = (4π/3) · √R · (R/d)
  = (4π/3) · R^(3/2) / d
```

Sanity check at `d = 1, R = 1`: vol(unit ball in ℝ³) = `4π/3`, matches.

## Status

Both axioms remain **axioms** (still not proved), but are now mathematically correct. This unblocks future axiom-elimination work — the corrected formula matches the natural proof strategy:

```
T : ℝ³ → ℝ³,  T = diag(√R, √(R/d), √(R/d))
det T = R^(3/2) / d
dirichletEllipsoid d R = T '' (unit ball)
vol(ellipsoid) = |det T| · vol(unit ball) = R^(3/2)/d · (4π/3)
```

## Background

The bug was noted in `lagrange-four-squares-oq-01-oq-02` Session 1 insights ("the existing axiom statement has 1/√d but the correct formula is 1/d") but never committed as a fix. This PR closes that loop.

## Test plan

- [ ] Docker build for `Proofs.ThreeSquares` (in progress)
- [x] Manual verification: standard ellipsoid volume formula `V = (4π/3)abc` with `a = √R, b = c = √(R/d)`.
- [x] Sanity check at `d = 1, R = 1`: vol(unit ball in ℝ³) = `4π/3`, matches.
- [x] No downstream breakage: the only proof referencing these axioms is `not_excluded_form_is_sum_three_sq` (itself an axiom, no proof depends on the volume formula's specific factor).
- [x] Research JSON updated: phase OBSERVE → ORIENT, iteration 2 → 3, builtItems + progressSummary.

## Files

- Modified: `proofs/Proofs/ThreeSquares.lean` (2 axiom statements + docstrings)
- Modified: `src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json`

🤖 Generated by researcher-3