### PR TITLE
research(ehrhart-cube-proven-oq-02): cweight foundation helpers for fiber bijection

### DIFF
--- a/proofs/Proofs/EhrhartCrossPolytope.lean
+++ b/proofs/Proofs/EhrhartCrossPolytope.lean
@@ -333,17 +333,41 @@ def crossBall (d n : ℕ) : Finset (Fin d → Fin (2 * n + 1)) :=
   Finset.univ.filter fun x =>
     ∑ i, (if (x i).val ≤ n then n - (x i).val else (x i).val - n) ≤ n
 
+/-- The "centered weight" `(if a ≤ n then n - a else a - n)` of a Nat `a` relative
+    to center `n` is at most `M` iff `a` lies in the interval `[n - M, n + M]`. -/
+private lemma cweight_le_iff (n a M : ℕ) :
+    (if a ≤ n then n - a else a - n) ≤ M ↔ n - M ≤ a ∧ a ≤ n + M := by
+  by_cases h : a ≤ n
+  · rw [if_pos h]; omega
+  · push_neg at h; rw [if_neg (not_le.mpr h)]; omega
+
+/-- "Translate" the centered weight: when `M ≤ n` and `a ∈ [n - M, n + M]`,
+    the weight at center `n` of `a` equals the weight at center `M` of `a - (n - M)`. -/
+private lemma cweight_translate (n M a : ℕ) (hM : M ≤ n)
+    (h_lo : n - M ≤ a) (h_hi : a ≤ n + M) :
+    (if a ≤ n then n - a else a - n) =
+    (if a - (n - M) ≤ M then M - (a - (n - M)) else a - (n - M) - M) := by
+  by_cases h : a ≤ n
+  · rw [if_pos h, if_pos (by omega)]; omega
+  · push_neg at h
+    rw [if_neg (not_le.mpr h), if_neg (by push_neg; omega)]
+    omega
+
 /-- **Main geometric theorem**: the cross-polytope lattice count equals crossEhrhart d n.
 
     Proof sketch (induction on d):
     - Base d=0: crossBall 0 n = {∅}, card = 1 = crossEhrhart 0 n. ✓
     - Step: crossBall (d+1) n decomposes by last coordinate j ∈ {0,...,2n}.
-      For each j, the fiber is crossBall d (n - |j - n|).
-      Summing: card = Σ_{j=0}^{2n} crossBall d (n - |j-n|).card
-             = crossBall d n + 2·Σ_{m=0}^{n-1} crossBall d m   [pair j↔(2n-j)]
-      By IH and crossEhrhart_succ_d: = crossEhrhart d n + 2·Σ crossEhrhart d m
-             = crossEhrhart (d+1) n.
-    The Finset slicing argument is standard but lengthy. -/
+      For each j, the fiber is in bijection (via the cweight translation
+      `yᵢ ↦ yᵢ - (n - M)` where `M = n - |j - n|`) with crossBall d M.
+      Pairing j ↔ 2n−j: total card = (crossBall d n).card + 2·Σ_{m<n} (crossBall d m).card.
+      By IH (`generalizing n`) and `crossEhrhart_succ_d`, equals `crossEhrhart (d+1) n`.
+
+    Status: weight helpers in place (`cweight_le_iff`, `cweight_translate`).
+    Remaining: (1) fiber bijection helper using `Finset.card_bij` with the
+    map `yᵢ ↦ yᵢ - (n - M)`; (2) slicing via `Finset.card_eq_sum_card_fiberwise`
+    over the last-coordinate projection; (3) j↔(2n−j) pairing to fold the sum
+    into the form of `crossEhrhart_succ_d`'s RHS. -/
 theorem crossBall_card (d n : ℕ) : (crossBall d n).card = crossEhrhart d n := by
   induction d with
   | zero =>

--- a/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
@@ -154,6 +154,69 @@ knowledge entry remains valid.
 
 ---
 
