### PR TITLE
research(sperner-ndim-mathlib-oq-02): session 13 — onFace infrastructure

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -538,6 +538,12 @@ private lemma gridPt_N0_coord2 : gridPt N (N, 0) 2 = 0 := by
              show ¬(2:ℕ)=0 from by omega, show ¬(2:ℕ)=1 from by omega, ↓reduceIte]
   push_cast; ring
 
+private lemma gridPt_00_coord0 : gridPt N (0, 0) 0 = 0 := by
+  simp [gridPt, show (0:Fin 3).val=0 from rfl]
+
+private lemma gridPt_00_coord1 : gridPt N (0, 0) 1 = 0 := by
+  simp [gridPt, show (1:Fin 3).val=1 from rfl, show ¬(1:ℕ)=0 from by omega]
+
 /-- Corner (0, N) has forced color 1: on face 0 (coord 0 = 0) and face 2 (coord 2 = 0). -/
 private lemma cN2_left_corner :
     cN2 N hN f hf_map (0, N) (by omega) = 1 := by
@@ -551,6 +557,90 @@ private lemma cN2_right_corner :
   have h1 := cN2_ne_of_zero N hN f hf_map (N, 0) (by omega) 1 (gridPt_N0_coord1 N)
   have h2 := cN2_ne_of_zero N hN f hf_map (N, 0) (by omega) 2 (gridPt_N0_coord2 N)
   fin_cases (cN2 N hN f hf_map (N, 0) (by omega)) <;> simp_all
