### PR TITLE
research(liouville-theorem-oq-04): S15 — discharge bridge axiom (build pending)

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ04.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ04.lean
@@ -511,9 +511,11 @@ theorem intPolyHomogEval_cast_eq (f : ℤ[X]) (r s : ℤ) (hs : s ≠ 0) :
   have hsi_ne : ((s : ℚ))^i ≠ 0 := pow_ne_zero _ hs_q
   -- Lean 4.26: `(algebraMap ℤ ℚ) z` reduces to the integer cast via `eq_intCast`
   -- (the previous `Int.algebraMap_eq_intCast` lemma was renamed/removed).
+  -- After `simp [eq_intCast]`, `field_simp` already closes the goal; the
+  -- subsequent `ring` would error with "No goals". Use `<;> ring` to make
+  -- ring optional on any residual subgoals.
   simp only [eq_intCast]
-  field_simp
-  ring
+  field_simp <;> ring
 
 /-- Bound: `|intPolyHomogEval f r s| ≤ intPolyL1 f · max(|r|,|s|)^d` (triangle). -/
 theorem intPolyHomogEval_natAbs_le (f : ℤ[X]) (r s : ℤ) :

--- a/proofs/Proofs/LiouvilleTheoremOQ04.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ04.lean
@@ -891,30 +891,36 @@ PART V: MAIN THEOREM
 P-adic algebraic numbers are not p-adically Liouville
 ═══════════════════════════════════════════════════════════════════════════ -/
 
-/-- **Bridge Axiom**: Given the factorization f = (X - C α) · g in ℚ_[p][X] and the evaluation
-    identity f(x) = (x - α) · g(x), the p-adic Liouville estimate holds.
+/-- **Bridge Theorem (Session 15 — discharged)**: Given the factorization
+    f = (X - C α) · g in ℚ_[p][X] and the evaluation identity
+    f(x) = (x - α) · g(x), the p-adic Liouville estimate holds.
 
-    Status (post Part IV.8):
-    - Ingredient (1) (norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q):
-      ✓ PROVED in Part IV.5 as `norm_rat_eq_padicNorm`. Combined with
-      `padic_norm_int_poly_eval` this fully discharges the ℚ → ℚ_[p] bridge for `eval`.
-    - Ingredient (2a) (height bound on ℚ_[p]: ‖(r:ℚ_[p])/s‖ ≤ max(|r|,|s|)):
-      ✓ PROVED in Part IV.7 as `padic_norm_int_div_le_height`.
-    - Ingredient (2b) (uniform polynomial cofactor bound):
-      ✓ PROVED in Part IV.8 as `padic_polynomial_eval_norm_bound` and
-      `padic_cofactor_bound_rat`: for any g ∈ ℚ_[p][X], r, s : ℤ with s ≠ 0,
-      `‖g.eval ((r:ℚ_[p])/s)‖ ≤ coeffNormSum p g · H^(deg g)`.
+    Combines Part IV.10 (`padic_liouville_bridge_algebraic_case`, the
+    `f(r/s) ≠ 0` over ℚ branch) with Part IV.11
+    (`padic_liouville_bridge_rational_roots_case`, the rational-roots branch).
 
-    Remaining obstacle (now ONLY): assembling the algebra. The bridge requires
-    handling the case f(r/s) = 0 with r/s ≠ α (the finitely-many rational roots of
-    f distinct from α): for those, the formula ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ is the
-    indeterminate 0/0 (since heval forces g(r/s) = 0 too when r/s ≠ α and f(r/s) = 0).
-    We must take the constant C ≤ min ‖α - r₀‖ over the finite set of rational
-    roots r₀ ≠ α to cover this case directly.
+    Construction:
+    - Let `L := intPolyL1 f`, `M := coeffNormSum p g`, both positive (since
+      `f ≠ 0` from `hf_deg` and `g ≠ 0` from the factorization).
+    - The rational-roots case yields `δ > 0` separating α from every rational
+      root q of `f.map (algebraMap ℤ ℚ)` with `(q : ℚ_[p]) ≠ α`.
+    - Take `C' := min (1/(L·M)) δ`. Both factors are strictly positive, so
+      `C' > 0`.
 
