### PR TITLE
fix(meta): konigsberg-oq-01-oq-02 sync stale leanFile counts

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "degree-sequences"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-05-03",
     "axiomCount": 2,
     "assumptions": "2 axioms: directed_eulerian_iff (Hierholzer's algorithm for directed graph Eulerian circuit — requires graph connectivity infrastructure) and directed_euler_path_iff (Eulerian path degree characterization). All other results (handshaking, concrete examples, consequences) are proved from first principles. NOTE 2026-05-08: file currently does not build under the latest Mathlib (omega tactic API drift on `walk.get ⟨i, by omega⟩` patterns inside Finset.filter expressions, pre-existing from PR #16675). Session 6 strengthened HasEulerianPath def and added a proof of euler_path_implies_degree_balance, but build verification is blocked until the file's omega calls are restructured.",
@@ -131,7 +131,7 @@
     "theoremCount": 26,
     "definitionCount": 13,
     "path": "Proofs/KonigsbergOQ01OQ02.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -150,5 +150,5 @@
       "description": "Original Königsberg bridges problem — Euler 1736; the undirected Eulerian theorem whose directed analogue is formalized here."
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -126,9 +126,9 @@
   },
   "leanFile": {
     "namespace": "KonigsbergOQ01OQ02",
-    "lineCount": 1108,
+    "lineCount": 1202,
     "axiomCount": 2,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 13,
     "path": "Proofs/KonigsbergOQ01OQ02.lean",
     "sorries": 2


### PR DESCRIPTION
## Fix

Sync `meta.json` counts for `konigsberg-oq-01-oq-02` to match the current Lean source after research PR #16855 (S6 — euler_path proof).

## Evidence

`proofs/Proofs/KonigsbergOQ01OQ02.lean` on `origin/main`:
- `wc -l` → **1202 lines** (claim was 1108)
- theorem/lemma decls (incl. `private`/`@[simp]`/etc) → **26** (claim was 25)
- `sorry` token (after stripping comments) → **1** (claim was 2)
- `axiom` decls → 2 (unchanged)
- `def`/`abbrev`/`opaque` → 13 (unchanged)

Both `meta.lineCount`/`meta.theoremCount` and `leanFile.lineCount`/`leanFile.theoremCount` were stale. Top-level `sorries`, `meta.sorries`, and `leanFile.sorries` all updated 2→1 because PR #16855 proved `euler_path_implies_degree_balance`, eliminating one of the two sorries.

Note: `assumptions` already documents the post-#16855 state ("Session 6 strengthened HasEulerianPath def and added a proof of euler_path_implies_degree_balance"), so no narrative drift introduced. The build-blocked omega-API drift is unrelated and tracked separately.

## Scope

Counts only — no narrative changes, no Lean source changes.

---
Automated fix by lean-mechanic agent.