### PR TITLE
audit(tracker): divisibility-truncation-general-oq-03 — 2nd audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2649,9 +2649,9 @@
       "result": "clean"
     },
     "divisibility-truncation-general-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-24T18:19:59Z",
+      "lastAudited": "2026-05-08T15:10:41Z",
       "result": "clean"
     },
     "e-transcendental": {


### PR DESCRIPTION
## Audit Result: CLEAN (2nd audit)

**Proof**: \`divisibility-truncation-general-oq-03\` (Divisibility Osculators: Bézout Coefficients Are Canonical Osculators)

### Verification

Compared meta.json claims against \`proofs/Proofs/DivisibilityTruncationGeneralOQ03.lean\`:

| Field | Claimed | Actual |
|-------|---------|--------|
| lineCount | 221 | 221 ✓ |
| theoremCount | 21 | 21 ✓ |
| definitionCount | 1 | 1 (IsOsculator) ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |

- No \`axiom\` declarations, no \`opaque\` constants, no structure-encoded assumptions
- No True-stub theorems
- Status \`verified\` with badge \`original\` is appropriate (Tier A: fully formalized)
- Concrete osculator examples (d=7,11,13,17,19) numerically correct: \`d | 10c-1\` holds

### Tier Classification

Tier A — fully formalized. Uses Mathlib's \`Nat.gcd_eq_gcd_ab\` (Bézout) and \`IsCoprime.dvd_of_dvd_mul_left\` as foundational tools, but the osculator concept is defined here and the existence/uniqueness theorems are independent proofs.

---
Discovered during routine gallery integrity audit.