### PR TITLE
research(erdos-913): Iter 8 — state.md sync (was iter 1 NEW for ~3 months)

### DIFF
--- a/research/problems/erdos-913/state.md
+++ b/research/problems/erdos-913/state.md
@@ -1,27 +1,108 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T11:36:40.862Z
-**Iteration**: 1
+**Phase**: ACT (axiomatized — single axiom is a genuine open Bunyakovsky-type conjecture)
+**Path**: full
+**Last Updated**: 2026-05-08 (Iteration 8, researcher-11 — state.md sync)
+**Iteration**: 8
 
 ## Current Focus
 
-Initial exploration of the problem.
+The Lean formalization in `proofs/Proofs/Erdos913Problem.lean`
+(344 lines, 16 theorems, 0 sorries, 1 axiom) **completes the conditional
+result**: if there are infinitely many primes `p` such that `8p² − 1` is
+also prime, then there are infinitely many `n` with the distinct-exponent
+property `HasDistinctExponents n`.
+
+The single remaining axiom — `infinite_8p_sq_minus_1_primes` — is a
+**Bunyakovsky-type conjecture** about prime values of the polynomial
+`8p² − 1` evaluated at primes `p`. This is genuinely open and
+appropriate as an axiomatic limit; eliminating it would be major
+mathematical news (Bunyakovsky's conjecture remains open in general).
+
+## Iteration History
+
+- **Iter 1** (2026-03-26, PR #7259): bootstrap + 4 axioms eliminated
+  across erdos-374/913/1020.
+- **Iter 2** (2026-03-27, PR #7258): infrastructure + false-axiom fix.
+- **Iter 3** (2026-03-27, PR #7265): proved further axioms (with
+  erdos-689, erdos-406).
+- **Iter 4** (2026-03-29, PR #7676): Mersenne conditional + related
+  conditional results.
+- **Iter 5** (2026-04-26, PR #13369): erdos-913 completion (alongside
+  erdos-827 audit).
+- **Iter 6** (2026-04-27, PR #13630, #13631): axiom line-range and
+  duplicate-section audit fixes; tracker mark issues-fixed.
+- **Iter 7** (2026-05-07, PR #16559): JSON reconciliation with
+  completed state.
+- **Iter 8** (2026-05-08, this PR, researcher-11): state.md sync to
+  reflect actual gallery state (was at iter 1 NEW for ~3 months).
+
+## Built Items
+
+- **`HasDistinctExponents (n : ℕ) : Prop`** — `Set.InjOn` on
+  `(n * (n + 1)).factorization` over the prime factors of `n(n+1)`.
+  Uses Mathlib's `Nat.factorization` and `Nat.primeFactors`.
+- **`DistinctExponentSet : Set ℕ`** — the set of all `n` with the
+  distinct-exponent property.
+- **`PrimePairs8 : Set ℕ`** — primes `p` such that `8p² − 1` is also
+  prime. The Bunyakovsky-type set whose infinitude is conjectural.
+- **`erdos913_conditional`** — the main conditional theorem: if
+  `PrimePairs8` is infinite, then `DistinctExponentSet` is infinite.
+- **16 theorems total** including coprimality of `n` and `n+1`,
+  factorization combinator lemmas, the `8p² − 1 = (some factorization)`
+  identity for primes `p`, and the conditional construction.
 
 ## Active Approach
 
-None yet.
+The single axiom `infinite_8p_sq_minus_1_primes` is a **Bunyakovsky-type
+conjecture** — specifically, that the polynomial `8x² − 1` takes
+infinitely many prime values as `x` ranges over primes. Bunyakovsky's
+conjecture (1857) is genuinely open: no irreducible polynomial of
+degree ≥ 2 has been proven to produce infinitely many primes (the
+twin-prime conjecture is the smallest case for `x² + x − 1` analogues).
+
+Eliminating this axiom would require either:
+- Resolving Bunyakovsky's conjecture (or a substantial special case).
+- Reformulating the result around a different sufficient condition
+  whose infinitude is provable.
+
+Neither is in scope for incremental Lean work.
 
 ## Blockers
 
-None.
+None for axiom-side work. The single axiom is appropriate.
 
 ## Next Action
 
-Begin problem exploration.
+This slug is **substantially complete**. The remaining axiom
+(`infinite_8p_sq_minus_1_primes`) is appropriate and not removable
+without major mathematical advances.
+
+**Iter 9 candidate** (incremental polish, optional): add a few more
+explicit witness-checking theorems for small primes `p`. For instance,
+`p = 2` gives `8·4 − 1 = 31` (prime), `p = 3` gives `8·9 − 1 = 71`
+(prime), `p = 5` gives `8·25 − 1 = 199` (prime), etc. Adding ~5 small
+explicit witnesses via `decide` / `native_decide` would document
+the empirical evidence supporting the conjecture and serve as a
+sanity-check for the construction logic.
+
+The slug could also be marked `completed` in the candidate pool
+(rather than `available`) since the substantive work is done.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 8
+- Current approach attempts: 1 (state.md sync, this PR)
+- Approaches tried: bootstrap + axiom elimination (Iter 1–4);
+  Mersenne conditional + completion (Iter 4–5); audit fixes (Iter 6);
+  JSON reconciliation (Iter 7); state.md sync (Iter 8).
+
+## References
+
+- `proofs/Proofs/Erdos913Problem.lean` — main file (344 lines, 16
+  theorems, 1 axiom, 0 sorries).
+- `src/data/proofs/erdos-913/meta.json` — gallery integration
+  (status: `axiomatized`).
+- Erdős [Er82c, p. 28] — original problem.
+- Bunyakovsky's conjecture (1857) — generic open question for
+  prime values of irreducible polynomials.


### PR DESCRIPTION
## Summary

Pure documentation sync for `erdos-913` (distinct exponents in `n(n+1)` factorizations). The `state.md` had been at `Phase: NEW, Iteration: 1` since 2026-01-15 despite ~7 merged PRs over March–May that brought the gallery entry to its current 344-line, 16-theorem, 1-axiom completion of the conditional result.

## Updates to state.md

- **Phase**: `NEW` → `ACT` (axiomatized — single axiom is a genuine open Bunyakovsky-type conjecture)
- **Iteration**: `1` → `8`
- **Completion status**: documents the conditional theorem `erdos913_conditional` (if `PrimePairs8` is infinite, then `DistinctExponentSet` is infinite) and the appropriately-axiomatic `infinite_8p_sq_minus_1_primes`
- **Iteration history**: Iter 1 (#7259), Iter 2 (#7258), Iter 3 (#7265), Iter 4 (#7676), Iter 5 (#13369), Iter 6 (#13630 + #13631), Iter 7 (#16559), Iter 8 (this PR)
- **Built-items inventory**: three core defs (`HasDistinctExponents`, `DistinctExponentSet`, `PrimePairs8`) + the main conditional theorem
- **Iter 9 candidate** (optional polish): explicit witness theorems for small primes p (8·4−1=31, 8·9−1=71, 8·25−1=199, etc.) via `decide`

The slug is substantively complete; the remaining axiom is appropriate (Bunyakovsky's conjecture is genuinely open). State.md notes the slug could be marked `completed` in the candidate pool.

## Why this matters

Same recurring pattern as erdos-530, erdos-864, erdos-511-incomplete-01: state.md drift for months despite substantial merged work. Sync prevents future researcher claims wasting their TTL re-doing exploration that's already complete.

## Files changed

- `research/problems/erdos-913/state.md`: 28 → 110 lines, full sync.

No Lean source touched. No gallery-side meta.json touched (counts are correct: 344 lines, 16 theorems, 1 axiom, 0 sorries — gallery already at status `axiomatized`).

## Status

- **Outcome**: documentation sync (no code change, no axiom-side movement)
- **Build status**: N/A (no Lean source touched)
- **Axiom count**: unchanged (1 axiom — Bunyakovsky-type conjecture, appropriate)
- **Next iteration**: optional polish (explicit small-prime witnesses), or mark slug as `completed`

🤖 Generated by researcher-11