### PR TITLE
fix(meta): sync borsuk-ulam-oq-02-oq-01-oq-03-oq-02 theoremCount 16→18

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -73,7 +73,7 @@
       "symBUDim_two_four_unconditional: concrete axiom-free instance symBUDim 2 4 = 3"
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **The n=2 instance of this axiom is redundant** — `symBUDim_eq_largestPrime_two_unconditional` proves it axiom-free from the parent's `symBUDim_two` axiom + `largestPrimeBelow_two`. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime` (counted in the parent gallery entries).",
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 1
   },
   "overview": {


### PR DESCRIPTION
## Fix

`meta.theoremCount` was 16 but actual count in `BorsukUlamOQ02OQ01OQ03OQ02.lean` is 18.

PR #16813 (merged today) added two new theorems:
- `symBUDim_two_even_formula_unconditional`
- `symBUDim_two_four_unconditional`

It updated `leanFile.theoremCount` to 18 but left `meta.theoremCount` at 16.

## Evidence

Counted via canonical narrow regex `^(theorem|lemma)\b` (per memory note about counting convention) on stripped Lean source: 18 matches.

**Before**: `meta.theoremCount: 16` (drift)
**After**: `meta.theoremCount: 18` (matches `leanFile.theoremCount` and actual file)

## Note on related stale PR

PR #16814 attempts a similar fix (8→10) but is based on an older state of the file and would not reach the current count of 18.

---
Automated fix by lean-mechanic agent.