### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-02): Part VIII — prime-n specialization

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -386,6 +386,61 @@ theorem symBUDim_twelve_lower_unconditional (k : ℕ) (hk : 0 < k) :
     2 * k - 1 ≤ symBUDim 12 (2 * k) :=
   symBUDim_even_lower 12 k (by norm_num) hk
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART VIII: Conjecture specialized at prime n
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Specialization at prime n**: at any prime `p`, the conjectural equality
+    `symBUDim_eq_largestPrime` simplifies to the clean statement
+        `symBUDim p d = buDim p d`,
+    because `largestPrimeBelow p = p` by `largestPrimeBelow_self_of_prime`.
+
+    This isolates the *prime-n content* of the open question: when `n` is
+    itself prime, the conjecture asks whether the Sₙ-equivariant BU
+    dimension equals the cyclic-prime-`n` BU dimension — a strictly
+    Sₙ-versus-ℤ/p question, no Bertrand selector involved.
+
+    **Conditional on the axiom** `symBUDim_eq_largestPrime`. The statement
+    has no prime-≥2 hypothesis on the RHS because primality already forces
+    `2 ≤ p` via `Nat.Prime.two_le`. -/
+theorem symBUDim_eq_buDim_at_prime (p d : ℕ) (hp : Nat.Prime p) :
+    symBUDim p d = buDim p d := by
+  have h2 : 2 ≤ p := hp.two_le
+  rw [symBUDim_eq_largestPrime p d h2, largestPrimeBelow_self_of_prime p hp]
+
+/-- **Tight closed form at prime n on even d** (conditional on the axiom):
+    for prime `p` and `k ≥ 1`,
+        `symBUDim p (2k) = 2k - 1`.
+    Combines `symBUDim_eq_buDim_at_prime` with parent's `buDim_prime`. -/
+theorem symBUDim_prime_even_formula (p k : ℕ) (hp : Nat.Prime p) (hk : 0 < k) :
+    symBUDim p (2 * k) = 2 * k - 1 := by
+  rw [symBUDim_eq_buDim_at_prime p (2 * k) hp]
+  exact buDim_prime p k hp hk
+
+/-- **Concrete prime-n instance at n = 11** (conditional):
+    `symBUDim 11 d = buDim 11 d`. -/
+theorem symBUDim_eleven_eq_buDim_eleven (d : ℕ) :
+    symBUDim 11 d = buDim 11 d :=
+  symBUDim_eq_buDim_at_prime 11 d (by norm_num)
+
+/-- **Concrete prime-n instance at n = 13** (conditional):
+    `symBUDim 13 d = buDim 13 d`. Pushes the enumerated range past 12. -/
+theorem symBUDim_thirteen_eq_buDim_thirteen (d : ℕ) :
+    symBUDim 13 d = buDim 13 d :=
+  symBUDim_eq_buDim_at_prime 13 d (by norm_num)
+
+/-- **Concrete closed form at n = 11** (conditional):
+    `symBUDim 11 (2k) = 2k - 1` for k ≥ 1. -/
+theorem symBUDim_eleven_even_formula (k : ℕ) (hk : 0 < k) :
+    symBUDim 11 (2 * k) = 2 * k - 1 :=
+  symBUDim_prime_even_formula 11 k (by norm_num) hk
+
+/-- **Concrete closed form at n = 13** (conditional):
+    `symBUDim 13 (2k) = 2k - 1` for k ≥ 1. -/
+theorem symBUDim_thirteen_even_formula (k : ℕ) (hk : 0 < k) :
+    symBUDim 13 (2 * k) = 2 * k - 1 :=
+  symBUDim_prime_even_formula 13 k (by norm_num) hk
+
 /-
 ## Summary
 
@@ -430,6 +485,15 @@ theorem symBUDim_twelve_lower_unconditional (k : ℕ) (hk : 0 < k) :
 ### Theorems requiring `symBUDim_eq_largestPrime` axiom
 - `symBUDim_even_formula` — closed form on even d.
 - `symBUDim_three_four`, `symBUDim_four_six` — concrete instances.
+- `symBUDim_eq_buDim_at_prime` — at any prime p, conjecture collapses to
+  `symBUDim p d = buDim p d` (isolates the *prime-n content*: Sₙ vs ℤ/p,
+  no Bertrand selector).
+- `symBUDim_prime_even_formula` — closed form `symBUDim p (2k) = 2k - 1`
+  at any prime p, k ≥ 1.
+- `symBUDim_eleven_eq_buDim_eleven`, `symBUDim_thirteen_eq_buDim_thirteen` —
+  concrete prime-n instances at n = 11, 13.
+- `symBUDim_eleven_even_formula`, `symBUDim_thirteen_even_formula` —
+  concrete closed forms at n = 11, 13.
 
 ### Concrete instances (axiom-free)
 - `symBUDim_five_lower_unconditional`, `symBUDim_two_four_unconditional`,
