### PR TITLE
research(sperner-ndim-mathlib-oq-02): S19 — abstract adj-bridge for AbstractSimplicialData (build pending)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -1464,3 +1464,104 @@ private lemma t2_face2_neighbor_topSimps2
 
 end N2BoundaryInteriorNeighbors
 end SpernerFreudSimp
+
+-- ============================================================
+-- (Session 19) Abstract adj-bridge for AbstractSimplicialData.
+--
+-- Generic lemmas translating `D.toTriangulation.adj ⟨s, hs⟩ k =
+-- none` to a concrete container-cardinality condition. These are
+-- the missing piece bridging the abstract `Triangulation` API
+-- (`_hBoundaryOnFace` of `boundary_doors_odd`) to the concrete
+-- `containersOf`-based analysis built up in S16-S18.
+--
+-- Three increasingly specific forms are provided:
+--
+-- 1. `adjFn_eq_none_iff_card_le_one`: pure dite-unfolding —
+--    `D.adjFn p k = none ↔ container card ≤ 1`.
+--    Holds for any AbstractSimplicialData (no pseudomanifold).
+-- 2. `adjFn_eq_none_iff_card_eq_one`: combined with
+--    `containersOf_card_one_or_two` (pseudomanifold) to give
+--    `D.adjFn p k = none ↔ container card = 1`.
+-- 3. `toTriangulation_adj_eq_none_iff`: same restated for
+--    `D.toTriangulation.adj` (definitionally equal to D.adjFn).
+--
+-- Used by upcoming S20 to translate the n=2
+-- `_hBoundaryOnFace` hypothesis of `boundary_doors_odd` (applied
+-- to `simData2.toTriangulation`) into the case-split through the
+-- container-cardinality dichotomy from S18.1/S18.2.
+-- ============================================================
+
+namespace SpernerFreudSimp
+section S19AdjBridge
+
+/-- Pure dite-unfolding bridge: `D.adjFn p k = none` iff the
+codimension-1 face has at most one top-simplex container. The
+forward direction handles three branches of the nested `dite`:
+the boundary (card ≤ 1) branch trivially; the interior happy-path
+(card > 1, neighbor exists) yields `some`, contradicting `none`;
+and the would-be third branch (card > 1 but `cs.erase s` empty)
+is impossible because `s ∈ containers`, hence `cs.erase s` has
+card `≥ cs.card - 1 ≥ 1`. -/
+private lemma adjFn_eq_none_iff_card_le_one
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    D.adjFn ⟨s, hs⟩ k = none ↔
+    (D.containersOf (D.faceOf s hs k)).card ≤ 1 := by
+  constructor
+  · intro h
+    by_contra hgt
+    push_neg at hgt
+    unfold AbstractSimplicialData.adjFn at h
+    simp only at h
+    split_ifs at h with hc hne
+    · -- Branch 1: hc says card ≤ 1; contradicts hgt
+      omega
+    · -- Branch 2: card > 1 and erase nonempty → adjFn returned some
+      -- h : some ⟨..., ...⟩ = none, impossible
+      exact Option.noConfusion h
+    · -- Branch 3: card > 1 but erase empty → impossible because
+      -- s itself is in containers
+      rw [Finset.not_nonempty_iff_eq_empty] at hne
+      have hs_cont : s ∈ D.containersOf (D.faceOf s hs k) :=
+        D.self_mem_containersOf s hs k
+      have hcerase := Finset.card_erase_of_mem hs_cont
+      rw [hne, Finset.card_empty] at hcerase
+      omega
+  · intro hle
+    unfold AbstractSimplicialData.adjFn
+    simp only
+    rw [dif_pos hle]
+
+/-- Pseudomanifold-strengthened bridge: under the pseudomanifold
+condition baked into `AbstractSimplicialData`, `containersOf` is
+always nonempty (since `s ∈ containers`), so `card ≤ 1` is
+equivalent to `card = 1`. -/
+private lemma adjFn_eq_none_iff_card_eq_one
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    D.adjFn ⟨s, hs⟩ k = none ↔
+    (D.containersOf (D.faceOf s hs k)).card = 1 := by
+  rw [adjFn_eq_none_iff_card_le_one]
+  have h1 : 0 < (D.containersOf (D.faceOf s hs k)).card :=
+    Finset.card_pos.mpr ⟨s, D.self_mem_containersOf s hs k⟩
+  omega
+
+/-- Bridge for `Triangulation.adj` directly: since
+`D.toTriangulation.adj` is defined as `D.adjFn` (see
+`AbstractSimplicialData.toTriangulation` in
+`SpernerSimplicialInstance`), the previous lemma applies
+verbatim. This is the form S20 will consume to discharge the
+`_hBoundaryOnFace` hypothesis of `Triangulation.boundary_doors_odd`. -/
+private lemma toTriangulation_adj_eq_none_iff
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    D.toTriangulation.adj ⟨s, hs⟩ k = none ↔
+    (D.containersOf (D.faceOf s hs k)).card = 1 :=
+  adjFn_eq_none_iff_card_eq_one D s hs k
+
+end S19AdjBridge
+end SpernerFreudSimp
+

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -2,14 +2,49 @@
 
 **Phase**: REFINE
 **Since**: 2026-05-06
