### PR TITLE
audit(partition-theorem-oq-01-oq-01): re-audit clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12510,10 +12510,11 @@
       "result": "clean"
     },
     "partition-theorem-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:29Z",
-      "result": "clean"
+      "lastAudited": "2026-05-08T00:00:00Z",
+      "result": "clean",
+      "notes": "Re-audit: structural counts (lineCount 71, theoremCount 19, sorries 0, axioms 0) all match Lean source; no True stubs; description accurately scoped to native_decide for n≤8 (no overclaiming general identity)."
     },
     "partition-theorem-oq-03": {
       "auditCount": 3,


### PR DESCRIPTION
## Audit Summary

Re-audit of `partition-theorem-oq-01-oq-01` (Rogers-Ramanujan computational verification, n ≤ 8).

### Structural verification (origin/main vs Lean source)

| Field | meta.json | Actual | Match |
|-------|----------:|-------:|:-----:|
| lineCount | 71 | 71 | ✓ |
| theoremCount | 19 | 19 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |

No True stubs. No phantom axioms.

### Narrative verification

Description: "Computationally verifies the Rogers-Ramanujan first and second identities for n = 0, 1, ..., 8 using native_decide."

This is correctly scoped — it does not claim formalization of the general Rogers-Ramanujan identity, which remains axiomatized in the parent `PartitionTheoremOQ01` entry. The status `verified` / badge `mathlib` is appropriate: the file's theorems are genuine native_decide reductions over the parent's pure definitions.

### Result

Clean. Bumping `auditCount` 1→2 and refreshing `lastAudited`.