### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-02-oq-01): S10 Layer 1 — tripleCount + zero-iff bridges (build pending)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean
@@ -621,10 +621,94 @@ theorem p_triple_n3_eq_expectedTriples (d : ℕ) (hd : 1 ≤ d) :
   rw [p_triple_n3 d hd]
   simp [expectedTriples, Nat.choose_self]
 
+-- ============================================================
+-- §3. INDICATOR ALGEBRA (Layer 1 of Lemma C roadmap, Session 10)
+-- ============================================================
+
+/-
+  Layer 1 is the foundational step of the four-layer plan in
+  `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/lemma-c-roadmap.md`
+  for discharging `axiom p_no_triple_tendsto` (Lemma C). It introduces the
+  triple-coincidence count `tripleCount d n f` (a Nat-valued sum of indicators
+  over strictly-increasing triples) and proves the two equivalences
+
+    tripleCount d n f = 0 ↔ ∀ i<j<k, ¬(f i = f j = f k)
+                          ↔ ∀ pairwise-distinct i,j,k, ¬(f i = f j = f k)
+
+  The second form matches the predicate inside the axiom, so the axiom's
+  no-triple filter equals the `tripleCount = 0` filter (`noTriple_filter_eq_…`).
+
+  Subsequent layers (queued):
+  - Layer 2: `expectedTripleCount_eq` — first moment, general n (PR #16837 partial).
+  - Layer 3: factorial-moment expansion + fusion-pattern bookkeeping (bottleneck).
+  - Layer 4: Method of Factorial Moments (Mathlib upstream candidate).
+-/
+
+/-- Triple-coincidence count: number of strictly-increasing triples `(i,j,k)`
+    in `Fin n × Fin n × Fin n` for which `f i = f j = f k`. The random variable
+    `X_d := tripleCount d n f` is exactly the sum of indicators
+    `Σ_{i<j<k} 𝟙{f i = f j = f k}` whose factorial moments drive the Method of
+    Factorial Moments approach to Lemma C. -/
+def tripleCount (d n : ℕ) (f : Fin n → Fin d) : ℕ :=
+  (Finset.univ.filter (fun t : Fin n × Fin n × Fin n =>
+    t.1 < t.2.1 ∧ t.2.1 < t.2.2 ∧ f t.1 = f t.2.1 ∧ f t.2.1 = f t.2.2)).card
+
+/-- Strict-inequality form of `tripleCount = 0 ↔ no triple`. Direct from the
+    definition; the only content is the empty-filter ↔ universal-negation
+    correspondence. -/
+lemma tripleCount_eq_zero_iff_strict (d n : ℕ) (f : Fin n → Fin d) :
+    tripleCount d n f = 0 ↔
+      ∀ i j k : Fin n, i < j → j < k → ¬(f i = f j ∧ f j = f k) := by
+  rw [tripleCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  refine ⟨?_, ?_⟩
+  · intro h i j k hij hjk hf
+    exact h (Finset.mem_univ ⟨i, j, k⟩) ⟨hij, hjk, hf.1, hf.2⟩
+  · intro h ⟨i, j, k⟩ _ ⟨hij, hjk, hfij, hfjk⟩
+    exact h i j k hij hjk ⟨hfij, hfjk⟩
+
+/-- Distinct-pairs form of `tripleCount = 0 ↔ no triple`. This is the form
+    matching the axiom `p_no_triple_tendsto`'s no-triple predicate. The
+    forward direction does the case-split sorting `(i, j, k)` into a strictly
+    increasing triple — six orderings, each preserving the symmetric predicate
+    `f a = f b ∧ f b = f c`. -/
+lemma tripleCount_eq_zero_iff_no_triple (d n : ℕ) (f : Fin n → Fin d) :
+    tripleCount d n f = 0 ↔
+      ∀ i j k : Fin n, i ≠ j → j ≠ k → i ≠ k →
+        ¬(f i = f j ∧ f j = f k) := by
+  rw [tripleCount_eq_zero_iff_strict]
+  refine ⟨?_, ?_⟩
+  · intro h i j k hij hjk hik hf
+    have hfik : f i = f k := hf.1.trans hf.2
+    rcases lt_or_gt_of_ne hij with h_ij | h_ij
+    · rcases lt_or_gt_of_ne hjk with h_jk | h_jk
+      · exact h i j k h_ij h_jk hf
+      · rcases lt_or_gt_of_ne hik with h_ik | h_ik
+        · exact h i k j h_ik h_jk ⟨hfik, hf.2.symm⟩
+        · exact h k i j h_ik h_ij ⟨hfik.symm, hf.1⟩
+    · rcases lt_or_gt_of_ne hjk with h_jk | h_jk
+      · rcases lt_or_gt_of_ne hik with h_ik | h_ik
+        · exact h j i k h_ij h_ik ⟨hf.1.symm, hfik⟩
+        · exact h j k i h_jk h_ik ⟨hf.2, hfik.symm⟩
+      · exact h k j i h_jk h_ij ⟨hf.2.symm, hf.1.symm⟩
+  · intro h i j k hij hjk hf
+    have hik : i < k := lt_trans hij hjk
+    exact h i j k (ne_of_lt hij) (ne_of_lt hjk) (ne_of_lt hik) hf
+
+/-- The axiom's no-triple filter equals the `tripleCount = 0` filter on
+    `Fin n → Fin d`. Bridges the axiom statement to the `tripleCount`-indexed
+    factorial-moment framework that Layer 3 will analyse. -/
+lemma noTriple_filter_eq_tripleCount_zero_filter (d n : ℕ) :
+    (Finset.univ.filter (fun f : Fin n → Fin d =>
+      ∀ i j k : Fin n, i ≠ j → j ≠ k → i ≠ k →
+        ¬(f i = f j ∧ f j = f k))) =
+    (Finset.univ.filter (fun f : Fin n → Fin d => tripleCount d n f = 0)) := by
+  ext f
+  simp [tripleCount_eq_zero_iff_no_triple]
+
 /-
   ## Summary
 
-  **Proved (15 theorems, 1 axiom):**
+  **Proved (18 theorems / lemmas, 1 axiom):**
   1. `choose3_ub`/`choose3_lb`: C(n,3) ∈ [(n-2)³/6, n³/6]
   2. `asympThreshold_cubed`: (asympThreshold d)³ = 6d² ln 2 (exact characterization)
   3. `asympThreshold_ratio`: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} (PROVED)
@@ -641,6 +725,13 @@ theorem p_triple_n3_eq_expectedTriples (d : ℕ) (hd : 1 ≤ d) :
   14. `p_triple_n3` (Session 7): P(triple|n=3) = 1/d² as a real number
   15. `p_triple_n3_eq_expectedTriples` (Session 7): n=3 first-moment identity
       P(triple|n=3) = expectedTriples 3 d (Markov is tight at n=3 since X_d ≤ 1)
+  16. `tripleCount_eq_zero_iff_strict` (Session 10, Layer 1): X_d = 0 ↔ no
+      strictly-increasing triple coincidence.
+  17. `tripleCount_eq_zero_iff_no_triple` (Session 10, Layer 1): X_d = 0 ↔ no
+      pairwise-distinct triple coincidence (matches axiom predicate; six-case
+      sorting argument).
+  18. `noTriple_filter_eq_tripleCount_zero_filter` (Session 10, Layer 1): the
+      axiom's no-triple filter equals `{f | tripleCount d n f = 0}`.
 
   **Axioms (1):** `p_no_triple_tendsto` (Lemma C) — pure Poisson limit:
     P_no_triple(n_c(d), d) → exp(-c³/6) (Lemma A+B proved; `poisson_approx_birthday3` derived from B+C)
@@ -663,5 +754,8 @@ theorem p_triple_n3_eq_expectedTriples (d : ℕ) (hd : 1 ≤ d) :
 #check @p_no_triple_n3
 #check @p_triple_n3
 #check @p_triple_n3_eq_expectedTriples
+#check @tripleCount
+#check @tripleCount_eq_zero_iff_no_triple
+#check @noTriple_filter_eq_tripleCount_zero_filter
 
 end BirthdayThreshold3

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
@@ -4,17 +4,19 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-29T00:00:00Z
-**Iteration**: 9
-**Last Update**: 2026-05-08 (Session 9, researcher-6)
+**Iteration**: 10
+**Last Update**: 2026-05-08 (Session 10, researcher-11)
 
 ## Current Focus
 Sessions 1–8 established the framework (Lemmas A, B; n=3,4 first-moment forms;
-canonical-triple count at n=4). Session 9 adds `lemma-c-roadmap.md`, a 4-layer
-plan for discharging the axiom: (1) indicator algebra, (2) general-n first
-moment, (3) factorial moments via fusion-pattern decomposition, (4) Method of
-Factorial Moments theorem. Roadmap inventories Mathlib 4.26 and master
-(`PoissonLimitThm` post-pin) and recommends Path C: contribute Layer 4 upstream
-to Mathlib while building Layers 1–3 locally. Next sessions implement Layer 1.
+canonical-triple count at n=4). Session 9 added `lemma-c-roadmap.md`, the
+four-layer plan. **Session 10 implements Layer 1** (≈ 95 lines): definition
+`tripleCount d n f` (sum-of-indicators count over strictly-increasing triples)
+plus the two zero-iff equivalences (strict-inequality form and pairwise-distinct
+form, the latter matching the axiom predicate via a six-case sorting argument)
+and the filter-equality lemma `noTriple_filter_eq_tripleCount_zero_filter`
+that bridges the axiom's no-triple filter to `{f | tripleCount d n f = 0}`.
+Layer 2 (general-n first moment) is queued for S11.
 
 ## Active Approach
 Decomposition strategy:
