### PR TITLE
fix(deploy): skip draft PRs in merge step

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -149,14 +149,16 @@ merge_prs() {
     local merged=0
     local failed=0
 
-    # Skip PRs with loom:review-requested — those are opted into Loom Judge review
-    local jq_filter='[.[] | select(.labels | map(.name) | any(. == "loom:review-requested") | not)]'
-    local all_prs=$(gh pr list --limit 100 --json number,mergeable,labels)
+    # Skip drafts (researcher "build pending" PRs) and PRs with loom:review-requested
+    # (those are opted into Loom Judge review).
+    local jq_filter='[.[] | select(.isDraft | not) | select(.labels | map(.name) | any(. == "loom:review-requested") | not)]'
+    local all_prs=$(gh pr list --limit 100 --json number,mergeable,labels,isDraft)
     local eligible_prs=$(echo "$all_prs" | jq "$jq_filter")
     local total=$(echo "$eligible_prs" | jq 'length')
-    local skipped=$(echo "$all_prs" | jq "length - ($total)")
+    local drafts=$(echo "$all_prs" | jq '[.[] | select(.isDraft)] | length')
+    local review_requested=$(echo "$all_prs" | jq '[.[] | select(.isDraft | not) | select(.labels | map(.name) | any(. == "loom:review-requested"))] | length')
 
-    print_info "Found $total eligible PRs ($skipped skipped — loom:review-requested)"
+    print_info "Found $total eligible PRs ($drafts drafts skipped, $review_requested loom:review-requested skipped)"
 
     if [[ $total -eq 0 ]]; then
         print_success "No PRs to merge"


### PR DESCRIPTION
## Summary

Researchers open draft PRs marked "build pending" until verified. The deploy script's merge loop ran `gh pr merge` on those and got `Pull Request is still a draft` errors, counting them as failures.

This adds `isDraft` to the `gh pr list` query in `merge_prs()` and filters drafts out alongside `loom:review-requested`, so each cycle only attempts merges that can actually succeed.

## Test plan

Simulated against live PRs (n=85):
- 9 drafts skipped (researcher "build pending" PRs)
- 2 `loom:review-requested` skipped
- 74 eligible, 9 currently `MERGEABLE`

Without this fix, the merge step would attempt 5 of those 9 drafts and fail each one. Verified the new log line reads e.g. `Found 74 eligible PRs (9 drafts skipped, 2 loom:review-requested skipped)`.

## Notes

- The `CONFLICTING` and `UNKNOWN` paths only loop over `eligible_prs`, so they automatically inherit the new filter.
- No behavior change for non-draft PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)