### PR TITLE
fix(meta): lebesgue-measure-oq-06 lineCount 1518→1517

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1518,
+    "lineCount": 1517,
     "assumptions": "1 axiom: banach_tarski main theorem (800+ lines via Hausdorff paradox + Axiom of Choice; provably unprovable in ZF alone — Solovay 1970). Declared as an explicit axiom rather than a placeholder proof so the mathematical assumption is tracked per the axiom integrity policy. All supporting lemmas fully proved: hausdorff_free_subgroup/orbit_ne (inductive proof via irrationality of sqrt 2 + ℤ[√2] invariant), free_group_paradoxical (F₂ is paradoxical under left action), free_group_not_amenable, int_amenable (Cesaro window-shift), banach_tarski_pieces_nonmeasurable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -218,7 +218,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 1518,
+    "lineCount": 1517,
     "axiomCount": 1,
     "theoremCount": 52,
     "definitionCount": 20,


### PR DESCRIPTION
## Summary

`LebesgueMeasureOQ06.lean` has 1517 lines on origin/main, but `meta.lineCount` and `leanFile.lineCount` both claim 1518.

Likely an off-by-one from a prior count-sync that used `split('\n')` instead of `\n`-count when the file ends with a trailing newline (canonical convention is `\n`-count).

Other structural counts verified against origin/main:
- theoremCount = 52 ✓
- definitionCount = 20 ✓
- axiomCount = 1 ✓
- sorries = 0 ✓

## Why find-targets missed it

`scripts/auditor/find-targets.ts` flags True-stubs, sorry mismatches, and axiom mismatches — but not `lineCount` drift. Caught via manual byte-level `\n`-count scan of all 2,396 gallery entries.

## Test plan

- [x] Manually verified `wc -l`-equivalent (`\n`-count) on origin/main matches 1517
- [x] Both `meta.lineCount` and `leanFile.lineCount` synced to 1517