### PR TITLE
fix(ci): drop broken push trigger from label-external-issues workflow

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -3,27 +3,13 @@ name: Label external issues
 on:
   issues:
     types: [opened]
-  push:
-    paths:
-      - '.github/workflows/label-external-issues.yml'
 
 permissions:
   issues: write
   contents: read
 
 jobs:
-  # Guard job to prevent workflow failure on push events
-  # GitHub Actions marks runs as failed when no jobs execute, so this ensures
-  # at least one job runs. Using explicit true condition for clarity.
-  validate:
-    if: ${{ true }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Workflow syntax valid
-        run: echo "Workflow file validated successfully"
-
   label_external:
-    if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if author is a collaborator


### PR DESCRIPTION
## Summary
Drop the `push:` trigger and the `validate` guard job from `.github/workflows/label-external-issues.yml`. The workflow now runs only on `issues: opened`, which is its actual purpose.

## Why
The push trigger was producing ~50+ false-positive CI-failure emails per day. Every research/enrich/audit branch push triggered a run because GitHub's `push: paths: [...]` filter treats the first push of a new branch as having all files in the diff (even when the file isn't modified relative to main). The `label_external` job is gated `if: github.event_name == 'issues'` so nothing runs on push events, and the `validate: if: \${{ true }}` guard job that was meant to prevent zero-job-runs-mark-failed wasn't actually executing. Every push run logs zero jobs and `conclusion=failure`.

```
$ gh run list --workflow label-external-issues.yml --limit 10
all 10 results: status=completed, conclusion=failure
```

The labeling functionality on `issues: opened` is unaffected.

## Upstream
The same buggy template ships as `defaults/optional/github-workflows/label-external-issues.yml` in the loom installer. Filing a separate issue at rjwalters/loom so future installs get the fix automatically.

## Test plan
- [x] Pushed this branch — should produce zero CI-failure emails for this push (the workflow no longer triggers on push)
- [ ] After merge: opening a fresh issue should still apply the `external` label and welcome comment for non-collaborator authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)