### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S7 — |G| = p²·q axiom-free, case p > q

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
@@ -44,6 +44,7 @@
 import Mathlib.GroupTheory.PGroup
 import Mathlib.GroupTheory.Solvable
 import Mathlib.GroupTheory.Nilpotent
+import Mathlib.GroupTheory.Sylow
 import Mathlib.GroupTheory.SpecificGroups.Alternating
 import Mathlib.GroupTheory.SpecificGroups.ZGroup
 import Mathlib.Tactic
@@ -262,6 +263,96 @@ theorem burnside_pq_with_normal_qSylow {G : Type*} [Group G] [Finite G]
   exact isSolvable_of_normal_quotient_solvable N
 
 -- ═══════════════════════════════════════════════════════════════════════
+-- PART III.6: |G| = p² · q axiom-free, case `p > q` (Iteration 7)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-! Iteration 7 begins discharging `burnside_pq_nontrivial` for the shape
+    `|G| = p² · q` (`a = 2, b = 1`). The full argument splits into three
+    sub-cases per `session-6-p-squared-q-spec.md`:
+    1. `p > q` — always `n_p = 1` by Sylow's third theorem (this iteration).
+    2. `p < q ≠ 3` — symmetric `n_q = 1` analysis (S7.5).
+    3. exceptional `(p, q) = (2, 3), |G| = 12` — element counting (S8).
+
+    Each sub-case combines `card_sylow_modEq_one` + `Sylow.card_dvd_index`
+    with the existing reduction lemmas `burnside_pq_with_normal_pSylow` /
+    `burnside_pq_with_normal_qSylow`. -/
+
+/-- **Sylow count constraint** (helper for `|G| = p² · q`, case `p > q`):
+    if `n ∣ q` (with `q` prime, `q < p`) and `n ≡ 1 [MOD p]`, then `n = 1`.
+    The two divisors of a prime are `1` and itself; `q ≡ 1 [MOD p]` with
+    `q < p` would force `p ≤ q - 1 < p`, contradiction. -/
+private lemma sylow_count_eq_one_of_lt_prime
+    {n p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : q < p)
+    (hmod : n ≡ 1 [MOD p]) (hdvd : n ∣ q) : n = 1 := by
+  rcases hq.eq_one_or_self_of_dvd n hdvd with h1 | hq_eq
+  · exact h1
+  · -- n = q. Then q ≡ 1 [MOD p], i.e. p ∣ q - 1, but p > q forces contradiction.
+    rw [hq_eq] at hmod
+    have hq_two_le : 2 ≤ q := hq.two_le
+    have hp_dvd_qm1 : p ∣ q - 1 :=
+      (Nat.modEq_iff_dvd' (by omega : 1 ≤ q)).mp hmod.symm
+    have hp_le : p ≤ q - 1 := Nat.le_of_dvd (by omega : 0 < q - 1) hp_dvd_qm1
+    omega
+
+/-- **Burnside `|G| = p² · q`, case `p > q`** (axiom-free).
+
+    Sylow's third theorem (`card_sylow_modEq_one`) gives `n_p ≡ 1 [MOD p]`,
+    and `Sylow.card_dvd_index` gives `n_p ∣ q` (the index of a Sylow
+    `p`-subgroup is `q`, since `|P| = p²` and `|G| = p² · q`). The helper
+    `sylow_count_eq_one_of_lt_prime` then forces `n_p = 1`: the only
+    divisors of the prime `q` are `1` and `q`, and `q ≡ 1 [MOD p]` with
+    `q < p` is impossible.
+
+    With `n_p = 1`, the unique Sylow `p`-subgroup `P` is normal
+    (`Sylow.normal_of_subsingleton`). Then `burnside_pq_with_normal_pSylow`
+    discharges, treating `|G| = p² · q¹`.
+
+    This eliminates the `(a, b) = (2, 1)` shape from the
+    `burnside_pq_nontrivial` axiom whenever `p > q`; the symmetric `p < q`
+    case (S7.5) and the exceptional `|G| = 12` case (S8) will complete
+    the `|G| = p² · q` discharge. -/
+theorem burnside_p_squared_q_p_gt_q
+    {G : Type*} [Group G] [Finite G]
+    {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : q < p) (hcard : Nat.card G = p ^ 2 * q) :
+    IsSolvable G := by
+  -- Step 1: pick a Sylow p-subgroup; |P| = p² by `Sylow.card_eq_multiplicity`.
+  obtain ⟨P⟩ : Nonempty (Sylow p G) := inferInstance
+  have hp_ne_q : p ≠ q := by omega
+  have hp_not_dvd_q : ¬ p ∣ q :=
+    mt (Nat.prime_dvd_prime_iff_eq hp.out hq.out).mp hp_ne_q
+  have hcop : Nat.Coprime (p ^ 2) q :=
+    ((Nat.coprime_primes hp.out hq.out).mpr hp_ne_q).pow_left 2
+  have hP_card : Nat.card (P : Subgroup G) = p ^ 2 := by
+    have hmult := Sylow.card_eq_multiplicity P
+    -- `hmult : Nat.card P = p ^ Nat.factorization (Nat.card G) p`
+    have hfact : Nat.factorization (Nat.card G) p = 2 := by
+      rw [hcard, Nat.factorization_mul_apply_of_coprime hcop,
+          Nat.Prime.factorization_pow hp.out,
+          Nat.factorization_eq_zero_of_not_dvd hp_not_dvd_q]
+      simp
+    rw [hfact] at hmult
+    exact hmult
+  -- Step 2: index of P is q (Lagrange + cancellation).
+  have hp2_pos : 0 < p ^ 2 := pow_pos hp.out.pos 2
+  have hP_index : (P : Subgroup G).index = q := by
+    have h := Subgroup.card_mul_index (P : Subgroup G)
+    rw [hP_card, hcard] at h
+    exact Nat.eq_of_mul_eq_mul_left hp2_pos h
+  -- Step 3: n_p ≡ 1 [MOD p] and n_p ∣ q, so n_p = 1.
+  have hnp_mod : Nat.card (Sylow p G) ≡ 1 [MOD p] := card_sylow_modEq_one p G
+  have hnp_dvd : Nat.card (Sylow p G) ∣ q := hP_index ▸ Sylow.card_dvd_index P
+  have hnp_eq_one : Nat.card (Sylow p G) = 1 :=
+    sylow_count_eq_one_of_lt_prime hp.out hq.out hpq hnp_mod hnp_dvd
+  -- Step 4: n_p = 1 ⇒ Subsingleton (Sylow p G) ⇒ P.Normal.
+  haveI hSub : Subsingleton (Sylow p G) :=
+    (Nat.card_eq_one_iff_unique.mp hnp_eq_one).1
+  haveI hP_normal : (P : Subgroup G).Normal := Sylow.normal_of_subsingleton P
+  -- Step 5: discharge via burnside_pq_with_normal_pSylow with a = 2, b = 1.
+  have hcard' : Nat.card G = p ^ 2 * q ^ 1 := by rw [pow_one]; exact hcard
+  exact burnside_pq_with_normal_pSylow (a := 2) (b := 1) hcard' (P : Subgroup G) hP_card
+
+-- ═══════════════════════════════════════════════════════════════════════
 -- PART IV: Main theorem
 -- ═══════════════════════════════════════════════════════════════════════
 
@@ -367,6 +458,17 @@ example {G : Type*} [Group G] [Finite G]
   have hN' : Nat.card N = 2 ^ 2 := by rw [hN]; norm_num
   exact burnside_pq_with_normal_pSylow hcard' N hN'
 
+/-- **Group of order `45 = 3² · 5` is solvable** (Iteration 7 sanity check):
+    `p = 3, q = 5` so `q > p`; the symmetric `p < q` case (S7.5) would
+    handle this. The example below uses the `p > q` case directly with
+    `p = 5, q = 3`: `|G| = 75 = 5² · 3` is solvable axiom-free. -/
+example {G : Type*} [Group G] [Finite G]
+    (hcard : Nat.card G = 75) : IsSolvable G := by
+  haveI : Fact (Nat.Prime 5) := ⟨by decide⟩
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  have hcard' : Nat.card G = 5 ^ 2 * 3 := by rw [hcard]; norm_num
+  exact burnside_p_squared_q_p_gt_q (by decide : (3 : ℕ) < 5) hcard'
+
 -- ═══════════════════════════════════════════════════════════════════════
 -- PART VI: Sharpness witness
 -- ═══════════════════════════════════════════════════════════════════════
@@ -452,6 +554,15 @@ theorem burnside_pq_sharp :
   exhibited.
 - `burnside_pq_with_normal_qSylow` (Iteration 5) — symmetric: a normal
   subgroup of order `qᵇ` gives `IsSolvable G`.
+- `sylow_count_eq_one_of_lt_prime` (Iteration 7, `private`) — Sylow-count
+  helper: `n ∣ q ∧ n ≡ 1 [MOD p] ∧ q < p ⇒ n = 1` (the only divisors of
+  the prime `q` are `1` and `q`, and `q ≡ 1 [MOD p]` forces `p ≤ q - 1`).
+- `burnside_p_squared_q_p_gt_q` (Iteration 7) — Burnside for `|G| = p²·q`
+  in the case `p > q`: Sylow's third theorem (`card_sylow_modEq_one` +
+  `Sylow.card_dvd_index`) forces `n_p = 1`; the unique Sylow `p`-subgroup
+  is normal, then `burnside_pq_with_normal_pSylow` discharges. Axiom-free.
+  This is the first of three sub-cases needed to remove `(a, b) = (2, 1)`
+  from the `burnside_pq_nontrivial` axiom hypothesis.
 - `burnside_pq` — main theorem combining trivial cases + pq case + axiom.
 - `alternatingGroupFin5_card` — `|A₅| = 2² · 3 · 5 = 60` (sharpness witness
   cardinality, three distinct primes).
