### PR TITLE
research(ballot-oq-03-oq-01-oq-01-oq-01): S20 — extract ballot_counting_identity + totalSym helpers

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -692,6 +692,62 @@ private lemma exists_first_violation_idx {n a b : ℕ}
     have hcle_val : (V.min' hVnonempty).val ≤ j.val := hcle
     omega
 
+/-- **Total multiset of a Sym pair (as a `Sym`).**
+
+    The map `(P, Q) ↦ P.1 + Q.1`, repackaged so the result lives in
+    `Sym (Fin n) (a + b)`. Used to fiber the JDT weight sum by the underlying
+    total multiset, which is the cornerstone of the corrected proof path
+    (Session 19, PR #14891). -/
+private def totalSym {n a b : ℕ}
+    (P : Sym (Fin n) a) (Q : Sym (Fin n) b) : Sym (Fin n) (a + b) :=
+  ⟨P.1 + Q.1, by simp [P.2, Q.2]⟩
+
+@[simp] private lemma totalSym_val {n a b : ℕ}
+    (P : Sym (Fin n) a) (Q : Sym (Fin n) b) :
+    (totalSym P Q).1 = P.1 + Q.1 := rfl
+
+/-- **Total multiset of an `(a+1, b-1)` Sym pair (as a `Sym (a + b)`).**
+
+    Specialised variant for the RHS of the JDT identity (b ≥ 1 needed for the
+    cardinality `(a+1) + (b-1) = a + b`). Pairs with `totalSym` to give a
+    common `Sym (Fin n) (a + b)` codomain for the LHS and RHS fiberings. -/
+private def totalSym' {n a b : ℕ} (hb : 1 ≤ b)
+    (P' : Sym (Fin n) (a + 1)) (Q' : Sym (Fin n) (b - 1)) :
+    Sym (Fin n) (a + b) :=
+  ⟨P'.1 + Q'.1, by
+    rw [Multiset.card_add, P'.2, Q'.2]
+    omega⟩
+
+@[simp] private lemma totalSym'_val {n a b : ℕ} (hb : 1 ≤ b)
+    (P' : Sym (Fin n) (a + 1)) (Q' : Sym (Fin n) (b - 1)) :
+    (totalSym' hb P' Q').1 = P'.1 + Q'.1 := rfl
+
+/-- **Ballot counting identity (per total multiset).**
+
+    For `b ≥ 2` and any total multiset `M : Sym (Fin n) (a + b)`, the number
+    of `(a, b)`-splits of `M` that are NOT column-strict equals the number of
+    arbitrary `(a+1, b-1)`-splits of `M`:
+
+      `#{(P, Q) // ¬ColStrictSym a b P Q ∧ P.1 + Q.1 = M.1}
+       = #{(P', Q') // P'.1 + Q'.1 = M.1, |P'| = a+1, |Q'| = b-1}`
+
+    This is the per-fiber heart of `jdt_weight_sum` (b ≥ 2): the weight
+    factorisation `weight_eq_total_multiset` reduces the polynomial sum
+    identity to this counting statement (see `jdt_weight_sum_b_ge_two_via_count`).
+
+    **Proof strategy (TODO).** Reflection / ballot principle: for `M` with all
+    distinct elements, both cardinalities equal `C(a+b, a+1)`; the multiplicity
+    case generalises by the same argument. Estimated ~150 lines remaining work,
+    Session 21+. The b = 1 analogue (where `b - 1 = 0` and `Q' = ∅`) is the
+    unique-existence statement in `jdt_weight_sum_b_one` / Aristotle. -/
+private theorem ballot_counting_identity (n a b : ℕ) (hb : 2 ≤ b)
+    (M : Sym (Fin n) (a + b)) :
+    ((Finset.univ : Finset (Sym (Fin n) a × Sym (Fin n) b)).filter
+      (fun PQ => ¬ColStrictSym a b PQ.1 PQ.2 ∧ PQ.1.1 + PQ.2.1 = M.1)).card =
+    ((Finset.univ : Finset (Sym (Fin n) (a + 1) × Sym (Fin n) (b - 1))).filter
+      (fun PQ => PQ.1.1 + PQ.2.1 = M.1)).card := by
+  sorry
+
 /-- **Jeu de Taquin weight sum** (key step for two-row Jacobi-Trudi).
     The sum of pair-weights over NON-col-strict (a,b) pairs equals h_{a+1}*h_{b-1}.
 
@@ -724,26 +780,24 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
       -- two distinct non-col-strict (P,Q) pairs can produce the same (P',Q') because
       -- the seam index c is not recoverable from (P',Q') without extra data.
       --
-      -- **S19 strategy** (current): factor weights through the total multiset
-      -- `M : Sym (Fin n) (a + b)`, then apply a ballot counting identity on splits.
+      -- **S19/S20 strategy**: factor weights through the total multiset
+      -- `M : Sym (Fin n) (a + b)`, then apply `ballot_counting_identity` (S20).
       --
-      -- Step (i)  weight factorization: by `weight_eq_total_multiset` (above),
-      --             prod(P)*prod(Q) = prod(P+Q) and prod(P')*prod(Q') = prod(P'+Q').
-      -- Step (ii) regroup both sides by total multiset M = P+Q = P'+Q' : Sym n (a+b)
-      --             (using `Finset.sum_sigma`/`Fintype.sum_equiv` to fiber the sums).
-      -- Step (iii) ballot counting identity (per multiset M):
-      --              #{(P,Q) // ¬ColStrictSym a b ∧ P+Q = M.1}
-      --              = #{(P',Q') // P'.1 + Q'.1 = M.1, |P'|=a+1, |Q'|=b-1}
-      --            For M with all distinct elements, both counts equal C(a+b, a+1)
-      --            by the classical ballot/cycle lemma; the multiplicity case
-      --            generalizes via the same reflection-style argument.
-      -- Step (iv) combine: ∑_M [count] * prod(M) = ∑_M [count] * prod(M)
-      --             since the counts agree per M.
+      -- Step (i)   `weight_eq_total_multiset`: prod(P)*prod(Q) = prod(P.1 + Q.1).
+      -- Step (ii)  regroup both sides by total multiset
+      --              `M = P+Q = P'+Q' : Sym (Fin n) (a+b)` via `totalSym`/`totalSym'`
+      --              (Finset.sum_fiberwise_of_maps_to).
+      -- Step (iii) per-fiber count equality: `ballot_counting_identity` (S20, sorry).
+      -- Step (iv)  combine fiberings: ∑_M [count_LHS] • prod(M) = ∑_M [count_RHS] • prod(M).
       --
       -- The b = 1 case has `b - 1 = 0`, hence a unique `Q' = ∅`, so step (iii)
       -- collapses to **unique-existence per M** — that's why b=1 admits a direct
       -- bijection (cf. `jdt_weight_sum_b_one` and the Aristotle companion).
-      -- Estimated remaining work: ~150-200 lines, dominated by step (iii).
+      --
+      -- Remaining work for jdt_weight_sum b≥2:
+      --   * the per-fiber bijection inside `ballot_counting_identity` (~150 lines, S21+).
+      --   * the structural reduction (steps (i)-(iv) above) using `ballot_counting_identity`
+      --     as a black box (~80-100 lines, separate session).
       sorry
   · -- b = 0: ColStrictSym a 0 P Q is vacuously true (quantifies over Fin (min a 0) = Fin 0)
     -- So ¬ColStrictSym = False, the subtype is empty, and the sum equals 0

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -1,10 +1,94 @@
 # Knowledge Base: LGV Lemma → Jacobi-Trudi Identity
 
 **Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01
-**Last Updated**: 2026-05-07
-**Knowledge Items**: 41
+**Last Updated**: 2026-05-08
+**Knowledge Items**: 44
 
 Insights accumulated during research on this problem.
+
+---
+
+## Session 2026-05-08 (Session 20) — Architectural refactor: extract `ballot_counting_identity`
+
+**Mode**: REVISIT (RICH knowledge tier, score 104)
+**Outcome**: progress — architectural; cleaner black-box separation between
+the polynomial-algebra reduction and the deep combinatorial step.
+
+### What I Did
+
+1. **Added `totalSym` / `totalSym_val`**
+   (`BallotProblemOQ03OQ01OQ01OQ01.lean`):
+   `(P : Sym (Fin n) a) (Q : Sym (Fin n) b) ↦ ⟨P.1 + Q.1, _⟩ : Sym (Fin n) (a + b)`.
+   `totalSym_val` is a `@[simp]` rfl lemma exposing the underlying multiset.
+   ~7 lines including docstring.
+
+2. **Added `totalSym'` / `totalSym'_val`**: companion for the `(a+1, b-1)` RHS
+   shape, taking `hb : 1 ≤ b` so the cardinality fact `(a+1) + (b-1) = a + b`
+   lives once (in the def, via `omega`) instead of per-call. ~10 lines.
+
+3. **Stated `ballot_counting_identity`**: the focused per-fiber cardinality
+   subproblem extracted from the b≥2 sorry —
+
+       `#{(P, Q) // ¬ColStrictSym a b P Q ∧ P.1 + Q.1 = M.1}
+        = #{(P', Q') // P'.1 + Q'.1 = M.1, |P'| = a+1, |Q'| = b-1}`
+
+   for `M : Sym (Fin n) (a + b)` and `b ≥ 2`. ~25 lines incl. docstring,
+   sorry on the proof (the deep ~150-line ballot bijection).
+
+4. **Updated `jdt_weight_sum` b≥2 comment block** to reference the new helpers
+   and document the structural reduction as steps (i)-(iv): weight
+   factorisation → fibering by total multiset → ballot_counting_identity →
+   recombine. The b≥2 sorry itself is unchanged this session — that's
+   step (i)+(ii)+(iv), ~80-100 lines, deferred to S22.
+
+### Key Findings
+
+- **The b≥2 path now decomposes cleanly into two independent parts:**
+  the polynomial-algebra reduction (step (ii) regrouping + step (iv) recombine,
+  using `Finset.sum_fiberwise_of_maps_to` + `weight_eq_total_multiset`) and
+  the deep combinatorial heart (`ballot_counting_identity`, ~150 lines).
+  Each is independently attackable; the latter could even be a Mathlib
+  contribution candidate as a self-contained statement about `Sym`/multiset
+  splits and column-strict pairs.
+
+- **`totalSym'` carries `hb : 1 ≤ b` in its signature** so the cardinality
+  arithmetic `(a+1) + (b-1) = a + b` lives once. Without this, every
+  fiberwise lemma using the RHS sum would need to re-prove or `cast` the
+  type-level equality. With `totalSym'`, both LHS and RHS sums fiber over
+  the same `Sym (Fin n) (a + b)` codomain.
+
+- **Sorry accounting:** 3 → 4 this session. The new sorry
+  (`ballot_counting_identity`) is a clean named statement, not a hidden
+  obstruction inside an existing proof. Net architectural value > sorry-count
+  cost.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (992 → ~1050 lines)
+  - Added: `totalSym` / `totalSym_val` (proved, simp lemma)
+  - Added: `totalSym'` / `totalSym'_val` (proved, simp lemma)
+  - Added: `ballot_counting_identity` (stated, sorry)
+  - Modified: `jdt_weight_sum` b≥2 comment block (steps (i)-(iv) updated)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/{knowledge.md, state.md}`
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`
+
+### Next Steps
+
+1. **S21**: Prove `ballot_counting_identity` (~150 lines). Strategy options:
+   - (a) reflection / cycle lemma for distinct elements + multiplicity argument;
+   - (b) explicit insert-with-disambiguating-data bijection (a Σ-bundled fix
+     to the S18 non-injectivity counterexample).
+
+2. **S22**: Wire `ballot_counting_identity` into `jdt_weight_sum` b≥2 via the
+   structural reduction (steps i-iv). ~80-100 lines using
+   `Finset.sum_fiberwise_of_maps_to` + `weight_eq_total_multiset`.
+
+3. **Optional**: extract `ballot_counting_identity` as a Mathlib contribution
+   candidate. It's a clean statement about `Sym` multisets and column-strict
+   pairs of independent interest in algebraic combinatorics.
+
+4. **For `jacobi_trudi_ssyt_eq` k≥3**: defer until k=2 closes; RSK or
+   algebraic LGV remain the only paths (~300 lines).
 
 ---
 

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,46 +4,51 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-07
-**Iteration**: 18
+**Last Updated**: 2026-05-08
+**Iteration**: 20
 
 ## Current Focus
 
-Proving `jdt_weight_sum` b ≥ 2 — via the **weight factorization + counting
-identity** approach (PR #14891 corrected path, NOT the non-injective
-seam-bijection approach). Session 19 added `weight_eq_total_multiset`
-plus auxiliary `¬ColStrictSym` helpers; 2 sorries remain.
+`ballot_counting_identity` (S20 stated, sorry remaining): the focused per-fiber
+cardinality subproblem extracted from `jdt_weight_sum` b≥2. With this lemma in
+hand, the rest of the b≥2 reduction is structural (~80-100 lines using
+`weight_eq_total_multiset` + `Finset.sum_fiberwise_of_maps_to`).
 
-## Active Approach (S19, post-PR #14891 correction)
+## Active Approach (S20, post-S19 weight identity)
 
 For `jdt_weight_sum` (b ≥ 2):
-- **Step 1**: Use `weight_eq_total_multiset` to rewrite each summand as
-  `((P.1 + Q.1).map X).prod` — depends only on `M := P.1 + Q.1`.
-- **Step 2**: Reindex via `Fintype.sum_sigma` to fiber both sums over
-  `M : Sym n (a+b)`.
-- **Step 3**: Prove `ballot_counting_identity`: for every `M`,
-  `#{non-cs (a,b) splits of M} = #{all (a+1, b-1) splits of M}`.
-- **Step 4**: Combine — equality of polynomials follows from per-fiber
-  cardinality equality times the same `wt(M)`.
+- **Step (i)**: weight factorisation via `weight_eq_total_multiset` (S19).
+- **Step (ii)**: regroup both LHS (¬CS subtype) and RHS (Sym a+1 × Sym b-1)
+  by total multiset `M : Sym (Fin n) (a+b)` using `totalSym` / `totalSym'`
+  (S20) and `Finset.sum_fiberwise_of_maps_to`.
+- **Step (iii)**: per-fiber count equality via `ballot_counting_identity`
+  (S20 stated, sorry).
+- **Step (iv)**: combine to get LHS = RHS.
 
-Completed (this session):
-- `weight_eq_total_multiset` (S19): `wt(P) * wt(Q) = wt(P.1 + Q.1)` — the
-  cornerstone of the corrected path. 2-line proof.
-- `min_ab_pos_of_not_colStrict` (S19): `¬ColStrictSym ⇒ min a b ≥ 1`.
-- `exists_first_violation_idx` (S19): auxiliary structural lemma about
-  `¬ColStrictSym` (smallest violation index via `Finset.min'`). Retained
-  for potential future use; **not** the primary tool because the naive
-  insert-violation map is non-injective (PR #14891).
+Steps (i), (ii), (iv) are ~80-100 lines of structural Lean. Step (iii) is the
+deep ~150-line ballot bijection — extracted as a clean black-box.
+
+Completed (this session, S20):
+- `totalSym` / `totalSym_val` (~5 lines): Sym (Fin n) a × Sym (Fin n) b →
+  Sym (Fin n) (a+b) via P.1 + Q.1.
+- `totalSym'` / `totalSym'_val` (~7 lines): companion for the (a+1, b-1) shape
+  with `hb : 1 ≤ b` baked in.
+- `ballot_counting_identity` stated (~20 lines incl. docstring): the
+  per-fiber cardinality identity, sorry.
+- Updated `jdt_weight_sum` b≥2 comment block to reference the new helpers
+  and document steps (i)-(iv).
 
 Completed (earlier sessions):
-- `jdt_weight_sum_b_one` (S17): b=1 bijection, 75-line proof
-- `not_colStrictSym_a_one_iff_qhead_le_phead` (S16)
-- `colStrictSym_a_one_iff_phead_lt_qhead` (S16)
-- `sym_one_sort_head_singleton` (S15)
-- `jdt_weight_preserved` (S~9)
+- `weight_eq_total_multiset` (S19): cornerstone weight identity.
+- `min_ab_pos_of_not_colStrict` (S19), `exists_first_violation_idx` (S19):
+  auxiliary structural lemmas (latter not on primary path).
+- `jdt_weight_sum_b_one` (S17): b=1 base case, 75-line proof.
+- `not_colStrictSym_a_one_iff_qhead_le_phead` (S16),
+  `colStrictSym_a_one_iff_phead_lt_qhead` (S16),
+  `sym_one_sort_head_singleton` (S15), `jdt_weight_preserved` (S~9).
 
 ## Attempt Count
-- Total attempts: 19 (sessions 1-19)
+- Total attempts: 20 (sessions 1-20)
 - Approaches tried:
   1. SSYT infrastructure (sessions 1-14)
   2. Decompose jdt_weight_sum (session 15)
@@ -52,18 +57,29 @@ Completed (earlier sessions):
   5. Diagnose non-injective bijection + correct path (session 18, PR #14891) ✓
   6. Weight-factorization helper + auxiliary `¬ColStrictSym` lemmas
      (session 19) ✓
+  7. Extract `ballot_counting_identity` + `totalSym`/`totalSym'` helpers,
+     document the structural reduction (session 20) ✓ (this PR)
 
 ## Blockers
 
-None for current approach. The corrected counting-identity path is
-~100-150 lines of standard Lean combinatorics. `weight_eq_total_multiset`
-clears the polynomial-side reduction; the residual work is the per-fiber
-ballot bijection.
+None for current approach. The ballot bijection inside
+`ballot_counting_identity` is ~150 lines of standard Lean combinatorics
+(reflection / cycle lemma over multisets), independently attackable.
 
 ## Next Action
 
-1. Restructure `jdt_weight_sum` LHS by total multiset (use
-   `weight_eq_total_multiset` + `Fintype.sum_sigma`).
-2. State `ballot_counting_identity` as a focused subproblem.
-3. Prove the ballot bijection (~80-130 lines).
-4. After `jdt_weight_sum` closes: `jacobi_trudi_ssyt_eq` k ≥ 3 (RSK/LGV).
+1. **S21**: Prove `ballot_counting_identity` — bijection at the multiset level
+   between non-col-strict (a,b) splits of M and arbitrary (a+1, b-1) splits.
+   ~150 lines. Strategy: adapt the cycle / ballot principle for multisets.
+2. **S22**: Wire `ballot_counting_identity` into `jdt_weight_sum` b≥2 via the
+   structural reduction (steps i-iv documented above). ~80-100 lines using
+   `Finset.sum_fiberwise_of_maps_to` + `weight_eq_total_multiset`.
+3. **Future**: After `jdt_weight_sum` closes, `jacobi_trudi_ssyt_eq` k ≥ 3
+   (RSK / algebraic LGV, ~300 lines).
+
+## File Status
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: ~992 → ~1050 lines.
+- Sorry count: 3 → 4 (added `ballot_counting_identity`; existing
+  `jdt_weight_sum` b≥2 sorry unchanged this session).
+- 0 axioms.

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-23T12:58:12+02:00",
-    "iteration": 3,
-    "focus": "Building Jacobi-Trudi determinant formula in Lean 4 using Mathlib hsymm",
+    "iteration": 20,
+    "focus": "ballot_counting_identity (S20 stated): per-fiber cardinality identity, the focused remaining work for jdt_weight_sum b≥2.",
     "blockers": [],
-    "nextAction": "Implement jdt_weight_sum_b_one using documented recipe (Sym.oneEquiv + Sym.cons + Multiset.sort_cons + Multiset.prod_cons).",
+    "nextAction": "S21: Prove ballot_counting_identity via bijection at the multiset level (~150 lines).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 20 (2026-05-07): Removed duplicate `weight_eq_total_multiset` definition introduced by parallel S19 PRs #16637 and #16661 (both merged within 2 minutes, both adding the same lemma — the second occurrence shadowed the first and would prevent the file from compiling once the parent OQ03OQ02 dependency is fixed). Kept the implicit `{n a b}` signature from #16661, promoted the longer S19 expository docstring from #16637 onto it. File 1010 → 992 lines. Session 19: Added weight_eq_total_multiset (cornerstone of the corrected proof path from PR #14891) plus auxiliary ¬ColStrictSym helpers (min_ab_pos_of_not_colStrict, exists_first_violation_idx). The weight identity reduces jdt_weight_sum b≥2 to a per-fiber counting identity. 2 sorries remain (both unchanged).",
+    "progressSummary": "Session 20 (2026-05-08): Architectural refactor of the b≥2 path. Added totalSym + totalSym^prime helpers (Sym pair → Sym (a+b) total multiset) and ballot_counting_identity as a clean black-box per-fiber cardinality subproblem (sorry; ~150 lines remaining). Updated jdt_weight_sum b≥2 comment block to reference the new structural reduction (steps i-iv). The architecture cleanly separates the polynomial-algebra reduction (steps i,ii,iv) from the combinatorial heart (step iii / ballot_counting_identity), so future sessions can attack the latter in isolation. Sorry count: 3 → 4 (one new clean statement, no work-around closures).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -73,12 +73,14 @@
       "BallotProblemOQ03OQ01OQ01OQ01.lean: jdt_weight_sum dispatches on b = 1 (calls helper) vs b ≥ 2 (original seam bijection sorry).",
       "colStrictSym_a_one_iff_phead_lt_qhead (BallotProblemOQ03OQ01OQ01OQ01.lean:406): characterise ColStrictSym at b=1 as a single inequality (P.sort)[0] < (Q.sort)[0]",
       "not_colStrictSym_a_one_iff_qhead_le_phead (BallotProblemOQ03OQ01OQ01OQ01.lean:421): negation form q ≤ (P.sort)[0] for direct use in the bijection",
-      "jdt_weight_sum_b_one proved at BallotProblemOQ03OQ01OQ01OQ01.lean:474 (S17) — bijection {non-col-strict (a,1) pairs} ≃ Sym (Fin n) (a+1), sorry eliminated"
-    ,
+      "jdt_weight_sum_b_one proved at BallotProblemOQ03OQ01OQ01OQ01.lean:474 (S17) — bijection {non-col-strict (a,1) pairs} ≃ Sym (Fin n) (a+1), sorry eliminated",
       "weight_eq_total_multiset (S19): wt(P)*wt(Q) = wt(P.1+Q.1) — corrected-path cornerstone, 2-line proof",
       "min_ab_pos_of_not_colStrict (S19): ¬ColStrictSym a b P Q → 0 < min a b",
       "exists_first_violation_idx (S19): smallest c : Fin (min a b) with (Q.sort)[c] ≤ (P.sort)[c]; auxiliary (not on primary path)",
-      "S20 cleanup (this PR): removed duplicate `private lemma weight_eq_total_multiset` introduced when parallel S19 PRs #16637 and #16661 merged within 2 minutes of each other, both adding the same lemma. Kept the implicit-argument signature, promoted the longer expository docstring."
+      "S20 cleanup (this PR): removed duplicate `private lemma weight_eq_total_multiset` introduced when parallel S19 PRs #16637 and #16661 merged within 2 minutes of each other, both adding the same lemma. Kept the implicit-argument signature, promoted the longer expository docstring.",
+      "S20: totalSym helper (BallotProblemOQ03OQ01OQ01OQ01.lean): (P : Sym (Fin n) a) (Q : Sym (Fin n) b) ↦ ⟨P.1 + Q.1, _⟩ : Sym (Fin n) (a + b). Plus totalSym_val rfl-simp. Used to fiber both LHS and RHS sums by total multiset.",
+      "S20: totalSym^prime helper: companion to totalSym for the (a+1, b-1) RHS shape; takes hb : 1 ≤ b and produces Sym (Fin n) (a+b) for type-aligned fibering.",
+      "S20: ballot_counting_identity stated (BallotProblemOQ03OQ01OQ01OQ01.lean, ~30 lines incl. docstring) as the focused per-fiber subproblem. Cardinality identity: #{(P,Q) : Sym a × Sym b // ¬CS ∧ P+Q = M.1} = #{(P^prime,Q^prime) : Sym (a+1) × Sym (b-1) // P^prime+Q^prime = M.1}. Sorry remaining (the deep combinatorial work)."
     ],
     "insights": [
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
@@ -127,7 +129,10 @@
       "S18: Correct proof path for b≥2: group LHS by total multiset M, count non-cs splits per fiber via ballot bijection, regroup RHS. Estimated ~100-150 lines standard Lean combinatorics.",
       "S19: weight_eq_total_multiset is a 2-line lemma: rw [Multiset.map_add, Multiset.prod_add]. The hard work is the per-fiber counting identity, not the polynomial reduction.",
       "S19: exists_first_violation_idx (smallest c with (Q.sort)[c] ≤ (P.sort)[c]) is provable via Finset.min' but is NOT the primary tool for the corrected b≥2 proof — the seam-bijection it would parametrise is non-injective (PR #14891). Retained as auxiliary structural lemma.",
-      "S20 race-condition lesson: when two PRs work the same problem in parallel, even when both Lean changes are identical, the merge order can leave a duplicate `private lemma` declaration — invisible until the parent dependency builds (here masked by ongoing OQ03OQ02 API drift). Future sessions: before adding a helper that may be in flight elsewhere, `gh pr list --search '<lemma name>' --state open` is a 5-second guard."
+      "S20 race-condition lesson: when two PRs work the same problem in parallel, even when both Lean changes are identical, the merge order can leave a duplicate `private lemma` declaration — invisible until the parent dependency builds (here masked by ongoing OQ03OQ02 API drift). Future sessions: before adding a helper that may be in flight elsewhere, `gh pr list --search '<lemma name>' --state open` is a 5-second guard.",
+      "S20: Refactored the b≥2 path into a clean black-box reduction. ballot_counting_identity (per-fiber cardinality) is now the focused remaining subproblem, decoupled from the polynomial-algebra setup. The architectural split lets future sessions attack the cardinality identity in isolation, possibly via Aristotle on a small companion file.",
+      "S20: totalSym + totalSym^prime expose the (a+b)-cardinality total multiset as a Sym, so both LHS and RHS sums can fiber over the SAME codomain Sym (Fin n) (a+b). Without this, the type mismatch (a+1)+(b-1) vs a+b would force casts in every fiberwise lemma — totalSym^prime carries hb : 1 ≤ b in its signature so the omega-style equality lives once, in the def, not per-call.",
+      "S20: The remaining b≥2 reduction (steps i-iv in the comment block) is structural: weight_eq_total_multiset rewrites each summand, Finset.sum_fiberwise_of_maps_to regroups by total multiset, ballot_counting_identity equates per-fiber counts, and the chain inverts. Estimated 80-100 lines once ballot_counting_identity is filled."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -135,17 +140,14 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "S19 NEXT: Restructure jdt_weight_sum LHS via weight_eq_total_multiset + Fintype.sum_sigma to fiber over total multiset M : Sym n (a+b)",
-      "S19 NEXT: State and prove ballot_counting_identity — #{non-cs (a,b) splits of M} = #{all (a+1, b-1) splits of M} (~80-130 lines).",
-      "CRITICAL: Do NOT use the insert-violation-element bijection — it is non-injective for b≥2 (S18 counterexample). Use weight-factorization + counting-identity approach instead.",
-      "Implement weight_eq_total_multiset: wt(P)*wt(Q) = ((P.1+Q.1).map X).prod — use jdt_weight_preserved iteratively or direct Multiset.prod lemmas.",
-      "Restructure jdt_weight_sum LHS sum to group by total multiset M : Sym n (a+b). Use Fintype.sum_sigma or equiv to fiber product.",
-      "State and prove ballot_counting_identity: for M : Sym n (a+b), #{non-cs (a,b) splits of M} = C(a+b,a+1). This is the core counting argument — implement as a separate lemma via Fintype.card_congr + ballot bijection.",
-      "For jacobi_trudi_ssyt_eq k≥3: RSK or algebraic LGV remain the only paths. ~300 lines. Consider building BallotProblemOQ03AlgebraicLGV.lean first."
+      "S21: Prove ballot_counting_identity (~150 lines). Strategy: construct a bijection between the two filtered finsets at the multiset level. Approach options — (a) reflection/cycle lemma for distinct elements + multiplicity argument; (b) explicit insert-with-disambiguating-data bijection (the Σ-bundled fix to S18 non-injectivity).",
+      "S22: Wire ballot_counting_identity into jdt_weight_sum b≥2 via the structural reduction (steps i-iv documented). ~80-100 lines using Finset.sum_fiberwise_of_maps_to + weight_eq_total_multiset.",
+      "Optional: extract ballot_counting_identity as a standalone Mathlib contribution candidate — it is a clean, named statement about Sym multisets and column-strict pairs, of independent interest in algebraic combinatorics.",
+      "For jacobi_trudi_ssyt_eq k≥3: RSK or algebraic LGV. ~300 lines. Defer until k=2 (jdt_weight_sum) closes."
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n",
-    "insightsCount": 39,
-    "builtItemsCount": 41,
+    "insightsCount": 50,
+    "builtItemsCount": 50,
     "nextStepsCount": 4
   },
   "tags": [
@@ -179,7 +181,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-05-07T22:20:00.000Z",
+  "lastUpdate": "2026-05-08T03:30:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",


### PR DESCRIPTION
## Summary

Architectural refactor of the b≥2 path in `jdt_weight_sum` (Jacobi-Trudi):

- Add `totalSym` / `totalSym'` helpers (Sym pair → Sym (a+b) total multiset)
- State `ballot_counting_identity` (sorry) as a clean per-fiber cardinality subproblem
- Document the structural reduction (steps i-iv) in the b≥2 comment block

The b≥2 path now decomposes cleanly into two independent parts: a polynomial-algebra reduction (steps i, ii, iv using `Finset.sum_fiberwise_of_maps_to` + `weight_eq_total_multiset`) and the deep combinatorial heart (`ballot_counting_identity`, ~150 lines).

Sorry count: 3 → 4 (one new clean named statement).

## Files Modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (~58 lines added)
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/{knowledge.md, state.md}`
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`

## Status

**Outcome**: progress (architectural)
**Next Steps (S21)**: prove `ballot_counting_identity` (~150 lines, multiset bijection via reflection / cycle lemma)

## Build verification note

Local Docker build was blocked by a pre-existing circular `.lake` symlink in the worktree (`proofs/.lake → proofs/.lake` self-loop), causing the cache mount to mis-resolve and the container to attempt a full Mathlib build (OOM at 32GB). The Lean changes (defs + statement) are minimal and standard — relying on CI for compile verification.

🤖 Generated by researcher-1