### PR TITLE
research(erdos-203): S1 — extend failing-case computational baseline (m=41..61)

### DIFF
--- a/proofs/Proofs/Erdos203Problem.lean
+++ b/proofs/Proofs/Erdos203Problem.lean
@@ -254,6 +254,46 @@ theorem thirtyseven_fails : ¬ AvoidsPrimes 37 := by
   intro ⟨_, h⟩
   have := h 2 0; simp only [candidateNumber] at this; norm_num at this
 
+-- m = 41: 2*41+1 = 83 is prime
+theorem fortyone_fails : ¬ AvoidsPrimes 41 := by
+  intro ⟨_, h⟩
+  have := h 1 0; simp only [candidateNumber] at this; norm_num at this
+
+-- m = 43: 4*43+1 = 173 is prime
+theorem fortythree_fails : ¬ AvoidsPrimes 43 := by
+  intro ⟨_, h⟩
+  have := h 2 0; simp only [candidateNumber] at this; norm_num at this
+
+-- m = 47: 6*47+1 = 283 is prime
+theorem fortyseven_fails : ¬ AvoidsPrimes 47 := by
+  intro ⟨_, h⟩
+  have := h 1 1; simp only [candidateNumber] at this; norm_num at this
+
+-- m = 49: 4*49+1 = 197 is prime
+theorem fortynine_fails : ¬ AvoidsPrimes 49 := by
+  intro ⟨_, h⟩
+  have := h 2 0; simp only [candidateNumber] at this; norm_num at this
+
+-- m = 53: 2*53+1 = 107 is prime
+theorem fiftythree_fails : ¬ AvoidsPrimes 53 := by
+  intro ⟨_, h⟩
+  have := h 1 0; simp only [candidateNumber] at this; norm_num at this
+
+-- m = 55: 6*55+1 = 331 is prime
+theorem fiftyfive_fails : ¬ AvoidsPrimes 55 := by
+  intro ⟨_, h⟩
+  have := h 1 1; simp only [candidateNumber] at this; norm_num at this
+
+-- m = 59: 12*59+1 = 709 is prime
+theorem fiftynine_fails : ¬ AvoidsPrimes 59 := by
+  intro ⟨_, h⟩
+  have := h 2 1; simp only [candidateNumber] at this; norm_num at this
+
+-- m = 61: 6*61+1 = 367 is prime
+theorem sixtyone_fails : ¬ AvoidsPrimes 61 := by
+  intro ⟨_, h⟩
+  have := h 1 1; simp only [candidateNumber] at this; norm_num at this
+
 -- Structural: if m is avoiding primes, then m+1, 2m+1, 3m+1 are all composite
 theorem avoiding_implies_composites (m : ℕ) (h : AvoidsPrimes m) :
     ¬ (m + 1).Prime ∧ ¬ (2 * m + 1).Prime ∧ ¬ (3 * m + 1).Prime := by

--- a/src/data/proofs/erdos-203/meta.json
+++ b/src/data/proofs/erdos-203/meta.json
@@ -57,9 +57,9 @@
       "erdos_203_statement theorem: formal main statement"
     ],
     "axiomCount": 0,
-    "lineCount": 350,
+    "lineCount": 390,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
-    "theoremCount": 36,
+    "theoremCount": 44,
     "definitionCount": 13
   },
   "overview": {
@@ -164,9 +164,9 @@
       "Nat"
     ],
     "namespace": "Erdos203",
-    "lineCount": 350,
+    "lineCount": 390,
     "axiomCount": 0,
-    "theoremCount": 36,
+    "theoremCount": 44,
     "definitionCount": 13,
     "path": "Proofs/Erdos203Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the "small m fails" computational baseline in `Erdos203Problem.lean` from m ≤ 37 to m ≤ 61 by adding eight new failing-case theorems, one for each odd m ∈ {41, 43, 47, 49, 53, 55, 59, 61} coprime to 6.

For each such m we exhibit a single small (k, l) pair such that `2^k · 3^l · m + 1` is prime, witnessing m ∉ AvoidingSet.

## What's new

| m  | (k, l) | candidate     | prime |
|----|--------|---------------|-------|
| 41 | (1, 0) | 2·41+1 = 83   | ✓     |
| 43 | (2, 0) | 4·43+1 = 173  | ✓     |
| 47 | (1, 1) | 6·47+1 = 283  | ✓     |
| 49 | (2, 0) | 4·49+1 = 197  | ✓     |
| 53 | (1, 0) | 2·53+1 = 107  | ✓     |
| 55 | (1, 1) | 6·55+1 = 331  | ✓     |
| 59 | (2, 1) | 12·59+1 = 709 | ✓     |
| 61 | (1, 1) | 6·61+1 = 367  | ✓     |

Each `*_fails` theorem is a one-liner in the existing pattern:
```lean
theorem fortyone_fails : ¬ AvoidsPrimes 41 := by
  intro ⟨_, h⟩
  have := h 1 0; simp only [candidateNumber] at this; norm_num at this
```

No new imports, no new tactics, no axioms, no sorries.

## Meta updates

- `meta.lineCount`: 350 → 390 (+40)
- `meta.theoremCount`: 36 → 44 (+8)
- `leanFile.lineCount`: 350 → 390 (+40)
- `leanFile.theoremCount`: 36 → 44 (+8)

`axiomCount`, `sorries`, status, badge, crossReferences, sections — unchanged.

## Verification

Each prime witness was independently verified with `sympy.isprime` prior to drafting the Lean proof:

```python
cases = [(41, 1, 0), (43, 2, 0), (47, 1, 1), (49, 2, 0),
         (53, 1, 0), (55, 1, 1), (59, 2, 1), (61, 1, 1)]
# All ((2**k) * (3**l) * m + 1) confirmed prime.
```

The Lean proofs use only `simp only [candidateNumber]` + `norm_num` on small integer arithmetic, which is well-established to succeed in the 13 existing cases (m=1..37). Build status: **pending** (full Mathlib build queue under load).

## Mathematical context

Together with the 13 existing failing-case theorems (m ≤ 37), the gallery entry now witnesses that **no m ≤ 61 with gcd(m, 6) = 1 lies in AvoidingSet**, a strict extension of the computational lower bound on any potential Erdős-203 counterexample. This is purely a baseline/enumeration extension; the open conjecture itself (existence of any such m) is unaffected.

A natural Session 2 follow-up is to consolidate these per-m theorems into a single `decide`-able Finset claim of the form `∀ m ∈ Finset.Ico 1 62, m.Coprime 6 → ¬ AvoidsPrimes m`. That requires a one-shot reduction of `AvoidsPrimes m` to a decidable predicate (currently it quantifies over all (k, l) ∈ ℕ²), so I left it for a separate iteration.

## Test plan

- [ ] Docker build of `Proofs.Erdos203Problem` (queued — Mathlib cache pressure today)
- [x] Primality of each (k, l) witness verified externally (sympy)
- [x] Meta count integrity: theoremCount = 44 matches `grep -c '^theorem ' Erdos203Problem.lean` (after stripping comments)
- [x] No new sorries / axioms introduced (count unchanged at 0/0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)