### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-03): Iter 6 — coprime_prime_pow_pow_of_ne (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -131,6 +131,31 @@ theorem prime_pow_dvd_lcmRange {p n : ℕ} (hp : p.Prime) (hn : 1 ≤ n) :
     p ^ Nat.log p n ∣ lcmRange n :=
   pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))
 
+/-- **Coprimality of distinct prime powers**: for distinct primes `p ≠ q`,
+    any prime-power factors `p ^ a` and `q ^ b` are coprime.
+
+    The pairwise-coprimality input needed to assemble the prime-power
+    factors of `lcmRange n` into Chebyshev's product decomposition
+    `lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ ⌊log_p n⌋`.
+
+    Combined with `prime_pow_dvd_lcmRange` it closes the easy direction
+    `(∏ p, p ^ ⌊log_p n⌋) ∣ lcmRange n` (next session): pairwise-coprime
+    divisors of a fixed `N` have their product dividing `N`.
+
+    Proof: `Nat.dvd_prime` reduces `p ∣ q` to `p = 1 ∨ p = q`; the first
+    contradicts `hp.one_lt`, the second contradicts `hpq`. Then
+    `Nat.Prime.coprime_iff_not_dvd` upgrades `¬ p ∣ q` to `Coprime p q`,
+    and `Coprime.pow_left a` / `Coprime.pow_right b` lift it to
+    `Coprime (p ^ a) (q ^ b)`. -/
+theorem coprime_prime_pow_pow_of_ne {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (a b : ℕ) : Nat.Coprime (p ^ a) (q ^ b) := by
+  have hndvd : ¬ p ∣ q := by
+    intro h
+    rcases (Nat.dvd_prime hq).mp h with h1 | heq
+    · exact hp.one_lt.ne' h1
+    · exact hpq heq
+  exact ((hp.coprime_iff_not_dvd.mpr hndvd).pow_left a).pow_right b
+
 /-- **Recursive structure**: lcm(1,...,n+1) = lcm(lcm(1,...,n), n+1).
 
     The inductive step that any inductive proof of Hanson's bound

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 255,
-    "theoremCount": 30,
+    "lineCount": 280,
+    "theoremCount": 31,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "mathlibDependencies": [

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -31,13 +31,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08",
-    "iteration": 3,
-    "focus": "Building structural lemma library toward prime-power decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}. Iteration 2 (#16704 merged) added lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange — any positive base power b^k ≤ n divides lcmRange n. Iteration 5 (this PR) specializes to the prime case: prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n — the maximal-prime-power half of Chebyshev's decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}.",
+    "iteration": 6,
+    "focus": "Building structural lemma library toward prime-power decomposition lcm(1,...,n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}. Iteration 2 (#16704 merged) added lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange — any positive base power b^k ≤ n divides lcmRange n. Iteration 5 (#17021 merged) specialized to the prime case: prime_pow_dvd_lcmRange. Iteration 6 (this PR) adds the pairwise-coprimality input coprime_prime_pow_pow_of_ne : for distinct primes p ≠ q and any exponents a, b, Coprime (p^a) (q^b). This is the structural prerequisite for the easy direction (∏ p ∈ filter Prime (range (n+1)), p^⌊log_p n⌋) ∣ lcmRange n of Chebyshev's decomposition: pairwise-coprime divisors of N have product dividing N.",
     "blockers": [
       "Mathlib lacks Beta-integral identity in rational-denominator form for Hanson's approach.",
       "Mathlib lacks the bridge `lcm(1,...,n) ≤ n · primorial(n)` for the easier 4^n route. (Note: the literal `≤ n · primorial(n)` form is FALSE — counterexample: lcm(1..9) = 2520 > 9 · 210 = 1890. The correct bridge is via Chebyshev's prime-power formula.)"
     ],
-    "nextAction": "Continue building the prime-power decomposition: the next structural step is `lcmRange_eq_prod_prime_powers : lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`. With prime_pow_dvd_lcmRange + pairwise-coprimality of distinct primes (Nat.Coprime.prime_pow_pow), the easy direction (RHS dvd LHS) follows from Finset.prod_dvd; the reverse direction follows from unique factorization (Mathlib's Nat.factorization framework).",
+    "nextAction": "Iteration 7 should prove `prod_prime_powers_dvd_lcmRange : (∏ p ∈ filter Prime (range (n+1)), p^Nat.log p n) ∣ lcmRange n` — the easy direction of Chebyshev's decomposition. Two ingredients are now in place: prime_pow_dvd_lcmRange (#17021) for each-factor-divides, and coprime_prime_pow_pow_of_ne (this PR) for pairwise-coprimality. Proof: Finset.induction on the prime filter; inductive step uses Nat.Coprime.prod_right (or .prod_left) to lift pairwise coprimality to coprime-with-product, then Nat.Coprime.mul_dvd_of_dvd_of_dvd to combine. Iteration 8+: reverse direction via Nat.factorization framework, then `lcmRange_eq_prod_prime_powers` by Nat.dvd_antisymm.",
     "attemptCounts": {
       "total": 5,
       "currentApproach": 1,
@@ -45,13 +45,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Iteration 5. `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (255 lines, 30 theorems, 1 def, 1 axiom, 0 sorries). Iteration 1 (bootstrap, merged) defined lcmRange and elementary bounds. Iteration 2 (#16704 merged) added structural lemmas lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange. Iteration 5 (this PR) adds `prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n`, the maximal-prime-power half of Chebyshev's decomposition. The proof is a one-line specialization of `pow_dvd_lcmRange` using `Nat.pow_log_le_self`. New imports: `Mathlib.Data.Nat.Log`, `Mathlib.Data.Nat.Prime.Basic`.",
+    "progressSummary": "Iteration 6. `Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (280 lines, 31 theorems, 1 def, 1 axiom, 0 sorries). Iteration 1 (bootstrap, merged) defined lcmRange and elementary bounds. Iteration 2 (#16704 merged) added structural lemmas lcmRange_succ, lcmRange_dvd_lcmRange_of_le, lcmRange_monotone. Iteration 3 (#16772 merged) added pow_dvd_lcmRange. Iteration 5 (#17021 merged) added prime_pow_dvd_lcmRange, the maximal-prime-power half of Chebyshev's decomposition. Iteration 6 (this PR) adds the pairwise-coprimality input `coprime_prime_pow_pow_of_ne {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) (a b : ℕ) : Nat.Coprime (p^a) (q^b)` — the structural prerequisite for the easy direction (∏ p, p^⌊log_p n⌋) ∣ lcmRange n of Chebyshev's decomposition. Proof: `Nat.dvd_prime hq` reduces `p ∣ q` to `p = 1 ∨ p = q`; `hp.one_lt.ne'` rules out `p = 1`, `hpq` rules out `p = q`; then `Nat.Prime.coprime_iff_not_dvd` + `Coprime.pow_left a` + `Coprime.pow_right b` lifts to the prime-power form.",
     "builtItems": [
       "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:80",
       "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:87-98",
       "dvd_lcmRange: each k ∈ {1,...,n} divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:101",
       "pow_dvd_lcmRange: any b^k ≤ n with positive base divides lcmRange n at BaselProblemOQ01OQ01OQ02OQ03.lean:114 (#16772)",
-      "prime_pow_dvd_lcmRange: ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n — at BaselProblemOQ01OQ01OQ02OQ03.lean:130 (this PR)",
+      "prime_pow_dvd_lcmRange: ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n — at BaselProblemOQ01OQ01OQ02OQ03.lean:130 (#17021)",
+      "coprime_prime_pow_pow_of_ne: for distinct primes p ≠ q and any exponents a, b, Coprime (p^a) (q^b) — at BaselProblemOQ01OQ01OQ02OQ03.lean:151 (this PR, Iteration 6)",
       "lcmRange_succ: recursion lcm(1..n+1) = lcm(lcm(1..n), n+1) (#16704)",
       "lcmRange_dvd_lcmRange_of_le: monotone divisibility (#16704)",
       "lcmRange_monotone: numerical monotonicity (#16704)",
@@ -71,7 +72,8 @@
       "The Chebyshev function reformulation ψ(n) = log lcm(1,...,n) connects this to the Prime Number Theorem (which gives only the asymptotic ψ(n)/n → 1).",
       "**Counterexample**: `lcm(1..n) ≤ n · primorial(n)` is FALSE in general — already at n=9 we have lcm(1..9) = 2520 > 9 · 210 = 1890. The intermediate primorial bridge as commonly stated does NOT yield the 4^n bound; the correct path goes through Chebyshev's prime-power formula `lcm(1..n) = ∏_{p prime ≤ n} p^{⌊log_p n⌋}`.",
       "**pow_dvd_lcmRange** is the structural-lemma counterpart of `dvd_lcmRange` for prime-power arguments: applied with `b = p` prime and `k = Nat.log p n`, with `Nat.pow_log_le_self p hn` it gives the maximal-prime-power divisibility `p^(⌊log_p n⌋) ∣ lcmRange n` in a single line — the easy direction of the Chebyshev decomposition.",
-      "**prime_pow_dvd_lcmRange** (Iteration 5) makes the corollary explicit. The proof is literally `pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))` — three Mathlib calls glued together. This is the canonical entry point for any prime-power Chebyshev-style argument on `lcmRange`."
+      "**prime_pow_dvd_lcmRange** (Iteration 5) makes the corollary explicit. The proof is literally `pow_dvd_lcmRange hp.pos (Nat.pow_log_le_self p (by omega))` — three Mathlib calls glued together. This is the canonical entry point for any prime-power Chebyshev-style argument on `lcmRange`.",
+      "**coprime_prime_pow_pow_of_ne** (Iteration 6) — the second half of the easy direction's machinery. The proof routes through `Nat.dvd_prime` rather than `Nat.prime_dvd_prime_iff_eq` to avoid an API drift risk: `(Nat.dvd_prime hq).mp` produces `p = 1 ∨ p = q`, both alternatives directly contradicting hypotheses (`hp.one_lt.ne'` and `hpq` respectively). The pow-lifting `((..).pow_left a).pow_right b` is the same idiom used in Erdos828Problem.lean:53 and Erdos1136Problem.lean:60 (cross-referenced for stability)."
     ],
     "mathlibGaps": [
       "No `lcm(1,...,n) ≤ X^n`-style bound exists in Mathlib for any X.",
@@ -79,14 +81,17 @@
       "No Beta-integral identity in usable rational form: `(n+1)·C(n,k)·∫₀¹ x^k(1-x)^(n-k) dx = 1`."
     ],
     "nextSteps": [
-      "✅ DONE (this PR): Added `prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n` (one-liner from `pow_dvd_lcmRange` + `Nat.pow_log_le_self`).",
-      "Add `lcmRange_eq_prod_prime_powers : lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p ^ Nat.log p n`. Forward direction (RHS ∣ LHS) follows from `prime_pow_dvd_lcmRange` + pairwise-coprimality of distinct primes; reverse direction uses Mathlib's `Nat.factorization` framework.",
+      "✅ DONE (#17021, Iteration 5): `prime_pow_dvd_lcmRange : ∀ p n, p.Prime → 1 ≤ n → p^(Nat.log p n) ∣ lcmRange n`.",
+      "✅ DONE (this PR, Iteration 6): `coprime_prime_pow_pow_of_ne : ∀ p q, p.Prime → q.Prime → p ≠ q → ∀ a b, Coprime (p^a) (q^b)`.",
+      "Iteration 7: `prod_prime_powers_dvd_lcmRange : (∏ p ∈ filter Prime (range (n+1)), p^Nat.log p n) ∣ lcmRange n` — easy direction. Proof: Finset.induction on the prime filter; inductive step combines `prime_pow_dvd_lcmRange` (each factor divides) with `coprime_prime_pow_pow_of_ne` lifted to coprime-with-product (via Nat.Coprime.prod_right) and Nat.Coprime.mul_dvd_of_dvd_of_dvd.",
+      "Iteration 8: reverse direction `lcmRange n ∣ ∏ p ∈ filter Prime (range (n+1)), p^Nat.log p n` via Mathlib's `Nat.factorization` framework.",
+      "Iteration 9: `lcmRange_eq_prod_prime_powers` by Nat.dvd_antisymm of Iter 7+8.",
       "With Chebyshev's decomposition, derive `lcmRange n ≤ ∏_{p ≤ n} n = n^{π(n)}` (still weaker than 3^n but proves a non-trivial bound).",
       "Wait for or contribute Mathlib Beta-integral machinery for ℚ-valued bounds.",
       "Explore Nair's 1982 alternative constants as a possibly-easier intermediate (uses central binomial coefficients).",
       "Add cross-references in `basel-problem-oq-01-oq-01-oq-02` and `basel-problem` gallery entries pointing to this OQ-03."
     ],
-    "markdown": "# Knowledge Base: basel-problem-oq-01-oq-01-oq-02-oq-03\n\nSee `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md` and `state.md` for full discussion.\n\n## Status\n\n* **Phase**: ACT (iteration 5)\n* **Files**: `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (255 lines, 30 theorems, 1 def, 1 axiom, 0 sorries; numerically verified n ∈ {1..10, 12, 15, 20}).\n* **Open target**: replace `axiom hanson_bound` with a theorem.\n* **Blocker**: Mathlib lacks Beta-integral / Chebyshev-prime-power-formula infrastructure.\n* **Iteration 5 (this PR)**: added `prime_pow_dvd_lcmRange`, the prime-power specialization of `pow_dvd_lcmRange`.\n"
+    "markdown": "# Knowledge Base: basel-problem-oq-01-oq-01-oq-02-oq-03\n\nSee `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/problem.md` and `state.md` for full discussion.\n\n## Status\n\n* **Phase**: ACT (iteration 6)\n* **Files**: `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` (280 lines, 31 theorems, 1 def, 1 axiom, 0 sorries; numerically verified n ∈ {1..10, 12, 15, 20}).\n* **Open target**: replace `axiom hanson_bound` with a theorem.\n* **Blocker**: Mathlib lacks Beta-integral / Chebyshev-prime-power-formula infrastructure.\n* **Iteration 6 (this PR)**: added `coprime_prime_pow_pow_of_ne`, the pairwise-coprimality input for the easy direction of Chebyshev's decomposition.\n"
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Summary

Iteration 6 for `basel-problem-oq-01-oq-01-oq-02-oq-03` (Hanson's bound `lcm(1,...,n) ≤ 3^n`). Adds the pairwise-coprimality input for the easy direction of Chebyshev's decomposition.

**New theorem** in `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean:150`:

```lean
theorem coprime_prime_pow_pow_of_ne {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
    (hpq : p ≠ q) (a b : ℕ) : Nat.Coprime (p ^ a) (q ^ b)
```

For distinct primes `p ≠ q`, any prime-power factors `p^a` and `q^b` are coprime — the structural prerequisite for assembling the prime-power factors of `lcmRange n` into Chebyshev's product decomposition `lcmRange n = ∏ p ∈ filter Prime (range (n+1)), p^⌊log_p n⌋`.

## Proof

Routes through `Nat.dvd_prime hq` rather than `Nat.prime_dvd_prime_iff_eq` to avoid Mathlib API drift risk:

1. `Nat.dvd_prime hq` reduces `p ∣ q` to `p = 1 ∨ p = q`.
2. `hp.one_lt.ne'` rules out `p = 1`; `hpq` rules out `p = q`.
3. `Nat.Prime.coprime_iff_not_dvd` upgrades `¬ p ∣ q` to `Coprime p q`.
4. `Coprime.pow_left a |>.pow_right b` lifts to `Coprime (p^a) (q^b)`.

Same idiom as `Erdos828Problem.lean:53` and `Erdos1136Problem.lean:60`.

## Why this matters

This is the second of two ingredients needed for the easy direction `(∏ p, p^⌊log_p n⌋) ∣ lcmRange n` of Chebyshev's decomposition:

| Ingredient | Source |
|---|---|
| each factor divides: `p^⌊log_p n⌋ ∣ lcmRange n` | `prime_pow_dvd_lcmRange` (#17021) |
| pairwise-coprimality of factors | **this PR** |
| product of pairwise-coprime divisors of N divides N | Mathlib (`Nat.Coprime.mul_dvd_of_dvd_of_dvd` + Finset induction) |

The reverse direction `lcmRange n ∣ ∏ p ∈ filter Prime (range (n+1)), p^⌊log_p n⌋` is harder and routes through Mathlib's `Nat.factorization` framework (planned Iteration 8).

## Files changed

- `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean`: 255 → 280 lines, 30 → 31 theorems, 1 def, 1 axiom, 0 sorries
- `src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json`: line/theorem count sync
- `src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json`: progressSummary, builtItems, insights, nextSteps for Iter 7+

## Status

- **Outcome**: progress (1 new theorem, structural prerequisite for Iter 7)
- **Build status**: pending (build-pending PR convention; cold-cache Docker queued separately)
- **Axiom count**: unchanged (1 axiom `hanson_bound`, the open target)
- **Next iteration**: `prod_prime_powers_dvd_lcmRange` — the easy direction itself (Finset induction, ~30 lines)

🤖 Generated by researcher-11