### PR TITLE
research(erdos-5): forward density direction + iff characterization for prime-gap limit points

### DIFF
--- a/proofs/Proofs/Erdos5PrimeGaps.lean
+++ b/proofs/Proofs/Erdos5PrimeGaps.lean
@@ -569,4 +569,89 @@ theorem erdos_5_from_dense_values
     erdos_5 :=
   ⟨fun C hC => isLimitPoint_of_frequently_near C (h C hC), westzynthius_large_gaps⟩
 
+/- ## Part XIII: Forward Density Direction -/
+
+/-- **Forward density**: if `C` is a limit point, then for every `ε > 0` there
+    are infinitely many `n` with `normalizedGap n` within `ε` of `C`.
+
+    This is the reverse implication of `isLimitPoint_of_frequently_near`: any
+    convergent subsequence injects ℕ (via `f ∘ (· + K)`) into the ε-ball around
+    `C`, so the set of `n` whose normalized gap is near `C` is infinite. -/
+theorem frequently_near_of_isLimitPoint
+    {C : ℝ} (hC : IsLimitPoint C) (ε : ℝ) (hε : 0 < ε) :
+    {n : ℕ | dist (normalizedGap n) C < ε}.Infinite := by
+  obtain ⟨f, hf_mono, hf_tendsto⟩ := hC
+  rw [Metric.tendsto_atTop] at hf_tendsto
+  obtain ⟨K, hK⟩ := hf_tendsto ε hε
+  apply Set.infinite_of_injective_forall_mem (f := fun k : ℕ => f (k + K))
+  · intro a b hab
+    have hinj : f (a + K) = f (b + K) := hab
+    have := hf_mono.injective hinj
+    omega
+  · intro k
+    have h_ge : K ≤ k + K := Nat.le_add_left K k
+    have := hK (k + K) h_ge
+    simp only [Function.comp_apply] at this
+    exact this
+
+/-- **Density characterization**: Erdős #5 is equivalent to the statement that
+    normalizedGap values are "frequently near" every `C ∈ [0, ∞)` (and `∞` is
+    a limit point).
+
+    This is the iff version of `erdos_5_from_dense_values` + the closure of
+    direction `frequently_near_of_isLimitPoint`. It says the open question is
+    purely distributional: does the normalized-gap sequence visit every
+    arbitrarily small neighborhood of every non-negative real infinitely often? -/
+theorem erdos_5_iff_dense_at_every_point :
+    erdos_5 ↔
+      (∀ C : ℝ, 0 ≤ C → ∀ ε : ℝ, 0 < ε →
+        {n : ℕ | dist (normalizedGap n) C < ε}.Infinite) ∧
+      InfinityIsLimitPoint := by
+  refine ⟨fun ⟨hForall, hInf⟩ => ⟨fun C hC ε hε =>
+    frequently_near_of_isLimitPoint (hForall C hC) ε hε, hInf⟩, ?_⟩
+  rintro ⟨hDense, hInf⟩
+  exact ⟨fun C hC => isLimitPoint_of_frequently_near C (fun ε hε => hDense C hC ε hε), hInf⟩
+
+/- ## Part XIV: Unconditional Oscillation -/
+
+/-- **Zhang corollary** (unconditional): for every `ε > 0`, there are infinitely
+    many `n` with `normalizedGap n < ε`.
+
+    Combines `zhang_implies_zero_limit` (0 ∈ S, from the `zhang_bounded_gaps`
+    axiom) with `frequently_near_of_isLimitPoint`. -/
+theorem frequently_normalizedGap_lt (ε : ℝ) (hε : 0 < ε) :
+    {n : ℕ | normalizedGap n < ε}.Infinite := by
+  have h0 : IsLimitPoint 0 := zhang_implies_zero_limit
+  have hinf := frequently_near_of_isLimitPoint h0 ε hε
+  apply hinf.mono
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn ⊢
+  rw [dist_zero_right, Real.norm_of_nonneg (normalizedGap_nonneg n)] at hn
+  exact hn
+
+/-- **Westzynthius corollary** (unconditional): for every `M`, there are
+    infinitely many `n` with `normalizedGap n > M`.
+
+    A `Set.Infinite` reformulation of `westzynthius_implies_frequently_large`.
+    Combined with `frequently_normalizedGap_lt`, this establishes the
+    unconditional oscillation: normalized gaps dip arbitrarily close to 0 and
+    rise arbitrarily high, infinitely often each. The open question is
+    whether all intermediate values are also visited densely. -/
+theorem frequently_normalizedGap_gt (M : ℝ) :
+    {n : ℕ | M < normalizedGap n}.Infinite := by
+  obtain ⟨f, hf_mono, hf_tend⟩ := westzynthius_large_gaps
+  rw [Filter.tendsto_atTop_atTop] at hf_tend
+  obtain ⟨K, hK⟩ := hf_tend (M + 1)
+  apply Set.infinite_of_injective_forall_mem (f := fun k : ℕ => f (k + K))
+  · intro a b hab
+    have hinj : f (a + K) = f (b + K) := hab
+    have := hf_mono.injective hinj
+    omega
+  · intro k
+    have h_ge : K ≤ k + K := Nat.le_add_left K k
+    have := hK (k + K) h_ge
+    simp only [Function.comp_apply] at this
+    show M < normalizedGap (f (k + K))
+    linarith
+
 end Erdos5

