### PR TITLE
Enrich angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01: Mathlib API insight + cross-refs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,11 +1,23 @@
 [
   {
+    "id": "ann-base-field-construction",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 78 },
+    "type": "definition",
+    "title": "Building $\\mathbb{F}_2(a)$ from `FractionRing` and `Polynomial.X`",
+    "content": "The base field is constructed as `FractionRing (Polynomial (ZMod 2))` — Mathlib's localization of the polynomial ring $\\mathbb{F}_2[X]$ at all nonzero elements, which is canonically the rational function field $\\mathbb{F}_2(X)$. The transcendental generator `aGen` is then the image of `Polynomial.X` under `algebraMap (Polynomial (ZMod 2)) base`. The polynomials `f_target = X^4 + X^2 + C aGen` and `g_factor = X^2 + X + C aGen` are then formed in `base[X]`, the *outer* polynomial ring whose variable is again called `X` (Lean disambiguates by namespace). This two-level polynomial setup — outer indeterminate `X` over the inner-indeterminate field $\\mathbb{F}_2(a)$ — is the standard way to write 'a polynomial whose coefficient field is itself a function field' in Mathlib.",
+    "mathContext": "$\\mathbb{F}_2(a) := \\mathrm{Frac}(\\mathbb{F}_2[a])$ — the field of rational functions in one variable over $\\mathbb{F}_2$. Concretely an element is a quotient $p(a)/q(a)$ with $q \\ne 0$. The polynomial ring $\\mathbb{F}_2(a)[X]$ contains $f(X) = X^4 + X^2 + a$, where the $a$ is a constant (a transcendental element of the coefficient field), not a polynomial variable. This distinction matters: in $\\mathbb{F}_2[X, a]$ (a UFD with two indeterminates) the polynomial $X^4 + X^2 + a$ is irreducible by a Gauss-style argument, but the relevant arena for Galois theory is the *univariate* $\\mathbb{F}_2(a)[X]$ where $a$ is a scalar.",
+    "significance": "supporting",
+    "relatedConcepts": ["FractionRing", "Polynomial.algebraMap", "transcendental generator", "function field", "two-level polynomial rings"],
+    "prerequisites": ["fraction rings of integral domains", "Polynomial.algebraMap", "Mathlib namespace `Polynomial`", "ZMod p as a field for prime p"]
+  },
+  {
     "id": "ann-counterexample-setup",
     "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 67, "endLine": 90 },
-    "type": "definition",
-    "title": "The Counterexample: F₂(a), f = X⁴+X²+a",
-    "content": "The base field is F₂(a) = FractionRing(F₂[X]) — the rational function field over F₂ with formal variable a (represented as the image of X in the fraction field). f_target = X⁴+X²+a (the inseparable irreducible polynomial) and g_factor = X²+X+a (the Artin-Schreier factor). Key lemmas: f_is_g_composed_sq (f = g∘X²) and f_derivative_zero (f' = 0 in char 2, proving inseparability).",
+    "range": { "startLine": 80, "endLine": 90 },
+    "type": "technique",
+    "title": "Two Structural Lemmas: $f = g(X^2)$ and $f' = 0$",
+    "content": "Two short lemmas that pin down the structural identity and the inseparability signature. `f_is_g_composed_sq` proves $f_{\\mathrm{target}} = g_{\\mathrm{factor}}.\\mathrm{comp}(X^2)$ by unfolding `Polynomial.comp` in terms of `eval₂` and closing with `ring` — making the Frobenius-pullback structure visible to downstream tactics. `f_derivative_zero` proves $f' = 0$ by `simp` using `derivative_add`, `derivative_pow`, `derivative_X_pow` and finishing with `ring`; the key arithmetic is that `4 * X^3 + 2 * X = 0` in any char-2 ring. Together these lemmas anchor the Artin-Schreier identification (used by future irreducibility arguments) and discharge inseparability (used directly by `insep_gal_trivial_refuted`).",
     "mathContext": "In characteristic 2: $f'(X) = 4X^3 + 2X = 0$, so $f$ is inseparable. The factoring structure $f(X) = g(X^2)$ where $g(X) = X^2 + X + a$ (Artin-Schreier polynomial) shows $f$ splits via the square root of a root of $g$. Since $g$ is irreducible over $\\mathbb{F}_2(a)$ (Artin-Schreier: $a \\neq t^2 + t$ for any $t \\in \\mathbb{F}_2(a)$), the splitting field $\\mathbb{F}_2(a)(\\alpha^{1/2})$ has non-trivial automorphism $\\alpha^{1/2} \\mapsto \\alpha^{1/2} + 1$.",
     "significance": "key",
     "relatedConcepts": ["Artin-Schreier polynomial", "characteristic 2", "inseparable polynomial", "fraction field"],
@@ -20,8 +32,8 @@
     "content": "The key technical lemma sub_pow_char_pow_eq: in a characteristic-p ring, (a − b)^(p^n) = a^(p^n) − b^(p^n). This is the additive Frobenius endomorphism: the map x ↦ x^p is a ring homomorphism in char p. The proof uses CharP.add_pow_char_pow repeatedly. This lemma is the algebraic engine of the purely-inseparable Galois triviality proof.",
     "mathContext": "In characteristic $p$: $(a - b)^p = a^p - b^p$ (since all binomial coefficients $\\binom{p}{k}$ for $0 < k < p$ are divisible by $p$). By induction: $(a-b)^{p^n} = a^{p^n} - b^{p^n}$. Applied to $\\sigma(x) - x$: $(\\sigma(x) - x)^{p^n} = \\sigma(x)^{p^n} - x^{p^n}$. If $x^{p^n} \\in F$ (purely inseparable condition), then $\\sigma(x^{p^n}) = x^{p^n}$ (since $\\sigma$ fixes $F$), so $(\\sigma(x) - x)^{p^n} = 0$.",
     "significance": "key",
-    "relatedConcepts": ["Frobenius endomorphism", "characteristic p", "binomial theorem in char p", "nilpotent elements"],
-    "prerequisites": ["characteristic p rings", "Frobenius endomorphism", "binomial coefficients mod p"]
+    "relatedConcepts": ["Frobenius endomorphism", "iterateFrobenius", "characteristic p", "binomial theorem in char p", "nilpotent elements", "RingHom.map_sub"],
+    "prerequisites": ["characteristic p rings", "Frobenius endomorphism", "binomial coefficients mod p", "Mathlib `iterateFrobenius` API"]
   },
   {
     "id": "ann-main-theorem",

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -73,7 +73,8 @@
       "The splitting field of g(X^p) (g separable irreducible) is isomorphic to g.SplittingField, and Gal(g(X^p)) ≅ Gal(g) — non-trivial when deg(g) ≥ 2",
       "The correct hypothesis is IsPurelyInseparable F f.SplittingField, which holds exactly when f has only ONE distinct root (f = c·(X - r)^(p^e))",
       "Proof of correct theorem: σ(x)^(p^n) = x^(p^n) (σ fixes F), then (σ(x) - x)^(p^n) = 0 by char-p Frobenius, then σ(x) = x since fields have no nilpotents",
-      "Artin-Schreier theory provides the cleanest source of inseparable-but-not-purely-inseparable counterexamples in characteristic p: the polynomial X^p − X − a is separable, but its composition with X^(p^k) (giving (X^(p^k))^p − X^(p^k) − a) is inseparable with a non-trivial Artin-Schreier Galois action — exactly the structure that breaks the false `insep_gal_trivial` axiom. The char-2 example f = X⁴ + X² + a in this file is the smallest non-trivial instance of this construction"
+      "Artin-Schreier theory provides the cleanest source of inseparable-but-not-purely-inseparable counterexamples in characteristic p: the polynomial X^p − X − a is separable, but its composition with X^(p^k) (giving (X^(p^k))^p − X^(p^k) − a) is inseparable with a non-trivial Artin-Schreier Galois action — exactly the structure that breaks the false `insep_gal_trivial` axiom. The char-2 example f = X⁴ + X² + a in this file is the smallest non-trivial instance of this construction",
+      "The proof of `algEquiv_eq_refl_of_isPurelyInseparable` is short (≈20 Lean lines) only because Mathlib already encodes the right abstractions: `IsPurelyInseparable.pow_mem` packages the inductive existence of $n$ with $x^{p^n} \\in F$, `iterateFrobenius` packages the iterated $x \\mapsto x^{p^n}$ as a *ring hom* (so `map_sub` discharges the binomial-coefficient combinatorics), and `AlgEquiv.commutes` discharges $\\sigma$-fixity on the base field. The mathematical content is one Bourbaki-style page; the Lean compactness comes from typeclass-driven lemma reuse"
     ],
     "proofStrategy": "1. **Counterexample construction**: Work over F₂(a) = FractionRing(F₂[X]). Set f = X⁴ + X² + a = g(X²) where g = X² + X + a (Artin-Schreier, irreducible). Show f is inseparable (f' = 0 in char 2) and has a nontrivial automorphism (σ: α^(1/2) ↦ α^(1/2) + 1).\n\n2. **Correct theorem**: For IsPurelyInseparable F K and σ : K ≃ₐ[F] K:\n   - Get n with x^(p^n) ∈ F via IsPurelyInseparable.pow_mem\n   - σ(x^(p^n)) = x^(p^n) since σ fixes F (AlgEquiv.commutes)\n   - So σ(x)^(p^n) = x^(p^n)\n   - Char-p Frobenius: (σ(x) - x)^(p^n) = σ(x)^(p^n) - x^(p^n) = 0\n   - Field = no nilpotents: σ(x) = x\n   - Hence σ = id by AlgEquiv.ext\n\n3. **Corollary**: Nat.card f.Gal = 1 when IsPurelyInseparable F f.SplittingField",
     "prerequisites": [
@@ -128,6 +129,16 @@
       "targetId": "angle-trisection",
       "relationship": "context",
       "description": "Top-level angle-trisection entry. The whole OQ chain leading here drills down on the Galois-theoretic inputs needed to make the impossibility argument fully rigorous in arbitrary characteristic."
+    },
+    {
+      "targetId": "angle-trisection-cos-20-gal",
+      "relationship": "contrasts",
+      "description": "Companion entry that computes |Gal(8X³−6X−1/ℚ)| = 3 in characteristic 0 (the cos(20°) minimal polynomial). Makes the same Galois-cardinality move on the trisection side, but in the well-behaved characteristic-0 / separable regime — illustrating exactly the regime where the false `insep_gal_trivial` axiom is unnecessary because separability already gives `natDegree | |Gal|`."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "context",
+      "description": "Provides the broader Galois-theoretic infrastructure (solvability of Sₙ, isSolvable lemmas) that consumes statements about |Gal(f)|. The corrected theorem here — `gal_card_one_of_purelyInseparable_splitting` — is the kind of building block that any characteristic-p extension of the Abel-Ruffini program would need to invoke when tracking inseparable factors."
     }
   ],
   "mainTheorems": [
@@ -235,7 +246,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The axiom insep_gal_trivial is mathematically incorrect. The correct theorem requires the splitting field to be purely inseparable, not just the polynomial to be inseparable.",
+    "summary": "The axiom `insep_gal_trivial` is mathematically incorrect. The correct theorem requires the **splitting field** to be purely inseparable, not just the polynomial to be inseparable. The two conditions are inequivalent in general: any inseparable irreducible $f = g(X^p)$ with $g$ separable of degree $\\ge 2$ has $|\\mathrm{Gal}(f)| = |\\mathrm{Gal}(g)| > 1$. The corrected theorem `gal_card_one_of_purelyInseparable_splitting` is proved here in roughly twenty Lean lines from Mathlib's `IsPurelyInseparable` API and the iterated Frobenius ring homomorphism, and a concrete char-2 counterexample $f = X^4 + X^2 + a$ over $\\mathbb{F}_2(a)$ formally refutes the original claim. One axiom remains (`counterexample_gal_card`) pending a full Artin-Schreier formalization of $|\\mathrm{Gal}(f)| = 2$ for the explicit witness.",
     "implications": "The parent entry's axiom should be replaced with the weaker (and correct) claim for purely inseparable polynomials only (f = X^(p^e) - c type). The general inseparable case has |Gal(f)| = |Gal(g)| where g is the separable part of f. More broadly, this result clarifies that 'natDegree | |Gal|' fails in characteristic p exactly because of separability: the standard divisibility holds for the *separable degree*, not the full degree. Any constructibility/impossibility argument that takes characteristic-p coefficient fields seriously (Abel-Ruffini in characteristic p, transcendence bases over F_p, finite-field algebraic geometry) must therefore distinguish between inseparable and purely inseparable hypotheses.",
     "openQuestions": [
       "Can xPow_sub_of_irreducible_isPurelyInseparable be proved directly from Mathlib's SplittingField API?",


### PR DESCRIPTION
## Summary

Enrichment pass for `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01` (Inseparable Galois Groups: Counterexample and Correct Statement). The entry was already substantially enriched (7 annotations w/ mathContext, full historicalContext, mainTheorems, references). This pass closes three remaining gaps:

1. **Conclusion was a single sentence.** Expanded `conclusion.summary` to a paragraph that names the corrected theorem, the witness, the Lean proof length, and the remaining axiom — so the reader gets the takeaway without scrolling.
2. **No insight tied the brevity of the Lean proof to Mathlib's abstractions.** Added a 6th `keyInsight` explaining that `algEquiv_eq_refl_of_isPurelyInseparable` is short (≈20 lines) only because `IsPurelyInseparable.pow_mem`, `iterateFrobenius`, and `AlgEquiv.commutes` already package the right structure.
3. **Cross-references missed nearby Galois-cardinality entries.** Added `angle-trisection-cos-20-gal` (contrasts: same Galois-cardinality move in char 0 / separable regime) and `abel-ruffini-galois-extensions` (broader solvability stack that would consume corrected statements like this one).

Also split the original `ann-counterexample-setup` annotation, which lumped the `FractionRing`/`aGen` field construction together with two structural lemmas:

- New `ann-base-field-construction` (lines 67-78) — explains the two-level polynomial setup (outer `X` over inner $\mathbb{F}_2(a)$), which was previously implicit.
- Refocused `ann-counterexample-setup` (lines 80-90) on `f_is_g_composed_sq` and `f_derivative_zero`, with the actual char-2 arithmetic ($4X^3 + 2X = 0$).

Refined `ann-frobenius-key-lemma`'s `relatedConcepts`/`prerequisites` to reference Mathlib's `iterateFrobenius` API and `RingHom.map_sub` (the proof's actual one-liner).

## Quality dimensions touched

- `overview.keyInsights`: 5 → 6
- `conclusion.summary`: 1 sentence → 1 paragraph (with LaTeX)
- `crossReferences`: 3 → 5
- `annotations`: 7 → 8 (one split, one new, one minor refinement)

No mathematical claims changed. No status / axiomCount / sorries changes (status remains `axiomatized`, axiomCount=1 for `counterexample_gal_card`, sorries=0).

## Test plan

- [x] `pnpm build` — passes (vite build succeeds; no JSON schema errors)
- [x] `git diff --cached --stat` — staged diff is exactly two files in `src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01/`
- [x] `python3 -c json.load` — both edited JSON files parse
- [x] No duplicate PR for slug — searched `gh pr list --search angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)