### PR TITLE
audit(subset-count-oq-02-oq-01): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13279,9 +13279,9 @@
       "result": "clean"
     },
     "subset-count-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:35Z",
+      "lastAudited": "2026-05-08T10:21:46Z",
       "result": "clean"
     },
     "sum-of-divisors": {


### PR DESCRIPTION
## Audit summary

Re-audited `subset-count-oq-02-oq-01` (gallery integrity).

**Result**: `clean` (auditCount 1→2)

### Verified claims

- `lineCount`: 159 ✓
- `theoremCount`: 10 ✓ (11 grep hits, but one is a Mathlib reference inside the `/-! ... -/` docstring at line 17)
- `sorries`: 0 ✓
- `axiomCount`: 0 ✓
- `definitionCount`: 0 ✓
- No True stubs
- Badge `mathlib` correctly applied (Tier B — main theorem is one-line `Multiset.card_Iic`)
- Description openly credits Mathlib: "directly from Mathlib's Multiset.card_Iic"

Tracker bump only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)