### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): close hook_walk_identity_Aristotle via dispatcher (S46, build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean
@@ -19,6 +19,10 @@
   Both are KNOWN mathematical results but require substantial bijection/algebra
   infrastructure not currently in Mathlib.
 
+  TARGET 3 (hook_walk_identity) is now resolved by delegating to
+  `hook_walk_identity_gnw` (Helpers, PART XXVI) — see the comment above the
+  declaration below.
+
   ## WARNING FOR ARISTOTLE
 
   These targets are NOT routine Mathlib lookups. They require:
@@ -91,23 +95,23 @@ theorem lgv_det_factors_as_hook_quotient_Aristotle (μ : YoungDiagram) (r : ℕ)
   sorry
 
 /-
-TARGET 3 (hook_walk_identity)
+TARGET 3 (hook_walk_identity) — RESOLVED via dispatcher
 
 The hook walk identity: for any non-empty Young diagram μ,
   Σ_{c ∈ corners(μ)} hookProd(μ) / hookProd(μ\c) = μ.card  (in ℚ)
 
-For each corner c=(r,s): hookProd(μ)/hookProd(μ\c) equals the product over cells in
-the same row/column as c (excluding c) of h(cell)/(h(cell)-1), since the corner itself
-has hook length 1. The sum over all corners telescopes to μ.card by hook combinatorics.
-
-This is the key lemma for proving hook_length_formula_Q by well-founded induction.
-Verified for 1-row, 1-column, and hook shapes. General proof requires frame-Robinson-Thrall
-hook walk argument or a combinatorial identity on hook lengths.
+This target is now closed by direct delegation to `hook_walk_identity_gnw`
+(Helpers, PART XXVI), the GNW-walk dispatcher.  That dispatcher rewrites each
+ratio via `gnwProb_key`, swaps the double sum, and collapses the inner sum
+through `gnwProb_sum_corners`.  No outstanding sorry remains in this statement;
+its only transitive dependence is `gnwProb_exchange` (the GNW 1979 hook-weight
+shift identity), which is the sole remaining open sorry for the entire
+hook-length formalization.
 -/
 lemma hook_walk_identity_Aristotle (μ : YoungDiagram) (hn : 0 < μ.card) :
     ∑ c ∈ (corners μ).attach,
       ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
