### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-02): S4 — per-term integrality bridge

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
@@ -97,10 +97,16 @@ strong-induction proof of `denominator_control`.
 * sorries: 0
 * lemmas: 4 reusable + 6 numerical witnesses + Part 4 adds
   `harmonicCubed` (the cubed-harmonic sum H_n^{(3)} = ∑_{k=1}^{n} 1/k^3)
-  with base values, non-negativity, and monotonicity (4 lemmas).
-  The main divisibility theorem `harmonicCubed_lcm_clear` is deferred
-  to a follow-up session (per-term `Nat.cast_div` proof exceeded
-  available Docker build time in this session).
+  with base values, non-negativity, monotonicity (4 lemmas), the
+  `harmonicCubed_succ` recurrence, and the numerical witness
+  `harmonicCubed_two = 9/8`.
+* Part 5 (session 4) adds the **per-term integrality bridge**:
+  `lcmRange_pow_eq_mul`, `term_lcm_clear_nat`, `term_lcm_clear_cube_nat`,
+  `term_lcm_clear_int` — the precise per-term identity that bypasses
+  the `Nat.cast_div`/`push_cast` issue that exceeded session 3's
+  Docker build time. Together these scaffold the main divisibility
+  theorem `harmonicCubed_lcm_clear` for a follow-up session via
+  induction on `n` using `harmonicCubed_succ` + the per-term lemmas.
 -/
 
 namespace BaselProblemOQ01OQ01OQ02OQ02
@@ -223,13 +229,86 @@ theorem harmonicCubed_mono {m n : ℕ} (h : m ≤ n) :
   intro k _ _
   positivity
 
+/-- **Recurrence**: `H_{n+1}^{(3)} = H_n^{(3)} + 1/(n+1)^3`.
+
+    This is the inductive-step identity for any proof of
+    `harmonicCubed_lcm_clear` by induction on `n`: the new contribution
+    `1/(n+1)^3` is exactly cleared by the new factor in `lcmRange (n+1)^3`
+    via `succ_cube_dvd_lcmRange_succ_cube`. -/
+theorem harmonicCubed_succ (n : ℕ) :
+    harmonicCubed (n + 1) = harmonicCubed n + (1 : ℚ) / (n + 1) ^ 3 := by
+  unfold harmonicCubed
+  rw [Finset.sum_range_succ]
+
+/-- `H_2^{(3)} = 1 + 1/8 = 9/8`. -/
+theorem harmonicCubed_two : harmonicCubed 2 = 9 / 8 := by
+  rw [show (2 : ℕ) = 1 + 1 from rfl, harmonicCubed_succ, harmonicCubed_one]
+  norm_num
+
+-- =====================================================================
+-- PART 5: Per-term integrality (the bridge to harmonicCubed_lcm_clear)
+-- =====================================================================
+
+/-- **Per-term integrality (Nat-witness form)**: `0 < k`, `k ≤ n` ⇒
+    `∃ m : ℕ, (lcmRange n)^p = m * k^p`.
+
+    This is just `pow_dvd_lcmRange_pow` repackaged with the witness `m`
+    extracted explicitly and the multiplication on the *outside* of `k^p`,
+    which is the orientation needed for the per-term rational identity
+    below. -/
+theorem lcmRange_pow_eq_mul {k n p : ℕ} (hk : 0 < k) (hkn : k ≤ n) :
+    ∃ m : ℕ, (lcmRange n) ^ p = m * k ^ p := by
+  obtain ⟨m, hm⟩ := pow_dvd_lcmRange_pow (p := p) hk hkn
+  exact ⟨m, by rw [hm]; ring⟩
+
+/-- **Per-term rational integrality**: `0 < k`, `k ≤ n` ⇒
+    `(lcmRange n : ℚ)^p / (k : ℚ)^p ∈ ℕ`.
+
+    This is *exactly* the per-term identity that the next session needs
+    to compose `harmonicCubed_lcm_clear` from `Finset.sum_div` (or by
+    induction via `harmonicCubed_succ` + this lemma). It bypasses the
+    `Nat.cast_div`/`push_cast` issue documented in session 3 by working
+    directly with the multiplicative form `(lcmRange n)^p = m * k^p` and
+    casting through `Nat → ℚ` (avoiding the `ℕ → ℤ → ℚ` chain that
+    `push_cast` aggressively rewrites via `Int.ofNat_div`). -/
+theorem term_lcm_clear_nat {k n p : ℕ} (hk : 0 < k) (hkn : k ≤ n) :
+    ∃ m : ℕ, (lcmRange n : ℚ) ^ p / (k : ℚ) ^ p = (m : ℚ) := by
+  obtain ⟨m, hm⟩ := lcmRange_pow_eq_mul (p := p) hk hkn
+  refine ⟨m, ?_⟩
+  have hkne : (k : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hk)
+  have hkpne : (k : ℚ) ^ p ≠ 0 := pow_ne_zero _ hkne
+  have hQ : (lcmRange n : ℚ) ^ p = (m : ℚ) * (k : ℚ) ^ p := by
+    have := congrArg (fun x : ℕ => (x : ℚ)) hm
+    push_cast at this
+    exact this
+  rw [hQ, mul_div_assoc, div_self hkpne, mul_one]
+
+/-- **Per-term rational integrality (cube form)**: the `p = 3` specialization
+    used in `harmonicCubed_lcm_clear`. -/
+theorem term_lcm_clear_cube_nat {k n : ℕ} (hk : 0 < k) (hkn : k ≤ n) :
+    ∃ m : ℕ, (lcmRange n : ℚ) ^ 3 / (k : ℚ) ^ 3 = (m : ℚ) :=
+  term_lcm_clear_nat hk hkn
+
+/-- **Per-term integrality, integer-witness form** for direct combination
+    with the `∃ m : ℤ, …` shape used in the parent's
+    `denominator_control_factorial`. -/
+theorem term_lcm_clear_int {k n p : ℕ} (hk : 0 < k) (hkn : k ≤ n) :
+    ∃ m : ℤ, (lcmRange n : ℚ) ^ p / (k : ℚ) ^ p = (m : ℚ) := by
+  obtain ⟨m, hm⟩ := term_lcm_clear_nat (p := p) hk hkn
+  exact ⟨(m : ℤ), by rw [hm]; push_cast; rfl⟩
+
 /- **Next session target**: prove
