### PR TITLE
fix(meta): declare Core/Helpers siblings in meta.additionalFiles (24 entries)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
@@ -7,6 +7,9 @@
     "author": "Lean Genius OQ04-OQ03",
     "status": "verified",
     "proofRepoPath": "Proofs/AngleTrisectionOQ04OQ03.lean",
+    "additionalFiles": [
+      "Proofs/AngleTrisectionOQ04.lean"
+    ],
     "tags": [
       "constructibility",
       "angle-trisection",

--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
@@ -18,6 +18,9 @@
       "dyck-paths"
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ04OQ01.lean",
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ01OQ04Core.lean"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -9,6 +9,9 @@
     "date": "2026",
     "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ04.lean",
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ01OQ04Core.lean"
+    ],
     "tags": [
       "combinatorics",
       "ballot-problem",

--- a/src/data/proofs/erdos-1011/meta.json
+++ b/src/data/proofs/erdos-1011/meta.json
@@ -9,6 +9,9 @@
     "date": "1962",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1011Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -9,6 +9,9 @@
     "date": "1982",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1091Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -9,6 +9,9 @@
     "date": "",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos626Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -9,6 +9,9 @@
     "date": "",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos627Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -9,6 +9,9 @@
     "date": "1968",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos628Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -9,6 +9,9 @@
     "date": "1980",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos630Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -9,6 +9,9 @@
     "date": "1979",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos631Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -8,6 +8,9 @@
     "sourceUrl": "https://erdosproblems.com/640",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos640Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-641/meta.json
+++ b/src/data/proofs/erdos-641/meta.json
@@ -9,6 +9,9 @@
     "date": "2024",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos641Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/erdos-923/meta.json
+++ b/src/data/proofs/erdos-923/meta.json
@@ -9,6 +9,9 @@
     "date": "1977",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos923Problem.lean",
+    "additionalFiles": [
+      "Proofs/GraphCore.lean"
+    ],
     "tags": [
       "erdos",
       "graph-theory",

--- a/src/data/proofs/frobenius-number-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01/meta.json
@@ -7,6 +7,9 @@
     "author": "Lean Genius",
     "status": "verified",
     "proofRepoPath": "Proofs/FrobeniusNumberOQ01.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumberOQ02.lean"
+    ],
     "tags": [
       "number-theory",
       "frobenius",

--- a/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-02/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-05-06",
     "status": "verified",
     "proofRepoPath": "Proofs/LawOfCosinesOQ01OQ02.lean",
+    "additionalFiles": [
+      "Proofs/SphericalLawOfCosines.lean"
+    ],
     "tags": [
       "spherical-geometry",
       "trigonometry",

--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -9,6 +9,9 @@
     "date": "2025",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/MotivicFlagMaps.lean",
+    "additionalFiles": [
+      "Proofs/MotivicFlagMapsProvable.lean"
+    ],
     "tags": [
       "algebraic-geometry",
       "moduli-spaces",

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -8,6 +8,9 @@
     "date": "1971",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/PNPBarriersUnified.lean",
+    "additionalFiles": [
+      "Proofs/ComplexityCore.lean"
+    ],
     "tags": [
       "computability",
       "complexity-theory",

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -19,6 +19,9 @@
       "topology"
     ],
     "proofRepoPath": "Proofs/SpernerSimplicialInstance.lean",
+    "additionalFiles": [
+      "Proofs/SpernerMathlib4.lean"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,

--- a/src/data/proofs/szemeredi-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-core-oq-01/meta.json
@@ -10,6 +10,9 @@
     "status": "verified",
     "badge": "original",
     "proofRepoPath": "Proofs/SzemerediCoreOQ01.lean",
+    "additionalFiles": [
+      "Proofs/SzemerediCore.lean"
+    ],
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 11,

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -9,6 +9,9 @@
     "date": "1978",
     "status": "verified",
     "proofRepoPath": "Proofs/SzemerediCounting.lean",
+    "additionalFiles": [
+      "Proofs/SzemerediCore.lean"
+    ],
     "tags": [
       "szemeredi",
       "combinatorics",

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -18,6 +18,9 @@
       "research"
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphGowers.lean",
+    "additionalFiles": [
+      "Proofs/SzemerediHypergraphCore.lean"
+    ],
     "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/szemeredi-regularity-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02/meta.json
@@ -9,6 +9,9 @@
     "date": "1999",
     "status": "verified",
     "proofRepoPath": "Proofs/SzemerediRegularityOQ02.lean",
+    "additionalFiles": [
+      "Proofs/SzemerediCore.lean"
+    ],
     "tags": [
       "combinatorics",
       "graph-theory",

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -9,6 +9,9 @@
     "date": "1975",
     "status": "verified",
     "proofRepoPath": "Proofs/SzemerediRegularity.lean",
+    "additionalFiles": [
+      "Proofs/SzemerediCore.lean"
+    ],
     "tags": [
       "szemeredi",
       "combinatorics",

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -13,6 +13,9 @@
       "truth-functions"
     ],
     "proofRepoPath": "Proofs/TractatusOntology.lean",
+    "additionalFiles": [
+      "Proofs/TractatusQuantifiers.lean"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Fixes the schema-split bug introduced in PRs #16518 and #16669: those PRs added Core/Helpers files to `leanFile.additionalFiles`, but the auditor's `find-targets.ts` (line 254 reads `meta.meta || {}`, line 151 reads `proofMeta.additionalFiles`) only checks **`meta.additionalFiles`**. The non-Aristotle imports (`GraphCore`, `SzemerediCore`, `ComplexityCore`, …) were therefore still invisible to the audit pass.

This batch mirrors `lf.additionalFiles` → `meta.additionalFiles` for the 24 entries that have a non-Aristotle Core/Helpers sibling.

## Why exclude Aristotle siblings

Aristotle companion files are auto-followed by `find-targets` via its import scan (line 178-186) when the main file imports them. They don't need to be in `meta.additionalFiles`, and adding them here would surface latent Aristotle sorry drift unrelated to this fix (e.g. erdos-626 would jump from 15 → 19 sorries).

Only Core/Helpers/Provable/etc. siblings (single-level non-Aristotle imports) are silently skipped, which is the documented gap (`feedback_mechanic_core_helpers_additionalfiles.md` and `feedback_mechanic_additionalfiles_schema_split.md`).

## Evidence

Per-entry, after the fix the auditor will now resolve the additional Lean file. Claimed sorry/axiom counts in `meta` still match the actual counts including the new siblings (zero new drift introduced):

| slug | sibling | sorries claim/actual | axioms claim/actual |
|------|---------|---------------------|---------------------|
| angle-trisection-oq-04-oq-03 | AngleTrisectionOQ04 | 0/0 | 0/0 |
| ballot-problem-oq-01-oq-04-oq-01 | BallotProblemOQ01OQ04Core | 0/0 | 0/0 |
| ballot-problem-oq-01-oq-04 | BallotProblemOQ01OQ04Core | 0/0 | 0/0 |
| erdos-1011 | GraphCore | 0/0 | 5/5 |
| erdos-1091 | GraphCore | 0/0 | 5/5 |
| erdos-626 | GraphCore | 15/15 | 7/7 |
| erdos-627 | GraphCore | 16/16 | 8/8 |
| erdos-628 | GraphCore | 12/12 | 4/4 |
| erdos-630 | GraphCore | 15/15 | 11/11 |
| erdos-631 | GraphCore | 10/10 | 16/16 |
| erdos-640 | GraphCore | 0/0 | 2/2 |
| erdos-641 | GraphCore | 2/2 | 1/1 |
| erdos-923 | GraphCore | 0/0 | 2/2 |
| frobenius-number-oq-01 | FrobeniusNumberOQ02 | 0/0 | 0/0 |
| law-of-cosines-oq-01-oq-02 | SphericalLawOfCosines | 0/0 | 0/0 |
| motivic-flag-maps | MotivicFlagMapsProvable | 0/0 | 2/2 |
| p-vs-np | ComplexityCore | 0/0 | 205/126 (underclaim, OK) |
| sperner-simplicial-instance | SpernerMathlib4 | 0/0 | 0/0 |
| szemeredi-core-oq-01 | SzemerediCore | 0/0 | 0/0 |
| szemeredi-counting | SzemerediCore | 0/0 | 0/0 |
| szemeredi-hypergraph-core-oq-01-incomplete-01 | SzemerediHypergraphCore | 0/0 | 0/0 |
| szemeredi-regularity-oq-02 | SzemerediCore | 0/0 | 0/0 |
| szemeredi-regularity | SzemerediCore | 0/0 | 0/0 |
| tractatus-ontology | TractatusQuantifiers | 0/0 | 1/1 |

p-vs-np is the one underclaim — meta.axiomCount (205) > actual (126). This is structural (axiom count includes import chain depth not in source) and is the safe direction per `feedback_auditor_lf_axiomcount_wrapper_overclaim.md`.

## What this does NOT do

- Does not modify any Lean source (proofs/Proofs/*.lean).
- Does not change any sorry/axiom counts.
- Does not touch `leanFile.additionalFiles` (the existing entries from #16518/#16669 stay; this PR only mirrors them into the meta block).

---
Automated fix by lean-mechanic agent.