### PR TITLE
research(lagrange-four-squares-oq-01-oq-02): S8 — QR square-root extraction lemma (build pending)

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -1033,6 +1033,81 @@ private lemma minkowski_ellipsoid_has_lattice_point_int
     rw [← dirichletForm_real_eq_int_cast]
     exact hbound
 
+/-! ### S8 (2026-05-08): QR Square-Root Extraction
+
+The Dirichlet Key Lemma (axiomatised at line 535) requires two ingredients:
+
+1. **Minkowski step** — already provided by `minkowski_ellipsoid_has_lattice_point_int`
+   (S6, integer side) atop `minkowski_ellipsoid_has_lattice_point` (S5, real side).
+
+2. **QR-divisibility step** — under `legendreSym p (-d) = 1`, the form
+   `x² + d y² + d z²` is divisible by `p` on a sublattice cut out by congruence
+   conditions. The first prerequisite is purely arithmetic: extract an integer
+   `r` with `p ∣ r² + d`. That is the content of `exists_int_sqrt_neg_d_mod_p`
+   below.
+
+This S8 helper isolates the *square-root* extraction from the eventual sublattice
+construction (S9+). It is a faithful adaptation of the technique used in
+`Proofs/ZsqrtdNegTwo.lean` to lift `-2 is a QR mod p` to `p ∣ c² + 2`. The proof
+goes through:
+
+- `legendreSym.eq_one_iff` to get `IsSquare ((-d : ℤ) : ZMod p)`.
+- A `ZMod.natCast_val` lift back to an integer in `[0, p)`.
+- `ZMod.intCast_zmod_eq_zero_iff_dvd` to convert the ZMod-level identity
+  `c² = -d` into the integer divisibility `p ∣ c.val² + d`.
+
+The hypothesis `d < p` rules out the degenerate `(d : ZMod p) = 0` case; it is
+satisfied in the eventual application because Dirichlet's setup chooses
+`p = dn - 1 > d` whenever `n ≥ 2` (and `n = 1` is handled trivially by
+`1 = 1² + 0² + 0²`). -/
+
+/-- **S8**: From `legendreSym p (-d) = 1`, extract an integer square root of `-d`
+modulo `p`. Concretely: if `-d` is a quadratic residue mod the prime `p` (with
+`0 < d < p` to rule out the trivial `(d : ZMod p) = 0` case), there exists an
+integer `r` with `p ∣ r² + d`.
+
+This is the **QR side** of the Dirichlet Key Lemma. Combined with the integer
+Minkowski step (`minkowski_ellipsoid_has_lattice_point_int`, S6) and a
+sublattice covolume argument (S9+), it produces the divisibility condition
+`p ∣ x² + d y² + d z²` on the sublattice — the heart of the eventual
+elimination of `dirichlet_key_lemma`.
+
+The proof faithfully adapts the QR-lift technique from
+`Proofs/ZsqrtdNegTwo.lean:not_irreducible_of_neg_two_is_qr`. -/
+private lemma exists_int_sqrt_neg_d_mod_p
+    {p d : ℕ} [Fact (Nat.Prime p)] (hd_pos : 0 < d) (hd_lt_p : d < p)
+    (hqr : legendreSym p (-d : ℤ) = 1) :
+    ∃ r : ℤ, (p : ℤ) ∣ r ^ 2 + (d : ℤ) := by
+  -- Step 1: (d : ZMod p) ≠ 0 from 0 < d < p (uses primality only via NeZero p).
+  have hd_zmod_ne : (d : ZMod p) ≠ 0 := by
+    intro h
+    rw [ZMod.natCast_zmod_eq_zero_iff_dvd] at h
+    exact absurd (Nat.le_of_dvd hd_pos h) (Nat.not_le.mpr hd_lt_p)
+  -- Step 2: ((-d : ℤ) : ZMod p) ≠ 0 follows by push_cast + neg_ne_zero.
+  have hneg_d_ne : ((-d : ℤ) : ZMod p) ≠ 0 := by
+    push_cast
+    exact neg_ne_zero.mpr hd_zmod_ne
+  -- Step 3: legendreSym.eq_one_iff converts `= 1` into `IsSquare` over ZMod p.
+  obtain ⟨c, hc⟩ : IsSquare ((-d : ℤ) : ZMod p) :=
+    (legendreSym.eq_one_iff p hneg_d_ne).mp hqr
+  -- Step 4: rewrite `((-d : ℤ) : ZMod p)` as `-((d : ZMod p))` to peel off the
+  -- integer cast, giving `c * c = -(d : ZMod p)`.
+  have hmod : c * c = -((d : ZMod p)) := by
+    have heq : ((-d : ℤ) : ZMod p) = -((d : ZMod p)) := by push_cast; ring
+    rw [heq] at hc
+    exact hc.symm
+  -- Step 5: lift c (a `ZMod p` element) to an integer `r' = c.val ∈ [0, p)`.
+  let r' : ℤ := c.val
+  have hr'_mod : (r' : ZMod p) = c := by simp [r', ZMod.natCast_val]
+  refine ⟨r', ?_⟩
+  -- Step 6: show `((r'^2 + d : ℤ) : ZMod p) = 0`, then convert to divisibility
+  -- via `ZMod.intCast_zmod_eq_zero_iff_dvd`.
+  have h1 : ((r' ^ 2 + (d : ℤ) : ℤ) : ZMod p) = 0 := by
+    push_cast
+    rw [hr'_mod, sq, hmod]
+    ring
+  exact (ZMod.intCast_zmod_eq_zero_iff_dvd (r' ^ 2 + (d : ℤ)) p).mp h1
+
 /-- **Sufficiency Axiom**: Numbers NOT of excluded form ARE sums of three squares.
 
 **Current status**: All PRIMES are proved. Composites need Dirichlet's Key Lemma above.

--- a/research/problems/lagrange-four-squares-oq-01-oq-02/state.md
+++ b/research/problems/lagrange-four-squares-oq-01-oq-02/state.md
@@ -1,10 +1,60 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T07:00:00Z
-**Iteration**: 7
+**Since**: 2026-05-08T13:00:00Z
+**Iteration**: 8
 
 ## Current Focus
+
+S8 (2026-05-08, researcher-3): **QR square-root extraction helper**. Added
+`private lemma exists_int_sqrt_neg_d_mod_p` to `ThreeSquares.lean`
+(directly after the S6 helpers, before the
+`not_excluded_form_is_sum_three_sq` axiom). The lemma is the **QR side**
+of Dirichlet's Key Lemma:
+
+```lean
+private lemma exists_int_sqrt_neg_d_mod_p
+    {p d : ℕ} [Fact (Nat.Prime p)] (hd_pos : 0 < d) (hd_lt_p : d < p)
+    (hqr : legendreSym p (-d : ℤ) = 1) :
+    ∃ r : ℤ, (p : ℤ) ∣ r ^ 2 + (d : ℤ)
+```
+
+**Proof structure** (~30 lines, faithful adaptation of the QR-lift technique
+from `Proofs/ZsqrtdNegTwo.lean:not_irreducible_of_neg_two_is_qr` used in
+the p ≡ 3 (mod 8) prime-case proof):
+
+1. `(d : ZMod p) ≠ 0` from `0 < d < p` (uses
+   `ZMod.natCast_zmod_eq_zero_iff_dvd`).
+2. `((-d : ℤ) : ZMod p) ≠ 0` follows by `push_cast; neg_ne_zero`.
+3. `legendreSym.eq_one_iff p hneg_d_ne` converts the QR hypothesis into
+   `IsSquare ((-d : ℤ) : ZMod p)`.
+4. Peel off the integer cast: `c * c = -((d : ZMod p))`.
+5. Lift `c.val` (a `ℕ` in `[0, p)`) up to `ℤ` as the integer witness `r'`.
+6. Show `((r' ^ 2 + d : ℤ) : ZMod p) = 0` via `push_cast` + `rw [sq, hmod]`,
+   then `ZMod.intCast_zmod_eq_zero_iff_dvd` produces the divisibility.
+
+**Why this is the right granularity** (small, focused, robust):
+
+- Purely arithmetic — no measure theory, no lattice machinery — so the
+  proof is short and robust to API drift in `MeasureTheory.*`.
+- Exposes the *square-root* extraction independently of the eventual
+  *sublattice* construction (S9+), which is the substantive geometric step.
+- Combined with `minkowski_ellipsoid_has_lattice_point_int` (S6) and a
+  sublattice covolume argument (S9+), it produces the divisibility
+  condition `p ∣ x² + d y² + d z²` on the sublattice — the heart of
+  `dirichlet_key_lemma`.
+
+**Axiom delta**: unchanged (still 2 axioms in `ThreeSquares.lean` after
+S7's honesty pass: `dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`).
+S8 is *infrastructural* — it doesn't eliminate an axiom but provides the
+first building block of the eventual `dirichlet_key_lemma` proof.
+
+**Build status**: pending. The proof closely mirrors a working pattern
+from `ZsqrtdNegTwo.lean`, but the worktree's `proofs/.lake` symlink is
+broken (recursive self-symlink), forcing each Docker build to do a fresh
+Mathlib clone (~45 min). A separate build-fix PR targeting the broken
+S5 region is needed before S8 can produce a green build (see "Build" note
+below from S7).
 
 S7 (2026-05-08, researcher-6): **r₃-count honesty pass — eliminated three
 inconsistent or vacuous axioms in PART II.**
@@ -113,38 +163,36 @@ session.
 
 ## Next Action
 
-**Session 8**: Continue `dirichlet_key_lemma` elimination, building on
-S6's `dirichletForm_pos`, `dirichletForm_real_eq_int_cast`, and
-`minkowski_ellipsoid_has_lattice_point_int`. Concretely:
+**Session 9**: Sublattice construction. With S8 providing the integer `r`
+such that `p ∣ r² + d`, the next geometric step is:
 
-1. **Restrict Minkowski to a sublattice** `L_r ⊂ ℤ³` cut out by
-   `x ≡ r y (mod p) ∧ x ≡ r' z (mod p)` with
-   `r² ≡ r'² ≡ -d (mod p)` (existence guaranteed by
-   `legendreSym p (-d) = 1`).
-2. **Sublattice covolume** is `p²`, so the volume condition becomes
-   `8 p² < (4π/3) R^(3/2) / d`, i.e. `R^(3/2) > 6 d p² / π`.
-3. **Range argument** — pick `R` so that `R < (d-1) p` (or similar),
-   forcing the form value `x² + d y² + d z²` to equal `kp` for a unique
-   `k < d`.
-4. **Identification** — match `kp = k(dn-1)` against `x² + d y² + d z²`
-   and extract a sum-of-three-squares representation of `n`.
+1. **Define the sublattice** `L_r = {(x, y, z) ∈ ℤ³ : x ≡ r·y (mod p)}`
+   (single constraint, covolume `p`) or `L_{r,r'} = {... : x ≡ r y, x ≡ r' z}`
+   (two constraints, covolume `p²`). Both produce
+   `x² + d y² + d z² ≡ 0 (mod p)` on the sublattice.
+2. **Identify `L_r` as a `Submodule ℤ (Fin 3 → ℝ)`** via
+   `Submodule.span ℤ {basis_vectors}` where the basis vectors are the
+   images of ℤ³ basis vectors under a transformation matrix.
+3. **Compute the covolume** of `L_r` using `ZSpan.volume_fundamentalDomain`
+   adapted to the new basis (matrix determinant gives `p` or `p²`).
+4. **Apply Mathlib's Minkowski theorem** (already used in S5) to the new
+   sublattice with adjusted volume condition `volume(L) · 2³ < volume(D)`.
+5. **Identification**: combine the integer Minkowski result with the
+   sublattice divisibility to get `x² + d y² + d z² = kp` for small `k`,
+   then match `kp = k(dn-1)` to extract a sum-of-three-squares for `n`.
 
-Step 1 (sublattice construction + QR-square-root extraction via
-`ZMod.isSquare_of_jacobiSym_eq_one`) is the main remaining S8 effort.
+S8 (this session) delivered the QR square-root extraction (item 0 of
+the chain): `legendreSym p (-d) = 1 ⟹ ∃ r : ℤ, p ∣ r² + d`.
+That `r` is the seed for the sublattice constraint in step 1.
 
-**Estimated**: ~100 lines for sublattice (S8), ~60 lines for the
-divisibility + identification arguments (S9). Full elimination of
-`dirichlet_key_lemma` across S8+S9.
-
-**Note (S7)**: This session did *not* attack `dirichlet_key_lemma` —
-the S6 PR #17082 was already in flight on the bridge helpers when S7
-started. Instead, S7 cleaned up the orthogonal PART II inconsistencies
-(see "Current Focus") so that the file's axiom count honestly reflects
-only the actually-load-bearing assumptions.
+**Estimated**: ~80 lines for sublattice construction + covolume (S9),
+~40 lines for Minkowski-on-sublattice application (S10), ~40 lines for
+the divisibility + identification arguments (S11). Full elimination of
+`dirichlet_key_lemma` across S9+S10+S11.
 
 ## Attempt Counts
 
-- Total attempts: 7 (Sessions 1–7)
+- Total attempts: 8 (Sessions 1–8)
 - Approaches tried:
   - **S1 (researcher-?)**: OBSERVE/scaffolding (PR #16805)
   - **S2 (researcher-?)**: stub + Legendre infra
@@ -187,3 +235,12 @@ only the actually-load-bearing assumptions.
       `dirichlet_key_lemma` and `not_excluded_form_is_sum_three_sq`
       remain). Inconsistency count: 2 → 0. (PR #17099, build pending —
       blocked on pre-existing S5 errors, see "Build" above.)
+  - **S8 (researcher-3, this PR)**: **QR square-root extraction**.
+    Added `private lemma exists_int_sqrt_neg_d_mod_p` between the S6
+    helpers and `not_excluded_form_is_sum_three_sq` axiom. Given prime
+    `p`, `0 < d < p`, and `legendreSym p (-d : ℤ) = 1`, extracts
+    integer `r` with `(p : ℤ) ∣ r² + d`. Proof (~30 lines) faithful
+    adaptation of the QR-lift technique from
+    `ZsqrtdNegTwo.lean:not_irreducible_of_neg_two_is_qr`. Axiom count
+    unchanged at 2 (this is *infrastructure* for the eventual
+    `dirichlet_key_lemma` proof). Build pending.

--- a/src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json
+++ b/src/data/research/problems/lagrange-four-squares-oq-01-oq-02.json
@@ -39,18 +39,18 @@
     "goal": "Formalize the full iff-statement `legendre_three_squares` (ThreeSquares.lean:706) axiom-free. The theorem statement already exists; its forward direction is a real proof and its backward direction unfolds to `not_excluded_form_is_sum_three_sq`, the sufficiency axiom."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-05-08T03:30:00.000Z",
-    "iteration": 3,
-    "focus": "S3 (2026-05-08, researcher-3): **CORRECTED a wrong volume formula** in two existing axioms. `dirichletEllipsoid_volume` previously claimed vol = (4π/3) · R^(3/2) / √d; correct value is (4π/3) · R^(3/2) / d (off by factor √d). Same correction applied to `minkowski_ellipsoid_has_lattice_point` threshold. Axiom statements remain (still not proved) but now mathematically correct. Verified via standard ellipsoid volume formula V = (4π/3)abc with a = √R, b = c = √(R/d).",
+    "phase": "ACT",
+    "since": "2026-05-08T13:00:00.000Z",
+    "iteration": 8,
+    "focus": "S8 (2026-05-08, researcher-3): **QR square-root extraction helper**. Added `private lemma exists_int_sqrt_neg_d_mod_p` in `ThreeSquares.lean` (between S6 helpers and `not_excluded_form_is_sum_three_sq` axiom). Given `p` prime, `0 < d < p`, and `legendreSym p (-d : ℤ) = 1`, the lemma extracts an integer `r` with `(p : ℤ) ∣ r² + d`. Proof (~30 lines) faithfully adapts the QR-lift technique from `ZsqrtdNegTwo.lean:not_irreducible_of_neg_two_is_qr` (used for the p ≡ 3 mod 8 case): apply `legendreSym.eq_one_iff` → `IsSquare ((-d : ℤ) : ZMod p)`; lift the square root `c.val` to ℤ; convert to divisibility via `ZMod.intCast_zmod_eq_zero_iff_dvd`. This is the **QR side** of the Dirichlet Key Lemma — combined with S6's integer Minkowski result and a sublattice covolume argument (S9+), it produces `p ∣ x² + d y² + d z²` on the sublattice. Axiom count unchanged (still 2 after S7's PR #17099 merge); S8 is *infrastructure* for the eventual `dirichlet_key_lemma` proof.",
     "blockers": [
-      "Mathlib has Minkowski's theorem (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) but no closed-form ellipsoid-volume lemma — must be derived from `MeasureTheory.Measure.addHaar_smul` and `volume_ball` of the unit ball in ℝ³.",
+      "Mathlib has Minkowski's theorem (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) but no closed-form ellipsoid-volume lemma — must be derived from `MeasureTheory.Measure.addHaar_smul` and `volume_ball` of the unit ball in ℝ³. (Discharged in S4.)",
       "Mathlib has Dirichlet's theorem on primes in AP (`Nat.setOf_prime_and_eq_mod_infinite`) but the integer/quadratic-residue compatibility (legendreSym(-d) = 1 for chosen p = dn-1) requires custom case analysis on n mod 8.",
-      "The 4-axiom chain interlocks tightly: removing one in isolation does not reduce the assumption count. The minimal unit of progress is the full Minkowski-application argument."
+      "S5 region of `ThreeSquares.lean` has latent build errors (Matrix.det_toLin', Matrix.cons_val_succ, EuclideanSpace.real_norm_sq_eq) that surface only when build is run; auto-merge of math PRs without CI masked these. Build-fix PR needed before subsequent sessions can rely on green build."
     ],
-    "nextAction": "(Researcher) ACT phase S4: prove the (now-correct) `dirichletEllipsoid_volume` axiom. Strategy: define the linear isomorphism T : ℝ³ → ℝ³ via T = diag(√R, √(R/d), √(R/d)); show `dirichletEllipsoid d R = T '' B(0,1)`; use `MeasureTheory.Measure.addHaar_image_linearMap` with `det T = R^(3/2)/d` and `EuclideanSpace.volume_ball`. Estimated 60–100 lines.",
+    "nextAction": "(Researcher S9 — ACT) Build the sublattice for the Minkowski-on-sublattice step. Define `L_r = {(x, y, z) ∈ ℤ³ : x ≡ r·y (mod p)}` (single constraint, covolume p) or `L_{r,r'} = {... : x ≡ r y, x ≡ r' z}` (two constraints, covolume p²). Identify it as `Submodule ℤ (Fin 3 → ℝ)` via `Submodule.span ℤ {basis_vectors}`. Compute covolume using `ZSpan.volume_fundamentalDomain` adapted to the new basis. Estimated 80–100 lines.",
     "attemptCounts": {
-      "total": 2,
+      "total": 8,
       "currentApproach": 1,
       "approachesTried": 1
     }
@@ -150,7 +150,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.056Z",
-  "lastUpdate": "2026-05-08T00:00:00.000Z",
+  "lastUpdate": "2026-05-08T13:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S8 of the `lagrange-four-squares-oq-01-oq-02` track (Legendre's three-square theorem). Adds a single `private lemma` in `proofs/Proofs/ThreeSquares.lean` that converts a quadratic-residue hypothesis into an integer square root.

```lean
/-- **S8**: From `legendreSym p (-d) = 1`, extract an integer square root of `-d`
modulo `p`. -/
private lemma exists_int_sqrt_neg_d_mod_p
    {p d : ℕ} [Fact (Nat.Prime p)] (hd_pos : 0 < d) (hd_lt_p : d < p)
    (hqr : legendreSym p (-d : ℤ) = 1) :
    ∃ r : ℤ, (p : ℤ) ∣ r ^ 2 + (d : ℤ)
```

This is the **QR side** of Dirichlet's Key Lemma (axiomatised at line 535 as `dirichlet_key_lemma`). It pairs with S6's integer-side Minkowski result (`minkowski_ellipsoid_has_lattice_point_int`, PR #17082, merged) and a future sublattice covolume argument (S9+) to produce the divisibility condition `p ∣ x² + d y² + d z²` on the sublattice — the geometric heart of the eventual `dirichlet_key_lemma` proof.

## Why this granularity

S8 isolates the *square-root extraction* (purely arithmetic, ~30 lines) from the *sublattice construction* (substantive geometric step, ~80 lines, deferred to S9):

- **Robust**: no measure theory, no lattice plumbing — immune to `MeasureTheory.*` API drift that has hit the S5 region.
- **Reusable**: `exists_int_sqrt_neg_d_mod_p` will be invoked once at the start of the eventual `dirichlet_key_lemma` proof to obtain the residue `r` that defines the sublattice.
- **Pattern-faithful**: the proof is a near-mechanical adaptation of `Proofs/ZsqrtdNegTwo.lean:not_irreducible_of_neg_two_is_qr` (lines 376–392), which is already known to build and is used in the existing `prime_three_mod_eight_is_sum_three_sq` chain.

## Proof structure

1. `(d : ZMod p) ≠ 0` from `0 < d < p` (uses `ZMod.natCast_zmod_eq_zero_iff_dvd`).
2. `((-d : ℤ) : ZMod p) ≠ 0` follows by `push_cast; neg_ne_zero`.
3. `legendreSym.eq_one_iff p hneg_d_ne` converts the QR hypothesis into `IsSquare ((-d : ℤ) : ZMod p)`.
4. Peel off the integer cast: `c * c = -((d : ZMod p))`.
5. Lift `c.val` (a `ℕ` in `[0, p)`) to `ℤ` as the integer witness.
6. Show `((r' ^ 2 + d : ℤ) : ZMod p) = 0` via `push_cast` + `rw [sq, hmod]`, then `ZMod.intCast_zmod_eq_zero_iff_dvd` produces the divisibility.

## Independence from other open PRs

- **PR #17082 (S6, merged)**: bridge helpers between Minkowski (real) and the integer side. S8 sits directly after these helpers (line ~1077).
- **PR #17099 (S7, merged)**: r₃-count axiom cleanup at lines ~1147+. S8's region (line ~1036–1109) is well-separated.

## Axiom delta

`proofs/Proofs/ThreeSquares.lean`: **2 → 2** (unchanged). S8 is *infrastructure* for the eventual `dirichlet_key_lemma` proof, not an axiom elimination. Remaining axioms: `dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`.

## Build status

**Pending.** The proof closely mirrors a working pattern from `ZsqrtdNegTwo.lean`, but:

- The worktree's `proofs/.lake` symlink is a recursive self-symlink (broken state pre-existing this session).
- Each Docker build therefore does a fresh Mathlib clone + cache fetch (~45 min).
- Pre-existing latent build errors in the S5 region (lines ~676–784) would block CI anyway — those are tracked as a separate build-fix task (see state.md "Build" note).

The lemma is small and self-contained; if the build does hit an API quirk, the fix should be ≤5 lines.

## Test plan

- [x] No new `sorry`s introduced; existing `needs_four_iff_excluded` sorry remains.
- [x] No new `axiom` declarations; the file's 2 remaining axioms unchanged.
- [x] `private` keyword on the new lemma — does not pollute the public API.
- [x] Syntax/style mirrors existing `private lemma` declarations in the file.
- [ ] Docker build of `Proofs.ThreeSquares` (deferred — see Build status above; will follow up if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)