### PR TITLE
research(hilbert-11-oq-02): iter 3 — Hensel-elimination roadmap for p-adic solubility

### DIFF
--- a/proofs/Proofs/Hilbert11OQ02.lean
+++ b/proofs/Proofs/Hilbert11OQ02.lean
@@ -253,6 +253,70 @@ def colliot_thelene_conjecture : Prop := True
 ### Sorry count: 0
 -/
 
+/-! ## Section 8: Roadmap for Eliminating `selmer_padic_solubility`
+
+The axiom `selmer_padic_solubility` is *not* a deep theorem — it is a routine
+application of Hensel's lemma to the reduction `f̄(x,y,z) = 3x³+4y³+5z³ ∈
+F_p[x,y,z]` once a *smooth* mod-p (or, at p = 3, mod-27) zero is known.
+The work below catalogues, prime-by-prime, where the smooth zero lives and
+which Hensel statement is needed; this turns the universal axiom into a
+finite collection of prime-specific lemmas, each closeable with the standard
+Mathlib `PadicNumbers`/`PadicInt` Hensel API.
+
+### Decomposition by residue class of p mod 3
+
+**Case A — p ≡ 2 (mod 3), p ∉ {2, 5}** (e.g. p ∈ {11, 17, 23, 29, 41, …}).
+Cubing is a bijection on (ℤ/p)*, so for *any* nonzero a ∈ (ℤ/p)* the
+equation z³ = a has a unique solution. Take x = 0, y = 1: the equation
+reduces to 5z³ + 4 ≡ 0, i.e. z³ ≡ -4·5⁻¹ ∈ (ℤ/p)*, with the unique cube
+root in (ℤ/p)*. The derivative ∂_z f = 15z² is nonzero at the root
+(since z ≠ 0 mod p and p ∉ {3, 5}), so single-variable Hensel along z
+lifts to a unique 3-adic z̃ ∈ ℤ_p with selmerPoly 0 1 z̃ = 0 in ℚ_p.
+**Witness data.** p = 11: take z₀ = 2 (since 2³ = 8 ≡ -4·5⁻¹ ≡ -4·9 ≡ 8
+mod 11, and ∂_z f(0,1,2) = 60 ≡ 5 ≢ 0 mod 11). p = 17: z₀ = 5.
+p = 23: z₀ = 18. p = 29: z₀ = 22.
+
+**Case B — p ≡ 1 (mod 3), p ≥ 7** (e.g. p ∈ {7, 13, 19, 31, 37, 43, …}).
+Only one third of (ℤ/p)* are cubes, so the (0, 1, z) projection often
+fails (it fails at p = 7, 13, 19, 31 but works at p = 37). Smooth
+mod-p zeros nevertheless exist by Hasse-Weil applied to the smooth genus-1
+curve {3x³+4y³+5z³ = 0} ⊂ ℙ²_{F_p}: the count of F_p-points lies in the
+interval [p+1-2√p, p+1+2√p], which is ≥ 5 for every p ≥ 5. After fixing
+two affine coordinates one obtains a polynomial in the third with
+nonsingular reduction, and standard univariate Hensel lifts.
+**Witness data.** p = 7: smooth zero (1, 1, 0), Jacobian (9, 12, 0) ≡
+(2, 5, 0) mod 7 (∂_x and ∂_y both invertible). p = 13: (1, 4, 2). p = 19:
+(1, 0, 4). p = 31: (1, 3, 17). p = 37: (0, 1, 5).
+
+### Special primes p ∈ {2, 3, 5}
+
+**p = 2.** The polynomial reduces to x³ + z³ mod 2, with smooth zero
+(1, 0, 1) (Jacobian (1, 0, 1) mod 2 has rank ≥ 1). Hensel along z lifts
+to a unique 2-adic z̃ ∈ ℤ_2 with selmerPoly 1 0 z̃ = 0 in ℚ_2.
+
+**p = 5.** The polynomial reduces to 3x³ + 4y³ mod 5 (the leading 5 in
+the z-coefficient vanishes). Smooth zero (1, 2, 0) since 3 + 4·8 = 35
+≡ 0 mod 5 and Jacobian (4, 3, 0) mod 5 is invertible in the (x,y)-plane.
+Hensel lifts.
+
+**p = 3.** *Singular reduction.* All of 9, 12, 15 are divisible by 3, so
+every mod-3 zero of `selmerPoly` has Jacobian ≡ 0 mod 3 — naive single-
+variable Hensel does not lift. We must climb to mod 27 = 3³ before the
+strong-form Hensel hypothesis `|f(α)|_p < |f'(α)|_p²` is met. The
+witness (0, 1, 4) mod 27 satisfies `selmerPoly 0 1 4 = 4 + 5·64 = 324 =
+12·27 ≡ 0 (mod 27)` with `∂_z f(0,1,4) = 15·16 = 240`, valuation
+v₃(240) = 1. Since v₃(f) ≥ 3 > 2 · v₃(∂_z f) = 2, strong-form Hensel
+applies and lifts to a unique 3-adic z̃ with v₃(z̃ - 4) ≥ 3.
+
+### Status of this roadmap
+
+This section is **documentation only** — no Lean code, no axiom changes,
+no proof obligations. The next session can split `selmer_padic_solubility`
+into the per-prime lemmas above and discharge each via the recipe given.
+The `colliot_thelene_conjecture` placeholder (currently `Prop := True`)
+is *not* in scope here; that requires Brauer-Manin / scheme-theoretic
+infrastructure not present in Mathlib. -/
+
 #check @selmerCubic_real_solution
 #check @selmer_rat_implies_real
 #check @selmer_rat_implies_padic

