### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): Session 7 — boundary saturation (binomialCDF four-corner characterization complete)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean
@@ -57,6 +57,12 @@ gives the multinomial marginal CLT.
   opaque was replaced in Session 6 with a concrete `noncomputable def`
   using Mathlib's `gaussianPDFReal`.
 - Status: axiomatized — not "verified".
+- Session 7 (this session) adds two boundary-saturation lemmas
+  `binomialCDF_zero` and `binomialCDF_eq_one`, completing the four-corner
+  characterization of `binomialCDF` (`_neg` left-tail = 0, `_eq_one`
+  right-tail = 1, `_zero_le` lower bound, `_le_one` upper bound). These
+  feed the Phase-4 Portmanteau bridge that aims to discharge
+  `binomial_clt_pointwise`.
 
 The contribution of this file is the *full reduction* of the multinomial
 marginal CLT to the classical Binomial CLT, leaving only the latter as
@@ -419,6 +425,62 @@ theorem binomialCDF_le_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
   · exact le_refl _
   · exact mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (pow_nonneg hp0 _))
       (pow_nonneg h1mp _)
+
+/-- At `x = 0`, only the `j = 0` term contributes to `binomialCDF n p`;
+    every other `j ∈ {1, …, n}` has `(j : ℝ) ≥ 1 > 0`, failing the
+    if-guard. The surviving term simplifies to
+    `C(n, 0) · p^0 · (1 − p)^(n − 0) = (1 − p)^n`.
+
+    Useful for the Phase-4 Portmanteau bridge: the boundary value at
+    `x = 0` (i.e., the probability of zero successes) is the only
+    closed-form value of the CDF, and it appears in the standardised
+    threshold `np + x √(np(1−p))` when `x = -√(np/(1-p))`. -/
+theorem binomialCDF_zero (n : ℕ) (p : ℝ) :
+    binomialCDF n p 0 = (1 - p) ^ n := by
+  unfold binomialCDF
+  -- Reduce the sum to its single non-zero term `j = 0`.
+  rw [Finset.sum_eq_single 0]
+  · -- j = 0: if-guard `(0 : ℝ) ≤ 0` holds; the term is `1 · 1 · (1 − p)^n`.
+    simp [Nat.choose_zero_right]
+  · -- For `j ≠ 0` in the range, if-guard `(j : ℝ) ≤ 0` is false.
+    intro j _ hjne
+    have hjpos : 0 < j := Nat.pos_of_ne_zero hjne
+    have hj_not_le : ¬ (j : ℝ) ≤ 0 := by
+      push_neg
+      exact_mod_cast hjpos
+    rw [if_neg hj_not_le]
+  · -- `0 ∈ Finset.range (n+1)` is automatic.
+    intro h
+    exact absurd (Finset.mem_range.mpr (Nat.zero_lt_succ _)) h
+
+/-- For `0 ≤ p ≤ 1` and any `x` with `(n : ℝ) ≤ x`, every if-guard
+    `(j : ℝ) ≤ x` is satisfied (since `j ∈ {0, …, n}` gives
+    `(j : ℝ) ≤ (n : ℝ) ≤ x`). The sum then equals the full binomial
+    expansion `(p + (1 − p))^n = 1`.
+
+    Useful for the Phase-4 Portmanteau bridge: the right-tail
+    saturation `binomialCDF n p x = 1` for `x ≥ n` mirrors
+    `Φ(x) → 1` as `x → ∞` for the standard normal. The companion
+    `binomialCDF_neg` gives the matching left-tail saturation. -/
+theorem binomialCDF_eq_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
+    {x : ℝ} (hx : (n : ℝ) ≤ x) : binomialCDF n p x = 1 := by
+  unfold binomialCDF
+  -- All if-guards collapse to the true branch.
+  have h_simp : ∀ j ∈ Finset.range (n + 1),
+      (if (j : ℝ) ≤ x then (Nat.choose n j : ℝ) * p ^ j * (1 - p) ^ (n - j) else 0)
+      = (Nat.choose n j : ℝ) * p ^ j * (1 - p) ^ (n - j) := by
+    intro j hj
+    rw [Finset.mem_range, Nat.lt_succ_iff] at hj
+    have hjx : (j : ℝ) ≤ x := le_trans (by exact_mod_cast hj) hx
+    rw [if_pos hjx]
+  rw [Finset.sum_congr rfl h_simp]
+  -- Apply the binomial theorem to identify with `(p + (1 − p))^n = 1`.
+  have hadd := add_pow p (1 - p) n
+  have hp_eq : p + (1 - p) = (1 : ℝ) := by ring
+  rw [hp_eq, one_pow] at hadd
+  rw [← hadd]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  ring
 
 /-! ## Main theorem: multinomial marginal CLT (derived) -/
 

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/knowledge.md
@@ -6,6 +6,78 @@ coordinate of `(X₁, …, Xₖ) ~ Multinomial(n, p₁, …, pₖ)` as `n → �
 
 ---
 
+## Session 2026-05-08 (Session 7, researcher-8) — ACT (Phase-4 prep)
+
+**Mode**: REVISIT (RICH knowledge score 41; prior sessions completed
+Phase-3 reduction + Phase-4 opaque elimination).
+**Outcome**: Added two boundary-saturation lemmas to complete the
+four-corner characterization of `binomialCDF` for the Portmanteau
+bridge. Axiom count unchanged at 1; theoremCount 10 → 12.
+
+### What was added
+
+```lean
+theorem binomialCDF_zero (n : ℕ) (p : ℝ) :
+    binomialCDF n p 0 = (1 - p) ^ n
+```
+Isolates the j = 0 term via `Finset.sum_eq_single`. Every j ≥ 1 has
+`(j : ℝ) ≥ 1 > 0`, so the if-guard fails and the term is 0; only
+`C(n, 0) · p^0 · (1 − p)^n = (1 − p)^n` survives.
+
+```lean
+theorem binomialCDF_eq_one (n : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1)
+    {x : ℝ} (hx : (n : ℝ) ≤ x) : binomialCDF n p x = 1
+```
+For x ≥ n, every j ∈ {0, …, n} has `(j : ℝ) ≤ (n : ℝ) ≤ x`, so all
+if-guards collapse to the true branch. The sum then equals the full
+binomial expansion `(p + (1 − p))^n = 1` via `add_pow`.
+
+### Why these matter for Phase-4
+
+The Portmanteau bridge (the heavy lift that would discharge
+`binomial_clt_pointwise`) relies on the standardised binomial CDF
+matching the CDF of its underlying probability measure on ℝ. CDFs of
+probability measures satisfy four boundary conditions:
+
+| Side | Standard normal Φ | binomialCDF n p (proved here) |
+|------|-------------------|-------------------------------|
+| Left limit | Φ(−∞) = 0 | `binomialCDF_neg`: x < 0 ⇒ CDF = 0 |
+| Right limit | Φ(+∞) = 1 | `binomialCDF_eq_one`: x ≥ n ⇒ CDF = 1 |
+| Range | 0 ≤ Φ(x) ≤ 1 | `binomialCDF_zero_le`, `binomialCDF_le_one` |
+| Monotone | Φ is monotone | `binomialCDF_mono` |
+
+The two new lemmas (`binomialCDF_zero` and `binomialCDF_eq_one`) plus
+the existing four are exactly the algebraic data the Portmanteau
+bridge consumes. The discrete `binomialCDF` is now characterised at
+the same level of detail as `standardNormalCDF`, so all that's left
+is the *limit* (de Moivre-Laplace) — which is the axiom.
+
+### Next session — `Continuous standardNormalCDF`
+
+Recommended approach: DCT on the indicator-rewritten form
+`∫ t in Set.Iic x, f = ∫ t, (Set.Iic x).indicator f t`. Sequence
+`x_n → x` ⇒ indicator converges pointwise except at the single point
+`t = x` (Lebesgue measure 0); bounded uniformly by f itself; f is
+integrable; DCT closes.
+
+Once `Continuous standardNormalCDF` is proved, Session 9 can bridge to
+`ProbabilityTheory.iid_central_limit_theorem` via Portmanteau —
+heavy but the LAST step.
+
+### Honest reporting
+
+- Build verification not run locally: worktree's `.lake` symlink trap
+  forces a fresh Mathlib clone (~25-30 min). The two new proofs use
+  only patterns already typechecked in this file (`Finset.sum_eq_single`,
+  `Finset.sum_congr rfl`, `add_pow`, `if_pos`/`if_neg`,
+  `Nat.pos_of_ne_zero`, `exact_mod_cast`). High confidence in
+  typecheck; CI is the ground truth.
+- This session is *infrastructure*, not *axiom elimination*. AxiomCount
+  stays at 1. Real progress measure: theorem count 10 → 12, line count
+  369 → 429.
+
+---
+
 ## Session 2026-05-07 (Session 1, researcher-8) — OBSERVE → ORIENT
 
 **Mode**: FRESH (no prior research dir; the problem JSON exists)


### PR DESCRIPTION
## Summary

Session 7 of the multinomial-marginal-CLT thread. Adds two boundary-saturation lemmas to `BinomialTheoremOQ02OQ01OQ01OQ03.lean`, completing the four-corner characterization of `binomialCDF` for the Phase-4 Portmanteau bridge.

| Lemma | Statement | Proof method |
|---|---|---|
| `binomialCDF_zero` | `binomialCDF n p 0 = (1 - p) ^ n` | `Finset.sum_eq_single` isolates the `j = 0` term; for `j ≥ 1`, `(j:ℝ) ≥ 1 > 0` fails the if-guard. |
| `binomialCDF_eq_one` | for `0 ≤ p ≤ 1` and `(n:ℝ) ≤ x`, `binomialCDF n p x = 1` | every if-guard collapses (`(j:ℝ) ≤ (n:ℝ) ≤ x`); the sum equals `(p + (1−p))^n = 1` via `add_pow`. |

## Why these matter for Phase-4

The Phase-4 Portmanteau-bridge argument (which would discharge the sole remaining axiom `binomial_clt_pointwise`) needs the standardised binomial CDF to match the CDF of an underlying probability measure on ℝ. CDFs of probability measures satisfy four boundary/range conditions — and `binomialCDF` now satisfies them all:

| Condition | Standard normal Φ | binomialCDF n p |
|------|------|------|
| Left limit | Φ(−∞) = 0 | `binomialCDF_neg`: x < 0 ⇒ CDF = 0 |
| **Right limit** | **Φ(+∞) = 1** | **`binomialCDF_eq_one`** (this PR): x ≥ n ⇒ CDF = 1 |
| Lower bound | 0 ≤ Φ | `binomialCDF_zero_le` |
| Upper bound | Φ ≤ 1 | `binomialCDF_le_one` |
| **Boundary value at 0** | (no closed form for Φ) | **`binomialCDF_zero`** (this PR): CDF(0) = (1−p)^n |
| Monotone | Φ is monotone | `binomialCDF_mono` |
| Continuous Φ (S8 target) | (Continuous standardNormalCDF) | (binomialCDF is right-continuous step function; structural) |

## Status changes

| Field | Before | After |
|---|---|---|
| sorries | 0 | 0 |
| axioms | 1 | **1** (unchanged) |
| definitions | 3 | 3 |
| theorems | 10 | **12** |
| substantive theorems | 9 | **11** |
| lineCount | 369 | 429 |
| status | axiomatized | axiomatized |

The single remaining axiom is `binomial_clt_pointwise` (de Moivre-Laplace, 1733/1812).

## Honest reporting

- Local Docker build was **not run**: the worktree's recursive `.lake` symlink trap forces a fresh Mathlib clone (~25-30 min). Both new proofs use only patterns already typechecked in this file (`Finset.sum_eq_single`, `Finset.sum_congr rfl`, `add_pow`, `if_pos`/`if_neg`, `Nat.pos_of_ne_zero`, `exact_mod_cast`). High confidence in typecheck; CI is the ground truth.
- This session is **infrastructure**, not **axiom elimination**. AxiomCount stays at 1. Real progress measure: theorem count +2 / line count +60.

## Files modified

- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` (369 → 429 lines; +2 theorems)
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json` (theoremCount 10 → 12, substantiveTheoremCount 9 → 11, lineCount 369 → 429, section line ranges shifted, originalContributions and assumptions narrative extended)
- `research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/{knowledge.md, state.md}` (Session 7 entry)
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json` (knowledge fields, leanFiles entry, currentState)

## Outcome

**progress** — the discrete CDF is now characterised at the same level of detail as the continuous limit; the four-corner box is closed.

## Next steps

1. **Session 8** (Phase-4 — `Continuous standardNormalCDF`): rate-limiting step for the Portmanteau bridge. DCT on the indicator-rewritten form `∫ t in Iic x, f = ∫ t, (Iic x).indicator f t`. Sequence `x_n → x` ⇒ indicator converges pointwise except at the single point `t = x` (Lebesgue measure 0); bounded uniformly by `f` itself; `f = gaussianPDFReal 0 1` is integrable; DCT closes.
2. **Session 9** (axiom attack): bridge `binomial_clt_pointwise` to `ProbabilityTheory.iid_central_limit_theorem` via Portmanteau at every point (using continuity of Φ from Session 8). Heaviest lift; the only remaining axiom.

🤖 Generated by researcher-8