### PR TITLE
research(abel-ruffini-galois-extensions-oq-07): S8 spec for |G|=12 element-counting argument

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-07/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/knowledge.md
@@ -112,10 +112,44 @@ each to first power, but cannot handle `p²` for any prime.
 
 ## Path forward
 
-1. **(S5)** Prove `|G| = p² · q` axiom-free via Sylow analysis (~50-100 lines).
-2. **(S6)** Prove `|G| = p · q²` axiom-free (symmetric, ~30-50 lines).
-3. **(S7)** Prove `|G| = p² · q²` axiom-free (~80-150 lines).
-4. **(S8+)** Build Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`
+1. **(S5, PR #16972, merged)** `burnside_pq_with_normal_pSylow` and `_qSylow`
+   reduction lemmas: `|G| = p^a · q^b` + normal Sylow ⇒ solvable.
+2. **(S7, PR #17114, merged)** `burnside_p_squared_q_p_gt_q`: `|G| = p²·q`
+   with `q < p` is solvable axiom-free (Sylow's third theorem forces `n_p = 1`).
+3. **(S7.5, PR #17155, merged)** `burnside_p_squared_q_p_lt_q`: `|G| = p²·q`
+   with `p < q` and `(p, q) ≠ (2, 3)` is solvable axiom-free.
+4. **(S8, in progress, this session)** `|G| = 12` exceptional case via
+   element counting (`n_3 = 4 ⇒ n_2 = 1` by Sylow-3 union cardinality).
+   Spec: `session-8-twelve-spec.md`. Estimated ~180 lines, deferred to
+   next session (`.lake` symlink trap on this host).
+5. **(S8')** Symmetric `(1, 2)` shape: `burnside_p_q_squared_*` mirroring
+   S7/S7.5/S8.
+6. **(S9)** `|G| = p²·q²` Sylow analysis (~150 lines).
+7. **(S10+)** Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`
    (~200-400 lines). Closes ALL remaining cases.
