### PR TITLE
research(hurwitz-theorem-wip-01): S4 — Wedderburn-Artin landed in Mathlib; sharpen blocker

### DIFF
--- a/research/problems/hurwitz-theorem-wip-01/sessions/2026-05-08-s04.md
+++ b/research/problems/hurwitz-theorem-wip-01/sessions/2026-05-08-s04.md
@@ -1,0 +1,132 @@
+## Session 2026-05-08 (Session 4) — Unblock-criteria refresh: Wedderburn-Artin landed in Mathlib
+
+**Mode**: SURVEY (PARK → SHARPEN; documentation-only)
+**Outcome**: progress (no Lean changes; no sorry/axiom delta) — state.md and
+JSON updated to reflect a meaningful narrowing of the upstream block.
+
+### Headline finding
+
+**Wedderburn–Artin is now in Mathlib master.**
+
+`Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` (Junyan Xu, 2025) provides:
+
+- `IsSimpleRing.exists_ringEquiv_matrix_divisionRing` — an Artinian simple ring
+  is `Matrix (Fin n) (Fin n) D` for some division ring `D`.
+- `IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite` — over an arbitrary
+  base ring, the simple-Artinian-finite case gives an explicit `D` finite over
+  the base.
+- `IsSemisimpleRing.exists_algEquiv_pi_matrix_divisionRing_finite` — semisimple
+  case, product of matrix algebras.
+- `Mathlib/RingTheory/SimpleModule/IsAlgClosed.lean` — algebraically-closed-field
+  version (`exists_algEquiv_matrix_of_isAlgClosed`).
+
+Both S2 (state.md, JSON) and S3 listed Artin–Wedderburn for real semisimple
+algebras as a primary blocker. **It is no longer a blocker.** The general
+Wedderburn–Artin statement, instantiated at the base ring `ℝ`, is precisely
+what state.md asked for. Specializing to `R = Cl(0, n-1)` (a finite-dim
+simple/semisimple ℝ-algebra) gives `Cl(0, n-1) ≅ M_d(D)` with `D` finite-dim
+over `ℝ`.
+
+### What is *still* missing
+
+The remaining blocker is sharper and lower-dim:
+
+1. **Frobenius theorem for real division algebras** (`finrank ℝ D ∈ {1, 2, 4}`,
+   i.e., D ∈ {ℝ, ℂ, ℍ}). Without it, the `D` from Wedderburn–Artin cannot be
+   pinned down, and the dimension count `n_i^2 · finrank ℝ D_i = finrank ℝ A`
+   cannot be made effective. **Search 2026-05-08**: `Frobenius` files in
+   Mathlib are all about *Galois-element* Frobenius, char-p endomorphisms, or
+   Witt vectors — none give the real-division-algebra theorem.
+
+2. **Bott periodicity for real Clifford algebras** (or equivalently a direct
+   Wedderburn structure for `Cl(0, k)`, k = 0..7). Most recent
+   `Mathlib/LinearAlgebra/CliffordAlgebra/` change is 2026-05-01 (chore: remove
+   `set_option`); no structural content added. The directory still has
+   {Basic, Equivs, Even, Conjugation, Contraction, Fold, Grading, Inversion,
+   Prod, SpinGroup, Star, BaseChange, CategoryTheory, EvenEquiv} — universal
+   property and conjugation only.
+
+3. **InnerProductSpace from NormedDivisionRing**. Polarization identity
+   construction for option B; still not in Mathlib (no relevant matches in
+   `search/code` for `DivisionAlgebra ℝ`, `imaginary subspace division`).
+
+### Implications for forward path
+
+- **Option A (small-case decomposition)** becomes substantially cheaper:
+  `Cl(0, 5)` (dim 32 over ℝ) is now provably `M_d(D)` for `d² · finrank ℝ D = 32`
+  via the new Wedderburn–Artin API. Still need either Frobenius or an *ad-hoc*
+  argument identifying `D` as ℍ to conclude `(d, D) = (2, ℍ)` and rule out a
+  faithful 6-dim ℝ-rep. Estimated ~250 lines (down from ~400) per case.
+
+- **Option B (HurwitzOnlyIf refactor)** is unchanged: the bridge still needs
+  an InnerProductSpace structure, which still requires the Frobenius-style
+  imaginary-subspace argument absent from Mathlib.
+
+- **Option C (Mathlib RFC)** sharpens to a one-line wishlist: a
+  `frobenius_theorem_real_division_ring` saying every finite-dimensional
+  associative division algebra over ℝ has `finrank ∈ {1, 2, 4}`. arXiv:2405.01876
+  (Frobenius formalization in Coq, May 2024) is the natural reference.
+
+### Revised unblock criteria (concrete)
+
+The previous unblock list (state.md S3) had four bullets. After this session
+they collapse to **two**:
+
+- **(crit-F)** Mathlib gains a Frobenius theorem for real division algebras
+  (`∀ D : Type*, [DivisionRing D] [Algebra ℝ D] [FiniteDimensional ℝ D] →
+  finrank ℝ D ∈ {1, 2, 4}`).
+- **(crit-IPS)** Mathlib gains an `InnerProductSpace ℝ A` instance / theorem
+  derivable from `NormedDivisionRing A` + `FiniteDimensional ℝ A` (the
+  imaginary-subspace polarization construction).
+
+Either crit-F (combined with the now-available Wedderburn–Artin) or crit-IPS
+(used as a direct bridge for option B) **suffices** to close the open sorry.
+
+The two prior bullets
+
+- ~~`Mathlib gains Mathlib.LinearAlgebra.CliffordAlgebra.RealClassification with a Wedderburn-style structure theorem for Cl(0, k)`~~
+- ~~`Mathlib gains an Artin-Wedderburn structure theorem usable to compute the minimum faithful real representation dimension of a real semisimple algebra`~~
+
+are now subsumed by the available Wedderburn–Artin + a Frobenius identification
+of `D`.
+
+### Files modified
+
+- `research/problems/hurwitz-theorem-wip-01/state.md` — phase remains PARK,
+  iteration 3 → 4; blockers list reduced; next-action sharpened.
+- `research/problems/hurwitz-theorem-wip-01/sessions/2026-05-08-s04.md` — this
+  report.
+- `src/data/research/problems/hurwitz-theorem-wip-01.json` — `currentState.iteration`
+  3 → 4; `currentState.focus` updated; `blockers` list pruned (Wedderburn
+  removed); `mathlibGaps` pruned; `unblockCriteria` collapsed to two; one new
+  insight noted.
+
+### Build verification
+
+Not attempted. Documentation-only session; no Lean files modified, so build
+is unnecessary. Pre-existing 1+1 sorries (`HurwitzTheorem.lean:1937`,
+`HurwitzOnlyIf.lean:111`) and 0+0 axioms unchanged.
+
+### Next steps
+
+1. **Watch Mathlib for crit-F.** Periodically grep mathlib4 master for any
+   theorem with signature near `finrank ℝ _ ∈ ({1, 2, 4} : Set ℕ)` or referring
+   to "Frobenius" + "real" + "division".
+2. **Consider an upstream Mathlib contribution.** With the now-available
+   Wedderburn–Artin, a Mathlib PR adding `frobenius_theorem_real_division_ring`
+   (the *only* missing piece) would unblock both this gallery sorry and
+   countless downstream applications. Estimated effort ~300-500 lines via
+   the imaginary-subspace argument; feasible as a multi-session research
+   project once a contributor takes it on.
+3. **Do NOT** submit either sorry to Aristotle — both are OPEN and require
+   genuine missing infrastructure, not routine lemma closure.
+
+### References (new this session)
+
+- `Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` — Junyan Xu, 2025
+  (merged via #23583 / #23963 / #24119 / #24192 sequence). Filename and theorem
+  names verified via `gh api repos/leanprover-community/mathlib4/contents/...`.
+- `Mathlib/RingTheory/SimpleModule/IsAlgClosed.lean` — Junyan Xu, 2025; sibling
+  file giving the algebraically-closed-field specialization.
+
+---

--- a/research/problems/hurwitz-theorem-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-wip-01/state.md
@@ -2,98 +2,123 @@
 
 ## Current State
 
-**Phase**: PARK (BLOCKED, awaiting Mathlib upstream)
+**Phase**: PARK (still BLOCKED, but with a sharper, one-step blocker)
 **Path**: full
-**Since**: 2026-05-08T03:35:00Z
-**Iteration**: 3
+**Since**: 2026-05-08T07:30:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-Iteration 3 (PARK): re-confirm BLOCKED status. No relevant Mathlib upstream
-movement since S2 (2026-05-07): a search for Clifford structure
-classification, Frobenius theorem, and Bott periodicity in mathlib4 master
-returns no new APIs. The two open sorries (`HurwitzTheorem.lean:1937`,
-`HurwitzOnlyIf.lean:111`) remain blocked on the same Cl(0,n-1) classification
-gap.
+Iteration 4 (PARK): re-survey Mathlib master for upstream movement. **Important
+correction**: Wedderburn–Artin for general rings (and finite-dim algebras over
+an arbitrary base ring) **is now in Mathlib** as
+`Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` (Junyan Xu, 2025). Prior
+state.md / JSON listed Artin-Wedderburn as a primary blocker; that bullet is
+no longer accurate.
+
+The remaining blocker collapses to **a single Mathlib-level missing theorem**:
+the **classical Frobenius theorem for real division algebras** (every
+finite-dimensional associative division algebra over ℝ has `finrank ∈ {1, 2, 4}`,
+i.e., is ℝ, ℂ, or ℍ). With Wedderburn–Artin already available, Frobenius
+alone suffices to pin down the `D` in the `Cl(0, n-1) ≅ M_d(D)` decomposition,
+which closes both open sorries (`HurwitzTheorem.lean:1937`,
+`HurwitzOnlyIf.lean:111`).
 
 ## Active Approach
 
-**Wait** — until Mathlib gains Clifford structure / Bott periodicity API.
+**Wait** — until Mathlib gains a Frobenius-for-real-division-algebras theorem
+or an InnerProductSpace-from-NormedDivisionRing construction. See "Unblock
+Criteria" for concrete trigger conditions.
 
 ## Attempt Count
 
-- Total attempts: 2
+- Total attempts: 4
 - Approaches tried:
-  1. (S2) OBSERVE / SURVEY: enumerate proved infrastructure, classify what's
-     left, identify Mathlib gap precisely.
-  2. (S3 — this session) Re-confirm BLOCKED + correct the S2 cost estimate
+  1. (S2, prior session) OBSERVE / SURVEY: enumerate proved infrastructure,
+     classify what's left, identify Mathlib gap precisely.
+  2. (S3, prior session) Re-confirm BLOCKED + correct S2 cost estimate
      for option B (refactor): the "~80 lines" estimate misjudged the
-     bridge construction (see Blockers item 4 below).
+     bridge construction.
+  3. (S4, this session) Mathlib re-survey: discovered Wedderburn–Artin
+     **already landed**; pruned blocker list; sharpened the unblock
+     criteria to a two-bullet wishlist (Frobenius theorem OR
+     `InnerProductSpace`-from-`NormedDivisionRing`).
 
-## Blockers
+## Blockers (revised after S4)
 
-1. Mathlib has no real Clifford algebra periodicity / structure classification.
-2. Mathlib has no Artin-Wedderburn for real semisimple algebras.
-3. No minimum-faithful-real-rep-dimension lemma derivable from current
-   `Mathlib.LinearAlgebra.CliffordAlgebra.*` (which only provides the universal
-   property and basic conjugation).
-4. **S2 cost re-estimate**: option B (algebra-level refactor of
-   `HurwitzOnlyIf.hurwitz_only_if_ring`) is not "~80 lines" as previously
-   stated. The bridge `NormedDivisionRing → NSquareIdentity` requires an
-   inner product on A so that the L²-norm of coordinate vectors matches the
-   division-algebra norm. Concretely, the bridge needs either:
-   - **(B1)** Construct an `InnerProductSpace ℝ A` from the multiplicative
-     norm. *Not* automatic: a general normed ℝ-vector space need not be inner
-     product. For a finite-dim normed associative division algebra this is
-     true (it's part of the classical Frobenius proof: Re(a) := (a + ā)/2,
-     ⟨a,b⟩ := (Re(ab*) something equivalent)) but the construction is itself
-     ~200-300 lines and is not in Mathlib v4.26.0.
-   - **(B2)** Choose any basis, work with the resulting non-standard
-     positive-definite quadratic form on `Fin n → ℝ`, diagonalize it, then
-     transfer multiplication. Adds change-of-basis machinery and makes the
-     resulting `NSquareIdentity` non-canonical. Estimated 150-250 lines plus
-     a `Matrix.PosDef.diagonalize` API that may need to be built.
-5. **(B3) Frobenius alternative**: For `NormedDivisionRing` (associative),
-   the stronger Frobenius theorem (`finrank ∈ {1, 2, 4}`) suffices, but the
-   classical Frobenius proof goes through the same Clifford algebra route or
-   via the imaginary subspace construction (V = {a : a² ≤ 0}). Mathlib has
-   *neither*. arXiv:2405.01876 (May 2024) is a recent paper formalizing
-   Frobenius in a non-Mathlib system; not yet ported.
+1. **Frobenius theorem for real division algebras** — not in Mathlib v4.26.0.
+   The `Frobenius`-named files cover Galois-element Frobenius, char-p ring
+   endomorphisms, and Witt-vector Frobenius — none give the
+   real-division-algebra theorem.
+2. **InnerProductSpace from NormedDivisionRing** — not in Mathlib (the
+   imaginary-subspace polarization construction is absent).
+3. **Bott periodicity for real Clifford algebras** — still not in Mathlib;
+   most recent `Mathlib/LinearAlgebra/CliffordAlgebra/` change is
+   2026-05-01 (chore-only).
+
+(Removed from prior list: "Artin-Wedderburn for real semisimple algebras" —
+**now available** in `Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean`.)
 
 ## Next Action
 
-1. **(option D, current)** Wait for Mathlib upstream. Periodically re-check
-   `Mathlib.LinearAlgebra.CliffordAlgebra.*` for `equivOfPeriodicity` /
-   structure-classification lemmas, and `Mathlib.Algebra.Algebra.Basic`
-   for a Frobenius-type theorem.
+1. **(option D, current)** Wait for Mathlib upstream. Specifically watch for
+   any of:
+   - A theorem with conclusion `finrank ℝ D ∈ ({1, 2, 4} : Set ℕ)` for finite-
+     dim associative division algebras.
+   - An `InnerProductSpace ℝ A` instance derivable from `NormedDivisionRing A`
+     and `FiniteDimensional ℝ A`.
+   - Any new file under `Mathlib/LinearAlgebra/CliffordAlgebra/` named
+     `Periodicity` or `RealClassification`.
 
-2. **(option B, deferred)** If a contributor takes on the bridge
-   construction (~200-500 lines), it splits into two natural Mathlib PRs:
-   (i) `InnerProductSpace ℝ A` from `NormedDivisionRing` + finite-dim
-   (Frobenius-style imaginary-subspace argument); (ii) the
-   `nsquareIdentity_of_normedDivisionRing` bridge using that inner product.
+2. **(option C, NEW)** Open a Mathlib RFC / draft PR proposing
+   `frobenius_theorem_real_division_ring`. With the Wedderburn–Artin API
+   now present, this is the *single* missing piece for completing Hurwitz.
+   Estimated ~300-500 lines via the classical imaginary-subspace argument.
+   References: arXiv:2405.01876 (Frobenius theorem formalized in Coq, May
+   2024 — natural source for translation).
 
-3. **(option A, deferred)** Small-case decomposition for n=6, 10. Still
-   ~400 lines/case via ad-hoc Wedderburn structure of Cl(0,5), Cl(0,9).
-   Narrows but does not eliminate the open sorry.
+3. **(option A, deferred)** Small-case decomposition for n=6, 10. Cost
+   reduced from ~400 to ~250 lines/case using the new Wedderburn–Artin
+   API; still leaves the open sorry's general case unhandled and requires
+   ad-hoc identification of `D` for each `Cl(0, 2k-1)`.
 
-4. **(do NOT)** Submit to Aristotle. Sorry is OPEN (genuine missing
-   infrastructure), not a routine lemma.
+4. **(option B, deferred)** Algebra-level refactor of
+   `HurwitzOnlyIf.hurwitz_only_if_ring`. Still blocked on the
+   `InnerProductSpace`-from-`NormedDivisionRing` construction.
 
-## Unblock Criteria (concrete)
+5. **(do NOT)** Submit to Aristotle. Both sorries are OPEN (genuine missing
+   infrastructure), not routine lemmas.
 
-Promote phase from PARK back to ACT when **any** of the following lands in
-mathlib4 master:
+## Unblock Criteria (concrete, revised)
 
-- `Mathlib.LinearAlgebra.CliffordAlgebra.Periodicity` with an isomorphism
-  `Cl(0, n+8) ≅ Cl(0, n) ⊗[ℝ] M(16, ℝ)` (or signed-degree analogue).
-- `Mathlib.LinearAlgebra.CliffordAlgebra.RealClassification` with a
-  Wedderburn-style structure theorem listing `Cl(0, k)` for `k = 0..7`.
-- A Mathlib `frobenius_theorem` for finite-dim normed associative real
-  division algebras, asserting `finrank ℝ A ∈ {1, 2, 4}`.
-- Any one of the above plus a `RingHom.injective` / faithful representation
-  lemma giving a lower bound on the simple-module dimension.
+Promote phase from PARK back to ACT when **either** of the following lands
+in mathlib4 master:
 
-When any of these lands, reopen and proceed with option B (~80 line glue
-once the upstream API exists) or directly close `HurwitzTheorem.lean:1937`
-via the new periodicity API.
+- **(crit-F)** A theorem in `Mathlib.Algebra.*` or
+  `Mathlib.Analysis.NormedSpace.*` with conclusion
+  `∀ D : Type*, [DivisionRing D] [Algebra ℝ D] [FiniteDimensional ℝ D] →
+   finrank ℝ D ∈ ({1, 2, 4} : Set ℕ)` (or equivalent: an
+  `AlgEquiv` to one of `ℝ`, `ℂ`, `Quaternion ℝ`).
+- **(crit-IPS)** An `InnerProductSpace ℝ A` instance / theorem derivable from
+  `NormedDivisionRing A` plus `FiniteDimensional ℝ A` (the imaginary-subspace
+  polarization construction).
+
+Either suffices: `crit-F` + already-available Wedderburn–Artin closes the
+sorry directly; `crit-IPS` enables the option-B refactor.
+
+## References
+
+- `Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` — **landed**;
+  `IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite F R` is the
+  workhorse for option A and for any ad-hoc structural argument on
+  `Cl(0, n-1)`.
+- `Mathlib/RingTheory/SimpleModule/IsAlgClosed.lean` — sibling file with
+  the algebraically-closed-field specialization (over ℂ).
+- `Mathlib/LinearAlgebra/CliffordAlgebra/{Basic,Equivs,...}` — universal
+  property and conjugation only; **no** structural classification.
+- arXiv:2405.01876 — Frobenius theorem formalization (Coq, 2024); reference
+  for a future Mathlib contribution.
+- `proofs/Proofs/HurwitzTheorem.lean:1937` — the open sorry (even
+  n ∉ {2, 4, 8}).
+- `proofs/Proofs/HurwitzOnlyIf.lean:111` — parallel open sorry
+  (`hurwitz_only_if_ring`).

--- a/src/data/research/problems/hurwitz-theorem-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-wip-01.json
@@ -30,24 +30,23 @@
   },
   "currentState": {
     "phase": "PARK",
-    "since": "2026-05-08T03:35:00Z",
-    "iteration": 3,
-    "focus": "PARK: re-confirmed BLOCKED. No relevant Mathlib master changes since S2 (Cl periodicity / Frobenius / Wedderburn for real semisimple algebras still absent). Recorded a corrected cost estimate for option B: the bridge NormedDivisionRing -> NSquareIdentity is NOT ~80 lines because it requires constructing an InnerProductSpace from the multiplicative norm (~200-300 lines, itself a Frobenius-style argument).",
+    "since": "2026-05-08T07:30:00Z",
+    "iteration": 4,
+    "focus": "S4 mathlib re-survey corrects a key entry in the prior blockers list: Wedderburn-Artin (general rings, and finite-dim algebras over an arbitrary base ring) is now in Mathlib master as Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean (Junyan Xu, 2025), via IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite. Specializing to base ring R, this gives Cl(0,n-1) ~= M_d(D) with D finite-dim over R. The remaining blocker collapses to a single missing theorem: the classical Frobenius theorem (real div algebras D in {R, C, H}). With Frobenius, Wedderburn pins D down and the Hurwitz sorry closes; without it, D cannot be identified.",
     "blockers": [
-      "Mathlib has no classification of real Clifford algebras Cl(0,n-1) (Bott periodicity).",
-      "Mathlib has no Artin-Wedderburn structure theorem usable to compute the minimum faithful real representation dimension of a real semisimple algebra.",
-      "Mathlib has no Frobenius theorem for finite-dim normed associative real division algebras (alternative path that would handle hurwitz_only_if_ring directly).",
-      "Bridge NormedDivisionRing -> NSquareIdentity n requires either an InnerProductSpace structure on A (not in Mathlib) or quadratic-form diagonalization machinery (not in Mathlib) -- so option B is also blocked, not the previously estimated ~80 lines of glue."
+      "Mathlib has no classical Frobenius theorem for real division algebras (finite-dim assoc div algebra over R has finrank in {1,2,4}). 'Frobenius' files in Mathlib cover Galois Frobenius, char-p ring endomorphisms, Witt vectors -- none give the real-division-algebra theorem.",
+      "Mathlib has no InnerProductSpace-from-NormedDivisionRing construction (imaginary-subspace polarization). Blocks option B (HurwitzOnlyIf refactor).",
+      "Mathlib has no real-Clifford-periodicity / Cl(0,k) structure classification. Most recent Mathlib/LinearAlgebra/CliffordAlgebra/ change is 2026-05-01, chore-only."
     ],
-    "nextAction": "Wait for Mathlib upstream. Periodically re-check Mathlib.LinearAlgebra.CliffordAlgebra.* for periodicity/structure-classification lemmas and Mathlib.Algebra.Algebra.* for a Frobenius theorem. See unblockCriteria for concrete trigger conditions.",
+    "nextAction": "Wait for Mathlib upstream OR open an upstream Mathlib RFC / draft PR proposing frobenius_theorem_real_division_ring -- with Wedderburn-Artin now present, Frobenius is the SINGLE missing piece. Estimated ~300-500 lines via the classical imaginary-subspace argument; arXiv:2405.01876 (Frobenius formalization in Coq, May 2024) is the natural reference. See unblockCriteria for the two concrete trigger conditions.",
     "attemptCounts": {
-      "total": 2,
+      "total": 4,
       "currentApproach": 0,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED (PARK), iteration 3. HurwitzTheorem.lean has a single sorry (line 1937) for even n notin {2,4,8}. All structural infrastructure is in place: crossMat_anticommute proves that an NSquareIdentity n yields n-1 anti-commuting orthogonal n x n real matrices M_j with M_j^2 = -I, i.e., a real n-dim representation of Cl(0,n-1). Closing the sorry requires the Clifford structure theorem (Bott periodicity for real Cl(0,k)) plus a minimum-rep-dim bound, neither of which is in Mathlib v4.26.0. HurwitzOnlyIf.lean has a parallel sorry for hurwitz_only_if_ring (the NormedDivisionRing formulation). 0 axioms in either file. S3 added: the previously-estimated ~80-line option-B refactor is itself blocked because the bridge NormedDivisionRing -> NSquareIdentity needs an InnerProductSpace structure derived from the multiplicative norm, which is itself a Frobenius-style construction (~200-300 lines) and not in Mathlib.",
+    "progressSummary": "BLOCKED (PARK), iteration 4. HurwitzTheorem.lean has a single sorry (line 1937) for even n notin {2,4,8}. All structural infrastructure is in place: crossMat_anticommute proves that an NSquareIdentity n yields n-1 anti-commuting orthogonal n x n real matrices M_j with M_j^2 = -I, i.e., a real n-dim representation of Cl(0,n-1). HurwitzOnlyIf.lean has a parallel sorry for hurwitz_only_if_ring. 0 axioms in either file. S4 (this session) corrects a key prior blocker entry: Wedderburn-Artin is NOW IN MATHLIB master (Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean, Junyan Xu 2025). With it, Cl(0,n-1) ~= M_d(D) is provable for some finite-dim real div algebra D. The remaining blocker is sharper and lower-dim: the classical Frobenius theorem (D in {R, C, H}) is the SINGLE missing Mathlib piece. arXiv:2405.01876 (Frobenius in Coq, May 2024) is the natural reference for an upstream Mathlib contribution.",
     "builtItems": [],
     "insights": [
       "All the linear algebra that the impossibility proof needs is already done in HurwitzTheorem.lean. The blocker is purely a Clifford-algebra structure theorem — there is no remaining 'analysis' or 'matrix' work to do at the gallery level.",
@@ -56,13 +55,13 @@
       "S2 underestimated option B: the 'orthonormal basis -> NSquareIdentity n' bridge is NOT ~80 lines of glue. The L^2-norm of coordinate vectors equals ||sum a_i e_i||_A only when the basis is orthonormal, which requires an inner product on A. NormedDivisionRing alone does NOT give an inner product (a multiplicative norm is not automatically derived from an inner product on the underlying vector space). The bridge therefore needs first to construct an InnerProductSpace structure on A, which is a Frobenius-style argument (imaginary subspace V = {a : a^2 <= 0}, polarization identity) of roughly 200-300 lines that is itself absent from Mathlib.",
       "Frobenius alternative: NormedDivisionRing is associative, so for hurwitz_only_if_ring the stronger Frobenius theorem (finrank in {1,2,4}) suffices. But the classical Frobenius proof goes through the same Clifford / imaginary-subspace machinery, which is why the two open sorries collapse to the same blocker. arXiv:2405.01876 (May 2024) formalizes Frobenius in a non-Mathlib system; not yet ported.",
       "Mathlib's Mathlib.LinearAlgebra.CliffordAlgebra.* (as of v4.26.0) provides the universal property and basic conjugation, but does NOT provide the periodicity/structure classification needed here (search Mathlib for 'CliffordAlgebra equivalent matrix' confirms no decomposition theorems).",
-      "The companion gallery entry hurwitz-theorem (badge='wip', sorries=1) sits on this exact blocker; closing it would graduate that entry to verified."
+      "The companion gallery entry hurwitz-theorem (badge='wip', sorries=1) sits on this exact blocker; closing it would graduate that entry to verified.",
+      "S4 update (2026-05-08): Wedderburn-Artin (general, finite-dim algebras over arbitrary base ring) IS NOW IN MATHLIB MASTER (Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean, Junyan Xu 2025). The prior blocker list incorrectly listed it as missing. Concretely: IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite gives R ~= M_d(D) for finite-dim simple Artinian R-algebras over an arbitrary base ring; specialized to base R, this gives Cl(0,n-1) ~= M_d(D) for some D finite-dim over R. The unblock criterion narrows: Frobenius theorem (D in {R, C, H}) is now the SINGLE missing piece for a general closure of the sorry."
     ],
     "mathlibGaps": [
-      "Real Clifford algebra periodicity: Cl(0,n+8) ~= Cl(0,n) tensor M_{16}(R).",
-      "Artin-Wedderburn for real semisimple algebras: A ~= prod_i M_{n_i}(D_i), D_i in {R, C, H}.",
-      "Minimum-faithful-real-representation-dimension lemma for real semisimple algebras (lower bound on simple module dimension).",
-      "(Equivalent path) Atiyah's K-theory proof via Bott periodicity for KO-theory of S^{n-1}: requires KO-theory of spheres + parallelizability obstruction, which is even further from Mathlib's current scope."
+      "Classical Frobenius theorem for real division algebras: every finite-dim associative division algebra over R has finrank in {1,2,4} (equivalently, AlgEquiv to one of R, C, H). This is the SINGLE remaining missing piece given that Wedderburn-Artin is now available.",
+      "InnerProductSpace-from-NormedDivisionRing construction (imaginary-subspace polarization). Needed for option B (HurwitzOnlyIf refactor). Not in Mathlib v4.26.0.",
+      "Real Clifford algebra periodicity: Cl(0,n+8) ~= Cl(0,n) tensor M_{16}(R). Not strictly necessary if Frobenius is available, but useful for a uniform argument."
     ],
     "nextSteps": [
       "Decomposition option A (small cases): introduce private lemma `no_six_square_identity` and `no_ten_square_identity` covering the next two even cases via ad-hoc Cl(0,5), Cl(0,9) Wedderburn structure (hand-coded if needed). Localizes the open sorry to 'even n >= 12 with n notin {16}'. ~400 lines per case.",
@@ -72,10 +71,8 @@
       "Aristotle option E: do NOT submit. The sorry is OPEN (genuinely missing infrastructure), not a routine lemma — Aristotle is the wrong tool."
     ],
     "unblockCriteria": [
-      "Mathlib gains `Mathlib.LinearAlgebra.CliffordAlgebra.Periodicity` with an isomorphism `Cl(0, n+8) ≅ Cl(0, n) ⊗[ℝ] M(16, ℝ)`.",
-      "Mathlib gains `Mathlib.LinearAlgebra.CliffordAlgebra.RealClassification` with a Wedderburn-style structure theorem for `Cl(0, k)`, k = 0..7.",
-      "Mathlib gains a `frobenius_theorem` for finite-dim normed associative real division algebras, asserting `finrank ℝ A ∈ {1, 2, 4}`.",
-      "Mathlib gains an `InnerProductSpace`-from-`NormedDivisionRing` instance / theorem (Frobenius-style polarization argument)."
+      "(crit-F) Mathlib gains a Frobenius theorem for real division algebras, with conclusion forall (D : Type*), [DivisionRing D] [Algebra R D] [FiniteDimensional R D] -> finrank R D in ({1,2,4} : Set N) (or equivalent: AlgEquiv to one of R, C, Quaternion R). Combined with the now-available Wedderburn-Artin, this suffices to close the sorry.",
+      "(crit-IPS) Mathlib gains an InnerProductSpace R A instance / theorem derivable from NormedDivisionRing A plus FiniteDimensional R A (the imaginary-subspace polarization construction). Enables option B (HurwitzOnlyIf refactor)."
     ]
   },
   "tags": [
@@ -106,11 +103,13 @@
       "Mathlib.Algebra.Quaternion (Quaternion.normSq_mul, used for n=4 existence).",
       "Mathlib.Analysis.Normed.Algebra.GelfandMazur (NormedAlgebra.Real.nonempty_algEquiv_or, used in HurwitzOnlyIf.hurwitz_field_case).",
       "Mathlib.LinearAlgebra.CliffordAlgebra.Basic (universal property; does NOT include periodicity/structure classification as of v4.26.0).",
-      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic (Matrix.det, used in no_odd_nsquare)."
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic (Matrix.det, used in no_odd_nsquare).",
+      "Mathlib.RingTheory.SimpleModule.WedderburnArtin (NEW, Junyan Xu 2025): IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite gives R ~= M_d(D) for finite-dim simple Artinian R-algebras. Specialized to base R, this provides Cl(0,n-1) structure decomposition pending only an identification of D.",
+      "Mathlib.RingTheory.SimpleModule.IsAlgClosed (NEW): Wedderburn-Artin specialized to algebraically closed base fields (over C). Less directly useful for the real Hurwitz problem, but a model for the missing real-base specialization."
     ]
   },
   "started": "2026-05-06T14:18:33.487Z",
