### PR TITLE
research(erdos-530): Iter 5 — sharp interval Sidon bound k(k+1)+2 ≤ 4N (build pending)

### DIFF
--- a/proofs/Proofs/Erdos530Problem.lean
+++ b/proofs/Proofs/Erdos530Problem.lean
@@ -348,6 +348,55 @@ theorem sidon_subset_interval_bound (S : Finset ℤ) (N : ℕ) (hN : 1 ≤ N)
   calc k * k ≤ k * (k + 1) := Nat.mul_le_mul_left k (Nat.le_succ k)
     _ ≤ 4 * N := h_prod
 
+/-- **Sharp** interval bound: every Sidon subset S of {1,...,N} satisfies
+    |S|(|S|+1) + 2 ≤ 4N (equivalently `k(k+1) ≤ 4N − 2`, sharper than the
+    `k² ≤ 4N` of `sidon_subset_interval_bound`).
+
+    Observation: pairwise sums `a + b` with `a, b ∈ S`, `a ≤ b` satisfy
+    `2 ≤ a + b ≤ 2N` (since `a, b ≥ 1`), so they lie in
+    `Finset.Icc 2 (2N)` of cardinality `2N − 1` rather than the
+    looser `Finset.Icc 1 (2N)` of cardinality `2N`. The `k(k+1)/2`
+    distinct Sidon sums therefore satisfy `k(k+1)/2 ≤ 2N − 1`, hence
+    `k(k+1) ≤ 4N − 2`.
+
+    Stated without ℕ-subtraction as `k(k+1) + 2 ≤ 4N`. -/
+theorem sidon_subset_interval_bound_sharp (S : Finset ℤ) (N : ℕ) (hN : 1 ≤ N)
+    (hS : IsSidon S) (hRange : ∀ x ∈ S, 1 ≤ x ∧ x ≤ ↑N) :
+    S.card * (S.card + 1) + 2 ≤ 4 * N := by
+  set k := S.card with hk_def
+  have h_count := sidon_sum_count S hS
+  -- Sums of sorted pairs from S with min ≥ 1 lie in [2, 2N]
+  have h_sub : ((S ×ˢ S).filter (fun p => p.1 ≤ p.2)).image (fun p => p.1 + p.2) ⊆
+      Finset.Icc (2 : ℤ) (2 * ↑N) := by
+    intro s hs
+    simp only [Finset.mem_image, Prod.exists] at hs
+    obtain ⟨a, b, hab, rfl⟩ := hs
+    simp only [Finset.mem_filter, Finset.mem_product] at hab
+    rw [Finset.mem_Icc]
+    refine ⟨?_, ?_⟩
+    · linarith [(hRange a hab.1.1).1, (hRange b hab.1.2).1]
+    · linarith [(hRange a hab.1.1).2, (hRange b hab.1.2).2]
+  -- |[2, 2N]| = 2N - 1
+  have h_icc : (Finset.Icc (2 : ℤ) (2 * ↑N)).card = 2 * N - 1 := by
+    simp [Finset.card_Icc]; omega
+  -- k(k+1)/2 ≤ 2N - 1
+  have h_sum_le : k * (k + 1) / 2 ≤ 2 * N - 1 := by
+    calc k * (k + 1) / 2
+        = (((S ×ˢ S).filter (fun p => p.1 ≤ p.2)).image (fun p => p.1 + p.2)).card :=
+          h_count.symm
+      _ ≤ (Finset.Icc (2 : ℤ) (2 * ↑N)).card := Finset.card_le_card h_sub
+      _ = 2 * N - 1 := h_icc
+  -- k(k+1) is even (one of k, k+1 is even)
+  have h_even : 2 ∣ k * (k + 1) := by
+    rcases Nat.even_or_odd k with ⟨m, hm⟩ | ⟨m, hm⟩
+    · exact ⟨m * (k + 1), by rw [hm]; ring⟩
+    · exact ⟨k * (m + 1), by rw [hm]; ring⟩
+  -- k(k+1) + 2 = 2·(k(k+1)/2) + 2 ≤ 2·(2N-1) + 2 = 4N
+  have h_mul : k * (k + 1) / 2 * 2 ≤ (2 * N - 1) * 2 :=
+    Nat.mul_le_mul_right 2 h_sum_le
+  have h_div : k * (k + 1) / 2 * 2 = k * (k + 1) := Nat.div_mul_cancel h_even
+  omega
+
 /-- The interval {1,...,N} has maxSidonSize² ≤ 4N. -/
 theorem interval_sidon_upper (N : ℕ) (hN : 1 ≤ N) :
     maxSidonSize (Finset.Icc (1 : ℤ) ↑N) * maxSidonSize (Finset.Icc (1 : ℤ) ↑N) ≤ 4 * N := by

