### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02): S4 — vector-form Cayley-Hamilton at e₀

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean
@@ -401,6 +401,109 @@ theorem nonderogatory_iff_similar_to_companion
   rintro ⟨P, hP, hsim⟩
   exact similar_to_companion_implies_nonderogatory M hP hsim hn
 
+/-! ## Session 4: companionMx satisfies its polynomial — vector form at e₀
+
+  Stepping stone toward `aeval (companionMx p) p = 0` for monic `p` of degree `n`,
+  which would give `minpoly K (companionMx p) = p` (Q2 of the openQuestions list).
+
+  Strategy:
+    - `companionMx_mulVec_eNm1`: action of `companionMx p` on e_{n-1} returns the
+      last column = `(-(p.coeff i))_{i<n}` (by the def of companionMx).
+    - `companionMx_pow_n_eq_lastCol_e0`: combining `companionMx_pow_e0` (k = n-1)
+      with the last-column action, `(companionMx p)^n e₀ = -∑ p.coeff i • e_i`.
+    - `aeval_companionMx_p_mulVec_e0_zero`: monicity (`p.coeff n = 1`) cancels the
+      `1 • C^n e₀` term against `∑_{k<n} p.coeff k • C^k e₀ = ∑_{k<n} p.coeff k • e_k`.
+
+  The matrix-level identity `aeval (companionMx p) p = 0` follows from cyclicity of
+  e₀ (Session 3's `companionMx_isCyclic_e0` extended just past `natDegree < n`)
+  but needs a small additional step and is deferred to Session 5.
+-/
+
+/-- Action of `companionMx p` on `e_{n-1}`: it returns the last column of the matrix,
+    which by the definition of `companionMx` is the vector `(-(p.coeff i))_{i<n}`. -/
+private lemma companionMx_mulVec_eNm1 (p : K[X]) (hn : 0 < n) :
+    (companionMx (n := n) p).mulVec
+        (Pi.single (⟨n - 1, Nat.sub_lt hn one_pos⟩ : Fin n) (1 : K)) =
+      fun i : Fin n => -(p.coeff i.val) := by
+  funext i
+  simp only [Matrix.mulVec, dotProduct]
+  rw [Finset.sum_eq_single (⟨n - 1, Nat.sub_lt hn one_pos⟩ : Fin n)]
+  · -- Main term: companionMx p i ⟨n-1, _⟩ * 1 = -(p.coeff i.val).
+    -- The first if-condition `j.val + 1 = n` triggers for j = ⟨n-1, _⟩.
+    simp only [Pi.single_eq_same, mul_one, companionMx]
+    have hnstep : (n - 1 : ℕ) + 1 = n := Nat.sub_add_cancel hn
+    rw [if_pos hnstep]
+  · -- Off-diagonal: Pi.single is zero away from ⟨n-1, _⟩.
+    intro j _ hjne
+    have hpsi : (Pi.single (⟨n - 1, Nat.sub_lt hn one_pos⟩ : Fin n) (1 : K)) j = 0 := by
+      simp only [Pi.single_apply, if_neg hjne]
+    rw [hpsi, mul_zero]
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+/-- For `n ≥ 1`, `(companionMx p)^n` applied to `e₀` returns the last-column
+    vector `(-(p.coeff i))_{i<n}`. Combines `companionMx_pow_e0` (k = n-1) with
+    `companionMx_mulVec_eNm1`. -/
+private lemma companionMx_pow_n_eq_lastCol_e0 (p : K[X]) (hn : 0 < n) :
+    ((companionMx (n := n) p) ^ n).mulVec (Pi.single (⟨0, hn⟩ : Fin n) (1 : K)) =
+      fun i : Fin n => -(p.coeff i.val) := by
+  have hnn1 : n - 1 < n := Nat.sub_lt hn one_pos
+  -- Rewrite the exponent n as (n-1) + 1 (via congr 1 + omega), then apply pow_succ'.
+  have hpow_eq : (companionMx (n := n) p) ^ n =
+      (companionMx (n := n) p) ^ (n - 1 + 1) := by
+    congr 1; omega
+  rw [hpow_eq, pow_succ', Matrix.mul_mulVec,
+      companionMx_pow_e0 p hn (n - 1) hnn1]
+  exact companionMx_mulVec_eNm1 p hn
+
+/-- For monic `p` of degree `n` (with `n ≥ 1`), the polynomial `p` annihilates
+    `companionMx p` *applied to* the standard basis vector `e₀`. This is the
+    main computational step toward the matrix-level identity
+    `aeval (companionMx p) p = 0` (which together with cyclicity of `e₀` would
+    yield `minpoly K (companionMx p) = p`). -/
+private lemma aeval_companionMx_p_mulVec_e0_zero
+    (p : K[X]) (hp_monic : p.Monic) (hp_deg : p.natDegree = n) (hn : 0 < n) :
+    (aeval (companionMx (n := n) p) p).mulVec
+        (Pi.single (⟨0, hn⟩ : Fin n) (1 : K)) = 0 := by
+  -- Expand aeval as a finite sum and apply mulVec termwise.
+  rw [aeval_eq_sum_range_natDegree p (companionMx (n := n) p), sum_mulVec_local, hp_deg]
+  -- Peel off the k = n top term.
+  rw [Finset.sum_range_succ]
+  -- Monic + natDegree = n: p.coeff n = 1.
+  have hcn : p.coeff n = 1 := by
+    have hlc := hp_monic.leadingCoeff
+    rwa [Polynomial.leadingCoeff, hp_deg] at hlc
+  rw [hcn, one_smul]
+  -- Apply C^n e₀ = (-(p.coeff i))_{i<n}.
+  rw [companionMx_pow_n_eq_lastCol_e0 p hn]
+  funext i
+  simp only [Pi.add_apply, Finset.sum_apply, Pi.zero_apply]
+  -- The sum over k < n of (p.coeff k • C^k.mulVec e₀) at i picks out k = i.val,
+  -- giving p.coeff i.val. The C^n term contributes -(p.coeff i.val); they cancel.
+  have hsum_at_i :
+      ∑ k ∈ Finset.range n,
+          (p.coeff k • (companionMx (n := n) p) ^ k).mulVec
+            (Pi.single (⟨0, hn⟩ : Fin n) 1) i = p.coeff i.val := by
+    rw [Finset.sum_eq_single i.val]
+    · -- Main term: k = i.val.
+      rw [Matrix.smul_mulVec, companionMx_pow_e0 p hn i.val i.isLt]
+      simp only [Pi.smul_apply, smul_eq_mul]
+      have hieq : (⟨i.val, i.isLt⟩ : Fin n) = i := Fin.ext rfl
+      rw [hieq, Pi.single_eq_same, mul_one]
+    · -- Off-diagonal: k ∈ range n, k ≠ i.val.
+      intro k hk hkne
+      have hk_lt_n : k < n := Finset.mem_range.mp hk
+      rw [Matrix.smul_mulVec, companionMx_pow_e0 p hn k hk_lt_n]
+      simp only [Pi.smul_apply, smul_eq_mul]
+      have hne : i ≠ (⟨k, hk_lt_n⟩ : Fin n) := by
+        intro heq; exact hkne (congrArg Fin.val heq).symm
+      have hpsi : (Pi.single (⟨k, hk_lt_n⟩ : Fin n) (1 : K)) i = 0 := by
+        rw [Pi.single_apply, if_neg hne]
+      rw [hpsi, mul_zero]
+    · -- Vacuous: i.val ∈ range n always.
+      intro h; exact absurd (Finset.mem_range.mpr i.isLt) h
+  rw [hsum_at_i]
+  ring
+
 end CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02
 
 end

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/knowledge.md
@@ -1,8 +1,132 @@
 # Knowledge Base: cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02
 
 **Problem**: Rational Canonical Form — Mathlib formalization connection (nonderogatory case)
-**Phase**: COMPLETE (CI pending)
-**Status**: verified (0 axioms, 0 sorries; PR #17039)
+**Phase**: COMPLETE (axiom-free, biconditional closed); S4 advancing toward `Matrix.minpoly_companionMatrix`.
+**Status**: verified (0 axioms, 0 sorries; S2 PR #17039 + S3 PR #17069 merged)
+
+---
+
+## Session 4 (2026-05-08) — Vector-form Cayley-Hamilton for the companion
+
+**Mode**: CONTINUE
+**Outcome**: vector-level identity proved; matrix-level deferred to S5.
+
+### What I Did
+
+Established `(aeval (companionMx p) p).mulVec e₀ = 0` for monic `p` of degree `n`,
+the computational core of the as-yet-unproved `Matrix.minpoly_companionMatrix : minpoly K (companionMx p) = p`.
+
+Three new private lemmas:
+
+1. **`companionMx_mulVec_eNm1`** (the last column): for any `p` and `n ≥ 1`,
+   `(companionMx p).mulVec e_{n-1} = (-(p.coeff i))_{i<n}`. Pure unfolding of
+   the `companionMx` definition; the first if-clause `j.val + 1 = n` triggers
+   for `j = ⟨n-1, _⟩`. Pattern: `Finset.sum_eq_single` at `⟨n-1, _⟩`,
+   `simp only [Pi.single_eq_same, mul_one, companionMx]`, `if_pos hnstep`
+   with `hnstep : (n-1) + 1 = n` (via `Nat.sub_add_cancel hn`).
+
+2. **`companionMx_pow_n_eq_lastCol_e0`** (n-th iterate at e₀):
+   `((companionMx p) ^ n).mulVec e₀ = (-(p.coeff i))_{i<n}`. Combines
+   Session 3's `companionMx_pow_e0` (k = n-1) with `companionMx_mulVec_eNm1`.
+   Trick: rewrite the exponent `n` as `(n-1) + 1` via `congr 1 + omega`
+   (a direct `rw [show n = (n-1) + 1 from by omega]` would also rewrite the
+   `Fin n` type-level `n`, breaking unification). Then `pow_succ'` +
+   `Matrix.mul_mulVec` + `companionMx_pow_e0 p hn (n-1) hnn1` closes.
+
+3. **`aeval_companionMx_p_mulVec_e0_zero`** (the main result):
+   `(aeval (companionMx p) p).mulVec e₀ = 0` for monic `p` of degree `n`.
+   - Expand `aeval` via the local `aeval_eq_sum_range_natDegree` (Session 3) +
+     `sum_mulVec_local` (Session 2) + `hp_deg : p.natDegree = n`.
+   - Peel off `k = n` term via `Finset.sum_range_succ`.
+   - Use `hp_monic.leadingCoeff` + `Polynomial.leadingCoeff` + `hp_deg` to set
+     `p.coeff n = 1`, then `one_smul` cancels the scalar.
+   - Apply `companionMx_pow_n_eq_lastCol_e0` for the k=n term and
+     `companionMx_pow_e0` for the k<n terms.
+   - Pointwise at index i: the `range n` sum picks out `k = i.val`, contributing
+     `p.coeff i.val`. The k=n term contributes `-(p.coeff i.val)`. They cancel.
+
+### Files Modified (Session 4)
+
+- `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean` (+103 lines net):
+  Three new private lemmas + Session 4 docstring section.
+- `src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/meta.json`:
+  - `meta.lineCount`: 406 → 509
+  - `meta.theoremCount`: 14 → 17
+  - `leanFile.lineCount`: 214 → 509 (was stale from S2; S3 merged without sync)
+  - `leanFile.theoremCount`: 8 → 17 (was stale from S2; S3 merged without sync)
+  - Updated `assumptions` and `overview.openQuestions[Q2]` to reflect S4 partial progress.
+- `research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/state.md`:
+  Refreshed (was stuck at "Iteration 2"); now records S3 + S4 with S5 plan.
+
+### Result
+
+Status remains `verified` / `original` / 0 axioms / 0 sorries. The new lemmas
+are `private` (not part of the public API) — S5 will promote the matrix-level
+result.
+
+### Honest Reporting
+
+- **Build was not verified locally** — same `.lake` symlink trap as before
+  (memory `feedback_researcher_lake_symlink_broken.md`). CI is the ground truth.
+- **API drift risk**: the proof uses `pow_succ'`, `Matrix.mul_mulVec`,
+  `Matrix.smul_mulVec`, `Polynomial.leadingCoeff`, `Polynomial.Monic.leadingCoeff`,
+  `Pi.single_apply`, `Pi.single_eq_same`, `Pi.smul_apply`, `Pi.add_apply`,
+  `Finset.sum_range_succ`, `Finset.sum_apply`, `Finset.sum_eq_single`,
+  `Finset.mem_range`, `Nat.sub_add_cancel`, `Nat.sub_lt`. All used by the existing
+  Session 1-3 proofs in this same file, so most are stable; if any break, S5 repairs.
+- **Did NOT close `aeval (companionMx p) p = 0`** at the matrix level. The
+  vector-level result is the harder computation (the last-column action +
+  monicity cancellation); lifting to the matrix level via cyclicity is a
+  smaller, more-API-driven step deferred to Session 5.
+
+---
+
+## Session 3 (2026-05-08) — Companion-similarity biconditional
+
+**Mode**: CONTINUE
+**Outcome**: completed; merged via PR #17069 into origin/main on 2026-05-08.
+
+### What I Did (recovered from origin/main commit history; this session record was
+not written at the time of the S3 merge)
+
+Established the *converse* of `nonderogatory_similar_to_companion`:
+`similar_to_companion_implies_nonderogatory` and packaged the full biconditional
+`nonderogatory_iff_similar_to_companion`. Three building-block lemmas added:
+
+1. **`aeval_eq_sum_range_natDegree`**: a generalization of S2's
+   `aeval_eq_sum_pow_local` to *any* polynomial (no `natDegree p = n` hypothesis),
+   producing `aeval M q = ∑ k ∈ range (q.natDegree + 1), q.coeff k • M^k`. Used
+   by `companionMx_isCyclic_e0` and (now) S4.
+
+2. **`companionMx_pow_e0` (k < n)**: for any `p` and `0 < n`, induction on `k`
+   shows `(companionMx p)^k * e₀ = e_k` for `k < n`. Captures the subdiagonal
+   structure of the companion matrix.
+
+3. **`companionMx_isCyclic_e0`**: the standard basis vector `e₀` is cyclic for
+   `companionMx p` (any p). Proof: for any `q` with `q.natDegree < n` annihilating
+   the matrix at e₀, expand `aeval (companionMx p) q` as a finite sum, evaluate
+   at `e₀` using `companionMx_pow_e0`, and the resulting linear combination of
+   `e_k`'s being zero forces all coefficients zero.
+
+4. **`cyclicVector_similar_transport`**: similarity transports cyclic vectors. If
+   `P⁻¹ M P = N` with `P` invertible and `w` is cyclic for `N`, then `P · w` is
+   cyclic for `M`. Proof: `aeval M q * P = P * aeval N q` (induction on power),
+   convert to `mulVec`, apply injectivity of `P.mulVec`.
+
+5. **`similar_to_companion_implies_nonderogatory`** (converse): if `M` is similar
+   to `companionMx (minpoly K M)`, then by `companionMx_isCyclic_e0` the matrix
+   has a cyclic vector (image of e₀ under the similarity), and the cyclic-vector
+   biconditional from sibling OQ-01-OQ-01 closes.
+
+6. **`nonderogatory_iff_similar_to_companion`**: full biconditional combining
+   forward (S1+S2) and converse (S3) directions.
+
+### Result
+
+The triangle `IsNonderogatory M ↔ ∃ v cyclic ↔ ∃ P, P⁻¹ M P = companionMx (μ_M)`
+is now machine-verified over arbitrary fields with **zero axioms**.
+
+PR: #17069 (S2 was merged separately as #17039 earlier the same day).
 
 ---
 

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/state.md
@@ -1,79 +1,102 @@
 # Research State: cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02
 
 ## Current State
-**Phase**: COMPLETE (axiom-free; CI pending)
+**Phase**: COMPLETE (axiom-free, biconditional closed); Session 4 advancing toward `minpoly K (companionMx p) = p`.
 **Path**: full
 **Since**: 2026-05-08
-**Iteration**: 2
+**Iteration**: 4
 
 ## Current Focus
 
-The entry is now `verified` (0 axioms, 0 sorries) over arbitrary fields. PR #17039
-opens with the Session 2 axiom-elimination work. CI verification pending.
+The full nonderogatory RCF is verified over arbitrary fields:
+- `nonderogatory_similar_to_companion` (Session 1+2): forward direction (the existing
+  proof, now axiom-free).
+- `similar_to_companion_implies_nonderogatory` + `nonderogatory_iff_similar_to_companion`
+  (Session 3, merged via PR #17069 into origin/main): converse + biconditional via
+  cyclic-vector transport using `companionMx_isCyclic_e0`.
+- **Session 4 (this iteration)**: vector-level Cayley-Hamilton for the companion —
+  `(aeval (companionMx p) p).mulVec e₀ = 0` for monic `p` of degree `n`. This is the
+  computational core of the as-yet-unproved `Matrix.minpoly_companionMatrix` (Q2).
 
-## Outcome
+## Outcome (Session 4)
 
-Session 2 replaced the residual `private axiom hMn_axiom` with a `private theorem
-hMn_axiom` proved from Mathlib's `minpoly.aeval` + `minpoly.monic (Matrix.isIntegral
-M)` and a local helper `aeval_eq_sum_pow_local` that converts `Polynomial.eval₂_eq_sum`'s
-output into the smul form via `← Algebra.smul_def`.
+**Three new private lemmas** added to `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean`:
 
-The implemented proof differs slightly from the Session 1 skeleton (which referenced
-`Polynomial.aeval_eq_sum_range`): the actually-shipped version uses the lower-level
-`Polynomial.eval₂_eq_sum` + `Polynomial.sum_def` + `← Algebra.smul_def` chain, with
-`Finset.sum_subset` (and `Polynomial.le_natDegree_of_mem_supp` for the subset
-direction; `Polynomial.notMem_support_iff` for the `f x = 0 outside the support`
-direction) to extend the support sum to `range (n+1)`. Once the smul-form expansion
-is in hand, monicity isolates `1 • M^n`, solving for `M^n` gives the matrix-level
-identity, and `mulVec v` (via local `sum_mulVec_local`) yields the desired vector
-identity.
+1. `companionMx_mulVec_eNm1 (p : K[X]) (hn : 0 < n)` — action of `companionMx p` on
+   `e_{n-1}` returns the last column, which by the def of `companionMx` is the
+   vector `(-(p.coeff i))_{i<n}`. Pure unfolding of the matrix definition; the
+   first `if-then-else` clause (`j.val + 1 = n`) triggers for `j = ⟨n-1, _⟩`.
 
-## File State
+2. `companionMx_pow_n_eq_lastCol_e0 (p : K[X]) (hn : 0 < n)` — combining
+   `companionMx_pow_e0` (Session 3, k = n-1) with `companionMx_mulVec_eNm1`,
+   `((companionMx p)^n).mulVec e₀ = (-(p.coeff i))_{i<n}`. The exponent rewrite
+   from `n` to `(n-1) + 1` uses `congr 1 + omega` to avoid scope-of-rewrite issues
+   that would otherwise break the type-level `Fin n`.
 
-- 214 lines (was 156; +58 net)
-- 8 theorems/lemmas (was 5; +3: `sum_mulVec_local`, `aeval_eq_sum_pow_local`,
-  the `private theorem hMn_axiom`)
+3. `aeval_companionMx_p_mulVec_e0_zero (p : K[X]) (hp_monic : p.Monic) (hp_deg : p.natDegree = n) (hn : 0 < n)`
+   — for monic p of degree n, `(aeval (companionMx p) p).mulVec e₀ = 0`. Proof:
+   expand `aeval` via `aeval_eq_sum_range_natDegree`, peel off the k=n term via
+   `Finset.sum_range_succ`, use `p.Monic ∧ p.natDegree = n` to set `p.coeff n = 1`,
+   apply `companionMx_pow_n_eq_lastCol_e0` for the C^n term and `companionMx_pow_e0`
+   for the k<n terms. Pointwise at index i: the sum picks out `k = i.val`, giving
+   `p.coeff i.val + (-(p.coeff i.val)) = 0`.
+
+## File State (after Session 4)
+
+- 509 lines (was 406; +103 net)
+- 17 theorems/lemmas (was 14; +3: the three above)
 - 2 definitions (`companionMx`, `cyclicMatrix`; unchanged)
-- **0 axioms, 0 sorries**
+- **0 axioms, 0 sorries** (status `verified`/`original` retained)
 
-## Triangle of Equivalences (now closed)
+## Triangle of Equivalences (already closed in S3)
 
-With OQ-01 (`nonderogatory ⇒ ∃ cyclic v`), OQ-01-OQ-01 (`cyclic ⇒ nonderogatory`),
-and this entry (`nonderogatory ⇒ similar to companion via the Krylov matrix`), the
-full triangle
+  `IsNonderogatory M ↔ ∃ v cyclic ↔ ∃ P invertible, P⁻¹ M P = companionMx (minpoly K M)`
 
-  IsNonderogatory M ↔ ∃ v cyclic ↔ ∃ P invertible, P⁻¹ M P = companionMx (minpoly K M)
+machine-verified over arbitrary fields with **zero axioms**.
 
-is now machine-verified over arbitrary fields with **zero axioms**.
+## Next Step (Session 5)
 
-## Next Steps (Session 3+, if pursued)
+**`aeval (companionMx p) p = 0`** as a matrix-level identity (currently we have
+the vector-level annihilation at e₀ only). Two approaches:
 
-1. **Companion-similarity biconditional**: with `cyclic_implies_nonderogatory` from
-   OQ-01-OQ-01, prove the converse `similar to companionMx ⇒ nonderogatory` and
-   package the full biconditional `IsNonderogatory M ↔ ∃ P invertible, P⁻¹ M P =
-   companionMx (minpoly K M)`.
+1. **Cyclicity-based** (preferred, reuses S3's infrastructure): `companionMx_isCyclic_e0`
+   says `IsCyclicVector (companionMx p) e₀`, but it's stated for polynomials of degree
+   `< n`. We'd need a small extension: if the matrix-polynomial is in the kernel of
+   `mulVec e₀` (i.e. annihilates e₀) AND has degree ≥ n, then it's a multiple of the
+   minpoly. The cleaner route: show that `aeval (companionMx p) p` commutes with
+   `companionMx p` (any polynomial in C does), so its kernel is a `K[C]`-submodule
+   containing e₀; combined with the cyclic decomposition `K^n = span_{0≤k<n}(C^k e₀)`
+   (which the cyclicity gives), the kernel is all of K^n, so the matrix is zero.
 
-2. **Companion-matrix charpoly/minpoly identities**: Mathlib v4.26.0 lacks
-   `Matrix.charpoly_companionMatrix` and `Matrix.minpoly_companionMatrix`. Adding
-   these (the standard "charpoly = minpoly = p" identities) would let this entry
-   export an even tighter `nonderogatory_companion` corollary.
+2. **Pointwise** (more work, less elegant): show `(aeval (companionMx p) p).mulVec e_k = 0`
+   for each `k = 0..n-1`. Since `e_k = ((companionMx p)^k).mulVec e₀` and `aeval (... p) p`
+   commutes with `(companionMx p)^k`, this reduces to S4's `aeval_companionMx_p_mulVec_e0_zero`.
 
-3. **Mathlib contribution**: with `companionMx` and `nonderogatory_similar_to_companion`
-   axiom-free, this is a candidate seed for adding `Matrix.companionMatrix` and
-   `Matrix.IsSimilar.companionMatrix_of_nonderogatory` to Mathlib. The route to the
-   multi-block RCF would go through the K[X]-module structure theorem.
+Once `aeval (companionMx p) p = 0` is in hand:
+- `(minpoly K (companionMx p)) ∣ p` by minimality.
+- `(minpoly K (companionMx p)).natDegree = n` from S3's `companionMx_isCyclic_e0` +
+  `minpoly_natDegree_of_cyclic` (from sibling OQ-01-OQ-01).
+- Both are monic of the same degree, so `minpoly K (companionMx p) = p`.
+
+This gives `Matrix.minpoly_companionMatrix : minpoly K (companionMx p) = p`, the
+companion-matrix minpoly identity that is missing from Mathlib v4.26.0.
 
 ## Risks
 
-- **Build risk**: not verified locally (worktree `.lake` symlink trap; ~45 min
-  Mathlib re-clone). CI is the ground truth for PR #17039. If CI flags an API drift
-  on one of `Polynomial.eval₂_eq_sum`, `Polynomial.sum_def`, `Algebra.smul_def`,
-  `Polynomial.le_natDegree_of_mem_supp`, `Polynomial.notMem_support_iff`,
-  `Matrix.isIntegral`, `Polynomial.finset_sum_coeff`, `Polynomial.Monic.leadingCoeff`,
-  or `eq_neg_of_add_eq_zero_right`, Session 3 will repair.
+- **Build risk (Session 4)**: not verified locally (worktree `.lake` symlink trap;
+  see memory `feedback_researcher_lake_symlink_broken.md`). CI is the ground truth.
+  If CI flags an API drift on `pow_succ'`, `Matrix.mul_mulVec`, `Matrix.smul_mulVec`,
+  `Polynomial.leadingCoeff`, `Polynomial.Monic.leadingCoeff`, `Pi.single_apply`,
+  `Pi.single_eq_same`, `Pi.smul_apply`, `Pi.add_apply`, `Finset.sum_range_succ`,
+  `Finset.sum_apply`, `Finset.sum_eq_single`, `Finset.mem_range`, `Nat.sub_add_cancel`,
+  or `Nat.sub_lt`, Session 5 will repair.
+- **Lemma scope**: all three new lemmas are `private` so they're not part of the
+  public API; Session 5 will likely promote `aeval_companionMx_p_eq_zero` to a
+  public theorem once the matrix-level version is proved.
 
-## Open Questions (post-completion)
+## Open Questions (post-S4)
 
-See `meta.json` `overview.openQuestions` — the previously-listed "eliminate
-hMn_axiom" item has been resolved; the remaining items are listed in priority order
-(biconditional, companion identities, Mathlib contribution, K[X]-module connection).
+See `meta.json` `overview.openQuestions`. Q1 (biconditional, S3) and Q5
+(eliminate hMn_axiom, S2) are resolved. Q2 (charpoly/minpoly companion identities)
+is now **half-resolved**: the vector-level annihilation at e₀ is proved (S4); the
+matrix-level identity remains for Session 5.

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/meta.json
@@ -29,10 +29,10 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 406,
-    "theoremCount": 14,
+    "lineCount": 509,
+    "theoremCount": 17,
     "definitionCount": 2,
-    "assumptions": "0 assumptions. Fully machine-verified. The previous hMn_axiom is now `private theorem hMn_axiom`, derived from `minpoly.aeval K M : aeval M (minpoly K M) = 0`, `minpoly.monic (Matrix.isIntegral M)` (giving the leading coefficient is 1), and a local lemma `aeval_eq_sum_pow_local` that expands aeval via `Polynomial.eval₂_eq_sum` + `Algebra.smul_def`. Applying mulVec v to both sides of M^n = -∑_{k<n} c_k • M^k yields the desired identity. **Session 3** adds the *converse* direction (`similar_to_companion_implies_nonderogatory`) via cyclic-vector transport: the standard basis vector e₀ is cyclic for `companionMx p` for any p (subdiagonal structure), and similarity P⁻¹ M P = N transports cyclic vectors. The full biconditional `nonderogatory_iff_similar_to_companion` is now machine-verified.",
+    "assumptions": "0 assumptions. Fully machine-verified. The previous hMn_axiom is now `private theorem hMn_axiom`, derived from `minpoly.aeval K M : aeval M (minpoly K M) = 0`, `minpoly.monic (Matrix.isIntegral M)` (giving the leading coefficient is 1), and a local lemma `aeval_eq_sum_pow_local` that expands aeval via `Polynomial.eval₂_eq_sum` + `Algebra.smul_def`. Applying mulVec v to both sides of M^n = -∑_{k<n} c_k • M^k yields the desired identity. **Session 3** adds the *converse* direction (`similar_to_companion_implies_nonderogatory`) via cyclic-vector transport: the standard basis vector e₀ is cyclic for `companionMx p` for any p (subdiagonal structure), and similarity P⁻¹ M P = N transports cyclic vectors. The full biconditional `nonderogatory_iff_similar_to_companion` is now machine-verified. **Session 4** adds the vector-level Cayley-Hamilton identity for the companion: for monic p of degree n, `(aeval (companionMx p) p).mulVec e₀ = 0`. Three new private lemmas (`companionMx_mulVec_eNm1`, `companionMx_pow_n_eq_lastCol_e0`, `aeval_companionMx_p_mulVec_e0_zero`) make the last-column structure of `companionMx p` explicit, computing `C^n e₀ = -∑ p.coeff i • e_i` and showing monicity cancels with the lower-power sum.",
     "dateAdded": "2026-05-08",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -76,7 +76,7 @@
     ],
     "openQuestions": [
       "**Companion-similarity biconditional (Session 3 — DONE)**: ✅ Resolved. The converse direction *similar-to-companion ⇒ nonderogatory* is now machine-verified as `similar_to_companion_implies_nonderogatory`, and packaged as the full biconditional `nonderogatory_iff_similar_to_companion`. Proof: e₀ is cyclic for companionMx p (any p, by subdiagonal structure), similarity transports cyclic vectors (via aeval(M)*P = P*aeval(N) and injectivity of P.mulVec), and the cyclic-vector biconditional from OQ-01-OQ-01 closes the converse.",
-      "**Companion-matrix charpoly/minpoly identities**: Mathlib lacks `Matrix.charpoly_companionMatrix` and `Matrix.minpoly_companionMatrix` for the `companionMx` defined here. These are standard results (`charpoly = minpoly = p` for the companion of monic `p` of degree `n`) and would let the gallery entry export an even tighter `nonderogatory_companion` corollary asserting the companion is the unique nonderogatory representative in its similarity class. *Note*: with Session 3's `companionMx_isCyclic_e0`, the minpoly identity for monic degree-n p is one short step away — e₀ being cyclic gives `(minpoly K (companionMx p)).natDegree = n` via `minpoly_natDegree_of_cyclic`, and then `aeval (companionMx p) p = 0` (a direct consequence of monic degree-n + the M^n-from-last-column relation) would force `minpoly = p` by minimality.",
+      "**Companion-matrix charpoly/minpoly identities (Session 4 — vector-form annihilation)**: Session 4 establishes the *vector-level* annihilation `(aeval (companionMx p) p).mulVec e₀ = 0` for monic `p` of degree `n`, via three new private lemmas: `companionMx_mulVec_eNm1` (action of C on e_{n-1} = the last column = `-(p.coeff i)_{i<n}`), `companionMx_pow_n_eq_lastCol_e0` (combining with `companionMx_pow_e0` for `k = n-1`), and `aeval_companionMx_p_mulVec_e0_zero` (monicity cancels the C^n-term against the lower-power sum). Remaining for Session 5: lift to the matrix-level `aeval (companionMx p) p = 0` via cyclicity of e₀, then derive `minpoly K (companionMx p) = p` by minimality (giving `Matrix.minpoly_companionMatrix`).",
       "**Mathlib contribution**: With `companionMx`, `nonderogatory_similar_to_companion`, and the full biconditional now axiom-free, this entry is a candidate seed for a Mathlib contribution adding `Matrix.companionMatrix` and `Matrix.IsSimilar.companionMatrix_of_nonderogatory`. The route to the multi-block RCF would then go through the K[X]-module structure theorem (`Module.IsTorsion.exists_isInternal`-style) — a much larger project but with this single-block result as a natural scaffold.",
       "**Functor between cyclic representations and cyclic-module-style RCF**: The K[X]-module given by M acting on K^n is cyclic (single-generator) iff M is nonderogatory. Can the existing `Module.IsTorsion`-style results be specialized cleanly to recover this entry's similarity? Doing so would unify the matrix-form proof with the module-theoretic proof and clarify which direction is more economical for Mathlib.",
       "**Eliminate hMn_axiom (Session 2 — DONE)**: ✅ Resolved. The previous residual axiom `(M^n).mulVec v = -∑ k<n, (minpoly K M).coeff k • (M^k).mulVec v` is now derived as `private theorem hMn_axiom` from `minpoly.aeval`, `minpoly.monic (Matrix.isIntegral M)`, and a local `aeval_eq_sum_pow_local` lemma (which uses `Polynomial.eval₂_eq_sum` + `Algebra.smul_def`)."
@@ -90,9 +90,9 @@
       "Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01"
     ],
     "namespace": "CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02",
-    "lineCount": 214,
+    "lineCount": 509,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 17,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Session 4 of `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02` establishes the vector-level Cayley-Hamilton identity for the companion matrix:

For monic `p` of natDegree `n`, `(aeval (companionMx p) p).mulVec e_0 = 0`.

This is the computational core of the as-yet-unproved `Matrix.minpoly_companionMatrix : minpoly K (companionMx p) = p` (Q2 of the openQuestions list, missing from Mathlib v4.26.0).

## Three new private lemmas

- **`companionMx_mulVec_eNm1`**: action of `companionMx p` on `e_{n-1}` returns the last column `(-(p.coeff i))_{i<n}`, by direct unfolding of the `companionMx` def. The first if-clause `j.val + 1 = n` triggers for `j = ⟨n-1, _⟩`.
- **`companionMx_pow_n_eq_lastCol_e0`**: combining S3's `companionMx_pow_e0` (k = n-1) with `companionMx_mulVec_eNm1`, `(companionMx p)^n e_0 = (-(p.coeff i))_{i<n}`. Uses `congr 1 + omega` to rewrite the exponent only (avoiding `Fin n` type-level rewrite issues from a direct `n = (n-1) + 1` rewrite).
- **`aeval_companionMx_p_mulVec_e0_zero`**: monicity (`p.coeff n = 1`) cancels the `1 • C^n e_0` term against `∑_{k<n} p.coeff k • e_k`. Pointwise at index `i`, the range-n sum picks out `k = i.val` giving `p.coeff i.val`, which cancels with `-(p.coeff i.val)` from the n-th term.

## File state

- 406 → 509 lines (+103 net).
- 14 → 17 theorems/lemmas (+3 above; `meta.theoremCount` and `leanFile.theoremCount` both bumped — `leanFile` was stale from S2).
- 2 definitions, 0 axioms, 0 sorries (status `verified` / `original` retained).

## Next step (Session 5)

Lift to the matrix-level `aeval (companionMx p) p = 0` via cyclicity of `e_0` (S3's `companionMx_isCyclic_e0`). Then `(minpoly K (companionMx p)) ∣ p` by minimality, and `(minpoly K (companionMx p)).natDegree = n` from `minpoly_natDegree_of_cyclic` (sibling OQ-01-OQ-01) — both monic of the same degree, so equal. This gives `Matrix.minpoly_companionMatrix`.

## Test plan

- [ ] CI builds `Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02`.
- [ ] No new sorries / axioms (verified by find-targets).
- [ ] `lf.theoremCount` and `meta.theoremCount` agree at 17.

Build was **not** verified locally — worktree `.lake` symlink trap (memory `feedback_researcher_lake_symlink_broken.md`). CI is the ground truth. If CI flags an API drift on `pow_succ'`, `Matrix.mul_mulVec`, `Matrix.smul_mulVec`, `Polynomial.leadingCoeff`, `Polynomial.Monic.leadingCoeff`, `Pi.single_apply`, `Pi.single_eq_same`, `Pi.smul_apply`, `Pi.add_apply`, `Finset.sum_range_succ`, `Finset.sum_apply`, `Finset.sum_eq_single`, `Finset.mem_range`, `Nat.sub_add_cancel`, or `Nat.sub_lt`, S5 will repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)