### PR TITLE
Enrich ballot-problem-oq-01-oq-01-oq-02: bridge-lemma annotation + complete mainTheorems

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/annotations.json
@@ -72,6 +72,18 @@
     "prerequisites": ["all_positive_prefixSum_step", "induction on Nat"]
   },
   {
+    "id": "ann-positivity-bridge",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 153, "endLine": 170 },
+    "type": "technique",
+    "title": "Positivity Bridge Lemmas: Interior Bound and Non-Negativity",
+    "content": "Two short bridge lemmas convert the strict-monotonicity property of all-positive prefix sums into the form needed by the wrapping case of `all_positive_all_rotations_good`. (1) `all_positive_prefixSum_lt_sum`: every interior prefix sum is strictly less than the total list sum. The proof is one line — apply strict monotonicity at $i < |l|$ and rewrite using `prefixSum_length` (which identifies $\\text{prefixSum}\\,l\\,|l| = l.\\text{sum}$). (2) `all_positive_prefixSum_nonneg`: every prefix sum (including the empty prefix at position 0) is non-negative. The proof unfolds to a `List.sum_nonneg` over a prefix list whose elements are all positive (transferred via `List.take_prefix l i`). These two lemmas are the only pieces of structure that the wrapping branch needs beyond strict monotonicity itself: the wrapping bound becomes $\\text{PS}(i+j-n) + \\text{sum}(l) - \\text{PS}(i) > 0$, which `linarith` solves once it knows $\\text{PS}(i) < \\text{sum}(l)$ and $\\text{PS}(i+j-n) \\geq 0$.",
+    "mathContext": "$\\text{Lemma 1 (interior bound):}\\quad i < |l| \\implies \\text{PS}(i) < \\sum l$ (strict, via mono).\n$\\text{Lemma 2 (non-negativity):}\\quad \\forall i,\\ 0 \\leq \\text{PS}(i)$ (positive elements give a non-negative sum).",
+    "significance": "supporting",
+    "relatedConcepts": ["List.sum_nonneg", "List.take_prefix", "prefixSum_length", "wrapping prefix decomposition"],
+    "prerequisites": ["all_positive_prefixSum_strictMono", "List.take_prefix membership lemma"]
+  },
+  {
     "id": "ann-all-rotations-good",
     "proofId": "ballot-problem-oq-01-oq-01-oq-02",
     "range": { "startLine": 172, "endLine": 197 },

--- a/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json
@@ -186,14 +186,49 @@
   ],
   "mainTheorems": [
     {
+      "name": "unit_decrement_step_bound",
+      "type": "lemma",
+      "description": "One-step bound: for step-≥-1 sequences, prefixSum l j - 1 ≤ prefixSum l (j+1). The local property that drives the downward IVT — a prefix sum cannot drop by more than 1 per step."
+    },
+    {
       "name": "unit_decrement_downward_ivt",
       "type": "core",
-      "description": "Downward IVT: for step-≥-1 sequences, if prefix sum at i > v and at j ≤ v, some k ∈ (i,j] achieves exactly v"
+      "description": "Downward IVT: for step-≥-1 sequences, if prefix sum at i exceeds v but at j > i is ≤ v, some k ∈ (i,j] achieves prefix sum exactly v. Proved via Finset.min' (leftmost crossing) — the discrete analog of the continuous IVT."
+    },
+    {
+      "name": "unit_decrement_levels_achieved",
+      "type": "core",
+      "description": "Global level-achievement: for step-≥-1 sequences, every integer level v ∈ [minPrefixSum l, 0] is achieved by some prefix sum position. Combines the IVT with the rightmost-min position to span the full reachable range."
+    },
+    {
+      "name": "all_positive_prefixSum_step",
+      "type": "lemma",
+      "description": "One-step strict increase for all-positive sequences: prefixSum l j < prefixSum l (j+1). The local positivity property that propagates to global strict monotonicity."
+    },
+    {
+      "name": "all_positive_prefixSum_strictMono",
+      "type": "lemma",
+      "description": "Global strict monotonicity: for all-positive sequences, i < j ≤ |l| ⟹ prefixSum l i < prefixSum l j. Proved by induction on j chaining the one-step increase."
+    },
+    {
+      "name": "all_positive_prefixSum_lt_sum",
+      "type": "lemma",
+      "description": "Interior bound: for all-positive sequences, i < |l| ⟹ prefixSum l i < l.sum. Used in the wrapping case of all_positive_all_rotations_good."
+    },
+    {
+      "name": "all_positive_prefixSum_nonneg",
+      "type": "lemma",
+      "description": "Universal non-negativity: for all-positive sequences, every prefix sum is ≥ 0. Used in the wrapping case alongside the interior bound."
+    },
+    {
+      "name": "all_positive_all_rotations_good",
+      "type": "core",
+      "description": "Every cyclic rotation is good for all-positive-step sequences. The non-wrapping case uses strict monotonicity directly; the wrapping case combines the interior bound with non-negativity of wrapped prefix sums."
     },
     {
       "name": "all_positive_goodRotations_card",
       "type": "core",
-      "description": "|goodRotations l| = l.length for all-positive-step sequences — every rotation is good"
+      "description": "|goodRotations l| = l.length for all-positive-step sequences — every rotation is good. Proved by Finset extensionality identifying goodRotations l with Finset.range l.length."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Targeted enrichment pass for `ballot-problem-oq-01-oq-01-oq-02` (Abstract Cycle Lemma for Arbitrary Integer Sequences). The entry was already heavily enriched by prior passes (8 references, 6 keyInsights, 4 crossRefs, full historical narrative). This pass closes the two remaining gaps.

### What changed

1. **New annotation `ann-positivity-bridge` (lines 153-170)** — covers the only remaining uncovered range in the Lean file. The two technical bridge lemmas (`all_positive_prefixSum_lt_sum`, `all_positive_prefixSum_nonneg`) are now explicitly explained as the structural pieces feeding the wrapping case of `all_positive_all_rotations_good`. Annotation coverage is now contiguous from line 1 to line 211.

2. **`mainTheorems` expanded from 2 to 9** — every theorem in the file now has an explicit description and `type` tag. Three `core` theorems (downward IVT, levels achieved, all rotations good / cardinality) plus six `lemma`-tagged supporting theorems. This makes the proof skeleton legible at a glance from the gallery page.

### What was preserved

- The 6 keyInsights, including the deep methodology insights about "step alphabet as proof skeleton" and "leftmost-crossing as discrete IVT primitive"
- The 8-entry `references` section (Bertrand, André, Dvoretzky-Motzkin, Raney, Mohanty, Stanley, Flajolet-Sedgewick, Bingham)
- The 4 `crossReferences` (parent, generalized ballot, Bertrand ancestor, OQ-02 sibling)
- The 5 openQuestions in `conclusion`

### Verification

- JSON validity confirmed via Python `json.load` for both `meta.json` and `annotations.json`
- `mainTheorems` count cross-checked against `theoremCount: 9` in `leanFile`
- Annotation coverage now spans the full file (1-211) without gaps

Note: `pnpm build` could not be run in this worktree due to an environmental issue — `better-sqlite3` fails to compile against Node v26 in the worktree's pnpm install. This is not a regression from these changes; the JSON files validate independently.