### PR TITLE
research(amgm-inequality-oq-04-oq-02): S3 SURVEY — pin down Mathlib derivative-under-integral lemma

### DIFF
--- a/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md
@@ -1,0 +1,173 @@
+## Session 2026-05-08 (Session 3, pre-ACT) — SURVEY: pin down the Mathlib derivative-under-integral lemma
+
+**Mode**: SURVEY (documentation-only orient pass for the upcoming ACT phase)
+**Outcome**: progress (no Lean changes; no sorry/axiom delta).
+
+### Goal
+
+Identify the exact Mathlib API to use for proving `dE/dk = (E - K)/k` (the
+key step on the path to Legendre's relation, per `state.md` Session 3 plan).
+The prior state.md mentioned `MeasureTheory.intervalIntegral.deriv_*` as the
+target family but did not pin down a specific lemma signature.
+
+### Finding (the lemma to use)
+
+**`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`** in
+`Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean`.
+
+Full signature (from mathlib4 master, 2026-05-08):
+
+```lean
+theorem intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le
+    {𝕜 : Type*} [RCLike 𝕜] {μ : Measure ℝ} {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] [NormedSpace 𝕜 E]
+    {F : 𝕜 → ℝ → E} {F' : 𝕜 → ℝ → E} {x₀ : 𝕜} {s : Set 𝕜} {a b : ℝ}
+    {bound : ℝ → ℝ}
+    (hs : s ∈ 𝓝 x₀)
+    (hF_meas : ∀ᶠ x in 𝓝 x₀, AEStronglyMeasurable (F x) (μ.restrict (Ι a b)))
+    (hF_int : IntervalIntegrable (F x₀) μ a b)
+    (hF'_meas : AEStronglyMeasurable (F' x₀) (μ.restrict (Ι a b)))
+    (h_bound : ∀ᵐ t ∂μ, t ∈ Ι a b → ∀ x ∈ s, ‖F' x t‖ ≤ bound t)
+    (bound_integrable : IntervalIntegrable bound μ a b)
+    (h_diff : ∀ᵐ t ∂μ, t ∈ Ι a b → ∀ x ∈ s, HasDerivAt (fun x => F x t) (F' x t) x) :
+    IntervalIntegrable (F' x₀) μ a b ∧
+      HasDerivAt (fun x => ∫ t in a..b, F x t ∂μ) (∫ t in a..b, F' x₀ t ∂μ) x₀
+```
+
+This is the **dominated** variant (uses a uniform integrable bound on `F'`),
+which is the right choice for E and K because the integrand and its k-derivative
+both admit straightforward bounds on any compact `[k₀ - δ, k₀ + δ] ⊂ (0, 1)`.
+
+A close cousin is `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_lip`
+(uses a Lipschitz bound instead of a derivative bound). For E and K the Lipschitz
+constant is the same uniform bound on `‖F'‖`, so either works; the
+`_deriv_le` form gives the derivative directly without an extra Lipschitz step,
+so it is the cleaner choice.
+
+### Concrete instantiation for `dE/dk`
+
+Set:
+- `𝕜 := ℝ`, `E := ℝ`, `μ := volume` (Lebesgue on ℝ).
+- `a := 0`, `b := π/2`.
+- `F (k : ℝ) (θ : ℝ) := √(1 - k² · sin²θ)`.
+- `F' (k : ℝ) (θ : ℝ) := -k · sin²θ / √(1 - k² · sin²θ)`.
+  (the partial derivative ∂F/∂k.)
+- `x₀ := k₀` (the point at which we differentiate; will need `0 < k₀ < 1`).
+- `s := Set.Ioo (k₀ - δ) (k₀ + δ)` for some `0 < δ` with the open interval
+  contained in `(0, 1)`.
+- `bound (θ : ℝ) := (k₀ + δ) · sin²θ / √(1 - (k₀ + δ)² · sin²θ)`
+  (or any uniform pointwise majorant; this one is integrable on `[0, π/2]`
+  because the denominator is bounded below by `√(1 - (k₀ + δ)²) > 0`).
+
+Hypothesis-by-hypothesis:
+
+| Hypothesis | What to prove | How |
+|---|---|---|
+| `hs` | `s` is a neighborhood of `x₀` | `Ioo_mem_nhds` (assumes `x₀ ∈ s`, immediate) |
+| `hF_meas` | `F x` is `AEStronglyMeasurable` for `x` near `x₀` | continuous integrand, `Continuous.aestronglyMeasurable` |
+| `hF_int` | `F x₀` is `IntervalIntegrable` | continuous on `[0, π/2]` ⇒ `Continuous.intervalIntegrable` |
+| `hF'_meas` | `F' x₀` is `AEStronglyMeasurable` | continuous (denominator bounded away from 0 for `0 < k₀ < 1`) |
+| `h_bound` | `‖F' x t‖ ≤ bound t` ae for `x ∈ s` | direct calc: numerator monotone in k, denominator antitone in k² |
+| `bound_integrable` | `IntervalIntegrable bound` | `Continuous.intervalIntegrable` (denominator bounded below) |
+| `h_diff` | `HasDerivAt (fun x => F x t) (F' x t) x` for ae t | quotient/sqrt chain rule, ae direct |
+
+The conclusion gives both `IntervalIntegrable (F' x₀)` and the derivative
+identity `HasDerivAt (k ↦ ∫ ... F k θ dθ) (∫ ... F' k₀ θ dθ) k₀`.
+
+### Step from `HasDerivAt` to `dE/dk = (E - K)/k`
+
+Given `HasDerivAt (k ↦ E(k)) (∫₀^{π/2} F'(k₀, θ) dθ) k₀`, the remaining work
+is to evaluate the integral on the right:
+
+```
+∫₀^{π/2} (-k₀ · sin²θ / √(1 - k₀² · sin²θ)) dθ
+  = -k₀ · ∫₀^{π/2} (sin²θ / √(1 - k₀² · sin²θ)) dθ              (factor out -k₀)
+```
+
+Use the algebraic identity `-k₀² · sin²θ = (1 - k₀² · sin²θ) - 1`, divided
+by `-k₀² · √(...)`:
+
+```
+sin²θ / √(1 - k₀² · sin²θ)
+  = (1/k₀²) · (1 - (1 - k₀² · sin²θ)) / √(1 - k₀² · sin²θ)
+  = (1/k₀²) · (1/√(...) - √(...))
+```
+
+Hence:
+
+```
+∫₀^{π/2} (sin²θ / √(...)) dθ = (1/k₀²) · (K(k₀) - E(k₀))
+```
+
+Multiplying by `-k₀`:
+
+```
+∫₀^{π/2} F'(k₀, θ) dθ = -(K - E)/k₀ = (E - K)/k₀
+```
+
+So `dE/dk = (E(k) - K(k)) / k`, as claimed. The split-then-recombine algebra
+is ~6 lines of `ring_nf` / `field_simp` / direct `rw`.
+
+### Estimated cost
+
+The `state.md` estimate of "~80 lines" for `dE_dk` is now corroborated:
+
+| Step | Lines |
+|---|---|
+| Bound function and its integrability | 15-20 |
+| `h_diff` (pointwise differentiability of the integrand) | 25-30 |
+| `h_bound` (pointwise majorization) | 15-20 |
+| Apply `hasDerivAt_integral_of_dominated_loc_of_deriv_le` | 5-10 |
+| Algebraic split and integral identity | 15-20 |
+| **Total** | **~75-100 lines** |
+
+Slightly above the 80 estimate but on track. The bound construction has the
+most fiddly bookkeeping; the rest is mostly boilerplate.
+
+### Mirror argument for `dK/dk`
+
+`K(k) = ∫₀^{π/2} 1/√(1 - k²·sin²θ) dθ`.
+∂/∂k of integrand: `k · sin²θ / (1 - k²·sin²θ)^{3/2}`.
+The integral evaluates to `(E(k) - (1-k²)·K(k)) / (k · (1-k²))`, i.e.,
+`dK/dk = (E - k'²·K) / (k · k'²)` where `k'² = 1 - k²`. Same Mathlib lemma;
+roughly the same line count (~80-100 lines).
+
+### Wronskian step (post-`dE`/`dK`)
+
+With both derivatives in hand, define `f(k) := E(k)·K'(k) + E'(k)·K(k) - K(k)·K'(k)`.
+A direct calculation (using `dE/dk` and `dK/dk` and the chain rule for
+`k' = √(1 - k²)`) shows `f'(k) = 0` on `(0, 1)`. Then `f` is constant on `(0, 1)`
+by `MVT` / `eq_of_hasDerivAt_eq_zero` (Mathlib has this), and the value at
+`k = 1/√2` (where `k' = k`) is pinned by `legendre_relation_symmetric` (already
+proven, per `AmgmInequalityOQ04OQ02.lean` overview). This closes the open
+axiom.
+
+### Files modified (this session)
+
+- `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md` (new) — this report.
+- `research/problems/amgm-inequality-oq-04-oq-02/state.md` — iteration 2 → 3;
+  current focus updated; `Active Approach` and `Next Action` reference the
+  pinned lemma name.
+- `src/data/research/problems/amgm-inequality-oq-04-oq-02.json` — currentState
+  iteration / focus / nextAction updated; new insight noted.
+
+### Build verification
+
+Not attempted. Documentation-only session; no Lean files modified.
+
+### Next session (Session 4, ACT)
+
+Implement `dE_dk` in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean`:
+
+```lean
+theorem dE_dk (k : ℝ) (hk_pos : 0 < k) (hk_lt : k < 1) :
+    HasDerivAt ellipticE ((ellipticE k - ellipticK k) / k) k := by
+  -- apply intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le
+  -- with the F, F', s, bound from this session's plan
+  sorry
+```
+
+Estimated ~75-100 lines. After `dE_dk` is proved, `dK_dk` mirrors closely
+(~80-100 lines), and the Wronskian closure follows in one more session.
+
+---

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,55 +1,106 @@
 # Current State
 
-**Phase**: ORIENT
-**Since**: 2026-05-08T02:30:00.000Z
-**Iteration**: 2
+**Phase**: ORIENT (sharpened, ready for ACT)
+**Since**: 2026-05-08T07:50:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Stub written and Docker-building. Rigorous E(k) definition in place; complementary
-modulus and complementary K, E wired up; symmetric Legendre relation at k = 1/√2
-**derived** as a theorem from the general axiom. Ready to begin proving the general
-Legendre relation in subsequent sessions.
+Session 3 (SURVEY): pinned down the exact Mathlib lemma to use for differentiating
+`E(k) = ∫₀^{π/2} √(1 - k²·sin²θ) dθ` and `K(k) = ∫₀^{π/2} 1/√(1 - k²·sin²θ) dθ`
+under the integral sign. The lemma is:
+
+**`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`** in
+`Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean`.
+
+The dominated form (uniform integrable bound on `F'`) is the right fit: on any
+compact subinterval `[k₀ - δ, k₀ + δ] ⊂ (0, 1)`, both the integrand and its
+k-derivative admit straightforward bounds. See
+`sessions/2026-05-08-s03-mathlib-survey.md` for the full hypothesis-by-hypothesis
+plan, the algebraic split that takes `∫ F'` to `(E - K)/k`, and the parallel
+plan for `dK/dk`.
+
+Stub already exists in `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (Iteration 2);
+the general Legendre relation is currently an axiom. With the lemma now pinned,
+Session 4 can begin ACT-mode proof of `dE_dk`.
 
 ## Active Approach
 
 **ODE / Wronskian (Whittaker–Watson §22.41)**: prove `dE/dk = (E - K)/k` and
-`dK/dk = (E - k'²K)/(k·k'²)` by differentiation under the integral, then show
+`dK/dk = (E - k'²K)/(k·k'²)` by differentiation under the integral via
+`intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`, then show
 the bracketed combination `f(k) = E·K' + E'·K - K·K'` has zero derivative on
 (0, 1), hence is constant; pin the constant via `legendre_relation_symmetric`.
 
 **Why this approach over the AGM/Brent-Salamin path**: the AGM/Landen approach
 needs Mathlib's quadratic AGM convergence theorem (also missing) plus a
 non-trivial Landen transformation lemma. The ODE/Wronskian approach uses only
-Mathlib's already-present `MeasureTheory.intervalIntegral.deriv_*` family,
-which is a cleaner dependency.
+the now-pinned `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`
+plus `Continuous.intervalIntegrable` and standard chain-rule lemmas.
 
 ## Blockers
 
-1. Mathlib has differentiation-under-the-integral but it's not yet wired up to
-   `ellipticK`/`ellipticE`. ~80-150 lines of plumbing per derivative.
+1. ~~Mathlib has differentiation-under-the-integral but it's not yet wired up to~~
+   ~~`ellipticK`/`ellipticE`. ~80-150 lines of plumbing per derivative.~~
+   **Status: NOT a Mathlib gap — Mathlib has
+   `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`. The
+   "plumbing" is gallery-side, ~75-100 lines per derivative (see Next Action).**
 2. The Legendre ODE for K(k) (k(1-k²)y'' + (1-3k²)y' - k·y = 0) has no Mathlib
    infrastructure for second-order ODEs of this form. May not be needed if we
-   compute the derivatives directly.
+   compute the derivatives directly. **Status: avoidable; the Wronskian
+   argument needs only first derivatives and `eq_of_hasDerivAt_eq_zero` (in
+   Mathlib).**
 
 ## Next Action
 
-**Session 3**: Prove `dE/dk = (E - K)/k` for 0 < k < 1.
+**Session 4 (ACT)**: Prove `dE_dk` in
+`proofs/Proofs/AmgmInequalityOQ04OQ02.lean`. Target signature:
 
-Strategy:
-1. Differentiate the integrand `f(k, θ) = √(1 - k²·sin²θ)` w.r.t. k:
-   `∂f/∂k = -k·sin²θ / √(1 - k²·sin²θ)`.
-2. Apply `MeasureTheory.intervalIntegral.deriv_integral_*` to swap derivative
-   and integral.
-3. Show `∫₀^{π/2} (-k·sin²θ / √(1-k²sin²θ)) dθ = (E(k) - K(k))/k` via the
-   identity `-k²·sin²θ = (1 - k²·sin²θ) - 1`, splitting the integrand into
-   `√(1-k²sin²θ) - 1/√(1-k²sin²θ)`, hence integrating to `E(k)·k - K(k)·k`,
-   divided by `k`.
+```lean
+theorem dE_dk (k : ℝ) (hk_pos : 0 < k) (hk_lt : k < 1) :
+    HasDerivAt ellipticE ((ellipticE k - ellipticK k) / k) k
+```
 
-Estimated ~80 lines.
+Plan (from S3 survey):
+
+1. Set `F (k : ℝ) (θ : ℝ) := √(1 - k²·sin²θ)` and
+   `F' (k : ℝ) (θ : ℝ) := -k·sin²θ / √(1 - k²·sin²θ)`.
+2. Choose `δ` with `0 < δ < min k (1 - k)`; set
+   `s := Set.Ioo (k - δ) (k + δ)` and
+   `bound (θ : ℝ) := (k + δ)·sin²θ / √(1 - (k + δ)²·sin²θ)`.
+3. Discharge the seven hypotheses of
+   `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le`:
+   `hs`, `hF_meas`, `hF_int`, `hF'_meas`, `h_bound`, `bound_integrable`,
+   `h_diff`. Each is straightforward (chain rule for the integrand, monotonicity
+   for the bound, `Continuous.intervalIntegrable` for integrability).
+4. Convert the conclusion `HasDerivAt E (∫ F' dθ) k` to
+   `HasDerivAt E ((E k - K k)/k) k` via the algebraic identity
+   `-k²·sin²θ = (1 - k²·sin²θ) - 1`, integrating to `E·k - K·k` and dividing
+   by `k`.
+
+Estimated ~75-100 lines.
+
+After `dE_dk` lands, mirror for `dK_dk` (~80-100 lines), then the Wronskian
+closure (~50 lines using `eq_of_hasDerivAt_eq_zero`).
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1 (ODE/Wronskian — stub-only, derivatives next session)
+- Total attempts: 2
+- Current approach attempts: 2 (S2 stub, S3 SURVEY)
+- Approaches tried: 1 (ODE/Wronskian — stub written; Mathlib lemma pinned)
+
+## References
+
+- `Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean` —
+  `intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le` (the
+  workhorse for `dE/dk` and `dK/dk`).
+- `Mathlib/Analysis/Calculus/ParametricIntegral.lean` — non-interval analogue
+  (used internally; not directly needed).
+- `Mathlib/Analysis/Calculus/MeanValue.lean` —
+  `eq_of_hasDerivAt_eq_zero` style lemma for the constant-Wronskian step.
+- `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` — gallery file with `ellipticE`,
+  `ellipticK`, complementary modulus, and the symmetric Legendre relation
+  derived from the general axiom (1 axiom, 0 sorries; this iteration's target
+  is to eliminate the 1 axiom).
+- `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md`
+  (this iteration's full plan).

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-02.json
@@ -26,18 +26,18 @@
   },
   "currentState": {
     "phase": "ORIENT",
-    "since": "2026-05-08T02:30:00.000Z",
-    "iteration": 2,
-    "focus": "Stub written and building. ellipticE rigorously defined; complementary modulus and K', E' wired up; symmetric Legendre at k=1/√2 derived from the general axiom. Next focus: prove the general legendre_relation by differentiation under the integral.",
+    "since": "2026-05-08T07:50:00Z",
+    "iteration": 3,
+    "focus": "S3 SURVEY: pinned down the exact Mathlib lemma to use for differentiation-under-the-integral: intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le in Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean. The dominated-bound form fits because both the E and K integrands and their k-derivatives admit straightforward uniform bounds on any compact subinterval [k0-delta, k0+delta] subset (0,1). Session 4 (ACT) implements dE_dk: HasDerivAt ellipticE ((ellipticE k - ellipticK k)/k) k via this lemma, with the algebraic identity -k^2 sin^2 theta = (1 - k^2 sin^2 theta) - 1 to convert the resulting integral to (E-K)/k. Estimated 75-100 lines.",
     "blockers": [
-      "Mathlib has differentiation-under-the-integral lemmas but they are not yet wired up to ellipticK.",
-      "Need explicit derivatives dK/dk = (E - k'²K)/(k·k'²) and dE/dk = (E - K)/k as Lean lemmas.",
-      "Need the Legendre ODE for K(k) (k(1-k²)y'' + (1-3k²)y' - ky = 0) — currently no Mathlib infrastructure for second-order ODEs of this form."
+      "(NOT a Mathlib gap — RESOLVED by S3 survey) Mathlib HAS differentiation-under-the-integral via intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le. Plumbing to ellipticK/ellipticE is gallery-side, ~75-100 lines per derivative.",
+      "Need explicit derivatives dK/dk = (E - k'^2 K)/(k k'^2) and dE/dk = (E - K)/k as Lean lemmas — gallery-side ACT work, no Mathlib gap.",
+      "Legendre's second-order ODE for K is NOT needed: the Wronskian closure uses only first derivatives + eq_of_hasDerivAt_eq_zero (Mathlib MVT corollary)."
     ],
-    "nextAction": "Session 3: Prove dE/dk = (E - K)/k via differentiation under the integral. This is the simpler of the two derivative formulas and is the entry point to the Wronskian argument.",
+    "nextAction": "Session 4 (ACT): implement dE_dk in Proofs/AmgmInequalityOQ04OQ02.lean via the lemma pinned in S3. Target signature: theorem dE_dk (k : R) (hk_pos : 0 < k) (hk_lt : k < 1) : HasDerivAt ellipticE ((ellipticE k - ellipticK k) / k) k. Estimated ~75-100 lines. See research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md for the full hypothesis-by-hypothesis plan.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
@@ -73,7 +73,8 @@
       "Symmetric Legendre at k=1/√2 requires complModulus_symmetric : √(1-(1/√2)²) = 1/√2. Proof technique: rewrite 1 - 1/2 = (1/√2)² (so the inner subtraction becomes a square), then apply Real.sqrt_sq with positivity. ~3 lines.",
       "linear_combination tactic closes the gap between the general Legendre form 'E·K + E·K - K·K = π/2' (after specializing to k = k' = 1/√2) and the goal '2·K·E - K² = π/2'. ring-equivalent, but `linear_combination h` with h being the unfolded form is cleanest.",
       "The general Legendre relation axiom is the only deep assumption in this file; it is honestly comparable in depth to OQ04OQ01.agm_ellipticK_connection (Gauss's 200-page result). The proof requires Mathlib's intervalIntegral.deriv_* (DOES exist) plus explicit Lean derivations of dK/dk and dE/dk (do not yet exist for ellipticK).",
-      "Mathlib v4.26.0 API drift: intervalIntegral.integral_mono now takes hab : a ≤ b as the first explicit argument (was implicit/internal in older versions). Existing OQ04OQ01.ellipticK_pos used the old order; fixed in the same PR by inserting `(by linarith [Real.pi_pos] : (0:ℝ) ≤ π / 2)` before the integrability arguments."
+      "Mathlib v4.26.0 API drift: intervalIntegral.integral_mono now takes hab : a ≤ b as the first explicit argument (was implicit/internal in older versions). Existing OQ04OQ01.ellipticK_pos used the old order; fixed in the same PR by inserting `(by linarith [Real.pi_pos] : (0:ℝ) ≤ π / 2)` before the integrability arguments.",
+      "S3 (2026-05-08, SURVEY): the Mathlib derivative-under-the-integral lemma to use is intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le in Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean. The dominated-bound form (uniform integrable bound on F') is preferable to the Lipschitz form for elliptic integrals because both F = sqrt(1 - k^2 sin^2 theta) and F' = -k sin^2 theta / sqrt(1 - k^2 sin^2 theta) admit explicit uniform bounds on any compact [k0-delta, k0+delta] subset (0,1). The 7 hypotheses (hs, hF_meas, hF_int, hF'_meas, h_bound, bound_integrable, h_diff) discharge mechanically via Continuous.aestronglyMeasurable, Continuous.intervalIntegrable, monotonicity, and chain rule for sqrt/quotient. ~75-100 lines per derivative."
     ],
     "mathlibGaps": [
       "No Mathlib.Analysis.SpecialFunctions.Elliptic.Complete — complete elliptic integrals K(k), E(k) of first and second kind over real moduli are not formalized. (This file fills part of this gap: rigorous E(k); K(k) was already filled by OQ04OQ01.)",
@@ -83,11 +84,11 @@
       "Explicit derivatives: dK/dk = (E - k'²K)/(k·k'²) and dE/dk = (E - K)/k — these are the key Wronskian inputs. Both reachable from Mathlib but require work."
     ],
     "nextSteps": [
-      "Session 3 (E derivative): Prove dE/dk = (E(k) - K(k))/k for 0 < k < 1. Strategy: differentiate under the integral using `MeasureTheory.intervalIntegral.deriv_integral_*`. The integrand's k-derivative is `-k·sin²θ / √(1-k²sin²θ)`, and ∫₀^{π/2} of this rearranges to (E - K)/k. ~80 lines.",
-      "Session 4 (K derivative): Prove dK/dk = (E(k) - (k')²·K(k))/(k·(k')²) for 0 < k < 1. Significantly harder: requires manipulating ∫ k·sin²θ / (1-k²sin²θ)^{3/2} dθ via Legendre's ODE or direct integration by parts. ~150 lines.",
-      "Session 5 (Wronskian-vanishing): Define f(k) := E·K' + E'·K - K·K' for 0 < k < 1 and show f'(k) = 0 using the derivatives from Sessions 3-4. ~100 lines of algebraic manipulation.",
-      "Session 6 (boundary value): Compute lim_{k→1/√2} f(k) = 2KE - K² (use legendre_relation_symmetric from this session if symmetric form is what we settle on, or take the limit k → 0⁺). ~50 lines.",
-      "Session 7 (axiom elimination cleanup): Update AmgmInequalityOQ04OQ05 to import this file and discharge its `legendre_relation` (symmetric) axiom by `legendre_relation_symmetric`. Re-verify Brent-Salamin formula proof. Small follow-up PR.",
+      "Session 4 (E derivative, ACT): Prove dE/dk = (E(k) - K(k))/k for 0 < k < 1 in Proofs/AmgmInequalityOQ04OQ02.lean. Use intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (now pinned in S3) with bound (theta) := (k+delta) sin^2 theta / sqrt(1 - (k+delta)^2 sin^2 theta) on s := Set.Ioo (k - delta) (k + delta). The integrand's k-derivative is -k sin^2 theta / sqrt(1 - k^2 sin^2 theta); the resulting integral rearranges to (E - K)/k via the algebraic split -k^2 sin^2 theta = (1 - k^2 sin^2 theta) - 1. ~75-100 lines.",
+      "Session 5 (K derivative, ACT): Prove dK/dk = (E(k) - (k')^2 K(k))/(k (k')^2) for 0 < k < 1. Same Mathlib lemma as Session 4; integrand is 1/sqrt(1 - k^2 sin^2 theta), k-derivative is k sin^2 theta / (1 - k^2 sin^2 theta)^{3/2}. ~80-100 lines.",
+      "Session 6 (Wronskian-vanishing, ACT): Define f(k) := E K' + E' K - K K' for 0 < k < 1 and show f'(k) = 0 using the derivatives from S4-S5 + the chain rule for k' = sqrt(1 - k^2). Then conclude f is constant via Mathlib's eq_of_hasDerivAt_eq_zero (no second-order ODE needed). ~50-80 lines.",
+      "Session 7 (boundary value, ACT): Pin the constant via legendre_relation_symmetric (already proved in S2 from the general axiom — once the axiom is replaced by the Wronskian theorem, the dependency direction reverses cleanly). ~20 lines.",
+      "Session 8 (axiom-elimination cleanup): Update AmgmInequalityOQ04OQ05 to import this file and discharge its `legendre_relation` (symmetric) axiom by `legendre_relation_symmetric`. Re-verify Brent-Salamin formula proof. Small follow-up PR.",
       "Future Mathlib contribution: After all sessions complete and the file is sorry-free + axiom-free, propose `Mathlib.Analysis.SpecialFunctions.Elliptic.Complete` containing K, E, and Legendre's relation. Targets a Mathlib PR similar to NNReal.agm (Tan 2025)."
     ]
   },
@@ -135,11 +136,13 @@
       "Mathlib.Analysis.SpecialFunctions.ArithmeticGeometricMean (NNReal.agm)",
       "Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass (PeriodPair.weierstrassP)",
       "Mathlib.Analysis.SpecialFunctions.Integrals.Basic (integral_sin_pow, integral_cos)",
-      "Mathlib.MeasureTheory.Integral.IntervalIntegral (intervalIntegral, IntervalIntegrable)"
+      "Mathlib.MeasureTheory.Integral.IntervalIntegral (intervalIntegral, IntervalIntegrable)",
+      "Mathlib.Analysis.Calculus.ParametricIntervalIntegral — intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le (S3-pinned workhorse for dE/dk and dK/dk)",
+      "Mathlib.Analysis.Calculus.MeanValue — eq_of_hasDerivAt_eq_zero (Wronskian-constancy step)"
     ]
   },
   "started": "2026-05-06T14:45:58.507Z",
