### PR TITLE
audit(tracker): tractatus-ontology — 2nd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13489,9 +13489,9 @@
       "result": "clean"
     },
     "tractatus-ontology": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:36Z",
+      "lastAudited": "2026-05-08T09:47:19Z",
       "result": "clean"
     },
     "triangle-angle-sum": {


### PR DESCRIPTION
## Summary
Re-audit of stale 2026-04-23 entry — second clean pass for tractatus-ontology.

## Verification (against `origin/main`)
**TractatusOntology.lean**: 1230 lines, 0 sorries, 1 axiom (`silence : True`, TLP 7), 41 theorems, 26 definitions — all match `meta.json` claims.

**TractatusQuantifiers.lean** (companion): 288 lines, 0 sorries, 0 axioms — matches the assumptions narrative.

**Status/badge**: `axiomatized` + `axiom` is correct for the single deliberate `silence : True` axiom (vacuous, philosophical gesture). No phantom-axiom narrative drift detected.

## Tracker change
`src/data/proofs/audit-tracker.json` — bump `tractatus-ontology` auditCount 1→2, lastAudited 2026-04-23 → 2026-05-08, result clean.

## Test plan
- [x] Counts re-derived from `git show origin/main:` (no working-tree pollution)
- [x] Comment-aware sorry/axiom regex (depth-tracked nested block comments)
- [x] Diff is exactly 2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)