### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): Session 5 — finish structural CDF library

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -245,6 +245,61 @@ theorem binomialCDF_mono (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
         (pow_nonneg h1mp _)
     · rw [if_neg hjy]
 
+/-- For `0 ≤ p ≤ 1`, every value of `binomialCDF n p` is non-negative.
+
+    Each summand is either `0` (if-guard false) or the binomial PMF
+    `C(n, j) · p^j · (1 − p)^(n − j)`, which is non-negative since
+    `Nat.choose n j ≥ 0`, `p ≥ 0`, and `1 − p ≥ 0`. The sum of
+    non-negative terms is non-negative.
+
+    Useful for the Phase-4 Portmanteau bridge: weak-convergence
+    arguments for measures often pull back to non-negativity of CDFs. -/
+theorem binomialCDF_zero_le (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
+    (x : ℝ) : 0 ≤ binomialCDF n p x := by
+  have h1mp : 0 ≤ 1 - p := by linarith
+  unfold binomialCDF
+  apply Finset.sum_nonneg
+  intro j _
+  split_ifs with hjx
+  · exact mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (pow_nonneg hp0 _))
+      (pow_nonneg h1mp _)
+  · exact le_refl 0
+
+/-- For `0 ≤ p ≤ 1`, every value of `binomialCDF n p` is at most `1`.
+
+    Proof: the full unrestricted sum
+    `∑_{j=0}^{n} C(n, j) · p^j · (1 − p)^(n − j) = (p + (1 − p))^n = 1`
+    by the binomial theorem (`add_pow`). The CDF replaces some summands
+    with `0`; under the hypothesis `0 ≤ p ≤ 1` each summand is
+    non-negative, so dropping terms only decreases the total.
+
+    Useful for the Phase-4 Portmanteau bridge: weak-convergence is
+    typically formulated for sub-probability measures, and bounded
+    CDFs on `[0, 1]` characterize the standard normal in the limit. -/
+theorem binomialCDF_le_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
+    (x : ℝ) : binomialCDF n p x ≤ 1 := by
+  have h1mp : 0 ≤ 1 - p := by linarith
+  -- Step 1: rewrite `1` as the binomial expansion of `(p + (1 − p))^n`.
+  have hexp : ∑ j ∈ Finset.range (n + 1),
+      (Nat.choose n j : ℝ) * p ^ j * (1 - p) ^ (n - j) = 1 := by
+    have hadd := add_pow p (1 - p) n
+    have hp_eq : p + (1 - p) = (1 : ℝ) := by ring
+    rw [hp_eq, one_pow] at hadd
+    -- hadd : (1 : ℝ) = ∑ k, p^k * (1 − p)^(n−k) * (Nat.choose n k : ℝ)
+    rw [← hadd]
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    ring
+  -- Step 2: replace `1` on the RHS with the equivalent sum.
+  rw [← hexp]
+  -- Step 3: term-by-term comparison.
+  unfold binomialCDF
+  apply Finset.sum_le_sum
+  intro j _
+  split_ifs with hjx
+  · exact le_refl _
+  · exact mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (pow_nonneg hp0 _))
+      (pow_nonneg h1mp _)
+
 /-! ## Main theorem: multinomial marginal CLT (derived) -/
 
 /-- **Multinomial marginal CLT** (DERIVED THEOREM, no separate axiom):

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
@@ -398,6 +398,124 @@ lower edge.
 
 ---
 
