### PR TITLE
Enrich erdos-1036-oq-01: mainTheorems + full section coverage

### DIFF
--- a/src/data/proofs/erdos-1036-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1036-oq-01/annotations.json
@@ -14,7 +14,7 @@
   {
     "id": "ann-isc-interface",
     "proofId": "erdos-1036-oq-01",
-    "range": { "startLine": 42, "endLine": 62 },
+    "range": { "startLine": 39, "endLine": 53 },
     "type": "technique",
     "title": "Axiomatizing numISCTrue: Three Properties Without Full Quotient",
     "content": "Rather than constructing the Quotient type (~200 lines), three axioms capture what's needed:\n\n**numISCTrue**: The function exists (maps SimpleGraph V → ℕ). Full construction: Fintype.card(Quotient ≈) where S ≈ T ↔ G.induce S ≅g G.induce T.\n\n**numISCTrue_le_pow**: numISCTrue G ≤ 2^n (ISC classes ≤ vertex subsets).\n\n**numISCTrue_pos**: numISCTrue G > 0 (∅ gives one ISC class).\n\nThese are 'trivially true' axioms (not genuine assumptions) that could be eliminated with a Fintype quotient construction.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-non-ramsey",
     "proofId": "erdos-1036-oq-01",
-    "range": { "startLine": 63, "endLine": 90 },
+    "range": { "startLine": 55, "endLine": 72 },
     "type": "concept",
     "title": "Non-Ramsey Graphs and Shelah's Theorem",
     "content": "**IsNonRamsey**: Both G and G^c are clique-free of size ⌈c·log n⌉. Non-Ramsey(c) graphs have no clique or independent set of size c·log n.\n\n**nonRamseyExistsTrue**: Axiom — non-Ramsey(c) graphs exist on all large vertex sets. Witness: G(n,1/2) for c < 2/log 2 (both ω(G) and α(G) are ~ 2log₂n a.s.).\n\n**shelah_isc**: Axiom — for c > 0, ∃ c' > 0 such that every non-Ramsey(c) graph has ≥ 2^{c'n} ISC classes. This is Shelah's 1998 theorem — the mathematical content.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-optimal-def",
     "proofId": "erdos-1036-oq-01",
-    "range": { "startLine": 91, "endLine": 120 },
+    "range": { "startLine": 74, "endLine": 114 },
     "type": "technique",
     "title": "Optimal Constant as Supremum + Auxiliary Setup",
     "content": "**optimalConstantTrue c = sSup { c' | ∀ G non-Ramsey(c): numISCTrue G ≥ 2^{c'n} }** — the optimal exponent as a conditionally complete lattice supremum.\n\n**optimalSet_nonempty**: c' = 0 ∈ S since 2^0 = 1 ≤ numISCTrue (by numISCTrue_pos).\n\n**optimalSet_le_one**: Every c' ∈ S satisfies c' ≤ 1. Proof by contradiction: if c' > 1, get G with n≥1 vertices and numISCTrue G ≥ 2^{c'n} > 2^n ≥ numISCTrue G — contradiction via `Real.rpow_lt_rpow_of_exponent_lt`.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-bounds",
     "proofId": "erdos-1036-oq-01",
-    "range": { "startLine": 121, "endLine": 142 },
+    "range": { "startLine": 116, "endLine": 135 },
     "type": "insight",
     "title": "c'(c) ∈ (0,1]: Two-Sided Bound via csSup API",
     "content": "Three theorems:\n\n**optimalConstantTrue_le_one**: `csSup_le ⟨0, nonempty⟩ bound_fn` — sSup ≤ 1.\n\n**optimalConstantTrue_pos**: From shelah_isc get c'' > 0. Show c'' ∈ S. Use `le_csSup ⟨1,bound⟩ hmem` to get c'' ≤ sSup. Chain: 0 < c'' ≤ optimalConstantTrue.\n\n**optimalConstantTrue_bounds**: Conjunction ⟨pos, le_one⟩.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-conjecture",
     "proofId": "erdos-1036-oq-01",
-    "range": { "startLine": 139, "endLine": 145 },
+    "range": { "startLine": 137, "endLine": 144 },
     "type": "insight",
     "title": "The Open Conjecture c'(c) = 1",
     "content": "**optimalConstantTrue_eq_one**: Axiom — ∀ c > 0, optimalConstantTrue c = 1. This is the genuine open conjecture, the only one of the six axioms that is not 'trivially true' (i.e., eliminable by additional Mathlib infrastructure).\n\n**Mathematical witness**: G(n,1/2) is non-Ramsey(c) for c < 2/log 2 (by the Erdős-Rényi 1959 / Bollobás 2001 estimates on $\\omega, \\alpha$), AND has numISCTrue G(n,1/2) = 2^n a.s. (almost all $2^n$ vertex subsets give pairwise non-isomorphic induced subgraphs — connected to the graph reconstruction conjecture). Establishing both probabilistic statements in Lean would put c' = 1 in the optimality set and prove the conjecture, eliminating the sixth axiom.\n\n**Why this is hard**: the ISC count of $G(n, 1/2)$ being $2^n$ a.s. is a strong rigidity property — it says the random graph has *trivial* induced-subgraph isomorphisms across almost every pair of subsets. This is essentially an asymptotic graph-reconstruction statement; full proofs use moment methods on the number of isomorphism pairs.",
@@ -86,7 +86,7 @@
   {
     "id": "ann-summary",
     "proofId": "erdos-1036-oq-01",
-    "range": { "startLine": 150, "endLine": 169 },
+    "range": { "startLine": 150, "endLine": 167 },
     "type": "context",
     "title": "Audit Trail: The Six Axioms by Type",
     "content": "The closing comment block functions as an *audit trail*, classifying each of the six axioms by the level of effort needed to eliminate it:\n\n**Trivially true (3 axioms, ~200 lines of Mathlib quotient infrastructure)**: `numISCTrue`, `numISCTrue_le_pow`, `numISCTrue_pos` are the interface for the ISC count function. Eliminating them requires constructing `Quotient (S : Finset V) (≈)` where `S₁ ≈ S₂ ↔ G.induce S₁ ≅g G.induce S₂`, equipping the quotient with `Fintype`, and proving `Fintype.card ≤ 2^|V|`. This is engineering, not mathematics.\n\n**Inherited from parent (2 axioms)**: `nonRamseyExistsTrue` and `shelah_isc` are imported as-axioms from the parent file `Erdos1036Problem.lean`, where they ultimately trace to Shelah's 1998 theorem and the existence of non-Ramsey graphs. Eliminating these would require formalising Shelah's $\\sim 30$-page proof.\n\n**Genuine open problem (1 axiom)**: `optimalConstantTrue_eq_one` is the only mathematical assumption — the actual Erdős open question this entry encodes. Eliminating it is the OQ.\n\nThis tripartite classification is the entry's main pedagogical contribution: it disambiguates *engineering work* from *mathematical assumption* and makes clear which axiom carries the genuine open content.",

--- a/src/data/proofs/erdos-1036-oq-01/meta.json
+++ b/src/data/proofs/erdos-1036-oq-01/meta.json
@@ -62,7 +62,9 @@
       "**Upper bound is tight**: The random graph G(n,1/2) achieves numISCTrue ≈ 2^n, showing c' = 1 is the best possible upper bound.",
       "**Shelah vs. optimal**: Shelah gives SOME c' > 0 (possibly small). The OQ asks whether the optimal c' = 1 (largest possible).",
       "**Quotient complexity**: Formalizing numISCTrue requires `Quotient` with a `Setoid` on induced subgraph pairs, plus a `Fintype` instance on the quotient — about 200 lines to eliminate axioms 1-3.",
-      "**Connection to Erdős-Hajnal**: The Erdős-Hajnal conjecture says graphs with forbidden induced subgraph H have polynomial clique/independent sets. Non-Ramsey(c) graphs lack such structure — c'(c)=1 would say they are 'maximally pseudorandom' despite their Ramsey constraints."
+      "**Connection to Erdős-Hajnal**: The Erdős-Hajnal conjecture says graphs with forbidden induced subgraph H have polynomial clique/independent sets. Non-Ramsey(c) graphs lack such structure — c'(c)=1 would say they are 'maximally pseudorandom' despite their Ramsey constraints.",
+      "**Reconstruction-flavored statement**: Asserting numISCTrue G(n,1/2) = 2^n a.s. says the random graph is 'reconstructable from any subset' in the limit — every pair of distinct vertex subsets gives non-isomorphic induced subgraphs with high probability. This is closely related to the (open) graph reconstruction conjecture and is typically proved via a moment estimate on the expected number of isomorphism pairs $\\binom{2^n}{2} \\cdot \\Pr[G[S] \\cong G[T]]$, which decays super-polynomially.",
+      "**Why the c = 2/log 2 specialization matters**: This is the Erdős-Rényi 1959 / Bollobás 2001 a.s. threshold for $G(n,1/2)$ being non-Ramsey($c$). The corollary `optimalConstantTrue_random` is a one-line specialization of the conjecture axiom at this value — concretely, any explicit pseudorandom graph (Paley graphs at primes $p \\equiv 1 \\pmod 4$, quadratic-residue graphs, certain Cayley expanders) achieving numISCTrue → 2^n would witness the conjecture at this threshold even before the random-graph proof goes through."
     ],
     "prerequisites": [
       "Shelah's theorem (Erdos1036Problem.lean, axiom shelah_1998)",
@@ -73,28 +75,87 @@
   },
   "sections": [
     {
-      "id": "interface",
-      "title": "ISC Count Interface",
-      "startLine": 42,
-      "endLine": 62,
-      "summary": "Axiomatizes numISCTrue with three key properties: it exists, is bounded by 2^n, and is positive. These replace the parent's placeholder definition.",
-      "mathContext": "The true ISC count counts non-isomorphic induced subgraphs: the quotient of {S : Finset V} by the equivalence S ~ T ↔ G.induce(S) ≅g G.induce(T). Requires Quotient and Fintype instances on the quotient type (~200 lines)."
+      "id": "preamble",
+      "title": "Imports and Header Docstring",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Imports `SimpleGraph.Basic`, `SimpleGraph.Clique`, `Real.Basic`, `Log.Basic`, and `Mathlib.Tactic`. The header docstring states the OQ-01 question, summarises Shelah 1998, and explains why a separate file is needed: the parent uses a placeholder $2^n$ count of all subsets rather than isomorphism classes.",
+      "mathContext": "The header makes the central distinction explicit: parent counts $|\\{S : \\mathrm{Finset}\\, V\\}| = 2^n$ (labeled); this file counts $|\\{S\\} / {\\cong}|$ (unlabeled), which can be strictly smaller."
+    },
+    {
+      "id": "isc-interface",
+      "title": "ISC Count Interface (axioms 1–3)",
+      "startLine": 39,
+      "endLine": 53,
+      "summary": "Axiomatizes `numISCTrue : SimpleGraph V → ℕ` plus two structural properties: `numISCTrue_le_pow` (≤ 2^n) and `numISCTrue_pos` (> 0). These three axioms stand in for a full Quotient construction (~200 lines) and let the rest of the file proceed on the correct, unlabeled count.",
+      "mathContext": "$\\mathrm{numISCTrue}(G) = |\\mathrm{Finset}\\, V / {\\sim}|$ where $S_1 \\sim S_2 \\iff G.\\mathrm{induce}(S_1) \\cong_g G.\\mathrm{induce}(S_2)$. Bounds: $1 \\le \\mathrm{numISCTrue}(G) \\le 2^{|V|}$."
+    },
+    {
+      "id": "non-ramsey-shelah",
+      "title": "Non-Ramsey Graphs and Shelah's Bound (axioms 4–5)",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "Defines `IsNonRamsey G c` (clique-free of size ⌈c·log n⌉ in both `G` and `Gᶜ`). Adds `nonRamseyExistsTrue` (arbitrarily large non-Ramsey(c) graphs exist) and `shelah_isc` (Shelah 1998 lower bound: ∃ c'>0 with numISCTrue G ≥ 2^{c'n}).",
+      "mathContext": "Non-Ramsey$(c)$: $\\omega(G), \\alpha(G) \\le c\\log n$. Shelah $1998$: $\\forall c>0, \\exists c'>0, \\forall G$ non-Ramsey$(c)$, $\\mathrm{numISCTrue}(G) \\ge 2^{c'n}$."
     },
     {
       "id": "optimal-constant",
-      "title": "Optimal Constant Definition and Bounds",
-      "startLine": 78,
-      "endLine": 140,
-      "summary": "Defines optimalConstantTrue as sSup of valid exponents. Proves it lies in (0,1]: upper bound from numISCTrue ≤ 2^n, lower bound from Shelah.",
-      "mathContext": "The optimal constant is the supremum of all c' such that every non-Ramsey(c) graph has ≥ 2^{c'n} ISC classes. The key proof: if c' > 1, then 2^{c'n} > 2^n ≥ numISCTrue, contradiction."
+      "title": "Optimal Constant Definition",
+      "startLine": 74,
+      "endLine": 79,
+      "summary": "Defines `optimalConstantTrue c := sSup { c' | ∀ G non-Ramsey(c): numISCTrue G ≥ 2^{c'n} }` as a conditionally-complete-lattice supremum over the optimality set.",
+      "mathContext": "$c'(c) := \\sup \\{c' \\in \\mathbb{R} \\mid \\forall G$ non-Ramsey$(c)\\colon \\mathrm{numISCTrue}(G) \\ge 2^{c' \\cdot |V|}\\}$. Uses `noncomputable def` because real `sSup` is non-constructive."
     },
     {
-      "id": "conjecture",
-      "title": "Main Conjecture: c'(c) = 1",
-      "startLine": 143,
-      "endLine": 160,
-      "summary": "States the main open conjecture as an axiom: optimalConstantTrue(c) = 1 for all c > 0.",
-      "mathContext": "This asserts that non-Ramsey graphs are 'pseudorandom' enough to maximize ISC diversity. Random graphs G(n,1/2) are the witness: they are non-Ramsey and achieve 2^n ISC classes a.s."
+      "id": "key-bounds",
+      "title": "Two-sided Bounds: $c'(c) \\in (0,1]$",
+      "startLine": 81,
+      "endLine": 135,
+      "summary": "Two private lemmas (`optimalSet_nonempty` via numISCTrue_pos, `optimalSet_le_one` via Real.rpow_lt_rpow_of_exponent_lt) feed three public theorems: `optimalConstantTrue_le_one` (csSup_le), `optimalConstantTrue_pos` (le_csSup applied to Shelah's c''), and `optimalConstantTrue_bounds` (the conjunction).",
+      "mathContext": "$c'(c) \\le 1$: if $c' > 1$ then $2^{c'n} > 2^n \\ge \\mathrm{numISCTrue}(G)$, contradiction. $c'(c) > 0$: Shelah's $c''$ is in the optimality set, and $\\mathrm{le\\_csSup}$ gives $0 < c'' \\le c'(c)$."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "Main Conjecture: $c'(c) = 1$ (axiom 6)",
+      "startLine": 137,
+      "endLine": 148,
+      "summary": "States the open conjecture as `axiom optimalConstantTrue_eq_one : ∀ c>0, optimalConstantTrue c = 1`. The corollary `optimalConstantTrue_random` is a one-line specialization at $c = 2/\\log 2$, the Erdős-Rényi a.s. threshold for $G(n,1/2)$ being non-Ramsey$(c)$.",
+      "mathContext": "$\\forall c > 0, c'(c) = 1$. Witness candidate: $G(n,1/2)$ is non-Ramsey$(c)$ for $c < 2/\\log 2 \\approx 2.885$ (Bollobás), and $\\mathrm{numISCTrue}(G(n,1/2)) = 2^n - o(2^n)$ a.s."
+    },
+    {
+      "id": "summary-audit",
+      "title": "Summary: Axiom Audit and Parent Contrast",
+      "startLine": 150,
+      "endLine": 167,
+      "summary": "Closing docstring tabulates the proved theorems, classifies the six axioms by elimination cost (3 trivially-true Quotient interface, 2 inherited from parent, 1 genuine OQ), and contrasts with the parent file where optimalConstant = 1 holds trivially via the placeholder count.",
+      "mathContext": "Axiom budget: 3 (Quotient interface, ~200 lines to eliminate) + 2 (Shelah / non-Ramsey existence, inherited) + 1 (the genuine open question $c'(c) = 1$) = 6."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "optimalConstantTrue_le_one",
+      "statement": "$\\forall c > 0\\colon$ optimalConstantTrue $c \\le 1$",
+      "significance": "Upper bound — the random-graph extremal $2^n$ is the ceiling. Proof uses csSup_le with the optimality set bounded above via Real.rpow_lt_rpow_of_exponent_lt."
+    },
+    {
+      "name": "optimalConstantTrue_pos",
+      "statement": "$\\forall c > 0\\colon$ optimalConstantTrue $c > 0$",
+      "significance": "Lower bound — Shelah's theorem (axiom shelah_isc) supplies some $c'' > 0$ in the optimality set; le_csSup then gives $0 < c'' \\le c'(c)$."
+    },
+    {
+      "name": "optimalConstantTrue_bounds",
+      "statement": "$\\forall c > 0\\colon 0 < $ optimalConstantTrue $c \\le 1$",
+      "significance": "Clean two-sided summary theorem combining the above; this is the machine-checked headline result of the file."
+    },
+    {
+      "name": "optimalConstantTrue_random",
+      "statement": "optimalConstantTrue $(2 / \\log 2) = 1$",
+      "significance": "Specialization of the conjecture axiom at the Erdős-Rényi a.s. threshold for $G(n,1/2)$ being non-Ramsey. Concretely testable: any explicit pseudorandom witness at this $c$ would corroborate the conjecture."
+    },
+    {
+      "name": "optimalConstantTrue_eq_one",
+      "statement": "**Axiom (open)**: $\\forall c > 0\\colon$ optimalConstantTrue $c = 1$",
+      "significance": "The genuine Erdős open problem this entry encodes. Eliminated by proving (i) $G(n,1/2)$ is non-Ramsey$(c)$ a.s., and (ii) numISCTrue $G(n,1/2) = 2^n - o(2^n)$ a.s."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-1036-oq-01` (Optimal Constant in Shelah's Coloring Theorem).

- **`mainTheorems` array (new)** — 5 entries pairing each public theorem/axiom with its formal statement and significance:
  - `optimalConstantTrue_le_one` (csSup_le upper bound from $\mathrm{numISCTrue} \le 2^n$)
  - `optimalConstantTrue_pos` (le_csSup lower bound from Shelah)
  - `optimalConstantTrue_bounds` (clean two-sided summary, $c'(c) \in (0,1]$)
  - `optimalConstantTrue_random` (corollary at the Erdős-Rényi threshold $c = 2/\log 2$)
  - `optimalConstantTrue_eq_one` (the genuine open conjecture, axiom 6)
- **Sections array** — replaced 3 partial sections (covering only lines 42–160) with 7 sections that span the full 169-line file: preamble, ISC interface, Non-Ramsey + Shelah, optimal-constant definition, key bounds, main conjecture, summary audit. Each section now carries its own `mathContext`.
- **Annotation ranges** — realigned to actual code blocks, removing the 121–142 / 139–145 overlap between `ann-bounds` and `ann-conjecture` and the 91–120 overshoot of `ann-optimal-def`.
- **`keyInsights`** — added two more (now 7 total):
  - reconstruction-flavored statement: $\mathrm{numISCTrue}\,G(n,1/2) = 2^n - o(2^n)$ a.s. is essentially an asymptotic graph-reconstruction property, typically established via a moment estimate;
  - why the $c = 2/\log 2$ specialization is concretely testable via Paley graphs / QR graphs / Cayley expanders.

## Test plan

- [x] `meta.json` and `annotations.json` parse as JSON
- [x] Section ranges $\subseteq [1, 169]$ and non-overlapping
- [x] Annotation ranges $\subseteq [1, 167]$ and pairwise non-overlapping
- [ ] `pnpm build` — local node v26 / better-sqlite3 native build fails on host (pre-existing, unrelated). Will be validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)