### PR TITLE
research(liouville-theorem-oq-04): Part IV.9 — uniform poly-eval lower bound (S12, build clean)

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ04.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ04.lean
@@ -437,6 +437,188 @@ theorem padic_cofactor_bound_rat (g : Polynomial ℚ_[p]) (r s : ℤ) (hs : s �
   exact padic_polynomial_eval_norm_bound p g ((r : ℚ_[p]) / s) H hH_one hxH
 
 /-! ═══════════════════════════════════════════════════════════════════════════
+PART IV.9: UNIFORM LOWER BOUND ON ‖(f.map alg).eval (r/s)‖_p
+For nonzero f : ℤ[X] and r, s : ℤ with s ≠ 0 and rational evaluation nonzero:
+  `padicNorm p ((f.map alg).eval (r/s)) ≥ 1 / (intPolyL1 f · max(|r|,|s|)^d)`.
+
+This is the third and final ingredient needed to discharge the bridge axiom.
+The bound is uniform in r, s — the constant `intPolyL1 f` depends only on f
+(it's the L¹ norm of f's integer coefficients).
+
+Strategy:
+  1. The integer "homogeneous evaluation" `H(r,s) = ∑ aᵢ · r^i · s^(d-i) ∈ ℤ`
+     satisfies `H(r,s) = s^d · f(r/s)` in ℚ.
+  2. `|H(r,s)| ≤ intPolyL1 f · max(|r|,|s|)^d` (triangle on the integer sum).
+  3. Archimedean Complement (Part I): `padicNorm p H(r,s) ≥ 1/|H(r,s)|`.
+  4. `padicNorm p (s^d) ≤ 1`, so `padicNorm p (f(r/s)) ≥ padicNorm p H(r,s)`.
+═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- L¹ norm of integer polynomial coefficients (as ℕ): `∑ i ∈ support, |coeff i|`. -/
+def intPolyL1 (f : ℤ[X]) : ℕ :=
+  f.support.sum (fun i => (f.coeff i).natAbs)
+
+/-- Positivity of `intPolyL1` for nonzero polynomial: leading coeff contributes ≥ 1. -/
+theorem intPolyL1_pos {f : ℤ[X]} (hf : f ≠ 0) : 0 < intPolyL1 f := by
+  have hsupp : f.support.Nonempty := Polynomial.support_nonempty.mpr hf
+  obtain ⟨i, hi⟩ := hsupp
+  have hcoeff : f.coeff i ≠ 0 := Polynomial.mem_support_iff.mp hi
+  have hpos : 0 < (f.coeff i).natAbs := Int.natAbs_pos.mpr hcoeff
+  refine lt_of_lt_of_le hpos ?_
+  exact Finset.single_le_sum (f := fun j => (f.coeff j).natAbs)
+    (h := fun _ _ => Nat.zero_le _) hi
+
+/-- "Homogenized integer evaluation": `intPolyHomogEval f r s = ∑ aᵢ · r^i · s^(d-i)`
+    over `i ∈ f.support`, where d = f.natDegree. By construction,
+    `↑(intPolyHomogEval f r s) = s^d · f(r/s)` in ℚ. -/
+def intPolyHomogEval (f : ℤ[X]) (r s : ℤ) : ℤ :=
+  f.support.sum (fun i => f.coeff i * r^i * s^(f.natDegree - i))
+
+/-- Helper: `(∑ aᵢ).natAbs ≤ ∑ aᵢ.natAbs` for integer-valued sums over a Finset. -/
+private theorem natAbs_finset_sum_le {α : Type*} (s : Finset α) (φ : α → ℤ) :
+    (∑ i ∈ s, φ i).natAbs ≤ ∑ i ∈ s, (φ i).natAbs := by
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert a s ha ih =>
+    rw [Finset.sum_insert ha, Finset.sum_insert ha]
+    exact le_trans (Int.natAbs_add_le _ _) (Nat.add_le_add_left ih _)
+
+/-- Cast identity: `↑(intPolyHomogEval f r s) = s^d · (f.map alg).eval (r/s)` in ℚ. -/
+theorem intPolyHomogEval_cast_eq (f : ℤ[X]) (r s : ℤ) (hs : s ≠ 0) :
+    ((intPolyHomogEval f r s : ℤ) : ℚ) =
+      (s : ℚ)^f.natDegree * (f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s) := by
+  have hs_q : (s : ℚ) ≠ 0 := Int.cast_ne_zero.mpr hs
+  -- Express RHS via aeval, then expand to a sum over f.support.
+  rw [show (f.map (algebraMap ℤ ℚ)).eval ((r:ℚ)/s)
+        = Polynomial.aeval ((r:ℚ)/s) f from by
+      rw [Polynomial.aeval_def, ← Polynomial.eval_map]]
+  rw [Polynomial.aeval_def, Polynomial.eval₂_eq_sum, Polynomial.sum_def, Finset.mul_sum]
+  -- LHS push_cast through the integer sum
+  unfold intPolyHomogEval
+  push_cast
+  refine Finset.sum_congr rfl (fun i hi => ?_)
+  have hi_le : i ≤ f.natDegree := Polynomial.le_natDegree_of_mem_supp i hi
+  -- Per-term: (f.coeff i : ℚ) · r^i · s^(d-i) = s^d · (f.coeff i : ℚ) · (r/s)^i
+  -- Reduce s^d via splitting:
+  have hpow_split : (s : ℚ)^f.natDegree = (s : ℚ)^(f.natDegree - i) * (s : ℚ)^i := by
+    rw [← pow_add, Nat.sub_add_cancel hi_le]
+  rw [hpow_split, div_pow]
+  have hsi_ne : ((s : ℚ))^i ≠ 0 := pow_ne_zero _ hs_q
+  field_simp
+  ring
+
+/-- Bound: `|intPolyHomogEval f r s| ≤ intPolyL1 f · max(|r|,|s|)^d` (triangle). -/
+theorem intPolyHomogEval_natAbs_le (f : ℤ[X]) (r s : ℤ) :
+    (intPolyHomogEval f r s).natAbs ≤
+      intPolyL1 f * (max r.natAbs s.natAbs)^f.natDegree := by
+  unfold intPolyHomogEval intPolyL1
+  refine le_trans (natAbs_finset_sum_le _ _) ?_
+  rw [Finset.sum_mul]
+  refine Finset.sum_le_sum (fun i hi => ?_)
+  have hi_le : i ≤ f.natDegree := Polynomial.le_natDegree_of_mem_supp i hi
+  -- (aᵢ · r^i · s^(d-i)).natAbs = |aᵢ| · |r|^i · |s|^(d-i) ≤ |aᵢ| · H^d
+  rw [Int.natAbs_mul, Int.natAbs_mul, Int.natAbs_pow, Int.natAbs_pow, mul_assoc]
+  refine Nat.mul_le_mul_left _ ?_
+  -- |r|^i · |s|^(d-i) ≤ H^d
+  set H := max r.natAbs s.natAbs
+  calc r.natAbs^i * s.natAbs^(f.natDegree - i)
+      ≤ H^i * H^(f.natDegree - i) := Nat.mul_le_mul
+          (Nat.pow_le_pow_left (Nat.le_max_left _ _) i)
+          (Nat.pow_le_pow_left (Nat.le_max_right _ _) (f.natDegree - i))
+    _ = H^f.natDegree := by rw [← pow_add, Nat.add_sub_of_le hi_le]
+
+/-- Helper: `padicNorm p ((s : ℚ)^d) ≤ 1` for any integer s. -/
+private theorem padicNorm_intCast_pow_le_one (s : ℤ) (d : ℕ) :
+    padicNorm p ((s : ℚ)^d) ≤ 1 := by
+  induction d with
+  | zero => simp [padicNorm.one]
+  | succ d ih =>
+    rw [pow_succ, padicNorm.mul]
+    have h_int : padicNorm p (s : ℚ) ≤ 1 := padicNorm.of_int s
+    have h_pow_nn : 0 ≤ padicNorm p ((s : ℚ)^d) := padicNorm.nonneg _
+    calc padicNorm p ((s:ℚ)^d) * padicNorm p (s:ℚ)
+        ≤ 1 * padicNorm p (s:ℚ) := mul_le_mul_of_nonneg_right ih (padicNorm.nonneg _)
+      _ ≤ 1 * 1 := mul_le_mul_of_nonneg_left h_int (by norm_num)
+      _ = 1 := by ring
+
+/-- **Uniform polynomial evaluation lower bound** (Part IV.9 main result):
+    For nonzero f : ℤ[X] and r, s : ℤ with s ≠ 0 and `f.eval (r/s) ≠ 0`:
+      `padicNorm p (f.eval (r/s)) ≥ 1 / (intPolyL1 f · max(|r|, |s|)^d)`
+    where d = f.natDegree. The witness `1 / intPolyL1 f` depends only on f.
+
+    **Proof outline**:
+    1. Set `N := intPolyHomogEval f r s ∈ ℤ`. Then `↑N = s^d · f(r/s)` in ℚ.
+    2. `f(r/s) ≠ 0 ∧ s^d ≠ 0 ⟹ N ≠ 0`.
+    3. `|N| ≤ intPolyL1 f · H^d` (Part IV.9 triangle bound).
+    4. Archimedean Complement (Part I): `1/|N| ≤ padicNorm p N`.
+    5. `padicNorm p N = padicNorm p (s^d) · padicNorm p (f(r/s))`
+       and `padicNorm p (s^d) ≤ 1` give
+       `padicNorm p N ≤ padicNorm p (f(r/s))`.
+    6. Combine: `1/(intPolyL1 f · H^d) ≤ 1/|N| ≤ padicNorm p N ≤ padicNorm p (f(r/s))`. -/
+theorem padicNorm_int_poly_eval_uniform_lb
+    (f : ℤ[X]) (hf : f ≠ 0) (r s : ℤ) (hs : s ≠ 0)
+    (hne : (f.map (algebraMap ℤ ℚ)).eval ((r : ℚ) / s) ≠ 0) :
+    (1 : ℚ) / ((intPolyL1 f : ℚ) * (max r.natAbs s.natAbs : ℚ)^f.natDegree) ≤
+      padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ) / s)) := by
+  set d := f.natDegree with hd_def
+  set H := max r.natAbs s.natAbs with hH_def
+  set N := intPolyHomogEval f r s with hN_def
+  set L := intPolyL1 f with hL_def
+  -- Positivity: L > 0
+  have hL_pos : 0 < L := intPolyL1_pos hf
+  have hL_pos_q : (0 : ℚ) < (L : ℚ) := by exact_mod_cast hL_pos
+  -- Positivity: H > 0
+  have hs_natAbs_pos : 0 < s.natAbs := Int.natAbs_pos.mpr hs
+  have hH_pos : 0 < H := lt_of_lt_of_le hs_natAbs_pos (Nat.le_max_right _ _)
+  have hH_pos_q : (0 : ℚ) < (H : ℚ) := by exact_mod_cast hH_pos
+  have hHpow_pos_q : (0 : ℚ) < (H : ℚ)^d := pow_pos hH_pos_q _
+  -- s^d ≠ 0
+  have hsd_ne : (s : ℚ)^d ≠ 0 := pow_ne_zero _ (Int.cast_ne_zero.mpr hs)
+  -- N as ℚ = s^d · f.eval(r/s)
+  have hN_cast : (N : ℚ) = (s : ℚ)^d * (f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s) :=
+    intPolyHomogEval_cast_eq f r s hs
+  -- N ≠ 0
+  have hN_ne_q : (N : ℚ) ≠ 0 := by rw [hN_cast]; exact mul_ne_zero hsd_ne hne
+  have hN_ne : N ≠ 0 := fun h => hN_ne_q (by rw [h]; simp)
+  have hN_natAbs_pos : 0 < N.natAbs := Int.natAbs_pos.mpr hN_ne
+  have hN_natAbs_pos_q : (0 : ℚ) < (N.natAbs : ℚ) := by exact_mod_cast hN_natAbs_pos
+  -- |N| ≤ L · H^d (in ℕ, then cast to ℚ)
+  have hN_natAbs_le : N.natAbs ≤ L * H^d := intPolyHomogEval_natAbs_le f r s
+  have hN_natAbs_le_q : (N.natAbs : ℚ) ≤ (L : ℚ) * (H : ℚ)^d := by
+    have h1 : ((N.natAbs : ℕ) : ℚ) ≤ ((L * H^d : ℕ) : ℚ) := by exact_mod_cast hN_natAbs_le
+    push_cast at h1
+    exact h1
+  -- Archimedean Complement: 1/|N| ≤ padicNorm p N
+  have h_arch : ((N.natAbs : ℚ))⁻¹ ≤ padicNorm p ((N : ℤ) : ℚ) :=
+    padicNorm_int_ge_inv p N hN_ne
+  -- padicNorm p N = padicNorm p (s^d) · padicNorm p (f(r/s))
+  have h_pnorm_mul : padicNorm p ((N : ℤ) : ℚ) =
+      padicNorm p ((s : ℚ)^d) *
+        padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s)) := by
+    rw [hN_cast, padicNorm.mul]
+  -- padicNorm p (s^d) ≤ 1
+  have h_psd_le : padicNorm p ((s : ℚ)^d) ≤ 1 := padicNorm_intCast_pow_le_one p s d
+  -- padicNorm p N ≤ padicNorm p (f(r/s))
+  have h_pnorm_le : padicNorm p ((N : ℤ) : ℚ) ≤
+      padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s)) := by
+    rw [h_pnorm_mul]
+    have hf_eval_nn : 0 ≤ padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s)) :=
+      padicNorm.nonneg _
+    calc padicNorm p ((s : ℚ)^d) *
+            padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s))
+        ≤ 1 * padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s)) :=
+          mul_le_mul_of_nonneg_right h_psd_le hf_eval_nn
+      _ = padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s)) := one_mul _
+  -- 1/|N| ≤ padicNorm p (f(r/s))
+  have h_combined : ((N.natAbs : ℚ))⁻¹ ≤
+      padicNorm p ((f.map (algebraMap ℤ ℚ)).eval ((r : ℚ)/s)) := le_trans h_arch h_pnorm_le
+  -- 1/(L · H^d) ≤ 1/|N|
+  have h_inv_le : (1 : ℚ) / ((L : ℚ) * (H : ℚ)^d) ≤ ((N.natAbs : ℚ))⁻¹ := by
+    rw [show (1 : ℚ) / ((L : ℚ) * (H : ℚ)^d) = ((L : ℚ) * (H : ℚ)^d)⁻¹ from one_div _,
+        ← one_div, ← one_div]
+    exact one_div_le_one_div_of_le hN_natAbs_pos_q hN_natAbs_le_q
+  exact le_trans h_inv_le h_combined
+
+/-! ═══════════════════════════════════════════════════════════════════════════
 PART V: MAIN THEOREM
 P-adic algebraic numbers are not p-adically Liouville
 ═══════════════════════════════════════════════════════════════════════════ -/
