### PR TITLE
audit(tracker): erdos-131-oq-01 — 3rd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4653,9 +4653,9 @@
       "result": "issues-fixed"
     },
     "erdos-131-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:46Z",
+      "lastAudited": "2026-05-08T12:48:49Z",
       "result": "clean"
     },
     "erdos-132": {


### PR DESCRIPTION
## Summary
Re-audit of erdos-131-oq-01 confirms gallery-claim integrity:

- 556 lines, 26 theorems, 6 definitions, 2 axioms, 0 sorries
- Axioms: `pham_zakharov_upper_bound`, `csaba_lower_bound`
- Status `axiomatized` + badge `axiom` correctly reflect the 2 assumptions
- The single string `sorry` in the file is inside a `**Proved theorems (sorry-free):**` docstring, not a real sorry

## Tracker change
auditCount 2→3, lastAudited bumped to 2026-05-08.

## Test plan
- [x] Verified counts via `wc -l`, `grep ^axiom`, `grep -E '^def|abbrev|opaque'`
- [x] Inspected the lone `sorry` regex hit (docstring text only)
- [x] Confirmed status/badge consistency with axiomatized rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)