### PR TITLE
research(erdos-411): S8 — Steinerberger r=2 reduction (sufficient direction)

### DIFF
--- a/proofs/Proofs/Erdos411Problem.lean
+++ b/proofs/Proofs/Erdos411Problem.lean
@@ -272,13 +272,54 @@ theorem cambie_ratio4_4325798 : GeneralRatioRelation 4325798 4 4 :=
   ⟨1, fun k hk => (ratio4_4325798_aux k hk).2⟩
 
 /-
-## Section V: Steinerberger's Reduction
+## Section VI: Steinerberger's Reduction (PROVED, sufficient direction)
+
+Steinerberger (2025, arXiv:2504.08023) observed that the r = 2 doubling
+problem is equivalent to the elementary equation φ(n) + φ(n + φ(n)) = n.
+We formalize the sufficient direction: if this equation holds for an
+even n > 2, then DoublingRelation n 2 holds (with K = 0).
+
+The converse (DoublingRelation n 2 → equation) requires backward reasoning
+along orbits of g and is not formalized here.
 -/
 
-/-- Steinerberger showed the r = 2 case is equivalent to solving
-φ(n) + φ(n + φ(n)) = n. -/
+/-- Computational expansion: g_2(n) = (n + φ(n)) + φ(n + φ(n)). -/
+theorem iteratedTotientStep_two (n : ℕ) :
+    iteratedTotientStep 2 n = (n + n.totient) + (n + n.totient).totient := by
+  rfl
+
+/-- Steinerberger's identity (computational form):
+g_2(n) = 2n ⟺ φ(n) + φ(n + φ(n)) = n. -/
+theorem steinerberger_iff (n : ℕ) :
+    iteratedTotientStep 2 n = 2 * n ↔
+      n.totient + (n + n.totient).totient = n := by
+  rw [iteratedTotientStep_two]; omega
+
+/-- **Steinerberger's reduction (sufficient direction).** If n is even, n > 2,
+and φ(n) + φ(n + φ(n)) = n, then DoublingRelation n 2 holds with K = 0.
+
+Proof: The hypothesis gives g_2(n) = 2n by `steinerberger_iff`, and
+`doubling_propagation` extends this to all k ≥ 0. -/
+theorem steinerberger_r2_sufficient {n : ℕ} (hn_even : 2 ∣ n) (hn_gt : n > 2)
+    (h_eq : n.totient + (n + n.totient).totient = n) :
+    DoublingRelation n 2 :=
+  ⟨0, fun k _ => doubling_propagation n hn_even hn_gt
+    ((steinerberger_iff n).mpr h_eq) k⟩
+
+/-- The known r = 2 solution n = 10 satisfies Steinerberger's equation:
+φ(10) + φ(10 + φ(10)) = 4 + φ(14) = 4 + 6 = 10. -/
+theorem steinerberger_eq_n10 :
+    (10 : ℕ).totient + (10 + (10 : ℕ).totient).totient = 10 := by
+  native_decide
+
+/-- The known r = 2 solution n = 94 satisfies Steinerberger's equation:
+φ(94) + φ(94 + φ(94)) = 46 + φ(140) = 46 + 48 = 94. -/
+theorem steinerberger_eq_n94 :
+    (94 : ℕ).totient + (94 + (94 : ℕ).totient).totient = 94 := by
+  native_decide
+
 /-
-## Section VI: Structural Properties
+## Section VII: Structural Properties
 -/
 
 /-- For even n, g(n) = n + φ(n) is always even, so the iterates

--- a/research/problems/erdos-411/state.md
+++ b/research/problems/erdos-411/state.md
@@ -1,27 +1,70 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-13T02:38:27.587Z
-**Iteration**: 1
+**Phase**: ITERATE
+**Since**: 2026-05-08
+**Iteration**: 8 (post-ratio4 + Steinerberger sufficient direction)
 
 ## Current Focus
 
-Initial exploration of the problem.
+Formalize Steinerberger's (2025) reduction of the r=2 doubling problem
+to the elementary equation φ(n) + φ(n + φ(n)) = n. The sufficient
+direction is now proved.
 
 ## Active Approach
 
