### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S22 — totalSym/weight bridge family for b≥2 structural reduction

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -722,6 +722,51 @@ private def totalSym' {n a b : ℕ} (hb : 1 ≤ b)
     (P' : Sym (Fin n) (a + 1)) (Q' : Sym (Fin n) (b - 1)) :
     (totalSym' hb P' Q').1 = P'.1 + Q'.1 := rfl
 
+/-- **`totalSym` membership in a fiber.** A `Sym` pair `(P, Q)` lies in the fiber
+    of `totalSym` over `M : Sym (Fin n) (a + b)` iff its underlying multisets sum
+    to `M.1`. Used to translate filter predicates between the multiset-equation
+    form (used inside `ballot_counting_identity`) and the `totalSym`-equation form
+    (used by `Finset.sum_fiberwise_of_maps_to` over the map `(P, Q) ↦ totalSym P Q`). -/
+private lemma totalSym_eq_iff {n a b : ℕ}
+    (P : Sym (Fin n) a) (Q : Sym (Fin n) b) (M : Sym (Fin n) (a + b)) :
+    totalSym P Q = M ↔ P.1 + Q.1 = M.1 := by
+  constructor
+  · intro h; rw [← totalSym_val P Q, h]
+  · intro h; exact Subtype.ext (by rw [totalSym_val]; exact h)
+
+/-- **`totalSym'` membership in a fiber.** Companion to `totalSym_eq_iff` for the
+    `(a + 1, b - 1)`-split side of `ballot_counting_identity`. -/
+private lemma totalSym'_eq_iff {n a b : ℕ} (hb : 1 ≤ b)
+    (P' : Sym (Fin n) (a + 1)) (Q' : Sym (Fin n) (b - 1))
+    (M : Sym (Fin n) (a + b)) :
+    totalSym' hb P' Q' = M ↔ P'.1 + Q'.1 = M.1 := by
+  constructor
+  · intro h; rw [← totalSym'_val hb P' Q', h]
+  · intro h; exact Subtype.ext (by rw [totalSym'_val]; exact h)
+
+/-- **Pair-weight factorisation through `totalSym`** — Sym-wrapped form of
+    `weight_eq_total_multiset`. The product of weights of a pair `(P, Q)` equals
+    the weight of the total multiset packaged as `totalSym P Q : Sym (Fin n) (a + b)`.
+
+    This is the cleanest form for chaining with `Finset.sum_fiberwise_of_maps_to`
+    over the map `(P, Q) ↦ totalSym P Q`, since the inner expression then depends
+    only on the fiber index. -/
+private lemma weight_eq_totalSym {n a b : ℕ}
+    (P : Sym (Fin n) a) (Q : Sym (Fin n) b) :
+    (P.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
+      (Q.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
+    ((totalSym P Q).1.map (X : Fin n → MvPolynomial (Fin n) R)).prod := by
+  rw [totalSym_val]; exact weight_eq_total_multiset P Q
+
+/-- **Pair-weight factorisation through `totalSym'`** — companion to
+    `weight_eq_totalSym` for the `(a + 1, b - 1)`-split side. -/
+private lemma weight_eq_totalSym' {n a b : ℕ} (hb : 1 ≤ b)
+    (P' : Sym (Fin n) (a + 1)) (Q' : Sym (Fin n) (b - 1)) :
+    (P'.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
+      (Q'.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
+    ((totalSym' hb P' Q').1.map (X : Fin n → MvPolynomial (Fin n) R)).prod := by
+  rw [totalSym'_val]; exact weight_eq_total_multiset P' Q'
+
 /-- **Ballot counting identity (per total multiset).**
 
     For `b ≥ 2` and any total multiset `M : Sym (Fin n) (a + b)`, the number
@@ -733,13 +778,42 @@ private def totalSym' {n a b : ℕ} (hb : 1 ≤ b)
 
     This is the per-fiber heart of `jdt_weight_sum` (b ≥ 2): the weight
     factorisation `weight_eq_total_multiset` reduces the polynomial sum
-    identity to this counting statement (see `jdt_weight_sum_b_ge_two_via_count`).
+    identity to this counting statement.
 
-    **Proof strategy (TODO).** Reflection / ballot principle: for `M` with all
-    distinct elements, both cardinalities equal `C(a+b, a+1)`; the multiplicity
-    case generalises by the same argument. Estimated ~150 lines remaining work,
-    Session 21+. The b = 1 analogue (where `b - 1 = 0` and `Q' = ∅`) is the
-    unique-existence statement in `jdt_weight_sum_b_one` / Aristotle. -/
+    ### Structural reduction `jdt_weight_sum (b ≥ 2)` ⟸ `ballot_counting_identity`
+
+    The Session 22 helper lemmas (`totalSym_eq_iff`, `totalSym'_eq_iff`,
+    `weight_eq_totalSym`, `weight_eq_totalSym'`) make the connection mechanical:
+
+    1. **LHS rewrite** (predicate-filtered subtype sum → fiber-card sum):
+       Convert `∑ PQ : { PQ // ¬ColStrictSym a b PQ.1 PQ.2 }, prod * prod`
+       to a sum over `M : Sym (Fin n) (a + b)`. Uses
+       `Fintype.sum_subtype_eq_sum_filter` to land in `Finset.univ.filter (¬cs)`,
+       then `weight_eq_totalSym` to express the inner product as
+       `prod((totalSym P Q).1.map X)`. Apply `Finset.sum_fiberwise_of_maps_to`
+       (Mathlib `Algebra.BigOperators.Group.Finset.Basic`) with
+       `g := fun PQ => totalSym PQ.1 PQ.2 : (Sym a × Sym b) → Sym (a + b)`
+       and target `Finset.univ : Finset (Sym (a + b))`. By `totalSym_eq_iff`
+       the inner condition `g PQ = M` is `P.1 + Q.1 = M.1`, matching the
+       `ballot_counting_identity` LHS filter.
+
+    2. **RHS rewrite** (full pair sum → fiber-card sum): same pattern with
+       `weight_eq_totalSym'` and `totalSym'_eq_iff` on `(a + 1, b - 1)`-pairs.
+
+    3. **Per-fiber counting**: `ballot_counting_identity` gives the equality
+       of fiber cardinalities; `Finset.sum_congr` over `M : Sym (a + b)` closes
+       the goal.
+
+    Estimated ~80–100 lines of structural Finset manipulation, with the only
+    deep mathematical input being `ballot_counting_identity` itself.
+
+    ### Proof strategy for `ballot_counting_identity` (this lemma — `sorry`)
+
+    Reflection / ballot principle: for `M` with all distinct elements, both
+    cardinalities equal `C(a + b, a + 1)`; the multiplicity case generalises by
+    the same argument. Estimated ~150 lines remaining work, Session 23+. The
+    b = 1 analogue (where `b - 1 = 0` and `Q' = ∅`) is the unique-existence
+    statement in `jdt_weight_sum_b_one` / Aristotle. -/
 private theorem ballot_counting_identity (n a b : ℕ) (hb : 2 ≤ b)
     (M : Sym (Fin n) (a + b)) :
     ((Finset.univ : Finset (Sym (Fin n) a × Sym (Fin n) b)).filter
@@ -783,10 +857,13 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
       -- **S19/S20 strategy**: factor weights through the total multiset
       -- `M : Sym (Fin n) (a + b)`, then apply `ballot_counting_identity` (S20).
       --
-      -- Step (i)   `weight_eq_total_multiset`: prod(P)*prod(Q) = prod(P.1 + Q.1).
+      -- Step (i)   `weight_eq_totalSym` (S22): prod(P)*prod(Q) = prod((totalSym P Q).1).
+      --              (Sym-wrapped form of `weight_eq_total_multiset`.)
       -- Step (ii)  regroup both sides by total multiset
-      --              `M = P+Q = P'+Q' : Sym (Fin n) (a+b)` via `totalSym`/`totalSym'`
-      --              (Finset.sum_fiberwise_of_maps_to).
+      --              `M : Sym (Fin n) (a+b)` via `Finset.sum_fiberwise_of_maps_to`
+      --              with map `(P, Q) ↦ totalSym P Q` (LHS) and `(P', Q') ↦ totalSym' hb P' Q'` (RHS).
+      --              The fiber predicate `g PQ = M` matches `ballot_counting_identity`'s
+      --              filter `P.1 + Q.1 = M.1` via `totalSym_eq_iff` / `totalSym'_eq_iff` (S22).
       -- Step (iii) per-fiber count equality: `ballot_counting_identity` (S20, sorry).
       -- Step (iv)  combine fiberings: ∑_M [count_LHS] • prod(M) = ∑_M [count_RHS] • prod(M).
       --

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 3,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "3 sorries remain: (1) ballot_counting_identity (S20 extracted, ~150 lines remaining) — per-fiber count equality C(a+b, a+1) for the b≥2 reflection step; (2) jdt_weight_sum b≥2 — structural reduction (steps i–iv) using ballot_counting_identity as a black box (~80–100 lines, separate session); (3) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S19 added weight_eq_total_multiset helper: prod(P)*prod(Q) = prod(P+Q) via Multiset.map_add+prod_add. jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
+    "assumptions": "3 sorries remain: (1) ballot_counting_identity (S20 extracted, ~150 lines remaining) — per-fiber count equality C(a+b, a+1) for the b≥2 reflection step; (2) jdt_weight_sum b≥2 — structural reduction (steps i–iv) using ballot_counting_identity as a black box (~80–100 lines, separate session); (3) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S22 added the totalSym/totalSym' bridge family: weight_eq_totalSym, weight_eq_totalSym' (Sym-wrapped weight factorisation), totalSym_eq_iff, totalSym'_eq_iff (fiber-membership characterisation as `P.1 + Q.1 = M.1`); these reduce the b≥2 structural-reduction goal to a chain `Fintype.sum_subtype_eq_sum_filter` ⟶ `Finset.sum_fiberwise_of_maps_to` ⟶ `ballot_counting_identity` and updated the inline strategy comment with the explicit Mathlib API. S19 added weight_eq_total_multiset helper: prod(P)*prod(Q) = prod(P+Q) via Multiset.map_add+prod_add. jdt_weight_sum_b_one proved (S17): b=1 bijection via Sym.cons/erase + Multiset.sort_cons (~100 lines). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
     "lineCount": 992,
     "theoremCount": 22,
     "definitionCount": 6,
@@ -36,7 +36,10 @@
       "schurPolynomial_two_row: explicit 2-row formula h_a*h_b - h_{a+1}*(h_{b-1} or 0)",
       "SSYTFin n k sh: first Lean 4 SSYT definition using sigma-type encoding (i:Fin k)×Fin(sh i) → Fin n with decidable row-weak and col-strict conditions; Fintype instance via Subtype.fintype",
       "ssytSchurFin: SSYT generating function — canonical tableau-sum definition of Schur polynomial",
-      "ssytSchurFin_empty: k=0 case proved via Unique (empty SSYT) + IsEmpty (empty sigma-type product)"
+      "ssytSchurFin_empty: k=0 case proved via Unique (empty SSYT) + IsEmpty (empty sigma-type product)",
+      "totalSym/totalSym' — Sym-wrapper for the total multiset of a (Sym a × Sym b) or (Sym (a+1) × Sym (b-1)) pair, packaged as Sym (a+b) (S19/S22)",
+      "weight_eq_totalSym / weight_eq_totalSym' (S22): Sym-wrapped weight factorisation `prod(P)*prod(Q) = prod((totalSym P Q).1)` and its (a+1, b-1) companion — the cleanest form for chaining with Finset.sum_fiberwise_of_maps_to in the b≥2 structural reduction",
+      "totalSym_eq_iff / totalSym'_eq_iff (S22): bridges the fiber-membership predicate `g PQ = M` (used by Finset.sum_fiberwise_of_maps_to) to `P.1 + Q.1 = M.1` (used by ballot_counting_identity), via Subtype extensionality"
     ]
   },
   "overview": {

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-23T12:58:12+02:00",
-    "iteration": 20,
-    "focus": "ballot_counting_identity (S20 stated): per-fiber cardinality identity, the focused remaining work for jdt_weight_sum b≥2.",
+    "iteration": 22,
+    "focus": "ballot_counting_identity remains the only open question gating jdt_weight_sum b≥2; S22 added the totalSym/weight bridge family making the structural reduction one Finset.sum_fiberwise_of_maps_to call away.",
     "blockers": [],
-    "nextAction": "S21: Prove ballot_counting_identity via bijection at the multiset level (~150 lines).",
+    "nextAction": "S23: Prove ballot_counting_identity via bijection at the multiset level (~150 lines). Once filled, jdt_weight_sum b≥2 follows in ~50–80 lines using the S22 helpers (weight_eq_totalSym, totalSym_eq_iff and primed companions) + Finset.sum_fiberwise_of_maps_to.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Session 20 (2026-05-08): Architectural refactor of the b≥2 path. Added totalSym + totalSym^prime helpers (Sym pair → Sym (a+b) total multiset) and ballot_counting_identity as a clean black-box per-fiber cardinality subproblem (sorry; ~150 lines remaining). Updated jdt_weight_sum b≥2 comment block to reference the new structural reduction (steps i-iv). The architecture cleanly separates the polynomial-algebra reduction (steps i,ii,iv) from the combinatorial heart (step iii / ballot_counting_identity), so future sessions can attack the latter in isolation. Sorry count: 3 → 4 (one new clean statement, no work-around closures).",
+    "progressSummary": "Session 22 (2026-05-08): Bridge-lemma family for the b≥2 structural reduction. Added weight_eq_totalSym, weight_eq_totalSym^prime (Sym-wrapped weight factorisations), totalSym_eq_iff, totalSym^prime_eq_iff (fiber-membership characterisations as `P.1 + Q.1 = M.1` via Subtype extensionality). Together they collapse the steps (i)+(ii) of the b≥2 reduction onto a single Finset.sum_fiberwise_of_maps_to call (with map (P, Q) ↦ totalSym P Q), with `totalSym_eq_iff` translating that map's fiber predicate into the form ballot_counting_identity already filters on. Updated the inline strategy block in jdt_weight_sum and the docstring of ballot_counting_identity to reference the explicit Mathlib API chain. Session 20 (2026-05-08): Architectural refactor of the b≥2 path. Added totalSym + totalSym^prime helpers (Sym pair → Sym (a+b) total multiset) and ballot_counting_identity as a clean black-box per-fiber cardinality subproblem (sorry; ~150 lines remaining). Updated jdt_weight_sum b≥2 comment block to reference the new structural reduction (steps i-iv). The architecture cleanly separates the polynomial-algebra reduction (steps i,ii,iv) from the combinatorial heart (step iii / ballot_counting_identity), so future sessions can attack the latter in isolation. Sorry count remained 3 (S22 added no new sorries — only structural helpers).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -80,7 +80,11 @@
       "S20 cleanup (this PR): removed duplicate `private lemma weight_eq_total_multiset` introduced when parallel S19 PRs #16637 and #16661 merged within 2 minutes of each other, both adding the same lemma. Kept the implicit-argument signature, promoted the longer expository docstring.",
       "S20: totalSym helper (BallotProblemOQ03OQ01OQ01OQ01.lean): (P : Sym (Fin n) a) (Q : Sym (Fin n) b) ↦ ⟨P.1 + Q.1, _⟩ : Sym (Fin n) (a + b). Plus totalSym_val rfl-simp. Used to fiber both LHS and RHS sums by total multiset.",
       "S20: totalSym^prime helper: companion to totalSym for the (a+1, b-1) RHS shape; takes hb : 1 ≤ b and produces Sym (Fin n) (a+b) for type-aligned fibering.",
-      "S20: ballot_counting_identity stated (BallotProblemOQ03OQ01OQ01OQ01.lean, ~30 lines incl. docstring) as the focused per-fiber subproblem. Cardinality identity: #{(P,Q) : Sym a × Sym b // ¬CS ∧ P+Q = M.1} = #{(P^prime,Q^prime) : Sym (a+1) × Sym (b-1) // P^prime+Q^prime = M.1}. Sorry remaining (the deep combinatorial work)."
+      "S20: ballot_counting_identity stated (BallotProblemOQ03OQ01OQ01OQ01.lean, ~30 lines incl. docstring) as the focused per-fiber subproblem. Cardinality identity: #{(P,Q) : Sym a × Sym b // ¬CS ∧ P+Q = M.1} = #{(P^prime,Q^prime) : Sym (a+1) × Sym (b-1) // P^prime+Q^prime = M.1}. Sorry remaining (the deep combinatorial work).",
+      "S22: weight_eq_totalSym (BallotProblemOQ03OQ01OQ01OQ01.lean): wt(P) * wt(Q) = wt((totalSym P Q).1) — Sym-wrapped form of weight_eq_total_multiset. 2-line proof via totalSym_val rfl + weight_eq_total_multiset.",
+      "S22: weight_eq_totalSym^prime: companion for the (a+1, b-1) RHS shape, takes hb : 1 ≤ b. Both forms feed Finset.sum_fiberwise_of_maps_to whose fiber index is the totalSym/totalSym^prime image, making the inner expression depend only on M (so it factors out of the inner sum cleanly).",
+      "S22: totalSym_eq_iff / totalSym^prime_eq_iff: bridges the predicate `g PQ = M` (the fiber-membership clause of Finset.sum_fiberwise_of_maps_to) to the predicate `P.1 + Q.1 = M.1` (the form already filtered on inside ballot_counting_identity). Two short Subtype.ext arguments. With these, ballot_counting_identity can be invoked verbatim on the inner-sum cardinality.",
+      "S22: Updated the inline strategy comment in jdt_weight_sum (b≥2 branch) and the docstring of ballot_counting_identity to spell out the exact Mathlib API chain — Fintype.sum_subtype_eq_sum_filter ⟶ weight_eq_totalSym ⟶ Finset.sum_fiberwise_of_maps_to ⟶ ballot_counting_identity ⟶ Finset.sum_congr — so the next session can fill the b≥2 sorry mechanically."
     ],
     "insights": [
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
@@ -132,7 +136,9 @@
       "S20 race-condition lesson: when two PRs work the same problem in parallel, even when both Lean changes are identical, the merge order can leave a duplicate `private lemma` declaration — invisible until the parent dependency builds (here masked by ongoing OQ03OQ02 API drift). Future sessions: before adding a helper that may be in flight elsewhere, `gh pr list --search '<lemma name>' --state open` is a 5-second guard.",
       "S20: Refactored the b≥2 path into a clean black-box reduction. ballot_counting_identity (per-fiber cardinality) is now the focused remaining subproblem, decoupled from the polynomial-algebra setup. The architectural split lets future sessions attack the cardinality identity in isolation, possibly via Aristotle on a small companion file.",
       "S20: totalSym + totalSym^prime expose the (a+b)-cardinality total multiset as a Sym, so both LHS and RHS sums can fiber over the SAME codomain Sym (Fin n) (a+b). Without this, the type mismatch (a+1)+(b-1) vs a+b would force casts in every fiberwise lemma — totalSym^prime carries hb : 1 ≤ b in its signature so the omega-style equality lives once, in the def, not per-call.",
-      "S20: The remaining b≥2 reduction (steps i-iv in the comment block) is structural: weight_eq_total_multiset rewrites each summand, Finset.sum_fiberwise_of_maps_to regroups by total multiset, ballot_counting_identity equates per-fiber counts, and the chain inverts. Estimated 80-100 lines once ballot_counting_identity is filled."
+      "S20: The remaining b≥2 reduction (steps i-iv in the comment block) is structural: weight_eq_total_multiset rewrites each summand, Finset.sum_fiberwise_of_maps_to regroups by total multiset, ballot_counting_identity equates per-fiber counts, and the chain inverts. Estimated 80-100 lines once ballot_counting_identity is filled.",
+      "S22: The b≥2 reduction now factors through TWO Sym-wrapped helpers (weight_eq_totalSym and weight_eq_totalSym^prime) plus TWO predicate-translation helpers (totalSym_eq_iff and its primed companion). The fiber-membership predicate of Finset.sum_fiberwise_of_maps_to (`g PQ = M`, where g is the totalSym map) and the filter predicate of ballot_counting_identity (`P.1 + Q.1 = M.1`) are propositionally equal but defeq-distinct — without an explicit iff lemma, the rewriter can't bridge them through `Finset.filter_congr`. The S22 helpers eliminate this friction at zero proof cost (Subtype extensionality only).",
+      "S22: Estimated structural-reduction body shrinks from ~80–100 lines (S20 estimate) to ~50–80 lines now that the bridges are in place. The bottleneck is no longer setup-vs-cleanup of the multiset/Sym translation; it is the cardinality identity itself (ballot_counting_identity, sorry)."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -140,14 +146,14 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "S21: Prove ballot_counting_identity (~150 lines). Strategy: construct a bijection between the two filtered finsets at the multiset level. Approach options — (a) reflection/cycle lemma for distinct elements + multiplicity argument; (b) explicit insert-with-disambiguating-data bijection (the Σ-bundled fix to S18 non-injectivity).",
-      "S22: Wire ballot_counting_identity into jdt_weight_sum b≥2 via the structural reduction (steps i-iv documented). ~80-100 lines using Finset.sum_fiberwise_of_maps_to + weight_eq_total_multiset.",
-      "Optional: extract ballot_counting_identity as a standalone Mathlib contribution candidate — it is a clean, named statement about Sym multisets and column-strict pairs, of independent interest in algebraic combinatorics.",
+      "S23: Prove ballot_counting_identity (~150 lines). Strategy: construct a bijection between the two filtered finsets at the multiset level. Approach options — (a) reflection/cycle lemma for distinct elements + multiplicity argument; (b) explicit insert-with-disambiguating-data bijection (the Σ-bundled fix to S18 non-injectivity). With ballot_counting_identity closed, the b≥2 sorry follows mechanically via the S22 bridges.",
+      "S24: Wire ballot_counting_identity into jdt_weight_sum b≥2 (~50–80 lines now that S22 bridges are landed). The proof now reads as: subtype→filter (Fintype.sum_subtype_eq_sum_filter) ⟶ weight_eq_totalSym (resp. weight_eq_totalSym^prime on RHS) ⟶ Finset.sum_fiberwise_of_maps_to with map (P, Q) ↦ totalSym P Q (resp. totalSym^prime hb) ⟶ rewrite the inner-fiber predicate via totalSym_eq_iff (resp. ^prime) ⟶ ballot_counting_identity ⟶ Finset.sum_congr.",
+      "Optional: extract ballot_counting_identity as a standalone Mathlib contribution candidate — it is a clean, named statement about Sym multisets and column-strict pairs, of independent interest in algebraic combinatorics. The S22 bridges (totalSym_eq_iff family) would also be Mathlib-quality if generalised away from the specific weight context.",
       "For jacobi_trudi_ssyt_eq k≥3: RSK or algebraic LGV. ~300 lines. Defer until k=2 (jdt_weight_sum) closes."
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n",
-    "insightsCount": 50,
-    "builtItemsCount": 50,
+    "insightsCount": 52,
+    "builtItemsCount": 54,
     "nextStepsCount": 4
   },
   "tags": [
@@ -181,7 +187,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-05-08T03:30:00.000Z",
+  "lastUpdate": "2026-05-08T09:30:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",


### PR DESCRIPTION
## Summary

Session 22 on the Jacobi-Trudi b≥2 reduction — adds the **bridge-lemma family** that collapses the steps (i)+(ii) of the structural reduction onto a single `Finset.sum_fiberwise_of_maps_to` call.

### Lean changes (`proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`)

Four short helper lemmas, all `private`, all using Subtype-extensionality / rfl-style proofs over the existing `weight_eq_total_multiset`, `totalSym`, `totalSym'`:

* **`weight_eq_totalSym`** / **`weight_eq_totalSym'`** — Sym-wrapped form of `weight_eq_total_multiset`. Expresses `prod(P)*prod(Q)` as `prod((totalSym P Q).1)` (and the `(a+1, b-1)` companion under `hb : 1 ≤ b`).
* **`totalSym_eq_iff`** / **`totalSym'_eq_iff`** — bridges the fiber-membership predicate `g PQ = M` (used by `Finset.sum_fiberwise_of_maps_to` over the map `(P, Q) ↦ totalSym P Q`) to the predicate `P.1 + Q.1 = M.1` (used by the existing `ballot_counting_identity` filter). Two short Subtype.ext arguments.

Updates the inline strategy comment block in the `jdt_weight_sum` b≥2 branch and the docstring of `ballot_counting_identity` to spell out the explicit Mathlib API chain end-to-end:

```
Fintype.sum_subtype_eq_sum_filter
  ⟶ weight_eq_totalSym (resp. weight_eq_totalSym' on RHS)
  ⟶ Finset.sum_fiberwise_of_maps_to with map (P,Q) ↦ totalSym P Q
  ⟶ rewrite the fiber predicate via totalSym_eq_iff (resp. ')
  ⟶ ballot_counting_identity (the deep, still-sorry step)
  ⟶ Finset.sum_congr.
```

### Why this matters

After S22, the b≥2 structural-reduction body estimate drops from ~80–100 lines (S20) to **~50–80 lines**, because the multiset/Sym translation friction is fully absorbed into the bridges. The bottleneck is no longer setup-vs-cleanup — it is the cardinality identity itself (`ballot_counting_identity`, ~150 lines, still sorry).

### Honest scope notes

* **Sorry count unchanged**: still 3 (`ballot_counting_identity` line ~772, `jdt_weight_sum` b≥2 line ~872, `jacobi_trudi_ssyt_eq` k≥3 line ~1119). S22 added no new sorries.
* **Not** a step toward `jacobi_trudi_ssyt_eq` k≥3 (still requires algebraic LGV + RSK).
* **Not** a closure of the b≥2 case — the structural reduction still needs to be written out (S24, with bridges now in place) and `ballot_counting_identity` still needs its ~150-line bijection proof (S23).
* **Does** make the next session's wiring step mechanical: every Mathlib lemma in the chain is now named, with the predicates lined up.

### JSON updates

* `src/data/proofs/.../meta.json` — extended `meta.assumptions` to record S22; appended 3 entries to `meta.originalContributions` for the new helper family. **Counts left unchanged** (PR #16899 already syncs `lineCount`/`theoremCount`/`definitionCount`; rebasing on top is mechanical once #16899 lands).
* `src/data/research/problems/.../json` — `currentState.iteration` 20 → 22, refreshed `focus`/`nextAction`, prepended S22 paragraph to `progressSummary`, +4 entries to `builtItems`, +2 entries to `insights`, refreshed all 4 `nextSteps` (S21/S22 → S23/S24 with the bridge-aware path).

## Build status

**Not verified locally.** This worktree's `proofs/.lake` is the recursive self-symlink trap (memory: `feedback_researcher_lake_symlink_broken`), forcing a fresh Mathlib clone + cache get (~25–30 min) before the actual file build, which exceeds the session window.

The new helpers are 16 lines total of Subtype.ext + rfl/`by rw`-style manipulation. The only Mathlib API used (`Subtype.ext`) plus the in-file already-built lemmas (`totalSym_val`, `totalSym'_val`, `weight_eq_total_multiset`) make a build failure here unlikely beyond a renamed-import nit. If the build does fail on these specific lemmas, fixes are isolated to one or two lines.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ03OQ01OQ01OQ01` (offline, separate session)
- [ ] Spot-check: the new lemmas appear at the expected positions; sorry count remains 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)