### PR TITLE
research(erdos-831): bookkeeping correction — phase NEW → ACT

### DIFF
--- a/research/problems/erdos-831/knowledge.md
+++ b/research/problems/erdos-831/knowledge.md
@@ -53,8 +53,44 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-05-08 (Bookkeeping audit, researcher-3)
+
+**Mode**: REVISIT
+**Outcome**: completed (no new mathematical work)
+
+#### What I Did
+- Verified `proofs/Proofs/Erdos831Problem.lean` on `origin/main`: 717 lines, 0 sorries, 1 axiom (`erdos_831_growing` on line 344)
+- Verified `src/data/proofs/erdos-831/meta.json` already reflects accurate state (`status: "axiomatized"`, `badge: "axiom"`, `sorries: 0`, `axiomCount: 1`)
+- Reviewed merged history: #7326, #7788, #7799, #7797, #7819, #7822, #7832, #15625, #15646 — converged to current axiomatized state on 2026-05-04
+- Updated `research/problems/erdos-831/state.md` and `src/data/research/problems/erdos-831.json` from `Phase: NEW / iter 1 / "Begin problem exploration"` (which was severely stale relative to the iter-7 JSON-knowledge state) to `Phase: ACT / iter 8` with accurate focus / blockers / nextAction text
+
+#### Axiom Classification
+- `erdos_831_growing : ∀ k : ℕ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → h n ≥ k`
+
+  This is the open Erdős conjecture itself, NOT a routine assumption. Estimating h(n) is the actual open problem. erdosproblems.com/831 lists status: OPEN. There is no Mathlib path to a proof — proving even h(n) → ∞ would be a research-level mathematical advance.
+
+#### Tractable Follow-Ups (out of scope for this session)
+The following are bounded Lean tasks that could be opened as separate slugs but are NOT required to consider this slug "formalized to the open conjecture":
+
+1. **Base cases h(n) for n ≤ 2.** Given the definition `h(n) = sInf {countDistinctRadii S | card S = n ∧ GP S}`, for any n ≤ 2 every term in the set is 0 (allCircumradiiFinset filters by p1≠p2≠p3≠p1, requiring ≥3 distinct points; sets of card ≤ 2 cannot produce such triples). Proof would route through a `countDistinctRadii_of_card_lt_three` lemma and pigeonhole arguments on the GP membership conditions.
+
+2. **Upgrade the h(4) = 1 docstring to a theorem.** The docstring (Erdos831Problem.lean:323-336) describes the equilateral-triangle + circumcenter counterexample showing h(4) ≤ 1 (and h(4) ≥ 1 is trivial). Formalizing this would require constructing the Lean-coordinate set {(0,0), (1,0), (1/2, √3/2), (1/2, √3/6)}, proving GP via the existing 27/81-case patterns from the h(3) proof (scaled up to 64-case collinearity and 4-point-concyclic verification), and computing all four circumradii to 1/√3 by `field_simp + ring` after expanding the 2×2 determinant area formula.
+
+3. **Prune unused stubs.** `orchardConfiguration` and `unitDistanceProblem` are defined but unused. They could either be removed or have at least one downstream use added.
+
+None of these advance the open conjecture; they polish the formalization at the margins.
+
+#### Files Modified
+- `src/data/research/problems/erdos-831.json` (phase, currentState, knownResults, lastUpdate)
+- `research/problems/erdos-831/state.md` (full rewrite to reflect actual iter-8 state)
+- `research/problems/erdos-831/knowledge.md` (this session block)
+
+#### Honest Outcome
+This is a tracker-correction session, not a proof advance. The pool entry's `phase: NEW / "Begin problem exploration"` was severely stale; the actual formalization has been at the axiomatized-with-1-axiom state since 2026-05-04. The candidate-pool record is now consistent with the gallery `meta.json` and the Lean source.
+
+The full Erdős #831 conjecture remains genuinely open at the research level.
 
 ---
+
 
 *Generated from erdosproblems.com on 2026-01-15*

--- a/research/problems/erdos-831/state.md
+++ b/research/problems/erdos-831/state.md
@@ -1,27 +1,59 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T09:46:19.704Z
-**Iteration**: 1
+**Phase**: ACT (formalization complete; mathematics open)
+**Since**: 2026-05-04T11:20:13Z
+**Iteration**: 8
 
 ## Current Focus
 
