### PR TITLE
fix(meta): hilbert-11-oq-02 — sync theoremCount 23→32

### DIFF
--- a/src/data/proofs/hilbert-11-oq-02/meta.json
+++ b/src/data/proofs/hilbert-11-oq-02/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "lineCount": 708,
-    "theoremCount": 23,
+    "theoremCount": 32,
     "definitionCount": 5,
     "assumptions": "2 axioms: (1) selmer_no_rational_solution — Selmer's 1951 theorem that 3x³ + 4y³ + 5z³ = 0 has no nontrivial rational solutions; the full proof uses 3-descent on the associated elliptic curve y² = x³ - 432·15² and computation of the 3-Selmer group, neither of which is available in Mathlib v4.26.0. (2) selmer_padic_solubility — for every prime p, the Selmer cubic is solvable over ℚₚ; provable via Hensel's lemma on the smooth reduction mod p for p ∉ {2,3,5} and direct construction at the small primes, but requires Hensel infrastructure for ℚₚ. The real solubility (existence of a nontrivial real root) and the easy directions ℚ → ℝ and ℚ → ℚₚ are proved unconditionally from Mathlib's intermediate_value_Icc and the standard ring embeddings.",
     "dateAdded": "2026-05-08",
@@ -251,7 +251,7 @@
     "namespace": "Hilbert11OQ02",
     "lineCount": 708,
     "axiomCount": 2,
-    "theoremCount": 23,
+    "theoremCount": 32,
     "definitionCount": 5,
     "path": "Proofs/Hilbert11OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale theoremCount in `src/data/proofs/hilbert-11-oq-02/meta.json`
after several iter-4 → iter-6 research PRs added theorems without bumping
counts.

## Evidence

- `proofs/Proofs/Hilbert11OQ02.lean` on origin/main contains **32**
  canonical `theorem|lemma` declarations (comment-stripped narrow regex).
- Both `meta.theoremCount` and `meta.leanFile.theoremCount` carried 23
  (S3 snapshot from PR #16971).
- Recent merged PRs adding theorems without count bump:
  - #16996 (iter 4 — Hensel-elimination witnesses)
  - #17070 (iter 5 — ℚ_[11] solubility, axiom-free)
  - #17093 (iter 6 — parametric Case-A Hensel + 3 ℚ_[p] instances)
- `definitionCount` (5), `axiomCount` (2), `sorries` (0) are accurate;
  `lineCount` left as-is per ongoing convention review.

## Diff

\`\`\`diff
-    "theoremCount": 23,
+    "theoremCount": 32,
\`\`\`

(applied to both the meta block and the leanFile block)

---
Automated fix by lean-mechanic agent.