### PR TITLE
Enrich Spherical Law of Sines (Angle-over-Side): deeper history + cross-refs + annotations

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-000",
+    "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "context",
+    "title": "Module Docstring: Question and Answer",
+    "content": "The module docstring is structured as the literal posing and resolution of an open question raised in the parent entry law-of-cosines-oq-01-oq-01. The grandparent question — whether the Gram determinant framework that yields the dual cosine law also yields the full sine rule — is answered affirmatively. Both forms (angle-over-side and side-over-angle) are stated, and the proof strategy (Gram-determinant identity sin²(X)sin²(y)sin²(z) = G in the parent file, algebraic inversion here) is summarized. The axiom and sorry counts are recorded inline to make verification independent of any external tracker.",
+    "mathContext": "The Gram determinant for three unit vectors $u, v, w$ on $S^2$ is $G(u,v,w) = \\det\\begin{pmatrix} 1 & u\\cdot v & u\\cdot w \\\\ u\\cdot v & 1 & v\\cdot w \\\\ u\\cdot w & v\\cdot w & 1 \\end{pmatrix} = 1 - \\cos^2 a - \\cos^2 b - \\cos^2 c + 2\\cos a\\cos b\\cos c$, where $a, b, c$ are the spherical sides $\\arccos(v\\cdot w), \\arccos(u\\cdot w), \\arccos(u\\cdot v)$ respectively. The identity $\\sin^2(X)\\sin^2(y)\\sin^2(z) = G$ for each cyclic triple $(X, y, z)$ is what makes the sine rule fall out: dividing two such identities gives $\\sin^2(A)\\sin^2(b)\\sin^2(c) / \\sin^2(B)\\sin^2(a)\\sin^2(c) = 1$, hence $\\sin(A)/\\sin(a) = \\sin(B)/\\sin(b)$.",
+    "significance": "context",
+    "relatedConcepts": ["Gram determinant", "spherical sine rule", "open question resolution", "research lineage"],
+    "prerequisites": ["spherical trigonometry"]
+  },
+  {
     "id": "ann-001",
     "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
     "range": { "startLine": 27, "endLine": 27 },
@@ -24,15 +36,39 @@
     "prerequisites": ["Lean 4 namespace mechanics"]
   },
   {
+    "id": "ann-003a",
+    "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
+    "range": { "startLine": 38, "endLine": 46 },
+    "type": "technique",
+    "title": "Theorem Statement and Hypothesis Pattern",
+    "content": "The theorem takes six positivity hypotheses: 0 < sin(side) for all three sides and 0 < sin(angle) for all three angles. These are the nondegeneracy conditions that make every denominator nonzero — without them the divisions sin(A)/sin(a) etc. are undefined or trivial. The conjunctive statement (A/a = B/b ∧ A/a = C/c) is sufficient to recover the third equality B/b = C/c by transitivity (handled by spherical_law_of_sines_BC_angle_over_side below). Lean's `obtain ⟨h1, h2⟩ := spherical_law_of_sines_all ...` destructures the parent's conjunction in one step, exposing both pieces simultaneously.",
+    "mathContext": "Nondegeneracy: a spherical triangle is *nondegenerate* iff all three vertices are distinct, all three sides are strictly between 0 and π, and all three angles are strictly between 0 and π. Equivalent (under the standard parametrization) to $0 < \\sin(\\cdot)$ on all sides and angles. The Gram-determinant approach requires this because $G = 0$ exactly on the degenerate locus (three coplanar unit vectors), and we are dividing by sines extracted from $\\sqrt{G}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["nondegenerate spherical triangle", "destructuring", "obtain pattern", "conjunction elimination"],
+    "prerequisites": ["Lean 4 destructuring syntax", "spherical triangle nondegeneracy"]
+  },
+  {
     "id": "ann-003",
     "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
-    "range": { "startLine": 38, "endLine": 54 },
-    "type": "key-step",
-    "title": "Algebraic Inversion via div_eq_div_iff",
-    "content": "The core of the proof: `div_eq_div_iff (ne_of_gt hA) (ne_of_gt hB)` rewrites the goal sin(A)/sin(a) = sin(B)/sin(b) into the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a). Applied symmetrically to the parent hypothesis h1 : sin(a)/sin(A) = sin(b)/sin(B), it yields sin(a)·sin(B) = sin(b)·sin(A). The two cross-multiplied forms differ only by a sign; `linear_combination -h1` closes the goal automatically.",
+    "range": { "startLine": 47, "endLine": 50 },
+    "type": "insight",
+    "title": "Algebraic Inversion via div_eq_div_iff (First Conjunct)",
+    "content": "The core of the proof for sin(A)/sin(a) = sin(B)/sin(b): `div_eq_div_iff (ne_of_gt hA) (ne_of_gt hB)` rewrites the goal into the cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a). Applied symmetrically to the parent hypothesis h1 : sin(a)/sin(A) = sin(b)/sin(B), it yields sin(a)·sin(B) = sin(b)·sin(A). The two cross-multiplied forms differ only by a sign; `linear_combination -h1` closes the goal automatically.",
     "mathContext": "$\\texttt{div\\_eq\\_div\\_iff}$: for nonzero $b, d$, the equation $\\frac{a}{b} = \\frac{c}{d}$ is equivalent to $a \\cdot d = c \\cdot b$. Applying it on both the goal and the hypothesis transforms a division-form equality into a polynomial identity that Lean's `linear_combination` tactic can verify by reducing to $0 = 0$ after a single linear combination of the hypothesis. The hypothesis 0 < sin(angle) provides the `ne_of_gt` nonzero requirement.",
     "significance": "key",
     "relatedConcepts": ["div_eq_div_iff", "linear_combination", "cross-multiplication", "polynomial identities"],
+    "prerequisites": ["division on Real", "linear_combination tactic", "ne_of_gt"]
+  },
+  {
+    "id": "ann-003b",
+    "proofId": "law-of-cosines-oq-01-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 54 },
+    "type": "technique",
+    "title": "Same Pattern for Second Conjunct (A/a = C/c)",
+    "content": "The proof of the second conjunct sin(A)/sin(a) = sin(C)/sin(c) is structurally identical to the first: clear denominators in both the goal (via div_eq_div_iff with hA, hC nonzero) and the parent hypothesis h2 : sin(a)/sin(A) = sin(c)/sin(C) (via div_eq_div_iff with ha, hc nonzero), then close with `linear_combination -h2`. This duplication is intrinsic to the conjunctive form of the parent theorem — each direction requires its own application of div_eq_div_iff because the cross-multiplied forms involve different pairs of nonzero hypotheses (hA, hC for the goal vs ha, hc for the hypothesis).",
+    "mathContext": "The two cross-multiplications produce $\\sin A \\cdot \\sin c = \\sin C \\cdot \\sin a$ (goal) and $\\sin a \\cdot \\sin C = \\sin c \\cdot \\sin A$ (from h2). These are negatives of each other after the standard sign convention, so `linear_combination -h2` (multiply h2 by -1 and check that the difference is zero) closes the goal in a single tactic step. The same technique would work for any two-variable analogue of the sine rule.",
+    "significance": "supporting",
+    "relatedConcepts": ["div_eq_div_iff", "linear_combination", "cross-multiplication", "structural symmetry"],
     "prerequisites": ["division on Real", "linear_combination tactic", "ne_of_gt"]
   },
   {

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01/meta.json
@@ -40,7 +40,7 @@
     "definitionCount": 0
   },
   "overview": {
-    "historicalContext": "The spherical law of sines, sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c), is one of the three fundamental relations of spherical trigonometry alongside the spherical law of cosines (cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C)) and its dual (cos(C) = -cos(A)cos(B) + sin(A)sin(B)cos(c)). It is symmetric — both forms (angle-over-side and side-over-angle) are equivalent under the nondegeneracy hypothesis (positive sines), and the side-over-angle form drops out cleanly from the Gram-determinant identity sin²(X)·sin²(y)·sin²(z) = G established in the dual law of cosines. Todhunter (1886) proves the sine rule first via the polar triangle construction; the modern Gram-determinant route (without polar duality) was reformulated in the present project's earlier entries (law-of-cosines-oq-01-oq-01, law-of-cosines-oq-01-oq-02).",
+    "historicalContext": "The spherical law of sines, sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c), is one of the three fundamental relations of spherical trigonometry alongside the spherical law of cosines (cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C)) and its dual (cos(C) = -cos(A)cos(B) + sin(A)sin(B)cos(c)). The earliest systematic treatment of spherical triangles is Menelaus of Alexandria's *Sphaerica* (c. 100 AD), which establishes Menelaus's theorem on transversals but uses chords rather than sines. The sine rule itself appears explicitly in the Islamic mathematical tradition: Abu al-Wafa' Buzjani (10th century) and Abu Nasr Mansur formulated and proved versions of the spherical sine rule, and Jabir ibn Aflah (Geber, c. 1130) gave a self-contained derivation in his *Islah al-Majisti*, replacing Menelaus's theorem by the sine rule as the foundational relation. Regiomontanus's *De Triangulis Omnimodis* (1464) brought the sine rule into Latin Europe as the cornerstone of spherical astronomy. Todhunter (*Spherical Trigonometry*, 1886) proves the sine rule first via the polar triangle construction, deriving it as a corollary of the cosine law applied to the polar triangle. The modern Gram-determinant route — viewing sin²(X)sin²(y)sin²(z) as a single invariant equal to G = 1 - cos²a - cos²b - cos²c + 2cos(a)cos(b)cos(c) — bypasses polar duality and exposes the sine rule as a symmetry property of the volume form on three vectors of the unit sphere. This determinantal approach is the framework used in the present project's earlier entries (law-of-cosines-oq-01-oq-01 for the dual cosine law, law-of-cosines-oq-01-oq-02 for the side-over-angle sine form), and the current 64-line wrapper closes the trilogy by inverting to the angle-over-side form.",
     "problemStatement": "The parent entry law-of-cosines-oq-01-oq-01 raised the open question: \"Generalize the Gram determinant argument to prove the full sine rule sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c).\" This file answers that question affirmatively. The side-over-angle form is proved in law-of-cosines-oq-01-oq-02 as `spherical_law_of_sines_all`; this file derives the angle-over-side equivalent.",
     "text": "Derives the angle-over-side form of the spherical law of sines from the side-over-angle form by algebraic inversion, closing the open question on generalizing the Gram-determinant framework to the full sine rule.",
     "proofStrategy": "Given `spherical_law_of_sines_all` (sin(a)/sin(A) = sin(b)/sin(B) and sin(a)/sin(A) = sin(c)/sin(C), proved in Proofs/LawOfCosinesOQ01OQ02.lean as a consequence of sin²(X)·sin²(y)·sin²(z) = gramDet for each angle-side triple), the angle-over-side form follows by clearing denominators with div_eq_div_iff and rearranging. Both equalities reduce to a single linear_combination once the hypotheses 0 < sin(angle), 0 < sin(side) are in scope. The B/b = C/c part follows by transitivity of the first two equalities (h₁.symm.trans h₂).",
@@ -49,7 +49,9 @@
       "The Gram-determinant identity sin²(X)·sin²(y)·sin²(z) = G (for each cyclic triple (X,y,z)) is the actual content of the sine rule. Once that is in hand from the parent, the inversion to angle-over-side is purely formal — no geometric content beyond what is already in the dual cosine law's framework is needed.",
       "Both directions of the sine rule require positive-sine hypotheses for both sides AND angles. In the side-over-angle form positive angle sines are needed to divide by sin(angle); in the angle-over-side form positive side sines are needed. The full theorem statement in this file takes all six hypotheses, matching the parent.",
       "B/b = C/c follows from A/a = B/b and A/a = C/c by transitivity: (A/a = B/b).symm.trans (A/a = C/c) ⟹ B/b = C/c. The bare minimum is the conjunction A/a = B/b ∧ A/a = C/c, since the C-equality is enough to derive the third.",
-      "This 64-line wrapper is the lightest possible closure of the open question oq-01-oq-01-oq-01: by the time the side-over-angle form (which IS the harder direction, requiring the Gram-determinant nonnegativity argument) is in place, the angle-over-side form is just algebraic bookkeeping."
+      "This 64-line wrapper is the lightest possible closure of the open question oq-01-oq-01-oq-01: by the time the side-over-angle form (which IS the harder direction, requiring the Gram-determinant nonnegativity argument) is in place, the angle-over-side form is just algebraic bookkeeping.",
+      "The two forms (angle/side and side/angle) are not redundant in practice: in spherical astronomy and geodesy, the angle-over-side form is the natural one when angles are measured directly (as observed at a vertex) and side lengths are the unknowns to be solved; the side-over-angle form is natural when sides (great-circle arc lengths) are measured (e.g., from chronometers and bearings) and angles are computed. The Lean formalization preserves this duality by making each direction a separate theorem statement, both proved from the common Gram-determinant identity.",
+      "From a categorical perspective, the symmetry sin(X)/sin(x) ↔ sin(x)/sin(X) is the involution induced by inversion in the multiplicative group of positive reals. The choice of which form to take as primitive is conventional; the Gram-determinant proof produces the symmetric expression sin²(X)·sin²(y)·sin²(z) = G first, and either single-fraction form is then a corollary. This is a small instance of the pattern that homogeneous polynomial identities are more fundamental than affine ratios — algebraic geometers prefer projective invariants over their affine charts for exactly this reason."
     ],
     "prerequisites": [
       "Spherical law of sines, side-over-angle form: spherical_law_of_sines_all in Proofs/LawOfCosinesOQ01OQ02.lean",
@@ -115,6 +117,26 @@
       "id": "law-of-cosines-oq-01",
       "title": "Spherical Law of Cosines (Open Question)",
       "relationship": "Grandparent open question about generalizing the planar law of cosines to the sphere. This entry, together with its siblings, completes the Lean 4 formalization of the three fundamental relations of spherical trigonometry."
+    },
+    {
+      "id": "spherical-law-of-sines",
+      "title": "Spherical Law of Sines",
+      "relationship": "Independent gallery formalization of the spherical sine rule (different proof strategy). This entry's Gram-determinant route via the dual cosine law is an alternative path to the same result, illustrating the multiple natural derivations of this fundamental relation."
+    },
+    {
+      "id": "spherical-law-of-cosines",
+      "title": "Spherical Law of Cosines",
+      "relationship": "The standard form cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C) — first of the three fundamental relations of spherical trigonometry. The dual law (proved in law-of-cosines-oq-01-oq-01) and the sine rule (this entry) complete the trilogy."
+    },
+    {
+      "id": "law-of-cosines",
+      "title": "Law of Cosines (Planar)",
+      "relationship": "Planar progenitor c² = a² + b² - 2ab·cos(C). The spherical sine rule reduces to the planar one, sin(A)/a = sin(B)/b = sin(C)/c, in the small-angle limit (sin(x) ≈ x as x → 0); see law-of-cosines-oq-01-oq-04 for the formal small-angle reduction of the spherical cosine law."
+    },
+    {
+      "id": "law-of-cosines-oq-01-oq-04",
+      "title": "Small-Angle Limit: Spherical Reduces to Euclidean",
+      "relationship": "Sibling: proves that the spherical law of cosines reduces to the planar law in the limit of small triangles. The analogous small-angle reduction sin(a) ≈ a converts the spherical sine rule (this entry) to the planar sine rule sin(A)/a = sin(B)/b = sin(C)/c."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for **law-of-cosines-oq-01-oq-01-oq-01** (Spherical Law of Sines, Angle-over-Side Form).

## Improvements

### meta.json — `historicalContext` (deepened)
Added pre-modern antecedents that were missing:
- Menelaus of Alexandria's *Sphaerica* (~100 AD) — earliest systematic spherical-triangle treatment, but with chords not sines
- Abu al-Wafa' Buzjani (10th c.) and Abu Nasr Mansur — first explicit sine rule in Islamic mathematics
- Jabir ibn Aflah / Geber (c. 1130) — *Islah al-Majisti* gives a self-contained derivation, replacing Menelaus's theorem with the sine rule
- Regiomontanus, *De Triangulis Omnimodis* (1464) — sine rule reaches Latin Europe as cornerstone of spherical astronomy
- Sharper framing of the modern Gram-determinant route as a symmetry property of the volume form, contrasting with Todhunter's polar-triangle approach

### meta.json — `keyInsights` (5 → 7)
- Practical duality: angle-over-side is natural when angles are observed (vertex measurements); side-over-angle is natural when sides are measured (chronometers, bearings). Spherical astronomy and geodesy use both forms.
- Categorical/algebraic insight: the homogeneous identity $\sin^2(X)\sin^2(y)\sin^2(z) = G$ is more fundamental than either single-fraction form, paralleling the algebraic-geometric preference for projective invariants over their affine charts.

### meta.json — `crossReferences` (+4)
- `spherical-law-of-sines` — independent gallery proof via different strategy
- `spherical-law-of-cosines` — sibling fundamental relation
- `law-of-cosines` — planar progenitor
- `law-of-cosines-oq-01-oq-04` — small-angle reduction sibling

### annotations.json (4 → 7 annotations)
- **ann-000** (lines 1-25, context): Module-docstring framing as Question/Answer; mathContext contains the full $3\times 3$ Gram-determinant matrix and shows how dividing two $\sin^2(X)\sin^2(y)\sin^2(z) = G$ identities yields the sine rule
- **ann-003a** (lines 38-46, technique): Theorem signature, the six positivity hypotheses, and a precise definition of nondegeneracy with the Gram-determinant $G = 0 \iff$ degenerate connection
- **ann-003b** (lines 51-54, technique): Walks through the second-conjunct proof (A/a = C/c) in parallel with the first, makes explicit why the duplication is intrinsic to the conjunctive parent statement

## Verification
- JSON validated with `jq`
- `tsx scripts/annotations/build.ts` reports no errors for this entry (full repo build is unrelated `better-sqlite3` native-compile failure under Node v26)
- No changes to the Lean file or schema; preserves all prior annotations and content

## Quality target
Lift quality score from **91** to ~95+ via deeper history, broader cross-referencing, and complete annotation coverage of the proof's three structural blocks (docstring, theorem signature/hypotheses, two conjunct proofs, transitivity corollary).