### PR TITLE
audit(tracker): cube-root-3-irrational — 3rd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2242,9 +2242,9 @@
       "result": "clean"
     },
     "cube-root-3-irrational": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:46Z",
+      "lastAudited": "2026-05-08T16:20:00Z",
       "result": "clean"
     },
     "cube-root-3-irrational-oq-02": {


### PR DESCRIPTION
## Summary

Re-audited `cube-root-3-irrational` (third audit; previous: 2026-04-24).

**Verified counts**: 83 lines, 5 theorems, 1 def, 0 axioms, 0 sorries — match meta.json exactly.
**Narrative integrity**: Description, assumptions, and conclusion all transparently credit Mathlib's `irrational_nrt_of_notint_nrt`. Status `verified` + badge `original` are appropriate — the non-perfect-cube argument via integer bounds is original work in this file; Mathlib is used only for the final `Irrational` wrapper.
**No issues found**.

Bumps `auditCount` 2 → 3 and `lastAudited` to 2026-05-08T16:20:00Z.

## Test plan

- [x] `find-targets.ts --next` returned this slug
- [x] Verified line/theorem/def/axiom/sorry counts against `git show origin/main:proofs/Proofs/CubeRoot3Irrational.lean`
- [x] Spot-checked all 5 theorems compile-clean (no `True` stubs, no `sorry`)
- [x] Tracker diff is 2-line surgical (no unicode re-encoding noise)