### PR TITLE
Enrich cube-root-3-irrational-oq-02-oq-02: add mainTheorems

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
@@ -131,6 +131,23 @@
         "definitionCount": 1,
         "theoremCount": 3
     },
+    "mainTheorems": [
+        {
+            "name": "α_minpoly_deg",
+            "type": "lemma",
+            "description": "Helper: natDegree(minpoly ℚ α) = 3 for α = (3:ℝ)^(1/3). One-line application of minpoly_nthRoot_natDegree 3 3 3 (Eisenstein at p=3) imported from CubeRoot2IrrationalOQ03. The single fact this entry needs about α."
+        },
+        {
+            "name": "cbrt3_powers_linearIndependent",
+            "type": "core",
+            "description": "Main theorem: {α^0, α^1, α^2} is ℚ-linearly independent, where α = (3:ℝ)^(1/3). Proved via Fintype.linearIndependent_iff: encode coefficients (c₀, c₁, c₂) into the polynomial p = C(c₀) + C(c₁)X + C(c₂)X², deduce minpoly ℚ α | p from aeval α p = 0, force p = 0 by degree comparison (3 > 2), then read each cᵢ = coeff(p, i) = 0."
+        },
+        {
+            "name": "one_cbrt3_cbrt3_sq_linearIndependent",
+            "type": "core",
+            "description": "User-facing form: ![1, α, α²] : Fin 3 → ℝ is ℚ-linearly independent. Proved by `convert cbrt3_powers_linearIndependent` plus a small fin_cases reducing each entry to α^(i:ℕ). This is the explicit-vector statement most likely to be cited in downstream proofs."
+        }
+    ],
     "references": [
         {
             "authors": "Mathlib Contributors",


### PR DESCRIPTION
## Summary

Targeted enrichment pass for `cube-root-3-irrational-oq-02-oq-02` (Linear Independence of {1, ∛3, (∛3)²} over ℚ).

The entry was already heavily enriched by prior passes — 8 keyInsights with deep methodology insights, 7 crossReferences, 5 references, complete historicalContext/proofStrategy/sections/openQuestions. The only structural gap was the missing `mainTheorems` field.

### What changed

Adds `mainTheorems` with one entry per declaration in `Proofs/CubeRoot3IrrationalOQ02OQ02.lean`:

- **`α_minpoly_deg`** (lemma) — the single helper fact: `natDegree(minpoly ℚ α) = 3`. One-line application of `minpoly_nthRoot_natDegree 3 3 3` (Eisenstein at p=3) imported from `CubeRoot2IrrationalOQ03`.
- **`cbrt3_powers_linearIndependent`** (core) — main theorem. Proved via the constructive-destructive duality (build polynomial p from coefficients; force p = 0 by degree comparison; read coefficients back).
- **`one_cbrt3_cbrt3_sq_linearIndependent`** (core) — user-facing form for the explicit vector `![1, α, α²]`.

Cross-checked against `leanFile.theoremCount: 3`.

### What was preserved

All prior enrichment work — keyInsights, crossReferences, references, sections, openQuestions, historicalContext, proofStrategy — remains unchanged.

Note: `pnpm build` is currently broken in this worktree (better-sqlite3 fails to build against Node v26). The single-key JSON addition is isolated and structurally trivial; validity confirmed via Python `json.load`.