### PR TITLE
audit(cube-root-3-irrational): badge original→mathlib (sibling-consistency)

### DIFF
--- a/src/data/proofs/cube-root-3-irrational/meta.json
+++ b/src/data/proofs/cube-root-3-irrational/meta.json
@@ -14,7 +14,7 @@
       "number-theory",
       "cube-roots"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,


### PR DESCRIPTION
## Audit finding

`cube-root-3-irrational` claims badge `original`, but its main theorem `irrational_cbrt3` obtains its result by directly calling Mathlib's `irrational_nrt_of_notint_nrt`. Per audit Tier B convention ("Formalized using Mathlib theorem"), the badge should be `mathlib`.

## Evidence

**Lean source** (`proofs/Proofs/CubeRoot3Irrational.lean:73-78`):
```lean
theorem irrational_cbrt3 : Irrational cbrt3 := by
  apply irrational_nrt_of_notint_nrt 3 3
  · exact_mod_cast cbrt3_cubed
  · exact cbrt3_not_int
  · norm_num
```

**Sibling proof** `cube-root-2-irrational` — same proof structure (the description even says "Mirrors the proof structure of CubeRoot2Irrational") — already uses badge `mathlib`.

**Meta narrative is already accurate**:
- description: "Proves that the cube root of 3 is irrational using Mathlib's `irrational_nrt_of_notint_nrt`"
- proofStrategy: "(4) `irrational_cbrt3`: from Mathlib's `irrational_nrt_of_notint_nrt 3 3`"
- assumptions: "Fully machine-verified using Mathlib's Irrational and `irrational_nrt_of_notint_nrt`"

Only the `badge` field was inconsistent.

## Auditor severity

MEDIUM — "Mathlib wrapper claimed as 'original'" per `.claude/commands/lean-auditor.md`.

## Diff

One field change: `meta.badge: "original"` → `"mathlib"`.

No content change; description, originalContributions, assumptions, and conclusion already credit Mathlib correctly.

---

Discovered during periodic gallery integrity audit.