### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): S21 — correct missing `b ≤ a` hypothesis on `ballot_counting_identity` (build pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -813,8 +813,32 @@ private lemma weight_eq_totalSym' {n a b : ℕ} (hb : 1 ≤ b)
     cardinalities equal `C(a + b, a + 1)`; the multiplicity case generalises by
     the same argument. Estimated ~150 lines remaining work, Session 23+. The
     b = 1 analogue (where `b - 1 = 0` and `Q' = ∅`) is the unique-existence
-    statement in `jdt_weight_sum_b_one` / Aristotle. -/
-private theorem ballot_counting_identity (n a b : ℕ) (hb : 2 ≤ b)
+    statement in `jdt_weight_sum_b_one` / Aristotle.
+
+    ### Why the hypothesis `b ≤ a` is necessary (S21)
+
+    The JDT slide bijection is asymmetric: it removes one element from `Q`
+    (size `b`) and adds it to `P` (size `a`), yielding `(P', Q')` of sizes
+    `(a+1, b-1)`. The "first column violation" `c := min{j < min a b : P[j] ≥
+    Q[j]}` only ranges over `Fin (min a b)`. When `b > a`, `min a b = a`
+    and `ColStrictSym a b P Q` quantifies only over `Fin a`, leaving
+    positions `j ∈ [a, b)` of `Q` unconstrained — the predicate becomes
+    *weaker*, not stronger, for the cardinality identity to balance.
+
+    **Concrete counter-example without `b ≤ a`** (n = 1, a = 0, b = 2):
+    `M = {0, 0}` is the unique element of `Sym (Fin 1) 2`. On the LHS,
+    `P : Sym (Fin 1) 0 = {∅}` and `Q : Sym (Fin 1) 2 = {{0,0}}` give the
+    single split `(∅, {0,0})`. `ColStrictSym 0 2 P Q = ∀ j : Fin 0, _`
+    is vacuously *true*, so `¬ColStrictSym` is *false* and the LHS filter
+    is empty — LHS cardinality = 0. On the RHS, `(P', Q') = ({0}, {0})`
+    is the unique split — RHS cardinality = 1. So `0 = 1` would be
+    required, falsifying the identity.
+
+    With `b ≤ a`, `min a b = b ≥ 2` and `ColStrictSym` is a genuine
+    strictness condition on the first `b` columns, restoring the
+    bijection. The call from `jdt_weight_sum` carries `hba : b ≤ a`
+    directly. -/
+private theorem ballot_counting_identity (n a b : ℕ) (hb : 2 ≤ b) (hba : b ≤ a)
     (M : Sym (Fin n) (a + b)) :
     ((Finset.univ : Finset (Sym (Fin n) a × Sym (Fin n) b)).filter
       (fun PQ => ¬ColStrictSym a b PQ.1 PQ.2 ∧ PQ.1.1 + PQ.2.1 = M.1)).card =
@@ -994,7 +1018,7 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
           jdt_weight_lhs_fibered (R := R),
           jdt_weight_rhs_fibered (R := R) hb]
       refine Finset.sum_congr rfl fun M _ => ?_
-      rw [ballot_counting_identity n a b hb2 M]
+      rw [ballot_counting_identity n a b hb2 hba M]
   · -- b = 0: ColStrictSym a 0 P Q is vacuously true (quantifies over Fin (min a 0) = Fin 0)
     -- So ¬ColStrictSym = False, the subtype is empty, and the sum equals 0
     push_neg at hb

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md
@@ -4,61 +4,99 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-24T01:12:29+02:00
-**Last Updated**: 2026-05-08
-**Iteration**: 20
+**Last Updated**: 2026-05-08 (S21 — researcher-12)
+**Iteration**: 21
 
 ## Current Focus
 
-`ballot_counting_identity` (S20 stated, sorry remaining): the focused per-fiber
-cardinality subproblem extracted from `jdt_weight_sum` b≥2. With this lemma in
-hand, the rest of the b≥2 reduction is structural (~80-100 lines using
-`weight_eq_total_multiset` + `Finset.sum_fiberwise_of_maps_to`).
+`ballot_counting_identity` (sorry remaining; signature corrected this session):
+the per-fiber cardinality subproblem extracted from `jdt_weight_sum` b≥2. With
+this lemma in hand, the rest of the b≥2 reduction is structural and already in
+place via `jdt_weight_lhs_fibered` / `jdt_weight_rhs_fibered` (closed S22-S23).
 
