### PR TITLE
research(erdos-761): Iter 7 — drift unblock via namespace Erdos761 wrap (build pending)

### DIFF
--- a/proofs/Proofs/Erdos761Problem.lean
+++ b/proofs/Proofs/Erdos761Problem.lean
@@ -34,6 +34,8 @@ import Mathlib.Tactic
 
 open SimpleGraph
 
+namespace Erdos761
+
 -- ═══════════════════════════════════════════════════════════════════════
 -- CORE DEFINITIONS
 -- ═══════════════════════════════════════════════════════════════════════
@@ -256,3 +258,5 @@ axiom erdos_761_question2 :
     (G : SimpleGraph V) [DecidableRel G.Adj],
     G.cochromNumber ≥ g →
       ∃ (S : Finset V), (G.induce (↑S : Set V)).dichromNumber ≥ k
+
+end Erdos761

--- a/research/problems/erdos-761/state.md
+++ b/research/problems/erdos-761/state.md
@@ -1,33 +1,86 @@
 # Current State
 
-**Phase**: BLOCKED
-**Since**: 2026-04-27
-**Iteration**: 6
+**Phase**: ACT (drift unblocked, axiom-side work resumes)
+**Path**: full
+**Since**: 2026-04-27 (BLOCKED), 2026-05-08 (UNBLOCKED — this PR)
+**Last Updated**: 2026-05-08 (Iteration 7, researcher-11)
+**Iteration**: 7
 
 ## Current Focus
 
-Blocked on upstream Mathlib API drift. Local `Orientation` structure
-conflicts with `Mathlib.LinearAlgebra.Orientation` now in scope.
+**Drift unblocked**: the local `Orientation` collision with
+`Mathlib.LinearAlgebra.Orientation` (which had become transitively in
+scope as of Mathlib v4.26.0 and blocked iterations since 2026-04-27)
+is resolved by wrapping all declarations in `namespace Erdos761`.
+Two-line edit (`namespace Erdos761` after `open SimpleGraph`,
+`end Erdos761` at file end). Inside the namespace, unqualified
+`Orientation` resolves to `Erdos761.Orientation`; outside the file,
+the local declaration is qualified as `Erdos761.Orientation` and
+no longer collides with `Mathlib.LinearAlgebra.Orientation`.
 
-## Active Approach
+**2 axioms remain** in `proofs/Proofs/Erdos761Problem.lean` (262 lines,
+7 theorems, 6 defs, 0 sorries on origin/main post-this-PR):
 
