### PR TITLE
audit(batch): re-audit 6 entries clean (2026-05-08)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2139,9 +2139,9 @@
       "result": "clean"
     },
     "collatz-structured-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T21:15:00Z",
       "result": "clean"
     },
     "collatz-structured-oq-03": {
@@ -2337,9 +2337,9 @@
       "result": "clean"
     },
     "derangements-convergence-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T15:00:20Z",
+      "lastAudited": "2026-05-08T21:15:00Z",
       "result": "clean"
     },
     "derangements-oq-02": {
@@ -11421,9 +11421,9 @@
       "result": "clean"
     },
     "friendship-theorem-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T15:06:50Z",
+      "lastAudited": "2026-05-08T21:15:00Z",
       "result": "clean"
     },
     "friendship-theorem-oq-03": {
@@ -11439,15 +11439,15 @@
       "result": "clean"
     },
     "fundamental-arithmetic-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T15:06:23Z",
+      "lastAudited": "2026-05-08T21:15:00Z",
       "result": "clean"
     },
     "fundamental-arithmetic-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T15:05:50Z",
+      "lastAudited": "2026-05-08T21:15:00Z",
       "result": "clean"
     },
     "fundamental-theorem-algebra": {
@@ -12762,9 +12762,9 @@
       "result": "clean"
     },
     "ptolemys-theorem-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T15:01:30Z",
+      "lastAudited": "2026-05-08T21:15:00Z",
       "result": "clean"
     },
     "puiseux-theorem": {
@@ -15072,5 +15072,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-08T20:50:00Z"
+  "lastUpdated": "2026-05-08T21:15:00Z"
 }


### PR DESCRIPTION
## Summary

Re-audited 6 stale gallery entries (last audited 2026-04-24) against `origin/main`. All structural counts match the Lean source, no True stubs, no axiom masking, badges accurate to tier classification.

## Audited entries

| Slug | Status / Badge | Lines | Axioms | Theorems | Defs | Sorries |
|------|----------------|-------|--------|----------|------|---------|
| collatz-structured-oq-02-oq-01 | axiomatized / axiom | 213 | 1 | 16 | 1 | 0 |
| derangements-convergence-oq-03 | verified / original | 88 | 0 | 2 | 0 | 0 |
| ptolemys-theorem-oq-01-oq-02 | verified / mathlib | 270 | 0 | 3 | 0 | 0 |
| fundamental-arithmetic-oq-02 | verified / original | 192 | 0 | 18 | 2 | 0 |
| fundamental-arithmetic-oq-01 | verified / mathlib | 113 | 0 | 10 | 0 | 0 |
| friendship-theorem-oq-01 | verified / original | 2276 | 0 | 84 | 3 | 0 |

Counts re-verified via comment-stripped parsing of `git show origin/main:proofs/<file>.lean` with line-start regex for `theorem|lemma`, `def|abbrev|opaque`, and `axiom`.

## Spot-checks

- **collatz-structured-oq-02-oq-01**: axiom `eliahou_cycle_bound` openly disclosed; case-analysis extension to j=5..8 verified. Status `axiomatized` / badge `axiom` correct.
- **derangements-convergence-oq-03**: badge `original` consistent with novel rounding derivation atop sibling `DerangementsConvergence.derangements_convergence_rate`. Sole proof: `derangements_eq_round` from rate bound + arithmetic.
- **ptolemys-theorem-oq-01-oq-02**: badge `mathlib` correctly attributes Euclidean Ptolemy core via `Proofs.PtolemysTheorem`; spherical extension is bridge/substitution work.
- **fundamental-arithmetic-oq-02**: original ℤ[√-5] non-UFD proof. Defines `normZ5`, proves multiplicativity, irreducibility of 2 and 3 — no Mathlib wrapping for the main result.
- **fundamental-arithmetic-oq-01**: badge `mathlib` correctly identifies `Nat.factorization_mul` as the load-bearing lemma.
- **friendship-theorem-oq-01**: 0 axiom declarations confirmed via line-start regex (file's *internal* opening docstring still says "1 axiom" but that text is stale — file was upgraded to axiom-free per later section comments; meta.json correctly claims `axiomCount=0`).

## Skipped (covered elsewhere)

- erdos-131-oq-01, isosceles-triangle-oq-01, gcd-algorithm-oq-01-oq-03, cube-root-3-irrational, bezout-identity-oq-01, binomial-theorem-oq-02-oq-03 → already in open PR #17088.

## Tracker mechanics

Surgical `re.sub` edits to `src/data/proofs/audit-tracker.json` (per prior auditor convention to avoid `json.dump` reformatting drift).
- 6 entries: `auditCount += 1`, `lastAudited` updated to `2026-05-08T21:15:00Z`
- `lastUpdated` bumped
- Diff: 13+/-13 — only the 6 targeted entries + `lastUpdated`

## Test plan

- [x] Round-trip JSON parse OK
- [x] `git diff --stat`: 26 lines (13+, 13−) — surgical, only targeted entries + `lastUpdated`
- [x] Counts re-verified against `git show origin/main:proofs/<file>.lean` (comment-stripped)
- [x] No True-stub theorems, no phantom axioms, no axiom masking, no Mathlib-wrapper-as-original mislabels
- [x] No conflict with open PR #17088 (disjoint slug sets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)