### PR TITLE
research(hilbert-10-oq-01-oq-02): add Σ₁/Π₁ duality formalization

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -185,20 +185,102 @@ theorem mazur_implies_not_sigma1_definable :
   exact mazur_implies_not_diophantine hMazur (integers_diophantine_iff.mp hSigma1)
 
 -- ============================================================
--- Part VII: The landscape, sharpened
+-- Part VII: Π₁ (universal) Definability and the Σ₁/Π₁ Duality
+-- ============================================================
+
+/-- A subset S ⊆ ℚ is **Π₁-definable** ("co-Diophantine", purely universal)
+    if there exists a parametric polynomial family `P_q` such that
+
+        q ∈ S  ⟺  ∀ x ∈ ℚᵏ : P_q(x) ≠ 0,
+
+    i.e., q ∈ S iff the equation `P_q(x) = 0` has NO rational solution.
+
+    Equivalently, the complement of a Π₁ subset is Σ₁ (Diophantine);
+    see `diophantine_iff_codiophantine_complement` below. -/
+def IsCoDiophantineDefinition (S : RatSubset) : Prop :=
+  ∃ P : Rat → RatDiophantinePoly,
+    ∀ q : Rat, S q ↔ ¬ hasRationalSolution (P q)
+
+/-- The complement of `IntSubset` in ℚ: the rationals that are NOT integers. -/
+def NotIntSubset : RatSubset := fun q => ¬ IntSubset q
+
+/-- **Σ₁ / Π₁ duality** (general):
+
+    A subset S ⊆ ℚ is Σ₁-definable iff its complement is Π₁-definable.
+
+    Formally proves the narrative claim "Σ₁ ⟺ ¬(Π₁ for the complement)"
+    asserted in the introduction of this file. The proof uses one
+    classical excluded-middle step (`Classical.byContradiction`) for the
+    direction Π₁(¬S) → Σ₁(S), reflecting the well-known fact that
+    complementing is classical. -/
+theorem diophantine_iff_codiophantine_complement (S : RatSubset) :
+    IsDiophantineDefinition S ↔ IsCoDiophantineDefinition (fun q => ¬ S q) := by
+  constructor
+  · intro h
+    obtain ⟨P, hP⟩ := h
+    refine ⟨P, fun q => ?_⟩
+    refine ⟨fun hnSq hsol => hnSq ((hP q).mpr hsol),
+            fun hnsol hSq => hnsol ((hP q).mp hSq)⟩
+  · intro h
+    obtain ⟨P, hP⟩ := h
+    refine ⟨P, fun q => ?_⟩
+    refine ⟨fun hSq => ?_, fun hsol => ?_⟩
+    · apply Classical.byContradiction
+      intro hnsol
+      have hnSq : ¬ S q := (hP q).mpr hnsol
+      exact hnSq hSq
+    · apply Classical.byContradiction
+      intro hnSq
+      have hnsol : ¬ hasRationalSolution (P q) := (hP q).mp hnSq
+      exact hnsol hsol
+
+/-- **Specialization to ℤ ⊂ ℚ**:
+
+    ℤ is Σ₁-definable in ℚ (the OPEN question OQ-01-OQ-02) iff its
+    complement ℚ \ ℤ is Π₁-definable in ℚ. -/
+theorem integers_diophantine_iff_complement_codiophantine :
+    IntegersAreDiophantineOverQ ↔ IsCoDiophantineDefinition NotIntSubset :=
+  diophantine_iff_codiophantine_complement IntSubset
+
+/-- Π₁-definability of ℚ \ ℤ in ℚ implies H10/ℚ undecidable.
+
+    Pure logical consequence of `integers_diophantine_iff_complement_codiophantine`
+    composed with `integers_diophantine_sigma1_implies_h10_q_undecidable`;
+    NOT a new axiom. Witnesses that the OPEN question can equivalently be
+    stated in Π₁ form on the complement. -/
+theorem codiophantine_complement_implies_h10_q_undecidable :
+    IsCoDiophantineDefinition NotIntSubset → ¬H10_Rational_Decidable := by
+  intro hCodiop
+  exact integers_diophantine_sigma1_implies_h10_q_undecidable
+    (integers_diophantine_iff_complement_codiophantine.mpr hCodiop)
+
+/-- Mazur's conjecture rules out Π₁-definability of ℚ \ ℤ in ℚ.
+
+    Pure logical consequence of `integers_diophantine_iff_complement_codiophantine`
+    composed with `mazur_implies_not_sigma1_definable`; NOT a new axiom. -/
+theorem mazur_implies_not_codiophantine_complement :
+    MazurConjecture → ¬IsCoDiophantineDefinition NotIntSubset := by
+  intro hMazur hCodiop
+  exact mazur_implies_not_sigma1_definable hMazur
+    (integers_diophantine_iff_complement_codiophantine.mpr hCodiop)
+
+-- ============================================================
+-- Part VIII: The landscape, sharpened
 -- ============================================================
 
 /-
