### PR TITLE
audit(tracker): sqrt2-minpoly + sqrt2-minpoly-oq-01 — clean (follow-up to #16872)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13202,15 +13202,15 @@
       "result": "clean"
     },
     "sqrt2-minpoly": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:34Z",
+      "lastAudited": "2026-05-08T03:41:29Z",
       "result": "clean"
     },
     "sqrt2-minpoly-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:34Z",
+      "lastAudited": "2026-05-08T03:41:29Z",
       "result": "clean"
     },
     "sqrt2-minpoly-oq-02": {


### PR DESCRIPTION
## Summary

Follow-up to PR #16872 (re-audit of the 2026-04-23 stale batch). That PR
covered 6 entries; this one adds the two sqrt2-minpoly entries that were
omitted.

| slug | status/badge | counts (sorries/axioms/lines/thm/def) |
|---|---|---|
| sqrt2-minpoly | verified/original | 0 / 0 / 140 / 9 / 0 |
| sqrt2-minpoly-oq-01 | verified/original | 0 / 0 / 252 / 20 / 0 |

All counts match between top-level, `meta.*`, and `meta.leanFile.*`
fields, and against the actual Lean source on `origin/main`. No True
stubs, no `axiom` declarations.

**Tier check**: `verified/original` is appropriate. The √2 case proves
irreducibility of `X² - 2` via Eisenstein and concludes via
`minpoly.eq_of_irreducible_of_monic` — that's legitimate mathematical
work assembling the bridge, not a thin Mathlib wrapper. The OQ01
generalization imports `CubeRoot2IrrationalOQ03` for the nth-root
case (sibling gallery entry).

Surgical 4-line diff: only `auditCount` (1→2) and `lastAudited` updated
on the two target entries, no formatting churn (built with git plumbing
to avoid disturbing concurrent agents in the main repo).

## Test plan

- [x] All counts verified against `git show origin/main:` for both meta.json and Lean source
- [x] No True stubs, no `:= trivial` placeholders
- [x] Comment-stripped regex used for sorry/axiom counts
- [x] Diff is exactly 4 lines (2 entries × 2 fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)