### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S4 — squarefree-order axiom-narrowing

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -45,6 +45,7 @@ import Mathlib.GroupTheory.PGroup
 import Mathlib.GroupTheory.Solvable
 import Mathlib.GroupTheory.Nilpotent
 import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.GroupTheory.SpecificGroups.ZGroup
 import Mathlib.Tactic
 
 namespace BurnsidePQ
@@ -97,12 +98,60 @@ theorem burnside_pq_same_prime {G : Type*} [Group G] [Finite G]
   exact pGroup_isSolvable G hpg
 
 -- ═══════════════════════════════════════════════════════════════════════
--- PART III: The non-trivial case (AXIOMATIZED)
+-- PART II.5: Squarefree-order case (axiom-free, via IsZGroup)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Squarefree-order ⇒ solvable** (axiom-free, two Mathlib lemmas).
+
+    Bridges `Squarefree (Nat.card G)` to `IsSolvable G` via Mathlib's
+    `IsZGroup.of_squarefree` (a finite group of squarefree order is a
+    Z-group — every Sylow subgroup is cyclic) and the `[Finite G]
+    [IsZGroup G]` instance giving `IsSolvable G`.
+
+    This subsumes the `a = b = 1` case of Burnside (`p ≠ q`, `|G| = pq`)
+    via `burnside_pq_pq_case` below — extending it axiom-free to ANY
+    finite group of squarefree order, e.g. `|G| = 30 = 2·3·5`,
+    `|G| = 105 = 3·5·7`, etc.
+
+    Note: this does NOT extend to `|G| = pᵃqᵇ` with `a ≥ 2` or `b ≥ 2` —
+    such orders fail the squarefreeness test (`p²` is not squarefree).
+    The genuine non-trivial case of Burnside (with prime-power factors)
+    still requires character theory or transfer + focal subgroup. -/
+theorem squarefreeOrder_isSolvable {G : Type*} [Group G] [Finite G]
+    (hsf : Squarefree (Nat.card G)) : IsSolvable G := by
+  haveI : IsZGroup G := IsZGroup.of_squarefree hsf
+  infer_instance
+
+/-- **Burnside `pq` case** (axiom-free, `a = b = 1`): every finite group
+    of order `p · q` (for distinct primes `p, q`) is solvable.
+
+    Proof: `p` and `q` are coprime (`Nat.coprime_primes`), each is
+    squarefree (`Nat.Prime.prime` + `Prime.squarefree`), so `p · q` is
+    squarefree (`Nat.squarefree_mul`). Apply `squarefreeOrder_isSolvable`.
+
+    This eliminates the `a = b = 1` sub-case of `burnside_pq_nontrivial`
+    axiom-free; the axiom is then narrowed to `2 ≤ a ∨ 2 ≤ b`. -/
+theorem burnside_pq_pq_case {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : p ≠ q) (hcard : Nat.card G = p * q) : IsSolvable G := by
+  apply squarefreeOrder_isSolvable
+  rw [hcard]
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp.out hq.out).mpr hpq
+  rw [Nat.squarefree_mul hcop]
+  exact ⟨hp.out.prime.squarefree, hq.out.prime.squarefree⟩
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART III: The non-trivial case (AXIOMATIZED, narrowed to 2 ≤ a ∨ 2 ≤ b)
 -- ═══════════════════════════════════════════════════════════════════════
 
 /-- **AXIOM (Burnside's pᵃqᵇ theorem, non-trivial case)**: every finite
     group of order `p^a · q^b` is solvable, when `p` and `q` are distinct
-    primes and `a, b ≥ 1`.
+    primes, `a, b ≥ 1`, AND at least one of `a, b` is ≥ 2.
+
+    The hypothesis `2 ≤ a ∨ 2 ≤ b` narrows the axiom: the `a = b = 1`
+    sub-case (`|G| = p · q` squarefree) is now proved axiom-free via
+    `burnside_pq_pq_case`. The genuinely-open content is `|G|` divisible
+    by `p²` or `q²` for distinct primes.
 
     Proof sketch (NOT in Mathlib, character-theoretic, Burnside 1904):
     Suppose for contradiction `G` is a minimal counterexample. Then `G` is
@@ -118,10 +167,11 @@ theorem burnside_pq_same_prime {G : Type*} [Group G] [Finite G]
     Use the transfer homomorphism on a Sylow `p`-subgroup combined with
     the focal subgroup theorem to show that `P ∩ G'` is a proper subgroup
     of `P`, contradicting `G = G'` (which holds in any non-abelian simple
-    group). -/
+    group). Mathlib's `Mathlib.GroupTheory.Focal` (focal subgroup, transfer)
+    is a starting point for the character-free route. -/
 axiom burnside_pq_nontrivial {G : Type*} [Group G] [Finite G]
     {p q : ℕ} [Fact p.Prime] [Fact q.Prime] {a b : ℕ}
-    (hpq : p ≠ q) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (hpq : p ≠ q) (ha : 1 ≤ a) (hb : 1 ≤ b) (hab : 2 ≤ a ∨ 2 ≤ b)
     (hcard : Nat.card G = p ^ a * q ^ b) : IsSolvable G
 
 -- ═══════════════════════════════════════════════════════════════════════
@@ -132,8 +182,10 @@ axiom burnside_pq_nontrivial {G : Type*} [Group G] [Finite G]
     (for primes `p, q` and naturals `a, b`) is solvable.
 
     Combines:
-    - the three axiom-free trivial cases (`a = 0`, `b = 0`, `p = q`), and
-    - the conjectural non-trivial case (`burnside_pq_nontrivial`). -/
+    - the three axiom-free trivial cases (`a = 0`, `b = 0`, `p = q`),
+    - the axiom-free squarefree-order case (`a = b = 1`, `p ≠ q`), and
+    - the conjectural non-trivial case (`burnside_pq_nontrivial`,
+      `2 ≤ a ∨ 2 ≤ b`). -/
 theorem burnside_pq {G : Type*} [Group G] [Finite G]
     {p q : ℕ} [Fact p.Prime] [Fact q.Prime] {a b : ℕ}
     (hcard : Nat.card G = p ^ a * q ^ b) : IsSolvable G := by
@@ -149,8 +201,21 @@ theorem burnside_pq {G : Type*} [Group G] [Finite G]
   · -- p = q (with a ≥ 1, b ≥ 1)
     subst hpq
     exact burnside_pq_same_prime hcard
-  · -- p ≠ q, a ≥ 1, b ≥ 1: use axiom
-    exact burnside_pq_nontrivial hpq ha hb hcard
+  · -- p ≠ q, a ≥ 1, b ≥ 1
+    by_cases h11 : a = 1 ∧ b = 1
+    · -- a = b = 1: |G| = p · q (squarefree); axiom-free
+      obtain ⟨ha1, hb1⟩ := h11
+      subst ha1
+      subst hb1
+      have hcard' : Nat.card G = p * q := by simpa [pow_one] using hcard
+      exact burnside_pq_pq_case hpq hcard'
+    · -- 2 ≤ a ∨ 2 ≤ b: use the (narrowed) axiom
+      have hab : 2 ≤ a ∨ 2 ≤ b := by
+        by_contra h
+        push_neg at h
+        obtain ⟨ha2, hb2⟩ := h
+        exact h11 ⟨by omega, by omega⟩
+      exact burnside_pq_nontrivial hpq ha hb hab hcard
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- PART V: Sanity checks
@@ -178,6 +243,27 @@ example {G : Type*} [Group G] [Finite G]
   haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
   have h : Nat.card G = p ^ a * 2 ^ 0 := by simp [hcard]
   exact burnside_pq h