-## Active Approach (S20, post-S19 weight identity)
+## S21 finding — `ballot_counting_identity` was missing `b ≤ a`
 
-For `jdt_weight_sum` (b ≥ 2):
-- **Step (i)**: weight factorisation via `weight_eq_total_multiset` (S19).
-- **Step (ii)**: regroup both LHS (¬CS subtype) and RHS (Sym a+1 × Sym b-1)
-  by total multiset `M : Sym (Fin n) (a+b)` using `totalSym` / `totalSym'`
-  (S20) and `Finset.sum_fiberwise_of_maps_to`.
+The S20 statement of `ballot_counting_identity` would have been provably
+**false** as stated (no `b ≤ a` hypothesis). Concrete counter-example:
+
+- Take `n = 1`, `a = 0`, `b = 2`. The unique total multiset is
+  `M = {0, 0} : Sym (Fin 1) 2`.
+- LHS: `P : Sym (Fin 1) 0 = {∅}`, `Q : Sym (Fin 1) 2 = {{0,0}}` give the
+  single split `(∅, {0,0})` with `P.1 + Q.1 = M.1`. The predicate
+  `ColStrictSym 0 2 P Q` quantifies over `Fin (min 0 2) = Fin 0`, hence is
+  vacuously **true**, hence `¬ColStrictSym` is **false**, hence the LHS
+  filter is empty. **LHS card = 0**.
+- RHS: `P', Q' : Sym (Fin 1) 1 = {{0}}` give the unique split `({0}, {0})`
+  with `P'.1 + Q'.1 = {0,0} = M.1`. **RHS card = 1**.
+
+So the original statement claimed `0 = 1`. The fix is to add `(hba : b ≤ a)`
+to the lemma signature: with `b ≤ a` we have `min a b = b ≥ 2`, so
+`ColStrictSym` becomes a genuine first-`b`-columns strictness condition and
+the JDT slide bijection is well-defined.
+
+The lemma is `private` and has a single call site (in `jdt_weight_sum`),
+which already carries `hba : b ≤ a` in scope — propagation is one extra
+argument at the rewrite site.
+
+## Active Approach (post-S22, post-S23 fiber bridges)
+
+For `jdt_weight_sum` (b ≥ 2), the b≥2 branch is now closed modulo
+`ballot_counting_identity`:
+- **Step (i)** ✓: weight factorisation via `weight_eq_total_multiset` /
+  `weight_eq_totalSym` / `weight_eq_totalSym'` (S19, S22).
+- **Step (ii)** ✓: regroup LHS / RHS by total multiset `M : Sym (Fin n) (a+b)`
+  via `Finset.sum_fiberwise_of_maps_to` — packaged as
+  `jdt_weight_lhs_fibered` / `jdt_weight_rhs_fibered` (S23).
 - **Step (iii)**: per-fiber count equality via `ballot_counting_identity`
-  (S20 stated, sorry).
-- **Step (iv)**: combine to get LHS = RHS.
+  (sorry; signature corrected S21).
+- **Step (iv)** ✓: combine — single `Finset.sum_congr rfl` line.
 
-Steps (i), (ii), (iv) are ~80-100 lines of structural Lean. Step (iii) is the
-deep ~150-line ballot bijection — extracted as a clean black-box.
+The deep remaining work is the bijection inside `ballot_counting_identity`
+itself (~150 lines, reflection / cycle lemma over multisets).
 
-Completed (this session, S20):
-- `totalSym` / `totalSym_val` (~5 lines): Sym (Fin n) a × Sym (Fin n) b →
-  Sym (Fin n) (a+b) via P.1 + Q.1.
-- `totalSym'` / `totalSym'_val` (~7 lines): companion for the (a+1, b-1) shape
-  with `hb : 1 ≤ b` baked in.
-- `ballot_counting_identity` stated (~20 lines incl. docstring): the
-  per-fiber cardinality identity, sorry.
-- Updated `jdt_weight_sum` b≥2 comment block to reference the new helpers
-  and document steps (i)-(iv).
+## This session (S21)
 
