### PR TITLE
research(erdos-826): S3 monotonicity in C + reconcile state.md

### DIFF
--- a/proofs/Proofs/Erdos826Problem.lean
+++ b/proofs/Proofs/Erdos826Problem.lean
@@ -119,6 +119,29 @@ These are starting points where divisor growth is well-controlled.
 def goodStartingPoints (C : ℝ) : Set ℕ :=
   { n | linearBoundCondition n C }
 
+/--
+**Monotonicity of `linearBoundCondition` in C.**
+
+If the linear bound holds with constant `C`, it holds with any larger
+constant `C'`. Trivial corollary of the inequality definition; useful
+when reducing to a normalised constant. -/
+theorem linearBoundCondition_mono {n : ℕ} {C C' : ℝ}
+    (hCC' : C ≤ C') (h : linearBoundCondition n C) :
+    linearBoundCondition n C' := by
+  intro k hk
+  have hk0 : (0 : ℝ) ≤ (k : ℝ) := by exact_mod_cast Nat.zero_le k
+  calc (σ 0 (n + k) : ℝ)
+      ≤ C * k := h k hk
+    _ ≤ C' * k := mul_le_mul_of_nonneg_right hCC' hk0
+
+/--
+**Monotonicity of `goodStartingPoints` in C.**
+
+The set of "good" starting points is monotone in `C`. -/
+theorem goodStartingPoints_mono {C C' : ℝ} (hCC' : C ≤ C') :
+    goodStartingPoints C ⊆ goodStartingPoints C' :=
+  fun _ hn => linearBoundCondition_mono hCC' hn
+
 /-
 # Part 4: The Erdős Conjecture
 

--- a/research/problems/erdos-826/knowledge.md
+++ b/research/problems/erdos-826/knowledge.md
@@ -51,7 +51,83 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Reconciled prior sessions (2026-05-08)
+
+The state.md was stuck at "Phase: NEW iter 1" but the gallery file
+already had several merged sessions. Reconciled to OBSERVE iter 3.
+
+* **PR #1084** — initial enhance: scaffolded divisor-function definitions
+  (`tau`, `linearBoundCondition`, `goodStartingPoints`,
+  `erdos_826_conjecture`, `erdos_248_weaker`). 320 lines, 0 sorries,
+  4 axioms.
+* **PR #7037** (Researcher) — axiom elimination 4 → 0:
+  - `erdos_826_statement` proved by `rfl` after unfold.
+  - `prime_satisfies_bound` proved from Mathlib's `sigma_apply` +
+    `Nat.Prime.divisors`.
+  - `average_order_tau` and `max_order_tau` converted from `axiom` to
+    `def Prop` (they were unused; safe conversion).
+* **PR #8241** — axiom integrity for open conjecture: status updated to
+  `axiomatized` then later refined to reflect 0 axioms.
+
+### Session 3 (2026-05-08) — Monotonicity in C + state reconcile
+
+**Mode**: REVISIT (claim from pool; state.md was "NEW iter 1" but gallery
+state was substantially advanced)
+
+**Outcome**: progress (small) — added `linearBoundCondition_mono` and
+`goodStartingPoints_mono` to `Erdos826Problem.lean`, plus reconciled
+`state.md` to reflect the actual prior progress.
+
+#### What I did
+
+1. Discovered drift: `state.md` was stuck at "Phase: NEW iter 1"
+   while `src/data/research/problems/erdos-826.json` showed phase
+   OBSERVE with merged axiom-elimination work (PR #7037). The Lean
+   file `Erdos826Problem.lean` is already at 320 lines, 0 sorries,
+   0 axioms.
+2. Added two small monotonicity lemmas to Part 3 of
+   `Erdos826Problem.lean`:
+   - `linearBoundCondition_mono`: if the linear bound holds with
+     `C`, it holds with any larger `C'`. Proof: `mul_le_mul_of_nonneg_right`
+     after exact_mod_cast on the `Nat.zero_le k` cast.
+   - `goodStartingPoints_mono`: `goodStartingPoints` is monotone
+     in `C`. Direct corollary.
+3. Rewrote `state.md` with a reconciled "Phase: OBSERVE iter 3"
+   record and an honest "no further substantive proof work" recommendation
+   for this OPEN-and-considered-hard conjecture.
+
+#### Key findings
+
+- The conjecture is at the research-mathematics frontier. Tao notes
+  it's hard. No partial result is known; the routine library
+  contributions add value as pedagogy / infrastructure but are NOT
+  progress on the conjecture.
+- The state.md drift suggests the daemon doesn't always sync
+  state.md with the JSON / Lean source; reconciling drift is a
+  legitimate session contribution similar to the
+  `frobenius-number-oq-01` reconcile (PR #16851 lineage,
+  predecessor `ba9ea10b`).
+
+#### Files modified
+
+- `proofs/Proofs/Erdos826Problem.lean` — +25 lines: 2 small lemmas
+  (`linearBoundCondition_mono`, `goodStartingPoints_mono`).
+- `research/problems/erdos-826/state.md` — rewritten (Phase: OBSERVE
+  iter 3, prior sessions documented).
+- `research/problems/erdos-826/knowledge.md` — this entry.
+- `src/data/research/problems/erdos-826.json` — synced phase /
+  iteration / nextAction with state.md.
+- `src/data/proofs/erdos-826/meta.json` — lineCount/theoremCount
+  bumped to reflect new file size.
+
+#### Honest assessment
+
+**Light contribution.** Two trivial monotonicity lemmas + a state
+reconcile. The lemmas are legitimate library additions that
+downstream code (or pedagogical annotations) might use, but they do
+not advance the conjecture. The state reconcile is mechanical
+janitorial work. The session avoids enumeration theater /
+busywork and is honest about being modest.
 
 ---
 

--- a/research/problems/erdos-826/state.md
+++ b/research/problems/erdos-826/state.md
@@ -1,27 +1,55 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T09:39:18.200Z
-**Iteration**: 1
+**Phase**: OBSERVE
+**Since**: 2026-01-15
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Erdős #826 (Tao notes this is hard) — small library lemmas about
+`linearBoundCondition` / `goodStartingPoints`. The core open
+question is unchanged; this iteration adds a monotonicity in C
+contribution + reconciles state.md drift with the JSON / Lean state.
 
 ## Active Approach
 
-None yet.
+**Library expansion + survey**, not a proof attempt. The conjecture
+is OPEN with no known partial result; the gallery file
+`Erdos826Problem.lean` already states the conjecture cleanly with
+0 axioms / 0 sorries. Useful additions are small structural lemmas
+about the predicates, not proof attempts.
+
+## Prior Sessions (reconciled 2026-05-08)
+
+* PR #1084 — initial enhance pass: filled out divisor-function
+  scaffolding (320 lines, 0 sorries, 4 axioms).
+* PR #7037 — axiom elimination 4 → 0: `erdos_826_statement` as
+  `rfl` after unfold; `prime_satisfies_bound` from Mathlib;
+  `average_order_tau`, `max_order_tau` converted from `axiom` to
+  `def Prop` (unused).
+* PR #8241 — axiom integrity for open conjecture (no behaviour
+  change).
+* (this session, S3, 2026-05-08) — added monotonicity in C for
+  `linearBoundCondition` and `goodStartingPoints` (Part 3).
 
 ## Blockers
 
-None.
+* **The conjecture itself is OPEN and considered hard** by Tao. No
+  known partial result, no Mathlib infrastructure for divisor-count
+  smoothing in short intervals at infinitely many starting points.
+  Cannot be advanced through routine techniques.
 
 ## Next Action
 
-Begin problem exploration.
+* **No further substantive proof work** is recommended at this
+  level — the gap is at the research-mathematics frontier. Future
+  enrichment passes can add small library lemmas (e.g.,
+  `tau_prime_power = a + 1`) but must be honest that they are
+  pedagogical infrastructure, not progress on the conjecture.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3
+- Approaches tried:
+  - Initial enhance + axiom elimination: PRs #1084, #7037, #8241
+  - Library expansion (monotonicity in C): this session

--- a/src/data/proofs/erdos-826/meta.json
+++ b/src/data/proofs/erdos-826/meta.json
@@ -55,9 +55,9 @@
       "erdos_826_main theorem: well-definedness and implications"
     ],
     "axiomCount": 0,
-    "lineCount": 320,
+    "lineCount": 343,
     "assumptions": "Open conjecture (Erdős #826) stated as a definition — not asserted as true. 0 axiom declarations, 0 sorries. Background facts (average/max order of τ) stated as Prop definitions. Proved theorems: erdos_826_statement (definitional equivalence), prime_satisfies_bound (from Mathlib), erdos_826_implies_248, erdos_826_main. Status is axiomatized because the subject is an open conjecture.",
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 11
   },
   "overview": {
@@ -183,7 +183,7 @@
       "Nat"
     ],
     "namespace": "Erdos826",
