### PR TITLE
research(ehrhart-cube-proven-oq-02): S4 — fiber bijection helper

### DIFF
--- a/proofs/Proofs/EhrhartCrossPolytope.lean
+++ b/proofs/Proofs/EhrhartCrossPolytope.lean
@@ -353,6 +353,120 @@ private lemma cweight_translate (n M a : ℕ) (hM : M ≤ n)
     rw [if_neg (not_le.mpr h), if_neg (by push_neg; omega)]
     omega
 
+/-- If the sum of centered weights at center `n` is at most `M`, then each
+    individual term is at most `M`. (Each summand is non-negative.) -/
+private lemma cweight_sum_individual {d n M : ℕ}
+    (y : Fin d → Fin (2 * n + 1))
+    (hsum : ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M)
+    (j : Fin d) :
+    (if (y j).val ≤ n then n - (y j).val else (y j).val - n) ≤ M :=
+  (Finset.single_le_sum
+    (f := fun i => if (y i).val ≤ n then n - (y i).val else (y i).val - n)
+    (fun _ _ => Nat.zero_le _) (Finset.mem_univ j)).trans hsum
+
+/-- Range corollary: a sum-of-cweights bound at center `n` with budget `M ≤ n`
+    forces each `(y j).val` into the interval `[n - M, n + M]`. -/
+private lemma cweight_sum_range {d n M : ℕ} (hM : M ≤ n)
+    (y : Fin d → Fin (2 * n + 1))
+    (hsum : ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M)
+    (j : Fin d) :
+    n - M ≤ (y j).val ∧ (y j).val ≤ n + M :=
+  (cweight_le_iff n (y j).val M).mp (cweight_sum_individual y hsum j)
+
+/-- **Fiber bijection**: when `M ≤ n`, the set of `y : Fin d → Fin (2n+1)` whose
+    centered-weight sum at `n` is at most `M` is in bijection with `crossBall d M`,
+    via the translation `yᵢ ↦ ⟨(yᵢ).val - (n - M), _⟩`.
+
+    This is the key counting lemma for the slicing decomposition: each fiber of
+    `crossBall (d+1) n` over the last coordinate is in bijection with `crossBall d M`
+    for the appropriate `M`. -/
+private lemma fiber_card_eq_crossBall_card (d n M : ℕ) (hM : M ≤ n) :
+    (Finset.univ.filter
+      fun y : Fin d → Fin (2 * n + 1) =>
+        ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M).card =
+    (crossBall d M).card := by
+  apply Finset.card_bij'
+    -- Forward: y ↦ z where z idx := (y idx).val - (n - M).
+    (fun y hy idx =>
+      ⟨(y idx).val - (n - M), by
+        have hsum :
+            ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M := by
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
+          exact hy
+        obtain ⟨h_lo, h_hi⟩ := cweight_sum_range hM y hsum idx
+        omega⟩)
+    -- Backward: z ↦ y' where y' idx := (z idx).val + (n - M).
+    (fun z _ idx =>
+      ⟨(z idx).val + (n - M), by
+        have hcoord : (z idx).val < 2 * M + 1 := (z idx).is_lt
+        omega⟩)
+    -- (1) Forward image lies in `crossBall d M`.
+    (by
+      intro y hy
+      have hsum :
+          ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M := by
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
+        exact hy
+      simp only [crossBall, Finset.mem_filter, Finset.mem_univ, true_and]
+      have heq :
+          ∑ i, (if ((y i).val - (n - M)) ≤ M
+                  then M - ((y i).val - (n - M))
+                  else ((y i).val - (n - M)) - M) =
+          ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        obtain ⟨h_lo, h_hi⟩ := cweight_sum_range hM y hsum i
+        exact (cweight_translate n M (y i).val hM h_lo h_hi).symm
+      show ∑ i, (if ((y i).val - (n - M)) ≤ M
+                  then M - ((y i).val - (n - M))
+                  else ((y i).val - (n - M)) - M) ≤ M
+      rw [heq]; exact hsum)
+    -- (2) Backward image lies in the filter set.
+    (by
+      intro z hz
+      have hzsum :
+          ∑ i, (if (z i).val ≤ M then M - (z i).val else (z i).val - M) ≤ M := by
+        simp only [crossBall, Finset.mem_filter, Finset.mem_univ, true_and] at hz
+        exact hz
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      have heq :
+          ∑ i, (if ((z i).val + (n - M)) ≤ n
+                  then n - ((z i).val + (n - M))
+                  else ((z i).val + (n - M)) - n) =
+          ∑ i, (if (z i).val ≤ M then M - (z i).val else (z i).val - M) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        have h_lo : n - M ≤ (z i).val + (n - M) := Nat.le_add_left _ _
+        have h_hi : (z i).val + (n - M) ≤ n + M := by
+          have hzlt : (z i).val < 2 * M + 1 := (z i).is_lt
+          omega
+        have hstep := cweight_translate n M ((z i).val + (n - M)) hM h_lo h_hi
+        have hsubadd : (z i).val + (n - M) - (n - M) = (z i).val := by omega
+        rw [hstep, hsubadd]
+      show ∑ i, (if ((z i).val + (n - M)) ≤ n
+                  then n - ((z i).val + (n - M))
+                  else ((z i).val + (n - M)) - n) ≤ M
+      rw [heq]; exact hzsum)
+    -- (3) Left inverse: backward ∘ forward = id.
+    (by
+      intro y hy
+      have hsum :
+          ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M := by
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy
+        exact hy
+      funext idx
+      apply Fin.ext
+      show (y idx).val - (n - M) + (n - M) = (y idx).val
+      obtain ⟨h_lo, _⟩ := cweight_sum_range hM y hsum idx
+      omega)
+    -- (4) Right inverse: forward ∘ backward = id.
+    (by
+      intro z _
+      funext idx
+      apply Fin.ext
+      show (z idx).val + (n - M) - (n - M) = (z idx).val
+      omega)
+
 /-- **Main geometric theorem**: the cross-polytope lattice count equals crossEhrhart d n.
 
     Proof sketch (induction on d):
