### PR TITLE
audit(tracker): mark 6 entries clean (3rd audit) — re-audit of stale 2026-04-23 batch

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12950,9 +12950,9 @@
       "result": "clean"
     },
     "schroeder-bernstein-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:31Z",
+      "lastAudited": "2026-05-08T03:08:33Z",
       "result": "clean"
     },
     "schroeder-bernstein-oq-04": {
@@ -12980,9 +12980,9 @@
       "result": "clean"
     },
     "shannon-channel-coding-oq-02-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:31Z",
+      "lastAudited": "2026-05-08T03:08:33Z",
       "result": "clean"
     },
     "shannon-channel-coding-oq-03": {
@@ -13052,9 +13052,9 @@
       "result": "clean"
     },
     "shannon-source-coding-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:32Z",
+      "lastAudited": "2026-05-08T03:08:33Z",
       "result": "clean"
     },
     "shapley-folkman": {
@@ -13064,9 +13064,9 @@
       "result": "clean"
     },
     "shapley-folkman-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:32Z",
+      "lastAudited": "2026-05-08T03:08:33Z",
       "result": "clean"
     },
     "solution-of-cubic": {
@@ -13106,9 +13106,9 @@
       "result": "clean"
     },
     "solution-of-cubic-oq-05": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:33Z",
+      "lastAudited": "2026-05-08T03:08:33Z",
       "result": "clean"
     },
     "sophie-germain": {
@@ -13124,9 +13124,9 @@
       "result": "clean"
     },
     "sophie-germain-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:33Z",
+      "lastAudited": "2026-05-08T03:08:33Z",
       "result": "clean"
     },
     "sperner-ndim": {


### PR DESCRIPTION
## Summary

Six entries last audited on 2026-04-23 verified clean against current main. All sorry/axiom/lineCount/theoremCount/definitionCount fields match between `meta.json`, `meta.leanFile`, and the actual Lean source. No True stubs, no axiom-narrative drift, no overclaim risk detected.

| slug | status/badge | counts (sorries/axioms/lines/thm/def) |
|---|---|---|
| schroeder-bernstein-oq-03 | formalized/wip | 4 / 0 / 257 / 14 / 4 |
| shannon-channel-coding-oq-02-oq-04 | axiomatized/axiom | 0 / 4 (inherited) / 248 / 11 / 1 |
| shapley-folkman-oq-03 | verified/mathlib | 0 / 0 / 203 / 5 / 0 |
| shannon-source-coding-oq-04 | verified/mathlib | 0 / 0 / 462 / 11 / 5 |
| sophie-germain-oq-02 | verified/original | 0 / 0 / 156 / 11 / 3 |
| solution-of-cubic-oq-05 | verified/mathlib | 0 / 0 / 183 / 9 / 3 |

For shannon-channel-coding-oq-02-oq-04 the 4 axioms are inherited from `Proofs.ShannonChannelCoding` via the import chain — `lf.axiomCount=0` (this file alone), `meta.axiomCount=4` (total). Status `axiomatized` reflects the inherited assumptions.

Surgical 12-line diff: only auditCount and lastAudited changed for the 6 targets — no formatting churn (memory: feedback_mechanic_plumbing_json_format).

## Test plan

- [x] All counts verified against `git show origin/main:` for both meta.json and Lean source
- [x] No True stubs, no `:= trivial` placeholders
- [x] Comment-stripped regex used for sorry/axiom counts
- [x] Aristotle companion (shannon-source-coding-oq-04) verified 0 sorries, 0 axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)