### PR TITLE
research(erdos-200): Iter 8 — strengthen pnt_green_tao_bracket via monotonicity (build pending)

### DIFF
--- a/proofs/Proofs/Erdos200Problem.lean
+++ b/proofs/Proofs/Erdos200Problem.lean
@@ -43,6 +43,35 @@ def IsPrimeAP (k N : ℕ) : Prop :=
 noncomputable def longestPrimeAP (N : ℕ) : ℕ :=
   sSup {k : ℕ | IsPrimeAP k N}
 
+/-- The set `{k | IsPrimeAP k N}` is bounded above by `N + 1`.
+    Reason: an AP of length k ≥ 1 with common difference d ≥ 1 has last term
+    `a + (k-1)·d ≥ k - 1`, so being ≤ N forces k ≤ N + 1. -/
+private lemma bddAbove_isPrimeAP (N : ℕ) :
+    BddAbove {k : ℕ | IsPrimeAP k N} := by
+  refine ⟨N + 1, ?_⟩
+  rintro k ⟨a, d, hd, _, hle⟩
+  rcases k with _ | k
+  · omega
+  · have hbound := hle k (by omega)
+    have hkd := Nat.le_mul_of_pos_right k hd
+    omega
+
+/-- The set `{k | IsPrimeAP k N}` is nonempty: `k = 0` is always a member
+    (the universally-quantified premises are vacuous for `i < 0`). -/
+private lemma nonempty_isPrimeAP (N : ℕ) :
+    ({k : ℕ | IsPrimeAP k N}).Nonempty :=
+  ⟨0, 1, 1, Nat.one_pos,
+    fun _ hi => (Nat.not_lt_zero _ hi).elim,
+    fun _ hi => (Nat.not_lt_zero _ hi).elim⟩
+
+/-- Monotonicity of `longestPrimeAP`: if `N ≤ N'`, then any prime AP of length k
+    in {1,...,N} is also a prime AP in {1,...,N'}, so the supremum is monotone. -/
+theorem longest_prime_ap_monotone {N N' : ℕ} (h : N ≤ N') :
+    longestPrimeAP N ≤ longestPrimeAP N' := by
+  apply csSup_le_csSup (bddAbove_isPrimeAP N') (nonempty_isPrimeAP N)
+  rintro k ⟨a, d, hd, hp, hle⟩
+  exact ⟨a, d, hd, hp, fun i hi => le_trans (hle i hi) h⟩
+
 /- ## Upper Bound from PNT -/
 
 /- The Prime Number Theorem implies: any AP of primes in {1,...,N}
@@ -174,14 +203,27 @@ theorem ap_difference_primorial (k : ℕ) (_hk : k ≥ 3) :
 
 /- ## Gap Between Green–Tao and Erdős #200 -/
 
-/-- The PNT upper bound and Green–Tao together bracket longestPrimeAP:
-    for any ε > 0 and large N, M ≤ longestPrimeAP N ≤ (1+ε)·log N
-    for all M (since AP length is unbounded). The open problem is
-    whether the lower growth rate is sublogarithmic. -/
+/-- The PNT upper bound and Green–Tao together bracket `longestPrimeAP`:
+    for every target length `M` and every `ε > 0`, there is a threshold `N₀`
+    such that for all `N ≥ N₀`,
+    `M ≤ longestPrimeAP N ≤ (1+ε)·log N`.
+
+    The lower bound `M ≤ longestPrimeAP N` uses Green–Tao together with
+    monotonicity of `longestPrimeAP` in `N`; the upper bound is the PNT
+    axiom. The open problem is whether the lower growth rate is
+    sublogarithmic — i.e., whether `M` may be taken proportional to `log N`
+    or strictly less. -/
 theorem pnt_green_tao_bracket :
-    ∀ ε : ℝ, ε > 0 →
+    ∀ ε : ℝ, ε > 0 → ∀ M : ℕ,
     ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N →
-      ∃ M : ℕ, M ≤ longestPrimeAP N ∧ (longestPrimeAP N : ℝ) ≤ (1 + ε) * Real.log N := by
-  intro ε hε
-  obtain ⟨N₀, hub⟩ := prime_ap_pnt_upper ε hε
-  exact ⟨N₀, fun N hN => ⟨0, Nat.zero_le _, hub N hN⟩⟩
+      M ≤ longestPrimeAP N ∧ (longestPrimeAP N : ℝ) ≤ (1 + ε) * Real.log N := by
+  intro ε hε M
+  obtain ⟨N₁, hub⟩ := prime_ap_pnt_upper ε hε
+  obtain ⟨N_M, hpa⟩ := green_tao M
+  refine ⟨max N₁ N_M, fun N hN => ?_⟩
+  have hN₁ : N₁ ≤ N := le_trans (le_max_left _ _) hN
+  have hN_M : N_M ≤ N := le_trans (le_max_right _ _) hN
+  refine ⟨?_, hub N hN₁⟩
+  have hM_at_N_M : M ≤ longestPrimeAP N_M :=
+    le_csSup (bddAbove_isPrimeAP N_M) hpa
+  exact le_trans hM_at_N_M (longest_prime_ap_monotone hN_M)

--- a/research/problems/erdos-200/state.md
+++ b/research/problems/erdos-200/state.md
@@ -1,27 +1,52 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-12T10:06:12.674Z
-**Iteration**: 1
+**Phase**: ACTIVE_RESEARCH
+**Since**: 2026-05-08
+**Iteration**: 8
 
 ## Current Focus
 
-Initial exploration of the problem.
+Strengthen the structural relationship between Green–Tao (lower bound) and PNT
+(upper bound) on `longestPrimeAP(N)`. The previous `pnt_green_tao_bracket`
+existentially-quantified the lower bound (∃ M ≤ longestPrimeAP N), making it
+trivially satisfiable with M = 0. This iteration makes M a free parameter, so
+the bracket statement now carries genuine content from Green–Tao via
+monotonicity.
 
 ## Active Approach
 
-None yet.
+Factor out two structural lemmas, prove monotonicity, then use it to
+strengthen `pnt_green_tao_bracket`:
+
+1. `bddAbove_isPrimeAP : BddAbove {k | IsPrimeAP k N}` — extracted from the
+   inline `le_csSup` argument used in `longest_prime_ap_unbounded`. Cleanly
+   reusable.
+2. `nonempty_isPrimeAP : {k | IsPrimeAP k N}.Nonempty` — `k = 0` is always a
+   member because the universally-quantified premises are vacuous.
+3. `longest_prime_ap_monotone : N ≤ N' → longestPrimeAP N ≤ longestPrimeAP N'`
+   — direct from `csSup_le_csSup` once the set is `BddAbove` and `Nonempty`.
+4. Strengthened `pnt_green_tao_bracket`:
+   `∀ ε > 0, ∀ M, ∃ N₀, ∀ N ≥ N₀, M ≤ longestPrimeAP N ∧ longestPrimeAP N ≤ (1+ε)·log N`.
+   Proof: pick `N₁` from PNT axiom, `N_M` from Green–Tao, take `N₀ = max N₁ N_M`,
+   apply `le_csSup` at `N_M` then `longest_prime_ap_monotone`.
 
 ## Blockers
 
-None.
+- Build verification deferred (broken `proofs/.lake` symlink in main repo
+  forces a fresh Mathlib clone). Marked PR as build pending per convention.
 
 ## Next Action
 
-Begin problem exploration.
+Iteration 9 candidates:
+- Add concrete `prime_ap_8` (d=210, length-8 starting at 199) and `prime_ap_10`
+  (d=210, length-10 ending at 2089) to push the explicit witness from k=7 to k=10.
+- Prove a *quantitative* lower bound on the smallest N containing a length-k
+  prime AP: combine `ap_difference_primorial` with primorial growth.
+- Replace inline proof in `longest_prime_ap_unbounded` with the factored
+  `bddAbove_isPrimeAP` lemma (cleanup).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 8 (per merged PR history)
+- Current approach attempts: 1
+- Approaches tried: structural-bracket strengthening, monotonicity

--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -65,13 +65,16 @@
       "exists_dvd_in_ap: Helper lemma — ZMod witness for divisibility in APs",
       "ap_difference_primorial: PROVED (was false axiom) — primorial divisibility with corrected hypothesis",
       "prime_ap_3, prime_ap_5, prime_ap_6: PROVED via native_decide — concrete prime AP examples",
-      "pnt_green_tao_bracket: PROVED — combines prime_ap_pnt_upper and Green-Tao to bracket longestPrimeAP between ω(1) and (1+ε)·log N",
-      "prime_ap_7: 7-term prime AP {7, 157, 307, 457, 607, 757, 907} with d=150"
+      "pnt_green_tao_bracket: PROVED (strengthened) — for every M, ε>0, there exists N₀ such that for all N≥N₀, M ≤ longestPrimeAP(N) ≤ (1+ε)·log N. The lower bound is now uniform in N (uses Green-Tao + monotonicity)",
+      "prime_ap_7: 7-term prime AP {7, 157, 307, 457, 607, 757, 907} with d=150",
+      "bddAbove_isPrimeAP: PROVED — the set {k | IsPrimeAP k N} is bounded above by N+1 (factored from inline proof)",
+      "nonempty_isPrimeAP: PROVED — the set {k | IsPrimeAP k N} is nonempty (k=0 is vacuously a member)",
+      "longest_prime_ap_monotone: PROVED — longestPrimeAP is monotone in N, so any prime AP of length k in {1,...,N} extends to {1,...,N'} for N≤N'"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 3,
-    "theoremCount": 8,
-    "lineCount": 187,
+    "theoremCount": 11,
+    "lineCount": 229,
     "assumptions": "3 axioms: prime_ap_pnt_upper (PNT upper bound), green_tao (Green-Tao 2008), erdos_200 (open conjecture). 0 sorries.",
     "mathlib_version": "4.26.0",
     "definitionCount": 3


### PR DESCRIPTION
## Summary

- Strengthen `pnt_green_tao_bracket`: lower bound is now a free parameter `M`, not an existential — making the statement non-trivial
- Factor out three structural lemmas: `bddAbove_isPrimeAP`, `nonempty_isPrimeAP`, `longest_prime_ap_monotone`
- Counts: `theoremCount` 8→11, `lineCount` 187→229. `axiomCount` unchanged (3)

## Theorem comparison

**Before** (trivial — `M = 0` works):
```
∀ ε > 0, ∃ N₀, ∀ N ≥ N₀, ∃ M, M ≤ longestPrimeAP N ∧ longestPrimeAP N ≤ (1+ε) log N
```

**After** (uniform in `M`, uses Green–Tao non-trivially):
```
∀ ε > 0, ∀ M : ℕ, ∃ N₀, ∀ N ≥ N₀, M ≤ longestPrimeAP N ∧ longestPrimeAP N ≤ (1+ε) log N
```

Proof: pick `N₁` from `prime_ap_pnt_upper`, `N_M` from `green_tao M`, take `N₀ = max N₁ N_M`; combine `le_csSup (bddAbove_isPrimeAP N_M) hpa` (giving `M ≤ longestPrimeAP N_M`) with `longest_prime_ap_monotone hN_M` (giving `longestPrimeAP N_M ≤ longestPrimeAP N`).

## Why this matters

The previous bracket statement had no lower content — it was the conjunction of the upper bound axiom with a trivial `0 ≤ longestPrimeAP N`. The strengthened form is the natural statement of "longestPrimeAP N is unbounded uniformly past a threshold and capped by `(1+ε) log N`" — directly useful as the lemma a proof of Erdős #200 (or its negation) would manipulate.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos200Problem` (build deferred — broken `proofs/.lake` symlink in main repo forces a fresh Mathlib clone; using the conventional "build pending" label per recent researcher PRs)
- [x] `axiomCount` unchanged at 3 (no new axioms introduced)
- [x] `meta.json` `theoremCount`/`lineCount` synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)