-## Σ₁ vs Π₂: the precise gap
+## Σ₁ vs Π₁ vs Π₂: the precise gap
 
 | Class | Statement on ℤ ⊂ ℚ | Status (2026) |
 |-------|--------------------|----------------|
-| Σ₁ (∃) | ℤ Diophantine over ℚ | **OPEN** (THIS PROBLEM) |
-| Π₁ (∀, in the negated form) | ℚ \ ℤ Diophantine over ℚ | **OPEN** (equivalent to Σ₁) |
-| Π₂ (∀∃) | ℤ universally-definable in ℚ | **PROVED** (Koenigsmann 2016) |
+| Σ₁ (∃)            | ℤ Diophantine over ℚ                  | **OPEN** (THIS PROBLEM) |
+| Π₁ (∀, complement) | ℚ \ ℤ Π₁-definable over ℚ              | **OPEN** (equivalent to Σ₁ via duality) |
+| Π₂ (∀∃)           | ℤ universally-existentially def. in ℚ | **PROVED** (Koenigsmann 2016) |
 
-Note: Σ₁ ⟺ ¬(Π₁ for the complement) at this level, by basic logic; the
-non-trivial gap is Σ₁ vs Π₂.
+The Σ₁ ⟺ Π₁(complement) equivalence is now proved in this file as
+`diophantine_iff_codiophantine_complement` (and its specialization
+`integers_diophantine_iff_complement_codiophantine`), formalizing the
+narrative claim. The non-trivial open gap is Σ₁ vs Π₂.
 
 ## Why this distinction matters
 
@@ -209,6 +291,9 @@ non-trivial gap is Σ₁ vs Π₂.
 - A positive Σ₁ answer would be a constructive polynomial witness; a
   negative answer would likely come from a structural theorem on the
   topological / Brauer–Manin geometry of ℚ-points.
+- The Π₁(complement) reformulation is sometimes more tractable for a
+  putative refutation: a Π₁ definition of ℚ \ ℤ would mean a polynomial
+  P(q, x) such that q ∉ ℤ ⟺ ∃ x rational with P(q,x) = 0.
 
 ## Axioms in THIS file (1 net new)
 
@@ -216,24 +301,30 @@ non-trivial gap is Σ₁ vs Π₂.
      (proved in Koenigsmann 2016; axiomatized pending Lean formalization
      of the explicit Hilbert-symbol polynomial witness).
 
-The two `theorem`s `integers_diophantine_sigma1_implies_h10_q_undecidable`
-and `mazur_implies_not_sigma1_definable` are NOT new axioms — they are
-logical consequences of the OQ-01 axioms and the Σ₁ ↔ existing-formulation
-equivalence proved here.
+All other declared `theorem`s are NOT new axioms — they are logical
+consequences of the OQ-01 axioms and the Σ₁ ↔ existing-formulation /
+Σ₁ ↔ Π₁(complement) equivalences proved here.
 
-## Theorems in THIS file (4)
+## Theorems in THIS file (8)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
   - `integers_diophantine_strengthens_koenigsmann` (positive answer ⟹ Π₂)
   - `integers_diophantine_sigma1_implies_h10_q_undecidable` (re-export)
   - `mazur_implies_not_sigma1_definable` (re-export)
