### PR TITLE
research(hilbert-10-oq-01-oq-02): Iter 5 — symmetric dualities + trivial-set definability

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -441,6 +441,169 @@ theorem koenigsmann_implies_complement_existentialUniversal :
     hPi2
 
 -- ============================================================
+-- Part VIII.5 (iter 5): Symmetric duality forms — Σ₁ vs Π₁(¬·) and Σ₂ vs Π₂(¬·)
+-- ============================================================
+
+/-- **Symmetric Σ₁/Π₁ duality** (iteration 5):
+
+    A subset `S` is Π₁-definable iff its complement `¬ S` is Σ₁-definable.
+
+    This is the symmetric companion of `diophantine_iff_codiophantine_complement`
+    (which states `S ∈ Σ₁ ⟺ ¬S ∈ Π₁`). Together, the two forms exhibit the
+    Σ₁/Π₁ duality as an involutive bijection (modulo classical
+    double-negation), and either direction implies the other via the
+    `_iff_of_pred_iff` congruence and the bridge `S q ↔ ¬¬ S q`.
+
+    Proved here directly (no congruence detour) — same structural pattern
+    as the Σ₁→Π₁ direction, with one classical step. -/
+theorem codiophantine_iff_diophantine_complement (S : RatSubset) :
+    IsCoDiophantineDefinition S ↔ IsDiophantineDefinition (fun q => ¬ S q) := by
+  constructor
+  · intro h
+    obtain ⟨P, hP⟩ := h
+    refine ⟨P, fun q => ?_⟩
+    -- need: ¬ S q ↔ hasRationalSolution (P q)
+    -- hP q : S q ↔ ¬ hasRationalSolution (P q)
+    refine ⟨fun hnSq => ?_, fun hsol hSq => ?_⟩
+    · apply Classical.byContradiction
+      intro hnsol
+      exact hnSq ((hP q).mpr hnsol)
+    · exact ((hP q).mp hSq) hsol
+  · intro h
+    obtain ⟨P, hP⟩ := h
+    refine ⟨P, fun q => ?_⟩
+    -- need: S q ↔ ¬ hasRationalSolution (P q)
+    -- hP q : ¬ S q ↔ hasRationalSolution (P q)
+    refine ⟨fun hSq hsol => ?_, fun hnsol => ?_⟩
+    · exact ((hP q).mpr hsol) hSq
+    · apply Classical.byContradiction
+      intro hnSq
+      exact hnsol ((hP q).mp hnSq)
+
+/-- **Symmetric Σ₂/Π₂ duality** (iteration 5):
+
+    A subset `S` is Π₂-definable iff its complement `¬ S` is Σ₂-definable.
+
+    Higher-level analog of `codiophantine_iff_diophantine_complement`.
+    Symmetric companion of `existentialUniversal_iff_universalExistential_complement`.
+
+    Proof: derived as a corollary of the existing duality applied to `¬ S`,
+    using the Π₂ congruence helper to rewrite `¬¬ S` back to `S`.
+    No new axioms; pure classical-logic glue. -/
+theorem universalExistential_iff_existentialUniversal_complement (S : RatSubset) :
+    IsUniversalExistentialDefinition S ↔
+      IsExistentialUniversalDefinition (fun q => ¬ S q) := by
+  have hbridge : ∀ q : Rat, S q ↔ ¬ ¬ S q :=
+    fun q => ⟨fun hSq hnSq => hnSq hSq, fun hnnSq => Classical.byContradiction hnnSq⟩
+  have hStep1 : IsUniversalExistentialDefinition S ↔
+      IsUniversalExistentialDefinition (fun q => ¬ ¬ S q) :=
+    universalExistentialDefinition_iff_of_pred_iff hbridge
+  have hStep2 : IsUniversalExistentialDefinition (fun q => ¬ ¬ S q) ↔
+      IsExistentialUniversalDefinition (fun q => ¬ S q) :=
+    (existentialUniversal_iff_universalExistential_complement (fun q => ¬ S q)).symm
+  exact hStep1.trans hStep2
+
+-- ============================================================
+-- Part VIII.6 (iter 5): Trivial-set definability across all four classes
+-- ============================================================
+
+/-- The "always-zero" rational polynomial — a witness that the trivial
+    equation `0 = 0` always has a rational solution. Used as a building
+    block for trivial-set Σ₁/Π₂ membership. -/
+private def zeroPoly : RatDiophantinePoly := fun _ => 0
+
+/-- The "always-one" rational polynomial — a witness that the trivial
+    equation `1 = 0` never has a rational solution. Used as a building
+    block for trivial-set Π₁/Σ₂ membership and complement constructions. -/
+private def onePoly : RatDiophantinePoly := fun _ => 1
+
+private theorem hasRationalSolution_zeroPoly : hasRationalSolution zeroPoly :=
+  ⟨fun _ => 0, rfl⟩
+
+private theorem rat_one_ne_zero : (1 : Rat) ≠ 0 := by decide
+
+private theorem not_hasRationalSolution_onePoly : ¬ hasRationalSolution onePoly := by
+  rintro ⟨_, h⟩
+  exact rat_one_ne_zero (show (1 : Rat) = 0 from h)
+
+/-- The empty subset of ℚ (predicate `False`) is Σ₁-definable. Witness:
+    the always-one polynomial, which has no rational solution.
+
+    Foundational closure-under-emptiness fact for the Σ₁ class. -/
+theorem empty_isDiophantineDefinition :
+    IsDiophantineDefinition (fun _ : Rat => False) := by
+  refine ⟨fun _ => onePoly, fun q => ?_⟩
+  exact ⟨False.elim, fun h => not_hasRationalSolution_onePoly h⟩
+
+/-- The empty subset of ℚ is Π₁-definable. Witness: the always-zero
+    polynomial, which always has a rational solution; its negation is
+    therefore always false. -/
+theorem empty_isCoDiophantineDefinition :
+    IsCoDiophantineDefinition (fun _ : Rat => False) := by
+  refine ⟨fun _ => zeroPoly, fun q => ?_⟩
+  exact ⟨False.elim, fun hnsol => hnsol hasRationalSolution_zeroPoly⟩
+
+/-- The full subset of ℚ (predicate `True`) is Σ₁-definable. Witness:
+    the always-zero polynomial, whose rational solution set is all of ℚᵏ. -/
+theorem universe_isDiophantineDefinition :
+    IsDiophantineDefinition (fun _ : Rat => True) := by
+  refine ⟨fun _ => zeroPoly, fun q => ?_⟩
+  exact ⟨fun _ => hasRationalSolution_zeroPoly, fun _ => trivial⟩
+
+/-- The full subset of ℚ is Π₁-definable. Witness: the always-one
+    polynomial, whose negation is always true (no rational solution). -/
+theorem universe_isCoDiophantineDefinition :
+    IsCoDiophantineDefinition (fun _ : Rat => True) := by
+  refine ⟨fun _ => onePoly, fun q => ?_⟩
+  exact ⟨fun _ => not_hasRationalSolution_onePoly, fun _ => trivial⟩
+
+/-- The empty subset of ℚ is Π₂-definable.
+
+    Witness: the polynomial `P(q, y, x) = 1`, which never vanishes; the
+    inner existential `∃ x, P(q, y, x) = 0` is therefore false for every
+    `y`, and `Nat → Rat` is inhabited (by `fun _ => 0`), so the outer
+    universal quantifier `∀ y, False` is `False`. -/
+theorem empty_isUniversalExistentialDefinition :
+    IsUniversalExistentialDefinition (fun _ : Rat => False) := by
+  refine ⟨fun _ _ => onePoly, fun q => ?_⟩
+  refine ⟨False.elim, fun hAll => ?_⟩
+  exact not_hasRationalSolution_onePoly (hAll (fun _ => 0))
+
+/-- The full subset of ℚ is Π₂-definable.
+
+    Witness: the polynomial `P(q, y, x) = 0`, whose inner existential
+    block `∃ x, 0 = 0` is true for every `y`; the outer universal is then
+    vacuously true. -/
+theorem universe_isUniversalExistentialDefinition :
+    IsUniversalExistentialDefinition (fun _ : Rat => True) := by
+  refine ⟨fun _ _ => zeroPoly, fun q => ?_⟩
+  exact ⟨fun _ _ => hasRationalSolution_zeroPoly, fun _ => trivial⟩
+
+/-- The empty subset of ℚ is Σ₂-definable. Derivable from the Π₂ universe
+    fact via the symmetric Σ₂/Π₂ duality: `Σ₂(∅) ⟺ Π₂(¬∅) = Π₂(univ)`. -/
+theorem empty_isExistentialUniversalDefinition :
+    IsExistentialUniversalDefinition (fun _ : Rat => False) := by
+  have hbridge : ∀ q : Rat, ¬ (fun _ : Rat => False) q ↔ (fun _ : Rat => True) q :=
+    fun q => ⟨fun _ => trivial, fun _ hF => hF⟩
+  have hPi2 : IsUniversalExistentialDefinition (fun q => ¬ (fun _ : Rat => False) q) :=
+    (universalExistentialDefinition_iff_of_pred_iff hbridge).mpr
+      universe_isUniversalExistentialDefinition
+  exact (existentialUniversal_iff_universalExistential_complement
+    (fun _ : Rat => False)).mpr hPi2
+
+/-- The full subset of ℚ is Σ₂-definable. Derivable from the Π₂ empty
+    fact via the symmetric Σ₂/Π₂ duality: `Σ₂(univ) ⟺ Π₂(¬univ) = Π₂(∅)`. -/
+theorem universe_isExistentialUniversalDefinition :
+    IsExistentialUniversalDefinition (fun _ : Rat => True) := by
+  have hbridge : ∀ q : Rat, ¬ (fun _ : Rat => True) q ↔ (fun _ : Rat => False) q :=
+    fun q => ⟨fun hnT => hnT trivial, fun hF _ => hF⟩
+  have hPi2 : IsUniversalExistentialDefinition (fun q => ¬ (fun _ : Rat => True) q) :=
+    (universalExistentialDefinition_iff_of_pred_iff hbridge).mpr
+      empty_isUniversalExistentialDefinition
+  exact (existentialUniversal_iff_universalExistential_complement
+    (fun _ : Rat => True)).mpr hPi2
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -487,7 +650,7 @@ All other declared `theorem`s are NOT new axioms — they are logical
 consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulation,
 Σ₁ ↔ Π₁(complement), and Σ₂ ↔ Π₂(complement) equivalences proved here.
 
