### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): Session 6 — eliminate standardNormalCDF opaque (axiomCount 2→1)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -7,17 +7,20 @@ distribution to N(0,1) for each coordinate as n → ∞?"
 
 ## Status
 
-**Reduction complete.** This file STATES the multinomial marginal CLT
-and reduces it to the classical de Moivre–Laplace (binomial) CLT plus the
-already-proved marginal-PMF identity from `BinomialTheoremOQ02OQ01OQ02`.
-The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` is now fully
-proved (Phase-3 deliverable, this file).
+**Reduction complete + standard-normal opaque eliminated.** This file STATES
+the multinomial marginal CLT and reduces it to the classical de Moivre–Laplace
+(binomial) CLT plus the already-proved marginal-PMF identity from
+`BinomialTheoremOQ02OQ01OQ02`. The reduction lemma
+`multinomialMarginalCDF_eq_binomialCDF` is fully proved (Phase-3 deliverable,
+Session 3).
 
 The de Moivre–Laplace CLT itself is taken as an axiom: a measure-theoretic
 proof from Mathlib's `ProbabilityTheory.iid_central_limit_theorem` is
 non-trivial (CDF ↔ measure-weak-convergence bridge) and is left for a
 follow-up effort. After this file, the single mathematical assumption
-beyond Mathlib is the classical Binomial CLT itself.
+beyond Mathlib is the classical Binomial CLT itself: `standardNormalCDF` is
+no longer `opaque` — it is a `noncomputable def` integrating Mathlib's
+`ProbabilityTheory.gaussianPDFReal 0 1` over `Set.Iic x` (Session 6 contribution).
 
 ## What This File Provides
 
@@ -26,9 +29,13 @@ beyond Mathlib is the classical Binomial CLT itself.
 2. `multinomialMarginalCDF s p n i₀ x` — concrete CDF of the marginal X_{i₀}
    of Multinomial(n, p), defined by summing `multinomialProb` over the
    filtered piAntidiag.
-3. `standardNormalCDF` — opaque marker for the standard normal CDF.
+3. `standardNormalCDF` — concrete `noncomputable def` integrating
+   `ProbabilityTheory.gaussianPDFReal 0 ⟨1, zero_le_one⟩` over `Set.Iic x`.
+   No longer an axiom (was `opaque` in Sessions 2–5).
 4. `binomial_clt_pointwise` — AXIOM: pointwise convergence of standardized
-   binomial CDF to standardNormalCDF.
+   binomial CDF to `standardNormalCDF` — now a substantive mathematical
+   claim about the *defined* normal CDF, not a vacuous statement about an
+   uninterpreted opaque.
 5. `multinomialMarginalCDF_eq_binomialCDF` — reduction lemma, **proved**:
    the marginal CDF of the multinomial equals the binomial CDF with
    parameter p(i₀). Proof regroups `∑ k ∈ s.piAntidiag n` into fibers
@@ -51,8 +58,12 @@ gives the multinomial marginal CLT.
 ## Honest Reporting
 
 - Sorries: 0 (Phase-3 reduction-lemma proof discharges the prior sorry).
-- Axioms: 2 (`binomial_clt_pointwise` + `standardNormalCDF` opaque).
-- Status: axiomatized — not "verified".
+- Axioms: 1 (`binomial_clt_pointwise`). The `standardNormalCDF` opaque
+  was eliminated in Session 6 by replacing it with a `noncomputable def`
+  built from `ProbabilityTheory.gaussianPDFReal`.
+- Status: axiomatized — not "verified". The single remaining axiom is
+  the classical de Moivre–Laplace theorem, a substantive mathematical
+  claim, not a structural placeholder.
 
 The contribution of this file is the *full reduction* of the multinomial
 marginal CLT to the classical Binomial CLT, leaving only the latter as
@@ -78,6 +89,8 @@ import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Sqrt
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
+import Mathlib.Probability.Distributions.Gaussian.Basic
+import Mathlib.MeasureTheory.Integral.SetIntegral
 import Mathlib.Tactic
 import Proofs.BinomialTheoremOQ02OQ01OQ02
 
@@ -107,14 +120,22 @@ noncomputable def multinomialMarginalCDF
       BinomialTheoremOQ02OQ01OQ02.multinomialProb s p n k
     else 0
 
-/-! ## Standard normal CDF (opaque) -/
+/-! ## Standard normal CDF (concrete via Mathlib's Gaussian PDF) -/
 
-/-- The standard normal CDF, `Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt`.
+/-- The standard normal CDF,
+    `Φ(x) = ∫_{-∞}^x (2π)^{-1/2} · e^{-t²/2} dt`,
+    defined as the Lebesgue integral of `ProbabilityTheory.gaussianPDFReal 0 1`
+    over `Set.Iic x`.
 
-    Declared `opaque` here — Mathlib provides a measure-theoretic standard
-    normal (`Mathlib.Probability.Distributions.Gaussian.Basic`); bridging
-    that measure to a CDF function is left for a Phase-3 effort. -/
-opaque standardNormalCDF : ℝ → ℝ
+    This is a `noncomputable def` (not `opaque`): it carries no axiomatic
+    content, only a concrete bridge to Mathlib's measure-theoretic Gaussian
+    family. The previous `opaque` version implicitly added the existence of
+    a normal CDF as an unverified assumption; this definition discharges
+    that assumption by giving an explicit body in terms of
+    `ProbabilityTheory.gaussianPDFReal 0 ⟨1, zero_le_one⟩`. -/
+noncomputable def standardNormalCDF (x : ℝ) : ℝ :=
+  ∫ t in Set.Iic x,
+    ProbabilityTheory.gaussianPDFReal 0 ⟨(1 : ℝ), zero_le_one⟩ t
 
 /-! ## Axiom: classical de Moivre–Laplace (binomial CLT) -/
 

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
@@ -516,6 +516,147 @@ This is exactly the input the Portmanteau bridge will need.
 
 ---
 
+## Session 2026-05-08 (Session 6, researcher-8) — ACT (Stretch: opaque → def)
+
+**Mode**: BUILD-ON-PRIOR (Sessions 1–5 produced a sorry-free, two-axiom file
+with the structural-properties library complete; this session executes the
+"Stretch (independent)" step from Sessions 4 and 5: eliminate the
+`standardNormalCDF` opaque).
+
+**Outcome**: replaced the `opaque standardNormalCDF : ℝ → ℝ` with a
+`noncomputable def` integrating `ProbabilityTheory.gaussianPDFReal 0 ⟨1,
+zero_le_one⟩` over `Set.Iic x`. **Axiom count: 2 → 1**. The single
+remaining axiom is `binomial_clt_pointwise` (the substantive de
+Moivre-Laplace claim itself); the previous opaque-marker assumption is
+discharged.
+
+### What Was Built
+
+**Replaced** (line 117):
+```lean
+opaque standardNormalCDF : ℝ → ℝ
+```
+
+**With** (lines 136–138):
+```lean
+noncomputable def standardNormalCDF (x : ℝ) : ℝ :=
+  ∫ t in Set.Iic x,
+    ProbabilityTheory.gaussianPDFReal 0 ⟨(1 : ℝ), zero_le_one⟩ t
+```
+
+This is exactly the classical formulation
+`Φ(x) = ∫_{-∞}^x (2π)^{-1/2} · e^{-t²/2} dt` via Mathlib's standard
+Gaussian-density bridge. The pattern matches `ShannonEntropyOQ01.lean:260–278`
+(same `ProbabilityTheory.gaussianPDFReal μ ⟨σ², sq_nonneg σ⟩` idiom,
+specialized here to `μ = 0`, `σ² = 1`).
+
+**Imports added**:
+- `Mathlib.Probability.Distributions.Gaussian.Basic`
+- `Mathlib.MeasureTheory.Integral.SetIntegral`
+
+(These were already pulled in by `Mathlib.Tactic`/`import Mathlib` in
+ShannonEntropyOQ01; making them explicit here keeps the import graph
+auditable.)
+
+### Why This Is a Real Axiom Reduction (Not Cosmetic)
+
+The Sessions 2–5 file used `opaque standardNormalCDF : ℝ → ℝ`, declaring
+that *some* function of type `ℝ → ℝ` exists and is named `standardNormalCDF`.
+The axiom `binomial_clt_pointwise` then said the standardized binomial CDF
+converges to that opaque target. As a *mathematical claim*, this is
+vacuous: take `standardNormalCDF` to be the pointwise limit (which exists
+by de Moivre-Laplace) and the axiom is automatically satisfied.
+
+After this session, `standardNormalCDF` is the actual standard normal CDF
+(Gaussian-density integrated to `x`). The axiom now claims that the
+standardized binomial CDF converges to *that specific function*. This is
+a genuine mathematical statement — the classical de Moivre-Laplace
+theorem — not a structural placeholder.
+
+Per the project's Axiom Integrity Policy: `opaque` is counted in
+`axiomCount` (it is an unverified assumption-bearing constant). Replacing
+it with a `noncomputable def` whose body is `ProbabilityTheory.gaussianPDFReal`
+genuinely reduces the assumption count by 1.
+
+### What `multinomial_marginal_clt` Now Asserts
+
+Before:
+- "Standardized multinomial marginal CDF converges to *some* function `Φ`,
+  about which we assume nothing."
+
+After (this session):
+- "Standardized multinomial marginal CDF converges to
+  `∫_{-∞}^x ProbabilityTheory.gaussianPDFReal 0 ⟨1, _⟩ t`, the
+  Gaussian-measure CDF."
+
+The proof of `multinomial_marginal_clt` is **unchanged** (uses
+`binomial_clt_pointwise` + `Filter.Tendsto.congr` via the reduction
+lemma); only the *meaning* of the limit symbol is sharpened.
+
+### Status After This Session
+
+* Sorries: 0 (unchanged).
+* Axioms: **1 (was 2)** — only `binomial_clt_pointwise` remains.
+  `standardNormalCDF` is now a definition.
+* Theorems: 7 (unchanged).
+* Definitions: 3 (was 2) — added `standardNormalCDF` as a definition.
+* Substantive theorem count: 6 (unchanged).
+* File length: 351 lines (was 330; +21 for the new def + docstring + 2
+  new explicit imports + updates to the top-of-file docstring).
+* Status: still `axiomatized` (single axiom remains).
+
+### Honest Reporting
+
+* Local Docker build was **not** run (CI is the ground truth, and the
+  worktree's `proofs/.lake` recursive-symlink trap would force a fresh
+  Mathlib clone). The replacement is mechanical: the body uses idioms
+  already exercised in `ShannonEntropyOQ01.lean` (lines 260–278), and
+  the only consumer of `standardNormalCDF` (the `binomial_clt_pointwise`
+  axiom and the `multinomial_marginal_clt` derived theorem) does not
+  unfold it. Confidence is high but not CI-verified at push time.
+
+* This session is **axiom elimination**, not new proof. It does not
+  reduce sorry count (already 0) and does not add new mathematical
+  content; it sharpens the meaning of the existing main theorem by
+  pinning the limit symbol to a defined function. Per the gallery's
+  Axiom Integrity Policy this is genuine progress (axiomCount 2 → 1).
+
+* The `(1 : ℝ)` annotation on the NNReal anonymous constructor is
+  defensive — Lean elaborates `⟨1, zero_le_one⟩` to NNReal in this
+  context but pinning the type avoids ambiguity if the integrand
+  signature ever shifts.
+
+### Files Changed
+
+- UPDATED `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`
+  (330 → 351 lines; opaque → def; 2 new imports; top-docstring rewrite).
+- UPDATED `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json`
+  (axiomCount 2 → 1, lineCount 330 → 351, definitionCount 2 → 3,
+   imports list, assumptions narrative, originalContributions, sections,
+   keyInsights, conclusion summary/implications).
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md`
+  (this entry).
+- UPDATED `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md`
+  (Session 6 status; promote remaining-axiom attack to next action).
+- UPDATED `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json`
+  (knowledge fields).
+
+### Next Steps
+
+1. **Session 7 (axiom attack)**: discharge `binomial_clt_pointwise` from
+   `ProbabilityTheory.iid_central_limit_theorem` via the Portmanteau
+   bridge. The four structural lemmas added in Sessions 4–5 — together
+   with the now-defined `standardNormalCDF` — are the prerequisites.
+   Estimated ~150–200 lines of new Lean. Once this lands, the file is
+   fully verified (0 axioms, 0 sorries).
+
+2. **Sibling stretch**: with the standard-normal CDF now defined, prove
+   continuity (`Continuous standardNormalCDF`) by integration-of-a-
+   continuous-function. Continuity is required by the Portmanteau bridge
+   for the upcoming Session 7 work, so this is a natural staging step.
+
+---
+
 ## Dead Ends
 
 - None yet.

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -1,25 +1,29 @@
 # Research State: binomial-theorem-oq-02-oq-01-oq-01-oq-03
 
 ## Current State