+  - `diophantine_iff_codiophantine_complement` (Σ₁/Π₁ duality, general)
+  - `integers_diophantine_iff_complement_codiophantine` (specialization to ℤ)
+  - `codiophantine_complement_implies_h10_q_undecidable` (Π₁(ℚ\ℤ) re-export)
+  - `mazur_implies_not_codiophantine_complement` (Π₁(ℚ\ℤ) re-export)
 -/
 
 #check @IsDiophantineDefinition
 #check @IsUniversalExistentialDefinition
+#check @IsCoDiophantineDefinition
 #check @koenigsmann_2016_universal
 #check @integers_diophantine_iff
 #check @diophantine_implies_universal_existential
+#check @diophantine_iff_codiophantine_complement
+#check @integers_diophantine_iff_complement_codiophantine
 
 end Hilbert10Rationals

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -1,0 +1,62 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-05-08T03:30:00Z
+**Iteration**: 2
+
+## Current Focus
+
+Adding the Σ₁/Π₁ duality layer to the existing Σ₁ vs Π₂ framework. The
+file already encodes Σ₁ (open) vs Π₂ (Koenigsmann 2016, axiomatized) on
+ℤ ⊂ ℚ. The narrative claims "Σ₁ ⟺ ¬(Π₁ for the complement)" but did not
+formalize it. Closing that gap with axiom-free additions.
+
+## Active Approach
+
+S2 — Π₁ definability + classical duality:
+
+1. Define `IsCoDiophantineDefinition` (Π₁, purely universal definability).
+2. Define `NotIntSubset = ℚ \ ℤ` as a predicate.
+3. Prove `diophantine_iff_codiophantine_complement` — the general Σ₁/Π₁
+   duality theorem (one classical step on the Π₁ → Σ₁ direction via
+   `Classical.byContradiction`).
+4. Specialize to ℤ as `integers_diophantine_iff_complement_codiophantine`.
+5. Re-export the OQ-01 conditionals (H10/ℚ-undecidability, Mazur) against
+   the new Π₁(ℚ\ℤ) predicate — pure logical consequences, no new axioms.
+
+Net new content: 2 definitions, 4 theorems, 0 new axioms.
+
+## Build Status
+
+Docker build: PENDING (running) — file uses Lean core only, no mathlib;
+fast build expected.
+
+First attempt failed because `by_contra` in Lean core requires `Decidable`
+(this file has no mathlib import). Fixed by switching to explicit
+`Classical.byContradiction` with type ascription on the negated
+hypotheses (forces beta reduction of `(fun q => ¬ S q) q ↔ ¬ S q`).
+
+## Blockers
+
+None.
+
+## Next Action
+
+Verify the Docker build passes; commit, push, create PR.
+
+If Σ₁/Π₁ duality lands cleanly, S3 candidates:
+- Σ₁ × Π₁ closure properties (under finite union/intersection) for the
+  Diophantine sets of ℚ.
+- Π₁ ⊆ Π₂ via the `a ≠ 0 ⟺ ∃ z, a·z = 1` polynomial-inversion trick
+  (cleaner once we have a `Field`-like API; would require minor
+  arithmetic lemmas about ℚ).
+- Daans 2021 (10-quantifier reduction) as a separate axiomatized witness
+  refining `koenigsmann_2016_universal` — would add 1 new axiom but
+  improve quantitative content; defer until Σ₁/Π₁ lands.
+
+## Attempt Counts
+
+- Total attempts: 2
+- Current approach attempts: 1 (build fix from `by_contra` to
+  `Classical.byContradiction`)
+- Approaches tried: 1 (S2 — Σ₁/Π₁ duality)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -25,24 +25,30 @@
     "originalContributions": [
       "IsDiophantineDefinition: Σ₁ (purely existential) definability of subsets of ℚ",
       "IsUniversalExistentialDefinition: Π₂ (∀∃, universal-existential) definability of subsets of ℚ",
+      "IsCoDiophantineDefinition: Π₁ (purely universal) definability of subsets of ℚ",
       "IntegersAreDiophantineOverQ: explicit Σ₁ form of the OPEN question, ↔-equivalent to OQ-01's IntegersDiophantineOverQ",
+      "NotIntSubset: ℚ \\ ℤ as a predicate on ℚ",
       "koenigsmann_2016_universal: Π₂-definability of ℤ in ℚ as an axiomatized witness of Koenigsmann (Annals 2016)",
       "diophantine_implies_universal_existential: Σ₁ ⊆ Π₂ — every Diophantine subset is universally-existentially definable",
+      "diophantine_iff_codiophantine_complement: Σ₁/Π₁ duality — S is Σ₁-definable iff its complement is Π₁-definable (formalizes the narrative claim 'Σ₁ ⟺ ¬(Π₁ for the complement)')",
+      "integers_diophantine_iff_complement_codiophantine: specialization of the duality to ℤ ⊂ ℚ — the OPEN Σ₁ question is equivalent to Π₁-definability of ℚ \\ ℤ",
+      "codiophantine_complement_implies_h10_q_undecidable: Π₁(ℚ\\ℤ) → ¬H10/ℚ-decidable, re-export against the Π₁ predicate (no new axiom)",
+      "mazur_implies_not_codiophantine_complement: Mazur conjecture → ¬Π₁(ℚ\\ℤ), re-export against the Π₁ predicate (no new axiom)",
       "integers_diophantine_sigma1_implies_h10_q_undecidable: re-export of the MRDP-reduction implication against the Σ₁ predicate",
       "mazur_implies_not_sigma1_definable: re-export of Mazur's-conjecture-rules-out-Σ₁ implication"
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 239,
+    "lineCount": 330,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
       "Basic computability (rational polynomial evaluation)"
     ],