-Completed (earlier sessions):
-- `weight_eq_total_multiset` (S19): cornerstone weight identity.
-- `min_ab_pos_of_not_colStrict` (S19), `exists_first_violation_idx` (S19):
-  auxiliary structural lemmas (latter not on primary path).
-- `jdt_weight_sum_b_one` (S17): b=1 base case, 75-line proof.
-- `not_colStrictSym_a_one_iff_qhead_le_phead` (S16),
-  `colStrictSym_a_one_iff_phead_lt_qhead` (S16),
-  `sym_one_sort_head_singleton` (S15), `jdt_weight_preserved` (S~9).
+Completed:
+- Identified the missing `b ≤ a` hypothesis on `ballot_counting_identity`
+  via concrete counter-example computation (above).
+- Added `(hba : b ≤ a)` to the lemma signature.
+- Updated the docstring with the counter-example and the JDT-slide
+  asymmetry explanation.
+- Propagated `hba` at the unique call site
+  `rw [ballot_counting_identity n a b hb2 hba M]` in `jdt_weight_sum`.
+- Added an `originalContributions` entry documenting the S21 correction.
+
+## Earlier sessions (summary)
+
+- **S22-S23**: `jdt_weight_lhs_fibered`, `jdt_weight_rhs_fibered`,
+  `totalSym_eq_iff` / `totalSym'_eq_iff`, `weight_eq_totalSym` /
+  `weight_eq_totalSym'`. Closed the b≥2 branch of `jdt_weight_sum` modulo
+  `ballot_counting_identity`.
+- **S20**: stated `ballot_counting_identity` (sorry); added `totalSym` /
+  `totalSym'` (Sym-wrapper for the total multiset).
+- **S19**: `weight_eq_total_multiset` (cornerstone weight identity);
+  `min_ab_pos_of_not_colStrict`, `exists_first_violation_idx` (auxiliary).
+- **S17**: `jdt_weight_sum_b_one` (b=1 base case, 75-line proof).
+- **S15-S16**: `not_colStrictSym_a_one_iff_qhead_le_phead`,
+  `colStrictSym_a_one_iff_phead_lt_qhead`, `sym_one_sort_head_singleton`.
+- **S~9**: `jdt_weight_preserved` (single-element move identity).
 
 ## Attempt Count
-- Total attempts: 20 (sessions 1-20)
+
+- Total iterations: 21 (sessions 1-21).
 - Approaches tried:
