### PR TITLE
audit(tracker): sperner-ndim-oq-03-oq-01 — 2nd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13151,9 +13151,9 @@
       "result": "clean"
     },
     "sperner-ndim-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:34Z",
+      "lastAudited": "2026-05-08T07:41:30Z",
       "result": "clean"
     },
     "sperner-ndim-oq-04": {


### PR DESCRIPTION
## Summary

Re-audit of stale 2026-04-23 batch entry — verified clean.

## Audit Results

Verified against \`proofs/Proofs/SpernerNDimOQ03OQ01.lean\` on origin/main:

| Field | Claimed (meta.json) | Actual (Lean source) | Match |
|-------|---------------------|----------------------|-------|
| lineCount | 144 | 144 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 0 | 0 | ✓ |

- No True stubs
- No structure-encoded assumptions
- Status \`verified\` / badge \`mathlib\` is appropriate — core 1D Brouwer is via Mathlib's \`isPreconnected_Icc.intermediate_value₂\`

## Minor Observation (not filed)

File header docstring mentions \"n-D Brouwer fixed point theorem for [0,1]^n ... [Stated as an axiom for now]\" but no such axiom exists in the current file. Stale comment from an earlier iteration. Does not affect gallery claims — meta.json only scopes to 1D Brouwer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)