### PR TITLE
Enrich Newton log-concavity: canonicalize index.ts + add 3 mainTheorems

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/index.ts
@@ -1,30 +1,40 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, ProofReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AmgmInequalityOQ02OQ02.lean?raw'
 
-const meta = metaJson as {
-  id: string; title: string; slug: string; description: string
-  meta: ProofMeta; sections: ProofSection[]
-  overview?: ProofOverview; conclusion?: ProofConclusion
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
   crossReferences?: CrossReference[]
+  references?: ProofReference[]
 }
 
-const leanSource = () => import('../../../../proofs/Proofs/AmgmInequalityOQ02OQ02.lean?raw')
-
-export const proof: Proof = {
-  id: meta.id, title: meta.title, slug: meta.slug,
-  description: meta.description, meta: meta.meta,
-  sections: meta.sections, source: '',
-  overview: meta.overview, conclusion: meta.conclusion,
+export const amgmInequalityOQ02OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
   crossReferences: meta.crossReferences,
+  references: meta.references,
 }
 
-export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
-export const proofData: ProofData = { proof, annotations }
+export const amgmInequalityOQ02OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
-export async function getProofSource(): Promise<string> {
-  const module = await leanSource()
-  return module.default
+export const amgmInequalityOQ02OQ02Data: ProofData = {
+  proof: amgmInequalityOQ02OQ02Proof,
+  annotations: amgmInequalityOQ02OQ02Annotations,
 }
 
-export default proofData
+export default amgmInequalityOQ02OQ02Data

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -106,6 +106,29 @@
       "description": "Imports `Proofs.NewtonInductiveStep` for the helper lemmas used in the 520-line `newton_cleared_denom_inductive_step` discriminant argument."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "newton_log_concavity_proved",
+      "type": "core",
+      "statement": "$\\forall n \\in \\mathbb{N},\\ \\forall k \\in \\mathbb{N},\\ 1 \\le k,\\ k+1 \\le n,\\ \\forall x : \\mathrm{Fin}\\,n \\to \\mathbb{R},\\ (\\forall i,\\ 0 \\le x_i) \\Rightarrow \\left(\\frac{e_k(x)}{\\binom{n}{k}}\\right)^2 \\ge \\frac{e_{k-1}(x)}{\\binom{n}{k-1}} \\cdot \\frac{e_{k+1}(x)}{\\binom{n}{k+1}}$",
+      "significance": "**The headline theorem of this file.** Newton's normalized log-concavity inequality for elementary symmetric polynomials of non-negative inputs. Replaces the parent file's `newton_log_concavity` axiom with a constructive proof. The 8-part architecture culminates here: `elemSymm_log_concave` (unnormalized) + `binom_log_concave` + `newton_cleared_denom` are assembled into the normalized form via division by binomials.",
+      "description": "The fundamental log-concavity inequality from Newton's *Arithmetica Universalis* (1707) in its normalized (mean-form) version. Together with `maclaurin_step_derived` it completes the elimination of both axioms `newton_log_concavity` and `maclaurin_step` from the parent `AmgmInequalityOQ02.lean`."
+    },
+    {
+      "name": "maclaurin_step_derived",
+      "type": "core",
+      "statement": "$\\forall n \\in \\mathbb{N},\\ \\forall k \\in \\mathbb{N},\\ 0 < k,\\ k+1 \\le n,\\ \\forall x : \\mathrm{Fin}\\,n \\to \\mathbb{R},\\ (\\forall i,\\ 0 \\le x_i) \\Rightarrow \\left(\\frac{e_k(x)}{\\binom{n}{k}}\\right)^{1/k} \\ge \\left(\\frac{e_{k+1}(x)}{\\binom{n}{k+1}}\\right)^{1/(k+1)}$",
+      "significance": "**The atomic Maclaurin step.** With this single-step inequality and transitivity, the parent file derives the full Maclaurin chain $M_1 \\ge M_2 \\ge \\cdots \\ge M_n$, of which AM ≥ GM is the extreme case $M_1 \\ge M_n$. Eliminates the parent's `maclaurin_step` axiom.",
+      "description": "Takes $k$-th and $(k+1)$-th roots of the cleared-denominator Newton inequality. Uses `power_ineq_of_log_concave` (Nat-power form $a_k^{k+1} \\ge a_{k+1}^k$) followed by `rpow_ineq_of_pow_ineq` to transfer to the real-power (rpow) form."
+    },
+    {
+      "name": "elemSymm_log_concave",
+      "type": "supporting",
+      "statement": "$\\forall n \\in \\mathbb{N},\\ \\forall k \\in \\mathbb{N},\\ 1 \\le k,\\ k+1 \\le n,\\ \\forall x : \\mathrm{Fin}\\,n \\to \\mathbb{R},\\ (\\forall i,\\ 0 \\le x_i) \\Rightarrow e_k(x)^2 \\ge e_{k-1}(x) \\cdot e_{k+1}(x)$",
+      "significance": "**The unnormalized Newton inequality.** Proved by induction on $n$ using the Newton-Girard recurrence $e_k(x, t) = e_k(x) + t \\cdot e_{k-1}(x)$ and `cross_product_of_log_concave`. The base case $n=1$ is trivial; the inductive step expands both sides and reduces to a quadratic-in-$t$ whose discriminant is bounded by the inductive hypothesis. Together with `binom_log_concave` it gives the normalized form `newton_log_concavity_proved`.",
+      "description": "The classical Newton inequality without normalization by binomial coefficients. Direct corollary of the inductive proof in Part II; serves as the building block for the cleared-denominator form in Parts IV–V."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.AmgmInequalityOQ02",


### PR DESCRIPTION
## Summary

### Critical fix
- **index.ts**: replaces the async-loader pattern with the canonical sibling pattern. The previous version forced \`source: ''\` so the live site never displayed the Lean source code for this 959-line proof. Now imports raw via \`?raw\` and exposes canonical \`amgmInequalityOQ02OQ02Proof / Annotations / Data\` exports. Added references passthrough.

### Content additions
- **mainTheorems**: was missing entirely. Added 3 entries for this 959-line, 18-theorem file's headline results:
  - \`newton_log_concavity_proved\` (core) — normalized Newton inequality \$(e_k/\\binom{n}{k})^2 \\ge (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})\$. Eliminates the parent's \`newton_log_concavity\` axiom.
  - \`maclaurin_step_derived\` (core) — atomic Maclaurin step \$M_k \\ge M_{k+1}\$. Eliminates the parent's \`maclaurin_step\` axiom.
  - \`elemSymm_log_concave\` (supporting) — unnormalized Newton \$e_k^2 \\ge e_{k-1} \\cdot e_{k+1}\$, proved by induction-on-\$n\$ via the Newton-Girard recurrence and the cross-product lemma. Building block for the normalized form.

## Test plan
- [x] \`tsc --noEmit\`: passes.
- [x] JSON validates.
- [ ] Full \`pnpm build\`: blocked by environment-side \`better-sqlite3\` native-build failure under Node v26; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)