### PR TITLE
Enrich laws-of-large-numbers-oq-01-oq-01: link to second-moment method

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
@@ -168,6 +168,11 @@
       "proofId": "prob-method-expectation",
       "relationship": "related",
       "description": "Foundational first-moment lemma 'E[X] > t implies some outcome exceeds t'. The contrapositive used here is parallel: 'almost-sure boundedness Xₙ/n → 0 forces a finite-mean tail estimate'. Both proofs hinge on the same Markov/Chebyshev quantitative core, in different guises (probabilistic method vs. necessity contradiction)."
+    },
+    {
+      "proofId": "prob-method-second-moment",
+      "relationship": "uses",
+      "description": "The variance-Chebyshev BC2 used here is exactly the second moment method specialized to sums of pairwise-independent indicators. The proof of `borel_cantelli_of_pairwise_independent` in the Aristotle companion mirrors the Paley-Zygmund step Var(S)/E[S]² → 0 ⇒ S concentrated, applied to S_N = Σ 𝟙_{Aₙ}. Reading the two entries side-by-side reveals that the SLLN necessity argument is a *probabilistic-method* proof in disguise — using the second moment to establish a.s. *occurrence* of a tail event, then using the deterministic Cesàro decay to show the same event almost-surely *fails*, with the contradiction forcing finite first moment."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Adds a single high-value cross-reference linking SLLN necessity to `prob-method-second-moment`. The variance-Chebyshev BC2 used in the Aristotle companion (`borel_cantelli_of_pairwise_independent`) is structurally identical to the Paley-Zygmund step formalized in `prob-method-second-moment`:

> Var(S_N)/E[S_N]^2 → 0 ⇒ S_N concentrated near E[S_N]

specialized to S_N = Σ 𝟙_{Aₙ} for pairwise-independent A_n.

## Why this is missing

The entry already cross-references `prob-method-expectation` (first-moment / Markov side), but the second-moment side — which is the *actual* technique driving the proof — was unlinked. Reading the two entries side-by-side reveals SLLN necessity is a probabilistic-method proof in disguise: the second moment establishes a.s. *occurrence* of the tail event {|X_n| > n}, then deterministic Cesàro decay shows the same event almost-surely *fails*, with the contradiction forcing finite first moment.

## Diff scope

Single 5-line addition to `meta.json` `crossReferences` array. No annotations, schema, or counts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)