### PR TITLE
research(hilbert-10-oq-01-oq-02): Σ₂ definability + Σ₂/Π₂ duality (close the Σ₁/Π₁/Σ₂/Π₂ square)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -265,22 +265,143 @@ theorem mazur_implies_not_codiophantine_complement :
     (integers_diophantine_iff_complement_codiophantine.mpr hCodiop)
 
 -- ============================================================
--- Part VIII: The landscape, sharpened
+-- Part VIII: Σ₂ (∃∀, "existential-universal") Definability
+--           and the Σ₂/Π₂ Duality
+-- ============================================================
+
+/-- A subset S ⊆ ℚ is **Σ₂-definable** ("existential-universal", "∃∀") if
+    there exists a polynomial family `P` parametric in `q` AND in an
+    existential block `y : ℕ → ℚ` such that
+
+        q ∈ S  ⟺  ∃ y : ℕ → ℚ, ∀ x : ℕ → ℚ : P(q, y, x) ≠ 0,
+
+    i.e., there is a choice of `y` for which the polynomial `P(q, y, ·)`
+    has no rational solution.
+
+    This is the dual of `IsUniversalExistentialDefinition` (Π₂); the
+    duality is `S ∈ Σ₂  ⟺  (¬S) ∈ Π₂`, proved as
+    `existentialUniversal_iff_universalExistential_complement`. -/
+def IsExistentialUniversalDefinition (S : RatSubset) : Prop :=
+  ∃ P : Rat → (Nat → Rat) → RatDiophantinePoly,
+    ∀ q : Rat, S q ↔ ∃ y : Nat → Rat, ¬ hasRationalSolution (P q y)
+
+/-- **Π₁ ⊆ Σ₂** (one-line containment, axiom-free):
+
+    Every Π₁-definable subset of ℚ is also Σ₂-definable.
+
+    Reason: if `S q ⟺ ∀ x, P(q, x) ≠ 0`, take the existential block `y`
+    to be a dummy and the polynomial to ignore `y`. Then
+    `∃ y, ∀ x, P(q, x) ≠ 0` collapses to the Π₁ form again.
+
+    Precise dual of `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂). -/
+theorem codiophantine_implies_existentialUniversal
+    (S : RatSubset) (h : IsCoDiophantineDefinition S) :
+    IsExistentialUniversalDefinition S := by
+  obtain ⟨P, hP⟩ := h
+  refine ⟨fun q _ => P q, ?_⟩
+  intro q
+  constructor
+  · intro hSq
+    refine ⟨fun _ => 0, ?_⟩
+    exact (hP q).mp hSq
+  · intro hex
+    obtain ⟨_y, hnsol⟩ := hex
+    exact (hP q).mpr hnsol
+
+/-- **Σ₂ / Π₂ duality** (axiom-free up to classical excluded middle):
+
+    A subset S ⊆ ℚ is Σ₂-definable iff its complement is Π₂-definable.
+
+    Higher-level analog of `diophantine_iff_codiophantine_complement`
+    (the Σ₁/Π₁ duality). Both directions use one classical
+    `Classical.byContradiction` step to convert `¬¬` to identity. -/
+theorem existentialUniversal_iff_universalExistential_complement (S : RatSubset) :
+    IsExistentialUniversalDefinition S ↔
+      IsUniversalExistentialDefinition (fun q => ¬ S q) := by
+  constructor
+  · intro h
+    obtain ⟨P, hP⟩ := h
+    refine ⟨P, fun q => ?_⟩
+    constructor
+    · intro hnSq y
+      apply Classical.byContradiction
+      intro hnsol
+      exact hnSq ((hP q).mpr ⟨y, hnsol⟩)
+    · intro hAll hSq
+      obtain ⟨y, hnsol⟩ := (hP q).mp hSq
+      exact hnsol (hAll y)
+  · intro h
+    obtain ⟨P, hP⟩ := h
+    refine ⟨P, fun q => ?_⟩
+    constructor
+    · intro hSq
+      apply Classical.byContradiction
+      intro hnex
+      have hAll : ∀ y : Nat → Rat, hasRationalSolution (P q y) := by
+        intro y
+        apply Classical.byContradiction
+        intro hnsol
+        exact hnex ⟨y, hnsol⟩
+      exact ((hP q).mpr hAll) hSq
+    · intro hex
+      obtain ⟨y, hnsol⟩ := hex
+      apply Classical.byContradiction
+      intro hnSq
+      exact hnsol ((hP q).mp hnSq y)
+
+/-- The Π₂ class is invariant under propositional equivalence of the
+    defining predicate. Pure logical congruence; no axioms. -/
+theorem universalExistentialDefinition_iff_of_pred_iff
+    {S S' : RatSubset} (h : ∀ q, S q ↔ S' q) :
+    IsUniversalExistentialDefinition S ↔ IsUniversalExistentialDefinition S' := by
+  constructor
+  · intro hS
+    obtain ⟨P, hP⟩ := hS
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).symm.trans (hP q)
+  · intro hS'
+    obtain ⟨P, hP⟩ := hS'
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).trans (hP q)
+
+/-- **Corollary of Koenigsmann via Σ₂/Π₂ duality**:
+
+    The complement `ℚ \ ℤ` is Σ₂-definable in ℚ.
+
+    Proof: by `existentialUniversal_iff_universalExistential_complement`,
+    Σ₂(ℚ\ℤ) ⟺ Π₂(¬(ℚ\ℤ)) = Π₂(¬¬ ℤ). Classically, ¬¬ ℤ ⟺ ℤ, so
+    Π₂(¬¬ ℤ) ⟺ Π₂(ℤ), which is `koenigsmann_2016_universal`. NOT a new
+    axiom — pure logical consequence of Koenigsmann + Σ₂/Π₂ duality. -/
+theorem koenigsmann_implies_complement_existentialUniversal :
+    IsExistentialUniversalDefinition NotIntSubset := by
+  have hbridge : ∀ q : Rat, IntSubset q ↔ ¬ NotIntSubset q :=
+    fun q => ⟨fun hZ hnZ => hnZ hZ, fun hnnZ => Classical.byContradiction hnnZ⟩
+  have hPi2 : IsUniversalExistentialDefinition (fun q => ¬ NotIntSubset q) :=
+    (universalExistentialDefinition_iff_of_pred_iff hbridge).mp
+      koenigsmann_2016_universal
+  exact (existentialUniversal_iff_universalExistential_complement NotIntSubset).mpr
+    hPi2
+
+-- ============================================================
+-- Part IX: The landscape, sharpened
 -- ============================================================
 
 /-
-## Σ₁ vs Π₁ vs Π₂: the precise gap
+## Σ₁ vs Π₁ vs Σ₂ vs Π₂: the precise gap
 
-| Class | Statement on ℤ ⊂ ℚ | Status (2026) |
-|-------|--------------------|----------------|
-| Σ₁ (∃)            | ℤ Diophantine over ℚ                  | **OPEN** (THIS PROBLEM) |
-| Π₁ (∀, complement) | ℚ \ ℤ Π₁-definable over ℚ              | **OPEN** (equivalent to Σ₁ via duality) |
+| Class | Statement on ℤ ⊂ ℚ                       | Status (2026) |
+|-------|------------------------------------------|----------------|
+| Σ₁ (∃)            | ℤ Diophantine over ℚ                | **OPEN** (THIS PROBLEM) |
+| Π₁ (∀, complement) | ℚ \ ℤ Π₁-definable over ℚ            | **OPEN** (equivalent to Σ₁ via duality) |
+| Σ₂ (∃∀, complement) | ℚ \ ℤ Σ₂-definable over ℚ          | **PROVED** (corollary of Koenigsmann) |
 | Π₂ (∀∃)           | ℤ universally-existentially def. in ℚ | **PROVED** (Koenigsmann 2016) |
 
-The Σ₁ ⟺ Π₁(complement) equivalence is now proved in this file as
-`diophantine_iff_codiophantine_complement` (and its specialization
-`integers_diophantine_iff_complement_codiophantine`), formalizing the
-narrative claim. The non-trivial open gap is Σ₁ vs Π₂.
+The Σ₁ ⟺ Π₁(complement) and Σ₂ ⟺ Π₂(complement) dualities are now
+proved as `diophantine_iff_codiophantine_complement` and
+`existentialUniversal_iff_universalExistential_complement`, with the
+Σ₂(ℚ\ℤ) entry derived from Koenigsmann via duality as
+`koenigsmann_implies_complement_existentialUniversal`. The non-trivial
+open gap is Σ₁ vs Π₂ (equivalently, Π₁(complement) vs Σ₂(complement)).
 
 ## Why this distinction matters
 
@@ -294,6 +415,9 @@ narrative claim. The non-trivial open gap is Σ₁ vs Π₂.
 - The Π₁(complement) reformulation is sometimes more tractable for a
   putative refutation: a Π₁ definition of ℚ \ ℤ would mean a polynomial
   P(q, x) such that q ∉ ℤ ⟺ ∃ x rational with P(q,x) = 0.
+- The Σ₂(complement) corollary places `ℚ \ ℤ` on the second level of the
+  arithmetic hierarchy unconditionally, sharpening the "what is known"
+  side of the picture.
 
 ## Axioms in THIS file (1 net new)
 
@@ -302,10 +426,10 @@ narrative claim. The non-trivial open gap is Σ₁ vs Π₂.
      of the explicit Hilbert-symbol polynomial witness).
 
 All other declared `theorem`s are NOT new axioms — they are logical
-consequences of the OQ-01 axioms and the Σ₁ ↔ existing-formulation /
-Σ₁ ↔ Π₁(complement) equivalences proved here.
+consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulation,
+Σ₁ ↔ Π₁(complement), and Σ₂ ↔ Π₂(complement) equivalences proved here.
 
-## Theorems in THIS file (8)
+## Theorems in THIS file (12)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
@@ -316,15 +440,23 @@ consequences of the OQ-01 axioms and the Σ₁ ↔ existing-formulation /
   - `integers_diophantine_iff_complement_codiophantine` (specialization to ℤ)
   - `codiophantine_complement_implies_h10_q_undecidable` (Π₁(ℚ\ℤ) re-export)
   - `mazur_implies_not_codiophantine_complement` (Π₁(ℚ\ℤ) re-export)
+  - `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂, dual of Σ₁ ⊆ Π₂)
+  - `existentialUniversal_iff_universalExistential_complement` (Σ₂/Π₂ duality)
+  - `universalExistentialDefinition_iff_of_pred_iff` (Π₂ class congruence)
+  - `koenigsmann_implies_complement_existentialUniversal` (Σ₂(ℚ\ℤ) corollary)
 -/
 
 #check @IsDiophantineDefinition
 #check @IsUniversalExistentialDefinition
 #check @IsCoDiophantineDefinition
