### PR TITLE
Enrich fodor-pressing-down: 8-section split, prerequisites, parent xref, accuracy fix

### DIFF
--- a/src/data/proofs/fodor-pressing-down/annotations.json
+++ b/src/data/proofs/fodor-pressing-down/annotations.json
@@ -2,10 +2,10 @@
   {
     "id": "ann-club",
     "proofId": "fodor-pressing-down",
-    "range": { "startLine": 39, "endLine": 86 },
+    "range": { "startLine": 43, "endLine": 80 },
     "type": "definition",
     "title": "Club and Stationary Sets: Set-Theoretic Infrastructure",
-    "content": "IsClubBelow S o is a structure with two fields: mem_lt (S ⊆ Iio o — bounded below o) and mem_of_isAcc (S is closed: every accumulation point of S below o is in S). IsUnboundedBelow S o says S is cofinal below o. IsClubBelow requires both closedness AND unboundedness. IsStationaryBelow S o says S meets every club below o. These definitions formalize concepts missing from Mathlib's set theory library.",
+    "content": "IsUnboundedBelow S o says S is cofinal below o. IsClubBelow S o is a `structure` with three fields — `subset_Iio : S ⊆ Iio o`, `closed : IsClosedBelow S o`, and `unbounded : IsUnboundedBelow S o` — i.e. a club is bounded below o, closed under accumulation points, and cofinal. The helper theorems IsClubBelow.mem_lt (membership ⟹ < o, derived from subset_Iio) and IsClubBelow.mem_of_isAcc (an accumulation point in Iio o is in S, derived from closed) reproduce the conventional 'closed unbounded' API. IsStationaryBelow S o says S meets every club below o. The standalone lemma isClubBelow_Iio_of_isSuccLimit witnesses that `Iio o` is itself a club whenever o is a successor-limit (used by IsStationaryBelow.nonempty in Part VI).",
     "mathContext": "$S$ is a **club** (closed unbounded set) below $o$ if: (1) $S \\subseteq \\{\\alpha < o\\}$, (2) every limit ordinal $\\gamma < o$ with $\\sup(S \\cap \\gamma) = \\gamma$ satisfies $\\gamma \\in S$, (3) $S$ is cofinal in $o$. $S$ is **stationary** below $o$ if $S \\cap C \\neq \\emptyset$ for every club $C$ below $o$.",
     "significance": "key",
     "relatedConcepts": ["club filter", "stationary set", "closed unbounded", "ordinal accumulation point"],
@@ -14,7 +14,7 @@
   {
     "id": "ann-diag-inter",
     "proofId": "fodor-pressing-down",
-    "range": { "startLine": 87, "endLine": 107 },
+    "range": { "startLine": 82, "endLine": 96 },
     "type": "definition",
     "title": "Diagonal Intersection: The Key Tool",
     "content": "diagInter f o = {γ ∈ Iio o | ∀ α < γ, γ ∈ f α}. Unlike ordinary intersection which requires γ ∈ f(α) for ALL α, the diagonal intersection only requires γ ∈ f(α) for those α BELOW γ — this respects the ordinal order. Intuitively, γ 'knows' about f(α) only for α that came before it. The iff characterization mem_diagInter and the subset lemma diagInter_subset_Iio are proved first.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-diag-club",
     "proofId": "fodor-pressing-down",
-    "range": { "startLine": 108, "endLine": 258 },
+    "range": { "startLine": 98, "endLine": 247 },
     "type": "technique",
     "title": "Diagonal Intersection of Clubs Is a Club: Zipper Construction",
     "content": "diagInter_isClubBelow proves the key set-theoretic fact: if f(α) is a club below κ for every α < κ (κ regular uncountable), then diagInter f κ is a club. Two-part proof: (1) diagInter_isClosedBelow: if γ is an accumulation point of Δ(f) below κ, then for each α < γ, γ is also an accumulation point of f(α), so γ ∈ f(α) by closedness of f(α). (2) diagInter_isUnboundedBelow: the 'zipper' argument — given any δ < κ, build an increasing sequence δ < γ_0 < γ_1 < ... where γ_{n+1} is the least element of f(γ_n) above γ_n. By regularity of κ, this sequence is bounded, and the supremum γ_ω lies in every f(α) for α < γ_ω.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-fodor",
     "proofId": "fodor-pressing-down",
-    "range": { "startLine": 259, "endLine": 333 },
+    "range": { "startLine": 249, "endLine": 313 },
     "type": "insight",
     "title": "Fodor's Lemma: Proof by Diagonal Intersection",
     "content": "fodor proves: for regular uncountable κ, stationary S ⊆ κ.ord, and regressive f (f(α) < α for α ∈ S): ∃ β, f⁻¹(β) ∩ S is stationary. By contradiction: if no f⁻¹(β) ∩ S is stationary, choose clubs C_β with C_β ∩ f⁻¹(β) ∩ S = ∅. Form D = Δ_{β<κ}(C_β) (a club by diagInter_isClubBelow). Take γ ∈ S ∩ D (nonempty since S is stationary and D is a club). Since f is regressive, β = f(γ) < γ, so γ ∈ C_β (because γ ∈ D = Δ C and β < γ). But then f(γ) = β ∈ C_β ∩ f⁻¹(β) ∩ S — contradiction.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-aleph1",
     "proofId": "fodor-pressing-down",
-    "range": { "startLine": 320, "endLine": 333 },
+    "range": { "startLine": 316, "endLine": 327 },
     "type": "context",
     "title": "Fodor's Lemma for ℵ₁: The Canonical Application",
     "content": "fodor_aleph1 specializes to κ = ℵ₁: any regressive function on a stationary subset of ω₁ is constant on some stationary subset. This is the most commonly used instance in descriptive set theory, forcing arguments, and the study of ω₁-trees. The ℵ₁ corollary is what most textbooks call 'Fodor's Lemma' without qualification.",

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -49,25 +49,60 @@
   },
   "sections": [
     {
-      "id": "club-sets",
-      "title": "Club and Stationary Set Infrastructure",
-      "startLine": 39,
-      "endLine": 86,
-      "summary": "Defines IsUnboundedBelow (cofinal below o), IsClubBelow (structure: closed and unbounded), IsStationaryBelow (meets every club). Basic lemmas: IsClubBelow.mem_lt, mem_of_isAcc, isClubBelow_Iio_of_isSuccLimit. These are missing from Mathlib."
+      "id": "header-docstring",
+      "title": "Header: Mathematical Context, References, and Proof Strategy",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Module docstring stating Fodor's lemma (regressive functions on stationary sets of regular uncountable \u03ba are constant on a stationary subset), citing Fodor (1956), Jech (2003) Theorem 8.7, and Kunen (2011) Theorem II.6.15, listing the new infrastructure built (IsUnboundedBelow / IsClubBelow / IsStationaryBelow / diagInter / fodor), and sketching the diagonal-intersection proof strategy."
     },
     {
-      "id": "diagonal-intersection",
-      "title": "Diagonal Intersection Definition and Properties",
-      "startLine": 87,
-      "endLine": 258,
-      "summary": "Defines diagInter f o = {\u03b3 < o | \u2200 \u03b1 < \u03b3, \u03b3 \u2208 f \u03b1}. Lemmas: mem_diagInter (iff characterization), diagInter_subset_Iio (stays below o), diagInter_isClosedBelow (closure from closedness of each f \u03b1), diagInter_isUnboundedBelow (zipper construction), diagInter_isClubBelow (main: diagonal intersection of clubs is a club)."
+      "id": "part-i-club",
+      "title": "Part I: Club and Stationary Set Infrastructure",
+      "startLine": 43,
+      "endLine": 80,
+      "summary": "Defines IsUnboundedBelow (cofinal below o), the structure IsClubBelow with three fields (subset_Iio, closed, unbounded), and IsStationaryBelow (meets every club). Helper lemmas: IsClubBelow.mem_lt, IsClubBelow.mem_of_isAcc, isClubBelow_Iio_of_isSuccLimit. None of these are in Mathlib as of 2026-04."
     },
     {
-      "id": "fodors-lemma",
-      "title": "Fodor's Pressing-Down Lemma",
-      "startLine": 259,
-      "endLine": 386,
-      "summary": "fodor: main theorem for regular uncountable \u03ba. fodor_aleph1: corollary for \u03ba = \u2135\u2081. Additional lemmas: IsStationaryBelow.nonempty, IsStationaryBelow.of_subset."
+      "id": "part-ii-diaginter",
+      "title": "Part II: Diagonal Intersection Definition",
+      "startLine": 82,
+      "endLine": 96,
+      "summary": "Defines diagInter f o = {\u03b3 | \u03b3 < o \u2227 \u2200 \u03b2 < \u03b3, \u03b3 \u2208 f \u03b2}. Provides the iff-characterization mem_diagInter (tagged @[simp]) and the obvious subset lemma diagInter_subset_Iio. The asymmetric quantifier over \u03b2 < \u03b3 (rather than all \u03b2 < o) is what distinguishes diagonal from ordinary intersection."
+    },
+    {
+      "id": "part-iii-club-club",
+      "title": "Part III: Diagonal Intersection of Clubs Is a Club",
+      "startLine": 98,
+      "endLine": 247,
+      "summary": "The technical heart of the proof. diagInter_isClosedBelow shows closure (\u03b3 an acc point of the diagonal intersection \u27f9 \u03b3 \u2208 f \u03b2 for each \u03b2 < \u03b3 via accumulation through f \u03b2). diagInter_isUnboundedBelow uses the zipper construction (build a strictly increasing \u03c9-sequence with seq(n+1) inside f(seq(n)); regularity of \u03ba keeps it bounded; the limit lies in every f(\u03b2) below it). diagInter_isClubBelow combines them."
+    },
+    {
+      "id": "part-iv-fodor",
+      "title": "Part IV: Fodor's Pressing-Down Lemma",
+      "startLine": 249,
+      "endLine": 313,
+      "summary": "fodor: for regular uncountable \u03ba, stationary S \u2286 \u03ba.ord, regressive f : Ordinal \u2192 Ordinal with f(\u03b1) < \u03b1 and f(\u03b1) < \u03ba.ord on S, \u2203 c < \u03ba.ord with S \u2229 f\u207b\u00b9{c} stationary. Proof by contradiction: if no fiber is stationary, choose clubs C_\u03b2 avoiding each S \u2229 f\u207b\u00b9{\u03b2}, form D = \u0394(C_\u03b2), find \u03b3 \u2208 S \u2229 D, derive \u03b3 \u2208 C_{f(\u03b3)} from membership in D, contradict the choice of C_{f(\u03b3)}."
+    },
+    {
+      "id": "part-v-aleph1",
+      "title": "Part V: Specialization to \u2135\u2081",
+      "startLine": 316,
+      "endLine": 327,
+      "summary": "fodor_aleph1: the canonical \u2135\u2081 instance of Fodor \u2014 every regressive f on a stationary subset of \u03c9\u2081 = (\u2135\u2081).ord is constant on a stationary subset. Discharged by applying `fodor` to `isRegular_aleph_one` and `aleph0_lt_aleph_one`."
+    },
+    {
+      "id": "part-vi-helpers",
+      "title": "Part VI: Subsidiary Stationary-Set Lemmas",
+      "startLine": 329,
+      "endLine": 348,
+      "summary": "IsStationaryBelow.nonempty: stationary sets are nonempty (intersect with the club Iio o at limit ordinals). IsStationaryBelow.of_subset: stationarity transfers to a subset T \u2286 S provided every club meeting S also meets T. These are utility lemmas for downstream applications."
+    },
+    {
+      "id": "summary-docstring",
+      "title": "Trailing Summary: Infrastructure Inventory and Parent Connection",
+      "startLine": 350,
+      "endLine": 385,
+      "summary": "Final docstring inventorying the new infrastructure (IsClubBelow / IsStationaryBelow / diagInter and the four key results), confirming 0 sorries, and stating the connection to the parent CantorDiagonalizationOQ02OQ03 (the parent's no-enumeration result follows from Fodor: any sub-\u03ba enumeration of \u03ba.ord ordinals would yield an injective regressive function, which Fodor blocks)."
     }
   ],
   "conclusion": {
@@ -82,6 +117,11 @@
     ]
   },
   "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Direct parent: the trailing docstring of FodorPressingDown.lean explicitly identifies CantorDiagonalizationOQ02OQ03 as the entry whose no-enumeration result Fodor's lemma supplies. Any sub-κ enumeration of ordinals < κ.ord would be an injective regressive function on a stationary set, which Fodor's lemma prevents."