-None yet.
+`iteratedTotientStep 2 n = (n + φ(n)) + φ(n + φ(n))` reduces by `rfl`,
+giving `steinerberger_iff` (g_2(n) = 2n ↔ Steinerberger equation) by `omega`.
+Combined with `doubling_propagation`, this proves
+`steinerberger_r2_sufficient` with K = 0 for any even n > 2 satisfying
+the equation. Verified the n=10, n=94 cases satisfy the equation by
+`native_decide`.
 
 ## Blockers
 
-None.
+The reverse direction (DoublingRelation n 2 → φ(n) + φ(n + φ(n)) = n)
+requires backward reasoning along orbits of g and is genuinely harder:
+the asymptotic doubling at K could begin with an iterate g_K(n), not n
+itself, so arguing back to n needs a different technique.
 
 ## Next Action
 
-Begin problem exploration.
+(Optional) Attempt the converse direction: show that for even n > 2, if
+DoublingRelation n 2 holds with witness K, then g_K(n) satisfies the
+Steinerberger equation; characterize when the witness can be taken K = 0.
+
+Alternatively: Selfridge–Weintraub g_{k+9}(n) = 9·g_k(n) solutions or
+Weintraub's g_{k+25}(3114) = 729·g_k(3114) (would need a totientStep_p_dvd
+lemma for general primes p).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 8
+- Current approach attempts: 1 (succeeded)
+- Approaches tried: 8 (axiomatic skeleton; Cambie ratio-3; Cambie ratio-4
+  for two cases; Steinerberger sufficient direction)
+
+## Sessions
+
+### Session 2026-05-08 — S8 Steinerberger sufficient direction (PROVED)
+
+**Mode**: ITERATE
+**Outcome**: 5 new theorems added (axiom-free, sorry-free)
+
+#### What I added
+- `iteratedTotientStep_two`: g_2(n) = (n + φ(n)) + φ(n + φ(n)) by rfl
+- `steinerberger_iff`: g_2(n) = 2n ↔ φ(n) + φ(n + φ(n)) = n (rw + omega)
+- `steinerberger_r2_sufficient`: even n > 2, equation ⇒ DoublingRelation n 2
+- `steinerberger_eq_n10`: n=10 satisfies the equation (native_decide)
+- `steinerberger_eq_n94`: n=94 satisfies the equation (native_decide)
+
+#### Files Modified
+- `proofs/Proofs/Erdos411Problem.lean` (+41 lines, 22 theorems total)
+- `src/data/proofs/erdos-411/meta.json` (lineCount, theoremCount,
+  originalContributions, proofStrategy, mainTheorems)
+- `research/problems/erdos-411/state.md` (this file)
+
+#### Notes
+- Build pending — Docker build typically takes 30-45 min from clean cache
+  due to broken proofs/.lake symlink (see memory: feedback_researcher_lake_symlink_broken)
+- All proofs use only definitional unfolding, omega, native_decide, and
+  composition of pre-existing lemmas; no Mathlib api drift risk

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -48,19 +48,19 @@
       "totientStep_quadruple: proved g(4m) = 4·g(m) when 4|m via double application of Nat.totient_mul_of_prime_of_dvd with p=2",
       "cambie_ratio4_148646: proved g_{k+4}(148646) = 4·g_k(148646) for all k≥1 via strong induction (native_decide base cases k=1..4)",
       "cambie_ratio4_4325798: proved g_{k+4}(4325798) = 4·g_k(4325798) for all k≥1 via same structure",
-      "Stated Steinerberger's (2025) reduction (DoublingRelation n 2 ↔ φ(n) + φ(n + φ(n)) = n) as a definition; equivalence proof not yet formalized",
+      "Formalized Steinerberger's (2025) reduction — sufficient direction: proved steinerberger_iff (g_2(n) = 2n ↔ φ(n) + φ(n + φ(n)) = n) and steinerberger_r2_sufficient (even n > 2 with φ(n) + φ(n + φ(n)) = n implies DoublingRelation n 2 with K = 0); also proved steinerberger_eq_n10 and steinerberger_eq_n94 verifying the two known r=2 cases satisfy the equation",
       "Proved even preservation under g using Mathlib's Nat.totient_even",
       "Stated Cambie's structural conjecture (n = 2^l·p with p ∈ {2,3,5,7,35,47}) as a definition; conjecture itself is open"
     ],
     "axiomCount": 0,
