### PR TITLE
research(erdos-190): Iter 2 — color-subset helpers + conjecture strength (build pending)

### DIFF
--- a/proofs/Proofs/Erdos190Problem.lean
+++ b/proofs/Proofs/Erdos190Problem.lean
@@ -345,4 +345,55 @@ theorem erdos_190_summary :
 -- The main conjecture (OPEN): H(k)^{1/k}/k → ∞, i.e., H(k) grows
 -- faster than k^k. This remains unresolved.
 
+/- ## Part XI: Subset Helpers and Conjecture Strength -/
+
+/-- Monochromaticity is preserved under subsets: if every element of `s` has
+    the same color under `χ`, then so does every element of any subset `s'`. -/
+theorem isMonochromatic_subset {ι Cα : Type*} {χ : ι → Cα}
+    {s s' : Finset ι} (hsub : s' ⊆ s) (h : isMonochromatic χ s) :
+    isMonochromatic χ s' := by
+  obtain ⟨c, hc⟩ := h
+  exact ⟨c, fun x hx => hc x (hsub hx)⟩
+
+/-- Rainbowness is preserved under subsets: if `χ` is injective on `s`
+    (witnessed by `(s.image χ).card = s.card`), then it is also injective on
+    any subset `s'`, hence the rainbow condition transfers. -/
+theorem isRainbow_subset {ι Cα : Type*} [DecidableEq Cα] {χ : ι → Cα}
+    {s s' : Finset ι} (hsub : s' ⊆ s) (h : isRainbow χ s) :
+    isRainbow χ s' := by
+  unfold isRainbow at *
+  -- From h : s.card = (s.image χ).card, derive Set.InjOn χ s.
+  have hInj : Set.InjOn χ (↑s : Set ι) := by
+    have : (s.image χ).card = s.card := h.symm
+    rwa [Finset.card_image_iff] at this
+  -- Restrict injectivity to s' and conclude.
+  have hInj' : Set.InjOn χ (↑s' : Set ι) :=
+    hInj.mono (by exact_mod_cast hsub)
+  rw [Finset.card_image_of_injOn hInj']
+
+/-- The Erdős #190 conjecture `H(k)^{1/k}/k → ∞` is strictly stronger than
+    the known result `H(k)^{1/k} → ∞`: any threshold function `K(M)` for the
+    conjecture also works for the known result, since
+    `H(k)^{1/k} ≥ H(k)^{1/k}/k · k > M · k ≥ M` once `k ≥ max(K(M), 1)`. -/
+theorem erdos190Conjecture_implies_root_to_infinity (h : erdos190Conjecture) :
+    ∀ M : ℕ, ∃ K : ℕ, ∀ k ≥ K, (H k : ℝ) ^ (1 / k : ℝ) > M := by
+  intro M
+  obtain ⟨K, hK⟩ := h M
+  refine ⟨max K 1, fun k hk => ?_⟩
+  have hkK : k ≥ K := le_trans (le_max_left _ _) hk
+  have hk1 : k ≥ 1 := le_trans (le_max_right _ _) hk
+  have hk_pos : (0 : ℝ) < k := by exact_mod_cast hk1
+  have hbound := hK k hkK
+  -- hbound : (H k : ℝ) ^ (1 / k : ℝ) / k > M
+  -- Multiply both sides by k > 0 to get (H k)^{1/k} > M·k.
+  have hMk : (M : ℝ) * k < (H k : ℝ) ^ (1 / k : ℝ) := by
+    have := (div_lt_iff₀ hk_pos).mp hbound
+    linarith
+  -- Then M·k ≥ M·1 = M since M ≥ 0 and k ≥ 1.
+  have hMle : (M : ℝ) ≤ M * k := by
+    have hM_nn : (0 : ℝ) ≤ M := by exact_mod_cast Nat.zero_le _
+    have hk_ge_one : (1 : ℝ) ≤ k := by exact_mod_cast hk1
+    nlinarith
+  linarith
+
 end Erdos190

--- a/research/problems/erdos-190/state.md
+++ b/research/problems/erdos-190/state.md
@@ -1,27 +1,49 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-12T16:01:50.836Z
-**Iteration**: 1
+**Phase**: ACTIVE_RESEARCH
+**Since**: 2026-05-08
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Add reusable structural lemmas for color conditions on subsets, and clarify
+the strength relationship between the Erdős #190 conjecture and the known
+result `H(k)^{1/k} → ∞`.
 
 ## Active Approach
 
-None yet.
+Three additions to `Erdos190Problem.lean`:
+
+1. `isMonochromatic_subset`: monochromaticity is preserved under subsets.
+   Direct destructure-and-restrict.
+2. `isRainbow_subset`: rainbowness is preserved under subsets, via
+   `Finset.card_image_iff` + `Set.InjOn.mono`. These two helpers form the
+   key building blocks for any future monotonicity argument on `H`
+   (e.g., `H_monotone : H k ≤ H (k+1)` by truncating canonical (k+1)-APs).
+3. `erdos190Conjecture_implies_root_to_infinity`: shows the conjecture
+   `H(k)^{1/k}/k → ∞` is strictly stronger than the known result
+   `H(k)^{1/k} → ∞` — proves the implication via `(H k)^{1/k} > M·k ≥ M·1 = M`
+   for `k ≥ max(K_M, 1)`. This crystallizes the dependency: any progress on
+   the conjecture also proves the known result, but not vice versa.
 
 ## Blockers
 
-None.
+- Build verification deferred (broken `proofs/.lake` symlink).
 
 ## Next Action
 
-Begin problem exploration.
+Iteration 3 candidates:
+- `H_monotone : H k ≤ H (k+1)` using `isMonochromatic_subset` /
+  `isRainbow_subset`. Truncate canonical (k+1)-AP `f : Fin (k+1) → Fin N` to
+  `g : Fin k → Fin N` via `g i := f ⟨i.val, by omega⟩`; AP property + color
+  helpers carry through.
+- Equivalent reformulation of the conjecture: `H(k) > k^k` eventually
+  (for `k` large enough in either direction). Requires `Real.rpow` arithmetic.
+- `H_zero : H 0 = 0` (vacuous case via empty Finset image).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: structural color-subset helpers, conjecture-strength
+  reduction

--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/190",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 348,
+    "lineCount": 399,
     "assumptions": "3 axioms: exists_canonical_threshold, vanDerWaerden_exists, H_root_to_infinity. 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 10
   },
   "overview": {


### PR DESCRIPTION
## Summary

- `isMonochromatic_subset`: monochromaticity is preserved under subsets
- `isRainbow_subset`: rainbowness is preserved under subsets (via `Finset.card_image_iff` + `Set.InjOn.mono`)
- `erdos190Conjecture_implies_root_to_infinity`: the open Erdős #190 conjecture `H(k)^{1/k}/k → ∞` is strictly stronger than the known result `H(k)^{1/k} → ∞`
- Counts: `theoremCount` 6→9, `lineCount` 348→399. `axiomCount` unchanged (3)

## Why these matter

The two color-subset helpers fill an obvious gap: the current file proves `H_spec`, `W_le_H` etc. with inline color-restriction arguments, and any future `H_monotone : H k ≤ H (k+1)` proof needs exactly these helpers (truncate a canonical `(k+1)`-AP to a canonical `k`-AP; the color condition transfers).

The strength theorem makes explicit that any progress on the conjecture *automatically* re-proves the known result. This is a useful sanity check — we cannot prove the conjecture by means that are weaker than what already established the known result.

## Proof sketch for the strength theorem

Suppose `(H k)^{1/k}/k > M` for all `k ≥ K`. For `k ≥ max(K, 1)`:
- `(H k)^{1/k}/k > M`, multiply by `k > 0`: `(H k)^{1/k} > M · k`.
- `M · k ≥ M · 1 = M` since `M ≥ 0` and `k ≥ 1`.
- Hence `(H k)^{1/k} > M`.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos190Problem` (build deferred — broken `proofs/.lake` symlink in main repo)
- [x] `axiomCount` unchanged at 3 (no new axioms; only adds proved theorems)
- [x] `meta.json` `theoremCount`/`lineCount` synced (6→9, 348→399)

🤖 Generated with [Claude Code](https://claude.com/claude-code)