### PR TITLE
fix(meta): follow-up meta-block drift sync (2 entries)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -83,7 +83,7 @@
       "symBUDim_{eleven,thirteen}_even_formula: concrete prime-n closed-form instances symBUDim 11 (2k) = 2k - 1, symBUDim 13 (2k) = 2k - 1 (conditional)"
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` — the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n ≥ 2. The lower-bound direction (`buDim p* d ≤ symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **The n=2 instance of this axiom is redundant** — `symBUDim_eq_largestPrime_two_unconditional` proves it axiom-free from the parent's `symBUDim_two` axiom + `largestPrimeBelow_two`. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime` (counted in the parent gallery entries).",
-    "theoremCount": 33,
+    "theoremCount": 35,
     "definitionCount": 1
   },
   "overview": {

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -67,7 +67,7 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 2,
-    "lineCount": 636,
+    "lineCount": 639,
     "assumptions": "2 axioms (Sessions 11–12 made structural progress on normal_imp_irrational): (1) normal_imp_irrational — normality in any base b ≥ 2 implies irrationality (the count/Tendsto step remains, but the missing-tuple input has been built); (2) e_absolutely_normal — e is absolutely normal (the main open conjecture, 2026). The rational-digits-periodic axiom was discharged in Session 11 via the 3-layer recipe: Layer 1 (eventually_periodic_iterate, S8, orbit pigeonhole), Layer 2 (ratResidue_eventually_periodic, S9, residue sequence in ZMod q.den), Layer 3a (floor_pow_mul_div, S10, ℝ→ℤ cast bridge), Layer 3b (nthDigit_succ_via_residue, S11, integer-arithmetic residue-to-digit bridge). Session 12 added Layer 4a (the Fin b cast bridge): nthDigitFin packages nthDigit's [0, b) bound into Fin b, and rational_has_missing_ktuple composes Layers 1–3 with periodic_has_missing_ktuple to assert that for any rational q some k-tuple never appears in (q : ℝ)'s base-b expansion past a finite cutoff. 29 public theorems including first 9 decimal digits of e proved from exp_one bounds.",
     "mathlib_version": "4.26.0",
     "definitionCount": 3


### PR DESCRIPTION
## Fix

Sync meta-block drift in two entries that PR #17176 left behind.

PR #17176 (open) syncs the **leanFile**-block `lineCount`/`theoremCount`/`definitionCount` for 45 entries but does not touch the duplicated **meta**-block in two cases. The meta block already matches actuality on every other field; only one field per entry remains stale.

## Evidence

### e-transcendental-oq-02

| Field | Before | After | Actual |
|-------|--------|-------|--------|
| `meta.lineCount` | 636 | **639** | 639 |
| `leanFile.lineCount` | 529 | (unchanged) | 639 |

`wc -l proofs/Proofs/ETranscendentalOQ02.lean` → 639. PR #17176 changes `leanFile.lineCount` 529 → 639 in this entry but leaves `meta.lineCount` at 636.

### borsuk-ulam-oq-02-oq-01-oq-03-oq-02

| Field | Before | After | Actual |
|-------|--------|-------|--------|
| `meta.theoremCount` | 33 | **35** | 35 |
| `leanFile.theoremCount` | 35 (already) | (unchanged) | 35 |

Comment-stripped declaration count of `proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` matches `leanFile.theoremCount` already; `meta.theoremCount` lagged behind.

## Conflict analysis

- **vs PR #17176**: Touches different lines (this PR edits `meta.lineCount` line 70 and `meta.theoremCount` line 86; PR #17176 edits `leanFile` block lines 174-177 for e-transcendental, and does not touch borsuk-ulam at all). Rebase-clean either order.
- **vs PR #16869** (research borsuk-ulam): That PR's diff includes `theoremCount: 21 → 33` against an older base; current `main` already has 33, so PR #16869's diff for that field becomes a no-op after rebase. Bumping to 35 is consistent with the actual file content.

## Scope

Surgical 2-line diff. No tracker changes, no narrative changes, no Lean source changes. Pure metadata sync to current reality.

---
Automated fix by lean-mechanic agent.