### PR TITLE
research(e-transcendental-oq-02): S10 — Layer 3a (ℝ→ℤ cast bridge)

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -322,17 +322,44 @@ private lemma ratResidue_eventually_periodic (b : ℕ) (q : ℚ) (hq : 0 < q.den
     simp only [ratResidue_eq_iterate]
     exact hper n hn
 
+/-! ### Layer 3a: floor of `b^n · (p/q)` reduces to integer division
+
+Layer 3 — the residue-bridge for `nthDigit b n (p/q)` — factors into two
+parts. Part (a), implemented here, discharges the `ℝ → ℤ` cast burden:
+for `p : ℤ` and `q : ℕ`, the floor of `b^n · (p/q)` taken in `ℝ` is just
+the integer Euclidean quotient `(b^n · p) / q`. Part (b), deferred,
+relates this quotient to the residue `(b^n · p) mod q` in the `% b` form
+needed by `nthDigit`. Splitting (a) out of (b) keeps the residue algebra
+a pure-integer-arithmetic exercise, free of `Real`-side floor lemmas.
+-/
+
+/-- Floor of `b^n · (p / q)` (real-valued division) equals `(b^n · p) / q`
+    (integer Euclidean division). For `q = 0` both sides reduce to 0 by
+    Lean's division convention (`x / 0 = 0`). The proof reduces to
+    `Int.floor_div_natCast` after rewriting the real expression as a
+    single `ℤ`-cast over a `ℕ`-divisor. -/
+private lemma floor_pow_mul_div (b : ℕ) (p : ℤ) (q : ℕ) (n : ℕ) :
+    ⌊(b : ℝ) ^ n * ((p : ℝ) / (q : ℝ))⌋ = ((b : ℤ) ^ n * p) / q := by
+  have hcast : (b : ℝ) ^ n * ((p : ℝ) / (q : ℝ)) =
+      (((b : ℤ) ^ n * p : ℤ) : ℝ) / (q : ℝ) := by
+    push_cast
+    ring
+  rw [hcast, Int.floor_div_natCast, Int.floor_intCast]
+
 /-- **Axiom**: Rational numbers have eventually periodic base-b expansions.
     Proof sketch: if x = p/q, then bⁿ·(p/q) mod 1 = (bⁿ·p mod q)/q, and
     bⁿ mod q is periodic (pigeonhole on {0,...,q-1}).
     The period T divides φ(q) ≤ q.
 
     Recipe-status (Session 3 #16976; Layer 1 added Session 8; Layer 2 added
-    Session 9): the orbit-form pigeonhole `eventually_periodic_iterate` plus
-    the residue bridge `ratResidue_eventually_periodic` together give the
-    abstract eventual-periodicity ingredient — the residue sequence
-    `q.num · bⁿ mod q.den` is now formally periodic for every `q : ℚ` with
-    `q.den > 0`. Layer 3 (`nthDigit_rat_eq_residue` cast bridge) remains. -/
+    Session 9; Layer 3a added Session 10): the orbit-form pigeonhole
+    `eventually_periodic_iterate` plus the residue bridge
+    `ratResidue_eventually_periodic` give the abstract eventual-periodicity
+    ingredient — the residue sequence `q.num · bⁿ mod q.den` is now formally
+    periodic for every `q : ℚ` with `q.den > 0`. Layer 3a
+    (`floor_pow_mul_div`) discharges the `ℝ → ℤ` cast burden, leaving
+    Layer 3b — the integer-arithmetic residue-bridge — as the only piece
+    between this axiom and a discharged theorem. -/
 axiom rational_digits_eventually_periodic (b : ℕ) (hb : 2 ≤ b) (q : ℚ) :
     ∃ (T : ℕ) (N₀ : ℕ), 0 < T ∧ ∀ n ≥ N₀, nthDigit b (n + T) q = nthDigit b n q
 

--- a/research/problems/e-transcendental-oq-02/knowledge.md
+++ b/research/problems/e-transcendental-oq-02/knowledge.md
@@ -455,3 +455,150 @@ sketch in §"Layer 3" of this knowledge file).
 
 No axiom-count changes; the axiom remains as a placeholder until Layer 3
 is in.
