### PR TITLE
audit(tracker): bezout-identity-oq-01 — 3rd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -796,9 +796,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:46Z",
+      "lastAudited": "2026-05-08T13:45:05Z",
       "result": "clean"
     },
     "bezout-identity-oq-02": {


### PR DESCRIPTION
3rd audit pass — clean.

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 208 | 208 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |

- No True stubs.
- additionalFiles `Proofs/BezoutIdentityOQ01Aristotle.lean` exists.
- status `verified` / badge `original` consistent with 0-axiom 0-sorry computable proof.
- Not a Mathlib wrapper: uses `Nat.gcd_rec`/`Nat.div_add_mod` as steps in well-founded induction, doesn't delegate the main result.