@@ -363,11 +477,13 @@ private lemma cweight_translate (n M a : ℕ) (hM : M ≤ n)
       Pairing j ↔ 2n−j: total card = (crossBall d n).card + 2·Σ_{m<n} (crossBall d m).card.
       By IH (`generalizing n`) and `crossEhrhart_succ_d`, equals `crossEhrhart (d+1) n`.
 
-    Status: weight helpers in place (`cweight_le_iff`, `cweight_translate`).
-    Remaining: (1) fiber bijection helper using `Finset.card_bij` with the
-    map `yᵢ ↦ yᵢ - (n - M)`; (2) slicing via `Finset.card_eq_sum_card_fiberwise`
-    over the last-coordinate projection; (3) j↔(2n−j) pairing to fold the sum
-    into the form of `crossEhrhart_succ_d`'s RHS. -/
+    Status: weight helpers + fiber bijection in place
+    (`cweight_le_iff`, `cweight_translate`, `cweight_sum_individual`,
+    `cweight_sum_range`, `fiber_card_eq_crossBall_card`).
+    Remaining: (1) project `crossBall (d+1) n` onto the last coordinate via
+    `Finset.card_eq_sum_card_fiberwise` and identify each fiber with the
+    filter-set used by `fiber_card_eq_crossBall_card`; (2) j↔(2n−j) pairing
+    to fold the resulting sum into `crossEhrhart_succ_d`'s RHS. -/
 theorem crossBall_card (d n : ℕ) : (crossBall d n).card = crossEhrhart d n := by
   induction d with
   | zero =>

--- a/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/knowledge.md
@@ -217,6 +217,90 @@ fiber_card_eq_crossBall_card  -- ≈80-120 lines, uses cweight_*
 
 ---
 
