### PR TITLE
research(binary-gcd-oq-03-oq-02): S21 — schonhageGcdOf API surface (PART X, build pending)

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean
@@ -543,6 +543,88 @@ example : schonhageGcdOf 1000 1000 = 1000 := by native_decide
 
 example : schonhageGcdOf 1000000 999999 = 1 := by native_decide
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART X: API SURFACE FOR `schonhageGcdOf` (S21)
+-- ═══════════════════════════════════════════════════════════════
+
+/-! ### `schonhageGcdOf` satisfies the standard `Nat.gcd` API
+
+    With `schonhageGcdOf_eq_gcd` (S20) in hand, the entire
+    `Nat.gcd` API transfers to the verified Schönhage GCD function
+    by routine rewriting. The lemmas below state these wrappers
+    explicitly so that downstream code can use `schonhageGcdOf`
+    as a drop-in replacement for `Nat.gcd` without manually
+    invoking the correctness theorem at every site.
+
+    Each proof reduces to `schonhageGcdOf_eq_gcd` plus a single
+    `Nat.gcd` lemma; the section is purely an API surface, with
+    no new mathematical content beyond Session 20. The point is
+    pragmatic: a verified GCD function should expose the same
+    algebraic identities as the reference, and after S21 it does. -/
+
+/-- Schönhage GCD with zero on the left: returns the right argument. -/
+theorem schonhageGcdOf_zero_left (a : ℕ) : schonhageGcdOf 0 a = a := by
+  rw [schonhageGcdOf_eq_gcd, Nat.gcd_zero_left]
+
+/-- Schönhage GCD with zero on the right: returns the left argument. -/
+theorem schonhageGcdOf_zero_right (a : ℕ) : schonhageGcdOf a 0 = a := by
+  rw [schonhageGcdOf_eq_gcd, Nat.gcd_zero_right]
+
+/-- Schönhage GCD of `a` with itself is `a`. -/
+theorem schonhageGcdOf_self (a : ℕ) : schonhageGcdOf a a = a := by
+  rw [schonhageGcdOf_eq_gcd, Nat.gcd_self]
+
+/-- Schönhage GCD with one on the left collapses to one. -/
+theorem schonhageGcdOf_one_left (a : ℕ) : schonhageGcdOf 1 a = 1 := by
+  rw [schonhageGcdOf_eq_gcd, Nat.gcd_one_left]
+
+/-- Schönhage GCD with one on the right collapses to one. -/
+theorem schonhageGcdOf_one_right (a : ℕ) : schonhageGcdOf a 1 = 1 := by
+  rw [schonhageGcdOf_eq_gcd, Nat.gcd_one_right]
+
+/-- Schönhage GCD is commutative. -/
+theorem schonhageGcdOf_comm (a b : ℕ) :
+    schonhageGcdOf a b = schonhageGcdOf b a := by
+  rw [schonhageGcdOf_eq_gcd, schonhageGcdOf_eq_gcd, Nat.gcd_comm]
+
+/-- The Schönhage GCD divides the first argument. -/
+theorem schonhageGcdOf_dvd_left (a b : ℕ) : schonhageGcdOf a b ∣ a := by
+  rw [schonhageGcdOf_eq_gcd]; exact Nat.gcd_dvd_left a b
+
+/-- The Schönhage GCD divides the second argument. -/
+theorem schonhageGcdOf_dvd_right (a b : ℕ) : schonhageGcdOf a b ∣ b := by
+  rw [schonhageGcdOf_eq_gcd]; exact Nat.gcd_dvd_right a b
+
+/-- Universal property: any common divisor divides the Schönhage GCD. -/
+theorem dvd_schonhageGcdOf {c a b : ℕ} (ha : c ∣ a) (hb : c ∣ b) :
+    c ∣ schonhageGcdOf a b := by
+  rw [schonhageGcdOf_eq_gcd]; exact Nat.dvd_gcd ha hb
+
+/-- Schönhage GCD is associative. -/
+theorem schonhageGcdOf_assoc (a b c : ℕ) :
+    schonhageGcdOf (schonhageGcdOf a b) c
+      = schonhageGcdOf a (schonhageGcdOf b c) := by
+  rw [schonhageGcdOf_eq_gcd, schonhageGcdOf_eq_gcd, schonhageGcdOf_eq_gcd,
+      schonhageGcdOf_eq_gcd, Nat.gcd_assoc]
+
+/-- Schönhage GCD vanishes precisely when both inputs vanish. -/
+theorem schonhageGcdOf_eq_zero_iff (a b : ℕ) :
+    schonhageGcdOf a b = 0 ↔ a = 0 ∧ b = 0 := by
+  rw [schonhageGcdOf_eq_gcd, Nat.gcd_eq_zero_iff]
+
+/-- **Fuel irrelevance.** The fuel-indexed `schonhageGcd` is
+    fundamentally fuel-free: every choice of fuel yields the same
+    answer (namely `Nat.gcd a b`). The fuel parameter exists only
+    to satisfy Lean's structural recursion checker; semantically
+    the function is `Nat.gcd`.
+
+    This packages a corollary of `schonhageGcd_eq_gcd` that
+    downstream consumers find more directly useful when fuel
+    accounting bookkeeping would otherwise pollute proofs. -/
+theorem schonhageGcd_fuel_irrelevant (f₁ f₂ a b : ℕ) :
+    schonhageGcd f₁ a b = schonhageGcd f₂ a b := by
+  rw [schonhageGcd_eq_gcd, schonhageGcd_eq_gcd]
+
 end HGcdSafe
 
 /-! ## Summary