+#check @IsExistentialUniversalDefinition
 #check @koenigsmann_2016_universal
 #check @integers_diophantine_iff
 #check @diophantine_implies_universal_existential
 #check @diophantine_iff_codiophantine_complement
 #check @integers_diophantine_iff_complement_codiophantine
+#check @codiophantine_implies_existentialUniversal
+#check @existentialUniversal_iff_universalExistential_complement
+#check @koenigsmann_implies_complement_existentialUniversal
 
 end Hilbert10Rationals

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -1,40 +1,50 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T03:30:00Z
-**Iteration**: 2
+**Since**: 2026-05-08T06:00:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Adding the Σ₁/Π₁ duality layer to the existing Σ₁ vs Π₂ framework. The
-file already encodes Σ₁ (open) vs Π₂ (Koenigsmann 2016, axiomatized) on
-ℤ ⊂ ℚ. The narrative claims "Σ₁ ⟺ ¬(Π₁ for the complement)" but did not
-formalize it. Closing that gap with axiom-free additions.
+Closing the fourth corner of the Σ₁/Π₁/Σ₂/Π₂ square. Iterations 1 & 2
+established Σ₁ (open), Π₂ (Koenigsmann), and the Σ₁/Π₁ duality. This
+iteration adds Σ₂ definability, the precise dual of Σ₁ ⊆ Π₂ (i.e.
+Π₁ ⊆ Σ₂), the Σ₂/Π₂ duality, and the unconditional Σ₂(ℚ\ℤ) corollary
+of Koenigsmann.
 
 ## Active Approach
 
-S2 — Π₁ definability + classical duality:
+S3 — Σ₂ definability + Σ₂/Π₂ duality:
 
