### PR TITLE
fix(meta): area-of-circle-oq-03-oq-02-oq-02 theoremCount 5→15

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
@@ -58,7 +58,7 @@
     "assumptions": "Fully verified: 0 axioms, 0 sorries.",
     "lineCount": 204,
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
+    "theoremCount": 15,
     "definitionCount": 2
   },
   "overview": {
@@ -159,7 +159,7 @@
     "namespace": "AreaOfCircleOQ03OQ02OQ02",
     "lineCount": 204,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 15,
     "definitionCount": 2,
     "mainTheorems": [
       "dalzell_polynomial_identity",


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` in `area-of-circle-oq-03-oq-02-oq-02/meta.json`: both `meta.theoremCount` and `leanFile.theoremCount` claimed 5, actual file contains 15 `theorem` declarations.

## Evidence

**File**: `proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean` (204 lines, unchanged)

**Before**: `theoremCount: 5` (both blocks)
**After**: `theoremCount: 15` (both blocks)

**Verification**:
```
$ grep -cE '^[[:space:]]*(@\[[^]]*\][[:space:]]+)*((private|protected|noncomputable)[[:space:]]+)*(theorem|lemma)[[:space:]]+' \
    proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean
15
```

The 15 theorems include the 4 listed in `mainTheorems` plus 11 supporting lemmas (`dalzell_*`, `hasDerivAt_*`, `continuous_*`).

`definitionCount: 2` is correct (`dalzellAntideriv`, `dalzellDecomposed`); no other count drifts.

---
Automated fix by lean-mechanic agent.