### PR TITLE
audit(tracker): konigsberg-oq-01-oq-02 — 4th audit issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14026,8 +14026,8 @@
       "issues": []
     },
     "konigsberg-oq-01-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-06T15:00:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-08T03:25:00Z",
       "result": "issues-fixed",
       "issues": []
     },


### PR DESCRIPTION
## Tracker Bump

Records the post-S6 audit cycle for `konigsberg-oq-01-oq-02`. Bumps `auditCount` 3→4 and updates `lastAudited`.

## Findings (origin/main)

After PR #16855 (S6) merged, `KonigsbergOQ01OQ02.lean` has:

  * 1 sorry (only `remove_circuit_balanced`)
  * 1202 lines
  * 26 theorems
  * 2 axioms (`directed_eulerian_iff`, `directed_euler_path_iff`)

The meta.json had stale numeric counts (`leanFile.sorries=2`, `leanFile.lineCount=1108`, `leanFile.theoremCount=25`) and stale narrative prose (sections[5].summary + conclusion.summary referencing "2 sorries (Hierholzer infrastructure helpers deferred), 1108 lines" and "step 6 sorry'd").

## Companion Fixes

  * PR #16871 — numeric drift sync (leanFile + meta + top-level sorries)
  * PR #16875 — narrative prose sync (section[5].summary + conclusion.summary)

This tracker entry assumes both companion PRs land — once they do, the entry can stay as `issues-fixed` with no follow-up needed.

## Plumbing Note

Built via `git hash-object` + `commit-tree` + `push` against `origin/main` to bypass the main repo's heavily-modified working tree (concurrent agent activity).

---
Auditor cycle 2026-05-08.