### PR TITLE
research(law-of-cosines-oq-01-oq-01-oq-01): ship gallery entry — spherical sine rule (angle-over-side)

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-001",
+    "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
+    "range": { "startLine": 27, "endLine": 27 },
+    "type": "technique",
+    "title": "Import the Side-over-Angle Form",
+    "content": "The single import `Proofs.LawOfCosinesOQ01OQ02` brings in `spherical_law_of_sines_all`, which is the conjunction sin(a)/sin(A) = sin(b)/sin(B) ∧ sin(a)/sin(A) = sin(c)/sin(C) for nondegenerate spherical triangles. The proof obligation in this file is the symmetric statement with sides and angles exchanged.",
+    "mathContext": "The side-over-angle form $\\frac{\\sin a}{\\sin A} = \\frac{\\sin b}{\\sin B} = \\frac{\\sin c}{\\sin C}$ is proved in the parent file via the Gram-determinant identity $\\sin^2(X)\\sin^2(y)\\sin^2(z) = G$ (where $G = 1 - \\cos^2 a - \\cos^2 b - \\cos^2 c + 2\\cos a\\cos b\\cos c$ is the Gram determinant of perpendicular projections on the unit sphere). Once the side-over-angle form is in hand, the angle-over-side form is purely formal — no further geometric content is needed.",
+    "significance": "supporting",
+    "relatedConcepts": ["spherical law of sines", "Gram determinant", "perpendicular projection"],
+    "prerequisites": ["spherical law of sines (side-over-angle form)", "Lean 4 imports"]
+  },
+  {
+    "id": "ann-002",
+    "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
+    "range": { "startLine": 32, "endLine": 32 },
+    "type": "technique",
+    "title": "Extend the Parent Namespace for Dot Notation",
+    "content": "Reopening `namespace LawOfCosinesOQ01OQ02` in this file is required so that the dot notation `t.angleA`, `t.angleB`, `t.angleC` resolves to the parent file's `SphericalTriangle.angleA` etc. Without the namespace match the dot-notation desugaring would fail to find these projections (since `SphericalTriangle` itself is defined further upstream in `SphericalLawOfCosines.lean`, but the `angleA`/`angleB` definitions live inside `LawOfCosinesOQ01OQ02`).",
+    "mathContext": "Lean's dot notation `x.foo` desugars to `<Namespace>.foo x` where `<Namespace>` is the head of the type of `x`. For `t : SphericalTriangle`, dot notation searches `SphericalTriangle.foo` first; if not found it falls back to the `open` namespace stack. Reopening the namespace places the definitions of angleA/angleB into the lookup path used during elaboration.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lean 4 namespaces", "dot notation", "name resolution"],
+    "prerequisites": ["Lean 4 namespace mechanics"]
+  },
+  {
+    "id": "ann-003",
+    "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
+    "range": { "startLine": 38, "endLine": 54 },
+    "type": "key-step",
+    "title": "Algebraic Inversion via div_eq_div_iff",
+    "content": "The core of the proof: `div_eq_div_iff (ne_of_gt hA) (ne_of_gt hB)` rewrites the goal sin(A)/sin(a) = sin(B)/sin(b) into the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a). Applied symmetrically to the parent hypothesis h1 : sin(a)/sin(A) = sin(b)/sin(B), it yields sin(a)·sin(B) = sin(b)·sin(A). The two cross-multiplied forms differ only by a sign; `linear_combination -h1` closes the goal automatically.",
+    "mathContext": "$\\texttt{div\\_eq\\_div\\_iff}$: for nonzero $b, d$, the equation $\\frac{a}{b} = \\frac{c}{d}$ is equivalent to $a \\cdot d = c \\cdot b$. Applying it on both the goal and the hypothesis transforms a division-form equality into a polynomial identity that Lean's `linear_combination` tactic can verify by reducing to $0 = 0$ after a single linear combination of the hypothesis. The hypothesis 0 < sin(angle) provides the `ne_of_gt` nonzero requirement.",
+    "significance": "key",
+    "relatedConcepts": ["div_eq_div_iff", "linear_combination", "cross-multiplication", "polynomial identities"],
+    "prerequisites": ["division on Real", "linear_combination tactic", "ne_of_gt"]
+  },
+  {
+    "id": "ann-004",
+    "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 64 },
+    "type": "technique",
+    "title": "Transitivity Closes the Third Equality",
+    "content": "Once sin(A)/sin(a) = sin(B)/sin(b) and sin(A)/sin(a) = sin(C)/sin(c) are established, the third equality sin(B)/sin(b) = sin(C)/sin(c) follows by symmetry and transitivity: from h1.symm we get sin(B)/sin(b) = sin(A)/sin(a), then trans h2 gives sin(B)/sin(b) = sin(C)/sin(c). No further algebraic manipulation is required.",
+    "mathContext": "Eq.symm : a = b → b = a; Eq.trans : a = b → b = c → a = c. These are the basic equality combinators. The pattern h1.symm.trans h2 with h1 : x = y, h2 : x = z yields y = z. Applied here with x = sin(A)/sin(a), y = sin(B)/sin(b), z = sin(C)/sin(c), it gives the missing third equality of the sine rule.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eq.symm", "Eq.trans", "transitivity"],
+    "prerequisites": ["Lean 4 equality calculus"]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,9 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const lawOfCosinesOQ01OQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const lawOfCosinesOQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const lawOfCosinesOQ01OQ01OQ01Data: ProofData = { proof: lawOfCosinesOQ01OQ01OQ01Proof, annotations: lawOfCosinesOQ01OQ01OQ01Annotations }
+export default lawOfCosinesOQ01OQ01OQ01Data

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "law-of-cosines-oq-01-oq-01-oq-01",
+  "title": "Spherical Law of Sines (Angle-over-Side Form)",
+  "slug": "law-of-cosines-oq-01-oq-01-oq-01",
+  "description": "Derives the angle-over-side form of the spherical law of sines, sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c), from the side-over-angle form sin(a)/sin(A) = sin(b)/sin(B) = sin(c)/sin(C) proved in Proofs/LawOfCosinesOQ01OQ02.lean. The proof is a 64-line algebraic inversion via div_eq_div_iff and linear_combination, completing the open question raised in law-of-cosines-oq-01-oq-01 about generalizing the Gram-determinant framework to the full sine rule.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ01OQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "spherical-geometry",
+      "law-of-sines",
+      "law-of-cosines",
+      "gram-determinant",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 64,
+    "assumptions": "No axioms or sorries. Inherits Mathlib's inner-product-space theory and the spherical-law-of-sines (side-over-angle form, spherical_law_of_sines_all) proved in Proofs/LawOfCosinesOQ01OQ02.lean. All hypotheses (positive sines of all sides and all angles) are inherited from the parent theorem.",
+    "dateAdded": "2026-05-08",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "spherical_law_of_sines_angle_over_side: angle-over-side equalities sin(A)/sin(a) = sin(B)/sin(b) and sin(A)/sin(a) = sin(C)/sin(c) derived by div_eq_div_iff inversion of the side-over-angle form",
+      "spherical_law_of_sines_BC_angle_over_side: sin(B)/sin(b) = sin(C)/sin(c) by transitivity of the previous theorem",
+      "Confirmation that the Gram-determinant framework introduced for the dual cosine law is sufficient for the full sine rule (no new geometry needed): the 64-line wrapper closes the open question oq-01-oq-01-oq-01 raised in the parent entry"
+    ],
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "path": "Proofs/LawOfCosinesOQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 64,
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The spherical law of sines, sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c), is one of the three fundamental relations of spherical trigonometry alongside the spherical law of cosines (cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C)) and its dual (cos(C) = -cos(A)cos(B) + sin(A)sin(B)cos(c)). It is symmetric — both forms (angle-over-side and side-over-angle) are equivalent under the nondegeneracy hypothesis (positive sines), and the side-over-angle form drops out cleanly from the Gram-determinant identity sin²(X)·sin²(y)·sin²(z) = G established in the dual law of cosines. Todhunter (1886) proves the sine rule first via the polar triangle construction; the modern Gram-determinant route (without polar duality) was reformulated in the present project's earlier entries (law-of-cosines-oq-01-oq-01, law-of-cosines-oq-01-oq-02).",
+    "problemStatement": "The parent entry law-of-cosines-oq-01-oq-01 raised the open question: \"Generalize the Gram determinant argument to prove the full sine rule sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c).\" This file answers that question affirmatively. The side-over-angle form is proved in law-of-cosines-oq-01-oq-02 as `spherical_law_of_sines_all`; this file derives the angle-over-side equivalent.",
+    "text": "Derives the angle-over-side form of the spherical law of sines from the side-over-angle form by algebraic inversion, closing the open question on generalizing the Gram-determinant framework to the full sine rule.",
+    "proofStrategy": "Given `spherical_law_of_sines_all` (sin(a)/sin(A) = sin(b)/sin(B) and sin(a)/sin(A) = sin(c)/sin(C), proved in Proofs/LawOfCosinesOQ01OQ02.lean as a consequence of sin²(X)·sin²(y)·sin²(z) = gramDet for each angle-side triple), the angle-over-side form follows by clearing denominators with div_eq_div_iff and rearranging. Both equalities reduce to a single linear_combination once the hypotheses 0 < sin(angle), 0 < sin(side) are in scope. The B/b = C/c part follows by transitivity of the first two equalities (h₁.symm.trans h₂).",
+    "keyInsights": [
+      "div_eq_div_iff transforms a/b = c/d (with b, d nonzero) into a·d = c·b, removing the denominators and reducing the goal to a polynomial-ring identity. This converts the inversion sin(a)/sin(A) ↦ sin(A)/sin(a) into a finite linear combination over Real.",
+      "The Gram-determinant identity sin²(X)·sin²(y)·sin²(z) = G (for each cyclic triple (X,y,z)) is the actual content of the sine rule. Once that is in hand from the parent, the inversion to angle-over-side is purely formal — no geometric content beyond what is already in the dual cosine law's framework is needed.",
+      "Both directions of the sine rule require positive-sine hypotheses for both sides AND angles. In the side-over-angle form positive angle sines are needed to divide by sin(angle); in the angle-over-side form positive side sines are needed. The full theorem statement in this file takes all six hypotheses, matching the parent.",
+      "B/b = C/c follows from A/a = B/b and A/a = C/c by transitivity: (A/a = B/b).symm.trans (A/a = C/c) ⟹ B/b = C/c. The bare minimum is the conjunction A/a = B/b ∧ A/a = C/c, since the C-equality is enough to derive the third.",
+      "This 64-line wrapper is the lightest possible closure of the open question oq-01-oq-01-oq-01: by the time the side-over-angle form (which IS the harder direction, requiring the Gram-determinant nonnegativity argument) is in place, the angle-over-side form is just algebraic bookkeeping."
+    ],
+    "prerequisites": [
+      "Spherical law of sines, side-over-angle form: spherical_law_of_sines_all in Proofs/LawOfCosinesOQ01OQ02.lean",
+      "div_eq_div_iff: a/b = c/d ↔ a·d = c·b for b, d nonzero (Mathlib)",
+      "linear_combination tactic: closes goals reducible to linear combinations of given hypotheses over a commutative ring (Mathlib.Tactic.LinearCombination)",
+      "Eq.symm and Eq.trans for transitivity of equalities"
+    ],
+    "openQuestions": [
+      "Does the sine rule extend to degenerate spherical triangles (some sides 0 or π, equivalently some sides have sin = 0)? In that case some divisions are not defined; the right reformulation may be the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a) (which holds even when both factors are zero).",
+      "Can the angle-over-side form be derived more directly (without going through the side-over-angle form first), e.g., by unfolding angleA = arccos(...) via the cosine formula and proving sin²(A)·sin²(b)·sin²(c) = sin²(B)·sin²(a)·sin²(c) directly?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module docstring stating the open question (`Generalize to prove the full spherical sine rule sin(A)/sin(a)=sin(B)/sin(b)=sin(C)/sin(c) using the Gram determinant framework`) and the answer (yes, by algebraic inversion of the side-over-angle form). Imports Proofs.LawOfCosinesOQ01OQ02 to inherit the side-over-angle theorem and dot notation for SphericalTriangle's angleA/angleB."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Angle-over-Side Form",
+      "startLine": 34,
+      "endLine": 54,
+      "summary": "spherical_law_of_sines_angle_over_side: sin(A)/sin(a) = sin(B)/sin(b) ∧ sin(A)/sin(a) = sin(C)/sin(c). Proof obtains the side-over-angle conjunction from spherical_law_of_sines_all, then for each part rewrites both sides via div_eq_div_iff to clear denominators, and closes with linear_combination -h."
+    },
+    {
+      "id": "transitivity-corollary",
+      "title": "Transitivity Corollary: B/b = C/c",
+      "startLine": 56,
+      "endLine": 64,
+      "summary": "spherical_law_of_sines_BC_angle_over_side: sin(B)/sin(b) = sin(C)/sin(c). Trivially follows from the conjunction in the main theorem via h1.symm.trans h2."
+    }
+  ],
+  "conclusion": {
+    "summary": "Closes the open question raised in law-of-cosines-oq-01-oq-01 (`Generalize to prove the full spherical sine rule using the Gram determinant framework established here`). The proof is a 64-line wrapper over the side-over-angle form spherical_law_of_sines_all (proved in law-of-cosines-oq-01-oq-02 from the Gram-determinant identity sin²(X)·sin²(y)·sin²(z) = G); the angle-over-side equivalent follows by div_eq_div_iff inversion and linear_combination. Verified: 2 theorems, 0 sorries, 0 axioms, 64 lines.",
+    "implications": "Confirms that the Gram-determinant framework is the right invariant for spherical trigonometry: it underpins both the dual cosine law (cos(C) = -cos(A)cos(B) + sin(A)sin(B)cos(c), proved in law-of-cosines-oq-01-oq-01) and now the full sine rule (proved here as a corollary of its side-over-angle form, established in law-of-cosines-oq-01-oq-02). Together these three results — the standard spherical law of cosines, its dual, and the sine rule — are now machine-checked in Lean 4 from a single common framework (the Gram determinant of perpendicular projections), without recourse to the polar triangle construction. The proof infrastructure (perpendicular projections, gramDet nonnegativity via Cauchy-Schwarz) generalizes to higher-dimensional spherical geometry and to hyperbolic analogues.",
+    "openQuestions": [
+      "Extend the sine rule to degenerate spherical triangles (sides 0 or π, where some sines vanish). The right reformulation is likely the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a), which holds without nondegeneracy hypotheses.",
+      "Derive the angle-over-side form directly without going through the side-over-angle form, as an exercise in the symmetry of the Gram determinant.",
+      "Generalize to spherical n-gons: does the Gram determinant of n perpendicular projections give angle-side relations for spherical polygons?",
+      "Prove the hyperbolic analogue: sinh(a)/sin(A) = sinh(b)/sin(B) = sinh(c)/sin(C) on the hyperbolic plane H², via a hyperbolic Gram determinant 1 - cosh²(a) - cosh²(b) - cosh²(c) + 2cosh(a)cosh(b)cosh(c) ≤ 0."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "law-of-cosines-oq-01-oq-01",
+      "title": "Dual Spherical Law of Cosines",
+      "relationship": "Direct parent: raised the open question that this entry answers. The Gram-determinant framework for the dual cosine law is reused (via the side-over-angle form proved in law-of-cosines-oq-01-oq-02) to derive the sine rule."
+    },
+    {
+      "id": "law-of-cosines-oq-01-oq-02",
+      "title": "Spherical Law of Sines (Side-over-Angle Form)",
+      "relationship": "Direct prerequisite: proves spherical_law_of_sines_all (the side-over-angle conjunction sin(a)/sin(A) = sin(b)/sin(B) ∧ sin(a)/sin(A) = sin(c)/sin(C)) via the Gram-determinant identity sin²(X)·sin²(y)·sin²(z) = G. This file inverts that to angle-over-side."
+    },
+    {
+      "id": "law-of-cosines-oq-01-oq-01-oq-03",
+      "title": "Polar Triangle and Dual Spherical Law",
+      "relationship": "Sibling: an alternative proof of the dual spherical law via the polar triangle construction. Together with this entry's framework-internal proof of the sine rule, the dual law has both indirect (polar) and direct (Gram-determinant) routes formalized."
+    },
+    {
+      "id": "law-of-cosines-oq-01",
+      "title": "Spherical Law of Cosines (Open Question)",
+      "relationship": "Grandparent open question about generalizing the planar law of cosines to the sphere. This entry, together with its siblings, completes the Lean 4 formalization of the three fundamental relations of spherical trigonometry."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/law-of-cosines-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-01-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "law-of-cosines-oq-01-oq-01-oq-01",
   "title": "Spherical sine rule generalization sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c)",
-  "phase": "BLOCKED",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,15 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-05-07T16:30:00Z",
-    "iteration": 2,
-    "focus": "Proof complete in worktree but cannot build: upstream Proofs/LawOfCosinesOQ01OQ02 fails on main (issue #16613).",
-    "blockers": [
-      "Proofs/LawOfCosinesOQ01OQ02.lean fails Docker build on main: spherical_law_of_sines_all C-case lines 347/349/354 (issue #16613)",
-      "Specifically: (a) dite vs ite mismatch between SphericalTriangle.angleC (uses dite via \"if h :\") and SphericalTriangle.angleA (uses plain ite); (b) Or.comm + real_inner_comm needed for t.angleB = t.angleA permutation step; (c) rewrite pattern stale at line 354."
-    ],
-    "nextAction": "Wait for issue #16613 to be resolved (mechanic agent will pick it up); then revisit and ship gallery entry.",
+    "phase": "COMPLETED",
+    "since": "2026-05-08T03:50:00Z",
+    "iteration": 3,
+    "focus": "Completed and shipped. Upstream blocker #16613 was resolved by PR #16710 (closed 2026-05-07). LawOfCosinesOQ01OQ02 now builds; the 64-line wrapper in proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean is verified (2 theorems, 0 sorries, 0 axioms) and gallery entry shipped in src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/.",
+    "blockers": [],
+    "nextAction": "None — entry shipped. Future work: degenerate-triangle generalization (sides 0/π) and curvature-parametric K ≠ 1 versions.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED on upstream OQ02 build failure (issue #16613, 2026-05-07). My 64-line wrapper file (proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean) is mathematically complete: spherical_law_of_sines_angle_over_side proves sin(A)/sin(a) = sin(B)/sin(b) ∧ sin(A)/sin(a) = sin(C)/sin(c) by algebraic inversion of spherical_law_of_sines_all from OQ02; spherical_law_of_sines_BC_angle_over_side adds B/b = C/c by transitivity. But OQ02 itself currently fails to build on main due to three specific tactic bugs in spherical_law_of_sines_all C-case (lines 347/349/354). Detailed root-cause analysis filed in issue #16613.",
+    "progressSummary": "COMPLETED 2026-05-08. Upstream blocker (issue #16613) was resolved by PR #16710 (closed 2026-05-07). The 64-line wrapper file (proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean) was already on main from earlier work; this iteration shipped the gallery entry (src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/) with meta.json + index.ts + annotations.json. spherical_law_of_sines_angle_over_side proves sin(A)/sin(a) = sin(B)/sin(b) ∧ sin(A)/sin(a) = sin(C)/sin(c) by algebraic inversion (div_eq_div_iff + linear_combination) of spherical_law_of_sines_all from OQ02; spherical_law_of_sines_BC_angle_over_side adds B/b = C/c by transitivity. Counts: 2 theorems, 0 sorries, 0 axioms, 64 lines. Closes the open question raised in law-of-cosines-oq-01-oq-01: 'Generalize the Gram determinant argument to prove the full sine rule.' Answer: yes, by 64 lines of formal inversion of the side-over-angle form, no new geometric content needed.",
     "builtItems": [
       "sinC_sq_gramDet: sin²(C)·sin²(a)·sin²(b) = gramDet (parallel to sinA/sinB)",
       "sinC_nonneg: 0 ≤ sin(C)",
@@ -54,9 +51,9 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Wait for #16613 (LawOfCosinesOQ01OQ02 build failure) to be resolved by mechanic.",
-      "After OQ02 builds: cp the lean file from main repo to worktree, build to verify, then add gallery entry (meta.json/index.ts/annotations.json).",
-      "Future generalizations (post-merge): degenerate triangles (sides 0/π) requiring limit arguments; geodesic triangles on surfaces of constant curvature K ≠ 1."
+      "Future generalization (open question): degenerate spherical triangles where sides are 0 or π (some sines vanish). Right reformulation likely the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a), which holds without nondegeneracy hypotheses.",
+      "Future generalization (open question): geodesic triangles on surfaces of constant curvature K ≠ 1, via the curvature-parametric framework of law-of-cosines-oq-01-oq-05 (UnifiedTriangle).",
+      "Possible direct proof (no inversion): unfold angleA = arccos(...) via the cosine formula and prove sin²(A)·sin²(b)·sin²(c) = sin²(B)·sin²(a)·sin²(c) directly, mirroring the dual cosine law's pattern."
     ]
   },
   "tags": [
@@ -83,7 +80,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.695Z",
-  "lastUpdate": "2026-05-07T16:30:00Z",
+  "lastUpdate": "2026-05-08T03:50:00Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Closes the open question raised in `law-of-cosines-oq-01-oq-01`: **\"Generalize the Gram determinant argument to prove the full sine rule sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c).\"** The 64-line wrapper `Proofs/LawOfCosinesOQ01OQ01OQ01.lean` has been on `main` since the upstream blocker (issue #16613, fixed by PR #16710 on 2026-05-07) was resolved. This PR ships the gallery entry that was held back while the block was active.

## Files added

- **`src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/meta.json`** (121 lines): full metadata with sections, conclusion, key insights, original contributions, prerequisites, follow-up open questions, and crossReferences linking to siblings:
  - `law-of-cosines-oq-01-oq-01` (dual cosine law — direct parent that raised this open question)
  - `law-of-cosines-oq-01-oq-02` (side-over-angle form — direct prerequisite)
  - `law-of-cosines-oq-01-oq-01-oq-03` (polar triangle / dual law — sibling alternative route)
  - `law-of-cosines-oq-01` (grandparent open question)
- **`src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/index.ts`**: standard glob-discovered registration matching the parent's pattern.
- **`src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/annotations.json`** (4 annotations): import structure, the parent-namespace reopening trick (for dot-notation resolution of `t.angleA`/`t.angleB`), the **div_eq_div_iff + linear_combination algebraic-inversion** technique (the actual content of the proof), and the transitivity corollary.

## Files updated

- **`src/data/research/problems/law-of-cosines-oq-01-oq-01-oq-01.json`**:
  - `status`: `active` → `completed`
  - `phase`: `BLOCKED` → `COMPLETED`
  - `currentState`: rewritten to point at the resolved blocker (#16613 closed by #16710)
  - `progressSummary`: updated with shipping summary
  - `nextSteps`: stale wait-for-mechanic items replaced with three open future-generalization questions (degenerate triangles where some sines vanish; curvature K ≠ 1 via the `UnifiedTriangle` framework in `law-of-cosines-oq-01-oq-05`; possible direct proof bypassing the side-over-angle route)
  - `lastUpdate`: bumped

## What the proof does

The 64-line wrapper extends the parent's namespace `LawOfCosinesOQ01OQ02` (so dot-notation for `SphericalTriangle.angleA`/`angleB` resolves correctly), then derives the angle-over-side form by **algebraic inversion** of the side-over-angle form (`spherical_law_of_sines_all`, proved upstream from the Gram-determinant identity sin²(X)·sin²(y)·sin²(z) = G):

1. `spherical_law_of_sines_angle_over_side` — main theorem: applies `div_eq_div_iff` to both the goal and each conjunct of `spherical_law_of_sines_all`, reducing to a single `linear_combination -h` for each part.
2. `spherical_law_of_sines_BC_angle_over_side` — corollary: the third equality follows by transitivity (`h1.symm.trans h2`).

Counts: **2 theorems, 0 sorries, 0 axioms, 64 lines**. Status: `verified`, badge: `original`.

## Why this matters

The Gram-determinant framework introduced for the dual cosine law in `law-of-cosines-oq-01-oq-01` is now confirmed sufficient for **all three fundamental relations of spherical trigonometry** — standard cosine law, dual cosine law, and the sine rule — all machine-checked in Lean 4 from a single common framework, without recourse to the polar triangle construction. The proof infrastructure (perpendicular projections, `gramDet` nonnegativity via Cauchy-Schwarz) generalizes to higher-dimensional spherical geometry and to hyperbolic analogues.

## Test plan

- [x] All three JSON files validate (`python3 -m json.tool`).
- [x] `npx tsc -b --noEmit` passes for the new entry (only pre-existing `research/index.ts` error from missing `research-listings.json`, unrelated).
- [x] No Lean files modified — wrapper already on `main` since the upstream blocker was resolved.
- [x] `pnpm annotations:build` (run locally) successfully picks up the new entry — \"📋 Generated listings.json (2398 proofs ...)\" includes \"law-of-cosines-oq-01-oq-01-oq-01 | verified | Spherical Law of Sines (Angle-over-Side Form)\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)