### PR TITLE
Enrich elementary-quadratic-reciprocity-oq-01-oq-01-oq-02: deeper history, class-field-theoretic insight, examples annotation

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/annotations.json
@@ -60,6 +60,18 @@
     "prerequisites": ["Euler's criterion", "Legendre symbol", "QR statement"]
   },
   {
+    "id": "ann-concrete-examples",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
+    "range": { "startLine": 172, "endLine": 201 },
+    "type": "insight",
+    "title": "Worked Examples: (5,3), (7,5), (11,7)",
+    "content": "Three `example` declarations exhibit the abstract theorems on concrete prime pairs:\n\n• **(p=5, q=3)** in any char-3 field: τ^3 = χ₅(3)·τ. Discharged by `frobenius_step χ hχ ψ (by norm_num)` — `norm_num` certifies the side-condition `5 ≠ 3`.\n• **(p=7, q=5)** in any char-5 field: τ^5 = χ₇(5)·τ. Same shape.\n• **(p=11, q=7)** in ZMod 7: (χ₁₁(-1)·11)^3 = χ₁₁(7). The QR cross-check: 11 ≡ 4 (mod 7) makes (11/7)=1; 11 ≡ 3 (mod 4) makes (-1/11)=-1; QR predicts (11/7)·(7/11) = (-1)^{((11-1)/2)·((7-1)/2)} = (-1)^{5·3} = -1, matching (-1)·(7/11) = (7/11) = ?... resolvable to -1.\n\nFour `private instance factPrime{3,5,7,11}` declarations (lines 172-175) supply the `[Fact p.Prime]` instances that the variable block depends on; `decide` is enough since the primes are concrete numerals.",
+    "mathContext": "QR check tables for the three pairs:\n\\begin{array}{c|c|c|c}\n(p,q) & (p/q) & (q/p) & (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}} \\\\\\\\ \\hline\n(5,3) & (5/3)=(2/3)=-1 & (3/5)=-1 & (-1)^{2\\cdot 1}=1 \\\\\\\\\n(7,5) & (7/5)=(2/5)=-1 & (5/7)=-1 & (-1)^{3\\cdot 2}=1 \\\\\\\\\n(11,7)& (11/7)=(4/7)=1 & (7/11)=-1 & (-1)^{5\\cdot 3}=-1 \\\\\\\\\n\\end{array}\nIn each case $(p/q)(q/p) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$, as QR demands.",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete QR verification", "norm_num", "Fact.Prime instances", "Legendre symbol values"],
+    "prerequisites": ["QR statement", "Legendre symbol computation", "decide tactic"]
+  },
+  {
     "id": "ann-pathway",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-02",
     "range": { "startLine": 156, "endLine": 175 },

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -112,7 +112,7 @@
     }
   ],
   "overview": {
-    "historicalContext": "The Law of Quadratic Reciprocity was conjectured by Euler (1744) and first proved by Gauss at age 18 (1796). Gauss found six distinct proofs over his lifetime. The seventh proof — using Gauss sums — was sketched by Gauss and completed by Eisenstein in 1844. The key step is τ^q = (q/p)·τ, which follows from the Frobenius automorphism in characteristic q. Mathlib’s algebraic formalization makes this generalization from ℂ to any char-q field explicit.",
+    "historicalContext": "The Law of Quadratic Reciprocity was conjectured by Euler (1744, in his correspondence with Goldbach) and Legendre (1785, in *Recherches d'analyse indéterminée*). Gauss gave the first complete proof at age 18 (1796) using induction on the smaller prime; he was so taken with the result that he called it the *aureum theorema* (\"golden theorem\") and produced six distinct proofs over his lifetime, published from the *Disquisitiones Arithmeticae* (1801) onward. The seventh proof — and the conceptual cornerstone of modern number theory — uses Gauss sums τ = Σχ(a)e^{2πia/p}: the identity τ² = χ(-1)·p (in ℂ) was proved by Gauss in 1811 (`Summatio quarundam serierum singularium`), and the Frobenius step τ^q = χ(q)·τ was first explicitly used by Eisenstein in 1844 to give a streamlined proof. The key conceptual leap, due to Hilbert, Hecke, and Artin in the early 20th century, was reinterpreting the Gauss sum proof inside the cyclotomic field ℚ(ζ_p): the Frobenius element of Gal(ℚ(ζ_p)/ℚ) over q acts on τ as multiplication by χ(q), making QR an instance of Artin reciprocity for the cyclotomic extension. Mathlib's `gaussSum_frob` and `Char.card_pow_card` formalize the algebraic core of this argument — abstracting away from ℂ and from cyclotomic embeddings — so that the same proof works in *any* characteristic-q field, exactly as Eisenstein's original argument did once divorced from the analytic origins. This entry uses these APIs to discharge the four-step pathway with 0 sorries and 0 axioms.",
     "problemStatement": "**Open Question**: Formalize Step 3 of the Gauss sum QR proof: τ^q = χ(q)·τ in any field F of characteristic q, and derive the full QR identity. **Answer**: YES — `MulChar.IsQuadratic.gaussSum_frob` proves Step 3; `Char.card_pow_card` assembles QR. 0 sorries, 0 axioms.",
     "proofStrategy": "**Auxiliary**: q_isUnit_in_ZMod_p (q invertible mod p, needed for reparametrization). **Part I** (frobenius_step): Frobenius φ: x↦x^q is a ring hom in char q; τ^q = Σ_a χ(a)ψ(qa) = χ(q)·τ (reparametrize b=qa). **Part II**: Combine with τ²=χ(-1)·p via Char.card_pow_char_pow. **Part III**: Full QR in ZMod q via Char.card_pow_card.",
     "keyInsights": [
@@ -120,7 +120,9 @@
       "**χ^q = χ in char q**: Since χ(a) ∈ {0,±1} and (-1)^q = -1 in char q, χ(a)^q = χ(a) — quadratic characters are fixed by Frobenius.",
       "**Reparametrization by q is a bijection**: b=qa is a bijection on ZMod p (q a unit mod p), allowing Σ_a χ(a)ψ(qa) = χ(q)·Σ_b χ(b)ψ(b) by change of variables.",
       "**Euler’s criterion encodes QR**: The identity (χ(-1)·p)^{(q-1)/2} = χ(q) in ZMod q encodes (-1/p)·(p/q) = (q/p), i.e., QR, via Euler’s criterion a^{(q-1)/2} ≡ (a/q) mod q.",
-      "**Algebraic generality**: The classical proof uses ψ(a) = e^{2πia/p} in ℂ. Mathlib’s MulChar/AddChar typeclasses generalize to any field F of characteristic q — the same argument works with no changes."
+      "**Algebraic generality**: The classical proof uses ψ(a) = e^{2πia/p} in ℂ. Mathlib’s MulChar/AddChar typeclasses generalize to any field F of characteristic q — the same argument works with no changes.",
+      "**Class-field-theoretic interpretation**: τ^q = χ(q)·τ is a shadow of Artin reciprocity for the cyclotomic field ℚ(ζ_p) — the Frobenius element Frob_q ∈ Gal(ℚ(ζ_p)/ℚ) acts on the Gauss sum by χ(q), exactly as it acts on χ as a Hecke character. Reading QR through this lens (Hilbert, Hecke, Artin) is what made Gauss's seventh proof the prototype for higher reciprocity laws and ultimately the Langlands program.",
+      "**Why characteristic q matters operationally**: Working in a field F of characteristic q rather than in ℤ/qℤ embedded in ℂ lets the freshman's dream (a+b)^q = a^q + b^q hold *strictly* (not just modulo q), so τ^q can be computed term-by-term without auxiliary congruence bookkeeping. Mathlib's `CharP F q` typeclass packages this so the proof is genuinely a one-liner once the right API exists."
     ],
     "prerequisites": [
       "Multiplicative characters (MulChar): ZMod p → F, Legendre symbol as algebra",
@@ -136,25 +138,31 @@
     "openQuestions": [
       "Can the four steps be assembled into a single self-contained proof of the Law of Quadratic Reciprocity without referencing OQ01OQ01OQ01?",
       "Extend to cubic reciprocity: formalize τ^q = J(χ,χ)·τ for cubic characters using Jacobi sums",
-      "Can the Gauss sum approach yield QR for function fields 𝔽_q[t]?"
+      "Can the Gauss sum approach yield QR for function fields 𝔽_q[t]?",
+      "Can `MulChar.IsQuadratic.gaussSum_frob` be repackaged as the Frobenius action on a cyclotomic Gauss sum, exposing the Artin-reciprocity content as an explicit Lean theorem `Frob_q · τ = χ(q) · τ` over Gal(ℚ(ζ_p)/ℚ)?",
+      "Is there a Mathlib-level statement of QR for arbitrary global fields (number fields and function fields) that the Gauss sum proof can be adapted to discharge?"
     ]
   },
   "crossReferences": [
     {
       "id": "elementary-quadratic-reciprocity-oq-01-oq-01",
-      "relationship": "parent — outlines the full four-step Gauss sum pathway for QR"
+      "title": "Gauss Sum QR Pathway (Four-Step Outline)",
+      "relationship": "parent — outlines the full four-step Gauss sum pathway for QR; this entry discharges Step 3 (τ^q = χ(q)·τ)."
     },
     {
       "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
-      "relationship": "sibling — proves Step 2 (τ² = χ(-1)·p) which this file's qr_via_frobenius assumes"
+      "title": "Gauss Sum Squared: τ² = χ(-1)·p",
+      "relationship": "sibling — proves Step 2 (τ² = χ(-1)·p) which this file's qr_via_frobenius takes as a hypothesis."
     },
     {
       "id": "elementary-quadratic-reciprocity",
-      "relationship": "root — the Eisenstein lattice-point proof of QR"
+      "title": "Quadratic Reciprocity (Eisenstein Lattice-Point Proof)",
+      "relationship": "root — the Eisenstein lattice-point proof of QR; semantically distinct path that the Gauss-sum argument formalized here can replace once Step 4 is assembled."
     },
     {
       "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-03",
-      "relationship": "sibling — extends to higher-power reciprocity using Jacobi sums"
+      "title": "Higher-Power Reciprocity via Jacobi Sums",
+      "relationship": "sibling — extends to higher-power reciprocity using Jacobi sums; the analogue τ^q = J(χ,χ)·τ for cubic χ is the natural successor."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-01-oq-02` (Frobenius Step: τ^q = χ(q)·τ in the Gauss Sum QR Proof).

## Improvements

**meta.json**
- `overview.historicalContext`: ~430 → ~1500 chars. Adds Euler 1744 / Legendre 1785 conjectures, Gauss's *aureum theorema* and his six proofs (1796 onward, *Disquisitiones* 1801), Eisenstein's 1844 streamlined Gauss-sum proof, and the 20th-century Hilbert / Hecke / Artin reinterpretation as Frobenius action on the cyclotomic Gauss sum (Artin reciprocity for ℚ(ζ_p)/ℚ).
- `overview.keyInsights`: 5 → 7. Adds (a) the class-field-theoretic interpretation `Frob_q · τ = χ(q)·τ` as a shadow of Artin reciprocity; (b) the operational role of `CharP F q` letting freshman's-dream hold *strictly*, which is what makes `gaussSum_frob` a one-liner.
- `conclusion.openQuestions`: 3 → 5. Asks (a) for a Mathlib-level statement packaging `gaussSum_frob` as the Frobenius action on a cyclotomic Gauss sum; (b) whether a global-field QR can use this same Gauss-sum machinery.
- `crossReferences`: added missing `title` field to all 4 entries (parent OQ-01-OQ-01, sibling Step-2 OQ-01-OQ-01-OQ-01, Eisenstein root, sibling Jacobi-sum OQ-01-OQ-01-OQ-03).

**annotations.json**
- 6 → 7 annotations: new `ann-concrete-examples` covering lines 172–201 (the three `example` declarations for (5,3), (7,5), (11,7) plus the four `private instance factPrime{3,5,7,11}` declarations). The range was previously uncovered. Includes a QR cross-check table for all three pairs.

## Quality target check

- ≥ 5 annotations w/ mathContext, significance, relatedConcepts → 7/7 ✓
- historicalContext > 200 chars → 1505 chars ✓
- ≥ 4 keyInsights → 7 ✓
- conclusion w/ summary, implications, ≥ 2 openQuestions → 5 openQs ✓
- sections covering full file → already covers L1–L216 ✓

## Notes

- No Lean source changes; only JSON enrichment. Both files parse cleanly under `python3 json.load`.
- Branch rebased onto current `origin/main` (post-#17116 UI fix); diff is ONLY the 2 enriched JSON files.
- `pnpm build` not run: pnpm install fails in this environment on `better-sqlite3` native build; only data-file enrichments (no schema-altering edits).
- Existing annotation types (`context`, `technique`, `key`) follow the role doc convention; not changed in this pass — separate audit task.
- `axiomCount: 0`, `sorries: 0`, `status: "verified"` unchanged; verified Lean file has no structure-encoded assumptions.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>