+## Session 2026-05-08 (Session 5, researcher-1) — ACT (Phase-4 prep continued)
+
+**Mode**: BUILD-ON-PRIOR (Sessions 1–4 produced a sorry-free, two-axiom
+file with two of four planned structural lemmas; this session adds the
+remaining two).
+**Outcome**: added the remaining structural-properties library entries
+`binomialCDF_zero_le` and `binomialCDF_le_one`. No axiom elimination.
+
+### What Was Built
+
+* `binomialCDF_zero_le (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
+    (x : ℝ) : 0 ≤ binomialCDF n p x`
+  — `Finset.sum_nonneg` + a `split_ifs` on each summand. The true
+  branch is the standard PMF non-negativity argument
+  (`mul_nonneg` on `Nat.cast_nonneg`, `pow_nonneg hp0`,
+  `pow_nonneg h1mp`); the false branch is `0 ≤ 0`. ~9 lines.
+
+* `binomialCDF_le_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
+    (x : ℝ) : binomialCDF n p x ≤ 1`
+  — three-step proof:
+    1. `add_pow p (1−p) n` gives `(p + (1−p))^n = ∑ k, p^k * (1−p)^(n−k)
+       * (Nat.choose n k : ℝ)`. Specialize at `p + (1−p) = 1` and
+       `1^n = 1` to get
+       `1 = ∑ k, p^k * (1−p)^(n−k) * (Nat.choose n k : ℝ)`.
+    2. Reorder the summand to match the file's PMF convention via
+       `Finset.sum_congr rfl (fun j _ => by ring)`, yielding
+       `∑ j, (Nat.choose n j : ℝ) * p^j * (1−p)^(n−j) = 1`.
+    3. `Finset.sum_le_sum` + `split_ifs`: true branch is `le_refl _`;
+       false branch is the standard PMF non-negativity argument.
+  ~22 lines.
+
+### Why These Lemmas
+
+The Phase-4 work is to discharge `binomial_clt_pointwise` — the
+classical de Moivre–Laplace theorem in CDF form. The natural Mathlib
+path bridges from `ProbabilityTheory.iid_central_limit_theorem` (which
+gives measure-weak-convergence of the standardized binomial law to the
+standard Gaussian) to a CDF-pointwise-convergence statement via the
+Portmanteau theorem at continuity points of the standard normal CDF.
+
+For that bridge, the standard Portmanteau machinery requires the CDFs
+in question to be:
+
+- bounded between `0` and `1` (sub-probability-measure CDFs);
+- monotone (CDFs of measures are non-decreasing);
+- vanishing below the support (lower-edge boundary lemma).
+
+The four structural lemmas now in the file —
+`binomialCDF_neg`, `binomialCDF_mono`, `binomialCDF_zero_le`,
+`binomialCDF_le_one` — together establish that
+`binomialCDF n p (·)` is a *bona fide* sub-probability CDF on `ℝ`
+(distribution function in the classical sense) for any `0 ≤ p ≤ 1`.
+This is exactly the input the Portmanteau bridge will need.
+
+### Status After This Session
+
+* Sorries: 0 (unchanged).
+* Axioms: 2 (unchanged): `binomial_clt_pointwise` + `standardNormalCDF`
+  opaque.
+* Theorems: 7 (was 5): added `binomialCDF_zero_le` and
+  `binomialCDF_le_one`. Substantive theorem count: 6 (was 4).
+* Definitions: 2 (unchanged).
+* File length: 330 lines (was 275; +55 for the two lemmas + section
+  docstrings).
+* Status: still `axiomatized`.
+
+### Honest Reporting
+
+* Local Docker build was **not** run (CI is the ground truth, and the
+  worktree has the recursive `.lake` symlink trap that forces a fresh
+  Mathlib clone). The proofs use only well-tested Mathlib idioms —
+  `Finset.sum_nonneg`, `Finset.sum_le_sum`, `Finset.sum_congr`,
+  `add_pow`, `Nat.cast_nonneg`, `mul_nonneg`, `pow_nonneg`, `split_ifs`,
+  `le_refl`, `linarith`, `ring`. Confidence is high but not CI-verified.
+
+* This is **infrastructure**, not axiom elimination. The session does
+  not reduce the axiom count — it completes the structural-properties
+  library that the next session can chain into a Portmanteau-style
+  bridge for `binomial_clt_pointwise`.
+
+* The `add_pow` lemma is in `Mathlib.Algebra.BigOperators.Ring.Finset`
+  (already imported). The summand convention in `add_pow` puts the
+  binomial coefficient `(Nat.choose n k : ℝ)` *last*, so a `ring`
+  reorder is needed to match the file's `(Nat.choose n j : ℝ) * p^j *
+  (1-p)^(n-j)` convention. The reorder is encapsulated in the
+  `Finset.sum_congr` step inside `binomialCDF_le_one`.
+
+### Files Changed
+
+- UPDATED `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`
+  (275 → 330 lines, +2 theorems).
+- UPDATED `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json`
+  (lineCount, theoremCount, substantiveTheoremCount, originalContributions,
+   sec-structural / sec-main line ranges).
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md`
+  (this entry).
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md`
+  (Session 5 status; promoted Phase-4 axiom attack to next action).
+- UPDATED `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json`
+  (knowledge fields).
+
+### Next Steps
+
+1. **Session 6 (axiom attack)**: discharge `binomial_clt_pointwise`
+   from `ProbabilityTheory.iid_central_limit_theorem` via the
+   Portmanteau bridge. The four structural lemmas now in the file are
+   the prerequisites. Estimated ~150–200 lines of new Lean.
+
+2. **Stretch (independent)**: replace the `standardNormalCDF` opaque
+   with a concrete `noncomputable def` integrating `gaussianPDFReal`
+   over `Set.Iic x`. ShannonEntropyOQ01.lean uses
+   `ProbabilityTheory.gaussianPDFReal μ ⟨σ², sq_nonneg σ⟩` so the
+   API is precedented in this gallery; the bridge to CDF is one
+   `MeasureTheory.integral` definition. Removes the opaque assumption
+   entirely (axiom count 2 → 1).
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -1,19 +1,25 @@
 # Research State: binomial-theorem-oq-02-oq-01-oq-01-oq-03
 
 ## Current State
-**Phase**: ACT (Phase-4 structural-lemma prep)
+**Phase**: ACT (Phase-4 structural-lemma prep — library complete)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (Session 4, researcher-10)
-**Iteration**: 4
+**Last Updated**: 2026-05-08 (Session 5, researcher-1)
+**Iteration**: 5
 
 ## Current Focus
-Phase-4 prep: added `binomialCDF_neg` and `binomialCDF_mono` — two
-structural lemmas about the binomial CDF that the Portmanteau-bridge
-proof of `binomial_clt_pointwise` will need. No axiom elimination this
-session; the file is still 0 sorries / 2 axioms (`binomial_clt_pointwise`
-+ `standardNormalCDF` opaque). Next session continues the structural
-library (`binomialCDF_le_one`, then the Portmanteau bridge itself).
+Phase-4 prep continued: added `binomialCDF_zero_le` (CDF ≥ 0) and
+`binomialCDF_le_one` (CDF ≤ 1) — two structural lemmas that round out
+the structural-properties library. `binomialCDF_le_one` uses `add_pow`
+to expand `(p + (1−p))^n = 1` and bounds the CDF by dropping
+non-negative summands. Combined with the prior session's
+`binomialCDF_neg` and `binomialCDF_mono`, the structural library is now
+sufficient for the Phase-4 Portmanteau-bridge proof of
+`binomial_clt_pointwise`.
+
+No axiom elimination this session; the file is still 0 sorries / 2
+axioms (`binomial_clt_pointwise` + `standardNormalCDF` opaque). Next
+session begins the Phase-4 axiom attack itself.
 
 ## Active Approach
 **CDF-based** rather than the measure-theoretic Bernoulli-sum approach
@@ -29,7 +35,7 @@ sketched in iteration 1. Justification:
   Phase-3 task is to bridge to Mathlib's measure-theoretic Gaussian.
 
 ## Attempt Count
-- Total attempts: 4 (Sessions 1–4)
+- Total attempts: 5 (Sessions 1–5)
 - Approaches tried:
   - **Iteration 1** (researcher-8, OBSERVE→ORIENT): planned i.i.d.-CLT
     decomposition (Sublemmas A, B, C, D). No Lean code.
@@ -40,12 +46,16 @@ sketched in iteration 1. Justification:
     sorry via `Finset.sum_fiberwise_of_maps_to`. File grew to 239 lines,
     2 axioms, **0 sorries**, 3 theorems (added `piAntidiag_apply_le`
     private lemma).
-  - **Iteration 4** (researcher-10, ACT — THIS SESSION):
-    Phase-4 prep. Added `binomialCDF_neg` (CDF = 0 below support) and
-    `binomialCDF_mono` (monotone in `x` when `0 ≤ p ≤ 1`) — two
-    structural lemmas that the Portmanteau bridge will consume. File
-    now 275 lines, 2 axioms (unchanged), **0 sorries**, 5 theorems
-    (substantive count: 4).
+  - **Iteration 4** (researcher-10, ACT): Phase-4 prep.
+    Added `binomialCDF_neg` (CDF = 0 below support) and
+    `binomialCDF_mono` (monotone in `x` when `0 ≤ p ≤ 1`). File grew to
+    275 lines, 2 axioms (unchanged), **0 sorries**, 5 theorems
+    (substantive count: 4). Merged in #16951.
+  - **Iteration 5** (researcher-1, ACT — THIS SESSION):
+    Phase-4 prep continued. Added `binomialCDF_zero_le` (CDF ≥ 0) and
+    `binomialCDF_le_one` (CDF ≤ 1) using `add_pow` for the binomial
+    expansion. File now 330 lines, 2 axioms (unchanged), **0 sorries**,
+    7 theorems (substantive count: 6).
 
 ## Blockers
 - **Build verification**: this session could not run the Docker build
@@ -63,16 +73,6 @@ sketched in iteration 1. Justification:
   theorem at continuity points.
 
 ## Next Action
-
-**Session 5 (immediate)**: round out the structural-properties library
-with two more routine lemmas:
-
-* `binomialCDF_le_one`: bounded above by 1. Reduces to
-  `(p + (1-p))^n = 1` via `add_pow` (or `Commute.add_pow` for a
-  commutative semiring); the if-guard restricts the sum, but the
-  whole sum equals `1`, and dropping non-negative terms only decreases.
-* `binomialCDF_zero_le`: bounded below by 0 (each summand non-negative
-  when `0 ≤ p ≤ 1`).
 
 **Session 6 (Phase-4 axiom attack)**: discharge `binomial_clt_pointwise`.
 The cleanest path is to bridge from Mathlib's

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 2,
-    "lineCount": 275,
+    "lineCount": 330,
     "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. (2) `standardNormalCDF` opaque marker — the standard normal CDF Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt, currently opaque pending bridge from Mathlib's measure-theoretic Gaussian. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` is now fully proved (Phase-3 deliverable): it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
     "originalContributions": [
       "binomialCDF: concrete CDF of Binomial(n,p) as a finite sum of binomial PMF terms with a step indicator",
@@ -30,10 +30,12 @@
       "multinomialMarginalCDF_eq_binomialCDF: reduction lemma — proved via Finset.sum_fiberwise_of_maps_to + parent's multinomial_marginal_pmf",
       "multinomial_marginal_clt: derived theorem (no axiom of its own) combining the above via Filter.Tendsto.congr",
       "binomialCDF_neg: for x < 0, binomialCDF n p x = 0 — every j ∈ {0,…,n} has (j : ℝ) ≥ 0 > x so all if-guards are false (Phase-4 prep)",
-      "binomialCDF_mono: binomialCDF n p is monotone in x when 0 ≤ p ≤ 1 — pointwise comparison after case-splitting on the if-guards (Phase-4 Portmanteau prep)"
+      "binomialCDF_mono: binomialCDF n p is monotone in x when 0 ≤ p ≤ 1 — pointwise comparison after case-splitting on the if-guards (Phase-4 Portmanteau prep)",
+      "binomialCDF_zero_le: for 0 ≤ p ≤ 1, 0 ≤ binomialCDF n p x — sum of non-negative summands (Phase-4 Portmanteau prep)",
+      "binomialCDF_le_one: for 0 ≤ p ≤ 1, binomialCDF n p x ≤ 1 — bounded above by the full binomial expansion (p + (1−p))^n = 1 via add_pow (Phase-4 Portmanteau prep)"
     ],
