### PR TITLE
audit: bump audit-tracker for 10 stale verified entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1096,12 +1096,12 @@
       "result": "clean"
     },
     "birch-swinnerton-dyer": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [
         "True-stub defs (p_adic_L_function, HeegnerPointExists, p_adic_height_pairing) added to meta.assumptions"
       ],
-      "lastAudited": "2026-04-24T00:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T11:04:20Z",
+      "result": "clean"
     },
     "birch-swinnerton-dyer-oq-06": {
       "auditCount": 2,
@@ -1609,9 +1609,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T04:27:46Z",
+      "lastAudited": "2026-05-08T11:04:20Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-02": {
@@ -7595,14 +7595,14 @@
     },
     "erdos-512": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
+      "auditCount": 4,
       "issuesFixed": [
         "stale originalContributions items (#12149)",
         "annotation L1norm_upper_bound incorrectly labelled (sorry) \u2014 proved",
         "annotation L2_norm incorrectly labelled (sorry) \u2014 proved pending expSumNorm_sq_double; range updated to 257-295"
       ],
-      "lastAudited": "2026-04-24T05:03:47Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T11:04:20Z",
+      "result": "clean"
     },
     "erdos-513": {
       "agentId": "auditor-cycle-20-batch",
@@ -11257,9 +11257,9 @@
       "result": "clean"
     },
     "fair-games-theorem-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T04:27:46Z",
+      "lastAudited": "2026-05-08T11:04:20Z",
       "result": "clean"
     },
     "fair-games-theorem-oq-02-oq-04": {
@@ -12039,10 +12039,10 @@
       "result": "clean"
     },
     "konigsberg-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T09:11:12Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T11:04:20Z",
+      "result": "clean"
     },
     "konigsberg-oq-03": {
       "auditCount": 5,
@@ -12389,9 +12389,9 @@
       "result": "clean"
     },
     "minkowski-fundamental-theorem-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T04:27:46Z",
+      "lastAudited": "2026-05-08T11:04:20Z",
       "result": "clean"
     },
     "minkowski-theorem": {
@@ -12401,9 +12401,9 @@
       "result": "clean"
     },
     "minkowski-theorem-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T11:04:20Z",
       "result": "clean"
     },
     "morleys-theorem": {
@@ -13136,9 +13136,9 @@
       "result": "clean"
     },
     "sperner-ndim-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T11:04:20Z",
       "result": "clean"
     },
     "sperner-ndim-oq-03": {
@@ -13226,9 +13226,9 @@
       "result": "clean"
     },
     "sqrt2-plus-sqrt3-irrational-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:35Z",
+      "lastAudited": "2026-05-08T11:04:20Z",
       "result": "clean"
     },
     "stirling-formula": {
@@ -13714,9 +13714,9 @@
       "result": "issues-fixed"
     },
     "yang-mills-transfer-matrix-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T04:27:46Z",
+      "lastAudited": "2026-05-08T11:04:20Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03": {
@@ -15072,5 +15072,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-08T09:30:00Z"
+  "lastUpdated": "2026-05-08T11:04:20Z"
 }


### PR DESCRIPTION
## Summary

Re-audited 10 stale gallery entries (last audit ≥ 2 weeks ago). All confirmed clean — meta.json counts and narrative match the Lean source on origin/main.

## Audited entries

| Slug | Status / Badge | LineCount | Axioms | Sorries | Theorems |
|------|----------------|-----------|--------|---------|----------|
| sqrt2-plus-sqrt3-irrational-oq-03 | verified / mathlib | 403 | 0 | 0 | 8 |
| birch-swinnerton-dyer | axiomatized / axiom | 7435 | 38 (17 axiom + 21 opaque) | 0 | 254 |
| yang-mills-transfer-matrix-oq-01 | axiomatized / axiom | 510 | 1 | 0 | 19 |
| minkowski-fundamental-theorem-oq-04 | verified / mathlib | 192 | 0 | 0 | 11 |
| fair-games-theorem-oq-02-oq-01-oq-01 | verified / original | 361 | 0 | 0 | 12 |
| cauchy-schwarz-integral-oq-01-oq-03-oq-01 | verified / mathlib | 176 | 0 | 0 | 6 |
| erdos-512 | axiomatized / axiom | 368 | 2 | 0 | 14 |
| konigsberg-oq-02-oq-01 | verified / mathlib | 954 | 0 | 0 | 17 |
| sperner-ndim-oq-01 | verified / original | 220 | 0 | 0 | 8 |
| minkowski-theorem-oq-02 | axiomatized / axiom | 284 | 3 | 0 | 6 |

All counts cross-checked against `git show origin/main:proofs/<path>` (comment-stripped). Narrative spot-checks: BSD title and assumptions disclose all 38 axioms; Yang-Mills title is appropriately scoped to "infinite-volume mass gap" with the strong-coupling axiom called out.

## Tracker mechanics

Surgical `re.sub` edits to `src/data/proofs/audit-tracker.json` (per memory: `json.dump` would reformat unrelated entries). Diff:
- 10 entries: `auditCount += 1`, `lastAudited` and `result` updated.
- `lastUpdated` bumped.
- No other entries touched.

## Test plan

- [x] Round-trip JSON parse OK; only the 10 targeted entries + `lastUpdated` differ from origin/main.
- [x] Counts re-verified against `git show origin/main:proofs/<file>.lean` (lines, axioms, opaques, sorries, theorems).
- [x] No True-stub theorems, no axiom masking, no Mathlib-wrapper-as-original mislabels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)