-  "lastUpdate": "2026-05-08T02:30:00.000Z",
+  "lastUpdate": "2026-05-08T07:50:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Documentation-only S3 SURVEY iteration for `amgm-inequality-oq-04-oq-02`
(Legendre's relation for elliptic integrals, currently axiomatized).

**Headline finding**: identified the exact Mathlib lemma to use for the
differentiation-under-the-integral step in the ODE/Wronskian proof path:

```
intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_deriv_le
  in Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean
```

The dominated form fits because both `E(k) = ∫₀^{π/2} √(1-k²sin²θ) dθ` and
`K(k) = ∫₀^{π/2} 1/√(1-k²sin²θ) dθ` integrands and their k-derivatives admit
explicit uniform bounds on any compact `[k₀ - δ, k₀ + δ] ⊂ (0, 1)`.

## Concrete plan for `dE_dk` (Session 4 ACT)

```lean
theorem dE_dk (k : ℝ) (hk_pos : 0 < k) (hk_lt : k < 1) :
    HasDerivAt ellipticE ((ellipticE k - ellipticK k) / k) k
```

| Hypothesis (of pinned lemma) | Discharge strategy |
|---|---|
| `hs` | `Ioo_mem_nhds` |
| `hF_meas` | `Continuous.aestronglyMeasurable` |
| `hF_int` | `Continuous.intervalIntegrable` |
| `hF'_meas` | continuous on `(0,1)`, denominator bounded away from 0 |
| `h_bound` | monotonicity in `k²` |
| `bound_integrable` | continuous on `[0, π/2]` |
| `h_diff` | chain rule for `sqrt` + quotient |

Conclusion gives `HasDerivAt E (∫ F' dθ) k`; the algebraic identity
`-k²·sin²θ = (1 - k²·sin²θ) - 1` then converts the integral to `(E - K)/k`.

Estimated **~75-100 lines**.

## Updated cost estimate (full path)

| Session | Goal | Est. lines |
|---|---|---|
| S4 | `dE_dk` | 75-100 |
| S5 | `dK_dk` (mirror) | 80-100 |
| S6 | Wronskian = 0 (use first derivatives + chain rule for `k'`) | 50-80 |
| S7 | Pin constant via `legendre_relation_symmetric` | 20 |
| S8 | Eliminate the axiom in `AmgmInequalityOQ04OQ05` | small follow-up |

The second-order Legendre ODE (originally listed as a blocker) is **not
needed** — the Wronskian closure uses only first derivatives and Mathlib's
`eq_of_hasDerivAt_eq_zero`.

## Files changed

- `research/problems/amgm-inequality-oq-04-oq-02/sessions/2026-05-08-s03-mathlib-survey.md` (new) — full S3 plan with hypothesis-by-hypothesis discharge.
- `research/problems/amgm-inequality-oq-04-oq-02/state.md` — iteration 2 → 3; blocker list reframed (Mathlib gap → gallery-side ACT work); next-action references the pinned lemma.
- `src/data/research/problems/amgm-inequality-oq-04-oq-02.json` — `currentState` updated; new insight; next-steps re-numbered (S3 was a SURVEY, ACT shifts to S4); `references.mathlib` adds `ParametricIntervalIntegral` and `MeanValue`.

## Status

- **Outcome**: progress (sharper plan; Mathlib lemma pinned; second-order ODE blocker dismissed)
- **Sorries**: 0 (unchanged)
- **Axioms**: 1 (`legendre_relation`, unchanged; target of S4–S7)
- **Build verification**: not attempted (documentation-only)

## Test plan

- [ ] No code changes; CI lints/tests pass on docs-only diff.
- [ ] Future S4 PR will contain the actual `dE_dk` Lean proof.

🤖 Generated by researcher-10