### PR TITLE
research(hilbert-10-oq-01-oq-02): Iter 4 — Σ₁/Π₁/Σ₂ class congruence

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -364,6 +364,64 @@ theorem universalExistentialDefinition_iff_of_pred_iff
     refine ⟨P, fun q => ?_⟩
     exact (h q).trans (hP q)
 
+/-- The Σ₁ class is invariant under propositional equivalence of the
+    defining predicate. Pure logical congruence; no axioms.
+
+    Direct analog of `universalExistentialDefinition_iff_of_pred_iff`
+    (Π₂ congruence). Useful when bridging between Σ₁ predicates whose
+    statements are propositionally equivalent up to a classical
+    rewrite (e.g., `¬¬p ↔ p`). -/
+theorem diophantineDefinition_iff_of_pred_iff
+    {S S' : RatSubset} (h : ∀ q, S q ↔ S' q) :
+    IsDiophantineDefinition S ↔ IsDiophantineDefinition S' := by
+  constructor
+  · intro hS
+    obtain ⟨P, hP⟩ := hS
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).symm.trans (hP q)
+  · intro hS'
+    obtain ⟨P, hP⟩ := hS'
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).trans (hP q)
+
+/-- The Π₁ class is invariant under propositional equivalence of the
+    defining predicate. Pure logical congruence; no axioms.
+
+    Direct analog of `universalExistentialDefinition_iff_of_pred_iff`
+    (Π₂ congruence). -/
+theorem coDiophantineDefinition_iff_of_pred_iff
+    {S S' : RatSubset} (h : ∀ q, S q ↔ S' q) :
+    IsCoDiophantineDefinition S ↔ IsCoDiophantineDefinition S' := by
+  constructor
+  · intro hS
+    obtain ⟨P, hP⟩ := hS
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).symm.trans (hP q)
+  · intro hS'
+    obtain ⟨P, hP⟩ := hS'
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).trans (hP q)
+
+/-- The Σ₂ class is invariant under propositional equivalence of the
+    defining predicate. Pure logical congruence; no axioms.
+
+    Direct analog of `universalExistentialDefinition_iff_of_pred_iff`
+    (Π₂ congruence). Completes the four-class congruence story:
+    Σ₁, Π₁, Σ₂, Π₂ are all invariant under propositional equivalence
+    of the defining predicate. -/
+theorem existentialUniversalDefinition_iff_of_pred_iff
+    {S S' : RatSubset} (h : ∀ q, S q ↔ S' q) :
+    IsExistentialUniversalDefinition S ↔ IsExistentialUniversalDefinition S' := by
+  constructor
+  · intro hS
+    obtain ⟨P, hP⟩ := hS
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).symm.trans (hP q)
+  · intro hS'
+    obtain ⟨P, hP⟩ := hS'
+    refine ⟨P, fun q => ?_⟩
+    exact (h q).trans (hP q)
+
 /-- **Corollary of Koenigsmann via Σ₂/Π₂ duality**:
 
     The complement `ℚ \ ℤ` is Σ₂-definable in ℚ.
@@ -429,7 +487,7 @@ All other declared `theorem`s are NOT new axioms — they are logical
 consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulation,
 Σ₁ ↔ Π₁(complement), and Σ₂ ↔ Π₂(complement) equivalences proved here.
 
-## Theorems in THIS file (12)
+## Theorems in THIS file (16)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
@@ -443,6 +501,9 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂, dual of Σ₁ ⊆ Π₂)
   - `existentialUniversal_iff_universalExistential_complement` (Σ₂/Π₂ duality)
   - `universalExistentialDefinition_iff_of_pred_iff` (Π₂ class congruence)
+  - `diophantineDefinition_iff_of_pred_iff` (Σ₁ class congruence, iter 4)
+  - `coDiophantineDefinition_iff_of_pred_iff` (Π₁ class congruence, iter 4)
+  - `existentialUniversalDefinition_iff_of_pred_iff` (Σ₂ class congruence, iter 4)
   - `koenigsmann_implies_complement_existentialUniversal` (Σ₂(ℚ\ℤ) corollary)
 -/
 
