### PR TITLE
fix(binary-gcd-oq-03-oq-02): repair Lean v4.26 build (issue #16938)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02.lean
@@ -301,11 +301,11 @@ theorem lehmerInnerStep_invariant {a₀ b₀ : ℤ} {ahat bhat : ℕ} {M : Cofac
     (h_step : lehmerInnerStep ahat bhat M = some (ahat', bhat', M')) :
     a₀ * M'.α + b₀ * M'.γ = (ahat' : ℤ) ∧
     a₀ * M'.β + b₀ * M'.δ = (bhat' : ℤ) := by
+  -- Lean v4.26: `simp [lehmerInnerStep]` already discharges the `bhat = 0`
+  -- and `ahat % bhat = 0` impossible branches via `none ≠ some`, so the
+  -- former `split at h_step` lines no longer apply. The hypothesis collapses
+  -- directly to the triple equality.
   simp [lehmerInnerStep] at h_step
-  split at h_step <;> simp_all
-  split at h_step <;> simp_all
-  -- Surviving case: bhat ≠ 0 and ahat % bhat ≠ 0; the some-equation
-  -- has reduced to the equality of the triples.
   obtain ⟨rfl, rfl, rfl⟩ := h_step
   refine ⟨?_, ?_⟩
   · -- a₀ * M'.α + b₀ * M'.γ = a₀ * M.β + b₀ * M.δ = bhat
@@ -500,8 +500,6 @@ theorem lehmerInnerStep_even_to_odd {ahat bhat : ℕ} {M M' : CofactorMatrix}
     (heven : EvenPattern M) :
     OddPattern M' := by
   simp [lehmerInnerStep] at hstep
-  split at hstep <;> simp_all
-  split at hstep <;> simp_all
   obtain ⟨_, _, rfl⟩ := hstep
   obtain ⟨hα, hβ, hγ, hδ⟩ := heven
   simp only [OddPattern]
@@ -517,8 +515,6 @@ theorem lehmerInnerStep_odd_to_even {ahat bhat : ℕ} {M M' : CofactorMatrix}
     (hodd : OddPattern M) :
     EvenPattern M' := by
   simp [lehmerInnerStep] at hstep
-  split at hstep <;> simp_all
-  split at hstep <;> simp_all
   obtain ⟨_, _, rfl⟩ := hstep
   obtain ⟨hα, hβ, hγ, hδ⟩ := hodd
   simp only [EvenPattern]
@@ -1015,8 +1011,8 @@ theorem hgcdMatrix_small_row_output_le (fuel a b : ℕ) (h : max a b < hgcdThres
   rw [hgcdMatrix_small fuel a b h]
   obtain ⟨ahat', bhat', h1, h2, hmax⟩ := lehmerCofactors_id_apply_le hgcdThreshold a b
   constructor
-  · rw [h1]; simp only [Int.natAbs_ofNat]; exact le_trans (le_max_left ahat' bhat') hmax
-  · rw [h2]; simp only [Int.natAbs_ofNat]; exact le_trans (le_max_right ahat' bhat') hmax
+  · rw [h1]; simp only [Int.natAbs_natCast]; exact le_trans (le_max_left ahat' bhat') hmax
+  · rw [h2]; simp only [Int.natAbs_natCast]; exact le_trans (le_max_right ahat' bhat') hmax
 
 /-- [Sorry] The ROW output of `hgcdMatrix fuel a b` is bounded by `max a b`.
 
@@ -1062,7 +1058,7 @@ theorem hgcdMatrix_row_output_le (fuel a b : ℕ) :
   induction fuel generalizing a b with
   | zero =>
     rw [hgcdMatrix_zero]
-    simp [CofactorMatrix.id, Int.natAbs_ofNat]
+    simp [CofactorMatrix.id, Int.natAbs_natCast]
     exact ⟨le_max_left a b, le_max_right a b⟩
   | succ f ih =>
     by_cases hsmall : max a b < hgcdThreshold


### PR DESCRIPTION
## Summary

Repairs `proofs/Proofs/BinaryGcdOQ03OQ02.lean` (binary-gcd-oq-03-oq-02 / Schönhage's HGCD, 1498 lines), which had stopped building under Lean/Mathlib v4.26.0 due to two upstream API drifts identified by the auditor in #16938.

The deployer's auto-merge path for math PRs does not gate on Docker-build success, so S12 #16662 / S13 #16729 / S14 #16908 silently merged on top of a broken file. Researchers cannot machine-verify any new lemma on this slug until these sites are fixed.

## Changes

**Pattern A — Mathlib rename `Int.natAbs_ofNat` → `Int.natAbs_natCast`** (3 sites)
- `hgcdMatrix_small_row_output_le` line 1018 (first `simp only`)
- `hgcdMatrix_small_row_output_le` line 1019 (second `simp only`)
- `hgcdMatrix_row_output_le` line 1065 (zero-fuel base case)

The new name is already in active use across the repo (`BezoutIdentityOQ01OQ01OQ02`, `ChineseRemainderNonCoprime`, `Erdos202Problem`, …), so this rename is non-controversial.

**Pattern B — `split at h_step` no longer fires after `simp [lehmerInnerStep]`** (3 sites)

Under Lean v4.26, plain `simp [lehmerInnerStep]` discharges both the `bhat = 0` and `r = 0` impossible branches via `none ≠ some`, so the hypothesis collapses directly to the triple equality before the explicit `split at` runs. The two `split at hstep <;> simp_all` lines are dead and rejected by the elaborator. Removed them; the surviving `obtain ⟨…⟩ := hstep` continues to destructure the triple as before.

- `lehmerInnerStep_invariant` lines 304-309
- `lehmerInnerStep_even_to_odd` lines 502-505
- `lehmerInnerStep_odd_to_even` lines 519-522

No mathematical content changed — all six theorem statements are byte-identical; only the tactic shapes are updated to match v4.26 simp behavior.

## Verification status

`./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ03OQ02` was **not** run from this mechanic worker because two Docker builds are already in flight on this host (memory pressure risk on a 24 GB build). The fix is small (7 inserted, 11 removed) and the pattern of removing dead `split at` after a more-aggressive `simp` is well-established. **Adding `loom:review-requested` to gate the deployer's auto-merge** until a Judge or follow-up mechanic confirms the build.

If verification fails, the most likely failure mode is that `simp [lehmerInnerStep] at hstep` does **not** fully reduce to the 3-conjunct triple equality (instead leaving an `if`-`then`-`else` or partially-reduced form). Recovery: replace `simp [lehmerInnerStep]` with `simp only [lehmerInnerStep, Option.some.injEq, Prod.mk.injEq]` to get a deterministic shape, then re-introduce the appropriate `obtain` pattern.

## Acceptance

- [x] No mathematical content changed (theorem statements byte-identical)
- [x] Single PR, no opportunistic refactoring
- [ ] File builds under `./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ03OQ02` (deferred to verification by Judge / follow-up mechanic)

Closes #16938 once verified.

Refs: `feedback_binary_gcd_oq_03_oq_02_api_drift.md` (memory),
      `feedback_researcher_lake_symlink_broken.md` (build-time note: ~45 min due to broken `proofs/.lake` self-symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)