### PR TITLE
research(hilbert-11-oq-02): S15 — fully parametric lift-z Hensel theorem (Case-B z₀≠0; build pending)

### DIFF
--- a/proofs/Proofs/Hilbert11OQ02.lean
+++ b/proofs/Proofs/Hilbert11OQ02.lean
@@ -692,6 +692,218 @@ axiom less load-bearing in practice.
   single-line corollaries; the four Case-A primes from Section 9
   (`p ∈ {11, 17, 23, 29}`) all admit axiom-free `ℚ_[p]`-solubility proofs. -/
 
+/-! ## Section 15: General Lift-z Hensel Theorem (Case-B subset)
+
+Section 13's `selmer_padic_solubility_caseA` lifts the `(0, 1, z)` projection of
+the Selmer cubic, covering primes whose Section 9 witness has the `(0, 1, z₀)`
+shape (`p ∈ {11, 17, 23, 29}`). Several Case-B primes
+(`p ≡ 1 (mod 3)`, `p ≥ 7`) admit different witness shapes, but for many of them
+the *same kind* of lift — fixing `(x, y) = (x₀, y₀) ∈ ℤ²` and Hensel-lifting `z`
+— still works, with a coefficient `c = 3·x₀³ + 4·y₀³` substituting for the bare
+constant `4` of Section 13.
+
+This section states the fully general lift-z theorem
+`selmer_padic_solubility_lift_z` and discharges the Case-B primes
+`p ∈ {13, 19, 31, 37}` as one-line corollaries. The remaining Case-B prime
+`p = 7` has Section-9 witness `(1, 1, 0)` with `z₀ = 0`, so the
+`IsCoprime (15·0² : ℤ) (7 : ℤ) = IsCoprime 0 7` hypothesis fails: lift-z is
+unavailable at `p = 7` and a complementary lift-x parametric theorem is needed
+in a later iteration. -/
+
+namespace HenselLiftZ
+
+open Polynomial
+
+/-- The univariate polynomial `G(z) = c + 5z³ ∈ ℤ[z]`, parametric in the
+    constant term `c`. Specialized to `c = 3·x₀³ + 4·y₀³` it becomes the
+    Selmer cubic with the `(x, y) = (x₀, y₀)` projection.
+    `Section 13.HenselCaseA.Gint` is exactly `G 4` (the `(0, 1, z)` slice). -/
+def G (c : ℤ) : Polynomial ℤ := C c + C 5 * X ^ 3
+
+private lemma G_derivative_eq (c : ℤ) : (G c).derivative = C 15 * X ^ 2 := by
+  unfold G
+  rw [derivative_add, derivative_C, zero_add, derivative_C_mul,
+      derivative_X_pow]
+  push_cast
+  ring
+
+private lemma G_aeval {p : ℕ} [Fact (Nat.Prime p)] (c : ℤ) (a : ℤ_[p]) :
+    aeval a (G c) = (c : ℤ_[p]) + (5 : ℤ_[p]) * a ^ 3 := by
+  unfold G
+  rw [map_add, map_mul, map_pow, aeval_C, aeval_C, aeval_X]
+  push_cast
+  ring
+
+private lemma G_derivative_aeval {p : ℕ} [Fact (Nat.Prime p)] (c : ℤ) (a : ℤ_[p]) :
+    aeval a (G c).derivative = (15 : ℤ_[p]) * a ^ 2 := by
+  rw [G_derivative_eq, map_mul, map_pow, aeval_C, aeval_X]
+  push_cast
+  ring
+
+end HenselLiftZ
+
+/-- **General lift-z Hensel theorem for the Selmer cubic.**
+
+    For any prime `p`, integer triple `(x₀, y₀, z₀)` with `(x₀, y₀) ≠ (0, 0)`,
+    and divisibility hypotheses
+    * `(p : ℤ) ∣ (3·x₀³ + 4·y₀³ + 5·z₀³)` — `(x₀, y₀, z₀)` is a mod-`p` zero
+      of the Selmer cubic,
+    * `IsCoprime (15·z₀² : ℤ) (p : ℤ)` — the `z`-derivative
+      `∂_z(3x³+4y³+5z³) = 15z²` is invertible mod `p` at `z₀`,
+
+    Mathlib's univariate Hensel lemma applied to
+    `HenselLiftZ.G (3·x₀³ + 4·y₀³)` lifts `z₀` to `zt ∈ ℤ_[p]` satisfying
+    `(3·x₀³ + 4·y₀³) + 5·zt³ = 0`. The triple
+    `((x₀ : ℚ_[p]), (y₀ : ℚ_[p]), (zt : ℚ_[p]))` is then a nontrivial
+    `ℚ_[p]`-zero of the Selmer cubic.
+
+    This generalizes Section 13's `selmer_padic_solubility_caseA` (which fixes
+    `x₀ = 0, y₀ = 1`) to any integer projection that fixes the `z`-coordinate
+    last. It dispatches Section 9's Case-B primes whose witness has nonzero
+    `z₀`: `p ∈ {13, 19, 31, 37}`. The Case-B prime `p = 7` has `z₀ = 0` and
+    is *not* covered (the coprimality hypothesis fails); a complementary
+    lift-x theorem is left for a future iteration. -/
+theorem selmer_padic_solubility_lift_z {p : ℕ} [Fact (Nat.Prime p)]
+    (x₀ y₀ z₀ : ℤ)
+    (h_xy_nontriv : x₀ ≠ 0 ∨ y₀ ≠ 0)
+    (h_root_div : (p : ℤ) ∣ (3 * x₀ ^ 3 + 4 * y₀ ^ 3 + 5 * z₀ ^ 3))
+    (h_deriv_coprime : IsCoprime (15 * z₀ ^ 2 : ℤ) (p : ℤ)) :
+    ∃ (x y z : ℚ_[p]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 := by
+  set c : ℤ := 3 * x₀ ^ 3 + 4 * y₀ ^ 3 with hc_def
+  have h_c_plus : c + 5 * z₀ ^ 3 = 3 * x₀ ^ 3 + 4 * y₀ ^ 3 + 5 * z₀ ^ 3 := by
+    rw [hc_def]
+  have h_div_total : (p : ℤ) ∣ (c + 5 * z₀ ^ 3) := by
+    rw [h_c_plus]; exact h_root_div
+  have h_aeval :
+      aeval ((z₀ : ℤ_[p])) (HenselLiftZ.G c) =
+        (((c + 5 * z₀ ^ 3 : ℤ)) : ℤ_[p]) := by
+    rw [HenselLiftZ.G_aeval]
+    push_cast
+    ring
+  have h_deriv :
+      aeval ((z₀ : ℤ_[p])) (HenselLiftZ.G c).derivative =
+        (((15 * z₀ ^ 2 : ℤ)) : ℤ_[p]) := by
+    rw [HenselLiftZ.G_derivative_aeval]
+    push_cast
+    ring
+  have h_norm_root :
+      ‖aeval ((z₀ : ℤ_[p])) (HenselLiftZ.G c)‖ < 1 := by
+    rw [h_aeval, PadicInt.norm_intCast_lt_one_iff]
+    exact_mod_cast h_div_total
+  have h_norm_deriv :
+      ‖aeval ((z₀ : ℤ_[p])) (HenselLiftZ.G c).derivative‖ = 1 := by
+    rw [h_deriv, PadicInt.norm_intCast_eq_one_iff]
+    exact h_deriv_coprime
+  have h_hensel :
+      ‖aeval ((z₀ : ℤ_[p])) (HenselLiftZ.G c)‖ <
+        ‖aeval ((z₀ : ℤ_[p])) (HenselLiftZ.G c).derivative‖ ^ 2 := by
+    rw [h_norm_deriv, one_pow]
+    exact h_norm_root
+  obtain ⟨zt, hz_root, _, _, _⟩ := hensels_lemma h_hensel
+  have hz_int : (c : ℤ_[p]) + 5 * zt ^ 3 = 0 := by
+    have heval := HenselLiftZ.G_aeval c zt
+    rw [heval] at hz_root
+    exact hz_root
+  refine ⟨(x₀ : ℚ_[p]), (y₀ : ℚ_[p]), (zt : ℚ_[p]), ?_, ?_⟩
+  · -- Nontriviality from `(x₀, y₀) ≠ (0, 0)` (using injectivity of ℤ → ℚ_[p]).
+    rcases h_xy_nontriv with hx | hy
+    · left
+      exact_mod_cast hx
+    · right; left
+      exact_mod_cast hy
+  · -- selmerPoly value: 3·x₀³ + 4·y₀³ + 5·zt³ = c + 5·zt³ = 0.
+    have hcast_zint : (c : ℚ_[p]) + 5 * (zt : ℚ_[p]) ^ 3 = 0 := by
+      have h := congrArg (fun w : ℤ_[p] => (w : ℚ_[p])) hz_int
+      push_cast at h
+      exact h
+    have h_c_cast :
+        ((c : ℤ) : ℚ_[p]) =
+          (3 : ℚ_[p]) * (x₀ : ℚ_[p]) ^ 3 + 4 * (y₀ : ℚ_[p]) ^ 3 := by
+      rw [hc_def]
+      push_cast
+      ring
+    show (3 : ℚ_[p]) * (x₀ : ℚ_[p]) ^ 3 + 4 * (y₀ : ℚ_[p]) ^ 3 +
+          5 * (zt : ℚ_[p]) ^ 3 = 0
+    linear_combination hcast_zint - h_c_cast
+
+instance : Fact (Nat.Prime 13) := ⟨by decide⟩
+instance : Fact (Nat.Prime 19) := ⟨by decide⟩
+instance : Fact (Nat.Prime 31) := ⟨by decide⟩
+instance : Fact (Nat.Prime 37) := ⟨by decide⟩
+
+/-- ℚ_[13] solubility of the Selmer cubic via the `(1, 4, 2)` Case-B witness
+    (cf. `selmer_witness_p13`). Routine corollary of
+    `selmer_padic_solubility_lift_z`; the witness data
+    `13 ∣ 3·1 + 4·4³ + 5·2³ = 299 = 13·23` and
+    `gcd(15·2², 13) = gcd(60, 13) = 1` are decidable. -/
+theorem selmer_padic_solubility_p13_hensel :
+    ∃ (x y z : ℚ_[13]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_lift_z 1 4 2
+    (Or.inl one_ne_zero)
+    (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide))
+
+/-- ℚ_[19] solubility of the Selmer cubic via the `(1, 0, 4)` Case-B witness
+    (cf. `selmer_witness_p19`). Witness data:
+    `19 ∣ 3·1 + 0 + 5·4³ = 323 = 19·17` and
+    `gcd(15·4², 19) = gcd(240, 19) = 1`. -/
+theorem selmer_padic_solubility_p19_hensel :
+    ∃ (x y z : ℚ_[19]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_lift_z 1 0 4
+    (Or.inl one_ne_zero)
+    (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide))
+
+/-- ℚ_[31] solubility of the Selmer cubic via the `(1, 3, 17)` Case-B witness
+    (cf. `selmer_witness_p31`). Witness data:
+    `31 ∣ 3·1 + 4·3³ + 5·17³ = 24676 = 31·796` and
+    `gcd(15·17², 31) = gcd(4335, 31) = 1`. -/
+theorem selmer_padic_solubility_p31_hensel :
+    ∃ (x y z : ℚ_[31]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_lift_z 1 3 17
+    (Or.inl one_ne_zero)
+    (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide))
+
+/-- ℚ_[37] solubility of the Selmer cubic via the `(0, 1, 5)` Case-B witness
+    (cf. `selmer_witness_p37`). Although `p = 37` belongs nominally to Case B
+    (`37 ≡ 1 mod 3`), its Section-9 witness has the same `(0, 1, z₀)` shape as
+    the Case-A primes, so `selmer_padic_solubility_caseA 5` would also work.
+    Stating it through `selmer_padic_solubility_lift_z` keeps the dispatch
+    table uniform across `p ∈ {13, 19, 31, 37}`. Witness data:
+    `37 ∣ 0 + 4 + 5·5³ = 629 = 37·17` and
+    `gcd(15·5², 37) = gcd(375, 37) = 1`. -/
+theorem selmer_padic_solubility_p37_hensel :
+    ∃ (x y z : ℚ_[37]), (x ≠ 0 ∨ y ≠ 0 ∨ z ≠ 0) ∧ selmerPoly x y z = 0 :=
+  selmer_padic_solubility_lift_z 0 1 5
+    (Or.inr one_ne_zero)
+    (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide))
+
+/-! ## Section 16: Status Summary (post Section 15) -/
+
+/-!
+Section 15 generalizes Section 13's Case-A Hensel lift to a fully parametric
+"lift-z" theorem `selmer_padic_solubility_lift_z`, then dispatches the
+Section-9 Case-B primes with nonzero `z₀` — `p ∈ {13, 19, 31, 37}` — as
+one-line corollaries. The universal axiom `selmer_padic_solubility` remains
+load-bearing, but eight of the twelve primes in the Section 8 roadmap
+(`p ∈ {11, 13, 17, 19, 23, 29, 31, 37}`) now admit axiom-free `ℚ_[p]`-solubility
+proofs.
+
+### Updated counts
+- Theorems: 22 + 1 (`selmer_padic_solubility_lift_z`) + 4 (per-prime
+  corollaries) = 27.
+- Substantive theorems (non-`decide` content): 8 (was 7).
+- Definitions: 5 + 1 (`HenselLiftZ.G`) = 6.
+- Sorries: 0 (unchanged).
+- Axioms: 2 (unchanged): `selmer_no_rational_solution` + `selmer_padic_solubility`.
+- Status: still `axiomatized`.
+- New milestone: parametric lift-z theorem + four new Case-B Hensel lifts;
+  the only remaining primes from Section 9 are `p = 7` (needs lift-x) and
+  the special primes `p ∈ {2, 3, 5}` (direct construction + strong-form
+  Hensel for the singular reduction at `p = 3`). -/
+
 #check @selmerCubic_real_solution
 #check @selmer_rat_implies_real
 #check @selmer_rat_implies_padic
