### PR TITLE
research(de-moivre-oq-02-oq-02): add U·U product-to-difference (salvaged from #15534)

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ02.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ02.lean
@@ -9,19 +9,23 @@ Can the Chebyshev T product-to-sum formula
   2 T_m(cos θ) · T_n(cos θ) = T_{m+n}(cos θ) + T_{m-n}(cos θ)
 be extended to Chebyshev polynomials of the second kind U_n?
 
-## Answer: YES (cross-product formula)
+## Answer: YES (cross-product and U·U formulas)
 
-We prove the mixed T·U product-to-sum identity for all integers m, n:
+We prove two mixed/U·U product-to-sum identities for all integers m, n:
 
-  2 · T_m(cos θ) · U_n(cos θ) = U_{m+n}(cos θ) + U_{n-m}(cos θ)
+  T·U: 2 · T_m(cos θ) · U_n(cos θ) = U_{m+n}(cos θ) + U_{n-m}(cos θ)
+  U·U: 2(1−cos²θ) · U_m(cos θ) · U_n(cos θ) = T_{m−n}(cos θ) − T_{m+n+2}(cos θ)
 
 ## Proof Strategy
 
-Paired integer induction on m, carrying P(m) and P(m-1) simultaneously:
+T·U identity: Paired integer induction on m, carrying P(m) and P(m-1) simultaneously:
   P(m) := 2 · T R m · U R n = U R (m + n) + U R (n - m)
 
 The key helper is 2·X·U_k = U_{k+1} + U_{k-1} (rearranged Chebyshev recurrence).
 Each induction step uses this helper twice, via linear_combination.
+
+U·U identity: Direct trig via cos(A-B) - cos(A+B) = 2·sin(A)·sin(B), combined
+with U_n(cos θ)·sin θ = sin((n+1)θ).
 -/
 
 open Polynomial Polynomial.Chebyshev Real
@@ -62,17 +66,9 @@ private lemma Q_zero : Q n 0 := by
     rw [hm1]
     exact two_X_U n
 
-private lemma Q_succ (m : ℤ) (⟨hm, hm1⟩ : Q n m) : Q n (m + 1) := by
+private lemma Q_succ (m : ℤ) (ih : Q n m) : Q n (m + 1) := by
+  obtain ⟨hm, hm1⟩ := ih
   refine ⟨?_, hm⟩
-  -- P(m+1): T(m+1) appears, use T(m+1) via T(m) and T(m-1) via hT
-  -- Actually: from Q(m), we have P(m) and P(m-1). Want P(m+1).
-  -- From T(m+1) = 2X*T(m) - T(m-1): T_add_two at m-1:
-  --   T(m+1) = 2X*T(m) - T(m-1)
-  -- 2*T(m+1)*U n = 2*(2X*T(m) - T(m-1))*U n
-  --   = 2X*(2*T(m)*U n) - (2*T(m-1)*U n)
-  --   = 2X*(U(m+n) + U(n-m)) - (U(m-1+n) + U(n-m+1))   by hm, hm1
-  --   = (U(m+n+1)+U(m+n-1)) + (U(n-m+1)+U(n-m-1)) - U(m-1+n) - U(n-m+1)  by two_X_U twice
-  --   = U(m+1+n) + U(n-m-1)  ✓
   simp only [P, show (m + 1 : ℤ) + n = m + n + 1 from by ring,
              show n - (m + 1 : ℤ) = n - m - 1 from by ring]
   have hT := T_add_two (R := R) (m - 1)
@@ -86,15 +82,9 @@ private lemma Q_succ (m : ℤ) (⟨hm, hm1⟩ : Q n m) : Q n (m + 1) := by
   simp only [show (m - 1 : ℤ) + n = m - 1 + n from rfl, show n - (m - 1 : ℤ) = n - m + 1 from by ring] at hm1
   linear_combination 2 * U R n * hT + 2 * X * hm - hm1 - hu1 - hu2
 
-private lemma Q_pred (m : ℤ) (⟨hm, hm1⟩ : Q n m) : Q n (m - 1) := by
+private lemma Q_pred (m : ℤ) (ih : Q n m) : Q n (m - 1) := by
+  obtain ⟨hm, hm1⟩ := ih
   refine ⟨hm1, ?_⟩
-  -- P(m-2): from P(m) and P(m-1), using T(m) = 2X*T(m-1) - T(m-2)
-  --   T(m-2) = 2X*T(m-1) - T(m)
-  --   2*T(m-2)*U n = 2*(2X*T(m-1) - T(m))*U n
-  --     = 2X*(2*T(m-1)*U n) - (2*T(m)*U n)
-  --     = 2X*(U(m-1+n) + U(n-m+1)) - (U(m+n) + U(n-m))  by hm1, hm
-  --     = (U(m+n) + U(m-2+n)) + (U(n-m+2) + U(n-m)) - U(m+n) - U(n-m)  by two_X_U twice
-  --     = U(m-2+n) + U(n-m+2) = U((m-1)-1+n) + U(n-((m-1)-1))  ✓
   simp only [P, show (m - 1 : ℤ) - 1 = m - 2 from by ring,
              show (m - 2 : ℤ) + n = m - 2 + n from rfl,
              show n - (m - 2 : ℤ) = n - m + 2 from by ring]
@@ -116,12 +106,10 @@ private lemma Q_pred (m : ℤ) (⟨hm, hm1⟩ : Q n m) : Q n (m - 1) := by
 Proved by integer induction (paired), using only the Chebyshev polynomial recurrences. -/
 theorem T_mul_U_product (m : ℤ) : (2 : R[X]) * T R m * U R n = U R (m + n) + U R (n - m) := by
   suffices h : Q n m from h.1
-  induction m using Int.induction_on with
-  | hz => exact Q_zero n
-  | hp k ih => exact Q_succ n k ih
-  | hn k ih =>
-    -- ih : Q n (-↑k), goal : Q n (-↑k - 1) = Q n ((-↑k) - 1)
-    exact Q_pred n (-(↑k : ℤ)) ih
+  apply Int.induction_on m
+  · exact Q_zero n
+  · intro k ih; exact Q_succ n k ih
+  · intro k ih; exact Q_pred n (-(↑k : ℤ)) ih
 
 end PolynomialIdentity
 
@@ -141,7 +129,9 @@ theorem chebyshev_T_U_product_to_sum (m n : ℤ) (θ : ℝ) :
     (U ℝ (m + n)).eval (Real.cos θ) + (U ℝ (n - m)).eval (Real.cos θ) := by
   have h := T_mul_U_product (R := ℝ) n m
   have key := congr_arg (Polynomial.eval (Real.cos θ)) h
-  simp only [Polynomial.eval_mul, Polynomial.eval_add, map_ofNat] at key
+  simp only [Polynomial.eval_mul, Polynomial.eval_add] at key
+  have h2 : (2 : ℝ[X]).eval (Real.cos θ) = 2 := by norm_num
+  rw [h2] at key
   linarith
 
 /-- Recurrence eval form: 2·cos θ·U_n(cos θ) = U_{n+1}(cos θ) + U_{n-1}(cos θ) -/
@@ -150,33 +140,77 @@ theorem chebyshev_cos_U (n : ℤ) (θ : ℝ) :
     (U ℝ (n + 1)).eval (Real.cos θ) + (U ℝ (n - 1)).eval (Real.cos θ) := by
   have h := chebyshev_T_U_product_to_sum 1 n θ
   simp only [T_real_cos, Int.cast_one, one_mul] at h
-  convert h using 2 <;> [ring; ring]
+  simp only [show (1 : ℤ) + n = n + 1 from by ring] at h
+  linarith
 
 /-- Trig form: 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ) -/
 theorem two_cos_sin_spreading (n : ℤ) (θ : ℝ) :
     2 * Real.cos θ * Real.sin (((n : ℝ) + 1) * θ) =
     Real.sin (((n : ℝ) + 2) * θ) + Real.sin ((n : ℝ) * θ) := by
