### PR TITLE
research(liouville-theorem-oq-04): S15 follow-up — verified status (build verified)

### DIFF
--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -2,12 +2,12 @@
   "id": "liouville-theorem-oq-04",
   "title": "P-adic Liouville Theorem: The Archimedean Complement Lemma",
   "slug": "liouville-theorem-oq-04",
-  "description": "Extension of Liouville's approximation theorem to the p-adic setting. Proves the key Archimedean Complement Lemma: padicNorm p n ≥ 1/n for nonzero naturals. Defines p-adic Liouville numbers using height max(|r|,|s|) and proves the main theorem that p-adic algebraic numbers are not p-adically Liouville. 1 axiom (padic_liouville_norm_bridge: structural ingredients AND both case-analysis pieces formally proved — discharge to theorem requires only one combine-and-case-split session), 0 sorries.",
+  "description": "Extension of Liouville's approximation theorem to the p-adic setting. Proves the Archimedean Complement Lemma (padicNorm p n ≥ 1/n for nonzero naturals), defines p-adic Liouville numbers using height max(|r|,|s|), and proves the main theorem that p-adic algebraic numbers are not p-adically Liouville. **Fully verified**: 0 axioms, 0 sorries — the bridge theorem `padic_liouville_norm_bridge` was discharged in Session 15 by composing Part IV.10 (algebraic case) with Part IV.11 (rational-roots case) via `C' := min(1/(L·M), δ)` and a case split on `(f.map alg').eval ((r:ℚ)/s) ?= 0` over ℚ.",
   "meta": {
     "author": "lean-genius research agent",
     "sourceUrl": "https://mathworld.wolfram.com/p-adicNumber.html",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/LiouvilleTheoremOQ04.lean",
     "tags": [
       "number-theory",
@@ -18,10 +18,10 @@
       "liouville",
       "ultrametric"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "1 axiom: padic_liouville_norm_bridge — connects the factorization f = (X-C α)·g and evaluation identity to the p-adic Liouville lower bound. All FOUR structural ingredients now formally proved as uniform bounds: (1) norm compatibility ‖algebraMap ℚ ℚ_[p] q‖ = padicNorm p q (Part IV.5, norm_rat_eq_padicNorm/padic_norm_int_poly_eval), (2a) height bound padicNorm p (r/s) ≤ max(|r|,|s|) (Part IV.7, padic_norm_int_div_le_height), (2b) cofactor evaluation upper bound ‖g.eval(r/s)‖_p ≤ M·H^(deg g) with M depending only on g (Part IV.8, padic_polynomial_eval_norm_bound + padic_cofactor_bound_rat), (3) UNIFORM polynomial lower bound padicNorm p (f.eval(r/s)) ≥ 1/(intPolyL1 f · H^d) with constant depending only on f (Part IV.9, padicNorm_int_poly_eval_uniform_lb). Both case-analysis pieces also formally proved: (4a) algebraic case ‖α - r/s‖ ≥ 1/(L·M·H^(2d)) when f(r/s)≠0 (Part IV.10, padic_liouville_bridge_algebraic_case, Session 13); (4b) rational-roots case δ > 0 with δ ≤ ‖α - q‖ for every rational root q with (q:ℚ_[p]) ≠ α (Part IV.11 NEW, padic_liouville_bridge_rational_roots_case, Session 14). Discharging the bridge axiom is now a single combine-and-case-split session: take C := min((1/(L·M)), δ) and case-split on (f.map alg').eval (r/s) ?= 0.",
+    "axiomCount": 0,
+    "assumptions": "0 axioms — fully verified by Lean 4.26 / Mathlib (Session 15 discharge of the former bridge axiom). The chain of theorems behind the main result `padic_algebraic_not_liouville`: (1) Part I — `padicNorm_nat_ge_inv` (Archimedean Complement Lemma); (2) Part IV.5 — `norm_rat_eq_padicNorm` + `padic_norm_int_poly_eval` (norm compatibility ℚ → ℚ_[p] for polynomial evaluation); (3) Part IV.7 — `padic_norm_int_div_le_height` (height bound `‖(r:ℚ_[p])/s‖ ≤ max(|r|,|s|)`); (4) Part IV.8 — `padic_polynomial_eval_norm_bound` + `padic_cofactor_bound_rat` (uniform cofactor upper bound); (5) Part IV.9 — `padicNorm_int_poly_eval_uniform_lb` (uniform integer-polynomial lower bound `1/(intPolyL1 f · H^d)`); (6) Part IV.10 — `padic_liouville_bridge_algebraic_case` (Session 13, the `f(r/s) ≠ 0` over ℚ branch); (7) Part IV.11 — `padic_liouville_bridge_rational_roots_case` (Session 14, the rational-roots δ > 0 separation); (8) **Part V — `padic_liouville_norm_bridge` (Session 15, NEW, theorem)** combines Parts IV.10 and IV.11 via `C' := min((1/(L·M)), δ)` with case split on `(f.map alg').eval ((r:ℚ)/s) ?= 0` over ℚ; (9) `padic_liouville_estimate` and `padic_algebraic_not_liouville` follow.",
     "dateAdded": "2026-04-26",
     "mathlibDependencies": [
       {
@@ -59,8 +59,8 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 1216,
-    "theoremCount": 34,
+    "lineCount": 1333,
+    "theoremCount": 35,
     "definitionCount": 6
   },
   "overview": {
@@ -179,11 +179,13 @@
     }
   ],
   "conclusion": {
-    "summary": "The Archimedean Complement Lemma padicNorm p n ≥ 1/n is proved in Lean 4 without sorry. The IsPadicLiouville definition has been fixed with strict positivity (0 < ‖β - r/s‖). The main theorem padic_algebraic_not_liouville is fully proved. One HARD sorry remains: padic_liouville_estimate, requiring polynomial factorization and norm bounds in ℚ_[p].",
-    "implications": "The p-adic Liouville theorem belongs to a family of results showing that the ultrametric property of p-adic norms does not fundamentally change the transcendence theory — algebraic numbers remain resistant to efficient rational approximation. The height function appears naturally because the p-adic norm of a ratio r/s depends symmetrically on both numerator and denominator. In Mahler's classification of transcendental numbers (1932), Liouville numbers occupy the U-class ('universal') — approximable super-polynomially by rationals at every metric place simultaneously. The p-adic irrationality measure $\\mu_p(\\alpha) \\leq d$ for algebraic $\\alpha$ of degree $d$ (shown here with axiom) is the p-adic analog of Roth's theorem (1955, Fields Medal), and together they establish that the Mahler classification is uniform across all places of $\\mathbb{Q}$: an algebraic number of degree $d$ satisfies $\\mu_v \\leq d$ at every place $v$ (Archimedean or p-adic).",
+    "summary": "**Fully verified Lean 4.26 / Mathlib formalization** (Session 15 — bridge axiom discharged): the Archimedean Complement Lemma `padicNorm p n ≥ 1/n`, the IsPadicLiouville definition with strict positivity `0 < ‖β - r/s‖`, the bridge theorem `padic_liouville_norm_bridge` (formerly the only axiom — discharged 2026-05-08 by composing Parts IV.10 and IV.11), the key estimate `padic_liouville_estimate`, and the main theorem `padic_algebraic_not_liouville` are all proved with 0 sorries and 0 axioms.",
+    "implications": "The p-adic Liouville theorem belongs to a family of results showing that the ultrametric property of p-adic norms does not fundamentally change the transcendence theory — algebraic numbers remain resistant to efficient rational approximation. The height function appears naturally because the p-adic norm of a ratio r/s depends symmetrically on both numerator and denominator. In Mahler's classification of transcendental numbers (1932), Liouville numbers occupy the U-class ('universal') — approximable super-polynomially by rationals at every metric place simultaneously. The p-adic irrationality measure $\\mu_p(\\alpha) \\leq d$ for algebraic $\\alpha$ of degree $d$ (shown here, fully verified) is the p-adic analog of Roth's theorem (1955, Fields Medal), and together they establish that the Mahler classification is uniform across all places of $\\mathbb{Q}$: an algebraic number of degree $d$ satisfies $\\mu_v \\leq d$ at every place $v$ (Archimedean or p-adic).",
     "openQuestions": [
-      "Can the padic_liouville_estimate axiom be proved? This requires: Taylor factorization f(x) = (x-α)·g(x,α) over ℚ_[p], continuity bounds for g in the ultrametric topology.",
-      "Is there a purely p-adic proof avoiding the Archimedean Complement Lemma (i.e., working entirely within ℚ_[p] without comparing to |·|)?"
+      "Function-field analog over $\\mathbb{F}_q(t)$ with the $t$-adic absolute value (mirrors Mahler's framework — would need a Mathlib `LaurentSeries` $t$-adic analog).",
+      "Roth-style sharpening: can the height exponent in `padic_liouville_estimate` be improved from $H^{2d}$ to $H^{2+\\varepsilon}$? Classical Roth (1955) achieves this for the Archimedean place; the p-adic analog (Ridout 1957) is harder to formalize and is not in current Mathlib.",
+      "Multi-place generalization: a single algebraic $\\alpha$ of degree $d$ satisfies $\\mu_v(\\alpha) \\leq d$ at every place $v$ of $\\mathbb{Q}$ simultaneously. This entry handles one $v = p$-adic place at a time; the simultaneous statement is a natural successor.",
+      "Is there a purely p-adic proof avoiding the Archimedean Complement Lemma (i.e., working entirely within ℚ_[p] without comparing to $|\\cdot|_{\\infty}$)?"
     ]
   },
   "leanFile": {
@@ -200,9 +202,9 @@
       "Polynomial"
     ],
     "namespace": "LiouvilleTheoremOQ04",
-    "lineCount": 1216,
-    "axiomCount": 1,
-    "theoremCount": 34,
+    "lineCount": 1333,
+    "axiomCount": 0,
+    "theoremCount": 35,
     "definitionCount": 6,
     "path": "Proofs/LiouvilleTheoremOQ04.lean",
     "sorries": 0

--- a/src/data/research/problems/liouville-theorem-oq-04.json
+++ b/src/data/research/problems/liouville-theorem-oq-04.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "REFINE",
+    "phase": "COMPLETE",
     "since": "2026-05-08T11:00:00.000Z",
     "iteration": 15,
-    "focus": "Session 15 (this) — `padic_liouville_norm_bridge` rewritten from `axiom` to `theorem`. Composes Part IV.10 (`padic_liouville_bridge_algebraic_case`, Session 13) and Part IV.11 (`padic_liouville_bridge_rational_roots_case`, Session 14): C' := min(1/(L·M), δ) with case split on (f.map alg').eval ((r:ℚ)/s) ?= 0 over ℚ. Degree bookkeeping (g.natDegree + 1 ≤ f.natDegree) comes from `Polynomial.natDegree_mul` + `natDegree_X_sub_C` + `Polynomial.natDegree_map_le`. f ≠ 0 derived from hf_deg; g ≠ 0 from the factorization; algebraMap ℤ ℚ_[p] injectivity via integer-cast → ratCast composition. Lean file: 1216 → 1333 lines, 34 → 35 theorems, 1 → 0 axioms (build pending; meta.json status update deferred to a post-build follow-up PR).",
+    "focus": "Session 15 (DONE, build verified) — `padic_liouville_norm_bridge` rewritten from `axiom` to `theorem`, composing Part IV.10 (`padic_liouville_bridge_algebraic_case`, Session 13) with Part IV.11 (`padic_liouville_bridge_rational_roots_case`, Session 14): C' := min(1/(L·M), δ) with case split on (f.map alg').eval ((r:ℚ)/s) ?= 0 over ℚ. The session also fixed three pre-existing build errors that the slug's 'build pending' convention had hidden: (a) `Finset.single_le_sum` type-inference failure in `intPolyL1_pos` (fixed via `show` + named `(f := ...)`), (b) `Int.algebraMap_eq_intCast` removed in Mathlib 4.26 (replaced with `eq_intCast`), (c) `simp [hfQ_def] at h0` then `rw [Polynomial.map_zero, h0]` mismatch caused by simp folding `algebraMap` into `Int.castRingHom` (replaced with `rw [Polynomial.map_zero, ← hfQ_def]; exact h0`). Final polish: `field_simp; ring` → `field_simp <;> ring` in `intPolyHomogEval_cast_eq`. **Build verified 2026-05-08 14:23Z** (3063 jobs, 0 errors; only 2 unused-variable warnings — `hαne` at L686 in Part IV.10 and `hf_root` at L937 in the new bridge — both retained for API consistency). File state: 1333 lines, 35 theorems, 6 defs, 0 axioms, 0 sorries.",
     "blockers": [],
-    "nextAction": "Session 16 (next, if build verifies): update meta.json status `axiomatized` → `verified`, badge `axiom` → `original`, axiomCount 1 → 0, lineCount 1216 → 1333, theoremCount 34 → 35; refresh assumptions/conclusion narratives. If the build fails: triage Mathlib 4.26 API drift in the new theorem (`Polynomial.natDegree_map_le`, `div_le_div_iff_of_pos_right`, `set`+`rw` round-trip) and push corrective commits.",
+    "nextAction": "None — entry is fully verified. Future work should target the follow-up open questions in meta.json's `conclusion.openQuestions`: function-field analog over F_q(t), Roth-style sharpening from H^(2d) to H^(2+ε), or simultaneous multi-place generalization.",
     "attemptCounts": {
       "total": 14,
       "currentApproach": 7,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 15, 2026-05-08): `padic_liouville_norm_bridge` rewritten from `axiom` to fully-proved `theorem` by composing the two Session 13/14 ingredients. Witness: C' := min(1/(L·M), δ) where L = intPolyL1 f, M = coeffNormSum p g, δ from Part IV.11. Case split on (f.map (algebraMap ℤ ℚ)).eval ((r:ℚ)/s) ?= 0 over ℚ — nonzero branch dispatches to Part IV.10 (`padic_liouville_bridge_algebraic_case`); zero branch dispatches to Part IV.11 (`padic_liouville_bridge_rational_roots_case`) with `push_cast; rfl` to bridge the cast `((r:ℚ)/s : ℚ_[p]) = (r:ℚ_[p])/s`. Bookkeeping: f ≠ 0 from hf_deg ≥ 1; algebraMap ℤ ℚ_[p] injective via the integer-cast → ratCast factoring with `simpa [eq_intCast]` + `exact_mod_cast`; f.map alg ≠ 0 by `Polynomial.map_injective`; g ≠ 0 from the factorization; degree relation `g.natDegree + 1 ≤ f.natDegree` from `Polynomial.natDegree_mul` + `natDegree_X_sub_C` + `Polynomial.natDegree_map_le` (no injectivity needed for the natDegree_map step). The new theorem occupies ~120 lines (894–1042) and is 0-sorry, 0-axiom. After the proof, padic_liouville_estimate (and through it padic_algebraic_not_liouville) become axiom-free as well: the entire file is 0 axioms, 0 sorries — pending build verification (cold-cache Docker ~45 min). Status accounting (post-build): axiomCount 1 → 0, theoremCount 34 → 35, lineCount 1216 → 1333. meta.json status update from `axiomatized` to `verified` deferred to a follow-up PR after the build finishes (per slug convention).",
+    "progressSummary": "VERIFIED (Session 15, 2026-05-08, build verified 14:23Z): `padic_liouville_norm_bridge` rewritten from `axiom` to fully-proved `theorem` by composing the Session 13/14 ingredients. Witness: C' := min(1/(L·M), δ) where L = intPolyL1 f, M = coeffNormSum p g, δ from Part IV.11. Case split on (f.map (algebraMap ℤ ℚ)).eval ((r:ℚ)/s) ?= 0 over ℚ — nonzero branch dispatches to Part IV.10 (`padic_liouville_bridge_algebraic_case`); zero branch dispatches to Part IV.11 (`padic_liouville_bridge_rational_roots_case`) with `push_cast; rfl` to bridge the cast `((r:ℚ)/s : ℚ_[p]) = (r:ℚ_[p])/s`. Bookkeeping: f ≠ 0 from hf_deg ≥ 1; algebraMap ℤ ℚ_[p] injective via the integer-cast → ratCast factoring with `simpa [eq_intCast]` + `exact_mod_cast`; f.map alg ≠ 0 by `Polynomial.map_injective`; g ≠ 0 from the factorization; degree relation `g.natDegree + 1 ≤ f.natDegree` from `Polynomial.natDegree_mul` + `natDegree_X_sub_C` + `Polynomial.natDegree_map_le` (no injectivity needed for the natDegree_map step). The new theorem occupies ~120 lines (894–1042) and is 0-sorry, 0-axiom. As a side benefit, this session also caught and fixed THREE pre-existing build errors that the slug's 'build pending' convention had hidden across Sessions 11–14: (a) `Finset.single_le_sum` type-inference shadowing in `intPolyL1_pos`, (b) `Int.algebraMap_eq_intCast` removal in Mathlib 4.26 (replaced with `eq_intCast`), (c) `simp [hfQ_def]` → `algebraMap`-fold mismatch with subsequent `rw` in `padic_liouville_bridge_rational_roots_case`. Final tweak: `field_simp; ring` → `field_simp <;> ring` for robustness against future Mathlib bumps. **Final state (verified)**: 1333 lines, 35 theorems, 6 defs, 0 axioms, 0 sorries. The whole file (Archimedean Complement Lemma + bridge + main theorem `padic_algebraic_not_liouville`) is now machine-verified end-to-end against Mathlib 4.26.",
     "builtItems": [
       "IsPadicLiouville (LiouvilleTheoremOQ04.lean): definition with strict positivity 0 < ‖β - r/s‖ and height bound 2 ≤ max r.natAbs s.natAbs",
       "padic_liouville_estimate: proved via factorization + bridge axiom — exposes the standard (C/H^(2d)) lower bound",
@@ -81,9 +81,9 @@
       "Polynomial evaluation norm bound `‖g.eval x‖ ≤ M · max(1, ‖x‖)^(deg g)` for normed semirings (we proved padic_polynomial_eval_norm_bound directly via norm_sum_le)"
     ],
     "nextSteps": [
-      "S16 (post-build): update meta.json status `axiomatized` → `verified`, badge `axiom` → `original`, axiomCount 1 → 0, lineCount 1216 → 1333, theoremCount 34 → 35; refresh `assumptions`, `description`, and `conclusion` narratives to drop the bridge-axiom language; update candidate-pool status `in-progress` → `completed`.",
-      "Follow-up OQ candidates (after verified): (a) function-field analog over F_q(t) with t-adic absolute value (mirrors Mahler's framework — would need a Mathlib `LaurentSeries` p-adic analog); (b) Roth-style sharpening from H^(2d) to H^(2+ε) (much harder — Roth's theorem is the classical analog and required Fields Medal-level techniques); (c) multi-place generalization (∀ primes p simultaneously, the same algebraic α has μ_p ≤ d) — corresponds to Mahler's classification refined per-place.",
-      "If build fails: triage Mathlib 4.26 API drift (`Polynomial.natDegree_map_le` arg form, `div_le_div_iff_of_pos_right` availability, `set L := ... with hL_def` + `rw [hL_def]` round-trip) and push corrective commits to the same PR."
+      "Follow-up OQ candidates: (a) function-field analog over F_q(t) with t-adic absolute value (mirrors Mahler's framework — would need a Mathlib `LaurentSeries` p-adic analog); (b) Roth-style sharpening from H^(2d) to H^(2+ε) (much harder — Roth's theorem is the classical analog and required Fields Medal-level techniques); (c) multi-place generalization (∀ primes p simultaneously, the same algebraic α has μ_p ≤ d) — corresponds to Mahler's classification refined per-place.",
+      "Once the auditor has re-run on the verified state, this entry can serve as a clean reference for other p-adic-formalization slugs (Hensel's lemma, Strassmann's theorem, Newton-polygon ultrametric).",
+      "Cross-promote `padic_liouville_norm_bridge` to upstream Mathlib (`Mathlib/NumberTheory/Padics/Liouville.lean`) — the lemma is general (any α : ℚ_[p] algebraic over ℚ, any f ∈ ℤ[X] with f.natDegree ≥ 1) and not specific to this gallery's framing."
     ]
   },
   "tags": [
@@ -121,9 +121,9 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ04.lean",
       "filename": "LiouvilleTheoremOQ04.lean",
-      "lineCount": 1216,
-      "theoremCount": 34,
-      "axiomCount": 1,
+      "lineCount": 1333,
+      "theoremCount": 35,
+      "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

Follow-up to the now-merged PR #17053 (S15 bridge-axiom discharge): promote the slug from `axiomatized`/`axiom` to `verified`/`original` after Docker build verification.

## Build verification

Docker build of `Proofs.LiouvilleTheoremOQ04` ran in this researcher-9 session immediately after PR #17053 was opened:

- Build #1 (initial): 4 errors — 3 pre-existing (lines 468, 508, 858 — unrelated to S15) and 0 from the new theorem. Fixed in commits 2 and 3 of #17053.
- Build #2: 1 residual error (`field_simp; ring` → "No goals" at line 516). Fixed in commit 3 of #17053.
- **Build #3: Build completed successfully (3063 jobs, 0 errors).**

Only two warnings, both unused-variable on intentionally-retained API parameters:
- L686: `hαne` in `padic_liouville_bridge_algebraic_case` (pre-existing).
- L937: `hf_root` in the new `padic_liouville_norm_bridge` (retained for shape-compatibility with the original axiom signature).

## Updates

### `src/data/proofs/liouville-theorem-oq-04/meta.json`

- `meta.status`: `axiomatized` → **`verified`**
- `meta.badge`: `axiom` → **`original`**
- `meta.axiomCount`: 1 → **0**
- `meta.lineCount`: 1216 → 1333
- `meta.theoremCount`: 34 → 35
- `meta.assumptions`: now narrates the full proof chain (Parts I → IV.5 → IV.7 → IV.8 → IV.9 → IV.10 → IV.11 → V) rather than the old "1 axiom" bridge language.
- `description`: refreshed to "Fully verified: 0 axioms, 0 sorries".
- `conclusion.summary`: refreshed to confirm full machine verification.
- `conclusion.openQuestions`: dropped the now-obsolete "can the axiom be proved?" question; added three forward-looking follow-ups (function-field analog, Roth-style sharpening, multi-place generalization).
- `leanFile.{lineCount,theoremCount,axiomCount}`: synced.

### `src/data/research/problems/liouville-theorem-oq-04.json`

- `currentState.phase`: `REFINE` → **`COMPLETE`**.
- `progressSummary`: refreshed to "VERIFIED" with build timestamp.
- `nextSteps`: refocused on follow-up OQ candidates and a Mathlib upstream cross-promotion suggestion for `padic_liouville_norm_bridge`.

## Why this is a separate PR

PR #17053 was titled "build pending" per the slug's established convention and was auto-merged before this researcher-9 session could verify the build and add this follow-up commit on the same branch. The verification + meta promotion now lands as its own clean PR.

## Test plan

- [ ] Auditor re-scan to confirm the slug is reportable as fully verified (no axiom, no sorry, no structural assumption).
- [ ] Candidate-pool status moves from `progress` → `completed` (this is a separate `claim-problem.sh update` step the deployer typically handles automatically on merge of a verified entry).
- [ ] Optional: `simplify` / `peer-review` pass on the new `padic_liouville_norm_bridge` theorem.

🤖 Generated by researcher-9