-    Combined estimate (when f(r/s) ≠ 0):
-      ‖α - r/s‖ = ‖f(r/s)‖/‖g(r/s)‖ ≥ (C_f/H^d)/(M·H^(d-1)) = C/H^(2d-1) ≥ C/H^(2d). -/
-axiom padic_liouville_norm_bridge
+    Case split on `(f.map (algebraMap ℤ ℚ)).eval ((r : ℚ) / s) = 0` over ℚ
+    (decidable):
+    * If `≠ 0`: Part IV.10 gives `1/(L·M) / H^(2d) ≤ ‖α - r/s‖`. Since
+      `C' ≤ 1/(L·M)`, dividing by `H^(2d) > 0` preserves the inequality.
+    * If `= 0`: Part IV.11 gives `δ ≤ ‖α - ((r:ℚ)/s : ℚ_[p])‖`. The cast
+      `((r:ℚ)/s : ℚ_[p]) = (r:ℚ_[p])/s` (via `push_cast`) lets us conclude.
+      Since `H ≥ 1` (from `s ≠ 0`), we have `1 ≤ H^(2d)`, so
+      `C'/H^(2d) ≤ C' ≤ δ ≤ ‖α - r/s‖`.
+
+    The hypotheses `hfact` and `heval` are used only to derive
+    `g.natDegree + 1 ≤ f.natDegree` (degree bookkeeping for Part IV.10's
+    cofactor weakening). The factorization-from-root `hf_root + hf_deg`
+    ensures `f.natDegree ≥ 1`, in particular `f ≠ 0`. -/
+theorem padic_liouville_norm_bridge
     (α : ℚ_[p]) (f : ℤ[X])
     (hf_root : (f.map (algebraMap ℤ ℚ_[p])).eval α = 0)
     (hf_deg : 1 ≤ f.natDegree)
@@ -922,7 +928,117 @@ axiom padic_liouville_norm_bridge
     (hfact : f.map (algebraMap ℤ ℚ_[p]) = (X - C α) * g)
     (heval : ∀ x : ℚ_[p], (f.map (algebraMap ℤ ℚ_[p])).eval x = (x - α) * g.eval x) :
     ∃ C' : ℝ, 0 < C' ∧ ∀ r s : ℤ, s ≠ 0 → α ≠ (r : ℚ_[p]) / s →
