### PR TITLE
fix(meta): ehrhart-cube-proven-oq-02 sync theoremCount 14→16

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -7,7 +7,7 @@
     "path": "Proofs/EhrhartCrossPolytope.lean",
     "filename": "EhrhartCrossPolytope.lean",
     "lineCount": 423,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 2,
     "sorries": 1,
     "axiomCount": 0
@@ -47,7 +47,7 @@
       "cweight_translate: bridge identity equating the centered weight at center n with the centered weight at center M (after translation), enabling the bijection between truncated lattice fibers and crossBall d M",
       "Concrete verifications: d=1 (2n+1), d=2 (2n\u00b2+2n+1), d=3 spot checks via native_decide"
     ],
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 2
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` in `ehrhart-cube-proven-oq-02/meta.json`: both `meta.theoremCount` and `leanFile.theoremCount` claimed 14, actual file has 16 theorem/lemma declarations.

## Evidence

**File**: `proofs/Proofs/EhrhartCrossPolytope.lean` (423 lines, unchanged)

**Before**: `theoremCount: 14` (both blocks)
**After**: `theoremCount: 16` (both blocks)

**Verification** (origin/main):
```
$ grep -cE '^[[:space:]]*(@\[[^]]*\][[:space:]]+)*((private|protected|noncomputable)[[:space:]]+)*(theorem|lemma)[[:space:]]+' \
    proofs/Proofs/EhrhartCrossPolytope.lean
16
```

11 `theorem` declarations + 5 `lemma` declarations:
- 11 `theorem`: `crossEhrhart_d0`, `crossEhrhart_n0`, `crossEhrhart_d1`, `crossEhrhart_pos`, `crossEhrhart_mono`, `crossEhrhart_expand`, `crossEhrhart_succ_d`, `crossEhrhart_d2`, `crossEhrhart_is_poly`, `crossBall_card`
- 5 `lemma`: `sum_choose_range`, `sum_shift_hockey`, `private natDegree_descPochhammer_le`, `private eval_descPochhammer_natCast`, `private cweight_le_iff`, `private cweight_translate`

(Latest research push #16842 added cweight foundation helpers and the count was not synced in either block.)

Other counts (`lineCount=423`, `definitionCount=2`, `axiomCount=0`, `sorries=1`) remain accurate.

---
Automated fix by lean-mechanic agent.