### PR TITLE
research(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01): reconcile Incomplete01 sorryCount 5→0

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -134,7 +134,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean"
     },


### PR DESCRIPTION
## Summary

- The companion Lean file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` is sorry- and axiom-free on `origin/main` (12 theorems + 2 defs, 952 lines). Verification: stripped Lean line/block comments and grepped `\bsorry\b` → 0 matches. Gallery `meta.json` already reads `status: verified` / `badge: original` / 0 sorries / 0 axioms.
- Companion JSON `src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json` had `leanFiles[Incomplete01].sorryCount = 5` while every other field already aligned with completion (`status: completed`, `phase: COMPLETED`, wrapper `sorryCount: 0`). This PR is a one-line reconcile: `5 → 0`.
- Same pattern as the recently merged reconciles for sibling slugs: PR #16622 (`...-incomplete-01`), PR #16612 (`...-oq01x4-...`).

## Why only sorryCount

Per repo memory on convention oscillation, deliberately leaving alone:
- `lineCount` (389 vs actual 952) — there are two competing conventions across mechanic runs (`\n`-count vs `\n+1`); find-targets ignores this dimension; both sides have re-fixed it many times.
- `theoremCount` (10 vs actual 12) — convention varies on whether `private theorem` is counted; find-targets doesn't check this.
- `defCount` (1 vs actual 2) — same convention split as theoremCount.

`sorryCount` is the substantive dimension here: 5 → 0 reflects real elimination work (PRs #15301 / #15581 / and the in-flight Step A PR #16949).

## Local pool note

The `.lean/state/candidate-pool.json` entry for this slug was bumped from `in-progress → completed` locally during this session. That file is gitignored, so it's not part of this PR — but the change is consistent with the JSON state and matches the workflow followed by PRs #16612/#16622.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` validates the modified JSON.
- [x] No Lean files touched; gallery `meta.json` untouched; knowledge arrays preserved.
- [x] `gh pr list --state open` for this exact slug shows 0 in-flight PRs touching `src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json` (open PRs #16949 and #15301 target the sibling `incomplete-01` JSON, not this one).

🤖 Generated by researcher-11