### PR TITLE
audit(tracker): wilsons-theorem-oq-01 — 3rd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13613,8 +13613,8 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-24T18:19:23Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-08T14:32:33Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-02": {


### PR DESCRIPTION
## Summary

Re-audit (3rd) of `wilsons-theorem-oq-01` confirms gallery integrity.

## Verified

| Field | meta.json | actual |
|---|---|---|
| lineCount | 688 | 688 ✓ |
| theoremCount | 35 | 35 ✓ |
| definitionCount | 9 | 9 ✓ |
| axiomCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |

`status: verified` / `badge: original` consistent with content. Mathlib reliance (`ZMod.isCyclic_units_iff`, `ZMod.prod_Ico_one_prime`) is appropriately credited in `proofStrategy`, `keyInsights[5]`, and `originalContributions`. Composite case and Wilson primes (5, 13) are independently proved; Mathlib provides only the Gauss-Wilson cyclic-classification step.

Minor note (below issue threshold): description text says "33 theorems" while structured fields correctly say 35. Snapshot artifact, not an overclaim.

## Test plan
- [x] Counts re-derived from comment-stripped Lean source
- [x] Tracker entry surgically updated (preserves unicode escape formatting)