### PR TITLE
audit(tracker): sylow-theorem-oq-02 — 2nd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13327,10 +13327,10 @@
       "result": "clean"
     },
     "sylow-theorem-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T18:12:09Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-08T14:10:00Z",
+      "result": "clean"
     },
     "sylow-theorem-oq-04": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Re-audit of `sylow-theorem-oq-02` (Orbit Enumeration of Sylow p-Subgroups). Result: **clean**.

## Verified

All structural counts match `meta.json`:
- lineCount: 204
- theoremCount: 10
- definitionCount: 2
- axiomCount: 0
- sorries: 0
- True stubs: 0

## Narrative integrity

Tier B classification (`badge: "mathlib"`) is correct. The `assumptions` field transparently credits Mathlib's Sylow API:
- `Sylow.orbit_eq_top` (line 61)
- `Sylow.stabilizer_eq_normalizer` (line 83)
- `Sylow.card_eq_index_normalizer` (line 102)
- `Sylow.equivQuotientNormalizer` (line 110)
- `card_sylow_modEq_one` (line 176)

All four cited APIs verified to be actually referenced in the Lean source. No delegation opacity, axiom masking, or pipeline inflation detected.

## Tracker change

`auditCount` 1 -> 2; `lastAudited` 2026-04-24 -> 2026-05-08; `result` `issues-fixed` -> `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)