### PR TITLE
Research: binomial-theorem-oq-02-oq-01-oq-01-oq-03 — Session 4 (Phase-4 prep)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -209,6 +209,42 @@ theorem multinomialMarginalCDF_eq_binomialCDF
     rw [Finset.mem_filter] at hk
     rw [hk.2, if_neg hcond]
 
+/-! ## Structural properties of `binomialCDF` (Phase-4 prep) -/
+
+/-- For `x < 0`, `binomialCDF n p x = 0`. Every `j ∈ {0, …, n}` satisfies
+    `(j : ℝ) ≥ 0 > x`, so the if-guard is false in every term. -/
+theorem binomialCDF_neg (n : ℕ) (p : ℝ) {x : ℝ} (hx : x < 0) :
+    binomialCDF n p x = 0 := by
+  unfold binomialCDF
+  apply Finset.sum_eq_zero
+  intro j _
+  rw [if_neg (not_le.mpr (lt_of_lt_of_le hx (Nat.cast_nonneg j)))]
+
+/-- `binomialCDF n p` is monotone in `x`, when `0 ≤ p ≤ 1`.
+
+    Each summand is either `0` or the binomial PMF
+    `C(n, j) · p^j · (1 − p)^(n − j)`, which is non-negative under the
+    standing hypothesis `0 ≤ p ≤ 1`. As `x` increases, more if-guards
+    become true, so each summand is non-decreasing.
+
+    Useful for the Phase-4 Portmanteau bridge: continuous monotone CDFs
+    characterize weak convergence on `ℝ`. -/
+theorem binomialCDF_mono (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    Monotone (binomialCDF n p) := by
+  intro x y hxy
+  unfold binomialCDF
+  apply Finset.sum_le_sum
+  intro j _
+  by_cases hjx : (j : ℝ) ≤ x
+  · rw [if_pos hjx, if_pos (le_trans hjx hxy)]
+  · rw [if_neg hjx]
+    by_cases hjy : (j : ℝ) ≤ y
+    · rw [if_pos hjy]
+      have h1mp : 0 ≤ 1 - p := by linarith
+      exact mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (pow_nonneg hp0 _))
+        (pow_nonneg h1mp _)
+    · rw [if_neg hjy]
+
 /-! ## Main theorem: multinomial marginal CLT (derived) -/
 
 /-- **Multinomial marginal CLT** (DERIVED THEOREM, no separate axiom):

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
@@ -288,6 +288,116 @@ measure-theoretic `gaussianMeasure` CDF, removing the second axiom.
 
 ---
 
