### PR TITLE
audit(batch): re-audit 7 entries clean (2026-05-08)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13214,9 +13214,9 @@
       "result": "clean"
     },
     "sqrt2-minpoly-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:35Z",
+      "lastAudited": "2026-05-08T10:38:53Z",
       "result": "clean"
     },
     "sqrt2-plus-sqrt3-irrational": {
@@ -13226,9 +13226,9 @@
       "result": "clean"
     },
     "sqrt2-plus-sqrt3-irrational-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:35Z",
+      "lastAudited": "2026-05-08T10:38:53Z",
       "result": "clean"
     },
     "stirling-formula": {
@@ -13453,9 +13453,9 @@
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:36Z",
+      "lastAudited": "2026-05-08T10:38:53Z",
       "result": "clean"
     },
     "taylor-theorem": {
@@ -13465,9 +13465,9 @@
       "result": "clean"
     },
     "taylor-theorem-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:36Z",
+      "lastAudited": "2026-05-08T10:38:53Z",
       "result": "clean"
     },
     "taylor-theorem-oq-03": {
@@ -13513,9 +13513,9 @@
       "result": "clean"
     },
     "triangle-angle-sum-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:37Z",
+      "lastAudited": "2026-05-08T10:38:53Z",
       "result": "clean"
     },
     "triangle-inequality": {
@@ -13578,9 +13578,9 @@
       "result": "clean"
     },
     "vietas-formulas-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:37Z",
+      "lastAudited": "2026-05-08T10:38:53Z",
       "result": "clean"
     },
     "vietas-formulas-oq-03": {
@@ -13700,9 +13700,9 @@
       "result": "clean"
     },
     "yang-mills-lattice-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:37Z",
+      "lastAudited": "2026-05-08T10:38:53Z",
       "result": "clean"
     },
     "yang-mills-transfer-matrix": {


### PR DESCRIPTION
## Summary

Re-audited 7 of the stalest entries (last audited 2026-04-23, ~2 weeks ago) and verified all structural counts match the Lean source.

## Method

For each entry:
1. Read meta.json from origin/main
2. Read corresponding Lean file at `proofs/Proofs/<File>.lean`
3. Strip comments (depth-aware) and count: `sorry`, top-level `axiom`, `theorem`/`lemma`, `def`/`abbrev`/`opaque`
4. Compare against `leanFile.{lineCount,axiomCount,theoremCount,definitionCount,sorries}` and `meta.{...}`

## Results

| Entry | Status / Badge | Lean (lines/axioms/thm/def/sorry) | Match |
|-------|---------------|-----------------------------------|-------|
| `sqrt2-plus-sqrt3-irrational-oq-03` | verified / mathlib | 403/0/8/0/0 | ✓ |
| `sqrt2-minpoly-oq-02` | verified / original | 202/0/21/0/0 | ✓ |
| `taylor-theorem-oq-02` | verified / original | 218/0/9/0/0 | ✓ |
| `taylor-sincos-convergence-oq-04` | verified / mathlib | 324/0/18/1/0 | ✓ |
| `yang-mills-lattice-oq-01` | axiomatized / axiom | 579/2/28/11/0 | ✓ |
| `vietas-formulas-oq-02` | verified / original | 204/0/10/10/0 | ✓ |
| `triangle-angle-sum-oq-03` | verified / original | 140/0/6/0/0 | ✓ |

`yang-mills-lattice-oq-01` is a Millennium-class problem with 2 axioms (`os_reconstruction`, `os_mass_gap_transfer`) — both openly disclosed in `meta.assumptions`. Status `axiomatized`/badge `axiom` is correct.

No True stubs, no phantom axioms, no hidden Mathlib delegation found.

## Test plan

- [x] `git diff --stat`: surgical 14-line change (7 entries × 2 fields each: auditCount 1→2, lastAudited timestamp)
- [x] No JSON formatting drift (used surgical string replacement, not `json.dump`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)