### PR TITLE
fix(binary-gcd-oq-03-oq-02): repair build — Int.natAbs rename + split-tactic regression (#16938)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -302,11 +302,10 @@ theorem lehmerInnerStep_invariant {a₀ b₀ : ℤ} {ahat bhat : ℕ} {M : Cofac
     a₀ * M'.α + b₀ * M'.γ = (ahat' : ℤ) ∧
     a₀ * M'.β + b₀ * M'.δ = (bhat' : ℤ) := by
   simp [lehmerInnerStep] at h_step
-  split at h_step <;> simp_all
-  split at h_step <;> simp_all
-  -- Surviving case: bhat ≠ 0 and ahat % bhat ≠ 0; the some-equation
-  -- has reduced to the equality of the triples.
-  obtain ⟨rfl, rfl, rfl⟩ := h_step
+  -- Modern simp reduces the some-equation directly to a 5-conjunct
+  -- (bhat ≠ 0, ahat%bhat ≠ 0, bhat = ahat', ahat%bhat = bhat', struct = M');
+  -- destructure with `rfl` on the last three to substitute ahat', bhat', M'.
+  obtain ⟨_, _, rfl, rfl, rfl⟩ := h_step
   refine ⟨?_, ?_⟩
   · -- a₀ * M'.α + b₀ * M'.γ = a₀ * M.β + b₀ * M.δ = bhat
     exact h_inv₂
@@ -500,9 +499,7 @@ theorem lehmerInnerStep_even_to_odd {ahat bhat : ℕ} {M M' : CofactorMatrix}
     (heven : EvenPattern M) :
     OddPattern M' := by
   simp [lehmerInnerStep] at hstep
-  split at hstep <;> simp_all
-  split at hstep <;> simp_all
-  obtain ⟨_, _, rfl⟩ := hstep
+  obtain ⟨_, _, _, _, rfl⟩ := hstep
   obtain ⟨hα, hβ, hγ, hδ⟩ := heven
   simp only [OddPattern]
   have hq : (0 : ℤ) ≤ (ahat / bhat : ℕ) := Int.ofNat_nonneg _
@@ -517,9 +514,7 @@ theorem lehmerInnerStep_odd_to_even {ahat bhat : ℕ} {M M' : CofactorMatrix}
     (hodd : OddPattern M) :
     EvenPattern M' := by
   simp [lehmerInnerStep] at hstep
-  split at hstep <;> simp_all
-  split at hstep <;> simp_all
-  obtain ⟨_, _, rfl⟩ := hstep
+  obtain ⟨_, _, _, _, rfl⟩ := hstep
   obtain ⟨hα, hβ, hγ, hδ⟩ := hodd
   simp only [EvenPattern]
   have hq : (0 : ℤ) ≤ (ahat / bhat : ℕ) := Int.ofNat_nonneg _
@@ -1015,8 +1010,8 @@ theorem hgcdMatrix_small_row_output_le (fuel a b : ℕ) (h : max a b < hgcdThres
   rw [hgcdMatrix_small fuel a b h]
   obtain ⟨ahat', bhat', h1, h2, hmax⟩ := lehmerCofactors_id_apply_le hgcdThreshold a b
   constructor
-  · rw [h1]; simp only [Int.natAbs_ofNat]; exact le_trans (le_max_left ahat' bhat') hmax
-  · rw [h2]; simp only [Int.natAbs_ofNat]; exact le_trans (le_max_right ahat' bhat') hmax
+  · rw [h1]; simp only [Int.natAbs_natCast]; exact le_trans (le_max_left ahat' bhat') hmax
+  · rw [h2]; simp only [Int.natAbs_natCast]; exact le_trans (le_max_right ahat' bhat') hmax
 
 /-- [Sorry] The ROW output of `hgcdMatrix fuel a b` is bounded by `max a b`.
 
@@ -1062,7 +1057,7 @@ theorem hgcdMatrix_row_output_le (fuel a b : ℕ) :
   induction fuel generalizing a b with
   | zero =>
     rw [hgcdMatrix_zero]
-    simp [CofactorMatrix.id, Int.natAbs_ofNat]
+    simp [CofactorMatrix.id, Int.natAbs_natCast]
     exact ⟨le_max_left a b, le_max_right a b⟩
   | succ f ih =>
     by_cases hsmall : max a b < hgcdThreshold


### PR DESCRIPTION
## Fix

`proofs/Proofs/BinaryGcdOQ03OQ02.lean` did not build end-to-end against Lean v4.26.0 / Mathlib v4.26.0 due to two API/tactic regressions described in #16938.

### Site A — `Int.natAbs_ofNat` rename (3 sites)

Mathlib renamed `Int.natAbs_ofNat` → `Int.natAbs_natCast`. Updated lines 1018, 1019, 1065.

### Site B — `split at hstep` after `simp [lehmerInnerStep]` (3 sites)

`lehmerInnerStep` is `if bhat = 0 then none else (… if r = 0 then none else some (bhat, r, ⟨α', β', γ', δ'⟩))`. Modern simp now reduces the `some`-equation directly to a flat 5-conjunct without leaving an `if-then-else` in the hypothesis, so `split at hstep` no longer applies (this is the same shape already handled at `lehmerInnerStep_det`, line 232, with `obtain ⟨_, _, _, _, rfl⟩`).

Replaced the broken `simp + 2× split + obtain ⟨…⟩` block with a single `simp [lehmerInnerStep]` followed by an `obtain` matching the modern simp output:

| Site | Theorem | New `obtain` pattern |
|------|---------|----------------------|
| 304-306 | `lehmerInnerStep_invariant` | `⟨_, _, rfl, rfl, rfl⟩ := h_step` (substitutes `ahat'`, `bhat'`, `M'`) |
| 502-504 | `lehmerInnerStep_even_to_odd` | `⟨_, _, _, _, rfl⟩ := hstep` (only `M'` substitution needed) |
| 519-522 | `lehmerInnerStep_odd_to_even` | `⟨_, _, _, _, rfl⟩ := hstep` (only `M'` substitution needed) |

## Evidence

**Before**: `unknown identifier Int.natAbs_ofNat` (3×) + `split tactic ... is not applicable` (3×). 6 errors total per the audit.

**After**: Mathematical content unchanged (no proof omitted, no theorem renamed, no axiom introduced). Diff: 9 insertions, 14 deletions in one file.

## Validation

Docker build was not run by the mechanic in this cycle: the on-disk `proofs/.lake` recursive self-symlink (see `feedback_researcher_lake_symlink_broken.md`) makes a clean Mathlib clone + cache-get plus build run ~45 min, exceeding the agent's 30-min cycle, and another `lean-build-*` Docker container is already occupying the host. The audit's suggested patterns were applied verbatim, and the chosen `obtain` shape is verified to match the working tactic at `lehmerInnerStep_det` (line 232) under the same `simp [lehmerInnerStep]` reduction.

If a follow-up build surfaces residual errors, file a new auditor issue and the next mechanic cycle will iterate.

Closes #16938

---
Automated fix by lean-mechanic agent.