### PR TITLE
audit(tracker): mark 5 stale-batch entries clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12365,9 +12365,9 @@
       "result": "clean"
     },
     "minkowski-fundamental-theorem-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:29Z",
+      "lastAudited": "2026-05-08T03:00:00Z",
       "result": "clean"
     },
     "minkowski-fundamental-theorem-oq-04": {
@@ -12726,21 +12726,21 @@
       "result": "clean"
     },
     "ptolemys-theorem-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:30Z",
+      "lastAudited": "2026-05-08T03:00:00Z",
       "result": "clean"
     },
     "ptolemys-theorem-oq-01-incomplete-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:30Z",
+      "lastAudited": "2026-05-08T03:00:00Z",
       "result": "clean"
     },
     "ptolemys-theorem-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:30Z",
+      "lastAudited": "2026-05-08T03:00:00Z",
       "result": "clean"
     },
     "ptolemys-theorem-oq-01-oq-02": {
@@ -12846,9 +12846,9 @@
       "result": "clean"
     },
     "randomized-maxcut-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:30Z",
+      "lastAudited": "2026-05-08T03:00:00Z",
       "result": "clean"
     },
     "rh-consequences": {


### PR DESCRIPTION
## Summary

Re-audit of 5 gallery entries last audited 2026-04-23. All `meta.json` structural counts match the Lean source on `origin/main` (`abb755e2a60`); tier classifications remain accurate.

| Slug | Status / Badge | sorries | axioms | thm | def | lines |
|------|----------------|---------|--------|-----|-----|-------|
| minkowski-fundamental-theorem-oq-02 | verified / mathlib (Tier B) | 0 | 0 | 5 | 0 | 130 |
| ptolemys-theorem-oq-01 | verified / original (Tier A) | 0 | 0 | 13 | 2 | 482 |
| ptolemys-theorem-oq-01-oq-01 | axiomatized / axiom (Tier C) | 0 | 1 | 8 | 1 | 288 |
| ptolemys-theorem-oq-01-incomplete-01 | verified / mathlib (Tier B) | 0 | 0 | 7 | 0 | 489 |
| randomized-maxcut-oq-04 | verified / original (Tier A) | 0 | 0 | 15 | 5 | 401 |

Tier audit:
- **minkowski-fundamental-theorem-oq-02**: All 5 theorems are direct Mathlib aliases (`NumberField.classNumber_pos`, `Rat.classNumber_eq`, etc.). Description and overview correctly attribute to Mathlib's `NumberField.ClassNumber` module.
- **ptolemys-theorem-oq-01**: 13 original lemmas including `exp_diff_factor` and `ptolemy_ratio_pos_of_ccw`; depends on Mathlib trig but provides genuine new contributions. `original` badge appropriate.
- **ptolemys-theorem-oq-01-oq-01**: One axiom `positive_ratio_implies_cyclic_order` correctly disclosed in `assumptions`; `axiomatized`/`axiom` matches.
- **ptolemys-theorem-oq-01-incomplete-01**: Mathlib bridge to companion `ptolemy_equality_implies_proportional`; `mathlib` badge consistent with Tier B.
- **randomized-maxcut-oq-04**: 15 original lemmas, no Mathlib dependencies for core result; `original` badge appropriate.

## Plumbing

- Built on top of `origin/main` `abb755e2a60` via `git hash-object` + custom `GIT_INDEX_FILE` + `commit-tree`; no working-tree state was used.
- Surgical text-replace preserves the existing JSON formatting; diff is exactly 10 lines (5 entries × `auditCount` + `lastAudited`).

## Test plan

- [x] All 5 Lean sources verified against `meta.json` counts via comment-stripped regex.
- [x] Tracker JSON parses and entries lookup correctly post-edit.
- [x] No structural drift detected; results = `clean`, no `issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)