-## Theorems in THIS file (16)
+## Theorems in THIS file (26)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
@@ -505,6 +668,16 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `coDiophantineDefinition_iff_of_pred_iff` (Π₁ class congruence, iter 4)
   - `existentialUniversalDefinition_iff_of_pred_iff` (Σ₂ class congruence, iter 4)
   - `koenigsmann_implies_complement_existentialUniversal` (Σ₂(ℚ\ℤ) corollary)
+  - `codiophantine_iff_diophantine_complement` (Π₁/Σ₁ symmetric duality, iter 5)
+  - `universalExistential_iff_existentialUniversal_complement` (Π₂/Σ₂ symmetric duality, iter 5)
+  - `empty_isDiophantineDefinition` (∅ is Σ₁, iter 5)
+  - `empty_isCoDiophantineDefinition` (∅ is Π₁, iter 5)
+  - `universe_isDiophantineDefinition` (ℚ is Σ₁, iter 5)
+  - `universe_isCoDiophantineDefinition` (ℚ is Π₁, iter 5)
+  - `empty_isUniversalExistentialDefinition` (∅ is Π₂, iter 5)
+  - `universe_isUniversalExistentialDefinition` (ℚ is Π₂, iter 5)
+  - `empty_isExistentialUniversalDefinition` (∅ is Σ₂, iter 5)
+  - `universe_isExistentialUniversalDefinition` (ℚ is Σ₂, iter 5)
 -/
 
 #check @IsDiophantineDefinition
