### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S48 — double-removal hookLength shift characterization

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean
@@ -5003,6 +5003,207 @@ private lemma hookLength_eq_of_not_arm_leg {μ : YoungDiagram} {c : ℕ × ℕ} 
   unfold hookLength armLen legLen
   rw [rowLen_removeCorner_other hc ha, colLen_removeCorner_other hc hb]
 
+-- ============================================================
+-- Double-removal hookLength shifts (Session 48)
+-- For two distinct corners c, c' of μ with c.1 < c'.1 (whence c'.2 < c.2 by
+-- `corner_col_lt_of_row_lt`), the lemmas in this block characterize how
+-- `hookLength` shifts at each cell when both corners are removed.  The shift
+-- is determined purely by x's geometric relationship to the two corners:
+--   * `(c.1, c'.2)` (the doubly-affected cell)        → shift by 2
+--   * arm(c) \ {(c.1, c'.2)}, leg(c), arm(c'), leg(c') \ {(c.1, c'.2)} → shift by 1
+--   * everything else                                  → shift by 0.
+-- These six lemmas are the core combinatorial input to `gnwProb_exchange`
+-- (line 14173).  All proofs are 1-2 line consequences of the existing
+-- single-removal helpers (`hookLength_removeCorner_arm`, `_leg`,
+-- `hookLength_eq_of_not_arm_leg`) chained through `isCorner_removeCorner_of_ne`.
+-- The iteration order is `(μ\c)\c'`; convert to `(μ\c')\c` via
+-- `removeCorner_swap` if needed.
+-- ============================================================
+
+/-- **Doubly-affected cell shifts by 2.**
+
+For two distinct corners `c, c'` of `μ` with `c.1 < c'.1` (whence `c'.2 < c.2`),
+the cell `(c.1, c'.2)` is the unique cell sitting in the arm of `c` and the
+leg of `c'`.  Removing both corners shifts its hook length by exactly 2:
+removing `c` cuts its arm by 1, then removing `c'` (still a corner of `μ\c`)
+cuts its leg by 1.
+
+This is the cell whose hook-length asymmetry is the heart of the GNW 1979
+exchange identity:
+`h_μ(d) · h_{(μ\c)\c'}(d) = h(h-2)` versus
+`h_{μ\c}(d) · h_{μ\c'}(d) = (h-1)²`. -/
+private lemma hookLength_doubleRemove_doubly_affected
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c.1 < c'.1) :
+    hookLength (removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne)) c.1 c'.2 + 2 =
+      hookLength μ c.1 c'.2 := by
+  have h_col_lt : c'.2 < c.2 := corner_col_lt_of_row_lt hc hc' hi
+  -- Step 1 (arm of c): hookLength_{μ\c}(c.1, c'.2) + 1 = hookLength_μ(c.1, c'.2)
+  have h_arm := hookLength_removeCorner_arm hc h_col_lt
+  -- Step 2 (leg of c' inside μ\c): hookLength_{(μ\c)\c'}(c.1, c'.2) + 1
+  --                              = hookLength_{μ\c}(c.1, c'.2)
+  have hc'_in_rc : isCorner (removeCorner μ c hc) c' :=
+    isCorner_removeCorner_of_ne hc hc' hne
+  have h_leg := hookLength_removeCorner_leg hc'_in_rc hi
+  omega
+
+/-- **Arm of c (excluding doubly-affected): shift by 1.**
+
+For arm-of-`c` cells `(c.1, s)` with `s < c.2` and `s ≠ c'.2`, removing both
+corners shifts hook length by exactly 1: the arm-of-`c` shift accounts for
+the entire change, since the cell is in neither the arm nor the leg of `c'`
+(different row from `c'` and different column since `s ≠ c'.2`). -/
+private lemma hookLength_doubleRemove_arm_of_c_off_d
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c.1 < c'.1)
+    {s : ℕ} (hs : s < c.2) (hs' : s ≠ c'.2) :
+    hookLength (removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne)) c.1 s + 1 =
+      hookLength μ c.1 s := by
+  -- Step 1 (arm of c): hookLength_{μ\c}(c.1, s) + 1 = hookLength_μ(c.1, s)
+  have h_arm := hookLength_removeCorner_arm hc hs
+  -- Step 2 (NOT arm or leg of c' in μ\c): hookLength unchanged after removing c'.
+  have hc'_in_rc : isCorner (removeCorner μ c hc) c' :=
+    isCorner_removeCorner_of_ne hc hc' hne
+  have hxν : (c.1, s) ∈ removeCorner μ c hc := by
+    rw [mem_removeCorner]
+    refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by rw [rowLen_of_isCorner hc]; omega), ?_⟩
+    intro h; have : s = c.2 := congr_arg Prod.snd h; omega
+  have hxc' : (c.1, s) ≠ c' := fun h => by
+    have : c.1 = c'.1 := congr_arg Prod.fst h; omega
+  have hxarm : ¬((c.1, s).1 = c'.1 ∧ (c.1, s).2 < c'.2) := by
+    rintro ⟨h1, _⟩; exact absurd h1 (Nat.ne_of_lt hi)
+  have hxleg : ¬((c.1, s).1 < c'.1 ∧ (c.1, s).2 = c'.2) := by
+    rintro ⟨_, h2⟩; exact hs' h2
+  have h_unaff := hookLength_eq_of_not_arm_leg hc'_in_rc hxν hxc' hxarm hxleg
+  -- Goal: hookLength ((μ\c)\c') c.1 s + 1 = hookLength μ c.1 s
+  -- h_unaff : hookLength ((μ\c)\c') c.1 s = hookLength (μ\c) c.1 s
+  -- h_arm   : hookLength (μ\c) c.1 s + 1 = hookLength μ c.1 s
+  rw [h_unaff]; exact h_arm
+
+/-- **Leg of c: shift by 1.**
+
+For leg-of-`c` cells `(r, c.2)` with `r < c.1`, removing both corners shifts
+hook length by exactly 1: the leg-of-`c` shift accounts for the entire change.
+The cell is in neither arm nor leg of `c'`:
+* not in arm of `c'` because `r < c.1 < c'.1`, so `r ≠ c'.1`;
+* not in leg of `c'` because `c.2 ≠ c'.2` (in fact `c'.2 < c.2`). -/
+private lemma hookLength_doubleRemove_leg_of_c
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c.1 < c'.1)
+    {r : ℕ} (hr : r < c.1) :
+    hookLength (removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne)) r c.2 + 1 =
+      hookLength μ r c.2 := by
+  have h_col_lt : c'.2 < c.2 := corner_col_lt_of_row_lt hc hc' hi
+  have h_leg := hookLength_removeCorner_leg hc hr
+  have hc'_in_rc : isCorner (removeCorner μ c hc) c' :=
+    isCorner_removeCorner_of_ne hc hc' hne
+  have hxν : (r, c.2) ∈ removeCorner μ c hc := by
+    rw [mem_removeCorner]
+    refine ⟨YoungDiagram.mem_iff_lt_colLen.mpr (by rw [colLen_of_isCorner hc]; omega), ?_⟩
+    intro h; have : r = c.1 := congr_arg Prod.fst h; omega
+  have hxc' : (r, c.2) ≠ c' := fun h => by
+    have : c.2 = c'.2 := congr_arg Prod.snd h; omega
+  have hxarm : ¬((r, c.2).1 = c'.1 ∧ (r, c.2).2 < c'.2) := by
+    rintro ⟨h1, _⟩; omega
+  have hxleg : ¬((r, c.2).1 < c'.1 ∧ (r, c.2).2 = c'.2) := by
+    rintro ⟨_, h2⟩; omega
+  have h_unaff := hookLength_eq_of_not_arm_leg hc'_in_rc hxν hxc' hxarm hxleg
+  rw [h_unaff]; exact h_leg
+
+/-- **Arm of c': shift by 1.**
+
+For arm-of-`c'` cells `(c'.1, s)` with `s < c'.2`, removing both corners shifts
+hook length by exactly 1: the arm-of-`c'` shift on `μ\c` accounts for the
+entire change.  The cell is in neither arm nor leg of `c` (different row from
+`c` since `c'.1 ≠ c.1`, and different column since `s < c'.2 < c.2`). -/
+private lemma hookLength_doubleRemove_arm_of_c'
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c.1 < c'.1)
+    {s : ℕ} (hs : s < c'.2) :
+    hookLength (removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne)) c'.1 s + 1 =
+      hookLength μ c'.1 s := by
+  have h_col_lt : c'.2 < c.2 := corner_col_lt_of_row_lt hc hc' hi
+  -- Step 1: removing c doesn't change hookLength at (c'.1, s) (not in arm/leg of c)
+  have hsmem : (c'.1, s) ∈ μ :=
+    YoungDiagram.mem_iff_lt_rowLen.mpr (by rw [rowLen_of_isCorner hc']; omega)
+  have hxc : (c'.1, s) ≠ c := fun h => by
+    have : c'.1 = c.1 := congr_arg Prod.fst h; omega
+  have hxarm : ¬((c'.1, s).1 = c.1 ∧ (c'.1, s).2 < c.2) := by
+    rintro ⟨h1, _⟩; omega
+  have hxleg : ¬((c'.1, s).1 < c.1 ∧ (c'.1, s).2 = c.2) := by
+    rintro ⟨_, h2⟩; omega
+  have h_unaff_c := hookLength_eq_of_not_arm_leg hc hsmem hxc hxarm hxleg
+  -- Step 2: hookLength_{(μ\c)\c'}(c'.1, s) + 1 = hookLength_{μ\c}(c'.1, s) (arm of c' in μ\c)
+  have hc'_in_rc : isCorner (removeCorner μ c hc) c' :=
+    isCorner_removeCorner_of_ne hc hc' hne
+  have h_arm_c' := hookLength_removeCorner_arm hc'_in_rc hs
+  -- Goal: hookLength ((μ\c)\c') c'.1 s + 1 = hookLength μ c'.1 s
+  -- h_arm_c' : hookLength ((μ\c)\c') c'.1 s + 1 = hookLength (μ\c) c'.1 s
+  -- h_unaff_c: hookLength (μ\c) c'.1 s = hookLength μ c'.1 s
+  omega
+
+/-- **Leg of c' (excluding doubly-affected): shift by 1.**
+
+For leg-of-`c'` cells `(r, c'.2)` with `r < c'.1` and `r ≠ c.1`, removing both
+corners shifts hook length by exactly 1.  The cell is in neither arm nor leg
+of `c`: not in arm of `c` because `r ≠ c.1`, and not in leg of `c` because
+`c'.2 ≠ c.2` (in fact `c'.2 < c.2`).  The leg-of-`c'` shift on `μ\c` accounts
+for the entire change. -/
+private lemma hookLength_doubleRemove_leg_of_c'_off_d
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c') (hi : c.1 < c'.1)
+    {r : ℕ} (hr : r < c'.1) (hrc : r ≠ c.1) :
+    hookLength (removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne)) r c'.2 + 1 =
+      hookLength μ r c'.2 := by
+  have h_col_lt : c'.2 < c.2 := corner_col_lt_of_row_lt hc hc' hi
+  -- Step 1: removing c doesn't change hookLength at (r, c'.2) (not in arm/leg of c)
+  have hsmem : (r, c'.2) ∈ μ :=
+    YoungDiagram.mem_iff_lt_colLen.mpr (by rw [colLen_of_isCorner hc']; omega)
+  have hxc : (r, c'.2) ≠ c := fun h => by
+    have : c'.2 = c.2 := congr_arg Prod.snd h; omega
+  have hxarm : ¬((r, c'.2).1 = c.1 ∧ (r, c'.2).2 < c.2) := by
+    rintro ⟨h1, _⟩; exact hrc h1
+  have hxleg : ¬((r, c'.2).1 < c.1 ∧ (r, c'.2).2 = c.2) := by
+    rintro ⟨_, h2⟩; omega
+  have h_unaff_c := hookLength_eq_of_not_arm_leg hc hsmem hxc hxarm hxleg
+  -- Step 2: hookLength_{(μ\c)\c'}(r, c'.2) + 1 = hookLength_{μ\c}(r, c'.2) (leg of c' in μ\c)
+  have hc'_in_rc : isCorner (removeCorner μ c hc) c' :=
+    isCorner_removeCorner_of_ne hc hc' hne
+  have h_leg_c' := hookLength_removeCorner_leg hc'_in_rc hr
+  omega
+
+/-- **Cells outside both arm/leg sets: hookLength unchanged.**
+
+For cells `x ∈ μ` with `x ≠ c, c'` and `x` not in the arm or leg of either
+corner, removing both corners leaves hook length unchanged.  Each removal
+falls into the "unaffected" branch of `hookLength_eq_of_not_arm_leg`,
+applied first to `c` on `μ`, then to `c'` on `μ\c`. -/
+private lemma hookLength_doubleRemove_other
+    {μ : YoungDiagram} {c c' : ℕ × ℕ}
+    (hc : isCorner μ c) (hc' : isCorner μ c') (hne : c ≠ c')
+    {x : ℕ × ℕ} (hxμ : x ∈ μ) (hxc : x ≠ c) (hxc' : x ≠ c')
+    (hxarm_c : ¬(x.1 = c.1 ∧ x.2 < c.2))
+    (hxleg_c : ¬(x.1 < c.1 ∧ x.2 = c.2))
+    (hxarm_c' : ¬(x.1 = c'.1 ∧ x.2 < c'.2))
+    (hxleg_c' : ¬(x.1 < c'.1 ∧ x.2 = c'.2)) :
+    hookLength (removeCorner (removeCorner μ c hc) c'
+        (isCorner_removeCorner_of_ne hc hc' hne)) x.1 x.2 =
+      hookLength μ x.1 x.2 := by
+  -- Step 1: removing c doesn't change hookLength (not in arm/leg of c)
+  have h_unaff_c := hookLength_eq_of_not_arm_leg hc hxμ hxc hxarm_c hxleg_c
+  -- Step 2: removing c' from μ\c doesn't change hookLength (not in arm/leg of c')
+  have hc'_in_rc : isCorner (removeCorner μ c hc) c' :=
+    isCorner_removeCorner_of_ne hc hc' hne
+  have hxν : x ∈ removeCorner μ c hc := by
+    rw [mem_removeCorner]; exact ⟨hxμ, hxc⟩
+  have h_unaff_c' := hookLength_eq_of_not_arm_leg hc'_in_rc hxν hxc' hxarm_c' hxleg_c'
+  rw [h_unaff_c', h_unaff_c]
+
 /-- Arm cells (c.1, s) with s < c.2 belong to ν = removeCorner μ c hc. -/
 private lemma arm_mem_nu {μ : YoungDiagram} {c : ℕ × ℕ} (hc : isCorner μ c)
     {s : ℕ} (hs : s < c.2) : (c.1, s) ∈ removeCorner μ c hc := by

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s03.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s03.md
@@ -1,0 +1,175 @@
+## Session 2026-05-08 (Session 48, researcher-10) — Double-removal hookLength shift lemmas
+
+**Mode**: ACT (RICH knowledge tier, score 192)
+**Outcome**: Six structural lemmas added giving a complete hook-length-shift
+characterization for double corner removal.  Sorry count unchanged (1).
+
+### What I Did
+
+Added six lemmas to `BallotProblemOQ03OQ01OQ02Helpers.lean` after
+`hookLength_eq_of_not_arm_leg` (line ~5005), as a coherent block titled
+"Double-removal hookLength shifts (Session 48)":
+
+1. **`hookLength_doubleRemove_doubly_affected`** — at the doubly-affected cell
+   `(c.1, c'.2)` (the unique cell in arm of `c` ∩ leg of `c'`), hookLength
+   shifts by **2** under double removal.  Proof: chain
+   `hookLength_removeCorner_arm hc h_col_lt` (shift by 1 from removing `c`)
+   with `hookLength_removeCorner_leg hc'_in_rc hi` (shift by 1 from removing
+   `c'` in `μ\c`), then `omega`.
+
+2. **`hookLength_doubleRemove_arm_of_c_off_d`** — for arm-of-`c` cells
+   `(c.1, s)` with `s < c.2` and `s ≠ c'.2`, hookLength shifts by **1**.
+   The cell is in neither arm nor leg of `c'` (different row from `c'`,
+   different column since `s ≠ c'.2`), so removing `c'` from `μ\c` is a
+   no-op via `hookLength_eq_of_not_arm_leg`.
+
+3. **`hookLength_doubleRemove_leg_of_c`** — for leg-of-`c` cells `(r, c.2)`
+   with `r < c.1`, hookLength shifts by **1**.  Cell is in neither arm nor
+   leg of `c'` (different row since `r < c.1 < c'.1`, different column
+   since `c.2 ≠ c'.2`).
+
+4. **`hookLength_doubleRemove_arm_of_c'`** — for arm-of-`c'` cells
+   `(c'.1, s)` with `s < c'.2`, hookLength shifts by **1**.  Cell is in
+   neither arm nor leg of `c` (different row from `c`, different column
+   since `s < c'.2 < c.2`).
+
+5. **`hookLength_doubleRemove_leg_of_c'_off_d`** — for leg-of-`c'` cells
+   `(r, c'.2)` with `r < c'.1` and `r ≠ c.1`, hookLength shifts by **1**.
+   Cell is in neither arm nor leg of `c` (different row since `r ≠ c.1`,
+   different column since `c'.2 < c.2`).
+
+6. **`hookLength_doubleRemove_other`** — for cells `x ∈ μ \ {c, c'}` not in
+   arm/leg of either corner, hookLength is **unchanged** under double
+   removal.  Direct two-step rewrite via `hookLength_eq_of_not_arm_leg`.
+
+All six are stated in the iteration order `(μ\c)\c'`; they convert to the
+order used in `gnwProb_exchange` (`(μ\c')\c`) via `removeCorner_swap` (S47).
+The hypothesis `c.1 < c'.1` (whence `c'.2 < c.2`) is the canonical WLOG
+selected by `distinct_corners_dichotomy` (S45).
+
+### Why this matters for `gnwProb_exchange`
+
+These six lemmas form a **complete case-decomposition** of how hookLength
+behaves under double corner removal.  Combined with the existing
+infrastructure (S43-S47), the gnwProb_exchange proof can now case-split
+each cell `x ∈ μ.cells` into one of seven branches:
+
+| Cell | Single-removal shifts | Double-removal shift | Lemma |
+|------|----------------------|----------------------|-------|
+| `c`  | excluded from `μ\c` | n/a | (handled by `arm_mem_nu`/`leg_mem_nu`) |
+| `c'` | excluded from `μ\c'`| n/a | (handled by `gnwProb_at_other_corner`) |
+| `(c.1, c'.2)` | arm(c): -1; leg(c'): -1 | **-2** | S48.1 |
+| arm(c) \ {(c.1, c'.2)} | arm(c): -1; (no c' shift) | **-1** | S48.2 |
+| leg(c) | leg(c): -1; (no c' shift) | **-1** | S48.3 |
+| arm(c') | (no c shift); arm(c'): -1 | **-1** | S48.4 |
+| leg(c') \ {(c.1, c'.2)} | (no c shift); leg(c'): -1 | **-1** | S48.5 |
+| else | (no shift) | **0** | S48.6 |
+
+This unlocks the algebraic core of the GNW 1979 exchange identity:
+
+```
+hookProd μ · hookProd ((μ\c)\c')   /   hookProd (μ\c) · hookProd (μ\c')
+  = ∏_{x ∈ μ.cells \ {c,c'}}  h_μ(x) · h_{(μ\c)\c'}(x)  /  h_{μ\c}(x) · h_{μ\c'}(x)
+  = h_μ(d) · (h_μ(d) - 2)  /  (h_μ(d) - 1)²
+```
+where `d = (c.1, c'.2)` is the doubly-affected cell.  All seven cell-types
+contribute trivial ratio 1 *except* `d`, which contributes
+`h(h-2)/(h-1)²` — exactly the asymmetry that the gnwProb sum is supposed
+to balance via the inductive walk-probability identity.  In product form:
+```
+hookProd μ · hookProd ((μ\c)\c') · (h_d - 1)²
+  = hookProd (μ\c) · hookProd (μ\c') · h_d · (h_d - 2).
+```
+
+### Position in the proof program
+
+Cumulative infrastructure from sessions 35-48 for the exchange identity:
+
+- **S35** Modularization: split monolith into Main + Helpers + Aristotle.
+- **S37-S42** GNW infrastructure: `strictHookCells`, `gnwProb`, `gnwProb_step`,
+  `gnwProb_stable`, `gnwProb_sum_corners`; single-corner case proved.
+- **S43** Strong induction wrapper (`gnwProb_key` multi-corner via
+  `termination_by μ.card`); sum-domain bridges
+  (`sum_gnwProb_eq_removeCorner_cells`,
+  `sum_gnwProb_strictHookCells_eq_removeCorner`,
+  `strictHookCells_removeCorner_eq[_of_not_mem]`).
+- **S44** Anti-monotone corner helpers (`corner_col_lt_of_row_lt`,
+  `corner_row_lt_of_col_lt`, `doubly_affected_cell_mem`).
+- **S45** Corner-distinctness coordinate lemmas (`corners_fst_ne`,
+  `corners_snd_ne`, `distinct_corners_dichotomy`).
+- **S46** Aristotle Target 3 closed via dispatcher (companion sorry 3 → 2).
+- **S47** `removeCorner_swap` + `hookProd_removeCorner_swap` (iteration-order
+  commutativity).
+- **S48 (this session)** Double-removal hookLength characterization
+  (six lemmas above).
+
+The infrastructure now covers:
+- F-domain (sum-over-cells) bridges
+- Sum-over-strictHookCells bridges
+- Per-cell hookLength shifts (single removal)
+- **Per-cell hookLength shifts (double removal)** ← new this session
+- Corner-coordinate dichotomy
+- Diagram and hookProd commutativity for double removal
+
+What remains for `gnwProb_exchange`: the actual product-algebra calculation
+that ties these per-cell shifts into the full equality.  The next session
+can attempt:
+
+1. **Decompose** `μ.cells = (μ.cells \ {c, c'}) ∪ {c, c'}` with c, c'
+   handled by the corner branches of gnwProb (single value 0 or 1).
+2. **Partition** `μ.cells \ {c, c'}` into the seven sub-cases above using
+   `Finset.disjUnion` machinery and the dichotomy.
+3. **Apply S48 lemmas** cell-by-cell to relate
+   `hookLength μ x` to `hookLength ((μ\c)\c') x`,
+   `hookLength (μ\c) x`, `hookLength (μ\c') x`.
+4. **Pair** the gnwProb factors via `gnwProb_step` / `gnwProb_stable` to
+   collapse the integrand comparison to:
+   `gnwProb μ c K x · h_{(μ\c)\c'}(x) = gnwProb (μ\c') c K x · h_{μ\c}(x)`
+   for `x ∉ {c, c'}` (modulo doubly-affected cell asymmetry).
+5. **Close** via `Finset.sum_attach` + `Finset.prod_congr` over the
+   case-decomposition.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+201 lines, line
+  count 14428 → 14629)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s03.md`
+  (this note)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (Iteration 48)
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (added
+  6 builtItems, 2 insights, updated progressSummary, currentState)
+
+### Sorry Count: 1 (unchanged — `gnwProb_exchange` remains)
+
+### Build Verification
+
+Not run in this session.  Reasons:
+- `proofs/.lake` is a self-referential symlink → fresh-clone Mathlib (~10-15
+  min) + cache get (~10 min) per Docker build, so total ≥45 min budget.
+- Helpers.lean is 14629 lines and has been at the edge of the 32GB Docker
+  memory ceiling since S35 modularization.
+- Weekly Claude usage at 87%; build verification through CI is the
+  responsible choice.
+
+The six lemmas use only well-tested existing helpers
+(`hookLength_removeCorner_arm`, `_leg`, `_eq_of_not_arm_leg`,
+`isCorner_removeCorner_of_ne`, `mem_removeCorner`,
+`rowLen_of_isCorner`, `colLen_of_isCorner`,
+`YoungDiagram.mem_iff_lt_rowLen`/`_colLen`,
+`Nat.ne_of_lt`, `corner_col_lt_of_row_lt`).  All proofs are 1-2 line
+chains closed by `omega` or `rw`+`exact`.  CI will verify.
+
+### Next Steps
+
+1. **Compile-check this PR via CI.**  If it succeeds, the case-decomposition
+   is solid and the gnwProb_exchange attack proceeds with the plan above.
+2. **Begin gnwProb_exchange proof in S49** using the six S48 lemmas to
+   match per-cell hookLength factors.  The hardest remaining step is
+   item 4 (gnwProb factor pairing); the ratio formula
+   `gnwProb (ν, c, K+1, x) = (1 / |strictHook ν x|) · ∑_{y ∈ strictHook ν x} gnwProb ν c K y`
+   should be combined with S43's `sum_gnwProb_strictHookCells_eq_removeCorner`
+   to descend the recursion in lockstep.
+3. If memory pressure becomes a problem, consider extracting the
+   ~600-line block of "double-removal" lemmas (S43-S48) into a separate
+   `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` file; they form a clean
+   sub-module independent of the rest of Helpers.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (GNW exchange-step framework + diagram commutativity; corner-distinctness coordinate lemmas added; Aristotle Target 3 closed via dispatcher)
+**Phase**: ACT (GNW exchange-step framework + diagram commutativity; corner-distinctness coordinate lemmas added; Aristotle Target 3 closed via dispatcher; double-removal hookLength shift characterization complete)
 **Path**: full
 **Since**: 2026-04-21T20:08:44+02:00
 **Last Updated**: 2026-05-08
-**Iteration**: 47
+**Iteration**: 48
 
 ## Current Focus
 Close `gnwProb_exchange` (Helpers, line 14143) — the GNW 1979 exchange identity
@@ -31,9 +31,9 @@ in place:
    (L-shape, (3,1)).
 
 ## Attempt Count
-- Total attempts: 43 (sessions 1–43; sessions 1–4 archived to
-  `sessions/`; sessions 5–43 in `knowledge.md`)
-- Current approach attempts: 7 (sessions 37–43 on GNW)
+- Total attempts: 48 (sessions 1–48; sessions 1–4 archived to
+  `sessions/`; sessions 5–48 in `knowledge.md` + `sessions/`)
+- Current approach attempts: 12 (sessions 37–48 on GNW)
 - Approaches tried:
   1. LGV-determinant via `lgv_lemma_rxr` + Jacobi–Trudi (sessions 1–10) —
      dead scaffolding deleted in session 32.
@@ -84,6 +84,20 @@ in place:
      `rw` corollary.  Together they let the upcoming `gnwProb_exchange`
      proof rewrite `H((μ\c')\c)` ↔ `H((μ\c)\c')` freely, avoiding
      iteration-order bookkeeping at every algebraic step.
+ 11. Double-removal hookLength shift characterization (session 48) — added
+     six lemmas after `hookLength_eq_of_not_arm_leg` (line ~5005) covering
+     every case of how `hookLength` shifts when both `c` and `c'` are removed:
+     `hookLength_doubleRemove_doubly_affected` (cell `(c.1, c'.2)` shifts by
+     2), the four single-shift lemmas
+     `_arm_of_c_off_d`, `_leg_of_c`, `_arm_of_c'`, `_leg_of_c'_off_d`
+     (each shifts by 1 with explicit "no shift from the other corner"
+     side-conditions), and `_other` (cells outside both arm/leg sets are
+     unchanged).  The block is iteration-order `(μ\c)\c'` (convert with
+     `removeCorner_swap` if needed) and uses only existing primitives:
+     `hookLength_removeCorner_arm/_leg/_eq_of_not_arm_leg`,
+     `corner_col_lt_of_row_lt`, `isCorner_removeCorner_of_ne`,
+     `mem_removeCorner`.  All proofs close with 1–2 lines of
+     `omega` / `rw`+`exact`.
 
 ## Blockers
 - **`gnwProb_exchange` proof.** This is the GNW 1979 hook-weight shift argument.
@@ -127,11 +141,18 @@ exchange step entirely (count weighted walks of every length, divide by
 - `knowledge.md` §Session 45 — corner-distinctness coordinate lemmas
 - `sessions/2026-05-08-s01.md` — Session 46: Aristotle Target 3 closed via dispatcher
 - `sessions/2026-05-08-s02.md` — Session 47: `removeCorner_swap` + `hookProd_removeCorner_swap`
+- `sessions/2026-05-08-s03.md` — Session 48: double-removal hookLength shift lemmas
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14173` — `gnwProb_exchange`
-  (sorry'd, target of next session — line shifted by +30 from session 47 additions)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14198` — `gnwProb_key`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5057` — `hookLength_doubleRemove_arm_of_c_off_d` (S48)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5092` — `hookLength_doubleRemove_leg_of_c` (S48)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5122` — `hookLength_doubleRemove_arm_of_c'` (S48)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5156` — `hookLength_doubleRemove_leg_of_c'_off_d` (S48)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5186` — `hookLength_doubleRemove_other` (S48)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14374` — `gnwProb_exchange`
+  (sorry'd, target of next session — line shifted by +201 from session 48 additions)
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14399` — `gnwProb_key`
   (proved modulo `gnwProb_exchange`)
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14407` — `hook_walk_identity_gnw`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:14608` — `hook_walk_identity_gnw`
   (sorry-free dispatcher, transitive on `gnwProb_exchange`)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -33,21 +33,20 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-21T13:45:00Z",
-    "iteration": 5,
-    "focus": "Post-modularization (Session 35): file split into Main (398 lines, 0 sorries, 16 theorems, 1 def) + Helpers (14050 lines, 1 sorry on gnwProb_key, 476 theorems, 38 defs). Sole remaining sorry is gnwProb_key (GNW 1979 KEY theorem) in Helpers. Aristotle companion has 3 sorries reserved for proof-search candidates.",
+    "iteration": 48,
+    "focus": "Sole remaining sorry is `gnwProb_exchange` (Helpers, line 14374; GNW 1979 hook-weight shift identity in product form). Session 48 added six double-removal hookLength characterization lemmas (Helpers, lines 5035–5186) covering all seven cell-type cases under double corner removal; combined with S43-S47 infrastructure this is sufficient for the per-cell algebra of the exchange identity. Next sessions should chain the per-cell shifts through the gnwProb walk recursion to close gnwProb_exchange.",
     "blockers": [
-      "gnwProb_key: GNW 1979 KEY theorem (~200-300 lines via exchange argument); the sole non-Aristotle sorry blocking full HLF",
-      "LGV well-formedness obstruction: requires transpose-duality case split for tall shapes (alternative path)"
+      "gnwProb_exchange: GNW 1979 hook-weight shift identity in product form (~100 lines of careful arm/leg case analysis); the sole remaining sorry. Per-cell hookLength shifts are now fully characterized (S48); remaining work is the gnwProb walk-probability factor pairing."
     ],
-    "nextAction": "Prove gnwProb_key — formalize GNW 1979 exchange argument (rectangle case follows from gnwProb_sum_corners + hook_walk_identity_rectYD; non-rectangle case needs induction on |μ|). RSK/Fomin (~600 lines) is an alternative independent path.",
+    "nextAction": "Prove gnwProb_exchange using S48's six double-removal hookLength lemmas to match per-cell hook factors, plus gnwProb_step / gnwProb_stable / sum_gnwProb_strictHookCells_eq_removeCorner to descend the walk recursion in lockstep on (μ, c) and (μ\\c', c). Decompose μ.cells via the dichotomy from S45 (corners c, c' with c.1 < c'.1); apply the seven-case partition.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 48,
+      "currentApproach": 12,
+      "approachesTried": 11
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS session 43: GNW exchange-step framework complete. gnwProb_key multi-corner case now PROVED via well-founded recursion on μ.card (termination_by μ.card; decreasing_by removeCorner_card). Sole remaining sorry: gnwProb_exchange (GNW 1979 hook-weight shift identity in product form, ~100 lines). hook_walk_identity_gnw → gnwProb_key → gnwProb_exchange chain is structurally complete.",
+    "progressSummary": "PROGRESS session 48: Double-removal hookLength shift characterization complete. Six lemmas (BallotProblemOQ03OQ01OQ02Helpers.lean:5035-5186) cover the seven cell-type cases under double corner removal: (1) doubly-affected cell shifts by 2; (2-5) arm/leg of c, arm/leg of c' (each excluding the doubly-affected cell where applicable) shift by 1; (6) cells outside both arm/leg sets unchanged. Sole remaining sorry: gnwProb_exchange (~100 lines, walk-probability factor pairing remains).",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -143,7 +142,13 @@
       "hook_walk_identity_gnw proved in BallotProblemOQ03OQ01OQ02Helpers.lean:13877-13896 (uses gnwProb_key which is sorry)",
       "strictHookCells_card proved: cardinality = hookLength - 1, using Finset.Ico image + disjointness argument (PR #15288)",
       "Cherry-picked exchange framework (isCorner_removeCorner_of_ne, gnwProb_exchange, multi-corner proof skeleton) from origin/fix/ballot-gnw-key onto research/ballot-gnw-strong-induction.",
-      "Closed IH sorry in gnwProb_key by replacing 'have h_IH := by sorry' with 'have h_IH := gnwProb_key (removeCorner μ c' hc') hc_in_rc'' + termination_by μ.card / decreasing_by clause."
+      "Closed IH sorry in gnwProb_key by replacing 'have h_IH := by sorry' with 'have h_IH := gnwProb_key (removeCorner μ c' hc') hc_in_rc'' + termination_by μ.card / decreasing_by clause.",
+      "hookLength_doubleRemove_doubly_affected proved in BallotProblemOQ03OQ01OQ02Helpers.lean:5035 — at the doubly-affected cell (c.1, c'.2), hookLength shifts by 2 under double corner removal (S48)",
+      "hookLength_doubleRemove_arm_of_c_off_d proved in BallotProblemOQ03OQ01OQ02Helpers.lean:5057 — for arm-of-c cells off the doubly-affected cell, hookLength shifts by 1 (S48)",
+      "hookLength_doubleRemove_leg_of_c proved in BallotProblemOQ03OQ01OQ02Helpers.lean:5092 — for leg-of-c cells, hookLength shifts by 1 (S48)",
+      "hookLength_doubleRemove_arm_of_c' proved in BallotProblemOQ03OQ01OQ02Helpers.lean:5122 — for arm-of-c' cells, hookLength shifts by 1 (S48)",
+      "hookLength_doubleRemove_leg_of_c'_off_d proved in BallotProblemOQ03OQ01OQ02Helpers.lean:5156 — for leg-of-c' cells off the doubly-affected cell, hookLength shifts by 1 (S48)",
+      "hookLength_doubleRemove_other proved in BallotProblemOQ03OQ01OQ02Helpers.lean:5186 — for cells outside arm/leg of either corner, hookLength is unchanged under double removal (S48)"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -236,7 +241,9 @@
       "Exchange identity attempt disproved: gnwProb_mu(c,K,x) != gnwProb_{mu\\c'}(c,K,x) in general -- counterexample on {(0,0),(0,1),(1,0)} with c=(1,0),c'=(0,1): mu gives 1/2, mu\\c' gives 1",
       "gnwProb_key multi-corner case reduces to gnwProb_exchange + IH on μ\\c'; well-founded recursion via termination_by μ.card matches the hook_length_formula_Q pattern in the main file.",
       "gnwProb_exchange product form F(μ,c)·H(μ\\c)·H(μ\\c') = F(μ\\c',c)·H((μ\\c')\\c)·H(μ) avoids division and probability theory imports; provable by arm/leg decomposition + hook-length shift.",
-      "Cherry-picking origin/fix/ballot-gnw-key (commit 6590609fa80) gives the structural framework; the IH sorry then closes via direct recursive call once termination_by μ.card is added."
+      "Cherry-picking origin/fix/ballot-gnw-key (commit 6590609fa80) gives the structural framework; the IH sorry then closes via direct recursive call once termination_by μ.card is added.",
+      "The doubly-affected cell (c.1, c'.2) (when c.1 < c'.1, hence c'.2 < c.2 by corner anti-monotonicity) is the unique cell where hookLength shifts by 2 under double removal: it is in arm of c AND leg of c'. All six other cell-types shift by at most 1, and most are unchanged.",
+      "GNW exchange identity asymmetry localizes entirely at the doubly-affected cell d: hookProd μ · hookProd ((μ\\c)\\c') / [hookProd (μ\\c) · hookProd (μ\\c')] = h_d (h_d - 2) / (h_d - 1)². Every other cell contributes ratio 1 (cancellation between the two single-removal shifts)."
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
@@ -244,9 +251,10 @@
       "BallotProblemOQ03.lean regression (omega failure near minSharedStepIdx_preserved) blocks all builds"
     ],
     "nextSteps": [
-      "Prove gnwProb_exchange (Helpers line 13871): GNW 1979 hook-weight shift identity. ~100 lines via arm/leg decomposition + hookProd product-form analysis.",
-      "Verify Docker build on the modular file structure (Helpers at 14126 lines, was 14022 pre-modularization at OOM threshold). CI on the session-43 PR will confirm buildability.",
-      "Consider deterministic weighted-walk recasting (~400 lines self-contained) as alternative to gnwProb_exchange if direct proof is intractable."
+      "Prove gnwProb_exchange using S48 hookLength shift lemmas to match per-cell hook factors",
+      "Pair gnwProb factors via gnwProb_step / gnwProb_stable / sum_gnwProb_strictHookCells_eq_removeCorner",
+      "Decompose μ.cells into seven cases using distinct_corners_dichotomy (S45)",
+      "Close via Finset.sum_attach + Finset.prod_congr over the case-decomposition"
     ]
   },
   "tags": [
@@ -287,7 +295,7 @@
     ]
   },
   "started": "2026-04-21T12:53:48.109Z",
-  "lastUpdate": "2026-05-07T17:05:00.000Z",
+  "lastUpdate": "2026-05-08T06:30:00.000Z",
   "significance": 8,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Session 48 for `ballot-problem-oq-03-oq-01-oq-02` (Hook Length Formula via GNW 1979). Adds six structural lemmas to `BallotProblemOQ03OQ01OQ02Helpers.lean` that completely characterize how `hookLength` behaves under removal of two distinct corners — the core combinatorial input to `gnwProb_exchange` (the sole remaining sorry).

## Mathematical content

For two distinct corners c, c' of μ with c.1 < c'.1 (whence c'.2 < c.2 by `corner_col_lt_of_row_lt`, S44), every cell x ∈ μ \ {c, c'} falls into one of seven cases under the double removal `(μ\c)\c'`:

| Case | Cells | Shift |
|------|-------|-------|
| Doubly-affected | `(c.1, c'.2)` | **2** |
| Arm of c off d | `(c.1, s)`, `s < c.2`, `s ≠ c'.2` | 1 |
| Leg of c | `(r, c.2)`, `r < c.1` | 1 |
| Arm of c' | `(c'.1, s)`, `s < c'.2` | 1 |
| Leg of c' off d | `(r, c'.2)`, `r < c'.1`, `r ≠ c.1` | 1 |
| Other | not in arm/leg of either | 0 |

The six new lemmas (one per row above):

* `hookLength_doubleRemove_doubly_affected` (Helpers:5035)
* `hookLength_doubleRemove_arm_of_c_off_d` (Helpers:5057)
* `hookLength_doubleRemove_leg_of_c` (Helpers:5092)
* `hookLength_doubleRemove_arm_of_c'` (Helpers:5122)
* `hookLength_doubleRemove_leg_of_c'_off_d` (Helpers:5156)
* `hookLength_doubleRemove_other` (Helpers:5186)

All proofs are 1-2 line chains of existing single-removal helpers (`hookLength_removeCorner_arm`, `_leg`, `_eq_of_not_arm_leg`) plus `isCorner_removeCorner_of_ne`, closed by `omega` or `rw`+`exact`.  Iteration order is `(μ\c)\c'`; convert to the order used by `gnwProb_exchange` via `removeCorner_swap` (S47).

## Why this matters

The GNW 1979 exchange identity — the sole remaining sorry — depends entirely on per-cell hookLength comparisons across four diagrams: μ, μ\c, μ\c', and (μ\c)\c'.  Until this PR, only the single-removal helpers existed (S43-S47).  These six lemmas are the algebraic skeleton needed to chain the gnwProb walk-probability factor pairing through the corner-removal recursion in S49+.

Specifically: hookProd μ · hookProd ((μ\c)\c') / [hookProd (μ\c) · hookProd (μ\c')] simplifies to h_d (h_d - 2) / (h_d - 1)² where d is the doubly-affected cell.  Cases 2-5 contribute trivial ratio 1; case 6 contributes 1.  Only the doubly-affected cell carries asymmetry — exactly the asymmetry that the gnwProb walk recursion is designed to balance.

## Files changed

* `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` (+201 lines: 14428 → 14629)
* `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (iteration 47 → 48; added approach 11; updated line refs)
* `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s03.md` (new session note)
* `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (currentState.iteration 5 → 48; +6 builtItems; +2 insights; updated progressSummary, nextSteps)

## Status
* **Outcome**: progress (infrastructure for gnwProb_exchange; sorry count unchanged at 1)
* **Sorry count**: 1 (Helpers:14374 `gnwProb_exchange` — unchanged)
* **Next step**: prove `gnwProb_exchange` using these six lemmas to match per-cell hook factors (~100 lines remain)

## Test plan
- [ ] CI: Lean build succeeds (`Proofs.BallotProblemOQ03OQ01OQ02Helpers`)
- [ ] CI: Gallery build succeeds (`pnpm build`)
- [ ] No new sorries introduced; gnwProb_exchange remains the sole sorry

🤖 Generated by researcher-10 (Session 48)