### PR TITLE
research(erdos-1151-oq-04): S20 — chebyshev_trig_sum_pos helper for finite-set min' (build pending)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -1583,6 +1583,30 @@ private lemma trig_sum_reindex_symmetry (n : ℕ) (hn : 0 < n) (θ : ℝ) :
         -(Real.cos θ - chebyshevNode n k) from by ring,
       abs_neg]
 
+/-- **(Step 6/7 helper) Strict positivity of the Chebyshev-Lebesgue trig sum.**
+
+    For any `θ` whose cosine avoids all `n` Chebyshev nodes, the trig sum
+    `S(θ, n) = Σₖ sin(φₖ)/|cos θ − cos φₖ|` is strictly positive (every term
+    has positive numerator by `chebyshevAngle_sin_pos`, positive denominator
+    by `hne`).
+
+    This is the building block for the **finite-set min'** argument in the
+    `trig_sum_harmonic_lb` proof: for `1 ≤ n < N₀(d)`, the ratio
+    `S(θ, n) / (n · log(n+1))` is well-defined and strictly positive, so its
+    minimum over the finite set `{1, …, N₀−1}` exists and is positive,
+    yielding the small-`n` constant in `trig_sum_harmonic_lb`. -/
+private lemma chebyshev_trig_sum_pos (n : ℕ) (hn : 0 < n) (θ : ℝ)
+    (hne : ∀ k : Fin n, Real.cos θ ≠ chebyshevNode n k) :
+    0 < ∑ k : Fin n, Real.sin ((2 * (k.val : ℝ) + 1) * Real.pi / (2 * n)) /
+                     |Real.cos θ - chebyshevNode n k| := by
+  -- Each term is strictly positive: sin > 0 by chebyshevAngle_sin_pos, denominator
+  -- > 0 by hne k. Apply Finset.sum_pos with the nonempty witness k = 0.
+  apply Finset.sum_pos
+  · intro k _
+    exact div_pos (chebyshevAngle_sin_pos n hn k)
+      (abs_pos.mpr (sub_ne_zero.mpr (hne k)))
+  · exact ⟨⟨0, hn⟩, Finset.mem_univ _⟩
+
 /-- **[SORRY] Harmonic trig sum lower bound for general θ ∈ (0, π).**
 
     For any θ ∈ (0, π) with cos θ not a Chebyshev node for any n, the sum

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -4,8 +4,22 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-21
-**Iteration**: 18
+**Iteration**: 20
 **Last Updated**: 2026-05-08
+
+## Session 20 (this session, build pending)
+
+Added one Step 6/7 helper: `chebyshev_trig_sum_pos` — strict positivity of
+the Chebyshev-Lebesgue trig sum `S(θ, n) = Σₖ sin(φₖ)/|cos θ − cos φₖ|`
+for any θ avoiding all chebyshev nodes. This is the building block for the
+finite-set `min'` argument in `trig_sum_harmonic_lb` Step 6/7: for the
+finitely many small `n` (`1 ≤ n < N₀(d)`), the ratio `S(θ, n)/(n·log(n+1))`
+is well-defined and positive, so its `Finset.min'` exists and is positive,
+yielding the small-n constant.
+
+Proof: every term has `sin > 0` (via `chebyshevAngle_sin_pos`) and
+`|cos θ − cos φₖ| > 0` (via the `hne` hypothesis). Apply `Finset.sum_pos`
+with the nonempty witness `k = 0` (`Fin n` nonempty since `n ≥ 1`).
 
 ## Current Focus
 2 sorries remain in `proofs/Proofs/Erdos1151OQ04.lean` (1567 lines, on `main`):


### PR DESCRIPTION
## Summary

Session 20 of `erdos-1151-oq-04`. Adds one Step 6/7 helper that feeds the
finite-set `min'` argument in `trig_sum_harmonic_lb`:

`chebyshev_trig_sum_pos (n : ℕ) (hn : 0 < n) (θ : ℝ) (hne : ∀ k, cos θ ≠ chebyshevNode n k)`
proves `0 < S(θ, n)` where `S(θ, n) = Σₖ sin(φₖ)/|cos θ − cos φₖ|`.

For the small-n branch (`1 ≤ n < N₀(d)`) of `trig_sum_harmonic_lb`'s proof,
this gives that `S(θ, n)/(n·log(n+1))` is well-defined and strictly
positive for each finite `n`, so its `Finset.min'` over `{1, …, N₀−1}`
exists and is positive — the small-`n` constant.

## Proof

Every summand has:
- positive numerator: `chebyshevAngle_sin_pos n hn k`
- positive denominator: `abs_pos.mpr (sub_ne_zero.mpr (hne k))`

Apply `Finset.sum_pos` with the nonempty witness `k = 0` (Fin n is
nonempty since `n ≥ 1`).

## Files

- `proofs/Proofs/Erdos1151OQ04.lean` (+24 lines): one new private lemma
  `chebyshev_trig_sum_pos` between `trig_sum_reindex_symmetry` and
  `trig_sum_harmonic_lb`.
- `research/problems/erdos-1151-oq-04/state.md` (+15 lines): S20 entry.

## Test plan

- [ ] Build pending (`proofs/.lake` is a recursive symlink in the
      worktree). Auditor / deployer Docker build needed.
- [x] Diff scoped to two files only (no main-repo index pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)