-  have hcos := chebyshev_cos_U n θ
-  rw [← U_real_cos θ n] at hcos
-  rw [show (n : ℝ) + 1 = ((n : ℤ) : ℝ) + 1 from by norm_cast]
-  have h1 := U_real_cos θ (n + 1)
-  have h2 := U_real_cos θ (n - 1)
-  have hn1 : (↑(n + 1 : ℤ) : ℝ) + 1 = (n : ℝ) + 2 := by push_cast; ring
-  have hn2 : (↑(n - 1 : ℤ) : ℝ) + 1 = (n : ℝ) := by push_cast; ring
-  rw [hn1] at h1; rw [hn2] at h2
-  nlinarith [hcos, h1, h2, Real.sin_sq_add_cos_sq θ,
-             mul_comm ((U ℝ n).eval (Real.cos θ)) (Real.sin θ),
-             mul_comm ((U ℝ (n + 1)).eval (Real.cos θ)) (Real.sin θ),
-             mul_comm ((U ℝ (n - 1)).eval (Real.cos θ)) (Real.sin θ)]
+  have h1 := Real.sin_add (((n : ℝ) + 1) * θ) θ
+  have h2 := Real.sin_sub (((n : ℝ) + 1) * θ) θ
+  simp only [show ((n : ℝ) + 1) * θ + θ = ((n : ℝ) + 2) * θ from by ring,
+             show ((n : ℝ) + 1) * θ - θ = (n : ℝ) * θ from by ring] at h1 h2
+  linarith
 
 end RealEvaluation
 