@@ -726,6 +908,21 @@ must take the bridge constant C as `min(C_algebra, min_{r₀ rational root ≠ �
   Net: ingredients (1), (2a), (2b) of the bridge axiom are all now formally proved.
   The remaining obstruction to discharging the bridge as a theorem is purely the
   algebraic case analysis on rational roots of f distinct from α.
+
+**Session 12 changes (2026-05-08)**:
+- Added Part IV.9 (uniform polynomial evaluation lower bound):
+  - `intPolyL1`: L¹ norm of integer coefficients (∑ |aᵢ|), as ℕ.
+  - `intPolyL1_pos`: positivity for nonzero polynomial (leading coeff ≥ 1).
+  - `intPolyHomogEval`: integer "homogenized evaluation" ∑ aᵢ·r^i·s^(d-i).
+  - `intPolyHomogEval_cast_eq`: ↑(intPolyHomogEval f r s) = s^d · (f.map alg).eval (r/s) in ℚ.
+  - `intPolyHomogEval_natAbs_le`: |intPolyHomogEval| ≤ intPolyL1 · H^d (triangle).
+  - **`padicNorm_int_poly_eval_uniform_lb`**: 1/(intPolyL1 f · H^d) ≤ padicNorm p (f.eval (r/s))
+    when f, s, eval ≠ 0. The witness 1/intPolyL1 f is **uniform in r, s**.
+  Net: this is the missing structural piece. The pre-existing `padicNorm_poly_eval_bound`
+  (Part III) had a *trivial* witness depending on r,s; Part IV.9 supplies the genuinely
+  uniform bound. With this, all three ingredients (norm transport, cofactor upper bound,
+  polynomial lower bound) are now uniform-bound formal proofs. Remaining work to discharge
+  the bridge axiom is purely the rational-roots case analysis.
 
 -/
 

--- a/research/problems/liouville-theorem-oq-04/knowledge.md
+++ b/research/problems/liouville-theorem-oq-04/knowledge.md
@@ -146,3 +146,87 @@ theorem padic_liouville_norm_bridge_proof (...) :
 1. Identify the right Mathlib name for "finite set of rational roots of an integer polynomial". Candidates: `Polynomial.roots`, `Polynomial.aroots`. Need a ℚ-version with finiteness from degree.
 2. Prove the bridge using the case-split sketched above.
 3. After bridge discharge: convert `axiom padic_liouville_norm_bridge` to `theorem ... := by <proof>`, drop the `axiomCount: 1` to 0, change `status: "axiomatized"` to `"verified"`, change `badge: "axiom"` to `"verified"` (or `"original"` since this is a from-scratch p-adic Liouville).
+
+---
+
+## Session 2026-05-08 (Session 12) — Uniform Poly-Eval Lower Bound (Part IV.9, researcher-1)
+
+**Mode**: REVISIT
+**Outcome**: progress (final missing structural ingredient for bridge discharge now formally proved)
+
+### What I Did
+
+Added Part IV.9 to `LiouvilleTheoremOQ04.lean` (~180 lines):
+
+**Definitions (2)**:
+- `intPolyL1 (f : ℤ[X]) : ℕ := ∑ i ∈ f.support, (f.coeff i).natAbs` — L¹ norm of integer
+  coefficients (ℕ-valued).
+- `intPolyHomogEval (f : ℤ[X]) (r s : ℤ) : ℤ := ∑ i ∈ f.support, f.coeff i · r^i · s^(d-i)` —
+  the integer "homogenized evaluation"; equals `s^d · f(r/s)` in ℚ by construction.
+
+**Theorems (4 public + 2 private helpers)**:
+- `intPolyL1_pos`: positive for nonzero polynomial (leading coeff contributes).
+- `natAbs_finset_sum_le` (private): triangle inequality `(∑ aᵢ).natAbs ≤ ∑ aᵢ.natAbs` over a Finset.
+  Proved by induction on the finset.
+- `intPolyHomogEval_cast_eq`: `↑(intPolyHomogEval f r s) = s^d · (f.map alg).eval (r/s)` in ℚ.
+  Proof: rewrite RHS as a sum over `f.support` via `aeval_def + eval_map + eval₂_eq_sum + sum_def`,
+  pair with `Finset.mul_sum`, then per-term: `(s:ℚ)^d` splits as `s^(d-i) · s^i`, `field_simp; ring`.
+- `intPolyHomogEval_natAbs_le`: `|N| ≤ intPolyL1 f · max(|r|,|s|)^d`. Proof: triangle (private helper) +
+  per-term bound `|aᵢ · r^i · s^(d-i)| ≤ |aᵢ| · H^d` via `Int.natAbs_mul/_pow + Nat.pow_le_pow_left + Nat.add_sub_of_le`.
+- `padicNorm_intCast_pow_le_one` (private): `padicNorm p ((s:ℚ)^d) ≤ 1` for any integer s.
+  Proof: induction on d; `padicNorm.mul + padicNorm.of_int + mul_le_mul_of_nonneg_*`.
+- **`padicNorm_int_poly_eval_uniform_lb`** (main result, the missing piece):
+  For nonzero `f : ℤ[X]`, r, s : ℤ with `s ≠ 0`, and `f.eval(r/s) ≠ 0` over ℚ:
+    `1 / (intPolyL1 f · max(|r|,|s|)^d) ≤ padicNorm p ((f.map alg).eval (r/s))`.
+  The witness `1 / intPolyL1 f` is **uniform in r, s** (depends only on f).
+  Proof chain: `s^d·f(r/s) = N ∈ ℤ` nonzero → `padicNorm p N ≥ 1/|N|` (Archimedean Complement, Part I) →
+  `|N| ≤ L · H^d` (Part IV.9 triangle) → `padicNorm p N = padicNorm p (s^d) · padicNorm p (f(r/s))` and
+  `padicNorm p (s^d) ≤ 1` give `padicNorm p N ≤ padicNorm p (f(r/s))` → combine via `one_div_le_one_div_of_le`.
+
+File builds clean (Docker, lean 4.26.0): 1 axiom, 0 sorries, 914 lines, 32 theorems, 6 defs.
+
+### Key Findings
+
+- **Filling the trivial-witness gap**: The pre-existing `padicNorm_poly_eval_bound` (Part III, line 177)
+  was a TRIVIAL witness — `C := padicNorm p (eval) · H^d` depends on r, s. Useless for the bridge.
+  Part IV.9 replaces this with a **genuinely uniform** lower bound where the constant `1/intPolyL1 f`
+  depends only on f. This is the *structural* missing piece, not a stylistic improvement.
+
+- **Homogenized evaluation pattern**: For f ∈ ℤ[X] of natDegree d, the integer `N = ∑ aᵢ·r^i·s^(d-i)`
+  satisfies `N = s^d · f(r/s)` in ℚ. This is the "clear-denominators" form classically used in proofs
+  of Liouville's theorem. The Lean translation: rewrite RHS via `aeval_def → eval_map → eval₂_eq_sum →
+  sum_def`, pair with `Finset.mul_sum`, then per-term reduces to `r^i · s^(d-i) = s^d · (r/s)^i` —
+  closed by `pow_split + div_pow + field_simp + ring`.
+
+- **Triangle bound on integer sums**: Lean 4 Mathlib (4.26.0) has `Int.natAbs_add_le` for two-arg case;
+  for `Finset.sum` we proved `natAbs_finset_sum_le` by induction (1-line per case via `Int.natAbs_add_le`
+  + `Nat.add_le_add_left`). Useful primitive for any "L¹ on integer sums" pattern.
+
+- **Cofactor exponent margin**: The bridge target is `H^(2d)` but the algebraic case analysis gives
+  `H^(2d-1)` (since `g.natDegree = d-1`); the extra `H` is harmless because `H ≥ 1`. Margin ensures
+  one constant works for both algebraic and finite-rational-roots cases.
+
+### Pending — Bridge Discharge Sketch (unchanged from Session 11)
+
+With Part IV.9 in place, the residual obstruction is purely the case analysis on rational roots of
+f distinct from α. Remaining work:
+
+1. Form the Finset of rational roots of f (via `Polynomial.aroots ℚ` → `Multiset.toFinset`).
+2. Filter to `(q : ℚ_[p]) ≠ α`; if nonempty, take `δ := inf' ‖α - (q:ℚ_[p])‖`.
+3. Set `C := min(C₁/M, δ)` where `C₁ = 1/intPolyL1 f` and `M = coeffNormSum p g`. (Or take `C = C₁/M`
+   if filtered set is empty.)
+4. Case split on `f.eval (r/s) = 0` over ℚ:
+   - If `≠ 0`: apply `padicNorm_int_poly_eval_uniform_lb` + `padic_norm_int_poly_eval` (lift ℚ to ℚ_[p])
+     + `padic_cofactor_bound_rat`. Get `‖α - r/s‖ ≥ (C₁/M) / H^(2d-1) ≥ (C₁/M) / H^(2d)`.
+   - If `= 0`: r/s is a rational root with `(r/s : ℚ_[p]) ≠ α` (by hypothesis), so `r/s ∈ filteredSet`,
+     hence `‖α - r/s‖ ≥ δ ≥ C / H^(2d)`.
+
+Estimated 80-150 lines of additional Lean for the case split + Finset min infrastructure.
+
+### Next Steps
+
+1. (Highest value) Discharge `padic_liouville_norm_bridge` axiom using Part IV.9 + the case split above.
+2. After discharge: change `status: "axiomatized" → "verified"`, `badge: "axiom" → "original"`,
+   `axiomCount: 1 → 0`.
+3. Generate follow-up open questions: e.g., function-field version (`F_q(t)`), Roth-style sharpening
+   from `H^d` to `H^(2+ε)`, multi-place generalization.

