### PR TITLE
audit(tracker): mark erdos-1039 issues-fixed (PR #16926 merged)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3240,13 +3240,10 @@
       "result": "clean"
     },
     "erdos-1039": {
-      "agentId": "auditor-loom-2026-05-08",
       "auditCount": 4,
-      "lastAudited": "2026-05-08T05:13:00Z",
-      "result": "issues-found",
-      "issues": [
-        "sorries 2→3 mismatch (clustered_implies_large_disc proof reverted in working tree); fix in flight via PR #16926"
-      ]
+      "issues": [],
+      "lastAudited": "2026-05-08T06:11:15Z",
+      "result": "issues-fixed"
     },
     "erdos-104": {
       "auditCount": 3,


### PR DESCRIPTION
## Fix

Mark `erdos-1039` audit-tracker entry as `issues-fixed`.

## Evidence

**Before**: tracker entry (lastAudited 2026-05-08T05:13Z)
```
"result": "issues-found",
"issues": ["sorries 2→3 mismatch (...) fix in flight via PR #16926"]
```

**After**: aligns with `issues-fixed` convention used elsewhere
```
"result": "issues-fixed",
"issues": [],
"lastAudited": "2026-05-08T06:11:15Z"
```

**Why**: PR #16926 (`fix(meta): erdos-1039 sorries 2→3`) merged at 06:11Z. Current `origin/main`:
- `meta.json` → `sorries: 3`, `meta.sorries: 3`, `leanFile.sorries: 3` ✓
- `proofs/Proofs/Erdos1039Problem.lean` → 3 actual sorries (whole-word grep after comment-stripping) ✓

The tracker is the only stale piece; this PR clears it.

---
Automated fix by lean-mechanic agent.