### PR TITLE
Enrich laws-of-large-numbers-oq-04-oq-03: canonical sections + mainTheorems + prerequisites

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/annotations.json
@@ -14,77 +14,87 @@
   {
     "id": "ann-axiom-1-proof",
     "proofId": "laws-of-large-numbers-oq-04-oq-03",
-    "range": { "startLine": 37, "endLine": 55 },
+    "range": { "startLine": 43, "endLine": 63 },
     "type": "technique",
     "title": "Integrability via Integrable.mono'",
-    "content": "The standard Lean 4 pattern for proving integrability of bounded measurable functions: find a dominating integrable function, prove AEMeasurability of the target, and bound the norm pointwise.\n\nHere the dominating function is the constant 1 (integrable on any probability space via `integrable_const`). The indicator 1_{X₀ ≤ x} has norm ≤ 1 (it takes values 0 or 1), proved by splitting on whether X₀(ω) ≤ x. AEMeasurability follows from composing Measurable (X 0) with the Borel-measurable indicator.",
-    "mathContext": "$\\|\\mathbf{1}_{X_0(\\omega) \\leq x}\\| \\leq 1$ for all $\\omega$ and $\\int_\\Omega 1 \\, d\\mu < \\infty$ when $\\mu$ is a probability measure. Therefore $\\mathbf{1}_{X_0 \\leq x}$ is integrable.",
+    "content": "The standard Lean 4 pattern for proving integrability of bounded measurable functions: find a dominating integrable function, prove AEMeasurability of the target, and bound the norm pointwise.\n\nHere the dominating function is the constant 1 (integrable on any probability space via `integrable_const`). The indicator 1_{X₀ ≤ x} has norm ≤ 1 (it takes values 0 or 1), proved by splitting on whether X₀(ω) ≤ x. AEMeasurability follows from composing Measurable (X 0) with the Borel-measurable indicator.\n\n**Lean walkthrough (lines 53–63)**:\n```\napply Integrable.mono' (integrable_const (1 : ℝ))\n· exact ((measurable_iic_indicator x).comp (hX 0)).aemeasurable  -- AEMeasurable\n· filter_upwards with ω; simp only [thresholdIndicator, Set.indicator, norm_one]\n  split_ifs with h\n  · norm_num   -- case X₀ ω ≤ x: indicator value 1, ‖1‖ = 1 ≤ 1\n  · norm_num   -- case X₀ ω > x: indicator value 0, ‖0‖ = 0 ≤ 1\n```\nThis is the *canonical* pattern for any 0/1-valued indicator on a probability space — replacing what could otherwise be a bare integrability axiom in dozens of similar formalizations.",
+    "mathContext": "$\\|\\mathbf{1}_{X_0(\\omega) \\leq x}\\| \\leq 1$ for all $\\omega$ and $\\int_\\Omega 1 \\, d\\mu = 1 < \\infty$ when $\\mu$ is a probability measure. By `Integrable.mono'`, an AEMeasurable function dominated a.e.\\ in norm by an integrable function is itself integrable. Hence $\\mathbf{1}_{X_0 \\leq x}$ is integrable with $\\int |\\mathbf{1}_{X_0 \\leq x}|\\, d\\mu \\leq 1$.",
     "significance": "key",
     "relatedConcepts": [
       "bounded measurable functions",
       "integrable_const",
       "Integrable.mono'",
-      "AEMeasurable"
-    ]
+      "AEMeasurable",
+      "filter_upwards",
+      "split_ifs"
+    ],
+    "prerequisites": ["IsProbabilityMeasure", "Measurable", "Set.indicator", "AEMeasurable composition"]
   },
   {
     "id": "ann-preimage-rewrite",
     "proofId": "laws-of-large-numbers-oq-04-oq-03",
-    "range": { "startLine": 58, "endLine": 68 },
+    "range": { "startLine": 65, "endLine": 75 },
     "type": "technique",
     "title": "Preimage Indicator Factorization",
-    "content": "The key algebraic step: the indicator function 1_{X₀ ≤ x}(ω) = (X₀ ⁻¹' Iic x).indicator(ω). This converts the indicator of a set in the range space (Iic x ⊆ ℝ) to an indicator of a set in the domain space (X₀ ⁻¹' Iic x ⊆ Ω). Only after this conversion can `integral_indicator` be applied, since that lemma requires the indicator to be of a subset of the integration domain.",
+    "content": "The key algebraic step (private lemma `thresholdIndicator_eq_preimage_indicator_fun`): the indicator function 1_{X₀ ≤ x}(ω) = (X₀ ⁻¹' Iic x).indicator(ω). This converts the indicator of a set in the range space (Iic x ⊆ ℝ) to an indicator of a set in the domain space (X₀ ⁻¹' Iic x ⊆ Ω). Only after this conversion can `integral_indicator` be applied, since that lemma requires the indicator to be of a subset of the integration domain.\n\n**Lean proof** (lines 70–75):\n```\nprivate lemma thresholdIndicator_eq_preimage_indicator_fun\n    {X : ℕ → Ω → ℝ} (x : ℝ) :\n    (fun ω => thresholdIndicator X x 0 ω) =\n    (fun ω => (X 0 ⁻¹' Set.Iic x).indicator (fun _ => (1 : ℝ)) ω) := by\n  ext ω\n  simp only [thresholdIndicator, Set.indicator, Set.mem_preimage, Set.mem_Iic]\n```\nThe one-line `simp only` discharges both the `thresholdIndicator` unfold and the membership rewrites $\\omega \\in X_0^{-1}(\\mathrm{Iic}\\,x) \\iff X_0(\\omega) \\in \\mathrm{Iic}\\,x \\iff X_0(\\omega) \\leq x$.",
     "mathContext": "$\\mathbf{1}_{X_0(\\omega) \\leq x} = \\mathbf{1}_{X_0(\\omega) \\in (-\\infty, x]} = \\mathbf{1}_{\\omega \\in X_0^{-1}((-\\infty, x])}$",
     "significance": "key",
     "relatedConcepts": [
       "Set.preimage",
       "Set.indicator",
       "integral_indicator",
-      "Set.mem_preimage"
-    ]
+      "Set.mem_preimage",
+      "Set.mem_Iic"
+    ],
+    "prerequisites": ["function extensionality (ext)", "simp lemma database"]
   },
   {
     "id": "ann-integral-chain",
     "proofId": "laws-of-large-numbers-oq-04-oq-03",
-    "range": { "startLine": 70, "endLine": 105 },
+    "range": { "startLine": 77, "endLine": 103 },
     "type": "proof-step",
     "title": "Three-Step Integration Chain for CDF Identity",
-    "content": "The proof of the CDF identity chains three Mathlib lemmas:\n\n1. **integral_indicator**: converts ∫ (X₀ ⁻¹' Iic x).indicator(ω) dμ to ∫ in X₀ ⁻¹' Iic x, 1 dμ. Requires MeasurableSet of the integration domain, which follows from Measurable (X 0) applied to the Borel set Iic x.\n\n2. **integral_const**: evaluates ∫ _, 1 ∂(μ.restrict s) as ((μ.restrict s) Set.univ).toReal • 1.\n\n3. **Measure.restrict_apply** + **Set.univ_inter**: computes (μ.restrict s) Set.univ = μ (Set.univ ∩ s) = μ s.",
+    "content": "Theorem `integral_thresholdIndicator_eq_cdf_proved`. The proof chains three Mathlib lemmas after a preimage rewrite:\n\n1. **`integral_indicator`**: converts ∫ (X₀ ⁻¹' Iic x).indicator(ω) dμ to ∫ in X₀ ⁻¹' Iic x, 1 dμ. Requires MeasurableSet of the integration domain — discharged by `(hX 0) measurableSet_Iic` since measurable functions pull back Borel sets to measurable sets.\n2. **`integral_const`**: evaluates ∫ _, 1 ∂(μ.restrict s) as ((μ.restrict s) Set.univ).toReal • 1.\n3. **`Measure.restrict_apply` + `Set.univ_inter`**: computes (μ.restrict s) Set.univ = μ (Set.univ ∩ s) = μ s.\n\nFinally a `simp only [trueCDF]; congr 1; ext ω; simp [...]` identifies the preimage set with the trueCDF defining set $\\{\\omega \\mid X_0(\\omega) \\leq x\\}$ — these are *definitionally* equal as sets, but Lean still needs the explicit `congr` + `ext` to align the two functional forms after the integral has been collapsed.\n\n**Reusable template**: any \"integral of an indicator equals a measure value\" identity follows the same chain — preimage rewrite, `integral_indicator`, `integral_const`, `Measure.restrict_apply`, `congr` to align with the target measure. This template applies to any random variable / measurable space, not just real-valued $X_0$ and $\\mathrm{Iic}\\,x$.",
     "mathContext": "\\begin{align*}\n\\int_\\Omega \\mathbf{1}_{X_0(\\omega) \\leq x} \\, d\\mu &= \\int_\\Omega \\mathbf{1}_{X_0^{-1}((-\\infty,x])}(\\omega) \\, d\\mu \\\\\n&= \\int_{X_0^{-1}((-\\infty,x])} 1 \\, d\\mu \\\\\n&= \\mu(X_0^{-1}((-\\infty, x])) \\\\\n&= \\mu(\\{\\omega : X_0(\\omega) \\leq x\\}) = F(x)\n\\end{align*}",
     "significance": "key",
     "relatedConcepts": [
       "integral_indicator",
       "integral_const",
       "Measure.restrict_apply",
-      "trueCDF"
-    ]
+      "trueCDF",
+      "Set.univ_inter",
+      "MeasurableSet.preimage"
+    ],
+    "prerequisites": ["thresholdIndicator_eq_preimage_indicator_fun", "Measure.restrict", "Bochner integral basics"]
   },
   {
     "id": "ann-pointwise-convergence",
     "proofId": "laws-of-large-numbers-oq-04-oq-03",
-    "range": { "startLine": 105, "endLine": 136 },
+    "range": { "startLine": 105, "endLine": 135 },
     "type": "concept",
     "title": "Corollary: Axiom-Free Pointwise Convergence of the Empirical CDF",
-    "content": "`empiricalCDF_pointwise_convergence_no_axiom` is the file's payoff: assuming the SLLN-applicable hypotheses (i.i.d., identically distributed, measurable) plus a probability measure, the empirical CDF converges pointwise to the true CDF a.s., and the proof now invokes *zero* integration axioms. The chain of steps inside the proof body is illuminating: (1) get integrability of the threshold indicator from `thresholdIndicator_integrable_proved` (this file), (2) get pairwise independence and identical distribution from the parent file (these are *not* integration axioms — they're structural lifts of independence/identity from $X$ to indicators, provable from definitions), (3) apply `strong_law_ae_real` (Mathlib's SLLN), (4) substitute the integral identity from `integral_thresholdIndicator_eq_cdf_proved` to identify the SLLN limit as $F(x)$, (5) `convert hω using 1; ext n; simp` extracts the empirical-mean form. Pointwise GC is now a chain of theorems with no holes; only the uniform-bracketing step remains.",
+    "content": "`empiricalCDF_pointwise_convergence_no_axiom` is the file's payoff: assuming the SLLN-applicable hypotheses (i.i.d., identically distributed, measurable) plus a probability measure, the empirical CDF converges pointwise to the true CDF a.s., and the proof now invokes *zero* integration axioms.\n\nThe chain of steps inside the proof body is illuminating: (1) get integrability of the threshold indicator from `thresholdIndicator_integrable_proved` (this file); (2) get pairwise independence and identical distribution from the parent file's `thresholdIndicator_pairwise_indep` and `thresholdIndicator_identDistrib` (these are *not* integration axioms — they're structural lifts of indep/i.d. from $X$ to indicators, provable from definitions); (3) apply `strong_law_ae_real` (Mathlib's SLLN); (4) `rw integral_thresholdIndicator_eq_cdf_proved` to identify the SLLN limit as $F(x)$; (5) `filter_upwards [hslln] with ω hω; convert hω using 1; ext n; simp only [empiricalCDF_eq_mean]` extracts the empirical-mean form $F_n(x, \\omega) = \\frac{1}{n}\\sum_{i=1}^n \\mathbf{1}_{X_i(\\omega) \\leq x}$ from the SLLN's empirical-mean conclusion. Pointwise GC is now a chain of theorems with no holes; only the uniform-bracketing step remains.",
     "mathContext": "$\\forall x \\in \\mathbb{R}: \\quad F_n(x) := \\frac{1}{n} \\sum_{i=1}^n \\mathbf{1}_{X_i \\leq x} \\to F(x) := \\mu(X_0 \\leq x) \\quad \\text{a.s.}$ The SLLN applied to the indicator sequence $\\{\\mathbf{1}_{X_i \\leq x}\\}_i$ — independent (from i.i.d. of $X_i$) and identically distributed (from i.d. of $X_i$) — gives the empirical mean converging to the expectation, which is exactly $F(x)$ by the integral identity.",
     "significance": "key",
-    "relatedConcepts": ["strong law of large numbers", "empirical CDF", "pointwise convergence", "iIndepFun"],
-    "prerequisites": ["thresholdIndicator_integrable_proved", "integral_thresholdIndicator_eq_cdf_proved", "strong_law_ae_real"]
+    "relatedConcepts": ["strong law of large numbers", "empirical CDF", "pointwise convergence", "iIndepFun", "IdentDistrib", "filter_upwards"],
+    "prerequisites": ["thresholdIndicator_integrable_proved", "integral_thresholdIndicator_eq_cdf_proved", "strong_law_ae_real", "thresholdIndicator_pairwise_indep", "thresholdIndicator_identDistrib", "empiricalCDF_eq_mean"]
   },
   {
     "id": "ann-remaining-axiom",
     "proofId": "laws-of-large-numbers-oq-04-oq-03",
-    "range": { "startLine": 110, "endLine": 128 },
+    "range": { "startLine": 137, "endLine": 156 },
     "type": "context",
     "title": "The One Remaining Axiom: Uniform Bracketing",
-    "content": "After this entry, only one axiom remains in the Glivenko-Cantelli formalization: `glivenko_cantelli_uniform`, the step that upgrades pointwise to uniform convergence.\n\nThis step requires: for any ε > 0, find continuity points q₁,...,qₖ of F such that (a) each interval [qⱼ, qⱼ₊₁) has F-mass < ε, and (b) for any x between grid points, |Fₙ(x) - F(x)| ≤ max_j |Fₙ(qⱼ) - F(qⱼ)| + ε by monotonicity of both Fₙ and F.\n\nThis requires: (1) existence of CDF continuity points with controlled density, (2) monotonicity of Fₙ and F, and (3) finite intersection of pointwise convergence events. Steps (2) and (3) are available in Mathlib. Step (1) — the density of continuity points with controlled jump sizes — is the missing piece in Mathlib 4.26.",
+    "content": "After this entry, only one axiom remains in the Glivenko-Cantelli formalization: `glivenko_cantelli_uniform`, the step that upgrades pointwise to uniform convergence.\n\nThis step requires: for any ε > 0, find continuity points q₁,...,qₖ of F such that (a) each interval [qⱼ, qⱼ₊₁) has F-mass < ε, and (b) for any x between grid points, |Fₙ(x) - F(x)| ≤ max_j |Fₙ(qⱼ) - F(qⱼ)| + ε by monotonicity of both Fₙ and F.\n\nThis requires: (1) existence of CDF continuity points with controlled density, (2) monotonicity of Fₙ and F, and (3) finite intersection of pointwise convergence events. Steps (2) and (3) are available in Mathlib (parent file's `empiricalCDF_mono`/`trueCDF_mono`, plus `MeasureTheory.ae_all_iff`). Step (1) — the density of continuity points with controlled jump sizes — is the missing piece in Mathlib 4.26.\n\nWhy is step (1) hard? *Density* alone of continuity points is straightforward (Mathlib has `Monotone.countable_not_continuousAt` for countability of discontinuities, and the complement of a countable set is dense in ℝ via `Set.Countable.dense_compl`). But the *bracketing* requires more: an ε-cover induction over [0,1] under the monotone $F$, producing a *finite* sequence with each F-jump < ε. Constructively producing this finite sequence — rather than just asserting its existence non-constructively — is what's currently missing.",
     "mathContext": "For the uniform bound: for $\\varepsilon > 0$, choose continuity points $q_1 < \\cdots < q_k$ of $F$ with $F(q_{j+1}) - F(q_j^-) < \\varepsilon$. For any $x$, find $j$ with $q_j \\leq x < q_{j+1}$. By monotonicity of $F_n$ and $F$:\n$$|F_n(x) - F(x)| \\leq |F_n(q_{j+1}) - F(q_{j+1})| + \\varepsilon$$\nand the right side is bounded by $\\max_j |F_n(q_j) - F(q_j)| + \\varepsilon \\to \\varepsilon$ a.s.",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": [
       "glivenko_cantelli_uniform",
       "CDF continuity points",
       "uniform convergence",
-      "bracketing argument"
+      "bracketing argument",
+      "Monotone.countable_not_continuousAt",
+      "MeasureTheory.ae_all_iff"
     ]
   },
   {

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -65,23 +65,98 @@
       "The preimage identification X₀ ⁻¹' Iic x = {ω | X₀ ω ≤ x} connects the integral computation to the trueCDF definition by definitional equality of sets.",
       "The one remaining axiom (glivenko_cantelli_uniform) corresponds to a qualitatively harder problem: choosing CDF continuity points with controlled mass per interval requires a measurability + density argument not yet in Mathlib.",
       "Forward path — VC-class generalization framework: the classical (distribution-free) bracketing step and its VC-class generalization share most of their Mathlib needs, and inherit the same scaffolding. Three classical pieces are required: (a) density of CDF continuity points — derivable from Mathlib's lemma that monotone real functions have countably many discontinuities, since the complement of a countable set is dense in ℝ; (b) a constructive ε-cover lemma producing finitely many continuity points q₁ < ⋯ < q_k with each F-jump F(q_{j+1}) − F(q_j⁻) < ε — this is the genuinely missing piece, requiring a covering-by-ε-mass induction over [0,1] under monotone F; (c) finite intersection of pointwise convergence events — already available via `MeasureTheory.ae_all_iff`. The VC-class generalization (uniform LLN over a class 𝓕 of indicators with finite VC dimension d, giving rate O(√(d/n))) requires three additional Mathlib gaps: shatter-coefficient/VC-dimension definitions, the Vapnik–Chervonenkis symmetrization inequality (Sauer–Shelah lemma + ghost-sample argument), and the Talagrand-style maximal inequality for empirical processes. Specializing the indicator class to threshold functions {1_{x ≤ ·} : x ∈ ℝ} (VC dimension 1) recovers classical Glivenko–Cantelli, so a VC-class formalization in Mathlib subsumes the classical step — making (b) above redundant once (d)–(f) are available."
+    ],
+    "prerequisites": [
+      "Probability spaces: $(\\Omega, \\mathcal{F}, \\mu)$ with $\\mu(\\Omega) = 1$. Mathlib's `IsProbabilityMeasure` / `IsFiniteMeasure` typeclasses",
+      "Random variables and CDF: $X : \\Omega \\to \\mathbb{R}$ measurable, $F(x) := \\mu(X \\leq x)$. Mathlib's `Measurable`, `Set.preimage`, `Set.Iic`, and the file's `trueCDF`",
+      "Lebesgue/Bochner integral basics: $\\int_\\Omega f \\, d\\mu$, integral of a constant ($\\int_\\Omega c\\, d\\mu = c \\cdot \\mu(\\Omega)$ for finite measures), `MeasureTheory.integral_const`",
+      "Indicator functions: `Set.indicator s f` $= \\mathbf{1}_s \\cdot f$. Pointwise rewrite identities (`Set.mem_preimage`, `Set.mem_Iic`, `Set.indicator_apply`)",
+      "Integrability via domination: `MeasureTheory.Integrable.mono'`: an AEMeasurable function dominated a.e. in norm by an integrable function is integrable. Used here with the integrable constant 1",
+      "Restricted measure: `Measure.restrict s` acts as $\\mu$ on $s$ and 0 elsewhere; `Measure.restrict_apply (MeasurableSet.univ)` computes $(\\mu.\\mathrm{restrict}\\,s)\\,\\mathrm{Set.univ} = \\mu(\\mathrm{Set.univ} \\cap s) = \\mu\\,s$",
+      "`MeasureTheory.integral_indicator`: converts $\\int_\\Omega s.\\mathrm{indicator}\\,f \\, d\\mu$ to $\\int_{s} f \\, d\\mu$ when $s$ is measurable — the principal lemma that turns a range-side indicator into a domain-side set integral",
+      "i.i.d. structures: `iIndepFun X μ`, `IdentDistrib (X i) (X 0) μ μ`. Mathlib's `MeasureTheory.strong_law_ae_real` (SLLN) consumes these plus integrability of the first coordinate",
+      "Empirical CDF: $F_n(x) := \\frac{1}{n}\\sum_{i=1}^n \\mathbf{1}_{X_i \\leq x}$. The parent file's `empiricalCDF_eq_mean` rewrites this as the empirical mean of the threshold indicator sequence — exactly the form SLLN consumes",
+      "Glivenko–Cantelli theorem (1933): the empirical CDF converges *uniformly* to the true CDF a.s. The pointwise step proved here is the easier half; the genuinely hard part is the bracketing argument that lifts pointwise to uniform convergence"
     ]
   },
   "sections": [
     {
-      "title": "Integrability of Threshold Indicators",
-      "content": "The threshold indicator ω ↦ 1_{X₀(ω) ≤ x} takes values 0 or 1, so its norm is bounded by 1. On a probability space, the constant function 1 is integrable. By `Integrable.mono'`, any AEMeasurable function dominated by an integrable function is itself integrable. The AEMeasurability follows from composing the measurable function X₀ with the Borel-measurable indicator of Iic x.",
-      "lean_names": ["thresholdIndicator_integrable_proved"]
+      "id": "sec-header",
+      "title": "Header Docstring and Imports",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring states the file's purpose: discharge two of the three Glivenko–Cantelli axioms (`thresholdIndicator_integrable`, `integral_thresholdIndicator_eq_cdf`) by proving them from Mathlib's measure-theoretic API. Lists the four key Mathlib lemmas used (`Integrable.mono'`, `integral_indicator`, `integral_const`, `Measure.restrict_apply`) and records the resulting axiom-count reduction 3 → 1. Imports the parent `Proofs.LawsOfLargeNumbersOQ04` (for `thresholdIndicator`, `trueCDF`, `empiricalCDF`, and the structural independence/identity lifts), `Mathlib.MeasureTheory.Integral.Bochner.Set` (for `integral_indicator`), and `Mathlib.Tactic`. Opens `MeasureTheory`, `ProbabilityTheory`, `Set` and enters the `GlivenkoCantelli` namespace.",
+      "mathContext": "Goal: replace `axiom thresholdIndicator_integrable` and `axiom integral_thresholdIndicator_eq_cdf` from the parent file with theorems whose proofs use only Mathlib. Result: $\\mathrm{axiomCount}_{\\mathrm{parent}} : 3 \\to 1$, with only the bracketing-uniformity axiom remaining open."
     },
     {
-      "title": "Integral of Indicator Equals CDF",
-      "content": "The key algebraic identity: the indicator function 1_{X₀(ω) ≤ x} evaluated at ω equals the preimage indicator (X₀ ⁻¹' Iic x).indicator evaluated at ω. This allows `integral_indicator` to convert the integral to a set integral on the preimage. Then `integral_const` evaluates the constant-1 integral over a set as the measure of the set.",
-      "lean_names": ["integral_thresholdIndicator_eq_cdf_proved", "thresholdIndicator_eq_preimage_indicator_fun"]
+      "id": "sec-axiom-1",
+      "title": "Proof of Axiom 1 — Threshold Indicators Are Integrable",
+      "startLine": 43,
+      "endLine": 63,
+      "summary": "Theorem `thresholdIndicator_integrable_proved`: on a probability space, the threshold indicator $\\omega \\mapsto \\mathbf{1}_{X_0(\\omega) \\leq x}$ is integrable. Strategy: apply `Integrable.mono' (integrable_const (1 : ℝ))` — the constant function 1 is integrable on a finite measure space, and the indicator is dominated by it (values ∈ {0, 1}). The two side conditions are: (a) AEMeasurability via `(measurable_iic_indicator x).comp (hX 0)` (composition of a measurable random variable with the Borel indicator of $(-\\infty, x]$), and (b) the pointwise norm bound `‖indicator ω‖ ≤ 1`, discharged by `filter_upwards`/`split_ifs` into the two cases $X_0(\\omega) \\leq x$ and $X_0(\\omega) > x$.",
+      "mathContext": "$\\|\\mathbf{1}_{X_0(\\omega) \\leq x}\\| \\leq 1 \\;\\text{a.e.}$; combined with $\\int_\\Omega 1 \\, d\\mu = 1 < \\infty$, `Integrable.mono'` produces $\\int_\\Omega |\\mathbf{1}_{X_0(\\omega) \\leq x}| \\, d\\mu \\leq 1 < \\infty$."
     },
     {
-      "title": "Axiom-Free Pointwise Convergence",
-      "content": "Combining the two proved lemmas with the existing SLLN infrastructure, the pointwise convergence theorem for the empirical CDF holds without any integration axioms. Only the uniform convergence step (glivenko_cantelli_uniform) remains axiomatic.",
-      "lean_names": ["empiricalCDF_pointwise_convergence_no_axiom"]
+      "id": "sec-preimage-lemma",
+      "title": "Preimage Indicator Factorization",
+      "startLine": 65,
+      "endLine": 75,
+      "summary": "Private lemma `thresholdIndicator_eq_preimage_indicator_fun`: pointwise equality $\\mathbf{1}_{X_0(\\omega) \\leq x} = (X_0^{-1}((-\\infty, x])).\\mathrm{indicator}\\,(\\lambda \\_, 1)\\,\\omega$. Proved by `ext`/`simp only [thresholdIndicator, Set.indicator, Set.mem_preimage, Set.mem_Iic]`. This is the algebraic step that bridges from a real-valued function-of-a-random-variable indicator (range-side) to a set-of-the-domain indicator (domain-side), unlocking `integral_indicator`. The lemma is `private` because it is purely a rewrite consumed only inside the next theorem.",
+      "mathContext": "$\\mathbf{1}_{X_0(\\omega) \\in (-\\infty, x]} = \\mathbf{1}_{\\omega \\in X_0^{-1}((-\\infty, x])}$ — definitional, but the orientation matters: `integral_indicator` requires the indicator of a *subset of the integration domain*, not of the codomain."
+    },
+    {
+      "id": "sec-axiom-2",
+      "title": "Proof of Axiom 2 — Integral of Indicator Equals CDF",
+      "startLine": 77,
+      "endLine": 103,
+      "summary": "Theorem `integral_thresholdIndicator_eq_cdf_proved`: $\\mathbb{E}[\\mathbf{1}_{X_0 \\leq x}] = F(x)$ where $F$ is `trueCDF X μ`. Five-step proof: (1) establish `MeasurableSet (X 0 ⁻¹' Iic x)` from `(hX 0) measurableSet_Iic`; (2) `simp_rw thresholdIndicator_eq_preimage_indicator_fun` to convert to the preimage-indicator form; (3) `rw integral_indicator hms` to convert the integral over $\\Omega$ of an indicator to a set integral over the preimage with the constant integrand 1; (4) chain `integral_const` + `Measure.restrict_apply MeasurableSet.univ` + `Set.univ_inter` + `smul_eq_mul` + `mul_one` to evaluate $\\int_{\\Omega \\cap s} 1 \\, d\\mu = (\\mu \\, s).\\mathrm{toReal}$; (5) `simp only [trueCDF]; congr 1; ext ω; simp [...]` to identify the preimage set $X_0^{-1}((-\\infty, x])$ with the trueCDF set $\\{\\omega \\mid X_0(\\omega) \\leq x\\}$.",
+      "mathContext": "$\\int_\\Omega \\mathbf{1}_{X_0 \\leq x}\\,d\\mu = \\int_{X_0^{-1}((-\\infty, x])} 1\\,d\\mu = \\mu\\bigl(X_0^{-1}((-\\infty, x])\\bigr).\\mathrm{toReal} = \\mu\\bigl(\\{\\omega \\mid X_0(\\omega) \\leq x\\}\\bigr).\\mathrm{toReal} = F(x)$."
+    },
+    {
+      "id": "sec-pointwise-corollary",
+      "title": "Application — Axiom-Free Pointwise Convergence",
+      "startLine": 105,
+      "endLine": 135,
+      "summary": "Theorem `empiricalCDF_pointwise_convergence_no_axiom`: for each fixed $x$, $F_n(x) \\to F(x)$ a.s. Composes the two newly-proved lemmas with the parent file's structural lifts (`thresholdIndicator_pairwise_indep`, `thresholdIndicator_identDistrib`) plus Mathlib's `strong_law_ae_real`. Step-by-step: get integrability from `thresholdIndicator_integrable_proved`, get pairwise independence and identical distribution from the parent's structural lifts (these are not integration axioms — just rewrites of indep/i.d. through the indicator function), apply SLLN, substitute the integral identity from `integral_thresholdIndicator_eq_cdf_proved` to identify the limit with $F(x)$, then `convert hω using 1; ext n; simp [empiricalCDF_eq_mean]` to extract the empirical-mean form. Result: pointwise GC has zero remaining integration axioms — only the bracketing-uniformity step is still open.",
+      "mathContext": "$\\forall x \\in \\mathbb{R} \\colon \\quad F_n(x) := \\frac{1}{n}\\sum_{i=1}^n \\mathbf{1}_{X_i \\leq x} \\xrightarrow[n \\to \\infty]{\\text{a.s.}} F(x).$ The SLLN is applied to the i.i.d. indicator sequence; the limit $\\mathbb{E}[\\mathbf{1}_{X_0 \\leq x}]$ is identified with $F(x)$ via Axiom 2 (now a theorem)."
+    },
+    {
+      "id": "sec-axiom-status",
+      "title": "Axiom Status Summary",
+      "startLine": 137,
+      "endLine": 158,
+      "summary": "Closing block: enumerates the parent file's three axioms with status flags — `thresholdIndicator_integrable` ✓ proved, `integral_thresholdIndicator_eq_cdf` ✓ proved, `glivenko_cantelli_uniform` ✗ remains. Notes that the remaining axiom is mathematically genuine: the uniformity step requires choosing finitely many CDF continuity points with controlled jump sizes plus a finite-intersection-of-pointwise-convergence-events argument — infrastructure for the first piece (a constructive ε-cover by continuity points of a monotone $F$) is not yet present in Mathlib 4.26. Records the headline corollary `empiricalCDF_pointwise_convergence_no_axiom` as the file's take-away.",
+      "mathContext": "Axiom-elimination ledger: $\\{\\mathrm{integrable}, \\mathrm{integral{=}CDF}, \\mathrm{uniform}\\} \\to \\{\\mathrm{uniform}\\}$. The remaining axiom is the only piece that depends on Mathlib infrastructure not yet in 4.26."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "thresholdIndicator_integrable_proved",
+      "type": "theorem",
+      "statement": "$\\forall \\Omega\\colon \\mathrm{MeasurableSpace}, \\forall \\mu\\colon \\mathrm{Measure}\\,\\Omega, [\\mathrm{IsProbabilityMeasure}\\,\\mu], \\forall X : \\mathbb{N} \\to \\Omega \\to \\mathbb{R}, (\\forall i, \\mathrm{Measurable}\\,(X_i)) \\Rightarrow \\forall x \\in \\mathbb{R}\\colon \\mathrm{Integrable}\\,(\\mathrm{thresholdIndicator}\\,X\\,x\\,0)\\,\\mu$",
+      "significance": "**Proves Axiom 1 of the parent Glivenko–Cantelli formalization.** Discharges integrability of the threshold indicator $\\omega \\mapsto \\mathbf{1}_{X_0(\\omega) \\leq x}$ by `Integrable.mono'` against the integrable constant 1, with the bound $\\|\\mathbf{1}_{X_0 \\leq x}\\| \\leq 1$ from values in $\\{0, 1\\}$. The pattern (`Integrable.mono' (integrable_const c) hAEMeas (filter_upwards bound)`) is the canonical Lean approach for any bounded measurable function on a finite measure space — replacing dozens of similar axioms across probability formalizations with a two-line proof.",
+      "description": "Theorem replacing the parent file's `thresholdIndicator_integrable` axiom. Uses `Integrable.mono'` with dominating function 1, AEMeasurability from composing measurability of $X_0$ with the Borel indicator of $(-\\infty, x]$, and the norm bound proved by case-splitting on whether $X_0(\\omega) \\leq x$."
+    },
+    {
+      "name": "thresholdIndicator_eq_preimage_indicator_fun",
+      "type": "lemma",
+      "statement": "$\\forall X : \\mathbb{N} \\to \\Omega \\to \\mathbb{R}, \\forall x \\in \\mathbb{R}\\colon (\\lambda\\,\\omega, \\mathrm{thresholdIndicator}\\,X\\,x\\,0\\,\\omega) = (\\lambda\\,\\omega, (X_0^{-1}((-\\infty, x])).\\mathrm{indicator}\\,(\\lambda\\,\\_, 1)\\,\\omega)$",
+      "significance": "**Bridge lemma between range-side and domain-side indicators.** Pointwise rewrite $\\mathbf{1}_{X_0(\\omega) \\leq x} = \\mathbf{1}_{\\omega \\in X_0^{-1}((-\\infty, x])}\\cdot 1$. This orientation flip is exactly what `integral_indicator` requires (it integrates an indicator of a subset of the integration domain), so without this lemma the next theorem cannot rewrite the integral as a set integral. Marked `private` because it is consumed only locally.",
+      "description": "Private lemma. Pointwise equality of the threshold indicator with the preimage-indicator function. One-line proof via `ext` + `simp only [thresholdIndicator, Set.indicator, Set.mem_preimage, Set.mem_Iic]`."
+    },
+    {
+      "name": "integral_thresholdIndicator_eq_cdf_proved",
+      "type": "theorem",
+      "statement": "$\\forall \\Omega\\colon \\mathrm{MeasurableSpace}, \\forall \\mu\\colon \\mathrm{Measure}\\,\\Omega, [\\mathrm{IsProbabilityMeasure}\\,\\mu], \\forall X : \\mathbb{N} \\to \\Omega \\to \\mathbb{R}, (\\forall i, \\mathrm{Measurable}\\,(X_i)) \\Rightarrow \\forall x \\in \\mathbb{R}\\colon \\int_\\Omega \\mathrm{thresholdIndicator}\\,X\\,x\\,0\\,d\\mu = \\mathrm{trueCDF}\\,X\\,\\mu\\,x$",
+      "significance": "**Proves Axiom 2 of the parent Glivenko–Cantelli formalization.** $\\mathbb{E}[\\mathbf{1}_{X_0 \\leq x}] = F(x)$, the integral identity that lets the SLLN limit be identified with the CDF. The proof chain — `integral_indicator` to collapse the indicator into a set integral, `integral_const` + `Measure.restrict_apply` to evaluate the constant-1 integral, then a `congr` + `ext` to identify the preimage set with the `trueCDF` defining set — is a fully reusable template for any 'integral of an indicator equals a measure' identity.",
+      "description": "Theorem replacing the parent file's `integral_thresholdIndicator_eq_cdf` axiom. Five-step proof chain: preimage-indicator rewrite → `integral_indicator` → `integral_const` → `Measure.restrict_apply` → `congr` to identify the trueCDF set."
+    },
+    {
+      "name": "empiricalCDF_pointwise_convergence_no_axiom",
+      "type": "theorem",
+      "statement": "$\\forall \\Omega\\colon \\mathrm{MeasurableSpace}, \\forall \\mu\\colon \\mathrm{Measure}\\,\\Omega, [\\mathrm{IsProbabilityMeasure}\\,\\mu], \\forall X : \\mathbb{N} \\to \\Omega \\to \\mathbb{R}, (\\forall i, \\mathrm{Measurable}\\,(X_i)) \\land \\mathrm{iIndepFun}\\,X\\,\\mu \\land (\\forall i, \\mathrm{IdentDistrib}\\,(X_i)\\,(X_0)\\,\\mu\\,\\mu) \\Rightarrow \\forall x \\in \\mathbb{R}, \\forall^\\mathrm{a.e.}\\,\\omega\\,\\partial\\mu, \\mathrm{Tendsto}\\,(\\lambda\\,n, \\mathrm{empiricalCDF}\\,X\\,n\\,x\\,\\omega)\\,\\mathrm{atTop}\\,(\\mathrm{nhds}\\,(\\mathrm{trueCDF}\\,X\\,\\mu\\,x))$",
+      "significance": "**Headline corollary of this file.** Pointwise convergence of the empirical CDF to the true CDF, $F_n(x) \\to F(x)$ a.s., with **zero integration axioms**. Composes the two preceding theorems with the parent file's structural lifts (`thresholdIndicator_pairwise_indep`, `thresholdIndicator_identDistrib`) and Mathlib's `strong_law_ae_real`. After this theorem, only the bracketing-uniformity axiom (`glivenko_cantelli_uniform`) stands between the formalization and a fully axiom-free proof of the classical Glivenko–Cantelli theorem.",
+      "description": "**The take-away.** Pointwise convergence of the empirical CDF using only proved lemmas and structural lifts — no integration axioms. SLLN-applied-to-indicators with the integrability and integral-equals-CDF identities discharged by the two preceding theorems."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Enriches the **Glivenko–Cantelli integration-axioms** proof entry (`laws-of-large-numbers-oq-04-oq-03`) with three structural enhancements that bring it in line with the recent enricher template (#17044, #17047) and resolve a known live-site display gap.

### Changes

1. **Canonical sections schema.** Existing sections used non-standard `{title, content, lean_names}` fields with no line ranges, which suppresses section rendering on the live site. Converted to the canonical `{id, title, startLine, endLine, summary, mathContext}` schema and expanded from 3 → 6 sections covering the full Lean file (lines 1–158): header docstring, Axiom 1 proof, preimage indicator factorization, Axiom 2 proof, pointwise-convergence corollary, and axiom-status summary.
2. **`mainTheorems` array (new).** Adds 4 entries (3 theorems + 1 private lemma) with formal LaTeX `statement` fields and `significance` commentary explaining what each declaration accomplishes — `thresholdIndicator_integrable_proved` (Axiom 1 → Theorem), `thresholdIndicator_eq_preimage_indicator_fun` (private bridge lemma), `integral_thresholdIndicator_eq_cdf_proved` (Axiom 2 → Theorem), `empiricalCDF_pointwise_convergence_no_axiom` (headline corollary).
3. **`overview.prerequisites` (new).** 10-item LaTeX list of measure-theoretic + probability-theoretic background a reader needs to follow the proof — probability spaces, indicator functions, integration via domination, restricted measures, `integral_indicator`, i.i.d. structures, empirical CDF, Glivenko–Cantelli theorem.

### Annotation alignment fixes

Realigned all 5 of the original 7 annotation ranges to point at the actual Lean construct, replacing ranges that previously pointed at section-header comment blocks or overlapped incorrectly:

| Annotation | Old range | New range | Reason |
|---|---|---|---|
| `ann-axiom-1-proof` | 37–55 | 43–63 | Theorem actually starts at 43; proof body extends to 63 |
| `ann-preimage-rewrite` | 58–68 | 65–75 | Old range covered a section-header comment, not the lemma |
| `ann-integral-chain` | 70–105 | 77–103 | Theorem actually starts at 77; old range bled into separator |
| `ann-pointwise-convergence` | 105–136 | 109–135 | Theorem actually starts at 109 |
| `ann-remaining-axiom` | 110–128 | 137–156 | Old range overlapped the convergence corollary; remaining-axiom discussion is in the closing summary block |

Also added Lean code walkthroughs to `ann-axiom-1-proof` and `ann-preimage-rewrite`, additional `prerequisites` arrays to four annotations, and broader `relatedConcepts`.

## What stayed the same

- All quality-relevant numerical metadata (axiomCount: 0, sorries: 0, theoremCount: 4, lineCount: 158).
- The existing 6 `keyInsights` (already substantive — including the VC-class roadmap insight).
- The `crossReferences` block (parent / sibling / ancestor links).
- The `conclusion` block (summary, implications, openQuestions).
- The Lean source file (`Proofs/LawsOfLargeNumbersOQ04OQ03.lean`) — this PR is data-only.

## Test plan
- [x] JSON validates (Python `json.load` on both files)
- [x] Annotation line ranges fall within file bounds (1–158)
- [x] All annotations align with actual Lean constructs (`pnpm annotations:build` produces zero warnings for this slug; warnings exist for many other entries but not this one)
- [x] Commit contains exactly the 2 entry files (115 insertions / 30 deletions)