-   `∃ m : ℤ, (lcmRange n : ℚ)^3 * harmonicCubed n = m`. The integer
-   witness is `∑ k ∈ range n, (lcmRange n)^3 / (k+1)^3` (each term is
-   integral via `pow_dvd_lcmRange_pow`), but the per-term identity
-   `(lcmRange n : ℚ)^3 * (1/(k+1)^3) = ((lcmRange n)^3 / (k+1)^3 : ℕ→ℚ)`
-   requires careful `Nat.cast_div` handling that ran out of Docker
-   build time in this session.
+   `∃ m : ℤ, (lcmRange n : ℚ)^3 * harmonicCubed n = m`. With
+   `term_lcm_clear_cube_nat` now available, the proof is a clean
+   induction on `n`:
+   - Base `n = 0`: `(lcmRange 0 : ℚ)^3 * harmonicCubed 0 = 1 * 0 = 0`.
+   - Step `n → n+1`: use `harmonicCubed_succ` and the structural
+     divisibility `lcmRange n ∣ lcmRange (n+1)` (sibling file
+     `BaselProblemOQ01OQ01OQ02OQ03.lcmRange_dvd_lcmRange_of_le`, or
+     prove a local copy) to lift the IH `(lcmRange n)^3 * harmonicCubed n
+     = m` to `(lcmRange (n+1))^3 * harmonicCubed n = q^3 · m` (an
+     integer multiple), then add the new term
+     `(lcmRange (n+1))^3 / (n+1)^3 = m₂` from `term_lcm_clear_cube_nat`.
 
    This is the H_n^{(3)} half of the van der Poorten denominator
    analysis for `denominator_control` (route F). Combined with a

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
@@ -1,27 +1,105 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-26T08:56:57.649Z
-**Iteration**: 1
+**Phase**: ORIENT
+**Since**: 2026-05-08T03:50:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-Initial exploration of the problem.
+Sessions 1-3 (research-9 et al) built the lcm-divisibility infrastructure
+(`lcmRange`, `dvd_lcmRange`, `pow_dvd_lcmRange_pow`) and the harmonic-cubed
+infrastructure (`harmonicCubed`, base values, non-negativity, monotonicity)
+in `Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean` (route F — van der Poorten
+closed-form denominator analysis). Session 3 noted the main divisibility
+theorem `harmonicCubed_lcm_clear` was scaffolded but ran out of Docker
+build time on the per-term `Nat.cast_div`/`push_cast` rewrite chain.
 
 ## Active Approach
 