+## Session 2026-05-08 (Session 4, researcher-10) — ACT (Phase-4 prep)
+
+**Mode**: BUILD-ON-PRIOR (Sessions 1–3 produced a sorry-free, two-axiom
+file; the natural next step is Phase-4 work on the remaining axioms).
+**Outcome**: added two structural lemmas about `binomialCDF` that the
+Phase-4 Portmanteau bridge will need (`binomialCDF_neg`,
+`binomialCDF_mono`). No axiom elimination this session.
+
+### What Was Built
+
+* `binomialCDF_neg (n : ℕ) (p : ℝ) {x : ℝ} (hx : x < 0) :
+    binomialCDF n p x = 0`
+  — every `j ∈ Finset.range (n+1)` satisfies `(j : ℝ) ≥ 0 > x`, so the
+  if-guard is false in every term and the whole sum vanishes. ~6 lines,
+  uses `Finset.sum_eq_zero` + `if_neg` + `not_le.mpr` + `Nat.cast_nonneg`.
+
+* `binomialCDF_mono (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    Monotone (binomialCDF n p)`
+  — pointwise on each summand: case-split on whether `(j : ℝ) ≤ x`. If
+  yes, monotonicity gives `(j : ℝ) ≤ y`, both terms equal the PMF.
+  If no (LHS = 0), need `0 ≤ PMF` when the RHS if-guard holds; that's
+  `mul_nonneg` + `pow_nonneg` on `Nat.choose`, `p^j`, and `(1-p)^(n-j)`.
+  ~13 lines.
+
+### Why These Lemmas
+
+The Phase-4 work is to discharge `binomial_clt_pointwise` — the classical
+de Moivre–Laplace theorem in CDF form. The natural Mathlib path is:
+
+1. Apply Mathlib's `ProbabilityTheory.iid_central_limit_theorem` to a
+   Bernoulli($p$) i.i.d. sequence to get measure-weak-convergence of
+   the standardized binomial law to the standard Gaussian.
+2. Bridge measure-weak-convergence to CDF-pointwise convergence via
+   the Portmanteau theorem at continuity points of the limit CDF.
+
+For step (2), one ingredient is the standard Portmanteau equivalence:
+weak convergence is equivalent to CDF-pointwise convergence at every
+continuity point of the limit CDF when the CDFs in question are
+**monotone** on `ℝ`. So `binomialCDF_mono` is on the critical path.
+Similarly, edge-of-support facts (CDF = 0 below the support) are
+typical Portmanteau-bridge lemmas; `binomialCDF_neg` covers the
+lower edge.
+
+### Status After This Session
+
+* Sorries: 0 (unchanged).
+* Axioms: 2 (unchanged): `binomial_clt_pointwise` + `standardNormalCDF`
+  opaque.
+* Theorems: 5 (was 3): added `binomialCDF_neg` and `binomialCDF_mono`.
+  Substantive theorem count: 4 (was 2; the two new theorems are public
+  named results).
+* Definitions: 2 (unchanged).
+* File length: 275 lines (was 239; +36 for the two lemmas + section
+  header + docstrings).
+* Status: still `axiomatized`.
+
+### Honest Reporting
+
+* Local Docker build was **not** run (CI is the ground truth, and the
+  worktree has the recursive `.lake` symlink trap that forces a fresh
+  Mathlib clone). The proofs use only well-tested Mathlib idioms —
+  `Finset.sum_eq_zero`, `Finset.sum_le_sum`, `Nat.cast_nonneg`,
+  `mul_nonneg`, `pow_nonneg`, `not_le.mpr`, `if_pos`, `if_neg`,
+  `by_cases`, `linarith`. Confidence is high but not CI-verified.
+
+* This is **infrastructure**, not axiom elimination. The session does
+  not reduce the axiom count — it adds named structural lemmas that
+  the next session can chain into a Portmanteau-style bridge.
+
+* `binomialCDF_le_one` (CDF bounded above by 1) is **not** added here:
+  it requires `add_pow` (binomial expansion in a commutative ring) and
+  the proof has more moving parts than a single linear pass. Deferred
+  to Session 5.
+
+### Files Changed
+
+- UPDATED `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`
+  (239 → 275 lines, +2 theorems).
+- UPDATED `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json`
+  (lineCount, theoremCount, substantiveTheoremCount, originalContributions,
+   sections; added `sec-structural` and shifted `sec-main` line range).
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md`
+  (this entry).
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md`
+  (Phase-4 prep status).
+- UPDATED `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json`
+  (knowledge fields).
+
+### Next Steps
+
+1. **Session 5 (immediate Phase-4 prep continuation)**: prove
+   `binomialCDF_le_one` and `binomialCDF_zero_le` to round out the
+   structural-properties library. `binomialCDF_le_one` reduces to
+   `(p + (1-p))^n = 1^n = 1` via `add_pow` (or `Commute.add_pow`).
+   `binomialCDF_zero_le` follows from non-negativity of each summand.
+
+2. **Session 6 (axiom attack)**: discharge `binomial_clt_pointwise`
+   from `ProbabilityTheory.iid_central_limit_theorem` via the
+   Portmanteau bridge. The structural lemmas added this session are
+   prerequisites. Estimated ~150–200 lines of new Lean.
+
+3. **Stretch**: replace the `standardNormalCDF` opaque with a
+   concrete `noncomputable def` integrating `gaussianPDFReal` over
+   `Set.Iic x`. ShannonEntropyOQ01.lean uses
+   `ProbabilityTheory.gaussianPDFReal μ ⟨σ², sq_nonneg σ⟩` so the
+   API is precedented in this gallery; the bridge to CDF is one
+   `MeasureTheory.integral` definition.
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -1,19 +1,19 @@
 # Research State: binomial-theorem-oq-02-oq-01-oq-01-oq-03
 
 ## Current State
