### PR TITLE
fix(deploy): defense-in-depth hardening for stuck deploy pipeline

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -552,12 +552,32 @@ build_website() {
     fi
 
     print_info "Running pnpm build..."
-    if pnpm build 2>&1 | tail -5; then
-        print_success "Build completed"
-    else
-        print_error "Build failed"
-        return 1
-    fi
+    # Capture full log so failures aren't masked by `| tail -5` (which forces
+    # the pipe's exit status to tail's, always 0). Cap node heap at 8 GB so
+    # OOMs surface as deterministic exits rather than thrashing the host, and
+    # bound the whole chain at 20 minutes so a hung step can't accumulate
+    # zombie pnpm/vite processes across cycles.
+    local build_log
+    build_log=$(mktemp)
+    local build_status=0
+    NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192" \
+        timeout --kill-after=30 20m pnpm build > "$build_log" 2>&1 \
+        || build_status=$?
+    tail -20 "$build_log"
+    case $build_status in
+        0)
+            print_success "Build completed"
+            rm -f "$build_log"
+            ;;
+        124|137)
+            print_error "Build timed out after 20m (status $build_status); see full log at $build_log"
+            return 1
+            ;;
+        *)
+            print_error "Build failed (exit $build_status); see full log at $build_log"
+            return 1
+            ;;
+    esac
 
     # Run quality audit and log results
     print_info "Running quality audit..."

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -249,7 +249,7 @@ merge_prs() {
 
             if git rebase origin/main 2>/dev/null; then
                 # Rebase succeeded cleanly
-                git push --force-with-lease origin "$branch" 2>/dev/null || true
+                git -c push.autoSetupRemote=false push --force-with-lease origin "$branch" 2>/dev/null || true
             else
                 # Handle conflicts intelligently
                 resolve_conflicts() {
@@ -317,7 +317,7 @@ fs.writeFileSync('$conflict_file', JSON.stringify(ours, null, 2) + '\n');
                             # If continue fails, try once more after resolving any new conflicts
                             resolve_conflicts && GIT_EDITOR=true git rebase --continue 2>/dev/null || git rebase --abort 2>/dev/null || true
                         }
-                        git push --force-with-lease origin "$branch" 2>/dev/null || true
+                        git -c push.autoSetupRemote=false push --force-with-lease origin "$branch" 2>/dev/null || true
                     fi
                 else
                     print_warning "  Could not auto-resolve all conflicts"

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -232,7 +232,11 @@ merge_prs() {
                 ((failed++))
                 continue
             }
-            (cd "$worktree_path" && git checkout -B "$branch" "origin/$branch")
+            # --no-track: don't write upstream-tracking config to .git/config,
+            # which is shared across all worktrees and serialized via a single
+            # lockfile. With ~60 worktrees doing concurrent rebases this lock
+            # is the dominant failure mode ("could not lock config file").
+            (cd "$worktree_path" && git checkout --no-track -B "$branch" "origin/$branch")
             temp_worktree=true
         fi
 


### PR DESCRIPTION
## Summary

Stacks four small fixes that together prevent the deploy pipeline from accumulating zombies. Each addresses a distinct failure mode observed today (six stalled `sync-and-deploy.sh` and five zombie `pnpm build` processes spread over 4+ hours).

Reviewable as 3 separate commits:

1. **`fix(deploy): fail loudly and bound pnpm build`** — `pnpm build 2>&1 | tail -5` made the pipe's exit status come from `tail` (always 0), so `vite build` OOMs (`Abort trap: 6`, exit 134) silently reported "Build completed" and the pipeline kept deploying stale `dist/`. Capture full log to a temp file, surface real exit, cap node heap at 8 GB so OOMs are deterministic, wrap in `timeout --kill-after=30 20m` so a hung step can't outlive its 30-min cycle.

2. **`fix(deploy): avoid shared .git/config lock on rebase checkout`** — `git checkout -B` writes upstream-tracking config to the shared `.git/config`, and ~60 worktrees serializing on its single lockfile produced `error: could not lock config file ... unable to write upstream branch configuration` in the rebase loop. Pass `--no-track` so checkout doesn't write config.

3. **`fix(deploy): disable push.autoSetupRemote on rebase pushes`** — `push.autoSetupRemote=true` is configured locally, so `git push` also writes upstream config on first push. Pass `-c push.autoSetupRemote=false` on the two rebase-loop pushes (the third push at line 735 runs serialized from main and is fine).

## Test plan

- [x] `bash -n scripts/deploy/sync-and-deploy.sh` clean
- [x] `which timeout` → `/opt/homebrew/bin/timeout` available on host
- [ ] Next deploy cycle should print `Found N eligible PRs` then either `✓ Build completed` or a real exit code with `tail -20` of the actual failure log
- [ ] Concurrent rebases shouldn't trigger `could not lock config file` errors

## Notes

- `timeout 20m` is a wall-clock budget for the *whole* `annotations:build && research:build && research:enrich && tsc -b && vite build` chain. Adjust upward if legit cold builds run longer.
- The 8 GB heap cap was sized below the box's physical memory (and below the 20 GB RSS we observed `vite` reach when the host was thrashing). If a legit build needs more, raise via `NODE_OPTIONS` env before invoking the script.
- Companion to #17117 (skip drafts in merge step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)