-    "lineCount": 320,
+    "lineCount": 343,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 11,

--- a/src/data/research/problems/erdos-826.json
+++ b/src/data/research/problems/erdos-826.json
@@ -16,33 +16,44 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "OBSERVE",
     "since": "2026-01-15T09:39:18.200Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 3,
+    "focus": "Library lemmas about linearBoundCondition and goodStartingPoints. Conjecture itself is OPEN and considered hard by Tao; no partial result known. This iteration adds monotonicity in C and reconciles state.md drift with the JSON / Lean state.",
+    "blockers": [
+      "Conjecture is OPEN at the research-mathematics frontier. No known partial result; routine library techniques cannot advance it. Future sessions should be honest about this and limit themselves to pedagogical/structural additions."
+    ],
+    "nextAction": "No further substantive proof work recommended. Future enrichment: optional small library lemmas like tau_prime_power = a + 1 (mathematically trivial via Mathlib), but they are pedagogy / infrastructure, not progress on the conjecture.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Eliminated all 4 axioms (4→0). erdos_826_statement proved by unfolding. prime_satisfies_bound proved from Mathlib. average_order_tau and max_order_tau converted to propositions.",
+    "progressSummary": "Session 3 (2026-05-08): added two small monotonicity lemmas to Erdos826Problem.lean Part 3 — linearBoundCondition_mono and goodStartingPoints_mono — plus reconciled state.md drift. The conjecture remains OPEN. | Prior: PR #1084 (initial enhance, 320 lines), PR #7037 (axiom elimination 4→0: erdos_826_statement by rfl after unfold; prime_satisfies_bound from Mathlib; average_order_tau and max_order_tau converted to def Prop), PR #8241 (axiom integrity).",
     "builtItems": [
-      "Proved erdos_826_statement as theorem via unfold + rfl",
-      "Proved prime_satisfies_bound as theorem via sigma_apply + Prime.divisors",
-      "Converted average_order_tau from axiom to def Prop",
-      "Converted max_order_tau from axiom to def Prop"
+      "Proved erdos_826_statement as theorem via unfold + rfl (PR #7037)",
+      "Proved prime_satisfies_bound as theorem via sigma_apply + Prime.divisors (PR #7037)",
+      "Converted average_order_tau from axiom to def Prop (PR #7037)",
+      "Converted max_order_tau from axiom to def Prop (PR #7037)",
+      "Erdos826Problem.lean Part 3 (Session 3): linearBoundCondition_mono — if linearBoundCondition n C and C ≤ C', then linearBoundCondition n C'. Proved by mul_le_mul_of_nonneg_right after Nat.zero_le k cast.",
+      "Erdos826Problem.lean Part 3 (Session 3): goodStartingPoints_mono — if C ≤ C' then goodStartingPoints C ⊆ goodStartingPoints C'. Direct corollary."
     ],
     "insights": [
       "All 4 axioms eliminated: erdos_826_statement proved by rfl after unfolding, prime_satisfies_bound proved from Mathlib, average_order_tau and max_order_tau converted to def Prop",
       "σ 0 p = 2 for prime p: unfold sigma_apply to sum over divisors, use Prime.divisors to get {1,p}, simplify",
-      "average_order_tau and max_order_tau are unused by any theorem — safe to convert from axiom to proposition"
+      "average_order_tau and max_order_tau are unused by any theorem — safe to convert from axiom to proposition",
+      "Session 3: Tao notes this is hard — no known partial result. The natural research strategy is library expansion, not direct proof. The honest assessment is that no routine technique advances this conjecture.",
+      "Session 3: state.md drift is a recurring issue. This session reconciles state.md (was Phase: NEW iter 1) to OBSERVE iter 3, matching the merged axiom-elimination work and this session's library additions. Similar to the frobenius-number-oq-01 reconcile (PR #16851 lineage)."
     ],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "mathlibGaps": [
+      "No Mathlib infrastructure for divisor-count smoothing in short intervals at infinitely many starting points. Building such infrastructure (smooth-number distribution, sieve methods) is a substantial multi-thousand-line foundational project, not routine."
+    ],
+    "nextSteps": [
+      "Optional: add tau_prime_power = a + 1 from Mathlib's Nat.divisors_prime_pow (pedagogical, not progress on conjecture).",
+      "Avoid: enumeration theater (proving the linear bound for specific small n) — would not advance the conjecture and qualifies as busywork."
+    ],
     "markdown": "# Erdős #826 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nAre there infinitely many $n$ such that, for all $k\\geq 1$,\\[\\tau(n+k)\\ll k?\\]\n\n\n\nA stronger form of [248].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #248\n- Problem #825\n- Problem #827\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er74b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Session 3 of erdos-826 (Erdős #826: divisor function growth along shifts).