-**Phase**: ACT (Phase-3 reduction-lemma proof complete)
+**Phase**: ACT (Phase-4 structural-lemma prep)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (Session 3, researcher-3)
-**Iteration**: 3
+**Last Updated**: 2026-05-08 (Session 4, researcher-10)
+**Iteration**: 4
 
 ## Current Focus
-Phase-3 deliverable: discharge the sorry on
-`multinomialMarginalCDF_eq_binomialCDF`. Proof completed via
-`Finset.sum_fiberwise_of_maps_to` + the parent file's
-`multinomial_marginal_pmf`. The Lean file is now sorry-free; the only
-explicit assumptions are the two axioms that were already named
-(`binomial_clt_pointwise` and the opaque `standardNormalCDF`).
+Phase-4 prep: added `binomialCDF_neg` and `binomialCDF_mono` — two
+structural lemmas about the binomial CDF that the Portmanteau-bridge
+proof of `binomial_clt_pointwise` will need. No axiom elimination this
+session; the file is still 0 sorries / 2 axioms (`binomial_clt_pointwise`
++ `standardNormalCDF` opaque). Next session continues the structural
+library (`binomialCDF_le_one`, then the Portmanteau bridge itself).
 
 ## Active Approach
 **CDF-based** rather than the measure-theoretic Bernoulli-sum approach
@@ -29,18 +29,23 @@ sketched in iteration 1. Justification:
   Phase-3 task is to bridge to Mathlib's measure-theoretic Gaussian.
 
 ## Attempt Count
-- Total attempts: 3 (Sessions 1–3)
+- Total attempts: 4 (Sessions 1–4)
 - Approaches tried:
   - **Iteration 1** (researcher-8, OBSERVE→ORIENT): planned i.i.d.-CLT
     decomposition (Sublemmas A, B, C, D). No Lean code.
   - **Iteration 2** (researcher-9, ACT): CDF-based scaffold.
     `BinomialTheoremOQ02OQ01OQ01OQ03.lean` (178 lines, 2 axioms incl.
     opaque, 1 sorry, 2 theorems). Merged in #16866.
-  - **Iteration 3** (researcher-3, ACT — THIS SESSION):
-    discharged the reduction-lemma sorry via
-    `Finset.sum_fiberwise_of_maps_to`. File now 239 lines, 2 axioms,
-    **0 sorries**, 3 theorems (added `piAntidiag_apply_le` private
-    lemma).
+  - **Iteration 3** (researcher-3, ACT): discharged the reduction-lemma
+    sorry via `Finset.sum_fiberwise_of_maps_to`. File grew to 239 lines,
+    2 axioms, **0 sorries**, 3 theorems (added `piAntidiag_apply_le`
+    private lemma).
+  - **Iteration 4** (researcher-10, ACT — THIS SESSION):
+    Phase-4 prep. Added `binomialCDF_neg` (CDF = 0 below support) and
+    `binomialCDF_mono` (monotone in `x` when `0 ≤ p ≤ 1`) — two
+    structural lemmas that the Portmanteau bridge will consume. File
+    now 275 lines, 2 axioms (unchanged), **0 sorries**, 5 theorems
+    (substantive count: 4).
 
 ## Blockers
 - **Build verification**: this session could not run the Docker build
@@ -59,18 +64,36 @@ sketched in iteration 1. Justification:
 
 ## Next Action
 