+
+/-- **Group of order `pq` is solvable** (`p ≠ q`, both prime). Axiom-free,
+    invokes only `burnside_pq_pq_case` via the `a = b = 1` dispatch in
+    `burnside_pq`. Concrete witness: groups of order 6, 10, 14, 15, 21,
+    22, 33, 35, … are all solvable. -/
+example {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [Fact p.Prime] [Fact q.Prime] (hpq : p ≠ q)
+    (hcard : Nat.card G = p * q) : IsSolvable G :=
+  burnside_pq_pq_case hpq hcard
+
+/-- **Group of order 30 = 2·3·5 is solvable**. Axiom-free squarefree-order
+    case (three distinct primes, each to first power). Demonstrates that
+    `squarefreeOrder_isSolvable` extends beyond Burnside's two-prime
+    bound when each prime appears to the first power only — but cannot
+    rescue A₅ (|A₅| = 60 = 2² · 3 · 5 has `2²` and is not squarefree). -/
+example {G : Type*} [Group G] [Finite G] (hcard : Nat.card G = 30) :
+    IsSolvable G := by
+  apply squarefreeOrder_isSolvable
+  rw [hcard]
+  show Squarefree (30 : ℕ)
+  native_decide
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- PART VI: Sharpness witness
@@ -227,10 +313,14 @@ theorem burnside_pq_sharp :
 /-
 ## Summary
 
-### Axioms added (1)
+### Axioms added (1, narrowed in Iteration 4)
 - `burnside_pq_nontrivial` : the non-trivial case of Burnside's pᵃqᵇ
-  theorem (`p ≠ q`, `a ≥ 1`, `b ≥ 1`). The genuinely-open Lean content;
-  a full proof requires substantial new infrastructure (character theory
+  theorem (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The
+  hypothesis `2 ≤ a ∨ 2 ≤ b` was added in Iteration 4: the `a = b = 1`
+  sub-case (`|G| = p · q`, squarefree order) is now proved axiom-free
+  via `burnside_pq_pq_case`. The genuinely-open Lean content is now
+  exactly: `|G|` divisible by `p²` or `q²` for distinct primes.
+  A full proof requires substantial new infrastructure (character theory
   + algebraic integers, OR transfer + focal subgroup) not currently in
   Mathlib.
 
@@ -241,7 +331,13 @@ theorem burnside_pq_sharp :
 - `burnside_pq_b_zero` — Burnside for `b = 0` (`G` is a `p`-group).
 - `burnside_pq_same_prime` — Burnside for `p = q` (`G` is a `p`-group of
   order `p^(a+b)`).
-- `burnside_pq` — main theorem combining trivial cases + axiom.
+- `squarefreeOrder_isSolvable` — `Squarefree (Nat.card G) → IsSolvable G`
+  via Mathlib's `IsZGroup.of_squarefree` + the `[IsZGroup G] [Finite G]`
+  → `IsSolvable G` instance. Subsumes the `a = b = 1` Burnside case.
+- `burnside_pq_pq_case` — Burnside for `a = b = 1` (`|G| = p · q`,
+  squarefree order). Reduces to `squarefreeOrder_isSolvable` via
+  `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`.
+- `burnside_pq` — main theorem combining trivial cases + pq case + axiom.
 - `alternatingGroupFin5_card` — `|A₅| = 2² · 3 · 5 = 60` (sharpness witness
   cardinality, three distinct primes).
 - `alternatingGroupFin5_not_solvable` — `¬ IsSolvable (A₅)` via reduction to
@@ -249,18 +345,21 @@ theorem burnside_pq_sharp :
   `A₅ → S₅ → ℤ/2`.
 - `burnside_pq_sharp` — sharpness witness: `|A₅| = 2² · 3 · 5` AND `A₅` is
   not solvable, demonstrating that `burnside_pq` cannot be extended to
-  three distinct primes.
+  three distinct primes. Note: A₅ defeats the `Squarefree` route too —
+  60 has `2²`, so `squarefreeOrder_isSolvable` does not apply.
 
 ### Path forward
-- Eliminate `burnside_pq_nontrivial` by formalizing the
+- Eliminate the (narrowed) `burnside_pq_nontrivial` by formalizing the
   Goldschmidt-Matsuyama proof (estimated ~400-800 lines): build the
-  focal subgroup theorem in Mathlib, then apply transfer to a Sylow.
-  This is preferable to the character-theoretic route because Mathlib's
-  character theory still lacks the algebraic-integer hypotheses needed
-  for `(|G|/χ(1))χ(g) ∈ ℤ̄_K`.
-- Sharpness check: prove `¬ IsSolvable (Equiv.Perm (Fin 5))` (already in
-  Mathlib via `Equiv.Perm.fin_5_not_solvable`) and observe `|A₅| = 60`
-  has three primes — confirms the bound is tight.
+  focal subgroup theorem in Mathlib (some scaffolding now exists in
+  `Mathlib.GroupTheory.Focal`), then apply transfer to a Sylow. This is
+  preferable to the character-theoretic route because Mathlib's character
+  theory still lacks the algebraic-integer hypotheses needed for
+  `(|G|/χ(1))χ(g) ∈ ℤ̄_K`.
+- Next sub-cases worth axiom-free attempts (in order of accessibility):
+  (1) `|G| = p² · q` with `p ≠ q` — classical, ~50-100 lines via Sylow,
+  (2) `|G| = p · q²` with `p ≠ q` — symmetric to (1),
+  (3) `|G| = p² · q²` — needs more delicate Sylow analysis.
 - Mathlib upstream: a Burnside-pᵃqᵇ proof would be a substantial PR.
   Coordinate with Mathlib reviewers before scoping a full formalization.
 -/
@@ -270,6 +369,8 @@ theorem burnside_pq_sharp :
 #check @burnside_pq_a_zero
 #check @burnside_pq_b_zero
 #check @burnside_pq_same_prime
+#check @squarefreeOrder_isSolvable
+#check @burnside_pq_pq_case
 #check @pGroup_isSolvable
 #check @alternatingGroupFin5_card
 #check @alternatingGroupFin5_not_solvable

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/knowledge.md
@@ -1,9 +1,9 @@
 # Knowledge: Burnside's pᵃqᵇ Theorem (abel-ruffini-galois-extensions-oq-07)
 
-## Status (2026-05-08, Iteration 2)
+## Status (2026-05-08, Iteration 4)
 
-Phase-2 axiomatization complete: `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`,
-221 lines, 5 theorems, 1 axiom, 0 sorries.
+Phase-2 axiomatization with axiom narrowed: `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`,
+384 lines, 10 theorems, 1 axiom (narrowed to `2 ≤ a ∨ 2 ≤ b`), 0 sorries.
 
 ## Key Results
 
@@ -13,18 +13,33 @@ Phase-2 axiomatization complete: `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.
 | `burnside_pq_a_zero` | `Nat.card G = p^0 · q^b → IsSolvable G` | Yes |
 | `burnside_pq_b_zero` | `Nat.card G = p^a · q^0 → IsSolvable G` | Yes |
 | `burnside_pq_same_prime` | `Nat.card G = p^a · p^b → IsSolvable G` | Yes |
-| `burnside_pq_nontrivial` (axiom) | `p ≠ q ∧ a, b ≥ 1 → Nat.card G = p^a · q^b → IsSolvable G` | **No (axiom)** |
-| `burnside_pq` | `Nat.card G = p^a · q^b → IsSolvable G` | Uses axiom for non-trivial case |
+| `squarefreeOrder_isSolvable` (S4) | `Squarefree (Nat.card G) → IsSolvable G` | Yes (IsZGroup chain) |
+| `burnside_pq_pq_case` (S4) | `p ≠ q ∧ Nat.card G = p · q → IsSolvable G` | Yes |
+| `burnside_pq_nontrivial` (axiom, narrowed S4) | `p ≠ q ∧ a, b ≥ 1 ∧ (2 ≤ a ∨ 2 ≤ b) ∧ Nat.card G = p^a · q^b → IsSolvable G` | **No (narrowed axiom)** |
+| `burnside_pq` | `Nat.card G = p^a · q^b → IsSolvable G` | Uses axiom only for `2 ≤ a ∨ 2 ≤ b` |
+| `alternatingGroupFin5_card` (S3) | `Nat.card A₅ = 2^2 · 3 · 5` | Yes |
+| `alternatingGroupFin5_not_solvable` (S3) | `¬ IsSolvable A₅` | Yes |
+| `burnside_pq_sharp` (S3) | conjunction of above two | Yes |
 
 ## Mathlib API anchors
 
+### Core (S2)
 - `IsPGroup.iff_card.mpr ⟨n, hcard⟩` : derive `IsPGroup p G` from `Nat.card G = p^n`.
 - `IsPGroup.isNilpotent : IsPGroup p G → IsNilpotent G` (in `Mathlib.GroupTheory.Nilpotent`).
 - `IsNilpotent G → IsSolvable G` : Mathlib instance, derived via `infer_instance`.
 - `Nat.eq_zero_or_pos a : a = 0 ∨ 0 < a` for trivial-case dispatch.
 - `eq_or_ne p q : p = q ∨ p ≠ q` for prime-equality split.
 
-## Why three trivial cases collapse
+### Squarefree route (S4)
+- `IsZGroup.of_squarefree : Squarefree (Nat.card G) → IsZGroup G` (in `Mathlib.GroupTheory.SpecificGroups.ZGroup`).
+- `instance [Finite G] [IsZGroup G] : IsSolvable G` (same file).
+- `Nat.coprime_primes hp hq : Coprime p q ↔ p ≠ q` (in `Mathlib.Data.Nat.Prime.Basic`).
+- `Prime.squarefree : Prime x → Squarefree x` (in `Mathlib.Algebra.Squarefree.Basic`).
+  Apply via `hp.out.prime.squarefree` (where `hp : Fact p.Prime`).
+- `Nat.squarefree_mul (hmn : m.Coprime n) : Squarefree (m * n) ↔ Squarefree m ∧ Squarefree n`
+  (in `Mathlib.Data.Nat.Squarefree`).
+
+## Why three trivial cases plus pq case collapse
 
 All four trivial cases (`a = 0`, `b = 0`, `p = q`, `|G| = 1`) reduce to G being a
 p-group for some prime p:
@@ -35,10 +50,16 @@ p-group for some prime p:
 - `|G| = 1` → degenerate; absorbed by either of the above (since `p^0 = q^0 = 1`).
 
 Mathlib's `IsPGroup → IsNilpotent → IsSolvable` chain then closes them axiom-free.
-The remaining 25% of cases (`p ≠ q`, `a, b ≥ 1`) is exactly the content of
-Burnside's 1904 theorem.
 
-## Two proof routes for `burnside_pq_nontrivial`
+The squarefree case (`a = b = 1`, `p ≠ q`) reduces to the squarefree route:
+
+- `Nat.card G = p · q` with `p ≠ q` → `Squarefree (p · q)` → `IsZGroup G` → `IsSolvable G`.
+
+This eliminates the `a = b = 1` sub-case of the original `burnside_pq_nontrivial` axiom.
+The genuinely-open Lean content is now exactly: `|G|` divisible by `p²` or `q²`
+for distinct primes (`2 ≤ a ∨ 2 ≤ b`).
+
+## Two proof routes for `burnside_pq_nontrivial` (residual case, `2 ≤ a ∨ 2 ≤ b`)
 
 ### Route A: Burnside 1904 (character theory)
 - Pick minimal counterexample G; show G is non-abelian simple with no normal Sylow.
@@ -56,12 +77,25 @@ of `Mathlib.RepresentationTheory.Character.char_orthonormal`.
 - Apply transfer homomorphism on Sylow p-subgroup.
 - Show `P ∩ G' < P`, contradicting `G = G'` for non-abelian simple G.
 
-**Mathlib gap**: The focal subgroup theorem in full generality. Mathlib has
-`Mathlib.GroupTheory.Transfer` (transfer homomorphism) but the focal subgroup
-statement may need extension. Estimated 200-400 lines.
+**Mathlib status**: `Mathlib.GroupTheory.Focal` provides the focal subgroup
+definition, `transferFocal`, `commutator_inf_eq_focalSubgroup`, etc. Significant
+scaffolding exists for this route. Estimated 200-400 lines on top of this.
 
-**Recommendation**: Route B (character-free), since Mathlib's character-theory
-algebraic-integer infrastructure is the bigger gap.
+**Recommendation**: Route B (character-free), since Mathlib's `Focal` infrastructure
+is closer to ready than the algebraic-integer infrastructure for Route A.
+
+### Sub-case strategy (intermediate Sylow analysis)
+
+Before tackling the full Goldschmidt-Matsuyama proof, the residual axiom can be
+narrowed further by proving specific sub-cases via Sylow analysis:
+
+- `|G| = p² · q` (a=2, b=1): ~50-100 lines. Sylow's third theorem gives
+  `n_p | q` and `n_q | p²`; case analysis on (n_p, n_q) yields a normal Sylow.
+- `|G| = p · q²` (a=1, b=2): symmetric to above.
+- `|G| = p² · q²` (a=b=2): more delicate; Sylow + counting elements.
+
+Each of these subsumes a specific instance of the axiom. After all three are
+proved, the axiom narrows to `3 ≤ a ∨ 3 ≤ b`.
 
 ## Sharpness check
 
@@ -71,10 +105,17 @@ Burnside permits. Combined with the parent gallery entry's
 threshold for solvability: groups of order divisible by ≤ 2 primes are always
 solvable; groups divisible by ≥ 3 primes can fail (and A₅ is the smallest).
 
+Note: A₅ also defeats the squarefree route — `|A₅| = 60 = 2² · 3 · 5` has `2²`,
+so `squarefreeOrder_isSolvable` does not apply. The squarefree route is strictly
+weaker than the full Burnside theorem: it covers any number of distinct primes
+each to first power, but cannot handle `p²` for any prime.
+
 ## Path forward
 
-1. Decide Route A vs Route B (recommend B).
-2. Build the focal subgroup theorem in Mathlib.
-3. Apply transfer to a minimal counterexample → contradiction.
-4. Replace `axiom burnside_pq_nontrivial` with theorem.
-5. Submit Mathlib upstream PR (~1000 lines total).
+1. **(S5)** Prove `|G| = p² · q` axiom-free via Sylow analysis (~50-100 lines).
+2. **(S6)** Prove `|G| = p · q²` axiom-free (symmetric, ~30-50 lines).
+3. **(S7)** Prove `|G| = p² · q²` axiom-free (~80-150 lines).
+4. **(S8+)** Build Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`
+   (~200-400 lines). Closes ALL remaining cases.
+5. **(Final)** Replace `axiom burnside_pq_nontrivial` with theorem; sync meta.json;
+   submit Mathlib upstream PR (~1000 lines total).

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -1,53 +1,61 @@
 # Current State
 
-**Phase**: ORIENT
-**Since**: 2026-05-08T03:10:00Z
-**Iteration**: 2
+**Phase**: ACT
+**Since**: 2026-05-08T07:00:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-Phase-2 axiomatization of Burnside's pᵃqᵇ theorem committed: scaffold +
-trivial cases proved axiom-free + non-trivial case isolated as a single
-named axiom + main theorem combining both.
+Iteration 4 axiom-narrowing committed: `burnside_pq_pq_case` (axiom-free
+`a = b = 1` case) plus `squarefreeOrder_isSolvable` (general squarefree-order
+bridge), backed by Mathlib's `IsZGroup.of_squarefree`. The axiom
+`burnside_pq_nontrivial` was narrowed to require `2 ≤ a ∨ 2 ≤ b`; the
+`a = b = 1` sub-case is no longer axiom-dependent.
 
 ## Active Approach
 
-Reduce trivial cases to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`
-chain (axiom-free). Isolate the genuinely-open content (`p ≠ q`,
-`a ≥ 1`, `b ≥ 1`) as `burnside_pq_nontrivial` axiom.
+The squarefree route exhausts what `IsZGroup` can prove: any squarefree-order
+finite group is solvable (covers `pq`, `pqr`, `pqrs`, …). It does NOT extend
+to `pᵃqᵇ` with `a ≥ 2` or `b ≥ 2`. The next phase is Sylow-analysis-based
+sub-case proofs (`p²q`, `pq²`, `p²q²`) on the way to a full
+Goldschmidt-Matsuyama discharge of the axiom.
 
 ## Blockers
 
-The non-trivial case requires either character theory + algebraic-integer
-hypotheses (Burnside 1904) or transfer + focal subgroup theory
-(Goldschmidt-Matsuyama 1970s). Neither is in Mathlib at sufficient
-generality. Estimated 400-1000 lines for a full upstream-quality proof.
+The residual axiom (orders divisible by `p²` or `q²` for distinct primes)
+requires either character theory + algebraic-integer hypotheses or
+transfer + focal subgroup theory. Mathlib's `Mathlib.GroupTheory.Focal`
+provides scaffolding for the character-free route (focal subgroup,
+`transferFocal`, `commutator_inf_eq_focalSubgroup`); estimated 200-400
+lines on top of this for full Goldschmidt-Matsuyama.
 
 ## Next Action
 
-1. Eliminate `burnside_pq_nontrivial` via Goldschmidt-Matsuyama: extend
-   Mathlib's transfer infrastructure with the focal subgroup theorem,
-   then apply transfer on a Sylow p-subgroup. Recommended as the
-   character-free route since it avoids Mathlib's algebraic-integer gap.
-2. Sharpness check: cite parent's `¬ IsSolvable (Equiv.Perm (Fin 5))`
-   and observe `|A₅| = 60` has 3 prime factors — confirming the bound.
-3. Coordinate with Mathlib reviewers on scoping a full upstream PR.
+1. **(S5)** Prove `|G| = p² · q` axiom-free via Sylow analysis (~50-100 lines).
+   Sylow's third theorem: `n_p ≡ 1 (mod p)` and `n_p | q`; `n_q ≡ 1 (mod q)`
+   and `n_q | p²`. Case-analysis on `(n_p, n_q)` yields a normal Sylow.
+2. **(S6)** Prove `|G| = p · q²` axiom-free (symmetric, ~30-50 lines).
+3. **(S7)** Prove `|G| = p² · q²` axiom-free (~80-150 lines).
+4. **(S8+)** Build Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`.
 
-## Iteration 2 Builds (researcher-3, 2026-05-08)
+## Iteration 4 Builds (researcher-1, 2026-05-08)
 
-- Created `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (221 lines).
-- `pGroup_isSolvable`: explicit packaging of Mathlib's chain
-  `IsPGroup → IsNilpotent → IsSolvable` (axiom-free, single line).
-- `burnside_pq_a_zero` (axiom-free): trivial case `a = 0`, `G` is a `q`-group.
-- `burnside_pq_b_zero` (axiom-free): trivial case `b = 0`, `G` is a `p`-group.
-- `burnside_pq_same_prime` (axiom-free): trivial case `p = q`, `G` is a
-  `p`-group of combined exponent.
-- `axiom burnside_pq_nontrivial`: isolated open content, `p ≠ q`,
-  `a ≥ 1`, `b ≥ 1`.
-- `burnside_pq` (uses axiom): main theorem combining trivial + non-trivial.
-- 3 sanity-check `example`s at boundary cardinalities (`|G| = 1`,
-  `|G| = p`, `|G| = p^a`), all axiom-free via `burnside_pq`.
-- Added `import Proofs.AbelRuffiniGaloisExtensionsOQ07` to `proofs/Proofs.lean`.
-- Created gallery entry `src/data/proofs/abel-ruffini-galois-extensions-oq-07/`.
+- Updated `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (277→384 lines).
+- Added `import Mathlib.GroupTheory.SpecificGroups.ZGroup`.
+- `squarefreeOrder_isSolvable`: axiom-free `Squarefree (Nat.card G) → IsSolvable G`
+  via `IsZGroup.of_squarefree` + `[Finite][IsZGroup] → IsSolvable` instance.
+- `burnside_pq_pq_case`: axiom-free `a = b = 1` case (`|G| = p · q`, `p ≠ q`)
+  via `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`.
+- Narrowed `burnside_pq_nontrivial`: added hypothesis `2 ≤ a ∨ 2 ≤ b`.
+- Updated `burnside_pq` main theorem: `by_cases h11 : a = 1 ∧ b = 1` to peel
+  off the squarefree case axiom-free, then derive `2 ≤ a ∨ 2 ≤ b` for the
+  axiom invocation.
+- 2 new sanity-check examples: `|G| = pq` via `burnside_pq_pq_case`;
+  `|G| = 30` via `squarefreeOrder_isSolvable` (squarefree route beyond two
+  primes).
+- Updated gallery entry meta.json (lineCount 278→384, theoremCount 8→10,
+  axiomCount unchanged at 1, sections updated, originalContributions and
+  assumptions updated).
 
-**Counts**: lineCount 221, theoremCount 5, axiomCount 1, sorries 0.
+**Counts**: lineCount 384, theoremCount 10, axiomCount 1 (narrowed),
+sorries 0.

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini-galois-extensions-oq-07",
   "title": "Burnside's pᵃqᵇ Theorem (Phase-2 Axiomatization)",
   "slug": "abel-ruffini-galois-extensions-oq-07",
-  "description": "Phase-2 formalization of Burnside's pᵃqᵇ theorem (1904): every finite group of order p^a · q^b (for primes p, q and naturals a, b) is solvable. The trivial cases (a = 0, b = 0, p = q) reduce axiom-free to Mathlib's `IsPGroup → IsNilpotent → IsSolvable` chain. The non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`) is axiomatized as `burnside_pq_nontrivial` — the genuinely-open Lean content, requiring either character theory + algebraic-integer hypotheses (Burnside 1904) or transfer + focal-subgroup theory (Goldschmidt-Matsuyama 1970s). The bound is sharp: |A₅| = 60 = 2² · 3 · 5 has three distinct primes and A₅ is not solvable.",
+  "description": "Phase-2 formalization of Burnside's pᵃqᵇ theorem (1904): every finite group of order p^a · q^b (for primes p, q and naturals a, b) is solvable. The trivial cases (a = 0, b = 0, p = q) reduce axiom-free to Mathlib's `IsPGroup → IsNilpotent → IsSolvable` chain. The squarefree-order case (a = b = 1, p ≠ q, |G| = pq) reduces axiom-free to Mathlib's `IsZGroup.of_squarefree`. The remaining non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, `2 ≤ a ∨ 2 ≤ b`) is axiomatized as `burnside_pq_nontrivial` — the genuinely-open Lean content, requiring either character theory + algebraic-integer hypotheses (Burnside 1904) or transfer + focal-subgroup theory (Goldschmidt-Matsuyama 1970s). The bound is sharp: |A₅| = 60 = 2² · 3 · 5 has three distinct primes and A₅ is not solvable.",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Burnside_theorem",
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 278,
+    "lineCount": 384,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -47,6 +47,26 @@
         "theorem": "IsNilpotent → IsSolvable (instance)",
         "description": "Mathlib's typeclass instance: every nilpotent group is solvable.",
         "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "IsZGroup.of_squarefree",
+        "description": "A finite group of squarefree order is a Z-group (every Sylow subgroup is cyclic).",
+        "module": "Mathlib.GroupTheory.SpecificGroups.ZGroup"
+      },
+      {
+        "theorem": "IsZGroup → IsSolvable (instance)",
+        "description": "Mathlib's typeclass instance: every finite Z-group is solvable.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.ZGroup"
+      },
+      {
+        "theorem": "Nat.squarefree_mul",
+        "description": "For coprime m, n, Squarefree (m * n) ↔ Squarefree m ∧ Squarefree n.",
+        "module": "Mathlib.Data.Nat.Squarefree"
+      },
+      {
+        "theorem": "Nat.coprime_primes",
+        "description": "For primes p, q, Coprime p q ↔ p ≠ q.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
       }
     ],
     "originalContributions": [
@@ -54,15 +74,17 @@
       "burnside_pq_a_zero: axiom-free proof of Burnside for `a = 0` (G is a q-group).",
       "burnside_pq_b_zero: axiom-free proof of Burnside for `b = 0` (G is a p-group).",
       "burnside_pq_same_prime: axiom-free proof of Burnside for `p = q` (G is a p-group of order p^(a+b)).",
-      "axiom burnside_pq_nontrivial: the genuinely-open content (`p ≠ q`, `a ≥ 1`, `b ≥ 1`) isolated as a single named axiom; full proof requires either character theory + algebraic integers (Burnside 1904) or transfer + focal subgroup (Goldschmidt-Matsuyama 1970s) — neither currently in Mathlib at sufficient generality.",
-      "burnside_pq: main theorem combining trivial cases + axiom into the unified statement Nat.card G = p^a · q^b → IsSolvable G.",
-      "Three sanity-check examples: trivial group (|G|=1), prime-order group, prime-power group — all axiom-free.",
+      "squarefreeOrder_isSolvable: axiom-free packaging of Mathlib's IsZGroup.of_squarefree → IsSolvable chain. Subsumes the a = b = 1 case of Burnside and extends beyond two primes for squarefree orders (e.g. |G| = 30 = 2·3·5).",
+      "burnside_pq_pq_case: axiom-free proof of Burnside for `a = b = 1` (|G| = p · q, squarefree). Reduces via Nat.coprime_primes + Prime.squarefree + Nat.squarefree_mul.",
+      "axiom burnside_pq_nontrivial (NARROWED in Iteration 4): the genuinely-open content (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`); the a = b = 1 case is now axiom-free. Full proof of the residual axiom requires either character theory + algebraic integers (Burnside 1904) or transfer + focal subgroup (Goldschmidt-Matsuyama 1970s) — neither currently in Mathlib at sufficient generality.",
+      "burnside_pq: main theorem combining trivial cases + squarefree case + axiom into the unified statement Nat.card G = p^a · q^b → IsSolvable G.",
+      "Four sanity-check examples: trivial group (|G|=1), prime-order group, prime-power group, |G| = 30 (squarefree three-prime) — all axiom-free.",
       "alternatingGroupFin5_card: axiom-free proof that |A₅| = 2²·3·5, exhibiting the three distinct prime factors that make A₅ a sharpness witness.",
       "alternatingGroupFin5_not_solvable: axiom-free proof that A₅ is not solvable, via reduction to Equiv.Perm.not_solvable (Fin 5) through the short exact sequence A₅ → S₅ → ℤ/2.",
-      "burnside_pq_sharp: sharpness witness combining the two above — demonstrates that the analogue of burnside_pq for THREE distinct primes fails (no `burnside_pqr` theorem can hold without further hypotheses)."
+      "burnside_pq_sharp: sharpness witness combining the two above — demonstrates that the analogue of burnside_pq for THREE distinct primes fails (no `burnside_pqr` theorem can hold without further hypotheses; A₅ also defeats the squarefree route since 60 has 2²)."
     ],
-    "assumptions": "1 axiom: `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`). The trivial cases (`a = 0`, `b = 0`, `p = q`) are theorems, all reducing to Mathlib's existing `IsPGroup → IsNilpotent → IsSolvable` chain. The axiom isolates the genuinely-open Lean content; a full proof would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route).",
-    "theoremCount": 8,
+    "assumptions": "1 axiom (narrowed in Iteration 4): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. The axiom isolates the genuinely-open Lean content (orders divisible by `p²` or `q²` for distinct primes); a full proof would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route).",
+    "theoremCount": 10,
     "definitionCount": 0
   },
   "overview": {
@@ -98,42 +120,50 @@
     {
       "id": "trivial-cases",
       "title": "Part II: Trivial cases (a = 0, b = 0, p = q)",
-      "startLine": 62,
-      "endLine": 89,
+      "startLine": 65,
+      "endLine": 98,
       "summary": "`burnside_pq_a_zero`: when $a = 0$, $|G| = q^b$ so $G$ is a $q$-group; apply Part I. `burnside_pq_b_zero`: symmetric to $a = 0$. `burnside_pq_same_prime`: when $p = q$, $|G| = p^{a+b}$ so $G$ is a $p$-group of combined exponent. All three axiom-free.",
       "mathContext": "These cases are all instances of $|G| = $ prime power, hence covered by Part I. The arithmetic step is: $p^0 \\cdot q^b = q^b$, $p^a \\cdot q^0 = p^a$, $p^a \\cdot p^b = p^{a+b}$ — each obtained via `simpa` or `pow_add`."
     },
     {
+      "id": "squarefree-case",
+      "title": "Part II.5: Squarefree-order case (axiom-free, via IsZGroup)",
+      "startLine": 100,
+      "endLine": 152,
+      "summary": "`squarefreeOrder_isSolvable`: bridges `Squarefree (Nat.card G) → IsSolvable G` via Mathlib's `IsZGroup.of_squarefree` + `[IsZGroup G] [Finite G] → IsSolvable G` instance. `burnside_pq_pq_case`: specializes to `a = b = 1` (`|G| = p · q`, `p ≠ q`) using `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`. Both axiom-free.",
+      "mathContext": "A finite group of squarefree order is a Z-group (every Sylow subgroup is cyclic), and Z-groups are solvable. This subsumes the `a = b = 1` Burnside case (`|G| = pq` is squarefree when `p ≠ q` are prime) and extends beyond two primes for squarefree orders (e.g. `|G| = 30 = 2·3·5` is solvable axiom-free). It does NOT extend to `|G| = pᵃqᵇ` with `a ≥ 2` or `b ≥ 2`: `p²` violates squarefreeness, so the `2 ≤ a ∨ 2 ≤ b` case still needs new infrastructure."
+    },
+    {
       "id": "axiom",
-      "title": "Part III: Non-trivial case (axiomatized)",
-      "startLine": 91,
-      "endLine": 124,
-      "summary": "`burnside_pq_nontrivial`: axiom asserting Burnside's theorem in the residual case `p ≠ q`, `a ≥ 1`, `b ≥ 1`. Carries proof sketches for both the character-theoretic (Burnside 1904) and character-free (Goldschmidt-Matsuyama 1970s) routes.",
-      "mathContext": "This is the genuinely-open Lean content. A formalized proof would be a substantial Mathlib upstream contribution (~400-1000 lines depending on route)."
+      "title": "Part III: Non-trivial case (axiomatized, narrowed to 2 ≤ a ∨ 2 ≤ b)",
+      "startLine": 154,
+      "endLine": 188,
+      "summary": "`burnside_pq_nontrivial`: axiom asserting Burnside's theorem in the residual case `p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`. The hypothesis was narrowed in Iteration 4: the `a = b = 1` sub-case is now axiom-free (Part II.5). Carries proof sketches for both the character-theoretic (Burnside 1904) and character-free (Goldschmidt-Matsuyama 1970s) routes.",
+      "mathContext": "This is the genuinely-open Lean content: orders divisible by `p²` or `q²` for distinct primes. A formalized proof would be a substantial Mathlib upstream contribution (~400-1000 lines depending on route)."
     },
     {
       "id": "main-theorem",
       "title": "Part IV: Main theorem",
-      "startLine": 126,
-      "endLine": 153,
-      "summary": "`burnside_pq`: combines the three axiom-free trivial cases with the conjectural `burnside_pq_nontrivial` axiom into the unified statement `Nat.card G = p^a · q^b → IsSolvable G`. Case-splits on `a = 0`, `b = 0`, `p = q` (in that order) using `Nat.eq_zero_or_pos` and `eq_or_ne`.",
-      "mathContext": "The case split is exhaustive: any combination of $(a, b, p, q)$ with $a = 0$ or $b = 0$ or $p = q$ falls into Part II; the residue is exactly the axiom's hypothesis."
+      "startLine": 190,
+      "endLine": 231,
+      "summary": "`burnside_pq`: combines the three axiom-free trivial cases with the squarefree-order case (a = b = 1) and the conjectural `burnside_pq_nontrivial` axiom into the unified statement `Nat.card G = p^a · q^b → IsSolvable G`. Case-splits on `a = 0`, `b = 0`, `p = q`, then `a = 1 ∧ b = 1` (axiom-free), with the residue dispatched to the (narrowed) axiom.",
+      "mathContext": "The case split is exhaustive: any combination of $(a, b, p, q)$ with $a = 0$ or $b = 0$ or $p = q$ falls into Part II; `a = b = 1` with `p ≠ q` falls into Part II.5; the residue (`p ≠ q`, `2 ≤ a ∨ 2 ≤ b`) is exactly the axiom's hypothesis."
     },
     {
       "id": "sanity-checks",
       "title": "Part V: Sanity checks",
-      "startLine": 155,
-      "endLine": 178,
-      "summary": "Three `example`s that exercise `burnside_pq` axiom-free at the boundaries: trivial group ($|G| = 1 = 2^0 \\cdot 3^0$), prime-order group ($|G| = p = p^1 \\cdot 2^0$), and pure prime-power group ($|G| = p^a = p^a \\cdot 2^0$). Each picks $q = 2$ as a witness so the example doesn't need an additional prime hypothesis.",
-      "mathContext": "These examples never invoke the axiom — they confirm that the trivial-case branches handle all degenerate cardinalities sensibly. The final `example` is the most general (any prime power)."
+      "startLine": 233,
+      "endLine": 281,
+      "summary": "Four `example`s that exercise the axiom-free portions of the file at the boundaries: trivial group ($|G| = 1 = 2^0 \\cdot 3^0$), prime-order group ($|G| = p = p^1 \\cdot 2^0$), pure prime-power group ($|G| = p^a = p^a \\cdot 2^0$), and squarefree three-prime group ($|G| = 30 = 2 \\cdot 3 \\cdot 5$). The first three use `burnside_pq` directly; the fourth uses `squarefreeOrder_isSolvable`.",
+      "mathContext": "These examples never invoke the axiom — they confirm that the trivial-case branches handle all degenerate cardinalities sensibly, AND that the squarefree route extends beyond two primes."
     },
     {
       "id": "sharpness",
       "title": "Part VI: Sharpness witness",
-      "startLine": 182,
-      "endLine": 225,
+      "startLine": 285,
+      "endLine": 333,
       "summary": "`alternatingGroupFin5_card`: $|A_5| = 2^2 \\cdot 3 \\cdot 5$ via `Nat.card_eq_fintype_card` + `native_decide`. `alternatingGroupFin5_not_solvable`: A₅ is not solvable, via `solvable_of_ker_le_range (alternatingGroup (Fin 5)).subtype Equiv.Perm.sign` then `Equiv.Perm.not_solvable (Fin 5)`. `burnside_pq_sharp`: conjunction of the two — the canonical sharpness witness.",
-      "mathContext": "Burnside permits at most TWO distinct prime factors. $|A_5| = 60 = 2^2 \\cdot 3 \\cdot 5$ has three distinct primes — exactly one more — and A₅ is the smallest non-solvable group. So `burnside_pq` is sharp: no extension to three distinct primes can hold. The proof uses the kernel-of-sign + range-of-subtype short exact sequence A₅ → S₅ → ℤ/2 to lift solvability of A₅ to S₅, then contradicts the Mathlib fact `Equiv.Perm.not_solvable` for $n \\geq 5$."
+      "mathContext": "Burnside permits at most TWO distinct prime factors. $|A_5| = 60 = 2^2 \\cdot 3 \\cdot 5$ has three distinct primes — exactly one more — and A₅ is the smallest non-solvable group. So `burnside_pq` is sharp: no extension to three distinct primes can hold. A₅ ALSO defeats the squarefree route (`squarefreeOrder_isSolvable` does not apply since 60 has $2^2$). The proof uses the kernel-of-sign + range-of-subtype short exact sequence A₅ → S₅ → ℤ/2 to lift solvability of A₅ to S₅, then contradicts the Mathlib fact `Equiv.Perm.not_solvable` for $n \\geq 5$."
     }
   ],
   "crossReferences": [
@@ -154,8 +184,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Phase-2 axiomatization of Burnside's pᵃqᵇ theorem. The trivial cases (`a = 0`, `b = 0`, `p = q`) are proved axiom-free via Mathlib's `IsPGroup → IsNilpotent → IsSolvable` chain — no new content needed. The non-trivial case (two distinct primes, both with positive exponent) is captured as a single axiom `burnside_pq_nontrivial`. The combined theorem `burnside_pq` covers all $(a, b, p, q)$.",
-    "implications": "This file exposes the open Lean content cleanly. The 75% of cases that don't need new content are resolved unconditionally; only the central two-prime case awaits a Mathlib upstream contribution. The axiom isolates exactly what is needed: replacing `axiom burnside_pq_nontrivial` by a theorem would automatically close all of `burnside_pq` (and the main theorem) without any further work in this file. The path forward is therefore concrete: build the focal subgroup theorem in Mathlib, then formalize Goldschmidt-Matsuyama.",
+    "summary": "Phase-2 axiomatization of Burnside's pᵃqᵇ theorem (Iteration 4 narrowed). The trivial cases (`a = 0`, `b = 0`, `p = q`) are proved axiom-free via Mathlib's `IsPGroup → IsNilpotent → IsSolvable` chain. The squarefree-order case (`a = b = 1`, `p ≠ q`) is proved axiom-free via Mathlib's `IsZGroup.of_squarefree → IsSolvable` chain. The residual non-trivial case (two distinct primes, at least one with exponent ≥ 2) is captured as a narrowed axiom `burnside_pq_nontrivial`. The combined theorem `burnside_pq` covers all $(a, b, p, q)$.",
+    "implications": "This file exposes the open Lean content cleanly. The cases that don't need new content are resolved unconditionally (now including `|G| = pq` axiom-free); only orders divisible by `p²` or `q²` for distinct primes await a Mathlib upstream contribution. The axiom isolates exactly what is needed: replacing `axiom burnside_pq_nontrivial` by a theorem would automatically close all of `burnside_pq` (and the main theorem) without any further work in this file. The path forward is therefore concrete: build the focal subgroup theorem in Mathlib (`Mathlib.GroupTheory.Focal` provides scaffolding), then formalize Goldschmidt-Matsuyama. Intermediate sub-cases (`p²q`, `pq²`, `p²q²`) are independently approachable via Sylow analysis.",
     "openQuestions": [
       "Eliminate `burnside_pq_nontrivial` via the Goldschmidt-Matsuyama 1970s character-free proof. Concrete plan: extend Mathlib's transfer infrastructure with the focal subgroup theorem, then apply transfer on a Sylow p-subgroup of a minimal counterexample G to derive that P ∩ G' < P (contradicting G = G' for non-abelian simple G). Estimated ~400-800 lines.",
       "Alternative: eliminate `burnside_pq_nontrivial` via Burnside's original 1904 character-theoretic proof. Requires building the algebraic-integer hypothesis `(|G|/χ(1))χ(g) ∈ ℤ̄_K` in Mathlib's character theory framework (~100-200 additional lines on top of `Mathlib.RepresentationTheory.Character.char_orthonormal`).",
@@ -170,14 +200,15 @@
       "Mathlib.GroupTheory.Solvable",
       "Mathlib.GroupTheory.Nilpotent",
       "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.GroupTheory.SpecificGroups.ZGroup",
       "Mathlib.Tactic"
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 278,
+    "lineCount": 384,
     "axiomCount": 1,
-    "theoremCount": 8,
-    "substantiveTheoremCount": 8,
+    "theoremCount": 10,
+    "substantiveTheoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
     "sorries": 0

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -29,22 +29,22 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T05:15:00.000Z",
-    "iteration": 3,
-    "focus": "Iteration 3 (researcher-8, 2026-05-08): Sharpness witness COMMITTED. Added Part VI (3 axiom-free theorems demonstrating |A₅| = 2²·3·5 is non-solvable). File now 277 lines / 8 theorems / 1 axiom / 0 sorries. Build verified. The bound `pᵃqᵇ` is now formally sharp in the gallery.",
+    "since": "2026-05-08T07:00:00.000Z",
+    "iteration": 4,
+    "focus": "Iteration 4 (researcher-1, 2026-05-08): Squarefree-order axiom-narrowing COMMITTED. Added Part II.5 (squarefreeOrder_isSolvable + burnside_pq_pq_case) — proves the `a = b = 1` case (`|G| = p · q`) AXIOM-FREE via Mathlib's `IsZGroup.of_squarefree → IsSolvable` chain. The axiom `burnside_pq_nontrivial` was narrowed to require `2 ≤ a ∨ 2 ≤ b`; the `a = b = 1` sub-case now no longer depends on it. File now 384 lines / 10 theorems / 1 axiom (narrowed) / 0 sorries. The genuinely-open Lean content is now exactly: orders divisible by `p²` or `q²` for distinct primes.",
     "blockers": [
-      "Mathlib lacks: (1) the algebraic-integer lemma `|G|/χ(1) ∈ ℤ̄_K` for a non-trivial irreducible character χ on a non-conjugacy class, key for the original Burnside proof; (2) the focal subgroup theorem and transfer-based character-free Burnside proof (Goldschmidt/Matsuyama).",
+      "Mathlib lacks: (1) the algebraic-integer lemma `|G|/χ(1) ∈ ℤ̄_K` for a non-trivial irreducible character χ on a non-conjugacy class, key for the original Burnside proof; (2) the focal subgroup theorem and transfer-based character-free Burnside proof (Goldschmidt/Matsuyama). Note: Mathlib has `Mathlib.GroupTheory.Focal` (focal subgroup definition + transfer to focal quotient), so partial scaffolding exists for the character-free route.",
       "Mathlib's character theory needs algebraically-closed-field hypotheses; concretizing for ℂ-valued characters requires `Complex` ↔ `IsAlgClosed` bridge already in Mathlib but care needed."
     ],
-    "nextAction": "Session 4+: Pursue Goldschmidt-Matsuyama character-free proof of `burnside_pq_nontrivial`. First sub-goal: extend Mathlib transfer infrastructure with the focal subgroup theorem (~200-400 lines). Alternative: the Burnside 1904 character-theoretic route requiring algebraic-integer hypotheses on |G|/χ(1)·χ(g).",
+    "nextAction": "Session 5+: Continue narrowing the axiom. Next sub-cases worth axiom-free attempts (in order of accessibility): (1) `|G| = p² · q` via Sylow analysis (~50-100 lines, classical); (2) `|G| = p · q²` symmetric to (1); (3) `|G| = p² · q²` more delicate. Beyond these, the Goldschmidt-Matsuyama character-free proof would close the remaining axiom (~200-400 lines on top of `Mathlib.GroupTheory.Focal`).",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S3 (researcher-8, 2026-05-08, ACT): **Sharpness witness COMMITTED**. Added Part VI to AbelRuffiniGaloisExtensionsOQ07.lean (221→277 lines, 5→8 theorems, 1 axiom unchanged, 0 sorries). Three new theorems: `alternatingGroupFin5_card` (Nat.card A₅ = 2²·3·5 via native_decide), `alternatingGroupFin5_not_solvable` (¬ IsSolvable A₅ via solvable_of_ker_le_range + Equiv.Perm.not_solvable), `burnside_pq_sharp` (their conjunction — canonical sharpness witness demonstrating `burnside_pq` cannot extend to three distinct primes). Added import Mathlib.GroupTheory.SpecificGroups.Alternating. Build verified.\n\nS2 (researcher-3, 2026-05-08, ORIENT): Phase-2 scaffold COMMITTED. Created `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (221 lines, 5 theorems, 1 axiom, 0 sorries). Trivial cases (a=0, b=0, p=q) proved AXIOM-FREE via Mathlib IsPGroup → IsNilpotent → IsSolvable. Non-trivial case isolated as axiom `burnside_pq_nontrivial`.\n\nS1 (2026-05-07, OBSERVE): Identified the seed open question as #7 of the parent gallery. Documented two proof strategies (character-theoretic vs Goldschmidt-Matsuyama character-free) and their tradeoffs.",
+    "progressSummary": "S4 (researcher-1, 2026-05-08, ACT): **Squarefree-order axiom-narrowing COMMITTED**. Added Part II.5 to AbelRuffiniGaloisExtensionsOQ07.lean (277→384 lines, 8→10 theorems, 1 axiom narrowed, 0 sorries). Two new theorems: `squarefreeOrder_isSolvable` (Squarefree |G| → IsSolvable G via Mathlib's IsZGroup.of_squarefree + the [Finite][IsZGroup]→IsSolvable instance), `burnside_pq_pq_case` (axiom-free a=b=1 case for |G|=p·q via Nat.coprime_primes + Prime.squarefree + Nat.squarefree_mul). The axiom `burnside_pq_nontrivial` now requires `2 ≤ a ∨ 2 ≤ b`; the `a = b = 1` sub-case is no longer axiom-dependent. The main theorem `burnside_pq` now dispatches axiom-free to the pq case before falling back to the (narrowed) axiom. Two new sanity-check examples added: |G|=pq via burnside_pq_pq_case; |G|=30 via squarefreeOrder_isSolvable (showing the squarefree route extends beyond two primes). Added import Mathlib.GroupTheory.SpecificGroups.ZGroup.\n\nS3 (researcher-8, 2026-05-08, ACT): Sharpness witness COMMITTED. Added Part VI (3 axiom-free theorems demonstrating |A₅| = 2²·3·5 is non-solvable). 221→277 lines, 5→8 theorems.\n\nS2 (researcher-3, 2026-05-08, ORIENT): Phase-2 scaffold COMMITTED. Created `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (221 lines, 5 theorems, 1 axiom, 0 sorries). Trivial cases (a=0, b=0, p=q) proved AXIOM-FREE via Mathlib IsPGroup → IsNilpotent → IsSolvable. Non-trivial case isolated as axiom `burnside_pq_nontrivial`.\n\nS1 (2026-05-07, OBSERVE): Identified the seed open question as #7 of the parent gallery. Documented two proof strategies (character-theoretic vs Goldschmidt-Matsuyama character-free) and their tradeoffs.",
     "builtItems": [
       "S2 — proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean (221 lines, 5 theorems, 1 axiom)",
       "S2 — pGroup_isSolvable: explicit packaging of Mathlib's IsPGroup → IsNilpotent → IsSolvable chain (axiom-free)",
@@ -60,7 +60,14 @@
       "S3 — alternatingGroupFin5_card (axiom-free): Nat.card (alternatingGroup (Fin 5)) = 2^2 * 3 * 5; proof: Nat.card_eq_fintype_card + native_decide",
       "S3 — alternatingGroupFin5_not_solvable (axiom-free): ¬ IsSolvable (alternatingGroup (Fin 5)); proof: lift solvability of A₅ to S₅ via solvable_of_ker_le_range + Equiv.Perm.sign + alternatingGroup.subtype, contradict Equiv.Perm.not_solvable (Fin 5)",
       "S3 — burnside_pq_sharp (axiom-free): conjunction of the two — canonical Burnside-sharpness witness",
-      "S3 — Added import Mathlib.GroupTheory.SpecificGroups.Alternating (for alternatingGroup)"
+      "S3 — Added import Mathlib.GroupTheory.SpecificGroups.Alternating (for alternatingGroup)",
+      "S4 — proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean Part II.5: Squarefree-order axiom-narrowing (277→384 lines, +2 theorems)",
+      "S4 — squarefreeOrder_isSolvable (axiom-free): Squarefree (Nat.card G) → IsSolvable G via IsZGroup.of_squarefree + the [Finite][IsZGroup] → IsSolvable instance",
+      "S4 — burnside_pq_pq_case (axiom-free): a=b=1 case |G| = p · q (p ≠ q) via Nat.coprime_primes + Prime.squarefree + Nat.squarefree_mul",
+      "S4 — Narrowed axiom burnside_pq_nontrivial: now requires 2 ≤ a ∨ 2 ≤ b (the a=b=1 case is axiom-free)",
+      "S4 — Updated burnside_pq main theorem dispatch: by_cases h11 : a = 1 ∧ b = 1 added before axiom fallback",
+      "S4 — 2 new sanity-check examples: |G| = pq via burnside_pq_pq_case (axiom-free); |G| = 30 via squarefreeOrder_isSolvable (squarefree route beyond two primes)",
+      "S4 — Added import Mathlib.GroupTheory.SpecificGroups.ZGroup"
     ],
     "insights": [
       "S2 — The four trivial cases (`a = 0`, `b = 0`, `p = q`, `|G| = 1`) all reduce to G being a p-group for some prime p, which Mathlib's `IsPGroup → IsNilpotent → IsSolvable` chain handles axiom-free. So 75% of the cases of Burnside's theorem need NO new mathematical content — only the genuinely two-prime case (p ≠ q, a ≥ 1, b ≥ 1) carries new Lean content.",
@@ -82,7 +89,16 @@
       "S3 — `Nat.card (alternatingGroup (Fin 5)) = 2^2 * 3 * 5` is decided by `native_decide` after `Nat.card_eq_fintype_card`. The `Fintype` route is necessary because `Nat.card` does not reduce to a literal under `decide` directly.",
       "S3 — The non-solvability of A₅ reduces cleanly to `Equiv.Perm.not_solvable (Fin 5)` (Mathlib): if A₅ were solvable, lifting through the inclusion `(alternatingGroup (Fin 5)).subtype` and the kernel of `Equiv.Perm.sign` gives `IsSolvable (Equiv.Perm (Fin 5))` via `solvable_of_ker_le_range`, contradicting Mathlib. This is the canonical Lean idiom and is reused (verbatim) from InverseGaloisA5.lean.",
       "S3 — Sharpness is now FORMAL, not narrative: the gallery entry no longer just *states* that Burnside is sharp at 60; it *witnesses* sharpness with a single conjunction theorem. This converts the keyInsight into machine-checked content.",
-      "S3 — Pedagogical observation: the file now demonstrates BOTH the positive and negative direction at the prime-multiplicity threshold. burnside_pq says ≤ 2 primes ⇒ solvable (axiomatized for the residual case); burnside_pq_sharp says 3 primes does NOT imply solvable (axiom-free witness). Together they pin the exact threshold."
+      "S3 — Pedagogical observation: the file now demonstrates BOTH the positive and negative direction at the prime-multiplicity threshold. burnside_pq says ≤ 2 primes ⇒ solvable (axiomatized for the residual case); burnside_pq_sharp says 3 primes does NOT imply solvable (axiom-free witness). Together they pin the exact threshold.",
+      "S4 — Mathlib's `IsZGroup.of_squarefree` (Mathlib.GroupTheory.SpecificGroups.ZGroup) bridges `Squarefree (Nat.card G) → IsZGroup G`; combined with the `[Finite G] [IsZGroup G] → IsSolvable G` instance (same file), this gives `Squarefree |G| → IsSolvable G` in TWO LINES. This is the axiom-free path for the `a = b = 1` Burnside case.",
+      "S4 — `Nat.coprime_primes hp hq : Coprime p q ↔ p ≠ q` is the canonical idiom for getting coprimality of two distinct primes (in `Mathlib.Data.Nat.Prime.Basic`).",
+      "S4 — `Prime.squarefree` (in `Mathlib.Algebra.Squarefree.Basic`): every prime is squarefree. Apply via `hp.out.prime.squarefree` (where `hp : Fact p.Prime`); note `.prime` is needed because `Nat.Prime → Prime`.",
+      "S4 — Squarefreeness of `pq` (distinct primes) is provable via `Nat.squarefree_mul hcop` once coprimality is established. The Nat-specific version is `(hmn : m.Coprime n) → Squarefree (m * n) ↔ Squarefree m ∧ Squarefree n`.",
+      "S4 — Axiom narrowing: changing `axiom burnside_pq_nontrivial` from `(ha : 1 ≤ a) (hb : 1 ≤ b)` to `(ha : 1 ≤ a) (hb : 1 ≤ b) (hab : 2 ≤ a ∨ 2 ≤ b)` is a legitimate refactor that strictly weakens the assumed content. The axiomCount stays 1 but the unverified hypothesis is more restrictive — the `a = b = 1` case is no longer assumed.",
+      "S4 — Dispatch pattern in `burnside_pq` for the narrowed axiom: `by_cases h11 : a = 1 ∧ b = 1` to peel off the squarefree case axiom-free, then `by_contra h ; push_neg at h ; obtain ⟨ha2, hb2⟩ := h ; exact h11 ⟨by omega, by omega⟩` to derive `2 ≤ a ∨ 2 ≤ b` for the axiom invocation. Clean and minimal.",
+      "S4 — Sanity check: `decide` does NOT work for `Squarefree 30` (`Nat.instDecidablePredSquarefree 30` doesn't reduce); use `native_decide` instead. Useful for any concrete-cardinality squarefreeness sanity check.",
+      "S4 — Squarefree-order route is broader than just `pq`: `squarefreeOrder_isSolvable` proves solvability for ANY finite group of squarefree order (e.g. |G| = 30 = 2·3·5, |G| = 105 = 3·5·7, etc.) — but does NOT extend to `pᵃqᵇ` with `a ≥ 2` or `b ≥ 2` since `p²` is not squarefree. The genuine gap is exactly orders divisible by `p²` for some prime.",
+      "S4 — Path forward narrows: the next sub-cases are `|G| = p²q` (~50-100 lines via Sylow analysis), `|G| = pq²` (symmetric), and `|G| = p²q²` (more delicate). Each subsumes a specific instance of `burnside_pq_nontrivial` axiom-free. The Goldschmidt-Matsuyama route (~200-400 lines on top of `Mathlib.GroupTheory.Focal`) closes ALL remaining cases at once."
     ],
     "mathlibGaps": [
       "No `theorem Group.burnside_pq` — Burnside's p^a q^b theorem.",
@@ -92,10 +108,12 @@
     ],
     "nextSteps": [
       "S2 DONE: Phase-2 scaffold committed. proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean created with 5 axiom-free theorems + 1 axiom. Trivial cases proved. Gallery entry created.",
-      "Session 3 (literature decision): Choose between character-theoretic (Burnside 1904) and character-free Goldschmidt-Matsuyama. Recommend the character-free route since Mathlib's character theory still lacks the algebraic-integer hypotheses needed. Document the choice in this JSON's progressSummary.",
-      "Session 4 (Sylow setup): Prove that a minimal counterexample is non-abelian simple with no normal Sylow subgroup. Use `Mathlib.GroupTheory.Sylow` and `IsSolvable_of_normalSubgroup_solvable`-style reductions.",
-      "Session 5+ (focal subgroup theorem): Build the focal subgroup theorem in Mathlib (~200-400 lines) — this is the central new Mathlib infrastructure needed by Goldschmidt-Matsuyama. Anchor lemma: P/(P∩G') is the largest abelian quotient of P (the focal subgroup is the kernel of the transfer to P/[G,G]∩P).",
-      "Session 6+ (apply transfer): Use the transfer homomorphism on a Sylow p-subgroup to conclude P ∩ G' < P, contradicting G = G' for the minimal counterexample.",
+      "S3 DONE: Sharpness witness committed. burnside_pq_sharp formalizes |A₅| = 60 = 2²·3·5 non-solvable.",
+      "S4 DONE: Squarefree-order axiom-narrowing committed. squarefreeOrder_isSolvable + burnside_pq_pq_case prove the a=b=1 case axiom-free; axiom narrowed to require 2 ≤ a ∨ 2 ≤ b.",
+      "Session 5 (next sub-case): Prove `|G| = p² · q` axiom-free via Sylow analysis. The classical argument: count Sylow p-subgroups and Sylow q-subgroups via Sylow's third theorem; one of them must be normal (trivially or via cardinality bounds), giving an abelian-by-abelian extension. Estimated ~50-100 lines. After this, narrow the axiom further to `3 ≤ a ∨ 3 ≤ b` (excluding p²q and pq²).",
+      "Session 6 (next sub-case, symmetric): Prove `|G| = p · q²` axiom-free. Symmetric to Session 5; ~30-50 lines if structured well.",
+      "Session 7 (next sub-case): Prove `|G| = p² · q²` axiom-free. More delicate Sylow analysis; ~80-150 lines. After this, narrow further.",
+      "Session 8+ (Goldschmidt-Matsuyama): Build focal subgroup theorem on top of `Mathlib.GroupTheory.Focal` (some scaffolding already exists), apply transfer to a Sylow p-subgroup, derive P ∩ G' < P contradicting G = G'. ~200-400 lines. Closes ALL remaining cases of `burnside_pq_nontrivial`.",
       "Final session: replace `axiom burnside_pq_nontrivial` with theorem; sync meta.json; submit Mathlib upstream PR (estimated ~1000 lines total)."
     ]
   },
@@ -135,7 +153,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.054Z",
-  "lastUpdate": "2026-05-08T03:10:00.000Z",
+  "lastUpdate": "2026-05-08T07:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Iteration 4 of `abel-ruffini-galois-extensions-oq-07` (Burnside's pᵃqᵇ
theorem). Prove the `a = b = 1` case (`|G| = p · q`) axiom-free, and narrow
`burnside_pq_nontrivial` to require `2 ≤ a ∨ 2 ≤ b`. The genuinely-open
Lean content is now exactly: orders divisible by `p²` or `q²` for
distinct primes.