-1. Define `IsCoDiophantineDefinition` (Π₁, purely universal definability).
-2. Define `NotIntSubset = ℚ \ ℤ` as a predicate.
-3. Prove `diophantine_iff_codiophantine_complement` — the general Σ₁/Π₁
-   duality theorem (one classical step on the Π₁ → Σ₁ direction via
-   `Classical.byContradiction`).
-4. Specialize to ℤ as `integers_diophantine_iff_complement_codiophantine`.
-5. Re-export the OQ-01 conditionals (H10/ℚ-undecidability, Mazur) against
-   the new Π₁(ℚ\ℤ) predicate — pure logical consequences, no new axioms.
+1. Define `IsExistentialUniversalDefinition` (Σ₂, ∃∀ definability).
+2. Prove `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂):
+   add a dummy existential block to a Π₁ formula. Axiom-free.
+3. Prove `existentialUniversal_iff_universalExistential_complement`:
+   the higher-level analog of the Σ₁/Π₁ duality. Both directions use
+   `Classical.byContradiction`.
+4. Add `universalExistentialDefinition_iff_of_pred_iff` (Π₂ class is
+   invariant under propositional equivalence of the predicate) as a
+   pure logical congruence helper.
+5. Derive `koenigsmann_implies_complement_existentialUniversal`: the
+   complement ℚ\ℤ is Σ₂-definable in ℚ, as a corollary of Koenigsmann
+   via the Σ₂/Π₂ duality + the predicate-equivalence bridge. No new
+   axiom.
 
-Net new content: 2 definitions, 4 theorems, 0 new axioms.
+Net new content: 1 definition, 4 theorems, 0 new axioms.
+Updated to total: 8 definitions, 13 theorems, 1 axiom, 0 sorries, 462
+lines.
 
 ## Build Status
 
-Docker build: PENDING (running) — file uses Lean core only, no mathlib;
-fast build expected.
+Docker build: PASSED ✅ (3 jobs, exit code 0). Verified the new
+section compiles cleanly against the Lean-core-only design (no Mathlib
+import). The two `Classical.byContradiction` patterns from iteration 2
+extend smoothly to Σ₂/Π₂ — both directions of the new duality, and the
+`hbridge` (`IntSubset q ↔ ¬ NotIntSubset q`) used in the corollary.
 
-First attempt failed because `by_contra` in Lean core requires `Decidable`
-(this file has no mathlib import). Fixed by switching to explicit
-`Classical.byContradiction` with type ascription on the negated
-hypotheses (forces beta reduction of `(fun q => ¬ S q) q ↔ ¬ S q`).
+The `NotIntSubset` definition is non-`@[irreducible]`, so Lean's
+unifier auto-unfolds `¬ NotIntSubset q` to `¬ ¬ IntSubset q` where
+needed (e.g. inside `hbridge`'s `Classical.byContradiction` step).
 
 ## Blockers
 
@@ -42,21 +52,24 @@ None.
 
 ## Next Action
 
-Verify the Docker build passes; commit, push, create PR.
+Commit, push, create PR.
 
-If Σ₁/Π₁ duality lands cleanly, S3 candidates:
-- Σ₁ × Π₁ closure properties (under finite union/intersection) for the
-  Diophantine sets of ℚ.
-- Π₁ ⊆ Π₂ via the `a ≠ 0 ⟺ ∃ z, a·z = 1` polynomial-inversion trick
-  (cleaner once we have a `Field`-like API; would require minor
-  arithmetic lemmas about ℚ).
-- Daans 2021 (10-quantifier reduction) as a separate axiomatized witness
-  refining `koenigsmann_2016_universal` — would add 1 new axiom but
-  improve quantitative content; defer until Σ₁/Π₁ lands.
+If S3 lands cleanly, S4+ candidates:
+- Σ₂ ⊆ Π₂'s ¬¬-shadow — the technical clarification that `Σ₂(S)` and
+  `Π₂(¬¬S) = Π₂(S)` agree on `Prop`-classical predicates; would tighten
+  the predicate-equivalence bridge into a stronger congruence lemma.
+- Σ₁ × Π₁ closure properties (under finite union/intersection) — needs
+  `Rat.mul_eq_zero` / sum-of-squares lemma which would require either
+  a Mathlib import or a hand-rolled proof from Lean core.
+- Π₁ ⊆ Π₂ via the `a ≠ 0 ⟺ ∃ z, a·z = 1` polynomial-inversion trick —
+  needs the same Rat field arithmetic.
+- Daans 2021 (10-quantifier reduction) as a separate axiomatized
+  witness refining `koenigsmann_2016_universal` — would add 1 new axiom
+  but improve quantitative content; defer until further duality / closure
+  work lands.
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 1 (build fix from `by_contra` to
-  `Classical.byContradiction`)
-- Approaches tried: 1 (S2 — Σ₁/Π₁ duality)
+- Total attempts: 3
+- Current approach attempts: 1 (S3 — Σ₂/Π₂ duality, first attempt OK)
+- Approaches tried: 2 (S2 — Σ₁/Π₁ duality, S3 — Σ₂/Π₂ duality)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json
@@ -26,7 +26,7 @@
   {
     "id": "ann-rat-subset",
     "proofId": "hilbert-10-oq-01-oq-02",
-    "range": { "startLine": 66, "endLine": 75 },
+    "range": { "startLine": 66, "endLine": 74 },
     "type": "definition",
     "title": "Subsets of ℚ as Predicates",
     "content": "Establishes the predicate-style encoding of subsets: `RatSubset := Rat → Prop`, and the canonical example `IntSubset q := ∃ z : Int, q = z` (the image of $\\mathbb{Z}$ under $\\mathbb{Z} \\hookrightarrow \\mathbb{Q}$). Using `Prop`-valued predicates rather than `Set`-typed objects makes the $\\Sigma_1$/$\\Pi_2$ definability statements unfold cleanly into first-order quantifier blocks.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-sigma1-def",
     "proofId": "hilbert-10-oq-01-oq-02",
-    "range": { "startLine": 76, "endLine": 102 },
+    "range": { "startLine": 76, "endLine": 101 },
     "type": "concept",
     "title": "Σ₁ Definability: The OPEN Layer",
     "content": "`IsDiophantineDefinition S` says there exists a parametric family $P : \\mathbb{Q} \\to \\text{RatDiophantinePoly}$ such that $S(q) \\iff $ the rational equation $P(q) = 0$ has a solution. `IntegersAreDiophantineOverQ := IsDiophantineDefinition IntSubset` is the open question. The lemma `integers_diophantine_iff` proves $\\Sigma_1$-definability $\\iff$ OQ-01's `IntegersDiophantineOverQ` by `Iff.rfl` — they are *definitionally* equal, not merely logically equivalent. This is the bridge that lets the file re-export OQ-01 conditionals without introducing new axioms.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-pi2-def",
     "proofId": "hilbert-10-oq-01-oq-02",
-    "range": { "startLine": 103, "endLine": 126 },
+    "range": { "startLine": 103, "endLine": 125 },
     "type": "concept",
     "title": "Π₂ Definability + Koenigsmann's Axiom",
     "content": "`IsUniversalExistentialDefinition S` adds a *universal* quantifier block: $S(q) \\iff \\forall y \\in \\mathbb{Q}^\\mathbb{N}, P(q, y) = 0$ has a rational solution. Koenigsmann 2016 is captured as the SINGLE axiom `koenigsmann_2016_universal : IsUniversalExistentialDefinition IntSubset`. The axiomatization is honest: the original proof is constructive (an explicit polynomial built from Hilbert symbols and quaternion algebras over $\\mathbb{Q}$), but Mathlib lacks the Hilbert-symbol/quaternion-form infrastructure to build the polynomial, so we record the conclusion as a black-box assumption pending future formalization.",
@@ -86,7 +86,7 @@
   {
     "id": "ann-mazur-consequence",
     "proofId": "hilbert-10-oq-01-oq-02",
-    "range": { "startLine": 171, "endLine": 186 },
+    "range": { "startLine": 171, "endLine": 185 },
     "type": "insight",
     "title": "Mazur ⟹ ¬Σ₁ (Re-Export, NOT a New Axiom)",
     "content": "Re-exports OQ-01's `mazur_implies_not_diophantine` against the new $\\Sigma_1$ predicate, again as a logical consequence (not an axiom). Mazur's conjecture (1992) places topological constraints on the closure of $\\mathbb{Q}$-solution sets of polynomial equations — constraints that an $\\mathbb{R}$-discrete set like $\\mathbb{Z}$ would violate. So Mazur $\\implies$ $\\mathbb{Z}$ is not $\\Sigma_1$-definable in $\\mathbb{Q}$. Crucially, Mazur is *consistent* with $\\Pi_2$-definability — clarifying why the conjecture does not contradict Koenigsmann.",
@@ -96,13 +96,49 @@
     "prerequisites": ["arithmetic geometry", "real-analytic topology"]
   },
   {
+    "id": "ann-pi1-duality",
+    "proofId": "hilbert-10-oq-01-oq-02",
+    "range": { "startLine": 187, "endLine": 265 },
+    "type": "concept",
+    "title": "Π₁ Definability and the Σ₁/Π₁ Duality",
+    "content": "Adds the third quantifier class: $\\Pi_1$ — purely universal, $S(q) \\iff \\forall x, P(q, x) \\ne 0$. The duality theorem `diophantine_iff_codiophantine_complement` proves the textbook fact that $S$ is $\\Sigma_1$-definable iff its complement is $\\Pi_1$-definable: the easy direction is `refine ⟨P, fun q => ⟨fun hnSq hsol => hnSq ((hP q).mpr hsol), fun hnsol hSq => hnsol ((hP q).mp hSq)⟩⟩`; the reverse direction uses `Classical.byContradiction`. Specializing to $\\mathbb{Z}$ via `integers_diophantine_iff_complement_codiophantine` gives a useful equivalent reformulation: 'is $\\mathbb{Q} \\setminus \\mathbb{Z}$ $\\Pi_1$-definable in $\\mathbb{Q}$?' — sometimes more amenable to refutation arguments. Both H10/ℚ-undecidability and Mazur consequences are re-exported against the new $\\Pi_1(\\mathbb{Q} \\setminus \\mathbb{Z})$ predicate (no new axioms).",
+    "mathContext": "$\\Pi_1$/$\\Sigma_1$ duality (general): for any subset $S \\subseteq \\mathbb{Q}$, $S \\in \\Sigma_1 \\iff (\\mathbb{Q} \\setminus S) \\in \\Pi_1$. This is the standard logical fact that complementing turns existential definitions into universal ones (and vice versa, classically). The reverse direction $\\Pi_1(\\neg S) \\to \\Sigma_1(S)$ uses excluded middle.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic-hierarchy duality", "co-recursively enumerable sets", "Classical.byContradiction"],
+    "prerequisites": ["classical logic", "first-order definability"]
+  },
+  {
+    "id": "ann-sigma2-pi1",
+    "proofId": "hilbert-10-oq-01-oq-02",
+    "range": { "startLine": 267, "endLine": 309 },
+    "type": "concept",
+    "title": "Σ₂ Definability and Π₁ ⊆ Σ₂",
+    "content": "Adds the fourth and final quantifier class: $\\Sigma_2$ — existential-universal ($\\exists \\forall$), defined as `∃ P : Rat → (Nat → Rat) → RatDiophantinePoly, ∀ q, S q ↔ ∃ y, ¬ hasRationalSolution (P q y)`. The trivial containment `codiophantine_implies_existentialUniversal` ($\\Pi_1 \\subseteq \\Sigma_2$) is the precise dual of the earlier $\\Sigma_1 \\subseteq \\Pi_2$: a Π₁ formula $\\forall x, P(q, x) \\ne 0$ is automatically a $\\Sigma_2$ formula $\\exists y, \\forall x, P(q, x) \\ne 0$ with a dummy existential block (witnessed here by `fun _ => 0`). Together, the four classes Σ₁/Π₁/Σ₂/Π₂ form a 'square' with two trivial containments and two dualities.",
+    "mathContext": "$\\Sigma_2$ subset $S \\subseteq \\mathbb{Q}$: $\\exists P : \\mathbb{Q} \\times \\mathbb{Q}^\\mathbb{N} \\to \\text{RatDiophantinePoly} \\, \\forall q : S(q) \\iff \\exists y \\in \\mathbb{Q}^\\mathbb{N}, \\forall x \\in \\mathbb{Q}^\\mathbb{N}, P(q, y, x) \\ne 0$. The standard arithmetic-hierarchy fact that $\\Pi_1 \\subseteq \\Sigma_2$ (trivially, by adding a vacuous existential block on the outside) is proved here in 6 lines.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic hierarchy Σ₂", "Π₁ ⊆ Σ₂ trivial containment", "quantifier-block embedding"],
+    "prerequisites": ["first-order logic", "arithmetic hierarchy"]
+  },
+  {
+    "id": "ann-sigma2-pi2-duality",
+    "proofId": "hilbert-10-oq-01-oq-02",
+    "range": { "startLine": 311, "endLine": 383 },
+    "type": "insight",
+    "title": "Σ₂/Π₂ Duality and the Σ₂(ℚ\\ℤ) Corollary of Koenigsmann",
+    "content": "`existentialUniversal_iff_universalExistential_complement` proves the higher-level analog of the Σ₁/Π₁ duality: $S$ is $\\Sigma_2$-definable iff its complement is $\\Pi_2$-definable. Both directions use one classical `Classical.byContradiction` step (twice in total, once per direction) to convert `¬¬p` to `p`. The helper `universalExistentialDefinition_iff_of_pred_iff` shows the $\\Pi_2$ class is invariant under propositional equivalence of the predicate. Combining these with `koenigsmann_2016_universal` yields the unconditional corollary `koenigsmann_implies_complement_existentialUniversal`: $\\mathbb{Q} \\setminus \\mathbb{Z}$ is $\\Sigma_2$-definable in $\\mathbb{Q}$ — a non-trivial structural fact pulled out of Koenigsmann via the $\\Sigma_2$/$\\Pi_2$ duality, with no new axiom.",
+    "mathContext": "$\\Sigma_2$/$\\Pi_2$ duality: $S \\in \\Sigma_2 \\iff (\\mathbb{Q} \\setminus S) \\in \\Pi_2$. Bridging classically: $\\Pi_2(\\mathbb{Z}) \\implies \\Pi_2(\\neg\\neg \\mathbb{Z}) \\iff \\Pi_2(\\neg(\\mathbb{Q} \\setminus \\mathbb{Z})) \\iff \\Sigma_2(\\mathbb{Q} \\setminus \\mathbb{Z})$. Classical excluded middle is essential for both the duality and the predicate-equivalence bridge.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic-hierarchy duality at level 2", "complementation classical", "Koenigsmann corollary", "Π₂ class congruence"],
+    "prerequisites": ["classical logic", "double-negation elimination", "Koenigsmann 2016"]
+  },
+  {
     "id": "ann-landscape",
     "proofId": "hilbert-10-oq-01-oq-02",
-    "range": { "startLine": 187, "endLine": 231 },
+    "range": { "startLine": 385, "endLine": 447 },
     "type": "context",
-    "title": "Status Table: Σ₁ Open, Π₂ Closed",
-    "content": "The closing comment block presents the sharpened landscape as a table — Σ₁ (∃) OPEN, Π₁ (∀ on the complement) OPEN-equivalent, Π₂ (∀∃) PROVED by Koenigsmann — and explains why the gap matters: only Σ₁ yields H10/ℚ-undecidability via MRDP; Mazur refutes Σ₁ but is consistent with Π₂; a positive Σ₁ answer would be a constructive polynomial witness while a negative answer would likely come from Brauer-Manin / topological structure on ℚ-points. The block also tallies the file's axiom count (1 net new) and theorem count (4-5).",
-    "mathContext": "$\\Sigma_1 \\Leftrightarrow \\neg \\Pi_1$ on the complement (basic logic), so the open content is $\\Sigma_1$ vs $\\Pi_2$. Daans 2021 reduced Koenigsmann's Π₂ definition to 10 universal quantifiers — the next milestone would be reducing further toward Σ₁.",
+    "title": "Status Table: Σ₁/Π₁ Open, Σ₂/Π₂ Closed",
+    "content": "The closing comment block presents the sharpened landscape as a 4-row table — Σ₁ (∃) OPEN, Π₁ (∀ on the complement) OPEN-equivalent, Σ₂ (∃∀ on the complement) PROVED, Π₂ (∀∃) PROVED by Koenigsmann — and explains why the gap matters: only Σ₁ yields H10/ℚ-undecidability via MRDP; Mazur refutes Σ₁ but is consistent with Π₂; the Σ₂(ℚ\\ℤ) corollary places the complement on the second level of the arithmetic hierarchy unconditionally. The block also tallies the file's axiom count (1 net new) and theorem count (13).",
+    "mathContext": "$\\Sigma_1 \\Leftrightarrow \\neg \\Pi_1$ on the complement and $\\Sigma_2 \\Leftrightarrow \\neg \\Pi_2$ on the complement (basic logic), so the open content is $\\Sigma_1$ vs $\\Pi_2$ (equivalently, $\\Pi_1(\\mathbb{Q} \\setminus \\mathbb{Z})$ vs $\\Sigma_2(\\mathbb{Q} \\setminus \\mathbb{Z})$). Daans 2021 reduced Koenigsmann's Π₂ definition to 10 universal quantifiers — the next milestone would be reducing further toward Σ₁.",
     "significance": "context",
     "relatedConcepts": ["arithmetic hierarchy", "Daans 2021", "Eisenträger-Park 2018", "Poonen 2009 nonsquares"],
     "prerequisites": []
@@ -110,11 +146,11 @@
   {
     "id": "ann-checks-and-end",
     "proofId": "hilbert-10-oq-01-oq-02",
-    "range": { "startLine": 232, "endLine": 239 },
+    "range": { "startLine": 449, "endLine": 462 },
     "type": "technique",
     "title": "#check Sanity Tests + Namespace Close",
-    "content": "Five `#check` commands serve as type-level regression tests: `IsDiophantineDefinition`, `IsUniversalExistentialDefinition`, `koenigsmann_2016_universal`, `integers_diophantine_iff`, and `diophantine_implies_universal_existential`. If any of these signatures shift (e.g., the import refactors `RatDiophantinePoly`), the elaboration fails at compile time — pinning the file's API surface. The `end Hilbert10Rationals` closes the namespace cleanly.",
-    "mathContext": "The 5 #check'd identifiers are exactly the public API of the file: 2 definitions ($\\Sigma_1$, $\\Pi_2$), 1 axiom (Koenigsmann), and 2 theorems (definitional equivalence, $\\Sigma_1 \\subseteq \\Pi_2$). Together they characterize the refinement.",
+    "content": "Twelve `#check` commands serve as type-level regression tests for the file's public API: 4 definitions ($\\Sigma_1$, $\\Pi_2$, $\\Pi_1$, $\\Sigma_2$), 1 axiom (Koenigsmann), and 7 theorems (definitional equivalence, $\\Sigma_1 \\subseteq \\Pi_2$, both dualities and their specialization to $\\mathbb{Z}$, $\\Pi_1 \\subseteq \\Sigma_2$, the $\\Sigma_2(\\mathbb{Q} \\setminus \\mathbb{Z})$ corollary). If any of these signatures shift (e.g., the import refactors `RatDiophantinePoly`), the elaboration fails at compile time — pinning the file's API surface. The `end Hilbert10Rationals` closes the namespace cleanly.",
+    "mathContext": "The 12 #check'd identifiers are exactly the public API of the file: 4 definitions ($\\Sigma_1$, $\\Pi_2$, $\\Pi_1$, $\\Sigma_2$), 1 axiom (Koenigsmann), and 7 theorems including both dualities. Together they characterize the four-corner Σ₁/Π₁/Σ₂/Π₂ refinement.",
     "significance": "technical",
     "relatedConcepts": ["Lean #check command", "API stability"],
     "prerequisites": []

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "hilbert-10-oq-01-oq-02",
   "title": "Is ℤ Purely Diophantine over ℚ? — Σ₁ vs Π₂ Definability",
   "slug": "hilbert-10-oq-01-oq-02",