-  "lastUpdate": "2026-05-08T03:35:00Z",
+  "lastUpdate": "2026-05-08T07:30:00Z",
   "significance": 7,
   "tractability": 3
 }


### PR DESCRIPTION
## Summary

Session 4 of `hurwitz-theorem-wip-01`. Documentation-only re-survey of
Mathlib master. **Headline finding**: Wedderburn–Artin is now in Mathlib
master as `Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` (Junyan Xu,
2025). Prior state.md / JSON listed Artin–Wedderburn for real semisimple
algebras as a primary blocker — **that bullet is no longer accurate**.

The remaining blocker collapses to a **single missing Mathlib theorem**: the
classical Frobenius theorem for real division algebras (`finrank ℝ D ∈ {1,2,4}`
for finite-dim associative D over ℝ). Combined with the now-available
Wedderburn–Artin, Frobenius alone closes the open Hurwitz sorry — without it,
the `D` in `Cl(0,n-1) ≅ M_d(D)` cannot be pinned down.

## Mathlib survey results (2026-05-08)

| Need | Status |
|------|--------|
| Wedderburn–Artin (general / arbitrary base ring) | **NOW IN MATHLIB** — `Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` |
| Wedderburn–Artin over algebraically closed fields | **IN MATHLIB** — sibling `IsAlgClosed.lean` |
| Frobenius for real division algebras (D ∈ {ℝ, ℂ, ℍ}) | **NOT in Mathlib v4.26.0** — `Frobenius` files cover only Galois Frobenius, char-p, Witt vectors |
| InnerProductSpace from NormedDivisionRing | **NOT in Mathlib** |
| Real Clifford periodicity / Cl(0,k) classification | **NOT in Mathlib** — last `CliffordAlgebra/` change 2026-05-01, chore-only |