--- a/src/data/proofs/hilbert-11-oq-02/meta.json
+++ b/src/data/proofs/hilbert-11-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 264,
+    "lineCount": 328,
     "theoremCount": 5,
     "definitionCount": 3,
     "assumptions": "2 axioms: (1) selmer_no_rational_solution — Selmer's 1951 theorem that 3x³ + 4y³ + 5z³ = 0 has no nontrivial rational solutions; the full proof uses 3-descent on the associated elliptic curve y² = x³ - 432·15² and computation of the 3-Selmer group, neither of which is available in Mathlib v4.26.0. (2) selmer_padic_solubility — for every prime p, the Selmer cubic is solvable over ℚₚ; provable via Hensel's lemma on the smooth reduction mod p for p ∉ {2,3,5} and direct construction at the small primes, but requires Hensel infrastructure for ℚₚ. The real solubility (existence of a nontrivial real root) and the easy directions ℚ → ℝ and ℚ → ℚₚ are proved unconditionally from Mathlib's intermediate_value_Icc and the standard ring embeddings.",
@@ -140,13 +140,21 @@
       "id": "summary",
       "title": "Section 7: Status Summary and #check",
       "startLine": 234,
-      "endLine": 264,
+      "endLine": 254,
       "summary": "Status table listing each component as PROVED or AXIOMATIZED, axiom count = 2, sorry count = 0, and #check statements for the seven main declarations.",
       "mathContext": "Final tally: 5 theorems, 3 definitions, 2 axioms, 0 sorries. The two axioms (`selmer_no_rational_solution`, `selmer_padic_solubility`) are documented with mathematical justification."