-/-- **Summary**: cross product-to-sum formula and the recurrence corollary -/
+-- ============================================================
+-- U·U Product-to-Difference
+-- ============================================================
+
+section UUProduct
+
+/-- **U·U Product-to-Difference** (real form):
+  2(1−cos²θ)·U_m(cosθ)·U_n(cosθ) = T_{m−n}(cosθ) − T_{m+n+2}(cosθ)
+
+  Completes the Chebyshev product table:
+    T·T: 2·T_m·T_n = T_{m+n} + T_{m−n}  (classical real identities)
+    T·U: 2·T_m·U_n = U_{m+n} + U_{n−m}  (proved above)
+    U·U: 2(1−x²)·U_m·U_n = T_{m−n} − T_{m+n+2}  (proved here) -/
+theorem chebyshev_U_U_product_to_diff (m n : ℤ) (θ : ℝ) :
+    2 * (1 - Real.cos θ ^ 2) * (U ℝ m).eval (Real.cos θ) * (U ℝ n).eval (Real.cos θ) =
+    (T ℝ (m - n)).eval (Real.cos θ) - (T ℝ (m + n + 2)).eval (Real.cos θ) := by
+  have hUm := U_real_cos θ m
+  have hUn := U_real_cos θ n
+  have hsin2 : 1 - Real.cos θ ^ 2 = Real.sin θ ^ 2 := by
+    nlinarith [Real.sin_sq_add_cos_sq θ]
+  have hprod : Real.cos ((↑(m - n) : ℝ) * θ) - Real.cos ((↑(m + n + 2) : ℝ) * θ) =
+      2 * Real.sin (((↑m : ℝ) + 1) * θ) * Real.sin (((↑n : ℝ) + 1) * θ) := by
+    have eq1 : (↑(m - n) : ℝ) * θ = ((↑m : ℝ) + 1) * θ - ((↑n : ℝ) + 1) * θ := by
+      push_cast; ring
+    have eq2 : (↑(m + n + 2) : ℝ) * θ = ((↑m : ℝ) + 1) * θ + ((↑n : ℝ) + 1) * θ := by
+      push_cast; ring
+    rw [eq1, eq2]
+    have h1 := Real.cos_sub (((↑m : ℝ) + 1) * θ) (((↑n : ℝ) + 1) * θ)
+    have h2 := Real.cos_add (((↑m : ℝ) + 1) * θ) (((↑n : ℝ) + 1) * θ)
+    linarith
+  have step : Real.sin (((↑m : ℝ) + 1) * θ) * Real.sin (((↑n : ℝ) + 1) * θ) =
+      (U ℝ m).eval (Real.cos θ) * Real.sin θ * ((U ℝ n).eval (Real.cos θ) * Real.sin θ) := by
+    rw [← hUm, ← hUn]
+  rw [hsin2, T_real_cos θ (m - n), T_real_cos θ (m + n + 2)]
+  linear_combination -hprod - 2 * step
+
+/-- Trig form: 2·sin((m+1)θ)·sin((n+1)θ) = cos((m−n)θ) − cos((m+n+2)θ) -/
+theorem two_sin_sin_spreading (m n : ℤ) (θ : ℝ) :
+    2 * Real.sin (((↑m : ℝ) + 1) * θ) * Real.sin (((↑n : ℝ) + 1) * θ) =
+    Real.cos (((↑m : ℝ) - ↑n) * θ) - Real.cos (((↑m : ℝ) + ↑n + 2) * θ) := by
+  have h1 := Real.cos_sub (((↑m : ℝ) + 1) * θ) (((↑n : ℝ) + 1) * θ)
+  have h2 := Real.cos_add (((↑m : ℝ) + 1) * θ) (((↑n : ℝ) + 1) * θ)
+  simp only [show ((↑m : ℝ) + 1) * θ - ((↑n : ℝ) + 1) * θ = ((↑m : ℝ) - ↑n) * θ from by ring,
+             show ((↑m : ℝ) + 1) * θ + ((↑n : ℝ) + 1) * θ = ((↑m : ℝ) + ↑n + 2) * θ from by ring] at h1 h2
+  linarith
+
+end UUProduct
+
+/-- **Summary**: cross product-to-sum, recurrence corollary, and U·U product -/
 theorem demoivre_oq02oq02_summary (m n : ℤ) (θ : ℝ) :
     (2 * (T ℝ m).eval (Real.cos θ) * (U ℝ n).eval (Real.cos θ) =
      (U ℝ (m + n)).eval (Real.cos θ) + (U ℝ (n - m)).eval (Real.cos θ)) ∧
     (2 * Real.cos θ * (U ℝ n).eval (Real.cos θ) =
-     (U ℝ (n + 1)).eval (Real.cos θ) + (U ℝ (n - 1)).eval (Real.cos θ)) :=
-  ⟨chebyshev_T_U_product_to_sum m n θ, chebyshev_cos_U n θ⟩
+     (U ℝ (n + 1)).eval (Real.cos θ) + (U ℝ (n - 1)).eval (Real.cos θ)) ∧
+    (2 * (1 - Real.cos θ ^ 2) * (U ℝ m).eval (Real.cos θ) * (U ℝ n).eval (Real.cos θ) =
+     (T ℝ (m - n)).eval (Real.cos θ) - (T ℝ (m + n + 2)).eval (Real.cos θ)) :=
+  ⟨chebyshev_T_U_product_to_sum m n θ, chebyshev_cos_U n θ, chebyshev_U_U_product_to_diff m n θ⟩
 
 end DeMoivreOQ02OQ02