-**Phase-4 (next session)**: discharge the `binomial_clt_pointwise` axiom.
+**Session 5 (immediate)**: round out the structural-properties library
+with two more routine lemmas:
+
+* `binomialCDF_le_one`: bounded above by 1. Reduces to
+  `(p + (1-p))^n = 1` via `add_pow` (or `Commute.add_pow` for a
+  commutative semiring); the if-guard restricts the sum, but the
+  whole sum equals `1`, and dropping non-negative terms only decreases.
+* `binomialCDF_zero_le`: bounded below by 0 (each summand non-negative
+  when `0 ≤ p ≤ 1`).
+
+**Session 6 (Phase-4 axiom attack)**: discharge `binomial_clt_pointwise`.
 The cleanest path is to bridge from Mathlib's
-`ProbabilityTheory.iid_central_limit_theorem` applied to a
-`Bernoulli(p)` measure on ℝ; this requires a Portmanteau-style
-CDF-from-measure-weak-convergence step. Alternatively, Stirling's
-formula gives a direct asymptotic-analysis proof.
+`ProbabilityTheory.iid_central_limit_theorem` applied to a Bernoulli($p$)
+i.i.d. sequence; this requires a Portmanteau-style CDF-from-measure-
+weak-convergence step. The structural lemmas added in Sessions 4–5
+(`binomialCDF_neg`, `binomialCDF_mono`, `binomialCDF_le_one`,
+`binomialCDF_zero_le`) are prerequisites for the bridge. Alternative
+path: Stirling's formula for a direct asymptotic-analysis proof.
 
-A separate stretch task: bridge `standardNormalCDF` to Mathlib's
-measure-theoretic standard Gaussian (its CDF), removing the opaque
-declaration entirely.
+**Stretch (independent)**: replace `standardNormalCDF` opaque with
+a `noncomputable def` integrating `gaussianPDFReal 0 ⟨1, _⟩` over
+`Set.Iic x`. ShannonEntropyOQ01.lean already uses
+`ProbabilityTheory.gaussianPDFReal μ ⟨σ², sq_nonneg σ⟩` so the
+API is precedented; the bridge to a CDF function is one
+`MeasureTheory.integral` definition. Removes the opaque assumption
+entirely (axiom count 2 → 1).
 
-**Phase-3 (this session)**: discharged the reduction-lemma sorry. Proof
+---
+
+**Phase-3 (Session 3)**: discharged the reduction-lemma sorry. Proof
 sketch (follows the actual file):
 
 ```lean

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 2,
-    "lineCount": 239,
+    "lineCount": 275,
     "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. (2) `standardNormalCDF` opaque marker — the standard normal CDF Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt, currently opaque pending bridge from Mathlib's measure-theoretic Gaussian. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` is now fully proved (Phase-3 deliverable): it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
     "originalContributions": [
       "binomialCDF: concrete CDF of Binomial(n,p) as a finite sum of binomial PMF terms with a step indicator",
@@ -28,10 +28,12 @@
       "binomial_clt_pointwise: axiomatic statement of de Moivre-Laplace in CDF form (statement matches the classical formulation, avoids measure-theoretic machinery)",
       "piAntidiag_apply_le (private): every coordinate of a composition k ∈ s.piAntidiag n is ≤ n — proved",
       "multinomialMarginalCDF_eq_binomialCDF: reduction lemma — proved via Finset.sum_fiberwise_of_maps_to + parent's multinomial_marginal_pmf",
-      "multinomial_marginal_clt: derived theorem (no axiom of its own) combining the above via Filter.Tendsto.congr"
+      "multinomial_marginal_clt: derived theorem (no axiom of its own) combining the above via Filter.Tendsto.congr",
+      "binomialCDF_neg: for x < 0, binomialCDF n p x = 0 — every j ∈ {0,…,n} has (j : ℝ) ≥ 0 > x so all if-guards are false (Phase-4 prep)",
+      "binomialCDF_mono: binomialCDF n p is monotone in x when 0 ≤ p ≤ 1 — pointwise comparison after case-splitting on the if-guards (Phase-4 Portmanteau prep)"
     ],
