### PR TITLE
research(four-square-distribution-oq-01): S7 — Part 17, n-keyed σ* closed form

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -1049,4 +1049,83 @@ example : jacobiR4 (2 ^ 0 * 3) = 8 * sigmaOne 3 :=
 example : jacobiR4 (2 ^ 3 * 5) = 24 * sigmaOne 5 :=
   jacobiR4_decomp (by decide) (by decide)
 
+-- =====================================================================
+-- PART 17: n-keyed σ* closed form (no caller-supplied decomposition).
+--
+-- Wraps Part 16's `sigmaStar_decomp` with Mathlib's
+-- `Nat.exists_eq_pow_mul_and_not_dvd` so that callers get a fully
+-- `n`-driven existential statement: for any positive `n` there exist
+-- `k m` realizing the 2-adic decomposition `n = 2^k · m` (with `m`
+-- odd and positive) together with the unified `if`-form for `σ*(n)`.
+--
+-- Compared to Part 16, this drops the friction of having the caller
+-- supply `(k, m)`. Mathlib's `exists_eq_pow_mul_and_not_dvd` guarantees
+-- the decomposition exists for every nonzero `n`; positivity of `m`
+-- follows from `n = 2^k · m > 0`.
+-- =====================================================================
+
+/-- Existential `n`-keyed closed form for σ*. For every `n > 0` there
+    exist `k m : ℕ` such that
+      * `n = 2 ^ k * m`,
+      * `m` is odd (i.e. `¬ 2 ∣ m`),
+      * `m > 0`,
+      * `σ*(n) = (if k = 0 then 1 else 3) * σ(m)`.
+
+    This packages Parts 6, 15, and 16 together with Mathlib's
+    `Nat.exists_eq_pow_mul_and_not_dvd` so that no caller-supplied
+    `(k, m)` decomposition is required: the σ*-side of Jacobi's r₄
+    formula is reduced to a single `Nat.sigma 1 m` call once the
+    decomposition is extracted. -/
+theorem sigmaStar_eq_decomp_form (n : ℕ) (hn : 0 < n) :
+    ∃ (k m : ℕ), n = 2 ^ k * m ∧ ¬ 2 ∣ m ∧ 0 < m ∧
+      sigmaStar n = (if k = 0 then 1 else 3) * sigmaOne m := by
+  have hn0 : n ≠ 0 := hn.ne'
+  obtain ⟨k, m, hodd, hn_eq⟩ :=
+    Nat.exists_eq_pow_mul_and_not_dvd hn0 2 (by decide)
+  have hmpos : 0 < m := by
+    rcases Nat.eq_zero_or_pos m with hm0 | hm0
+    · exfalso
+      apply hn0
+      rw [hn_eq, hm0, Nat.mul_zero]
+    · exact hm0
+  refine ⟨k, m, hn_eq, hodd, hmpos, ?_⟩
+  rw [hn_eq]
+  exact sigmaStar_decomp hmpos hodd
+
+/-- Existential `n`-keyed closed form for `jacobiR4`. For every `n > 0`
+    there exist `k m : ℕ` with `n = 2^k · m`, `m` odd and positive, and
+    `jacobiR4(n) = (if k = 0 then 8 else 24) · σ(m)`.
+
+    Companion to `sigmaStar_eq_decomp_form`: the same `(k, m)`
+    decomposition fixes both σ* and `jacobiR4 = 8·σ*`. -/
+theorem jacobiR4_eq_decomp_form (n : ℕ) (hn : 0 < n) :
+    ∃ (k m : ℕ), n = 2 ^ k * m ∧ ¬ 2 ∣ m ∧ 0 < m ∧
+      jacobiR4 n = (if k = 0 then 8 else 24) * sigmaOne m := by
+  obtain ⟨k, m, hn_eq, hodd, hmpos, _⟩ := sigmaStar_eq_decomp_form n hn
+  refine ⟨k, m, hn_eq, hodd, hmpos, ?_⟩
+  rw [hn_eq]
+  exact jacobiR4_decomp hmpos hodd
+
+-- ---------------------------------------------------------------------
+-- Cross-validation: existence form applied to specific n.
+-- ---------------------------------------------------------------------
+
+/-- Existence form on n = 1 (odd): produces some k, m with σ*(1)
+    expressed via the unified `if`-form. -/
+example : ∃ (k m : ℕ), (1 : ℕ) = 2 ^ k * m ∧ ¬ 2 ∣ m ∧ 0 < m ∧
+    sigmaStar 1 = (if k = 0 then 1 else 3) * sigmaOne m :=
+  sigmaStar_eq_decomp_form 1 (by decide)
+
+/-- Existence form on n = 8 (= 2^3 · 1, even): yields the σ*(8) closed
+    form via Part 17 without supplying `(k, m)`. -/
+example : ∃ (k m : ℕ), (8 : ℕ) = 2 ^ k * m ∧ ¬ 2 ∣ m ∧ 0 < m ∧
+    sigmaStar 8 = (if k = 0 then 1 else 3) * sigmaOne m :=
+  sigmaStar_eq_decomp_form 8 (by decide)
+
+/-- Existence form on n = 40 (= 2^3 · 5, even): yields the jacobiR4(40)
+    closed form (= 144) via Part 17 without supplying `(k, m)`. -/
+example : ∃ (k m : ℕ), (40 : ℕ) = 2 ^ k * m ∧ ¬ 2 ∣ m ∧ 0 < m ∧
+    jacobiR4 40 = (if k = 0 then 8 else 24) * sigmaOne m :=
+  jacobiR4_eq_decomp_form 40 (by decide)
+
 end FourSquareDistributionOQ01

