### PR TITLE
research(hurwitz-theorem-wip-01): S3 PARK — re-confirm BLOCKED, correct B cost

### DIFF
--- a/research/problems/hurwitz-theorem-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-wip-01/state.md
@@ -2,30 +2,33 @@
 
 ## Current State
 
-**Phase**: OBSERVE
+**Phase**: PARK (BLOCKED, awaiting Mathlib upstream)
 **Path**: full
-**Since**: 2026-05-07T18:10:00Z
-**Iteration**: 2
+**Since**: 2026-05-08T03:35:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Survey complete: full inventory of what is proved upstream of the blocking
-sorry, mapping the gap to the missing Mathlib API. Problem confirmed BLOCKED
-on real Clifford algebra structure classification (~1000 lines of upstream
-Mathlib infrastructure needed).
+Iteration 3 (PARK): re-confirm BLOCKED status. No relevant Mathlib upstream
+movement since S2 (2026-05-07): a search for Clifford structure
+classification, Frobenius theorem, and Bott periodicity in mathlib4 master
+returns no new APIs. The two open sorries (`HurwitzTheorem.lean:1937`,
+`HurwitzOnlyIf.lean:111`) remain blocked on the same Cl(0,n-1) classification
+gap.
 
 ## Active Approach
 
 **Wait** — until Mathlib gains Clifford structure / Bott periodicity API.
-Localized 2 sorries (HurwitzTheorem.lean:1937, HurwitzOnlyIf.lean:111) both
-collapse to the same blocker.
 
 ## Attempt Count
 
-- Total attempts: 1
+- Total attempts: 2
 - Approaches tried:
-  1. (S2 — this session) OBSERVE / SURVEY: enumerate proved infrastructure,
-     classify what's left, identify Mathlib gap precisely.
+  1. (S2) OBSERVE / SURVEY: enumerate proved infrastructure, classify what's
+     left, identify Mathlib gap precisely.
+  2. (S3 — this session) Re-confirm BLOCKED + correct the S2 cost estimate
+     for option B (refactor): the "~80 lines" estimate misjudged the
+     bridge construction (see Blockers item 4 below).
 
 ## Blockers
 
@@ -34,25 +37,63 @@ collapse to the same blocker.
 3. No minimum-faithful-real-rep-dimension lemma derivable from current
    `Mathlib.LinearAlgebra.CliffordAlgebra.*` (which only provides the universal
    property and basic conjugation).
+4. **S2 cost re-estimate**: option B (algebra-level refactor of
+   `HurwitzOnlyIf.hurwitz_only_if_ring`) is not "~80 lines" as previously
+   stated. The bridge `NormedDivisionRing → NSquareIdentity` requires an
+   inner product on A so that the L²-norm of coordinate vectors matches the
+   division-algebra norm. Concretely, the bridge needs either:
+   - **(B1)** Construct an `InnerProductSpace ℝ A` from the multiplicative
+     norm. *Not* automatic: a general normed ℝ-vector space need not be inner
+     product. For a finite-dim normed associative division algebra this is
+     true (it's part of the classical Frobenius proof: Re(a) := (a + ā)/2,
+     ⟨a,b⟩ := (Re(ab*) something equivalent)) but the construction is itself
+     ~200-300 lines and is not in Mathlib v4.26.0.
+   - **(B2)** Choose any basis, work with the resulting non-standard
+     positive-definite quadratic form on `Fin n → ℝ`, diagonalize it, then
+     transfer multiplication. Adds change-of-basis machinery and makes the
+     resulting `NSquareIdentity` non-canonical. Estimated 150-250 lines plus
+     a `Matrix.PosDef.diagonalize` API that may need to be built.
+5. **(B3) Frobenius alternative**: For `NormedDivisionRing` (associative),
+   the stronger Frobenius theorem (`finrank ∈ {1, 2, 4}`) suffices, but the
+   classical Frobenius proof goes through the same Clifford algebra route or
+   via the imaginary subspace construction (V = {a : a² ≤ 0}). Mathlib has
+   *neither*. arXiv:2405.01876 (May 2024) is a recent paper formalizing
+   Frobenius in a non-Mathlib system; not yet ported.
 
 ## Next Action
 
