### PR TITLE
audit(tracker): hilbert-15-oq-02 issues-found → issues-fixed (PR #16719)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11733,10 +11733,10 @@
       "result": "clean"
     },
     "hilbert-15-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-07T19:26:16Z",
-      "result": "issues-found"
+      "lastAudited": "2026-05-08T00:00:00Z",
+      "result": "issues-fixed"
     },
     "hilbert-16": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker entry for `hilbert-15-oq-02` was stuck at `result: \"issues-found\"` with an empty `issues` list since 2026-05-07. The underlying axiomCount drift (#16699: claimed 3, actual 0) was already fixed by mechanic PR #16719 (merged 2026-05-07T22:39:18Z).

## Verification (origin/main @ abb755e2a60)

- `meta.lineCount` = `lf.lineCount` = actual = 506 ✓
- `meta.theoremCount` = `lf.theoremCount` = actual = 25 ✓
- `meta.definitionCount` = `lf.definitionCount` = actual = 5 ✓
- `meta.axiomCount` = `lf.axiomCount` = actual = 0 ✓
- `sorries` = 0 ✓
- `status` = `verified`, `badge` = `original` (consistent with axiom-free)

## Change

```diff
 "hilbert-15-oq-02": {
-  "auditCount": 2,
+  "auditCount": 3,
   "issues": [],
-  "lastAudited": "2026-05-07T19:26:16Z",
-  "result": "issues-found"
+  "lastAudited": "2026-05-08T00:00:00Z",
+  "result": "issues-fixed"
 }
```

## Test plan

- [x] Re-counted theorems/defs/axioms/sorries on origin/main Lean source
- [x] Confirmed `meta` and `leanFile` blocks agree
- [x] JSON parses (entries count unchanged at 2393)