### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-01-oq-01 — sync theoremCount 30→31 + definitionCount 6→8

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) ballot_counting_identity (~150 lines) — per-fiber count equality C(a+b, a+1) for the b≥2 reflection step; (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
     "lineCount": 1242,
-    "theoremCount": 30,
-    "definitionCount": 6,
+    "theoremCount": 31,
+    "definitionCount": 8,
     "originalContributions": [
       "jacobiTrudiMatrix: the k×k matrix with entries h_{sh_i + j - i} (or 0 for negative index) — first Lean 4 Jacobi-Trudi matrix definition",
       "schurPolynomial: det(jacobiTrudiMatrix) as the primary definition of Schur polynomials in Lean 4",
@@ -84,8 +84,8 @@
     "namespace": "JacobiTrudi",
     "lineCount": 1242,
     "axiomCount": 0,
-    "theoremCount": 30,
-    "definitionCount": 6,
+    "theoremCount": 31,
+    "definitionCount": 8,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Sync stale theoremCount and definitionCount in
`src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json` after
S22 (#16983) and S23 (#17040) added decls without bumping canonical counts.

## Evidence

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` on origin/main:
  - 31 canonical `theorem|lemma` declarations (comment-stripped narrow regex)
  - 8 canonical `def|abbrev|opaque` declarations
- Previous values were 30 and 6 in both `meta.*` and `meta.leanFile.*`.

## Diff

\`\`\`diff
-    "theoremCount": 30,
-    "definitionCount": 6,
+    "theoremCount": 31,
+    "definitionCount": 8,
\`\`\`

(applied to both the meta block and the leanFile block — keeps them aligned)

`lineCount`, `sorries` (2), and `axiomCount` (0) are already accurate and untouched.

---
Automated fix by lean-mechanic agent.