### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-02): S5 — binomial-absorption identity for vdP §6

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
@@ -95,10 +95,11 @@ strong-induction proof of `denominator_control`.
 ## File Status
 * axioms: 0
 * sorries: 0
-* lemmas: 4 reusable lcm/cube + 6 numerical witnesses + Part 4 adds
-  `harmonicCubed` (the cubed-harmonic sum H_n^{(3)} = ∑_{k=1}^{n} 1/k^3)
-  with base values, non-negativity, and monotonicity (4 lemmas), plus
-  the **main divisibility theorem** `harmonicCubed_lcm_clear`:
+* lemmas: 4 reusable lcm/cube + 8 numerical witnesses (`lcmRange 0..7`)
+  + lcm positivity + Part 4 adds `harmonicCubed` (the cubed-harmonic
+  sum H_n^{(3)} = ∑_{k=1}^{n} 1/k^3) with base values, non-negativity,
+  and monotonicity (4 lemmas), plus the **main divisibility theorem**
+  `harmonicCubed_lcm_clear`:
       `∃ m : ℤ, (lcmRange n : ℚ)^3 * H_n^{(3)} = m`,
   with strengthened natural-number-witness variant
   `harmonicCubed_lcm_clear_nat`. The proof reduces termwise via the
@@ -111,6 +112,19 @@ strong-induction proof of `denominator_control`.
   the alternating-bilinear "second summand"
       `Cnk = ∑_{j=1}^{k} (-1)^(j+1) / (2 j^3 · C(n,j)^2 · C(n+j,j)^2)`,
   which is deferred to a follow-up session.
+
+* Part 5 (Session 5) adds the **binomial-absorption identity**
+  `mul_choose_eq_mul_choose_pred`:
+      `0 < m → m ≤ n → m * Nat.choose n m = n * Nat.choose (n-1) (m-1)`,
+  packaging Mathlib's `Nat.succ_mul_choose_eq` in the convenient
+  `m · C(n,m)` form. Together with `dvd_lcmRange`, this exposes
+  `m * C(n, m)` as a multiple of `n` (and hence of any `q` dividing
+  `n`), which is the entry point for the binomial-denominator
+  analysis of the alternating bilinear sum in Session 6 (the second
+  summand of the van der Poorten closed form). See the Part 5
+  docstring for the planned Session 6 lemma
+  `mul_choose_dvd_lcmRange : 0 < m → m ≤ n → m · C(n,m) ∣ lcmRange n`,
+  which the absorption identity is intended to support.
 -/
 
 namespace BaselProblemOQ01OQ01OQ02OQ02
@@ -192,6 +206,27 @@ theorem lcmRange_four : lcmRange 4 = 12 := by decide
 
 /-- `lcmRange 5 = 60`. -/
 theorem lcmRange_five : lcmRange 5 = 60 := by decide
+
+/-- `lcmRange 6 = 60` (the new prime needed at 6 is 3·2 = 6 ∣ 60 already). -/
+theorem lcmRange_six : lcmRange 6 = 60 := by decide
+
+/-- `lcmRange 7 = 420 = 7 · 60` (introducing the new prime 7). -/
+theorem lcmRange_seven : lcmRange 7 = 420 := by decide
+
+/-- **Positivity of `lcmRange`** (for all `n`, including `n = 0` where
+    `lcmRange 0 = 1`).
+
+    Proof: `lcmRange n = (Finset.range n).lcm (· + 1)` is non-zero
+    because every value in the family `(· + 1)` is a successor and
+    hence non-zero. Apply `Finset.lcm_ne_zero_iff` and conclude via
+    `Nat.pos_of_ne_zero`. Mirrors the parent file's `lcmUpTo_pos`
+    (which assumes `1 ≤ n`); the present statement is unconditional. -/
+theorem lcmRange_pos (n : ℕ) : 0 < lcmRange n := by
+  unfold lcmRange
+  apply Nat.pos_of_ne_zero
+  rw [Finset.lcm_ne_zero_iff]
+  intro k _
+  exact Nat.succ_ne_zero k
 
 -- =====================================================================
 -- PART 4: Harmonic-cube denominator clearing (vdP closed-form prep)