@@ -31,8 +33,18 @@ First-moment scaffolding (Sessions 6–8, on main / open PRs):
 - `bad_count_n4_canonical`, `p_canonical_triple_n4` (Session 8 PR #16873):
   n=4 canonical triple count and probability
 
+Layer 1 (Session 10, this session — DONE pending build):
+- `tripleCount d n f` def (≈ 4 lines): card of strictly-increasing triples
+  with `f i = f j = f k`.
+- `tripleCount_eq_zero_iff_strict` (≈ 8 lines): bridges to `Finset.filter`
+  emptiness; trivial direction.
+- `tripleCount_eq_zero_iff_no_triple` (≈ 25 lines): the axiom-matching
+  pairwise-distinct form; six-case sort over linear order of `(i, j, k)`.
+- `noTriple_filter_eq_tripleCount_zero_filter` (≈ 6 lines): filter-level
+  bridge to the axiom's no-triple filter.
+
 Roadmap layers (Session 9, see `lemma-c-roadmap.md`):
-- **Layer 1** (≈ 50 lines): `tripleCount` indicator-algebra definition + zero-iff-no-triple.
+- **Layer 1** (≈ 50 lines target / 95 actual): DONE this session.
 - **Layer 2** (≈ 160 lines): `bad_count_general` (Next Action #1) and
   `expectedTripleCount_eq` (Markov / first-moment, general n).
 - **Layer 3** (≈ 300 lines): factorial-moment expansion; convergence of disjoint
@@ -40,8 +52,8 @@ Roadmap layers (Session 9, see `lemma-c-roadmap.md`):
 - **Layer 4** (≈ 200 lines or upstream): Method of Factorial Moments theorem.
 
 ## Attempt Count
-- Total attempts: 9
-- Current approach attempts: 6 (Sessions 4–9 ACT)
+- Total attempts: 10
+- Current approach attempts: 7 (Sessions 4–10 ACT)
 - Approaches tried: 1 (decomposition into Lemmas A/B/C, with multi-layer Layer-C plan)
 
 ## Blockers
@@ -52,9 +64,9 @@ Roadmap layers (Session 9, see `lemma-c-roadmap.md`):
   verification — non-Lean documentation work (this session) sidesteps the issue.
 
 ## Next Action
-1. **Layer 1 (S10)**: define `tripleCount d n f` and prove `tripleCount = 0 ↔ no triple`.
+1. ✅ **Layer 1 (S10, this session)**: `tripleCount` def + `tripleCount_eq_zero_iff_no_triple` + filter bridge — DONE pending build.
 2. **Layer 2 part 1 (S11)**: `bad_count_general` — per-triple count `d^(n−2)` for distinct i,j,k.
-3. **Layer 2 part 2 (S12)**: `expectedTripleCount_eq` — first-moment identity, general n.
+3. **Layer 2 part 2 (S12)**: `expectedTripleCount_eq` — first-moment identity, general n. Connects `(∑ f, tripleCount d n f) / |Fin n → Fin d| = C(n,3)/d² = expectedTriples n d`.
 4. **Layer 3 (S13–15)**: factorial-moment expansion + fusion-pattern bookkeeping.
 5. **Layer 4 (S16–17)**: Method of Factorial Moments — local proof or apply Mathlib upstream.
 6. **Mathlib upstream (Path C)**: draft `Mathlib/Probability/MomentsConvergence.lean`

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,9 +24,9 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 667,
-    "theoremCount": 30,
-    "definitionCount": 3,
+    "lineCount": 761,
+    "theoremCount": 33,
+    "definitionCount": 4,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
       "asympThreshold_cubed: (asympThreshold d)³ = 6d² ln 2 (PROVED)",
@@ -142,12 +142,12 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 667,
+    "lineCount": 761,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 30,
-    "definitionCount": 3
+    "theoremCount": 33,
+    "definitionCount": 4
   },
   "sorries": 0
 }

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
@@ -32,10 +32,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-06T13:21:41Z",
-    "iteration": 9,
-    "focus": "Session 9 (2026-05-08, researcher-6): added lemma-c-roadmap.md, a 4-layer plan for discharging the Lemma C axiom: (1) indicator algebra ~50 lines, (2) general-n first moment ~160 lines, (3) factorial moments via fusion-pattern decomposition ~300 lines, (4) Method of Factorial Moments theorem ~200 lines (or upstream Mathlib). Total ~600 lines local, or ~360 if Layer 4 lands upstream. Inventoried Mathlib 4.26 (only Poisson PMF/measure constructors) vs master (PoissonLimitThm.lean by Yi Yuan, 2026-03-08, post-pin; binomial→Poisson but does NOT cover dependent indicators). Recommended Path C: upstream contribution for Layer 4 + local Layers 1–3.",
+    "iteration": 10,
+    "focus": "Session 10 (2026-05-08, researcher-11): implemented Layer 1 of the lemma-c-roadmap (~95 lines added to BirthdayProblemOQ03OQ01OQ02.lean, line 624 onward, before Summary block). New definition `tripleCount d n f` (sum-of-indicators count over strictly-increasing triples), plus three lemmas: `tripleCount_eq_zero_iff_strict` (basic Finset.filter form), `tripleCount_eq_zero_iff_no_triple` (axiom-matching distinct-pairs form, six-case sort over linear order of (i,j,k) using lt_or_gt_of_ne), and `noTriple_filter_eq_tripleCount_zero_filter` (filter equality bridging axiom predicate to tripleCount=0). Lean file: 667→761 lines, 30→33 theorems, 3→4 defs. Build status: pending (cold-cache Docker build queued; risk: 32 GB cgroup limit per memory feedback). Layer 2 (general-n first moment, S11) is unblocked by this layer.",
     "blockers": [],
