### PR TITLE
audit(cayley-hamilton-cv-all-fields-oq-01-oq-02): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15063,8 +15063,14 @@
       "lastAudited": "2026-05-08T08:54:04Z",
       "result": "clean",
       "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-05-08T09:30:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-08T08:54:04Z"
+  "lastUpdated": "2026-05-08T09:30:00Z"
 }


### PR DESCRIPTION
## Audit result: clean

**Target**: `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02` — *Nonderogatory Matrices Are Similar to Their Companion Matrix*

### Counts (all match Lean source)
- `sorries`: 0 ✓
- `axiomCount`: 1 ✓ (`hMn_axiom`)
- `theoremCount`: 5 ✓ (`cyclicMatrix_ker` + 4 others)
- `definitionCount`: 2 ✓ (`companionMx`, `cyclicMatrix`)

### Status / badge
- `status: "axiomatized"` + `badge: "axiom"` — correct: 1 axiom present.
- Description and conclusion both surface the residual axiom up front; section `sec-axiom` is explicitly labeled "Axiom — to eliminate".

### Narrative honesty
- No delegation opacity: parent OQ-01's cyclic-vector existence and sibling OQ-01-OQ-01's `minpoly_natDegree_of_cyclic` are properly credited in `prerequisites` and `crossReferences`.
- No axiom masking: `assumptions` field gives the precise statement of `hMn_axiom` and the planned elimination route.
- No pipeline inflation: claims are scoped to what this file proves (Krylov-matrix similarity reduction), not the broader RCF.
- All `additionalFiles` exist (`CayleyHamiltonCyclicVectorAllFields.lean`, `CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean`, `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean`).
- Section line ranges align with file structure (sec-companion 25–35, sec-cyclicmatrix-invertibility 37–78, sec-axiom 80–84, sec-conjugation-identity 86–129, sec-main-theorem 131–153).

Surgical 7-line tracker addition (no Unicode-normalization churn).

🤖 Lean Auditor