-    "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. The two further conditional results (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁) are NOT new axioms — they are logical consequences of the OQ-01 axioms via the Σ₁ ↔ existing-formulation equivalence proved in this file.",
+    "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ duality and its specialization to ℤ ⊂ ℚ, and the Π₁(ℚ\\ℤ) re-exports) are NOT new axioms — they are logical consequences of the OQ-01 axioms and the Σ₁/Π₁ equivalences proved here. The duality direction Π₁(¬S) → Σ₁(S) uses one classical excluded-middle step.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
-    "definitionCount": 5
+    "theoremCount": 9,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -54,7 +60,8 @@
       "Koenigsmann (Annals 2016) settled $\\Pi_2$: $\\mathbb{Z}$ is $\\forall\\exists$-definable in $\\mathbb{Q}$ via an explicit Hilbert-symbol/quaternion polynomial",
       "$\\Sigma_1$ remains open and is precisely the form whose positive answer would yield H10/ℚ undecidable",
       "$\\Sigma_1 \\subseteq \\Pi_2$ is trivial (any existential formula is also $\\forall\\exists$ with a dummy universal block); the reverse is the open content",
-      "Mazur's conjecture refutes $\\Sigma_1$ but is consistent with $\\Pi_2$ — clarifying why the conjecture does not contradict Koenigsmann"
+      "Mazur's conjecture refutes $\\Sigma_1$ but is consistent with $\\Pi_2$ — clarifying why the conjecture does not contradict Koenigsmann",
+      "$\\Sigma_1$/$\\Pi_1$ duality: a subset is $\\Sigma_1$-definable iff its complement is $\\Pi_1$-definable (proved as `diophantine_iff_codiophantine_complement`); specializing to $\\mathbb{Z}$ yields the equivalent reformulation 'is $\\mathbb{Q} \\setminus \\mathbb{Z}$ $\\Pi_1$-definable in $\\mathbb{Q}$?' — sometimes more amenable to refutation arguments"
     ],
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
@@ -102,15 +109,22 @@
       "id": "consequences",
       "title": "Consequences: H10/ℚ Undecidability and Mazur's Conjecture",
       "startLine": 161,
