### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iteration 4 — extend Hanson empirical evidence to n ∈ {25, 30, 50} (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -215,12 +215,17 @@ theorem hanson_n10 : lcmRange 10 ≤ 3 ^ 10 := by decide
 theorem hanson_n12 : lcmRange 12 ≤ 3 ^ 12 := by decide
 theorem hanson_n15 : lcmRange 15 ≤ 3 ^ 15 := by native_decide
 theorem hanson_n20 : lcmRange 20 ≤ 3 ^ 20 := by native_decide
+theorem hanson_n25 : lcmRange 25 ≤ 3 ^ 25 := by native_decide
+theorem hanson_n30 : lcmRange 30 ≤ 3 ^ 30 := by native_decide
+theorem hanson_n50 : lcmRange 50 ≤ 3 ^ 50 := by native_decide
 
 -- Concrete lcm values (sanity checks, expected from OEIS A003418):
 theorem lcmRange_5_eq  : lcmRange 5  = 60        := by decide
 theorem lcmRange_10_eq : lcmRange 10 = 2520      := by decide
 theorem lcmRange_15_eq : lcmRange 15 = 360360    := by native_decide
 theorem lcmRange_20_eq : lcmRange 20 = 232792560 := by native_decide
+theorem lcmRange_25_eq : lcmRange 25 = 26771144400 := by native_decide
+theorem lcmRange_30_eq : lcmRange 30 = 2329089562800 := by native_decide
 
 -- =====================================================================
 -- PART 5: Hanson's general bound (open conjecture, axiomatized)


### PR DESCRIPTION
## Summary

Iteration 4 of the Hanson \`lcmRange n ≤ 3^n\` open question. **Five small numerical-verification theorems** extending the empirical-evidence layer past n=20:

- \`hanson_n25\`, \`hanson_n30\`, \`hanson_n50\` (3 new, via \`native_decide\`): three additional \`lcmRange n ≤ 3^n\` checks at higher n. The verified safety margin grows with n:
  - lcm(1..20) = 2.33×10⁸ vs 3²⁰ = 3.49×10⁹ — **factor-15** margin
  - lcm(1..30) = 2.33×10¹² vs 3³⁰ = 2.06×10¹⁴ — **factor-88** margin
  - lcm(1..50) = 3.10×10²¹ vs 3⁵⁰ = 7.18×10²³ — **factor-232** margin
  
  consistent with PNT (ψ(n)/n → 1 < ln 3 ≈ 1.099).
- \`lcmRange_25_eq\` (= 26771144400), \`lcmRange_30_eq\` (= 2329089562800) (2 new): concrete OEIS A003418 sanity checks via \`native_decide\`.

Also **reconciles \`state.md\`** (was 1 iteration stale): bumps Iteration 2 → 4 with Iteration 3 entry restored (PR #16772 merged 2026-05-07 added \`pow_dvd_lcmRange\`).

## Mathematical context

\`hanson_bound : ∀ n, lcmRange n ≤ 3^n\` is the **open target axiom**. Hanson (1972) proved it pencil-and-paper using Beta-integral identities; Mathlib lacks the Beta-integral / Chebyshev-prime-power-formula infrastructure for a Lean proof.

The empirical-evidence layer is **the lowest-cost contribution** that builds confidence in the bound while structural/analytic infrastructure is being developed (Iterations 2, 3 added the structural building blocks: \`lcmRange_succ\`, monotonicity, \`pow_dvd_lcmRange\`). The grow-with-n margin pattern documented here gives a quantitative sense of how slack the bound is at small n — useful when designing constants for any future inductive-step proof.

## Files

- \`proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean\` (+5; 5 new theorems; 237 → 242 lines)
- \`src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json\` (lineCount 237→242, theoremCount 29→34; \`assumptions\` text widened to include n ∈ {25, 30, 50})
- \`research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md\` (iteration 2→4; Iteration 3 entry restored; Iteration 4 added)
- \`src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json\` (\`currentState.iteration\` 3→4; \`focus\`/\`progressSummary\`/\`insights\`/\`builtItems\` updated; \`leanFiles[BaselProblemOQ01OQ01OQ02OQ03]\` lineCount/theoremCount synced; \`markdown\` summary refreshed)

## Build status: pending

Cold-cache Docker build was killed by 32GB cgroup memory limit during Mathlib cache download earlier this session (PR #16873 ran into the same issue). Following established convention (PR #16873, #16777, #16837), this PR is opened as **draft** with build verification deferred to a follow-up agent or warm-cache rebuild.

The new theorems use **only \`decide\`/\`native_decide\`** (no Mathlib API surface beyond what was already exercised by \`hanson_n15\`/\`hanson_n20\`). Numerical values were independently verified via Python:

\`\`\`
lcm(1..25) = 26771144400 ≤ 3^25 = 847288609443
lcm(1..30) = 2329089562800 ≤ 3^30 = 205891132094649
lcm(1..50) = 3099044504245996706400 ≤ 3^50 = 717897987691852588770249
\`\`\`

Risk of build failure: low (no API drift surface).

## Test plan

- [ ] Re-run \`./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ03\` from a worktree with warm Mathlib cache
- [ ] Confirm the 5 new theorems type-check (3 \`hanson_nXX\` and 2 \`lcmRange_XX_eq\`)
- [ ] Verify \`native_decide\` evaluates lcm/exponential at n=50 within reasonable time

## Related

- Iterations 1-3 in \`research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md\`
- PR #16772 (merged 2026-05-07) — Iteration 3 \`pow_dvd_lcmRange\`
- PR #16704 (merged) — Iteration 2 structural lemmas
- Parent file \`Proofs/BaselProblemOQ01OQ01OQ02.lean:410\` — \`axiom lcm_hanson_bound\` that this OQ ultimately discharges

🤖 Generated with [Claude Code](https://claude.com/claude-code)