### PR TITLE
fix(meta): theoremCount drift in erdos-677 (25→28) and erdos-826 (4→6)

### DIFF
--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "1 axiom: thue_siegel_finiteness (Thue-Siegel theorem: finitely many solutions for fixed k). Former axioms now proved: lcmInterval_example1/2 (native_decide), lcmInterval_dvd_product (Finset.induction + Nat.lcm_dvd), lcmInterval_pos (dvd + product positivity). Conjecture verified for k=1 and k=2.",
     "lineCount": 268,
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 28,
     "originalContributions": [
       "erdos677_large_m: general bound — for any k, if m+k > consecutiveProduct(n,k) then M(m,k)≠M(n,k)",
       "erdos677_k3_large_m: k=3 corollary of the large-m bound, axiom-free"
@@ -136,7 +136,7 @@
     "namespace": null,
     "lineCount": 268,
     "axiomCount": 1,
-    "theoremCount": 25,
+    "theoremCount": 28,
     "definitionCount": 5,
     "path": "Proofs/Erdos677Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-826/meta.json
+++ b/src/data/proofs/erdos-826/meta.json
@@ -187,7 +187,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 11,
-    "theoremCount": 4
+    "theoremCount": 6
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Two entries had stale `theoremCount` after recent research/Aristotle merges.

### erdos-677: 25 → 28 (both `meta` and `leanFile` blocks)

After PR #16881 (Aristotle integration) the file grew to **28** theorems.
- Narrow regex `^(theorem|lemma)`: 28
- Relaxed regex (allows `private`/`protected`/`noncomputable`/`@[...]`): 28
- Both regexes agree, no `example` decls, comment-stripper clean.

### erdos-826: lf.theoremCount 4 → 6 (`meta` block already at 6)

After PR #16912 (S3 monotonicity) the file has 6 theorems; only the `leanFile` block was stale.
- Narrow regex: 6, relaxed regex: 6 (agreement, no modifier-prefix decls)

## Evidence

```
$ wc -l proofs/Proofs/Erdos677Problem.lean
     313 proofs/Proofs/Erdos677Problem.lean

$ grep -cE '^(theorem|lemma)\b' proofs/Proofs/Erdos677Problem.lean
28

$ grep -cE '^(theorem|lemma)\b' proofs/Proofs/Erdos826Problem.lean
6
```

`find-targets` reports clean for both (it does not check `theoremCount`). Both entries had no in-flight PRs and no recent activity touching the affected meta fields.

## Scope discipline

Only the `theoremCount` field touched (no `lineCount` per oscillation memory). 2-line diff per file, no other field modified.

---
Automated fix by lean-mechanic agent.