+
+---
+
+## Session 2026-05-08 (Session 10, researcher-11) — Layer 3 split + Layer 3a closed
+
+**Mode**: ACT
+**Outcome**: Split Layer 3 (the residue-bridge for `nthDigit b n (p/q)`) into
+two parts and implemented part (a) — the `ℝ → ℤ` cast bridge — as a single
+private lemma in `proofs/Proofs/ETranscendentalOQ02.lean`:
+
+```lean
+private lemma floor_pow_mul_div (b : ℕ) (p : ℤ) (q : ℕ) (n : ℕ) :
+    ⌊(b : ℝ) ^ n * ((p : ℝ) / (q : ℝ))⌋ = ((b : ℤ) ^ n * p) / q := by
+  have hcast : (b : ℝ) ^ n * ((p : ℝ) / (q : ℝ)) =
+      (((b : ℤ) ^ n * p : ℤ) : ℝ) / (q : ℝ) := by
+    push_cast
+    ring
+  rw [hcast, Int.floor_div_natCast, Int.floor_intCast]
+```
+
+### Why split Layer 3 (a) and (b)
+
+The original Session 3 recipe estimated Layer 3 at 50–80 lines because it
+bundled three orthogonal concerns:
+
+1. The `ℝ → ℤ` cast burden for `⌊b^n · (p / q : ℝ)⌋`.
+2. The integer-arithmetic identity that turns `(b^n · p) / q` (Euclidean
+   quotient) into `(b · ((b^n · p) mod q)) / q` (residue form).
+3. Sign-handling for negative `p`.
+
+These concerns interact poorly in a single proof: the cast machinery
+(`push_cast`, `field_simp`, `Int.floor_eq_iff`) shares simp sets with the
+integer-arithmetic algebra (`Int.ediv_add_emod`, `Int.emod_lt_of_pos`),
+making large bundled goals fragile. Splitting (a) out as a standalone
+lemma:
+
+- Keeps the Real-side proof tiny (3 lines: `push_cast` + `ring` + two
+  `rw`s).
+- Lets Layer 3b operate purely in `ℤ`, reusing `Int.ediv` /
+  `Int.emod` lemmas without any `Nat.cast`/`Int.cast` interference.
+- Gives a reusable Mathlib-style helper: `floor_pow_mul_div` is exactly
+  the statement a future Mathlib contribution would expose for
+  base-`b` digit extraction from rationals.
+
+### Mathlib v4.26.0 lemmas used
+
+Confirmed via `gh api repos/leanprover-community/mathlib4/contents/Mathlib/Algebra/Order/Floor/Ring.lean` at the `v4.26.0` ref:
+
+| Lemma | Statement |
+|-------|-----------|
+| `Int.floor_intCast` | `⌊(z : R)⌋ = z` for `z : ℤ` |
+| `Int.floor_div_natCast` | `⌊a / n⌋ = ⌊a⌋ / n` for `a : k`, `n : ℕ` |
+
+Both are `@[simp]` and live in `namespace Int` `section floor` (resp.
+`section LinearOrderedField`). The `Int.floor_div_natCast` proof itself
+specializes `Int.floor_div_cast_of_nonneg` to `n.cast_nonneg`; we use
+the natural-number version for cleaner unification with our `q : ℕ`.
+
+### Proof anatomy
+
+```lean
+have hcast : (b : ℝ)^n * ((p : ℝ) / (q : ℝ)) = (((b : ℤ)^n * p : ℤ) : ℝ) / (q : ℝ)
+```
+
+`push_cast` pulls the `(b : ℕ)` and `(p : ℤ)` casts to the outermost
+position and normalizes `((b : ℤ)^n : ℝ) = (b : ℝ)^n`. After that, the
+identity `a * (b/c) = (a*b)/c` is a ring identity in any field — `ring`
+handles it (Lean 4 Mathlib's `ring` operates on `Field` and treats
+division as multiplication by inverse).
+
+After `rw [hcast]`, the goal is `⌊((... : ℤ) : ℝ) / (q : ℝ)⌋ = ((... : ℤ)) / q`.
+
+`Int.floor_div_natCast` rewrites `⌊a / n⌋ → ⌊a⌋ / n` (a real-side
+division becomes ℤ-side division), reducing to
+`⌊((... : ℤ) : ℝ)⌋ / q = (...) / q`.
+
+`Int.floor_intCast` rewrites `⌊(z : ℝ)⌋ → z`, leaving the goal as
+`(... : ℤ) / q = (... : ℤ) / q`. `rfl` (closed by `rw` automatically).
+
+### Why no `hq : 0 < q` hypothesis
+
+The lemma works for `q = 0`: on the `ℝ` side, `(p : ℝ) / 0 = 0`, so
+`⌊b^n · 0⌋ = 0`; on the `ℤ` side, `(b^n · p) / 0 = 0` per Lean's
+integer-division convention. Both equal 0. Dropping `hq` makes the
+lemma maximally usable downstream (Layer 3b can pattern-match without
+managing positivity in the low-level cast bridge).
+
+### What Layer 3b will need
+
+The remaining piece, deferred to S11:
+
+```lean
+private lemma nthDigit_rat_eq_residue (b : ℕ) (hb : 2 ≤ b)
+    (p : ℤ) (q : ℕ) (hq : 0 < q) (n : ℕ) :
+    nthDigit b n ((p : ℝ) / (q : ℝ)) =
+      ((b : ℤ) * ((p * (b : ℤ)^n) % (q : ℤ))) / (q : ℤ)
+```
+
+(Or with a `% (b : ℤ)` postfix if needed for compatibility with
+`nthDigit`'s definition.) Proof skeleton:
+
+1. Unfold `nthDigit`: `⌊(b : ℝ)^n * ((p : ℝ) / (q : ℝ))⌋ % (b : ℤ)`.
+2. Apply `floor_pow_mul_div` (S10): turn the floor into
+   `((b : ℤ)^n * p) / (q : ℤ)`.
+3. Now in pure ℤ, derive the residue form via:
+   - `Int.ediv_add_emod : (a / b) * b + (a % b) = a` (write
+     `(b^n · p) = q · k + r` where `k = quotient`,
+     `r = (b^n · p) % q`).
+   - `(q · k + r) / q = k` when `0 ≤ r < q` (covered by
+     `Int.add_mul_ediv_left` or `Int.add_ediv_of_le` style).
+   - Finish with `(k · b) / q` reduction (use `Int.mul_ediv` patterns).
+
+Sign-handling for `p < 0`: in Mathlib, `Int.emod` with positive divisor
+returns a result in `[0, |q|)` regardless of the sign of the dividend,
+so the formula `(b · ((p · b^n) % q)) / q` is well-defined and matches
+the "correct" digit extraction for both signs of `p`. (The proof
+obligation shifts from sign-handling to checking that the identity
+holds uniformly.)
+
+Estimated effort for Layer 3b: 30–50 lines, pure ℤ arithmetic.
+
+### Build status
+
+Build verification deferred to CI per S8/S9 convention on this slug
+(broken `proofs/.lake` self-symlink forces 45+ min cold-clone of
+Mathlib for every Docker build attempt; not feasible mid-session).
+The proof uses only `push_cast`, `ring`, and two `@[simp]`-tagged
+Mathlib v4.26.0 lemmas (verified by name and signature against the
+v4.26.0 tag), so the build risk is contained.
+
+### Lines & decl deltas
+
+- `proofs/Proofs/ETranscendentalOQ02.lean`: +27 lines (427 → 454).
+  Adds 1 private lemma + 1 docstring section + minor expansion of
+  axiom docstring referring to S10.
+- `meta.json`: `lineCount` 300 → 454 (was severely stale —
+  unrelated to S10's add; the previous lineCount predates S8 Layer 1).
+- No theorem/axiom count changes.
+
+### Files Modified (Session 10, researcher-11)
+
+- `proofs/Proofs/ETranscendentalOQ02.lean` (Layer 3a + axiom docstring)
+- `research/problems/e-transcendental-oq-02/state.md` (S10 entry)
+- `research/problems/e-transcendental-oq-02/knowledge.md` (this entry)
+- `src/data/proofs/e-transcendental-oq-02/meta.json` (lineCount sync)
+- `src/data/research/problems/e-transcendental-oq-02.json` (insights,
+  builtItems, nextSteps)

--- a/research/problems/e-transcendental-oq-02/state.md
+++ b/research/problems/e-transcendental-oq-02/state.md
@@ -2,103 +2,120 @@
 
 **Phase**: ACT — gallery entry built; 2 axioms tractable, 1 is the main open conjecture
 **Since**: 2026-05-04T16:38:18.044Z
-**Last Updated**: 2026-05-08 (Session 9, researcher-9)
-**Iteration**: 9
+**Last Updated**: 2026-05-08 (Session 10, researcher-11)
+**Iteration**: 10
 
 ## Current Focus
 
-Session 9 implemented **Layer 2** of the 3-layer recipe for
-`rational_digits_eventually_periodic`, building directly on the Layer 1
-helpers added in Session 8 (PR #16993). Four new private declarations
-were added to `proofs/Proofs/ETranscendentalOQ02.lean`:
+Session 10 split **Layer 3** of the 3-layer recipe for
+`rational_digits_eventually_periodic` into two parts and implemented
+**Layer 3a** — the `ℝ → ℤ` cast bridge — as a single private helper:
 
-* `ratResidue (b q n)` — the residue sequence `q.num · bⁿ mod q.den`.
-* `ratResidue_succ` — one-step recurrence `r(n+1) = b · r(n)`.
-* `ratResidue_eq_iterate` — bridge to `(· * (b : ZMod q.den))^[n]`.
-* `ratResidue_eventually_periodic` — eventual periodicity (`T, N₀ ≤ q.den`)
-  by composing Layer 1's `eventually_periodic_iterate` with the bridge.
+```lean
+private lemma floor_pow_mul_div (b : ℕ) (p : ℤ) (q : ℕ) (n : ℕ) :
+    ⌊(b : ℝ) ^ n * ((p : ℝ) / (q : ℝ))⌋ = ((b : ℤ) ^ n * p) / q
+```
 
-Layer 3 (`nthDigit_rat_eq_residue` cast bridge) is the only remaining
-piece before the axiom can be discharged.
+The proof is two lines: `push_cast` + `ring` rewrites the `ℝ` expression
+as a single `ℤ`-cast over a `ℕ`-divisor, then `Int.floor_div_natCast` +
+`Int.floor_intCast` discharge the floor. This isolates the cast burden
+of the residue bridge `nthDigit_rat_eq_residue` from the integer-arithmetic
+`(b^n · p) / q ↔ (b^n · p mod q) · b / q` algebra of Layer 3b.
 
-Earlier session context (Session 3 produced the recipe):
-- Surveys Mathlib 4.26 API for "fintype ⇒ eventually periodic" (named lemma is
-  missing; must be assembled from `Fintype.exists_ne_map_eq_of_card_lt` +
-  iterated `Function.iterate_add_apply`).
-- Corrects a subtle error in the naive pigeonhole approach (bare pigeonhole
-  gives `f(i)=f(j)` but NOT `f(i+k)=f(j+k)`; the iterate form
-  `g^[i] x₀ = g^[j] x₀` ⇒ `g^[i+k] x₀ = g^[j+k] x₀` is what's actually needed).
-- Decomposes the proof into 3 independently-buildable layers totaling ~150–200
-  lines:
-  - Layer 1 (~30–40 lines): `eventually_periodic_iterate` general lemma.
-  - Layer 2 (~30–50 lines): `ratResidue` definition + ZMod q bridge.
-  - Layer 3 (~50–80 lines): `nthDigit_rat_eq_residue` cast-bridge.
-- Identifies that `n ↦ b^n · p mod q` IS the orbit of `(· * b) : ZMod q → ZMod q`,
-  making the iterate-form pigeonhole the right abstraction (not the bare pigeonhole
-  that the original axiom docstring sketched).
+After Layer 3a is in place, **Layer 3b** is a pure-integer-arithmetic
+step (`Int.ediv_add_emod` + `Int.emod_lt_of_pos` style), free of any
+`Real`/`Rat` machinery. Estimated 30–50 lines for Layer 3b once the
+sign-handling for negative `p` is decomposed (recipe convention:
+restrict to `p ≥ 0, q > 0` first, then handle `p < 0` via
+`nthDigit b n (-x)` symmetry as a small follow-up).
 
-Session 3 made no `.lean` edits and did not run a Docker build — recipe-only
-deliverable, following the konigsberg-oq-01-oq-02 Session 7 precedent.
+Earlier session context:
+
+* Session 9 (researcher-9, PR #17016): Layer 2 — `ratResidue`,
+  `ratResidue_succ`, `ratResidue_eq_iterate`,
+  `ratResidue_eventually_periodic`.
+* Session 8 (researcher-11, PR #16993): Layer 1 —
+  `exists_iterate_collision`, `eventually_periodic_iterate`.
+* Session 3 (researcher-11, PR #16976): the 3-layer recipe.
 
 ## Active Approach
 
 The current Lean entry establishes the framework:
-- Definitions: `nthDigit`, `IsNormalInBase`, `IsAbsolutelyNormal`.
-- 28 theorems: includes `e_floor`, `e_floor_10..1000000000`, `e_digit1..9`
-  (proves first 9 decimal digits 2.718281828 from `Real.exp_one_gt_d9` /
+- Definitions: `nthDigit`, `IsNormalInBase`, `IsAbsolutelyNormal`,
+  `ratResidue` (private, S9).
+- 28 public theorems: `e_floor`, `e_floor_10..1000000000`, `e_digit1..9`
+  (first 9 decimal digits 2.718281828 from `Real.exp_one_gt_d9` /
   `Real.exp_one_lt_d9`), `e_normal_implies_uniform_decimal_digits`,
   `periodic_has_missing_ktuple` (orbit cardinality).
+- 6 private helpers (Layers 1, 2, 3a): `exists_iterate_collision`,
+  `eventually_periodic_iterate`, `ratResidue_succ`,
+  `ratResidue_eq_iterate`, `ratResidue_eventually_periodic`,
+  `floor_pow_mul_div`.
 
-Three remaining axioms (per `proofs/Proofs/ETranscendentalOQ02.lean`):
-- `rational_digits_eventually_periodic` (line 209) — tractable. **Session 3 (2026-05-08)**
-  produced a refined 3-layer recipe; see `knowledge.md`. Note: naive pigeonhole
-  alone gives `f(i)=f(j)` but NOT periodic propagation. Use the iterate form
-  `(· * b) : ZMod q.den → ZMod q.den` orbit pigeonhole instead.
-- `normal_imp_irrational` (line 261) — derives from axiom 1 +
-  `periodic_has_missing_ktuple` (already proved). Discharging axiom 1 first
-  then proving 2 is the natural sequence.
-- `e_absolutely_normal` (line 271) — the **main open conjecture**. Genuinely
+Three remaining axioms:
+- `rational_digits_eventually_periodic` — **tractable**. Layers 1, 2, 3a
+  in place; Layer 3b (residue → digit form) is the only piece remaining.
+- `normal_imp_irrational` — derives from axiom 1 +
+  `periodic_has_missing_ktuple`. Discharging axiom 1 first then proving 2
+  is the natural sequence.
+- `e_absolutely_normal` — the **main open conjecture**. Genuinely
   open as of 2026; will remain axiomatized.
 
 ## Blockers
 
-- **Local Lean build unreliable**: Worktree's `proofs/.lake` is a self-cycle
-  symlink, so my Docker build attempts hung on `mathlib: cloning` for 14+ min.
-  Closing axioms requires careful Mathlib API alignment that's risky without
-  fast feedback. Future iterations may need to copy file to main repo and
-  build there.
+- **Local Lean build unreliable**: Worktree's `proofs/.lake` is a
+  self-cycle symlink — Docker build cold-clones Mathlib (~45 min).
+  Following S8/S9 convention, build verification is deferred to CI.
+  Layer 3a uses well-established Mathlib v4.26.0 lemmas
+  (`Int.floor_div_natCast`, `Int.floor_intCast`, both confirmed via
+  `gh api repos/leanprover-community/mathlib4/contents/...`), so
+  the build risk is contained to the `push_cast` + `ring` step which
+  uses only standard cast-pushing simp lemmas.
 
 ## Next Action
 
-**ACT (Session 10)** — implement Layer 3: the
-`nthDigit_rat_eq_residue` cast bridge. The recipe (knowledge.md
-"Layer 3") sketches it as ~50–80 lines, cast-juggling-heavy. Once
-Layer 3 is in, the axiom can be replaced by a theorem chaining Layers
-1, 2, 3.
+**ACT (Session 11)** — implement Layer 3b: the integer-arithmetic
+residue-to-digit bridge
 
-Layer 3 statement (paraphrased):
-```
-private lemma nthDigit_rat_eq_residue (b : ℕ) (hb : 2 ≤ b) (p : ℤ) (q : ℕ) (hq : 0 < q) :
-    ∀ n, nthDigit b n ((p : ℝ) / q) = ⌊((p * (b : ℤ)^n) % q : ℤ) * (b : ℝ) / q⌋ % b
+```lean
+private lemma nthDigit_rat_eq_residue (b : ℕ) (hb : 2 ≤ b)
+    (p : ℤ) (q : ℕ) (hq : 0 < q) (n : ℕ) :
+    nthDigit b n ((p : ℝ) / (q : ℝ)) =
+      (b * ((p * (b : ℤ)^n) % (q : ℤ))) / (q : ℤ)  -- conjectural form
 ```
 
-The hard part is the floor algebra (`⌊b^n · p/q⌋ % b` reformulated in terms of
-`(p · bⁿ) mod q`). Sign handling for negative `p` adds a wrinkle.
+(Note: the exact statement may need sign-restriction; the natural
+single-step version factors via Layer 3a as
+
+```
+nthDigit b n ((p : ℝ) / q) = (((b : ℤ)^n * p) / q) % (b : ℤ)
+                          = ⟨residue-bridge in ℤ⟩
+```
+
+where the second `=` is what Layer 3b proves.)
+
+Estimated ~30–50 lines. With Layer 3a's `floor_pow_mul_div` as starting
+point, the proof reduces to integer division/modular arithmetic
+(`Int.ediv_add_emod` patterns), bypassing any further `Real` machinery.
+
+After Layer 3b lands, the axiom `rational_digits_eventually_periodic`
+can be replaced by a theorem chaining Layers 1, 2, 3a, 3b — and then
+`normal_imp_irrational` becomes tractable as a follow-up.
 
 ## Attempt Counts
 
-- Total attempts: 4 (Session 1 = entry built 2026-05-04; Session 2 =
+- Total attempts: 5 (Session 1 = entry built 2026-05-04; Session 2 =
   metadata reconciliation 2026-05-07; Session 3 = recipe (2026-05-08);
   Session 8 = Layer 1 (#16993, 2026-05-08); Session 9 = Layer 2
-  (researcher-9, 2026-05-08)).
-- Current approach attempts: 2 (Layer 1 closed; Layer 2 closed)
-- Approaches tried: 0 for the rational-digits axiom; 1 successful approach
-  for `periodic_has_missing_ktuple` (orbit cardinality, archived in
-  `knowledge.md`).
+  (researcher-9, #17016, 2026-05-08); Session 10 = Layer 3a
+  (researcher-11, 2026-05-08)).
+- Current approach attempts: 3 (Layers 1, 2, 3a all closed; Layer 3b
+  remains).
 
 ## References
 
-- `proofs/Proofs/ETranscendentalOQ02.lean:209` — `rational_digits_eventually_periodic`
-- `proofs/Proofs/ETranscendentalOQ02.lean:261` — `normal_imp_irrational`
-- `proofs/Proofs/ETranscendentalOQ02.lean:271` — `e_absolutely_normal`
-- `src/data/proofs/e-transcendental-oq-02/meta.json` — gallery metadata (correct as of 2026-05-04)
+- `proofs/Proofs/ETranscendentalOQ02.lean:336` — `rational_digits_eventually_periodic` (axiom)
+- `proofs/Proofs/ETranscendentalOQ02.lean:325` — `floor_pow_mul_div` (Layer 3a, S10)
+- `proofs/Proofs/ETranscendentalOQ02.lean:308` — `ratResidue_eventually_periodic` (Layer 2, S9)
+- `proofs/Proofs/ETranscendentalOQ02.lean:243` — `eventually_periodic_iterate` (Layer 1, S8)
+- `src/data/proofs/e-transcendental-oq-02/meta.json` — gallery metadata

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 3,
-    "lineCount": 300,
+    "lineCount": 454,
     "assumptions": "3 axioms: (1) rational_digits_eventually_periodic — rationals have eventually periodic base-b digit expansions (pigeonhole principle, period T | φ(q)); (2) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (uses axiom 1 + periodic_has_missing_ktuple + Tendsto formalism); (3) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026). periodic_has_missing_ktuple is now a proved theorem (orbit cardinality argument). 28 theorems including first 9 decimal digits of e proved from exp_one bounds.",
     "mathlib_version": "4.26.0",
     "definitionCount": 3
@@ -169,7 +169,7 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 300,
+    "lineCount": 454,
     "axiomCount": 3,
     "theoremCount": 28,
     "definitionCount": 3,

--- a/src/data/research/problems/e-transcendental-oq-02.json
+++ b/src/data/research/problems/e-transcendental-oq-02.json
@@ -32,28 +32,31 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-04T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "Recipe-only progress (Session 3, researcher-11, 2026-05-08): refined 3-layer recipe in knowledge.md for discharging the next tractable axiom (rational_digits_eventually_periodic). Mathlib gap survey + iterate-form pigeonhole abstraction selected over naive collision pigeonhole.",
+    "iteration": 10,
+    "focus": "Layer 3a closed (Session 10, researcher-11, 2026-05-08). Implemented `floor_pow_mul_div : ⌊(b : ℝ)^n * ((p : ℝ) / (q : ℝ))⌋ = ((b : ℤ)^n * p) / q` — the ℝ→ℤ cast bridge for the residue-bridge of `nthDigit b n (p/q)`. Layer 3 was split into 3a (cast bridge, S10) and 3b (integer-arithmetic residue identity, deferred). With Layers 1, 2, 3a in place, only Layer 3b stands between the axiom and a discharged theorem.",
     "blockers": [
-      "No named Mathlib lemma 'eventually_periodic_of_fintype'; must assemble from Fintype.exists_ne_map_eq_of_card_lt + Function.iterate_add_apply.",
-      "No Mathlib bridge connecting nthDigit b n (p/q : ℝ) to the (p · b^n) mod q residue sequence — must write manually (cast-juggling-heavy)."
+      "Layer 3b residue-bridge `nthDigit_rat_eq_residue` is the only remaining piece for axiom 1; estimated 30–50 lines pure ℤ arithmetic.",
+      "Local Docker build deferred to CI on this slug (broken `proofs/.lake` self-symlink forces 45+ min cold-clone of Mathlib)."
     ],
-    "nextAction": "Apply Session 3 recipe Layer 1: prove eventually_periodic_iterate (~30-40 lines, fully self-contained orbit-pigeonhole lemma). Layer 2 (ratResidue ZMod bridge) and Layer 3 (nthDigit cast bridge) are sketched but deferred to follow-up sessions.",
+    "nextAction": "Apply Session 10 recipe-extension Layer 3b: prove `nthDigit_rat_eq_residue : nthDigit b n ((p : ℝ) / q) = ((b : ℤ) * ((p * (b : ℤ)^n) % q)) / q`. With `floor_pow_mul_div` (Layer 3a) as the entry point, the proof is pure ℤ arithmetic via `Int.ediv_add_emod` patterns.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 1,
+      "total": 6,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (Session 3, 2026-05-08): Gallery entry ETranscendentalOQ02.lean (origin/main: 300 lines, 0 sorries, 3 axioms, 28 theorems, 3 defs). PRs #15637 (digits 7→9) and #15750 (periodic_has_missing_ktuple proved, axioms 4→3) closed previous progress. Session 3 produced a 3-layer recipe in knowledge.md for the next axiom-elimination target rational_digits_eventually_periodic, identifying the iterate-form pigeonhole as the right abstraction (correcting the naive bare-pigeonhole approach the original axiom docstring sketched). Remaining axioms: rational_digits_eventually_periodic (tractable, Layer 1-3 recipe ready), normal_imp_irrational (tractable, derives from axiom 1), e_absolutely_normal (the genuinely open conjecture — will stay axiomatized).",
+    "progressSummary": "ACT (Session 10, 2026-05-08): Gallery entry ETranscendentalOQ02.lean (origin/main: 454 lines, 0 sorries, 3 axioms, 28 public theorems + 6 private helpers, 4 defs). Sessions 8 (#16993, Layer 1: orbit pigeonhole `eventually_periodic_iterate`), 9 (#17016, Layer 2: ratResidue ZMod bridge `ratResidue_eventually_periodic`), and 10 (Layer 3a: cast bridge `floor_pow_mul_div`) have built the full machinery for axiom 1 except the integer-arithmetic residue identity (Layer 3b). Layer 3 was split S10 to isolate the ℝ→ℤ cast burden from the integer-arithmetic algebra, making Layer 3b a pure-ℤ exercise. Remaining axioms: rational_digits_eventually_periodic (Layer 3b only, tractable next session), normal_imp_irrational (tractable, derives from axiom 1 once discharged), e_absolutely_normal (the genuinely open conjecture — will stay axiomatized).",
     "builtItems": [
       "ETranscendentalOQ02.lean: nthDigit, IsNormalInBase, IsAbsolutelyNormal definitions",
       "ETranscendentalOQ02.lean: e_floor=2, e_floor_10=27, e_floor_100=271, e_floor_1000=2718, e_floor_10000=27182, e_floor_100000=271828, e_floor_1000000=2718281 all proved",
       "ETranscendentalOQ02.lean: e_digit1..e_digit9 (digits 7,1,8,2,8,1,8,2,8) machine-checked from exp_one bounds",
       "ETranscendentalOQ02.lean: periodic_has_missing_ktuple PROVED (PR #15750) via orbit-cardinality argument — no longer an axiom",
       "ETranscendentalOQ02.lean: e_normal_implies_uniform_decimal_digits theorem proved",
-      "src/data/proofs/e-transcendental-oq-02/: full gallery entry with meta.json, annotations.json, index.ts"
+      "src/data/proofs/e-transcendental-oq-02/: full gallery entry with meta.json, annotations.json, index.ts",
+      "[S8 #16993] ETranscendentalOQ02.lean: Layer 1 — `exists_iterate_collision`, `eventually_periodic_iterate` (orbit-pigeonhole on Fintype, T ≤ card α)",
+      "[S9 #17016] ETranscendentalOQ02.lean: Layer 2 — `ratResidue` def + `ratResidue_succ`, `ratResidue_eq_iterate`, `ratResidue_eventually_periodic` (residue sequence in ZMod q.den, eventually periodic with T ≤ q.den)",
+      "[S10] ETranscendentalOQ02.lean: Layer 3a — `floor_pow_mul_div : ⌊(b : ℝ)^n * ((p : ℝ) / (q : ℝ))⌋ = ((b : ℤ)^n * p) / q` (ℝ→ℤ cast bridge, isolates cast burden from Layer 3b's integer-arithmetic residue identity)"
     ],
     "insights": [
       "Mathlib's exp_one_gt_d9 (e>2.718281828) and exp_one_lt_d9 (e<2.7182818286) suffice to pin all 9 decimal digits 2.718281828... (the 9th saturates the lower bound)",
@@ -64,7 +67,10 @@
       "The open conjecture e_absolutely_normal mirrors the pattern from e-transcendental-oq-01 (schanuel_conjecture axiom)",
       "[S3 2026-05-08] Naive Fintype.exists_ne_map_eq_of_card_lt gives only f(i)=f(j) — not the periodicity propagation f(i+k)=f(j+k) needed for eventual-periodicity. The right abstraction is the iterate form: g^[i] x₀ = g^[j] x₀ ⇒ g^[i+k] x₀ = g^[j+k] x₀ (via Function.iterate_add_apply + congr).",
       "[S3 2026-05-08] For x = p/q, the residue sequence n ↦ (q.num · b^n : ZMod q.den) IS the orbit of (· * b) : ZMod q.den → ZMod q.den. So the iterate-form pigeonhole applies directly with α = ZMod q.den.",
-      "[S3 2026-05-08] The 'cast hell' in this proof is concentrated in Layer 3 (nthDigit b n (p/q : ℝ) ↔ residue mod q · b / q expression). Layers 1 (general fintype iterate pigeonhole) and 2 (ratResidue ZMod bridge) are clean; isolating Layer 3 lets each cast obstacle be debugged in isolation."
+      "[S3 2026-05-08] The 'cast hell' in this proof is concentrated in Layer 3 (nthDigit b n (p/q : ℝ) ↔ residue mod q · b / q expression). Layers 1 (general fintype iterate pigeonhole) and 2 (ratResidue ZMod bridge) are clean; isolating Layer 3 lets each cast obstacle be debugged in isolation.",
+      "[S10 2026-05-08] Layer 3 cleanly splits into (3a) a pure ℝ→ℤ cast bridge `floor_pow_mul_div` and (3b) a pure-ℤ residue-arithmetic identity `nthDigit_rat_eq_residue`. The split keeps each part's proof small — Layer 3a is 3 lines of `push_cast` + `ring` + two `rw`s using `Int.floor_div_natCast` and `Int.floor_intCast`; Layer 3b can then operate entirely in ℤ via `Int.ediv_add_emod` patterns without any `Real`/`Rat` interference.",
+      "[S10 2026-05-08] `Int.floor_div_natCast (a : k) (n : ℕ) : ⌊a / n⌋ = ⌊a⌋ / n` is the right Mathlib v4.26.0 lemma (in `Mathlib.Algebra.Order.Floor.Ring`, `Int` namespace, `LinearOrderedField` section). It accepts `n : ℕ` directly, which avoids the `(q : ℤ)` vs `((q : ℕ) : ℤ)` cast mismatches that arise when stating the conclusion with an explicit ℤ-cast.",
+      "[S10 2026-05-08] `floor_pow_mul_div` does NOT need a `0 < q` hypothesis: when `q = 0`, both sides reduce to 0 by Lean's division convention (`x / 0 = 0`), so the equation holds vacuously. Dropping `hq` makes the lemma maximally usable downstream."
     ],
     "mathlibGaps": [
       "No Mathlib lemma connecting ℤ-valued digit functions to Fin b sequences in Tendsto framework — blocks full proof of normal_imp_irrational",
@@ -73,10 +79,10 @@
       "[S3 2026-05-08] No named lemma bridging ⌊b^n · (p/q)⌋ % b to (b^n · p mod q) digit-extraction. Must be written manually — combination of Int.emod, Int.floor, Rat.cast_div casts."
     ],
     "nextSteps": [
-      "[S3 priority] Apply recipe Layer 1: prove eventually_periodic_iterate (~30-40 lines) as a self-contained orbit-pigeonhole lemma. Most reusable artifact; clean Mathlib contribution candidate.",
-      "[S3 priority] After Layer 1: apply Layer 2 (ratResidue ZMod q.den bridge, ~30-50 lines).",
-      "[S3 priority] After Layer 2: apply Layer 3 (nthDigit cast-bridge, ~50-80 lines, the cast-juggling-heavy step).",
-      "After axiomCount 3 → 2: discharge normal_imp_irrational via axiom 1 (now theorem) + periodic_has_missing_ktuple (already theorem) + Tendsto-frequency-zero-vs-positive contradiction (~50 lines)."
+      "[S11 priority] Implement Layer 3b: `nthDigit_rat_eq_residue (b : ℕ) (hb : 2 ≤ b) (p : ℤ) (q : ℕ) (hq : 0 < q) (n : ℕ) : nthDigit b n ((p : ℝ) / (q : ℝ)) = ((b : ℤ) * ((p * (b : ℤ)^n) % (q : ℤ))) / (q : ℤ)`. Use `floor_pow_mul_div` (S10) as the entry point; the rest is pure ℤ arithmetic via Int.ediv_add_emod / Int.add_mul_ediv_left patterns. Estimated 30–50 lines.",
+      "[S12 priority] After Layer 3b: combine Layers 1, 2, 3a, 3b into a single theorem replacing `axiom rational_digits_eventually_periodic`. axiomCount 3 → 2.",
+      "[S13 priority] After axiomCount 3 → 2: discharge normal_imp_irrational via axiom 1 (now theorem) + periodic_has_missing_ktuple (already theorem) + Tendsto-frequency-zero-vs-positive contradiction (~50 lines).",
+      "[Mathlib contribution candidate] `eventually_periodic_iterate` (Layer 1) and `floor_pow_mul_div` (Layer 3a) are both standalone and could be upstreamed to Mathlib's `Mathlib.Logic.Function.Iterate` and `Mathlib.Algebra.Order.Floor.Ring` respectively."
     ]
   },
   "tags": [
@@ -108,7 +114,7 @@
     ]
   },
   "started": "2026-05-04T00:00:00.000Z",
-  "lastUpdate": "2026-05-07T19:00:00.000Z",
+  "lastUpdate": "2026-05-08T13:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -137,7 +143,7 @@
     {
       "path": "Proofs/ETranscendentalOQ02.lean",
       "filename": "ETranscendentalOQ02.lean",
-      "lineCount": 300,
+      "lineCount": 454,
       "theoremCount": 28,
       "axiomCount": 3,
       "defCount": 3,


### PR DESCRIPTION
## Summary

- Splits **Layer 3** of the `rational_digits_eventually_periodic` recipe into 3a (ℝ→ℤ cast bridge) + 3b (integer-arithmetic residue identity)
- Implements **Layer 3a** as a single private helper

```lean
private lemma floor_pow_mul_div (b : ℕ) (p : ℤ) (q : ℕ) (n : ℕ) :
    ⌊(b : ℝ) ^ n * ((p : ℝ) / (q : ℝ))⌋ = ((b : ℤ) ^ n * p) / q := by
  have hcast : (b : ℝ) ^ n * ((p : ℝ) / (q : ℝ)) =
      (((b : ℤ) ^ n * p : ℤ) : ℝ) / (q : ℝ) := by
    push_cast
    ring
  rw [hcast, Int.floor_div_natCast, Int.floor_intCast]
```

## Why split Layer 3?

Original recipe estimated Layer 3 at 50–80 lines because it bundled three orthogonal concerns: ℝ→ℤ cast, integer-arithmetic residue identity, and sign-handling. Splitting (a) out keeps the ℝ-side proof tiny (3 lines: `push_cast` + `ring` + two `rw`s) and lets Layer 3b operate purely in ℤ (via `Int.ediv_add_emod` patterns), free of any `Real`/`Rat` machinery.

`floor_pow_mul_div` is also a clean Mathlib contribution candidate — exactly the helper a future digit-extraction-from-rationals PR would expose.

## Mathlib v4.26.0 lemmas used

Verified via `gh api repos/leanprover-community/mathlib4/contents/Mathlib/Algebra/Order/Floor/Ring.lean?ref=v4.26.0`:

- `Int.floor_intCast (z : ℤ) : ⌊(z : R)⌋ = z` (`@[simp]`)
- `Int.floor_div_natCast (a : k) (n : ℕ) : ⌊a / n⌋ = ⌊a⌋ / n`

Both live in `namespace Int` in `Mathlib.Algebra.Order.Floor.Ring`.

## What remains for the axiom

After this PR, the layered build for `rational_digits_eventually_periodic` is:

| Layer | Status | PR | Statement |
|-------|--------|-----|-----------|
| 1 | ✓ | #16993 (S8) | `eventually_periodic_iterate` (orbit pigeonhole on Fintype) |
| 2 | ✓ | #17016 (S9) | `ratResidue` + `ratResidue_eventually_periodic` (residue sequence in ZMod q.den) |
| 3a | ✓ | this PR (S10) | `floor_pow_mul_div` (ℝ→ℤ cast bridge) |
| 3b | next | S11 | `nthDigit_rat_eq_residue` (integer-arithmetic residue identity) |

Estimated 30–50 lines for Layer 3b, pure ℤ arithmetic via `Int.ediv_add_emod` patterns. After 3b lands, the axiom becomes a theorem chaining 1+2+3a+3b. axiomCount 3 → 2.

## Build status

Build deferred to CI per S8/S9 convention on this slug (broken `proofs/.lake` self-symlink at `/Users/rwalters/GitHub/lean-genius/proofs/.lake -> proofs/.lake` forces every Docker build to fresh-clone Mathlib, ~45 min cold-cache).

The proof uses only `push_cast`, `ring`, and two `@[simp]`-tagged Mathlib v4.26.0 lemmas verified by name and signature against the `v4.26.0` tag, so the build risk is contained.

## Files

- `proofs/Proofs/ETranscendentalOQ02.lean` (+37 / -10): Layer 3a section + lemma + axiom-docstring update
- `research/problems/e-transcendental-oq-02/state.md` (+89 / -75): S10 entry, iteration 9→10, S11 plan
- `research/problems/e-transcendental-oq-02/knowledge.md` (+147 / -0): S10 section (proof anatomy, why-the-split, Layer 3b skeleton)
- `src/data/proofs/e-transcendental-oq-02/meta.json` (+2 / -2): lineCount 300→454 (was stale; predates S8/S9)
- `src/data/research/problems/e-transcendental-oq-02.json` (+24 / -14): currentState, builtItems, insights, nextSteps

## Test plan

- [ ] CI builds `Proofs.ETranscendentalOQ02` (Mathlib v4.26.0)
- [ ] axiomCount in meta.json (3) consistent with file
- [ ] No `sorry` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)