### PR TITLE
fix(meta): roth-theorem-k3-oq-03 — declare SzemerediTheorem dep + bump axiomCount 1->2

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -17,11 +17,14 @@
     "badge": "axiom",
     "sorries": 1,
     "dateAdded": "2026-03-30",
-    "axiomCount": 1,
-    "assumptions": "1 axiom: density_increment_kAP (density increases on subprogression, AP-free preserved). gowersNorm and kAPCount constructive.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms: density_increment_kAP (density increases on subprogression, AP-free preserved) declared in this file; szemeredi_k_ge_4 inherited transitively via Proofs.SzemerediTheorem. gowersNorm and kAPCount constructive.",
     "lineCount": 277,
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "additionalFiles": [
+      "Proofs/SzemerediTheorem.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

`roth-theorem-k3-oq-03` (`Proofs/RothTheoremOQ03.lean`) transitively imports `Proofs.SzemerediTheorem`, which declares `axiom szemeredi_k_ge_4`. The dependency was not declared in `meta.additionalFiles`, so the auditor's `find-targets` script (which only follows `*Aristotle` companions and prefix-matched submodules at single-level imports) silently skipped the file — masking 1 inherited axiom from the integrity check.

## Evidence

```bash
$ git show origin/main:proofs/Proofs/RothTheoremOQ03.lean | grep "^import"
import Mathlib
import Proofs.RothTheorem
import Proofs.SzemerediTheorem

$ git show origin/main:proofs/Proofs/SzemerediTheorem.lean | grep "^axiom"
axiom szemeredi_k_ge_4 : ∀ (k : ℕ) (δ : ℝ), k ≥ 4 → δ > 0 → ...
```

`Proofs/RothTheorem.lean` declares no axioms, so it is not added (only files with assumptions need explicit declaration to fix the under-claim).

**Before**: `meta.axiomCount = 1` (only counts `density_increment_kAP` declared in this file)
**After**: `meta.axiomCount = 2` (adds inherited `szemeredi_k_ge_4` via `Proofs.SzemerediTheorem`); `meta.additionalFiles` now exposes the dependency to the auditor.

## Why this matters

Per the project Axiom Integrity Policy, `meta.axiomCount` must reflect **all** assumptions including transitive ones. The previous value omitted an inherited axiom, technically over-claiming the integrity of the proof chain.

---
Automated fix by lean-mechanic agent.