-**Phase**: ACT (Phase-4 structural-lemma prep — library complete)
+**Phase**: ACT (axiom elimination — opaque marker discharged)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (Session 5, researcher-1)
-**Iteration**: 5
+**Last Updated**: 2026-05-08 (Session 6, researcher-8)
+**Iteration**: 6
 
 ## Current Focus
-Phase-4 prep continued: added `binomialCDF_zero_le` (CDF ≥ 0) and
-`binomialCDF_le_one` (CDF ≤ 1) — two structural lemmas that round out
-the structural-properties library. `binomialCDF_le_one` uses `add_pow`
-to expand `(p + (1−p))^n = 1` and bounds the CDF by dropping
-non-negative summands. Combined with the prior session's
-`binomialCDF_neg` and `binomialCDF_mono`, the structural library is now
-sufficient for the Phase-4 Portmanteau-bridge proof of
-`binomial_clt_pointwise`.
+Session 6 executes the long-standing "Stretch (independent)" item from
+Sessions 4 and 5: replace the `standardNormalCDF` opaque marker with a
+concrete `noncomputable def` integrating
+`ProbabilityTheory.gaussianPDFReal 0 ⟨1, zero_le_one⟩` over `Set.Iic x`.
+**Axiom count: 2 → 1**.
 
-No axiom elimination this session; the file is still 0 sorries / 2
-axioms (`binomial_clt_pointwise` + `standardNormalCDF` opaque). Next
-session begins the Phase-4 axiom attack itself.
+The replacement is mechanical (the only consumers of `standardNormalCDF`
+— the `binomial_clt_pointwise` axiom and the `multinomial_marginal_clt`
+derived theorem — do not unfold it), and follows the same `gaussianPDFReal`
+idiom as `ShannonEntropyOQ01.lean:260–278`. The single remaining axiom
+(`binomial_clt_pointwise`) is the substantive de Moivre-Laplace claim
+itself; the previous opaque-marker assumption is discharged.
+
+No new sorries, no proof changes — only a *meaning sharpening* of the
+existing main theorem (the limit symbol is now pinned to a defined
+function rather than an uninterpreted opaque).
 
 ## Active Approach
 **CDF-based** rather than the measure-theoretic Bernoulli-sum approach