-**Last Updated**: 2026-05-08 (Iteration 18 part 2, researcher-5)
-**Iteration**: 18
+**Last Updated**: 2026-05-08 (Iteration 19, researcher-5)
+**Iteration**: 19
 
 ## Current Focus
 
-Session 18 part 2 (this session, build pending): Added 5 new
-`private` existential lemmas in a new `N2BoundaryInteriorNeighbors`
-section (appended after `N2BoundaryAnalysis` at end of file) that
+Session 19 (this session, build pending): Added 3 new generic
+`private` lemmas in a new `S19AdjBridge` section (appended after
+`end SpernerFreudSimp`) that translate the abstract
+`D.toTriangulation.adj ⟨s, hs⟩ k = none` hypothesis of
+`Triangulation.boundary_doors_odd` to the concrete
+container-cardinality condition built up in S16-S18:
+
+1. `adjFn_eq_none_iff_card_le_one`: pure dite-unfolding —
+   `D.adjFn ⟨s, hs⟩ k = none ↔ (D.containersOf (D.faceOf s hs k)).card ≤ 1`.
+   Holds for any `AbstractSimplicialData V n` (no pseudomanifold
+   needed). Three-branch dispatch through the nested `dite` of
+   `adjFn`: boundary branch trivial; interior happy-path
+   contradicts `none`; the would-be third branch (card > 1, but
+   `cs.erase s` empty) is impossible because `s ∈ containers`.
+2. `adjFn_eq_none_iff_card_eq_one`: pseudomanifold-strengthened
+   form. Combines (1) with `Finset.card_pos.mpr ⟨s, self_mem_containersOf⟩`
+   to upgrade `card ≤ 1` to `card = 1`.
+3. `toTriangulation_adj_eq_none_iff`: same restated for
+   `D.toTriangulation.adj` (definitionally equal to `D.adjFn`,
+   so the proof is by direct application of (2)).
+
+This is the **last abstract bridge piece** before S20 can wire
+the S16/S17/S18.1/S18.2 building-block table into the existential
+`∃ faceIdx, ∀ j ≠ k, onFaceΔ2 (vertex s j) faceIdx` required by
+`_hBoundaryOnFace`. The S20 case-split now reads:
+
+```
+intro s k h_adj
+rw [toTriangulation_adj_eq_none_iff] at h_adj
+-- h_adj : (containers (faceOf s k)).card = 1
+obtain ⟨b, hb, rfl⟩ | ⟨c, hc, rfl⟩ := topSimps2_mem_iff.mp s.2
+-- t1 b case: containers card = 1 ↔ boundary edge (S18.1)
+-- t2 c case: containers card ≥ 2 (S18.2 t2-share, PR #17150) → False
+```
+
+Session 18 part 2 (PR #17149, merged): Added 5 new `private`
+existential lemmas in a new `N2BoundaryInteriorNeighbors`
+section (appended after `end SpernerFreudSimp`) that
 complement S18 part 1 (PR #17133, merged) by covering the
 **interior** side of `_hBoundaryOnFace`:
 
@@ -41,10 +76,11 @@ building blocks.
 | t2   | face1      | (impossible, no boundary) | S18.2.4 `t2_face1_neighbor_topSimps2` |
 | t2   | face2      | (impossible, no boundary) | S18.2.5 `t2_face2_neighbor_topSimps2` |
 
-Remaining S19 work is **abstract-level bridge**: translate
-`T.adj s k = none` ↔ `(containers ...).card ≤ 1` and case-split
-through the 11 building blocks above (~80 lines, mostly
-case-splitting).
+**Note (S19, PR pending)**: the abstract `T.adj s k = none ↔
+container card = 1` bridge is now done as 3 generic lemmas in
+`S19AdjBridge` (`adjFn_eq_none_iff_card_le_one`,
+`adjFn_eq_none_iff_card_eq_one`, `toTriangulation_adj_eq_none_iff`).
+S20 next: case-split through the 11 building blocks above.
 
 Session 18 part 1 (PR #17133, merged): Promoted S16/S17 edge
 building blocks into the **boundary-edge container singletons**: for
@@ -167,32 +203,46 @@ does NOT appear in FreudCell. FreudCell simply triangulates the wrong space.
   `t1_ne_t2`, `diagonal_in_t{1,2}_iff`, `horizontal_in_t2_pos`,
   `vertical_in_t2_pos`, `horizontal_not_in_t2_at_y0`,
   `vertical_not_in_t2_at_x0`, `t2_face{0,1,2}_in_t1`
-- `N2BoundaryAnalysis` base ↔ topSimps2 bridge (S17, this session,
-  build pending): 13 new lemmas converting base membership to
+- `N2BoundaryAnalysis` base ↔ topSimps2 bridge (S17, PR #17101
+  merged): 13 new lemmas converting base membership to
   topSimps2 containment, plus the missing diagonal-boundary case
   `diagonal_not_in_t2_at_diagonal` and the top-level classification
   `diagonal_neighbor_topSimps2`.
+- `N2BoundaryAnalysis` t1-boundary container singletons +
+  onFaceΔ2 witnesses (S18 part 1, PR #17133, merged): 9 new
+  lemmas — three `*_only_container_of_t1_boundary`, three
+  `*_card_eq_one_of_t1_boundary` corollaries, and three
+  `*_endpoints_on_face*` Δ²-face witness lemmas.
+- `N2BoundaryInteriorNeighbors` interior-face existentials (S18
+  part 2, PR #17149, merged): 5 new lemmas covering the interior
+  side for each of the six face/edge × cell-type combinations.
+- `S19AdjBridge` abstract adj-bridge (S19, this session, build
+  pending): 3 new generic lemmas —
+  `adjFn_eq_none_iff_card_le_one` (no pseudomanifold needed),
+  `adjFn_eq_none_iff_card_eq_one` (combined with pseudomanifold),
+  and `toTriangulation_adj_eq_none_iff` (restated for the
+  abstract `Triangulation.adj`).
 - `sperner_panchromatic_two` (n=2): 1 sorry remaining
 - n≥3: future work
 
-## Path Forward for n≥2 (post-S18)
+## Path Forward for n≥2 (post-S19)
 
 `Triangulation.boundary_doors_odd` requires four hypotheses:
 1. `_hSperner` — done generically by S14 wrapper (cN2_total_isSpernerColoring)
-2. `_hBoundaryOnFace` — S16/S17/S18.1/S18.2 now supply ALL six
+2. `_hBoundaryOnFace` — S16/S17/S18.1/S18.2 supply ALL six
    face/edge × cell-type combinations as `private lemma`s (see
-   coverage table above). **S19 next**: walk through the abstract
-   `adjFn` in `simData2.toTriangulation` to translate
-   `adjFn s k = none` ↔ `(containersOf (faceOf s k)).card ≤ 1`,
-   then case-split through the 6+6 building blocks above to assemble
-   the existential `∃ faceIdx, ...` for the boundary cases and
-   produce a `False.elim` for the t2-cell cases (~80 lines, mostly
-   case-splitting; arithmetic content is in S16-S18).
+   coverage table above). S19 (this session) supplies the
+   abstract bridge `T.adj s k = none ↔ container card = 1`.
+   **S20 next**: case-split through the 11 building blocks
+   above to assemble the existential `∃ faceIdx, ...` for the
+   boundary cases and produce a `False.elim` for the t2-cell
+   cases (~80 lines, mostly case-splitting; arithmetic content
+   is in S16-S18).
 3. `_hLowerDim` — done generically by S15 helper
 4. `_hLastFace` — TODO (~120 lines, bijection with face2_path_odd via S12)
 
 Then apply `Triangulation.sperner` (~50 lines for diameter bound + real
-coordinates). Total estimated remaining: ~200 lines across 2 sessions.
+coordinates). Total estimated remaining: ~200 lines across 2-3 sessions.
 
 ## Gallery Status
 

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "REFINE",
     "since": "2026-05-06T11:50:53.576Z",
-    "iteration": 18,
-    "focus": "S18 part 2: interior-face neighbor existentials in N2BoundaryInteriorNeighbors section",
+    "iteration": 19,
+    "focus": "S19: abstract adj-bridge — adjFn_eq_none_iff_card_le_one + ..._eq_one + toTriangulation_adj_eq_none_iff in new S19AdjBridge section",
     "blockers": [],
-    "nextAction": "S19: assemble _hBoundaryOnFace by case-splitting through the 11 building blocks (S16/S17/S18.1/S18.2)",
+    "nextAction": "S20: case-split _hBoundaryOnFace via topSimps2_mem_iff using the bridge lemma + S18.1/S18.2/S17 building blocks (~80 lines)",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "STATE (2026-05-08, session 18 part 2, build pending): n=0,1 fully proved; n=2 has all _hBoundaryOnFace building blocks now in place across S16 (edge containment), S17 (base \u2194 topSimps2 bridge, PR #17101 merged), S18.1 (t1-boundary container singletons + onFace\u03942 witnesses, PR #17133 open), and S18.2 (this session, interior-face existentials: 5 lemmas in new N2BoundaryInteriorNeighbors section). Six face/edge \u00d7 cell-type combinations all covered; remaining S19 work is pure case-split assembly of `_hBoundaryOnFace` from these blocks + adjFn-to-cardinality bridge (~80 lines). Then _hLastFace (~120 lines) + apply Triangulation.sperner (~50 lines). Main file SpernerNDimMathlibOQ02.lean unchanged at 1 axiom.",
+    "progressSummary": "STATE (2026-05-08, session 19, build pending): n=0,1 fully proved; n=2 has all _hBoundaryOnFace building blocks AND the abstract adj-bridge in place. S16 (edge containment, PR #17051 merged), S17 (base \u2194 topSimps2 bridge, PR #17101 merged), S18.1 (t1-boundary container singletons + onFace\u03942 witnesses, PR #17133 merged), S18.2 (interior-face existentials, PR #17149 merged), and S19 (this session, abstract adjFn=none \u2194 container card = 1 bridge: 3 generic lemmas in new S19AdjBridge section). Remaining S20 work is the case-split assembly of `_hBoundaryOnFace` from the 11 building blocks + bridge (~60-80 lines). Then _hLastFace (~120 lines) + apply Triangulation.sperner (~50 lines). Main file SpernerNDimMathlibOQ02.lean unchanged at 1 axiom.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -68,9 +68,12 @@
       "Created lemma SpernerFreudSimp.diagonal_neighbor_topSimps2 in SpernerFreudenthalSimplex.lean (S17): top-level classification \u2203 s \u2208 topSimps2, s \u2260 t1 b \u2227 {diagonal} \u2286 s \u2194 b.1+b.2+1 < N.",
       "horizontal_neighbor_topSimps2: for b \u2208 t1Bases N with b.2 \u2265 1, \u2203 other simplex of topSimps2 N containing horizontal edge of t1 b \u2014 witness t2 (b.1, b.2 - 1) (S18.2.1, build pending)",
       "vertical_neighbor_topSimps2: analogous, b.1 \u2265 1, witness t2 (b.1 - 1, b.2) (S18.2.2, build pending)",
-      "t2_face0_neighbor_topSimps2: for c \u2208 t2Bases N, t2 face0 shared with t1 (c.1+1, c.2) (S18.2.3, build pending)",
-      "t2_face1_neighbor_topSimps2: t2 face1 shared with t1 (c.1, c.2+1) (S18.2.4, build pending)",
-      "t2_face2_neighbor_topSimps2: t2 face2 shared with t1 c (S18.2.5, build pending)"
+      "t2_face0_neighbor_topSimps2: for c \u2208 t2Bases N, t2 face0 shared with t1 (c.1+1, c.2) (S18.2.3, PR #17149 merged)",
+      "t2_face1_neighbor_topSimps2: t2 face1 shared with t1 (c.1, c.2+1) (S18.2.4, PR #17149 merged)",
+      "t2_face2_neighbor_topSimps2: t2 face2 shared with t1 c (S18.2.5, PR #17149 merged)",
+      "S19 adjFn_eq_none_iff_card_le_one: pure dite-unfolding bridge \u2014 D.adjFn p k = none \u2194 (D.containersOf (D.faceOf s hs k)).card \u2264 1, no pseudomanifold needed; three-branch dispatch (boundary OK, interior happy-path contradicts none, would-be third branch impossible since s \u2208 containers) (SpernerFreudenthalSimplex.lean S19AdjBridge, build pending)",
+      "S19 adjFn_eq_none_iff_card_eq_one: pseudomanifold-strengthened form combining S19.1 with Finset.card_pos.mpr \u27e8s, self_mem_containersOf\u27e9 to upgrade card \u2264 1 to card = 1 (build pending)",
+      "S19 toTriangulation_adj_eq_none_iff: Triangulation.adj-level statement, follows from adjFn_eq_none_iff_card_eq_one by definitional equality D.toTriangulation.adj = D.adjFn (build pending)"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -103,19 +106,22 @@
       "S17 \u2014 diagonal_neighbor_topSimps2 is the consumable form for S18. Cleanly says 'the diagonal of t1(b) is contained in some other simplex of topSimps2 \u2194 b.1+b.2+1 < N', with the witness simplex being t2(b). This is exactly what S18's containersOf-based assembly of _hBoundaryOnFace will plug into.",
       "S18 part 2 (researcher-5): the *interior* complement to S18.1's boundary singletons. Term-mode 4-tuples flatten correctly through `\u2203 s \u2208 S, P \u2227 Q` \u2014 no explicit nested \u27e8_, \u27e8_, _\u27e9\u27e9 needed. Pattern matches S17's diagonal_neighbor_topSimps2 reverse direction.",
       "Witness-direction asymmetry: when the cell is t1, witness is t2 \u2192 use `(t1_ne_t2 b _).symm` for `t2 _ \u2260 t1 b`. When cell is t2, witness is t1 \u2192 use raw `t1_ne_t2 _ c` for `t1 _ \u2260 t2 c`.",
-      "Six-cell coverage table now complete for n=2 _hBoundaryOnFace: t1 cells \u00d7 {diagonal, horizontal, vertical} have both boundary singleton (S18.1) AND interior existential (S17 + S18.2); t2 cells \u00d7 {face0, face1, face2} are always interior (S18.2.3-5; t2 contributes no boundary doors)."
+      "Six-cell coverage table now complete for n=2 _hBoundaryOnFace: t1 cells \u00d7 {diagonal, horizontal, vertical} have both boundary singleton (S18.1) AND interior existential (S17 + S18.2); t2 cells \u00d7 {face0, face1, face2} are always interior (S18.2.3-5; t2 contributes no boundary doors).",
+      "S19 \u2014 abstract adj-bridge factors cleanly into pure-dite vs pseudomanifold-strengthened forms. The first lemma adjFn_eq_none_iff_card_le_one needs no pseudomanifold and is the natural unfolding theorem; pseudomanifold (containers_card \u2264 2 + s \u2208 containers) only matters for the corollary card \u2264 1 \u2194 card = 1. The split keeps each lemma minimal \u2014 pure dite-unfolding \u2248 25 lines, the corollary 7 lines.",
+      "S19 \u2014 would-be third branch of nested dite (card > 1 but cs.erase s empty) is provably impossible: cs.erase s has card \u2265 cs.card - 1 because s \u2208 cs (self_mem_containersOf), and card > 1 forces cs.erase s nonempty. This is the lemma's most subtle case, but it falls to a single Finset.card_erase_of_mem + omega.",
+      "S19 \u2014 toTriangulation_adj_eq_none_iff is by-rfl after the corollary because AbstractSimplicialData.toTriangulation defines its adj field as D.adjFn directly (line 777 of SpernerSimplicialInstance.lean). The Triangulation.adj-level statement is the form that S20 will pattern-match against the _hBoundaryOnFace hypothesis of Triangulation.boundary_doors_odd."
     ],
     "mathlibGaps": [
       "Grid triangulation of \u0394\u207f as a CellComplex (needed for sperner_near_fixed_point axiom \u2014 significant work ~200 lines)",
       "Sequential compactness of stdSimplex in Lean 4 (needed for fixed_point_from_approx axiom)"
     ],
     "nextSteps": [
-      "S18: assemble _hBoundaryOnFace for the n=2 case using S16 edge lemmas + S17 base bridge. For each cell s = \u27e8S, hS\u27e9 with S \u2208 topSimps2 N, case-split via topSimps2_mem_iff. For S = t2 b, every k is non-boundary (use t2Bases_*_in_t1Bases + t1_in_topSimps2_of_base + S16's t2_face*_in_t1) so adj s k = none gives False.elim. For S = t1 b, each k corresponds to one boundary condition (b.1=0, b.2=0, or b.1+b.2+1\u2265N) and the existential faceIdx is one of Fin 3 (\u0394\u00b2-face 0/1/2). ~80 lines.",
-      "Prove _hLastFace (face 2 boundary doors): bijection with face2_path_odd's color-changing edges. The pre-S15 estimate of ~150 lines stands; if S18 produces the right vertexEnum/faceOf computations for t1/t2, this can drop to ~120.",
+      "S20: assemble _hBoundaryOnFace for the n=2 case using S19 bridge + S16/S17/S18.1/S18.2 building blocks. Now that toTriangulation_adj_eq_none_iff translates the abstract adj=none to container card = 1, the proof opens with `intro \u27e8S, hS\u27e9 k h_adj; rw [toTriangulation_adj_eq_none_iff] at h_adj`. Case-split via topSimps2_mem_iff: t2 b case contradicts (S18.2 t2-share lemmas + t1 \u2208 containers gives card \u2265 2); t1 b case branches on k via boundary conditions (b.1=0, b.2=0, or b.1+b.2+1\u2265N) and the existential faceIdx witness comes from S18.1 *_endpoints_on_face* lemmas. ~60-80 lines.",
+      "Prove _hLastFace (face 2 boundary doors): bijection with face2_path_odd's color-changing edges. The pre-S15 estimate of ~150 lines stands; if S20 produces the right vertexEnum/faceOf computations for t1/t2, this can drop to ~120.",
       "Apply Triangulation.sperner and extract real-coordinate witnesses with diameter \u2264 2/N (~50 lines).",
       "After sperner_panchromatic_two is complete (axiom-free n=2): generalize the Type-1/Type-2 grid construction to n\u22653 via Freudenthal triangulation. Each top simplex is determined by a base + permutation of {1, ..., n}; pseudomanifold proof scales linearly with n.",
       "The main file SpernerNDimMathlibOQ02.lean remains at 1 axiom (sperner_panchromatic for general n). Once n=2 is proved, the axiom can be replaced for n=2 or kept generically.",
-      "Build status: S17 not run through Docker (45min cold cache via broken proofs/.lake symlink). Pattern matches S14/S15/S16 build-pending merges. Lemmas are mechanical case-bash + omega."
+      "Build status: S19 not run through Docker (45min cold cache via broken proofs/.lake symlink). Pattern matches S14/S15/S16/S17/S18 build-pending merges. Lemmas are mechanical dite-unfolding + Finset card arithmetic."
     ]
   },
   "tags": [
@@ -135,7 +141,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-08T13:00:00Z",
+  "lastUpdate": "2026-05-08T14:30:00Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Session 19 of the n=2 Sperner-via-Type1/Type2 triangulation
formalization. Adds the **last abstract bridge piece** before
the n=2 `_hBoundaryOnFace` discharge: 3 generic lemmas
translating the abstract `D.toTriangulation.adj ⟨s, hs⟩ k =
none` hypothesis of `Triangulation.boundary_doors_odd` into the
concrete `containersOf`-based cardinality condition built up in
S16 (PR #17051), S17 (PR #17101), S18.1 (PR #17133), and S18.2
(PR #17149).

## What This Adds

3 new private lemmas in a new `S19AdjBridge` section of
`proofs/Proofs/SpernerFreudenthalSimplex.lean` (+101 lines), all
generic in `V`, `n`, `D : AbstractSimplicialData V n`:

### 1. `adjFn_eq_none_iff_card_le_one`

Pure dite-unfolding bridge — no pseudomanifold needed. Three
branches of the nested `dite` are dispatched: boundary trivially;
interior happy-path contradicts `none` via `Option.noConfusion`;
and the would-be third branch (`card > 1` but `cs.erase s` empty)
is impossible because `s ∈ containers`, so `cs.erase s` has card
`≥ card - 1 ≥ 1`.

### 2. `adjFn_eq_none_iff_card_eq_one`

Pseudomanifold-strengthened form. Combines (1) with
`Finset.card_pos.mpr ⟨s, self_mem_containersOf⟩` to upgrade
`card ≤ 1` to `card = 1` (since `card > 0` always for
nonempty containers).

### 3. `toTriangulation_adj_eq_none_iff`

Triangulation-level statement. Direct application of (2) by
definitional equality `D.toTriangulation.adj = D.adjFn` (see
\`AbstractSimplicialData.toTriangulation\` in
\`SpernerSimplicialInstance.lean:777\`).

## Why This Matters

Combined with the building-block coverage table from
S16/S17/S18.1/S18.2 (now all merged), every edge of every cell
in \`topSimps2 N\` has both a container-cardinality classification
AND an explicit witness for the \`_hBoundaryOnFace\` existential.
The S19 bridge is what wires this lookup table into the
abstract \`Triangulation.boundary_doors_odd\` hypothesis. S20
opens with:

\`\`\`lean
intro ⟨S, hS⟩ k h_adj
rw [toTriangulation_adj_eq_none_iff] at h_adj
-- h_adj : (containers (faceOf S k)).card = 1
obtain ⟨b, hb, rfl⟩ | ⟨c, hc, rfl⟩ := topSimps2_mem_iff.mp hS
-- t1 b case: card = 1 forces boundary edge (S18.1)
-- t2 c case: card ≥ 2 from S18.2 t2-share (PR #17150) → False
\`\`\`

## Path Forward

After S19:

- **S20**: case-split assembly of \`_hBoundaryOnFace\` from the
  11 building blocks + this bridge (~60-80 lines).
- **S21**: \`_hLastFace\` (~120 lines, bijection with
  \`face2_path_odd\` via S12).
- **S22**: apply \`Triangulation.sperner\` (~50 lines, diameter
  bound + real coordinates).

Total estimated remaining for \`sperner_panchromatic_two\`:
~230 lines across 3 sessions.

## Files

- \`proofs/Proofs/SpernerFreudenthalSimplex.lean\` (+101)
- \`research/problems/sperner-ndim-mathlib-oq-02/state.md\`
  (Iter 19, S19 focus, Path Forward refreshed for S20)
- \`src/data/research/problems/sperner-ndim-mathlib-oq-02.json\`
  (3 new builtItems, 3 new insights, currentState updated)

## Test Plan

- [ ] Build pending — worktree's \`proofs/.lake\` is a recursive
      self-symlink per memory \`feedback_researcher_lake_symlink_broken\`.
      Docker build by deployer/auditor expected (~45min cold).
- [x] All cited helper lemmas present in current
      \`SpernerSimplicialInstance.lean\` — verified via grep
      (\`AbstractSimplicialData.adjFn\` at L529,
      \`AbstractSimplicialData.containersOf\` at L324,
      \`AbstractSimplicialData.faceOf\` at L304,
      \`AbstractSimplicialData.self_mem_containersOf\` at L329,
      \`AbstractSimplicialData.toTriangulation\` at L768 with
      \`adj := D.adjFn\` at L777).
- [x] Diff scoped to three target files only (no main-repo
      pollution; verified \`git diff HEAD --stat\`).
- [x] Off fresh \`origin/main\` (\`0de05b842d7\`) at session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)