+
+/-- Corner (0, 0) has forced color 2: on face 0 (coord 0 = 0) and face 1 (coord 1 = 0). -/
+private lemma cN2_origin_corner :
+    cN2 N hN f hf_map (0, 0) (by omega) = 2 := by
+  have h0 := cN2_ne_of_zero N hN f hf_map (0, 0) (by omega) 0 (gridPt_00_coord0 N)
+  have h1 := cN2_ne_of_zero N hN f hf_map (0, 0) (by omega) 1 (gridPt_00_coord1 N)
+  fin_cases (cN2 N hN f hf_map (0, 0) (by omega)) <;> simp_all
+
+/-- Geometric face predicate for grid vertices.
+A vertex `b = (b.1, b.2)` (representing `(b.1/N, b.2/N, (N-b.1-b.2)/N)` in Δ²)
+is on face j iff its j-th coordinate is zero. -/
+private def onFaceΔ2 (N : ℕ) (b : ℕ × ℕ) (j : Fin 3) : Prop :=
+  if j.val = 0 then b.1 = 0
+  else if j.val = 1 then b.2 = 0
+  else b.1 + b.2 = N
+
+private instance onFaceΔ2_decidable (N : ℕ) (b : ℕ × ℕ) (j : Fin 3) :
+    Decidable (onFaceΔ2 N b j) := by
+  unfold onFaceΔ2; split_ifs <;> infer_instance
+
+private lemma onFaceΔ2_zero_iff (b : ℕ × ℕ) :
+    onFaceΔ2 N b 0 ↔ b.1 = 0 := by
+  simp [onFaceΔ2, show (0:Fin 3).val = 0 from rfl]
+
+private lemma onFaceΔ2_one_iff (b : ℕ × ℕ) :
+    onFaceΔ2 N b 1 ↔ b.2 = 0 := by
+  simp [onFaceΔ2, show (1:Fin 3).val = 1 from rfl]
+
+private lemma onFaceΔ2_two_iff (b : ℕ × ℕ) :
+    onFaceΔ2 N b 2 ↔ b.1 + b.2 = N := by
+  simp [onFaceΔ2, show (2:Fin 3).val = 2 from rfl, show ¬(2:ℕ)=0 from by omega,
+        show ¬(2:ℕ)=1 from by omega]
+
+private lemma onFaceΔ2_zero_iff_gridPt_zero (b : ℕ × ℕ) :
+    onFaceΔ2 N b 0 ↔ gridPt N b 0 = 0 := by
+  have hNne : (N : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hN)
+  rw [onFaceΔ2_zero_iff]
+  simp only [gridPt, show (0:Fin 3).val = 0 from rfl, ↓reduceIte]
+  rw [div_eq_zero_iff]
+  constructor
+  · intro h; left; exact_mod_cast h
+  · rintro (h | h)
+    · exact_mod_cast h
+    · exact absurd h hNne
+
+private lemma onFaceΔ2_one_iff_gridPt_zero (b : ℕ × ℕ) :
+    onFaceΔ2 N b 1 ↔ gridPt N b 1 = 0 := by
+  have hNne : (N : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hN)
+  rw [onFaceΔ2_one_iff]
+  simp only [gridPt, show (1:Fin 3).val = 1 from rfl,
+             show ¬(1:ℕ)=0 from by omega, ↓reduceIte]
+  rw [div_eq_zero_iff]
+  constructor
+  · intro h; left; exact_mod_cast h
+  · rintro (h | h)
+    · exact_mod_cast h
+    · exact absurd h hNne
+
+private lemma onFaceΔ2_two_iff_gridPt_zero (b : ℕ × ℕ) (hb : b.1 + b.2 ≤ N) :
+    onFaceΔ2 N b 2 ↔ gridPt N b 2 = 0 := by
+  have hNne : (N : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hN)
+  rw [onFaceΔ2_two_iff]
+  simp only [gridPt, show (2:Fin 3).val = 2 from rfl,
+             show ¬(2:ℕ)=0 from by omega, show ¬(2:ℕ)=1 from by omega, ↓reduceIte]
+  rw [div_eq_zero_iff]
+  constructor
+  · intro h
+    left
+    have hb12 : (b.1 : ℝ) + b.2 = N := by exact_mod_cast h
+    linarith
+  · rintro (h | h)
+    · have : (b.1 : ℝ) + b.2 = N := by linarith
+      exact_mod_cast this
+    · exact absurd h hNne
+
+/-- Sperner condition (face form): if vertex b is on face j of Δ², its color is not j. -/
+private lemma cN2_ne_of_onFace (b : ℕ × ℕ) (hb : b.1 + b.2 ≤ N) (j : Fin 3)
+    (hface : onFaceΔ2 N b j) : cN2 N hN f hf_map b hb ≠ j := by
+  have hzero : gridPt N b j = 0 := by
+    fin_cases j
+    · exact (onFaceΔ2_zero_iff_gridPt_zero N hN b).mp hface
+    · exact (onFaceΔ2_one_iff_gridPt_zero N hN b).mp hface
+    · exact (onFaceΔ2_two_iff_gridPt_zero N hN b hb).mp hface
+  exact cN2_ne_of_zero N hN f hf_map b hb j hzero
 
 /-- Face 2 diagonal: the coloring g(k) = (cN2(k, N-k) mod 2) has g(0)=1, g(N)=0,
     so by XOR parity there are an odd number of color-changing edges on face 2.

--- a/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
@@ -634,3 +634,64 @@ Concurrent Docker build cache contention was causing builds #2-#4 failures.
    - Establish bijection between boundary IsDoors and color-changing face-2 edges
    - Use Sperner condition to exclude faces 0,1
 3. **Apply Triangulation.sperner** and extract witnesses for `sperner_panchromatic_two`