--- a/research/problems/erdos-530/state.md
+++ b/research/problems/erdos-530/state.md
@@ -1,27 +1,123 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-13T04:39:49.623Z
-**Iteration**: 1
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-03-24 (gallery entry shipped)
+**Last Updated**: 2026-05-08 (Iteration 5, researcher-11)
+**Iteration**: 5
 
 ## Current Focus
 
-Initial exploration of the problem.
+**2 axioms remain** in `proofs/Proofs/Erdos530Problem.lean` (430 lines, 17
+theorems, 5 definitions, 0 sorries on origin/main post-this-PR):
 
-## Active Approach
+1. `komlos_sulyok_szemeredi` — the KSS 1975 improved √N lower bound;
+   stated for ℤ-Finsets with `A.card ≥ 4 → maxSidonSize² ≥ c·|A|`.
+   Deep known result; eliminating it would require the full KSS
+   probabilistic deletion argument (substantial Mathlib contribution).
 
-None yet.
+2. `alon_erdos_partition_conjecture` — Alon-Erdős 1985 conjecture that
+   `N`-element sets partition into `O(√N)` Sidon sets. Open problem.
+
+Both are appropriate as axioms (one is a deep proved theorem, one is
+genuinely open).
+
+## Active Approach (this iteration)
+
+Iteration 5 (2026-05-08, researcher-11, this PR): added the **sharp**
+interval upper bound `sidon_subset_interval_bound_sharp`:
+
+- `sidon_subset_interval_bound_sharp (S : Finset ℤ) (N : ℕ) (hN : 1 ≤ N)
+   (hS : IsSidon S) (hRange : ∀ x ∈ S, 1 ≤ x ∧ x ≤ ↑N) :
+   S.card * (S.card + 1) + 2 ≤ 4 * N`
+
+This sharpens the existing `sidon_subset_interval_bound` (which gives
+only `|S|² ≤ 4N`) by observing that pairwise sums `a + b` with `a, b ∈ S`,
+`a ≤ b` satisfy `2 ≤ a + b ≤ 2N` (since both `a, b ≥ 1`). The sums
+therefore lie in `Finset.Icc 2 (2N)` of cardinality `2N − 1` rather than
+the looser `Finset.Icc 1 (2N)` of cardinality `2N`. The `k(k+1)/2`
+distinct Sidon sums then satisfy `k(k+1)/2 ≤ 2N − 1`, hence
+`k(k+1) ≤ 4N − 2`, stated without ℕ-subtraction as `k(k+1) + 2 ≤ 4N`.
+
+Numerically: at `N = 100`, the trivial `k² ≤ 4N` gives `k ≤ 20`; the
+sharp `k(k+1) ≤ 398` gives `k ≤ 19`. At `N = 10000`, `k ≤ 200` vs
+`k ≤ 199`. The `+1` saving compounds to a meaningful gain at finite
+scales, and the bound makes the gap to the conjectured optimal
+`k ≤ √N + O(1)` more visible.
+
+## Iteration History
+
+- **Iter 1** (2026-03-24, PR #5840): structural Sidon-set theorems
+  (isSidon_empty/singleton/pair/subset, maxSidonSize basics).
+- **Iter 2** (2026-03-26, PR #6992): proved `erdos_lower_bound` from the
+  KSS axiom (3→2 axioms). Eliminated a redundant axiom.
+- **Iter 3** (2026-03-29, PR #7855): proved `interval_sidon_upper`
+  (`maxSidonSize²(Icc 1 N) ≤ 4N` for the model interval set), proved
+  `sidon_sum_count` (k(k+1)/2 distinct sums) and `card_sorted_pairs`,
+  added the `ErdosProblem530Corrected` formulation, proved
+  `erdos530_corrected_proof` from KSS + interval bound.
+- **Iter 4** (2026-03-28, PR #7636): metadata fix accompanying
+  erdos-687 axiom elimination work.
+- **Iter 5** (2026-05-08, this PR, researcher-11): sharp interval
+  bound `sidon_subset_interval_bound_sharp`. lineCount 381→430,
+  theoremCount 16→17.
+
+## Active Approach (next sessions)
+
+Two avenues remain open for substantive progress without touching
+the deep `komlos_sulyok_szemeredi` or `alon_erdos_partition_conjecture`
+axioms:
+
+1. **Difference-injectivity refinement**: prove `sidon_diff_injOn`,
+   the dual of `sidon_sum_injective` for `(a, b) ↦ a − b` on off-diagonal
+   pairs. This gives a parallel bound `k(k − 1) ≤ 2N − 2` from differences
+   in `{−(N−1), …, −1, 1, …, N−1}`, matching the asymptotic constant of
+   the sharp sum bound but illuminating the dual structure. ~25 lines.
+
+2. **Singer-style explicit construction** (lower-bound witness): prove
+   that the geometric set `{2^0, 2^1, …, 2^(k−1)}` is Sidon (binary
+   uniqueness), giving an explicit construction of arbitrarily large
+   Sidon sets. ~20 lines, requires only `Mathlib.Data.Nat.Bits`-style
+   tactics. This complements the abstract `maxSidonSize_pos`/`_ge_two`
+   bootstrapping by exhibiting concrete witnesses.
+
+Both are independent of each other and of the open axioms.
 
 ## Blockers
 
-None.
+None for incremental work. The two remaining axioms (`komlos_sulyok_szemeredi`,
+`alon_erdos_partition_conjecture`) are appropriate axiomatic limits;
+eliminating either requires deep new mathematics (KSS proof, or progress
+on the Alon-Erdős conjecture).
 
 ## Next Action
 
-Begin problem exploration.
+**Iter 6 candidate**: prove `sidon_diff_injOn`, the difference-injectivity
+characterization of Sidon sets. Statement:
+
+```lean
+theorem sidon_diff_injOn (S : Finset ℤ) (hS : IsSidon S) :
+    Set.InjOn (fun p : ℤ × ℤ => p.1 - p.2)
+      ((S ×ˢ S).filter (fun p => p.1 ≠ p.2) : Set (ℤ × ℤ))
+```
+
+Proof: from `a − b = c − d` derive `a + d = b + c`; apply Sidon with
+appropriate orderings on the four cases of `(a ≤ d, a > d) × (b ≤ c, b > c)`.
+~20–30 lines.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5
+- Current approach attempts: 1 (sharp interval bound, this PR)
+- Approaches tried (axiom-side): bootstrap + KSS axioms, downstream proof
+  of corrected statement (Iter 1–4); upper-bound sharpening (Iter 5).
+
+## References
+
+- `proofs/Proofs/Erdos530Problem.lean` — main file (430 lines, 17 theorems,
+  2 axioms, 0 sorries).
+- `src/data/proofs/erdos-530/meta.json` — gallery integration.
+- KSS 1975 paper: Komlós, Sulyok, Szemerédi — "Linear problems in
+  combinatorial number theory", *Acta Math. Acad. Sci. Hungar.* 26.
+- Alon-Erdős 1985: "An application of graph theory to additive number
+  theory", *European J. Combin.* 6.

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/530",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 381,
-    "assumptions": "2 axiom declarations: komlos_sulyok_szemeredi (KSS improved N^{1/2} lower bound, deep known result), alon_erdos_partition_conjecture (Sidon partition, open problem). ErdosProblem530Corrected proved from KSS + interval sum counting (erdos530_corrected_proof). 16 theorems proved.",
+    "lineCount": 430,
+    "assumptions": "2 axiom declarations: komlos_sulyok_szemeredi (KSS improved N^{1/2} lower bound, deep known result), alon_erdos_partition_conjecture (Sidon partition, open problem). ErdosProblem530Corrected proved from KSS + interval sum counting (erdos530_corrected_proof). 17 theorems proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 5
   },
   "overview": {
@@ -156,9 +156,9 @@
       "Finset"
     ],
     "namespace": "Erdos530",
-    "lineCount": 381,
+    "lineCount": 430,
     "axiomCount": 2,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 5,
     "path": "Proofs/Erdos530Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Iter 5 for `erdos-530` (max Sidon subsets of finite sets, Erdős' Problem #530). Adds the **sharp interval Sidon bound**:

```lean
theorem sidon_subset_interval_bound_sharp (S : Finset ℤ) (N : ℕ) (hN : 1 ≤ N)
    (hS : IsSidon S) (hRange : ∀ x ∈ S, 1 ≤ x ∧ x ≤ ↑N) :
    S.card * (S.card + 1) + 2 ≤ 4 * N
```

This sharpens the existing `sidon_subset_interval_bound` (`|S|² ≤ 4N`) by observing that pairwise sums `a + b` with `a, b ∈ S`, `a ≤ b` satisfy `2 ≤ a + b ≤ 2N` (since both `a, b ≥ 1`). Sums lie in `Finset.Icc 2 (2N)` of cardinality `2N − 1`, not the looser `Finset.Icc 1 (2N)` of cardinality `2N`. The `k(k+1)/2` distinct Sidon sums therefore satisfy `k(k+1)/2 ≤ 2N − 1`, hence `k(k+1) ≤ 4N − 2`. Stated without ℕ-subtraction as `k(k+1) + 2 ≤ 4N`.

## Numerical impact

| `N` | trivial `k² ≤ 4N` allows | sharp `k(k+1) ≤ 4N − 2` allows |
|---|---|---|
| 100 | `k ≤ 20` | `k ≤ 19` |
| 1 000 | `k ≤ 63` | `k ≤ 62` |
| 10 000 | `k ≤ 200` | `k ≤ 199` |

The `+1` saving at each scale closes one rung of the gap toward the conjectured `k ≤ √N + O(1)`.

## Proof structure

Identical scaffolding to the existing `sidon_subset_interval_bound`, with one key tightening:
- Subset target: `Finset.Icc 2 (2*↑N)` (was `Finset.Icc 1 (2*↑N)`).
- Cardinality: `2N − 1` (was `2N`); proof unchanged (`simp [Finset.card_Icc]; omega`).
- Lower-bound argument: `2 ≤ a + b` from `(hRange a).1 ≥ 1` and `(hRange b).1 ≥ 1`.
- Final assembly: `k(k+1)/2 * 2 + 2 = k(k+1) + 2 ≤ (2N−1) * 2 + 2 = 4N` via `Nat.div_mul_cancel` (using evenness of `k(k+1)`) and one `omega`.

The reuse of `sidon_sum_count` (k(k+1)/2 distinct Sidon sums) keeps this self-contained with no new Mathlib API dependencies.

## State.md sync

The previous `state.md` was at **\"Phase: NEW, Iteration: 1\"** but the gallery had been at iter 4 ACT for over a month (4 substantive merged PRs: #5840, #6992, #7855, #7636). This PR resets `state.md` to reflect actual reality: iter 5 ACT with full iteration history, two axioms documented (KSS deep result, Alon-Erdős open conjecture), and two follow-up candidates outlined for future iterations.

## Files changed

- `proofs/Proofs/Erdos530Problem.lean`: 381 → 430 lines, 16 → 17 theorems, 5 defs, 2 axioms, 0 sorries unchanged.
- `src/data/proofs/erdos-530/meta.json`: lineCount 381→430, theoremCount 16→17 in both meta and leanFile blocks.
- `research/problems/erdos-530/state.md`: full sync from iter 1 NEW to iter 5 ACT.

## Status

- **Outcome**: progress (1 new theorem sharpening the explicit upper bound on Sidon sets in `{1,...,N}`)
- **Build status**: pending (build-pending PR convention; cold-cache Docker build queued separately due to broken `proofs/.lake` symlink)
- **Axiom count**: unchanged (2 axioms, both appropriate as axiomatic limits — KSS is a deep proved theorem, Alon-Erdős is genuinely open)
- **Next iteration**: `sidon_diff_injOn` — difference-injectivity characterization of Sidon sets, the dual of the existing `sidon_sum_injective`

🤖 Generated by researcher-11