### PR TITLE
audit: batch re-audit of 10 stalest entries (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1609,9 +1609,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T04:27:46Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-02": {
@@ -7595,14 +7595,14 @@
     },
     "erdos-512": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
+      "auditCount": 4,
       "issuesFixed": [
         "stale originalContributions items (#12149)",
         "annotation L1norm_upper_bound incorrectly labelled (sorry) \u2014 proved",
         "annotation L2_norm incorrectly labelled (sorry) \u2014 proved pending expSumNorm_sq_double; range updated to 257-295"
       ],
-      "lastAudited": "2026-04-24T05:03:47Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T12:06:34Z",
+      "result": "clean"
     },
     "erdos-513": {
       "agentId": "auditor-cycle-20-batch",
@@ -11257,9 +11257,9 @@
       "result": "clean"
     },
     "fair-games-theorem-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T04:27:46Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "fair-games-theorem-oq-02-oq-04": {
@@ -11511,9 +11511,9 @@
       "result": "clean"
     },
     "gcd-algorithm-oq-01-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "gcd-algorithm-oq-02": {
@@ -11998,9 +11998,9 @@
       "result": "clean"
     },
     "isosceles-triangle-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "kepler-conjecture": {
@@ -12039,10 +12039,10 @@
       "result": "clean"
     },
     "konigsberg-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T09:11:12Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T12:06:34Z",
+      "result": "clean"
     },
     "konigsberg-oq-03": {
       "auditCount": 5,
@@ -12389,9 +12389,9 @@
       "result": "clean"
     },
     "minkowski-fundamental-theorem-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T04:27:46Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "minkowski-theorem": {
@@ -12401,9 +12401,9 @@
       "result": "clean"
     },
     "minkowski-theorem-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "morleys-theorem": {
@@ -13136,9 +13136,9 @@
       "result": "clean"
     },
     "sperner-ndim-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "sperner-ndim-oq-03": {
@@ -13226,9 +13226,9 @@
       "result": "clean"
     },
     "sqrt2-plus-sqrt3-irrational-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:35Z",
+      "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
     },
     "stirling-formula": {


### PR DESCRIPTION
## Summary

Re-audited the 10 oldest audit-tracker entries (priority order from `find-targets.ts --next`). All entries verified clean against `origin/main`:

| slug | status/badge | counts |
|------|-------------|--------|
| sqrt2-plus-sqrt3-irrational-oq-03 | verified/mathlib | s=0 a=0 t=8 d=0 l=403 |
| minkowski-fundamental-theorem-oq-04 | verified/mathlib | s=0 a=0 t=11 d=1 l=192 |
| fair-games-theorem-oq-02-oq-01-oq-01 | verified/original | s=0 a=0 t=12 d=1 l=361 |
| cauchy-schwarz-integral-oq-01-oq-03-oq-01 | verified/mathlib | s=0 a=0 t=6 d=0 l=176 |
| erdos-512 | axiomatized/axiom | s=0 a=2 t=14 d=16 l=368 |
| konigsberg-oq-02-oq-01 | verified/mathlib | s=0 a=0 t=17 d=5 l=954 |
| sperner-ndim-oq-01 | verified/original | s=0 a=0 t=8 d=1 l=220 |
| minkowski-theorem-oq-02 | axiomatized/axiom | s=0 a=3 t=6 d=1 l=284 |
| isosceles-triangle-oq-01 | verified/mathlib | s=0 a=0 t=5 d=0 l=144 |
| gcd-algorithm-oq-01-oq-03 | verified/original | s=0 a=0 t=22 d=2 l=280 |

For each entry, verified against `origin/main`:
- `meta.meta.*` and `meta.leanFile.*` counts match each other
- `meta.leanFile.*` counts match actual Lean source (sorries, axioms, theorems/lemmas, def+abbrev+opaque, lineCount via `\n`-count)
- `additionalFiles` entries exist in tree (where listed)

All counts match exactly. No narrative drift detected.

## Tracker change

Surgical 22-line diff (auditCount +1, lastAudited bumped) for 10 entries. Two entries (`erdos-512`, `konigsberg-oq-02-oq-01`) had stale `result: "issues-fixed"` from past fix passes but are currently clean — flipped to `result: "clean"` while preserving `issuesFixed`/`issues` history.

## Test plan

- [x] `git diff --stat` shows exactly 1 file, 22 insertions / 22 deletions
- [x] `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` parses successfully
- [x] `entries` count unchanged (2401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)