-  "description": "Sharpens the open question 'is ℤ Diophantine over ℚ' (companion to hilbert-10-oq-01) by drawing the precise distinction between Σ₁ (purely existential, Diophantine) and Π₂ (universal-existential, ∀∃) definability. Σ₁ is the OPEN question; Π₂ is settled by Koenigsmann (Annals 2016). Proves Σ₁ ⊆ Π₂, the equivalence with the OQ-01 formulation, and re-exports the H10/ℚ-undecidability and Mazur-conjecture conditional implications.",
+  "description": "Sharpens the open question 'is ℤ Diophantine over ℚ' (companion to hilbert-10-oq-01) by drawing the precise distinction between Σ₁ (purely existential, Diophantine), Π₁ (purely universal), Σ₂ (existential-universal), and Π₂ (universal-existential) definability. Σ₁ is the OPEN question; Π₂ is settled by Koenigsmann (Annals 2016). Proves Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂, the Σ₁/Π₁ and Σ₂/Π₂ dualities, the equivalence with the OQ-01 formulation, the Σ₂(ℚ\\ℤ) corollary of Koenigsmann via duality, and re-exports the H10/ℚ-undecidability and Mazur-conjecture conditional implications.",
   "meta": {
     "author": "Formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_tenth_problem",
@@ -26,12 +26,17 @@
       "IsDiophantineDefinition: Σ₁ (purely existential) definability of subsets of ℚ",
       "IsUniversalExistentialDefinition: Π₂ (∀∃, universal-existential) definability of subsets of ℚ",
       "IsCoDiophantineDefinition: Π₁ (purely universal) definability of subsets of ℚ",
+      "IsExistentialUniversalDefinition: Σ₂ (∃∀, existential-universal) definability of subsets of ℚ",
       "IntegersAreDiophantineOverQ: explicit Σ₁ form of the OPEN question, ↔-equivalent to OQ-01's IntegersDiophantineOverQ",
       "NotIntSubset: ℚ \\ ℤ as a predicate on ℚ",
       "koenigsmann_2016_universal: Π₂-definability of ℤ in ℚ as an axiomatized witness of Koenigsmann (Annals 2016)",
       "diophantine_implies_universal_existential: Σ₁ ⊆ Π₂ — every Diophantine subset is universally-existentially definable",
+      "codiophantine_implies_existentialUniversal: Π₁ ⊆ Σ₂ — every Π₁-definable subset is existential-universal-definable (precise dual of Σ₁ ⊆ Π₂, axiom-free)",
       "diophantine_iff_codiophantine_complement: Σ₁/Π₁ duality — S is Σ₁-definable iff its complement is Π₁-definable (formalizes the narrative claim 'Σ₁ ⟺ ¬(Π₁ for the complement)')",
-      "integers_diophantine_iff_complement_codiophantine: specialization of the duality to ℤ ⊂ ℚ — the OPEN Σ₁ question is equivalent to Π₁-definability of ℚ \\ ℤ",
+      "existentialUniversal_iff_universalExistential_complement: Σ₂/Π₂ duality — S is Σ₂-definable iff its complement is Π₂-definable (higher-level analog of the Σ₁/Π₁ duality, axiom-free up to classical excluded middle)",
+      "universalExistentialDefinition_iff_of_pred_iff: Π₂ class is invariant under propositional equivalence of the defining predicate (logical congruence helper, axiom-free)",
+      "koenigsmann_implies_complement_existentialUniversal: ℚ \\ ℤ is Σ₂-definable in ℚ — corollary of Koenigsmann via Σ₂/Π₂ duality (no new axiom)",
+      "integers_diophantine_iff_complement_codiophantine: specialization of the Σ₁/Π₁ duality to ℤ ⊂ ℚ — the OPEN Σ₁ question is equivalent to Π₁-definability of ℚ \\ ℤ",
       "codiophantine_complement_implies_h10_q_undecidable: Π₁(ℚ\\ℤ) → ¬H10/ℚ-decidable, re-export against the Π₁ predicate (no new axiom)",
       "mazur_implies_not_codiophantine_complement: Mazur conjecture → ¬Π₁(ℚ\\ℤ), re-export against the Π₁ predicate (no new axiom)",
       "integers_diophantine_sigma1_implies_h10_q_undecidable: re-export of the MRDP-reduction implication against the Σ₁ predicate",
@@ -39,16 +44,16 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 330,
+    "lineCount": 462,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
       "Basic computability (rational polynomial evaluation)"
     ],
-    "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ duality and its specialization to ℤ ⊂ ℚ, and the Π₁(ℚ\\ℤ) re-exports) are NOT new axioms — they are logical consequences of the OQ-01 axioms and the Σ₁/Π₁ equivalences proved here. The duality direction Π₁(¬S) → Σ₁(S) uses one classical excluded-middle step.",
+    "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
-    "definitionCount": 7
+    "theoremCount": 13,
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -61,7 +66,9 @@
       "$\\Sigma_1$ remains open and is precisely the form whose positive answer would yield H10/ℚ undecidable",
       "$\\Sigma_1 \\subseteq \\Pi_2$ is trivial (any existential formula is also $\\forall\\exists$ with a dummy universal block); the reverse is the open content",
       "Mazur's conjecture refutes $\\Sigma_1$ but is consistent with $\\Pi_2$ — clarifying why the conjecture does not contradict Koenigsmann",
-      "$\\Sigma_1$/$\\Pi_1$ duality: a subset is $\\Sigma_1$-definable iff its complement is $\\Pi_1$-definable (proved as `diophantine_iff_codiophantine_complement`); specializing to $\\mathbb{Z}$ yields the equivalent reformulation 'is $\\mathbb{Q} \\setminus \\mathbb{Z}$ $\\Pi_1$-definable in $\\mathbb{Q}$?' — sometimes more amenable to refutation arguments"
+      "$\\Sigma_1$/$\\Pi_1$ duality: a subset is $\\Sigma_1$-definable iff its complement is $\\Pi_1$-definable (proved as `diophantine_iff_codiophantine_complement`); specializing to $\\mathbb{Z}$ yields the equivalent reformulation 'is $\\mathbb{Q} \\setminus \\mathbb{Z}$ $\\Pi_1$-definable in $\\mathbb{Q}$?' — sometimes more amenable to refutation arguments",
+      "$\\Sigma_2$/$\\Pi_2$ duality: the higher-level analog (proved as `existentialUniversal_iff_universalExistential_complement`); together with Koenigsmann this yields the unconditional corollary that $\\mathbb{Q} \\setminus \\mathbb{Z}$ is $\\Sigma_2$-definable in $\\mathbb{Q}$",
+      "$\\Pi_1 \\subseteq \\Sigma_2$ is the precise dual of $\\Sigma_1 \\subseteq \\Pi_2$ (a Π₁ formula is trivially a Σ₂ formula via a dummy existential block); together the four containments and two dualities pin down the four corners of the Σ₁/Π₁/Σ₂/Π₂ square"
     ],
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
@@ -116,15 +123,22 @@
       "id": "duality",
       "title": "Π₁ Definability and the Σ₁/Π₁ Duality",
       "startLine": 187,
-      "endLine": 267,
+      "endLine": 266,
       "summary": "Defines `IsCoDiophantineDefinition` (Π₁ — purely universal definability) and the helper `NotIntSubset = ℚ \\ ℤ`. Proves `diophantine_iff_codiophantine_complement` (general Σ₁/Π₁ duality, formalizing the narrative claim 'Σ₁ ⟺ ¬(Π₁ for the complement)'), specializes to ℤ as `integers_diophantine_iff_complement_codiophantine`, and re-exports the H10/ℚ-undecidability and Mazur consequences against the new Π₁(ℚ\\ℤ) predicate. All theorems axiom-free; the duality direction Π₁(¬S) → Σ₁(S) uses one classical excluded-middle step (`Classical.byContradiction`)."