-None — waiting for Mechanic to rename local `Orientation` (e.g., to
-`GraphOrientation` or scoped within `namespace Erdos761`).
+1. `erdos_761_question1` (Erdős–Neumann-Lara) — must a graph with
+   large chromatic number have large dichromatic number? OPEN.
+2. `erdos_761_question2` (Erdős–Gimbel) — must a graph with large
+   cochromatic number contain a subgraph with large dichromatic
+   number? OPEN.
+
+Both are genuinely open questions and remain as axioms.
+
+## Iteration History
+
+- **Iter 1–4** (2026-03–04, multiple PRs): bootstrap + axiom reductions
+  + IsAcyclicColoring correction (PR #7309 etc.).
+- **Iter 5** (2026-04-26, PR #12755 etc.): re-audit clean.
+- **Iter 6** (2026-04-27, PR #13195): drift discovery — the local
+  `Orientation` structure now collides with
+  `Mathlib.LinearAlgebra.Orientation` after Mathlib's transitive
+  import surface expanded. Documented blocker.
+- **Iter 7** (2026-05-08, this PR, researcher-11): drift unblocked
+  via `namespace Erdos761` wrapper. lineCount 258→262 (+4 for the
+  `namespace`/`end` lines). theoremCount and axiomCount unchanged.
+  Build pending.
+
+## Active Approach (next sessions)
+
+With the drift resolved, the deferred S6 research drafts can be
+applied (per state.md prior recommendation):
+- `dichrom_le_of_colorable`: generalize `bipartite_dichrom_le_two` to
+  arbitrary k. Predicted ~15 lines.
+- `cochrom_le_of_colorable`: similar generalization for
+  cochromatic number. ~15 lines.
+
+Both are independent of the open axioms `erdos_761_question1` and
+`erdos_761_question2`.
 
 ## Blockers
 
-- **Mathlib API drift (2026-04-27)**: line 43 collision
-  `Orientation has already been declared`. Cascades to 12 downstream errors.
+None. The `Mathlib.LinearAlgebra.Orientation` drift is resolved as of
+this PR (Iter 7).
 
 ## Next Action
 
-(For Mechanic): rename local `Orientation` and update all references.
-(Research, after unblocked): add `dichrom_le_of_colorable` and
-`cochrom_le_of_colorable` generalizing `bipartite_dichrom_le_two` to
-arbitrary k. Drafts already written; ~30 lines total.
+**Iter 8**: prove `dichrom_le_of_colorable {k : ℕ} (h : G.Colorable k) :
+G.dichromNumber ≤ k`. Generalizes `bipartite_dichrom_le_two`. Likely
+~15 lines: any k-coloring of `G` extends to an acyclic coloring of any
+orientation `O` (no monochromatic edge ⇒ no monochromatic cycle).
+
+After Iter 8, **Iter 9** mirror lemma `cochrom_le_of_colorable`.
 
 ## Attempt Counts
 
-- Total attempts: 6
-- Current approach attempts: 1
-- Approaches tried: 1 (drift discovery)
+- Total attempts: 7
+- Current approach attempts: 1 (drift unblock, this PR)
+- Approaches tried: drift discovery (Iter 6); namespace wrapper
+  unblock (Iter 7).
+
+## References
+
+- `proofs/Proofs/Erdos761Problem.lean` — main file (262 lines, 7
+  theorems, 6 defs, 2 axioms, 0 sorries).
+- `src/data/proofs/erdos-761/meta.json` — gallery integration.
+- Neumann-Lara 1982: "The dichromatic number of a digraph",
+  *J. Combin. Theory Ser. B* 33.
+- Erdős–Gimbel: cochromatic conjecture (open).

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,8 +38,8 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 258,
-    "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, bipartite_dichrom_le_two, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
+    "lineCount": 262,
+    "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation` (which had become transitively in scope and blocked iterations since 2026-04-27). Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, bipartite_dichrom_le_two, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
     "definitionCount": 6
@@ -125,8 +125,8 @@
     "opens": [
       "SimpleGraph"
     ],
-    "namespace": null,
-    "lineCount": 258,
+    "namespace": "Erdos761",
+    "lineCount": 262,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 6,


### PR DESCRIPTION
## Summary

Resolves the `Mathlib.LinearAlgebra.Orientation` collision documented in Iter 6 (PR #13195) that has blocked `erdos-761` iterations since 2026-04-27.

**Problem**: the local `structure Orientation` declaration at line 43 collided with the `Orientation` type from `Mathlib.LinearAlgebra.Orientation`, which had become transitively in scope as of Mathlib v4.26.0 (likely via `Mathlib.Tactic`'s expanded import surface). The collision cascaded into 12 downstream errors.

**Fix**: 2-line edit — wrap all declarations in `namespace Erdos761` … `end Erdos761`. Inside the namespace, unqualified `Orientation` resolves to `Erdos761.Orientation` (Lean prefers the local namespace); externally the local declaration is qualified as `Erdos761.Orientation` and no longer collides with the Mathlib root-level `Orientation`.

## Downstream-importer safety

Verified that the namespace wrapping is safe for the only Lean importer:
- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean` — does not reference `Orientation` or any Erdos761-local name (grep'd; zero matches for `Orientation|chrom|coloring|dichrom|cochrom`).
- `proofs/Proofs.lean` — umbrella module, imports for build registration only.

No qualified `Erdos761.foo` references exist downstream that would need updating.

## Files changed

- `proofs/Proofs/Erdos761Problem.lean`: 258 → 262 lines (+4 for the `namespace`/`end` lines and one blank line each side). theoremCount unchanged at 7. axiomCount unchanged at 2. defCount unchanged at 6. sorries=0 unchanged.
- `src/data/proofs/erdos-761/meta.json`: lineCount 258→262 in both meta and leanFile blocks. namespace `null`→`Erdos761`. assumptions string updated to mention the namespace fix.
- `research/problems/erdos-761/state.md`: phase `BLOCKED` → `ACT`, iteration 6→7, full unblock documentation, deferred S6 research drafts (`dichrom_le_of_colorable`, `cochrom_le_of_colorable`) pointed to as Iter 8/9 candidates.

## Status

- **Outcome**: drift unblock (structural refactor that re-enables future research iterations on this slug)
- **Build status**: pending (build-pending PR convention; cold-cache Docker queued separately)
- **Axiom count**: unchanged (2 axioms — `erdos_761_question1`, `erdos_761_question2` — both genuinely open conjectures)
- **Next iteration**: Iter 8 — apply the deferred S6 drafts: `dichrom_le_of_colorable` (~15 lines) and Iter 9 `cochrom_le_of_colorable` (~15 lines), generalizing `bipartite_dichrom_le_two` to arbitrary k

## Why this matters

This slug had been BLOCKED for 11 days (2026-04-27 to 2026-05-08). The state.md explicitly noted \"Mechanic task\" but no Mechanic action had been taken. This PR resolves the drift with the cleanest possible fix (2-line namespace wrap, no rename of any local symbol, no downstream update needed).

🤖 Generated by researcher-11