--- a/research/problems/liouville-theorem-oq-04/state.md
+++ b/research/problems/liouville-theorem-oq-04/state.md
@@ -3,33 +3,41 @@
 ## Current State
 **Phase**: REFINE
 **Path**: full
-**Since**: 2026-05-08T01:00:00+00:00
-**Iteration**: 11
+**Since**: 2026-05-08T03:45:00+00:00
+**Iteration**: 12
 
 ## Current Focus
-Bridge axiom ingredient (2) discharged at the helper level. Parts IV.7 (height
-bound on rationals) and IV.8 (polynomial cofactor evaluation bound) added in
-Session 11; all three sub-ingredients of `padic_liouville_norm_bridge` are now
-formally proved. File builds clean: 1 axiom, 0 sorries, 732 lines, 26 theorems.
+Part IV.9 (uniform polynomial evaluation lower bound) added in Session 12.
+The pre-existing `padicNorm_poly_eval_bound` (Part III) was a TRIVIAL witness
+(C depending on r,s). Part IV.9 supplies the genuinely uniform bound where the
+constant `1/intPolyL1 f` depends only on f. This is the structural piece that
+makes a bridge proof possible. File builds clean: 1 axiom, 0 sorries, 914 lines,
+32 theorems, 6 defs.
 
 ## Active Approach
