### PR TITLE
fix(meta): erdos-1039 sorries 3→2 (clustered_implies_large_disc proved)

### DIFF
--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -17,14 +17,14 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 1039,
     "erdosUrl": "https://erdosproblems.com/1039",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 5,
     "lineCount": 303,
-    "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. 3 sorries remain (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc). Fixed sublevelArea type (ENNReal→ℝ via toReal).",
+    "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. 2 sorries remain (area_implies_disc_bound, degree_one_optimal); clustered_implies_large_disc has been proved. Fixed sublevelArea type (ENNReal→ℝ via toReal).",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
       {
@@ -243,10 +243,10 @@
     "theoremCount": 9,
     "definitionCount": 16,
     "path": "Proofs/Erdos1039Problem.lean",
-    "sorries": 3,
+    "sorries": 2,
     "additionalFiles": [
       "Proofs/Erdos1039ProblemAristotle.lean"
     ]
   },
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Sync stale sorry count: meta.json claimed 3 sorries but actual count in `proofs/Proofs/Erdos1039Problem.lean` is 2. The `clustered_implies_large_disc` theorem was proved in a prior research PR.

## Evidence

**Before** (find-targets.ts output):
```
erdos-1039 (3x, last 2026-05-03) [axiomatized/axiom] ❌ sorry mismatch: claims 3, actual 2
```

**Actual sorries in Erdos1039Problem.lean**:
- `area_implies_disc_bound` (line 312)
- `degree_one_optimal` (line 325)

The third name still appearing in the `assumptions` text (`clustered_implies_large_disc`) is now a fully proved theorem (lines 340–388).

## Changes

- `meta.sorries`: 3 → 2
- `leanFile.sorries`: 3 → 2
- top-level `sorries`: 3 → 2
- `meta.assumptions`: drop `clustered_implies_large_disc` from "sorries remain" list, note it has been proved

After fix, `find-targets.ts --slug erdos-1039` is clean.

---
Automated fix by lean-mechanic agent.