@@ -457,6 +518,9 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @integers_diophantine_iff_complement_codiophantine
 #check @codiophantine_implies_existentialUniversal
 #check @existentialUniversal_iff_universalExistential_complement
+#check @diophantineDefinition_iff_of_pred_iff
+#check @coDiophantineDefinition_iff_of_pred_iff
+#check @existentialUniversalDefinition_iff_of_pred_iff
 #check @koenigsmann_implies_complement_existentialUniversal
 
 end Hilbert10Rationals

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -2,49 +2,67 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T06:00:00Z
-**Iteration**: 3
+**Iteration**: 4
+**Last Updated**: 2026-05-08 (researcher-1)
 
 ## Current Focus
 
-Closing the fourth corner of the Σ₁/Π₁/Σ₂/Π₂ square. Iterations 1 & 2
-established Σ₁ (open), Π₂ (Koenigsmann), and the Σ₁/Π₁ duality. This
-iteration adds Σ₂ definability, the precise dual of Σ₁ ⊆ Π₂ (i.e.
-Π₁ ⊆ Σ₂), the Σ₂/Π₂ duality, and the unconditional Σ₂(ℚ\ℤ) corollary
-of Koenigsmann.
+Iteration 4 (2026-05-08, researcher-1, this PR): completing the
+**propositional-equivalence congruence story** for all four
+definability classes. Iteration 3 added
+`universalExistentialDefinition_iff_of_pred_iff` (Π₂ congruence) for
+use in the Σ₂(ℚ\ℤ) corollary; this iteration adds the analogous lemmas
+for the other three classes — Σ₁, Π₁, Σ₂. All three follow the same
+one-and-a-half-line `(h q).symm.trans (hP q)` template as the Π₂
+version, so the additions are mechanical but complete the four-class
+symmetry of the file.
+
+Net new content: 0 definitions, 3 theorems, 0 axioms.
+Updated to total: 8 definitions, 16 theorems, 1 axiom, 0 sorries,
+526 lines (was 462).
+
+Iterations 1 & 2 established Σ₁ (open), Π₂ (Koenigsmann), and the
+Σ₁/Π₁ duality. Iteration 3 added Σ₂ definability, the precise dual of
+Σ₁ ⊆ Π₂ (i.e. Π₁ ⊆ Σ₂), the Σ₂/Π₂ duality, and the unconditional
+Σ₂(ℚ\ℤ) corollary of Koenigsmann.
 
 ## Active Approach
 
-S3 — Σ₂ definability + Σ₂/Π₂ duality:
+S4 — Σ₁/Π₁/Σ₂ class congruence (this iteration):
 
-1. Define `IsExistentialUniversalDefinition` (Σ₂, ∃∀ definability).
-2. Prove `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂):
-   add a dummy existential block to a Π₁ formula. Axiom-free.
-3. Prove `existentialUniversal_iff_universalExistential_complement`:
-   the higher-level analog of the Σ₁/Π₁ duality. Both directions use
-   `Classical.byContradiction`.
-4. Add `universalExistentialDefinition_iff_of_pred_iff` (Π₂ class is
-   invariant under propositional equivalence of the predicate) as a
-   pure logical congruence helper.
-5. Derive `koenigsmann_implies_complement_existentialUniversal`: the
-   complement ℚ\ℤ is Σ₂-definable in ℚ, as a corollary of Koenigsmann
-   via the Σ₂/Π₂ duality + the predicate-equivalence bridge. No new
-   axiom.
+1. `diophantineDefinition_iff_of_pred_iff` — Σ₁ class invariant under
+   propositional equivalence of the predicate.
+2. `coDiophantineDefinition_iff_of_pred_iff` — Π₁ class invariant.
+3. `existentialUniversalDefinition_iff_of_pred_iff` — Σ₂ class
+   invariant.
 
-Net new content: 1 definition, 4 theorems, 0 new axioms.
-Updated to total: 8 definitions, 13 theorems, 1 axiom, 0 sorries, 462
-lines.
+Each is the same `(h q).symm.trans (hP q)` / `(h q).trans (hP q)`
+two-line proof as `universalExistentialDefinition_iff_of_pred_iff`
+(iteration 3, the Π₂ version). All four classes are now invariant
+under propositional equivalence, completing the propositional-
+congruence story for the file.
+
+S3 (iteration 3) — Σ₂ definability + Σ₂/Π₂ duality:
+
+1. `IsExistentialUniversalDefinition` (Σ₂, ∃∀ definability).
+2. `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂).
+3. `existentialUniversal_iff_universalExistential_complement` (Σ₂/Π₂
+   duality).
+4. `universalExistentialDefinition_iff_of_pred_iff` (Π₂ congruence).
+5. `koenigsmann_implies_complement_existentialUniversal` (Σ₂(ℚ\ℤ)
+   corollary).
 
 ## Build Status
 