+    },
     {
       "targetId": "continuum-hypothesis",
       "relationship": "related",
@@ -165,6 +205,20 @@
       "title": "Mathlib.SetTheory.Ordinal.Topology",
       "venue": "Mathlib4",
       "note": "The closest existing Mathlib analogue to this entry's club/stationary/diagInter infrastructure. A direct upstream contribution would extend this module."
+    },
+    {
+      "author": "Kunen, K.",
+      "year": 2011,
+      "title": "Set Theory",
+      "venue": "Studies in Logic and the Foundations of Mathematics, College Publications, Theorem II.6.15",
+      "note": "Self-contained graduate text whose Theorem II.6.15 is precisely Fodor's pressing-down lemma; the proof structure (diagonal intersection of fiber-avoiding clubs, then derive contradiction at any γ in the diagonal) matches this entry verbatim. Cited explicitly in the file's header docstring."
+    },
+    {
+      "author": "Shelah, S.",
+      "year": 1998,
+      "title": "Proper and Improper Forcing",
+      "venue": "Perspectives in Logic, Springer, 2nd ed., Chapter III",
+      "note": "Foundational reference for proper-forcing arguments where Fodor's lemma is wielded routinely (proper forcing preserves stationary subsets of ω₁). The 'normality of the club filter' framing in keyInsights[6] traces back to the perspective on Fodor used throughout this monograph."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass for fodor-pressing-down

Fodor's Pressing-Down Lemma (1956) — diagonal-intersection proof of regressive functions on stationary sets being constant on a stationary subset.

### Changes (rebased on main after PR #17054 added overview.prerequisites)

- **sections**: 3 → 8 ranges. The Lean file has 6 explicit `§ Part I-VI` headers plus a header docstring and a trailing summary docstring; the previous sections lumped Parts II/III together and Parts III/IV/V/VI together. New ranges align 1-1 with the file structure:
  - `header-docstring` 1-30 (mathematical context, references, infrastructure summary, proof strategy sketch)
  - Part I `part-i-club` 43-80 (IsUnboundedBelow / IsClubBelow / IsStationaryBelow + helper theorems)
  - Part II `part-ii-diaginter` 82-96 (diagInter def + mem_diagInter / diagInter_subset_Iio)
  - Part III `part-iii-club-club` 98-247 (diagInter_isClosedBelow + diagInter_isUnboundedBelow zipper + diagInter_isClubBelow)
  - Part IV `part-iv-fodor` 249-313 (the fodor proof)
  - Part V `part-v-aleph1` 316-327 (fodor_aleph1 specialization)
  - Part VI `part-vi-helpers` 329-348 (IsStationaryBelow.nonempty / .of_subset)
  - `summary-docstring` 350-385 (formalization inventory + parent-connection note)

- **annotations**: tightened 4 line ranges to land on the correct definition/theorem boundaries: `ann-club` 39-86 → 43-80, `ann-diag-inter` 87-107 → 82-96, `ann-diag-club` 108-258 → 98-247, `ann-fodor` 259-333 → 249-313, `ann-aleph1` 320-333 → 316-327 (the previous `ann-fodor` ⊃ `ann-aleph1` overlap is gone).

- **Accuracy fix in `ann-club` content**: previously claimed that `IsClubBelow` is a `structure` with two fields `mem_lt` and `mem_of_isAcc`. The actual definition (line 53) is a structure with three fields — `subset_Iio`, `closed`, `unbounded`. `mem_lt` and `mem_of_isAcc` are *helper theorems* (lines 62-68) built on top of those fields. Annotation now reflects the source.

- **crossReferences**: 2 → 3. Added `cantor-diagonalization-oq-02-oq-03` as the immediate parent — the Lean file's trailing docstring (line 372 onward) explicitly states *"Connection to parent (CantorDiagonalizationOQ02OQ03)"* and explains that the parent's no-enumeration result follows from Fodor (any sub-κ enumeration of κ.ord ordinals would be an injective regressive function, which Fodor blocks).

- **references**: 5 → 7. Added Kunen *Set Theory* (2011) Theorem II.6.15 (cited verbatim in the Lean file's header docstring) and Shelah *Proper and Improper Forcing* (1998) — the foundational reference behind the club-filter-normality framing in keyInsights[6].

### Note on prerequisites field

The original commit also added an `overview.prerequisites` list, but PR #17054 (merged 2026-05-08) had already added a more comprehensive 8-item list. After rebasing on origin/main, this PR keeps main's prerequisites and contributes only the unique improvements above.

### Verification

- JSON validity confirmed via `python3 -c 'import json; json.load(...)'`.
- `pnpm build` could not run locally due to a pre-existing better-sqlite3 / node-gyp v26 install failure (unrelated to these edits). All schema fields used are present in other gallery entries.
- `gh pr view 17089` reports CLEAN mergeable state after the rebase.