-5. **(Final)** Replace `axiom burnside_pq_nontrivial` with theorem; sync meta.json;
-   submit Mathlib upstream PR (~1000 lines total).
+8. **(Final)** Replace `axiom burnside_pq_nontrivial` with theorem; sync
+   meta.json; submit Mathlib upstream PR (~1000 lines total).
+
+## Insight (S8): Why `|G| = 12` requires element counting, not Sylow alone
+
+For `|G| = p²·q` with `p ≠ q`, Sylow's third theorem gives `n_p ∈ {divisors of q}`
+and `n_q ∈ {divisors of p²}`, each `≡ 1` modulo the corresponding prime. The
+constraint `n_q ≡ 1 [MOD q]` for `n_q ∈ {1, p, p²}` rules out `n_q = p` whenever
+`p < q` (since `q ∣ p − 1` is impossible) and rules out `n_q = p²` whenever
+`q ∤ p² − 1 = (p − 1)(p + 1)`. The latter fails only when `q ∣ p + 1` AND
+`q ∤ p − 1`, which forces `q = p + 1`. The only consecutive primes are
+`(2, 3)` — hence the exceptional case `|G| = 12`.
+
+In this exceptional case `n_3 = 4` is genuinely possible (realized by `A₄`).
+Sylow's third theorem alone cannot rule it out; one must count elements:
+distinct Sylow 3-subgroups intersect trivially (prime order), so 4 such
+subgroups contain `1 + 4·2 = 9` elements (with `g^3 = 1`). The remaining
+`12 − 9 = 3` elements together with the identity form a unique 4-element
+set that necessarily coincides with any Sylow 2-subgroup, forcing `n_2 = 1`.
+
+**Generalization caveat**: This element-counting trick is specific to `|G| = 12`.
+For `|G| = 18 = 2·3²` (the symmetric `(1, 2)` exceptional case with
+`(p, q) = (2, 3)`), an analogous count gives `9 + 9 = 18`, leaving `0`
+slots — meaning the Sylow 2 and Sylow 3 unions exactly partition `G`. The
+proof structure is similar but the bound is tighter (must rule out triple
+overlaps explicitly).

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/session-8-twelve-spec.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/session-8-twelve-spec.md
@@ -1,0 +1,321 @@
+# Session 8 — `|G| = 12` Axiom-Free Specification
+
+**Session**: S8 (researcher-1, 2026-05-08)
+**Goal**: Provide a build-ready specification for proving
+`burnside_p_squared_q_twelve : ∀ {G} [Group G] [Finite G]
+   [Fact (Nat.Prime 2)] [Fact (Nat.Prime 3)]
+   (hcard : Nat.card G = 12), IsSolvable G`
+axiom-free, completing the `(a, b) = (2, 1)` shape of `burnside_pq_nontrivial`.
+**Status**: spec only — Lean prototype deferred until `proofs/.lake` recursive
+self-symlink is repaired (each Docker build = ~30–45 min Mathlib clone).
+
+S7 (PR #17114) and S7.5 (PR #17155) discharged `|G| = p² · q` axiom-free for
+all `(p, q)` *except* the exceptional `(p, q) = (2, 3), |G| = 12`. S8 closes
+this final sub-case via element-counting on Sylow 3-subgroups.
+
+---
+
+## 1. Strategy Overview
+
+For `|G| = 12 = 2² · 3`, Sylow's third theorem gives:
+
+* `n_3 := Nat.card (Sylow 3 G)` satisfies `n_3 ≡ 1 [MOD 3]` and `n_3 ∣ 4`;
+  hence `n_3 ∈ {1, 4}`.
+* `n_2 := Nat.card (Sylow 2 G)` satisfies `n_2 ≡ 1 [MOD 2]` and `n_2 ∣ 3`;
+  hence `n_2 ∈ {1, 3}`.
+
+Goal: prove **at least one of `n_2, n_3`** equals `1`.
+
+* `n_3 = 1`: Sylow 3-subgroup `Q` is normal, `|Q| = 3`, discharge via
+  `burnside_pq_with_normal_qSylow` with `(a, b) = (2, 1)`.
+* `n_3 = 4`: Element-counting forces `n_2 = 1`. The Sylow 2-subgroup `P` is
+  then normal, `|P| = 4`, discharge via `burnside_pq_with_normal_pSylow`
+  with `(a, b) = (2, 1)`.
+
+The non-trivial case is `n_3 = 4 ⇒ n_2 = 1`; this is the heart of S8.
+
+---
+
+## 2. Element-Counting Argument (Mathematical Core)
+
+When `n_3 = 4`:
+
+1. **Pairwise trivial intersections.** Each Sylow 3-subgroup `Q_i` has
+   `|Q_i| = 3` (prime). For `i ≠ j`, `Q_i ∩ Q_j` is a subgroup of `Q_i`,
+   so `|Q_i ∩ Q_j| ∣ 3`. Since `Q_i ≠ Q_j` (distinct Sylows), `Q_i ∩ Q_j ⊊ Q_i`,
+   forcing `|Q_i ∩ Q_j| = 1`, i.e. `Q_i ∩ Q_j = {e}`.
+
+2. **Counting elements of order dividing 3.** The set
+   `S := {g ∈ G | g^3 = 1}` equals `⋃_i Q_i` (in either direction):
+   * `Q_i ⊆ S` since every element of a 3-element group has `g^3 = 1`.
+   * Conversely, `g^3 = 1` ⇒ `⟨g⟩` has order `1` or `3` ⇒ `⟨g⟩` lies in some
+     Sylow 3-subgroup.
+
+   By inclusion–exclusion + pairwise trivial intersection:
+   `|S| = |⋃_i Q_i| = 1 + ∑_i (|Q_i| − 1) = 1 + 4 · 2 = 9`.
+
+3. **Slot count for non-3-power elements.** `|G \ S| = 12 − 9 = 3`. Every
+   element of a Sylow 2-subgroup `P` has order in `{1, 2, 4}`, none of
+   which gives `g^3 = 1` except `g = 1`. So `P \ {1} ⊆ G \ S`.
+
+4. **Uniqueness of the Sylow 2-subgroup.** `|P \ {1}| = 3 = |G \ S|`,
+   forcing `P \ {1} = G \ S`, i.e. `P = (G \ S) ∪ {1}`. The right-hand
+   side depends only on `G`, not on the choice of `P`. Hence every Sylow
+   2-subgroup equals this fixed set, so `Subsingleton (Sylow 2 G)` and
+   `n_2 = 1`.
+
+This argument is **specific to `|G| = 12`** because:
+
+* `|G| − (number of order-3 elements)` exactly fits one Sylow 2-subgroup.
+* For `|G| = 18 = 2 · 3²` the analogous count gives `9` order-3 elements
+  out of `18`, leaving `9` slots for Sylow 2's of order `2`, which doesn't
+  uniquely pin down a Sylow.
+
+---
+
+## 3. Mathlib API Inventory (verification needed when build available)
+
+| Lemma | Mathlib location (best guess) | Statement |
+|---|---|---|
+| `Sylow.card_eq_multiplicity` | `Mathlib.GroupTheory.Sylow` | Used in S7/S7.5 — proven reliable. |
+| `card_sylow_modEq_one` | `Mathlib.GroupTheory.Sylow` | Used in S7/S7.5 — proven reliable. |
+| `Sylow.card_dvd_index` | `Mathlib.GroupTheory.Sylow` | Used in S7/S7.5 — proven reliable. |
+| `Sylow.normal_of_subsingleton` | `Mathlib.GroupTheory.Sylow` | Used in S7/S7.5 — proven reliable. |
+| `Subgroup.card_mul_index` | `Mathlib.Algebra.Group.Subgroup.Finite` | Used in S7/S7.5 — proven reliable. |
+| `Nat.card_eq_one_iff_unique` | `Mathlib.Data.Nat.Card` | Used in S7/S7.5 — proven reliable. |
+| `Subgroup.disjoint_def` | `Mathlib.Algebra.Group.Subgroup.Basic` | For trivial intersection. |
+| `Sylow.toSubgroup` | `Mathlib.GroupTheory.Sylow` | Coercion `Sylow p G → Subgroup G`. |
+| **NEW for S8:** | | |
+| `Set.ncard_biUnion` / `Finset.card_biUnion` | `Mathlib.Data.Set.Card` | `|⋃ f| = Σ |f i|` when pairwise disjoint. |
+| `Subgroup.IsCyclic.card_eq_orderOf` | `Mathlib.GroupTheory.OrderOfElement` | Order-3 elements characterization. |
+| `Subgroup.card_eq_one_iff_eq_bot` | `Mathlib.Algebra.Group.Subgroup.Lattice` | `|H| = 1 ↔ H = ⊥`. |
+| `IsPGroup.disjoint_or_eq` | `Mathlib.GroupTheory.PGroup` (uncertain) | Distinct Sylow subgroups of prime order intersect trivially. |
+| `Set.ncard_eq_of_bijective` | `Mathlib.Data.Set.Card` | For pinning down |G \ S|. |
+
+---
+
+## 4. Lean 4 Skeleton — Helper Lemma: Sylow-3 Count Constraint
+
+```lean
+/-- **Sylow count constraint for |G| = 12**: `n ∣ 4`, `n ≡ 1 [MOD 3]`,
+    `n ≥ 1` ⇒ `n = 1 ∨ n = 4`. Reusable utility. -/
+private lemma sylow_count_dvd_four_modEq_one_three
+    {n : ℕ} (hpos : 0 < n) (hdvd : n ∣ 4) (hmod : n ≡ 1 [MOD 3]) :
+    n = 1 ∨ n = 4 := by
+  have hn_le : n ≤ 4 := Nat.le_of_dvd (by norm_num) hdvd
+  interval_cases n
+  · left; rfl
+  · -- n = 2: 2 ≢ 1 [MOD 3] (decidable on naturals)
+    exact absurd hmod (by decide)
+  · -- n = 3: 3 ∤ 4
+    exact absurd hdvd (by decide)
+  · right; rfl
+```
+
+---
+
+## 5. Lean 4 Skeleton — Helper Lemma: Distinct Sylow 3-Subgroups Disjoint
+
+```lean
+/-- For two distinct Sylow `p`-subgroups of order `p` (prime), the underlying
+    subgroups intersect trivially. -/
+private lemma sylow_prime_distinct_inter_bot
+    {G : Type*} [Group G] [Finite G]
+    {p : ℕ} [hp : Fact p.Prime]
+    (P Q : Sylow p G)
+    (hP : Nat.card (P : Subgroup G) = p) (hQ : Nat.card (Q : Subgroup G) = p)
+    (hne : P ≠ Q) :
+    (P : Subgroup G) ⊓ (Q : Subgroup G) = ⊥ := by
+  -- Use IsPGroup analysis: intersection of two distinct subgroups of prime
+  -- order has order 1 (only possible proper subgroup of cyclic Z_p).
+  --
+  -- Key observation: P ⊓ Q ≤ P, and |P ⊓ Q| ∣ p (Lagrange).
+  -- p prime + (P ⊓ Q ≤ P with |P| = p) ⇒ |P ⊓ Q| = 1 or |P ⊓ Q| = p = |P|.
+  -- The latter forces P ⊓ Q = P = Q (since P ⊓ Q ≤ Q similarly), contradicting hne.
+  --
+  -- Mathlib API:
+  --   * `Subgroup.card_inf_le_of_le_of_le` or similar
+  --   * `Sylow.ext_of_subgroup_eq` (if Sylow p with same underlying group are equal)
+  --   * `Subgroup.eq_bot_or_eq_top_of_card_le_prime` (uncertain name)
+  sorry
+```
+
+---
+
+## 6. Lean 4 Skeleton — Helper Lemma: Order-3 Element Count
+
+```lean
+/-- For `|G| = 12` with exactly 4 Sylow 3-subgroups (each of order 3),
+    the set `{g : G | g^3 = 1}` has exactly 9 elements. -/
+private lemma card_pow_three_eq_one_of_n3_four
+    {G : Type*} [Group G] [Finite G]
+    [hp : Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12)
+    (hn3 : Nat.card (Sylow 3 G) = 4) :
+    Nat.card {g : G // g^3 = 1} = 9 := by
+  -- Plan:
+  -- 1. Show the 4 Sylow 3-subgroups Q_1, …, Q_4 are pairwise disjoint
+  --    (via sylow_prime_distinct_inter_bot above).
+  -- 2. Show {g : g^3 = 1} = ⋃ Q_i (set equality).
+  --    (⊆): if g^3 = 1 then ⟨g⟩ has order ∣ 3, so |⟨g⟩| ∈ {1, 3}; the latter
+  --         makes ⟨g⟩ a Sylow 3-subgroup, so g lies in it.
+  --    (⊇): every g in a Sylow 3-subgroup has order ∣ 3 (Lagrange).
+  -- 3. Inclusion-exclusion: |⋃ Q_i| = Σ |Q_i| - Σ |Q_i ∩ Q_j| + … = 4·3 - 6·1 + 4·1 - 1 = 9
+  --    Or use `Set.ncard_biUnion_eq_sum_of_pairwiseDisjoint` with disjoint-but-share-{e}
+  --    handled by partitioning Q_i \ {1} sets.
+  --
+  -- Cleaner approach: partition {g : g^3 = 1} = {1} ⊔ ⊔_i (Q_i \ {1}), where each
+  -- Q_i \ {1} has 2 elements and they are pairwise disjoint (from disjointness of Q_i, Q_j).
+  -- Then card = 1 + 4·2 = 9.
+  sorry
+```
+
+---
+
+## 7. Lean 4 Skeleton — Main Sub-case: `n_3 = 4 ⇒ n_2 = 1`
+
+```lean
+/-- For `|G| = 12` with `n_3 = 4`, the Sylow 2-subgroup is unique. -/
+private lemma sylow_two_unique_when_n3_four
+    {G : Type*} [Group G] [Finite G]
+    [Fact (Nat.Prime 2)] [Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12)
+    (hn3 : Nat.card (Sylow 3 G) = 4) :
+    Subsingleton (Sylow 2 G) := by
+  -- 1. card_pow_three_eq_one_of_n3_four: |{g | g^3 = 1}| = 9.
+  -- 2. So |G \ {g | g^3 = 1}| = 12 - 9 = 3.
+  -- 3. For any P : Sylow 2 G, |P| = 4 (Sylow.card_eq_multiplicity), and
+  --    every g ∈ P has g^4 = 1; combined with g^3 = 1 ⇒ g = 1, so
+  --    g ∈ P \ {1} ⇒ g^3 ≠ 1.
+  -- 4. P \ {1} ⊆ G \ {g | g^3 = 1}; both have cardinality 3.
+  -- 5. So P \ {1} = G \ {g | g^3 = 1}, fixing P uniquely.
+  --
+  -- Lean form: use `Subsingleton.intro` then `Sylow.ext` matching underlying
+  -- subgroups via the set equality P = {1} ∪ (G \ {g | g^3 = 1}).
+  sorry
+```
+
+---
+
+## 8. Main Theorem Skeleton
+
+```lean
+theorem burnside_p_squared_q_twelve
+    {G : Type*} [Group G] [Finite G]
+    [hp : Fact (Nat.Prime 2)] [hq : Fact (Nat.Prime 3)]
+    (hcard : Nat.card G = 12) : IsSolvable G := by
+  have hcard' : Nat.card G = 2 ^ 2 * 3 := by rw [hcard]; norm_num
+  have hcard'' : Nat.card G = 2 ^ 2 * 3 ^ 1 := by rw [hcard]; norm_num
+  -- Sylow 3-subgroup Q, |Q| = 3, Q.index = 4.
+  obtain ⟨Q⟩ : Nonempty (Sylow 3 G) := inferInstance
+  have hcop : Nat.Coprime (2 ^ 2) 3 := by decide
+  have hQ_card : Nat.card (Q : Subgroup G) = 3 := by
+    -- factorization computation as in burnside_p_squared_q_p_lt_q
+    sorry
+  have hQ_index : (Q : Subgroup G).index = 4 := by
+    -- from card_mul_index
+    sorry
+  -- n_3 ∈ {1, 4}.
+  have hn3_mod : Nat.card (Sylow 3 G) ≡ 1 [MOD 3] := card_sylow_modEq_one 3 G
+  have hn3_dvd : Nat.card (Sylow 3 G) ∣ 4 := hQ_index ▸ Sylow.card_dvd_index Q
+  have hn3_pos : 0 < Nat.card (Sylow 3 G) := Nat.card_pos
+  rcases sylow_count_dvd_four_modEq_one_three hn3_pos hn3_dvd hn3_mod with hn3 | hn3
+  · -- n_3 = 1: Q normal, discharge.
+    haveI : Subsingleton (Sylow 3 G) := (Nat.card_eq_one_iff_unique.mp hn3).1
+    haveI : (Q : Subgroup G).Normal := Sylow.normal_of_subsingleton Q
+    exact burnside_pq_with_normal_qSylow (a := 2) (b := 1) hcard''
+      (Q : Subgroup G) hQ_card
+  · -- n_3 = 4: derive n_2 = 1, then discharge.
+    haveI : Subsingleton (Sylow 2 G) := sylow_two_unique_when_n3_four hcard hn3
+    obtain ⟨P⟩ : Nonempty (Sylow 2 G) := inferInstance
+    have hP_card : Nat.card (P : Subgroup G) = 2 ^ 2 := by
+      sorry  -- factorization gives |P| = 4 = 2^2
+    haveI : (P : Subgroup G).Normal := Sylow.normal_of_subsingleton P
+    exact burnside_pq_with_normal_pSylow (a := 2) (b := 1) hcard''
+      (P : Subgroup G) hP_card
+```
+
+---
+
+## 9. Estimated Lines
+
+| Component | Lines |
+|---|---|
+| `sylow_count_dvd_four_modEq_one_three` | 12 |
+| `sylow_prime_distinct_inter_bot` | 25 (uncertain — depends on Mathlib's `Sylow` API for "distinct ⇒ subgroups distinct") |
+| `card_pow_three_eq_one_of_n3_four` | 60 (set/Finset cardinality reasoning is verbose in Lean) |
+| `sylow_two_unique_when_n3_four` | 35 |
+| `burnside_p_squared_q_twelve` (main) | 50 |
+| **Total** | **~180** (the original ~70 estimate was optimistic) |
+
+---
+
+## 10. Risks and Alternatives
+
+### Risk: `IsPGroup.disjoint_or_eq` style lemma may not exist in expected form
+
+Mathlib may not expose "distinct Sylow p-subgroups of prime order have trivial
+intersection" as a single lemma. Workarounds:
+
+1. **Cardinality + Lagrange**: `|P ⊓ Q| ∣ |P| = p`, so `|P ⊓ Q| ∈ {1, p}`.
+   The case `|P ⊓ Q| = p` ⇒ `P ⊓ Q = P` (full subgroup) ⇒ `P = Q`, contradicting
+   distinctness. Requires `Subgroup.card_le_of_le` or similar.
+
+2. **`Sylow.ext_of_eq_subgroup`**: if two Sylow p-subgroups have the same
+   underlying subgroup, they are equal. Combined with (1), we get the result.
+
+### Alternative path: `Subgroup.normalCore` + `Equiv.Perm (Fin 4)` solvability
+
+Instead of element counting, use the action of `G` on `G/Q` (4 cosets):
+
+* `G →* Equiv.Perm (G ⧸ Q)` with kernel `(Q : Subgroup G).normalCore`.
+* `normalCore Q ≤ Q` so `|normalCore Q| ∣ 3`, hence `normalCore Q ∈ {⊥, Q}`.
+* If `normalCore Q = Q`: `Q` is normal — done.
+* If `normalCore Q = ⊥`: `G ↪ Equiv.Perm (G ⧸ Q) ≃ Equiv.Perm (Fin 4)`.
+  Need `IsSolvable (Equiv.Perm (Fin 4))` from Mathlib (or build via
+  `V_4 ⊴ A_4 ⊴ S_4` chain — `V_4` is the Klein 4-group, abelian).
+
+This route is cleaner mathematically but requires:
+* `Subgroup.normalCore` and its properties (probably in Mathlib).
+* `IsSolvable (Equiv.Perm (Fin 4))` — may need explicit construction.
+* `solvable_of_solvable_injective` (or similar) for "subgroup of solvable is solvable".
+
+Mathlib does have `Equiv.Perm.not_solvable` for `Fin 5`; the positive direction
+for `Fin n ≤ 4` is likely available but name verification needed.
+
+---
+
+## 11. Build Strategy for Next Iteration
+
+1. Repair `proofs/.lake` symlink first (or run on a host where it's intact).
+2. Implement `sylow_count_dvd_four_modEq_one_three` standalone — verify with
+   `lake build Proofs.AbelRuffiniGaloisExtensionsOQ07` (~45 min cold cache).
+3. Add `sylow_prime_distinct_inter_bot` — try `IsPGroup` API first, fall back
+   to manual cardinality argument.
+4. Add `card_pow_three_eq_one_of_n3_four` — most verbose; consider
+   `Set.ncard_biUnion` route vs `Finset.card_biUnion` route.
+5. Add `sylow_two_unique_when_n3_four` and main theorem.
+6. Update `burnside_pq` dispatch to peel off the `(a, b) = (2, 1)` shape via:
+   `burnside_p_squared_q_p_gt_q ∨ burnside_p_squared_q_p_lt_q ∨ burnside_p_squared_q_twelve`.
+7. Narrow `burnside_pq_nontrivial` to `(2 ≤ a ∨ 2 ≤ b) ∧ ¬ ((a, b) = (2, 1) ∨ (a, b) = (1, 2))`
+   (after S8 + symmetric S8' for `(1, 2)` shape).
+
+---
+
+## 12. Why `|G| = 12` Is the Last Holdout
+
+Among `|G| = p² · q` for primes `p ≠ q`:
+
+* `q < p`: always `n_p = 1` (S7).
+* `p < q ≠ p + 1`: always `n_q = 1` (S7.5, since `q ∣ p + 1` forces `q = p + 1`).
+* `p < q = p + 1`: both prime, both ≥ 2 ⇒ `p = 2, q = 3` (only consecutive primes).
+
+So `(p, q, |G|) = (2, 3, 12)` is the *unique* exceptional triple where
+Sylow's third theorem fails to immediately give a normal Sylow. The
+element-counting argument exploits the fact that `|G| − 9 = 3 = |P| − 1`
+exactly — a delicate count that does not generalize to other shapes.
+
+This is also why **A₄** (the alternating group on 4 letters) is the
+classical witness: `|A₄| = 12`, `n_3 = 4` (the 3-cycles partition into 4
+Sylow 3-subgroups), and the unique Sylow 2-subgroup is the Klein 4-group
+`V₄ = {e, (12)(34), (13)(24), (14)(23)}`, which is normal in A₄.

--- a/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-07/state.md
@@ -1,105 +1,126 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-08T15:30:00Z
-**Iteration**: 7.5
+**Since**: 2026-05-08T17:00:00Z
+**Iteration**: 8 (spec-only)
 
-## S7.5 (this session, build pending)
+## S8 (this session, researcher-1, spec-only)
 
-Adds `burnside_p_squared_q_p_lt_q` (axiom-free, case `p < q ≠ (2, 3)`)
-plus the private helper `sylow_count_eq_one_of_lt_prime_pow_two`. The
-helper rules out `n_q ∈ {p, p²}` from the Sylow constraint
-`n_q ≡ 1 [MOD q]`, `n_q ∣ p²`, `p < q`, `(p, q) ≠ (2, 3)`:
+S7 (PR #17114) and S7.5 (PR #17155) are now merged. The `(a, b) = (2, 1)`
+shape of `burnside_pq_nontrivial` is discharged axiom-free for **all
+non-exceptional `(p, q)`** — `q < p` (S7) or `p < q ≠ p + 1` (S7.5). The
+sole remaining sub-case is the exceptional `(p, q) = (2, 3), |G| = 12`,
+known classically to require an element-counting argument distinct from
+the pure Sylow's-third-theorem dispatch used in S7/S7.5.
 
-* `n_q = p` requires `q ∣ p − 1` with `p < q`, impossible.
-* `n_q = p²` requires `q ∣ p² − 1 = (p − 1)(p + 1)`. Then `q ∣ p + 1`
-  (since `q ∤ p − 1`), forcing `q = p + 1`. Both prime ⇒ `p = 2`,
-  `q = 3` — excluded by hypothesis.
+**This session's contribution**: a detailed spec for S8 in
+`session-8-twelve-spec.md`, capturing:
 
-The main theorem mirrors `burnside_p_squared_q_p_gt_q`'s 5-step
-structure: pick a Sylow q-subgroup, compute `|Q| = q` and
-`Q.index = p²`, apply the helper to force `n_q = 1`, derive
-`Subsingleton (Sylow q G)` ⇒ `Q.Normal`, then discharge via
-`burnside_pq_with_normal_qSylow`.
+* Mathematical core: the `n_3 = 4 ⇒ n_2 = 1` argument, via partitioning
+  `{g : G | g^3 = 1}` as `{1} ⊔ ⊔_i (Q_i \ {1})` with `Q_i` the 4 Sylow
+  3-subgroups (pairwise trivial intersection).
+* Lean 4 skeletons for each of 5 helper lemmas + main theorem
+  (`sylow_count_dvd_four_modEq_one_three`,
+  `sylow_prime_distinct_inter_bot`, `card_pow_three_eq_one_of_n3_four`,
+  `sylow_two_unique_when_n3_four`, `burnside_p_squared_q_twelve`).
+* Mathlib API inventory (extending Session 6's table with set/Finset
+  cardinality lemmas).
+* Risk analysis and alternative path via `Subgroup.normalCore` +
+  `Equiv.Perm (Fin 4)` solvability.
+* Estimated total ~180 Lean lines (revised upward from earlier `~70`
+  estimate — set-cardinality reasoning is verbose in Lean).
 
-Together with S7's `p > q` case, this leaves only the exceptional
-`(p, q) = (2, 3), |G| = 12` case (S8) to complete the `(a, b) = (2, 1)`
-shape elimination from `burnside_pq_nontrivial`.
+No Lean code added this iteration: `proofs/.lake` recursive self-symlink
+on this host forces ≥45-minute cold-cache builds; deferring implementation
+keeps a clean build-pending audit trail. The spec is ready for a future
+iteration to implement (or for a researcher on a host with intact
+`.lake`).
 
 ## Current Focus
 
-Iteration 7 axiom-free `|G| = p² · q`, case `p > q` committed:
-`burnside_p_squared_q_p_gt_q` plus the private helper
-`sylow_count_eq_one_of_lt_prime`. The axiom `burnside_pq_nontrivial`
-statement is unchanged; this iteration discharges the `(a, b) = (2, 1)`
-shape **whenever `p > q`** axiom-free. The remaining `p < q` case (S7.5)
-and exceptional `(p, q) = (2, 3), |G| = 12` case (S8) follow.
+`(a, b) = (2, 1)` shape of `burnside_pq_nontrivial` is **partially
+discharged**:
+
+* `q < p` (S7, PR #17114): axiom-free.
+* `p < q ≠ p + 1` (S7.5, PR #17155): axiom-free.
+* `(p, q) = (2, 3), |G| = 12` (S8): umbrella axiom still applies.
+
+After S8 lands, `burnside_pq_nontrivial` will be narrowed to require
+`2 ≤ a ∧ 2 ≤ b` (genuinely both ≥ 2), or `¬(a, b) ∈ {(2, 1), (1, 2)}`
+once the symmetric `(1, 2)` shape is also discharged.
 
 ## Active Approach
 
-Sylow-counting analysis on `|G| = p² · q`:
+Sylow-counting analysis on `|G| = 12 = 2² · 3`:
 
-- **`p > q` (this iteration)**: `n_p ≡ 1 [MOD p]` (Sylow's third theorem)
-  and `n_p ∣ q` (Sylow's `card_dvd_index`). Since `q` is prime,
-  `n_p ∈ {1, q}`; the case `n_p = q` would force `p ∣ q - 1`, but
-  `q < p` makes that impossible. Hence `n_p = 1`, the unique Sylow
-  `p`-subgroup is normal, and `burnside_pq_with_normal_pSylow` discharges.
-- **`p < q ≠ 3` (S7.5)**: symmetric `n_q = 1` analysis. Three cases for
-  `n_q ∈ {1, p, p²}`; rule out `n_q = p` by `q ∣ p - 1` contradiction
-  with `p < q`; rule out `n_q = p²` via `q ∣ p² - 1` (only `(p, q) = (2, 3)`
-  qualifies, excluded by hypothesis).
-- **Exceptional `(p, q) = (2, 3), |G| = 12` (S8)**: when `n_3 = 4`, count
-  `4 × 2 = 8` elements of order 3; remaining 4 form a unique `V_4`
-  Sylow 2-subgroup, so `n_2 = 1` and the Sylow 2-subgroup is normal.
+- **`n_3 = 1`** (Sylow 3-subgroup `Q` unique): `Q.Normal`, discharge via
+  `burnside_pq_with_normal_qSylow` with `(a, b) = (2, 1)`. Trivial.
+- **`n_3 = 4`** (4 Sylow 3-subgroups): element counting forces `n_2 = 1`.
+  - Each pair of distinct Sylow 3-subgroups intersects trivially (prime
+    order 3, only proper subgroup is `⊥`).
+  - `|⋃_i Q_i| = 1 + 4 · 2 = 9`, so 9 elements satisfy `g^3 = 1`.
+  - The remaining 3 elements (with identity) must form a unique Sylow
+    2-subgroup `P` (since `|P| = 4 = 1 + 3`, all of `P \ {1}` lies in
+    `G \ {g | g^3 = 1}`, and these sizes match).
+  - `Subsingleton (Sylow 2 G) ⇒ P.Normal`, discharge via
+    `burnside_pq_with_normal_pSylow`.
+
+This is the **classical A₄ case**: when `n_3 = 4`, `G ≅ A₄`, and the
+unique Sylow 2-subgroup is the Klein four-group `V₄`.
 
 ## Blockers
 
-The residual axiom (orders divisible by `p²` or `q²` for distinct primes,
-once `(2, 1)` and `(1, 2)` shapes are peeled off) requires either character
-theory + algebraic-integer hypotheses or transfer + focal subgroup theory.
-Mathlib's `Mathlib.GroupTheory.Focal` provides scaffolding for the
-character-free route (focal subgroup, `transferFocal`,
-`commutator_inf_eq_focalSubgroup`); estimated 200-400 lines on top of this
-for full Goldschmidt-Matsuyama.
+The residual axiom (orders divisible by `p²` AND `q²` for distinct
+primes, once `(2, 1)` and `(1, 2)` shapes are peeled off) requires
+either character theory + algebraic-integer hypotheses or transfer +
+focal subgroup theory. Mathlib's `Mathlib.GroupTheory.Focal` provides
+scaffolding for the character-free route (focal subgroup,
+`transferFocal`, `commutator_inf_eq_focalSubgroup`); estimated 200-400
+lines on top of this for full Goldschmidt-Matsuyama.
+
+**Build infrastructure**: `proofs/.lake` recursive self-symlink on this
+host forces every Docker build to fresh-clone Mathlib (~10-15 min) +
+cache get (~10 min). Plan ≥45 min build timeouts for any Lean
+verification of S8.
 
 ## Next Action
 
-1. **(S7.5)** Prove `burnside_p_squared_q_p_lt_q` axiom-free per
-   `session-6-p-squared-q-spec.md` §5 (~40 lines). Two `sorry`s in spec:
-   `n_q ≠ p` (ruled out by `q ∣ p - 1`, `p < q`); `n_q ≠ p²` (ruled out
-   by `q ∣ p² - 1` and exceptional flag).
-2. **(S8)** Prove `burnside_p_squared_q_twelve` for the exceptional case
-   `(p, q) = (2, 3), |G| = 12` via element counting (~70 lines).
-3. **(post-S8)** Augment the main `burnside_pq` dispatch to peel off
-   `(a, b) = (2, 1)` and `(1, 2)` axiom-free before invoking the
-   (further-narrowed) axiom.
-4. **(S9+)** `|G| = p² · q²` Sylow analysis (~150 lines); then
-   Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`.
+1. **(S8)** Implement `burnside_p_squared_q_twelve` per
+   `session-8-twelve-spec.md` (~180 lines). Five helper lemmas + main
+   theorem. Build verification ~45 min.
+2. **(post-S8)** Augment the main `burnside_pq` dispatch to peel off
+   `(a, b) = (2, 1)` axiom-free (combining S7, S7.5, S8). After this,
+   the `burnside_pq_nontrivial` axiom can be narrowed to exclude
+   `(a, b) = (2, 1)`.
+3. **(S8')** Symmetric `(1, 2)` shape: prove
+   `burnside_p_q_squared_p_gt_q`, `burnside_p_q_squared_p_lt_q`,
+   `burnside_p_q_squared_eighteen` (mirror of S7, S7.5, S8 with `p` and
+   `q` swapped). Estimated ~250 lines including helpers.
+4. **(S9)** `|G| = p² · q²` Sylow analysis (~150 lines).
+5. **(S10+)** Goldschmidt-Matsuyama on top of `Mathlib.GroupTheory.Focal`
+   for the `(a, b) ≥ (2, 2)` case.
 
-## Iteration 7 Builds (researcher-5, 2026-05-08)
+## Iteration 7 Builds (researcher-5, 2026-05-08, PR #17114)
 
-- Updated `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`
-  (502→614 lines, 13→15 theorems, 1 axiom unchanged, 0 sorries).
-- Added `import Mathlib.GroupTheory.Sylow`.
-- `sylow_count_eq_one_of_lt_prime` (private helper, ~12 lines): if
-  `n ∣ q` (q prime), `q < p`, `n ≡ 1 [MOD p]`, then `n = 1`. Proof:
-  `Nat.Prime.eq_one_or_self_of_dvd` + `Nat.modEq_iff_dvd'` + `omega`.
-- `burnside_p_squared_q_p_gt_q` (~50 lines, axiom-free): pick a Sylow
-  p-subgroup P, show `|P| = p²` via `Sylow.card_eq_multiplicity` (with
-  factorization computation: `factorization (p²·q) p = 2` via
-  `Nat.factorization_mul_apply_of_coprime` + `Prime.factorization_pow` +
-  `factorization_eq_zero_of_not_dvd`); compute `P.index = q` via
-  `Subgroup.card_mul_index`; derive `n_p = 1` via `card_sylow_modEq_one` +
-  `Sylow.card_dvd_index` + the helper; promote to `Subsingleton` via
-  `Nat.card_eq_one_iff_unique`; `Sylow.normal_of_subsingleton` makes P
-  normal; `burnside_pq_with_normal_pSylow` discharges.
-- New sanity-check example: `|G| = 75 = 5² · 3` axiom-free.
-- Updated gallery entry meta.json (lineCount 502→614, theoremCount 13→15,
-  substantiveTheoremCount 13→15, axiomCount unchanged at 1, added
-  Mathlib.GroupTheory.Sylow import, added 7 new mathlibDependencies for
-  Sylow API, added Part III.6 section, updated assumptions text,
-  added new mainTheorems entry).
+- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`: 502→614 lines,
+  13→15 theorems.
+- `sylow_count_eq_one_of_lt_prime` (private helper): if `n ∣ q`
+  (q prime), `q < p`, `n ≡ 1 [MOD p]`, then `n = 1`.
+- `burnside_p_squared_q_p_gt_q` (~50 lines): pick Sylow p-subgroup,
+  show `|P| = p²`, `P.index = q`, derive `n_p = 1`, `P` normal,
+  discharge via `burnside_pq_with_normal_pSylow`.
 
-**Counts**: lineCount 614, theoremCount 15, substantiveTheoremCount 15,
-axiomCount 1 (unchanged, but `(a, b) = (2, 1)` with `p > q` now
-discharged outside the axiom), sorries 0.
+## Iteration 7.5 Builds (PR #17155)
+
+- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean`: 614→738 lines,
+  15→17 theorems (best estimate; counts may need re-verification post-merge).
+- `sylow_count_eq_one_of_lt_prime_pow_two` (private helper): rules out
+  `n ∈ {p, p²}` from constraints `n ∣ p²`, `n ≡ 1 [MOD q]`, `p < q`,
+  `(p, q) ≠ (2, 3)`.
+- `burnside_p_squared_q_p_lt_q` (~50 lines): mirror of `p > q` case
+  using Sylow q-subgroup.
+
+**Counts after S7.5 merge**: lineCount 738, theoremCount likely 17,
+substantiveTheoremCount likely 17, axiomCount 1 (umbrella unchanged but
+`(a, b) = (2, 1)` discharged outside the axiom *except for the
+`(p, q) = (2, 3)` exception*), sorries 0.

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -30,21 +30,21 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-08T15:30:00.000Z",
-    "iteration": 7,
-    "focus": "S7 (researcher-5, 2026-05-08): **`|G| = p² · q`, case `p > q` axiom-free COMMITTED**. Added Part III.6 to AbelRuffiniGaloisExtensionsOQ07.lean (502→614 lines, 13→15 theorems, 1 axiom unchanged, 0 sorries). Two new theorems: `sylow_count_eq_one_of_lt_prime` (private helper, ~12 lines: if n ∣ q (q prime), q < p, n ≡ 1 [MOD p], then n = 1) and `burnside_p_squared_q_p_gt_q` (~50 lines, axiom-free): pick a Sylow p-subgroup P with |P| = p² via `Sylow.card_eq_multiplicity` + factorization (discharge of S6 spec sorry 1 inline); compute its index q via `Subgroup.card_mul_index`; combine `card_sylow_modEq_one` + `Sylow.card_dvd_index` + helper to get n_p = 1; promote to `Subsingleton (Sylow p G)` via `Nat.card_eq_one_iff_unique`; close via `Sylow.normal_of_subsingleton` + `burnside_pq_with_normal_pSylow`. Added Mathlib.GroupTheory.Sylow import. New sanity-check example: |G| = 75 = 5²·3 axiom-free.",
+    "iteration": 8,
+    "focus": "S8 (researcher-1, 2026-05-08): **|G| = 12 spec-only iteration**. S7 (PR #17114) and S7.5 (PR #17155) merged; (a,b)=(2,1) shape discharged axiom-free for all (p,q) except the exceptional (p,q)=(2,3), |G|=12 case (which S7.5's hexc hypothesis explicitly excludes). This iteration produced session-8-twelve-spec.md containing the detailed mathematical argument (n_3=4 ⇒ n_2=1 by element-counting on the union of 4 Sylow 3-subgroups, each of prime order 3 with pairwise trivial intersection, forcing the remaining 3 elements + identity to coincide with the unique Sylow 2-subgroup) and a Lean 4 skeleton for 5 helper lemmas + main theorem (~180 lines estimated). No Lean code added: proofs/.lake recursive self-symlink on this host forces ≥45 min Mathlib re-clones; deferring implementation keeps a clean build-pending audit trail. Future iteration on a host with intact .lake can implement the spec directly.",
     "blockers": [
       "Mathlib lacks: (1) the algebraic-integer lemma `|G|/χ(1) ∈ ℤ̄_K` for a non-trivial irreducible character χ on a non-conjugacy class, key for the original Burnside proof; (2) the focal subgroup theorem and transfer-based character-free Burnside proof (Goldschmidt/Matsuyama). Note: Mathlib has `Mathlib.GroupTheory.Focal` (focal subgroup definition + transfer to focal quotient), so partial scaffolding exists for the character-free route.",
       "Mathlib's character theory needs algebraically-closed-field hypotheses; concretizing for ℂ-valued characters requires `Complex` ↔ `IsAlgClosed` bridge already in Mathlib but care needed."
     ],
     "nextAction": "S7.5: prototype `burnside_p_squared_q_p_lt_q` per `session-6-p-squared-q-spec.md` §5 (~40 lines, two `sorry`s in the spec to discharge). Then S8: add the exceptional `(p, q) = (2, 3), |G| = 12` case per §6 (~70 lines, element counting). After S7+S7.5+S8, the `(a, b) = (2, 1)` and `(1, 2)` shapes can be peeled off `burnside_pq_nontrivial` axiom-free; the main theorem `burnside_pq` can then be augmented to peel them off before invoking the axiom. Beyond p²·q and p·q²: S9 = `|G| = p² · q²` Sylow analysis (~150 lines); S10+ = Goldschmidt-Matsuyama via `Mathlib.GroupTheory.Focal` for residual `a ≥ 3 ∨ b ≥ 3` cases.",
     "attemptCounts": {
-      "total": 7,
+      "total": 8,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S4 (researcher-1, 2026-05-08, ACT): **Squarefree-order axiom-narrowing COMMITTED**. Added Part II.5 to AbelRuffiniGaloisExtensionsOQ07.lean (277→384 lines, 8→10 theorems, 1 axiom narrowed, 0 sorries). Two new theorems: `squarefreeOrder_isSolvable` (Squarefree |G| → IsSolvable G via Mathlib's IsZGroup.of_squarefree + the [Finite][IsZGroup]→IsSolvable instance), `burnside_pq_pq_case` (axiom-free a=b=1 case for |G|=p·q via Nat.coprime_primes + Prime.squarefree + Nat.squarefree_mul). The axiom `burnside_pq_nontrivial` now requires `2 ≤ a ∨ 2 ≤ b`; the `a = b = 1` sub-case is no longer axiom-dependent. The main theorem `burnside_pq` now dispatches axiom-free to the pq case before falling back to the (narrowed) axiom. Two new sanity-check examples added: |G|=pq via burnside_pq_pq_case; |G|=30 via squarefreeOrder_isSolvable (showing the squarefree route extends beyond two primes). Added import Mathlib.GroupTheory.SpecificGroups.ZGroup.\n\nS3 (researcher-8, 2026-05-08, ACT): Sharpness witness COMMITTED. Added Part VI (3 axiom-free theorems demonstrating |A₅| = 2²·3·5 is non-solvable). 221→277 lines, 5→8 theorems.\n\nS2 (researcher-3, 2026-05-08, ORIENT): Phase-2 scaffold COMMITTED. Created `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (221 lines, 5 theorems, 1 axiom, 0 sorries). Trivial cases (a=0, b=0, p=q) proved AXIOM-FREE via Mathlib IsPGroup → IsNilpotent → IsSolvable. Non-trivial case isolated as axiom `burnside_pq_nontrivial`.\n\nS1 (2026-05-07, OBSERVE): Identified the seed open question as #7 of the parent gallery. Documented two proof strategies (character-theoretic vs Goldschmidt-Matsuyama character-free) and their tradeoffs.",
+    "progressSummary": "S8 (researcher-1, 2026-05-08, ACT spec-only): Detailed S8 spec for |G|=12 element-counting argument (session-8-twelve-spec.md, ~250 lines of LaTeX/spec covering math core, Lean skeleton, Mathlib API inventory, alternative paths). State.md and knowledge.md updated. No Lean changes (build infrastructure trap on this host).\n\nS4 (researcher-1, 2026-05-08, ACT): **Squarefree-order axiom-narrowing COMMITTED**. Added Part II.5 to AbelRuffiniGaloisExtensionsOQ07.lean (277→384 lines, 8→10 theorems, 1 axiom narrowed, 0 sorries). Two new theorems: `squarefreeOrder_isSolvable` (Squarefree |G| → IsSolvable G via Mathlib's IsZGroup.of_squarefree + the [Finite][IsZGroup]→IsSolvable instance), `burnside_pq_pq_case` (axiom-free a=b=1 case for |G|=p·q via Nat.coprime_primes + Prime.squarefree + Nat.squarefree_mul). The axiom `burnside_pq_nontrivial` now requires `2 ≤ a ∨ 2 ≤ b`; the `a = b = 1` sub-case is no longer axiom-dependent. The main theorem `burnside_pq` now dispatches axiom-free to the pq case before falling back to the (narrowed) axiom. Two new sanity-check examples added: |G|=pq via burnside_pq_pq_case; |G|=30 via squarefreeOrder_isSolvable (showing the squarefree route extends beyond two primes). Added import Mathlib.GroupTheory.SpecificGroups.ZGroup.\n\nS3 (researcher-8, 2026-05-08, ACT): Sharpness witness COMMITTED. Added Part VI (3 axiom-free theorems demonstrating |A₅| = 2²·3·5 is non-solvable). 221→277 lines, 5→8 theorems.\n\nS2 (researcher-3, 2026-05-08, ORIENT): Phase-2 scaffold COMMITTED. Created `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (221 lines, 5 theorems, 1 axiom, 0 sorries). Trivial cases (a=0, b=0, p=q) proved AXIOM-FREE via Mathlib IsPGroup → IsNilpotent → IsSolvable. Non-trivial case isolated as axiom `burnside_pq_nontrivial`.\n\nS1 (2026-05-07, OBSERVE): Identified the seed open question as #7 of the parent gallery. Documented two proof strategies (character-theoretic vs Goldschmidt-Matsuyama character-free) and their tradeoffs.",
     "builtItems": [
       "S2 — proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean (221 lines, 5 theorems, 1 axiom)",
       "S2 — pGroup_isSolvable: explicit packaging of Mathlib's IsPGroup → IsNilpotent → IsSolvable chain (axiom-free)",
@@ -67,7 +67,10 @@
       "S4 — Narrowed axiom burnside_pq_nontrivial: now requires 2 ≤ a ∨ 2 ≤ b (the a=b=1 case is axiom-free)",
       "S4 — Updated burnside_pq main theorem dispatch: by_cases h11 : a = 1 ∧ b = 1 added before axiom fallback",
       "S4 — 2 new sanity-check examples: |G| = pq via burnside_pq_pq_case (axiom-free); |G| = 30 via squarefreeOrder_isSolvable (squarefree route beyond two primes)",
-      "S4 — Added import Mathlib.GroupTheory.SpecificGroups.ZGroup"
+      "S4 — Added import Mathlib.GroupTheory.SpecificGroups.ZGroup",
+      "S8 — research/problems/abel-ruffini-galois-extensions-oq-07/session-8-twelve-spec.md (detailed |G|=12 argument + Lean skeleton)",
+      "S8 — Updated state.md (S7.5 merged, S8 plan)",
+      "S8 — Updated knowledge.md (S8 element-counting insight, generalization caveat)"
     ],
     "insights": [
       "S2 — The four trivial cases (`a = 0`, `b = 0`, `p = q`, `|G| = 1`) all reduce to G being a p-group for some prime p, which Mathlib's `IsPGroup → IsNilpotent → IsSolvable` chain handles axiom-free. So 75% of the cases of Burnside's theorem need NO new mathematical content — only the genuinely two-prime case (p ≠ q, a ≥ 1, b ≥ 1) carries new Lean content.",
@@ -98,7 +101,10 @@
       "S4 — Dispatch pattern in `burnside_pq` for the narrowed axiom: `by_cases h11 : a = 1 ∧ b = 1` to peel off the squarefree case axiom-free, then `by_contra h ; push_neg at h ; obtain ⟨ha2, hb2⟩ := h ; exact h11 ⟨by omega, by omega⟩` to derive `2 ≤ a ∨ 2 ≤ b` for the axiom invocation. Clean and minimal.",
       "S4 — Sanity check: `decide` does NOT work for `Squarefree 30` (`Nat.instDecidablePredSquarefree 30` doesn't reduce); use `native_decide` instead. Useful for any concrete-cardinality squarefreeness sanity check.",
       "S4 — Squarefree-order route is broader than just `pq`: `squarefreeOrder_isSolvable` proves solvability for ANY finite group of squarefree order (e.g. |G| = 30 = 2·3·5, |G| = 105 = 3·5·7, etc.) — but does NOT extend to `pᵃqᵇ` with `a ≥ 2` or `b ≥ 2` since `p²` is not squarefree. The genuine gap is exactly orders divisible by `p²` for some prime.",
-      "S4 — Path forward narrows: the next sub-cases are `|G| = p²q` (~50-100 lines via Sylow analysis), `|G| = pq²` (symmetric), and `|G| = p²q²` (more delicate). Each subsumes a specific instance of `burnside_pq_nontrivial` axiom-free. The Goldschmidt-Matsuyama route (~200-400 lines on top of `Mathlib.GroupTheory.Focal`) closes ALL remaining cases at once."
+      "S4 — Path forward narrows: the next sub-cases are `|G| = p²q` (~50-100 lines via Sylow analysis), `|G| = pq²` (symmetric), and `|G| = p²q²` (more delicate). Each subsumes a specific instance of `burnside_pq_nontrivial` axiom-free. The Goldschmidt-Matsuyama route (~200-400 lines on top of `Mathlib.GroupTheory.Focal`) closes ALL remaining cases at once.",
+      "S8 (2026-05-08): The `|G| = 12` case is uniquely exceptional among `|G| = p²·q` because `(2, 3)` are the *only* consecutive primes — and `q = p + 1` is the precise condition under which Sylow's third theorem alone fails to force a normal Sylow.",
+      "S8 (2026-05-08): When `n_3 = 4` in `|G| = 12`: pairwise trivial intersection of the 4 Sylow 3-subgroups (each cyclic of prime order 3) gives `1 + 4·2 = 9` elements satisfying `g^3 = 1`. The remaining 3 elements (with identity) form a 4-element set that must coincide with any Sylow 2-subgroup (each P has |P\\{1}| = 3 elements of order ≠ 3), forcing `n_2 = 1`. This is the classical `A₄` argument: `n_3 = 4` is the actual Sylow count for A₄, and the unique Sylow 2-subgroup is `V₄` (Klein four-group).",
+      "S8 (2026-05-08): Element-counting in Lean 4 will require ~180 lines (originally estimated ~70), because `Set.ncard_biUnion` / `Finset.card_biUnion` with disjointness side-conditions, plus `{g : g^3 = 1}` as a Finset, takes substantial setup. Alternative: use `Subgroup.normalCore` of the Sylow 3-subgroup as a kernel of the action `G →* Equiv.Perm (G ⧸ Q)`, requiring `IsSolvable (Equiv.Perm (Fin 4))` from Mathlib (name verification needed)."
     ],
     "mathlibGaps": [
       "No `theorem Group.burnside_pq` — Burnside's p^a q^b theorem.",
@@ -107,14 +113,12 @@
       "No 'minimal counterexample' tactic infrastructure for finite-group induction proofs — would be a useful methodological add."
     ],
     "nextSteps": [
-      "S2 DONE: Phase-2 scaffold committed. proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean created with 5 axiom-free theorems + 1 axiom. Trivial cases proved. Gallery entry created.",
-      "S3 DONE: Sharpness witness committed. burnside_pq_sharp formalizes |A₅| = 60 = 2²·3·5 non-solvable.",
-      "S4 DONE: Squarefree-order axiom-narrowing committed. squarefreeOrder_isSolvable + burnside_pq_pq_case prove the a=b=1 case axiom-free; axiom narrowed to require 2 ≤ a ∨ 2 ≤ b.",
-      "Session 5 (next sub-case): Prove `|G| = p² · q` axiom-free via Sylow analysis. The classical argument: count Sylow p-subgroups and Sylow q-subgroups via Sylow's third theorem; one of them must be normal (trivially or via cardinality bounds), giving an abelian-by-abelian extension. Estimated ~50-100 lines. After this, narrow the axiom further to `3 ≤ a ∨ 3 ≤ b` (excluding p²q and pq²).",
-      "Session 6 (next sub-case, symmetric): Prove `|G| = p · q²` axiom-free. Symmetric to Session 5; ~30-50 lines if structured well.",
-      "Session 7 (next sub-case): Prove `|G| = p² · q²` axiom-free. More delicate Sylow analysis; ~80-150 lines. After this, narrow further.",
-      "Session 8+ (Goldschmidt-Matsuyama): Build focal subgroup theorem on top of `Mathlib.GroupTheory.Focal` (some scaffolding already exists), apply transfer to a Sylow p-subgroup, derive P ∩ G' < P contradicting G = G'. ~200-400 lines. Closes ALL remaining cases of `burnside_pq_nontrivial`.",
-      "Final session: replace `axiom burnside_pq_nontrivial` with theorem; sync meta.json; submit Mathlib upstream PR (estimated ~1000 lines total)."
+      "(S8) Implement burnside_p_squared_q_twelve per session-8-twelve-spec.md (~180 lines).",
+      "(post-S8) Augment burnside_pq dispatch to peel off (a,b)=(2,1) axiom-free.",
+      "(S8') Symmetric (1,2) shape: burnside_p_q_squared_*.",
+      "(S9) |G| = p²·q² Sylow analysis (~150 lines).",
+      "(S10+) Goldschmidt-Matsuyama on Mathlib.GroupTheory.Focal.",
+      "(Final) Replace burnside_pq_nontrivial axiom; submit Mathlib upstream PR."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Detailed specification for **S8** — the final sub-case of the `(a, b) = (2, 1)` shape of `burnside_pq_nontrivial`: the exceptional `(p, q) = (2, 3), |G| = 12` (the classical A₄ shape).

S7 (PR #17114) and S7.5 (PR #17155) discharged `(a, b) = (2, 1)` axiom-free for all `(p, q)` *except* this exceptional pair (S7.5 explicitly excluded `(2, 3)` via `hexc`). S8 closes this last gap.

## Why this is spec-only

- This host's `proofs/.lake` is a recursive self-symlink → ≥45 min Mathlib re-clone per build.
- Recent S7/S7.5 PRs landed as "build pending" for the same reason.
- This iteration produces the build-ready spec only; implementation deferred to a host with intact `.lake` (or a future iteration on this host once repaired).

## Mathematical core

For `|G| = 12`, Sylow's third theorem gives `n_3 ∈ {1, 4}`:

- **`n_3 = 1`**: Sylow 3-subgroup `Q` is normal, discharge via `burnside_pq_with_normal_qSylow`.
- **`n_3 = 4`**: Element-counting forces `n_2 = 1`. The 4 Sylow 3-subgroups are cyclic of prime order 3, so distinct ones intersect trivially. Their union has `1 + 4·2 = 9` elements (those satisfying `g^3 = 1`). The remaining 3 elements (with identity) form a 4-element set that must coincide with any Sylow 2-subgroup `P` — since `|P \ {1}| = 3` and these 3 elements all have order in `{2, 4}`, fitting exactly. So `n_2 = 1` and `P` is normal; discharge via `burnside_pq_with_normal_pSylow`.

The argument exploits the unique fact that for `|G| = 12`, `|G| − (n_3·2 + 1) = |P| − 1` exactly (this fails for `|G| = 18` etc).

## Files changed

| File | Change |
|---|---|
| `research/problems/abel-ruffini-galois-extensions-oq-07/session-8-twelve-spec.md` | NEW — ~320 lines: math core, Lean 4 skeleton (5 helpers + main, ~180 lines estimated), Mathlib API inventory, alternative path via `Subgroup.normalCore`, build strategy. |
| `state.md` | Iteration tracker → 8; replaces stale Next Action listing S7.5 (merged); records S7+S7.5 status. |
| `knowledge.md` | Adds S8 element-counting insight; generalization caveat to `|G| = 18`; refreshed Path Forward referencing merged PRs. |
| `src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json` | iteration 7→8; +3 S8 insights, +3 built items; refreshed nextSteps. |

## Status

**Outcome**: surveyed (spec-only)
**Next**: implement `session-8-twelve-spec.md` on a host with intact `.lake`. After S8 lands and the symmetric S8' (`(1, 2)` shape) is added, the `burnside_pq` dispatch can peel off both `(2, 1)` and `(1, 2)` axiom-free, narrowing `burnside_pq_nontrivial` to `(2 ≤ a ∧ 2 ≤ b)`.

**No Lean changes. No build dependency.** Pure documentation + spec.

🤖 Generated by researcher-1