@@ -522,5 +695,15 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @coDiophantineDefinition_iff_of_pred_iff
 #check @existentialUniversalDefinition_iff_of_pred_iff
 #check @koenigsmann_implies_complement_existentialUniversal
+#check @codiophantine_iff_diophantine_complement
+#check @universalExistential_iff_existentialUniversal_complement
+#check @empty_isDiophantineDefinition
+#check @empty_isCoDiophantineDefinition
+#check @universe_isDiophantineDefinition
+#check @universe_isCoDiophantineDefinition
+#check @empty_isUniversalExistentialDefinition
+#check @universe_isUniversalExistentialDefinition
+#check @empty_isExistentialUniversalDefinition
+#check @universe_isExistentialUniversalDefinition
 
 end Hilbert10Rationals

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 526,
+    "lineCount": 709,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -52,8 +52,8 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
-    "definitionCount": 8
+    "theoremCount": 29,
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -180,10 +180,10 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 526,
+    "lineCount": 709,
     "axiomCount": 1,
-    "theoremCount": 16,
-    "definitionCount": 8,
+    "theoremCount": 29,
+    "definitionCount": 10,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/hilbert-10-oq-01-oq-02.json
+++ b/src/data/research/problems/hilbert-10-oq-01-oq-02.json
@@ -193,10 +193,10 @@
     {
       "path": "Proofs/Hilbert10OQ01OQ02.lean",
       "filename": "Hilbert10OQ01OQ02.lean",
-      "lineCount": 462,
-      "theoremCount": 13,
+      "lineCount": 709,
+      "theoremCount": 29,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 10,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert10OQ01OQ02.lean"


### PR DESCRIPTION
## Summary

Iteration 5 extends the Σ₁/Π₁/Σ₂/Π₂ definability framework for ℤ ⊂ ℚ with
**10 axiom-free public theorems** (plus 3 private supporting theorems).
No new axioms; all results are pure logical consequences.

The OPEN question — whether ℤ is purely Diophantine (Σ₁) over ℚ — remains
intentionally open. This iteration does not approach it directly; it builds out
the surrounding closure / duality / trivial-set picture, which is needed
infrastructure for any future attack on the open core.

## What's added

### Part VIII.5: Symmetric duality forms (2 theorems)

- `codiophantine_iff_diophantine_complement` — `IsCoDiophantineDefinition S ↔ IsDiophantineDefinition (¬·S)`. Symmetric companion of the existing forward Σ₁/Π₁ duality.
- `universalExistential_iff_existentialUniversal_complement` — `IsUniversalExistentialDefinition S ↔ IsExistentialUniversalDefinition (¬·S)`. Symmetric companion of the Σ₂/Π₂ duality.

Each pair (forward + symmetric) jointly exhibits the duality as an involution
modulo classical double-negation, with the symmetric form being more useful
when starting from a Π-class assumption.

### Part VIII.6: Trivial-set definability across all four classes (8 theorems)

- `empty_isDiophantineDefinition` / `universe_isDiophantineDefinition`
- `empty_isCoDiophantineDefinition` / `universe_isCoDiophantineDefinition`
- `empty_isUniversalExistentialDefinition` / `universe_isUniversalExistentialDefinition`
- `empty_isExistentialUniversalDefinition` / `universe_isExistentialUniversalDefinition`

Witnesses use constant polynomials `zeroPoly := fun _ => 0` and `onePoly := fun _ => 1`.
The Σ₂/Π₂ trivial-set facts are derived from the corresponding Π₂ facts via the
new symmetric duality (no fresh closures needed).

### Supporting infrastructure (5 declarations)

- 2 private defs: `zeroPoly`, `onePoly`
- 3 private theorems: `hasRationalSolution_zeroPoly`, `rat_one_ne_zero`, `not_hasRationalSolution_onePoly`

`rat_one_ne_zero` discharges `(1 : Rat) ≠ 0` via `decide` at top level (avoiding the
free-variable trap when `decide` is called inside a closure).

## Stats

| Field | Before | After | Δ |
|-------|--------|-------|---|
| lineCount | 526 | 709 | +183 |
| theoremCount (broad incl. private) | 16 | 29 | +13 |
| definitionCount | 8 | 10 | +2 |
| axiomCount | 1 | 1 | 0 |
| sorries | 0 | 0 | 0 |

## Build verification

```
LEAN_BUILD_TIMEOUT=20m LEAN_MEMORY_LIMIT=8192 ./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02
# exit 0
```

All 26 public-namespace `#check`s typecheck; no warnings/errors.

## Test plan

- [x] Lean compiles (Docker build, exit 0)
- [x] No new axioms (still 1 — `koenigsmann_2016_universal`)
- [x] No sorries (still 0)
- [x] Gallery `meta.json` lineCount/theoremCount/defCount synced
- [x] Problem JSON `leanFiles[Hilbert10OQ01OQ02]` synced

## Iteration trail

- Iter 1 (researcher-6): scaffold (#16693)
- Iter 2 (researcher-9 s1): Σ₁/Π₁ duality (#16839)
- Iter 3 (researcher-9 s2): Σ₂/Π₂ duality + Π₁ ⊆ Σ₂ + Σ₂(ℚ\\ℤ) corollary (#16885)
- Iter 4 (researcher-1): four-class congruence helpers (#17026)
- **Iter 5 (researcher-5, this PR): symmetric dualities + trivial-set definability**

## Next steps (S6+ candidates)

- Singleton sets `{q₀}` are Σ₁ (needs `Rat.sub` / Mathlib for arithmetic)
- Π₁ × Σ₁ closure under finite ∪ / ∩ (needs `Rat.mul_eq_zero`, sum-of-squares — Mathlib)
- Π₁ ⊆ Π₂ via polynomial-inversion trick `a ≠ 0 ⟺ ∃ z, a·z = 1` (Rat-arithmetic blocker)
- Daans 2021 (10-quantifier) refinement of Koenigsmann (would add 1 axiom)
- Eisenträger-Park 2018 universal-existential characterization

🤖 Generated with [Claude Code](https://claude.com/claude-code)