### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-02-oq-01): S8 — per-triple count for n=4 canonical triple (build pending)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
@@ -621,10 +621,54 @@ theorem p_triple_n3_eq_expectedTriples (d : ℕ) (hd : 1 ≤ d) :
   rw [p_triple_n3 d hd]
   simp [expectedTriples, Nat.choose_self]
 
+/-- For n=4 with the canonical (0,1,2) triple: bad functions = d².
+    Bijection f ↔ (f 0, f 3): the constraint forces f 0 = f 1 = f 2 = v (one
+    degree of freedom for the common value) and f 3 is free.
+
+    First step toward the general per-triple coincidence count
+    `card {f : Fin n → Fin d | f i = f j ∧ f j = f k} = d^(n-2)` for distinct
+    i,j,k (state.md Next Action #1): the n=4 case extends `bad_count_n3`
+    (n=3, exponent 1) to exponent 2, isolating the single extra free position
+    introduced when n grows by 1. -/
+theorem bad_count_n4_canonical (d : ℕ) :
+    (Finset.univ.filter (fun f : Fin 4 → Fin d =>
+      f 0 = f 1 ∧ f 1 = f 2)).card = d ^ 2 := by
+  rw [show (d ^ 2 : ℕ) = Fintype.card (Fin d × Fin d) from by
+        simp [Fintype.card_prod, Fintype.card_fin, sq],
+      ← Fintype.card_coe]
+  apply Fintype.card_congr
+  exact {
+    toFun := fun ⟨f, _⟩ => (f 0, f 3)
+    invFun := fun ⟨v, w⟩ =>
+      ⟨fun i => if i.val = 3 then w else v,
+        Finset.mem_filter.mpr ⟨Finset.mem_univ _, rfl, rfl⟩⟩
+    left_inv := fun ⟨f, hf⟩ => by
+      simp only [Subtype.mk.injEq]
+      have h := (Finset.mem_filter.mp hf).2
+      ext i
+      fin_cases i <;> simp_all [h.1, h.1.trans h.2]
+    right_inv := fun ⟨v, w⟩ => rfl }
+
+/-- Per-triple probability for the canonical (0,1,2) triple in Fin 4 (d ≥ 1):
+    P(f 0 = f 1 = f 2) = 1/d². The probability is independent of n in the per-triple
+    sense — `p_triple_n3` gives the same 1/d² value at n=3, since each additional
+    "free" position contributes a factor of `d` to both numerator and denominator. -/
+theorem p_canonical_triple_n4 (d : ℕ) (hd : 1 ≤ d) :
+    ((Finset.univ.filter (fun f : Fin 4 → Fin d =>
+      f 0 = f 1 ∧ f 1 = f 2)).card : ℝ) /
+    (Fintype.card (Fin 4 → Fin d) : ℝ) = 1 / (d : ℝ) ^ 2 := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := by exact_mod_cast hd
+  have hcard_nat : Fintype.card (Fin 4 → Fin d) = d ^ 4 := by simp [Fintype.card_fun]
+  rw [bad_count_n4_canonical, hcard_nat]
+  push_cast
+  have hne : (d : ℝ) ≠ 0 := hd_pos.ne'
+  field_simp
+  ring
+
 /-
   ## Summary
 
-  **Proved (15 theorems, 1 axiom):**
+  **Proved (17 theorems, 1 axiom):**
   1. `choose3_ub`/`choose3_lb`: C(n,3) ∈ [(n-2)³/6, n³/6]
   2. `asympThreshold_cubed`: (asympThreshold d)³ = 6d² ln 2 (exact characterization)
   3. `asympThreshold_ratio`: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} (PROVED)
@@ -641,6 +685,11 @@ theorem p_triple_n3_eq_expectedTriples (d : ℕ) (hd : 1 ≤ d) :
   14. `p_triple_n3` (Session 7): P(triple|n=3) = 1/d² as a real number
   15. `p_triple_n3_eq_expectedTriples` (Session 7): n=3 first-moment identity
       P(triple|n=3) = expectedTriples 3 d (Markov is tight at n=3 since X_d ≤ 1)