-      "endLine": 200,
+      "endLine": 186,
       "summary": "Re-exports the OQ-01 conditionals against the Σ₁ predicate: `integers_diophantine_sigma1_implies_h10_q_undecidable` (Σ₁ → ¬decidable) and `mazur_implies_not_sigma1_definable` (Mazur → ¬Σ₁). Both are logical consequences of the OQ-01 axioms via `integers_diophantine_iff`, NOT new axioms."
+    },
+    {
+      "id": "duality",
+      "title": "Π₁ Definability and the Σ₁/Π₁ Duality",
+      "startLine": 187,
+      "endLine": 267,
+      "summary": "Defines `IsCoDiophantineDefinition` (Π₁ — purely universal definability) and the helper `NotIntSubset = ℚ \\ ℤ`. Proves `diophantine_iff_codiophantine_complement` (general Σ₁/Π₁ duality, formalizing the narrative claim 'Σ₁ ⟺ ¬(Π₁ for the complement)'), specializes to ℤ as `integers_diophantine_iff_complement_codiophantine`, and re-exports the H10/ℚ-undecidability and Mazur consequences against the new Π₁(ℚ\\ℤ) predicate. All theorems axiom-free; the duality direction Π₁(¬S) → Σ₁(S) uses one classical excluded-middle step (`Classical.byContradiction`)."
     },
     {
       "id": "landscape",
       "title": "The Sharpened Landscape",
-      "startLine": 201,
-      "endLine": 239,
-      "summary": "Status table summarizing Σ₁ (open), Π₁ (open, equivalent to Σ₁ for the complement), Π₂ (proved by Koenigsmann). Lists this file's 1 net new axiom and 5 theorems, with #check commands for the main definitions and theorems."
+      "startLine": 268,
+      "endLine": 330,
+      "summary": "Status table summarizing Σ₁ (open), Π₁(ℚ\\ℤ) (open, now formally equivalent to Σ₁ via `integers_diophantine_iff_complement_codiophantine`), Π₂ (proved by Koenigsmann). Lists this file's 1 net new axiom and 9 theorems, with #check commands for the main definitions and theorems including the new Π₁ predicate and duality."
     }
   ],
   "crossReferences": [
@@ -136,7 +150,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This file refines the OQ-01 framework with the precise Σ₁/Π₂ distinction that captures the mathematical content separating the open question from Koenigsmann's 2016 Annals theorem. With 1 axiom (Koenigsmann's Π₂ result, proved in 2016 and pending Lean formalization of the explicit polynomial witness) and 5 theorems re-exporting the OQ-01 conditionals against the new Σ₁ predicate, it provides the formal vocabulary in which 'is ℤ purely Diophantine over ℚ' becomes a well-posed Lean statement.",
+    "summary": "This file refines the OQ-01 framework with the precise Σ₁/Π₂ distinction that captures the mathematical content separating the open question from Koenigsmann's 2016 Annals theorem, and adds an explicit Σ₁/Π₁ duality (general and specialized to ℤ ⊂ ℚ). With 1 axiom (Koenigsmann's Π₂ result, proved in 2016 and pending Lean formalization of the explicit polynomial witness) and 9 theorems — including the duality `diophantine_iff_codiophantine_complement` and its specialization showing the OPEN Σ₁ question is equivalent to Π₁-definability of ℚ \\ ℤ — it provides the formal vocabulary in which 'is ℤ purely Diophantine over ℚ' becomes a well-posed Lean statement reachable from either the Σ₁ or Π₁(complement) angle.",
     "implications": "A positive answer to the Σ₁ question would strengthen Koenigsmann (we prove this strengthening as `integers_diophantine_strengthens_koenigsmann`) and would resolve H10/ℚ negatively. A negative answer (e.g., via Mazur's conjecture) would NOT settle H10/ℚ but would close this specific reduction route.",
     "openQuestions": [
       "Resolve the Σ₁ question: does $\\mathbb{Z}$ admit a purely Diophantine definition in $\\mathbb{Q}$?",
@@ -152,10 +166,10 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 239,
+    "lineCount": 330,
     "axiomCount": 1,
-    "theoremCount": 5,
-    "definitionCount": 5,
+    "theoremCount": 9,
+    "definitionCount": 7,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },
@@ -221,6 +235,21 @@
       "name": "diophantine_implies_universal_existential",
       "type": "theorem",
       "description": "Σ₁ ⊆ Π₂: every Diophantine subset is universally-existentially definable"
