### PR TITLE
audit: batched re-audit clean for 9 entries (2026-05-08)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8334,12 +8334,12 @@
       "result": "clean"
     },
     "erdos-606-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "badge axiom->wip (fixed by PR #11028)"
       ],
-      "lastAudited": "2026-04-24T00:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T10:54:10Z",
+      "result": "clean"
     },
     "erdos-606-oq-03-oq-03": {
       "auditCount": 2,
@@ -13214,9 +13214,9 @@
       "result": "clean"
     },
     "sqrt2-minpoly-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:35Z",
+      "lastAudited": "2026-05-08T10:54:10Z",
       "result": "clean"
     },
     "sqrt2-plus-sqrt3-irrational": {
@@ -13453,9 +13453,9 @@
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:36Z",
+      "lastAudited": "2026-05-08T10:54:10Z",
       "result": "clean"
     },
     "taylor-theorem": {
@@ -13465,9 +13465,9 @@
       "result": "clean"
     },
     "taylor-theorem-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:36Z",
+      "lastAudited": "2026-05-08T10:54:10Z",
       "result": "clean"
     },
     "taylor-theorem-oq-03": {
@@ -13507,15 +13507,15 @@
       "result": "clean"
     },
     "triangle-angle-sum-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:37Z",
+      "lastAudited": "2026-05-08T10:54:10Z",
       "result": "clean"
     },
     "triangle-angle-sum-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:37Z",
+      "lastAudited": "2026-05-08T10:54:10Z",
       "result": "clean"
     },
     "triangle-inequality": {
@@ -13578,9 +13578,9 @@
       "result": "clean"
     },
     "vietas-formulas-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:37Z",
+      "lastAudited": "2026-05-08T10:54:10Z",
       "result": "clean"
     },
     "vietas-formulas-oq-03": {
@@ -13602,9 +13602,9 @@
       "result": "clean"
     },
     "weak-goldbach": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-24T00:00:00Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-08T10:54:10Z",
+      "result": "clean"
     },
     "wilsons-theorem": {
       "auditCount": 3,
@@ -13700,9 +13700,9 @@
       "result": "clean"
     },
     "yang-mills-lattice-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:37Z",
+      "lastAudited": "2026-05-08T10:54:10Z",
       "result": "clean"
     },
     "yang-mills-transfer-matrix": {


### PR DESCRIPTION
## Summary

Re-audited 9 gallery entries last audited 2026-04-23 / 2026-04-24. All structural counts (sorries, axioms, theorems, definitions, lineCount) match Lean source on origin/main. Marked clean.

## Entries

| ID | status/badge | counts (s/a/t/d/lines) | prior result |
|---|---|---|---|
| sqrt2-minpoly-oq-02 | verified/original | 0/0/21/0/202 ✓ | clean |
| taylor-theorem-oq-02 | verified/original | 0/0/9/0/218 ✓ | clean |
| taylor-sincos-convergence-oq-04 | verified/mathlib | 0/0/18/1/324 ✓ | clean |
| yang-mills-lattice-oq-01 | axiomatized/axiom | 0/2/28/11/579 ✓ | clean |
| vietas-formulas-oq-02 | verified/original | 0/0/10/10/204 ✓ | clean |
| triangle-angle-sum-oq-02 | axiomatized/axiom | 0/0/25/2/382 ✓ (lf=0; meta=3 chain count) | clean |
| triangle-angle-sum-oq-03 | verified/original | 0/0/6/0/140 ✓ | clean |
| weak-goldbach | axiomatized/axiom | 0/9/24/15/480 ✓ | issues-fixed→clean |
| erdos-606-oq-03 | axiomatized/wip | 0/0/3/0/100 ✓ | issues-fixed→clean |

## Patch shape

40-line surgical patch via `re.sub` (preserves `—`/`→` Unicode escapes); avoids the 250+-line `ensure_ascii=False` rewrite that `claim-target.sh complete` produces and that concurrent-agent main-repo resets clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)