### PR TITLE
research(derangements-convergence-oq-01-oq-01): document parity-sign follow-up

### DIFF
--- a/research/problems/derangements-convergence-oq-01-oq-01/knowledge.md
+++ b/research/problems/derangements-convergence-oq-01-oq-01/knowledge.md
@@ -41,3 +41,72 @@
 - **Axiom count**: 0 (no external assumptions)
 - **Sorry count**: 0
 - **Phase**: COMPLETED (pending Docker build verification)
+
+## Session 2026-05-08 (Session 2) — Follow-Up Direction Documented (researcher-6)
+
+**Mode**: REVISIT
+**Outcome**: documented — problem confirmed COMPLETED; identified one substantive follow-up direction (parity-sign theorem) with full proof sketch using existing infrastructure.
+
+### Verification of Prior Work
+- `DerangementsConvergenceOQ01OQ01.lean`: 147 lines, 7 theorems, 0 sorries, 0 axioms ✓
+- Parent `DerangementsConvergence.lean`: 282 lines, 14 theorems, 0 sorries, 0 axioms ✓
+- Pool entry was stale (`status: in-progress` with note about already-resolved `∑ k in` issue) — corrected to `completed` in `.lean/state/candidate-pool.json` runtime state.
+
+### Follow-Up: Parity-Controlled Error Sign
+
+The current file proves `|D(n) - n!/e| < 1/2`. A natural strengthening is the **signed** version: the rounding direction is determined by parity of `n`.
+
+**Conjecture (`derangements_error_sign`)**:
+$$0 \le (-1)^n \cdot \big(D(n) - n!/e\big) \quad \text{for all } n \ge 0$$
+
+Equivalently: $D(n) \ge n!/e$ when $n$ is even, $D(n) \le n!/e$ when $n$ is odd.
+
+**Empirical verification** (`D(n)` and `n!/e`):
+- $n=0$: $D(0)=1$, $0!/e = 1/e \approx 0.368$, diff $\approx +0.632$ → sign $+$ → $(-1)^0 = +$ ✓
+- $n=1$: $D(1)=0$, $1!/e \approx 0.368$, diff $\approx -0.368$ → sign $-$ → $(-1)^1 = -$ ✓
+- $n=2$: $D(2)=1$, $2!/e \approx 0.736$, diff $\approx +0.264$ → sign $+$ → $(-1)^2 = +$ ✓
+- $n=3$: $D(3)=2$, $3!/e \approx 2.207$, diff $\approx -0.207$ → sign $-$ → $(-1)^3 = -$ ✓
+- $n=4$: $D(4)=9$, $4!/e \approx 8.829$, diff $\approx +0.171$ → sign $+$ → $(-1)^4 = +$ ✓
+
+### Proof Sketch (uses only already-public lemmas)
+
+Let $a_k = (-1)^k / k!$ so $\text{altFactPartialSum}(n) = \sum_{k=0}^n a_k$ and $e^{-1} = \sum_{k\ge 0} a_k$.
+
+1. From `derangements_div_factorial`: $D(n)/n! = \sum_{k=0}^n a_k$.
+2. From `exp_neg_one_eq_tsum_alt` and `tsum_eq_partial_sum_add_tail`:
+   $$e^{-1} = \sum_{k=0}^n a_k + \sum_{k\ge 0} a_{n+1+k}$$
+3. So $D(n)/n! - e^{-1} = -\sum_{k\ge 0} a_{n+1+k}$.
+4. **Factor extraction**: $a_{n+1+k} = (-1)^{n+1+k}/(n+1+k)! = (-1)^{n+1} \cdot c_k$ where $c_k = (-1)^k/(n+1+k)!$.
+5. Therefore $D(n)/n! - e^{-1} = (-1)^{n} \cdot \sum_{k\ge 0} c_k$ (the two minus signs combine).
+6. **Sign of the residual sum**: by `alt_partial_sum_nonneg` (already proved, with `m = n+1`), every partial sum $\sum_{k=0}^N c_k \ge 0$. Taking the limit: $\sum_{k\ge 0} c_k \ge 0$.
+7. Multiply by $(-1)^n$: $(-1)^n \cdot (D(n)/n! - e^{-1}) = \sum_{k\ge 0} c_k \ge 0$.
+8. Multiply by $n! > 0$: $(-1)^n \cdot (D(n) - n!/e) \ge 0$. ∎
+
+### Lean Skeleton (for future implementation)
+
+```lean
+/-- The sign of D(n) - n!/e is (-1)^n. -/
+theorem derangements_error_sign (n : ℕ) :
+    0 ≤ (-1 : ℝ) ^ n * ((numDerangements n : ℝ) - (n.factorial : ℝ) / rexp 1) := by
+  -- Strategy: show (-1)^n * (D(n)/n! - 1/e) = ∑' k, (-1)^k / (n+1+k)! ≥ 0,
+  -- then scale by n! ≥ 0.
+  -- Uses: derangements_div_factorial, exp_neg_one_eq_tsum_alt,
+  --       tsum_eq_partial_sum_add_tail, alt_partial_sum_nonneg
+  sorry  -- TODO
+```
+
+### Why This Is Worth Proving
+- **Theory-level**: Tells us the precise rounding rule (round-up for even $n$, round-down for odd $n$), not just that rounding works.
+- **Reuses existing infrastructure**: `alt_partial_sum_nonneg` was proved (lines 119–166 of `DerangementsConvergence.lean`) but is currently unused outside the absolute-value bound. The signed version exposes its mathematical content.
+- **Sharper bound**: Combined with `derangements_rate_scaled`, gives $0 \le (-1)^n(D(n) - n!/e) \le 1/(n+1)$ — a two-sided sharp bound.
+- **Complements `derangements_unique_nearest`**: uniqueness picks the right integer, sign identifies the rounding direction.
+
+### Why Not Done This Session
+- Build infrastructure currently slow (`proofs/.lake` is a recursive self-symlink → every Docker build does fresh Mathlib clone, ~30–45 min).
+- Risk of partial Lean error not worth holding the gallery entry; this slug is already verified+original.
+- Recorded as a self-contained follow-up so the next researcher (or Aristotle) can pick it up cheaply.
+
+### Status
+- **Axiom count**: 0 (unchanged)
+- **Sorry count**: 0 (unchanged)
+- **Phase**: COMPLETED with documented follow-up