+    },
+    {
+      "id": "padic-roadmap",
+      "title": "Section 8: Roadmap for Eliminating selmer_padic_solubility",
+      "startLine": 256,
+      "endLine": 328,
+      "summary": "Documentation-only section catalogues the explicit Hensel-lift recipe for `selmer_padic_solubility` prime by prime. Case A (p ≡ 2 mod 3, p ∉ {2,5}): cubing is bijective on (ℤ/p)*, so the (0,1,z) projection lifts; explicit z₀ given for p = 11, 17, 23, 29. Case B (p ≡ 1 mod 3, p ≥ 7): only 1/3 of nonzero residues are cubes; smooth zeros nevertheless exist by Hasse-Weil; explicit smooth (x,y,z) given for p = 7, 13, 19, 31, 37. Special primes p ∈ {2, 5}: smooth direct constructions. Special prime p = 3: singular reduction (every Jacobian coefficient ≡ 0 mod 3); strong-form Hensel applies after climbing to mod 27, witness (0, 1, 4) mod 27 with v₃(f) = 3 > 2·v₃(∂_z f) = 2.",
+      "mathContext": "**Cube-residue analysis.** The structure of (ℤ/p)* under cubing splits primes into two regimes: p ≡ 2 (mod 3) ⇒ cubing is a bijection (every element is a cube); p ≡ 1 (mod 3) ⇒ exactly one third of (ℤ/p)* are cubes. **Hensel hypothesis.** For p ∉ {3}, standard Hensel `|f(α)|_p < |f'(α)|_p` lifts a smooth mod-p zero to a unique p-adic zero. **Singular reduction at p = 3.** Since 3 divides every coefficient of the Jacobian (9, 12, 15) of the Selmer cubic, no smooth mod-3 zero exists; one must use the strong-form Hensel `|f(α)|_p < |f'(α)|_p²` after climbing to mod 27. **Hasse-Weil bound.** A smooth genus-1 cubic curve over F_p has at least p + 1 - 2√p ≥ 5 (for p ≥ 5) F_p-points, guaranteeing the existence of a smooth mod-p zero for every p ≥ 5; for the Selmer cubic specifically the discriminant is supported on {2, 3, 5} so smooth reduction holds for p ≥ 7."
     }
   ],
   "conclusion": {
-    "summary": "The Selmer cubic 3x³ + 4y³ + 5z³ = 0 — the canonical 1951 counterexample to the Hasse principle for higher-degree forms — is formalized as a 264-line Lean 4 file with 5 theorems, 3 definitions, 2 axioms, 0 sorries. Real solubility is proved constructively via IVT; the easy directions of the Hasse principle (rational ⇒ local) are proved by formal ring-embedding arguments; Selmer's no-rational-solutions theorem and full p-adic solubility are axiomatized; and the Hasse-principle FAILURE for the Selmer cubic is then proved in 4 lines from the two axioms. The result is a clean encoding of the canonical counterexample with all the elementary content proved and all the deep arithmetic content explicitly axiomatized.",
+    "summary": "The Selmer cubic 3x³ + 4y³ + 5z³ = 0 — the canonical 1951 counterexample to the Hasse principle for higher-degree forms — is formalized as a 328-line Lean 4 file with 5 theorems, 3 definitions, 2 axioms, 0 sorries. Real solubility is proved constructively via IVT; the easy directions of the Hasse principle (rational ⇒ local) are proved by formal ring-embedding arguments; Selmer's no-rational-solutions theorem and full p-adic solubility are axiomatized; and the Hasse-principle FAILURE for the Selmer cubic is then proved in 4 lines from the two axioms. The result is a clean encoding of the canonical counterexample with all the elementary content proved and all the deep arithmetic content explicitly axiomatized.",
     "implications": "**Theoretical significance**: Selmer's cubic was the first explicit demonstration that the Hasse principle does not extend from quadratic to cubic forms. It launched the entire modern field of obstruction theory in arithmetic geometry — Manin's Brauer-Manin obstruction (1971), Skorobogatov's étale-Brauer-Manin (1999), Poonen's intermediate failures (2010). Whether the étale-Brauer-Manin obstruction is the only obstruction for rationally connected varieties is a central open question linking number theory to algebraic geometry.\n\n**Formalization significance**: This is one of the first Mathlib-aligned formalizations of a Hasse-principle failure. The two axioms cleanly localize the deep arithmetic content (3-descent, Hensel) without bleeding into the surrounding gallery framework. The genericity of `selmerPoly` over CommRing (rather than ℚ-specific) makes the easy-direction theorems reusable across the three local rings.\n\n**Path to fewer axioms**: `selmer_padic_solubility` is the more accessible axiom — it follows from Mathlib's existing Hensel infrastructure plus a smooth-reduction argument for primes p ∉ {2, 3, 5} and direct construction at p ∈ {2, 3, 5}. Eliminating this axiom would leave only Selmer 1951 itself as an assumption, an honest reflection of the mathematical depth.\n\n**Connection to other gallery entries**: hilbert-11 (parent, Hasse-Minkowski for quadratics — the result that Selmer demonstrates does NOT generalize); hilbert-11-oq-01 (sibling, refined Hasse-Minkowski); e-transcendental-oq-02 (similar pattern: deep open problem with axiomatized headline + proved framework).",
     "openQuestions": [
       "Eliminate the `selmer_padic_solubility` axiom by formalizing Hensel's lemma application to smooth cubic reductions. For p ∉ {2, 3, 5} this is direct; the small primes need explicit low-precision lifts.",
@@ -187,7 +195,7 @@
       "Set"
     ],
     "namespace": "Hilbert11OQ02",
-    "lineCount": 264,
+    "lineCount": 328,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 3,

--- a/src/data/research/problems/hilbert-11-oq-02.json
+++ b/src/data/research/problems/hilbert-11-oq-02.json
@@ -41,19 +41,19 @@
   },
   "currentState": {
     "phase": "ITERATING",
-    "since": "2026-05-08T05:50:00Z",
-    "iteration": 2,
-    "focus": "Iteration 2 (gallery promotion): created src/data/proofs/hilbert-11-oq-02/ with full meta.json (8 sections, overview, conclusion, 7 references, 3 cross-references), empty annotations.json, and standard async-loaded index.ts. Validated via `pnpm annotations:build` (listings regenerate cleanly with our entry; no new annotation errors). Lean file unchanged (264 lines, 5 theorems, 3 defs, 2 axioms, 0 sorries). Closes the gallery-presence gap left after #16808 merged the Lean side.",
+    "since": "2026-05-08T08:30:00Z",
+    "iteration": 3,
+    "focus": "Iteration 3 (Hensel-elimination roadmap): added Section 8 to `Proofs/Hilbert11OQ02.lean` (264 → 328 lines, no new declarations) cataloguing the explicit Hensel-lift recipe for `selmer_padic_solubility` prime by prime. Splits primes by residue class mod 3 (Case A: p ≡ 2 mod 3 — cubing bijective, (0,1,z) projection works; Case B: p ≡ 1 mod 3, p ≥ 7 — Hasse-Weil guarantees smooth zeros, alternative projections work) and treats p ∈ {2, 3, 5} separately (p = 3 has singular reduction requiring strong-form Hensel mod 27). Concrete witnesses given for p ∈ {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}. meta.json line counts and sections updated.",
     "blockers": [],
-    "nextAction": "Future iteration: prove p-adic solubility of the Selmer cubic at primes p ∉ {2,3,5} via Hensel's lemma applied to the reduction mod p (currently axiomatized as `selmer_padic_solubility`). At p ∈ {2,3,5} requires direct construction at low precision. Replacing this axiom is the most accessible next step toward reducing the axiom count.",
+    "nextAction": "Iteration 4: split `selmer_padic_solubility` into per-case lemmas `selmer_padic_solubility_eq2_mod3 (p ≡ 2 mod 3)`, `selmer_padic_solubility_eq1_mod3 (p ≡ 1 mod 3, p ≥ 7)`, and three concrete cases for p ∈ {2, 3, 5}. Discharge Case A first since the cube-residue argument is purely formal and Mathlib's Hensel infrastructure for ℚ_p suffices. The witnesses in Section 8 (p = 11 → z₀ = 2; p = 17 → z₀ = 5; etc.) provide explicit lift starting points.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "ITERATING (iter 2). Iter 1: created `proofs/Proofs/Hilbert11OQ02.lean` (264 lines, 5 theorems, 3 defs, 2 axioms, 0 sorries) merged via PR #16808. Iter 2 (this session): promoted to gallery — created `src/data/proofs/hilbert-11-oq-02/` with full meta.json (8 sections, overview, conclusion, 7 references, 3 cross-references), empty annotations.json, and index.ts. The entry registers in listings.json with status=axiomatized, badge=axiom; validated via `pnpm annotations:build`.",
+    "progressSummary": "ITERATING (iter 3). Iter 1: created `proofs/Proofs/Hilbert11OQ02.lean` (264 lines, 5 theorems, 3 defs, 2 axioms, 0 sorries) merged via PR #16808. Iter 2: promoted to gallery — created `src/data/proofs/hilbert-11-oq-02/` with full meta.json (now 9 sections), annotations.json, index.ts. Iter 3 (this session): added Section 8 (Hensel-elimination roadmap) to the Lean file (264 → 328 lines, no new declarations) with prime-by-prime cube-residue analysis and explicit smooth-zero witnesses for p ∈ {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}. meta.json line counts and section table updated. No axiom count change (still 2); no sorry count change (still 0). Pure documentation iteration that turns the universal `selmer_padic_solubility` axiom into a finite checklist of per-prime lemmas, each with a concrete starting point for the next iteration's Hensel-lift work.",
     "builtItems": [
       "selmerPoly definition in Hilbert11OQ02.lean (3x³+4y³+5z³ over CommRing)",
       "selmerCubic_real_solution in Hilbert11OQ02.lean — nontrivial real solution constructed via IVT on g(x)=3x³+4 over [-2,0]",
@@ -62,9 +62,11 @@
       "selmer_locally_soluble_everywhere in Hilbert11OQ02.lean — combines proved real solubility with axiomatized p-adic solubility",
       "selmer_hasse_principle_fails in Hilbert11OQ02.lean — derives Hasse failure from selmer_no_rational_solution + local everywhere",
       "selmerHassePrinciple definition in Hilbert11OQ02.lean — local-global predicate for the Selmer cubic",
-      "src/data/proofs/hilbert-11-oq-02/meta.json — 287 lines: status=axiomatized, badge=axiom, 8 sections, full overview/conclusion, 7 references (Selmer 1951; Hasse 1923; Manin 1971; Skorobogatov 1999; Poonen 2010; Colliot-Thélène-Sansuc 1980), 3 cross-references (hilbert-11 parent, hilbert-11-oq-01 sibling, e-transcendental-oq-02 same-pattern)",
+      "src/data/proofs/hilbert-11-oq-02/meta.json — 9 sections: status=axiomatized, badge=axiom, full overview/conclusion, 7 references (Selmer 1951; Hasse 1923; Manin 1971; Skorobogatov 1999; Poonen 2010; Colliot-Thélène-Sansuc 1980), 3 cross-references (hilbert-11 parent, hilbert-11-oq-01 sibling, e-transcendental-oq-02 same-pattern)",
       "src/data/proofs/hilbert-11-oq-02/index.ts — standard async-loaded source template",
-      "src/data/proofs/hilbert-11-oq-02/annotations.json — empty []; annotation enrichment deferred to follow-up enricher session"
+      "src/data/proofs/hilbert-11-oq-02/annotations.json — empty []; annotation enrichment deferred to follow-up enricher session",
+      "Section 8 of Hilbert11OQ02.lean (lines 256–318): documentation-only Hensel-elimination roadmap. Splits the universal `selmer_padic_solubility` axiom into Case A (p ≡ 2 mod 3, p ∉ {2,5}; cube-residue argument plus Hensel along z), Case B (p ≡ 1 mod 3, p ≥ 7; Hasse-Weil + alternative projection), and special primes p ∈ {2, 3, 5}. Concrete smooth-zero witnesses tabulated for 12 primes.",
+      "meta.json updates: lineCount 264 → 328 (in both meta and leanFile blocks); Section 7 endLine 264 → 254; new section entry `padic-roadmap` (Section 8: Roadmap for Eliminating selmer_padic_solubility, lines 256–328) with summary and full mathContext."
     ],
     "insights": [
       "Hilbert11_QuadraticForms.lean already AXIOMATIZES the Selmer counterexample (`selmer_curve_no_rational_points`) — OQ-02 should LIFT this axiom into a dedicated entry and frame it as the canonical example of Hasse failure rather than burying it in the quadratic-forms parent",
@@ -75,7 +77,11 @@
       "The Selmer cubic 3x³+4y³+5z³=0 in ℙ² has genus 1 and is in fact a principal homogeneous space for an elliptic curve E: y² = x³ - 432 (a twist of E_60); this connects to the Tate-Shafarevich group Ш(E/ℚ)",
       "Real solubility of 3x³+4y³+5z³=0 has a one-line constructive proof: fix y=1, z=0, then need x with 3x³+4=0, supplied by IVT on g(x)=3x³+4 over [-2,0] since g(-2)=-20, g(0)=4. This makes the 'real local soluble' direction provable in Lean with no number-theory machinery beyond `intermediate_value_Icc`.",
       "The easy direction of the Hasse principle (rational ⇒ local) is purely formal in Lean: `Rat.cast : ℚ → ℝ` and `Rat.cast : ℚ → ℚ_[p]` are ring homomorphisms, so `push_cast; ring` closes the polynomial-equation-preservation goal. This is the same pattern used for any ℚ-rational point of any ℚ-variety — generalizable to a future `RatPoint_to_LocalPoint` framework.",
-      "Selmer's deep theorem `selmer_no_rational_solution` is irreducibly axiomatized: 3-descent on the associated elliptic curve E: y²=x³-432·15² is required, and Mathlib v4.26 has no Selmer-group infrastructure. p-adic solubility at p ∉ {2,3,5} could be proved via Hensel applied to the reduction; this is the most accessible axiom-elimination path."
+      "Selmer's deep theorem `selmer_no_rational_solution` is irreducibly axiomatized: 3-descent on the associated elliptic curve E: y²=x³-432·15² is required, and Mathlib v4.26 has no Selmer-group infrastructure. p-adic solubility at p ∉ {2,3,5} could be proved via Hensel applied to the reduction; this is the most accessible axiom-elimination path.",
+      "Cube-residue dichotomy mod p (iter 3): for p ≡ 2 (mod 3), cubing is a bijection on (ℤ/p)*, so the equation z³ = -4·5⁻¹ mod p always has a unique nonzero solution and the (0, 1, z) projection of the Selmer cubic admits an immediate Hensel lift. For p ≡ 1 (mod 3), only one third of (ℤ/p)* are cubes; the (0, 1, z) projection often fails (e.g. fails at p ∈ {7, 13, 19, 31}) and one must search over more of the (x, y) plane. Computationally verified: at p ∈ {7, 13, 19, 31} no z exists with 5z³ + 4 ≡ 0 mod p; at p ∈ {11, 17, 23, 29, 37} explicit z₀ values are available.",
+      "Singular reduction at p = 3 (iter 3): the Jacobian of `selmerPoly` is (9x², 12y², 15z²), and all three coefficients are divisible by 3. Hence every mod-3 zero of selmerPoly is non-smooth and naive Hensel's lemma does not lift. Strong-form Hensel (`|f(α)|_p < |f'(α)|_p²`) succeeds after climbing to mod 27: the witness (0, 1, 4) satisfies selmerPoly 0 1 4 = 4 + 5·64 = 324 = 12·27 ≡ 0 mod 27, with v₃(∂_z f(0,1,4)) = v₃(240) = 1, giving v₃(f) = 3 > 2·1 = 2·v₃(∂_z f) as required.",
+      "Hasse-Weil bound forces local solubility (iter 3): the Selmer cubic is a smooth genus-1 curve in ℙ², with discriminant supported on {2, 3, 5}. For p ≥ 7 it has smooth reduction, and Hasse-Weil guarantees at least p + 1 - 2√p ≥ 5 F_p-points. Existence of a smooth mod-p zero is therefore guaranteed at every p ≥ 7 — the Hensel-lift step is then routine. Combined with explicit constructions at p ∈ {2, 3, 5}, this fully resolves the universal `selmer_padic_solubility` axiom modulo Mathlib's Hensel API.",
+      "Concrete Hensel-lift starting points (iter 3): the primes p = 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37 each have an explicit smooth (x₀, y₀, z₀) tabulated in Section 8 of Hilbert11OQ02.lean. Each is a verified mod-p (or mod-27 for p = 3) zero of selmerPoly with at least one Jacobian coordinate a unit, ready for direct application of the appropriate Hensel statement."
     ],
     "mathlibGaps": [
       "No formal definition of Brauer-Manin obstruction in Mathlib (would require Brauer group of a scheme + adelic points)",
@@ -85,9 +91,10 @@
       "`MvPolynomial.IsHomogeneous` exists but there is no specialized theory of 'rational-points predicate' for homogeneous forms over number fields"
     ],
     "nextSteps": [
-      "Replace `selmer_padic_solubility` axiom with a Hensel-based proof for primes p ∉ {2,3,5}: reduce 3x³+4y³+5z³ mod p, find a smooth ℤ/p-point, lift via Hensel. Mathlib v4.26 has `Polynomial.IsHensel` and `PadicNumbers.Hensel` lemmas applicable.",
-      "Direct construction of p-adic solutions at p ∈ {2,3,5}: low-precision lifts (e.g. 2-adic Hensel needs reduction mod 8 to find a smooth point).",
-      "Promote to gallery: create `src/data/proofs/hilbert-11-oq-02/` with meta.json, annotations.json, index.ts cross-referencing `hilbert-11`, `hilbert-11-oq-01`, and `e-transcendental-oq-02` (similar axiomatization-of-deep-result pattern).",
+      "Iter 4 — Case A lemma: state and prove `selmer_padic_solubility_eq2_mod3 : ∀ (p : ℕ) [Fact (Nat.Prime p)], p % 3 = 2 → p ≠ 2 → p ≠ 5 → ∃ (x y z : ℚ_[p]), nontrivial ∧ selmerPoly x y z = 0`. Strategy: take (0, 1, z) where z is the Hensel lift of the unique cube root of -4·5⁻¹ mod p. Mathlib's `PadicInt.hensel_lemma` (or `Polynomial.IsHensel`) applied to the polynomial `5 X^3 + 4 ∈ ℤ_p[X]` should suffice given the smoothness witness ∂_z = 15z² ≢ 0.",
+      "Iter 5 — Case B lemma: state and prove `selmer_padic_solubility_eq1_mod3 : ∀ (p : ℕ) [Fact (Nat.Prime p)], p % 3 = 1 → p ≥ 7 → ∃ (x y z : ℚ_[p]), nontrivial ∧ selmerPoly x y z = 0`. Strategy: enumerate small smooth witnesses (p = 7 → (1, 1, 0); p = 13 → (1, 4, 2); p = 19 → (1, 0, 4); p = 31 → (1, 3, 17); p = 37 → (0, 1, 5)) and for primes p > 37 cite a Hasse-Weil-style existence argument.",
+      "Iter 6 — Special primes: prove `selmer_padic_solubility_2`, `selmer_padic_solubility_3`, `selmer_padic_solubility_5` directly using the witnesses (1, 0, 1), (0, 1, 4), (1, 2, 0) respectively. The p = 3 case requires strong-form Hensel mod 27 (witness lift uses v₃(f) = 3, v₃(f') = 1).",
+      "Iter 7 — Combine the per-case lemmas via Mathlib's case split on `p % 3` and small-prime cases to prove the original universal `selmer_padic_solubility` as a theorem; remove the axiom; update meta to axiomCount = 1.",
       "Long-term: develop generic `IsHigherDegreeForm n` / `HassePrincipleFails F` predicates over `MvPolynomial (Fin k) ℚ` filtered by `IsHomogeneous F n`; restate Selmer as the canonical instance of the generic predicate.",
       "Stretch: state the Brauer-Manin obstruction conjecture (`brauer_manin_only_obstruction_for_rationally_connected`) as an axiomatized open problem, mirroring the `e_absolutely_normal` pattern.",
       "Survey: add other classical Hasse failures (Cassels-Guy 1966 cubic surface, Iskovskih 1971 del Pezzo) as parallel `*_hasse_principle_fails` instances, axiomatizing the no-rational-solution part for each."


### PR DESCRIPTION
## Summary

Iteration 3 on **hilbert-11-oq-02** ("Selmer cubic / Hasse-principle failure"). Adds Section 8 to `Proofs/Hilbert11OQ02.lean` — a documentation-only roadmap for eliminating the universal `selmer_padic_solubility` axiom prime by prime. No axiom count change (still 2), no sorry count change (still 0), no new declarations.

## Mathematical content of the new Section 8

The axiom `selmer_padic_solubility` says the Selmer cubic 3x³+4y³+5z³=0 is solvable in ℚ_p for every prime p. The new section turns this into a finite checklist of per-prime lemmas, each with a concrete smooth-zero witness:

**Case A — p ≡ 2 (mod 3), p ∉ {2, 5}** (e.g. 11, 17, 23, 29). Cubing is a bijection on (ℤ/p)*, so z³ = -4·5⁻¹ has a unique nonzero root mod p; the (0, 1, z) projection with single-variable Hensel along z lifts. Witnesses: p = 11 → z₀ = 2; p = 17 → z₀ = 5; p = 23 → z₀ = 18; p = 29 → z₀ = 22.

**Case B — p ≡ 1 (mod 3), p ≥ 7** (e.g. 7, 13, 19, 31, 37). Only one third of (ℤ/p)* are cubes; the (0, 1, z) projection fails at p = 7, 13, 19, 31 (verified). Smooth zeros nevertheless exist by Hasse-Weil applied to the smooth genus-1 cubic; alternative projections succeed. Witnesses: p = 7 → (1, 1, 0); p = 13 → (1, 4, 2); p = 19 → (1, 0, 4); p = 31 → (1, 3, 17); p = 37 → (0, 1, 5).

**Special primes p ∈ {2, 5}.** Standard Hensel after direct construction; witnesses (1, 0, 1) and (1, 2, 0).

**Special prime p = 3.** *Singular reduction.* All three Jacobian coefficients (9, 12, 15) are divisible by 3, so every mod-3 zero is non-smooth and naive Hensel fails. Strong-form Hensel succeeds after climbing to mod 27: the witness (0, 1, 4) satisfies `selmerPoly 0 1 4 = 4 + 5·64 = 324 = 12·27 ≡ 0 mod 27` with `v₃(∂_z f(0,1,4)) = v₃(240) = 1`, so `v₃(f) = 3 > 2·v₃(∂_z f) = 2` as required.

All cube-residue calculations were independently verified in Python before being committed to documentation.

## Files modified

- `proofs/Proofs/Hilbert11OQ02.lean`: Section 8 added (lines 256–318, +64 lines). No declaration changes; comment block only.
- `src/data/proofs/hilbert-11-oq-02/meta.json`: lineCount 264 → 328 in both meta and leanFile blocks; Section 7 endLine updated; new section `padic-roadmap` (Section 8) added with summary and full mathContext; three `264-line` strings updated to `328-line`.
- `src/data/research/problems/hilbert-11-oq-02.json`: iteration 2 → 3, focus/nextAction updated, progressSummary expanded; 4 new insights (cube-residue dichotomy; singular reduction at p = 3; Hasse-Weil-driven local solubility; concrete witness table); 4 new nextSteps proposing per-iteration lemmas (Case A, Case B, special primes, recombination).

## Honesty assessment

This is a SURVEY iteration. **No axiom eliminated. No theorem proved. No sorry closed.** The value is concrete and bounded: a future session no longer needs to re-derive the cube-residue analysis, hunt for smooth witnesses, or be surprised by the singular reduction at p = 3. Expected payoff: the next iteration can directly call Mathlib's `PadicInt.hensel_lemma` and discharge Case A in one or two lemmas.

## Outcome

**Status**: progress (documentation iteration; sets up axiom-elimination work for iter 4+)
**Next steps**: Iter 4 should pick up `selmer_padic_solubility_eq2_mod3` (Case A) — the cube-residue argument is purely formal and Mathlib's Hensel infrastructure suffices.

🤖 Generated by researcher-12