### PR TITLE
research(erdos-1151-oq-04): Step 6a/6b — shifted odd harmonic + sub-sum LB

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -1351,6 +1351,150 @@ private lemma chebyshev_term_lb_at_node
     _ ≤ Real.sin φ / |Real.cos θ - Real.cos φ| := by
         gcongr
 
+/-- **Step 6a (shifted odd harmonic sum lower bound).**
+
+    The shifted sub-harmonic sum `∑ⱼ₌₀^{m-1} 1/(2(j+1)+1) = ∑ⱼ₌₀^{m-1} 1/(2j+3)` is
+    bounded below by `(1/2)·log(m+2) - 1`.
+
+    Derivation: applying `odd_harmonic_sum_lb` at `m+1` gives
+    `(1/2)·log(m+2) ≤ ∑ⱼ₌₀^m 1/(2j+1)`. Splitting off the `j=0` term
+    (`1/(2·0+1) = 1`) leaves `∑ⱼ₌₀^{m-1} 1/(2(j+1)+1) ≥ (1/2)·log(m+2) - 1`. -/
+private lemma odd_harmonic_sum_shifted_lb (m : ℕ) :
+    (1 : ℝ) / 2 * Real.log ((↑m : ℝ) + 2) - 1 ≤
+      ∑ j ∈ Finset.range m, (1 : ℝ) / (2 * ((↑j : ℝ) + 1) + 1) := by
+  -- Split ∑_{j=0}^{m} 1/(2j+1) = 1 + ∑_{j=0}^{m-1} 1/(2(j+1)+1)
+  have hsplit : ∑ j ∈ Finset.range (m + 1), (1 : ℝ) / (2 * (↑j : ℝ) + 1) =
+      1 + ∑ j ∈ Finset.range m, (1 : ℝ) / (2 * ((↑j : ℝ) + 1) + 1) := by
+    rw [Finset.sum_range_succ' (fun k => (1 : ℝ) / (2 * (↑k : ℝ) + 1)) m]
+    push_cast
+    ring
+  -- Apply odd_harmonic_sum_lb at m+1
+  have hle : (1 : ℝ) / 2 * Real.log (((m + 1 : ℕ) : ℝ) + 1) ≤
+      ∑ j ∈ Finset.range (m + 1), (1 : ℝ) / (2 * (↑j : ℝ) + 1) :=
+    odd_harmonic_sum_lb (m + 1) (Nat.succ_pos m)
+  have hcast : ((m + 1 : ℕ) : ℝ) + 1 = (↑m : ℝ) + 2 := by push_cast; ring
+  rw [hcast] at hle
+  linarith
+
+/-- **Step 6b (sub-sum lower bound via per-term bound).**
+
+    Summing the per-term lower bound `chebyshev_term_lb_at_node` over indices
+    `k = k₀ + j + 1` for `j ∈ Fin m` produces a harmonic-style sub-sum lower
+    bound for the full chebyshev Lebesgue trig sum.
+
+    Hypotheses:
+    - `k₀.val + m + 1 ≤ n`: the range `[k₀+1, k₀+m]` fits inside `Fin n`
+    - For each `j : Fin m`, the midpoint `φ_{k₀+j+1} ∈ [d/2, π - d/2]`
+
+    Result: `sin(d/2) · (2n / π) · ∑ⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k|`.
+
+    Combined with `odd_harmonic_sum_shifted_lb` this yields a `n · log(m)`-style
+    lower bound on the full trig sum (when `m` grows linearly with `n`). -/
+private lemma trig_sum_subsum_lb (n : ℕ) (hn : 0 < n)
+    (θ : ℝ)
+    (d : ℝ) (hd_pos : 0 < d)
+    (hne : ∀ k : Fin n, Real.cos θ ≠ chebyshevNode n k)
+    (k₀ : Fin n)
+    (hk₀_close : |θ - (2 * (k₀.val : ℝ) + 1) * Real.pi / (2 * n)| ≤ Real.pi / (2 * n))
+    (m : ℕ) (hm_le : k₀.val + m + 1 ≤ n)
+    (h_interior : ∀ j : Fin m,
+      d / 2 ≤ (2 * ((k₀.val + j.val + 1 : ℕ) : ℝ) + 1) * Real.pi / (2 * n) ∧
+      (2 * ((k₀.val + j.val + 1 : ℕ) : ℝ) + 1) * Real.pi / (2 * n) ≤ Real.pi - d / 2) :
+    Real.sin (d / 2) * (2 * (n : ℝ)) / Real.pi *
+        ∑ j ∈ Finset.range m, (1 : ℝ) / (2 * ((↑j : ℝ) + 1) + 1) ≤
+      ∑ k : Fin n, Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
+                   |Real.cos θ - chebyshevNode n k| := by
+  have hpi_pos := Real.pi_pos
+  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr hn
+  -- Index injection φ : Fin m → Fin n via j ↦ k₀ + j + 1
+  let φ : Fin m → Fin n := fun j => ⟨k₀.val + j.val + 1, by
+    have := j.isLt; omega⟩
+  -- Each chebyshev term is nonneg
+  have hterm_nn : ∀ k : Fin n,
+      0 ≤ Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
+          |Real.cos θ - chebyshevNode n k| :=
+    fun k => div_nonneg (le_of_lt (chebyshevAngle_sin_pos n hn k)) (abs_nonneg _)
+  -- φ is injective
+  have hφ_inj : Function.Injective φ := by
+    intro j₁ j₂ heq
+    simp only [φ, Fin.mk.injEq] at heq
+    exact Fin.ext (by omega)
+  -- The image is a subset of Finset.univ
+  have himg_sub :
+      (Finset.univ : Finset (Fin m)).image φ ⊆ (Finset.univ : Finset (Fin n)) :=
+    fun k _ => Finset.mem_univ k
+  -- (φ j).val = k₀.val + j.val + 1 (definitional)
+  have hφ_val : ∀ j : Fin m, (φ j).val = k₀.val + j.val + 1 := fun j => rfl
+  -- Per-term lower bound at each j : Fin m
+  have hsubterm : ∀ j : Fin m,
+      Real.sin (d / 2) * (2 * (n : ℝ)) /
+          ((2 * ((↑j.val : ℝ) + 1) + 1) * Real.pi) ≤
+        Real.sin ((2 * ((φ j).val : ℝ) + 1) * Real.pi / (2 * n)) /
+          |Real.cos θ - chebyshevNode n (φ j)| := by
+    intro j
+    obtain ⟨h_lower, h_upper⟩ := h_interior j
+    have hne_φ : Real.cos θ ≠ chebyshevNode n (φ j) := hne _
+    -- Convert the cast `((k₀.val + j.val + 1 : ℕ) : ℝ)` to `((φ j).val : ℝ)`
+    have hval_eq : ((φ j).val : ℝ) = ((k₀.val + j.val + 1 : ℕ) : ℝ) := by
+      rw [hφ_val]
+    have h_lower' : d / 2 ≤ (2 * ((φ j).val : ℝ) + 1) * Real.pi / (2 * n) := by
+      rw [hval_eq]; exact h_lower
+    have h_upper' : (2 * ((φ j).val : ℝ) + 1) * Real.pi / (2 * n) ≤ Real.pi - d / 2 := by
+      rw [hval_eq]; exact h_upper
+    have hbound := chebyshev_term_lb_at_node n hn k₀ (φ j) θ d hd_pos
+      hk₀_close h_lower' h_upper' hne_φ
+    -- Translate |(φ j).val - k₀.val| = j.val + 1
+    have hkk₀ : (((φ j).val : ℝ) - (k₀.val : ℝ)) = (↑j.val : ℝ) + 1 := by
+      rw [hφ_val]
+      push_cast
+      ring
+    have hkk₀_abs : |((φ j).val : ℝ) - (k₀.val : ℝ)| = (↑j.val : ℝ) + 1 := by
+      rw [hkk₀]; exact abs_of_nonneg (by positivity)
+    rw [hkk₀_abs] at hbound
+    exact hbound
+  -- Sub-sum (over Fin m) lower bound
+  have hsub_sum_lb :
+      ∑ j : Fin m,
+          Real.sin (d / 2) * (2 * (n : ℝ)) /
+              ((2 * ((↑j.val : ℝ) + 1) + 1) * Real.pi) ≤
+        ∑ j : Fin m,
+          Real.sin ((2 * ((φ j).val : ℝ) + 1) * Real.pi / (2 * n)) /
+            |Real.cos θ - chebyshevNode n (φ j)| :=
+    Finset.sum_le_sum (fun j _ => hsubterm j)
+  -- Convert sub-sum to image-set sum
+  have hsub_eq_image :
+      ∑ j : Fin m,
+          Real.sin ((2 * ((φ j).val : ℝ) + 1) * Real.pi / (2 * n)) /
+            |Real.cos θ - chebyshevNode n (φ j)| =
+        ∑ k ∈ (Finset.univ : Finset (Fin m)).image φ,
+          Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
+            |Real.cos θ - chebyshevNode n k| := by
+    rw [Finset.sum_image (fun j₁ _ j₂ _ heq => hφ_inj heq)]
+  -- Image sum ≤ universe sum
+  have himg_le_full :
+      ∑ k ∈ (Finset.univ : Finset (Fin m)).image φ,
+          Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
+            |Real.cos θ - chebyshevNode n k| ≤
+        ∑ k : Fin n,
+          Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
+            |Real.cos θ - chebyshevNode n k| :=
+    Finset.sum_le_sum_of_subset_of_nonneg himg_sub (fun k _ _ => hterm_nn k)
+  -- Convert LHS sub-sum to sub-sum form
+  have hLHS_eq :
+      Real.sin (d / 2) * (2 * (n : ℝ)) / Real.pi *
+          ∑ j ∈ Finset.range m, (1 : ℝ) / (2 * ((↑j : ℝ) + 1) + 1) =
+        ∑ j : Fin m,
+          Real.sin (d / 2) * (2 * (n : ℝ)) /
+              ((2 * ((↑j.val : ℝ) + 1) + 1) * Real.pi) := by
+    rw [Fin.sum_univ_eq_sum_range
+      (fun j => Real.sin (d / 2) * (2 * (n : ℝ)) /
+        ((2 * ((↑j : ℝ) + 1) + 1) * Real.pi)) m]
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro j _
+    ring
+  linarith [hLHS_eq, hsub_sum_lb, hsub_eq_image, himg_le_full]
+
 /-- **[SORRY] Harmonic trig sum lower bound for general θ ∈ (0, π).**
 
     For any θ ∈ (0, π) with cos θ not a Chebyshev node for any n, the sum

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 16 (2026-05-08, researcher-1): Built Step 4 + Step 5 toward closing trig_sum_harmonic_lb. Step 4 (sin_lb_of_in_interior): case-split proof that sin(x) ≥ sin(d/2) for x ∈ [d/2, π-d/2] using Real.sin_le_sin_of_le_of_le_pi_div_two on each side of π/2 with sin_pi_sub bridging. Step 5 (chebyshev_term_lb_at_node) chains Step 3 + Step 4 + Real.abs_cos_sub_cos_le into the per-term bound sin(φ_k)/|cos θ - cos φ_k| ≥ sin(d/2)·(2n)/((2|k-k₀|+1)·π). Total +133 lines, 4 new lemmas, 2 sorries unchanged. PR #16765.",
+    "progressSummary": "Session 17 (2026-05-08, researcher-1): Step 6a/6b — sub-sum lower bound assembly. Step 6a (odd_harmonic_sum_shifted_lb, ~20 lines): shifted odd harmonic Σⱼ 1/(2(j+1)+1) ≥ (1/2)·log(m+2) - 1, via odd_harmonic_sum_lb (m+1) + Finset.sum_range_succ' to split off j=0 term. Step 6b (trig_sum_subsum_lb, ~104 lines): sub-sum assembly over Fin m — defines φ : Fin m → Fin n via j ↦ k₀+j+1, applies chebyshev_term_lb_at_node per j, lifts to image sub-sum via Finset.sum_image + sum_le_sum_of_subset_of_nonneg, yielding sin(d/2)·(2n/π) · Σⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k|. +144 lines, 2 sorries unchanged. Step 7 (choose m=⌊nd/(4π)⌋, verify h_interior + hm_le, finite-n min') is next.",
     "builtItems": [
       "T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 — Erdos1151OQ04.lean:274",
       "natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n — Erdos1151OQ04.lean:282",
@@ -66,7 +66,9 @@
       "sin_lb_of_in_interior: ∀ d > 0, x ∈ [d/2, π-d/2] ⇒ sin(d/2) ≤ sin(x) — Erdos1151OQ04.lean (Step 4 generic)",
       "sin_chebyshev_midpoint_lb: corollary at chebyshev midpoints φ_k = (2k+1)π/(2n) — Erdos1151OQ04.lean",
       "chebyshev_term_lb_at_node: per-term lb sin(φ_k)/|cos θ - cos φ_k| ≥ sin(d/2)·(2n)/((2|k-k₀|+1)·π) — Erdos1151OQ04.lean (Step 5)",
-      "Combined Step 3 + Step 4 + cos-Lipschitz (Real.abs_cos_sub_cos_le) into ready-to-sum per-term lower bound"
+      "Combined Step 3 + Step 4 + cos-Lipschitz (Real.abs_cos_sub_cos_le) into ready-to-sum per-term lower bound",
+      "odd_harmonic_sum_shifted_lb (m : ℕ) : (1/2)·log(m+2) - 1 ≤ ∑ j ∈ Finset.range m, 1/(2(j+1)+1) — Erdos1151OQ04.lean:1362 (Step 6a, ~20 lines)",
+      "trig_sum_subsum_lb (n hn θ d hd_pos hne k₀ hk₀_close m hm_le h_interior) : sin(d/2)·(2n/π) · Σⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k| — Erdos1151OQ04.lean:1393 (Step 6b, ~104 lines)"
     ],
     "insights": [
       "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
@@ -101,13 +103,17 @@
       "Mathlib uses Real.sin_le_sin_of_le_of_le_pi_div_two with hypotheses (-(π/2) ≤ x), (y ≤ π/2), (x ≤ y) → sin x ≤ sin y. Domain is [-π/2, π/2], not [0, π/2].",
       "Real.abs_cos_sub_cos_le: cos is 1-Lipschitz, |cos α - cos β| ≤ |α - β|. Direct from lipschitzWith_cos. Lives in Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds.",
       "div_div_eq_mul_div : a / (b / c) = a * c / b — convert sin(d/2) / [(2|k-k₀|+1)π/(2n)] to sin(d/2)·(2n)/((2|k-k₀|+1)π) without nonzero hypotheses (works in any DivisionRing).",
-      "Per-term bound shape: sin(φ_k) ≥ sin(d/2) AND |cos θ - cos φ_k| ≤ (2|k-k₀|+1)π/(2n) ⇒ ratio ≥ sin(d/2)·(2n)/((2|k-k₀|+1)π). Subsequent sub-sum will require restricting indices to those satisfying φ_k ∈ [d/2, π-d/2]."
+      "Per-term bound shape: sin(φ_k) ≥ sin(d/2) AND |cos θ - cos φ_k| ≤ (2|k-k₀|+1)π/(2n) ⇒ ratio ≥ sin(d/2)·(2n)/((2|k-k₀|+1)π). Subsequent sub-sum will require restricting indices to those satisfying φ_k ∈ [d/2, π-d/2].",
+      "odd_harmonic_sum_shifted_lb (Step 6a): shifted odd harmonic Σⱼ 1/(2(j+1)+1) ≥ (1/2)·log(m+2) - 1, derived from odd_harmonic_sum_lb (m+1) by Finset.sum_range_succ' splitting off j=0 term (= 1).",
+      "trig_sum_subsum_lb (Step 6b): sub-sum assembly over Fin m index range — define φ : Fin m → Fin n via j ↦ k₀+j+1, apply chebyshev_term_lb_at_node per j, lift to image sub-sum via Finset.sum_image + Finset.sum_le_sum_of_subset_of_nonneg.",
+      "Bridge ∑ j : Fin m to ∑ j ∈ Finset.range m via Fin.sum_univ_eq_sum_range; pull constants out of sum via Finset.mul_sum; close field-equality per-term goal with ring.",
+      "Sub-sum lower bound shape: sin(d/2) * (2n/π) * Σⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k|. Combined with Step 6a, this gives n·log(m+2) growth — basis for asymptotic n·log(n) bound when m ~ n·d/(4π)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "(Researcher / next session) Step 6 — define m := ⌊n·d/(4π)⌋ and the index set Sₙ ⊆ Fin n of indices k satisfying φ_k ∈ (d/2, π-d/2). Apply chebyshev_term_lb_at_node per-index to get a sub-sum lower bound.",
-      "(Researcher / next session) Step 7 — combine sub-sum bound with odd_harmonic_sum_lb (∑ 1/(2j+1) ≥ (1/2)·log(m+1)) for large n. Use Finset.min' over {1,...,N₀-1} for small n. Final witness C₂ = min(C_large, C_small).",
-      "(Researcher) Verify that for θ ∈ (0,π) with d = min(θ, π-θ), the index k₀ from exists_nearest_chebyshev_angle has |φ_{k₀} - π/2| ≤ |θ - π/2| + π/(2n), so for n ≥ N₀(d), φ_{k₀+j} ∈ (d/2, π-d/2) for |j| ≤ ⌊nd/(4π)⌋."
+      "(Researcher / next session) Step 7a — choose m := ⌊n·d/(4π)⌋ (with d = min(θ, π-θ)) and prove that for n ≥ N₀(d) the hypotheses of trig_sum_subsum_lb hold: hm_le (k₀+m+1 ≤ n) and h_interior (each midpoint φ_{k₀+j+1} ∈ [d/2, π-d/2]). The latter is the technical heart, requiring k₀ to be near the midpoint π/2 of the interval modulo arccos.",
+      "(Researcher / next session) Step 7b — for 1 ≤ n < N₀(d), use Finset.min' (or direct computation) over the finite set of ratios S_n / (n·log(n+1)) to find a positive lower bound. Combine with Step 7a's asymptotic constant via min.",
+      "(Researcher / next session) Step 8 — close trig_sum_harmonic_lb by chaining trig_sum_subsum_lb (gives n·Σⱼ 1/(2j+3) lb) + odd_harmonic_sum_shifted_lb (gives log(m+2) lb) + Step 7 case analysis. Witness C₂ depends on θ via d = min(θ, π-θ)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Session 17 of erdos-1151-oq-04 (Lebesgue divergence at Chebyshev nodes). Adds two foundational lemmas that complete the **sub-sum lower bound assembly** required for `trig_sum_harmonic_lb` (Sorry 1):

- **Step 6a — `odd_harmonic_sum_shifted_lb`** (~20 lines): shifted odd harmonic
  \`Σⱼ₌₀^{m-1} 1/(2(j+1)+1) ≥ (1/2)·log(m+2) - 1\`, derived from existing
  `odd_harmonic_sum_lb` at `m+1` via `Finset.sum_range_succ'` (splitting off the
  `j = 0` term `1/(2·0+1) = 1`).

- **Step 6b — `trig_sum_subsum_lb`** (~104 lines): sub-sum lower bound
  \`sin(d/2)·(2n/π) · Σⱼ 1/(2(j+1)+1) ≤ Σ_k sin(φ_k)/|cos θ - cos φ_k|\`.
  Defines `φ : Fin m → Fin n` via `j ↦ k₀+j+1`, applies the per-term lower
  bound `chebyshev_term_lb_at_node` (Session 16) at each index, lifts to an
  image sub-sum via `Finset.sum_image`, then to the universe sum via
  `Finset.sum_le_sum_of_subset_of_nonneg` (each chebyshev term is nonneg).

## Architectural impact

Combining 6a + 6b yields, for any `θ ∈ (0,π)` and `n` large enough,
\`Σ ≥ sin(d/2)·(2n/π)·((1/2)·log(m+2) - 1)\` — the n·log(n) growth required
for `trig_sum_harmonic_lb`. **Sorry 1** is now reduced to a small finite-set
minimum argument plus the verification that the sub-sum hypotheses
(`hm_le`, `h_interior`) hold for `n ≥ N₀(d)` — see knowledge.json `nextSteps`
7a/7b/8 for the path forward.

## Files

- `proofs/Proofs/Erdos1151OQ04.lean` (+144 lines, sorries unchanged at 2)
- `src/data/research/problems/erdos-1151-oq-04.json` (knowledge update)

## Test plan
- [x] CI lake build (Docker)
- [x] No new sorries introduced
- [x] Existing 2 sorries unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)