### PR TITLE
Enrich sperner-simplicial-instance: Sperner 1928 history, Brouwer-equivalence insight, lemma-library + adjacency annotations

### DIFF
--- a/src/data/proofs/sperner-simplicial-instance/annotations.json
+++ b/src/data/proofs/sperner-simplicial-instance/annotations.json
@@ -46,6 +46,31 @@
     ]
   },
   {
+    "id": "si-sperner-and-coloring",
+    "proofId": "sperner-simplicial-instance",
+    "type": "theorem",
+    "range": {
+      "startLine": 137,
+      "endLine": 172
+    },
+    "title": "IsSpernerColoring + Triangulation.sperner: The Main Theorem",
+    "content": "Two declarations: (1) `IsSpernerColoring (T : Triangulation V n) (c : V → Fin (n+1)) : Prop` defines what it means for c to be a *Sperner coloring* — for each cell s and each face index k, the color c(T.vertex s i) is never k for at least one vertex i (so the face opposite vertex k cannot be monochromatically colored k). (2) `Triangulation.sperner (T : Triangulation V n) (c : V → Fin (n+1)) (hbdry : Odd (...).card) : ∃ s : T.Cell, CellComplex.IsPanchromatic c T.toCellComplex s` is the entry's main theorem.\n\nThe proof is a single line: `CellComplex.sperner c T.toCellComplex hbdry`. All combinatorial work happens in `SpernerMathlib4.CellComplex.sperner`; this file just supplies the bridge.\n\nThe `hbdry` hypothesis (\"odd number of boundary doors\") is the geometric input — for the standard simplex triangulation this is `boundary_doors_odd` proved on lines 173-254.",
+    "significance": "critical",
+    "mathContext": "Sperner's lemma (1928): for any Sperner-colored triangulation $T$ of an $n$-simplex, the number of panchromatic $n$-cells is odd. A cell $s$ is *panchromatic* if its $n+1$ vertices receive all $n+1$ distinct colors. The classical statement requires the odd-boundary-door hypothesis to hold automatically (true for the standard triangulation by induction); here we keep `hbdry` as an explicit hypothesis so the abstract `CellComplex.sperner` theorem applies to any pseudomanifold, not only the standard triangulation.",
+    "relatedConcepts": [
+      "Sperner's lemma",
+      "Sperner coloring",
+      "panchromatic cell",
+      "CellComplex.sperner",
+      "boundary door parity"
+    ],
+    "prerequisites": [
+      "Sperner's lemma statement",
+      "CellComplex framework",
+      "boundary door parity hypothesis"
+    ]
+  },
+  {
     "id": "si-boundary-doors-odd",
     "proofId": "sperner-simplicial-instance",
     "type": "theorem",
@@ -90,6 +115,55 @@
     "prerequisites": [
       "Finset and LinearOrder in Lean 4",
       "Finset.sort API"
+    ]
+  },
+  {
+    "id": "si-asd-lemma-library",
+    "proofId": "sperner-simplicial-instance",
+    "type": "theorem",
+    "range": {
+      "startLine": 295,
+      "endLine": 790
+    },
+    "title": "AbstractSimplicialData Lemma Library (~25 lemmas, L295–790)",
+    "content": "After `AbstractSimplicialData V n` is defined, this ~500-line block builds the library of supporting lemmas needed to construct a `Triangulation` from unordered Finset-based simplicial data. Roughly grouped:\n\n• **Vertex enumeration** (L295–328): `vertexEnum_mem`, `faceOf_card`, `faceOf_subset` — basic facts about `Finset.sort`-derived vertex lists.\n• **Container lemmas** (L329–399): `self_mem_containersOf`, `containersOf_card_le_two`, `containersOf_card_one_or_two`, `sdiff_nonempty` — pseudomanifold property (≤ 2 top-cells per codim-1 face) made operational.\n• **Opposite-vertex machinery** (L401–456): `vertexEnum_findOppositeIdx_not_mem`, `erase_opposite_eq`, `vertexEnum_injective`, `vertexEnum_image_univ`, `vertexEnum_image_erase` — locate, verify, and characterize the opposite vertex of a codim-1 face.\n• **Face equalities** (L482–550): `faceOf_eq`, `vertexEnum_not_mem_faceOf_iff`, `findOppositeIdx_eq` — bridging Finset-level and List-level views of faces.\n• **Adjacency function** (L553–790): `adjFn_vertex`, `containersOf_card_eq_two_of_adjFn`, `adjFn_s'_mem_containers`, `adjFn_ne`, `adjFn_face_eq`, `adjFn_symm` — build the `adj : Cell → Fin (n+1) → Option (...)` function and prove its four pseudomanifold axioms.\n\nThe payoff comes shortly after this block: `AbstractSimplicialData.toTriangulation` packages all the verified field witnesses into a `Triangulation` value, completing the bridge from Mathlib-style Finset simplicial complexes to the CellComplex-friendly `Triangulation` form.",
+    "significance": "critical",
+    "mathContext": "The library proves, for an abstract simplicial complex given as a `Finset (Finset V)` of top-dimensional simplices: (1) sorting via `Finset.sort` gives a canonical vertex enumeration with no duplicates; (2) the *opposite vertex* of a codim-1 face $F \\subset s$ is uniquely determined ($\\{v\\} = s \\setminus F$); (3) any two top-cells sharing a codim-1 face are uniquely paired by the `adjFn` map; (4) the resulting adjacency satisfies the pseudomanifold axioms (symmetry, vertex-preservation, distinctness). Together these promote unordered simplicial data into the ordered, axiom-verified Triangulation form.",
+    "relatedConcepts": [
+      "Finset.sort",
+      "List.nodup_iff_injective_get",
+      "pseudomanifold adjacency",
+      "opposite vertex",
+      "Mathlib SimplicialComplex bridging"
+    ],
+    "prerequisites": [
+      "Finset.sort and linear order",
+      "List-level injectivity lemmas",
+      "AbstractSimplicialData structure"
+    ]
+  },
+  {
+    "id": "si-iadj-machinery",
+    "proofId": "sperner-simplicial-instance",
+    "type": "tactic",
+    "range": {
+      "startLine": 813,
+      "endLine": 955
+    },
+    "title": "Interval Adjacency: ivtx, iadj, iadj_cases (L813–955)",
+    "content": "Concrete 1-d triangulation primitives, all `private`:\n\n• `ivtx (_ : 0 < m) (i : Fin m) (k : Fin 2) : ℕ` (L813): the vertex map. Cell $i$ of the interval $[0,m]$ has vertices $\\{i, i+1\\}$, with `k=0 ↦ i` and `k=1 ↦ i+1`.\n• `iadj (m : ℕ) (i : Fin m) (k : Fin 2)` (L818): the adjacency function. `iadj i 0` (face opposite vertex 0, the right face $\\{i+1\\}$) connects to cell $i+1$ (when $i+1 < m$, else `none`). `iadj i 1` connects to cell $i-1$ symmetrically.\n• `iadj_cases` (L832): exhaustive case-split lemma for `iadj` — splits into two cases by the `k.val` value, used as the standard tactic for discharging adjacency goals.\n• `iadj_symm'` (L866): the symmetry axiom `adj_symm` for `iadj` — if `iadj i k = some (j, k')`, then `iadj j k' = some (i, k)`. Proved by `iadj_cases` × 2.\n• `iadj_ne'` (L893): the distinctness axiom — adjacent cells differ.\n• `iadj_vertex'` (L901): the vertex-preservation axiom — vertices of the shared face agree on both sides.\n\nAll four pseudomanifold axioms for the interval are discharged by `iadj_cases` + `simp`/`omega`. This is the *concrete* infrastructure that makes `intervalTriangulation m hm` (L958) and `interval_sperner` (L982) trivial one-liners.",
+    "significance": "key",
+    "mathContext": "The unit-interval subdivision $[0,m] = \\bigcup_{i=0}^{m-1} [i, i+1]$ is the canonical 1-d simplicial complex: $m$ top-cells (edges), $m+1$ vertices ($0, 1, \\ldots, m$). Each interior vertex $i$ ($0 < i < m$) is shared by two cells (cell $i-1$ on the right, cell $i$ on the left), so the codim-1 face $\\{i\\}$ is in exactly 2 top simplices — pseudomanifold ✓. Boundary vertices $0$ and $m$ each touch only one cell — boundary doors (= 2, even? No: per cell only ONE face is boundary, so each boundary cell contributes 1 boundary door — total = 2 boundary doors). Wait: in the standard Sperner boundary-door counting, what counts is doors *on the last face* — for a 1-d Sperner coloring with $0 \\mapsto 0$, $m \\mapsto 1$, the parity of doors of color $1$ on the boundary is $1$ (only at vertex $m$), which is odd — so `interval_sperner` applies.",
+    "relatedConcepts": [
+      "1-d triangulation",
+      "iadj_cases tactic",
+      "pseudomanifold adjacency",
+      "boundary doors"
+    ],
+    "prerequisites": [
+      "Fin and arithmetic",
+      "case analysis tactics",
+      "Triangulation structure"
     ]
   },
   {

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -47,7 +47,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Sperner's lemma (1928) states that any Sperner-colored triangulation of a simplex contains at least one fully colored (panchromatic) cell. The proof uses a parity argument: boundary doors have odd count, and each interior cell contributes 0 or 2 door-swaps. This formalization provides the instance layer connecting abstract combinatorial Sperner (proved in SpernerMathlib4.lean for any CellComplex) to concrete geometric triangulations.\n\nThe `AbstractSimplicialData` structure supports the Mathlib `Geometry.SimplicialComplex` (Finset-based) representation, bridging Mathlib's unordered simplices to the ordered vertex enumeration needed for CellComplex.",
+    "historicalContext": "Sperner's lemma was proved by Emanuel Sperner in 1928 (\"Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes\", *Abhandlungen aus dem mathematischen Seminar der Universität Hamburg*) as a combinatorial route to L. E. J. Brouwer's invariance-of-domain and fixed-point theorems. The lemma asserts: in any Sperner-colored triangulation of an n-simplex (corner i gets color i; faces inherit colors from corners), the number of panchromatic n-cells is odd — in particular, at least one exists. The proof is a clean parity argument on a pseudomanifold's boundary doors. Knaster, Kuratowski, and Mazurkiewicz (the KKM trio) used Sperner's lemma in 1929 to prove the KKM lemma, which gives the cleanest derivation of Brouwer's fixed-point theorem; Scarf (1967) reignited interest by turning the Sperner argument into the *constructive* fixed-point algorithm that powers modern computational economics. This formalization provides the *instance layer* connecting the abstract combinatorial Sperner proof (proved in `SpernerMathlib4.lean` for any `CellComplex`) to concrete geometric triangulations. The architectural separation — abstract `CellComplex` interface plus concrete `Triangulation` instance — mirrors Mathlib's pattern for filters, manifolds, and probability theory: prove once at the abstract level, instantiate for each concrete object. The `AbstractSimplicialData` structure further bridges to Mathlib's `Geometry.SimplicialComplex` (which uses unordered `Finset V` simplices), supplying the `Finset.sort`-based ordered-vertex enumeration required by `CellComplex`.",
     "problemStatement": "**Sperner's Lemma for Triangulations**: Given a `Triangulation V n` and a Sperner coloring c : V → Fin (n+1), if the number of boundary doors is odd, then there exists a panchromatic cell.\n\nFormalized as: `Triangulation.sperner (T : Triangulation V n) (c : V → Fin (n+1)) (hbdry : Odd (...).card) : ∃ s : T.Cell, CellComplex.IsPanchromatic c T.toCellComplex s`",
     "text": "A 994-line bridge construction. Part 1 defines `Triangulation V n` as a finite pure simplicial complex with pseudomanifold adjacency. Part 2 constructs the `toCellComplex` bridge and proves `Triangulation.sperner`. Part 3 develops the `boundary_doors_odd` theorem showing Sperner colorings give odd boundary doors. Part 4 introduces `AbstractSimplicialData` for constructing triangulations from unordered simplices (as in Mathlib). Part 5 provides the concrete `intervalTriangulation m hm` with all axioms fully proved.",
     "proofStrategy": "**Architecture**: `SpernerMathlib4.lean` proves the abstract `CellComplex.sperner` theorem for any abstract CellComplex. This file provides:\n\n**Step 1 (Triangulation structure)**: Define `Triangulation V n` with fields mirroring `CellComplex` plus `vertex_injective`. The bridge `toCellComplex` simply forgets `vertex_injective`.\n\n**Step 2 (Abstract Sperner)**: `Triangulation.sperner` is a one-line application of `CellComplex.sperner` via the bridge.\n\n**Step 3 (Boundary parity)**: `boundary_doors_odd` proves the boundary door parity hypothesis for any Sperner coloring. Key: if a door (s,k) is on geometric face faceIdx with faceIdx.val < n, then `IsDoor` would require color faceIdx on some non-k vertex, but the Sperner condition forbids it. So all boundary doors must be on the 'last' face, whose count is odd by hypothesis.\n\n**Step 4 (From unordered simplices)**: `AbstractSimplicialData` uses `Finset.sort` to produce ordered vertex enumerations from `Finset V` simplices. Injectivity follows from `List.nodup_iff_injective_get` on the sorted list.\n\n**Step 5 (Interval example)**: `intervalTriangulation m hm` uses vertex map `ivtx hm i k = if k=0 then i else i+1` and adjacency `iadj` connecting consecutive intervals. All adjacency axioms proved by case analysis on `iadj_cases`.",
@@ -55,7 +55,9 @@
       "**Trivial bridge**: The `Triangulation` structure is designed to have exactly the same fields as `CellComplex` plus `vertex_injective`, making `toCellComplex` trivial (just field projection). This design choice keeps the bridge one-liner.",
       "**Boundary door parity via Sperner constraint**: `boundary_doors_odd` reduces the parity question to showing all boundary doors lie on the 'last face'. If a door is on face faceIdx with faceIdx.val < n, the Sperner constraint directly contradicts the door condition — a clean contradiction proof.",
       "**vertexEnum injectivity via nodup sort**: `AbstractSimplicialData.vertexEnum_injective` uses `List.nodup_iff_injective_get` on the sorted vertex list. Since `Finset.sort` produces a nodup list, `List.get` is injective on it, giving vertex injectivity immediately.",
-      "**Concrete 1-d example fully verified**: `intervalTriangulation m hm` provides a complete worked example with all 4 adjacency axioms proved. The adjacency structure (adj i 0 = i+1 left face, adj i 1 = i-1 right face) is verified by `iadj_cases` splitting into two cases."
+      "**Concrete 1-d example fully verified**: `intervalTriangulation m hm` provides a complete worked example with all 4 adjacency axioms proved. The adjacency structure (adj i 0 = i+1 left face, adj i 1 = i-1 right face) is verified by `iadj_cases` splitting into two cases.",
+      "**Sperner ⇔ Brouwer**: Sperner's lemma is logically equivalent to Brouwer's fixed-point theorem (and to the KKM lemma); each yields the others by a short argument. The combinatorial Sperner proof is *constructive* (it provides an algorithm — Scarf's pivoting method — that locates a panchromatic cell in finite time), making this entry a foundation stone for any Lean-verified Brouwer theorem and for computational fixed-point search.",
+      "**Pseudomanifold, not arbitrary simplicial complex**: The pseudomanifold condition (each codim-1 face in ≤ 2 top simplices) is exactly what the parity argument needs. General simplicial complexes (e.g., a wedge of triangles meeting at a vertex, or a triangle with extra hanging edges) violate it and are excluded — `boundary_doors_odd` would not hold. This is *why* the Triangulation structure carries the pseudomanifold fields rather than just a generic simplicial complex."
     ],
     "prerequisites": [
       "Sperner's lemma and CellComplex (SpernerMathlib4.lean)",
@@ -69,6 +71,21 @@
       "targetId": "sperner-ndim",
       "relationship": "extends",
       "description": "This file provides the concrete simplicial complex instance for the abstract n-dimensional Sperner framework"
+    },
+    {
+      "targetId": "sperner-ndim-mathlib",
+      "relationship": "depends-on",
+      "description": "SpernerMathlib4.lean (additionalFile) supplies the abstract CellComplex.sperner theorem that this entry instantiates via toCellComplex."
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "implies",
+      "description": "Sperner's lemma is the constructive combinatorial route to Brouwer's fixed-point theorem; this entry is foundational machinery for any Lean-verified Brouwer proof."
+    },
+    {
+      "targetId": "sperner-ndim-mathlib-oq-01",
+      "relationship": "sibling",
+      "description": "Companion entry developing the n-dimensional Sperner / Freudenthal triangulation API for Mathlib; both share the abstract CellComplex framework."
     }
   ],
   "leanFile": {
@@ -127,7 +144,9 @@
     "openQuestions": [
       "Verify the standard 2-simplex triangulation (triangulated triangle) as a concrete Triangulation instance",
       "Connect AbstractSimplicialData.toTriangulation to Mathlib's Geometry.SimplicialComplex for a fully Mathlib-compatible pipeline",
-      "Prove boundary_doors_odd for the standard n-simplex triangulation from first principles (geometric facts about the barycentric subdivision)"
+      "Prove boundary_doors_odd for the standard n-simplex triangulation from first principles (geometric facts about the barycentric subdivision)",
+      "Build a Brouwer-fixed-point theorem on top of this: combine `interval_sperner` (or its 2-d analogue) with a continuous-coloring → Sperner-coloring reduction to derive Brouwer for [0,1]^n.",
+      "Implement Scarf's algorithm as a *computable* function in Lean 4: input a Sperner-colored triangulation, output a panchromatic cell. The parity proof is non-constructive in form but the door-following procedure is finite — bridging the two would yield a verified fixed-point algorithm."
     ]
   },
   "sorries": 0


