### PR TITLE
research(sperner-ndim-mathlib-oq-02): S18 part 2 — t2-share container card ≥ 2 (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -1351,6 +1351,144 @@ private lemma vertical_endpoints_on_face0
   · rw [onFaceΔ2_zero_iff]; exact hb1
   · rw [onFaceΔ2_zero_iff]; exact hb1
 
+-- ----------------------------------------------------------------
+-- (S18 part 2) t2-face shared with t1: container card ≥ 2.
+--
+-- For `b ∈ t2Bases N`, every face of `t2 b` is shared with a t1
+-- cell (per S16 `t2_face{0,1,2}_in_t1` + S17 `t2Bases_*_in_t1Bases`).
+-- Hence the container set in `topSimps2 N` for any face of `t2 b`
+-- contains both `t2 b` and a sharing t1 cell, giving card ≥ 2.
+-- This *rules out* t2 faces from being boundary doors in
+-- `_hBoundaryOnFace`, completing the t1/t2 dichotomy:
+--
+--   * t1 boundary edges (S18 part 1): container card = 1.
+--   * t2 faces (S18 part 2): container card ≥ 2 (interior shared).
+--   * t1 interior edges (diagonal/horizontal/vertical, non-boundary
+--     positions): container card ≥ 2 via S17's
+--     `diagonal_neighbor_topSimps2` + S16's `*_in_t2_pos`.
+-- ----------------------------------------------------------------
+
+-- Each face of `t2 b` is contained in `t2 b` itself (used as the
+-- second container alongside the sharing t1 cell). These three
+-- inclusions are pure unfolding + omega.
+
+private lemma t2_face0_in_t2 (b : ℕ × ℕ) :
+    ({(b.1+1, b.2), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ t2 b := by
+  intro x hx
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+  rcases hx with rfl | rfl <;>
+    · simp only [t2, Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+      omega
+
+private lemma t2_face1_in_t2 (b : ℕ × ℕ) :
+    ({(b.1, b.2+1), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ t2 b := by
+  intro x hx
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+  rcases hx with rfl | rfl <;>
+    · simp only [t2, Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+      omega
+
+private lemma t2_face2_in_t2 (b : ℕ × ℕ) :
+    ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ t2 b := by
+  intro x hx
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+  rcases hx with rfl | rfl <;>
+    · simp only [t2, Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+      omega
+
+-- Card-≥-2 lemmas: each t2 face has at least two containers in
+-- `topSimps2 N` — `t2 b` itself and the sharing t1 cell.
+
+private lemma t2_face0_card_ge_two (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t2Bases N) :
+    2 ≤ ((topSimps2 N).filter
+        (fun s => ({(b.1+1, b.2), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s)).card := by
+  have h_t1_in : t1 (b.1+1, b.2) ∈ (topSimps2 N).filter
+      (fun s => ({(b.1+1, b.2), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · exact t1_in_topSimps2_of_base N (t2Bases_right_in_t1Bases N hb)
+    · exact t2_face0_in_t1 b
+  have h_t2_in : t2 b ∈ (topSimps2 N).filter
+      (fun s => ({(b.1+1, b.2), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · exact t2_in_topSimps2_of_base N hb
+    · exact t2_face0_in_t2 b
+  have h_ne : t1 (b.1+1, b.2) ≠ t2 b := t1_ne_t2 _ _
+  have h_pair_card : ({t1 (b.1+1, b.2), t2 b} : Finset (Finset (ℕ × ℕ))).card = 2 := by
+    rw [Finset.card_insert_of_not_mem (by rw [Finset.mem_singleton]; exact h_ne),
+        Finset.card_singleton]
+  have h_pair_sub :
+      ({t1 (b.1+1, b.2), t2 b} : Finset (Finset (ℕ × ℕ))) ⊆
+        (topSimps2 N).filter
+          (fun s => ({(b.1+1, b.2), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact h_t1_in
+    · exact h_t2_in
+  calc 2 = ({t1 (b.1+1, b.2), t2 b} : Finset (Finset (ℕ × ℕ))).card := h_pair_card.symm
+    _ ≤ _ := Finset.card_le_card h_pair_sub
+
+private lemma t2_face1_card_ge_two (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t2Bases N) :
+    2 ≤ ((topSimps2 N).filter
+        (fun s => ({(b.1, b.2+1), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s)).card := by
+  have h_t1_in : t1 (b.1, b.2+1) ∈ (topSimps2 N).filter
+      (fun s => ({(b.1, b.2+1), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · exact t1_in_topSimps2_of_base N (t2Bases_top_in_t1Bases N hb)
+    · exact t2_face1_in_t1 b
+  have h_t2_in : t2 b ∈ (topSimps2 N).filter
+      (fun s => ({(b.1, b.2+1), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · exact t2_in_topSimps2_of_base N hb
+    · exact t2_face1_in_t2 b
+  have h_ne : t1 (b.1, b.2+1) ≠ t2 b := t1_ne_t2 _ _
+  have h_pair_card : ({t1 (b.1, b.2+1), t2 b} : Finset (Finset (ℕ × ℕ))).card = 2 := by
+    rw [Finset.card_insert_of_not_mem (by rw [Finset.mem_singleton]; exact h_ne),
+        Finset.card_singleton]
+  have h_pair_sub :
+      ({t1 (b.1, b.2+1), t2 b} : Finset (Finset (ℕ × ℕ))) ⊆
+        (topSimps2 N).filter
+          (fun s => ({(b.1, b.2+1), (b.1+1, b.2+1)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact h_t1_in
+    · exact h_t2_in
+  calc 2 = ({t1 (b.1, b.2+1), t2 b} : Finset (Finset (ℕ × ℕ))).card := h_pair_card.symm
+    _ ≤ _ := Finset.card_le_card h_pair_sub
+
+private lemma t2_face2_card_ge_two (N : ℕ) {b : ℕ × ℕ}
+    (hb : b ∈ t2Bases N) :
+    2 ≤ ((topSimps2 N).filter
+        (fun s => ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ s)).card := by
+  have h_t1_in : t1 b ∈ (topSimps2 N).filter
+      (fun s => ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · exact t1_in_topSimps2_of_base N (t2Bases_self_in_t1Bases N hb)
+    · exact t2_face2_in_t1 b
+  have h_t2_in : t2 b ∈ (topSimps2 N).filter
+      (fun s => ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · exact t2_in_topSimps2_of_base N hb
+    · exact t2_face2_in_t2 b
+  have h_ne : t1 b ≠ t2 b := t1_ne_t2 _ _
+  have h_pair_card : ({t1 b, t2 b} : Finset (Finset (ℕ × ℕ))).card = 2 := by
+    rw [Finset.card_insert_of_not_mem (by rw [Finset.mem_singleton]; exact h_ne),
+        Finset.card_singleton]
+  have h_pair_sub :
+      ({t1 b, t2 b} : Finset (Finset (ℕ × ℕ))) ⊆
+        (topSimps2 N).filter
+          (fun s => ({(b.1, b.2+1), (b.1+1, b.2)} : Finset (ℕ × ℕ)) ⊆ s) := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact h_t1_in
+    · exact h_t2_in
+  calc 2 = ({t1 b, t2 b} : Finset (Finset (ℕ × ℕ))).card := h_pair_card.symm
+    _ ≤ _ := Finset.card_le_card h_pair_sub
+
 end N2BoundaryAnalysis
 
 -- ============================================================


### PR DESCRIPTION
## Summary

Session 18 part 2 / Iteration 19 of the n=2 Sperner-via-Type1/Type2
triangulation formalization. Closes the **t1/t2 dichotomy** on
`_hBoundaryOnFace` cardinality, building directly on the merged
S16 (PR #17051), S17 (PR #17101), and S18 part 1 (PR #17133).

## What This Adds

Six new private lemmas in
`proofs/Proofs/SpernerFreudenthalSimplex.lean` (+138 lines):

### t2-face self-containment (3 lemmas)

Each of the three edges of `t2 b` is contained in `t2 b` itself —
pure unfolding + omega:

- `t2_face0_in_t2` (right edge `{(b.1+1, b.2), (b.1+1, b.2+1)}`)
- `t2_face1_in_t2` (top edge `{(b.1, b.2+1), (b.1+1, b.2+1)}`)
- `t2_face2_in_t2` (diagonal edge `{(b.1, b.2+1), (b.1+1, b.2)}`)

### t2-face container card ≥ 2 (3 lemmas)

For `b ∈ t2Bases N`, each face of `t2 b` has container set in
`topSimps2 N` of cardinality ≥ 2, containing both `t2 b` itself
and the sharing t1 cell:

- `t2_face0_card_ge_two` — sharing `t1 (b.1+1, b.2)`
  (via S17 `t2Bases_right_in_t1Bases` + S16 `t2_face0_in_t1`)
- `t2_face1_card_ge_two` — sharing `t1 (b.1, b.2+1)`
  (via S17 `t2Bases_top_in_t1Bases` + S16 `t2_face1_in_t1`)
- `t2_face2_card_ge_two` — sharing `t1 b`
  (via S17 `t2Bases_self_in_t1Bases` + S16 `t2_face2_in_t1`)

Each card-bound is established via the standard pair-subset
argument: build `({t1 c, t2 b} : Finset _) ⊆ filter`, derive
`pair.card = 2` from `t1_ne_t2`, conclude
`Finset.card_le_card`.

## Why This Matters

Combined with S18 part 1's three `*_card_eq_one_of_t1_boundary`
lemmas, every edge of every cell in `topSimps2 N` now has a
clean container-cardinality classification:

| Edge type | Geometric condition | Container card |
|---|---|---|
| t1 cell, diagonal edge, `N ≤ b.1+b.2+1` | boundary | 1 |
| t1 cell, horizontal edge, `b.2 = 0` | boundary | 1 |
| t1 cell, vertical edge, `b.1 = 0` | boundary | 1 |
| t2 cell, any edge (`b ∈ t2Bases N`) | always interior | ≥ 2 |
| t1 cell, interior edge | interior | ≥ 2 |

This is the lookup table the abstract
`Triangulation.boundary_doors_odd` will consume in S19.

## Path Forward

S19 (next session): walk through the abstract `adjFn` in
`simData2.toTriangulation` to translate
`adjFn s k = none ↔ containersOf (faceOf s k) = {s}` via
`topSimps2_mem_iff` case split + this dichotomy, then assemble
the existential `∃ faceIdx, ∀ j ≠ k, onFaceΔ2 N (vertex s j)
faceIdx` using the existing `onFaceΔ2_*_iff` lemmas (~60 lines).

After that: `_hLastFace` (~120 lines, bijection with
`face2_path_odd` via S12) + `Triangulation.sperner` application
(~50 lines).

## Files

- `proofs/Proofs/SpernerFreudenthalSimplex.lean` (+138)
- `research/problems/sperner-ndim-mathlib-oq-02/state.md`
  (updated to Iter 19, S18 part 2 focus, revised path-forward)
- `src/data/research/problems/sperner-ndim-mathlib-oq-02.json`
  (1 new insight, 2 new builtItems, currentState refreshed)

## Test Plan

- [ ] Build pending — worktree's `proofs/.lake` is a recursive
      self-symlink per memory
      `feedback_researcher_lake_symlink_broken`. Docker build by
      deployer/auditor expected.
- [x] All cited helper lemmas present in current `SpernerFreudenthalSimplex.lean` — verified via grep
      (`t2_face{0,1,2}_in_t1` at L984/L994/L1005,
      `t2Bases_{self,right,top}_in_t1Bases` at L1078/L1084/L1090,
      `t1_in_topSimps2_of_base` at L1052,
      `t2_in_topSimps2_of_base` at L1057,
      `t1_ne_t2` at L874).
- [x] Diff scoped to three target files only (no main-repo
      pollution; verified `git diff HEAD --stat`).

🤖 Generated by researcher-8