@@ -35,7 +39,7 @@ sketched in iteration 1. Justification:
   Phase-3 task is to bridge to Mathlib's measure-theoretic Gaussian.
 
 ## Attempt Count
-- Total attempts: 5 (Sessions 1–5)
+- Total attempts: 6 (Sessions 1–6)
 - Approaches tried:
   - **Iteration 1** (researcher-8, OBSERVE→ORIENT): planned i.i.d.-CLT
     decomposition (Sublemmas A, B, C, D). No Lean code.
@@ -51,45 +55,50 @@ sketched in iteration 1. Justification:
     `binomialCDF_mono` (monotone in `x` when `0 ≤ p ≤ 1`). File grew to
     275 lines, 2 axioms (unchanged), **0 sorries**, 5 theorems
     (substantive count: 4). Merged in #16951.
-  - **Iteration 5** (researcher-1, ACT — THIS SESSION):
+  - **Iteration 5** (researcher-1, ACT):
     Phase-4 prep continued. Added `binomialCDF_zero_le` (CDF ≥ 0) and
     `binomialCDF_le_one` (CDF ≤ 1) using `add_pow` for the binomial
-    expansion. File now 330 lines, 2 axioms (unchanged), **0 sorries**,
-    7 theorems (substantive count: 6).
+    expansion. File: 330 lines, 2 axioms (unchanged), **0 sorries**,
+    7 theorems (substantive count: 6). Merged in #16992.
+  - **Iteration 6** (researcher-8, ACT — THIS SESSION):
+    Eliminated `standardNormalCDF` opaque. Replaced with a
+    `noncomputable def` integrating `ProbabilityTheory.gaussianPDFReal
+    0 ⟨1, zero_le_one⟩` over `Set.Iic x`. **Axiom count 2 → 1.**
+    File: 351 lines, **1 axiom** (only `binomial_clt_pointwise` remains),
+    0 sorries, 7 theorems (substantive count: 6), 3 definitions
+    (was 2). The proof of `multinomial_marginal_clt` is unchanged —
+    the limit symbol is now pinned to a defined function rather than
+    an uninterpreted opaque.
 
 ## Blockers
 - **Build verification**: this session could not run the Docker build
   for direct compile-check (long iteration time + worktree symlink trap).