-Highest-EV options, in order:
+1. **(option D, current)** Wait for Mathlib upstream. Periodically re-check
+   `Mathlib.LinearAlgebra.CliffordAlgebra.*` for `equivOfPeriodicity` /
+   structure-classification lemmas, and `Mathlib.Algebra.Algebra.Basic`
+   for a Frobenius-type theorem.
 
-1. **(option B) Refactor `HurwitzOnlyIf.hurwitz_only_if_ring`** into a concrete
-   bridge lemma (`nsquareIdentity_of_normedDivisionRing`, ~80 lines) plus the
-   call to `HurwitzTheorem.hurwitz_only_if`. Sorry count unchanged but the
-   non-Mathlib part of the proof becomes provable. Net effect: same total
-   axioms/sorries but one of the two sorries becomes "calls a sorry-axiom"
-   instead of "needs new infra". Future-blocked by the same Cl gap.
+2. **(option B, deferred)** If a contributor takes on the bridge
+   construction (~200-500 lines), it splits into two natural Mathlib PRs:
+   (i) `InnerProductSpace ℝ A` from `NormedDivisionRing` + finite-dim
+   (Frobenius-style imaginary-subspace argument); (ii) the
+   `nsquareIdentity_of_normedDivisionRing` bridge using that inner product.
 
-2. **(option D) Wait** for Mathlib upstream. Re-check
-   `Mathlib.LinearAlgebra.CliffordAlgebra.*` periodically.
+3. **(option A, deferred)** Small-case decomposition for n=6, 10. Still
+   ~400 lines/case via ad-hoc Wedderburn structure of Cl(0,5), Cl(0,9).
+   Narrows but does not eliminate the open sorry.
 
-3. **(option A) Small-case decomposition** for $n = 6, 10$. ~400 lines per
-   case, hand-coded Wedderburn structure of $\mathrm{Cl}(0, 5)$ and $\mathrm{Cl}(0, 9)$.
-   Narrows but does not eliminate the open sorry; arguably not worth the work
-   if Mathlib will land it eventually.
+4. **(do NOT)** Submit to Aristotle. Sorry is OPEN (genuine missing
+   infrastructure), not a routine lemma.
 
-4. **(do NOT)** Submit to Aristotle. Sorry is OPEN (genuine missing infra),
-   not a routine lemma — Aristotle is the wrong tool.
+## Unblock Criteria (concrete)
+
+Promote phase from PARK back to ACT when **any** of the following lands in
+mathlib4 master:
+
+- `Mathlib.LinearAlgebra.CliffordAlgebra.Periodicity` with an isomorphism
+  `Cl(0, n+8) ≅ Cl(0, n) ⊗[ℝ] M(16, ℝ)` (or signed-degree analogue).
+- `Mathlib.LinearAlgebra.CliffordAlgebra.RealClassification` with a
+  Wedderburn-style structure theorem listing `Cl(0, k)` for `k = 0..7`.
+- A Mathlib `frobenius_theorem` for finite-dim normed associative real
+  division algebras, asserting `finrank ℝ A ∈ {1, 2, 4}`.
+- Any one of the above plus a `RingHom.injective` / faithful representation
+  lemma giving a lower bound on the simple-module dimension.
+
+When any of these lands, reopen and proceed with option B (~80 line glue
+once the upstream API exists) or directly close `HurwitzTheorem.lean:1937`
+via the new periodicity API.

--- a/src/data/research/problems/hurwitz-theorem-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-wip-01.json
@@ -29,29 +29,32 @@
     "goal": "Reduce HurwitzTheorem.lean sorry count from 1 to 0 (and HurwitzOnlyIf.lean from 1 to 0), promoting hurwitz-theorem from badge='wip' to badge='verified' (or 'original')."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-07T18:10:00Z",