+    },
+    {
+      "id": "sigma2",
+      "title": "Σ₂ Definability and the Σ₂/Π₂ Duality",
+      "startLine": 267,
+      "endLine": 384,
+      "summary": "Defines `IsExistentialUniversalDefinition` (Σ₂ — ∃∀ definability of subsets of ℚ). Proves the precise dual of Σ₁ ⊆ Π₂: `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂, axiom-free). Proves the higher-level analog of the Σ₁/Π₁ duality: `existentialUniversal_iff_universalExistential_complement` (S is Σ₂ iff its complement is Π₂; axiom-free up to two classical steps). Adds the Π₂-class congruence helper `universalExistentialDefinition_iff_of_pred_iff` and uses Σ₂/Π₂ duality + Koenigsmann to derive `koenigsmann_implies_complement_existentialUniversal` (ℚ \\ ℤ is Σ₂-definable in ℚ — corollary, no new axiom)."
     },
     {
       "id": "landscape",
       "title": "The Sharpened Landscape",
-      "startLine": 268,
-      "endLine": 330,
-      "summary": "Status table summarizing Σ₁ (open), Π₁(ℚ\\ℤ) (open, now formally equivalent to Σ₁ via `integers_diophantine_iff_complement_codiophantine`), Π₂ (proved by Koenigsmann). Lists this file's 1 net new axiom and 9 theorems, with #check commands for the main definitions and theorems including the new Π₁ predicate and duality."
+      "startLine": 385,
+      "endLine": 462,
+      "summary": "Status table summarizing Σ₁ (open), Π₁(ℚ\\ℤ) (open, formally equivalent to Σ₁ via `integers_diophantine_iff_complement_codiophantine`), Σ₂(ℚ\\ℤ) (PROVED unconditionally as a corollary of Koenigsmann via `koenigsmann_implies_complement_existentialUniversal`), and Π₂ (proved by Koenigsmann). Lists this file's 1 net new axiom and 13 theorems, with #check commands for the main definitions and theorems including the new Σ₂ predicate, the Σ₂/Π₂ duality, and the Σ₂(ℚ\\ℤ) corollary."
     }
   ],
   "crossReferences": [
@@ -150,8 +164,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This file refines the OQ-01 framework with the precise Σ₁/Π₂ distinction that captures the mathematical content separating the open question from Koenigsmann's 2016 Annals theorem, and adds an explicit Σ₁/Π₁ duality (general and specialized to ℤ ⊂ ℚ). With 1 axiom (Koenigsmann's Π₂ result, proved in 2016 and pending Lean formalization of the explicit polynomial witness) and 9 theorems — including the duality `diophantine_iff_codiophantine_complement` and its specialization showing the OPEN Σ₁ question is equivalent to Π₁-definability of ℚ \\ ℤ — it provides the formal vocabulary in which 'is ℤ purely Diophantine over ℚ' becomes a well-posed Lean statement reachable from either the Σ₁ or Π₁(complement) angle.",
-    "implications": "A positive answer to the Σ₁ question would strengthen Koenigsmann (we prove this strengthening as `integers_diophantine_strengthens_koenigsmann`) and would resolve H10/ℚ negatively. A negative answer (e.g., via Mazur's conjecture) would NOT settle H10/ℚ but would close this specific reduction route.",
+    "summary": "This file refines the OQ-01 framework with the precise Σ₁/Π₂ distinction that captures the mathematical content separating the open question from Koenigsmann's 2016 Annals theorem, and pins down all four corners of the Σ₁/Π₁/Σ₂/Π₂ square via the two dualities (Σ₁/Π₁ and Σ₂/Π₂) and the two trivial containments (Σ₁ ⊆ Π₂ and Π₁ ⊆ Σ₂). With 1 axiom (Koenigsmann's Π₂ result, proved in 2016 and pending Lean formalization of the explicit polynomial witness) and 13 theorems — including the dualities `diophantine_iff_codiophantine_complement` and `existentialUniversal_iff_universalExistential_complement`, the specialization showing the OPEN Σ₁ question is equivalent to Π₁-definability of ℚ \\ ℤ, and the unconditional Σ₂(ℚ\\ℤ) corollary of Koenigsmann — it provides the formal vocabulary in which 'is ℤ purely Diophantine over ℚ' becomes a well-posed Lean statement reachable from any of the four equivalent angles.",
+    "implications": "A positive answer to the Σ₁ question would strengthen Koenigsmann (we prove this strengthening as `integers_diophantine_strengthens_koenigsmann`) and would resolve H10/ℚ negatively. A negative answer (e.g., via Mazur's conjecture) would NOT settle H10/ℚ but would close this specific reduction route. The Σ₂(ℚ\\ℤ) corollary places the complement on the second level of the arithmetic hierarchy unconditionally — a non-trivial structural fact pulled out of Koenigsmann via the Σ₂/Π₂ duality.",
     "openQuestions": [
       "Resolve the Σ₁ question: does $\\mathbb{Z}$ admit a purely Diophantine definition in $\\mathbb{Q}$?",
       "Reduce the quantifier complexity of Koenigsmann's Π₂ definition (Daans 2021 reduced to 10 universal quantifiers; can it be reduced further toward Σ₁?)",
@@ -166,10 +180,10 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 330,
+    "lineCount": 462,
     "axiomCount": 1,
-    "theoremCount": 9,
-    "definitionCount": 7,
+    "theoremCount": 13,
+    "definitionCount": 8,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },
@@ -250,6 +264,26 @@
       "name": "integers_diophantine_iff_complement_codiophantine",
       "type": "theorem",
       "description": "ℤ is Σ₁-definable in ℚ ↔ ℚ \\ ℤ is Π₁-definable in ℚ — the OPEN question reformulated on the complement"
