### PR TITLE
Enrich ballot-problem-oq-01-oq-04-oq-01: Whitworth/Bertrand/André/Dvoretzky-Motzkin history, cycle-lemma insight, lemma-block annotations

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/annotations.json
@@ -24,6 +24,31 @@
     ]
   },
   {
+    "id": "cf-good-rotation-properties",
+    "proofId": "ballot-problem-oq-01-oq-04-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 75,
+      "endLine": 331
+    },
+    "title": "Good Rotation Properties (L75–331)",
+    "content": "The ~250-line block proving four invariants of `chungFellerRot l`:\n\n• `chungFellerRot_head_eq_one`: the good rotation always begins with `+1`. Reason: `1 :: l` has at least one entry equal to 1 (the prepended head), and rotating to put the rightmost minimum *position* at the front lands a 1 at the head.\n• `chungFellerRot_tail_nonneg_prefixSum`: dropping the leading 1 yields a sequence whose every prefix sum is ≥ 0. Reason: after rotation, all prefix sums of `chungFellerRot l` are ≥ 1 (since we rotated past the minimum); subtracting the leading 1 shifts these down by 1, giving prefix sums ≥ 0 — the Dyck condition.\n• `chungFellerRot_tail_upsteps_all_above`: every upstep in the tail crosses the *axis* (i.e., is one of the upsteps of a Dyck path). Used in the type-counting argument.\n• `chungFellerRot_tail_type_eq_n`: the tail's `upstepsAboveAxis` equals exactly $n$ — i.e., the tail is a *Type-n* path. Combined with the prefix-sum bound, this is what makes the tail a Dyck path.\n\nThese four invariants together give `chungFellerRot_tail_is_dyck` (lemma below) — the cornerstone of the bijection: every balanced path's good rotation has a Dyck-path tail.",
+    "significance": "critical",
+    "mathContext": "The Dvoretzky-Motzkin cycle lemma in concrete form: among the $|l|+1$ cyclic rotations of $1\\!::\\!l$, the rotation by `rightmostMinPos(1::l)` is the *unique* rotation whose tail satisfies $\\sum_{i \\leq k} t_i \\geq 0$ for all $k$. This invariant is what the four lemmas in L75–331 establish in machine-checkable detail.",
+    "relatedConcepts": [
+      "cycle lemma",
+      "Dvoretzky-Motzkin",
+      "rightmostMinPos",
+      "prefix sum invariants",
+      "upstepsAboveAxis"
+    ],
+    "prerequisites": [
+      "cyclicRotation API",
+      "rightmostMinPos lemmas",
+      "prefix-sum manipulation"
+    ]
+  },
+  {
     "id": "cf-tail-is-dyck",
     "proofId": "ballot-problem-oq-01-oq-04-oq-01",
     "type": "theorem",
@@ -68,6 +93,32 @@
       "chungFellerRot definition",
       "cyclicRotation_compose_wrap",
       "rightmostMinPos uniqueness"
+    ]
+  },
+  {
+    "id": "cf-chung-feller-map",
+    "proofId": "ballot-problem-oq-01-oq-04-oq-01",
+    "type": "definition",
+    "range": {
+      "startLine": 456,
+      "endLine": 781
+    },
+    "title": "chungFellerMap and Reconstruction Lemmas (L456–781)",
+    "content": "`chungFellerMap n hn l` (around L456) is defined as the pair $(D, t)$ where $D$ is the *tail* of `chungFellerRot l` (a Dyck path of semi-length $n$) and $t$ is the path `type` index — `upstepsAboveAxis l : Fin (n+1)`. This is the candidate bijection whose injectivity and surjectivity are established later (L782–1023).\n\nThe ~325 lines following the definition build the *reconstruction* infrastructure needed for the bijectivity proof:\n• Inverse-rotation lemmas: given a Dyck path $D$ and a type $k$, recover the unique balanced path $l$ whose `chungFellerRot` has tail $D$ and whose `upstepsAboveAxis = k`. The inverse is `cyclicRotation` of `1::D` by `n+1-k` (mod) followed by tail extraction.\n• `cyclicRotation_get?_zero` and friends: characterize the entry of a rotated list at position 0, used to relate $l$'s head to the rotation amount.\n• Type-index transport lemmas: show that `upstepsAboveAxis` is invariant under the bijection in the controlled way the bijectivity proof needs (it equals the rotation index, which is the type).\n\nThe payoff is `chung_feller_bijection_exists` (next annotation): both injectivity (via reconstruction) and surjectivity (via building $l$ from $(D, k)$) become one-line applications.",
+    "significance": "critical",
+    "mathContext": "$\\text{chungFellerMap}: \\{\\text{balanced paths of length }2n\\} \\to \\{\\text{Dyck paths of semi-length }n\\} \\times \\{0,1,\\ldots,n\\}$. The map is the *combinatorial heart* of Chung-Feller: it canonicalises each rotation orbit (yielding the Dyck representative) and exposes the rotation index (the type) as a structurally meaningful coordinate. Inverting the map: given $(D, k)$, the preimage is the $k$-th rotation of $1\\!::\\!D$ (with the leading 1 removed), which has exactly $k$ upsteps above the axis.",
+    "relatedConcepts": [
+      "bijection construction",
+      "cyclicRotation_get?_zero",
+      "inverse rotation",
+      "type index",
+      "orbit canonicalisation"
+    ],
+    "prerequisites": [
+      "chungFellerRot tail-is-Dyck",
+      "cyclicRotation API",
+      "Fin arithmetic",
+      "upstepsAboveAxis"
     ]
   },
   {

--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
@@ -45,7 +45,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Chung-Feller theorem (1949) states that among all balanced lattice paths of length 2n (equal steps up and down), the paths with exactly k 'upsteps above the axis' are counted by the Catalan number Cₙ = C(2n,n)/(n+1), independently of k ∈ {0,1,...,n}. This gives a combinatorial proof that Cₙ = C(2n,n)/(n+1) by counting all (n+1)·Cₙ balanced paths.\n\nThe bijection proceeds by 'good rotation': given a balanced path l, prepend 1 to get (1::l), then cyclically rotate by the position of the rightmost minimum. The rotation starts with 1 (always) and its tail is a Dyck path. The rotation index encodes the 'type' of l — how many upsteps cross the axis.\n\nThis formalization answers OQ-01 of ballot-problem-oq-01-oq-04: 'Can we prove the bijection explicitly?' with a complete, verified proof.",
+    "historicalContext": "The combinatorial setting traces to W. A. Whitworth's *Choice and Chance* (1879) and Joseph Bertrand's classical 1887 ballot problem: in how many ways can the votes for two candidates be counted so that one always leads? Désiré André's 1887 reflection-principle proof (the same year as Bertrand's note in *Comptes Rendus*) gave the modern $\\binom{2n}{n} - \\binom{2n}{n-1}$ formula. The *cycle lemma* — that exactly one cyclic rotation of any sequence with positive sum has all positive prefix sums — was first stated explicitly by Aryeh Dvoretzky and Theodore Motzkin in 1947 (\"A problem of arrangements\", *Duke Math. J.*) and is the structural backbone of every modern Catalan / ballot-style enumeration. The Chung-Feller theorem appeared in K. L. Chung and W. Feller's 1949 paper \"On fluctuations in coin-tossing\" (*Proc. Nat. Acad. Sci.*), strengthening the ballot result: among all balanced ±1 paths of length $2n$, those with exactly $k$ upsteps above the axis are *equinumerous* for every $k \\in \\{0,1,\\ldots,n\\}$, each class containing exactly $C_n = \\binom{2n}{n}/(n+1)$ paths. This gives a *combinatorial* — not just generating-function — proof that $|{\\text{Dyck paths}}| = C_n$, by counting balanced paths in two ways. The proof presented here mechanizes the explicit bijection (used by Stanley in *Catalan Numbers* §1.6.1; called the \"second proof\" on Wikipedia): prepend 1 to a balanced path $l$, rotate by the *rightmost minimum* position, take the tail. The rightmost-minimum choice is the unique rotation making the tail a Dyck path — exactly the cycle-lemma content. This entry answers OQ-01 of `ballot-problem-oq-01-oq-04` (\"Can we prove the bijection explicitly?\") with a complete, verified construction, eliminating the `chung_feller_uniform` axiom that the parent entry previously used.",
     "problemStatement": "**Chung-Feller theorem**: For any n ≥ 1 and any j, k ∈ {0,...,n}:\n|{balanced paths of length 2n and type j}| = |{balanced paths of length 2n and type k}|\n(where 'type j' means the path has exactly j upsteps above the horizontal axis).\n\nFormalized as: `chung_feller_uniform'`.",
     "text": "A 1164-line explicit construction of the Chung-Feller bijection. The proof establishes: (1) the good rotation produces a Dyck path as its tail, (2) paths in the same rotation orbit share the same Dyck image, (3) the bijection chungFellerMap is injective (via inversion) and surjective, (4) uniform distribution follows by type-swapping through the bijection.",
     "proofStrategy": "**Definitions**: `chungFellerRot l = cyclicRotation (1::l) (rightmostMinPos (1::l))` — cyclic rotation of (1::l) by the position of the rightmost minimum. `chungFellerMap n hn l = (tail of chungFellerRot l, upstepsAboveAxis l)`.\n\n**Step 1 (good rotation is Dyck)**: `chungFellerRot_tail_is_dyck` — the tail D of the good rotation satisfies IsDyckPath D n. Proof: D has all non-negative prefix sums (since the rightmostMinPos rotation ensures this) and upstepsAboveAxis D = n.\n\n**Step 2 (orbit invariance)**: `orbit_same_dyck` — if l₂ is a cyclic rotation of l₁ by r, then chungFellerRot l₁ = chungFellerRot l₂ (they map to the same Dyck path). The good rotation is orbit-canonical.\n\n**Step 3 (bijectivity)**: `chung_feller_bijection_exists` — injectivity: if two balanced paths have the same (Dyck, type) pair, they must be the same path (reconstruct from D and type). Surjectivity: every (D, k) pair comes from some balanced path (the k-th rotation of (1::D)).\n\n**Step 4 (uniformity)**: `chung_feller_uniform'` — apply `Set.ncard_congr` with the type-swapping map: send a type-j path l to the unique type-k preimage sharing the same Dyck path. This map is well-defined and bijective via the bijection e.",
@@ -53,7 +53,10 @@
       "**Rightmost minimum rotation**: The key insight is that among all cyclic rotations of (1::l), exactly one starts with 1 and has all subsequent prefix sums ≥ 1 (the 'good rotation'). Taking the rightmost minimum position ensures uniqueness. This is the cycle lemma in disguise.",
       "**Orbit-canonical Dyck path**: All n+1 balanced paths in the same rotation orbit (the orbit of 1::D under cyclic rotation) share the same Dyck path D as their chungFellerRot tail. This is the structural key: the bijection sends each orbit to a single Dyck path, with the path type encoding which element of the orbit the path is.",
       "**Type-swapping surjection for uniformity**: `chung_feller_uniform'` avoids recomputing cardinalities by using `Set.ncard_congr`. The type-swapping map l ↦ e.symm((e(l).1, ⟨k, ...⟩)) replaces the type index j with k while keeping the Dyck path. This is a bijection between type-j and type-k paths.",
-      "**Injectivity via reconstruction**: To show injectivity of chungFellerMap, given (D, type₁) = (D, type₂), reconstruct the original paths as specific rotations of (1::D). The reconstruction uses cyclicRotation_get?_zero and the inverse rotation formula."
+      "**Injectivity via reconstruction**: To show injectivity of chungFellerMap, given (D, type₁) = (D, type₂), reconstruct the original paths as specific rotations of (1::D). The reconstruction uses cyclicRotation_get?_zero and the inverse rotation formula.",
+      "**Cycle lemma packaged geometrically**: The Dvoretzky-Motzkin cycle lemma (1947) — \"exactly one cyclic rotation of a positive-sum sequence has all positive prefix sums\" — is what makes `chungFellerRot` well-defined. The choice of *rightmost* minimum (rather than leftmost) ensures that the augmented `(1::l)` rotation, once shifted, has all *strict* prefix sums ≥ 1, and so the *tail* (after dropping the leading 1) has prefix sums ≥ 0 — i.e., is a Dyck path. The rightmost-vs-leftmost asymmetry is necessary because of the prepended 1.",
+      "**Two-way counting reveals C_n = (1/(n+1))·(2n choose n)**: Total balanced paths of length 2n = $\\binom{2n}{n}$. The bijection partitions them into $n+1$ classes by type, each of equal size = $C_n$. Therefore $\\binom{2n}{n} = (n+1) \\cdot C_n$, giving the closed form $C_n = \\frac{1}{n+1}\\binom{2n}{n}$ as a *combinatorial corollary* — no Catalan recurrence or generating function needed. This is the Chung-Feller proof's distinguishing virtue.",
+      "**Reflection-principle complement**: For the original Bertrand ballot problem, the standard proof is André's reflection (1887). The Chung-Feller bijection is its sibling for the *symmetric* counting variant: while reflection gives a non-bijective inclusion-exclusion, Chung-Feller gives a clean bijection — a useful pedagogical contrast available in this gallery via the cross-references below."
     ],
     "prerequisites": [
       "Dyck paths and Catalan numbers",
@@ -72,6 +75,16 @@
       "targetId": "ballot-problem-oq-01",
       "relationship": "related",
       "description": "Parent ballot problem formalization; this proves the uniform distribution subcase"
+    },
+    {
+      "targetId": "ballot-problem",
+      "relationship": "ancestor",
+      "description": "Original Bertrand-1887 ballot problem entry; uses André's reflection principle (1887). This entry's bijective Chung-Feller approach is the structural complement to reflection — both prove ballot-style equalities, with bijection winning when one needs an explicit *witness* for each class."
+    },
+    {
+      "targetId": "catalan-numbers",
+      "relationship": "applies-to",
+      "description": "The Chung-Feller bijection gives a self-contained combinatorial proof that the n-th Catalan number is $\\binom{2n}{n}/(n+1)$ via two-way counting of balanced paths."
     }
   ],
   "leanFile": {
@@ -137,7 +150,9 @@
     "openQuestions": [
       "Generalize to k-balanced paths (paths with p ups and q downs, gcd(p,q)=1) — the generalized ballot problem",
       "Connect to the Lindström-Gessel-Viennot lemma for multi-path generalizations",
-      "Prove the Chung-Feller theorem using the kernel method (generating function approach) for a second proof"
+      "Prove the Chung-Feller theorem using the kernel method (generating function approach) for a second proof",
+      "Extract a *computable* bijection: as currently formalized `chungFellerMap` and its inverse should be definitionally computable (no choice principles used) — confirm and demonstrate by `#eval`-ing on small n.",
+      "Lift the file to `Mathlib.Combinatorics.Catalan` as a contribution: the Chung-Feller bijection complements `Mathlib`'s existing Catalan API (recursion-based) with an explicit combinatorial route."
     ]
   },
   "sorries": 0


