### PR TITLE
Enrich laws-of-large-numbers-oq-01-oq-03: Mathlib-gap insight + LLL cross-ref

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-header",
     "proofId": "laws-of-large-numbers-oq-01-oq-03",
-    "range": { "startLine": 1, "endLine": 59 },
+    "range": { "startLine": 1, "endLine": 22 },
     "type": "context",
     "title": "Open Question + Erdős-Rényi 1959 Background",
     "content": "The header poses the OQ-03 sub-question: can the pairwise-independent Borel-Cantelli lemma be extracted as a standalone Mathlib-worthy theorem, and is pairwise independence the *minimal* hypothesis? The answer is yes on both counts. The result is due to Erdős & Rényi (1959), proved as a Cantor-series convergence question and now standard in probability textbooks (Feller II, Ch. VIII). The five-step proof sketch in the header — divergent expectation, variance ≤ expectation via covariance cancellation, Chebyshev, monotone limit, equivalence to limsup — is exactly the Aristotle-discovered proof in the companion file.",
@@ -74,7 +74,7 @@
   {
     "id": "ann-007",
     "proofId": "laws-of-large-numbers-oq-01-oq-03",
-    "range": { "startLine": 1, "endLine": 59 },
+    "range": { "startLine": 49, "endLine": 58 },
     "type": "context",
     "title": "Module Docstring: Cantor-Series Origin and the Erdős-Rényi 1959 Trick",
     "content": "The 59-line module-level docstring is more than introductory matter — it records the historical origin of the result and the form of the underlying number-theoretic question. Erdős and Rényi did not set out to prove a generalized BC2; their 1959 paper was titled *On Cantor's series with convergent $\\sum 1/q_n$*, addressing the question: when does a Cantor expansion $x = \\sum a_n / q_n$ (with $a_n \\in \\{0, 1, \\ldots, q_n - 1\\}$) determine $x$ uniquely / generate a normal number / exhibit some large-deviation behavior? The events $A_n = \\{a_n = b_n\\}$ for fixed digits $b_n$ are pairwise independent under the natural Cantor-product measure (because each $a_n$ is uniform on $\\{0, \\ldots, q_n-1\\}$ independently across $n$), so $\\sum P(A_n) = \\sum 1/q_n$. Erdős-Rényi needed BC2 *for these specific pairwise-independent events* in order to conclude that almost every $x$ has each digit $b_n$ appearing infinitely often. Recognizing that their proof strategy required *only* pairwise independence — not the full mutual independence that the events trivially also satisfied — was the key methodological observation. Subsequent expositors (Feller II, Ch. VIII) abstracted the lemma out as a standalone result and named it after them. This file's purpose is to mirror that abstraction inside Lean's gallery, completing the long arc from a 1959 number-theoretic question to a clean Mathlib-ready measure-theoretic statement.",

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-03/meta.json
@@ -76,7 +76,8 @@
       "Pairwise independence is strictly weaker than mutual independence, but strictly stronger than uncorrelated-ness. Uncorrelated events (Cov = 0 without the joint independence condition P(A∩B) = P(A)P(B)) can fail BC2: Petrov (2002, §10) constructs events Aₙ with all pairwise correlations zero but P(Aₙ i.o.) = 0 despite Σ P(Aₙ) = ∞. The 'pairwise' level is optimal.",
       "The limsup of a sequence of sets — {ω : ω ∈ Aₙ for infinitely many n} = ∩_{m} ∪_{n≥m} Aₙ — is modeled in Lean via `Filter.limsup A atTop`. The proof that Sₙ → ∞ a.s. is equivalent to μ(limsup Aₙ) = 1 relies on the equivalence: ω is in limsup Aₙ iff 1_{Aₙ}(ω) does not converge to 0, iff Sₙ(ω) = Σ_{k<n} 1_{Aₖ}(ω) is unbounded.",
       "**Etemadi's leverage**: Etemadi's 1981 elementary SLLN proof exploits this lemma at exactly one place — the necessity direction. Given the SLLN $S_n / n \\to \\mu$ a.s., apply the lemma to $A_n = \\{|X_n| > n\\}$. If $E[|X_1|]$ were infinite, then $\\sum_n P(|X_1| > n) = \\sum_n P(A_n) = \\infty$ (this is the layer-cake lemma). Pairwise independence of $X_n$ implies pairwise independence of $A_n$, so BC2 forces $|X_n| > n$ infinitely often a.s., contradicting $S_n/n \\to \\mu$ (since the latter forces $X_n / n \\to 0$). The classical proof needed full mutual independence here; Etemadi's contribution was recognizing pairwise suffices, opening the door to weak-dependence SLLNs.",
-      "**Hypothesis economy as a research principle**: This result is a paradigm case of identifying the *minimal* hypothesis for a probabilistic conclusion. The same paradigm has driven extensions of the SLLN to ergodic stationary processes (Birkhoff 1931), exchangeable sequences (de Finetti), m-dependent and weakly dependent sequences, and martingales — each by relaxing independence to the next-weakest property compatible with variance control. The Chebyshev-variance method is robust enough to apply throughout this hierarchy, making it one of the most reused proof templates in probability theory."
+      "**Hypothesis economy as a research principle**: This result is a paradigm case of identifying the *minimal* hypothesis for a probabilistic conclusion. The same paradigm has driven extensions of the SLLN to ergodic stationary processes (Birkhoff 1931), exchangeable sequences (de Finetti), m-dependent and weakly dependent sequences, and martingales — each by relaxing independence to the next-weakest property compatible with variance control. The Chebyshev-variance method is robust enough to apply throughout this hierarchy, making it one of the most reused proof templates in probability theory.",
+      "**Mathlib readiness and the gap with `measure_limsup_eq_one`**: Mathlib's existing Borel-Cantelli infrastructure (`MeasureTheory.measure_limsup_eq_one`) is stated for *fully* independent events via the `iIndepSet` typeclass. The present theorem upgrades the hypothesis to the strictly weaker `Pairwise IndepSet` (using `IndepSet`, not `iIndepSet`) — which is exactly the API surface that downstream callers like `slln_necessity` actually have access to in practice (e.g., in Etemadi's argument the events $A_n = \\{|X_n| > n\\}$ are pairwise but not necessarily fully independent). Closing this hypothesis gap in Mathlib directly would let users invoke BC2 without first having to upgrade pairwise independence to mutual independence — an upgrade that is sometimes false and is generally proof-heavy when true."
     ],
     "openQuestions": [
       "Can borel_cantelli_pairwise_indep be contributed to Mathlib4 directly? The existing Mathlib theorem measure_limsup_eq_one requires full independence (via limsup_ae_eq_of_forall_ae_eq or similar), so this would be a genuine new contribution.",
@@ -214,6 +215,16 @@
       "proofId": "laws-of-large-numbers-oq-01-oq-02",
       "relationship": "sibling",
       "description": "Sibling: explores pairwise independence in the SLLN context more broadly (Etemadi's theorem). BC2 for pairwise independence (this entry) is a lemma in that proof."
+    },
+    {
+      "proofId": "lovasz-local-lemma",
+      "relationship": "contrasts",
+      "description": "Companion in the opposite direction. BC2 says $\\sum P(A_n) = \\infty + \\text{pairwise indep} \\Rightarrow P(\\limsup A_n) = 1$, i.e., infinitely many bad events occur a.s. The Lovász Local Lemma gives sufficient conditions under which $P(\\bigcap_n A_n^c) > 0$, i.e., zero bad events occur with positive probability — even under sparse dependence rather than independence. Together they bracket the dependent-events landscape between 'almost sure occurrence' (BC2) and 'positive probability of total avoidance' (LLL)."
+    },
+    {
+      "proofId": "laws-of-large-numbers-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling SLLN OQ: extends LLN to ergodic / stationary dependent sequences (Birkhoff 1931). Both entries instantiate the broader research program of replacing full independence in the SLLN with the next-weakest property compatible with variance control — pairwise independence here, ergodicity there."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Enrichment pass for `laws-of-large-numbers-oq-01-oq-03` (Borel-Cantelli for Pairwise Independence, Erdős-Rényi 1959). The entry was already richly enriched (8 annotations, 6 keyInsights, 9 references, multi-paragraph historicalContext, two `mainTheorems`). This pass closes three remaining gaps:

1. **No `keyInsight` named the practical Mathlib-readiness gap.** Added a 7th `keyInsight` explaining that `MeasureTheory.measure_limsup_eq_one` in Mathlib requires `iIndepSet` (full mutual independence), and this entry's contribution is to upgrade to the strictly weaker `Pairwise IndepSet` — exactly the API surface that downstream callers like Etemadi's SLLN proof have access to.
2. **`crossReferences` missed the dependent-events bracket.** Added `lovasz-local-lemma` (contrasts) — the companion result in the opposite direction (P(∩ Aₙᶜ) > 0 under sparse dependence). Added `laws-of-large-numbers-oq-03` (sibling) — the ergodic/stationary SLLN extension that instantiates the same minimal-hypothesis research program.
3. **Two annotations both claimed the entire 1-59 docstring range.** Narrowed `ann-header` to 1-22 (Open Question + Answer) and `ann-007` to 49-58 (References block) so each anchors to its actual subject matter.

## Quality dimensions touched

- `overview.keyInsights`: 6 → 7
- `crossReferences`: 4 → 6
- `annotations`: ranges narrowed on 2 of 8 to remove overlap; content unchanged

No mathematical claims changed. Status remains `verified`; `axiomCount`=0; `sorries`=0; `mainTheorems` and `references` unchanged.

## Test plan

- [x] `pnpm build` — passes (vite build succeeds; no JSON schema errors)
- [x] `git diff --cached --stat` — staged diff is exactly two files in `src/data/proofs/laws-of-large-numbers-oq-01-oq-03/`
- [x] `python3 -c json.load` — both edited JSON files parse
- [x] No duplicate PR for slug — searched `gh pr list --search laws-of-large-numbers-oq-01-oq-03`

🤖 Generated with [Claude Code](https://claude.com/claude-code)