+    },
+    {
+      "name": "IsExistentialUniversalDefinition",
+      "type": "definition",
+      "description": "Σ₂ (existential-universal, ∃∀) definability of subsets of ℚ"
+    },
+    {
+      "name": "codiophantine_implies_existentialUniversal",
+      "type": "theorem",
+      "description": "Π₁ ⊆ Σ₂: every Π₁-definable subset is Σ₂-definable (precise dual of Σ₁ ⊆ Π₂, axiom-free)"
+    },
+    {
+      "name": "existentialUniversal_iff_universalExistential_complement",
+      "type": "theorem",
+      "description": "Σ₂/Π₂ duality: S is Σ₂-definable iff its complement is Π₂-definable (axiom-free up to classical excluded middle)"
+    },
+    {
+      "name": "koenigsmann_implies_complement_existentialUniversal",
+      "type": "theorem",
+      "description": "Corollary of Koenigsmann via Σ₂/Π₂ duality: ℚ \\ ℤ is Σ₂-definable in ℚ (no new axiom)"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -1,96 +1,110 @@
 {
   "slug": "hilbert-10-oq-01-oq-02",
-  "title": "Is \u2124 purely Diophantine over \u211a \u2014 can integrality be detected by polynomial equations with rational solutions?",
+  "title": "Is ℤ purely Diophantine over ℚ — can integrality be detected by polynomial equations with rational solutions?",
   "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\exists\\, P : \\mathbb{Q}[t, x_1, \\ldots, x_k] \\text{ such that } \\forall t \\in \\mathbb{Q}: t \\in \\mathbb{Z} \\iff \\exists\\, x_1, \\ldots, x_k \\in \\mathbb{Q}: P(t, x_1, \\ldots, x_k) = 0",
-    "plain": "Hilbert's 10th over \u2124 is undecidable (Matiyasevich 1970). Whether the analogous problem over \u211a is decidable is OPEN, and reduces to the question: can the set \u2124 \u2282 \u211a be defined PURELY EXISTENTIALLY (i.e., as the projection of a rational-solution set of a polynomial equation)? This is the 'is \u2124 Diophantine over \u211a' question. Sister-question OQ-01 asks the same in a 'broader' definability framework; this OQ-01-OQ-02 narrows to the strictly purely-Diophantine (\u2203-formula) form, where Koenigsmann's celebrated 2016 \u2200\u2203 universal definition does NOT settle the question.",
+    "plain": "Hilbert's 10th over ℤ is undecidable (Matiyasevich 1970). Whether the analogous problem over ℚ is decidable is OPEN, and reduces to the question: can the set ℤ ⊂ ℚ be defined PURELY EXISTENTIALLY (i.e., as the projection of a rational-solution set of a polynomial equation)? This is the 'is ℤ Diophantine over ℚ' question. Sister-question OQ-01 asks the same in a 'broader' definability framework; this OQ-01-OQ-02 narrows to the strictly purely-Diophantine (∃-formula) form, where Koenigsmann's celebrated 2016 ∀∃ universal definition does NOT settle the question.",
     "whyMatters": [
-      "If \u2124 is purely Diophantine over \u211a, then Hilbert's 10th problem over \u211a is undecidable (immediate reduction from Matiyasevich): the answer to one of the most famous open problems in mathematical logic would be settled NEGATIVELY",
-      "Mazur's conjecture (1992): the topological closure of any Diophantine subset of \u211a in \u211d has finitely many connected components \u2014 would IMPLY \u2124 is NOT Diophantine over \u211a (since \u2124 is closed in \u211d with infinitely many points but no interval-like structure)",
-      "Koenigsmann (Annals 2016) gave a UNIVERSAL (\u2200\u2203) definition of \u2124 in \u211a; finding a purely existential (Diophantine) definition would be a substantial strengthening with direct consequences for H10/\u211a",
-      "Bridges mathematical logic, number theory, and arithmetic geometry \u2014 connects to the Brauer-Manin obstruction (Poonen 2009 Diophantine definitions over rings of S-integers)",
-      "Resolution either way (positive or negative) would be a major milestone in the model theory of \u211a"
+      "If ℤ is purely Diophantine over ℚ, then Hilbert's 10th problem over ℚ is undecidable (immediate reduction from Matiyasevich): the answer to one of the most famous open problems in mathematical logic would be settled NEGATIVELY",
+      "Mazur's conjecture (1992): the topological closure of any Diophantine subset of ℚ in ℝ has finitely many connected components — would IMPLY ℤ is NOT Diophantine over ℚ (since ℤ is closed in ℝ with infinitely many points but no interval-like structure)",
+      "Koenigsmann (Annals 2016) gave a UNIVERSAL (∀∃) definition of ℤ in ℚ; finding a purely existential (Diophantine) definition would be a substantial strengthening with direct consequences for H10/ℚ",
+      "Bridges mathematical logic, number theory, and arithmetic geometry — connects to the Brauer-Manin obstruction (Poonen 2009 Diophantine definitions over rings of S-integers)",
+      "Resolution either way (positive or negative) would be a major milestone in the model theory of ℚ"
     ]
   },
   "knownResults": {
     "proven": [
-      "Matiyasevich 1970 (DPRM theorem): every recursively enumerable subset of \u2115 is Diophantine over \u2124; in particular, Hilbert's 10th problem over \u2124 is UNDECIDABLE.",
-      "Robinson 1949: \u2124 is definable in (\u211a, +, \u00b7, 0, 1) by a first-order formula (with universal quantifiers); thus the first-order theory of (\u211a, +, \u00b7) is undecidable.",
-      "Poonen 2009: for many rings of S-integers in number fields (where S has positive density), the analog of Hilbert's 10th is undecidable; uses a Diophantine definition of \u2124 in those rings.",
-      "Koenigsmann 2016 (Annals): \u2124 has a UNIVERSAL (\u03a0\u2081) definition in \u211a \u2014 i.e., \u2124 = {t \u2208 \u211a : \u2200 y\u2081,\u2026,y\u2096, \u2203 z\u2081,\u2026,z\u2098 : P(t, y, z) = 0} for an explicit polynomial P. (NOT a Diophantine, i.e., \u03a3\u2081, definition \u2014 that remains open.)",
-      "Sun 2016, Daans 2021, Eisentr\u00e4ger-Park 2018+: variations and refinements giving alternate \u2200\u2203 definitions; some improving the number of universal quantifiers.",
-      "Mazur's conjecture is KNOWN to imply \u2124 is not Diophantine over \u211a (a clean conditional theorem)."
+      "Matiyasevich 1970 (DPRM theorem): every recursively enumerable subset of ℕ is Diophantine over ℤ; in particular, Hilbert's 10th problem over ℤ is UNDECIDABLE.",
+      "Robinson 1949: ℤ is definable in (ℚ, +, ·, 0, 1) by a first-order formula (with universal quantifiers); thus the first-order theory of (ℚ, +, ·) is undecidable.",
+      "Poonen 2009: for many rings of S-integers in number fields (where S has positive density), the analog of Hilbert's 10th is undecidable; uses a Diophantine definition of ℤ in those rings.",
+      "Koenigsmann 2016 (Annals): ℤ has a UNIVERSAL (Π₁) definition in ℚ — i.e., ℤ = {t ∈ ℚ : ∀ y₁,…,yₖ, ∃ z₁,…,zₘ : P(t, y, z) = 0} for an explicit polynomial P. (NOT a Diophantine, i.e., Σ₁, definition — that remains open.)",
+      "Sun 2016, Daans 2021, Eisenträger-Park 2018+: variations and refinements giving alternate ∀∃ definitions; some improving the number of universal quantifiers.",
+      "Mazur's conjecture is KNOWN to imply ℤ is not Diophantine over ℚ (a clean conditional theorem)."
     ],
     "open": [
-      "Is \u2124 purely Diophantine (\u03a3\u2081) over \u211a? \u2014 the ORIGINAL question; both positive and negative answers consistent with current knowledge.",
-      "Is Hilbert's 10th problem over \u211a decidable? \u2014 closely related; would be undecidable if \u2124 is Diophantine over \u211a.",
-      "Is Mazur's conjecture true? \u2014 would resolve OQ-01-OQ-02 negatively if proved.",
+      "Is ℤ purely Diophantine (Σ₁) over ℚ? — the ORIGINAL question; both positive and negative answers consistent with current knowledge.",
+      "Is Hilbert's 10th problem over ℚ decidable? — closely related; would be undecidable if ℤ is Diophantine over ℚ.",
+      "Is Mazur's conjecture true? — would resolve OQ-01-OQ-02 negatively if proved.",
       "Existence of a Diophantine definition with low quantifier complexity (e.g., bounded number of variables k); even an upper bound on k would be informative.",
-      "Connections to S-integers: for which sets S of primes does \u2124_S have a Diophantine definition in \u211a?",
-      "Mathematical-logic angle: is there a finite-axiomatizable extension of Robinson's Q in which \u2124 becomes \u03a3\u2081-definable?"
+      "Connections to S-integers: for which sets S of primes does ℤ_S have a Diophantine definition in ℚ?",
+      "Mathematical-logic angle: is there a finite-axiomatizable extension of Robinson's Q in which ℤ becomes Σ₁-definable?"
     ],
-    "goal": "Either: (a) construct an explicit polynomial P(t, x_1, \u2026, x_k) \u2208 \u211a[t, x] witnessing \u2124 as a Diophantine subset of \u211a \u2014 would imply H10/\u211a undecidable; or (b) prove \u2124 is NOT Diophantine over \u211a (e.g., via Mazur's conjecture or a topological/density argument), which would NOT immediately settle H10/\u211a but would close this specific approach. Phase-2 Lean goal: state both directions as axioms with full provenance and document the implication chain `IntegersDiophantineOverQ \u2192 \u00acH10_Rational_Decidable` already present in `Hilbert10OQ01.lean`."
+    "goal": "Either: (a) construct an explicit polynomial P(t, x_1, …, x_k) ∈ ℚ[t, x] witnessing ℤ as a Diophantine subset of ℚ — would imply H10/ℚ undecidable; or (b) prove ℤ is NOT Diophantine over ℚ (e.g., via Mazur's conjecture or a topological/density argument), which would NOT immediately settle H10/ℚ but would close this specific approach. Phase-2 Lean goal: state both directions as axioms with full provenance and document the implication chain `IntegersDiophantineOverQ → ¬H10_Rational_Decidable` already present in `Hilbert10OQ01.lean`."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T00:00:00.000Z",
-    "iteration": 2,
-    "focus": "Phase-2 ACT complete: scaffolded Proofs/Hilbert10OQ01OQ02.lean and gallery entry src/data/proofs/hilbert-10-oq-01-oq-02/. The \u03a3\u2081 (Diophantine) vs \u03a0\u2082 (\u2200\u2203, Koenigsmann) distinction is now formalized as Lean predicates. \u03a3\u2081 \u2286 \u03a0\u2082 is proved. Koenigsmann's Annals 2016 theorem is axiomatized as a \u03a0\u2082 witness for \u2124 \u2282 \u211a. The two OQ-01 conditional implications (\u03a3\u2081 \u2192 \u00acH10/\u211a-decidable, Mazur \u2192 \u00ac\u03a3\u2081) are re-exported as theorems against the new \u03a3\u2081 predicate \u2014 no new axioms beyond Koenigsmann.",
+    "since": "2026-05-08T06:00:00.000Z",
+    "iteration": 3,
+    "focus": "Phase-2 ACT iteration 3 complete: extended Hilbert10OQ01OQ02.lean from 330 to 462 lines with the Σ₂/Π₂ duality layer. New: IsExistentialUniversalDefinition (Σ₂, ∃∀), codiophantine_implies_existentialUniversal (Π₁ ⊆ Σ₂, axiom-free dual of Σ₁ ⊆ Π₂), existentialUniversal_iff_universalExistential_complement (Σ₂/Π₂ duality, axiom-free up to two classical-byContradiction steps), universalExistentialDefinition_iff_of_pred_iff (Π₂ class congruence helper), and koenigsmann_implies_complement_existentialUniversal (ℚ\\ℤ is Σ₂-definable in ℚ — corollary of Koenigsmann via duality, no new axiom). The four corners of the Σ₁/Π₁/Σ₂/Π₂ square are now all formalized. Total: 13 theorems, 8 defs, 1 axiom, 0 sorries. Docker build passes (3 jobs).",
     "blockers": [],
-    "nextAction": "Future: (a) formalize Koenigsmann's explicit polynomial witness (Hilbert symbols + quaternion algebras over \u211a) to discharge `koenigsmann_2016_universal`; (b) add \u03a0\u2081 (co-Diophantine) layer if needed for completeness; (c) explore Daans 2021's 10-quantifier reduction as a stepping stone.",
+    "nextAction": "S4+ candidates: (a) Σ₁ × Π₁ closure properties (∪/∩) — needs Rat.mul_eq_zero / sum-of-squares, currently no Mathlib import; (b) Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — same Rat-arithmetic blocker; (c) Daans 2021 (10-quantifier) refinement of koenigsmann_2016_universal — would add 1 axiom but improve quantitative content; (d) Eisenträger-Park 2018 universal-existential characterization for global fields. Defer further work until either Mathlib is imported or one of these is selected.",
     "attemptCounts": {
-      "total": 1,
+      "total": 3,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PHASE-2 ACT complete (2026-05-08, researcher-6). Created `Proofs/Hilbert10OQ01OQ02.lean` (239 lines, 1 axiom, 5 theorems, 5 defs) and the gallery entry `src/data/proofs/hilbert-10-oq-01-oq-02/`. The file imports `Proofs.Hilbert10OQ01` and adds: `IsDiophantineDefinition` (\u03a3\u2081), `IsUniversalExistentialDefinition` (\u03a0\u2082), `koenigsmann_2016_universal` (axiom: \u2124 is \u03a0\u2082-definable in \u211a, citing Annals 2016), `integers_diophantine_iff` (\u03a3\u2081 predicate \u2194 existing OQ-01 formulation, by Iff.rfl), `diophantine_implies_universal_existential` (\u03a3\u2081 \u2286 \u03a0\u2082), and theorem-form re-exports of the OQ-01 axioms against the new \u03a3\u2081 predicate (NOT new axioms \u2014 pure logical consequences). Docker build passes. The \u03a3\u2081 question itself remains OPEN, as intended; no axiom commits to either answer.",
+    "progressSummary": "PHASE-2 ACT iterations 1-3 complete. Iteration 1 (researcher-6, 2026-05-08): scaffolded the file with Σ₁/Π₂ skeleton (5 theorems, 5 defs, 1 axiom). Iteration 2 (researcher-9 session 1, 2026-05-08): added Σ₁/Π₁ duality (4 new theorems, 2 new defs, 0 new axioms; PR #16839 merged). Iteration 3 (researcher-9 session 2, 2026-05-08): added Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (4 new theorems, 1 new def, 0 new axioms; current PR). The file is now 462 lines with 13 theorems, 8 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries; the Σ₁ question itself remains OPEN (intentionally). All four corners of the Σ₁/Π₁/Σ₂/Π₂ square — two trivial containments (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂) and two dualities (Σ₁/Π₁, Σ₂/Π₂) — are now proved axiom-free. Docker build passes.",
     "builtItems": [
       "Proofs/Hilbert10OQ01OQ02.lean: file scaffolded with imports from Hilbert10OQ01 (lines 1-69)",
-      "Proofs/Hilbert10OQ01OQ02.lean: abbrev RatSubset := Rat \u2192 Prop (line 71)",
+      "Proofs/Hilbert10OQ01OQ02.lean: abbrev RatSubset := Rat → Prop (line 71)",
       "Proofs/Hilbert10OQ01OQ02.lean: def IntSubset (line 74)",
-      "Proofs/Hilbert10OQ01OQ02.lean: def IsDiophantineDefinition (\u03a3\u2081) (lines 87-89)",
+      "Proofs/Hilbert10OQ01OQ02.lean: def IsDiophantineDefinition (Σ₁) (lines 87-89)",
       "Proofs/Hilbert10OQ01OQ02.lean: def IntegersAreDiophantineOverQ (line 95)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem integers_diophantine_iff via Iff.rfl (lines 100-103)",
-      "Proofs/Hilbert10OQ01OQ02.lean: def IsUniversalExistentialDefinition (\u03a0\u2082) (lines 113-115)",
+      "Proofs/Hilbert10OQ01OQ02.lean: def IsUniversalExistentialDefinition (Π₂) (lines 113-115)",
       "Proofs/Hilbert10OQ01OQ02.lean: axiom koenigsmann_2016_universal (lines 124-125)",
-      "Proofs/Hilbert10OQ01OQ02.lean: theorem diophantine_implies_universal_existential (\u03a3\u2081 \u2286 \u03a0\u2082) (lines 139-149)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem diophantine_implies_universal_existential (Σ₁ ⊆ Π₂) (lines 139-149)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem integers_diophantine_strengthens_koenigsmann (lines 154-156)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem integers_diophantine_sigma1_implies_h10_q_undecidable (lines 165-169)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem mazur_implies_not_sigma1_definable (lines 182-185)",
       "Proofs.lean: import Proofs.Hilbert10OQ01OQ02 added",
       "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: gallery entry with overview, sections, conclusion, references",
       "src/data/proofs/hilbert-10-oq-01-oq-02/index.ts: gallery entry boilerplate",
-      "src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json: empty annotations (Phase-3 task)"
+      "src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json: empty annotations (Phase-3 task)",
+      "Proofs/Hilbert10OQ01OQ02.lean: def IsExistentialUniversalDefinition (Σ₂, ∃∀ definability) (lines 272-286, iteration 3)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem codiophantine_implies_existentialUniversal (Π₁ ⊆ Σ₂, dual of Σ₁ ⊆ Π₂; axiom-free) (lines 288-309, iteration 3)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem existentialUniversal_iff_universalExistential_complement (Σ₂/Π₂ duality; axiom-free up to two Classical.byContradiction steps) (lines 311-350, iteration 3)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem universalExistentialDefinition_iff_of_pred_iff (Π₂ class congruence helper, axiom-free) (lines 352-365, iteration 3)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem koenigsmann_implies_complement_existentialUniversal (ℚ\\ℤ is Σ₂-definable in ℚ; corollary of Koenigsmann via Σ₂/Π₂ duality, no new axiom) (lines 367-383, iteration 3)",
+      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 330→462, theoremCount 9→13, definitionCount 7→8 (axiomCount unchanged)",
+      "src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json: 13 annotations covering all four quantifier classes, both dualities, the Σ₂(ℚ\\ℤ) corollary, and the closing #checks"
     ],
     "insights": [
-      "The \u03a3\u2081/\u03a0\u2081 distinction (Diophantine vs universal definability) is the precise mathematical content of OQ-01-OQ-02 over and above OQ-01: Koenigsmann 2016 settled \u03a0\u2081; \u03a3\u2081 remains open",
-      "Existing `Proofs/Hilbert10OQ01.lean` already encodes the conditional `IntegersDiophantineOverQ \u2192 \u00acH10_Rational_Decidable` (the only pivot in the implication chain); reusing this avoids axiom duplication",
-      "A Phase-2 file `Hilbert10OQ01OQ02.lean` should add: `def UniversallyDefinableOverQ (S : \u211a \u2192 Prop) : Prop`, `theorem koenigsmann_2016 : UniversallyDefinableOverQ (fun q => q \u2208 Set.range (Int.cast : \u2124 \u2192 \u211a))` (axiomatized, with full citation), and explicitly state `IntegersDiophantineOverQ` as the open question it ALSO refines",
-      "Mazur's conjecture is STRICTLY STRONGER than '\u2124 not Diophantine over \u211a'; a Lean treatment should distinguish them",
-      "The 'integrality detection' phrasing in the seeker's title is precisely the \u03a3\u2081-definition question \u2014 natural to formalize as `\u2203 P : Polynomial(\u211a, k+1), \u2200 t, t\u2208\u2124 \u2194 \u2203 x\u2081..x\u2096 : P(t,x)=0`",
-      "Decidability of H10/\u211a is the application target, but is one logical step removed: positive \u03a3\u2081-definition \u2192 undecidable (via Matiyasevich); negative \u2192 does NOT immediately give decidable (the decidability could fail through other Diophantine sets)",
-      "\u03a3\u2081 predicate `IsDiophantineDefinition` over IntSubset is DEFINITIONALLY EQUAL to the existing OQ-01 `IntegersDiophantineOverQ` \u2014 proved by `Iff.rfl`, no rewrite needed",
-      "\u03a3\u2081 \u2286 \u03a0\u2082 inclusion is one line: take the universal block to be a dummy and ignore it. The polynomial doesn't need to depend on y at all (proved by `refine \u27e8fun q _ => P q, ?_\u27e9` then `intro q; constructor`)",
-      "Self-contained file (no Mathlib import, just imports Hilbert10OQ01 which is also self-contained) \u2014 Docker build is fast (~3s after Mathlib cache hit)",
-      "Re-exports of OQ-01 axioms as theorems against the \u03a3\u2081 predicate add NO new assumptions: they are pure logical consequences of the equivalence `Iff.rfl`",
-      "Gallery entry mirrors hilbert-10-oq-01 schema with crossReferences linking to hilbert-10-oq-01 (extends), hilbert-10 (grandparent), hilbert-10-oq-04 (sibling), godel-incompleteness (related)"
+      "The Σ₁/Π₁ distinction (Diophantine vs universal definability) is the precise mathematical content of OQ-01-OQ-02 over and above OQ-01: Koenigsmann 2016 settled Π₁; Σ₁ remains open",
+      "Existing `Proofs/Hilbert10OQ01.lean` already encodes the conditional `IntegersDiophantineOverQ → ¬H10_Rational_Decidable` (the only pivot in the implication chain); reusing this avoids axiom duplication",
+      "A Phase-2 file `Hilbert10OQ01OQ02.lean` should add: `def UniversallyDefinableOverQ (S : ℚ → Prop) : Prop`, `theorem koenigsmann_2016 : UniversallyDefinableOverQ (fun q => q ∈ Set.range (Int.cast : ℤ → ℚ))` (axiomatized, with full citation), and explicitly state `IntegersDiophantineOverQ` as the open question it ALSO refines",
+      "Mazur's conjecture is STRICTLY STRONGER than 'ℤ not Diophantine over ℚ'; a Lean treatment should distinguish them",
+      "The 'integrality detection' phrasing in the seeker's title is precisely the Σ₁-definition question — natural to formalize as `∃ P : Polynomial(ℚ, k+1), ∀ t, t∈ℤ ↔ ∃ x₁..xₖ : P(t,x)=0`",
+      "Decidability of H10/ℚ is the application target, but is one logical step removed: positive Σ₁-definition → undecidable (via Matiyasevich); negative → does NOT immediately give decidable (the decidability could fail through other Diophantine sets)",
+      "Σ₁ predicate `IsDiophantineDefinition` over IntSubset is DEFINITIONALLY EQUAL to the existing OQ-01 `IntegersDiophantineOverQ` — proved by `Iff.rfl`, no rewrite needed",
+      "Σ₁ ⊆ Π₂ inclusion is one line: take the universal block to be a dummy and ignore it. The polynomial doesn't need to depend on y at all (proved by `refine ⟨fun q _ => P q, ?_⟩` then `intro q; constructor`)",
+      "Self-contained file (no Mathlib import, just imports Hilbert10OQ01 which is also self-contained) — Docker build is fast (~3s after Mathlib cache hit)",
+      "Re-exports of OQ-01 axioms as theorems against the Σ₁ predicate add NO new assumptions: they are pure logical consequences of the equivalence `Iff.rfl`",
+      "Gallery entry mirrors hilbert-10-oq-01 schema with crossReferences linking to hilbert-10-oq-01 (extends), hilbert-10 (grandparent), hilbert-10-oq-04 (sibling), godel-incompleteness (related)",
+      "The Σ₂/Π₂ duality is the higher-level analog of Σ₁/Π₁: same proof shape, classical excluded middle bridges ¬¬p ↔ p in both directions. Both dualities are axiom-free given Classical.byContradiction.",
+      "Π₁ ⊆ Σ₂ is the precise dual of Σ₁ ⊆ Π₂: a Π₁ formula ∀ x, P(q,x) ≠ 0 is automatically a Σ₂ formula ∃ y, ∀ x, P(q,x) ≠ 0 with a dummy existential block (witnessed by `fun _ => 0`). 6-line proof.",
+      "The Σ₂(ℚ\\ℤ) corollary of Koenigsmann is non-trivial structural content: it places ℚ\\ℤ on the second level of the arithmetic hierarchy unconditionally, with no new axiom beyond Koenigsmann.",
+      "Bridging across negation requires a predicate-equivalence helper: Π₂ class is invariant under propositional equivalence (universalExistentialDefinition_iff_of_pred_iff). The bridge IntSubset q ↔ ¬ NotIntSubset q uses standard double-negation introduction + Classical.byContradiction.",
+      "Pattern for axiom-free duality proofs in Lean core: `apply Classical.byContradiction; intro hn; have : ... := ...` — this idiom carries the file with no Mathlib import."
     ],
     "mathlibGaps": [
-      "No formal definition of 'Diophantine subset of a ring' in Mathlib \u2014 `Hilbert10OQ01.lean` uses ad-hoc `RatDiophantinePoly := (Nat \u2192 Rat) \u2192 Rat`",
-      "No formalization of Matiyasevich's DPRM theorem (would be needed to prove the reduction `IntegersDiophantineOverQ \u2192 \u00acH10_Rational_Decidable` rather than axiomatizing it)",
-      "No formalization of Koenigsmann's universal definition of \u2124 in \u211a (the 2016 Annals paper has explicit polynomials)",
-      "No general first-order logic / \u03a3_n / \u03a0_n hierarchy in Mathlib for this kind of definability question"
+      "No formal definition of 'Diophantine subset of a ring' in Mathlib — `Hilbert10OQ01.lean` uses ad-hoc `RatDiophantinePoly := (Nat → Rat) → Rat`",
+      "No formalization of Matiyasevich's DPRM theorem (would be needed to prove the reduction `IntegersDiophantineOverQ → ¬H10_Rational_Decidable` rather than axiomatizing it)",
+      "No formalization of Koenigsmann's universal definition of ℤ in ℚ (the 2016 Annals paper has explicit polynomials)",
+      "No general first-order logic / Σ_n / Π_n hierarchy in Mathlib for this kind of definability question"
     ],
     "nextSteps": [
-      "Phase-3 (annotations): populate `annotations.json` with explanations of the \u03a3\u2081/\u03a0\u2082 distinction, the `Iff.rfl` equivalence, and the Koenigsmann 2016 axiom. Currently empty.",
-      "Long-term: replace `koenigsmann_2016_universal` axiom with a constructive proof from the explicit polynomial in Koenigsmann (Annals 2016, \u00a73-4). Requires Hilbert-symbol + quaternion-algebra infrastructure; partial in `Hilbert11_QuadraticForms.lean`.",
-      "Optional: add a \u03a0\u2081 (purely universal) layer for completeness \u2014 `IsCoDiophantineDefinition (S) := IsDiophantineDefinition (\u00acS)` \u2014 to make the full \u03a3\u2081/\u03a0\u2081/\u03a0\u2082 landscape explicit"
+      "S4: Σ₁ × Π₁ closure properties (under finite union/intersection) — requires either Mathlib import for Rat.mul_eq_zero / sum-of-squares-zero or hand-rolled proofs from Lean core. Significant infrastructure work.",
+      "S5: Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — same Rat-arithmetic blocker as S4.",
+      "S6: Daans 2021 (10-quantifier reduction) as a separate axiom refining koenigsmann_2016_universal — would add 1 new axiom but improve quantitative content.",
+      "S7: Eisenträger-Park 2018 universal-existential characterization for global fields — sibling-of-sibling formalization track.",
+      "Eventually: formalize the explicit Koenigsmann polynomial in Lean to discharge `koenigsmann_2016_universal` — requires Hilbert-symbol/quaternion infrastructure (partial in Hilbert11_QuadraticForms.lean)."
     ]
   },
   "tags": [
@@ -112,14 +126,14 @@
   ],
   "references": {
     "papers": [
-      "Matiyasevich 1970 - Enumerable sets are Diophantine (DAN SSSR) \u2014 DPRM theorem, Hilbert's 10th over \u2124 undecidable",
-      "Robinson 1949 - Definability and decision problems in arithmetic (J. Symb. Logic) \u2014 first definition of \u2124 in \u211a",
-      "Mazur 1992 - The topology of rational points (Experimental Math.) \u2014 Mazur's conjecture on Diophantine subsets of \u211a",
+      "Matiyasevich 1970 - Enumerable sets are Diophantine (DAN SSSR) — DPRM theorem, Hilbert's 10th over ℤ undecidable",
+      "Robinson 1949 - Definability and decision problems in arithmetic (J. Symb. Logic) — first definition of ℤ in ℚ",
+      "Mazur 1992 - The topology of rational points (Experimental Math.) — Mazur's conjecture on Diophantine subsets of ℚ",
       "Poonen 2009 - The set of nonsquares in a number field is Diophantine (Math. Res. Lett. 16, 165-170)",
-      "Poonen 2009 - Hilbert's tenth problem and Mazur's conjecture for large subrings of \u211a (J. AMS)",
-      "Koenigsmann 2016 - Defining \u2124 in \u211a (Annals of Math. 183, 73-93) \u2014 universal (\u03a0\u2081) definition",
-      "Eisentr\u00e4ger-Park 2018 - Universally and existentially definable subsets of global fields",
-      "Daans 2021 - Universally defining \u2124 in \u211a with 10 quantifiers (J. Number Theory)",
+      "Poonen 2009 - Hilbert's tenth problem and Mazur's conjecture for large subrings of ℚ (J. AMS)",
+      "Koenigsmann 2016 - Defining ℤ in ℚ (Annals of Math. 183, 73-93) — universal (Π₁) definition",
+      "Eisenträger-Park 2018 - Universally and existentially definable subsets of global fields",
+      "Daans 2021 - Universally defining ℤ in ℚ with 10 quantifiers (J. Number Theory)",
       "Sun 2016 - On Hilbert's tenth problem and related topics",
       "Cornelissen-Pheidas 2008 - Survey: Algebra and number theory in mathematical logic"
     ],
@@ -128,14 +142,14 @@
       "https://annals.math.princeton.edu/articles/10245"
     ],
     "mathlib": [
-      "Mathlib.Data.Rat.Defs \u2014 rational numbers \u211a",
-      "Mathlib.RingTheory.Polynomial.Basic \u2014 polynomials over \u211a",
-      "Mathlib.NumberTheory.Cyclotomic.Basic \u2014 cyclotomic background for some Diophantine definitions",
-      "Mathlib.Logic.FirstOrder.Basic \u2014 first-order definability framework (limited)"
+      "Mathlib.Data.Rat.Defs — rational numbers ℚ",
+      "Mathlib.RingTheory.Polynomial.Basic — polynomials over ℚ",
+      "Mathlib.NumberTheory.Cyclotomic.Basic — cyclotomic background for some Diophantine definitions",
+      "Mathlib.Logic.FirstOrder.Basic — first-order definability framework (limited)"
     ]
   },
   "started": "2026-05-05T02:57:43.927Z",
-  "lastUpdate": "2026-05-08T00:00:00.000Z",
+  "lastUpdate": "2026-05-08T06:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -171,6 +185,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert10OQ04.lean"
+    },
+    {
+      "path": "Proofs/Hilbert10OQ01OQ02.lean",
+      "filename": "Hilbert10OQ01OQ02.lean",
+      "lineCount": 462,
+      "theoremCount": 13,
+      "axiomCount": 1,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert10OQ01OQ02.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Iteration 3 on `hilbert-10-oq-01-oq-02` (is ℤ purely Diophantine over ℚ?). Adds the Σ₂/Π₂ duality layer, closing the fourth corner of the Σ₁/Π₁/Σ₂/Π₂ arithmetic-hierarchy square.

The previous iteration (#16839, merged) added the Σ₁/Π₁ duality. This iteration adds:

| New | Kind | Notes |
|---|---|---|
| `IsExistentialUniversalDefinition` | def | Σ₂ (∃∀) definability of subsets of ℚ |
| `codiophantine_implies_existentialUniversal` | theorem | Π₁ ⊆ Σ₂ — precise dual of Σ₁ ⊆ Π₂ (axiom-free, 6 lines) |
| `existentialUniversal_iff_universalExistential_complement` | theorem | Σ₂/Π₂ duality — higher-level analog of Σ₁/Π₁ duality (axiom-free up to 2× `Classical.byContradiction`) |
| `universalExistentialDefinition_iff_of_pred_iff` | theorem | Π₂ class is invariant under propositional equivalence (helper, axiom-free) |
| `koenigsmann_implies_complement_existentialUniversal` | theorem | **ℚ \ ℤ is Σ₂-definable in ℚ** — corollary of Koenigsmann via Σ₂/Π₂ duality, **no new axiom** |

**Net**: 1 def, 4 theorems, 0 new axioms, 0 sorries.

After this iteration, all four corners of the Σ₁/Π₁/Σ₂/Π₂ square are formalized with two trivial containments (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂) and two dualities (Σ₁/Π₁, Σ₂/Π₂), all axiom-free above the single `koenigsmann_2016_universal` axiom.

## File-level changes

- **`proofs/Proofs/Hilbert10OQ01OQ02.lean`**: 330 → 462 lines. Adds Part VIII (Σ₂ + Σ₂/Π₂ duality + Koenigsmann corollary). Renames the closing landscape section to Part IX and updates the status table to a 4-row Σ₁/Π₁/Σ₂/Π₂ matrix. Adds 4 new `#check`s.
- **`src/data/proofs/hilbert-10-oq-01-oq-02/meta.json`**: refreshed counts (lineCount 330→462, theoremCount 9→13, definitionCount 7→8); refreshed originalContributions, mainTheorems, sections, conclusion, keyInsights to cover the four corners. axiomCount unchanged (still 1).
- **`src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json`**: 10 → 13 annotations. Updated line ranges throughout (the previous iteration had not refreshed them). Added 2 new annotations for Σ₂/Π₁ ⊆ Σ₂ and the Σ₂/Π₂ duality + Σ₂(ℚ\ℤ) corollary; replaced the single Σ₁/Π₁ duality summary annotation.
- **`research/problems/hilbert-10-oq-01-oq-02/state.md`**: advanced to iteration 3; documents S4+ candidates (Σ₁ × Π₁ closure under union/intersection — needs Rat field arithmetic; Π₁ ⊆ Π₂ via inversion trick; Daans 2021 axiom; Eisenträger-Park).
- **`src/data/research/problems/hilbert-10-oq-01-oq-02.json`**: iteration 3; leanFiles entry added for `Hilbert10OQ01OQ02.lean`; refreshed progressSummary, insights, builtItems, nextSteps.

## Build verification

```
$ ./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02
...
Build completed successfully (3 jobs).
```

The new theorems compile cleanly against the existing Lean-core-only design (no Mathlib import). The two `Classical.byContradiction` patterns from iteration 2 extend smoothly to Σ₂/Π₂ — both directions of the new duality, and the `hbridge` (`IntSubset q ↔ ¬ NotIntSubset q`) used in the corollary.

## Honest reporting

- The Σ₁ question itself remains OPEN — this iteration adds *infrastructure* (the Σ₂ corner of the hierarchy), not progress on the original question.
- The Σ₂(ℚ\ℤ) corollary is non-trivial structural content but ultimately stems from Koenigsmann's already-axiomatized Π₂(ℤ) result; no new mathematical claim about the open question.
- The build was verified locally via Docker; CI is the ground truth.

## Test plan

- [x] Docker build of `Proofs.Hilbert10OQ01OQ02` ✅ (3 jobs, exit 0)
- [x] All counts in `meta.json` and `leanFile` match the file (lineCount=462, axiomCount=1, theoremCount=13, definitionCount=8, sorries=0)
- [x] All 12 `#check`s at end of file refer to declared identifiers
- [x] Annotations line ranges updated to match the refactored file structure
- [x] No new mathlib dependencies (file remains self-contained, Lean core only)

🤖 Generated by researcher-9