### PR TITLE
audit(tracker): four-square-distribution-oq-01 — issues-fixed (stale entry)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13855,14 +13855,11 @@
       "issues": []
     },
     "four-square-distribution-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-07T22:30:00Z",
-      "result": "issues-found",
-      "issues": [
-        "meta.theoremCount=33 vs actual 51",
-        "meta.lineCount=210 vs actual 209"
-      ],
-      "notes": "stale theoremCount and lineCount in legacy meta sub-object; lf block absent so find-targets misses. See issue #16708."
+      "auditCount": 2,
+      "lastAudited": "2026-05-08T03:30:00Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "notes": "Original drift fixed via #16716, then file grew to 888 lines / 84 theorems via #16804/#16860/#16893; meta.lineCount and meta.theoremCount now match origin/main."
     },
     "inverse-galois-d4": {
       "auditCount": 1,


### PR DESCRIPTION
## Fix

Update stale audit-tracker entry for `four-square-distribution-oq-01` from `issues-found` → `issues-fixed`. The original drift was fixed long ago; tracker just lagged.

## Evidence

The tracker entry (added 2026-05-07T22:30:00Z by issue #16708) reported:
- `meta.theoremCount=33 vs actual 51`
- `meta.lineCount=210 vs actual 209`

That drift was fixed by **#16716** within hours of being filed. Since then the proof file has grown substantially through five additional research/sync PRs, each updating counts:

| PR | Action |
|----|--------|
| #16716 | Initial sync (closed #16708) |
| #16804 | Sync lineCount 609→613 |
| #16790 | Sync lineCount 353→402 (closed) |
| #16860 | Batch lineCount sync |
| #16893 | Sync counts after #16832 |

Current state on `origin/main` (HEAD `1018aba162e`):
- `proofs/Proofs/FourSquareDistributionOQ01.lean`: **888 lines, 84 theorems**
- `meta.json` `meta.lineCount`: **888** ✓
- `meta.json` `meta.theoremCount`: **84** ✓

So the originally-reported drift is fully resolved and the file's counts match reality. Tracker is the only stale artifact.

## Diff

```diff
-      "auditCount": 1,
-      "lastAudited": "2026-05-07T22:30:00Z",
-      "result": "issues-found",
-      "issues": [
-        "meta.theoremCount=33 vs actual 51",
-        "meta.lineCount=210 vs actual 209"
-      ],
-      "notes": "stale theoremCount and lineCount in legacy meta sub-object; lf block absent so find-targets misses. See issue #16708."
+      "auditCount": 2,
+      "lastAudited": "2026-05-08T03:30:00Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "notes": "Original drift fixed via #16716, then file grew to 888 lines / 84 theorems via #16804/#16860/#16893; meta.lineCount and meta.theoremCount now match origin/main."
```

---
Automated fix by lean-mechanic agent.