--- a/src/data/proofs/de-moivre-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02/annotations.json
@@ -30,7 +30,7 @@
       "startLine": 42,
       "endLine": 88
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Paired Induction: Q(m) = P(m) ∧ P(m-1) with Successor Step",
     "content": "The Chebyshev recurrence T_{m+2} = 2X·T_{m+1} - T_m is second-order in m, so the induction step for P(m+1) needs both P(m) and P(m-1). The standard solution is to carry a conjunction Q(m) = P(m) ∧ P(m-1) and prove Q by Int.induction_on. The Q_zero base case proves both P(0) (trivial: 2·1·U_n = 2U_n) and P(-1) (using T_{-1} = X and two_X_U). The Q_succ successor step receives Q(m) = ⟨P(m), P(m-1)⟩ and must return Q(m+1) = ⟨P(m+1), P(m)⟩; the second component is free (just P(m) from the hypothesis), and P(m+1) is closed by linear_combination using T_add_two and two applications of two_X_U.",
     "mathContext": "Successor step: $2T_{m+1} \\cdot U_n \\stackrel{T_{m+1}=2X T_m - T_{m-1}}{=} 2X(2T_m U_n) - (2T_{m-1}U_n) \\stackrel{\\text{IH}}{=} 2X(U_{m+n}+U_{n-m}) - (U_{m-1+n}+U_{n-m+1})$. Apply two\\_X\\_U to each term: $= (U_{m+n+1}+U_{m+n-1}) + (U_{n-m+1}+U_{n-m-1}) - U_{m-1+n} - U_{n-m+1} = U_{m+1+n} + U_{n-m-1}$ ✓.",
@@ -80,7 +80,7 @@
       "startLine": 89,
       "endLine": 112
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Q_pred: Backward Induction Step via T_{m-2} = 2X·T_{m-1} - T_m",
     "content": "The predecessor step is the symmetric counterpart to Q_succ. Given Q(m) = ⟨P(m), P(m-1)⟩, Q_pred must produce Q(m-1) = ⟨P(m-1), P(m-2)⟩. The first component P(m-1) is free from the hypothesis. For P(m-2), use T_add_two at (m-2) rearranged as T_{m-2} = 2X·T_{m-1} - T_m. Then 2T_{m-2}·U_n = 2X·(2T_{m-1}·U_n) - (2T_m·U_n), and apply P(m-1) and P(m) from the IH, then two_X_U twice, with linear_combination closing the resulting algebraic identity. This symmetric structure — needing both a successor and predecessor step for integer induction — is what makes the paired conjunction Q the right carrier.",
     "mathContext": "Predecessor step: $2T_{m-2} \\cdot U_n \\stackrel{T_{m-2}=2X T_{m-1}-T_m}{=} 2X(2T_{m-1}U_n) - (2T_mU_n)$. By IH: $= 2X(U_{m-1+n}+U_{n-m+1}) - (U_{m+n}+U_{n-m})$. By two\\_X\\_U: $= (U_{m+n}+U_{m-2+n}) + (U_{n-m+2}+U_{n-m}) - U_{m+n} - U_{n-m} = U_{m-2+n} + U_{n-m+2}$ ✓.",