-    "nextAction": "S10: implement Layer 1 (tripleCount + zero-iff-no-triple, ~50 lines). S11: Layer 2 part 1 (bad_count_general, per-triple count d^(n-2) for distinct i,j,k). S12: Layer 2 part 2 (expectedTripleCount_eq, general-n first-moment identity). S13–15: Layer 3 (factorial-moment expansion + fusion-pattern bookkeeping). S16–17: Layer 4 (MoFM theorem — local or upstream-applied). Parallel: Mathlib upstream PR drafting Mathlib/Probability/MomentsConvergence.lean.",
+    "nextAction": "S11: Layer 2 part 1 (bad_count_general — per-triple count d^(n-2) for distinct i,j,k; ≈ 80 lines). Use Finset.card_eq_pow + an explicit bijection between `{f | f i = f j = f k}` and `Fin n → Fin d` restricted to the (n-2) free indices. S12: Layer 2 part 2 (expectedTripleCount_eq — general-n first-moment identity Σ tripleCount / |Fin n → Fin d| = C(n,3)/d²). S13–15: Layer 3 (factorial-moment expansion + fusion-pattern bookkeeping). S16–17: Layer 4 (MoFM theorem — local or upstream-applied). Parallel: Mathlib upstream PR drafting Mathlib/Probability/MomentsConvergence.lean.",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 2,
@@ -58,7 +58,8 @@
       "Session 6 (2026-05-07): repaired 4 Mathlib API drift errors in lambda_tendsto, bad_count_n3, good_count_n3 (introduced upstream after PR #16150 merged on 2026-05-06): tendsto_..._of_le_of_le → primed eventual variant; div_le_div_right → div_le_div_iff_of_pos_right; ← Fintype.card_coe inserted to bridge Finset.card ↔ Fintype.card; explicit predicate passed to filter_card_add_filter_neg_card_eq_card to satisfy DecidablePred synthesis.",
       "Session 7 (2026-05-08, researcher-9): p_triple_n3 in BirthdayProblemOQ03OQ01OQ02.lean (line ~601) — real-number form of bad_count_n3: ((|bad_n=3|) : ℝ) / (d^3 : ℝ) = 1 / d² for d ≥ 1, proved via bad_count_n3, Fintype.card_fun, push_cast, field_simp, ring.",
       "Session 7 (2026-05-08, researcher-9): p_triple_n3_eq_expectedTriples in BirthdayProblemOQ03OQ01OQ02.lean (line ~617) — n=3 first-moment identity P(triple|n=3) = expectedTriples 3 d, proved by p_triple_n3 + simp [expectedTriples, Nat.choose_self]. First explicit connection between `expectedTriples` (analytic) and an actual probability.",
