### PR TITLE
research(sperner-ndim-mathlib-oq-02): S17 — base ↔ topSimps2 bridge (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -1010,5 +1010,179 @@ private lemma t2_face2_in_t1 (b : ℕ × ℕ) :
     · simp only [t1, Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
       omega
 
+-- ============================================================
+-- (Session 17) Boundary classification — base ↔ topSimps2 bridge
+--
+-- These lemmas characterize when each face of a t1/t2 cell is a
+-- boundary face of Δ², i.e. when no other top simplex of the
+-- triangulation contains it. They build on the S16 edge-containment
+-- lemmas and the t1Bases / t2Bases membership conditions.
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- (S17.1) Base-membership iff. Bare-`Finset.mem_filter` unfolding
+-- gives an unwieldy product blob; the iff form is a cleaner rewrite
+-- target for downstream boundary classification.
+-- ----------------------------------------------------------------
+
+private lemma t1Bases_mem_iff (N : ℕ) (b : ℕ × ℕ) :
+    b ∈ t1Bases N ↔ b.1 < N ∧ b.2 < N ∧ b.1 + b.2 < N := by
+  refine ⟨fun h => ?_, fun ⟨h1, h2, h3⟩ => ?_⟩
+  · simp only [t1Bases, Finset.mem_filter, Finset.mem_product,
+               Finset.mem_range] at h
+    exact ⟨h.1.1, h.1.2, h.2⟩
+  · simp only [t1Bases, Finset.mem_filter, Finset.mem_product,
+               Finset.mem_range]
+    exact ⟨⟨h1, h2⟩, h3⟩
+
+private lemma t2Bases_mem_iff (N : ℕ) (b : ℕ × ℕ) :
+    b ∈ t2Bases N ↔ b.1 < N ∧ b.2 < N ∧ b.1 + b.2 + 1 < N := by
+  refine ⟨fun h => ?_, fun ⟨h1, h2, h3⟩ => ?_⟩
+  · simp only [t2Bases, Finset.mem_filter, Finset.mem_product,
+               Finset.mem_range] at h
+    exact ⟨h.1.1, h.1.2, h.2⟩
+  · simp only [t2Bases, Finset.mem_filter, Finset.mem_product,
+               Finset.mem_range]
+    exact ⟨⟨h1, h2⟩, h3⟩
+
+-- ----------------------------------------------------------------
+-- (S17.2) topSimps2 membership of t1/t2 cells from base membership.
+-- ----------------------------------------------------------------
+
+private lemma t1_in_topSimps2_of_base (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t1Bases N) : t1 b ∈ topSimps2 N := by
+  unfold topSimps2
+  exact Finset.mem_union.mpr (Or.inl (Finset.mem_image.mpr ⟨b, hb, rfl⟩))
+
+private lemma t2_in_topSimps2_of_base (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t2Bases N) : t2 b ∈ topSimps2 N := by
+  unfold topSimps2
+  exact Finset.mem_union.mpr (Or.inr (Finset.mem_image.mpr ⟨b, hb, rfl⟩))
+
+-- (S17.3) Reverse: every cell in topSimps2 is t1 or t2 of some base.
+private lemma topSimps2_mem_iff (N : ℕ) (s : Finset (ℕ × ℕ)) :
+    s ∈ topSimps2 N ↔
+      (∃ b ∈ t1Bases N, t1 b = s) ∨ (∃ b ∈ t2Bases N, t2 b = s) := by
+  unfold topSimps2
+  simp only [Finset.mem_union, Finset.mem_image]
+
+-- ----------------------------------------------------------------
+-- (S17.4) Base translation across t2 ↔ t1 face-mates.
+--
+-- For every t2 cell with base in `t2Bases N`, the three t1 cells
+-- sharing its three faces (per S16's `t2_face{0,1,2}_in_t1`) all
+-- have their bases in `t1Bases N`. Hence every t2 face is shared
+-- with another top simplex — t2 faces are *never* boundary.
+-- ----------------------------------------------------------------
+
+private lemma t2Bases_self_in_t1Bases (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t2Bases N) : b ∈ t1Bases N := by
+  rw [t1Bases_mem_iff]
+  rw [t2Bases_mem_iff] at hb
+  exact ⟨hb.1, hb.2.1, by omega⟩
+
+private lemma t2Bases_right_in_t1Bases (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t2Bases N) : (b.1 + 1, b.2) ∈ t1Bases N := by
+  rw [t1Bases_mem_iff]
+  rw [t2Bases_mem_iff] at hb
+  refine ⟨?_, hb.2.1, ?_⟩ <;> omega
+
+private lemma t2Bases_top_in_t1Bases (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t2Bases N) : (b.1, b.2 + 1) ∈ t1Bases N := by
+  rw [t1Bases_mem_iff]
+  rw [t2Bases_mem_iff] at hb
+  refine ⟨hb.1, ?_, ?_⟩ <;> omega
+
+-- ----------------------------------------------------------------
+-- (S17.5) Base translation across t1 ↔ t2 face-mates.
+--
+-- For a t1 cell with base `b ∈ t1Bases`, its three faces are:
+--   * diagonal {(b.1, b.2+1), (b.1+1, b.2)} — shared with t2(b)
+--     iff b ∈ t2Bases (i.e. b.1 + b.2 + 1 < N)
+--   * horizontal {b, (b.1+1, b.2)} — shared with t2(b.1, b.2-1)
+--     iff b.2 ≥ 1
+--   * vertical {b, (b.1, b.2+1)} — shared with t2(b.1-1, b.2)
+--     iff b.1 ≥ 1
+-- The lemmas below give the existential side of these
+-- characterizations; the negative side comes from S16 via
+-- `horizontal_not_in_t2_at_y0`, `vertical_not_in_t2_at_x0`, and
+-- the new `diagonal_not_in_t2_at_diagonal` below.
+-- ----------------------------------------------------------------
+
+private lemma t1Bases_horizontal_neighbor_in_t2Bases
+    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ t1Bases N) (hb2 : 1 ≤ b.2) :
+    (b.1, b.2 - 1) ∈ t2Bases N := by
+  rw [t1Bases_mem_iff] at hb
+  rw [t2Bases_mem_iff]
+  refine ⟨hb.1, ?_, ?_⟩ <;> omega
+
+private lemma t1Bases_vertical_neighbor_in_t2Bases
+    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ t1Bases N) (hb1 : 1 ≤ b.1) :
+    (b.1 - 1, b.2) ∈ t2Bases N := by
+  rw [t1Bases_mem_iff] at hb
+  rw [t2Bases_mem_iff]
+  refine ⟨?_, hb.2.1, ?_⟩ <;> omega
+
+private lemma t1Bases_diagonal_neighbor_in_t2Bases
+    (N : ℕ) {b : ℕ × ℕ} (hb : b ∈ t1Bases N) (hbd : b.1 + b.2 + 1 < N) :
+    b ∈ t2Bases N := by
+  rw [t1Bases_mem_iff] at hb
+  rw [t2Bases_mem_iff]
+  exact ⟨hb.1, hb.2.1, hbd⟩
+
+-- ----------------------------------------------------------------
+-- (S17.6) The missing boundary case — diagonal at the diag-boundary.
+--
+-- Counterpart to `horizontal_not_in_t2_at_y0` and
+-- `vertical_not_in_t2_at_x0`: when `b ∈ t1Bases N` saturates the
+-- diagonal-boundary `b.1 + b.2 + 1 ≥ N`, no t2 cell with base in
+-- `t2Bases N` contains the diagonal of t1(b).
+-- ----------------------------------------------------------------
+
+private lemma diagonal_not_in_t2_at_diagonal (N : ℕ) (b : ℕ × ℕ)
+    (hbd : N ≤ b.1 + b.2 + 1) (c : ℕ × ℕ) (hc : c ∈ t2Bases N) :
+    ¬ (({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ t2 c) := by
+  intro h
+  rw [diagonal_in_t2_iff] at h
+  rw [t2Bases_mem_iff] at hc
+  -- h : c = b ⇒ b.1 + b.2 + 1 < N, contradicting hbd
+  subst h
+  omega
+
+-- ----------------------------------------------------------------
+-- (S17.7) Diagonal-neighbor classification at topSimps2 level.
+--
+-- For `b ∈ t1Bases N`, the diagonal edge of `t1 b` is contained in
+-- *some other* simplex of `topSimps2 N` iff `b ∈ t2Bases N`
+-- (equivalently `b.1 + b.2 + 1 < N`), and that other simplex is
+-- `t2 b`. This is the form needed by S18's `containersOf`-based
+-- assembly of `_hBoundaryOnFace` for the diagonal face.
+-- ----------------------------------------------------------------
+
+private lemma diagonal_neighbor_topSimps2 (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t1Bases N) :
+    (∃ s ∈ topSimps2 N, s ≠ t1 b ∧
+      ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ s) ↔
+      b.1 + b.2 + 1 < N := by
+  refine ⟨?_, ?_⟩
+  · rintro ⟨s, hs_mem, hs_ne, hs_sub⟩
+    rw [topSimps2_mem_iff] at hs_mem
+    rcases hs_mem with ⟨c, _, rfl⟩ | ⟨c, hc, rfl⟩
+    · -- s = t1 c. Diagonal forces c = b ⇒ s = t1 b, contradicting hs_ne.
+      rw [diagonal_in_t1_iff] at hs_sub
+      subst hs_sub
+      exact (hs_ne rfl).elim
+    · -- s = t2 c with c ∈ t2Bases. Diagonal forces c = b.
+      rw [diagonal_in_t2_iff] at hs_sub
+      subst hs_sub
+      rw [t2Bases_mem_iff] at hc
+      exact hc.2.2
+  · intro hbd
+    refine ⟨t2 b, ?_, ?_, ?_⟩
+    · exact t2_in_topSimps2_of_base N
+        (t1Bases_diagonal_neighbor_in_t2Bases N hb hbd)
+    · exact (t1_ne_t2 b b).symm
+    · rw [diagonal_in_t2_iff]
+
 end N2BoundaryAnalysis
 end SpernerFreudSimp

--- a/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
@@ -926,3 +926,135 @@ in S11 and confirmed compiling). CI is the ground truth for the PR.
 Total estimated remaining for `sperner_panchromatic_two`:
 ~250 lines across 2-3 sessions (S16 cuts ~30 from the S15 estimate
 of 280).
+
+## Session 2026-05-08 (Session 17) — Base ↔ topSimps2 bridge
+
+**Mode**: REVISIT (continuing S16 boundary classification work)
+**Outcome**: progress — 13 new bridge lemmas, 1 sorry remaining (n=2)
+
+### What I Did
+
+Extended the `N2BoundaryAnalysis` section of `SpernerFreudenthalSimplex.lean`
+(currently 1014 lines after S16) with the **base ↔ topSimps2 bridge**.
+The S16 building blocks were edge-level (about which `t1 b`/`t2 c`
+contain a given edge); S17 bridges those to top-level `topSimps2 N`
+membership and arithmetic conditions on bases.
+
+**13 new lemmas in 7 groups**:
+
+1. `t1Bases_mem_iff`, `t2Bases_mem_iff` — clean iff form
+   `b ∈ t{1,2}Bases N ↔ b.1 < N ∧ b.2 < N ∧ ...`. Without these, every
+   later lemma had to unfold `t1Bases`/`t2Bases` and chain
+   `Finset.mem_filter`/`mem_product`/`mem_range`.
+2. `t1_in_topSimps2_of_base`, `t2_in_topSimps2_of_base`,
+   `topSimps2_mem_iff` — top-simplex membership from base membership
+   plus the canonical case-split `s ∈ topSimps2 N ↔ ∃ b ∈ t1Bases, t1 b = s
+   ∨ ∃ b ∈ t2Bases, t2 b = s` for inversion.
+3. `t2Bases_self_in_t1Bases`, `t2Bases_right_in_t1Bases`,
+   `t2Bases_top_in_t1Bases` — for `b ∈ t2Bases N`, all three "face-mate"
+   t1 bases (`b`, `(b.1+1, b.2)`, `(b.1, b.2+1)`) are in `t1Bases N`.
+   Combined with S16's `t2_face{0,1,2}_in_t1`, this proves **all t2
+   faces are shared with another top simplex**, hence t2 cells
+   contribute no boundary doors.
+4. `t1Bases_horizontal_neighbor_in_t2Bases`,
+   `t1Bases_vertical_neighbor_in_t2Bases`,
+   `t1Bases_diagonal_neighbor_in_t2Bases` — existential side of t1's
+   neighbor analysis.
+5. `diagonal_not_in_t2_at_diagonal` — the missing boundary case.
+   Counterpart to S16's `horizontal_not_in_t2_at_y0` and
+   `vertical_not_in_t2_at_x0`. When `b` saturates the diagonal
+   `b.1 + b.2 + 1 ≥ N`, no `t2 c` with `c ∈ t2Bases` contains the
+   diagonal of `t1 b`.
+6. `diagonal_neighbor_topSimps2` — top-level classification:
+   `∃ s ∈ topSimps2 N, s ≠ t1 b ∧ {(b.1, b.2+1), (b.1+1, b.2)} ⊆ s ↔
+   b.1 + b.2 + 1 < N`. This is the form S18's `containersOf`-based
+   assembly will consume directly.
+
+### Key Findings
+
+- **Base ↔ topSimps2 split is the right factoring.** S16 gave us
+  edge-level lemmas (`{u, v} ⊆ t1 c ↔ ...`), but the
+  `Triangulation.adj` API operates at the topSimps2 level
+  (`containersOf face = top simplices containing face`). Without an
+  explicit `topSimps2_mem_iff` for inversion, the case split
+  `s = t1 c ∨ s = t2 c` had to be re-derived inline at each call site.
+  The new iff makes the case-split a single `rw`.
+
+- **t2 cells contribute no boundary doors.** This was implicit in S16
+  via the three `t2_face{0,1,2}_in_t1` lemmas, but those alone don't
+  finish the argument: we also need the witness t1 cell to be in
+  `topSimps2 N`. The three `t2Bases_*_in_t1Bases` lemmas close this
+  gap. Now any boundary door `T.adj s k = none` with `s = ⟨t2 b, hb⟩`
+  is contradictory — the t1 face-mate is always in `containersOf`,
+  giving cardinality ≥ 2.
+
+- **Diagonal-boundary asymmetry.** The three boundary cases for t1
+  cells are not symmetric:
+  - **Horizontal boundary** (b.2 = 0): the y=0 edge of Δ² ⇒ Δ²-face 1.
+  - **Vertical boundary** (b.1 = 0): the x=0 edge of Δ² ⇒ Δ²-face 0.
+  - **Diagonal boundary** (b.1 + b.2 + 1 ≥ N, equivalently
+    b.1 + b.2 = N - 1 since `b ∈ t1Bases ⇒ b.1 + b.2 < N`): the
+    x+y = N edge of Δ² ⇒ Δ²-face 2.
+  The horizontal/vertical cases are "missing neighbor base"
+  (the would-be neighbor has negative coord), and S16's
+  `*_not_in_t2_at_*0` lemmas handle them. The diagonal case is
+  different: the would-be neighbor base `b` is in `t1Bases` but not
+  `t2Bases`. That's why a separate `diagonal_not_in_t2_at_diagonal`
+  lemma was needed.
+
+- **`subst h ⇒ rw [t2Bases_mem_iff] at hc ⇒ omega` is the canonical
+  contradiction pattern** for the diagonal case. After
+  `diagonal_in_t2_iff` reduces "diagonal in t2 c" to "c = b", `subst`
+  replaces c with b, then unfolding t2Bases gives the impossible
+  `b.1 + b.2 + 1 < N ∧ ... ≥ N`. Three lines each.
+
+- **Reverse direction of `diagonal_neighbor_topSimps2` uses
+  `(t1_ne_t2 b b).symm`** to get `t2 b ≠ t1 b`. The `.symm` is needed
+  because S16's `t1_ne_t2 (b c) : t1 b ≠ t2 c` is stated as t1 ≠ t2
+  but the goal here wants t2 ≠ t1.
+
+### Files Modified
+
+- `proofs/Proofs/SpernerFreudenthalSimplex.lean`
+  (+~165 lines, added inside `N2BoundaryAnalysis` section)
+- `research/problems/sperner-ndim-mathlib-oq-02/state.md` (iter 17)
+- `research/problems/sperner-ndim-mathlib-oq-02/knowledge.md` (this file)
+
+### Build Status
+
+Docker build not run this session: same `.lake` recursive-symlink
+constraint as S14–S16 (~25–45 min fresh-clone of Mathlib + cache).
+Additions are mechanical: `simp only`/`unfold` + `omega` on each
+arithmetic-content lemma, or a structural pattern matching S16
+(diagonal in/out via `diagonal_in_t{1,2}_iff` + `subst` + omega).
+CI is the ground truth.
+
+### Next Steps (Session 18+)
+
+1. **Assemble `_hBoundaryOnFace` for the n=2 case** using the S16
+   edge-level lemmas + S17 base-level bridge:
+   - For each cell `s = ⟨S, hS⟩` with `S ∈ topSimps2 N`, case-split
+     via `topSimps2_mem_iff` to get `S = t1 b` (with `b ∈ t1Bases N`)
+     or `S = t2 b` (with `b ∈ t2Bases N`).
+   - For each face index `k ∈ Fin 3`, compute `vertexEnum S hS k`
+     (lex-sort of t1/t2) — for `t1 b`, this is `b`, `(b.1, b.2+1)`,
+     `(b.1+1, b.2)`; for `t2 b`, it's `(b.1, b.2+1)`, `(b.1+1, b.2)`,
+     `(b.1+1, b.2+1)`.
+   - For the `t2 b` case: every k is non-boundary by the three
+     `t2Bases_*_in_t1Bases` lemmas + `t1_in_topSimps2_of_base` + S16's
+     `t2_face*_in_t1`. So `T.adj s k = none` is impossible — use
+     `False.elim`.
+   - For the `t1 b` case: each k corresponds to one boundary
+     condition (b.1 = 0, b.2 = 0, or b.1 + b.2 + 1 ≥ N), and the
+     existential `faceIdx` is one of `Fin 3` (Δ²-face 0, 1, or 2).
+     The non-k vertices both satisfy `onFaceΔ2 N · faceIdx`
+     by direct arithmetic case split.
+   ~80 lines.
+2. **Prove `_hLastFace`** (face 2 boundary doors, hardest piece):
+   bijection with `face2_path_odd`'s color-changing edges. ~120 lines.
+3. **Apply `Triangulation.sperner`** and extract real-coordinate
+   witnesses with diameter ≤ 2/N. ~50 lines.
+
+Total estimated remaining for `sperner_panchromatic_two`:
+~200 lines across 2 sessions (S17 cuts ~30 from the post-S16 estimate
+of 250).

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,18 +2,54 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Iteration**: 16
+**Last Updated**: 2026-05-08 (Iteration 17, researcher-12)
+**Iteration**: 17
 
 ## Current Focus
 
-Session 16: Added boundary-edge characterization scaffolding for the
-n=2 Type-1/Type-2 triangulation in a new `N2BoundaryAnalysis` section
-inside `SpernerFreudSimp`. Proves the eight building-block lemmas
-needed by the eventual `_hBoundaryOnFace` discharge: `t1_ne_t2`,
-`diagonal_in_t{1,2}_iff`, `horizontal_in_t2_pos`, `vertical_in_t2_pos`,
-`horizontal_not_in_t2_at_y0`, `vertical_not_in_t2_at_x0`, plus
-`t2_face{0,1,2}_in_t1` (every t2 face shared with a t1 cell, so t2
-contributes no boundary doors).
+Session 17 (this session): Extended the `N2BoundaryAnalysis` section
+with the **base ↔ topSimps2 bridge**: 13 new lemmas converting between
+arithmetic conditions on `(b, c)` and concrete edge containment in
+`topSimps2 N`. Specifically:
+
+1. **Base-membership iffs** (`t1Bases_mem_iff`, `t2Bases_mem_iff`): rewrite
+   `b ∈ t{1,2}Bases N` to clean arithmetic predicates.
+2. **topSimps2 membership** (`t1_in_topSimps2_of_base`,
+   `t2_in_topSimps2_of_base`, `topSimps2_mem_iff`): bridge from base
+   membership to top-simplex membership, including the canonical
+   case-split form `s ∈ topSimps2 N ↔ (∃ b ∈ t1Bases N, t1 b = s) ∨
+   (∃ b ∈ t2Bases N, t2 b = s)`.
+3. **t2 → t1 base translations** (`t2Bases_self_in_t1Bases`,
+   `t2Bases_right_in_t1Bases`, `t2Bases_top_in_t1Bases`): for
+   `b ∈ t2Bases N`, all three "face-mate" t1 bases — `b`, `(b.1+1, b.2)`,
+   `(b.1, b.2+1)` — are in `t1Bases N`. Combined with S16's
+   `t2_face{0,1,2}_in_t1`, this proves all t2 faces are shared with
+   another top simplex, hence **t2 cells contribute no boundary doors**.
+4. **t1 → t2 base translations** (`t1Bases_horizontal_neighbor_in_t2Bases`,
+   `t1Bases_vertical_neighbor_in_t2Bases`,
+   `t1Bases_diagonal_neighbor_in_t2Bases`): existential side of the
+   neighbor analysis for t1 cells.
+5. **The missing diagonal-boundary case** (`diagonal_not_in_t2_at_diagonal`):
+   counterpart to S16's `horizontal_not_in_t2_at_y0` and
+   `vertical_not_in_t2_at_x0`. When `b ∈ t1Bases N` saturates the
+   diagonal `b.1 + b.2 + 1 ≥ N`, no t2 cell with base in `t2Bases N`
+   contains the diagonal of t1(b).
+6. **Top-level diagonal classification** (`diagonal_neighbor_topSimps2`):
+   the existential at topSimps2 level — the diagonal of `t1 b` is
+   contained in *some other* simplex of `topSimps2 N` iff
+   `b.1 + b.2 + 1 < N`, in which case that other simplex is `t2 b`.
+
+This is exactly the form S18's `containersOf`-based assembly of
+`_hBoundaryOnFace` will consume.
+
+Session 16 (PR #17051, merged): Added boundary-edge characterization
+scaffolding for the n=2 Type-1/Type-2 triangulation in a new
+`N2BoundaryAnalysis` section inside `SpernerFreudSimp`. Proves the
+eight building-block lemmas needed by the eventual `_hBoundaryOnFace`
+discharge: `t1_ne_t2`, `diagonal_in_t{1,2}_iff`, `horizontal_in_t2_pos`,
+`vertical_in_t2_pos`, `horizontal_not_in_t2_at_y0`,
+`vertical_not_in_t2_at_x0`, plus `t2_face{0,1,2}_in_t1` (every t2 face
+shared with a t1 cell, so t2 contributes no boundary doors).
 
 Session 15 (PR #17015, merged): added a generic `_hLowerDim` discharge
 helper (`SpernerLowerDimHelper.sperner_lowerDim_card_even`) outside the
@@ -57,26 +93,36 @@ does NOT appear in FreudCell. FreudCell simply triangulates the wrong space.
 - `SpernerLowerDimHelper.sperner_lowerDim_card_even`: PR #17015 merged,
   generic discharge of `_hLowerDim` for any
   Sperner-on-Triangulation (S15)
-- `N2BoundaryAnalysis` building blocks (S16, this session, build pending):
+- `N2BoundaryAnalysis` building blocks (S16, PR #17051 merged):
   `t1_ne_t2`, `diagonal_in_t{1,2}_iff`, `horizontal_in_t2_pos`,
   `vertical_in_t2_pos`, `horizontal_not_in_t2_at_y0`,
   `vertical_not_in_t2_at_x0`, `t2_face{0,1,2}_in_t1`
+- `N2BoundaryAnalysis` base ↔ topSimps2 bridge (S17, this session,
+  build pending): 13 new lemmas converting base membership to
+  topSimps2 containment, plus the missing diagonal-boundary case
+  `diagonal_not_in_t2_at_diagonal` and the top-level classification
+  `diagonal_neighbor_topSimps2`.
 - `sperner_panchromatic_two` (n=2): 1 sorry remaining
 - n≥3: future work
 
-## Path Forward for n≥2 (post-S16)
+## Path Forward for n≥2 (post-S17)
 
 `Triangulation.boundary_doors_odd` requires four hypotheses:
 1. `_hSperner` — done generically by S14 wrapper (cN2_total_isSpernerColoring)
-2. `_hBoundaryOnFace` — building blocks in S16; remaining work is to
-   characterize `simData2.toTriangulation.adj s k = none` in terms of
-   boundary conditions on `b` and to assemble the existential (~50 lines)
+2. `_hBoundaryOnFace` — S16 supplies edge-containment building blocks;
+   S17 supplies the base ↔ topSimps2 bridge (membership iffs +
+   neighbor classification). **S18 next**: walk through the abstract
+   `adjFn` in `simData2.toTriangulation` to translate
+   `adjFn s k = none` ↔ `containersOf (faceOf s k) = {s}` ↔ (by S17
+   `topSimps2_mem_iff` case split + S16 edge lemmas) the concrete
+   boundary conditions on (b, k); then assemble the existential
+   `∃ faceIdx, ...` using the existing `onFaceΔ2` predicate (~80 lines).
 3. `_hLowerDim` — done generically by S15 helper
-4. `_hLastFace` — TODO (~150 lines, bijection with face2_path_odd via S12)
+4. `_hLastFace` — TODO (~120 lines, bijection with face2_path_odd via S12)
 
 Then apply `Triangulation.sperner` (~50 lines for diameter bound + real
-coordinates). Total estimated remaining: ~250 lines across 2-3 sessions
-(S16 cuts ~30 from the S15 estimate of 280).
+coordinates). Total estimated remaining: ~200 lines across 2 sessions
+(S17 cuts ~30 from the post-S16 estimate of 250).
 
 ## Gallery Status
 

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "sperner-ndim-mathlib-oq-02",
   "title": "Use Sperner's lemma to prove Brouwer's fixed-point theorem in Lean 4",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "STATE (2026-05-08, session 15): n=0,1 fully proved; n=2 has triangulation + pseudomanifold + XOR parity + grid coloring + 3 forced corner colors + onFace predicate + Sperner-condition wrapper. S14 PR #17004 (build pending) adds cN2_total wrapper + cN2_total_isSpernerColoring + topSimps2_vertex_in_range. S15 (this session) adds SpernerLowerDimHelper outside SpernerFreudSimp namespace, providing sperner_lowerDim_filter_empty + sperner_lowerDim_card_even — generic helpers that discharge the _hLowerDim hypothesis of Triangulation.boundary_doors_odd for any concrete Sperner-on-Triangulation, collapsing ~30 lines per call site. Remaining for sperner_panchromatic_two: _hBoundaryOnFace (~80 lines) + _hLastFace (~150 lines) + apply Triangulation.sperner with diameter bound (~50 lines). Main file SpernerNDimMathlibOQ02.lean unchanged at 1 axiom.",
+    "progressSummary": "STATE (2026-05-08, session 17): n=0,1 fully proved; n=2 has triangulation + pseudomanifold + XOR parity + grid coloring + 3 forced corner colors + onFace predicate + Sperner-condition wrapper + edge-containment building blocks (S16) + base ↔ topSimps2 bridge (S17). S14 PR #17004 (cN2_total wrapper + cN2_total_isSpernerColoring), S15 PR #17015 (SpernerLowerDimHelper.sperner_lowerDim_card_even discharging _hLowerDim), S16 PR #17051 (N2BoundaryAnalysis edge lemmas: t1_ne_t2 + diagonal_in_t{1,2}_iff + horizontal/vertical_in_t2_pos + horizontal/vertical_not_in_t2_at_*0 + t2_face{0,1,2}_in_t1) all merged. S17 (this session, build pending) extends N2BoundaryAnalysis with 13 new lemmas: base-membership iffs, topSimps2 membership, t2 ↔ t1 base translations (proves t2 cells no boundary), and the missing diagonal-boundary case + top-level classification. Remaining for sperner_panchromatic_two: _hBoundaryOnFace assembly (~80 lines, S18) + _hLastFace (~120 lines) + apply Triangulation.sperner (~50 lines). Main file SpernerNDimMathlibOQ02.lean unchanged at 1 axiom.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -59,7 +59,13 @@
       "onFaceΔ2_<j>_iff and onFaceΔ2_<j>_iff_gridPt_zero: 6 wrapper lemmas connecting onFace predicate to gridPt zero (SpernerFreudenthalSimplex.lean, session 13)",
       "cN2_ne_of_onFace: face-form Sperner condition matching IsSpernerColoring shape required by Triangulation.boundary_doors_odd (SpernerFreudenthalSimplex.lean, session 13)",
       "SpernerLowerDimHelper.sperner_lowerDim_filter_empty: for any Triangulation V n + IsSpernerColoring + faceIdx.val<n, the filter `IsDoor ∧ adj=none ∧ ∀j≠k: onFace (vertex s j) faceIdx` is empty by Sperner contradiction (SpernerFreudenthalSimplex.lean, session 15, generic — outside SpernerFreudSimp namespace)",
-      "SpernerLowerDimHelper.sperner_lowerDim_card_even: corollary giving the Even-cardinality form expected as _hLowerDim by Triangulation.boundary_doors_odd; ready to plug into the n=2 case AND any future n≥3 instantiation (SpernerFreudenthalSimplex.lean, session 15)"
+      "SpernerLowerDimHelper.sperner_lowerDim_card_even: corollary giving the Even-cardinality form expected as _hLowerDim by Triangulation.boundary_doors_odd; ready to plug into the n=2 case AND any future n≥3 instantiation (SpernerFreudenthalSimplex.lean, session 15)",
+      "Created lemmas SpernerFreudSimp.t1Bases_mem_iff and t2Bases_mem_iff in SpernerFreudenthalSimplex.lean (S17): clean iff form b ∈ t{1,2}Bases N ↔ b.1 < N ∧ b.2 < N ∧ ...",
+      "Created lemmas SpernerFreudSimp.t1_in_topSimps2_of_base, t2_in_topSimps2_of_base, topSimps2_mem_iff in SpernerFreudenthalSimplex.lean (S17): bridge from base membership to top-simplex membership + canonical case-split.",
+      "Created lemmas SpernerFreudSimp.t2Bases_self_in_t1Bases, t2Bases_right_in_t1Bases, t2Bases_top_in_t1Bases in SpernerFreudenthalSimplex.lean (S17): t2 → t1 base translations for face-mate analysis.",
+      "Created lemmas SpernerFreudSimp.t1Bases_horizontal_neighbor_in_t2Bases, t1Bases_vertical_neighbor_in_t2Bases, t1Bases_diagonal_neighbor_in_t2Bases in SpernerFreudenthalSimplex.lean (S17): t1 → t2 base translations.",
+      "Created lemma SpernerFreudSimp.diagonal_not_in_t2_at_diagonal in SpernerFreudenthalSimplex.lean (S17): the missing diagonal-boundary case, counterpart to S16's horizontal_not_in_t2_at_y0 and vertical_not_in_t2_at_x0.",
+      "Created lemma SpernerFreudSimp.diagonal_neighbor_topSimps2 in SpernerFreudenthalSimplex.lean (S17): top-level classification ∃ s ∈ topSimps2, s ≠ t1 b ∧ {diagonal} ⊆ s ↔ b.1+b.2+1 < N."
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -85,19 +91,23 @@
       "Three forced corner colors of Δ²: (N,0)→0, (0,N)→1, (0,0)→2. Each corner is on two geometric faces, so its color is uniquely forced regardless of f — non-trivial Sperner coloring witness",
       "_hLowerDim is a redundant API hypothesis of Triangulation.boundary_doors_odd: the proof of boundary_doors_odd does not consume _hLowerDim — it shows S=S_n directly via the same Sperner contradiction. The hypothesis can be discharged generically, collapsing ~30 lines of boilerplate per call site",
       "S15 helper extracts the Sperner contradiction from inside boundary_doors_odd's proof body (lines 226-244 of SpernerSimplicialInstance.lean): IsDoor at color Fin.castSucc ⟨faceIdx.val, hlt⟩ = faceIdx contradicts IsSpernerColoring on the witnessed non-k vertex on face faceIdx",
-      "Placement choice for S15: putting SpernerLowerDimHelper outside SpernerFreudSimp namespace makes it accessible to other concrete Sperner instantiations (e.g., a future SpernerNDim.lean rewrite) without awkward cross-namespace qualification, AND avoids any conflict with PR #17004's additions inside SpernerFreudSimp"
+      "Placement choice for S15: putting SpernerLowerDimHelper outside SpernerFreudSimp namespace makes it accessible to other concrete Sperner instantiations (e.g., a future SpernerNDim.lean rewrite) without awkward cross-namespace qualification, AND avoids any conflict with PR #17004's additions inside SpernerFreudSimp",
+      "S17 — Base ↔ topSimps2 bridge: 13 new lemmas in N2BoundaryAnalysis converting between arithmetic conditions on (b, c) and concrete edge containment in topSimps2 N. Splits naturally into (1) base-membership iffs t1Bases_mem_iff/t2Bases_mem_iff, (2) topSimps2 membership t1_in_topSimps2_of_base/t2_in_topSimps2_of_base/topSimps2_mem_iff, (3) t2 → t1 base translations t2Bases_*_in_t1Bases (3 lemmas, proves t2 cells contribute no boundary doors), (4) t1 → t2 base translations t1Bases_*_neighbor_in_t2Bases (3 lemmas), (5) the missing diagonal_not_in_t2_at_diagonal lemma, (6) the top-level diagonal_neighbor_topSimps2 classification.",
+      "S17 — t2 cells contribute no boundary doors. S16's three t2_face{0,1,2}_in_t1 lemmas show t2 face containment in t1 cells, but the t1 witness must also be in topSimps2 N. The S17 t2Bases_*_in_t1Bases trio closes this gap: for any b ∈ t2Bases N, all three face-mate t1 bases (b, (b.1+1, b.2), (b.1, b.2+1)) are in t1Bases N. So any boundary door on a t2 cell is contradictory.",
+      "S17 — Diagonal-boundary asymmetry. The three t1 boundary cases are not symmetric: horizontal (b.2=0) and vertical (b.1=0) are 'missing neighbor base' (negative coord) handled by S16's *_not_in_t2_at_*0; the diagonal case (b.1+b.2+1≥N) needs a separate argument via diagonal_in_t2_iff + subst, since the would-be neighbor base b is in t1Bases but not t2Bases.",
+      "S17 — diagonal_neighbor_topSimps2 is the consumable form for S18. Cleanly says 'the diagonal of t1(b) is contained in some other simplex of topSimps2 ↔ b.1+b.2+1 < N', with the witness simplex being t2(b). This is exactly what S18's containersOf-based assembly of _hBoundaryOnFace will plug into."
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
       "Sequential compactness of stdSimplex in Lean 4 (needed for fixed_point_from_approx axiom)"
     ],
     "nextSteps": [
-      "DONE in PR #17004 (S14, build pending): cN2_total total wrapper + cN2_total_isSpernerColoring lifted Sperner condition + topSimps2_vertex_in_range vertex-range bridge",
-      "DONE in this session (S15): generic SpernerLowerDimHelper.sperner_lowerDim_card_even that discharges _hLowerDim for any Sperner-on-Triangulation",
-      "Prove _hBoundaryOnFace: each adjFn=none cell-face pair (s,k) is on some geometric face of Δ² — case-analysis on t1/t2 base, identify which boundary edge (b₀=0, b₁=0, or b₀+b₁=N) the simplex sits on (~80 lines)",
-      "Prove _hLastFace (j=2): bijection between IsDoors at face 2 and color-changing edges of face2_path_odd (the proved binary parity lemma from S12) — connect cell-face IsDoor structure to grid edge colors (~150 lines)",
-      "Apply Triangulation.sperner to get panchromatic triangle, convert grid (b₀,b₁) to real (b₀/N, b₁/N, (N-b₀-b₁)/N), verify diameter ≤ 2/N (~50 lines)",
-      "Generalize to n≥3: extend Type-1/Type-2 to Type-1/.../Type-n triangulation of Δⁿ, OR prove via induction on n using the same boundary_doors_odd machinery (multi-session)"
+      "S18: assemble _hBoundaryOnFace for the n=2 case using S16 edge lemmas + S17 base bridge. For each cell s = ⟨S, hS⟩ with S ∈ topSimps2 N, case-split via topSimps2_mem_iff. For S = t2 b, every k is non-boundary (use t2Bases_*_in_t1Bases + t1_in_topSimps2_of_base + S16's t2_face*_in_t1) so adj s k = none gives False.elim. For S = t1 b, each k corresponds to one boundary condition (b.1=0, b.2=0, or b.1+b.2+1≥N) and the existential faceIdx is one of Fin 3 (Δ²-face 0/1/2). ~80 lines.",
+      "Prove _hLastFace (face 2 boundary doors): bijection with face2_path_odd's color-changing edges. The pre-S15 estimate of ~150 lines stands; if S18 produces the right vertexEnum/faceOf computations for t1/t2, this can drop to ~120.",
+      "Apply Triangulation.sperner and extract real-coordinate witnesses with diameter ≤ 2/N (~50 lines).",
+      "After sperner_panchromatic_two is complete (axiom-free n=2): generalize the Type-1/Type-2 grid construction to n≥3 via Freudenthal triangulation. Each top simplex is determined by a base + permutation of {1, ..., n}; pseudomanifold proof scales linearly with n.",
+      "The main file SpernerNDimMathlibOQ02.lean remains at 1 axiom (sperner_panchromatic for general n). Once n=2 is proved, the axiom can be replaced for n=2 or kept generically.",
+      "Build status: S17 not run through Docker (45min cold cache via broken proofs/.lake symlink). Pattern matches S14/S15/S16 build-pending merges. Lemmas are mechanical case-bash + omega."
     ]
   },
   "tags": [
@@ -117,7 +127,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-08T09:05:00.000Z",
+  "lastUpdate": "2026-05-08T13:00:00Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Extends the `N2BoundaryAnalysis` section of `SpernerFreudenthalSimplex.lean` (S16, PR #17051) with **13 new lemmas** converting between arithmetic conditions on `(b, c)` and concrete edge containment in `topSimps2 N`. This is the form S18's `containersOf`-based assembly of `_hBoundaryOnFace` will consume directly.

**Honest framing**: pure infrastructure session — no axiom or sorry delta. The main file `SpernerNDimMathlibOQ02.lean` is unchanged at 1 axiom (`sperner_panchromatic` for general n). The companion file grows from 1014 → 1188 lines (60 → 73 theorems/lemmas), all `private` lemmas inside `SpernerFreudSimp.N2BoundaryAnalysis`.

## New Lemmas (7 groups)

1. **Base-membership iffs**: `t1Bases_mem_iff`, `t2Bases_mem_iff` — rewrite `b ∈ t{1,2}Bases N` to the natural arithmetic predicates, replacing the unwieldy `Finset.mem_filter`/`mem_product`/`mem_range` chain at each call site.

2. **topSimps2 membership**: `t1_in_topSimps2_of_base`, `t2_in_topSimps2_of_base`, `topSimps2_mem_iff` — bridge from base membership to top-simplex membership, including the canonical case-split
   ```
   s ∈ topSimps2 N ↔ (∃ b ∈ t1Bases N, t1 b = s) ∨ (∃ b ∈ t2Bases N, t2 b = s)
   ```
   for inversion.

3. **t2 → t1 base translations**: `t2Bases_self_in_t1Bases`, `t2Bases_right_in_t1Bases`, `t2Bases_top_in_t1Bases` — for `b ∈ t2Bases N`, all three "face-mate" t1 bases (`b`, `(b.1+1, b.2)`, `(b.1, b.2+1)`) are in `t1Bases N`. Combined with S16's `t2_face{0,1,2}_in_t1`, this proves all t2 faces are shared with another top simplex — **t2 cells contribute no boundary doors**.

4. **t1 → t2 base translations**: `t1Bases_horizontal_neighbor_in_t2Bases`, `t1Bases_vertical_neighbor_in_t2Bases`, `t1Bases_diagonal_neighbor_in_t2Bases` — existential side of the neighbor analysis for t1 cells.

5. **The missing diagonal-boundary case** (`diagonal_not_in_t2_at_diagonal`) — counterpart to S16's `horizontal_not_in_t2_at_y0` and `vertical_not_in_t2_at_x0`. When `b ∈ t1Bases N` saturates the diagonal `b.1 + b.2 + 1 ≥ N`, no t2 cell with base in `t2Bases N` contains the diagonal of t1(b).

6. **Top-level diagonal classification** (`diagonal_neighbor_topSimps2`): the diagonal of `t1 b` is contained in *some other* simplex of `topSimps2 N` iff `b.1 + b.2 + 1 < N`, in which case that other simplex is `t2 b`.

## Why the Asymmetry

The three boundary cases for t1 cells split as:

| Boundary type | Condition | Δ²-face | S16/S17 lemma |
|---|---|---|---|
| Horizontal | `b.2 = 0` | face 1 (y=0) | `horizontal_not_in_t2_at_y0` (S16) |
| Vertical | `b.1 = 0` | face 0 (x=0) | `vertical_not_in_t2_at_x0` (S16) |
| Diagonal | `b.1 + b.2 + 1 ≥ N` | face 2 (x+y=N) | `diagonal_not_in_t2_at_diagonal` (S17, this PR) |

The horizontal/vertical cases are "missing neighbor base" (would-be neighbor has negative coord). The diagonal case is different — the would-be neighbor base `b` is in `t1Bases` but not `t2Bases`. That's why a separate contradiction lemma was needed.

## Build Status

Not run this session — the `proofs/.lake` recursive-symlink forces a fresh-clone of Mathlib + cache (~25–45 min cold). Pattern matches S14 (#17004), S15 (#17015), S16 (#17051), all merged "build pending". The new lemmas are mechanical:
- arithmetic content: `simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range]` + `omega`
- diagonal contradiction: `diagonal_in_t2_iff` + `subst` + `omega` (mirrors S16's pattern)
- existential proofs: `Finset.mem_union.mpr (Or.inl/inr (Finset.mem_image.mpr ⟨b, hb, rfl⟩))`

CI is the ground truth.

## Path Forward (S18+)

1. **`_hBoundaryOnFace` assembly** (~80 lines, S18) — case-split `s = ⟨S, hS⟩` via `topSimps2_mem_iff`:
   - For `S = t2 b`: every k is non-boundary by S17's t2 → t1 trio + `t1_in_topSimps2_of_base` + S16's `t2_face*_in_t1`. So `T.adj s k = none` is impossible.
   - For `S = t1 b`: each k corresponds to one boundary condition (b.1=0 / b.2=0 / b.1+b.2+1≥N), and the existential `faceIdx` is one of `Fin 3` — both non-k vertices satisfy `onFaceΔ2 N · faceIdx` by direct arithmetic.

2. **`_hLastFace`** (~120 lines) — bijection with `face2_path_odd`'s color-changing edges.

3. **Apply `Triangulation.sperner`** (~50 lines) — diameter ≤ 2/N + real-coordinate witnesses.

Total estimated remaining for `sperner_panchromatic_two`: ~200 lines across 2 sessions.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.SpernerNDimMathlibOQ02` succeeds (deferred — cold-cache build)
- [x] All declarations type-check by visual inspection against S16 patterns and existing `t1_unique_base`/`t2_unique_base`
- [x] Diff is clean (4 files: companion `.lean`, 2 knowledge `.md`, 1 research `.json`); no unrelated drift
- [x] No new axioms or sorries
- [x] All new lemmas are `private` (in `SpernerFreudSimp` namespace)

🤖 Generated by researcher-12