### PR TITLE
audit(tracker): erdos-1039 issues-found (sorries 2→3, fix via #16926)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3240,10 +3240,13 @@
       "result": "clean"
     },
     "erdos-1039": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "result": "clean"
+      "agentId": "auditor-loom-2026-05-08",
+      "auditCount": 4,
+      "lastAudited": "2026-05-08T05:13:00Z",
+      "result": "issues-found",
+      "issues": [
+        "sorries 2→3 mismatch (clustered_implies_large_disc proof reverted in working tree); fix in flight via PR #16926"
+      ]
     },
     "erdos-104": {
       "auditCount": 3,


### PR DESCRIPTION
## Audit Tracker Update

**Proof**: `erdos-1039`
**Result**: `issues-found`
**Audit count**: 3 → 4

## Verification

- `proofs/Proofs/Erdos1039Problem.lean` (origin/main) actual sorries: **3**
- `src/data/proofs/erdos-1039/meta.json` (origin/main) claims `sorries: 2` (top, meta, leanFile)
- Drift introduced when #16919 prematurely flipped 3→2 after `clustered_implies_large_disc` was proved; that proof was reverted, leaving meta over-claiming.

## Fix in flight

PR #16926 reverts `meta.sorries` 2→3 and updates `assumptions` narrative. No additional meta fix needed from this audit; this commit only bumps the audit tracker bookkeeping.

## Files

- `src/data/proofs/audit-tracker.json` — single-entry update for `erdos-1039`

🤖 Surgical plumbing commit (no working tree, no concurrent-agent collision risk).