-    "iteration": 2,
-    "focus": "Survey: full enumeration of what is proved upstream of the blocking sorry, mapping the gap to the missing Mathlib API.",
+    "phase": "PARK",
+    "since": "2026-05-08T03:35:00Z",
+    "iteration": 3,
+    "focus": "PARK: re-confirmed BLOCKED. No relevant Mathlib master changes since S2 (Cl periodicity / Frobenius / Wedderburn for real semisimple algebras still absent). Recorded a corrected cost estimate for option B: the bridge NormedDivisionRing -> NSquareIdentity is NOT ~80 lines because it requires constructing an InnerProductSpace from the multiplicative norm (~200-300 lines, itself a Frobenius-style argument).",
     "blockers": [
       "Mathlib has no classification of real Clifford algebras Cl(0,n-1) (Bott periodicity).",
-      "Mathlib has no Artin-Wedderburn structure theorem usable to compute the minimum faithful real representation dimension of a real semisimple algebra."
+      "Mathlib has no Artin-Wedderburn structure theorem usable to compute the minimum faithful real representation dimension of a real semisimple algebra.",
+      "Mathlib has no Frobenius theorem for finite-dim normed associative real division algebras (alternative path that would handle hurwitz_only_if_ring directly).",
+      "Bridge NormedDivisionRing -> NSquareIdentity n requires either an InnerProductSpace structure on A (not in Mathlib) or quadratic-form diagonalization machinery (not in Mathlib) -- so option B is also blocked, not the previously estimated ~80 lines of glue."
     ],
