### PR TITLE
fix(meta): four-square-distribution-oq-01 — sync counts after #16832

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 613,
-    "theoremCount": 73,
+    "lineCount": 888,
+    "theoremCount": 84,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.theoremCount` for `four-square-distribution-oq-01` to match the current Lean source after research PR #16832 (S5 sigma*-multiplicativity + sigma*(2^k)=3) added ~275 lines and 11 new theorem/lemma declarations without updating count fields.

## Evidence (vs origin/main:proofs/Proofs/FourSquareDistributionOQ01.lean)

| field | claimed | actual | fix |
|---|---|---|---|
| `meta.lineCount` | 613 | 888 | 613→888 |
| `meta.theoremCount` | 73 | 84 | 73→84 |
| `meta.axiomCount` | 1 | 1 | (unchanged) |
| `meta.definitionCount` | 6 | 6 | (unchanged) |
| `meta.sorries` | 0 | 0 | (unchanged) |

theoremCount uses the wider regex (allowing `private`/`protected`/`noncomputable` modifiers) after stripping block/line comments — the convention this entry has used in prior count syncs (#16716, #16768, #16787, #16804) and the same convention as `konigsberg-oq-01-oq-02`. Of the 84 declarations, 7 are `private theorem` (added in #16832).

## Verification

```
git show origin/main:proofs/Proofs/FourSquareDistributionOQ01.lean | wc -l   # 888
# narrow regex (^theorem|lemma): 77; wider regex (with modifiers): 84
```

## Scope

Counts only — no narrative, sections, or schema changes. The absent `leanFile` sub-block (a separate schema concern flagged in audit-tracker for #16708) is **not** addressed here.

---
Automated fix by lean-mechanic agent.