### PR TITLE
research(erdos-1150): S7 — Rudin-Shapiro pair definition + recursive identities

### DIFF
--- a/proofs/Proofs/Erdos1150Problem.lean
+++ b/proofs/Proofs/Erdos1150Problem.lean
@@ -290,12 +290,61 @@ axiom flat_does_not_imply_ultraflat :
         c₁ * Real.sqrt n ≤ supNorm p ∧ supNorm p ≤ c₂ * Real.sqrt n
 
 /-
-## Rudin-Shapiro Bound
+## Rudin-Shapiro Polynomials
+
+The Rudin-Shapiro construction (Shapiro 1951; Rudin 1959) gives an explicit
+family of Littlewood polynomials with bounded sup-norm-to-√degree ratio.
+The pair `(P_k, Q_k)` is defined recursively by
+
+  P_0 = Q_0 = 1
+  P_{k+1}(z) = P_k(z) + z^{2^k} · Q_k(z)
+  Q_{k+1}(z) = P_k(z) - z^{2^k} · Q_k(z)
+
+By the parallelogram law `|a+b|² + |a-b|² = 2(|a|² + |b|²)` one inductively
+obtains `|P_k(z)|² + |Q_k(z)|² = 2^{k+1}` on the unit circle, hence
+`sup_{|z|=1} |P_k(z)| ≤ √(2^{k+1})`. Combined with `deg P_k = 2^k - 1`
+(for `k ≥ 1`), this yields `supNorm P_k / √(deg P_k) ≤ √2` asymptotically:
+the best known *explicit* bound for Littlewood polynomials.
+
+This section records the recursive definition and its definitional unfolding
+identities, providing the foundation for proving the sup-norm bound (left to
+future iterations; cf. closed PR #7666 for an attempted full proof).
 -/
 
-/-- **Rudin-Shapiro polynomials** give a concrete family with
-    max_{|z|=1} |P(z)| ≤ √(2(n+1)) for degree n.
-    These are Littlewood polynomials with bounded sup norm. -/
+/-- The **Rudin-Shapiro polynomial pair** `(P_k, Q_k)`, defined recursively:
+
+  - `P_0 = Q_0 = 1`
+  - `P_{k+1} = P_k + X^{2^k} · Q_k`
+  - `Q_{k+1} = P_k - X^{2^k} · Q_k`
+
+These are the canonical concrete examples of Littlewood polynomials with
+bounded sup-norm-to-√degree ratio. -/
+noncomputable def rudinShapiroPair : ℕ → Polynomial ℂ × Polynomial ℂ
+  | 0 => (1, 1)
+  | k + 1 =>
+      let prev := rudinShapiroPair k
+      (prev.1 + X ^ (2 ^ k) * prev.2, prev.1 - X ^ (2 ^ k) * prev.2)
+
+/-- The **Rudin-Shapiro `P`-polynomial**: first component of `rudinShapiroPair`. -/
+noncomputable def rudinShapiroP (k : ℕ) : Polynomial ℂ := (rudinShapiroPair k).1
+
+/-- The **Rudin-Shapiro `Q`-polynomial**: second component of `rudinShapiroPair`. -/
+noncomputable def rudinShapiroQ (k : ℕ) : Polynomial ℂ := (rudinShapiroPair k).2
+
+/-- Base case: `P_0 = 1`. -/
+theorem rudinShapiroP_zero : rudinShapiroP 0 = 1 := rfl
+
+/-- Base case: `Q_0 = 1`. -/
+theorem rudinShapiroQ_zero : rudinShapiroQ 0 = 1 := rfl
+
+/-- Recursive identity for `P`: `P_{k+1} = P_k + X^{2^k} · Q_k`. -/
+theorem rudinShapiroP_succ (k : ℕ) :
+    rudinShapiroP (k + 1) = rudinShapiroP k + X ^ (2 ^ k) * rudinShapiroQ k := rfl
+
+/-- Recursive identity for `Q`: `Q_{k+1} = P_k - X^{2^k} · Q_k`. -/
+theorem rudinShapiroQ_succ (k : ℕ) :
+    rudinShapiroQ (k + 1) = rudinShapiroP k - X ^ (2 ^ k) * rudinShapiroQ k := rfl
+
 /-
 ## Summary
 -/

--- a/research/problems/erdos-1150/knowledge.md
+++ b/research/problems/erdos-1150/knowledge.md
@@ -106,4 +106,50 @@ Initial formalization: definitions, conjecture statement, axiomatized known resu
 
 ---
 
-*Updated by researcher-3 on 2026-03-28*
+### Sessions 6 (2026-03-29, researcher-6) — closed
+
+PR #7666 attempted to prove `rudin_shapiro_bound` constructively (159 LOC) but was
+closed due to an unrelated `ShannonChannelCoding.lean` merge conflict in a large
+batched PR. The Rudin-Shapiro work was never re-replayed onto fresh main.
+
+Subsequent audit/mechanic PRs (#11855, #14747, #14752) cleaned up phantom axiom
+claims and section line drift. Current state has only 3 axioms (rudin_shapiro_bound
+and kahane_unimodular_ultraflat were never present in source despite being
+listed in old meta).
+
+### Session 7 (2026-05-08, researcher-6)
+
+**What Was Done:**
+- Replaced the orphan-docstring stub Rudin-Shapiro section with formal infrastructure
+- Added `rudinShapiroPair : ℕ → Polynomial ℂ × Polynomial ℂ` (recursive definition)
+- Added `rudinShapiroP, rudinShapiroQ` (first/second component projections)
+- Added 4 definitional unfolding theorems by `rfl`:
+  - `rudinShapiroP_zero : rudinShapiroP 0 = 1`
+  - `rudinShapiroQ_zero : rudinShapiroQ 0 = 1`
+  - `rudinShapiroP_succ : rudinShapiroP (k+1) = rudinShapiroP k + X^(2^k) * rudinShapiroQ k`
+  - `rudinShapiroQ_succ : rudinShapiroQ (k+1) = rudinShapiroP k - X^(2^k) * rudinShapiroQ k`
+- 390 lines (+49), 13 theorems (+4), 7 definitions (+3), 3 axioms (unchanged), 0 sorries
+
+**Why This Matters:**
+This provides the foundation for the parallelogram-law induction
+`|P_k(z)|² + |Q_k(z)|² = 2^{k+1}` on the unit circle — the key step toward
+proving `supNorm P_k ≤ √(2^{k+1})` and hence the explicit `√2` constant.
+With these recursive identities available, future iterations can prove:
+1. `rs_norm_sq_sum`: `|P_k(z)|² + |Q_k(z)|² = 2^{k+1}` (parallelogram induction)
+2. `rs_degree`: `(rudinShapiroP k).natDegree = 2^k - 1` for `k ≥ 1`
+3. `rs_littlewood`: `IsLittlewoodPolynomial (rudinShapiroP k)` (joint induction)
+4. `rudin_shapiro_bound`: `supNorm (rudinShapiroP k) ≤ Real.sqrt (2 * 2^k)`
+
+**Build Status:** PR built only at the syntactic/definitional level via `rfl` —
+the constructions use only standard `Polynomial.X` and pair projections.
+Build pending CI verification.
+
+**Next Steps:**
+- Prove `rs_norm_sq_sum` via parallelogram law on the unit circle (`|z| = 1`)
+- Prove the degree formula and Littlewood property via joint induction
+- Combine into `rudin_shapiro_bound` to give a 4th proved theorem about the
+  state of knowledge for #1150 (independent of axioms)
+
+---
+
+*Updated by researcher-6 on 2026-05-08*

--- a/research/problems/erdos-1150/state.md
+++ b/research/problems/erdos-1150/state.md
@@ -1,27 +1,33 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T16:24:55.487Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-05-08
+**Iteration**: 7
 
 ## Current Focus
 
-Initial exploration of the problem.
+Building Rudin-Shapiro constructive infrastructure toward an explicit upper
+bound on supNorm P_k / √(deg P_k).
 
 ## Active Approach
 
-None yet.
+Recursive definition + structural theorems. Session 7 added the pair definition
+`rudinShapiroPair` and 4 definitional unfolding identities. Next iterations
+should prove the parallelogram-law identity `|P_k|² + |Q_k|² = 2^{k+1}` and the
+Littlewood / degree formulas, then combine to give a 4th proved theorem.
 
 ## Blockers
 
-None.
+None. Build verification pending CI.
 
 ## Next Action
 
-Begin problem exploration.
+Prove `rs_norm_sq_sum`: `∀ z : ℂ, ‖z‖ = 1 → ‖(rudinShapiroP k).eval z‖² + ‖(rudinShapiroQ k).eval z‖² = 2^(k+1)`
+via induction on k using the parallelogram law on the recursive identities
+`rudinShapiroP_succ` and `rudinShapiroQ_succ`.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 7
+- Current approach attempts: 1
+- Approaches tried: 1 (Rudin-Shapiro construction)

--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/1150",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-11",
-    "dateUpdated": "2026-03-28",
+    "dateUpdated": "2026-05-08",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "Definition IsLittlewoodPolynomial, supNorm, IsUltraflat, Erdos1150Conjecture",
@@ -35,15 +35,18 @@
       "Proved conjecture_equiv_no_ultraflat (full iff, both directions proved)",
       "Proved bbmst_upper_bound_exists (sup-norm bound from BBMST pointwise bound via ciSup_le)",
       "Proved erdos_1150_summary (Parseval + BBMST + equivalence combined)",
+      "Definition rudinShapiroPair, rudinShapiroP, rudinShapiroQ (recursive Rudin-Shapiro polynomial pair)",
+      "Proved rudinShapiroP_zero, rudinShapiroQ_zero (base-case identities P_0 = Q_0 = 1)",
+      "Proved rudinShapiroP_succ, rudinShapiroQ_succ (recursive unfolding identities)",
       "Axiom parseval_lower_bound (sup ≥ √(n+1), Parseval/DFT)",
       "Axiom bbmst_flat (flat Littlewood polynomials exist, BBMST 2019)",
       "Axiom flat_does_not_imply_ultraflat (BBMST ratio bounded but not converging to 1)"
     ],
     "axiomCount": 3,
-    "lineCount": 341,
-    "assumptions": "3 axioms: parseval_lower_bound (Littlewood polynomials have sup norm ≥ √(deg+1), via Parseval/DFT), bbmst_flat (flat Littlewood polynomials with bounded sup-to-√n ratio exist, BBMST 2019), flat_does_not_imply_ultraflat (encodes the BBMST bounded-but-not-converging gap as an explicit witness). 0 sorries. Kahane's unimodular ultraflat theorem and the Rudin-Shapiro construction are referenced in docstrings as background but are NOT axiomatized or formalized in this file.",
-    "theoremCount": 9,
-    "definitionCount": 4
+    "lineCount": 390,
+    "assumptions": "3 axioms: parseval_lower_bound (Littlewood polynomials have sup norm ≥ √(deg+1), via Parseval/DFT), bbmst_flat (flat Littlewood polynomials with bounded sup-to-√n ratio exist, BBMST 2019), flat_does_not_imply_ultraflat (encodes the BBMST bounded-but-not-converging gap as an explicit witness). 0 sorries. Kahane's unimodular ultraflat theorem is referenced in docstrings as background but is NOT axiomatized or formalized. The Rudin-Shapiro construction is now formalized at the definition level (rudinShapiroPair, rudinShapiroP/Q) with recursive unfolding identities; the sup-norm bound itself is left for future iterations.",
+    "theoremCount": 13,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #1150 as part of his investigations into extremal properties of polynomials with restricted coefficients. The study of Littlewood polynomials — polynomials with all coefficients ±1 — dates to J.E. Littlewood's 1966 monograph, where he asked about the minimal sup norm on the unit circle. By Parseval's identity, every degree-$n$ Littlewood polynomial satisfies $\\max_{|z|=1}|P(z)| \\ge \\sqrt{n+1}$, since the $L^2$ norm equals $\\sqrt{n+1}$. The question is whether this can be improved by a multiplicative constant. Kahane's 1980 breakthrough showed that for general unimodular coefficients ($|a_k| = 1$, complex phases allowed), ultraflat polynomials exist — the sup norm can be made $(1+o(1))\\sqrt{n}$. This made the ±1 restriction the essential barrier. The problem gained renewed attention after Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (BBMST, 2019) proved flat Littlewood polynomials exist ($c_1\\sqrt{n} \\le |P(z)| \\le c_2\\sqrt{n}$), resolving Erdős Problem #228. But flat is weaker than ultraflat: the gap between 'bounded ratio' and 'ratio converging to 1' is precisely what Problem #1150 asks about. The Rudin-Shapiro polynomials, constructed recursively since the 1950s, provide the best explicit examples with sup norm at most $\\sqrt{2(n+1)}$.",
@@ -115,23 +118,23 @@
     },
     {
       "id": "rudin-shapiro",
-      "title": "Rudin-Shapiro Bound",
+      "title": "Rudin-Shapiro Polynomials",
       "startLine": 292,
-      "endLine": 298,
-      "summary": "Discusses the Rudin-Shapiro construction in a docstring as background context: for each k ≥ 1, a degree-(2^k - 1) Littlewood polynomial with sup norm at most √(2·2^k), the best known explicit upper bound on minimal sup norm. NOT axiomatized or formalized in this file.",
-      "mathContext": "Discusses the Rudin-Shapiro construction in a docstring as background context: for each k $\\geq$ 1, a degree-($2^{k}$ - 1) Littlewood polynomial with sup norm at most √(2·$2^{k}$), the best known explicit upper bound on minimal sup norm. NOT axiomatized or formalized in this file."
+      "endLine": 346,
+      "summary": "Records the recursive Rudin-Shapiro polynomial pair (P_k, Q_k): rudinShapiroPair, rudinShapiroP, rudinShapiroQ, with base cases P_0 = Q_0 = 1 (rudinShapiroP_zero, rudinShapiroQ_zero) and recursive unfolding identities P_{k+1} = P_k + X^{2^k}·Q_k and Q_{k+1} = P_k - X^{2^k}·Q_k (rudinShapiroP_succ, rudinShapiroQ_succ). Provides the foundation for proving the parallelogram identity |P_k|² + |Q_k|² = 2^{k+1} and the resulting sup-norm bound; those proofs are left to future iterations.",
+      "mathContext": "Records the recursive Rudin-Shapiro polynomial pair $(P_k, Q_k)$ with base cases $P_0 = Q_0 = 1$ and recursive unfolding identities $P_{k+1} = P_k + X^{2^{k}} \\cdot Q_k$, $Q_{k+1} = P_k - X^{2^{k}} \\cdot Q_k$. Foundation for the parallelogram identity $|P_k|^2 + |Q_k|^2 = 2^{k+1}$ and the explicit $\\sqrt{2}$ sup-norm-to-$\\sqrt{n}$ ratio."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 299,
-      "endLine": 341,
+      "startLine": 348,
+      "endLine": 390,
       "summary": "Packages Parseval bound + BBMST flat existence + ultraflat equivalence into erdos_1150_summary, proved from axioms. Now includes the equivalence conjecture ↔ ¬ultraflat as a proved component.",
       "mathContext": "Axiomatized: Packages Parseval bound + BBMST flat existence + ultraflat equivalence into erdos_1150_summary, proved from axioms. Now includes the equivalence conjecture ↔ ¬ultraflat as a proved component."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1150, an open question in extremal polynomial theory. The conjecture asks whether the sup norm of degree-$n$ Littlewood polynomials on the unit circle must exceed $(1+c)\\sqrt{n}$ for some universal $c > 0$ — equivalently, whether ultraflat Littlewood polynomials do not exist. Axioms encoded: Parseval lower bound (parseval_lower_bound), BBMST flat polynomials (bbmst_flat, 2019), and the BBMST bounded-but-not-converging gap (flat_does_not_imply_ultraflat). Key theorems proved: full equivalence conjecture ↔ no ultraflat (both directions), BBMST sup-norm bound, Parseval ratio bound, DFT orthogonality lemmas, and a combined summary. Contains 0 sorries and 3 axioms encoding deep external results. Kahane's unimodular ultraflat theorem and the Rudin-Shapiro construction are referenced in docstrings as background context but are NOT axiomatized or formalized in this file. Uses subsequence-based IsUltraflat definition for mathematical correctness.",
+    "summary": "This formalization captures Erdős Problem #1150, an open question in extremal polynomial theory. The conjecture asks whether the sup norm of degree-$n$ Littlewood polynomials on the unit circle must exceed $(1+c)\\sqrt{n}$ for some universal $c > 0$ — equivalently, whether ultraflat Littlewood polynomials do not exist. Axioms encoded: Parseval lower bound (parseval_lower_bound), BBMST flat polynomials (bbmst_flat, 2019), and the BBMST bounded-but-not-converging gap (flat_does_not_imply_ultraflat). Key theorems proved: full equivalence conjecture ↔ no ultraflat (both directions), BBMST sup-norm bound, Parseval ratio bound, DFT orthogonality lemmas, and a combined summary. The Rudin-Shapiro construction is now formalized at the definition level (rudinShapiroPair, rudinShapiroP, rudinShapiroQ) with recursive unfolding identities, providing the foundation for proving the parallelogram identity $|P_k|^2 + |Q_k|^2 = 2^{k+1}$ and the resulting $\\sqrt{2}$ sup-norm-to-$\\sqrt{n}$ ratio. Contains 0 sorries and 3 axioms encoding deep external results. Kahane's unimodular ultraflat theorem is referenced in docstrings as background context but is NOT axiomatized or formalized. Uses subsequence-based IsUltraflat definition for mathematical correctness.",
     "implications": "**Theoretical Significance**: A positive resolution (confirming the conjecture) would establish that the discrete structure of {-1,+1} coefficients imposes a fundamental rigidity on polynomial behavior on the unit circle — a qualitative separation from the continuous case |$a_k$| = 1.\n\nThis would connect to concentration of measure phenomena and Boolean function analysis. A negative resolution (constructing ultraflat ±1 polynomials) would be equally striking, requiring new techniques beyond BBMST's probabilistic approach.",
     "openQuestions": [
       "Does the conjecture hold: is $\\inf_{P \\in \\mathcal{L}_n} \\|P\\|_\\infty / \\sqrt{n} > 1$ for all large $n$?",
@@ -168,10 +171,10 @@
       "Filter"
     ],
     "namespace": "Erdos1150",
-    "lineCount": 341,
+    "lineCount": 390,
     "axiomCount": 3,
-    "theoremCount": 9,
-    "definitionCount": 4,
+    "theoremCount": 13,
+    "definitionCount": 7,
     "path": "Proofs/Erdos1150Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary
Session 7 of erdos-1150 (Supremum of Littlewood Polynomials). Adds Rudin-Shapiro polynomial pair infrastructure as a foundation for proving the explicit `√2` bound on `supNorm P_k / √(deg P_k)`.

## What Changed
- `noncomputable def rudinShapiroPair : ℕ → Polynomial ℂ × Polynomial ℂ`
  - `P_0 = Q_0 = 1`
  - `P_{k+1} = P_k + X^{2^k} · Q_k`
  - `Q_{k+1} = P_k - X^{2^k} · Q_k`
- `rudinShapiroP`, `rudinShapiroQ` (component projections)
- 4 definitional unfolding theorems by `rfl`:
  - `rudinShapiroP_zero`, `rudinShapiroQ_zero` (base cases)
  - `rudinShapiroP_succ`, `rudinShapiroQ_succ` (recursive identities)

Also replaces the orphan-docstring stub at the prior `## Rudin-Shapiro Bound` header with a proper section comment + formal definitions.

## Why
This is incremental, structural progress toward proving `|P_k(z)|² + |Q_k(z)|² = 2^{k+1}` on the unit circle (parallelogram-law induction), and from there the sup-norm bound `supNorm P_k ≤ √(2^{k+1})` — the best-known *explicit* upper bound for Littlewood polynomials. Closed PR #7666 attempted the full proof in one shot (159 LOC) but was lost to an unrelated `ShannonChannelCoding.lean` batch conflict; this PR establishes the minimal definitional foundation so future iterations can prove the bound incrementally.

## Counts
| | Before | After |
|---|---|---|
| Lines | 341 | 390 |
| Theorems | 9 | 13 |
| Definitions | 4 | 7 |
| Axioms | 3 | 3 |
| Sorries | 0 | 0 |

The 3 axioms remain `parseval_lower_bound`, `bbmst_flat`, `flat_does_not_imply_ultraflat` (Erdős #1150 is OPEN; status remains `axiomatized`).

## Test Plan
- [ ] CI build passes (Lean 4 / Mathlib 4.26.0)
- [ ] All 4 new `rfl` proofs check (uses only `Polynomial.X` and pair projections — definitionally clean)
- [ ] Gallery render check via `pnpm build` (meta.json sections updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)