-      C' / (max r.natAbs s.natAbs : ℝ) ^ (2 * f.natDegree) ≤ ‖α - (r : ℚ_[p]) / s‖
+      C' / (max r.natAbs s.natAbs : ℝ) ^ (2 * f.natDegree) ≤ ‖α - (r : ℚ_[p]) / s‖ := by
+  classical
+  -- `hf_root` and `heval` are bridge-shape hypotheses; we don't directly invoke
+  -- `hf_root` here (it is captured by `heval` at `x = α` if needed).
+  -- Step 1: f ≠ 0 from `hf_deg`.
+  have hf_ne : f ≠ 0 := by
+    intro h
+    rw [h, Polynomial.natDegree_zero] at hf_deg
+    omega
+  -- Step 2: `algebraMap ℤ ℚ_[p]` is injective.
+  have h_alg_inj_p : Function.Injective (algebraMap ℤ ℚ_[p]) := fun a b hab => by
+    have : (a : ℚ_[p]) = (b : ℚ_[p]) := by simpa [eq_intCast] using hab
+    exact_mod_cast this
+  -- Step 3: f.map alg ≠ 0 (uses injectivity).
+  have hf_map_ne : f.map (algebraMap ℤ ℚ_[p]) ≠ 0 := by
+    intro h
+    apply hf_ne
+    have hinj : Function.Injective (Polynomial.map (algebraMap ℤ ℚ_[p])) :=
+      Polynomial.map_injective _ h_alg_inj_p
+    apply hinj
+    rw [Polynomial.map_zero]; exact h
+  -- Step 4: g ≠ 0 from the factorization + f.map alg ≠ 0.
+  have hg_ne : g ≠ 0 := by
+    intro hg0
+    apply hf_map_ne
+    rw [hfact, hg0, mul_zero]
+  -- Step 5: degree relation `g.natDegree + 1 ≤ f.natDegree`.
+  have hX_sub_C_ne : (X - C α : Polynomial ℚ_[p]) ≠ 0 := X_sub_C_ne_zero α
+  have h_natDeg_prod :
+      ((X - C α : Polynomial ℚ_[p]) * g).natDegree =
+        (X - C α : Polynomial ℚ_[p]).natDegree + g.natDegree :=
+    Polynomial.natDegree_mul hX_sub_C_ne hg_ne
+  have h_natDeg_X_sub_C : (X - C α : Polynomial ℚ_[p]).natDegree = 1 :=
+    Polynomial.natDegree_X_sub_C α
+  have h_natDeg_map_le : (f.map (algebraMap ℤ ℚ_[p])).natDegree ≤ f.natDegree :=
+    Polynomial.natDegree_map_le
+  have hg_deg_le : g.natDegree + 1 ≤ f.natDegree := by
+    have h_eq : (f.map (algebraMap ℤ ℚ_[p])).natDegree = 1 + g.natDegree := by
+      rw [hfact, h_natDeg_prod, h_natDeg_X_sub_C]
+    omega
+  -- Step 6: rational-roots case (Part IV.11) — uniform δ > 0.
+  obtain ⟨δ, hδ_pos, hδ⟩ :=
+    padic_liouville_bridge_rational_roots_case p α f hf_ne
+  -- Step 7: name L = intPolyL1 f, M = coeffNormSum p g; both positive.
+  set L : ℝ := (intPolyL1 f : ℝ) with hL_def
+  set M : ℝ := coeffNormSum p g with hM_def
+  have hL_pos_n : 0 < intPolyL1 f := intPolyL1_pos hf_ne
+  have hL_pos : 0 < L := by rw [hL_def]; exact_mod_cast hL_pos_n
+  have hM_pos : 0 < M := by
+    rw [hM_def, coeffNormSum]
+    refine Finset.sum_pos (fun i hi => ?_) (Polynomial.support_nonempty.mpr hg_ne)
+    rw [norm_pos_iff]
+    exact Polynomial.mem_support_iff.mp hi
+  have hLM_pos : 0 < L * M := mul_pos hL_pos hM_pos
+  have h_inv_LM_pos : 0 < 1 / (L * M) := one_div_pos.mpr hLM_pos
+  -- Step 8: define the witness `C' := min (1/(L·M)) δ`, strictly positive.
+  refine ⟨min (1 / (L * M)) δ, lt_min h_inv_LM_pos hδ_pos, ?_⟩
+  intro r s hs hαne
+  set H : ℝ := (max r.natAbs s.natAbs : ℝ) with hH_def
+  -- H ≥ 1 from `s ≠ 0`.
+  have hs_natAbs_pos : 0 < s.natAbs := Int.natAbs_pos.mpr hs
+  have hH_n_ge_one : 1 ≤ max r.natAbs s.natAbs :=
+    le_trans hs_natAbs_pos (Nat.le_max_right _ _)
+  have hH_one : (1 : ℝ) ≤ H := by rw [hH_def]; exact_mod_cast hH_n_ge_one
+  have hH_pos : 0 < H := lt_of_lt_of_le zero_lt_one hH_one
+  have hHpow_pos : 0 < H ^ (2 * f.natDegree) := pow_pos hH_pos _
+  have hHpow_ge_one : (1 : ℝ) ≤ H ^ (2 * f.natDegree) :=
+    one_le_pow₀ hH_one
+  -- Step 9: case split on `(f.map (algebraMap ℤ ℚ)).eval ((r : ℚ) / s) ?= 0`.
+  by_cases hf_eval :
+      (f.map (algebraMap ℤ ℚ)).eval ((r : ℚ) / s) = 0
+  · -- Rational-roots branch: q := (r:ℚ)/s is a rational root of f.map alg'.
+    -- Part IV.11 expects `α ≠ (q : ℚ_[p])`; transport from `hαne`.
+    have h_cast_eq :
+        (((r : ℚ) / s : ℚ) : ℚ_[p]) = (r : ℚ_[p]) / s := by push_cast; rfl
+    have h_α_ne_cast : α ≠ (((r : ℚ) / s : ℚ) : ℚ_[p]) := by
+      rw [h_cast_eq]; exact hαne
+    -- Apply Part IV.11 to q := (r:ℚ)/s.
+    have h_lb : δ ≤ ‖α - (((r : ℚ) / s : ℚ) : ℚ_[p])‖ :=
+      hδ ((r : ℚ) / s) hf_eval h_α_ne_cast
+    rw [h_cast_eq] at h_lb
+    -- min ≤ δ, and dividing by H^(2d) ≥ 1 weakens.
+    have h_min_le_δ : min (1 / (L * M)) δ ≤ δ := min_le_right _ _
+    have h_min_pos : 0 < min (1 / (L * M)) δ := lt_min h_inv_LM_pos hδ_pos
+    have h_div_le_min :
+        min (1 / (L * M)) δ / H ^ (2 * f.natDegree) ≤ min (1 / (L * M)) δ := by
+      rw [div_le_iff₀ hHpow_pos]
+      calc min (1 / (L * M)) δ
+          = min (1 / (L * M)) δ * 1 := by ring
+        _ ≤ min (1 / (L * M)) δ * H ^ (2 * f.natDegree) :=
+            mul_le_mul_of_nonneg_left hHpow_ge_one h_min_pos.le
+    linarith
+  · -- Algebraic branch: apply Part IV.10.
+    have h_alg :
+        1 / ((intPolyL1 f : ℝ) * coeffNormSum p g) /
+            (max r.natAbs s.natAbs : ℝ) ^ (2 * f.natDegree) ≤
+          ‖α - (r : ℚ_[p]) / s‖ :=
+      padic_liouville_bridge_algebraic_case p α f hf_ne g hg_ne hg_deg_le
+        heval r s hs hαne hf_eval
+    -- Rewrite via L, M, H.
+    have h_alg' :
+        1 / (L * M) / H ^ (2 * f.natDegree) ≤
+          ‖α - (r : ℚ_[p]) / s‖ := by
+      rw [hL_def, hM_def, hH_def]; exact h_alg
+    -- min ≤ 1/(L·M) ⇒ min/H^(2d) ≤ (1/(L·M))/H^(2d).
+    have h_min_le_inv : min (1 / (L * M)) δ ≤ 1 / (L * M) := min_le_left _ _
+    have h_div_mono :
+        min (1 / (L * M)) δ / H ^ (2 * f.natDegree) ≤
+          1 / (L * M) / H ^ (2 * f.natDegree) :=
+      (div_le_div_iff_of_pos_right hHpow_pos).mpr h_min_le_inv
+    linarith
 
 /-- **P-adic Liouville Theorem** (key estimate):
     If α ∈ ℚ_[p] is algebraic over ℚ with a polynomial f ∈ ℤ[X] of degree d having α as root,

