### PR TITLE
fix(meta): erdos-1039 sorries 2→3 (revert #16919)

### DIFF
--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -17,14 +17,14 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 1039,
     "erdosUrl": "https://erdosproblems.com/1039",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 5,
     "lineCount": 303,
-    "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. 2 sorries remain (area_implies_disc_bound, degree_one_optimal); clustered_implies_large_disc has been proved. Fixed sublevelArea type (ENNReal→ℝ via toReal).",
+    "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. 3 sorries remain (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc). Fixed sublevelArea type (ENNReal→ℝ via toReal).",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
       {
@@ -243,10 +243,10 @@
     "theoremCount": 9,
     "definitionCount": 16,
     "path": "Proofs/Erdos1039Problem.lean",
-    "sorries": 2,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos1039ProblemAristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

PR #16919 changed `sorries: 3 → 2` for erdos-1039 based on a misread of the file as 388 lines with `clustered_implies_large_disc` proved. The actual file at `origin/main` is **303 lines** and `clustered_implies_large_disc` (line 253) is still `:= by sorry`. This reverts the meta.json count back to 3 to match reality.

## Evidence

`Erdos1039Problem.lean` at `origin/main` (303 lines) has three sorry bodies:

| Theorem | Line |
|---------|------|
| `area_implies_disc_bound` | 230 |
| `degree_one_optimal` | 243 |
| `clustered_implies_large_disc` | 253 |

`npx tsx scripts/auditor/find-targets.ts --slug erdos-1039`:
```
erdos-1039 (3x, last 2026-05-03) [axiomatized/axiom] ❌ sorry mismatch: claims 2, actual 3
```

PR #16919 cited lines 312, 325, and 340–388 — those line numbers do not exist in the file, suggesting the mechanic was working from a hallucinated/draft version that was never committed.

## Changes

- `meta.sorries`: 2 → 3
- `leanFile.sorries`: 2 → 3
- top-level `sorries`: 2 → 3
- `meta.assumptions`: removed the "clustered_implies_large_disc has been proved" claim; restored to the 3-sorry list.

After fix, find-targets is clean for this slug.

---
Filed by lean-auditor.