@@ -578,7 +660,7 @@ end HGcdSafe
 
 5. **Recursive Schönhage-style GCD via iterated safe HGCD**
    (`schonhageGcd`, `schonhageGcdOf`, `schonhageGcd_eq_gcd`,
-   `schonhageGcdOf_eq_gcd`, S20, this PR): a TOTAL CORRECT
+   `schonhageGcdOf_eq_gcd`, S20): a TOTAL CORRECT
    ITERATED GCD function. The body applies `hgcdSafeApply` once,
    checks whether the column-output natAbs strictly decreased
    `max a b`, and either recurses on the reduced pair or falls
@@ -588,6 +670,17 @@ end HGcdSafe
    holds unconditionally, INDEPENDENT of whether the underlying
    `hgcdMatrixSafe` ever reduces magnitude — the OUTER guard here
    handles every pathological input by dispatching to `Nat.gcd`.
+
+6. **API surface for `schonhageGcdOf`** (PART X, S21, this PR):
+   eleven wrapper lemmas establishing that `schonhageGcdOf`
+   satisfies the standard `Nat.gcd` algebraic identities — zero
+   absorption, commutativity, associativity, divisibility, the
+   universal property, and zero-vanishing. Plus
+   `schonhageGcd_fuel_irrelevant`, which packages the corollary
+   that the fuel parameter is semantically irrelevant: every
+   choice of fuel yields `Nat.gcd a b`. With S21 in place the
+   verified Schönhage GCD is a drop-in replacement for `Nat.gcd`
+   with respect to all standard rewriting tactics.
 
 **Significance of S20.** With `schonhageGcd_eq_gcd` in hand, the
 verified algorithmic story for Path A is complete: a recursive
@@ -599,7 +692,15 @@ yield an asymptotic speedup over `Nat.gcd`. That step requires
 both (a) a stronger invariant on `hgcdMatrixSafe` and (b) Mathlib
 bit-complexity infrastructure that does not yet exist.
 
-**Path A roadmap (Session 21+):**
+**Significance of S21.** The S21 API surface closes the
+ergonomic gap: callers can use the verified Schönhage GCD with
+exactly the same `simp`-style identities they would use for
+`Nat.gcd`, without ever invoking the correctness theorem at the
+call site. The proofs are uniformly trivial, but the lemmas are
+load-bearing for downstream usability and document that the
+verified function inherits the entire `Nat.gcd` theory.
+
+**Path A roadmap (Session 22+):**
 
 - Prove a structural inner-reduction theorem for
   `hgcdMatrixSafe`: characterise the input regime in which the

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -1,20 +1,23 @@
 # Current State
 
-**Phase**: ACT — Path A chosen post-S17. S20 closes the verified
-ALGORITHMIC story for Path A: `schonhageGcd` is a recursive
-Schönhage-style GCD function with correctness
-`schonhageGcd a b = Nat.gcd a b`, total and 0 axioms.
+**Phase**: ACT — Path A's algorithmic story (S18–S20) is closed.
+S21 adds the API surface: 11 wrapper lemmas + fuel-irrelevance,
+making `schonhageGcdOf` a drop-in replacement for `Nat.gcd` under
+standard rewriting.
 
 **Since**: 2026-05-01
-**Iteration**: 20
+**Iteration**: 21
 
 ## Current Focus
 
-Session 20 builds on S18–S19 to define an ITERATIVE Schönhage-style
-GCD function `schonhageGcd : ℕ → ℕ → ℕ → ℕ` (and top-level
-`schonhageGcdOf`), with correctness theorem
-`schonhageGcd_eq_gcd : schonhageGcd fuel a b = Nat.gcd a b` for
-every fuel and every pair of natural inputs.
+Session 21 packages the API surface for `schonhageGcdOf`. With
+`schonhageGcdOf_eq_gcd` (S20) in hand, the entire `Nat.gcd`
+algebraic theory transfers to the verified Schönhage GCD by
+routine rewriting — but downstream consumers shouldn't have to
+invoke the correctness theorem at every site. PART X provides
+named wrappers for every standard `Nat.gcd` identity, plus a
+fuel-irrelevance theorem packaging the corollary that the fuel
+parameter is semantically inert.
 
 The body iterates `hgcdSafeApply` (S19) on the reduced pair: each
 step takes the column output `(p.1.natAbs, p.2.natAbs)` and