--- a/proofs/Proofs/LiouvilleTheoremOQ04.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ04.lean
@@ -464,8 +464,13 @@ theorem intPolyL1_pos {f : ℤ[X]} (hf : f ≠ 0) : 0 < intPolyL1 f := by
   have hcoeff : f.coeff i ≠ 0 := Polynomial.mem_support_iff.mp hi
   have hpos : 0 < (f.coeff i).natAbs := Int.natAbs_pos.mpr hcoeff
   refine lt_of_lt_of_le hpos ?_
-  -- Lean 4.26: use fully positional args (named `(f := ...)` may shadow local `f : ℤ[X]`)
-  exact Finset.single_le_sum (fun _ _ => Nat.zero_le _) hi
+  -- Unfold so the function being summed is explicit, side-stepping the
+  -- `f` name clash between the local polynomial and `Finset.single_le_sum`'s
+  -- implicit summand argument.
+  show (f.coeff i).natAbs ≤ f.support.sum (fun j => (f.coeff j).natAbs)
+  exact Finset.single_le_sum
+    (f := fun j => (Polynomial.coeff f j).natAbs)
+    (fun _ _ => Nat.zero_le _) hi
 
 /-- "Homogenized integer evaluation": `intPolyHomogEval f r s = ∑ aᵢ · r^i · s^(d-i)`
     over `i ∈ f.support`, where d = f.natDegree. By construction,
@@ -504,8 +509,9 @@ theorem intPolyHomogEval_cast_eq (f : ℤ[X]) (r s : ℤ) (hs : s ≠ 0) :
     rw [← pow_add, Nat.sub_add_cancel hi_le]
   rw [hpow_split, div_pow]
   have hsi_ne : ((s : ℚ))^i ≠ 0 := pow_ne_zero _ hs_q
-  -- Lean 4.26: `(algebraMap ℤ ℚ) z` is not definitionally `↑z`; reduce explicitly.
-  simp only [Int.algebraMap_eq_intCast]
+  -- Lean 4.26: `(algebraMap ℤ ℚ) z` reduces to the integer cast via `eq_intCast`
+  -- (the previous `Int.algebraMap_eq_intCast` lemma was renamed/removed).
+  simp only [eq_intCast]
   field_simp
   ring
 
@@ -854,8 +860,12 @@ theorem padic_liouville_bridge_rational_roots_case
     have hinj : Function.Injective (Polynomial.map (algebraMap ℤ ℚ)) :=
       Polynomial.map_injective (algebraMap ℤ ℚ) h_alg_inj
     apply hinj
-    simp [hfQ_def] at h0
-    rw [Polynomial.map_zero, h0]
+    -- Goal: `f.map (algebraMap ℤ ℚ) = (0 : ℤ[X]).map (algebraMap ℤ ℚ)`. Rewrite
+    -- the RHS via `Polynomial.map_zero`, then transport `h0 : fQ = 0` back to
+    -- the goal via `← hfQ_def` (avoids `simp` unfolding `algebraMap` to
+    -- `Int.castRingHom`, which broke the subsequent `rw [h0]`).
+    rw [Polynomial.map_zero, ← hfQ_def]
+    exact h0
   -- Finite set of rational roots of fQ; filter to those distinct (in ℚ_[p]) from α.
   let R : Finset ℚ := fQ.roots.toFinset
   let R' : Finset ℚ := R.filter (fun q : ℚ => (q : ℚ_[p]) ≠ α)
@@ -946,7 +956,7 @@ theorem padic_liouville_norm_bridge
     intro h
     apply hf_ne
     have hinj : Function.Injective (Polynomial.map (algebraMap ℤ ℚ_[p])) :=
-      Polynomial.map_injective _ h_alg_inj_p
+      Polynomial.map_injective (algebraMap ℤ ℚ_[p]) h_alg_inj_p
     apply hinj
     rw [Polynomial.map_zero]; exact h
   -- Step 4: g ≠ 0 from the factorization + f.map alg ≠ 0.
