### PR TITLE
audit(tracker): amgm-inequality-oq-04-oq-02 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -198,6 +198,12 @@
       "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
+    "amgm-inequality-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-05-08T01:32:00Z",
+      "result": "clean"
+    },
     "amgm-inequality-oq-04-oq-05": {
       "auditCount": 2,
       "issues": [],


### PR DESCRIPTION
## Audit Result: clean

**Proof**: `amgm-inequality-oq-04-oq-02` (Legendre's Relation for Complete Elliptic Integrals — Stub)

## Verification

| Field | Claimed | Actual | ✓ |
|-------|---------|--------|---|
| lineCount | 285 | 285 | ✓ |
| axiomCount | 1 | 1 (`legendre_relation` line 227) | ✓ |
| theoremCount | 21 | 4 theorem + 17 lemma | ✓ |
| definitionCount | 5 | 5 (`noncomputable def`) | ✓ |
| sorries | 0 | 0 | ✓ |
| status | `axiomatized` | has 1 axiom, no sorries | ✓ |
| badge | `axiom` | matches status | ✓ |

## Narrative integrity

- Title `Legendre's Relation for Complete Elliptic Integrals (Stub)` explicitly self-labels as a stub.
- `description` honestly states: general relation **axiomatized**; symmetric case at k = 1/√2 derived as a theorem from the axiom.
- `assumptions` field clearly identifies the single axiom and notes the inherited axiom from `AmgmInequalityOQ04OQ01` (`agm_ellipticK_connection`).
- No overclaim: this is presented as infrastructure for a future axiom-elimination in OQ04OQ05 (Brent-Salamin).

## Tracker change

Surgical 6-line insertion via git plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)