### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-01-oq-01): retire iteratedIntervalIntegral_order_independent axiom

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean
@@ -34,8 +34,12 @@
   Key insight: Integrable.integral_prod_right derives integrability of the
   parameterized integral from 3D compactness, avoiding separate measurability proofs.
 
-  ## Axioms: 1 (iteratedIntervalIntegral_order_independent for general n)
+  ## Axioms: 0
   ## Sorries: 0
+
+  Note: the formerly-axiomatized n-D order independence has been retired here.
+  A first-principles proof for arbitrary `n` lives in the subsidiary module
+  `Proofs.GreensTheoremOQ01OQ01OQ01OQ01`.
 -/
 
 import Mathlib
@@ -231,26 +235,12 @@ lemma iteratedIntervalIntegral_two {a b : Fin 2 → ℝ} {f : (Fin 2 → ℝ) �
   simp only [iteratedIntervalIntegral_succ, iteratedIntervalIntegral_zero, Fin.tail,
              show (Fin.succ (0 : Fin 1) : Fin 2) = 1 from rfl]
 
-/-- **N-Dimensional Order Independence** (axiomatized for n ≥ 4).
-
-    For continuous f, any permutation of integration variables preserves the value.
-    The 2D case: proved by `fubini_n2`.
-    The 3D case: proved by `triple_fubini_of_continuous`.
-    General n: axiomatized here. The inductive proof follows the 3D strategy:
-    peel off the outermost variable, apply IH inside, use integral_integral_swap +
-    integral_prod_right for the outer swap. -/
-axiom iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → ℝ}
-    (hab : ∀ i, a i ≤ b i) {f : (Fin n → ℝ) → ℝ} (hf : Continuous f)
-    (σ : Equiv.Perm (Fin n)) :
-    iteratedIntervalIntegral a b f =
-    iteratedIntervalIntegral (a ∘ σ) (b ∘ σ) (fun x => f (fun i => x (σ.symm i)))
-
 /-
 ## Research Outcome
 
 **Answer**: YES, the 2D Fubini bridge from GreensTheoremOQ01OQ01 generalizes to n-D.
 
-**Main proved theorems** (0 sorries):
+**Main proved theorems** (0 sorries, 0 axioms):
 - `triple_fubini_of_continuous`: ∫z∫y∫x f = ∫x∫y∫z f for continuous f on 3D box
 - `triple_fubini_yxz_eq_xyz`: (y,x,z) ordering equals (x,y,z)
 - `triple_fubini_all_equal`: collects 3 key orderings
@@ -259,8 +249,12 @@ axiom iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → ℝ}
 parameterized integral from 3D compactness + continuity, avoiding any need for
 separate measurability lemmas or continuity of parameterized integrals.
 