+    },
+    {
+      "name": "IsCoDiophantineDefinition",
+      "type": "definition",
+      "description": "Π₁ (purely universal) definability of subsets of ℚ"
+    },
+    {
+      "name": "diophantine_iff_codiophantine_complement",
+      "type": "theorem",
+      "description": "Σ₁/Π₁ duality: S is Σ₁-definable iff its complement is Π₁-definable"
+    },
+    {
+      "name": "integers_diophantine_iff_complement_codiophantine",
+      "type": "theorem",
+      "description": "ℤ is Σ₁-definable in ℚ ↔ ℚ \\ ℤ is Π₁-definable in ℚ — the OPEN question reformulated on the complement"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Adds a Π₁ (purely universal) definability layer to the existing Σ₁/Π₂
framework for "is ℤ Diophantine over ℚ" (Hilbert's 10th over ℚ — the
open question OQ-01-OQ-02).

The file's introduction asserts that "Σ₁ ⟺ ¬(Π₁ for the complement)"
but never formalized it. This PR fills that gap: it adds the Π₁
predicate, proves the general Σ₁/Π₁ duality theorem, specializes it to
ℤ ⊂ ℚ, and re-exports the H10/ℚ-undecidability and Mazur-conjecture
implications against the new Π₁(ℚ\ℤ) predicate.

## Mathematical content

| Class | Statement on ℤ ⊂ ℚ | Status (2026) |
|-------|--------------------|----------------|
| Σ₁    | ℤ Diophantine over ℚ                  | **OPEN** (THIS PROBLEM) |
| Π₁    | ℚ \ ℤ Π₁-definable over ℚ              | **OPEN** (now proved equivalent to Σ₁ via duality) |
| Π₂    | ℤ universally-existentially def. in ℚ | **PROVED** (Koenigsmann 2016) |

The Π₁(complement) reformulation is sometimes more amenable to
refutation arguments (Mazur 1992 → ¬Σ₁ becomes Mazur → ¬Π₁(ℚ\ℤ) by
specialization, which is closer to the topological-density form of the
original conjecture).

## What's new

**Definitions (2):**
- `IsCoDiophantineDefinition` — Π₁ (purely universal) definability of subsets of ℚ
- `NotIntSubset` — ℚ \ ℤ as a predicate on ℚ

**Theorems (4, all axiom-free):**
- `diophantine_iff_codiophantine_complement` — general Σ₁/Π₁ duality
- `integers_diophantine_iff_complement_codiophantine` — specialization to ℤ
- `codiophantine_complement_implies_h10_q_undecidable` — Π₁(ℚ\ℤ)-version of the H10/ℚ-undecidability re-export
- `mazur_implies_not_codiophantine_complement` — Π₁(ℚ\ℤ)-version of the Mazur-rules-out re-export

**Axiom count: unchanged** (still 1: `koenigsmann_2016_universal`).
All four new theorems are pure logical consequences of existing OQ-01
axioms via the new Σ₁/Π₁ equivalence. The Π₁(¬S) → Σ₁(S) direction
uses one classical excluded-middle step via explicit
`Classical.byContradiction` (Lean core's `by_contra` requires
`Decidable`, which this Mathlib-free file does not import).

## File metrics

| Metric | Before | After |
|--------|--------|-------|
| lineCount | 239 | 330 |
| theoremCount | 5 | 9 |
| definitionCount | 5 | 7 |
| axiomCount | 1 | 1 |
| sorries | 0 | 0 |

## Test plan

- [x] `LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02` succeeded (file uses Lean core only — no Mathlib imports)
- [x] `meta.json` updated: lineCount, theoremCount, definitionCount, originalContributions (+5 entries), mainTheorems (+3), keyInsights (+1), assumptions narrative, conclusion summary, sections (+1 "duality")
- [x] No new axioms introduced
- [x] `state.md` documents the S2 approach and S3 candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)