### PR TITLE
research(hilbert-10-oq-01-oq-02): S6 — singleton {0}/ℚ\{0} in all four classes

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -604,6 +604,71 @@ theorem universe_isExistentialUniversalDefinition :
     (fun _ : Rat => True)).mpr hPi2
 
 -- ============================================================
+-- Part VIII.7 (iter 6): Singleton {0} and complement ℚ\{0} definability
+-- ============================================================
+
+/-- The "projection" parametric polynomial: for each `q : ℚ`, the polynomial
+    that ignores its variable assignment and returns the constant `q`.
+
+    Concretely, `parameterPoly q = fun _ => q`. This is the simplest
+    `q`-dependent polynomial witness in the file, used to place the
+    smallest non-trivial subset `{0} ⊂ ℚ` (and its complement) into the
+    Σ₁ and Π₁ classes respectively.
+
+    Beyond the iteration-5 trivial-set witnesses (`zeroPoly`, `onePoly`),
+    which are constant in *both* the parameter and the variable, this
+    polynomial is constant only in the variable. -/
+private def parameterPoly : Rat → RatDiophantinePoly := fun q _ => q
+
+/-- The singleton `{0} ⊂ ℚ` is Σ₁-definable.
+
+    Witness: the projection polynomial `P(q, x) = q`. Then
+    `hasRationalSolution (P q) ⟺ ∃ x, q = 0 ⟺ q = 0` (the polynomial
+    is constant in `x`, so existence of a rational solution reduces to
+    the constant value being `0`).
+
+    This is the smallest non-trivial Σ₁ subset of ℚ — beyond the trivial
+    `∅` and `ℚ` cases of iteration 5, here the polynomial genuinely
+    depends on the parameter `q`. No new axioms; no Mathlib import. -/
+theorem singletonZero_isDiophantineDefinition :
+    IsDiophantineDefinition (fun q : Rat => q = 0) := by
+  refine ⟨parameterPoly, fun q => ?_⟩
+  exact ⟨fun hq => ⟨fun _ => 0, hq⟩, fun ⟨_, hP⟩ => hP⟩
+
+/-- The complement `ℚ \ {0}` is Π₁-definable.
+
+    Witness: the same projection polynomial `P(q, x) = q`. Then
+    `¬ hasRationalSolution (P q) ⟺ ∀ x, q ≠ 0 ⟺ q ≠ 0` (since the
+    polynomial value does not depend on `x`).
+
+    Direct dual of `singletonZero_isDiophantineDefinition`, obtained from
+    the same polynomial witness by negating the equivalence. -/
+theorem notZero_isCoDiophantineDefinition :
+    IsCoDiophantineDefinition (fun q : Rat => q ≠ 0) := by
+  refine ⟨parameterPoly, fun q => ?_⟩
+  exact ⟨fun hq ⟨_, hP⟩ => hq hP, fun hnsol hq => hnsol ⟨fun _ => 0, hq⟩⟩
+
+/-- The singleton `{0}` is Π₂-definable.
+
+    Corollary of `singletonZero_isDiophantineDefinition` via the trivial
+    inclusion `Σ₁ ⊆ Π₂` (`diophantine_implies_universal_existential`).
+    The Π₂ witness is the projection polynomial padded with a dummy
+    universal block, in line with iteration 4's congruence story. -/
+theorem singletonZero_isUniversalExistentialDefinition :
+    IsUniversalExistentialDefinition (fun q : Rat => q = 0) :=
+  diophantine_implies_universal_existential _ singletonZero_isDiophantineDefinition
+
+/-- The complement `ℚ \ {0}` is Σ₂-definable.
+
+    Corollary of `notZero_isCoDiophantineDefinition` via the trivial
+    inclusion `Π₁ ⊆ Σ₂` (`codiophantine_implies_existentialUniversal`).
+    Together with `singletonZero_isUniversalExistentialDefinition`, this
+    completes the four-class placement of `{0}` and `ℚ \ {0}`. -/
+theorem notZero_isExistentialUniversalDefinition :
+    IsExistentialUniversalDefinition (fun q : Rat => q ≠ 0) :=
+  codiophantine_implies_existentialUniversal _ notZero_isCoDiophantineDefinition
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -639,6 +704,11 @@ open gap is Σ₁ vs Π₂ (equivalently, Π₁(complement) vs Σ₂(complement)
 - The Σ₂(complement) corollary places `ℚ \ ℤ` on the second level of the
   arithmetic hierarchy unconditionally, sharpening the "what is known"
   side of the picture.
+- The smallest *non-trivial* parameter-dependent witness is the projection
+  polynomial `P(q, x) = q`, which places `{0} ⊂ ℚ` (resp. `ℚ \ {0}`) into
+  Σ₁ (resp. Π₁); these in turn place them into Π₂ and Σ₂ via the trivial
+  inclusions `Σ₁ ⊆ Π₂` and `Π₁ ⊆ Σ₂`. This sharpens the iteration-5
+  trivial-set library (∅, ℚ) to the smallest non-degenerate subset.
 
 ## Axioms in THIS file (1 net new)
 
@@ -650,7 +720,7 @@ All other declared `theorem`s are NOT new axioms — they are logical
 consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulation,
 Σ₁ ↔ Π₁(complement), and Σ₂ ↔ Π₂(complement) equivalences proved here.
 
-## Theorems in THIS file (26)
+## Theorems in THIS file (30)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
@@ -678,6 +748,10 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `universe_isUniversalExistentialDefinition` (ℚ is Π₂, iter 5)
   - `empty_isExistentialUniversalDefinition` (∅ is Σ₂, iter 5)
   - `universe_isExistentialUniversalDefinition` (ℚ is Σ₂, iter 5)
+  - `singletonZero_isDiophantineDefinition` ({0} is Σ₁, iter 6)
+  - `notZero_isCoDiophantineDefinition` (ℚ\{0} is Π₁, iter 6)
+  - `singletonZero_isUniversalExistentialDefinition` ({0} is Π₂, iter 6)
+  - `notZero_isExistentialUniversalDefinition` (ℚ\{0} is Σ₂, iter 6)
 -/
 
 #check @IsDiophantineDefinition
@@ -705,5 +779,9 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @universe_isUniversalExistentialDefinition
 #check @empty_isExistentialUniversalDefinition
 #check @universe_isExistentialUniversalDefinition
+#check @singletonZero_isDiophantineDefinition
+#check @notZero_isCoDiophantineDefinition
+#check @singletonZero_isUniversalExistentialDefinition
+#check @notZero_isExistentialUniversalDefinition
 
 end Hilbert10Rationals

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -40,11 +40,15 @@
       "codiophantine_complement_implies_h10_q_undecidable: Π₁(ℚ\\ℤ) → ¬H10/ℚ-decidable, re-export against the Π₁ predicate (no new axiom)",
       "mazur_implies_not_codiophantine_complement: Mazur conjecture → ¬Π₁(ℚ\\ℤ), re-export against the Π₁ predicate (no new axiom)",
       "integers_diophantine_sigma1_implies_h10_q_undecidable: re-export of the MRDP-reduction implication against the Σ₁ predicate",
-      "mazur_implies_not_sigma1_definable: re-export of Mazur's-conjecture-rules-out-Σ₁ implication"
+      "mazur_implies_not_sigma1_definable: re-export of Mazur's-conjecture-rules-out-Σ₁ implication",
+      "singletonZero_isDiophantineDefinition: {0} ⊂ ℚ is Σ₁-definable via the projection polynomial P(q,x) = q (smallest non-trivial Σ₁ subset; iter 6, axiom-free)",
+      "notZero_isCoDiophantineDefinition: ℚ \\ {0} is Π₁-definable via the same projection polynomial (iter 6, axiom-free)",
+      "singletonZero_isUniversalExistentialDefinition: {0} ⊂ ℚ is Π₂-definable, corollary of Σ₁ membership via Σ₁ ⊆ Π₂ (iter 6, no new axiom)",
+      "notZero_isExistentialUniversalDefinition: ℚ \\ {0} is Σ₂-definable, corollary of Π₁ membership via Π₁ ⊆ Σ₂ (iter 6, no new axiom)"
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 709,
+    "lineCount": 787,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -52,8 +56,8 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 29,
-    "definitionCount": 10
+    "theoremCount": 33,
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -180,10 +184,10 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 709,
+    "lineCount": 787,
     "axiomCount": 1,
-    "theoremCount": 29,
-    "definitionCount": 10,
+    "theoremCount": 33,
+    "definitionCount": 11,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Iteration 6 (S6) of `hilbert-10-oq-01-oq-02`. Adds the smallest non-trivial parameter-dependent witnesses to the Σ₁ / Π₁ / Σ₂ / Π₂ definability scaffold built in iters 1–5: the singleton `{0} ⊂ ℚ` and its complement `ℚ \ {0}` are placed in all four classes via the projection polynomial `P(q, x) = q`.

- `parameterPoly : Rat → RatDiophantinePoly := fun q _ => q` — the simplest q-dependent polynomial witness, constant in the variable block but varying in the parameter (iter 5's `zeroPoly` / `onePoly` are constant in both)
- `singletonZero_isDiophantineDefinition` — {0} is Σ₁ (direct, axiom-free)
- `notZero_isCoDiophantineDefinition` — ℚ\{0} is Π₁ (direct dual via the same polynomial)
- `singletonZero_isUniversalExistentialDefinition` — {0} is Π₂ (corollary of Σ₁ ⊆ Π₂)
- `notZero_isExistentialUniversalDefinition` — ℚ\{0} is Σ₂ (corollary of Π₁ ⊆ Σ₂)

This sharpens the iter-5 trivial-set library (∅, ℚ in all four classes) to the smallest non-degenerate subset, where the polynomial genuinely depends on the parameter `q`.

## Counts

- lineCount 709 → 787 (+78)
- theoremCount 29 → 33 (+4 public theorems; 1 new private def)
- definitionCount 10 → 11 (+1: `parameterPoly`)
- axiomCount unchanged: still 1 (`koenigsmann_2016_universal`)
- 0 sorries throughout

No Mathlib import added (file remains self-contained over Lean core + `Proofs.Hilbert10OQ01`).

## Test plan

- [x] Counts in `meta.json` (top-level `meta` block AND `leanFile` block) match the Lean source
- [x] No new axioms (count unchanged at 1)
- [x] All four new public theorems have `#check` exposures at end of file
- [x] Docker build verifies (`./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