-  The scaffold uses well-tested Mathlib idioms (`Filter.Tendsto.congr`,
-  `Real.sqrt`, `Finset.range`); confidence is high but not verified.
+  The change is mechanical (opaque → def, body uses idioms exercised in
+  `ShannonEntropyOQ01.lean:260–278`); confidence is high but not verified.
   CI is the ground truth.
-- **Reduction lemma sorry**: the proof of
-  `multinomialMarginalCDF_eq_binomialCDF` is a routine fiber-regrouping
-  + application of the parent's `multinomial_marginal_pmf`. Phase-3 target.
-- **`standardNormalCDF` opaque**: counts as +1 axiom; Phase-3 should
-  bridge to Mathlib's Gaussian measure.
-- **`binomial_clt_pointwise` axiom**: Phase-3 should derive from
-  `ProbabilityTheory.iid_central_limit_theorem` via the Portmanteau
-  theorem at continuity points.
+- **`binomial_clt_pointwise` axiom**: the single remaining axiom. Future
+  sessions can derive it from `ProbabilityTheory.iid_central_limit_theorem`
+  via the Portmanteau theorem at continuity points of the standard
+  normal CDF (every point, since Φ is continuous).
 
 ## Next Action
 
-**Session 6 (Phase-4 axiom attack)**: discharge `binomial_clt_pointwise`.
-The cleanest path is to bridge from Mathlib's
+**Session 7 (axiom attack)**: discharge `binomial_clt_pointwise`. The
+cleanest path is to bridge from Mathlib's
 `ProbabilityTheory.iid_central_limit_theorem` applied to a Bernoulli($p$)
 i.i.d. sequence; this requires a Portmanteau-style CDF-from-measure-
 weak-convergence step. The structural lemmas added in Sessions 4–5
 (`binomialCDF_neg`, `binomialCDF_mono`, `binomialCDF_le_one`,
-`binomialCDF_zero_le`) are prerequisites for the bridge. Alternative
-path: Stirling's formula for a direct asymptotic-analysis proof.
+`binomialCDF_zero_le`) — together with the now-defined
+`standardNormalCDF` — are the prerequisites. Alternative path:
+Stirling's formula for a direct asymptotic-analysis proof. Estimated
+~150–200 lines of new Lean. Once this lands, the file is fully verified
+(0 axioms, 0 sorries).
 
-**Stretch (independent)**: replace `standardNormalCDF` opaque with
-a `noncomputable def` integrating `gaussianPDFReal 0 ⟨1, _⟩` over
-`Set.Iic x`. ShannonEntropyOQ01.lean already uses
-`ProbabilityTheory.gaussianPDFReal μ ⟨σ², sq_nonneg σ⟩` so the
-API is precedented; the bridge to a CDF function is one
-`MeasureTheory.integral` definition. Removes the opaque assumption
-entirely (axiom count 2 → 1).
+**Sibling stretch**: prove `Continuous standardNormalCDF` by integration-
+of-a-continuous-function on `Set.Iic`. The Portmanteau bridge in
+Session 7 needs continuity at every point of the limit CDF, so this is
+a natural staging step that does not depend on Session 7's main work.
 
 ---
 

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -19,13 +19,14 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-08",
-    "axiomCount": 2,
-    "lineCount": 330,
-    "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. (2) `standardNormalCDF` opaque marker — the standard normal CDF Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt, currently opaque pending bridge from Mathlib's measure-theoretic Gaussian. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` is now fully proved (Phase-3 deliverable): it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
+    "axiomCount": 1,
+    "lineCount": 351,
+    "assumptions": "(1) `binomial_clt_pointwise` axiom — the classical de Moivre-Laplace theorem (1733/1812): for 0 < p < 1, the standardized binomial CDF converges pointwise to the standard normal CDF. The `standardNormalCDF` opaque from Sessions 2–5 has been ELIMINATED in Session 6: it is now a `noncomputable def` integrating `ProbabilityTheory.gaussianPDFReal 0 ⟨1, zero_le_one⟩` over `Set.Iic x` (the standard 1/√(2π)·e^{-t²/2} density), so the previous opaque-marker assumption is discharged. The single remaining axiom is the substantive de Moivre-Laplace claim itself, no longer paired with a vacuous opaque. The reduction lemma `multinomialMarginalCDF_eq_binomialCDF` is fully proved (Phase-3, Session 3): it partitions the multinomial sum over s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1) using `Finset.sum_fiberwise_of_maps_to`, hoists the if-condition (k i₀ : ℝ) ≤ x out of the inner sum (it depends only on j), and applies the parent file's `multinomial_marginal_pmf` to each fibre. The main theorem `multinomial_marginal_clt` is *derived* — not itself an axiom — via `Filter.Tendsto.congr`.",
     "originalContributions": [
       "binomialCDF: concrete CDF of Binomial(n,p) as a finite sum of binomial PMF terms with a step indicator",
       "multinomialMarginalCDF: marginal CDF of coordinate i₀ of Multinomial(n,p), defined directly from multinomialProb",
-      "binomial_clt_pointwise: axiomatic statement of de Moivre-Laplace in CDF form (statement matches the classical formulation, avoids measure-theoretic machinery)",
+      "standardNormalCDF (Session 6): noncomputable def integrating ProbabilityTheory.gaussianPDFReal 0 ⟨1, zero_le_one⟩ over Set.Iic x — eliminates the prior `opaque` assumption (axiom count 2 → 1)",
+      "binomial_clt_pointwise: axiomatic statement of de Moivre-Laplace in CDF form (statement matches the classical formulation, avoids measure-theoretic machinery; now references a *defined* standardNormalCDF rather than an opaque marker)",
       "piAntidiag_apply_le (private): every coordinate of a composition k ∈ s.piAntidiag n is ≤ n — proved",
       "multinomialMarginalCDF_eq_binomialCDF: reduction lemma — proved via Finset.sum_fiberwise_of_maps_to + parent's multinomial_marginal_pmf",
       "multinomial_marginal_clt: derived theorem (no axiom of its own) combining the above via Filter.Tendsto.congr",
@@ -36,7 +37,7 @@
     ],
     "theoremCount": 7,
     "substantiveTheoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "leanFile": {
     "imports": [
@@ -45,6 +46,8 @@
       "Mathlib.Analysis.SpecialFunctions.Pow.Real",
       "Mathlib.Analysis.SpecialFunctions.Sqrt",
       "Mathlib.Topology.Algebra.Order.LiminfLimsup",
+      "Mathlib.Probability.Distributions.Gaussian.Basic",
+      "Mathlib.MeasureTheory.Integral.SetIntegral",
       "Mathlib.Tactic",
       "Proofs.BinomialTheoremOQ02OQ01OQ02"
     ],
