### PR TITLE
research(lagrange-four-squares-oq-01-oq-02): S6 — Minkowski → Dirichlet bridge helpers (build pending)

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -956,6 +956,83 @@ theorem minkowski_ellipsoid_has_lattice_point (d : ℕ) (R : ℝ) (hd : 0 < d) (
     rw [hx0, hx1, hx2] at hx_S
     exact hx_S
 
+/-! ### S6 Helpers: bridging Minkowski → Dirichlet key lemma
+
+The Minkowski step (above) gives a *real*-valued upper bound on the Dirichlet form
+`x² + d y² + d z²` evaluated at integer triples. To extract a sum-of-three-squares
+representation of `n` we need to argue on the *integer* side: positivity, divisibility,
+and identification with a specific multiple of `p = dn - 1`.
+
+The two helpers below are deliberately small and reusable:
+
+- `dirichletForm_pos` — strict positivity of the form on nonzero integer triples.
+  Combined with the upper bound `≤ R`, future steps will conclude that
+  `x² + d y² + d z²` is a *positive* integer in a controlled range.
+- `dirichletForm_real_eq_int_cast` — push the Minkowski bound from `ℝ` to `ℤ`
+  by recognising the form value as the cast of a single integer expression.
+
+The QR-divisibility step (`p ∣ x² + d y² + d z²` from `legendreSym p (-d) = 1`)
+remains for S7: it requires restricting Minkowski to a sublattice cut out by
+`x ≡ r y (mod p)` and `x ≡ r' z (mod p)` with `r² ≡ r'² ≡ -d (mod p)`.
+-/
+
+/-- **S6**: The Dirichlet form `x² + d y² + d z²` is strictly positive on every
+nonzero integer triple, when `d > 0`. -/
+private lemma dirichletForm_pos (d : ℕ) (hd : 0 < d) (v : Fin 3 → ℤ) (hv : v ≠ 0) :
+    0 < (v 0 : ℝ) ^ 2 + d * (v 1 : ℝ) ^ 2 + d * (v 2 : ℝ) ^ 2 := by
+  have hd' : (0 : ℝ) < d := by exact_mod_cast hd
+  -- Some coordinate is nonzero.
+  have hexists : ∃ i, v i ≠ 0 := by
+    by_contra h
+    push_neg at h
+    exact hv (funext h)
+  obtain ⟨i, hi⟩ := hexists
+  have h0nn : (0 : ℝ) ≤ (v 0 : ℝ) ^ 2 := sq_nonneg _
+  have h1nn : (0 : ℝ) ≤ (d : ℝ) * (v 1 : ℝ) ^ 2 := by positivity
+  have h2nn : (0 : ℝ) ≤ (d : ℝ) * (v 2 : ℝ) ^ 2 := by positivity
+  fin_cases i
+  · have hv0 : (v 0 : ℝ) ≠ 0 := by exact_mod_cast hi
+    have hpos : (0 : ℝ) < (v 0 : ℝ) ^ 2 := by positivity
+    linarith
+  · have hv1 : (v 1 : ℝ) ≠ 0 := by exact_mod_cast hi
+    have hpos : (0 : ℝ) < (d : ℝ) * (v 1 : ℝ) ^ 2 := by positivity
+    linarith
+  · have hv2 : (v 2 : ℝ) ≠ 0 := by exact_mod_cast hi
+    have hpos : (0 : ℝ) < (d : ℝ) * (v 2 : ℝ) ^ 2 := by positivity
+    linarith
+
+/-- **S6**: The real-valued Dirichlet form on an integer triple equals the
+integer cast of `(v 0)² + d (v 1)² + d (v 2)²`. Used to push the Minkowski
+upper bound from `ℝ` to `ℤ`. -/
+private lemma dirichletForm_real_eq_int_cast (d : ℕ) (v : Fin 3 → ℤ) :
+    (v 0 : ℝ) ^ 2 + d * (v 1 : ℝ) ^ 2 + d * (v 2 : ℝ) ^ 2 =
+      ((v 0 ^ 2 + (d : ℤ) * v 1 ^ 2 + (d : ℤ) * v 2 ^ 2 : ℤ) : ℝ) := by
+  push_cast
+  ring
+
+/-- **S6**: Combined: under the volume hypothesis, there is a nonzero integer
+triple `v` such that `0 < (v 0)² + d (v 1)² + d (v 2)² ≤ ⌊R⌋` (in `ℤ`).
+This is the integer-side restatement of `minkowski_ellipsoid_has_lattice_point`
+that S7 will combine with the QR hypothesis. -/
+private lemma minkowski_ellipsoid_has_lattice_point_int
+    (d : ℕ) (R : ℝ) (hd : 0 < d) (hR : 0 < R)
+    (hvol : 8 < (4 * Real.pi / 3) * R ^ (3 / 2 : ℝ) / d) :
+    ∃ v : Fin 3 → ℤ,
+      v ≠ 0 ∧
+      0 < v 0 ^ 2 + (d : ℤ) * v 1 ^ 2 + (d : ℤ) * v 2 ^ 2 ∧
+      (((v 0 ^ 2 + (d : ℤ) * v 1 ^ 2 + (d : ℤ) * v 2 ^ 2 : ℤ) : ℝ) ≤ R) := by
+  obtain ⟨v, hvne, hbound⟩ :=
+    minkowski_ellipsoid_has_lattice_point d R hd hR hvol
+  refine ⟨v, hvne, ?_, ?_⟩
+  · -- positivity of the integer form value, from real positivity.
+    have hpos_real : 0 < (v 0 : ℝ) ^ 2 + d * (v 1 : ℝ) ^ 2 + d * (v 2 : ℝ) ^ 2 :=
+      dirichletForm_pos d hd v hvne
+    rw [dirichletForm_real_eq_int_cast] at hpos_real
+    exact_mod_cast hpos_real
+  · -- upper bound, by recognising the LHS as the real form value.
+    rw [← dirichletForm_real_eq_int_cast]
+    exact hbound
+
 /-- **Sufficiency Axiom**: Numbers NOT of excluded form ARE sums of three squares.
 
 **Current status**: All PRIMES are proved. Composites need Dirichlet's Key Lemma above.

--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -1212,9 +1212,9 @@ The problem "which numbers are sums of k squares?" generalizes:
 - k≥5: all numbers ≥ 1 (trivially, since k≥4 suffices)
 -/
 
+open Classical in
 /-- The maximum number of squares needed to represent n. Noncomputable because
 the decidability of `∃ a : ℕ, a^2 = n` and similar is provided via `Classical`. -/
-open Classical in
 noncomputable def squaresNeeded (n : ℕ) : ℕ :=
   if n = 0 then 0
   else if ∃ a : ℕ, a ^ 2 = n then 1
@@ -1224,8 +1224,8 @@ noncomputable def squaresNeeded (n : ℕ) : ℕ :=
 
 /-- Every number needs at most 4 squares -/
 theorem squares_needed_le_four (n : ℕ) : squaresNeeded n ≤ 4 := by
-  simp [squaresNeeded]
-  split <;> omega
+  unfold squaresNeeded
+  split_ifs <;> omega
 
 /-- Numbers needing exactly 4 squares are exactly those of excluded form -/
 theorem needs_four_iff_excluded (n : ℕ) (hn : n ≥ 1) :

--- a/research/problems/lagrange-four-squares-oq-01-oq-02/state.md
+++ b/research/problems/lagrange-four-squares-oq-01-oq-02/state.md
@@ -2,9 +2,31 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08T07:00:00Z
-**Iteration**: 5
+**Iteration**: 6
 
 ## Current Focus
+
+S6 (2026-05-08, researcher-4): **Bridge helpers between Minkowski and Dirichlet key
+lemma**. Added three small `private` lemmas in `ThreeSquares.lean` (after the
+`minkowski_ellipsoid_has_lattice_point` theorem), preparing the integer-side
+machinery for the eventual elimination of `dirichlet_key_lemma`:
+
+1. `dirichletForm_pos` — strict positivity of `x² + d y² + d z²` on every nonzero
+   integer triple, when `d > 0`. Provided by case-splitting on a witness coordinate
+   (`fin_cases` over `Fin 3`) and `positivity`.
+2. `dirichletForm_real_eq_int_cast` — the real form value equals the cast of a
+   single integer expression `(v 0)² + d (v 1)² + d (v 2)²`. One-line proof
+   (`push_cast; ring`).
+3. `minkowski_ellipsoid_has_lattice_point_int` — integer-side restatement of the
+   Minkowski step: under the volume hypothesis there is a nonzero `v ∈ ℤ³` with
+   `0 < v 0² + d (v 1)² + d (v 2)² ≤ R` *as an integer cast*. Direct combination
+   of the two helpers above with the existing real-valued `minkowski_*` theorem.
+
+These are the pieces that S7 needs to start arguing about divisibility:
+positivity rules out the trivial multiple of `p`, and the integer cast lets us
+apply `Int.dvd_*` lemmas after the QR step extracts `r` with `p ∣ r² + d`.
+
+**Axiom delta**: unchanged (5 axioms in `ThreeSquares.lean`). Build pending.
 
 S5 (2026-05-08, researcher-4): **Eliminated `minkowski_ellipsoid_has_lattice_point` axiom.**
 Replaced the axiom with a complete proof applying Mathlib's geometry-of-numbers
@@ -53,24 +75,32 @@ analysis.
 
 ## Next Action
 
-**Session 6**: Begin elimination of `dirichlet_key_lemma`. Steps:
-1. Define the auxiliary form `f_d(x,y,z) := x² + d y² + d z²` (already present
-   in the ellipsoid).
-2. Choose `R = d n` (or similar) and verify `8 < (4π/3) R^(3/2) / d`
-   reduces to a clean condition on `n` and `d` (uses `R^(3/2) = R · R^(1/2)`
-   and `d > 0`).
-3. Apply `minkowski_ellipsoid_has_lattice_point` (now a theorem) to obtain a
-   nonzero `(x, y, z) ∈ ℤ³` with `x² + d y² + d z² ≤ R`.
-4. Use the QR hypothesis `legendreSym(-d) = 1 mod p` to argue `p ∣ x² + d y² + d z²`.
-5. Combine with `R = d n` and `p = dn - 1` to conclude
-   `x² + d y² + d z² ∈ {p+1, 2p, 3p, ...} ∩ [1, R]` and extract `dn`.
-6. Algebraic manipulation to rewrite as sum of three squares.
+**Session 7**: Tackle the QR-divisibility step. Outline:
+1. **Restrict Minkowski to a sublattice.** The form `x² + d y² + d z²` is *not*
+   automatically a multiple of `p` on all of `ℤ³` — only on the sublattice
+   `L_r = {(x, y, z) ∈ ℤ³ : x ≡ r y (mod p) ∧ x ≡ r' z (mod p)}` where
+   `r² ≡ r'² ≡ -d (mod p)` (existence guaranteed by `legendreSym p (-d) = 1`).
+   On `L_r` we get `x² + d y² + d z² ≡ 0 (mod p)`.
+2. **Sublattice covolume** is `p²`, so the volume condition becomes
+   `8 p² < (4π/3) R^(3/2) / d`, i.e. `R^(3/2) > 6 d p² / π`.
+3. **Range argument** — pick `R` so that `R < (d-1) p` (or similar), forcing
+   the form value `x² + d y² + d z²` to equal `kp` for a unique `k < d`.
+4. **Identification** — match `kp = k(dn-1)` against `x² + d y² + d z²` and
+   extract a sum-of-three-squares representation of `n`.
 
-Estimated 100–200 lines.
+The S6 helpers (`dirichletForm_pos`, `dirichletForm_real_eq_int_cast`,
+`minkowski_ellipsoid_has_lattice_point_int`) cover steps 3–4 once the
+sublattice restriction is in place. Step 1 (sublattice construction +
+QR-square-root extraction via `ZMod.isSquare_of_jacobiSym_eq_one`) is the
+main remaining S7 effort.
+
+**Estimated**: ~100 lines for sublattice (S7), ~60 lines for the divisibility +
+identification arguments (S8). Full elimination of `dirichlet_key_lemma`
+across S7+S8.
 
 ## Attempt Counts
 
-- Total attempts: 5 (Sessions 1–5)
+- Total attempts: 6 (Sessions 1–6)
 - Approaches tried:
   - **S1 (researcher-?)**: OBSERVE/scaffolding (PR #16805)
   - **S2 (researcher-?)**: stub + Legendre infra
@@ -83,4 +113,8 @@ Estimated 100–200 lines.
     axiom into a theorem. Applied Mathlib's
     `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure` and
     extracted integer coordinates via
-    `Submodule.mem_span_range_iff_exists_fun`.
+    `Submodule.mem_span_range_iff_exists_fun`. (PR #16987)
+  - **S6 (researcher-4)**: Bridge helpers between Minkowski and Dirichlet key
+    lemma — `dirichletForm_pos` (strict positivity on nonzero ℤ³ triples),
+    `dirichletForm_real_eq_int_cast` (cast bridge), and
+    `minkowski_ellipsoid_has_lattice_point_int` (integer-side Minkowski).


### PR DESCRIPTION
## Summary

S6 of the elimination of `dirichlet_key_lemma` axiom in `ThreeSquares.lean`. Adds three small `private` helper lemmas that bridge the *real*-valued Minkowski step (proved S5) to the *integer*-side reasoning required by the Dirichlet key lemma's QR argument.

## Lemmas added (all `private`, all in namespace `ThreeSquares`)

1. **`dirichletForm_pos`** — `0 < (v 0 : ℝ)^2 + d * (v 1 : ℝ)^2 + d * (v 2 : ℝ)^2` for any nonzero `v : Fin 3 → ℤ` and `d > 0`. Case-split on a witness coordinate via `fin_cases`, finished with `positivity`.

2. **`dirichletForm_real_eq_int_cast`** — recognises the real-valued form on integer inputs as the cast of `v 0 ^ 2 + (d : ℤ) * v 1 ^ 2 + (d : ℤ) * v 2 ^ 2`. One-line proof (`push_cast; ring`).

3. **`minkowski_ellipsoid_has_lattice_point_int`** — under the same volume hypothesis as the existing `minkowski_ellipsoid_has_lattice_point`, produces a nonzero `v ∈ ℤ³` with the form value *strictly positive* and bounded above by `R`, both stated *on the integer side*.

## Why these three

The eventual `dirichlet_key_lemma` proof needs to argue: *the form value at the Minkowski point is a positive integer divisible by `p = dn − 1` and at most some explicit bound.* The S5 theorem only gives a real bound. These helpers give:

- positivity (rules out the trivial `0 = 0·p` case)
- ℤ-side equality (lets us apply `Int.dvd_*` lemmas)
- combined integer Minkowski restatement (single application point in S7)

## Remaining for S7+

The QR-divisibility step (`legendreSym p (-d) = 1 ⟹ p ∣ x² + d y² + d z²`) requires *restricting Minkowski to a sublattice* `L_r ⊂ ℤ³` cut out by `x ≡ r y (mod p)` ∧ `x ≡ r' z (mod p)` with `r² ≡ r'² ≡ -d (mod p)`. The sublattice has covolume `p²`, so the volume condition becomes `8 p² < (4π/3) R^(3/2) / d`. See updated `state.md` for the full S7 plan.

## Axiom count

`ThreeSquares.lean`: unchanged at 5 axioms (`dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`, `gauss_eisenstein_r3`, `general_r3_formula`, `class_number_positive`).

## Build status

Docker build launched in background (`./proofs/scripts/docker-build.sh Proofs.ThreeSquares`). The broken `proofs/.lake` symlink (see MEMORY) means a full Mathlib refetch is expected (~45min). PR title carries `build pending` — will follow up with a status comment.

## Test plan

- [ ] Docker build of `Proofs.ThreeSquares` succeeds
- [ ] No new sorries/axioms introduced
- [ ] Existing theorems (`legendre_three_squares`, `four_squares_always_suffice`, etc.) still typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)