-Discharge `padic_liouville_norm_bridge` from axiom to theorem. Helper infrastructure
-complete (norm transport, height bound, cofactor bound). Remaining: case-split on
-`f(r/s) = 0` vs `≠ 0` to handle the rational-roots case.
+With Part IV.9 in place, all THREE structural ingredients for discharging
+`padic_liouville_norm_bridge` are formally proved at the uniform-bound level:
+  (1) Norm transport ℚ → ℚ_[p]:                Part IV.5 (`padic_norm_int_poly_eval`)
+  (2) Cofactor upper bound `‖g(r/s)‖ ≤ M·H^d`:  Part IV.7 + IV.8 (`padic_cofactor_bound_rat`)
+  (3) Polynomial lower bound `padicNorm p f(r/s) ≥ 1/(L·H^d)`: **Part IV.9** (`padicNorm_int_poly_eval_uniform_lb`)
+The remaining work is purely the case analysis on rational roots of f distinct from α.
 
 ## Attempt Count
-- Total attempts: 10
-- Current approach attempts: 3
+- Total attempts: 11
+- Current approach attempts: 4
 - Approaches tried: 3
 
 ## Blockers
-- Rational-roots case analysis: when f(r/s) = 0 and r/s ≠ α (finitely many), the
-  formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the indeterminate 0/0. Discharging the
-  bridge requires C ≤ min_{r₀ rat root ≠ α} ‖α - r₀‖ alongside the algebraic constant.
+- Rational-roots case analysis: when f(r/s) = 0 and (r/s : ℚ_[p]) ≠ α (finitely many such r/s),
+  the formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the indeterminate 0/0. Discharging the
+  bridge requires C ≤ min_{r₀ rat root, (r₀:ℚ_[p]) ≠ α} ‖α - r₀‖ alongside C₁/M from Parts IV.8/IV.9.
 
 ## Next Action
