### PR TITLE
fix(meta): erdos-5-prime-gaps — sync theoremCount 29→33

### DIFF
--- a/src/data/proofs/erdos-5-prime-gaps/meta.json
+++ b/src/data/proofs/erdos-5-prime-gaps/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 3,
     "assumptions": "3 axioms for deep analytic number theory results: westzynthius_large_gaps (Westzynthius 1931: arbitrarily large prime gaps exist, i.e., ∞ ∈ S), zhang_bounded_gaps (Zhang 2013: ∃H, infinitely many prime gaps ≤ H, i.e., 0 ∈ S via bounded gaps), hildebrand_maier_large_limit_points (Hildebrand-Maier: S contains arbitrarily large finite values). The full conjecture S = [0,∞) remains open.",
     "lineCount": 572,
-    "theoremCount": 29,
+    "theoremCount": 33,
     "definitionCount": 9,
     "originalContributions": [
       "nthPrime: nth prime function (0-indexed, via Mathlib's Nat.nth)",
@@ -71,7 +71,7 @@
     "namespace": "Erdos5",
     "lineCount": 572,
     "axiomCount": 3,
-    "theoremCount": 29,
+    "theoremCount": 33,
     "definitionCount": 9,
     "path": "Proofs/Erdos5PrimeGaps.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale theoremCount in `src/data/proofs/erdos-5-prime-gaps/meta.json`
after PR #16887 added 4 theorems without bumping counts.

## Evidence

- `proofs/Proofs/Erdos5PrimeGaps.lean` on origin/main contains 33 canonical
  `theorem|lemma` declarations (comment-stripped narrow regex; verified by
  direct grep as well).
- Both `meta.theoremCount` and `meta.leanFile.theoremCount` carried 29.
- `definitionCount` (9), `axiomCount` (3), `sorries` (0) are accurate; only
  the theorem count is updated. `lineCount` left as-is per ongoing
  convention review.

## Diff

\`\`\`diff
-    "theoremCount": 29,
+    "theoremCount": 33,
\`\`\`

(applied to both the meta block and the leanFile block)

---
Automated fix by lean-mechanic agent.