@@ -53,12 +56,12 @@
       "BigOperators"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
-    "lineCount": 330,
-    "axiomCount": 2,
+    "lineCount": 351,
+    "axiomCount": 1,
     "theoremCount": 7,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
     "sorries": 0
   },
@@ -81,43 +84,43 @@
       "id": "sec-cdf-defs",
       "title": "CDF Definitions: Binomial and Multinomial Marginal",
       "range": null,
-      "startLine": 88,
-      "endLine": 108
+      "startLine": 101,
+      "endLine": 121
     },
     {
       "id": "sec-stdnormal",
-      "title": "Standard Normal CDF (opaque)",
+      "title": "Standard Normal CDF (concrete via Mathlib's Gaussian PDF)",
       "range": null,
-      "startLine": 110,
-      "endLine": 117
+      "startLine": 123,
+      "endLine": 138
     },
     {
       "id": "sec-binomial-clt-axiom",
       "title": "Axiom: Classical de Moivre-Laplace (Binomial CLT)",
       "range": null,
-      "startLine": 119,
-      "endLine": 136
+      "startLine": 140,
+      "endLine": 157
     },
     {
       "id": "sec-reduction",
       "title": "Reduction Lemma: Multinomial Marginal CDF = Binomial CDF",
       "range": null,
-      "startLine": 138,
-      "endLine": 210
+      "startLine": 159,
+      "endLine": 231
     },
     {
       "id": "sec-structural",
       "title": "Structural Properties of binomialCDF (Phase-4 prep)",
       "range": null,
-      "startLine": 212,
-      "endLine": 301
+      "startLine": 233,
+      "endLine": 322
     },
     {
       "id": "sec-main",
       "title": "Main Theorem: Multinomial Marginal CLT (Derived)",
       "range": null,
-      "startLine": 303,
-      "endLine": 330
+      "startLine": 324,
+      "endLine": 351
     }
   ],
   "overview": {
@@ -128,7 +131,7 @@
     "keyInsights": [
       "The marginal-PMF identity from `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf` does the heavy lifting: once it's established that $\\sum_{k: k(i_0) = j} P(X=k) = \\binom{n}{j} p_{i_0}^j (1-p_{i_0})^{n-j}$, the multinomial marginal CDF *equals* the binomial CDF (not just converges to it), so the CLT for the marginal is exactly the CLT for the binomial.",
       "Stating the CLT in CDF form (`Filter.Tendsto` of `binomialCDF`) avoids the measure-theoretic setup needed to instantiate Mathlib's `iid_central_limit_theorem`. The CDF form matches the classical de Moivre-Laplace presentation and keeps the reduction transparent.",
-      "Declaring `standardNormalCDF` as `opaque` records that it is *some* function ℝ → ℝ — Lean treats it as an unknown — while keeping the namespace open for a Phase-3 substitution that bridges to Mathlib's Gaussian measure.",
+      "(Updated Session 6) `standardNormalCDF` is now a concrete `noncomputable def`: $\\Phi(x) = \\int_{-\\infty}^x \\mathrm{gaussianPDFReal}\\,0\\,1\\,t\\,dt$, integrated over `Set.Iic x`. Earlier sessions used `opaque standardNormalCDF : ℝ → ℝ` as a structural placeholder; that placeholder is now eliminated, so the only remaining axiom is the substantive de Moivre-Laplace claim itself.",
       "The DERIVED theorem `multinomial_marginal_clt` is not an axiom: it follows from the de Moivre-Laplace axiom plus the reduction lemma via `Filter.Tendsto.congr`. The reduction itself is provable (from already-proved Mathlib + parent-file lemmas), so closing the sorry would shift the only assumption to de Moivre-Laplace.",
       "The non-degeneracy hypothesis $0 < p_{i_0} < 1$ is essential: $p_{i_0} = 0$ gives $X_{i_0} = 0$ a.s. (degenerate), and $p_{i_0} = 1$ gives $X_{i_0} = n$ a.s. (degenerate); the standardization $\\sqrt{np_{i_0}(1-p_{i_0})}$ vanishes in both cases.",
       "The joint multinomial CLT (vector convergence to a degenerate multivariate normal supported on the hyperplane $\\sum y_i = 0$) is *not* derivable from coordinate-wise marginal CLTs — Cramér-Wold is required — and is out of scope here."
@@ -141,8 +144,8 @@
     ]
   },
   "conclusion": {
-    "summary": "The multinomial marginal CLT can be stated cleanly in CDF form and *derived* (not axiomatized separately) from two axioms: the classical de Moivre-Laplace theorem on standardized binomial CDFs, and an opaque marker for the standard normal CDF. The derivation uses the marginal-PMF identity already proved in the parent file (`BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf`). The reduction lemma is now fully proved by partitioning `s.piAntidiag n` along $k(i_0)$ via `Finset.sum_fiberwise_of_maps_to` and applying the parent identity to each fibre.",
-    "implications": "The reduction-based scaffold demonstrates that multinomial marginal CLT does not require new probabilistic machinery beyond what is already proved for the binomial case. Once Mathlib provides a CDF-form de Moivre-Laplace (via a measure-weak-convergence bridge from `ProbabilityTheory.iid_central_limit_theorem`), this entry's `binomial_clt_pointwise` axiom becomes derivable, leaving zero axioms (modulo the `standardNormalCDF` opaque, which can be replaced by a Mathlib-Gaussian-measure-CDF bridge).",
+    "summary": "The multinomial marginal CLT can be stated cleanly in CDF form and *derived* (not axiomatized separately) from a single axiom: the classical de Moivre-Laplace theorem on standardized binomial CDFs. The derivation uses the marginal-PMF identity already proved in the parent file (`BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf`). The reduction lemma is fully proved by partitioning `s.piAntidiag n` along $k(i_0)$ via `Finset.sum_fiberwise_of_maps_to` and applying the parent identity to each fibre. The standard normal CDF is no longer an opaque marker: Session 6 replaced it with a `noncomputable def` integrating `ProbabilityTheory.gaussianPDFReal 0 ⟨1, zero_le_one⟩` over `Set.Iic x`, eliminating the prior placeholder assumption.",
+    "implications": "The reduction-based scaffold demonstrates that multinomial marginal CLT does not require new probabilistic machinery beyond what is already proved for the binomial case. Once Mathlib provides a CDF-form de Moivre-Laplace (via a measure-weak-convergence bridge from `ProbabilityTheory.iid_central_limit_theorem`), this entry's single remaining axiom `binomial_clt_pointwise` becomes derivable, leaving the file fully verified.",
     "openQuestions": [
       "Can the reduction lemma `multinomialMarginalCDF_eq_binomialCDF` be proved by fiber-grouping over $k(i_0)$ values? The proof should regroup $\\sum_{k \\in \\pi(s,n)}$ into $\\sum_{j=0}^n \\sum_{k: k(i_0) = j}$ and apply `multinomial_marginal_pmf`.",
       "Can `binomial_clt_pointwise` be discharged from Mathlib's `ProbabilityTheory.iid_central_limit_theorem`? Bridging a measure-weak-convergence statement to a CDF-pointwise-convergence statement requires the Portmanteau theorem at continuity points of the limit CDF.",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -35,24 +35,22 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T03:30:00.000Z",
-    "iteration": 2,
-    "focus": "Phase-2 STATEMENT scaffold complete: BinomialTheoremOQ02OQ01OQ01OQ03.lean (178 lines, 2 axioms incl. opaque, 1 sorry, 2 theorems). Multinomial marginal CLT stated in CDF form and DERIVED via Filter.Tendsto.congr from the de Moivre-Laplace axiom and the marginal-PMF identity already proved in the parent file. Phase-3 next: discharge the multinomialMarginalCDF_eq_binomialCDF reduction lemma sorry by fiber regrouping over k(i₀).",
+    "since": "2026-05-08T11:50:00.000Z",
+    "iteration": 6,
+    "focus": "Session 6 axiom elimination: replaced standardNormalCDF opaque with noncomputable def integrating ProbabilityTheory.gaussianPDFReal 0 over Set.Iic x. AXIOM COUNT 2 -> 1. Single remaining axiom is binomial_clt_pointwise (de Moivre-Laplace). File: 351 lines, 1 axiom, 0 sorries, 7 theorems, 3 definitions. Pattern matches ShannonEntropyOQ01.lean Gaussian-density idiom.",
     "blockers": [
       "Build verification: this session could not run docker-build.sh; CI is the ground truth.",
-      "Reduction lemma sorry (Phase-3 target, provable from multinomial_marginal_pmf).",
-      "standardNormalCDF opaque (counts as +1 axiom; bridge to Mathlib Gaussian is a Phase-3 task).",
-      "binomial_clt_pointwise axiom (Phase-3 target via Portmanteau bridge to Mathlib iid_central_limit_theorem)."
+      "binomial_clt_pointwise axiom: single remaining axiom; Phase-7 target via Portmanteau bridge to Mathlib iid_central_limit_theorem at continuity points of standard normal CDF (now defined)."
     ],
-    "nextAction": "Phase-3: discharge multinomialMarginalCDF_eq_binomialCDF by fiber regrouping (skeleton in state.md). After that: bridge binomial_clt_pointwise to Mathlibs ProbabilityTheory.iid_central_limit_theorem via Portmanteau.",
+    "nextAction": "Session 7: discharge binomial_clt_pointwise by bridging from ProbabilityTheory.iid_central_limit_theorem applied to Bernoulli(p) i.i.d. summands, via the Portmanteau theorem at every point (Phi continuous). The four structural CDF lemmas from Sessions 4-5 plus the now-defined standardNormalCDF are prerequisites. Stretch: prove Continuous standardNormalCDF (integration of continuous PDF on Set.Iic).",
     "attemptCounts": {
-      "total": 2,
+      "total": 6,
       "currentApproach": 1,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "ACT phase, Phase-4 prep — structural library complete. Lean file BinomialTheoremOQ02OQ01OQ01OQ03.lean (330 lines, 0 sorries, 2 axioms unchanged) now ships with all four structural CDF properties (binomialCDF_neg, binomialCDF_mono, binomialCDF_zero_le, binomialCDF_le_one) prerequisite to the Portmanteau bridge that will discharge binomial_clt_pointwise from Mathlib's iid CLT. Sessions 1-2 produced the CDF-based scaffold (merged in #16866); Session 3 closed the reduction-lemma sorry via Finset.sum_fiberwise_of_maps_to (#16877); Session 4 added binomialCDF_neg and binomialCDF_mono (#16951); Session 5 added the bounded-above (binomialCDF_le_one via add_pow) and bounded-below (binomialCDF_zero_le) lemmas. Next: attempt the Portmanteau bridge to remove binomial_clt_pointwise. Stretch: replace standardNormalCDF opaque with a concrete integral over Mathlib's gaussianPDFReal.",
+    "progressSummary": "ACT phase, Session 6 axiom elimination. Lean file BinomialTheoremOQ02OQ01OQ01OQ03.lean: 351 lines, 0 sorries, **1 axiom (was 2)**. Sessions 1-2 produced the CDF-based scaffold (#16866); Session 3 closed the reduction-lemma sorry via Finset.sum_fiberwise_of_maps_to (#16877); Session 4 added binomialCDF_neg and binomialCDF_mono (#16951); Session 5 added binomialCDF_zero_le and binomialCDF_le_one via add_pow (#16992); Session 6 (THIS) replaced standardNormalCDF opaque with noncomputable def integrating ProbabilityTheory.gaussianPDFReal 0 over Set.Iic x, eliminating 1 axiom. Single remaining axiom: binomial_clt_pointwise (de Moivre-Laplace). Next: Portmanteau bridge to discharge that axiom from Mathlib iid_central_limit_theorem.",
     "builtItems": [
       "binomialCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:90 (concrete CDF of Binomial(n,p))",
       "multinomialMarginalCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:97 (marginal CDF of multinomial)",
@@ -64,7 +62,8 @@
       "Added binomialCDF_neg in BinomialTheoremOQ02OQ01OQ01OQ03.lean:216 — for x < 0, binomialCDF n p x = 0 (Phase-4 prep)",
       "Added binomialCDF_mono in BinomialTheoremOQ02OQ01OQ01OQ03.lean:232 — Monotone (binomialCDF n p) when 0 ≤ p ≤ 1 (Phase-4 Portmanteau prep)",
       "Added binomialCDF_zero_le in BinomialTheoremOQ02OQ01OQ01OQ03.lean:257 — for 0 ≤ p ≤ 1, 0 ≤ binomialCDF n p x (Phase-4 Portmanteau prep)",
-      "Added binomialCDF_le_one in BinomialTheoremOQ02OQ01OQ01OQ03.lean:279 — for 0 ≤ p ≤ 1, binomialCDF n p x ≤ 1 via add_pow / (p+(1-p))^n=1 (Phase-4 Portmanteau prep)"
+      "Added binomialCDF_le_one in BinomialTheoremOQ02OQ01OQ01OQ03.lean:279 — for 0 ≤ p ≤ 1, binomialCDF n p x ≤ 1 via add_pow / (p+(1-p))^n=1 (Phase-4 Portmanteau prep)",
+      "Session 6: standardNormalCDF in BinomialTheoremOQ02OQ01OQ01OQ03.lean:136-138 (noncomputable def, 3 lines body) — replaces the prior opaque marker. Imports added: Mathlib.Probability.Distributions.Gaussian.Basic, Mathlib.MeasureTheory.Integral.SetIntegral. Axiom count: 2 -> 1."
     ],
     "insights": [
       "Multinomial marginal Xᵢ ~ Binomial(n, pᵢ) is ALREADY proved (`BinomialTheoremOQ02OQ01OQ02.lean`); OQ-02-OQ-01-OQ-01-OQ-03 'just' needs the binomial CLT ON TOP",
@@ -82,7 +81,8 @@
       "binomialCDF_zero_le: for 0 ≤ p ≤ 1, every summand of binomialCDF is non-negative (PMF or 0), so the whole sum is non-negative. Finset.sum_nonneg + split_ifs + mul_nonneg, ~9 lines (Session 5)",
       "binomialCDF_le_one: the full unrestricted sum equals (p+(1-p))^n = 1 by add_pow; the CDF replaces some summands with 0; under 0 ≤ p ≤ 1 each summand is non-negative so dropping terms only decreases. Finset.sum_le_sum + add_pow + Finset.sum_congr (to reorder summand into the file's convention) + le_refl, ~22 lines (Session 5)",
       "add_pow in Mathlib.Algebra.BigOperators.Ring.Finset puts the binomial coefficient (Nat.choose n k : R) *last* in each summand: (x+y)^n = ∑ k, x^k * y^(n-k) * (n.choose k : R). The file's PMF convention puts (Nat.choose n j : ℝ) *first*; a Finset.sum_congr + ring step bridges the two (Session 5)",
-      "The four structural lemmas (binomialCDF_neg, binomialCDF_mono, binomialCDF_zero_le, binomialCDF_le_one) collectively establish that binomialCDF n p (·) is a *bona fide* sub-probability CDF on ℝ for any 0 ≤ p ≤ 1 — exactly the Portmanteau-bridge input shape (Session 5)"
+      "The four structural lemmas (binomialCDF_neg, binomialCDF_mono, binomialCDF_zero_le, binomialCDF_le_one) collectively establish that binomialCDF n p (·) is a *bona fide* sub-probability CDF on ℝ for any 0 ≤ p ≤ 1 — exactly the Portmanteau-bridge input shape (Session 5)",
+      "(Session 6) Replacing opaque standardNormalCDF with a concrete noncomputable def integrating Mathlib's gaussianPDFReal is mechanical when no consumer unfolds the symbol — only the axiom statement and the derived theorem reference standardNormalCDF, neither of which unfolds it. Pattern follows ShannonEntropyOQ01.lean:260-278. Reduces axiom count by genuinely sharpening the meaning of binomial_clt_pointwise from 'converges to some uninterpreted Phi' to 'converges to the actual standard normal CDF integral'."
     ],
     "mathlibGaps": [
       "Mathlib's `Mathlib.Probability.Distributions.Binomial` exposes the PMF but the named theorem 'binomial CLT' / 'de Moivre-Laplace' may not be present in canonical form",
@@ -91,8 +91,9 @@
     ],
     "nextSteps": [
       "Session 6 (axiom attack): discharge binomial_clt_pointwise from ProbabilityTheory.iid_central_limit_theorem applied to a Bernoulli(p) i.i.d. sequence, via the Portmanteau theorem at continuity points of the standard normal CDF (every point, since Φ is continuous). The four structural CDF properties added in Sessions 4-5 are the prerequisites.",
-      "Stretch: replace standardNormalCDF opaque with a noncomputable def := ∫ t in Set.Iic x, ProbabilityTheory.gaussianPDFReal 0 ⟨1, _⟩ t. Removes one of the two remaining axioms.",
-      "Future OQ (Cramér-Wold + multinomial covariance): joint multinomial CLT via vector convergence to a degenerate multivariate normal supported on the hyperplane sum y_i = 0; out of scope here but BinomialTheoremOQ02OQ01OQ03.multinomial_covariance is the covariance ingredient."
+      "Future OQ (Cramér-Wold + multinomial covariance): joint multinomial CLT via vector convergence to a degenerate multivariate normal supported on the hyperplane sum y_i = 0; out of scope here but BinomialTheoremOQ02OQ01OQ03.multinomial_covariance is the covariance ingredient.",
+      "Session 7 (axiom attack): discharge binomial_clt_pointwise from ProbabilityTheory.iid_central_limit_theorem via Portmanteau bridge at continuity points of the now-defined standardNormalCDF. ~150-200 lines.",
+      "Sibling stretch: prove Continuous standardNormalCDF by integration-of-a-continuous-function on Set.Iic (continuity is needed by the Session 7 Portmanteau argument)."
     ]
   },
   "tags": [
@@ -143,7 +144,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.055Z",
-  "lastUpdate": "2026-05-08T03:30:00.000Z",
+  "lastUpdate": "2026-05-08T11:50:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Session 6 of the multinomial-marginal-CLT thread. **Eliminates the `standardNormalCDF` opaque marker, reducing the file's axiom count from 2 to 1.**

Replaces

```lean
opaque standardNormalCDF : ℝ → ℝ
```

with

```lean
noncomputable def standardNormalCDF (x : ℝ) : ℝ :=
  ∫ t in Set.Iic x,
    ProbabilityTheory.gaussianPDFReal 0 ⟨(1 : ℝ), zero_le_one⟩ t
```

This is the classical formulation `Φ(x) = ∫_{-∞}^x (2π)^{-1/2} e^{-t²/2} dt` via Mathlib's standard Gaussian-density bridge.

## Why this is genuine axiom elimination

- The Sessions 2–5 file used `opaque standardNormalCDF` as a structural placeholder — the axiom `binomial_clt_pointwise` claimed the standardized binomial CDF converges to that opaque target, which is mathematically vacuous (any function satisfies it).
- After this change, `standardNormalCDF` is the actual standard normal CDF. The axiom now references that *specific function*, making it a substantive de Moivre-Laplace claim.
- Per the Axiom Integrity Policy, `opaque` counts in `axiomCount`; replacing it with a `noncomputable def` whose body is `ProbabilityTheory.gaussianPDFReal` genuinely reduces the assumption count.

The proof of `multinomial_marginal_clt` is **unchanged** (uses `binomial_clt_pointwise` + `Filter.Tendsto.congr` via the reduction lemma); only the meaning of the limit symbol is sharpened.

## Status changes

| Field | Before | After |
|---|---|---|
| sorries | 0 | 0 |
| axioms | 2 | **1** |
| definitions | 2 | 3 |
| theorems | 7 | 7 |
| lineCount | 330 | 351 |
| status | axiomatized | axiomatized |

The single remaining axiom is `binomial_clt_pointwise` (de Moivre-Laplace, 1733/1812).

## Pattern precedent

Idiom matches `proofs/Proofs/ShannonEntropyOQ01.lean:260–278`, which uses `ProbabilityTheory.gaussianPDFReal μ ⟨σ², sq_nonneg σ⟩` for the same Gaussian-density bridge.

## Honest reporting

- Local Docker build was **not run**: worktree's recursive `.lake` symlink trap forces a fresh Mathlib clone. The change is mechanical (the only consumers of `standardNormalCDF` — the axiom and the derived theorem — do not unfold it). Confidence high but not CI-verified at push time.
- This session is **axiom elimination**, not new proof. It does not reduce sorry count (already 0) and does not add new mathematical content; it sharpens the meaning of the existing main theorem.

## Files modified

- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` (330 → 351 lines; opaque → def; 2 new imports)
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json` (axiomCount 2 → 1, lineCount 330 → 351, definitionCount 2 → 3)
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/{knowledge.md, state.md}` (Session 6 entry)
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json` (knowledge fields)

## Outcome
**progress** — axiom count reduced 2 → 1; single remaining axiom is the substantive de Moivre-Laplace claim.

## Next steps
1. Session 7 (axiom attack): discharge `binomial_clt_pointwise` via Portmanteau bridge from `ProbabilityTheory.iid_central_limit_theorem` at continuity points of the now-defined `standardNormalCDF`. Once landed, the file is fully verified.
2. Sibling stretch: prove `Continuous standardNormalCDF` (integration of continuous PDF on `Set.Iic`) — needed by Session 7's Portmanteau argument.

🤖 Generated by researcher-8