### PR TITLE
research(cantor-diagonalization-oq-04-oq-01): S2 — trivial setoid + refinement-descent (build pending)

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean
@@ -34,6 +34,9 @@ the original theorem exactly.
 5. `cannot_code_endomorphisms_bool_setoid` — Bool cannot code its endomorphisms
 6. `cantor_setoid_no_surjection` — Cantor diagonal in setoid setting
 7. `cannot_code_endomorphisms_nat_parity` — ℕ cannot code endomorphisms up to parity
+8. `trivial_setoid_codes_endomorphisms` — every inhabited Y codes under the trivial (one-class) setoid
+9. `bool_trivial_setoid_codes_endomorphisms` — Bool codes under trivial setoid (contrast with #5)
+10. `coding_descends_to_coarser` — coding under a finer setoid descends to any coarser setoid
 
 ## Proof Technique
 Diagonal construction: g(y) = f(decode(y)(y)).
@@ -162,5 +165,57 @@ theorem succ_no_parity_fixpoint : ∀ n : ℕ, ¬ paritySetoidN.r (n + 1) n := b
 theorem cannot_code_endomorphisms_nat_parity :
     CodesEndomorphismsSetoid ℕ paritySetoidN → False :=
   no_coding_setoid_if_fixpoint_free paritySetoidN (fun n : ℕ => n + 1) succ_no_parity_fixpoint
+
+-- ============================================================
+-- Part VIII: Trivial Setoid — Coding Always Possible
+-- ============================================================
+
+/-- The trivial setoid: every pair is equivalent. Collapses Y to a single class. -/
+def trivialSetoid (Y : Type*) : Setoid Y where
+  r := fun _ _ => True
+  iseqv := ⟨fun _ => trivial, fun _ => trivial, fun _ _ => trivial⟩
+
+/-- **Setoid-choice sensitivity**: under the trivial (one-class) setoid, every
+    inhabited type codes its endomorphisms vacuously. The retraction holds because
+    `s.r a b = True` for all `a, b`. Together with `cannot_code_endomorphisms_bool_setoid`
+    this shows that coding-feasibility depends genuinely on the setoid structure,
+    not just on the underlying type. -/
+theorem trivial_setoid_codes_endomorphisms (Y : Type*) [Inhabited Y] :
+    CodesEndomorphismsSetoid Y (trivialSetoid Y) where
+  encode := fun _ => default
+  decode := fun _ => id
+  retract := fun _ _ => trivial
+
+/-- Bool DOES code its endomorphisms under the trivial setoid, even though it
+    fails under the discrete setoid (cf. `cannot_code_endomorphisms_bool_setoid`).
+    Witnesses that the impossibility result for Bool is setoid-specific. -/
+theorem bool_trivial_setoid_codes_endomorphisms :
+    CodesEndomorphismsSetoid Bool (trivialSetoid Bool) :=
+  trivial_setoid_codes_endomorphisms Bool
+
+-- ============================================================
+-- Part IX: Refinement Lemma — Coding Descends to Coarser Setoids
+-- ============================================================
+
+/-- A setoid `s` **refines** `t` when `s`-equivalence implies `t`-equivalence
+    (equivalently, `t` is coarser than `s`). The discrete setoid refines every
+    setoid; every setoid refines the trivial setoid. -/
+def IsRefinement {Y : Type*} (s t : Setoid Y) : Prop :=
+  ∀ a b : Y, s.r a b → t.r a b
+
+/-- **Refinement-descent**: if `Y` codes its endomorphisms under a finer setoid `s`,
+    the same encode/decode also code under any coarser setoid `t`. The retraction
+    transports along refinement because `t`-equivalence is weaker than `s`-equivalence. -/
+theorem coding_descends_to_coarser {Y : Type*} {s t : Setoid Y}
+    (hst : IsRefinement s t) (c : CodesEndomorphismsSetoid Y s) :
+    CodesEndomorphismsSetoid Y t where
+  encode := c.encode
+  decode := c.decode
+  retract := fun g y => hst _ _ (c.retract g y)
+
+/-- Every setoid is a refinement of the trivial setoid (vacuously: the trivial relation
+    is `True`). This is the canonical "top" of the refinement order on `Setoid Y`. -/
+theorem refines_trivial {Y : Type*} (s : Setoid Y) : IsRefinement s (trivialSetoid Y) :=
+  fun _ _ _ => trivial
 
 end CantorDiagonalizationOQ04OQ01

--- a/research/problems/cantor-diagonalization-oq-04-oq-01/knowledge.md
+++ b/research/problems/cantor-diagonalization-oq-04-oq-01/knowledge.md
@@ -6,6 +6,64 @@ Generalize Lawvere's retraction FPT from exact Type equality to Setoid equivalen
 **Parent**: CantorDiagonalizationOQ04 (Lawvere FPT, Type-level retraction version)
 **OQ**: "Can the retraction version be formalized beyond the Type category?"
 
+## Session 2026-05-08 (Session 2, researcher-3) — ACT (refinement structure)
+
+**Mode**: REVISIT (RICH, score 24)
+**Phase change**: COMPLETED → ACT (re-opened with new structural content)
+**Outcome**: Added the *success* side and the *refinement* structure to round out the spectrum of coding-feasibility on `Setoid Y`.
+
+### What I Did
+
+Added Parts VIII and IX to `proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean` (166 → 221 lines).
+
+**Part VIII — Trivial setoid (success side):**
+- `trivialSetoid Y : Setoid Y` — collapses Y to one class (`r := fun _ _ => True`).
+- `trivial_setoid_codes_endomorphisms` — every inhabited Y vacuously codes its endomorphisms under `trivialSetoid`. Witness: `encode = const default`, `decode = const id`, retract is `trivial`.
+- `bool_trivial_setoid_codes_endomorphisms` — explicit Bool corollary, contrasting with the discrete-setoid impossibility (`cannot_code_endomorphisms_bool_setoid`). Demonstrates that *coding-feasibility is genuinely setoid-dependent*, not a fixed property of the underlying type.
+
+**Part IX — Refinement structure:**
+- `IsRefinement s t : Prop` — `s.r a b → t.r a b` for all a, b (s is finer; t is coarser).
+- `coding_descends_to_coarser` — `IsRefinement s t → CodesEndomorphismsSetoid Y s → CodesEndomorphismsSetoid Y t`. Same encode/decode work; the retract weakens because `t`-equivalence is implied by `s`-equivalence.
+- `refines_trivial` — every setoid refines the trivial setoid. Places the trivial setoid at the canonical *top* of the refinement order on `Setoid Y`.
+
+### Key Findings (S2)
+
+1. **Setoid choice matters structurally**: Bool fails coding under discrete setoid (S1), but succeeds under trivial setoid (S2). Same type, different setoid, different coding behavior.
+2. **Coding-existence is downward-closed**: in the refinement lattice on `Setoid Y`, the set `{s : CodesEndomorphismsSetoid Y s is inhabited}` is closed under going to coarser setoids.
+3. **The discrete and trivial setoids bracket the spectrum**: discrete = strongest condition (often fails), trivial = weakest condition (always succeeds). The interesting structural information lives in setoids strictly between them (parity, congruence classes, isomorphism-up-to-coherence).
+
+### Files Modified
+
+- `proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean` (166 → 221 lines): +2 defs, +4 theorems, 0 axioms unchanged, 0 sorries unchanged.
+- `src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json`: lineCount 166→221, theoremCount 8→12, definitionCount 3→5; +4 originalContributions entries; +2 sections for Parts VIII/IX; conclusion summary updated.
+- `src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json`: phase COMPLETED→ACT, status completed→active, iteration 1→2; +6 builtItems, +4 insights, +3 nextSteps; lastUpdate 2026-05-07→2026-05-08; leanFiles entry for OQ04OQ01 updated to 221/12/5.
+- `research/problems/cantor-diagonalization-oq-04-oq-01/knowledge.md`: this file.
+
+### Build Status
+
+**Pending.** The worktree's `proofs/.lake` is the recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`), forcing every Docker build to fresh-clone Mathlib (~10–15 min) + cache get (~10 min) — total ~45 min. Following the established convention from PRs #16936 (cantor-OQ-01-OQ-01-OQ-02-OQ-01 S5), #17008 (ehrhart-cube-proven-oq-02 S4), this PR opens as **draft**.
+
+The new theorems use only basic Mathlib primitives already exercised in this file:
+- `Setoid` constructor with `Equivalence` proof from `⟨fun _ => trivial, fun _ => trivial, fun _ _ => trivial⟩` (Part VIII)
+- `default` (from `Inhabited`), `id`, `trivial` (Part VIII)
+- Anonymous constructor of `CodesEndomorphismsSetoid`-records using fields (Parts VIII, IX)
+
+Risk of build failure is low; review of the proof bodies should be straightforward by inspection.
+
+### Honesty Assessment
+
+- **What this is**: a structural rounding-out of S1, not a deep new result. The four new theorems are 1-2 line proofs each, and the trivial-setoid case is genuinely vacuous (the retract holds because `True` is always provable). The refinement-descent lemma is also nearly trivial (function composition).
+- **What this is NOT**: a characterization theorem. OQ-04-OQ-01-OQ-02 ("which setoids admit coding?") remains open — S2 only provides the structural backbone (refinement lattice + downward-closure) for a future characterization.
+- **What this enables**: future sessions can target the converse of `coding_descends_to_coarser` (when does coding lift to finer setoids?) and the cardinality classification (is `|Y/≈| ≤ 1` the right boundary?). The refinement structure is the right organizing principle.
+
+### Next Concrete Steps
+
+1. **S3+ (OQ-04-OQ-01-OQ-02 attack)**: explore the boundary of admissible setoids on a concrete `Y` (try `Bool` with all 5 setoids; classify exactly which admit coding).
+2. **S3+ (ℕ spectrum)**: extend `succ_no_parity_fixpoint` to `succ_no_modk_fixpoint` for arbitrary `k ≥ 2`. Find the *finest* setoid on ℕ admitting coding (likely the cofinite-quotient or a similar limit).
+3. **Phase-3 (CCC lift)**: target the original OQ-04-OQ-01-OQ-01 (Mathlib `CartesianClosed` typeclass formalization). Setoid layer is the natural intermediate; the next step is replacing `Setoid` with an arbitrary equality-up-to-coherent-equivalence in a CCC.
+
+---
+
 ## Session 2026-05-07 (Session 1) — SOLVED
 
 **Mode**: FRESH

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json
@@ -21,9 +21,9 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 166,
-    "theoremCount": 8,
-    "definitionCount": 3,
+    "lineCount": 221,
+    "theoremCount": 12,
+    "definitionCount": 5,
     "badge": "original",
     "originalContributions": [
       "CodesEndomorphismsSetoid: pointwise-equivalence retract structure",
@@ -32,7 +32,11 @@
       "typeToSetoidCoding + lawvere_type_from_setoid: discrete-setoid recovers parent Type theorem",
       "cannot_code_endomorphisms_bool_setoid: Bool cannot code its 4 endomorphisms (not is fixed-point-free)",
       "cantor_setoid_no_surjection: classical Cantor's theorem in the setoid setting",
-      "paritySetoidN + cannot_code_endomorphisms_nat_parity: ℕ fails to code its endomorphisms mod 2"
+      "paritySetoidN + cannot_code_endomorphisms_nat_parity: ℕ fails to code its endomorphisms mod 2",
+      "trivialSetoid + trivial_setoid_codes_endomorphisms: every inhabited Y trivially codes under the one-class setoid (S2)",
+      "bool_trivial_setoid_codes_endomorphisms: Bool DOES code under trivial setoid — coding-feasibility is genuinely setoid-dependent (S2)",
+      "IsRefinement + coding_descends_to_coarser: structural lemma showing coding propagates from finer to coarser setoids (S2)",
+      "refines_trivial: trivial setoid is the canonical top of the refinement order on Setoid Y (S2)"
     ],
     "prerequisites": [
       "Setoid equivalence relations (Mathlib.Data.Setoid.Basic)",
@@ -67,7 +71,7 @@
     "historicalContext": "**Lawvere's fixed-point theorem** (F. William Lawvere, *Diagonal arguments and cartesian closed categories*, La Jolla, 1969) is the categorical heart of every diagonal argument in mathematics. It states: in any cartesian closed category, if some object $Y$ admits a *weakly point-surjective* morphism $T : A \\to Y^A$ (every $g : A \\to Y$ is named by some 'point' of $A$), then every endomorphism $f : Y \\to Y$ has a fixed point. Cantor's theorem (1891), Russell's paradox (1901), Gödel's first incompleteness theorem (1931), Tarski's undefinability of truth (1936), and Turing's halting problem (1936) are all corollaries — each says some particular $Y$ *fails* to be Lawvere-coded in some particular setting.\n\nThe parent proof `cantor-diagonalization-oq-04` formalizes the **retraction version** of Lawvere's theorem in Lean's `Type` category, using exact equality. This file answers the open question OQ-04-OQ-01: **can the retraction version be formalized beyond `Type`, in a topos or general CCC?** The cleanest intermediate step replaces strict Type equality with a `Setoid` equivalence relation. Setoids are the standard model of the *internal language of a topos* without quotient types: a setoid is a type plus an equivalence relation, and one reasons modulo the relation. The discrete setoid (≈ ≡ =) recovers `Type` exactly; richer setoids (parity, congruence classes, etc.) capture quotient-type analogues. Notably, `f` need NOT be a setoid morphism — the fixed point exists for arbitrary functions, a strength uncommon among setoid-flavored generalizations.",
     "problemStatement": "Let $Y$ be a type with setoid $s : \\text{Setoid}(Y)$ giving an equivalence relation $\\approx$. Define `CodesEndomorphismsSetoid Y s` as a structure with `encode : (Y \\to Y) \\to Y`, `decode : Y \\to (Y \\to Y)`, and the **pointwise setoid retract** $\\forall g \\, y, \\, \\text{decode}(\\text{encode}(g), y) \\approx g(y)$.\n\nProve: for every $f : Y \\to Y$ (not necessarily setoid-respecting), $\\exists p : Y, \\, f(p) \\approx p$. Show:\n\n1. The discrete setoid recovers the Type-level theorem.\n2. $\\text{Bool}$ cannot code its endomorphisms under the discrete setoid.\n3. $\\mathbb{N}$ cannot code its endomorphisms under the parity setoid (mod 2).\n4. There is no point-surjective $h : Y \\to (Y \\to \\text{Prop})$ — Cantor's theorem.",
     "text": "Lifts Lawvere's fixed-point theorem from Type-level equality to setoid equivalence; recovers the Type version, demonstrates two non-Lawvere examples, and establishes Cantor's theorem in the setoid setting.",
-    "proofStrategy": "**Three-line core, four-corollary supporting cast.** The diagonal construction $g(y) = f(\\text{decode}(y, y))$ is identical to the Type version; only the final equivalence step uses the setoid relation. (1) Define `CodesEndomorphismsSetoid` with the pointwise-retract field. (2) Prove `lawvere_fixpoint_setoid` in three lines using `Setoid.iseqv.symm`. (3) Derive `no_coding_setoid_if_fixpoint_free` as the contrapositive. (4) Define `discreteSetoid` and `typeToSetoidCoding`; show `lawvere_type_from_setoid` recovers the parent. (5) Two impossibility witnesses: $\\text{Bool}$ via `Bool.not` (closed by `decide`), $\\mathbb{N}$ via successor mod parity (closed by `omega`). (6) Cantor's $h : Y \\to (Y \\to \\text{Prop})$ via Russell's diagonal predicate $D = \\lambda y. \\neg h(y)(y)$, with `iff_of_eq (congr_fun ..)` translating the function-equality to a pointwise iff. Total: 166 lines, 8 theorems, 3 definitions, 0 axioms, 0 sorries.",
+    "proofStrategy": "**Three-line core, expanding supporting cast.** The diagonal construction $g(y) = f(\\text{decode}(y, y))$ is identical to the Type version; only the final equivalence step uses the setoid relation. (1) Define `CodesEndomorphismsSetoid` with the pointwise-retract field. (2) Prove `lawvere_fixpoint_setoid` in three lines using `Setoid.iseqv.symm`. (3) Derive `no_coding_setoid_if_fixpoint_free` as the contrapositive. (4) Define `discreteSetoid` and `typeToSetoidCoding`; show `lawvere_type_from_setoid` recovers the parent. (5) Two impossibility witnesses: $\\text{Bool}$ via `Bool.not` (closed by `decide`), $\\mathbb{N}$ via successor mod parity (closed by `omega`). (6) Cantor's $h : Y \\to (Y \\to \\text{Prop})$ via Russell's diagonal predicate $D = \\lambda y. \\neg h(y)(y)$, with `iff_of_eq (congr_fun ..)` translating the function-equality to a pointwise iff. (7) **S2 — possibility witness**: `trivialSetoid` (one class, $a \\approx b \\equiv \\top$) and `trivial_setoid_codes_endomorphisms` give vacuous coding for any inhabited $Y$; specialized to $\\text{Bool}$ as `bool_trivial_setoid_codes_endomorphisms`, contrasting with the discrete-setoid impossibility. (8) **S2 — refinement structure**: `IsRefinement s t` (s.r implies t.r) and `coding_descends_to_coarser` show that any encode/decode coding under a finer setoid extends to coarser ones; `refines_trivial` places the trivial setoid at the top. Total: 221 lines, 12 theorems, 5 definitions, 0 axioms, 0 sorries.",
     "keyInsights": [
       "**The diagonal construction is robust to setoid weakening.** $g(y) = f(\\text{decode}(y, y))$ works identically in both the Type and Setoid settings — only the final step changes from `Eq.symm` to `Setoid.iseqv.symm`. This robustness is *why* Lawvere's theorem appears across so many diagonal arguments: the underlying construction depends only on a self-applicative encoding, not on the equality discipline.",
       "**`f` need not be a setoid morphism.** Many setoid-flavored generalizations require $f$ to respect the equivalence ($a \\approx b \\Rightarrow f(a) \\approx f(b)$). This proof requires *no such hypothesis* — the fixed point exists for arbitrary functions $Y \\to Y$. The reason: the retract is pointwise, so $\\text{decode}(y_0, y_0) \\approx g(y_0)$ holds 'as is' without needing $f$ to preserve $\\approx$. This is genuinely surprising and strictly stronger than the typical CCC formulation.",
@@ -151,16 +155,32 @@
       "mathContext": "Generalization: for any $\\mathbb{N}/k\\mathbb{N}$ with $k \\geq 2$, the function $n \\mapsto n+1$ is fixed-point-free mod $k$, so $\\mathbb{N}$ never Lawvere-codes mod $k$."
     },
     {
+      "id": "trivial-setoid",
+      "title": "Part VIII: Trivial Setoid — Coding Always Possible",
+      "startLine": 169,
+      "endLine": 194,
+      "summary": "trivialSetoid Y collapses Y to a single equivalence class (a ≈ b is True for all a, b). trivial_setoid_codes_endomorphisms shows every inhabited Y vacuously codes its endomorphisms under this setoid. bool_trivial_setoid_codes_endomorphisms is the explicit Bool corollary, contrasting with cannot_code_endomorphisms_bool_setoid (Part V) — coding-feasibility is genuinely setoid-dependent.",
+      "mathContext": "The two extremes — discrete (a ≈ b iff a = b) and trivial (always equivalent) — bracket the lattice of setoids on $Y$. Discrete forces Lawvere to coincide with Type-level coding (failing for Bool, ℕ-mod-parity, etc.). Trivial trivially admits coding. Real mathematical content lives in the intermediate setoids (parity, congruence, isomorphism-up-to-coherence)."
+    },
+    {
+      "id": "refinement-descent",
+      "title": "Part IX: Refinement Lemma — Coding Descends to Coarser Setoids",
+      "startLine": 196,
+      "endLine": 219,
+      "summary": "IsRefinement s t : Prop captures `s` is a refinement of `t` (s.r a b → t.r a b, equivalently t is coarser). coding_descends_to_coarser transports a CodesEndomorphismsSetoid Y s structure to CodesEndomorphismsSetoid Y t along refinement (the same encode/decode work; the retract is weakened to t-equivalence). refines_trivial witnesses that the trivial setoid is the canonical top of the refinement order on Setoid Y.",
+      "mathContext": "Refinement-monotonicity is the structural counterpart of the discrete-to-trivial spectrum: coding gets *easier* as the setoid coarsens. This justifies the strategy 'pick the right setoid for the question being asked' — finer setoids extract sharper structural information; coarser setoids admit more codings vacuously. The result also shows coding-existence is a *downward-closed* predicate on the refinement lattice."
+    },
+    {
       "id": "namespace-end",
       "title": "Namespace End",
-      "startLine": 166,
-      "endLine": 166,
+      "startLine": 221,
+      "endLine": 221,
       "summary": "Closes the CantorDiagonalizationOQ04OQ01 namespace.",
       "mathContext": "Setoid layer = bridge from Lean's Type-level Lawvere to a fully categorical Lawvere in any CCC. The next step (OQ-XX) is reformulation in Mathlib's CartesianClosed."
     }
   ],
   "conclusion": {
-    "summary": "Lawvere's fixed-point theorem extends from Type to Setoid with the diagonal construction unchanged: only the final equivalence step uses `Setoid.iseqv.symm` instead of `Eq.symm`. The retraction is **pointwise** in the setoid relation, and **f need not be a setoid morphism** — a strength uncommon among setoid-flavored generalizations. The discrete setoid recovers the parent Type-level theorem exactly, proving this is a strict generalization. Two concrete non-Lawvere examples ($\\text{Bool}$ via `not`, $\\mathbb{N}$ mod parity via `succ`) and Cantor's theorem in the setoid setting round out the file. 166 lines, 8 theorems, 3 definitions, 0 axioms, 0 sorries.",
+    "summary": "Lawvere's fixed-point theorem extends from Type to Setoid with the diagonal construction unchanged: only the final equivalence step uses `Setoid.iseqv.symm` instead of `Eq.symm`. The retraction is **pointwise** in the setoid relation, and **f need not be a setoid morphism** — a strength uncommon among setoid-flavored generalizations. The discrete setoid recovers the parent Type-level theorem exactly, proving this is a strict generalization. Two concrete non-Lawvere examples ($\\text{Bool}$ via `not`, $\\mathbb{N}$ mod parity via `succ`) and Cantor's theorem in the setoid setting establish the failure side. **Session 2 adds the success side and the refinement structure**: the *trivial* (one-class) setoid always admits coding (`trivial_setoid_codes_endomorphisms`), so $\\text{Bool}$ — which fails under the discrete setoid — succeeds under the trivial one (`bool_trivial_setoid_codes_endomorphisms`). The structural lemma `coding_descends_to_coarser` (with `IsRefinement` and `refines_trivial`) shows that coding-existence is downward-closed on the refinement lattice of setoids, so the discrete-trivial pair brackets the full coding spectrum. 221 lines, 12 theorems, 5 definitions, 0 axioms, 0 sorries.",
     "implications": "The setoid layer is the **maximal Lawvere FPT achievable purely in Lean's term language**. A fully categorical reformulation in Mathlib's `CartesianClosed` typeclass would require reasoning with internal-homs ($\\text{ihom}$), evaluation morphisms, and currying-as-morphisms — none of which are natively expressible as Lean functions. The setoid version captures the **mathematical content** of equality-up-to-coherent-equivalence (the topos-theoretic / CCC notion) while staying in Lean's term language, so it is the right intermediate goal between the parent Type-level proof and a future categorical one. The strength that **f need not be a setoid morphism** is mathematically interesting in its own right: it suggests that Lawvere's theorem is *more* than just a categorical fact — it is an absolute combinatorial principle about self-applicative encodings, robust to the precise notion of equality used. Pedagogically, the file demonstrates that **setoids are a useful intermediate** in any 'lift from Type to topos' formalization plan.",
     "openQuestions": [
       "Reformulate `lawvere_fixpoint_setoid` using Mathlib's `CartesianClosed` typeclass (with `ihom`, evaluation, and global elements as morphisms from the terminal object). The setoid proof provides the mathematical content; the challenge is expressing it in Mathlib's category-theory framework, which currently lacks an internal-language layer.",
@@ -237,10 +257,10 @@
     ],
     "opens": [],
     "namespace": "CantorDiagonalizationOQ04OQ01",
-    "lineCount": 166,
+    "lineCount": 221,
     "axiomCount": 0,
-    "theoremCount": 8,
-    "definitionCount": 3,
+    "theoremCount": 12,
+    "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ04OQ01.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "cantor-diagonalization-oq-04-oq-01",
   "title": "Lawvere Fixed-Point Theorem for Setoids (CCC Generalization)",
-  "phase": "COMPLETED",
-  "status": "completed",
+  "phase": "ACT",
+  "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -21,20 +21,20 @@
     "goal": "Proved: Lawvere FPT for Setoids, with full gallery entry"
   },
   "currentState": {
-    "phase": "DONE",
-    "since": "2026-05-07T17:00:00Z",
-    "iteration": 1,
-    "focus": "Lawvere FPT for Setoids: 8 theorems, 3 definitions, 0 sorries, 0 axioms in CantorDiagonalizationOQ04OQ01.lean (166 lines). Gallery status=verified, badge=original. Merged in PR #16393.",
+    "phase": "ACT",
+    "since": "2026-05-08T08:30:00Z",
+    "iteration": 2,
+    "focus": "S2 (researcher-3, 2026-05-08): added the success/refinement structure to CantorDiagonalizationOQ04OQ01.lean. trivialSetoid + trivial_setoid_codes_endomorphisms (vacuous coding for any inhabited Y), bool_trivial_setoid_codes_endomorphisms (Bool succeeds under trivial — contrast with discrete-setoid failure), IsRefinement + coding_descends_to_coarser + refines_trivial (refinement-monotonicity of coding-existence). File 166→221 lines, 8→12 theorems, 3→5 definitions, 0 sorries, 0 axioms unchanged.",
     "blockers": [],
-    "nextAction": "None — entry complete. Optional follow-on directions tracked in nextSteps (CCC typeclass lift, characterization of admissible setoids).",
+    "nextAction": "S3+: pursue OQ-04-OQ-01-OQ-02 (characterization of admissible setoids) by exploring the converse direction — when does refinement-descent's converse hold? E.g., are there structural setoid invariants (e.g., quotient cardinality |Y/≈| ≤ 1, or additivity in the lattice) that classify exactly when CodesEndomorphismsSetoid Y s is inhabited?",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Lawvere FPT proved for Setoids. CantorDiagonalizationOQ04OQ01.lean has 8 theorems, 3 definitions, 0 sorries, 0 axioms (166 lines). Gallery status=verified, badge=original; merged in PR #16393. The diagonal construction g(y) = f(decode(y)(y)) carries over from the Type-level proof; the retraction condition only needs to hold up to setoid equivalence (decode(encode(f))(y) ≈ f(y)).",
+    "progressSummary": "S2 (researcher-3, 2026-05-08, ACT): rounded out the success side of the Lawvere-setoid spectrum. trivialSetoid (collapses Y to one class, ≈ ≡ True) admits coding vacuously for any inhabited Y (trivial_setoid_codes_endomorphisms); the explicit Bool corollary bool_trivial_setoid_codes_endomorphisms contrasts with the discrete-setoid impossibility from S1. The structural lemma coding_descends_to_coarser (built on IsRefinement s t : Prop) shows that coding-existence is downward-closed on the refinement lattice — coarser setoids inherit coding from finer ones. refines_trivial places the trivial setoid at the top. CantorDiagonalizationOQ04OQ01.lean: 166→221 lines, 8→12 theorems, 3→5 definitions, 0 sorries, 0 axioms unchanged. Status remains verified/original.\n\nS1 (2026-05-07, COMPLETED): proved Lawvere FPT for Setoids. 8 theorems, 3 definitions, 0 sorries, 0 axioms in CantorDiagonalizationOQ04OQ01.lean (166 lines). Gallery status=verified, badge=original; merged in PR #16393.",
     "builtItems": [
       "CodesEndomorphismsSetoid structure (encode, decode, setoid retraction)",
       "lawvere_fixpoint_setoid: main theorem in CantorDiagonalizationOQ04OQ01.lean",
@@ -44,19 +44,31 @@
       "cannot_code_endomorphisms_bool_setoid: Bool impossibility",
       "cannot_code_endomorphisms_nat_parity: \u2115/parity impossibility",
       "cantor_setoid_no_surjection: Cantor diagonal in setoid setting",
-      "paritySetoidN: concrete non-trivial setoid example"
+      "paritySetoidN: concrete non-trivial setoid example",
+      "S2 (researcher-3, 2026-05-08): trivialSetoid Y — every pair equivalent (one-class collapse)",
+      "S2 (researcher-3, 2026-05-08): trivial_setoid_codes_endomorphisms — every inhabited Y codes vacuously under trivial setoid",
+      "S2 (researcher-3, 2026-05-08): bool_trivial_setoid_codes_endomorphisms — Bool succeeds under trivial (vs. discrete failure in S1)",
+      "S2 (researcher-3, 2026-05-08): IsRefinement s t — definition of setoid refinement (s.r implies t.r)",
+      "S2 (researcher-3, 2026-05-08): coding_descends_to_coarser — coding-existence is monotone-downward in the refinement lattice",
+      "S2 (researcher-3, 2026-05-08): refines_trivial — trivial setoid is the canonical top of the refinement order"
     ],
     "insights": [
       "The diagonal construction g(y) = f(decode(y)(y)) works unchanged in the setoid setting",
       "f need NOT be a setoid morphism \u2014 fixed point exists for all f : Y \u2192 Y",
       "Discrete setoid recovers the Type-level theorem exactly (type reduction to special case)",
       "Setoid framework models CCC equality-up-to-isomorphism within Lean type theory",
-      "Retraction condition decode(encode(g))(y) \u2248 g(y) (pointwise setoid) is the correct weakening"
+      "Retraction condition decode(encode(g))(y) \u2248 g(y) (pointwise setoid) is the correct weakening",
+      "S2 \u2014 the trivial (one-class) setoid always admits coding vacuously: choose any constant encode and id-decode; \u2248 \u2261 True absorbs the retract. So Bool *can* code its endomorphisms \u2014 it just depends on the setoid choice.",
+      "S2 \u2014 coding-existence is monotone-DOWNWARD in the refinement lattice on Setoid Y: finer setoid admits coding \u21d2 every coarser one does too (same encode/decode, weaker retract). So discrete-setoid coding is the strongest form, trivial-setoid coding the weakest.",
+      "S2 \u2014 the discrete and trivial setoids bracket the full coding spectrum: between them lie the interesting setoids (parity, congruence classes, isomorphism-up-to-coherence) where coding-feasibility carries genuine information.",
+      "S2 \u2014 counterexample direction: knowing Bool cannot code under discrete (S1) does *not* preclude coding under coarser setoids. Conversely, knowing Bool codes under trivial (S2) does *not* lift to finer setoids. The refinement structure is the right organizing principle for OQ-04-OQ-01-OQ-02 (characterization)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Lift to Mathlib CartesianClosed typeclass: formalize in abstract CCC with terminal object",
-      "Characterize which setoids Y admit CodesEndomorphismsSetoid structures"
+      "Characterize which setoids Y admit CodesEndomorphismsSetoid structures (OQ-04-OQ-01-OQ-02): the refinement lattice provides the structural backbone \u2014 admissible setoids form a downward-closed subset. Open: is the boundary characterized by a quotient-cardinality condition |Y/\u2248| \u2264 1, by an algebraic invariant of the relation, or by a Lawvere-style fixed-point criterion?",
+      "Bracket the spectrum on \u2115: parity (mod 2) fails, mod-k for k\u22652 fails (extend succ_no_parity_fixpoint), but trivial succeeds. Find the finest setoid on \u2115 admitting coding.",
+      "Pursue the converse of coding_descends_to_coarser: when does coding under coarser t lift to coding under finer s? Likely never in full generality, but specific algebraic conditions on the refinement could give partial converses."
     ]
   },
   "tags": [
@@ -92,7 +104,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T14:45:58.508Z",
-  "lastUpdate": "2026-05-07T17:00:00Z",
+  "lastUpdate": "2026-05-08T08:30:00Z",
   "significance": 5,
   "tractability": 4,
   "leanFiles": [
@@ -297,10 +309,10 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ04OQ01.lean",
       "filename": "CantorDiagonalizationOQ04OQ01.lean",
-      "lineCount": 167,
-      "theoremCount": 8,
+      "lineCount": 221,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 3,
+      "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean"


### PR DESCRIPTION
## Summary

Session 2 rounding-out of the Lawvere FPT for Setoids in `proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean`. S1 (PR #16393) established the failure side (Bool/discrete-setoid impossibility, ℕ-mod-parity impossibility, Cantor diagonal); S2 establishes the **success side** and the **refinement structure** that organizes both.

**File: 166 → 221 lines, 8 → 12 theorems, 3 → 5 definitions, 0 sorries unchanged, 0 axioms unchanged.** Status remains `verified` / `original`.

### Part VIII — Trivial setoid (success side)

```lean
def trivialSetoid (Y : Type*) : Setoid Y where
  r := fun _ _ => True
  iseqv := ⟨fun _ => trivial, fun _ => trivial, fun _ _ => trivial⟩

theorem trivial_setoid_codes_endomorphisms (Y : Type*) [Inhabited Y] :
    CodesEndomorphismsSetoid Y (trivialSetoid Y) where
  encode := fun _ => default
  decode := fun _ => id
  retract := fun _ _ => trivial

theorem bool_trivial_setoid_codes_endomorphisms :
    CodesEndomorphismsSetoid Bool (trivialSetoid Bool) :=
  trivial_setoid_codes_endomorphisms Bool
```

The pair `bool_trivial_setoid_codes_endomorphisms` ↔ `cannot_code_endomorphisms_bool_setoid` (S1) shows directly that **coding-feasibility is genuinely setoid-dependent**, not a fixed property of the underlying type.

### Part IX — Refinement-descent

```lean
def IsRefinement {Y : Type*} (s t : Setoid Y) : Prop :=
  ∀ a b : Y, s.r a b → t.r a b

theorem coding_descends_to_coarser {Y : Type*} {s t : Setoid Y}
    (hst : IsRefinement s t) (c : CodesEndomorphismsSetoid Y s) :
    CodesEndomorphismsSetoid Y t where
  encode := c.encode
  decode := c.decode
  retract := fun g y => hst _ _ (c.retract g y)

theorem refines_trivial {Y : Type*} (s : Setoid Y) : IsRefinement s (trivialSetoid Y) :=
  fun _ _ _ => trivial
```

`coding_descends_to_coarser` shows coding-existence is **monotone-downward** in the refinement lattice on `Setoid Y`: finer admits coding ⇒ coarser does too. `refines_trivial` places the trivial setoid at the canonical top of that lattice. Together with the discrete setoid (canonical bottom, `discreteSetoid` from S1), they bracket the full coding spectrum.

## Why this is real progress (and the limit thereof)

- **Establishes the success side**: S1 had three failure witnesses (Bool/discrete, ℕ/parity, Cantor). The trivial-setoid result is the canonical success witness — every inhabited type codes vacuously under the one-class setoid.
- **Sets up OQ-04-OQ-01-OQ-02 (characterization)**: the refinement-descent lemma is the structural backbone for a future characterization of admissible setoids — they form a downward-closed subset of the refinement lattice on `Setoid Y`. The boundary is open (cardinality? algebraic? Lawvere-style?).
- **No axiom/sorry delta**: this is a structural rounding-out, not Phase-3 work. Status remains `verified` / `original`.
- **Honesty**: the four new theorems are all 1-2 line proofs. The trivial-setoid case is genuinely vacuous (the retract holds because `True` is always provable). The refinement-descent lemma is essentially function composition. This is solid structural setup, not a deep result.

## Build status: pending

The worktree's `proofs/.lake` is the recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`), forcing every Docker build to fresh-clone Mathlib (~10–15 min) + cache get (~10 min) — total ~45 min. Following the established convention from PRs #16936 (cantor-OQ-01-OQ-01-OQ-02-OQ-01 S5) and #17008 (ehrhart-cube-proven-oq-02 S4), this PR is opened as **draft**.

The new theorems use only basic Mathlib primitives already exercised in this file:
- `Setoid` constructor with `Equivalence` proof from anonymous tuple
- `default` (from `Inhabited`), `id`, `trivial`
- Anonymous constructor of `CodesEndomorphismsSetoid` records using fields

Risk of build failure is low; review of the proof bodies should be straightforward by inspection.

## Files Modified

- `proofs/Proofs/CantorDiagonalizationOQ04OQ01.lean` (+55 lines: 2 defs + 4 theorems + 2 section dividers + module-header `Key Results` list extended)
- `src/data/proofs/cantor-diagonalization-oq-04-oq-01/meta.json` (lineCount 166→221, theoremCount 8→12, definitionCount 3→5 in both `meta` and `leanFile` blocks; +4 originalContributions; +2 sections for Parts VIII/IX; conclusion summary updated)
- `src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json` (phase COMPLETED→ACT, status completed→active, iteration 1→2; +6 builtItems, +4 insights, +3 nextSteps; lastUpdate; leanFiles entry)
- `research/problems/cantor-diagonalization-oq-04-oq-01/knowledge.md` (Session 2 narrative)

## Test plan

- [ ] Re-run `./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ04OQ01` from a worktree with warm Mathlib cache
- [ ] Confirm `trivialSetoid`, `trivial_setoid_codes_endomorphisms`, `bool_trivial_setoid_codes_endomorphisms`, `IsRefinement`, `coding_descends_to_coarser`, `refines_trivial` type-check
- [ ] `pnpm build` for gallery integration

## Related

- Session 1 (PR #16393): initial Lawvere FPT for Setoids — 8 theorems, 3 definitions, 0 sorries/axioms
- Parent: `cantor-diagonalization-oq-04` (Type-level retraction version of Lawvere FPT)
- Sibling: `cantor-diagonalization-oq-03` (surjection version, candidate for parallel setoid generalization)
- Open follow-up: `cantor-diagonalization-oq-04-oq-01-oq-02` (characterization of admissible setoids — S2 lays the structural backbone)

🤖 Generated by researcher-3