### PR TITLE
Research: feuerbachs-theorem-oq-02 — pair-equidistance decomposition [BUILD UNVERIFIED]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ02.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ02.lean
@@ -632,6 +632,29 @@ theorem edge_midpoints_equidist_from_centroid (T : OrthocentricTetrahedron) :
     Tetrahedron.midpoint_CD midpoint3 vec3 dot3 at *
   refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;> nlinarith
 
+/-- For ANY tetrahedron (no orthocentric hypothesis required), each pair of opposite
+    edge midpoints is equidistant from the centroid:
+      dist²(G, M_AB) = dist²(G, M_CD)
+      dist²(G, M_AC) = dist²(G, M_BD)
+      dist²(G, M_AD) = dist²(G, M_BC)
+
+    Proof: G - M_AB = (C + D - A - B)/4 = -(G - M_CD), so the two displacements
+    are negatives of each other and hence have equal squared length. The same
+    argument applies to the other two opposite-edge pairs.
+
+    Combined with `edge_midpoints_equidist_from_centroid` (which uses
+    orthocentricity to bridge across the three pairs), this gives a clean
+    decomposition: the three pair-equalities hold universally, while the
+    inter-pair equality is the orthocentric content. -/
+theorem edge_midpoints_paired_equidist_from_centroid (T : Tetrahedron) :
+    dist3_sq T.centroid T.midpoint_AB = dist3_sq T.centroid T.midpoint_CD ∧
+    dist3_sq T.centroid T.midpoint_AC = dist3_sq T.centroid T.midpoint_BD ∧
+    dist3_sq T.centroid T.midpoint_AD = dist3_sq T.centroid T.midpoint_BC := by
+  unfold dist3_sq Tetrahedron.centroid Tetrahedron.midpoint_AB Tetrahedron.midpoint_AC
+    Tetrahedron.midpoint_AD Tetrahedron.midpoint_BC Tetrahedron.midpoint_BD
+    Tetrahedron.midpoint_CD midpoint3
+  refine ⟨?_, ?_, ?_⟩ <;> ring
+
 /-- The exact squared distance from centroid G to each edge midpoint, for an orthocentric
     tetrahedron. The formula dist²(G, M_AB) = (|AC|² + |BD|²)/16 follows from the
     orthocentric condition AC⊥BD: writing G - M_AB = (C+D-A-B)/4 = (AC + BD)/4 as
@@ -686,13 +709,16 @@ theorem edge_midpoints_dist_sq_formula (T : OrthocentricTetrahedron) :
    from the centroid G (requires orthocentric hypothesis)
 10. edge_midpoints_dist_sq_formula: dist²(G, M_AB) = (|AC|²+|BD|²)/16, and
     dist²(G, M_AC) = (|AB|²+|CD|²)/16 (exact formula using orthocentric conditions)
+11. edge_midpoints_paired_equidist_from_centroid: For ANY tetrahedron, each pair
+    of opposite edge midpoints is equidistant from the centroid (3 pair-equalities;
+    no orthocentric hypothesis required)
 
 ### Sorries (0): all five tangency theorems were removed in 2026-05-02 after
 the symbolic counterexample at PART 10 closed the question of whether the
 (N₂₄, R/3)-sphere is tangent to the insphere/exspheres — it is not.
 
 ### Axioms (1):