### PR DESCRIPTION
First enrichment pass for `sperner-simplicial-instance` (Sperner's Lemma: SimplicialComplex → CellComplex Bridge). Previously **0** enrichment PRs in history.

## Improvements

**meta.json**
- `overview.historicalContext`: ~640 → ~1580 chars. Adds Sperner's 1928 *Hamburger Abh.* paper (\"Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes\"), Knaster–Kuratowski–Mazurkiewicz 1929 (KKM lemma → Brouwer), Scarf 1967 (constructive fixed-point algorithm), and the architectural reading of the abstract-`CellComplex` / concrete-`Triangulation` separation as a Mathlib-style design pattern (cf. filters, manifolds, probability theory).
- `overview.keyInsights`: 4 → 6. Adds (a) the Sperner ⇔ Brouwer equivalence and the constructive content (Scarf's pivoting algorithm); (b) the *pseudomanifold-vs-arbitrary-simplicial-complex* distinction explaining why `Triangulation` carries pseudomanifold fields rather than a generic simplicial complex.
- `crossReferences`: 1 → 4. Adds `sperner-ndim-mathlib` (the additionalFile this entry depends on), `brouwer-fixed-point` (the headline consequence), and `sperner-ndim-mathlib-oq-01` (sibling Mathlib n-dim API entry).
- `conclusion.openQuestions`: 3 → 5. Adds (a) build a Brouwer fixed-point theorem on top of `interval_sperner` / 2-d analogue; (b) implement Scarf's algorithm as a *computable* Lean function.

**annotations.json** (5 → 8 entries)
- `+si-sperner-and-coloring` (L137–172): the actual main theorem `Triangulation.sperner` + the `IsSpernerColoring` predicate. Previously uncovered.
- `+si-asd-lemma-library` (L295–790): summarises the ~25-lemma `AbstractSimplicialData` support library, grouped by purpose (vertex enum / container lemmas / opposite-vertex machinery / face equalities / adjacency-function lemmas). Previously only the structure definition (L265–300) had an annotation; the ~500-line proof scaffolding was uncovered.
- `+si-iadj-machinery` (L813–955): the `ivtx` / `iadj` / `iadj_cases` / `iadj_symm'` / `iadj_ne'` / `iadj_vertex'` primitives that make `intervalTriangulation` and `interval_sperner` one-liners. Previously only the final `intervalTriangulation` definition (L957–992) had an annotation.

## Quality target check

- ≥ 5 annotations w/ mathContext, significance, relatedConcepts → 8/8 ✓
- historicalContext > 200 chars → 1583 chars ✓
- ≥ 4 keyInsights → 6 ✓
- conclusion w/ summary, implications, ≥ 2 openQuestions → 5 openQs ✓
- sections covering full file → already covers L64–L994 ✓

## Notes

- No Lean source changes; only JSON enrichment. Both files parse cleanly under `python3 json.load`.
- Branch rebased onto current `origin/main` (post-#17121 #17120 #17119); diff is exactly the 2 enriched JSON files.
- `pnpm build` not run: pnpm install fails in this environment on `better-sqlite3` native build; only data-file enrichments (no schema-altering edits).
- Existing `crossReferences` use `targetId`/`relationship`/`description` form; new entries follow same convention to stay consistent within the file.
- `axiomCount: 0`, `sorries: 0`, `status: "verified"` unchanged; verified Lean file has no structure-encoded assumptions or axiom declarations (and `additionalFiles: ["Proofs/SpernerMathlib4.lean"]` also has 0 axioms).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>