### PR TITLE
research(erdos-986-incomplete-01): mark COMPLETED — bookkeeping S2

### DIFF
--- a/research/problems/erdos-986-incomplete-01/knowledge.md
+++ b/research/problems/erdos-986-incomplete-01/knowledge.md
@@ -26,3 +26,29 @@
 
 ### Next Steps
 - PR #9157 merged when deployer runs
+
+## Session 2026-05-08 (Session 2) — Bookkeeping update (researcher-3)
+
+**Mode**: REVISIT
+**Outcome**: completed (no new mathematical work)
+
+### What I Did
+- Verified `proofs/Proofs/Erdos986Problem.lean` on `origin/main`: 224 lines, 0 sorries, 3 axioms (`spencer_1977`, `mattheus_verstraete_2023`, `bohman_keevash_2010`)
+- Verified `src/data/proofs/erdos-986/meta.json` already reflects accurate state (`status: "axiomatized"`, `badge: "axiom"`, `sorries: 0`, `axiomCount: 3`)
+- Updated `src/data/research/problems/erdos-986-incomplete-01.json` `phase`/`status`/`currentState.phase` from `NEW`/`active` → `COMPLETED`/`completed` (S1 work was done but JSON bookkeeping was never advanced)
+- Did NOT add new theorems or attempt to prove existing axioms — see classification below
+
+### Axiom Classification (per role guidance)
+- `spencer_1977`: Probabilistic alterations + Lovász Local Lemma; major Mathlib gap, deep result. NOT provable in a single session.
+- `mattheus_verstraete_2023`: Pseudorandom hypergraph construction from a 2023 breakthrough paper (arXiv:2306.04007). NOT in Mathlib. NOT provable in a single session.
+- `bohman_keevash_2010`: H-free process analysis with martingale concentration. NOT in Mathlib. NOT provable in a single session.
+
+All three are genuine research-level open contributions to the Lean record; they cannot be discharged from Mathlib. Conversion to `theorem ... := by sorry` would be lossy (loses provenance) and would not constitute progress.
+
+### Files Modified
+- `src/data/research/problems/erdos-986-incomplete-01.json` (phase/status bookkeeping)
+
+### Outcome (honest)
+This is a tracker-correction session, not a proof advance. The "incomplete-01" goal (eliminate 1 sorry) was already done in S1. The pool entry is now correctly marked `COMPLETED` so future researchers won't reclaim it.
+
+The full Erdős #986 conjecture for k ≥ 5 remains a genuinely open mathematical problem and is out of scope for this slug.

--- a/src/data/research/problems/erdos-986-incomplete-01.json
+++ b/src/data/research/problems/erdos-986-incomplete-01.json
@@ -1,31 +1,33 @@
 {
   "slug": "erdos-986-incomplete-01",
   "title": "Erdős #986: Ramsey Number Lower Bounds (1 sorry)",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal mathematical investigation: Erdős #986: Ramsey Number Lower Bounds (1 sorry).",
+    "formal": "\\text{Eliminate the 1 sorry in Erdos986Problem.lean}",
+    "plain": "Completion task: eliminate the single sorry in Erdos986Problem.lean (RamseyExists in the where-clause of RamseyNumber).",
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "Sorry was for a FALSE statement (asymmetric colorings can avoid all monochromatic cliques) — replaced with (RamseysTheorem.ramsey_theorem k n h.1 h.2).choose using the existing symmetric Ramsey proof in proofs/Proofs/RamseysTheorem.lean"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "0 sorries — achieved"
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-03T22:29:17.629Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Completion task done in S1 (PR #9157). Bookkeeping update: file has 0 sorries on origin/main; remaining 3 axioms (spencer_1977, mattheus_verstraete_2023, bohman_keevash_2010) are deep research-level results not provable from Mathlib.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completion task done; full Erdős #986 conjecture for k≥5 remains OPEN but is out of scope for this slug.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -60,7 +62,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T22:29:17.628Z",
-  "lastUpdate": "2026-04-03T22:29:17.628Z",
+  "lastUpdate": "2026-05-08T17:46:00Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

S1 (2026-04-03) closed the *erdos-986-incomplete-01* completion task — eliminated the sole sorry in `proofs/Proofs/Erdos986Problem.lean` and PR #9157 merged. However the candidate-pool / problem-JSON bookkeeping was never advanced past `phase=NEW / status=active`, leaving the slug vulnerable to future re-claim. This PR is a **tracker correction**, not a proof advance.

## Changes

- `src/data/research/problems/erdos-986-incomplete-01.json`
  - `phase`: `NEW` → `COMPLETED`
  - `status`: `active` → `completed`
  - `currentState.phase`: `NEW` → `COMPLETED`
  - Filled in `problemStatement.formal`/`plain`, `knownResults.proven`/`goal`, `currentState.focus`/`nextAction`, `attemptCounts`
  - Refreshed `lastUpdate`
- `research/problems/erdos-986-incomplete-01/knowledge.md`
  - Appended **Session 2** entry documenting the bookkeeping change and classifying the remaining 3 axioms

## Verification

```
$ git show origin/main:proofs/Proofs/Erdos986Problem.lean | wc -l
224

$ git show origin/main:proofs/Proofs/Erdos986Problem.lean | grep -c "^axiom "
3

$ git show origin/main:proofs/Proofs/Erdos986Problem.lean | grep -c "sorry"
0
```

The 3 axioms are:
- `spencer_1977` (R(3,n) ≫ n²/log n)
- `mattheus_verstraete_2023` (R(4,n) ≫ n³/(log n)^c, arXiv:2306.04007)
- `bohman_keevash_2010` (general R(k,n) lower bound via H-free process)

All three are deep research-level results not in Mathlib. None are convertible to `theorem ... := by sorry` as a routine task — they require probabilistic methods (Lovász Local Lemma, martingale concentration, pseudorandom hypergraph constructions) that are major Mathlib gaps.

`src/data/proofs/erdos-986/meta.json` already correctly carries `status: "axiomatized"`, `badge: "axiom"`, `sorries: 0`, `axiomCount: 3`.

## Status

**Outcome**: completed (bookkeeping)
**Mathematical delta**: 0 sorries, 0 axioms, 0 theorems
**Next steps**: None for this slug. The full Erdős #986 conjecture for k ≥ 5 remains genuinely open and is out of scope here.

🤖 Generated by researcher-3