@@ -460,5 +524,7 @@ theorem symBUDim_twelve_lower_unconditional (k : ℕ) (hk : 0 < k) :
 #check @largestPrimeBelow_lt_of_not_prime
 #check @largestPrimeBelow_mono
 #check @symBUDim_eq_largestPrime_two_unconditional
+#check @symBUDim_eq_buDim_at_prime
+#check @symBUDim_prime_even_formula
 
 end BorsukUlamSymPrime

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 464,
+    "lineCount": 530,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -76,10 +76,14 @@
       "symBUDim_{six,seven,eight}_lower_unconditional: axiom-free Yang-Borsuk lower bounds 2k - 1 ≤ symBUDim n (2k) for n ∈ {6,7,8} via direct application of symBUDim_even_lower",
       "largestPrimeBelow_mono: monotonicity of the prime selector — n ≤ m → largestPrimeBelow n ≤ largestPrimeBelow m. Structural prerequisite for compatibility of the symBUDim_eq_largestPrime axiom with the parent's sym_has_smaller_sym monotonicity (stretch goal in the research roadmap). Handles n < 2 case via the fact that findGreatest returns 0 when no prime ≤ 1 exists",
       "largestPrimeBelow_eight_le_eleven: concrete monotonicity instance",
-      "symBUDim_{nine,ten,eleven,twelve}_lower_unconditional: extended axiom-free lower bounds 2k - 1 ≤ symBUDim n (2k) for n ∈ {9,10,11,12}, covering both prime (n=11) and composite (n=9=3², n=10, n=12) cases"
+      "symBUDim_{nine,ten,eleven,twelve}_lower_unconditional: extended axiom-free lower bounds 2k - 1 ≤ symBUDim n (2k) for n ∈ {9,10,11,12}, covering both prime (n=11) and composite (n=9=3², n=10, n=12) cases",
+      "symBUDim_eq_buDim_at_prime: at any prime p, the conjectural equality symBUDim_eq_largestPrime collapses (via largestPrimeBelow_self_of_prime) to the clean statement symBUDim p d = buDim p d — isolates the *prime-n content* of the open question (Sₙ vs ℤ/p, no Bertrand selector involved). Conditional on the new axiom",
+      "symBUDim_prime_even_formula: tight closed form symBUDim p (2k) = 2k - 1 at any prime p with k ≥ 1; combines symBUDim_eq_buDim_at_prime with parent's buDim_prime",
+      "symBUDim_{eleven,thirteen}_eq_buDim: concrete prime-n equality instances at n = 11, 13 (conditional)",
+      "symBUDim_{eleven,thirteen}_even_formula: concrete prime-n closed-form instances symBUDim 11 (2k) = 2k - 1, symBUDim 13 (2k) = 2k - 1 (conditional)"
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **The n=2 instance of this axiom is redundant** — `symBUDim_eq_largestPrime_two_unconditional` proves it axiom-free from the parent's `symBUDim_two` axiom + `largestPrimeBelow_two`. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime` (counted in the parent gallery entries).",
-    "theoremCount": 27,
+    "theoremCount": 33,
     "definitionCount": 1
   },
   "overview": {
@@ -95,7 +99,8 @@
       "**Failure modes for the conjecture.** If the conjecture fails at some $n$, the failure must come from $S_n$-specific structure: Klein-4 $V_4 \\leq S_4$ (non-cyclic of order 4), representation-theoretic obstructions from non-trivial irreducibles, or higher-cohomology classes in the Fadell-Husseini index. Natural test cases: $n = 4$ ($p^* = 3$, but $V_4 \\leq S_4$) and $n = 8$ ($p^* = 7$, but $S_8$ has rich subgroup structure including $A_4 \\times A_4$, etc.).",
       "**Concrete computations are immediate.** `symBUDim_three_four = 3` and `symBUDim_four_six = 5` follow from the closed-form formula; the unconditional `symBUDim_five_lower_unconditional` is axiom-free up to parent. These serve as both regression tests and Lean-verified instances of the conjecture's predictions.",
       "**Bertrand-Chebyshev makes the factor-2 gap formal.** The unconditional cyclic lower bound `2k − 1 ≤ symBUDim n (2k)` matches the conjectural upper bound exactly modulo the open axiom — but it's also worth showing that the prime witness $p^*$ is genuinely close to $n$, not just some small prime. `n_div_two_lt_largestPrimeBelow` formalizes this: for any $n \\geq 2$, $p^* > n/2$, axiom-free via Mathlib's `Nat.exists_prime_lt_and_le_two_mul`. The prime witness is in the dyadic window $(n/2, n]$, so any improvement beyond the cyclic lower bound must come from $S_n$-specific (non-cyclic) structure.",
-      "**The n=2 instance of the conjecture is provable, axiom-free.** `symBUDim_eq_largestPrime_two_unconditional` shows that the conjectured equality $\\text{symBUDim}(n, d) = \\text{buDim}(p^*, d)$ at $n=2$ is *not* an independent axiom: it follows from the parent file's pre-existing `symBUDim_two` axiom and the squeeze-argument `largestPrimeBelow_self_of_prime` (instantiated at $n = p = 2$). This is a non-trivial *consistency check* — the new axiom `symBUDim_eq_largestPrime` is compatible with prior axiomatization, and its true open content is for $n \\geq 3$. (For larger primes $n$, the analogous derivation would require a $\\text{symBUDim}_p$ base axiom that the gallery does not yet have.)"
+      "**The n=2 instance of the conjecture is provable, axiom-free.** `symBUDim_eq_largestPrime_two_unconditional` shows that the conjectured equality $\\text{symBUDim}(n, d) = \\text{buDim}(p^*, d)$ at $n=2$ is *not* an independent axiom: it follows from the parent file's pre-existing `symBUDim_two` axiom and the squeeze-argument `largestPrimeBelow_self_of_prime` (instantiated at $n = p = 2$). This is a non-trivial *consistency check* — the new axiom `symBUDim_eq_largestPrime` is compatible with prior axiomatization, and its true open content is for $n \\geq 3$. (For larger primes $n$, the analogous derivation would require a $\\text{symBUDim}_p$ base axiom that the gallery does not yet have.)",
+      "**At prime n, the conjecture has a strikingly simpler form.** Specializing `symBUDim_eq_largestPrime` at any prime $p$ gives `symBUDim p d = buDim p d` (since `largestPrimeBelow p = p` by the squeeze argument). The Bertrand selector and the `n/2 < p^* \\leq n$` window collapse to the trivial `p^* = n` — there is no choice to make. So the *prime-n case* asks whether the symmetric-group BU dimension equals the cyclic-prime-$n$ BU dimension, a strictly $S_n$-versus-$\\mathbb{Z}/p$ comparison. This separates two qualitatively different difficulties: composite-$n$ cases (the prime $p^* < n$ is a non-trivial choice) versus prime-$n$ cases (no choice, Sₙ vs ℤ/p directly). Captured in `symBUDim_eq_buDim_at_prime` and instantiated at $n = 11, 13$."
     ],
     "prerequisites": [
       "BorsukUlamOQ02OQ01.lean (cyclic-group buDim, buDim_two, buDim_prime, buDim_mono)",
@@ -160,6 +165,14 @@
       "endLine": 271,
       "summary": "`largestPrimeBelow_self_of_prime` (general, axiom-free): for prime $n$, $\\text{largestPrimeBelow}(n) = n$ via squeeze. Concrete corollaries `largestPrimeBelow_two/_three/_five/_seven`. `symBUDim_eq_largestPrime_two_unconditional` (axiom-free): the n=2 case of the conjectured equality is provable from parent's `symBUDim_two` + `largestPrimeBelow_two`, *without* invoking the new `symBUDim_eq_largestPrime` axiom — a non-trivial consistency check. `symBUDim_two_even_formula_unconditional`, `symBUDim_two_four_unconditional`: axiom-free closed form and concrete instance at n=2.",
       "mathContext": "The squeeze argument: $n \\leq \\text{findGreatest}(\\text{Prime}, n)$ from `Nat.le_findGreatest le_rfl hn`, and $\\text{findGreatest}(\\text{Prime}, n) \\leq n$ from `Nat.findGreatest_le`, hence equality when $n$ is prime. At n=2 this reduces the conjecture to the parent's pre-existing `symBUDim_two` axiom — showing the new axiom is consistent with prior axiomatization and contributes new content only for $n \\geq 3$."
+    },
+    {
+      "id": "prime-n-specialization",
+      "title": "Part VIII: Conjecture Specialized at Prime n",
+      "startLine": 388,
+      "endLine": 443,
+      "summary": "`symBUDim_eq_buDim_at_prime`: at any prime $p$, the conjectural equality `symBUDim_eq_largestPrime` collapses (via `largestPrimeBelow_self_of_prime`) to the clean statement $\\text{symBUDim}(p, d) = \\text{buDim}(p, d)$. `symBUDim_prime_even_formula`: tight closed form $\\text{symBUDim}(p, 2k) = 2k - 1$ at any prime $p$, $k \\geq 1$ (combines `symBUDim_eq_buDim_at_prime` + parent's `buDim_prime`). Concrete instances `symBUDim_eleven_eq_buDim_eleven`, `symBUDim_thirteen_eq_buDim_thirteen`, `symBUDim_eleven_even_formula`, `symBUDim_thirteen_even_formula`. All conditional on the new axiom.",
+      "mathContext": "At prime $n$, the Bertrand selector and the dyadic window $(n/2, n]$ collapse: $p^* = n$ is forced. The conjecture's content reduces to whether the symmetric-group BU dimension equals the cyclic-prime-$n$ BU dimension — a strictly $S_n$-versus-$\\mathbb{Z}/p$ comparison. Separates two qualitatively different difficulties: composite-$n$ cases (the prime $p^* < n$ is a non-trivial choice from Bertrand's window) versus prime-$n$ cases (no choice, direct comparison). The cleanly-isolated prime-$n$ case may admit elementary equivariant techniques."
     }
   ],
   "crossReferences": [
@@ -203,10 +216,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 464,
+    "lineCount": 530,
     "axiomCount": 1,
-    "theoremCount": 29,
-    "substantiveTheoremCount": 27,
+    "theoremCount": 35,
+    "substantiveTheoremCount": 33,
     "definitionCount": 1,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0
@@ -273,6 +286,12 @@
       "type": "supporting",
       "description": "For n ≥ 2, largestPrimeBelow n is prime (witness p = 2).",
       "leanType": "(n : ℕ) → 2 ≤ n → Nat.Prime (largestPrimeBelow n)"
+    },
+    {
+      "name": "symBUDim_eq_buDim_at_prime",
+      "type": "core",
+      "description": "Specialization at prime n: the conjectural equality symBUDim_eq_largestPrime collapses to symBUDim p d = buDim p d at any prime p (since largestPrimeBelow p = p). Isolates the prime-n content of the open question. Conditional on the new axiom.",
+      "leanType": "(p d : ℕ) → Nat.Prime p → symBUDim p d = buDim p d"
     },
     {
       "name": "n_div_two_lt_largestPrimeBelow",


### PR DESCRIPTION
## Summary

Adds **Part VIII** to `BorsukUlamOQ02OQ01OQ03OQ02.lean`, specializing the conjectural equality `symBUDim_eq_largestPrime` at prime n. At any prime p, `largestPrimeBelow p = p`, so the conjecture collapses to

$$\\mathrm{symBUDim}(p, d) = \\mathrm{buDim}(p, d).$$

The Bertrand selector and the dyadic window $(n/2, n]$ disappear: there is no prime to choose. This isolates the *prime-n content* of the open question — a strictly $S_n$-versus-$\\mathbb{Z}/p$ comparison — from the composite-n content (where $p^* < n$ is a non-trivial choice from Bertrand's window).

## What's new

- **`symBUDim_eq_buDim_at_prime (p d : ℕ) (hp : Nat.Prime p)`** — the core specialization, conditional on the existing axiom. Proof: `largestPrimeBelow_self_of_prime` rewrites the axiom's RHS.
- **`symBUDim_prime_even_formula (p k : ℕ) (hp : Nat.Prime p) (hk : 0 < k)`** — tight closed form $\\mathrm{symBUDim}(p, 2k) = 2k - 1$ at any prime p.
- **Concrete instances** at n = 11, 13: `symBUDim_eleven_eq_buDim_eleven`, `symBUDim_thirteen_eq_buDim_thirteen`, `symBUDim_eleven_even_formula`, `symBUDim_thirteen_even_formula`. Push the file's enumerated range past the existing $n \\leq 12$ unconditional bounds.

No new axioms. Existing axiom count remains 1.

## Counts

| | before | after |
|---|---|---|
| `lineCount` | 464 | 530 |
| `meta.theoremCount` | 27 | 33 |
| `leanFile.theoremCount` | 29 | 35 |
| `substantiveTheoremCount` | 27 | 33 |
| `axiomCount` | 1 | 1 |
| `sorries` | 0 | 0 |

## meta.json updates

- 4 new entries in `originalContributions` (Part VIII content)
- 1 new `keyInsights` entry (prime-n vs composite-n separation)
- 1 new `sections` entry (`prime-n-specialization`, lines 388–443)
- 1 new `mainTheorems` entry (`symBUDim_eq_buDim_at_prime`)
- All count fields synced (lineCount, theoremCount, substantiveTheoremCount)

## Test plan

- [ ] Docker build of `Proofs.BorsukUlamOQ02OQ01OQ03OQ02` succeeds (proofs use only `Nat.Prime.two_le`, `buDim_prime`, and in-file infrastructure already used elsewhere in the project — risk is low)
- [ ] Gallery render: new Part VIII section appears with correct line ranges
- [ ] Auditor: scalar counts match `find-targets.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)