-Initial exploration of the problem.
+Formalization is complete on `origin/main`:
+`proofs/Proofs/Erdos831Problem.lean` — 717 lines, 0 sorries, 1 axiom.
+
+The single axiom `erdos_831_growing : ∀ k, ∃ N, ∀ n ≥ N, h n ≥ k` IS the
+open Erdős conjecture itself. Gallery `meta.json` correctly reflects
+`status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`.
 
 ## Active Approach
 
-None yet.
+None active. The formalization phase is complete pending a mathematical
+breakthrough on the open conjecture, which is out of scope for any single
+Lean session.
 
 ## Blockers
 
-None.
+- The Erdős conjecture h(n) → ∞ is genuinely OPEN — there is no Mathlib path.
+- Quantitative lower bounds on h(n) (the actual estimate Erdős asked for)
+  require new mathematics, not just Lean engineering.
 
 ## Next Action
 
-Begin problem exploration.
+None for this slug. Tractable bounded extensions exist but should be
+considered separately:
+
+1. Add base-case theorems `h_zero : h 0 = 0`, `h_one : h 1 = 0`,
+   `h_two : h 2 = 0` (currently absent; provable via pigeonhole on
+   `card S ≥ 3` requirement for any triple).
+2. Upgrade the h(4) = 1 docstring into a formal theorem by formalizing
+   the equilateral-triangle-plus-circumcenter construction (substantial
+   coordinate-geometry work, ~200-300 lines).
+3. Formalize the orchard configuration and unitDistanceProblem stubs
+   (defined but unused; pruning vs proof choice).
+
+None of these would discharge the open `erdos_831_growing` axiom.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 8
+- Current approach attempts: 1
+- Approaches tried: 8 (all converged to current axiomatized state)
+
+## Approaches Tried (chronological)
+
+1. Initial structure + h_upper_bound stub (PR #7326, 2026-03-28)
+2. Proof architecture refactor (PR #7788, 2026-03-29)
+3. circumradiusOf S₃ permutation invariance (PR #7799)
+4. Metadata/sorry-count audit cycles (#7797, #7819, #7822, #7832)
+5. h_upper_bound full proof + countDistinctRadii fix (S2-S5)
+6. h_three full proof via standard triangle 27/81-case GP analysis (S6)
+7. h(4) ≥ 2 axiom correction → h(4) = 1 (PR #15646, 2026-05-04)
+8. Replace stale axioms with `erdos_831_growing` open-conjecture axiom (PR #15625, 2026-05-04)

--- a/src/data/research/problems/erdos-831.json
+++ b/src/data/research/problems/erdos-831.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-831",
   "title": "Erdős #831",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -11,25 +11,36 @@
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "h_upper_bound: h(n) ≤ C(n,3) for all n",
+      "h_three: h(3) = 1 (any 3-point GP config has exactly one circumradius)",
+      "h(4) = 1 docstring/correction: equilateral + circumcenter shows all 4 circumradii can coincide (correcting the previously axiomatized h(4) ≥ 2 which was false; PR #15646 merged 2026-05-04)",
+      "circumradiusOf S₃ permutation invariance (perm12, cycle, perm23, perm13)",
+      "regular_polygon_not_general: regular polygons are not in general position (4 vertices concyclic)"
+    ],
+    "open": [
+      "Erdős's original question h(n) → ∞ as n → ∞ (axiomatized as erdos_831_growing on Erdos831Problem.lean:344)",
+      "Quantitative lower bound for h(n) (the actual estimate Erdős asked for)"
+    ],
+    "goal": "Sorry-free formalization with the open conjecture cleanly axiomatized — achieved on origin/main as of #15625 (2026-05-04)."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-15T09:46:19.704Z",
-    "iteration": 7,
-    "focus": "All sorries eliminated. h_upper_bound proved via powersetCard 3 factoring.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACT",
+    "since": "2026-05-04T11:20:13Z",
+    "iteration": 8,
+    "focus": "Formalization complete: 0 sorries, 1 axiom (erdos_831_growing = the open conjecture). Remaining work is exclusively at the level of the open mathematical problem.",
+    "blockers": [
+      "The Erdős conjecture h(n) → ∞ is genuinely OPEN — no Mathlib path to a proof"
+    ],
+    "nextAction": "Out of scope for this slug. Tractable extensions (e.g. proving h(n) = 0 for n ≤ 2 as concrete base cases, or formalizing the equilateral+circumcenter construction to upgrade the h(4) docstring into a theorem) are candidate follow-ups but require careful Lean work; current bookkeeping reflects the formalization is at the axiomatized state.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 8,
+      "currentApproach": 1,
+      "approachesTried": 8
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 4→0 sorries. h_three fully proved. h_upper_bound proved via tripleCircumradius on S.powersetCard 3, using circumradiusOf_eq_of_mem_triple for S₃ invariance. Only axiom: h_four_lower.",
+    "progressSummary": "AXIOMATIZED: 0 sorries; 1 axiom (erdos_831_growing) which is the open Erdős conjecture itself. h_upper_bound (≤ C(n,3)) and h_three (=1) proved. h(4)=1 corrected from prior false h(4)≥2 (PR #15646). meta.json status: axiomatized, badge: axiom.",
     "builtItems": [
       "Proved regular_polygon_not_general via Finset.exists_smaller_set + card_eq_succ extraction",
       "Proved circumradiusOf_perm12: swap first two args preserves circumradius (signed area negates, |area| preserved)",
@@ -78,7 +89,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T09:46:19.704Z",
-  "lastUpdate": "2026-03-29T13:00:00.000Z",
+  "lastUpdate": "2026-05-08T17:50:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

`Erdos831Problem.lean` reached the axiomatized state on `origin/main` with PR #15625 (2026-05-04): **717 lines, 0 sorries, 1 axiom** (`erdos_831_growing`, line 344). The single axiom **is the open Erdős conjecture itself** (h(n) → ∞). Gallery `meta.json` correctly carries `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`.

The candidate-pool / state.md / problem-JSON bookkeeping has been severely stale:

- `research/problems/erdos-831/state.md` showed `Phase: NEW / Iteration: 1 / "Begin problem exploration"` — wrong by 8 sessions.
- `src/data/research/problems/erdos-831.json` showed `phase: OBSERVE / currentState.phase: NEW / iteration: 7` while the same JSON's `knowledge.progressSummary` said `COMPLETE` with 14 `builtItems`.

This is a **tracker correction**, not a proof advance.

## Changes

- `src/data/research/problems/erdos-831.json`
  - `phase`: `OBSERVE` → `ACT`
  - `currentState.phase`: `NEW` → `ACT`
  - `currentState.iteration`: `7` → `8`
  - `knownResults.proven` / `open` / `goal` populated
  - `currentState.focus` / `blockers` / `nextAction` rewritten
  - `attemptCounts`: `0/0/0` → `8/1/8`
  - `progressSummary`: corrected stale `"Only axiom: h_four_lower"` (h_four_lower was REMOVED via #15646; only `erdos_831_growing` remains)
  - `lastUpdate` refreshed

- `research/problems/erdos-831/state.md`
  - Full rewrite to reflect **Phase ACT / iter 8** with accurate focus, blockers, next-action, and a chronological 8-step approaches-tried log.

- `research/problems/erdos-831/knowledge.md`
  - Appended **Session 2026-05-08** block documenting the correction, classifying `erdos_831_growing` as the OPEN conjecture (not a routine assumption), and listing three out-of-scope tractable follow-ups: h(n) ≤ 2 base cases, h(4) = 1 docstring → theorem, and pruning unused stubs.

## Verification

```
$ git show origin/main:proofs/Proofs/Erdos831Problem.lean | wc -l
717

$ git show origin/main:proofs/Proofs/Erdos831Problem.lean | grep -c "^axiom "
1

$ git show origin/main:proofs/Proofs/Erdos831Problem.lean | grep -nc "sorry"
0

$ git show origin/main:src/data/proofs/erdos-831/meta.json | jq '{sorries, axiomCount: .meta.axiomCount, status: .meta.status}'
{ "sorries": 0, "axiomCount": 1, "status": "axiomatized" }
```

`erdos_831_growing : ∀ k : ℕ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → h n ≥ k` — this IS the open Erdős conjecture (estimate h(n)). erdosproblems.com/831 lists status: OPEN. No Mathlib path exists.

## Status

**Outcome**: completed (bookkeeping)
**Mathematical delta**: 0 sorries, 0 axioms, 0 theorems
**Next steps**: None for this slug. The full Erdős #831 question (estimate h(n)) remains genuinely open and is out of scope.

🤖 Generated by researcher-3