Adds two small library lemmas to `Erdos826Problem.lean` Part 3 (+25 lines,
0 sorries, 0 axioms):

- **`linearBoundCondition_mono`** — if `linearBoundCondition n C` holds and
  `C ≤ C'`, then `linearBoundCondition n C'`. Proof: `mul_le_mul_of_nonneg_right`
  after the `Nat.zero_le k` cast to ℝ.
- **`goodStartingPoints_mono`** — `goodStartingPoints` is monotone in `C`.
  Direct corollary.

Also reconciles `state.md` drift: was stuck at "Phase: NEW iter 1" while
the JSON / Lean source already reflected merged axiom-elimination work
(PRs #7037, #8241) and the gallery file is at 320 lines / 0 axioms /
0 sorries. Updated `state.md` to "Phase: OBSERVE iter 3" with prior
sessions documented; synced `erdos-826.json` accordingly.

## Status

**Outcome**: progress (small) — two trivial monotonicity lemmas + state
reconcile. The conjecture itself is OPEN and Tao notes it's hard; no
routine technique advances it. These lemmas are legitimate library
additions but do not advance the conjecture.

**Honest scope**: light contribution. Avoids enumeration theater. The
gallery file's existing axiom-elimination (PR #7037) was the substantive
prior work; this session adds incremental library polish + janitorial
reconcile.

## Files Modified

- `proofs/Proofs/Erdos826Problem.lean` (+25 lines: 2 monotonicity lemmas
  in Part 3)
- `research/problems/erdos-826/state.md` (rewritten, OBSERVE iter 3)
- `research/problems/erdos-826/knowledge.md` (Session 3 entry +
  reconciled prior sessions)
- `src/data/research/problems/erdos-826.json` (phase, focus, blockers,
  nextAction, builtItems, insights synced)
- `src/data/proofs/erdos-826/meta.json` (lineCount 320→343,
  theoremCount 4→6)

🤖 Generated by researcher-6