### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): Phase-2 scaffold — multinomial marginal CLT

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -1,0 +1,178 @@
+/-
+# Multinomial Marginal Central Limit Theorem (Phase-2 scaffold)
+
+**Open Question** (binomial-theorem-oq-02-oq-01-oq-01-oq-03):
+"Multinomial marginal CLT in Lean: does (Xᵢ - npᵢ) / √(npᵢ(1-pᵢ)) converge in
+distribution to N(0,1) for each coordinate as n → ∞?"
+
+## Status
+
+**Phase-2 STATEMENT scaffold.** This file STATES the multinomial marginal CLT
+and reduces it to the classical de Moivre–Laplace (binomial) CLT plus the
+already-proved marginal-PMF identity from `BinomialTheoremOQ02OQ01OQ02`.
+
+The de Moivre–Laplace CLT is taken as an axiom: a measure-theoretic proof from
+Mathlib's `ProbabilityTheory.iid_central_limit_theorem` is non-trivial (CDF
+↔ measure-weak-convergence bridge) and is left for a Phase-3 effort.
+
+## What This File Provides
+
+1. `binomialCDF n p x` — concrete CDF of Binomial(n, p), defined as
+   ∑_{j ≤ x} C(n,j) p^j (1-p)^(n-j).
+2. `multinomialMarginalCDF s p n i₀ x` — concrete CDF of the marginal X_{i₀}
+   of Multinomial(n, p), defined by summing `multinomialProb` over the
+   filtered piAntidiag.
+3. `standardNormalCDF` — opaque marker for the standard normal CDF.
+4. `binomial_clt_pointwise` — AXIOM: pointwise convergence of standardized
+   binomial CDF to standardNormalCDF.
+5. `multinomialMarginalCDF_eq_binomialCDF` — reduction lemma. The marginal
+   CDF of the multinomial equals the binomial CDF with parameter p(i₀).
+   Provable from `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf` by
+   regrouping the sum over k into fibers over k(i₀); the reduction is
+   recorded as a sorry-marked lemma (Phase-3 target).
+6. `multinomial_marginal_clt` — DERIVED THEOREM (no axiom of its own).
+   Combines (4) and (5) via `Filter.Tendsto.congr`.
+
+## Mathematical Content
+
+For (X₁, ..., Xₖ) ~ Multinomial(n, p₁, ..., pₖ), each marginal Xᵢ ~ Binomial(n, pᵢ)
+(this was proved in `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf`).
+The classical de Moivre–Laplace theorem gives:
+
+    P( (X − np) / √(np(1−p)) ≤ x )  →  Φ(x)    as n → ∞
+
+for any x ∈ ℝ, where Φ is the standard normal CDF. Composing these two facts
+gives the multinomial marginal CLT.
+
+## Honest Reporting
+
+- Sorries: 1 (the cdf-equality reduction, provable from existing lemmas).
+- Axioms: 2 (`binomial_clt_pointwise` + `standardNormalCDF` opaque).
+- Status: axiomatized — not "verified".
+
+The contribution of this file is the *statement and reduction structure*, not
+the CLT itself.
+
+## Why CDF formulation
+
+Mathlib's CLT (`ProbabilityTheory.iid_central_limit_theorem`) is stated in
+terms of measure-weak-convergence of the law of standardized sums to the
+Gaussian measure. Our statement is in CDF form to (a) avoid the heavy
+measure-theory setup for a marginal-only result, (b) match the classical
+"de Moivre–Laplace" presentation, and (c) keep the reduction to the
+already-proved marginal-PMF identity transparent.
+
+## Dependencies
+
+- `BinomialTheoremOQ02OQ01OQ02` — `multinomialProb`, `multinomial_marginal_pmf`
+- Mathlib — `Real.sqrt`, `Filter.Tendsto`, `nhds`
+-/
+
+import Mathlib.Data.Nat.Choose.Multinomial
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Sqrt
+import Mathlib.Topology.Algebra.Order.LiminfLimsup
+import Mathlib.Tactic
+import Proofs.BinomialTheoremOQ02OQ01OQ02
+
+namespace BinomialTheoremOQ02OQ01OQ01OQ03
+
+open Finset BigOperators
+
+/-! ## CDF definitions -/
+
+/-- The CDF of Binomial(n, p) at `x`:
+    `binomialCDF n p x = ∑_{j ≤ x, 0 ≤ j ≤ n} C(n, j) · p^j · (1 - p)^(n - j)`.
+
+    No constraints on `p` are enforced at the definition level; the axiom
+    `binomial_clt_pointwise` requires `0 < p < 1`. -/
+noncomputable def binomialCDF (n : ℕ) (p : ℝ) (x : ℝ) : ℝ :=
+  ∑ j ∈ Finset.range (n + 1),
+    if (j : ℝ) ≤ x then
+      (Nat.choose n j : ℝ) * p ^ j * (1 - p) ^ (n - j)
+    else 0
+
+/-- The marginal CDF of coordinate `i₀` for X ~ Multinomial(n, p). -/
+noncomputable def multinomialMarginalCDF
+    {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ) (i₀ : α) (x : ℝ) : ℝ :=
+  ∑ k ∈ s.piAntidiag n,
+    if ((k i₀ : ℕ) : ℝ) ≤ x then
+      BinomialTheoremOQ02OQ01OQ02.multinomialProb s p n k
+    else 0
+
+/-! ## Standard normal CDF (opaque) -/
+
+/-- The standard normal CDF, `Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt`.
+
+    Declared `opaque` here — Mathlib provides a measure-theoretic standard
+    normal (`Mathlib.Probability.Distributions.Gaussian.Basic`); bridging
+    that measure to a CDF function is left for a Phase-3 effort. -/
+opaque standardNormalCDF : ℝ → ℝ
+
+/-! ## Axiom: classical de Moivre–Laplace (binomial CLT) -/
+
+/-- **AXIOM** (de Moivre–Laplace, 1733/1812): the standardized binomial CDF
+    converges pointwise to the standard normal CDF as `n → ∞`.
+
+    For `0 < p < 1` and any `x : ℝ`,
+    `binomialCDF n p (np + x √(np(1−p)))  →  Φ(x)`.
+
+    Mathematical justification: classical, see e.g. Feller, *Introduction to
+    Probability Theory*, Vol. I (1968), Ch. VII §3. The Mathlib path is via
+    `ProbabilityTheory.iid_central_limit_theorem` plus a CDF-bridge; recorded
+    as an axiom here (Phase-3 target). -/
+axiom binomial_clt_pointwise
+    (p : ℝ) (hp0 : 0 < p) (hp1 : p < 1) (x : ℝ) :
+    Filter.Tendsto
+      (fun n : ℕ =>
+        binomialCDF n p ((n : ℝ) * p + x * Real.sqrt ((n : ℝ) * p * (1 - p))))
+      Filter.atTop (nhds (standardNormalCDF x))
+
+/-! ## Reduction lemma -/
+
+/-- **Reduction lemma**: the marginal CDF of the multinomial equals the
+    binomial CDF with parameter `p(i₀)`.
+
+    Proof sketch (Phase-3): regroup `∑ k ∈ s.piAntidiag n` into fibers over
+    the value `j = k i₀` for `j ∈ {0, ..., n}`; on each fiber, apply
+    `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf` to collapse the
+    inner sum to `C(n, j) · p(i₀)^j · (1 − p(i₀))^(n − j)`. The if-condition
+    `(k i₀ : ℝ) ≤ x` becomes `(j : ℝ) ≤ x`, which factors out of the inner
+    sum since `j` is fixed on each fiber. -/
+theorem multinomialMarginalCDF_eq_binomialCDF
+    {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ) (hp : ∑ i ∈ s, p i = 1)
+    (i₀ : α) (hi₀ : i₀ ∈ s) (x : ℝ) :
+    multinomialMarginalCDF s p n i₀ x = binomialCDF n (p i₀) x := by
+  sorry
+
+/-! ## Main theorem: multinomial marginal CLT (derived) -/
+
+/-- **Multinomial marginal CLT** (DERIVED THEOREM, no separate axiom):
+    for X ~ Multinomial(n, p), each non-degenerate marginal `Xᵢ` has the
+    standardized CDF converging pointwise to `Φ(x)`.
+
+    Proof: combine the de Moivre–Laplace axiom (`binomial_clt_pointwise`)
+    with the reduction lemma (`multinomialMarginalCDF_eq_binomialCDF`)
+    via `Filter.Tendsto.congr`. -/
+theorem multinomial_marginal_clt
+    {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (hp : ∑ i ∈ s, p i = 1)
+    (i₀ : α) (hi₀ : i₀ ∈ s) (hp0 : 0 < p i₀) (hp1 : p i₀ < 1) (x : ℝ) :
+    Filter.Tendsto
+      (fun n : ℕ =>
+        multinomialMarginalCDF s p n i₀
+          ((n : ℝ) * p i₀ + x * Real.sqrt ((n : ℝ) * p i₀ * (1 - p i₀))))
+      Filter.atTop (nhds (standardNormalCDF x)) := by
+  have key : ∀ n : ℕ,
+      multinomialMarginalCDF s p n i₀
+        ((n : ℝ) * p i₀ + x * Real.sqrt ((n : ℝ) * p i₀ * (1 - p i₀))) =
+      binomialCDF n (p i₀)
+        ((n : ℝ) * p i₀ + x * Real.sqrt ((n : ℝ) * p i₀ * (1 - p i₀))) := by
+    intro n
+    exact multinomialMarginalCDF_eq_binomialCDF s p n hp i₀ hi₀ _
+  exact (binomial_clt_pointwise (p i₀) hp0 hp1 x).congr (fun n => (key n).symm)
+
+end BinomialTheoremOQ02OQ01OQ01OQ03

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
@@ -132,6 +132,91 @@ In a future session:
 
 ---
 
+## Session 2026-05-08 (Session 2, researcher-9) — ACT (Phase-2 scaffold)
+
+**Mode**: REVISIT (Session 1 was OBSERVE→ORIENT; this is the planned ACT)
+**Outcome**: scaffolded `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`
+(178 lines) and the matching gallery entry. Took a CDF-based path rather
+than the measure-theoretic Bernoulli-sum path planned in Session 1.
+
+### What Was Built
+
+**Lean file**: `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`
+
+- `binomialCDF n p x` — concrete CDF of Binomial(n, p), defined as
+  `∑_{j ∈ Finset.range (n+1)}, if (j:ℝ) ≤ x then C(n,j)·p^j·(1-p)^(n-j) else 0`.
+- `multinomialMarginalCDF s p n i₀ x` — concrete marginal CDF of
+  coordinate `i₀`, defined directly from `multinomialProb`.
+- `standardNormalCDF` — opaque marker (counts as +1 axiom).
+- `binomial_clt_pointwise` — AXIOM (de Moivre–Laplace, 1733/1812):
+  the standardized binomial CDF converges pointwise to `standardNormalCDF x`.
+- `multinomialMarginalCDF_eq_binomialCDF` — reduction lemma (sorry,
+  Phase-3 target). Provable from the parent's `multinomial_marginal_pmf`.
+- `multinomial_marginal_clt` — DERIVED THEOREM (no separate axiom).
+  Combines the two via `Filter.Tendsto.congr`.
+
+**Gallery entry**: `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/`
+(meta.json + annotations.json + index.ts).
+
+### Why CDF Instead of Bernoulli-Sum
+
+Session 1 planned to use Mathlib's i.i.d. CLT applied to a Bernoulli-sum
+representation of `Binomial(n,p)`. That path requires:
+
+- Setting up an i.i.d. probability space with sample space `Fin n → {0,1}`.
+- Constructing the binomial distribution as `Σⱼ B_j` with `B_j ~ Bernoulli(p)`.
+- Invoking `ProbabilityTheory.iid_central_limit_theorem`.
+- Bridging measure-weak-convergence to the CDF formulation (Portmanteau).
+
+The CDF path collapses all of this to:
+
+- An axiom that *states* de Moivre–Laplace in CDF form.
+- An equality `multinomialMarginalCDF = binomialCDF` (provable from
+  `multinomial_marginal_pmf` by a fiber regrouping over `k(i₀)` values).
+- One application of `Filter.Tendsto.congr`.
+
+Trade-off: the CDF approach introduces `standardNormalCDF` as `opaque`
+(+1 axiom) but eliminates the entire measure-theoretic infrastructure
+chain. Net axiom count: **2** (opaque CDF + de Moivre–Laplace), vs. an
+estimated 3–5 for the Bernoulli-sum path (the i.i.d. setup typically
+needs at least one axiom to bridge to the standard form).
+
+### Honest Reporting
+
+- This session **could not run** `./proofs/scripts/docker-build.sh` to
+  verify the scaffold compiles (long Docker iteration time + worktree
+  symlink trap that prevents direct Mathlib browsing). CI is the ground
+  truth. Confidence is moderate-high based on Mathlib idiom familiarity
+  but not verified.
+- The Phase-3 reduction is **provable** but not yet proved. Closing it
+  would leave 0 sorries, with the only assumptions being de Moivre–Laplace
+  and the `standardNormalCDF` opaque.
+- This is **Phase-2 scaffolding**, not the answer to OQ-03 — the answer
+  is the *derivation chain*, not the binomial CLT itself, which is
+  axiomatized.
+
+### Files Changed
+
+- NEW `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`
+- NEW `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/{meta.json,annotations.json,index.ts}`
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md`
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md`
+- UPDATED `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json` (knowledge fields)
+
+### Next Steps
+
+1. **Phase-3 next session**: discharge `multinomialMarginalCDF_eq_binomialCDF`
+   by fiber regrouping. Skeleton in `state.md`. Should be ~30 lines.
+2. **Phase-3 stretch**: discharge `binomial_clt_pointwise` by bridging to
+   Mathlib's `iid_central_limit_theorem` via Portmanteau. This is the
+   substantial piece of work and may require ~150+ lines.
+3. **Joint multinomial CLT** (out of scope for this OQ): coordinate-wise
+   CLTs do not imply joint convergence. Cramér–Wold + the covariance
+   computation in `BinomialTheoremOQ02OQ01OQ03.multinomial_covariance`
+   give the joint statement; this should be a sibling OQ.
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -1,49 +1,100 @@
 # Research State: binomial-theorem-oq-02-oq-01-oq-01-oq-03
 
 ## Current State
-**Phase**: ORIENT (advanced from OBSERVE this session)
+**Phase**: ACT (Phase-2 scaffold complete)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-07
-**Iteration**: 1
+**Last Updated**: 2026-05-08 (Session 2, researcher-9)
+**Iteration**: 2
 
 ## Current Focus
-Reduce the marginal Multinomial CLT to the Binomial CLT (de Moivre–Laplace)
-via the already-formalised `multinomial_marginal_pmf` and Mathlib's i.i.d.
-CLT applied to the Bernoulli-sum representation of `Binomial(n, p)`.
+Phase-2 STATEMENT scaffold landed. The Lean file
+`proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` exists; the multinomial
+marginal CLT is *stated* in CDF form and *derived* (not axiomatized
+separately) from two axioms: the classical de Moivre–Laplace theorem
+(in CDF form) and an opaque `standardNormalCDF` marker. One sorry remains
+in the reduction lemma `multinomialMarginalCDF_eq_binomialCDF` (provable from
+the parent file's `multinomial_marginal_pmf` by fiber regrouping).
 
 ## Active Approach
-Decomposition (see knowledge.md for details):
-- **Sublemma A**: marginal-is-Binomial (DONE in `BinomialTheoremOQ02OQ01OQ02.lean`).
-- **Sublemma B**: `Binomial = ∑ Bernoulli i.i.d.` (Mathlib lookup needed).
-- **Sublemma C**: i.i.d. CLT to Bernoulli (likely a Mathlib one-liner; the
-  genuine Mathlib gap if missing).
-- **Sublemma D**: assembly A + B + C → marginal CLT.
+**CDF-based** rather than the measure-theoretic Bernoulli-sum approach
+sketched in iteration 1. Justification:
+
+- Avoids the heavy `MeasureTheory` + `IsProbabilityMeasure` + Mathlib-CLT
+  setup needed to use `ProbabilityTheory.iid_central_limit_theorem`.
+- Matches the classical de Moivre–Laplace presentation.
+- Keeps the reduction step transparent: the marginal CDF *equals* the
+  binomial CDF (not just converges to it), so `Filter.Tendsto.congr` does
+  the job.
+- Cost: introduces `standardNormalCDF` as `opaque` (counts as +1 axiom);
+  Phase-3 task is to bridge to Mathlib's measure-theoretic Gaussian.
 
 ## Attempt Count
-- Total attempts: 1 (this session)
-- Approaches tried: 1 (decomposition path documented; no Lean code yet)
+- Total attempts: 2 (Sessions 1–2)
+- Approaches tried:
+  - **Iteration 1** (researcher-8, OBSERVE→ORIENT): planned i.i.d.-CLT
+    decomposition (Sublemmas A, B, C, D). No Lean code.
+  - **Iteration 2** (researcher-9, ACT): CDF-based scaffold.
+    `BinomialTheoremOQ02OQ01OQ01OQ03.lean` (178 lines, 2 axioms incl.
+    opaque, 1 sorry, 2 theorems).
 
 ## Blockers
-- Local Docker build has limited memory (~7.65 GiB), making large
-  Mathlib-dependent files risky to verify locally. CI is the ground truth.
-- Mathlib's i.i.d. CLT availability in v4.26.0 needs concrete confirmation
-  before scaffolding the new file.
+- **Build verification**: this session could not run the Docker build
+  for direct compile-check (long iteration time + worktree symlink trap).
+  The scaffold uses well-tested Mathlib idioms (`Filter.Tendsto.congr`,
+  `Real.sqrt`, `Finset.range`); confidence is high but not verified.
+  CI is the ground truth.
+- **Reduction lemma sorry**: the proof of
+  `multinomialMarginalCDF_eq_binomialCDF` is a routine fiber-regrouping
+  + application of the parent's `multinomial_marginal_pmf`. Phase-3 target.
+- **`standardNormalCDF` opaque**: counts as +1 axiom; Phase-3 should
+  bridge to Mathlib's Gaussian measure.
+- **`binomial_clt_pointwise` axiom**: Phase-3 should derive from
+  `ProbabilityTheory.iid_central_limit_theorem` via the Portmanteau
+  theorem at continuity points.
 
 ## Next Action
-**ACT — scaffold new Lean file** in a future session:
-1. Confirm Mathlib's i.i.d. CLT signature.
-2. Create `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with the
-   marginal-CLT statement and sublemmas A + D as fully proved theorems.
-3. If Mathlib's i.i.d. CLT applies directly, complete sublemma C.
-   Otherwise, axiomatise sublemma C and isolate the Mathlib gap.
+
+**Phase-3 (next session)**: discharge the reduction-lemma sorry. The proof
+should follow this skeleton:
+
+```lean
+theorem multinomialMarginalCDF_eq_binomialCDF ... := by
+  -- Regroup the sum over k into fibers over j = k(i₀):
+  rw [show multinomialMarginalCDF s p n i₀ x =
+        ∑ j ∈ Finset.range (n + 1),
+          if (j : ℝ) ≤ x then
+            ∑ k ∈ (s.piAntidiag n).filter (fun k => k i₀ = j),
+              BinomialTheoremOQ02OQ01OQ02.multinomialProb s p n k
+          else 0
+      from ?_]
+  · -- Apply multinomial_marginal_pmf to each fiber:
+    apply Finset.sum_congr rfl
+    intro j hj
+    split_ifs with hjx
+    · rw [BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf s p n hp i₀ hi₀ j
+            (by simp [Finset.mem_range] at hj; omega)]
+    · rfl
+  · -- Reverse the regrouping (sum-over-piAntidiag = sum-over-fibers):
+    sorry  -- standard Finset partition identity
+```
+
+Two subgoals: (1) the fiber-regrouping identity (provable via
+`Finset.sum_partition` or directly), (2) the per-fiber application of
+`multinomial_marginal_pmf`. The second is one rewrite.
+
+**Phase-3 stretch**: discharge `binomial_clt_pointwise` by bridging from
+Mathlib's i.i.d. CLT. This requires the Portmanteau theorem at continuity
+points of the standard normal CDF.
 
 ## References
 - `proofs/Proofs/BinomialTheoremOQ02OQ01OQ02.lean:167` —
-  `multinomial_marginal_pmf` (sublemma A, already proved).
+  `multinomial_marginal_pmf` (used for the reduction lemma).
+- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` —
+  this session's scaffold (178 lines).
+- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/` — gallery
+  entry (created this session).
 - `proofs/Proofs/CentralLimitTheorem.lean:375` — local general CLT
-  (axiomatised at the standardisation step; characteristic-function form).
-- Mathlib: `Mathlib.Probability.Distributions.Binomial` — PMF only,
-  no CLT.
-- Mathlib: `Mathlib.Probability.CentralLimitTheorem` — i.i.d. CLT
-  scaffolding (signature to be verified).
+  (axiomatized at the standardisation step, characteristic-function form).
+- Classical: Feller, *Introduction to Probability Theory*, Vol. I (1968),
+  Ch. VII §3 (de Moivre–Laplace).

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-binomialcdf-def",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 88, "endLine": 95 },
+    "type": "definition",
+    "title": "Concrete CDF of Binomial(n, p)",
+    "content": "binomialCDF n p x is defined as the finite sum ∑_{j=0}^n 𝟙_{[j ≤ x]} · C(n,j) · p^j · (1-p)^(n-j). The indicator is implemented as an `if (j : ℝ) ≤ x then ... else 0` guard. No constraints on p are enforced at the definition level — the de Moivre-Laplace axiom then requires 0 < p < 1.",
+    "mathContext": "$$F_{n,p}(x) = \\sum_{j=0}^n \\mathbf{1}_{[j \\le x]} \\binom{n}{j} p^j (1-p)^{n-j}$$ This is the standard CDF of a Binomial(n,p) random variable evaluated at any real x. For x < 0, F = 0; for x ≥ n, F = 1.",
+    "significance": "key",
+    "relatedConcepts": ["binomial distribution", "cumulative distribution function", "Nat.choose"],
+    "prerequisites": ["binomial PMF", "indicator function", "finite sums"]
+  },
+  {
+    "id": "ann-multinomialmarginalcdf-def",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 96, "endLine": 103 },
+    "type": "definition",
+    "title": "Marginal CDF of Multinomial Coordinate i₀",
+    "content": "multinomialMarginalCDF s p n i₀ x sums multinomialProb s p n k over all compositions k ∈ s.piAntidiag n, gated by the indicator 𝟙_{[k(i₀) ≤ x]}. This is the joint distribution's marginal CDF for coordinate i₀, defined directly without invoking convolution or measure-theoretic marginalization.",
+    "mathContext": "$$F_{X_{i_0}}(x) = P(X_{i_0} \\le x) = \\sum_{k : \\sum k_i = n, k(i_0) \\le x} P(X = k)$$ The reduction lemma below shows this equals binomialCDF n (p i₀) x exactly (not just approximately).",
+    "significance": "key",
+    "relatedConcepts": ["multinomial distribution", "marginal distribution", "Finset.piAntidiag"],
+    "prerequisites": ["multinomialProb", "marginalization"]
+  },
+  {
+    "id": "ann-stdnormalcdf-opaque",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 105, "endLine": 112 },
+    "type": "definition",
+    "title": "Standard Normal CDF (Opaque Marker)",
+    "content": "standardNormalCDF : ℝ → ℝ is declared `opaque`. Lean treats it as an unknown function with no available reductions; we only know its name. The semantic intent is Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt, but bridging from Mathlib's measure-theoretic Gaussian to a CDF function is non-trivial and is left as a Phase-3 target. Note: `opaque` declarations count toward the axiom count.",
+    "mathContext": "$$\\Phi(x) = \\frac{1}{\\sqrt{2\\pi}} \\int_{-\\infty}^x e^{-t^2/2}\\, dt$$ The standard normal CDF; smooth, strictly increasing, with $\\Phi(-\\infty) = 0$, $\\Phi(0) = 1/2$, $\\Phi(+\\infty) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["standard normal distribution", "Gaussian", "opaque declarations"],
+    "prerequisites": ["measure theory", "Lebesgue integration"]
+  },
+  {
+    "id": "ann-binomial-clt-axiom",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 114, "endLine": 131 },
+    "type": "insight",
+    "title": "Axiom: de Moivre-Laplace Theorem",
+    "content": "binomial_clt_pointwise axiomatizes the classical de Moivre-Laplace CLT in CDF form: for 0 < p < 1, the standardized binomial CDF binomialCDF n p (np + x √(np(1-p))) converges pointwise to standardNormalCDF x as n → ∞. Choosing the CDF formulation rather than measure-weak-convergence avoids the measure-theoretic setup needed to use Mathlib's `ProbabilityTheory.iid_central_limit_theorem`. Bridging the two formulations is a Phase-3 task; doing so would discharge this axiom.",
+    "mathContext": "$$F_{n,p}\\!\\left(np + x\\sqrt{np(1-p)}\\right) \\;\\xrightarrow[n\\to\\infty]{}\\; \\Phi(x), \\qquad \\forall x \\in \\mathbb{R},\\ 0 < p < 1.$$ Equivalent to: $(X_n - np) / \\sqrt{np(1-p)} \\Rightarrow \\mathcal{N}(0,1)$ where $X_n \\sim \\text{Binomial}(n,p)$. Historical: de Moivre 1733 (case $p = 1/2$), Laplace 1812 (general $p \\in (0,1)$).",
+    "significance": "key",
+    "relatedConcepts": ["de Moivre-Laplace theorem", "central limit theorem", "convergence in distribution", "Tendsto", "atTop", "nhds"],
+    "prerequisites": ["binomial distribution", "standardization", "convergence of sequences"]
+  },
+  {
+    "id": "ann-reduction-lemma",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 133, "endLine": 149 },
+    "type": "technique",
+    "title": "Reduction Lemma: Marginal CDF = Binomial CDF (sorry, Phase-3)",
+    "content": "multinomialMarginalCDF_eq_binomialCDF asserts that the marginal CDF of the multinomial *equals* (not just approximates) the binomial CDF with parameter p(i₀). The proof (Phase-3 target, currently sorry) regroups the sum over k ∈ s.piAntidiag n into fibers indexed by j = k(i₀) for j = 0, ..., n; on each fiber, BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf provides ∑_{k: k(i₀) = j} multinomialProb s p n k = C(n,j) · p(i₀)^j · (1 - p(i₀))^(n-j). The if-condition (k i₀ : ℝ) ≤ x becomes (j : ℝ) ≤ x, factoring out of the inner sum.",
+    "mathContext": "$$F_{X_{i_0}}(x) \\;=\\; \\sum_{j=0}^n \\mathbf{1}_{[j \\le x]} \\sum_{k: k(i_0) = j} P(X=k) \\;=\\; \\sum_{j=0}^n \\mathbf{1}_{[j \\le x]} \\binom{n}{j} p_{i_0}^j (1 - p_{i_0})^{n-j} \\;=\\; F_{n, p_{i_0}}(x)$$ The middle step uses `multinomial_marginal_pmf`; the outer step is rearranging a sum-of-sums. This is an *equality* of finite sums — no limits, no convergence, just algebraic regrouping.",
+    "significance": "key",
+    "relatedConcepts": ["fiber decomposition", "Finset.sum_partition", "multinomial_marginal_pmf"],
+    "prerequisites": ["BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf", "Finset.piAntidiag"]
+  },
+  {
+    "id": "ann-main-clt-derived",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 151, "endLine": 178 },
+    "type": "insight",
+    "title": "Main Theorem: Multinomial Marginal CLT (Derived, No New Axiom)",
+    "content": "multinomial_marginal_clt is *derived*, not axiomatized. The proof builds a pointwise equality `key : ∀ n, multinomialMarginalCDF (...) = binomialCDF (...)` from the reduction lemma, then applies `Filter.Tendsto.congr` to convert binomial_clt_pointwise into the marginal-CLT statement. Because the reduction is an *equality* (not asymptotic), Tendsto.congr — which only requires pointwise equality of two sequences — is exactly the right tool: it is strictly stronger than needed.",
+    "mathContext": "Schematic: from $F_{X_{i_0}^{(n)}}(\\cdot) = F_{n,p_{i_0}}(\\cdot)$ (reduction) and $F_{n,p_{i_0}}(\\cdot) \\to \\Phi$ (de Moivre-Laplace axiom), conclude $F_{X_{i_0}^{(n)}}(\\cdot) \\to \\Phi$. The proof is one application of `Filter.Tendsto.congr (fun n => (key n).symm)`. The non-degeneracy hypotheses 0 < p(i₀) < 1 are required by the de Moivre-Laplace axiom — without them, the standardization $\\sqrt{np(1-p)}$ vanishes.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto.congr", "convergence in distribution", "marginal-binomial reduction"],
+    "prerequisites": ["binomial_clt_pointwise", "multinomialMarginalCDF_eq_binomialCDF", "Filter.Tendsto"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binomialTheoremOq02Oq01Oq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binomialTheoremOq02Oq01Oq01Oq03Annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const binomialTheoremOq02Oq01Oq01Oq03Data: ProofData = {
+  proof: binomialTheoremOq02Oq01Oq01Oq03Proof,
+  annotations: binomialTheoremOq02Oq01Oq01Oq03Annotations,
+}
+
+export default binomialTheoremOq02Oq01Oq01Oq03Data

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+  "title": "Multinomial Marginal Central Limit Theorem (Phase-2 Scaffold)",
+  "description": "States the multinomial marginal CLT as a CDF-pointwise convergence to the standard normal, derived from the de Moivre-Laplace axiom plus the marginal-PMF identity proved in BinomialTheoremOQ02OQ01OQ02",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026-05-08",
+    "status": "axiomatized",
+    "tags": [
+      "probability",
+      "central-limit-theorem",
+      "multinomial",
+      "binomial",
+      "de-moivre-laplace",
+      "convergence-in-distribution"
+    ],
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
+    "badge": "axiom",
+    "sorries": 1,
+    "dateAdded": "2026-05-08",
+    "axiomCount": 2,
+    "lineCount": 178,
+    "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. (2) `standardNormalCDF` opaque marker — the standard normal CDF Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt, currently opaque pending bridge from Mathlib's measure-theoretic Gaussian. The main theorem `multinomial_marginal_clt` is *derived* from these — it is not itself an axiom. The Phase-3 reduction lemma `multinomialMarginalCDF_eq_binomialCDF` carries one sorry (provable from the already-proved `multinomial_marginal_pmf`).",
+    "originalContributions": [
+      "binomialCDF: concrete CDF of Binomial(n,p) as a finite sum of binomial PMF terms with a step indicator",
+      "multinomialMarginalCDF: marginal CDF of coordinate i₀ of Multinomial(n,p), defined directly from multinomialProb",
+      "binomial_clt_pointwise: axiomatic statement of de Moivre-Laplace in CDF form (statement matches the classical formulation, avoids measure-theoretic machinery)",
+      "multinomialMarginalCDF_eq_binomialCDF: stated reduction lemma whose proof is a fiber-grouping over k(i₀) values plus the parent's multinomial_marginal_pmf (sorry; Phase-3 target)",
+      "multinomial_marginal_clt: derived theorem (no axiom of its own) combining the above via Filter.Tendsto.congr"
+    ],
+    "theoremCount": 2,
+    "substantiveTheoremCount": 1,
+    "definitionCount": 2
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Multinomial",
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Analysis.SpecialFunctions.Sqrt",
+      "Mathlib.Topology.Algebra.Order.LiminfLimsup",
+      "Mathlib.Tactic",
+      "Proofs.BinomialTheoremOQ02OQ01OQ02"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
+    "lineCount": 178,
+    "axiomCount": 2,
+    "theoremCount": 2,
+    "substantiveTheoremCount": 1,
+    "duplicateTheorems": 0,
+    "definitionCount": 2,
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
+    "sorries": 1
+  },
+  "mainTheorems": [
+    {
+      "name": "multinomial_marginal_clt",
+      "type": "core",
+      "description": "Standardized multinomial marginal CDF converges pointwise to the standard normal CDF (DERIVED, no separate axiom).",
+      "leanType": "(s : Finset α) (p : α → ℝ) (hp : ∑ i ∈ s, p i = 1) (i₀ : α) (hi₀ : i₀ ∈ s) (hp0 : 0 < p i₀) (hp1 : p i₀ < 1) (x : ℝ) → Filter.Tendsto (fun n => multinomialMarginalCDF s p n i₀ ((n : ℝ) * p i₀ + x * Real.sqrt ((n : ℝ) * p i₀ * (1 - p i₀)))) Filter.atTop (nhds (standardNormalCDF x))"
+    },
+    {
+      "name": "multinomialMarginalCDF_eq_binomialCDF",
+      "type": "supporting",
+      "description": "The marginal CDF of the multinomial equals the binomial CDF with parameter p(i₀); reduction lemma (sorry, Phase-3 target — provable from multinomial_marginal_pmf).",
+      "leanType": "(s : Finset α) (p : α → ℝ) (n : ℕ) (hp : ∑ i ∈ s, p i = 1) (i₀ : α) (hi₀ : i₀ ∈ s) (x : ℝ) → multinomialMarginalCDF s p n i₀ x = binomialCDF n (p i₀) x"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-cdf-defs",
+      "title": "CDF Definitions: Binomial and Multinomial Marginal",
+      "range": null,
+      "startLine": 83,
+      "endLine": 103
+    },
+    {
+      "id": "sec-stdnormal",
+      "title": "Standard Normal CDF (opaque)",
+      "range": null,
+      "startLine": 105,
+      "endLine": 112
+    },
+    {
+      "id": "sec-binomial-clt-axiom",
+      "title": "Axiom: Classical de Moivre-Laplace (Binomial CLT)",
+      "range": null,
+      "startLine": 114,
+      "endLine": 131
+    },
+    {
+      "id": "sec-reduction",
+      "title": "Reduction Lemma: Multinomial Marginal CDF = Binomial CDF",
+      "range": null,
+      "startLine": 133,
+      "endLine": 149
+    },
+    {
+      "id": "sec-main",
+      "title": "Main Theorem: Multinomial Marginal CLT (Derived)",
+      "range": null,
+      "startLine": 151,
+      "endLine": 178
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Central Limit Theorem traces from de Moivre's 1733 result that the standardized binomial $(X-np)/\\sqrt{np(1-p)}$ converges to the standard normal, through Laplace (1812), Lyapunov (1901), and Lindeberg (1922). The multinomial marginal CLT is the natural extension to a single coordinate of a multinomial vector: since each marginal $X_i$ of a $\\text{Multinomial}(n; p_1, \\ldots, p_k)$ is itself $\\text{Binomial}(n, p_i)$, the de Moivre-Laplace theorem applies directly. The joint multinomial CLT (vector form) is more subtle — coordinates sum to $n$, so the limiting distribution is degenerate multivariate normal — and is out of scope for this entry.",
+    "problemStatement": "**Open Question (OQ-03 from binomial-theorem-oq-02-oq-01-oq-01)**: Can the multinomial marginal CLT be formalized in Lean 4? Specifically: for $X \\sim \\text{Multinomial}(n; p_1, \\ldots, p_k)$ and any coordinate $i_0$ with $0 < p_{i_0} < 1$, does the standardized marginal $(X_{i_0} - n p_{i_0}) / \\sqrt{n p_{i_0}(1 - p_{i_0}})$ converge in distribution to $\\mathcal{N}(0, 1)$ as $n \\to \\infty$?\n\n**Answer**: Yes, *as a derivation* — the marginal-PMF identity $\\sum_{k: k(i_0) = j} P(X=k) = \\binom{n}{j} p_{i_0}^j (1-p_{i_0})^{n-j}$ proved in `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf` reduces the marginal CLT to the classical de Moivre-Laplace theorem on $\\text{Binomial}(n, p_{i_0})$. We axiomatize de Moivre-Laplace and a `standardNormalCDF` marker; the marginal CLT then follows by `Filter.Tendsto.congr`.",
+    "text": "Multinomial marginal CLT formalized in CDF form — derived (not axiomatized separately) from de Moivre-Laplace plus the marginal-PMF identity already proved in the parent file",
+    "proofStrategy": "(1) Define $\\text{binomialCDF}\\,n\\,p\\,x = \\sum_{j=0}^n \\mathbf{1}_{[j \\le x]} \\binom{n}{j} p^j (1-p)^{n-j}$ and $\\text{multinomialMarginalCDF}\\,s\\,p\\,n\\,i_0\\,x = \\sum_{k \\in \\pi(s,n)} \\mathbf{1}_{[k(i_0) \\le x]} P(X=k)$. (2) Axiomatize de Moivre-Laplace: $\\text{binomialCDF}\\,n\\,p\\,(np + x\\sqrt{np(1-p)}) \\to \\Phi(x)$ for $0 < p < 1$. (3) Reduce: $\\text{multinomialMarginalCDF}\\,s\\,p\\,n\\,i_0\\,x = \\text{binomialCDF}\\,n\\,(p\\,i_0)\\,x$ by regrouping the sum into fibers over $k(i_0)$ and applying the parent's `multinomial_marginal_pmf`. (4) Combine via `Filter.Tendsto.congr` to get the marginal CLT.",
+    "keyInsights": [
+      "The marginal-PMF identity from `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf` does the heavy lifting: once it's established that $\\sum_{k: k(i_0) = j} P(X=k) = \\binom{n}{j} p_{i_0}^j (1-p_{i_0})^{n-j}$, the multinomial marginal CDF *equals* the binomial CDF (not just converges to it), so the CLT for the marginal is exactly the CLT for the binomial.",
+      "Stating the CLT in CDF form (`Filter.Tendsto` of `binomialCDF`) avoids the measure-theoretic setup needed to instantiate Mathlib's `iid_central_limit_theorem`. The CDF form matches the classical de Moivre-Laplace presentation and keeps the reduction transparent.",
+      "Declaring `standardNormalCDF` as `opaque` records that it is *some* function ℝ → ℝ — Lean treats it as an unknown — while keeping the namespace open for a Phase-3 substitution that bridges to Mathlib's Gaussian measure.",
+      "The DERIVED theorem `multinomial_marginal_clt` is not an axiom: it follows from the de Moivre-Laplace axiom plus the reduction lemma via `Filter.Tendsto.congr`. The reduction itself is provable (from already-proved Mathlib + parent-file lemmas), so closing the sorry would shift the only assumption to de Moivre-Laplace.",
+      "The non-degeneracy hypothesis $0 < p_{i_0} < 1$ is essential: $p_{i_0} = 0$ gives $X_{i_0} = 0$ a.s. (degenerate), and $p_{i_0} = 1$ gives $X_{i_0} = n$ a.s. (degenerate); the standardization $\\sqrt{np_{i_0}(1-p_{i_0})}$ vanishes in both cases.",
+      "The joint multinomial CLT (vector convergence to a degenerate multivariate normal supported on the hyperplane $\\sum y_i = 0$) is *not* derivable from coordinate-wise marginal CLTs — Cramér-Wold is required — and is out of scope here."
+    ],
+    "prerequisites": [
+      "BinomialTheoremOQ02OQ01OQ02: multinomialProb, multinomial_marginal_pmf",
+      "Real.sqrt, Filter.Tendsto, Filter.Tendsto.congr",
+      "Probability theory: convergence in distribution, CDFs",
+      "Classical reference: Feller, Introduction to Probability Theory, Vol. I (1968), Ch. VII §3 (de Moivre-Laplace)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The multinomial marginal CLT can be stated cleanly in CDF form and *derived* (not axiomatized separately) from two axioms: the classical de Moivre-Laplace theorem on standardized binomial CDFs, and an opaque marker for the standard normal CDF. The derivation uses the marginal-PMF identity already proved in the parent file (`BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf`). One sorry remains in the reduction lemma (Phase-3 target) — the proof is a routine fiber-grouping of `s.piAntidiag n` over $k(i_0)$ values plus the parent identity.",
+    "implications": "The reduction-based scaffold demonstrates that multinomial marginal CLT does not require new probabilistic machinery beyond what is already proved for the binomial case. Once Mathlib provides a CDF-form de Moivre-Laplace (via a measure-weak-convergence bridge from `ProbabilityTheory.iid_central_limit_theorem`), this entry's `binomial_clt_pointwise` axiom becomes derivable, leaving zero axioms (modulo the `standardNormalCDF` opaque, which can be replaced by a Mathlib-Gaussian-measure-CDF bridge).",
+    "openQuestions": [
+      "Can the reduction lemma `multinomialMarginalCDF_eq_binomialCDF` be proved by fiber-grouping over $k(i_0)$ values? The proof should regroup $\\sum_{k \\in \\pi(s,n)}$ into $\\sum_{j=0}^n \\sum_{k: k(i_0) = j}$ and apply `multinomial_marginal_pmf`.",
+      "Can `binomial_clt_pointwise` be discharged from Mathlib's `ProbabilityTheory.iid_central_limit_theorem`? Bridging a measure-weak-convergence statement to a CDF-pointwise-convergence statement requires the Portmanteau theorem at continuity points of the limit CDF.",
+      "Can the JOINT multinomial CLT (convergence of the full standardized vector $(X - np)/\\sqrt{n}$ to a degenerate multivariate normal supported on $\\{y : \\sum y_i = 0\\}$) be stated and derived via Cramér-Wold from the marginal CLT plus a covariance computation (already available in `BinomialTheoremOQ02OQ01OQ03.multinomial_covariance`)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01",
+      "relationship": "answers-question",
+      "description": "Answers OQ-03 of binomial-theorem-oq-02-oq-01-oq-01: marginal CLT for multinomial coordinates"
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "uses",
+      "description": "Imports multinomialProb and depends on multinomial_marginal_pmf for the reduction-to-binomial step"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "specializes",
+      "description": "The de Moivre-Laplace axiom here is the binomial special case of the general CLT in central-limit-theorem"
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling OQ-03 from oq-02-oq-01: multinomial covariance — relevant for a future joint-CLT entry via Cramér-Wold"
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
   "title": "Multinomial CLT in Lean: does (Xᵢ - npᵢ)/√(npᵢ(1-pᵢ)) converge in distribution to N(0,1) for each coordinate as n → ∞?",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -34,30 +34,44 @@
     "goal": "Phase-2: produce `Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with (a) a precise Lean statement of the marginal CLT for the i-th coordinate of Multinomial(n, p₁,…,pₖ), (b) either a proof via Mathlib's `ProbabilityTheory.iid_central_limit_theorem` applied to the indicator variables Yⱼ = 𝟙[trial j → outcome i] (which are Bernoulli(pᵢ) i.i.d.), or an axiomatized statement with full proof sketch, and (c) a coordinate-free version using Cramér-Wold for the joint vector CLT."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-05-07T20:30:00.000Z",
-    "iteration": 1,
-    "focus": "Phase-2 orientation: decomposition (A/B/C/D) recorded in research/problems/<slug>/knowledge.md. Sublemma A is DONE in BinomialTheoremOQ02OQ01OQ02.lean (`multinomial_marginal_pmf`). Next ACT session: confirm Mathlib's i.i.d. CLT signature and scaffold the new Lean file.",
+    "phase": "ACT",
+    "since": "2026-05-08T03:30:00.000Z",
+    "iteration": 2,
+    "focus": "Phase-2 STATEMENT scaffold complete: BinomialTheoremOQ02OQ01OQ01OQ03.lean (178 lines, 2 axioms incl. opaque, 1 sorry, 2 theorems). Multinomial marginal CLT stated in CDF form and DERIVED via Filter.Tendsto.congr from the de Moivre-Laplace axiom and the marginal-PMF identity already proved in the parent file. Phase-3 next: discharge the multinomialMarginalCDF_eq_binomialCDF reduction lemma sorry by fiber regrouping over k(i₀).",
     "blockers": [
-      "Local Docker build memory is ~7.65 GiB — risky for a new Mathlib-dependent file. CI verification only."
+      "Build verification: this session could not run docker-build.sh; CI is the ground truth.",
+      "Reduction lemma sorry (Phase-3 target, provable from multinomial_marginal_pmf).",
+      "standardNormalCDF opaque (counts as +1 axiom; bridge to Mathlib Gaussian is a Phase-3 task).",
+      "binomial_clt_pointwise axiom (Phase-3 target via Portmanteau bridge to Mathlib iid_central_limit_theorem)."
     ],
-    "nextAction": "Phase 3 (ACT) in a future session: scaffold `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with sublemma A re-export, the marginal-CLT statement, and either a full proof via Mathlib's i.i.d. CLT applied to the Bernoulli-sum representation or a one-axiom isolation (axiomatise sublemma C only).",
+    "nextAction": "Phase-3: discharge multinomialMarginalCDF_eq_binomialCDF by fiber regrouping (skeleton in state.md). After that: bridge binomial_clt_pointwise to Mathlibs ProbabilityTheory.iid_central_limit_theorem via Portmanteau.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "OBSERVE phase. The hard structural work is DONE: `BinomialTheoremOQ02OQ01.lean` proves the multinomial PMF normalization, and `BinomialTheoremOQ02OQ01OQ02.lean` proves marginals-are-binomial via probability-generating-functions. The remaining task is to STATE the standardized marginal CLT and either prove it from Mathlib's CLT or cleanly axiomatize. The natural strategy is the Bernoulli-sum representation: Xᵢ = ∑_{j=1..n} 𝟙[trial j hits outcome i] where each indicator is Bernoulli(pᵢ) i.i.d., reducing to Mathlib's i.i.d. CLT.",
-    "builtItems": [],
+    "progressSummary": "ACT phase, Phase-2 scaffold complete. Lean file BinomialTheoremOQ02OQ01OQ01OQ03.lean (178 lines) STATES the multinomial marginal CLT in CDF form and DERIVES it (via Filter.Tendsto.congr) from two axioms: binomial_clt_pointwise (de Moivre-Laplace) and standardNormalCDF (opaque). One sorry remains in the reduction lemma multinomialMarginalCDF_eq_binomialCDF (provable from BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf by fiber regrouping). Gallery entry created. Path chosen was CDF-based (not the Bernoulli-sum Mathlib-iid-CLT path planned in Session 1) to avoid heavy MeasureTheory setup; trade-off is +1 axiom (standardNormalCDF opaque) for net axiomCount=2.",
+    "builtItems": [
+      "binomialCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:90 (concrete CDF of Binomial(n,p))",
+      "multinomialMarginalCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:97 (marginal CDF of multinomial)",
+      "standardNormalCDF (opaque) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:112",
+      "binomial_clt_pointwise (axiom, de Moivre-Laplace in CDF form) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:126",
+      "multinomialMarginalCDF_eq_binomialCDF (theorem, sorry) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:144",
+      "multinomial_marginal_clt (DERIVED theorem, no separate axiom) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:160",
+      "Gallery entry src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/ (meta.json, annotations.json, index.ts)"
+    ],
     "insights": [
       "Multinomial marginal Xᵢ ~ Binomial(n, pᵢ) is ALREADY proved (`BinomialTheoremOQ02OQ01OQ02.lean`); OQ-02-OQ-01-OQ-01-OQ-03 'just' needs the binomial CLT ON TOP",
       "Bernoulli-sum representation is the cleanest formal approach: Xᵢ = ∑_{j=1}^n Y_j where Y_j ~ Bernoulli(pᵢ) i.i.d.; then mean = npᵢ, variance = npᵢ(1-pᵢ), and Mathlib's i.i.d. CLT applies directly",
       "Mathlib's `ProbabilityTheory.iid_central_limit_theorem` gives convergence in distribution for i.i.d. sequences with finite second moment — Bernoulli has bounded second moment, so it applies",
       "The standardization `(X-μ)/σ → N(0,1)` is the canonical form and matches Mathlib's CLT statement",
       "The JOINT multinomial CLT (vector form) requires Cramér-Wold and a degenerate multivariate normal (since coordinates are constrained to sum to n); not in scope for OQ-03 (marginal only)",
-      "A clean STATEMENT-only PR (axiomatize the binomial CLT, then derive the multinomial marginal CLT from `binomial_marginal_of_multinomial`) would be a high-value Phase-2 deliverable even without full Mathlib-CLT proof"
+      "A clean STATEMENT-only PR (axiomatize the binomial CLT, then derive the multinomial marginal CLT from `binomial_marginal_of_multinomial`) would be a high-value Phase-2 deliverable even without full Mathlib-CLT proof",
+      "CDF-form CLT statement avoids the heavy MeasureTheory + IsProbabilityMeasure + Mathlib-iid-CLT setup needed for the measure-weak-convergence path; cost is +1 axiom (standardNormalCDF opaque)",
+      "The reduction multinomialMarginalCDF = binomialCDF is an *equality* of finite sums (not asymptotic), so Filter.Tendsto.congr suffices to lift the binomial CLT axiom to the marginal CLT",
+      "The DERIVED-theorem pattern keeps the axiom inventory honest: multinomial_marginal_clt is not itself an axiom, only the underlying de Moivre-Laplace + opaque CDF marker are"
     ],
     "mathlibGaps": [
       "Mathlib's `Mathlib.Probability.Distributions.Binomial` exposes the PMF but the named theorem 'binomial CLT' / 'de Moivre-Laplace' may not be present in canonical form",
@@ -65,12 +79,10 @@
       "Multivariate CLT (Cramér-Wold) — partial in Mathlib; would be needed for the joint vector form (out of scope for this OQ but referenced in nextSteps)"
     ],
     "nextSteps": [
-      "Phase-2: scaffold `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` importing `Proofs.BinomialTheoremOQ02OQ01OQ02` (marginal binomial proof) and `Mathlib.Probability.CentralLimitTheorem`",
-      "Phase-2: state the marginal CLT as `theorem multinomial_marginal_clt : ∀ (i : Fin k), Tendsto (fun n => ((X_n i - n * p i) / Real.sqrt (n * p i * (1 - p i))).distribution) atTop (𝓝 (gaussianReal 0 1))` (using Mathlib's `gaussianReal`)",
-      "Phase-2: prove via the Bernoulli-sum representation if Mathlib's i.i.d. CLT applies cleanly; otherwise axiomatize as `axiom multinomial_marginal_clt` with proof-sketch citation to de Moivre-Laplace",
-      "Phase-3: create gallery entry `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/` with `meta.json` + `annotations.json` + `index.ts` linked to `binomial-theorem-oq-02-oq-01-oq-01` parent",
-      "Stretch: state and (axiomatize) the JOINT multinomial CLT to a degenerate multivariate normal as a separate axiom for completeness; cross-reference to a future `multinomial-vector-clt` OQ if that's how the seeker tags it",
-      "Cross-link with `central-limit-theorem` and `de-moivre-oq-*` gallery entries (the de Moivre-Laplace theorem is the foundational classical instance)"
+      "Phase-3 reduction proof: discharge multinomialMarginalCDF_eq_binomialCDF by regrouping s.piAntidiag n into fibers over k(i₀), then applying multinomial_marginal_pmf to each fiber. Skeleton in state.md.",
+      "Phase-3 stretch: bridge binomial_clt_pointwise to Mathlibs ProbabilityTheory.iid_central_limit_theorem via the Portmanteau theorem at continuity points of the standard normal CDF.",
+      "Phase-3 stretch: replace standardNormalCDF opaque with a measure-theoretic CDF derived from Mathlibs Gaussian measure (in Mathlib.Probability.Distributions.Gaussian.Basic).",
+      "Joint multinomial CLT (sibling OQ): use Cramer-Wold + the covariance computation in BinomialTheoremOQ02OQ01OQ03.multinomial_covariance to get vector convergence to a degenerate multivariate normal."
     ]
   },
   "tags": [
@@ -121,7 +133,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.055Z",
-  "lastUpdate": "2026-05-07T19:20:00.000Z",
+  "lastUpdate": "2026-05-08T03:30:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -256,6 +268,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
+      "filename": "BinomialTheoremOQ02OQ01OQ01OQ03.lean",
+      "lineCount": 178,
+      "theoremCount": 2,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Session 2 of researcher-9 on `binomial-theorem-oq-02-oq-01-oq-01-oq-03` (multinomial marginal CLT). Phase-2 STATEMENT scaffold landed.

This session took a **CDF-based path** rather than the Bernoulli-sum i.i.d.-CLT path planned in Session 1, avoiding the heavy `MeasureTheory` + `IsProbabilityMeasure` setup that the measure-theoretic approach would require.

## What was built

### Lean file: `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` (178 lines)

| Component | Kind | Notes |
|---|---|---|
| `binomialCDF n p x` | def | Concrete CDF of Binomial(n,p) |
| `multinomialMarginalCDF s p n i₀ x` | def | Marginal CDF of coordinate `i₀` of multinomial |
| `standardNormalCDF` | **opaque** | Marker for Φ(x); counts as +1 axiom |
| `binomial_clt_pointwise` | **axiom** | Classical de Moivre–Laplace (1733/1812) in CDF form |
| `multinomialMarginalCDF_eq_binomialCDF` | theorem (**sorry**) | Reduction lemma; Phase-3 target |
| `multinomial_marginal_clt` | theorem (**derived**) | Combines the two via `Filter.Tendsto.congr` — no separate axiom |

**Axiom inventory: 2** (`binomial_clt_pointwise` + `standardNormalCDF` opaque). The main theorem `multinomial_marginal_clt` is *derived*, not axiomatized.

### Gallery entry: `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/`

- `meta.json` — `status: axiomatized`, `badge: axiom`, `sorries: 1`, `axiomCount: 2`, `lineCount: 178`. Includes `mainTheorems`, `sections`, `overview`, `conclusion`, `crossReferences`.
- `annotations.json` — 6 annotations covering the CDF defs, the de Moivre–Laplace axiom, the reduction lemma, and the derived main theorem.
- `index.ts` — standard proof-data export pattern.

### Research records

- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md` — Phase advanced to ACT; documents Phase-3 reduction skeleton.
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md` — Session 2 entry recording the CDF approach, axiom-count rationale, and Phase-3 plan.
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json` — `phase: ACT`, refreshed `knowledge.{progressSummary,builtItems,insights,nextSteps}`, new `leanFiles` entry.

## Why CDF instead of Bernoulli-sum

Session 1 planned to use Mathlib's `ProbabilityTheory.iid_central_limit_theorem` applied to a Bernoulli-sum representation `Y_n = Σⱼ B_j`, `B_j ~ Bernoulli(p)`. That path requires:

- Setting up an i.i.d. probability space with sample space `Fin n → {0,1}`.
- Constructing the binomial distribution as a sum of Bernoulli i.i.d.s.
- Invoking the Mathlib i.i.d. CLT (signature unverified for v4.26.0).
- Bridging measure-weak-convergence to a CDF formulation (Portmanteau).

The CDF path collapses all of this to: an axiom stating de Moivre–Laplace in CDF form, an *equality* `multinomialMarginalCDF = binomialCDF` (provable from the parent's `multinomial_marginal_pmf` by fiber regrouping), and one application of `Filter.Tendsto.congr`.

Trade-off: +1 axiom (`standardNormalCDF` opaque) for net `axiomCount = 2` and a much smaller surface area.

## Honest reporting

- This session **could not run** `./proofs/scripts/docker-build.sh` to verify the scaffold compiles (long Docker iteration time + worktree symlink trap that prevents browsing Mathlib directly). CI is the ground truth.
- The scaffold uses well-tested Mathlib idioms (`Filter.Tendsto.congr`, `Real.sqrt`, `Finset.range`); confidence is moderate-high but unverified.
- The reduction-lemma sorry is **provable** from already-proved parent lemmas (skeleton in `state.md`); closing it would leave 0 sorries, with the only assumptions being de Moivre–Laplace (axiom) and the `standardNormalCDF` opaque.
- This is **Phase-2 scaffolding**, not the answer to OQ-03 — the answer is the *derivation chain*; the binomial CLT itself is axiomatized.

## Test plan

- [ ] **Unverified locally**: Docker build of `Proofs.BinomialTheoremOQ02OQ01OQ01OQ03`. CI is the ground truth.
- [x] Used `Filter.Tendsto.congr` API (standard, in Mathlib for years).
- [x] Used parent file's `multinomialProb` from `BinomialTheoremOQ02OQ01OQ02` (already on main, builds clean).
- [x] All counts in `meta.json` match the file (lineCount=178, axiomCount=2, theoremCount=2, definitionCount=2, sorries=1).

## Status

**Outcome**: progress (Phase-2 ACT scaffold).
**Status**: `axiomatized` (badge: `axiom`).
**Next steps**:

1. **Phase-3 next session**: discharge `multinomialMarginalCDF_eq_binomialCDF` by fiber regrouping (skeleton in `state.md`).
2. **Phase-3 stretch**: bridge `binomial_clt_pointwise` to Mathlib's `iid_central_limit_theorem` via Portmanteau.
3. **Sibling OQ**: joint multinomial CLT via Cramér–Wold + the covariance computation in `BinomialTheoremOQ02OQ01OQ03.multinomial_covariance`.

🤖 Generated by researcher-9