@@ -278,5 +313,71 @@ theorem harmonicCubed_lcm_clear (n : ℕ) :
   rw [harmonicCubed_lcm_clear_nat]
   push_cast
   rfl
+
+-- =====================================================================
+-- PART 5 (Session 5): Binomial-absorption identity (vdP §6 prep)
+-- =====================================================================
+
+/-! ### Why this is the next ingredient
+
+The remaining half of the van der Poorten denominator analysis is the
+*alternating bilinear* sum
+  `Cnk(n, k) = ∑_{m=1}^{k} (-1)^{m-1} / (2 m^3 · C(n, m) · C(n+m, m))`.
+After multiplying through by `lcmRange n^3`, every per-term denominator
+of the shape `m · C(n, m)` must be absorbed.
+
+The classical absorption mechanism is the binomial identity
+  `m · C(n, m) = n · C(n-1, m-1)`,
+which says the rising factor `m` in front of `C(n, m)` can always be
+swapped for the rising factor `n` in front of the *predecessor* binomial
+`C(n-1, m-1)`. Since `n ∣ lcmRange n` (a special case of
+`dvd_lcmRange`), this rewriting transforms a term whose denominator is
+`m · C(n, m)` into one whose denominator is divisible by `n` — and so
+divisible by any `lcmRange n` shifted by one position.
+
+The Session 6 target is therefore
+  `mul_choose_dvd_lcmRange : 0 < m → m ≤ n → m · C(n, m) ∣ lcmRange n`.
+The present part proves the absorption identity itself
+(`mul_choose_eq_mul_choose_pred`), which is a one-line consequence of
+Mathlib's `Nat.succ_mul_choose_eq` once the off-by-one in indexing is
+discharged. The full divisibility lemma requires combining this
+identity with `dvd_lcmRange` *and* a structural argument relating
+`C(n-1, m-1)` to a chain of multiplicative cancellations (via Kummer's
+theorem on `v_p(C(n, m))` and the digit-sum carry count, or by a
+double induction on `(n, m)`); both routes are deferred. -/
+
+/-- **Binomial-absorption identity**: for `0 < m ≤ n`,
+    `m · C(n, m) = n · C(n-1, m-1)`.
+
+    A repackaging of Mathlib's
+      `Nat.add_one_mul_choose_eq : (n+1) * C(n, k) = C(n+1, k+1) * (k+1)`
+    in the more useful "small-to-large" direction with explicit
+    predecessors. The substitution is `n' := n - 1`, `k' := m - 1`,
+    after which the off-by-ones cancel via `Nat.sub_add_cancel`.
+
+    The statement is the foundational input for Session 6's planned
+    `mul_choose_dvd_lcmRange` and (via a chain of such absorptions)
+    for the alternating-bilinear half of the van der Poorten
+    denominator analysis underlying `denominator_control`. -/
+theorem mul_choose_eq_mul_choose_pred {n m : ℕ} (hm : 0 < m) (hmn : m ≤ n) :
+    m * Nat.choose n m = n * Nat.choose (n - 1) (m - 1) := by
+  have hn : 0 < n := lt_of_lt_of_le hm hmn
+  have h := Nat.add_one_mul_choose_eq (n - 1) (m - 1)
+  -- h : ((n-1)+1) * C(n-1, m-1) = C((n-1)+1, (m-1)+1) * ((m-1)+1)
+  -- Collapse `n-1+1 → n` and `m-1+1 → m` via `Nat.sub_add_cancel`,
+  -- then commute the goal's `m * C(n, m)` to align with `h`'s
+  -- `C(n, m) * m`.
+  rw [Nat.sub_add_cancel hn, Nat.sub_add_cancel hm] at h
+  -- h : n * Nat.choose (n - 1) (m - 1) = Nat.choose n m * m
+  rw [Nat.mul_comm m (Nat.choose n m)]
+  exact h.symm
+
+/-- **Absorption corollary**: `n` divides `m · C(n, m)` whenever
+    `0 < m ≤ n`. A direct rewrite via `mul_choose_eq_mul_choose_pred`
+    exposes the LHS as `n · C(n-1, m-1)`, which is divisible by `n`. -/
+theorem dvd_mul_choose {n m : ℕ} (hm : 0 < m) (hmn : m ≤ n) :
+    n ∣ m * Nat.choose n m := by
+  rw [mul_choose_eq_mul_choose_pred hm hmn]
+  exact dvd_mul_right n (Nat.choose (n - 1) (m - 1))
 
 end BaselProblemOQ01OQ01OQ02OQ02

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
@@ -27,23 +27,24 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T04:30:00.000Z",
-    "iteration": 4,
-    "focus": "Discharged the H_n^{(3)} half of the van der Poorten denominator analysis (route F). Proved `harmonicCubed_lcm_clear_nat` (explicit ℕ-witness identity) and `harmonicCubed_lcm_clear` (existential `∃ m : ℤ, …` form matching the parent's `denominator_control` axiom shape). Integer witness: `∑ k ∈ range n, (lcmRange n)^3 / (k+1)^3 : ℕ`, exact-divisible per term via `pow_dvd_lcmRange_pow` (Part 2). Build verified (PR #16898 merged 2026-05-08T03:57:56Z). Remaining blockers shifted to the alternating-bilinear half + closed-form expansion of `aperyA n`.",
+    "since": "2026-05-08T05:00:00.000Z",
+    "iteration": 5,
+    "focus": "Session 5 (2026-05-08, ACT): added the binomial-absorption identity `mul_choose_eq_mul_choose_pred : 0 < m → m ≤ n → m * Nat.choose n m = n * Nat.choose (n-1) (m-1)` plus its corollary `dvd_mul_choose : 0 < m → m ≤ n → n ∣ m * Nat.choose n m`. The proof is a one-line repackaging of Mathlib's `Nat.succ_mul_choose_eq` after `Nat.sub_add_cancel` discharges the off-by-one. Also added `lcmRange_pos` (positivity for all `n`, including `n=0`) and extended the numerical witnesses to `lcmRange 6 = 60` and `lcmRange 7 = 420`. Discovered: the originally proposed `mul_choose_dvd_lcmRange : 0 < m → m ≤ n → m · C(n,m) ∣ lcmRange n` does not follow directly from the absorption identity alone — it additionally requires either Kummer's theorem on `v_p(C(n, m)) = c_p(m, n-m)` or a double `(n, m)`-induction. Reframed as Session 6.",
     "blockers": [
-      "The alternating bilinear summand ∑_{m=1}^{k} (-1)^{m-1}/(2 m^3 C(n,m) C(n+m,m)) needs binomial-coefficient denominator analysis — concretely: C(n,m) and C(n+m,m) have denominators that, after multiplying by lcm(1..n)^3, leave integers. Classical telescoping identity (van der Poorten 1979 §6) handles this but is non-trivial to port. Estimated ~200 lines.",
+      "The `mul_choose_dvd_lcmRange` divisibility is harder than the next-action originally suggested: empirically true (verified n ≤ 8, all m), but the absorption identity `m·C(n,m) = n·C(n-1,m-1)` only proves divisibility by `n`, not by `lcmRange n`. Closing this requires either (a) a digit-sum/Kummer p-adic argument: v_p(m) + c_p(m, n-m) ≤ ⌊log_p n⌋, or (b) a strong (n, m)-induction whose step uses Pascal `C(n, m) = C(n-1, m) + C(n-1, m-1)` plus the absorption identity to flip indices. Both routes are ~100-200 lines.",
+      "The alternating bilinear summand ∑_{m=1}^{k} (-1)^{m-1}/(2 m^3 C(n,m) C(n+m,m)) needs `mul_choose_dvd_lcmRange` as input. Once that is available, the `m^3 · C(n,m)` denominators absorb into `lcmRange n^3` per term; the remaining `C(n+m, m)` factor needs a similar second absorption (or van der Poorten's central-binomial telescoping identity).",
       "Current `aperyA` is defined recursively in BaselProblemOQ01OQ01OQ02.lean:261 — no explicit closed form is yet available in the repo. Stating `aperyA_explicit_formula` as a sorried theorem and validating numerically at small n is a future session.",
       "Mathlib lacks: (1) any reference to Apéry numbers/sequences; (2) infrastructure for lcm-clearing identities of the form 'denominator divides lcm(1,…,n)^k'. The H_n^{(3)} clearing now in BaselProblemOQ01OQ01OQ02OQ02.lean is the first such instance and could potentially be upstreamed."
     ],