-      "Session 9 (2026-05-08, researcher-6): research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/lemma-c-roadmap.md (~320 lines, 9 sections): axiom statement; why direct binomial→Poisson does not apply (dependent indicators, sharing one index between two triples creates positive correlation); Mathlib 4.26 inventory (only Poisson PMF/measure constructors) vs master (PoissonLimitThm.lean by Yi Yuan, post-v4.26.0; binomial→Poisson convergence); method-of-factorial-moments approach with fusion-pattern decomposition; 4-layer Lean sub-lemma plan with line estimates (Layer 1 ~50, Layer 2 ~160, Layer 3 ~300, Layer 4 ~200); 4 candidate paths A/B/C/D; session sequence S10–S17."
+      "Session 9 (2026-05-08, researcher-6): research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/lemma-c-roadmap.md (~320 lines, 9 sections): axiom statement; why direct binomial→Poisson does not apply (dependent indicators, sharing one index between two triples creates positive correlation); Mathlib 4.26 inventory (only Poisson PMF/measure constructors) vs master (PoissonLimitThm.lean by Yi Yuan, post-v4.26.0; binomial→Poisson convergence); method-of-factorial-moments approach with fusion-pattern decomposition; 4-layer Lean sub-lemma plan with line estimates (Layer 1 ~50, Layer 2 ~160, Layer 3 ~300, Layer 4 ~200); 4 candidate paths A/B/C/D; session sequence S10–S17.",
+      "Session 10 (2026-05-08, researcher-11): Layer 1 implemented in BirthdayProblemOQ03OQ01OQ02.lean §3 (line ~624 onward, before Summary block, ~95 lines). New `def tripleCount (d n : ℕ) (f : Fin n → Fin d) : ℕ` = `Finset.univ.filter (fun t : Fin n × Fin n × Fin n => t.1 < t.2.1 ∧ t.2.1 < t.2.2 ∧ f t.1 = f t.2.1 ∧ f t.2.1 = f t.2.2).card`. Three lemmas: (1) `tripleCount_eq_zero_iff_strict` — i<j<k form, direct from Finset.card_eq_zero + Finset.filter_eq_empty_iff; (2) `tripleCount_eq_zero_iff_no_triple` — pairwise-distinct form (matches axiom predicate), six-case sort using lt_or_gt_of_ne on each of (i,j), (j,k), (i,k); (3) `noTriple_filter_eq_tripleCount_zero_filter` — ext + simp using the previous lemma. File: 667 → 761 lines, 30 → 33 theorems, 3 → 4 defs. Build status: pending (cold-cache Docker queued)."
     ],
     "insights": [
       "JSON `formal` field drifted from actual Lean axiom: JSON claimed quantitative |triple_prob − (1−exp(−λ))| ≤ C·n⁴/d³, but the Lean axiom is qualitative Tendsto along the threshold scaling — discrepancy was the cause of Session 1's BLOCKED conclusion",
@@ -79,7 +80,9 @@
       "Session 7: `expectedTriples` was previously a purely analytic quantity (a definition with no probability content). p_triple_n3_eq_expectedTriples is the first place in the file where it is identified with an actual probability. The identification is exact at n=3 and gives a one-sided Markov bound P(some triple) ≤ expectedTriples n d for general n (not yet formalized, but a clean next building block).",
       "Session 9: PoissonLimitThm.lean (master Mathlib, post-v4.26.0) does NOT discharge Lemma C — it requires independent Bernoulli trials, but the triple-coincidence indicators B_{ijk} are positively correlated (sharing one index between (i,j,k) and (i',j',k') forces both triples to either occur or not, with probability 1/d^4 vs the independence value 1/d^4 — actually equal in this case but the joint moments differ for sharing-2 patterns: 1/d^3 vs 1/d^4 = independence). The binomial limit cannot bridge this gap.",
       "Session 9: fusion-pattern scaling rule. For an ordered r-tuple of distinct triples in [n], let m = |union of indices|, q = number of connected components in the triple-overlap graph. Then the contribution to the r-th factorial moment is O(n^m / d^(m-q)). With n_c(d) ~ c·d^(2/3), this scales as d^(q - m/3). Disjoint pattern (m=3r, q=r): exponent 0, contribution → λ^r. Any pattern with ≥ 1 shared index: q ≤ r-1, m ≤ 3r-1, exponent ≤ -2/3. Non-disjoint patterns vanish at rate O(d^(-2/3)), the disjoint pattern dominates and gives the Poisson limit.",
-      "Session 9: the Method of Factorial Moments theorem (Bollobás §I.3, Janson–Łuczak–Ruciński §6.1) is absent from Mathlib in any form. It is a project-independent, generally-useful lemma (random-graph triangle counts, Erdős–Rényi subgraph counts, hash collisions). Recommended upstream contribution at Mathlib/Probability/MomentsConvergence.lean. ~150–250 lines once descFactorial arithmetic is in place; would benefit many downstream consumers."
+      "Session 9: the Method of Factorial Moments theorem (Bollobás §I.3, Janson–Łuczak–Ruciński §6.1) is absent from Mathlib in any form. It is a project-independent, generally-useful lemma (random-graph triangle counts, Erdős–Rényi subgraph counts, hash collisions). Recommended upstream contribution at Mathlib/Probability/MomentsConvergence.lean. ~150–250 lines once descFactorial arithmetic is in place; would benefit many downstream consumers.",
+      "Session 10: the strict→distinct bridge `tripleCount_eq_zero_iff_no_triple` admits a clean six-case proof: for any pairwise-distinct (i,j,k), `lt_or_gt_of_ne` on each of the three pairs gives 2 × 2 × 2 = 8 cases, of which 2 are inconsistent (e.g. i<j ∧ j<k ∧ k<i is cyclic) and 6 give a strictly-increasing triple after at most one swap. The predicate `f a = f b ∧ f b = f c` is symmetric under permutations of {a,b,c}, so each strictly-increasing rearrangement preserves it after the right .symm/.trans rewrites. Total proof ≈ 25 lines.",
+      "Session 10: `tripleCount` connects directly to the axiom statement: `noTriple_filter_eq_tripleCount_zero_filter` is `ext + simp [tripleCount_eq_zero_iff_no_triple]`. The axiom's count-of-no-triple-functions can be replaced by `Finset.univ.filter (fun f => tripleCount d n f = 0).card`, opening the door to factorial-moment analysis: `(Σ f, [tripleCount = 0]) / |Fin n → Fin d|` is what Layer 4 (Method of Factorial Moments) computes. Layer 2 is now unblocked: with `tripleCount` defined, `expectedTripleCount_eq` is the natural next step (Σ f, tripleCount = C(n,3) · d^(n-2), so dividing by d^n gives C(n,3)/d²)."
     ],
     "mathlibGaps": [
       "Method of factorial moments → Poisson convergence (qualitative form) — not in Mathlib but smaller than Chen-Stein",
@@ -128,7 +131,7 @@
     ]
   },
   "started": "2026-04-21T06:38:17Z",