@@ -155,11 +155,11 @@
       "startLine": 174,
       "endLine": 182
     },
-    "type": "concept",
+    "type": "context",
     "title": "Summary Theorem: Cross-Product and Recurrence Together",
     "content": "The demoivre_oq02oq02_summary theorem packages the two main results as a conjunction for easy export: the full cross-product formula at arbitrary (m, n, θ) and the m=1 recurrence corollary. As a trivial conjunction proof, it serves as a single import point for downstream use. It also signals the boundary of the namespace — everything provable here about T×U mixed products has been captured. The pattern of a summary theorem as a ∧-conjunction of the key results, proved by ⟨theorem1, theorem2⟩, is a clean documentation idiom in Lean formalization.",
     "mathContext": "Summary: $(\\forall m, n, \\theta)\\; 2T_m(\\cos\\theta)U_n(\\cos\\theta) = U_{m+n}(\\cos\\theta) + U_{n-m}(\\cos\\theta)$ $\\;\\land\\;$ $(\\forall n, \\theta)\\; 2\\cos\\theta \\cdot U_n(\\cos\\theta) = U_{n+1}(\\cos\\theta) + U_{n-1}(\\cos\\theta)$.",
-    "significance": "supporting",
+    "significance": "context",
     "relatedConcepts": [
       "conjunction proof pattern",
       "namespace boundary",

--- a/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "de-moivre-oq-02-oq-02",
   "title": "Chebyshev T·U Cross-Product Formula",
   "slug": "de-moivre-oq-02-oq-02",
-  "description": "Proves the cross-product-to-sum formula 2·T_m·U_n = U_{m+n} + U_{n-m} as a polynomial identity over any commutative ring R, extending the T×T formula to the T×U setting. Proved via paired integer induction with 0 sorries. Also derives the trig identity 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ).",
+  "description": "Proves two Chebyshev product identities: T·U: 2·T_m·U_n = U_{m+n} + U_{n-m} as a polynomial identity over any commutative ring R; and U·U: 2·sin²θ·U_m(cosθ)·U_n(cosθ) = T_{m-n}(cosθ) − T_{m+n+2}(cosθ). Together they complete the Chebyshev product table (T·T, T·U, U·U). Both proved with 0 sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials#Products_of_Chebyshev_polynomials",
@@ -24,14 +24,16 @@
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 182,
-    "assumptions": "0 axioms, 0 sorries. Polynomial identity proved over any commutative ring R.",
-    "theoremCount": 9,
+    "lineCount": 216,
+    "assumptions": "0 axioms, 0 sorries. Polynomial identity proved over any commutative ring R; U·U formula proved in ℝ.",
+    "theoremCount": 11,
     "originalContributions": [
       "T_mul_U_product: 2·T_m·U_n = U_{m+n} + U_{n-m} as a polynomial identity in R[X] for any CommRing R",
       "chebyshev_T_U_product_to_sum: real evaluation form of the cross-product formula",
       "chebyshev_cos_U: 2·cos θ·U_n(cos θ) = U_{n+1}(cos θ) + U_{n-1}(cos θ)",
-      "two_cos_sin_spreading: 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ)"
+      "two_cos_sin_spreading: 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ)",
+      "chebyshev_U_U_product_to_diff: 2·sin²θ·U_m(cosθ)·U_n(cosθ) = T_{m-n}(cosθ) − T_{m+n+2}(cosθ)",
+      "two_sin_sin_spreading: 2·sin((m+1)θ)·sin((n+1)θ) = cos((m-n)θ) − cos((m+n+2)θ)"
     ],
     "historicalContext": "Chebyshev polynomials of the first kind T_n satisfy T_n(cos θ) = cos(nθ), while the second kind U_n satisfy U_n(cos θ)·sin θ = sin((n+1)θ). The product-to-sum formula 2·T_m·T_n = T_{m+n} + T_{m-n} follows immediately from the cosine addition formula. A natural extension is the cross-product 2·T_m·U_n = U_{m+n} + U_{n-m}, which mixes both kinds and corresponds to the trigonometric identity 2·cos(mθ)·sin((n+1)θ) = sin((m+n+1)θ) + sin((n-m+1)θ). Unlike the T×T formula, this identity requires polynomial (not trigonometric) proof techniques, since dividing by sin θ introduces singularities.",
     "problemStatement": "**The Open Question**\n\nThe parent OQ-02 proved $2T_m \\cdot T_n = T_{m+n} + T_{m-n}$ via trigonometry. Can a similar product-to-sum formula hold involving Chebyshev polynomials of the second kind $U_n$?\n\n**Answer: YES — cross-product formula**\n\nFor $m, n : \\mathbb{Z}$ and any commutative ring $R$:\n$$2 \\cdot T_m \\cdot U_n = U_{m+n} + U_{n-m} \\quad \\text{in } R[X]$$\n\nProved algebraically (no trigonometric bridge) via paired integer induction.",
@@ -43,22 +45,15 @@
       "**T_{-1} = X**: The base case P(-1) requires T_{-1} = X, which itself needs a mini induction via T_add_two at -1: T(1) = 2X·T(0) - T(-1) gives X = 2X·1 - T(-1), so T(-1) = X.",
       "**No sin θ = 0 case analysis**: Converting to the trig form via polynomial evaluation avoids the singularity sin θ = 0 that would arise from U_real_cos directly.",
       "**two_X_U powers all three cases**: The helper lemma $2X \\cdot U_k = U_{k+1} + U_{k-1}$ (a rearrangement of the U recurrence) is applied exactly twice per induction step — once at index $m+n$ and once at $n-m$ (or their shifted versions). This precise re-use is what makes `linear_combination` close all three cases automatically."
-    ],
-    "definitionCount": 2
+    ]
   },
   "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Polynomial",