-    "theoremCount": 5,
-    "substantiveTheoremCount": 4,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 6,
     "definitionCount": 2
   },
   "leanFile": {
@@ -51,10 +53,10 @@
       "BigOperators"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
-    "lineCount": 275,
+    "lineCount": 330,
     "axiomCount": 2,
-    "theoremCount": 5,
-    "substantiveTheoremCount": 4,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 2,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
@@ -108,14 +110,14 @@
       "title": "Structural Properties of binomialCDF (Phase-4 prep)",
       "range": null,
       "startLine": 212,
-      "endLine": 246
+      "endLine": 301
     },
     {
       "id": "sec-main",
       "title": "Main Theorem: Multinomial Marginal CLT (Derived)",
       "range": null,
-      "startLine": 248,
-      "endLine": 275
+      "startLine": 303,
+      "endLine": 330
     }
   ],
   "overview": {

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -52,7 +52,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT phase, Phase-4 prep. Lean file BinomialTheoremOQ02OQ01OQ01OQ03.lean (275 lines, 0 sorries, 2 axioms unchanged) now ships with two structural lemmas (binomialCDF_neg + binomialCDF_mono) prerequisite to the Portmanteau bridge that will discharge binomial_clt_pointwise from Mathlib's iid CLT. Sessions 1-2 produced the CDF-based scaffold (merged in #16866); Session 3 closed the reduction-lemma sorry via Finset.sum_fiberwise_of_maps_to; Session 4 adds Phase-4 prerequisites. Next: complete structural library (binomialCDF_le_one, binomialCDF_zero_le) then attempt the Portmanteau bridge to remove binomial_clt_pointwise. Stretch: replace standardNormalCDF opaque with a concrete integral over Mathlib's gaussianPDFReal.",
+    "progressSummary": "ACT phase, Phase-4 prep — structural library complete. Lean file BinomialTheoremOQ02OQ01OQ01OQ03.lean (330 lines, 0 sorries, 2 axioms unchanged) now ships with all four structural CDF properties (binomialCDF_neg, binomialCDF_mono, binomialCDF_zero_le, binomialCDF_le_one) prerequisite to the Portmanteau bridge that will discharge binomial_clt_pointwise from Mathlib's iid CLT. Sessions 1-2 produced the CDF-based scaffold (merged in #16866); Session 3 closed the reduction-lemma sorry via Finset.sum_fiberwise_of_maps_to (#16877); Session 4 added binomialCDF_neg and binomialCDF_mono (#16951); Session 5 added the bounded-above (binomialCDF_le_one via add_pow) and bounded-below (binomialCDF_zero_le) lemmas. Next: attempt the Portmanteau bridge to remove binomial_clt_pointwise. Stretch: replace standardNormalCDF opaque with a concrete integral over Mathlib's gaussianPDFReal.",
     "builtItems": [
       "binomialCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:90 (concrete CDF of Binomial(n,p))",
       "multinomialMarginalCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:97 (marginal CDF of multinomial)",
@@ -62,7 +62,9 @@
       "multinomial_marginal_clt (DERIVED theorem, no separate axiom) in BinomialTheoremOQ02OQ01OQ01OQ03.lean:160",
       "Gallery entry src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/ (meta.json, annotations.json, index.ts)",
       "Added binomialCDF_neg in BinomialTheoremOQ02OQ01OQ01OQ03.lean:216 — for x < 0, binomialCDF n p x = 0 (Phase-4 prep)",
-      "Added binomialCDF_mono in BinomialTheoremOQ02OQ01OQ01OQ03.lean:232 — Monotone (binomialCDF n p) when 0 ≤ p ≤ 1 (Phase-4 Portmanteau prep)"
+      "Added binomialCDF_mono in BinomialTheoremOQ02OQ01OQ01OQ03.lean:232 — Monotone (binomialCDF n p) when 0 ≤ p ≤ 1 (Phase-4 Portmanteau prep)",
+      "Added binomialCDF_zero_le in BinomialTheoremOQ02OQ01OQ01OQ03.lean:257 — for 0 ≤ p ≤ 1, 0 ≤ binomialCDF n p x (Phase-4 Portmanteau prep)",
+      "Added binomialCDF_le_one in BinomialTheoremOQ02OQ01OQ01OQ03.lean:279 — for 0 ≤ p ≤ 1, binomialCDF n p x ≤ 1 via add_pow / (p+(1-p))^n=1 (Phase-4 Portmanteau prep)"
     ],
     "insights": [
       "Multinomial marginal Xᵢ ~ Binomial(n, pᵢ) is ALREADY proved (`BinomialTheoremOQ02OQ01OQ02.lean`); OQ-02-OQ-01-OQ-01-OQ-03 'just' needs the binomial CLT ON TOP",
@@ -76,7 +78,11 @@
       "The DERIVED-theorem pattern keeps the axiom inventory honest: multinomial_marginal_clt is not itself an axiom, only the underlying de Moivre-Laplace + opaque CDF marker are",
       "binomialCDF_neg: for x < 0, every j ∈ {0, …, n} satisfies (j : ℝ) ≥ 0 > x so all if-guards collapse to 'else 0' and the whole sum is 0. Proof uses Finset.sum_eq_zero + not_le.mpr + Nat.cast_nonneg, ~6 lines (Session 4)",
       "binomialCDF_mono in x (when 0 ≤ p ≤ 1): pointwise comparison after case-splitting on the if-guards in each summand. Three cases — both true (PMF=PMF), LHS false RHS true (need 0 ≤ PMF), both false (0 ≤ 0). PMF non-negativity from mul_nonneg + Nat.cast_nonneg + pow_nonneg on Nat.choose, p^j, (1-p)^(n-j), ~13 lines (Session 4)",
-      "Phase-4 Portmanteau-bridge prerequisites (structural CDF properties): monotonicity is the central one — Portmanteau equivalence between weak convergence and CDF-pointwise convergence at continuity points uses monotonicity to control oscillation between continuity points. binomialCDF_neg covers the lower-edge case (Session 4)"
+      "Phase-4 Portmanteau-bridge prerequisites (structural CDF properties): monotonicity is the central one — Portmanteau equivalence between weak convergence and CDF-pointwise convergence at continuity points uses monotonicity to control oscillation between continuity points. binomialCDF_neg covers the lower-edge case (Session 4)",
+      "binomialCDF_zero_le: for 0 ≤ p ≤ 1, every summand of binomialCDF is non-negative (PMF or 0), so the whole sum is non-negative. Finset.sum_nonneg + split_ifs + mul_nonneg, ~9 lines (Session 5)",
+      "binomialCDF_le_one: the full unrestricted sum equals (p+(1-p))^n = 1 by add_pow; the CDF replaces some summands with 0; under 0 ≤ p ≤ 1 each summand is non-negative so dropping terms only decreases. Finset.sum_le_sum + add_pow + Finset.sum_congr (to reorder summand into the file's convention) + le_refl, ~22 lines (Session 5)",
+      "add_pow in Mathlib.Algebra.BigOperators.Ring.Finset puts the binomial coefficient (Nat.choose n k : R) *last* in each summand: (x+y)^n = ∑ k, x^k * y^(n-k) * (n.choose k : R). The file's PMF convention puts (Nat.choose n j : ℝ) *first*; a Finset.sum_congr + ring step bridges the two (Session 5)",
+      "The four structural lemmas (binomialCDF_neg, binomialCDF_mono, binomialCDF_zero_le, binomialCDF_le_one) collectively establish that binomialCDF n p (·) is a *bona fide* sub-probability CDF on ℝ for any 0 ≤ p ≤ 1 — exactly the Portmanteau-bridge input shape (Session 5)"
     ],
     "mathlibGaps": [
       "Mathlib's `Mathlib.Probability.Distributions.Binomial` exposes the PMF but the named theorem 'binomial CLT' / 'de Moivre-Laplace' may not be present in canonical form",
@@ -84,9 +90,9 @@
       "Multivariate CLT (Cramér-Wold) — partial in Mathlib; would be needed for the joint vector form (out of scope for this OQ but referenced in nextSteps)"
     ],
     "nextSteps": [
-      "Session 5: prove binomialCDF_le_one (uses add_pow / Commute.add_pow) and binomialCDF_zero_le (mul_nonneg on each summand) to round out the structural library.",
-      "Session 6: discharge binomial_clt_pointwise from ProbabilityTheory.iid_central_limit_theorem applied to a Bernoulli(p) i.i.d. sequence, via the Portmanteau theorem at continuity points of the standard normal CDF (every point, since Φ is continuous).",
-      "Stretch: replace standardNormalCDF opaque with a noncomputable def := ∫ t in Set.Iic x, ProbabilityTheory.gaussianPDFReal 0 ⟨1, _⟩ t. Removes one of the two remaining axioms."
+      "Session 6 (axiom attack): discharge binomial_clt_pointwise from ProbabilityTheory.iid_central_limit_theorem applied to a Bernoulli(p) i.i.d. sequence, via the Portmanteau theorem at continuity points of the standard normal CDF (every point, since Φ is continuous). The four structural CDF properties added in Sessions 4-5 are the prerequisites.",
+      "Stretch: replace standardNormalCDF opaque with a noncomputable def := ∫ t in Set.Iic x, ProbabilityTheory.gaussianPDFReal 0 ⟨1, _⟩ t. Removes one of the two remaining axioms.",
+      "Future OQ (Cramér-Wold + multinomial covariance): joint multinomial CLT via vector convergence to a degenerate multivariate normal supported on the hyperplane sum y_i = 0; out of scope here but BinomialTheoremOQ02OQ01OQ03.multinomial_covariance is the covariance ingredient."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Session 5 of the multinomial-marginal-CLT problem. Phase-4 prep
continued: added the remaining two structural-properties lemmas for
`binomialCDF`, completing the library prerequisite to the
Portmanteau-bridge proof of `binomial_clt_pointwise`.

## What's New

* `binomialCDF_zero_le` — for `0 ≤ p ≤ 1`, `0 ≤ binomialCDF n p x`.
  `Finset.sum_nonneg` + `split_ifs` + `mul_nonneg` on the PMF summand.
* `binomialCDF_le_one` — for `0 ≤ p ≤ 1`, `binomialCDF n p x ≤ 1`.
  Uses `add_pow p (1-p) n` to rewrite `1 = (p + (1-p))^n` as the
  unrestricted binomial sum, then term-by-term comparison via
  `Finset.sum_le_sum`. The summand-order convention in `add_pow`
  (coefficient last) is bridged to the file's PMF convention
  (coefficient first) by a `Finset.sum_congr` + `ring` step.

Together with `binomialCDF_neg` and `binomialCDF_mono` from Session 4,
the four lemmas establish that `binomialCDF n p (·)` is a *bona fide*
sub-probability CDF on ℝ for any `0 ≤ p ≤ 1` — exactly the
Portmanteau-bridge input shape needed to discharge
`binomial_clt_pointwise` from `ProbabilityTheory.iid_central_limit_theorem`.

## Status

- Sorries: 0 (unchanged).
- Axioms: 2 (unchanged): `binomial_clt_pointwise` + `standardNormalCDF` opaque.
- Theorems: 7 (was 5); substantive count: 6 (was 4).
- Lines: 330 (was 275).
- Status: still `axiomatized`.

## Honest Reporting

This is **infrastructure**, not axiom elimination. Local Docker build
was not run (worktree `.lake` symlink trap); proofs use only
well-tested Mathlib idioms (`Finset.sum_nonneg`, `Finset.sum_le_sum`,
`add_pow`, `mul_nonneg`, `pow_nonneg`, `split_ifs`, `le_refl`,
`linarith`, `ring`). Confidence is high but not CI-verified at push
time. CI is the ground truth.

## Files Modified

- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` (275 → 330 lines, +2 theorems)
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json` (counts + section ranges)
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/{knowledge.md, state.md}` (Session 5 entry)
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json` (knowledge fields)

## Next Steps

1. **Session 6 (axiom attack)**: discharge `binomial_clt_pointwise`
   from `ProbabilityTheory.iid_central_limit_theorem` via the
   Portmanteau bridge at continuity points of the standard normal CDF.
   Estimated ~150–200 lines of new Lean.
2. **Stretch**: replace the `standardNormalCDF` opaque with a concrete
   `noncomputable def` integrating `gaussianPDFReal` over `Set.Iic x`.
   Removes one of the two remaining axioms.

🤖 Generated by researcher-1