-  1. SSYT infrastructure (sessions 1-14)
-  2. Decompose jdt_weight_sum (session 15)
-  3. ColStrictSym b=1 characterisation (session 16)
-  4. Prove jdt_weight_sum_b_one bijection (session 17) ✓
-  5. Diagnose non-injective bijection + correct path (session 18, PR #14891) ✓
-  6. Weight-factorization helper + auxiliary `¬ColStrictSym` lemmas
-     (session 19) ✓
-  7. Extract `ballot_counting_identity` + `totalSym`/`totalSym'` helpers,
-     document the structural reduction (session 20) ✓ (this PR)
+  1. SSYT infrastructure (sessions 1-14).
+  2. Decompose `jdt_weight_sum` (S15).
+  3. `ColStrictSym` b=1 characterisation (S16).
+  4. `jdt_weight_sum_b_one` bijection (S17) ✓.
+  5. Diagnose non-injective bijection + correct path (S18, PR #14891) ✓.
+  6. Weight-factorization helper + auxiliary `¬ColStrictSym` lemmas (S19) ✓.
+  7. Extract `ballot_counting_identity` + `totalSym` / `totalSym'` helpers (S20) ✓.
+  8. `totalSym_eq_iff` / `weight_eq_totalSym` bridges + structural strategy (S22) ✓.
+  9. `jdt_weight_lhs_fibered` / `jdt_weight_rhs_fibered` — close b≥2 branch
+     of `jdt_weight_sum` modulo `ballot_counting_identity` (S23) ✓.
+ 10. Identify missing `b ≤ a` hypothesis on `ballot_counting_identity` +
+     correct signature + propagate at call site (S21, this session) ✓.
 
 ## Blockers
 
@@ -68,18 +106,21 @@ None for current approach. The ballot bijection inside
 
 ## Next Action
 
-1. **S21**: Prove `ballot_counting_identity` — bijection at the multiset level
+1. **S22-next**: Prove `ballot_counting_identity (n a b : ℕ) (hb : 2 ≤ b)
+   (hba : b ≤ a) (M : Sym (Fin n) (a + b))` — bijection at the multiset level
    between non-col-strict (a,b) splits of M and arbitrary (a+1, b-1) splits.
-   ~150 lines. Strategy: adapt the cycle / ballot principle for multisets.
-2. **S22**: Wire `ballot_counting_identity` into `jdt_weight_sum` b≥2 via the
-   structural reduction (steps i-iv documented above). ~80-100 lines using
-   `Finset.sum_fiberwise_of_maps_to` + `weight_eq_total_multiset`.
-3. **Future**: After `jdt_weight_sum` closes, `jacobi_trudi_ssyt_eq` k ≥ 3
-   (RSK / algebraic LGV, ~300 lines).
+   ~150 lines. Strategy: adapt the cycle / ballot principle for multisets,
+   using the "first column violation" `c ∈ Fin b` (well-defined now that
+   `b ≤ a` so `min a b = b`).
+2. **Future**: After `jdt_weight_sum` fully closes, `jacobi_trudi_ssyt_eq`
+   k ≥ 3 (RSK / algebraic LGV, ~300 lines).
 
 ## File Status
 
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: ~992 → ~1050 lines.
-- Sorry count: 3 → 4 (added `ballot_counting_identity`; existing
-  `jdt_weight_sum` b≥2 sorry unchanged this session).
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`: 1242 → 1266 lines (+24
+  this session, all in the `ballot_counting_identity` docstring + signature
+  + the one-token call-site update).
+- Sorry count: 2 (`ballot_counting_identity`, `jacobi_trudi_ssyt_eq` k≥3).
 - 0 axioms.
+- Theorems: 31 (unchanged).
+- Definitions: 8 (unchanged).

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) ballot_counting_identity (~150 lines) — per-fiber count equality C(a+b, a+1) for the b≥2 reflection step; (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). S23 closed the b≥2 case of jdt_weight_sum (was sorry, now proved) by adding the structural fiber-bridge helpers jdt_weight_lhs_fibered and jdt_weight_rhs_fibered: each re-expresses one side of the polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with the integrand reduced to constant wt(M.1) on each fiber. Proof recipe: Finset.sum_bij for subtype→filter conversion (LHS), weight_eq_totalSym/weight_eq_totalSym' for weight factorisation, Finset.sum_fiberwise_of_maps_to for the fibering, totalSym_eq_iff/totalSym'_eq_iff to bridge filter predicates; ballot_counting_identity then equates the per-fiber cardinalities, closed by Finset.sum_congr. S22 added the totalSym/totalSym' bridge family. S19 added weight_eq_total_multiset. jdt_weight_sum_b_one proved (S17). ssytSchurFin_two_row and ssytFin_two_row_eq_sum_colstrict proved. k=0,1,2 proved.",
-    "lineCount": 1242,
+    "lineCount": 1266,
     "theoremCount": 31,
     "definitionCount": 8,
     "originalContributions": [
@@ -40,7 +40,8 @@
       "totalSym/totalSym' — Sym-wrapper for the total multiset of a (Sym a × Sym b) or (Sym (a+1) × Sym (b-1)) pair, packaged as Sym (a+b) (S19/S22)",
       "weight_eq_totalSym / weight_eq_totalSym' (S22): Sym-wrapped weight factorisation `prod(P)*prod(Q) = prod((totalSym P Q).1)` and its (a+1, b-1) companion — the cleanest form for chaining with Finset.sum_fiberwise_of_maps_to in the b≥2 structural reduction",
       "totalSym_eq_iff / totalSym'_eq_iff (S22): bridges the fiber-membership predicate `g PQ = M` (used by Finset.sum_fiberwise_of_maps_to) to `P.1 + Q.1 = M.1` (used by ballot_counting_identity), via Subtype extensionality",
-      "jdt_weight_lhs_fibered / jdt_weight_rhs_fibered (S23): re-expresses each side of the b≥2 jdt_weight_sum polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with constant-on-fiber integrand wt(M.1). Closes the b≥2 branch of jdt_weight_sum modulo ballot_counting_identity via a single `Finset.sum_congr rfl` line — the structural reduction outlined in the S22 strategy comment is now realised as named lemmas and the b≥2 sorry is eliminated"
+      "jdt_weight_lhs_fibered / jdt_weight_rhs_fibered (S23): re-expresses each side of the b≥2 jdt_weight_sum polynomial identity as a fiber-card sum indexed by the total multiset M : Sym (Fin n) (a+b), with constant-on-fiber integrand wt(M.1). Closes the b≥2 branch of jdt_weight_sum modulo ballot_counting_identity via a single `Finset.sum_congr rfl` line — the structural reduction outlined in the S22 strategy comment is now realised as named lemmas and the b≥2 sorry is eliminated",
+      "ballot_counting_identity hypothesis correction (S21, this session): identified that the S20 statement of ballot_counting_identity was missing the `b ≤ a` hypothesis and would have been formally false as stated. Concrete counter-example: at n = 1, a = 0, b = 2 the unique multiset M = {0, 0} : Sym (Fin 1) 2 gives LHS card = 0 (because ColStrictSym 0 2 P Q quantifies over Fin (min 0 2) = Fin 0 and is vacuously true, so ¬ColStrictSym filters out the only candidate split (∅, M)) but RHS card = 1 (the unique split P' = Q' = {0}). With `hba : b ≤ a` added to the lemma signature, `min a b = b ≥ 2` so ColStrictSym becomes a genuine first-b-columns strictness condition and the JDT slide bijection is well-defined. The call from jdt_weight_sum already has hba in scope (`(n a b : ℕ) (hba : b ≤ a)`) so the only required propagation is at the rewrite site (`rw [ballot_counting_identity n a b hb2 hba M]`)"
     ]
   },
   "overview": {
@@ -82,7 +83,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 1242,
+    "lineCount": 1266,
     "axiomCount": 0,
     "theoremCount": 31,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary

Identified that the S20 statement of `ballot_counting_identity` (the focused
per-fiber cardinality subproblem extracted by S20 from the b≥2 branch of
`jdt_weight_sum`) was missing the hypothesis `b ≤ a` and would have been
provably **false** as stated. Added the hypothesis, propagated at the unique
call site, and documented with a concrete counter-example in the docstring.

This is a **signature correction**, not a proof. The lemma still has its
sorry; but the corrected statement is mathematically true and can be filled
by the planned ~150-line bijection (S22-next).

## The bug

At `n = 1`, `a = 0`, `b = 2` the unique multiset is `M = {0, 0} : Sym (Fin 1) 2`.

- **LHS**: `P : Sym (Fin 1) 0 = {∅}` and `Q : Sym (Fin 1) 2 = {{0,0}}` give the
  single split `(∅, {0,0})` with `P.1 + Q.1 = M.1`. The predicate
  `ColStrictSym 0 2 P Q` quantifies over `Fin (min 0 2) = Fin 0`, hence is
  vacuously *true*, hence `¬ColStrictSym` is *false*, hence the LHS filter
  is empty. **LHS card = 0**.

- **RHS**: `P', Q' : Sym (Fin 1) 1 = {{0}}` give the unique split `({0}, {0})`
  with `P'.1 + Q'.1 = {0,0} = M.1`. **RHS card = 1**.

So the original statement claimed `0 = 1` for this configuration.

## The fix

Add `(hba : b ≤ a)` to `ballot_counting_identity`. With `b ≤ a` we have
`min a b = b ≥ 2`, so `ColStrictSym a b P Q` becomes a genuine
column-strictness condition on the first `b` positions, and the JDT-slide
bijection (which removes one element from `Q` and adds it to `P`) is
well-defined.

The lemma is `private` and has a single call site, in `jdt_weight_sum`,
which already carries `hba : b ≤ a` in scope:

```lean
private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
    ...
  ...
      rw [ballot_counting_identity n a b hb2 hba M]   -- ← one extra argument
```

## Files changed

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` — `(hba : b ≤ a)` added
  to lemma signature; docstring extended with JDT-asymmetry explanation and
  the explicit counter-example; `hba` passed at the unique call site.
- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json` —
  `lineCount` 1242 → 1266; `originalContributions` entry added for S21.
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/state.md` —
  iteration 20 → 21; current focus and S21 finding documented.

Sorry count unchanged (still 2: `ballot_counting_identity` and
`jacobi_trudi_ssyt_eq` k≥3). 0 axioms. Theorems / definitions unchanged.

## Test plan

- [ ] CI build — `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ03OQ01OQ01OQ01`
- [ ] Auditor — verify `theoremCount`, `definitionCount`, `lineCount`, `sorries` match
- [ ] No new sorries / axioms introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)