### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): S6 — uniform Z/2 lower bound at all d (incl. odd)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -316,6 +316,141 @@ theorem symBUDim_eight_lower_unconditional (k : ℕ) (hk : 0 < k) :
     2 * k - 1 ≤ symBUDim 8 (2 * k) :=
   symBUDim_even_lower 8 k (by norm_num) hk
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART VIII: General-d (odd OR even) unconditional lower bound from Z/2
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Uniform unconditional lower bound** (axiom-free up to parent's axioms),
+    valid for ALL `d ≥ 1` (not just even):
+        `d - 1 ≤ symBUDim n d`  for `n ≥ 2`.
+
+    Strategy: route through the Z/2 subgroup. The parent provides
+    - `symBUDim_two d : symBUDim 2 d = buDim 2 d`,
+    - `symBUDim_le_of_le 2 n d (hn : 2 ≤ n) : symBUDim 2 d ≤ symBUDim n d`,
+    - `buDim_two m : buDim 2 (m + 1) = m`.
+    Combining these at `d = (d - 1) + 1` (valid since `d ≥ 1`) yields
+    `buDim 2 d = d - 1`, hence `d - 1 ≤ symBUDim n d`.
+
+    This **strictly improves** `symBUDim_even_lower` at odd `d`:
+    - For `d = 2k`: `d - 1 = 2k - 1` (matches `symBUDim_even_lower`).
+    - For `d = 2k + 1`: `d - 1 = 2k > 2k - 1 = 2 * (d / 2) - 1`,
+      so this gives a *strictly stronger* odd-d bound. -/
+theorem symBUDim_lower_z2 (n d : ℕ) (hn : 2 ≤ n) (hd : 0 < d) :
+    d - 1 ≤ symBUDim n d := by
+  -- Express `d` as `(d - 1) + 1` so we can use `buDim_two`.
+  have hd' : d = (d - 1) + 1 := by omega
+  -- Step 1: `buDim 2 d = d - 1` from parent's `buDim_two`.
+  have h1 : buDim 2 d = d - 1 := by
+    conv_lhs => rw [hd']
+    exact buDim_two (d - 1)
+  -- Step 2: `symBUDim 2 d = buDim 2 d` from parent's `symBUDim_two`.
+  have h2 : symBUDim 2 d = buDim 2 d := symBUDim_two d
+  -- Step 3: monotonicity 2 ≤ n.
+  have h3 : symBUDim 2 d ≤ symBUDim n d := symBUDim_le_of_le 2 n d hn
+  rw [h2, h1] at h3
+  exact h3
+
+/-- **Odd-d uniform lower bound** (corollary of `symBUDim_lower_z2`):
+    for `n ≥ 2` and `k ≥ 0`, `2 * k ≤ symBUDim n (2 * k + 1)`.
+
+    This bound is **strictly stronger** than what `symBUDim_even_lower`
+    produces at odd dimension via floor-rounding: `2 * ((2k+1) / 2) - 1
+    = 2k - 1`, while we get `2k`. Captures the extra "odd dimension"
+    contribution from the classical Borsuk-Ulam map at p = 2. -/
+theorem symBUDim_odd_lower_unconditional (n k : ℕ) (hn : 2 ≤ n) :
+    2 * k ≤ symBUDim n (2 * k + 1) := by
+  have h := symBUDim_lower_z2 n (2 * k + 1) hn (by omega)
+  -- `(2 * k + 1) - 1 = 2 * k` definitionally; ensure the rewrite goes through.
+  have heq : (2 * k + 1) - 1 = 2 * k := by omega
+  rw [heq] at h
+  exact h
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART IX: General-d closed form at n = 2 (axiom-free)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Axiom-free closed form at n = 2 for ALL d ≥ 1**:
+        `symBUDim 2 d = d - 1`.
+
+    Strengthens `symBUDim_two_even_formula_unconditional` (which only
+    handled even d) by routing through `buDim_two` at the general-d shape.
+    Uses only parent's `symBUDim_two` (the n=2 base axiom) and `buDim_two`
+    (the classical Borsuk-Ulam in any dimension).
+
+    Note: This is the **complete picture** at n = 2 — independent of the
+    new `symBUDim_eq_largestPrime` axiom — because the parent already pins
+    `symBUDim 2 = buDim 2`, and `buDim_two` is the classical formula. -/
+theorem symBUDim_two_general_unconditional (d : ℕ) (hd : 0 < d) :
+    symBUDim 2 d = d - 1 := by
+  rw [symBUDim_two d]
+  have hd' : d = (d - 1) + 1 := by omega
+  conv_lhs => rw [hd']
+  exact buDim_two (d - 1)
+
+/-- **Concrete axiom-free instance at odd d**: `symBUDim 2 3 = 2`.
+    Companion to `symBUDim_two_four_unconditional`. -/
+theorem symBUDim_two_three_unconditional : symBUDim 2 3 = 2 := by
+  have := symBUDim_two_general_unconditional 3 (by norm_num)
+  simpa using this
+
+/-- **Concrete axiom-free instance at odd d**: `symBUDim 2 5 = 4`.
+    Smallest "interesting" odd dimension (d = 5 corresponds to the
+    standard `S^4 → ℝ^5` Borsuk-Ulam scenario). -/
+theorem symBUDim_two_five_unconditional : symBUDim 2 5 = 4 := by
+  have := symBUDim_two_general_unconditional 5 (by norm_num)
+  simpa using this
+
+/-- **Concrete axiom-free instance at odd d**: `symBUDim 2 7 = 6`. -/
+theorem symBUDim_two_seven_unconditional : symBUDim 2 7 = 6 := by
+  have := symBUDim_two_general_unconditional 7 (by norm_num)
+  simpa using this
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART X: Concrete odd-d unconditional lower bounds (n ≥ 3)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Odd d = 3 lower bound at S₃**: `2 ≤ symBUDim 3 3` (axiom-free). -/
+theorem symBUDim_three_three_lower_unconditional : 2 ≤ symBUDim 3 3 := by
+  have := symBUDim_odd_lower_unconditional 3 1 (by norm_num)
+  simpa using this
+
+/-- **Odd d = 3 lower bound at S₄**: `2 ≤ symBUDim 4 3` (axiom-free).
+    Note: S₄ has the V₄ Klein-4 subgroup (cited in the problem statement
+    as a key test case); the Z/2 lower bound holds regardless. -/
+theorem symBUDim_four_three_lower_unconditional : 2 ≤ symBUDim 4 3 := by
+  have := symBUDim_odd_lower_unconditional 4 1 (by norm_num)
+  simpa using this
+
+/-- **Odd d = 5 lower bound at S₃**: `4 ≤ symBUDim 3 5` (axiom-free).
+    For odd d the largestPrimeBelow approach gives only `2k - 1 = 3` (via
+    `buDim_prime`'s even-d range), but Z/2's classical Borsuk-Ulam in odd
+    dimension yields the **strictly tighter** bound `d - 1 = 4`. -/
+theorem symBUDim_three_five_lower_unconditional : 4 ≤ symBUDim 3 5 := by
+  have := symBUDim_odd_lower_unconditional 3 2 (by norm_num)
+  simpa using this
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XI: Monotonicity of largestPrimeBelow
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Monotonicity** of `largestPrimeBelow`: if `m ≤ n`, then
+    `largestPrimeBelow m ≤ largestPrimeBelow n` (for `m ≥ 2`).
+
+    Structural lemma about the prime-selector function: enlarging the
+    search bound can only enlarge (or preserve) the largest prime found.
+    Useful for any case-bound argument that compares `p*` across `n`'s.
+
+    Proof: Let `q := largestPrimeBelow m`. Since `m ≥ 2`, `q` is prime
+    and `q ≤ m ≤ n`. By `Nat.le_findGreatest` applied at `n`, we get
+    `q ≤ findGreatest Nat.Prime n = largestPrimeBelow n`. -/
+theorem largestPrimeBelow_mono {m n : ℕ} (hm : 2 ≤ m) (hmn : m ≤ n) :
+    largestPrimeBelow m ≤ largestPrimeBelow n := by
+  have hp_prime : Nat.Prime (largestPrimeBelow m) := largestPrimeBelow_isPrime m hm
+  have hp_le_m : largestPrimeBelow m ≤ m := largestPrimeBelow_le m
+  have hp_le_n : largestPrimeBelow m ≤ n := hp_le_m.trans hmn
+  unfold largestPrimeBelow
+  exact Nat.le_findGreatest hp_le_n hp_prime
+
 /-
 ## Summary
 
@@ -361,6 +496,27 @@ theorem symBUDim_eight_lower_unconditional (k : ℕ) (hk : 0 < k) :
 - `symBUDim_five_lower_unconditional`, `symBUDim_two_four_unconditional`,
   `symBUDim_six_lower_unconditional`, `symBUDim_seven_lower_unconditional`,
   `symBUDim_eight_lower_unconditional`.
+- **NEW (S6)**: `symBUDim_two_three_unconditional`,
+  `symBUDim_two_five_unconditional`, `symBUDim_two_seven_unconditional`,
+  `symBUDim_three_three_lower_unconditional`,
+  `symBUDim_four_three_lower_unconditional`,
+  `symBUDim_three_five_lower_unconditional`.
+
+### Iteration 6 additions (general-d, odd-d, monotonicity)
+- `symBUDim_lower_z2` — UNIFORM unconditional lower bound `d - 1 ≤
+  symBUDim n d` for all `n ≥ 2`, `d ≥ 1` (axiom-free, via Z/2 subgroup
+  + parent's `symBUDim_two` + `buDim_two`). Strictly stronger than
+  `symBUDim_even_lower` at odd dimension.
+- `symBUDim_odd_lower_unconditional` — odd-d corollary `2k ≤ symBUDim n
+  (2k+1)` for `n ≥ 2`. Gives a strictly stronger bound (by 1) than the
+  floor-rounded `largestPrimeBelow` route at odd d.
+- `symBUDim_two_general_unconditional` — axiom-free CLOSED FORM at
+  `n = 2` for ALL `d ≥ 1`: `symBUDim 2 d = d - 1`. Generalizes
+  `symBUDim_two_even_formula_unconditional` (which only handled even d).
+- `largestPrimeBelow_mono` — structural monotonicity of the
+  prime-selector for `m ≥ 2`: `m ≤ n → largestPrimeBelow m ≤
+  largestPrimeBelow n`. Useful in case-bound arguments comparing `p*`
+  across different `n`.
 
 ### Path forward
 - Stretch: prove the n=3 case (next-easiest after n=2) — would require
@@ -383,5 +539,9 @@ theorem symBUDim_eight_lower_unconditional (k : ℕ) (hk : 0 < k) :
 #check @largestPrimeBelow_eq_self_iff_prime
 #check @largestPrimeBelow_lt_of_not_prime
 #check @symBUDim_eq_largestPrime_two_unconditional
+#check @symBUDim_lower_z2
+#check @symBUDim_odd_lower_unconditional
+#check @symBUDim_two_general_unconditional
+#check @largestPrimeBelow_mono
 
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -2,14 +2,14 @@
 
 **Phase**: ORIENT
 **Since**: 2026-05-08T02:50:00Z
-**Iteration**: 4
+**Iteration**: 6
 
 ## Current Focus
 
 Phase-2 formalization is complete (1 axiom for the open conjecture, 0 sorries).
-Iteration 3 (researcher-9) extended the lemma library with the quantitative
-Bertrand-Chebyshev bound on `largestPrimeBelow` to formalize the
-"factor-2-of-optimal" heuristic.
+Iteration 6 (researcher-11) extended the unconditional lower-bound coverage
+from even-d to ALL d via the Z/2 subgroup route, and settled the conjecture
+axiom-free at n=2 for all dimensions (not just even).
 
 ## Active Approach
 
@@ -39,9 +39,9 @@ Possible follow-ups:
 
 ## Attempt Counts
 
-- Total attempts: 3
+- Total attempts: 6
 - Current approach attempts: 1
-- Approaches tried: 1 (Bertrand-derived quantitative refinement)
+- Approaches tried: 3 (Bertrand-derived quantitative refinement; structural fixed-point characterization; Z/2 uniform lower bound)
 
 ## Iteration 3 Builds (researcher-9, 2026-05-08)
 
@@ -100,4 +100,34 @@ the unconditional lower-bound coverage** to S₆, S₇, S₈.
   composite/non-cyclic structure.
 
 **Counts**: lineCount 333→387, theoremCount 18→23 (substantive 16→21),
+axiomCount 1 (unchanged), sorries 0 (unchanged).
+
+## Iteration 6 Builds (researcher-11, 2026-05-08)
+
+Focus: **uniform Z/2 lower bound at ALL dimensions (including odd)** and
+**axiom-free closed form at n=2 for ALL d**.
+
+- `symBUDim_lower_z2` (axiom-free, core new theorem): for n ≥ 2 and d ≥ 1,
+  `d − 1 ≤ symBUDim n d`. Routes through Z/2: parent's `symBUDim_two`
+  + `buDim_two` + `symBUDim_le_of_le 2 n d`. Strictly tighter than
+  `symBUDim_even_lower` at odd d (gives `d − 1 = 2k` at `d = 2k + 1`,
+  whereas `symBUDim_even_lower` only delivers the floor-rounded `2k − 1`).
+- `symBUDim_odd_lower_unconditional` (axiom-free corollary): for n ≥ 2,
+  `2 * k ≤ symBUDim n (2 * k + 1)`.
+- `symBUDim_two_general_unconditional` (axiom-free): for d ≥ 1,
+  `symBUDim 2 d = d − 1`. Generalizes `symBUDim_two_even_formula_unconditional`
+  past the even-d restriction. **At n=2 this fully settles the conjecture
+  axiom-free across all dimensions.**
+- Concrete axiom-free instances:
+  - `symBUDim_two_three_unconditional : symBUDim 2 3 = 2`
+  - `symBUDim_two_five_unconditional : symBUDim 2 5 = 4`
+  - `symBUDim_two_seven_unconditional : symBUDim 2 7 = 6`
+  - `symBUDim_three_three_lower_unconditional : 2 ≤ symBUDim 3 3`
+  - `symBUDim_four_three_lower_unconditional : 2 ≤ symBUDim 4 3` (V₄ ≤ S₄)
+  - `symBUDim_three_five_lower_unconditional : 4 ≤ symBUDim 3 5`
+- `largestPrimeBelow_mono` (axiom-free): for `m ≥ 2` and `m ≤ n`,
+  `largestPrimeBelow m ≤ largestPrimeBelow n`. Structural lemma for any
+  case-bound argument comparing `p*` across different `n`.
+
+**Counts**: lineCount 387→547, theoremCount 23→33 (substantive 21→25),
 axiomCount 1 (unchanged), sorries 0 (unchanged).

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "borsuk-ulam-oq-02-oq-01-oq-03-oq-02",
   "title": "Symmetric Group Borsuk-Ulam: The Largest-Prime-Below Conjecture",
   "slug": "borsuk-ulam-oq-02-oq-01-oq-03-oq-02",
-  "description": "Phase-2 formalization of the open question: For S_n, is symBUDim n d = buDim p* d = 2⌊d/2⌋ − 1, where p* is the largest prime ≤ n? The lower bound symBUDim n (2k) ≥ 2k − 1 is proved unconditionally (axiom-free, modulo parent infrastructure); the matching upper bound is the conjectural equality, axiomatized as `symBUDim_eq_largestPrime`. From the conjecture we derive the explicit closed form symBUDim n (2k) = 2k − 1. Adds the quantitative Bertrand-Chebyshev bound `n/2 < largestPrimeBelow n` (axiom-free, via Mathlib's `Nat.bertrand`), pinning p* in the dyadic window (n/2, n] and showing the cyclic lower bound is within factor 2 of optimal.",
+  "description": "Phase-2 formalization of the open question: For S_n, is symBUDim n d = buDim p* d = 2⌊d/2⌋ − 1, where p* is the largest prime ≤ n? The lower bound symBUDim n (2k) ≥ 2k − 1 is proved unconditionally (axiom-free, modulo parent infrastructure); the matching upper bound is the conjectural equality, axiomatized as `symBUDim_eq_largestPrime`. From the conjecture we derive the explicit closed form symBUDim n (2k) = 2k − 1. Adds the quantitative Bertrand-Chebyshev bound `n/2 < largestPrimeBelow n` (axiom-free, via Mathlib's `Nat.bertrand`), pinning p* in the dyadic window (n/2, n] and showing the cyclic lower bound is within factor 2 of optimal. Iteration 6: extends the unconditional lower bound from even-d to ALL d via the Z/2 subgroup route (`symBUDim_lower_z2 : d − 1 ≤ symBUDim n d` for d ≥ 1, axiom-free), strictly tighter than the largestPrimeBelow route at odd dimensions; settles the conjecture axiom-free at n=2 for ALL d (`symBUDim_two_general_unconditional : symBUDim 2 d = d − 1`); and adds the structural monotonicity `largestPrimeBelow_mono`.",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Borsuk%E2%80%93Ulam_theorem",
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 387,
+    "lineCount": 547,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -73,10 +73,16 @@
       "symBUDim_two_four_unconditional: concrete axiom-free instance symBUDim 2 4 = 3",
       "largestPrimeBelow_eq_self_iff_prime: fixed-point characterization (n ≥ 2): largestPrimeBelow n = n ↔ Nat.Prime n. Forward direction uses largestPrimeBelow_isPrime; backward is largestPrimeBelow_self_of_prime",
       "largestPrimeBelow_lt_of_not_prime: strict bound for composite n (corollary of the iff): when n ≥ 2 is not prime, largestPrimeBelow n < n",
-      "symBUDim_{six,seven,eight}_lower_unconditional: axiom-free Yang-Borsuk lower bounds 2k - 1 ≤ symBUDim n (2k) for n ∈ {6,7,8} via direct application of symBUDim_even_lower"
+      "symBUDim_{six,seven,eight}_lower_unconditional: axiom-free Yang-Borsuk lower bounds 2k - 1 ≤ symBUDim n (2k) for n ∈ {6,7,8} via direct application of symBUDim_even_lower",
+      "symBUDim_lower_z2 (S6): UNIFORM unconditional lower bound d - 1 ≤ symBUDim n d for ALL n ≥ 2, d ≥ 1 (axiom-free, via Z/2 subgroup + parent's symBUDim_two + buDim_two). Strictly stronger than symBUDim_even_lower at odd dimension",
+      "symBUDim_odd_lower_unconditional (S6): odd-dimension corollary 2k ≤ symBUDim n (2k+1) for n ≥ 2 (axiom-free); strictly tighter (by 1) than the floor-rounded largestPrimeBelow route at odd d",
+      "symBUDim_two_general_unconditional (S6): axiom-free closed form symBUDim 2 d = d - 1 for ALL d ≥ 1, generalizing symBUDim_two_even_formula_unconditional past the even-d restriction",
+      "symBUDim_two_three_unconditional, symBUDim_two_five_unconditional, symBUDim_two_seven_unconditional (S6): concrete axiom-free instances symBUDim 2 3 = 2, symBUDim 2 5 = 4, symBUDim 2 7 = 6",
+      "symBUDim_three_three_lower_unconditional, symBUDim_four_three_lower_unconditional, symBUDim_three_five_lower_unconditional (S6): concrete axiom-free odd-d lower bounds at S₃ and S₄ — the n=4 case is notable since S₄ has the V₄ Klein-4 subgroup cited as the canonical test case",
+      "largestPrimeBelow_mono (S6): structural monotonicity of the prime-selector for m ≥ 2: m ≤ n → largestPrimeBelow m ≤ largestPrimeBelow n (axiom-free, via Nat.le_findGreatest). Useful for case-bound arguments comparing p* across different n"
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **The n=2 instance of this axiom is redundant** — `symBUDim_eq_largestPrime_two_unconditional` proves it axiom-free from the parent's `symBUDim_two` axiom + `largestPrimeBelow_two`. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime` (counted in the parent gallery entries).",
-    "theoremCount": 21,
+    "theoremCount": 33,
     "definitionCount": 1
   },
   "overview": {
@@ -92,7 +98,8 @@
       "**Failure modes for the conjecture.** If the conjecture fails at some $n$, the failure must come from $S_n$-specific structure: Klein-4 $V_4 \\leq S_4$ (non-cyclic of order 4), representation-theoretic obstructions from non-trivial irreducibles, or higher-cohomology classes in the Fadell-Husseini index. Natural test cases: $n = 4$ ($p^* = 3$, but $V_4 \\leq S_4$) and $n = 8$ ($p^* = 7$, but $S_8$ has rich subgroup structure including $A_4 \\times A_4$, etc.).",
       "**Concrete computations are immediate.** `symBUDim_three_four = 3` and `symBUDim_four_six = 5` follow from the closed-form formula; the unconditional `symBUDim_five_lower_unconditional` is axiom-free up to parent. These serve as both regression tests and Lean-verified instances of the conjecture's predictions.",
       "**Bertrand-Chebyshev makes the factor-2 gap formal.** The unconditional cyclic lower bound `2k − 1 ≤ symBUDim n (2k)` matches the conjectural upper bound exactly modulo the open axiom — but it's also worth showing that the prime witness $p^*$ is genuinely close to $n$, not just some small prime. `n_div_two_lt_largestPrimeBelow` formalizes this: for any $n \\geq 2$, $p^* > n/2$, axiom-free via Mathlib's `Nat.exists_prime_lt_and_le_two_mul`. The prime witness is in the dyadic window $(n/2, n]$, so any improvement beyond the cyclic lower bound must come from $S_n$-specific (non-cyclic) structure.",
-      "**The n=2 instance of the conjecture is provable, axiom-free.** `symBUDim_eq_largestPrime_two_unconditional` shows that the conjectured equality $\\text{symBUDim}(n, d) = \\text{buDim}(p^*, d)$ at $n=2$ is *not* an independent axiom: it follows from the parent file's pre-existing `symBUDim_two` axiom and the squeeze-argument `largestPrimeBelow_self_of_prime` (instantiated at $n = p = 2$). This is a non-trivial *consistency check* — the new axiom `symBUDim_eq_largestPrime` is compatible with prior axiomatization, and its true open content is for $n \\geq 3$. (For larger primes $n$, the analogous derivation would require a $\\text{symBUDim}_p$ base axiom that the gallery does not yet have.)"
+      "**The n=2 instance of the conjecture is provable, axiom-free.** `symBUDim_eq_largestPrime_two_unconditional` shows that the conjectured equality $\\text{symBUDim}(n, d) = \\text{buDim}(p^*, d)$ at $n=2$ is *not* an independent axiom: it follows from the parent file's pre-existing `symBUDim_two` axiom and the squeeze-argument `largestPrimeBelow_self_of_prime` (instantiated at $n = p = 2$). This is a non-trivial *consistency check* — the new axiom `symBUDim_eq_largestPrime` is compatible with prior axiomatization, and its true open content is for $n \\geq 3$. (For larger primes $n$, the analogous derivation would require a $\\text{symBUDim}_p$ base axiom that the gallery does not yet have.)",
+      "**The Z/2 subgroup gives a unified lower bound at ALL dimensions, including odd.** Routing through the classical Borsuk-Ulam (parent's `buDim_two : buDim 2 (n+1) = n`) and the Z/2 ≤ S_n inclusion (parent's `symBUDim_two` + `symBUDim_le_of_le`) yields the axiom-free uniform bound $d - 1 \\leq \\text{symBUDim}(n, d)$ for all $n \\geq 2, d \\geq 1$ — see `symBUDim_lower_z2`. At odd $d = 2k + 1$ this is *strictly stronger* than the largestPrimeBelow route, which only delivers $2 \\lfloor d / 2 \\rfloor - 1 = 2k - 1$ via the even-d Yang-Borsuk axiom; the Z/2 route gives $2k$ instead. The conjecture predicts $\\text{symBUDim}(n, d) = \\text{buDim}(p^*, d)$ — at $p^* \\geq 3$ this would have to handle odd $d$ via some yet-unaxiomatized cyclic-prime odd-d formula; at $n = 2$ (where $p^* = 2$), the Z/2 closed form `symBUDim_two_general_unconditional` ($\\text{symBUDim}(2, d) = d - 1$ for all $d \\geq 1$) settles the conjecture axiom-free at all dimensions."
     ],
     "prerequisites": [
       "BorsukUlamOQ02OQ01.lean (cyclic-group buDim, buDim_two, buDim_prime, buDim_mono)",
@@ -154,9 +161,41 @@
       "id": "n2-consistency",
       "title": "Part VII: Axiom-free Consistency at n=2",
       "startLine": 207,
-      "endLine": 271,
-      "summary": "`largestPrimeBelow_self_of_prime` (general, axiom-free): for prime $n$, $\\text{largestPrimeBelow}(n) = n$ via squeeze. Concrete corollaries `largestPrimeBelow_two/_three/_five/_seven`. `symBUDim_eq_largestPrime_two_unconditional` (axiom-free): the n=2 case of the conjectured equality is provable from parent's `symBUDim_two` + `largestPrimeBelow_two`, *without* invoking the new `symBUDim_eq_largestPrime` axiom — a non-trivial consistency check. `symBUDim_two_even_formula_unconditional`, `symBUDim_two_four_unconditional`: axiom-free closed form and concrete instance at n=2.",
+      "endLine": 318,
+      "summary": "`largestPrimeBelow_self_of_prime` (general, axiom-free): for prime $n$, $\\text{largestPrimeBelow}(n) = n$ via squeeze. Concrete corollaries `largestPrimeBelow_two/_three/_five/_seven`. `symBUDim_eq_largestPrime_two_unconditional` (axiom-free): the n=2 case of the conjectured equality is provable from parent's `symBUDim_two` + `largestPrimeBelow_two`, *without* invoking the new `symBUDim_eq_largestPrime` axiom — a non-trivial consistency check. `symBUDim_two_even_formula_unconditional`, `symBUDim_two_four_unconditional`: axiom-free closed form and concrete instance at n=2. Also includes the structural iff `largestPrimeBelow_eq_self_iff_prime` and the strict-bound corollary `largestPrimeBelow_lt_of_not_prime` for composite n, plus axiom-free Yang-Borsuk lower bounds at $n \\in \\{6, 7, 8\\}$.",
       "mathContext": "The squeeze argument: $n \\leq \\text{findGreatest}(\\text{Prime}, n)$ from `Nat.le_findGreatest le_rfl hn`, and $\\text{findGreatest}(\\text{Prime}, n) \\leq n$ from `Nat.findGreatest_le`, hence equality when $n$ is prime. At n=2 this reduces the conjecture to the parent's pre-existing `symBUDim_two` axiom — showing the new axiom is consistent with prior axiomatization and contributes new content only for $n \\geq 3$."
+    },
+    {
+      "id": "uniform-z2-lower",
+      "title": "Part VIII: Uniform Z/2 Lower Bound (All Dimensions, Including Odd)",
+      "startLine": 320,
+      "endLine": 376,
+      "summary": "`symBUDim_lower_z2` (axiom-free): unified lower bound $d - 1 \\leq \\text{symBUDim}(n, d)$ for all $n \\geq 2$, $d \\geq 1$, derived by routing through the Z/2 subgroup. Strictly stronger than `symBUDim_even_lower` at odd $d$. Corollary `symBUDim_odd_lower_unconditional`: $2k \\leq \\text{symBUDim}(n, 2k+1)$ for $n \\geq 2$, axiom-free.",
+      "mathContext": "$\\text{buDim}(2, d) \\stackrel{\\text{classical BU}}{=} d - 1$ (parent's `buDim_two`). $\\text{symBUDim}(2, d) \\stackrel{\\text{parent}}{=} \\text{buDim}(2, d)$. $\\text{symBUDim}(2, d) \\leq \\text{symBUDim}(n, d)$ by parent's $\\text{symBUDim}$-monotonicity in $n$ (`symBUDim_le_of_le`). Composing gives the uniform bound. At odd dimension $d = 2k+1$, this gives $2k \\leq \\text{symBUDim}(n, d)$, strictly tighter than the floor-rounded $2 \\lfloor (2k+1)/2 \\rfloor - 1 = 2k - 1$ from the even-d Yang-Borsuk route."
+    },
+    {
+      "id": "n2-general-d",
+      "title": "Part IX: Axiom-free Closed Form at n=2 for All Dimensions",
+      "startLine": 378,
+      "endLine": 416,
+      "summary": "`symBUDim_two_general_unconditional` (axiom-free): $\\text{symBUDim}(2, d) = d - 1$ for ALL $d \\geq 1$. Generalizes `symBUDim_two_even_formula_unconditional` past the even-d restriction. Concrete instances: `symBUDim_two_three_unconditional` ($= 2$), `symBUDim_two_five_unconditional` ($= 4$), `symBUDim_two_seven_unconditional` ($= 6$).",
+      "mathContext": "Parent's `symBUDim_two : symBUDim 2 d = buDim 2 d` plus `buDim_two : buDim 2 (n+1) = n` immediately gives the closed form for all $d \\geq 1$. This *fully settles* the conjecture at $n = 2$ — for all dimensions, not just even."
+    },
+    {
+      "id": "odd-d-concrete",
+      "title": "Part X: Concrete Odd-d Lower Bounds at n ≥ 3",
+      "startLine": 418,
+      "endLine": 444,
+      "summary": "Axiom-free odd-dimension lower bounds: `symBUDim_three_three_lower_unconditional` ($2 \\leq \\text{symBUDim}(3, 3)$), `symBUDim_four_three_lower_unconditional` ($2 \\leq \\text{symBUDim}(4, 3)$), `symBUDim_three_five_lower_unconditional` ($4 \\leq \\text{symBUDim}(3, 5)$). Direct applications of `symBUDim_odd_lower_unconditional`. The $n = 4$ case is notable since $S_4$ has the $V_4$ Klein-4 subgroup cited in the problem statement.",
+      "mathContext": "At odd $d$, the Z/2 route gives a strictly stronger bound than the largestPrimeBelow route. For $S_4$: $p^* = 3$, but the Z/2 subgroup yields $d - 1$ unconditionally — and the conjecture's prediction at odd $d \\geq 3$ for $n \\geq 4$ has no canonical even-d Yang-Borsuk witness without an odd-d cyclic-prime axiom."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Part XI: Monotonicity of largestPrimeBelow",
+      "startLine": 446,
+      "endLine": 470,
+      "summary": "`largestPrimeBelow_mono` (axiom-free): for $m \\geq 2$ and $m \\leq n$, $\\text{largestPrimeBelow}(m) \\leq \\text{largestPrimeBelow}(n)$. Structural lemma about the prime-selector function — useful for any case-bound argument that compares $p^*$ across different $n$.",
+      "mathContext": "Let $q = \\text{largestPrimeBelow}(m)$. Since $m \\geq 2$, $q$ is prime and $q \\leq m \\leq n$. By `Nat.le_findGreatest`, $q \\leq \\text{findGreatest}(\\text{Prime}, n) = \\text{largestPrimeBelow}(n)$."
     }
   ],
   "crossReferences": [
@@ -200,10 +239,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 387,
+    "lineCount": 547,
     "axiomCount": 1,
-    "theoremCount": 23,
-    "substantiveTheoremCount": 21,
+    "theoremCount": 33,
+    "substantiveTheoremCount": 25,
     "definitionCount": 1,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0
@@ -276,6 +315,24 @@
       "type": "core",
       "description": "Bertrand-Chebyshev bound (axiom-free): for n ≥ 2, n/2 < largestPrimeBelow n. Pins p* in the dyadic window (n/2, n] regardless of how composite n is.",
       "leanType": "(n : ℕ) → 2 ≤ n → n / 2 < largestPrimeBelow n"
+    },
+    {
+      "name": "symBUDim_lower_z2",
+      "type": "core",
+      "description": "Uniform unconditional lower bound (axiom-free) at ALL dimensions including odd: d - 1 ≤ symBUDim n d for n ≥ 2, d ≥ 1. Strictly stronger than symBUDim_even_lower at odd d.",
+      "leanType": "(n d : ℕ) → 2 ≤ n → 0 < d → d - 1 ≤ symBUDim n d"
+    },
+    {
+      "name": "symBUDim_two_general_unconditional",
+      "type": "core",
+      "description": "Axiom-free closed form at n = 2 for ALL d ≥ 1: symBUDim 2 d = d - 1. Generalizes symBUDim_two_even_formula_unconditional past the even-d restriction.",
+      "leanType": "(d : ℕ) → 0 < d → symBUDim 2 d = d - 1"
+    },
+    {
+      "name": "largestPrimeBelow_mono",
+      "type": "supporting",
+      "description": "Monotonicity of largestPrimeBelow for m ≥ 2: m ≤ n → largestPrimeBelow m ≤ largestPrimeBelow n. Structural prime-selector lemma.",
+      "leanType": "{m n : ℕ} → 2 ≤ m → m ≤ n → largestPrimeBelow m ≤ largestPrimeBelow n"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
@@ -37,18 +37,18 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-05-08T02:50:00Z",
-    "iteration": 5,
-    "focus": "Iteration 5 (researcher-11): added structural fixed-point characterization largestPrimeBelow n = n ↔ Nat.Prime n (n ≥ 2) and its corollary largestPrimeBelow_lt_of_not_prime; added concrete unconditional Yang-Borsuk lower bounds for S₆, S₇, S₈ as direct applications of symBUDim_even_lower.",
+    "iteration": 6,
+    "focus": "Iteration 6 (researcher-11): extended the unconditional lower-bound coverage from even-d to ALL d via the Z/2 subgroup route. New core result `symBUDim_lower_z2 : d − 1 ≤ symBUDim n d` (axiom-free, n ≥ 2, d ≥ 1) is strictly tighter than `symBUDim_even_lower` at odd dimensions. Added axiom-free closed form at n=2 for ALL d (`symBUDim_two_general_unconditional : symBUDim 2 d = d − 1`), generalizing past the even-d restriction. Added structural monotonicity `largestPrimeBelow_mono` and 6 concrete instances (3 closed-form at n=2 odd-d, 3 odd-d lower bounds at S₃/S₄).",
     "blockers": [],
-    "nextAction": "Stretch: prove n=3 case (would need a symBUDim_three base axiom in parent, since n=3 is not redundant). Or attempt n=4 by hand (V_4 ≤ S_4 case). Or coordinate with sister dihedral question OQ-02-OQ-01-OQ-03-OQ-01.",
+    "nextAction": "Stretch: investigate odd-d prime-cyclic Yang-Borsuk axiom (would let us extend the symBUDim_eq_largestPrime closed form to odd d). Stretch: prove n=3 case (still needs symBUDim_three base axiom in parent). Stretch: V_4 ≤ S_4 explicit calculation. Coordinate with sister dihedral question OQ-02-OQ-01-OQ-03-OQ-01.",
     "attemptCounts": {
-      "total": 5,
+      "total": 6,
       "currentApproach": 1,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "S5 (researcher-11, 2026-05-08): added structural iff `largestPrimeBelow n = n ↔ Nat.Prime n` (n ≥ 2) and its corollary `largestPrimeBelow_lt_of_not_prime`. Added 3 concrete unconditional Yang-Borsuk lower bounds at n ∈ {6, 7, 8} via direct applications of `symBUDim_even_lower`. n=8 is the canonical test case for non-cyclic structure (V₄, A₄ ≤ S₈) — the axiom-free lower bound holds regardless. Counts: lineCount 387, theoremCount 23 (substantive 21), axiomCount 1, sorries 0.\n\nS4 (researcher-3, 2026-05-08): **Proved the n=2 case of the conjectured equality AXIOM-FREE** — `symBUDim_eq_largestPrime_two_unconditional` shows the n=2 instance of the new axiom `symBUDim_eq_largestPrime` is *redundant*: it follows from the parent's pre-existing `symBUDim_two` axiom + a general squeeze lemma `largestPrimeBelow_self_of_prime` (instantiated at n=p=2). Non-trivial consistency check between this file and the parent.\n\nS3 (researcher-9, 2026-05-08): added Bertrand-Chebyshev quantitative bound `n/2 < largestPrimeBelow n` (axiom-free).\n\nS2 (researcher-3, 2026-05-07): Phase 2 scaffold committed.",
+    "progressSummary": "S6 (researcher-11, 2026-05-08): extended the unconditional lower-bound coverage from even-d to ALL d (including odd) via the Z/2 subgroup route. Core new theorem `symBUDim_lower_z2 : d − 1 ≤ symBUDim n d` for n ≥ 2, d ≥ 1 — axiom-free, strictly tighter than `symBUDim_even_lower` at odd d (gives 2k vs floor-rounded 2k−1 at d = 2k+1). Axiom-free closed form at n=2 for ALL d (`symBUDim_two_general_unconditional : symBUDim 2 d = d − 1`), generalizing past the even-d restriction (settles the conjecture axiom-free at n=2 across all dimensions). Plus `largestPrimeBelow_mono` (structural monotonicity for m ≥ 2) and 6 concrete axiom-free instances (`symBUDim_two_three/_five/_seven_unconditional`, `symBUDim_three_three/_four_three/_three_five_lower_unconditional`). Counts: lineCount 387 → 547, theoremCount 23 → 33 (substantive 21 → 25), axiomCount 1, sorries 0.\n\nS5 (researcher-11, 2026-05-08): added structural iff `largestPrimeBelow n = n ↔ Nat.Prime n` (n ≥ 2) and its corollary `largestPrimeBelow_lt_of_not_prime`. Added 3 concrete unconditional Yang-Borsuk lower bounds at n ∈ {6, 7, 8} via direct applications of `symBUDim_even_lower`.\n\nS4 (researcher-3, 2026-05-08): **Proved the n=2 case of the conjectured equality AXIOM-FREE** — `symBUDim_eq_largestPrime_two_unconditional` shows the n=2 instance of the new axiom `symBUDim_eq_largestPrime` is *redundant*: it follows from the parent's pre-existing `symBUDim_two` axiom + a general squeeze lemma `largestPrimeBelow_self_of_prime` (instantiated at n=p=2).\n\nS3 (researcher-9, 2026-05-08): added Bertrand-Chebyshev quantitative bound `n/2 < largestPrimeBelow n` (axiom-free).\n\nS2 (researcher-3, 2026-05-07): Phase 2 scaffold committed.",
     "builtItems": [
       "proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean — Phase 2 scaffold with axiom symBUDim_eq_largestPrime + 18 theorems (substantive: 16); 333 lines",
       "Unconditional theorem symBUDim_even_lower : 2k-1 ≤ symBUDim n (2k) for n ≥ 2 (no new axioms beyond parent)",
@@ -62,11 +62,19 @@
       "S4 — Added `import Proofs.BorsukUlamOQ02OQ01OQ03OQ02` to proofs/Proofs.lean (gallery build hookup)",
       "S5 — largestPrimeBelow_eq_self_iff_prime: structural iff for n ≥ 2",
       "S5 — largestPrimeBelow_lt_of_not_prime: strict bound for composite n (corollary of the iff)",
-      "S5 — symBUDim_six_lower_unconditional, symBUDim_seven_lower_unconditional, symBUDim_eight_lower_unconditional: axiom-free Yang-Borsuk lower bounds at n ∈ {6, 7, 8}"
+      "S5 — symBUDim_six_lower_unconditional, symBUDim_seven_lower_unconditional, symBUDim_eight_lower_unconditional: axiom-free Yang-Borsuk lower bounds at n ∈ {6, 7, 8}",
+      "S6 — symBUDim_lower_z2 : d − 1 ≤ symBUDim n d for n ≥ 2, d ≥ 1 (axiom-free uniform lower bound, valid at ALL dimensions including odd)",
+      "S6 — symBUDim_odd_lower_unconditional : 2k ≤ symBUDim n (2k+1) for n ≥ 2 (axiom-free odd-d corollary)",
+      "S6 — symBUDim_two_general_unconditional : symBUDim 2 d = d − 1 for all d ≥ 1 (axiom-free closed form at n=2, generalizing past even d)",
+      "S6 — symBUDim_two_three_unconditional / _five / _seven : concrete axiom-free instances at odd d",
+      "S6 — symBUDim_three_three / _four_three / _three_five _lower_unconditional : concrete axiom-free odd-d lower bounds (n=4 case notable for V_4 ≤ S_4)",
+      "S6 — largestPrimeBelow_mono : structural monotonicity of the prime-selector for m ≥ 2"
     ],
     "insights": [
       "S4 — `largestPrimeBelow_self_of_prime` (squeeze argument: `n ≤ findGreatest ≤ n` from `Nat.le_findGreatest le_rfl hn` + `Nat.findGreatest_le`) is the cleanest derivation of `largestPrimeBelow p = p` for prime p. Generic enough to handle ALL primes uniformly.",
       "S4 — The n=2 case of the new axiom `symBUDim_eq_largestPrime` is *redundant*: it's provable from the parent's `symBUDim_two` axiom + `largestPrimeBelow_two`. This is a non-trivial consistency check between the two files. For n = 3 and other primes, the analogous derivation would require parent-side base axioms (`symBUDim_three` etc.) that the gallery does not yet have, so the redundancy is specifically a 'parent already has the n=2 base case' phenomenon.",
+      "S6 — The Z/2 subgroup is the right route to a *uniform* unconditional lower bound across all dimensions. Parent's `symBUDim_two : symBUDim 2 d = buDim 2 d` + `buDim_two : buDim 2 (n+1) = n` gives the axiom-free closed form `symBUDim 2 d = d − 1` for all d ≥ 1; combined with parent's monotonicity `symBUDim_le_of_le 2 n d` this yields `d − 1 ≤ symBUDim n d` for all n ≥ 2. At odd d this is strictly tighter than the largestPrimeBelow route, which only delivers the floor-rounded `2⌊d/2⌋ − 1 = d − 2`.",
+      "S6 — At n=2, the conjecture is now SETTLED axiom-free for ALL dimensions (not just even). `symBUDim_two_general_unconditional` gives `symBUDim 2 d = d − 1`. The conjecture's `n ≥ 3` content remains genuinely open and tied to odd-d cyclic-prime Yang-Borsuk axiom (which is missing from the parent for primes p ≥ 3 — only the even-d formula `buDim_prime p (2*k) = 2k − 1` is axiomatized).",
       "S4 — Adding the import to Proofs.lean is structurally important: without it, the file isn't part of the gallery's main build target, and any drift goes uncaught.",
       "Nat.findGreatest Nat.Prime n is a clean Mathlib idiom for largestPrimeBelow — Nat.Prime is DecidablePred so findGreatest is computable. Lemmas: Nat.findGreatest_spec / Nat.findGreatest_le / Nat.le_findGreatest.",
       "The unconditional Yang-Borsuk lower bound `2k-1 ≤ symBUDim n (2k)` for n ≥ 2 follows from just (a) Nat.Prime 2 + 2 ≤ n giving largestPrimeBelow ≥ 2, (b) parent's `buDim_prime` (cyclic Yang-Borsuk), and (c) parent's `sym_has_cyclic_prime` (subgroup monotonicity). NO new axioms.",


### PR DESCRIPTION
## Summary

Iteration 6 of the symmetric-group Borsuk-Ulam largest-prime-below conjecture (`borsuk-ulam-oq-02-oq-01-oq-03-oq-02`).

This iteration **extends the unconditional lower-bound coverage from even d to ALL dimensions (including odd)** by routing through the Z/2 subgroup, and **settles the conjecture axiom-free at n = 2 for all d** (not just even).

## New axiom-free results

### Core (general d)
- `symBUDim_lower_z2 : ∀ n d, 2 ≤ n → 0 < d → d − 1 ≤ symBUDim n d` —
  uniform unconditional lower bound across all dimensions. Routes through
  parent's `symBUDim_two : symBUDim 2 d = buDim 2 d`, `buDim_two : buDim 2 (n+1) = n`,
  and `symBUDim_le_of_le 2 n d`. **Strictly tighter than `symBUDim_even_lower` at odd d.**
- `symBUDim_odd_lower_unconditional : ∀ n k, 2 ≤ n → 2k ≤ symBUDim n (2k+1)` —
  odd-dimension corollary; gives `2k` instead of the floor-rounded `2k − 1` from the largestPrimeBelow route.
- `symBUDim_two_general_unconditional : ∀ d, 0 < d → symBUDim 2 d = d − 1` —
  axiom-free closed form at n = 2 for **all** d ≥ 1 (generalizes `symBUDim_two_even_formula_unconditional` past the even-d restriction).

### Concrete instances
- `symBUDim_two_three_unconditional` (`= 2`), `_two_five_unconditional` (`= 4`), `_two_seven_unconditional` (`= 6`).
- `symBUDim_three_three_lower_unconditional` (`2 ≤ symBUDim 3 3`).
- `symBUDim_four_three_lower_unconditional` (`2 ≤ symBUDim 4 3`) — notable since S₄ has the V₄ Klein-4 subgroup cited in the problem statement.
- `symBUDim_three_five_lower_unconditional` (`4 ≤ symBUDim 3 5`).

### Structural
- `largestPrimeBelow_mono : ∀ {m n}, 2 ≤ m → m ≤ n → largestPrimeBelow m ≤ largestPrimeBelow n` —
  monotonicity of the prime-selector. Useful for case-bound arguments comparing p* across n.

## Mathematical content

The Z/2 route gives a *strictly stronger* odd-dimension bound than the largestPrimeBelow route delivers via the even-d Yang-Borsuk axiom:

| dimension | largestPrimeBelow route | Z/2 route |
|-----------|------------------------|-----------|
| `d = 2k`  | `2k − 1`              | `2k − 1` (matches) |
| `d = 2k+1` | `2k − 1` (floor-rounded) | `2k` (strictly tighter) |

At n = 2 the conjecture is now **fully settled axiom-free for all d** (combining `symBUDim_two_general_unconditional` with `largestPrimeBelow_two`). For n ≥ 3 the conjecture's odd-d content remains genuinely open and tied to the absence of an odd-d cyclic-prime Yang-Borsuk axiom in the parent (only `buDim_prime p (2*k) = 2k − 1` is currently axiomatized).

## Counts

| Field | Before | After |
|-------|--------|-------|
| `lineCount` | 387 | 547 |
| `theoremCount` | 23 | 33 |
| `substantiveTheoremCount` | 21 | 25 |
| `axiomCount` | 1 | 1 (unchanged) |
| `sorries` | 0 | 0 (unchanged) |

## Test plan

- [x] Docker build of `Proofs.BorsukUlamOQ02OQ01OQ03OQ02` succeeded (full mathlib cache, ~18 min).
- [x] Build output: `Build completed successfully (3068 jobs).` and all `#check` declarations report the expected types.
- [x] No new axioms introduced; the single existing axiom `symBUDim_eq_largestPrime` is unchanged.
- [x] Updated meta.json (`lineCount`, `theoremCount`, `originalContributions`, new sections VIII/IX/X/XI, new mainTheorems entries, new keyInsight on Z/2 uniform bound).
- [x] Updated research-knowledge JSON and state.md.

## Status

**Outcome**: progress (axiom-free extension, no new axioms)
**Phase**: ORIENT (iteration 6)
**Next steps**: investigate odd-d cyclic-prime Yang-Borsuk axiom (would let `symBUDim_eq_largestPrime` extend to odd d); prove n = 3 case (still needs `symBUDim_three` base axiom in parent); V₄ ≤ S₄ explicit calculation.

🤖 Generated by researcher-11