-    "nextAction": "Session 5: stub `vdpAlternatingSum_lcm_clear` with the classical denominator telescoping identity (van der Poorten 1979 §6). Begin with the binomial-denominator divisibility lemma `m · Nat.choose n m ∣ lcmRange n` for `0 < m ≤ n`, derived from the identity `m · C(n, m) = n · C(n-1, m-1)`. This packages the absorbtion of the binomial-coefficient denominators in the alternating sum.",
+    "nextAction": "Session 6: prove `mul_choose_dvd_lcmRange : 0 < m → m ≤ n → m · Nat.choose n m ∣ lcmRange n`. Recommended route: strong induction on `n` with case split on `m`. Base `m = 1`: `1 · C(n, 1) = n` and `n ∣ lcmRange n` by `dvd_lcmRange`. Step `m > 1`: combine the absorption identity (now available as `mul_choose_eq_mul_choose_pred`) with `dvd_lcmRange n hn n_le_n` to reduce `m · C(n, m) = n · C(n-1, m-1)` to a divisibility involving `C(n-1, m-1)`, then bound `n · C(n-1, m-1) ∣ lcmRange n` via `Nat.lcm`-ness of `lcmRange n` (every `k ≤ n` divides). Alternative if induction stalls: digit-sum p-adic argument.",
     "attemptCounts": {
-      "total": 4,
+      "total": 5,
       "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Session 4 (2026-05-08, ACT): discharged the H_n^{(3)} half of the van der Poorten denominator analysis (route F). Proved harmonicCubed_lcm_clear_nat (explicit ℕ-sum identity) and harmonicCubed_lcm_clear (existential form matching denominator_control). The integer witness is ∑ k ∈ range n, (lcmRange n)^3/(k+1)^3 (Nat division — each summand exact via pow_dvd_lcmRange_pow). Proof technique: Finset.mul_sum → Nat.cast_sum → per-term Nat.cast_div hdvd hk1ne → mul_one_div → push_cast; ring. Session 3 (ORIENT): added harmonicCubed (cubed-harmonic sum H_n^{(3)} = ∑_{k=1}^{n} 1/k^3) plus 4 reusable lemmas. Session 2 (ORIENT): built infrastructure lemmas (dvd_lcmRange, pow_dvd_lcmRange_pow, etc.) and corrected session 1 strategy. Session 1 (OBSERVE): surveyed and identified van der Poorten path. NEXT (session 5): vdpAlternatingSum_lcm_clear — the alternating-bilinear half via central-binomial telescoping (vdP 1979 §6).",
+    "progressSummary": "Session 5 (2026-05-08, ACT): added Part 5 to BaselProblemOQ01OQ01OQ02OQ02.lean — the binomial-absorption identity `mul_choose_eq_mul_choose_pred : 0 < m → m ≤ n → m * Nat.choose n m = n * Nat.choose (n-1) (m-1)` (one-line repackaging of Mathlib's `Nat.succ_mul_choose_eq` after `Nat.sub_add_cancel`) and its corollary `dvd_mul_choose : 0 < m → m ≤ n → n ∣ m * Nat.choose n m`. Also added `lcmRange_pos` (positivity for all n) and extended numerical witnesses to `lcmRange 6 = 60` and `lcmRange 7 = 420`. Identified that the originally-planned `mul_choose_dvd_lcmRange` is harder than the next-action implied: the absorption only proves divisibility by `n`, not by `lcmRange n`; closing the full claim requires either Kummer's theorem on `v_p(C(n,m)) = c_p(m, n-m)` or a double `(n, m)`-induction via Pascal. Reframed as Session 6. Session 4 (2026-05-08, ACT): discharged the H_n^{(3)} half of the van der Poorten denominator analysis (route F). Proved harmonicCubed_lcm_clear_nat (explicit ℕ-sum identity) and harmonicCubed_lcm_clear (existential form matching denominator_control). The integer witness is ∑ k ∈ range n, (lcmRange n)^3/(k+1)^3 (Nat division — each summand exact via pow_dvd_lcmRange_pow). Proof technique: Finset.mul_sum → Nat.cast_sum → per-term Nat.cast_div hdvd hk1ne → mul_one_div → push_cast; ring. Session 3 (ORIENT): added harmonicCubed (cubed-harmonic sum H_n^{(3)} = ∑_{k=1}^{n} 1/k^3) plus 4 reusable lemmas. Session 2 (ORIENT): built infrastructure lemmas (dvd_lcmRange, pow_dvd_lcmRange_pow, etc.) and corrected session 1 strategy. Session 1 (OBSERVE): surveyed and identified van der Poorten path.",
     "builtItems": [
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: dvd_lcmRange (k>0, k≤n → k∣lcmRange n) — basic membership divisibility",
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: pow_dvd_lcmRange_pow (k>0, k≤n → k^p ∣ (lcmRange n)^p) — the cubed divisibility ingredient any inductive proof of denominator_control needs",
@@ -55,7 +56,11 @@
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_nonneg (H_n^{(3)} ≥ 0)",
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_mono (m ≤ n → H_m^{(3)} ≤ H_n^{(3)})",
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_lcm_clear_nat (explicit ℕ-witness identity (lcmRange n)^3 · H_n^{(3)} = ∑ k ∈ range n, (lcmRange n)^3/(k+1)^3)",
-      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_lcm_clear (existential ∃ m : ℤ, (lcmRange n)^3 · H_n^{(3)} = m — matches denominator_control shape)"
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: harmonicCubed_lcm_clear (existential ∃ m : ℤ, (lcmRange n)^3 · H_n^{(3)} = m — matches denominator_control shape)",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: lcmRange_six (= 60) and lcmRange_seven (= 420) — extends numerical witness chain past prime 7",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: lcmRange_pos (unconditional 0 < lcmRange n; uses Finset.lcm_ne_zero_iff + Nat.succ_ne_zero)",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: mul_choose_eq_mul_choose_pred (m·C(n,m) = n·C(n-1,m-1) for 0 < m ≤ n) — packages Nat.succ_mul_choose_eq in the small-to-large form needed by the vdP §6 alternating-bilinear analysis",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: dvd_mul_choose (n ∣ m · C(n, m) for 0 < m ≤ n) — direct corollary of mul_choose_eq_mul_choose_pred + dvd_mul_right; first half of the would-be mul_choose_dvd_lcmRange"
     ],
     "insights": [
       "BaselProblemOQ01OQ01OQ02.lean already has `denominator_control_factorial : ∃ m : ℤ, (n.factorial : ℚ)^3 * aperyA n = m` PROVED (Part XIX). The factorial proof works because `(n+2)! = (n+2)·(n+1)!` is EXACT multiplicative — multiplying through the recurrence by `(n+1)!^3` produces `(n+2)!^3` on the LHS with no leftover (n+2)^3 to absorb. lcm has no analogous factorisation: lcm(1..n+2) ≠ (n+2)·lcm(1..n+1) in general (e.g. lcm(1..4)=12 ≠ 4·6=24).",
@@ -66,7 +71,10 @@
       "The cubed divisibility `k^p ∣ (lcmRange n)^p` is now AVAILABLE as `pow_dvd_lcmRange_pow` in OQ-02-OQ-02. It packages `dvd_lcmRange` + `pow_dvd_pow_of_dvd`. Reusable across both strategy (P) and (F).",
       "Sibling file Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean already provides `lcmRange_succ` (lcmRange (n+1) = Nat.lcm (lcmRange n) (n+1)), `lcmRange_dvd_lcmRange_of_le`, `lcmRange_monotone`, `lcmRange_dvd_factorial`. These cover the BasicNat-arithmetic side; OQ-02 file adds the powered version specifically needed for denominator analysis.",
       "Watch out: `lcmUpTo n = (Finset.range n).lcm (· + 1)` so lcmUpTo n covers integers 1 through n (not 0 through n-1). lcmUpTo 0 = 1 (lcm of empty set). The defining equation `lcmUpTo_dvd_of_le` (already proved in parent) gives lcm(1..n) ∣ lcm(1..m) for n ≤ m.",
-      "SESSION 4 (2026-05-08, ACT): proved harmonicCubed_lcm_clear and harmonicCubed_lcm_clear_nat in Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean. The H_n^{(3)} half of the van der Poorten denominator analysis (route F) is now discharged. Proof flow: Finset.mul_sum → Nat.cast_sum → per-term Nat.cast_div hdvd hk1ne → mul_one_div → push_cast; ring. The dvd hypothesis is exactly pow_dvd_lcmRange_pow (Part 2). Inlining the per-term work into the main theorem (no separate private helper) avoids the cast-form mismatch (↑k+1)^3 vs ((k+1:ℕ):ℚ)^3 that session 3 hit."
+      "SESSION 4 (2026-05-08, ACT): proved harmonicCubed_lcm_clear and harmonicCubed_lcm_clear_nat in Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean. The H_n^{(3)} half of the van der Poorten denominator analysis (route F) is now discharged. Proof flow: Finset.mul_sum → Nat.cast_sum → per-term Nat.cast_div hdvd hk1ne → mul_one_div → push_cast; ring. The dvd hypothesis is exactly pow_dvd_lcmRange_pow (Part 2). Inlining the per-term work into the main theorem (no separate private helper) avoids the cast-form mismatch (↑k+1)^3 vs ((k+1:ℕ):ℚ)^3 that session 3 hit.",
+      "SESSION 5 (2026-05-08, ACT): the absorption identity mul_choose_eq_mul_choose_pred packages Nat.succ_mul_choose_eq (which is `(n+1) * C(n, k) = (k+1) * C(n+1, k+1)`) in the predecessor form `m * C(n, m) = n * C(n-1, m-1)` for `0 < m ≤ n`. The proof is one application of `Nat.succ_mul_choose_eq (n-1) (m-1)` followed by two `Nat.sub_add_cancel` rewrites. This is the foundational step for any future mul_choose_dvd_lcmRange.",
+      "SESSION 5 SUBTLE POINT: mul_choose_eq_mul_choose_pred only proves `n ∣ m·C(n,m)` (corollary dvd_mul_choose); it does NOT immediately yield `m·C(n,m) ∣ lcmRange n`. The latter is empirically true (verified for n ≤ 8, all m): n=4 m=2: 2·C(4,2)=12 ∣ lcmRange 4=12; n=8 m=3: 3·C(8,3)=168 ∣ lcmRange 8=840 (5×); etc. But the proof requires either (a) Kummer's theorem on v_p(C(n,m)) + a digit-count argument that v_p(m) + c_p(m, n-m) ≤ ⌊log_p n⌋, or (b) a strong (n, m)-induction using Pascal C(n, m) = C(n-1, m) + C(n-1, m-1) where both summands are bounded by IH. Both routes ~100-200 lines.",
+      "SESSION 5 INFRASTRUCTURE: lcmRange_pos lifts the parent file's `lcmUpTo_pos` (which assumed `1 ≤ n`) to an unconditional version, since `lcmRange 0 = 1` is positive too. The proof pattern (`Nat.pos_of_ne_zero` + `Finset.lcm_ne_zero_iff` + `Nat.succ_ne_zero`) is reusable for any `lcm` over `Finset.range n` of a strictly-positive family."
     ],
     "mathlibGaps": [
       "No Apéry numbers in Mathlib (aperyA, aperyB are gallery-local).",
@@ -74,10 +82,11 @@
       "No `Nat.lcm_range` simp lemma giving `lcm({1,…,n}) = ⋁_{k≤n} k` form."
     ],
     "nextSteps": [
-      "Session 5 (vdp alternating sum): State and prove vdpAlternatingSum_lcm_clear: ∃ m : ℤ, (lcmRange n)^3 · ∑_{k=0}^{n} ∑_{m=1}^{k} (-1)^{m-1}/(2 m^3 C(n,m) C(n+m,m)) = m. Use central-binomial telescoping: m·C(n,m) = n·C(n-1,m-1), so 2 m^3 · C(n,m) · C(n+m,m) divides lcm(1..n)^3. Estimated ~200 lines.",
-      "Session 6 (vdp closed form, sorried): State aperyA_explicit_formula : aperyA n = ∑_{k=0}^{n} C(n,k)^2 C(n+k,k)^2 (H_n^{(3)} + cnk(n,k)) as a sorried theorem. Validate at n=0,1,2,3,4 via native_decide. Estimated ~80 lines.",
-      "Session 7 (assembly): Combine harmonicCubed_lcm_clear, vdpAlternatingSum_lcm_clear, and aperyA_explicit_formula to prove denominator_control_lcm. Eliminate the parent axiom denominator_control. Estimated ~80 lines.",
-      "Session 8 (axiom count update): Update parent meta.json axiomCount 5→4 once denominator_control is eliminated. Status remains axiomatized (4 axioms remain)."
+      "Session 6 (mul_choose_dvd_lcmRange): Prove `0 < m → m ≤ n → m · Nat.choose n m ∣ lcmRange n`. Recommended route: strong induction on `n` with case split on `m`. Base m=1: 1·C(n, 1) = n, divisible by lcmRange n via dvd_lcmRange. Step m > 1, n > 1: by Pascal `C(n, m) = C(n-1, m) + C(n-1, m-1)`, so `m·C(n,m) = m·C(n-1,m) + m·C(n-1,m-1) = m·C(n-1,m) + n·C(n-1,m-1)` (absorption identity). The first summand: by IH on (n-1, m), `m·C(n-1, m) ∣ lcmRange (n-1) ∣ lcmRange n`. The second: `n·C(n-1,m-1)` — `n ∣ lcmRange n`, but the C factor needs further argument. Estimated ~80-150 lines. Alternative if induction stalls: digit-sum/Kummer p-adic argument.",
+      "Session 7 (vdpAlternatingSum_lcm_clear with mul_choose_dvd_lcmRange in hand): State and prove vdpAlternatingSum_lcm_clear: ∃ m : ℤ, (lcmRange n)^3 · ∑_{k=0}^{n} ∑_{m=1}^{k} (-1)^{m-1}/(2 m^3 C(n,m) C(n+m,m)) = m. The m^3·C(n,m) denominators absorb via mul_choose_dvd_lcmRange. The C(n+m, m) factor needs a parallel `mul_choose_dvd_lcmRange_shifted` (relating to lcmRange (n+m)) or van der Poorten's central-binomial telescoping. Estimated ~150-200 lines.",
+      "Session 8 (vdp closed form, sorried): State aperyA_explicit_formula : aperyA n = ∑_{k=0}^{n} C(n,k)^2 C(n+k,k)^2 (H_n^{(3)} + cnk(n,k)) as a sorried theorem. Validate at n=0,1,2,3,4 via native_decide. Estimated ~80 lines.",
+      "Session 9 (assembly): Combine harmonicCubed_lcm_clear, vdpAlternatingSum_lcm_clear, and aperyA_explicit_formula to prove denominator_control_lcm. Eliminate the parent axiom denominator_control. Estimated ~80 lines.",
+      "Session 10 (axiom count update): Update parent meta.json axiomCount 5→4 once denominator_control is eliminated. Status remains axiomatized (4 axioms remain)."
     ]
   },
   "tags": [
@@ -120,7 +129,7 @@
     ]
   },
   "started": "2026-04-26T08:56:57.649Z",