@@ -103,7 +106,7 @@ Status of the proof plan (Sessions 1–19):
     counterexample family `(130, 89)` and worst-case `(107, 85)`.
     PART VI–VII of `BinaryGcdOQ03OQ02PathA.lean`.
 13. **Recursive Schönhage-style GCD via iteration** ✅ (S20,
-    this session): `schonhageGcd`, `schonhageGcdOf`,
+    PR #17087): `schonhageGcd`, `schonhageGcdOf`,
     `schonhageGcd_zero`, `schonhageGcd_succ`,
     `hgcdSafeApply_natAbs_gcd`, `schonhageGcd_eq_gcd`,
     `schonhageGcdOf_eq_gcd`. PART VIII–IX of
@@ -111,6 +114,18 @@ Status of the proof plan (Sessions 1–19):
     with two structural fallbacks (below-threshold + per-step
     guard). Native-decide examples include the S17
     counterexample family and `(1000000, 999999)`.
+14. **API surface for `schonhageGcdOf`** ✅ (S21, this session):
+    11 wrapper lemmas covering the standard `Nat.gcd` identities
+    (`schonhageGcdOf_zero_left`, `_zero_right`, `_self`,
+    `_one_left`, `_one_right`, `_comm`, `_dvd_left`, `_dvd_right`,
+    `dvd_schonhageGcdOf`, `_assoc`, `_eq_zero_iff`) plus
+    `schonhageGcd_fuel_irrelevant`. PART X of
+    `BinaryGcdOQ03OQ02PathA.lean`. Each wrapper reduces to
+    `schonhageGcdOf_eq_gcd` plus the corresponding `Nat.gcd`
+    lemma. The lemmas are uniformly trivial; their value is
+    pragmatic — `schonhageGcdOf` now responds to standard
+    `simp`-style tactics without manual unfolding at the call
+    site, completing the drop-in replacement story.
 
 **Open / Refuted**:
 - **Recursive case of `hgcdMatrix_row_output_le`** ❌ (line 1078,
@@ -136,6 +151,9 @@ The verified ALGORITHMIC story for Path A is now complete:
 - S20: a recursive iterated GCD function `schonhageGcd` with
   guarded fallback to `Nat.gcd`; correct via
   `schonhageGcd_eq_gcd`. Total and unconditional.
+- S21: API surface (PART X) — eleven wrapper lemmas + fuel
+  irrelevance, making `schonhageGcdOf` a drop-in replacement
+  for `Nat.gcd` under standard rewriting tactics.
 
 Remaining work for Path A is QUANTITATIVE only (asymptotic
 speedup, bit-complexity bound).
@@ -153,7 +171,7 @@ speedup, bit-complexity bound).
 
 ## Next Action
 
-1. **Session 21 — quantitative inner-reduction characterisation**:
+1. **Session 22 — quantitative inner-reduction characterisation**:
    establish the input regime in which `hgcdMatrixSafe`'s inner
    runtime guard fires. The S17 PART XIV counterexample shows the
    guard can abort, but a density argument may still yield a
@@ -161,12 +179,14 @@ speedup, bit-complexity bound).
 2. **Empirical comparison**: native_decide-checked
    `schonhageGcdOf` on the S17 counterexample family vs `Nat.gcd`,
    to characterise the practical impact of the OUTER guard
-   firing on those inputs.
+   firing on those inputs (e.g. by exhibiting that
+   `(hgcdSafeApply 130 89)` does NOT reduce `max`, so the OUTER
+   guard fires unconditionally on this input).
 3. **Bit-complexity bound**: still blocked on Mathlib; defer.
 
 ## Attempt Counts
 