+  16. `bad_count_n4_canonical` (Session 8): per-triple count for canonical (0,1,2)
+      triple in Fin 4 = d² (one common value + one free position) — first step
+      toward general n per-triple count d^(n-2)
+  17. `p_canonical_triple_n4` (Session 8): per-triple probability for canonical
+      triple in Fin 4 = 1/d² (= same per-triple value as n=3, by symmetry)
 
   **Axioms (1):** `p_no_triple_tendsto` (Lemma C) — pure Poisson limit:
     P_no_triple(n_c(d), d) → exp(-c³/6) (Lemma A+B proved; `poisson_approx_birthday3` derived from B+C)
@@ -663,5 +712,7 @@ theorem p_triple_n3_eq_expectedTriples (d : ℕ) (hd : 1 ≤ d) :
 #check @p_no_triple_n3
 #check @p_triple_n3
 #check @p_triple_n3_eq_expectedTriples
+#check @bad_count_n4_canonical
+#check @p_canonical_triple_n4
 
 end BirthdayThreshold3

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
@@ -585,3 +585,95 @@ summary block to reflect 15 proved theorems.
    correction. Foundation for higher-order factorial moments.
 4. Lemma C itself remains the target; expect to need a multi-session push or a
    Mathlib upstream contribution.
+
+---
+
+## Session 2026-05-08 (Session 8, researcher-6) — Per-triple Count for n=4
+
+**Mode**: ACT (extending Session 7's n=3 first-moment identity to per-triple count for n=4)
+**Outcome**: PROGRESS — added `bad_count_n4_canonical` and `p_canonical_triple_n4`
+
+### What I Did
+
+Added two theorems after `p_triple_n3_eq_expectedTriples` in
+`BirthdayProblemOQ03OQ01OQ02.lean`:
+
+1. **`bad_count_n4_canonical (d : ℕ)`** — for the canonical triple (0,1,2) in
+   `Fin 4`, the count of `f : Fin 4 → Fin d` with `f 0 = f 1 ∧ f 1 = f 2`
+   equals `d²`. Proof: explicit `Equiv` between the bad subtype and `Fin d × Fin d`
+   via `f ↔ (f 0, f 3)`. Forward map projects out the common value and the free
+   position; inverse map sets f 0, f 1, f 2 to the common value and f 3 to the
+   free value (using `if i.val = 3 then w else v`).
+
+2. **`p_canonical_triple_n4 (d : ℕ) (hd : 1 ≤ d)`** — the real-number probability
+   form: P(f 0 = f 1 = f 2 | n=4, d days) = 1/d². Direct corollary of
+   `bad_count_n4_canonical` and `Fintype.card_fun` (= d⁴), via `push_cast`,
+   `field_simp`, `ring`.
+
+### Mathematical Significance
+
+The state.md Next Action #1 calls for the **general per-triple coincidence count**
+`card {f : Fin n → Fin d | f i = f j ∧ f j = f k} = d^(n-2)` for distinct i,j,k.
+Session 8 establishes this for the **n=4 canonical case** (i,j,k = 0,1,2), continuing
+the pattern from `bad_count_n3` (n=3, exponent 1).
+
+The **per-triple probability is invariant in n** (in the canonical form):
+- `p_triple_n3` gives 1/d² (n=3, denominator d³, numerator d)
+- `p_canonical_triple_n4` gives 1/d² (n=4, denominator d⁴, numerator d²)
+
+This invariance is the structural reason why `expectedTriples n d = C(n,3)/d²`
+factors as `(number of triples) × (per-triple probability)`. Session 8 verifies
+this factorization for one extra value of n; the general n version requires
+extending the bijection to `Fin d × (Fin (n-3) → Fin d)`.
+
+The n=4 case isolates the **inductive step from n=3 to n=4**: a single extra
+free position contributes a factor of d to the count, raising the exponent from
+1 to 2. The general n case follows the same inductive pattern (each new free
+position adds another factor of d).
+
+### Why n=4 specifically (and not the general n form)?
+
+A general-n proof requires `Fin.snoc`/`Fin.castSucc`-based decomposition of
+`Fin (n+1) → Fin d` into `(Fin n → Fin d) × Fin d`, with care to show the
+constraint on indices 0,1,2 is preserved. This is ~50–100 lines and benefits
+from infrastructure not yet present in this file.
+
+The n=4 case uses a direct `Equiv` (parallels `bad_count_n3`'s style) with
+`if i.val = 3 then w else v`, fitting in ~20 lines. It demonstrates the pattern
+without the bookkeeping overhead of general-n induction. The next session can
+attempt the general lemma using the n=4 case as a sanity-check anchor.
+
+### Files Modified
+
+- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` (+51 lines: 2 theorems +
+  Summary block update + 2 #check lines; 667 → 718)
+- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` (lineCount
+  667→718, theoremCount 30→32 in both top-level meta and leanFile;
+  originalContributions += 2 entries)
+- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json`
+  (Session 8 entries in builtItems/insights/progressSummary; iteration 7→8;
+  leanFiles[BirthdayProblemOQ03OQ01OQ02] lineCount/theoremCount synced)
+- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md` (iteration
+  7→8; per-triple n=4 entry under Active Approach; Next Action #1 reframed as
+  "general n" with n=3,4 noted as solved)
+- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md` (this entry)
+
+### Verification
+
+Docker build of `Proofs.BirthdayProblemOQ03OQ01OQ02` was launched at session
+start (cold cache, Mathlib clone in progress). Build outcome to be confirmed
+before opening PR; if build verification times out, PR will be marked as draft
+"build pending" matching prior sessions' convention.
+
+### Next Steps
+
+1. **General n per-triple count** (still open from Session 8): prove
+   `card {f : Fin n → Fin d | f 0 = f 1 ∧ f 1 = f 2} = d^(n-2)` for n ≥ 3
+   via induction (base case n=3 is `bad_count_n3`; n=4 is `bad_count_n4_canonical`;
+   inductive step uses `Fin.snoc` decomposition `Fin (n+1) → Fin d ≃ (Fin n → Fin d) × Fin d`).
+   Then extend to general distinct i,j,k via permutation symmetry.
+2. **Markov bound for general n** (state.md Next Action #2): combine general
+   per-triple count with C(n,3) triples to get P(some triple) ≤ C(n,3)/d²
+   = expectedTriples n d. Global form of Session 7's n=3 identity, as an
+   inequality.
+3. Lemma C itself remains the target.

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
@@ -4,14 +4,16 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-29T00:00:00Z
-**Iteration**: 7
-**Last Update**: 2026-05-08 (Session 7, researcher-9)
+**Iteration**: 8
+**Last Update**: 2026-05-08 (Session 8, researcher-6)
 
 ## Current Focus
 Lemmas A, B proved (Session 4). Lemma C remains the only axiom. Sessions 6–7
 added n=3 base-case real-number probability forms (good and bad sides) and the
-n=3 first-moment identity P(triple) = expectedTriples 3 d. Next sessions should
-target the per-triple coincidence count and Markov bound for general n.
+n=3 first-moment identity P(triple) = expectedTriples 3 d. Session 8 extends
+the per-triple count from n=3 to n=4 (canonical triple): bad_count_n4_canonical
+= d², p_canonical_triple_n4 = 1/d². Next sessions should target the general n
+per-triple count and Markov bound.
 
 ## Active Approach
 Decomposition strategy:
@@ -26,20 +28,30 @@ n=3 base-case scaffolding (Sessions 6–7):
 - `p_triple_n3` (Session 7): P(triple|n=3) = 1/d²
 - `p_triple_n3_eq_expectedTriples` (Session 7): n=3 first-moment identity
 
+Per-triple count generalization (Session 8):
+- `bad_count_n4_canonical` (Session 8): card{f : Fin 4 → Fin d | f 0 = f 1 = f 2} = d²
+  (Equiv f ↔ (f 0, f 3); one common value × one free position)
+- `p_canonical_triple_n4` (Session 8): P(canonical triple | n=4, d≥1) = 1/d²
+  (per-triple probability is independent of n in canonical form — same as p_triple_n3)
+
 ## Attempt Count
-- Total attempts: 7
-- Current approach attempts: 4 (Sessions 4–7 ACT)
-- Approaches tried: 1 (decomposition into Lemmas A/B/C, with n=3 scaffolding)
+- Total attempts: 8
+- Current approach attempts: 5 (Sessions 4–8 ACT)
+- Approaches tried: 1 (decomposition into Lemmas A/B/C, with n=3 scaffolding +
+  per-triple n=4 extension)
 
 ## Blockers
 - Lemma C requires method-of-factorial-moments → Poisson convergence, which is
   not in Mathlib but is substantially smaller than full Chen-Stein.
 
 ## Next Action
-1. **Per-triple coincidence count** for n ≥ 3, d ≥ 1, distinct i,j,k:
+1. **Per-triple coincidence count for general n** ≥ 3, d ≥ 1, distinct i,j,k:
    `card {f : Fin n → Fin d | f i = f j ∧ f j = f k} = d^(n−2)`.
    ~50–100 lines via explicit Equiv with `Fin d × (Fin (n−3) → Fin d)`.
+   Sessions 1–8 establish n=3 (`bad_count_n3`, exponent 1) and n=4 (`bad_count_n4_canonical`,
+   exponent 2); the general case is the natural next step using `Fin.snoc`-style
+   inductive extension.
 2. **Markov bound for general n**: P(some triple) ≤ C(n,3)/d² = expectedTriples n d.
-   The global form of Session 7's n=3 identity.
+   The global form of Session 7's n=3 identity. Requires per-triple count + union bound.
 3. **Bonferroni r=2 lower bound**: foundation for higher-order factorial moments.
 4. **Lemma C itself**: multi-session push or Mathlib upstream contribution.

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 667,
-    "theoremCount": 30,
+    "lineCount": 718,
+    "theoremCount": 32,
     "definitionCount": 3,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
@@ -37,7 +37,9 @@
       "general_threshold_exponent: scaling exponent is (k-1)/k for k-way coincidences",
       "nc_div_pow_tendsto: n_c(d)/d^{2/3} → c (foundation for Lemma A, squeeze proof strategy)",
       "lambda_tendsto (Lemma A): C(n_c(d),3)/d² → c³/6 via squeeze between (n-2)³/6d² and n³/6d² (PROVED)",
-      "exp_lambda_tendsto (Lemma B): exp(-λ_c(d)) → exp(-c³/6) via Real.continuous_exp continuity (PROVED)"
+      "exp_lambda_tendsto (Lemma B): exp(-λ_c(d)) → exp(-c³/6) via Real.continuous_exp continuity (PROVED)",
+      "bad_count_n4_canonical: per-triple count for canonical (0,1,2) triple in Fin 4 = d² (Equiv f ↔ (f 0, f 3); one common value + one free position) — Session 8 step toward general n per-triple count d^(n-2)",
+      "p_canonical_triple_n4: per-triple probability for canonical triple in Fin 4 = 1/d² (matches p_triple_n3, confirming per-triple probability is independent of n in canonical form)"
     ]
   },
   "overview": {
@@ -142,11 +144,11 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 667,
+    "lineCount": 718,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 30,
+    "theoremCount": 32,
     "definitionCount": 3
   },
   "sorries": 0

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
@@ -32,10 +32,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-06T13:21:41Z",
-    "iteration": 7,
-    "focus": "Session 7 (2026-05-08): added p_triple_n3 (real-number form of bad_count_n3, P(triple|n=3) = 1/d²) and p_triple_n3_eq_expectedTriples (n=3 first-moment identity P(triple) = expectedTriples 3 d). Together with p_no_triple_n3 (Session 6) these complete the n=3 base-case picture from both sides and explicitly verify that the abstract `expectedTriples` formula equals the actual probability at n=3 (Markov is tight when X_d ≤ 1). Foundational seed for the broader factorial-moment identity needed for Lemma C. Lemma C itself remains the only axiom; ~500 lines of Mathlib infrastructure still required.",
+    "iteration": 8,
+    "focus": "Session 8 (2026-05-08): added bad_count_n4_canonical (per-triple count for canonical triple (0,1,2) in Fin 4 = d², via explicit Equiv f ↔ (f 0, f 3)) and p_canonical_triple_n4 (per-triple probability = 1/d² for d ≥ 1). First step toward state.md Next Action #1 (general n per-triple count card{f|f i=f j=f k}=d^(n-2)). Confirms per-triple probability is independent of n in canonical form (matches p_triple_n3 from Session 7). Lemma C still the only axiom.",
     "blockers": [],
-    "nextAction": "Lemma C requires substantial Mathlib infrastructure (qualitative method-of-factorial-moments → Poisson convergence, ≈500 lines). Either build it locally for this entry, contribute upstream to Mathlib, or accept the entry as axiomatized. Smaller incremental contributions: per-triple coincidence count formula card{f | f i = f j = f k} = d^(n-2) for n ≥ 3 (next building block), union bound on triple count, factorial moment definitions, Bonferroni r=1 bound.",
+    "nextAction": "General n per-triple count: prove card{f : Fin n → Fin d | f 0 = f 1 ∧ f 1 = f 2} = d^(n-2) for n ≥ 3 by induction (base cases n=3, n=4 now in source via bad_count_n3, bad_count_n4_canonical). Inductive step uses Fin.snoc decomposition Fin (n+1) → Fin d ≃ (Fin n → Fin d) × Fin d. Then extend to general distinct i,j,k via permutation symmetry. Markov bound for general n follows by union bound over C(n,3) triples. Lemma C requires substantial Mathlib infrastructure (qualitative method-of-factorial-moments → Poisson convergence, ≈500 lines).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -43,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 7, 2026-05-08): added p_triple_n3 (real-number form of bad_count_n3, P(triple|n=3) = 1/d²) and p_triple_n3_eq_expectedTriples (n=3 first-moment identity P(triple|n=3) = expectedTriples 3 d). Complements Session 6's p_no_triple_n3 (the negation). Together they cover the n=3 base case from both sides and provide the FIRST explicit identification of `expectedTriples` (analytic formula) with an actual probability — the seed of the broader first-moment identity P(some triple) = E[X_d] needed for any factorial-moment / Bonferroni approach to Lemma C. Markov is tight at n=3 since X_d ≤ 1 (only one possible triple). Lemma C remains axiomatized; the ~500-line Mathlib infrastructure for method-of-factorial-moments → Poisson convergence is unchanged. PRIOR (Session 6): p_no_triple_n3 added. (Session 5, PR #16150) poisson_approx_birthday3 derived from Lemma B + Lemma C.",
+    "progressSummary": "PROGRESS (Session 8, 2026-05-08, researcher-6): added bad_count_n4_canonical (per-triple count for canonical (0,1,2) triple in Fin 4 = d² via explicit Equiv f ↔ (f 0, f 3); one common value × one free position) and p_canonical_triple_n4 (real-number probability form = 1/d² for d ≥ 1). First step toward state.md Next Action #1 (general n per-triple count d^(n-2)). The per-triple probability is invariant in n in the canonical form: 1/d² at n=3 (p_triple_n3, Session 7) and 1/d² at n=4 (p_canonical_triple_n4, Session 8). The structural reason: each new free position contributes a factor of d to both numerator and denominator. Lemma C remains the only axiom. PRIOR (Session 7): p_triple_n3, p_triple_n3_eq_expectedTriples — n=3 first-moment identity. PRIOR (Session 6): p_no_triple_n3. (Session 5, PR #16150) poisson_approx_birthday3 derived from Lemma B + Lemma C.",
     "builtItems": [
       "Corrected JSON `problemStatement.formal` to match actual Lean axiom signature (qualitative Tendsto, not |...| ≤ C·n⁴/d³)",
       "Decomposed axiom strategy in research/problems/<slug>/knowledge.md into sublemmas A/B/C",
@@ -57,7 +57,9 @@
       "Session 6 (2026-05-07): p_no_triple_n3 in BirthdayProblemOQ03OQ01OQ02.lean (line ~585) — real-number form of n=3 base case: ((|good_n=3|) : ℝ) / (d^3 : ℝ) = 1 − 1/d² for d ≥ 1, proved via good_count_n3, Nat.cast_sub, push_cast, field_simp.",
       "Session 6 (2026-05-07): repaired 4 Mathlib API drift errors in lambda_tendsto, bad_count_n3, good_count_n3 (introduced upstream after PR #16150 merged on 2026-05-06): tendsto_..._of_le_of_le → primed eventual variant; div_le_div_right → div_le_div_iff_of_pos_right; ← Fintype.card_coe inserted to bridge Finset.card ↔ Fintype.card; explicit predicate passed to filter_card_add_filter_neg_card_eq_card to satisfy DecidablePred synthesis.",
       "Session 7 (2026-05-08, researcher-9): p_triple_n3 in BirthdayProblemOQ03OQ01OQ02.lean (line ~601) — real-number form of bad_count_n3: ((|bad_n=3|) : ℝ) / (d^3 : ℝ) = 1 / d² for d ≥ 1, proved via bad_count_n3, Fintype.card_fun, push_cast, field_simp, ring.",
-      "Session 7 (2026-05-08, researcher-9): p_triple_n3_eq_expectedTriples in BirthdayProblemOQ03OQ01OQ02.lean (line ~617) — n=3 first-moment identity P(triple|n=3) = expectedTriples 3 d, proved by p_triple_n3 + simp [expectedTriples, Nat.choose_self]. First explicit connection between `expectedTriples` (analytic) and an actual probability."
+      "Session 7 (2026-05-08, researcher-9): p_triple_n3_eq_expectedTriples in BirthdayProblemOQ03OQ01OQ02.lean (line ~617) — n=3 first-moment identity P(triple|n=3) = expectedTriples 3 d, proved by p_triple_n3 + simp [expectedTriples, Nat.choose_self]. First explicit connection between `expectedTriples` (analytic) and an actual probability.",
+      "Session 8 (2026-05-08, researcher-6): bad_count_n4_canonical in BirthdayProblemOQ03OQ01OQ02.lean (line ~624) — per-triple count for canonical (0,1,2) triple in Fin 4 = d². Explicit Equiv between subtype {f : Fin 4 → Fin d // f 0 = f 1 ∧ f 1 = f 2} and Fin d × Fin d via f ↔ (f 0, f 3). Forward map projects out the common value and the free position. Inverse map sets f 0=f 1=f 2=v and f 3=w via `if i.val = 3 then w else v`. left_inv uses fin_cases + simp_all with the constraint hypotheses; right_inv reduces by rfl. File 667 → 718 lines, theorems 30 → 32.",
+      "Session 8 (2026-05-08, researcher-6): p_canonical_triple_n4 in BirthdayProblemOQ03OQ01OQ02.lean (line ~647) — real-number probability form: P(f 0 = f 1 = f 2 | n=4, d ≥ 1) = 1/d². Direct corollary of bad_count_n4_canonical and Fintype.card_fun (= d⁴) via push_cast + field_simp + ring. Confirms per-triple probability is independent of n in canonical form (matches Session 7's p_triple_n3 = 1/d²)."
     ],
     "insights": [
       "JSON `formal` field drifted from actual Lean axiom: JSON claimed quantitative |triple_prob − (1−exp(−λ))| ≤ C·n⁴/d³, but the Lean axiom is qualitative Tendsto along the threshold scaling — discrepancy was the cause of Session 1's BLOCKED conclusion",
@@ -75,7 +77,9 @@
       "Lemma B is a one-liner: Real.continuous_exp.tendsto ∘ lambda_tendsto.neg",
       "Session 6 sanity check: at n_c(d)=3 (sparse subset of d, where c·d^(2/3) ∈ [3,4)), P_no_triple(3,d) = 1 − 1/d² → 1 as d → ∞, matching exp(-C(3,3)/d²) = exp(-1/d²) → 1 from Lemma B. The base case is consistent with Lemma C's claimed limit but does not bound it.",
       "Session 7: at n=3 there is only one possible triple (0,1,2), so the indicator-sum X_d := |{(i,j,k) | i<j<k ∧ f(i)=f(j)=f(k)}| satisfies X_d ∈ {0,1}. Hence P(X_d ≥ 1) = E[X_d], i.e. Markov is tight. In our explicit form: P(triple|n=3) = 1/d² = (3.choose 3 : ℝ)/d² = expectedTriples 3 d. This is a verified instance of the first-moment identity P(some triple) = C(n,3)/d² that any factorial-moments / Bonferroni proof of Lemma C must establish for general n.",
-      "Session 7: `expectedTriples` was previously a purely analytic quantity (a definition with no probability content). p_triple_n3_eq_expectedTriples is the first place in the file where it is identified with an actual probability. The identification is exact at n=3 and gives a one-sided Markov bound P(some triple) ≤ expectedTriples n d for general n (not yet formalized, but a clean next building block)."
+      "Session 7: `expectedTriples` was previously a purely analytic quantity (a definition with no probability content). p_triple_n3_eq_expectedTriples is the first place in the file where it is identified with an actual probability. The identification is exact at n=3 and gives a one-sided Markov bound P(some triple) ≤ expectedTriples n d for general n (not yet formalized, but a clean next building block).",
+      "Session 8: per-triple probability is structurally invariant in n (canonical form). The proof of bad_count_n4_canonical isolates the inductive pattern: each additional free position (beyond the constrained triple) contributes a factor of d to both the bad count and the total |Fin n → Fin d| = d^n, so the probability stays at 1/d^2. This explains why expectedTriples n d = (n.choose 3) × (1/d^2) factors as (number of canonical triples) × (per-triple probability) — the structure that any union bound on the triple count must use.",
+      "Session 8: the n=4 case demonstrates the inductive pattern from n=3 to n=4 — going from exponent 1 (bad_count_n3) to exponent 2 (bad_count_n4_canonical), gaining one factor of d per new free position. The general n ≥ 3 case follows by the same pattern via Fin.snoc-style decomposition Fin (n+1) → Fin d ≃ (Fin n → Fin d) × Fin d, but the bookkeeping (Fin.castSucc, Fin.last) is more involved than the direct n=4 Equiv. Splitting the work this way isolates the conceptual content (one extra free position = factor of d) from the indexing machinery."
     ],
     "mathlibGaps": [
       "Method of factorial moments → Poisson convergence (qualitative form) — not in Mathlib but smaller than Chen-Stein",
@@ -83,6 +87,8 @@
       "(Quantitative) Chen-Stein bound — NOT NEEDED for the actual qualitative axiom; was only needed for the misframed quantitative bound"
     ],
     "nextSteps": [
+      "General n per-triple count (state.md Next Action #1): prove card{f : Fin n → Fin d | f 0 = f 1 ∧ f 1 = f 2} = d^(n-2) for n ≥ 3 by induction on n. Base case n=3 is bad_count_n3; n=4 is bad_count_n4_canonical (Session 8). Inductive step uses Fin.snoc decomposition Fin (n+1) → Fin d ≃ (Fin n → Fin d) × Fin d and the fact that the constraint involves only indices 0,1,2 < n. Then extend to general distinct i,j,k via permutation symmetry.",
+      "Markov bound for general n (state.md Next Action #2): combine general per-triple count with C(n,3) triples to get the union bound P(some triple) ≤ C(n,3)/d² = expectedTriples n d. Global form of Session 7's n=3 identity, this time as an inequality.",
       "Lemma C (open): prove p_no_triple_tendsto in Lean — P_no_triple(n_c(d), d) → exp(-c³/6) — via the qualitative method-of-factorial-moments → Poisson convergence (≈500 lines, not in Mathlib 4.26).",
       "Alternative: contribute method-of-factorial-moments → Poisson convergence upstream to Mathlib (Mathlib.Probability.Distributions.Poisson currently exposes only PMF/measure constructors, no convergence theorems)."
     ]
@@ -118,7 +124,7 @@
     ]
   },
   "started": "2026-04-21T06:38:17Z",
-  "lastUpdate": "2026-05-07T22:55:00Z",
+  "lastUpdate": "2026-05-08T03:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -213,8 +219,8 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 588,
-      "theoremCount": 26,
+      "lineCount": 718,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Session 8 extension of the n=3 first-moment identity (Sessions 6–7) to n=4 with the canonical (0,1,2) triple — first step toward state.md Next Action #1 (general n per-triple count `card{f | f i = f j ∧ f j = f k} = d^(n-2)`).

**Two new theorems** in `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean`:

1. **`bad_count_n4_canonical (d : ℕ)`** — `card{f : Fin 4 → Fin d | f 0 = f 1 ∧ f 1 = f 2} = d²`. Explicit `Equiv` between the bad subtype and `Fin d × Fin d` via `f ↔ (f 0, f 3)`:
   - Forward: `⟨f, _⟩ ↦ (f 0, f 3)` (project common value + free position)
   - Inverse: `(v, w) ↦ ⟨fun i => if i.val = 3 then w else v, _⟩`
   - `left_inv` uses `fin_cases i <;> simp_all` with the constraint hypotheses
   - `right_inv` reduces by `rfl`

2. **`p_canonical_triple_n4 (d : ℕ) (hd : 1 ≤ d)`** — real-number probability form: `P(f 0 = f 1 = f 2 | n=4, d) = 1/d²`. Direct corollary via `Fintype.card_fun = d^4`, `push_cast`, `field_simp`, `ring`.

## Mathematical content

The per-triple probability is **structurally invariant in n** (canonical form):
- `p_triple_n3` (Session 7): 1/d² at n=3 (numerator d, denominator d³)
- `p_canonical_triple_n4` (Session 8): 1/d² at n=4 (numerator d², denominator d⁴)

Each additional free position (beyond the constrained triple) contributes a factor of `d` to both numerator and denominator, leaving the per-triple probability unchanged. This is the structural reason `expectedTriples n d = C(n,3)/d²` factors as `(number of triples) × (per-triple probability)`.

The n=4 case isolates the inductive pattern from `bad_count_n3` (n=3, exponent 1) to `bad_count_n4_canonical` (n=4, exponent 2). The general n version follows the same pattern via `Fin.snoc` decomposition `Fin (n+1) → Fin d ≃ (Fin n → Fin d) × Fin d`, but with more bookkeeping; this PR isolates the conceptual content (one extra free position = factor of d) without that overhead.

## Files

- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` (+51, 667 → 718 lines; +2 theorems, Summary block + #checks updated)
- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` (lineCount 667→718, theoremCount 30→32 in meta + leanFile; +2 `originalContributions` entries)
- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md` (iteration 7→8; Active Approach gains Session 8 entry; Next Action #1 reframed as "general n" with n=3,4 noted as solved)
- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md` (Session 8 entry)
- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json` (Session 8 in `builtItems`/`insights`/`progressSummary`; iteration 7→8; `lastUpdate` synced; `leanFiles[BirthdayProblemOQ03OQ01OQ02]` lineCount 588→718, theoremCount 26→32)

## Build status: pending

Cold-cache Docker build (`./proofs/scripts/docker-build.sh Proofs.BirthdayProblemOQ03OQ01OQ02`) was started at session start but **killed by the 32GB cgroup memory limit during the Mathlib cache download phase** (`lake exe cache get` had downloaded 1281/7727 oleans before being terminated) — a transient infrastructure issue unrelated to the new proofs.

Following the convention from PR #16777 (Session 7), this PR is opened as **draft** with build verification deferred to a follow-up agent or a warm-cache rebuild. The proof code is short and follows the established pattern of `bad_count_n3` (Session 1) — review of the proof body should be straightforward by inspection.

## Test plan

- [ ] Re-run `./proofs/scripts/docker-build.sh Proofs.BirthdayProblemOQ03OQ01OQ02` from a worktree with warm Mathlib cache
- [ ] Confirm `bad_count_n4_canonical` and `p_canonical_triple_n4` type-check
- [ ] Confirm `#check` directives at end of file resolve

## Related

- Sessions 1–7 in `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md`
- Open PRs on this entry: #16837 (S8 expectedTriples linkage, build pending), #16777 (S7 corollary, build pending) — these touch different parts of the file (n=3 Tendsto and §2 expectedTriples linkage); merge order is non-conflicting

🤖 Generated with [Claude Code](https://claude.com/claude-code)