### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-02): S7 — m=3 algebraic identities (build pending)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
@@ -454,4 +454,52 @@ theorem mul_choose_dvd_lcmRange_two {n : ℕ} (hn : 2 ≤ n) :
   -- Step 4: n · (n - 1) ∣ lcmRange n via the coprime mul_dvd lemma.
   exact hcop.mul_dvd_of_dvd_of_dvd h_n h_n1
 
+-- =====================================================================
+-- PART 7 (Session 7): Algebraic identities for the m=3 case
+-- =====================================================================
+
+/-! ### Why these identities
+
+Session 6 closed `m = 1, 2` of `mul_choose_dvd_lcmRange`. The next step
+is `m = 3`. The general `mul_choose_dvd_lcmRange` (m ≥ 3) requires
+Kummer's theorem on `v_p(C(n, m))` or a double `(n, m)` induction. As an
+**algebraic foundation** for either route, this section provides two
+short identities that pin down the structure of `3 · C(n, 3)`:
+
+1. `three_mul_choose_three_eq` (one-line, no hypotheses besides `3 ≤ n`):
+   `3 · C(n, 3) = n · C(n - 1, 2)`. Direct corollary of
+   `mul_choose_eq_mul_choose_pred` at `m = 3`.
+
+2. `two_mul_three_mul_choose_three_eq` (algebraic): for `n ≥ 3`,
+   `2 · (3 · C(n, 3)) = n · (n - 1) · (n - 2)`. Reduces the m=3
+   divisibility question to whether `n(n-1)(n-2)/2 ∣ lcmRange n`.
+
+These identities are the entry-point for Session 8's m=3 work,
+independent of which divisibility route is chosen. -/
+
+/-- **m=3 absorption identity**: `3 · C(n, 3) = n · C(n - 1, 2)` for
+    `n ≥ 3`. Direct instantiation of `mul_choose_eq_mul_choose_pred`. -/
+theorem three_mul_choose_three_eq {n : ℕ} (hn : 3 ≤ n) :
+    3 * Nat.choose n 3 = n * Nat.choose (n - 1) 2 :=
+  mul_choose_eq_mul_choose_pred (by decide) hn
+
+/-- **m=3 explicit form**: `2 · (3 · C(n, 3)) = n · (n - 1) · (n - 2)`
+    for `n ≥ 3`. Combines `three_mul_choose_three_eq` with the m=2
+    absorption step `2 · C(n - 1, 2) = (n - 1) · (n - 2)`. The factor
+    of 2 on the LHS captures the "extra `/2`" in the Pascal-style
+    `C(n, 3) = n(n-1)(n-2)/6` formula. -/
+theorem two_mul_three_mul_choose_three_eq {n : ℕ} (hn : 3 ≤ n) :
+    2 * (3 * Nat.choose n 3) = n * ((n - 1) * (n - 2)) := by
+  rw [three_mul_choose_three_eq hn]
+  -- Goal: 2 * (n * C(n - 1, 2)) = n * ((n - 1) * (n - 2))
+  rw [show 2 * (n * Nat.choose (n - 1) 2) =
+        n * (2 * Nat.choose (n - 1) 2) from by ring]
+  -- Apply m=2 absorption to `n - 1`: 2 * C(n-1, 2) = (n-1) * C(n-2, 1).
+  have hnm1 : (2 : ℕ) ≤ n - 1 := by omega
+  rw [mul_choose_eq_mul_choose_pred (by decide : (0:ℕ) < 2) hnm1]
+  -- Goal: n * ((n - 1) * Nat.choose (n - 1 - 1) (2 - 1)) =
+  --       n * ((n - 1) * (n - 2))
+  rw [show ((n - 1 - 1) : ℕ) = n - 2 from by omega,
+      Nat.choose_one_right]
+
 end BaselProblemOQ01OQ01OQ02OQ02

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
@@ -2,7 +2,26 @@
 
 **Phase**: ACT
 **Since**: 2026-05-08
-**Iteration**: 6
+**Iteration**: 7
+
+## Session 7 (this session, build pending)
+
+Added two algebraic identities for the m=3 case as Part 7 of
+`BaselProblemOQ01OQ01OQ02OQ02.lean`:
+
+1. `three_mul_choose_three_eq` (n ≥ 3): `3 · C(n, 3) = n · C(n - 1, 2)`.
+   Direct one-line corollary of `mul_choose_eq_mul_choose_pred`.
+2. `two_mul_three_mul_choose_three_eq` (n ≥ 3):
+   `2 · (3 · C(n, 3)) = n · (n - 1) · (n - 2)`. Combines (1) with the
+   m=2 absorption step `2 · C(n - 1, 2) = (n - 1) · (n - 2)`.
+
+These reduce the m=3 divisibility question
+`3 · C(n, 3) ∣ lcmRange n` to whether `n(n-1)(n-2)/2 ∣ lcmRange n`
+(the `/2` being the substantive obstacle that needs Kummer's theorem
+or a careful coprimality argument). Either route — Kummer or double
+induction — can use these identities as the entry point.
+
+**Axiom delta**: 0 (algebraic identities, no divisibility yet).
 
 ## Current Focus
 


### PR DESCRIPTION
## Summary

Session 7 of `basel-problem-oq-01-oq-01-oq-02-oq-02`. Adds **Part 7**
with two short algebraic identities that pin down the structure of
`3 · C(n, 3)`, providing the entry-point for the Session 6-flagged
m=3 case of `mul_choose_dvd_lcmRange`.

* **`three_mul_choose_three_eq`** (n ≥ 3): `3 · C(n, 3) = n · C(n - 1, 2)`.
  One-line corollary of `mul_choose_eq_mul_choose_pred` at m = 3.

* **`two_mul_three_mul_choose_three_eq`** (n ≥ 3):
  `2 · (3 · C(n, 3)) = n · (n - 1) · (n - 2)`. Combines (1) with the
  m=2 absorption step `2 · C(n - 1, 2) = (n - 1) · (n - 2)`.

## Why this matters

The full m=3 case of `mul_choose_dvd_lcmRange` requires either
Kummer's theorem on `v_p(C(n, m))` or a double `(n, m)` induction.
Either route needs to start from an explicit form of `3 · C(n, 3)`.
The second identity exposes the substantive obstacle directly: the
m=3 divisibility reduces to whether `n(n-1)(n-2)/2 ∣ lcmRange n` —
the `/2` factor is the digit-sum / coprimality burden.

These are pure algebraic identities (no divisibility yet), so axiom
delta is 0 and the contributions are infrastructural for S8+.

## Files

- `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean` (+48 lines): Part 7
  with two theorems + section header.
- `research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md`
  (+21 lines): S7 entry.

## Test plan

- [ ] Build pending (`proofs/.lake` recursive symlink in worktree).
- [x] Diff scoped to two files only.
- [x] Both identities use already-proven primitives:
      `mul_choose_eq_mul_choose_pred`, `Nat.choose_one_right`, plain
      `omega` / `ring` arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)