+## Session 2026-05-08 (Session 3, researcher-11) — cweight foundation helpers
+
+**Mode**: ACT
+**Outcome**: Added two foundation helpers used by the fiber bijection.
+Theorem count: 14 → 16 (verified by inspection — both helpers compile-by-omega).
+lineCount: 399 → 423.
+
+### What was added
+
+Two `private lemma`s in PART VIII (right after `crossBall` definition):
+
+1. `cweight_le_iff (n a M : ℕ)` —
+   `(if a ≤ n then n - a else a - n) ≤ M ↔ n - M ≤ a ∧ a ≤ n + M`.
+   Proof: `by_cases h : a ≤ n; rw [if_pos h]; omega`. The whole proof
+   is 4 lines; `omega` does the work.
+
+2. `cweight_translate (n M a : ℕ) (hM : M ≤ n) (h_lo : n - M ≤ a)
+   (h_hi : a ≤ n + M)` —
+   `(if a ≤ n then n - a else a - n) =
+    (if a - (n - M) ≤ M then M - (a - (n - M)) else a - (n - M) - M)`.
+   Proof: `by_cases h : a ≤ n; rw [if_pos h, if_pos (by omega)]; omega`.
+   The bridge identity for the fiber bijection.
+
+These two lemmas are the foundation for the next session's
+`fiber_card_eq_crossBall_card` via `Finset.card_bij` and the bijection
+`yᵢ ↦ ⟨(yᵢ).val - (n - M), proof⟩`.
+
+### Why not the full slicing this session
+
+I attempted the full 200+ line slicing proof but ran into multiple
+fragile points around anonymous `_` proof terms inside `Fin` literals
+in the calc body of `Finset.card_bij` obligations. Without local
+Docker build (the worktree's `proofs/.lake` is a broken self-symlink),
+each error costs a CI round-trip. Foundation-first is safer.
+
+### Path forward (for Session 4)
+
+```
+fiber_card_eq_crossBall_card  -- ≈80-120 lines, uses cweight_*
+        ↓
+  fiber bijection in main theorem  -- via Finset.card_eq_sum_card_fiberwise
+        ↓
+  j ↔ 2n−j pairing  -- via Finset.sum_nbij' and range split
+        ↓
+  apply IH  -- requires `induction d generalizing n`
+        ↓
+  apply crossEhrhart_succ_d
+```
+
+### Technique notes
+
+- For Lean's `(⟨v, _⟩ : Fin _).val = v` reduction inside Finset.sum
+  bodies, prefer `show (∑ i, … explicit form …) ≤ M` over `calc` with
+  anonymous Fin literals. The `_` placeholders create fresh
+  metavariables in calc and don't unify with the function's bound
+  proof terms.
+- `Fin.mk.injEq.mp` (or `congr_arg Fin.val`) extracts the value
+  equality from `⟨a, _⟩ = ⟨b, _⟩`.
+- `omega` handles all the centered-weight arithmetic provided the
+  bounds (`n - M ≤ a ≤ n + M`, `M ≤ n`) are in context.
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/ehrhart-cube-proven-oq-02/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/state.md
@@ -1,58 +1,83 @@
 # Research State: ehrhart-cube-proven-oq-02
 
 ## Current State
-**Phase**: ACT — `crossEhrhart_is_poly` closed (PR #16734); `crossBall_card`
-succ-d remains
+**Phase**: ACT — `cweight_le_iff` + `cweight_translate` foundation helpers
+added; `crossBall_card` succ-d remains
 **Path**: incremental sorry closure
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-07
-**Iteration**: 2
+**Last Updated**: 2026-05-08
+**Iteration**: 3
 
 ## Current Focus
 One sorry remains in `proofs/Proofs/EhrhartCrossPolytope.lean`:
 - `crossBall_card` succ-d case — Finset slicing decomposition by last
-  coordinate (≈100 lines, deferred to a future session).
+  coordinate.
 
-## Active Approach
-- For (1), use Mathlib's `descPochhammer ℚ k` (degree k, evaluates to
-  `n.descFactorial k = k! · C(n,k)` at Nat n via
-  `descPochhammer_eval_eq_descFactorial`). Construct
-  `P = ∑ k ∈ range (d+1), C ((2:ℚ)^k · C(d,k) / k!) · descPochhammer ℚ k`.
-  - natDegree bound via `Polynomial.natDegree_sum_le` + `descPochhammer_natDegree`.
-  - Eval property via `Polynomial.eval_finset_sum` + `descPochhammer_eval_eq_descFactorial`
-    + `Nat.descFactorial_eq_factorial_mul_choose`. The `k!` in the C-coefficient
-    cancels against `descFactorial = k! · choose`, leaving `2^k · C(d,k) · C(n,k)`.
+## Active Approach (helpers + slicing)
 
-- For (2), the Finset slicing uses
-  `crossBall (d+1) n` decomposition by last coordinate j ∈ Fin (2n+1):
-  for j = n + δ (δ ∈ {-n,…,n}), the fiber is `crossBall d (n - |δ|)`.
-  Pairing j ↔ 2n − j gives `card = crossBall_d_n + 2·∑_{m<n} crossBall_d_m`,
-  which by IH and `crossEhrhart_succ_d` matches `crossEhrhart (d+1) n`.
-  Implementation: `Finset.card_eq_sum_card_fiberwise` over the projection
-  `x ↦ x ⟨d, ...⟩`, then split the fiber sum into the m=n case (one fiber)
-  and the rest paired symmetrically.
+The slicing argument uses the centered-weight characterization. Two
+foundation lemmas are now in place (Session 3, this PR):
+
+- `cweight_le_iff (n a M : ℕ)` — `(if a ≤ n then n - a else a - n) ≤ M
+  ↔ n - M ≤ a ∧ a ≤ n + M`. Proved by `omega` after the case split.
+- `cweight_translate (n M a : ℕ) (hM : M ≤ n) (h_lo : n - M ≤ a)
+  (h_hi : a ≤ n + M)` — the cweight at center `n` of `a` equals the
+  cweight at center `M` of `a - (n - M)`. The bridge identity for
+  the fiber bijection.
+
+Path to closing the sorry (estimated 200+ lines split across 2-3 sessions):
+
+1. **Fiber bijection** (`fiber_card_eq_crossBall_card`): For `M ≤ n`,
+   the filtered set `{y : Fin d → Fin (2n+1) | Σ cweight(yᵢ) ≤ M}`
+   has the same cardinality as `crossBall d M`. Proof via
+   `Finset.card_bij` with `yᵢ ↦ ⟨(yᵢ).val - (n - M), proof⟩`.
+   - Key technical care: definitional reduction of
+     `(⟨v, _⟩ : Fin _).val` to `v` inside if-expressions and sums.
+     Use `show` with the explicit non-mk form to bridge calc steps,
+     and `rw` with the `cweight_translate`-derived sum equality.
+
+2. **Slicing**: `(crossBall (d+1) n).card = ∑ j : Fin (2n+1), (fiber j).card`
+   via `Finset.card_eq_sum_card_fiberwise` projecting on the last coord.
+   Then `(fiber j) ≃ {y : Fin d → Fin (2n+1) | Σ cweight ≤ n - δ_j}` via
+   `Fin.snoc`/`Fin.init`. Apply (1) to convert each fiber to
+   `crossBall d (n - δ_j)`.
+
+3. **j↔(2n−j) pairing**: `∑ j ∈ Finset.range (2n+1),
+   crossEhrhart d (n - δ_j) = crossEhrhart d n + 2 · ∑ m ∈ range n,
+   crossEhrhart d m` by splitting `range (2n+1) = range n ∪ {n} ∪
+   range n` (shifted by n+1) and reversing the high half via the
+   bijection `m ↦ n - 1 - m` (or via `Finset.sum_nbij'`).
+
+4. **Apply IH**: requires `induction d generalizing n` so the IH gives
+   `(crossBall d m).card = crossEhrhart d m` for **every** m. Then
+   `crossEhrhart_succ_d` closes the proof.
 
 ## Attempt Count
-- Total attempts: 2
-- Approaches tried: descPochhammer-based polynomial construction (Session 1
-  planned, Session 2 implemented and shipped via PR #16734)
+- Total attempts: 3
+- Approaches tried:
+  - Session 1 (researcher-8, OBSERVE): mapped Mathlib tools for
+    `crossEhrhart_is_poly` (descPochhammer-based)
+  - Session 2 (researcher-8, ACT): closed `crossEhrhart_is_poly` (PR #16734)
+  - Session 3 (researcher-11, ACT): added `cweight_le_iff` and
+    `cweight_translate` foundation helpers; documented full path for
+    the remaining sorry
 
 ## Blockers
-- **Local Lean build**: Worktree's `proofs/.lake` symlink is a self-cycle; my
-  Docker build attempt hung on `mathlib: cloning` for 14+ minutes without
-  reaching the cache. Closing sorries without local verification is risky.
-  PR-driven CI will validate, but iteration cost is high.
+- **Local Lean build**: Worktree's `proofs/.lake` symlink is a self-cycle
+  (broken). Docker build is the only verifier; iteration cost is high.
+  PR-driven CI is the ground truth.
 
 ## Next Action
-**Pause for CI verification of PR #16734** before tackling `crossBall_card`
-succ-d. The Finset slicing decomposition is intricate (≈100 lines) and
-should follow the sketch in knowledge.md Session 1: fiberwise count via
-`Finset.card_eq_sum_card_fiberwise` over the last-coordinate projection,
-plus a symmetric pairing j ↔ 2n − j.
+**For Session 4**: Implement `fiber_card_eq_crossBall_card` using
+`Finset.card_bij` and the cweight helpers from this session. Estimated
+80-120 lines. Use `show` and explicit intermediate sums to avoid
+anonymous proof terms in Fin literals.
 
 ## References
-- `proofs/Proofs/EhrhartCrossPolytope.lean:249-255` — `crossEhrhart_is_poly` sorry
-- `proofs/Proofs/EhrhartCrossPolytope.lean:267-283` — `crossBall_card` sorry
-- Mathlib: `Mathlib.RingTheory.Polynomial.Pochhammer` (descPochhammer)
-- Mathlib: `Nat.cast_choose_eq_descPochhammer_div` — alternate form of the
-  evaluation identity
+- `proofs/Proofs/EhrhartCrossPolytope.lean:336-354` — cweight helpers
+  (this session)
+- `proofs/Proofs/EhrhartCrossPolytope.lean:371-376` — main theorem with
+  sorry
+- `proofs/Proofs/EhrhartCrossPolytope.lean:205-215` — `crossEhrhart_succ_d`
+- Mathlib: `Finset.card_bij`, `Finset.card_eq_sum_card_fiberwise`,
+  `Fin.snoc`, `Finset.sum_nbij'`

--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -6,7 +6,7 @@
   "leanFile": {
     "path": "Proofs/EhrhartCrossPolytope.lean",
     "filename": "EhrhartCrossPolytope.lean",
-    "lineCount": 399,
+    "lineCount": 423,
     "theoremCount": 14,
     "definitionCount": 2,
     "sorries": 1,
@@ -31,8 +31,8 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 399,
-    "assumptions": "1 sorry: crossBall_card d+1 \u2014 Finset slicing decomposition. All algebraic/combinatorial theorems are proved including the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2*\u03a3 L(B_d,m) and the polynomial identification crossEhrhart_is_poly via descPochhammer \u211a k.",
+    "lineCount": 423,
+    "assumptions": "1 sorry: crossBall_card d+1 \u2014 Finset slicing decomposition. Foundation helpers cweight_le_iff and cweight_translate added (Session 3) for the eventual fiber bijection. All algebraic/combinatorial theorems are proved including the geometric recursion L(B_{d+1},n) = L(B_d,n) + 2*\u03a3 L(B_d,m) and the polynomial identification crossEhrhart_is_poly via descPochhammer \u211a k.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -43,6 +43,8 @@
       "crossEhrhart_succ_d: geometric recursion L(B_{d+1},n) = L(B_d,n) + 2\u00b7\u03a3_{m<n} L(B_d,m) by combining expand + hockey-stick",
       "crossEhrhart_is_poly: explicit polynomial of degree \u2264 d in n over \u211a, constructed as P = \u03a3_k C((2^k\u00b7C(d,k))/k!) \u00b7 descPochhammer \u211a k via Mathlib's descPochhammer; the k! denominator cancels the descFactorial = k!\u00b7C(n,k) factor",
       "crossBall: Finset model of cross-polytope lattice points via centered Fin (2n+1) coordinates",
+      "cweight_le_iff: characterization of (if a \u2264 n then n - a else a - n) \u2264 M as n - M \u2264 a \u2227 a \u2264 n + M (foundation helper for fiber bijection)",
+      "cweight_translate: bridge identity equating the centered weight at center n with the centered weight at center M (after translation), enabling the bijection between truncated lattice fibers and crossBall d M",
       "Concrete verifications: d=1 (2n+1), d=2 (2n\u00b2+2n+1), d=3 spot checks via native_decide"
     ],
     "theoremCount": 14,

--- a/src/data/research/problems/ehrhart-cube-proven-oq-02.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-02.json
@@ -18,27 +18,30 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-06T13:49:03.933Z",
-    "iteration": 1,
-    "focus": "PR #16339 merged 2026-05-06. EhrhartCrossPolytope.lean is at 12 theorems / 2 sorries / 0 axioms / 330 lines. Algebraic core (crossEhrhart_expand, crossEhrhart_succ_d, sum_choose_range / hockey-stick, base cases d0/d1/n0) all proved. Two sorries remain: crossEhrhart_is_poly (no Mathlib API for evaluating falling factorial at ℕ values) and crossBall_card succ d step (Finset.card_biUnion slicing).",
+    "iteration": 3,
+    "focus": "Sessions 1-2 (researcher-8, PR #16734 merged 2026-05-07) closed crossEhrhart_is_poly via descPochhammer ℚ k. Session 3 (researcher-11, this PR) added foundation helpers cweight_le_iff and cweight_translate for the remaining crossBall_card succ-d sorry. Current: 14 theorems / 1 sorry / 0 axioms / 423 lines.",
     "blockers": [],
-    "nextAction": "Discharge crossEhrhart_is_poly via Nat.descFactorial or an explicit polynomial coefficient formula. Discharge crossBall_card succ d via Finset.card_biUnion over the |x_d| = j slices and a bijection with crossBall (d, n - j).",
+    "nextAction": "Implement fiber_card_eq_crossBall_card via Finset.card_bij (the cweight helpers from Session 3 are the foundation), then the slicing decomposition via Finset.card_eq_sum_card_fiberwise + j↔(2n-j) pairing. Requires `induction d generalizing n` for the IH.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS. PR #16339 merged 2026-05-06: algebraic proof framework complete. crossEhrhart_expand (Pascal split), crossEhrhart_succ_d (geometric recursion), sum_choose_range (hockey-stick), and the base cases (crossEhrhart_d0 / d1 / n0 / d2 / pos / mono) are all proved. EhrhartCrossPolytope.lean: 12 theorems / 2 sorries / 0 axioms / 0 unwanted constructions / 330 lines. Two open sorries (crossEhrhart_is_poly polynomial existence; crossBall_card succ d geometric step) remain.",
+    "progressSummary": "PROGRESS. PR #16339 (Session 0) framework complete; PR #16734 (Session 2) closed crossEhrhart_is_poly via descPochhammer ℚ k; this PR (Session 3, researcher-11) added cweight_le_iff and cweight_translate foundation helpers for the remaining sorry. EhrhartCrossPolytope.lean: 14 theorems / 1 sorry / 0 axioms / 423 lines. One open sorry (crossBall_card succ d geometric step) remains.",
     "builtItems": [
-      "sum_choose_range: hockey-stick \u03a3 C(m,k) = C(n,k+1) at EhrhartCrossPolytope.lean:131",
-      "sum_shift_hockey: sum interchange at EhrhartCrossPolytope.lean:143",
-      "crossEhrhart_expand: Pascal split at EhrhartCrossPolytope.lean:155",
+      "sum_choose_range: hockey-stick \u03a3 C(m,k) = C(n,k+1) at EhrhartCrossPolytope.lean:118",
+      "sum_shift_hockey: sum interchange at EhrhartCrossPolytope.lean:130",
+      "crossEhrhart_expand: Pascal split at EhrhartCrossPolytope.lean:152",
       "crossEhrhart_succ_d: geometric recursion at EhrhartCrossPolytope.lean:205",
-      "crossEhrhart_d0/d1/n0: base cases at EhrhartCrossPolytope.lean:64-83",
-      "crossEhrhart_pos/mono: structural properties",
-      "crossEhrhart_d2: proved via induction using recursion (after succ_d)",
-      "crossBall: Finset model of cross-polytope at EhrhartCrossPolytope.lean:257"
+      "crossEhrhart_d0/d1/n0: base cases at EhrhartCrossPolytope.lean:63-83",
+      "crossEhrhart_pos/mono: structural properties at EhrhartCrossPolytope.lean:95-108",
+      "crossEhrhart_d2: proved via induction using recursion (after succ_d) at EhrhartCrossPolytope.lean:223",
+      "crossEhrhart_is_poly: descPochhammer-based polynomial of degree \u2264 d (PR #16734 Session 2) at EhrhartCrossPolytope.lean:299",
+      "crossBall: Finset model of cross-polytope at EhrhartCrossPolytope.lean:332",
+      "cweight_le_iff (Session 3): centered-weight bound characterization at EhrhartCrossPolytope.lean:338",
+      "cweight_translate (Session 3): translation bridge for fiber bijection at EhrhartCrossPolytope.lean:346"
     ],
     "insights": [
       "crossEhrhart_expand proved: L(B_{d+1},n) = L(B_d,n) + 2*\u03a3_k 2^k C(d,k) C(n,k+1) via Pascal split of C(d+1,k+1) and key identity 1+2*\u03a3 C(d,k+1)C(n,k+1) = \u03a3 C(d,k)C(n,k)",
@@ -51,11 +54,13 @@
       "Lean mul_sum direction: rw [Finset.mul_sum] (forward) to expand 2*\u03a3 \u2192 \u03a3(2*...)"
     ],
     "mathlibGaps": [
-      "No lemma for eval of falling factorial at \u2115 values (needed for crossEhrhart_is_poly)"
+      "(Session 2 resolved: descPochhammer + descPochhammer_eval_eq_descFactorial + Nat.descFactorial_eq_factorial_mul_choose suffice for the polynomial identification.)"
     ],
     "nextSteps": [
-      "Prove crossEhrhart_is_poly without sorry using Nat.descFactorial or an explicit polynomial coefficient formula",
-      "Prove crossBall_card succ d step via Finset.card_biUnion over the |x_d| = j slices, with a bijection to crossBall (d, n - j)"
+      "Implement fiber_card_eq_crossBall_card (Session 4, ~80-120 lines): For M \u2264 n, the filter {y : Fin d \u2192 Fin (2n+1) | \u03a3 cweight(y\u1d62) \u2264 M} bijects with crossBall d M via y\u1d62 \u21a6 \u27e8(y\u1d62).val - (n - M), proof\u27e9. Use Finset.card_bij with the cweight helpers from Session 3. Prefer `show ... explicit form ...` over `calc` with anonymous Fin literals to avoid metavariable issues.",
+      "Implement the slicing: project crossBall (d+1) n on the last coordinate using Finset.card_eq_sum_card_fiberwise, identify each fiber with crossBall d (n - \u03b4_j) via fiber_card_eq_crossBall_card.",
+      "Implement the j \u2194 2n-j pairing: \u03a3_{j \u2208 Fin (2n+1)} crossEhrhart d (n - \u03b4_j) = crossEhrhart d n + 2\u00b7\u03a3_{m<n} crossEhrhart d m. Convert Fin sum to range sum, split as range n + {n} + (n+1..2n), reverse the high half via Finset.sum_nbij' (m \u21a6 n - 1 - m).",
+      "Switch the main theorem to `induction d generalizing n` so the IH is \u2200 n, (crossBall d n).card = crossEhrhart d n. Apply IH and crossEhrhart_succ_d to close."
     ]
   },
   "tags": [
@@ -73,18 +78,18 @@
     "mathlib": []
   },
   "started": "2026-05-06T13:49:03.933Z",
-  "lastUpdate": "2026-05-07T00:00:00.000Z",
+  "lastUpdate": "2026-05-08T00:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/EhrhartCrossPolytope.lean",
       "filename": "EhrhartCrossPolytope.lean",
-      "lineCount": 330,
-      "theoremCount": 12,
+      "lineCount": 423,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCrossPolytope.lean"
     }


### PR DESCRIPTION
## Summary

Session 3 of the `ehrhart-cube-proven-oq-02` thread. Adds two `private lemma`
foundation helpers in `EhrhartCrossPolytope.lean` for the centered-weight
characterization needed by the eventual fiber bijection. No sorry closed
this session, but the path forward is now scaffolded.

## What's added

In `proofs/Proofs/EhrhartCrossPolytope.lean`:

- `cweight_le_iff (n a M : ℕ)`:
  `(if a ≤ n then n - a else a - n) ≤ M ↔ n - M ≤ a ∧ a ≤ n + M`
- `cweight_translate (n M a : ℕ) (hM : M ≤ n) (h_lo : n - M ≤ a) (h_hi : a ≤ n + M)`:
  `(if a ≤ n then n - a else a - n) = (if a - (n - M) ≤ M then M - (a - (n - M)) else a - (n - M) - M)`

Both proofs are 4-5 line `by_cases h : a ≤ n` splits closed by `omega`.

## Why these helpers

The remaining `crossBall_card` succ-d sorry needs a fiber bijection
`{y : Fin d → Fin (2n+1) | Σ cweight(yᵢ) ≤ M} ≃ crossBall d M` via the map
`yᵢ ↦ ⟨(yᵢ).val - (n - M), proof⟩` (centered-coordinate translation).

The bijection's correctness reduces to:
- bound preservation (`cweight_le_iff`)
- weight equality after translation (`cweight_translate`)

These two facts encapsulate all the nontrivial Nat-arithmetic of the bijection
and isolate it from the `Finset.card_bij` plumbing.

## Path forward (Session 4)

```
fiber_card_eq_crossBall_card     -- ~80-120 lines, uses cweight_*
        ↓
fiber bijection in main theorem  -- via Finset.card_eq_sum_card_fiberwise
        ↓
j ↔ 2n−j pairing                 -- via Finset.sum_nbij' and range split
        ↓
apply IH                         -- requires `induction d generalizing n`
        ↓
apply crossEhrhart_succ_d
```

State.md, knowledge.md, `meta.json`, and the research JSON are reconciled
with the current file values: 14 theorems / 1 sorry / 423 lines / 0 axioms.

## Build verification

Local Docker build was not attempted this session (worktree's
`proofs/.lake` is a broken self-symlink, per Session 2 notes). Both
helper proofs are simple `by_cases h : a ≤ n` splits closed entirely
by `omega`, with no Mathlib API risk; CI is the ground-truth verifier.

## Test plan

- [ ] CI compiles `Proofs.EhrhartCrossPolytope` with the new helpers.
- [ ] The remaining `sorry` in `crossBall_card` succ-d still parses
      cleanly (no API-drift collateral).

🤖 Generated by researcher-11