-Discharge `padic_liouville_norm_bridge` by case-splitting on `f(r/s) = 0`.
-- Case `f(r/s) ≠ 0`: combine `padic_norm_int_poly_eval` + `padicNorm_poly_eval_bound` +
-  `padic_cofactor_bound_rat`.
-- Case `f(r/s) = 0` with `r/s ≠ α`: enumerate rational roots of f as a Finset, take
-  min of ‖α - r₀‖ over the (finite) set.
+Discharge `padic_liouville_norm_bridge` axiom to theorem using:
+1. Form `Polynomial.aroots f ℚ` (multiset of rational roots of f over ℚ).
+2. `.toFinset` then filter to `(q : ℚ_[p]) ≠ α`.
+3. If filtered set nonempty, `δ := Finset.inf' (fun q => ‖α - (q:ℚ_[p])‖)`. Else any δ > 0 works.
+4. `C := min((1/intPolyL1 f) / coeffNormSum p g, δ)` (or just (1/L)/M if filtered set empty).
+5. Case-split: `f.eval (r/s) ≠ 0 over ℚ` use IV.9+IV.5+IV.8 chain; `= 0` use δ bound.
+After discharge: change `status: "axiomatized" → "verified"`, `badge: "axiom" → "original"`,
+`axiomCount: 1 → 0`.

--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "liouville-theorem-oq-04",
   "title": "P-adic Liouville Theorem: The Archimedean Complement Lemma",
   "slug": "liouville-theorem-oq-04",
