### PR TITLE
audit(ptolemys-complex-proof-oq-02): re-audit clean (2026-05-08)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12732,9 +12732,9 @@
       "result": "clean"
     },
     "ptolemys-complex-proof-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T14:29:20Z",
+      "lastAudited": "2026-05-08T20:50:00Z",
       "result": "clean"
     },
     "ptolemys-theorem": {
@@ -15072,5 +15072,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-08T09:30:00Z"
+  "lastUpdated": "2026-05-08T20:50:00Z"
 }


### PR DESCRIPTION
## Summary

Re-audited gallery entry `ptolemys-complex-proof-oq-02` (last audited 2026-04-23, oldest 2x-audited stale-but-not-in-flight entry after the four open audit batches above). All counts match `origin/main`:

| Field | Claimed | Actual | Match |
|-------|---------|--------|-------|
| lineCount | 351 | 351 (`\n`-count) | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 11 | 11 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |

`leanFile.*` and `meta.*` blocks agree.

## Narrative spot-checks (Tier B)

- **Status `verified` + badge `mathlib`** is correct. Core sine addition step uses Mathlib's `Real.sin_add` inside `norm_exp_diff` — disclosed in `meta.assumptions`.
- **`originalContributions`** appropriately scoped to chord-length calculus, CCW order verification, and non-degeneracy lemmas. No "first formalization" / "we proved sin addition" claims.
- **Title**: "Ptolemy's Theorem → Sine Addition Formula" uses arrow to signal derivation, not standalone proof.

No True stubs, no axiom masking, no Mathlib-wrapper-as-original mislabel.

## Tracker mechanics

- Surgical `re.sub` edit on `origin/main` copy (per `feedback_mechanic_plumbing_json_format`): 4-line diff total.
- No format-only churn; round-trip JSON parses; `entries` count unchanged (2401).
- `auditCount` 1 → 2; `lastAudited` 2026-04-24 → 2026-05-08; top-level `lastUpdated` bumped.

## Test plan

- [x] `git diff --stat`: 1 file, 3 insertions / 3 deletions
- [x] `python3 -c "import json; json.load(open(...))"` succeeds
- [x] Counts re-verified against `git show origin/main:proofs/Proofs/PtolemysComplexProofOQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)