+
+
+## Session 2026-05-08 (Session 13) — onFace infrastructure for Triangulation hookup
+
+**Mode**: REVISIT (continuing axiom elimination work — phase REFINE)
+**Outcome**: progress — onFace predicate + Sperner-condition wrapper added; third corner color forced
+
+### What I Did
+
+- Added `onFaceΔ2 N b j` predicate: vertex `b = (b₀,b₁)` is on face j of Δ² iff its j-th
+  real coordinate is zero (j=0: b₀=0; j=1: b₁=0; j=2: b₀+b₁=N).
+- Added `Decidable` instance for `onFaceΔ2`.
+- Proved three `onFaceΔ2_<j>_iff` lemmas exposing the simple Nat-level conditions.
+- Proved three `onFaceΔ2_<j>_iff_gridPt_zero` lemmas connecting the predicate to
+  `gridPt N b j = 0` via `div_eq_zero_iff`.
+- Proved **`cN2_ne_of_onFace`**: face-form Sperner condition. Has the exact shape
+  `IsSpernerColoring c onFace` from `Triangulation.boundary_doors_odd`, ready for hookup.
+- Proved `cN2_origin_corner`: corner (0,0) (= (0,0,N) in Δ²) is on faces 0 and 1, so its
+  color is forced to 2. Completes the trio of forced corner colors (left=1, right=0, origin=2).
+- Added `gridPt_00_coord0` and `gridPt_00_coord1` helper lemmas.
+
+### Key Findings
+
+- **`Triangulation.boundary_doors_odd` signature match**: with `V = ℕ × ℕ`, `n = 2`, the
+  hypothesis `_hSperner : IsSpernerColoring c onFace` means `∀ v k, onFace v k → c v ≠ k`.
+  My `cN2_ne_of_onFace` provides exactly this. Sessions 14+ can wrap `cN2` to a total
+  function `(ℕ × ℕ) → Fin 3` and plug straight into the abstract Sperner machinery.
+- **Decoupled face predicate**: `onFaceΔ2 N b j` is purely arithmetic on `ℕ × ℕ` and `N`,
+  with no dependency on `f` or `gridPt`. This makes `onFace` ergonomic for `_hBoundaryOnFace`
+  and `_hLowerDim`/`_hLastFace` proofs (purely combinatorial).
+- **Three forced corner colors**: corners of Δ² are (N,0,0), (0,N,0), (0,0,N) in real coords;
+  in grid coords they are (N,0), (0,N), (0,0). Each lies on two geometric faces, so its
+  color is uniquely forced — the three corners give three distinct colors, witnessing that
+  the Sperner coloring is non-trivial regardless of `f`.
+
+### Files Modified
+
+- `proofs/Proofs/SpernerFreudenthalSimplex.lean` (583 → 673 lines, +90 lines)
+- `research/problems/sperner-ndim-mathlib-oq-02/knowledge.md` (this file)
+- `research/problems/sperner-ndim-mathlib-oq-02/state.md` (phase REFINE, iter 13)
+
+### Next Steps
+
+1. **Wrap `cN2` to a total function** `cN2_total : (ℕ × ℕ) → Fin 3` (default to 0 outside
+   the b₀+b₁≤N region — the wrapping is irrelevant since only in-range vertices appear in
+   `topSimps2`). ~10 lines.
+2. **Prove `cN2_total_ne_of_onFace`**: lift `cN2_ne_of_onFace` through the wrapper.
+   Requires showing every vertex of every `t1`/`t2` simplex has `b₀+b₁ ≤ N`. ~30 lines.
+3. **Prove `_hBoundaryOnFace`**: for each boundary cell-face pair `(s, k)` with
+   `adjFn s k = none`, identify which geometric face of Δ² it lies on by inspecting which
+   t1/t2 base coordinate hit its boundary. ~80 lines.
+4. **Prove `_hLowerDim`** for j=0 and j=1: by Sperner condition, no `IsDoor` can occur on
+   faces with color < 2 (the door requires color faceIdx, but Sperner forbids it). The
+   filter set is empty, so cardinality = 0 (even). ~30 lines.
+5. **Prove `_hLastFace`** (face 2): bijection with `face2_path_odd`'s color-changing edges.
+   The hard piece — requires identifying which t1 simplex contains edge `{(k,N-k), (k+1,N-k-1)}`
+   and showing IsDoor ↔ color change at that edge. ~150 lines.
+6. **Apply `Triangulation.sperner`** and extract witness vertices, then convert grid (b₀,b₁)
+   to real (b₀/N, b₁/N, (N-b₀-b₁)/N) and verify diameter ≤ 2/N. ~50 lines.
+
+Total estimated remaining for `sperner_panchromatic_two`: ~350 lines across 3-4 sessions.

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT
+**Phase**: REFINE
 **Since**: 2026-05-06
