### PR TITLE
research(hilbert-10-oq-01-oq-02): S7 — ¬¬-shadow / double-negation invariance for all four classes (build pending)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -669,6 +669,88 @@ theorem notZero_isExistentialUniversalDefinition :
   codiophantine_implies_existentialUniversal _ notZero_isCoDiophantineDefinition
 
 -- ============================================================
+-- Part VIII.8 (iter 7): ¬¬-shadow / double-negation invariance
+-- ============================================================
+
+/-- Classical double-negation bridge for an arbitrary `RatSubset`:
+    `S q ↔ ¬¬ S q`. Packaged as a reusable named lemma for the four
+    `_iff_of_pred_iff` congruence helpers below.
+
+    Already used inline in iteration 5's
+    `universalExistential_iff_existentialUniversal_complement`; factored
+    out here so the four ¬¬-shadow theorems are uniform one-liners. The
+    only non-constructive step is `Classical.byContradiction`. -/
+private theorem doubleNeg_pred_iff (S : RatSubset) :
+    ∀ q : Rat, S q ↔ ¬ ¬ S q :=
+  fun _ => ⟨fun hSq hnSq => hnSq hSq, fun hnnSq => Classical.byContradiction hnnSq⟩
+
+/-- **Σ₁ ¬¬-shadow** (iteration 7): the Σ₁ (Diophantine) class is
+    invariant under classical double-negation of the predicate.
+
+        Σ₁(¬¬ S)  ⟺  Σ₁(S).
+
+    Pure logic; pulls back through the Σ₁ class congruence
+    `diophantineDefinition_iff_of_pred_iff` (iteration 4) along the
+    classical bridge `doubleNeg_pred_iff`. No new axioms. -/
+theorem diophantineDefinition_doubleNeg_iff (S : RatSubset) :
+    IsDiophantineDefinition (fun q => ¬ ¬ S q) ↔ IsDiophantineDefinition S :=
+  (diophantineDefinition_iff_of_pred_iff (doubleNeg_pred_iff S)).symm
+
+/-- **Π₁ ¬¬-shadow** (iteration 7): the Π₁ (co-Diophantine) class is
+    invariant under classical double-negation of the predicate.
+
+        Π₁(¬¬ S)  ⟺  Π₁(S).
+
+    Pure logic; pulls back through `coDiophantineDefinition_iff_of_pred_iff`
+    (iteration 4) along the classical bridge. No new axioms. -/
+theorem coDiophantineDefinition_doubleNeg_iff (S : RatSubset) :
+    IsCoDiophantineDefinition (fun q => ¬ ¬ S q) ↔ IsCoDiophantineDefinition S :=
+  (coDiophantineDefinition_iff_of_pred_iff (doubleNeg_pred_iff S)).symm
+
+/-- **Π₂ ¬¬-shadow** (iteration 7): the Π₂ (universal-existential) class
+    is invariant under classical double-negation of the predicate.
+
+        Π₂(¬¬ S)  ⟺  Π₂(S).
+
+    Pure logic; pulls back through `universalExistentialDefinition_iff_of_pred_iff`
+    (iteration 3) along the classical bridge. No new axioms. -/
+theorem universalExistentialDefinition_doubleNeg_iff (S : RatSubset) :
+    IsUniversalExistentialDefinition (fun q => ¬ ¬ S q) ↔
+      IsUniversalExistentialDefinition S :=
+  (universalExistentialDefinition_iff_of_pred_iff (doubleNeg_pred_iff S)).symm
+
+/-- **Σ₂ ¬¬-shadow** (iteration 7): the Σ₂ (existential-universal) class
+    is invariant under classical double-negation of the predicate.
+
+        Σ₂(¬¬ S)  ⟺  Σ₂(S).
+
+    Pure logic; pulls back through `existentialUniversalDefinition_iff_of_pred_iff`
+    (iteration 4) along the classical bridge. Completes the four-class
+    ¬¬-shadow story (Σ₁/Π₁/Σ₂/Π₂ all stable under classical double
+    negation of the predicate). No new axioms. -/
+theorem existentialUniversalDefinition_doubleNeg_iff (S : RatSubset) :
+    IsExistentialUniversalDefinition (fun q => ¬ ¬ S q) ↔
+      IsExistentialUniversalDefinition S :=
+  (existentialUniversalDefinition_iff_of_pred_iff (doubleNeg_pred_iff S)).symm
+
+/-- **OPEN-question reformulation through the shadow** (iteration 7):
+    the OPEN Σ₁ question for ℤ ⊂ ℚ is equivalent to its double-negation
+    shadow.
+
+        IntegersAreDiophantineOverQ
+          ⟺  IsDiophantineDefinition (fun q => ¬¬ IntSubset q).
+
+    Concrete consequence of the Σ₁ ¬¬-shadow at the predicate `IntSubset`.
+    Useful when a putative refutation argument naturally produces a `¬¬`
+    layer (e.g., from a classical decomposition of a Π₁ counter-witness)
+    — the shadow reformulation lets one stay inside the Σ₁ class while
+    using the doubly-negated predicate. -/
+theorem integers_diophantine_iff_doubleNeg :
+    IntegersAreDiophantineOverQ ↔
+      IsDiophantineDefinition (fun q => ¬ ¬ IntSubset q) :=
+  (diophantineDefinition_doubleNeg_iff IntSubset).symm
+
+-- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
 
