### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S5 — normal-Sylow reductions

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -175,6 +175,93 @@ axiom burnside_pq_nontrivial {G : Type*} [Group G] [Finite G]
     (hcard : Nat.card G = p ^ a * q ^ b) : IsSolvable G
 
 -- ═══════════════════════════════════════════════════════════════════════
+-- PART III.5: Normal-Sylow reductions (axiom-free, Iteration 5)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-! Two reduction lemmas that discharge `burnside_pq_nontrivial` whenever
+    a normal subgroup whose order is the full `p`-part (or `q`-part) of `|G|`
+    can be exhibited. They neither modify nor weaken `burnside_pq_nontrivial`
+    itself, but provide axiom-free shortcuts that any future
+    `|G| = pᵃ · qᵇ` analysis can plug into. -/
+
+/-- **Solvability extension via normal-quotient pair** (Mathlib repackaging):
+    if `N` is a normal subgroup of `G` with both `N` and `G ⧸ N` solvable,
+    then `G` is solvable.
+
+    This is the standard fact that solvability is closed under group
+    extensions. We package it as a named theorem for repeated use below.
+    The proof reuses Mathlib's `solvable_of_ker_le_range` against the
+    canonical short exact sequence `1 → N → G → G ⧸ N → 1`: the kernel of
+    `QuotientGroup.mk' N` is exactly the range of `N.subtype`. -/
+theorem isSolvable_of_normal_quotient_solvable {G : Type*} [Group G]
+    (N : Subgroup G) [N.Normal] [IsSolvable N] [IsSolvable (G ⧸ N)] :
+    IsSolvable G := by
+  apply solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
+  intro x hx
+  rw [MonoidHom.mem_ker, QuotientGroup.mk'_apply, QuotientGroup.eq_one_iff] at hx
+  exact ⟨⟨x, hx⟩, rfl⟩
+
+/-- **Burnside reduction via a normal `p`-Sylow-sized subgroup** (axiom-free):
+    if `|G| = pᵃ · qᵇ` and `G` admits a normal subgroup `N` with
+    `|N| = pᵃ`, then `G` is solvable.
+
+    Proof outline:
+    - `IsPGroup p N` follows from `IsPGroup.iff_card` and `|N| = pᵃ`,
+      so `pGroup_isSolvable` gives `IsSolvable N`.
+    - Lagrange (`Subgroup.card_mul_index`) plus `|G| = pᵃ · qᵇ` and
+      `pᵃ > 0` yield `Nat.card (G ⧸ N) = qᵇ`.
+    - Then `IsPGroup q (G ⧸ N)` and `pGroup_isSolvable` give
+      `IsSolvable (G ⧸ N)`.
+    - `isSolvable_of_normal_quotient_solvable` closes `G`.
+
+    Strategic value: combined with future Sylow-counting analysis on
+    specific `|G| = pᵃ · qᵇ` shapes (`|G| = p² · q`, `|G| = p · q²`, …),
+    this lemma turns "produce a normal Sylow `p`-subgroup" into a complete
+    axiom-free solvability proof. -/
+theorem burnside_pq_with_normal_pSylow {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [hp : Fact p.Prime] [Fact q.Prime] {a b : ℕ}
+    (hcard : Nat.card G = p ^ a * q ^ b)
+    (N : Subgroup G) [N.Normal] (hN_card : Nat.card N = p ^ a) :
+    IsSolvable G := by
+  have hN_pg : IsPGroup p N := IsPGroup.iff_card.mpr ⟨a, hN_card⟩
+  haveI : IsSolvable N := pGroup_isSolvable N hN_pg
+  have hpa_pos : 0 < p ^ a := pow_pos hp.out.pos a
+  have hQ_card : Nat.card (G ⧸ N) = q ^ b := by
+    have h := Subgroup.card_mul_index N
+    rw [hN_card, hcard] at h
+    have hidx : N.index = q ^ b := Nat.eq_of_mul_eq_mul_left hpa_pos h
+    rw [N.index_eq_card] at hidx
+    exact hidx
+  have hQ_pg : IsPGroup q (G ⧸ N) := IsPGroup.iff_card.mpr ⟨b, hQ_card⟩
+  haveI : IsSolvable (G ⧸ N) := pGroup_isSolvable (G ⧸ N) hQ_pg
+  exact isSolvable_of_normal_quotient_solvable N
+
+/-- **Burnside reduction via a normal `q`-Sylow-sized subgroup** (axiom-free,
+    symmetric to `burnside_pq_with_normal_pSylow`): if `|G| = pᵃ · qᵇ` and
+    `G` admits a normal subgroup `N` with `|N| = qᵇ`, then `G` is solvable.
+
+    Proof: dual to the `p`-Sylow case — `N` is a `q`-group (hence solvable),
+    `|G ⧸ N| = pᵃ` (Lagrange + cancellation, after a `mul_comm` rearrangement),
+    so `G ⧸ N` is a `p`-group (hence solvable), and the extension is solvable. -/
+theorem burnside_pq_with_normal_qSylow {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [Fact p.Prime] [hq : Fact q.Prime] {a b : ℕ}
+    (hcard : Nat.card G = p ^ a * q ^ b)
+    (N : Subgroup G) [N.Normal] (hN_card : Nat.card N = q ^ b) :
+    IsSolvable G := by
+  have hN_pg : IsPGroup q N := IsPGroup.iff_card.mpr ⟨b, hN_card⟩
+  haveI : IsSolvable N := pGroup_isSolvable N hN_pg
+  have hqb_pos : 0 < q ^ b := pow_pos hq.out.pos b
+  have hQ_card : Nat.card (G ⧸ N) = p ^ a := by
+    have h := Subgroup.card_mul_index N
+    rw [hN_card, hcard, mul_comm (p ^ a) (q ^ b)] at h
+    have hidx : N.index = p ^ a := Nat.eq_of_mul_eq_mul_left hqb_pos h
+    rw [N.index_eq_card] at hidx
+    exact hidx
+  have hQ_pg : IsPGroup p (G ⧸ N) := IsPGroup.iff_card.mpr ⟨a, hQ_card⟩
+  haveI : IsSolvable (G ⧸ N) := pGroup_isSolvable (G ⧸ N) hQ_pg
+  exact isSolvable_of_normal_quotient_solvable N
+
+-- ═══════════════════════════════════════════════════════════════════════
 -- PART IV: Main theorem
 -- ═══════════════════════════════════════════════════════════════════════
 
@@ -265,6 +352,21 @@ example {G : Type*} [Group G] [Finite G] (hcard : Nat.card G = 30) :
   show Squarefree (30 : ℕ)
   native_decide
 
+/-- **Group of order `12 = 2² · 3` with a normal subgroup of order `4` is
+    solvable**, axiom-free, via `burnside_pq_with_normal_pSylow`. This is
+    exactly the structure realized by `A₄` (the Klein four-group `V₄ ⊆ A₄`
+    is normal of order `4 = 2²`); it shows the new Iteration-5 reduction
+    discharges the previously-axiomatized `2 ≤ a` shape `|G| = p² · q`
+    whenever a normal `p`-Sylow is exhibited. -/
+example {G : Type*} [Group G] [Finite G]
+    (hcard : Nat.card G = 12)
+    (N : Subgroup G) [N.Normal] (hN : Nat.card N = 4) : IsSolvable G := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  have hcard' : Nat.card G = 2 ^ 2 * 3 ^ 1 := by rw [hcard]; norm_num
+  have hN' : Nat.card N = 2 ^ 2 := by rw [hN]; norm_num
+  exact burnside_pq_with_normal_pSylow hcard' N hN'
+
 -- ═══════════════════════════════════════════════════════════════════════
 -- PART VI: Sharpness witness
 -- ═══════════════════════════════════════════════════════════════════════
@@ -337,6 +439,19 @@ theorem burnside_pq_sharp :
 - `burnside_pq_pq_case` — Burnside for `a = b = 1` (`|G| = p · q`,
   squarefree order). Reduces to `squarefreeOrder_isSolvable` via
   `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`.
+- `isSolvable_of_normal_quotient_solvable` (Iteration 5) — solvability is
+  closed under group extensions: `[N.Normal] [IsSolvable N]
+  [IsSolvable (G ⧸ N)] → IsSolvable G`. Repackaging of Mathlib's
+  `solvable_of_ker_le_range` against the canonical sequence
+  `N → G → G ⧸ N`.
+- `burnside_pq_with_normal_pSylow` (Iteration 5) — if `|G| = pᵃ · qᵇ`
+  and `G` admits a normal subgroup of order `pᵃ`, then `G` is solvable.
+  Axiom-free reduction tool: combined with Sylow-counting on specific
+  shapes (`|G| = p² · q`, `|G| = p · q²`, …), discharges
+  `burnside_pq_nontrivial` outright once a normal `p`-Sylow is
+  exhibited.
+- `burnside_pq_with_normal_qSylow` (Iteration 5) — symmetric: a normal
+  subgroup of order `qᵇ` gives `IsSolvable G`.
 - `burnside_pq` — main theorem combining trivial cases + pq case + axiom.
 - `alternatingGroupFin5_card` — `|A₅| = 2² · 3 · 5 = 60` (sharpness witness
   cardinality, three distinct primes).
@@ -357,8 +472,13 @@ theorem burnside_pq_sharp :
   theory still lacks the algebraic-integer hypotheses needed for
   `(|G|/χ(1))χ(g) ∈ ℤ̄_K`.
 - Next sub-cases worth axiom-free attempts (in order of accessibility):
-  (1) `|G| = p² · q` with `p ≠ q` — classical, ~50-100 lines via Sylow,
-  (2) `|G| = p · q²` with `p ≠ q` — symmetric to (1),
+  (1) `|G| = p² · q` with `p ≠ q` — classical, ~50-100 lines via Sylow.
+      With Iteration 5 the residual content shrinks to "exhibit a normal
+      Sylow"; the standard Sylow-counting argument (`n_p ∣ q`,
+      `n_p ≡ 1 (mod p)`, `n_q ∣ p²`, `n_q ≡ 1 (mod q)` and an
+      element-count) then composes with `burnside_pq_with_normal_pSylow`
+      / `burnside_pq_with_normal_qSylow` for an axiom-free finish.
+  (2) `|G| = p · q²` with `p ≠ q` — symmetric to (1).
   (3) `|G| = p² · q²` — needs more delicate Sylow analysis.
 - Mathlib upstream: a Burnside-pᵃqᵇ proof would be a substantial PR.
   Coordinate with Mathlib reviewers before scoping a full formalization.
@@ -372,6 +492,9 @@ theorem burnside_pq_sharp :
 #check @squarefreeOrder_isSolvable
 #check @burnside_pq_pq_case
 #check @pGroup_isSolvable
+#check @isSolvable_of_normal_quotient_solvable
+#check @burnside_pq_with_normal_pSylow
+#check @burnside_pq_with_normal_qSylow
 #check @alternatingGroupFin5_card
 #check @alternatingGroupFin5_not_solvable
 #check @burnside_pq_sharp

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 384,
+    "lineCount": 502,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -76,15 +76,19 @@
       "burnside_pq_same_prime: axiom-free proof of Burnside for `p = q` (G is a p-group of order p^(a+b)).",
       "squarefreeOrder_isSolvable: axiom-free packaging of Mathlib's IsZGroup.of_squarefree → IsSolvable chain. Subsumes the a = b = 1 case of Burnside and extends beyond two primes for squarefree orders (e.g. |G| = 30 = 2·3·5).",
       "burnside_pq_pq_case: axiom-free proof of Burnside for `a = b = 1` (|G| = p · q, squarefree). Reduces via Nat.coprime_primes + Prime.squarefree + Nat.squarefree_mul.",
-      "axiom burnside_pq_nontrivial (NARROWED in Iteration 4): the genuinely-open content (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`); the a = b = 1 case is now axiom-free. Full proof of the residual axiom requires either character theory + algebraic integers (Burnside 1904) or transfer + focal subgroup (Goldschmidt-Matsuyama 1970s) — neither currently in Mathlib at sufficient generality.",
+      "isSolvable_of_normal_quotient_solvable (Iteration 5): axiom-free packaging of solvability under group extensions — given a normal subgroup N of G with both N and G/N solvable, G is solvable. Repackages Mathlib's solvable_of_ker_le_range against the canonical short exact sequence 1 → N → G → G/N → 1.",
+      "burnside_pq_with_normal_pSylow (Iteration 5): axiom-free reduction tool — if |G| = pᵃ · qᵇ and G admits a normal subgroup of order pᵃ, then G is solvable. Proof: N is a p-group (hence solvable), |G/N| = qᵇ via Lagrange (Subgroup.card_mul_index + cancellation), so G/N is a q-group (hence solvable), and the extension is solvable.",
+      "burnside_pq_with_normal_qSylow (Iteration 5): symmetric reduction — a normal subgroup of order qᵇ gives IsSolvable G. Together with burnside_pq_with_normal_pSylow, these two lemmas turn 'exhibit a normal Sylow' into a complete axiom-free discharge of burnside_pq_nontrivial.",
+      "Worked example (Iteration 5): |G| = 12 = 2² · 3 with a normal subgroup of order 4 is solvable axiom-free via burnside_pq_with_normal_pSylow — exactly the structure realized by A₄ (whose Klein four-group V₄ ⊂ A₄ is normal of order 4). Demonstrates that the new reduction discharges the previously-axiomatized `2 ≤ a` shape `|G| = p² · q` whenever a normal p-Sylow is exhibited.",
+      "axiom burnside_pq_nontrivial (NARROWED in Iteration 4, unchanged in Iteration 5): the genuinely-open content (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`); the a = b = 1 case is now axiom-free. Iteration 5 leaves the axiom statement unchanged but adds reduction tooling above. Full proof of the residual axiom requires either character theory + algebraic integers (Burnside 1904) or transfer + focal subgroup (Goldschmidt-Matsuyama 1970s) — neither currently in Mathlib at sufficient generality.",
       "burnside_pq: main theorem combining trivial cases + squarefree case + axiom into the unified statement Nat.card G = p^a · q^b → IsSolvable G.",
-      "Four sanity-check examples: trivial group (|G|=1), prime-order group, prime-power group, |G| = 30 (squarefree three-prime) — all axiom-free.",
+      "Five sanity-check examples: trivial group (|G|=1), prime-order group, prime-power group, |G| = 30 (squarefree three-prime), and |G| = 12 with normal Sylow-2 (A₄-style) — all axiom-free.",
       "alternatingGroupFin5_card: axiom-free proof that |A₅| = 2²·3·5, exhibiting the three distinct prime factors that make A₅ a sharpness witness.",
       "alternatingGroupFin5_not_solvable: axiom-free proof that A₅ is not solvable, via reduction to Equiv.Perm.not_solvable (Fin 5) through the short exact sequence A₅ → S₅ → ℤ/2.",
       "burnside_pq_sharp: sharpness witness combining the two above — demonstrates that the analogue of burnside_pq for THREE distinct primes fails (no `burnside_pqr` theorem can hold without further hypotheses; A₅ also defeats the squarefree route since 60 has 2²)."
     ],
-    "assumptions": "1 axiom (narrowed in Iteration 4): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. The axiom isolates the genuinely-open Lean content (orders divisible by `p²` or `q²` for distinct primes); a full proof would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route).",
-    "theoremCount": 10,
+    "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iteration 5): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited; this is a strict shortcut for any future case-by-case Sylow-counting analysis (`|G| = p² · q`, `|G| = p · q²`, …). The axiom statement itself is unchanged: it still isolates the genuinely-open Lean content (orders divisible by `p²` or `q²` for distinct primes); a full proof would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route).",
+    "theoremCount": 13,
     "definitionCount": 0
   },
   "overview": {
@@ -205,10 +209,10 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 384,
+    "lineCount": 502,
     "axiomCount": 1,
-    "theoremCount": 10,
-    "substantiveTheoremCount": 10,
+    "theoremCount": 13,
+    "substantiveTheoremCount": 13,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Iteration 5 of `abel-ruffini-galois-extensions-oq-07` (Burnside's pᵃqᵇ theorem). Adds two axiom-free **reduction lemmas** that turn "exhibit a normal Sylow subgroup" into a complete axiom-free discharge of `burnside_pq_nontrivial`.

The `burnside_pq_nontrivial` axiom statement is **unchanged**; this iteration only adds tooling.

## New theorems (axiom-free)

- **`isSolvable_of_normal_quotient_solvable`** — Solvability is closed under group extensions: given a normal subgroup `N` of `G` with both `N` and `G ⧸ N` solvable, `G` is solvable. Repackages Mathlib's `solvable_of_ker_le_range` against the canonical short exact sequence `1 → N → G → G ⧸ N → 1`.

- **`burnside_pq_with_normal_pSylow`** — If `|G| = pᵃ · qᵇ` and `G` admits a normal subgroup `N` with `|N| = pᵃ`, then `G` is solvable.
  - `N` is a `p`-group (by `IsPGroup.iff_card`), hence solvable via `pGroup_isSolvable`.
  - Lagrange (`Subgroup.card_mul_index`) plus `pᵃ > 0` and the `|G| = pᵃ · qᵇ` hypothesis give `|G ⧸ N| = qᵇ`.
  - `G ⧸ N` is then a `q`-group, hence solvable.
  - `isSolvable_of_normal_quotient_solvable` closes `G`.

- **`burnside_pq_with_normal_qSylow`** — Symmetric: a normal subgroup of order `qᵇ` likewise gives `IsSolvable G`.

## Worked example

`|G| = 12 = 2² · 3` with a normal subgroup of order `4` is solvable axiom-free via the new tooling — exactly the structure realized by `A₄` (the Klein four-group `V₄ ⊂ A₄` is normal of order `4`). Demonstrates that the previously-axiomatized `2 ≤ a` shape `|G| = p² · q` is **discharged whenever a normal `p`-Sylow is exhibited**.

## Strategic value

Future Sylow-counting iterations on specific shapes (`|G| = p² · q`, `|G| = p · q²`, …) can plug directly into these reductions to give axiom-free proofs. The standard Sylow-counting argument (`n_p ∣ q`, `n_p ≡ 1 (mod p)`, `n_q ∣ p²`, `n_q ≡ 1 (mod q)` plus an element count) typically yields a normal Sylow; combined with `burnside_pq_with_normal_pSylow` / `burnside_pq_with_normal_qSylow`, this discharges the axiom outright.

## Counts

| Field | Before | After | Δ |
|---|---|---|---|
| theoremCount | 10 | 13 | +3 |
| substantiveTheoremCount | 10 | 13 | +3 |
| lineCount | 384 | 502 | +118 |
| axiomCount | 1 | 1 | 0 |
| sorries | 0 | 0 | 0 |

## Test plan

- [ ] Docker build succeeds (`./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ07`)
- [ ] No new sorries or axioms
- [ ] `meta.json` counts match Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)