### PR TITLE
fix(meta): area-of-circle-oq-03-oq-02-oq-02 theoremCount 15→5

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "Fully verified: 0 axioms, 0 sorries.",
     "lineCount": 204,
     "mathlib_version": "4.26.0",
-    "theoremCount": 15,
+    "theoremCount": 5,
     "definitionCount": 2
   },
   "overview": {
@@ -159,7 +159,7 @@
     "namespace": "AreaOfCircleOQ03OQ02OQ02",
     "lineCount": 204,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 5,
     "definitionCount": 2,
     "mainTheorems": [
       "dalzell_polynomial_identity",


### PR DESCRIPTION
## Summary

`AreaOfCircleOQ03OQ02OQ02.lean` has 5 `theorem` declarations on origin/main:

1. `dalzell_polynomial_identity`
2. `dalzell_integrand_decomposition`
3. `dalzell_integrand_nonneg`
4. `dalzell_integrand_pos`
5. `hasDerivAt_dalzellAntideriv`

Both `meta.theoremCount` and `leanFile.theoremCount` claimed 15 — an overclaim of 10.

## Origin

PR #15037 (May 3, batch fix) copied `leanFile.theoremCount=15` into `meta.theoremCount=15`. The 15 was already wrong in `leanFile` from the entry's first commit. The .lean file has only ever had 5 theorems (`git log` on the file shows 1 commit).

## Other counts (verified against origin/main)

- `lineCount` = 204 ✓
- `definitionCount` = 2 ✓
- `axiomCount` = 0 ✓
- `sorries` = 0 ✓

`leanFile.mainTheorems` lists 4 of the 5 declarations — accurate.

## Why find-targets missed it

`scripts/auditor/find-targets.ts` flags True-stubs, sorry mismatches, and axiom mismatches — not `theoremCount` drift. Caught via manual regex scan with stacked-modifier support.

## Note on conflicts

Two old (5-day) `CONFLICTING` PRs touch this file (#15030, #15056); they're stale and unlikely to land. This single-line correction is orthogonal to whatever they ultimately do.

## Test plan

- [x] Manually verified theorem regex against origin/main file: 5 matches
- [x] Both `meta.theoremCount` and `leanFile.theoremCount` synced to 5