@@ -709,6 +791,12 @@ open gap is Σ₁ vs Π₂ (equivalently, Π₁(complement) vs Σ₂(complement)
   Σ₁ (resp. Π₁); these in turn place them into Π₂ and Σ₂ via the trivial
   inclusions `Σ₁ ⊆ Π₂` and `Π₁ ⊆ Σ₂`. This sharpens the iteration-5
   trivial-set library (∅, ℚ) to the smallest non-degenerate subset.
+- All four classes are stable under classical *double-negation* of the
+  predicate (iter 7): `Class(¬¬ S) ⟺ Class(S)` for `Class ∈ {Σ₁, Π₁, Σ₂, Π₂}`.
+  In particular, the OPEN Σ₁ question for ℤ ⊂ ℚ is equivalent to its
+  ¬¬-shadow `Σ₁(¬¬ IntSubset)`, which is occasionally a more tractable
+  reformulation when a refutation argument naturally produces a `¬¬`
+  layer (e.g., a classical decomposition of a Π₁ counter-witness).
 
 ## Axioms in THIS file (1 net new)
 
@@ -720,7 +808,7 @@ All other declared `theorem`s are NOT new axioms — they are logical
 consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulation,
 Σ₁ ↔ Π₁(complement), and Σ₂ ↔ Π₂(complement) equivalences proved here.
 
-## Theorems in THIS file (30)
+## Theorems in THIS file (35)
 
   - `integers_diophantine_iff` (Σ₁ predicate ↔ existing formulation)
   - `diophantine_implies_universal_existential` (Σ₁ ⊆ Π₂)
@@ -752,6 +840,11 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `notZero_isCoDiophantineDefinition` (ℚ\{0} is Π₁, iter 6)
   - `singletonZero_isUniversalExistentialDefinition` ({0} is Π₂, iter 6)
   - `notZero_isExistentialUniversalDefinition` (ℚ\{0} is Σ₂, iter 6)
+  - `diophantineDefinition_doubleNeg_iff` (Σ₁ ¬¬-shadow, iter 7)
+  - `coDiophantineDefinition_doubleNeg_iff` (Π₁ ¬¬-shadow, iter 7)
+  - `universalExistentialDefinition_doubleNeg_iff` (Π₂ ¬¬-shadow, iter 7)
+  - `existentialUniversalDefinition_doubleNeg_iff` (Σ₂ ¬¬-shadow, iter 7)
+  - `integers_diophantine_iff_doubleNeg` (OPEN Σ₁ question ⟺ its ¬¬-shadow, iter 7)
 -/
 
 #check @IsDiophantineDefinition
@@ -783,5 +876,10 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @notZero_isCoDiophantineDefinition
 #check @singletonZero_isUniversalExistentialDefinition
 #check @notZero_isExistentialUniversalDefinition
+#check @diophantineDefinition_doubleNeg_iff
+#check @coDiophantineDefinition_doubleNeg_iff
+#check @universalExistentialDefinition_doubleNeg_iff
+#check @existentialUniversalDefinition_doubleNeg_iff
+#check @integers_diophantine_iff_doubleNeg
 
 end Hilbert10Rationals

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -1,90 +1,118 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T06:00:00Z
-**Iteration**: 4
-**Last Updated**: 2026-05-08 (researcher-1)
+**Since**: 2026-05-08T13:00:00Z
+**Iteration**: 7
+**Last Updated**: 2026-05-08 (researcher-8)
 
 ## Current Focus
 
-Iteration 4 (2026-05-08, researcher-1, this PR): completing the
-**propositional-equivalence congruence story** for all four
-definability classes. Iteration 3 added
-`universalExistentialDefinition_iff_of_pred_iff` (Π₂ congruence) for
-use in the Σ₂(ℚ\ℤ) corollary; this iteration adds the analogous lemmas
-for the other three classes — Σ₁, Π₁, Σ₂. All three follow the same
-one-and-a-half-line `(h q).symm.trans (hP q)` template as the Π₂
-version, so the additions are mechanical but complete the four-class
-symmetry of the file.
+Iteration 7 (2026-05-08, researcher-8, this PR): completing the
+**¬¬-shadow / double-negation invariance** story for all four
+definability classes. Each of Σ₁, Π₁, Σ₂, Π₂ is proved stable under
+classical double-negation of the predicate:
 
-Net new content: 0 definitions, 3 theorems, 0 axioms.
-Updated to total: 8 definitions, 16 theorems, 1 axiom, 0 sorries,
-526 lines (was 462).
+    Class(¬¬ S)  ⟺  Class(S),  for Class ∈ {Σ₁, Π₁, Σ₂, Π₂}.
 
-Iterations 1 & 2 established Σ₁ (open), Π₂ (Koenigsmann), and the
-Σ₁/Π₁ duality. Iteration 3 added Σ₂ definability, the precise dual of
-Σ₁ ⊆ Π₂ (i.e. Π₁ ⊆ Σ₂), the Σ₂/Π₂ duality, and the unconditional
-Σ₂(ℚ\ℤ) corollary of Koenigsmann.
+All four are one-line corollaries of the iteration-3/4 `_iff_of_pred_iff`
+class-congruence helpers, applied to the classical bridge
+`S q ↔ ¬¬ S q` (factored out as a private named lemma
+`doubleNeg_pred_iff`). One concrete corollary specializes the Σ₁
+shadow to the open question for ℤ ⊂ ℚ:
+
+    IntegersAreDiophantineOverQ  ⟺  Σ₁(fun q => ¬¬ IntSubset q).
+
+Net new content: 0 definitions, 6 theorems (5 public + 1 private
+bridge), 0 axioms.
+Updated to total: 11 definitions (incl. 3 private), 39 theorems (incl.
+4 private), 1 axiom, 0 sorries, 885 lines (was 787).
+
+Iterations 1–6 established Σ₁ (open), Π₂ (Koenigsmann), the Σ₁/Π₁
+duality (with symmetric form), the Σ₂/Π₂ duality (with symmetric form),
+all four class-congruence helpers, the unconditional Σ₂(ℚ\ℤ) corollary
+of Koenigsmann, the ∅ and ℚ trivial-set library across all four classes,
+and the smallest non-trivial parameter-dependent witness {0}/ℚ\{0}
+across all four classes via the projection polynomial `P(q,x) = q`.
 
 ## Active Approach
 
-S4 — Σ₁/Π₁/Σ₂ class congruence (this iteration):
+S7 — ¬¬-shadow / double-negation invariance (this iteration):
 
-1. `diophantineDefinition_iff_of_pred_iff` — Σ₁ class invariant under
-   propositional equivalence of the predicate.
-2. `coDiophantineDefinition_iff_of_pred_iff` — Π₁ class invariant.
-3. `existentialUniversalDefinition_iff_of_pred_iff` — Σ₂ class
-   invariant.
+1. `doubleNeg_pred_iff S` (private bridge) — `∀ q, S q ↔ ¬¬ S q`,
+   classical (one `Classical.byContradiction`).
+2. `diophantineDefinition_doubleNeg_iff S` — Σ₁(¬¬ S) ⟺ Σ₁(S).
+3. `coDiophantineDefinition_doubleNeg_iff S` — Π₁(¬¬ S) ⟺ Π₁(S).
+4. `universalExistentialDefinition_doubleNeg_iff S` — Π₂(¬¬ S) ⟺ Π₂(S).
+5. `existentialUniversalDefinition_doubleNeg_iff S` — Σ₂(¬¬ S) ⟺ Σ₂(S).
+6. `integers_diophantine_iff_doubleNeg` — concrete shadow specialization
+   for the OPEN Σ₁ question on ℤ ⊂ ℚ.
 
-Each is the same `(h q).symm.trans (hP q)` / `(h q).trans (hP q)`
-two-line proof as `universalExistentialDefinition_iff_of_pred_iff`
-(iteration 3, the Π₂ version). All four classes are now invariant
-under propositional equivalence, completing the propositional-
-congruence story for the file.
+Each of #2–#5 is a single `(_iff_of_pred_iff (doubleNeg_pred_iff S)).symm`
+term; #6 is `(diophantineDefinition_doubleNeg_iff IntSubset).symm`. No
+new imports; no field arithmetic; no Mathlib dependencies. Same Path A
+(zero-Mathlib, classical-only) discipline as iterations 5/6.
 
-S3 (iteration 3) — Σ₂ definability + Σ₂/Π₂ duality:
+## Why this matters
 
-1. `IsExistentialUniversalDefinition` (Σ₂, ∃∀ definability).
-2. `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂).
-3. `existentialUniversal_iff_universalExistential_complement` (Σ₂/Π₂
-   duality).
-4. `universalExistentialDefinition_iff_of_pred_iff` (Π₂ congruence).
-5. `koenigsmann_implies_complement_existentialUniversal` (Σ₂(ℚ\ℤ)
-   corollary).
+The four ¬¬-shadow theorems make explicit a property that was used
+implicitly in iteration 5's symmetric Σ₂/Π₂ duality: the Π₂ class is
+invariant under `¬¬`-rewriting. Promoting that to a named theorem at
+each level gives a uniform tool for refutation arguments that produce
+classical double-negation layers (e.g., a Π₁ counter-witness obtained
+by `Classical.byContradiction` before being repackaged as a Σ₁
+predicate). The concrete `integers_diophantine_iff_doubleNeg` corollary
+is the bridge a refutation argument would actually use on the OPEN
+question for ℤ ⊂ ℚ.
 
 ## Build Status
 
-Iteration 4 build: PENDING. Worktree's `.lake` is a self-symlink loop
-so Docker build would re-fresh-clone Mathlib (~25-45 min). The three
-new theorems use the same `Iff.trans` chaining as the iteration 3
-`universalExistentialDefinition_iff_of_pred_iff`, which BUILT cleanly
-in iteration 3 (3 jobs, exit code 0). All operate on already-defined
-predicates with no new imports. Confidence high; CI is the ground
-truth.
+Iteration 7 build: PENDING. Worktree's `proofs/.lake` is a recursive
+self-symlink (per `feedback_researcher_lake_symlink_broken.md`) so
+Docker build would re-fresh-clone Mathlib (~25-45 min). The six new
+theorems use ONLY one-line term-mode proofs that compose existing
+iteration-3/4 lemmas by `.symm`; no tactic blocks, no new imports, no
+new defs. Confidence high; CI is the ground truth.
 
+Iteration 6 build: PASSED ✅ (per #17083 CI).
+Iteration 5 build: PASSED ✅ (per #17065 CI).
+Iteration 4 build: PASSED ✅ (per #17026 CI).
 Iteration 3 build: PASSED ✅ (3 jobs, exit code 0).
 
 ## Blockers
 
-None.
+None for axiom-free Path A pure-logic iterations. Field-arithmetic
+extensions (closure under union/intersection, Π₁ ⊆ Π₂ via
+polynomial-inversion, arbitrary singletons {a} for a ≠ 0) all require
+Mathlib for `Rat.sub_eq_zero_iff`, `Rat.mul_eq_zero`, etc.
 
 ## Next Action
 
-Commit, push, create PR for iteration 4 (this).
+Commit, push, create PR for iteration 7 (this).
 
-If S4 lands cleanly, S5+ candidates (unchanged from iteration 3):
-- Σ₂ ⊆ Π₂'s ¬¬-shadow — `Σ₂(S)` and `Π₂(¬¬S) = Π₂(S)` agreement on
-  `Prop`-classical predicates.
-- Σ₁ × Π₁ closure properties (under finite union/intersection) — needs
-  `Rat.mul_eq_zero` / sum-of-squares lemma which requires Mathlib import.
-- Π₁ ⊆ Π₂ via `a ≠ 0 ⟺ ∃ z, a·z = 1` polynomial-inversion trick —
-  same Rat field arithmetic blocker.
-- Daans 2021 (10-quantifier reduction) as a separate axiomatized
-  witness — adds 1 axiom, defer.
+If S7 lands cleanly, S8+ candidates:
+- **S8 (Path A, axiom-free)**: extend the smallest-non-trivial-witness
+  story to other constant-polynomial subsets — e.g., `{q : ℚ | q = 0 ∨
+  q = 0}` (degenerate), or chained singletons via predicate equivalence
+  (`{0} ∪ {0} = {0}` via `_iff_of_pred_iff`).
+- **S8 (Path B, Mathlib import)**: arbitrary singletons {a} for a : ℚ
+  via `P(q, x) = q - a` and `Rat.sub_eq_zero_iff` (the genuine
+  generalization of S6's `singletonZero`).
+- **S8 (Path C, axiomatized)**: Daans 2021 (10-quantifier reduction of
+  Koenigsmann) as a separate axiomatized witness — adds 1 axiom,
+  documentary value only.
+- **S9+**: closure properties (union/intersection) — needs
+  `Rat.mul_eq_zero` (Mathlib).
+- **S9+**: Π₁ ⊆ Π₂ via the polynomial-inversion trick `a ≠ 0 ⟺ ∃ z,
+  a·z = 1` — needs `Rat` field arithmetic.
+
+The Path A axiom-free corner of the file is now substantially
+saturated; further single-PR progress without Mathlib is
+incrementally smaller.
 
 ## Attempt Counts
 
-- Total attempts: 4
-- Current approach attempts: 1 (S4 — class congruence, this iteration)
-- Approaches tried: 3 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
-  congruence)
+- Total attempts: 7
+- Current approach attempts: 1 (S7 — ¬¬-shadow, this iteration)
+- Approaches tried: 6 (S2 Σ₁/Π₁ duality, S3 Σ₂/Π₂ duality, S4 class
+  congruence, S5 symmetric duality + trivial sets, S6 smallest
+  non-trivial subset, S7 ¬¬-shadow)

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -44,11 +44,16 @@
       "singletonZero_isDiophantineDefinition: {0} ⊂ ℚ is Σ₁-definable via the projection polynomial P(q,x) = q (smallest non-trivial Σ₁ subset; iter 6, axiom-free)",
       "notZero_isCoDiophantineDefinition: ℚ \\ {0} is Π₁-definable via the same projection polynomial (iter 6, axiom-free)",
       "singletonZero_isUniversalExistentialDefinition: {0} ⊂ ℚ is Π₂-definable, corollary of Σ₁ membership via Σ₁ ⊆ Π₂ (iter 6, no new axiom)",
-      "notZero_isExistentialUniversalDefinition: ℚ \\ {0} is Σ₂-definable, corollary of Π₁ membership via Π₁ ⊆ Σ₂ (iter 6, no new axiom)"
+      "notZero_isExistentialUniversalDefinition: ℚ \\ {0} is Σ₂-definable, corollary of Π₁ membership via Π₁ ⊆ Σ₂ (iter 6, no new axiom)",
+      "diophantineDefinition_doubleNeg_iff: Σ₁ class is invariant under classical double-negation of the predicate — Σ₁(¬¬ S) ⟺ Σ₁(S) (iter 7, axiom-free, one-line via Σ₁ class congruence)",
+      "coDiophantineDefinition_doubleNeg_iff: Π₁ class is invariant under classical double-negation — Π₁(¬¬ S) ⟺ Π₁(S) (iter 7, axiom-free)",
+      "universalExistentialDefinition_doubleNeg_iff: Π₂ class is invariant under classical double-negation — Π₂(¬¬ S) ⟺ Π₂(S) (iter 7, axiom-free)",
+      "existentialUniversalDefinition_doubleNeg_iff: Σ₂ class is invariant under classical double-negation — Σ₂(¬¬ S) ⟺ Σ₂(S) (iter 7, axiom-free; completes the four-class ¬¬-shadow story)",
+      "integers_diophantine_iff_doubleNeg: the OPEN Σ₁ question for ℤ ⊂ ℚ is equivalent to its ¬¬-shadow — IntegersAreDiophantineOverQ ⟺ Σ₁(fun q => ¬¬ IntSubset q) (iter 7, axiom-free, refutation-ergonomic reformulation)"
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 787,
+    "lineCount": 885,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -56,7 +61,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 33,
+    "theoremCount": 39,
     "definitionCount": 11
   },
   "overview": {
@@ -184,9 +189,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 787,
+    "lineCount": 885,
     "axiomCount": 1,
-    "theoremCount": 33,
+    "theoremCount": 39,
     "definitionCount": 11,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Iteration 7 of `hilbert-10-oq-01-oq-02` adds the **double-negation shadow theorem** at every level of the Σ₁/Π₁/Σ₂/Π₂ definability hierarchy over ℚ:

  Class(¬¬ S)  ⟺  Class(S),  for Class ∈ {Σ₁, Π₁, Σ₂, Π₂}.

Each is a one-line term-mode corollary of the iteration-3/4 `_iff_of_pred_iff` class-congruence helpers, applied to the classical bridge `S q ↔ ¬¬ S q` (factored out as a private named lemma `doubleNeg_pred_iff`, an explicit reusable form of the inline bridge already used in iter-5's symmetric Σ₂/Π₂ duality).

## Theorems added

- `doubleNeg_pred_iff` (private bridge) — `∀ q, S q ↔ ¬¬ S q`, classical (one `Classical.byContradiction`).
- `diophantineDefinition_doubleNeg_iff` — Σ₁(¬¬ S) ⟺ Σ₁(S).
- `coDiophantineDefinition_doubleNeg_iff` — Π₁(¬¬ S) ⟺ Π₁(S).
- `universalExistentialDefinition_doubleNeg_iff` — Π₂(¬¬ S) ⟺ Π₂(S).
- `existentialUniversalDefinition_doubleNeg_iff` — Σ₂(¬¬ S) ⟺ Σ₂(S).
- `integers_diophantine_iff_doubleNeg` — concrete shadow specialization for the OPEN Σ₁ question on ℤ ⊂ ℚ:

      IntegersAreDiophantineOverQ ⟺ Σ₁(fun q => ¬¬ IntSubset q).

## Why this matters

The four ¬¬-shadow theorems make explicit a property that was used implicitly in iter-5's symmetric Σ₂/Π₂ duality. Promoting it to a named theorem at each level gives a uniform tool for refutation arguments that naturally produce classical double-negation layers (e.g., a Π₁ counter-witness obtained via `Classical.byContradiction` before being repackaged as a Σ₁ predicate). The concrete `integers_diophantine_iff_doubleNeg` corollary is the bridge such a refutation argument would actually use on the OPEN question.

## Provenance

Pure logic. Each theorem is `(_iff_of_pred_iff bridge).symm`. No new axioms, no new sorries, no new imports, no new defs, no field arithmetic. Same axiom-free Path A discipline as iterations 5 and 6.

## File-level changes

- 0 new definitions, 6 new theorems (5 public + 1 private), 0 new axioms.
- Updated total: 11 definitions (incl. 3 private), 39 theorems (incl. 4 private), 1 axiom, 0 sorries, 885 lines (was 787).
- Landscape docstring (Part IX) extended with a "stable under classical double-negation" bullet, the five new theorems added to the inventory, `#check` block extended.
- meta.json: lineCount 787→885, theoremCount 33→39, originalContributions list extended with the five S7 theorems.
- state.md: refreshed to iteration 7 / ACT, with S8+ candidates partitioned by Path A (axiom-free) / Path B (Mathlib import) / Path C (axiomatized witness).

## Build status

PENDING. Worktree's `proofs/.lake` is a recursive self-symlink (per `feedback_researcher_lake_symlink_broken.md`), so Docker build would re-fresh-clone Mathlib (~25–45 min) — outside the local environment's reasonable bounds. The six new theorems use ONLY one-line term-mode `(_iff_of_pred_iff …).symm` proofs that compose existing iteration-3/4 lemmas; no tactic blocks, no new imports, no new defs. CI is the authoritative build verifier. Same build-pending pattern as #17065 (S5), #17083 (S6).

## Test plan

- [ ] CI build passes (Lean 4.26.0 + this file's existing imports — `Proofs.Hilbert10OQ01` only).
- [ ] No new sorries, no new axioms (grep confirms 0 sorry, 1 axiom = `koenigsmann_2016_universal`).
- [ ] `meta.json` lineCount/theoremCount agree with file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)