@@ -704,5 +916,10 @@ axiom less load-bearing in practice.
 #check @selmer_padic_solubility_p17_hensel
 #check @selmer_padic_solubility_p23_hensel
 #check @selmer_padic_solubility_p29_hensel
+#check @selmer_padic_solubility_lift_z
+#check @selmer_padic_solubility_p13_hensel
+#check @selmer_padic_solubility_p19_hensel
+#check @selmer_padic_solubility_p31_hensel
+#check @selmer_padic_solubility_p37_hensel
 
 end Hilbert11OQ02

--- a/research/problems/hilbert-11-oq-02/state.md
+++ b/research/problems/hilbert-11-oq-02/state.md
@@ -1,21 +1,27 @@
 # Current State
 
-**Phase**: ITERATING (parametric Hensel lift — Case-A primes complete)
+**Phase**: ITERATING (parametric lift-z — Case-B primes with z₀ ≠ 0 complete)
 **Since**: 2026-05-07T22:45:00Z
-**Last Updated**: 2026-05-08 (Iteration 6, researcher-9)
-**Iteration**: 6
+**Last Updated**: 2026-05-08 (Iteration 7, researcher-12)
+**Iteration**: 7
 
 ## Current Focus
 
-Iteration 6 (this session): generalized the Section 11 prime-specific
-Hensel argument (PR #17070, p = 11) to a parametric theorem
-`selmer_padic_solubility_caseA` covering every Case-A prime
-(p ≡ 2 mod 3, p ∉ {2, 5}). Three new corollaries
-(`selmer_padic_solubility_p17_hensel`, `_p23_hensel`, `_p29_hensel`)
-discharge p ∈ {17, 23, 29} as one-line invocations with `by decide`
-on the witness arithmetic. Combined with iter 5's p = 11 result, all
-four Case-A primes from Section 9 now admit axiom-free ℚ_[p] solubility
-proofs. Universal axiom `selmer_padic_solubility` is unchanged.
+Iteration 7 (this session): generalized iteration 6's
+`selmer_padic_solubility_caseA` (which fixes the (0, 1, z) projection)
+to a fully parametric lift-z theorem `selmer_padic_solubility_lift_z`
+taking any integer triple (x₀, y₀, z₀) with (x₀, y₀) ≠ (0, 0). The
+underlying Hensel polynomial `HenselLiftZ.G c = C c + C 5 * X^3 ∈ ℤ[X]`
+is parametric in the constant term `c = 3·x₀³ + 4·y₀³`. Four new
+corollaries (`selmer_padic_solubility_p13_hensel`, `_p19_hensel`,
+`_p31_hensel`, `_p37_hensel`) discharge the Section-9 Case-B witnesses
+with nonzero z₀ as one-line invocations. The remaining Case-B prime
+p = 7 has witness (1, 1, 0), so its `IsCoprime (15·0² : ℤ) (7 : ℤ)`
+hypothesis is false and lift-z does not apply at p = 7 — a complementary
+lift-x parametric theorem is needed. Combined with iters 5 and 6, eight
+of the twelve Section-8 primes (p ∈ {11, 13, 17, 19, 23, 29, 31, 37})
+now have axiom-free ℚ_[p]-solubility proofs. Universal axiom
+`selmer_padic_solubility` is unchanged.
 
 ## Active Approach
 
@@ -29,21 +35,27 @@ proofs. Universal axiom `selmer_padic_solubility` is unchanged.
    every prime in the Section 8 roadmap. **Done.**
 4. (Iter 5) Section 11: axiom-free ℚ_[11] solubility via Mathlib's
    `hensels_lemma`. **Done** (PR #17070).
-5. (Iter 6 — THIS SESSION) Section 13: parametric Case-A theorem
+5. (Iter 6) Section 13: parametric Case-A theorem
    `selmer_padic_solubility_caseA` + p ∈ {17, 23, 29} corollaries.
+   **Done** (PR #17093).
+6. (Iter 7 — THIS SESSION) Section 15: fully general lift-z theorem
+   `selmer_padic_solubility_lift_z` + p ∈ {13, 19, 31, 37} corollaries.
    **Done.**
-6. (Future iter) Case B parametric theorem (p ≡ 1 mod 3, p ≥ 7) using
-   the smooth zeros from `selmer_witness_p7/13/19/31/37`. The
-   corresponding univariate-Hensel reduction is *not* the (0, 1, z)
-   projection — it picks a different fixed coordinate per prime, so the
-   parametric setup is more involved than Case A.
-7. (Future iter) Special primes p ∈ {2, 5} via direct construction; the
+7. (Future iter) Lift-x parametric theorem for p = 7
+   (witness (1, 1, 0), z₀ = 0 forces a different univariate reduction).
+   The polynomial would be `H(x) = 3x³ + d` with `d = 4·y₀³ + 5·z₀³`,
+   and the coprimality hypothesis becomes
+   `IsCoprime (9·x₀² : ℤ) (p : ℤ)`. Single corollary at p = 7 with
+   witness (1, 1, 0); also re-derives Sections 11/13/15's Case A primes
+   that have nonzero x in their witness (none in Section 9, so this is
+   a strict extension covering only p = 7).
+8. (Future iter) Special primes p ∈ {2, 5} via direct construction; the
    `selmer_witness_p2 = (1, 0, 1)` and `selmer_witness_p5 = (1, 2, 0)`
    give the obvious univariate reductions to lift.
-8. (Future iter) Special prime p = 3: strong-form Hensel on
+9. (Future iter) Special prime p = 3: strong-form Hensel on
    `selmer_witness_p3_mod27` (singular mod-3 reduction).
-9. (Future iter — far) `selmer_no_rational_solution` from 3-descent
-   on the associated elliptic curve. Beyond present Mathlib.
+10. (Future iter — far) `selmer_no_rational_solution` from 3-descent
+    on the associated elliptic curve. Beyond present Mathlib.
 
 ## Blockers
 
@@ -56,30 +68,42 @@ The full Colliot-Thélène conjecture requires:
 
 None of these are present in Mathlib at sufficient depth. The more
 tractable axiom-elimination path is `selmer_padic_solubility` via
-Hensel; the present iteration completes the Case-A subset of that path.
+Hensel; the present iteration completes the Case-B-with-nonzero-z₀
+subset of that path. Eight primes remain to fully eliminate the
+universal axiom: p = 7 (lift-x), p ∈ {2, 5} (direct lift), p = 3
+(strong-form Hensel on singular reduction), and the universal
+"all primes" closure (which would need a meta-argument, not a
+prime-by-prime list).
 
 ## Next Action
 
-**Next iteration (Case B parametric)**: state and prove a parametric
-Case-B Hensel-lift theorem analogous to `selmer_padic_solubility_caseA`,
-adapted to the (1, y, z) or (x, y, 0) projections used in Section 9 for
-primes p ∈ {7, 13, 19, 31, 37}. The witness data per prime is already
-present (Section 9), so this is a direct generalization once the right
-parametric form is found. Note that the projection depends on the prime
-(e.g. (1, 1, 0) at p = 7, (0, 1, 5) at p = 37), so a single parametric
-theorem may not cover the full Case B — alternatively, three parametric
-sub-cases keyed on which coordinate is fixed.
+**Next iteration (Iter 8, lift-x parametric)**: state and prove
+`selmer_padic_solubility_lift_x` analogous to
+`selmer_padic_solubility_lift_z`, fixing (y₀, z₀) ∈ ℤ² and
+Hensel-lifting x. The Hensel polynomial is
+`H(x) = 3x³ + (4·y₀³ + 5·z₀³) ∈ ℤ[X]`; its derivative is `9x²`.
+The hypotheses become
+* `(p : ℤ) ∣ (3·x₀³ + 4·y₀³ + 5·z₀³)` — same as lift-z.
+* `IsCoprime (9·x₀² : ℤ) (p : ℤ)` — derivative invertible.
+* `(y₀, z₀) ≠ (0, 0)` — non-triviality.
+Single corollary at p = 7 via (x₀, y₀, z₀) = (1, 1, 0):
+3·1 + 4·1 + 0 = 7 = 7·1 (divisibility) and gcd(9, 7) = 1 (coprimality).
+This completes the Case-B prime sweep.
 
-Stretch: state the full Case-A theorem with the witness encoded as a
-canonical lift via `(ZMod p)`-arithmetic rather than passing
-`(p : ℤ) ∣ (4 + 5·z₀³)` directly; this would make the per-prime
-corollaries cite `selmer_witness_p17` etc. rather than recompute the
-divisibility from scratch.
+After Iter 8, the next axiom-elimination targets are p ∈ {2, 5}
+(direct construction without Hensel — both witnesses already give
+exact `selmerPoly = 0` over the relevant ring) and p = 3 (singular
+reduction; strong-form Hensel via `selmer_witness_p3_mod27`).
+
+Stretch: a single "lift k" parametric theorem (k ∈ {x, y, z}) keyed by
+which coordinate is being lifted, with the polynomial selected by a
+small sum-type. This would unify lift-x, lift-y, and lift-z but adds
+indirection that may not pay off given there are only three cases.
 
 ## Attempt Counts
 
-- Total attempts: 6 (iterations 1–6)
-- Current approach attempts: 6
+- Total attempts: 7 (iterations 1–7)
+- Current approach attempts: 7
 - Approaches tried:
   - Iter 1 (researcher-9, FRESH): Selmer-cubic framework, real
     solubility via IVT, easy directions, Hasse-failure proof from
@@ -93,7 +117,11 @@ divisibility from scratch.
   - Iter 5 (researcher-1): Section 11 — axiom-free ℚ_[11]
     solubility via `hensels_lemma`. File 418 → 551 lines, theorems
     17 → 18, axioms unchanged at 2. PR #17070.
-  - **Iter 6 (researcher-9, THIS SESSION)**: Section 13 — parametric
-    Case-A theorem `selmer_padic_solubility_caseA` + p ∈ {17, 23, 29}
-    corollaries. File 551 → 699 lines, theorems 18 → 22, definitions
-    4 → 5, axioms unchanged at 2.
+  - Iter 6 (researcher-9): Section 13 — parametric Case-A theorem
+    `selmer_padic_solubility_caseA` + p ∈ {17, 23, 29} corollaries.
+    File 551 → 699 lines, theorems 18 → 22, definitions 4 → 5,
+    axioms unchanged at 2. PR #17093.
+  - **Iter 7 (researcher-12, THIS SESSION)**: Section 15 — fully
+    general lift-z theorem `selmer_padic_solubility_lift_z` +
+    p ∈ {13, 19, 31, 37} corollaries. File 708 → 925 lines, theorems
+    23 → 28, definitions 5 → 6, axioms unchanged at 2. Build pending.


### PR DESCRIPTION
## Summary

Iteration 7 of the Selmer-cubic Hasse-principle entry. Generalizes the
Section-13 Case-A theorem (which fixes the (0, 1, z) projection) to a
fully parametric lift-z theorem covering every integer triple
`(x₀, y₀, z₀)` with `(x₀, y₀) ≠ (0, 0)`. Four new per-prime corollaries
dispatch all Section-9 Case-B witnesses with nonzero `z₀`.

## Mathematical content (Section 15)

- **`HenselLiftZ.G c = C c + C 5 * X^3 ∈ ℤ[X]`** — univariate polynomial
  parametric in the constant `c`. Specializes to Section 13's `Gint = G 4`
  for the `(0, 1, z)` projection.
- **`selmer_padic_solubility_lift_z`** — for any prime `p`, integer triple
  `(x₀, y₀, z₀)` with `(x₀, y₀) ≠ (0, 0)`, divisibility
  `(p : ℤ) ∣ (3·x₀³ + 4·y₀³ + 5·z₀³)`, and coprimality
  `IsCoprime (15·z₀² : ℤ) (p : ℤ)`, Mathlib's `hensels_lemma` lifts `z₀`
  to `zt ∈ ℤ_[p]` with `c + 5·zt³ = 0` (where `c = 3·x₀³ + 4·y₀³`), and
  the triple `((x₀ : ℚ_[p]), (y₀ : ℚ_[p]), (zt : ℚ_[p]))` is a nontrivial
  ℚ_[p]-zero of the Selmer cubic.
- **Four per-prime corollaries** (one-line invocations with `by decide`):
  | prime | witness `(x₀, y₀, z₀)` | divisibility | coprimality |
  |-------|------------------------|--------------|-------------|
  | 13 | (1, 4, 2)  | 13 ∣ 299 = 13·23   | gcd(60, 13) = 1   |
  | 19 | (1, 0, 4)  | 19 ∣ 323 = 19·17   | gcd(240, 19) = 1  |
  | 31 | (1, 3, 17) | 31 ∣ 24676 = 31·796 | gcd(4335, 31) = 1 |
  | 37 | (0, 1, 5)  | 37 ∣ 629 = 37·17   | gcd(375, 37) = 1  |

## Coverage

After Iter 7, **8 of 12 primes** in the Section-8 Hensel-elimination
roadmap have axiom-free ℚ_[p]-solubility proofs:
`p ∈ {11, 13, 17, 19, 23, 29, 31, 37}`.

Remaining: `p = 7` (Case-B, witness `(1, 1, 0)`, requires lift-x —
deferred to Iter 8), `p ∈ {2, 5}` (special, direct construction),
`p = 3` (singular reduction, strong-form Hensel via `selmer_witness_p3_mod27`).

## Why p = 7 is excluded

Section-9's witness for `p = 7` is `(1, 1, 0)` — `z₀ = 0`. This makes
`IsCoprime (15·0² : ℤ) (7 : ℤ) = IsCoprime 0 7` *false*, so the
parametric lift-z theorem cannot be invoked. The clean fix is a
complementary lift-x theorem (polynomial `H(x) = 3x³ + d` with
`d = 4·y₀³ + 5·z₀³`, derivative `9x²`); for `(x₀, y₀, z₀) = (1, 1, 0)`,
divisibility `7 ∣ 7` and coprimality `gcd(9, 7) = 1` both hold. This is
the single open Case-B item, scheduled for Iter 8.

## Counts (meta.json + leanFile)

- `lineCount`:        708 → 925  (+217)
- `theoremCount`:      23 →  28  (+5: lift_z + 4 corollaries)
- `definitionCount`:    5 →   6  (+1: HenselLiftZ.G)
- `axiomCount`:         2 (unchanged)
- `sorries`:            0 (unchanged)

Universal axiom `selmer_padic_solubility` is unchanged.

## Build status

**Build pending.** Section 15 closely mirrors the proven structure of
Sections 11 and 13 (which are merged and known to build). The polynomial
machinery (`derivative`, `aeval` of `C c`, `C 5 * X^3`) and the Hensel-norm
boilerplate (`PadicInt.norm_intCast_lt_one_iff`,
`PadicInt.norm_intCast_eq_one_iff`, `Int.isCoprime_iff_gcd_eq_one`) are
reused verbatim. Cast manipulations on `ℚ_[p]` (`linear_combination`) follow
the same template as the Section-11 closing step.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Hilbert11OQ02` builds clean
  (no new sorries, axioms unchanged)
- [ ] Spot-check the four corollaries' divisibility claims
  - 13 ∣ 299: `299 / 13 = 23` ✓
  - 19 ∣ 323: `323 / 19 = 17` ✓
  - 31 ∣ 24676: `24676 / 31 = 796` ✓
  - 37 ∣ 629: `629 / 37 = 17` ✓
- [ ] Spot-check the four coprimality claims
  - gcd(60, 13) = 1 ✓ (60 = 4·13 + 8, gcd(13, 8) = 1)
  - gcd(240, 19) = 1 ✓ (240 = 12·19 + 12, gcd(19, 12) = 1)
  - gcd(4335, 31) = 1 ✓ (4335 = 139·31 + 26, gcd(31, 26) = 1)
  - gcd(375, 37) = 1 ✓ (375 = 10·37 + 5, gcd(37, 5) = 1)
- [ ] meta.json + leanFile counts are consistent (28 col-0 theorems/lemmas,
  6 col-0 defs, 2 axiom decls, 0 sorries, 925 lines)

## Open questions resolved / deferred

- ✅ "Case B parametric for primes with nonzero z₀ projection" — done.
- ⏸ "Lift-x for p = 7" — scheduled for Iter 8.
- ⏸ "Special primes p ∈ {2, 5}" — Iter 9.
- ⏸ "Strong-form Hensel for p = 3" — Iter 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)