-      "Polynomial.Chebyshev",
-      "Real"
-    ],
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial", "Polynomial.Chebyshev", "Real"],
     "namespace": "DeMoivreOQ02OQ02",
-    "lineCount": 182,
+    "lineCount": 216,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2,
     "path": "Proofs/DeMoivreOQ02OQ02.lean",
     "sorries": 0,
@@ -78,7 +73,7 @@
   "overview": {
     "historicalContext": "**Two Chebyshev Families**\n\nChebyshev polynomials come in two families sharing the same recurrence $p_{n+2} = 2x \\cdot p_{n+1} - p_n$:\n- **First kind** $T_n$: $T_n(\\cos\\theta) = \\cos(n\\theta)$, initial conditions $T_0 = 1$, $T_1 = x$\n- **Second kind** $U_n$: $U_n(\\cos\\theta)\\sin\\theta = \\sin((n+1)\\theta)$, initial conditions $U_0 = 1$, $U_1 = 2x$\n\n**Product Formulas**\n\nThe parent OQ-02 proved $2T_m \\cdot T_n = T_{m+n} + T_{m-n}$ directly from $2\\cos(m\\theta)\\cos(n\\theta) = \\cos((m+n)\\theta) + \\cos((m-n)\\theta)$. The analogous trigonometric identity for mixed products is $2\\cos(m\\theta)\\sin((n+1)\\theta) = \\sin((m+n+1)\\theta) + \\sin((n-m+1)\\theta)$, which in polynomial form becomes $2T_m \\cdot U_n = U_{m+n} + U_{n-m}$. This requires algebraic proof (the trigonometric conversion would require dividing by $\\sin\\theta$, introducing singularities).",
     "problemStatement": "**The Open Question**\n\nCan the product-to-sum formula be extended to Chebyshev polynomials of the second kind?\n\n**Answer: YES — the cross-product formula**\n\n$$2 \\cdot T_m \\cdot U_n = U_{m+n} + U_{n-m} \\in R[X]$$\n\nfor any commutative ring $R$ and integers $m, n$.",
-    "text": "Proves 2·T_m·U_n = U_{m+n} + U_{n-m} as a polynomial identity over any commutative ring R, via paired integer induction. Also derives the real-evaluation form, the recurrence identity 2·cos θ·U_n(cos θ) = U_{n+1}(cos θ) + U_{n-1}(cos θ), and the trig spreading identity 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ).",
+    "text": "Proves two Chebyshev product identities completing the product table: T·U: 2·T_m·U_n = U_{m+n} + U_{n-m} over any commutative ring R via paired integer induction; and U·U: 2·sin²θ·U_m·U_n = T_{m-n} − T_{m+n+2} via the cos-subtraction formula. Also derives recurrence identity 2·cos θ·U_n = U_{n+1} + U_{n-1} and spreading identities for sin and cos.",
     "proofStrategy": "**Paired Integer Induction**\n\nThe proof defines $Q(m) := P(m) \\wedge P(m-1)$ where $P(m) := 2T_m \\cdot U_n = U_{m+n} + U_{n-m}$ and proves $Q$ by `Int.induction_on`. The key engine is the identity $2X \\cdot U_k = U_{k+1} + U_{k-1}$ (from `U_add_two`), which powers:\n- Base case $P(-1)$: $2T_{-1} \\cdot U_n = 2X \\cdot U_n = U_{n+1} + U_{n-1} = U_{-1+n} + U_{n-(-1)}$ ✓\n- Successor step: from $P(m)$ and $P(m-1)$, apply $T_{m+1} = 2X \\cdot T_m - T_{m-1}$ and `linear_combination`\n- Predecessor step: from $P(m)$ and $P(m-1)$, apply $T_{m-2} = 2X \\cdot T_{m-1} - T_m$ and `linear_combination`",
     "keyInsights": [
       "**Polynomial identity, not trigonometric**: The formula holds in R[X] for any CommRing R, proved without evaluating at cos θ.",
@@ -132,15 +127,23 @@
       "title": "Trig Identity: 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ)",
       "startLine": 155,
       "endLine": 182,
-      "summary": "Converts chebyshev_cos_U to pure trigonometric form via U_real_cos (U_n(cos θ)·sin θ = sin((n+1)θ)). Uses nlinarith with sin²θ + cos²θ = 1 to handle the sin θ factors. Final theorem demoivre_oq02oq02_summary collects the main results.",
-      "mathContext": "From $U_n(\\cos\\theta) \\cdot \\sin\\theta = \\sin((n+1)\\theta)$: multiply $2\\cos\\theta \\cdot U_n(\\cos\\theta) = U_{n+1}(\\cos\\theta) + U_{n-1}(\\cos\\theta)$ by $\\sin\\theta$ to get $2\\cos\\theta \\cdot \\sin((n+1)\\theta) = \\sin((n+2)\\theta) + \\sin(n\\theta)$."
+      "summary": "Converts chebyshev_cos_U to pure trig form via sin_add/sin_sub (not U_real_cos, which has rewrite issues). Proves 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ).",
+      "mathContext": "Uses $\\sin(A+B) + \\sin(A-B) = 2\\sin A \\cos B$ with $A = (n+1)\\theta$, $B = \\theta$."
+    },
+    {
+      "id": "uu-product",
+      "title": "U·U Product-to-Difference Formula",
+      "startLine": 140,
+      "endLine": 215,
+      "summary": "Proves 2·sin²θ·U_m(cosθ)·U_n(cosθ) = T_{m-n}(cosθ) − T_{m+n+2}(cosθ) via: (1) cos(A-B) − cos(A+B) = 2·sin(A)·sin(B); (2) U_n(cosθ)·sinθ = sin((n+1)θ). Also proves two_sin_sin_spreading: 2·sin((m+1)θ)·sin((n+1)θ) = cos((m−n)θ) − cos((m+n+2)θ). Summary theorem demoivre_oq02oq02_summary collects all main results.",
+      "mathContext": "$\\cos((m-n)\\theta) - \\cos((m+n+2)\\theta) = 2\\sin((m+1)\\theta)\\sin((n+1)\\theta) = 2 \\cdot U_m(\\cos\\theta)\\sin\\theta \\cdot U_n(\\cos\\theta)\\sin\\theta$. Dividing by $\\sin^2\\theta = 1 - \\cos^2\\theta$ (in the polynomial sense) gives the formula."
     }
   ],
   "conclusion": {
-    "summary": "Proves 5 theorems with 0 sorries, establishing the Chebyshev T×U cross-product formula as a polynomial identity over any commutative ring R. The paired integer induction technique generalizes the first-kind product-to-sum to the mixed T×U setting.",
+    "summary": "Proves 11 theorems/lemmas with 0 sorries, completing the Chebyshev product table (T·T, T·U, U·U). The T·U identity holds over any commutative ring R via paired integer induction; the U·U identity is proved in ℝ via the cosine subtraction formula.",
     "implications": "**Theoretical Significance**\n\n1. **Over any CommRing R**: Unlike the parent OQ-02 (which uses trigonometry and is specific to ℝ), this identity holds algebraically in any commutative ring — broader generality.\n\n2. **Basis for U×U product formula**: The T×U cross-product can serve as a building block for the U×U product formula $U_m \\cdot U_n = \\sum_{k=0}^{\\min(m,n)} U_{m+n-2k}$ via recurrence matching.\n\n3. **Sin spreading identity**: The trig corollary $2\\cos\\theta \\cdot \\sin((n+1)\\theta) = \\sin((n+2)\\theta) + \\sin(n\\theta)$ is an important building block for Fourier-type series manipulations.",
     "openQuestions": [
-      "Can the U×U product formula U_m · U_n = ∑_{k=0}^{min(m,n)} U_{m+n-2k} be proved by recurrence matching over ℝ[X]?",
+      "Can the U×U product formula U_m · U_n = ∑_{k=0}^{min(m,n)} U_{m+n-2k} (sum form) be proved as a polynomial identity over R[X], analogous to the T·U formula?",
       "Can the T×U cross-product be proved over a more general setting (e.g., Chebyshev polynomials over ℤ)?",
       "Does a T×V cross-product formula hold for the third-kind Chebyshev polynomials V_n (satisfying V_n(cos θ) = cos((n+½)θ)/cos(θ/2))?"
     ]


### PR DESCRIPTION
## Summary

Salvages the unique mathematical content of #15534 onto a fresh branch off `origin/main`. The original PR's branch had accumulated ~3990 files of unrelated main-repo-index pollution (classic issue per `feedback_enricher_main_repo_index_pollution.md`) and was not rebasable.

This PR contains **only the 3 intended files** that #15534 meant to change:

- `proofs/Proofs/DeMoivreOQ02OQ02.lean`  (+93 / -39)
- `src/data/proofs/de-moivre-oq-02-oq-02/meta.json`  (+12 / -19, count/description sync)
- `src/data/proofs/de-moivre-oq-02-oq-02/annotations.json`  (+5 / -5, validator-enum tightening)

## New mathematical content

Completes the Chebyshev product table (T·T, T·U, U·U) for the gallery:

- **chebyshev_U_U_product_to_diff**:
  $2(1 - \cos^2\theta)\cdot U_m(\cos\theta)\cdot U_n(\cos\theta) = T_{m-n}(\cos\theta) - T_{m+n+2}(\cos\theta)$
- **two_sin_sin_spreading**:
  $2\sin((m+1)\theta)\sin((n+1)\theta) = \cos((m-n)\theta) - \cos((m+n+2)\theta)$

Proof technique: direct from `Real.cos_sub` / `Real.cos_add` combined with `U_real_cos`. No new induction.

## Mathlib API drift fixes (also from #15534)

- `Q_succ` / `Q_pred`: switch from binder-pattern `⟨hm, hm1⟩` to `obtain ⟨hm, hm1⟩ := ih`.
- `T_mul_U_product`: rewrite integer induction with `apply Int.induction_on` + `intro` (avoids a goal-shape mismatch in the negative branch).
- `chebyshev_T_U_product_to_sum`: replace `map_ofNat` simp step with explicit `(2 : ℝ[X]).eval _ = 2`.
- `chebyshev_cos_U`: drop `convert … using 2 <;> [ring; ring]` for explicit normalisation + `linarith`.
- `two_cos_sin_spreading`: replace the `U_real_cos`-rewrite path (coercion shape changed) with direct `sin_add` / `sin_sub`.

## Counts

Verified with the canonical regex (excluding block comments):

| field        | claimed | actual |
|--------------|---------|--------|
| theoremCount | 11      | 11     |
| definitionCount | 2    | 2      |
| axiomCount   | 0       | 0      |
| lineCount    | 216     | 216    |

## Build status

**UNVERIFIED.** Host load average was ~25 and `/Users` was 93% full at salvage time, making a Docker build impractical. The mathematical content was cross-checked against the Mathlib API
(`Real.cos_sub`, `Real.cos_add`, `Polynomial.Chebyshev.U_real_cos`, `Polynomial.Chebyshev.T_real_cos`,
`Real.sin_sq_add_cos_sq`) but the `linear_combination` / `linarith` closures should be exercised by CI/Docker.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ02OQ02` succeeds with 0 sorries
- [ ] Gallery page renders new section/annotation entries

Closes #15534. Original mathematical work credit to that PR.