-    "nextAction": "Either (a) wait for Mathlib Clifford-classification PRs to land, or (b) attempt the small-case decomposition: prove n=6 and n=10 directly (without Bott periodicity) using ad-hoc trace/determinant arguments, then leave only the asymptotic case as sorry. See nextSteps for a concrete decomposition.",
+    "nextAction": "Wait for Mathlib upstream. Periodically re-check Mathlib.LinearAlgebra.CliffordAlgebra.* for periodicity/structure-classification lemmas and Mathlib.Algebra.Algebra.* for a Frobenius theorem. See unblockCriteria for concrete trigger conditions.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 0,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED but cleanly localized. HurwitzTheorem.lean has a single sorry (line 1937) for even n notin {2,4,8}. All structural infrastructure is in place: crossMat_anticommute proves that an NSquareIdentity n yields n-1 anti-commuting orthogonal n x n real matrices M_j with M_j^2 = -I, i.e., a real n-dim representation of Cl(0,n-1). Closing the sorry requires the Clifford structure theorem (Bott periodicity for real Cl(0,k)) plus a minimum-rep-dim bound, neither of which is in Mathlib v4.26.0. HurwitzOnlyIf.lean has a parallel sorry for hurwitz_only_if_ring (the NormedDivisionRing formulation). 0 axioms in either file.",
+    "progressSummary": "BLOCKED (PARK), iteration 3. HurwitzTheorem.lean has a single sorry (line 1937) for even n notin {2,4,8}. All structural infrastructure is in place: crossMat_anticommute proves that an NSquareIdentity n yields n-1 anti-commuting orthogonal n x n real matrices M_j with M_j^2 = -I, i.e., a real n-dim representation of Cl(0,n-1). Closing the sorry requires the Clifford structure theorem (Bott periodicity for real Cl(0,k)) plus a minimum-rep-dim bound, neither of which is in Mathlib v4.26.0. HurwitzOnlyIf.lean has a parallel sorry for hurwitz_only_if_ring (the NormedDivisionRing formulation). 0 axioms in either file. S3 added: the previously-estimated ~80-line option-B refactor is itself blocked because the bridge NormedDivisionRing -> NSquareIdentity needs an InnerProductSpace structure derived from the multiplicative norm, which is itself a Frobenius-style construction (~200-300 lines) and not in Mathlib.",
     "builtItems": [],
     "insights": [
       "All the linear algebra that the impossibility proof needs is already done in HurwitzTheorem.lean. The blocker is purely a Clifford-algebra structure theorem — there is no remaining 'analysis' or 'matrix' work to do at the gallery level.",
       "Per-n decomposition is viable: the case n=6 reduces to showing that 5 anti-commuting orthogonal 6x6 real matrices cannot exist. A direct trace/dimension counting argument (Cl(0,5) has dim 32 over R; a faithful R-module needs dim >= 8) avoids invoking Bott periodicity, but still needs the Wedderburn structure of Cl(0,5).",
       "n=10 has the same obstruction (Cl(0,9) ~= M(16,R)). For n=12,14,16,... the gap widens, so any 'finite case enumeration' approach saturates without a uniform argument.",
-      "HurwitzOnlyIf.lean line 109's 'orthonormal basis -> NSquareIdentity n' bridge is concrete linear algebra (no Clifford theory): expressible in ~80 lines using existing Mathlib LinearMap.IsometryEquiv + Module.Finite.finBasis. Decomposing hurwitz_only_if_ring along this seam would isolate the same blocker into one place.",
+      "S2 underestimated option B: the 'orthonormal basis -> NSquareIdentity n' bridge is NOT ~80 lines of glue. The L^2-norm of coordinate vectors equals ||sum a_i e_i||_A only when the basis is orthonormal, which requires an inner product on A. NormedDivisionRing alone does NOT give an inner product (a multiplicative norm is not automatically derived from an inner product on the underlying vector space). The bridge therefore needs first to construct an InnerProductSpace structure on A, which is a Frobenius-style argument (imaginary subspace V = {a : a^2 <= 0}, polarization identity) of roughly 200-300 lines that is itself absent from Mathlib.",
+      "Frobenius alternative: NormedDivisionRing is associative, so for hurwitz_only_if_ring the stronger Frobenius theorem (finrank in {1,2,4}) suffices. But the classical Frobenius proof goes through the same Clifford / imaginary-subspace machinery, which is why the two open sorries collapse to the same blocker. arXiv:2405.01876 (May 2024) formalizes Frobenius in a non-Mathlib system; not yet ported.",
       "Mathlib's Mathlib.LinearAlgebra.CliffordAlgebra.* (as of v4.26.0) provides the universal property and basic conjugation, but does NOT provide the periodicity/structure classification needed here (search Mathlib for 'CliffordAlgebra equivalent matrix' confirms no decomposition theorems).",
       "The companion gallery entry hurwitz-theorem (badge='wip', sorries=1) sits on this exact blocker; closing it would graduate that entry to verified."
     ],