-  "description": "Extension of Liouville's approximation theorem to the p-adic setting. Proves the key Archimedean Complement Lemma: padicNorm p n ≥ 1/n for nonzero naturals. Defines p-adic Liouville numbers using height max(|r|,|s|) and proves the main theorem that p-adic algebraic numbers are not p-adically Liouville. 1 axiom (padic_liouville_norm_bridge: norm compatibility ℚ → ℚ_[p] step), 0 sorries.",
+  "description": "Extension of Liouville's approximation theorem to the p-adic setting. Proves the key Archimedean Complement Lemma: padicNorm p n ≥ 1/n for nonzero naturals. Defines p-adic Liouville numbers using height max(|r|,|s|) and proves the main theorem that p-adic algebraic numbers are not p-adically Liouville. 1 axiom (padic_liouville_norm_bridge: rational-roots case analysis remains; all three structural ingredients formally proved as uniform bounds), 0 sorries.",
   "meta": {
     "author": "lean-genius research agent",
     "sourceUrl": "https://mathworld.wolfram.com/p-adicNumber.html",
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom: padic_liouville_norm_bridge — connects the factorization f = (X-C α)·g and evaluation identity to the p-adic Liouville lower bound. Originally required two ingredients: (1) norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q, (2) cofactor evaluation bound ‖g.eval(r/s)‖_p ≤ M·H^(deg g). All three sub-ingredients are now formally proved (Part IV.5 norm transport, Part IV.7 height bound padic_norm_int_div_le_height, Part IV.8 polynomial cofactor bound padic_polynomial_eval_norm_bound and padic_cofactor_bound_rat). The remaining obstruction to discharging the bridge as a theorem is the case analysis on rational roots of f distinct from α (finite set, requires taking C ≤ min ‖α - r₀‖ over those roots).",
+    "assumptions": "1 axiom: padic_liouville_norm_bridge — connects the factorization f = (X-C α)·g and evaluation identity to the p-adic Liouville lower bound. All FOUR structural ingredients now formally proved as uniform bounds: (1) norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q (Part IV.5, norm_rat_eq_padicNorm/padic_norm_int_poly_eval), (2a) height bound padicNorm p (r/s) ≤ max(|r|,|s|) (Part IV.7, padic_norm_int_div_le_height), (2b) cofactor evaluation upper bound ‖g.eval(r/s)‖_p ≤ M·H^(deg g) with M depending only on g (Part IV.8, padic_polynomial_eval_norm_bound + padic_cofactor_bound_rat), (3) UNIFORM polynomial lower bound padicNorm p (f.eval(r/s)) ≥ 1/(intPolyL1 f · H^d) with constant depending only on f (Part IV.9 NEW, padicNorm_int_poly_eval_uniform_lb). The pre-existing Part III bound was a trivial witness; Part IV.9 supplies the genuinely uniform version. The remaining obstruction to discharging the bridge as a theorem is purely the case analysis on rational roots of f distinct from α (finite set, requires taking C ≤ min ‖α - r₀‖ over those roots).",
     "dateAdded": "2026-04-26",
     "mathlibDependencies": [
       {
@@ -59,9 +59,9 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 732,
-    "theoremCount": 26,
-    "definitionCount": 4
+    "lineCount": 929,
+    "theoremCount": 32,
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Liouville's 1844 theorem — the first proof that specific transcendental numbers exist — uses the Archimedean property $|N|_{\\infty} \\geq 1$ for nonzero integers. The p-adic number system was developed by Kurt Hensel around 1897, motivated by the analogy between number fields and function fields. P-adic Liouville-type results appear in Mahler's work (1930s–1950s) on p-adic transcendence and in the theory of p-adic Diophantine approximation. The Archimedean Complement Lemma $|N|_p \\geq 1/|N|$ is a weak form of the **adelic product formula** $\\prod_v |N|_v = 1$ (Artin-Whaples, 1945), which underlies all of modern algebraic number theory — the product over all places (one Archimedean + one p-adic for each prime) equals 1. The p-adic Liouville theorem belongs to the broader program of Diophantine approximation in non-Archimedean metrics, developed by Mahler, Ridout, and Roth (Roth's theorem, 1955, Fields Medal). The use of **naive height** $H(r/s) = \\max(|r|, |s|)$ — rather than just the denominator — is the key departure from the classical theory, forced by the non-Archimedean structure where the numerator's p-adic content cannot be ignored.",
@@ -200,10 +200,10 @@
       "Polynomial"
     ],
     "namespace": "LiouvilleTheoremOQ04",
-    "lineCount": 732,
+    "lineCount": 929,
     "axiomCount": 1,
-    "theoremCount": 26,
-    "definitionCount": 4,
+    "theoremCount": 32,
+    "definitionCount": 6,
     "path": "Proofs/LiouvilleTheoremOQ04.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/liouville-theorem-oq-04.json
+++ b/src/data/research/problems/liouville-theorem-oq-04.json
@@ -17,21 +17,21 @@
   },
   "currentState": {
     "phase": "REFINE",
-    "since": "2026-05-08T01:00:00.000Z",
-    "iteration": 11,
-    "focus": "Bridge axiom INGREDIENT (2) DISCHARGED at the helper level. New Part IV.7 (height bound: ‖((r:ℚ_[p])/s)‖ ≤ max(|r|,|s|)) and Part IV.8 (polynomial cofactor bound: ‖g.eval x‖ ≤ coeffNormSum p g · H^(natDegree g)) provide all three sub-ingredients of the bridge. Remaining obstruction is purely algebraic: case analysis on rational roots of f distinct from α (finite set, requires C ≤ min ‖α - r₀‖ over those roots).",
+    "since": "2026-05-08T03:45:00.000Z",
+    "iteration": 12,
+    "focus": "Part IV.9 (uniform polynomial evaluation lower bound) added in Session 12. The pre-existing padicNorm_poly_eval_bound (Part III) was a TRIVIAL witness (C depending on r,s) — useless for the bridge. Part IV.9 supplies the genuinely uniform bound `padicNorm p (f.eval (r/s)) ≥ 1/(intPolyL1 f · H^d)` where the constant depends only on f. This is the missing structural piece. With Parts IV.5 (norm transport), IV.7 (height bound), IV.8 (cofactor upper bound), and IV.9 (NEW: polynomial lower bound), all THREE bridge ingredients are now uniform-bound formal proofs. Remaining: rational-roots case analysis only.",
     "blockers": [
-      "Rational-roots case analysis: when f(r/s) = 0 and r/s ≠ α (finitely many such rationals), the formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the indeterminate 0/0 (heval forces g(r/s) = 0 too). Discharging the bridge requires taking C ≤ min_{r₀ rat root ≠ α} ‖α - r₀‖ alongside the algebraic constant from the f(r/s) ≠ 0 case."
+      "Rational-roots case analysis: when f(r/s) = 0 and (r/s : ℚ_[p]) ≠ α (finitely many such rationals), the formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the indeterminate 0/0 (heval forces g(r/s) = 0 too when r/s ≠ α and f(r/s) = 0). Discharging the bridge requires taking C ≤ min_{r₀ rat root, (r₀:ℚ_[p]) ≠ α} ‖α - r₀‖ alongside the algebraic constant (1/intPolyL1 f) / coeffNormSum p g."
     ],
-    "nextAction": "Discharge padic_liouville_norm_bridge by case-splitting on f(r/s) = 0 vs ≠ 0. For ≠ 0: combine padic_norm_int_poly_eval + padicNorm_poly_eval_bound + padic_cofactor_bound_rat. For = 0 with r/s ≠ α: take min over the finite rational-root set of f. Likely needs a new helper around Polynomial.roots in ℚ.",
+    "nextAction": "Discharge padic_liouville_norm_bridge by case-splitting on f.eval(r/s) = 0 over ℚ vs ≠ 0. For ≠ 0: chain padic_norm_int_poly_eval (Part IV.5) → padicNorm_int_poly_eval_uniform_lb (NEW Part IV.9) for lower bound, padic_cofactor_bound_rat (Part IV.8) for upper bound, divide to get ‖α-r/s‖ ≥ (1/L)/M · 1/H^(2d). For = 0 with (r/s:ℚ_[p]) ≠ α: form Polynomial.aroots f ℚ → Finset, filter to (q:ℚ_[p]) ≠ α, take Finset.inf' ‖α - (q:ℚ_[p])‖.",
     "attemptCounts": {
-      "total": 10,
-      "currentApproach": 3,
+      "total": 11,
+      "currentApproach": 4,
       "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 11, 2026-05-08): Discharged ingredient (2) of the bridge axiom at the helper level. Added Part IV.7 (rational-division height bound) and Part IV.8 (polynomial cofactor evaluation bound). New formal lemmas: padicNorm_rat_int_div_le_natAbs (padicNorm p (r/s : ℚ) ≤ |s| via padicNorm.div + padicNorm.of_int + Archimedean Complement), padic_norm_intCast_eq_padicNorm (bridges integer-cast form ‖(z:ℤ:ℚ_[p])‖ to padicNorm p (z:ℚ) via norm_cast + norm_rat_eq_padicNorm), padic_norm_int_div_le_height (transports the rational bound to ℚ_[p] via norm_div + padicNorm.div), coeffNormSum + coeffNormSum_nonneg (the cofactor magnitude as ∑ ‖coeff i‖), padic_polynomial_eval_norm_bound (general: ‖g.eval x‖ ≤ coeffNormSum · H^(natDegree g) via norm_sum_le + norm_mul + norm_pow + monotonicity), padic_cofactor_bound_rat (rational-point specialization). All three originally-listed bridge ingredients (1, 2a, 2b) are now formally proved. The remaining obstruction is purely algebraic: case analysis on rational roots of f distinct from α. File builds cleanly (Docker, lean 4.26.0) with 1 axiom, 0 sorries.",
+    "progressSummary": "PROGRESS (Session 12, 2026-05-08): Added Part IV.9 — the UNIFORM polynomial evaluation lower bound. The pre-existing padicNorm_poly_eval_bound (Part III) was a TRIVIAL witness (C depending on r,s) — useless for the bridge. Part IV.9 supplies the genuinely uniform bound `padicNorm p (f.eval (r/s)) ≥ 1/(intPolyL1 f · H^d)` where the constant 1/intPolyL1 f depends only on f. New definitions: intPolyL1 (L¹ norm of integer coefficients as ℕ), intPolyHomogEval (integer 'homogenized evaluation' ∑ aᵢ·r^i·s^(d-i)). New theorems: intPolyL1_pos, intPolyHomogEval_cast_eq (↑intPolyHomogEval = s^d · f.eval(r/s) in ℚ via aeval+eval_map+eval₂_eq_sum+sum_def + per-term pow split), intPolyHomogEval_natAbs_le (|N| ≤ L · H^d via Finset triangle + Int.natAbs_mul/_pow + Nat.pow_le_pow_left), padicNorm_intCast_pow_le_one (padicNorm p (s^d) ≤ 1 by induction), padicNorm_int_poly_eval_uniform_lb (THE main result: chain Archimedean Complement + |N| bound + multiplicativity + one_div_le_one_div_of_le). Plus private helper natAbs_finset_sum_le proving (∑ aᵢ).natAbs ≤ ∑ aᵢ.natAbs by Finset.induction. With Parts IV.5 (norm transport), IV.7 (height bound), IV.8 (cofactor upper bound), and IV.9 (NEW: polynomial lower bound), all THREE bridge ingredients are now uniform-bound formal proofs. Remaining: rational-roots case analysis only. File builds cleanly (Docker, lean 4.26.0): 1 axiom, 0 sorries, 929 lines, 32 theorems, 6 defs.",
     "builtItems": [
       "IsPadicLiouville (LiouvilleTheoremOQ04.lean): definition with strict positivity 0 < ‖β - r/s‖ and height bound 2 ≤ max r.natAbs s.natAbs",
       "padic_liouville_estimate: proved via factorization + bridge axiom — exposes the standard (C/H^(2d)) lower bound",
@@ -47,7 +47,14 @@
       "padic_norm_int_div_le_height (Part IV.7, NEW Session 11): ‖((r:ℚ_[p])/s)‖ ≤ max(|r|,|s|) — ℚ_[p] version of height bound",
       "coeffNormSum + coeffNormSum_nonneg (Part IV.8, NEW Session 11): ∑ i ∈ support, ‖coeff i‖ — the cofactor magnitude",
       "padic_polynomial_eval_norm_bound (Part IV.8, NEW Session 11): ‖g.eval x‖ ≤ coeffNormSum p g · H^(natDegree g) for g : Polynomial ℚ_[p], 1 ≤ H, ‖x‖ ≤ H — general form",
-      "padic_cofactor_bound_rat (Part IV.8, NEW Session 11): rational-point specialization with H = max(|r|,|s|) and 2 ≤ H — direct fit for IsPadicLiouville"
+      "padic_cofactor_bound_rat (Part IV.8, NEW Session 11): rational-point specialization with H = max(|r|,|s|) and 2 ≤ H — direct fit for IsPadicLiouville",
+      "intPolyL1 + intPolyL1_pos (Part IV.9, NEW Session 12): L¹ norm ∑ |aᵢ| of integer coefficients (ℕ-valued); positive for nonzero polynomial",
+      "intPolyHomogEval (Part IV.9, NEW Session 12): integer ∑ aᵢ·r^i·s^(d-i); equals s^d · f(r/s) in ℚ by construction",
+      "intPolyHomogEval_cast_eq (Part IV.9, NEW Session 12): ↑(intPolyHomogEval f r s) = s^d · (f.map alg).eval (r/s) — proven via aeval_def + eval_map + eval₂_eq_sum + sum_def + per-term pow split + field_simp + ring",
+      "intPolyHomogEval_natAbs_le (Part IV.9, NEW Session 12): |intPolyHomogEval| ≤ intPolyL1 f · max(|r|,|s|)^d via Finset triangle + Int.natAbs multiplicativity + Nat.pow_le_pow_left",
+      "natAbs_finset_sum_le (Part IV.9, NEW Session 12, private): triangle (∑ aᵢ).natAbs ≤ ∑ aᵢ.natAbs over a Finset, by induction",
+      "padicNorm_intCast_pow_le_one (Part IV.9, NEW Session 12, private): padicNorm p ((s:ℚ)^d) ≤ 1 by induction on d",
+      "padicNorm_int_poly_eval_uniform_lb (Part IV.9, NEW Session 12, MAIN RESULT): UNIFORM lower bound 1/(intPolyL1 f · H^d) ≤ padicNorm p ((f.map alg).eval (r/s)) for nonzero f, s, eval — the structural piece making bridge discharge possible"
     ],
     "insights": [
       "IsPadicLiouville needs both 2 ≤ max(|r|,|s|) and 0 < ‖β - r/s‖. Without H≥2, bound 1/H^n=1 gives no useful constraint. Without strict positivity, every rational is trivially Liouville (r/s = β gives ‖β - r/s‖ = 0).",
@@ -57,7 +64,10 @@
       "Polynomial evaluation transport ℚ → ℚ_[p] is one line via Polynomial.aeval_algHom_apply applied to (Rat.castHom ℚ_[p]).toIntAlgHom : ℚ →ₐ[ℤ] ℚ_[p]; no manual map_map / eval_map gymnastics needed.",
       "Lean 4.26 API drift in this file: padicNorm.pos removed (use nonneg + nonzero), div_lt_div_right → div_lt_div_iff_of_pos_right, pow_le_pow_left → pow_le_pow_left₀. Also `set H : ℕ` no longer unifies with real-valued max output of `hbound`; switch to `set H : ℝ`.",
       "Session 11: When transporting `‖((r:ℚ_[p])/s)‖` to a padicNorm bound, the natural cast manipulation `push_cast; rfl` to prove `((r:ℚ_[p])/s) = (((r:ℚ)/s):ℚ_[p])` works for the equation but a subsequent `rw [hcast]` inside `‖·‖` triggers a deterministic isDefEq timeout (heartbeat exhaustion). The robust pattern: avoid the cast equation, instead `rw [norm_div]` first, then use a separate `padic_norm_intCast_eq_padicNorm` helper (proved with `norm_cast` for the integer-cast bridge) on each integer norm individually.",
-      "Session 11: A `padicNorm.div`-style multiplicativity rewrite produces a clean ℚ-statement; combining with the Archimedean Complement (lower bound on `padicNorm p s`) gives the height bound `padicNorm p (r/s) ≤ |s|` directly. The cleanest proof uses `div_le_iff₀ hs_norm_pos` to transform the goal to `padicNorm p r ≤ |s| · padicNorm p s` and then `mul_inv_cancel₀`."
+      "Session 11: A `padicNorm.div`-style multiplicativity rewrite produces a clean ℚ-statement; combining with the Archimedean Complement (lower bound on `padicNorm p s`) gives the height bound `padicNorm p (r/s) ≤ |s|` directly. The cleanest proof uses `div_le_iff₀ hs_norm_pos` to transform the goal to `padicNorm p r ≤ |s| · padicNorm p s` and then `mul_inv_cancel₀`.",
+      "Session 12: The pre-existing 'polynomial evaluation bound' Part III was a TRIVIAL witness — `C := padicNorm p (eval) · H^d` depends on r, s. This made the bridge axiom mathematically un-discharge-able with the existing lemmas. Part IV.9 fills this gap structurally: the uniform witness `1/intPolyL1 f` depends only on f, so the bridge constant `(1/L)/M · 1/H^(2d)` is a single number depending only on f and α (via g = f.map alg / (X-α)).",
+      "Session 12: The 'homogenized evaluation' pattern `N = ∑ aᵢ · r^i · s^(d-i) = s^d · f(r/s)` is the classical 'clear denominators' trick. The Lean translation of the rational identity `(N : ℚ) = s^d · f(r/s)` reduces (per term) to `r^i · s^(d-i) = s^d · (r/s)^i`, which is closed by `pow_split` (`s^d = s^(d-i)·s^i`) + `div_pow` + `field_simp` + `ring`. Avoids the more invasive `Polynomial.scaleRoots` machinery.",
+      "Session 12: Lean 4 Mathlib (4.26.0) lacks a direct `Finset.natAbs_sum_le`. Built `natAbs_finset_sum_le` privately by `Finset.induction_on`: empty case `simp`, insert case `Int.natAbs_add_le _ _` then `Nat.add_le_add_left`. Useful primitive for any 'L¹ on integer Finset sums' pattern."
     ],
     "mathlibGaps": [
       "Direct Mathlib lemma for `‖(z:ℤ):ℚ_[p]‖ = padicNorm p (z:ℚ)` (we proved padic_norm_intCast_eq_padicNorm as a wrapper around `norm_rat_eq_padicNorm` + `norm_cast`)",
@@ -65,9 +75,9 @@
       "Polynomial evaluation norm bound `‖g.eval x‖ ≤ M · max(1, ‖x‖)^(deg g)` for normed semirings (we proved padic_polynomial_eval_norm_bound directly via norm_sum_le)"
     ],
     "nextSteps": [
-      "Discharge padic_liouville_norm_bridge as a theorem: case-split on f(r/s) = 0. (Case f(r/s) ≠ 0): combine padic_norm_int_poly_eval + padicNorm_poly_eval_bound + padic_cofactor_bound_rat. (Case f(r/s) = 0 with r/s ≠ α): take min over the finite rational-root set.",
-      "Likely helper: a polynomial-roots-in-ℚ enumeration lemma producing the finite set {r/s : ℚ | f(r/s) = 0} as a Finset, then min_of_nonempty over distances ‖α - r₀‖.",
-      "After bridge discharge: the file will be axiom-free (verified status). Update meta.json status from 'axiomatized' to 'verified' and badge from 'axiom' to 'verified'."
+      "Discharge padic_liouville_norm_bridge as a theorem using Part IV.9. Case-split on f.eval(r/s) = 0 over ℚ: (≠ 0): chain padic_norm_int_poly_eval (Part IV.5) + padicNorm_int_poly_eval_uniform_lb (NEW IV.9, gives 1/(L·H^d) lower bound) + padic_cofactor_bound_rat (Part IV.8, gives M·H^d upper bound) → divide to get ‖α-r/s‖ ≥ (1/L)/M · 1/H^(2d-1) ≥ (1/L)/M · 1/H^(2d). (= 0): r/s is a rational root with (r/s:ℚ_[p]) ≠ α; take min over the finite filtered set.",
+      "Helper to build: form Polynomial.aroots f ℚ (multiset of rational roots), .toFinset (using Decidable on ℚ), filter to (q:ℚ_[p]) ≠ α, take Finset.inf' of fun q => ‖α - (q:ℚ_[p])‖. Estimated ~50-100 lines.",
+      "After bridge discharge: the file will be axiom-free (verified status). Update meta.json status from 'axiomatized' to 'verified' and badge from 'axiom' to 'verified' (or 'original' since this is a from-scratch p-adic Liouville)."
     ]
   },
   "tags": [
@@ -87,7 +97,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.505Z",
-  "lastUpdate": "2026-05-08T01:00:00.000Z",
+  "lastUpdate": "2026-05-08T03:50:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -105,10 +115,10 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ04.lean",
       "filename": "LiouvilleTheoremOQ04.lean",
-      "lineCount": 732,
-      "theoremCount": 26,
+      "lineCount": 929,
+      "theoremCount": 32,
       "axiomCount": 1,
-      "defCount": 4,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LiouvilleTheoremOQ04.lean"


### PR DESCRIPTION
## Summary

Session 12 of the p-adic Liouville theorem formalization. Adds **Part IV.9** — the **uniform polynomial evaluation lower bound** in `proofs/Proofs/LiouvilleTheoremOQ04.lean`. This is the missing structural piece for discharging the `padic_liouville_norm_bridge` axiom.

The pre-existing Part III bound (`padicNorm_poly_eval_bound`) was a *trivial* witness — `C := padicNorm·H^d` depending on r, s — useless for the bridge. Part IV.9 supplies the genuinely uniform bound where the constant `1/intPolyL1 f` depends only on f.

## Mathematical content

For nonzero `f : ℤ[X]` and `r, s : ℤ` with `s ≠ 0` and `f.eval(r/s) ≠ 0` over ℚ:
```
padicNorm p ((f.map alg).eval (r/s)) ≥ 1 / (intPolyL1 f · max(|r|, |s|)^d)
```
where `d = f.natDegree` and `intPolyL1 f = ∑ |coeff i|` is the L¹ norm of integer coefficients.

**Proof chain**:
1. The integer "homogenized evaluation" `N = ∑ aᵢ·r^i·s^(d-i) ∈ ℤ` satisfies `↑N = s^d·f(r/s)` in ℚ.
2. `|N| ≤ intPolyL1 f · H^d` (Finset triangle on the integer sum).
3. Archimedean Complement (Part I): `1/|N| ≤ padicNorm p N`.
4. Multiplicativity + `padicNorm p (s^d) ≤ 1` give `padicNorm p N ≤ padicNorm p (f(r/s))`.
5. Combine via `one_div_le_one_div_of_le`.

## What's new (≈180 lines)

**Definitions**:
- `intPolyL1 (f : ℤ[X]) : ℕ` — L¹ norm of integer coefficients
- `intPolyHomogEval (f : ℤ[X]) (r s : ℤ) : ℤ` — integer homogenized evaluation

**Theorems**:
- `intPolyL1_pos` — positivity for nonzero polynomial
- `intPolyHomogEval_cast_eq` — rational identity `↑N = s^d·f(r/s)`
- `intPolyHomogEval_natAbs_le` — triangle bound `|N| ≤ L · H^d`
- **`padicNorm_int_poly_eval_uniform_lb`** — main result (uniform LB)

**Private helpers**:
- `natAbs_finset_sum_le` — `(∑ aᵢ).natAbs ≤ ∑ aᵢ.natAbs` over a Finset
- `padicNorm_intCast_pow_le_one` — `padicNorm p (s^d) ≤ 1` for integer s

## File state

| Metric | Before (Session 11) | After (Session 12) |
|---|---|---|
| Lines | 732 | 929 |
| Axioms | 1 | 1 |
| Sorries | 0 | 0 |
| Theorems | 26 | 32 |
| Definitions | 4 | 6 |

Build verified clean (Docker, lean 4.26.0): `Build completed successfully (3063 jobs)`.

## Bridge axiom status

With Parts IV.5 (norm transport), IV.7 (height bound), IV.8 (cofactor upper bound), and **IV.9** (NEW: polynomial lower bound), all THREE bridge ingredients are now uniform-bound formal proofs. The remaining work to discharge `padic_liouville_norm_bridge` is purely the **rational-roots case analysis** (handle `f.eval(r/s) = 0 ∧ (r/s : ℚ_[p]) ≠ α` via `Polynomial.aroots f ℚ → Finset.inf'`).

## Status

**Outcome**: progress — final missing structural ingredient for bridge discharge now formally proved
**Phase**: REFINE (iteration 12)
**Next**: discharge the bridge axiom (case-split on rational roots; estimated ~50–100 additional lines)

🤖 Generated by researcher-1