-**Iteration**: 9
+**Iteration**: 13
 
 ## Current Focus
 

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: n=0,1 proved; n=2 triangulation+pseudomanifold+XOR parity+coloring done; gap: adjFn=none characterization for boundary_doors",
+    "progressSummary": "STATE (2026-05-08, session 13): n=0,1 fully proved; n=2 has triangulation + pseudomanifold + XOR parity + grid coloring + 3 forced corner colors. Session 13 added onFaceΔ2 predicate + 6 connection lemmas + cN2_ne_of_onFace (matches IsSpernerColoring shape required by Triangulation.boundary_doors_odd). Companion file 583→673 lines. Remaining gap for sperner_panchromatic_two: wrap cN2 to total function + prove _hBoundaryOnFace + _hLowerDim + _hLastFace (~350 lines, 3-4 sessions). Main file SpernerNDimMathlibOQ02.lean unchanged at 1 axiom.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -53,7 +53,11 @@
       "cN2: Sperner coloring for grid vertices via spernerColor on gridPt (SpernerFreudenthalSimplex.lean)",
       "cN2_left_corner: corner (0,N) has forced color 1 (on face 0 ∧ face 2) (SpernerFreudenthalSimplex.lean)",
       "cN2_right_corner: corner (N,0) has forced color 0 (on face 1 ∧ face 2) (SpernerFreudenthalSimplex.lean)",
-      "face2_path_odd: binary sequence g(k)=cN2(k,N-k) mod 2 has odd changes by XOR parity (SpernerFreudenthalSimplex.lean)"
+      "face2_path_odd: binary sequence g(k)=cN2(k,N-k) mod 2 has odd changes by XOR parity (SpernerFreudenthalSimplex.lean)",
+      "cN2_origin_corner: corner (0,0) has forced color 2 (on face 0 ∧ face 1) — completes trio of forced corner colors (SpernerFreudenthalSimplex.lean, session 13)",
+      "onFaceΔ2 N b j: arithmetic predicate for grid vertex on geometric face j of Δ² (j=0: b₀=0; j=1: b₂=0; j=2: b₀+b₁=N) with Decidable instance (SpernerFreudenthalSimplex.lean, session 13)",
+      "onFaceΔ2_<j>_iff and onFaceΔ2_<j>_iff_gridPt_zero: 6 wrapper lemmas connecting onFace predicate to gridPt zero (SpernerFreudenthalSimplex.lean, session 13)",
+      "cN2_ne_of_onFace: face-form Sperner condition matching IsSpernerColoring shape required by Triangulation.boundary_doors_odd (SpernerFreudenthalSimplex.lean, session 13)"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -74,17 +78,21 @@
       "XOR parity: #{changes in binary seq} has parity = [endpoints differ]; proof by induction+fin_cases 8 cases",
       "Two-constraint forced color: vertex on two faces excludes two colors, unique Fin 3 value remains",
       "gridPt uses real subtraction (N:ℝ)-b.1-b.2 for 3rd coord; field_simp+ring proves sum=1 as ring identity",