+## Session 2026-05-08 (Session 4, researcher-9) — fiber bijection lemma
+
+**Mode**: ACT
+**Outcome**: Closed the foundation needed to apply `Finset.card_bij'`
+in the slicing decomposition. Added 3 private lemmas spanning ~95 lines.
+Sorry count unchanged (1). lineCount: 423 → 537.
+
+### What was added
+
+**Two trivial sum-bound corollaries** (under 10 lines each):
+
+1. `cweight_sum_individual {d n M} (y) (hsum) (j)` —
+   `(if (y j).val ≤ n then n - (y j).val else (y j).val - n) ≤ M`,
+   from `hsum : ∑_i cweight(y i, n) ≤ M`. Proof is one line via
+   `Finset.single_le_sum` (each summand is nonneg).
+
+2. `cweight_sum_range {d n M} (hM : M ≤ n) (y) (hsum) (j)` —
+   `n - M ≤ (y j).val ∧ (y j).val ≤ n + M`. Proof is one line via
+   `cweight_le_iff ▸ cweight_sum_individual`.
+
+**The fiber bijection** (≈80 lines):
+
+```lean
+private lemma fiber_card_eq_crossBall_card (d n M : ℕ) (hM : M ≤ n) :
+    (Finset.univ.filter
+      fun y : Fin d → Fin (2 * n + 1) =>
+        ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M).card =
+    (crossBall d M).card
+```
+
+via `Finset.card_bij'` with:
+- forward `y ↦ ⟨(y idx).val - (n - M), _⟩` — bound from
+  `cweight_sum_range` + `omega`.
+- backward `z ↦ ⟨(z idx).val + (n - M), _⟩` — bound from
+  `(z idx).is_lt` + `omega` + `hM`.
+- forward image bound: `cweight_translate` term-by-term reduces
+  the new sum to the old sum, hence `≤ M`.
+- backward image bound: same `cweight_translate` step, with the
+  intermediate `(z i).val + (n - M) - (n - M) = (z i).val` cleanup
+  via `omega`.
+- both inverses: `funext idx; apply Fin.ext`, then a one-line
+  `omega` after unfolding to `(...).val ± (n - M) ∓ (n - M)`.
+
+### Why this is the right factoring
+
+The two-sum-equal step (forward image bound) was the trickiest part
+of the previous session's attempted full slicing proof. Pulling it
+out as `fiber_card_eq_crossBall_card` lets future sessions use it
+as a black box: once the slicing identifies a fiber with
+`{y : Fin d → Fin (2n+1) | sum cweight ≤ M_j}`, this lemma
+collapses to `(crossBall d M_j).card`.
+
+### Build verification
+
+Local build deferred to CI (broken `.lake` symlink — see memory
+note `feedback_researcher_lake_symlink_broken.md`).
+
+### Risks
+
+- `Finset.card_bij'` arity in Mathlib 4.26.0 may differ slightly
+  from the Erdos278Problem.lean usage I patterned after; if the
+  6-argument form rejects, the fix is straightforward.
+- The four `show` statements rewrite the goal in unfolded form; if
+  Lean doesn't reduce `(⟨a, _⟩ : Fin _).val` to `a`, an explicit
+  `simp only [Fin.val_mk]` may be needed.
+- The `(z idx).is_lt` field name (vs `Fin.isLt`) — both forms exist
+  in this codebase; if rejected, switch to `(z idx).2`.
+
+### Path forward (for Session 5)
+
+```
+Use fiber_card_eq_crossBall_card to compute fiber cards
+        ↓
+Slicing via Finset.card_eq_sum_card_fiberwise on last coordinate
+        ↓
+j ↔ 2n−j pairing via Finset.sum_nbij' and range split
+        ↓
+apply IH (induction d generalizing n)
+        ↓
+apply crossEhrhart_succ_d
+```
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/ehrhart-cube-proven-oq-02/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-02/state.md
@@ -1,66 +1,73 @@
 # Research State: ehrhart-cube-proven-oq-02
 
 ## Current State
-**Phase**: ACT — `cweight_le_iff` + `cweight_translate` foundation helpers
-added; `crossBall_card` succ-d remains
+**Phase**: ACT — fiber bijection helper added; 1 sorry remains
 **Path**: incremental sorry closure
 **Since**: 2026-05-07
 **Last Updated**: 2026-05-08
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
 One sorry remains in `proofs/Proofs/EhrhartCrossPolytope.lean`:
-- `crossBall_card` succ-d case — Finset slicing decomposition by last
-  coordinate.
+- `crossBall_card` succ-d case — slicing decomposition that uses
+  `fiber_card_eq_crossBall_card` (this session) once fibers are
+  identified with the filter-set form.
 
 ## Active Approach (helpers + slicing)
 
-The slicing argument uses the centered-weight characterization. Two
-foundation lemmas are now in place (Session 3, this PR):
+The slicing argument uses the centered-weight characterization. Five
+foundation lemmas are now in place:
 
 - `cweight_le_iff (n a M : ℕ)` — `(if a ≤ n then n - a else a - n) ≤ M
-  ↔ n - M ≤ a ∧ a ≤ n + M`. Proved by `omega` after the case split.
+  ↔ n - M ≤ a ∧ a ≤ n + M`. (Session 3)
 - `cweight_translate (n M a : ℕ) (hM : M ≤ n) (h_lo : n - M ≤ a)