@@ -495,6 +606,7 @@ theorem burnside_pq_sharp :
 #check @isSolvable_of_normal_quotient_solvable
 #check @burnside_pq_with_normal_pSylow
 #check @burnside_pq_with_normal_qSylow
+#check @burnside_p_squared_q_p_gt_q
 #check @alternatingGroupFin5_card
 #check @alternatingGroupFin5_not_solvable
 #check @burnside_pq_sharp

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -1,61 +1,83 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T07:00:00Z
-**Iteration**: 4
+**Since**: 2026-05-08T15:30:00Z
+**Iteration**: 7
 
 ## Current Focus
 
-Iteration 4 axiom-narrowing committed: `burnside_pq_pq_case` (axiom-free
-`a = b = 1` case) plus `squarefreeOrder_isSolvable` (general squarefree-order
-bridge), backed by Mathlib's `IsZGroup.of_squarefree`. The axiom
-`burnside_pq_nontrivial` was narrowed to require `2 ≤ a ∨ 2 ≤ b`; the
-`a = b = 1` sub-case is no longer axiom-dependent.
+Iteration 7 axiom-free `|G| = p² · q`, case `p > q` committed:
+`burnside_p_squared_q_p_gt_q` plus the private helper
+`sylow_count_eq_one_of_lt_prime`. The axiom `burnside_pq_nontrivial`
+statement is unchanged; this iteration discharges the `(a, b) = (2, 1)`
+shape **whenever `p > q`** axiom-free. The remaining `p < q` case (S7.5)
+and exceptional `(p, q) = (2, 3), |G| = 12` case (S8) follow.
 
 ## Active Approach
 
