### PR TITLE
audit(tracker): binomial-theorem-oq-02-oq-03 — 3rd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1036,9 +1036,9 @@
       "issues": []
     },
     "binomial-theorem-oq-02-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T13:57:46Z",
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-04": {


### PR DESCRIPTION
Re-audit of `binomial-theorem-oq-02-oq-03` (q-Multinomial Coefficients and the q-Multinomial Theorem).

## Verification (against origin/main 38ed238)

**Lean file** (`proofs/Proofs/BinomialTheoremOQ02OQ03.lean`):
- lineCount: **269** ✓ (meta claims 269)
- sorries: **0** ✓
- axiomCount: **0** ✓ (no `axiom` declarations)
- theoremCount: **12** ✓
- definitionCount: **1** ✓ (one `noncomputable def qMultinom`)
- no True-stubs ✓

All 12 theorems are named `qMultinom_*` and present in the file (lines 65–256). 11 of 12 are listed in `originalContributions`; the remaining one (`qMultinom_eq_zero_when_head_exceeds_sum`) is a corollary of `qMultinom_eq_zero_of_lt`.

## Tier B classification stands

`qBinom`, `qFactorial`, `qBinom_at_one`, `qBinom_product` are defined in sibling gallery file `Proofs.CombinationsFormulaOQ03` (not in Mathlib core), but that file builds the q-binomial / Gaussian-binomial infrastructure directly on Mathlib's `CommRing`. Badge `mathlib` and assumptions text are defensible.

## Tracker change

```diff
       "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-24T12:27:47Z",
+      "lastAudited": "2026-05-08T13:57:46Z",
```

Built via plumbing off fresh origin/main; only the 2 lines for this entry change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)