-    "lineCount": 303,
-    "assumptions": "No axioms. All results (cambie_ratio3, cambie_ratio4_148646, cambie_ratio4_4325798, r=2 solutions n=10/94) are proved. Open conjecture stated as definition, not axiom.",
-    "theoremCount": 17,
+    "lineCount": 344,
+    "assumptions": "No axioms. All results (cambie_ratio3, cambie_ratio4_148646, cambie_ratio4_4325798, r=2 solutions n=10/94, Steinerberger's sufficient direction) are proved. Open conjecture stated as definition, not axiom.",
+    "theoremCount": 22,
     "definitionCount": 6
   },
   "leanFile": {
     "path": "Proofs/Erdos411Problem.lean",
-    "lineCount": 303,
+    "lineCount": 344,
     "namespace": "root",
     "imports": [
       "Mathlib.Data.Nat.Totient",
@@ -70,7 +70,8 @@
     ],
     "mainTheorems": [
       "totientStep_even_of_even",
-      "totientStep_ge"
+      "totientStep_ge",
+      "steinerberger_r2_sufficient"
     ],
     "mainDefinitions": [
       "totientStep",
@@ -81,7 +82,7 @@
       "CambieConjecture"
     ],
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 22,
     "sorries": 0,
     "definitionCount": 6
   },
@@ -89,7 +90,7 @@
     "historicalContext": "Erdős and Graham posed this question in their influential monograph 'Old and New Problems and Results in Combinatorial Number Theory' (1980, p. 81). They studied the iteration $g(n) = n + \\varphi(n)$, where $\\varphi$ is Euler's totient function, asking for which $n$ and $r$ the $r$-step iterate doubles the value: $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all large $k$. The function $g$ is a natural object: since $\\varphi(n)$ counts integers up to $n$ coprime to $n$, the map $n \\mapsto n + \\varphi(n)$ augments $n$ by its 'coprime complement.'\n\nThe simplest solutions are $n = 10$ (orbit: $10 \\to 14 \\to 20 \\to 28 \\to 40 \\to \\ldots$, doubling every 2 steps) and $n = 94$. For decades, little progress was made on characterizing all solutions. Stefan Steinerberger achieved a breakthrough in 2025 by showing the $r = 2$ case reduces to a single finitely-checkable equation: $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. This transforms an asymptotic dynamical condition into elementary number theory.\n\nSjoerd Cambie extended the investigation to general multiplicative ratios $c \\neq 2$, discovering that $n = 738$ gives a ratio-3 solution ($g^{k+4}(738) = 3 \\cdot g^k(738)$) and $n = 148646, 4325798$ give ratio-4 solutions. These findings reveal the problem has far richer structure than Erdős originally anticipated. Cambie also conjectured that all $r = 2$ solutions have the form $n = 2^l \\cdot p$ for $p \\in \\{2, 3, 5, 7, 35, 47\\}$.\n\nThe problem belongs to a cluster of related Erdős questions (#410--#415) about iterating arithmetic functions: $\\sigma$ (sum of divisors), $\\tau$ (divisor count), $\\omega$ (distinct prime factors), and $\\varphi$ (totient). Together they form a rich chapter in arithmetic dynamics, connecting multiplicative number theory to discrete dynamical systems.",
     "problemStatement": "Let $g(n) = n + \\varphi(n)$ and $g^k = g \\circ \\cdots \\circ g$ ($k$ times). For which $n$ and $r$ is $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all sufficiently large $k$?",
     "text": "Define $g(n) = n + \\varphi(n)$ and let $g^k$ denote the $k$-th iterate. For which $n$ and $r$ does $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all large $k$? Known $r = 2$ solutions: $n = 10, 94$. Cambie found ratio-3 and ratio-4 solutions. Steinerberger (2025) reduced the $r = 2$ case to $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. OPEN in general.",