### PR DESCRIPTION
First enrichment pass for `ballot-problem-oq-01-oq-04-oq-01` (Chung-Feller Bijection: Rotation Index to Path Type). Previously **0** enrichment PRs in history.

## Improvements

**meta.json**
- `overview.historicalContext`: ~530 → ~1800 chars. Adds W. A. Whitworth's *Choice and Chance* (1879), Bertrand's classical 1887 ballot problem (*Comptes Rendus*), André's 1887 reflection-principle proof, the Dvoretzky-Motzkin 1947 cycle lemma (*Duke Math. J.*), Chung-Feller's 1949 paper (*Proc. Nat. Acad. Sci.*), and Stanley's *Catalan Numbers* §1.6.1 packaging.
- `overview.keyInsights`: 4 → 7. Adds (a) the rightmost-vs-leftmost-minimum asymmetry as the operational form of the cycle lemma; (b) the two-way-counting derivation of $C_n = \binom{2n}{n}/(n+1)$ as a *combinatorial corollary* — distinguishing virtue of Chung-Feller; (c) reflection-principle complement contrast (André vs Chung-Feller).
- `crossReferences`: 2 → 4 (ballot-problem root with André reflection contrast; catalan-numbers application).
- `conclusion.openQuestions`: 3 → 5 (computable-bijection demonstration via `#eval`; potential `Mathlib.Combinatorics.Catalan` contribution).