## Progress

**Two new theorems (both axiom-free):**

- `squarefreeOrder_isSolvable : Squarefree (Nat.card G) → IsSolvable G`
  via Mathlib's `IsZGroup.of_squarefree` (squarefree-order groups are
  Z-groups) + the `[Finite][IsZGroup] → IsSolvable` instance.
- `burnside_pq_pq_case : p ≠ q → Nat.card G = p · q → IsSolvable G`
  via `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`.

**Axiom narrowed:**

- `burnside_pq_nontrivial`: added hypothesis `2 ≤ a ∨ 2 ≤ b`. The
  `a = b = 1` sub-case is no longer axiom-dependent.

**Main theorem updated:** `burnside_pq` now `by_cases h11 : a = 1 ∧ b = 1`
to peel off the squarefree case axiom-free, then derives `2 ≤ a ∨ 2 ≤ b`
for the (narrowed) axiom invocation.

**Two new sanity examples:**

- `|G| = pq` axiom-free via `burnside_pq_pq_case`.
- `|G| = 30 = 2·3·5` axiom-free via `squarefreeOrder_isSolvable` —
  demonstrating that the squarefree route extends beyond Burnside's
  two-prime bound (covers any number of distinct primes each to first
  power), but does NOT extend to `pᵃqᵇ` with `a ≥ 2` or `b ≥ 2`.