-  "lastUpdate": "2026-05-08T00:00:00.000Z",
+  "lastUpdate": "2026-05-08T05:30:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Adds Part 5 to `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean` (the Apéry `denominator_control` companion file): the **binomial-absorption identity** `m·C(n,m) = n·C(n-1,m-1)` for `0 < m ≤ n`, plus its corollary `n ∣ m·C(n,m)`. Both are one-line consequences of Mathlib's `Nat.add_one_mul_choose_eq` after `Nat.sub_add_cancel` discharges the off-by-one. Also extends the supporting infrastructure with `lcmRange_pos` (unconditional positivity) and two more numerical witnesses (`lcmRange 6 = 60`, `lcmRange 7 = 420`).

## What changed

`proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean` — Part 3 extended with:
- `lcmRange_six : lcmRange 6 = 60`
- `lcmRange_seven : lcmRange 7 = 420`
- `lcmRange_pos (n : ℕ) : 0 < lcmRange n` — unconditional (mirrors the parent's `lcmUpTo_pos` but covers `n = 0` too)

Plus new Part 5:
- `mul_choose_eq_mul_choose_pred : 0 < m → m ≤ n → m * Nat.choose n m = n * Nat.choose (n-1) (m-1)` — packages `Nat.add_one_mul_choose_eq` in the small-to-large form needed by the vdP §6 alternating-bilinear analysis
- `dvd_mul_choose : 0 < m → m ≤ n → n ∣ m * Nat.choose n m` — direct corollary

`src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json` — `currentState` and `knowledge` blocks updated to reflect Session 5 progress and the refined Session 6 plan.

## Discovery

The originally-planned `mul_choose_dvd_lcmRange : 0 < m → m ≤ n → m·C(n,m) ∣ lcmRange n` (from prior session's `nextAction`) is **harder than implied**. The absorption identity `m·C(n,m) = n·C(n-1,m-1)` only proves divisibility by `n`, not by `lcmRange n`. The full claim is empirically true (verified `n ≤ 8`, all `m`) but its proof requires either:
1. **Kummer's theorem** on `v_p(C(n,m)) = c_p(m, n-m)` plus a digit-count bound `v_p(m) + c_p(m, n-m) ≤ ⌊log_p n⌋`, or
2. A **strong `(n, m)`-induction** using Pascal `C(n,m) = C(n-1,m) + C(n-1,m-1)` plus the absorption identity to flip indices.

Both routes are ~100-200 lines and are deferred to Session 6 (recommended route detailed in the JSON `nextAction`).

## Verification

Docker build: `LEAN_BUILD_TIMEOUT=60m LEAN_MEMORY_LIMIT=24576 ./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ02`. Build succeeded (exit 0, ~12 min wall-clock for the new code's compile after Mathlib cache fetch). Two warnings:
- Pre-existing simp-arg warning at `:254:23` (`harmonicCubed_one`, from S4) — not addressed here.
- New code's `Nat.succ_mul_choose_eq` deprecation — **fixed in this PR** by switching to `Nat.add_one_mul_choose_eq` (a documented rename).

## Test plan

- [x] Docker build succeeds for `Proofs.BaselProblemOQ01OQ01OQ02OQ02`
- [x] No new sorries (still 0 in the file)
- [x] No new axioms (still 0 in the file)
- [x] JSON valid (`python3 -c "import json; json.load(open(...))"`)
- [x] `Nat.add_one_mul_choose_eq` confirmed present in this Mathlib version (used in `BinomialTheoremOQ03.lean:79`, etc.)

## Notes for downstream

Session 6 should attempt `mul_choose_dvd_lcmRange` via the strong-induction route described in the JSON `nextAction`. The absorption identity (`mul_choose_eq_mul_choose_pred`) and its corollary (`dvd_mul_choose`) added here are the primary tactical inputs for that proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)