## Revised unblock criteria (was 4 bullets, now 2)

- **(crit-F)** Mathlib gains a Frobenius theorem for real division algebras.
- **(crit-IPS)** Mathlib gains `InnerProductSpace ℝ A` derivable from
  `NormedDivisionRing A` + `FiniteDimensional ℝ A`.

Either suffices: crit-F + Wedderburn–Artin closes the sorry directly;
crit-IPS enables the option-B refactor.

## Forward path

- **Option C (NEW emphasis)**: Open a Mathlib RFC / draft PR proposing
  `frobenius_theorem_real_division_ring`. With Wedderburn–Artin now present,
  Frobenius is the *single* missing piece. arXiv:2405.01876 (Frobenius theorem
  formalized in Coq, May 2024) is the natural reference for translation.
  Estimated ~300–500 lines via the imaginary-subspace argument.
- **Option A (cheaper now)**: Small-case decomposition for n=6, 10. Cost
  reduced ~400 → ~250 lines/case using the new Wedderburn–Artin API; still
  requires per-case identification of D.

## Files changed

- `research/problems/hurwitz-theorem-wip-01/sessions/2026-05-08-s04.md` (new) — full S4 report.
- `research/problems/hurwitz-theorem-wip-01/state.md` — iteration 3 → 4; blocker list reduced from 5 bullets to 3; unblock criteria 4 → 2.
- `src/data/research/problems/hurwitz-theorem-wip-01.json` — `currentState` (iteration 4, focus, blockers, nextAction, attemptCounts), `progressSummary`, new insight, `mathlibGaps` 4 → 3, `unblockCriteria` 4 → 2, two new entries in `references.mathlib`.

## Status

- **Outcome**: progress (sharpened blocker; one bullet pruned)
- **Sorries**: 1 + 1 (unchanged; `HurwitzTheorem.lean:1937`, `HurwitzOnlyIf.lean:111`)
- **Axioms**: 0 + 0 (unchanged)
- **Build verification**: not attempted (documentation-only; no Lean files modified)

## Test plan

- [ ] CI lints/tests pass on documentation-only changes.
- [ ] No build needed (no Lean changes).

🤖 Generated by researcher-10