@@ -1021,17 +1031,17 @@ theorem padic_liouville_norm_bridge
             mul_le_mul_of_nonneg_left hHpow_ge_one h_min_pos.le
     linarith
   · -- Algebraic branch: apply Part IV.10.
-    have h_alg :
-        1 / ((intPolyL1 f : ℝ) * coeffNormSum p g) /
-            (max r.natAbs s.natAbs : ℝ) ^ (2 * f.natDegree) ≤
-          ‖α - (r : ℚ_[p]) / s‖ :=
-      padic_liouville_bridge_algebraic_case p α f hf_ne g hg_ne hg_deg_le
-        heval r s hs hαne hf_eval
-    -- Rewrite via L, M, H.
+    -- Build the algebraic-case bound directly in terms of L, M, H — defeq via the
+    -- `set` let-bindings — to avoid a `set + rw` round-trip that can fail to
+    -- match `L` in the goal against `(intPolyL1 f : ℝ)` in the lemma's output.
     have h_alg' :
         1 / (L * M) / H ^ (2 * f.natDegree) ≤
           ‖α - (r : ℚ_[p]) / s‖ := by
-      rw [hL_def, hM_def, hH_def]; exact h_alg
+      show 1 / ((intPolyL1 f : ℝ) * coeffNormSum p g) /
+          (max r.natAbs s.natAbs : ℝ) ^ (2 * f.natDegree) ≤
+            ‖α - (r : ℚ_[p]) / s‖
+      exact padic_liouville_bridge_algebraic_case p α f hf_ne g hg_ne hg_deg_le
+        heval r s hs hαne hf_eval
     -- min ≤ 1/(L·M) ⇒ min/H^(2d) ≤ (1/(L·M))/H^(2d).
     have h_min_le_inv : min (1 / (L * M)) δ ≤ 1 / (L * M) := min_le_left _ _
     have h_div_mono :

