### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): S49 — refined attack plan; cell-wise → sum-level pivot

### DIFF
--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s04.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s04.md
@@ -1,0 +1,208 @@
+## Session 2026-05-08 (Session 49, researcher-6) — Refined attack plan for `gnwProb_exchange`
+
+**Mode**: ORIENT/PLAN (RICH knowledge tier, score 201)
+**Outcome**: Strategic analysis only; no Lean code change. Identifies a
+subtle obstacle in S48's outlined cell-wise attack and proposes a refined
+sum-level joint-induction strategy. Sorry count unchanged (1).
+
+### Why a planning-only session
+
+The sole remaining sorry is `gnwProb_exchange` (Helpers:14374) — the GNW
+1979 hook-weight shift identity. S48 outlined a five-step plan (decompose
+`μ.cells`, partition by case, apply S48 lemmas cell-by-cell, pair gnwProb
+factors, close via `Finset.prod_congr`). Before writing any Lean for the
+proof, this session examines whether the *cell-by-cell pairing* in step 4
+actually goes through.  It does **not**, in general — and the obstacle has
+implications for the whole attack.  Documenting the obstacle in advance
+saves a future session from a stalled coding attempt.
+
+### The S48 outlined plan, restated
+
+S48 proposed:
+
+1. Decompose `μ.cells = (μ.cells \ {c, c'}) ∪ {c, c'}`.
+2. Partition `μ.cells \ {c, c'}` into the seven sub-cases of S48
+   (doubly-affected `d`, arm of c off d, leg of c, arm of c', leg of c'
+   off d, "other") via the `distinct_corners_dichotomy` (S45).
+3. Apply S48 lemmas cell-by-cell to relate `hookLength μ x` to
+   `hookLength ((μ\c)\c') x`, `hookLength (μ\c) x`, `hookLength (μ\c') x`.
+4. **Pair the gnwProb factors** via `gnwProb_step` / `gnwProb_stable` to
+   collapse the integrand comparison to:
+   `gnwProb μ c K x · h_{(μ\c)\c'}(x) = gnwProb (μ\c') c K x · h_{μ\c}(x)`
+   for `x ∉ {c, c'}` (modulo the doubly-affected cell).
+5. Close via `Finset.sum_attach` + `Finset.prod_congr`.
+
+The product-form exchange identity is:
+
+```
+F(μ,c) · H(μ\c) · H(μ\c') = F(μ\c',c) · H((μ\c')\c) · H(μ)
+```
+where `F(ν,d) = ∑_{x ∈ ν.cells} gnwProb ν d (hookLength ν x.1 x.2) x`.
+
+### Obstacle: cell-wise gnwProb invariance does **not** hold
+
+Consider the simplest "Bucket C" case from a naive S48 reading: a cell
+`x ∈ μ.cells \ {c, c'}` that is **not** in the arm or leg of `c'`.  By
+S48.6 (`hookLength_doubleRemove_other`), `hookLength μ x = hookLength (μ\c') x`.
+By `strictHookCells_removeCorner_eq_of_not_mem`, `strictHookCells μ x =
+strictHookCells (μ\c') x` (since `c' ∉ strictHookCells μ x` for
+arm/leg-disjoint `x`).
+
+One might expect this implies, cell-wise:
+```
+gnwProb μ c (hookLength μ x) x = gnwProb (μ\c') c (hookLength (μ\c') x) x.
+```
+**This is false.**  The recursive structure of `gnwProb` collects values
+on `strictHookCells x`, and elements `y ∈ strictHookCells μ x` *can* land
+in the arm or leg of `c'` even when `x` itself does not.
+
+**Counterexample sketch.**  Take `μ` such that `c' = (c'.1, c'.2)` is a
+distant corner.  Pick `x = (c'.1 - 1, 0)` (i.e., row immediately above
+c', leftmost column).  Then `x` is in neither the arm of c' (different
+row) nor the leg of c' (different column, since `0 ≠ c'.2` whenever
+`c'.2 ≥ 1`).  Yet `strictHookCells μ x` includes `(c'.1, 0)` (a leg-of-x
+cell with first coord `c'.1 = x.1 + 1`).  And `(c'.1, 0)` *is* in the
+arm of c' (row `c'.1`, col `0 < c'.2`).  So the recursive `gnwProb` step
+on `x` reaches a cell `y` whose hookLength behaves differently in `μ`
+vs `μ\c'`.
+
+**Consequence.**  Cell-wise invariance breaks even one recursion step
+deep.  A purely cell-wise pairing in step 4 of the S48 plan cannot work.
+
+### Why GNW 1979 still goes through (sum-level invariance)
+
+The GNW exchange identity is fundamentally a **sum-level** statement: the
+*total* probability mass of walks from anywhere to `c` shifts by exactly
+the predicted hookProd ratio when one corner `c'` is removed.  The walk
+recursion itself shuffles probability between cells in arm/leg of `c'`;
+only after summing does the "magic" factor `h_d (h_d - 2) / (h_d - 1)²`
+emerge cleanly.
+
+Concretely, the right invariant to prove inductively is the *summed*
+form:
+
+```
+∀ K ≥ max_{x∈μ} hookLength μ x.   (sum-Inv)
+  ∑_{x ∈ μ.cells} gnwProb μ c K x · w_μ(x)
+   = ∑_{x ∈ (μ\c').cells} gnwProb (μ\c') c K x · w_{μ\c'}(x) · F_d
+```
+for an appropriate cell-weight `w_ν(x)` (encoding `H(ν\c) / [hookLength ν x]`-style
+normalizations) and a global factor `F_d` capturing the doubly-affected
+cell.  The exact form of `w` and `F_d` is what S50+ needs to nail down.
+
+The proof would proceed by **joint strong induction on K**, using
+the recursion of `gnwProb` to step both sides simultaneously.  At each
+step, the contributions of the doubly-affected cell `d` propagate
+through `strictHookCells`, but the propagation cancels in expectation
+(this is GNW's KEY insight) — so the inductive sum-level invariant is
+preserved.
+
+### Concrete bridge lemmas for S50+
+
+Working backward from `gnwProb_exchange`, the most natural sub-targets:
+
+1. **`hookProd_doubleRemove_factor`** (purely algebraic, ~50-100 lines).
+   Statement:
+   ```
+   ∀ μ c c'.  isCorner μ c → isCorner μ c' → c ≠ c' → c.1 < c'.1 →
+     (hookProd μ : ℚ) * hookProd ((removeCorner μ c hc).removeCorner c' …) *
+       (hookLength μ c.1 c'.2 - 1)^2
+     = hookProd (removeCorner μ c hc) * hookProd (removeCorner μ c' hc') *
+       hookLength μ c.1 c'.2 * (hookLength μ c.1 c'.2 - 2)
+   ```
+   *Proof sketch.*  Two applications of `hookProd_ratio_formula`:
+   - `(H(μ) / H(μ\c)) = ∏_{s<c.2} h_μ(c.1,s)/(h_μ(c.1,s)-1) · ∏_{r<c.1} h_μ(r,c.2)/(h_μ(r,c.2)-1)`.
+   - `(H(μ\c') / H((μ\c')\c)) = ∏_{s<c.2} h_{μ\c'}(c.1,s)/(h_{μ\c'}(c.1,s)-1) · ∏_{r<c.1} h_{μ\c'}(r,c.2)/(h_{μ\c'}(r,c.2)-1)`
+     (same arm/leg sets; `c` is a corner of `μ\c'` with the same rowLen/colLen).
+   For `s ≠ c'.2`: arm cells `(c.1, s)` are unaffected by removing c'
+   (different row, different column), so the ratio cell-wise is 1 (cancels
+   in the quotient).  For `r ∈ Finset.range c.1`: leg cells `(r, c.2)`
+   are unaffected by removing c' since `r < c.1 < c'.1` (different row)
+   and `c.2 ≠ c'.2` (different column); ratio is 1.
+   The only non-cancelling cell is `s = c'.2` (the doubly-affected cell
+   `d = (c.1, c'.2)`):
+   ```
+   [h_μ(d)/(h_μ(d)-1)] / [(h_μ(d)-1)/(h_μ(d)-2)] = h_μ(d)·(h_μ(d)-2) / (h_μ(d)-1)².
+   ```
+   This is the algebraic "easy half" of `gnwProb_exchange` — purely
+   hookProd-side, no random-walk reasoning.  Confidence: high.
+
+2. **`gnwProb_invariant_off_arm_leg_cp_via_simul_induction`** (~100-200
+   lines).  The "hard half" — joint K-induction showing the F-side
+   (sum of gnwProb) shifts by exactly the inverse factor.  Statement:
+   ```
+   ∀ K ≥ ⌈max_{x∈μ} hookLength μ x⌉ + ε.
+     (∑_{x ∈ μ.cells} gnwProb μ c K x) ·
+       hookLength μ d · (hookLength μ d - 2)
+     = (∑_{x ∈ (μ\c').cells} gnwProb (μ\c') c K x) ·
+       (hookLength μ d - 1)²
+   ```
+   Proof by simultaneous strong induction on K (using `gnwProb_step` for
+   stability above max hookLength).  The case-decomposition uses S48's
+   six lemmas; the cancellation at d uses the recursion identity
+   `gnwProb K+1 x = (1/|H*|) Σ_{y ∈ H* x} gnwProb K y` and the
+   sum-bridges from S43 (`sum_gnwProb_strictHookCells_eq_removeCorner`).
+   Confidence: medium — requires careful K-bookkeeping.
+
+3. **`gnwProb_exchange` itself** (~50 lines).  Combine 1 + 2 by
+   multiplying each side of the identity in 2 by `hookProd (μ\c)`,
+   matching the product form needed for `gnwProb_key`.  At this point
+   the remaining work is algebraic rearrangement.  Confidence: high
+   given 1 and 2.
+
+### Alternative path (deferred): deterministic recasting
+
+`literature/closing-the-final-sorry.md` notes a self-contained
+~400-line deterministic weighted-walk recasting that *avoids* the
+exchange step entirely (count weighted walks of every length, divide
+by `μ.card · ∏ |strict hook|`).  This bypasses both lemmas above.
+Cost: rewrite from scratch, no leverage of S37-S48 infrastructure.
+Decision: continue with the GNW exchange path; the deterministic
+recast is the fallback if S50-S52 stall.
+
+### Risk register
+
+* **File-size wall.**  Helpers.lean is at 14629 lines after S48.  The
+  bridge lemmas above add ~150-300 lines.  Approaching the conservative
+  ceiling for Docker 32GB-memory builds.  Mitigation: extract
+  S43-S48 + new lemmas into a new file `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`
+  (clean sub-module, only depends on YoungDiagram + earlier sections).
+  Rewire `meta.json` `additionalFiles` accordingly.
+
+* **Build verification.**  `proofs/.lake` is a self-referential symlink,
+  so each Docker build is ≥45 minutes.  Recommend running CI verification
+  in parallel with subsequent coding sessions, not blocking session
+  output on local Docker.
+
+* **Mathlib API drift.**  The arithmetic uses `Finset.prod_congr`,
+  `Nat.cast_prod`, `Finset.mul_prod_erase`, `Finset.prod_div_telescope`,
+  `field_simp`, `push_cast`.  All used elsewhere in this file (search
+  `hookProd_ratio_formula` proof for the canonical pattern).  Risk: low.
+
+### Next Steps (S50)
+
+1. **Extract a new file** `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`
+   containing S43-S48 lemmas + the new bridges below (preempting the
+   file-size wall).  Add it to `meta.json` `additionalFiles`.
+2. **Prove `hookProd_doubleRemove_factor`** (target 1 above) — ~80
+   lines, purely algebraic, leverages `hookProd_ratio_formula` and the
+   six S48 shift lemmas.
+3. **Begin the joint K-induction** for target 2.
+4. (Stretch) Combine with target 3 to close `gnwProb_exchange` — and
+   thereby `gnwProb_key` and `hook_walk_identity_gnw`, finally promoting
+   the entry to `verified` status.
+
+### Files modified this session
+
+* `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s04.md`
+  (this note)
+* `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (Iteration
+  48 → 49; refined Active Approach + Next Action with the obstacle and
+  refined plan)
+* `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json`
+  (Iteration 48 → 49; updated `focus`, `nextAction`, add S49 insight on
+  the cell-wise / sum-level distinction)
+
+### Sorry count: 1 (unchanged)
+
+### Build verification: not run (no Lean code modified)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: ballot-problem-oq-03-oq-01-oq-02
 
 ## Current State
-**Phase**: ACT (GNW exchange-step framework + diagram commutativity; corner-distinctness coordinate lemmas added; Aristotle Target 3 closed via dispatcher; double-removal hookLength shift characterization complete)
+**Phase**: ORIENT/PLAN (S49 — refined attack plan for `gnwProb_exchange`: cell-wise gnwProb invariance shown to fail; pivot to sum-level joint-K induction strategy)
 **Path**: full
 **Since**: 2026-04-21T20:08:44+02:00
 **Last Updated**: 2026-05-08
-**Iteration**: 48
+**Iteration**: 49
 
 ## Current Focus
 Close `gnwProb_exchange` (Helpers, line 14143) — the GNW 1979 exchange identity
@@ -31,9 +31,9 @@ in place:
    (L-shape, (3,1)).
 
 ## Attempt Count
-- Total attempts: 48 (sessions 1–48; sessions 1–4 archived to
-  `sessions/`; sessions 5–48 in `knowledge.md` + `sessions/`)
-- Current approach attempts: 12 (sessions 37–48 on GNW)
+- Total attempts: 49 (sessions 1–49; sessions 1–4 archived to
+  `sessions/`; sessions 5–49 in `knowledge.md` + `sessions/`)
+- Current approach attempts: 13 (sessions 37–49 on GNW)
 - Approaches tried:
   1. LGV-determinant via `lgv_lemma_rxr` + Jacobi–Trudi (sessions 1–10) —
      dead scaffolding deleted in session 32.
@@ -109,25 +109,50 @@ in place:
   not yet confirmed in this session. CI will verify the PR.
 
 ## Next Action
-**ACT — prove `gnwProb_exchange`.**
+**S50 — extract `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` + prove
+`hookProd_doubleRemove_factor`** (the algebraic "easy half" of
+`gnwProb_exchange`).
 
-1. Decompose `μ.cells = (removeCorner μ c').cells ∪ {c'}` and split the LHS sum
-   into the c' contribution + the rest.
-2. For x ≠ c', relate `gnwProb μ c (h(x)) x` to `gnwProb (μ\c') c (h(x)) x`
-   by analyzing how `strictHookCells x` changes when c' is removed
-   (changes only when x is in the arm/leg of c').
-3. The hook lengths satisfy:
-   - `h_{μ\c'}(r,c'.2) = h_μ(r,c'.2) - 1` for r < c'.1 (leg of c')
-   - `h_{μ\c'}(c'.1,s) = h_μ(c'.1,s) - 1` for s < c'.2 (arm of c')
-   - `h_{μ\c'}(x) = h_μ(x)` elsewhere
-4. The product
-   `H(μ)·H((μ\c')\c) = H(μ\c)·H(μ\c')` follows from a careful tally of the
-   doubly-affected cell `(c'.1,c.2)` (or similar boundary cells if c, c'
-   are adjacent in the appropriate sense).
+S49 (this session) re-examined S48's outlined cell-by-cell pairing and
+identified a subtle obstacle: cell-wise gnwProb invariance for cells
+"far from c'" does NOT hold, because the gnwProb random walk
+recursively descends into arm/leg of c' even when starting at cells
+disjoint from arm/leg of c'.  See `sessions/2026-05-08-s04.md` for the
+counterexample sketch (e.g., `x = (c'.1 - 1, 0)` reaches `(c'.1, 0)` in
+one walk step, and `(c'.1, 0)` is in the arm of c').
 
-Alternative: a deterministic weighted-path recasting of GNW that avoids the
-exchange step entirely (count weighted walks of every length, divide by
-`μ.card · ∏ |strict hook|`); ~400 lines self-contained.
+The refined attack splits `gnwProb_exchange` into two sub-lemmas:
+
+1. **Algebraic "easy half" — `hookProd_doubleRemove_factor`** (~80 lines).
+   Pure hookProd identity using `hookProd_ratio_formula` (twice) plus
+   the six S48 shift lemmas.  States that
+   `H(μ) · H((μ\c)\c') · (h_d − 1)² = H(μ\c) · H(μ\c') · h_d · (h_d − 2)`
+   where `d = (c.1, c'.2)`.  Confidence: high.
+
+2. **F-side "hard half"** (~100-200 lines).  Joint K-induction on the
+   sum-level invariant
+   `(∑ gnwProb μ c K) · h_d (h_d−2) = (∑ gnwProb (μ\c') c K) · (h_d − 1)²`,
+   using `gnwProb_step` for K-stability and the S43 sum-bridges
+   (`sum_gnwProb_eq_removeCorner_cells`,
+   `sum_gnwProb_strictHookCells_eq_removeCorner`).  Confidence: medium.
+
+3. **Combine** to close `gnwProb_exchange` (~50 lines algebraic
+   rearrangement).
+
+Practical sequencing for S50: do step 1 first (purely algebraic, low risk,
+buildable in isolation).  Step 2 involves K-bookkeeping and may need
+multiple sub-sessions.
+
+**File-size mitigation.** Helpers.lean is at 14629 lines after S48; the
+new bridge lemmas add ~150-300 lines.  Before S50 starts coding, extract
+S43-S48 + new bridges into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean`
+to stay below the 32GB Docker build ceiling.  This file would import
+the existing primitives and re-export the bridges to Helpers.
+
+Alternative (deferred): a deterministic weighted-path recasting of GNW
+that avoids the exchange step entirely (count weighted walks of every
+length, divide by `μ.card · ∏ |strict hook|`); ~400 lines self-contained.
+Fallback if S50-S52 stall.
 
 ## References
 
@@ -142,6 +167,7 @@ exchange step entirely (count weighted walks of every length, divide by
 - `sessions/2026-05-08-s01.md` — Session 46: Aristotle Target 3 closed via dispatcher
 - `sessions/2026-05-08-s02.md` — Session 47: `removeCorner_swap` + `hookProd_removeCorner_swap`
 - `sessions/2026-05-08-s03.md` — Session 48: double-removal hookLength shift lemmas
+- `sessions/2026-05-08-s04.md` — Session 49: refined attack plan; cell-wise → sum-level pivot
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4397` — `removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:4412` — `hookProd_removeCorner_swap`
 - `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean:5035` — `hookLength_doubleRemove_doubly_affected` (S48)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -31,18 +31,18 @@
     "goal": "Prove hook_length_formula using lgv_lemma_rxr from BallotProblemOQ03OQ02.lean, starting with rectangular shapes then generalizing"
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "ORIENT/PLAN",
     "since": "2026-04-21T13:45:00Z",
-    "iteration": 48,
-    "focus": "Sole remaining sorry is `gnwProb_exchange` (Helpers, line 14374; GNW 1979 hook-weight shift identity in product form). Session 48 added six double-removal hookLength characterization lemmas (Helpers, lines 5035–5186) covering all seven cell-type cases under double corner removal; combined with S43-S47 infrastructure this is sufficient for the per-cell algebra of the exchange identity. Next sessions should chain the per-cell shifts through the gnwProb walk recursion to close gnwProb_exchange.",
+    "iteration": 49,
+    "focus": "Sole remaining sorry is `gnwProb_exchange` (Helpers, line 14374; GNW 1979 hook-weight shift identity in product form). Session 49 (this session) is a strategic planning iteration: re-examined S48's outlined cell-wise attack and identified an obstacle — cell-wise gnwProb invariance for cells \"far from c'\" does NOT hold, because the gnwProb random walk recursively descends into arm/leg of c' even when starting at cells disjoint from arm/leg of c'. Pivots the attack to a SUM-LEVEL joint-K induction strategy, splitting `gnwProb_exchange` into an algebraic \"easy half\" (`hookProd_doubleRemove_factor`) and an F-side \"hard half\" (joint K-induction). See sessions/2026-05-08-s04.md for the counterexample sketch and refined plan. Sorry count unchanged (1).",
     "blockers": [
-      "gnwProb_exchange: GNW 1979 hook-weight shift identity in product form (~100 lines of careful arm/leg case analysis); the sole remaining sorry. Per-cell hookLength shifts are now fully characterized (S48); remaining work is the gnwProb walk-probability factor pairing."
+      "gnwProb_exchange: GNW 1979 hook-weight shift identity in product form. S49 refined the attack plan: split into algebraic `hookProd_doubleRemove_factor` (easy half, ~80 lines via `hookProd_ratio_formula` + S48 shift lemmas) and F-side joint-K-induction (hard half, ~100-200 lines). Cell-wise gnwProb invariance was shown to fail (counterexample in s04.md), so the F-side proof must use sum-level invariance via `gnwProb_step` and the S43 sum-bridges, not cell-wise pairing as initially outlined in S48."
     ],
-    "nextAction": "Prove gnwProb_exchange using S48's six double-removal hookLength lemmas to match per-cell hook factors, plus gnwProb_step / gnwProb_stable / sum_gnwProb_strictHookCells_eq_removeCorner to descend the walk recursion in lockstep on (μ, c) and (μ\\c', c). Decompose μ.cells via the dichotomy from S45 (corners c, c' with c.1 < c'.1); apply the seven-case partition.",
+    "nextAction": "S50: extract `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` (preempting the file-size wall on Helpers.lean) and prove `hookProd_doubleRemove_factor` — the algebraic \"easy half\" of `gnwProb_exchange`, ~80 lines via two applications of `hookProd_ratio_formula` plus the six S48 shift lemmas. Then in S51-S52 tackle the F-side joint-K-induction. Confidence: high for S50 (purely algebraic), medium for S51-S52.",
     "attemptCounts": {
-      "total": 48,
-      "currentApproach": 12,
-      "approachesTried": 11
+      "total": 49,
+      "currentApproach": 13,
+      "approachesTried": 12
     }
   },
   "knowledge": {


### PR DESCRIPTION
## Summary

Session 49 for `ballot-problem-oq-03-oq-01-oq-02` (Hook Length Formula via GNW 1979). **Strategic planning iteration; no Lean code change.** Sorry count unchanged at 1 (`gnwProb_exchange`).

## What this session does

Re-examines the cell-by-cell attack outlined in S48 for `gnwProb_exchange` and identifies a subtle obstacle that, if missed, would stall a future coding session. Pivots the attack from cell-wise to sum-level reasoning.

### The obstacle (counterexample sketch)

S48 step 4 proposed pairing `gnwProb` factors cell-by-cell. Even for cells `x` with `x ∉ arm c' ∪ leg c' ∪ {c'}` — where `hookLength μ x = hookLength (μ\c') x` and `strictHookCells μ x = strictHookCells (μ\c') x` — the cell-wise identity
```
gnwProb μ c (hookLength μ x) x = gnwProb (μ\c') c (hookLength (μ\c') x) x
```
**fails**, because the recursive walk descends one step into arm/leg of c'.

**Concrete counterexample**: take `x = (c'.1 - 1, 0)`. Then `x ∉ arm c' ∪ leg c'`. But `(c'.1, 0) ∈ strictHookCells μ x` (a leg-of-x cell), and `(c'.1, 0)` *is* in the arm of c' (row `c'.1`, col `0 < c'.2`). So the recursion at `x` reaches a cell `y` whose hookLength differs in `μ` vs `μ\c'`.

### The refined attack

`gnwProb_exchange` splits cleanly into:

| Sub-target | Lines | Description | Confidence |
|---|---|---|---|
| `hookProd_doubleRemove_factor` | ~80 | Algebraic "easy half" using `hookProd_ratio_formula` (twice) + the six S48 shift lemmas. States `H(μ) · H((μ\c)\c') · (h_d - 1)² = H(μ\c) · H(μ\c') · h_d · (h_d - 2)`. | **high** |
| F-side joint K-induction | ~100-200 | Hard half: simultaneous induction on K showing the gnwProb sum shifts inversely. Uses `gnwProb_step` for K-stability and the S43 sum-bridges (`sum_gnwProb_eq_removeCorner_cells`, `sum_gnwProb_strictHookCells_eq_removeCorner`). | medium |
| `gnwProb_exchange` itself | ~50 | Combine the two halves via product-form rearrangement. | high (given prior) |

## Why a planning-only session

- The S48 attack plan, taken literally, leads to a stalled coding attempt.
- Documenting the obstacle + refined plan in advance saves a future session from rediscovering it.
- Build verification of any new Lean code requires ≥45 minutes (broken `proofs/.lake` symlink); spending that budget on a planning session would be premature.

## File-size mitigation also recommended

Helpers.lean is at 14629 lines after S48; the new bridge lemmas add ~150-300 lines. Before S50 starts coding, extract S43-S48 + new bridges into `BallotProblemOQ03OQ01OQ02DoubleRemove.lean` to stay below the 32GB Docker build ceiling.

## Files changed

- `research/problems/ballot-problem-oq-03-oq-01-oq-02/sessions/2026-05-08-s04.md` (new; 208 lines)
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/state.md` (Iteration 48 → 49; refined Active Approach + Next Action)
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (Iteration 48 → 49; updated focus, nextAction, blockers)

## Status

* **Outcome**: planning (refined attack plan; sorry count unchanged at 1)
* **Sorry count**: 1 (Helpers:14374 `gnwProb_exchange` — unchanged)
* **Build verification**: not run (no Lean code modified)

## Test plan

- [x] Markdown renders cleanly (gallery uses these files for state display)
- [x] JSON parses and preserves unicode (μ, λ, π, etc.)
- [x] state.md cross-references all six S48 lemma line numbers (already verified)
- [ ] CI / deployer auto-merge (no Lean files touched, so no Lean build risk)