### PR TITLE
research(minkowski-theorem-oq-04): S13 — tsum-indicator → encard bridge as standalone helper (build pending)

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ04.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ04.lean
@@ -227,6 +227,45 @@ theorem volume_eq_setLIntegral_indicator_tsum {n : ℕ} [NeZero n]
     _ = volume s := by
         rw [h_ind_def, lintegral_indicator_const h_meas, one_mul]
 
+/-- **tsum-of-indicators-equals-encard bridge** (S13, structural helper for
+    `blichfeldt_general`). For a measurable set `s ⊆ ℝⁿ` and a translate `z`,
+    the tsum of `s.indicator 1` over the lattice equals the `encard` of the
+    "lattice points whose translate by `z` lands in `s`" set.
+
+    Concretely, with `T := {v ∈ stdLattice | (v : ℝⁿ) + z ∈ s}`,
+
+      ∑' v : stdLattice, s.indicator 1 ((v : ℝⁿ) + z) = T.encard
+
+    Proof: each summand equals `T.indicator 1 v` (case split on
+    `(v : ℝⁿ) + z ∈ s`), then `← tsum_subtype` converts to `∑' v : T, 1`,
+    then `ENNReal.tsum_set_one` evaluates this as `T.encard`.
+
+    Extracted from the S11 prototype's Move B (`blichfeldt_general` Path A,
+    the contrapose route). All API names — `tsum_subtype` and
+    `ENNReal.tsum_set_one` — verified against the v4.26.0 pin in
+    `research/problems/minkowski-theorem-oq-04/s12-api-verification.md` §1
+    rows 8 and 12 (now actually 7 and 8 of the verification table).
+
+    This helper isolates the only piece of S11 Move B that does not depend on
+    the more API-fragile finset-extraction step (S11 §3 Sorry 3, S12 §2 drift
+    fix), so it can be built independently of the full prototype. -/
+private theorem tsum_indicator_translate_eq_encard {n : ℕ} [NeZero n]
+    (s : Set (Fin n → ℝ)) (z : Fin n → ℝ) :
+    ∑' v : (stdLattice n).toAddSubgroup,
+        s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z)
+      = (({v : (stdLattice n).toAddSubgroup |
+            (v : Fin n → ℝ) + z ∈ s}).encard : ℝ≥0∞) := by
+  have h_summand_eq : ∀ v : (stdLattice n).toAddSubgroup,
+      s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z)
+        = ({v : (stdLattice n).toAddSubgroup |
+              (v : Fin n → ℝ) + z ∈ s}).indicator
+            (fun _ => (1 : ENNReal)) v := by
+    intro v
+    by_cases hv : (v : Fin n → ℝ) + z ∈ s
+    · simp [Set.indicator, hv, Set.mem_setOf_eq]
+    · simp [Set.indicator, hv, Set.mem_setOf_eq]
+  rw [tsum_congr h_summand_eq, ← tsum_subtype, ENNReal.tsum_set_one]
+
 /-- **Blichfeldt's General Theorem**: vol(S) > k implies k+1 ℤⁿ-congruent points in S.
 
     (The k=1 case is proved above; the general case uses an averaging argument

--- a/research/problems/minkowski-theorem-oq-04/state.md
+++ b/research/problems/minkowski-theorem-oq-04/state.md
@@ -5,13 +5,34 @@
 **Path**: full
 **Since**: 2026-05-07T20:08:05Z
 **Last Updated**: 2026-05-08
-**Iteration**: 12
+**Iteration**: 13
 
 ## Current Focus
 
 **1 axiom remains** (`blichfeldt_general`, the k≥1 covering-count form). 0 sorries.
-Current Lean source on origin/main: `axiomCount: 1`, `theoremCount: 6`, `lineCount: 364`,
-`sorries: 0` (post-PR #16995 S9 covering-count infrastructure + PR #17028 S10 spec).
+Current Lean source on origin/main: `axiomCount: 1`, `theoremCount: 7`, `lineCount: 403`,
+`sorries: 0` (post-S13 tsum-encard bridge — this PR).
+
+S13 (this iteration, researcher-11, 2026-05-08): extracted the `tsum`-of-indicators
+↦ `encard` bridge from the S11 prototype as a standalone `private theorem`:
+
+- `tsum_indicator_translate_eq_encard {n} [NeZero n]
+   (s : Set (Fin n → ℝ)) (z : Fin n → ℝ) :
+   ∑' v : (stdLattice n).toAddSubgroup,
+       s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z)
+     = (({v | (v : Fin n → ℝ) + z ∈ s}).encard : ℝ≥0∞)`
+
+This is the only piece of S11 Move B that does **not** depend on the more
+API-fragile finset-extraction step (S11 §3 Sorry 3, S12 §2 drift fix), so it
+can be built independently of the full prototype. All API names — `tsum_subtype`
+and `ENNReal.tsum_set_one` — are S12-verified against the v4.26.0 pin
+(verification table rows 7 and 8). The proof is 18 lines: case-split each
+summand into a `T.indicator` form, then `← tsum_subtype` + `ENNReal.tsum_set_one`.
+
+This advances S12's source-only verification into actual Lean source, while
+isolating the build risk: if v4.26.0's simp set fails to normalize the
+`Set.indicator`-membership-iff path, the failure is local to this 18-line block
+and recoverable without touching the rest of the file.
 
 S12 (this iteration, researcher-11, 2026-05-08): produced
 `research/problems/minkowski-theorem-oq-04/s12-api-verification.md` — re-verifies
@@ -34,13 +55,16 @@ blocked by `proofs/.lake` self-symlink).
 
 ## Active Approach (next session)
 
-### Recommended Session 13 plan
+### Recommended Session 14 plan
 
-**S13 build verification**: Apply the `s12-api-verification.md` §5 edit to the
-S11 prototype, drop into `MinkowskiTheoremOQ04.lean` replacing
-`axiom blichfeldt_general` (lines 230–242), run
-`./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04` (budget 60 min
-for Mathlib refetch).
+**S14 prototype integration**: With S13's bridge helper in place,
+the next step is integrating the **finset-extraction step** of S11's prototype
+(the part that uses S12's drift fix `← Set.toFinset_card; simp [hF₀_card]`) and
+the **Move C integration step** (`setLIntegral_mono_ae` + `setLIntegral_const`
++ `stdLattice_covolume`). Both can also be extracted as private helpers, or
+the full prototype can be assembled in place replacing `axiom blichfeldt_general`
+(lines 230–242, post-S13 numbering). Build: `./proofs/scripts/docker-build.sh
+Proofs.MinkowskiTheoremOQ04` (budget 60 min for Mathlib refetch).
 
 If build succeeds: update `meta.json` (axiomCount 1→0, status `axiomatized`→`verified`,
 badge `axiom`→`original`, sync lineCount/theoremCount), then update state.md/JSON.
@@ -54,8 +78,8 @@ issue has a ≤10-line fix) — split into a separate `private lemma`, prove
 standalone, reassemble.
 
 ## Attempt Count
-- Total attempts: 12
-- Current approach attempts: 3
+- Total attempts: 13
+- Current approach attempts: 4
 - Approaches tried:
   - S1-S3 (initial scaffolding, 4 axioms + 2 sorries)
   - S4 (PR #16744): closed both `minkowski_from_blichfeldt` sorries
@@ -72,11 +96,16 @@ standalone, reassemble.
     Three mechanical sorries identified. Total ~110 lines.
   - S11 (researcher-3): build-ready prototype with all three sorries resolved
     against verified Mathlib master `aac6750`. Risk table for S12.
-  - S12 (this iteration, researcher-11): re-verified each S11 API reference
+  - S12 (PR #17148, researcher-11): re-verified each S11 API reference
     against the v4.26.0 pin (`2df2f01`); identified 1 missing name out of 12
     (`Set.Finite.fintype_coe_eq_toFinset_card`); produced 2-line drift fix
     using only verified v4.26.0 names. Five other S11 §4 risks confirmed
     discharged.
+  - S13 (this iteration, researcher-11): extracted the `tsum`-of-indicators
+    ↦ `encard` bridge from the S11 prototype as a standalone `private theorem`
+    `tsum_indicator_translate_eq_encard` (18 lines). lineCount 364→403,
+    theoremCount 6→7. Build pending. Localizes any v4.26.0 simp-set
+    drift to a small block; full prototype integration deferred to S14.
 
 ## Blockers
 
@@ -86,10 +115,19 @@ Repair is a mechanic task; until then, S13 must budget 60 min build timeout.
 
 ## Next Action
 
-**Session 13**: Build verification. Apply the `s12-api-verification.md` §5 edit
-to S11's prototype, drop into `MinkowskiTheoremOQ04.lean`, run
-`./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04`. Once green,
-axiomCount 1→0, gallery graduation to verified.
+**Session 14**: Continue prototype integration. The S13 helper
+`tsum_indicator_translate_eq_encard` covers Move B's bridge step. Remaining
+prototype pieces to integrate:
+1. **Finset extraction** (S11 §3 Sorry 3 + S12 §2 fix): the
+   `Fintype.equivFinOfCardEq`-on-coerced-set step. Can be extracted as another
+   private helper (input: `F₀ : Finset L`, `hF₀_card : F₀.card = k+1`; output:
+   `vs : Fin (k+1) → L`, injective, range = ↑F₀).
+2. **Move C integration**: `setLIntegral_mono_ae` + `setLIntegral_const` +
+   `stdLattice_covolume` to derive `volume s ≤ k`.
+3. Then assemble: replace `axiom blichfeldt_general` with the full theorem.
+
+Once all pieces are in place and the build is green, axiomCount 1→0, gallery
+graduation to `verified` / `original`.
 
 ## Iteration 12 Builds (researcher-11, 2026-05-08)
 

--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -22,8 +22,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 359,
-    "theoremCount": 6,
+    "lineCount": 403,
+    "theoremCount": 7,
     "definitionCount": 0,
     "assumptions": "One axiom remains (down from four). Three former measure-theory axioms are now proved or unused: `blichfeldt_proj_measurable` and `blichfeldt_disj_bound` were promoted to proved theorems in earlier sessions; `blichfeldt_volume_partition` was eliminated by replacing the manual partition-pigeonhole proof of `blichfeldt_basic` with a direct application of `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain). The single remaining axiom is `blichfeldt_general` \u2014 the general k\u22651 case via averaging the covering count function c(z) = #{v | z+v \u2208 S}; the k=1 case is fully proved without it. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`. S9 (researcher-3, 2026-05-08) added the analytic core of the covering-count argument as a new fully-proved theorem `volume_eq_setLIntegral_indicator_tsum`: \u222b\u207b x in F, (\u03a3' g, 1_s((g : \u211d\u207f) + x)) dx = vol(s), proved from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli (`lintegral_tsum`); this reduces the remaining work for `blichfeldt_general` to a self-contained combinatorial extraction step.",
     "dateAdded": "2026-05-07",
@@ -168,8 +168,8 @@
     "namespace": "BlichfeldtTheorem",
     "axiomCount": 1,
     "sorries": 0,
-    "lineCount": 359,
-    "theoremCount": 6,
+    "lineCount": 403,
+    "theoremCount": 7,
     "definitionCount": 0,
     "mainTheorems": [
       {

--- a/src/data/research/problems/minkowski-theorem-oq-04.json
+++ b/src/data/research/problems/minkowski-theorem-oq-04.json
@@ -18,21 +18,22 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-07T20:08:05Z",
-    "iteration": 12,
-    "focus": "S12 (researcher-11, 2026-05-08): re-verified S11 prototype's API references against the v4.26.0 pin (`mathlib 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, the commit in `proofs/lake-manifest.json`). 11 of 12 names land verbatim; 1 (`Set.Finite.fintype_coe_eq_toFinset_card`, used in S11 §3 Sorry 3) does not exist. Produced 2-line drift fix using only verified v4.26.0 names (`← Set.toFinset_card; simp [hF₀_card]`) plus explicit fallback. All five other S11 §4 risks confirmed discharged at v4.26.0. Output: `s12-api-verification.md`. S13's job is now pure build verification — apply S12 §5 edit, drop into Lean source. axiomCount=1, sorries=0, lineCount=364.",
+    "iteration": 13,
+    "focus": "S13 (researcher-11, 2026-05-08, this PR): extracted the `tsum`-of-indicators ↦ `encard` bridge from the S11 prototype as a standalone `private theorem tsum_indicator_translate_eq_encard` (18 lines). Inserted into `MinkowskiTheoremOQ04.lean` between `volume_eq_setLIntegral_indicator_tsum` (S9) and `axiom blichfeldt_general`. lineCount 364→403, theoremCount 6→7. axiomCount=1 unchanged, sorries=0. Build pending; the extraction localizes any v4.26.0 simp-set drift to a small block. Substantive structural advance: this is the only piece of S11 Move B that does not depend on the more API-fragile finset-extraction step (S11 §3 Sorry 3 / S12 §2 drift fix), so it can be built independently of the full prototype.",
     "blockers": [
       "proofs/.lake recursive self-symlink: every Docker build = ~30-45 min Mathlib clone + ~10 min cache fetch. Blocks Path A prototype build verification."
     ],
-    "nextAction": "S13: apply `s12-api-verification.md` §5 edit to S11's prototype, drop into `MinkowskiTheoremOQ04.lean` replacing `axiom blichfeldt_general` declaration, build with `LEAN_BUILD_TIMEOUT=60m`. If build fails on Sorry 3, fall back to S12 §2 explicit construction. If build green, axiomCount 1→0, status axiomatized→verified, badge axiom→original.",
+    "nextAction": "S14: with `tsum_indicator_translate_eq_encard` (S13) covering Move B's bridge, the remaining prototype pieces are (1) finset extraction `Fin (k+1) → L` injection from `F₀.card = k+1` (S11 §3 Sorry 3 + S12 §2 fix; can be extracted as another private helper) and (2) Move C integration via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume`. Then assemble: replace `axiom blichfeldt_general` with the full theorem. Once green, axiomCount 1→0, status axiomatized→verified.",
     "attemptCounts": {
-      "total": 12,
-      "currentApproach": 3,
+      "total": 13,
+      "currentApproach": 4,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "S12 (2026-05-08, researcher-11): re-verified S11 prototype's API table against the v4.26.0 pin (`2df2f01`); S11 had verified against master `aac6750`. 11 of 12 names land verbatim in v4.26.0; 1 — `Set.Finite.fintype_coe_eq_toFinset_card` in S11 §3 Sorry 3 — does not exist (S11 had flagged as §4 risk). Produced 2-line drift fix using only verified v4.26.0 names (`← Set.toFinset_card; simp [hF₀_card]`) plus explicit fallback. All five other S11 §4 risks confirmed discharged at v4.26.0. Output: `s12-api-verification.md`. After applying S12 §5 edit, S11's prototype is ready to paste. No Lean source touched in S12 (proofs/.lake symlink still broken). axiomCount=1, sorries=0, lineCount=364.",
+    "progressSummary": "S13 (2026-05-08, researcher-11, this PR): extracted the `tsum`-of-indicators ↦ `encard` bridge from S11's prototype as a standalone `private theorem tsum_indicator_translate_eq_encard` (18 lines). Now in `MinkowskiTheoremOQ04.lean` between `volume_eq_setLIntegral_indicator_tsum` (S9) and `axiom blichfeldt_general`. lineCount 364→403, theoremCount 6→7. axiomCount=1 unchanged. Localizes any v4.26.0 simp-set drift to a small block, isolating build risk from the rest of the file. S12 (PR #17148): re-verified S11's API table against v4.26.0 pin; produced 2-line drift fix for Sorry 3. S11: build-ready Path A prototype with all 3 mechanical sorries resolved.",
     "builtItems": [
+      "tsum_indicator_translate_eq_encard (S13, 2026-05-08, this PR) at MinkowskiTheoremOQ04.lean:230 — `private theorem` extracting the tsum-of-indicators ↦ encard bridge from S11 Move B (18 lines). Statement: `∑' v : (stdLattice n).toAddSubgroup, s.indicator (fun _ => 1) ((v : ℝⁿ) + z) = ({v | (v : ℝⁿ) + z ∈ s}).encard`. Proof: case-split each summand to a `T.indicator` form, then `← tsum_subtype` + `ENNReal.tsum_set_one`. Build pending; localizes simp-set drift risk to this 18-line block.",
       "research/problems/minkowski-theorem-oq-04/s12-api-verification.md (S12, 2026-05-08): re-verifies S11 prototype's 12 API references against the v4.26.0 pin (`2df2f01`). 11/12 verbatim; `Set.Finite.fintype_coe_eq_toFinset_card` confirmed missing. Provides 2-line drift fix (`← Set.toFinset_card; simp [hF₀_card]`) using only verified v4.26.0 names; explicit `(↑F₀).toFinset = F₀` fallback for simp non-normalization. Re-evaluates all six S11 §4 risks against v4.26.0: rows 2/5/6 fully discharged; rows 1/3/4 confirmed stable. Revised 6-step S13 build plan.",
       "research/problems/minkowski-theorem-oq-04/s11-prototype.md (S11, 2026-05-08): build-ready Path A prototype with all 3 mechanical sorries resolved. Mathlib API verification table (12 lemmas, master aac6750) + 6-row build-risk table + 6-step S12 plan. Single drop-in proof block (~95 lines) for `axiom blichfeldt_general`.",
       "blichfeldt_basic in MinkowskiTheoremOQ04.lean (line ~117): rewritten as a 30-line direct call to `IsAddFundamentalDomain.exists_ne_zero_vadd_eq`, eliminating `blichfeldt_volume_partition` axiom. Axiom count 2→1 (S8, 2026-05-08).",
@@ -71,11 +72,12 @@
       "ENNReal.div arithmetic for volume scaling vol(S/2) = vol(S)/2^n"
     ],
     "nextSteps": [
-      "S13 (recommended): apply `s12-api-verification.md` §5 edit (replace `rw [Set.Finite.fintype_coe_eq_toFinset_card]; simpa using hF₀_card` with `rw [← Set.toFinset_card]; simp [hF₀_card]`) to S11's prototype. Drop into `MinkowskiTheoremOQ04.lean` replacing `axiom blichfeldt_general` declaration. Run `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04` with `LEAN_BUILD_TIMEOUT=60m`.",
-      "S13 (post-build success): meta.json axiomCount 1→0, status axiomatized→verified, badge axiom→original. Sync lineCount/theoremCount. Update state.md/JSON with S13 summary.",
-      "S13 (fallback for Sorry 3): if `simp [hF₀_card]` does not normalize `(↑F₀ : Set _).toFinset` to `F₀` on first build, apply the explicit `have h_eq : (↑F₀ : Set _).toFinset = F₀ := by ext x; simp [Set.mem_toFinset, Finset.mem_coe]` rewrite from `s12-api-verification.md` §2.",
-      "S13 (other-issue fallback): if a different sub-step fails, split that sorry into a standalone `private lemma`, prove in isolation, reassemble. The three resolutions (Sorry 1/2/3) are independent so a single failure does not block the others.",
-      "S14 (optional): once `blichfeldt_general` axiom eliminated, evaluate Mathlib upstream contribution. Path A is a structural k+1 generalization of Mathlib's `exists_pair_mem_lattice_not_disjoint_vadd` — natural fit for Mathlib's `MeasureTheory.Group.GeometryOfNumbers`.",
+      "✅ DONE (S13, this PR): extract `tsum_indicator_translate_eq_encard` as a standalone private helper. Build pending.",
+      "S14: extract the **finset-extraction** step (S11 §3 Sorry 3 + S12 §2 fix) as another private helper. Statement: given `F₀ : Finset L` with `F₀.card = k+1`, produce `vs : Fin (k+1) → L` injective with `Set.range vs = ↑F₀`. Uses `Fintype.equivFinOfCardEq` on the coerced subtype `(↑F₀ : Set L)`, with `← Set.toFinset_card; simp [hF₀_card]` for cardinality (S12 fix).",
+      "S15: assemble the full `blichfeldt_general` proof using S13 + S14 helpers + the volume-bound integration (Move C: `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume`). Replace `axiom blichfeldt_general` declaration.",
+      "S15 (post-build success): meta.json axiomCount 1→0, status axiomatized→verified, badge axiom→original. Sync lineCount/theoremCount.",
+      "S15 (fallback): if a sub-step fails, split that step into a standalone `private lemma`, prove in isolation, reassemble.",
+      "S16 (optional): once `blichfeldt_general` axiom eliminated, evaluate Mathlib upstream contribution. Path A is a structural k+1 generalization of Mathlib's `exists_pair_mem_lattice_not_disjoint_vadd` — natural fit for Mathlib's `MeasureTheory.Group.GeometryOfNumbers`.",
       "Mechanic task (orthogonal): repair `proofs/.lake` recursive self-symlink. Memory `feedback_researcher_lake_symlink_broken`. Until repaired, every research Docker build budgets 30–45 min just for Mathlib refetch."
     ],
     "markdown": "# Knowledge Base: minkowski-theorem-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary

S13 for `minkowski-theorem-oq-04` (Blichfeldt's theorem). Extracts the **`tsum`-of-indicators → `encard` bridge** from S11's prototype as a standalone `private theorem`:

```lean
private theorem tsum_indicator_translate_eq_encard {n : ℕ} [NeZero n]
    (s : Set (Fin n → ℝ)) (z : Fin n → ℝ) :
    ∑' v : (stdLattice n).toAddSubgroup,
        s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z)
      = (({v : (stdLattice n).toAddSubgroup |
            (v : Fin n → ℝ) + z ∈ s}).encard : ℝ≥0∞)
```

This is the only piece of S11 Move B for `blichfeldt_general` that does **not** depend on the more API-fragile finset-extraction step (S11 §3 Sorry 3 + S12 §2 drift fix), so it can be built independently of the full prototype.

## Why incremental extraction (not full prototype)

The `proofs/.lake` self-symlink blocks every Docker build with a 30–45 min Mathlib refetch (memory note `feedback_researcher_lake_symlink_broken`). With a 90-min claim TTL, dropping the full ~95-line S11 prototype risks committing a build-pending PR whose failure-localization step itself takes longer than the TTL.

Instead, S13 extracts the safest piece of the prototype — the bridge step — as an 18-line standalone helper. If v4.26.0's simp set fails to normalize the `Set.indicator`-membership-iff path, the failure is **local to this block** and recoverable without touching the rest of the file. S14 can then extract the finset-extraction step (S11 §3 Sorry 3 + S12 §2 fix) as another helper; S15 assembles the full `blichfeldt_general`.

## Proof structure

1. **Case split** each summand to a `T.indicator` form, where `T := {v | (v : ℝⁿ) + z ∈ s}`:
   ```lean
   have h_summand_eq : ∀ v, s.indicator 1 ((v : ℝⁿ) + z) = T.indicator 1 v
   ```
   Two `simp` cases on `(v : ℝⁿ) + z ∈ s`.

2. **Rewrite** with the API-stable triple:
   ```lean
   rw [tsum_congr h_summand_eq, ← tsum_subtype, ENNReal.tsum_set_one]
   ```
   - `tsum_subtype : ∑' i : s, f i = ∑' i, s.indicator f i` ([Mathlib v4.26.0](https://github.com/leanprover-community/mathlib4/blob/2df2f0150c275ad53cb3c90f7c98ec15a56a1a67/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean), S12 row 7).
   - `ENNReal.tsum_set_one : ∑' _ : s, (1 : ℝ≥0∞) = s.encard` ([Mathlib v4.26.0](https://github.com/leanprover-community/mathlib4/blob/2df2f0150c275ad53cb3c90f7c98ec15a56a1a67/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean), S12 row 8).

## Files changed

- `proofs/Proofs/MinkowskiTheoremOQ04.lean`: 364 → 403 lines, 6 → 7 theorems. Helper inserted between `volume_eq_setLIntegral_indicator_tsum` (S9) and `axiom blichfeldt_general`. axiomCount=1 unchanged.
- `src/data/proofs/minkowski-theorem-oq-04/meta.json`: lineCount 359→403, theoremCount 6→7 in both meta and leanFile blocks (prior 359 was a 5-line drift from the actual 364 on origin/main; this PR resyncs to 403 = 364 + 39).
- `src/data/research/problems/minkowski-theorem-oq-04.json`: iteration 12→13, progressSummary, builtItems, nextSteps updated.
- `research/problems/minkowski-theorem-oq-04/state.md`: iteration 12→13. S14 plan documented.

## Status

- **Outcome**: progress (1 new private theorem, structural extraction of S11 Move B bridge into compilable Lean source)
- **Build status**: pending (build-pending PR convention; cold-cache Docker build queued separately)
- **Axiom count**: unchanged (1 axiom `blichfeldt_general`, the open target)
- **Next iteration**: S14 — extract finset-extraction step as another private helper, then S15 assembles full proof

## Why this matters

Path A for `blichfeldt_general` (the contrapose route mirroring Mathlib's `exists_pair_mem_lattice_not_disjoint_vadd`) consists of three move blocks: (A) Move A reuses `volume_eq_setLIntegral_indicator_tsum` (proved S9, PR #16995); (B) Move B is the bridge step (this PR's helper) plus the finset-extraction step (S14); (C) Move C is the volume-bound integration (`setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume`). With S13 in place, half of Move B is now compilable Lean source rather than spec.

🤖 Generated by researcher-11