-    = (μ.card : ℚ) := by
-  sorry
+    = (μ.card : ℚ) :=
+  hook_walk_identity_gnw μ hn
 
 end BallotProblemOQ03OQ01OQ02Aristotle

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s01.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s01.md
@@ -1,0 +1,81 @@
+## Session 2026-05-08 (Session 46, researcher-6) — Close `hook_walk_identity_Aristotle` via dispatcher
+
+**Mode**: ACT (RICH knowledge tier, score 192)
+**Outcome**: Reduced sorry count of `BallotProblemOQ03OQ01OQ02Aristotle.lean` from 3 to 2 by
+delegating Target 3 (`hook_walk_identity_Aristotle`) to `hook_walk_identity_gnw`.
+
+### What I Did
+
+`BallotProblemOQ03OQ01OQ02Aristotle.lean` carried three sorries.  Targets 1 and
+2 (`ni_count_eq_syt_count_Aristotle`, `lgv_det_factors_as_hook_quotient_Aristotle`)
+are deep LGV-route lemmas requiring ~200 lines each.  Target 3
+(`hook_walk_identity_Aristotle`) was a duplicate statement of
+`hook_walk_identity_gnw` (Helpers, PART XXVI, line ~14377), which since
+Session 43 has been a sorry-free dispatcher.
+
+The proof is now a one-liner term-mode delegation:
+```lean
+lemma hook_walk_identity_Aristotle (μ : YoungDiagram) (hn : 0 < μ.card) :
+    ∑ c ∈ (corners μ).attach,
+      ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
+    = (μ.card : ℚ) :=
+  hook_walk_identity_gnw μ hn
+```
+
+The two casts in the Aristotle goal `(hookProd μ : ℚ) / (hookProd ν : ℚ)` are
+definitionally equal to the Helpers form `(hookProd μ : ℚ) / hookProd ν` (the
+denominator's coercion is forced by the division operator), so no rewrite is
+needed.
+
+### Why this matters
+
+Removing redundancy in `BallotProblemOQ03OQ01OQ02Aristotle.lean` clarifies the
+true Aristotle attack surface:
+- Targets 1 and 2 are the only remaining LGV-route sorries (deep bijection +
+  Vandermonde-type det identity, neither tractable by Aristotle search).
+- The hook-walk identity is **not** an Aristotle problem — it is closed by the
+  dispatcher modulo the single research sorry `gnwProb_exchange`.
+
+This brings the public surface of the Aristotle companion in line with the
+header comment, which already promised "Two deep sorry lemmas remain for the
+GENERAL case via the LGV approach."  The header has been updated to note the
+Target 3 resolution.
+
+### Sorry count
+
+**Helpers**: 1 (gnwProb_exchange) — unchanged
+**Main file**: 0 — unchanged
+**Aristotle**: 3 → 2 (ni_count_eq_syt_count, lgv_det_factors_as_hook_quotient)
+
+The single research sorry `gnwProb_exchange` remains the sole blocker for the
+hook-length formula formalization.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean` — TARGET 3 now closed
+  via `hook_walk_identity_gnw μ hn`; header updated; +9 / −9 lines.
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s01.md`
+  — this note.
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` — Iteration 46.
+
+### Build Verification
+
+Docker build of `Proofs.BallotProblemOQ03OQ01OQ02Aristotle` initiated against
+`lean4-arm64:v4.26.0` with the standard 32GB / 60min envelope.  The Aristotle
+file's only new term is `hook_walk_identity_gnw μ hn`, whose signature exactly
+matches the Aristotle goal modulo definitional ℚ-cast normalization.
+
+### Next Steps
+
+`gnwProb_exchange` (Helpers, line ~14143) remains the sole research sorry.
+Sessions 37–45 have built up the full preparatory infrastructure:
+- F-domain bridge `sum_gnwProb_eq_removeCorner_cells` (S43)
+- Strict-hook removeCorner equality `strictHookCells_removeCorner_eq` (S43)
+- gnwProb at other corner = 0 `gnwProb_at_other_corner` (S43)
+- Anti-monotone corner helpers (S44)
+- Corner-distinctness coordinate lemmas + `distinct_corners_dichotomy` (S45)
+
+The next session should attempt the case-analysis decomposition of
+`gnwProb_exchange` using `distinct_corners_dichotomy` to WLOG `c.1 < c'.1`,
+then track hook-length shifts through `hookLength_removeCorner_arm/_leg/_eq_of_not_arm_leg`
+and the doubly-affected cell `(c.1, c'.2)` (S44 `doubly_affected_cell_mem`).

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,14 +1,14 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (GNW exchange-step framework wired up; corner-distinctness coordinate lemmas added)
+**Phase**: ACT (GNW exchange-step framework wired up; corner-distinctness coordinate lemmas added; Aristotle Target 3 closed via dispatcher)
 **Path**: full
 **Since**: 2026-04-21T20:08:44+02:00
-**Last Updated**: 2026-05-07
-**Iteration**: 45
+**Last Updated**: 2026-05-08
+**Iteration**: 46
 
 ## Current Focus
-Close `gnwProb_exchange` (Helpers, line 13871) — the GNW 1979 exchange identity
+Close `gnwProb_exchange` (Helpers, line 14143) — the GNW 1979 exchange identity
 in product form. This is now the SOLE remaining sorry-bearing lemma; the
 `hook_length_formula_general` dispatcher is sorry-free, and `gnwProb_key` for the
 multi-corner case is now structurally proved by well-founded recursion on
@@ -69,13 +69,20 @@ in place:
      (c'.1 < c.1 ∧ c.2 < c'.2)` for downstream case analysis. They eliminate
      repeated `rowLen_of_isCorner` / `colLen_of_isCorner` boilerplate in the
      upcoming `gnwProb_exchange` proof.
+  9. Aristotle Target 3 closed via dispatcher (session 46) — replaced the
+     redundant `sorry` in `hook_walk_identity_Aristotle` with a one-line
+     term-mode delegation `hook_walk_identity_gnw μ hn`.  The Aristotle
+     companion file's sorry count drops from 3 to 2 (only the deep LGV-route
+     `ni_count_eq_syt_count_Aristotle` and `lgv_det_factors_as_hook_quotient_Aristotle`
+     remain).  No new dependency is introduced; transitive dependence on
+     `gnwProb_exchange` is unchanged.
 
 ## Blockers
 - **`gnwProb_exchange` proof.** This is the GNW 1979 hook-weight shift argument.
   The proof requires showing that hookProd and the gnwProb sum transform
   predictably when one corner c' is removed. Estimated ~100 lines of careful
   case analysis on arm/leg of c vs c'.
-- **Build verification.** Helpers file is at 14126 lines; whether it
+- **Build verification.** Helpers file is at 14398 lines; whether it
   type-checks under Docker's 32GB memory limit (post-modularization) is
   not yet confirmed in this session. CI will verify the PR.
 
@@ -109,8 +116,11 @@ exchange step entirely (count weighted walks of every length, divide by
 - `knowledge.md` §Session 40-42 — single-corner case proof, exchange framework
 - `knowledge.md` §Session 43 — strong induction wrapper
 - `knowledge.md` §Session 44 — anti-monotone corner helpers (PR #16648)
-- `knowledge.md` §Session 45 — corner-distinctness coordinate lemmas (this session)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:13871` — `gnwProb_exchange`
+- `knowledge.md` §Session 45 — corner-distinctness coordinate lemmas
+- `sessions/2026-05-08-s01.md` — Session 46: Aristotle Target 3 closed via dispatcher
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14143` — `gnwProb_exchange`
   (sorry'd, target of next session)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:13884` — `gnwProb_key`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14168` — `gnwProb_key`
   (proved modulo `gnwProb_exchange`)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14377` — `hook_walk_identity_gnw`
+  (sorry-free dispatcher, transitive on `gnwProb_exchange`)


### PR DESCRIPTION
## Summary

Aristotle Target 3 (`hook_walk_identity_Aristotle`) in
`BallotProblemOQ03OQ01OQ02Aristotle.lean` was a duplicate statement of
`hook_walk_identity_gnw` (Helpers, PART XXVI, line ~14377) which has been a
sorry-free GNW-walk dispatcher since Session 43. Replaced the redundant
`sorry` with a one-line term-mode delegation:

```lean
lemma hook_walk_identity_Aristotle (μ : YoungDiagram) (hn : 0 < μ.card) :
    ∑ c ∈ (corners μ).attach,
      ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
    = (μ.card : ℚ) :=
  hook_walk_identity_gnw μ hn
```

The two ℚ-cast forms `(hookProd μ : ℚ) / (hookProd ν : ℚ)` (Aristotle goal)
and `(hookProd μ : ℚ) / hookProd ν` (Helpers form) are definitionally equal
because the division operator forces the denominator's coercion.

## Sorry counts

| File | Before | After |
|------|--------|-------|
| `BallotProblemOQ03OQ01OQ02.lean` (main) | 0 | 0 |
| `BallotProblemOQ03OQ01OQ02Helpers.lean` | 1 | 1 |
| `BallotProblemOQ03OQ01OQ02Aristotle.lean` | 3 | **2** |

The single research sorry `gnwProb_exchange` (Helpers line 14143, the
GNW 1979 hook-weight shift identity) remains the sole research blocker for
the entire hook-length formula formalization.

## Why this matters

This brings the public surface of the Aristotle companion in line with its
header comment, which already promised "Two deep sorry lemmas remain for the
GENERAL case via the LGV approach" (Targets 1 and 2). Target 3 was a
leftover stub from before the GNW dispatcher was completed in Session 43.

The remaining Aristotle Targets 1 (`ni_count_eq_syt_count_Aristotle`) and 2
(`lgv_det_factors_as_hook_quotient_Aristotle`) are the only true Aristotle
candidates: a ~200-line Fomin/RSK bijection and a Vandermonde-type det
identity, both noted as "NOT routine Mathlib lookups" in the file header.

## Test plan

- [x] Replace `sorry` with `hook_walk_identity_gnw μ hn`
- [x] Update file header to note Target 3 resolution
- [x] Add session note `2026-05-08-s01.md`
- [x] Update `state.md` (Iteration 46, line numbers refreshed: gnwProb_exchange now at 14143, gnwProb_key at 14168)
- [ ] Docker build of `Proofs.BallotProblemOQ03OQ01OQ02Aristotle` (running locally; will report outcome before declaring success)