-  (h_hi : a ≤ n + M)` — the cweight at center `n` of `a` equals the
-  cweight at center `M` of `a - (n - M)`. The bridge identity for
-  the fiber bijection.
+  (h_hi : a ≤ n + M)` — bridge identity; cweight at center `n` of `a`
+  equals cweight at center `M` of `a - (n - M)`. (Session 3)
+- `cweight_sum_individual {d n M} (y) (hsum) (j)` — sum bound implies
+  individual bound. (Session 4)
+- `cweight_sum_range {d n M} (hM) (y) (hsum) (j)` — sum bound + `M ≤ n`
+  forces `(y j).val ∈ [n - M, n + M]`. (Session 4)
+- `fiber_card_eq_crossBall_card (d n M : ℕ) (hM : M ≤ n)` — the cardinality
+  identity: `{y : Fin d → Fin (2n+1) | Σ cweight(y, n) ≤ M}` is in bijection
+  with `crossBall d M`, via `yᵢ ↦ ⟨(yᵢ).val - (n - M), _⟩`. (Session 4,
+  via `Finset.card_bij'`, ~80 lines.)
 
-Path to closing the sorry (estimated 200+ lines split across 2-3 sessions):
+## Path to closing the remaining sorry
 
-1. **Fiber bijection** (`fiber_card_eq_crossBall_card`): For `M ≤ n`,
-   the filtered set `{y : Fin d → Fin (2n+1) | Σ cweight(yᵢ) ≤ M}`
-   has the same cardinality as `crossBall d M`. Proof via
-   `Finset.card_bij` with `yᵢ ↦ ⟨(yᵢ).val - (n - M), proof⟩`.
-   - Key technical care: definitional reduction of
-     `(⟨v, _⟩ : Fin _).val` to `v` inside if-expressions and sums.
-     Use `show` with the explicit non-mk form to bridge calc steps,
-     and `rw` with the `cweight_translate`-derived sum equality.
-
-2. **Slicing**: `(crossBall (d+1) n).card = ∑ j : Fin (2n+1), (fiber j).card`
+1. **Slicing** (the rest of `crossBall_card` succ-d, ≈80–120 lines):
+   `(crossBall (d+1) n).card = ∑ j : Fin (2n+1), (fiber j).card`
    via `Finset.card_eq_sum_card_fiberwise` projecting on the last coord.
-   Then `(fiber j) ≃ {y : Fin d → Fin (2n+1) | Σ cweight ≤ n - δ_j}` via
-   `Fin.snoc`/`Fin.init`. Apply (1) to convert each fiber to
-   `crossBall d (n - δ_j)`.
+   For each `j`, the fiber is in bijection with the filter-set used by
+   `fiber_card_eq_crossBall_card` for `M_j = if j.val ≤ n then j.val
+   else 2n - j.val` (= `n - cweight(j, n)`). Apply
+   `fiber_card_eq_crossBall_card d n M_j (by omega)` to get
+   `(fiber j).card = (crossBall d M_j).card`.
+   - The fiber-to-filter-set bijection itself is via `Fin.snoc` /
+     `Fin.init`: drop the last coordinate, and the remaining d
+     coordinates satisfy the cweight-sum-bound at center `n` with
+     budget `M_j`.
 
-3. **j↔(2n−j) pairing**: `∑ j ∈ Finset.range (2n+1),
-   crossEhrhart d (n - δ_j) = crossEhrhart d n + 2 · ∑ m ∈ range n,
+2. **j↔(2n−j) pairing**: `∑ j ∈ Finset.range (2n+1),
+   crossEhrhart d (n - cweight(j, n)) = crossEhrhart d n + 2 · ∑ m ∈ range n,
    crossEhrhart d m` by splitting `range (2n+1) = range n ∪ {n} ∪
-   range n` (shifted by n+1) and reversing the high half via the
+   range n` (shifted by `n+1`) and reversing the high half via the
    bijection `m ↦ n - 1 - m` (or via `Finset.sum_nbij'`).
 
-4. **Apply IH**: requires `induction d generalizing n` so the IH gives
+3. **Apply IH**: requires `induction d generalizing n` so the IH gives
    `(crossBall d m).card = crossEhrhart d m` for **every** m. Then
    `crossEhrhart_succ_d` closes the proof.
 
 ## Attempt Count