-11. feuerbach_3d_fails_general: A non-orthocentric tetrahedron exists for
+12. feuerbach_3d_fails_general: A non-orthocentric tetrahedron exists for
     which the (N₂₄, R/3)-sphere fails to be internally tangent to the insphere.
     (Existential claim. Note: per the PART 10 refutation, tangency also fails
     for many *orthocentric* tetrahedra, so the orthocentric hypothesis does


### PR DESCRIPTION
## Summary

Research session S5 (2026-05-08) for `feuerbachs-theorem-oq-02-incomplete-01` (3D analogue of Feuerbach's theorem for tetrahedra).

Adds one new theorem to `FeuerbachsTheoremOQ02.lean` (PART 14):
`edge_midpoints_paired_equidist_from_centroid (T : Tetrahedron)` — proves
three pair-equalities of edge-midpoint distances from the centroid for **any**
tetrahedron (no orthocentric hypothesis required).

## Why This Is Useful

The existing `edge_midpoints_equidist_from_centroid` (added in Session 1, on
`OrthocentricTetrahedron`) bundles five equalities and uses `nlinarith` with
the two orthocentric perpendicularity hypotheses. Inspecting that proof shows
that three of the five equalities — namely the three pair-equalities for
opposite edges — don't actually need the orthocentric hypotheses. They follow
from a simple centroid-symmetry argument:

```
G - M_AB = (A+B+C+D)/4 - (A+B)/2 = (C+D-A-B)/4
G - M_CD = (A+B+C+D)/4 - (C+D)/2 = (A+B-C-D)/4 = -(G - M_AB)
```

So the two displacements are negatives of each other, hence have equal squared
length. The same applies to the (M_AC, M_BD) and (M_AD, M_BC) pairs.

The new theorem captures this universal pair-symmetry. Combined with the
existing equidistance theorem, this gives a clean separation:
- **Automatic** (every tetrahedron): the 3 pair-equalities.
- **Orthocentric content** (requires AB⊥CD ∧ AC⊥BD): the inter-pair equality
  bridging across the three pairs.

## Files Modified

- `proofs/Proofs/FeuerbachsTheoremOQ02.lean` (+28 / -2)
  - Added `edge_midpoints_paired_equidist_from_centroid` after the existing
    `edge_midpoints_equidist_from_centroid` in PART 14.
  - Updated PART 15 summary to list 11 proved theorems (was 10);
    renumbered `feuerbach_3d_fails_general` axiom entry from 11 to 12.
- `research/problems/feuerbachs-theorem-oq-02-incomplete-01/knowledge.md`
  (+80) — Session 5 entry with mathematical observation, honest assessment,
  and build-verification note.
- `research/problems/feuerbachs-theorem-oq-02-incomplete-01/state.md`
  — iteration 3 → 5; added approach 5 to attempt history.
- `src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json`
  — phase COMPLETE → ACT (reopened with new structural work); iteration
  4 → 5; added one built item, one insight, updated `progressSummary`.

## Sorry / Axiom Delta

- Theorems: 10 → 11 (+1)
- Sorries: 0 → 0 (unchanged)
- Axioms: 1 → 1 (unchanged — `feuerbach_3d_fails_general` still requires
  algebraic-number arithmetic to discharge; out of scope here)
- Lines: 743 → 769 (+26)

## Build Status — IMPORTANT

**This PR is marked `[BUILD UNVERIFIED]`** because the recursive
`proofs/.lake → proofs/.lake` self-symlink (documented in MEMORY.md
as a known infrastructure issue) forces every Docker build to fresh-clone
Mathlib (~10–15 min) plus cache get (~10 min), exceeding the 90-min
researcher claim TTL.

The new proof is a pure `ring` identity over `ℝ` after `unfold` of
structurally compatible definitions (`dist3_sq`, `Tetrahedron.centroid`,
`Tetrahedron.midpoint_*`, `midpoint3` — all with `ℝ × ℝ × ℝ` arithmetic).
It follows the exact same pattern as `twentyFourPointCenter_is_2G_minus_O`
(file line 551) and `centroid_on_euler_line` (line 540) already in the
file, both of which build and pass.

**Risk of build failure**: low but nonzero (e.g., `unfold` ordering or
`refine` arity issue). The `loom:review-requested` label is set so a
Judge / Builder agent can verify with a warm Mathlib cache before this
merges.

## Honest Assessment

This is a **structural lemma addition, not a breakthrough**. It does not
advance the single remaining axiom (`feuerbach_3d_fails_general`) nor
identify the correct (Murakami / Court) Feuerbach sphere. Its value is
decomposition: clarifying which content of the existing equidistance
theorem is universal vs orthocentric. Cost is one line of `ring` after
`unfold`.

## Status

**Outcome**: progress (one structural theorem added; build unverified)
**Next Steps**:
1. Build verification by Judge / Builder.
2. (Long-term) `feuerbach_3d_fails_general` discharge via Heronian-style
   non-orthocentric tetrahedron with rational face areas, or √-arithmetic
   Lean tactic.
3. (Long-term) Murakami (1952) / Court (1934) literature survey to identify
   the correct 3D Feuerbach sphere.

🤖 Generated by researcher-8