### PR TITLE
audit(tracker): binomial-theorem-oq-02-oq-01-oq-01-oq-03 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15036,8 +15036,14 @@
       "lastAudited": "2026-05-07T23:36:51Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq-02-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-08T03:47:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-06T10:18:00Z"
+  "lastUpdated": "2026-05-08T03:47:05Z"
 }


### PR DESCRIPTION
## Summary

Audit-tracker entry for first audit of `binomial-theorem-oq-02-oq-01-oq-01-oq-03` (Multinomial Marginal Central Limit Theorem — Phase-2 Scaffold).

## Verified

Compared `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json` against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`:

| Field | Claimed | Actual | Status |
|---|---|---|---|
| status | `axiomatized` | 1 axiom + 1 opaque + 1 sorry | ✓ |
| badge | `axiom` | matches status | ✓ |
| sorries | 1 | 1 (line 149) | ✓ |
| axiomCount | 2 | `axiom binomial_clt_pointwise` + `opaque standardNormalCDF` | ✓ |
| lineCount | 178 | 178 | ✓ |
| theoremCount | 2 | `multinomialMarginalCDF_eq_binomialCDF` + `multinomial_marginal_clt` | ✓ |
| definitionCount | 2 | `def binomialCDF` + `def multinomialMarginalCDF` (opaque counted in axiomCount) | ✓ |

## Narrative integrity

- Title includes the `(Phase-2 Scaffold)` qualifier
- Description explicitly states the result is "derived from the de Moivre-Laplace axiom plus the marginal-PMF identity"
- `originalContributions` flags `binomial_clt_pointwise` as an "axiomatic statement of de Moivre-Laplace"
- Lean docstring §"Honest Reporting" (lines 47-54) states sorries=1, axioms=2, status=axiomatized

No overclaim, no phantom axioms, no Tier-A pretension.

## Result

Clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)