-- Total attempts: 3
+- Total attempts: 4
 - Approaches tried:
   - Session 1 (researcher-8, OBSERVE): mapped Mathlib tools for
     `crossEhrhart_is_poly` (descPochhammer-based)
   - Session 2 (researcher-8, ACT): closed `crossEhrhart_is_poly` (PR #16734)
   - Session 3 (researcher-11, ACT): added `cweight_le_iff` and
-    `cweight_translate` foundation helpers; documented full path for
-    the remaining sorry
+    `cweight_translate` foundation helpers
+  - Session 4 (researcher-9, ACT): added `cweight_sum_individual`,
+    `cweight_sum_range`, and `fiber_card_eq_crossBall_card` (via
+    `Finset.card_bij'`)
 
 ## Blockers
 - **Local Lean build**: Worktree's `proofs/.lake` symlink is a self-cycle
@@ -68,16 +75,20 @@ Path to closing the sorry (estimated 200+ lines split across 2-3 sessions):
   PR-driven CI is the ground truth.
 
 ## Next Action
-**For Session 4**: Implement `fiber_card_eq_crossBall_card` using
-`Finset.card_bij` and the cweight helpers from this session. Estimated
-80-120 lines. Use `show` and explicit intermediate sums to avoid
-anonymous proof terms in Fin literals.
+**For Session 5**: Use `fiber_card_eq_crossBall_card` to express
+`(crossBall (d+1) n).card = ∑ j ∈ range (2n+1), (crossBall d M_j).card`
+where `M_j = if j ≤ n then j else 2n - j`. The fiber-to-filter
+bijection over `Fin.snoc` is the next chunk; estimate ~80–120 lines.
 
 ## References
-- `proofs/Proofs/EhrhartCrossPolytope.lean:336-354` — cweight helpers
-  (this session)
-- `proofs/Proofs/EhrhartCrossPolytope.lean:371-376` — main theorem with
-  sorry
+- `proofs/Proofs/EhrhartCrossPolytope.lean:336-354` — cweight bridge
+  helpers (Session 3)
+- `proofs/Proofs/EhrhartCrossPolytope.lean:356-374` — sum-bound helpers
+  (Session 4)
+- `proofs/Proofs/EhrhartCrossPolytope.lean:376-468` — fiber bijection
+  (Session 4)
+- `proofs/Proofs/EhrhartCrossPolytope.lean:485-490` — main theorem
+  with sorry
 - `proofs/Proofs/EhrhartCrossPolytope.lean:205-215` — `crossEhrhart_succ_d`
-- Mathlib: `Finset.card_bij`, `Finset.card_eq_sum_card_fiberwise`,
+- Mathlib: `Finset.card_bij'`, `Finset.card_eq_sum_card_fiberwise`,
   `Fin.snoc`, `Finset.sum_nbij'`


### PR DESCRIPTION
## Summary

Session 4 progress on `ehrhart-cube-proven-oq-02`. Adds three private
lemmas to `proofs/Proofs/EhrhartCrossPolytope.lean` that close the
foundation needed for the slicing decomposition of `crossBall_card`.

**Sorry count**: 1 → 1 (unchanged). **lineCount**: 423 → 537.

## What's added

- `cweight_sum_individual` — sum of centered weights at center `n` is
  ≤ `M` ⇒ each individual weight is ≤ `M`. (One-line proof via
  `Finset.single_le_sum`.)
- `cweight_sum_range` — same hypothesis + `M ≤ n` ⇒ each `y_i` lies in
  `[n - M, n + M]`. (One-line corollary of `cweight_le_iff`.)
- `fiber_card_eq_crossBall_card (d n M)` `(hM : M ≤ n)` — the
  cardinality identity:
  ```lean
  (Finset.univ.filter fun y : Fin d → Fin (2*n+1) =>
    ∑ i, (if (y i).val ≤ n then n - (y i).val else (y i).val - n) ≤ M).card =
  (crossBall d M).card
  ```
  Proof via `Finset.card_bij'` with the translation
  `yᵢ ↦ ⟨(yᵢ).val - (n - M), _⟩`. ~80 lines.

The two-sum-equal step in the bijection's image-bound obligations was
the trickiest part of the previous session's attempted full slicing
proof. Pulling it out as a black-box lemma lets future sessions
collapse fiber cards directly to `crossBall d M_j`.

## Path forward

Session 5 should:
1. project `crossBall (d+1) n` on the last coordinate via
   `Finset.card_eq_sum_card_fiberwise`;
2. identify each fiber with the filter-set form, apply
   `fiber_card_eq_crossBall_card`;
3. j↔(2n−j) pairing via `Finset.sum_nbij'` and range split;
4. apply IH (`induction d generalizing n`) and `crossEhrhart_succ_d`.

Estimate ≈80–120 lines.

## Test plan

- [ ] CI Docker build passes (local build deferred — broken `.lake`
      symlink, ≥45 min CI cycle).
- [ ] If CI rejects: most likely culprits are (a) `Finset.card_bij'`
      arity differences, (b) `(z idx).is_lt` field name vs `.isLt`,
      (c) `Fin.mk.val` definitional reduction needing an explicit
      `simp only [Fin.val_mk]`. All three are mechanical fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)