-    "proofStrategy": "The formalization defines `totientStep` ($g$), `iteratedTotientStep` ($g^k$), and `DoublingRelation`. The main conjecture `ErdosProblem411` asks for a characterization of all solution pairs $(n, r)$. Known solutions ($n = 10, 94$ for $r = 2$) are proved via native_decide + doubling_propagation induction; Cambie's ratio-3 and ratio-4 cases fully proved via strong induction. `GeneralRatioRelation` extends to arbitrary multiplicative ratios. Structural properties (even preservation, monotonicity) are proved. Cambie's conjecture and the open problem are stated as defs (not axioms).",
+    "proofStrategy": "The formalization defines `totientStep` ($g$), `iteratedTotientStep` ($g^k$), and `DoublingRelation`. The main conjecture `ErdosProblem411` asks for a characterization of all solution pairs $(n, r)$. Known solutions ($n = 10, 94$ for $r = 2$) are proved via native_decide + doubling_propagation induction; Cambie's ratio-3 and ratio-4 cases fully proved via strong induction. `GeneralRatioRelation` extends to arbitrary multiplicative ratios. Structural properties (even preservation, monotonicity) are proved. The sufficient direction of Steinerberger's r=2 reduction is proved as `steinerberger_r2_sufficient`: any even $n > 2$ satisfying $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$ is a doubling solution, by combining the elementary identity `steinerberger_iff` with `doubling_propagation`. Cambie's conjecture and the open problem are stated as defs (not axioms).",
     "keyInsights": [
       "**Orbit structure**: $g(n) = n + \\varphi(n)$ produces strictly increasing orbits; for $n = 10$, the orbit $10 \\to 14 \\to 20 \\to 28 \\to 40 \\to \\ldots$ doubles every two steps because $\\varphi(10) + \\varphi(14) = 4 + 6 = 10$",
       "**Steinerberger's reduction**: The asymptotic condition $g^{k+2}(n) = 2 \\cdot g^k(n)$ for large $k$ is equivalent to the single equation $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$, transforming dynamics into elementary arithmetic",


### PR DESCRIPTION
## Summary

Formalize the easy direction of Steinerberger's (2025) reduction of the
Erdős–Graham r=2 doubling problem (#411) to the elementary number-theoretic
equation $\varphi(n) + \varphi(n + \varphi(n)) = n$.

## What changed

Five new theorems in `Proofs/Erdos411Problem.lean` (axiom-free, sorry-free):

- `iteratedTotientStep_two`: $g_2(n) = (n + \varphi(n)) + \varphi(n + \varphi(n))$, by `rfl`
- `steinerberger_iff`: $g_2(n) = 2n \iff \varphi(n) + \varphi(n + \varphi(n)) = n$, by `rw + omega`
- `steinerberger_r2_sufficient`: even $n > 2$ satisfying the equation gives `DoublingRelation n 2` with $K = 0$ (combines `steinerberger_iff` with the existing `doubling_propagation` lemma)
- `steinerberger_eq_n10`, `steinerberger_eq_n94`: the known $r = 2$ cases satisfy the equation (`native_decide`)

The converse direction (`DoublingRelation n 2` $\to$ equation) is **not** proved; it requires backward reasoning along orbits of $g$, and the asymptotic doubling at iteration $K$ does not directly imply the equation at $n$ itself.

Metadata sync: `theoremCount` 17 → 22, `lineCount` 303 → 344, `axiomCount` = 0, `sorries` = 0. State note added under `research/problems/erdos-411/state.md`.

## Build status

**BUILD UNVERIFIED** — `proofs/.lake` self-symlink forces a fresh Mathlib clone (~30–45 min). Proofs use only `rfl`, `omega`, `native_decide`, and composition of pre-existing lemmas — minimal Mathlib API drift risk.

## Test plan

- [ ] Docker build of `Proofs.Erdos411Problem` succeeds
- [ ] Gallery `pnpm build` succeeds with updated `meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)