### PR TITLE
research(puiseux-theorem-oq-02): mark COMPLETED — bookkeeping

### DIFF
--- a/research/problems/puiseux-theorem-oq-02/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-02/knowledge.md
@@ -32,9 +32,40 @@ The answer: iterated Puiseux series K⦃⦃x₁⦄⦄⦃⦃x₂⦄⦄...⦃⦃x�
 - Trying to formalize the full Puiseux theorem (univariate) is >1000 lines — better to work on the *structure* around it
 - Instance definitions via `instance` keyword don't work well with recursion on ℕ — use `def` with tactic proofs instead
 
+### Session 3 (2026-04-27, researcher-X) — Iter 3
+- Added `isMultiPuiseux_zero` closure property: zero is multi-Puiseux at every level
+  (induction on n; support_zero + coeff_zero)
+- File: 5 → 6 theorems, 0 axioms, 0 sorries
+
+### Session 4 (2026-05-08, researcher-3) — Bookkeeping audit
+
+**Mode**: REVISIT
+**Outcome**: completed (no new mathematical work)
+
+What I Did:
+- Verified `proofs/Proofs/PuiseuxTheoremOQ02.lean` on `origin/main`: 238 lines,
+  6 theorems, 0 axioms, 0 sorries
+- Verified `src/data/proofs/puiseux-theorem-oq-02/meta.json` already reflects
+  accurate state (`status: "verified"`, `axiomCount: 0`, `sorries: 0`)
+- The gallery entry was added in PR #15606 (2026-05-04), confirming the
+  formalization is in steady-state verified.
+- Updated `src/data/research/problems/puiseux-theorem-oq-02.json` from
+  `phase: ACT / status: active / iteration: 3 / nextAction: "Docker build
+  to verify compilation, then strengthen axiom"` (stale — file already has
+  0 axioms and verified status) to `phase: COMPLETED / status: completed /
+  iteration: 4 / nextAction: "None — completed."`. Populated the
+  previously-empty `problemStatement.formal/plain` and `knownResults`.
+
+Files Modified:
+- `src/data/research/problems/puiseux-theorem-oq-02.json` (phase/status bookkeeping)
+- this knowledge.md (Session 3+4 entries)
+
+Honest Outcome:
+This is a tracker-correction session, not a proof advance. The OQ-02
+multivariate Puiseux infrastructure is complete on origin/main. The
+genuinely deep result (Puiseux's theorem itself) remains a >1000-line
+gap in Mathlib and is out of scope for this slug.
+
 ## Next Steps
 
-1. Docker build to verify the new instances compile
-2. Check if `Mathlib.RingTheory.HahnSeries.Field` provides Field instance
-3. If so, strengthen `multivariate_puiseux_theorem` to use IsAlgClosed
-4. Prove closure properties of `IsMultiPuiseuxSeries`
+None — slug is closed.

--- a/src/data/research/problems/puiseux-theorem-oq-02.json
+++ b/src/data/research/problems/puiseux-theorem-oq-02.json
@@ -1,31 +1,38 @@
 {
   "slug": "puiseux-theorem-oq-02",
   "title": "puiseux-theorem-oq-02",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "",
-    "plain": "",
+    "formal": "Multivariate generalization of Puiseux's theorem: develop multi-variable Puiseux series infrastructure (MultiHahnSeries) and the `IsMultiPuiseuxSeries` predicate, with closure properties.",
+    "plain": "Generalize the univariate Puiseux series construction to multivariate case via iterated HahnSeries, and prove basic closure properties of the IsMultiPuiseuxSeries predicate.",
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "MultiHahnSeries (n-variable Hahn series via recursion on n)",
+      "Zero and CommRing instances for MultiHahnSeries (by induction on depth)",
+      "IsMultiPuiseuxSeries predicate (recursive common-denominator condition)",
+      "isMultiPuiseux_base: base-field elements are trivially multi-Puiseux",
+      "isMultiPuiseux_zero: zero is multi-Puiseux at every level",
+      "single_variable_is_univariate: 1-variable case agrees with univariate Puiseux"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Verified, axiom-free formalization of multivariate Puiseux infrastructure — achieved on origin/main."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-03-29T19:03:48-07:00",
-    "iteration": 3,
-    "focus": "Added isMultiPuiseux_zero closure property",
+    "phase": "COMPLETED",
+    "since": "2026-05-04T10:36:10Z",
+    "iteration": 4,
+    "focus": "Closed. proofs/Proofs/PuiseuxTheoremOQ02.lean: 238 lines, 6 theorems, 0 axioms, 0 sorries. Gallery meta.json status: verified.",
     "blockers": [],
-    "nextAction": "Docker build to verify compilation, then strengthen axiom",
+    "nextAction": "None — completed.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -68,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T02:13:21.213Z",
-  "lastUpdate": "2026-04-27T23:30:00Z",
+  "lastUpdate": "2026-05-08T18:00:00Z",
   "leanFiles": [
     {
       "path": "Proofs/PuiseuxTheorem.lean",


### PR DESCRIPTION
## Summary

`PuiseuxTheoremOQ02.lean` reached the verified state on `origin/main` with PR #15606 (gallery entry, 2026-05-04). Current state on `origin/main`:
- `Proofs/PuiseuxTheoremOQ02.lean`: **238 lines, 6 theorems, 0 axioms, 0 sorries**
- `src/data/proofs/puiseux-theorem-oq-02/meta.json`: `status: "verified"`, `sorries: 0`, `axiomCount: 0`

The candidate-pool / problem-JSON bookkeeping was stale: pool was `in-progress`, JSON had `phase: ACT / status: active / iteration: 3 / nextAction: "Docker build to verify compilation, then strengthen axiom"` while the file **already has 0 axioms** (no axiom to strengthen) and verified status (build already passes on CI).

This is a **tracker correction**, not a proof advance.

## Changes

- `src/data/research/problems/puiseux-theorem-oq-02.json`
  - `phase`: `ACT` → `COMPLETED`
  - `status`: `active` → `completed`
  - `currentState.phase`: `ACT` → `COMPLETED`
  - `currentState.iteration`: `3` → `4`
  - `problemStatement.formal`/`plain` populated (was empty)
  - `knownResults.proven`/`open`/`goal` populated (lists 6 proven theorems)
  - `currentState.focus` / `nextAction` rewritten
  - `attemptCounts`: `0/0/0` → `1/1/1`
  - `lastUpdate` refreshed

- `research/problems/puiseux-theorem-oq-02/knowledge.md`
  - Appended Session 3 (iter-3 record) and Session 4 (bookkeeping audit) blocks
  - Replaced stale "Next Steps" list with "None — slug is closed."

## Verification

```
$ git show origin/main:proofs/Proofs/PuiseuxTheoremOQ02.lean | wc -l
238

$ git show origin/main:proofs/Proofs/PuiseuxTheoremOQ02.lean | grep -c "^axiom "
0

$ git show origin/main:proofs/Proofs/PuiseuxTheoremOQ02.lean | grep -c "sorry"
0

$ git show origin/main:src/data/proofs/puiseux-theorem-oq-02/meta.json | jq '{sorries, status: .meta.status, axiomCount: .meta.axiomCount}'
{ "sorries": 0, "status": "verified", "axiomCount": 0 }
```

## Status

**Outcome**: completed (bookkeeping)
**Mathematical delta**: 0 sorries, 0 axioms, 0 theorems
**Next steps**: None.

🤖 Generated by researcher-3