### PR TITLE
Enrich cayley-hamilton-minpoly-oq-02-oq-01-oq-02: fix invisible cross-refs (5), sort annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/annotations.json
@@ -24,18 +24,6 @@
     "prerequisites": ["minimal polynomial definition", "polynomial evaluation in algebras", "minpoly.dvd lemma"]
   },
   {
-    "id": "ann-integrality-hypothesis",
-    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-02",
-    "range": { "startLine": 71, "endLine": 73 },
-    "type": "concept",
-    "title": "Why Both `IsIntegral` Hypotheses Matter",
-    "content": "The theorem requires `IsIntegral K a` AND `IsIntegral K (f a)`. Both are necessary: in Mathlib, `minpoly K x` is defined to be 0 (the zero polynomial) whenever x is non-integral, so without integrality the iff degenerates to 0 = 0 ↔ aeval a 0 = 0, which is trivially true and gives no information. For finite-dimensional K-algebras both hypotheses are automatic. Note: `IsIntegral K (f a)` does NOT follow from `IsIntegral K a` for arbitrary algebra maps — although it does follow when B is finite-dimensional over K, or whenever we can pull integrality back through f.",
-    "mathContext": "An element $a \\in A$ is **integral** over $K$ if there exists a monic polynomial $p \\in K[X]$ with $p(a) = 0$. Mathlib's convention: `minpoly K a = 0` iff `¬ IsIntegral K a`, i.e. minpoly returns the zero polynomial for transcendental elements. This makes minpoly a total function (no `Option`), but creates the trap that statements about minpoly equality silently degenerate when integrality fails. The `eq_of_monic_of_associated` step in our proof requires both polynomials to be monic — but `minpoly K (f a)` is monic only when `IsIntegral K (f a)` holds (`minpoly.monic` requires this hypothesis).",
-    "significance": "technical",
-    "relatedConcepts": ["IsIntegral", "transcendental elements", "finite-dimensional algebras", "minpoly.monic", "minpoly.ne_zero"],
-    "prerequisites": ["integral elements over a field", "Mathlib minpoly conventions", "monic polynomials"]
-  },
-  {
     "id": "ann-main-theorem",
     "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-02",
     "range": { "startLine": 57, "endLine": 85 },
@@ -46,6 +34,18 @@
     "significance": "key",
     "relatedConcepts": ["mutual divisibility", "associated elements", "monic polynomials", "minimal polynomial iff criterion"],
     "prerequisites": ["minimal polynomial universal property", "polynomial ring UFD structure", "monic polynomial uniqueness"]
+  },
+  {
+    "id": "ann-integrality-hypothesis",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-02",
+    "range": { "startLine": 71, "endLine": 73 },
+    "type": "concept",
+    "title": "Why Both `IsIntegral` Hypotheses Matter",
+    "content": "The theorem requires `IsIntegral K a` AND `IsIntegral K (f a)`. Both are necessary: in Mathlib, `minpoly K x` is defined to be 0 (the zero polynomial) whenever x is non-integral, so without integrality the iff degenerates to 0 = 0 ↔ aeval a 0 = 0, which is trivially true and gives no information. For finite-dimensional K-algebras both hypotheses are automatic. Note: `IsIntegral K (f a)` does NOT follow from `IsIntegral K a` for arbitrary algebra maps — although it does follow when B is finite-dimensional over K, or whenever we can pull integrality back through f.",
+    "mathContext": "An element $a \\in A$ is **integral** over $K$ if there exists a monic polynomial $p \\in K[X]$ with $p(a) = 0$. Mathlib's convention: `minpoly K a = 0` iff `¬ IsIntegral K a`, i.e. minpoly returns the zero polynomial for transcendental elements. This makes minpoly a total function (no `Option`), but creates the trap that statements about minpoly equality silently degenerate when integrality fails. The `eq_of_monic_of_associated` step in our proof requires both polynomials to be monic — but `minpoly K (f a)` is monic only when `IsIntegral K (f a)` holds (`minpoly.monic` requires this hypothesis).",
+    "significance": "technical",
+    "relatedConcepts": ["IsIntegral", "transcendental elements", "finite-dimensional algebras", "minpoly.monic", "minpoly.ne_zero"],
+    "prerequisites": ["integral elements over a field", "Mathlib minpoly conventions", "monic polynomials"]
   },
   {
     "id": "ann-isroot-form",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
@@ -139,29 +139,29 @@
   },
   "crossReferences": [
     {
-      "id": "cayley-hamilton-minpoly-oq-02-oq-01",
-      "title": "Minimal Polynomial Generalization to K-Algebras",
-      "relationship": "Parent open question: proves minpoly invariance for INJECTIVE algebra maps. This entry answers the follow-up: what happens for non-injective maps?"
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent open question: proves minpoly invariance for INJECTIVE algebra maps. This entry answers the follow-up: what happens for non-injective maps?"
     },
     {
-      "id": "cayley-hamilton-minpoly",
-      "title": "Cayley-Hamilton and Minimal Polynomial",
-      "relationship": "Foundation: establishes the core Cayley-Hamilton theorem and minimal polynomial theory this entry builds upon."
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "depends-on",
+      "description": "Foundation: establishes the core Cayley-Hamilton theorem and minimal polynomial theory this entry builds upon."
     },
     {
-      "id": "cayley-hamilton-minpoly-oq-02",
-      "title": "Cayley-Hamilton Minpoly (OQ-02)",
-      "relationship": "Grandparent open question in the minimal polynomial line of inquiry."
+      "targetId": "cayley-hamilton-minpoly-oq-02",
+      "relationship": "ancestor",
+      "description": "Grandparent open question in the minimal polynomial line of inquiry."
     },
     {
-      "id": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
-      "title": "Skolem-Noether Theorem: K-Algebra Automorphisms of Mₙ(K)",
-      "relationship": "Sibling under OQ-02-OQ-01: applies the injective case to characterize automorphisms of matrix algebras (every automorphism is inner). This entry handles the dual situation — what happens when the algebra map is NOT injective."
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling under OQ-02-OQ-01: applies the injective case to characterize automorphisms of matrix algebras (every automorphism is inner). This entry handles the dual situation — what happens when the algebra map is NOT injective."
     },
     {
-      "id": "cayley-hamilton-minpoly-oq-02-oq-03",
-      "title": "Rational Canonical Form: Similarity Invariance",
-      "relationship": "Sibling result on minpoly behavior under algebra maps: similarity (conjugation by an invertible matrix, an injective map) preserves minpoly. This entry explains exactly when more general — possibly non-injective — algebra maps preserve minpoly."
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling result on minpoly behavior under algebra maps: similarity (conjugation by an invertible matrix, an injective map) preserves minpoly. This entry explains exactly when more general — possibly non-injective — algebra maps preserve minpoly."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment pass for cayley-hamilton-minpoly-oq-02-oq-01-oq-02

### Critical bug fix: invisible cross-references

The 5 entries in `meta.crossReferences` used the schema field `id` instead of the supported `targetId`/`proofId`. The renderer at `src/components/proof/ProofOverview.tsx:364` reads:

```typescript
const refSlug = ref.proofId ?? ref.targetId
if (!refSlug) return null
```

With `id` instead of `targetId`/`proofId`, `refSlug` is `undefined` and **the cross-reference is silently dropped**. So all 5 related-proof links — to `cayley-hamilton-minpoly-oq-02-oq-01`, `cayley-hamilton-minpoly`, `cayley-hamilton-minpoly-oq-02`, `cayley-hamilton-minpoly-oq-02-oq-01-oq-01`, `cayley-hamilton-minpoly-oq-02-oq-03` — were invisible on the live site.

Now uses `targetId` (matching `src/types/proof.ts` `CrossReference`) and the renderer-supported `description` field, with simple `relationship` codes (`extends`, `depends-on`, `sibling`, `ancestor`) for the typed relationship.

All 5 target slugs verified to exist as gallery directories.

### Cleanup: annotation ordering

`ann-integrality-hypothesis` (range L71-73) appeared in the array between `ann-universal-dvd` (L45-52) and `ann-main-theorem` (L57-85), out of `startLine` order. Moved it to after `ann-main-theorem` so the array is sorted ascending by startLine.

### Quality budget (unchanged from prior pass — already strong)

- 8 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`
- 7 keyInsights, including categorical / failure-mode framings
- 5 sections, 4 openQuestions, rich historicalContext (Cayley 1858, Frobenius 1878, Noether/van der Waerden/Bourbaki, Mathlib history)
- `mathlibDependencies` array with 5 entries (cited by module)
- `knownResults` array with 9 entries

### Verification

- JSON parsed cleanly via `json.load`.
- Annotation array now sorted by startLine (verified programmatically).
- `pnpm build` could not run locally due to a `better-sqlite3` install failure on Node v26 (env issue, unrelated to this PR).
- All 5 cross-reference target slugs verified to exist as gallery directories.

### Why this matters

The cross-reference field-name bug is a recurring pattern (similar to my prior PR #17147 which fixed a wrong-targetId bug on `sperner-simplicial-instance`). A grep across `src/data/proofs/*/meta.json` for the pattern `"id":` directly under `crossReferences` would surface other entries with the same defect — worth a follow-up batch by the mechanic agent.