-None yet.
+Continue route (F): supply the *isolable* per-term integrality bridge
+that bypasses the per-term `Nat.cast_div`/`push_cast` issue documented in
+session 3, leaving the next session a clean induction on `n` for the full
+`harmonicCubed_lcm_clear`.
 
 ## Blockers
 
-None.
+None for this session — the per-term bridge compiles fast (no Finset
+aggregation, no `push_cast` through `Int.ofNat_div`).
+
+The full `harmonicCubed_lcm_clear` still needs:
+1. The local `lcmRange n ∣ lcmRange (n+1)` step lemma (or import from sibling
+   `BaselProblemOQ01OQ01OQ02OQ03.lcmRange_dvd_lcmRange_of_le`); and
+2. The induction-step assembly combining `harmonicCubed_succ` with
+   `term_lcm_clear_cube_nat` to lift the IH across the new term.
 
 ## Next Action
 
-Begin problem exploration.
+Session 5: prove `harmonicCubed_lcm_clear : ∃ m : ℤ, (lcmRange n : ℚ)^3 *
+harmonicCubed n = m` by induction on `n`, using
+`harmonicCubed_succ` + `term_lcm_clear_cube_nat` (now available from
+session 4) + a structural `lcmRange n ∣ lcmRange (n+1)` lemma.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3
+- Current approach attempts: 3
+- Approaches tried: 1 (route F, van der Poorten closed form)
+
+## Iteration 4 Builds (researcher-10, 2026-05-08)
+
+Focus: provide the **per-term integrality bridge** that the next session
+needs to compose `harmonicCubed_lcm_clear` cleanly — sidestepping the
+`Nat.cast_div`/`push_cast` rewrite chain that timed out the Docker build
+in session 3.
+
+- `harmonicCubed_succ : harmonicCubed (n + 1) = harmonicCubed n + 1/(n+1)^3`
+  (axiom-free): the inductive-step identity, one-line proof via
+  `Finset.sum_range_succ`. Required for any induction on `n` of
+  `harmonicCubed_lcm_clear`.
+- `harmonicCubed_two : harmonicCubed 2 = 9/8` (axiom-free): numerical
+  witness verifying the recurrence at the smallest non-trivial case.
+- `lcmRange_pow_eq_mul`: repackages `pow_dvd_lcmRange_pow` with an
+  explicit `m : ℕ` witness and the multiplication on the *outside*,
+  i.e., `(lcmRange n)^p = m * k^p`. This is the Nat-arithmetic form
+  needed to bridge cleanly into ℚ without going through `Int.div`.
+- `term_lcm_clear_nat {k n p} (hk : 0 < k) (hkn : k ≤ n)`:
+  `∃ m : ℕ, (lcmRange n : ℚ)^p / (k : ℚ)^p = (m : ℚ)`. The per-term
+  rational integrality: bypasses session 3's `Nat.cast_div` issue by
+  rewriting through the multiplicative form `lcmRange_pow_eq_mul` and
+  casting `Nat → ℚ` directly (no intermediate `Int` step that
+  `push_cast` would aggressively rewrite).
+- `term_lcm_clear_cube_nat`: the `p = 3` specialization for
+  `harmonicCubed_lcm_clear`'s recurrence target.
+- `term_lcm_clear_int`: integer-witness form (`∃ m : ℤ, …`) matching
+  the `denominator_control` axiom's signature, for direct combination
+  with the parent's `denominator_control_factorial` API.
+
+**Counts**: lineCount 239 → ~312 (+73), theoremCount 14 → 20 (+6),
+axiomCount 0 (unchanged), sorries 0 (unchanged). New theorems: 6
+substantive lemmas (1 recurrence, 1 numerical witness, 4 integrality).
+
+**Build**: verified via `./proofs/scripts/docker-build.sh
+Proofs.BaselProblemOQ01OQ01OQ02OQ02`.
+
+## Iteration 3 Builds (researcher-9, 2026-05-08)
+
+Earlier session's progress (carried forward):
+- Added `harmonicCubed` definition + base values + non-negativity +
+  monotonicity (4 lemmas).
+- Scaffolded `harmonicCubed_lcm_clear` proof but Docker build timed
+  out twice on the `Nat.cast_div`/`push_cast` rewrite chain.
+
+## Iteration 2 Builds (earlier session, 2026-05-08)
+
+- Added `dvd_lcmRange`, `pow_dvd_lcmRange_pow`,
+  `cube_dvd_lcmRange_cube`, `succ_cube_dvd_lcmRange_succ_cube`.
+- Added numerical witnesses `lcmRange_zero` through `lcmRange_five`.
+- Documented gap analysis showing route (P) (recurrence-induction)
+  fails at n=2→n=4 step due to cancellation.
+
+## Iteration 1 Builds (earlier session, OBSERVE phase, 2026-05-07)
+
+- Surveyed parent file's `denominator_control_factorial` (axiom-free
+  factorial bound).
+- Identified route (F) (van der Poorten closed form) as the cleanest
+  path forward; route (P) requires per-prime p-adic invariant (heavy).

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
@@ -27,24 +27,24 @@
   },
   "currentState": {
     "phase": "ORIENT",
-    "since": "2026-05-08T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "Defined harmonicCubed (H_n^{(3)}) infrastructure (4 lemmas: base values, non-negativity, monotonicity) — the first half of the van der Poorten denominator analysis for route (F). The main divisibility theorem `harmonicCubed_lcm_clear` is deferred to a follow-up session due to Docker build timeout from concurrent agent contention.",
+    "since": "2026-05-08T03:50:00Z",
+    "iteration": 4,
+    "focus": "Session 4 (researcher-10): added the per-term integrality bridge (harmonicCubed_succ, lcmRange_pow_eq_mul, term_lcm_clear_nat, term_lcm_clear_cube_nat, term_lcm_clear_int) that bypasses the Nat.cast_div/push_cast issue from session 3. Docker build verified successfully (3058 jobs, 22s for target file). Together with harmonicCubed_succ, the per-term lemmas are exactly what the next session needs to compose harmonicCubed_lcm_clear via induction on n.",
     "blockers": [
-      "The main divisibility theorem `harmonicCubed_lcm_clear : ∃ m : ℤ, (lcmRange n)^3 · H_n^{(3)} = m` requires careful `Nat.cast_div`/`field_simp` handling — `push_cast` aggressively pushes through `Nat.div` via `Int.ofNat_div`, creating an `Int.div` that doesn't match the per-term identity. Workaround: use `harmonicCubed_term_eq` private lemma + `Int.cast_natCast` + `Nat.cast_sum` — proved correct on paper, but local Docker build (cold cache + concurrent agents) exceeded 30-minute timeout in 2 attempts during session 3.",
+      "The main divisibility theorem `harmonicCubed_lcm_clear : ∃ m : ℤ, (lcmRange n)^3 · H_n^{(3)} = m` is now scaffold-ready: combine harmonicCubed_succ (recurrence) + term_lcm_clear_cube_nat (per-term integrality, axiom-free) + a local `lcmRange n ∣ lcmRange (n+1)` step lemma (or import sibling OQ-03 lemma). Session 4 deliberately stopped short of the full induction to keep the iteration build-bounded.",
       "The alternating bilinear summand ∑_{m=1}^{k} (-1)^{m-1}/(2 m^3 C(n,m) C(n+m,m)) needs binomial-coefficient denominator analysis — concretely: C(n,m) and C(n+m,m) have denominators that, after multiplying by lcm(1..n)^3, leave integers. Classical telescoping identity (van der Poorten 1979 §6) handles this but is non-trivial to port.",
       "Current `aperyA` is defined recursively in BaselProblemOQ01OQ01OQ02.lean:261 — no explicit closed form is yet available in the repo. Stating `aperyA_explicit_formula` as a sorry-axiom is a future session.",
       "Mathlib lacks: (1) any reference to Apéry numbers/sequences; (2) infrastructure for lcm-clearing identities of the form 'denominator divides lcm(1,…,n)^k'."
     ],
-    "nextAction": "Session 4: Re-attempt `harmonicCubed_lcm_clear` (proof scaffolded in Session 3 but Docker build timed out) — once verified, advance to `vdpAlternatingSum_lcm_clear`.",
+    "nextAction": "Session 5: prove `harmonicCubed_lcm_clear : ∃ m : ℤ, (lcmRange n : ℚ)^3 * harmonicCubed n = m` by induction on n, using the now-available `harmonicCubed_succ` + `term_lcm_clear_cube_nat` (both axiom-free, build-verified) + a `lcmRange n ∣ lcmRange (n+1)` step lemma (10-line local proof from `lcmRange_succ` analogue, or import from sibling OQ-03 file).",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Session 3 (2026-05-08, ORIENT): Added the `harmonicCubed` definition (the cubed-harmonic sum H_n^{(3)} = ∑_{k=1}^{n} 1/k^3) plus 4 reusable lemmas (`harmonicCubed_zero`, `harmonicCubed_one`, `harmonicCubed_nonneg`, `harmonicCubed_mono`) to `Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean`. These provide the basic infrastructure for the H_n^{(3)} half of the van der Poorten denominator analysis (route F). The MAIN divisibility theorem `harmonicCubed_lcm_clear : ∃ m : ℤ, (lcmRange n)^3 · H_n^{(3)} = m` was scaffolded with witness and proof structure but local Docker build timed out twice (30-min cold cache + concurrent agent contention). Documented for next session: the integer witness is `∑ k ∈ range n, (lcmRange n)^3 / (k+1)^3` (each term integral via `pow_dvd_lcmRange_pow`); the per-term identity `(lcmRange n : ℚ)^3 * (1/(k+1)^3) = ((Nat.div : ℕ→ℚ))` requires `Int.cast_natCast` + `Nat.cast_sum` + private `Nat.cast_div`-based lemma to avoid `push_cast` pushing through to `Int.div`. PROOF TECHNIQUE INSIGHT: `push_cast` is aggressive on `((a/b : ℕ) : ℤ)` via `Int.ofNat_div` — collapse the ℕ→ℤ→ℚ chain to ℕ→ℚ FIRST via `Int.cast_natCast`, then per-term work in ℕ→ℚ using `Nat.cast_div`. Session 2 (ORIENT): Built infrastructure lemmas (`dvd_lcmRange`, `pow_dvd_lcmRange_pow`, etc.) and corrected session 1's strategy. Session 1 (OBSERVE): Surveyed and identified van der Poorten path.",
+    "progressSummary": "Session 4 (2026-05-08, ORIENT, researcher-10): Added the **per-term integrality bridge** to `Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean` (lineCount 239 → 318, theoremCount 14 → 20, sorries 0, axioms 0): (a) `harmonicCubed_succ`: H_{n+1}^{(3)} = H_n^{(3)} + 1/(n+1)^3 (one-line via Finset.sum_range_succ) — the recurrence step. (b) `harmonicCubed_two = 9/8` (numerical witness). (c) `lcmRange_pow_eq_mul`: ∃ m:ℕ, (lcmRange n)^p = m * k^p — repackages pow_dvd_lcmRange_pow with explicit witness. (d) `term_lcm_clear_nat`: ∃ m:ℕ, (lcmRange n : ℚ)^p / (k:ℚ)^p = (m:ℚ) — the per-term rational identity, bypasses session 3's Nat.cast_div/push_cast issue by working through the multiplicative form directly in Nat→ℚ (no Int intermediate). (e) `term_lcm_clear_cube_nat` and `term_lcm_clear_int`: p=3 specialization and integer-witness form. Build verified: 3058 jobs, 22s for target file (Docker, cold cache). KEY INSIGHT: avoid the Nat→ℤ→ℚ chain that push_cast aggressively rewrites via Int.ofNat_div by going Nat→ℚ directly through congrArg + push_cast on the multiplicative form (lcmRange n)^p = m * k^p; this gives `(lcmRange n:ℚ)^p = (m:ℚ) * (k:ℚ)^p` cleanly, then field-simp closes the goal. Session 3 (2026-05-08, ORIENT): Added the `harmonicCubed` definition + 4 base lemmas (zero, one, nonneg, mono); main divisibility theorem scaffolded but Docker timed out twice on the per-term Nat.cast_div chain (now resolved in session 4). Session 2 (ORIENT): Built infrastructure lemmas (`dvd_lcmRange`, `pow_dvd_lcmRange_pow`, etc.) and corrected session 1's strategy. Session 1 (OBSERVE): Surveyed and identified van der Poorten path.",
     "builtItems": [
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: dvd_lcmRange (k>0, k≤n → k∣lcmRange n) — basic membership divisibility",
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: pow_dvd_lcmRange_pow (k>0, k≤n → k^p ∣ (lcmRange n)^p) — the cubed divisibility ingredient any inductive proof of denominator_control needs",
@@ -54,7 +54,13 @@
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed (cubed-harmonic sum H_n^{(3)} = ∑_{k=1}^n 1/k^3, reproduced locally to keep file self-contained)",
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_zero, harmonicCubed_one (base values: H_0^{(3)} = 0, H_1^{(3)} = 1)",
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_nonneg (H_n^{(3)} ≥ 0)",
-      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_mono (m ≤ n → H_m^{(3)} ≤ H_n^{(3)})"
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_mono (m ≤ n → H_m^{(3)} ≤ H_n^{(3)})",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_succ (H_{n+1}^{(3)} = H_n^{(3)} + 1/(n+1)^3) — recurrence step for induction on n",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_two (H_2^{(3)} = 9/8) — numerical witness verifying the recurrence",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: lcmRange_pow_eq_mul (∃ m:ℕ, (lcmRange n)^p = m * k^p) — Nat-witness form of pow_dvd_lcmRange_pow",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: term_lcm_clear_nat (per-term integrality: ∃ m:ℕ, (lcmRange n:ℚ)^p / (k:ℚ)^p = (m:ℚ)) — bypasses Nat.cast_div/push_cast issue from session 3",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: term_lcm_clear_cube_nat (p=3 specialization for harmonicCubed_lcm_clear)",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: term_lcm_clear_int (∃ m:ℤ, …) — integer-witness form for combination with denominator_control_factorial"
     ],
     "insights": [
       "BaselProblemOQ01OQ01OQ02.lean already has `denominator_control_factorial : ∃ m : ℤ, (n.factorial : ℚ)^3 * aperyA n = m` PROVED (Part XIX). The factorial proof works because `(n+2)! = (n+2)·(n+1)!` is EXACT multiplicative — multiplying through the recurrence by `(n+1)!^3` produces `(n+2)!^3` on the LHS with no leftover (n+2)^3 to absorb. lcm has no analogous factorisation: lcm(1..n+2) ≠ (n+2)·lcm(1..n+1) in general (e.g. lcm(1..4)=12 ≠ 4·6=24).",
@@ -64,7 +70,8 @@
       "Mathlib `Mathlib.Data.Nat.GCD.Basic` has `Nat.lcm` and `Finset.lcm`. The basic divisibility `(k+1) ∣ Finset.lcm (Finset.range n) (· + 1)` follows from `Finset.dvd_lcm` and is now packaged in OQ-02-OQ-02 as `dvd_lcmRange`.",
       "The cubed divisibility `k^p ∣ (lcmRange n)^p` is now AVAILABLE as `pow_dvd_lcmRange_pow` in OQ-02-OQ-02. It packages `dvd_lcmRange` + `pow_dvd_pow_of_dvd`. Reusable across both strategy (P) and (F).",
       "Sibling file Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean already provides `lcmRange_succ` (lcmRange (n+1) = Nat.lcm (lcmRange n) (n+1)), `lcmRange_dvd_lcmRange_of_le`, `lcmRange_monotone`, `lcmRange_dvd_factorial`. These cover the BasicNat-arithmetic side; OQ-02 file adds the powered version specifically needed for denominator analysis.",
-      "Watch out: `lcmUpTo n = (Finset.range n).lcm (· + 1)` so lcmUpTo n covers integers 1 through n (not 0 through n-1). lcmUpTo 0 = 1 (lcm of empty set). The defining equation `lcmUpTo_dvd_of_le` (already proved in parent) gives lcm(1..n) ∣ lcm(1..m) for n ≤ m."
+      "Watch out: `lcmUpTo n = (Finset.range n).lcm (· + 1)` so lcmUpTo n covers integers 1 through n (not 0 through n-1). lcmUpTo 0 = 1 (lcm of empty set). The defining equation `lcmUpTo_dvd_of_le` (already proved in parent) gives lcm(1..n) ∣ lcm(1..m) for n ≤ m.",
+      "PER-TERM RATIONAL CASTING (session 4 resolution): The clean way to prove `(lcmRange n : ℚ)^p / (k : ℚ)^p ∈ ℕ` from `k^p ∣ (lcmRange n)^p` is to extract the multiplicative form `∃ m:ℕ, (lcmRange n)^p = m * k^p`, then cast that ℕ-equality to ℚ via `congrArg (· : ℕ → ℚ) + push_cast`, giving `(lcmRange n:ℚ)^p = (m:ℚ) * (k:ℚ)^p` directly. From there `mul_div_assoc + div_self + mul_one` closes the goal. Avoids the ℕ→ℤ→ℚ chain that `push_cast` aggressively rewrites via `Int.ofNat_div`. Implemented as `term_lcm_clear_nat` in OQ-02-OQ-02."
     ],
     "mathlibGaps": [
       "No Apéry numbers in Mathlib (aperyA, aperyB are gallery-local).",
@@ -72,11 +79,12 @@
       "No `Nat.lcm_range` simp lemma giving `lcm({1,…,n}) = ⋁_{k≤n} k` form."
     ],
     "nextSteps": [
-      "Session 4 (vdp alternating sum): State and prove `vdpAlternatingSum_lcm_clear`: `∃ m : ℤ, (lcmRange n)^3 · ∑_{k=0}^n ∑_{m=1}^k (-1)^{m-1}/(2 m^3 C(n,m) C(n+m,m)) = m`. The classical denominator identity (van der Poorten 1979 §6) shows that 2 m^3 · C(n,m) · C(n+m,m) divides lcm(1..n)^3 (the factor 2 is absorbed by the squared central binomial; the m^3 factor is `pow_dvd_lcmRange_pow`; the binomial denominators follow from m·C(n,m) = n·C(n-1,m-1) and similar). Estimated ~200 lines.",
-      "Session 5 (vdp closed form, sorried): State `aperyA_explicit_formula : aperyA n = ∑_{k=0}^{n} C(n,k)^2 C(n+k,k)^2 (H_n^{(3)} + cnk(n,k))` as a sorried theorem. Validate at n=0,1,2,3,4 via `native_decide`. Estimated ~80 lines.",
-      "Session 6 (assembly): Combine `harmonicCubed_lcm_clear`, `vdpAlternatingSum_lcm_clear`, and `aperyA_explicit_formula` to prove `denominator_control_lcm : ∃ m : ℤ, (lcmRange n)^3 · aperyA n = m`. Eliminate the parent's `axiom denominator_control` by importing the result. Estimated ~80 lines.",
-      "Session 7 (axiom count update): Update meta.json axiomCount 5→4, status remains axiomatized (4 axioms remain: aperyB_recurrence, lcm_hanson_bound, apery_linearForm_decay, apery_linearForm_nonzero). Update gallery integration.",
-      "Optional Session 8 (Mathlib contribution): If `pow_dvd_lcmRange_pow` is judged clean and general, draft a Mathlib PR — `Finset.lcm_pow_dvd_pow_of_mem` or similar. Currently only OQ-02 and OQ-03 in this gallery use this lemma; broader applicability uncertain."
+      "Session 5 (harmonicCubed_lcm_clear): prove `∃ m : ℤ, (lcmRange n : ℚ)^3 * harmonicCubed n = m` by induction on n. Base n=0: 1·0=0 (witness 0). Step n→n+1: use harmonicCubed_succ + IH to split (lcmRange (n+1))^3 * harmonicCubed n + (lcmRange (n+1))^3 / (n+1)^3, lifting the IH via lcmRange n ∣ lcmRange (n+1) (state locally as `lcmRange_dvd_lcmRange_succ`, ~10 lines, or import sibling OQ-03's `lcmRange_dvd_lcmRange_of_le`); the new term is integral via `term_lcm_clear_cube_nat` with k=n+1. Estimated ~80 lines, build-quick (per-term lemma already verified). Now unblocked.",
+      "Session 6 (vdp alternating sum): State and prove `vdpAlternatingSum_lcm_clear`: `∃ m : ℤ, (lcmRange n)^3 · ∑_{k=0}^n ∑_{m=1}^k (-1)^{m-1}/(2 m^3 C(n,m) C(n+m,m)) = m`. The classical denominator identity (van der Poorten 1979 §6) shows that 2 m^3 · C(n,m) · C(n+m,m) divides lcm(1..n)^3 (the factor 2 is absorbed by the squared central binomial; the m^3 factor is `pow_dvd_lcmRange_pow`; the binomial denominators follow from m·C(n,m) = n·C(n-1,m-1) and similar). Estimated ~200 lines.",
+      "Session 7 (vdp closed form, sorried): State `aperyA_explicit_formula : aperyA n = ∑_{k=0}^{n} C(n,k)^2 C(n+k,k)^2 (H_n^{(3)} + cnk(n,k))` as a sorried theorem. Validate at n=0,1,2,3,4 via `native_decide`. Estimated ~80 lines.",
+      "Session 8 (assembly): Combine `harmonicCubed_lcm_clear`, `vdpAlternatingSum_lcm_clear`, and `aperyA_explicit_formula` to prove `denominator_control_lcm : ∃ m : ℤ, (lcmRange n)^3 · aperyA n = m`. Eliminate the parent's `axiom denominator_control` by importing the result. Estimated ~80 lines.",
+      "Session 9 (axiom count update): Update meta.json axiomCount 5→4, status remains axiomatized (4 axioms remain: aperyB_recurrence, lcm_hanson_bound, apery_linearForm_decay, apery_linearForm_nonzero). Update gallery integration.",
+      "Optional Session 10 (Mathlib contribution): If `pow_dvd_lcmRange_pow` is judged clean and general, draft a Mathlib PR — `Finset.lcm_pow_dvd_pow_of_mem` or similar. Currently only OQ-02 and OQ-03 in this gallery use this lemma; broader applicability uncertain."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Session 4 of `basel-problem-oq-01-oq-01-oq-02-oq-02` (Apéry denominator
control via van der Poorten route F). Adds the **per-term integrality
bridge** that resolves session 3's Docker-build blocker on
`harmonicCubed_lcm_clear`.

- `harmonicCubed_succ` — recurrence step `H_{n+1}^{(3)} = H_n^{(3)} + 1/(n+1)^3`
- `harmonicCubed_two` — numerical witness `H_2^{(3)} = 9/8`
- `lcmRange_pow_eq_mul` — Nat-witness form of `pow_dvd_lcmRange_pow`
- `term_lcm_clear_nat` / `term_lcm_clear_cube_nat` / `term_lcm_clear_int` —
  the per-term rational identity `(lcmRange n : ℚ)^p / (k : ℚ)^p ∈ ℕ`
  that bypasses the `Nat.cast_div`/`push_cast` issue from session 3 by
  going `Nat → ℚ` directly through `congrArg + push_cast` on the
  multiplicative form `(lcmRange n)^p = m * k^p`.

## Counts

`Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean`:
- lineCount 239 → 318 (+79)
- theoremCount 14 → 20 (+6 substantive)
- axiomCount 0 (unchanged), sorries 0 (unchanged)

## Build

Verified via `./proofs/scripts/docker-build.sh
Proofs.BaselProblemOQ01OQ01OQ02OQ02` — 3058 jobs, 22s for target file
post Mathlib cache restore. One pre-existing `simp` warning at line
215:23 (in `harmonicCubed_one`, unrelated to this PR).

## Test plan

- [x] Docker build green (3058 jobs, exit 0)
- [x] No new sorries / axioms
- [x] All new lemmas axiom-free (transitively, no new dependency on
  parent's `aperyB_recurrence` / `lcm_hanson_bound` / etc.)
- [x] state.md updated to iteration 4
- [x] research JSON `currentState` and `knowledge.progressSummary` updated

## Next session

Prove `harmonicCubed_lcm_clear : ∃ m : ℤ, (lcmRange n : ℚ)^3 *
harmonicCubed n = m` by induction on `n` using `harmonicCubed_succ` +
`term_lcm_clear_cube_nat` + a `lcmRange n ∣ lcmRange (n+1)` step lemma
(~10 lines, can be imported from sibling `OQ-03` file or proved
locally). The session-3 blocker is now resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)