--- a/src/data/research/problems/derangements-convergence-oq-01-oq-01.json
+++ b/src/data/research/problems/derangements-convergence-oq-01-oq-01.json
@@ -3,31 +3,34 @@
   "phase": "COMPLETED",
   "status": "completed",
   "problemStatement": {
-    "formal": "∀ n ≥ 1, |(numDerangements n : ℝ) - (n.factorial : ℝ) / rexp 1| < 1/2",
-    "plain": "For all n ≥ 1, D(n) is the nearest integer to n!/e.",
+    "formal": "\u2200 n \u2265 1, |(numDerangements n : \u211d) - (n.factorial : \u211d) / rexp 1| < 1/2",
+    "plain": "For all n \u2265 1, D(n) is the nearest integer to n!/e.",
     "whyMatters": [
       "The rounding formula D(n) = round(n!/e) provides a simple computation rule",
       "The unique nearest integer property characterizes D(n) analytically"
     ]
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 7 theorems proved, 0 sorries, 0 axioms in DerangementsConvergenceOQ01OQ01.lean (nearest integer theorem). Reconciled stale leanFiles drift (DerangementsConvergenceOQ01.lean: sorryCount 4→0, lineCount 153→152) — those 'sorries' were comment mentions, the file actually has 0 real sorries.",
+    "progressSummary": "COMPLETE: 7 theorems proved, 0 sorries, 0 axioms in DerangementsConvergenceOQ01OQ01.lean (nearest integer theorem). Reconciled stale leanFiles drift (DerangementsConvergenceOQ01.lean: sorryCount 4\u21920, lineCount 153\u2192152) \u2014 those 'sorries' were comment mentions, the file actually has 0 real sorries. Session 2 (2026-05-08, researcher-6): documented parity-sign follow-up with full proof sketch using existing public lemmas.",
     "builtItems": [
-      "derangements_rate_scaled: |D(n) - n!/e| ≤ 1/(n+1) for all n",
-      "derangements_nearest_integer: |D(n) - n!/e| < 1/2 for n ≥ 2",
+      "derangements_rate_scaled: |D(n) - n!/e| \u2264 1/(n+1) for all n",
+      "derangements_nearest_integer: |D(n) - n!/e| < 1/2 for n \u2265 2",
       "derangements_nearest_integer_n1: |D(1) - 1/e| < 1/2 via e > 2",
-      "derangements_nearest_all: |D(n) - n!/e| < 1/2 for all n ≥ 1",
+      "derangements_nearest_all: |D(n) - n!/e| < 1/2 for all n \u2265 1",
       "derangements_unique_nearest: D(n) is unique nearest natural to n!/e",
       "derangements_quarter_bound and derangements_parametric_bound"
     ],
     "insights": [
-      "Rate scaling: multiply |D(n)/n! - e⁻¹| ≤ 1/(n+1)! by n! to get |D(n) - n!/e| ≤ 1/(n+1)",
+      "Rate scaling: multiply |D(n)/n! - e\u207b\u00b9| \u2264 1/(n+1)! by n! to get |D(n) - n!/e| \u2264 1/(n+1)",
       "n=1 case uses Real.add_one_lt_exp one_ne_zero for strict e > 2",
-      "Integer gap lemma: omega closes |m-D(n)| < 1 → m = D(n) after Int casting",
-      "macOS sed silently fails on Unicode: use Python for ∑ k in → ∑ k ∈ fixes"
+      "Integer gap lemma: omega closes |m-D(n)| < 1 \u2192 m = D(n) after Int casting",
+      "macOS sed silently fails on Unicode: use Python for \u2211 k in \u2192 \u2211 k \u2208 fixes",
+      "Parity-controlled error sign: (-1)^n * (D(n) - n!/e) \u2265 0 \u2014 proof via alt_partial_sum_nonneg (already public) + tsum tail extraction. Documents precise rounding direction."
     ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Formalize derangements_error_sign theorem: 0 \u2264 (-1)^n * (numDerangements n - n!/e). Proof skeleton in research/problems/derangements-convergence-oq-01-oq-01/knowledge.md (Session 2)."
+    ]
   },
   "leanFiles": [
     {


### PR DESCRIPTION
## Summary
Session 2 (REVISIT, researcher-6) on `derangements-convergence-oq-01-oq-01`. The slug is already COMPLETED (7 theorems, 0 sorries, 0 axioms in `DerangementsConvergenceOQ01OQ01.lean`); this PR documents one substantive follow-up direction without modifying any Lean source.

## Mathematical Content

**Conjecture (parity-controlled error sign)**: $0 \le (-1)^n \cdot (D(n) - n!/e)$ for all $n \ge 0$.

Equivalently: $D(n)$ rounds $n!/e$ up when $n$ is even, down when $n$ is odd. Empirically verified for $n=0,\dots,4$ in the knowledge file. This complements the existing absolute-value bound `derangements_nearest_all` (`|D(n) - n!/e| < 1/2`) by identifying the rounding direction.

## Proof Sketch (no new infrastructure needed)

Uses only already-public lemmas from `proofs/Proofs/DerangementsConvergence.lean`:
- `derangements_div_factorial`: $D(n)/n! = \sum_{k=0}^{n}(-1)^k/k!$
- `exp_neg_one_eq_tsum_alt`: $e^{-1} = \sum_{k\ge 0}(-1)^k/k!$
- `tsum_eq_partial_sum_add_tail`: split sum at index $n$
- `alt_partial_sum_nonneg`: every partial sum of the shifted alternating series is $\ge 0$

Strategy: factor $(-1)^{n+1}$ out of the alternating tail starting at $k=n+1$, combine the two minus signs to get $D(n)/n! - e^{-1} = (-1)^n \cdot S$ where $S \ge 0$, then scale by $n! \ge 0$. Full step-by-step proof in the knowledge file.

## Why This Adds Value
- **Theory-level**: the original file proves $|\Delta_n| < 1/2$ but says nothing about the sign of $\Delta_n = D(n) - n!/e$. The signed version pins down the precise rounding rule.
- **Reuses dormant infrastructure**: `alt_partial_sum_nonneg` (lines 119–166 of the parent file) was proved but its mathematical content — sign, not magnitude — is currently hidden behind an absolute-value wrapper.
- **Sharper two-sided bound**: combined with `derangements_rate_scaled`, gives $0 \le (-1)^n(D(n) - n!/e) \le 1/(n+1)$.

## Why Not Done This Session
- `proofs/.lake` is currently a recursive self-symlink → every Docker build would fresh-clone Mathlib (~30–45 min).
- This slug is already verified+original; risk of an in-flight Lean error is not worth holding the gallery state.
- Recorded as a self-contained, well-specified follow-up so the next researcher (or Aristotle) can pick it up cheaply.

## Files Changed
- `research/problems/derangements-convergence-oq-01-oq-01/knowledge.md` — Session 2 entry with empirical verification, full proof sketch, Lean skeleton.
- `src/data/research/problems/derangements-convergence-oq-01-oq-01.json` — added insight + nextStep for the parity-sign theorem.

## Status
**Outcome**: documented (REVISIT)
**Next Steps**: formalize `derangements_error_sign` per the proof sketch when build infra recovers.

🤖 Generated by researcher-6