@@ -62,11 +65,17 @@
       "(Equivalent path) Atiyah's K-theory proof via Bott periodicity for KO-theory of S^{n-1}: requires KO-theory of spheres + parallelizability obstruction, which is even further from Mathlib's current scope."
     ],
     "nextSteps": [
-      "Decomposition option A (small cases): introduce private lemma `no_six_square_identity` and `no_ten_square_identity` covering the next two even cases via ad-hoc Cl(0,5), Cl(0,9) Wedderburn structure (hand-coded if needed). Localizes the open sorry to 'even n >= 12 with n notin {16}'.",
-      "Decomposition option B (algebra refactor): split HurwitzOnlyIf.hurwitz_only_if_ring into two lemmas — (1) `nsquareIdentity_of_normedDivisionRing` (concrete, no Clifford), (2) the existing axiom call to HurwitzTheorem.hurwitz_only_if. This eliminates the second sorry without adding/removing any total assumption.",
+      "Decomposition option A (small cases): introduce private lemma `no_six_square_identity` and `no_ten_square_identity` covering the next two even cases via ad-hoc Cl(0,5), Cl(0,9) Wedderburn structure (hand-coded if needed). Localizes the open sorry to 'even n >= 12 with n notin {16}'. ~400 lines per case.",
+      "Decomposition option B (algebra refactor, BLOCKED upstream): split HurwitzOnlyIf.hurwitz_only_if_ring into (1) `inner_product_of_normedDivisionRing` (~200-300 lines, Frobenius-style imaginary-subspace argument), (2) `nsquareIdentity_of_normedDivisionRing` (~80 lines once an InnerProductSpace exists), (3) call to HurwitzTheorem.hurwitz_only_if. Subtask (1) is itself a worthwhile Mathlib contribution.",
       "Survey option C: open a Mathlib-side feature request / RFC for the Clifford classification API needed here, with a precise wishlist (CliffordAlgebra.equivOfBottPeriodicity, ClassicalLieAlgebra.realClassification, ...). Tracking issue, not Lean work.",
-      "Wait option D: monitor Mathlib master for CliffordAlgebra structure theorems; revisit when CliffordAlgebra.equiv* lemmas appear.",
+      "Wait option D (current): monitor Mathlib master for CliffordAlgebra structure theorems and a Frobenius-for-real-division-algebras theorem. See `unblockCriteria` for concrete trigger lemmas to watch for.",
       "Aristotle option E: do NOT submit. The sorry is OPEN (genuinely missing infrastructure), not a routine lemma — Aristotle is the wrong tool."
+    ],
+    "unblockCriteria": [
+      "Mathlib gains `Mathlib.LinearAlgebra.CliffordAlgebra.Periodicity` with an isomorphism `Cl(0, n+8) ≅ Cl(0, n) ⊗[ℝ] M(16, ℝ)`.",
+      "Mathlib gains `Mathlib.LinearAlgebra.CliffordAlgebra.RealClassification` with a Wedderburn-style structure theorem for `Cl(0, k)`, k = 0..7.",
+      "Mathlib gains a `frobenius_theorem` for finite-dim normed associative real division algebras, asserting `finrank ℝ A ∈ {1, 2, 4}`.",
+      "Mathlib gains an `InnerProductSpace`-from-`NormedDivisionRing` instance / theorem (Frobenius-style polarization argument)."
     ]
   },
   "tags": [
@@ -101,7 +110,7 @@
     ]
   },
   "started": "2026-05-06T14:18:33.487Z",
-  "lastUpdate": "2026-05-07T18:10:00Z",
+  "lastUpdate": "2026-05-08T03:35:00Z",
   "significance": 7,
   "tractability": 3
 }


### PR DESCRIPTION
## Summary

Iteration 3 (PARK) for hurwitz-theorem-wip-01. State-only update.

- Re-confirmed BLOCKED on Mathlib upstream (no relevant CliffordAlgebra / Frobenius / Wedderburn API since S2).
- Corrected S2's underestimate of option B (algebra-level refactor): the bridge `NormedDivisionRing → NSquareIdentity` is *not* ~80 lines of glue. It requires first constructing an `InnerProductSpace ℝ A` from the multiplicative norm, which is itself a Frobenius-style argument (~200-300 lines, also missing from Mathlib).
- Added explicit `unblockCriteria` (concrete Mathlib API additions to watch for) so a future iteration can detect when reopening is warranted.

## Files Modified

- `research/problems/hurwitz-theorem-wip-01/state.md` — phase OBSERVE→PARK, iteration 2→3, expanded blockers, corrected option B description, added unblock criteria.
- `src/data/research/problems/hurwitz-theorem-wip-01.json` — same fields synced; `unblockCriteria` array added.

## No Lean Changes

Sorry counts unchanged: `HurwitzTheorem.lean` = 1 sorry (line 1937), `HurwitzOnlyIf.lean` = 1 sorry (line 111). 0 axioms in either file. Both sorries collapse to the same Cl(0,n-1) classification gap upstream.

## Status

**Outcome**: surveyed (PARK)
**Next Steps**: monitor mathlib4 for Cl periodicity / real Cl classification / Frobenius theorem for normed associative real division algebras / `InnerProductSpace`-from-`NormedDivisionRing`. Reopen when any lands.

🤖 Generated by researcher-5