-  "lastUpdate": "2026-05-08T09:55:00Z",
+  "lastUpdate": "2026-05-08T10:30:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -223,10 +226,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 588,
-      "theoremCount": 26,
+      "lineCount": 761,
+      "theoremCount": 33,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"


### PR DESCRIPTION
## Summary

Session 10 of the [Lemma C roadmap](https://github.com/rjwalters/lean-genius/blob/main/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/lemma-c-roadmap.md). Implements **Layer 1 (indicator algebra)**, the foundational bridge from the axiom's no-triple predicate to the sum-of-indicators random variable `X_d := tripleCount d n f` whose factorial moments drive the Method of Factorial Moments approach.

## What's added

In `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` §3 (new section, line ~624 onward, before the Summary block):

```lean
def tripleCount (d n : ℕ) (f : Fin n → Fin d) : ℕ :=
  (Finset.univ.filter (fun t : Fin n × Fin n × Fin n =>
    t.1 < t.2.1 ∧ t.2.1 < t.2.2 ∧ f t.1 = f t.2.1 ∧ f t.2.1 = f t.2.2)).card

lemma tripleCount_eq_zero_iff_strict     -- ↔ ∀ i<j<k, ¬(f i = f j = f k)
lemma tripleCount_eq_zero_iff_no_triple  -- ↔ ∀ pairwise-distinct i,j,k, ¬(f i = f j = f k)
lemma noTriple_filter_eq_tripleCount_zero_filter
  -- {f | axiom predicate} = {f | tripleCount d n f = 0}
```

The `_strict` form is a one-liner from `Finset.card_eq_zero` + `Finset.filter_eq_empty_iff`. The `_no_triple` form is the axiom-matching version; the forward direction sorts an arbitrary distinct triple `(i,j,k)` into a strictly-increasing rearrangement, exploiting the symmetry of `f a = f b ∧ f b = f c` under permutations of `{a,b,c}` — a six-case split using `lt_or_gt_of_ne` on each pair (i,j), (j,k), (i,k). The filter-equality lemma is `ext + simp [tripleCount_eq_zero_iff_no_triple]`.

## Why this matters

The axiom

```lean
axiom p_no_triple_tendsto (c : ℝ) (hc : 0 < c) : ... → nhds (Real.exp (-(c ^ 3 / 6)))
```

quantifies over the no-triple predicate. With Layer 1, the same probability is `(card {f | tripleCount = 0}) / |Fin n → Fin d|`, which is `P(X_d = 0)` for `X_d := tripleCount`. Layers 2–4 then compute the factorial moments of `X_d` and apply MoFM to get `P(X_d = 0) → exp(-c³/6)`.

**Layer 2 (S11)** is now unblocked: with `tripleCount` in scope, `expectedTripleCount_eq` (`Σ f, tripleCount d n f = C(n,3) · d^(n-2)`) is the natural next step.

## Files

- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean`: 667 → 761 lines (+94); 30 → 33 theorems; 3 → 4 defs.
- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md`: iter 9 → 10, S10 entry, Next-Action checkbox advanced.
- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json`: `lineCount` 667 → 761, `theoremCount` 30 → 33, `definitionCount` 3 → 4 (both `meta.*` and `leanFile.*`).
- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json`: iter 9 → 10; `focus`, `nextAction` refreshed; two new `builtItems` (Session 10 implementation note + leanFiles delta); two new `insights` (six-case sort technique + factorial-moment connection).

## Build status: pending

Cold-cache Docker build is queued in `lean-build-28860` and progressing through Mathlib clone + cache fetch at the time of writing. Following the established convention on this slug (PRs #16873, #16777, #16837 all marked "build pending" under the 32 GB cgroup memory limit), this PR is opened with build verification deferred to a follow-up agent or warm-cache rebuild.

**Static rationale**: the proof uses only `Finset.card_eq_zero`, `Finset.filter_eq_empty_iff`, `lt_or_gt_of_ne`, `ne_of_lt`, `lt_trans`, and core `Eq.trans`/`Eq.symm` — all stable Mathlib 4.26 primitives already exercised in this file (`p_no_triple_n3`, `p_triple_n3`). No new Mathlib API surface; risk of build failure is low.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BirthdayProblemOQ03OQ01OQ02` from a worktree with warm Mathlib cache
- [ ] Confirm the new `def` and three `lemma`s type-check
- [ ] Spot-check the six-case proof — particularly the `j < i` branch sub-cases — picks the correct strict triple and predicate rewrites

## Related

- [Lemma C roadmap](https://github.com/rjwalters/lean-genius/blob/main/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/lemma-c-roadmap.md) §5 Layer 1 (S9, PR #16975, merged)
- Open: PR #16777 (S7 n=3), PR #16837 (S8 expectedTriples linkage), PR #16873 (S8 n=4 canonical) — all build-pending; orthogonal to this Layer 1 addition (different sections of the file)
- Parent axiom: `Proofs/BirthdayProblemOQ03OQ01OQ02.lean:329` `axiom p_no_triple_tendsto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)