-The squarefree route exhausts what `IsZGroup` can prove: any squarefree-order
-finite group is solvable (covers `pq`, `pqr`, `pqrs`, …). It does NOT extend
-to `pᵃqᵇ` with `a ≥ 2` or `b ≥ 2`. The next phase is Sylow-analysis-based
-sub-case proofs (`p²q`, `pq²`, `p²q²`) on the way to a full
-Goldschmidt-Matsuyama discharge of the axiom.
+Sylow-counting analysis on `|G| = p² · q`:
+
+- **`p > q` (this iteration)**: `n_p ≡ 1 [MOD p]` (Sylow's third theorem)
+  and `n_p ∣ q` (Sylow's `card_dvd_index`). Since `q` is prime,
+  `n_p ∈ {1, q}`; the case `n_p = q` would force `p ∣ q - 1`, but
+  `q < p` makes that impossible. Hence `n_p = 1`, the unique Sylow
+  `p`-subgroup is normal, and `burnside_pq_with_normal_pSylow` discharges.
+- **`p < q ≠ 3` (S7.5)**: symmetric `n_q = 1` analysis. Three cases for
+  `n_q ∈ {1, p, p²}`; rule out `n_q = p` by `q ∣ p - 1` contradiction
+  with `p < q`; rule out `n_q = p²` via `q ∣ p² - 1` (only `(p, q) = (2, 3)`
+  qualifies, excluded by hypothesis).
+- **Exceptional `(p, q) = (2, 3), |G| = 12` (S8)**: when `n_3 = 4`, count
+  `4 × 2 = 8` elements of order 3; remaining 4 form a unique `V_4`
+  Sylow 2-subgroup, so `n_2 = 1` and the Sylow 2-subgroup is normal.
 
 ## Blockers
 
-The residual axiom (orders divisible by `p²` or `q²` for distinct primes)
-requires either character theory + algebraic-integer hypotheses or
-transfer + focal subgroup theory. Mathlib's `Mathlib.GroupTheory.Focal`
-provides scaffolding for the character-free route (focal subgroup,
-`transferFocal`, `commutator_inf_eq_focalSubgroup`); estimated 200-400
-lines on top of this for full Goldschmidt-Matsuyama.
+The residual axiom (orders divisible by `p²` or `q²` for distinct primes,
+once `(2, 1)` and `(1, 2)` shapes are peeled off) requires either character
+theory + algebraic-integer hypotheses or transfer + focal subgroup theory.
+Mathlib's `Mathlib.GroupTheory.Focal` provides scaffolding for the
+character-free route (focal subgroup, `transferFocal`,
+`commutator_inf_eq_focalSubgroup`); estimated 200-400 lines on top of this
+for full Goldschmidt-Matsuyama.
 
 ## Next Action
 
-1. **(S5)** Prove `|G| = p² · q` axiom-free via Sylow analysis (~50-100 lines).
-   Sylow's third theorem: `n_p ≡ 1 (mod p)` and `n_p | q`; `n_q ≡ 1 (mod q)`
-   and `n_q | p²`. Case-analysis on `(n_p, n_q)` yields a normal Sylow.
-2. **(S6)** Prove `|G| = p · q²` axiom-free (symmetric, ~30-50 lines).
-3. **(S7)** Prove `|G| = p² · q²` axiom-free (~80-150 lines).
-4. **(S8+)** Build Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`.
+1. **(S7.5)** Prove `burnside_p_squared_q_p_lt_q` axiom-free per
+   `session-6-p-squared-q-spec.md` §5 (~40 lines). Two `sorry`s in spec:
+   `n_q ≠ p` (ruled out by `q ∣ p - 1`, `p < q`); `n_q ≠ p²` (ruled out
+   by `q ∣ p² - 1` and exceptional flag).
+2. **(S8)** Prove `burnside_p_squared_q_twelve` for the exceptional case
+   `(p, q) = (2, 3), |G| = 12` via element counting (~70 lines).
+3. **(post-S8)** Augment the main `burnside_pq` dispatch to peel off
+   `(a, b) = (2, 1)` and `(1, 2)` axiom-free before invoking the
+   (further-narrowed) axiom.
+4. **(S9+)** `|G| = p² · q²` Sylow analysis (~150 lines); then
+   Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`.
 
-## Iteration 4 Builds (researcher-1, 2026-05-08)
+## Iteration 7 Builds (researcher-5, 2026-05-08)
 
-- Updated `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (277→384 lines).
-- Added `import Mathlib.GroupTheory.SpecificGroups.ZGroup`.
-- `squarefreeOrder_isSolvable`: axiom-free `Squarefree (Nat.card G) → IsSolvable G`
-  via `IsZGroup.of_squarefree` + `[Finite][IsZGroup] → IsSolvable` instance.
-- `burnside_pq_pq_case`: axiom-free `a = b = 1` case (`|G| = p · q`, `p ≠ q`)
-  via `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`.
-- Narrowed `burnside_pq_nontrivial`: added hypothesis `2 ≤ a ∨ 2 ≤ b`.
-- Updated `burnside_pq` main theorem: `by_cases h11 : a = 1 ∧ b = 1` to peel
-  off the squarefree case axiom-free, then derive `2 ≤ a ∨ 2 ≤ b` for the
-  axiom invocation.
-- 2 new sanity-check examples: `|G| = pq` via `burnside_pq_pq_case`;
-  `|G| = 30` via `squarefreeOrder_isSolvable` (squarefree route beyond two
-  primes).
-- Updated gallery entry meta.json (lineCount 278→384, theoremCount 8→10,
-  axiomCount unchanged at 1, sections updated, originalContributions and
-  assumptions updated).
+- Updated `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`
+  (502→614 lines, 13→15 theorems, 1 axiom unchanged, 0 sorries).
+- Added `import Mathlib.GroupTheory.Sylow`.
+- `sylow_count_eq_one_of_lt_prime` (private helper, ~12 lines): if
+  `n ∣ q` (q prime), `q < p`, `n ≡ 1 [MOD p]`, then `n = 1`. Proof:
+  `Nat.Prime.eq_one_or_self_of_dvd` + `Nat.modEq_iff_dvd'` + `omega`.
+- `burnside_p_squared_q_p_gt_q` (~50 lines, axiom-free): pick a Sylow
+  p-subgroup P, show `|P| = p²` via `Sylow.card_eq_multiplicity` (with
+  factorization computation: `factorization (p²·q) p = 2` via
+  `Nat.factorization_mul_apply_of_coprime` + `Prime.factorization_pow` +
+  `factorization_eq_zero_of_not_dvd`); compute `P.index = q` via
+  `Subgroup.card_mul_index`; derive `n_p = 1` via `card_sylow_modEq_one` +
+  `Sylow.card_dvd_index` + the helper; promote to `Subsingleton` via
+  `Nat.card_eq_one_iff_unique`; `Sylow.normal_of_subsingleton` makes P
+  normal; `burnside_pq_with_normal_pSylow` discharges.
+- New sanity-check example: `|G| = 75 = 5² · 3` axiom-free.
+- Updated gallery entry meta.json (lineCount 502→614, theoremCount 13→15,
+  substantiveTheoremCount 13→15, axiomCount unchanged at 1, added
+  Mathlib.GroupTheory.Sylow import, added 7 new mathlibDependencies for
+  Sylow API, added Part III.6 section, updated assumptions text,
+  added new mainTheorems entry).
 
-**Counts**: lineCount 384, theoremCount 10, axiomCount 1 (narrowed),
-sorries 0.
+**Counts**: lineCount 614, theoremCount 15, substantiveTheoremCount 15,
+axiomCount 1 (unchanged, but `(a, b) = (2, 1)` with `p > q` now
+discharged outside the axiom), sorries 0.

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 502,
+    "lineCount": 614,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -67,6 +67,41 @@
         "theorem": "Nat.coprime_primes",
         "description": "For primes p, q, Coprime p q ↔ p ≠ q.",
         "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "card_sylow_modEq_one",
+        "description": "Sylow's third theorem: the number of Sylow p-subgroups is ≡ 1 modulo p.",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.card_dvd_index",
+        "description": "The number of Sylow p-subgroups of G divides the index of any Sylow p-subgroup.",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.card_eq_multiplicity",
+        "description": "For finite G, the cardinality of a Sylow p-subgroup is p^(p-adic valuation of |G|).",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.normal_of_subsingleton",
+        "description": "If there is at most one Sylow p-subgroup, then it is normal in G.",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Subgroup.card_mul_index",
+        "description": "Lagrange's theorem: |H| · [G : H] = |G|.",
+        "module": "Mathlib.Algebra.Group.Subgroup.Finite"
+      },
+      {
+        "theorem": "Nat.card_eq_one_iff_unique",
+        "description": "Nat.card α = 1 ↔ Subsingleton α ∧ Nonempty α.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Nat.factorization_mul_apply_of_coprime",
+        "description": "For coprime a, b: (a * b).factorization p = a.factorization p + b.factorization p.",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
       }
     ],
     "originalContributions": [
@@ -80,15 +115,18 @@
       "burnside_pq_with_normal_pSylow (Iteration 5): axiom-free reduction tool — if |G| = pᵃ · qᵇ and G admits a normal subgroup of order pᵃ, then G is solvable. Proof: N is a p-group (hence solvable), |G/N| = qᵇ via Lagrange (Subgroup.card_mul_index + cancellation), so G/N is a q-group (hence solvable), and the extension is solvable.",
       "burnside_pq_with_normal_qSylow (Iteration 5): symmetric reduction — a normal subgroup of order qᵇ gives IsSolvable G. Together with burnside_pq_with_normal_pSylow, these two lemmas turn 'exhibit a normal Sylow' into a complete axiom-free discharge of burnside_pq_nontrivial.",
       "Worked example (Iteration 5): |G| = 12 = 2² · 3 with a normal subgroup of order 4 is solvable axiom-free via burnside_pq_with_normal_pSylow — exactly the structure realized by A₄ (whose Klein four-group V₄ ⊂ A₄ is normal of order 4). Demonstrates that the new reduction discharges the previously-axiomatized `2 ≤ a` shape `|G| = p² · q` whenever a normal p-Sylow is exhibited.",
-      "axiom burnside_pq_nontrivial (NARROWED in Iteration 4, unchanged in Iteration 5): the genuinely-open content (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`); the a = b = 1 case is now axiom-free. Iteration 5 leaves the axiom statement unchanged but adds reduction tooling above. Full proof of the residual axiom requires either character theory + algebraic integers (Burnside 1904) or transfer + focal subgroup (Goldschmidt-Matsuyama 1970s) — neither currently in Mathlib at sufficient generality.",
+      "sylow_count_eq_one_of_lt_prime (Iteration 7, private): Sylow-count helper for the `p > q` case of `|G| = p² · q`. Asserts that if n divides a prime q, q < p, and n ≡ 1 [MOD p], then n = 1. Combines Nat.Prime.eq_one_or_self_of_dvd (only divisors of q are 1 and q) with Nat.modEq_iff_dvd' (ruling out n = q since p ≤ q - 1 < p is impossible).",
+      "burnside_p_squared_q_p_gt_q (Iteration 7): axiom-free Burnside for `|G| = p² · q` in the case `p > q`. Sylow's third theorem (card_sylow_modEq_one + Sylow.card_dvd_index) forces n_p ∣ q and n_p ≡ 1 [MOD p]; the helper sylow_count_eq_one_of_lt_prime then forces n_p = 1. The unique Sylow p-subgroup is normal (Sylow.normal_of_subsingleton via Nat.card_eq_one_iff_unique), and burnside_pq_with_normal_pSylow discharges. This is the FIRST of three sub-cases needed to remove `(a, b) = (2, 1)` from the burnside_pq_nontrivial axiom hypothesis. The symmetric `p < q ≠ 3` case (S7.5) and the exceptional `(p, q) = (2, 3), |G| = 12` case (S8) will complete the discharge.",
+      "Worked example (Iteration 7): |G| = 75 = 5² · 3 is solvable axiom-free via burnside_p_squared_q_p_gt_q. Concrete witness for the `p > q` case (p = 5, q = 3).",
+      "axiom burnside_pq_nontrivial (NARROWED in Iteration 4, unchanged in Iterations 5/7): the genuinely-open content (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`); the a = b = 1 case is now axiom-free. Iterations 5 and 7 leave the axiom statement unchanged but add reduction tooling and discharge the `(a, b) = (2, 1)` case for `p > q`. Full proof of the residual axiom requires either character theory + algebraic integers (Burnside 1904) or transfer + focal subgroup (Goldschmidt-Matsuyama 1970s) — neither currently in Mathlib at sufficient generality.",
       "burnside_pq: main theorem combining trivial cases + squarefree case + axiom into the unified statement Nat.card G = p^a · q^b → IsSolvable G.",
-      "Five sanity-check examples: trivial group (|G|=1), prime-order group, prime-power group, |G| = 30 (squarefree three-prime), and |G| = 12 with normal Sylow-2 (A₄-style) — all axiom-free.",
+      "Six sanity-check examples: trivial group (|G|=1), prime-order group, prime-power group, |G| = 30 (squarefree three-prime), |G| = 12 with normal Sylow-2 (A₄-style), and |G| = 75 = 5²·3 (Iteration 7, axiom-free via burnside_p_squared_q_p_gt_q) — all axiom-free.",
       "alternatingGroupFin5_card: axiom-free proof that |A₅| = 2²·3·5, exhibiting the three distinct prime factors that make A₅ a sharpness witness.",
       "alternatingGroupFin5_not_solvable: axiom-free proof that A₅ is not solvable, via reduction to Equiv.Perm.not_solvable (Fin 5) through the short exact sequence A₅ → S₅ → ℤ/2.",
       "burnside_pq_sharp: sharpness witness combining the two above — demonstrates that the analogue of burnside_pq for THREE distinct primes fails (no `burnside_pqr` theorem can hold without further hypotheses; A₅ also defeats the squarefree route since 60 has 2²)."
     ],