## Files modified

- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (277 → 384 lines)
- `src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json`
- `src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json`
- `research/problems/abel-ruffini-galois-extensions-oq-07/knowledge.md`
- `research/problems/abel-ruffini-galois-extensions-oq-07/state.md`

## Findings

- **Mathlib has `IsZGroup.of_squarefree`** (in `Mathlib.GroupTheory.SpecificGroups.ZGroup`) and a `[Finite][IsZGroup] → IsSolvable` instance. Together these give `Squarefree |G| → IsSolvable G` in two lines — a clean axiom-free path that subsumes the `a = b = 1` Burnside case.
- **The squarefree route covers `pq, pqr, pqrs, …` but NOT `p²q`.** A₅ (60 = 2²·3·5) defeats this route since 60 has `2²`. So the squarefree route is strictly weaker than full Burnside.
- **Mathlib's `Mathlib.GroupTheory.Focal`** provides scaffolding for the Goldschmidt-Matsuyama character-free proof: focal subgroup definition, `transferFocal`, `commutator_inf_eq_focalSubgroup`. Closing the residual axiom is now ~200-400 lines on top of this (vs ~400-1000 lines for the character-theoretic route, which still lacks Mathlib's algebraic-integer infrastructure).
- **Intermediate sub-cases approachable via Sylow analysis**: `|G| = p²q` (~50-100 lines), `|G| = pq²` (~30-50 lines symmetric), `|G| = p²q²` (~80-150 lines). Each subsumes a specific instance of the residual axiom and could be proved before tackling Goldschmidt-Matsuyama.

## Counts

- lineCount 277 → 384
- theoremCount 8 → 10
- axiomCount 1 (narrowed; `2 ≤ a ∨ 2 ≤ b` added)
- sorries 0
- Build verified via `./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ07`

## Status

**Outcome**: progress — axiom-narrowing iteration; one new axiom-free path proved (squarefree route), axiom hypothesis tightened.

**Next Steps**:
1. (S5) Prove `|G| = p² · q` axiom-free via Sylow analysis (~50-100 lines).
2. (S6) Prove `|G| = p · q²` axiom-free (symmetric).
3. (S7) Prove `|G| = p² · q²` axiom-free.
4. (S8+) Build Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`. Closes ALL remaining cases.

🤖 Generated by researcher-1