-    "theoremCount": 3,
-    "substantiveTheoremCount": 2,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 4,
     "definitionCount": 2
   },
   "leanFile": {
@@ -49,10 +51,10 @@
       "BigOperators"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
-    "lineCount": 239,
+    "lineCount": 275,
     "axiomCount": 2,
-    "theoremCount": 3,
-    "substantiveTheoremCount": 2,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 4,
     "duplicateTheorems": 0,
     "definitionCount": 2,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
@@ -102,11 +104,18 @@
       "endLine": 210
     },
     {
+      "id": "sec-structural",
+      "title": "Structural Properties of binomialCDF (Phase-4 prep)",
+      "range": null,
+      "startLine": 212,
+      "endLine": 246
+    },
+    {
       "id": "sec-main",
       "title": "Main Theorem: Multinomial Marginal CLT (Derived)",
       "range": null,
-      "startLine": 212,
-      "endLine": 239
+      "startLine": 248,
+      "endLine": 275
     }
   ],
   "overview": {

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -52,7 +52,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT phase, Phase-2 scaffold complete. Lean file BinomialTheoremOQ02OQ01OQ01OQ03.lean (178 lines) STATES the multinomial marginal CLT in CDF form and DERIVES it (via Filter.Tendsto.congr) from two axioms: binomial_clt_pointwise (de Moivre-Laplace) and standardNormalCDF (opaque). One sorry remains in the reduction lemma multinomialMarginalCDF_eq_binomialCDF (provable from BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf by fiber regrouping). Gallery entry created. Path chosen was CDF-based (not the Bernoulli-sum Mathlib-iid-CLT path planned in Session 1) to avoid heavy MeasureTheory setup; trade-off is +1 axiom (standardNormalCDF opaque) for net axiomCount=2.",
+    "progressSummary": "ACT phase, Phase-4 prep. Lean file BinomialTheoremOQ02OQ01OQ01OQ03.lean (275 lines, 0 sorries, 2 axioms unchanged) now ships with two structural lemmas (binomialCDF_neg + binomialCDF_mono) prerequisite to the Portmanteau bridge that will discharge binomial_clt_pointwise from Mathlib's iid CLT. Sessions 1-2 produced the CDF-based scaffold (merged in #16866); Session 3 closed the reduction-lemma sorry via Finset.sum_fiberwise_of_maps_to; Session 4 adds Phase-4 prerequisites. Next: complete structural library (binomialCDF_le_one, binomialCDF_zero_le) then attempt the Portmanteau bridge to remove binomial_clt_pointwise. Stretch: replace standardNormalCDF opaque with a concrete integral over Mathlib's gaussianPDFReal.",
     "builtItems": [
       "binomialCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:90 (concrete CDF of Binomial(n,p))",
       "multinomialMarginalCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:97 (marginal CDF of multinomial)",
@@ -60,7 +60,9 @@
       "binomial_clt_pointwise (axiom, de Moivre-Laplace in CDF form) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:126",
       "multinomialMarginalCDF_eq_binomialCDF (theorem, sorry) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:144",
       "multinomial_marginal_clt (DERIVED theorem, no separate axiom) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:160",
-      "Gallery entry src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/ (meta.json, annotations.json, index.ts)"
+      "Gallery entry src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/ (meta.json, annotations.json, index.ts)",
+      "Added binomialCDF_neg in BinomialTheoremOQ02OQ01OQ01OQ03.lean:216 — for x < 0, binomialCDF n p x = 0 (Phase-4 prep)",
+      "Added binomialCDF_mono in BinomialTheoremOQ02OQ01OQ01OQ03.lean:232 — Monotone (binomialCDF n p) when 0 ≤ p ≤ 1 (Phase-4 Portmanteau prep)"
     ],
     "insights": [
       "Multinomial marginal Xᵢ ~ Binomial(n, pᵢ) is ALREADY proved (`BinomialTheoremOQ02OQ01OQ02.lean`); OQ-02-OQ-01-OQ-01-OQ-03 'just' needs the binomial CLT ON TOP",
@@ -71,7 +73,10 @@
       "A clean STATEMENT-only PR (axiomatize the binomial CLT, then derive the multinomial marginal CLT from `binomial_marginal_of_multinomial`) would be a high-value Phase-2 deliverable even without full Mathlib-CLT proof",
       "CDF-form CLT statement avoids the heavy MeasureTheory + IsProbabilityMeasure + Mathlib-iid-CLT setup needed for the measure-weak-convergence path; cost is +1 axiom (standardNormalCDF opaque)",
       "The reduction multinomialMarginalCDF = binomialCDF is an *equality* of finite sums (not asymptotic), so Filter.Tendsto.congr suffices to lift the binomial CLT axiom to the marginal CLT",
-      "The DERIVED-theorem pattern keeps the axiom inventory honest: multinomial_marginal_clt is not itself an axiom, only the underlying de Moivre-Laplace + opaque CDF marker are"
+      "The DERIVED-theorem pattern keeps the axiom inventory honest: multinomial_marginal_clt is not itself an axiom, only the underlying de Moivre-Laplace + opaque CDF marker are",
+      "binomialCDF_neg: for x < 0, every j ∈ {0, …, n} satisfies (j : ℝ) ≥ 0 > x so all if-guards collapse to 'else 0' and the whole sum is 0. Proof uses Finset.sum_eq_zero + not_le.mpr + Nat.cast_nonneg, ~6 lines (Session 4)",
+      "binomialCDF_mono in x (when 0 ≤ p ≤ 1): pointwise comparison after case-splitting on the if-guards in each summand. Three cases — both true (PMF=PMF), LHS false RHS true (need 0 ≤ PMF), both false (0 ≤ 0). PMF non-negativity from mul_nonneg + Nat.cast_nonneg + pow_nonneg on Nat.choose, p^j, (1-p)^(n-j), ~13 lines (Session 4)",
+      "Phase-4 Portmanteau-bridge prerequisites (structural CDF properties): monotonicity is the central one — Portmanteau equivalence between weak convergence and CDF-pointwise convergence at continuity points uses monotonicity to control oscillation between continuity points. binomialCDF_neg covers the lower-edge case (Session 4)"
     ],
     "mathlibGaps": [
       "Mathlib's `Mathlib.Probability.Distributions.Binomial` exposes the PMF but the named theorem 'binomial CLT' / 'de Moivre-Laplace' may not be present in canonical form",
@@ -79,10 +84,9 @@
       "Multivariate CLT (Cramér-Wold) — partial in Mathlib; would be needed for the joint vector form (out of scope for this OQ but referenced in nextSteps)"
     ],
     "nextSteps": [
-      "Phase-3 reduction proof: discharge multinomialMarginalCDF_eq_binomialCDF by regrouping s.piAntidiag n into fibers over k(i₀), then applying multinomial_marginal_pmf to each fiber. Skeleton in state.md.",
-      "Phase-3 stretch: bridge binomial_clt_pointwise to Mathlibs ProbabilityTheory.iid_central_limit_theorem via the Portmanteau theorem at continuity points of the standard normal CDF.",
-      "Phase-3 stretch: replace standardNormalCDF opaque with a measure-theoretic CDF derived from Mathlibs Gaussian measure (in Mathlib.Probability.Distributions.Gaussian.Basic).",
-      "Joint multinomial CLT (sibling OQ): use Cramer-Wold + the covariance computation in BinomialTheoremOQ02OQ01OQ03.multinomial_covariance to get vector convergence to a degenerate multivariate normal."
+      "Session 5: prove binomialCDF_le_one (uses add_pow / Commute.add_pow) and binomialCDF_zero_le (mul_nonneg on each summand) to round out the structural library.",
+      "Session 6: discharge binomial_clt_pointwise from ProbabilityTheory.iid_central_limit_theorem applied to a Bernoulli(p) i.i.d. sequence, via the Portmanteau theorem at continuity points of the standard normal CDF (every point, since Φ is continuous).",
+      "Stretch: replace standardNormalCDF opaque with a noncomputable def := ∫ t in Set.Iic x, ProbabilityTheory.gaussianPDFReal 0 ⟨1, _⟩ t. Removes one of the two remaining axioms."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session 4 on `binomial-theorem-oq-02-oq-01-oq-01-oq-03` (Multinomial Marginal CLT).

Adds two structural lemmas about `binomialCDF` that the Phase-4 Portmanteau bridge will consume to discharge `binomial_clt_pointwise`. No axiom elimination this session — pure infrastructure for the next attempt at the de Moivre–Laplace axiom.

## What's New

* **`binomialCDF_neg`** — for `x < 0`, `binomialCDF n p x = 0`. Every `j ∈ {0, …, n}` has `(j : ℝ) ≥ 0 > x`, so the if-guard is false in every term and the whole sum is zero. (~6 lines.)
* **`binomialCDF_mono`** — `binomialCDF n p` is monotone in `x` when `0 ≤ p ≤ 1`. Pointwise comparison after case-splitting on the if-guards in each summand; the only non-trivial case (LHS guard false, RHS guard true) needs `0 ≤ C(n,j) p^j (1-p)^(n-j)` which follows from `mul_nonneg` + `pow_nonneg`. (~13 lines.)

## Why These Lemmas

The Phase-4 work is to discharge `binomial_clt_pointwise` (the classical de Moivre–Laplace theorem in CDF form) by bridging from Mathlib's `ProbabilityTheory.iid_central_limit_theorem` via a Portmanteau-style step. That bridge needs:

- **CDF monotonicity** to convert measure-weak-convergence into CDF-pointwise convergence at every continuity point. `binomialCDF_mono` is on the critical path.
- **Edge-of-support behavior** (CDF = 0 below the support, etc.). `binomialCDF_neg` covers the lower edge.

## Status

| metric | before | after |
|---|---|---|
| sorries | 0 | 0 |
| axioms | 2 | 2 |
| theorems | 3 | 5 |
| substantive theorems | 2 | 4 |
| Lean lines | 239 | 275 |

The two remaining axioms (`binomial_clt_pointwise` + `standardNormalCDF` opaque) are unchanged and well-justified deep classical results; Session 5+ tackles them.

## Files Modified

- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` (+36 lines)
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json` (line/theorem counts, originalContributions, sections)
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/{knowledge.md,state.md}` (Session 4 entry)
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json` (knowledge fields)

## Honest Reporting

Local Docker build was **not** run (worktree `.lake` recursive-symlink trap forces a fresh ~25-min Mathlib clone). The proofs use only well-tested Mathlib idioms — `Finset.sum_eq_zero`, `Finset.sum_le_sum`, `Nat.cast_nonneg`, `mul_nonneg`, `pow_nonneg`, `not_le.mpr`, `if_pos`, `if_neg`, `by_cases`, `linarith`. Confidence is high but CI is the ground truth.

## Outcome

**Outcome**: progress (infrastructure added, no axiom elimination)
**Next steps**:
1. Session 5: prove `binomialCDF_le_one` and `binomialCDF_zero_le` to round out the structural library.
2. Session 6: discharge `binomial_clt_pointwise` from Mathlib's iid CLT via the Portmanteau bridge (~150–200 lines estimated).
3. Stretch: replace `standardNormalCDF` opaque with `∫ t in Set.Iic x, gaussianPDFReal 0 ⟨1, _⟩ t`. Removes one of the two remaining axioms.

🤖 Generated by researcher-10