-**Axiom** (1): `iteratedIntervalIntegral_order_independent` for general n.
-The 2D and 3D fully-proved cases establish the inductive pattern.
+**N-D Order Independence**: a real proof of
+`iteratedIntervalIntegral_order_independent` for arbitrary `n` is provided in the
+subsidiary file `Proofs.GreensTheoremOQ01OQ01OQ01OQ01` (Equiv.Perm.swap_induction_on
++ adjacent-swap Fubini). The previously-stated axiom in this file has been
+removed: it was unused locally, and a real theorem of the same statement now
+exists downstream.
 -/
 
 end GreensTheoremOQ01OQ01OQ01

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. 0 sorries, 0 axiom declarations. All theorems follow from Mathlib's Fubini theorem (MeasureTheory.integral_integral_swap) and standard measure theory. The parent module Proofs.GreensTheoremOQ01OQ01OQ01 still declares iteratedIntervalIntegral_order_independent as an axiom, but that declaration is not used by any theorem in this file — all results here are proved independently.",
+    "assumptions": "None. 0 sorries, 0 axiom declarations. All theorems follow from Mathlib's Fubini theorem (MeasureTheory.integral_integral_swap) and standard measure theory. The parent module Proofs.GreensTheoremOQ01OQ01OQ01 previously declared iteratedIntervalIntegral_order_independent as an axiom; that declaration has now been retired (it was unused in the parent), since this file proves the same statement as a real theorem from first principles.",
     "dateAdded": "2026-05-06",
     "openQuestions": [
       {

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Fubini (1907), extended to n-dim 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fubini%27s_theorem",
     "date": "1907",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/GreensTheoremOQ01OQ01OQ01.lean",
     "tags": [
       "analysis",
@@ -15,12 +15,13 @@
       "fubini",
       "integration",
       "n-dimensional",
-      "greens-theorem"
+      "greens-theorem",
+      "axiom-elimination"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "1 axiom: iteratedIntervalIntegral_order_independent (n-dimensional order independence for continuous functions). The 2D and 3D cases are fully proved. The general case is sound by induction but requires Fin-n type infrastructure not yet formalized.",
+    "axiomCount": 0,
+    "assumptions": "None. 0 sorries, 0 axioms. The 2D and 3D cases are proved here directly; n-dimensional order independence (iteratedIntervalIntegral_order_independent) is proved as a real theorem in the subsidiary module Proofs.GreensTheoremOQ01OQ01OQ01OQ01 via Equiv.Perm.swap_induction_on plus the adjacent-swap Fubini lemma.",
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [
       {
@@ -49,9 +50,9 @@
       "Triple Fubini theorem: all 3 key orderings of ∫∫∫ equal each other for continuous f",
       "2D and 3D swap theorems proved sorry-free using integral_integral_swap",
       "Key technique: Integrable.integral_prod_right avoids separate measurability lemmas",
-      "Axiomatized general n-dim order independence for arbitrary permutations"
+      "Retired the previous iteratedIntervalIntegral_order_independent axiom — a first-principles proof for arbitrary n now lives in Proofs.GreensTheoremOQ01OQ01OQ01OQ01"
     ],
-    "lineCount": 266,
+    "lineCount": 260,
     "theoremCount": 10,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
@@ -69,8 +70,8 @@
       "Topology"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ01",
-    "lineCount": 266,
-    "axiomCount": 1,
+    "lineCount": 260,
+    "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/GreensTheoremOQ01OQ01OQ01.lean",
@@ -81,7 +82,7 @@
     "historicalContext": "Fubini's theorem (1907) established that iterated integrals can be computed in any order for absolutely integrable functions. The n-dimensional generalization via product measures is foundational to modern measure theory. Mathlib formalizes the 2D case via `MeasureTheory.integral_integral_swap`, and the n-dimensional case via `Mathlib.MeasureTheory.Integral.Marginal` (lmarginal). The concrete bridge from abstract measure theory to Lean's `intervalIntegral` API (∫ x in a..b, f x) is non-trivial and requires careful handling of measure restrictions and null sets.",
     "problemStatement": "Answer to greens-theorem-oq-01-oq-01: Can the 2D Fubini bridge be generalized to n dimensions? YES, via the iteratedIntervalIntegral definition and product measure connection.",
     "text": "Defines the n-fold iterated interval integral and proves its key properties, including order independence for continuous functions.",
-    "proofStrategy": "The proof proceeds in layers: (1) For 3D, a 3-step transposition using integral_integral_swap and the 2D swap from the parent entry; (2) For general n, `iteratedIntervalIntegral` is defined by induction and order independence is axiomatized (proved for n≤3, general case follows the same inductive pattern). The key technical innovation is using `Integrable.integral_prod_right` to derive integrability of parametric integrals from 3D integrability, avoiding the need for separate measurability arguments.",
+    "proofStrategy": "The proof proceeds in layers: (1) For 3D, a 3-step transposition using integral_integral_swap and the 2D swap from the parent entry; (2) For general n, `iteratedIntervalIntegral` is defined by induction; arbitrary-permutation order independence is established as a real theorem in the subsidiary module Proofs.GreensTheoremOQ01OQ01OQ01OQ01 (Equiv.Perm.swap_induction_on plus an adjacent-swap Fubini lemma). The key technical innovation is using `Integrable.integral_prod_right` to derive integrability of parametric integrals from 3D integrability, avoiding the need for separate measurability arguments.",
     "keyInsights": [
       "iteratedIntervalIntegral defined by Fin-n induction: ∫ x₀, iteratedIntervalIntegral tail...",
       "Integrable.integral_prod_right: if G(z,x,y) is integrable on 3D product, then (z,x)↦∫y G is integrable on 2D product",
@@ -109,15 +110,15 @@
       "id": "n-dimensional",
       "title": "N-Dimensional Iterated Integral",
       "startLine": 204,
-      "endLine": 255,
-      "summary": "Defines iteratedIntervalIntegral by Fin-n recursion: base f(∅), inductive ∫_{a₀}^{b₀} iteratedIntervalIntegral(tail). Proves n=0,1,2 cases explicitly. Axiomatizes the general order independence for permutations σ ∈ Sₙ — the 2D and 3D cases establish the inductive pattern."
+      "endLine": 248,
+      "summary": "Defines iteratedIntervalIntegral by Fin-n recursion: base f(∅), inductive ∫_{a₀}^{b₀} iteratedIntervalIntegral(tail). Proves n=0,1,2 cases explicitly. The general order independence for permutations σ ∈ Sₙ is delegated to the subsidiary module Proofs.GreensTheoremOQ01OQ01OQ01OQ01, where it is proved as a real theorem; this file no longer carries an axiom."
     }
   ],
   "conclusion": {
-    "summary": "YES: The Fubini bridge generalizes to n dimensions. The 3D case is fully proved (0 sorries) using integral_integral_swap applied twice. The general n-dimensional definition is provided via iteratedIntervalIntegral, with order independence axiomatized for now.",
-    "implications": "This result enables n-dimensional Green's theorem and Stokes' theorem formalizations to use concrete iterated interval integrals rather than abstract product measure integrals. The `iteratedIntervalIntegral` definition provides the right interface for higher-dimensional calculus proofs.",
+    "summary": "YES: The Fubini bridge generalizes to n dimensions. The 3D case is fully proved (0 sorries) using integral_integral_swap applied twice. The general n-dimensional iteratedIntervalIntegral is defined here, and arbitrary-permutation order independence is now proved as a real theorem in the subsidiary module Proofs.GreensTheoremOQ01OQ01OQ01OQ01 — eliminating the previously-stated axiom from this file.",
+    "implications": "This result enables n-dimensional Green's theorem and Stokes' theorem formalizations to use concrete iterated interval integrals rather than abstract product measure integrals. The `iteratedIntervalIntegral` definition provides the right interface for higher-dimensional calculus proofs, and the proof chain is now axiom-free for continuous integrands.",
     "openQuestions": [
-      "Can iteratedIntervalIntegral_order_independent be proved without the axiom, using Mathlib.MeasureTheory.Integral.Marginal.lmarginal_union?",
+      "Can iteratedIntervalIntegral_order_independent be derived directly from Mathlib's Mathlib.MeasureTheory.Integral.Marginal (lmarginal_union / lmarginal_univ) for a shorter proof?",
       "Can the n-dimensional result connect to Mathlib's Measure.pi via the lmarginal_univ theorem?"
     ]
   },


### PR DESCRIPTION
## Summary

Eliminates the dead `iteratedIntervalIntegral_order_independent` axiom from the
parent module `Proofs.GreensTheoremOQ01OQ01OQ01`. The axiom was declared but
never referenced by any theorem in that file, and the same statement is already
proved as a real theorem from first principles in the subsidiary
`Proofs.GreensTheoremOQ01OQ01OQ01OQ01` (line 423, via `Equiv.Perm.swap_induction_on`
+ the adjacent-swap Fubini lemma).

After this change:
- `proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean` no longer carries any `axiom`
  declarations.
- `src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json` is promoted from
  `status=axiomatized` / `badge=axiom` / `axiomCount=1` to `status=verified` /
  `badge=verified` / `axiomCount=0`.
- `src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json`
  (this entry — the axiom-elimination subsidiary) has its `assumptions` prose
  refreshed: it previously claimed *"the parent module still declares the axiom"*,
  which is no longer true.

## Why removing the axiom is safe

1. `grep iteratedIntervalIntegral_order_independent proofs/Proofs/` shows zero
   uses of `GreensTheoremOQ01OQ01OQ01.iteratedIntervalIntegral_order_independent`
   anywhere in the codebase. The only uses are inside
   `GreensTheoremOQ01OQ01OQ01OQ01.lean`, which references its own
   *theorem* of that name, not the parent's axiom.
2. The subsidiary opens only `iteratedIntervalIntegral`, `..._zero`, `..._succ`,
   `..._one`, `..._two` from the parent (line 33–35), not the axiom.
3. The proof in the subsidiary is independent: it uses `Equiv.Perm.swap_induction_on`
   to reduce to adjacent transpositions, then applies the parent's `swap_outer_two`
   pattern via Mathlib `integral_integral_swap`.

## Bookkeeping

- `lineCount` 266 → 260 (meta + leanFile blocks).
- `theoremCount`, `definitionCount`, `sorries` unchanged.
- All other narrative fields (`proofStrategy`, `conclusion`, `originalContributions`,
  `openQuestions`, n-dimensional section summary) updated to point at the
  subsidiary as the home of the n-D order-independence proof.

## Test plan
- [ ] Lean: `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ01`
- [ ] Lean: `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ01OQ01`
- [ ] Gallery: `pnpm build` (verify both entries render with the new
      verified/axiom-free badges and refreshed prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)