### PR TITLE
fix(meta): p-vs-np axiomCount 205 → 211 (ComplexityCore opaques)

### DIFF
--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -19,7 +19,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 205,
+    "axiomCount": 211,
     "assumptions": "121 axiom(s). No sorries.",
     "mathlibDependencies": [
       {
@@ -130,7 +130,7 @@
     "opens": [
       "ComplexityCore"
     ],
-    "axiomCount": 205,
+    "axiomCount": 211,
     "sorries": 0,
     "definitionCount": 150,
     "theoremCount": 302,


### PR DESCRIPTION
## Fix

Sync \`meta.axiomCount\` and \`leanFile.axiomCount\` for \`p-vs-np\` from **205 → 211**.

PR #16917 declared \`ComplexityCore.lean\` as a non-Aristotle additionalFile (mirroring \`leanFile.additionalFiles\` to \`meta.additionalFiles\` so find-targets can see it), but did not sync the chain-total axiom count. Per the axiom integrity policy and the convention established in PR #16557 (which counts \`opaque\` as assumption-bearing), the chain total should include axioms+opaques from all declared files.

## Evidence

Counts via comment-stripped regex \`^\s*(?:(?:private|protected|noncomputable)\s+)*(?:axiom|opaque)\s+\S\`:

| File | axiom | opaque | total |
|------|-------|--------|-------|
| \`Proofs/PNPBarriersUnified.lean\` | 121 | 84 | 205 |
| \`Proofs/ComplexityCore.lean\`     |   5 |  1 |   6 |
| **Chain total**                    | **126** | **85** | **211** |

**Before**: \`meta.axiomCount = 205\`, \`leanFile.axiomCount = 205\` (counted main file only)
**After**: \`meta.axiomCount = 211\`, \`leanFile.axiomCount = 211\` (chain total, matches the eight entries synced in #16557)

## Scope

Two-line surgical edit. No Lean source changes, no narrative changes. The \`assumptions\` field continues to say \`\"121 axiom(s)\"\` — that is a separate drift dimension (axiom-keyword-only count for main file) untouched here.

PR #16917 noted: *\"p-vs-np remains an underclaim (205 vs 126), which is acceptable per project convention (audit only flags claimed > actual).\"* That is correct for find-targets (which reads \`axiom\` declarations only), but does not satisfy the axiom integrity policy where \`opaque\` is also an assumption.

---

Automated fix by lean-mechanic agent.