### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): removeCorner_swap + hookProd_removeCorner_swap (S47)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -4387,6 +4387,36 @@ lemma removeCorner_proof_irrel (μ : YoungDiagram) (c : ℕ × ℕ)
   apply YoungDiagram.ext
   simp [removeCorner]
 
+/-- Removing two distinct corners commutes: the diagram obtained by removing
+    `c` then `c'` equals the one obtained by removing `c'` then `c`.
+
+    Why this matters for `gnwProb_exchange`: the exchange identity relates
+    `H((μ\c')\c)` to `H(μ\c)` and `H(μ\c')`.  Writing the equation in either
+    iteration order is equivalent thanks to this commutativity, freeing the
+    proof from having to track whether `c` is removed before or after `c'`. -/
+private lemma removeCorner_swap {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne) =
+    removeCorner (removeCorner μ c' hc') c
+        (isCorner_removeCorner_of_ne hc' hc hne.symm) := by
+  apply YoungDiagram.ext
+  show (μ.cells.erase c).erase c' = (μ.cells.erase c').erase c
+  ext x
+  simp only [Finset.mem_erase]
+  tauto
+
+/-- Hook products are invariant under swapping the order of two distinct corner
+    removals.  Direct corollary of `removeCorner_swap`: equal diagrams have
+    equal hook products. -/
+private lemma hookProd_removeCorner_swap {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') :
+    hookProd (removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne)) =
+    hookProd (removeCorner (removeCorner μ c' hc') c
+        (isCorner_removeCorner_of_ne hc' hc hne.symm)) := by
+  rw [removeCorner_swap hc hc' hne]
+
 /-- For any SYT, its entries surject onto {1,...,μ.card}. -/
 private lemma syt_entry_image {μ : YoungDiagram} (T : StandardYoungTableau μ)
     (hn : 0 < μ.card) :

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s02.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s02.md
@@ -1,0 +1,106 @@
+## Session 2026-05-08 (Session 47, researcher-7) — `removeCorner_swap` + `hookProd_removeCorner_swap`
+
+**Mode**: ACT (RICH knowledge tier, score 192)
+**Outcome**: Two small structural lemmas added as preparatory infrastructure for
+`gnwProb_exchange`.  Sorry count unchanged (1).
+
+### What I Did
+
+Added two lemmas to `BallotProblemOQ03OQ01OQ02Helpers.lean` after
+`removeCorner_proof_irrel` (line ~4390):
+
+1. **`removeCorner_swap`** — for distinct corners `c, c'` of `μ`, removing them
+   in either order yields the same Young diagram:
+   ```
+   removeCorner (removeCorner μ c) c' = removeCorner (removeCorner μ c') c
+   ```
+   Proof: `YoungDiagram.ext` reduces to a `Finset` equality; the cells of the
+   nested `removeCorner` are `(μ.cells.erase c).erase c'`; the swap follows by
+   `Finset.mem_erase` on both sides plus `tauto`.
+
+2. **`hookProd_removeCorner_swap`** — direct corollary: `hookProd` of the two
+   double-removed diagrams agree.  Proof: `rw [removeCorner_swap]`.
+
+### Why this matters for `gnwProb_exchange`
+
+The exchange identity (Helpers, line 14143) involves the term
+`H((μ\c')\c)`.  In any algebraic manipulation of the identity, one is free to
+write this as `H((μ\c)\c')` because the order doesn't matter.  Without
+`removeCorner_swap` the proof has to either pick a canonical iteration order or
+re-derive commutativity inline at every algebraic step.
+
+This lemma also unlocks the natural balance interpretation of the exchange
+identity:
+```
+F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)
+                          = F(μ\c',c) · H((μ\c)\c') · H(μ)   [by removeCorner_swap]
+```
+which symmetrizes the right-hand side and makes downstream cancellations
+visible (the `H((μ\c)\c')` factor naturally pairs with `H(μ\c)` via a
+ratio formula on the corner `c'` in the diagram `μ\c`).
+
+### Position in the proof program
+
+Combined with the helpers from sessions 43-45:
+- `sum_gnwProb_eq_removeCorner_cells` (S43) — F-domain bridge
+- `strictHookCells_removeCorner_eq` (S43) — strict-hook differs only at c'
+- `sum_gnwProb_strictHookCells_eq_removeCorner` (S43) — sum bridge
+- `corner_col_lt_of_row_lt`, `doubly_affected_cell_mem` (S44)
+- `corners_fst_ne`, `corners_snd_ne`, `distinct_corners_dichotomy` (S45)
+- `hookLength_removeCorner_arm/_leg/_eq_of_not_arm_leg` (existing)
+- **`removeCorner_swap`, `hookProd_removeCorner_swap`** (this session)
+
+The infrastructure now covers:
+- F-domain (sum-over-cells) bridges
+- Sum-over-strictHookCells bridges
+- Per-cell hookLength shifts (arm/leg of one corner)
+- Corner-coordinate dichotomy
+- Diagram and hookProd commutativity for double removal
+
+What remains: the actual product algebra for `gnwProb_exchange`.  The next
+session can attempt:
+1. `dichotomy_split` — case-split via `distinct_corners_dichotomy` (WLOG
+   `c.1 < c'.1`, `c'.2 < c.2`).
+2. Decompose `μ.cells = (μ\c').cells ∪ {c'}` via
+   `sum_gnwProb_eq_removeCorner_cells`.
+3. For each `x ∈ μ\c'`:
+   - If `x` is in arm of `c'` (`x.1 = c'.1`, `x.2 < c'.2`): use
+     `hookLength_removeCorner_arm`.
+   - If `x` is in leg of `c'` (`x.1 < c'.1`, `x.2 = c'.2`): use
+     `hookLength_removeCorner_leg`.  Special-case the doubly-affected cell
+     `(c.1, c'.2)` via `doubly_affected_cell_mem`.
+   - Otherwise: use `hookLength_eq_of_not_arm_leg`.
+4. Use `gnwProb_step` / `gnwProb_stable` to align the K bound at every cell.
+5. The product `H(μ) · H((μ\c)\c')` (via `hookProd_removeCorner_swap`) factors
+   into `H(μ\c) · H(μ\c')` after applying `hookProd_ratio_formula` twice — this
+   is the key cancellation that closes the identity.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+30 lines, line count
+  14398 → 14428)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s02.md`
+  (this note)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (Iteration 47)
+
+### Sorry Count: 1 (unchanged — `gnwProb_exchange` remains)
+
+### Build Verification
+
+Not run in this session — Helpers.lean is now 14428 lines and full Docker build
+under the 32GB memory ceiling has been uncertain since session 35
+modularization.  The two new lemmas use only basic, well-tested tactics
+(`apply YoungDiagram.ext`, `show`, `ext`, `simp only [Finset.mem_erase]`,
+`tauto`, `rw`) and reference no unestablished symbols.  CI on the PR will
+verify.
+
+### Next Steps
+
+1. **Compile-check this PR via CI.**  If it succeeds, the infrastructure is
+   solid and the gnwProb_exchange attack proceeds with the plan above.
+2. If memory pressure becomes a problem, consider extracting all "structural"
+   lemmas (corner properties, removeCorner bridges, distinct-corner helpers)
+   into a separate `BallotProblemOQ03OQ01OQ02Structure.lean` file to reduce
+   the Helpers compilation footprint.
+3. Begin the `gnwProb_exchange` proof in the next session, using the
+   `dichotomy_split` plan above.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (GNW exchange-step framework wired up; corner-distinctness coordinate lemmas added; Aristotle Target 3 closed via dispatcher)
+**Phase**: ACT (GNW exchange-step framework + diagram commutativity; corner-distinctness coordinate lemmas added; Aristotle Target 3 closed via dispatcher)
 **Path**: full
 **Since**: 2026-04-21T20:08:44+02:00
 **Last Updated**: 2026-05-08
-**Iteration**: 46
+**Iteration**: 47
 
 ## Current Focus
 Close `gnwProb_exchange` (Helpers, line 14143) — the GNW 1979 exchange identity
@@ -76,14 +76,22 @@ in place:
      `ni_count_eq_syt_count_Aristotle` and `lgv_det_factors_as_hook_quotient_Aristotle`
      remain).  No new dependency is introduced; transitive dependence on
      `gnwProb_exchange` is unchanged.
+ 10. Diagram commutativity for double removal (session 47) — added
+     `removeCorner_swap` (line ~4397) and its corollary
+     `hookProd_removeCorner_swap`.  The first is a `Finset`-level identity
+     `(μ.cells.erase c).erase c' = (μ.cells.erase c').erase c` lifted to
+     `YoungDiagram` via `YoungDiagram.ext`; the second is a one-line
+     `rw` corollary.  Together they let the upcoming `gnwProb_exchange`
+     proof rewrite `H((μ\c')\c)` ↔ `H((μ\c)\c')` freely, avoiding
+     iteration-order bookkeeping at every algebraic step.
 
 ## Blockers
 - **`gnwProb_exchange` proof.** This is the GNW 1979 hook-weight shift argument.
   The proof requires showing that hookProd and the gnwProb sum transform
   predictably when one corner c' is removed. Estimated ~100 lines of careful
   case analysis on arm/leg of c vs c'.
-- **Build verification.** Helpers file is at 14398 lines; whether it
-  type-checks under Docker's 32GB memory limit (post-modularization) is
+- **Build verification.** Helpers file is at 14428 lines (was 14398); whether
+  it type-checks under Docker's 32GB memory limit (post-modularization) is
   not yet confirmed in this session. CI will verify the PR.
 
 ## Next Action
@@ -118,9 +126,12 @@ exchange step entirely (count weighted walks of every length, divide by
 - `knowledge.md` §Session 44 — anti-monotone corner helpers (PR #16648)
 - `knowledge.md` §Session 45 — corner-distinctness coordinate lemmas
 - `sessions/2026-05-08-s01.md` — Session 46: Aristotle Target 3 closed via dispatcher
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14143` — `gnwProb_exchange`
-  (sorry'd, target of next session)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14168` — `gnwProb_key`
+- `sessions/2026-05-08-s02.md` — Session 47: `removeCorner_swap` + `hookProd_removeCorner_swap`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14173` — `gnwProb_exchange`
+  (sorry'd, target of next session — line shifted by +30 from session 47 additions)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14198` — `gnwProb_key`
   (proved modulo `gnwProb_exchange`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14377` — `hook_walk_identity_gnw`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14407` — `hook_walk_identity_gnw`
   (sorry-free dispatcher, transitive on `gnwProb_exchange`)


### PR DESCRIPTION
## Summary

Session 47 of the GNW hook-walk program for `ballot-problem-oq-03-oq-01-oq-02`.

Adds two small structural lemmas to `BallotProblemOQ03OQ01OQ02Helpers.lean`:

- **`removeCorner_swap`** (line 4397) — for distinct corners `c, c'` of `μ`, removing them in either order yields the same Young diagram. Proof reduces to a `Finset` identity `(μ.cells.erase c).erase c' = (μ.cells.erase c').erase c` lifted via `YoungDiagram.ext`.
- **`hookProd_removeCorner_swap`** (line 4412) — one-line corollary: hook products commute under double-removal.

## Why this matters

The exchange identity `gnwProb_exchange` (the sole remaining sorry in this proof, line 14173) involves the term `H((μ\\c')\\c)`. Without commutativity, every algebraic manipulation has to pick a canonical iteration order or re-derive it inline. With these lemmas, the proof is free to rewrite `H((μ\\c')\\c) ↔ H((μ\\c)\\c')` and pair the latter with `H(μ\\c)` via `hookProd_ratio_formula` on the corner `c'` in the diagram `μ\\c`.

## Sorry count

**Helpers**: 1 (gnwProb_exchange) — unchanged
**Main file**: 0 — unchanged
**Aristotle**: 2 — unchanged

## Test plan

- [ ] CI verifies `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` compiles (line count 14398 → 14428)
- [ ] No new sorries introduced
- [ ] Two new lemmas use only basic, well-tested tactics: `apply YoungDiagram.ext`, `show`, `ext`, `simp only [Finset.mem_erase]`, `tauto`, `rw`

## Files changed

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+30 lines)
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s02.md` (new — session note)
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (Iteration 47, attempts list, references updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)