-    "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iteration 5): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited; this is a strict shortcut for any future case-by-case Sylow-counting analysis (`|G| = p² · q`, `|G| = p · q²`, …). The axiom statement itself is unchanged: it still isolates the genuinely-open Lean content (orders divisible by `p²` or `q²` for distinct primes); a full proof would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route).",
-    "theoremCount": 13,
+    "assumptions": "1 axiom (narrowed in Iteration 4, unchanged in Iterations 5/7): `burnside_pq_nontrivial` — Burnside's pᵃqᵇ theorem for the residual non-trivial case (`p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`). The trivial cases (`a = 0`, `b = 0`, `p = q`) reduce to Mathlib's `IsPGroup → IsNilpotent → IsSolvable`; the `a = b = 1` case (squarefree |G| = p·q) reduces to `IsZGroup.of_squarefree → IsSolvable`. Iteration 5 adds two axiom-free reduction lemmas (`burnside_pq_with_normal_pSylow`, `burnside_pq_with_normal_qSylow`) that discharge the axiom outright whenever a normal Sylow subgroup of either prime can be exhibited; this is a strict shortcut for any future case-by-case Sylow-counting analysis (`|G| = p² · q`, `|G| = p · q²`, …). Iteration 7 adds the FIRST sub-case discharge of the `(a, b) = (2, 1)` shape: `burnside_p_squared_q_p_gt_q` proves Burnside axiom-free whenever `|G| = p² · q` with `p > q`, by combining Sylow's third theorem (`card_sylow_modEq_one`) with `Sylow.card_dvd_index` to force `n_p = 1`, then plugging into `burnside_pq_with_normal_pSylow`. The symmetric `p < q ≠ 3` case (S7.5) and the exceptional `(p, q) = (2, 3), |G| = 12` case (S8) are the remaining S-iterations needed to remove `(a, b) = (2, 1)` from the axiom hypothesis entirely. The axiom statement itself is unchanged: it still isolates the genuinely-open Lean content (orders divisible by `p²` or `q²` for distinct primes); a full proof would be a substantial Mathlib upstream contribution (estimated 400-1000 lines, depending on proof route).",
+    "theoremCount": 15,
     "definitionCount": 0
   },
   "overview": {
@@ -116,56 +154,72 @@
     {
       "id": "p-group-chain",
       "title": "Part I: p-group lemma (axiom-free)",
-      "startLine": 50,
-      "endLine": 60,
+      "startLine": 54,
+      "endLine": 64,
       "summary": "`pGroup_isSolvable`: for any finite group `G` with `IsPGroup p G` (and `Fact p.Prime`), `IsSolvable G`. Single-line proof via `IsPGroup.isNilpotent` + `infer_instance` for `IsNilpotent → IsSolvable`. Axiom-free.",
       "mathContext": "$p$-groups are nilpotent (an inductive consequence of the non-trivial centre), and nilpotent groups are solvable (the lower central series refines the derived series). Both facts are in Mathlib."
     },
     {
       "id": "trivial-cases",
       "title": "Part II: Trivial cases (a = 0, b = 0, p = q)",
-      "startLine": 65,
-      "endLine": 98,
+      "startLine": 66,
+      "endLine": 99,
       "summary": "`burnside_pq_a_zero`: when $a = 0$, $|G| = q^b$ so $G$ is a $q$-group; apply Part I. `burnside_pq_b_zero`: symmetric to $a = 0$. `burnside_pq_same_prime`: when $p = q$, $|G| = p^{a+b}$ so $G$ is a $p$-group of combined exponent. All three axiom-free.",
       "mathContext": "These cases are all instances of $|G| = $ prime power, hence covered by Part I. The arithmetic step is: $p^0 \\cdot q^b = q^b$, $p^a \\cdot q^0 = p^a$, $p^a \\cdot p^b = p^{a+b}$ — each obtained via `simpa` or `pow_add`."
     },
     {
       "id": "squarefree-case",
       "title": "Part II.5: Squarefree-order case (axiom-free, via IsZGroup)",
-      "startLine": 100,
-      "endLine": 152,
+      "startLine": 101,
+      "endLine": 142,
       "summary": "`squarefreeOrder_isSolvable`: bridges `Squarefree (Nat.card G) → IsSolvable G` via Mathlib's `IsZGroup.of_squarefree` + `[IsZGroup G] [Finite G] → IsSolvable G` instance. `burnside_pq_pq_case`: specializes to `a = b = 1` (`|G| = p · q`, `p ≠ q`) using `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`. Both axiom-free.",
       "mathContext": "A finite group of squarefree order is a Z-group (every Sylow subgroup is cyclic), and Z-groups are solvable. This subsumes the `a = b = 1` Burnside case (`|G| = pq` is squarefree when `p ≠ q` are prime) and extends beyond two primes for squarefree orders (e.g. `|G| = 30 = 2·3·5` is solvable axiom-free). It does NOT extend to `|G| = pᵃqᵇ` with `a ≥ 2` or `b ≥ 2`: `p²` violates squarefreeness, so the `2 ≤ a ∨ 2 ≤ b` case still needs new infrastructure."
     },
     {
       "id": "axiom",
       "title": "Part III: Non-trivial case (axiomatized, narrowed to 2 ≤ a ∨ 2 ≤ b)",
-      "startLine": 154,
-      "endLine": 188,
+      "startLine": 144,
+      "endLine": 176,
       "summary": "`burnside_pq_nontrivial`: axiom asserting Burnside's theorem in the residual case `p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`. The hypothesis was narrowed in Iteration 4: the `a = b = 1` sub-case is now axiom-free (Part II.5). Carries proof sketches for both the character-theoretic (Burnside 1904) and character-free (Goldschmidt-Matsuyama 1970s) routes.",
       "mathContext": "This is the genuinely-open Lean content: orders divisible by `p²` or `q²` for distinct primes. A formalized proof would be a substantial Mathlib upstream contribution (~400-1000 lines depending on route)."
     },
     {
+      "id": "normal-sylow-reductions",
+      "title": "Part III.5: Normal-Sylow reductions (axiom-free, Iteration 5)",
+      "startLine": 178,
+      "endLine": 263,
+      "summary": "`isSolvable_of_normal_quotient_solvable`: solvability is closed under group extensions (repackaging `solvable_of_ker_le_range` against `1 → N → G → G/N → 1`). `burnside_pq_with_normal_pSylow`: if `|G| = pᵃqᵇ` and `G` admits a normal subgroup of order `pᵃ`, then `G` is solvable (axiom-free). `burnside_pq_with_normal_qSylow`: symmetric reduction via a normal subgroup of order `qᵇ`.",
+      "mathContext": "These reductions turn 'exhibit a normal Sylow subgroup' into a complete axiom-free discharge of `burnside_pq_nontrivial`. Combined with Sylow-counting analyses on specific shapes (`|G| = p² · q`, `|G| = p · q²`, …), they enable axiom-free closure of those cases — as concretely realized in Part III.6."
+    },
+    {
+      "id": "p-squared-q",
+      "title": "Part III.6: |G| = p² · q axiom-free, case `p > q` (Iteration 7)",
+      "startLine": 265,
+      "endLine": 354,
+      "summary": "`sylow_count_eq_one_of_lt_prime` (private helper): if `n ∣ q` (q prime), `n ≡ 1 [MOD p]`, and `q < p`, then `n = 1`. `burnside_p_squared_q_p_gt_q`: axiom-free Burnside for `|G| = p² · q` in the case `p > q` — Sylow's third theorem (`card_sylow_modEq_one` + `Sylow.card_dvd_index`) forces `n_p = 1`; the unique Sylow `p`-subgroup is normal (`Sylow.normal_of_subsingleton`); `burnside_pq_with_normal_pSylow` discharges.",
+      "mathContext": "First sub-case of `|G| = p² · q`. By Sylow's third theorem, `n_p ≡ 1 [MOD p]` and `n_p ∣ q`. Since `q` is prime, `n_p ∈ {1, q}`; the case `n_p = q` would require `q ≡ 1 [MOD p]`, i.e. `p ∣ q - 1`, contradicting `q < p`. The remaining sub-cases (`p < q ≠ 3` symmetric, exceptional `(p, q) = (2, 3) |G| = 12`) are tracked for S7.5/S8."
+    },
+    {
       "id": "main-theorem",
       "title": "Part IV: Main theorem",
-      "startLine": 190,
-      "endLine": 231,
+      "startLine": 356,
+      "endLine": 396,
       "summary": "`burnside_pq`: combines the three axiom-free trivial cases with the squarefree-order case (a = b = 1) and the conjectural `burnside_pq_nontrivial` axiom into the unified statement `Nat.card G = p^a · q^b → IsSolvable G`. Case-splits on `a = 0`, `b = 0`, `p = q`, then `a = 1 ∧ b = 1` (axiom-free), with the residue dispatched to the (narrowed) axiom.",
       "mathContext": "The case split is exhaustive: any combination of $(a, b, p, q)$ with $a = 0$ or $b = 0$ or $p = q$ falls into Part II; `a = b = 1` with `p ≠ q` falls into Part II.5; the residue (`p ≠ q`, `2 ≤ a ∨ 2 ≤ b`) is exactly the axiom's hypothesis."
     },
     {
       "id": "sanity-checks",
       "title": "Part V: Sanity checks",
-      "startLine": 233,
-      "endLine": 281,
-      "summary": "Four `example`s that exercise the axiom-free portions of the file at the boundaries: trivial group ($|G| = 1 = 2^0 \\cdot 3^0$), prime-order group ($|G| = p = p^1 \\cdot 2^0$), pure prime-power group ($|G| = p^a = p^a \\cdot 2^0$), and squarefree three-prime group ($|G| = 30 = 2 \\cdot 3 \\cdot 5$). The first three use `burnside_pq` directly; the fourth uses `squarefreeOrder_isSolvable`.",
-      "mathContext": "These examples never invoke the axiom — they confirm that the trivial-case branches handle all degenerate cardinalities sensibly, AND that the squarefree route extends beyond two primes."
+      "startLine": 398,
+      "endLine": 471,
+      "summary": "Six `example`s that exercise the axiom-free portions of the file at the boundaries: trivial group ($|G| = 1 = 2^0 \\cdot 3^0$), prime-order group ($|G| = p = p^1 \\cdot 2^0$), pure prime-power group ($|G| = p^a = p^a \\cdot 2^0$), `|G| = pq` squarefree, three-prime squarefree ($|G| = 30 = 2 \\cdot 3 \\cdot 5$), `|G| = 12` with normal Sylow-2 (A₄-style), and the new Iteration-7 example `|G| = 75 = 5^2 \\cdot 3` axiom-free via `burnside_p_squared_q_p_gt_q`.",
+      "mathContext": "These examples never invoke the axiom — they confirm that the trivial-case branches, the squarefree route, and the new `p² · q` (`p > q`) discharge all handle their respective shapes axiom-free."
     },
     {
       "id": "sharpness",
       "title": "Part VI: Sharpness witness",
-      "startLine": 285,
-      "endLine": 333,
+      "startLine": 473,
+      "endLine": 528,
       "summary": "`alternatingGroupFin5_card`: $|A_5| = 2^2 \\cdot 3 \\cdot 5$ via `Nat.card_eq_fintype_card` + `native_decide`. `alternatingGroupFin5_not_solvable`: A₅ is not solvable, via `solvable_of_ker_le_range (alternatingGroup (Fin 5)).subtype Equiv.Perm.sign` then `Equiv.Perm.not_solvable (Fin 5)`. `burnside_pq_sharp`: conjunction of the two — the canonical sharpness witness.",
       "mathContext": "Burnside permits at most TWO distinct prime factors. $|A_5| = 60 = 2^2 \\cdot 3 \\cdot 5$ has three distinct primes — exactly one more — and A₅ is the smallest non-solvable group. So `burnside_pq` is sharp: no extension to three distinct primes can hold. A₅ ALSO defeats the squarefree route (`squarefreeOrder_isSolvable` does not apply since 60 has $2^2$). The proof uses the kernel-of-sign + range-of-subtype short exact sequence A₅ → S₅ → ℤ/2 to lift solvability of A₅ to S₅, then contradicts the Mathlib fact `Equiv.Perm.not_solvable` for $n \\geq 5$."
     }
@@ -203,16 +257,17 @@
       "Mathlib.GroupTheory.PGroup",
       "Mathlib.GroupTheory.Solvable",
       "Mathlib.GroupTheory.Nilpotent",
+      "Mathlib.GroupTheory.Sylow",
       "Mathlib.GroupTheory.SpecificGroups.Alternating",
       "Mathlib.GroupTheory.SpecificGroups.ZGroup",
       "Mathlib.Tactic"
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 502,
+    "lineCount": 614,
     "axiomCount": 1,
-    "theoremCount": 13,
-    "substantiveTheoremCount": 13,
+    "theoremCount": 15,
+    "substantiveTheoremCount": 15,
     "definitionCount": 0,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
     "sorries": 0
@@ -248,6 +303,11 @@
       "name": "burnside_pq",
       "statement": "∀ {G : Type*} [Group G] [Finite G] {p q : ℕ} [Fact p.Prime] [Fact q.Prime] {a b : ℕ}, Nat.card G = p^a · q^b → IsSolvable G",
       "description": "Burnside's pᵃqᵇ theorem. Combines axiom-free trivial cases with the conjectural `burnside_pq_nontrivial` axiom."
+    },
+    {
+      "name": "burnside_p_squared_q_p_gt_q",
+      "statement": "∀ {G : Type*} [Group G] [Finite G] {p q : ℕ} [Fact p.Prime] [Fact q.Prime], q < p → Nat.card G = p^2 · q → IsSolvable G",
+      "description": "Iteration 7 axiom-free discharge: Burnside for `|G| = p² · q` in the case `p > q`. Sylow's third theorem forces n_p = 1 (the only divisor of q that is ≡ 1 [MOD p] is 1, since q < p); the unique Sylow p-subgroup is normal, then `burnside_pq_with_normal_pSylow` discharges. First of three sub-cases needed to remove `(a, b) = (2, 1)` from `burnside_pq_nontrivial`'s hypothesis."
     },
     {
       "name": "burnside_pq_sharp",

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -29,16 +29,16 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-08T07:00:00.000Z",
-    "iteration": 6,
-    "focus": "S6 (researcher-12, 2026-05-08): `|G| = p² · q` axiom-free SPECIFICATION written to `research/problems/abel-ruffini-galois-extensions-oq-07/session-6-p-squared-q-spec.md`. Three sub-cases identified: (1) `p > q` via `n_p = 1` from Sylow's third theorem (`n_p ≡ 1 [MOD p]` + `n_p ∣ q < p`); (2) `p < q ≠ 3` via symmetric `n_q = 1` analysis; (3) exceptional `(p, q) = (2, 3), |G| = 12` via element counting (when `n_3 = 4`, the unique Sylow 2-subgroup V_4 is normal). Mathlib API verified (`Sylow.card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Sylow.normal_of_subsingleton`, `Sylow.card_eq_multiplicity`); the existing S5 helpers `burnside_pq_with_normal_pSylow`/`qSylow` discharge cases (1) and (2) directly. Build-ready Lean 4 skeleton with 4 mechanical `sorry`s (factorization, n_q ≠ p ruled out by p < q, n_q ≠ p² ruled out by exceptional flag, exceptional element counting). Estimated ~150-180 new lines. Lean prototype deferred to S7 pending `.lake` symlink repair. S5 (PR #16972) merged successfully; file now 502 lines / 13 theorems / 1 axiom (narrowed to 2 ≤ a ∨ 2 ≤ b) / 0 sorries.",
+    "since": "2026-05-08T15:30:00.000Z",
+    "iteration": 7,
+    "focus": "S7 (researcher-5, 2026-05-08): **`|G| = p² · q`, case `p > q` axiom-free COMMITTED**. Added Part III.6 to AbelRuffiniGaloisExtensionsOQ07.lean (502→614 lines, 13→15 theorems, 1 axiom unchanged, 0 sorries). Two new theorems: `sylow_count_eq_one_of_lt_prime` (private helper, ~12 lines: if n ∣ q (q prime), q < p, n ≡ 1 [MOD p], then n = 1) and `burnside_p_squared_q_p_gt_q` (~50 lines, axiom-free): pick a Sylow p-subgroup P with |P| = p² via `Sylow.card_eq_multiplicity` + factorization (discharge of S6 spec sorry 1 inline); compute its index q via `Subgroup.card_mul_index`; combine `card_sylow_modEq_one` + `Sylow.card_dvd_index` + helper to get n_p = 1; promote to `Subsingleton (Sylow p G)` via `Nat.card_eq_one_iff_unique`; close via `Sylow.normal_of_subsingleton` + `burnside_pq_with_normal_pSylow`. Added Mathlib.GroupTheory.Sylow import. New sanity-check example: |G| = 75 = 5²·3 axiom-free.",
     "blockers": [
       "Mathlib lacks: (1) the algebraic-integer lemma `|G|/χ(1) ∈ ℤ̄_K` for a non-trivial irreducible character χ on a non-conjugacy class, key for the original Burnside proof; (2) the focal subgroup theorem and transfer-based character-free Burnside proof (Goldschmidt/Matsuyama). Note: Mathlib has `Mathlib.GroupTheory.Focal` (focal subgroup definition + transfer to focal quotient), so partial scaffolding exists for the character-free route.",
       "Mathlib's character theory needs algebraically-closed-field hypotheses; concretizing for ℂ-valued characters requires `Complex` ↔ `IsAlgClosed` bridge already in Mathlib but care needed."
     ],
-    "nextAction": "S7: prototype `burnside_p_squared_q_p_gt_q` per `session-6-p-squared-q-spec.md` §4 + helper §3. Discharge sorry 1 (factorization). Run Docker build with `LEAN_BUILD_TIMEOUT=60m`. ~50 lines. Then S7.5 adds `burnside_p_squared_q_p_lt_q` (~40 lines) and S8 adds the exceptional `|G| = 12` case (~70 lines). After all three sub-cases land, the axiom hypothesis can be tightened to exclude (a, b) = (2, 1) and (1, 2). Beyond p²·q and p·q²: S9 = `|G| = p² · q²` Sylow analysis (~150 lines); S10+ = Goldschmidt-Matsuyama via `Mathlib.GroupTheory.Focal` for residual `a ≥ 3 ∨ b ≥ 3` cases.",
+    "nextAction": "S7.5: prototype `burnside_p_squared_q_p_lt_q` per `session-6-p-squared-q-spec.md` §5 (~40 lines, two `sorry`s in the spec to discharge). Then S8: add the exceptional `(p, q) = (2, 3), |G| = 12` case per §6 (~70 lines, element counting). After S7+S7.5+S8, the `(a, b) = (2, 1)` and `(1, 2)` shapes can be peeled off `burnside_pq_nontrivial` axiom-free; the main theorem `burnside_pq` can then be augmented to peel them off before invoking the axiom. Beyond p²·q and p·q²: S9 = `|G| = p² · q²` Sylow analysis (~150 lines); S10+ = Goldschmidt-Matsuyama via `Mathlib.GroupTheory.Focal` for residual `a ≥ 3 ∨ b ≥ 3` cases.",
     "attemptCounts": {
-      "total": 6,
+      "total": 7,
       "currentApproach": 1,
       "approachesTried": 1
     }
@@ -153,7 +153,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.054Z",
-  "lastUpdate": "2026-05-08T10:25:00.000Z",
+  "lastUpdate": "2026-05-08T15:30:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Iteration 7 of `abel-ruffini-galois-extensions-oq-07` (Burnside's pᵃqᵇ theorem). **Axiom-free discharge** of `burnside_pq_nontrivial` for the shape `|G| = p² · q` in the case `p > q`. The axiom `burnside_pq_nontrivial` statement is **unchanged** — this iteration adds a parallel axiom-free path that handles `(a, b) = (2, 1)` whenever `p > q`.

This is the FIRST of three sub-cases (per `session-6-p-squared-q-spec.md`) needed to fully remove `(a, b) = (2, 1)` from the axiom hypothesis. After S7.5 (symmetric `p < q ≠ 3`) and S8 (exceptional `|G| = 12`) land, the main `burnside_pq` dispatch can be augmented to peel `(a, b) = (2, 1)` off axiom-free.

## New theorems (axiom-free)

- **`sylow_count_eq_one_of_lt_prime`** (private helper, ~12 lines) — if `n ∣ q` (q prime), `q < p`, and `n ≡ 1 [MOD p]`, then `n = 1`. Proof combines `Nat.Prime.eq_one_or_self_of_dvd` (only divisors of `q` are `1, q`) with `Nat.modEq_iff_dvd'` (ruling out `n = q` since `p ≤ q - 1 < p` is impossible).

- **`burnside_p_squared_q_p_gt_q`** (~50 lines, axiom-free) — Burnside for `|G| = p² · q` in the case `p > q`. Five-step proof:
  1. Pick a Sylow `p`-subgroup `P`; compute `|P| = p²` via `Sylow.card_eq_multiplicity` + factorization (`Nat.factorization_mul_apply_of_coprime` + `Nat.Prime.factorization_pow` + `Nat.factorization_eq_zero_of_not_dvd`).
  2. Compute `P.index = q` via `Subgroup.card_mul_index` and cancellation.
  3. Derive `n_p = 1` from `card_sylow_modEq_one` (`n_p ≡ 1 [MOD p]`) + `Sylow.card_dvd_index` (`n_p ∣ q`) + the helper.
  4. Promote `n_p = 1` to `Subsingleton (Sylow p G)` via `Nat.card_eq_one_iff_unique`.
  5. `Sylow.normal_of_subsingleton P` makes `P` normal; `burnside_pq_with_normal_pSylow` (S5) discharges, treating `|G| = p² · q¹`.

## Worked example

`|G| = 75 = 5² · 3` is solvable axiom-free (`p = 5, q = 3`, `q < p`).

## Counts

| Field | Before | After | Δ |
|---|---|---|---|
| theoremCount | 13 | 15 | +2 |
| substantiveTheoremCount | 13 | 15 | +2 |
| lineCount | 502 | 614 | +112 |
| axiomCount | 1 | 1 | 0 |
| sorries | 0 | 0 | 0 |

The added theorems are 1 substantive `theorem` + 1 `private lemma`. Both axiom-free; the existing axiom statement is unchanged.

## Strategic value

After S7 + S7.5 + S8 land, the `burnside_pq_nontrivial` hypothesis tightens from `2 ≤ a ∨ 2 ≤ b` to exclude both `(a, b) = (2, 1)` and `(1, 2)`. Sequential follow-ons (`p² · q²`, then Goldschmidt-Matsuyama for `a ≥ 3 ∨ b ≥ 3`) are sketched in §10 of the S6 spec.

## Test plan

- [x] Docker build succeeds (`./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ07`) — 3073/3073 jobs, all theorems compile and `#check` lines confirm types.
- [x] No new sorries (still 0).
- [x] No new axioms (still 1, statement unchanged).
- [x] meta.json counts match Lean file (lineCount 614, theoremCount 15, substantiveTheoremCount 15, axiomCount 1).
- [x] All 6 sanity-check examples compile axiom-free (including new |G| = 75 example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)