--- a/research/problems/four-square-distribution-oq-01/knowledge.md
+++ b/research/problems/four-square-distribution-oq-01/knowledge.md
@@ -377,3 +377,61 @@ already proven in Parts 6 and 15. S6 simply hands the user a single
 lemma that handles both branches. The open axiom `jacobi_r4_formula`
 is unchanged. The σ*-side is reduced from two named lemmas to one;
 the modular-form bridge remains the open frontier.
+
+## Session 7 (2026-05-08, researcher-11)
+
+### Part 17 — `n`-keyed existential closed form
+
+S7 wraps Part 16's caller-supplies-`(k, m)` closed form with Mathlib's
+`Nat.exists_eq_pow_mul_and_not_dvd`, removing the last "user supplies
+(k, m)" friction from the σ*-side:
+
+* `sigmaStar_eq_decomp_form (n : ℕ) (hn : 0 < n) :`
+  `∃ k m, n = 2^k · m ∧ ¬ 2 ∣ m ∧ 0 < m ∧`
+  `σ*(n) = (if k = 0 then 1 else 3) · σ(m)`
+* `jacobiR4_eq_decomp_form` — same shape, `8`/`24` constants.
+
+### Proof structure
+
+1. From `0 < n` derive `n ≠ 0`.
+2. Apply `Nat.exists_eq_pow_mul_and_not_dvd hn0 2 (by decide : 2 ≠ 1)`
+   to obtain `(k, m, ¬ 2 ∣ m, n = 2^k · m)`.
+3. Derive `0 < m` from `n = 2^k · m > 0` (`m = 0` would force
+   `n = 2^k · 0 = 0`, contradicting `hn0`).
+4. The σ* equality is a one-line delegation:
+   `rw [hn_eq]; exact sigmaStar_decomp hmpos hodd`.
+5. `jacobiR4_eq_decomp_form` reuses (1)-(3) by destructuring the σ*
+   form, then delegates to `jacobiR4_decomp` (Part 16).
+
+### Cross-validation
+
+Three `example` checks exercise the existential form on concrete `n`:
+
+| n  | Branch    | Witness  | Statement                       |
+|----|-----------|----------|---------------------------------|
+| 1  | k = 0     | (0, 1)   | σ*(1) = 1·σ(1) = 1              |
+| 8  | k = 3 ≥ 1 | (3, 1)   | σ*(8) = 3·σ(1) = 3              |
+| 40 | k = 3 ≥ 1 | (3, 5)   | jacobiR4(40) = 24·σ(5) = 144   |
+
+Each is discharged by `sigmaStar_eq_decomp_form n (by decide)` (or
+`jacobiR4_eq_decomp_form n (by decide)`) — the existence statement on
+a specific `n` is established by re-invoking S7 with `0 < n` proved
+by `decide`.
+
+### S7 build status
+
+Build pending (same as S6 — `proofs/.lake` self-referential symlink
+forces a fresh Mathlib clone per Docker build). The new theorems are
+short delegations: `Nat.exists_eq_pow_mul_and_not_dvd` provides the
+decomposition, the σ* equality delegates to Part 16. Auditor pipeline
+carries the build outcome on the PR.
+
+### Honest assessment
+
+S7 is another **packaging refinement** — a one-step convenience wrap
+on top of S6. It does not extend the mathematical content; it just
+removes the caller-side burden of producing `(k, m)`. The σ*-side is
+now reduced to a single `Nat.sigma 1` lookup (the odd part's σ-value),
+parameterized by `n` alone. The open axiom `jacobi_r4_formula` is
+unchanged. Mathlib's q-expansion of `jacobiTheta` remains the gating
+blocker on the modular-form side.

--- a/research/problems/four-square-distribution-oq-01/state.md
+++ b/research/problems/four-square-distribution-oq-01/state.md
@@ -1,41 +1,46 @@
 # Research State: four-square-distribution-oq-01
 
 ## Current State
-**Phase**: ACT (S6: σ*-side closed form **unified into a single
-`if`-form** statement). Closure of `jacobi_r4_formula` still requires
+**Phase**: ACT (S7: σ*-side **fully n-driven** — Part 17 wraps Part 16
+with `Nat.exists_eq_pow_mul_and_not_dvd` so callers no longer need to
+supply `(k, m)`). Closure of `jacobi_r4_formula` still requires
 Mathlib q-expansion of `jacobiTheta`.
 **Path**: full
 **Since**: 2026-05-07
-**Last Updated**: 2026-05-08 (S6, researcher-11)
-**Iteration**: 6
+**Last Updated**: 2026-05-08 (S7, researcher-11)
+**Iteration**: 7
 
 ## Current Focus
-S6 (this session) added **Part 16** to FourSquareDistributionOQ01.lean,
-unifying S5's two-case closed form into a single statement:
+S7 (this session) added **Part 17** to FourSquareDistributionOQ01.lean,
+wrapping Part 16's caller-supplies-`(k, m)` form with Mathlib's
+`Nat.exists_eq_pow_mul_and_not_dvd`:
 
-* **`sigmaStar_decomp`**: for `m` odd, `0 < m`, **any** `k ≥ 0`,
-  `σ*(2^k · m) = (if k = 0 then 1 else 3) · σ(m)`.
-* **`jacobiR4_decomp`**: same hypotheses,
-  `jacobiR4(2^k · m) = (if k = 0 then 8 else 24) · σ(m)`.
+* **`sigmaStar_eq_decomp_form`**: for any `n > 0`,
+  `∃ k m, n = 2^k · m ∧ ¬ 2 ∣ m ∧ 0 < m ∧
+   σ*(n) = (if k = 0 then 1 else 3) · σ(m)`.
+* **`jacobiR4_eq_decomp_form`**: same hypotheses,
+  `∃ k m, n = 2^k · m ∧ ¬ 2 ∣ m ∧ 0 < m ∧
+   jacobiR4(n) = (if k = 0 then 8 else 24) · σ(m)`.
 
-This drops Part 15's `1 ≤ k` side-condition by absorbing the `k = 0`
-case into the `if`. The proof is a 4-line case split: `k = 0` reduces
-via `sigmaStar_eq_sigmaOne_of_odd` (Part 6); `k ≠ 0` reduces via
-`sigmaStar_two_pow_mul_odd` (Part 15). Seven cross-validation
-`example` checks cover both branches at n ∈ {1, 3, 2, 40}.
+Three cross-validation `example` checks (n ∈ {1, 8, 40}) exercise the
+new existential form. Proof is short: `Nat.exists_eq_pow_mul_and_not_dvd
+hn0 2 (by decide)` produces `(k, m, ¬2∣m, n = 2^k·m)`; positivity of
+`m` follows from `n > 0 = 2^k·m`; the σ* equation is a one-line
+delegation to Part 16.
 
-**What S6 changes**: the σ*-side now exposes a single uniform formula
-that future modular-form work can pattern-match on without case
-analysis at the call site. The `if`-form mirrors the Eisenstein-series
-coefficient structure in `1 + 8(E₂(τ) − 4·E₂(4τ))`, where the factor
-of 3 (resp. 1) corresponds to the odd-divisor weight on even (resp.
-odd) n. The open axiom `jacobi_r4_formula` is unchanged.
+**What S7 changes**: the σ*-side is now keyed *off `n` directly* — no
+caller-supplied `(k, m)` decomposition is required, just `n > 0`.
+Mathlib provides the 2-adic decomposition. Combined with the open
+modular-form bridge, the σ*-side of Jacobi's r₄ formula is now a
+two-step closure: extract `(k, m)` (Part 17), apply the if-form
+(Part 16). The open axiom `jacobi_r4_formula` is unchanged.
 
 ## Reduction Frontier
-The σ*-side is now reduced to **two** Mathlib lookups: `Nat.factorization`
-to extract `(k, m)` from any `n > 0`, and `Nat.sigma 1 m` for the
-σ-value. With S6 in place, the remaining gap is purely on the
-modular-form side; the divisor-sum side is closed.
+The σ*-side is now reduced to **one** Mathlib lookup: `Nat.sigma 1 m`
+for the σ-value of the odd part. The decomposition `n = 2^k · m` is
+already provided by `Nat.exists_eq_pow_mul_and_not_dvd` in Part 17.
+With S7 in place, the σ*-side is fully `n`-keyed and the remaining
+gap is purely on the modular-form side.
 
 ## Active Approach
 
@@ -59,7 +64,7 @@ Currently still blocked on Mathlib infrastructure:
 
 ## Attempt Count
 
-- Total attempts: 6.
+- Total attempts: 7.
 - S1 (researcher-?): OBSERVE/ORIENT bootstrap (axiomatize, n = 1..10).
 - S2 (researcher-10): ACT — σ*(n) = σ(n) − 4·σ(n/4)·[4∣n] structural.
 - S3 (researcher-?): σ* on odd prime powers, σ*(2n)/σ*(4n) = 3·σ(n).
@@ -67,6 +72,8 @@ Currently still blocked on Mathlib infrastructure:
 - S5 (researcher-8, 2026-05-08): σ*(2^k · m) = 3·σ(m) closed form.
 - S6 (researcher-11, 2026-05-08): Part 16 — unified `sigmaStar_decomp`
   / `jacobiR4_decomp` (single-formula `if`-form for k ≥ 0).
+- S7 (researcher-11, 2026-05-08): Part 17 — `n`-keyed existential form
+  via `Nat.exists_eq_pow_mul_and_not_dvd` (no caller-supplied (k,m)).
 - Approaches tried: 1 (Approach A — modular form bridge).
 
 ## Blockers
@@ -74,24 +81,23 @@ Currently still blocked on Mathlib infrastructure:
 - **Mathlib q-expansion infrastructure absent** for `jacobiTheta` —
   unchanged from S1.
 - **Mathlib Eisenstein-coefficient identification absent** — unchanged.
-- **Local Docker build verification**: S6 elects the "build pending"
-  pattern (S13/S14 of sperner-ndim-mathlib-oq-02 precedent) — the
-  proofs/.lake self-referential symlink forces a fresh Mathlib clone
-  per Docker build (~45 min cold). New theorems are 4-line corollaries
-  of already-proven Part 15 / Part 6 lemmas; auditor pipeline carries
-  the build outcome.
+- **Local Docker build verification**: S7 (like S6) elects the "build
+  pending" pattern — the `proofs/.lake` self-referential symlink forces
+  a fresh Mathlib clone per Docker build (~45 min cold). New theorems
+  are short delegations to Mathlib's `Nat.exists_eq_pow_mul_and_not_dvd`
+  + Part 16's `sigmaStar_decomp` / `jacobiR4_decomp`; auditor pipeline
+  carries the build outcome.
 
 ## Next Action
 
 1. **(opportunistic)** When Mathlib gains q-expansion for `jacobiTheta`,
-   apply `sigmaStar_decomp` (S6) — one rewrite rather than two — to
-   close `axiom jacobi_r4_formula` for all n > 0 given a 2-adic
-   decomposition.
-2. **(productive — small)** Wrap `sigmaStar_decomp` with
-   `Nat.exists_eq_pow_mul_and_not_dvd` (or equivalent factorization
-   helper) to get a `∃ k m`-statement keyed off `n` directly, with
-   no caller-supplied decomposition. Once attempted, this would
-   eliminate the last "user supplies (k, m)" friction.
+   apply `sigmaStar_eq_decomp_form` (S7) — one rewrite — to close
+   `axiom jacobi_r4_formula` for all n > 0 directly.
+2. **(productive — small)** Promote the existential `(k, m)` to a
+   `noncomputable` function: `oddPart : (n : ℕ) → 0 < n → ℕ` returning
+   `(Nat.exists_eq_pow_mul_and_not_dvd hn 2 _).choose_spec` paired data,
+   or use `padicValNat 2 n` directly (k = padicValNat 2 n; m = n / 2^k).
+   Yields a ready-to-call `σ*(n) = ... · σ(oddPart n)` rewrite rule.
 3. **(speculative)** Pursue the Hurwitz-quaternion route. Mathlib has
    quaternions but no Hurwitz integers; multi-month project upstream.
 4. **(skip)** Brute-force extension beyond n = 10 — pure enumeration
@@ -101,12 +107,12 @@ Currently still blocked on Mathlib infrastructure:
 
 ## References
 
-- `proofs/Proofs/FourSquareDistributionOQ01.lean` — Parts 1-16:
+- `proofs/Proofs/FourSquareDistributionOQ01.lean` — Parts 1-17:
   bootstrap (1-5), structural σ* ↔ σ (6-7), σ* on odd prime powers (8),
   σ*(2n) = σ*(4n) = 3·σ(n) for odd n (9-10), σ-multiplicativity bridge
   (11), σ*-multiplicativity (12), σ*(2^k) closed form (13),
   cross-validation (14), σ*(2^k · m) closed form (15, S5),
-  unified `if`-form (16, S6).
+  unified `if`-form (16, S6), `n`-keyed existential form (17, S7).
 - `proofs/Proofs/FourSquareDistribution.lean` — parent file with
   type-decomposition theorems used as cross-checks.
 - `src/data/proofs/four-square-distribution-oq-01/meta.json` —

--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1052,
-    "theoremCount": 88,
+    "lineCount": 1131,
+    "theoremCount": 90,
     "definitionCount": 6,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

S7 of `four-square-distribution-oq-01`. Wraps Part 16's caller-supplies-`(k, m)` closed form with Mathlib's `Nat.exists_eq_pow_mul_and_not_dvd` to give an `n`-only existential closed form for σ* and `jacobiR4`. No new mathematical content — packaging refinement that removes the last "user supplies (k, m)" friction from the σ*-side of Jacobi's r₄ formula.

## Changes

`proofs/Proofs/FourSquareDistributionOQ01.lean` — Part 17 (~80 lines):

* `sigmaStar_eq_decomp_form (n : ℕ) (hn : 0 < n) :`
  `∃ k m, n = 2^k · m ∧ ¬ 2 ∣ m ∧ 0 < m ∧`
  `σ*(n) = (if k = 0 then 1 else 3) · σ(m)`
* `jacobiR4_eq_decomp_form` — same shape, `8`/`24` constants.
* Three `example` cross-checks at n ∈ {1, 8, 40} exercise the existential form.

`src/data/proofs/four-square-distribution-oq-01/meta.json`:
* `lineCount` 1052 → 1131
* `theoremCount` 88 → 90

`research/problems/four-square-distribution-oq-01/state.md` and `knowledge.md`:
* Iteration bumped to 7; current focus + reduction frontier updated; honest assessment recorded.

## Proof structure

1. From `0 < n` derive `n ≠ 0`.
2. Apply `Nat.exists_eq_pow_mul_and_not_dvd hn0 2 (by decide : 2 ≠ 1)` to obtain `(k, m, ¬ 2 ∣ m, n = 2^k · m)`.
3. Derive `0 < m` from `n = 2^k · m > 0` (`m = 0` would force `n = 0`).
4. The σ* equality is a one-line delegation to Part 16's `sigmaStar_decomp`.
5. `jacobiR4_eq_decomp_form` reuses (1)-(3) and delegates to Part 16's `jacobiR4_decomp`.

## Build status

Build pending (S6 precedent — `proofs/.lake` symlink-trap forces a fresh Mathlib clone per Docker build, ~45 min cold). The new theorems are short delegations to already-proven Part 16 lemmas + a single-step Mathlib call. Auditor pipeline carries the build outcome.

## Honest assessment

Packaging refinement only. The mathematical content was already proven in Parts 6 / 15 / 16. S7 just removes the caller-side burden of producing `(k, m)`. Open axiom `jacobi_r4_formula` is unchanged — the modular-form bridge (q-expansion of `jacobiTheta` in Mathlib) remains the gating blocker.

## Test plan

- [ ] `proofs/scripts/docker-build.sh Proofs.FourSquareDistributionOQ01` (auditor pipeline)
- [ ] `pnpm build` to confirm gallery integration