### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-01-oq-01 sorries 2→3

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -19,10 +19,10 @@
       "ssyt"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 3,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "2 sorries remain: (1) jdt_weight_sum b≥2 — strategy refined in S19 to weight factorization + ballot counting identity (S18 diagnosed naive insert-violation bijection as non-injective for b≥2); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S19 added weight_eq_total_multiset helper: prod(P)*prod(Q) = prod(P+Q) via Multiset.map_add+prod_add. jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
+    "assumptions": "3 sorries remain: (1) ballot_counting_identity (S20 extracted, ~150 lines remaining) — per-fiber count equality C(a+b, a+1) for the b≥2 reflection step; (2) jdt_weight_sum b≥2 — structural reduction (steps i–iv) using ballot_counting_identity as a black box (~80–100 lines, separate session); (3) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S19 added weight_eq_total_multiset helper: prod(P)*prod(Q) = prod(P+Q) via Multiset.map_add+prod_add. jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
     "lineCount": 992,
     "theoremCount": 22,
     "definitionCount": 6,
@@ -83,7 +83,7 @@
     "theoremCount": 22,
     "definitionCount": 6,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 2,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean"
     ]
@@ -173,5 +173,5 @@
       "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)×Fin(sh i)→Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = ∑_T T.weight where T.weight = ∏_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection ψ: SSYTFin n 1 ≃ Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone ↔ SortedLE). General case (k ≥ 2): RSK correspondence (~300 lines), 2 sorries remain (ssytSchurFin_two_row + jacobi_trudi_ssyt_eq k≥3)."
     }
   ],
-  "sorries": 2
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Sync stale `sorries` count for `ballot-problem-oq-03-oq-01-oq-01-oq-01` (Jacobi-Trudi) after PR #16876 (S20 — ballot_counting_identity extraction) added a third sorry.

## Evidence

**Before**: `meta.sorries`, `leanFile.sorries`, top-level `sorries` all = 2; `assumptions` prose enumerates 2 sorries.

**After**: All three count fields = 3; `assumptions` prose enumerates the 3 remaining sorries (ballot_counting_identity, jdt_weight_sum b≥2 reduction, jacobi_trudi_ssyt_eq k≥3).

Verification: `BallotProblemOQ03OQ01OQ01OQ01.lean` has 3 sorries (after stripping comments) at lines 749, 801, 1044.

Auditor target: `ballot-problem-oq-03-oq-01-oq-01-oq-01 (4x, last 2026-05-02) [formalized/wip] ❌ sorry mismatch: claims 2, actual 3`.

---
Automated fix by lean-mechanic agent.