### PR TITLE
audit(greens-theorem-oq-01-oq-02): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15048,8 +15048,14 @@
       "lastAudited": "2026-05-08T07:00:00Z",
       "result": "clean",
       "issues": []
+    },
+    "greens-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-08T07:18:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-08T07:00:00Z"
+  "lastUpdated": "2026-05-08T07:18:42Z"
 }


### PR DESCRIPTION
## Audit result: clean

**Proof**: `greens-theorem-oq-01-oq-02` (Green's Theorem for Smooth Curves via Mathlib Path Integrals)
**File**: `proofs/Proofs/GreensTheoremOQ01OQ02.lean`

### Verified counts (all match `meta.json`)

| Field | Claimed | Actual |
|------:|--------:|-------:|
| lineCount | 227 | 227 |
| theoremCount | 5 | 5 (3 lemmas + 2 theorems) |
| definitionCount | 2 | 2 (`pathLineIntegral`, `rectBoundaryPathIntegral`) |
| axiomCount | 1 | 1 (`greens_theorem_smooth_boundary`) |
| sorries | 0 | 0 |

### Tier classification

Tier C (axiomatized): one axiom packages the open Mathlib gap (planar Stokes/Green for parametrized Jordan curve). `status=axiomatized` and `badge=axiom` are correctly applied. Description, `assumptions`, and `originalContributions` all explicitly disclose the axiom — no overclaim.

### Narrative checks

- Title qualifies "via Mathlib Path Integrals" — no bare-theorem claim.
- Path-integral side independently formalized (no axioms, no sorries).
- Rectangular bridge `pathLineIntegral_rect_boundary_eq_rectLineIntegral` is a real proof, not a stub.
- The single axiom is named, scoped, and documented as the open gap.

### Tracker update

Adds `greens-theorem-oq-01-oq-02` entry (auditCount=1, result=clean) via plumbing surgery to avoid touching unrelated unicode-encoding drift in the tracker file.

---
Discovered during gallery integrity audit.