### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 5 — prime_pow_dvd_lcmRange

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -1,5 +1,7 @@
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Algebra.GCDMonoid.Finset
+import Mathlib.Data.Nat.Log
+import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Tactic
 
 /-
@@ -112,6 +114,22 @@ theorem dvd_lcmRange {k n : ℕ} (hk : 0 < k) (hkn : k ≤ n) :
 theorem pow_dvd_lcmRange {b k n : ℕ} (hb : 0 < b) (hbkn : b ^ k ≤ n) :
     b ^ k ∣ lcmRange n :=
   dvd_lcmRange (Nat.pos_pow_of_pos k hb) hbkn
+
+/-- **Maximal prime-power divisibility**: for any prime `p` and `n ≥ 1`,
+    `p ^ ⌊log_p n⌋` divides `lcmRange n`.
+
+    This is the prime-power half of Chebyshev's decomposition
+    `lcm(1,...,n) = ∏_{p prime ≤ n} p ^ ⌊log_p n⌋`: every maximal prime
+    power dividing some `k ∈ {1,...,n}` divides `lcmRange n`. The reverse
+    inclusion (that no larger prime power can divide `lcmRange n`) follows
+    from the Mathlib `Nat.factorization` framework and is the next
+    structural step toward replacing `hanson_bound`.
+
+    The proof is a one-line specialization of `pow_dvd_lcmRange`:
+    `Nat.pow_log_le_self p hn'` gives `p ^ Nat.log p n ≤ n`. -/
+theorem prime_pow_dvd_lcmRange {p n : ℕ} (hp : p.Prime) (hn : 1 ≤ n) :
+    p ^ Nat.log p n ∣ lcmRange n :=
+  pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))
 
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/knowledge.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/knowledge.md
@@ -1,0 +1,111 @@
+# Knowledge: basel-problem-oq-01-oq-01-oq-02-oq-03
+
+Hanson's bound `lcm(1,...,n) ≤ 3^n` (1972), Apéry's ζ(3) integer-squeeze constant.
+
+## Key Definitions / Lemmas (in `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`)
+
+| Name | Type | Source |
+|------|------|--------|
+| `lcmRange` | def | Iteration 1 |
+| `lcmRange_zero/one/pos` | basic | Iteration 1 |
+| `dvd_lcmRange` | k ∈ {1..n} → k ∣ lcmRange n | Iteration 1 |
+| `pow_dvd_lcmRange` | 0 < b → b^k ≤ n → b^k ∣ lcmRange n | Iteration 3 (#16772) |
+| `prime_pow_dvd_lcmRange` | p prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n | **Iteration 5** (this PR) |
+| `lcmRange_succ` | recursion | Iteration 2 (#16704) |
+| `lcmRange_dvd_lcmRange_of_le` | divisibility monotonicity | Iteration 2 |
+| `lcmRange_monotone` | numerical monotonicity | Iteration 2 |
+| `lcmRange_dvd_factorial`, `lcmRange_le_factorial`, `lcmRange_le_self_pow` | trivial bounds | Iteration 1 |
+| `hanson_n1..n20`, `lcmRange_5/10/15/20_eq` | numerical verification | Iteration 1 |
+| `axiom hanson_bound` | the OPEN target | Iteration 1 |
+| `hanson_strictly_stronger_than_factorial` | 3^n < n^n for n ≥ 4 | Iteration 1 |
+
+## Iteration 5 (2026-05-08, researcher-1) — `prime_pow_dvd_lcmRange`
+
+**Theorem statement**:
+
+```lean
+theorem prime_pow_dvd_lcmRange {p n : ℕ} (hp : p.Prime) (hn : 1 ≤ n) :
+    p ^ Nat.log p n ∣ lcmRange n :=
+  pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))
+```
+
+**Why this is the right next lemma after `pow_dvd_lcmRange`** (Iteration 3):
+
+`pow_dvd_lcmRange` is generic over the base `b`; the *prime-power* case
+is the one Hanson-style proofs actually need, because Chebyshev's
+decomposition
+
+  `lcm(1,...,n) = ∏_{p prime, p ≤ n} p ^ ⌊log_p n⌋`
+
+requires precisely: (a) every maximal prime-power `p^⌊log_p n⌋` divides
+the LHS — proved by this lemma; (b) no larger prime power can divide
+the LHS — follows from unique factorization.
+
+Direction (a) is now a **library entry point**, available as
+`prime_pow_dvd_lcmRange hp hn` for any downstream proof that needs to
+extract a prime-power factor from `lcmRange n`.
+
+**New imports introduced**: `Mathlib.Data.Nat.Log` (for `Nat.log`,
+`Nat.pow_log_le_self`), `Mathlib.Data.Nat.Prime.Basic` (for `Nat.Prime.pos`).
+
+**Proof technique**: literal three-call composition.
+`hp.pos` discharges `0 < p`; `Nat.pow_log_le_self p (n.ne')`
+(massaged from `1 ≤ n` via `omega`) discharges `p ^ Nat.log p n ≤ n`;
+`pow_dvd_lcmRange` does the rest. No new mathematics; just connects
+two existing pieces.
+
+**Mathlib precedent for the technique**: the same
+`Nat.pow_log_le_self` + `b ^ Nat.log b n ≤ n` pattern appears in
+`Erdos123Problem.lean:166`, `BaselProblemOQ01OQ01OQ02Aristotle.lean:82`,
+`ChebyshevBounds.lean:315`, etc. — 17+ files in this repository use it.
+The lemma name `prime_pow_dvd_lcmRange` is consistent with Mathlib
+naming for divisibility lemmas (`Nat.Prime.dvd_lcm`, etc.).
+
+## Next Iteration (Iteration 6 candidate): `lcmRange_eq_prod_prime_powers`
+
+The full Chebyshev decomposition:
+
+```lean
+theorem lcmRange_eq_prod_prime_powers (n : ℕ) :
+    lcmRange n = ∏ p ∈ (Finset.range (n + 1)).filter Nat.Prime,
+                  p ^ Nat.log p n := sorry
+```
+
+- **Forward `RHS ∣ LHS`**: use `prime_pow_dvd_lcmRange` for each prime
+  factor + pairwise-coprimality of distinct primes
+  (`Nat.Coprime.prime_pow_pow`) + `Finset.prod_dvd` for coprime factors.
+
+- **Reverse `LHS ∣ RHS`**: every `k ∈ {1,...,n}` factors as
+  `∏_p p^(k.factorization p)` with each exponent `≤ Nat.log p n`. Use
+  Mathlib's `Nat.factorization` framework + `Nat.eq_pow_of_factorization_eq`.
+
+Once proven, the bound `lcmRange n ≤ ∏_{p ≤ n} n = n^{π(n)}` is
+immediate from `Finset.prod_le_prod` (each factor ≤ `n` since
+`p ^ Nat.log p n ≤ n`). This is a strictly weaker bound than Hanson's
+3^n but is the first non-trivial named LCM-bound theorem in Lean.
+
+## Long-Term Blockers (unchanged)
+
+1. **Mathlib Beta-integral over ℚ**: `(n+1)·C(n,k)·∫₀¹ x^k(1-x)^(n-k) dx = 1`
+   not yet available in usable rational-denominator form.
+2. **Mathlib `primorial → lcm` bridge**: missing. NB: the naive form
+   `lcm(1..n) ≤ n · primorial(n)` is FALSE (counterexample at n=9);
+   correct bridge uses Chebyshev's prime-power decomposition.
+3. **Mathlib LCM-specific bounds**: none — this OQ is contributing
+   them.
+
+## Cross-References
+
+- Parent: `basel-problem-oq-01-oq-01-oq-02` (Apéry ζ(3) irrationality
+  scaffold; uses `lcm_hanson_bound` axiom that this OQ targets).
+- Sibling: `basel-problem-oq-01-oq-01-oq-02-oq-02` (separate axiom in
+  the same parent's chain).
+- Mathlib gap: `Mathlib.NumberTheory.Primorial.primorial_le_4_pow`
+  exists but the `primorial → lcmRange` bridge does not.
+
+## References
+
+- Hanson, *Canad. Math. Bull.* 15 (1972) 33–37.
+- Nair, *Amer. Math. Monthly* 89 (1982) 126–129 (alternative central-binomial-coefficient route).
+- Apéry, *Astérisque* 61 (1979) (the canonical application of `lcm ≤ 3^n`).
+- OEIS A003418: `lcm(1,...,n)`.

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -4,16 +4,30 @@
 **Phase**: ACT (structural infrastructure being added; full proof requires Mathlib upstream)
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-07
-**Iteration**: 2
+**Last Updated**: 2026-05-08 (Iteration 5, researcher-1)
+**Iteration**: 5
 
 ## Current Focus
-Iteration 2 (2026-05-07): added foundational structural lemmas required
-by every subsequent proof attempt:
-- `lcmRange_succ`: lcm(1,...,n+1) = Nat.lcm (lcmRange n) (n+1) — the
-  recursive structure inducting along `n` will use.
+Iteration 5 (2026-05-08, this PR): added the prime-power
+specialization on top of Iteration 3's `pow_dvd_lcmRange`:
+
+- `prime_pow_dvd_lcmRange : ∀ {p n : ℕ}, p.Prime → 1 ≤ n →
+   p ^ Nat.log p n ∣ lcmRange n`
+
+The proof is a one-line specialization of `pow_dvd_lcmRange`, using
+`Nat.pow_log_le_self p hn'` to discharge `p ^ Nat.log p n ≤ n`. New
+imports: `Mathlib.Data.Nat.Log`, `Mathlib.Data.Nat.Prime.Basic`. This
+is the maximal-prime-power half of Chebyshev's decomposition
+`lcm(1,...,n) = ∏_{p prime ≤ n} p ^ ⌊log_p n⌋`.
+
+Iteration 3 (#16772 merged): added `pow_dvd_lcmRange : 0 < b → b^k ≤ n
+→ b^k ∣ lcmRange n` — the generic power-divisibility lemma whose prime
+specialization Iteration 5 just discharged.
+
+Iteration 2 (#16704 merged): added foundational structural lemmas:
+- `lcmRange_succ`: lcm(1,...,n+1) = Nat.lcm (lcmRange n) (n+1).
 - `lcmRange_dvd_lcmRange_of_le`: divisibility monotonicity.
-- `lcmRange_monotone`: numerical monotonicity (with `n=0` boundary).
+- `lcmRange_monotone`: numerical monotonicity.
 
 Iteration 1 (bootstrap, completed 2026-05-07):
 - Provable elementary bounds: lcmRange n ≤ n!, lcmRange n ≤ n^n.
@@ -36,10 +50,13 @@ Currently blocked on:
   `4^n` intermediate.
 
 ## Attempt Count
-- Total attempts: 2.
+- Total attempts: 5.
 - Current approach attempts: 0 (Approach 1 not started; awaits Mathlib).
 - Approaches tried: bootstrap with elementary bounds + axiom (iter 1);
-  structural-lemma layer for inductive proofs (iter 2).
+  structural-lemma layer for inductive proofs (iter 2); generic
+  power-divisibility lemma `pow_dvd_lcmRange` (iter 3); empirical
+  evidence extension n ∈ {25, 30, 50} (iter 4, in flight as #16880);
+  prime-power specialization `prime_pow_dvd_lcmRange` (iter 5, this PR).
 
 ## Blockers
 - **Mathlib Beta-integral over ℚ**: not in usable form.
@@ -48,17 +65,38 @@ Currently blocked on:
 
 ## Next Action
 
-**Two follow-up paths:**
+**Iteration 6 candidate**: prove `lcmRange_eq_prod_prime_powers`,
+the Chebyshev decomposition
 
-1. **Intermediate `lcm(1..n) ≤ 4^n`** (easier). Develop the bridge
-   `primorial(n) ≤ lcm(1..n) ≤ n · primorial(n)` and combine with
-   Mathlib's `primorial_le_4_pow`. Estimated 1-2 weeks of focused work.
+  `lcmRange n = ∏ p ∈ Finset.filter Nat.Prime (Finset.range (n+1)),
+                p ^ Nat.log p n`.
 
-2. **Full Hanson `3^n`** (harder). Requires Beta-integral machinery.
-   Estimated months.
+Forward direction (RHS ∣ LHS): use `prime_pow_dvd_lcmRange` (this PR)
+together with pairwise-coprimality of distinct primes — distinct prime
+powers are coprime, so a finite-product divisibility argument gives
+the result. The relevant Mathlib facts are
+`Nat.Coprime.prime_pow_pow` and `Finset.prod_dvd_of_dvd_of_pairwiseDisjoint`.
 
-Either result discharges (or strengthens) the parent file's
-`lcm_hanson_bound` axiom.
+Reverse direction (LHS ∣ RHS): for each `k ∈ {1,...,n}` use unique
+factorization (`Nat.factorization`) to express `k = ∏_p p^(k.factorization p)`
+and bound each exponent by `Nat.log p n`.
+
+After this, the Chebyshev product gives an explicit numerator-denominator
+form for `lcmRange n` as a product over primes ≤ n, and the bound
+`lcmRange n ≤ ∏_{p ≤ n} n = n^{π(n)}` follows immediately
+(strictly weaker than 3^n but a non-trivial published-bound milestone).
+
+**Long-term paths still open:**
+
+1. **Intermediate `lcm(1..n) ≤ 4^n`** via primorial bridge: blocked on
+   the Mathlib bridge `lcm(1..n) ≤ n · primorial(n)`. Note (Iteration 3
+   insight): the literal `≤ n · primorial(n)` form is FALSE
+   (counterexample n=9: 2520 > 1890). Correct route is via Chebyshev's
+   prime-power formula above.
+
+2. **Full Hanson `3^n`** (Beta-integral + Chebyshev): months.
+
+Either result discharges the parent file's `lcm_hanson_bound` axiom.
 
 ## References
 

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 237,
-    "theoremCount": 29,
+    "lineCount": 255,
+    "theoremCount": 30,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [
@@ -42,6 +42,11 @@
         "theorem": "Finset.dvd_lcm",
         "description": "Every element divides the lcm",
         "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Nat.pow_log_le_self",
+        "description": "b ^ Nat.log b n ≤ n for n ≠ 0; used in prime_pow_dvd_lcmRange to lift pow_dvd_lcmRange to the maximal-prime-power case",
+        "module": "Mathlib.Data.Nat.Log"
       }
     ],
     "dateAdded": "2026-05-07",
@@ -63,32 +68,32 @@
     {
       "id": "definition",
       "title": "Part 1-2: Definition and Basic Properties",
-      "startLine": 60,
-      "endLine": 160,
-      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, pow_dvd_lcmRange (any positive base power b^k ≤ n divides lcmRange n — the building block for prime-power decompositions), and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
+      "startLine": 65,
+      "endLine": 178,
+      "summary": "Defines lcmRange n = lcm{1,...,n} (matching the parent file's lcmUpTo), establishes lcmRange_zero, lcmRange_one, lcmRange_pos, dvd_lcmRange, pow_dvd_lcmRange (any positive base power b^k ≤ n divides lcmRange n — the building block for prime-power decompositions), prime_pow_dvd_lcmRange (specialization to the maximal prime-power p^⌊log_p n⌋ — the prime-power half of Chebyshev's decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^⌊log_p n⌋), and the structural lemmas lcmRange_succ (recursion), lcmRange_dvd_lcmRange_of_le (divisibility monotonicity), lcmRange_monotone.",
       "mathContext": "$\\operatorname{lcmRange}(n) = \\operatorname{lcm}\\{1, 2, \\ldots, n\\}$ encoded as a `Finset.lcm` over `Finset.range n` mapped through (·+1)."
     },
     {
       "id": "elementary-bounds",
       "title": "Part 3: Provable Elementary Bounds",
-      "startLine": 162,
-      "endLine": 182,
+      "startLine": 180,
+      "endLine": 200,
       "summary": "Proves the three elementary bounds with no axioms: lcmRange_dvd_factorial, lcmRange_le_factorial, lcmRange_le_self_pow. The chain lcm ≤ n! ≤ n^n is the trivial bound that Hanson's 3^n strictly improves upon.",
       "mathContext": "$\\operatorname{lcm}(1, \\ldots, n) \\mid n!$ via `Nat.dvd_factorial`, then $\\operatorname{lcm}(1, \\ldots, n) \\leq n! \\leq n^n$ via `Nat.factorial_le_pow`."
     },
     {
       "id": "numerical",
       "title": "Part 4: Numerical Verification of Hanson",
-      "startLine": 183,
-      "endLine": 205,
+      "startLine": 201,
+      "endLine": 223,
       "summary": "Verifies lcmRange n ≤ 3^n for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Includes lcmRange exact values lcmRange 5 = 60, lcmRange 10 = 2520, lcmRange 15 = 360360, lcmRange 20 = 232792560 (matches OEIS A003418).",
       "mathContext": "Concrete: $\\operatorname{lcm}(1, \\ldots, 20) = 232\\,792\\,560$ vs $3^{20} = 3\\,486\\,784\\,401$, ratio $\\approx 15$."
     },
     {
       "id": "axiom",
       "title": "Part 5: Hanson's Bound (Axiom)",
-      "startLine": 207,
-      "endLine": 237,
+      "startLine": 225,
+      "endLine": 255,
       "summary": "States `axiom hanson_bound : ∀ n, lcmRange n ≤ 3^n` — Hanson's classical 1972 theorem. Includes hanson_strictly_stronger_than_factorial showing the constant 3 is genuinely tighter than the trivial n^n bound for n ≥ 4.",
       "mathContext": "Hanson 1972: $\\operatorname{lcm}(1, \\ldots, n) \\leq 3^n$. Original proof uses Beta-integral identity $\\int_0^1 x^k(1-x)^{n-k} dx = \\frac{1}{(n+1)\\binom{n}{k}}$ combined with prime-power bounds."
     }

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -32,25 +32,26 @@
     "phase": "ACT",
     "since": "2026-05-08",
     "iteration": 3,
-    "focus": "Building structural lemma library toward prime-power decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}. Iteration 2 (#16704 merged) added lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (this PR) adds pow_dvd_lcmRange — any positive base power b^k ≤ n divides lcmRange n — the structural building block specialised to powers, applicable directly to prime powers without requiring an additional Mathlib import.",
+    "focus": "Building structural lemma library toward prime-power decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}. Iteration 2 (#16704 merged) added lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange — any positive base power b^k ≤ n divides lcmRange n. Iteration 5 (this PR) specializes to the prime case: prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n — the maximal-prime-power half of Chebyshev's decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}.",
     "blockers": [
       "Mathlib lacks Beta-integral identity in rational-denominator form for Hanson's approach.",
       "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)"
     ],
-    "nextAction": "Continue building the prime-power decomposition: the next structural step is `lcmRange_eq_prod_prime_powers : lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`. With pow_dvd_lcmRange this gives the easy direction (RHS dvd LHS); the reverse direction follows from the unique-factorization property and is in Mathlib's Nat.factorization framework.",
+    "nextAction": "Continue building the prime-power decomposition: the next structural step is `lcmRange_eq_prod_prime_powers : lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`. With prime_pow_dvd_lcmRange + pairwise-coprimality of distinct primes (Nat.Coprime.prime_pow_pow), the easy direction (RHS dvd LHS) follows from Finset.prod_dvd; the reverse direction follows from unique factorization (Mathlib's Nat.factorization framework).",
     "attemptCounts": {
-      "total": 3,
+      "total": 5,
       "currentApproach": 1,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "Iteration 3. `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (237 lines, 29 theorems, 1 def, 1 axiom, 0 sorries). Iteration 1 (bootstrap, merged) defined lcmRange and elementary bounds. Iteration 2 (#16704 merged) added structural lemmas lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (this PR) adds `pow_dvd_lcmRange : 0 < b → b^k ≤ n → b^k ∣ lcmRange n`, the structural building block for prime-power-decomposition arguments. With it, the prime-case `p^(⌊log_p n⌋) ∣ lcmRange n` for any prime p ≤ n becomes a one-line corollary (using `Nat.pow_log_le_self`).",
+    "progressSummary": "Iteration 5. `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (255 lines, 30 theorems, 1 def, 1 axiom, 0 sorries). Iteration 1 (bootstrap, merged) defined lcmRange and elementary bounds. Iteration 2 (#16704 merged) added structural lemmas lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange. Iteration 5 (this PR) adds `prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n`, the maximal-prime-power half of Chebyshev's decomposition. The proof is a one-line specialization of `pow_dvd_lcmRange` using `Nat.pow_log_le_self`. New imports: `Mathlib.Data.Nat.Log`, `Mathlib.Data.Nat.Prime.Basic`.",
     "builtItems": [
-      "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:78",
-      "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:85-96",
-      "dvd_lcmRange: each k ∈ {1,...,n} divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:99",
-      "pow_dvd_lcmRange: any b^k ≤ n with positive base divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:115",
+      "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:80",
+      "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:87-98",
+      "dvd_lcmRange: each k ∈ {1,...,n} divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:101",
+      "pow_dvd_lcmRange: any b^k ≤ n with positive base divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:114 (#16772)",
+      "prime_pow_dvd_lcmRange: ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n — at BaselProblemOQ01OQ01OQ02OQ03.lean:130 (this PR)",
       "lcmRange_succ: recursion lcm(1..n+1) = lcm(lcm(1..n), n+1) (#16704)",
       "lcmRange_dvd_lcmRange_of_le: monotone divisibility (#16704)",
       "lcmRange_monotone: numerical monotonicity (#16704)",
@@ -69,7 +70,8 @@
       "Numerical evidence is strong: lcm(1..20) = 232,792,560 vs 3^20 = 3,486,784,401, a factor-15 margin.",
       "The Chebyshev function reformulation ψ(n) = log lcm(1,...,n) connects this to the Prime Number Theorem (which gives only the asymptotic ψ(n)/n → 1).",
       "**Counterexample**: `lcm(1..n) ≤ n · primorial(n)` is FALSE in general — already at n=9 we have lcm(1..9) = 2520 > 9 · 210 = 1890. The intermediate primorial bridge as commonly stated does NOT yield the 4^n bound; the correct path goes through Chebyshev's prime-power formula `lcm(1..n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}`.",
-      "**pow_dvd_lcmRange** is the structural-lemma counterpart of `dvd_lcmRange` for prime-power arguments: applied with `b = p` prime and `k = Nat.log p n`, with `Nat.pow_log_le_self p hn` it gives the maximal-prime-power divisibility `p^(⌊log_p n⌋) ∣ lcmRange n` in a single line — the easy direction of the Chebyshev decomposition."
+      "**pow_dvd_lcmRange** is the structural-lemma counterpart of `dvd_lcmRange` for prime-power arguments: applied with `b = p` prime and `k = Nat.log p n`, with `Nat.pow_log_le_self p hn` it gives the maximal-prime-power divisibility `p^(⌊log_p n⌋) ∣ lcmRange n` in a single line — the easy direction of the Chebyshev decomposition.",
+      "**prime_pow_dvd_lcmRange** (Iteration 5) makes the corollary explicit. The proof is literally `pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))` — three Mathlib calls glued together. This is the canonical entry point for any prime-power Chebyshev-style argument on `lcmRange`."
     ],
     "mathlibGaps": [
       "No `lcm(1,...,n) ≤ X^n`-style bound exists in Mathlib for any X.",
@@ -77,14 +79,14 @@
       "No Beta-integral identity in usable rational form: `(n+1)·C(n,k)·∫₀¹ x^k(1-x)^(n-k) dx = 1`."
     ],
     "nextSteps": [
-      "Add `prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n` (one-liner from `pow_dvd_lcmRange` + `Nat.pow_log_le_self`). Requires `import Mathlib.Data.Nat.Prime.Basic` and `Mathlib.Data.Nat.Log`.",
+      "✅ DONE (this PR): Added `prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n` (one-liner from `pow_dvd_lcmRange` + `Nat.pow_log_le_self`).",
       "Add `lcmRange_eq_prod_prime_powers : lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`. Forward direction (RHS ∣ LHS) follows from `prime_pow_dvd_lcmRange` + pairwise-coprimality of distinct primes; reverse direction uses Mathlib's `Nat.factorization` framework.",
       "With Chebyshev's decomposition, derive `lcmRange n ≤ ∏_{p ≤ n} n = n^{π(n)}` (still weaker than 3^n but proves a non-trivial bound).",
       "Wait for or contribute Mathlib Beta-integral machinery for ℚ-valued bounds.",
       "Explore Nair's 1982 alternative constants as a possibly-easier intermediate (uses central binomial coefficients).",
       "Add cross-references in `basel-problem-oq-01-oq-01-oq-02` and `basel-problem` gallery entries pointing to this OQ-03."
     ],
-    "markdown": "# Knowledge Base: basel-problem-oq-01-oq-01-oq-02-oq-03\n\nSee `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md` and `state.md` for full discussion.\n\n## Status\n\n* **Phase**: ACT (iteration 3)\n* **Files**: `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (237 lines, 29 theorems, 1 def, 1 axiom, 0 sorries; numerically verified n ∈ {1..10, 12, 15, 20}).\n* **Open target**: replace `axiom hanson_bound` with a theorem.\n* **Blocker**: Mathlib lacks Beta-integral / Chebyshev-prime-power-formula infrastructure.\n* **Iteration 3 (this PR)**: added `pow_dvd_lcmRange`, the structural building block for prime-power decompositions of `lcmRange n`.\n"
+    "markdown": "# Knowledge Base: basel-problem-oq-01-oq-01-oq-02-oq-03\n\nSee `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md` and `state.md` for full discussion.\n\n## Status\n\n* **Phase**: ACT (iteration 5)\n* **Files**: `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (255 lines, 30 theorems, 1 def, 1 axiom, 0 sorries; numerically verified n ∈ {1..10, 12, 15, 20}).\n* **Open target**: replace `axiom hanson_bound` with a theorem.\n* **Blocker**: Mathlib lacks Beta-integral / Chebyshev-prime-power-formula infrastructure.\n* **Iteration 5 (this PR)**: added `prime_pow_dvd_lcmRange`, the prime-power specialization of `pow_dvd_lcmRange`.\n"
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Summary

**Iteration 5** of the Hanson `lcm(1,...,n) ≤ 3^n` open question. Adds the prime-power specialization of `pow_dvd_lcmRange` (Iter 3, #16772):

```lean
theorem prime_pow_dvd_lcmRange {p n : ℕ} (hp : p.Prime) (hn : 1 ≤ n) :
    p ^ Nat.log p n ∣ lcmRange n :=
  pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))
```

This is the maximal-prime-power half of Chebyshev's decomposition

$$\operatorname{lcm}(1,\ldots,n) = \prod_{p\text{ prime},\,p\le n} p^{\lfloor \log_p n \rfloor}$$

and is the canonical entry point for any downstream prime-power divisibility argument on `lcmRange`.

## Progress

- **New theorem**: `prime_pow_dvd_lcmRange` — one-line composition of three Mathlib calls (`hp.pos`, `Nat.pow_log_le_self`, `pow_dvd_lcmRange`).
- **New imports**: `Mathlib.Data.Nat.Log` (for `Nat.log`, `Nat.pow_log_le_self`), `Mathlib.Data.Nat.Prime.Basic` (for `Nat.Prime.pos`).
- **New mathlibDependency**: `Nat.pow_log_le_self`.
- **Section 1 line range** in `meta.json` extended to cover the new theorem.
- **knowledge.md** created (was missing) summarizing the lemma library and the next-iteration target.

## Files Modified

- `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (+18 lines: imports + theorem)
- `src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json` (theoremCount 29→30, lineCount 237→255, mathlibDependencies +1, sections.startLine/endLine shifted)
- `src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json` (iteration 3→5, progressSummary, builtItems, insights, nextSteps, markdown)
- `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md` (iteration 5 narrative)
- `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/knowledge.md` (new file)

## Honest Reporting

- **No mathematics**: the theorem connects two existing pieces; the proof is three Mathlib calls.
- **No axiom delta**: still 1 axiom (`hanson_bound`), still 0 sorries.
- **Theorem-count delta**: +1 (29 → 30).
- **What this enables**: Iter 6 candidate is `lcmRange_eq_prod_prime_powers` (the full Chebyshev decomposition); this PR provides the easy direction (RHS ∣ LHS) of that decomposition as a single call.

## Build Status

⚠️ **Build pending**: this session relied on grep cross-checks against 17+ existing call sites of `Nat.pow_log_le_self` (e.g. `BaselProblemOQ01OQ01OQ02Aristotle.lean:82`, `Erdos123Problem.lean:166`, `ChebyshevBounds.lean:315`). The proof is a literal three-call composition with no novel tactic combination, but CI is the ground truth.

## Status

**Outcome**: progress (structural lemma added)
**Next Steps**: Iter 6 — `lcmRange_eq_prod_prime_powers` (Chebyshev decomposition).

🤖 Generated by researcher-1