-- Total attempts: 20 (Sessions 1–20)
+- Total attempts: 21 (Sessions 1–21)
 - Approaches tried:
   - Path A (fuel-indexed correctness): merged Session 2 (#14389)
   - Row-convention size-reduction infrastructure: Sessions 3–16
@@ -174,5 +194,7 @@ speedup, bit-complexity bound).
     invariant target was REFUTED by Session 17.
   - Path A algorithm refinement: GCD-preservation foundation
     (S18, #17042), verified single-step GCD function (S19, #17063),
-    recursive Schönhage-style iterated GCD (S20, this PR).
-  - Path A quantitative bounds (S21+): pending.
+    recursive Schönhage-style iterated GCD (S20, #17087).
+  - Path A API surface (S21, this PR): standard `Nat.gcd` API
+    transferred to `schonhageGcdOf`; fuel irrelevance packaged.
+  - Path A quantitative bounds (S22+): pending.


### PR DESCRIPTION
## Summary

Adds **PART X** to `BinaryGcdOQ03OQ02PathA.lean`: an eleven-lemma API surface exposing the standard `Nat.gcd` algebraic identities on the verified Schönhage GCD function `schonhageGcdOf`, plus a fuel-irrelevance theorem.

With S20's `schonhageGcdOf_eq_gcd` in hand, the entire `Nat.gcd` API transfers to the verified Schönhage GCD by routine rewriting. PART X states these wrappers explicitly so downstream consumers can use `schonhageGcdOf` as a drop-in replacement for `Nat.gcd` without manually invoking the correctness theorem at every call site.

## Theorems added (PART X)

| Lemma | Statement |
|-------|-----------|
| `schonhageGcdOf_zero_left` | `schonhageGcdOf 0 a = a` |
| `schonhageGcdOf_zero_right` | `schonhageGcdOf a 0 = a` |
| `schonhageGcdOf_self` | `schonhageGcdOf a a = a` |
| `schonhageGcdOf_one_left` | `schonhageGcdOf 1 a = 1` |
| `schonhageGcdOf_one_right` | `schonhageGcdOf a 1 = 1` |
| `schonhageGcdOf_comm` | `schonhageGcdOf a b = schonhageGcdOf b a` |
| `schonhageGcdOf_dvd_left` | `schonhageGcdOf a b ∣ a` |
| `schonhageGcdOf_dvd_right` | `schonhageGcdOf a b ∣ b` |
| `dvd_schonhageGcdOf` | `c ∣ a → c ∣ b → c ∣ schonhageGcdOf a b` |
| `schonhageGcdOf_assoc` | `schonhageGcdOf (schonhageGcdOf a b) c = schonhageGcdOf a (schonhageGcdOf b c)` |
| `schonhageGcdOf_eq_zero_iff` | `schonhageGcdOf a b = 0 ↔ a = 0 ∧ b = 0` |
| `schonhageGcd_fuel_irrelevant` | `schonhageGcd f₁ a b = schonhageGcd f₂ a b` |

Each proof is a two-step rewrite chain through `schonhageGcdOf_eq_gcd` plus the corresponding `Nat.gcd` lemma. Lines added: +101 in PART X plus an updated Summary block.

## Honest assessment

The lemmas are uniformly trivial — that is the point. Once `schonhageGcdOf_eq_gcd` is established (S20), no further mathematical work is needed; PART X is purely a packaging step that exposes `schonhageGcdOf` to the standard simp/rewrite vocabulary. The contribution is pragmatic, not mathematical.

The fuel-irrelevance theorem `schonhageGcd_fuel_irrelevant` packages a slightly more substantive corollary: that the fuel parameter is semantically inert (every fuel yields `Nat.gcd a b`), so consumers can choose any fuel without affecting answers. The proof is two-line, but the statement encodes a non-obvious fact about the fuel-indexed definition.

## Path A roadmap going forward

After S21 the verified algorithmic story for Path A is **complete and ergonomic**:

- S18 (#17042): unimodularity + GCD preservation for `hgcdMatrixSafe`.
- S19 (#17063): single-step verified GCD function `hgcdSafeGcd`.
- S20 (#17087): recursive Schönhage-style iterated GCD `schonhageGcdOf`.
- **S21 (this PR):** API surface — `schonhageGcdOf` is a drop-in replacement.

Remaining Path A work is **quantitative only**:

1. Inner-reduction characterisation: prove that the runtime guard on `hgcdMatrixSafe` fires on a measurable density of inputs above threshold (would yield a probabilistic speedup bound).
2. Bit-complexity O(M(n) log n): genuinely blocked on Mathlib (no fast multiplication, no bit-complexity model).
3. Empirical comparison vs `Nat.gcd` on the S17 PR #17024 counterexample family.

## Build status

The local Docker build path is **not currently usable**: the recursive self-symlink at `proofs/.lake → proofs/.lake` forces every Docker build to fresh-clone Mathlib (~45 min). Build was not attempted this session. Mathematical confidence is **high** — each proof is a two-step rewrite through `schonhageGcdOf_eq_gcd` and a canonical `Nat.gcd` lemma. CI is the authoritative build verifier.

This follows the build-pending pattern of #17042 (S18), #17063 (S19), and #17087 (S20).

## Test plan

- [ ] CI build of `Proofs.BinaryGcdOQ03OQ02PathA` succeeds
- [ ] No new sorries; no new axioms
- [ ] `schonhageGcdOf_eq_gcd` (S20) typechecks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)