### PR TITLE
fix(meta): sync meta.additionalFiles for 15 entries (auditor blindspot)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-04-04",
     "status": "verified",
     "proofRepoPath": "Proofs/AlgebraicNumbersCountable.lean",
+    "additionalFiles": [
+      "Proofs/AlgebraicNumbersCountableAristotle.lean"
+    ],
     "tags": [
       "set-theory",
       "countability",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-04-25",
     "status": "verified",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean",
+    "additionalFiles": [
+      "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
+    ],
     "tags": [
       "algebra",
       "symmetric-functions",

--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -9,6 +9,9 @@
     "date": "1729",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02.lean",
+    "additionalFiles": [
+      "Proofs/AmgmInequalityOQ02Aristotle.lean"
+    ],
     "tags": [
       "analysis",
       "inequalities",

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -9,6 +9,9 @@
     "date": "~300 BCE / 1821",
     "status": "verified",
     "proofRepoPath": "Proofs/AMGMInequality.lean",
+    "additionalFiles": [
+      "Proofs/AMGMInequalityAristotle.lean"
+    ],
     "tags": [
       "analysis",
       "inequalities",

--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -16,6 +16,9 @@
       "angle-trisection"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
+    "additionalFiles": [
+      "Proofs/AngleTrisectionOQ02OQ04OQ01Aristotle.lean"
+    ],
     "badge": "wip",
     "sorries": 2,
     "mathlibDependencies": [

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -18,6 +18,9 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/AngleTrisection.lean",
+    "additionalFiles": [
+      "Proofs/AngleTrisectionAristotle.lean"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -9,6 +9,9 @@
     "date": "1901",
     "status": "verified",
     "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ03.lean",
+    "additionalFiles": [
+      "Proofs/AreaOfCircleOQ01OQ03Aristotle.lean"
+    ],
     "tags": [
       "analysis",
       "geometry",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
@@ -7,6 +7,9 @@
     "author": "Classical (Schläfli / Euler)",
     "status": "verified",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ03.lean",
+    "additionalFiles": [
+      "Proofs/ArithmeticSeriesOQ02OQ03Aristotle.lean"
+    ],
     "tags": [
       "combinatorics",
       "simplicial numbers",

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -9,6 +9,9 @@
     "date": "1978",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
+    "additionalFiles": [
+      "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean"
+    ],
     "tags": [
       "number-theory",
       "irrationality",

--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -9,6 +9,9 @@
     "date": "2000",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BaselProblemOQ02.lean",
+    "additionalFiles": [
+      "Proofs/BaselProblemOQ02Aristotle.lean"
+    ],
     "tags": [
       "analysis",
       "number-theory",

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json
@@ -9,6 +9,9 @@
     "date": "1896",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BertrandsPostulateOQ03OQ04.lean",
+    "additionalFiles": [
+      "Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean"
+    ],
     "tags": [
       "number-theory",
       "prime-numbers",

--- a/src/data/proofs/bezout-identity-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-02-15",
     "status": "verified",
     "proofRepoPath": "Proofs/BezoutIdentityOQ01.lean",
+    "additionalFiles": [
+      "Proofs/BezoutIdentityOQ01Aristotle.lean"
+    ],
     "tags": [
       "number-theory",
       "bezout-identity",

--- a/src/data/proofs/binomial-theorem-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01/meta.json
@@ -9,6 +9,9 @@
     "date": "1665",
     "status": "verified",
     "proofRepoPath": "Proofs/BinomialTheoremOQ01.lean",
+    "additionalFiles": [
+      "Proofs/BinomialTheoremOQ01Aristotle.lean"
+    ],
     "tags": [
       "analysis",
       "combinatorics",

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -80,6 +80,9 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "bsd",
     "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean",
+    "additionalFiles": [
+      "Proofs/BirchSwinnertonDyerAristotle.lean"
+    ],
     "lineCount": 7435,
     "mathlib_version": "4.26.0",
     "theoremCount": 254,

--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -7,6 +7,9 @@
     "author": "Lean Genius Researcher",
     "status": "verified",
     "proofRepoPath": "Proofs/BirthdayProblemOQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/BirthdayProblemOQ01OQ01Aristotle.lean"
+    ],
     "tags": [
       "probability",
       "birthday-problem",


### PR DESCRIPTION
## Summary

Adds `meta.additionalFiles` to mirror existing `lf.additionalFiles` for 15 entries where Aristotle companion files exist but were silently invisible to the auditor.

## Background

`scripts/auditor/find-targets.ts` reads `meta.meta.additionalFiles` (line 151) when resolving all Lean files for sorry/axiom counting. The mechanic memory note `[additionalFiles schema split — meta.meta vs meta.leanFile]` flags that PR #16669 only updated the `leanFile.additionalFiles` side, leaving `meta.additionalFiles` empty — so `find-targets` continues to skip these companions.

This is a **future-proofing** fix: all 15 entries currently have `compS == 0` and `compA == 0`, so adding the companions to `meta.additionalFiles` does not change find-targets verdicts today. But it ensures any future drift in companion files (sorries added, axioms introduced) is caught by the auditor on the next pass.

## Selection criteria

Each entry meets ALL of:
1. `meta.leanFile.additionalFiles` is non-empty (companion exists)
2. `meta.meta.additionalFiles` is empty/missing (schema split)
3. Main Lean file does NOT `import` the companion (so find-targets cannot auto-follow)
4. Companion file exists at the listed path
5. `meta.sorries == mainSorries + companionSorries` (totals consistent — won't gain new mismatch)
6. `meta.axiomCount >= mainAxioms + companionAxioms` (find-targets axiom check stays green)
7. No open PR currently editing `meta.json` (avoids merge conflicts)

## Verified

After applying the fix, my mimic of `find-targets.ts` aggregation logic flags **0 issues** across all 15 entries.

## Entries (alphabetical, batch 1 of ~5)

| slug | companion |
|---|---|
| algebraic-numbers-countable | AlgebraicNumbersCountableAristotle |
| amgm-inequality | AMGMInequalityAristotle |
| amgm-inequality-oq-02 | AmgmInequalityOQ02Aristotle |
| amgm-inequality-oq-02-oq-01-oq-02-oq-01 | AmgmInequalityOQ02OQ01OQ02OQ01Aristotle |
| angle-trisection | AngleTrisectionAristotle |
| angle-trisection-oq-02-oq-04-oq-01 | AngleTrisectionOQ02OQ04OQ01Aristotle |
| area-of-circle-oq-01-oq-03 | AreaOfCircleOQ01OQ03Aristotle |
| arithmetic-series-oq-02-oq-03 | ArithmeticSeriesOQ02OQ03Aristotle |
| basel-problem-oq-01-oq-01-oq-02 | BaselProblemOQ01OQ01OQ02Aristotle |
| basel-problem-oq-02 | BaselProblemOQ02Aristotle |
| bertrands-postulate-oq-03-oq-04 | BertrandsPostulateOQ03OQ04Aristotle |
| bezout-identity-oq-01 | BezoutIdentityOQ01Aristotle |
| binomial-theorem-oq-01 | BinomialTheoremOQ01Aristotle |
| birch-swinnerton-dyer | BirchSwinnertonDyerAristotle |
| birthday-problem-oq-01-oq-01 | BirthdayProblemOQ01OQ01Aristotle |

15 files changed, 45 insertions(+) — each diff is exactly 3 lines added after `proofRepoPath`.

## Test plan

- [x] All meta.json files re-parse as valid JSON after edit
- [x] Mimic of find-targets aggregation flags 0 issues on changed entries
- [x] No existing open PRs touch these meta.json files
- [ ] CI auditor pass after merge confirms no regressions