**annotations.json** (5 → 7 entries)
- `+cf-good-rotation-properties` (L75–331): summarises the four invariants `chungFellerRot_head_eq_one` / `tail_nonneg_prefixSum` / `tail_upsteps_all_above` / `tail_type_eq_n`. Previously this ~250-line block had no annotation; only the lemma-cluster summary on L332+ (`cf-tail-is-dyck`) was covered.
- `+cf-chung-feller-map` (L456–781): the `chungFellerMap` definition plus the ~325-line reconstruction infrastructure (`cyclicRotation_get?_zero`, inverse rotation, type-index transport). Previously only `cf-orbit-same-dyck` (L388–456) covered any of this band.

## Quality target check

- ≥ 5 annotations w/ mathContext, significance, relatedConcepts → 7/7 ✓
- historicalContext > 200 chars → 1807 chars ✓
- ≥ 4 keyInsights → 7 ✓
- conclusion w/ summary, implications, ≥ 2 openQuestions → 5 openQs ✓
- sections covering full file → already covers L44–L1164 ✓

## Notes

- No Lean source changes; only JSON enrichment. Both files parse cleanly under `python3 json.load`.
- Branch rebased onto current `origin/main`; diff is exactly the 2 enriched JSON files.
- `pnpm build` not run: pnpm install fails in this environment on `better-sqlite3` native build; only data-file enrichments (no schema-altering edits).
- Existing `crossReferences` use `targetId`/`relationship`/`description` form; new entries follow same convention.
- `axiomCount: 0`, `sorries: 0`, `status: "verified"` unchanged; verified Lean file has no structure-encoded assumptions or axiom declarations (`additionalFiles: ["Proofs/BallotProblemOQ01OQ04Core.lean"]` also has 0 axioms per `assumptions` field).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>