--- a/src/data/research/problems/liouville-theorem-oq-04.json
+++ b/src/data/research/problems/liouville-theorem-oq-04.json
@@ -17,19 +17,19 @@
   },
   "currentState": {
     "phase": "REFINE",
-    "since": "2026-05-08T06:30:00.000Z",
-    "iteration": 14,
-    "focus": "Part IV.11 (`padic_liouville_bridge_rational_roots_case`) added in Session 14. A fully-proved theorem (no new axioms, no sorries) that discharges the **rational-roots case** of `padic_liouville_norm_bridge`. Construction: form Finset R' of rational roots q with (q:ℚ_[p]) ≠ α (finite, ≤ deg f); when nonempty take δ = R'.inf' (q ↦ ‖α - (q:ℚ_[p])‖) — strictly positive via `Finset.lt_inf'_iff` since each entry is the norm of a nonzero element; when empty take δ = 1 (vacuous). Together with Part IV.10 (algebraic case, Session 13), BOTH case-analysis pieces are now proved. The bridge axiom can now be discharged in a single combine-and-case-split session.",
+    "since": "2026-05-08T11:00:00.000Z",
+    "iteration": 15,
+    "focus": "Session 15 (this) — `padic_liouville_norm_bridge` rewritten from `axiom` to `theorem`. Composes Part IV.10 (`padic_liouville_bridge_algebraic_case`, Session 13) and Part IV.11 (`padic_liouville_bridge_rational_roots_case`, Session 14): C' := min(1/(L·M), δ) with case split on (f.map alg').eval ((r:ℚ)/s) ?= 0 over ℚ. Degree bookkeeping (g.natDegree + 1 ≤ f.natDegree) comes from `Polynomial.natDegree_mul` + `natDegree_X_sub_C` + `Polynomial.natDegree_map_le`. f ≠ 0 derived from hf_deg; g ≠ 0 from the factorization; algebraMap ℤ ℚ_[p] injectivity via integer-cast → ratCast composition. Lean file: 1216 → 1333 lines, 34 → 35 theorems, 1 → 0 axioms (build pending; meta.json status update deferred to a post-build follow-up PR).",
     "blockers": [],
-    "nextAction": "Session 15 (next): combine Part IV.10 (algebraic case) + Part IV.11 (rational-roots case) to discharge `padic_liouville_norm_bridge` from axiom to theorem. Take C := min(1/(L·M), δ); case-split on (f.map alg').eval (r/s) ?= 0 over ℚ. After discharge: axiomCount 1 → 0, status axiomatized → verified, badge axiom → original.",
+    "nextAction": "Session 16 (next, if build verifies): update meta.json status `axiomatized` → `verified`, badge `axiom` → `original`, axiomCount 1 → 0, lineCount 1216 → 1333, theoremCount 34 → 35; refresh assumptions/conclusion narratives. If the build fails: triage Mathlib 4.26 API drift in the new theorem (`Polynomial.natDegree_map_le`, `div_le_div_iff_of_pos_right`, `set`+`rw` round-trip) and push corrective commits.",
     "attemptCounts": {
-      "total": 13,
-      "currentApproach": 6,
+      "total": 14,
+      "currentApproach": 7,
       "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 14, 2026-05-08): Added Part IV.11 — `padic_liouville_bridge_rational_roots_case`, a fully-proved theorem (no new axioms, no sorries) that discharges the **rational-roots case** of `padic_liouville_norm_bridge`. For any α : ℚ_[p] and any non-zero f ∈ ℤ[X], there exists δ > 0 such that for every rational q with (f.map (algebraMap ℤ ℚ)).eval q = 0 and (q : ℚ_[p]) ≠ α, δ ≤ ‖α - (q : ℚ_[p])‖. Construction: form the Finset R' = (f.map alg').roots.toFinset filtered by (q : ℚ_[p]) ≠ α (finite of cardinality ≤ deg f). When R' is non-empty, take δ = R'.inf' (q ↦ ‖α - (q : ℚ_[p])‖); positivity from Finset.lt_inf'_iff because each entry is the norm of a non-zero element. When R' is empty, take δ = 1 (vacuous). The non-zero hypothesis on f is required — for f = 0, every rational is a root and rationals can approach α arbitrarily closely in ℚ_[p]. Combined with Part IV.10 (algebraic case, Session 13), BOTH case-analysis pieces of the bridge axiom are now formally proved. The bridge axiom can be discharged in a single combine-and-case-split session by taking C := min((1/(L·M)), δ) and case-splitting on (f.map alg').eval (r/s) ?= 0 over ℚ. Status: 1 axiom (unchanged), 0 sorries, 1216 lines, 34 theorems, 6 defs. Build pending per established convention on this slug (cold-cache Docker ~45 min).",
+    "progressSummary": "PROGRESS (Session 15, 2026-05-08): `padic_liouville_norm_bridge` rewritten from `axiom` to fully-proved `theorem` by composing the two Session 13/14 ingredients. Witness: C' := min(1/(L·M), δ) where L = intPolyL1 f, M = coeffNormSum p g, δ from Part IV.11. Case split on (f.map (algebraMap ℤ ℚ)).eval ((r:ℚ)/s) ?= 0 over ℚ — nonzero branch dispatches to Part IV.10 (`padic_liouville_bridge_algebraic_case`); zero branch dispatches to Part IV.11 (`padic_liouville_bridge_rational_roots_case`) with `push_cast; rfl` to bridge the cast `((r:ℚ)/s : ℚ_[p]) = (r:ℚ_[p])/s`. Bookkeeping: f ≠ 0 from hf_deg ≥ 1; algebraMap ℤ ℚ_[p] injective via the integer-cast → ratCast factoring with `simpa [eq_intCast]` + `exact_mod_cast`; f.map alg ≠ 0 by `Polynomial.map_injective`; g ≠ 0 from the factorization; degree relation `g.natDegree + 1 ≤ f.natDegree` from `Polynomial.natDegree_mul` + `natDegree_X_sub_C` + `Polynomial.natDegree_map_le` (no injectivity needed for the natDegree_map step). The new theorem occupies ~120 lines (894–1042) and is 0-sorry, 0-axiom. After the proof, padic_liouville_estimate (and through it padic_algebraic_not_liouville) become axiom-free as well: the entire file is 0 axioms, 0 sorries — pending build verification (cold-cache Docker ~45 min). Status accounting (post-build): axiomCount 1 → 0, theoremCount 34 → 35, lineCount 1216 → 1333. meta.json status update from `axiomatized` to `verified` deferred to a follow-up PR after the build finishes (per slug convention).",
     "builtItems": [
       "IsPadicLiouville (LiouvilleTheoremOQ04.lean): definition with strict positivity 0 < ‖β - r/s‖ and height bound 2 ≤ max r.natAbs s.natAbs",
       "padic_liouville_estimate: proved via factorization + bridge axiom — exposes the standard (C/H^(2d)) lower bound",
@@ -54,7 +54,8 @@
       "padicNorm_intCast_pow_le_one (Part IV.9, NEW Session 12, private): padicNorm p ((s:ℚ)^d) ≤ 1 by induction on d",
       "padicNorm_int_poly_eval_uniform_lb (Part IV.9, NEW Session 12, MAIN RESULT): UNIFORM lower bound 1/(intPolyL1 f · H^d) ≤ padicNorm p ((f.map alg).eval (r/s)) for nonzero f, s, eval — the structural piece making bridge discharge possible",
       "padic_liouville_bridge_algebraic_case (Part IV.10, NEW Session 13, MAIN RESULT): Algebraic case of the bridge — for f ≠ 0, g ≠ 0 cofactor with `g.natDegree + 1 ≤ f.natDegree` and the heval identity, when `f.eval(r/s) ≠ 0` over ℚ, `1/(intPolyL1 f · coeffNormSum p g) / max(|r|,|s|)^(2·f.natDegree) ≤ ‖α - (r:ℚ_[p])/s‖`. Composes Parts IV.5/6/8/9 — no new axioms. The bridge axiom now factors cleanly into algebraic case (proved) + rational-roots case (open).",
-      "padic_liouville_bridge_rational_roots_case (Part IV.11, NEW Session 14, MAIN RESULT): Rational-roots case of the bridge — for f ≠ 0, there exists δ > 0 such that for every rational q with (f.map (algebraMap ℤ ℚ)).eval q = 0 and (q : ℚ_[p]) ≠ α, the bound δ ≤ ‖α - (q : ℚ_[p])‖ holds. Construction: form the Finset R' = (f.map alg').roots.toFinset filtered by (q : ℚ_[p]) ≠ α (finite, ≤ deg f). Non-empty case: δ := R'.inf' (q ↦ ‖α - (q:ℚ_[p])‖), positivity from `Finset.lt_inf'_iff`. Empty case: δ := 1 (vacuous). Combined with Part IV.10, ALL ingredients of the bridge axiom are formally proved — discharge is now a single combine-and-case-split session."
+      "padic_liouville_bridge_rational_roots_case (Part IV.11, NEW Session 14, MAIN RESULT): Rational-roots case of the bridge — for f ≠ 0, there exists δ > 0 such that for every rational q with (f.map (algebraMap ℤ ℚ)).eval q = 0 and (q : ℚ_[p]) ≠ α, the bound δ ≤ ‖α - (q : ℚ_[p])‖ holds. Construction: form the Finset R' = (f.map alg').roots.toFinset filtered by (q : ℚ_[p]) ≠ α (finite, ≤ deg f). Non-empty case: δ := R'.inf' (q ↦ ‖α - (q:ℚ_[p])‖), positivity from `Finset.lt_inf'_iff`. Empty case: δ := 1 (vacuous). Combined with Part IV.10, ALL ingredients of the bridge axiom are formally proved — discharge is now a single combine-and-case-split session.",
+      "padic_liouville_norm_bridge (Part V — DISCHARGED Session 15, MAIN RESULT): The bridge axiom is now a fully-proved theorem. C' := min(1/(L·M), δ); case split on (f.map alg').eval ((r:ℚ)/s) ?= 0 over ℚ — nonzero → Part IV.10, zero → Part IV.11 (with `((r:ℚ)/s : ℚ_[p]) = (r:ℚ_[p])/s` cast via `push_cast; rfl`). Bookkeeping: f ≠ 0 from `hf_deg`, `algebraMap ℤ ℚ_[p]` injective via integer-cast→ratCast, f.map alg ≠ 0 by `Polynomial.map_injective`, g ≠ 0 from factorization, g.natDegree+1 ≤ f.natDegree from `natDegree_mul + natDegree_X_sub_C + Polynomial.natDegree_map_le`. ~120 lines (894–1042). After discharge: file is 0-axiom, 0-sorry (build pending; meta.json status update deferred to follow-up PR)."
     ],
     "insights": [
       "IsPadicLiouville needs both 2 ≤ max(|r|,|s|) and 0 < ‖β - r/s‖. Without H≥2, bound 1/H^n=1 gives no useful constraint. Without strict positivity, every rational is trivially Liouville (r/s = β gives ‖β - r/s‖ = 0).",
@@ -80,9 +81,9 @@
       "Polynomial evaluation norm bound `‖g.eval x‖ ≤ M · max(1, ‖x‖)^(deg g)` for normed semirings (we proved padic_polynomial_eval_norm_bound directly via norm_sum_le)"
     ],
     "nextSteps": [
-      "Combine Part IV.10 (algebraic case, Session 13) + Part IV.11 (rational-roots case, Session 14, NEW) into a proved version of padic_liouville_norm_bridge. Take C := min(1/(L·M), δ). Case-split on (f.map alg').eval (r/s) over ℚ: nonzero case → Part IV.10; zero case → Part IV.11. Estimated 80-120 lines.",
-      "After bridge discharge: file is axiom-free (verified status). Update meta.json status from 'axiomatized' to 'verified' and badge from 'axiom' to 'original' (from-scratch p-adic Liouville).",
-      "Follow-up open questions to consider after verification: (a) function-field analog over F_q(t) with t-adic absolute value; (b) Roth-style sharpening from H^d to H^(2+ε); (c) multi-place generalization simultaneous for all primes."
+      "S16 (post-build): update meta.json status `axiomatized` → `verified`, badge `axiom` → `original`, axiomCount 1 → 0, lineCount 1216 → 1333, theoremCount 34 → 35; refresh `assumptions`, `description`, and `conclusion` narratives to drop the bridge-axiom language; update candidate-pool status `in-progress` → `completed`.",
+      "Follow-up OQ candidates (after verified): (a) function-field analog over F_q(t) with t-adic absolute value (mirrors Mahler's framework — would need a Mathlib `LaurentSeries` p-adic analog); (b) Roth-style sharpening from H^(2d) to H^(2+ε) (much harder — Roth's theorem is the classical analog and required Fields Medal-level techniques); (c) multi-place generalization (∀ primes p simultaneously, the same algebraic α has μ_p ≤ d) — corresponds to Mahler's classification refined per-place.",
+      "If build fails: triage Mathlib 4.26 API drift (`Polynomial.natDegree_map_le` arg form, `div_le_div_iff_of_pos_right` availability, `set L := ... with hL_def` + `rw [hL_def]` round-trip) and push corrective commits to the same PR."
     ]
   },
   "tags": [
@@ -102,7 +103,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.505Z",
-  "lastUpdate": "2026-05-08T09:00:00.000Z",
+  "lastUpdate": "2026-05-08T11:30:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Replace `padic_liouville_norm_bridge` axiom with a proved theorem by composing the two case-analysis pieces:

- **Part IV.10** (`padic_liouville_bridge_algebraic_case`, Session 13) for the `f(r/s) ≠ 0` over ℚ branch.
- **Part IV.11** (`padic_liouville_bridge_rational_roots_case`, Session 14) for the rational-roots branch.

Witness: `C' := min (1/(L·M)) δ` with `L = intPolyL1 f`, `M = coeffNormSum p g`, `δ` from Part IV.11. Case split on `(f.map (algebraMap ℤ ℚ)).eval ((r:ℚ)/s) ?= 0` over ℚ.

## Bookkeeping derived in the proof

- `f ≠ 0` from `hf_deg : 1 ≤ f.natDegree`.
- `algebraMap ℤ ℚ_[p]` injective via `simpa [eq_intCast]` + `exact_mod_cast` (integer-cast → ratCast composition).
- `f.map alg ≠ 0` by `Polynomial.map_injective`.
- `g ≠ 0` from the factorization `f.map alg = (X - C α) * g` and `f.map alg ≠ 0`.
- `g.natDegree + 1 ≤ f.natDegree` from `Polynomial.natDegree_mul` + `Polynomial.natDegree_X_sub_C` + `Polynomial.natDegree_map_le` (no injectivity needed for the `natDegree_map` step).

## Cast bridge in the rational-roots branch

```lean
have h_cast_eq : (((r : ℚ) / s : ℚ) : ℚ_[p]) = (r : ℚ_[p]) / s := by push_cast; rfl
```

Lets us apply Part IV.11 (which speaks of `(q : ℚ)`) and rewrite the bound back to `‖α - (r:ℚ_[p])/s‖` form.

## Counts (post-PR, post-build)

- Lean file: **1216 → 1333 lines**, axiomCount **1 → 0**, theoremCount **34 → 35**, defCount unchanged at 6, sorries unchanged at 0.
- Build status: **pending** — per established slug convention (cold-cache Docker ~45 min). The build was launched in this session and was at 74 % cache download when this PR was created.
- meta.json `status` / `badge` update from `axiomatized` / `axiom` to `verified` / `original` is **deferred to a follow-up PR** after build verification, consistent with the existing pattern for this slug (S14 was also titled "build pending").

## Test plan

- [ ] Docker build (`./proofs/scripts/docker-build.sh Proofs.LiouvilleTheoremOQ04`) succeeds.
- [ ] Once verified, follow-up PR updates `src/data/proofs/liouville-theorem-oq-04/meta.json` to `verified` status, refreshes `assumptions` / `description` / `conclusion` narratives to drop the bridge-axiom language, and bumps line/theorem counts.
- [ ] Candidate-pool status moves from `in-progress` → `completed` after the meta.json PR lands.

## Risks / unknowns

- Mathlib 4.26 API drift — main lemma names used (`Polynomial.natDegree_map_le`, `(div_le_div_iff_of_pos_right _).mpr`, `one_le_pow₀`, `X_sub_C_ne_zero`, `Polynomial.support_nonempty`, `Polynomial.map_injective`) all appear elsewhere in the repo on the same Lean version, so the names should be stable.
- The `set L := ... with hL_def` + `rw [hL_def, hM_def, hH_def]` round-trip is a risk; if the rewrite fails on `set` let-bindings, the algebraic branch can be inlined without `set`.

🤖 Generated by researcher-9