-Docker build: PASSED ✅ (3 jobs, exit code 0). Verified the new
-section compiles cleanly against the Lean-core-only design (no Mathlib
-import). The two `Classical.byContradiction` patterns from iteration 2
-extend smoothly to Σ₂/Π₂ — both directions of the new duality, and the
-`hbridge` (`IntSubset q ↔ ¬ NotIntSubset q`) used in the corollary.
+Iteration 4 build: PENDING. Worktree's `.lake` is a self-symlink loop
+so Docker build would re-fresh-clone Mathlib (~25-45 min). The three
+new theorems use the same `Iff.trans` chaining as the iteration 3
+`universalExistentialDefinition_iff_of_pred_iff`, which BUILT cleanly
+in iteration 3 (3 jobs, exit code 0). All operate on already-defined
+predicates with no new imports. Confidence high; CI is the ground
+truth.
 
-The `NotIntSubset` definition is non-`@[irreducible]`, so Lean's
-unifier auto-unfolds `¬ NotIntSubset q` to `¬ ¬ IntSubset q` where
-needed (e.g. inside `hbridge`'s `Classical.byContradiction` step).
+Iteration 3 build: PASSED ✅ (3 jobs, exit code 0).
 
 ## Blockers
 
@@ -52,24 +70,21 @@ None.
 
 ## Next Action
 
-Commit, push, create PR.
+Commit, push, create PR for iteration 4 (this).
 
-If S3 lands cleanly, S4+ candidates:
-- Σ₂ ⊆ Π₂'s ¬¬-shadow — the technical clarification that `Σ₂(S)` and
-  `Π₂(¬¬S) = Π₂(S)` agree on `Prop`-classical predicates; would tighten
-  the predicate-equivalence bridge into a stronger congruence lemma.
+If S4 lands cleanly, S5+ candidates (unchanged from iteration 3):
+- Σ₂ ⊆ Π₂'s ¬¬-shadow — `Σ₂(S)` and `Π₂(¬¬S) = Π₂(S)` agreement on
+  `Prop`-classical predicates.
 - Σ₁ × Π₁ closure properties (under finite union/intersection) — needs
-  `Rat.mul_eq_zero` / sum-of-squares lemma which would require either
-  a Mathlib import or a hand-rolled proof from Lean core.
-- Π₁ ⊆ Π₂ via the `a ≠ 0 ⟺ ∃ z, a·z = 1` polynomial-inversion trick —
-  needs the same Rat field arithmetic.
+  `Rat.mul_eq_zero` / sum-of-squares lemma which requires Mathlib import.
+- Π₁ ⊆ Π₂ via `a ≠ 0 ⟺ ∃ z, a·z = 1` polynomial-inversion trick —
+  same Rat field arithmetic blocker.
 - Daans 2021 (10-quantifier reduction) as a separate axiomatized
-  witness refining `koenigsmann_2016_universal` — would add 1 new axiom
-  but improve quantitative content; defer until further duality / closure
-  work lands.
+  witness — adds 1 axiom, defer.
 
 ## Attempt Counts
 
-- Total attempts: 3
-- Current approach attempts: 1 (S3 — Σ₂/Π₂ duality, first attempt OK)
-- Approaches tried: 2 (S2 — Σ₁/Π₁ duality, S3 — Σ₂/Π₂ duality)
+- Total attempts: 4
+- Current approach attempts: 1 (S4 — class congruence, this iteration)
+- Approaches tried: 3 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
+  congruence)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 462,
+    "lineCount": 526,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -52,7 +52,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 16,
     "definitionCount": 8
   },
   "overview": {
@@ -180,9 +180,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 462,
+    "lineCount": 526,
     "axiomCount": 1,
-    "theoremCount": 13,
+    "theoremCount": 16,
     "definitionCount": 8,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -38,18 +38,18 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08T06:00:00.000Z",
-    "iteration": 3,
-    "focus": "Phase-2 ACT iteration 3 complete: extended Hilbert10OQ01OQ02.lean from 330 to 462 lines with the Σ₂/Π₂ duality layer. New: IsExistentialUniversalDefinition (Σ₂, ∃∀), codiophantine_implies_existentialUniversal (Π₁ ⊆ Σ₂, axiom-free dual of Σ₁ ⊆ Π₂), existentialUniversal_iff_universalExistential_complement (Σ₂/Π₂ duality, axiom-free up to two classical-byContradiction steps), universalExistentialDefinition_iff_of_pred_iff (Π₂ class congruence helper), and koenigsmann_implies_complement_existentialUniversal (ℚ\\ℤ is Σ₂-definable in ℚ — corollary of Koenigsmann via duality, no new axiom). The four corners of the Σ₁/Π₁/Σ₂/Π₂ square are now all formalized. Total: 13 theorems, 8 defs, 1 axiom, 0 sorries. Docker build passes (3 jobs).",
+    "iteration": 4,
+    "focus": "Phase-2 ACT iteration 4 (this PR, researcher-1): completes the propositional-equivalence congruence story for all four definability classes. Adds three theorems analogous to iteration 3's `universalExistentialDefinition_iff_of_pred_iff` (Π₂ congruence): `diophantineDefinition_iff_of_pred_iff` (Σ₁), `coDiophantineDefinition_iff_of_pred_iff` (Π₁), and `existentialUniversalDefinition_iff_of_pred_iff` (Σ₂). All three follow the same `(h q).symm.trans (hP q)` two-line template; mechanical but completes the four-class symmetry. Net: +3 theorems, 0 defs, 0 axioms. Total 526 lines (was 462), 16 theorems (was 13), 8 defs, 1 axiom, 0 sorries. Build pending (CI). Iteration 3 (researcher-9 session 2, 2026-05-08, PR #16885 merged): Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary.",
     "blockers": [],
-    "nextAction": "S4+ candidates: (a) Σ₁ × Π₁ closure properties (∪/∩) — needs Rat.mul_eq_zero / sum-of-squares, currently no Mathlib import; (b) Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — same Rat-arithmetic blocker; (c) Daans 2021 (10-quantifier) refinement of koenigsmann_2016_universal — would add 1 axiom but improve quantitative content; (d) Eisenträger-Park 2018 universal-existential characterization for global fields. Defer further work until either Mathlib is imported or one of these is selected.",
+    "nextAction": "S5+ candidates (after this PR lands): (a) Σ₂ ⊆ Π₂'s ¬¬-shadow technical clarification — would tighten the predicate-equivalence bridge into a stronger congruence lemma; (b) Σ₁ × Π₁ closure properties (∪/∩) — needs Rat.mul_eq_zero / sum-of-squares, currently no Mathlib import; (c) Π₁ ⊆ Π₂ via polynomial-inversion trick (a ≠ 0 ⟺ ∃ z, a·z = 1) — same Rat-arithmetic blocker; (d) Daans 2021 (10-quantifier) refinement of koenigsmann_2016_universal — would add 1 axiom but improve quantitative content; (e) Eisenträger-Park 2018 universal-existential characterization for global fields.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "PHASE-2 ACT iterations 1-3 complete. Iteration 1 (researcher-6, 2026-05-08): scaffolded the file with Σ₁/Π₂ skeleton (5 theorems, 5 defs, 1 axiom). Iteration 2 (researcher-9 session 1, 2026-05-08): added Σ₁/Π₁ duality (4 new theorems, 2 new defs, 0 new axioms; PR #16839 merged). Iteration 3 (researcher-9 session 2, 2026-05-08): added Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (4 new theorems, 1 new def, 0 new axioms; current PR). The file is now 462 lines with 13 theorems, 8 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries; the Σ₁ question itself remains OPEN (intentionally). All four corners of the Σ₁/Π₁/Σ₂/Π₂ square — two trivial containments (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂) and two dualities (Σ₁/Π₁, Σ₂/Π₂) — are now proved axiom-free. Docker build passes.",
+    "progressSummary": "PHASE-2 ACT iterations 1-4 complete. Iteration 1 (researcher-6, 2026-05-08): scaffolded the file with Σ₁/Π₂ skeleton (5 theorems, 5 defs, 1 axiom). Iteration 2 (researcher-9 session 1, 2026-05-08): added Σ₁/Π₁ duality (4 new theorems, 2 new defs, 0 new axioms; PR #16839 merged). Iteration 3 (researcher-9 session 2, 2026-05-08): added Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (4 new theorems, 1 new def, 0 new axioms; PR #16885 merged). Iteration 4 (researcher-1, 2026-05-08, this PR): completes the propositional-equivalence congruence story by adding the three remaining class congruence helpers — diophantineDefinition_iff_of_pred_iff (Σ₁), coDiophantineDefinition_iff_of_pred_iff (Π₁), existentialUniversalDefinition_iff_of_pred_iff (Σ₂) — all axiom-free, mechanically templated on the existing Π₂ congruence. The file is now 526 lines with 16 theorems, 8 defs, 1 axiom (koenigsmann_2016_universal), 0 sorries; the Σ₁ question itself remains OPEN (intentionally). All four corners of the Σ₁/Π₁/Σ₂/Π₂ square — two trivial containments (Σ₁ ⊆ Π₂, Π₁ ⊆ Σ₂), two dualities (Σ₁/Π₁, Σ₂/Π₂), and now four propositional-equivalence congruences — are formalized. Iteration 4 build pending; iteration 3 build passed.",
     "builtItems": [
       "Proofs/Hilbert10OQ01OQ02.lean: file scaffolded with imports from Hilbert10OQ01 (lines 1-69)",
       "Proofs/Hilbert10OQ01OQ02.lean: abbrev RatSubset := Rat → Prop (line 71)",
@@ -73,7 +73,11 @@
       "Proofs/Hilbert10OQ01OQ02.lean: theorem universalExistentialDefinition_iff_of_pred_iff (Π₂ class congruence helper, axiom-free) (lines 352-365, iteration 3)",
       "Proofs/Hilbert10OQ01OQ02.lean: theorem koenigsmann_implies_complement_existentialUniversal (ℚ\\ℤ is Σ₂-definable in ℚ; corollary of Koenigsmann via Σ₂/Π₂ duality, no new axiom) (lines 367-383, iteration 3)",
       "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 330→462, theoremCount 9→13, definitionCount 7→8 (axiomCount unchanged)",
-      "src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json: 13 annotations covering all four quantifier classes, both dualities, the Σ₂(ℚ\\ℤ) corollary, and the closing #checks"
+      "src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json: 13 annotations covering all four quantifier classes, both dualities, the Σ₂(ℚ\\ℤ) corollary, and the closing #checks",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem diophantineDefinition_iff_of_pred_iff (Σ₁ class congruence under propositional equivalence; pure logic, no axioms) (lines 367-385, iteration 4)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem coDiophantineDefinition_iff_of_pred_iff (Π₁ class congruence under propositional equivalence; pure logic, no axioms) (lines 387-403, iteration 4)",
+      "Proofs/Hilbert10OQ01OQ02.lean: theorem existentialUniversalDefinition_iff_of_pred_iff (Σ₂ class congruence under propositional equivalence; pure logic, no axioms) (lines 405-422, iteration 4)",
+      "src/data/proofs/hilbert-10-oq-01-oq-02/meta.json: lineCount 462→526, theoremCount 13→16 (axiomCount/definitionCount unchanged)"
     ],
     "insights": [
       "The Σ₁/Π₁ distinction (Diophantine vs universal definability) is the precise mathematical content of OQ-01-OQ-02 over and above OQ-01: Koenigsmann 2016 settled Π₁; Σ₁ remains open",


### PR DESCRIPTION
## Summary

**Iteration 4** of the OQ-01-OQ-02 (purely-Diophantine ℤ in ℚ) Lean formalization. Adds three theorems that complete the propositional-equivalence congruence story for all four definability classes:

- `diophantineDefinition_iff_of_pred_iff` (Σ₁)
- `coDiophantineDefinition_iff_of_pred_iff` (Π₁)
- `existentialUniversalDefinition_iff_of_pred_iff` (Σ₂)

All three are direct analogs of iteration 3's `universalExistentialDefinition_iff_of_pred_iff` (Π₂ congruence) and follow the same `(h q).symm.trans (hP q)` / `(h q).trans (hP q)` two-line template. Pure logical congruence; no new axioms.

## Why this matters

After this PR all four classes (Σ₁, Π₁, Σ₂, Π₂) are invariant under propositional equivalence of the defining predicate. The Π₂ congruence already pulled its weight in `koenigsmann_implies_complement_existentialUniversal` (the unconditional Σ₂(ℚ\ℤ) corollary of Koenigsmann, derived via Π₂(¬¬ ℤ) ⟺ Π₂(ℤ)); adding the other three makes the same kind of derivation available for any of the other classes — useful for any future bridging theorems crossing classical negation.

## Files Modified

- `proofs/Proofs/Hilbert10OQ01OQ02.lean` (+66 lines: three theorems with docstrings, plus updates to the bottom-of-file theorem list and `#check` block)
- `src/data/proofs/hilbert-10-oq-01-oq-02/meta.json` (lineCount 462→526, theoremCount 13→16; axiomCount/definitionCount unchanged)
- `src/data/research/problems/hilbert-10-oq-01-oq-02.json` (iteration 3→4, focus, builtItems, progressSummary)
- `research/problems/hilbert-10-oq-01-oq-02/state.md` (iteration 4 narrative)

## Honest Reporting

- **No mathematics**: the theorems are pure logical congruence, mechanically templated on the existing Π₂ helper.
- **No axiom delta**: still 1 axiom (`koenigsmann_2016_universal`), still 0 sorries.
- **Theorem-count delta**: +3 (13 → 16).
- **Line-count delta**: +64 lines (462 → 526), mostly docstrings.

## Build Status

⚠️ **Build pending**: this session's worktree has a recursive `.lake` symlink trap so Docker build would fresh-clone Mathlib (~25–45 min). The three new theorems use the same `Iff.trans` chaining as iteration 3's `universalExistentialDefinition_iff_of_pred_iff`, which built cleanly in iteration 3 (3 jobs, exit code 0). All operate on already-defined predicates with no new imports.

## Status

**Outcome**: progress (structural lemmas added; four-class congruence story complete)
**Next Steps**: S5 — Σ₂ ⊆ Π₂'s ¬¬-shadow technical clarification, OR closure properties (needs Mathlib Rat arithmetic).

🤖 Generated by researcher-1