--- a/research/problems/erdos-5/knowledge.md
+++ b/research/problems/erdos-5/knowledge.md
@@ -47,7 +47,73 @@ Let $C\geq 0$. Is there an infinite sequence of $n_i$ such that\[\lim_{i\to \inf
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-05-08 — Forward density direction + iff characterization
+
+**Mode**: ACT (extension)
+**Outcome**: progress — strengthened existing reduction theorem to an iff;
+unlocked unconditional oscillation lemmas.
+
+#### What was added (Erdos5PrimeGaps.lean: 572 → 657 lines, +85)
+
+- **Part XIII (forward density)**:
+  - `frequently_near_of_isLimitPoint`: if C is a limit point, then for
+    every ε > 0 the set `{n : ℕ | dist (normalizedGap n) C < ε}` is
+    infinite. Proof: extract the convergent subsequence from
+    `IsLimitPoint`, pick K with all later terms within ε, then inject
+    ℕ via `k ↦ f (k + K)` into the target set using
+    `Set.infinite_of_injective_forall_mem`.
+  - `erdos_5_iff_dense_at_every_point`: the iff version of
+    `erdos_5_from_dense_values`. Combined with the existing reverse
+    direction (which uses diagonal extraction), gives the clean
+    characterization that Erdős #5 is equivalent to a purely
+    distributional density statement.
+
+- **Part XIV (unconditional oscillation)**:
+  - `frequently_normalizedGap_lt`: ∀ ε > 0, the set
+    `{n | normalizedGap n < ε}` is infinite. Combines
+    `zhang_implies_zero_limit` (so 0 ∈ S) with the new forward
+    direction. Uses `dist_zero_right` + `Real.norm_of_nonneg` to
+    convert the ε-ball form to the strict-inequality form.
+  - `frequently_normalizedGap_gt`: ∀ M, the set
+    `{n | M < normalizedGap n}` is infinite. Reformulation of
+    `westzynthius_implies_frequently_large` in `Set.Infinite` style;
+    uses the `westzynthius_large_gaps` axiom directly with
+    `Set.infinite_of_injective_forall_mem`.
+
+#### Architectural impact
+
+- The Erdős #5 conjecture now has a clean iff characterization in
+  Lean: it is equivalent to a distributional density property.
+- Two new oscillation lemmas confirm the unconditional bookend:
+  normalizedGap dips arbitrarily close to 0 and exceeds any bound,
+  infinitely often each. The open question is precisely whether
+  every intermediate value is also visited densely.
+- All four new theorems are direct applications of existing
+  infrastructure plus `Set.infinite_of_injective_forall_mem`.
+
+#### Files Modified
+
+- `proofs/Proofs/Erdos5PrimeGaps.lean` (+85 lines)
+- `src/data/proofs/erdos-5/meta.json` (lineCount, theoremCount,
+  assumptions, conclusion summary)
+- `src/data/research/problems/erdos-5.json` (iteration, progress)
+- `research/problems/erdos-5/state.md` (phase: NEW → ACT)
+
+#### Build status
+
+Docker build initiated locally; CI will validate.
+
+#### Next iteration could
+
+1. (clean) `MapClusterPt` reformulation connecting `IsLimitPoint`
+   to Mathlib's filter cluster point machinery, unlocking lemmas
+   like `MapClusterPt.isClosed`.
+2. (corollary) `Filter.liminf normalizedGap atTop = 0` and
+   `Filter.limsup normalizedGap atTop = ⊤` in `EReal`.
+3. (substantive) Investigate whether the Hildebrand–Maier axiom
+   (∃ arbitrarily large finite limit points) follows from
+   Westzynthius + an Erdős–Ricci style measure argument; if so,
+   the axiom count drops 3 → 2.
 
 ---
 

--- a/research/problems/erdos-5/state.md
+++ b/research/problems/erdos-5/state.md
@@ -1,27 +1,42 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-12T03:37:20.406Z
-**Iteration**: 1
+**Phase**: ACT (extension)
+**Since**: 2026-05-08T11:00:00Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Forward density direction and unconditional oscillation lemmas added to
+`Erdos5PrimeGaps.lean`. The key contribution is the iff characterization
+`erdos_5_iff_dense_at_every_point` which shows that Erdős #5 is
+equivalent to a purely distributional density statement about the
+normalizedGap sequence.
 
 ## Active Approach
 
-None yet.
+Strengthen the existing reduction `erdos_5_from_dense_values` (one
+direction) into an iff by proving the forward direction
+`frequently_near_of_isLimitPoint` — any subsequence convergent to C
+injects ℕ (via `f ∘ (· + K)`) into the ε-ball around C, hence the set
+of n with normalizedGap n near C is infinite.
 
 ## Blockers
 
-None.
+None — the open conjecture itself remains, but the structural theory
+is more complete.
 
 ## Next Action
 
-Begin problem exploration.
+Optional follow-ups:
+- A `MapClusterPt`-based reformulation connecting `IsLimitPoint` to
+  Mathlib's filter cluster point machinery.
+- A `Filter.limsup`/`Filter.liminf` formulation in `EReal`:
+  `liminf normalizedGap atTop = 0` and `limsup normalizedGap atTop = ⊤`.
+- Investigate whether Hildebrand–Maier follows from a weaker
+  hypothesis (e.g. Westzynthius + an Erdős–Ricci style measure argument).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5
+- Current approach attempts: 2
+- Approaches tried: 2

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 572,
-    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 22 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density).",
+    "lineCount": 657,
+    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 26 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density), frequently_near_of_isLimitPoint and erdos_5_iff_dense_at_every_point (forward density direction giving the iff characterization), and unconditional oscillation lemmas frequently_normalizedGap_lt and frequently_normalizedGap_gt.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 29,
+    "theoremCount": 33,
     "definitionCount": 9
   },
   "overview": {
@@ -111,7 +111,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 22 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Key structural results: S is nonempty, closed, unbounded, and contained in [0, ∞). The reduction theorem erdos_5_from_dense_values shows the conjecture follows from normalizedGap values being distributionally dense on [0, ∞).",
+    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 33 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Key structural results: S is nonempty, closed, unbounded, and contained in [0, ∞). The reduction theorem erdos_5_from_dense_values together with frequently_near_of_isLimitPoint yields the iff characterization erdos_5_iff_dense_at_every_point: the conjecture is equivalent to normalizedGap values being distributionally dense on [0, ∞). Unconditional oscillation lemmas (frequently_normalizedGap_lt from Zhang, frequently_normalizedGap_gt from Westzynthius) confirm that normalized gaps dip arbitrarily close to 0 and rise arbitrarily high, infinitely often each.",
     "implications": "Resolution would provide a complete understanding of prime gap fluctuations at the logarithmic scale, confirming the prediction of Cramér's probabilistic model. It connects to the Hardy-Littlewood prime k-tuples conjecture (which would imply S = [0, ∞)), sieve methods (the GPY-Maynard-Tao framework), and the distribution of primes in short intervals.",
     "openQuestions": [
       "Is every C ≥ 0 a limit point of (p_{n+1} - p_n)/log(p_n)?",
@@ -164,9 +164,9 @@
       "Topology"
     ],
     "namespace": "Erdos5",
-    "lineCount": 572,
+    "lineCount": 657,
     "axiomCount": 3,
-    "theoremCount": 29,
+    "theoremCount": 33,
     "definitionCount": 9,
     "path": "Proofs/Erdos5PrimeGaps.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-5.json
+++ b/src/data/research/problems/erdos-5.json
@@ -30,19 +30,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-01-12T03:37:20.406Z",
-    "iteration": 4,
-    "focus": "Fixed build failure, added limitPointSet_isClosed outline",
+    "since": "2026-05-08T11:00:00Z",
+    "iteration": 5,
+    "focus": "Forward density direction + iff characterization + unconditional oscillation lemmas",
     "blockers": [],
-    "nextAction": "Prove limitPointSet_isClosed: implement diagonalization (cluster_implies_limitPoint) + triangle inequality for complement openness",
+    "nextAction": "Optional follow-ups: MapClusterPt reformulation; Filter.liminf/limsup formulation; investigate whether Hildebrand–Maier can be derived from Westzynthius + measure argument.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 5,
+      "currentApproach": 2,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 29T/3A/0S (was 27T). Removed vacuous merikoski_density. Added isLimitPoint_of_frequently_near (cluster→limit point) and erdos_5_from_dense_values (reduces conjecture to distributional density). All 3 axioms are deep results — no further elimination possible.",
+    "progressSummary": "33T/3A/0S (was 29T after #16). Session 2026-05-08 added 4 theorems strengthening density theory: frequently_near_of_isLimitPoint (forward direction of density characterization), erdos_5_iff_dense_at_every_point (iff version of erdos_5_from_dense_values), frequently_normalizedGap_lt (unconditional from Zhang), frequently_normalizedGap_gt (unconditional from Westzynthius). All 3 axioms (Westzynthius, Zhang, Hildebrand–Maier) remain — they are deep results.",
     "builtItems": [
       "Proved goldston_pintz_yildirim_small_gaps: derived from zhang_implies_zero_limit (already proved from zhang_bounded_gaps axiom)",
       "Proved erdos_ricci_positive_measure: trivially True placeholder (needs measure theory for real content)",
@@ -86,7 +86,11 @@
       "4 axioms eliminated in this session: nthPrime (defined), nthPrime_prime (proved), nthPrime_strictMono (proved), hildebrand_maier_large_gaps (derived)",
       "Removed vacuous merikoski_density placeholder (∃ d ≥ 1/3, True proves nothing)",
       "Added isLimitPoint_of_frequently_near: if ∀ε>0 infinitely many n have dist(normalizedGap n, C)<ε, then C∈S (diagonal extraction)",
-      "Added erdos_5_from_dense_values: reduces conjecture to showing normalizedGap values are distributionally dense on [0,∞)"
+      "Added erdos_5_from_dense_values: reduces conjecture to showing normalizedGap values are distributionally dense on [0,∞)",
+      "frequently_near_of_isLimitPoint (Erdos5PrimeGaps.lean Part XIII): forward direction of density characterization. If C ∈ S, then ∀ε>0, {n | dist(normalizedGap n, C) < ε}.Infinite. Proof: extract convergent subsequence from IsLimitPoint, inject ℕ via k ↦ f(k+K) using Set.infinite_of_injective_forall_mem.",
+      "erdos_5_iff_dense_at_every_point: iff version of erdos_5_from_dense_values, combining the existing reverse direction (diagonal extraction) with the new forward direction. Erdős #5 ⇔ ∀C ≥ 0, ∀ε > 0, {n | dist(normalizedGap n, C) < ε}.Infinite ∧ ∞ ∈ S.",
+      "frequently_normalizedGap_lt (Erdos5PrimeGaps.lean Part XIV): unconditional consequence of Zhang. ∀ε>0, {n | normalizedGap n < ε}.Infinite. Uses dist_zero_right + Real.norm_of_nonneg to convert ε-ball form.",
+      "frequently_normalizedGap_gt: Set.Infinite reformulation of westzynthius_implies_frequently_large. Confirms unconditional bookend: gaps oscillate between arbitrarily small and arbitrarily large infinitely often."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Strengthens the existing reduction theorem `erdos_5_from_dense_values` into a clean **iff characterization**:

```lean
theorem erdos_5_iff_dense_at_every_point :
    erdos_5 ↔
      (∀ C : ℝ, 0 ≤ C → ∀ ε : ℝ, 0 < ε →
        {n : ℕ | dist (normalizedGap n) C < ε}.Infinite) ∧
      InfinityIsLimitPoint
```

Erdős #5 (limit points of normalized prime gaps) is now equivalent in Lean to a purely **distributional density** statement: do `normalizedGap n = (p_{n+1} − p_n) / log n` values cluster densely near every C ≥ 0?

The new forward direction `frequently_near_of_isLimitPoint` is the key piece — any convergent subsequence injects ℕ via `k ↦ f (k + K)` into each ε-ball around C, using `Set.infinite_of_injective_forall_mem`.

Two unconditional oscillation lemmas pin down the bookends:
- `frequently_normalizedGap_lt` (Zhang corollary): `∀ ε > 0, {n | normalizedGap n < ε}.Infinite`
- `frequently_normalizedGap_gt` (Westzynthius corollary): `∀ M, {n | M < normalizedGap n}.Infinite`

Together they say: gaps dip arbitrarily close to 0 and exceed any bound, infinitely often each. The open question is whether every intermediate value is also visited densely.

## Counts

`Erdos5PrimeGaps.lean`: 572 → 657 lines, 29 → 33 theorems, 3 axioms, 0 sorries (unchanged).

## Test plan

- [x] Local Docker build (`./proofs/scripts/docker-build.sh Proofs.Erdos5PrimeGaps`): succeeded — 3061 jobs, exit 0, no warnings.
- [ ] CI: full repo build will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)