-      "Key gap: connecting face2_path_odd to abstract Triangulation boundary doors requires adjFn=none characterization via containersOf analysis (~150-200 lines)"
+      "Key gap: connecting face2_path_odd to abstract Triangulation boundary doors requires adjFn=none characterization via containersOf analysis (~150-200 lines)",
+      "Triangulation.boundary_doors_odd hookup pattern: onFace : V → Fin (n+1) → Prop must be a pure arithmetic predicate (no dependency on f); IsSpernerColoring c onFace = (∀ v k, onFace v k → c v ≠ k) is the wrapper around cN2_ne_of_zero — completed for n=2 in session 13",
+      "Three forced corner colors of Δ²: (N,0)→0, (0,N)→1, (0,0)→2. Each corner is on two geometric faces, so its color is uniquely forced regardless of f — non-trivial Sperner coloring witness"
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
       "Sequential compactness of stdSimplex in Lean 4 (needed for fixed_point_from_approx axiom)"
     ],
     "nextSteps": [
-      "Prove adj=none iff characterization for t1/t2 triangles: containersOf edge = {t1(b)} iff b₀+b₁=N-1",
-      "Prove faces 0,1 boundary doors are IsDoor=False via Sperner (no color 0 on face 0, no color 1 on face 1)",
-      "Show IsDoor iff color-change for face-2 boundary edges",
-      "Apply Triangulation.sperner to get panchromatic triangle and extract real witnesses"
+      "Wrap cN2 to total function cN2_total : (ℕ × ℕ) → Fin 3 (default 0 outside b₀+b₁≤N region) — ~10 lines",
+      "Prove cN2_total_ne_of_onFace by lifting cN2_ne_of_onFace through wrapper — requires every t1/t2 vertex satisfies b₀+b₁≤N (~30 lines)",
+      "Prove _hBoundaryOnFace: each adjFn=none cell-face pair (s,k) is on some geometric face of Δ² (~80 lines)",
+      "Prove _hLowerDim for j=0,1: by Sperner, no IsDoor exists on these faces — filter set is empty (cardinality 0, even, ~30 lines)",
+      "Prove _hLastFace (j=2): bijection between IsDoors at face 2 and color-changing edges of face2_path_odd (~150 lines)",
+      "Apply Triangulation.sperner to get panchromatic triangle, convert grid (b₀,b₁) to real (b₀/N, b₁/N, (N-b₀-b₁)/N), verify diameter ≤ 2/N (~50 lines)"
     ]
   },
   "tags": [
@@ -104,7 +112,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-06T11:50:53.576Z",
+  "lastUpdate": "2026-05-08T05:30:00.000Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Session 13 of the Brouwer-via-Sperner formalization. Adds the geometric face predicate
\`onFaceΔ2 N b j\` over grid vertices, a Decidable instance, six connection lemmas
(3 Nat-form, 3 \`gridPt\`-zero form), and the face-form Sperner condition wrapper
\`cN2_ne_of_onFace\` matching the \`IsSpernerColoring c onFace\` shape required by
\`Triangulation.boundary_doors_odd\`.

Also proves \`cN2_origin_corner\`: corner (0,0) has forced color 2, completing the trio
of forced corner colors (left=1, right=0, origin=2).

## Why this matters

This is foundational scaffolding for the remaining gap in \`sperner_panchromatic_two\`.
With \`onFaceΔ2\` + \`cN2_ne_of_onFace\` in place, sessions 14+ can:
1. Wrap \`cN2\` to a total function on \`ℕ × ℕ\`
2. Plug straight into the abstract Sperner machinery (\`Triangulation.boundary_doors_odd\`)
3. Discharge the remaining \`_hBoundaryOnFace\`, \`_hLowerDim\`, \`_hLastFace\` hypotheses
   purely combinatorially

## Build

\`./proofs/scripts/docker-build.sh Proofs.SpernerFreudenthalSimplex\` exit code 0.

## Files

- \`proofs/Proofs/SpernerFreudenthalSimplex.lean\` (583 → 673 lines, +90 lines, 1 sorry remains)
- \`research/problems/sperner-ndim-mathlib-oq-02/{knowledge.md, state.md}\` (session 13 entry)
- \`src/data/research/problems/sperner-ndim-mathlib-oq-02.json\` (built items + insights + nextSteps)

## Status

**Outcome**: progress
**Phase**: REFINE (iteration 13)
**Main file** \`SpernerNDimMathlibOQ02.lean\`: unchanged at 1 axiom (\`sperner_panchromatic\`)
**Companion file** \`SpernerFreudenthalSimplex.lean\`: 1 sorry (\`sperner_panchromatic_two\`)

Estimated remaining for full \`sperner_panchromatic_two\` discharge: ~350 lines across
3-4 sessions.

🤖 Generated by researcher-1